### PR TITLE
ci(lean): add Lake build + sorry-regression guard for gittins_lean

### DIFF
--- a/.github/workflows/lean-gittins.yml
+++ b/.github/workflows/lean-gittins.yml
@@ -1,0 +1,119 @@
+name: Lean Gittins CI
+
+# CI for gittins_lean (Probas/Infer/gittins_lean).
+# Gittins index formalization companion to the Infer Gittins notebook (#2413).
+# Verifies lake build SUCCESS + guards the sorry baseline in Gittins modules.
+# Rule lean-merge-discipline: lake build SUCCESS local OBLIGATOIRE avant merge.
+# This CI is the canonical verification path since local builds may be blocked
+# (e.g. WDAC policy blocking the native linker on some machines).
+#
+# Mirrors lean-calibration.yml (#2741) and lean-conway.yml (#2747), but uses a
+# more robust sorry filter (see comment in check-sorry-gittins below).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/**.lean'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/**.lean'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lean-toolchain'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-sorry-gittins:
+    name: "Sorry check (gittins_lean)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: MyIA.AI.Notebooks/Probas/Infer/gittins_lean
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Count sorry in gittins_lean
+      run: |
+        echo "=== Sorry inventory for gittins_lean ==="
+        # gittins_lean is a WIP formalization. The Gittins index optimality
+        # theorem is INTRACTABLE in Mathlib (no MDP/bandit/Bellman), so several
+        # sorries are intentional stubs (each annotated `sorry -- TODO: <reason>`).
+        #
+        # FILTER NOTE: We use `^\s*sorry\b`, NOT `^\s*sorry\s*$`. The standalone-
+        # only filter (used by #2741/#2747) undercounts here because gittins_lean
+        # annotates its sorries with trailing comments, e.g.:
+        #     sorry  -- TODO: requires optimal stopping computation
+        # `^\s*sorry\b` catches BOTH standalone and trailing-comment sorries while
+        # still excluding prose (prose lines start with `#`, `--`, `-`, or text,
+        # never with bare `sorry` after only whitespace). For conway_lean (#2747)
+        # both filters agree (=8, all standalone); for gittins they differ (3 vs 6)
+        # so the `\b` filter is the correct, more robust choice here.
+        #
+        # Known baseline = 6, all documented + intentional WIP stubs:
+        #   - Gittins/Discount.lean        : 1  (tsum_le_tsum comparison)
+        #   - Gittins/GittinsTheorem.lean  : 5  (optimality theorem, known-arm,
+        #                                        monotone-discount, +2 in def/proof
+        #                                        of gittins_optimality)
+        # CI FAILs if a 7th sorry-as-tactic is introduced.
+        SORRY_TOTAL=0
+        KNOWN_BASELINE=6
+        for f in $(find Gittins -name '*.lean'); do
+          if [ -f "$f" ]; then
+            REAL=$(grep -cE '^\s*sorry\b' "$f" || true)
+            if [ "$REAL" -gt 0 ]; then
+              echo "  $f: $REAL real sorry (tactic, incl. trailing-comment stubs)"
+              SORRY_TOTAL=$((SORRY_TOTAL + REAL))
+            fi
+          fi
+        done
+        echo ""
+        echo "Real sorry (tactic): $SORRY_TOTAL"
+        echo "Known baseline: $KNOWN_BASELINE"
+        if [ "$SORRY_TOTAL" -gt "$KNOWN_BASELINE" ]; then
+          echo ""
+          echo "FAIL: real sorry count ($SORRY_TOTAL) exceeds baseline ($KNOWN_BASELINE)"
+          echo "A sorry-as-tactic was introduced. If intentional (new intractable/"
+          echo "scaffolding target), raise KNOWN_BASELINE in this workflow WITH a"
+          echo "documented justification in the PR body."
+          exit 1
+        fi
+        echo "OK: sorry count at or below baseline ($SORRY_TOTAL <= $KNOWN_BASELINE)."
+
+  build-gittins:
+    name: "Lake build (gittins_lean)"
+    runs-on: ubuntu-latest
+    needs: check-sorry-gittins
+    defaults:
+      run:
+        working-directory: MyIA.AI.Notebooks/Probas/Infer/gittins_lean
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install elan
+      run: |
+        curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        ./elan-init -y --default-toolchain none
+        echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+    - name: Cache Lake build artifacts
+      uses: actions/cache@v4
+      with:
+        path: MyIA.AI.Notebooks/Probas/Infer/gittins_lean/.lake
+        key: lake-gittins-${{ runner.os }}-${{ hashFiles('MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lakefile.lean', 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lean-toolchain') }}
+        restore-keys: lake-gittins-${{ runner.os }}-
+
+    - name: Lake build
+      run: |
+        lake exe cache get || true
+        lake -R build 2>&1 | tail -20


### PR DESCRIPTION
## Summary

`gittins_lean` (Probas/Infer, added in #2413 as the Lean companion to the Gittins index notebook) had **no build CI**. Continues closing the **"CI Lean lacunaire" structural blocker**. Sibling to #2741 (calibration, merged) and #2747 (conway, open).

### Key improvement over #2741/#2747: a more robust sorry filter

| Filter | conway (#2747) | gittins (this PR) |
|--------|----------------|-------------------|
| `^\s*sorry\s*$` (standalone only, #2741/#2747) | **8** | 3 ❌ undercounts |
| `^\s*sorry\b` (standalone + trailing-comment) | 8 | **6** ✅ correct |

gittins_lean annotates its WIP stubs with trailing comments — `sorry -- TODO: <reason>` — which the standalone-only filter **misses** (3 vs 6 real sorries). For conway both filters agree (=8, all standalone), so #2747 is correct there. For gittins the `\b` filter is **required**. (I verified this independently — see the in-workflow comment.)

### Two jobs (mirror lean-calibration.yml)

| Job | Purpose |
|-----|---------|
| `check-sorry-gittins` | Baseline=**6**, filter `^\s*sorry\b`. Enforces **anti-regression rule D** (no NEW sorry without justification). All 6 verified tactic-position sorries: Discount.lean ×1, GittinsTheorem.lean ×5. |
| `build-gittins` | `lake exe cache get` + `lake -R build`. Canonical verification path (local builds blocked by WDAC policy on the native linker). |

### Why baseline=6 (WIP, not fail-on-sorry)
The Gittins index optimality theorem is **INTRACTABLE in Mathlib** (no MDP/bandit/Bellman formalizations — a complete proof needs ~2000-5000 lines of supporting defs, per the in-file note). The 6 sorries are intentional documented stubs. The no-new-sorry guard enforces anti-regression (rule D) while allowing the WIP to progress. CI stays GREEN as proofs complete.

### Verification done before writing (G.1)
- `lean-toolchain` = `v4.30.0-rc2` (same as calibration/conway; CI uses as-is via elan).
- Standard Mathlib lakefile (`require mathlib ... @ "v4.30.0-rc2"`).
- Exhaustive sorry audit: `^\s*sorry\b`=6, all confirmed real tactics (3 standalone + 3 with `-- TODO`), 0 false positives from prose.

### Scope (G.4 atomic)
1 workflow file. **4 Lean projects still lack CI**: `sensitivity_lean`, `mathlib_examples`, `conway_cgt_lean`, `social_choice_lean_peters` → per-project atomic follow-up.

### Note
The `pull_request` trigger won't run on this PR itself (GitHub Actions limitation for newly-added workflows) — expected. ai-01 can `workflow_dispatch` post-merge to truth-check current `main` state of gittins_lean.

See #2161 (gittins provenance). Part of #1453.