### PR TITLE
fix(Lean-5): revert #2680 — restaure convention #2613/#2622 (pas de corrigés intercalés)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
@@ -5,10 +5,10 @@
    "id": "17bf1bc5",
    "metadata": {
     "papermill": {
-     "duration": 0.005438,
-     "end_time": "2026-06-07T08:36:30.046197+00:00",
+     "duration": 0.005569,
+     "end_time": "2026-06-07T15:28:10.656184+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.040759+00:00",
+     "start_time": "2026-06-07T15:28:10.650615+00:00",
      "status": "completed"
     },
     "tags": []
@@ -63,10 +63,10 @@
    "id": "6d822f2b",
    "metadata": {
     "papermill": {
-     "duration": 0.004746,
-     "end_time": "2026-06-07T08:36:30.055746+00:00",
+     "duration": 0.003964,
+     "end_time": "2026-06-07T15:28:10.664389+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.051000+00:00",
+     "start_time": "2026-06-07T15:28:10.660425+00:00",
      "status": "completed"
     },
     "tags": []
@@ -87,16 +87,16 @@
    "id": "2d996e6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:30.065827Z",
-     "iopub.status.busy": "2026-06-07T08:36:30.065639Z",
-     "iopub.status.idle": "2026-06-07T08:36:30.288773Z",
-     "shell.execute_reply": "2026-06-07T08:36:30.287904Z"
+     "iopub.execute_input": "2026-06-07T15:28:10.673706Z",
+     "iopub.status.busy": "2026-06-07T15:28:10.673533Z",
+     "iopub.status.idle": "2026-06-07T15:28:11.983606Z",
+     "shell.execute_reply": "2026-06-07T15:28:11.982733Z"
     },
     "papermill": {
-     "duration": 0.228992,
-     "end_time": "2026-06-07T08:36:30.289312+00:00",
+     "duration": 1.315388,
+     "end_time": "2026-06-07T15:28:11.984135+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.060320+00:00",
+     "start_time": "2026-06-07T15:28:10.668747+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,10 +206,10 @@
    "id": "32371d33",
    "metadata": {
     "papermill": {
-     "duration": 0.004222,
-     "end_time": "2026-06-07T08:36:30.298034+00:00",
+     "duration": 0.0039,
+     "end_time": "2026-06-07T15:28:11.993158+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.293812+00:00",
+     "start_time": "2026-06-07T15:28:11.989258+00:00",
      "status": "completed"
     },
     "tags": []
@@ -234,16 +234,16 @@
    "id": "1799fb34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:30.307445Z",
-     "iopub.status.busy": "2026-06-07T08:36:30.307300Z",
-     "iopub.status.idle": "2026-06-07T08:36:30.413536Z",
-     "shell.execute_reply": "2026-06-07T08:36:30.412701Z"
+     "iopub.execute_input": "2026-06-07T15:28:12.001699Z",
+     "iopub.status.busy": "2026-06-07T15:28:12.001542Z",
+     "iopub.status.idle": "2026-06-07T15:28:12.107749Z",
+     "shell.execute_reply": "2026-06-07T15:28:12.106935Z"
     },
     "papermill": {
-     "duration": 0.111958,
-     "end_time": "2026-06-07T08:36:30.414051+00:00",
+     "duration": 0.11157,
+     "end_time": "2026-06-07T15:28:12.108525+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.302093+00:00",
+     "start_time": "2026-06-07T15:28:11.996955+00:00",
      "status": "completed"
     },
     "tags": []
@@ -318,10 +318,10 @@
    "id": "3cd3b600",
    "metadata": {
     "papermill": {
-     "duration": 0.004749,
-     "end_time": "2026-06-07T08:36:30.423850+00:00",
+     "duration": 0.003918,
+     "end_time": "2026-06-07T15:28:12.116650+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.419101+00:00",
+     "start_time": "2026-06-07T15:28:12.112732+00:00",
      "status": "completed"
     },
     "tags": []
@@ -340,16 +340,16 @@
    "id": "f2e40954",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:30.434970Z",
-     "iopub.status.busy": "2026-06-07T08:36:30.434775Z",
-     "iopub.status.idle": "2026-06-07T08:36:30.544864Z",
-     "shell.execute_reply": "2026-06-07T08:36:30.543678Z"
+     "iopub.execute_input": "2026-06-07T15:28:12.125363Z",
+     "iopub.status.busy": "2026-06-07T15:28:12.125223Z",
+     "iopub.status.idle": "2026-06-07T15:28:12.234591Z",
+     "shell.execute_reply": "2026-06-07T15:28:12.233514Z"
     },
     "papermill": {
-     "duration": 0.117409,
-     "end_time": "2026-06-07T08:36:30.545986+00:00",
+     "duration": 0.114603,
+     "end_time": "2026-06-07T15:28:12.235083+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.428577+00:00",
+     "start_time": "2026-06-07T15:28:12.120480+00:00",
      "status": "completed"
     },
     "tags": []
@@ -418,10 +418,10 @@
    "id": "caf83a6d",
    "metadata": {
     "papermill": {
-     "duration": 0.006444,
-     "end_time": "2026-06-07T08:36:30.558689+00:00",
+     "duration": 0.004031,
+     "end_time": "2026-06-07T15:28:12.243145+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.552245+00:00",
+     "start_time": "2026-06-07T15:28:12.239114+00:00",
      "status": "completed"
     },
     "tags": []
@@ -440,16 +440,16 @@
    "id": "9f814019",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:30.571876Z",
-     "iopub.status.busy": "2026-06-07T08:36:30.571684Z",
-     "iopub.status.idle": "2026-06-07T08:36:30.682936Z",
-     "shell.execute_reply": "2026-06-07T08:36:30.681813Z"
+     "iopub.execute_input": "2026-06-07T15:28:12.253152Z",
+     "iopub.status.busy": "2026-06-07T15:28:12.252976Z",
+     "iopub.status.idle": "2026-06-07T15:28:12.362704Z",
+     "shell.execute_reply": "2026-06-07T15:28:12.362043Z"
     },
     "papermill": {
-     "duration": 0.118296,
-     "end_time": "2026-06-07T08:36:30.683459+00:00",
+     "duration": 0.115568,
+     "end_time": "2026-06-07T15:28:12.363234+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.565163+00:00",
+     "start_time": "2026-06-07T15:28:12.247666+00:00",
      "status": "completed"
     },
     "tags": []
@@ -545,10 +545,10 @@
    "id": "bd153878",
    "metadata": {
     "papermill": {
-     "duration": 0.005337,
-     "end_time": "2026-06-07T08:36:30.694327+00:00",
+     "duration": 0.003837,
+     "end_time": "2026-06-07T15:28:12.371282+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.688990+00:00",
+     "start_time": "2026-06-07T15:28:12.367445+00:00",
      "status": "completed"
     },
     "tags": []
@@ -565,16 +565,16 @@
    "id": "45ee591b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:30.706486Z",
-     "iopub.status.busy": "2026-06-07T08:36:30.706300Z",
-     "iopub.status.idle": "2026-06-07T08:36:30.813919Z",
-     "shell.execute_reply": "2026-06-07T08:36:30.813122Z"
+     "iopub.execute_input": "2026-06-07T15:28:12.380615Z",
+     "iopub.status.busy": "2026-06-07T15:28:12.380470Z",
+     "iopub.status.idle": "2026-06-07T15:28:12.488136Z",
+     "shell.execute_reply": "2026-06-07T15:28:12.487109Z"
     },
     "papermill": {
-     "duration": 0.114924,
-     "end_time": "2026-06-07T08:36:30.814507+00:00",
+     "duration": 0.113668,
+     "end_time": "2026-06-07T15:28:12.488734+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.699583+00:00",
+     "start_time": "2026-06-07T15:28:12.375066+00:00",
      "status": "completed"
     },
     "tags": []
@@ -664,10 +664,10 @@
    "id": "1fcbf065",
    "metadata": {
     "papermill": {
-     "duration": 0.005245,
-     "end_time": "2026-06-07T08:36:30.825224+00:00",
+     "duration": 0.008055,
+     "end_time": "2026-06-07T15:28:12.501271+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.819979+00:00",
+     "start_time": "2026-06-07T15:28:12.493216+00:00",
      "status": "completed"
     },
     "tags": []
@@ -684,16 +684,16 @@
    "id": "63cdc226",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:30.836712Z",
-     "iopub.status.busy": "2026-06-07T08:36:30.836550Z",
-     "iopub.status.idle": "2026-06-07T08:36:30.944880Z",
-     "shell.execute_reply": "2026-06-07T08:36:30.943670Z"
+     "iopub.execute_input": "2026-06-07T15:28:12.510470Z",
+     "iopub.status.busy": "2026-06-07T15:28:12.510324Z",
+     "iopub.status.idle": "2026-06-07T15:28:12.618749Z",
+     "shell.execute_reply": "2026-06-07T15:28:12.617805Z"
     },
     "papermill": {
-     "duration": 0.115221,
-     "end_time": "2026-06-07T08:36:30.945610+00:00",
+     "duration": 0.113667,
+     "end_time": "2026-06-07T15:28:12.619274+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.830389+00:00",
+     "start_time": "2026-06-07T15:28:12.505607+00:00",
      "status": "completed"
     },
     "tags": []
@@ -791,10 +791,10 @@
    "id": "405db572",
    "metadata": {
     "papermill": {
-     "duration": 0.007392,
-     "end_time": "2026-06-07T08:36:30.959241+00:00",
+     "duration": 0.00411,
+     "end_time": "2026-06-07T15:28:12.627885+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.951849+00:00",
+     "start_time": "2026-06-07T15:28:12.623775+00:00",
      "status": "completed"
     },
     "tags": []
@@ -811,16 +811,16 @@
    "id": "f5244c6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:30.973224Z",
-     "iopub.status.busy": "2026-06-07T08:36:30.973053Z",
-     "iopub.status.idle": "2026-06-07T08:36:31.084496Z",
-     "shell.execute_reply": "2026-06-07T08:36:31.083610Z"
+     "iopub.execute_input": "2026-06-07T15:28:12.636987Z",
+     "iopub.status.busy": "2026-06-07T15:28:12.636853Z",
+     "iopub.status.idle": "2026-06-07T15:28:12.748256Z",
+     "shell.execute_reply": "2026-06-07T15:28:12.747406Z"
     },
     "papermill": {
-     "duration": 0.119612,
-     "end_time": "2026-06-07T08:36:31.085078+00:00",
+     "duration": 0.116597,
+     "end_time": "2026-06-07T15:28:12.748720+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:30.965466+00:00",
+     "start_time": "2026-06-07T15:28:12.632123+00:00",
      "status": "completed"
     },
     "tags": []
@@ -892,10 +892,10 @@
    "id": "74e9802f",
    "metadata": {
     "papermill": {
-     "duration": 0.009041,
-     "end_time": "2026-06-07T08:36:31.100242+00:00",
+     "duration": 0.004176,
+     "end_time": "2026-06-07T15:28:12.757446+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.091201+00:00",
+     "start_time": "2026-06-07T15:28:12.753270+00:00",
      "status": "completed"
     },
     "tags": []
@@ -912,16 +912,16 @@
    "id": "c937eb84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:31.120145Z",
-     "iopub.status.busy": "2026-06-07T08:36:31.119966Z",
-     "iopub.status.idle": "2026-06-07T08:36:31.232166Z",
-     "shell.execute_reply": "2026-06-07T08:36:31.231301Z"
+     "iopub.execute_input": "2026-06-07T15:28:12.766541Z",
+     "iopub.status.busy": "2026-06-07T15:28:12.766403Z",
+     "iopub.status.idle": "2026-06-07T15:28:12.877395Z",
+     "shell.execute_reply": "2026-06-07T15:28:12.876547Z"
     },
     "papermill": {
-     "duration": 0.120624,
-     "end_time": "2026-06-07T08:36:31.232748+00:00",
+     "duration": 0.116392,
+     "end_time": "2026-06-07T15:28:12.878121+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.112124+00:00",
+     "start_time": "2026-06-07T15:28:12.761729+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1011,10 +1011,10 @@
    "id": "6f2ac925",
    "metadata": {
     "papermill": {
-     "duration": 0.006088,
-     "end_time": "2026-06-07T08:36:31.246210+00:00",
+     "duration": 0.004808,
+     "end_time": "2026-06-07T15:28:12.888049+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.240122+00:00",
+     "start_time": "2026-06-07T15:28:12.883241+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,16 +1031,16 @@
    "id": "f6ad0774",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:31.260140Z",
-     "iopub.status.busy": "2026-06-07T08:36:31.259976Z",
-     "iopub.status.idle": "2026-06-07T08:36:31.388416Z",
-     "shell.execute_reply": "2026-06-07T08:36:31.387686Z"
+     "iopub.execute_input": "2026-06-07T15:28:12.898686Z",
+     "iopub.status.busy": "2026-06-07T15:28:12.898524Z",
+     "iopub.status.idle": "2026-06-07T15:28:13.024873Z",
+     "shell.execute_reply": "2026-06-07T15:28:13.024139Z"
     },
     "papermill": {
-     "duration": 0.136375,
-     "end_time": "2026-06-07T08:36:31.389006+00:00",
+     "duration": 0.132792,
+     "end_time": "2026-06-07T15:28:13.025781+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.252631+00:00",
+     "start_time": "2026-06-07T15:28:12.892989+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1127,10 +1127,10 @@
    "id": "51847327",
    "metadata": {
     "papermill": {
-     "duration": 0.005761,
-     "end_time": "2026-06-07T08:36:31.401887+00:00",
+     "duration": 0.005053,
+     "end_time": "2026-06-07T15:28:13.035683+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.396126+00:00",
+     "start_time": "2026-06-07T15:28:13.030630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1147,16 +1147,16 @@
    "id": "d7673f0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:31.415662Z",
-     "iopub.status.busy": "2026-06-07T08:36:31.415465Z",
-     "iopub.status.idle": "2026-06-07T08:36:31.522959Z",
-     "shell.execute_reply": "2026-06-07T08:36:31.521998Z"
+     "iopub.execute_input": "2026-06-07T15:28:13.046125Z",
+     "iopub.status.busy": "2026-06-07T15:28:13.045939Z",
+     "iopub.status.idle": "2026-06-07T15:28:13.152508Z",
+     "shell.execute_reply": "2026-06-07T15:28:13.151760Z"
     },
     "papermill": {
-     "duration": 0.115666,
-     "end_time": "2026-06-07T08:36:31.523731+00:00",
+     "duration": 0.112548,
+     "end_time": "2026-06-07T15:28:13.153013+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.408065+00:00",
+     "start_time": "2026-06-07T15:28:13.040465+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1228,10 +1228,10 @@
    "id": "bb7bc147",
    "metadata": {
     "papermill": {
-     "duration": 0.007764,
-     "end_time": "2026-06-07T08:36:31.539132+00:00",
+     "duration": 0.004201,
+     "end_time": "2026-06-07T15:28:13.161915+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.531368+00:00",
+     "start_time": "2026-06-07T15:28:13.157714+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1248,16 +1248,16 @@
    "id": "7b22e015",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:31.554245Z",
-     "iopub.status.busy": "2026-06-07T08:36:31.554059Z",
-     "iopub.status.idle": "2026-06-07T08:36:31.660732Z",
-     "shell.execute_reply": "2026-06-07T08:36:31.659843Z"
+     "iopub.execute_input": "2026-06-07T15:28:13.171214Z",
+     "iopub.status.busy": "2026-06-07T15:28:13.171081Z",
+     "iopub.status.idle": "2026-06-07T15:28:13.280495Z",
+     "shell.execute_reply": "2026-06-07T15:28:13.279775Z"
     },
     "papermill": {
-     "duration": 0.115484,
-     "end_time": "2026-06-07T08:36:31.661319+00:00",
+     "duration": 0.11488,
+     "end_time": "2026-06-07T15:28:13.281011+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.545835+00:00",
+     "start_time": "2026-06-07T15:28:13.166131+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1329,10 +1329,10 @@
    "id": "74f93458",
    "metadata": {
     "papermill": {
-     "duration": 0.00608,
-     "end_time": "2026-06-07T08:36:31.673871+00:00",
+     "duration": 0.004361,
+     "end_time": "2026-06-07T15:28:13.290206+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.667791+00:00",
+     "start_time": "2026-06-07T15:28:13.285845+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1349,16 +1349,16 @@
    "id": "d116e2e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:31.688251Z",
-     "iopub.status.busy": "2026-06-07T08:36:31.688067Z",
-     "iopub.status.idle": "2026-06-07T08:36:31.800805Z",
-     "shell.execute_reply": "2026-06-07T08:36:31.799796Z"
+     "iopub.execute_input": "2026-06-07T15:28:13.301845Z",
+     "iopub.status.busy": "2026-06-07T15:28:13.301697Z",
+     "iopub.status.idle": "2026-06-07T15:28:13.416873Z",
+     "shell.execute_reply": "2026-06-07T15:28:13.416331Z"
     },
     "papermill": {
-     "duration": 0.120477,
-     "end_time": "2026-06-07T08:36:31.801648+00:00",
+     "duration": 0.122243,
+     "end_time": "2026-06-07T15:28:13.417310+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.681171+00:00",
+     "start_time": "2026-06-07T15:28:13.295067+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1478,10 +1478,10 @@
    "id": "b70a5584",
    "metadata": {
     "papermill": {
-     "duration": 0.005725,
-     "end_time": "2026-06-07T08:36:31.813595+00:00",
+     "duration": 0.004715,
+     "end_time": "2026-06-07T15:28:13.427015+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.807870+00:00",
+     "start_time": "2026-06-07T15:28:13.422300+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1498,16 +1498,16 @@
    "id": "db139759",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:31.827264Z",
-     "iopub.status.busy": "2026-06-07T08:36:31.827090Z",
-     "iopub.status.idle": "2026-06-07T08:36:31.941727Z",
-     "shell.execute_reply": "2026-06-07T08:36:31.940446Z"
+     "iopub.execute_input": "2026-06-07T15:28:13.438879Z",
+     "iopub.status.busy": "2026-06-07T15:28:13.438706Z",
+     "iopub.status.idle": "2026-06-07T15:28:13.553483Z",
+     "shell.execute_reply": "2026-06-07T15:28:13.552697Z"
     },
     "papermill": {
-     "duration": 0.122605,
-     "end_time": "2026-06-07T08:36:31.942374+00:00",
+     "duration": 0.121056,
+     "end_time": "2026-06-07T15:28:13.554029+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.819769+00:00",
+     "start_time": "2026-06-07T15:28:13.432973+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1609,10 +1609,10 @@
    "id": "a4f14a25",
    "metadata": {
     "papermill": {
-     "duration": 0.005781,
-     "end_time": "2026-06-07T08:36:31.954329+00:00",
+     "duration": 0.004775,
+     "end_time": "2026-06-07T15:28:13.563997+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.948548+00:00",
+     "start_time": "2026-06-07T15:28:13.559222+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1629,16 +1629,16 @@
    "id": "18307adc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:31.967726Z",
-     "iopub.status.busy": "2026-06-07T08:36:31.967560Z",
-     "iopub.status.idle": "2026-06-07T08:36:32.075054Z",
-     "shell.execute_reply": "2026-06-07T08:36:32.073832Z"
+     "iopub.execute_input": "2026-06-07T15:28:13.575082Z",
+     "iopub.status.busy": "2026-06-07T15:28:13.574927Z",
+     "iopub.status.idle": "2026-06-07T15:28:13.684030Z",
+     "shell.execute_reply": "2026-06-07T15:28:13.683425Z"
     },
     "papermill": {
-     "duration": 0.115023,
-     "end_time": "2026-06-07T08:36:32.075833+00:00",
+     "duration": 0.115768,
+     "end_time": "2026-06-07T15:28:13.684538+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:31.960810+00:00",
+     "start_time": "2026-06-07T15:28:13.568770+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1713,10 +1713,10 @@
    "id": "58e75458",
    "metadata": {
     "papermill": {
-     "duration": 0.006433,
-     "end_time": "2026-06-07T08:36:32.129279+00:00",
+     "duration": 0.00462,
+     "end_time": "2026-06-07T15:28:13.694354+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.122846+00:00",
+     "start_time": "2026-06-07T15:28:13.689734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1733,16 +1733,16 @@
    "id": "81c6424d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:32.142785Z",
-     "iopub.status.busy": "2026-06-07T08:36:32.142611Z",
-     "iopub.status.idle": "2026-06-07T08:36:32.252865Z",
-     "shell.execute_reply": "2026-06-07T08:36:32.251862Z"
+     "iopub.execute_input": "2026-06-07T15:28:13.719039Z",
+     "iopub.status.busy": "2026-06-07T15:28:13.718894Z",
+     "iopub.status.idle": "2026-06-07T15:28:13.827584Z",
+     "shell.execute_reply": "2026-06-07T15:28:13.826499Z"
     },
     "papermill": {
-     "duration": 0.118224,
-     "end_time": "2026-06-07T08:36:32.253561+00:00",
+     "duration": 0.129441,
+     "end_time": "2026-06-07T15:28:13.828392+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.135337+00:00",
+     "start_time": "2026-06-07T15:28:13.698951+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1814,10 +1814,10 @@
    "id": "68918a35",
    "metadata": {
     "papermill": {
-     "duration": 0.009764,
-     "end_time": "2026-06-07T08:36:32.273929+00:00",
+     "duration": 0.005876,
+     "end_time": "2026-06-07T15:28:13.840346+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.264165+00:00",
+     "start_time": "2026-06-07T15:28:13.834470+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1836,16 +1836,16 @@
    "id": "36816a73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:32.291114Z",
-     "iopub.status.busy": "2026-06-07T08:36:32.290952Z",
-     "iopub.status.idle": "2026-06-07T08:36:32.406681Z",
-     "shell.execute_reply": "2026-06-07T08:36:32.405860Z"
+     "iopub.execute_input": "2026-06-07T15:28:13.851854Z",
+     "iopub.status.busy": "2026-06-07T15:28:13.851698Z",
+     "iopub.status.idle": "2026-06-07T15:28:13.967830Z",
+     "shell.execute_reply": "2026-06-07T15:28:13.967110Z"
     },
     "papermill": {
-     "duration": 0.123582,
-     "end_time": "2026-06-07T08:36:32.407295+00:00",
+     "duration": 0.122416,
+     "end_time": "2026-06-07T15:28:13.968335+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.283713+00:00",
+     "start_time": "2026-06-07T15:28:13.845919+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1929,10 +1929,10 @@
    "id": "44cb4396",
    "metadata": {
     "papermill": {
-     "duration": 0.006764,
-     "end_time": "2026-06-07T08:36:32.420561+00:00",
+     "duration": 0.005328,
+     "end_time": "2026-06-07T15:28:13.978822+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.413797+00:00",
+     "start_time": "2026-06-07T15:28:13.973494+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1949,16 +1949,16 @@
    "id": "182cdbc9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:32.434641Z",
-     "iopub.status.busy": "2026-06-07T08:36:32.434475Z",
-     "iopub.status.idle": "2026-06-07T08:36:32.555034Z",
-     "shell.execute_reply": "2026-06-07T08:36:32.554228Z"
+     "iopub.execute_input": "2026-06-07T15:28:13.990555Z",
+     "iopub.status.busy": "2026-06-07T15:28:13.990392Z",
+     "iopub.status.idle": "2026-06-07T15:28:14.111525Z",
+     "shell.execute_reply": "2026-06-07T15:28:14.110877Z"
     },
     "papermill": {
-     "duration": 0.128865,
-     "end_time": "2026-06-07T08:36:32.555905+00:00",
+     "duration": 0.127982,
+     "end_time": "2026-06-07T15:28:14.112059+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.427040+00:00",
+     "start_time": "2026-06-07T15:28:13.984077+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2045,10 +2045,10 @@
    "id": "875f866e",
    "metadata": {
     "papermill": {
-     "duration": 0.006187,
-     "end_time": "2026-06-07T08:36:32.568724+00:00",
+     "duration": 0.005089,
+     "end_time": "2026-06-07T15:28:14.122659+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.562537+00:00",
+     "start_time": "2026-06-07T15:28:14.117570+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2063,16 +2063,16 @@
    "id": "6eeec3ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:32.581409Z",
-     "iopub.status.busy": "2026-06-07T08:36:32.581265Z",
-     "iopub.status.idle": "2026-06-07T08:36:32.698244Z",
-     "shell.execute_reply": "2026-06-07T08:36:32.697159Z"
+     "iopub.execute_input": "2026-06-07T15:28:14.133297Z",
+     "iopub.status.busy": "2026-06-07T15:28:14.133180Z",
+     "iopub.status.idle": "2026-06-07T15:28:14.250003Z",
+     "shell.execute_reply": "2026-06-07T15:28:14.249096Z"
     },
     "papermill": {
-     "duration": 0.124167,
-     "end_time": "2026-06-07T08:36:32.699018+00:00",
+     "duration": 0.12349,
+     "end_time": "2026-06-07T15:28:14.250889+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.574851+00:00",
+     "start_time": "2026-06-07T15:28:14.127399+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2150,10 +2150,10 @@
    "id": "589d7c21",
    "metadata": {
     "papermill": {
-     "duration": 0.009108,
-     "end_time": "2026-06-07T08:36:32.715471+00:00",
+     "duration": 0.004923,
+     "end_time": "2026-06-07T15:28:14.261093+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.706363+00:00",
+     "start_time": "2026-06-07T15:28:14.256170+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2172,16 +2172,16 @@
    "id": "1c8cf1a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:32.730989Z",
-     "iopub.status.busy": "2026-06-07T08:36:32.730805Z",
-     "iopub.status.idle": "2026-06-07T08:36:32.845891Z",
-     "shell.execute_reply": "2026-06-07T08:36:32.845167Z"
+     "iopub.execute_input": "2026-06-07T15:28:14.274807Z",
+     "iopub.status.busy": "2026-06-07T15:28:14.274676Z",
+     "iopub.status.idle": "2026-06-07T15:28:14.391422Z",
+     "shell.execute_reply": "2026-06-07T15:28:14.390743Z"
     },
     "papermill": {
-     "duration": 0.124213,
-     "end_time": "2026-06-07T08:36:32.846679+00:00",
+     "duration": 0.125967,
+     "end_time": "2026-06-07T15:28:14.391911+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.722466+00:00",
+     "start_time": "2026-06-07T15:28:14.265944+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2262,10 +2262,10 @@
    "id": "aea953de",
    "metadata": {
     "papermill": {
-     "duration": 0.005922,
-     "end_time": "2026-06-07T08:36:32.859098+00:00",
+     "duration": 0.005175,
+     "end_time": "2026-06-07T15:28:14.402347+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.853176+00:00",
+     "start_time": "2026-06-07T15:28:14.397172+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2280,16 +2280,16 @@
    "id": "e00b63d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:32.871556Z",
-     "iopub.status.busy": "2026-06-07T08:36:32.871421Z",
-     "iopub.status.idle": "2026-06-07T08:36:32.988091Z",
-     "shell.execute_reply": "2026-06-07T08:36:32.986855Z"
+     "iopub.execute_input": "2026-06-07T15:28:14.412787Z",
+     "iopub.status.busy": "2026-06-07T15:28:14.412666Z",
+     "iopub.status.idle": "2026-06-07T15:28:14.528203Z",
+     "shell.execute_reply": "2026-06-07T15:28:14.527234Z"
     },
     "papermill": {
-     "duration": 0.123838,
-     "end_time": "2026-06-07T08:36:32.988787+00:00",
+     "duration": 0.121474,
+     "end_time": "2026-06-07T15:28:14.528657+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.864949+00:00",
+     "start_time": "2026-06-07T15:28:14.407183+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2373,10 +2373,10 @@
    "id": "64af1a30",
    "metadata": {
     "papermill": {
-     "duration": 0.007835,
-     "end_time": "2026-06-07T08:36:33.003561+00:00",
+     "duration": 0.005554,
+     "end_time": "2026-06-07T15:28:14.539884+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:32.995726+00:00",
+     "start_time": "2026-06-07T15:28:14.534330+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2393,16 +2393,16 @@
    "id": "497820cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:33.020895Z",
-     "iopub.status.busy": "2026-06-07T08:36:33.020734Z",
-     "iopub.status.idle": "2026-06-07T08:36:33.130358Z",
-     "shell.execute_reply": "2026-06-07T08:36:33.129568Z"
+     "iopub.execute_input": "2026-06-07T15:28:14.551653Z",
+     "iopub.status.busy": "2026-06-07T15:28:14.551418Z",
+     "iopub.status.idle": "2026-06-07T15:28:14.662274Z",
+     "shell.execute_reply": "2026-06-07T15:28:14.661417Z"
     },
     "papermill": {
-     "duration": 0.117765,
-     "end_time": "2026-06-07T08:36:33.130812+00:00",
+     "duration": 0.117505,
+     "end_time": "2026-06-07T15:28:14.662852+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.013047+00:00",
+     "start_time": "2026-06-07T15:28:14.545347+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2471,10 +2471,10 @@
    "id": "1d2a77dd",
    "metadata": {
     "papermill": {
-     "duration": 0.00573,
-     "end_time": "2026-06-07T08:36:33.143000+00:00",
+     "duration": 0.00542,
+     "end_time": "2026-06-07T15:28:14.673884+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.137270+00:00",
+     "start_time": "2026-06-07T15:28:14.668464+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2491,16 +2491,16 @@
    "id": "eb55cf94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:33.155787Z",
-     "iopub.status.busy": "2026-06-07T08:36:33.155603Z",
-     "iopub.status.idle": "2026-06-07T08:36:33.263016Z",
-     "shell.execute_reply": "2026-06-07T08:36:33.262077Z"
+     "iopub.execute_input": "2026-06-07T15:28:14.684980Z",
+     "iopub.status.busy": "2026-06-07T15:28:14.684851Z",
+     "iopub.status.idle": "2026-06-07T15:28:14.793256Z",
+     "shell.execute_reply": "2026-06-07T15:28:14.792466Z"
     },
     "papermill": {
-     "duration": 0.114706,
-     "end_time": "2026-06-07T08:36:33.263666+00:00",
+     "duration": 0.114822,
+     "end_time": "2026-06-07T15:28:14.793838+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.148960+00:00",
+     "start_time": "2026-06-07T15:28:14.679016+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2572,10 +2572,10 @@
    "id": "81603479",
    "metadata": {
     "papermill": {
-     "duration": 0.008505,
-     "end_time": "2026-06-07T08:36:33.280202+00:00",
+     "duration": 0.005778,
+     "end_time": "2026-06-07T15:28:14.805542+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.271697+00:00",
+     "start_time": "2026-06-07T15:28:14.799764+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2590,16 +2590,16 @@
    "id": "cefe9134",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:33.296531Z",
-     "iopub.status.busy": "2026-06-07T08:36:33.296355Z",
-     "iopub.status.idle": "2026-06-07T08:36:33.404514Z",
-     "shell.execute_reply": "2026-06-07T08:36:33.403532Z"
+     "iopub.execute_input": "2026-06-07T15:28:14.817347Z",
+     "iopub.status.busy": "2026-06-07T15:28:14.817205Z",
+     "iopub.status.idle": "2026-06-07T15:28:14.926486Z",
+     "shell.execute_reply": "2026-06-07T15:28:14.925941Z"
     },
     "papermill": {
-     "duration": 0.117773,
-     "end_time": "2026-06-07T08:36:33.405399+00:00",
+     "duration": 0.115964,
+     "end_time": "2026-06-07T15:28:14.927166+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.287626+00:00",
+     "start_time": "2026-06-07T15:28:14.811202+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2677,10 +2677,10 @@
    "id": "8b56cefe",
    "metadata": {
     "papermill": {
-     "duration": 0.00786,
-     "end_time": "2026-06-07T08:36:33.421294+00:00",
+     "duration": 0.005125,
+     "end_time": "2026-06-07T15:28:14.938230+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.413434+00:00",
+     "start_time": "2026-06-07T15:28:14.933105+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2695,16 +2695,16 @@
    "id": "abd55f74",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:33.437640Z",
-     "iopub.status.busy": "2026-06-07T08:36:33.437494Z",
-     "iopub.status.idle": "2026-06-07T08:36:33.550306Z",
-     "shell.execute_reply": "2026-06-07T08:36:33.549476Z"
+     "iopub.execute_input": "2026-06-07T15:28:14.949419Z",
+     "iopub.status.busy": "2026-06-07T15:28:14.949286Z",
+     "iopub.status.idle": "2026-06-07T15:28:15.060168Z",
+     "shell.execute_reply": "2026-06-07T15:28:15.059349Z"
     },
     "papermill": {
-     "duration": 0.121974,
-     "end_time": "2026-06-07T08:36:33.551000+00:00",
+     "duration": 0.117524,
+     "end_time": "2026-06-07T15:28:15.060850+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.429026+00:00",
+     "start_time": "2026-06-07T15:28:14.943326+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2788,10 +2788,10 @@
    "id": "63c6176f",
    "metadata": {
     "papermill": {
-     "duration": 0.00813,
-     "end_time": "2026-06-07T08:36:33.567366+00:00",
+     "duration": 0.005976,
+     "end_time": "2026-06-07T15:28:15.073210+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.559236+00:00",
+     "start_time": "2026-06-07T15:28:15.067234+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2808,16 +2808,16 @@
    "id": "e4ca8a52",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:33.583790Z",
-     "iopub.status.busy": "2026-06-07T08:36:33.583638Z",
-     "iopub.status.idle": "2026-06-07T08:36:33.700881Z",
-     "shell.execute_reply": "2026-06-07T08:36:33.700135Z"
+     "iopub.execute_input": "2026-06-07T15:28:15.087100Z",
+     "iopub.status.busy": "2026-06-07T15:28:15.086943Z",
+     "iopub.status.idle": "2026-06-07T15:28:15.202882Z",
+     "shell.execute_reply": "2026-06-07T15:28:15.201833Z"
     },
     "papermill": {
-     "duration": 0.126394,
-     "end_time": "2026-06-07T08:36:33.701513+00:00",
+     "duration": 0.124178,
+     "end_time": "2026-06-07T15:28:15.203409+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.575119+00:00",
+     "start_time": "2026-06-07T15:28:15.079231+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2938,10 +2938,10 @@
    "id": "edb2e20d",
    "metadata": {
     "papermill": {
-     "duration": 0.00754,
-     "end_time": "2026-06-07T08:36:33.717580+00:00",
+     "duration": 0.00623,
+     "end_time": "2026-06-07T15:28:15.216142+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.710040+00:00",
+     "start_time": "2026-06-07T15:28:15.209912+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2956,16 +2956,16 @@
    "id": "a53ec84b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:33.734451Z",
-     "iopub.status.busy": "2026-06-07T08:36:33.734258Z",
-     "iopub.status.idle": "2026-06-07T08:36:33.847350Z",
-     "shell.execute_reply": "2026-06-07T08:36:33.846461Z"
+     "iopub.execute_input": "2026-06-07T15:28:15.229345Z",
+     "iopub.status.busy": "2026-06-07T15:28:15.229197Z",
+     "iopub.status.idle": "2026-06-07T15:28:15.343825Z",
+     "shell.execute_reply": "2026-06-07T15:28:15.342953Z"
     },
     "papermill": {
-     "duration": 0.123165,
-     "end_time": "2026-06-07T08:36:33.847940+00:00",
+     "duration": 0.121969,
+     "end_time": "2026-06-07T15:28:15.344405+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.724775+00:00",
+     "start_time": "2026-06-07T15:28:15.222436+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3040,10 +3040,10 @@
    "id": "636978fd",
    "metadata": {
     "papermill": {
-     "duration": 0.007788,
-     "end_time": "2026-06-07T08:36:33.864969+00:00",
+     "duration": 0.006495,
+     "end_time": "2026-06-07T15:28:15.357567+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.857181+00:00",
+     "start_time": "2026-06-07T15:28:15.351072+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3058,16 +3058,16 @@
    "id": "9f0f0026",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:33.880292Z",
-     "iopub.status.busy": "2026-06-07T08:36:33.880143Z",
-     "iopub.status.idle": "2026-06-07T08:36:34.012410Z",
-     "shell.execute_reply": "2026-06-07T08:36:34.011774Z"
+     "iopub.execute_input": "2026-06-07T15:28:15.370373Z",
+     "iopub.status.busy": "2026-06-07T15:28:15.370230Z",
+     "iopub.status.idle": "2026-06-07T15:28:15.501736Z",
+     "shell.execute_reply": "2026-06-07T15:28:15.501128Z"
     },
     "papermill": {
-     "duration": 0.141606,
-     "end_time": "2026-06-07T08:36:34.013410+00:00",
+     "duration": 0.138327,
+     "end_time": "2026-06-07T15:28:15.502227+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:33.871804+00:00",
+     "start_time": "2026-06-07T15:28:15.363900+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3139,10 +3139,10 @@
    "id": "0de421f5",
    "metadata": {
     "papermill": {
-     "duration": 0.008939,
-     "end_time": "2026-06-07T08:36:34.030794+00:00",
+     "duration": 0.006571,
+     "end_time": "2026-06-07T15:28:15.515008+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:34.021855+00:00",
+     "start_time": "2026-06-07T15:28:15.508437+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3157,16 +3157,16 @@
    "id": "f32f45f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:34.047810Z",
-     "iopub.status.busy": "2026-06-07T08:36:34.047617Z",
-     "iopub.status.idle": "2026-06-07T08:36:34.162033Z",
-     "shell.execute_reply": "2026-06-07T08:36:34.161248Z"
+     "iopub.execute_input": "2026-06-07T15:28:15.529916Z",
+     "iopub.status.busy": "2026-06-07T15:28:15.529756Z",
+     "iopub.status.idle": "2026-06-07T15:28:15.646658Z",
+     "shell.execute_reply": "2026-06-07T15:28:15.645769Z"
     },
     "papermill": {
-     "duration": 0.124061,
-     "end_time": "2026-06-07T08:36:34.163021+00:00",
+     "duration": 0.125539,
+     "end_time": "2026-06-07T15:28:15.647554+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:34.038960+00:00",
+     "start_time": "2026-06-07T15:28:15.522015+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3256,10 +3256,10 @@
    "id": "b189bc94",
    "metadata": {
     "papermill": {
-     "duration": 0.008908,
-     "end_time": "2026-06-07T08:36:34.180201+00:00",
+     "duration": 0.006864,
+     "end_time": "2026-06-07T15:28:15.661234+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:34.171293+00:00",
+     "start_time": "2026-06-07T15:28:15.654370+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3276,16 +3276,16 @@
    "id": "b4ec3331",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:34.196622Z",
-     "iopub.status.busy": "2026-06-07T08:36:34.196443Z",
-     "iopub.status.idle": "2026-06-07T08:36:34.310648Z",
-     "shell.execute_reply": "2026-06-07T08:36:34.309326Z"
+     "iopub.execute_input": "2026-06-07T15:28:15.675045Z",
+     "iopub.status.busy": "2026-06-07T15:28:15.674871Z",
+     "iopub.status.idle": "2026-06-07T15:28:15.788002Z",
+     "shell.execute_reply": "2026-06-07T15:28:15.787161Z"
     },
     "papermill": {
-     "duration": 0.12418,
-     "end_time": "2026-06-07T08:36:34.311422+00:00",
+     "duration": 0.120909,
+     "end_time": "2026-06-07T15:28:15.788441+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:34.187242+00:00",
+     "start_time": "2026-06-07T15:28:15.667532+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3363,10 +3363,10 @@
    "id": "c856651d",
    "metadata": {
     "papermill": {
-     "duration": 0.007452,
-     "end_time": "2026-06-07T08:36:34.326850+00:00",
+     "duration": 0.006105,
+     "end_time": "2026-06-07T15:28:15.801011+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:34.319398+00:00",
+     "start_time": "2026-06-07T15:28:15.794906+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3381,16 +3381,16 @@
    "id": "37f1d764",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:34.342766Z",
-     "iopub.status.busy": "2026-06-07T08:36:34.342609Z",
-     "iopub.status.idle": "2026-06-07T08:36:34.451119Z",
-     "shell.execute_reply": "2026-06-07T08:36:34.450152Z"
+     "iopub.execute_input": "2026-06-07T15:28:15.813986Z",
+     "iopub.status.busy": "2026-06-07T15:28:15.813839Z",
+     "iopub.status.idle": "2026-06-07T15:28:15.920851Z",
+     "shell.execute_reply": "2026-06-07T15:28:15.920207Z"
     },
     "papermill": {
-     "duration": 0.117535,
-     "end_time": "2026-06-07T08:36:34.451874+00:00",
+     "duration": 0.114675,
+     "end_time": "2026-06-07T15:28:15.921543+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:34.334339+00:00",
+     "start_time": "2026-06-07T15:28:15.806868+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3462,859 +3462,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "754f3737",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008701,
-     "end_time": "2026-06-07T08:36:34.469000+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:34.460299+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## 10. Exercices\n",
-    "\n",
-    "### Exercice 1 : Preuve tactique de l'associativite de And"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "f382bcf1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:34.485285Z",
-     "iopub.status.busy": "2026-06-07T08:36:34.485130Z",
-     "iopub.status.idle": "2026-06-07T08:36:34.594060Z",
-     "shell.execute_reply": "2026-06-07T08:36:34.593315Z"
-    },
-    "papermill": {
-     "duration": 0.117833,
-     "end_time": "2026-06-07T08:36:34.594696+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:34.476863+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">variable</span><span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>and_assoc_tactic<span class=\"w\"> </span>:<span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>(q<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 30</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 0</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"variable (p q r : Prop)\\n\\ntheorem and_assoc_tactic : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  sorry\", \"env\": 29}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 0,\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
-       "   \"goal\": \"p q r : Prop\\n⊢ (p ∧ q) ∧ r ↔ p ∧ q ∧ r\",\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 24},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 30}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "variable (p q r : Prop)\n",
-       "\n",
-       "theorem and_assoc_tactic : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n",
-       "        ────────────────▶ 🟨 declaration uses `sorry`\n",
-       "  sorry\n",
-       "--% env 30\n",
-       "--% prove 0\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"variable (p q r : Prop)\\n\\ntheorem and_assoc_tactic : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  sorry\", \"env\": 29}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 0,\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
-       "   \"goal\": \"p q r : Prop\\n⊢ (p ∧ q) ∧ r ↔ p ∧ q ∧ r\",\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 24},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 30}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "variable (p q r : Prop)\n",
-    "\n",
-    "theorem and_assoc_tactic : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n",
-    "  sorry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "51a04de9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007862,
-     "end_time": "2026-06-07T08:36:34.611103+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:34.603241+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "**Corrigé — rendu PR #2510 (@thorgal27)** : preuve de `and_assoc_tactic` avec `constructor`, `intro`, `cases`, `exact`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "id": "87c5396c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:34.628333Z",
-     "iopub.status.busy": "2026-06-07T08:36:34.628158Z",
-     "iopub.status.idle": "2026-06-07T08:36:34.748460Z",
-     "shell.execute_reply": "2026-06-07T08:36:34.747022Z"
-    },
-    "papermill": {
-     "duration": 0.130117,
-     "end_time": "2026-06-07T08:36:34.749392+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:34.619275+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Corrigé — rendu PR #2510 (@thorgal27)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">variable</span><span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>and_assoc_tactic_corrige<span class=\"w\"> </span>:<span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>(q<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">·</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>h</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    cases<span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hpq<span class=\"w\"> </span>hr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hpq<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hq<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hq</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hr</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">·</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>h</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    cases<span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hqr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hqr<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hq<span class=\"w\"> </span>hr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hq</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hr</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 31</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Corrig\\u00e9 \\u2014 rendu PR #2510 (@thorgal27)\\nvariable (p q r : Prop)\\ntheorem and_assoc_tactic_corrige : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hpq hr =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 constructor\\n          \\u00b7 exact hq\\n          \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | intro hq hr =>\\n        constructor\\n        \\u00b7 constructor\\n          \\u00b7 exact hp\\n          \\u00b7 exact hq\\n        \\u00b7 exact hr\", \"env\": 30}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"env\": 31}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Corrigé — rendu PR #2510 (@thorgal27)\n",
-       "variable (p q r : Prop)\n",
-       "theorem and_assoc_tactic_corrige : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n",
-       "  constructor\n",
-       "  · intro h\n",
-       "    cases h with\n",
-       "    | intro hpq hr =>\n",
-       "      cases hpq with\n",
-       "      | intro hp hq =>\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · constructor\n",
-       "          · exact hq\n",
-       "          · exact hr\n",
-       "  · intro h\n",
-       "    cases h with\n",
-       "    | intro hp hqr =>\n",
-       "      cases hqr with\n",
-       "      | intro hq hr =>\n",
-       "        constructor\n",
-       "        · constructor\n",
-       "          · exact hp\n",
-       "          · exact hq\n",
-       "        · exact hr\n",
-       "--% env 31\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Corrig\\u00e9 \\u2014 rendu PR #2510 (@thorgal27)\\nvariable (p q r : Prop)\\ntheorem and_assoc_tactic_corrige : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hpq hr =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 constructor\\n          \\u00b7 exact hq\\n          \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | intro hq hr =>\\n        constructor\\n        \\u00b7 constructor\\n          \\u00b7 exact hp\\n          \\u00b7 exact hq\\n        \\u00b7 exact hr\", \"env\": 30}\n",
-       "Raw output:\n",
-       "{\"env\": 31}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Corrigé — rendu PR #2510 (@thorgal27)\n",
-    "variable (p q r : Prop)\n",
-    "theorem and_assoc_tactic_corrige : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n",
-    "  constructor\n",
-    "  · intro h\n",
-    "    cases h with\n",
-    "    | intro hpq hr =>\n",
-    "      cases hpq with\n",
-    "      | intro hp hq =>\n",
-    "        constructor\n",
-    "        · exact hp\n",
-    "        · constructor\n",
-    "          · exact hq\n",
-    "          · exact hr\n",
-    "  · intro h\n",
-    "    cases h with\n",
-    "    | intro hp hqr =>\n",
-    "      cases hqr with\n",
-    "      | intro hq hr =>\n",
-    "        constructor\n",
-    "        · constructor\n",
-    "          · exact hp\n",
-    "          · exact hq\n",
-    "        · exact hr"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a28082f5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.009766,
-     "end_time": "2026-06-07T08:36:34.770084+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:34.760318+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice 2 : Utiliser rw pour une preuve arithmetique"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "id": "9009ecb1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:34.795406Z",
-     "iopub.status.busy": "2026-06-07T08:36:34.794781Z",
-     "iopub.status.idle": "2026-06-07T08:36:34.905462Z",
-     "shell.execute_reply": "2026-06-07T08:36:34.904707Z"
-    },
-    "papermill": {
-     "duration": 0.124869,
-     "end_time": "2026-06-07T08:36:34.905949+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:34.781080+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>arith_rw<span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>(b<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>a)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 32</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 1</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"theorem arith_rw (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  sorry\", \"env\": 31}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 1,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 2},\r\n",
-       "   \"goal\": \"a b : Nat\\n⊢ a + b + (b + a) = 2 * (a + b)\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 1, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 1, \"column\": 16},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 32}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "theorem arith_rw (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n",
-       "        ────────▶ 🟨 declaration uses `sorry`\n",
-       "  sorry\n",
-       "--% env 32\n",
-       "--% prove 1\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"theorem arith_rw (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  sorry\", \"env\": 31}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 1,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 2},\r\n",
-       "   \"goal\": \"a b : Nat\\n⊢ a + b + (b + a) = 2 * (a + b)\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 1, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 1, \"column\": 16},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 32}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "theorem arith_rw (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n",
-    "  sorry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c097b9a9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007655,
-     "end_time": "2026-06-07T08:36:34.921683+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:34.914028+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "**Corrigé — rendu PR #2510 (@thorgal27)** : preuve de `arith_rw` avec `rw [Nat.two_mul]` et `rw [Nat.add_comm b a]`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "id": "ffa8c330",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:34.937690Z",
-     "iopub.status.busy": "2026-06-07T08:36:34.937516Z",
-     "iopub.status.idle": "2026-06-07T08:36:35.051728Z",
-     "shell.execute_reply": "2026-06-07T08:36:35.050939Z"
-    },
-    "papermill": {
-     "duration": 0.12289,
-     "end_time": "2026-06-07T08:36:35.052355+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:34.929465+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Corrigé — rendu PR #2510 (@thorgal27)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>arith_rw_corrige<span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>(b<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>a)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`p</span><span class=\"bp\">`</span>\n",
-       "\n",
-       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`q</span><span class=\"bp\">`</span>\n",
-       "\n",
-       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`r</span><span class=\"bp\">`</span>\n",
-       "\n",
-       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  rw<span class=\"w\"> </span>[Nat<span class=\"bp\">.</span>two_mul]</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  rw<span class=\"w\"> </span>[Nat<span class=\"bp\">.</span>add_comm<span class=\"w\"> </span>b<span class=\"w\"> </span>a]</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 33</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Corrig\\u00e9 \\u2014 rendu PR #2510 (@thorgal27)\\ntheorem arith_rw_corrige (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  rw [Nat.two_mul]\\n  rw [Nat.add_comm b a]\", \"env\": 32}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 10},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 11},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `p`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
-       "  {\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 12},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 13},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `q`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
-       "  {\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 14},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 15},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `r`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
-       " \"env\": 33}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Corrigé — rendu PR #2510 (@thorgal27)\n",
-       "theorem arith_rw_corrige (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n",
-       "          ─▶ 🟨 unused variable `p`\n",
-       "\n",
-       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
-       "            ─▶ 🟨 unused variable `q`\n",
-       "\n",
-       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
-       "              ─▶ 🟨 unused variable `r`\n",
-       "\n",
-       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
-       "  rw [Nat.two_mul]\n",
-       "  rw [Nat.add_comm b a]\n",
-       "--% env 33\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Corrig\\u00e9 \\u2014 rendu PR #2510 (@thorgal27)\\ntheorem arith_rw_corrige (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  rw [Nat.two_mul]\\n  rw [Nat.add_comm b a]\", \"env\": 32}\n",
-       "Raw output:\n",
-       "{\"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 10},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 11},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `p`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
-       "  {\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 12},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 13},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `q`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
-       "  {\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 14},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 15},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `r`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
-       " \"env\": 33}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Corrigé — rendu PR #2510 (@thorgal27)\n",
-    "theorem arith_rw_corrige (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n",
-    "  rw [Nat.two_mul]\n",
-    "  rw [Nat.add_comm b a]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "567872b0",
-   "metadata": {
-    "papermill": {
-     "duration": 0.009164,
-     "end_time": "2026-06-07T08:36:35.071601+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:35.062437+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice 3 : Analyse par cas avec Or"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "id": "5614eaac",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:35.089953Z",
-     "iopub.status.busy": "2026-06-07T08:36:35.089729Z",
-     "iopub.status.idle": "2026-06-07T08:36:35.197880Z",
-     "shell.execute_reply": "2026-06-07T08:36:35.197018Z"
-    },
-    "papermill": {
-     "duration": 0.118487,
-     "end_time": "2026-06-07T08:36:35.198974+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:35.080487+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>or_distrib<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>(q<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>r)<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 34</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 2</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"theorem or_distrib (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  sorry\", \"env\": 33}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 2,\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 2},\r\n",
-       "   \"goal\": \"p q r : Prop\\n⊢ p ∧ (q ∨ r) ↔ p ∧ q ∨ p ∧ r\",\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 1, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 1, \"column\": 18},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 34}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "theorem or_distrib (p q r : Prop) :\n",
-       "        ──────────▶ 🟨 declaration uses `sorry`\n",
-       "  p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n",
-       "  sorry\n",
-       "--% env 34\n",
-       "--% prove 2\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"theorem or_distrib (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  sorry\", \"env\": 33}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 2,\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 2},\r\n",
-       "   \"goal\": \"p q r : Prop\\n⊢ p ∧ (q ∨ r) ↔ p ∧ q ∨ p ∧ r\",\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 1, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 1, \"column\": 18},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 34}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "theorem or_distrib (p q r : Prop) :\n",
-    "  p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n",
-    "  sorry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e8846af2",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008626,
-     "end_time": "2026-06-07T08:36:35.217713+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:35.209087+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "**Corrigé — rendu PR #2510 (@thorgal27)** : preuve de `or_distrib` avec `constructor`, `intro`, `cases`, `left`/`right`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "id": "913de7ff",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:35.237377Z",
-     "iopub.status.busy": "2026-06-07T08:36:35.237197Z",
-     "iopub.status.idle": "2026-06-07T08:36:35.360870Z",
-     "shell.execute_reply": "2026-06-07T08:36:35.359996Z"
-    },
-    "papermill": {
-     "duration": 0.134486,
-     "end_time": "2026-06-07T08:36:35.361430+00:00",
-     "exception": false,
-     "start_time": "2026-06-07T08:36:35.226944+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Corrigé — rendu PR #2510 (@thorgal27)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>or_distrib_corrige<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`p</span><span class=\"bp\">`</span>\n",
-       "\n",
-       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`q</span><span class=\"bp\">`</span>\n",
-       "\n",
-       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`r</span><span class=\"bp\">`</span>\n",
-       "\n",
-       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>(q<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>r)<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">·</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>h</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    cases<span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hqr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hqr<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>inl<span class=\"w\"> </span>hq<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        left</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hq</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>inr<span class=\"w\"> </span>hr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        right</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hr</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">·</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>h</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    cases<span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>inl<span class=\"w\"> </span>hpq<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hpq<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hq<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>left</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          exact<span class=\"w\"> </span>hq</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>inr<span class=\"w\"> </span>hpr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hpr<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>right</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          exact<span class=\"w\"> </span>hr</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 35</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Corrig\\u00e9 \\u2014 rendu PR #2510 (@thorgal27)\\ntheorem or_distrib_corrige (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | inl hq =>\\n        left\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hq\\n      | inr hr =>\\n        right\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | inl hpq =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 left\\n          exact hq\\n    | inr hpr =>\\n      cases hpr with\\n      | intro hp hr =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 right\\n          exact hr\", \"env\": 34}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 10},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 11},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `p`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
-       "  {\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 12},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 13},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `q`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
-       "  {\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 14},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 15},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `r`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
-       " \"env\": 35}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Corrigé — rendu PR #2510 (@thorgal27)\n",
-       "theorem or_distrib_corrige (p q r : Prop) :\n",
-       "          ─▶ 🟨 unused variable `p`\n",
-       "\n",
-       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
-       "            ─▶ 🟨 unused variable `q`\n",
-       "\n",
-       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
-       "              ─▶ 🟨 unused variable `r`\n",
-       "\n",
-       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
-       "  p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n",
-       "  constructor\n",
-       "  · intro h\n",
-       "    cases h with\n",
-       "    | intro hp hqr =>\n",
-       "      cases hqr with\n",
-       "      | inl hq =>\n",
-       "        left\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · exact hq\n",
-       "      | inr hr =>\n",
-       "        right\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · exact hr\n",
-       "  · intro h\n",
-       "    cases h with\n",
-       "    | inl hpq =>\n",
-       "      cases hpq with\n",
-       "      | intro hp hq =>\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · left\n",
-       "          exact hq\n",
-       "    | inr hpr =>\n",
-       "      cases hpr with\n",
-       "      | intro hp hr =>\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · right\n",
-       "          exact hr\n",
-       "--% env 35\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Corrig\\u00e9 \\u2014 rendu PR #2510 (@thorgal27)\\ntheorem or_distrib_corrige (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | inl hq =>\\n        left\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hq\\n      | inr hr =>\\n        right\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | inl hpq =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 left\\n          exact hq\\n    | inr hpr =>\\n      cases hpr with\\n      | intro hp hr =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 right\\n          exact hr\", \"env\": 34}\n",
-       "Raw output:\n",
-       "{\"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 10},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 11},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `p`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
-       "  {\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 12},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 13},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `q`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
-       "  {\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 14},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 15},\r\n",
-       "   \"data\":\r\n",
-       "   \"unused variable `r`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
-       " \"env\": 35}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Corrigé — rendu PR #2510 (@thorgal27)\n",
-    "theorem or_distrib_corrige (p q r : Prop) :\n",
-    "  p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n",
-    "  constructor\n",
-    "  · intro h\n",
-    "    cases h with\n",
-    "    | intro hp hqr =>\n",
-    "      cases hqr with\n",
-    "      | inl hq =>\n",
-    "        left\n",
-    "        constructor\n",
-    "        · exact hp\n",
-    "        · exact hq\n",
-    "      | inr hr =>\n",
-    "        right\n",
-    "        constructor\n",
-    "        · exact hp\n",
-    "        · exact hr\n",
-    "  · intro h\n",
-    "    cases h with\n",
-    "    | inl hpq =>\n",
-    "      cases hpq with\n",
-    "      | intro hp hq =>\n",
-    "        constructor\n",
-    "        · exact hp\n",
-    "        · left\n",
-    "          exact hq\n",
-    "    | inr hpr =>\n",
-    "      cases hpr with\n",
-    "      | intro hp hr =>\n",
-    "        constructor\n",
-    "        · exact hp\n",
-    "        · right\n",
-    "          exact hr"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "4ac1958b",
    "metadata": {
     "papermill": {
-     "duration": 0.010394,
-     "end_time": "2026-06-07T08:36:35.382576+00:00",
+     "duration": 0.00607,
+     "end_time": "2026-06-07T15:28:15.933956+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:35.372182+00:00",
+     "start_time": "2026-06-07T15:28:15.927886+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4322,25 +3476,29 @@
    "source": [
     "## Exemples guides : Preuves tactiques\n",
     "\n",
-    "Voici trois exemples complets illustrant les tactiques `constructor`, `rw` et `cases`."
+    "Voici trois exemples complets illustrant les tactiques `constructor`, `rw` et `cases`.\n",
+    "\n",
+    "Ces exemples reprennent les preuves soumises par **@thorgal27** dans le PR #2510, promues en exemples guides.\n",
+    "Les solutions integrent : `constructor` pour les equivalences, `intro`/`cases` pour la decomposition,\n",
+    "`exact` pour la fourniture de termes, `rw` pour la reecriture arithmetique, et `left`/`right` pour les disjonctions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 31,
    "id": "80ef06cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:35.403499Z",
-     "iopub.status.busy": "2026-06-07T08:36:35.403342Z",
-     "iopub.status.idle": "2026-06-07T08:36:35.552295Z",
-     "shell.execute_reply": "2026-06-07T08:36:35.550960Z"
+     "iopub.execute_input": "2026-06-07T15:28:15.946409Z",
+     "iopub.status.busy": "2026-06-07T15:28:15.946281Z",
+     "iopub.status.idle": "2026-06-07T15:28:16.090941Z",
+     "shell.execute_reply": "2026-06-07T15:28:16.090201Z"
     },
     "papermill": {
-     "duration": 0.160207,
-     "end_time": "2026-06-07T08:36:35.553018+00:00",
+     "duration": 0.152561,
+     "end_time": "2026-06-07T15:28:16.092191+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:35.392811+00:00",
+     "start_time": "2026-06-07T15:28:15.939630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4424,15 +3582,15 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>right</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          exact<span class=\"w\"> </span>hr</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 36</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 30</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exemple guide 1 : Associativite de la conjonction (avec tactics)\\n-- Demonstrateur : constructor, intro, cases, exact\\ntheorem and_assoc_practice (p q r : Prop) : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hpq hr =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 constructor\\n          \\u00b7 exact hq\\n          \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | intro hq hr =>\\n        constructor\\n        \\u00b7 constructor\\n          \\u00b7 exact hp\\n          \\u00b7 exact hq\\n        \\u00b7 exact hr\\n\\n-- Exemple guide 2 : Manipulation arithmetique avec rw\\n-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm\\ntheorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  rw [Nat.two_mul]\\n  rw [Nat.add_comm b a]\\n\\n-- Exemple guide 3 : Distribution avec tactics\\n-- Demonstrateur : constructor, intro, cases, left/right\\ntheorem or_distrib_practice (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | inl hq =>\\n        left\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hq\\n      | inr hr =>\\n        right\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | inl hpq =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 left\\n          exact hq\\n    | inr hpr =>\\n      cases hpr with\\n      | intro hp hr =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 right\\n          exact hr\", \"env\": 35}</code>\n",
+       "            <code>{\"cmd\": \"-- Exemple guide 1 : Associativite de la conjonction (avec tactics)\\n-- Demonstrateur : constructor, intro, cases, exact\\ntheorem and_assoc_practice (p q r : Prop) : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hpq hr =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 constructor\\n          \\u00b7 exact hq\\n          \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | intro hq hr =>\\n        constructor\\n        \\u00b7 constructor\\n          \\u00b7 exact hp\\n          \\u00b7 exact hq\\n        \\u00b7 exact hr\\n\\n-- Exemple guide 2 : Manipulation arithmetique avec rw\\n-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm\\ntheorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  rw [Nat.two_mul]\\n  rw [Nat.add_comm b a]\\n\\n-- Exemple guide 3 : Distribution avec tactics\\n-- Demonstrateur : constructor, intro, cases, left/right\\ntheorem or_distrib_practice (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | inl hq =>\\n        left\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hq\\n      | inr hr =>\\n        right\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | inl hpq =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 left\\n          exact hq\\n    | inr hpr =>\\n      cases hpr with\\n      | intro hp hr =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 right\\n          exact hr\", \"env\": 29}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
-       "            <code>{\"env\": 36}</code>\n",
+       "            <code>{\"env\": 30}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -4503,12 +3661,12 @@
        "        · exact hp\n",
        "        · right\n",
        "          exact hr\n",
-       "--% env 36\n",
+       "--% env 30\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exemple guide 1 : Associativite de la conjonction (avec tactics)\\n-- Demonstrateur : constructor, intro, cases, exact\\ntheorem and_assoc_practice (p q r : Prop) : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hpq hr =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 constructor\\n          \\u00b7 exact hq\\n          \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | intro hq hr =>\\n        constructor\\n        \\u00b7 constructor\\n          \\u00b7 exact hp\\n          \\u00b7 exact hq\\n        \\u00b7 exact hr\\n\\n-- Exemple guide 2 : Manipulation arithmetique avec rw\\n-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm\\ntheorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  rw [Nat.two_mul]\\n  rw [Nat.add_comm b a]\\n\\n-- Exemple guide 3 : Distribution avec tactics\\n-- Demonstrateur : constructor, intro, cases, left/right\\ntheorem or_distrib_practice (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | inl hq =>\\n        left\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hq\\n      | inr hr =>\\n        right\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | inl hpq =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 left\\n          exact hq\\n    | inr hpr =>\\n      cases hpr with\\n      | intro hp hr =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 right\\n          exact hr\", \"env\": 35}\n",
+       "{\"cmd\": \"-- Exemple guide 1 : Associativite de la conjonction (avec tactics)\\n-- Demonstrateur : constructor, intro, cases, exact\\ntheorem and_assoc_practice (p q r : Prop) : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hpq hr =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 constructor\\n          \\u00b7 exact hq\\n          \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | intro hq hr =>\\n        constructor\\n        \\u00b7 constructor\\n          \\u00b7 exact hp\\n          \\u00b7 exact hq\\n        \\u00b7 exact hr\\n\\n-- Exemple guide 2 : Manipulation arithmetique avec rw\\n-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm\\ntheorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  rw [Nat.two_mul]\\n  rw [Nat.add_comm b a]\\n\\n-- Exemple guide 3 : Distribution avec tactics\\n-- Demonstrateur : constructor, intro, cases, left/right\\ntheorem or_distrib_practice (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | inl hq =>\\n        left\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hq\\n      | inr hr =>\\n        right\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | inl hpq =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 left\\n          exact hq\\n    | inr hpr =>\\n      cases hpr with\\n      | intro hp hr =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 right\\n          exact hr\", \"env\": 29}\n",
        "Raw output:\n",
-       "{\"env\": 36}"
+       "{\"env\": 30}"
       ]
      },
      "metadata": {},
@@ -4589,10 +3747,10 @@
    "id": "d532845b",
    "metadata": {
     "papermill": {
-     "duration": 0.010994,
-     "end_time": "2026-06-07T08:36:35.576212+00:00",
+     "duration": 0.007247,
+     "end_time": "2026-06-07T15:28:16.107497+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:35.565218+00:00",
+     "start_time": "2026-06-07T15:28:16.100250+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4609,21 +3767,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 32,
    "id": "0b2e60f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:35.599727Z",
-     "iopub.status.busy": "2026-06-07T08:36:35.599527Z",
-     "iopub.status.idle": "2026-06-07T08:36:35.707433Z",
-     "shell.execute_reply": "2026-06-07T08:36:35.706466Z"
+     "iopub.execute_input": "2026-06-07T15:28:16.123881Z",
+     "iopub.status.busy": "2026-06-07T15:28:16.123732Z",
+     "iopub.status.idle": "2026-06-07T15:28:16.231648Z",
+     "shell.execute_reply": "2026-06-07T15:28:16.230287Z"
     },
     "language": "lean4",
     "papermill": {
-     "duration": 0.120778,
-     "end_time": "2026-06-07T08:36:35.708224+00:00",
+     "duration": 0.117093,
+     "end_time": "2026-06-07T15:28:16.232516+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:35.587446+00:00",
+     "start_time": "2026-06-07T15:28:16.115423+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4643,19 +3801,19 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : Commutativite de la conjunction</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : prouvez p /\\ q &lt;-&gt; q /\\ p</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>and_comm_exercise<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>and_comm_exercise<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 37</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 3</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 31</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 0</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 1 : Commutativite de la conjunction\\n-- TODO etudiant : prouvez p /\\\\ q <-> q /\\\\ p\\ntheorem and_comm_exercise (p q : Prop) : p /\\\\ q <-> q /\\\\ p := sorry\\n\", \"env\": 36}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 1 : Commutativite de la conjunction\\n-- TODO etudiant : prouvez p /\\\\ q <-> q /\\\\ p\\ntheorem and_comm_exercise (p q : Prop) : p /\\\\ q <-> q /\\\\ p := sorry\\n\", \"env\": 30}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
        "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 3,\r\n",
+       " [{\"proofState\": 0,\r\n",
        "   \"pos\": {\"line\": 3, \"column\": 62},\r\n",
        "   \"goal\": \"p q : Prop\\n⊢ p ∧ q ↔ q ∧ p\",\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 67}}],\r\n",
@@ -4664,7 +3822,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 25},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 37}</code>\n",
+       " \"env\": 31}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -4674,14 +3832,14 @@
        "theorem and_comm_exercise (p q : Prop) : p /\\ q <-> q /\\ p := sorry\n",
        "        ─────────────────▶ 🟨 declaration uses `sorry`\n",
        "\n",
-       "--% env 37\n",
-       "--% prove 3\n",
+       "--% env 31\n",
+       "--% prove 0\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 1 : Commutativite de la conjunction\\n-- TODO etudiant : prouvez p /\\\\ q <-> q /\\\\ p\\ntheorem and_comm_exercise (p q : Prop) : p /\\\\ q <-> q /\\\\ p := sorry\\n\", \"env\": 36}\n",
+       "{\"cmd\": \"-- Exercice 1 : Commutativite de la conjunction\\n-- TODO etudiant : prouvez p /\\\\ q <-> q /\\\\ p\\ntheorem and_comm_exercise (p q : Prop) : p /\\\\ q <-> q /\\\\ p := sorry\\n\", \"env\": 30}\n",
        "Raw output:\n",
        "{\"sorries\":\r\n",
-       " [{\"proofState\": 3,\r\n",
+       " [{\"proofState\": 0,\r\n",
        "   \"pos\": {\"line\": 3, \"column\": 62},\r\n",
        "   \"goal\": \"p q : Prop\\n⊢ p ∧ q ↔ q ∧ p\",\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 67}}],\r\n",
@@ -4690,7 +3848,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 25},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 37}"
+       " \"env\": 31}"
       ]
      },
      "metadata": {},
@@ -4708,10 +3866,10 @@
    "id": "0cc13061",
    "metadata": {
     "papermill": {
-     "duration": 0.009119,
-     "end_time": "2026-06-07T08:36:35.727799+00:00",
+     "duration": 0.007512,
+     "end_time": "2026-06-07T15:28:16.247773+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:35.718680+00:00",
+     "start_time": "2026-06-07T15:28:16.240261+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4724,21 +3882,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 33,
    "id": "1dcfda73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:35.747519Z",
-     "iopub.status.busy": "2026-06-07T08:36:35.747338Z",
-     "iopub.status.idle": "2026-06-07T08:36:35.857222Z",
-     "shell.execute_reply": "2026-06-07T08:36:35.856222Z"
+     "iopub.execute_input": "2026-06-07T15:28:16.264970Z",
+     "iopub.status.busy": "2026-06-07T15:28:16.264797Z",
+     "iopub.status.idle": "2026-06-07T15:28:16.372730Z",
+     "shell.execute_reply": "2026-06-07T15:28:16.371822Z"
     },
     "language": "lean4",
     "papermill": {
-     "duration": 0.120821,
-     "end_time": "2026-06-07T08:36:35.858079+00:00",
+     "duration": 0.117475,
+     "end_time": "2026-06-07T15:28:16.373334+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:35.737258+00:00",
+     "start_time": "2026-06-07T15:28:16.255859+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4759,19 +3917,19 @@
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : Rearrangement avec rw</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : prouvez (a + b) + c = (c + a) + b</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Indice : Nat.add_assoc, Nat.add_comm</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>rearrange_exercise<span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>(c<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>a)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>rearrange_exercise<span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>(c<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>a)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 38</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 4</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 32</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 1</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 2 : Rearrangement avec rw\\n-- TODO etudiant : prouvez (a + b) + c = (c + a) + b\\n-- Indice : Nat.add_assoc, Nat.add_comm\\ntheorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\\n\", \"env\": 37}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 2 : Rearrangement avec rw\\n-- TODO etudiant : prouvez (a + b) + c = (c + a) + b\\n-- Indice : Nat.add_assoc, Nat.add_comm\\ntheorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\\n\", \"env\": 31}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
        "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 4,\r\n",
+       " [{\"proofState\": 1,\r\n",
        "   \"pos\": {\"line\": 4, \"column\": 72},\r\n",
        "   \"goal\": \"a b c : Nat\\n⊢ a + b + c = c + a + b\",\r\n",
        "   \"endPos\": {\"line\": 4, \"column\": 77}}],\r\n",
@@ -4780,7 +3938,7 @@
        "   \"pos\": {\"line\": 4, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 4, \"column\": 26},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 38}</code>\n",
+       " \"env\": 32}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -4791,14 +3949,14 @@
        "theorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\n",
        "        ──────────────────▶ 🟨 declaration uses `sorry`\n",
        "\n",
-       "--% env 38\n",
-       "--% prove 4\n",
+       "--% env 32\n",
+       "--% prove 1\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 2 : Rearrangement avec rw\\n-- TODO etudiant : prouvez (a + b) + c = (c + a) + b\\n-- Indice : Nat.add_assoc, Nat.add_comm\\ntheorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\\n\", \"env\": 37}\n",
+       "{\"cmd\": \"-- Exercice 2 : Rearrangement avec rw\\n-- TODO etudiant : prouvez (a + b) + c = (c + a) + b\\n-- Indice : Nat.add_assoc, Nat.add_comm\\ntheorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\\n\", \"env\": 31}\n",
        "Raw output:\n",
        "{\"sorries\":\r\n",
-       " [{\"proofState\": 4,\r\n",
+       " [{\"proofState\": 1,\r\n",
        "   \"pos\": {\"line\": 4, \"column\": 72},\r\n",
        "   \"goal\": \"a b c : Nat\\n⊢ a + b + c = c + a + b\",\r\n",
        "   \"endPos\": {\"line\": 4, \"column\": 77}}],\r\n",
@@ -4807,7 +3965,7 @@
        "   \"pos\": {\"line\": 4, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 4, \"column\": 26},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 38}"
+       " \"env\": 32}"
       ]
      },
      "metadata": {},
@@ -4826,10 +3984,10 @@
    "id": "5bb9f488",
    "metadata": {
     "papermill": {
-     "duration": 0.010477,
-     "end_time": "2026-06-07T08:36:35.880062+00:00",
+     "duration": 0.007451,
+     "end_time": "2026-06-07T15:28:16.388473+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:35.869585+00:00",
+     "start_time": "2026-06-07T15:28:16.381022+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4842,21 +4000,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 34,
    "id": "5d40d3cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T08:36:35.900313Z",
-     "iopub.status.busy": "2026-06-07T08:36:35.900125Z",
-     "iopub.status.idle": "2026-06-07T08:36:36.007998Z",
-     "shell.execute_reply": "2026-06-07T08:36:36.007377Z"
+     "iopub.execute_input": "2026-06-07T15:28:16.402897Z",
+     "iopub.status.busy": "2026-06-07T15:28:16.402747Z",
+     "iopub.status.idle": "2026-06-07T15:28:16.509749Z",
+     "shell.execute_reply": "2026-06-07T15:28:16.508926Z"
     },
     "language": "lean4",
     "papermill": {
-     "duration": 0.119855,
-     "end_time": "2026-06-07T08:36:36.008593+00:00",
+     "duration": 0.115122,
+     "end_time": "2026-06-07T15:28:16.510425+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:35.888738+00:00",
+     "start_time": "2026-06-07T15:28:16.395303+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4876,19 +4034,19 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : De Morgan</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : prouvez la premiere direction de De Morgan</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>de_morgan_exercise<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">¬</span>(p<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span><span class=\"bp\">¬</span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span><span class=\"bp\">¬</span>q<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>de_morgan_exercise<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">¬</span>(p<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span><span class=\"bp\">¬</span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span><span class=\"bp\">¬</span>q<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 39</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 5</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 33</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 2</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 3 : De Morgan\\n-- TODO etudiant : prouvez la premiere direction de De Morgan\\ntheorem de_morgan_exercise (p q : Prop) : \\u00ac(p \\\\/ q) -> \\u00acp /\\\\ \\u00acq := sorry\\n\", \"env\": 38}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 3 : De Morgan\\n-- TODO etudiant : prouvez la premiere direction de De Morgan\\ntheorem de_morgan_exercise (p q : Prop) : \\u00ac(p \\\\/ q) -> \\u00acp /\\\\ \\u00acq := sorry\\n\", \"env\": 32}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
        "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 5,\r\n",
+       " [{\"proofState\": 2,\r\n",
        "   \"pos\": {\"line\": 3, \"column\": 67},\r\n",
        "   \"goal\": \"p q : Prop\\n⊢ ¬(p ∨ q) → ¬p ∧ ¬q\",\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 72}}],\r\n",
@@ -4897,7 +4055,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 26},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 39}</code>\n",
+       " \"env\": 33}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -4907,14 +4065,14 @@
        "theorem de_morgan_exercise (p q : Prop) : ¬(p \\/ q) -> ¬p /\\ ¬q := sorry\n",
        "        ──────────────────▶ 🟨 declaration uses `sorry`\n",
        "\n",
-       "--% env 39\n",
-       "--% prove 5\n",
+       "--% env 33\n",
+       "--% prove 2\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 3 : De Morgan\\n-- TODO etudiant : prouvez la premiere direction de De Morgan\\ntheorem de_morgan_exercise (p q : Prop) : \\u00ac(p \\\\/ q) -> \\u00acp /\\\\ \\u00acq := sorry\\n\", \"env\": 38}\n",
+       "{\"cmd\": \"-- Exercice 3 : De Morgan\\n-- TODO etudiant : prouvez la premiere direction de De Morgan\\ntheorem de_morgan_exercise (p q : Prop) : \\u00ac(p \\\\/ q) -> \\u00acp /\\\\ \\u00acq := sorry\\n\", \"env\": 32}\n",
        "Raw output:\n",
        "{\"sorries\":\r\n",
-       " [{\"proofState\": 5,\r\n",
+       " [{\"proofState\": 2,\r\n",
        "   \"pos\": {\"line\": 3, \"column\": 67},\r\n",
        "   \"goal\": \"p q : Prop\\n⊢ ¬(p ∨ q) → ¬p ∧ ¬q\",\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 72}}],\r\n",
@@ -4923,7 +4081,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 26},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 39}"
+       " \"env\": 33}"
       ]
      },
      "metadata": {},
@@ -4941,10 +4099,10 @@
    "id": "9bd5a610",
    "metadata": {
     "papermill": {
-     "duration": 0.009511,
-     "end_time": "2026-06-07T08:36:36.027393+00:00",
+     "duration": 0.007943,
+     "end_time": "2026-06-07T15:28:16.526162+00:00",
      "exception": false,
-     "start_time": "2026-06-07T08:36:36.017882+00:00",
+     "start_time": "2026-06-07T15:28:16.518219+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4998,14 +4156,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 7.832171,
-   "end_time": "2026-06-07T08:36:36.253560+00:00",
+   "duration": 9.434021,
+   "end_time": "2026-06-07T15:28:16.748113+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb",
    "output_path": "/tmp/Lean-5-Tactics_wsl_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-07T08:36:28.421389+00:00",
+   "start_time": "2026-06-07T15:28:07.314092+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Régression corrigée

Le merge de **#2680** (par moi-même, ai-01, ce cron) a ré-introduit les corrigés étudiants @thorgal27 **intercalés sous les énoncés** dans `Lean-5-Tactics.ipynb` — exactement l'antipattern que **#2622** (Closes **#2613**) avait délibérément supprimé la veille sur **mandat user 2026-06-07** : « Les exercices doivent toujours suivre les exemples guidés, à la fin du notebook. »

### Diagnostic
- #2592 avait mergé le rendu @thorgal27 avec corrigés inline.
- #2613 (mandat user) : pas de corrigé inline ; exemples guidés d'abord, exercices stubs purs à la fin.
- #2622 a appliqué le mandat : corrigés promus en « Exemples guidés » (crédités @thorgal27), notés **identiques** aux `*_practice` existants (redondance pure).
- #2680 (sa branche `clean-2510` était partie d'avant #2622) a **ré-intercalé** les corrigés → revert du mandat user. Erreur de ma part : je n'ai pas vérifié l'historique du fichier et ai lu les corrigés comme « ajout étudiant neuf » alors que #2510 était déjà intégré et l'intercalage retiré.

### Ce que fait cette PR
Restaure `Lean-5-Tactics.ipynb` à l'état **pré-#2680** = état **#2622** (byte-identique, sha1 `d2772c67`, déjà ré-exécuté 34/34 0 erreur). Le travail @thorgal27 **reste préservé** sur main (Exemples guidés crédités). Aucune perte pédagogique.

Verif : 0 `Corrigé — rendu PR` intercalé, 0 `*_corrige` theorem, 1 mention @thorgal27 (crédit exemple guidé). Diff = inverse exact de #2680.