### PR TITLE
fix(SL-7): switch LLM to Gemini 3.5 Flash (reasoning model)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/.env.example
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/.env.example
@@ -8,7 +8,7 @@
 # --- Option A : OpenRouter (cloud, many models) ---
 OPENAI_API_KEY=sk-or-v1-...
 OPENAI_BASE_URL=https://openrouter.ai/api/v1
-OPENAI_CHAT_MODEL_ID=google/gemini-2.5-flash
+OPENAI_CHAT_MODEL_ID=google/gemini-3.5-flash
 
 # --- Option B : OpenAI direct ---
 # OPENAI_API_KEY=sk-proj-...

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "097196f2",
    "metadata": {
     "papermill": {
-     "duration": 0.006057,
-     "end_time": "2026-06-10T10:51:07.697610",
+     "duration": 0.004854,
+     "end_time": "2026-06-10T11:40:10.999492",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.691553",
+     "start_time": "2026-06-10T11:40:10.994638",
      "status": "completed"
     },
     "tags": []
@@ -48,16 +48,16 @@
    "id": "3dc32d19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:07.706401Z",
-     "iopub.status.busy": "2026-06-10T10:51:07.706401Z",
-     "iopub.status.idle": "2026-06-10T10:51:07.722725Z",
-     "shell.execute_reply": "2026-06-10T10:51:07.721719Z"
+     "iopub.execute_input": "2026-06-10T11:40:10.999492Z",
+     "iopub.status.busy": "2026-06-10T11:40:10.999492Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.027003Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.026423Z"
     },
     "papermill": {
-     "duration": 0.02197,
-     "end_time": "2026-06-10T10:51:07.723724",
+     "duration": 0.028516,
+     "end_time": "2026-06-10T11:40:11.028008",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.701754",
+     "start_time": "2026-06-10T11:40:10.999492",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "23731406",
    "metadata": {
     "papermill": {
-     "duration": 0.006,
-     "end_time": "2026-06-10T10:51:07.736724",
+     "duration": 0.004017,
+     "end_time": "2026-06-10T11:40:11.035796",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.730724",
+     "start_time": "2026-06-10T11:40:11.031779",
      "status": "completed"
     },
     "tags": []
@@ -144,16 +144,16 @@
    "id": "f1d96718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:07.748938Z",
-     "iopub.status.busy": "2026-06-10T10:51:07.748421Z",
-     "iopub.status.idle": "2026-06-10T10:51:07.768375Z",
-     "shell.execute_reply": "2026-06-10T10:51:07.767232Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.045415Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.045415Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.057924Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.057924Z"
     },
     "papermill": {
-     "duration": 0.028686,
-     "end_time": "2026-06-10T10:51:07.769410",
+     "duration": 0.01911,
+     "end_time": "2026-06-10T11:40:11.058928",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.740724",
+     "start_time": "2026-06-10T11:40:11.039818",
      "status": "completed"
     },
     "tags": []
@@ -236,10 +236,10 @@
    "id": "3827f67e",
    "metadata": {
     "papermill": {
-     "duration": 0.004841,
-     "end_time": "2026-06-10T10:51:07.780472",
+     "duration": 0.004926,
+     "end_time": "2026-06-10T11:40:11.071021",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.775631",
+     "start_time": "2026-06-10T11:40:11.066095",
      "status": "completed"
     },
     "tags": []
@@ -261,10 +261,10 @@
    "id": "59e172f2",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T10:51:07.789547",
+     "duration": 0.007835,
+     "end_time": "2026-06-10T11:40:11.084502",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.784547",
+     "start_time": "2026-06-10T11:40:11.076667",
      "status": "completed"
     },
     "tags": []
@@ -299,16 +299,16 @@
    "id": "581df035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:07.803062Z",
-     "iopub.status.busy": "2026-06-10T10:51:07.803062Z",
-     "iopub.status.idle": "2026-06-10T10:51:07.813335Z",
-     "shell.execute_reply": "2026-06-10T10:51:07.812759Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.097492Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.097492Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.104490Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.104490Z"
     },
     "papermill": {
-     "duration": 0.018826,
-     "end_time": "2026-06-10T10:51:07.814372",
+     "duration": 0.014811,
+     "end_time": "2026-06-10T11:40:11.105491",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.795546",
+     "start_time": "2026-06-10T11:40:11.090680",
      "status": "completed"
     },
     "tags": []
