### PR TITLE
chore: remove duplicate sudoku_models/checkpoints from repo root (See #2379)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -586,8 +586,7 @@ $null
 *_model.pt
 **/checkpoints/**/*.pt
 **/checkpoints/**/*.pth
-# EXCEPTION: Sudoku validated checkpoints
-!sudoku_models/checkpoints/
+# Sudoku checkpoints live in MyIA.AI.Notebooks/Sudoku/sudoku_models/checkpoints/ only
 
 # PyTorch extended model formats
 **/checkpoints/**/*.ckpt
@@ -852,7 +851,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/data/temp_*.owl
 /output_analytique/
 
 # Root-level artifacts from notebooks/scripts run with wrong CWD (canonical copies live in series dirs)
-# NOTE: /sudoku_models/ intentionally NOT ignored — it carries live in-flight ai-01 training WIP (Blocker A, not user-signed-off)
+/sudoku_models/
 /data/pizza_test.owl
 /results/
 /tmp_*.py

--- a/sudoku_models/checkpoints/comparison_cnn_h64_l8_303k_best.pt
+++ b/sudoku_models/checkpoints/comparison_cnn_h64_l8_303k_best.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f84396455863e4fd30ab7d996a0aa8d932e5beb0a3fc0a7cc9bf0ff9659ae2a
-size 1235871

--- a/sudoku_models/checkpoints/comparison_cnn_h72_l7_335k_best.pt
+++ b/sudoku_models/checkpoints/comparison_cnn_h72_l7_335k_best.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af30bb05bc849704a7fbcc453441480716dad330cfa1fe4c2120773ae1a07c98
-size 1362188

--- a/sudoku_models/checkpoints/comparison_mlp_h200_l2_349k_best.pt
+++ b/sudoku_models/checkpoints/comparison_mlp_h200_l2_349k_best.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01f3198deef6052c692c66710cb0f537fec26d71daf60b7d5b09facf63815658
-size 1399169

--- a/sudoku_models/checkpoints/comparison_mlp_h256_l3_409k_best.pt
+++ b/sudoku_models/checkpoints/comparison_mlp_h256_l3_409k_best.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c206e3856fd1a47ee62e06c52befa8df328a2fb1491b9234874fd30692ed918f
-size 2110379

--- a/sudoku_models/checkpoints/finetuned_h192_s16_strat_v2_best.pt
+++ b/sudoku_models/checkpoints/finetuned_h192_s16_strat_v2_best.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:119670dcf3f020c2944d988c8a856d49bbd0f78e0daed2846d257429205277e0
-size 1420911

--- a/sudoku_models/checkpoints/finetuned_h256_s16_strat_v2_best.pt
+++ b/sudoku_models/checkpoints/finetuned_h256_s16_strat_v2_best.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ead3c27312fb201430dc4c5b4b05bd8f4baf5730e27f6c05c84d7edda1ea804
-size 2482095

--- a/sudoku_models/checkpoints/sweep_h128_s16_best.pt
+++ b/sudoku_models/checkpoints/sweep_h128_s16_best.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eddaa2d9d584b30703e3da88b136e974bbb56282f7c3421b13d9206f0a59a08d
-size 654340

--- a/sudoku_models/checkpoints/sweep_h192_s16_best.pt
+++ b/sudoku_models/checkpoints/sweep_h192_s16_best.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb7b02dd128166fee1d41dd0e6b57354186705f47f8c3476b9737bd8e9ef20a1
-size 1420548


### PR DESCRIPTION
## Summary

Remove 8 duplicate `.pt` files (12 MB) tracked at repo root `sudoku_models/checkpoints/`. The canonical copy at `MyIA.AI.Notebooks/Sudoku/sudoku_models/checkpoints/` is byte-identical (MD5 verified).

### Root cause

PR #2379 was squash-merged with an amendment to keep the files tracked (Blocker A: ai-01 WIP on these files). The WIP never materialized — no modifications since June 1. The "split trivial différé" was never tracked as a separate issue and fell through the cracks.

### Changes

- `git rm -r --cached sudoku_models/checkpoints/` (8 files, -27 lines)
- `.gitignore`: add `/sudoku_models/` to prevent future wrong-CWD artifacts
- `.gitignore`: remove stale `!sudoku_models/checkpoints/` exception and Blocker A comment

### Verification

```
# Both copies byte-identical
$ md5sum sudoku_models/checkpoints/*.pt
$ md5sum MyIA.AI.Notebooks/Sudoku/sudoku_models/checkpoints/*.pt
# Hashes match for all 8 files

# Zero live code references into root sudoku_models/
$ grep -r "sudoku_models/" --include="*.py" --include="*.ipynb" | grep -v "Sudoku/sudoku_models"
# Only .gitignore entries
```

See #2379 (original cleanup, MERGED but files kept due to Blocker A)