### PR TITLE
fix(symbolic-learning): tour 2 - repair broken demos SL-5/SL-6 + deep pass SL-7 (course 17/06)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "6b0e8fee",
    "metadata": {
     "papermill": {
-     "duration": 0.004059,
-     "end_time": "2026-06-10T10:14:17.886241",
+     "duration": 0.006435,
+     "end_time": "2026-06-10T10:40:14.016634",
      "exception": false,
-     "start_time": "2026-06-10T10:14:17.882182",
+     "start_time": "2026-06-10T10:40:14.010199",
      "status": "completed"
     },
     "tags": []
@@ -44,10 +44,10 @@
    "id": "2b4d29e4",
    "metadata": {
     "papermill": {
-     "duration": 0.003063,
-     "end_time": "2026-06-10T10:14:17.893243",
+     "duration": 0.00562,
+     "end_time": "2026-06-10T10:40:14.029003",
      "exception": false,
-     "start_time": "2026-06-10T10:14:17.890180",
+     "start_time": "2026-06-10T10:40:14.023383",
      "status": "completed"
     },
     "tags": []
@@ -91,16 +91,16 @@
    "id": "dc85e1f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:17.900348Z",
-     "iopub.status.busy": "2026-06-10T10:14:17.900348Z",
-     "iopub.status.idle": "2026-06-10T10:14:17.913566Z",
-     "shell.execute_reply": "2026-06-10T10:14:17.912982Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.042129Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.042129Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.056545Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.055728Z"
     },
     "papermill": {
-     "duration": 0.019053,
-     "end_time": "2026-06-10T10:14:17.914802",
+     "duration": 0.022799,
+     "end_time": "2026-06-10T10:40:14.057604",
      "exception": false,
-     "start_time": "2026-06-10T10:14:17.895749",
+     "start_time": "2026-06-10T10:40:14.034805",
      "status": "completed"
     },
     "tags": []
@@ -143,7 +143,11 @@
     "    \"WaitEstimate\": [\"0-10\", \"10-30\", \"30-60\", \">60\"],\n",
     "}\n",
     "\n",
-    "# Les 12 exemples du restaurant (AIMA Table 19.1)\n",
+    "# Les 12 exemples du restaurant, adaptes de la Table 19.1 d'AIMA.\n",
+    "# Attention : les labels de X2 et X3 sont inverses par rapport au livre (et le\n",
+    "# WaitEstimate de X9 differe). Consequence pedagogique assumee : aucune clause\n",
+    "# conjonctive unique n'est consistante avec les 12 exemples, ce qui provoque\n",
+    "# l'effondrement du Version Space observe en section 5.\n",
     "RAW_EXAMPLES = [\n",
     "    # (Alternate, Bar, Fri/Sat, Hungry, Patrons, Price, Raining, Reservation, Type, WaitEstimate, WillWait)\n",
     "    (\"Yes\", \"No\",  \"No\",  \"Yes\", \"Some\", \"$$$\", \"No\",  \"Yes\",  \"French\", \"0-10\",  True),\n",
@@ -178,10 +182,10 @@
    "id": "62d393f1",
    "metadata": {
     "papermill": {
-     "duration": 0.004354,
-     "end_time": "2026-06-10T10:14:17.925423",
+     "duration": 0.004193,
+     "end_time": "2026-06-10T10:40:14.065484",
      "exception": false,
-     "start_time": "2026-06-10T10:14:17.921069",
+     "start_time": "2026-06-10T10:40:14.061291",
      "status": "completed"
     },
     "tags": []
@@ -205,10 +209,10 @@
    "id": "ee8b228d",
    "metadata": {
     "papermill": {
-     "duration": 0.0063,
-     "end_time": "2026-06-10T10:14:17.936272",
+     "duration": 0.003721,
+     "end_time": "2026-06-10T10:40:14.072830",
      "exception": false,
-     "start_time": "2026-06-10T10:14:17.929972",
+     "start_time": "2026-06-10T10:40:14.069109",
      "status": "completed"
     },
     "tags": []
@@ -236,16 +240,16 @@
    "id": "4b2b04b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:17.948729Z",
-     "iopub.status.busy": "2026-06-10T10:14:17.948225Z",
-     "iopub.status.idle": "2026-06-10T10:14:17.959763Z",
-     "shell.execute_reply": "2026-06-10T10:14:17.958762Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.081339Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.080338Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.102360Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.101222Z"
     },
     "papermill": {
-     "duration": 0.019274,
-     "end_time": "2026-06-10T10:14:17.960762",
+     "duration": 0.026274,
+     "end_time": "2026-06-10T10:40:14.102885",
      "exception": false,
-     "start_time": "2026-06-10T10:14:17.941488",
+     "start_time": "2026-06-10T10:40:14.076611",
      "status": "completed"
     },
     "tags": []
@@ -329,10 +333,10 @@
    "id": "3fcf13d2",
    "metadata": {
     "papermill": {
-     "duration": 0.00605,
-     "end_time": "2026-06-10T10:14:17.971827",
+     "duration": 0.003136,
+     "end_time": "2026-06-10T10:40:14.110170",
      "exception": false,
-     "start_time": "2026-06-10T10:14:17.965777",
+     "start_time": "2026-06-10T10:40:14.107034",
      "status": "completed"
     },
     "tags": []
@@ -356,10 +360,10 @@
    "id": "3fb92770",
    "metadata": {
     "papermill": {
-     "duration": 0.004507,
-     "end_time": "2026-06-10T10:14:17.982421",
+     "duration": 0.003786,
+     "end_time": "2026-06-10T10:40:14.117219",
      "exception": false,
-     "start_time": "2026-06-10T10:14:17.977914",
+     "start_time": "2026-06-10T10:40:14.113433",
      "status": "completed"
     },
     "tags": []
@@ -393,16 +397,16 @@
    "id": "e4d6947a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:17.995472Z",
-     "iopub.status.busy": "2026-06-10T10:14:17.995472Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.006512Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.006512Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.126090Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.125570Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.148466Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.147304Z"
     },
     "papermill": {
-     "duration": 0.019565,
-     "end_time": "2026-06-10T10:14:18.007516",
+     "duration": 0.028646,
+     "end_time": "2026-06-10T10:40:14.149516",
      "exception": false,
-     "start_time": "2026-06-10T10:14:17.987951",
+     "start_time": "2026-06-10T10:40:14.120870",
      "status": "completed"
     },
     "tags": []
@@ -503,10 +507,10 @@
    "id": "b1a2400b",
    "metadata": {
     "papermill": {
-     "duration": 0.006021,
-     "end_time": "2026-06-10T10:14:18.019561",
+     "duration": 0.006258,
+     "end_time": "2026-06-10T10:40:14.162063",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.013540",
+     "start_time": "2026-06-10T10:40:14.155805",
      "status": "completed"
     },
     "tags": []
@@ -532,10 +536,10 @@
    "id": "77fbb6ab",
    "metadata": {
     "papermill": {
-     "duration": 0.006022,
-     "end_time": "2026-06-10T10:14:18.032120",
+     "duration": 0.003655,
+     "end_time": "2026-06-10T10:40:14.171741",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.026098",
+     "start_time": "2026-06-10T10:40:14.168086",
      "status": "completed"
     },
     "tags": []
@@ -579,16 +583,16 @@
    "id": "ebd916fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.046172Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.045670Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.054199Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.054199Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.180545Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.180030Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.196347Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.195327Z"
     },
     "papermill": {
-     "duration": 0.017064,
-     "end_time": "2026-06-10T10:14:18.055204",
+     "duration": 0.021697,
+     "end_time": "2026-06-10T10:40:14.197352",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.038140",
+     "start_time": "2026-06-10T10:40:14.175655",
      "status": "completed"
     },
     "tags": []
@@ -705,10 +709,10 @@
    "id": "462c713b",
    "metadata": {
     "papermill": {
-     "duration": 0.006142,
-     "end_time": "2026-06-10T10:14:18.067607",
+     "duration": 0.005554,
+     "end_time": "2026-06-10T10:40:14.209453",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.061465",
+     "start_time": "2026-06-10T10:40:14.203899",
      "status": "completed"
     },
     "tags": []
@@ -737,10 +741,10 @@
    "id": "22c65a7f",
    "metadata": {
     "papermill": {
-     "duration": 0.005048,
-     "end_time": "2026-06-10T10:14:18.078344",
+     "duration": 0.003655,
+     "end_time": "2026-06-10T10:40:14.220371",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.073296",
+     "start_time": "2026-06-10T10:40:14.216716",
      "status": "completed"
     },
     "tags": []
@@ -785,16 +789,16 @@
    "id": "cf277e5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.091915Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.091915Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.116690Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.115635Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.231162Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.230651Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.241952Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.241952Z"
     },
     "papermill": {
-     "duration": 0.03384,
-     "end_time": "2026-06-10T10:14:18.117710",
+     "duration": 0.018035,
+     "end_time": "2026-06-10T10:40:14.241952",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.083870",
+     "start_time": "2026-06-10T10:40:14.223917",
      "status": "completed"
     },
     "tags": []
@@ -951,10 +955,10 @@
    "id": "98b8d953",
    "metadata": {
     "papermill": {
-     "duration": 0.006588,
-     "end_time": "2026-06-10T10:14:18.130002",
+     "duration": 0.00649,
+     "end_time": "2026-06-10T10:40:14.255920",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.123414",
+     "start_time": "2026-06-10T10:40:14.249430",
      "status": "completed"
     },
     "tags": []
@@ -991,10 +995,10 @@
    "id": "e4ab2892",
    "metadata": {
     "papermill": {
-     "duration": 0.005977,
-     "end_time": "2026-06-10T10:14:18.141642",
+     "duration": 0.006048,
+     "end_time": "2026-06-10T10:40:14.267872",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.135665",
+     "start_time": "2026-06-10T10:40:14.261824",
      "status": "completed"
     },
     "tags": []
@@ -1023,16 +1027,16 @@
    "id": "e5d20a7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.154647Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.154138Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.178389Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.177808Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.280491Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.280491Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.304979Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.303853Z"
     },
     "papermill": {
-     "duration": 0.031997,
-     "end_time": "2026-06-10T10:14:18.179397",
+     "duration": 0.032656,
+     "end_time": "2026-06-10T10:40:14.306048",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.147400",
+     "start_time": "2026-06-10T10:40:14.273392",
      "status": "completed"
     },
     "tags": []
@@ -1181,10 +1185,10 @@
    "id": "15fc8c86",
    "metadata": {
     "papermill": {
-     "duration": 0.006018,
-     "end_time": "2026-06-10T10:14:18.191440",
+     "duration": 0.00621,
+     "end_time": "2026-06-10T10:40:14.316416",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.185422",
+     "start_time": "2026-06-10T10:40:14.310206",
      "status": "completed"
     },
     "tags": []
@@ -1211,10 +1215,10 @@
    "id": "ccca7f32",
    "metadata": {
     "papermill": {
-     "duration": 0.00601,
-     "end_time": "2026-06-10T10:14:18.202976",
+     "duration": 0.007511,
+     "end_time": "2026-06-10T10:40:14.329056",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.196966",
+     "start_time": "2026-06-10T10:40:14.321545",
      "status": "completed"
     },
     "tags": []
@@ -1233,16 +1237,16 @@
    "id": "c68c743e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.215513Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.215513Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.240584Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.239578Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.342398Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.342398Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.366401Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.366401Z"
     },
     "papermill": {
-     "duration": 0.033095,
-     "end_time": "2026-06-10T10:14:18.241582",
+     "duration": 0.032996,
+     "end_time": "2026-06-10T10:40:14.367642",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.208487",
+     "start_time": "2026-06-10T10:40:14.334646",
      "status": "completed"
     },
     "tags": []
@@ -1380,10 +1384,10 @@
    "id": "de22cbc0",
    "metadata": {
     "papermill": {
-     "duration": 0.006033,
-     "end_time": "2026-06-10T10:14:18.252323",
+     "duration": 0.005589,
+     "end_time": "2026-06-10T10:40:14.380299",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.246290",
+     "start_time": "2026-06-10T10:40:14.374710",
      "status": "completed"
     },
     "tags": []
@@ -1410,10 +1414,10 @@
    "id": "f98934d2",
    "metadata": {
     "papermill": {
-     "duration": 0.006532,
-     "end_time": "2026-06-10T10:14:18.264882",
+     "duration": 0.003553,
+     "end_time": "2026-06-10T10:40:14.388622",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.258350",
+     "start_time": "2026-06-10T10:40:14.385069",
      "status": "completed"
     },
     "tags": []
@@ -1436,16 +1440,16 @@
    "id": "0ff352e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.279039Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.279039Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.288583Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.287578Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.397538Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.397538Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.413739Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.412731Z"
     },
     "papermill": {
-     "duration": 0.019681,
-     "end_time": "2026-06-10T10:14:18.289582",
+     "duration": 0.022108,
+     "end_time": "2026-06-10T10:40:14.414737",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.269901",
+     "start_time": "2026-06-10T10:40:14.392629",
      "status": "completed"
     },
     "tags": []
@@ -1455,14 +1459,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exemple bruite ajoute : WillWait=False (inverse)"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "Exemple bruite ajoute : WillWait=False (inverse)\n",
       "Patrons=Some, Type=French, Price=$$$\n",
       "\n",
       "RESULTAT : Version Space VIDE !\n",
@@ -1498,10 +1495,10 @@
    "id": "ce6eb73f",
    "metadata": {
     "papermill": {
-     "duration": 0.006522,
-     "end_time": "2026-06-10T10:14:18.302633",
+     "duration": 0.004015,
+     "end_time": "2026-06-10T10:40:14.423329",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.296111",
+     "start_time": "2026-06-10T10:40:14.419314",
      "status": "completed"
     },
     "tags": []
@@ -1518,16 +1515,16 @@
    "id": "ad095fa3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.316702Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.316702Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.334746Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.334242Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.432012Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.431013Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.444726Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.443972Z"
     },
     "papermill": {
-     "duration": 0.0276,
-     "end_time": "2026-06-10T10:14:18.336255",
+     "duration": 0.018883,
+     "end_time": "2026-06-10T10:40:14.445731",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.308655",
+     "start_time": "2026-06-10T10:40:14.426848",
      "status": "completed"
     },
     "tags": []
@@ -1590,10 +1587,10 @@
    "id": "0ec254c5",
    "metadata": {
     "papermill": {
-     "duration": 0.006017,
-     "end_time": "2026-06-10T10:14:18.349301",
+     "duration": 0.003007,
+     "end_time": "2026-06-10T10:40:14.452754",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.343284",
+     "start_time": "2026-06-10T10:40:14.449747",
      "status": "completed"
     },
     "tags": []
@@ -1616,10 +1613,10 @@
    "id": "affee29e",
    "metadata": {
     "papermill": {
-     "duration": 0.006519,
-     "end_time": "2026-06-10T10:14:18.362427",
+     "duration": 0.00351,
+     "end_time": "2026-06-10T10:40:14.460843",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.355908",
+     "start_time": "2026-06-10T10:40:14.457333",
      "status": "completed"
     },
     "tags": []
@@ -1637,10 +1634,10 @@
    "id": "23cff9a5",
    "metadata": {
     "papermill": {
-     "duration": 0.006026,
-     "end_time": "2026-06-10T10:14:18.374979",
+     "duration": 0.004005,
+     "end_time": "2026-06-10T10:40:14.468361",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.368953",
+     "start_time": "2026-06-10T10:40:14.464356",
      "status": "completed"
     },
     "tags": []
@@ -1657,16 +1654,16 @@
    "id": "d1ecd1cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.389230Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.388723Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.397995Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.396910Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.477543Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.476024Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.491257Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.490605Z"
     },
     "papermill": {
-     "duration": 0.017983,
-     "end_time": "2026-06-10T10:14:18.398503",
+     "duration": 0.02087,
+     "end_time": "2026-06-10T10:40:14.492263",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.380520",
+     "start_time": "2026-06-10T10:40:14.471393",
      "status": "completed"
     },
     "tags": []
@@ -1702,10 +1699,10 @@
    "id": "1266c022",
    "metadata": {
     "papermill": {
-     "duration": 0.006524,
-     "end_time": "2026-06-10T10:14:18.412465",
+     "duration": 0.004499,
+     "end_time": "2026-06-10T10:40:14.500276",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.405941",
+     "start_time": "2026-06-10T10:40:14.495777",
      "status": "completed"
     },
     "tags": []
@@ -1729,10 +1726,10 @@
    "id": "e767a280",
    "metadata": {
     "papermill": {
-     "duration": 0.006747,
-     "end_time": "2026-06-10T10:14:18.425568",
+     "duration": 0.005022,
+     "end_time": "2026-06-10T10:40:14.508309",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.418821",
+     "start_time": "2026-06-10T10:40:14.503287",
      "status": "completed"
     },
     "tags": []
@@ -1754,16 +1751,16 @@
    "id": "f2c3a922",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.440170Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.439648Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.458866Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.458312Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.516318Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.516318Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.522338Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.521833Z"
     },
     "papermill": {
-     "duration": 0.027972,
-     "end_time": "2026-06-10T10:14:18.459882",
+     "duration": 0.01103,
+     "end_time": "2026-06-10T10:40:14.522338",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.431910",
+     "start_time": "2026-06-10T10:40:14.511308",
      "status": "completed"
     },
     "tags": []
@@ -1795,10 +1792,10 @@
    "id": "4bfff412",
    "metadata": {
     "papermill": {
-     "duration": 0.006028,
-     "end_time": "2026-06-10T10:14:18.472996",
+     "duration": 0.00417,
+     "end_time": "2026-06-10T10:40:14.531022",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.466968",
+     "start_time": "2026-06-10T10:40:14.526852",
      "status": "completed"
     },
     "tags": []
@@ -1815,16 +1812,16 @@
    "id": "883aa023",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.487498Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.486982Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.504978Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.504433Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.539108Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.539108Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.552716Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.552716Z"
     },
     "papermill": {
-     "duration": 0.026501,
-     "end_time": "2026-06-10T10:14:18.506024",
+     "duration": 0.020182,
+     "end_time": "2026-06-10T10:40:14.554214",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.479523",
+     "start_time": "2026-06-10T10:40:14.534032",
      "status": "completed"
     },
     "tags": []
@@ -1865,10 +1862,10 @@
    "id": "a483cb1cf590",
    "metadata": {
     "papermill": {
-     "duration": 0.006249,
-     "end_time": "2026-06-10T10:14:18.518956",
+     "duration": 0.003509,
+     "end_time": "2026-06-10T10:40:14.561729",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.512707",
+     "start_time": "2026-06-10T10:40:14.558220",
      "status": "completed"
     },
     "tags": []
@@ -1887,16 +1884,16 @@
    "id": "a66db8dd23f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:14:18.534045Z",
-     "iopub.status.busy": "2026-06-10T10:14:18.533522Z",
-     "iopub.status.idle": "2026-06-10T10:14:18.551495Z",
-     "shell.execute_reply": "2026-06-10T10:14:18.550901Z"
+     "iopub.execute_input": "2026-06-10T10:40:14.571288Z",
+     "iopub.status.busy": "2026-06-10T10:40:14.570282Z",
+     "iopub.status.idle": "2026-06-10T10:40:14.584296Z",
+     "shell.execute_reply": "2026-06-10T10:40:14.584296Z"
     },
     "papermill": {
-     "duration": 0.026275,
-     "end_time": "2026-06-10T10:14:18.552017",
+     "duration": 0.020034,
+     "end_time": "2026-06-10T10:40:14.585763",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.525742",
+     "start_time": "2026-06-10T10:40:14.565729",
      "status": "completed"
     },
     "tags": []
@@ -1923,10 +1920,10 @@
    "id": "ec85b3dd",
    "metadata": {
     "papermill": {
-     "duration": 0.007523,
-     "end_time": "2026-06-10T10:14:18.566545",
+     "duration": 0.003992,
+     "end_time": "2026-06-10T10:40:14.594286",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.559022",
+     "start_time": "2026-06-10T10:40:14.590294",
      "status": "completed"
     },
     "tags": []
@@ -1948,10 +1945,10 @@
    "id": "b7e4d1a9",
    "metadata": {
     "papermill": {
-     "duration": 0.006081,
-     "end_time": "2026-06-10T10:14:18.579682",
+     "duration": 0.004021,
+     "end_time": "2026-06-10T10:40:14.601315",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.573601",
+     "start_time": "2026-06-10T10:40:14.597294",
      "status": "completed"
     },
     "tags": []
@@ -1973,10 +1970,10 @@
    "id": "a464171c",
    "metadata": {
     "papermill": {
-     "duration": 0.006973,
-     "end_time": "2026-06-10T10:14:18.593221",
+     "duration": 0.005,
+     "end_time": "2026-06-10T10:40:14.610831",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.586248",
+     "start_time": "2026-06-10T10:40:14.605831",
      "status": "completed"
     },
     "tags": []
@@ -2014,10 +2011,10 @@
    "id": "410e5149",
    "metadata": {
     "papermill": {
-     "duration": 0.005987,
-     "end_time": "2026-06-10T10:14:18.606019",
+     "duration": 0.003998,
+     "end_time": "2026-06-10T10:40:14.617831",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.600032",
+     "start_time": "2026-06-10T10:40:14.613833",
      "status": "completed"
     },
     "tags": []
@@ -2037,10 +2034,10 @@
    "id": "902a1f86",
    "metadata": {
     "papermill": {
-     "duration": 0.006016,
-     "end_time": "2026-06-10T10:14:18.619114",
+     "duration": 0.003503,
+     "end_time": "2026-06-10T10:40:14.624849",
      "exception": false,
-     "start_time": "2026-06-10T10:14:18.613098",
+     "start_time": "2026-06-10T10:40:14.621346",
      "status": "completed"
     },
     "tags": []
@@ -2081,14 +2078,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.624953,
-   "end_time": "2026-06-10T10:14:18.865488",
+   "duration": 2.520301,
+   "end_time": "2026-06-10T10:40:14.863622",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-1-LogicalLearning.ipynb",
    "output_path": "SL-1-LogicalLearning.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T10:14:16.240535",
+   "start_time": "2026-06-10T10:40:12.343321",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
@@ -5,10 +5,10 @@
    "id": "b727b480",
    "metadata": {
     "papermill": {
-     "duration": 0.005598,
-     "end_time": "2026-06-06T21:01:22.407557",
+     "duration": 0.005257,
+     "end_time": "2026-06-10T10:26:05.495923",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.401959",
+     "start_time": "2026-06-10T10:26:05.490666",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "c9962789",
    "metadata": {
     "papermill": {
-     "duration": 0.007197,
-     "end_time": "2026-06-06T21:01:22.426382",
+     "duration": 0.002545,
+     "end_time": "2026-06-10T10:26:05.502082",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.419185",
+     "start_time": "2026-06-10T10:26:05.499537",
      "status": "completed"
     },
     "tags": []
@@ -70,16 +70,16 @@
    "id": "56964821",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:22.442277Z",
-     "iopub.status.busy": "2026-06-06T21:01:22.441571Z",
-     "iopub.status.idle": "2026-06-06T21:01:22.585194Z",
-     "shell.execute_reply": "2026-06-06T21:01:22.583622Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.510955Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.510436Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.613552Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.613005Z"
     },
     "papermill": {
-     "duration": 0.154179,
-     "end_time": "2026-06-06T21:01:22.587701",
+     "duration": 0.107847,
+     "end_time": "2026-06-10T10:26:05.613552",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.433522",
+     "start_time": "2026-06-10T10:26:05.505705",
      "status": "completed"
     },
     "tags": []
@@ -90,13 +90,15 @@
      "output_type": "stream",
      "text": [
       "=== SL-5 : Integration Neuro-Symbolique ===\n",
-      "NumPy version : 2.4.3\n"
+      "NumPy version : 1.26.0\n"
      ]
     }
    ],
    "source": [
     "import numpy as np\n",
     "from typing import List, Tuple, Callable\n",
+    "\n",
+    "np.random.seed(42)  # reproductibilite des initialisations aleatoires\n",
     "\n",
     "print('=== SL-5 : Integration Neuro-Symbolique ===')\n",
     "print(f'NumPy version : {np.__version__}')"
@@ -107,10 +109,10 @@
    "id": "ec77af60",
    "metadata": {
     "papermill": {
-     "duration": 0.007798,
-     "end_time": "2026-06-06T21:01:22.603121",
+     "duration": 0.002509,
+     "end_time": "2026-06-10T10:26:05.620084",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.595323",
+     "start_time": "2026-06-10T10:26:05.617575",
      "status": "completed"
     },
     "tags": []
@@ -126,10 +128,10 @@
    "id": "32df7b08",
    "metadata": {
     "papermill": {
-     "duration": 0.006641,
-     "end_time": "2026-06-06T21:01:22.616393",
+     "duration": 0.001503,
+     "end_time": "2026-06-10T10:26:05.625095",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.609752",
+     "start_time": "2026-06-10T10:26:05.623592",
      "status": "completed"
     },
     "tags": []
@@ -139,12 +141,16 @@
     "\n",
     "En logique classique, les connecteurs sont binaires (vrai/faux). En logique **floue** ou **differentiable**, on remplace ces valeurs binaires par des nombres dans [0, 1]. Les t-norms et t-conorms sont les generalisations differentiables de AND et OR.\n",
     "\n",
-    "| Connecteur | Logique classique | T-norm (differentiable) |\n",
-    "|------------|-------------------|------------------------|\n",
-    "| AND(a, b) | min(a, b) | a * b (produit de Godel) |\n",
-    "| OR(a, b) | max(a, b) | a + b - a*b (probabiliste) |\n",
+    "| Connecteur | Logique classique | Version differentiable (utilisee ici) |\n",
+    "|------------|-------------------|---------------------------------------|\n",
+    "| AND(a, b) | min(a, b) | a * b (**t-norm produit**) |\n",
+    "| OR(a, b) | max(a, b) | a + b - a*b (t-conorm probabiliste) |\n",
     "| NOT(a) | 1 - a | 1 - a |\n",
-    "| IMPLIES(a, b) | NOT(a) OR b | 1 - a + a*b |"
+    "| IMPLIES(a, b) | NOT(a) OR b | min(1, b/a) (**implication de Goguen**, residuelle du produit) |\n",
+    "\n",
+    "> Il existe plusieurs familles de t-norms : **produit** (a*b), **Godel** (min(a,b),\n",
+    "> differentiable presque partout) et **Lukasiewicz** (max(0, a+b-1), cf. exercice 4).\n",
+    "> Chaque t-norm induit son implication residuelle ; celle du produit est Goguen."
    ]
   },
   {
@@ -153,16 +159,16 @@
    "id": "a01933cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:22.633067Z",
-     "iopub.status.busy": "2026-06-06T21:01:22.632345Z",
-     "iopub.status.idle": "2026-06-06T21:01:22.641533Z",
-     "shell.execute_reply": "2026-06-06T21:01:22.640693Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.632165Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.631162Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.643197Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.643197Z"
     },
     "papermill": {
-     "duration": 0.018906,
-     "end_time": "2026-06-06T21:01:22.643431",
+     "duration": 0.016591,
+     "end_time": "2026-06-10T10:26:05.644699",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.624525",
+     "start_time": "2026-06-10T10:26:05.628108",
      "status": "completed"
     },
     "tags": []
@@ -226,10 +232,10 @@
    "id": "ad12fe5d",
    "metadata": {
     "papermill": {
-     "duration": 0.007403,
-     "end_time": "2026-06-06T21:01:22.658296",
+     "duration": 0.002017,
+     "end_time": "2026-06-10T10:26:05.649225",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.650893",
+     "start_time": "2026-06-10T10:26:05.647208",
      "status": "completed"
     },
     "tags": []
@@ -250,10 +256,10 @@
    "id": "6a1fad49",
    "metadata": {
     "papermill": {
-     "duration": 0.007092,
-     "end_time": "2026-06-06T21:01:22.672229",
+     "duration": 0.002514,
+     "end_time": "2026-06-10T10:26:05.654250",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.665137",
+     "start_time": "2026-06-10T10:26:05.651736",
      "status": "completed"
     },
     "tags": []
@@ -270,16 +276,16 @@
    "id": "918f263e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:22.688432Z",
-     "iopub.status.busy": "2026-06-06T21:01:22.687658Z",
-     "iopub.status.idle": "2026-06-06T21:01:22.714505Z",
-     "shell.execute_reply": "2026-06-06T21:01:22.713060Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.659305Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.659305Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.674382Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.674382Z"
     },
     "papermill": {
-     "duration": 0.037336,
-     "end_time": "2026-06-06T21:01:22.716835",
+     "duration": 0.018791,
+     "end_time": "2026-06-10T10:26:05.675547",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.679499",
+     "start_time": "2026-06-10T10:26:05.656756",
      "status": "completed"
     },
     "tags": []
@@ -289,7 +295,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "parent(np.float64(1.0), np.float64(0.5)) = 0.5279\n"
+      "parent(1.0, 0.5) = 0.5269\n"
      ]
     }
    ],
@@ -318,7 +324,7 @@
     "# Test\n",
     "parent_pred = NeuralPredicate(n_inputs=2, name='parent')\n",
     "x_test = np.array([1.0, 0.5])\n",
-    "print(f'parent{tuple(x_test)} = {parent_pred(x_test):.4f}')"
+    "print(f'parent({x_test[0]:.1f}, {x_test[1]:.1f}) = {parent_pred(x_test):.4f}')"
    ]
   },
   {
@@ -326,10 +332,10 @@
    "id": "3b49a998",
    "metadata": {
     "papermill": {
-     "duration": 0.016173,
-     "end_time": "2026-06-06T21:01:22.740516",
+     "duration": 0.001999,
+     "end_time": "2026-06-10T10:26:05.680550",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.724343",
+     "start_time": "2026-06-10T10:26:05.678551",
      "status": "completed"
     },
     "tags": []
@@ -345,10 +351,10 @@
    "id": "9e4bbd02",
    "metadata": {
     "papermill": {
-     "duration": 0.007475,
-     "end_time": "2026-06-06T21:01:22.755058",
+     "duration": 0.00301,
+     "end_time": "2026-06-10T10:26:05.685560",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.747583",
+     "start_time": "2026-06-10T10:26:05.682550",
      "status": "completed"
     },
     "tags": []
@@ -365,16 +371,16 @@
    "id": "639acc57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:22.773180Z",
-     "iopub.status.busy": "2026-06-06T21:01:22.772431Z",
-     "iopub.status.idle": "2026-06-06T21:01:22.790541Z",
-     "shell.execute_reply": "2026-06-06T21:01:22.788935Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.692580Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.692580Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.704632Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.704632Z"
     },
     "papermill": {
-     "duration": 0.030515,
-     "end_time": "2026-06-06T21:01:22.793174",
+     "duration": 0.01706,
+     "end_time": "2026-06-10T10:26:05.705637",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.762659",
+     "start_time": "2026-06-10T10:26:05.688577",
      "status": "completed"
     },
     "tags": []
@@ -385,24 +391,22 @@
      "output_type": "stream",
      "text": [
       "=== Entrainement du predicat neuronal \"parent\" ===\n",
-      "  Epoch  5 : perte = 4.3144\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Epoch 10 : perte = 4.3186\n",
-      "  Epoch 15 : perte = 4.3204\n",
-      "  Epoch 20 : perte = 4.3210\n",
+      "  Epoch 30 : perte = 2.3809\n",
+      "  Epoch 60 : perte = 1.3391\n",
+      "  Epoch 90 : perte = 0.9147\n",
+      "  Epoch 120 : perte = 0.6909\n",
+      "  Epoch 150 : perte = 0.5539\n",
       "\n",
-      "=== Resultats ===\n",
-      "  parent(Marie, Pierre) = 0.4667\n",
-      "  parent(Pierre, Paul) = 0.4755\n",
-      "  parent(Sophie, Luc) = 0.4755\n",
-      "  parent(Marie, Paul) = 0.4630\n",
-      "  parent(Pierre, Sophie) = 0.4755\n",
-      "  parent(Sophie, Pierre) = 0.4792\n"
+      "=== Resultats (cible : positifs proches de 1, negatifs proches de 0) ===\n",
+      "  parent(Marie, Pierre) = 0.8966   [positif]\n",
+      "  parent(Pierre, Paul) = 0.9193   [positif]\n",
+      "  parent(Sophie, Luc) = 0.9143   [positif]\n",
+      "  parent(Marie, Paul) = 0.0746   [negatif]\n",
+      "  parent(Pierre, Sophie) = 0.0353   [negatif]\n",
+      "  parent(Sophie, Pierre) = 0.0804   [negatif]\n",
+      "  parent(Paul, Marie) = 0.0032   [negatif]\n",
+      "  parent(Luc, Luc) = 0.0391   [negatif]\n",
+      "  parent(Luc, Sophie) = 0.0000   [negatif]\n"
      ]
     }
    ],
@@ -414,40 +418,43 @@
     "def get_embedding(name: str) -> np.ndarray:\n",
     "    return entity_embeddings[entities[name]]\n",
     "\n",
+    "def pair_embedding(s: str, o: str) -> np.ndarray:\n",
+    "    \"\"\"Concatenation des one-hot du sujet et de l'objet (2 x 5 = 10 entrees).\"\"\"\n",
+    "    return np.concatenate([get_embedding(s), get_embedding(o)])\n",
+    "\n",
     "# Entrainement LTN\n",
-    "parent_pred = NeuralPredicate(n_inputs=2, name='parent')\n",
+    "parent_pred = NeuralPredicate(n_inputs=2 * len(entities), name='parent')\n",
     "\n",
     "positive = [('Marie', 'Pierre'), ('Pierre', 'Paul'), ('Sophie', 'Luc')]\n",
-    "negative = [('Marie', 'Paul'), ('Pierre', 'Sophie'), ('Sophie', 'Pierre')]\n",
+    "# Negatifs echantillonnes en monde clos (comme pour les embeddings de KG, cf. SL-6)\n",
+    "negative = [('Marie', 'Paul'), ('Pierre', 'Sophie'), ('Sophie', 'Pierre'),\n",
+    "            ('Paul', 'Marie'), ('Luc', 'Luc'), ('Luc', 'Sophie')]\n",
     "\n",
     "print('=== Entrainement du predicat neuronal \"parent\" ===')\n",
+    "# Gradient de l'entropie croisee : pour une sortie sigmoide, la derivee de la\n",
+    "# perte par rapport au score z se simplifie en (val - cible) --- la derivee de\n",
+    "# la sigmoide se compense. D'ou la mise a jour w += lr * (cible - val) * x.\n",
     "lr = 0.5\n",
-    "for epoch in range(20):\n",
+    "for epoch in range(150):\n",
     "    total_loss = 0.0\n",
     "    for s, o in positive:\n",
-    "        x = np.array([get_embedding(s)[0], get_embedding(o)[1]])\n",
+    "        x = pair_embedding(s, o)\n",
     "        val = parent_pred(x)\n",
-    "        loss = -np.log(max(val, 1e-10))\n",
-    "        gw, gb = parent_pred.gradient(x)\n",
-    "        parent_pred.update(gw * (1 - val), gb * (1 - val), lr)\n",
-    "        total_loss += loss\n",
+    "        total_loss += -np.log(max(val, 1e-10))\n",
+    "        parent_pred.update(x * (1 - val), (1 - val), lr)\n",
     "    for s, o in negative:\n",
-    "        x = np.array([get_embedding(s)[0], get_embedding(o)[1]])\n",
+    "        x = pair_embedding(s, o)\n",
     "        val = parent_pred(x)\n",
-    "        loss = -np.log(max(1 - val, 1e-10))\n",
-    "        gw, gb = parent_pred.gradient(x)\n",
-    "        parent_pred.update(-gw * val, -gb * val, lr)\n",
-    "        total_loss += loss\n",
-    "    if (epoch + 1) % 5 == 0:\n",
+    "        total_loss += -np.log(max(1 - val, 1e-10))\n",
+    "        parent_pred.update(-x * val, -val, lr)\n",
+    "    if (epoch + 1) % 30 == 0:\n",
     "        print(f'  Epoch {epoch+1:2d} : perte = {total_loss:.4f}')\n",
     "\n",
-    "print('\\n=== Resultats ===')\n",
+    "print('\\n=== Resultats (cible : positifs proches de 1, negatifs proches de 0) ===')\n",
     "for s, o in positive:\n",
-    "    x = np.array([get_embedding(s)[0], get_embedding(o)[1]])\n",
-    "    print(f'  parent({s}, {o}) = {parent_pred(x):.4f}')\n",
+    "    print(f'  parent({s}, {o}) = {parent_pred(pair_embedding(s, o)):.4f}   [positif]')\n",
     "for s, o in negative:\n",
-    "    x = np.array([get_embedding(s)[0], get_embedding(o)[1]])\n",
-    "    print(f'  parent({s}, {o}) = {parent_pred(x):.4f}')"
+    "    print(f'  parent({s}, {o}) = {parent_pred(pair_embedding(s, o)):.4f}   [negatif]')\n"
    ]
   },
   {
@@ -455,10 +462,10 @@
    "id": "e76b2686",
    "metadata": {
     "papermill": {
-     "duration": 0.00827,
-     "end_time": "2026-06-06T21:01:22.809768",
+     "duration": 0.005065,
+     "end_time": "2026-06-10T10:26:05.714206",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.801498",
+     "start_time": "2026-06-10T10:26:05.709141",
      "status": "completed"
     },
     "tags": []
@@ -466,11 +473,23 @@
    "source": [
     "### Interpretation : Entrainement LTN\n",
     "\n",
-    "Le predicat neuronal `parent` apprend a distinguer les vraies relations parentales (valeur proche de 1) des fausses (valeur proche de 0). L'entrainement utilise la descente de gradient classique, mais la fonction de perte est guidee par la semantique logique.\n",
+    "Le predicat neuronal `parent` apprend a distinguer les vraies relations parentales\n",
+    "(valeur proche de 1) des fausses (valeur proche de 0). L'entrainement utilise la\n",
+    "descente de gradient classique sur une perte de type entropie croisee.\n",
     "\n",
-    "| Avant entrainement | Apres entrainement |\n",
-    "|-------------------|--------------------|\n",
-    "| Valeurs ~0.5 (aleatoire) | Positifs ~1.0, Negatifs ~0.0 |"
+    "Deux choix de representation sont importants :\n",
+    "\n",
+    "- **Encodage des paires** : on concatene les one-hot du sujet et de l'objet\n",
+    "  (10 entrees). Le classificateur logistique apprend alors un score additif\n",
+    "  *w(sujet) + w(objet)* --- suffisant ici car les exemples sont lineairement\n",
+    "  separables dans cette representation.\n",
+    "- **Negatifs en monde clos** : comme aucune base ne fournit de \"non-parents\"\n",
+    "  explicites, on echantillonne des paires absentes des faits positifs. C'est\n",
+    "  exactement la strategie d'entrainement des embeddings de Knowledge Graphs (SL-6).\n",
+    "\n",
+    "| Avant entrainement | Apres entrainement (60 epoques) |\n",
+    "|-------------------|--------------------------------|\n",
+    "| Valeurs ~0.5 (aleatoire) | Positifs ~0.9, negatifs < 0.1 |\n"
    ]
   },
   {
@@ -478,10 +497,10 @@
    "id": "e1560747",
    "metadata": {
     "papermill": {
-     "duration": 0.007591,
-     "end_time": "2026-06-06T21:01:22.824477",
+     "duration": 0.004064,
+     "end_time": "2026-06-10T10:26:05.723269",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.816886",
+     "start_time": "2026-06-10T10:26:05.719205",
      "status": "completed"
     },
     "tags": []
@@ -498,16 +517,16 @@
    "id": "60775122",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:22.841499Z",
-     "iopub.status.busy": "2026-06-06T21:01:22.841057Z",
-     "iopub.status.idle": "2026-06-06T21:01:22.851872Z",
-     "shell.execute_reply": "2026-06-06T21:01:22.850326Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.732795Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.732795Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.751313Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.750699Z"
     },
     "papermill": {
-     "duration": 0.022487,
-     "end_time": "2026-06-06T21:01:22.854371",
+     "duration": 0.027593,
+     "end_time": "2026-06-10T10:26:05.752863",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.831884",
+     "start_time": "2026-06-10T10:26:05.725270",
      "status": "completed"
     },
     "tags": []
@@ -519,20 +538,20 @@
      "text": [
       "=== Entrainement guide par regle ===\n",
       "Regle : parent(X,Y) AND parent(Y,Z) => grandparent(X,Z)\n",
-      "  Epoch 10 : perte = 0.0000\n",
-      "  Epoch 20 : perte = 0.0000\n",
-      "  Epoch 30 : perte = 0.0000\n",
+      "  Epoch 10 : perte = 0.2284\n",
+      "  Epoch 20 : perte = 0.1096\n",
+      "  Epoch 30 : perte = 0.0637\n",
       "\n",
       "=== Verifications ===\n",
-      "grandparent(Marie, Paul) = 0.2807\n",
-      "  (Attendu : proche de 1)\n",
-      "grandparent(Sophie, Luc) = 0.3657\n",
-      "  (Attendu : proche de 0)\n"
+      "grandparent(Marie, Paul) = 0.7757\n",
+      "  (Attendu : eleve, proche de la verite du corps de la regle ~0.8)\n",
+      "grandparent(Sophie, Luc) = 0.5821\n",
+      "  (Attendu : ~0.5 --- paire non couverte par la regle, donc non contrainte)\n"
      ]
     }
    ],
    "source": [
-    "grandparent_pred = NeuralPredicate(n_inputs=2, name='grandparent')\n",
+    "grandparent_pred = NeuralPredicate(n_inputs=2 * len(entities), name='grandparent')\n",
     "chains = [('Marie', 'Pierre', 'Paul')]\n",
     "\n",
     "print('=== Entrainement guide par regle ===')\n",
@@ -542,9 +561,9 @@
     "for epoch in range(30):\n",
     "    total_loss = 0.0\n",
     "    for g, p, c in chains:\n",
-    "        x_gc = np.array([get_embedding(g)[0], get_embedding(c)[1]])\n",
-    "        gp_val = parent_pred(np.array([get_embedding(g)[0], get_embedding(p)[1]]))\n",
-    "        pc_val = parent_pred(np.array([get_embedding(p)[0], get_embedding(c)[1]]))\n",
+    "        x_gc = pair_embedding(g, c)\n",
+    "        gp_val = parent_pred(pair_embedding(g, p))\n",
+    "        pc_val = parent_pred(pair_embedding(p, c))\n",
     "        gc_val = grandparent_pred(x_gc)\n",
     "        body = fuzzy_and(gp_val, pc_val)\n",
     "        rule_truth = fuzzy_implies(body, gc_val)\n",
@@ -557,12 +576,12 @@
     "        print(f'  Epoch {epoch+1:2d} : perte = {total_loss:.4f}')\n",
     "\n",
     "print('\\n=== Verifications ===')\n",
-    "x_gc = np.array([get_embedding('Marie')[0], get_embedding('Paul')[1]])\n",
+    "x_gc = pair_embedding('Marie', 'Paul')\n",
     "print(f'grandparent(Marie, Paul) = {grandparent_pred(x_gc):.4f}')\n",
-    "print(f'  (Attendu : proche de 1)')\n",
-    "x_sl = np.array([get_embedding('Sophie')[0], get_embedding('Luc')[1]])\n",
+    "print(f'  (Attendu : eleve, proche de la verite du corps de la regle ~0.8)')\n",
+    "x_sl = pair_embedding('Sophie', 'Luc')\n",
     "print(f'grandparent(Sophie, Luc) = {grandparent_pred(x_sl):.4f}')\n",
-    "print(f'  (Attendu : proche de 0)')"
+    "print(f'  (Attendu : ~0.5 --- paire non couverte par la regle, donc non contrainte)')"
    ]
   },
   {
@@ -570,10 +589,10 @@
    "id": "7bffc423",
    "metadata": {
     "papermill": {
-     "duration": 0.00732,
-     "end_time": "2026-06-06T21:01:22.868788",
+     "duration": 0.004663,
+     "end_time": "2026-06-10T10:26:05.760641",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.861468",
+     "start_time": "2026-06-10T10:26:05.755978",
      "status": "completed"
     },
     "tags": []
@@ -583,7 +602,12 @@
     "\n",
     "Le predicat `grandparent` a ete entraine **sans exemples directs** de grand-parent. Il a appris uniquement a partir de la regle logique `parent(X,Y) AND parent(Y,Z) => grandparent(X,Z)`.\n",
     "\n",
-    "C'est la puissance du neuro-symbolique : la **connaissance logique** guide l'apprentissage neuronal, meme sans donnees etiquetees pour le predicat cible."
+    "C'est la puissance du neuro-symbolique : la **connaissance logique** guide l'apprentissage neuronal, meme sans donnees etiquetees pour le predicat cible.\n",
+    "> **Limite a noter** : la regle est un *modus ponens* flou --- elle ne fournit\n",
+    "> qu'une contrainte **positive** (si le corps est vrai, la tete doit l'etre).\n",
+    "> Pour la paire (Sophie, Luc), aucune chaine parent-parent n'existe : le predicat\n",
+    "> reste a son initialisation (~0.5), ni vrai ni faux. Pousser ces paires vers 0\n",
+    "> demanderait des exemples negatifs ou une hypothese de monde clos.\n"
    ]
   },
   {
@@ -591,10 +615,10 @@
    "id": "7a1c36be",
    "metadata": {
     "papermill": {
-     "duration": 0.007544,
-     "end_time": "2026-06-06T21:01:22.884349",
+     "duration": 0.002605,
+     "end_time": "2026-06-10T10:26:05.767923",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.876805",
+     "start_time": "2026-06-10T10:26:05.765318",
      "status": "completed"
     },
     "tags": []
@@ -611,16 +635,16 @@
    "id": "4028d94f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:22.901297Z",
-     "iopub.status.busy": "2026-06-06T21:01:22.900548Z",
-     "iopub.status.idle": "2026-06-06T21:01:22.914580Z",
-     "shell.execute_reply": "2026-06-06T21:01:22.912685Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.779562Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.779047Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.796778Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.796778Z"
     },
     "papermill": {
-     "duration": 0.025838,
-     "end_time": "2026-06-06T21:01:22.917372",
+     "duration": 0.02444,
+     "end_time": "2026-06-10T10:26:05.797779",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.891534",
+     "start_time": "2026-06-10T10:26:05.773339",
      "status": "completed"
     },
     "tags": []
@@ -631,62 +655,74 @@
      "output_type": "stream",
      "text": [
       "=== Requetes DeepProbLog ===\n",
-      "  parent('Marie', 'Pierre') = 0.4630\n",
-      "  parent('Marie', 'Paul') = 0.4630\n",
-      "  grandparent('Marie', 'Paul') = 0.0000\n",
-      "  grandparent('Sophie', 'Luc') = 0.0000\n"
+      "  parent('Marie', 'Pierre') = 0.8966\n",
+      "  parent('Marie', 'Paul') = 0.0746\n",
+      "  grandparent('Marie', 'Paul') = 0.8242\n",
+      "  grandparent('Sophie', 'Luc') = 0.0804\n"
      ]
     }
    ],
    "source": [
+    "from itertools import product as iter_product\n",
+    "\n",
     "class SimpleDeepProbLog:\n",
     "    def __init__(self):\n",
     "        self.neural_preds = {}\n",
     "        self.rules = []\n",
     "        self.facts = {}\n",
-    "    \n",
+    "\n",
     "    def add_neural_predicate(self, name, pred):\n",
     "        self.neural_preds[name] = pred\n",
-    "    \n",
+    "\n",
     "    def add_rule(self, body, head):\n",
     "        self.rules.append((body, head))\n",
-    "    \n",
+    "\n",
     "    def add_fact(self, predicate, args, prob):\n",
     "        self.facts[(predicate, args)] = prob\n",
-    "    \n",
+    "\n",
     "    def _is_variable(self, arg):\n",
     "        return len(arg) == 1 and arg.isupper()\n",
-    "    \n",
+    "\n",
     "    def query(self, predicate, args, depth=0, max_depth=5):\n",
+    "        \"\"\"Chainage arriere : probabilite que predicate(args) soit vrai.\n",
+    "\n",
+    "        Les variables du corps non liees par la tete sont EXISTENTIELLES :\n",
+    "        on enumere les individus et on garde le meilleur binding (max).\n",
+    "        \"\"\"\n",
     "        if depth > max_depth:\n",
-    "            return 0.0\n",
-    "        # Si un argument est une variable non-substituee, retourner 0\n",
-    "        if any(self._is_variable(a) for a in args):\n",
     "            return 0.0\n",
     "        key = (predicate, args)\n",
     "        if key in self.facts:\n",
     "            return self.facts[key]\n",
     "        if predicate in self.neural_preds:\n",
-    "            x = np.array([get_embedding(a) for a in args]).flatten()[:2]\n",
-    "            return self.neural_preds[predicate](x)\n",
+    "            x = np.concatenate([get_embedding(a) for a in args])\n",
+    "            return float(self.neural_preds[predicate](x))\n",
     "        max_prob = 0.0\n",
     "        for body, head in self.rules:\n",
-    "            if head[0] == predicate and len(head[1]) == len(args):\n",
-    "                subst = {}\n",
-    "                match = True\n",
-    "                for h_a, q_a in zip(head[1], args):\n",
-    "                    if self._is_variable(h_a):\n",
-    "                        subst[h_a] = q_a\n",
-    "                    elif h_a != q_a:\n",
-    "                        match = False\n",
-    "                        break\n",
-    "                if not match:\n",
-    "                    continue\n",
+    "            if head[0] != predicate or len(head[1]) != len(args):\n",
+    "                continue\n",
+    "            subst = {}\n",
+    "            match = True\n",
+    "            for h_a, q_a in zip(head[1], args):\n",
+    "                if self._is_variable(h_a):\n",
+    "                    subst[h_a] = q_a\n",
+    "                elif h_a != q_a:\n",
+    "                    match = False\n",
+    "                    break\n",
+    "            if not match:\n",
+    "                continue\n",
+    "            free = sorted({a for _, b_args in body for a in b_args\n",
+    "                           if self._is_variable(a) and a not in subst})\n",
+    "            for binding in iter_product(entities, repeat=len(free)):\n",
+    "                s = dict(subst)\n",
+    "                s.update(zip(free, binding))\n",
     "                body_truth = 1.0\n",
     "                for b_pred, b_args in body:\n",
-    "                    resolved = tuple(subst.get(a, a) for a in b_args)\n",
-    "                    prob = self.query(b_pred, resolved, depth+1, max_depth)\n",
-    "                    body_truth = fuzzy_and(body_truth, prob)\n",
+    "                    resolved = tuple(s.get(a, a) for a in b_args)\n",
+    "                    body_truth = fuzzy_and(\n",
+    "                        body_truth, self.query(b_pred, resolved, depth + 1, max_depth))\n",
+    "                    if body_truth == 0.0:\n",
+    "                        break\n",
     "                max_prob = max(max_prob, body_truth)\n",
     "        return max_prob\n",
     "\n",
@@ -698,7 +734,7 @@
     "for pred, args in [('parent', ('Marie', 'Pierre')), ('parent', ('Marie', 'Paul')),\n",
     "                   ('grandparent', ('Marie', 'Paul')), ('grandparent', ('Sophie', 'Luc'))]:\n",
     "    prob = dpl.query(pred, args)\n",
-    "    print(f'  {pred}{args} = {prob:.4f}')"
+    "    print(f'  {pred}{args} = {prob:.4f}')\n"
    ]
   },
   {
@@ -706,10 +742,10 @@
    "id": "93b3b181",
    "metadata": {
     "papermill": {
-     "duration": 0.008674,
-     "end_time": "2026-06-06T21:01:22.934822",
+     "duration": 0.003001,
+     "end_time": "2026-06-10T10:26:05.803779",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.926148",
+     "start_time": "2026-06-10T10:26:05.800778",
      "status": "completed"
     },
     "tags": []
@@ -718,11 +754,18 @@
     "### Interpretation : DeepProbLog\n",
     "\n",
     "Le systeme DeepProbLog combine :\n",
-    "1. **Predicats neuronaux** : `parent` est un predicat appris\n",
+    "1. **Predicats neuronaux** : `parent` est le predicat appris en section 4\n",
     "2. **Regles logiques** : `grandparent(X,Z) :- parent(X,Y), parent(Y,Z)`\n",
-    "3. **Inference** : la requete `grandparent(Marie, Paul)` est resolue par chainage\n",
+    "3. **Inference** : la requete `grandparent(Marie, Paul)` est resolue par\n",
+    "   **chainage arriere**. La variable `Y` du corps n'est pas liee par la tete :\n",
+    "   elle est **existentielle**. Le moteur enumere donc les 5 individus et garde\n",
+    "   le meilleur binding --- ici `Y = Pierre`, qui donne\n",
+    "   `parent(Marie, Pierre) * parent(Pierre, Paul)`, un produit eleve.\n",
     "\n",
-    "La probabilite finale est le produit des probabilites intermediaires (t-norm)."
+    "La probabilite du corps est le **produit** des probabilites de ses atomes\n",
+    "(t-norm produit), et la quantification existentielle est approximee par le\n",
+    "**max** sur les bindings. `grandparent(Sophie, Luc)` reste faible : aucune\n",
+    "chaine `parent-parent` plausible ne relie Sophie a Luc en deux pas.\n"
    ]
   },
   {
@@ -730,10 +773,10 @@
    "id": "7422dd81",
    "metadata": {
     "papermill": {
-     "duration": 0.010626,
-     "end_time": "2026-06-06T21:01:22.954053",
+     "duration": 0.002999,
+     "end_time": "2026-06-10T10:26:05.810790",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.943427",
+     "start_time": "2026-06-10T10:26:05.807791",
      "status": "completed"
     },
     "tags": []
@@ -754,10 +797,10 @@
    "id": "c4b87086",
    "metadata": {
     "papermill": {
-     "duration": 0.008167,
-     "end_time": "2026-06-06T21:01:22.970965",
+     "duration": 0.003971,
+     "end_time": "2026-06-10T10:26:05.818339",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.962798",
+     "start_time": "2026-06-10T10:26:05.814368",
      "status": "completed"
     },
     "tags": []
@@ -778,10 +821,10 @@
    "id": "b7545afb",
    "metadata": {
     "papermill": {
-     "duration": 0.008456,
-     "end_time": "2026-06-06T21:01:22.988271",
+     "duration": 0.00312,
+     "end_time": "2026-06-10T10:26:05.824556",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.979815",
+     "start_time": "2026-06-10T10:26:05.821436",
      "status": "completed"
     },
     "tags": []
@@ -821,16 +864,16 @@
    "id": "d6a2c3fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:23.006694Z",
-     "iopub.status.busy": "2026-06-06T21:01:23.006003Z",
-     "iopub.status.idle": "2026-06-06T21:01:23.016408Z",
-     "shell.execute_reply": "2026-06-06T21:01:23.015020Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.833426Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.832911Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.843452Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.842949Z"
     },
     "papermill": {
-     "duration": 0.021651,
-     "end_time": "2026-06-06T21:01:23.018677",
+     "duration": 0.01621,
+     "end_time": "2026-06-10T10:26:05.844455",
      "exception": false,
-     "start_time": "2026-06-06T21:01:22.997026",
+     "start_time": "2026-06-10T10:26:05.828245",
      "status": "completed"
     },
     "tags": []
@@ -928,10 +971,10 @@
    "id": "cd9f3d77",
    "metadata": {
     "papermill": {
-     "duration": 0.008034,
-     "end_time": "2026-06-06T21:01:23.035030",
+     "duration": 0.004001,
+     "end_time": "2026-06-10T10:26:05.851456",
      "exception": false,
-     "start_time": "2026-06-06T21:01:23.026996",
+     "start_time": "2026-06-10T10:26:05.847455",
      "status": "completed"
     },
     "tags": []
@@ -948,16 +991,16 @@
    "id": "b7c8387b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:23.055023Z",
-     "iopub.status.busy": "2026-06-06T21:01:23.054252Z",
-     "iopub.status.idle": "2026-06-06T21:01:23.062447Z",
-     "shell.execute_reply": "2026-06-06T21:01:23.060802Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.859455Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.859455Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.873973Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.873973Z"
     },
     "papermill": {
-     "duration": 0.021734,
-     "end_time": "2026-06-06T21:01:23.065357",
+     "duration": 0.018511,
+     "end_time": "2026-06-10T10:26:05.874974",
      "exception": false,
-     "start_time": "2026-06-06T21:01:23.043623",
+     "start_time": "2026-06-10T10:26:05.856463",
      "status": "completed"
     },
     "tags": []
@@ -985,10 +1028,10 @@
    "id": "8fcfd862",
    "metadata": {
     "papermill": {
-     "duration": 0.00892,
-     "end_time": "2026-06-06T21:01:23.082745",
+     "duration": 0.001999,
+     "end_time": "2026-06-10T10:26:05.879973",
      "exception": false,
-     "start_time": "2026-06-06T21:01:23.073825",
+     "start_time": "2026-06-10T10:26:05.877974",
      "status": "completed"
     },
     "tags": []
@@ -1005,16 +1048,16 @@
    "id": "b2483326",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:23.101515Z",
-     "iopub.status.busy": "2026-06-06T21:01:23.100732Z",
-     "iopub.status.idle": "2026-06-06T21:01:23.106371Z",
-     "shell.execute_reply": "2026-06-06T21:01:23.105257Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.886479Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.886479Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.889487Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.889487Z"
     },
     "papermill": {
-     "duration": 0.017728,
-     "end_time": "2026-06-06T21:01:23.108624",
+     "duration": 0.008507,
+     "end_time": "2026-06-10T10:26:05.890480",
      "exception": false,
-     "start_time": "2026-06-06T21:01:23.090896",
+     "start_time": "2026-06-10T10:26:05.881973",
      "status": "completed"
     },
     "tags": []
@@ -1045,10 +1088,10 @@
    "id": "f8c58c48",
    "metadata": {
     "papermill": {
-     "duration": 0.008642,
-     "end_time": "2026-06-06T21:01:23.126380",
+     "duration": 0.002696,
+     "end_time": "2026-06-10T10:26:05.896183",
      "exception": false,
-     "start_time": "2026-06-06T21:01:23.117738",
+     "start_time": "2026-06-10T10:26:05.893487",
      "status": "completed"
     },
     "tags": []
@@ -1088,16 +1131,16 @@
    "id": "e2b9c7aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:23.143734Z",
-     "iopub.status.busy": "2026-06-06T21:01:23.143125Z",
-     "iopub.status.idle": "2026-06-06T21:01:23.149963Z",
-     "shell.execute_reply": "2026-06-06T21:01:23.148611Z"
+     "iopub.execute_input": "2026-06-10T10:26:05.902479Z",
+     "iopub.status.busy": "2026-06-10T10:26:05.902479Z",
+     "iopub.status.idle": "2026-06-10T10:26:05.920995Z",
+     "shell.execute_reply": "2026-06-10T10:26:05.920995Z"
     },
     "papermill": {
-     "duration": 0.017032,
-     "end_time": "2026-06-06T21:01:23.151477",
+     "duration": 0.023508,
+     "end_time": "2026-06-10T10:26:05.921987",
      "exception": false,
-     "start_time": "2026-06-06T21:01:23.134445",
+     "start_time": "2026-06-10T10:26:05.898479",
      "status": "completed"
     },
     "tags": []
@@ -1152,10 +1195,10 @@
    "id": "367f1c08",
    "metadata": {
     "papermill": {
-     "duration": 0.00841,
-     "end_time": "2026-06-06T21:01:23.167686",
+     "duration": 0.001998,
+     "end_time": "2026-06-10T10:26:05.927492",
      "exception": false,
-     "start_time": "2026-06-06T21:01:23.159276",
+     "start_time": "2026-06-10T10:26:05.925494",
      "status": "completed"
     },
     "tags": []
@@ -1187,10 +1230,10 @@
    "id": "afb393b9",
    "metadata": {
     "papermill": {
-     "duration": 0.009084,
-     "end_time": "2026-06-06T21:01:23.184750",
+     "duration": 0.002999,
+     "end_time": "2026-06-10T10:26:05.933493",
      "exception": false,
-     "start_time": "2026-06-06T21:01:23.175666",
+     "start_time": "2026-06-10T10:26:05.930494",
      "status": "completed"
     },
     "tags": []
@@ -1198,7 +1241,7 @@
    "source": [
     "### Perspectives\n",
     "\n",
-    "Ce notebook a explore l'integration neuro-symbolique, qui vise a combiner les forces complementaires des reseaux de neurones (apprentissage a partir de donnees, tolerance au bruit) et du raisonnement symbolique (garanties formelles, interpretabilite). Les operateurs logiques differentiables (t-norms) transforment les connecteurs binaires AND, OR, NOT en fonctions continues derivables sur [0, 1], permettant leur integration dans des graphes de calcul optimisables par descente de gradient. Les predicats neuronaux implementent des fonctions P(x) -> [0, 1] via des reseaux de neurones, et la Logique Tensorielle (LTN) combine ces predicats avec une semantique logique pour entrainer des modeles guidees par des regles.\n",
+    "Ce notebook a explore l'integration neuro-symbolique, qui vise a combiner les forces complementaires des reseaux de neurones (apprentissage a partir de donnees, tolerance au bruit) et du raisonnement symbolique (garanties formelles, interpretabilite). Les operateurs logiques differentiables (t-norms) transforment les connecteurs binaires AND, OR, NOT en fonctions continues derivables sur [0, 1], permettant leur integration dans des graphes de calcul optimisables par descente de gradient. Les predicats neuronaux implementent des fonctions P(x) -> [0, 1] via des reseaux de neurones, et la Logique Tensorielle (LTN) combine ces predicats avec une semantique logique pour entrainer des modeles guides par des regles.\n",
     "\n",
     "L'implementation du raisonnement guide par regle a illustre un resultat remarquable : le predicat `grandparent` a ete appris sans aucun exemple direct de grand-parent, uniquement a partir de la regle logique `parent(X,Y) AND parent(Y,Z) => grandparent(X,Z)`. Le systeme DeepProbLog simplifie a ensuite unifie la programmation logique probabiliste et les predicats neuronaux, permettant de resoudre des requetes par chainage arriere. L'exemple guide de l'operateur OR parametrique a demontre comment un parametre de combinaison convexe (alpha) peut etre appris pour choisir automatiquement entre la semantique de Godel (max) et la semantique probabiliste (a+b-a*b).\n",
     "\n",
@@ -1233,18 +1276,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.151731,
-   "end_time": "2026-06-06T21:01:23.548324",
+   "duration": 1.998192,
+   "end_time": "2026-06-10T10:26:06.184737",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb",
-   "output_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb",
+   "input_path": "SL-5-NeuroSymbolic.ipynb",
+   "output_path": "SL-5-NeuroSymbolic.ipynb",
    "parameters": {},
-   "start_time": "2026-06-06T21:01:19.396593",
+   "start_time": "2026-06-10T10:26:04.186545",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
@@ -5,10 +5,10 @@
    "id": "cc001308",
    "metadata": {
     "papermill": {
-     "duration": 0.010519,
-     "end_time": "2026-06-06T21:02:50.200348",
+     "duration": 0.002992,
+     "end_time": "2026-06-10T10:34:50.864868",
      "exception": false,
-     "start_time": "2026-06-06T21:02:50.189829",
+     "start_time": "2026-06-10T10:34:50.861876",
      "status": "completed"
     },
     "tags": []
@@ -25,7 +25,7 @@
     "2. Implementer un algorithme de **rule mining** simplifie inspire d'AMIE3 pour decouvrir des regles de Horn dans un KG\n",
     "3. Distinguer **support**, **confidence** et **PCA confidence** pour evaluer la qualite des regles\n",
     "4. Comprendre le lien entre **regles d'association** statistiques et **regles logiques** du premier ordre\n",
-    "5. Appliquer les regles minnees pour **inferer de nouveaux triples** dans le graphe\n",
+    "5. Appliquer les regles minees pour **inferer de nouveaux triples** dans le graphe\n",
     "\n",
     "### Prerequis\n",
     "- SL-4 (ILP : FOIL, resolution inverse) recommande\n",
@@ -46,10 +46,10 @@
    "id": "a521d3e8",
    "metadata": {
     "papermill": {
-     "duration": 0.005816,
-     "end_time": "2026-06-06T21:02:50.212006",
+     "duration": 0.002008,
+     "end_time": "2026-06-10T10:34:50.870876",
      "exception": false,
-     "start_time": "2026-06-06T21:02:50.206190",
+     "start_time": "2026-06-10T10:34:50.868868",
      "status": "completed"
     },
     "tags": []
@@ -93,10 +93,10 @@
    "id": "fb76430f",
    "metadata": {
     "papermill": {
-     "duration": 0.006883,
-     "end_time": "2026-06-06T21:02:50.225209",
+     "duration": 0.003009,
+     "end_time": "2026-06-10T10:34:50.877391",
      "exception": false,
-     "start_time": "2026-06-06T21:02:50.218326",
+     "start_time": "2026-06-10T10:34:50.874382",
      "status": "completed"
     },
     "tags": []
@@ -115,16 +115,16 @@
    "id": "6422a73a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:50.239894Z",
-     "iopub.status.busy": "2026-06-06T21:02:50.239430Z",
-     "iopub.status.idle": "2026-06-06T21:02:55.774716Z",
-     "shell.execute_reply": "2026-06-06T21:02:55.773463Z"
+     "iopub.execute_input": "2026-06-10T10:34:50.884392Z",
+     "iopub.status.busy": "2026-06-10T10:34:50.884392Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.071478Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.070339Z"
     },
     "papermill": {
-     "duration": 5.545778,
-     "end_time": "2026-06-06T21:02:55.776866",
+     "duration": 5.192136,
+     "end_time": "2026-06-10T10:34:56.072527",
      "exception": false,
-     "start_time": "2026-06-06T21:02:50.231088",
+     "start_time": "2026-06-10T10:34:50.880391",
      "status": "completed"
     },
     "tags": []
@@ -141,11 +141,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
       "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+      "[notice] A new release of pip is available: 23.0.1 -> 26.1.2\n",
+      "[notice] To update, run: C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],
@@ -159,10 +157,10 @@
    "id": "859f5cfd",
    "metadata": {
     "papermill": {
-     "duration": 0.007086,
-     "end_time": "2026-06-06T21:02:55.792736",
+     "duration": 0.00568,
+     "end_time": "2026-06-10T10:34:56.083931",
      "exception": false,
-     "start_time": "2026-06-06T21:02:55.785650",
+     "start_time": "2026-06-10T10:34:56.078251",
      "status": "completed"
     },
     "tags": []
@@ -179,16 +177,16 @@
    "id": "1cd6d433",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:55.812470Z",
-     "iopub.status.busy": "2026-06-06T21:02:55.811950Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.317242Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.315969Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.098041Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.097529Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.475309Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.474610Z"
     },
     "papermill": {
-     "duration": 0.517814,
-     "end_time": "2026-06-06T21:02:56.318736",
+     "duration": 0.386174,
+     "end_time": "2026-06-10T10:34:56.476404",
      "exception": false,
-     "start_time": "2026-06-06T21:02:55.800922",
+     "start_time": "2026-06-10T10:34:56.090230",
      "status": "completed"
     },
     "tags": []
@@ -261,8 +259,11 @@
     "\n",
     "# grandparentOf: we add a SUBSET of grandparent triples\n",
     "# (simulates a KG where grandparentOf is incomplete -- ILP should discover the rule)\n",
-    "# Body pairs = 8 possible: Marie->Luc,Sophie,Paul,Anne + Pierre->Luc,Sophie,Paul,Anne\n",
-    "# We add 5 out of 8 to get confidence = 5/8 = 0.625 (above our threshold)\n",
+    "# True grandparent pairs = 14: Marie/Pierre -> Luc,Sophie,Paul,Anne (2x4=8),\n",
+    "# Jean -> Marc,Lea,Hugo,Julie (4), Claire -> Thomas,Emma (2).\n",
+    "# We add 5 of them, all for Marie/Pierre:\n",
+    "#   standard confidence = 5/14 ~ 0.36 (penalisee par l'incompletude du KG)\n",
+    "#   PCA confidence      = 5/8  = 0.625 (seuls Marie et Pierre ont des head triples)\n",
     "grandparent_triples = [\n",
     "    (\"Marie\", \"Luc\"),      # Marie -> Jean -> Luc\n",
     "    (\"Marie\", \"Sophie\"),   # Marie -> Jean -> Sophie\n",
@@ -324,10 +325,10 @@
    "id": "c7f62d31",
    "metadata": {
     "papermill": {
-     "duration": 0.008184,
-     "end_time": "2026-06-06T21:02:56.333431",
+     "duration": 0.003518,
+     "end_time": "2026-06-10T10:34:56.483690",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.325247",
+     "start_time": "2026-06-10T10:34:56.480172",
      "status": "completed"
     },
     "tags": []
@@ -340,14 +341,14 @@
     "| Relation | Triples | Signification |\n",
     "|----------|---------|---------------|\n",
     "| `parentOf` | 14 | Lien parent-enfant (complet) |\n",
-    "| `grandparentOf` | 5 | Lien grand-parent (INCOMPLET -- 5 sur 8 possibles) |\n",
+    "| `grandparentOf` | 5 | Lien grand-parent (INCOMPLET -- 5 sur 14 possibles) |\n",
     "| `siblingOf` | 12 | Lien fratrie (symetrique) |\n",
     "| `marriedTo` | 2 | Lien mariage (symetrique) |\n",
     "\n",
     "**Points cles** :\n",
-    "1. `grandparentOf` est **incomplet** : seuls 5 triples sur les 8 possibles sont presents\n",
+    "1. `grandparentOf` est **incomplet** : seuls 5 triples sur les 14 possibles sont presents (les grands-parents des generations 1 et 2 -- Jean, Claire -- n'ont aucun triple)\n",
     "2. C'est exactement la situation ou le rule mining est utile : **completer les donnees manquantes**\n",
-    "3. Si on peut decouvrir la regle `parentOf(X,Y) ^ parentOf(Y,Z) => grandparentOf(X,Z)`, on pourra inferer les 3 triples manquants\n",
+    "3. Si on peut decouvrir la regle `parentOf(X,Y) ^ parentOf(Y,Z) => grandparentOf(X,Z)`, on pourra inferer les 9 triples manquants\n",
     "\n",
     "> **Note** : Cette incompletude est typique des vrais Knowledge Graphs. Wikidata, par exemple, contient des millions de triples mais reste largement incomplet. Le rule mining est une technique cle pour la completion."
    ]
@@ -357,10 +358,10 @@
    "id": "09e1dbc5",
    "metadata": {
     "papermill": {
-     "duration": 0.007192,
-     "end_time": "2026-06-06T21:02:56.348263",
+     "duration": 0.005001,
+     "end_time": "2026-06-10T10:34:56.492032",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.341071",
+     "start_time": "2026-06-10T10:34:56.487031",
      "status": "completed"
     },
     "tags": []
@@ -379,16 +380,16 @@
    "id": "135b849e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:56.365122Z",
-     "iopub.status.busy": "2026-06-06T21:02:56.364334Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.375714Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.374746Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.504049Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.503045Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.521249Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.521249Z"
     },
     "papermill": {
-     "duration": 0.021358,
-     "end_time": "2026-06-06T21:02:56.377561",
+     "duration": 0.02772,
+     "end_time": "2026-06-10T10:34:56.522750",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.356203",
+     "start_time": "2026-06-10T10:34:56.495030",
      "status": "completed"
     },
     "tags": []
@@ -474,10 +475,10 @@
    "id": "4e7a7a8e",
    "metadata": {
     "papermill": {
-     "duration": 0.009367,
-     "end_time": "2026-06-06T21:02:56.395257",
+     "duration": 0.005,
+     "end_time": "2026-06-10T10:34:56.535754",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.385890",
+     "start_time": "2026-06-10T10:34:56.530754",
      "status": "completed"
     },
     "tags": []
@@ -501,10 +502,10 @@
    "id": "2ebba873",
    "metadata": {
     "papermill": {
-     "duration": 0.009911,
-     "end_time": "2026-06-06T21:02:56.415388",
+     "duration": 0.005529,
+     "end_time": "2026-06-10T10:34:56.548488",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.405477",
+     "start_time": "2026-06-10T10:34:56.542959",
      "status": "completed"
     },
     "tags": []
@@ -526,9 +527,9 @@
     "\n",
     "| Metrique | Formule | Signification |\n",
     "|----------|---------|---------------|\n",
-    "| **Support** | $|\\{(a,c) : body(a,c) \\wedge head(a,c)\\}|$ | Nombre de paires couvertes |\n",
-    "| **Confidence standard** | $\\frac{support}{|\\{(a,c) : body(a,c)\\}|}$ | Probabilite que head soit vrai si body est vrai |\n",
-    "| **PCA confidence** | $\\frac{support}{|\\{(a,c) : body(a,c)\\}| + |\\{(a,c') : body(a,c') \\wedge \\neg head(a,c')\\}|}$ | Ajuste pour l'incompletude du KG |"
+    "| **Support** | $\\lvert\\{(a,c) : body(a,c) \\wedge head(a,c)\\}\\rvert$ | Nombre de paires couvertes |\n",
+    "| **Confidence standard** | $\\frac{support}{\\lvert\\{(a,c) : body(a,c)\\}\\rvert}$ | Probabilite que head soit vrai si body est vrai |\n",
+    "| **PCA confidence** | $\\frac{support}{\\lvert\\{(a,c) : body(a,c) \\wedge \\exists z\\, head(a,z)\\}\\rvert}$ | Ajuste pour l'incompletude du KG (denominateur restreint aux sujets ayant au moins un head connu) |"
    ]
   },
   {
@@ -537,16 +538,16 @@
    "id": "91350691",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:56.435476Z",
-     "iopub.status.busy": "2026-06-06T21:02:56.434527Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.448639Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.446867Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.561624Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.560621Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.584143Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.583150Z"
     },
     "papermill": {
-     "duration": 0.027456,
-     "end_time": "2026-06-06T21:02:56.451246",
+     "duration": 0.030026,
+     "end_time": "2026-06-10T10:34:56.584143",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.423790",
+     "start_time": "2026-06-10T10:34:56.554117",
      "status": "completed"
     },
     "tags": []
@@ -649,10 +650,10 @@
    "id": "2f9e5ce7",
    "metadata": {
     "papermill": {
-     "duration": 0.010048,
-     "end_time": "2026-06-06T21:02:56.473086",
+     "duration": 0.004,
+     "end_time": "2026-06-10T10:34:56.591150",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.463038",
+     "start_time": "2026-06-10T10:34:56.587150",
      "status": "completed"
     },
     "tags": []
@@ -666,7 +667,7 @@
     "|-----------|-------------|------------------|\n",
     "| `compute_body_pairs(r1, r2)` | `SELECT r1.s, r2.o FROM r1 JOIN r2 ON r1.o = r2.s` | Trouver A, C tels que $r_1(A,B) \\wedge r_2(B,C)$ |\n",
     "| `support_pairs = body & head` | `WHERE head.s = body.s AND head.o = body.o` | $r_{body}(A,C) \\wedge r_{head}(A,C)$ |\n",
-    "| `confidence = support / body_size` | Ratio de vrai positifs | $P(head | body)$ |\n",
+    "| `confidence = support / body_size` | Ratio de vrai positifs | $P(head \\mid body)$ |\n",
     "\n",
     "> **Note** : La PCA confidence differe de la confidence standard en excluant du denominateur les body pairs dont le sujet n'a aucun head triple. Si Marie n'a aucun `grandparentOf` dans le KG, la paire `(Marie, Luc)` ne compte ni pour ni contre la regle."
    ]
@@ -676,10 +677,10 @@
    "id": "55e6358c",
    "metadata": {
     "papermill": {
-     "duration": 0.009386,
-     "end_time": "2026-06-06T21:02:56.491864",
+     "duration": 0.002993,
+     "end_time": "2026-06-10T10:34:56.597143",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.482478",
+     "start_time": "2026-06-10T10:34:56.594150",
      "status": "completed"
     },
     "tags": []
@@ -698,16 +699,16 @@
    "id": "93a15c8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:56.514515Z",
-     "iopub.status.busy": "2026-06-06T21:02:56.513922Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.530762Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.529629Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.604655Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.604655Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.614663Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.614663Z"
     },
     "papermill": {
-     "duration": 0.031051,
-     "end_time": "2026-06-06T21:02:56.532856",
+     "duration": 0.015006,
+     "end_time": "2026-06-10T10:34:56.615657",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.501805",
+     "start_time": "2026-06-10T10:34:56.600651",
      "status": "completed"
     },
     "tags": []
@@ -821,10 +822,10 @@
    "id": "f171e286",
    "metadata": {
     "papermill": {
-     "duration": 0.010513,
-     "end_time": "2026-06-06T21:02:56.553883",
+     "duration": 0.002999,
+     "end_time": "2026-06-10T10:34:56.622164",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.543370",
+     "start_time": "2026-06-10T10:34:56.619165",
      "status": "completed"
     },
     "tags": []
@@ -832,17 +833,24 @@
    "source": [
     "### Interpretation : Regles decouvertes\n",
     "\n",
-    "L'algorithme de rule mining a decouvert plusieurs regles dans le Knowledge Graph familial.\n",
+    "L'algorithme a decouvert 5 regles. Le classement par confidence standard reserve une surprise :\n",
     "\n",
-    "**Regles decouvertes** :\n",
+    "| Regle | Conf | PCA | Lecture |\n",
+    "|-------|------|-----|---------|\n",
+    "| `parentOf ^ siblingOf => parentOf` | 1.00 | 1.00 | Vraie par construction : les freres et soeurs partagent leurs parents |\n",
+    "| `marriedTo ^ parentOf => parentOf` | 1.00 | 1.00 | Le conjoint d'un parent est aussi parent (vrai dans cette famille) |\n",
+    "| `grandparentOf ^ siblingOf => grandparentOf` | 0.80 | 0.80 | Le grand-parent de X l'est aussi de sa fratrie |\n",
+    "| `marriedTo ^ grandparentOf => grandparentOf` | 0.80 | 0.80 | Le conjoint d'un grand-parent est grand-parent |\n",
+    "| **`parentOf ^ parentOf => grandparentOf`** | **0.36** | **0.62** | **La regle cible... derniere du classement !** |\n",
     "\n",
-    "| Regle | Pourquoi elle est vraie | Confidence |\n",
-    "|-------|------------------------|------------|\n",
-    "| `parentOf ^ parentOf => grandparentOf` | Definition meme de grand-parent | Elevee |\n",
-    "| `parentOf ^ siblingOf => parentOf` | Si X est parent de Y et Y est frere de Z, X est parent de Z | 1.0 |\n",
-    "| `marriedTo ^ parentOf => parentOf` | Le conjoint d'un parent est aussi parent | 1.0 |\n",
-    "\n",
-    "> **Point cle** : La regle `parentOf ^ parentOf => grandparentOf` est exactement le type de regle que l'on veut decouvrir. Elle correspond a la regle logique $\\forall X,Y,Z : parentOf(X,Y) \\wedge parentOf(Y,Z) \\Rightarrow grandparentOf(X,Z)$. C'est une regle de Horn binaire."
+    "> **Point cle --- c'est tout l'interet de la PCA confidence.** La regle que l'on\n",
+    "> veut decouvrir est la **moins bien notee** en confidence standard : sur les\n",
+    "> 14 paires (grand-parent, petit-enfant) reelles, seules 5 sont dans le KG, donc\n",
+    "> 5/14 = 0.36. L'incompletude du KG **punit** la bonne regle. La PCA confidence\n",
+    "> (Partial Completeness Assumption) ne compte au denominateur que les paires dont\n",
+    "> le sujet a *au moins un* triple `grandparentOf` connu (Marie et Pierre, 8 paires) :\n",
+    "> 5/8 = 0.62. Sous OWA, c'est l'estimateur le plus fiable --- AMIE classe ses\n",
+    "> regles par PCA confidence, pas par confidence standard.\n"
    ]
   },
   {
@@ -850,10 +858,10 @@
    "id": "d17f08c2",
    "metadata": {
     "papermill": {
-     "duration": 0.010122,
-     "end_time": "2026-06-06T21:02:56.573995",
+     "duration": 0.004,
+     "end_time": "2026-06-10T10:34:56.629164",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.563873",
+     "start_time": "2026-06-10T10:34:56.625164",
      "status": "completed"
     },
     "tags": []
@@ -872,16 +880,16 @@
    "id": "e5d644f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:56.596077Z",
-     "iopub.status.busy": "2026-06-06T21:02:56.595283Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.610180Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.608681Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.636165Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.636165Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.645674Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.645674Z"
     },
     "papermill": {
-     "duration": 0.028462,
-     "end_time": "2026-06-06T21:02:56.612381",
+     "duration": 0.014242,
+     "end_time": "2026-06-10T10:34:56.646407",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.583919",
+     "start_time": "2026-06-10T10:34:56.632165",
      "status": "completed"
     },
     "tags": []
@@ -913,7 +921,7 @@
       "  Datalog: grandparentOf(X,Z) :- grandparentOf(X,Y), siblingOf(Y,Z)\n",
       "  Body pairs (5): [('Marie', 'Anne'), ('Marie', 'Luc'), ('Marie', 'Sophie'), ('Pierre', 'Luc'), ('Pierre', 'Sophie')]\n",
       "  Support pairs (4): [('Marie', 'Luc'), ('Marie', 'Sophie'), ('Pierre', 'Luc'), ('Pierre', 'Sophie')]\n",
-      "  ** Nouveaux triples inferees (1): [('Marie', 'Anne')]\n",
+      "  ** Nouveaux triples inferes (1): [('Marie', 'Anne')]\n",
       "  Support=4, Confidence=0.80\n",
       "\n",
       "Regle 4 :\n",
@@ -921,7 +929,7 @@
       "  Datalog: grandparentOf(X,Z) :- marriedTo(X,Y), grandparentOf(Y,Z)\n",
       "  Body pairs (5): [('Marie', 'Luc'), ('Marie', 'Sophie'), ('Pierre', 'Luc'), ('Pierre', 'Paul'), ('Pierre', 'Sophie')]\n",
       "  Support pairs (4): [('Marie', 'Luc'), ('Marie', 'Sophie'), ('Pierre', 'Luc'), ('Pierre', 'Sophie')]\n",
-      "  ** Nouveaux triples inferees (1): [('Pierre', 'Paul')]\n",
+      "  ** Nouveaux triples inferes (1): [('Pierre', 'Paul')]\n",
       "  Support=4, Confidence=0.80\n",
       "\n",
       "Regle 5 :\n",
@@ -929,7 +937,7 @@
       "  Datalog: grandparentOf(X,Z) :- parentOf(X,Y), parentOf(Y,Z)\n",
       "  Body pairs (14): [('Claire', 'Emma'), ('Claire', 'Thomas'), ('Jean', 'Hugo'), ('Jean', 'Julie'), ('Jean', 'Lea'), ('Jean', 'Marc')]\n",
       "  Support pairs (5): [('Marie', 'Luc'), ('Marie', 'Paul'), ('Marie', 'Sophie'), ('Pierre', 'Luc'), ('Pierre', 'Sophie')]\n",
-      "  ** Nouveaux triples inferees (9): [('Claire', 'Emma'), ('Claire', 'Thomas'), ('Jean', 'Hugo'), ('Jean', 'Julie'), ('Jean', 'Lea'), ('Jean', 'Marc'), ('Marie', 'Anne'), ('Pierre', 'Anne'), ('Pierre', 'Paul')]\n",
+      "  ** Nouveaux triples inferes (9): [('Claire', 'Emma'), ('Claire', 'Thomas'), ('Jean', 'Hugo'), ('Jean', 'Julie'), ('Jean', 'Lea'), ('Jean', 'Marc'), ('Marie', 'Anne'), ('Pierre', 'Anne'), ('Pierre', 'Paul')]\n",
       "  Support=5, Confidence=0.36\n",
       "\n",
       "============================================================\n",
@@ -937,7 +945,7 @@
       "\n",
       "  parentOf ^ parentOf JOIN result : 14 paires\n",
       "  grandparentOf existants : [('Marie', 'Luc'), ('Marie', 'Paul'), ('Marie', 'Sophie'), ('Pierre', 'Luc'), ('Pierre', 'Sophie')]\n",
-      "  Triples inferees (manquants) : [('Claire', 'Emma'), ('Claire', 'Thomas'), ('Jean', 'Hugo'), ('Jean', 'Julie'), ('Jean', 'Lea'), ('Jean', 'Marc'), ('Marie', 'Anne'), ('Pierre', 'Anne'), ('Pierre', 'Paul')]\n",
+      "  Triples inferes (manquants) : [('Claire', 'Emma'), ('Claire', 'Thomas'), ('Jean', 'Hugo'), ('Jean', 'Julie'), ('Jean', 'Lea'), ('Jean', 'Marc'), ('Marie', 'Anne'), ('Pierre', 'Anne'), ('Pierre', 'Paul')]\n",
       "  Gain : +9 triples (de 5 a 14)\n"
      ]
     }
@@ -969,7 +977,7 @@
     "        # Identify inferred pairs (body but NOT in head)\n",
     "        inferred = body_pairs - relations[rh]\n",
     "        if inferred:\n",
-    "            print(f\"  ** Nouveaux triples inferees ({len(inferred)}): {sorted(inferred)}\")\n",
+    "            print(f\"  ** Nouveaux triples inferes ({len(inferred)}): {sorted(inferred)}\")\n",
     "    else:\n",
     "        r1 = rule[\"body\"][0]\n",
     "        rh = rule[\"head\"]\n",
@@ -988,7 +996,7 @@
     "\n",
     "print(f\"\\n  parentOf ^ parentOf JOIN result : {len(body_gp)} paires\")\n",
     "print(f\"  grandparentOf existants : {sorted(existing_gp)}\")\n",
-    "print(f\"  Triples inferees (manquants) : {sorted(new_gp)}\")\n",
+    "print(f\"  Triples inferes (manquants) : {sorted(new_gp)}\")\n",
     "print(f\"  Gain : +{len(new_gp)} triples (de {len(existing_gp)} a {len(existing_gp) + len(new_gp)})\")"
    ]
   },
@@ -997,10 +1005,10 @@
    "id": "5dc0af7c",
    "metadata": {
     "papermill": {
-     "duration": 0.009227,
-     "end_time": "2026-06-06T21:02:56.628892",
+     "duration": 0.004007,
+     "end_time": "2026-06-10T10:34:56.653419",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.619665",
+     "start_time": "2026-06-10T10:34:56.649412",
      "status": "completed"
     },
     "tags": []
@@ -1029,10 +1037,10 @@
    "id": "16b4761d",
    "metadata": {
     "papermill": {
-     "duration": 0.009132,
-     "end_time": "2026-06-06T21:02:56.647538",
+     "duration": 0.004013,
+     "end_time": "2026-06-10T10:34:56.659935",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.638406",
+     "start_time": "2026-06-10T10:34:56.655922",
      "status": "completed"
     },
     "tags": []
@@ -1051,16 +1059,16 @@
    "id": "b1263c6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:56.668104Z",
-     "iopub.status.busy": "2026-06-06T21:02:56.667213Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.681769Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.680424Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.667930Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.666930Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.676452Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.676452Z"
     },
     "papermill": {
-     "duration": 0.027712,
-     "end_time": "2026-06-06T21:02:56.683946",
+     "duration": 0.014067,
+     "end_time": "2026-06-10T10:34:56.677453",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.656234",
+     "start_time": "2026-06-10T10:34:56.663386",
      "status": "completed"
     },
     "tags": []
@@ -1074,12 +1082,19 @@
       "  Total triples : 47\n",
       "  grandparentOf triples : 5\n",
       "\n",
-      "APRES application des regles (conf >= 0.5) :\n",
-      "  Total triples : 49 (+2)\n",
-      "  grandparentOf triples : 7 (+2)\n",
+      "APRES application des regles (PCA conf >= 0.5) :\n",
+      "  Total triples : 56 (+9)\n",
+      "  grandparentOf triples : 14 (+9)\n",
       "\n",
-      "Triples inferees :\n",
+      "Triples inferes :\n",
+      "  Claire -- grandparentOf --> Emma\n",
+      "  Claire -- grandparentOf --> Thomas\n",
+      "  Jean -- grandparentOf --> Hugo\n",
+      "  Jean -- grandparentOf --> Julie\n",
+      "  Jean -- grandparentOf --> Lea\n",
+      "  Jean -- grandparentOf --> Marc\n",
       "  Marie -- grandparentOf --> Anne\n",
+      "  Pierre -- grandparentOf --> Anne\n",
       "  Pierre -- grandparentOf --> Paul\n"
      ]
     }
@@ -1093,13 +1108,19 @@
     "    min_confidence: float = 0.5\n",
     ") -> list[tuple]:\n",
     "    \"\"\"Apply discovered rules to infer new triples in the graph.\n",
-    "    \n",
+    "\n",
+    "    Le filtre porte sur la PCA confidence : sous Open World Assumption,\n",
+    "    c'est elle qui estime la fiabilite d'une regle (cf. section 5). Filtrer\n",
+    "    sur la confidence standard eliminerait la regle cible\n",
+    "    parentOf ^ parentOf => grandparentOf (0.36 < 0.5) alors que sa PCA\n",
+    "    confidence (0.62) la qualifie -- c'est le choix d'AMIE.\n",
+    "\n",
     "    Returns list of inferred (subject, predicate, object) triples.\n",
     "    \"\"\"\n",
     "    inferred_triples = []\n",
     "    \n",
     "    for rule in rules:\n",
-    "        if rule[\"confidence\"] < min_confidence:\n",
+    "        if rule[\"pca_confidence\"] < min_confidence:\n",
     "            continue\n",
     "        \n",
     "        head_pred = rule[\"head\"]\n",
@@ -1120,7 +1141,8 @@
     "            o_uri = URIRef(namespace + obj)\n",
     "            triple = (s_uri, head_uri, o_uri)\n",
     "            \n",
-    "            # Add to graph\n",
+    "            if triple in graph:\n",
+    "                continue  # deja infere par une regle precedente\n",
     "            graph.add(triple)\n",
     "            inferred_triples.append((subj, head_pred, obj))\n",
     "    \n",
@@ -1136,21 +1158,21 @@
     "print(f\"  grandparentOf triples : {n_gp_before}\")\n",
     "print()\n",
     "\n",
-    "# Apply rules with confidence >= 0.5\n",
+    "# Apply rules with PCA confidence >= 0.5\n",
     "inferred = apply_rules(g, relations, rules, FAM, min_confidence=0.5)\n",
     "\n",
     "# Count triples after\n",
     "n_after = len(g)\n",
     "n_gp_after = len(list(g.triples((None, FAM.grandparentOf, None))))\n",
     "\n",
-    "print(f\"APRES application des regles (conf >= 0.5) :\")\n",
+    "print(f\"APRES application des regles (PCA conf >= 0.5) :\")\n",
     "print(f\"  Total triples : {n_after} (+{n_after - n_before})\")\n",
     "print(f\"  grandparentOf triples : {n_gp_after} (+{n_gp_after - n_gp_before})\")\n",
     "print()\n",
     "\n",
     "# Show inferred triples\n",
     "if inferred:\n",
-    "    print(\"Triples inferees :\")\n",
+    "    print(\"Triples inferes :\")\n",
     "    for subj, pred, obj in sorted(inferred):\n",
     "        print(f\"  {subj} -- {pred} --> {obj}\")\n",
     "else:\n",
@@ -1162,10 +1184,10 @@
    "id": "1a969bc5",
    "metadata": {
     "papermill": {
-     "duration": 0.009645,
-     "end_time": "2026-06-06T21:02:56.703530",
+     "duration": 0.003999,
+     "end_time": "2026-06-10T10:34:56.687444",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.693885",
+     "start_time": "2026-06-10T10:34:56.683445",
      "status": "completed"
     },
     "tags": []
@@ -1173,15 +1195,23 @@
    "source": [
     "### Interpretation : Completion du Knowledge Graph\n",
     "\n",
-    "Les regles de haute confiance ont permis d'inferer de nouveaux triples, completant le graphe.\n",
+    "Les regles qualifiees par leur **PCA confidence** ont permis d'inferer les 9 triples\n",
+    "`grandparentOf` manquants : le graphe passe de 5 a 14 triples, couvrant les trois\n",
+    "generations de grands-parents (Marie/Pierre, mais aussi Jean et Claire qui n'avaient\n",
+    "aucun triple).\n",
     "\n",
     "**Le processus complet** :\n",
     "1. **Extraction** : Convertir le KG en ensembles de paires\n",
-    "2. **Minage** : Enumerer les candidats, calculer support/confidence\n",
-    "3. **Filtrage** : Garder les regles de haute confiance\n",
-    "4. **Application** : Inserer les nouveaux triples dans le graphe\n",
+    "2. **Minage** : Enumerer les candidats, calculer support/confidence/PCA\n",
+    "3. **Filtrage** : Garder les regles de haute **PCA confidence** (pas la confidence\n",
+    "   standard, qui aurait elimine la regle cible -- cf. section 5)\n",
+    "4. **Application** : Inserer les nouveaux triples dans le graphe (avec deduplication,\n",
+    "   plusieurs regles pouvant inferer le meme triple)\n",
     "\n",
-    "> **Note** : Dans les vrais systemes (AMIE3, AnyBURL), l'etape de minage est beaucoup plus sophistiquee avec des optimisations (pruning par support, enumeration fermeture sous les specialisations). Notre implementation simplifiee a une complexite cubique en le nombre de predicats."
+    "> **Note** : Dans les vrais systemes (AMIE3, AnyBURL), l'etape de minage est beaucoup\n",
+    "> plus sophistiquee avec des optimisations (pruning par support, enumeration fermee\n",
+    "> sous les specialisations). Notre implementation simplifiee a une complexite cubique\n",
+    "> en le nombre de predicats.\n"
    ]
   },
   {
@@ -1189,10 +1219,10 @@
    "id": "d71be242",
    "metadata": {
     "papermill": {
-     "duration": 0.009018,
-     "end_time": "2026-06-06T21:02:56.721858",
+     "duration": 0.003258,
+     "end_time": "2026-06-10T10:34:56.693702",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.712840",
+     "start_time": "2026-06-10T10:34:56.690444",
      "status": "completed"
     },
     "tags": []
@@ -1211,16 +1241,16 @@
    "id": "4022209e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:56.741275Z",
-     "iopub.status.busy": "2026-06-06T21:02:56.740605Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.752530Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.751619Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.702645Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.702645Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.708539Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.708539Z"
     },
     "papermill": {
-     "duration": 0.024779,
-     "end_time": "2026-06-06T21:02:56.754796",
+     "duration": 0.011334,
+     "end_time": "2026-06-10T10:34:56.709533",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.730017",
+     "start_time": "2026-06-10T10:34:56.698199",
      "status": "completed"
     },
     "tags": []
@@ -1262,6 +1292,12 @@
       "\n",
       "\n",
       "Triples grandparentOf (apres completion) :\n",
+      "  Claire -- grandparentOf --> Thomas\n",
+      "  Claire -- grandparentOf --> Emma\n",
+      "  Jean -- grandparentOf --> Lea\n",
+      "  Jean -- grandparentOf --> Julie\n",
+      "  Jean -- grandparentOf --> Marc\n",
+      "  Jean -- grandparentOf --> Hugo\n",
       "  Marie -- grandparentOf --> Luc\n",
       "  Marie -- grandparentOf --> Sophie\n",
       "  Marie -- grandparentOf --> Paul\n",
@@ -1269,8 +1305,9 @@
       "  Pierre -- grandparentOf --> Luc\n",
       "  Pierre -- grandparentOf --> Sophie\n",
       "  Pierre -- grandparentOf --> Paul\n",
+      "  Pierre -- grandparentOf --> Anne\n",
       "\n",
-      "Total : 7 triples grandparentOf\n"
+      "Total : 14 triples grandparentOf\n"
      ]
     }
    ],
@@ -1318,10 +1355,10 @@
    "id": "e22df85d",
    "metadata": {
     "papermill": {
-     "duration": 0.009355,
-     "end_time": "2026-06-06T21:02:56.773184",
+     "duration": 0.004009,
+     "end_time": "2026-06-10T10:34:56.717055",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.763829",
+     "start_time": "2026-06-10T10:34:56.713046",
      "status": "completed"
     },
     "tags": []
@@ -1336,7 +1373,9 @@
     "- **Generation 2** : Luc, Sophie, Paul, Anne (petits-enfants)\n",
     "- **Generation 3** : Marc, Lea, Hugo, Julie, Thomas, Emma (arrieres-petits-enfants)\n",
     "\n",
-    "Les triples `grandparentOf` couvrent maintenant toutes les paires (grand-parent, petit-enfant) possibles grace a la regle decouverte."
+    "Les triples `grandparentOf` couvrent maintenant les **14 paires (grand-parent,\n",
+    "petit-enfant)** du graphe : les 5 d'origine, plus les 9 inferes par les regles\n",
+    "(generations 0, 1 et 2 confondues)."
    ]
   },
   {
@@ -1344,10 +1383,10 @@
    "id": "f1e0ba93",
    "metadata": {
     "papermill": {
-     "duration": 0.007877,
-     "end_time": "2026-06-06T21:02:56.789701",
+     "duration": 0.003724,
+     "end_time": "2026-06-10T10:34:56.723779",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.781824",
+     "start_time": "2026-06-10T10:34:56.720055",
      "status": "completed"
     },
     "tags": []
@@ -1366,16 +1405,16 @@
    "id": "6759ffea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:56.810029Z",
-     "iopub.status.busy": "2026-06-06T21:02:56.809242Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.824221Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.822407Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.731461Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.731461Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.740136Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.739135Z"
     },
     "papermill": {
-     "duration": 0.027397,
-     "end_time": "2026-06-06T21:02:56.826144",
+     "duration": 0.013059,
+     "end_time": "2026-06-10T10:34:56.740136",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.798747",
+     "start_time": "2026-06-10T10:34:56.727077",
      "status": "completed"
     },
     "tags": []
@@ -1453,10 +1492,10 @@
    "id": "c00743ef",
    "metadata": {
     "papermill": {
-     "duration": 0.010203,
-     "end_time": "2026-06-06T21:02:56.847498",
+     "duration": 0.003504,
+     "end_time": "2026-06-10T10:34:56.747636",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.837295",
+     "start_time": "2026-06-10T10:34:56.744132",
      "status": "completed"
     },
     "tags": []
@@ -1467,7 +1506,7 @@
     "| Propriete | Exemple detecte | Interpretation |\n",
     "|-----------|----------------|---------------|\n",
     "| **Symetrie** | `siblingOf`, `marriedTo` | Relation reciproque |\n",
-    "| **Transitivite** | `parentOf` NON transitif | Un parent n'est pas un grand-parent |\n",
+    "| **Transitivite** | `parentOf` NON transitif | Le parent d'un parent n'est pas un parent (c'est un grand-parent) |\n",
     "| **Composition** | `parentOf ^ parentOf => grandparentOf` | Nouvelle relation decouverte |\n",
     "\n",
     "**Points cles** :\n",
@@ -1481,10 +1520,10 @@
    "id": "a6ccf734",
    "metadata": {
     "papermill": {
-     "duration": 0.009688,
-     "end_time": "2026-06-06T21:02:56.866602",
+     "duration": 0.005014,
+     "end_time": "2026-06-10T10:34:56.759176",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.856914",
+     "start_time": "2026-06-10T10:34:56.754162",
      "status": "completed"
     },
     "tags": []
@@ -1503,16 +1542,16 @@
    "id": "092cac51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:56.888943Z",
-     "iopub.status.busy": "2026-06-06T21:02:56.888026Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.899036Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.897705Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.772788Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.772788Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.786811Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.785804Z"
     },
     "papermill": {
-     "duration": 0.024846,
-     "end_time": "2026-06-06T21:02:56.901297",
+     "duration": 0.022124,
+     "end_time": "2026-06-10T10:34:56.786811",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.876451",
+     "start_time": "2026-06-10T10:34:56.764687",
      "status": "completed"
     },
     "tags": []
@@ -1581,10 +1620,10 @@
    "id": "01ea5c6c",
    "metadata": {
     "papermill": {
-     "duration": 0.009264,
-     "end_time": "2026-06-06T21:02:56.920524",
+     "duration": 0.006519,
+     "end_time": "2026-06-10T10:34:56.800369",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.911260",
+     "start_time": "2026-06-10T10:34:56.793850",
      "status": "completed"
     },
     "tags": []
@@ -1608,10 +1647,10 @@
    "id": "671bff9b",
    "metadata": {
     "papermill": {
-     "duration": 0.009946,
-     "end_time": "2026-06-06T21:02:56.941929",
+     "duration": 0.007072,
+     "end_time": "2026-06-10T10:34:56.813111",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.931983",
+     "start_time": "2026-06-10T10:34:56.806039",
      "status": "completed"
     },
     "tags": []
@@ -1629,10 +1668,10 @@
    "id": "341c7bfb",
    "metadata": {
     "papermill": {
-     "duration": 0.010308,
-     "end_time": "2026-06-06T21:02:56.962033",
+     "duration": 0.005944,
+     "end_time": "2026-06-10T10:34:56.826150",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.951725",
+     "start_time": "2026-06-10T10:34:56.820206",
      "status": "completed"
     },
     "tags": []
@@ -1655,16 +1694,16 @@
    "id": "409ababa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:56.984490Z",
-     "iopub.status.busy": "2026-06-06T21:02:56.983958Z",
-     "iopub.status.idle": "2026-06-06T21:02:56.991307Z",
-     "shell.execute_reply": "2026-06-06T21:02:56.989648Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.840929Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.840424Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.848907Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.848300Z"
     },
     "papermill": {
-     "duration": 0.022089,
-     "end_time": "2026-06-06T21:02:56.993669",
+     "duration": 0.017712,
+     "end_time": "2026-06-10T10:34:56.849914",
      "exception": false,
-     "start_time": "2026-06-06T21:02:56.971580",
+     "start_time": "2026-06-10T10:34:56.832202",
      "status": "completed"
     },
     "tags": []
@@ -1709,25 +1748,25 @@
    "id": "719920a9",
    "metadata": {
     "papermill": {
-     "duration": 0.009409,
-     "end_time": "2026-06-06T21:02:57.013069",
+     "duration": 0.007249,
+     "end_time": "2026-06-10T10:34:56.864169",
      "exception": false,
-     "start_time": "2026-06-06T21:02:57.003660",
+     "start_time": "2026-06-10T10:34:56.856920",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Implementer la PCA confidence correcte\n",
+    "### Exercice 2 : Reimplementer la PCA confidence\n",
     "\n",
     "La PCA confidence (Partial Completeness Assumption) est une amelioration de la confidence standard. L'idee est : si le sujet A a au moins un triple de type `head(A, _)` dans le KG, alors on considere que les triples `head` de A sont **complets** (tous les objets possibles sont listes). Si A n'a aucun triple `head`, on ne peut rien conclure.\n",
     "\n",
     "$$\n",
-    "PCA(\\text{body} \\Rightarrow \\text{head}) = \\frac{\\text{support}}{|\\{(a,c) : \\text{body}(a,c) \\wedge \\text{head}(a,c)\\}| + |\\{(a,c) : \\text{body}(a,c) \\wedge \\neg \\text{head}(a,c) \\wedge \\exists z.\\text{head}(a,z)\\}|\n",
+    "PCA(\\text{body} \\Rightarrow \\text{head}) = \\frac{\\text{support}}{|\\{(a,c) : \\text{body}(a,c) \\wedge \\text{head}(a,c)\\}| + |\\{(a,c) : \\text{body}(a,c) \\wedge \\neg \\text{head}(a,c) \\wedge \\exists z.\\text{head}(a,z)\\}|}\n",
     "$$\n",
     "\n",
     "**Etapes** :\n",
-    "1. Modifier `evaluate_rule` pour calculer la PCA confidence correctement\n",
+    "1. Reimplementer le calcul PCA de zero dans `evaluate_rule_pca` (sans recopier la section 4) et verifier que vous retrouvez les valeurs de la section 5\n",
     "2. Le denominateur PCA = support + (body pairs ou A a un head triple mais pas vers C)\n",
     "3. Comparer PCA vs confidence standard sur les regles decouvertes"
    ]
@@ -1738,16 +1777,16 @@
    "id": "89b763a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:57.035613Z",
-     "iopub.status.busy": "2026-06-06T21:02:57.034774Z",
-     "iopub.status.idle": "2026-06-06T21:02:57.045865Z",
-     "shell.execute_reply": "2026-06-06T21:02:57.044534Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.879715Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.879183Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.895096Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.895096Z"
     },
     "papermill": {
-     "duration": 0.025444,
-     "end_time": "2026-06-06T21:02:57.048120",
+     "duration": 0.025594,
+     "end_time": "2026-06-10T10:34:56.896915",
      "exception": false,
-     "start_time": "2026-06-06T21:02:57.022676",
+     "start_time": "2026-06-10T10:34:56.871321",
      "status": "completed"
     },
     "tags": []
@@ -1764,7 +1803,7 @@
    ],
    "source": [
     "# Exercice 2 : Implementer la PCA confidence correcte\n",
-    "# TODO etudiant : reimplanter evaluate_rule avec la vraie formule PCA\n",
+    "# TODO etudiant : reimplementer le calcul PCA de zero (verifiez contre la section 5)\n",
     "# Indice : le denominateur PCA compte les body pairs ou A a un head triple\n",
     "#          (vers n'importe quel objet) mais PAS vers C specifiquement\n",
     "\n",
@@ -1811,10 +1850,10 @@
    "id": "44737d28",
    "metadata": {
     "papermill": {
-     "duration": 0.010612,
-     "end_time": "2026-06-06T21:02:57.069934",
+     "duration": 0.006358,
+     "end_time": "2026-06-10T10:34:56.910832",
      "exception": false,
-     "start_time": "2026-06-06T21:02:57.059322",
+     "start_time": "2026-06-10T10:34:56.904474",
      "status": "completed"
     },
     "tags": []
@@ -1822,7 +1861,7 @@
    "source": [
     "### Exercice 3 : Regles a 3 atomes\n",
     "\n",
-    "Les regles que nous avons minnees ont au plus 2 atomes dans le corps. Etendez l'algorithme pour supporter des regles a 3 atomes :\n",
+    "Les regles que nous avons minees ont au plus 2 atomes dans le corps. Etendez l'algorithme pour supporter des regles a 3 atomes :\n",
     "\n",
     "$$\n",
     "r_1(A,B) \\wedge r_2(B,C) \\wedge r_3(C,D) \\Rightarrow r_{head}(A,D)\n",
@@ -1840,16 +1879,16 @@
    "id": "d20502d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:02:57.092931Z",
-     "iopub.status.busy": "2026-06-06T21:02:57.092212Z",
-     "iopub.status.idle": "2026-06-06T21:02:57.101754Z",
-     "shell.execute_reply": "2026-06-06T21:02:57.100355Z"
+     "iopub.execute_input": "2026-06-10T10:34:56.925426Z",
+     "iopub.status.busy": "2026-06-10T10:34:56.923830Z",
+     "iopub.status.idle": "2026-06-10T10:34:56.941547Z",
+     "shell.execute_reply": "2026-06-10T10:34:56.940995Z"
     },
     "papermill": {
-     "duration": 0.023143,
-     "end_time": "2026-06-06T21:02:57.103792",
+     "duration": 0.024795,
+     "end_time": "2026-06-10T10:34:56.942058",
      "exception": false,
-     "start_time": "2026-06-06T21:02:57.080649",
+     "start_time": "2026-06-10T10:34:56.917263",
      "status": "completed"
     },
     "tags": []
@@ -1900,10 +1939,10 @@
    "id": "a1ba5b56",
    "metadata": {
     "papermill": {
-     "duration": 0.009724,
-     "end_time": "2026-06-06T21:02:57.123747",
+     "duration": 0.006662,
+     "end_time": "2026-06-10T10:34:56.955754",
      "exception": false,
-     "start_time": "2026-06-06T21:02:57.114023",
+     "start_time": "2026-06-10T10:34:56.949092",
      "status": "completed"
     },
     "tags": []
@@ -1921,7 +1960,7 @@
     "| **rdflib** | Bibliotheque Python de reference pour manipuler les KG |\n",
     "| **Rule Mining** | Decouvrir des regles de Horn dans un KG (inspire d'AMIE3) |\n",
     "| **Support** | Nombre de paires couvrant a la fois le corps et la tete de la regle |\n",
-    "| **Confidence** | Probabilite conditionnelle P(tete | corps) |\n",
+    "| **Confidence** | Probabilite conditionnelle P(tete sachant corps) |\n",
     "| **PCA Confidence** | Confidence ajustee pour l'Open World Assumption |\n",
     "| **Composition** | Decouvrir de nouvelles relations par jointure (ex: parentOf ^ parentOf = grandparentOf) |\n",
     "\n",
@@ -1950,10 +1989,10 @@
    "id": "c4b6e83b",
    "metadata": {
     "papermill": {
-     "duration": 0.010362,
-     "end_time": "2026-06-06T21:02:57.145190",
+     "duration": 0.006515,
+     "end_time": "2026-06-10T10:34:56.968316",
      "exception": false,
-     "start_time": "2026-06-06T21:02:57.134828",
+     "start_time": "2026-06-10T10:34:56.961801",
      "status": "completed"
     },
     "tags": []
@@ -1963,7 +2002,7 @@
     "\n",
     "Ce notebook a explore l'intersection entre la Programmation Logique Inductive (ILP) et les Knowledge Graphs, en montrant comment les techniques de minage de regles d'association s'adaptent aux donnees du Web Semantique. La construction d'un Knowledge Graph familial avec rdflib a illustre la correspondance naturelle entre triples RDF `(sujet, predicat, objet)` et faits logiques `predicat(sujet, objet)`. L'algorithme de rule mining inspire d'AMIE3 a decouvert automatiquement des regles de Horn dans ce graphe, notamment la regle compositionnelle `parentOf(X,Y) ^ parentOf(Y,Z) => grandparentOf(X,Z)` avec une confiance de 0.36 et une PCA confiance de 0.62.\n",
     "\n",
-    "La distinction entre confiance standard et PCA confiance est centrale dans le contexte des Knowledge Graphs. L'Open World Assumption (OWA) signifie que l'absence d'un triple ne signifie pas que le fait est faux -- il est simplement inconnu. La PCA confiance corrige partiellement cette limitation en excluant du denominateur les paires dont le sujet n'a aucun triple de tete connu. L'application pratique des regles decouvertes a permis de completer le graphe en inferant 2 nouveaux triples `grandparentOf` manquants, passant de 5 a 7 triples sur les 8 possibles.\n",
+    "La distinction entre confiance standard et PCA confiance est centrale dans le contexte des Knowledge Graphs. L'Open World Assumption (OWA) signifie que l'absence d'un triple ne signifie pas que le fait est faux -- il est simplement inconnu. La PCA confiance corrige partiellement cette limitation en excluant du denominateur les paires dont le sujet n'a aucun triple de tete connu. L'application pratique des regles decouvertes a permis de completer le graphe en inferant 2 nouveaux triples `grandparentOf` manquants, passant de 5 a 14 triples -- a condition de filtrer les regles par PCA confidence et non par confidence standard.\n",
     "\n",
     "Les proprietes logiques detectees automatiquement (symetrie de `siblingOf` et `marriedTo`, composition `parentOf ^ parentOf => grandparentOf`) correspondent aux proprietes OWL declarees manuellement dans les ontologies formelles. Le rule mining les apprend directement des donnees, offrant une alternative scalable a la modelisation ontologique manuelle. Le notebook suivant, [SL-7 - LLM + Symbolic Learning](SL-7-LLM-SymbolicLearning.ipynb), prolonge cette reflexion en explorant comment les grands modeles de langage peuvent generer et valider des regles symboliques, ouvrant la voie a une cooperation entre approches statistiques a grande echelle et raisonnement formel.\n"
    ]
@@ -1973,10 +2012,10 @@
    "id": "cf1b23f7",
    "metadata": {
     "papermill": {
-     "duration": 0.009805,
-     "end_time": "2026-06-06T21:02:57.164747",
+     "duration": 0.00663,
+     "end_time": "2026-06-10T10:34:56.980474",
      "exception": false,
-     "start_time": "2026-06-06T21:02:57.154942",
+     "start_time": "2026-06-10T10:34:56.973844",
      "status": "completed"
     },
     "tags": []
@@ -2015,18 +2054,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.129837,
-   "end_time": "2026-06-06T21:02:57.523315",
+   "duration": 8.127889,
+   "end_time": "2026-06-10T10:34:57.315675",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb",
-   "output_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb",
+   "input_path": "SL-6-KnowledgeGraphs-ILP.ipynb",
+   "output_path": "SL-6-KnowledgeGraphs-ILP.ipynb",
    "parameters": {},
-   "start_time": "2026-06-06T21:02:47.393478",
+   "start_time": "2026-06-10T10:34:49.187786",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "097196f2",
    "metadata": {
     "papermill": {
-     "duration": 0.007001,
-     "end_time": "2026-06-10T10:10:42.202943",
+     "duration": 0.006777,
+     "end_time": "2026-06-10T10:40:08.146918",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.195942",
+     "start_time": "2026-06-10T10:40:08.140141",
      "status": "completed"
     },
     "tags": []
@@ -47,16 +47,16 @@
    "id": "3dc32d19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.215138Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.214138Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.226868Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.226868Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.155271Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.155271Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.170451Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.170451Z"
     },
     "papermill": {
-     "duration": 0.018849,
-     "end_time": "2026-06-10T10:10:42.227868",
+     "duration": 0.020862,
+     "end_time": "2026-06-10T10:40:08.171451",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.209019",
+     "start_time": "2026-06-10T10:40:08.150589",
      "status": "completed"
     },
     "tags": []
@@ -99,10 +99,10 @@
    "id": "23731406",
    "metadata": {
     "papermill": {
-     "duration": 0.004436,
-     "end_time": "2026-06-10T10:10:42.235813",
+     "duration": 0.004022,
+     "end_time": "2026-06-10T10:40:08.177977",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.231377",
+     "start_time": "2026-06-10T10:40:08.173955",
      "status": "completed"
     },
     "tags": []
@@ -141,16 +141,16 @@
    "id": "f1d96718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.248715Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.248206Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.258309Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.257308Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.185008Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.185008Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.202983Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.202372Z"
     },
     "papermill": {
-     "duration": 0.015764,
-     "end_time": "2026-06-10T10:10:42.258309",
+     "duration": 0.023081,
+     "end_time": "2026-06-10T10:40:08.204574",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.242545",
+     "start_time": "2026-06-10T10:40:08.181493",
      "status": "completed"
     },
     "tags": []
@@ -233,10 +233,10 @@
    "id": "3827f67e",
    "metadata": {
     "papermill": {
-     "duration": 0.0051,
-     "end_time": "2026-06-10T10:10:42.270407",
+     "duration": 0.005432,
+     "end_time": "2026-06-10T10:40:08.215757",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.265307",
+     "start_time": "2026-06-10T10:40:08.210325",
      "status": "completed"
     },
     "tags": []
@@ -258,10 +258,10 @@
    "id": "59e172f2",
    "metadata": {
     "papermill": {
-     "duration": 0.00618,
-     "end_time": "2026-06-10T10:10:42.281312",
+     "duration": 0.00543,
+     "end_time": "2026-06-10T10:40:08.226501",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.275132",
+     "start_time": "2026-06-10T10:40:08.221071",
      "status": "completed"
     },
     "tags": []
@@ -296,16 +296,16 @@
    "id": "581df035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.294900Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.294365Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.303736Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.303139Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.237776Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.237202Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.248664Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.248087Z"
     },
     "papermill": {
      "duration": 0.01727,
-     "end_time": "2026-06-10T10:10:42.304787",
+     "end_time": "2026-06-10T10:40:08.249671",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.287517",
+     "start_time": "2026-06-10T10:40:08.232401",
      "status": "completed"
     },
     "tags": []
@@ -336,7 +336,10 @@
     "    \"Type\", \"WaitEstimate\"\n",
     "]\n",
     "\n",
-    "# Les 12 exemples du restaurant (AIMA Table 19.1)\n",
+    "# Les 12 exemples du restaurant, adaptes de la Table 19.1 d'AIMA.\n",
+    "# Comme en SL-1, les labels de X2 et X3 sont inverses par rapport au livre :\n",
+    "# ainsi AUCUNE clause de Horn unique n'est consistante (meme Patrons=Some a un\n",
+    "# contre-exemple), ce qui est exactement le scenario que l'oracle doit detecter.\n",
     "RAW_EXAMPLES = [\n",
     "    (\"Yes\", \"No\",  \"No\",  \"Yes\", \"Some\", \"$$$\", \"No\",  \"Yes\",  \"French\", \"0-10\",  True),\n",
     "    (\"Yes\", \"No\",  \"No\",  \"Yes\", \"Full\", \"$\",   \"No\",  \"No\",   \"Thai\",   \"30-60\", True),\n",
@@ -375,10 +378,10 @@
    "id": "72e21fc7",
    "metadata": {
     "papermill": {
-     "duration": 0.006176,
-     "end_time": "2026-06-10T10:10:42.317688",
+     "duration": 0.003001,
+     "end_time": "2026-06-10T10:40:08.255690",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.311512",
+     "start_time": "2026-06-10T10:40:08.252689",
      "status": "completed"
     },
     "tags": []
@@ -402,16 +405,16 @@
    "id": "eed948cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.331776Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.331262Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.349673Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.348583Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.266291Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.265282Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.279472Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.278888Z"
     },
     "papermill": {
-     "duration": 0.026699,
-     "end_time": "2026-06-10T10:10:42.350711",
+     "duration": 0.019723,
+     "end_time": "2026-06-10T10:40:08.280480",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.324012",
+     "start_time": "2026-06-10T10:40:08.260757",
      "status": "completed"
     },
     "tags": []
@@ -501,10 +504,10 @@
    "id": "85c22afd",
    "metadata": {
     "papermill": {
-     "duration": 0.006178,
-     "end_time": "2026-06-10T10:10:42.363612",
+     "duration": 0.004042,
+     "end_time": "2026-06-10T10:40:08.287716",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.357434",
+     "start_time": "2026-06-10T10:40:08.283674",
      "status": "completed"
     },
     "tags": []
@@ -523,16 +526,16 @@
    "id": "1c109513",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.376023Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.376023Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.396063Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.394922Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.295790Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.295790Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.311229Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.310655Z"
     },
     "papermill": {
-     "duration": 0.028285,
-     "end_time": "2026-06-10T10:10:42.397098",
+     "duration": 0.019978,
+     "end_time": "2026-06-10T10:40:08.311746",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.368813",
+     "start_time": "2026-06-10T10:40:08.291768",
      "status": "completed"
     },
     "tags": []
@@ -644,10 +647,10 @@
    "id": "bf930a24",
    "metadata": {
     "papermill": {
-     "duration": 0.005508,
-     "end_time": "2026-06-10T10:10:42.410875",
+     "duration": 0.003519,
+     "end_time": "2026-06-10T10:40:08.318776",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.405367",
+     "start_time": "2026-06-10T10:40:08.315257",
      "status": "completed"
     },
     "tags": []
@@ -666,7 +669,7 @@
     "| R5 | Patrons=Full AND Price=$$$ | NOT WillWait | Regle negative conjonctive |\n",
     "\n",
     "**Observations** :\n",
-    "- R1 et R2 correspondent au concept cible AIMA (`Patrons=Some OU (Patrons=Full AND Hungry=Yes)`)\n",
+    "- R1 et R2 visent la disjonction classique du domaine restaurant (`Patrons=Some OU (Patrons=Full AND Hungry=Yes)`) -- mais on verra que, dans notre variante des donnees, meme elles ont chacune un contre-exemple\n",
     "- R3 est une **sur-generalisation** (Hungry=Yes couvre aussi des negatifs)\n",
     "- R4 et R5 sont des regles negatives complementaires\n",
     "\n",
@@ -678,10 +681,10 @@
    "id": "d6bb9fe1",
    "metadata": {
     "papermill": {
-     "duration": 0.005508,
-     "end_time": "2026-06-10T10:10:42.423383",
+     "duration": 0.006115,
+     "end_time": "2026-06-10T10:40:08.329911",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.417875",
+     "start_time": "2026-06-10T10:40:08.323796",
      "status": "completed"
     },
     "tags": []
@@ -708,16 +711,16 @@
    "id": "2c0873ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.437841Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.437291Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.458569Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.457479Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.344067Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.342559Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.357227Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.356652Z"
     },
     "papermill": {
-     "duration": 0.029232,
-     "end_time": "2026-06-10T10:10:42.459616",
+     "duration": 0.022304,
+     "end_time": "2026-06-10T10:40:08.358235",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.430384",
+     "start_time": "2026-06-10T10:40:08.335931",
      "status": "completed"
     },
     "tags": []
@@ -839,10 +842,10 @@
    "id": "0f9984a1",
    "metadata": {
     "papermill": {
-     "duration": 0.006225,
-     "end_time": "2026-06-10T10:10:42.472081",
+     "duration": 0.005528,
+     "end_time": "2026-06-10T10:40:08.369807",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.465856",
+     "start_time": "2026-06-10T10:40:08.364279",
      "status": "completed"
     },
     "tags": []
@@ -861,8 +864,9 @@
     "| R5 (Patrons=Full AND Price=$$$ => NOT) | **Consistante** | 2 | 0 | Regle negative correcte |\n",
     "\n",
     "**Observation importante** : Aucune regle positive n'est parfaitement consistante !\n",
-    "C'est parce que le concept cible AIMA ()\n",
-    "est **disjonctif** -- il ne peut pas etre capture par une seule clause de Horn.\n",
+    "C'est voulu : les donnees (labels de X2/X3 inverses par rapport au livre) rendent le\n",
+    "concept strictement **disjonctif avec exceptions** -- il ne peut pas etre capture par\n",
+    "une seule clause de Horn.\n",
     "L'exemple 9 (Full, Hungry=Yes, Italian, Price=$$$ => WillWait=False) contredit meme R2.\n",
     "\n",
     "> **Point cle** : L'oracle symbolique detecte que le concept est disjonctif. Seules les regles negatives (R4, R5) passent la verification. C'est une limitation fondamentale de la representation par clauses de Horn individuelles, que nous avions deja rencontree en SL-1 avec le Version Space vide.\n"
@@ -874,16 +878,16 @@
    "id": "9a30e01b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.486019Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.486019Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.505584Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.504583Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.383417Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.383417Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.389882Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.388845Z"
     },
     "papermill": {
-     "duration": 0.027678,
-     "end_time": "2026-06-10T10:10:42.506584",
+     "duration": 0.013519,
+     "end_time": "2026-06-10T10:40:08.389882",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.478906",
+     "start_time": "2026-06-10T10:40:08.376363",
      "status": "completed"
     },
     "tags": []
@@ -966,10 +970,10 @@
    "id": "74c02d03",
    "metadata": {
     "papermill": {
-     "duration": 0.006243,
-     "end_time": "2026-06-10T10:10:42.520827",
+     "duration": 0.005027,
+     "end_time": "2026-06-10T10:40:08.401950",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.514584",
+     "start_time": "2026-06-10T10:40:08.396923",
      "status": "completed"
     },
     "tags": []
@@ -1005,16 +1009,16 @@
    "id": "83e5f5eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.535832Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.534830Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.552341Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.551340Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.413017Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.412502Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.436513Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.435960Z"
     },
     "papermill": {
-     "duration": 0.02451,
-     "end_time": "2026-06-10T10:10:42.552341",
+     "duration": 0.030556,
+     "end_time": "2026-06-10T10:40:08.437520",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.527831",
+     "start_time": "2026-06-10T10:40:08.406964",
      "status": "completed"
     },
     "tags": []
@@ -1024,7 +1028,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Traces Chain-of-Thought (simulees)\n",
+      "Traces Chain-of-Thought (simulees)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "=================================================================\n",
       "\n",
       "Ex 0 [+] Pat=Some, Type=French, Hungry=Yes\n",
@@ -1179,10 +1190,10 @@
    "id": "3653b321",
    "metadata": {
     "papermill": {
-     "duration": 0.007016,
-     "end_time": "2026-06-10T10:10:42.565979",
+     "duration": 0.006567,
+     "end_time": "2026-06-10T10:40:08.448653",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.558963",
+     "start_time": "2026-06-10T10:40:08.442086",
      "status": "completed"
     },
     "tags": []
@@ -1195,10 +1206,16 @@
     "| Element CoT | Equivalent EBL | Description |\n",
     "|-------------|---------------|-------------|\n",
     "| Observation initiale | Fait de l'exemple | Point de depart du raisonnement |\n",
-    "| Etape de raisonnement | Application d'une regle | InfERENCE logique |\n",
+    "| Etape de raisonnement | Application d'une regle | Inference logique |\n",
     "| Conclusion intermediaire | Fait derive | Resultat d'une etape |\n",
     "| Decision finale | Conclusion de la preuve | Predicat cible |\n",
     "| Regle extraite | Regle EBL | Generalisation de la trace |\n",
+    "\n",
+    "> **Attention (Ex 2)** : la trace simulee conclut `WillWait=True` sur l'exemple 2\n",
+    "> alors que son label est **False** -- le \"raisonnement\" applique l'heuristique\n",
+    "> `Patrons=Some` sans verifier le reste. Une chaine de raisonnement plausible peut\n",
+    "> donc etre fausse : c'est precisement pourquoi la regle extraite repasse par\n",
+    "> l'oracle symbolique (qui la rejettera, section 5).\n",
     "\n",
     "> **Point cle** : Le CoT est une forme \"approximative\" d'arbre de preuve. La difference principale est que le CoT peut contenir des erreurs logiques, tandis que l'arbre de preuve EBL est formellement correct. La verification symbolique permet de detecter ces erreurs."
    ]
@@ -1209,16 +1226,16 @@
    "id": "dc08268f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.580592Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.580592Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.599790Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.598786Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.459035Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.459035Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.467014Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.466402Z"
     },
     "papermill": {
-     "duration": 0.027623,
-     "end_time": "2026-06-10T10:10:42.600293",
+     "duration": 0.014549,
+     "end_time": "2026-06-10T10:40:08.467014",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.572670",
+     "start_time": "2026-06-10T10:40:08.452465",
      "status": "completed"
     },
     "tags": []
@@ -1294,10 +1311,10 @@
    "id": "a575226a",
    "metadata": {
     "papermill": {
-     "duration": 0.007012,
-     "end_time": "2026-06-10T10:10:42.613820",
+     "duration": 0.002517,
+     "end_time": "2026-06-10T10:40:08.473743",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.606808",
+     "start_time": "2026-06-10T10:40:08.471226",
      "status": "completed"
     },
     "tags": []
@@ -1305,15 +1322,20 @@
    "source": [
     "### Interpretation : Extraction de regles depuis CoT\n",
     "\n",
-    "| Methode | Nombre de regles | Qualite | Source |\n",
-    "|---------|-----------------|---------|--------|\n",
-    "| LLM direct | 5 candidates | Mixte (3 correctes, 2 incorrectes) | Generation globale |\n",
-    "| CoT extraction | 3-4 uniques | Plus precise | Raisonnement pas-a-pas |\n",
+    "| Methode | Nombre de regles | Verdict oracle (section 3) | Source |\n",
+    "|---------|-----------------|----------------------------|--------|\n",
+    "| LLM direct | 5 candidates | 2 consistantes (les negatives), 3 rejetees | Generation globale |\n",
+    "| CoT extraction | 4 uniques (sur 6 traces) | 2 consistantes (les negatives), 2 rejetees | Raisonnement pas-a-pas |\n",
     "\n",
-    "Les regles extraites du CoT sont souvent **plus fiables** car :\n",
-    "1. Elles sont produites par un raisonnement explicite (pas une intuition globale)\n",
-    "2. Chaque etape peut etre verifiee individuellement\n",
-    "3. Elles sont ancrees dans des exemples concrets\n",
+    "Les regles extraites du CoT ont deux atouts :\n",
+    "1. Chaque etape du raisonnement peut etre verifiee individuellement\n",
+    "2. Elles sont ancrees dans des exemples concrets -- la trace sur l'exemple 4\n",
+    "   (negatif) produit `Patrons=Full AND Hungry=No => NOT WillWait`, une regle\n",
+    "   que la generation directe avait manquee\n",
+    "\n",
+    "Mais l'ancrage ne garantit rien : la trace sur l'exemple 2 (mal classe par le\n",
+    "CoT simule, cf. section 4) re-produit la regle fautive `Patrons=Some => WillWait`.\n",
+    "L'oracle reste indispensable.\n",
     "\n",
     "> **Analogie EBL** : Le CoT est a l'extraction de regles ce que la preuve EBL est a la variabilisation. La trace guide la generalisation."
    ]
@@ -1323,10 +1345,10 @@
    "id": "1bd557a0",
    "metadata": {
     "papermill": {
-     "duration": 0.007323,
-     "end_time": "2026-06-10T10:10:42.627280",
+     "duration": 0.006112,
+     "end_time": "2026-06-10T10:40:08.484406",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.619957",
+     "start_time": "2026-06-10T10:40:08.478294",
      "status": "completed"
     },
     "tags": []
@@ -1366,16 +1388,16 @@
    "id": "f9d67f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.643097Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.643097Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.661322Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.660322Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.493389Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.491874Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.514193Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.513633Z"
     },
     "papermill": {
-     "duration": 0.028185,
-     "end_time": "2026-06-10T10:10:42.662322",
+     "duration": 0.027405,
+     "end_time": "2026-06-10T10:40:08.515199",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.634137",
+     "start_time": "2026-06-10T10:40:08.487794",
      "status": "completed"
     },
     "tags": []
@@ -1440,11 +1462,19 @@
     "        \n",
     "        # Etape 2b (optionnel) : Generation CoT\n",
     "        if self.use_cot:\n",
+    "            # CoT sur un mix de positifs ET de negatifs : les traces sur les\n",
+    "            # negatifs produisent des regles negatives que la generation\n",
+    "            # directe peut manquer. Deduplication contre les candidates\n",
+    "            # directes pour ne garder que l'apport reel du CoT.\n",
     "            positives = [e for e in examples if e[target]]\n",
-    "            for i, ex in enumerate(positives[:3]):  # CoT sur 3 positifs\n",
+    "            negatives = [e for e in examples if not e[target]]\n",
+    "            seen = {str(r) for r in candidates}\n",
+    "            for i, ex in enumerate(positives[:3] + negatives[:3]):\n",
     "                trace = simulate_cot_classification(ex, i)\n",
-    "                if trace.extracted_rule:\n",
-    "                    candidates.append(trace.extracted_rule)\n",
+    "                rule = trace.extracted_rule\n",
+    "                if rule and str(rule) not in seen:\n",
+    "                    seen.add(str(rule))\n",
+    "                    candidates.append(rule)\n",
     "        \n",
     "        # Etape 3 : Verification\n",
     "        verified = []\n",
@@ -1510,10 +1540,10 @@
    "id": "2f9d2c01",
    "metadata": {
     "papermill": {
-     "duration": 0.0072,
-     "end_time": "2026-06-10T10:10:42.675540",
+     "duration": 0.004157,
+     "end_time": "2026-06-10T10:40:08.522440",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.668340",
+     "start_time": "2026-06-10T10:40:08.518283",
      "status": "completed"
     },
     "tags": []
@@ -1521,12 +1551,19 @@
    "source": [
     "### Execution du pipeline avec Chain-of-Thought\n",
     "\n",
-    "Le pipeline `NeuroSymbolicPipeline` ci-dessus a ete execute **sans** l'option Chain-of-Thought. Activons maintenant le CoT pour observer comment les traces de raisonnement enrichissent le pool de candidats :\n",
+    "Le pipeline `NeuroSymbolicPipeline` ci-dessus a ete execute **sans** l'option\n",
+    "Chain-of-Thought. Activons maintenant le CoT pour observer ce que les traces de\n",
+    "raisonnement apportent au pool de candidats :\n",
     "\n",
     "- **Sans CoT** : seules les 5 regles simulees par `simulate_llm_response()` sont candidates\n",
-    "- **Avec CoT** : 3 regles supplementaires sont extraites des traces de raisonnement sur les exemples positifs, portant le total a 8 candidates\n",
+    "- **Avec CoT** : des traces sont generees sur 3 exemples positifs et 3 negatifs ;\n",
+    "  apres deduplication contre les candidates directes, une seule regle nouvelle\n",
+    "  emerge -- `Patrons=Full AND Hungry=No => NOT WillWait`, issue d'une trace sur\n",
+    "  un exemple **negatif**\n",
     "\n",
-    "Cette comparaison illustre le gain qualitatif du CoT : les regles extraites des traces sont ancrees dans des exemples concrets, tandis que les regles globales risquent davantage d'etre des sur-generalisations."
+    "C'est le point interessant : la generation directe, focalisee sur \"expliquer les\n",
+    "positifs\", avait manque cette regle negative. Le raisonnement exemple-par-exemple\n",
+    "du CoT la fait apparaitre -- et l'oracle la valide.\n"
    ]
   },
   {
@@ -1535,16 +1572,16 @@
    "id": "8917b738",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.691675Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.691083Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.708040Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.707039Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.530561Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.530561Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.546206Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.544988Z"
     },
     "papermill": {
-     "duration": 0.026414,
-     "end_time": "2026-06-10T10:10:42.709050",
+     "duration": 0.021263,
+     "end_time": "2026-06-10T10:40:08.546722",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.682636",
+     "start_time": "2026-06-10T10:40:08.525459",
      "status": "completed"
     },
     "tags": []
@@ -1558,24 +1595,22 @@
       "\n",
       "Pipeline Neuro-Symbolique - Resultat\n",
       "=======================================================\n",
-      "  Candidates generees : 8\n",
-      "  Regles validees     : 2\n",
-      "  Regles rejetees     : 6\n",
+      "  Candidates generees : 6\n",
+      "  Regles validees     : 3\n",
+      "  Regles rejetees     : 3\n",
       "  Couverture positifs : 0%\n",
       "\n",
       "Regles validees :\n",
       "  [OK] Patrons=None => NOT WillWait  (TP=2, FP=0)\n",
       "  [OK] Patrons=Full AND Price=$$$ => NOT WillWait  (TP=2, FP=0)\n",
+      "  [OK] Patrons=Full AND Hungry=No => NOT WillWait  (TP=2, FP=0)\n",
       "\n",
       "Regles rejetees :\n",
       "  [KO] Patrons=Some => WillWait  (FP=1)\n",
       "  [KO] Patrons=Full AND Hungry=Yes => WillWait  (FP=1)\n",
       "  [KO] Hungry=Yes => WillWait  (FP=1)\n",
-      "  [KO] Patrons=Some => WillWait  (FP=1)\n",
-      "  [KO] Patrons=Full AND Hungry=Yes => WillWait  (FP=1)\n",
-      "  [KO] Patrons=Full AND Hungry=Yes => WillWait  (FP=1)\n",
       "\n",
-      "Comparaison : sans CoT (2 validees) vs avec CoT (2 validees)\n"
+      "Comparaison : sans CoT (2 validees) vs avec CoT (3 validees)\n"
      ]
     }
    ],
@@ -1594,10 +1629,10 @@
    "id": "a2edb6e2",
    "metadata": {
     "papermill": {
-     "duration": 0.006524,
-     "end_time": "2026-06-10T10:10:42.722114",
+     "duration": 0.003523,
+     "end_time": "2026-06-10T10:40:08.554253",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.715590",
+     "start_time": "2026-06-10T10:40:08.550730",
      "status": "completed"
     },
     "tags": []
@@ -1615,7 +1650,11 @@
     "| 4. Verification | HornClauses + donnees | Resultats | Oracle symbolique |\n",
     "| 5. Selection | Resultats | Regles validees | Seuils de qualite |\n",
     "\n",
-    "**Avec CoT** : le pipeline genere des regles supplementaires a partir des traces de raisonnement, augmentant potentiellement la couverture.\n",
+    "**Avec CoT** : la regle supplementaire issue d'une trace sur un negatif est validee\n",
+    "par l'oracle (3 validees contre 2 sans CoT). La couverture des positifs reste a 0% :\n",
+    "toutes les regles validees sont negatives, consequence du concept disjonctif. C'est\n",
+    "le pipeline iteratif (section 6), avec sa tolerance aux faux positifs, qui couvrira\n",
+    "les positifs.\n",
     "\n",
     "> **Point cle** : Le pipeline est **iterable**. Si la couverture est insuffisante, on peut re-prompter le LLM avec les erreurs residuelles pour generer de nouvelles hypotheses."
    ]
@@ -1626,16 +1665,16 @@
    "id": "54a6b7c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.735722Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.734722Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.754358Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.753358Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.562855Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.562855Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.576452Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.575451Z"
     },
     "papermill": {
-     "duration": 0.025657,
-     "end_time": "2026-06-10T10:10:42.754358",
+     "duration": 0.019202,
+     "end_time": "2026-06-10T10:40:08.576961",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.728701",
+     "start_time": "2026-06-10T10:40:08.557759",
      "status": "completed"
     },
     "tags": []
@@ -1655,10 +1694,10 @@
       "  Regles negatives   : 2\n",
       "\n",
       "--- Avec CoT ---\n",
-      "  Taux d'acceptation : 2/8 (25%)\n",
+      "  Taux d'acceptation : 3/6 (50%)\n",
       "  Couverture         : 0% des positifs\n",
       "  Regles positives   : 0\n",
-      "  Regles negatives   : 2\n",
+      "  Regles negatives   : 3\n",
       "\n",
       "Metriques par regle validee (sans CoT) :\n",
       "  Regle                               | Precision | Recall |   F1\n",
@@ -1696,10 +1735,10 @@
    "id": "d74db354",
    "metadata": {
     "papermill": {
-     "duration": 0.006019,
-     "end_time": "2026-06-10T10:10:42.768421",
+     "duration": 0.004019,
+     "end_time": "2026-06-10T10:40:08.585115",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.762402",
+     "start_time": "2026-06-10T10:40:08.581096",
      "status": "completed"
     },
     "tags": []
@@ -1723,10 +1762,10 @@
    "id": "3c2e7728",
    "metadata": {
     "papermill": {
-     "duration": 0.006547,
-     "end_time": "2026-06-10T10:10:42.782642",
+     "duration": 0.004435,
+     "end_time": "2026-06-10T10:40:08.592555",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.776095",
+     "start_time": "2026-06-10T10:40:08.588120",
      "status": "completed"
     },
     "tags": []
@@ -1751,16 +1790,16 @@
    "id": "dada4cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.798190Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.797682Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.817919Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.816822Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.603984Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.603984Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.623017Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.623017Z"
     },
     "papermill": {
-     "duration": 0.030298,
-     "end_time": "2026-06-10T10:10:42.818941",
+     "duration": 0.025435,
+     "end_time": "2026-06-10T10:40:08.624019",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.788643",
+     "start_time": "2026-06-10T10:40:08.598584",
      "status": "completed"
     },
     "tags": []
@@ -1770,7 +1809,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pipeline iteratif avec raffinement\n",
+      "Pipeline iteratif avec raffinement"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "=======================================================\n",
       "(Tolerance : max 1 faux positif par regle)\n",
       "\n",
@@ -1886,10 +1932,10 @@
    "id": "3cc1a67b",
    "metadata": {
     "papermill": {
-     "duration": 0.007081,
-     "end_time": "2026-06-10T10:10:42.832745",
+     "duration": 0.003505,
+     "end_time": "2026-06-10T10:40:08.632031",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.825664",
+     "start_time": "2026-06-10T10:40:08.628526",
      "status": "completed"
     },
     "tags": []
@@ -1917,10 +1963,10 @@
    "id": "ba9beb92",
    "metadata": {
     "papermill": {
-     "duration": 0.006517,
-     "end_time": "2026-06-10T10:10:42.846303",
+     "duration": 0.003837,
+     "end_time": "2026-06-10T10:40:08.639887",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.839786",
+     "start_time": "2026-06-10T10:40:08.636050",
      "status": "completed"
     },
     "tags": []
@@ -1936,10 +1982,10 @@
    "id": "3c800f32",
    "metadata": {
     "papermill": {
-     "duration": 0.007548,
-     "end_time": "2026-06-10T10:10:42.860898",
+     "duration": 0.004002,
+     "end_time": "2026-06-10T10:40:08.648906",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.853350",
+     "start_time": "2026-06-10T10:40:08.644904",
      "status": "completed"
     },
     "tags": []
@@ -1962,16 +2008,16 @@
    "id": "5101d0d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.875949Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.875949Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.896078Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.895070Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.657424Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.657424Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.670488Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.669983Z"
     },
     "papermill": {
-     "duration": 0.029163,
-     "end_time": "2026-06-10T10:10:42.897082",
+     "duration": 0.01859,
+     "end_time": "2026-06-10T10:40:08.671494",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.867919",
+     "start_time": "2026-06-10T10:40:08.652904",
      "status": "completed"
     },
     "tags": []
@@ -2018,10 +2064,10 @@
    "id": "2936e442",
    "metadata": {
     "papermill": {
-     "duration": 0.007262,
-     "end_time": "2026-06-10T10:10:42.911635",
+     "duration": 0.002991,
+     "end_time": "2026-06-10T10:40:08.678549",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.904373",
+     "start_time": "2026-06-10T10:40:08.675558",
      "status": "completed"
     },
     "tags": []
@@ -2043,16 +2089,16 @@
    "id": "174aa8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.928412Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.927405Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.941967Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.941967Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.688059Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.687060Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.702071Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.702071Z"
     },
     "papermill": {
-     "duration": 0.02537,
-     "end_time": "2026-06-10T10:10:42.944041",
+     "duration": 0.020524,
+     "end_time": "2026-06-10T10:40:08.703073",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.918671",
+     "start_time": "2026-06-10T10:40:08.682549",
      "status": "completed"
     },
     "tags": []
@@ -2096,10 +2142,10 @@
    "id": "0962260b",
    "metadata": {
     "papermill": {
-     "duration": 0.007044,
-     "end_time": "2026-06-10T10:10:42.955114",
+     "duration": 0.003507,
+     "end_time": "2026-06-10T10:40:08.710086",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.948070",
+     "start_time": "2026-06-10T10:40:08.706579",
      "status": "completed"
     },
     "tags": []
@@ -2121,16 +2167,16 @@
    "id": "3548d43c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.970571Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.970571Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.989643Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.988636Z"
+     "iopub.execute_input": "2026-06-10T10:40:08.719454Z",
+     "iopub.status.busy": "2026-06-10T10:40:08.718448Z",
+     "iopub.status.idle": "2026-06-10T10:40:08.734751Z",
+     "shell.execute_reply": "2026-06-10T10:40:08.733746Z"
     },
     "papermill": {
-     "duration": 0.028514,
-     "end_time": "2026-06-10T10:10:42.990659",
+     "duration": 0.02096,
+     "end_time": "2026-06-10T10:40:08.734751",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.962145",
+     "start_time": "2026-06-10T10:40:08.713791",
      "status": "completed"
     },
     "tags": []
@@ -2195,10 +2241,10 @@
    "id": "7cb00ad4",
    "metadata": {
     "papermill": {
-     "duration": 0.007322,
-     "end_time": "2026-06-10T10:10:43.005111",
+     "duration": 0.004021,
+     "end_time": "2026-06-10T10:40:08.742772",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.997789",
+     "start_time": "2026-06-10T10:40:08.738751",
      "status": "completed"
     },
     "tags": []
@@ -2250,10 +2296,10 @@
    "id": "b2e6b9c6",
    "metadata": {
     "papermill": {
-     "duration": 0.007623,
-     "end_time": "2026-06-10T10:10:43.020493",
+     "duration": 0.004512,
+     "end_time": "2026-06-10T10:40:08.750270",
      "exception": false,
-     "start_time": "2026-06-10T10:10:43.012870",
+     "start_time": "2026-06-10T10:40:08.745758",
      "status": "completed"
     },
     "tags": []
@@ -2295,14 +2341,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.999494,
-   "end_time": "2026-06-10T10:10:43.377115",
+   "duration": 2.533096,
+   "end_time": "2026-06-10T10:40:08.982371",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-7-LLM-SymbolicLearning.ipynb",
    "output_path": "SL-7-LLM-SymbolicLearning.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T10:10:40.377621",
+   "start_time": "2026-06-10T10:40:06.449275",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Tour 2 de la passe critique SymbolicLearning (mandat user : "serie absolument nickel" pour le cours EPITA-IS du 17/06 ; tour 1 = #2756). SL-5 et SL-6 avaient chacun leur **demo centrale silencieusement cassee**, avec des outputs committes qui contredisaient les interpretations. SL-7 inversait le verdict de son propre oracle et revendiquait un gain CoT que son pipeline ne produisait pas.

### SL-5 NeuroSymbolic (LTN / DeepProbLog) — les 3 demos coeur reparees

- **Entrainement LTN casse** [11] : le predicat binaire `parentOf` recevait l'embedding d'UNE seule entite (2 dims) au lieu de la paire. Fix : `pair_embedding = concat(one-hot(sujet), one-hot(objet))` (10 dims), 6 negatifs closed-world (pratique KG embeddings, lien SL-6), gradient cross-entropy propre `(target - val) * x` (l'ancien `gradient() * (1-val)` etait amorti par `val(1-val)^2` et stagnait). Resultat verifie : positifs 0.90-0.92, negatifs <= 0.08 (avant : 0.54-0.62 vs 0.37 — indiscernables).
- **Regle floue grandparent** [14] : `n_inputs=2` -> ValueError corrigee en 2*len(entities) ; attentes honnetes (~0.8 pour la verite du corps, ~0.5 pour les paires non contraintes — modus ponens flou = contrainte positive seulement).
- **DeepProbLog `query()` retournait 0 pour toute variable libre** [17] : Exercice 3 etait insoluble. Fix : enumeration existentielle des bindings (produit des probabilites des atomes, max sur les bindings) -> `grandparent(Marie, Paul) = 0.824` via Y=Pierre.
- Table des t-normes corrigee [4] : `a*b` = **t-norme produit** (pas "AND flou" generique), `min(1, b/a)` = **implication de Goguen** (etait etiquetee Reichenbach), note sur les familles Godel/Lukasiewicz (cf. Exercice 4).
- `np.random.seed(42)` [2], format prints [8], typo [30].

### SL-6 Knowledge Graphs / AMIE — le recit de completion repare

- **Bug central** [20] : `apply_rules` filtrait sur la confidence **standard** >= 0.5, ce qui excluait silencieusement la regle vedette `parentOf ^ parentOf => grandparentOf` (conf 0.36). Seuls +2 triples etaient inferes par des regles annexes, pendant que [24]/[39] revendiquaient "toutes les paires couvertes". Fix : filtre sur la **PCA confidence** (le choix d'AMIE) + deduplication -> **+9 triples (5 -> 14)**, completion reelle des 3 generations. Le bug devient la demonstration pedagogique centrale : l'incompletude du KG punit la bonne regle en confidence standard (5/14=0.36), la PCA la sauve (5/8=0.62).
- **Combinatoire fausse** [5]/[6] : "8 paires possibles, 5/8=0.625" -> 14 paires reelles (Jean et Claire oublies) ; 0.625 est la PCA, pas la confidence standard. [15] reecrit : table = match exact de l'output [14] (la regle cible DERNIERE du classement standard).
- **Rendu LaTeX casse** : pipes `|` dans `$...$` a l'interieur de tables markdown [10]/[12]/[38] (colonnes explosees) -> `\lvert`/`\mid`/reformulation ; accolade fermante manquante dans le `\frac` de l'Exercice 2 [34].
- Exercice 2 recadre ("Reimplementer la PCA" — l'implementation de la section 4 etait deja correcte, le titre laissait croire le contraire) ; typos minees/inferes ; transitivite [27].

### SL-7 LLM-SymbolicLearning — deep pass (tour 1 n'avait couvert que [3])

- **Verdict oracle inverse** [20] : "Mixte (3 correctes, 2 incorrectes)" alors que l'output [13]/[15] prouve 2 validees / 3 rejetees. Corrige.
- **Gain CoT fictif** [22]/[23] : le pipeline ne lancait le CoT que sur les positifs -> il n'ajoutait que des doublons rejetes (acceptation 25% en baisse), pendant que le texte revendiquait un "gain qualitatif". Fix : CoT sur positifs[:3] + negatifs[:3] avec deduplication -> la trace sur l'exemple 4 (negatif) decouvre `Patrons=Full AND Hungry=No => NOT WillWait`, **validee par l'oracle : 3/6 (50%) vs 2/5 (40%)**. [23]/[25] reecrits sur le gain reel.
- **Hallucination CoT documentee** [18] : la trace simulee classe l'exemple 2 `WillWait=True` (label False) sans que rien ne le commente — desormais explicite comme motif "chaine plausible mais fausse => l'oracle reste indispensable".
- **Claim "(AIMA Table 19.1)" rendue honnete** [6] + SL-1 [2] : les labels X2/X3 sont inverses par rapport au livre (et WaitEstimate X9 modifie), deliberement pour qu'aucune clause unique ne soit consistante. C'etait presente comme la table AIMA verbatim.
- [14] phrase tronquee "concept cible AIMA ()" reecrite ; [11] R1/R2 ne sont pas "le concept cible AIMA" ; typo InfERENCE.

Exercices-stubs C.1 (SL-5[20]/[22]/[24]/[26]/[28], SL-6[33]/[35]/[37], SL-7[33]/[35]/[37]) : verifies legitimes, non touches.

## Validation

Papermill end-to-end (kernel python3, conda mcp-jupyter) apres edits, 4 notebooks :

```
SL-1-LogicalLearning.ipynb:      42 cells, code=13, noexec=0, errors=0
SL-5-NeuroSymbolic.ipynb:        31 cells, code=13, noexec=0, errors=0
SL-6-KnowledgeGraphs-ILP.ipynb:  41 cells, code=13, noexec=0, errors=0
SL-7-LLM-SymbolicLearning.ipynb: 40 cells, code=16, noexec=0, errors=0
```

Outputs prouvant les claims (H.1) :

```
SL-5 [11] : loss 2.38->0.55 ; parentOf(Marie,Pierre)=0.897, (Marie,Paul nega)=0.075
SL-5 [17] : grandparent(Marie,Paul)=0.824 (binding Y=Pierre), gp(Sophie,Luc)=0.080
SL-6 [20] : APRES application des regles (PCA conf >= 0.5) : grandparentOf 14 (+9)
SL-6 [23] : Total : 14 triples grandparentOf
SL-7 [24] : Candidates 6, validees 3 (dont Patrons=Full AND Hungry=No => NOT, TP=2 FP=0)
SL-7 [26] : Taux d'acceptation sans CoT 2/5 (40%) / avec CoT 3/6 (50%)
```

`grep -nE "raise NotImplementedError|assert False|1/0"` : 0 occurrence sur les 4 notebooks.

## Suite

Rapport d'analyse critique + propositions d'enrichissement (exercices format presentation-groupe, candidats nouveau notebook), puis les 2 demandes user : re-passe Epic pour vrais imports de packages tiers, et integration LLM reelle dans SL-7 (.env.example dedie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
