### PR TITLE
fix(QC): configurable brokerage for all 10 research strategies (See #2471, #1630)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/AllWeather/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/AllWeather/main.py
@@ -52,7 +52,10 @@ class AllWeatherPortfolio(QCAlgorithm):
         self.set_cash(100000)
 
         # Brokerage: US ETFs (SPY/IEF/GLD/XLP) traded via IBKR margin account
-        self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
+        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
+        if self._brokerage_mode != "none":
+            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
 
         # v5.0: IEF reduced 40%->30%, GLD raised 20%->30%
         # Rationale: IEF returned only 1.47% annualized (2015-2026) due to rate hike drag.

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/main.py
@@ -11,7 +11,10 @@ class EMACrossAlphaAlgorithm(QCAlgorithm):
         self.set_start_date(2015, 1, 1)
         self.set_end_date(2024, 12, 31)
         self.set_cash(100000)
-        self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
+        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
+        if self._brokerage_mode != "none":
+            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
 
         tickers = ["AAPL", "MSFT", "GOOGL", "AMZN", "NVDA"]
         for ticker in tickers:

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/main.py
@@ -43,7 +43,10 @@ class ForexCarryTradeStrategy(QCAlgorithm):
         self.set_cash(100000)
 
         # Brokerage: G10 FX traded via OANDA margin account
-        self.set_brokerage_model(BrokerageName.OANDA_BROKERAGE, AccountType.MARGIN)
+        # Configurable brokerage for fee sweep (default: OANDA margin with real fees)
+        self._brokerage_mode = self.get_parameter("brokerage", "oanda")
+        if self._brokerage_mode != "none":
+            self.set_brokerage_model(BrokerageName.OANDA_BROKERAGE, AccountType.MARGIN)
 
         # 4 diversified FX pairs (Europe, Commodity, Asia, Americas) - confirmed best
         self.pair_names = ["EURUSD", "AUDUSD", "USDJPY", "USDCAD"]

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_MomentumRegime/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_MomentumRegime/main.py
@@ -29,7 +29,10 @@ class FrameworkCompositeMomentumRegime(QCAlgorithm):
         self.set_start_date(2015, 1, 1)
         self.set_end_date(2025, 12, 31)
         self.set_cash(100000)
-        self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
+        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
+        if self._brokerage_mode != "none":
+            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
 
         # Combined universe from both strategies
         # SectorMomentum: SPY, IEF, GLD (IEF instead of TLT - TLT destroys value 2015-2026)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MomentumStrategy/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MomentumStrategy/main.py
@@ -31,7 +31,10 @@ class SectorMomentumETFRotation(QCAlgorithm):
         self.set_cash(100000)
 
         # Brokerage: US sector ETFs traded via IBKR margin account
-        self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
+        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
+        if self._brokerage_mode != "none":
+            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
 
         self.sector_tickers = [
             "XLK", "XLF", "XLE", "XLV", "XLI",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
@@ -15,7 +15,10 @@ class PortfolioHybridIBKRBinance(QCAlgorithm):
         self.set_cash(100000)
 
         # Brokerage: dual IBKR (equities) + Binance (crypto) model
-        self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
+        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
+        if self._brokerage_mode != "none":
+            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
 
         # Rebalancing
         self.rebalance_freq = 30  # monthly

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/main.py
@@ -21,6 +21,12 @@ class TrendFollowingAQR(QCAlgorithm):
         self.set_start_date(2015, 1, 1)
         self.set_end_date(2024, 12, 31)
         self.set_cash(100_000)
+
+        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
+        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
+        if self._brokerage_mode != "none":
+            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+
         self.set_benchmark("SPY")
 
         self.risky_tickers = ["SPY", "EFA", "EEM", "TLT", "GLD", "DBC"]

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocks-Alpha/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocks-Alpha/main.py
@@ -11,7 +11,10 @@ class TrendStocksAlphaAlgorithm(QCAlgorithm):
         self.set_start_date(2015, 1, 1)
         self.set_end_date(2024, 12, 31)
         self.set_cash(100000)
-        self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
+        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
+        if self._brokerage_mode != "none":
+            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
 
         tickers = [
             "AAPL", "MSFT", "GOOGL", "AMZN", "NVDA",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/main.py
@@ -23,7 +23,10 @@ class VolTargetMomentum(QCAlgorithm):
         self.set_benchmark("SPY")
 
         # Brokerage: multi-asset ETFs traded via IBKR margin account
-        self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
+        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
+        if self._brokerage_mode != "none":
+            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
 
         self.risky_tickers = ["SPY", "EFA", "EEM", "TLT", "GLD", "DBC"]
         self.safe_ticker = "BND"

--- a/docs/qc-comparative-backtests.md
+++ b/docs/qc-comparative-backtests.md
@@ -268,19 +268,19 @@ Source code analysis of all 10 research projects. Zero strategies have explicitl
 
 ### Fee Model Configuration
 
-| Project | QC ID | `SetFeeModel` | `SetBrokerageModel` | Default Fees |
-|---------|-------|---------------|----------------------|--------------|
-| TrendFollowing | 28797562 | NONE | NONE | QC Default (equity) |
-| EMA-Cross-Stocks | 28789946 | NONE | `IBKR, MARGIN` (#2575) | IBKR tiered |
-| MomentumStrategy | 28657837 | NONE | `IBKR, MARGIN` (#2575) | IBKR tiered |
-| AllWeather | 28657833 | NONE | `IBKR, MARGIN` (#2575) | IBKR tiered |
-| VolTarget-Momentum | 30784745 | NONE | `IBKR, MARGIN` (#2575) | IBKR tiered |
-| Crypto-MultiCanal | 30750734 | NONE | `BINANCE, CASH` (configurable) | Binance schedule (0.1%) |
-| Portfolio-IBKR-Binance | 31717642 | NONE | `IBKR, MARGIN` (#2575) | IBKR tiered |
-| MomentumRegime | 31243821 | NONE | `IBKR, MARGIN` | IBKR tiered |
-| TrendStocks-Alpha | 28885507 | NONE | `IBKR, MARGIN` | IBKR tiered |
-| EMA-Cross-Alpha | 28885488 | NONE | `IBKR, MARGIN` | IBKR tiered |
-| ForexCarry | 28657908 | NONE | `OANDA, MARGIN` (#2575) | OANDA schedule |
+| Project | QC ID | `SetFeeModel` | `SetBrokerageModel` | Configurable | Default Fees |
+|---------|-------|---------------|----------------------|--------------|--------------|
+| Trend-Following | 28797562 | NONE | `IBKR, MARGIN` | YES (`brokerage=ibkr/none`) | IBKR tiered |
+| EMA-Cross-Stocks | 28789946 | NONE | `IBKR, MARGIN` | YES (`brokerage=ibkr/none`) | IBKR tiered |
+| MomentumStrategy | 28657837 | NONE | `IBKR, MARGIN` | YES (`brokerage=ibkr/none`) | IBKR tiered |
+| AllWeather | 28657833 | NONE | `IBKR, MARGIN` | YES (`brokerage=ibkr/none`) | IBKR tiered |
+| VolTarget-Momentum | 30784745 | NONE | `IBKR, MARGIN` | YES (`brokerage=ibkr/none`) | IBKR tiered |
+| Crypto-MultiCanal | 30750734 | NONE | `BINANCE, CASH` | YES (`brokerage=binance/none`) | Binance schedule (0.1%) |
+| Portfolio-IBKR-Binance | 31717642 | NONE | `IBKR, MARGIN` | YES (`brokerage=ibkr/none`) | IBKR tiered |
+| MomentumRegime | 31243821 | NONE | `IBKR, MARGIN` | YES (`brokerage=ibkr/none`) | IBKR tiered |
+| TrendStocks-Alpha | 28885507 | NONE | `IBKR, MARGIN` | YES (`brokerage=ibkr/none`) | IBKR tiered |
+| EMA-Cross-Alpha | 28885488 | NONE | `IBKR, MARGIN` | YES (`brokerage=ibkr/none`) | IBKR tiered |
+| ForexCarry | 28657908 | NONE | `OANDA, MARGIN` | YES (`brokerage=oanda/none`) | OANDA schedule |
 
 ### Turnover Estimation
 


### PR DESCRIPTION
## Summary

Add configurable brokerage parameter to all 10 research strategies, enabling systematic fee sweep testing.

## Changes

**9 strategy files** — each adds 4 lines (configurable brokerage pattern):

| Strategy | Brokerage | Default | Was Before |
|----------|-----------|---------|------------|
| Trend-Following | IBKR MARGIN | ibkr | **NONE** (QC default — now fixed) |
| MomentumStrategy | IBKR MARGIN | ibkr | Fixed IBKR |
| AllWeather | IBKR MARGIN | ibkr | Fixed IBKR |
| VolTarget-Momentum | IBKR MARGIN | ibkr | Fixed IBKR |
| Portfolio-IBKR-Binance | IBKR MARGIN | ibkr | Fixed IBKR |
| MomentumRegime | IBKR MARGIN | ibkr | Fixed IBKR |
| TrendStocks-Alpha | IBKR MARGIN | ibkr | Fixed IBKR |
| EMA-Cross-Alpha | IBKR MARGIN | ibkr | Fixed IBKR |
| ForexCarry | OANDA MARGIN | oanda | Fixed OANDA |

**+ 2 strategies already configurable** (from #2588, #2593): EMA-Cross-Stocks, Crypto-MultiCanal

**Doc update**: docs/qc-comparative-backtests.md — added Configurable column to Fee Model table

## Pattern Applied

```python
self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
if self._brokerage_mode != "none":
    self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
```

Pass `brokerage=none` at backtest time for cost-free baseline comparison.

## Validation

- [x] All 9 files compile (py_compile)
- [x] Pattern identical across all strategies
- [x] No other code changes
- [x] Doc table updated

See #2471, See #1630
