### PR TITLE
fix(sl-1): fix guided-example/exercise reflection pairing (de-leak + placement)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -1853,13 +1853,13 @@
    "source": [
     "### Exemple guide : Reflexion corrigee (synthese)\n",
     "\n",
-    "Voici trois questions de synthese sur ce notebook, **avec leur correction**. Utilisez-les comme auto-evaluation : ne les lisez qu'**apres** avoir tente l'exercice ci-dessous.\n",
+    "Pour conclure, voici une demonstration de la demarche attendue sur trois questions de synthese, avec leur correction. Observez la structure des reponses : un **mecanisme precis** (pas une generalite), puis sa **consequence pratique**. L'exercice 4 ci-dessous vous propose trois questions du meme type --- mais distinctes --- a traiter de la meme maniere.\n",
     "\n",
     "| Question | Reponse |\n",
     "|----------|--------|\n",
-    "| Pourquoi CBH depend de l'ordre mais pas le Version Space ? | Le VS maintient TOUTES les hypotheses consistantes, pas une seule. L'ordre n'affecte que la vitesse de convergence, pas le resultat final. |\n",
-    "| Que se passe-t-il si le concept cible n'est pas representable par une conjonction ? | Le VS ne converge jamais. G et S restent separes, et certaines hypotheses entre les deux sont incorrectes. |\n",
-    "| Pourquoi le Version Space est-il fragile face au bruit ? | Un seul exemple contradictoire elimine TOUTES les hypotheses, vidant le VS. Pas de mecanisme de tolerance. |"
+    "| Pourquoi CBH depend de l'ordre des exemples, mais pas le Version Space ? | Le VS maintient TOUTES les hypotheses consistantes, pas une seule. L'ordre n'affecte que la vitesse de convergence, pas le resultat final. |\n",
+    "| Pourquoi la prediction par vote majoritaire (section 6) peut-elle etre utile alors meme que le Version Space n'a pas converge ? | Chaque hypothese consistante \"vote\" sur le nouvel exemple : si une large majorite predit la meme classe, la prediction est fiable sans attendre la convergence. Seuls les cas partages (vote proche de 50/50) doivent etre refuses ou renvoyes a l'acquisition de nouveaux exemples. |\n",
+    "| Pourquoi le Version Space est-il fragile face au bruit ? | Un seul exemple contradictoire elimine TOUTES les hypotheses, vidant le VS. Pas de mecanisme de tolerance. |\n"
    ]
   },
   {
@@ -1869,13 +1869,13 @@
    "source": [
     "### Exercice 4 : Reflexion\n",
     "\n",
-    "A votre tour. Repondez aux questions suivantes en vous appuyant sur les algorithmes implementes plus haut (CBH, Candidate Elimination). Ne consultez l'exemple guide corrige ci-dessus qu'**apres** avoir formule vos propres reponses.\n",
+    "A votre tour, sur le modele de l'exemple guide ci-dessus. Repondez aux questions suivantes en vous appuyant sur les algorithmes implementes plus haut (CBH, Candidate Elimination) : pour chaque reponse, identifiez le mecanisme en jeu, puis sa consequence pratique.\n",
     "\n",
     "| Question | Reponse |\n",
     "|----------|--------|\n",
     "| Donnez une sequence concrete d'exemples (positifs/negatifs) qui force CBH a backtracker, alors que le Version Space converge sans jamais revenir en arriere. | _(a completer)_ |\n",
     "| Un concept disjonctif comme \"animal = chien OU chat\" n'est pas capturable par une hypothese conjonctive unique. Pourquoi ? Que faudrait-il changer dans la representation des hypotheses pour le permettre ? | _(a completer)_ |\n",
-    "| La complexite memoire du Version Space est O(\\|G\\| + \\|S\\|). Decrivez un cas ou \\|G\\| ou \\|S\\| explose, et la consequence pratique sur l'apprentissage. | _(a completer)_ |"
+    "| La complexite memoire du Version Space est O(\\|G\\| + \\|S\\|). Decrivez un cas ou \\|G\\| ou \\|S\\| explose, et la consequence pratique sur l'apprentissage. | _(a completer)_ |\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

User-reported follow-up to #2753 on [SL-1](MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb): the *Exemple guide : Reflexion corrigee* / *Exercice 4 : Reflexion* pairing was a misfire:

1. **Contradictory placement**: the guide said « ne les lisez qu'apres avoir tente l'exercice ci-dessous » while sitting *above* the exercise — students read the corrections first by construction.
2. **Partial leak**: guide Q2 (« concept non representable par une conjonction ») near-duplicated Exercice 4 Q2 (« concept disjonctif pas capturable — pourquoi ? »), giving away the answer.

## Fix (markdown-only, 2 cells)

- Guide intro now **assumes its upstream position**: it demonstrates the expected answering method (precise mechanism + practical consequence) on three questions **distinct** from the exercise's.
- Guide Q2 replaced by a **majority-vote prediction** question (recycles section 6 `predict_vs`), removing the overlap.
- Exercice 4 intro reworded: « A votre tour, sur le modele de l'exemple guide ci-dessus... identifiez le mecanisme en jeu, puis sa consequence pratique. »

## Validation

- `git diff` = 2 markdown cells in 1 file, 0 code cell touched — committed outputs preserved (C.2 exception, exec 1-13 + 0 errors intact).
- Conforms to exercise-example-labeling: guided example (solutions, distinct questions) above, exercise stub below, no answer-key under its own statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)