### PR TITLE
docs(archives): add INDEX.md to 3 archive directories (See #2456)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -149,7 +149,13 @@ Guides pedagogiques pour les parcours d'apprentissage.
 
 ## Historique et archives
 
-Ces documents sont conserves pour reference mais ne sont plus actifs.
+Ces documents sont conserves pour reference mais ne sont plus actifs. Index complet : [_archives/INDEX.md](_archives/INDEX.md).
+
+**Sous-repertoires archives** :
+
+- [_archives/investigation-mcp-nuget/](_archives/investigation-mcp-nuget/INDEX.md) — Investigation MCP Jupyter / NuGet (26 fichiers)
+- [_archives/genai/](_archives/genai/README.md) — Infrastructure GenAI detaillee (13+ fichiers)
+- [_archives/suivis/genai-image/](_archives/suivis/genai-image/INDEX.md) — Suivi ComfyUI/Qwen (8 fichiers + 4 phases)
 
 | Fichier | Description |
 |---------|-------------|

--- a/docs/_archives/INDEX.md
+++ b/docs/_archives/INDEX.md
@@ -1,0 +1,44 @@
+# INDEX — Archives docs/
+
+**Archive le** : 2026-06 (docs-reorg S3, See #2456).
+**Theme** : Documents archives du repertoire `docs/` — investigations closes, audits datats, references historiques.
+
+Ces documents sont conserves pour reference mais ne sont plus actifs. Ne pas modifier sans justification.
+
+## Fichiers racine
+
+| Fichier | Resume |
+|---------|--------|
+| 01-cartographie-initiale.md | Cartographie initiale du projet CoursIA |
+| 02-etude-adk-deepmind.md | Etude DeepMind ADK |
+| 03-plan-formation-datascience-agentique.md | Plan formation data science agentique |
+| GROTHENDIECK_MATHLIB_MAP.md | Map Mathlib pour le projet Grothendieck |
+| H7_P2_DOCKER_ERROR_CATALOG.md | Catalog erreurs Docker H7/P2 |
+| NOTEBOOK_ENV_COVERAGE.md | Couverture environnements notebooks |
+| REVERSE_PROXY_CIRCUIT.md | Reverse proxy circuit |
+| dette-branches-audit-2026-05-27.md | Audit dette branches (mai 2026) |
+| env-audit-cluster-2026-05-10.md | Audit environnements cluster (mai 2026) |
+| epf-universalisation-design.md | Design universalisation EPF |
+| epic-1028-audiobook-postmortem.md | Postmortem audiobook (Epic #1028) |
+| genai-images-mission-complete.md | Mission complete images GenAI |
+| genai-services-inventory-2026-05.md | Inventory services GenAI (mai 2026) |
+| genai-stack-audit-2026-05-10.md | Audit stack GenAI (mai 2026) |
+| handson-book-mapping.md | Cartographie du livre Hands-On AI Trading (Jared Broad) |
+| integration-roadmap.md | Roadmap integration |
+| qc-broken-strategies-audit.md | Audit strategies QuantConnect broken |
+| qc-league-ece.md | League ECE QuantConnect |
+| qc-stabilization-phase2.md | Stabilisation QC phase 2 |
+| slides-refonte-procedure.md | Procedure refonte slides |
+| stabilization-phase1-matrix.md | Matrice stabilization phase 1 |
+
+## Sous-repertoires
+
+| Repertoire | Contenu | INDEX |
+|-------------|---------|-------|
+| investigation-mcp-nuget/ | 26 fichiers d'investigation MCP Jupyter / NuGet / .NET Interactive | [INDEX.md](investigation-mcp-nuget/INDEX.md) |
+| genai/ | 13+ fichiers infrastructure GenAI detaillee | [README.md](genai/README.md) |
+| suivis/genai-image/ | 8 fichiers + 4 repertoires de phases (ComfyUI/Qwen) | [INDEX.md](suivis/genai-image/INDEX.md) |
+
+## Issue de reference
+
+Part of #1925 (EPIC refonte docs/). See #2456 (S3 archivage).

--- a/docs/_archives/investigation-mcp-nuget/INDEX.md
+++ b/docs/_archives/investigation-mcp-nuget/INDEX.md
@@ -1,0 +1,40 @@
+# INDEX — Investigation MCP-NuGet (Archives)
+
+**Archive le** : 2026-06 (docs-reorg S3, See #2456).
+**Origine** : `docs/investigation-mcp-nuget/` (supprime apres archivage).
+**Theme** : Investigation du pipeline MCP Jupyter / NuGet / .NET Interactive pour l'execution des notebooks CoursIA.
+
+## Chronologie
+
+| # | Fichier | Resume |
+|---|---------|--------|
+| 06 | 06-MCP-Jupyter-Setup.md | Rapport d'echec initial execution notebook via MCP Jupyter |
+| 07 | 07-SDDD-Investigation-Bug-SDK-Solutions-Alternatives.md | Bug SDK et solutions alternatives |
+| 08 | 08-SDDD-Checkpoint-Semantique-Papermill.md | Checkpoint architecture Papermill-CoursIA |
+| 09 | 09-SDDD-Implementation-Success-Papermill-CoursIA.md | Implementation reussie Papermill-CoursIA |
+| 10 | 10-SDDD-Comparaison-Outils-MCP-Servers.md | Comparaison des outils MCP |
+| 11 | 11-SDDD-Rapport-Validation-Complete-MCP-Servers.md | Validation complete serveurs MCP Jupyter |
+| 12 | 12-MIGRATION-MCP-Jupyter-Python-Server.md | Migration serveur Jupyter Node.js vers Python |
+| 13 | 13-ROLLBACK-MCP-JUPYTER-SERVER.md | Rollback configuration serveur MCP Jupyter |
+| 14 | 14-DIAGNOSTIC-CRITIQUE-MCP-JUPYTER-RECOVERY.md | Diagnostic critique et strategie de recuperation |
+| 15 | 15-TEST-CRITIQUE-SOLUTION-A-SUCCESS-FINAL.md | Test critique final - Solution A architecture MCP amelioree |
+| 16 | 16-VALIDATION-NOTEBOOKS-PYTHON-COMPLEXES-SOLUTION-A.md | Validation notebooks Python complexes via Papermill Direct API |
+| 17 | 17-SDDD-RESOLUTION-DEFINITIVE-NUGET-DOTNET-INTERACTIVE.md | Resolution definitive probleme NuGet .NET Interactive |
+| 18 | 18-SDDD-ETAT-FINAL-MCP-JUPYTER-NUGET.md | Etat final MCP Jupyter-Papermill post-investigation |
+| 19 | 19-RESOLUTION-DEFINITIVE-MICROSOFT-ML-MCP.md | Resolution blocage Microsoft.ML dans MCP |
+| 20 | 20-SYNTHESE-DOCUMENTAIRE-COMPLETE-06-19.md | Synthese documentaire complete (documents 06-19) |
+| 21 | 21-ANALYSE-ARCHITECTURE-MCP-EVOLUTION-GIT.md | Analyse architecture MCP et evolution Git |
+| 22 | 22-RESOLUTION-DEFINITIVE-FINALE-MCP-NUGET.md | Resolution definitive finale MCP-NuGet |
+| 23 | 23-VALIDATION-EXHAUSTIVE-NOTEBOOKS-DOTNET-MCP.md | Validation exhaustive notebooks .NET reels |
+| 24 | 24-RESOLUTION-TECHNIQUE-NUGET-TARGETS-PATH1-NULL.md | Resolution technique erreur NuGet.targets Path1 Null |
+| 25 | 25-SYNTHESE-FINALE-ET-PLAN-ACTION-MCP-NUGET.md | Synthese finale et plan d'action MCP-NuGet |
+| 25b | 25-SYNTHESE-HISTORIQUE-INVESTIGATION-MCP-NUGET.md | Synthese historique investigation MCP-NuGet |
+| 26 | 26-RESOLUTION-DEFINITIVE-MCP-NUGET-SOLUTION-RETROUVEE.md | Resolution definitive MCP-NuGet : la solution retrouvee |
+| 27 | 27-RESOLUTION-FINALE-NOTEBOOK-MAKER-SUJET-COMPLEXE.md | Resolution finale Notebook Maker avec sujets complexes |
+| 29 | 29-ARCHITECTURE-ASYNC-EXECUTIONMANAGER-RESOLUTION-TIMEOUTS.md | Architecture async ExecutionManager - resolution timeouts MCP |
+| 30 | 30-RESOLUTION-DEFINITIVE-SEMANTIC-KERNEL-CLR-NOTEBOOK.md | Resolution definitive SemanticKernel CLR Notebook |
+| 31 | 31-VALIDATION-SYMBOLIQUE-AI-ARGUMENT-ANALYSIS-SUITE.md | Validation suite Argument Analysis |
+
+## Issue de reference
+
+Part of #1925 (EPIC refonte docs/). See #2456 (S3 archivage).

--- a/docs/_archives/suivis/genai-image/INDEX.md
+++ b/docs/_archives/suivis/genai-image/INDEX.md
@@ -1,0 +1,31 @@
+# INDEX — Suivi GenAI Image (Archives)
+
+**Archive le** : 2026-06 (docs-reorg S3, See #2456).
+**Origine** : `docs/suivis/genai-image/` (supprime apres archivage).
+**Theme** : Suivi de l'infrastructure GenAI Image (ComfyUI + Qwen, authentification, Docker, validation exhaustive).
+
+## Fichiers racine
+
+| Fichier | Resume |
+|---------|--------|
+| README.md | Projet GenAI Image - infrastructure locale ComfyUI + Qwen |
+| DOCKER-LOCAL-SETUP.md | Guide configuration Docker local - services GenAI |
+| GUIDE-APIS-ETUDIANTS.md | Guide APIs generation images pour etudiants |
+| RAPPORT-FINAL-MISSION-QWEN-COMFYUI.md | Rapport final stabilisation Qwen ComfyUI |
+| README-AUTH.md | Guide authentification ComfyUI pour notebooks GenAI |
+| README-ETUDIANTS-AUTH.md | Guide authentification ComfyUI pour etudiants |
+| SYNTHESE_FINALE_PHASE_30_EXHAUSTIVITE.md | Synthese finale validation exhaustive notebooks GenAI (Phase 30) |
+| TROUBLESHOOTING.md | Guide troubleshooting GenAI Images |
+
+## Repertoires de phases
+
+| Repertoire | Resume |
+|-------------|--------|
+| phase-12a-production/ | Rapports, screenshots, scripts phase production |
+| phase-29-corrections-qwen-20251031-111200/ | Corrections Qwen (nov 2025) |
+| phase-30-validation-sanctuarisation-docker-qwen/ | Validation et sanctuarisation Docker Qwen (inclut INDEX.md) |
+| phase-31-comfyui-auth/ | Architecture finale ComfyUI-Qwen, analyse Docker configs |
+
+## Issue de reference
+
+Part of #1925 (EPIC refonte docs/). See #2456 (S3 archivage).


### PR DESCRIPTION
## Summary

Ajout de fichiers INDEX.md aux 3 repertoires d'archives docs/_archives/ pour tracer le contenu archive et faciliter la navigation. Mise a jour du docs/README.md pour pointer vers ces index.

See #2456

## Changes

- **_archives/INDEX.md** : index racine (21 fichiers + 3 sous-repertoires)
- **_archives/investigation-mcp-nuget/INDEX.md** : 26 fichiers MCP/NuGet chronologiques
- **_archives/suivis/genai-image/INDEX.md** : 8 fichiers + 4 phases GenAI Image
- **docs/README.md** : liens index archives dans section Historique

## Context #2456 (S3 archivage)

La plupart des archivages S3 etaient deja effectues par ai-01. Les fichiers restants a la racine (STABLE_SNAPSHOT.md, qc-strategies-status.md, audit-reassessment-findings.md) sont actifs et references par des rules/READMEs. Cette PR comble le gap restant : les INDEX.md manquants.

## Verification

- 4 files changed, 122 insertions, 1 deletion
- Aucun contenu vivant deplace (ajout uniquement)