@@ -381,10 +381,10 @@
    "id": "72e21fc7",
    "metadata": {
     "papermill": {
-     "duration": 0.004671,
-     "end_time": "2026-06-10T10:51:07.822675",
+     "duration": 0.00801,
+     "end_time": "2026-06-10T11:40:11.122529",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.818004",
+     "start_time": "2026-06-10T11:40:11.114519",
      "status": "completed"
     },
     "tags": []
@@ -408,16 +408,16 @@
    "id": "eed948cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:07.833233Z",
-     "iopub.status.busy": "2026-06-10T10:51:07.833233Z",
-     "iopub.status.idle": "2026-06-10T10:51:07.843671Z",
-     "shell.execute_reply": "2026-06-10T10:51:07.843066Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.136183Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.136183Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.152441Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.151436Z"
     },
     "papermill": {
-     "duration": 0.017818,
-     "end_time": "2026-06-10T10:51:07.844196",
+     "duration": 0.023221,
+     "end_time": "2026-06-10T11:40:11.152441",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.826378",
+     "start_time": "2026-06-10T11:40:11.129220",
      "status": "completed"
     },
     "tags": []
@@ -507,10 +507,10 @@
    "id": "85c22afd",
    "metadata": {
     "papermill": {
-     "duration": 0.00617,
-     "end_time": "2026-06-10T10:51:07.856216",
+     "duration": 0.004704,
+     "end_time": "2026-06-10T11:40:11.162556",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.850046",
+     "start_time": "2026-06-10T11:40:11.157852",
      "status": "completed"
     },
     "tags": []
@@ -529,16 +529,16 @@
    "id": "1c109513",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:07.870749Z",
-     "iopub.status.busy": "2026-06-10T10:51:07.869749Z",
-     "iopub.status.idle": "2026-06-10T10:51:07.890751Z",
-     "shell.execute_reply": "2026-06-10T10:51:07.889432Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.173246Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.172247Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.183584Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.182900Z"
     },
     "papermill": {
-     "duration": 0.028043,
-     "end_time": "2026-06-10T10:51:07.891284",
+     "duration": 0.017008,
+     "end_time": "2026-06-10T11:40:11.184588",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.863241",
+     "start_time": "2026-06-10T11:40:11.167580",
      "status": "completed"
     },
     "tags": []
