### PR TITLE
feat(Lean-13b): complete Grothendieck Lean exercises

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13b-Lean-Grothendieck.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13b-Lean-Grothendieck.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 47,
    "id": "lean13b-setup",
    "metadata": {
     "execution": {
@@ -77,8 +77,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Setup OK : grothendieck_lean project detecte a D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\grothendieck_lean\n",
-      "  WSL path : /mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean\n",
+      "Setup OK : grothendieck_lean project detecte a /Users/macbookpro/epita/prog_contrainte/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean\n",
+      "  WSL path : /Users/macbookpro/epita/prog_contrainte/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean\n",
       "  6 modules Grothendieck disponibles\n"
      ]
     }
@@ -131,11 +131,11 @@
     "    return f'/mnt/{drive}{p.as_posix()[2:]}'\n",
     "\n",
     "WIN_LEAN_PROJECT = find_grothendieck_lean_project()\n",
-    "LEAN_PROJECT = win_to_wsl(WIN_LEAN_PROJECT)\n",
+    "LEAN_PROJECT = str(WIN_LEAN_PROJECT.absolute())\n",
     "\n",
     "def wsl(cmd, timeout=60):\n",
     "    \"\"\"Run a bash command inside WSL Ubuntu.\"\"\"\n",
-    "    full = ['wsl', '-d', 'Ubuntu', '--', 'bash', '-lc', cmd]\n",
+    "    full = ['bash', '-lc', cmd]\n",
     "    try:\n",
     "        r = subprocess.run(full, capture_output=True, text=True, timeout=timeout)\n",
     "        return r.returncode, r.stdout, r.stderr\n",
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 48,
    "id": "lean13b-project-overview",
    "metadata": {
     "execution": {
@@ -279,7 +279,7 @@
       "Structure du projet grothendieck_lean/\n",
       "============================================================\n",
       "\n",
-      "Grothendieck.lean (racine) : 26 lignes\n",
+      "Grothendieck.lean (racine) : 27 lignes\n",
       "\n",
       "  Grothendieck/CategoryAndSites      106 lignes  sorry=0  -- Part 1: Sieves, topologies, 3 axioms\n",
       "  Grothendieck/SchemesTour            79 lignes  sorry=0  -- Part 2: Scheme, Spec, Gamma\n",
@@ -320,7 +320,8 @@
       "      24 | import Grothendieck.MathlibMap\n",
       "      25 | import Grothendieck.Calibration\n",
       "      26 | import Grothendieck.SieveLattice\n",
-      "--- fin (26 lignes) ---\n"
+      "      27 | import Grothendieck.SheafBasics\n",
+      "--- fin (27 lignes) ---\n"
      ]
     }
    ],
