### PR TITLE
fix(tests): isolate genai_audio env leak + fix WSL case-sensitive assertion

### DIFF
--- a/scripts/tests/test_genai_audio_apis.py
+++ b/scripts/tests/test_genai_audio_apis.py
@@ -228,7 +228,8 @@ class TestGetAuthHeaders:
 
     def test_no_auth_without_env(self):
         """Without env vars or files, no Authorization header."""
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {}, clear=True), \
+             patch.object(Path, "exists", return_value=False):
             result = _get_auth_headers()
             assert "Authorization" not in result
 

--- a/scripts/tests/test_wsl_papermill.py
+++ b/scripts/tests/test_wsl_papermill.py
@@ -52,10 +52,11 @@ class TestWinToWslPath:
         assert "Users/test/file.txt" in result
 
     def test_d_drive(self):
-        """D: drive maps to /mnt/d."""
+        """D: drive maps to /mnt/d (case-insensitive check due to resolve())."""
         result = win_to_wsl_path("D:\\dev\\project")
         assert result.startswith("/mnt/d/")
-        assert "dev/project" in result
+        # Path.resolve() may capitalize path components based on physical disk
+        assert "dev/project" in result.lower()
 
     def test_lowercase_drive(self):
         """Drive letter is lowercased in WSL path."""


### PR DESCRIPTION
## Summary

Fix 2 pre-existing test failures (11→9 remaining, all GARCH `arch` module missing):

1. **test_genai_audio_apis** (`test_no_auth_without_env`): `patch.dict(os.environ, {}, clear=True)` only clears env vars but `_get_auth_headers()` also reads from `MyIA.AI.Notebooks/GenAI/.env` on disk. Added `patch.object(Path, "exists", return_value=False)` to fully isolate the test.

2. **test_wsl_papermill** (`test_d_drive`): `Path("D:\dev\project").resolve()` capitalizes to `D:\Dev\project` based on physical disk. Changed assertion to case-insensitive `.lower()` check.

## Verification

```
58/58 passed in test_wsl_papermill.py + test_genai_audio_apis.py
Full suite: 2189 passed, 9 failed (all GARCH), 18 skipped
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>