@@ -651,10 +651,10 @@
    "id": "bf930a24",
    "metadata": {
     "papermill": {
-     "duration": 0.005928,
-     "end_time": "2026-06-10T10:51:07.901846",
+     "duration": 0.006998,
+     "end_time": "2026-06-10T11:40:11.198788",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.895918",
+     "start_time": "2026-06-10T11:40:11.191790",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +685,10 @@
    "id": "d6bb9fe1",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T10:51:07.913987",
+     "duration": 0.007001,
+     "end_time": "2026-06-10T11:40:11.212297",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.908987",
+     "start_time": "2026-06-10T11:40:11.205296",
      "status": "completed"
     },
     "tags": []
@@ -715,16 +715,16 @@
    "id": "2c0873ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:07.928272Z",
-     "iopub.status.busy": "2026-06-10T10:51:07.928272Z",
-     "iopub.status.idle": "2026-06-10T10:51:07.952296Z",
-     "shell.execute_reply": "2026-06-10T10:51:07.951116Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.222975Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.222079Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.230186Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.230186Z"
     },
     "papermill": {
-     "duration": 0.034272,
-     "end_time": "2026-06-10T10:51:07.953302",
+     "duration": 0.013806,
+     "end_time": "2026-06-10T11:40:11.231189",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.919030",
+     "start_time": "2026-06-10T11:40:11.217383",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +846,10 @@
    "id": "0f9984a1",
    "metadata": {
     "papermill": {
-     "duration": 0.006803,
-     "end_time": "2026-06-10T10:51:07.967303",
+     "duration": 0.005513,
+     "end_time": "2026-06-10T11:40:11.241208",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.960500",
+     "start_time": "2026-06-10T11:40:11.235695",
      "status": "completed"
     },
     "tags": []
@@ -882,16 +882,16 @@
    "id": "9a30e01b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:07.982760Z",
-     "iopub.status.busy": "2026-06-10T10:51:07.981730Z",
-     "iopub.status.idle": "2026-06-10T10:51:07.998023Z",
-     "shell.execute_reply": "2026-06-10T10:51:07.997428Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.254240Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.253718Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.261409Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.260806Z"
     },
     "papermill": {
-     "duration": 0.025586,
-     "end_time": "2026-06-10T10:51:07.999031",
+     "duration": 0.015494,
+     "end_time": "2026-06-10T11:40:11.262452",
      "exception": false,
-     "start_time": "2026-06-10T10:51:07.973445",
+     "start_time": "2026-06-10T11:40:11.246958",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +974,10 @@
    "id": "74c02d03",
    "metadata": {
     "papermill": {
-     "duration": 0.006391,
-     "end_time": "2026-06-10T10:51:08.012210",
+     "duration": 0.007295,
+     "end_time": "2026-06-10T11:40:11.276597",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.005819",
+     "start_time": "2026-06-10T11:40:11.269302",
      "status": "completed"
     },
     "tags": []
@@ -1013,16 +1013,16 @@
    "id": "83e5f5eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:08.027628Z",
-     "iopub.status.busy": "2026-06-10T10:51:08.027628Z",
-     "iopub.status.idle": "2026-06-10T10:51:08.045031Z",
-     "shell.execute_reply": "2026-06-10T10:51:08.043895Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.287406Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.287406Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.309082Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.307484Z"
     },
     "papermill": {
-     "duration": 0.026478,
-     "end_time": "2026-06-10T10:51:08.046078",
+     "duration": 0.027738,
+     "end_time": "2026-06-10T11:40:11.309610",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.019600",
+     "start_time": "2026-06-10T11:40:11.281872",
      "status": "completed"
     },
     "tags": []
@@ -1187,10 +1187,10 @@
    "id": "3653b321",
    "metadata": {
     "papermill": {
-     "duration": 0.006375,
-     "end_time": "2026-06-10T10:51:08.059617",
+     "duration": 0.006575,
+     "end_time": "2026-06-10T11:40:11.323430",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.053242",
+     "start_time": "2026-06-10T11:40:11.316855",
      "status": "completed"
     },
     "tags": []
@@ -1223,16 +1223,16 @@
    "id": "dc08268f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:08.074090Z",
-     "iopub.status.busy": "2026-06-10T10:51:08.074090Z",
-     "iopub.status.idle": "2026-06-10T10:51:08.090941Z",
-     "shell.execute_reply": "2026-06-10T10:51:08.089919Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.338734Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.338734Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.355333Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.354509Z"
     },
     "papermill": {
-     "duration": 0.026354,
-     "end_time": "2026-06-10T10:51:08.091949",
+     "duration": 0.025939,
+     "end_time": "2026-06-10T11:40:11.356362",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.065595",
+     "start_time": "2026-06-10T11:40:11.330423",
      "status": "completed"
     },
     "tags": []
@@ -1308,10 +1308,10 @@
    "id": "a575226a",
    "metadata": {
     "papermill": {
-     "duration": 0.007263,
-     "end_time": "2026-06-10T10:51:08.105748",
+     "duration": 0.006585,
+     "end_time": "2026-06-10T11:40:11.370493",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.098485",
+     "start_time": "2026-06-10T11:40:11.363908",
      "status": "completed"
     },
     "tags": []
@@ -1342,10 +1342,10 @@
    "id": "1bd557a0",
    "metadata": {
     "papermill": {
-     "duration": 0.006961,
-     "end_time": "2026-06-10T10:51:08.119984",
+     "duration": 0.006788,
+     "end_time": "2026-06-10T11:40:11.385187",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.113023",
+     "start_time": "2026-06-10T11:40:11.378399",
      "status": "completed"
     },
     "tags": []
@@ -1385,16 +1385,16 @@
    "id": "f9d67f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:08.135986Z",
-     "iopub.status.busy": "2026-06-10T10:51:08.134708Z",
-     "iopub.status.idle": "2026-06-10T10:51:08.152747Z",
-     "shell.execute_reply": "2026-06-10T10:51:08.151737Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.400735Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.400735Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.417194Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.416051Z"
     },
     "papermill": {
-     "duration": 0.026635,
-     "end_time": "2026-06-10T10:51:08.153757",
+     "duration": 0.025577,
+     "end_time": "2026-06-10T11:40:11.418249",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.127122",
+     "start_time": "2026-06-10T11:40:11.392672",
      "status": "completed"
     },
     "tags": []
@@ -1537,10 +1537,10 @@
    "id": "2f9d2c01",
    "metadata": {
     "papermill": {
-     "duration": 0.007896,
-     "end_time": "2026-06-10T10:51:08.168158",
+     "duration": 0.007512,
+     "end_time": "2026-06-10T11:40:11.432975",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.160262",
+     "start_time": "2026-06-10T11:40:11.425463",
      "status": "completed"
     },
     "tags": []
@@ -1569,16 +1569,16 @@
    "id": "8917b738",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:08.184851Z",
-     "iopub.status.busy": "2026-06-10T10:51:08.183847Z",
-     "iopub.status.idle": "2026-06-10T10:51:08.198525Z",
-     "shell.execute_reply": "2026-06-10T10:51:08.197407Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.449331Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.448820Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.463251Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.462017Z"
     },
     "papermill": {
-     "duration": 0.024415,
-     "end_time": "2026-06-10T10:51:08.199590",
+     "duration": 0.023899,
+     "end_time": "2026-06-10T11:40:11.464277",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.175175",
+     "start_time": "2026-06-10T11:40:11.440378",
      "status": "completed"
     },
     "tags": []
@@ -1626,10 +1626,10 @@
    "id": "a2edb6e2",
    "metadata": {
     "papermill": {
-     "duration": 0.007278,
-     "end_time": "2026-06-10T10:51:08.214694",
+     "duration": 0.007942,
+     "end_time": "2026-06-10T11:40:11.478754",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.207416",
+     "start_time": "2026-06-10T11:40:11.470812",
      "status": "completed"
     },
     "tags": []
@@ -1662,16 +1662,16 @@
    "id": "54a6b7c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:08.231539Z",
-     "iopub.status.busy": "2026-06-10T10:51:08.231539Z",
-     "iopub.status.idle": "2026-06-10T10:51:08.244236Z",
-     "shell.execute_reply": "2026-06-10T10:51:08.243081Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.495448Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.494921Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.509791Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.508582Z"
     },
     "papermill": {
-     "duration": 0.022814,
-     "end_time": "2026-06-10T10:51:08.245302",
+     "duration": 0.024362,
+     "end_time": "2026-06-10T11:40:11.510848",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.222488",
+     "start_time": "2026-06-10T11:40:11.486486",
      "status": "completed"
     },
     "tags": []
@@ -1732,10 +1732,10 @@
    "id": "d74db354",
    "metadata": {
     "papermill": {
-     "duration": 0.0074,
-     "end_time": "2026-06-10T10:51:08.260059",
+     "duration": 0.007417,
+     "end_time": "2026-06-10T11:40:11.526204",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.252659",
+     "start_time": "2026-06-10T11:40:11.518787",
      "status": "completed"
     },
     "tags": []
@@ -1759,10 +1759,10 @@
    "id": "3c2e7728",
    "metadata": {
     "papermill": {
-     "duration": 0.007566,
-     "end_time": "2026-06-10T10:51:08.274959",
+     "duration": 0.007447,
+     "end_time": "2026-06-10T11:40:11.541081",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.267393",
+     "start_time": "2026-06-10T11:40:11.533634",
      "status": "completed"
     },
     "tags": []
@@ -1787,16 +1787,16 @@
    "id": "dada4cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:08.291259Z",
-     "iopub.status.busy": "2026-06-10T10:51:08.290735Z",
-     "iopub.status.idle": "2026-06-10T10:51:08.304757Z",
-     "shell.execute_reply": "2026-06-10T10:51:08.303655Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.558123Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.557117Z",
+     "iopub.status.idle": "2026-06-10T11:40:11.570768Z",
+     "shell.execute_reply": "2026-06-10T11:40:11.569756Z"
     },
     "papermill": {
-     "duration": 0.023973,
-     "end_time": "2026-06-10T10:51:08.305763",
+     "duration": 0.022361,
+     "end_time": "2026-06-10T11:40:11.570768",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.281790",
+     "start_time": "2026-06-10T11:40:11.548407",
      "status": "completed"
     },
     "tags": []
@@ -1922,10 +1922,10 @@
    "id": "3cc1a67b",
    "metadata": {
     "papermill": {
-     "duration": 0.00734,
-     "end_time": "2026-06-10T10:51:08.320837",
+     "duration": 0.007334,
+     "end_time": "2026-06-10T11:40:11.586158",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.313497",
+     "start_time": "2026-06-10T11:40:11.578824",
      "status": "completed"
     },
     "tags": []
@@ -1953,10 +1953,10 @@
    "id": "74eec2fe",
    "metadata": {
     "papermill": {
-     "duration": 0.007952,
-     "end_time": "2026-06-10T10:51:08.336100",
+     "duration": 0.007296,
+     "end_time": "2026-06-10T11:40:11.600808",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.328148",
+     "start_time": "2026-06-10T11:40:11.593512",
      "status": "completed"
     },
     "tags": []
@@ -1994,16 +1994,16 @@
    "id": "a916457d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:08.352511Z",
-     "iopub.status.busy": "2026-06-10T10:51:08.352511Z",
-     "iopub.status.idle": "2026-06-10T10:51:09.160299Z",
-     "shell.execute_reply": "2026-06-10T10:51:09.159790Z"
+     "iopub.execute_input": "2026-06-10T11:40:11.617429Z",
+     "iopub.status.busy": "2026-06-10T11:40:11.617429Z",
+     "iopub.status.idle": "2026-06-10T11:40:12.372709Z",
+     "shell.execute_reply": "2026-06-10T11:40:12.372148Z"
     },
     "papermill": {
-     "duration": 0.817822,
-     "end_time": "2026-06-10T10:51:09.161307",
+     "duration": 0.764524,
+     "end_time": "2026-06-10T11:40:12.373225",
      "exception": false,
-     "start_time": "2026-06-10T10:51:08.343485",
+     "start_time": "2026-06-10T11:40:11.608701",
      "status": "completed"
     },
     "tags": []
@@ -2015,7 +2015,7 @@
      "text": [
       "LLM reel configure :\n",
       "  Endpoint : https://openrouter.ai/api/v1\n",
-      "  Modele   : google/gemini-2.5-flash\n",
+      "  Modele   : google/gemini-3.5-flash\n",
       "  (la cle API n'est jamais affichee)\n"
      ]
     }
@@ -2051,16 +2051,16 @@
    "id": "426133ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:09.176681Z",
-     "iopub.status.busy": "2026-06-10T10:51:09.175645Z",
-     "iopub.status.idle": "2026-06-10T10:51:13.155439Z",
-     "shell.execute_reply": "2026-06-10T10:51:13.155439Z"
+     "iopub.execute_input": "2026-06-10T11:40:12.393458Z",
+     "iopub.status.busy": "2026-06-10T11:40:12.393458Z",
+     "iopub.status.idle": "2026-06-10T11:40:30.699008Z",
+     "shell.execute_reply": "2026-06-10T11:40:30.698012Z"
     },
     "papermill": {
-     "duration": 3.988372,
-     "end_time": "2026-06-10T10:51:13.156433",
+     "duration": 18.315317,
+     "end_time": "2026-06-10T11:40:30.699008",
      "exception": false,
-     "start_time": "2026-06-10T10:51:09.168061",
+     "start_time": "2026-06-10T11:40:12.383691",
      "status": "completed"
     },
     "tags": []
@@ -2070,27 +2070,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Reponse brute (google/gemini-2.5-flash) :\n",
+      "Reponse brute (google/gemini-3.5-flash) :\n",
       "============================================================\n",
-      "En tant qu'expert en apprentissage symbolique, j'ai analysé les données fournies pour générer des règles logiques (clauses de Horn) qui expliquent la décision de \"WillWait\". J'ai cherché à identifier des motifs discriminants entre les exemples positifs et négatifs.\n",
+      "En tant qu'expert en apprentissage symbolique (notamment via des algorithmes de type CN2 ou FOIL qui cherchent à maximiser la couverture et la pureté des règles), voici un ensemble de 4 règles logiques sous forme de clauses de Horn. \n",
       "\n",
-      "Voici 3 à 5 règles candidates, en privilégiant la couverture des exemples positifs et la spécificité pour éviter les faux positifs :\n",
+      "Ces règles permettent d'expliquer parfaitement les décisions de classification (généralisation cohérente sans surapprentissage) :\n",
       "\n",
-      "1.  `Hungry=Yes AND Patrons=Full AND WaitEstimate=30-60 => WillWait`\n",
-      "    *   *Justification :* Cette règle couvre les exemples positifs 2 et 6. Elle capture l'idée que si l'on est affamé, l'endroit est bondé et l'attente est modérée à longue, on est prêt à attendre.\n",
+      "### Règles pour décider d'attendre (WillWait = True)\n",
       "\n",
-      "2.  `Hungry=Yes AND Patrons=Some AND Raining=Yes AND WaitEstimate=0-10 => WillWait`\n",
-      "    *   *Justification :* Cette règle couvre les exemples positifs 4 et 5. Elle suggère que même avec une affluence modérée, si l'on est affamé et qu'il pleut (ce qui peut limiter les autres options), on est prêt à attendre une courte période.\n",
+      "1. **Patrons = Some AND Hungry = Yes => WillWait**\n",
+      "   *(Explication : S'il y a quelques clients et que l'on a faim, on attend toujours. Couvre les exemples positifs 1, 4 et 5. Aucun faux positif.)*\n",
       "\n",
-      "3.  `Hungry=No => NOT WillWait`\n",
-      "    *   *Justification :* Cette règle couvre tous les exemples négatifs (1, 2, 3, 4, 6). Elle est très forte et indique que si l'on n'a pas faim, on ne va pas attendre, q\n",
+      "2. **Patrons = Full AND Hungry = Yes AND Price = $ => WillWait**\n",
+      "   *(Explication : Si le restaurant est plein et qu'on a faim, on accepte d'attendre uniquement si le prix est très abordable ($). Couvre les exemples positifs 2, 3 et 6. Aucun faux positif.)*\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### Règles pour décider de ne pas attendre (NOT WillWait)\n",
+      "\n",
+      "3. **Hungry = No => NOT WillWait**\n",
+      "   *(Explication : Si on n'a pas faim, on n'attend jamais. Couvre les exemples négatifs 1, 2, 3, 4 et 6.)*\n",
+      "\n",
+      "4. **Patrons = None => NOT WillWait**\n",
+      "   *(Explication : Si le restaurant est vide, c'est suspect ou fermé, on n'at\n",
       "============================================================\n",
       "\n",
-      "Regles parsees : 4\n",
-      "  R1: Hungry=Yes AND Patrons=Full AND WaitEstimate=30-60 => WillWait\n",
-      "  R2: Hungry=Yes AND Patrons=Some AND Raining=Yes AND WaitEstimate=0-10 => WillWait\n",
-      "  R3: Hungry=No => NOT WillWait\n",
-      "  R4: Hungry=Yes AND Fri/Sat=Yes AND Patrons=Full AND WaitEstimate=10-30 => WillWait\n"
+      "Regles parsees : 5\n",
+      "  R1: Patrons = Some AND Hungry = Yes => WillWait\n",
+      "  R2: Patrons = Full AND Hungry = Yes AND Price = $ => WillWait\n",
+      "  R3: Hungry = No => NOT WillWait\n",
+      "  R4: Patrons = None => NOT WillWait\n",
+      "  R5: Patrons = Full AND Price = $$$ => NOT WillWait\n"
      ]
     }
    ],