@@ -416,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 49,
    "id": "lean13b-cat-sites-display",
    "metadata": {
     "execution": {
@@ -589,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 50,
    "id": "lean13b-cat-sites-check",
    "metadata": {
     "execution": {
@@ -612,22 +613,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Execution du snippet Lean (verification CompleteLattice + topologies extremes)...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Snippet Lean en attente du build Lake (fichiers .olean manquants).\n",
-      "Pour activer les snippets interactifs, lancez d'abord :\n",
-      "  wsl -d Ubuntu -- bash -lc \"cd /mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean && lake build Grothendieck\"\n",
-      "\n",
-      "Resultat attendu (une fois le build termine) :\n",
-      "  #check @instCompleteLatticeSieve -> ... CompleteLattice (Sieve X)\n",
-      "  #check @GrothendieckTopology.trivial -> GrothendieckTopology C\n",
-      "  #check @GrothendieckTopology.discrete -> GrothendieckTopology C\n",
-      "  #check @GrothendieckTopology.dense    -> GrothendieckTopology C\n"
+      "Execution du snippet Lean (verification CompleteLattice + topologies extremes)...\n",
+      "/tmp/lean13b_snippet.lean:3:8: error(lean.unknownIdentifier): Unknown identifier `instCompleteLatticeSieve`\n",
+      "/tmp/lean13b_snippet.lean:6:8: error(lean.unknownIdentifier): Unknown identifier `GrothendieckTopology.trivial`\n",
+      "/tmp/lean13b_snippet.lean:7:8: error(lean.unknownIdentifier): Unknown identifier `GrothendieckTopology.discrete`\n",
+      "/tmp/lean13b_snippet.lean:8:8: error(lean.unknownIdentifier): Unknown identifier `GrothendieckTopology.dense`\n"
      ]
     }
    ],
@@ -694,7 +684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 51,
    "id": "lean13b-schemes-display",
    "metadata": {
     "execution": {
@@ -837,7 +827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 52,
    "id": "lean13b-schemes-check",
    "metadata": {
     "execution": {
@@ -860,21 +850,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Execution du snippet Lean (Scheme, Spec, Gamma)...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Snippet Lean en attente du build Lake (fichiers .olean manquants).\n",
-      "Pour activer les snippets interactifs, lancez d'abord :\n",
-      "  wsl -d Ubuntu -- bash -lc \"cd /mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean && lake build Grothendieck\"\n",
-      "\n",
-      "Resultat attendu :\n",
-      "  #check Scheme       -> Type (u+1)\n",
-      "  #check @Scheme.Spec -> CommRingCat^op ⥤ Scheme\n",
-      "  #check @Scheme.Γ    -> Scheme^op ⥤ CommRingCat\n"
+      "Execution du snippet Lean (Scheme, Spec, Gamma)...\n",
+      "AlgebraicGeometry.Scheme.{u_1} : Type (u_1 + 1)\n",
+      "Scheme.Spec : CommRingCatᵒᵖ ⥤ Scheme\n",
+      "Scheme.Γ : Schemeᵒᵖ ⥤ CommRingCat\n"
      ]
     }
    ],
@@ -941,7 +920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 53,
    "id": "lean13b-zariski-display",
    "metadata": {
     "execution": {
@@ -1090,7 +1069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 54,
    "id": "lean13b-zariski-check",
    "metadata": {
     "execution": {
@@ -1113,21 +1092,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Execution du snippet Lean (Zariski pretopology + topology)...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Snippet Lean en attente du build Lake (fichiers .olean manquants).\n",
-      "Pour activer les snippets interactifs, lancez d'abord :\n",
-      "  wsl -d Ubuntu -- bash -lc \"cd /mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean && lake build Grothendieck\"\n",
-      "\n",
-      "Resultat attendu :\n",
-      "  #check @Scheme.zariskiPretopology -> Pretopology Scheme\n",
-      "  #check @Scheme.zariskiTopology     -> GrothendieckTopology Scheme\n",
-      "  #check @Scheme.zariskiTopology_eq  -> zariskiTopology = zariskiPretopology.toGrothendieck\n"
+      "Execution du snippet Lean (Zariski pretopology + topology)...\n",
+      "Scheme.zariskiPretopology : Pretopology Scheme\n",
+      "Scheme.zariskiTopology : GrothendieckTopology Scheme\n",
+      "Scheme.zariskiTopology_eq : Scheme.zariskiTopology = Scheme.zariskiPretopology.toGrothendieck\n"
      ]
     }
    ],
@@ -1198,7 +1166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 55,
    "id": "lean13b-calibration-display",
    "metadata": {
     "execution": {
@@ -1386,7 +1354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 56,
    "id": "lean13b-sieve-display",
    "metadata": {
     "execution": {
@@ -1565,7 +1533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 57,
    "id": "lean13b-mathlibmap-display",
    "metadata": {
     "execution": {
@@ -1727,7 +1695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 58,
    "id": "lean13b-mathlibmap-count",
    "metadata": {
     "execution": {
@@ -1817,7 +1785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "lean13b-exercise1",
    "metadata": {
     "execution": {
@@ -1840,7 +1808,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 1 a completer\n"
+      "Exercice 1 a completer\n",
+      "CategoryTheory.Limits.HasEqualizers : (C : Type u_2) → [CategoryTheory.Category.{u_1, u_2} C] → Prop\n",
+      "\n"
      ]
     }
    ],
@@ -1859,8 +1829,9 @@
     "#check @CategoryTheory.Limits.HasEqualizers\n",
     "\"\"\"\n",
     "\n",
-    "resultat_ex1 = None  # TODO etudiant : remplacer par run_lean(snippet_ex1, timeout_s=300)\n",
-    "print(\"Exercice 1 a completer\")"
+    "resultat_ex1 = run_lean(snippet_ex1, timeout_s=300)\n",
+    "#print(\"Exercice 1 a completer\")\n",
+    "print(resultat_ex1)"
    ]
   },
   {
@@ -1891,7 +1862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 64,
    "id": "lean13b-exercise2",
    "metadata": {
     "execution": {
@@ -1914,7 +1885,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 2 a completer\n"
+      "\n"
      ]
     }
    ],
@@ -1935,11 +1906,13 @@
     "    (Sieve.pullback f ⊤ : Sieve Y) = ⊤ := by\n",
     "  -- TODO etudiant : completer la preuve\n",
     "  -- Indice : essayez ext Z g puis simp [Sieve.pullback]\n",
-    "  sorry\n",
+    "  ext Z g\n",
+    "  simp [Sieve.pullback]\n",
     "\"\"\"\n",
     "\n",
-    "resultat_ex2 = None  # TODO etudiant : remplacer par run_lean(snippet_ex2, timeout_s=300)\n",
-    "print(\"Exercice 2 a completer\")"
+    "resultat_ex2 = run_lean(snippet_ex2, timeout_s=300)\n",
+    "#print(\"Exercice 2 a completer\")\n",
+    "print(resultat_ex2)"
    ]
   },
   {
@@ -1970,7 +1943,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "lean13b-exercise3",
    "metadata": {
     "execution": {
@@ -1993,7 +1966,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 3 a completer\n"
+      "Exercice 3 a completer\n",
+      "\n"
      ]
     }
    ],
@@ -2017,11 +1991,13 @@
     "    GrothendieckTopology.trivial C ≤ J := by\n",
     "  -- TODO etudiant : completer la preuve\n",
     "  -- Indice : rw [GrothendieckTopology.trivial_eq_bot]\n",
-    "  sorry\n",
+    "  rw [GrothendieckTopology.trivial_eq_bot]\n",
+    "  exact bot_le\n",
     "\"\"\"\n",
     "\n",
-    "resultat_ex3 = None  # TODO etudiant : remplacer par run_lean(snippet_ex3, timeout_s=300)\n",
-    "print(\"Exercice 3 a completer\")"
+    "resultat_ex3 = run_lean(snippet_ex3, timeout_s=300)\n",
+    "#print(\"Exercice 3 a completer\")\n",
+    "print(resultat_ex3)"
    ]
   },
   {
@@ -2084,7 +2060,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -2098,7 +2074,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13b-Lean-Grothendieck.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13b-Lean-Grothendieck.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "lean13b-setup",
    "metadata": {
     "execution": {
@@ -131,11 +131,11 @@
     "    return f'/mnt/{drive}{p.as_posix()[2:]}'\n",
     "\n",
     "WIN_LEAN_PROJECT = find_grothendieck_lean_project()\n",
-    "LEAN_PROJECT = str(WIN_LEAN_PROJECT.absolute())\n",
+    "LEAN_PROJECT = win_to_wsl(WIN_LEAN_PROJECT)\n",
     "\n",
     "def wsl(cmd, timeout=60):\n",
     "    \"\"\"Run a bash command inside WSL Ubuntu.\"\"\"\n",
-    "    full = ['bash', '-lc', cmd]\n",
+    "    full = ['wsl', '-d', 'Ubuntu', '--', 'bash', '-lc', cmd]\n",
     "    try:\n",
     "        r = subprocess.run(full, capture_output=True, text=True, timeout=timeout)\n",
     "        return r.returncode, r.stdout, r.stderr\n",


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->

- Cette PR est la complétion du notebook Lean-13b-Lean-Grothendieck.ipynb. Je voulais précisé que travaillant sur mac, j'ai chercher un moyen de faire fonctionner WSL, j'ai du adapter quelques variable et fonction : la variable LEAN_PROJECT ainsi que la fonction wsl ont été légèrement modifiées, j'espère que cela n'est pas dérangeant pour la correction du TP. Je suis en groupe avec Nicolas Teisseire. Aussi je vous prie de nous excuser si la date de rendu est passée.

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
