### PR TITLE
fix(docs): repair 36 broken links + skip archive/ in link checker

### DIFF
--- a/.claude/agents/genai-iterator.md
+++ b/.claude/agents/genai-iterator.md
@@ -96,7 +96,7 @@ Commandes :
 
 ## Voir aussi
 
-- [docs/genai-services.md](../../docs/genai-services.md) — architectures Qwen/Lumina, scripts genai-stack, mappings
+- [docs/genai-services.md](../../docs/genai/genai-services.md) — architectures Qwen/Lumina, scripts genai-stack, mappings
 - [.claude/rules/genai-config.md](../rules/genai-config.md) — GenAI Docker config, GPU, .env
 - [.claude/rules/secrets-hygiene.md](../rules/secrets-hygiene.md) — secrets content-based
 - [.claude/skills/genai-iterate/SKILL.md](../skills/genai-iterate/SKILL.md) + [.claude/skills/validate-genai/SKILL.md](../skills/validate-genai/SKILL.md)

--- a/.claude/agents/training-specialist.md
+++ b/.claude/agents/training-specialist.md
@@ -85,7 +85,7 @@ Toute PR claim "BEATS"/"improvement" DOIT inclure : WF 5-fold (pas single split)
 
 ## Voir aussi
 
-- [docs/ml-trading-state.md](../../docs/ml-trading-state.md) — anti-FAANG, multi-seed, walk-forward
+- [docs/ml-trading-state.md](../../docs/archive/ml-trading-state.md) — anti-FAANG, multi-seed, walk-forward
 - [.claude/skills/train-model/SKILL.md](../skills/train-model/SKILL.md) — slash-command d'entrainement
 - [.claude/rules/proactive-coordination.md](../rules/proactive-coordination.md) — modele side-track async
-- [docs/quantconnect.md](../../docs/quantconnect.md) — contexte trading QC
+- [docs/quantconnect.md](../../docs/qc/quantconnect.md) — contexte trading QC

--- a/.claude/skills/genai-iterate/SKILL.md
+++ b/.claude/skills/genai-iterate/SKILL.md
@@ -60,5 +60,5 @@ python genai.py quant summary # bonne quant chargee ?
 ## Voir aussi
 - [.claude/agents/genai-iterator.md](../../agents/genai-iterator.md) — orchestrateur async
 - [.claude/skills/validate-genai/SKILL.md](../validate-genai/SKILL.md) — validation stack
-- [docs/genai-services.md](../../../docs/genai-services.md) — architectures, scripts, mappings
+- [docs/genai-services.md](../../../docs/genai/genai-services.md) — architectures, scripts, mappings
 - [.claude/rules/genai-config.md](../../rules/genai-config.md) — Docker config, GPU, .env

--- a/.claude/skills/train-model/SKILL.md
+++ b/.claude/skills/train-model/SKILL.md
@@ -66,5 +66,5 @@ python -c "from gpu_training import batch_thermal_check, get_gpu_temp; print('te
 ## Voir aussi
 
 - [.claude/agents/training-specialist.md](../../agents/training-specialist.md) — orchestrateur async
-- [docs/ml-trading-state.md](../../../docs/ml-trading-state.md) — anti-FAANG, multi-seed, walk-forward
+- [docs/ml-trading-state.md](../../../docs/archive/ml-trading-state.md) — anti-FAANG, multi-seed, walk-forward
 - [.claude/rules/pr-review-discipline.md](../../rules/pr-review-discipline.md) C — gate ML PR

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/README.md
@@ -105,4 +105,4 @@ Texte litteraire -> Benchmark voix (P0)
 
 - [Documentation Audio principale](../README.md)
 - [Live Coding Guide](04-5-LiveCoding-LLM-Music.ipynb)
-- [GenAI Services Documentation](../../../../docs/genai-services.md)
+- [GenAI Services Documentation](../../../../docs/genai/genai-services.md)

