### PR TITLE
docs(symbolic-learning): README SL-1..SL-10 + table de pioche 34 exercices + nav footers

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -9,9 +9,9 @@ maturity: PRODUCTION=7
 
 Comment un agent peut-il apprendre a partir de connaissances existantes plutot que de donnees brutes ? Cette serie explore l'apprentissage symbolique tel que decrit dans le chapitre 19 d'AIMA (Russell & Norvig), depuis l'apprentissage inductif pur (CBH, Version Space) jusqu'aux methodes guidees par la connaissance (EBL, RBL).
 
-Le premier notebook pose les bases : representation d'hypotheses comme conjonctions de contraintes, algorithmes Current-Best-Hypothesis et Candidate Elimination (Version Space), et leurs limites face au bruit et aux concepts disjonctifs. Le second notebook montre comment la connaissance du domaine accelere l'apprentissage : l'apprentissage base sur les explications (EBL) compile les theories en heuristiques operationnelles, et l'apprentissage base sur la pertinence (RBL) identifie les attributs determinant via les determinations. Le troisieme notebook approfondit le RBL avec le treillis des determinations, l'algorithme MINIMAL-CONSISTENT-DET et une comparaison avec sklearn. Le quatrieme notebook couvre la programmation logique inductive (ILP) : l'algorithme FOIL (top-down), la resolution inverse (bottom-up) et la connexion avec les knowledge graphs. Les trois derniers notebooks ouvrent vers des methodes contemporaines : SL-5 introduit le neuro-symbolique (T-norms differentiables, Logic Tensor Networks, DeepProbLog) ; SL-6 outille la decouverte de regles sur knowledge graphs reels avec rdflib et AMIE rule mining ; SL-7 boucle LLM et verification symbolique pour fiabiliser le raisonnement formel guide par modeles de langage.
+Le premier notebook pose les bases : representation d'hypotheses comme conjonctions de contraintes, algorithmes Current-Best-Hypothesis et Candidate Elimination (Version Space), et leurs limites face au bruit et aux concepts disjonctifs. Le second notebook montre comment la connaissance du domaine accelere l'apprentissage : l'apprentissage base sur les explications (EBL) compile les theories en heuristiques operationnelles, et l'apprentissage base sur la pertinence (RBL) identifie les attributs determinant via les determinations. Le troisieme notebook approfondit le RBL avec le treillis des determinations, l'algorithme MINIMAL-CONSISTENT-DET et une comparaison avec sklearn. Le quatrieme notebook couvre la programmation logique inductive (ILP) : l'algorithme FOIL (top-down), la resolution inverse (bottom-up) et la connexion avec les knowledge graphs. Les trois derniers notebooks ouvrent vers des methodes contemporaines : SL-5 introduit le neuro-symbolique (T-norms differentiables, Logic Tensor Networks, DeepProbLog) ; SL-6 outille la decouverte de regles sur knowledge graphs reels avec rdflib et AMIE rule mining ; SL-7 boucle LLM et verification symbolique pour fiabiliser le raisonnement formel guide par modeles de langage. Trois notebooks etendent la serie : SL-8 change de paradigme avec l'apprentissage *actif* (l'algorithme L* d'Angluin interroge un oracle au lieu de subir un echantillon, et apprend des automates finis avec garanties de minimalite) ; SL-9 complete l'ILP de SL-4 par la voie bottom-up aboutie (LGG de Plotkin, theta-subsomption, clause bottom et recherche a la Progol) ; SL-10 est le capstone qui assemble toute la serie en un pipeline neuro-symbolique de bout en bout — du texte brut aux faits decouverts, avec un LLM reel (Gemini 3.5 Flash) aux deux extremites et le symbolique comme colonne vertebrale.
 
