### PR TITLE
docs(archive): add INDEX.md for genai and suivis subdirs (rebase of #2538)

### DIFF
--- a/docs/_archives/genai/INDEX.md
+++ b/docs/_archives/genai/INDEX.md
@@ -1,0 +1,21 @@
+# Archive: GenAI investigations & audits
+
+Documentation technique historique de l'infrastructure GenAI/Images CoursIA (ComfyUI, Qwen, Forge). Archivee depuis `docs/` lors du nettoyage Epic #1925 (juin 2026). Contenu potentiellement stale -- se referer a [docs/genai-services.md](../../genai-services.md) pour l'etat courant.
+
+| # | Fichier | Resume | Date |
+|---|--------|--------|------|
+| 1 | [ecosystem-readme.md](ecosystem-readme.md) | Vue d'ensemble pedagogique de l'ecosysteme GenAI Images (SDDD, objectifs, notebooks) | 2025-10-07 |
+| 2 | [development-standards.md](development-standards.md) | Standards unifies pour l'ecosysteme GenAI Images (nommage, structure modulaire) | 2025-10-07 |
+| 3 | [docker-specs.md](docker-specs.md) | Specifications infrastructure Docker hybride (isolation controlee, APIs REST) | 2025-10-07 |
+| 4 | [docker-orchestration.md](docker-orchestration.md) | Strategie d'orchestration Docker modulaire isolee pour services GenAI | 2025-10-07 |
+| 5 | [docker-lifecycle-management.md](docker-lifecycle-management.md) | Gestion lifecycle containers Docker (approche GitOps, automatisation) | 2025-10-07 |
+| 6 | [environment-configurations.md](environment-configurations.md) | Configurations multi-environnements securisees (strategie hierarchique) | 2025-10-07 |
+| 7 | [integration-procedures.md](integration-procedures.md) | Procedures d'integration MCP avec principe zero-regression | 2025-10-07 |
+| 8 | [phase2-templates.md](phase2-templates.md) | Templates production-ready pour implementation Phase 2 GenAI | 2025-10-07 |
+| 9 | [powershell-scripts.md](powershell-scripts.md) | Scripts PowerShell d'automatisation (setup, validation, deploiement) | 2025-10-07 |
+| 10 | [troubleshooting.md](troubleshooting.md) | Guide de resolution de probleme systematique (approche en couches) | 2025-10-07 |
+| 11 | [infrastructure-tests.md](infrastructure-tests.md) | Strategie de tests multicouches pour l'infrastructure GenAI | 2025-10-08 |
+| 12 | [user-guide.md](user-guide.md) | Guide etudiant APIs generation d'images (ComfyUI + Forge, REST) | 2025-10-16 |
+| 13 | [architecture.md](architecture.md) | Architecture complete ecosysteme GenAI (Phase 30, sanctuarisation) | 2025-12-10 |
+| 14 | [deployment-guide.md](deployment-guide.md) | Guide deploiement production ComfyUI + Qwen Image-Edit (RTX 3090) | 2025-12-10 |
+| 15 | [README.md](README.md) | Documentation de reference globale GenAI/Images (ComfyUI v1.0 + Forge) | n/c |

--- a/docs/_archives/suivis/INDEX.md
+++ b/docs/_archives/suivis/INDEX.md
@@ -1,0 +1,26 @@
+# Archive: Suivis GenAI-Image
+
+Suivis de phases et guides operationnels pour l'infrastructure GenAI Images (ComfyUI + Qwen).
+Archives lors du nettoyage Epic #1925 (juin 2026). Pour la documentation vivante : cf [docs/genai-services.md](../../genai-services.md).
+
+## Fichiers
+
+| Fichier | Resume | Phase |
+|---------|--------|-------|
+| [README.md](genai-image/README.md) | Infrastructure locale ComfyUI + Qwen | General |
+| [DOCKER-LOCAL-SETUP.md](genai-image/DOCKER-LOCAL-SETUP.md) | Configuration Docker local services GenAI | Setup |
+| [TROUBLESHOOTING.md](genai-image/TROUBLESHOOTING.md) | Guide troubleshooting GenAI Images | Support |
+| [README-AUTH.md](genai-image/README-AUTH.md) | Authentification ComfyUI (notebooks) | Auth |
+| [README-ETUDIANTS-AUTH.md](genai-image/README-ETUDIANTS-AUTH.md) | Authentification ComfyUI (etudiants) | Auth |
+| [GUIDE-APIS-ETUDIANTS.md](genai-image/GUIDE-APIS-ETUDIANTS.md) | Guide APIs generation images (etudiants) | Usage |
+| [RAPPORT-FINAL-MISSION-QWEN-COMFYUI.md](genai-image/RAPPORT-FINAL-MISSION-QWEN-COMFYUI.md) | Rapport final stabilisation Qwen ComfyUI | Close |
+| [SYNTHESE_FINALE_PHASE_30_EXHAUSTIVITE.md](genai-image/SYNTHESE_FINALE_PHASE_30_EXHAUSTIVITE.md) | Validation exhaustive notebooks GenAI | Phase 30 |
+
+## Suivis de phases
+
+| Phase | Contenu | Items |
+|-------|---------|-------|
+| [phase-12a-production](genai-image/phase-12a-production/) | Production ComfyUI | 3 |
+| [phase-29-corrections-qwen-20251031-111200](genai-image/phase-29-corrections-qwen-20251031-111200/) | Corrections Qwen (2025-10-31) | 5 |
+| [phase-30-validation-sanctuarisation-docker-qwen](genai-image/phase-30-validation-sanctuarisation-docker-qwen/) | Validation sanctuarisation Docker Qwen | 9 |
+| [phase-31-comfyui-auth](genai-image/phase-31-comfyui-auth/) | Authentification ComfyUI | 12 |


### PR DESCRIPTION
## Summary

Rebase of #2538 — keeps only the net-new content that was NOT already delivered by #2560 (merged).

### What changed (net-new only)
- `docs/_archives/genai/INDEX.md` — 15 entries catalogued (ecosystem, Docker, architecture, deployment)
- `docs/_archives/suivis/INDEX.md` — 8 files + 4 phase subdirectories catalogued

### What was removed (already on main via #2560)
- `docs/_archives/INDEX.md` — already on main
- `docs/_archives/investigation-mcp-nuget/INDEX.md` — already on main

### Validation
- [x] `check_docs_links.py --check` = OK (0 broken links, 2086 total)
- [x] Catalogue byte-identical to main
- [x] 2 files, 47 insertions, 0 deletions

Closes #2538 (supersedes the stale branch)
See #2456