@@ -2139,7 +2149,8 @@
     "                model=LLM_MODEL,\n",
     "                messages=[{\"role\": \"user\", \"content\": prompt}],\n",
     "                temperature=0,  # reduit (sans annuler) la variabilite\n",
-    "                max_tokens=1000,\n",
+    "                max_tokens=4000,  # large : les modeles 'reasoning' (Gemini 3.5) consomment\n",
+    "                #         des tokens de reflexion AVANT la reponse visible\n",
     "            )\n",
     "            raw = response.choices[0].message.content\n",
     "            parsed = parse_llm_rules(raw)\n",
@@ -2170,16 +2181,16 @@
    "id": "6e670307",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:13.165971Z",
-     "iopub.status.busy": "2026-06-10T10:51:13.165971Z",
-     "iopub.status.idle": "2026-06-10T10:51:13.170988Z",
-     "shell.execute_reply": "2026-06-10T10:51:13.170359Z"
+     "iopub.execute_input": "2026-06-10T11:40:30.709518Z",
+     "iopub.status.busy": "2026-06-10T11:40:30.708518Z",
+     "iopub.status.idle": "2026-06-10T11:40:30.714748Z",
+     "shell.execute_reply": "2026-06-10T11:40:30.714028Z"
     },
     "papermill": {
-     "duration": 0.010549,
-     "end_time": "2026-06-10T10:51:13.170988",
+     "duration": 0.011238,
+     "end_time": "2026-06-10T11:40:30.714748",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.160439",
+     "start_time": "2026-06-10T11:40:30.703510",
      "status": "completed"
     },
     "tags": []
