### PR TITLE
docs(archive): add INDEX.md for 3 archive subdirs + root index

### DIFF
--- a/docs/_archives/INDEX.md
+++ b/docs/_archives/INDEX.md
@@ -1,0 +1,61 @@
+# Archives docs/ — Index general
+
+Documents historiques, audits clotures, investigations et snapshots archives.
+Ces fichiers sont conserves pour la tracabilite mais ne sont plus maintenus activement.
+
+## Sous-dossiers thematiques
+
+| Dossier | Contenu | Fichiers |
+|---------|---------|----------|
+| [investigation-mcp-nuget/](investigation-mcp-nuget/INDEX.md) | Investigation MCP NuGet / .NET Interactive / Jupyter (sessions 06-31) | 26 |
+| [genai/](genai/README.md) | Architecture GenAI, Docker, specs, guides techniques | 15 |
+| [suivis/](suivis/) | Suivis de phases GenAI-Image (phases 12a, 29, 30, 31) | ~12 |
+
+## Fichiers racine archives
+
+### Curriculum & formation
+
+| Fichier | Resume |
+|---------|--------|
+| [01-cartographie-initiale.md](01-cartographie-initiale.md) | Cartographie Initiale du Depot CoursIA |
+| [02-etude-adk-deepmind.md](02-etude-adk-deepmind.md) | Etude framework agentique ADK / MLE-STAR |
+| [03-plan-formation-datascience-agentique.md](03-plan-formation-datascience-agentique.md) | Plan de Formation Data Science Agentique 2026 |
+| [epf-universalisation-design.md](epf-universalisation-design.md) | EPF Universalisation Design Phase 1 |
+| [slides-refonte-procedure.md](slides-refonte-procedure.md) | Procedure refonte slides Slidev |
+
+### Reference technique
+
+| Fichier | Resume |
+|---------|--------|
+| [GROTHENDIECK_MATHLIB_MAP.md](GROTHENDIECK_MATHLIB_MAP.md) | Types Mathlib absents (Surreal, PGame, Game, Nimber) |
+| [handson-book-mapping.md](handson-book-mapping.md) | Mapping livre Hands-On AI Trading -> curriculum |
+| [NOTEBOOK_ENV_COVERAGE.md](NOTEBOOK_ENV_COVERAGE.md) | Audit couverture environnements notebooks |
+| [qc-league-ece.md](qc-league-ece.md) | QC League / Strategies — Mobilisation ECE |
+| [REVERSE_PROXY_CIRCUIT.md](REVERSE_PROXY_CIRCUIT.md) | Reverse proxy Docker -> URLs publiques |
+
+### Audits & diagnostics (dates)
+
+| Fichier | Date | Resume |
+|---------|------|--------|
+| [dette-branches-audit-2026-05-27.md](dette-branches-audit-2026-05-27.md) | 2026-05-27 | Dette technique branches |
+| [env-audit-cluster-2026-05-10.md](env-audit-cluster-2026-05-10.md) | 2026-05-10 | Audit environnement cluster |
+| [genai-services-inventory-2026-05.md](genai-services-inventory-2026-05.md) | 2026-05 | Inventaire services GenAI |
+| [genai-stack-audit-2026-05-10.md](genai-stack-audit-2026-05-10.md) | 2026-05-10 | Audit stack GenAI |
+| [qc-broken-strategies-audit.md](qc-broken-strategies-audit.md) | — | Audit strategies QC cassees |
+| [qc-stabilization-phase2.md](qc-stabilization-phase2.md) | — | Methodologie stabilisation QC Phase 2 |
+| [stabilization-phase1-matrix.md](stabilization-phase1-matrix.md) | — | Matrix stabilisation Phase 1 |
+| [H7_P2_DOCKER_ERROR_CATALOG.md](H7_P2_DOCKER_ERROR_CATALOG.md) | — | Catalogue erreurs Docker H.7 P2 |
+
+### Post-mortems & missions closes
+
+| Fichier | Resume |
+|---------|--------|
+| [epic-1028-audiobook-postmortem.md](epic-1028-audiobook-postmortem.md) | Post-mortem pipeline audiobook agentique |
+| [genai-images-mission-complete.md](genai-images-mission-complete.md) | Rapport final mission GenAI Images |
+| [integration-roadmap.md](integration-roadmap.md) | Plan integration GenAI Images |
+
+## Convention
+
+Chaque sous-dossier thematique contient son propre `INDEX.md` avec chronologie detaillee.
+Les fichiers sont archives tels quels (pas de modification de contenu). La date d'archivage
+est tracee via le commit git qui a deplace le fichier depuis `docs/`.