-**A qui s'adresse cette serie** : etudiants en IA, informaticiens interesses par le raisonnement symbolique, et chercheurs en apprentissage automatique souhaitant comprendre les approches non-statistiques. Les notebooks (~6h total) ne necessitent que Python 3.10+ standard library, sauf SL-3 (scikit-learn + numpy pour la comparaison RBL / information mutuelle) et SL-6 (rdflib pour les knowledge graphs). Une familiarite avec la logique propositionnelle suffit pour SL-1 a SL-4 ; SL-5 et SL-7 supposent une intuition des reseaux de neurones et des LLMs respectivement. Ils constituent un complement theorique aux series [Tweety](../Tweety/README.md) (argumentation computationnelle), [SemanticWeb](../SemanticWeb/README.md) (representation de connaissances) et [ML](../../ML/README.md) (apprentissage statistique - contraste avec l'inductif symbolique).
+**A qui s'adresse cette serie** : etudiants en IA, informaticiens interesses par le raisonnement symbolique, et chercheurs en apprentissage automatique souhaitant comprendre les approches non-statistiques. Les notebooks (~9h30 total) ne necessitent que Python 3.10+ standard library, sauf SL-3 (scikit-learn + numpy pour la comparaison RBL / information mutuelle) et SL-6 (rdflib pour les knowledge graphs) ; SL-7 et SL-10 acceptent une cle OpenRouter optionnelle (fichier `.env`) pour des appels LLM reels, avec un simulateur deterministe en repli. Une familiarite avec la logique propositionnelle suffit pour SL-1 a SL-4, SL-8 et SL-9 ; SL-5, SL-7 et SL-10 supposent une intuition des reseaux de neurones et des LLMs. Ils constituent un complement theorique aux series [Tweety](../Tweety/README.md) (argumentation computationnelle), [SemanticWeb](../SemanticWeb/README.md) (representation de connaissances) et [ML](../../ML/README.md) (apprentissage statistique - contraste avec l'inductif symbolique).
 
 ## Pourquoi cette serie
 
@@ -34,15 +34,19 @@ A l'issue de cette serie, vous serez capable de :
 5. **Intégrer** logique et apprentissage neuronal via T-norms, Logique Tensorielle, et DeepProbLog
 6. **Extraire** des regles de knowledge graphs reels avec rdflib et AMIE, et **effectuer** la completion de graphes
 7. **Concevoir** une boucle LLM-symbolique : extraction de regles IF-THEN depuis du texte, verification de coherence formelle, feedback pour l'amelioration
+8. **Implémenter** l'algorithme L* d'Angluin : table d'observation, requetes d'appartenance et d'equivalence, apprentissage actif d'automates minimaux
+9. **Construire** la chaine bottom-up de l'ILP : LGG de Plotkin, theta-subsomption, clause bottom et recherche de clause a la Progol
+10. **Assembler** un pipeline neuro-symbolique complet : extraction LLM, oracle de validation type, mining de regles, chainage avant avec provenance, et confrontation LLM vs KG
 
 ## Vue d'ensemble
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 7 |
+| Notebooks | 10 |
+| Exercices (table de pioche) | 34 |
 | Kernel | Python 3 |
-| Duree estimee | ~360 min |
-| prerequis | Python 3.10+ (standard library + sklearn pour SL-3/SL-4, rdflib pour SL-6) |
+| Duree estimee | ~570 min |
+| prerequis | Python 3.10+ (standard library + sklearn pour SL-3/SL-4, rdflib pour SL-6, cle OpenRouter optionnelle pour SL-7/SL-10) |
 
 ## Parcours d'apprentissage
 
@@ -62,19 +66,70 @@ SL-4 fait le pont entre apprentissage automatique et intelligence artificielle s
 
 La phase finale explore les methodes contemporaines a l'intersection du symbolique et du connexionniste. SL-5 introduit les T-norms differentiables, les predicats neuronaux et les Logics Tensor Networks qui rendent la logique operationnelle dans un gradient descent. SL-6 passe a l'echelle avec le rule mining reel sur des knowledge graphs construits avec rdflib (AMIE, completion de graphes). SL-7 ferme la boucle avec LLMs : extraction de regles depuis du texte naturel, verification symbolique des sorties, et boucles de retroaction pour fiabiliser le raisonnement.
 
