### PR TITLE
ci(lean): reusable lean-build.yml + matrix callers (DRY consolidation)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -1,0 +1,115 @@
+name: Lean Build (reusable)
+
+# Reusable Lake-build + sorry-baseline CI for any Lean project in the repo.
+# Extracted from the per-file workflows lean-calibration.yml (#2741),
+# lean-grothendieck.yml (#2743), lean-conway.yml (#2747) per ai-01 DRY
+# decision (option 2: matrix). See Epic "CI Lean lacunaire".
+#
+# Callers invoke this via:
+#   jobs:
+#     ci:
+#       uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+#       with:
+#         project-path:      MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
+#         display-name:      grothendieck_lean
+#         sorry-baseline:    "0"
+#         sorry-filter-mode: prose-header   # raw | prose-header | standalone-tactic
+#
+# Sorry-filter modes (chosen per project's sorry "profile"):
+#   raw               : grep -c "sorry"                          (every mention)
+#   prose-header      : grep "sorry" | grep -viE "sorries|sorry.s"   (excludes prose plural/possessive)
+#   standalone-tactic : grep -cE "^\s*sorry\s*$"                  (only sorry as sole token on a line)
+# Use raw only when sorry ALWAYS means tactic (no prose mentions). Use prose-header
+# when the only non-tactic mentions are "sorries"/"sorry's" in header comments.
+# Use standalone-tactic when there are MANY prose mentions of "sorry" mixed with
+# real tactic sorries (e.g. Conway block comments). Choose the mode whose baseline
+# is robust to editing comments in that project.
+
+on:
+  workflow_call:
+    inputs:
+      project-path:
+        description: "Repo-relative path to the lake project root"
+        type: string
+        required: true
+      display-name:
+        description: "Human-readable project name (for job labels)"
+        type: string
+        required: true
+      sorry-baseline:
+        description: "Known-good standalone/real sorry count (regression floor)"
+        type: string
+        required: true
+      sorry-filter-mode:
+        description: "How to count sorry: raw | prose-header | standalone-tactic"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  ci:
+    name: "Lean CI (${{ inputs.display-name }})"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Sorry check (${{ inputs.display-name }})
+      working-directory: ${{ inputs.project-path }}
+      run: |
+        set -eu
+        MODE="${{ inputs.sorry-filter-mode }}"
+        BASELINE="${{ inputs.sorry-baseline }}"
+        echo "=== Sorry inventory for ${{ inputs.display-name }} (mode: $MODE, baseline: $BASELINE) ==="
+        SORRY_TOTAL=0
+        for f in $(find . -name '*.lean' -not -path './.lake/*'); do
+          if [ -f "$f" ]; then
+            case "$MODE" in
+              raw)
+                COUNT=$(grep -c "sorry" "$f" || true) ;;
+              prose-header)
+                COUNT=$(grep "sorry" "$f" | grep -viE "sorries|sorry.s" | wc -l || true) ;;
+              standalone-tactic)
+                COUNT=$(grep -cE "^\s*sorry\s*$" "$f" || true) ;;
+              *)
+                echo "ERROR: unknown sorry-filter-mode '$MODE'"; exit 2 ;;
+            esac
+            if [ "${COUNT:-0}" -gt 0 ]; then
+              echo "  $f: $COUNT"
+              SORRY_TOTAL=$((SORRY_TOTAL + COUNT))
+            fi
+          fi
+        done
+        echo ""
+        echo "Real sorry ($MODE): $SORRY_TOTAL"
+        echo "Known baseline: $BASELINE"
+        if [ "$SORRY_TOTAL" -gt "$BASELINE" ]; then
+          echo ""
+          echo "FAIL: sorry count ($SORRY_TOTAL) exceeds baseline ($BASELINE)"
+          echo "A sorry-as-tactic was introduced. If intentional (new intractable/"
+          echo "scaffolding target), raise sorry-baseline in the caller workflow WITH"
+          echo "a documented justification in the PR body."
+          exit 1
+        fi
+        echo "OK: sorry count at or below baseline ($SORRY_TOTAL <= $BASELINE)."
+
+    - name: Install elan
+      run: |
+        curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        ./elan-init -y --default-toolchain none
+        echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+    - name: Cache Lake build artifacts
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.project-path }}/.lake
+        key: lake-${{ inputs.display-name }}-${{ runner.os }}-${{ hashFiles(format('{0}/lakefile.lean', inputs.project-path), format('{0}/lakefile.toml', inputs.project-path), format('{0}/lean-toolchain', inputs.project-path)) }}
+        restore-keys: lake-${{ inputs.display-name }}-${{ runner.os }}-
+
+    - name: Lake build
+      working-directory: ${{ inputs.project-path }}
+      run: |
+        lake exe cache get || true
+        lake -R build 2>&1 | tail -20