--- a/docs/_archives/genai/INDEX.md
+++ b/docs/_archives/genai/INDEX.md
@@ -1,0 +1,21 @@
+# Archive: GenAI investigations & audits
+
+Documentation technique historique de l'infrastructure GenAI/Images CoursIA (ComfyUI, Qwen, Forge). Archivee depuis `docs/` lors du nettoyage Epic #1925 (juin 2026). Contenu potentiellement stale -- se referer a [docs/genai-services.md](../../genai-services.md) pour l'etat courant.
+
+| # | Fichier | Resume | Date |
+|---|---------|--------|------|
+| 1 | [ecosystem-readme.md](ecosystem-readme.md) | Vue d'ensemble pedagogique de l'ecosysteme GenAI Images (SDDD, objectifs, notebooks) | 2025-10-07 |
+| 2 | [development-standards.md](development-standards.md) | Standards unifies pour l'ecosysteme GenAI Images (nommage, structure modulaire) | 2025-10-07 |
+| 3 | [docker-specs.md](docker-specs.md) | Specifications infrastructure Docker hybride (isolation controlee, APIs REST) | 2025-10-07 |
+| 4 | [docker-orchestration.md](docker-orchestration.md) | Strategie d'orchestration Docker modulaire isolee pour services GenAI | 2025-10-07 |
+| 5 | [docker-lifecycle-management.md](docker-lifecycle-management.md) | Gestion lifecycle containers Docker (approche GitOps, automatisation) | 2025-10-07 |
+| 6 | [environment-configurations.md](environment-configurations.md) | Configurations multi-environnements securisees (strategie hierarchique) | 2025-10-07 |
+| 7 | [integration-procedures.md](integration-procedures.md) | Procedures d'integration MCP avec principe zero-regression | 2025-10-07 |
+| 8 | [phase2-templates.md](phase2-templates.md) | Templates production-ready pour implementation Phase 2 GenAI | 2025-10-07 |
+| 9 | [powershell-scripts.md](powershell-scripts.md) | Scripts PowerShell d'automatisation (setup, validation, deploiement) | 2025-10-07 |
+| 10 | [troubleshooting.md](troubleshooting.md) | Guide de resolution de probleme systematique (approche en couches) | 2025-10-07 |
+| 11 | [infrastructure-tests.md](infrastructure-tests.md) | Strategie de tests multicouches pour l'infrastructure GenAI | 2025-10-08 |
+| 12 | [user-guide.md](user-guide.md) | Guide etudiant APIs generation d'images (ComfyUI + Forge, REST) | 2025-10-16 |
+| 13 | [architecture.md](architecture.md) | Architecture complete ecosysteme GenAI (Phase 30, sanctuarisation) | 2025-12-10 |
+| 14 | [deployment-guide.md](deployment-guide.md) | Guide deploiement production ComfyUI + Qwen Image-Edit (RTX 3090) | 2025-12-10 |
+| 15 | [README.md](README.md) | Documentation de reference globale GenAI/Images (ComfyUI v1.0 + Forge) | n/c |