+### Phase 5 : Apprentissage actif, ILP bottom-up et capstone (SL-8 a SL-10, ~210 min)
+
+Trois extensions concluent la serie. SL-8 inverse le rapport de l'apprenant aux donnees : au lieu de subir un echantillon, L* d'Angluin *choisit* ses questions (requetes d'appartenance et d'equivalence a un oracle MAT) et apprend des automates finis deterministes prouvablement minimaux — le cadre theorique (Myhill-Nerode, fermeture et coherence de la table d'observation) est implemente et verifie de zero. SL-9 reprend la promesse bottom-up esquissee en SL-4 et la mene a terme : LGG de Plotkin, theta-subsomption, clause bottom par entailment inverse, et recherche de clause a la Progol qui retrouve la definition de `grandfather/2` parmi 56 candidats. SL-10 est le capstone : un pipeline neuro-symbolique en 6 etages (extraction LLM -> oracle de validation -> knowledge graph -> mining de regles -> chainage avant avec provenance -> confrontation LLM vs KG) execute avec de vrais appels Gemini 3.5 Flash, ou chaque etage mobilise un notebook anterieur de la serie — y compris une lecon d'architecture decouverte dans les sorties reelles : le chainage avant peut violer les contraintes que l'oracle impose en amont.
+
 ### Parcours alternatives
 
-#### Parcours rapide (SL-1 + SL-5 + SL-7, ~2h)
+#### Parcours rapide (SL-1 + SL-5 + SL-7 + SL-10, ~4h)
 
-Pour ceux qui veulent saisir l'essence sans suivre toute la progression : les fondements inductifs (SL-1), l'integration neuro-symbolique (SL-5), et la verification LLM (SL-7). Donne une vue d'ensemble du spectre, de l'inductif pur au LLM symbolique.
+Pour ceux qui veulent saisir l'essence sans suivre toute la progression : les fondements inductifs (SL-1), l'integration neuro-symbolique (SL-5), la verification LLM (SL-7) et le capstone qui assemble le tout (SL-10). Donne une vue d'ensemble du spectre, de l'inductif pur au pipeline neuro-symbolique complet.
 
-#### Parcours ILP approfondi (SL-1 a SL-4, ~265 min)
+#### Parcours ILP approfondi (SL-1 a SL-4 + SL-9, ~325 min)
 
-Pour les etudiants en logique et IA symbolique : suivre les quatre premiers notebooks dans l'ordre pour maitriser l'apprentissage inductif complet — de Candidate Elimination a FOIL, resolution inverse, et rule mining sur KG.
+Pour les etudiants en logique et IA symbolique : suivre les quatre premiers notebooks dans l'ordre, puis SL-9 qui mene le bottom-up a terme — de Candidate Elimination a FOIL, puis LGG, theta-subsomption, clause bottom et Progol.
+
+#### Parcours theorie des langages (SL-1 + SL-8, ~110 min)
+
+Pour les etudiants en informatique theorique : le cadre inductif general (SL-1), puis l'apprentissage actif d'automates avec ses garanties formelles (SL-8) — requetes, Myhill-Nerode, minimalite, bornes PAC de l'oracle d'equivalence echantillonne.
 
 #### Parcours knowledge graphs (SL-2, SL-3, SL-4, SL-6, ~220 min)
 
 Pour les professionnels du web semantique et des donnees structurees : EBL, RBL, FOIL sur clauses Horn, puis application directe sur des knowledge graphs reels avec rdflib et AMIE. Presuppose une familiarite avec RDF/SPARQL.
+
+## Seance du 17 juin : la table de pioche (34 exercices)
+
+Modalite de la seance : chaque groupe choisit **un exercice** dans la table ci-dessous, le prepare, et le presente en seance. Resoudre l'exercice est le minimum attendu ; chaque exercice est assorti d'une **question-twist** (detaillee dans la cellule « Defi presentation » du notebook correspondant) qui fait partie integrante de la presentation. Premier arrive, premier servi : annoncez votre choix pour eviter les doublons.
+
+| # | Notebook | Exercice | Question-twist (en bref) |
+|---|----------|----------|--------------------------|
+| 1 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 1 — CBH avec ordre personnalise | Deux ordres d'exemples, deux hypotheses finales : pourquoi, a accuracy egale ? |
+| 2 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 2 — Version Space sur sous-ensemble | Qu'est-ce qui rend un exemple *informatif* (frontieres S et G) ? |
+| 3 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 3 — Regles avec couverture | Compacite vs hypothese AIMA : quel biais (rasoir d'Occam) prefere l'une a l'autre ? |
+| 4 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 4 — Reflexion sur le biais conjonctif | Un domaine ou ce biais est ideal, un ou il est catastrophique (no free lunch) |
+| 5 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 1 — EBL differentiation symbolique | Exhiber une variabilisation trop agressive qui produit une regle compilee fausse |
+| 6 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 2 — Filtrage des regles (operationnalite) | Deux distributions de requetes qui inversent le classement d'utilite des regles |
+| 7 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 3 — Speedup EBL | Le *utility problem* (Minton 1990) : pourquoi apprendre plus finit par ralentir |
+| 8 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 1 — Determinations meteo | Une observation bruitee : quelle determination minimale survit ? |
+| 9 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 2 — RBL vs selection aleatoire | Trouver le point de croisement ou la selection statistique bat le RBL |
+| 10 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 3 — Selecteur hybride | Quelles garanties votre hybride herite-t-il vraiment ? Contre-exemple construit |
+| 11 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 1 — `sibling` avec FOIL | Le role du biais de langage : que se passe-t-il sans le litteral `X != Y` ? |
+| 12 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 2 — Operateur W | Generalisation consistante mais fausse : pourquoi le bottom-up y est expose |
+| 13 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 3 — Regles sur mini-KG | Monde clos vs PCA (cf SL-6) : quelle confiance est la bonne pour VOTRE KG ? |
+| 14 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 2 — LTN frere/oncle | Retirer les axiomes negatifs : pourquoi une LTN a besoin de negatifs explicites |
+| 15 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 3 — Regle transitive `ancestor` | Le modele trivial « vrai partout » sature la regle : qu'est-ce qui l'evite ? |
+| 16 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 4 — T-norm de Lukasiewicz | Gradients exactement nuls : qu'est-ce qu'une semantique floue *apprenable* ? |
+| 17 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 1 — Nouvelle relation au KG | Regles redondantes (meme extension, syntaxe differente) : comment AMIE les evite |
+| 18 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 2 — PCA confidence | Construire un mini-KG ou la PCA confidence est trompeuse |
+| 19 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 3 — Regles a 3 atomes | Explosion combinatoire : pourquoi AMIE impose des regles fermees, a quel prix |
+| 20 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 1 — Prompt personnalise | Changer de modele LLM : que garantit vraiment l'oracle symbolique ? |
+| 21 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 2 — Prompt direct vs CoT | Validation oracle vs plausibilite du texte : les deux metriques peuvent diverger |
+| 22 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 3 — Detection d'hallucinations | Le detecteur suppose un monde clos : que devient-il en monde ouvert (cf SL-6) ? |
+| 23 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 1 — Le langage « contient abb » | Certificat de minimalite : un suffixe distinguant pour chaque paire d'etats (Myhill-Nerode) |
+| 24 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 2 — Fiabilite de l'EQ echantillonnee | Relier le taux de reussite empirique a la borne PAC ; construire une distribution adverse |
+| 25 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 3 — Contre-exemples : prefixes vs suffixes | Le pire cas qui fait exploser la table d'observation (Rivest-Schapire) |
+| 26 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 4 — Oracle bruite | Reparer L* par vote majoritaire : surcout en requetes et probabilite residuelle d'erreur |
+| 27 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 1 — Apprendre `grandmother/2` | Pourquoi `grandparent/2` (sans sexe) est *plus facile* — role des negatifs |
+| 28 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 2 — Profondeur de la clause bottom | Croissance de la clause bottom avec la profondeur ; la cible reste-t-elle dans le treillis ? |
+| 29 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 3 — Tolerance au bruit | Le score `p - n - L` comme argument MDL : quand prefere-t-il une clause imparfaite ? |
+| 30 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 4 — Reduction de Plotkin | Subsomption vs implication : le cas des clauses recursives ou elles divergent |
+| 31 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 1 — Etendre le schema (`marie_avec`) | Le mineur redecouvre la symetrie injectee par l'oracle : regle ou tautologie ? |
+| 32 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 2 — Politique de conflit a sources | *Truth discovery* : estimer la fiabilite des sources en meme temps que les faits |
+| 33 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 3 — Le bon seuil n'existe pas | Vraie et fausse regle a confiance egale (0.67) : quel signal au-dela du seuil ? |
+| 34 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 4 — Empoisonnement bout-en-bout | Classer les defenses par etage du pipeline ; ou s'arrete la provenance ? |
+
+Note : dans SL-5, le premier exercice de la numerotation interne est un exemple guide ; les exercices a piocher sont Ex. 2 a Ex. 4.
 
 ## Notebooks
 
@@ -86,7 +141,10 @@ Pour les professionnels du web semantique et des donnees structurees : EBL, RBL,
 | 4 | [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb) | FOIL, resolution inverse, clauses Horn, knowledge graphs | 55 min |
 | 5 | [SL-5 - Integration Neuro-Symbolique](SL-5-NeuroSymbolic.ipynb) | T-norms, predicats neuronaux, LTN, DeepProbLog | 55 min |
 | 6 | [SL-6 - ILP Moderne et Knowledge Graphs](SL-6-KnowledgeGraphs-ILP.ipynb) | rdflib, AMIE rule mining, completion KG | 55 min |
-| 7 | [SL-7 - LLMs et Apprentissage Symbolique](SL-7-LLM-SymbolicLearning.ipynb) | Prompting, extraction de regles, verification symbolique | 50 min |
+| 7 | [SL-7 - LLMs et Apprentissage Symbolique](SL-7-LLM-SymbolicLearning.ipynb) | Prompting, extraction de regles, verification symbolique (Gemini 3.5 Flash optionnel) | 50 min |
+| 8 | [SL-8 - Apprentissage Actif d'Automates](SL-8-ActiveAutomataLearning.ipynb) | L* d'Angluin, table d'observation, requetes MQ/EQ, Myhill-Nerode | 60 min |
+| 9 | [SL-9 - Resolution Inverse et Progol](SL-9-InverseResolution.ipynb) | LGG de Plotkin, theta-subsomption, clause bottom, recherche Progol | 60 min |
+| 10 | [SL-10 - Capstone Neuro-Symbolique](SL-10-Capstone-NeuroSymbolic.ipynb) | Pipeline 6 etages : extraction LLM, oracle, KG, mining, inference avec provenance, QA | 90 min |
 
 ## Contenu detaille
 
@@ -162,6 +220,41 @@ Pour les professionnels du web semantique et des donnees structurees : EBL, RBL,
 | Verification symbolique | Coherence formelle des sorties LLM |
 | Boucle LLM-Symbolique | Generation + verification + feedback |
 
+### SL-8-ActiveAutomataLearning.ipynb
+
+| Section | Contenu |
+|---------|---------|
+| Apprentissage actif | Passif vs actif, le cadre MAT (Minimally Adequate Teacher) |
+| DFA | Representation, execution, langage du mot « se termine par a » |
+| Table d'observation | Prefixes S, suffixes E, fermeture et coherence |
+| L* | Algorithme complet d'Angluin (1987), construction de l'hypothese |
+| Contre-exemples | Traitement, raffinement, convergence vers le DFA minimal |
+| Oracle echantillonne | Equivalence approchee par tirage, lien PAC |
+| Theorie | Myhill-Nerode, minimalite, bornes sur le nombre de requetes |
+
+### SL-9-InverseResolution.ipynb
+
+| Section | Contenu |
+|---------|---------|
+| Clauses et couverture | `covers()` par backtracking, validation de la cible `grandfather/2` |
+| LGG de Plotkin | Anti-unification, generalisation la moins generale, sur-specialisation |
+| Theta-subsomption | `subsumes()` par skolemisation, le treillis de generalite |
+| Clause bottom | Saturation bornee, entailment inverse, variabilisation |
+| Recherche Progol | Sous-ensembles connectes du corps de bottom, score `f = p - L`, consistance dure |
+| Cover-set | Boucle d'apprentissage de theorie complete |
+
+### SL-10-Capstone-NeuroSymbolic.ipynb
+
+| Section | Contenu |
+|---------|---------|
+| Corpus | Saga « Atelier Verne » : 13 enonces, 2 pieges factuels |
+| Etage 1 - Extraction | LLM (Gemini 3.5 Flash) ou simulateur : texte -> triples candidats |
+| Etage 2 - Oracle | Validation typee + contraintes fonctionnelles (cf SL-7) |
+| Etage 3 - KG | Knowledge graph valide (cf SL-6) |
+| Etage 4 - Mining | AMIE-lite : decouverte de regles avec confiance standard (cf SL-4/SL-6) |
+| Etage 5 - Inference | Chainage avant avec provenance ; le derive peut violer l'oracle (lecon d'architecture) |
+| Etage 6 - QA | Question 2 sauts : reponse KG (derivation citee) vs reponse LLM seule |
+
 ## Concepts cles
 
 | Concept | Explication | Notebook |
@@ -185,6 +278,16 @@ Pour les professionnels du web semantique et des donnees structurees : EBL, RBL,
 | **Knowledge Graph** | Graphe oriente de triples (sujet, predicat, objet) | SL-6 |
 | **AMIE** | Rule mining sur knowledge graphs incomplets | SL-6 |
 | **LLM-Symbolique** | Boucle de retroaction LLM + verification formelle | SL-7 |
+| **Apprentissage actif** | L'apprenant choisit ses questions au lieu de subir un echantillon | SL-8 |
+| **MAT** | Minimally Adequate Teacher : oracle d'appartenance + equivalence | SL-8 |
+| **Table d'observation** | Structure (S, E, T) fermee et coherente dont on lit un DFA | SL-8 |
+| **Myhill-Nerode** | Classes d'equivalence de suffixes = etats du DFA minimal | SL-8 |
+| **LGG** | Generalisation la moins generale de deux clauses (Plotkin) | SL-9 |
+| **Theta-subsomption** | Ordre de generalite decidable entre clauses (∃θ : Cθ ⊆ D) | SL-9 |
+| **Clause bottom** | Clause la plus specifique couvrant un exemple (entailment inverse) | SL-9 |
+| **Progol** | Recherche de clause guidee par la clause bottom | SL-9 |
+| **Provenance** | Trace de derivation attachee a chaque fait infere | SL-10 |
+| **Pipeline neuro-symbolique** | LLM aux extremites, validation et inference symboliques au centre | SL-10 |
 
 ## prerequis
 
@@ -196,7 +299,7 @@ Pour les professionnels du web semantique et des donnees structurees : EBL, RBL,
 
 ### Environnement Python
 
-Aucune dependance externe pour SL-1 et SL-2 (bibliothèque standard Python 3.10+ uniquement). SL-3 utilise `scikit-learn` et `numpy` pour la comparaison avec la selection statistique. SL-4 utilise uniquement la bibliotheque standard. SL-5 utilise uniquement la bibliotheque standard. SL-6 utilise `rdflib`. SL-7 utilise uniquement la bibliotheque standard.
+Aucune dependance externe pour SL-1, SL-2, SL-4, SL-5, SL-8 et SL-9 (bibliotheque standard Python 3.10+ uniquement). SL-3 utilise `scikit-learn` et `numpy` pour la comparaison avec la selection statistique. SL-6 utilise `rdflib`. SL-7 et SL-10 utilisent `python-dotenv` et `openai` pour les appels LLM optionnels via OpenRouter (Gemini 3.5 Flash) : copiez `.env.example` vers `.env` et renseignez `OPENROUTER_API_KEY` ; sans cle, un simulateur deterministe prend le relais et le notebook s'execute integralement.
 
 ## FAQ / Troubleshooting
 
@@ -267,7 +370,12 @@ SymbolicLearning/
 ├── SL-4-InductiveLogicProgramming.ipynb     # FOIL, resolution inverse, knowledge graphs
 ├── SL-5-NeuroSymbolic.ipynb                 # T-norms, LTN, DeepProbLog
 ├── SL-6-KnowledgeGraphs-ILP.ipynb           # rdflib, AMIE rule mining
-├── SL-7-LLM-SymbolicLearning.ipynb          # LLMs + verification symbolique
+├── SL-7-LLM-SymbolicLearning.ipynb          # LLMs + verification symbolique (Gemini 3.5 Flash optionnel)
+├── SL-8-ActiveAutomataLearning.ipynb        # L* d'Angluin, apprentissage actif d'automates
+├── SL-9-InverseResolution.ipynb             # LGG, theta-subsomption, clause bottom, Progol
+├── SL-10-Capstone-NeuroSymbolic.ipynb       # Capstone : pipeline neuro-symbolique 6 etages
+├── .env.example                             # Modele de configuration LLM (OpenRouter)
+├── requirements.txt                         # Dependances optionnelles
 ├── reference/
 │   └── AIMA_Ch19_Knowledge_in_Learning.md   # Notes de reference
 └── README.md                                # Cette documentation

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -2239,7 +2239,11 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebook suivant** : [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb)"
+    "**Notebook suivant** : [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Retour** : [Index SymbolicLearning](./README.md) | [SL-2 >>](SL-2-KnowledgeBasedLearning.ipynb)\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
@@ -1839,7 +1839,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Retour** : [Index SymbolicLearning](./README.md) | [<< SL-3](SL-3-RelevanceLearning.ipynb)"
+    "**Retour** : [Index SymbolicLearning](./README.md) | [<< SL-3](SL-3-RelevanceLearning.ipynb) | [SL-5 >>](SL-5-NeuroSymbolic.ipynb)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
@@ -2054,7 +2054,11 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebook suivant** : [SL-7 - LLM + Symbolic Learning](SL-7-LLM-SymbolicLearning.ipynb)"
+    "**Notebook suivant** : [SL-7 - LLM + Symbolic Learning](SL-7-LLM-SymbolicLearning.ipynb)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Retour** : [Index SymbolicLearning](./README.md) | [<< SL-5](SL-5-NeuroSymbolic.ipynb) | [SL-7 >>](SL-7-LLM-SymbolicLearning.ipynb)\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -2662,7 +2662,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Retour** : [Index SymbolicLearning](./README.md) | [<< Knowledge Graphs ILP](SL-6-KnowledgeGraphs-ILP.ipynb)"
+    "**Retour** : [Index SymbolicLearning](./README.md) | [<< Knowledge Graphs ILP](SL-6-KnowledgeGraphs-ILP.ipynb) | [SL-8 >>](SL-8-ActiveAutomataLearning.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Item 6/6 du mandat d'enrichissement de la serie SymbolicLearning pour la seance du 17 juin (apres #2760 #2761 #2762 #2763 #2764, tous merges).

- **README de serie etendu de 7 a 10 notebooks** : intro, objectifs 8-10, vue d'ensemble (~570 min, 34 exercices), nouvelle Phase 5 (SL-8 L* / SL-9 Progol / SL-10 Capstone), parcours alternatifs revises (+ parcours theorie des langages), lignes 8-10 de la table Notebooks, tables Contenu detaille SL-8/9/10, 10 nouveaux Concepts cles, environnement Python (.env.example OpenRouter, simulateur en repli), structure des fichiers.
- **Nouvelle section « Seance du 17 juin : la table de pioche »** : les 34 exercices de la serie en une table (notebook, exercice, question-twist en bref) — modalite : ~30 groupes, 1 exercice par groupe, twist detaille dans la cellule « Defi presentation » de chaque notebook.
- **Nav footers completes** (4 notebooks, **markdown-only**) : SL-1 (footer ajoute), SL-4 (lien SL-5 ajoute), SL-6 (footer ajoute), SL-7 (lien SL-8 ajoute). La chaine SL-1 -> SL-10 est maintenant complete dans les deux sens (SL-5 utilise son footer 'Navigation' existant).
- Bloc CATALOG-STATUS **non touche** (bot cron, decision #2632).

## Validation

- Modifications notebooks = cellule markdown finale uniquement -> outputs precedents valides (regle C.2, exception markdown-only).
- Audit post-edit : 10/10 notebooks avec footer prev/next correct ; exec_count_null=0 et errors=0 sur les 4 notebooks touches (verifie par script JSON).
- Aucun secret, aucun fichier hors scope (5 fichiers, +132/-16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)