--- a/.github/workflows/lean-calibration.yml
+++ b/.github/workflows/lean-calibration.yml
@@ -2,10 +2,17 @@ name: Lean Calibration CI
 
 # CI for calibration_lean (SymbolicAI/Lean/calibration_lean).
 # Calibration targets for the multi-agent Lean prover (Epic #1452 / #1453).
-# Verifies lake build SUCCESS + tracks sorry count in calibration theorems.
 # Rule lean-merge-discipline: lake build SUCCESS local OBLIGATOIRE avant merge.
-# This CI is the canonical verification path since local builds may be blocked
-# (e.g. WDAC policy blocking native linker on some machines).
+#
+# Migrated to the reusable lean-build.yml per ai-01 DRY decision (option 2: matrix).
+# Behavior is identical to the former inline check-sorry + build jobs.
+#
+# Sorry profile (verified 2026-06-10, raw mode, baseline=4): the 4 raw "sorry"
+# mentions in Nash.lean are 2 INTENTIONAL P4 tactic targets (L95/L96 — the
+# sorry-increase case the harness must NOT revert) + 2 prose mentions (L89/L97
+# describing them). raw mode + baseline 4 preserves the exact prior enforcement:
+# any new sorry-as-tactic raises the raw count >4 and fails. (standalone-tactic
+# would read 0 here because the P4 sorries carry a leading `·` and inline comment.)
 
 on:
   push:
@@ -24,72 +31,11 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lean-toolchain'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
-  check-sorry-calibration:
-    name: "Sorry check (calibration_lean)"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Count sorry in calibration_lean
-      run: |
-        echo "=== Sorry inventory for calibration_lean ==="
-        SORRY_TOTAL=0
-        # Baseline = 4: all current "sorry" occurrences are doc comments in
-        # Nash.lean describing the P4 sorry-increase calibration design.
-        # Calibration targets are designed to be PROVABLE (0 sorry in proofs).
-        KNOWN_BASELINE=4
-        for f in $(find Calibration -name '*.lean'); do
-          if [ -f "$f" ]; then
-            COUNT=$(grep -c "sorry" "$f" || true)
-            echo "  $f: $COUNT sorry"
-            SORRY_TOTAL=$((SORRY_TOTAL + COUNT))
-          fi
-        done
-        echo ""
-        echo "Total sorry: $SORRY_TOTAL"
-        echo "Known baseline: $KNOWN_BASELINE"
-        if [ "$SORRY_TOTAL" -gt "$KNOWN_BASELINE" ]; then
-          echo ""
-          echo "FAIL: sorry count ($SORRY_TOTAL) exceeds baseline ($KNOWN_BASELINE)"
-          echo "New sorrys introduced — calibration targets must stay provable."
-          exit 1
-        fi
-        echo "OK: no new sorrys introduced."
-
-  build-calibration:
-    name: "Lake build (calibration_lean)"
-    runs-on: ubuntu-latest
-    needs: check-sorry-calibration
-    defaults:
-      run:
-        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install elan
-      run: |
-        curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain none
-        echo "$HOME/.elan/bin" >> $GITHUB_PATH
-
-    - name: Cache Lake build artifacts
-      uses: actions/cache@v4
-      with:
-        path: MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/.lake
-        key: lake-cal-${{ runner.os }}-${{ hashFiles('MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.lean', 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lean-toolchain') }}
-        restore-keys: lake-cal-${{ runner.os }}-
-
-    - name: Lake build
-      run: |
-        lake exe cache get || true
-        lake -R build 2>&1 | tail -20
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean
+      display-name: calibration_lean
+      sorry-baseline: "4"
+      sorry-filter-mode: raw

--- a/.github/workflows/lean-conway-cgt.yml
+++ b/.github/workflows/lean-conway-cgt.yml
@@ -1,0 +1,31 @@
+name: Lean CI (conway_cgt_lean)
+
+# CI for conway_cgt_lean (GameTheory/conway_cgt_lean).
+# Combinatorial game theory port. 0 sorry (raw=0, verified). Toolchain v4.31.0-rc1.
+# Consolidated per ai-01 DRY decision (option 2: matrix). See lean-build.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/**.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/**.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/GameTheory/conway_cgt_lean
+      display-name: conway_cgt_lean
+      sorry-baseline: "0"
+      sorry-filter-mode: standalone-tactic

--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -1,15 +1,23 @@
 name: Lean Conway CI
 
 # CI for conway_lean (SymbolicAI/Lean/conway_lean).
-# Conway homage — accessible formalizations of lesser-known results by
-# John Horton Conway (Game of Life, FRACTRAN, Look-and-Say, Doomsday,
-# Free Will Theorem, Kochen-Specker, Angel, Collatz-like, Nim).
-# Verifies lake build SUCCESS + guards the sorry baseline in Conway modules.
+# Conway's Game of Life formalization (Hashlife, Kochen-Specker, Free Will).
 # Rule lean-merge-discipline: lake build SUCCESS local OBLIGATOIRE avant merge.
-# This CI is the canonical verification path since local builds may be blocked
-# (e.g. WDAC policy blocking native linker on some machines).
 #
-# Mirrors lean-grothendieck.yml (#2743) and lean-calibration.yml (#2741).
+# Consolidated per ai-01 DRY decision (option 2: matrix). Supersedes the inline
+# version in PR #2747 (same standalone-tactic mode, same baseline 8, now via the
+# shared lean-build.yml reusable workflow).
+#
+# Sorry profile (verified 2026-06-10, standalone-tactic mode, baseline=8):
+# conway has 8 real tactic sorries + many PROSE mentions in block comments
+# ("Each sorry is a target", "Left as sorry", "remain sorry-gated"). The
+# grothendieck prose-header filter OVERCOUNTS here (reads the prose), so we use
+# standalone-tactic (sorry as sole token on its line) to distinguish tactic vs
+# prose. Breakdown of the 8:
+#   - HashlifeCorrectness.lean: 2 (intractable P4/P5 — central correctness + main theorem)
+#   - HashlifeMemo.lean:        2 (scaffolding, Phase 3c)
+#   - Pillars.lean:             4 (scaffolding witnesses, Phase 3c)
+# Raising this baseline requires a documented justification in the PR body.
 
 on:
   push:
@@ -28,87 +36,11 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
-  check-sorry-conway:
-    name: "Sorry check (conway_lean)"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Count sorry in conway_lean
-      run: |
-        echo "=== Sorry inventory for conway_lean ==="
-        # Unlike grothendieck (0 real sorry, only header-comment prose),
-        # conway_lean has 8 documented real tactic sorries AND many PROSE
-        # mentions of "sorry" in block comments (e.g. "Each `sorry` is a
-        # target", "Left as sorry", "remain `sorry`-gated", "Originally
-        # left as `sorry`"). Those prose mentions are NOT real sorries.
-        #
-        # A real sorry-as-tactic is the SOLE token on its line (optionally
-        # indented). We match ^\s*sorry\s*$ to distinguish tactic from prose.
-        #
-        # Known baseline = 8, all documented + intentional:
-        #   - HashlifeCorrectness.lean : 2  (intractable P4 central / P5 main theorem)
-        #   - HashlifeMemo.lean        : 2  (scaffolding, Phase 3c roadmap)
-        #   - Pillars.lean             : 4  (scaffolding: otca/unitcell/gemini/cpu)
-        # CI FAILs if a 9th sorry-as-tactic is introduced.
-        SORRY_TOTAL=0
-        KNOWN_BASELINE=8
-        for f in $(find Conway -name '*.lean'); do
-          if [ -f "$f" ]; then
-            REAL=$(grep -cE "^\s*sorry\s*$" "$f" || true)
-            if [ "$REAL" -gt 0 ]; then
-              echo "  $f: $REAL real sorry (standalone tactic)"
-              SORRY_TOTAL=$((SORRY_TOTAL + REAL))
-            fi
-          fi
-        done
-        echo ""
-        echo "Real sorry (standalone tactic): $SORRY_TOTAL"
-        echo "Known baseline: $KNOWN_BASELINE"
-        if [ "$SORRY_TOTAL" -gt "$KNOWN_BASELINE" ]; then
-          echo ""
-          echo "FAIL: real sorry count ($SORRY_TOTAL) exceeds baseline ($KNOWN_BASELINE)"
-          echo "A sorry-as-tactic was introduced. If intentional (new intractable/"
-          echo "scaffolding target), raise KNOWN_BASELINE in this workflow WITH a"
-          echo "documented justification in the PR body."
-          exit 1
-        fi
-        echo "OK: sorry count at or below baseline ($SORRY_TOTAL <= $KNOWN_BASELINE)."
-
-  build-conway:
-    name: "Lake build (conway_lean)"
-    runs-on: ubuntu-latest
-    needs: check-sorry-conway
-    defaults:
-      run:
-        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install elan
-      run: |
-        curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain none
-        echo "$HOME/.elan/bin" >> $GITHUB_PATH
-
-    - name: Cache Lake build artifacts
-      uses: actions/cache@v4
-      with:
-        path: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/.lake
-        key: lake-conway-${{ runner.os }}-${{ hashFiles('MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean', 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain') }}
-        restore-keys: lake-conway-${{ runner.os }}-
-
-    - name: Lake build
-      run: |
-        lake exe cache get || true
-        lake -R build 2>&1 | tail -20
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+      display-name: conway_lean
+      sorry-baseline: "8"
+      sorry-filter-mode: standalone-tactic

--- a/.github/workflows/lean-gittins.yml
+++ b/.github/workflows/lean-gittins.yml
@@ -1,0 +1,43 @@
+name: Lean CI (gittins_lean)
+
+# CI for gittins_lean (Probas/Infer/gittins_lean).
+# Gittins index theorem statement. Research scaffolding.
+#
+# Sorry profile (verified 2026-06-10): 6 REAL tactic sorries, but split across
+# two forms the filter handles differently:
+#   - 3 standalone (`sorry` sole token on line): GittinsTheorem.lean L69/L81/L88
+#   - 3 inline-commented (`sorry -- TODO ...`):   GittinsTheorem.lean L27/L65,
+#                                                 Discount.lean L51
+#   - 4 prose mentions (header comments) excluded by standalone mode.
+# standalone-tactic mode (baseline=3) is a CONSERVATIVE regression floor: it
+# never false-positives on prose, and catches any NEW standalone sorry, but it
+# UNDERCOUNTS (3 vs 6 real) — it will not catch a new inline-commented sorry.
+# Tightening to the full 6 needs a 4th mode (strip `--` comments before counting);
+# left as a documented follow-up, not a blocker for this consolidation.
+# Consolidated per ai-01 DRY decision (option 2: matrix). See lean-build.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/**.lean'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/**.lean'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/Probas/Infer/gittins_lean/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/Probas/Infer/gittins_lean
+      display-name: gittins_lean
+      sorry-baseline: "3"
+      sorry-filter-mode: standalone-tactic

--- a/.github/workflows/lean-grothendieck.yml
+++ b/.github/workflows/lean-grothendieck.yml
@@ -2,12 +2,17 @@ name: Lean Grothendieck CI
 
 # CI for grothendieck_lean (SymbolicAI/Lean/grothendieck_lean).
 # Grothendieck tribute — Mathlib tour of Grothendieck's mathematical language.
-# Verifies lake build SUCCESS + tracks sorry count in Grothendieck modules.
 # Rule lean-merge-discipline: lake build SUCCESS local OBLIGATOIRE avant merge.
-# This CI is the canonical verification path since local builds may be blocked
-# (e.g. WDAC policy blocking native linker on some machines).
 #
-# Mirrors lean-calibration.yml (#2741) and lean-game-theory.yml.
+# Migrated to the reusable lean-build.yml per ai-01 DRY decision (option 2: matrix).
+# Behavior is identical to the former inline check-sorry + build jobs.
+#
+# Sorry profile (verified 2026-06-10, prose-header mode, baseline=0): every
+# Grothendieck module carries the boilerplate header comment "All `sorry`s
+# eliminated at creation". The raw count therefore equals the number of .lean
+# files (one header each) and is NOT a real sorry. prose-header mode filters
+# out the prose forms (`sorries`, `sorry's`) so the count reflects only
+# sorry-as-tactic. Known false-positive pattern documented in MEMORY.
 
 on:
   push:
@@ -26,77 +31,11 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lean-toolchain'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
-  check-sorry-grothendieck:
-    name: "Sorry check (grothendieck_lean)"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Count sorry in grothendieck_lean
-      run: |
-        echo "=== Sorry inventory for grothendieck_lean ==="
-        # Every Grothendieck module carries the boilerplate header comment
-        # "All `sorry`s eliminated at creation". The raw `grep -c sorry` count
-        # therefore equals the number of .lean files (one header each) and is
-        # NOT a real sorry. We filter out the prose forms (`sorries`, `sorry's`)
-        # so the count reflects only sorry-as-tactic. Known false-positive
-        # pattern documented in MEMORY (same as Conway.lean).
-        SORRY_TOTAL=0
-        KNOWN_BASELINE=0
-        for f in $(find Grothendieck -name '*.lean'); do
-          if [ -f "$f" ]; then
-            # raw count (informational) + filtered count (real tactic sorry)
-            RAW=$(grep -c "sorry" "$f" || true)
-            REAL=$(grep "sorry" "$f" | grep -viE "sorries|sorry.s" | wc -l || true)
-            echo "  $f: $RAW raw (header comments), $REAL real sorry"
-            SORRY_TOTAL=$((SORRY_TOTAL + REAL))
-          fi
-        done
-        echo ""
-        echo "Real sorry (tactic): $SORRY_TOTAL"
-        echo "Known baseline: $KNOWN_BASELINE"
-        if [ "$SORRY_TOTAL" -gt "$KNOWN_BASELINE" ]; then
-          echo ""
-          echo "FAIL: real sorry count ($SORRY_TOTAL) exceeds baseline ($KNOWN_BASELINE)"
-          echo "A sorry-as-tactic was introduced — Grothendieck proofs must stay sorry-free."
-          exit 1
-        fi
-        echo "OK: no sorry-as-tactic (header comments filtered out)."
-
-  build-grothendieck:
-    name: "Lake build (grothendieck_lean)"
-    runs-on: ubuntu-latest
-    needs: check-sorry-grothendieck
-    defaults:
-      run:
-        working-directory: MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install elan
-      run: |
-        curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain none
-        echo "$HOME/.elan/bin" >> $GITHUB_PATH
-
-    - name: Cache Lake build artifacts
-      uses: actions/cache@v4
-      with:
-        path: MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/.lake
-        key: lake-gro-${{ runner.os }}-${{ hashFiles('MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lakefile.lean', 'MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lean-toolchain') }}
-        restore-keys: lake-gro-${{ runner.os }}-
-
-    - name: Lake build
-      run: |
-        lake exe cache get || true
-        lake -R build 2>&1 | tail -20
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
+      display-name: grothendieck_lean
+      sorry-baseline: "0"
+      sorry-filter-mode: prose-header

--- a/.github/workflows/lean-mathlib-examples.yml
+++ b/.github/workflows/lean-mathlib-examples.yml
@@ -1,0 +1,31 @@
+name: Lean CI (mathlib_examples)
+
+# CI for mathlib_examples (SymbolicAI/Lean/mathlib_examples).
+# Mathlib usage examples. 0 sorry (raw=0, verified). Toolchain v4.27.0.
+# Consolidated per ai-01 DRY decision (option 2: matrix). See lean-build.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples
+      display-name: mathlib_examples
+      sorry-baseline: "0"
+      sorry-filter-mode: standalone-tactic

--- a/.github/workflows/lean-sensitivity.yml
+++ b/.github/workflows/lean-sensitivity.yml
@@ -1,0 +1,31 @@
+name: Lean CI (sensitivity_lean)
+
+# CI for sensitivity_lean (SymbolicAI/Lean/sensitivity_lean).
+# Sensitivity / one-step lookahead demo. 0 sorry (raw=0, verified).
+# Consolidated per ai-01 DRY decision (option 2: matrix). See lean-build.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean
+      display-name: sensitivity_lean
+      sorry-baseline: "0"
+      sorry-filter-mode: standalone-tactic

--- a/.github/workflows/lean-social-choice-peters.yml
+++ b/.github/workflows/lean-social-choice-peters.yml
@@ -1,0 +1,31 @@
+name: Lean CI (social_choice_lean_peters)
+
+# CI for social_choice_lean_peters (GameTheory/social_choice_lean_peters).
+# Reference port (Peters). 0 sorry (raw=0, verified). Toolchain v4.27.0-rc1.
+# Consolidated per ai-01 DRY decision (option 2: matrix). See lean-build.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/**.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/lakefile.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/lakefile.toml'
+      - 'MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/**.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/lakefile.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/lakefile.toml'
+      - 'MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters
+      display-name: social_choice_lean_peters
+      sorry-baseline: "0"
+      sorry-filter-mode: standalone-tactic


### PR DESCRIPTION
## Summary

Closes the structural **"CI Lean lacunaire"** blocker in 1 consolidated PR, per **ai-01 DRY decision (option 2: matrix)** on #2743.

Extracts a reusable [lean-build.yml](.github/workflows/lean-build.yml) (Lake build + sorry-baseline, 3 filter modes) and either migrates existing per-file workflows to thin callers or adds CI for previously-uncovered projects.

## What lands

**Reusable workflow** — `.github/workflows/lean-build.yml`
- `inputs`: `project-path`, `display-name`, `sorry-baseline`, `sorry-filter-mode`
- 3 sorry-filter modes (`raw` / `prose-header` / `standalone-tactic`) chosen per project's sorry profile — documented in-file
- elan install + `actions/cache@v4` (keyed on lakefile+toolchain hash) + `lake exe cache get` + `lake -R build`

**Migrated to thin callers** (behavior-identical; −115 lines on the 2 originals):

| workflow | mode | baseline | note |
|---|---|---|---|
| lean-calibration.yml | raw | 4 | Nash P4 targets + prose |
| lean-grothendieck.yml | prose-header | 0 | boilerplate header filtered |
| lean-conway.yml | standalone-tactic | 8 | **supersedes #2747** (same mode/baseline, now via shared reusable) |

**New CI** for previously-uncovered (lacunaire) projects:

| workflow | mode | baseline | toolchain |
|---|---|---|---|
| lean-sensitivity.yml | standalone | 0 | v4.30.0-rc2 |
| lean-mathlib-examples.yml | standalone | 0 | v4.27.0 |
| lean-gittins.yml | standalone | 3 | v4.30.0-rc2 |
| lean-conway-cgt.yml | standalone | 0 | v4.31.0-rc1 |
| lean-social-choice-peters.yml | standalone | 0 | v4.27.0-rc1 |

## Verification (G.1)

All baselines verified locally against current source on a **fresh checkout of `origin/main`** — a sorry count is meaningless without a buildable project (the lesson from #2748). Filter mode chosen per project to be robust to comment editing (see in-file rationale). All 11 YAML files pass `yaml.safe_load`.

## ⚠️ Deliberately NOT included — needs ai-01 direction

1. **`lean_game_defs`** (one of the 6 gaps in the dispatch list): **not buildable** — no lakefile, 14 compile errors (see #2748, opened this session). Adding a `lake build` caller here would **red-X `main`**. Excluded pending ai-01 fix-direction.

2. **`lean-game-theory.yml`** (one of the 4 baseline-pattern projects): **deferred**. Two issues:
   - It bundles **2 projects** (stable_marriage + cooperative) in one file with explicit per-file lists — doesn't map cleanly to the single-project reusable.
   - **stable_marriage baseline (5) is STALE**: actual raw count is **8** (Lattice.lean grew from 5→8 via the intractable Case A2 / chain-differ decomposition work). Fixing that regression-floor is a separate task, out of scope for a pure DRY consolidation.

3. **`lean-social-choice.yml`** (#617): left as-is per dispatch (fail-on-sorry pattern).

## Decision points for ai-01

- **#2747 vs this PR**: lean-conway.yml here supersedes #2747 (same baseline/mode, now thin). Recommend **close #2747**, merge this. (If you prefer to merge #2747 first, I'll rebase this to drop the conway caller.)
- **lean_game_defs #2748**: greenlight a Mathlib-dependent lake project + `payoff` field fix, or mark pedagogical-only (no CI)?
- **stable_marriage stale baseline (5→8)**: raise the baseline to 8 with justification (the intractable decomposition), or investigate whether 3 unintended sorries slipped in?

See #2748. Epic "CI Lean lacunaire" + ai-01 DRY decision on #2743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)