### PR TITLE
feat(SL-9): integrate Aleph (SWI-Prolog pack) — real Progol vs from-scratch

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-9-InverseResolution.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-9-InverseResolution.ipynb
@@ -5,10 +5,10 @@
    "id": "sl9-01",
    "metadata": {
     "papermill": {
-     "duration": 0.003524,
-     "end_time": "2026-06-10T12:02:36.993762",
+     "duration": 0.003813,
+     "end_time": "2026-06-10T13:49:38.886424",
      "exception": false,
-     "start_time": "2026-06-10T12:02:36.990238",
+     "start_time": "2026-06-10T13:49:38.882611",
      "status": "completed"
     },
     "tags": []
@@ -40,10 +40,10 @@
    "id": "sl9-02",
    "metadata": {
     "papermill": {
-     "duration": 0.002717,
-     "end_time": "2026-06-10T12:02:36.999017",
+     "duration": 0.002867,
+     "end_time": "2026-06-10T13:49:38.891291",
      "exception": false,
-     "start_time": "2026-06-10T12:02:36.996300",
+     "start_time": "2026-06-10T13:49:38.888424",
      "status": "completed"
     },
     "tags": []
@@ -83,10 +83,10 @@
    "id": "sl9-03",
    "metadata": {
     "papermill": {
-     "duration": 0.002002,
-     "end_time": "2026-06-10T12:02:37.003017",
+     "duration": 0.001986,
+     "end_time": "2026-06-10T13:49:38.896937",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.001015",
+     "start_time": "2026-06-10T13:49:38.894951",
      "status": "completed"
     },
     "tags": []
@@ -109,16 +109,16 @@
    "id": "sl9-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:02:37.008646Z",
-     "iopub.status.busy": "2026-06-10T12:02:37.008646Z",
-     "iopub.status.idle": "2026-06-10T12:02:37.022424Z",
-     "shell.execute_reply": "2026-06-10T12:02:37.021380Z"
+     "iopub.execute_input": "2026-06-10T13:49:38.904524Z",
+     "iopub.status.busy": "2026-06-10T13:49:38.904524Z",
+     "iopub.status.idle": "2026-06-10T13:49:38.929537Z",
+     "shell.execute_reply": "2026-06-10T13:49:38.928186Z"
     },
     "papermill": {
-     "duration": 0.018415,
-     "end_time": "2026-06-10T12:02:37.023433",
+     "duration": 0.029864,
+     "end_time": "2026-06-10T13:49:38.930590",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.005018",
+     "start_time": "2026-06-10T13:49:38.900726",
      "status": "completed"
     },
     "tags": []
@@ -223,10 +223,10 @@
    "id": "sl9-05",
    "metadata": {
     "papermill": {
-     "duration": 0.002545,
-     "end_time": "2026-06-10T12:02:37.029866",
+     "duration": 0.003121,
+     "end_time": "2026-06-10T13:49:38.936859",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.027321",
+     "start_time": "2026-06-10T13:49:38.933738",
      "status": "completed"
     },
     "tags": []
@@ -242,10 +242,10 @@
    "id": "sl9-06",
    "metadata": {
     "papermill": {
-     "duration": 0.002062,
-     "end_time": "2026-06-10T12:02:37.033972",
+     "duration": 0.002465,
+     "end_time": "2026-06-10T13:49:38.942460",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.031910",
+     "start_time": "2026-06-10T13:49:38.939995",
      "status": "completed"
     },
     "tags": []
@@ -274,16 +274,16 @@
    "id": "sl9-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:02:37.044954Z",
-     "iopub.status.busy": "2026-06-10T12:02:37.044448Z",
-     "iopub.status.idle": "2026-06-10T12:02:37.053162Z",
-     "shell.execute_reply": "2026-06-10T12:02:37.053162Z"
+     "iopub.execute_input": "2026-06-10T13:49:38.950614Z",
+     "iopub.status.busy": "2026-06-10T13:49:38.950614Z",
+     "iopub.status.idle": "2026-06-10T13:49:38.959063Z",
+     "shell.execute_reply": "2026-06-10T13:49:38.959063Z"
     },
     "papermill": {
-     "duration": 0.016143,
-     "end_time": "2026-06-10T12:02:37.054592",
+     "duration": 0.014887,
+     "end_time": "2026-06-10T13:49:38.960510",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.038449",
+     "start_time": "2026-06-10T13:49:38.945623",
      "status": "completed"
     },
     "tags": []
@@ -345,10 +345,10 @@
    "id": "sl9-08",
    "metadata": {
     "papermill": {
-     "duration": 0.004735,
-     "end_time": "2026-06-10T12:02:37.063478",
+     "duration": 0.004436,
+     "end_time": "2026-06-10T13:49:38.968989",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.058743",
+     "start_time": "2026-06-10T13:49:38.964553",
      "status": "completed"
     },
     "tags": []
@@ -376,10 +376,10 @@
    "id": "sl9-09",
    "metadata": {
     "papermill": {
-     "duration": 0.005043,
-     "end_time": "2026-06-10T12:02:37.071965",
+     "duration": 0.004224,
+     "end_time": "2026-06-10T13:49:38.977522",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.066922",
+     "start_time": "2026-06-10T13:49:38.973298",
      "status": "completed"
     },
     "tags": []
@@ -410,16 +410,16 @@
    "id": "sl9-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:02:37.081917Z",
-     "iopub.status.busy": "2026-06-10T12:02:37.080746Z",
-     "iopub.status.idle": "2026-06-10T12:02:37.101111Z",
-     "shell.execute_reply": "2026-06-10T12:02:37.099597Z"
+     "iopub.execute_input": "2026-06-10T13:49:38.986328Z",
+     "iopub.status.busy": "2026-06-10T13:49:38.986328Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.006499Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.004867Z"
     },
     "papermill": {
-     "duration": 0.026693,
-     "end_time": "2026-06-10T12:02:37.102128",
+     "duration": 0.026446,
+     "end_time": "2026-06-10T13:49:39.007064",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.075435",
+     "start_time": "2026-06-10T13:49:38.980618",
      "status": "completed"
     },
     "tags": []
@@ -477,10 +477,10 @@
    "id": "sl9-11",
    "metadata": {
     "papermill": {
-     "duration": 0.004684,
-     "end_time": "2026-06-10T12:02:37.110494",
+     "duration": 0.005198,
+     "end_time": "2026-06-10T13:49:39.018496",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.105810",
+     "start_time": "2026-06-10T13:49:39.013298",
      "status": "completed"
     },
     "tags": []
@@ -500,10 +500,10 @@
    "id": "sl9-12",
    "metadata": {
     "papermill": {
-     "duration": 0.003516,
-     "end_time": "2026-06-10T12:02:37.117484",
+     "duration": 0.005228,
+     "end_time": "2026-06-10T13:49:39.029559",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.113968",
+     "start_time": "2026-06-10T13:49:39.024331",
      "status": "completed"
     },
     "tags": []
@@ -531,16 +531,16 @@
    "id": "sl9-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:02:37.128873Z",
-     "iopub.status.busy": "2026-06-10T12:02:37.127841Z",
-     "iopub.status.idle": "2026-06-10T12:02:37.148348Z",
-     "shell.execute_reply": "2026-06-10T12:02:37.147343Z"
+     "iopub.execute_input": "2026-06-10T13:49:39.042729Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.042188Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.051190Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.050631Z"
     },
     "papermill": {
-     "duration": 0.02624,
-     "end_time": "2026-06-10T12:02:37.148348",
+     "duration": 0.016932,
+     "end_time": "2026-06-10T13:49:39.052240",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.122108",
+     "start_time": "2026-06-10T13:49:39.035308",
      "status": "completed"
     },
     "tags": []
@@ -595,10 +595,10 @@
    "id": "sl9-14",
    "metadata": {
     "papermill": {
-     "duration": 0.002851,
-     "end_time": "2026-06-10T12:02:37.153868",
+     "duration": 0.005244,
+     "end_time": "2026-06-10T13:49:39.062729",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.151017",
+     "start_time": "2026-06-10T13:49:39.057485",
      "status": "completed"
     },
     "tags": []
@@ -620,10 +620,10 @@
    "id": "sl9-15",
    "metadata": {
     "papermill": {
-     "duration": 0.003296,
-     "end_time": "2026-06-10T12:02:37.158682",
+     "duration": 0.004833,
+     "end_time": "2026-06-10T13:49:39.073365",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.155386",
+     "start_time": "2026-06-10T13:49:39.068532",
      "status": "completed"
     },
     "tags": []
@@ -649,16 +649,16 @@
    "id": "sl9-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:02:37.164518Z",
-     "iopub.status.busy": "2026-06-10T12:02:37.164518Z",
-     "iopub.status.idle": "2026-06-10T12:02:37.178934Z",
-     "shell.execute_reply": "2026-06-10T12:02:37.178363Z"
+     "iopub.execute_input": "2026-06-10T13:49:39.085986Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.085471Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.113267Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.112095Z"
     },
     "papermill": {
-     "duration": 0.018994,
-     "end_time": "2026-06-10T12:02:37.180449",
+     "duration": 0.035697,
+     "end_time": "2026-06-10T13:49:39.114305",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.161455",
+     "start_time": "2026-06-10T13:49:39.078608",
      "status": "completed"
     },
     "tags": []
@@ -748,10 +748,10 @@
    "id": "sl9-17",
    "metadata": {
     "papermill": {
-     "duration": 0.002511,
-     "end_time": "2026-06-10T12:02:37.187478",
+     "duration": 0.005713,
+     "end_time": "2026-06-10T13:49:39.126280",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.184967",
+     "start_time": "2026-06-10T13:49:39.120567",
      "status": "completed"
     },
     "tags": []
@@ -785,10 +785,10 @@
    "id": "sl9-18",
    "metadata": {
     "papermill": {
-     "duration": 0.003022,
-     "end_time": "2026-06-10T12:02:37.192499",
+     "duration": 0.005275,
+     "end_time": "2026-06-10T13:49:39.136869",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.189477",
+     "start_time": "2026-06-10T13:49:39.131594",
      "status": "completed"
     },
     "tags": []
@@ -811,10 +811,366 @@
     "recherche ne peut pas inventer de predicat intermediaire (`parent_de_parent`), ne\n",
     "gere pas la recursion, et le bruit la fait echouer brutalement (exercice 3).\n",
     "\n",
-    "> **Note pratique** : Popper et Aleph s'appuient sur SWI-Prolog, absent des machines\n",
-    "> de TP --- leur integration est differee (Epic #1404). Le present notebook\n",
-    "> implemente les *mecanismes* (LGG, subsomption, bottom, compression) en Python pur,\n",
-    "> precisement pour que la mecanique reste visible.\n"
+    "> **Note pratique** : Popper et Aleph s'appuient sur SWI-Prolog. Depuis la passe\n",
+    "> \"vraies librairies\" de la serie (Epic #1404), Popper est integre dans SL-4\n",
+    "> (kernel Linux : son timeout repose sur `SIGALRM`) et **Aleph est integre plus\n",
+    "> bas dans ce notebook** --- pur Prolog, il tourne sur le kernel Windows standard\n",
+    "> via le pont `janus_swi`. Le notebook implemente d'abord les *mecanismes* (LGG,\n",
+    "> subsomption, bottom, compression) en Python pur, precisement pour que la\n",
+    "> mecanique reste visible.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f186cd73",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005353,
+     "end_time": "2026-06-10T13:49:39.147951",
+     "exception": false,
+     "start_time": "2026-06-10T13:49:39.142598",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d7e3f15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005317,
+     "end_time": "2026-06-10T13:49:39.159042",
+     "exception": false,
+     "start_time": "2026-06-10T13:49:39.153725",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## La vraie librairie : Aleph (Progol en chair et en os)\n",
+    "\n",
+    "Tout ce notebook reconstruit la pile de Progol *from scratch* : saturation,\n",
+    "variabilisation, treillis borne par la clause bottom, score de compression.\n",
+    "**Aleph** (Srinivasan, 2001) --- deja croise dans la table de la section 7 ---\n",
+    "est la reimplementation Prolog de reference de Progol, le cheval de trait\n",
+    "academique de l'ILP : des centaines d'articles l'utilisent comme baseline.\n",
+    "Il est distribue aujourd'hui comme **pack SWI-Prolog** (port de Fabrizio\n",
+    "Riguzzi) et se pilote depuis Python via le pont `janus_swi`, le meme que\n",
+    "SL-4 utilise pour verifier les programmes de Popper.\n",
+    "\n",
+    "Contraste d'environnement avec SL-4 : Popper exigeait un kernel Linux (son\n",
+    "timeout repose sur `signal.SIGALRM`), Aleph est du **pur Prolog** --- il\n",
+    "tourne sur le kernel Windows standard de ce notebook. Il suffit de\n",
+    "[SWI-Prolog](https://www.swi-prolog.org/Download.html) et de\n",
+    "`pip install janus_swi` ; le pack `aleph` s'installe tout seul a la\n",
+    "premiere execution.\n",
+    "\n",
+    "L'interet pedagogique est exact : Aleph expose **les deux etapes que nous\n",
+    "venons de coder**. `sat/1` construit (et affiche) la clause bottom d'un\n",
+    "exemple, `induce/0` lance la recherche au-dessus. On va donc comparer notre\n",
+    "clause bottom et la sienne, litteral par litteral --- puis faire verifier la\n",
+    "theorie qu'il apprend... par notre propre `covers()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4fea51c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:49:39.172715Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.172189Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.419571Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.419067Z"
+    },
+    "papermill": {
+     "duration": 0.255202,
+     "end_time": "2026-06-10T13:49:39.420579",
+     "exception": false,
+     "start_time": "2026-06-10T13:49:39.165377",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "swipl : C:\\Users\\MYIA\\OneDrive\\Documents\\swipl\\bin\\swipl.EXE"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pack aleph : v5 -- pret\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Environnement Aleph : SWI-Prolog + pont janus_swi (pur Prolog -> kernel Windows OK)\n",
+    "import os\n",
+    "import platform\n",
+    "import shutil\n",
+    "\n",
+    "HAS_ALEPH = False\n",
+    "swipl = shutil.which(\"swipl\")\n",
+    "if swipl is None and platform.system() == \"Windows\":\n",
+    "    candidats = [os.path.expanduser(p) for p in\n",
+    "                 (r\"~\\OneDrive\\Documents\\swipl\", r\"~\\Documents\\swipl\")] + [r\"C:\\Program Files\\swipl\"]\n",
+    "    for cand in candidats:\n",
+    "        if os.path.exists(os.path.join(cand, \"bin\", \"swipl.exe\")):\n",
+    "            os.environ[\"PATH\"] = os.path.join(cand, \"bin\") + os.pathsep + os.environ[\"PATH\"]\n",
+    "            os.environ[\"SWI_HOME_DIR\"] = cand\n",
+    "            swipl = shutil.which(\"swipl\")\n",
+    "            break\n",
+    "print(f\"swipl : {swipl or 'INTROUVABLE'}\")\n",
+    "\n",
+    "if swipl is None:\n",
+    "    print(\"SWI-Prolog manquant : https://www.swi-prolog.org/Download.html\")\n",
+    "    print(\"(Windows : winget install SWI-Prolog.SWI-Prolog ; Linux : apt install swi-prolog)\")\n",
+    "else:\n",
+    "    try:\n",
+    "        import janus_swi as janus\n",
+    "    except ImportError:\n",
+    "        janus = None\n",
+    "        print(\"Pont Python<->Prolog manquant : pip install janus_swi\")\n",
+    "    if janus is not None:\n",
+    "        if not janus.query_once(\"pack_property(aleph, version(_V))\")[\"truth\"]:\n",
+    "            print(\"Installation du pack aleph (une seule fois)...\")\n",
+    "            janus.query_once(\"pack_install(aleph, [interactive(false)])\")\n",
+    "        v = janus.query_once(\"pack_property(aleph, version(V))\")\n",
+    "        HAS_ALEPH = v[\"truth\"]\n",
+    "        print(f\"pack aleph : v{v['V']} -- pret\" if HAS_ALEPH else \"pack aleph : installation echouee\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d06951df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:49:39.432821Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.432310Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.560498Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.559379Z"
+    },
+    "papermill": {
+     "duration": 0.135244,
+     "end_time": "2026-06-10T13:49:39.561673",
+     "exception": false,
+     "start_time": "2026-06-10T13:49:39.426429",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[sat] [1]\n",
+      "[grandfather(tom,ann)]\n",
+      "\n",
+      "[bottom clause]\n",
+      "grandfather(A,B) :-\n",
+      "   parent(A,C), parent(A,D), male(A), parent(C,B), \n",
+      "   male(C), female(D).\n",
+      "[literals] [7]\n",
+      "[saturation time] [0.0]\n",
+      "\n",
+      "Notre bottom_clause() (saturation naive, profondeur 2) : 9 litteraux\n",
+      "  grandfather(V1, V2) :- parent(V1, V3), parent(V1, V4), parent(V3, V2), male(V1), female(V2), parent(V3, V5), parent(V4, V6), male(V3), female(V4).\n",
+      "Celle d'Aleph, bornee par les modes, est plus serree.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# La meme tache grandfather/2, ecrite dans le format d'Aleph : modes, determinations,\n",
+    "# background et exemples. Les declarations de modes sont LA reponse de Progol a la\n",
+    "# taille de la clause bottom (section 7) : +person = variable d'entree (deja liee),\n",
+    "# -person = variable de sortie, et determination/2 liste les predicats autorises\n",
+    "# dans le corps. C'est un biais de langage declare, pas un parametre de profondeur.\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "if HAS_ALEPH:\n",
+    "    pl_fact = lambda a: f\"{a[0]}({','.join(a[1:])}).\"\n",
+    "    task_pl = \"\\n\".join([\n",
+    "        \":- use_module(library(aleph)).\",\n",
+    "        \":- aleph.\",\n",
+    "        \":- style_check(-discontiguous).\",\n",
+    "        \":- aleph_set(verbosity, 1).\",\n",
+    "        \":- aleph_set(clauselength, 4).\",\n",
+    "        \":- modeh(*, grandfather(+person, -person)).\",\n",
+    "        \":- modeb(*, parent(+person, -person)).\",\n",
+    "        \":- modeb(*, parent(-person, +person)).\",\n",
+    "        \":- modeb(*, male(+person)).\",\n",
+    "        \":- modeb(*, female(+person)).\",\n",
+    "        \":- determination(grandfather/2, parent/2).\",\n",
+    "        \":- determination(grandfather/2, male/1).\",\n",
+    "        \":- determination(grandfather/2, female/1).\",\n",
+    "        \":- begin_bg.\", *[pl_fact(a) for a in FACTS], \":- end_bg.\",\n",
+    "        \":- begin_in_pos.\", *[pl_fact(a) for a in POS], \":- end_in_pos.\",\n",
+    "        \":- begin_in_neg.\", *[pl_fact(a) for a in NEG], \":- end_in_neg.\",\n",
+    "    ])\n",
+    "    task_file = Path(tempfile.mkdtemp(prefix=\"aleph_gf_\")) / \"grandfather.pl\"\n",
+    "    task_file.write_text(task_pl)\n",
+    "    janus.query_once(f\"consult('{task_file.as_posix()}')\")\n",
+    "\n",
+    "    # sat/1 : Aleph construit (et affiche) SA clause bottom pour le 1er positif.\n",
+    "    # Toute sortie Prolog doit etre capturee via with_output_to pour etre visible ici.\n",
+    "    out = janus.query_once(\"with_output_to(string(S), sat(1))\")[\"S\"]\n",
+    "    print(out)\n",
+    "    print(f\"Notre bottom_clause() (saturation naive, profondeur 2) : {len(bottom[1])} litteraux\")\n",
+    "    print(f\"  {show_clause(bottom)}\")\n",
+    "    print(\"Celle d'Aleph, bornee par les modes, est plus serree.\")\n",
+    "else:\n",
+    "    print(\"Aleph indisponible : cellule sautee (voir la cellule precedente).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "70a93825",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:49:39.575284Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.575284Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.591298Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.590288Z"
+    },
+    "papermill": {
+     "duration": 0.024401,
+     "end_time": "2026-06-10T13:49:39.591298",
+     "exception": false,
+     "start_time": "2026-06-10T13:49:39.566897",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[theory]\n",
+      "\n",
+      "[Rule 1] [Pos cover = 4 Neg cover = 0]\n",
+      "grandfather(A,B) :-\n",
+      "   parent(A,C), parent(C,B), male(A).\n",
+      "\n",
+      "[Training set performance]\n",
+      "          Actual\n",
+      "        +          -  \n",
+      "     +  4          0          4  \n",
+      "Pred \n",
+      "     -  0          6          6  \n",
+      "\n",
+      "        4          6         10 \n",
+      "\n",
+      "Accuracy = 1\n",
+      "[Training set summary] [[4,0,0,6]]\n",
+      "[time taken] [0.0]\n",
+      "[total clauses constructed] [13]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Theorie d'Aleph relue dans notre representation tuple :\n",
+      "  grandfather(A, B) :- parent(A, C), parent(C, B), male(A).\n",
+      "\n",
+      "Verification par notre covers() : 4/4 positifs, 0/6 negatifs couverts\n",
+      "Equivalente a la cible (subsomption dans les deux sens) ? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# induce : la recherche au-dessus de la clause bottom, puis VERIFICATION de la\n",
+    "# theorie apprise par Aleph... avec notre moteur de couverture from-scratch.\n",
+    "# SL-4 faisait l'inverse (Python apprend, Prolog verifie) ; ici Prolog apprend,\n",
+    "# Python verifie. Les deux mondes se controlent mutuellement.\n",
+    "import re\n",
+    "\n",
+    "if HAS_ALEPH:\n",
+    "    r = janus.query_once(\n",
+    "        \"with_output_to(string(Log), induce(_P)), \"\n",
+    "        \"with_output_to(string(Prog), forall(member(_C, _P), portray_clause(_C)))\")\n",
+    "    log = r[\"Log\"]\n",
+    "    print(log[log.index(\"[theory]\"):] if \"[theory]\" in log else log)\n",
+    "\n",
+    "    def parse_prolog_clause(text):\n",
+    "        \"\"\"'h(A,B) :- b1(A,C), b2(C)' -> representation tuple du notebook.\"\"\"\n",
+    "        atoms = [(m[0], *[t.strip() for t in m[1].split(\",\")])\n",
+    "                 for m in re.findall(r\"(\\w+)\\(([^)]*)\\)\", \" \".join(text.split()))]\n",
+    "        return (atoms[0], atoms[1:])\n",
+    "\n",
+    "    learned = [parse_prolog_clause(c)\n",
+    "               for c in re.split(r\"\\.\\s*\\n\", r[\"Prog\"]) if c.strip()]\n",
+    "    print(\"Theorie d'Aleph relue dans notre representation tuple :\")\n",
+    "    for c in learned:\n",
+    "        print(f\"  {show_clause(c)}\")\n",
+    "\n",
+    "    ok_pos = sum(1 for e in POS if any(covers(c, e, FACTS) for c in learned))\n",
+    "    ok_neg = sum(1 for e in NEG if any(covers(c, e, FACTS) for c in learned))\n",
+    "    exact = any(subsumes(c, target) and subsumes(target, c) for c in learned)\n",
+    "    print(f\"\\nVerification par notre covers() : {ok_pos}/{len(POS)} positifs,\"\n",
+    "          f\" {ok_neg}/{len(NEG)} negatifs couverts\")\n",
+    "    print(f\"Equivalente a la cible (subsomption dans les deux sens) ? {exact}\")\n",
+    "else:\n",
+    "    print(\"Aleph indisponible : cellule sautee.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb7354bd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005889,
+     "end_time": "2026-06-10T13:49:39.603242",
+     "exception": false,
+     "start_time": "2026-06-10T13:49:39.597353",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : ce que 25 ans de maturite changent\n",
+    "\n",
+    "1. **Les modes bornent la clause bottom.** Notre saturation naive a profondeur 2\n",
+    "   produit 9 litteraux ; celle d'Aleph en garde 7. Les declarations\n",
+    "   `modeh`/`modeb` (entree `+`/sortie `-`, typage `person`) et `determination/2`\n",
+    "   eliminent d'office les litteraux non connectables --- la limite n'est pas une\n",
+    "   profondeur brute mais le **langage declare**. C'est la reponse concrete a\n",
+    "   l'explosion combinatoire etudiee dans l'exercice 2.\n",
+    "2. **La recherche est dirigee, pas exhaustive.** Notre `progol_search` enumere\n",
+    "   56 candidats connectes ; Aleph n'en construit que 13 (cf. `[total clauses\n",
+    "   constructed]` ci-dessus) : A* guide par la compression, elagage par bornes.\n",
+    "   Meme treillis, meme resultat --- juste 25 ans d'ingenierie du parcours.\n",
+    "3. **Python verifie Prolog.** La theorie d'Aleph, relue dans notre representation\n",
+    "   tuple et passee a notre `covers()`, couvre 4/4 positifs et 0/6 negatifs, et\n",
+    "   `subsumes()` dans les deux sens confirme que c'est exactement la cible ---\n",
+    "   apprise par un moteur de 2001, verifiee par le moteur de ce notebook.\n",
+    "\n",
+    "Pour creuser : le [manuel d'Aleph](https://www.cs.ox.ac.uk/activities/programinduction/Aleph/aleph.html)\n",
+    "et le [pack SWI-Prolog](https://www.swi-prolog.org/pack/list?p=aleph). Aleph\n",
+    "gere aussi le bruit (`aleph_set(noise, N)`, `aleph_set(minacc, A)`) --- c'est\n",
+    "l'objet de l'exercice 5 ci-dessous."
    ]
   },
   {
@@ -822,10 +1178,10 @@
    "id": "sl9-19",
    "metadata": {
     "papermill": {
-     "duration": 0.00451,
-     "end_time": "2026-06-10T12:02:37.201600",
+     "duration": 0.005756,
+     "end_time": "2026-06-10T13:49:39.614267",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.197090",
+     "start_time": "2026-06-10T13:49:39.608511",
      "status": "completed"
     },
     "tags": []
@@ -848,20 +1204,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "sl9-20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:02:37.211654Z",
-     "iopub.status.busy": "2026-06-10T12:02:37.211654Z",
-     "iopub.status.idle": "2026-06-10T12:02:37.225511Z",
-     "shell.execute_reply": "2026-06-10T12:02:37.225511Z"
+     "iopub.execute_input": "2026-06-10T13:49:39.627697Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.627697Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.637734Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.636468Z"
     },
     "papermill": {
-     "duration": 0.020991,
-     "end_time": "2026-06-10T12:02:37.227109",
+     "duration": 0.018996,
+     "end_time": "2026-06-10T13:49:39.638742",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.206118",
+     "start_time": "2026-06-10T13:49:39.619746",
      "status": "completed"
     },
     "tags": []
@@ -893,10 +1249,10 @@
    "id": "sl9-21",
    "metadata": {
     "papermill": {
-     "duration": 0.00343,
-     "end_time": "2026-06-10T12:02:37.233577",
+     "duration": 0.005559,
+     "end_time": "2026-06-10T13:49:39.650580",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.230147",
+     "start_time": "2026-06-10T13:49:39.645021",
      "status": "completed"
     },
     "tags": []
@@ -909,20 +1265,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "sl9-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:02:37.244280Z",
-     "iopub.status.busy": "2026-06-10T12:02:37.243281Z",
-     "iopub.status.idle": "2026-06-10T12:02:37.258378Z",
-     "shell.execute_reply": "2026-06-10T12:02:37.257373Z"
+     "iopub.execute_input": "2026-06-10T13:49:39.664733Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.664733Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.682302Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.682302Z"
     },
     "papermill": {
-     "duration": 0.021752,
-     "end_time": "2026-06-10T12:02:37.259378",
+     "duration": 0.02762,
+     "end_time": "2026-06-10T13:49:39.683807",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.237626",
+     "start_time": "2026-06-10T13:49:39.656187",
      "status": "completed"
     },
     "tags": []
@@ -956,10 +1312,10 @@
    "id": "sl9-23",
    "metadata": {
     "papermill": {
-     "duration": 0.004023,
-     "end_time": "2026-06-10T12:02:37.268142",
+     "duration": 0.00535,
+     "end_time": "2026-06-10T13:49:39.695981",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.264119",
+     "start_time": "2026-06-10T13:49:39.690631",
      "status": "completed"
     },
     "tags": []
@@ -971,20 +1327,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "sl9-24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:02:37.278254Z",
-     "iopub.status.busy": "2026-06-10T12:02:37.278254Z",
-     "iopub.status.idle": "2026-06-10T12:02:37.289031Z",
-     "shell.execute_reply": "2026-06-10T12:02:37.288413Z"
+     "iopub.execute_input": "2026-06-10T13:49:39.710447Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.710447Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.713772Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.713772Z"
     },
     "papermill": {
-     "duration": 0.017928,
-     "end_time": "2026-06-10T12:02:37.290686",
+     "duration": 0.012277,
+     "end_time": "2026-06-10T13:49:39.715072",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.272758",
+     "start_time": "2026-06-10T13:49:39.702795",
      "status": "completed"
     },
     "tags": []
@@ -1019,10 +1375,10 @@
    "id": "sl9-25",
    "metadata": {
     "papermill": {
-     "duration": 0.004942,
-     "end_time": "2026-06-10T12:02:37.299746",
+     "duration": 0.005496,
+     "end_time": "2026-06-10T13:49:39.727099",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.294804",
+     "start_time": "2026-06-10T13:49:39.721603",
      "status": "completed"
     },
     "tags": []
@@ -1035,20 +1391,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "sl9-26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:02:37.310597Z",
-     "iopub.status.busy": "2026-06-10T12:02:37.310082Z",
-     "iopub.status.idle": "2026-06-10T12:02:37.320091Z",
-     "shell.execute_reply": "2026-06-10T12:02:37.318951Z"
+     "iopub.execute_input": "2026-06-10T13:49:39.738956Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.738956Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.746062Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.745059Z"
     },
     "papermill": {
-     "duration": 0.016805,
-     "end_time": "2026-06-10T12:02:37.321138",
+     "duration": 0.014622,
+     "end_time": "2026-06-10T13:49:39.747060",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.304333",
+     "start_time": "2026-06-10T13:49:39.732438",
      "status": "completed"
     },
     "tags": []
@@ -1080,13 +1436,85 @@
   },
   {
    "cell_type": "markdown",
+   "id": "483f5450",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00571,
+     "end_time": "2026-06-10T13:49:39.759040",
+     "exception": false,
+     "start_time": "2026-06-10T13:49:39.753330",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Dernier exercice, en echo a l'exercice 3 : le bruit, vu cette fois du cote\n",
+    "d'un systeme reel. La ou il a fallu reecrire `progol_search` pour passer de la\n",
+    "consistance stricte au score $f = p - n - L$, Aleph expose ce compromis en un\n",
+    "parametre --- mais ses choix par defaut reservent une surprise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "fe495e59",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:49:39.771777Z",
+     "iopub.status.busy": "2026-06-10T13:49:39.770084Z",
+     "iopub.status.idle": "2026-06-10T13:49:39.777183Z",
+     "shell.execute_reply": "2026-06-10T13:49:39.776602Z"
+    },
+    "papermill": {
+     "duration": 0.011901,
+     "end_time": "2026-06-10T13:49:39.778558",
+     "exception": false,
+     "start_time": "2026-06-10T13:49:39.766657",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 5 : Aleph face au bruit\n",
+    "# TODO etudiant : reprenez le positif errone de l'exercice 3 (grandfather(liz, eve),\n",
+    "# une erreur d'etiquetage : liz est une grand-mere) et donnez la tache bruitee a Aleph.\n",
+    "# Etape 1 : reconstruisez un fichier de tache avec POS + [(\"grandfather\", \"liz\", \"eve\")]\n",
+    "#           et les memes NEG (reutilisez pl_fact et le squelette de la section Aleph ;\n",
+    "#           un nouveau consult remplace la tache precedente sans redemarrer le kernel).\n",
+    "# Etape 2 : induce en reglages par defaut (consistance stricte) : examinez la theorie\n",
+    "#           clause par clause. Comment Aleph s'arrange-t-il d'un positif impossible\n",
+    "#           a couvrir sans toucher un negatif ?\n",
+    "# Etape 3 : ajoutez ':- aleph_set(noise, 1).' a la tache et re-induce : la theorie\n",
+    "#           change --- laquelle des clauses de l'etape 2 a survecu, et a quel prix ?\n",
+    "# Etape 4 : ni l'etape 2 ni l'etape 3 ne retrouvent la cible propre. Lequel des deux\n",
+    "#           comportements votre progol_search_noisy de l'exercice 3 reproduit-il ?\n",
+    "# Indice : a l'etape 2, comptez les clauses de la theorie et regardez si l'une\n",
+    "#          d'elles n'a AUCUNE variable.\n",
+    "\n",
+    "if HAS_ALEPH:\n",
+    "    print(\"Exercice a completer\")\n",
+    "else:\n",
+    "    print(\"Aleph indisponible : exercice a faire sur une machine avec SWI-Prolog.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "sl9-27",
    "metadata": {
     "papermill": {
-     "duration": 0.005394,
-     "end_time": "2026-06-10T12:02:37.331212",
+     "duration": 0.007085,
+     "end_time": "2026-06-10T13:49:39.791338",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.325818",
+     "start_time": "2026-06-10T13:49:39.784253",
      "status": "completed"
     },
     "tags": []
@@ -1106,7 +1534,8 @@
     "| **Ex. 1 (grandmother)** | Apprenez maintenant `grandparent/2` (sans contrainte de sexe) : pourquoi est-ce *plus facile* que grandfather, et qu'est-ce que cela dit du role des exemples negatifs comme porteurs du signal d'apprentissage ? |\n",
     "| **Ex. 2 (profondeur de bottom)** | Estimez la croissance de $|\\bot(e)|$ en fonction de la profondeur $i$ et du degre moyen du graphe de faits. A partir de quelle profondeur l'enumeration par sous-ensembles devient-elle intraitable, et comment les *declarations de modes* de Progol (types + recall) repoussent-elles cette limite ? |\n",
     "| **Ex. 3 (bruit)** | Le score $f = p - n - L$ est un argument de longueur de description minimale (MDL). Construisez un jeu d'exemples ou ce score prefere une clause *fausse* a la cible, et expliquez quel terme du compromis (couverture, consistance, longueur) a ete trompe. |\n",
-    "| **Ex. 4 (reduction)** | Subsomption et implication ne coincident pas : la clause recursive $p(f(X)) \\leftarrow p(X)$ implique $p(f(f(X))) \\leftarrow p(X)$ sans la subsumer. Verifiez-le a la main, et expliquez pourquoi l'ILP travaille quand meme avec la subsomption (decidabilite, theoreme de Gottlob). |\n"
+    "| **Ex. 4 (reduction)** | Subsomption et implication ne coincident pas : la clause recursive $p(f(X)) \\leftarrow p(X)$ implique $p(f(f(X))) \\leftarrow p(X)$ sans la subsumer. Verifiez-le a la main, et expliquez pourquoi l'ILP travaille quand meme avec la subsomption (decidabilite, theoreme de Gottlob). |\n",
+    "| **Ex. 5 (Aleph et le bruit)** | Trois reponses au meme positif bruite : memoriser l'exception (defaut strict), sur-generaliser (`noise(1)`), arbitrer par $f = p - n - L$ (ex. 3). `aleph_set(minacc, 0.9)` introduit un 4e levier : un seuil *relatif* de precision par clause. Pourquoi un budget *absolu* de bruit et un seuil *relatif* de precision ne tracent-ils pas la meme frontiere quand la couverture des clauses varie ? |\n"
    ]
   },
   {
@@ -1114,10 +1543,10 @@
    "id": "sl9-28",
    "metadata": {
     "papermill": {
-     "duration": 0.004266,
-     "end_time": "2026-06-10T12:02:37.339772",
+     "duration": 0.006439,
+     "end_time": "2026-06-10T13:49:39.802782",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.335506",
+     "start_time": "2026-06-10T13:49:39.796343",
      "status": "completed"
     },
     "tags": []
@@ -1171,10 +1600,10 @@
    "id": "sl9-29",
    "metadata": {
     "papermill": {
-     "duration": 0.004731,
-     "end_time": "2026-06-10T12:02:37.349252",
+     "duration": 0.006404,
+     "end_time": "2026-06-10T13:49:39.815228",
      "exception": false,
-     "start_time": "2026-06-10T12:02:37.344521",
+     "start_time": "2026-06-10T13:49:39.808824",
      "status": "completed"
     },
     "tags": []
@@ -1218,14 +1647,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.236434,
-   "end_time": "2026-06-10T12:02:37.597283",
+   "duration": 5.478865,
+   "end_time": "2026-06-10T13:49:42.715882",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-9-InverseResolution.ipynb",
    "output_path": "SL-9-InverseResolution.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T12:02:35.360849",
+   "start_time": "2026-06-10T13:49:37.237017",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Last real-library integration of **Epic #1404** for the SymbolicLearning series (after aima SL-1, Popper SL-4, LTNtorch SL-5, clingo SL-6, LLM SL-7). SL-9 reconstructs the full Progol stack from scratch (saturation, bottom clause, lattice search, compression score) — this PR confronts it with **Aleph** (Srinivasan 2001), the academic reference reimplementation of Progol, installed as the official SWI-Prolog pack (Riguzzi port) and driven from Python via `janus_swi`. No vendoring: runtime `pack_install` only (license garde-fou of #1404).

### New section « La vraie librairie : Aleph » (6 cells, before exercises)
- Env check: swipl detection (PATH candidates on Windows), `janus_swi` import, **pack aleph auto-install** on first run, graceful `HAS_ALEPH` skip.
- Same grandfather/2 task written in Aleph's format: `modeh`/`modeb`/`determination` declarations — the concrete answer to Ex2's twist about bounding ⊥(e).
- `sat(1)`: Aleph's real bottom clause (**7 literals**, mode-bounded) printed next to the notebook's naive `bottom_clause()` (**9 literals**, depth 2).
- `induce`: **13 clauses constructed** vs the notebook's 56 exhaustive candidates; same learned target.
- **Python verifies Prolog** (mirror of SL-4 where Python learns and Prolog verifies): Aleph's portrayed theory parsed back into the notebook's tuple representation, checked with the notebook's own `covers()` → 4/4 pos, 0/6 neg, and `subsumes()` both ways → exactly the target.
- Pure Prolog ⇒ runs on the **standard Windows python3 kernel** (no WSL, unlike Popper/SIGALRM in SL-4).

### New Exercice 5 « Aleph face au bruit » + défi row
- C.1-compliant stub (`print("Exercice a completer")`, HAS_ALEPH guard), echoing Ex3: spike-verified behaviors — strict mode **memorizes the noisy positive as a ground fact**, `noise(1)` **over-generalizes** (drops `male/1`); students compare with their `progol_search_noisy` (f = p − n − L).
- Défi table: Ex5 twist row (absolute noise budget vs relative `minacc` threshold).

### Collateral
- Section 7 stale note updated: SWI-Prolog integrations no longer « differees » (Popper in SL-4, Aleph here).

## Validation (rule D)
- Papermill end-to-end, kernel `python3` (Windows), **exit 0** — 13/13 code cells executed, `execution_count` set everywhere, **0 errors**, real Aleph outputs committed (C.2).
- `grep -cE 'raise NotImplementedError|assert False|1/0'` → **0** (C.1).
- Key committed outputs:
```
[bottom clause] grandfather(A,B) :- parent(A,C), parent(A,D), male(A), parent(C,B), male(C), female(D).  [literals] [7]
[Rule 1] [Pos cover = 4 Neg cover = 0] grandfather(A,B) :- parent(A,C), parent(C,B), male(A).
Accuracy = 1   [total clauses constructed] [13]
Verification par notre covers() : 4/4 positifs, 0/6 negatifs couverts
Equivalente a la cible (subsomption dans les deux sens) ? True
```

Part of #1404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)