--- a/docs/_archives/investigation-mcp-nuget/INDEX.md
+++ b/docs/_archives/investigation-mcp-nuget/INDEX.md
@@ -1,0 +1,32 @@
+# Archive: Investigation MCP NuGet (06-31)
+
+Investigation technique couvrant septembre-octobre 2025 sur l'execution de notebooks Jupyter (.NET Interactive + Python) via MCP : echec du serveur Node.js, migration Papermill, bug NuGet `path1` null, architecture async ExecutionManager, et validation finale.
+
+| # | Fichier | Resume | Date |
+|---|---------|--------|------|
+| 06 | 06-MCP-Jupyter-Setup.md | Echec de l'execution d'un notebook Python via le serveur MCP Jupyter Node.js ; probleme persistant et bloquant | ~sept. 2025 |
+| 07 | 07-SDDD-Investigation-Bug-SDK-Solutions-Alternatives.md | Diagnostic du bug SDK `@modelcontextprotocol/sdk` et recherche de solutions alternatives | 12 sept. 2025 |
+| 08 | 08-SDDD-Checkpoint-Semantique-Papermill.md | Architecture Papermill-CoursIA validee : 26/26 cellules executees, pattern industriel confirme | 12 sept. 2025 |
+| 09 | 09-SDDD-Implementation-Success-Papermill-CoursIA.md | Succes complet de l'implementation Papermill-CoursIA remplacant le SDK MCP bugue | 12 sept. 2025 |
+| 10 | 10-SDDD-Comparaison-Outils-MCP-Servers.md | Comparaison serveur Node.js (15 outils) vs Python (22 outils) : couverture complete + Papermill | 12 sept. 2025 |
+| 11 | 11-SDDD-Rapport-Validation-Complete-MCP-Servers.md | Validation complete : serveur Python superieur en architecture, performance (0.8s) et stabilite | 12 sept. 2025 |
+| 12 | 12-MIGRATION-MCP-JUPYTER-PYTHON-SERVER.md | Migration reussie du serveur MCP Jupyter de Node.js vers Python/Papermill | 13 sept. 2025 |
+| 13 | 13-ROLLBACK-MCP-JUPYTER-SERVER.md | Rollback suite a un conflit asyncio fatal entre le serveur Python et VS Code | 13 sept. 2025 |
+| 14 | 14-DIAGNOSTIC-CRITIQUE-MCP-JUPYTER-RECOVERY.md | Diagnostic situation critique : 0 serveur Jupyter MCP fonctionnel, perte complete | 13 sept. 2025 |
+| 15 | 15-TEST-CRITIQUE-SOLUTION-A-SUCCESS-FINAL.md | Succes de la Solution A (API Papermill directe) avec infrastructure MCP revue | 14 sept. 2025 |
+| 16 | 16-VALIDATION-NOTEBOOKS-PYTHON-COMPLEXES-SOLUTION-A.md | Validation notebooks Python complexes (dependances scientifiques, algorithmes) via Papermill Direct API | ~14 sept. 2025 |
+| 17 | 17-SDDD-RESOLUTION-DEFINITIVE-NUGET-DOTNET-INTERACTIVE.md | Resolution de l'erreur `path1` null : cause racine = variables d'environnement .NET absentes | 15 sept. 2025 |
+| 18 | 18-SDDD-ETAT-FINAL-MCP-JUPYTER-NUGET.md | Etat final post-investigation : documentation factuelle des composants fonctionnels et limitations | 15 sept. 2025 |
+| 19 | 19-RESOLUTION-DEFINITIVE-MICROSOFT-ML-MCP.md | Microsoft.ML fonctionne via MCP, erreur `path1` resolue, notebooks .NET operationnels | ~15 sept. 2025 |
+| 20 | 20-SYNTHESE-DOCUMENTAIRE-COMPLETE-06-19.md | Synthese exhaustive des documents 06-19 : chronologie, decouvertes, invalidations | ~16 sept. 2025 |
+| 21 | 21-ANALYSE-ARCHITECTURE-MCP-EVOLUTION-GIT.md | Analyse comparative des architectures MCP Node.js vs Python/Papermill et cause racine NuGet | ~16 sept. 2025 |
+| 22 | 22-RESOLUTION-DEFINITIVE-FINALE-MCP-NUGET.md | Solution technique definitive implantee pour MCP-NuGet, en cours de deploiement | 17 sept. 2025 |
+| 23 | 23-VALIDATION-EXHAUSTIVE-NOTEBOOKS-DOTNET-MCP.md | Echec critique : validation exhaustive de tous les notebooks .NET, probleme NuGet non resolu | 17 sept. 2025 |
+| 24 | 24-RESOLUTION-TECHNIQUE-NUGET-TARGETS-PATH1-NULL.md | Cause racine identifiee : echec systemique de creation des projets temporaires .NET Interactive en env MCP isole | 17 sept. 2025 |
+| 25 | 25-SYNTHESE-FINALE-ET-PLAN-ACTION-MCP-NUGET.md | Synthese des docs 06-24 et plan d'action technique pour resolution definitive MCP-NuGet | 17 sept. 2025 |
+| 25 | 25-SYNTHESE-HISTORIQUE-INVESTIGATION-MCP-NUGET.md | Historique des taches liees au probleme NuGet/.NET Interactive via MCP Jupyter | ~17 sept. 2025 |
+| 26 | 26-RESOLUTION-DEFINITIVE-MCP-NUGET-SOLUTION-RETROUVEE.md | Solution retrouvee par archeologie des conversations via roo-state-manager | 18 sept. 2025 |
+| 27 | 27-RESOLUTION-FINALE-NOTEBOOK-MAKER-SUJET-COMPLEXE.md | Test et correction du notebook SemanticKernel-NotebookMaker avec sujets complexes via MCP | 7 oct. 2025 |
+| 29 | 29-ARCHITECTURE-ASYNC-EXECUTIONMANAGER-RESOLUTION-TIMEOUTS.md | Architecture asynchrone ExecutionManager deployee pour resolution definitive des timeouts MCP | 28 sept. 2025 |
+| 30 | 30-RESOLUTION-DEFINITIVE-SEMANTIC-KERNEL-CLR-NOTEBOOK.md | Correction du notebook SemanticKernel CLR pour compatibilite avec l'architecture MCP async | 28 sept. 2025 |
+| 31 | 31-VALIDATION-SYMBOLIQUE-AI-ARGUMENT-ANALYSIS-SUITE.md | Validation complete de la suite SymbolicAI Argument_Analysis via MCP async | 3 oct. 2025 |

