### PR TITLE
feat(SL-4): integrate Popper (Learning From Failures) real ILP library

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -60,7 +60,7 @@ La deuxieme phase introduit l'idee centrale que **la connaissance accelere l'app
 
 ### Phase 3 : Programmation logique inductive (SL-4, ~55 min)
 
-SL-4 fait le pont entre apprentissage automatique et intelligence artificielle symbolique classique en couvrant l'ILP : apprentissage de programmes logiques (clauses Horn) a partir d'exemples. L'algorithme FOIL (top-down) et la resolution inverse (bottom-up) sont implémentes de zero, puis appliques aux knowledge graphs — avec extraction de regles AMIE et requetes SPARQL CONSTRUCT.
+SL-4 fait le pont entre apprentissage automatique et intelligence artificielle symbolique classique en couvrant l'ILP : apprentissage de programmes logiques (clauses Horn) a partir d'exemples. L'algorithme FOIL (top-down) et la resolution inverse (bottom-up) sont implémentes de zero, puis appliques aux knowledge graphs — avec extraction de regles AMIE et requetes SPARQL CONSTRUCT. La section finale confronte le FOIL artisanal a l'ILP moderne : **Popper** (Learning From Failures) retrouve le programme recursif `ancestor` optimal sur les memes donnees, demontre l'apport de la recursion par ablation, et le programme appris est verifie independamment en SWI-Prolog.
 
 ### Phase 4 : Integration neuro-symbolique (SL-5 a SL-7, ~160 min)
 
@@ -138,7 +138,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | 1 | [SL-1 - Apprentissage Logique](SL-1-LogicalLearning.ipynb) | CBH, Version Space, Candidate Elimination | 50 min |
 | 2 | [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb) | EBL, introduction au RBL (determinations) | 45 min |
 | 3 | [SL-3 - Apprentissage Base sur la Pertinence](SL-3-RelevanceLearning.ipynb) | Treillis des determinations, MINIMAL-CONSISTENT-DET, RBL vs sklearn | 50 min |
-| 4 | [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb) | FOIL, resolution inverse, clauses Horn, knowledge graphs | 55 min |
+| 4 | [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb) | FOIL, resolution inverse, clauses Horn, knowledge graphs, Popper (LFF) | 55 min |
 | 5 | [SL-5 - Integration Neuro-Symbolique](SL-5-NeuroSymbolic.ipynb) | T-norms, predicats neuronaux, LTN, DeepProbLog | 55 min |
 | 6 | [SL-6 - ILP Moderne et Knowledge Graphs](SL-6-KnowledgeGraphs-ILP.ipynb) | rdflib, AMIE rule mining, completion KG, ASP avec clingo | 55 min |
 | 7 | [SL-7 - LLMs et Apprentissage Symbolique](SL-7-LLM-SymbolicLearning.ipynb) | Prompting, extraction de regles, verification symbolique (Gemini 3.5 Flash optionnel) | 50 min |
@@ -191,6 +191,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | FOIL pas-a-pas | Trace detaillee sur le probleme ancestor |
 | Resolution inverse | Operateurs V (absorption) et W (identification) |
 | Knowledge Graphs | Regles AMIE, triples RDF, SPARQL CONSTRUCT |
+| Popper (Learning From Failures) | Programme recursif optimal, ablation sans recursion, verification SWI-Prolog (kernel Linux/WSL) |
 | Exercices | sibling, operateur W, regles sur KG |
 
 ### SL-5-NeuroSymbolic.ipynb
@@ -274,6 +275,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | **Clause Horn** | Regle logique avec au plus un litteral positif | SL-4 |
 | **Unification** | Trouve une substitution rendant deux termes egaux | SL-4 |
 | **ILP** | Apprentissage de programmes logiques a partir d'exemples | SL-4 |
+| **Learning From Failures (Popper)** | ILP moderne : recherche de programme optimal par contraintes (clingo + Prolog) | SL-4 |
 | **T-norm** | Generalisation differentiable de AND | SL-5 |
 | **DeepProbLog** | Programmation logique probabiliste + predicats neuronaux | SL-5 |
 | **Knowledge Graph** | Graphe oriente de triples (sujet, predicat, objet) | SL-6 |
@@ -300,7 +302,9 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 
 ### Environnement Python
 
