### PR TITLE
fix(SymbolicLearning): SL-1 Exercice 3 = vrai exo de reflexion + exemple guide corrige

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -1781,15 +1781,31 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Reflexion\n",
+    "### Exemple guide : Reflexion corrigee (synthese)\n",
     "\n",
-    "Repondez aux questions suivantes :\n",
+    "Voici trois questions de synthese sur ce notebook, **avec leur correction**. Utilisez-les comme auto-evaluation : ne les lisez qu'**apres** avoir tente l'exercice ci-dessous.\n",
     "\n",
     "| Question | Reponse |\n",
     "|----------|--------|\n",
     "| Pourquoi CBH depend de l'ordre mais pas le Version Space ? | Le VS maintient TOUTES les hypotheses consistantes, pas une seule. L'ordre n'affecte que la vitesse de convergence, pas le resultat final. |\n",
     "| Que se passe-t-il si le concept cible n'est pas representable par une conjonction ? | Le VS ne converge jamais. G et S restent separes, et certaines hypotheses entre les deux sont incorrectes. |\n",
     "| Pourquoi le Version Space est-il fragile face au bruit ? | Un seul exemple contradictoire elimine TOUTES les hypotheses, vidant le VS. Pas de mecanisme de tolerance. |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7e4d1a9",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Reflexion\n",
+    "\n",
+    "A votre tour. Repondez aux questions suivantes en vous appuyant sur les algorithmes implementes plus haut (CBH, Candidate Elimination). Ne consultez l'exemple guide corrige ci-dessus qu'**apres** avoir formule vos propres reponses.\n",
+    "\n",
+    "| Question | Reponse |\n",
+    "|----------|--------|\n",
+    "| Donnez une sequence concrete d'exemples (positifs/negatifs) qui force CBH a backtracker, alors que le Version Space converge sans jamais revenir en arriere. | _(a completer)_ |\n",
+    "| Un concept disjonctif comme \"animal = chien OU chat\" n'est pas capturable par une hypothese conjonctive unique. Pourquoi ? Que faudrait-il changer dans la representation des hypotheses pour le permettre ? | _(a completer)_ |\n",
+    "| La complexite memoire du Version Space est O(\\|G\\| + \\|S\\|). Decrivez un cas ou \\|G\\| ou \\|S\\| explose, et la consequence pratique sur l'apprentissage. | _(a completer)_ |"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Audit qualite serie SymbolicLearning (ai-01, mandat user 09/06). Seule observation remontee au user : SL-1 « Exercice 3 : Reflexion » etait une table markdown dont la colonne **Reponse etait deja remplie** (auto-correction) -> pas un exo que l'etudiant fait. Decision user : en faire un vrai exercice (transformer l'existant en exemple guide + ajouter un nouvel exo).

## Changements (markdown-only, 1 fichier)

- L'ancienne cellule (reponses completes) devient **« Exemple guide : Reflexion corrigee (synthese) »** -> exemple resolu garde (labeling content-based, cf `.claude/rules/exercise-example-labeling.md`).
- Nouveau **« Exercice 3 : Reflexion »** ajoute : 3 questions ouvertes distinctes (backtracking CBH vs Version Space, concepts disjonctifs, explosion memoire G/S), colonne Reponse en stub `_(a completer)_`.

## Verification

- 13 cellules code **byte-identiques** (source + `execution_count` + outputs) vs `origin/main` -> aucune re-execution requise (exception C.2 markdown-only).
- 0 cellule code `execution_count: null` (H.3 OK).
- C.1 : aucun pattern interdit (markdown pur).
- Total cellules 40 -> 41 (+1 exo). Convention #2161 (>=3 exos pertinents/NB) preservee.
- Catalogue **non touche** (hors-branche, cron-only).