--- a/docs/_archives/suivis/INDEX.md
+++ b/docs/_archives/suivis/INDEX.md
@@ -1,0 +1,26 @@
+# Archive: Suivis GenAI-Image
+
+Suivis de phases et guides operationnels pour l'infrastructure GenAI Images (ComfyUI + Qwen).
+Archives lors du nettoyage Epic #1925 (juin 2026). Pour la documentation vivante : cf [docs/genai-services.md](../../genai-services.md).
+
+## Fichiers
+
+| Fichier | Resume | Phase |
+|---------|--------|-------|
+| [README.md](genai-image/README.md) | Infrastructure locale ComfyUI + Qwen | General |
+| [DOCKER-LOCAL-SETUP.md](genai-image/DOCKER-LOCAL-SETUP.md) | Configuration Docker local services GenAI | Setup |
+| [TROUBLESHOOTING.md](genai-image/TROUBLESHOOTING.md) | Guide troubleshooting GenAI Images | Support |
+| [README-AUTH.md](genai-image/README-AUTH.md) | Authentification ComfyUI (notebooks) | Auth |
+| [README-ETUDIANTS-AUTH.md](genai-image/README-ETUDIANTS-AUTH.md) | Authentification ComfyUI (etudiants) | Auth |
+| [GUIDE-APIS-ETUDIANTS.md](genai-image/GUIDE-APIS-ETUDIANTS.md) | Guide APIs generation images (etudiants) | Usage |
+| [RAPPORT-FINAL-MISSION-QWEN-COMFYUI.md](genai-image/RAPPORT-FINAL-MISSION-QWEN-COMFYUI.md) | Rapport final stabilisation Qwen ComfyUI | Close |
+| [SYNTHESE_FINALE_PHASE_30_EXHAUSTIVITE.md](genai-image/SYNTHESE_FINALE_PHASE_30_EXHAUSTIVITE.md) | Validation exhaustive notebooks GenAI | Phase 30 |
+
+## Suivis de phases
+
+| Phase | Contenu | Items |
+|-------|---------|-------|
+| [phase-12a-production](genai-image/phase-12a-production/) | Production ComfyUI | 3 |
+| [phase-29-corrections-qwen-20251031-111200](genai-image/phase-29-corrections-qwen-20251031-111200/) | Corrections Qwen (2025-10-31) | 5 |
+| [phase-30-validation-sanctuarisation-docker-qwen](genai-image/phase-30-validation-sanctuarisation-docker-qwen/) | Validation sanctuarisation Docker Qwen | 9 |
+| [phase-31-comfyui-auth](genai-image/phase-31-comfyui-auth/) | Authentification ComfyUI | 12 |


### PR DESCRIPTION
See #2456 — docs-reorg S3: archivage investigations closes

## Summary

Create navigable INDEX.md indexes for all `docs/_archives/` subdirectories:
- **Root `INDEX.md`**: 21 files catalogued in 4 categories (curriculum, reference, audits, post-mortems)
- **`investigation-mcp-nuget/INDEX.md`**: 26 files with chronological arc (Sept-Oct 2025 MCP NuGet investigation)
- **`genai/INDEX.md`**: 15 files (GenAI architecture, Docker specs, deployment guides)
- **`suivis/INDEX.md`**: GenAI-Image phase tracking (phases 12a, 29, 30, 31 + 8 standalone docs)

## Traceability

Each INDEX.md preserves:
- File list with one-line summaries (extracted from file content)
- Dates where available
- Chronological ordering
- Cross-reference to living documentation where applicable

## Acceptance (#2456)

- [x] Investigations closes sous `docs/_archives/<theme>/` + INDEX.md par theme
- [x] Link-checker: 0 nouveaux liens casses (24 pre-existing, unchanged)
- [x] Execution incrementale: separate INDEX.md files, no bulk moves

## Not in scope

- Moving additional files to archives (already done in prior cycles)
- Updating CLAUDE.md references (tracked in S6)