-Aucune dependance externe pour SL-1, SL-2, SL-4, SL-5, SL-8 et SL-9 (bibliotheque standard Python 3.10+ uniquement). SL-3 utilise `scikit-learn` et `numpy` pour la comparaison avec la selection statistique. SL-6 utilise `rdflib` et `clingo` (module Python officiel Potassco, installe silencieusement par le notebook — meme moteur ASP que le binaire utilise par la serie Tweety via `scripts/install_clingo.py`). SL-7 et SL-10 utilisent `python-dotenv` et `openai` pour les appels LLM optionnels via OpenRouter (Gemini 3.5 Flash) : copiez `.env.example` vers `.env` et renseignez `OPENROUTER_API_KEY` ; sans cle, un simulateur deterministe prend le relais et le notebook s'execute integralement.
+Aucune dependance externe pour SL-1, SL-2, SL-5, SL-8 et SL-9 (bibliotheque standard Python 3.10+ uniquement). SL-3 utilise `scikit-learn` et `numpy` pour la comparaison avec la selection statistique. SL-6 utilise `rdflib` et `clingo` (module Python officiel Potassco, installe silencieusement par le notebook — meme moteur ASP que le binaire utilise par la serie Tweety via `scripts/install_clingo.py`). SL-7 et SL-10 utilisent `python-dotenv` et `openai` pour les appels LLM optionnels via OpenRouter (Gemini 3.5 Flash) : copiez `.env.example` vers `.env` et renseignez `OPENROUTER_API_KEY` ; sans cle, un simulateur deterministe prend le relais et le notebook s'execute integralement.
+
+SL-4 est en bibliotheque standard pour l'essentiel, mais sa section finale **Popper** requiert un environnement Unix : Popper utilise `signal.SIGALRM`, absent de Windows — le notebook s'execute donc sur un kernel Python **Linux** (kernel `python3-wsl` via WSL sous Windows, kernel natif sous Linux/macOS). Dependances de la section (installees silencieusement par le notebook) : SWI-Prolog >= 9.1.12 (`ppa:swi-prolog/stable`), `popper-ilp` epingle a **v4.4.0** (la 5.0 exige Python >= 3.14), `janus_swi`, `clingo`, `setuptools < 81`. Si Popper est indisponible, les cellules de la section l'indiquent et se sautent proprement — le reste du notebook tourne sur n'importe quel kernel Python.
 
 ## FAQ / Troubleshooting
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
@@ -5,10 +5,10 @@
    "id": "266f89ed",
    "metadata": {
     "papermill": {
-     "duration": 0.009431,
-     "end_time": "2026-06-06T21:01:07.460930",
+     "duration": 0.003936,
+     "end_time": "2026-06-10T13:18:41.945398",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.451499",
+     "start_time": "2026-06-10T13:18:41.941462",
      "status": "completed"
     },
     "tags": []
@@ -42,16 +42,16 @@
    "id": "06eb2d41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:07.484186Z",
-     "iopub.status.busy": "2026-06-06T21:01:07.483694Z",
-     "iopub.status.idle": "2026-06-06T21:01:07.495101Z",
-     "shell.execute_reply": "2026-06-06T21:01:07.493763Z"
+     "iopub.execute_input": "2026-06-10T13:18:41.955811Z",
+     "iopub.status.busy": "2026-06-10T13:18:41.955638Z",
+     "iopub.status.idle": "2026-06-10T13:18:41.959652Z",
+     "shell.execute_reply": "2026-06-10T13:18:41.958856Z"
     },
     "papermill": {
-     "duration": 0.022959,
-     "end_time": "2026-06-06T21:01:07.497635",
+     "duration": 0.009144,
+     "end_time": "2026-06-10T13:18:41.957359",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.474676",
+     "start_time": "2026-06-10T13:18:41.948215",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "5136dc92",
    "metadata": {
     "papermill": {
-     "duration": 0.007102,
-     "end_time": "2026-06-06T21:01:07.512625",
+     "duration": 0.003002,
+     "end_time": "2026-06-10T13:18:41.963360",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.505523",
+     "start_time": "2026-06-10T13:18:41.960358",
      "status": "completed"
     },
     "tags": []
@@ -142,10 +142,10 @@
    "id": "934f66f1",
    "metadata": {
     "papermill": {
-     "duration": 0.007812,
-     "end_time": "2026-06-06T21:01:07.527715",
+     "duration": 0.003442,
+     "end_time": "2026-06-10T13:18:41.970352",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.519903",
+     "start_time": "2026-06-10T13:18:41.966910",
      "status": "completed"
     },
     "tags": []
@@ -177,16 +177,16 @@
    "id": "4bc27cf5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:07.548141Z",
-     "iopub.status.busy": "2026-06-06T21:01:07.547490Z",
-     "iopub.status.idle": "2026-06-06T21:01:07.569631Z",
-     "shell.execute_reply": "2026-06-06T21:01:07.567959Z"
+     "iopub.execute_input": "2026-06-10T13:18:41.980784Z",
+     "iopub.status.busy": "2026-06-10T13:18:41.980622Z",
+     "iopub.status.idle": "2026-06-10T13:18:41.989606Z",
+     "shell.execute_reply": "2026-06-10T13:18:41.988790Z"
     },
     "papermill": {
-     "duration": 0.035502,
-     "end_time": "2026-06-06T21:01:07.572268",
+     "duration": 0.01396,
+     "end_time": "2026-06-10T13:18:41.988062",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.536766",
+     "start_time": "2026-06-10T13:18:41.974102",
      "status": "completed"
     },
     "tags": []
@@ -350,10 +350,10 @@
    "id": "bcb1f969",
    "metadata": {
     "papermill": {
-     "duration": 0.008409,
-     "end_time": "2026-06-06T21:01:07.589312",
+     "duration": 0.002998,
+     "end_time": "2026-06-10T13:18:41.994442",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.580903",
+     "start_time": "2026-06-10T13:18:41.991444",
      "status": "completed"
     },
     "tags": []
@@ -377,10 +377,10 @@
    "id": "cec859d5",
    "metadata": {
     "papermill": {
-     "duration": 0.007784,
-     "end_time": "2026-06-06T21:01:07.605400",
+     "duration": 0.004517,
+     "end_time": "2026-06-10T13:18:42.002059",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.597616",
+     "start_time": "2026-06-10T13:18:41.997542",
      "status": "completed"
     },
     "tags": []
@@ -422,16 +422,16 @@
    "id": "bad9e00d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:07.622739Z",
-     "iopub.status.busy": "2026-06-06T21:01:07.622368Z",
-     "iopub.status.idle": "2026-06-06T21:01:07.636522Z",
-     "shell.execute_reply": "2026-06-06T21:01:07.634942Z"
+     "iopub.execute_input": "2026-06-10T13:18:42.016952Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.016741Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.023960Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.023003Z"
     },
     "papermill": {
-     "duration": 0.025926,
-     "end_time": "2026-06-06T21:01:07.638958",
+     "duration": 0.014745,
+     "end_time": "2026-06-10T13:18:42.022448",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.613032",
+     "start_time": "2026-06-10T13:18:42.007703",
      "status": "completed"
     },
     "tags": []
@@ -551,10 +551,10 @@
    "id": "15c74a56",
    "metadata": {
     "papermill": {
-     "duration": 0.007142,
-     "end_time": "2026-06-06T21:01:07.654233",
+     "duration": 0.005438,
+     "end_time": "2026-06-10T13:18:42.033525",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.647091",
+     "start_time": "2026-06-10T13:18:42.028087",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "2c67b535",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:07.670169Z",
-     "iopub.status.busy": "2026-06-06T21:01:07.669409Z",
-     "iopub.status.idle": "2026-06-06T21:01:07.678670Z",
-     "shell.execute_reply": "2026-06-06T21:01:07.677500Z"
+     "iopub.execute_input": "2026-06-10T13:18:42.049030Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.048778Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.055519Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.054093Z"
     },
     "papermill": {
-     "duration": 0.01942,
-     "end_time": "2026-06-06T21:01:07.680663",
+     "duration": 0.015756,
+     "end_time": "2026-06-10T13:18:42.053788",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.661243",
+     "start_time": "2026-06-10T13:18:42.038032",
      "status": "completed"
     },
     "tags": []
@@ -595,7 +595,7 @@
       "Probleme ancestor(X, Y)\n",
       "==================================================\n",
       "Background : 5 faits parent/2\n",
-      "Positifs : 10 couples ancestor\n",
+      "Positifs : 9 couples ancestor\n",
       "Negatifs : 10 couples non-ancestor\n",
       "\n",
       "Familles :\n",
@@ -626,7 +626,7 @@
     "    (\"Arthur\", \"Bob\"), (\"Arthur\", \"Catherine\"),\n",
     "    (\"Bob\", \"Diana\"), (\"Catherine\", \"Eve\"), (\"Eve\", \"Frank\"),\n",
     "    (\"Arthur\", \"Diana\"), (\"Arthur\", \"Eve\"), (\"Arthur\", \"Frank\"),\n",
-    "    (\"Bob\", \"Frank\"), (\"Catherine\", \"Frank\"),\n",
+    "    (\"Catherine\", \"Frank\"),\n",
     "}\n",
     "\n",
     "# Exemples negatifs : non-ancestor(X, Y)\n",
@@ -654,10 +654,10 @@
    "id": "a621e158",
    "metadata": {
     "papermill": {
-     "duration": 0.007479,
-     "end_time": "2026-06-06T21:01:07.696192",
+     "duration": 0.003648,
+     "end_time": "2026-06-10T13:18:42.063097",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.688713",
+     "start_time": "2026-06-10T13:18:42.059449",
      "status": "completed"
     },
     "tags": []
@@ -672,16 +672,16 @@
    "id": "a3200acb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:07.714964Z",
-     "iopub.status.busy": "2026-06-06T21:01:07.714325Z",
-     "iopub.status.idle": "2026-06-06T21:01:07.731483Z",
-     "shell.execute_reply": "2026-06-06T21:01:07.730102Z"
+     "iopub.execute_input": "2026-06-10T13:18:42.077307Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.077040Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.086295Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.084922Z"
     },
     "papermill": {
-     "duration": 0.028368,
-     "end_time": "2026-06-06T21:01:07.733475",
+     "duration": 0.017341,
+     "end_time": "2026-06-10T13:18:42.085362",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.705107",
+     "start_time": "2026-06-10T13:18:42.068021",
      "status": "completed"
     },
     "tags": []
@@ -697,17 +697,17 @@
       "Clause : ancestor(x, y) :- parent(x, y).\n",
       "  Couvre 5 positifs : [('Arthur', 'Bob'), ('Arthur', 'Catherine'), ('Bob', 'Diana'), ('Catherine', 'Eve'), ('Eve', 'Frank')]...\n",
       "  Couvre 0 negatifs : []...\n",
-      "  Gain FOIL : 5.000\n",
+      "  Gain FOIL : 5.390\n",
       "\n",
       "Clause : ancestor(x, y) :- parent(x, z), parent(z, y).\n",
       "  Couvre 3 positifs : [('Arthur', 'Diana'), ('Arthur', 'Eve'), ('Catherine', 'Frank')]...\n",
       "  Couvre 0 negatifs : []...\n",
-      "  Gain FOIL : 3.000\n",
+      "  Gain FOIL : 3.234\n",
       "\n",
       "Clause : ancestor(x, y) :- parent(x, z), ancestor(z, y). [recursive]\n",
       "  Couvre 3 positifs : [('Arthur', 'Diana'), ('Arthur', 'Eve'), ('Catherine', 'Frank')]...\n",
       "  Couvre 0 negatifs : []...\n",
-      "  Gain FOIL : 3.000\n"
+      "  Gain FOIL : 3.234\n"
      ]
     }
    ],
@@ -808,10 +808,10 @@
    "id": "f1ebd7f3",
    "metadata": {
     "papermill": {
-     "duration": 0.009102,
-     "end_time": "2026-06-06T21:01:07.752588",
+     "duration": 0.005842,
+     "end_time": "2026-06-10T13:18:42.097006",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.743486",
+     "start_time": "2026-06-10T13:18:42.091164",
      "status": "completed"
     },
     "tags": []
@@ -839,10 +839,10 @@
    "id": "0630919b",
    "metadata": {
     "papermill": {
-     "duration": 0.00821,
-     "end_time": "2026-06-06T21:01:07.768371",
+     "duration": 0.006316,
+     "end_time": "2026-06-10T13:18:42.108027",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.760161",
+     "start_time": "2026-06-10T13:18:42.101711",
      "status": "completed"
     },
     "tags": []
@@ -877,16 +877,16 @@
    "id": "e1385825",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:07.786332Z",
-     "iopub.status.busy": "2026-06-06T21:01:07.785276Z",
-     "iopub.status.idle": "2026-06-06T21:01:07.802904Z",
-     "shell.execute_reply": "2026-06-06T21:01:07.801800Z"
+     "iopub.execute_input": "2026-06-10T13:18:42.124327Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.124087Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.133656Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.132117Z"
     },
     "papermill": {
-     "duration": 0.029246,
-     "end_time": "2026-06-06T21:01:07.805042",
+     "duration": 0.018675,
+     "end_time": "2026-06-10T13:18:42.132669",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.775796",
+     "start_time": "2026-06-10T13:18:42.113994",
      "status": "completed"
     },
     "tags": []
@@ -1044,10 +1044,10 @@
    "id": "f4c90f47",
    "metadata": {
     "papermill": {
-     "duration": 0.007789,
-     "end_time": "2026-06-06T21:01:07.821235",
+     "duration": 0.004077,
+     "end_time": "2026-06-10T13:18:42.142993",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.813446",
+     "start_time": "2026-06-10T13:18:42.138916",
      "status": "completed"
     },
     "tags": []
@@ -1070,10 +1070,10 @@
    "id": "65c8458f",
    "metadata": {
     "papermill": {
-     "duration": 0.006458,
-     "end_time": "2026-06-06T21:01:07.834920",
+     "duration": 0.006614,
+     "end_time": "2026-06-10T13:18:42.154882",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.828462",
+     "start_time": "2026-06-10T13:18:42.148268",
      "status": "completed"
     },
     "tags": []
@@ -1092,16 +1092,16 @@
    "id": "474df76d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:07.852042Z",
-     "iopub.status.busy": "2026-06-06T21:01:07.851259Z",
-     "iopub.status.idle": "2026-06-06T21:01:07.877553Z",
-     "shell.execute_reply": "2026-06-06T21:01:07.876315Z"
+     "iopub.execute_input": "2026-06-10T13:18:42.171782Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.171535Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.189741Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.188306Z"
     },
     "papermill": {
-     "duration": 0.037631,
-     "end_time": "2026-06-06T21:01:07.879847",
+     "duration": 0.027132,
+     "end_time": "2026-06-10T13:18:42.188629",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.842216",
+     "start_time": "2026-06-10T13:18:42.161497",
      "status": "completed"
     },
     "tags": []
@@ -1113,17 +1113,17 @@
      "text": [
       "\n",
       "--- Regle 1 ---\n",
-      "Positifs restants : 10\n",
+      "Positifs restants : 9\n",
       "\n",
       "  Profondeur 0 :\n",
       "    Body actuel : true\n",
-      "    Pos couverts : 10, Neg couverts : 10\n",
-      "    Meilleur litteral : parent(x, z) (gain=7.719)\n",
+      "    Pos couverts : 9, Neg couverts : 10\n",
+      "    Meilleur litteral : parent(x, z) (gain=7.888)\n",
       "\n",
       "  Profondeur 1 :\n",
       "    Body actuel : parent(x, z)\n",
-      "    Pos couverts : 15, Neg couverts : 6\n",
-      "    Meilleur litteral : parent(x, y) (gain=3.398)\n",
+      "    Pos couverts : 14, Neg couverts : 6\n",
+      "    Meilleur litteral : parent(x, y) (gain=3.602)\n",
       "\n",
       "  Profondeur 2 :\n",
       "    Body actuel : parent(x, z), parent(x, y)\n",
@@ -1133,17 +1133,17 @@
       "  Regle apprise : ancestor(x, y) :- parent(x, z), parent(x, y).\n",
       "\n",
       "--- Regle 2 ---\n",
-      "Positifs restants : 5\n",
+      "Positifs restants : 4\n",
       "\n",
       "  Profondeur 0 :\n",
       "    Body actuel : true\n",
-      "    Pos couverts : 5, Neg couverts : 10\n",
-      "    Meilleur litteral : parent(x, z) (gain=6.221)\n",
+      "    Pos couverts : 4, Neg couverts : 10\n",
+      "    Meilleur litteral : parent(x, z) (gain=6.400)\n",
       "\n",
       "  Profondeur 1 :\n",
       "    Body actuel : parent(x, z)\n",
-      "    Pos couverts : 8, Neg couverts : 6\n",
-      "    Meilleur litteral : parent(z, y) (gain=2.422)\n",
+      "    Pos couverts : 7, Neg couverts : 6\n",
+      "    Meilleur litteral : parent(z, y) (gain=2.679)\n",
       "\n",
       "  Profondeur 2 :\n",
       "    Body actuel : parent(x, z), parent(z, y)\n",
@@ -1153,16 +1153,16 @@
       "  Regle apprise : ancestor(x, y) :- parent(x, z), parent(z, y).\n",
       "\n",
       "--- Regle 3 ---\n",
-      "Positifs restants : 2\n",
+      "Positifs restants : 1\n",
       "\n",
       "  Profondeur 0 :\n",
       "    Body actuel : true\n",
-      "    Pos couverts : 2, Neg couverts : 10\n",
-      "    Meilleur litteral : parent(x, z) (gain=3.000)\n",
+      "    Pos couverts : 1, Neg couverts : 10\n",
+      "    Meilleur litteral : parent(x, z) (gain=2.919)\n",
       "\n",
       "  Profondeur 1 :\n",
       "    Body actuel : parent(x, z)\n",
-      "    Pos couverts : 3, Neg couverts : 6\n",
+      "    Pos couverts : 2, Neg couverts : 6\n",
       "    Pas d'amelioration possible\n",
       "\n",
       "  Regle apprise : ancestor(x, y) :- parent(x, z).\n",
@@ -1279,10 +1279,10 @@
    "id": "824ba714",
    "metadata": {
     "papermill": {
-     "duration": 0.008157,
-     "end_time": "2026-06-06T21:01:07.896525",
+     "duration": 0.005775,
+     "end_time": "2026-06-10T13:18:42.200851",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.888368",
+     "start_time": "2026-06-10T13:18:42.195076",
      "status": "completed"
     },
     "tags": []
@@ -1302,15 +1302,15 @@
     "2. **Regle 2** : `ancestor(x, y) :- parent(x, z), parent(z, y).` --- la composition\n",
     "   **grand-parent** : x est parent d'un intermediaire z, lui-meme parent de y.\n",
     "\n",
-    "3. **Regle 3** : `ancestor(x, y) :- parent(x, z).` --- pour les 2 positifs restants\n",
-    "   (arriere-grands-parents), aucun litteral n'ameliore plus le gain et la clause\n",
+    "3. **Regle 3** : `ancestor(x, y) :- parent(x, z).` --- pour le positif restant\n",
+    "   (l'arriere-grand-parent `ancestor(arthur, frank)`), aucun litteral n'ameliore plus le gain et la clause\n",
     "   est apprise **inconsistante** (elle couvre encore 6 negatifs). C'est une\n",
     "   limite honnete de notre implementation : la profondeur est bornee et la regle\n",
     "   recursive `ancestor(x, y) :- parent(x, z), ancestor(z, y)` ne peut pas etre\n",
     "   apprise sans mecanisme d'evaluation recursive.\n",
     "\n",
     "> **Note sur les comptages** : a la profondeur 1 de la regle 1, on lit\n",
-    "> \"Pos couverts : 15\" pour 10 positifs. C'est normal : FOIL compte des\n",
+    "> \"Pos couverts : 14\" pour 9 positifs. C'est normal : FOIL compte des\n",
     "> **bindings** (instanciations des variables, y compris z), pas des exemples ---\n",
     "> un meme positif peut etre couvert par plusieurs valeurs de z (AIMA 19.5.1).\n",
     "\n",
@@ -1325,10 +1325,10 @@
    "id": "da423029",
    "metadata": {
     "papermill": {
-     "duration": 0.008701,
-     "end_time": "2026-06-06T21:01:07.913078",
+     "duration": 0.005775,
+     "end_time": "2026-06-10T13:18:42.212475",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.904377",
+     "start_time": "2026-06-10T13:18:42.206700",
      "status": "completed"
     },
     "tags": []
@@ -1365,16 +1365,16 @@
    "id": "d4641c82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:07.930278Z",
-     "iopub.status.busy": "2026-06-06T21:01:07.929918Z",
-     "iopub.status.idle": "2026-06-06T21:01:07.941246Z",
-     "shell.execute_reply": "2026-06-06T21:01:07.940217Z"
+     "iopub.execute_input": "2026-06-10T13:18:42.229724Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.229449Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.236614Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.235551Z"
     },
     "papermill": {
-     "duration": 0.021341,
-     "end_time": "2026-06-06T21:01:07.943077",
+     "duration": 0.016479,
+     "end_time": "2026-06-10T13:18:42.235310",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.921736",
+     "start_time": "2026-06-10T13:18:42.218831",
      "status": "completed"
     },
     "tags": []
@@ -1405,18 +1405,18 @@
       "\n",
       "2. Transitivite de localisation :\n",
       "   livesIn(X, Z) :- livesIn(X, Y), locatedIn(Y, Z).\n",
+      "   Diana livesIn Paris, Paris locatedIn France => Diana livesIn France [IMPLICITE (infere)]\n",
+      "   Alice livesIn Paris, Paris locatedIn France => Alice livesIn France [IMPLICITE (infere)]\n",
       "   Charlie livesIn Lyon, Lyon locatedIn France => Charlie livesIn France [IMPLICITE (infere)]\n",
       "   Bob livesIn Paris, Paris locatedIn France => Bob livesIn France [IMPLICITE (infere)]\n",
-      "   Alice livesIn Paris, Paris locatedIn France => Alice livesIn France [IMPLICITE (infere)]\n",
-      "   Diana livesIn Paris, Paris locatedIn France => Diana livesIn France [IMPLICITE (infere)]\n",
       "   Total inferences possibles : 4\n",
       "\n",
       "3. Co-residence des epoux :\n",
       "   livesIn(X, L) :- marriedTo(X, Y), livesIn(Y, L).\n",
-      "   Bob marriedTo Alice, Alice livesIn Paris => Bob livesIn Paris [EXPLICITE]\n",
-      "   Alice marriedTo Bob, Bob livesIn Paris => Alice livesIn Paris [EXPLICITE]\n",
       "   Charlie marriedTo Diana, Diana livesIn Paris => Charlie livesIn Paris [NON VERIFIE]\n",
+      "   Alice marriedTo Bob, Bob livesIn Paris => Alice livesIn Paris [EXPLICITE]\n",
       "   Diana marriedTo Charlie, Charlie livesIn Lyon => Diana livesIn Lyon [NON VERIFIE]\n",
+      "   Bob marriedTo Alice, Alice livesIn Paris => Bob livesIn Paris [EXPLICITE]\n",
       "   Total inferences : 4\n"
      ]
     }
@@ -1492,10 +1492,10 @@
    "id": "3e601ecb",
    "metadata": {
     "papermill": {
-     "duration": 0.008491,
-     "end_time": "2026-06-06T21:01:07.959200",
+     "duration": 0.00574,
+     "end_time": "2026-06-10T13:18:42.247394",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.950709",
+     "start_time": "2026-06-10T13:18:42.241654",
      "status": "completed"
     },
     "tags": []
@@ -1516,13 +1516,329 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d5be334e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006109,
+     "end_time": "2026-06-10T13:18:42.259860",
+     "exception": false,
+     "start_time": "2026-06-10T13:18:42.253751",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77f0ac97",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006289,
+     "end_time": "2026-06-10T13:18:42.272605",
+     "exception": false,
+     "start_time": "2026-06-10T13:18:42.266316",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## La vraie librairie : Popper (Learning From Failures)\n",
+    "\n",
+    "Le FOIL implemente ci-dessus date de 1990 : il construit ses clauses gloutonnement,\n",
+    "litteral par litteral, guide par le gain d'information. L'ILP moderne pose le probleme\n",
+    "autrement. **Popper** (Cropper & Morel, 2021) formule l'apprentissage comme une recherche\n",
+    "dans l'espace des *programmes* complets, dirigee par les echecs (*Learning From Failures*) :\n",
+    "chaque hypothese testee qui echoue genere des **contraintes** qui elaguent definitivement\n",
+    "des familles entieres de programmes. Popper garantit de trouver un programme **optimal**\n",
+    "(taille minimale) couvrant tous les positifs et aucun negatif -- la ou FOIL ne garantit\n",
+    "qu'un optimum local glouton.\n",
+    "\n",
+    "Sous le capot, Popper combine exactement les deux moteurs rencontres dans cette serie :\n",
+    "\n",
+    "- **clingo** (ASP, utilise dans [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb)) enumere les\n",
+    "  hypotheses candidates comme modeles stables d'un encodage du langage d'hypotheses ;\n",
+    "- **SWI-Prolog** (via le pont `janus_swi`) teste chaque hypothese contre les exemples.\n",
+    "\n",
+    "**Note environnement** : Popper s'appuie sur `signal.SIGALRM`, qui n'existe pas sous\n",
+    "Windows. Ce notebook s'execute donc sur un kernel **Python Linux** (`python3-wsl` :\n",
+    "WSL sous Windows ; kernel natif sous Linux/macOS). Le reste du notebook est en Python\n",
+    "standard et tourne sur n'importe quel kernel. Versions epinglees : **Popper v4.4.0**\n",
+    "(la 5.0 exige Python >= 3.14), `janus_swi` (requiert SWI-Prolog >= 9.1.12, PPA\n",
+    "`ppa:swi-prolog/stable`), `setuptools < 81` (Popper importe encore `pkg_resources`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8022039d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:18:42.286599Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.286361Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.302677Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.301195Z"
+    },
+    "papermill": {
+     "duration": 0.023998,
+     "end_time": "2026-06-10T13:18:42.300826",
+     "exception": false,
+     "start_time": "2026-06-10T13:18:42.276828",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Python : 3.12.3 (Linux)\n",
+      "swipl  : /usr/bin/swipl\n",
+      "clingo : 5.8.0\n",
+      "Popper : v4.4.0 -- pret\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Environnement Popper : kernel Python Linux requis (SIGALRM absent de Windows)\n",
+    "import importlib.util, platform, shutil, subprocess, sys, warnings\n",
+    "\n",
+    "HAS_POPPER = False\n",
+    "swipl = shutil.which(\"swipl\")\n",
+    "print(f\"Python : {sys.version.split()[0]} ({platform.system()})\")\n",
+    "print(f\"swipl  : {swipl or 'INTROUVABLE'}\")\n",
+    "\n",
+    "if platform.system() != \"Linux\":\n",
+    "    print(\"\\nPopper requiert un OS Unix (SIGALRM) : basculer sur le kernel 'python3-wsl'\")\n",
+    "    print(\"(Windows + WSL) ou un kernel Python natif Linux/macOS.\")\n",
+    "elif swipl is None:\n",
+    "    print(\"\\nSWI-Prolog manquant : sudo apt install swi-prolog\")\n",
+    "    print(\"(version >= 9.1.12 requise par janus_swi -> PPA ppa:swi-prolog/stable).\")\n",
+    "else:\n",
+    "    if importlib.util.find_spec(\"popper\") is None:\n",
+    "        subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"-q\",\n",
+    "                               \"setuptools<81\", \"clingo\",\n",
+    "                               \"git+https://github.com/logic-and-learning-lab/Popper@v4.4.0\"])\n",
+    "    warnings.filterwarnings(\"ignore\", message=\".*pkg_resources.*\")\n",
+    "    import clingo\n",
+    "    import popper\n",
+    "    HAS_POPPER = True\n",
+    "    print(f\"clingo : {clingo.__version__}\")\n",
+    "    print(\"Popper : v4.4.0 -- pret\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "878ee645",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:18:42.318483Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.318238Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.580873Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.580128Z"
+    },
+    "papermill": {
+     "duration": 0.27129,
+     "end_time": "2026-06-10T13:18:42.579354",
+     "exception": false,
+     "start_time": "2026-06-10T13:18:42.308064",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Programme appris par Popper :\n",
+      "\n",
+      "ancestor(V0,V1):- parent(V0,V2),ancestor(V2,V1).\n",
+      "ancestor(V0,V1):- parent(V0,V1).\n",
+      "\n",
+      "Score : 9 tp, 0 fn, 10 tn, 0 fp -- taille 5 litteraux\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le probleme ancestor, cette fois resolu par Popper -- memes faits, memes exemples.\n",
+    "# Popper tourne dans un sous-processus : son testeur Prolog (janus) garde un etat\n",
+    "# global par processus, et deux apprentissages successifs dans le meme kernel\n",
+    "# cumuleraient les faits consultes (comptes d'exemples fausses).\n",
+    "import json, subprocess, sys, tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "POPPER_RUNNER = r'''\n",
+    "import json, sys, warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "from popper.util import Settings, format_prog\n",
+    "# Patch de compatibilite Popper v4.4.0 : en mode datalog, l'ordonnancement des\n",
+    "# litteraux ne connait pas le predicat de tete (recursif) -> pire score, donc\n",
+    "# ordonne en dernier, ce qui est le comportement voulu.\n",
+    "def tmp_score_(self, seen_vars, literal):\n",
+    "    pred, args = literal\n",
+    "    return self.recall.get((pred, tuple(1 if x in seen_vars else 0 for x in args)), float(\"inf\"))\n",
+    "Settings.tmp_score_ = tmp_score_\n",
+    "from popper.loop import learn_solution\n",
+    "settings = Settings(kbpath=sys.argv[1], quiet=True)\n",
+    "prog, score, stats = learn_solution(settings)\n",
+    "print(json.dumps({\"prog\": format_prog(prog) if prog else None, \"score\": score}))\n",
+    "'''\n",
+    "\n",
+    "def run_popper(kbpath: Path) -> dict:\n",
+    "    \"\"\"Lance Popper sur un repertoire de tache (bias.pl, bk.pl, exs.pl), isole.\"\"\"\n",
+    "    out = subprocess.run([sys.executable, \"-c\", POPPER_RUNNER, str(kbpath)],\n",
+    "                         capture_output=True, text=True, timeout=300)\n",
+    "    return json.loads(out.stdout.strip().splitlines()[-1])\n",
+    "\n",
+    "if HAS_POPPER:\n",
+    "    task = Path(tempfile.mkdtemp(prefix=\"popper_ancestor_\"))\n",
+    "    (task / \"bk.pl\").write_text(\n",
+    "        \"\".join(f\"parent({p.lower()},{c.lower()}).\\n\" for _, (p, c) in sorted(BACKGROUND)))\n",
+    "    (task / \"exs.pl\").write_text(\n",
+    "        \"\".join(f\"pos(ancestor({x.lower()},{y.lower()})).\\n\" for x, y in sorted(POSITIVES)) +\n",
+    "        \"\".join(f\"neg(ancestor({x.lower()},{y.lower()})).\\n\" for x, y in sorted(NEGATIVES)))\n",
+    "    (task / \"bias.pl\").write_text(\n",
+    "        \"max_vars(3).\\nmax_body(2).\\nmax_clauses(2).\\n\"\n",
+    "        \"head_pred(ancestor,2).\\nbody_pred(parent,2).\\nenable_recursion.\\n\")\n",
+    "\n",
+    "    result = run_popper(task)\n",
+    "    tp, fn, tn, fp, size = result[\"score\"]\n",
+    "    print(\"Programme appris par Popper :\\n\")\n",
+    "    print(result[\"prog\"])\n",
+    "    print(f\"\\nScore : {tp} tp, {fn} fn, {tn} tn, {fp} fp -- taille {size} litteraux\")\n",
+    "else:\n",
+    "    result = None\n",
+    "    print(\"Popper indisponible : cellule sautee (voir instructions ci-dessus).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "bacc8d6a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:18:42.595338Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.595195Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.813849Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.812949Z"
+    },
+    "papermill": {
+     "duration": 0.226125,
+     "end_time": "2026-06-10T13:18:42.812243",
+     "exception": false,
+     "start_time": "2026-06-10T13:18:42.586118",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sans enable_recursion :\n",
+      "\n",
+      "ancestor(V0,V1):- parent(V0,V1).\n",
+      "ancestor(V0,V1):- parent(V3,V2),parent(V0,V3),parent(V2,V1).\n",
+      "ancestor(V0,V1):- parent(V2,V1),parent(V0,V2).\n",
+      "\n",
+      "Score : 9 tp, 0 fn, 10 tn, 0 fp -- taille 9 litteraux\n",
+      "\n",
+      "Verification SWI-Prolog du programme recursif :\n",
+      "  9/9 positifs derives, 0/10 negatifs derives\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1) Ablation : que peut apprendre Popper SANS le droit a la recursion ?\n",
+    "# 2) Verification independante : le programme appris est execute en Prolog (janus),\n",
+    "#    hors de Popper -- meme esprit que la validation croisee clingo de SL-6.\n",
+    "if HAS_POPPER and result and result[\"prog\"]:\n",
+    "    norec = Path(tempfile.mkdtemp(prefix=\"popper_norec_\"))\n",
+    "    for f in (\"bk.pl\", \"exs.pl\"):\n",
+    "        (norec / f).write_text((task / f).read_text())\n",
+    "    (norec / \"bias.pl\").write_text(\n",
+    "        \"max_vars(4).\\nmax_body(3).\\nmax_clauses(3).\\n\"\n",
+    "        \"head_pred(ancestor,2).\\nbody_pred(parent,2).\\n\")\n",
+    "    ablation = run_popper(norec)\n",
+    "    tp, fn, tn, fp, size = ablation[\"score\"]\n",
+    "    print(\"Sans enable_recursion :\\n\")\n",
+    "    print(ablation[\"prog\"])\n",
+    "    print(f\"\\nScore : {tp} tp, {fn} fn, {tn} tn, {fp} fp -- taille {size} litteraux\")\n",
+    "\n",
+    "    import janus_swi as janus\n",
+    "    janus.consult(str(task / \"bk.pl\"))\n",
+    "    janus.consult(\"learned\", result[\"prog\"] + \"\\n\")\n",
+    "    derive = lambda x, y: janus.query_once(f\"ancestor({x.lower()},{y.lower()})\")[\"truth\"]\n",
+    "    vp = sum(1 for x, y in POSITIVES if derive(x, y))\n",
+    "    vn = sum(1 for x, y in NEGATIVES if derive(x, y))\n",
+    "    print(f\"\\nVerification SWI-Prolog du programme recursif :\")\n",
+    "    print(f\"  {vp}/{len(POSITIVES)} positifs derives, {vn}/{len(NEGATIVES)} negatifs derives\")\n",
+    "else:\n",
+    "    print(\"Popper indisponible : cellule sautee.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb7b46ef",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004012,
+     "end_time": "2026-06-10T13:18:42.819764",
+     "exception": false,
+     "start_time": "2026-06-10T13:18:42.815752",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : ce que Popper change par rapport a FOIL\n",
+    "\n",
+    "1. **L'optimalite remplace la gloutonnerie.** Popper retrouve le programme canonique\n",
+    "   (cas de base + cas recursif, 5 litteraux) en une fraction de seconde, et *prouve*\n",
+    "   qu'aucun programme plus court ne couvre les exemples : les contraintes accumulees a\n",
+    "   chaque echec elaguent l'espace au lieu de re-scorer des clauses une par une. FOIL,\n",
+    "   glouton, peut s'arreter sur des clauses correctes mais non minimales (comparez avec\n",
+    "   la trace pas-a-pas plus haut).\n",
+    "\n",
+    "2. **La recursion est la compression infinie.** L'ablation sans `enable_recursion` le\n",
+    "   montre : Popper ne peut alors que *deplier* des chaines `parent` de profondeur bornee\n",
+    "   (un programme presque deux fois plus gros), qui echouerait sur une genealogie plus\n",
+    "   profonde que le biais. Les deux clauses recursives, elles, couvrent une profondeur\n",
+    "   arbitraire -- c'est exactement l'argument de la cellule FOIL recursive, mais ici la\n",
+    "   recursion est **apprise et certifiee optimale**, pas seulement proposee.\n",
+    "\n",
+    "3. **Un apprenant exact est aussi un verificateur de donnees.** La toute premiere\n",
+    "   execution de Popper sur ce notebook a refuse le score parfait : la paire\n",
+    "   `ancestor(bob, frank)`, presente dans les exemples positifs depuis la creation du\n",
+    "   dataset, n'est **pas derivable** du background (la lignee de Frank passe par\n",
+    "   Catherine et Eve, pas par Bob). FOIL, qui ne cherche que des clauses a gain positif,\n",
+    "   n'avait jamais signale l'incoherence ; Popper, qui exige de couvrir *tous* les\n",
+    "   positifs, l'a exposee immediatement -- le dataset a ete corrige (9 positifs). Pour\n",
+    "   des donnees reellement bruitees, Popper propose un mode `noisy` qui optimise le\n",
+    "   compromis couverture/taille au lieu d'exiger la perfection.\n",
+    "\n",
+    "**Pour aller plus loin** : le [depot Popper](https://github.com/logic-and-learning-lab/Popper)\n",
+    "fournit des dizaines de taches classiques (trains de Michalski, zendo, jeux IGGP) pretes a\n",
+    "l'emploi. Cote apprentissage de programmes ASP, voir ILASP (mentionne dans\n",
+    "[SL-6](SL-6-KnowledgeGraphs-ILP.ipynb)) ; cote systemes historiques, Aleph (Progol-like,\n",
+    "voir [SL-9](SL-9-Progol-InverseEntailment.ipynb)) reste accessible via SWI-Prolog."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "18e8e42f",
    "metadata": {
     "papermill": {
-     "duration": 0.008776,
-     "end_time": "2026-06-06T21:01:07.977036",
+     "duration": 0.003999,
+     "end_time": "2026-06-10T13:18:42.828769",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.968260",
+     "start_time": "2026-06-10T13:18:42.824770",
      "status": "completed"
     },
     "tags": []
@@ -1545,20 +1861,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "4e6e75a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:07.996192Z",
-     "iopub.status.busy": "2026-06-06T21:01:07.995645Z",
-     "iopub.status.idle": "2026-06-06T21:01:08.001597Z",
-     "shell.execute_reply": "2026-06-06T21:01:08.000479Z"
+     "iopub.execute_input": "2026-06-10T13:18:42.840591Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.840437Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.843476Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.842740Z"
     },
     "papermill": {
-     "duration": 0.018235,
-     "end_time": "2026-06-06T21:01:08.003782",
+     "duration": 0.009409,
+     "end_time": "2026-06-10T13:18:42.842178",
      "exception": false,
-     "start_time": "2026-06-06T21:01:07.985547",
+     "start_time": "2026-06-10T13:18:42.832769",
      "status": "completed"
     },
     "tags": []
@@ -1598,10 +1914,10 @@
    "id": "d5bb07b4",
    "metadata": {
     "papermill": {
-     "duration": 0.009279,
-     "end_time": "2026-06-06T21:01:08.022092",
+     "duration": 0.004508,
+     "end_time": "2026-06-10T13:18:42.850686",
      "exception": false,
-     "start_time": "2026-06-06T21:01:08.012813",
+     "start_time": "2026-06-10T13:18:42.846178",
      "status": "completed"
     },
     "tags": []
@@ -1612,20 +1928,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "498d3825",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:08.042145Z",
-     "iopub.status.busy": "2026-06-06T21:01:08.041654Z",
-     "iopub.status.idle": "2026-06-06T21:01:08.049167Z",
-     "shell.execute_reply": "2026-06-06T21:01:08.047576Z"
+     "iopub.execute_input": "2026-06-10T13:18:42.865309Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.865147Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.869387Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.868318Z"
     },
     "papermill": {
-     "duration": 0.019324,
-     "end_time": "2026-06-06T21:01:08.051559",
+     "duration": 0.012233,
+     "end_time": "2026-06-10T13:18:42.867783",
      "exception": false,
-     "start_time": "2026-06-06T21:01:08.032235",
+     "start_time": "2026-06-10T13:18:42.855550",
      "status": "completed"
     },
     "tags": []
@@ -1662,10 +1978,10 @@
    "id": "403bc426",
    "metadata": {
     "papermill": {
-     "duration": 0.009138,
-     "end_time": "2026-06-06T21:01:08.068860",
+     "duration": 0.004998,
+     "end_time": "2026-06-10T13:18:42.876919",
      "exception": false,
-     "start_time": "2026-06-06T21:01:08.059722",
+     "start_time": "2026-06-10T13:18:42.871921",
      "status": "completed"
     },
     "tags": []
@@ -1676,20 +1992,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "fa814830",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T21:01:08.087686Z",
-     "iopub.status.busy": "2026-06-06T21:01:08.087133Z",
-     "iopub.status.idle": "2026-06-06T21:01:08.096212Z",
-     "shell.execute_reply": "2026-06-06T21:01:08.094696Z"
+     "iopub.execute_input": "2026-06-10T13:18:42.894282Z",
+     "iopub.status.busy": "2026-06-10T13:18:42.894128Z",
+     "iopub.status.idle": "2026-06-10T13:18:42.897736Z",
+     "shell.execute_reply": "2026-06-10T13:18:42.896831Z"
     },
     "papermill": {
-     "duration": 0.020757,
-     "end_time": "2026-06-06T21:01:08.098413",
+     "duration": 0.01198,
+     "end_time": "2026-06-10T13:18:42.895942",
      "exception": false,
-     "start_time": "2026-06-06T21:01:08.077656",
+     "start_time": "2026-06-10T13:18:42.883962",
      "status": "completed"
     },
     "tags": []
@@ -1745,10 +2061,10 @@
    "id": "d7fb32ee",
    "metadata": {
     "papermill": {
-     "duration": 0.008705,
-     "end_time": "2026-06-06T21:01:08.115557",
+     "duration": 0.00772,
+     "end_time": "2026-06-10T13:18:42.910147",
      "exception": false,
-     "start_time": "2026-06-06T21:01:08.106852",
+     "start_time": "2026-06-10T13:18:42.902427",
      "status": "completed"
     },
     "tags": []
@@ -1794,7 +2110,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "fc9bb0dd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007521,
+     "end_time": "2026-06-10T13:18:42.923672",
+     "exception": false,
+     "start_time": "2026-06-10T13:18:42.916151",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1817,10 +2143,10 @@
    "id": "f519236c",
    "metadata": {
     "papermill": {
-     "duration": 0.009472,
-     "end_time": "2026-06-06T21:01:08.133106",
+     "duration": 0.007441,
+     "end_time": "2026-06-10T13:18:42.937962",
      "exception": false,
-     "start_time": "2026-06-06T21:01:08.123634",
+     "start_time": "2026-06-10T13:18:42.930521",
      "status": "completed"
     },
     "tags": []
@@ -1845,9 +2171,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (WSL)",
    "language": "python",
-   "name": "python3"
+   "name": "python3-wsl"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1859,18 +2185,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.12.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.017672,
-   "end_time": "2026-06-06T21:01:08.270539",
+   "duration": 2.771395,
+   "end_time": "2026-06-10T13:18:43.075696",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb",
-   "output_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb",
+   "input_path": "SL-4-InductiveLogicProgramming.ipynb",
+   "output_path": "SL-4-InductiveLogicProgramming.ipynb",
    "parameters": {},
-   "start_time": "2026-06-06T21:01:04.252867",
+   "start_time": "2026-06-10T13:18:40.304301",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Epic #1404 — real external library integration #2 of the approved pair (clingo→SL-6 merged in #2766; this PR = popper-ilp→SL-4), before the 17 June EPITA course.

- New 6-cell section **« La vraie librairie : Popper (Learning From Failures) »** inserted before the exercises: env check (graceful skip outside Linux), the notebook's own `ancestor` task re-solved by Popper, optimal recursive program learned, no-recursion ablation, independent SWI-Prolog verification via janus.
- **Dataset bug found and fixed by Popper itself**: positive example `ancestor(bob, frank)` was never derivable from the background (Frank's lineage goes through Catherine→Eve, not Bob). Present since the notebook's creation; FOIL (greedy) never flagged it. POSITIVES 10→9, FOIL trace interpretation (cell 18) updated to match.
- **Kernel switched to `python3-wsl`** (dedicated Linux kernel): Popper uses `signal.SIGALRM` (Unix-only, on any Python version) — a Windows kernel upgrade would not help. Kernelspec repaired with a path-translation wrapper (mirrors the lean4 WSL wrapper). Rest of the notebook is stdlib-only and kernel-agnostic.
- Pinned versions: Popper **v4.4.0** (5.0 requires Python ≥3.14), `janus_swi` (needs SWI-Prolog ≥9.1.12 → PPA), `setuptools<81` (pkg_resources). Documented v4.4.0 datalog-ordering compat patch; each Popper run isolated in a subprocess (janus keeps process-global state).
- README: Phase 3, contents table, key concepts, SL-4 detail table, environment section.

## Validation (rule D)

Papermill end-to-end on the `python3-wsl` kernel, exit 0, **0 errors**, all `execution_count` set, real outputs committed:

```
Python : 3.12.3 (Linux)
swipl  : /usr/bin/swipl
clingo : 5.8.0
Popper : v4.4.0 -- pret
```

```
Programme appris par Popper :

ancestor(V0,V1):- parent(V0,V2),ancestor(V2,V1).
ancestor(V0,V1):- parent(V0,V1).

Score : 9 tp, 0 fn, 10 tn, 0 fp -- taille 5 litteraux
```

```
Sans enable_recursion : programme 3 clauses (chaines parent profondeur 1/2/3), 9 litteraux

Verification SWI-Prolog du programme recursif :
  9/9 positifs derives, 0/10 negatifs derives
```

- `grep -nE "raise NotImplementedError|assert False|1/0"` → 0 match in the notebook.
- No `# Solution` / `# Exemple résolu` cell removed (anti-regression): section is additive + 1-line dataset fix + matching markdown patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)