### PR TITLE
fix(ci): remove orphan submodule + restore fast-downward service files

### DIFF
--- a/docker-configurations/services/planners-fast-downward/.env.example
+++ b/docker-configurations/services/planners-fast-downward/.env.example
@@ -1,0 +1,3 @@
+# Fast Downward Planner configuration
+PLANNER_PORT=8200
+TZ=Europe/Paris

--- a/docker-configurations/services/planners-fast-downward/.gitignore
+++ b/docker-configurations/services/planners-fast-downward/.gitignore
@@ -1,0 +1,2 @@
+# Source is cloned at build time, not tracked in git
+src/

--- a/docker-configurations/services/planners-fast-downward/Dockerfile
+++ b/docker-configurations/services/planners-fast-downward/Dockerfile
@@ -1,0 +1,51 @@
+# Fast Downward - Classical AI Planning System
+# https://github.com/aibasel/downward
+#
+# Build: docker compose build
+# Run:   docker compose up -d
+# Test:  curl http://localhost:8200/health
+#
+# CPU-only service (no GPU required for classical planning)
+# Source: cloned from aibasel/downward release-24.06.1
+
+FROM python:3.11-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake \
+    make \
+    g++ \
+    gcc \
+    gawk \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone source at build time (reproducible, no local src/ needed)
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && git clone --depth 1 --branch release-24.06.1 https://github.com/aibasel/downward.git /opt/fast-downward-src \
+    && apt-get remove -y git && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+RUN cd /opt/fast-downward-src \
+    && python3 build.py
+
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gawk \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy built artifacts from builder
+COPY --from=builder /opt/fast-downward-src /opt/fast-downward
+
+# Install unified-planning with Fast Downward support
+RUN pip install --no-cache-dir \
+    unified-planning \
+    up-fast-downward
+
+# HTTP API for planner invocation
+COPY api/ /opt/api/
+
+WORKDIR /opt/fast-downward
+
+EXPOSE 8200
+
+CMD ["python3", "/opt/api/server.py"]

--- a/docker-configurations/services/planners-fast-downward/api/server.py
+++ b/docker-configurations/services/planners-fast-downward/api/server.py
@@ -1,0 +1,77 @@
+"""Minimal HTTP API for Fast Downward planner."""
+import json
+import os
+import subprocess
+import tempfile
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+FD_SCRIPT = "/opt/fast-downward/fast-downward.py"
+
+
+class PlannerHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            self._json_response({
+                "status": "healthy",
+                "planner": "fast-downward",
+                "version": "24.06.1",
+            })
+        else:
+            self._json_response({"error": "not found"}, 404)
+
+    def do_POST(self):
+        if self.path == "/plan":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(content_length))
+
+            domain = body.get("domain", "")
+            problem = body.get("problem", "")
+            search = body.get("search", "astar(lmcut())")
+
+            if not domain or not problem:
+                self._json_response({"error": "domain and problem PDDL required"}, 400)
+                return
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                domain_file = os.path.join(tmpdir, "domain.pddl")
+                problem_file = os.path.join(tmpdir, "problem.pddl")
+
+                with open(domain_file, "w") as f:
+                    f.write(domain)
+                with open(problem_file, "w") as f:
+                    f.write(problem)
+
+                try:
+                    result = subprocess.run(
+                        ["python3", FD_SCRIPT, domain_file, problem_file, "--search", search],
+                        capture_output=True, text=True, timeout=300,
+                        cwd="/opt/fast-downward",
+                    )
+                    self._json_response({
+                        "returncode": result.returncode,
+                        "stdout": result.stdout[-5000:] if result.stdout else "",
+                        "stderr": result.stderr[-5000:] if result.stderr else "",
+                        "search": search,
+                    })
+                except subprocess.TimeoutExpired:
+                    self._json_response({"error": "planning timeout (300s)"}, 504)
+                except Exception as e:
+                    self._json_response({"error": str(e)}, 500)
+        else:
+            self._json_response({"error": "not found"}, 404)
+
+    def _json_response(self, data, code=200):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+    def log_message(self, format, *args):
+        print(f"[planner-api] {args[0]}")
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PLANNER_PORT", 8200))
+    server = HTTPServer(("0.0.0.0", port), PlannerHandler)
+    print(f"Fast Downward API server running on port {port}")
+    server.serve_forever()

--- a/docker-configurations/services/planners-fast-downward/docker-compose.yml
+++ b/docker-configurations/services/planners-fast-downward/docker-compose.yml
@@ -1,0 +1,44 @@
+# Fast Downward - Classical AI Planning System
+# https://github.com/aibasel/fast-downward
+#
+# Build: docker compose build
+# Run:   docker compose up -d
+# Test:  curl http://localhost:8200/health
+# Plan:  curl -X POST http://localhost:8200/plan -H 'Content-Type: application/json' -d '{"domain":"...","problem":"..."}'
+#
+# CPU-only service (no GPU required for classical planning)
+# Port: 8200
+
+services:
+  fast-downward:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: jsboige/coursia-fast-downward:latest
+    container_name: fast-downward
+    hostname: fast-downward
+
+    ports:
+      - "127.0.0.1:${PLANNER_PORT:-8200}:8200"
+
+    volumes:
+      - ../../shared/pddl:/data/pddl
+
+    environment:
+      - PLANNER_PORT=8200
+      - TZ=${TZ:-Europe/Paris}
+
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:8200/health | grep -q healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+    restart: unless-stopped
+
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G


### PR DESCRIPTION
## Problem

The merge commit `d458ac8f` (2026-05-18, P4 branch merge) accidentally:
1. Introduced a gitlink (`src/`, mode 160000) for `docker-configurations/services/planners-fast-downward/src` without a `.gitmodules` entry
2. Dropped all 5 real service files (Dockerfile, docker-compose.yml, api/server.py, .env.example, .gitignore)

This caused **ALL CI workflows** using `actions/checkout@v4` to fail with:
```
fatal: No url found for submodule path 'docker-configurations/services/planners-fast-downward/src' in .gitmodules
```

Affected CI failures (last 24h):
- `Docs Link Check`: 6+ branches
- `Notebook Execution Required`: 2 branches

## Fix

- Remove the dangling gitlink (`git rm --cached`)
- Restore all 5 files from their last good state (commit `27e97dfb`)

## MAJ image Docker

The setup is ready for updating the Fast Downward container image:
```bash
cd docker-configurations/services/planners-fast-downward/
docker compose build
docker push jsboige/coursia-fast-downward:latest
```

The `.gitignore` correctly ignores `src/` (cloned at build time by the Dockerfile from `aibasel/downward` release-24.06.1). The notebooks (`Planners-4-Fast-Downward.ipynb`, `Planners-0-Setup.ipynb`) already `docker pull` from Docker Hub.

## Validation

- `git ls-files -s docker-configurations/services/planners-fast-downward/` shows only regular files (no 160000 entries)
- `.gitmodules` unchanged (no entry needed)
- No notebooks modified → no re-execution needed