### PR TITLE
feat(SL-8): notebook Apprentissage Actif d'Automates (L* d'Angluin)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
@@ -1,0 +1,1415 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "sl8-01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005216,
+     "end_time": "2026-06-10T11:53:41.348666",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.343450",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# SL-8 --- Apprentissage Actif d'Automates (L* d'Angluin)\n",
+    "\n",
+    "**Navigation** : [Index](./README.md) | [<< SL-7](SL-7-LLM-SymbolicLearning.ipynb) | [SL-9 >>](SL-9-InverseResolution.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. Distinguer apprentissage **passif** (exemples imposes, SL-1) et **actif** (l'apprenant pose des questions)\n",
+    "2. Formaliser le modele **MAT** (Minimally Adequate Teacher) : requetes d'appartenance et d'equivalence\n",
+    "3. Implementer la **table d'observation** d'Angluin (fermeture, consistance)\n",
+    "4. Derouler l'algorithme **L*** complet et apprendre un DFA inconnu\n",
+    "5. Relier la garantie de **minimalite** au theoreme de Myhill-Nerode\n",
+    "6. Mesurer ce qui se passe quand l'oracle d'equivalence devient **approximatif** (echantillonnage, PAC)\n",
+    "\n",
+    "### Prerequis\n",
+    "- SL-1 (espaces d'hypotheses, apprentissage passif)\n",
+    "- Notions d'automates finis deterministes (rappel complet en section 1)\n",
+    "- Python pur : aucune dependance externe dans ce notebook\n",
+    "\n",
+    "### Duree estimee : 60 minutes\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004149,
+     "end_time": "2026-06-10T11:53:41.357502",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.353353",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Du passif a l'actif : le modele MAT\n",
+    "\n",
+    "Tous les algorithmes de la serie jusqu'ici sont **passifs** : l'apprenant recoit un\n",
+    "jeu d'exemples qu'il n'a pas choisi (les 12 restaurants de SL-1, les triples du KG\n",
+    "de SL-6) et doit s'en contenter. Or certains concepts sont *exponentiellement* plus\n",
+    "faciles a apprendre si l'apprenant peut **poser des questions**.\n",
+    "\n",
+    "Dana Angluin (1987) formalise cela avec le **MAT** (*Minimally Adequate Teacher*),\n",
+    "un professeur qui repond a exactement deux types de requetes :\n",
+    "\n",
+    "| Requete | Question | Reponse |\n",
+    "|---------|----------|---------|\n",
+    "| **Appartenance** (MQ) | « le mot $w$ est-il dans le langage cible $L$ ? » | Oui / Non |\n",
+    "| **Equivalence** (EQ) | « mon hypothese $H$ est-elle exactement $L$ ? » | Oui, ou un **contre-exemple** $w \\in H \\triangle L$ |\n",
+    "\n",
+    "La cible est ici un **langage regulier** : un ensemble de mots reconnu par un\n",
+    "**automate fini deterministe** (DFA). C'est un objet pleinement symbolique --- etats,\n",
+    "transitions, etats acceptants --- et le theoreme central d'Angluin est remarquable :\n",
+    "\n",
+    "> **Theoreme (Angluin 1987).** L* apprend le DFA minimal de tout langage regulier\n",
+    "> avec un nombre de requetes **polynomial** en le nombre d'etats $n$ du DFA minimal\n",
+    "> et la longueur $m$ du plus long contre-exemple.\n",
+    "\n",
+    "A titre de comparaison, apprendre un DFA *passivement* (trouver le plus petit DFA\n",
+    "consistant avec un echantillon donne) est **NP-difficile** (Gold 1978). Le droit de\n",
+    "poser des questions change la classe de complexite du probleme.\n",
+    "\n",
+    "Commencons par la cible : un DFA jouet que L* devra decouvrir *sans jamais regarder\n",
+    "sa structure*, uniquement en l'interrogeant.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "sl8-03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.365310Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.364782Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.390956Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.389835Z"
+    },
+    "papermill": {
+     "duration": 0.030299,
+     "end_time": "2026-06-10T11:53:41.391486",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.361187",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cible : DFA(4 etats, 1 acceptants)  (structure invisible pour l'apprenant)\n",
+      "     mot | nb_a | nb_b | dans L ?\n",
+      "------------------------------------\n",
+      "       ε |    0 |    0 | OUI\n",
+      "       a |    1 |    0 | non\n",
+      "       b |    0 |    1 | non\n",
+      "      ab |    1 |    1 | non\n",
+      "    aabb |    2 |    2 | OUI\n",
+      "    abab |    2 |    2 | OUI\n",
+      "     aab |    2 |    1 | non\n",
+      "    bbaa |    2 |    2 | OUI\n",
+      "    abba |    2 |    2 | OUI\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Un DFA = (etats, alphabet, transitions, etat initial, etats acceptants)\n",
+    "from collections import deque\n",
+    "\n",
+    "\n",
+    "class DFA:\n",
+    "    \"\"\"Automate fini deterministe. delta : dict (etat, symbole) -> etat.\"\"\"\n",
+    "\n",
+    "    def __init__(self, states, alphabet, delta, start, accepting):\n",
+    "        self.states = set(states)\n",
+    "        self.alphabet = list(alphabet)\n",
+    "        self.delta = dict(delta)\n",
+    "        self.start = start\n",
+    "        self.accepting = set(accepting)\n",
+    "\n",
+    "    def accepts(self, word):\n",
+    "        q = self.start\n",
+    "        for ch in word:\n",
+    "            q = self.delta[(q, ch)]\n",
+    "        return q in self.accepting\n",
+    "\n",
+    "    def __repr__(self):\n",
+    "        return f\"DFA({len(self.states)} etats, {len(self.accepting)} acceptants)\"\n",
+    "\n",
+    "\n",
+    "# Langage cible (cache pour L*) : mots sur {a, b} avec un nombre PAIR de 'a'\n",
+    "# ET un nombre PAIR de 'b'. Etat = (parite des a, parite des b) -> 4 etats.\n",
+    "ALPHABET = [\"a\", \"b\"]\n",
+    "_states = [\"ee\", \"eo\", \"oe\", \"oo\"]  # (pair, pair), (pair, impair), ...\n",
+    "_delta = {}\n",
+    "for s in _states:\n",
+    "    pa, pb = s[0], s[1]\n",
+    "    _delta[(s, \"a\")] = (\"o\" if pa == \"e\" else \"e\") + pb\n",
+    "    _delta[(s, \"b\")] = pa + (\"o\" if pb == \"e\" else \"e\")\n",
+    "TARGET = DFA(_states, ALPHABET, _delta, \"ee\", {\"ee\"})\n",
+    "\n",
+    "# L'apprenant n'aura acces qu'a cette fonction (la requete d'appartenance) :\n",
+    "def membership_query(word: str) -> bool:\n",
+    "    return TARGET.accepts(word)\n",
+    "\n",
+    "# Verification rapide sur quelques mots\n",
+    "tests = [\"\", \"a\", \"b\", \"ab\", \"aabb\", \"abab\", \"aab\", \"bbaa\", \"abba\"]\n",
+    "print(f\"Cible : {TARGET}  (structure invisible pour l'apprenant)\")\n",
+    "print(f\"{'mot':>8} | nb_a | nb_b | dans L ?\")\n",
+    "print(\"-\" * 36)\n",
+    "for w in tests:\n",
+    "    print(f\"{w or chr(949):>8} | {w.count('a'):>4} | {w.count('b'):>4} | \"\n",
+    "          f\"{'OUI' if membership_query(w) else 'non'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004022,
+     "end_time": "2026-06-10T11:53:41.400206",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.396184",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Pourquoi ce langage ?\n",
+    "\n",
+    "Le mot vide est accepte (0 est pair), `ab` est rejete (1 'a', 1 'b'), `aabb` et\n",
+    "`abab` sont acceptes. Le DFA minimal a exactement **4 etats** --- le produit des\n",
+    "deux parites --- et aucune conjonction d'attributs a la SL-1 ne peut le representer :\n",
+    "l'appartenance depend d'un *compteur modulaire*, pas de la presence ou l'absence\n",
+    "d'un motif. C'est un concept hors de portee des espaces d'hypotheses de SL-1, et\n",
+    "parfaitement dans celui de L*.\n",
+    "\n",
+    "L'apprenant ne voit que `membership_query` : une boite noire mot -> booleen.\n",
+    "Tout l'enjeu est de reconstruire la structure (etats, transitions) a partir de\n",
+    "reponses oui/non bien choisies.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-05",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004002,
+     "end_time": "2026-06-10T11:53:41.408729",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.404727",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. La table d'observation\n",
+    "\n",
+    "L* organise ses requetes d'appartenance dans une **table d'observation** $(S, E, T)$ :\n",
+    "\n",
+    "- $S$ : un ensemble de **prefixes d'acces** (chaque $s \\in S$ est un chemin candidat\n",
+    "  vers un etat du DFA) ;\n",
+    "- $E$ : un ensemble de **suffixes distinguants** (des « experiences » qui separent\n",
+    "  les etats) ;\n",
+    "- $T(s \\cdot e) \\in \\{0, 1\\}$ : la reponse de l'oracle a la requete $s \\cdot e \\in L$ ?\n",
+    "\n",
+    "La **ligne** d'un prefixe $s$ est le vecteur $row(s) = (T(s \\cdot e))_{e \\in E}$.\n",
+    "L'intuition centrale : *deux prefixes qui ont la meme ligne menent (provisoirement)\n",
+    "au meme etat*. C'est une approximation finie de la congruence de Myhill-Nerode :\n",
+    "$u \\equiv_L v \\iff \\forall w,\\; uw \\in L \\Leftrightarrow vw \\in L$ --- ici on ne\n",
+    "teste pas *tous* les suffixes $w$, seulement ceux de $E$.\n",
+    "\n",
+    "Pour pouvoir construire un DFA a partir de la table, deux proprietes sont requises :\n",
+    "\n",
+    "| Propriete | Definition | Si violee... |\n",
+    "|-----------|------------|--------------|\n",
+    "| **Fermeture** | $\\forall s \\in S, a \\in \\Sigma$, $row(s a)$ est la ligne d'un element de $S$ | la transition $row(s) \\xrightarrow{a} {?}$ sort de la table : **promouvoir** $sa$ dans $S$ |\n",
+    "| **Consistance** | $row(s_1) = row(s_2) \\Rightarrow \\forall a, row(s_1 a) = row(s_2 a)$ | deux etats fusionnes a tort : **ajouter** le suffixe $a e$ qui les separe a $E$ |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "sl8-06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.418789Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.417272Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.437988Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.436907Z"
+    },
+    "papermill": {
+     "duration": 0.025744,
+     "end_time": "2026-06-10T11:53:41.438497",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.412753",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Table initiale (haut : S ; bas : les successeurs S.A) :\n",
+      "\n",
+      "       |    ε\n",
+      "--------------\n",
+      "     ε |    1\n",
+      "--------------\n",
+      "     a |    0\n",
+      "     b |    0\n",
+      "\n",
+      "Requetes MQ posees : 3\n",
+      "Fermee ? NON : row('a') absente de S\n"
+     ]
+    }
+   ],
+   "source": [
+    "class ObservationTable:\n",
+    "    \"\"\"Table d'observation (S, E, T) d'Angluin, remplie par requetes MQ.\"\"\"\n",
+    "\n",
+    "    def __init__(self, alphabet, mq):\n",
+    "        self.A = list(alphabet)\n",
+    "        self.mq = mq\n",
+    "        self.S = [\"\"]          # prefixes d'acces\n",
+    "        self.E = [\"\"]          # suffixes distinguants (E[0] = mot vide, toujours)\n",
+    "        self.T = {}            # cache mot -> bool\n",
+    "        self.n_mq = 0          # compteur de requetes reelles\n",
+    "        self.fill()\n",
+    "\n",
+    "    def ask(self, w):\n",
+    "        if w not in self.T:\n",
+    "            self.T[w] = self.mq(w)\n",
+    "            self.n_mq += 1\n",
+    "        return self.T[w]\n",
+    "\n",
+    "    def fill(self):\n",
+    "        for s in self.S + [s + a for s in self.S for a in self.A]:\n",
+    "            for e in self.E:\n",
+    "                self.ask(s + e)\n",
+    "\n",
+    "    def row(self, s):\n",
+    "        return tuple(self.ask(s + e) for e in self.E)\n",
+    "\n",
+    "    def find_unclosed(self):\n",
+    "        \"\"\"Renvoie un s.a dont la ligne n'apparait pas dans S, ou None.\"\"\"\n",
+    "        rows_S = {self.row(s) for s in self.S}\n",
+    "        for s in self.S:\n",
+    "            for a in self.A:\n",
+    "                if self.row(s + a) not in rows_S:\n",
+    "                    return s + a\n",
+    "        return None\n",
+    "\n",
+    "    def find_inconsistency(self):\n",
+    "        \"\"\"Renvoie un suffixe a+e qui separe deux lignes egales de S, ou None.\"\"\"\n",
+    "        for i, s1 in enumerate(self.S):\n",
+    "            for s2 in self.S[i + 1:]:\n",
+    "                if self.row(s1) != self.row(s2):\n",
+    "                    continue\n",
+    "                for a in self.A:\n",
+    "                    for e in self.E:\n",
+    "                        if self.ask(s1 + a + e) != self.ask(s2 + a + e):\n",
+    "                            return a + e\n",
+    "        return None\n",
+    "\n",
+    "    def show(self):\n",
+    "        eps = chr(949)\n",
+    "        cols = [e or eps for e in self.E]\n",
+    "        w = max(6, max(len(s) for s in self.S) + 2)\n",
+    "        print(f\"{'':>{w}} | \" + \" \".join(f\"{c:>4}\" for c in cols))\n",
+    "        print(\"-\" * (w + 3 + 5 * len(cols)))\n",
+    "        for s in self.S:\n",
+    "            r = \" \".join(f\"{int(v):>4}\" for v in self.row(s))\n",
+    "            print(f\"{s or eps:>{w}} | {r}\")\n",
+    "        print(\"-\" * (w + 3 + 5 * len(cols)))\n",
+    "        for s in self.S:\n",
+    "            for a in self.A:\n",
+    "                sa = s + a\n",
+    "                if sa in self.S:\n",
+    "                    continue\n",
+    "                r = \" \".join(f\"{int(v):>4}\" for v in self.row(sa))\n",
+    "                print(f\"{sa:>{w}} | {r}\")\n",
+    "\n",
+    "\n",
+    "# Table initiale : S = {epsilon}, E = {epsilon}\n",
+    "table = ObservationTable(ALPHABET, membership_query)\n",
+    "print(\"Table initiale (haut : S ; bas : les successeurs S.A) :\\n\")\n",
+    "table.show()\n",
+    "sa = table.find_unclosed()\n",
+    "print(f\"\\nRequetes MQ posees : {table.n_mq}\")\n",
+    "print(f\"Fermee ? {'oui' if sa is None else f'NON : row({sa!r}) absente de S'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002504,
+     "end_time": "2026-06-10T11:53:41.444513",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.442009",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture de la table initiale\n",
+    "\n",
+    "La ligne de $\\varepsilon$ vaut $(1)$ (le mot vide est dans $L$), mais celles de\n",
+    "`a` et `b` valent $(0)$ : la table n'est **pas fermee** --- l'automate conjecture\n",
+    "aurait une transition vers un etat qui n'existe pas encore. Le remede est mecanique :\n",
+    "promouvoir le prefixe fautif dans $S$, ce qui *cree* l'etat manquant, puis re-remplir\n",
+    "la table. L'algorithme L* n'est rien d'autre que la repetition disciplinee de ce\n",
+    "geste, plus le traitement des contre-exemples.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-08",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002661,
+     "end_time": "2026-06-10T11:53:41.449705",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.447044",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. L'algorithme L*\n",
+    "\n",
+    "```text\n",
+    "L*(alphabet, MQ, EQ):\n",
+    "    initialiser la table (S = E = {epsilon})\n",
+    "    repeter:\n",
+    "        tant que la table n'est pas fermee ou pas consistante:\n",
+    "            non fermee      -> promouvoir le prefixe s.a fautif dans S\n",
+    "            non consistante -> ajouter le suffixe a.e separateur a E\n",
+    "        H <- DFA conjecture a partir des lignes de la table\n",
+    "        si EQ(H) repond OUI : retourner H\n",
+    "        sinon (contre-exemple c) : ajouter TOUS les prefixes de c a S\n",
+    "```\n",
+    "\n",
+    "La **conjecture** se lit directement dans la table : les etats sont les lignes\n",
+    "distinctes de $S$, l'etat initial est $row(\\varepsilon)$, un etat est acceptant si\n",
+    "sa premiere colonne ($e = \\varepsilon$) vaut 1, et la transition par $a$ envoie\n",
+    "$row(s)$ sur $row(sa)$ --- la fermeture garantit que cette ligne existe, la\n",
+    "consistance qu'elle ne depend pas du representant $s$ choisi.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "sl8-09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.458835Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.458835Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.468503Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.467911Z"
+    },
+    "papermill": {
+     "duration": 0.01686,
+     "end_time": "2026-06-10T11:53:41.469026",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.452166",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L* implemente : ObservationTable + conjecture + boucle de raffinement.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def conjecture(table):\n",
+    "    \"\"\"Construit le DFA des lignes distinctes de S.\"\"\"\n",
+    "    reps = {}                      # ligne -> prefixe representant\n",
+    "    for s in table.S:\n",
+    "        reps.setdefault(table.row(s), s)\n",
+    "    delta = {}\n",
+    "    for r, s in reps.items():\n",
+    "        for a in table.A:\n",
+    "            delta[(r, a)] = table.row(s + a)\n",
+    "    start = table.row(\"\")\n",
+    "    accepting = {r for r in reps if r[0]}      # E[0] = epsilon\n",
+    "    return DFA(set(reps), table.A, delta, start, accepting)\n",
+    "\n",
+    "\n",
+    "def find_counterexample(hyp, target, alphabet):\n",
+    "    \"\"\"Oracle d'equivalence EXACT : BFS sur l'automate produit, renvoie le plus\n",
+    "    court mot sur lequel hyp et target different (None si equivalents).\"\"\"\n",
+    "    start = (hyp.start, target.start)\n",
+    "    seen = {start}\n",
+    "    queue = deque([(\"\", *start)])\n",
+    "    while queue:\n",
+    "        w, qh, qt = queue.popleft()\n",
+    "        if (qh in hyp.accepting) != (qt in target.accepting):\n",
+    "            return w\n",
+    "        for a in alphabet:\n",
+    "            nxt = (hyp.delta[(qh, a)], target.delta[(qt, a)])\n",
+    "            if nxt not in seen:\n",
+    "                seen.add(nxt)\n",
+    "                queue.append((w + a, *nxt))\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "def lstar(alphabet, mq, eq, verbose=True):\n",
+    "    \"\"\"L* d'Angluin. eq(hyp) renvoie None (equivalent) ou un contre-exemple.\"\"\"\n",
+    "    table = ObservationTable(alphabet, mq)\n",
+    "    n_eq = 0\n",
+    "    round_ = 0\n",
+    "    while True:\n",
+    "        # 1. Stabiliser la table\n",
+    "        while True:\n",
+    "            sa = table.find_unclosed()\n",
+    "            if sa is not None:\n",
+    "                table.S.append(sa)\n",
+    "                table.fill()\n",
+    "                if verbose:\n",
+    "                    print(f\"  table non fermee -> S += {sa!r}\")\n",
+    "                continue\n",
+    "            ae = table.find_inconsistency()\n",
+    "            if ae is not None:\n",
+    "                table.E.append(ae)\n",
+    "                table.fill()\n",
+    "                if verbose:\n",
+    "                    print(f\"  table non consistante -> E += {ae!r}\")\n",
+    "                continue\n",
+    "            break\n",
+    "        # 2. Conjecturer et interroger le professeur\n",
+    "        hyp = conjecture(table)\n",
+    "        n_eq += 1\n",
+    "        round_ += 1\n",
+    "        cex = eq(hyp)\n",
+    "        if verbose:\n",
+    "            verdict = \"ACCEPTEE\" if cex is None else f\"contre-exemple {cex!r}\"\n",
+    "            print(f\"Conjecture {round_} : {len(hyp.states)} etats -> {verdict}\")\n",
+    "        if cex is None:\n",
+    "            return hyp, table, n_eq\n",
+    "        # 3. Integrer le contre-exemple (tous ses prefixes dans S, Angluin 1987)\n",
+    "        for i in range(1, len(cex) + 1):\n",
+    "            if cex[:i] not in table.S:\n",
+    "                table.S.append(cex[:i])\n",
+    "        table.fill()\n",
+    "\n",
+    "print(\"L* implemente : ObservationTable + conjecture + boucle de raffinement.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002575,
+     "end_time": "2026-06-10T11:53:41.474033",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.471458",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Execution complete sur le langage cible\n",
+    "\n",
+    "Lancons L* contre la boite noire. L'oracle d'equivalence est ici *exact* (BFS sur\n",
+    "l'automate produit) : un luxe possible seulement parce que nous connaissons la cible\n",
+    "--- la section 6 le remplacera par ce qu'on a vraiment en pratique.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "sl8-11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.481402Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.481402Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.500329Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.499220Z"
+    },
+    "papermill": {
+     "duration": 0.024439,
+     "end_time": "2026-06-10T11:53:41.501363",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.476924",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  table non fermee -> S += 'a'\n",
+      "Conjecture 1 : 2 etats -> contre-exemple 'ba'\n",
+      "  table non consistante -> E += 'a'\n",
+      "  table non consistante -> E += 'b'\n",
+      "Conjecture 2 : 4 etats -> ACCEPTEE\n",
+      "\n",
+      "DFA appris : DFA(4 etats, 1 acceptants)\n",
+      "Requetes d'appartenance : 19\n",
+      "Requetes d'equivalence  : 2\n",
+      "\n",
+      "Table finale (S = 4 prefixes, E = ['', 'a', 'b']) :\n",
+      "\n",
+      "       |    ε    a    b\n",
+      "------------------------\n",
+      "     ε |    1    0    0\n",
+      "     a |    0    1    0\n",
+      "     b |    0    0    1\n",
+      "    ba |    0    0    0\n",
+      "------------------------\n",
+      "    aa |    1    0    0\n",
+      "    ab |    0    0    0\n",
+      "    bb |    1    0    0\n",
+      "   baa |    0    0    1\n",
+      "   bab |    0    1    0\n",
+      "\n",
+      "Verification exhaustive : 2047/2047 mots (longueur <= 10) identiques\n"
+     ]
+    }
+   ],
+   "source": [
+    "learned, final_table, n_eq = lstar(ALPHABET, membership_query,\n",
+    "                                   lambda h: find_counterexample(h, TARGET, ALPHABET))\n",
+    "\n",
+    "print(f\"\\nDFA appris : {learned}\")\n",
+    "print(f\"Requetes d'appartenance : {final_table.n_mq}\")\n",
+    "print(f\"Requetes d'equivalence  : {n_eq}\")\n",
+    "print(f\"\\nTable finale (S = {len(final_table.S)} prefixes, E = {final_table.E}) :\\n\")\n",
+    "final_table.show()\n",
+    "\n",
+    "# Verification independante exhaustive jusqu'a la longueur 10\n",
+    "def all_words(alphabet, max_len):\n",
+    "    yield \"\"\n",
+    "    frontier = [\"\"]\n",
+    "    for _ in range(max_len):\n",
+    "        frontier = [w + a for w in frontier for a in alphabet]\n",
+    "        yield from frontier\n",
+    "\n",
+    "mismatch = sum(learned.accepts(w) != TARGET.accepts(w) for w in all_words(ALPHABET, 10))\n",
+    "total = sum(1 for _ in all_words(ALPHABET, 10))\n",
+    "print(f\"\\nVerification exhaustive : {total - mismatch}/{total} mots (longueur <= 10) identiques\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003665,
+     "end_time": "2026-06-10T11:53:41.510252",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.506587",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : que s'est-il passe ?\n",
+    "\n",
+    "1. **La premiere conjecture est minuscule et fausse.** Avec $S = E = \\{\\varepsilon\\}$\n",
+    "   stabilises, la table ne distingue que « accepte / rejette » : 2 etats. Le\n",
+    "   professeur repond par un contre-exemple court.\n",
+    "\n",
+    "2. **Le contre-exemple force la croissance.** Ses prefixes entrent dans $S$, la\n",
+    "   consistance casse, des suffixes distinguants entrent dans $E$ --- chaque rejet\n",
+    "   d'une conjecture ajoute *au moins un etat* a la suivante. Comme le DFA minimal a\n",
+    "   4 etats, il y a au plus 4 conjectures : la terminaison est garantie, pas\n",
+    "   seulement esperee.\n",
+    "\n",
+    "3. **Le cout total est modeste** : quelques dizaines de MQ et une poignee d'EQ pour\n",
+    "   identifier exactement un langage infini. Comparez avec SL-1 : 12 exemples\n",
+    "   *imposes* n'avaient pas suffi a stabiliser une simple conjonction. Le choix actif\n",
+    "   des questions est la source de l'efficacite --- chaque requete de la table sert a\n",
+    "   trancher une distinction precise entre deux etats candidats.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003214,
+     "end_time": "2026-06-10T11:53:41.516079",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.512865",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Garanties : minimalite et complexite polynomiale\n",
+    "\n",
+    "Le theoreme de **Myhill-Nerode** (1958) donne la borne inferieure structurelle : le\n",
+    "nombre d'etats du DFA minimal de $L$ est exactement le nombre de classes de la\n",
+    "congruence $u \\equiv_L v \\iff \\forall w,\\; uw \\in L \\Leftrightarrow vw \\in L$.\n",
+    "\n",
+    "L* s'y adosse directement :\n",
+    "\n",
+    "- chaque paire de lignes **distinctes** de la table est un *certificat* de\n",
+    "  non-equivalence (un suffixe de $E$ separe les deux prefixes), donc la conjecture\n",
+    "  n'a jamais *plus* d'etats que le DFA minimal ;\n",
+    "- l'oracle d'equivalence fournit des contre-exemples tant qu'elle en a *moins* ;\n",
+    "- l'algorithme s'arrete donc precisement sur le DFA minimal --- il ne peut pas\n",
+    "  retourner autre chose.\n",
+    "\n",
+    "Cote complexite : $O(n)$ requetes d'equivalence et $O(|\\Sigma| \\cdot m \\cdot n^2)$\n",
+    "requetes d'appartenance, ou $n$ est le nombre d'etats du minimal et $m$ la longueur\n",
+    "du plus long contre-exemple. Verifions empiriquement la croissance sur la famille\n",
+    "$L_k$ = « le nombre de 'a' est divisible par $k$ » (DFA minimal a $k$ etats) :\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "sl8-14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.526540Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.526014Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.546077Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.544931Z"
+    },
+    "papermill": {
+     "duration": 0.025824,
+     "end_time": "2026-06-10T11:53:41.546589",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.520765",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classes de Myhill-Nerode empiriques (prefixes <= 4, suffixes <= 4) : 4\n",
+      "  classe de    'ε' : 11 prefixes\n",
+      "  classe de    'a' : 5 prefixes\n",
+      "  classe de    'b' : 5 prefixes\n",
+      "  classe de   'ab' : 10 prefixes\n",
+      "\n",
+      "  k | etats appris | MQ | EQ\n",
+      "----------------------------------\n",
+      "  2 |            2 |    5 |  1\n",
+      "  3 |            3 |   14 |  2\n",
+      "  4 |            4 |   23 |  2\n",
+      "  5 |            5 |   34 |  2\n",
+      "  6 |            6 |   47 |  2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verification empirique 1 : les classes de Myhill-Nerode du langage cible\n",
+    "def nerode_classes(mq, alphabet, max_prefix=4, max_suffix=4):\n",
+    "    \"\"\"Partitionne les prefixes par leur comportement sur tous les suffixes courts.\"\"\"\n",
+    "    suffixes = list(all_words(alphabet, max_suffix))\n",
+    "    signature = {}\n",
+    "    for u in all_words(alphabet, max_prefix):\n",
+    "        signature.setdefault(tuple(mq(u + w) for w in suffixes), []).append(u)\n",
+    "    return signature\n",
+    "\n",
+    "classes = nerode_classes(membership_query, ALPHABET)\n",
+    "print(f\"Classes de Myhill-Nerode empiriques (prefixes <= 4, suffixes <= 4) : {len(classes)}\")\n",
+    "for sig, members in classes.items():\n",
+    "    eps = chr(949)\n",
+    "    print(f\"  classe de {members[0] or eps!r:>6} : {len(members)} prefixes\")\n",
+    "\n",
+    "# Verification empirique 2 : croissance du cout en fonction de n\n",
+    "print(f\"\\n{'k':>3} | etats appris | MQ | EQ\")\n",
+    "print(\"-\" * 34)\n",
+    "for k in range(2, 7):\n",
+    "    def mq_k(word, k=k):\n",
+    "        return word.count(\"a\") % k == 0\n",
+    "    dk_states = list(range(k))\n",
+    "    dk = DFA(dk_states, ALPHABET,\n",
+    "             {(q, \"a\"): (q + 1) % k for q in dk_states} |\n",
+    "             {(q, \"b\"): q for q in dk_states},\n",
+    "             0, {0})\n",
+    "    hyp, tbl, neq = lstar(ALPHABET, mq_k,\n",
+    "                          lambda h, dk=dk: find_counterexample(h, dk, ALPHABET),\n",
+    "                          verbose=False)\n",
+    "    print(f\"{k:>3} | {len(hyp.states):>12} | {tbl.n_mq:>4} | {neq:>2}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004784,
+     "end_time": "2026-06-10T11:53:41.556597",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.551813",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation\n",
+    "\n",
+    "Les classes empiriques de Myhill-Nerode sont bien au nombre de **4** --- et L* a\n",
+    "appris un DFA a 4 etats : la garantie de minimalite n'est pas un a-cote theorique,\n",
+    "c'est le mecanisme meme de l'algorithme. Sur la famille $L_k$, le nombre d'etats\n",
+    "appris suit exactement $k$ et le nombre de requetes croit polynomialement, tres\n",
+    "loin de l'explosion exponentielle qu'exigerait l'enumeration des DFA candidats.\n",
+    "\n",
+    "A noter : c'est un des rares algorithmes de la serie a venir avec une garantie\n",
+    "*exacte* (identification du concept, pas approximation). Le prix est le professeur :\n",
+    "sans oracle d'equivalence fiable, la garantie s'evapore --- voyons precisement\n",
+    "comment.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-16",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004695,
+     "end_time": "2026-06-10T11:53:41.566067",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.561372",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. L'oracle d'equivalence en pratique\n",
+    "\n",
+    "Dans le monde reel (retro-ingenierie d'un protocole, test d'un composant boite\n",
+    "noire), personne ne sait repondre exactement a « ton hypothese est-elle correcte ? ».\n",
+    "On *approxime* l'EQ par echantillonnage : tirer $N$ mots au hasard, comparer\n",
+    "l'hypothese et le systeme, renvoyer le premier desaccord. S'il n'y en a aucun,\n",
+    "declarer l'hypothese correcte... en croisant les doigts.\n",
+    "\n",
+    "C'est exactement le cadre **PAC** (SL-3) : le DFA retourne est *probablement\n",
+    "approximativement correct* --- mais plus *exactement* correct. Et la nuance n'est\n",
+    "pas academique : elle depend entierement de la **densite des desaccords** entre une\n",
+    "hypothese fausse et la cible. Mesurons-la sur deux langages aux profils opposes :\n",
+    "le langage des parites (ou une hypothese fausse se trompe sur environ un mot sur\n",
+    "quatre) et un langage-aiguille, « les mots contenant le facteur `aabbaabb` », ou\n",
+    "les mots discriminants sont rares.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "sl8-17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.576609Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.576609Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.622118Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.620993Z"
+    },
+    "papermill": {
+     "duration": 0.051855,
+     "end_time": "2026-06-10T11:53:41.622642",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.570787",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Langage parites (desaccords DENSES) :\n",
+      " N essais | etats | DFA exact ?\n",
+      "        1 |     4 | OUI\n",
+      "       10 |     4 | OUI\n",
+      "      100 |     4 | OUI\n",
+      "     1000 |     4 | OUI\n",
+      "\n",
+      "Langage contient 'aabbaabb' (desaccords RARES) :\n",
+      " N essais | etats | DFA exact ?\n",
+      "        1 |     1 | NON\n",
+      "       10 |     1 | NON\n",
+      "      100 |     9 | OUI\n",
+      "     1000 |     9 | OUI\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import random\n",
+    "\n",
+    "\n",
+    "def make_sampling_eq(mq, alphabet, n_samples, max_len=20, seed=0):\n",
+    "    \"\"\"Oracle d'equivalence approximatif : N mots aleatoires, premier desaccord.\"\"\"\n",
+    "    rng = random.Random(seed)\n",
+    "    def eq(hyp):\n",
+    "        for _ in range(n_samples):\n",
+    "            w = \"\".join(rng.choice(alphabet) for _ in range(rng.randint(0, max_len)))\n",
+    "            if hyp.accepts(w) != mq(w):\n",
+    "                return w\n",
+    "        return None\n",
+    "    return eq\n",
+    "\n",
+    "\n",
+    "# Le langage-aiguille : mots contenant le facteur \"aabbaabb\".\n",
+    "# Son DFA minimal est l'automate de Knuth-Morris-Pratt du motif : 9 etats.\n",
+    "def factor_dfa(pattern, alphabet):\n",
+    "    n = len(pattern)\n",
+    "    delta = {}\n",
+    "    for q in range(n + 1):\n",
+    "        for ch in alphabet:\n",
+    "            if q == n:\n",
+    "                delta[(q, ch)] = n              # motif deja vu : etat absorbant\n",
+    "            elif pattern[q] == ch:\n",
+    "                delta[(q, ch)] = q + 1          # on avance dans le motif\n",
+    "            else:                               # repli KMP : plus long prefixe\n",
+    "                s = pattern[:q] + ch            # du motif encore suffixe de s\n",
+    "                delta[(q, ch)] = max(k for k in range(len(s) + 1)\n",
+    "                                     if s.endswith(pattern[:k]))\n",
+    "    return DFA(range(n + 1), alphabet, delta, 0, {n})\n",
+    "\n",
+    "\n",
+    "NEEDLE = factor_dfa(\"aabbaabb\", ALPHABET)\n",
+    "\n",
+    "for name, mq, tgt in [(\"parites (desaccords DENSES)\", membership_query, TARGET),\n",
+    "                      (\"contient 'aabbaabb' (desaccords RARES)\", NEEDLE.accepts, NEEDLE)]:\n",
+    "    print(f\"Langage {name} :\")\n",
+    "    print(f\"{'N essais':>9} | etats | DFA exact ?\")\n",
+    "    for n_samples in [1, 10, 100, 1000]:\n",
+    "        hyp, tbl, _ = lstar(ALPHABET, mq,\n",
+    "                            make_sampling_eq(mq, ALPHABET, n_samples, seed=7),\n",
+    "                            verbose=False)\n",
+    "        exact = find_counterexample(hyp, tgt, ALPHABET) is None\n",
+    "        print(f\"{n_samples:>9} | {len(hyp.states):>5} | {'OUI' if exact else 'NON'}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-18",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003139,
+     "end_time": "2026-06-10T11:53:41.628942",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.625803",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : tout depend de la densite des desaccords\n",
+    "\n",
+    "Sur les **parites**, un seul mot aleatoire par appel suffit deja : une hypothese\n",
+    "fausse y est en desaccord avec la cible sur environ un mot sur quatre, le premier\n",
+    "tirage venu fait office de contre-exemple. La garantie *semble* intacte --- mais\n",
+    "c'est une propriete du langage, pas de l'algorithme.\n",
+    "\n",
+    "Sur le **langage-aiguille**, un mot aleatoire de longueur $\\le 20$ ne contient le\n",
+    "facteur qu'avec une probabilite de quelques pourcents. A $N = 1$ ou $10$ essais,\n",
+    "l'EQ approximatif ne voit jamais de desaccord et accepte la *toute premiere*\n",
+    "conjecture : un DFA a **un etat qui rejette tout**. Le resultat est grossierement\n",
+    "faux et *rien dans l'execution ne le signale* --- c'est le sens exact du PAC :\n",
+    "correct avec probabilite $1 - \\delta$ *sur la distribution d'echantillonnage*,\n",
+    "rien de plus. A $N = 100$, le contre-exemple finit par sortir, et un seul suffit :\n",
+    "ses prefixes injectent dans la table tout le materiel necessaire, et L* deroule\n",
+    "les 9 etats sans aide supplementaire.\n",
+    "\n",
+    "C'est la meme lecon que SL-7, vue de l'autre cote : la-bas, un generateur faillible\n",
+    "(le LLM) etait discipline par un oracle exact ; ici, un apprenant exact est\n",
+    "fragilise par un oracle faillible. Dans un pipeline neuro-symbolique, *identifier\n",
+    "qui joue le role de l'oracle et ce qu'il garantit vraiment* est la premiere\n",
+    "question d'architecture.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-19",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002614,
+     "end_time": "2026-06-10T11:53:41.634720",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.632106",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 7. Posterite : le *model learning*\n",
+    "\n",
+    "L* n'est pas reste un resultat theorique. Sous le nom de **model learning**\n",
+    "(Vaandrager, CACM 2017), ses descendants directs apprennent des machines a etats\n",
+    "de systemes reels, en branchant les MQ sur le systeme lui-meme :\n",
+    "\n",
+    "- **Retro-ingenierie de protocoles** : les implementations de TLS, TCP, SSH ou des\n",
+    "  cartes bancaires ont ete apprises comme des machines de Mealy ; plusieurs\n",
+    "  violations de specification et failles ont ete trouvees en *lisant le DFA appris*\n",
+    "  (etats parasites, transitions interdites presentes).\n",
+    "- **[LearnLib](https://learnlib.de/)** (open source, Java) industrialise L* et ses\n",
+    "  variantes modernes (TTT, Rivest-Schapire, ADT), avec des EQ approximatifs\n",
+    "  intelligents (W-method, echantillonnage dirige).\n",
+    "- **Verification** : le DFA appris sert d'interface formelle d'un composant boite\n",
+    "  noire, sur laquelle un model checker peut ensuite prouver des proprietes\n",
+    "  (assume-guarantee reasoning).\n",
+    "\n",
+    "Et la boucle se referme avec les LLM : des travaux recents utilisent un LLM comme\n",
+    "*professeur approximatif* (repondre aux MQ sur un format textuel, proposer des\n",
+    "contre-exemples) et L* comme *apprenant exact* qui en extrait un automate verifiable\n",
+    "--- la division generateur faillible / verificateur symbolique de SL-7, devenue\n",
+    "protocole d'apprentissage.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002646,
+     "end_time": "2026-06-10T11:53:41.640017",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.637371",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 8. Exercices\n",
+    "\n",
+    "### Tableau recapitulatif\n",
+    "\n",
+    "| Concept | Definition | Implementation |\n",
+    "|---------|------------|----------------|\n",
+    "| Requete MQ / EQ | $w \\in L$ ? / $H = L$ ? | `membership_query`, `find_counterexample` |\n",
+    "| Table d'observation | $(S, E, T)$, lignes = etats candidats | `ObservationTable` |\n",
+    "| Fermeture | $row(sa)$ presente dans $S$ | `find_unclosed()` |\n",
+    "| Consistance | lignes egales -> successeurs egaux | `find_inconsistency()` |\n",
+    "| Conjecture | DFA des lignes distinctes | `conjecture()` |\n",
+    "| EQ approximatif | echantillonnage, garantie PAC | `make_sampling_eq()` |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "sl8-21",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.647830Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.647306Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.652053Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.651468Z"
+    },
+    "papermill": {
+     "duration": 0.009991,
+     "end_time": "2026-06-10T11:53:41.652582",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.642591",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Apprendre le langage \"contient 'abb' comme facteur\"\n",
+    "# TODO etudiant : faites apprendre par L* le langage des mots qui contiennent\n",
+    "# la sous-chaine \"abb\", SANS construire le DFA cible vous-meme.\n",
+    "# Indice : la requete d'appartenance peut etre une simple fonction Python ;\n",
+    "#          pour l'equivalence, utilisez make_sampling_eq avec n_samples=2000.\n",
+    "# Etape 1 : ecrivez mq_abb(word) (une ligne : l'operateur 'in' suffit)\n",
+    "# Etape 2 : lancez lstar(ALPHABET, mq_abb, make_sampling_eq(mq_abb, ALPHABET, 2000))\n",
+    "# Etape 3 : combien d'etats a le DFA appris ? Expliquez chacun d'eux\n",
+    "#           (prediction theorique : 4 -- rien vu, 'a' vu, 'ab' vu, 'abb' vu)\n",
+    "# Etape 4 : verifiez le DFA sur 10 mots de votre choix\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-22",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004676,
+     "end_time": "2026-06-10T11:53:41.662437",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.657761",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "L'exercice suivant quantifie ce que la section 6 a montre qualitativement : la\n",
+    "fiabilite de l'oracle d'equivalence par echantillonnage est une variable aleatoire,\n",
+    "qui se mesure en repetant l'experience.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "sl8-23",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.670811Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.670301Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.684028Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.682949Z"
+    },
+    "papermill": {
+     "duration": 0.017447,
+     "end_time": "2026-06-10T11:53:41.684028",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.666581",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Fiabilite de l'oracle d'equivalence approximatif\n",
+    "# TODO etudiant : pour n_samples dans [1, 10, 50, 100, 500], lancez L* sur le\n",
+    "# langage-aiguille NEEDLE (section 6) avec 20 graines differentes (seed=0..19)\n",
+    "# et mesurez le TAUX de runs qui retournent un DFA exactement correct.\n",
+    "# Indice : la correction se verifie avec find_counterexample(hyp, NEEDLE, ALPHABET)\n",
+    "# Etape 1 : double boucle n_samples x seed, verbose=False\n",
+    "# Etape 2 : tableau n_samples -> taux de reussite (sur 20 runs)\n",
+    "# Etape 3 : ou situez-vous le seuil de fiabilite ? Refaites la mesure sur TARGET\n",
+    "#           (parites) : pourquoi le seuil depend-il du langage ?\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00453,
+     "end_time": "2026-06-10T11:53:41.695102",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.690572",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "L'exercice suivant touche au coeur algorithmique : la maniere d'integrer le\n",
+    "contre-exemple. Angluin ajoute tous ses **prefixes** a $S$ ; la variante de\n",
+    "Maler-Pnueli ajoute tous ses **suffixes** a $E$ --- meme garantie, couts differents.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "sl8-25",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.703377Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.702372Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.713792Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.713228Z"
+    },
+    "papermill": {
+     "duration": 0.016676,
+     "end_time": "2026-06-10T11:53:41.714796",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.698120",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Variante de traitement du contre-exemple (suffixes vs prefixes)\n",
+    "# TODO etudiant : implementez la variante qui, au lieu d'ajouter les prefixes du\n",
+    "# contre-exemple a S, ajoute tous ses SUFFIXES a E (variante Maler-Pnueli).\n",
+    "# Indice : copiez lstar() et modifiez uniquement le traitement du contre-exemple ;\n",
+    "#          les suffixes de c sont c[i:] pour i in range(len(c))\n",
+    "# Etape 1 : ecrivez lstar_suffixes(alphabet, mq, eq)\n",
+    "# Etape 2 : comparez sur le langage cible ET sur L_5 (divisibilite par 5) :\n",
+    "#           |S|, |E|, nombre de MQ, nombre d'EQ pour les deux variantes\n",
+    "# Etape 3 : laquelle maintient la table la plus compacte ? Pourquoi la variante\n",
+    "#           suffixes ne peut-elle jamais rendre la table inconsistante ?\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-26",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003012,
+     "end_time": "2026-06-10T11:53:41.721808",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.718796",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Dernier exercice : la robustesse. Tous les algorithmes de la serie rencontrent\n",
+    "tot ou tard cette question, et la reponse de L* est singuliere.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "sl8-27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T11:53:41.728334Z",
+     "iopub.status.busy": "2026-06-10T11:53:41.728334Z",
+     "iopub.status.idle": "2026-06-10T11:53:41.744900Z",
+     "shell.execute_reply": "2026-06-10T11:53:41.744900Z"
+    },
+    "papermill": {
+     "duration": 0.02309,
+     "end_time": "2026-06-10T11:53:41.746406",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.723316",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : Oracle d'appartenance bruite\n",
+    "# TODO etudiant : enveloppez membership_query dans un oracle qui MENT avec\n",
+    "# probabilite p = 0.05 (graine fixee), et observez le comportement de L*.\n",
+    "# Indice : copiez lstar() en ajoutant un parametre max_rounds (ex. 15) pour\n",
+    "#          eviter une boucle infinie ; le mensonge doit etre DETERMINISTE par mot\n",
+    "#          (memoisez la premiere reponse, sinon la table T cache deja pour vous).\n",
+    "# Etape 1 : noisy_mq avec random.Random(0), p=0.05\n",
+    "# Etape 2 : lancez L* (borne) : la table se stabilise-t-elle ? combien d'etats ?\n",
+    "# Etape 3 : relancez avec p=0.01 et p=0.20 : que devient le DFA appris ?\n",
+    "# Question : pourquoi UNE seule reponse fausse peut-elle creer un etat fantome\n",
+    "# permanent, alors qu'un bruit de 5% est anodin pour un classifieur statistique ?\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-28",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00262,
+     "end_time": "2026-06-10T11:53:41.753654",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.751034",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Defi presentation (seance du 17 juin)\n",
+    "\n",
+    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
+    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
+    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
+    "Elle fait partie integrante de la presentation attendue.\n",
+    "\n",
+    "| Exercice | Question-twist a traiter en plus |\n",
+    "|----------|----------------------------------|\n",
+    "| **Ex. 1 (langage 'abb')** | Verifiez que le DFA appris est *minimal* en exhibant, pour chaque paire d'etats, un suffixe qui les distingue (certificat de Myhill-Nerode). Pourquoi L* est-il structurellement incapable de retourner un DFA non minimal ? |\n",
+    "| **Ex. 2 (fiabilite de l'EQ)** | Reliez votre taux de reussite empirique a la borne PAC : combien d'echantillons la theorie exige-t-elle pour $\\varepsilon = 0.01, \\delta = 0.05$ ? Construisez une distribution de tirage qui fait echouer l'echantillonnage quel que soit $N$ raisonnable. |\n",
+    "| **Ex. 3 (prefixes vs suffixes)** | Exhibez le pire cas : une famille de langages ou les contre-exemples sont longs et ou la variante prefixes fait exploser $|S|$. La variante de Rivest-Schapire n'ajoute qu'UN suffixe trouve par dichotomie sur le contre-exemple : quel est son cout en MQ et pourquoi est-ce le bon compromis ? |\n",
+    "| **Ex. 4 (oracle bruite)** | Peut-on reparer L* par vote majoritaire (poser chaque MQ 2k+1 fois) ? Calculez le surcout en requetes et la probabilite residuelle d'erreur ; comparez avec la degradation *graduelle* d'un classifieur statistique sous le meme bruit. Que conclure sur le contrat exactitude-contre-robustesse du symbolique ? |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-29",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002592,
+     "end_time": "2026-06-10T11:53:41.759382",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.756790",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 9. Conclusion\n",
+    "\n",
+    "### Recapitulatif\n",
+    "\n",
+    "1. **Le modele MAT** (Angluin 1987) donne a l'apprenant le droit de poser des\n",
+    "   questions : appartenance (MQ) et equivalence (EQ). Ce droit change la classe de\n",
+    "   complexite du probleme --- l'inference passive du plus petit DFA consistant est\n",
+    "   NP-difficile, l'inference active est polynomiale.\n",
+    "\n",
+    "2. **La table d'observation** $(S, E, T)$ approxime la congruence de Myhill-Nerode\n",
+    "   avec un ensemble fini de suffixes distinguants. Fermeture et consistance sont\n",
+    "   les deux conditions pour qu'elle definisse un DFA.\n",
+    "\n",
+    "3. **L*** alterne stabilisation de la table, conjecture, et integration du\n",
+    "   contre-exemple. Chaque conjecture rejetee gagne au moins un etat : terminaison\n",
+    "   et minimalite sont garanties, en au plus $n$ equivalences.\n",
+    "\n",
+    "4. **L'oracle d'equivalence exact n'existe pas en pratique** : on echantillonne, et\n",
+    "   la garantie exacte devient garantie PAC. La fiabilite du resultat est plafonnee\n",
+    "   par celle du professeur.\n",
+    "\n",
+    "5. **Le model learning** industrialise tout cela (LearnLib, machines de Mealy,\n",
+    "   protocoles reels) --- et la variante moderne « LLM comme professeur, L* comme\n",
+    "   apprenant » re-applique la division du travail de SL-7.\n",
+    "\n",
+    "### Position dans la serie\n",
+    "\n",
+    "| Methode | Type | L'apprenant... | Garantie |\n",
+    "|---------|------|----------------|----------|\n",
+    "| Version Space (SL-1) | passif, symbolique | subit les exemples | convergence si realisable |\n",
+    "| FOIL (SL-4) | passif, relationnel | subit les exemples | heuristique (gain) |\n",
+    "| LTN (SL-5) | passif, neuro-symbolique | subit les exemples | satisfaction approchee |\n",
+    "| **L* (SL-8)** | **actif, symbolique** | **choisit ses questions** | **identification exacte, DFA minimal** |\n",
+    "\n",
+    "### Connexions\n",
+    "\n",
+    "| Direction | Sujet | Lien |\n",
+    "|-----------|-------|------|\n",
+    "| Prerequis | Espaces d'hypotheses, PAC | [SL-1](SL-1-LogicalLearning.ipynb), [SL-3](SL-3-RelevanceLearning.ipynb) |\n",
+    "| Suite | Resolution inverse, Progol | [SL-9](SL-9-InverseResolution.ipynb) |\n",
+    "| Capstone | LLM professeur / oracle symbolique | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) |\n",
+    "| Automates & verification | Model checking | Serie SymbolicAI |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-30",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003016,
+     "end_time": "2026-06-10T11:53:41.764954",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.761938",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Ressources\n",
+    "\n",
+    "- D. Angluin, *Learning Regular Sets from Queries and Counterexamples*, Information and Computation 75(2), 1987\n",
+    "- M. Kearns & U. Vazirani, *An Introduction to Computational Learning Theory*, ch. 8 (MIT Press, 1994)\n",
+    "- F. Vaandrager, *Model Learning*, Communications of the ACM 60(2), 2017\n",
+    "- R. Rivest & R. Schapire, *Inference of Finite Automata Using Homing Sequences*, Information and Computation 103(2), 1993\n",
+    "- [LearnLib](https://learnlib.de/) --- bibliotheque de reference du model learning\n",
+    "- E. M. Gold, *Complexity of Automaton Identification from Given Data*, Information and Control 37, 1978\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Retour** : [Index SymbolicLearning](./README.md) | [<< SL-7](SL-7-LLM-SymbolicLearning.ipynb) | [SL-9 >>](SL-9-InverseResolution.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.436989,
+   "end_time": "2026-06-10T11:53:45.159511",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "SL-8-ActiveAutomataLearning.ipynb",
+   "output_path": "SL-8-ActiveAutomataLearning.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-10T11:53:39.722522",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Nouveau notebook **SL-8-ActiveAutomataLearning.ipynb** (mandat user 2026-06-10 : 3 nouveaux notebooks à 4 exercices pour la séance du 17 juin, ~30 groupes × 1 exercice).

**Python pur, zéro dépendance.** Arc pédagogique :
1. Modèle MAT d'Angluin (MQ/EQ) — contraste passif (SL-1, NP-difficile) vs actif (polynomial)
2. Table d'observation (S, E, T) : fermeture, consistance, lien Myhill-Nerode
3. L* complet avec trace verbose (cible : parité de 'a' ET de 'b', 4 états)
4. Exécution : 19 MQ + 2 EQ, vérification exhaustive 2047/2047 mots
5. Garanties : classes de Nerode empiriques = 4, sweep L_k (k=2..6) coût polynomial
6. **Oracle EQ par échantillonnage** : contraste honnête langage dense (exact dès N=1) vs langage-aiguille `aabbaabb` (DFA 1-état faux accepté silencieusement jusqu'à N=100) — la garantie exacte devient PAC
7. Model learning (LearnLib, protocoles TLS/TCP, LLM-as-teacher → boucle avec SL-7)

4 exercices stubs C.1 (langage 'abb', fiabilité EQ sur 20 graines, variante Maler-Pnueli suffixes, oracle bruité) + cellule **Défi présentation** (4 twists : certificat de minimalité, borne PAC adversariale, Rivest-Schapire, vote majoritaire vs robustesse statistique).

## Validation (H.1)

Papermill end-to-end depuis le répertoire série, kernel `python3` : **30 cells, 10 code, 0 noexec, 0 errors**, outputs committés.

Extraits réels :
```
Conjecture 1 : 2 etats -> contre-exemple 'ba'
Conjecture 2 : 4 etats -> ACCEPTEE
Classes de Myhill-Nerode empiriques : 4
Langage contient 'aabbaabb' (desaccords RARES) :
        1 |     1 | NON
      100 |     9 | OUI
```

`grep -nE "raise NotImplementedError|assert False|1/0"` = 0 (C.1).

Part of the SL series enrichment for the 2026-06-17 session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)