### PR TITLE
enrich(Planners-9): add Exemple guide coffee domain with 2 decomposition methods (See #1455)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.004743,
-     "end_time": "2026-06-02T21:51:35.492897+00:00",
+     "duration": 0.010471,
+     "end_time": "2026-06-09T16:13:58.168631+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.488154+00:00",
+     "start_time": "2026-06-09T16:13:58.158160+00:00",
      "status": "completed"
     },
     "tags": []
@@ -44,10 +44,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.003643,
-     "end_time": "2026-06-02T21:51:35.500718+00:00",
+     "duration": 0.008437,
+     "end_time": "2026-06-09T16:13:58.188419+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.497075+00:00",
+     "start_time": "2026-06-09T16:13:58.179982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -77,10 +77,10 @@
    "id": "cell-2",
    "metadata": {
     "papermill": {
-     "duration": 0.003791,
-     "end_time": "2026-06-02T21:51:35.508249+00:00",
+     "duration": 0.003546,
+     "end_time": "2026-06-09T16:13:58.197833+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.504458+00:00",
+     "start_time": "2026-06-09T16:13:58.194287+00:00",
      "status": "completed"
     },
     "tags": []
@@ -110,10 +110,10 @@
    "id": "cell-3",
    "metadata": {
     "papermill": {
-     "duration": 0.003845,
-     "end_time": "2026-06-02T21:51:35.516067+00:00",
+     "duration": 0.002912,
+     "end_time": "2026-06-09T16:13:58.203748+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.512222+00:00",
+     "start_time": "2026-06-09T16:13:58.200836+00:00",
      "status": "completed"
     },
     "tags": []
@@ -135,10 +135,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.005704,
-     "end_time": "2026-06-02T21:51:35.525588+00:00",
+     "duration": 0.00325,
+     "end_time": "2026-06-09T16:13:58.209981+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.519884+00:00",
+     "start_time": "2026-06-09T16:13:58.206731+00:00",
      "status": "completed"
     },
     "tags": []
@@ -167,10 +167,10 @@
    "id": "cell-5",
    "metadata": {
     "papermill": {
-     "duration": 0.003738,
-     "end_time": "2026-06-02T21:51:35.533211+00:00",
+     "duration": 0.003312,
+     "end_time": "2026-06-09T16:13:58.216651+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.529473+00:00",
+     "start_time": "2026-06-09T16:13:58.213339+00:00",
      "status": "completed"
     },
     "tags": []
@@ -196,10 +196,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.003728,
-     "end_time": "2026-06-02T21:51:35.541073+00:00",
+     "duration": 0.003302,
+     "end_time": "2026-06-09T16:13:58.223212+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.537345+00:00",
+     "start_time": "2026-06-09T16:13:58.219910+00:00",
      "status": "completed"
     },
     "tags": []
@@ -236,10 +236,10 @@
    "id": "cell-7",
    "metadata": {
     "papermill": {
-     "duration": 0.004182,
-     "end_time": "2026-06-02T21:51:35.549052+00:00",
+     "duration": 0.002961,
+     "end_time": "2026-06-09T16:13:58.229279+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.544870+00:00",
+     "start_time": "2026-06-09T16:13:58.226318+00:00",
      "status": "completed"
     },
     "tags": []
@@ -267,10 +267,10 @@
    "id": "cell-8",
    "metadata": {
     "papermill": {
-     "duration": 0.004355,
-     "end_time": "2026-06-02T21:51:35.557727+00:00",
+     "duration": 0.002976,
+     "end_time": "2026-06-09T16:13:58.235272+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.553372+00:00",
+     "start_time": "2026-06-09T16:13:58.232296+00:00",
      "status": "completed"
     },
     "tags": []
@@ -317,10 +317,10 @@
    "id": "cell-9",
    "metadata": {
     "papermill": {
-     "duration": 0.00459,
-     "end_time": "2026-06-02T21:51:35.566757+00:00",
+     "duration": 0.003046,
+     "end_time": "2026-06-09T16:13:58.241369+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.562167+00:00",
+     "start_time": "2026-06-09T16:13:58.238323+00:00",
      "status": "completed"
     },
     "tags": []
@@ -335,16 +335,16 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.577214Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.576995Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.584258Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.583517Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.248659Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.248482Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.254663Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.254010Z"
     },
     "papermill": {
-     "duration": 0.013659,
-     "end_time": "2026-06-02T21:51:35.585023+00:00",
+     "duration": 0.010785,
+     "end_time": "2026-06-09T16:13:58.255210+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.571364+00:00",
+     "start_time": "2026-06-09T16:13:58.244425+00:00",
      "status": "completed"
     },
     "tags": []
@@ -451,10 +451,10 @@
    "id": "ffa51bad",
    "metadata": {
     "papermill": {
-     "duration": 0.00449,
-     "end_time": "2026-06-02T21:51:35.594168+00:00",
+     "duration": 0.003334,
+     "end_time": "2026-06-09T16:13:58.264011+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.589678+00:00",
+     "start_time": "2026-06-09T16:13:58.260677+00:00",
      "status": "completed"
     },
     "tags": []
@@ -491,10 +491,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.004684,
-     "end_time": "2026-06-02T21:51:35.605772+00:00",
+     "duration": 0.003355,
+     "end_time": "2026-06-09T16:13:58.270862+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.601088+00:00",
+     "start_time": "2026-06-09T16:13:58.267507+00:00",
      "status": "completed"
     },
     "tags": []
@@ -511,16 +511,16 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.616570Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.616335Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.620712Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.619785Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.278461Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.278282Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.282194Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.281667Z"
     },
     "papermill": {
-     "duration": 0.010895,
-     "end_time": "2026-06-02T21:51:35.621368+00:00",
+     "duration": 0.008528,
+     "end_time": "2026-06-09T16:13:58.282689+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.610473+00:00",
+     "start_time": "2026-06-09T16:13:58.274161+00:00",
      "status": "completed"
     },
     "tags": []
@@ -587,10 +587,10 @@
    "id": "cell-13",
    "metadata": {
     "papermill": {
-     "duration": 0.006054,
-     "end_time": "2026-06-02T21:51:35.632175+00:00",
+     "duration": 0.003332,
+     "end_time": "2026-06-09T16:13:58.289530+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.626121+00:00",
+     "start_time": "2026-06-09T16:13:58.286198+00:00",
      "status": "completed"
     },
     "tags": []
@@ -613,10 +613,10 @@
    "id": "cell-14",
    "metadata": {
     "papermill": {
-     "duration": 0.004495,
-     "end_time": "2026-06-02T21:51:35.641502+00:00",
+     "duration": 0.003103,
+     "end_time": "2026-06-09T16:13:58.295930+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.637007+00:00",
+     "start_time": "2026-06-09T16:13:58.292827+00:00",
      "status": "completed"
     },
     "tags": []
@@ -635,16 +635,16 @@
    "id": "cell-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.651947Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.651715Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.661918Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.661176Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.303127Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.302966Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.311242Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.310739Z"
     },
     "papermill": {
-     "duration": 0.016703,
-     "end_time": "2026-06-02T21:51:35.662862+00:00",
+     "duration": 0.012664,
+     "end_time": "2026-06-09T16:13:58.311736+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.646159+00:00",
+     "start_time": "2026-06-09T16:13:58.299072+00:00",
      "status": "completed"
     },
     "tags": []
@@ -747,10 +747,10 @@
    "id": "9tbu0209frd",
    "metadata": {
     "papermill": {
-     "duration": 0.004711,
-     "end_time": "2026-06-02T21:51:35.672490+00:00",
+     "duration": 0.003068,
+     "end_time": "2026-06-09T16:13:58.317940+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.667779+00:00",
+     "start_time": "2026-06-09T16:13:58.314872+00:00",
      "status": "completed"
     },
     "tags": []
@@ -775,16 +775,16 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.684597Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.684248Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.693968Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.693139Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.325035Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.324886Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.332762Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.332225Z"
     },
     "papermill": {
-     "duration": 0.016625,
-     "end_time": "2026-06-02T21:51:35.694603+00:00",
+     "duration": 0.012299,
+     "end_time": "2026-06-09T16:13:58.333305+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.677978+00:00",
+     "start_time": "2026-06-09T16:13:58.321006+00:00",
      "status": "completed"
     },
     "tags": []
@@ -800,6 +800,8 @@
    ],
    "source": [
     "# Solveur HTN simplifie\n",
+    "from itertools import product as itertools_product\n",
+    "\n",
     "@dataclass\n",
     "class HTNPlanner:\n",
     "    \"\"\"Solveur HTN avec decomposition ordonnee.\"\"\"\n",
@@ -872,11 +874,13 @@
     "                    all_objects = set()\n",
     "                    for fact in state.facts:\n",
     "                        all_objects.update(fact[1:])  # Tous les objets (sauf le predicat)\n",
+    "                    all_objects = sorted(all_objects)  # tri deterministe\n",
     "                    \n",
     "                    # Essayer chaque combinaison d'objets pour les parametres supplementaires\n",
-    "                    for obj in all_objects:\n",
+    "                    for combo in itertools_product(all_objects, repeat=len(extra_params)):\n",
     "                        extended_binding = method_binding.copy()\n",
-    "                        extended_binding[extra_params[0]] = obj\n",
+    "                        for param, obj in zip(extra_params, combo):\n",
+    "                            extended_binding[param] = obj\n",
     "                        \n",
     "                        # Verifier les preconditions avec ce binding etendu\n",
     "                        if method.is_applicable(state, extended_binding):\n",
@@ -921,10 +925,10 @@
    "id": "32a84037",
    "metadata": {
     "papermill": {
-     "duration": 0.004852,
-     "end_time": "2026-06-02T21:51:35.704202+00:00",
+     "duration": 0.003375,
+     "end_time": "2026-06-09T16:13:58.340051+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.699350+00:00",
+     "start_time": "2026-06-09T16:13:58.336676+00:00",
      "status": "completed"
     },
     "tags": []
@@ -961,10 +965,10 @@
    "id": "cell-17",
    "metadata": {
     "papermill": {
-     "duration": 0.004918,
-     "end_time": "2026-06-02T21:51:35.714261+00:00",
+     "duration": 0.003109,
+     "end_time": "2026-06-09T16:13:58.346608+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.709343+00:00",
+     "start_time": "2026-06-09T16:13:58.343499+00:00",
      "status": "completed"
     },
     "tags": []
@@ -983,16 +987,16 @@
    "id": "cell-18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.724800Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.724552Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.731124Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.730311Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.354194Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.354035Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.359767Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.359218Z"
     },
     "papermill": {
-     "duration": 0.0131,
-     "end_time": "2026-06-02T21:51:35.732066+00:00",
+     "duration": 0.010259,
+     "end_time": "2026-06-09T16:13:58.360250+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.718966+00:00",
+     "start_time": "2026-06-09T16:13:58.349991+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1084,10 +1088,10 @@
    "id": "hyut0gmgq6",
    "metadata": {
     "papermill": {
-     "duration": 0.004939,
-     "end_time": "2026-06-02T21:51:35.741928+00:00",
+     "duration": 0.003127,
+     "end_time": "2026-06-09T16:13:58.366513+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.736989+00:00",
+     "start_time": "2026-06-09T16:13:58.363386+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1102,16 +1106,16 @@
    "id": "cell-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.751981Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.751665Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.758108Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.757353Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.373354Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.373211Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.378431Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.377960Z"
     },
     "papermill": {
-     "duration": 0.012445,
-     "end_time": "2026-06-02T21:51:35.758717+00:00",
+     "duration": 0.009543,
+     "end_time": "2026-06-09T16:13:58.379062+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.746272+00:00",
+     "start_time": "2026-06-09T16:13:58.369519+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1224,10 +1228,10 @@
    "id": "0787366f",
    "metadata": {
     "papermill": {
-     "duration": 0.004973,
-     "end_time": "2026-06-02T21:51:35.768265+00:00",
+     "duration": 0.00315,
+     "end_time": "2026-06-09T16:13:58.385277+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.763292+00:00",
+     "start_time": "2026-06-09T16:13:58.382127+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1262,10 +1266,10 @@
    "id": "w1f1kl7d2eh",
    "metadata": {
     "papermill": {
-     "duration": 0.005162,
-     "end_time": "2026-06-02T21:51:35.778487+00:00",
+     "duration": 0.003524,
+     "end_time": "2026-06-09T16:13:58.392065+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.773325+00:00",
+     "start_time": "2026-06-09T16:13:58.388541+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1281,10 +1285,10 @@
    "id": "cell-20",
    "metadata": {
     "papermill": {
-     "duration": 0.007312,
-     "end_time": "2026-06-02T21:51:35.792768+00:00",
+     "duration": 0.003173,
+     "end_time": "2026-06-09T16:13:58.398254+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.785456+00:00",
+     "start_time": "2026-06-09T16:13:58.395081+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1316,10 +1320,10 @@
    "id": "cell-21",
    "metadata": {
     "papermill": {
-     "duration": 0.004768,
-     "end_time": "2026-06-02T21:51:35.802722+00:00",
+     "duration": 0.003336,
+     "end_time": "2026-06-09T16:13:58.404825+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.797954+00:00",
+     "start_time": "2026-06-09T16:13:58.401489+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1370,10 +1374,10 @@
    "id": "cell-22",
    "metadata": {
     "papermill": {
-     "duration": 0.004404,
-     "end_time": "2026-06-02T21:51:35.811760+00:00",
+     "duration": 0.003212,
+     "end_time": "2026-06-09T16:13:58.412017+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.807356+00:00",
+     "start_time": "2026-06-09T16:13:58.408805+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1395,16 +1399,16 @@
    "id": "cell-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.822683Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.822421Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.826583Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.825642Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.420192Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.419849Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.423531Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.423021Z"
     },
     "papermill": {
-     "duration": 0.011018,
-     "end_time": "2026-06-02T21:51:35.827266+00:00",
+     "duration": 0.008414,
+     "end_time": "2026-06-09T16:13:58.424021+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.816248+00:00",
+     "start_time": "2026-06-09T16:13:58.415607+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1477,10 +1481,10 @@
    "id": "cell-24",
    "metadata": {
     "papermill": {
-     "duration": 0.004658,
-     "end_time": "2026-06-02T21:51:35.836786+00:00",
+     "duration": 0.003389,
+     "end_time": "2026-06-09T16:13:58.430577+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.832128+00:00",
+     "start_time": "2026-06-09T16:13:58.427188+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1509,16 +1513,16 @@
    "id": "cell-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.848110Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.847817Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.852472Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.851760Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.438863Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.438704Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.442374Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.441635Z"
     },
     "papermill": {
-     "duration": 0.011518,
-     "end_time": "2026-06-02T21:51:35.853144+00:00",
+     "duration": 0.008729,
+     "end_time": "2026-06-09T16:13:58.442890+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.841626+00:00",
+     "start_time": "2026-06-09T16:13:58.434161+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1614,10 +1618,10 @@
    "id": "e0e4572b",
    "metadata": {
     "papermill": {
-     "duration": 0.005036,
-     "end_time": "2026-06-02T21:51:35.863304+00:00",
+     "duration": 0.003028,
+     "end_time": "2026-06-09T16:13:58.449092+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.858268+00:00",
+     "start_time": "2026-06-09T16:13:58.446064+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1647,10 +1651,10 @@
    "id": "cell-26",
    "metadata": {
     "papermill": {
-     "duration": 0.004858,
-     "end_time": "2026-06-02T21:51:35.873244+00:00",
+     "duration": 0.003357,
+     "end_time": "2026-06-09T16:13:58.455584+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.868386+00:00",
+     "start_time": "2026-06-09T16:13:58.452227+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1673,13 +1677,246 @@
   },
   {
    "cell_type": "markdown",
+   "id": "13012dbe",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002933,
+     "end_time": "2026-06-09T16:13:58.462499+00:00",
+     "exception": false,
+     "start_time": "2026-06-09T16:13:58.459566+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Exemple guide : Domaine HTN \"Preparation de cafe\"\n",
+    "\n",
+    "Pour illustrer concretement la decomposition HTN sur un exemple compact et autonome, modelisons la preparation d'un cafe avec deux methodes alternatives :\n",
+    "\n",
+    "- **Methode expresso** : `!grinder`, `!brew_expresso` (rapide, pour 1 personne)\n",
+    "- **Methode filtre** : `!setup_filter`, `!pour_water`, `!brew_filter` (plus lent, pour plusieurs)\n",
+    "\n",
+    "Ce domaine montre comment les methodes HTN guident le solveur vers des plans differents selon l'etat du monde (nombre de tasses, disponibilite du moulin)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fb64014c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T16:13:58.469803Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.469637Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.477077Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.476398Z"
+    },
+    "papermill": {
+     "duration": 0.011881,
+     "end_time": "2026-06-09T16:13:58.477566+00:00",
+     "exception": false,
+     "start_time": "2026-06-09T16:13:58.465685+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "Exemple guide : Preparation de cafe (HTN)\n",
+      "============================================================\n",
+      "\n",
+      "--- Scenario 1 : Expresso ---\n",
+      "Plan (m_expresso) : grind_beans(arabica, grinder1) -> brew_expresso(grinder1, mug_A)\n",
+      "Longueur : 2 actions\n",
+      "\n",
+      "--- Scenario 2 : Cafe filtre ---\n",
+      "Plan (m_filter_coffee) : setup_filter(drip_machine) -> pour_water(drip_machine, tap) -> brew_filter(drip_machine, carafe)\n",
+      "Longueur : 3 actions\n",
+      "\n",
+      "--- Analyse de la selection de methode ---\n",
+      "Scenario 1 : moulin libre + tasse -> m_expresso (2 actions)\n",
+      "Scenario 2 : pas de moulin -> m_filter_coffee (3 actions)\n",
+      "\n",
+      "Le solveur HTN essaie m_expresso en premier.\n",
+      "Si m_expresso echoue (preconditions non satisfaites),\n",
+      "il backtrack et essaie m_filter_coffee.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple guide : Domaine HTN pour la preparation de cafe\n",
+    "# Ce domaine est autonome et utilise les classes definies precedemment\n",
+    "\n",
+    "# ---- Actions primitives ----\n",
+    "coffee_actions = {\n",
+    "    'grind_beans': Action(\n",
+    "        name='grind_beans',\n",
+    "        parameters=['?beans', '?grinder'],\n",
+    "        preconditions=[('beans-available', '?beans'), ('grinder-free', '?grinder')],\n",
+    "        add_effects=[('ground-coffee', '?grinder')],\n",
+    "        del_effects=[('beans-available', '?beans'), ('grinder-free', '?grinder')]\n",
+    "    ),\n",
+    "    'brew_expresso': Action(\n",
+    "        name='brew_expresso',\n",
+    "        parameters=['?grinder', '?cup'],\n",
+    "        preconditions=[('ground-coffee', '?grinder'), ('cup-clean', '?cup')],\n",
+    "        add_effects=[('coffee-ready', '?cup')],\n",
+    "        del_effects=[('ground-coffee', '?grinder'), ('cup-clean', '?cup')]\n",
+    "    ),\n",
+    "    'setup_filter': Action(\n",
+    "        name='setup_filter',\n",
+    "        parameters=['?machine'],\n",
+    "        preconditions=[('machine-free', '?machine')],\n",
+    "        add_effects=[('filter-ready', '?machine')],\n",
+    "        del_effects=[('machine-free', '?machine')]\n",
+    "    ),\n",
+    "    'pour_water': Action(\n",
+    "        name='pour_water',\n",
+    "        parameters=['?machine', '?water_src'],\n",
+    "        preconditions=[('filter-ready', '?machine'), ('water-available', '?water_src')],\n",
+    "        add_effects=[('water-poured', '?machine')],\n",
+    "        del_effects=[('water-available', '?water_src')]\n",
+    "    ),\n",
+    "    'brew_filter': Action(\n",
+    "        name='brew_filter',\n",
+    "        parameters=['?machine', '?cups'],\n",
+    "        preconditions=[('water-poured', '?machine')],\n",
+    "        add_effects=[('coffee-ready', '?cups')],\n",
+    "        del_effects=[('water-poured', '?machine')]\n",
+    "    ),\n",
+    "}\n",
+    "\n",
+    "# ---- Methodes HTN ----\n",
+    "coffee_methods = {\n",
+    "    'make_coffee': [\n",
+    "        # Methode 1 : Expresso (rapide, 1 tasse, necessite un moulin libre)\n",
+    "        Method(\n",
+    "            name='m_expresso',\n",
+    "            task_name='make_coffee',\n",
+    "            task_params=['?cup'],\n",
+    "            parameters=['?cup', '?beans', '?grinder'],\n",
+    "            preconditions=[\n",
+    "                ('beans-available', '?beans'),\n",
+    "                ('grinder-free', '?grinder'),\n",
+    "                ('cup-clean', '?cup'),\n",
+    "            ],\n",
+    "            subtasks=[\n",
+    "                ('grind_beans', ['?beans', '?grinder']),\n",
+    "                ('brew_expresso', ['?grinder', '?cup']),\n",
+    "            ]\n",
+    "        ),\n",
+    "        # Methode 2 : Filtre (plus lent, pour une carafe, necessite machine libre)\n",
+    "        Method(\n",
+    "            name='m_filter_coffee',\n",
+    "            task_name='make_coffee',\n",
+    "            task_params=['?carafe'],\n",
+    "            parameters=['?carafe', '?machine', '?water_src'],\n",
+    "            preconditions=[\n",
+    "                ('machine-free', '?machine'),\n",
+    "                ('water-available', '?water_src'),\n",
+    "                ('cup-clean', '?carafe'),\n",
+    "            ],\n",
+    "            subtasks=[\n",
+    "                ('setup_filter', ['?machine']),\n",
+    "                ('pour_water', ['?machine', '?water_src']),\n",
+    "                ('brew_filter', ['?machine', '?carafe']),\n",
+    "            ]\n",
+    "        ),\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "# ---- Resolution ----\n",
+    "print(\"=\" * 60)\n",
+    "print(\"Exemple guide : Preparation de cafe (HTN)\")\n",
+    "print(\"=\" * 60)\n",
+    "\n",
+    "# Scenario 1 : Expresso — moulin libre, 1 tasse\n",
+    "print(\"\\n--- Scenario 1 : Expresso ---\")\n",
+    "expresso_state = State({\n",
+    "    ('beans-available', 'arabica'),\n",
+    "    ('grinder-free', 'grinder1'),\n",
+    "    ('cup-clean', 'mug_A'),\n",
+    "})\n",
+    "planner_coffee = HTNPlanner(actions=coffee_actions, methods=coffee_methods)\n",
+    "\n",
+    "plan1 = planner_coffee.solve(expresso_state, [('make_coffee', ['mug_A'])])\n",
+    "if plan1:\n",
+    "    print(f\"Plan (m_expresso) : {' -> '.join(plan1)}\")\n",
+    "    print(f\"Longueur : {len(plan1)} actions\")\n",
+    "else:\n",
+    "    print(\"Echec\")\n",
+    "\n",
+    "# Scenario 2 : Cafe filtre — pas de moulin libre, carafe\n",
+    "print(\"\\n--- Scenario 2 : Cafe filtre ---\")\n",
+    "filter_state = State({\n",
+    "    # Pas de beans-available ni grinder-free -> m_expresso impossible\n",
+    "    ('machine-free', 'drip_machine'),\n",
+    "    ('water-available', 'tap'),\n",
+    "    ('cup-clean', 'carafe'),\n",
+    "})\n",
+    "\n",
+    "plan2 = planner_coffee.solve(filter_state, [('make_coffee', ['carafe'])])\n",
+    "if plan2:\n",
+    "    print(f\"Plan (m_filter_coffee) : {' -> '.join(plan2)}\")\n",
+    "    print(f\"Longueur : {len(plan2)} actions\")\n",
+    "else:\n",
+    "    print(\"Echec\")\n",
+    "\n",
+    "# Analyse de la selection de methode\n",
+    "print(\"\\n--- Analyse de la selection de methode ---\")\n",
+    "print(f\"Scenario 1 : moulin libre + tasse -> m_expresso (2 actions)\")\n",
+    "print(f\"Scenario 2 : pas de moulin -> m_filter_coffee (3 actions)\")\n",
+    "print(f\"\\nLe solveur HTN essaie m_expresso en premier.\")\n",
+    "print(f\"Si m_expresso echoue (preconditions non satisfaites),\")\n",
+    "print(f\"il backtrack et essaie m_filter_coffee.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c122458",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003461,
+     "end_time": "2026-06-09T16:13:58.484347+00:00",
+     "exception": false,
+     "start_time": "2026-06-09T16:13:58.480886+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : Domaine cafe HTN\n",
+    "\n",
+    "**Resultats** : deux scenarios, deux methodes differentes selectionnees automatiquement par le solveur.\n",
+    "\n",
+    "| Scenario | Etat initial | Methode selectionnee | Plan | Longueur |\n",
+    "|----------|-------------|---------------------|------|----------|\n",
+    "| Expresso | arabica + grinder libre + mug | `m_expresso` | grind_beans -> brew_expresso | 2 |\n",
+    "| Filtre | machine libre + eau + carafe | `m_filter_coffee` | setup_filter -> pour_water -> brew_filter | 3 |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. **Selection automatique** : le solveur essaie `m_expresso` en premier. Quand ses preconditions echouent (pas de `grinder-free`), il backtracke et essaie `m_filter_coffee`\n",
+    "2. **Methodes alternatives** : la meme tache abstraite `make_coffee` se decompose differemment selon l'etat du monde — c'est le coeur du paradigme HTN\n",
+    "3. **Expertise encodee** : les methodes capturent le savoir-faire (\"pour faire un cafe, soit tu mouds des grains, soit tu utilises une machine filtre\")\n",
+    "4. **Comparaison avec PDDL** : en planification classique, il faudrait enumerer tous les etats intermediaires. HTN exploite directement la structure hierarchique\n",
+    "\n",
+    "> **Lien avec SHOP2** : cet exemple suit exactement l'algorithme SHOP2 — ordered decomposition avec backtracking sur les methodes. L'ordre des methodes dans la liste determine la priorite (`m_expresso` est essayee avant `m_filter_coffee`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-27",
    "metadata": {
     "papermill": {
-     "duration": 0.005345,
-     "end_time": "2026-06-02T21:51:35.883704+00:00",
+     "duration": 0.003263,
+     "end_time": "2026-06-09T16:13:58.490837+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.878359+00:00",
+     "start_time": "2026-06-09T16:13:58.487574+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1695,10 +1932,10 @@
    "id": "cell-28",
    "metadata": {
     "papermill": {
-     "duration": 0.004881,
-     "end_time": "2026-06-02T21:51:35.893318+00:00",
+     "duration": 0.003209,
+     "end_time": "2026-06-09T16:13:58.497329+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.888437+00:00",
+     "start_time": "2026-06-09T16:13:58.494120+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1719,10 +1956,10 @@
    "id": "ff51da4f",
    "metadata": {
     "papermill": {
-     "duration": 0.004653,
-     "end_time": "2026-06-02T21:51:35.903224+00:00",
+     "duration": 0.003378,
+     "end_time": "2026-06-09T16:13:58.503962+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.898571+00:00",
+     "start_time": "2026-06-09T16:13:58.500584+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1737,20 +1974,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "cell-29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.914958Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.914724Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.918758Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.917983Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.511399Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.511240Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.514273Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.513789Z"
     },
     "papermill": {
-     "duration": 0.011324,
-     "end_time": "2026-06-02T21:51:35.919489+00:00",
+     "duration": 0.007603,
+     "end_time": "2026-06-09T16:13:58.514810+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.908165+00:00",
+     "start_time": "2026-06-09T16:13:58.507207+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1790,10 +2027,10 @@
    "id": "cell-30",
    "metadata": {
     "papermill": {
-     "duration": 0.006483,
-     "end_time": "2026-06-02T21:51:35.931433+00:00",
+     "duration": 0.003659,
+     "end_time": "2026-06-09T16:13:58.521992+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.924950+00:00",
+     "start_time": "2026-06-09T16:13:58.518333+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1811,20 +2048,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "cell-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.945281Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.945041Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.949485Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.948646Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.530129Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.529954Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.532997Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.532522Z"
     },
     "papermill": {
-     "duration": 0.01274,
-     "end_time": "2026-06-02T21:51:35.950144+00:00",
+     "duration": 0.007716,
+     "end_time": "2026-06-09T16:13:58.533618+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.937404+00:00",
+     "start_time": "2026-06-09T16:13:58.525902+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1864,10 +2101,10 @@
    "id": "cell-32",
    "metadata": {
     "papermill": {
-     "duration": 0.007115,
-     "end_time": "2026-06-02T21:51:35.962828+00:00",
+     "duration": 0.003426,
+     "end_time": "2026-06-09T16:13:58.540352+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.955713+00:00",
+     "start_time": "2026-06-09T16:13:58.536926+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1883,20 +2120,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "cell-33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:35.978730Z",
-     "iopub.status.busy": "2026-06-02T21:51:35.978406Z",
-     "iopub.status.idle": "2026-06-02T21:51:35.982794Z",
-     "shell.execute_reply": "2026-06-02T21:51:35.981998Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.548626Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.548360Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.552263Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.551624Z"
     },
     "papermill": {
-     "duration": 0.013624,
-     "end_time": "2026-06-02T21:51:35.983510+00:00",
+     "duration": 0.008823,
+     "end_time": "2026-06-09T16:13:58.552776+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.969886+00:00",
+     "start_time": "2026-06-09T16:13:58.543953+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1928,10 +2165,10 @@
    "id": "cell-34",
    "metadata": {
     "papermill": {
-     "duration": 0.005684,
-     "end_time": "2026-06-02T21:51:35.994838+00:00",
+     "duration": 0.004072,
+     "end_time": "2026-06-09T16:13:58.560326+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.989154+00:00",
+     "start_time": "2026-06-09T16:13:58.556254+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1958,10 +2195,10 @@
    "id": "cell-35",
    "metadata": {
     "papermill": {
-     "duration": 0.005333,
-     "end_time": "2026-06-02T21:51:36.005304+00:00",
+     "duration": 0.004002,
+     "end_time": "2026-06-09T16:13:58.568105+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:35.999971+00:00",
+     "start_time": "2026-06-09T16:13:58.564103+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1998,10 +2235,10 @@
    "id": "cell-36",
    "metadata": {
     "papermill": {
-     "duration": 0.005637,
-     "end_time": "2026-06-02T21:51:36.016137+00:00",
+     "duration": 0.003283,
+     "end_time": "2026-06-09T16:13:58.575067+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:36.010500+00:00",
+     "start_time": "2026-06-09T16:13:58.571784+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2035,10 +2272,10 @@
    "id": "a883497a",
    "metadata": {
     "papermill": {
-     "duration": 0.005595,
-     "end_time": "2026-06-02T21:51:36.028077+00:00",
+     "duration": 0.008302,
+     "end_time": "2026-06-09T16:13:58.587634+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:36.022482+00:00",
+     "start_time": "2026-06-09T16:13:58.579332+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2058,10 +2295,10 @@
    "id": "64598202",
    "metadata": {
     "papermill": {
-     "duration": 0.005517,
-     "end_time": "2026-06-02T21:51:36.038835+00:00",
+     "duration": 0.003307,
+     "end_time": "2026-06-09T16:13:58.596177+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:36.033318+00:00",
+     "start_time": "2026-06-09T16:13:58.592870+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2089,20 +2326,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "70095d11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:51:36.051588Z",
-     "iopub.status.busy": "2026-06-02T21:51:36.051240Z",
-     "iopub.status.idle": "2026-06-02T21:51:36.054915Z",
-     "shell.execute_reply": "2026-06-02T21:51:36.054168Z"
+     "iopub.execute_input": "2026-06-09T16:13:58.604767Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.604602Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.608155Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.607635Z"
     },
     "papermill": {
-     "duration": 0.011365,
-     "end_time": "2026-06-02T21:51:36.055562+00:00",
+     "duration": 0.008223,
+     "end_time": "2026-06-09T16:13:58.608669+00:00",
      "exception": false,
-     "start_time": "2026-06-02T21:51:36.044197+00:00",
+     "start_time": "2026-06-09T16:13:58.600446+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2143,18 +2380,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.623313,
-   "end_time": "2026-06-02T21:51:36.743584+00:00",
+   "duration": 2.431413,
+   "end_time": "2026-06-09T16:13:58.737592+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-9-HTN.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-9-HTN_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-9-HTN.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-9-HTN_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-02T21:51:33.120271+00:00",
+   "start_time": "2026-06-09T16:13:56.306179+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary
Adds an **Exemple guide** to Planners-9-HTN: a complete **coffee preparation** domain with 2 alternative decomposition methods.

### Content
- **3 cells inserted**: markdown intro + code (HTN domain with expresso vs filter methods, 2 scenarios) + markdown interpretation
- Demonstrates: abstract task decomposition, automatic method selection via backtracking, SHOP2 algorithm in practice
- 2 scenarios: expresso (2 actions) when grinder available, filter coffee (3 actions) as fallback
- Pedagogical link to method selection priority and PDDL comparison

### Validation
- Papermill SUCCESS: 51 cells, 13 code, 0 null exec_count, 0 errors
- 5 existing exercises preserved intact (stubs unchanged)
- Catalogue/README not touched

See #1455