### PR TITLE
ci(conway): Lean Conway CI — lake build + sorry baseline guard (8)

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -1,0 +1,114 @@
+name: Lean Conway CI
+
+# CI for conway_lean (SymbolicAI/Lean/conway_lean).
+# Conway homage — accessible formalizations of lesser-known results by
+# John Horton Conway (Game of Life, FRACTRAN, Look-and-Say, Doomsday,
+# Free Will Theorem, Kochen-Specker, Angel, Collatz-like, Nim).
+# Verifies lake build SUCCESS + guards the sorry baseline in Conway modules.
+# Rule lean-merge-discipline: lake build SUCCESS local OBLIGATOIRE avant merge.
+# This CI is the canonical verification path since local builds may be blocked
+# (e.g. WDAC policy blocking native linker on some machines).
+#
+# Mirrors lean-grothendieck.yml (#2743) and lean-calibration.yml (#2741).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-sorry-conway:
+    name: "Sorry check (conway_lean)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Count sorry in conway_lean
+      run: |
+        echo "=== Sorry inventory for conway_lean ==="
+        # Unlike grothendieck (0 real sorry, only header-comment prose),
+        # conway_lean has 8 documented real tactic sorries AND many PROSE
+        # mentions of "sorry" in block comments (e.g. "Each `sorry` is a
+        # target", "Left as sorry", "remain `sorry`-gated", "Originally
+        # left as `sorry`"). Those prose mentions are NOT real sorries.
+        #
+        # A real sorry-as-tactic is the SOLE token on its line (optionally
+        # indented). We match ^\s*sorry\s*$ to distinguish tactic from prose.
+        #
+        # Known baseline = 8, all documented + intentional:
+        #   - HashlifeCorrectness.lean : 2  (intractable P4 central / P5 main theorem)
+        #   - HashlifeMemo.lean        : 2  (scaffolding, Phase 3c roadmap)
+        #   - Pillars.lean             : 4  (scaffolding: otca/unitcell/gemini/cpu)
+        # CI FAILs if a 9th sorry-as-tactic is introduced.
+        SORRY_TOTAL=0
+        KNOWN_BASELINE=8
+        for f in $(find Conway -name '*.lean'); do
+          if [ -f "$f" ]; then
+            REAL=$(grep -cE "^\s*sorry\s*$" "$f" || true)
+            if [ "$REAL" -gt 0 ]; then
+              echo "  $f: $REAL real sorry (standalone tactic)"
+              SORRY_TOTAL=$((SORRY_TOTAL + REAL))
+            fi
+          fi
+        done
+        echo ""
+        echo "Real sorry (standalone tactic): $SORRY_TOTAL"
+        echo "Known baseline: $KNOWN_BASELINE"
+        if [ "$SORRY_TOTAL" -gt "$KNOWN_BASELINE" ]; then
+          echo ""
+          echo "FAIL: real sorry count ($SORRY_TOTAL) exceeds baseline ($KNOWN_BASELINE)"
+          echo "A sorry-as-tactic was introduced. If intentional (new intractable/"
+          echo "scaffolding target), raise KNOWN_BASELINE in this workflow WITH a"
+          echo "documented justification in the PR body."
+          exit 1
+        fi
+        echo "OK: sorry count at or below baseline ($SORRY_TOTAL <= $KNOWN_BASELINE)."
+
+  build-conway:
+    name: "Lake build (conway_lean)"
+    runs-on: ubuntu-latest
+    needs: check-sorry-conway
+    defaults:
+      run:
+        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install elan
+      run: |
+        curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        ./elan-init -y --default-toolchain none
+        echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+    - name: Cache Lake build artifacts
+      uses: actions/cache@v4
+      with:
+        path: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/.lake
+        key: lake-conway-${{ runner.os }}-${{ hashFiles('MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean', 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain') }}
+        restore-keys: lake-conway-${{ runner.os }}-
+
+    - name: Lake build
+      run: |
+        lake exe cache get || true
+        lake -R build 2>&1 | tail -20


### PR DESCRIPTION
## Summary

`conway_lean` (SymbolicAI/Lean/conway_lean) was the **largest Lean project without CI coverage** — 14+ modules, ~3350-job `lake build`, with documented intractable + scaffolding sorries that deserve a regression guard. This adds CI mirroring `lean-grothendieck.yml` (#2743) + `lean-calibration.yml` (#2741).

## What it does

Two jobs (same 2-job baseline pattern as grothendieck/calibration):

| Job | Purpose |
|-----|---------|
| `check-sorry-conway` | Counts standalone-tactic sorries; **baseline = 8**; FAILs on a 9th |
| `build-conway` | elan + cache Mathlib + `lake -R build` (needs sorry-check first) |

## Sorry filter — differs from grothendieck (important)

grothendieck has **0 real sorries** (only header-comment prose mentioning "sorry"). conway has **8 real tactic sorries AND many prose mentions** in block comments (`Each sorry is a target`, `Left as sorry`, `remain sorry-gated`, `Originally left as sorry`). The grothendieck prose-filter (`grep -viE "sorries|sorry.s"`) would **mis-count those prose mentions as real**, inflating the count.

Instead this workflow matches `^\s*sorry\s*$` (standalone tactic line — the sole token on its line), which **precisely** distinguishes tactic from prose.

## Baseline 8 = documented intentional sorries

| File | Count | Nature |
|------|-------|--------|
| `HashlifeCorrectness.lean` | 2 (L748, L828) | **intractable** — P4 central correctness, P5 main theorem |
| `HashlifeMemo.lean` | 2 (L189, L209) | scaffolding — Phase 3c roadmap |
| `Pillars.lean` | 4 (L177/190/205/219) | scaffolding — otca/unitcell/gemini/cpu witnesses |

All 8 are documented in MEMORY and tracked as prover targets / scaffolding. CI protects against a **9th** (regression) while accepting the documented baseline. If a new intractable/scaffolding target is added intentionally, the PR raises the baseline here with justification.

## Verification (pre-merge)

- **YAML**: `python -c "import yaml; yaml.safe_load(open(...))"` → parses cleanly
- **Sorry-check logic**: re-run the exact CI bash against real `conway_lean` source → returns exactly **8** (2 + 2 + 4), matches baseline. No false positives from prose.
- **Catalog**: byte-identical to `main` (workflow-only PR, no catalog regeneration — per catalog-pr-hygiene HARD 1)
- **Branch**: fresh off `origin/main` (catalog-pr-hygiene HARD 2)

## Scope

One file, +114 lines, docs/CI-only (no Lean source touched). `See Epic #1646` (Conway Lean formalization) — partial CI coverage, does not close the epic.

## Note on DRY

Orthogonal to the DRY matrix decision on #2743: this is **new coverage in the established per-project pattern**, not a refactor. A future matrix (if chosen) would fold `conway` in alongside grothendieck/calibration/game-theory identically. I clarified my earlier "hold" comment: new-coverage creation is not gated by the matrix-refactor decision.

No self-merge — awaiting ai-01 review + merge (lean-merge-discipline §1: ai-01 re-builds locally before merge).