### PR TITLE
ci(lean): add Lake build + sorry-regression guard for conway_lean

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -1,0 +1,101 @@
+name: Lean Conway CI
+
+# CI for conway_lean (SymbolicAI/Lean/conway_lean).
+# Conway hommage: accessible formalizations of lesser-known Conway results.
+# Closes part of the "CI Lean lacunaire" structural blocker (7 Lean projects
+# previously had no build CI). Mirrors lean-calibration.yml / lean-game-theory.yml.
+# Rule lean-merge-discipline: lake build SUCCESS is the canonical verification path
+# since local builds may be blocked (e.g. WDAC policy blocking the native linker).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-sorry-conway:
+    name: "Sorry check (conway_lean)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Count sorry in conway_lean (no-new-sorry regression guard)
+      run: |
+        echo "=== Sorry inventory for conway_lean ==="
+        SORRY_TOTAL=0
+        # conway_lean is a WIP formalization. Baseline = 22 (snapshot 2026-06-09):
+        #   Angel.lean 1, CollatzLike.lean 1, DoomsdayLemmas.lean 1,
+        #   HashlifeCorrectness.lean 9, HashlifeMemo.lean 4, Pillars.lean 5,
+        #   Conway.lean (root) 1.
+        # This enforces anti-regression rule D (no NEW sorry without justification).
+        # As proofs are completed, sorry count decreases below baseline -> CI stays GREEN.
+        # If baseline must be RAISED (new WIP theorem added), do it in a dedicated commit
+        # with justification in the message.
+        KNOWN_BASELINE=22
+        for f in $(find . -name '*.lean' -not -path './.lake/*'); do
+          if [ -f "$f" ]; then
+            COUNT=$(grep -c "sorry" "$f" || true)
+            echo "  $f: $COUNT sorry"
+            SORRY_TOTAL=$((SORRY_TOTAL + COUNT))
+          fi
+        done
+        echo ""
+        echo "Total sorry: $SORRY_TOTAL"
+        echo "Known baseline: $KNOWN_BASELINE"
+        if [ "$SORRY_TOTAL" -gt "$KNOWN_BASELINE" ]; then
+          echo ""
+          echo "FAIL: sorry count ($SORRY_TOTAL) exceeds baseline ($KNOWN_BASELINE)"
+          echo "New sorrys introduced — conway_lean is WIP but sorry must not increase"
+          echo "without justification (anti-regression rule D)."
+          exit 1
+        fi
+        echo "OK: no new sorrys introduced (count $SORRY_TOTAL <= baseline $KNOWN_BASELINE)."
+
+  build-conway:
+    name: "Lake build (conway_lean)"
+    runs-on: ubuntu-latest
+    needs: check-sorry-conway
+    defaults:
+      run:
+        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install elan
+      run: |
+        curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        ./elan-init -y --default-toolchain none
+        echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+    - name: Cache Lake build artifacts
+      uses: actions/cache@v4
+      with:
+        path: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/.lake
+        key: lake-conway-${{ runner.os }}-${{ hashFiles('MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean', 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain') }}
+        restore-keys: lake-conway-${{ runner.os }}-
+
+    - name: Lake build
+      run: |
+        lake exe cache get || true
+        lake -R build 2>&1 | tail -20


### PR DESCRIPTION
## Summary

`conway_lean` (SymbolicAI/Lean) — a WIP formalization of lesser-known Conway results (Doomsday, Game of Life/Hashlife, Collatz, Fractran, Nim, Angel, Kochen-Specker, Free Will Theorem) — had **no build CI**. This continues closing the **"CI Lean lacunaire" structural blocker**: 7 Lean projects previously had no build CI (the merged #2741 fixed `calibration_lean`; this fixes `conway_lean`).

Mirrors the proven `lean-calibration.yml` / `lean-game-theory.yml` structure exactly.

### Two jobs

| Job | Purpose |
|-----|---------|
| `check-sorry-conway` | Baseline=**22** (WIP snapshot, 2026-06-09). Enforces **anti-regression rule D**: no NEW sorry without justification. As proofs get completed, the count drops below 22 → CI stays GREEN. If baseline must be raised (new WIP theorem), it must be a dedicated commit with justification. |
| `build-conway` | `lake exe cache get` + `lake -R build`. **Canonical verification path** — local builds are blocked by WDAC policy on the native linker `ld.lld.exe`. |

### Why baseline=22 (not fail-on-sorry)

Unlike `calibration_lean` (designed provable, baseline=4) or `social_choice_lean` (strict certified-module gate), `conway_lean` is a **live WIP formalization** with 22 real sorries across 7 files (HashlifeCorrectness 9, Pillars 5, HashlifeMemo 4, Angel/CollatzLike/DoomsdayLemmas/Conway.root 1 each). A strict fail-on-sorry would block all WIP progress. The no-new-sorry guard enforces anti-regression (rule D) while allowing proofs to be completed naturally.

### Toolchain note
`v4.30.0-rc2` is the project's declared `lean-toolchain`. CI uses it as-is via elan (RC toolchains are fetchable; `cache get` is best-effort with `|| true`).

### Scope (G.4 atomic)
1 workflow file. **6 Lean projects still lack CI**: `grothendieck_lean`, `sensitivity_lean`, `mathlib_examples`, `conway_cgt_lean`, `social_choice_lean_peters`, `gittins_lean` → per-project atomic follow-up (do NOT bundle).

### Note
The `pull_request` trigger won't run on this PR itself (GitHub Actions limitation for newly-added workflows) — expected. ai-01 can `workflow_dispatch` post-merge to truth-check current `main` state of conway_lean.

See #1452. Part of #1453.