### PR TITLE
feat(symbolic-learning): SL-6 section ASP avec clingo (vraie librairie, pont Tweety)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -140,7 +140,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | 3 | [SL-3 - Apprentissage Base sur la Pertinence](SL-3-RelevanceLearning.ipynb) | Treillis des determinations, MINIMAL-CONSISTENT-DET, RBL vs sklearn | 50 min |
 | 4 | [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb) | FOIL, resolution inverse, clauses Horn, knowledge graphs | 55 min |
 | 5 | [SL-5 - Integration Neuro-Symbolique](SL-5-NeuroSymbolic.ipynb) | T-norms, predicats neuronaux, LTN, DeepProbLog | 55 min |
-| 6 | [SL-6 - ILP Moderne et Knowledge Graphs](SL-6-KnowledgeGraphs-ILP.ipynb) | rdflib, AMIE rule mining, completion KG | 55 min |
+| 6 | [SL-6 - ILP Moderne et Knowledge Graphs](SL-6-KnowledgeGraphs-ILP.ipynb) | rdflib, AMIE rule mining, completion KG, ASP avec clingo | 55 min |
 | 7 | [SL-7 - LLMs et Apprentissage Symbolique](SL-7-LLM-SymbolicLearning.ipynb) | Prompting, extraction de regles, verification symbolique (Gemini 3.5 Flash optionnel) | 50 min |
 | 8 | [SL-8 - Apprentissage Actif d'Automates](SL-8-ActiveAutomataLearning.ipynb) | L* d'Angluin, table d'observation, requetes MQ/EQ, Myhill-Nerode | 60 min |
 | 9 | [SL-9 - Resolution Inverse et Progol](SL-9-InverseResolution.ipynb) | LGG de Plotkin, theta-subsomption, clause bottom, recherche Progol | 60 min |
@@ -210,6 +210,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | Knowledge Graphs | Construction avec rdflib |
 | AMIE rule mining | Decouverte de regles de Horn sur KG |
 | Completion | Inference de nouveaux triples |
+| ASP avec clingo | Validation croisee de la completion, recursion (`ancestorOf`), contraintes d'integrite (pont serie Tweety) |
 
 ### SL-7-LLM-SymbolicLearning.ipynb
 
@@ -299,7 +300,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 
 ### Environnement Python
 
-Aucune dependance externe pour SL-1, SL-2, SL-4, SL-5, SL-8 et SL-9 (bibliotheque standard Python 3.10+ uniquement). SL-3 utilise `scikit-learn` et `numpy` pour la comparaison avec la selection statistique. SL-6 utilise `rdflib`. SL-7 et SL-10 utilisent `python-dotenv` et `openai` pour les appels LLM optionnels via OpenRouter (Gemini 3.5 Flash) : copiez `.env.example` vers `.env` et renseignez `OPENROUTER_API_KEY` ; sans cle, un simulateur deterministe prend le relais et le notebook s'execute integralement.
+Aucune dependance externe pour SL-1, SL-2, SL-4, SL-5, SL-8 et SL-9 (bibliotheque standard Python 3.10+ uniquement). SL-3 utilise `scikit-learn` et `numpy` pour la comparaison avec la selection statistique. SL-6 utilise `rdflib` et `clingo` (module Python officiel Potassco, installe silencieusement par le notebook — meme moteur ASP que le binaire utilise par la serie Tweety via `scripts/install_clingo.py`). SL-7 et SL-10 utilisent `python-dotenv` et `openai` pour les appels LLM optionnels via OpenRouter (Gemini 3.5 Flash) : copiez `.env.example` vers `.env` et renseignez `OPENROUTER_API_KEY` ; sans cle, un simulateur deterministe prend le relais et le notebook s'execute integralement.
 
 ## FAQ / Troubleshooting
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
@@ -5,10 +5,10 @@
    "id": "cc001308",
    "metadata": {
     "papermill": {
-     "duration": 0.002992,
-     "end_time": "2026-06-10T10:34:50.864868",
+     "duration": 0.004892,
+     "end_time": "2026-06-10T12:35:02.271478",
      "exception": false,
-     "start_time": "2026-06-10T10:34:50.861876",
+     "start_time": "2026-06-10T12:35:02.266586",
      "status": "completed"
     },
     "tags": []
@@ -46,10 +46,10 @@
    "id": "a521d3e8",
    "metadata": {
     "papermill": {
-     "duration": 0.002008,
-     "end_time": "2026-06-10T10:34:50.870876",
+     "duration": 0.004004,
+     "end_time": "2026-06-10T12:35:02.279010",
      "exception": false,
-     "start_time": "2026-06-10T10:34:50.868868",
+     "start_time": "2026-06-10T12:35:02.275006",
      "status": "completed"
     },
     "tags": []
@@ -93,10 +93,10 @@
    "id": "fb76430f",
    "metadata": {
     "papermill": {
-     "duration": 0.003009,
-     "end_time": "2026-06-10T10:34:50.877391",
+     "duration": 0.003497,
+     "end_time": "2026-06-10T12:35:02.285514",
      "exception": false,
-     "start_time": "2026-06-10T10:34:50.874382",
+     "start_time": "2026-06-10T12:35:02.282017",
      "status": "completed"
     },
     "tags": []
@@ -115,16 +115,16 @@
    "id": "6422a73a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:50.884392Z",
-     "iopub.status.busy": "2026-06-10T10:34:50.884392Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.071478Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.070339Z"
+     "iopub.execute_input": "2026-06-10T12:35:02.294528Z",
+     "iopub.status.busy": "2026-06-10T12:35:02.294528Z",
+     "iopub.status.idle": "2026-06-10T12:35:03.755204Z",
+     "shell.execute_reply": "2026-06-10T12:35:03.754615Z"
     },
     "papermill": {
-     "duration": 5.192136,
-     "end_time": "2026-06-10T10:34:56.072527",
+     "duration": 1.466798,
+     "end_time": "2026-06-10T12:35:03.756314",
      "exception": false,
-     "start_time": "2026-06-10T10:34:50.880391",
+     "start_time": "2026-06-10T12:35:02.289516",
      "status": "completed"
     },
     "tags": []
@@ -157,10 +157,10 @@
    "id": "859f5cfd",
    "metadata": {
     "papermill": {
-     "duration": 0.00568,
-     "end_time": "2026-06-10T10:34:56.083931",
+     "duration": 0.007176,
+     "end_time": "2026-06-10T12:35:03.770582",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.078251",
+     "start_time": "2026-06-10T12:35:03.763406",
      "status": "completed"
     },
     "tags": []
@@ -177,16 +177,16 @@
    "id": "1cd6d433",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.098041Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.097529Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.475309Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.474610Z"
+     "iopub.execute_input": "2026-06-10T12:35:03.785859Z",
+     "iopub.status.busy": "2026-06-10T12:35:03.785859Z",
+     "iopub.status.idle": "2026-06-10T12:35:03.911392Z",
+     "shell.execute_reply": "2026-06-10T12:35:03.910841Z"
     },
     "papermill": {
-     "duration": 0.386174,
-     "end_time": "2026-06-10T10:34:56.476404",
+     "duration": 0.134314,
+     "end_time": "2026-06-10T12:35:03.912397",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.090230",
+     "start_time": "2026-06-10T12:35:03.778083",
      "status": "completed"
     },
     "tags": []
@@ -325,10 +325,10 @@
    "id": "c7f62d31",
    "metadata": {
     "papermill": {
-     "duration": 0.003518,
-     "end_time": "2026-06-10T10:34:56.483690",
+     "duration": 0.00651,
+     "end_time": "2026-06-10T12:35:03.924934",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.480172",
+     "start_time": "2026-06-10T12:35:03.918424",
      "status": "completed"
     },
     "tags": []
@@ -358,10 +358,10 @@
    "id": "09e1dbc5",
    "metadata": {
     "papermill": {
-     "duration": 0.005001,
-     "end_time": "2026-06-10T10:34:56.492032",
+     "duration": 0.007032,
+     "end_time": "2026-06-10T12:35:03.938556",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.487031",
+     "start_time": "2026-06-10T12:35:03.931524",
      "status": "completed"
     },
     "tags": []
@@ -380,16 +380,16 @@
    "id": "135b849e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.504049Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.503045Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.521249Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.521249Z"
+     "iopub.execute_input": "2026-06-10T12:35:03.953121Z",
+     "iopub.status.busy": "2026-06-10T12:35:03.952117Z",
+     "iopub.status.idle": "2026-06-10T12:35:03.974037Z",
+     "shell.execute_reply": "2026-06-10T12:35:03.972952Z"
     },
     "papermill": {
-     "duration": 0.02772,
-     "end_time": "2026-06-10T10:34:56.522750",
+     "duration": 0.030975,
+     "end_time": "2026-06-10T12:35:03.975058",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.495030",
+     "start_time": "2026-06-10T12:35:03.944083",
      "status": "completed"
     },
     "tags": []
@@ -475,10 +475,10 @@
    "id": "4e7a7a8e",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T10:34:56.535754",
+     "duration": 0.006436,
+     "end_time": "2026-06-10T12:35:03.987880",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.530754",
+     "start_time": "2026-06-10T12:35:03.981444",
      "status": "completed"
     },
     "tags": []
@@ -502,10 +502,10 @@
    "id": "2ebba873",
    "metadata": {
     "papermill": {
-     "duration": 0.005529,
-     "end_time": "2026-06-10T10:34:56.548488",
+     "duration": 0.006019,
+     "end_time": "2026-06-10T12:35:04.001012",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.542959",
+     "start_time": "2026-06-10T12:35:03.994993",
      "status": "completed"
     },
     "tags": []
@@ -538,16 +538,16 @@
    "id": "91350691",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.561624Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.560621Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.584143Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.583150Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.016761Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.015762Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.036868Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.035749Z"
     },
     "papermill": {
-     "duration": 0.030026,
-     "end_time": "2026-06-10T10:34:56.584143",
+     "duration": 0.028824,
+     "end_time": "2026-06-10T12:35:04.036868",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.554117",
+     "start_time": "2026-06-10T12:35:04.008044",
      "status": "completed"
     },
     "tags": []
@@ -558,7 +558,7 @@
      "output_type": "stream",
      "text": [
       "Test de compute_body_pairs :\n",
-      "  r1 = {('A', 'B'), ('C', 'D')}\n",
+      "  r1 = {('C', 'D'), ('A', 'B')}\n",
       "  r2 = {('D', 'F'), ('B', 'E')}\n",
       "  JOIN result = {('A', 'E'), ('C', 'F')}\n",
       "  Attendu : (('A', 'E'), ('C', 'F'))\n",
@@ -650,10 +650,10 @@
    "id": "2f9e5ce7",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T10:34:56.591150",
+     "duration": 0.006861,
+     "end_time": "2026-06-10T12:35:04.051646",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.587150",
+     "start_time": "2026-06-10T12:35:04.044785",
      "status": "completed"
     },
     "tags": []
@@ -677,10 +677,10 @@
    "id": "55e6358c",
    "metadata": {
     "papermill": {
-     "duration": 0.002993,
-     "end_time": "2026-06-10T10:34:56.597143",
+     "duration": 0.006937,
+     "end_time": "2026-06-10T12:35:04.064812",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.594150",
+     "start_time": "2026-06-10T12:35:04.057875",
      "status": "completed"
     },
     "tags": []
@@ -699,16 +699,16 @@
    "id": "93a15c8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.604655Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.604655Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.614663Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.614663Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.078477Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.078477Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.098223Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.097532Z"
     },
     "papermill": {
-     "duration": 0.015006,
-     "end_time": "2026-06-10T10:34:56.615657",
+     "duration": 0.028323,
+     "end_time": "2026-06-10T12:35:04.099739",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.600651",
+     "start_time": "2026-06-10T12:35:04.071416",
      "status": "completed"
     },
     "tags": []
@@ -822,10 +822,10 @@
    "id": "f171e286",
    "metadata": {
     "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-06-10T10:34:56.622164",
+     "duration": 0.007013,
+     "end_time": "2026-06-10T12:35:04.113804",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.619165",
+     "start_time": "2026-06-10T12:35:04.106791",
      "status": "completed"
     },
     "tags": []
@@ -858,10 +858,10 @@
    "id": "d17f08c2",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T10:34:56.629164",
+     "duration": 0.006916,
+     "end_time": "2026-06-10T12:35:04.127216",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.625164",
+     "start_time": "2026-06-10T12:35:04.120300",
      "status": "completed"
     },
     "tags": []
@@ -880,16 +880,16 @@
    "id": "e5d644f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.636165Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.636165Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.645674Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.645674Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.142783Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.142275Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.161562Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.160969Z"
     },
     "papermill": {
-     "duration": 0.014242,
-     "end_time": "2026-06-10T10:34:56.646407",
+     "duration": 0.029345,
+     "end_time": "2026-06-10T12:35:04.163088",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.632165",
+     "start_time": "2026-06-10T12:35:04.133743",
      "status": "completed"
     },
     "tags": []
@@ -1005,10 +1005,10 @@
    "id": "5dc0af7c",
    "metadata": {
     "papermill": {
-     "duration": 0.004007,
-     "end_time": "2026-06-10T10:34:56.653419",
+     "duration": 0.007065,
+     "end_time": "2026-06-10T12:35:04.177097",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.649412",
+     "start_time": "2026-06-10T12:35:04.170032",
      "status": "completed"
     },
     "tags": []
@@ -1037,10 +1037,10 @@
    "id": "16b4761d",
    "metadata": {
     "papermill": {
-     "duration": 0.004013,
-     "end_time": "2026-06-10T10:34:56.659935",
+     "duration": 0.007107,
+     "end_time": "2026-06-10T12:35:04.190792",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.655922",
+     "start_time": "2026-06-10T12:35:04.183685",
      "status": "completed"
     },
     "tags": []
@@ -1059,16 +1059,16 @@
    "id": "b1263c6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.667930Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.666930Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.676452Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.676452Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.205417Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.205417Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.223207Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.222136Z"
     },
     "papermill": {
-     "duration": 0.014067,
-     "end_time": "2026-06-10T10:34:56.677453",
+     "duration": 0.026383,
+     "end_time": "2026-06-10T12:35:04.224249",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.663386",
+     "start_time": "2026-06-10T12:35:04.197866",
      "status": "completed"
     },
     "tags": []
@@ -1184,10 +1184,10 @@
    "id": "1a969bc5",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-06-10T10:34:56.687444",
+     "duration": 0.007421,
+     "end_time": "2026-06-10T12:35:04.237743",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.683445",
+     "start_time": "2026-06-10T12:35:04.230322",
      "status": "completed"
     },
     "tags": []
@@ -1219,10 +1219,10 @@
    "id": "d71be242",
    "metadata": {
     "papermill": {
-     "duration": 0.003258,
-     "end_time": "2026-06-10T10:34:56.693702",
+     "duration": 0.00653,
+     "end_time": "2026-06-10T12:35:04.251840",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.690444",
+     "start_time": "2026-06-10T12:35:04.245310",
      "status": "completed"
     },
     "tags": []
@@ -1241,16 +1241,16 @@
    "id": "4022209e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.702645Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.702645Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.708539Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.708539Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.268934Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.268421Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.287012Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.286010Z"
     },
     "papermill": {
-     "duration": 0.011334,
-     "end_time": "2026-06-10T10:34:56.709533",
+     "duration": 0.027614,
+     "end_time": "2026-06-10T12:35:04.287012",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.698199",
+     "start_time": "2026-06-10T12:35:04.259398",
      "status": "completed"
     },
     "tags": []
@@ -1294,10 +1294,10 @@
       "Triples grandparentOf (apres completion) :\n",
       "  Claire -- grandparentOf --> Thomas\n",
       "  Claire -- grandparentOf --> Emma\n",
-      "  Jean -- grandparentOf --> Lea\n",
-      "  Jean -- grandparentOf --> Julie\n",
-      "  Jean -- grandparentOf --> Marc\n",
       "  Jean -- grandparentOf --> Hugo\n",
+      "  Jean -- grandparentOf --> Lea\n",
+      "  Jean -- grandparentOf --> Marc\n",
+      "  Jean -- grandparentOf --> Julie\n",
       "  Marie -- grandparentOf --> Luc\n",
       "  Marie -- grandparentOf --> Sophie\n",
       "  Marie -- grandparentOf --> Paul\n",
@@ -1355,10 +1355,10 @@
    "id": "e22df85d",
    "metadata": {
     "papermill": {
-     "duration": 0.004009,
-     "end_time": "2026-06-10T10:34:56.717055",
+     "duration": 0.007376,
+     "end_time": "2026-06-10T12:35:04.302518",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.713046",
+     "start_time": "2026-06-10T12:35:04.295142",
      "status": "completed"
     },
     "tags": []
@@ -1383,10 +1383,10 @@
    "id": "f1e0ba93",
    "metadata": {
     "papermill": {
-     "duration": 0.003724,
-     "end_time": "2026-06-10T10:34:56.723779",
+     "duration": 0.007079,
+     "end_time": "2026-06-10T12:35:04.316856",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.720055",
+     "start_time": "2026-06-10T12:35:04.309777",
      "status": "completed"
     },
     "tags": []
@@ -1405,16 +1405,16 @@
    "id": "6759ffea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.731461Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.731461Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.740136Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.739135Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.332618Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.332618Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.349445Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.348761Z"
     },
     "papermill": {
-     "duration": 0.013059,
-     "end_time": "2026-06-10T10:34:56.740136",
+     "duration": 0.026586,
+     "end_time": "2026-06-10T12:35:04.350958",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.727077",
+     "start_time": "2026-06-10T12:35:04.324372",
      "status": "completed"
     },
     "tags": []
@@ -1492,10 +1492,10 @@
    "id": "c00743ef",
    "metadata": {
     "papermill": {
-     "duration": 0.003504,
-     "end_time": "2026-06-10T10:34:56.747636",
+     "duration": 0.007023,
+     "end_time": "2026-06-10T12:35:04.364924",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.744132",
+     "start_time": "2026-06-10T12:35:04.357901",
      "status": "completed"
     },
     "tags": []
@@ -1520,10 +1520,10 @@
    "id": "a6ccf734",
    "metadata": {
     "papermill": {
-     "duration": 0.005014,
-     "end_time": "2026-06-10T10:34:56.759176",
+     "duration": 0.004698,
+     "end_time": "2026-06-10T12:35:04.376545",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.754162",
+     "start_time": "2026-06-10T12:35:04.371847",
      "status": "completed"
     },
     "tags": []
@@ -1542,16 +1542,16 @@
    "id": "092cac51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.772788Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.772788Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.786811Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.785804Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.387404Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.387404Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.395424Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.395424Z"
     },
     "papermill": {
-     "duration": 0.022124,
-     "end_time": "2026-06-10T10:34:56.786811",
+     "duration": 0.015645,
+     "end_time": "2026-06-10T12:35:04.396430",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.764687",
+     "start_time": "2026-06-10T12:35:04.380785",
      "status": "completed"
     },
     "tags": []
@@ -1620,10 +1620,10 @@
    "id": "01ea5c6c",
    "metadata": {
     "papermill": {
-     "duration": 0.006519,
-     "end_time": "2026-06-10T10:34:56.800369",
+     "duration": 0.004084,
+     "end_time": "2026-06-10T12:35:04.406512",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.793850",
+     "start_time": "2026-06-10T12:35:04.402428",
      "status": "completed"
     },
     "tags": []
@@ -1647,10 +1647,10 @@
    "id": "671bff9b",
    "metadata": {
     "papermill": {
-     "duration": 0.007072,
-     "end_time": "2026-06-10T10:34:56.813111",
+     "duration": 0.00451,
+     "end_time": "2026-06-10T12:35:04.414531",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.806039",
+     "start_time": "2026-06-10T12:35:04.410021",
      "status": "completed"
     },
     "tags": []
@@ -1665,13 +1665,383 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b26804b3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003523,
+     "end_time": "2026-06-10T12:35:04.422062",
+     "exception": false,
+     "start_time": "2026-06-10T12:35:04.418539",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## La vraie librairie : Answer Set Programming avec clingo\n",
+    "\n",
+    "Tout ce notebook a manipule des regles de Horn avec du Python artisanal : `compute_body_pairs`\n",
+    "fait la jointure, `apply_rules` fait une passe de chainage avant. C'est exactement le travail\n",
+    "d'un moteur **Datalog** -- et il existe une famille d'outils industriels qui font cela (et bien\n",
+    "plus) : les solveurs **ASP** (Answer Set Programming) de la suite Potassco, dont **clingo**\n",
+    "est le representant standard.\n",
+    "\n",
+    "L'ASP generalise Datalog sur trois points qui nous concernent directement :\n",
+    "\n",
+    "1. **Saturation au point fixe** : clingo applique les regles jusqu'a ce que plus rien ne soit\n",
+    "   derivable, y compris pour des regles **recursives** (`ancestorOf`) que notre mineur de\n",
+    "   regles fermees a 2 atomes ne peut meme pas exprimer.\n",
+    "2. **Contraintes d'integrite** : une regle sans tete (`:- corps.`) *interdit* un motif. Le\n",
+    "   solveur ne se contente pas de deriver, il **verifie la coherence** du graphe complete.\n",
+    "3. **Negation par echec et regles de choix** : au-dela de notre usage ici, l'ASP exprime des\n",
+    "   problemes combinatoires complets (planification, configuration).\n",
+    "\n",
+    "**Mutualisation avec la serie Tweety** : la serie [Tweety](../Tweety/README.md) utilise deja\n",
+    "clingo -- sous forme de binaire `clingo.exe` (installe par\n",
+    "[`scripts/install_clingo.py`](../scripts/install_clingo.py)) pilote par TweetyProject via la\n",
+    "JVM (`ClingoSolver`, cf. Tweety-3). Ici nous utilisons le **module Python `clingo`**\n",
+    "(`pip install clingo`) : c'est le meme moteur Potassco, expose en librairie -- pas de\n",
+    "binaire externe, pas de JVM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "454852af",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T12:35:04.433097Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.433097Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.458105Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.457111Z"
+    },
+    "papermill": {
+     "duration": 0.031549,
+     "end_time": "2026-06-10T12:35:04.458611",
+     "exception": false,
+     "start_time": "2026-06-10T12:35:04.427062",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "clingo version : 5.8.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Installation silencieuse de clingo (module Python officiel Potassco)\n",
+    "import importlib, subprocess, sys\n",
+    "\n",
+    "if importlib.util.find_spec(\"clingo\") is None:\n",
+    "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"clingo\"])\n",
+    "\n",
+    "import clingo\n",
+    "print(f\"clingo version : {clingo.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8b0a3dcf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T12:35:04.470145Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.470145Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.488692Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.488692Z"
+    },
+    "papermill": {
+     "duration": 0.025092,
+     "end_time": "2026-06-10T12:35:04.489704",
+     "exception": false,
+     "start_time": "2026-06-10T12:35:04.464612",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Programme ASP : 33 faits + 5 regles\n",
+      "  parentof(X,Y) :- parentof(X,Z), siblingof(Z,Y).\n",
+      "  parentof(X,Y) :- marriedto(X,Z), parentof(Z,Y).\n",
+      "  grandparentof(X,Y) :- grandparentof(X,Z), siblingof(Z,Y).\n",
+      "  grandparentof(X,Y) :- marriedto(X,Z), grandparentof(Z,Y).\n",
+      "  grandparentof(X,Y) :- parentof(X,Z), parentof(Z,Y).\n",
+      "\n",
+      "Modele stable : 42 atomes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Traduction du KG et des regles minees en programme ASP, puis resolution.\n",
+    "# On repart des structures de ce notebook : `relations` (le KG AVANT completion),\n",
+    "# `rules` (les regles minees avec leur PCA confidence) et `inferred` (les triples\n",
+    "# ajoutes par notre apply_rules Python) -- la comparaison est donc a perimetre egal.\n",
+    "\n",
+    "def asp_atom(pred: str, subj: str, obj: str) -> str:\n",
+    "    \"\"\"Un atome ASP : predicat en minuscules, constantes entre guillemets.\"\"\"\n",
+    "    return f'{pred.lower()}(\"{subj}\",\"{obj}\")'\n",
+    "\n",
+    "def kg_to_asp(relations: dict[str, set[tuple[str, str]]]) -> list[str]:\n",
+    "    \"\"\"Chaque paire (s, o) du KG devient un fait ASP.\"\"\"\n",
+    "    return [asp_atom(pred, s, o) + \".\" for pred, pairs in sorted(relations.items())\n",
+    "            for s, o in sorted(pairs)]\n",
+    "\n",
+    "def rule_to_asp(rule: dict) -> str:\n",
+    "    \"\"\"Traduit une regle minee (1 ou 2 atomes de corps, memes conventions que\n",
+    "    compute_body_pairs : chainage X->Z->Y) en regle ASP.\"\"\"\n",
+    "    head = f'{rule[\"head\"].lower()}(X,Y)'\n",
+    "    if len(rule[\"body\"]) == 2:\n",
+    "        r1, r2 = rule[\"body\"]\n",
+    "        body = f'{r1.lower()}(X,Z), {r2.lower()}(Z,Y)'\n",
+    "    else:\n",
+    "        body = f'{rule[\"body\"][0].lower()}(X,Y)'\n",
+    "    return f\"{head} :- {body}.\"\n",
+    "\n",
+    "facts = kg_to_asp(relations)\n",
+    "asp_rules = [rule_to_asp(r) for r in rules if r[\"pca_confidence\"] >= 0.5]\n",
+    "\n",
+    "program = \"\\n\".join(facts + asp_rules)\n",
+    "print(f\"Programme ASP : {len(facts)} faits + {len(asp_rules)} regles\")\n",
+    "for r in asp_rules:\n",
+    "    print(f\"  {r}\")\n",
+    "\n",
+    "# Grounding + solving : le modele stable contient le KG sature\n",
+    "ctl = clingo.Control()\n",
+    "ctl.add(\"base\", [], program)\n",
+    "ctl.ground([(\"base\", [])])\n",
+    "\n",
+    "model_atoms = set()\n",
+    "with ctl.solve(yield_=True) as handle:\n",
+    "    for model in handle:\n",
+    "        model_atoms = {str(a) for a in model.symbols(atoms=True)}\n",
+    "\n",
+    "print(f\"\\nModele stable : {len(model_atoms)} atomes\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "871be88a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T12:35:04.500712Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.499710Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.520742Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.519744Z"
+    },
+    "papermill": {
+     "duration": 0.02604,
+     "end_time": "2026-06-10T12:35:04.520742",
+     "exception": false,
+     "start_time": "2026-06-10T12:35:04.494702",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicat           KG initial  + Python  + clingo  verdict\n",
+      "--------------------------------------------------------------\n",
+      "grandparentOf               5        14        14  IDENTIQUE\n",
+      "marriedTo                   2         2         2  IDENTIQUE\n",
+      "parentOf                   14        14        14  IDENTIQUE\n",
+      "siblingOf                  12        12        12  IDENTIQUE\n",
+      "\n",
+      "Les deux moteurs derivent exactement la meme completion : notre\n",
+      "apply_rules etait bien un chainage avant Datalog -- clingo le confirme.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Comparaison : clingo (saturation au point fixe) vs notre apply_rules (passe unique)\n",
+    "def model_pairs(pred: str) -> set[tuple[str, str]]:\n",
+    "    \"\"\"Extrait du modele stable les paires (s, o) d'un predicat.\"\"\"\n",
+    "    out = set()\n",
+    "    prefix = pred.lower() + '(\"'\n",
+    "    for atom in model_atoms:\n",
+    "        if atom.startswith(prefix):\n",
+    "            inner = atom[len(pred) + 1:-1]          # '\"s\",\"o\"'\n",
+    "            s, o = [t.strip('\"') for t in inner.split('\",\"')]\n",
+    "            out.add((s, o))\n",
+    "    return out\n",
+    "\n",
+    "print(f\"{'Predicat':18} {'KG initial':>10} {'+ Python':>9} {'+ clingo':>9}  verdict\")\n",
+    "print(\"-\" * 62)\n",
+    "all_match = True\n",
+    "for pred in sorted(relations):\n",
+    "    base = relations[pred]\n",
+    "    python_final = base | {(s, o) for s, p, o in inferred if p == pred}\n",
+    "    clingo_final = model_pairs(pred)\n",
+    "    verdict = \"IDENTIQUE\" if clingo_final == python_final else \"DIFFERENT\"\n",
+    "    all_match &= (verdict == \"IDENTIQUE\")\n",
+    "    print(f\"{pred:18} {len(base):>10} {len(python_final):>9} {len(clingo_final):>9}  {verdict}\")\n",
+    "\n",
+    "if all_match:\n",
+    "    print(\"\\nLes deux moteurs derivent exactement la meme completion : notre\")\n",
+    "    print(\"apply_rules etait bien un chainage avant Datalog -- clingo le confirme.\")\n",
+    "else:\n",
+    "    print(\"\\nDivergence : clingo sature au point fixe (les regles se nourrissent\")\n",
+    "    print(\"entre elles), la ou apply_rules ne fait qu'une seule passe.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "f9414515",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T12:35:04.531265Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.530265Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.551777Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.551273Z"
+    },
+    "papermill": {
+     "duration": 0.027526,
+     "end_time": "2026-06-10T12:35:04.552791",
+     "exception": false,
+     "start_time": "2026-06-10T12:35:04.525265",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Coherent (acyclique) : True\n",
+      "ancestorOf derive : 40 paires (a partir de 14 parentOf)\n",
+      "\n",
+      "Avec le fait cyclique parentof(Emma, Marie) : UNSAT\n",
+      "UNSAT = le solveur REFUSE tout modele : la contrainte d'integrite\n",
+      "transforme le KG complete en KG verifie.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Ce que l'ASP ajoute : recursion et contraintes d'integrite.\n",
+    "# 1) ancestorOf est RECURSIF -- inexprimable par nos regles fermees a 2 atomes\n",
+    "#    (le mineur enumere des corps de taille fixe ; un point fixe ne s'enumere pas).\n",
+    "# 2) une contrainte d'integrite valide l'acyclicite du graphe familial.\n",
+    "\n",
+    "extension = \"\"\"\n",
+    "ancestorof(X,Y) :- parentof(X,Y).\n",
+    "ancestorof(X,Y) :- parentof(X,Z), ancestorof(Z,Y).\n",
+    ":- ancestorof(X,X).\n",
+    "\"\"\"\n",
+    "\n",
+    "ctl2 = clingo.Control()\n",
+    "ctl2.add(\"base\", [], program + extension)\n",
+    "ctl2.ground([(\"base\", [])])\n",
+    "\n",
+    "result_atoms = set()\n",
+    "sat = ctl2.solve(yield_=True)\n",
+    "with sat as handle:\n",
+    "    satisfiable = False\n",
+    "    for model in handle:\n",
+    "        satisfiable = True\n",
+    "        result_atoms = {str(a) for a in model.symbols(atoms=True)}\n",
+    "\n",
+    "n_anc = sum(1 for a in result_atoms if a.startswith(\"ancestorof(\"))\n",
+    "n_par = len(relations[\"parentOf\"])\n",
+    "print(f\"Coherent (acyclique) : {satisfiable}\")\n",
+    "print(f\"ancestorOf derive : {n_anc} paires (a partir de {n_par} parentOf)\")\n",
+    "\n",
+    "# Contre-experience : on injecte un cycle (Emma serait parent de Marie)\n",
+    "ctl3 = clingo.Control()\n",
+    "ctl3.add(\"base\", [], program + extension + 'parentof(\"Emma\",\"Marie\").')\n",
+    "ctl3.ground([(\"base\", [])])\n",
+    "verdict = str(ctl3.solve())\n",
+    "print(f\"\\nAvec le fait cyclique parentof(Emma, Marie) : {verdict}\")\n",
+    "print(\"UNSAT = le solveur REFUSE tout modele : la contrainte d'integrite\")\n",
+    "print(\"transforme le KG complete en KG verifie.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5966b66d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004515,
+     "end_time": "2026-06-10T12:35:04.561296",
+     "exception": false,
+     "start_time": "2026-06-10T12:35:04.556781",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : du chainage artisanal au solveur industriel\n",
+    "\n",
+    "Trois enseignements :\n",
+    "\n",
+    "1. **Validation croisee** : sur les memes faits et les memes regles minees -- les **cinq**\n",
+    "   regles qualifiees par la PCA, pas seulement la regle cible, dont deux qui reinjectent\n",
+    "   `grandparentOf` dans leur propre corps -- clingo derive exactement la meme completion que\n",
+    "   notre `apply_rules`. La saturation au point fixe coincide ici avec la passe unique parce\n",
+    "   que les derivations supplementaires etaient deja couvertes ; sur un KG plus dense, les\n",
+    "   regles qui s'alimentent entre elles auraient fait diverger les deux moteurs, et c'est le\n",
+    "   point fixe qui aurait eu raison. Notre implementation pedagogique etait correcte -- mais\n",
+    "   elle tenait en 40 lignes parce que le probleme etait restreint.\n",
+    "\n",
+    "2. **La recursion change de classe** : `ancestorOf` demande un calcul de point fixe que notre\n",
+    "   mineur ne peut ni exprimer (les regles fermees enumerees ont une taille fixe) ni evaluer.\n",
+    "   Pour clingo, c'est deux lignes. C'est la frontiere entre *rule mining* (decouvrir des\n",
+    "   regles plausibles, AMIE) et *raisonnement* (appliquer des regles exactes, ASP) : les deux\n",
+    "   outils sont complementaires, pas concurrents.\n",
+    "\n",
+    "3. **La contrainte d'integrite inverse la charge de la preuve** : au lieu de deriver puis\n",
+    "   d'inspecter, on declare l'invariant (`:- ancestorof(X,X)`) et le solveur garantit que tout\n",
+    "   modele le respecte -- ou repond UNSAT. C'est exactement le role que l'oracle de validation\n",
+    "   jouera dans le capstone [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb), et ce que le chainage\n",
+    "   avant nu ne fait pas.\n",
+    "\n",
+    "**Pour aller plus loin** : l'apprentissage *de programmes ASP* (et non plus seulement leur\n",
+    "execution) est le domaine d'**ILASP** (Inductive Learning of Answer Set Programs) -- voir par\n",
+    "exemple [asp-game-strategies](https://github.com/susuhahnml/asp-game-strategies) qui apprend\n",
+    "des strategies de jeu en ASP. Cote CoursIA, la serie [Tweety](../Tweety/README.md) (Tweety-3)\n",
+    "montre l'ASP via TweetyProject/JVM, et [Popper](https://github.com/logic-and-learning-lab/Popper)\n",
+    "(integre dans [SL-4](SL-4-InductiveLogicProgramming.ipynb)) utilise clingo comme moteur de\n",
+    "recherche d'hypotheses ILP : la boucle est bouclee."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c400b44",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004,
+     "end_time": "2026-06-10T12:35:04.569296",
+     "exception": false,
+     "start_time": "2026-06-10T12:35:04.565296",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "341c7bfb",
    "metadata": {
     "papermill": {
-     "duration": 0.005944,
-     "end_time": "2026-06-10T10:34:56.826150",
+     "duration": 0.004509,
+     "end_time": "2026-06-10T12:35:04.577806",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.820206",
+     "start_time": "2026-06-10T12:35:04.573297",
      "status": "completed"
     },
     "tags": []
@@ -1690,20 +2060,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "id": "409ababa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.840929Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.840424Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.848907Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.848300Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.586815Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.586815Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.598326Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.597333Z"
     },
     "papermill": {
-     "duration": 0.017712,
-     "end_time": "2026-06-10T10:34:56.849914",
+     "duration": 0.017512,
+     "end_time": "2026-06-10T12:35:04.599326",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.832202",
+     "start_time": "2026-06-10T12:35:04.581814",
      "status": "completed"
     },
     "tags": []
@@ -1748,10 +2118,10 @@
    "id": "719920a9",
    "metadata": {
     "papermill": {
-     "duration": 0.007249,
-     "end_time": "2026-06-10T10:34:56.864169",
+     "duration": 0.005,
+     "end_time": "2026-06-10T12:35:04.608332",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.856920",
+     "start_time": "2026-06-10T12:35:04.603332",
      "status": "completed"
     },
     "tags": []
@@ -1773,20 +2143,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "id": "89b763a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.879715Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.879183Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.895096Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.895096Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.617834Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.617834Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.628832Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.628832Z"
     },
     "papermill": {
-     "duration": 0.025594,
-     "end_time": "2026-06-10T10:34:56.896915",
+     "duration": 0.01851,
+     "end_time": "2026-06-10T12:35:04.629834",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.871321",
+     "start_time": "2026-06-10T12:35:04.611324",
      "status": "completed"
     },
     "tags": []
@@ -1850,10 +2220,10 @@
    "id": "44737d28",
    "metadata": {
     "papermill": {
-     "duration": 0.006358,
-     "end_time": "2026-06-10T10:34:56.910832",
+     "duration": 0.003999,
+     "end_time": "2026-06-10T12:35:04.638341",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.904474",
+     "start_time": "2026-06-10T12:35:04.634342",
      "status": "completed"
     },
     "tags": []
@@ -1875,20 +2245,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "id": "d20502d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:34:56.925426Z",
-     "iopub.status.busy": "2026-06-10T10:34:56.923830Z",
-     "iopub.status.idle": "2026-06-10T10:34:56.941547Z",
-     "shell.execute_reply": "2026-06-10T10:34:56.940995Z"
+     "iopub.execute_input": "2026-06-10T12:35:04.647341Z",
+     "iopub.status.busy": "2026-06-10T12:35:04.647341Z",
+     "iopub.status.idle": "2026-06-10T12:35:04.659848Z",
+     "shell.execute_reply": "2026-06-10T12:35:04.659848Z"
     },
     "papermill": {
-     "duration": 0.024795,
-     "end_time": "2026-06-10T10:34:56.942058",
+     "duration": 0.018508,
+     "end_time": "2026-06-10T12:35:04.660849",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.917263",
+     "start_time": "2026-06-10T12:35:04.642341",
      "status": "completed"
     },
     "tags": []
@@ -1939,10 +2309,10 @@
    "id": "a1ba5b56",
    "metadata": {
     "papermill": {
-     "duration": 0.006662,
-     "end_time": "2026-06-10T10:34:56.955754",
+     "duration": 0.003506,
+     "end_time": "2026-06-10T12:35:04.668355",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.949092",
+     "start_time": "2026-06-10T12:35:04.664849",
      "status": "completed"
     },
     "tags": []
@@ -1989,10 +2359,10 @@
    "id": "c4b6e83b",
    "metadata": {
     "papermill": {
-     "duration": 0.006515,
-     "end_time": "2026-06-10T10:34:56.968316",
+     "duration": 0.004001,
+     "end_time": "2026-06-10T12:35:04.676356",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.961801",
+     "start_time": "2026-06-10T12:35:04.672355",
      "status": "completed"
     },
     "tags": []
@@ -2009,7 +2379,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "5bb1e4b9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004509,
+     "end_time": "2026-06-10T12:35:04.684864",
+     "exception": false,
+     "start_time": "2026-06-10T12:35:04.680355",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -2032,10 +2412,10 @@
    "id": "cf1b23f7",
    "metadata": {
     "papermill": {
-     "duration": 0.00663,
-     "end_time": "2026-06-10T10:34:56.980474",
+     "duration": 0.005008,
+     "end_time": "2026-06-10T12:35:04.693872",
      "exception": false,
-     "start_time": "2026-06-10T10:34:56.973844",
+     "start_time": "2026-06-10T12:35:04.688864",
      "status": "completed"
     },
     "tags": []
@@ -2082,14 +2462,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 8.127889,
-   "end_time": "2026-06-10T10:34:57.315675",
+   "duration": 4.430307,
+   "end_time": "2026-06-10T12:35:04.924004",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-6-KnowledgeGraphs-ILP.ipynb",
    "output_path": "SL-6-KnowledgeGraphs-ILP.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T10:34:49.187786",
+   "start_time": "2026-06-10T12:35:00.493697",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Re-passe « vrais imports » de l'Epic #1404 — **candidat n°2 (clingo/clorm)**, différé dans le bilan du 10/06, maintenant livré. Mutualisation avec la série Tweety conformément à la demande user : même moteur Potassco que `scripts/install_clingo.py` / `ClingoSolver` (binaire+JVM côté Tweety), ici via le **module Python officiel `clingo`** (pip, pas de JVM ni binaire externe).

Nouvelle section « La vraie librairie : Answer Set Programming avec clingo » dans SL-6 (insérée avant les exercices) :

1. **Traduction générique** du KG (`relations`) et des règles minées (PCA ≥ 0.5) en programme ASP — 33 faits + 5 règles.
2. **Validation croisée** : la complétion clingo (point fixe) est **IDENTIQUE** au `apply_rules` Python du notebook (grandparentOf 5→14) — y compris avec 2 règles qui réinjectent `grandparentOf` dans leur propre corps ; l'interprétation explique pourquoi et quand les deux moteurs divergeraient.
3. **Ce que l'ASP ajoute** : récursion `ancestorOf` (40 paires dérivées — inexprimable par le mineur de règles fermées à 2 atomes) + contrainte d'intégrité d'acyclicité avec **démo UNSAT** sur injection d'un cycle — pont pédagogique vers l'oracle de SL-10.
4. Référence ILASP / asp-game-strategies (apprentissage *de* programmes ASP) et Popper (clingo comme moteur de recherche ILP, à venir dans SL-4).

README : ligne SL-6, table « Contenu détaillé », section environnement.

## Validation

- Papermill end-to-end 49 cellules, kernel python3, **0 erreur**, outputs réels committés (C.2/H.3) ; `clingo` 5.8.0 installé dans le Python du kernel.
- Sorties relues contre les interprétations post-run (verdict IDENTIQUE, 5 règles, 40 paires, UNSAT) — interprétation enrichie en conséquence (markdown-only).
- Cellules existantes du notebook re-exécutées sans modification de source — mêmes résultats (PCA 0.625, complétion +9).
- Aucun secret, 2 fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)