--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -11,7 +11,7 @@ maturity: PRODUCTION=27, BETA=3
 
 Le traitement audio est souvent le parent pauvre de l'IA generative, eclipsé par les images et le texte. Pourtant, la voix et la musique sont les modalites les plus naturelles de l'interaction humaine. Cette serie couvre l'ensemble de la chaine audio IA : reconnaissance vocale, synthese, clonage, generation musicale, et orchestration de pipelines.
 
-30 notebooks repartis sur 4 niveaux progressifs, des bases STT/TTS aux applications de production, dont un pipeline audiobook agentique complet (Epic #1028, livre 18/05/2026, 8 PRs, post-mortem [ici](../../../docs/_archives/epic-1028-audiobook-postmortem.md)) etendu par une variante FishAudio S2-Pro avec 29 tags prosodiques officiels et validation WER (Epic #1273, en cours).
+30 notebooks repartis sur 4 niveaux progressifs, des bases STT/TTS aux applications de production, dont un pipeline audiobook agentique complet (Epic #1028, livre 18/05/2026, 8 PRs, post-mortem [ici](../../../docs/archive/epic-1028-audiobook-postmortem.md)) etendu par une variante FishAudio S2-Pro avec 29 tags prosodiques officiels et validation WER (Epic #1273, en cours).
 
 ## Fil rouge : construire un podcast automatise
 

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
@@ -81,4 +81,4 @@ pip install -r requirements-comfyui.txt
 
 - [Documentation Image principale](../README.md)
 - [Guide ComfyUI](../../00-GenAI-Environment/README.md)
-- [Architecture ComfyUI](../../../../docs/genai-services.md)
+- [Architecture ComfyUI](../../../../docs/genai/genai-services.md)

--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
@@ -73,4 +73,4 @@ Input → Model Selection → Processing → Output
 
 - [Documentation Image principale](../README.md)
 - [Guide ComfyUI](../../00-GenAI-Environment/README.md)
-- [Architecture ComfyUI](../../../../docs/genai-services.md)
+- [Architecture ComfyUI](../../../../docs/genai/genai-services.md)

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/README.md
@@ -89,4 +89,4 @@ Batch → Queue → Processing → QC → Output → Analytics
 
 - [Documentation Image principale](../README.md)
 - [Guide ComfyUI](../../00-GenAI-Environment/README.md)
-- [GenAI Services](../../../../docs/genai-services.md)
+- [GenAI Services](../../../../docs/genai/genai-services.md)

--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -292,7 +292,7 @@ Verifiez que Docker Desktop est en cours d'execution et que les conteneurs sont 
 python scripts/genai-stack/genai.py docker status
 ```
 
-Si les services sont DOWN, relancez avec `genai.py docker start`. Details : [docs/genai-services.md](../../docs/genai-services.md).
+Si les services sont DOWN, relancez avec `genai.py docker start`. Details : [docs/genai-services.md](../../docs/genai/genai-services.md).
 
 ### Erreur `torch.cuda.OutOfMemoryError` sur les notebooks locaux
 

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/README.md
@@ -87,4 +87,4 @@ pip install -r requirements-comfyui.txt
 
 - [Documentation Video principale](../README.md)
 - [Guide ComfyUI](../../00-GenAI-Environment/README.md)
-- [Architecture ComfyUI](../../../../docs/genai-services.md)
+- [Architecture ComfyUI](../../../../docs/genai/genai-services.md)

--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/README.md
@@ -74,4 +74,4 @@ Input → Model Router → Processing → Output
 
 - [Documentation Video principale](../README.md)
 - [Guide ComfyUI](../../00-GenAI-Environment/README.md)
-- [GenAI Services](../../../../docs/genai-services.md)
+- [GenAI Services](../../../../docs/genai/genai-services.md)

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
@@ -88,4 +88,4 @@ Batch → Queue → Processing → QC → Distribution → Analytics
 
 - [Documentation Video principale](../README.md)
 - [Guide ComfyUI](../../00-GenAI-Environment/README.md)
-- [GenAI Services](../../../../docs/genai-services.md)
+- [GenAI Services](../../../../docs/genai/genai-services.md)

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -219,7 +219,7 @@ Les deux sous-series sont independantes et peuvent etre suivies dans n'importe q
 | Probleme | Solution |
 | -------- | -------- |
 | `dotnet-interactive` non trouve | `dotnet tool install -g Microsoft.dotnet-interactive` puis `dotnet interactive jupyter install` |
-| Kernel `.net-csharp` absent | Verifier avec `jupyter kernelspec list`. Reinstaller si necessaire (cf. [docs/kernels-runtime.md](../../docs/kernels-runtime.md)) |
+| Kernel `.net-csharp` absent | Verifier avec `jupyter kernelspec list`. Reinstaller si necessaire (cf. [docs/kernels-runtime.md](../../docs/reference/kernels-runtime.md)) |
 | ML.NET : erreur `IDataView` au chargement | Verifier le chemin du CSV (utilisez `Path.Combine` plutot qu'un chemin absolu) |
 | `OPENAI_API_KEY` manquant (Labs 2-3) | Creer un fichier `.env` a la racine avec `OPENAI_API_KEY=sk-...` |
 | PyTorch lent sur CPU | Normal pour les Labs 8+. Le GPU est recommande mais pas obligatoire |

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -13,7 +13,7 @@ All 4 notebooks in this directory are **(c) standalone research** — independen
 | `research_what_dl_can_predict.ipynb` | What DL can predict in finance | (c) |
 | `research_l4_decision_transformer.ipynb` | Decision Transformer evaluation | (c) |
 
-Full classification: [docs/_archives/qc-strategies-status.md](../../../docs/_archives/qc-strategies-status.md)
+Full classification: [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md)
 
 ## Curriculum V2 — Validated Keepers (2026-05-16, gate FERMEE)
 

--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -14,9 +14,9 @@ Supports de cours pour l'apprentissage du trading algorithmique avec QuantConnec
 | **(c)** standalone research | 6 | Local yfinance/sklearn training |
 | **(d)** pedagogical placeholder | 33 | Course material with embedded QCAlgorithm strings |
 
-> Récapitulatif : 16+2+6+33 = 57 entrées de classification. Le nombre total de fichiers `.ipynb` dans le dossier est **51** : la différence reflète les notebooks classés dans plusieurs catégories (ex. course material exécuté localement = (c)+(d)). Voir [docs/_archives/qc-strategies-status.md](../../../docs/_archives/qc-strategies-status.md) pour la classification détaillée.
+> Récapitulatif : 16+2+6+33 = 57 entrées de classification. Le nombre total de fichiers `.ipynb` dans le dossier est **51** : la différence reflète les notebooks classés dans plusieurs catégories (ex. course material exécuté localement = (c)+(d)). Voir [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md) pour la classification détaillée.
 
-Full classification: [docs/_archives/qc-strategies-status.md](../../../docs/_archives/qc-strategies-status.md)
+Full classification: [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md)
 
 ---
 

--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -246,7 +246,7 @@ Each notebook in the QC tree falls into one of four types:
 | **(c)** | standalone research | Local (yfinance/sklearn) | 24 |
 | **(d)** | pedagogical placeholder | Read-only / copy-paste | 33 |
 
-See [docs/_archives/qc-strategies-status.md](../../docs/_archives/qc-strategies-status.md) for the exhaustive classification.
+See [docs/archive/qc-strategies-status.md](../../docs/archive/qc-strategies-status.md) for the exhaustive classification.
 
 ## Cours partenaire — Exemples de Recherche
 
@@ -456,7 +456,7 @@ Après completion de cette série, vous maîtriserez :
 
 ## Stratégies Vérifiées — Baselines Comparatives
 
-Les 50+ projets du dossier `projects/` ont été backtestés sur des périodes standardisées via QC Cloud API. Le tableau ci-dessous présente les **meilleures performances vérifiées** (Sharpe, CAGR, MaxDD, PSR) : [catalogue complet](../../docs/qc-comparative-backtests.md).
+Les 50+ projets du dossier `projects/` ont été backtestés sur des périodes standardisées via QC Cloud API. Le tableau ci-dessous présente les **meilleures performances vérifiées** (Sharpe, CAGR, MaxDD, PSR) : [catalogue complet](../../docs/archive/qc-comparative-backtests.md).
 
 ### Top 5 stratégies (Sharpe aligned, 2018-2025)
 
@@ -476,7 +476,7 @@ Les 50+ projets du dossier `projects/` ont été backtestés sur des périodes s
 - **Composites < single-strategies** : MomentumRegime (combinaison SectorMom + Regime) obtient seulement 0.185, confirmant le problème de "double-defense".
 - **Crypto = diversification stable** : MaxDD maitrisé (~17%), rendement modéré.
 
-> Voir [docs/qc-comparative-backtests.md](../../docs/qc-comparative-backtests.md) pour les 17 baselines vérifiées, les comparaisons best-vs-aligned, et les diagnostics détaillés (See #1630).
+> Voir [docs/qc-comparative-backtests.md](../../docs/archive/qc-comparative-backtests.md) pour les 17 baselines vérifiées, les comparaisons best-vs-aligned, et les diagnostics détaillés (See #1630).
 
 ---
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/README.md
@@ -80,7 +80,7 @@ MonProjet/
 ## Ressources
 
 - [Descriptions détaillées](STRATEGIES_DETAIL.md) — Toutes les stratégies par catégorie
-- [Leçons et patterns](../../../docs/quantconnect.md) — 20 patterns confirmés + anti-patterns
+- [Leçons et patterns](../../../docs/qc/quantconnect.md) — 20 patterns confirmés + anti-patterns
 - [Catalogue QC Cloud](../docs/qc_strategies_catalog.md) — Métriques par stratégie avec Cloud IDs
 - [Quick Tour](../QUICK_TOUR.md) — Vue d'ensemble en 2 minutes
 - [QuantConnect Lab](https://www.quantconnect.com/terminal) · [Documentation](https://www.quantconnect.com/docs) · [Forum](https://www.quantconnect.com/forum)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ MyIA.AI.Notebooks/
   cross-series/    -> Applications transverses (matching-cv : data science multi-domaines)
 ```
 
-Pour un guide complet des parcours d'apprentissage, voir [docs/parcours/](docs/parcours/).
+Pour un guide complet des parcours d'apprentissage, voir les README de chaque serie dans `MyIA.AI.Notebooks/`.
 
 ---
 

--- a/docker-configurations/_archive-20251125/flux-1-dev/README.md
+++ b/docker-configurations/_archive-20251125/flux-1-dev/README.md
@@ -151,4 +151,4 @@ docker run --rm --gpus all nvidia/cuda:11.8.0-base-ubuntu22.04 nvidia-smi
 
 - [ComfyUI GitHub](https://github.com/comfyanonymous/ComfyUI)
 - [FLUX.1 Hugging Face](https://huggingface.co/black-forest-labs/FLUX.1-dev)
-- [Documentation Workflows](../../../docs/genai-services.md)
+- [Documentation Workflows](../../../docs/genai/genai-services.md)

--- a/docs/qc/quantconnect.md
+++ b/docs/qc/quantconnect.md
@@ -19,7 +19,7 @@ Le repo contient deja plusieurs documents canoniques. **Ne pas dupliquer ici** c
 | [MyIA.AI.Notebooks/QuantConnect/docs/qc_strategies_catalog.md](../../MyIA.AI.Notebooks/QuantConnect/docs/qc_strategies_catalog.md) | Catalog strategies live | 96 ALIVE projects, Sharpe top 15, IDs QC Cloud (regenere depuis API) |
 | [MyIA.AI.Notebooks/QuantConnect/docs/audits/](../../MyIA.AI.Notebooks/QuantConnect/docs/audits/) | Audits historiques | AUDIT_QC_CLOUD, AUDIT_QC_ORG_2026-04, AUDIT_RAPPORT_2026-03-22, VALIDATION-REPORT |
 | [MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md](../../MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md) | Registry training | 70+ checkpoints, stages -1/0/1/2, Anti-Bias |
-| [docs/ml-trading-state.md](ml-trading-state.md) | Lecons ML trading | Pattern central vol vs direction, 7 disciplines, anti-FAANG |
+| [docs/ml-trading-state.md](../archive/ml-trading-state.md) | Lecons ML trading | Pattern central vol vs direction, 7 disciplines, anti-FAANG |
 | [MyIA.AI.Notebooks/QuantConnect/docs/QC_CLOUD_ASSISTANTS_WORKFLOW.md](../../MyIA.AI.Notebooks/QuantConnect/docs/QC_CLOUD_ASSISTANTS_WORKFLOW.md) | Assistants QC Cloud | 8 assistants, protocole couts QCC, matrice delegation |
 
 **Regle de coherence** : pour les performances par strategie (Sharpe, CAGR) -> `qc_strategies_catalog.md`. Pour les patterns reutilisables -> ce fichier. Pour les lecons ML trans-iteration -> `ml-trading-state.md`. Pour le mapping livre -> `BOOK_MAPPING.md` (racine, pas doublon `docs/`).
@@ -280,7 +280,7 @@ Toute l'historique des trainings ML/QC est preservee dans le depot et accessible
 | `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/Curriculum_V2_Meta_Analysis.md` | Meta-analyse curriculum V2 |
 | `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/*/checkpoint.jsonl` + `train.log` | 27 runs avec etat par combo et logs unbuffered (local, gitignored) |
 | QC Cloud (MCP `list_projects` + `list_backtests` + `read_backtest`) | Sharpe/CAGR/MaxDD live de chaque iteration |
-| [docs/ml-trading-state.md](ml-trading-state.md) | Lecons consolidees (vol vs direction, parcimonie, transaction costs, recommandations datasets) |
+| [docs/ml-trading-state.md](../archive/ml-trading-state.md) | Lecons consolidees (vol vs direction, parcimonie, transaction costs, recommandations datasets) |
 
 **Regle** : pas de duplication. Si tu veux ajouter une note sur une iteration training, vise `ML-Training-Pipeline/docs/M<N>_*.md` ou QC Cloud notes, pas un memo coordinateur. Pour une lecon trans-iteration : `docs/ml-trading-state.md`.
 

--- a/docs/reference/cluster-agents.md
+++ b/docs/reference/cluster-agents.md
@@ -118,7 +118,7 @@ Tokens API QC configures dans `.mcp.json` sur les 2 machines (Docker MCP server 
 
 ### Lean / Mathlib -> po-2026
 
-Specialisation `*.lean`, port social_choice, Lake build, reecriture preuves structurelles. ai-01 = secours (env Lean a installer si manquant). Cf [docs/lean/prover_iteration_history.md](lean/prover_iteration_history.md).
+Specialisation `*.lean`, port social_choice, Lake build, reecriture preuves structurelles. ai-01 = secours (env Lean a installer si manquant). Cf [docs/lean/prover_iteration_history.md](../lean/prover_iteration_history.md).
 
 ### Whisper API host -> po-2023
 
@@ -170,5 +170,5 @@ Pour tout sprint / curriculum >= 3 etapes, creer **Epic GitHub** + sub-issues nu
 - Regles de coordination Git + dashboard : [CLAUDE.md](../../CLAUDE.md) section A
 - Calendrier enseignement + scope ecoles : [docs/teaching-context.md](teaching-context.md)
 - Wrapper training BG avec checkpoints : `scripts/training/train_with_checkpoints.py`
-- QC backtest + MCP Docker : [docs/quantconnect.md](quantconnect.md)
-- Lean prover BG forensic protocol : [docs/lean/prover_iteration_history.md](lean/prover_iteration_history.md)
+- QC backtest + MCP Docker : [docs/quantconnect.md](../qc/quantconnect.md)
+- Lean prover BG forensic protocol : [docs/lean/prover_iteration_history.md](../lean/prover_iteration_history.md)

--- a/docs/reference/common-commands.md
+++ b/docs/reference/common-commands.md
@@ -19,7 +19,7 @@ python scripts/genai-stack/genai.py docker start all # Demarrer tous les service
 python scripts/genai-stack/genai.py docker stop all  # Arreter tous les services
 ```
 
-Cf [genai-services.md](./genai-services.md) pour le detail des services et notebooks.
+Cf [genai-services.md](../genai/genai-services.md) pour le detail des services et notebooks.
 
 ## Validation & Testing
 

--- a/docs/reference/esgf-grading.md
+++ b/docs/reference/esgf-grading.md
@@ -157,6 +157,6 @@ Voir [.claude/rules/student-pr-reviews.md](../../.claude/rules/student-pr-review
 
 - [docs/ece-grading.md](ece-grading.md) - Pattern ECE Finance Ing4 (3 groupes, 2 projets, bonus CC)
 - [docs/teaching-context.md](teaching-context.md) - Calendrier toutes ecoles, scope par cohorte
-- [docs/quantconnect.md](quantconnect.md) - Org QC Trading-Firm-ESGF, MCP qc-mcp, baselines
+- [docs/quantconnect.md](../qc/quantconnect.md) - Org QC Trading-Firm-ESGF, MCP qc-mcp, baselines
 - [GradeBookApp/README.md](../../GradeBookApp/README.md) - Moteur generique
 - [.claude/rules/student-pr-reviews.md](../../.claude/rules/student-pr-reviews.md) - Anti-fuite jury (HARD)

--- a/docs/reference/regles-validation-detail.md
+++ b/docs/reference/regles-validation-detail.md
@@ -110,7 +110,7 @@ L'audit du 2026-05-09 a revele un pattern systemique : 988 notebooks repo, dont 
 - **P3** (2 semaines) : workflow GitHub Actions `notebook-execution-required.yml` qui execute via Papermill toute notebook touchee dans une PR. Failure → merge bloque. Runner = Docker compose (.NET + Python + Lean + WSL bypass)
 - **P4** (continu) : `STABLE_SNAPSHOT.md` regenere mensuel, gravant `sha + date + matrice exec_status` → point de reference factuel quand quelqu'un dit "X est valide"
 
-Cf [docs/_archives/STABLE_SNAPSHOT.md](_archives/STABLE_SNAPSHOT.md).
+Cf [docs/archive/STABLE_SNAPSHOT.md](../archive/STABLE_SNAPSHOT.md).
 
 ---
 
@@ -120,4 +120,4 @@ Cf [docs/_archives/STABLE_SNAPSHOT.md](_archives/STABLE_SNAPSHOT.md).
 - [docs/regles-vigilance-detail.md](regles-vigilance-detail.md) — Regles G.1-G.9 anti-complaisance
 - [docs/env-python-reparation.md](env-python-reparation.md) — Reparation env Python (regle F)
 - [docs/kernels-runtime.md](kernels-runtime.md) — Inventaire kernels par machine
-- [docs/STABLE_SNAPSHOT.md](_archives/STABLE_SNAPSHOT.md) — Matrice exec_status des notebooks
+- [docs/STABLE_SNAPSHOT.md](../archive/STABLE_SNAPSHOT.md) — Matrice exec_status des notebooks

--- a/docs/reference/scripts-reference.md
+++ b/docs/reference/scripts-reference.md
@@ -101,7 +101,7 @@ python scripts/notebook_tools/notebook_tools.py execute SmartContracts --scrub-k
 | `scripts/lean/smoke_test_epita_is.py` | Smoke-test kernels Lean EPITA-IS |
 | `scripts/mcp-maintenance/` | Maintenance MCP (config, docs, scripts) — cf `README_MCP_MAINTENANCE.md` |
 | `scripts/validation/dispatch.py` + `matrix.yml` | Matrice de validation / dispatch |
-| `scripts/genai-stack/genai.py` | GenAI Docker (ComfyUI + Qwen) + validation — cf [docs/genai-services.md](genai-services.md) |
+| `scripts/genai-stack/genai.py` | GenAI Docker (ComfyUI + Qwen) + validation — cf [docs/genai-services.md](../genai/genai-services.md) |
 | `scripts/repair_genai_notebooks.py`, `scripts/audit_genai_corruption.py` | Réparation / audit corruption GenAI |
 | `scripts/fix_robust_dotenv.py` | Robustesse chargement `.env` |
 | `scripts/scan_student_forks.py` | Scan des forks étudiants |
@@ -133,5 +133,5 @@ Modules genai-stack non testes (intentionnellement) : commands/docker.py (subpro
 
 - [docs/common-commands.md](common-commands.md) — setup env, validation notebooks, slash commands
 - [docs/kernels-runtime.md](kernels-runtime.md) — .NET / Python / WSL kernels, conda envs
-- [docs/genai-services.md](genai-services.md) — scripts genai-stack, mappings notebooks
+- [docs/genai-services.md](../genai/genai-services.md) — scripts genai-stack, mappings notebooks
 - [.claude/rules/wsl-kernels.md](../../.claude/rules/wsl-kernels.md) — Papermill WSL

--- a/docs/reference/teaching-context.md
+++ b/docs/reference/teaching-context.md
@@ -92,4 +92,4 @@ Voir [.claude/rules/student-pr-reviews.md](../../.claude/rules/student-pr-review
 - Pipeline notation et bonus CC : [docs/ece-grading.md](ece-grading.md)
 - Mapping cluster machines (au-dela enseignement) : [docs/cluster-agents.md](cluster-agents.md)
 - Slides Slidev EPITA : `MyIA.AI.Notebooks/SymbolicAI/<serie>/slides/` (workflow Slidev verify, cf [.claude/rules/](../../.claude/rules/))
-- QuantConnect (partenaire) : [docs/quantconnect.md](quantconnect.md)
+- QuantConnect (partenaire) : [docs/quantconnect.md](../qc/quantconnect.md)

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -44,6 +44,7 @@ SKIP_DIRS = {
     "_archives", "_output", ".ipynb_checkpoints", "worktrees",
     ".mypy_cache", ".pytest_cache", ".ruff_cache",
     "custom_nodes",  # Third-party ComfyUI plugins, not ours to fix
+    "archive",  # Historical docs, links intentionally stale
 }
 
 # Baseline file location


### PR DESCRIPTION
## Summary

After docs reorg #2648 (commit dc9260f2), 475 relative links broke across the repository. The Docs Link Check CI has been permanently failing (10/10 recent runs).

## Changes

1. **`scripts/check_docs_links.py`**: Added `"archive"` to `SKIP_DIRS` — eliminates 439 broken links in historical docs (intentionally stale)

2. **36 broken link repairs** across 27 files:
   - **genai-services.md** path (13 links): Updated in READMEs, agents, skills after move from `docs/` to `docs/genai/`
   - **quantconnect.md** path (4 links): Updated relative paths from `docs/reference/` files
   - **_archives → archive** redirects (7 links)
   - **Other stale references** (12 links): kernels-runtime, parcours, qc-comparative, etc.

## Verification

- `python scripts/check_docs_links.py` should now pass with only the 5 pre-existing baseline broken links (all in custom_nodes)
- No catalog regeneration (rule: catalog belongs to automation)

See #2648