### PR TITLE
fix(symboliclearning): deep series review — structure, de-overlap SL-2/SL-3, dedup resumes

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -41,7 +41,7 @@ A l'issue de cette serie, vous serez capable de :
 |-------------|--------|
 | Notebooks | 7 |
 | Kernel | Python 3 |
-| Duree estimee | ~370 min |
+| Duree estimee | ~360 min |
 | prerequis | Python 3.10+ (standard library + sklearn pour SL-3/SL-4, rdflib pour SL-6) |
 
 ## Parcours d'apprentissage
@@ -50,9 +50,9 @@ A l'issue de cette serie, vous serez capable de :
 
 Le parcours commence par l'apprentissage inductif pur : un agent doit decouvrir une regle cachee a partir d'exemples. SL-1 presente les algorithmes fondamentaux — Current-Best-Hypothesis (ajuste une seule hypothese incrementalement) et Candidate Elimination (maintient l'ensemble complet des hypotheses consistantes, le "Version Space"). Vous experimentez leurs limites face au bruit et aux concepts disjonctifs, ce qui motive naturellement les approches plus riches introduites ensuite.
 
-### Phase 2 : Apprentissage base sur la connaissance (SL-2 a SL-3, ~105 min)
+### Phase 2 : Apprentissage base sur la connaissance (SL-2 a SL-3, ~95 min)
 
-La deuxieme phase introduit l'idee centrale que **la connaissance accelere l'apprentissage**. EBL (SL-2) montre comment compiler un exemple prouve en une regle operationnelle generale, en quatre etapes : expliquer, variabiliser, extraire, simplifier. RBL (SL-2 + SL-3) explore une autre facette : identifier les attributs qui determinant vraiment la cible via le formalisme des determinations et le treillis des sous-ensembles d'attributs. La comparaison avec sklearn (information mutuelle) montre quand la connaissance du domaine bat la statistique brute.
+La deuxieme phase introduit l'idee centrale que **la connaissance accelere l'apprentissage**. EBL (SL-2) montre comment compiler un exemple prouve en une regle operationnelle generale, en quatre etapes : expliquer, variabiliser, extraire, simplifier. RBL (introduit en SL-2, approfondi en SL-3) explore une autre facette : identifier les attributs qui determinant vraiment la cible via le formalisme des determinations et le treillis des sous-ensembles d'attributs. La comparaison avec sklearn (information mutuelle) montre quand la connaissance du domaine bat la statistique brute.
 
 ### Phase 3 : Programmation logique inductive (SL-4, ~55 min)
 
@@ -81,7 +81,7 @@ Pour les professionnels du web semantique et des donnees structurees : EBL, RBL,
 | # | Notebook | Contenu | Duree |
 |---|----------|---------|-------|
 | 1 | [SL-1 - Apprentissage Logique](SL-1-LogicalLearning.ipynb) | CBH, Version Space, Candidate Elimination | 50 min |
-| 2 | [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb) | EBL, RBL, determinations | 55 min |
+| 2 | [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb) | EBL, introduction au RBL (determinations) | 45 min |
 | 3 | [SL-3 - Apprentissage Base sur la Pertinence](SL-3-RelevanceLearning.ipynb) | Treillis des determinations, MINIMAL-CONSISTENT-DET, RBL vs sklearn | 50 min |
 | 4 | [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb) | FOIL, resolution inverse, clauses Horn, knowledge graphs | 55 min |
 | 5 | [SL-5 - Integration Neuro-Symbolique](SL-5-NeuroSymbolic.ipynb) | T-norms, predicats neuronaux, LTN, DeepProbLog | 55 min |
@@ -111,9 +111,7 @@ Pour les professionnels du web semantique et des donnees structurees : EBL, RBL,
 | EBL - Arithmetique | Simplification d'expressions, arbre de preuve |
 | EBL - Implementation | Classe ArithmeticEBL complete |
 | EBL - Efficacite | Operationalite vs generalite, proliferation de regles |
-| RBL - Determinations | Verification fonctionnelle, reduction d'espace |
-| RBL - MINIMAL-CONSISTENT-DET | Algorithme AIMA 19.4 |
-| RBL - Impact quantitatif | Reduction exponentielle de l'espace des hypotheses |
+| RBL - Introduction | Determinations, verification fonctionnelle, reduction d'espace (approfondi dans SL-3) |
 
 ### SL-3-RelevanceLearning.ipynb
 
@@ -121,7 +119,7 @@ Pour les professionnels du web semantique et des donnees structurees : EBL, RBL,
 |---------|---------|
 | Determinations | Formalisme, monotonie, minimalite, `check_determination()` |
 | Treillis des determinations | `build_determination_lattice()`, visualisation ASCII, up-set |
-| MINIMAL-CONSISTENT-DET | Implementation detaillee, donnees moleculaires |
+| MINIMAL-CONSISTENT-DET | Implementation detaillee, donnees moleculaires, cas d'echec disjonctif (restaurant) |
 | Selection guidee | RBL vs sklearn (information mutuelle), comparaison |
 | Analyse PAC | Reduction exponentielle, bornes d'echantillonnage |
 | Web Semantique | Parallel RBL <-> OWL (FunctionalProperty, hasKey) |

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -1541,6 +1541,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "affee29e",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 9. Exercices\n",
+    "\n",
+    "Les **exemples guides** ci-dessous sont resolus et commentes ; les **exercices** sont a completer par vos soins. Chaque exercice reutilise les implementations du notebook (`current_best_hypothesis`, `candidate_elimination`, `count_errors`).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "23cff9a5",
    "metadata": {
     "papermill": {
@@ -1769,6 +1781,64 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a483cb1cf590",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010918,
+     "end_time": "2026-06-06T20:57:01.099984",
+     "exception": false,
+     "start_time": "2026-06-06T20:57:01.089066",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Apprentissage de regles avec couverture\n",
+    "\n",
+    "Implementer un algorithme de couverture sequentiel pour apprendre des regles logiques.\n",
+    "\n",
+    "**Indice** : Pour chaque regle, specialisez jusqu a couvrir uniquement des positifs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a66db8dd23f7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-06T20:57:01.125087Z",
+     "iopub.status.busy": "2026-06-06T20:57:01.124644Z",
+     "iopub.status.idle": "2026-06-06T20:57:01.129807Z",
+     "shell.execute_reply": "2026-06-06T20:57:01.128775Z"
+    },
+    "papermill": {
+     "duration": 0.019592,
+     "end_time": "2026-06-06T20:57:01.131213",
+     "exception": false,
+     "start_time": "2026-06-06T20:57:01.111621",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : Apprentissage de regles avec couverture\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice : Apprentissage de regles avec couverture\n",
+    "# TODO etudiant : Implementer un algorithme de couverture sequentiel pour apprendre des regles logiques\n",
+    "# Indice : Pour chaque regle, specialisez jusqu a couvrir uniquement des positifs\n",
+    "result = None  # TODO etudiant : remplacer par votre implementation\n",
+    "print(\"Exercice a completer : Apprentissage de regles avec couverture\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ec85b3dd",
    "metadata": {
     "papermill": {
@@ -1797,7 +1867,7 @@
    "id": "b7e4d1a9",
    "metadata": {},
    "source": [
-    "### Exercice 3 : Reflexion\n",
+    "### Exercice 4 : Reflexion\n",
     "\n",
     "A votre tour. Repondez aux questions suivantes en vous appuyant sur les algorithmes implementes plus haut (CBH, Candidate Elimination). Ne consultez l'exemple guide corrige ci-dessus qu'**apres** avoir formule vos propres reponses.\n",
     "\n",
@@ -1846,14 +1916,7 @@
     "| Ordre-dependance | Oui | Non |\n",
     "| Backtracking | Possible | Jamais |\n",
     "| Bruit | Robuste (peut revenir) | Fragile (VS vide) |\n",
-    "| Complexite memoire | O(1) | O(|G| + |S|) |\n",
-    "\n",
-    "### Prochaines etapes\n",
-    "\n",
-    "Dans le notebook suivant **SL-2 - Apprentissage et Connaissance**, nous decouvrirons :\n",
-    "- L'apprentissage base sur les explications (EBL)\n",
-    "- Comment transformer une experience unique en regle generale\n",
-    "- L'utilisation de la deduction pour l'apprentissage"
+    "| Complexite memoire | O(1) | O(|G| + |S|) |\n"
    ]
   },
   {
@@ -1870,7 +1933,7 @@
     "tags": []
    },
    "source": [
-    "## Resume et perspectives\n",
+    "### Perspectives\n",
     "\n",
     "Ce notebook a explore les methodes d'apprentissage logique symbolique dans le cadre de la contrainte d'entrainement : trouver une hypothese H telle que H et les descriptions entrainent logiquement les classifications. L'algorithme CBH (Current-Best-Hypothesis) maintient une unique hypothese ajustee incrementalement par generalisation et specialisation, avec un risque de backtracking lorsque aucune specialisation consistante n'existe. L'algorithme Candidate Elimination resout ce probleme en representant l'ensemble complet des hypotheses consistantes via les frontieres G-set et S-set, garantissant qu'aucune hypothese valide n'est oubliee. Cependant, les deux approches partagent des limites fondamentales : la fragilite face au bruit (un seul exemple mal etiquete vide le Version Space) et l'incapacite a representer des concepts disjonctifs avec des conjonctions pures.\n",
     "\n",
@@ -1905,64 +1968,6 @@
     "---\n",
     "\n",
     "**Notebook suivant** : [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a483cb1cf590",
-   "metadata": {
-    "papermill": {
-     "duration": 0.010918,
-     "end_time": "2026-06-06T20:57:01.099984",
-     "exception": false,
-     "start_time": "2026-06-06T20:57:01.089066",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice 4 : Apprentissage de regles avec couverture\n",
-    "\n",
-    "Implementer un algorithme de couverture sequentiel pour apprendre des regles logiques.\n",
-    "\n",
-    "**Indice** : Pour chaque regle, specialisez jusqu a couvrir uniquement des positifs.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "a66db8dd23f7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:01.125087Z",
-     "iopub.status.busy": "2026-06-06T20:57:01.124644Z",
-     "iopub.status.idle": "2026-06-06T20:57:01.129807Z",
-     "shell.execute_reply": "2026-06-06T20:57:01.128775Z"
-    },
-    "papermill": {
-     "duration": 0.019592,
-     "end_time": "2026-06-06T20:57:01.131213",
-     "exception": false,
-     "start_time": "2026-06-06T20:57:01.111621",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice a completer : Apprentissage de regles avec couverture\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Exercice : Apprentissage de regles avec couverture\n",
-    "# TODO etudiant : Implementer un algorithme de couverture sequentiel pour apprendre des regles logiques\n",
-    "# Indice : Pour chaque regle, specialisez jusqu a couvrir uniquement des positifs\n",
-    "result = None  # TODO etudiant : remplacer par votre implementation\n",
-    "print(\"Exercice a completer : Apprentissage de regles avec couverture\")\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "0c89ba96",
    "metadata": {
     "papermill": {
-     "duration": 0.010964,
-     "end_time": "2026-06-06T20:57:14.991751",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:18.584272",
      "exception": false,
-     "start_time": "2026-06-06T20:57:14.980787",
+     "start_time": "2026-06-10T08:20:18.581272",
      "status": "completed"
     },
     "tags": []
@@ -23,7 +23,7 @@
     "A la fin de ce notebook, vous saurez :\n",
     "1. Comprendre la **contrainte d'entrainement** qui relie hypothese, descriptions et classifications\n",
     "2. Implementer l'apprentissage base sur les explications (**EBL**) : extraire une regle generale d'un seul exemple\n",
-    "3. Implementer la verification de **determinations** et l'algorithme **MINIMAL-CONSISTENT-DET**\n",
+    "3. Comprendre les **determinations** et verifier la pertinence d'attributs (introduction au RBL, approfondi dans SL-3)\n",
     "4. Comparer les trois paradigmes : EBL (deductif), RBL (pertinence), KBIL (inductif base sur la connaissance)\n",
     "\n",
     "### Prerequis\n",
@@ -31,7 +31,7 @@
     "- Python 3.10+\n",
     "- Notions de logique du premier ordre (predicats, regles d'inference)\n",
     "\n",
-    "### Duree estimee : 55 minutes\n",
+    "### Duree estimee : 45 minutes\n",
     "\n",
     "### References\n",
     "- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, 3e ed., Chapitres 19.3-19.4\n",
@@ -45,16 +45,16 @@
    "id": "a0468061",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.008607Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.007841Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.018823Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.017473Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.592274Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.591272Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.612346Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.611778Z"
     },
     "papermill": {
-     "duration": 0.023338,
-     "end_time": "2026-06-06T20:57:15.021254",
+     "duration": 0.024593,
+     "end_time": "2026-06-10T08:20:18.612865",
      "exception": false,
-     "start_time": "2026-06-06T20:57:14.997916",
+     "start_time": "2026-06-10T08:20:18.588272",
      "status": "completed"
     },
     "tags": []
@@ -95,10 +95,10 @@
    "id": "6941f342",
    "metadata": {
     "papermill": {
-     "duration": 0.009898,
-     "end_time": "2026-06-06T20:57:15.047652",
+     "duration": 0.003104,
+     "end_time": "2026-06-10T08:20:18.619065",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.037754",
+     "start_time": "2026-06-10T08:20:18.615961",
      "status": "completed"
     },
     "tags": []
@@ -145,16 +145,16 @@
    "id": "5569731d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.068656Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.068157Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.075788Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.074590Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.625164Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.625164Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.643673Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.642669Z"
     },
     "papermill": {
-     "duration": 0.021337,
-     "end_time": "2026-06-06T20:57:15.078263",
+     "duration": 0.022029,
+     "end_time": "2026-06-10T08:20:18.643673",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.056926",
+     "start_time": "2026-06-10T08:20:18.621644",
      "status": "completed"
     },
     "tags": []
@@ -216,10 +216,10 @@
    "id": "a12264d8",
    "metadata": {
     "papermill": {
-     "duration": 0.009339,
-     "end_time": "2026-06-06T20:57:15.097930",
+     "duration": 0.00312,
+     "end_time": "2026-06-10T08:20:18.649792",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.088591",
+     "start_time": "2026-06-10T08:20:18.646672",
      "status": "completed"
     },
     "tags": []
@@ -242,10 +242,10 @@
    "id": "f666e94d",
    "metadata": {
     "papermill": {
-     "duration": 0.009071,
-     "end_time": "2026-06-06T20:57:15.115620",
+     "duration": 0.002778,
+     "end_time": "2026-06-10T08:20:18.655570",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.106549",
+     "start_time": "2026-06-10T08:20:18.652792",
      "status": "completed"
     },
     "tags": []
@@ -283,16 +283,16 @@
    "id": "945eff3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.130792Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.130434Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.138305Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.137176Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.662616Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.662081Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.674315Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.673812Z"
     },
     "papermill": {
-     "duration": 0.017422,
-     "end_time": "2026-06-06T20:57:15.140103",
+     "duration": 0.017001,
+     "end_time": "2026-06-10T08:20:18.675319",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.122681",
+     "start_time": "2026-06-10T08:20:18.658318",
      "status": "completed"
     },
     "tags": []
@@ -368,10 +368,10 @@
    "id": "4bb3bfc1",
    "metadata": {
     "papermill": {
-     "duration": 0.007536,
-     "end_time": "2026-06-06T20:57:15.157843",
+     "duration": 0.001999,
+     "end_time": "2026-06-10T08:20:18.680327",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.150307",
+     "start_time": "2026-06-10T08:20:18.678328",
      "status": "completed"
     },
     "tags": []
@@ -394,10 +394,10 @@
    "id": "a03df116",
    "metadata": {
     "papermill": {
-     "duration": 0.005764,
-     "end_time": "2026-06-06T20:57:15.169739",
+     "duration": 0.003001,
+     "end_time": "2026-06-10T08:20:18.686320",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.163975",
+     "start_time": "2026-06-10T08:20:18.683319",
      "status": "completed"
     },
     "tags": []
@@ -425,16 +425,16 @@
    "id": "58666a2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.188049Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.187517Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.198284Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.197197Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.692324Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.692324Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.705418Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.704837Z"
     },
     "papermill": {
-     "duration": 0.023201,
-     "end_time": "2026-06-06T20:57:15.200613",
+     "duration": 0.016096,
+     "end_time": "2026-06-10T08:20:18.705418",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.177412",
+     "start_time": "2026-06-10T08:20:18.689322",
      "status": "completed"
     },
     "tags": []
@@ -517,10 +517,10 @@
    "id": "0bbc55d8",
    "metadata": {
     "papermill": {
-     "duration": 0.008239,
-     "end_time": "2026-06-06T20:57:15.217752",
+     "duration": 0.00302,
+     "end_time": "2026-06-10T08:20:18.712440",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.209513",
+     "start_time": "2026-06-10T08:20:18.709420",
      "status": "completed"
     },
     "tags": []
@@ -535,16 +535,16 @@
    "id": "2804a17a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.238340Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.237983Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.245962Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.245095Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.719221Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.719221Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.737463Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.736455Z"
     },
     "papermill": {
-     "duration": 0.020176,
-     "end_time": "2026-06-06T20:57:15.247497",
+     "duration": 0.021909,
+     "end_time": "2026-06-10T08:20:18.737463",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.227321",
+     "start_time": "2026-06-10T08:20:18.715554",
      "status": "completed"
     },
     "tags": []
@@ -643,10 +643,10 @@
    "id": "e8a85fbd",
    "metadata": {
     "papermill": {
-     "duration": 0.00827,
-     "end_time": "2026-06-06T20:57:15.264258",
+     "duration": 0.003001,
+     "end_time": "2026-06-10T08:20:18.743465",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.255988",
+     "start_time": "2026-06-10T08:20:18.740464",
      "status": "completed"
     },
     "tags": []
@@ -670,10 +670,10 @@
    "id": "95c1f106",
    "metadata": {
     "papermill": {
-     "duration": 0.008069,
-     "end_time": "2026-06-06T20:57:15.278281",
+     "duration": 0.002999,
+     "end_time": "2026-06-10T08:20:18.749472",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.270212",
+     "start_time": "2026-06-10T08:20:18.746473",
      "status": "completed"
     },
     "tags": []
@@ -699,16 +699,16 @@
    "id": "1b6b6247",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.296925Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.296415Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.305089Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.304154Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.756969Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.755970Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.768223Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.767471Z"
     },
     "papermill": {
-     "duration": 0.017778,
-     "end_time": "2026-06-06T20:57:15.306358",
+     "duration": 0.015748,
+     "end_time": "2026-06-10T08:20:18.768223",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.288580",
+     "start_time": "2026-06-10T08:20:18.752475",
      "status": "completed"
     },
     "tags": []
@@ -815,10 +815,10 @@
    "id": "3a8e6838",
    "metadata": {
     "papermill": {
-     "duration": 0.00929,
-     "end_time": "2026-06-06T20:57:15.322645",
+     "duration": 0.003001,
+     "end_time": "2026-06-10T08:20:18.774226",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.313355",
+     "start_time": "2026-06-10T08:20:18.771225",
      "status": "completed"
     },
     "tags": []
@@ -842,10 +842,10 @@
    "id": "d5e7f465",
    "metadata": {
     "papermill": {
-     "duration": 0.009206,
-     "end_time": "2026-06-06T20:57:15.341411",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:18.780226",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.332205",
+     "start_time": "2026-06-10T08:20:18.777226",
      "status": "completed"
     },
     "tags": []
@@ -877,16 +877,16 @@
    "id": "750b1f6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.360936Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.360576Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.377624Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.376505Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.787228Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.787228Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.798730Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.798730Z"
     },
     "papermill": {
-     "duration": 0.027772,
-     "end_time": "2026-06-06T20:57:15.379302",
+     "duration": 0.016507,
+     "end_time": "2026-06-10T08:20:18.799733",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.351530",
+     "start_time": "2026-06-10T08:20:18.783226",
      "status": "completed"
     },
     "tags": []
@@ -1105,10 +1105,10 @@
    "id": "c52b429c",
    "metadata": {
     "papermill": {
-     "duration": 0.008819,
-     "end_time": "2026-06-06T20:57:15.396868",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:18.805733",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.388049",
+     "start_time": "2026-06-10T08:20:18.802733",
      "status": "completed"
     },
     "tags": []
@@ -1134,10 +1134,10 @@
    "id": "149b52a3",
    "metadata": {
     "papermill": {
-     "duration": 0.008607,
-     "end_time": "2026-06-06T20:57:15.414979",
+     "duration": 0.003005,
+     "end_time": "2026-06-10T08:20:18.811741",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.406372",
+     "start_time": "2026-06-10T08:20:18.808736",
      "status": "completed"
     },
     "tags": []
@@ -1168,16 +1168,16 @@
    "id": "1bf94123",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.432932Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.432574Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.442770Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.441620Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.818747Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.818747Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.831256Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.830250Z"
     },
     "papermill": {
-     "duration": 0.021444,
-     "end_time": "2026-06-06T20:57:15.444438",
+     "duration": 0.016515,
+     "end_time": "2026-06-10T08:20:18.831256",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.422994",
+     "start_time": "2026-06-10T08:20:18.814741",
      "status": "completed"
     },
     "tags": []
@@ -1272,10 +1272,10 @@
    "id": "c4c050aa",
    "metadata": {
     "papermill": {
-     "duration": 0.009174,
-     "end_time": "2026-06-06T20:57:15.462806",
+     "duration": 0.003001,
+     "end_time": "2026-06-10T08:20:18.837258",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.453632",
+     "start_time": "2026-06-10T08:20:18.834257",
      "status": "completed"
     },
     "tags": []
@@ -1303,10 +1303,10 @@
    "id": "485b6968",
    "metadata": {
     "papermill": {
-     "duration": 0.010253,
-     "end_time": "2026-06-06T20:57:15.484525",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:18.843258",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.474272",
+     "start_time": "2026-06-10T08:20:18.840258",
      "status": "completed"
     },
     "tags": []
@@ -1314,7 +1314,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. RBL --- Determinations et pertinence\n",
+    "## 7. RBL --- Introduction aux determinations\n",
     "\n",
     "L'apprentissage base sur la pertinence (Relevance-Based Learning) utilise la connaissance prealable pour identifier **quels attributs sont pertinents** pour la tache d'apprentissage.\n",
     "\n",
@@ -1342,16 +1342,16 @@
    "id": "9649140c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.505440Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.504600Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.516723Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.515620Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.850351Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.850351Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.861854Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.861351Z"
     },
     "papermill": {
-     "duration": 0.024948,
-     "end_time": "2026-06-06T20:57:15.518632",
+     "duration": 0.015597,
+     "end_time": "2026-06-10T08:20:18.861854",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.493684",
+     "start_time": "2026-06-10T08:20:18.846257",
      "status": "completed"
     },
     "tags": []
@@ -1455,10 +1455,10 @@
    "id": "b02799f6",
    "metadata": {
     "papermill": {
-     "duration": 0.006627,
-     "end_time": "2026-06-06T20:57:15.534402",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:18.868429",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.527775",
+     "start_time": "2026-06-10T08:20:18.865429",
      "status": "completed"
     },
     "tags": []
@@ -1480,439 +1480,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5227d29",
+   "id": "7a891be0",
    "metadata": {
     "papermill": {
-     "duration": 0.008873,
-     "end_time": "2026-06-06T20:57:15.551692",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:18.874429",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.542819",
+     "start_time": "2026-06-10T08:20:18.871429",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "### Pour aller plus loin : SL-3\n",
     "\n",
-    "## 8. RBL --- Algorithme MINIMAL-CONSISTENT-DET\n",
+    "Nous nous arretons volontairement ici. La formalisation complete du RBL --- proprietes des determinations (monotonie, minimalite), **treillis des determinations**, algorithme **MINIMAL-CONSISTENT-DET** et sa complexite, cas d'echec sur les concepts disjonctifs (le restaurant de SL-1), et comparaison avec la selection statistique d'attributs (information mutuelle, sklearn) --- est l'objet du notebook dedie [SL-3 - Apprentissage Base sur la Pertinence](SL-3-RelevanceLearning.ipynb).\n",
     "\n",
-    "L'algorithme MINIMAL-CONSISTENT-DET (AIMA Section 19.4) trouve le **plus petit ensemble d'attributs** qui determine la cible.\n",
-    "\n",
-    "### Principe\n",
-    "\n",
-    "Pour chaque taille k de 1 a n :\n",
-    "  - Enumerer toutes les combinaisons de k attributs\n",
-    "  - Verifier si la combinaison determine la cible\n",
-    "  - Retourner la premiere (plus petite) trouvée\n",
-    "\n",
-    "### Complexite\n",
-    "\n",
-    "L'algorithme explore au pire $2^n$ sous-ensembles, mais s'arrete des qu'une determination minimale est trouvee. En pratique, si la determination est petite (d attributs), il s'arrete apres $O(n^d)$ combinaisons."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "9048603c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.569855Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.569337Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.578577Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.577442Z"
-    },
-    "papermill": {
-     "duration": 0.020749,
-     "end_time": "2026-06-06T20:57:15.581250",
-     "exception": false,
-     "start_time": "2026-06-06T20:57:15.560501",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MINIMAL-CONSISTENT-DET sur nationalite -> langue\n",
-      "=======================================================\n",
-      "\n",
-      "  Taille 1 : test de 3 combinaisons...\n",
-      "    TROUVE : ('nationality',) (test #1)\n",
-      "\n",
-      "Determination minimale : ('nationality',)\n",
-      "Nombre d'attributs : 1 / 3\n",
-      "Reduction de l'espace : O(2^3) -> O(2^1)\n",
-      "Facteur de reduction : 2^2 = 4\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Implementation de MINIMAL-CONSISTENT-DET\n",
-    "\n",
-    "def minimal_consistent_det(\n",
-    "    data: list[dict],\n",
-    "    all_attrs: list[str],\n",
-    "    target_attr: str,\n",
-    "    verbose: bool = True\n",
-    ") -> Optional[tuple[str, ...]]:\n",
-    "    \"\"\"Trouve le plus petit sous-ensemble d'attributs qui determine target.\n",
-    "    \n",
-    "    Parcourt les sous-ensembles par taille croissante.\n",
-    "    Retourne le premier (plus petit) sous-ensemble valide, ou None.\n",
-    "    \"\"\"\n",
-    "    total_tested = 0\n",
-    "    \n",
-    "    for size in range(1, len(all_attrs) + 1):\n",
-    "        if verbose:\n",
-    "            comb_count = len(list(itertools.combinations(all_attrs, size)))\n",
-    "            print(f\"  Taille {size} : test de {comb_count} combinaisons...\")\n",
-    "        \n",
-    "        for subset in itertools.combinations(all_attrs, size):\n",
-    "            total_tested += 1\n",
-    "            subset_list = list(subset)\n",
-    "            if check_determination(data, subset_list, target_attr):\n",
-    "                if verbose:\n",
-    "                    print(f\"    TROUVE : {subset} (test #{total_tested})\")\n",
-    "                return subset\n",
-    "    \n",
-    "    if verbose:\n",
-    "        print(f\"  Aucune determination trouvee apres {total_tested} tests\")\n",
-    "    return None\n",
-    "\n",
-    "\n",
-    "# Application sur les donnees de nationalite\n",
-    "print(\"MINIMAL-CONSISTENT-DET sur nationalite -> langue\")\n",
-    "print(\"=\" * 55)\n",
-    "print()\n",
-    "\n",
-    "det_result = minimal_consistent_det(\n",
-    "    nationality_data,\n",
-    "    ALL_ATTRS,\n",
-    "    \"language\"\n",
-    ")\n",
-    "\n",
-    "print()\n",
-    "if det_result:\n",
-    "    print(f\"Determination minimale : {det_result}\")\n",
-    "    print(f\"Nombre d'attributs : {len(det_result)} / {len(ALL_ATTRS)}\")\n",
-    "    \n",
-    "    # Calcul de la reduction de l'espace des hypotheses\n",
-    "    n = len(ALL_ATTRS)\n",
-    "    d = len(det_result)\n",
-    "    print(f\"Reduction de l'espace : O(2^{n}) -> O(2^{d})\")\n",
-    "    print(f\"Facteur de reduction : 2^{n-d} = {2**(n-d)}\")\n",
-    "else:\n",
-    "    print(\"Aucune determination trouvee.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "02f1cd30",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00974,
-     "end_time": "2026-06-06T20:57:15.599630",
-     "exception": false,
-     "start_time": "2026-06-06T20:57:15.589890",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "Appliquons maintenant cet algorithme sur les donnees du restaurant deja rencontrees dans SL-1. Ce domaine est plus complexe car le concept `WillWait` est disjonctif, ce qui rend la recherche de determination particulierement interessante."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "55dc2b78",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.623336Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.622612Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.635006Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.633805Z"
-    },
-    "papermill": {
-     "duration": 0.026022,
-     "end_time": "2026-06-06T20:57:15.636404",
-     "exception": false,
-     "start_time": "2026-06-06T20:57:15.610382",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MINIMAL-CONSISTENT-DET sur le restaurant\n",
-      "=======================================================\n",
-      "\n",
-      "Attributs disponibles : 10\n",
-      "Exemples : 12\n",
-      "\n",
-      "Recherche sur les 5 premiers attributs :\n",
-      "  Taille 1 : test de 5 combinaisons...\n",
-      "  Taille 2 : test de 10 combinaisons...\n",
-      "  Taille 3 : test de 10 combinaisons...\n",
-      "  Taille 4 : test de 5 combinaisons...\n",
-      "  Taille 5 : test de 1 combinaisons...\n",
-      "  Aucune determination trouvee apres 31 tests\n",
-      "\n",
-      "Pas de determination sur les 5 premiers attributs seuls.\n",
-      "(Le concept WillWait est disjonctif, pas de determination simple)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Application sur des donnees du restaurant (SL-1)\n",
-    "# Quelle est la determination minimale pour WillWait ?\n",
-    "\n",
-    "# Reutilisation des donnees du restaurant\n",
-    "RESTAURANT_ATTRS = [\n",
-    "    \"Alternate\", \"Bar\", \"Fri/Sat\", \"Hungry\",\n",
-    "    \"Patrons\", \"Price\", \"Raining\", \"Reservation\",\n",
-    "    \"Type\", \"WaitEstimate\"\n",
-    "]\n",
-    "\n",
-    "# Donnees du restaurant (12 exemples, AIMA Table 19.1)\n",
-    "restaurant_data = [\n",
-    "    {\"Alternate\": \"Yes\", \"Bar\": \"No\",  \"Fri/Sat\": \"No\",  \"Hungry\": \"Yes\", \"Patrons\": \"Some\", \"Price\": \"$$$\", \"Raining\": \"No\",  \"Reservation\": \"Yes\", \"Type\": \"French\",  \"WaitEstimate\": \"0-10\",  \"WillWait\": \"Yes\"},\n",
-    "    {\"Alternate\": \"Yes\", \"Bar\": \"No\",  \"Fri/Sat\": \"No\",  \"Hungry\": \"Yes\", \"Patrons\": \"Full\", \"Price\": \"$\",   \"Raining\": \"No\",  \"Reservation\": \"No\",  \"Type\": \"Thai\",    \"WaitEstimate\": \"30-60\", \"WillWait\": \"Yes\"},\n",
-    "    {\"Alternate\": \"No\",  \"Bar\": \"Yes\", \"Fri/Sat\": \"No\",  \"Hungry\": \"No\",  \"Patrons\": \"Some\", \"Price\": \"$\",   \"Raining\": \"No\",  \"Reservation\": \"No\",  \"Type\": \"Burger\",  \"WaitEstimate\": \"0-10\",  \"WillWait\": \"No\"},\n",
-    "    {\"Alternate\": \"Yes\", \"Bar\": \"No\",  \"Fri/Sat\": \"Yes\", \"Hungry\": \"Yes\", \"Patrons\": \"Full\", \"Price\": \"$\",   \"Raining\": \"Yes\", \"Reservation\": \"No\",  \"Type\": \"Thai\",    \"WaitEstimate\": \"10-30\", \"WillWait\": \"Yes\"},\n",
-    "    {\"Alternate\": \"Yes\", \"Bar\": \"No\",  \"Fri/Sat\": \"Yes\", \"Hungry\": \"No\",  \"Patrons\": \"Full\", \"Price\": \"$$$\", \"Raining\": \"No\",  \"Reservation\": \"Yes\", \"Type\": \"French\",  \"WaitEstimate\": \">60\",   \"WillWait\": \"No\"},\n",
-    "    {\"Alternate\": \"No\",  \"Bar\": \"Yes\", \"Fri/Sat\": \"No\",  \"Hungry\": \"Yes\", \"Patrons\": \"Some\", \"Price\": \"$$\",  \"Raining\": \"Yes\", \"Reservation\": \"Yes\", \"Type\": \"Italian\", \"WaitEstimate\": \"0-10\",  \"WillWait\": \"Yes\"},\n",
-    "    {\"Alternate\": \"No\",  \"Bar\": \"Yes\", \"Fri/Sat\": \"No\",  \"Hungry\": \"No\",  \"Patrons\": \"None\", \"Price\": \"$\",   \"Raining\": \"Yes\", \"Reservation\": \"No\",  \"Type\": \"Burger\",  \"WaitEstimate\": \"0-10\",  \"WillWait\": \"No\"},\n",
-    "    {\"Alternate\": \"No\",  \"Bar\": \"No\",  \"Fri/Sat\": \"No\",  \"Hungry\": \"Yes\", \"Patrons\": \"Some\", \"Price\": \"$$\",  \"Raining\": \"Yes\", \"Reservation\": \"Yes\", \"Type\": \"Thai\",    \"WaitEstimate\": \"0-10\",  \"WillWait\": \"Yes\"},\n",
-    "    {\"Alternate\": \"No\",  \"Bar\": \"Yes\", \"Fri/Sat\": \"Yes\", \"Hungry\": \"No\",  \"Patrons\": \"Full\", \"Price\": \"$\",   \"Raining\": \"Yes\", \"Reservation\": \"No\",  \"Type\": \"Burger\",  \"WaitEstimate\": \"10-30\", \"WillWait\": \"No\"},\n",
-    "    {\"Alternate\": \"Yes\", \"Bar\": \"Yes\", \"Fri/Sat\": \"Yes\", \"Hungry\": \"Yes\", \"Patrons\": \"Full\", \"Price\": \"$$$\", \"Raining\": \"No\",  \"Reservation\": \"Yes\", \"Type\": \"Italian\", \"WaitEstimate\": \"10-30\", \"WillWait\": \"No\"},\n",
-    "    {\"Alternate\": \"No\",  \"Bar\": \"No\",  \"Fri/Sat\": \"No\",  \"Hungry\": \"No\",  \"Patrons\": \"None\", \"Price\": \"$\",   \"Raining\": \"No\",  \"Reservation\": \"No\",  \"Type\": \"Thai\",    \"WaitEstimate\": \"0-10\",  \"WillWait\": \"No\"},\n",
-    "    {\"Alternate\": \"Yes\", \"Bar\": \"Yes\", \"Fri/Sat\": \"Yes\", \"Hungry\": \"Yes\", \"Patrons\": \"Full\", \"Price\": \"$\",   \"Raining\": \"No\",  \"Reservation\": \"No\",  \"Type\": \"Burger\",  \"WaitEstimate\": \"30-60\", \"WillWait\": \"Yes\"},\n",
-    "]\n",
-    "\n",
-    "print(\"MINIMAL-CONSISTENT-DET sur le restaurant\")\n",
-    "print(\"=\" * 55)\n",
-    "print()\n",
-    "print(f\"Attributs disponibles : {len(RESTAURANT_ATTRS)}\")\n",
-    "print(f\"Exemples : {len(restaurant_data)}\")\n",
-    "print()\n",
-    "\n",
-    "# Attention : avec 10 attributs, les combinaisons deviennent nombreuses\n",
-    "# On limite la recherche aux 5 premiers attributs pour la demo\n",
-    "print(\"Recherche sur les 5 premiers attributs :\")\n",
-    "det_rest = minimal_consistent_det(\n",
-    "    restaurant_data,\n",
-    "    RESTAURANT_ATTRS[:5],\n",
-    "    \"WillWait\",\n",
-    "    verbose=True\n",
-    ")\n",
-    "print()\n",
-    "if det_rest:\n",
-    "    print(f\"Determination minimale : {det_rest}\")\n",
-    "else:\n",
-    "    print(\"Pas de determination sur les 5 premiers attributs seuls.\")\n",
-    "    print(\"(Le concept WillWait est disjonctif, pas de determination simple)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5838ce73",
-   "metadata": {
-    "papermill": {
-     "duration": 0.011394,
-     "end_time": "2026-06-06T20:57:15.657347",
-     "exception": false,
-     "start_time": "2026-06-06T20:57:15.645953",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : MINIMAL-CONSISTENT-DET\n",
-    "\n",
-    "L'algorithme trouve efficacement la determination minimale quand elle existe :\n",
-    "\n",
-    "| Domaine | Attributs | Determination minimale | Reduction d'espace |\n",
-    "|---------|-----------|----------------------|--------------------|\n",
-    "| Nationalite/Langue | 3 | `nationality` (1) | $2^3 \\to 2^1$ = 4x |\n",
-    "| Restaurant | 10 | Disjonctif | Pas de determination unique |\n",
-    "\n",
-    "**Pourquoi le restaurant echoue** : Le concept `WillWait` est disjonctif (`Patrons=Some` OU `(Patrons=Full AND Hungry=Yes)`). Aucune determination unique ne peut capturer cette logique, car la meme combinaison de valeurs peut donner des resultats differents selon le contexte.\n",
-    "\n",
-    "> **Point cle** : RBL suppose que les attributs determinants existent et forment une determination fonctionnelle. Quand le concept est disjonctif ou bruite, cette hypothese ne tient pas, et il faut se tourner vers KBIL (apprentissage inductif base sur la connaissance)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5c64432b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.010304,
-     "end_time": "2026-06-06T20:57:15.677730",
-     "exception": false,
-     "start_time": "2026-06-06T20:57:15.667426",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## 9. RBL --- Impact quantitatif sur l'apprentissage\n",
-    "\n",
-    "Quantifions l'avantage concret d'une determination. Si on sait que `nationality` determine `language`, combien d'exemples faut-il pour apprendre la langue de chaque nationalite ?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "1cefbbbf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.698868Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.698412Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.708191Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.707381Z"
-    },
-    "papermill": {
-     "duration": 0.022954,
-     "end_time": "2026-06-06T20:57:15.710001",
-     "exception": false,
-     "start_time": "2026-06-06T20:57:15.687047",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Donnees synthetiques : 50 echantillons, 6 attributs\n",
-      "Attribut determinant : A (4 valeurs possibles)\n",
-      "Autres attributs : B-F (bruit, 3 valeurs chacun)\n",
-      "\n",
-      "Recherche de la determination minimale :\n",
-      "  Taille 1 : test de 6 combinaisons...\n",
-      "    TROUVE : ('A',) (test #1)\n",
-      "\n",
-      "Determination trouvee : ('A',)\n",
-      "Dimension : d=1 sur n=6 attributs\n",
-      "\n",
-      "Impact sur l'espace des hypotheses :\n",
-      "  Sans RBL : espace = O(2^6) = O(64)\n",
-      "  Avec RBL : espace = O(2^1) = O(2)\n",
-      "  Facteur de reduction : 2^5 = 32\n",
-      "\n",
-      "Estimation du nombre d'exemples (borne PAC simplifiee) :\n",
-      "  Sans RBL : ~60 exemples\n",
-      "  Avec RBL : ~10 exemples\n",
-      "  Economie : 50 exemples (83% de reduction)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Comparaison : apprentissage avec et sans connaissance de pertinence\n",
-    "\n",
-    "# Generation de donnees synthetiques pour un domaine avec 6 attributs\n",
-    "# Seul 1 attribut (le premier) determine reellement la cible\n",
-    "\n",
-    "import random\n",
-    "random.seed(42)\n",
-    "\n",
-    "# Attributs : A (determine Y), B, C, D, E, F (bruit)\n",
-    "N_ATTRS = 6\n",
-    "N_SAMPLES = 50\n",
-    "ATTR_NAMES = [\"A\", \"B\", \"C\", \"D\", \"E\", \"F\"]\n",
-    "A_VALUES = [\"a1\", \"a2\", \"a3\", \"a4\"]\n",
-    "NOISE_VALUES = [\"x\", \"y\", \"z\"]\n",
-    "\n",
-    "# Y est determine uniquement par A\n",
-    "Y_MAP = {\"a1\": \"Y1\", \"a2\": \"Y2\", \"a3\": \"Y3\", \"a4\": \"Y4\"}\n",
-    "\n",
-    "# Generer les donnees\n",
-    "synth_data = []\n",
-    "for _ in range(N_SAMPLES):\n",
-    "    a_val = random.choice(A_VALUES)\n",
-    "    row = {\n",
-    "        \"A\": a_val,\n",
-    "        \"B\": random.choice(NOISE_VALUES),\n",
-    "        \"C\": random.choice(NOISE_VALUES),\n",
-    "        \"D\": random.choice(NOISE_VALUES),\n",
-    "        \"E\": random.choice(NOISE_VALUES),\n",
-    "        \"F\": random.choice(NOISE_VALUES),\n",
-    "        \"Y\": Y_MAP[a_val]\n",
-    "    }\n",
-    "    synth_data.append(row)\n",
-    "\n",
-    "print(f\"Donnees synthetiques : {N_SAMPLES} echantillons, {N_ATTRS} attributs\")\n",
-    "print(f\"Attribut determinant : A (4 valeurs possibles)\")\n",
-    "print(f\"Autres attributs : B-F (bruit, 3 valeurs chacun)\")\n",
-    "print()\n",
-    "\n",
-    "# 1. Trouver la determination minimale\n",
-    "print(\"Recherche de la determination minimale :\")\n",
-    "det_synth = minimal_consistent_det(synth_data, ATTR_NAMES, \"Y\", verbose=True)\n",
-    "print()\n",
-    "\n",
-    "if det_synth:\n",
-    "    d = len(det_synth)\n",
-    "    n = N_ATTRS\n",
-    "    \n",
-    "    print(f\"Determination trouvee : {det_synth}\")\n",
-    "    print(f\"Dimension : d={d} sur n={n} attributs\")\n",
-    "    print()\n",
-    "    \n",
-    "    # 2. Calcul de la reduction de l'espace des hypotheses\n",
-    "    print(\"Impact sur l'espace des hypotheses :\")\n",
-    "    print(f\"  Sans RBL : espace = O(2^{n}) = O({2**n})\")\n",
-    "    print(f\"  Avec RBL : espace = O(2^{d}) = O({2**d})\")\n",
-    "    print(f\"  Facteur de reduction : 2^{n-d} = {2**(n-d)}\")\n",
-    "    print()\n",
-    "    \n",
-    "    # 3. Nombre d'exemples necessaires (borne PAC simplifiee)\n",
-    "    # m >= (1/epsilon) * (ln(|H|) + ln(1/delta))\n",
-    "    # Simplification : m ~ O(log(|H|))\n",
-    "    import math\n",
-    "    m_without = math.log2(2**n) * 10  # facteur multiplicatif arbitraire\n",
-    "    m_with = math.log2(2**d) * 10\n",
-    "    \n",
-    "    print(\"Estimation du nombre d'exemples (borne PAC simplifiee) :\")\n",
-    "    print(f\"  Sans RBL : ~{m_without:.0f} exemples\")\n",
-    "    print(f\"  Avec RBL : ~{m_with:.0f} exemples\")\n",
-    "    print(f\"  Economie : {m_without - m_with:.0f} exemples ({(1 - m_with/m_without)*100:.0f}% de reduction)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c613d608",
-   "metadata": {
-    "papermill": {
-     "duration": 0.009848,
-     "end_time": "2026-06-06T20:57:15.728982",
-     "exception": false,
-     "start_time": "2026-06-06T20:57:15.719134",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Impact quantitatif du RBL\n",
-    "\n",
-    "| Metrique | Sans RBL | Avec RBL | Gain |\n",
-    "|----------|----------|----------|------|\n",
-    "| Espace des hypotheses | $O(2^n)$ | $O(2^d)$ | Exponentiel quand d << n |\n",
-    "| Exemples necessaires | $O(\\log(2^n))$ | $O(\\log(2^d))$ | Facteur $n/d$ |\n",
-    "| Attributs a considerer | Tous (n) | Pertinents (d) | Reduction $1 - d/n$ |\n",
-    "\n",
-    "La connaissance de la determination agit comme un **filtre puissant** sur l'espace de recherche. Au lieu d'explorer toutes les combinaisons d'attributs, on se concentre uniquement sur ceux qui sont pertinents.\n",
-    "\n",
-    "> **Analogie** : Si vous savez que la nationalite determine la langue, vous n'avez pas besoin d'essayer l'age, la ville ou la taille des chaussures comme predicteurs. La determination elimine tous les attributs irrationnels d'un coup."
+    "Pour situer le RBL parmi les paradigmes d'apprentissage utilisant la connaissance, le concept de determination introduit ci-dessus suffit.\n"
    ]
   },
   {
@@ -1920,10 +1504,10 @@
    "id": "d971dcd5",
    "metadata": {
     "papermill": {
-     "duration": 0.006907,
-     "end_time": "2026-06-06T20:57:15.744818",
+     "duration": 0.003138,
+     "end_time": "2026-06-10T08:20:18.881084",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.737911",
+     "start_time": "2026-06-10T08:20:18.877946",
      "status": "completed"
     },
     "tags": []
@@ -1931,7 +1515,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 10. Synthese et exercices\n",
+    "## 8. Synthese et exercices\n",
     "\n",
     "### Tableau recapitulatif\n",
     "\n",
@@ -1950,27 +1534,27 @@
     "\n",
     "2. **RBL** utilise les determinations pour reduire exponentiellement l'espace des hypotheses. Il suffit de connaitre les attributs pertinents pour accelerer considerablement l'apprentissage.\n",
     "\n",
-    "3. **KBIL** (couvert dans SL-3) combine la connaissance de fond avec l'induction pour apprendre de veritables nouvelles hypotheses que ni EBL ni RBL ne pourraient decouvrir seuls.\n",
+    "3. **KBIL** (couvert a partir de SL-4) combine la connaissance de fond avec l'induction pour apprendre de veritables nouvelles hypotheses que ni EBL ni RBL ne pourraient decouvrir seuls.\n",
     "\n",
     "4. L'**operationalite** en EBL est un compromis : les regles trop specifiques ne sont pas reutilisees, les regles trop generales n'apportent rien."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "id": "d8492780",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.764527Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.764082Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.770238Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.769268Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.888387Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.887855Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.892390Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.892390Z"
     },
     "papermill": {
-     "duration": 0.017569,
-     "end_time": "2026-06-06T20:57:15.771542",
+     "duration": 0.009329,
+     "end_time": "2026-06-10T08:20:18.893536",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.753973",
+     "start_time": "2026-06-10T08:20:18.884207",
      "status": "completed"
     },
     "tags": []
@@ -2023,34 +1607,34 @@
    "id": "94f38997",
    "metadata": {
     "papermill": {
-     "duration": 0.006557,
-     "end_time": "2026-06-06T20:57:15.784033",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:18.899535",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.777476",
+     "start_time": "2026-06-10T08:20:18.896535",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "L'exercice suivant passe au cadre RBL : vous y chercherez la determination minimale d'un attribut cible dans un nouveau jeu de donnees."
+    "L'exercice suivant revient sur le compromis d'operationalite vu en section 6 : chaque regle apprise a un cout de recherche, et n'est rentable que si elle est suffisamment reutilisee. Vous implementerez un mecanisme de filtrage (desapprentissage) des regles peu utiles.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "id": "5835c6f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.799172Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.798827Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.805976Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.804761Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.907042Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.906043Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.924078Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.924078Z"
     },
     "papermill": {
-     "duration": 0.018017,
-     "end_time": "2026-06-06T20:57:15.807799",
+     "duration": 0.022547,
+     "end_time": "2026-06-10T08:20:18.925082",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.789782",
+     "start_time": "2026-06-10T08:20:18.902535",
      "status": "completed"
     },
     "tags": []
@@ -2060,39 +1644,49 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : appelez minimal_consistent_det\n"
+      "Exercice a completer : filtrage des regles EBL peu utilisees\n",
+      "Etape 1 : enseignez 3 regles a une instance d'ArithmeticEBL\n",
+      "Etape 2 : simplifiez 10 expressions et comptez les utilisations par regle\n",
+      "Etape 3 : implementez prune_learned_rules et appliquez-la (min_usage=2)\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : Trouver la determination minimale\n",
-    "# TODO etudiant : Appliquez minimal_consistent_det sur un nouveau jeu de donnees\n",
-    "# Indice : Les donnees representent des etudiants avec differents attributs\n",
-    "#          Un seul attribut determine la reussite finale\n",
+    "# Exercice 2 : Filtrage des regles apprises (operationalite)\n",
+    "# TODO etudiant : Implementez un mecanisme de desapprentissage des regles peu utiles\n",
+    "# Indice : la section 6 a montre que chaque regle apprise augmente le temps de recherche.\n",
+    "#          Une regle n'est rentable que si elle est suffisamment reutilisee.\n",
     "\n",
-    "student_data = [\n",
-    "    {\"study_hours\": \"high\", \"sleep\": \"low\",  \"exercise\": \"low\",  \"diet\": \"good\",   \"result\": \"pass\"},\n",
-    "    {\"study_hours\": \"high\", \"sleep\": \"high\", \"exercise\": \"low\",  \"diet\": \"poor\",   \"result\": \"pass\"},\n",
-    "    {\"study_hours\": \"high\", \"sleep\": \"med\",  \"exercise\": \"high\", \"diet\": \"good\",   \"result\": \"pass\"},\n",
-    "    {\"study_hours\": \"low\",  \"sleep\": \"high\", \"exercise\": \"high\", \"diet\": \"good\",   \"result\": \"fail\"},\n",
-    "    {\"study_hours\": \"low\",  \"sleep\": \"med\",  \"exercise\": \"med\",  \"diet\": \"poor\",   \"result\": \"fail\"},\n",
-    "    {\"study_hours\": \"low\",  \"sleep\": \"high\", \"exercise\": \"low\",  \"diet\": \"good\",   \"result\": \"fail\"},\n",
-    "    {\"study_hours\": \"med\",  \"sleep\": \"high\", \"exercise\": \"med\",  \"diet\": \"good\",   \"result\": \"pass\"},\n",
-    "    {\"study_hours\": \"med\",  \"sleep\": \"low\",  \"exercise\": \"low\",  \"diet\": \"poor\",   \"result\": \"fail\"},\n",
-    "]\n",
+    "# Etape 1 : Creez une instance d'ArithmeticEBL et enseignez-lui 3 regles\n",
+    "# ebl = ArithmeticEBL()\n",
+    "# ebl.learn(\"1*(0+x)\", {\"x\": \"z\"}, verbose=False)\n",
+    "# ebl.learn(\"1*y\", {\"y\": \"v\"}, verbose=False)\n",
+    "# ebl.learn(\"0+u\", {\"u\": \"w\"}, verbose=False)\n",
     "\n",
-    "student_attrs = [\"study_hours\", \"sleep\", \"exercise\", \"diet\"]\n",
+    "# Etape 2 : Simplifiez une liste d'expressions et comptez les utilisations par regle\n",
+    "# Indice : simplify_with_learned indique la methode utilisee ; comptez dans un dict\n",
     "\n",
-    "# Etape 1 : Trouvez la determination minimale pour \"result\"\n",
-    "result = None  # TODO etudiant : remplacez par minimal_consistent_det(student_data, student_attrs, \"result\")\n",
+    "def prune_learned_rules(ebl, usage_counts: dict[str, int], min_usage: int = 2) -> list:\n",
+    "    \"\"\"Retourne la liste des regles apprises a CONSERVER.\n",
     "\n",
-    "if result is not None:\n",
-    "    print(f\"Determination minimale : {result}\")\n",
-    "    print(f\"Reduction : O(2^{len(student_attrs)}) -> O(2^{len(result)})\")\n",
-    "else:\n",
-    "    print(\"Exercice a completer : appelez minimal_consistent_det\")\n",
+    "    Une regle est conservee si elle a ete utilisee au moins min_usage fois.\n",
     "\n",
-    "# Indice : Quel attribut est le meilleur predicteur de la reussite ?"
+    "    Args:\n",
+    "        ebl: instance d'ArithmeticEBL (regles apprises dans ebl.learned)\n",
+    "        usage_counts: nombre d'utilisations par pattern de regle\n",
+    "        min_usage: seuil de conservation\n",
+    "\n",
+    "    Returns:\n",
+    "        Liste des LearnedRule a conserver\n",
+    "    \"\"\"\n",
+    "    pass  # TODO etudiant : filtrez ebl.learned selon usage_counts\n",
+    "\n",
+    "\n",
+    "# Etape 3 : Appliquez prune_learned_rules et verifiez que les regles inutilisees disparaissent\n",
+    "print(\"Exercice a completer : filtrage des regles EBL peu utilisees\")\n",
+    "print(\"Etape 1 : enseignez 3 regles a une instance d'ArithmeticEBL\")\n",
+    "print(\"Etape 2 : simplifiez 10 expressions et comptez les utilisations par regle\")\n",
+    "print(\"Etape 3 : implementez prune_learned_rules et appliquez-la (min_usage=2)\")\n"
    ]
   },
   {
@@ -2100,10 +1694,10 @@
    "id": "8a44d796",
    "metadata": {
     "papermill": {
-     "duration": 0.008858,
-     "end_time": "2026-06-06T20:57:15.828238",
+     "duration": 0.003116,
+     "end_time": "2026-06-10T08:20:18.932466",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.819380",
+     "start_time": "2026-06-10T08:20:18.929350",
      "status": "completed"
     },
     "tags": []
@@ -2114,20 +1708,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "id": "d4d1535a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:15.851620Z",
-     "iopub.status.busy": "2026-06-06T20:57:15.851138Z",
-     "iopub.status.idle": "2026-06-06T20:57:15.856805Z",
-     "shell.execute_reply": "2026-06-06T20:57:15.855753Z"
+     "iopub.execute_input": "2026-06-10T08:20:18.939665Z",
+     "iopub.status.busy": "2026-06-10T08:20:18.938665Z",
+     "iopub.status.idle": "2026-06-10T08:20:18.955833Z",
+     "shell.execute_reply": "2026-06-10T08:20:18.955169Z"
     },
     "papermill": {
-     "duration": 0.020112,
-     "end_time": "2026-06-06T20:57:15.858728",
+     "duration": 0.02077,
+     "end_time": "2026-06-10T08:20:18.955833",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.838616",
+     "start_time": "2026-06-10T08:20:18.935063",
      "status": "completed"
     },
     "tags": []
@@ -2180,10 +1774,10 @@
    "id": "864f2055",
    "metadata": {
     "papermill": {
-     "duration": 0.009974,
-     "end_time": "2026-06-06T20:57:15.878120",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:18.962836",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.868146",
+     "start_time": "2026-06-10T08:20:18.959836",
      "status": "completed"
     },
     "tags": []
@@ -2193,9 +1787,9 @@
     "\n",
     "Ce notebook a etudie deux approches qui exploitent la connaissance prealable du domaine pour ameliorer l'apprentissage : l'EBL (Explanation-Based Learning) et le RBL (Relevance-Based Learning). L'EBL compile une theorie de premiers principes en regles operationnelles a partir d'un seul exemple, en construisant un arbre de preuve puis en variabilisant les constantes. L'implementation sur la simplification arithmetique a montre comment les regles `1*u -> u` et `0+u -> u` peuvent etre combinees en une regle composee `Simplify(1*(0+z), z)` qui court-circuite les etapes intermediaires. Le compromis fondamental de l'EBL reside dans l'operationalite : les regles trop specifiques ne sont jamais reutilisees, tandis que les regles trop generales n'apportent aucun gain.\n",
     "\n",
-    "Le RBL, quant a lui, identifie les attributs pertinents via les determinations. L'algorithme MINIMAL-CONSISTENT-DET explore les sous-ensembles d'attributs par taille croissante et s'arrete des qu'une determination fonctionnelle est trouvee, reduisant l'espace des hypotheses de O(2^n) a O(2^d) ou d est le nombre d'attributs determinants. Sur le domaine nationalite-langue, la determination minimale `nationality` seule a permis une reduction de l'espace par un facteur 4. Cependant, le concept disjonctif du restaurant a montre que les determinations echouent quand la relation entre attributs et cible n'est pas fonctionnelle.\n",
+    "Le RBL, quant a lui, identifie les attributs pertinents via les determinations : si un sous-ensemble de d attributs determine la cible parmi n attributs, l'espace des hypotheses se reduit de O(2^n) a O(2^d) --- une reduction exponentielle quand d << n. Sur le domaine nationalite-langue, la determination `nationality` seule suffit a predire la langue, rendant les autres attributs (age, ville) inutiles a l'apprentissage. La formalisation complete du cadre --- treillis des determinations, algorithme MINIMAL-CONSISTENT-DET, cas d'echec sur les concepts disjonctifs et comparaison avec la selection statistique d'attributs --- est l'objet du notebook suivant.\n",
     "\n",
-    "Ces deux approches sont deductives et ne creent pas de connaissance factuellement nouvelle. Le passage a l'apprentissage inductif base sur la connaissance (KBIL), qui combine connaissances de fond et induction pour decouvrir de veritables nouvelles hypotheses, sera explore dans les notebooks suivants de la serie SymbolicLearning."
+    "Ces deux approches sont deductives et ne creent pas de connaissance factuellement nouvelle. Le notebook suivant, [SL-3 - Apprentissage Base sur la Pertinence](SL-3-RelevanceLearning.ipynb), approfondit le RBL ; le passage a l'apprentissage inductif base sur la connaissance (KBIL), qui combine connaissances de fond et induction pour decouvrir de veritables nouvelles hypotheses, sera explore a partir de [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb).\n"
    ]
   },
   {
@@ -2203,10 +1797,10 @@
    "id": "42508ff0",
    "metadata": {
     "papermill": {
-     "duration": 0.008968,
-     "end_time": "2026-06-06T20:57:15.896453",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:18.968836",
      "exception": false,
-     "start_time": "2026-06-06T20:57:15.887485",
+     "start_time": "2026-06-10T08:20:18.965836",
      "status": "completed"
     },
     "tags": []
@@ -2223,7 +1817,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Retour** : [Index SymbolicLearning](./README.md) | [<< SL-1](SL-1-LogicalLearning.ipynb)"
+    "**Retour** : [Index SymbolicLearning](./README.md) | [<< SL-1](SL-1-LogicalLearning.ipynb) | [SL-3 >>](SL-3-RelevanceLearning.ipynb)"
    ]
   }
  ],
@@ -2243,18 +1837,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.104977,
-   "end_time": "2026-06-06T20:57:16.244500",
+   "duration": 2.313281,
+   "end_time": "2026-06-10T08:20:19.189745",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb",
-   "output_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb",
+   "input_path": "SL-2-KnowledgeBasedLearning.ipynb",
+   "output_path": "SL-2-KnowledgeBasedLearning.ipynb",
    "parameters": {},
-   "start_time": "2026-06-06T20:57:12.139523",
+   "start_time": "2026-06-10T08:20:16.876464",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "dbf96c32",
    "metadata": {
     "papermill": {
-     "duration": 0.005685,
-     "end_time": "2026-06-06T20:57:30.143196",
+     "duration": 0.003697,
+     "end_time": "2026-06-10T08:20:22.832466",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.137511",
+     "start_time": "2026-06-10T08:20:22.828769",
      "status": "completed"
     },
     "tags": []
@@ -29,7 +29,7 @@
     "\n",
     "### Prerequis\n",
     "- SL-1 (apprentissage logique, espaces d'hypotheses)\n",
-    "- SL-2 sections 7-9 (introduction aux determinations et RBL)\n",
+    "- SL-2 section 7 (introduction aux determinations)\n",
     "- Bases de Python et structures de donnees\n",
     "\n",
     "### Duree estimee : 50 minutes"
@@ -41,16 +41,16 @@
    "id": "4eb99804",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:30.157432Z",
-     "iopub.status.busy": "2026-06-06T20:57:30.156850Z",
-     "iopub.status.idle": "2026-06-06T20:57:30.167732Z",
-     "shell.execute_reply": "2026-06-06T20:57:30.166287Z"
+     "iopub.execute_input": "2026-06-10T08:20:22.839135Z",
+     "iopub.status.busy": "2026-06-10T08:20:22.838623Z",
+     "iopub.status.idle": "2026-06-10T08:20:22.860412Z",
+     "shell.execute_reply": "2026-06-10T08:20:22.859766Z"
     },
     "papermill": {
-     "duration": 0.018213,
-     "end_time": "2026-06-06T20:57:30.169423",
+     "duration": 0.025892,
+     "end_time": "2026-06-10T08:20:22.860931",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.151210",
+     "start_time": "2026-06-10T08:20:22.835039",
      "status": "completed"
     },
     "tags": []
@@ -91,10 +91,10 @@
    "id": "359e4cd2",
    "metadata": {
     "papermill": {
-     "duration": 0.004983,
-     "end_time": "2026-06-06T20:57:30.178694",
+     "duration": 0.002557,
+     "end_time": "2026-06-10T08:20:22.867103",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.173711",
+     "start_time": "2026-06-10T08:20:22.864546",
      "status": "completed"
     },
     "tags": []
@@ -104,7 +104,7 @@
     "\n",
     "## 1. Introduction --- Pourquoi la pertinence ?\n",
     "\n",
-    "Dans SL-2, nous avons introduit le concept de **determination** et l'algorithme MINIMAL-CONSISTENT-DET. Ce notebook approfondit le cadre formel du **Relevance-Based Learning** (RBL, AIMA 19.4).\n",
+    "Dans SL-2, nous avons introduit le concept de **determination**. Ce notebook approfondit le cadre formel du **Relevance-Based Learning** (RBL, AIMA 19.4) : proprietes mathematiques, treillis, algorithme MINIMAL-CONSISTENT-DET et selection d'attributs.\n",
     "\n",
     "### Le probleme central\n",
     "\n",
@@ -130,7 +130,8 @@
     "| 3. Treillis des determinations | Visualisation, relations d'inclusion | 10 min |\n",
     "| 4. Algorithme MINIMAL-CONSISTENT-DET | Implementation detaillee | 10 min |\n",
     "| 5. Selection d'attributs guidee | RBL vs sklearn, comparaison | 10 min |\n",
-    "| 6. Exercices | 3 exercices pratiques | 10 min |"
+    "| 6. Determinations et semantique web | Parallel RBL <-> OWL | 5 min |\n",
+    "| 7. Exercices | 3 exercices pratiques | 10 min |"
    ]
   },
   {
@@ -138,10 +139,10 @@
    "id": "3a901336",
    "metadata": {
     "papermill": {
-     "duration": 0.004723,
-     "end_time": "2026-06-06T20:57:30.188783",
+     "duration": 0.002559,
+     "end_time": "2026-06-10T08:20:22.872227",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.184060",
+     "start_time": "2026-06-10T08:20:22.869668",
      "status": "completed"
     },
     "tags": []
@@ -174,16 +175,16 @@
    "id": "6b2244c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:30.203024Z",
-     "iopub.status.busy": "2026-06-06T20:57:30.202681Z",
-     "iopub.status.idle": "2026-06-06T20:57:30.214506Z",
-     "shell.execute_reply": "2026-06-06T20:57:30.213441Z"
+     "iopub.execute_input": "2026-06-10T08:20:22.878981Z",
+     "iopub.status.busy": "2026-06-10T08:20:22.878470Z",
+     "iopub.status.idle": "2026-06-10T08:20:22.891311Z",
+     "shell.execute_reply": "2026-06-10T08:20:22.890761Z"
     },
     "papermill": {
-     "duration": 0.020423,
-     "end_time": "2026-06-06T20:57:30.216824",
+     "duration": 0.017035,
+     "end_time": "2026-06-10T08:20:22.891824",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.196401",
+     "start_time": "2026-06-10T08:20:22.874789",
      "status": "completed"
     },
     "tags": []
@@ -294,10 +295,10 @@
    "id": "3fd9dbce",
    "metadata": {
     "papermill": {
-     "duration": 0.006508,
-     "end_time": "2026-06-06T20:57:30.231270",
+     "duration": 0.003069,
+     "end_time": "2026-06-10T08:20:22.897968",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.224762",
+     "start_time": "2026-06-10T08:20:22.894899",
      "status": "completed"
     },
     "tags": []
@@ -321,10 +322,10 @@
    "id": "29d1b9a6",
    "metadata": {
     "papermill": {
-     "duration": 0.006112,
-     "end_time": "2026-06-06T20:57:30.243748",
+     "duration": 0.003066,
+     "end_time": "2026-06-10T08:20:22.903597",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.237636",
+     "start_time": "2026-06-10T08:20:22.900531",
      "status": "completed"
     },
     "tags": []
@@ -347,16 +348,16 @@
    "id": "b19e64de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:30.257838Z",
-     "iopub.status.busy": "2026-06-06T20:57:30.257419Z",
-     "iopub.status.idle": "2026-06-06T20:57:30.268720Z",
-     "shell.execute_reply": "2026-06-06T20:57:30.267727Z"
+     "iopub.execute_input": "2026-06-10T08:20:22.910842Z",
+     "iopub.status.busy": "2026-06-10T08:20:22.910315Z",
+     "iopub.status.idle": "2026-06-10T08:20:22.922212Z",
+     "shell.execute_reply": "2026-06-10T08:20:22.921662Z"
     },
     "papermill": {
-     "duration": 0.021104,
-     "end_time": "2026-06-06T20:57:30.270858",
+     "duration": 0.016577,
+     "end_time": "2026-06-10T08:20:22.922724",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.249754",
+     "start_time": "2026-06-10T08:20:22.906147",
      "status": "completed"
     },
     "tags": []
@@ -474,10 +475,10 @@
    "id": "1bfe64c6",
    "metadata": {
     "papermill": {
-     "duration": 0.008235,
-     "end_time": "2026-06-06T20:57:30.286867",
+     "duration": 0.003073,
+     "end_time": "2026-06-10T08:20:22.928877",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.278632",
+     "start_time": "2026-06-10T08:20:22.925804",
      "status": "completed"
     },
     "tags": []
@@ -502,16 +503,16 @@
    "id": "0aecc697",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:30.302158Z",
-     "iopub.status.busy": "2026-06-06T20:57:30.301700Z",
-     "iopub.status.idle": "2026-06-06T20:57:30.309937Z",
-     "shell.execute_reply": "2026-06-06T20:57:30.308524Z"
+     "iopub.execute_input": "2026-06-10T08:20:22.936062Z",
+     "iopub.status.busy": "2026-06-10T08:20:22.935548Z",
+     "iopub.status.idle": "2026-06-10T08:20:22.953193Z",
+     "shell.execute_reply": "2026-06-10T08:20:22.952580Z"
     },
     "papermill": {
-     "duration": 0.01877,
-     "end_time": "2026-06-06T20:57:30.312316",
+     "duration": 0.021759,
+     "end_time": "2026-06-10T08:20:22.953708",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.293546",
+     "start_time": "2026-06-10T08:20:22.931949",
      "status": "completed"
     },
     "tags": []
@@ -586,10 +587,10 @@
    "id": "5ea54d7e",
    "metadata": {
     "papermill": {
-     "duration": 0.007581,
-     "end_time": "2026-06-06T20:57:30.327066",
+     "duration": 0.003093,
+     "end_time": "2026-06-10T08:20:22.960431",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.319485",
+     "start_time": "2026-06-10T08:20:22.957338",
      "status": "completed"
     },
     "tags": []
@@ -627,16 +628,16 @@
    "id": "6319964e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:30.343990Z",
-     "iopub.status.busy": "2026-06-06T20:57:30.343448Z",
-     "iopub.status.idle": "2026-06-06T20:57:30.357301Z",
-     "shell.execute_reply": "2026-06-06T20:57:30.356109Z"
+     "iopub.execute_input": "2026-06-10T08:20:22.967671Z",
+     "iopub.status.busy": "2026-06-10T08:20:22.967153Z",
+     "iopub.status.idle": "2026-06-10T08:20:22.984348Z",
+     "shell.execute_reply": "2026-06-10T08:20:22.983738Z"
     },
     "papermill": {
-     "duration": 0.024396,
-     "end_time": "2026-06-06T20:57:30.359094",
+     "duration": 0.021362,
+     "end_time": "2026-06-10T08:20:22.984883",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.334698",
+     "start_time": "2026-06-10T08:20:22.963521",
      "status": "completed"
     },
     "tags": []
@@ -770,10 +771,10 @@
    "id": "1ed6994f",
    "metadata": {
     "papermill": {
-     "duration": 0.006262,
-     "end_time": "2026-06-06T20:57:30.370897",
+     "duration": 0.002523,
+     "end_time": "2026-06-10T08:20:22.990498",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.364635",
+     "start_time": "2026-06-10T08:20:22.987975",
      "status": "completed"
     },
     "tags": []
@@ -794,13 +795,148 @@
   },
   {
    "cell_type": "markdown",
+   "id": "88f1d020",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003001,
+     "end_time": "2026-06-10T08:20:22.996497",
+     "exception": false,
+     "start_time": "2026-06-10T08:20:22.993496",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Cas d'echec : le concept disjonctif du restaurant\n",
+    "\n",
+    "Reprenons les donnees du restaurant (SL-1, AIMA Table 19.1). Le concept cible est **disjonctif** : `WillWait` si `Patrons=Some` **ou** (`Patrons=Full` **et** `Hungry=Yes`). Une telle logique n'est une fonction d'aucun petit sous-ensemble d'attributs : que trouve MINIMAL-CONSISTENT-DET ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "57161fdd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T08:20:23.003501Z",
+     "iopub.status.busy": "2026-06-10T08:20:23.002499Z",
+     "iopub.status.idle": "2026-06-10T08:20:23.015015Z",
+     "shell.execute_reply": "2026-06-10T08:20:23.015015Z"
+    },
+    "papermill": {
+     "duration": 0.016195,
+     "end_time": "2026-06-10T08:20:23.015696",
+     "exception": false,
+     "start_time": "2026-06-10T08:20:22.999501",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MINIMAL-CONSISTENT-DET sur le restaurant (concept disjonctif)\n",
+      "==============================================================\n",
+      "\n",
+      "Recherche sur les 5 premiers attributs :\n",
+      "  Niveau 1 : test de 5 combinaisons...\n",
+      "  Niveau 2 : test de 10 combinaisons...\n",
+      "  Niveau 3 : test de 10 combinaisons...\n",
+      "  Niveau 4 : test de 5 combinaisons...\n",
+      "  Niveau 5 : test de 1 combinaisons...\n",
+      "  Aucune determination trouvee (31 tests)\n",
+      "\n",
+      "Aucune determination sur les 5 premiers attributs :\n",
+      "le concept disjonctif n'est une fonction d'aucun de ces sous-ensembles.\n",
+      "\n",
+      "Recherche sur les 10 attributs :\n",
+      "  Determination 'trouvee' : {Alternate, Fri/Sat, Price} apres 66 tests\n",
+      "\n",
+      "ATTENTION : cette determination est FALLACIEUSE (spurious).\n",
+      "Avec seulement 12 exemples et 10 attributs, de nombreux triplets\n",
+      "d'attributs separent les exemples par pur hasard, sans rapport avec\n",
+      "le vrai concept (qui depend de Patrons et Hungry).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cas d'echec : concept disjonctif du restaurant (donnees SL-1, AIMA Table 19.1)\n",
+    "restaurant_data = [\n",
+    "    {\"Alternate\": \"Yes\", \"Bar\": \"No\",  \"Fri/Sat\": \"No\",  \"Hungry\": \"Yes\", \"Patrons\": \"Some\", \"Price\": \"$$$\", \"Raining\": \"No\",  \"Reservation\": \"Yes\", \"Type\": \"French\",  \"WaitEstimate\": \"0-10\",  \"WillWait\": \"Yes\"},\n",
+    "    {\"Alternate\": \"Yes\", \"Bar\": \"No\",  \"Fri/Sat\": \"No\",  \"Hungry\": \"Yes\", \"Patrons\": \"Full\", \"Price\": \"$\",   \"Raining\": \"No\",  \"Reservation\": \"No\",  \"Type\": \"Thai\",    \"WaitEstimate\": \"30-60\", \"WillWait\": \"Yes\"},\n",
+    "    {\"Alternate\": \"No\",  \"Bar\": \"Yes\", \"Fri/Sat\": \"No\",  \"Hungry\": \"No\",  \"Patrons\": \"Some\", \"Price\": \"$\",   \"Raining\": \"No\",  \"Reservation\": \"No\",  \"Type\": \"Burger\",  \"WaitEstimate\": \"0-10\",  \"WillWait\": \"No\"},\n",
+    "    {\"Alternate\": \"Yes\", \"Bar\": \"No\",  \"Fri/Sat\": \"Yes\", \"Hungry\": \"Yes\", \"Patrons\": \"Full\", \"Price\": \"$\",   \"Raining\": \"Yes\", \"Reservation\": \"No\",  \"Type\": \"Thai\",    \"WaitEstimate\": \"10-30\", \"WillWait\": \"Yes\"},\n",
+    "    {\"Alternate\": \"Yes\", \"Bar\": \"No\",  \"Fri/Sat\": \"Yes\", \"Hungry\": \"No\",  \"Patrons\": \"Full\", \"Price\": \"$$$\", \"Raining\": \"No\",  \"Reservation\": \"Yes\", \"Type\": \"French\",  \"WaitEstimate\": \">60\",   \"WillWait\": \"No\"},\n",
+    "    {\"Alternate\": \"No\",  \"Bar\": \"Yes\", \"Fri/Sat\": \"No\",  \"Hungry\": \"Yes\", \"Patrons\": \"Some\", \"Price\": \"$$\",  \"Raining\": \"Yes\", \"Reservation\": \"Yes\", \"Type\": \"Italian\", \"WaitEstimate\": \"0-10\",  \"WillWait\": \"Yes\"},\n",
+    "    {\"Alternate\": \"No\",  \"Bar\": \"Yes\", \"Fri/Sat\": \"No\",  \"Hungry\": \"No\",  \"Patrons\": \"None\", \"Price\": \"$\",   \"Raining\": \"Yes\", \"Reservation\": \"No\",  \"Type\": \"Burger\",  \"WaitEstimate\": \"0-10\",  \"WillWait\": \"No\"},\n",
+    "    {\"Alternate\": \"No\",  \"Bar\": \"No\",  \"Fri/Sat\": \"No\",  \"Hungry\": \"Yes\", \"Patrons\": \"Some\", \"Price\": \"$$\",  \"Raining\": \"Yes\", \"Reservation\": \"Yes\", \"Type\": \"Thai\",    \"WaitEstimate\": \"0-10\",  \"WillWait\": \"Yes\"},\n",
+    "    {\"Alternate\": \"No\",  \"Bar\": \"Yes\", \"Fri/Sat\": \"Yes\", \"Hungry\": \"No\",  \"Patrons\": \"Full\", \"Price\": \"$\",   \"Raining\": \"Yes\", \"Reservation\": \"No\",  \"Type\": \"Burger\",  \"WaitEstimate\": \"10-30\", \"WillWait\": \"No\"},\n",
+    "    {\"Alternate\": \"Yes\", \"Bar\": \"Yes\", \"Fri/Sat\": \"Yes\", \"Hungry\": \"Yes\", \"Patrons\": \"Full\", \"Price\": \"$$$\", \"Raining\": \"No\",  \"Reservation\": \"Yes\", \"Type\": \"Italian\", \"WaitEstimate\": \"10-30\", \"WillWait\": \"No\"},\n",
+    "    {\"Alternate\": \"No\",  \"Bar\": \"No\",  \"Fri/Sat\": \"No\",  \"Hungry\": \"No\",  \"Patrons\": \"None\", \"Price\": \"$\",   \"Raining\": \"No\",  \"Reservation\": \"No\",  \"Type\": \"Thai\",    \"WaitEstimate\": \"0-10\",  \"WillWait\": \"No\"},\n",
+    "    {\"Alternate\": \"Yes\", \"Bar\": \"Yes\", \"Fri/Sat\": \"Yes\", \"Hungry\": \"Yes\", \"Patrons\": \"Full\", \"Price\": \"$\",   \"Raining\": \"No\",  \"Reservation\": \"No\",  \"Type\": \"Burger\",  \"WaitEstimate\": \"30-60\", \"WillWait\": \"Yes\"},\n",
+    "]\n",
+    "RESTAURANT_ATTRS = [\"Alternate\", \"Bar\", \"Fri/Sat\", \"Hungry\", \"Patrons\",\n",
+    "                    \"Price\", \"Raining\", \"Reservation\", \"Type\", \"WaitEstimate\"]\n",
+    "\n",
+    "print(\"MINIMAL-CONSISTENT-DET sur le restaurant (concept disjonctif)\")\n",
+    "print(\"=\" * 62)\n",
+    "print()\n",
+    "print(\"Recherche sur les 5 premiers attributs :\")\n",
+    "rest5 = minimal_consistent_det(restaurant_data, RESTAURANT_ATTRS[:5], \"WillWait\")\n",
+    "print()\n",
+    "if rest5.determination is None:\n",
+    "    print(\"Aucune determination sur les 5 premiers attributs :\")\n",
+    "    print(\"le concept disjonctif n'est une fonction d'aucun de ces sous-ensembles.\")\n",
+    "print()\n",
+    "print(\"Recherche sur les 10 attributs :\")\n",
+    "rest10 = minimal_consistent_det(restaurant_data, RESTAURANT_ATTRS, \"WillWait\", verbose=False)\n",
+    "if rest10.determination:\n",
+    "    print(f\"  Determination 'trouvee' : {{{', '.join(rest10.determination)}}}\"\n",
+    "          f\" apres {rest10.subsets_tested} tests\")\n",
+    "print()\n",
+    "print(\"ATTENTION : cette determination est FALLACIEUSE (spurious).\")\n",
+    "print(\"Avec seulement 12 exemples et 10 attributs, de nombreux triplets\")\n",
+    "print(\"d'attributs separent les exemples par pur hasard, sans rapport avec\")\n",
+    "print(\"le vrai concept (qui depend de Patrons et Hungry).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03c12410",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003003,
+     "end_time": "2026-06-10T08:20:23.021204",
+     "exception": false,
+     "start_time": "2026-06-10T08:20:23.018201",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : echec et determination fallacieuse\n",
+    "\n",
+    "| Recherche | Resultat | Lecture |\n",
+    "|-----------|----------|--------|\n",
+    "| 5 premiers attributs (31 tests) | Aucune determination | Le concept `WillWait` est disjonctif (`Patrons=Some OU (Patrons=Full ET Hungry=Yes)`) : ce n'est une fonction d'aucun petit sous-ensemble de ces attributs |\n",
+    "| 10 attributs (66 tests) | `{Alternate, Fri/Sat, Price}` | Determination **fallacieuse** : 29 triplets distincts \"determinent\" la cible sur ce petit echantillon, par pure coincidence |\n",
+    "\n",
+    "> **Point cle** : une determination n'a de valeur que si l'echantillon est assez grand pour la contraindre. Sur 12 exemples, beaucoup de triplets d'attributs separent les exemples par coincidence --- c'est l'analogue logique du **sur-apprentissage**. La comparaison statistique de la section 5 ci-dessous (information mutuelle, sklearn) aide precisement a detecter ce piege : les attributs d'une determination fallacieuse ont des scores MI faibles.\n",
+    "\n",
+    "> **Deux lecons** : (1) l'absence de determination signale un concept disjonctif ou bruite --- il faut alors passer aux arbres de decision ou a l'ILP ([SL-4](SL-4-InductiveLogicProgramming.ipynb)) ; (2) la presence d'une determination sur un petit echantillon ne prouve rien --- il faut la valider statistiquement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "72861666",
    "metadata": {
     "papermill": {
-     "duration": 0.006786,
-     "end_time": "2026-06-06T20:57:30.384776",
+     "duration": 0.003,
+     "end_time": "2026-06-10T08:20:23.027204",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.377990",
+     "start_time": "2026-06-10T08:20:23.024204",
      "status": "completed"
     },
     "tags": []
@@ -821,20 +957,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "8352f3b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:30.397918Z",
-     "iopub.status.busy": "2026-06-06T20:57:30.397570Z",
-     "iopub.status.idle": "2026-06-06T20:57:30.407788Z",
-     "shell.execute_reply": "2026-06-06T20:57:30.407006Z"
+     "iopub.execute_input": "2026-06-10T08:20:23.033206Z",
+     "iopub.status.busy": "2026-06-10T08:20:23.033206Z",
+     "iopub.status.idle": "2026-06-10T08:20:23.046209Z",
+     "shell.execute_reply": "2026-06-10T08:20:23.046209Z"
     },
     "papermill": {
-     "duration": 0.018475,
-     "end_time": "2026-06-06T20:57:30.409080",
+     "duration": 0.017005,
+     "end_time": "2026-06-10T08:20:23.047211",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.390605",
+     "start_time": "2026-06-10T08:20:23.030206",
      "status": "completed"
     },
     "tags": []
@@ -915,10 +1051,10 @@
    "id": "61cf237e",
    "metadata": {
     "papermill": {
-     "duration": 0.005338,
-     "end_time": "2026-06-06T20:57:30.419438",
+     "duration": 0.002999,
+     "end_time": "2026-06-10T08:20:23.052717",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.414100",
+     "start_time": "2026-06-10T08:20:23.049718",
      "status": "completed"
     },
     "tags": []
@@ -929,20 +1065,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "bad47a00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:30.432076Z",
-     "iopub.status.busy": "2026-06-06T20:57:30.431448Z",
-     "iopub.status.idle": "2026-06-06T20:57:30.439053Z",
-     "shell.execute_reply": "2026-06-06T20:57:30.438244Z"
+     "iopub.execute_input": "2026-06-10T08:20:23.059745Z",
+     "iopub.status.busy": "2026-06-10T08:20:23.059745Z",
+     "iopub.status.idle": "2026-06-10T08:20:23.077340Z",
+     "shell.execute_reply": "2026-06-10T08:20:23.077340Z"
     },
     "papermill": {
-     "duration": 0.016398,
-     "end_time": "2026-06-06T20:57:30.440792",
+     "duration": 0.022625,
+     "end_time": "2026-06-10T08:20:23.078342",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.424394",
+     "start_time": "2026-06-10T08:20:23.055717",
      "status": "completed"
     },
     "tags": []
@@ -994,10 +1130,10 @@
    "id": "3913ca3c",
    "metadata": {
     "papermill": {
-     "duration": 0.007175,
-     "end_time": "2026-06-06T20:57:30.452450",
+     "duration": 0.002495,
+     "end_time": "2026-06-10T08:20:23.083949",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.445275",
+     "start_time": "2026-06-10T08:20:23.081454",
      "status": "completed"
     },
     "tags": []
@@ -1012,20 +1148,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "7c8627eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:30.468121Z",
-     "iopub.status.busy": "2026-06-06T20:57:30.467498Z",
-     "iopub.status.idle": "2026-06-06T20:57:37.584482Z",
-     "shell.execute_reply": "2026-06-06T20:57:37.582947Z"
+     "iopub.execute_input": "2026-06-10T08:20:23.091337Z",
+     "iopub.status.busy": "2026-06-10T08:20:23.089872Z",
+     "iopub.status.idle": "2026-06-10T08:20:28.596906Z",
+     "shell.execute_reply": "2026-06-10T08:20:28.596305Z"
     },
     "papermill": {
-     "duration": 7.128417,
-     "end_time": "2026-06-06T20:57:37.586609",
+     "duration": 5.511028,
+     "end_time": "2026-06-10T08:20:28.597945",
      "exception": false,
-     "start_time": "2026-06-06T20:57:30.458192",
+     "start_time": "2026-06-10T08:20:23.086917",
      "status": "completed"
     },
     "tags": []
@@ -1040,12 +1176,12 @@
       "\n",
       "Attribut | Info. Mutuelle | Rang\n",
       "----------------------------------------\n",
-      "R2       |         2.6943 | #1 (RELEVANT)\n",
-      "R1       |         2.5523 | #2 (RELEVANT)\n",
-      "N6       |         0.3245 | #3 (noise)\n",
-      "N1       |         0.2953 | #4 (noise)\n",
-      "N3       |         0.1785 | #5 (noise)\n",
-      "N2       |         0.0000 | #6 (noise)\n",
+      "R2       |         2.5861 | #1 (RELEVANT)\n",
+      "R1       |         2.3647 | #2 (RELEVANT)\n",
+      "N2       |         0.3651 | #3 (noise)\n",
+      "N3       |         0.3294 | #4 (noise)\n",
+      "N6       |         0.2749 | #5 (noise)\n",
+      "N1       |         0.2068 | #6 (noise)\n",
       "N4       |         0.0000 | #7 (noise)\n",
       "N5       |         0.0000 | #8 (noise)\n",
       "N7       |         0.0000 | #9 (noise)\n",
@@ -1101,10 +1237,10 @@
    "id": "cf88517c",
    "metadata": {
     "papermill": {
-     "duration": 0.007663,
-     "end_time": "2026-06-06T20:57:37.601391",
+     "duration": 0.004147,
+     "end_time": "2026-06-10T08:20:28.606228",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.593728",
+     "start_time": "2026-06-10T08:20:28.602081",
      "status": "completed"
     },
     "tags": []
@@ -1132,20 +1268,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "ffe3e3fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:37.619715Z",
-     "iopub.status.busy": "2026-06-06T20:57:37.618967Z",
-     "iopub.status.idle": "2026-06-06T20:57:37.635657Z",
-     "shell.execute_reply": "2026-06-06T20:57:37.634133Z"
+     "iopub.execute_input": "2026-06-10T08:20:28.616221Z",
+     "iopub.status.busy": "2026-06-10T08:20:28.615694Z",
+     "iopub.status.idle": "2026-06-10T08:20:28.627747Z",
+     "shell.execute_reply": "2026-06-10T08:20:28.627146Z"
     },
     "papermill": {
-     "duration": 0.028318,
-     "end_time": "2026-06-06T20:57:37.637907",
+     "duration": 0.018403,
+     "end_time": "2026-06-10T08:20:28.628788",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.609589",
+     "start_time": "2026-06-10T08:20:28.610385",
      "status": "completed"
     },
     "tags": []
@@ -1212,10 +1348,10 @@
    "id": "79de4eaf",
    "metadata": {
     "papermill": {
-     "duration": 0.007279,
-     "end_time": "2026-06-06T20:57:37.652100",
+     "duration": 0.004729,
+     "end_time": "2026-06-10T08:20:28.638918",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.644821",
+     "start_time": "2026-06-10T08:20:28.634189",
      "status": "completed"
     },
     "tags": []
@@ -1238,10 +1374,10 @@
    "id": "6d1d952f",
    "metadata": {
     "papermill": {
-     "duration": 0.007295,
-     "end_time": "2026-06-06T20:57:37.667264",
+     "duration": 0.005291,
+     "end_time": "2026-06-10T08:20:28.649981",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.659969",
+     "start_time": "2026-06-10T08:20:28.644690",
      "status": "completed"
     },
     "tags": []
@@ -1266,20 +1402,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "7c4e0e96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:37.683806Z",
-     "iopub.status.busy": "2026-06-06T20:57:37.683068Z",
-     "iopub.status.idle": "2026-06-06T20:57:37.691888Z",
-     "shell.execute_reply": "2026-06-06T20:57:37.690169Z"
+     "iopub.execute_input": "2026-06-10T08:20:28.662682Z",
+     "iopub.status.busy": "2026-06-10T08:20:28.662682Z",
+     "iopub.status.idle": "2026-06-10T08:20:28.674411Z",
+     "shell.execute_reply": "2026-06-10T08:20:28.673869Z"
     },
     "papermill": {
-     "duration": 0.020445,
-     "end_time": "2026-06-06T20:57:37.694610",
+     "duration": 0.018842,
+     "end_time": "2026-06-10T08:20:28.674411",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.674165",
+     "start_time": "2026-06-10T08:20:28.655569",
      "status": "completed"
     },
     "tags": []
@@ -1340,10 +1476,10 @@
    "id": "b2ed3f33",
    "metadata": {
     "papermill": {
-     "duration": 0.006338,
-     "end_time": "2026-06-06T20:57:37.707302",
+     "duration": 0.004047,
+     "end_time": "2026-06-10T08:20:28.684008",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.700964",
+     "start_time": "2026-06-10T08:20:28.679961",
      "status": "completed"
     },
     "tags": []
@@ -1365,20 +1501,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "5f23755b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:37.726829Z",
-     "iopub.status.busy": "2026-06-06T20:57:37.726143Z",
-     "iopub.status.idle": "2026-06-06T20:57:37.739068Z",
-     "shell.execute_reply": "2026-06-06T20:57:37.736907Z"
+     "iopub.execute_input": "2026-06-10T08:20:28.694258Z",
+     "iopub.status.busy": "2026-06-10T08:20:28.694258Z",
+     "iopub.status.idle": "2026-06-10T08:20:28.706278Z",
+     "shell.execute_reply": "2026-06-10T08:20:28.705272Z"
     },
     "papermill": {
-     "duration": 0.025828,
-     "end_time": "2026-06-06T20:57:37.741559",
+     "duration": 0.019394,
+     "end_time": "2026-06-10T08:20:28.707279",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.715731",
+     "start_time": "2026-06-10T08:20:28.687885",
      "status": "completed"
     },
     "tags": []
@@ -1429,10 +1565,10 @@
    "id": "68e70655",
    "metadata": {
     "papermill": {
-     "duration": 0.00736,
-     "end_time": "2026-06-06T20:57:37.757715",
+     "duration": 0.003001,
+     "end_time": "2026-06-10T08:20:28.713279",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.750355",
+     "start_time": "2026-06-10T08:20:28.710278",
      "status": "completed"
     },
     "tags": []
@@ -1443,20 +1579,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "cc196778",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:37.777689Z",
-     "iopub.status.busy": "2026-06-06T20:57:37.776774Z",
-     "iopub.status.idle": "2026-06-06T20:57:37.785537Z",
-     "shell.execute_reply": "2026-06-06T20:57:37.784068Z"
+     "iopub.execute_input": "2026-06-10T08:20:28.721361Z",
+     "iopub.status.busy": "2026-06-10T08:20:28.721361Z",
+     "iopub.status.idle": "2026-06-10T08:20:28.737526Z",
+     "shell.execute_reply": "2026-06-10T08:20:28.736366Z"
     },
     "papermill": {
-     "duration": 0.021174,
-     "end_time": "2026-06-06T20:57:37.787701",
+     "duration": 0.02024,
+     "end_time": "2026-06-10T08:20:28.737526",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.766527",
+     "start_time": "2026-06-10T08:20:28.717286",
      "status": "completed"
     },
     "tags": []
@@ -1493,10 +1629,10 @@
    "id": "ba0bdbc2",
    "metadata": {
     "papermill": {
-     "duration": 0.005222,
-     "end_time": "2026-06-06T20:57:37.798500",
+     "duration": 0.002999,
+     "end_time": "2026-06-10T08:20:28.744526",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.793278",
+     "start_time": "2026-06-10T08:20:28.741527",
      "status": "completed"
     },
     "tags": []
@@ -1507,20 +1643,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "8072ef89",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T20:57:37.811948Z",
-     "iopub.status.busy": "2026-06-06T20:57:37.811313Z",
-     "iopub.status.idle": "2026-06-06T20:57:37.818509Z",
-     "shell.execute_reply": "2026-06-06T20:57:37.817147Z"
+     "iopub.execute_input": "2026-06-10T08:20:28.752527Z",
+     "iopub.status.busy": "2026-06-10T08:20:28.752527Z",
+     "iopub.status.idle": "2026-06-10T08:20:28.768173Z",
+     "shell.execute_reply": "2026-06-10T08:20:28.767056Z"
     },
     "papermill": {
-     "duration": 0.015465,
-     "end_time": "2026-06-06T20:57:37.820281",
+     "duration": 0.020178,
+     "end_time": "2026-06-10T08:20:28.768704",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.804816",
+     "start_time": "2026-06-10T08:20:28.748526",
      "status": "completed"
     },
     "tags": []
@@ -1581,10 +1717,10 @@
    "id": "5eba2e20",
    "metadata": {
     "papermill": {
-     "duration": 0.005026,
-     "end_time": "2026-06-06T20:57:37.830981",
+     "duration": 0.00264,
+     "end_time": "2026-06-10T08:20:28.775020",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.825955",
+     "start_time": "2026-06-10T08:20:28.772380",
      "status": "completed"
     },
     "tags": []
@@ -1623,10 +1759,10 @@
    "id": "730925ce",
    "metadata": {
     "papermill": {
-     "duration": 0.004932,
-     "end_time": "2026-06-06T20:57:37.841118",
+     "duration": 0.003487,
+     "end_time": "2026-06-10T08:20:28.781972",
      "exception": false,
-     "start_time": "2026-06-06T20:57:37.836186",
+     "start_time": "2026-06-10T08:20:28.778485",
      "status": "completed"
     },
     "tags": []
@@ -1663,18 +1799,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 11.106369,
-   "end_time": "2026-06-06T20:57:38.407820",
+   "duration": 7.379403,
+   "end_time": "2026-06-10T08:20:29.032909",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb",
-   "output_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb",
+   "input_path": "SL-3-RelevanceLearning.ipynb",
+   "output_path": "SL-3-RelevanceLearning.ipynb",
    "parameters": {},
-   "start_time": "2026-06-06T20:57:27.301451",
+   "start_time": "2026-06-10T08:20:21.653506",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
@@ -1651,7 +1651,7 @@
     "tags": []
    },
    "source": [
-    "L'exercice suivant s'appuie sur les operateurs V et W pour decouvrir des regles ILP sur un domaine libre."
+    "L'exercice suivant fait le pont avec les Knowledge Graphs (approfondis dans SL-6) : vous verifierez des regles ILP sur un mini-graphe de triples."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
@@ -51,8 +51,6 @@
     "tags": []
    },
    "source": [
-    "# Integration Neuro-Symbolique\n",
-    "\n",
     "L'integration neuro-symbolique combine les **reseaux de neurones** (apprentissage a partir de donnees) avec le **raisonnement symbolique** (logique, regles). L'objectif est d'obtenir le meilleur des deux mondes.\n",
     "\n",
     "## 1. Pourquoi combiner neural et symbolique ?\n",
@@ -941,7 +939,7 @@
    "source": [
     "### Exercice 2 : Entrainement LTN sur un nouveau domaine\n",
     "\n",
-    "Entraenez un predicat neuronal `frere(X,Y)` sur des faits positifs et negatifs, puis utilisez la regle `frere(X,Y) AND parent(Y,Z) => oncle(X,Z)` pour apprendre `oncle`."
+    "Entrainez un predicat neuronal `frere(X,Y)` sur des faits positifs et negatifs, puis utilisez la regle `frere(X,Y) AND parent(Y,Z) => oncle(X,Z)` pour apprendre `oncle`."
    ]
   },
   {
@@ -1163,29 +1161,6 @@
     "tags": []
    },
    "source": [
-    "## Resume et perspectives\n",
-    "\n",
-    "Ce notebook a explore l'integration neuro-symbolique, qui vise a combiner les forces complementaires des reseaux de neurones (apprentissage a partir de donnees, tolerance au bruit) et du raisonnement symbolique (garanties formelles, interpretabilite). Les operateurs logiques differentiables (t-norms) transforment les connecteurs binaires AND, OR, NOT en fonctions continues derivables sur [0, 1], permettant leur integration dans des graphes de calcul optimisables par descente de gradient. Les predicats neuronaux implementent des fonctions P(x) -> [0, 1] via des reseaux de neurones, et la Logique Tensorielle (LTN) combine ces predicats avec une semantique logique pour entrainer des modeles guidees par des regles.\n",
-    "\n",
-    "L'implementation du raisonnement guide par regle a illustre un resultat remarquable : le predicat `grandparent` a ete appris sans aucun exemple direct de grand-parent, uniquement a partir de la regle logique `parent(X,Y) AND parent(Y,Z) => grandparent(X,Z)`. Le systeme DeepProbLog simplifie a ensuite unifie la programmation logique probabiliste et les predicats neuronaux, permettant de resoudre des requetes par chainage arriere. L'exemple guide de l'operateur OR parametrique a demontre comment un parametre de combinaison convexe (alpha) peut etre appris pour choisir automatiquement entre la semantique de Godel (max) et la semantique probabiliste (a+b-a*b).\n",
-    "\n",
-    "L'integration neuro-symbolique reste un domaine de recherche actif. Les approches LTN, Neural Theorem Prover et DeepProbLog chacune proposent des compromis differents entre expressivite logique, passage a l'echelle et facilite d'entrainement. Le notebook suivant, [SL-6 - Knowledge Graphs et ILP](SL-6-KnowledgeGraphs-ILP.ipynb), aborde une autre dimension de l'apprentissage symbolique moderne : le minage de regles dans les Knowledge Graphs, ou les triples RDF remplacent les faits logiques traditionnels et l'echelle atteint des milliards de donnees."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "afb393b9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.009084,
-     "end_time": "2026-06-06T21:01:23.184750",
-     "exception": false,
-     "start_time": "2026-06-06T21:01:23.175666",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
     "---\n",
     "\n",
     "## 8. Resume\n",
@@ -1204,7 +1179,30 @@
     "- La logique differentiable transforme les connecteurs binaires en fonctions continues derivables\n",
     "- Les predicats neuronaux peuvent etre combines avec des regles logiques\n",
     "- L'entrainement peut etre guide par la connaissance logique, meme sans donnees etiquetees\n",
-    "- DeepProbLog unifie programmation logique et reseaux de neurones\n",
+    "- DeepProbLog unifie programmation logique et reseaux de neurones\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afb393b9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009084,
+     "end_time": "2026-06-06T21:01:23.184750",
+     "exception": false,
+     "start_time": "2026-06-06T21:01:23.175666",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Perspectives\n",
+    "\n",
+    "Ce notebook a explore l'integration neuro-symbolique, qui vise a combiner les forces complementaires des reseaux de neurones (apprentissage a partir de donnees, tolerance au bruit) et du raisonnement symbolique (garanties formelles, interpretabilite). Les operateurs logiques differentiables (t-norms) transforment les connecteurs binaires AND, OR, NOT en fonctions continues derivables sur [0, 1], permettant leur integration dans des graphes de calcul optimisables par descente de gradient. Les predicats neuronaux implementent des fonctions P(x) -> [0, 1] via des reseaux de neurones, et la Logique Tensorielle (LTN) combine ces predicats avec une semantique logique pour entrainer des modeles guidees par des regles.\n",
+    "\n",
+    "L'implementation du raisonnement guide par regle a illustre un resultat remarquable : le predicat `grandparent` a ete appris sans aucun exemple direct de grand-parent, uniquement a partir de la regle logique `parent(X,Y) AND parent(Y,Z) => grandparent(X,Z)`. Le systeme DeepProbLog simplifie a ensuite unifie la programmation logique probabiliste et les predicats neuronaux, permettant de resoudre des requetes par chainage arriere. L'exemple guide de l'operateur OR parametrique a demontre comment un parametre de combinaison convexe (alpha) peut etre appris pour choisir automatiquement entre la semantique de Godel (max) et la semantique probabiliste (a+b-a*b).\n",
+    "\n",
+    "L'integration neuro-symbolique reste un domaine de recherche actif. Les approches LTN, Neural Theorem Prover et DeepProbLog chacune proposent des compromis differents entre expressivite logique, passage a l'echelle et facilite d'entrainement. Le notebook suivant, [SL-6 - Knowledge Graphs et ILP](SL-6-KnowledgeGraphs-ILP.ipynb), aborde une autre dimension de l'apprentissage symbolique moderne : le minage de regles dans les Knowledge Graphs, ou les triples RDF remplacent les faits logiques traditionnels et l'echelle atteint des milliards de donnees.\n",
     "\n",
     "---\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
@@ -1909,29 +1909,6 @@
     "tags": []
    },
    "source": [
-    "## Resume et perspectives\n",
-    "\n",
-    "Ce notebook a explore l'intersection entre la Programmation Logique Inductive (ILP) et les Knowledge Graphs, en montrant comment les techniques de minage de regles d'association s'adaptent aux donnees du Web Semantique. La construction d'un Knowledge Graph familial avec rdflib a illustre la correspondance naturelle entre triples RDF `(sujet, predicat, objet)` et faits logiques `predicat(sujet, objet)`. L'algorithme de rule mining inspire d'AMIE3 a decouvert automatiquement des regles de Horn dans ce graphe, notamment la regle compositionnelle `parentOf(X,Y) ^ parentOf(Y,Z) => grandparentOf(X,Z)` avec une confiance de 0.36 et une PCA confiance de 0.62.\n",
-    "\n",
-    "La distinction entre confiance standard et PCA confiance est centrale dans le contexte des Knowledge Graphs. L'Open World Assumption (OWA) signifie que l'absence d'un triple ne signifie pas que le fait est faux -- il est simplement inconnu. La PCA confiance corrige partiellement cette limitation en excluant du denominateur les paires dont le sujet n'a aucun triple de tete connu. L'application pratique des regles decouvertes a permis de completer le graphe en inferant 2 nouveaux triples `grandparentOf` manquants, passant de 5 a 7 triples sur les 8 possibles.\n",
-    "\n",
-    "Les proprietes logiques detectees automatiquement (symetrie de `siblingOf` et `marriedTo`, composition `parentOf ^ parentOf => grandparentOf`) correspondent aux proprietes OWL declarees manuellement dans les ontologies formelles. Le rule mining les apprend directement des donnees, offrant une alternative scalable a la modelisation ontologique manuelle. Le notebook suivant, [SL-7 - LLM + Symbolic Learning](SL-7-LLM-SymbolicLearning.ipynb), prolonge cette reflexion en explorant comment les grands modeles de langage peuvent generer et valider des regles symboliques, ouvrant la voie a une cooperation entre approches statistiques a grande echelle et raisonnement formel."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c4b6e83b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.010362,
-     "end_time": "2026-06-06T21:02:57.145190",
-     "exception": false,
-     "start_time": "2026-06-06T21:02:57.134828",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
     "---\n",
     "\n",
     "## 11. Resume\n",
@@ -1965,11 +1942,30 @@
     "| **SemanticWeb (SW)** | rdflib, SPARQL, OWL, RDFS -- les KG sont le coeur du Web Semantique |\n",
     "| **Tweety** | Logique propositionnelle et FOL -- fondement des regles de Horn |\n",
     "| **SL-4 (ILP)** | FOIL, resolution inverse -- les regles de Horn sont les memes |\n",
-    "| **SL-5 (NeuroSymbolic)** | Embeddings (TransE) + regles -- combinaison neuronal/symbolique |\n",
+    "| **SL-5 (NeuroSymbolic)** | Embeddings (TransE) + regles -- combinaison neuronal/symbolique |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4b6e83b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010362,
+     "end_time": "2026-06-06T21:02:57.145190",
+     "exception": false,
+     "start_time": "2026-06-06T21:02:57.134828",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Perspectives\n",
     "\n",
-    "### Prochaines etapes\n",
+    "Ce notebook a explore l'intersection entre la Programmation Logique Inductive (ILP) et les Knowledge Graphs, en montrant comment les techniques de minage de regles d'association s'adaptent aux donnees du Web Semantique. La construction d'un Knowledge Graph familial avec rdflib a illustre la correspondance naturelle entre triples RDF `(sujet, predicat, objet)` et faits logiques `predicat(sujet, objet)`. L'algorithme de rule mining inspire d'AMIE3 a decouvert automatiquement des regles de Horn dans ce graphe, notamment la regle compositionnelle `parentOf(X,Y) ^ parentOf(Y,Z) => grandparentOf(X,Z)` avec une confiance de 0.36 et une PCA confiance de 0.62.\n",
     "\n",
-    "Dans le notebook suivant **SL-7 - LLM + Symbolic Learning**, nous decouvrirons comment les grands modeles de langage (LLM) peuvent completer l'apprentissage symbolique pour la generation de regles et le raisonnement."
+    "La distinction entre confiance standard et PCA confiance est centrale dans le contexte des Knowledge Graphs. L'Open World Assumption (OWA) signifie que l'absence d'un triple ne signifie pas que le fait est faux -- il est simplement inconnu. La PCA confiance corrige partiellement cette limitation en excluant du denominateur les paires dont le sujet n'a aucun triple de tete connu. L'application pratique des regles decouvertes a permis de completer le graphe en inferant 2 nouveaux triples `grandparentOf` manquants, passant de 5 a 7 triples sur les 8 possibles.\n",
+    "\n",
+    "Les proprietes logiques detectees automatiquement (symetrie de `siblingOf` et `marriedTo`, composition `parentOf ^ parentOf => grandparentOf`) correspondent aux proprietes OWL declarees manuellement dans les ontologies formelles. Le rule mining les apprend directement des donnees, offrant une alternative scalable a la modelisation ontologique manuelle. Le notebook suivant, [SL-7 - LLM + Symbolic Learning](SL-7-LLM-SymbolicLearning.ipynb), prolonge cette reflexion en explorant comment les grands modeles de langage peuvent generer et valider des regles symboliques, ouvrant la voie a une cooperation entre approches statistiques a grande echelle et raisonnement formel.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -1921,7 +1921,7 @@
     "Simulez un LLM qui genere des regles pour un nouveau domaine : la prediction de la qualite d'un film.\n",
     "\n",
     "**Etapes** :\n",
-    "1. Definir les attributs du domaine (genre, duree, budget, realisateur, acteur principal)\n",
+    "1. Definir les attributs du domaine (genre, duree, budget, critique)\n",
     "2. Creer 6 exemples (3 positifs, 3 negatifs)\n",
     "3. Generer 3 regles candidates (simulatees)\n",
     "4. Verifier chaque regle avec l'oracle symbolique"


### PR DESCRIPTION
## Summary

Deep review of the 7-notebook SymbolicLearning series ahead of the 2026-06-17 EPITA-IS course (new modality: student groups prepare TP exercises in advance and present in class). Both user-reported defects fixed + full-series pass.

### SL-1 — misplaced exercise (user-reported)
- The exercise *Apprentissage de regles avec couverture* had slipped **after the Ressources footer**. Repositioned as **Exercice 3** inside a new `## 9. Exercices` section (code exercises 1-3, then the Reflexion pair as Exercice 4, footer last again).
- Removed the *Prochaines etapes* block triple-duplicated across resume/perspectives/footer.

### SL-2 / SL-3 — RBL overlap (user-reported)
- **SL-2**: sections 8 (MINIMAL-CONSISTENT-DET) and 9 (PAC impact) duplicated SL-3 sections 3-5 -> removed, replaced by a bridge cell pointing to SL-3. Section 7 retitled *Introduction aux determinations*; objectives + duration (55->45 min) softened accordingly. Ex2 (RBL minimal determination — duplicate of SL-3 Ex1, and orphaned by the removal) replaced by a **new EBL exercise on rule pruning/operationality** extending section 6. Fixed wrong pointer *KBIL (couvert dans SL-3)* -> SL-4. Synthesis renumbered 10->8, nav link to SL-3 added.
- **SL-3**: new 3-cell **failure-case demo** — MINIMAL-CONSISTENT-DET on the disjunctive restaurant concept (SL-1 data): no determination on 5 attrs (31 tests), **spurious** determination `{Alternate, Fri/Sat, Price}` on all 10 attrs (66 tests; 29 spurious triplets exist) — the logical analogue of overfitting, tying into the MI/sklearn section. Fixed stale plan table + prerequisites.

### Series pass (markdown-only)
- **SL-4**: Ex3 transition described V/W operators while the exercise is a KG bridge -> fixed.
- **SL-5**: duplicate H1 removed; resume restructured (tables -> `### Perspectives` -> Ressources); typo *Entraenez*.
- **SL-6**: same resume restructure; redundant *Prochaines etapes* removed.
- **SL-7**: Ex1 markdown attribute list aligned with code (`genre, duree, budget, critique`).
- **README**: durations + SL-2/SL-3 detail tables updated (RBL = introduction in SL-2, full treatment in SL-3).

## Validation (H.1/C.2)

```
papermill (conda env mcp-jupyter, in place):
SL-2-KnowledgeBasedLearning.ipynb: 12 code cells, errors=0, exec_count_null=[]
SL-3-RelevanceLearning.ipynb:      14 code cells, errors=0, exec_count_null=[]
New SL-3 demo output: 'Aucune determination trouvee (31 tests)' /
"Determination 'trouvee' : {Alternate, Fri/Sat, Price} apres 66 tests"
```

- `grep -nE "raise NotImplementedError|assert False|1/0"` on the series: 0 hits; new Ex2 stub is C.1-compliant (`pass` + `# TODO etudiant` + prints).
- SL-1/4/5/6/7: markdown-only edits — committed outputs preserved (C.2 exception). SL-1's moved code cell is source-identical and keeps its output (exec 1-13 sequential, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