@@ -2193,12 +2204,13 @@
       "==============================================================================\n",
       "Regle                                            |  TP |  FP |  Prec |  OK\n",
       "------------------------------------------------------------------------------\n",
-      "Hungry=Yes AND Patrons=Full AND WaitEstimate=30- |   2 |   0 |  1.00 | OUI\n",
-      "Hungry=Yes AND Patrons=Some AND Raining=Yes AND  |   2 |   0 |  1.00 | OUI\n",
-      "Hungry=No => NOT WillWait                        |   5 |   0 |  1.00 | OUI\n",
-      "Hungry=Yes AND Fri/Sat=Yes AND Patrons=Full AND  |   1 |   1 |  0.50 | NON\n",
+      "Patrons = Some AND Hungry = Yes => WillWait      |   3 |   0 |  1.00 | OUI\n",
+      "Patrons = Full AND Hungry = Yes AND Price = $ => |   3 |   0 |  1.00 | OUI\n",
+      "Hungry = No => NOT WillWait                      |   5 |   0 |  1.00 | OUI\n",
+      "Patrons = None => NOT WillWait                   |   2 |   0 |  1.00 | OUI\n",
+      "Patrons = Full AND Price = $$$ => NOT WillWait   |   2 |   0 |  1.00 | OUI\n",
       "\n",
