### PR TITLE
ci(lean): add Lake build + sorry check for calibration_lean (#1452)

### DIFF
--- a/.github/workflows/lean-calibration.yml
+++ b/.github/workflows/lean-calibration.yml
@@ -1,0 +1,95 @@
+name: Lean Calibration CI
+
+# CI for calibration_lean (SymbolicAI/Lean/calibration_lean).
+# Calibration targets for the multi-agent Lean prover (Epic #1452 / #1453).
+# Verifies lake build SUCCESS + tracks sorry count in calibration theorems.
+# Rule lean-merge-discipline: lake build SUCCESS local OBLIGATOIRE avant merge.
+# This CI is the canonical verification path since local builds may be blocked
+# (e.g. WDAC policy blocking native linker on some machines).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lean-toolchain'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-sorry-calibration:
+    name: "Sorry check (calibration_lean)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Count sorry in calibration_lean
+      run: |
+        echo "=== Sorry inventory for calibration_lean ==="
+        SORRY_TOTAL=0
+        # Baseline = 4: all current "sorry" occurrences are doc comments in
+        # Nash.lean describing the P4 sorry-increase calibration design.
+        # Calibration targets are designed to be PROVABLE (0 sorry in proofs).
+        KNOWN_BASELINE=4
+        for f in $(find Calibration -name '*.lean'); do
+          if [ -f "$f" ]; then
+            COUNT=$(grep -c "sorry" "$f" || true)
+            echo "  $f: $COUNT sorry"
+            SORRY_TOTAL=$((SORRY_TOTAL + COUNT))
+          fi
+        done
+        echo ""
+        echo "Total sorry: $SORRY_TOTAL"
+        echo "Known baseline: $KNOWN_BASELINE"
+        if [ "$SORRY_TOTAL" -gt "$KNOWN_BASELINE" ]; then
+          echo ""
+          echo "FAIL: sorry count ($SORRY_TOTAL) exceeds baseline ($KNOWN_BASELINE)"
+          echo "New sorrys introduced — calibration targets must stay provable."
+          exit 1
+        fi
+        echo "OK: no new sorrys introduced."
+
+  build-calibration:
+    name: "Lake build (calibration_lean)"
+    runs-on: ubuntu-latest
+    needs: check-sorry-calibration
+    defaults:
+      run:
+        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install elan
+      run: |
+        curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        ./elan-init -y --default-toolchain none
+        echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+    - name: Cache Lake build artifacts
+      uses: actions/cache@v4
+      with:
+        path: MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/.lake
+        key: lake-cal-${{ runner.os }}-${{ hashFiles('MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.lean', 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lean-toolchain') }}
+        restore-keys: lake-cal-${{ runner.os }}-
+
+    - name: Lake build
+      run: |
+        lake exe cache get || true
+        lake -R build 2>&1 | tail -20


### PR DESCRIPTION
## Summary

`calibration_lean` (the prover calibration targets from #1452) had **NO CI coverage**. The proofs merged in #2737 (Nim.lean, Doomsday.lean) and the pre-existing Nash.lean were never compiled — neither locally (WDAC policy blocks the native linker `ld.lld.exe` on Windows) nor in CI. This violates [lean-merge-discipline.md](.claude/rules/lean-merge-discipline.md) (lake build SUCCESS obligatoire) and the #1452 dispatch deliverable ("`lake build` SUCCESS").

### What this adds

Mirrors the existing working `.github/workflows/lean-game-theory.yml`:

| Job | Purpose |
|-----|---------|
| `check-sorry-calibration` | Baseline=4 (all current `sorry` are doc comments in Nash.lean describing the P4 sorry-increase design). Calibration targets must stay **provable** (0 sorry in proofs). Fails if count increases. |
| `build-calibration` | `lake exe cache get` (fetches prebuilt Mathlib oleans — fast on CI) + `lake build`. **This is the canonical verification path** that truth-checks the merged proofs. |

### Why this matters now

PR #2737 merged 11 new Lean theorems (Nim + Doomsday) with only Catalog/Gitleaks/Stale-Base CI checks — **none of which compile Lean**. Once this workflow is on `main`, `workflow_dispatch` can run it to verify whether #2737's proofs actually compile. This closes the verification gap that lean-merge-discipline mandates.

### Scope (G.4 atomic)

This PR covers **only** `calibration_lean` (my #1452 lane). A broader gap remains — 7 other Lean projects also lack CI:
- `conway_lean`, `grothendieck_lean`, `sensitivity_lean` (SymbolicAI/Lean)
- `conway_cgt_lean`, `social_choice_lean_peters` (GameTheory)
- `gittins_lean` (Probas/Infer), `mathlib_examples`

Recommend ai-01 scope follow-up per project (each is an atomic PR — don't bundle 8 projects into one CI PR).

### Verification
- YAML structure mirrored verbatim from working `lean-game-theory.yml`
- `paths:` filter triggers on calibration_lean changes; `workflow_dispatch` enables manual runs to verify existing main state

See #1452, Part of #1453, Part of #2162