### PR TITLE
fix(slides): update 4 stale stable_baseline refs to current RL filenames

### DIFF
--- a/slides/04-probabilites/analysis/improvement_plan.md
+++ b/slides/04-probabilites/analysis/improvement_plan.md
@@ -104,7 +104,7 @@
 | 36-50 | Inférence probabiliste | `Probas/Infer/Infer-5-Inference.ipynb`, `Infer-7-Variable-Elimination.ipynb` |
 | 51-70 | HMM et chaînes de Markov | `Probas/Infer/Infer-6-HMM.ipynb`, `Infer-8-Temporal.ipynb` |
 | 71-90 | MDP et décision | `GameTheory/GameTheory-2b-MDP.ipynb`, `Probas/Infer/Infer-12-Decision.ipynb` |
-| 91-98 | Applications RL | `RL/stable_baseline_cartpole.ipynb`, `GameTheory/GameTheory-14b-RL-Basics.ipynb` |
+| 91-98 | Applications RL | `RL/rl_1_intro_cartpole.ipynb`, `GameTheory/GameTheory-14b-RL-Basics.ipynb` |
 
 **Action** : Ajouter QR codes ou liens courts vers notebooks dans les slides de transition.
 

--- a/slides/06-apprentissage/analysis/improvement_plan.md
+++ b/slides/06-apprentissage/analysis/improvement_plan.md
@@ -32,7 +32,7 @@
 2. **Images sous copyright** : Slides SVM (autour du 60) affichent "Copyright 2001, 2003" - nécessite remplacement ou attribution formelle
 3. **Taille excessive** : 9.84 MB - la plus lourde des 3 decks analysés, peut causer problèmes de chargement
 4. **Densité variable** : Certaines slides trop chargées (>250 mots), d'autres trop légères
-5. **Manque de liens notebooks** : Cross-références absentes vers `ML/ML.Net/` (5 notebooks) et `RL/stable_baseline_*.ipynb`
+5. **Manque de liens notebooks** : Cross-références absentes vers `ML/ML.Net/` (5 notebooks) et `RL/rl_*.ipynb`
 6. **Absence d'architectures modernes** : Pas de Transformers, diffusion models, LLMs dans partie supervisée
 7. **Section RL datée** : Pas de mention RLHF, PPO moderne, InstructGPT/ChatGPT
 
@@ -161,7 +161,7 @@
 |-----------|---------|-----------|
 | 101-110 | MDP, Q-learning classique | `GameTheory/GameTheory-14b-RL-Basics.ipynb` |
 | 111-115 | Value iteration, policy iteration | `Probas/Infer/Infer-12-Decision.ipynb` |
-| 116-120 | Deep RL (DQN, PPO) | `RL/stable_baseline_cartpole.ipynb`, `RL/stable_baseline_dqn.ipynb` |
+| 116-120 | Deep RL (DQN, PPO) | `RL/rl_1_intro_cartpole.ipynb`, `RL/rl_6_dqn_policy_gradient.ipynb` |
 | 121-125 | RLHF, LLMs | `GenAI/llm-finetuning.ipynb` (si disponible, sinon créer démo) |
 | 126 | Multi-agent RL | `GameTheory/GameTheory-15b-Multi-Agent-RL.ipynb` |
 
@@ -182,7 +182,7 @@
 | 81-95 | EM, HMM learning, Bayes nets | `Probas/Infer/Infer-9-Learning.ipynb`, `Infer-10-Structure-Learning.ipynb` |
 | 96-100 | Modèles génératifs (VAE, GANs) | `GenAI/vae-*.ipynb`, `GenAI/diffusion-models.ipynb` |
 | 101-115 | RL classique (Q-learning, MDP) | `GameTheory/GameTheory-14b-RL-Basics.ipynb` |
-| 116-120 | Deep RL (DQN, PPO, SAC) | `RL/stable_baseline_cartpole.ipynb`, `RL/stable_baseline_dqn.ipynb` |
+| 116-120 | Deep RL (DQN, PPO, SAC) | `RL/rl_1_intro_cartpole.ipynb`, `RL/rl_6_dqn_policy_gradient.ipynb` |
 | 121-125 | RLHF et LLMs | `GenAI/llm-finetuning.ipynb` (créer si absent) |
 | 126 | Multi-agent RL | `GameTheory/GameTheory-15b-Multi-Agent-RL.ipynb` |
 


### PR DESCRIPTION
## Summary

Follow-up to the RL series renumbering (`stable_baseline_*` → `rl_*`). Two slide analysis plans still referenced pre-rename (and inexact) `stable_baseline_*` placeholders. This PR fixes those 4 references.

Companion to **#2742** (which fixed the same stale refs in GenAI PostTraining README, `slides/01-introduction`, and `.gitignore`). That PR touches `.ipynb`-adjacent files and is blocked behind the catalog-drift fix **#2745** (user-gated, governance #2632). **This PR is poison-immune** (0 `.ipynb` / 0 `README.md` in diff — `slides/**/analysis/*.md` does not match the catalog-drift bot's path triggers) and can merge independently of #2745.

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `slides/04-probabilites/analysis/improvement_plan.md` | 107 | `stable_baseline_cartpole.ipynb` | `rl_1_intro_cartpole.ipynb` |
| `slides/06-apprentissage/analysis/improvement_plan.md` | 35 | `stable_baseline_*.ipynb` | `rl_*.ipynb` |
| `slides/06-apprentissage/analysis/improvement_plan.md` | 164 | `stable_baseline_cartpole`, `stable_baseline_dqn` | `rl_1_intro_cartpole`, `rl_6_dqn_policy_gradient` |
| `slides/06-apprentissage/analysis/improvement_plan.md` | 185 | `stable_baseline_cartpole`, `stable_baseline_dqn` | `rl_1_intro_cartpole`, `rl_6_dqn_policy_gradient` |

### Mapping (verified against actual RL series files on disk)

- `cartpole` → **`rl_1_intro_cartpole.ipynb`** ✓ (the intro/cartpole notebook)
- `stable_baseline_dqn` in the **"Deep RL (DQN, PPO)"** row → **`rl_6_dqn_policy_gradient.ipynb`** ✓ — the deep-RL notebook. This is NOT `rl_3` (tabular experience-replay DQN), because the slide context is explicitly *Deep RL (DQN, PPO, SAC)*.
- `stable_baseline_*` wildcard → `rl_*`

All 3 target filenames verified to exist in `MyIA.AI.Notebooks/RL/`.

## Validation

- `grep -cE "stable_baseline"` on both files → **0 remaining** (was 4)
- `git diff` is **markdown-only** — 0 notebook code cells modified → no re-execution required (C.2 exception)
- `COURSE_CATALOG.generated.*` left **byte-identical to main** (cron-owned, not regenerated — catalog-pr-hygiene HARD 1)
- **Poison-safe**: `git diff --name-only` contains 0 `.ipynb` and 0 `README.md` → the catalog-drift bot does not trigger on this PR's files

## Out of scope

- `docs/archive/investigation-mcp-nuget/*` (2 files with stale `stable_baseline` refs) — **historical archive**, not edited (would falsify investigation history).
- 3 orphan `stable_baseline_*_output.ipynb` files still present in `RL/` — touching `.ipynb` would trigger the catalog-drift bot; deferred behind #2745.
- RL series notebooks themselves — covered by #2738/#2739.

See #2711