-      "Bilan LLM reel  : 3/4 regles validees par l'oracle\n",
+      "Bilan LLM reel  : 5/5 regles validees par l'oracle\n",
       "Bilan simulateur: 2/5 regles validees (section 3)\n",
       "\n",
       "Le generateur change (simule ou reel, deterministe ou non), l'oracle\n",
@@ -2235,10 +2247,10 @@
    "id": "d4216022",
    "metadata": {
     "papermill": {
-     "duration": 0.0038,
-     "end_time": "2026-06-10T10:51:13.179306",
+     "duration": 0.004,
+     "end_time": "2026-06-10T11:40:30.722796",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.175506",
+     "start_time": "2026-06-10T11:40:30.718796",
      "status": "completed"
     },
     "tags": []
@@ -2259,16 +2271,16 @@
     "   la supprimer). En re-executant, vous obtiendrez probablement un ensemble de regles\n",
     "   different --- mais le verdict de l'oracle sur chaque regle, lui, ne changera jamais.\n",
     "\n",
-    "3. **La division du travail tient --- et le run reel l'illustre mieux que le\n",
-    "   simulateur.** Sur ce run, le modele a spontanement propose des regles plus\n",
-    "   *specifiques* (3-4 conditions) que les heuristiques larges du simulateur :\n",
-    "   trois passent l'oracle (FP=0), dont `Hungry=No => NOT WillWait` qui couvre 5\n",
-    "   des 6 negatifs. Mais chaque regle positive consistante ne couvre que 2 positifs\n",
-    "   (recall faible) : la specificite achete la consistance au prix de la couverture,\n",
-    "   exactement le dilemme des sections 2-3 (aucune clause unique ne couvre TOUS les\n",
-    "   positifs sans faux positif). Et la 4e regle, refutee (FP=1), montre l'oracle\n",
-    "   faire son travail : ses justifications en langage naturel etaient plausibles,\n",
-    "   les donnees disent non.\n"
+    "3. **La division du travail tient --- meme quand le generateur est bon.** Sur ce\n",
+    "   run (Gemini 3.5 Flash, modele *reasoning* : il depense un budget de tokens en\n",
+    "   reflexion interne avant de repondre), les 5 regles proposees passent l'oracle\n",
+    "   (FP=0 partout), la ou le simulateur n'en validait que 2/5. Les deux regles\n",
+    "   positives se partagent exactement les 6 exemples positifs (3+3) : le modele a\n",
+    "   retrouve seul la structure du dilemme couverture/consistance des sections 2-3.\n",
+    "   Faut-il alors encore un oracle ? Oui : c'est lui qui *prouve* que ce run est bon.\n",
+    "   Avec un modele plus faible (essayez dans le `.env`), une partie des regles ---\n",
+    "   plausibles en langage naturel --- est refutee par les donnees ; sans verification\n",
+    "   symbolique, rien ne distingue ces deux situations.\n"
    ]
   },
   {
@@ -2276,10 +2288,10 @@
    "id": "ba9beb92",
    "metadata": {
     "papermill": {
-     "duration": 0.003011,
-     "end_time": "2026-06-10T10:51:13.186830",
+     "duration": 0.004004,
+     "end_time": "2026-06-10T11:40:30.730800",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.183819",
+     "start_time": "2026-06-10T11:40:30.726796",
      "status": "completed"
     },
     "tags": []
@@ -2295,10 +2307,10 @@
    "id": "3c800f32",
    "metadata": {
     "papermill": {
-     "duration": 0.004008,
-     "end_time": "2026-06-10T10:51:13.195377",
+     "duration": 0.004002,
+     "end_time": "2026-06-10T11:40:30.739317",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.191369",
+     "start_time": "2026-06-10T11:40:30.735315",
      "status": "completed"
     },
     "tags": []
@@ -2321,16 +2333,16 @@
    "id": "5101d0d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:13.205558Z",
-     "iopub.status.busy": "2026-06-10T10:51:13.204984Z",
-     "iopub.status.idle": "2026-06-10T10:51:13.216912Z",
-     "shell.execute_reply": "2026-06-10T10:51:13.216912Z"
+     "iopub.execute_input": "2026-06-10T11:40:30.749315Z",
+     "iopub.status.busy": "2026-06-10T11:40:30.748315Z",
+     "iopub.status.idle": "2026-06-10T11:40:30.761250Z",
+     "shell.execute_reply": "2026-06-10T11:40:30.760615Z"
     },
     "papermill": {
-     "duration": 0.018525,
-     "end_time": "2026-06-10T10:51:13.217903",
+     "duration": 0.018982,
+     "end_time": "2026-06-10T11:40:30.762305",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.199378",
+     "start_time": "2026-06-10T11:40:30.743323",
      "status": "completed"
     },
     "tags": []
@@ -2377,10 +2389,10 @@
    "id": "2936e442",
    "metadata": {
     "papermill": {
-     "duration": 0.004011,
-     "end_time": "2026-06-10T10:51:13.226427",
+     "duration": 0.004165,
+     "end_time": "2026-06-10T11:40:30.772820",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.222416",
+     "start_time": "2026-06-10T11:40:30.768655",
      "status": "completed"
     },
     "tags": []
@@ -2402,16 +2414,16 @@
    "id": "174aa8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:13.236005Z",
-     "iopub.status.busy": "2026-06-10T10:51:13.236005Z",
-     "iopub.status.idle": "2026-06-10T10:51:13.247512Z",
-     "shell.execute_reply": "2026-06-10T10:51:13.247512Z"
+     "iopub.execute_input": "2026-06-10T11:40:30.781872Z",
+     "iopub.status.busy": "2026-06-10T11:40:30.781872Z",
+     "iopub.status.idle": "2026-06-10T11:40:30.791134Z",
+     "shell.execute_reply": "2026-06-10T11:40:30.791134Z"
     },
     "papermill": {
-     "duration": 0.01759,
-     "end_time": "2026-06-10T10:51:13.248534",
+     "duration": 0.015262,
+     "end_time": "2026-06-10T11:40:30.792134",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.230944",
+     "start_time": "2026-06-10T11:40:30.776872",
      "status": "completed"
     },
     "tags": []
@@ -2455,10 +2467,10 @@
    "id": "0962260b",
    "metadata": {
     "papermill": {
-     "duration": 0.00471,
-     "end_time": "2026-06-10T10:51:13.257813",
+     "duration": 0.003999,
+     "end_time": "2026-06-10T11:40:30.803134",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.253103",
+     "start_time": "2026-06-10T11:40:30.799135",
      "status": "completed"
     },
     "tags": []
@@ -2480,16 +2492,16 @@
    "id": "3548d43c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:51:13.267646Z",
-     "iopub.status.busy": "2026-06-10T10:51:13.267646Z",
-     "iopub.status.idle": "2026-06-10T10:51:13.277654Z",
-     "shell.execute_reply": "2026-06-10T10:51:13.277654Z"
+     "iopub.execute_input": "2026-06-10T11:40:30.815884Z",
+     "iopub.status.busy": "2026-06-10T11:40:30.815363Z",
+     "iopub.status.idle": "2026-06-10T11:40:30.823866Z",
+     "shell.execute_reply": "2026-06-10T11:40:30.823224Z"
     },
     "papermill": {
-     "duration": 0.016644,
-     "end_time": "2026-06-10T10:51:13.278646",
+     "duration": 0.016269,
+     "end_time": "2026-06-10T11:40:30.824914",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.262002",
+     "start_time": "2026-06-10T11:40:30.808645",
      "status": "completed"
     },
     "tags": []
@@ -2554,10 +2566,10 @@
    "id": "7cb00ad4",
    "metadata": {
     "papermill": {
-     "duration": 0.004016,
-     "end_time": "2026-06-10T10:51:13.287196",
+     "duration": 0.004702,
+     "end_time": "2026-06-10T11:40:30.836230",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.283180",
+     "start_time": "2026-06-10T11:40:30.831528",
      "status": "completed"
     },
     "tags": []
@@ -2609,10 +2621,10 @@
    "id": "b2e6b9c6",
    "metadata": {
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-06-10T10:51:13.295188",
+     "duration": 0.004219,
+     "end_time": "2026-06-10T11:40:30.844534",
      "exception": false,
-     "start_time": "2026-06-10T10:51:13.291187",
+     "start_time": "2026-06-10T11:40:30.840315",
      "status": "completed"
     },
     "tags": []
@@ -2654,14 +2666,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 7.63755,
-   "end_time": "2026-06-10T10:51:13.617009",
+   "duration": 22.103717,
+   "end_time": "2026-06-10T11:40:31.418231",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-7-LLM-SymbolicLearning.ipynb",
    "output_path": "SL-7-LLM-SymbolicLearning.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T10:51:05.979459",
+   "start_time": "2026-06-10T11:40:09.314514",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

User request 2026-06-10: « l'utilisation de gemini 2.5 Flash est un peu maladroite, on a bien mieux maintenant, Gemini 3.5 flash ».

- `.env.example`: `OPENAI_CHAT_MODEL_ID=google/gemini-3.5-flash` (les `.env` locaux gitignorés mis à jour de même).
- `llm_generate_rules`: `max_tokens` 1000 → 4000 avec commentaire — Gemini 3.5 Flash est un modèle **reasoning** : il consomme des tokens de réflexion interne avant la réponse visible (probe: 797 reasoning tokens sur ce prompt ; à 1000 le run renvoyait `content=null` / finish_reason MAX_TOKENS).
- Cellule d'interprétation (section 7) réécrite pour coller au nouveau run committé.

## Validation (H.1)

Papermill end-to-end depuis le répertoire série, kernel `python3` : **45 cells, 19 code, 0 noexec, 0 errors**.

Run réel committé (section 7) :
```
Modele   : google/gemini-3.5-flash
Regles parsees : 5
Bilan LLM reel  : 5/5 regles validees par l'oracle   (gemini-2.5-flash : 3/4)
Bilan simulateur: 2/5 regles validees
```

Aucune clé dans les outputs (grep `sk-or-` = 0). Modif markdown post-run = interprétation seule (C.2 : outputs du run conservés, aucune cellule code touchée après exécution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)