### PR TITLE
feat(SL): +1 exercice par integration reelle (SL-1/4/5/6/7) + table de pioche 40

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -43,7 +43,7 @@ A l'issue de cette serie, vous serez capable de :
 | Statistique | Valeur |
 |-------------|--------|
 | Notebooks | 10 |
-| Exercices (table de pioche) | 34 |
+| Exercices (table de pioche) | 40 |
 | Kernel | Python 3 |
 | Duree estimee | ~570 min |
 | prerequis | Python 3.10+ (standard library + sklearn pour SL-3/SL-4, rdflib pour SL-6, cle OpenRouter optionnelle pour SL-7/SL-10) |
@@ -88,7 +88,7 @@ Pour les etudiants en informatique theorique : le cadre inductif general (SL-1),
 
 Pour les professionnels du web semantique et des donnees structurees : EBL, RBL, FOIL sur clauses Horn, puis application directe sur des knowledge graphs reels avec rdflib et AMIE. Presuppose une familiarite avec RDF/SPARQL.
 
-## Seance du 17 juin : la table de pioche (34 exercices)
+## Seance du 17 juin : la table de pioche (40 exercices)
 
 Modalite de la seance : chaque groupe choisit **un exercice** dans la table ci-dessous, le prepare, et le presente en seance. Resoudre l'exercice est le minimum attendu ; chaque exercice est assorti d'une **question-twist** (detaillee dans la cellule « Defi presentation » du notebook correspondant) qui fait partie integrante de la presentation. Premier arrive, premier servi : annoncez votre choix pour eviter les doublons.
 
@@ -98,38 +98,44 @@ Modalite de la seance : chaque groupe choisit **un exercice** dans la table ci-d
 | 2 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 2 — Version Space sur sous-ensemble | Qu'est-ce qui rend un exemple *informatif* (frontieres S et G) ? |
 | 3 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 3 — Regles avec couverture | Compacite vs hypothese AIMA : quel biais (rasoir d'Occam) prefere l'une a l'autre ? |
 | 4 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 4 — Reflexion sur le biais conjonctif | Un domaine ou ce biais est ideal, un ou il est catastrophique (no free lunch) |
-| 5 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 1 — EBL differentiation symbolique | Exhiber une variabilisation trop agressive qui produit une regle compilee fausse |
-| 6 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 2 — Filtrage des regles (operationnalite) | Deux distributions de requetes qui inversent le classement d'utilite des regles |
-| 7 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 3 — Speedup EBL | Le *utility problem* (Minton 1990) : pourquoi apprendre plus finit par ralentir |
-| 8 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 1 — Determinations meteo | Une observation bruitee : quelle determination minimale survit ? |
-| 9 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 2 — RBL vs selection aleatoire | Trouver le point de croisement ou la selection statistique bat le RBL |
-| 10 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 3 — Selecteur hybride | Quelles garanties votre hybride herite-t-il vraiment ? Contre-exemple construit |
-| 11 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 1 — `sibling` avec FOIL | Le role du biais de langage : que se passe-t-il sans le litteral `X != Y` ? |
-| 12 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 2 — Operateur W | Generalisation consistante mais fausse : pourquoi le bottom-up y est expose |
-| 13 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 3 — Regles sur mini-KG | Monde clos vs PCA (cf SL-6) : quelle confiance est la bonne pour VOTRE KG ? |
-| 14 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 2 — LTN frere/oncle | Retirer les axiomes negatifs : pourquoi une LTN a besoin de negatifs explicites |
-| 15 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 3 — Regle transitive `ancestor` | Le modele trivial « vrai partout » sature la regle : qu'est-ce qui l'evite ? |
-| 16 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 4 — T-norm de Lukasiewicz | Gradients exactement nuls : qu'est-ce qu'une semantique floue *apprenable* ? |
-| 17 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 1 — Nouvelle relation au KG | Regles redondantes (meme extension, syntaxe differente) : comment AMIE les evite |
-| 18 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 2 — PCA confidence | Construire un mini-KG ou la PCA confidence est trompeuse |
-| 19 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 3 — Regles a 3 atomes | Explosion combinatoire : pourquoi AMIE impose des regles fermees, a quel prix |
-| 20 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 1 — Prompt personnalise | Changer de modele LLM : que garantit vraiment l'oracle symbolique ? |
-| 21 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 2 — Prompt direct vs CoT | Validation oracle vs plausibilite du texte : les deux metriques peuvent diverger |
-| 22 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 3 — Detection d'hallucinations | Le detecteur suppose un monde clos : que devient-il en monde ouvert (cf SL-6) ? |
-| 23 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 1 — Le langage « contient abb » | Certificat de minimalite : un suffixe distinguant pour chaque paire d'etats (Myhill-Nerode) |
-| 24 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 2 — Fiabilite de l'EQ echantillonnee | Relier le taux de reussite empirique a la borne PAC ; construire une distribution adverse |
-| 25 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 3 — Contre-exemples : prefixes vs suffixes | Le pire cas qui fait exploser la table d'observation (Rivest-Schapire) |
-| 26 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 4 — Oracle bruite | Reparer L* par vote majoritaire : surcout en requetes et probabilite residuelle d'erreur |
-| 27 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 1 — Apprendre `grandmother/2` | Pourquoi `grandparent/2` (sans sexe) est *plus facile* — role des negatifs |
-| 28 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 2 — Profondeur de la clause bottom | Croissance de la clause bottom avec la profondeur ; la cible reste-t-elle dans le treillis ? |
-| 29 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 3 — Tolerance au bruit | Le score `p - n - L` comme argument MDL : quand prefere-t-il une clause imparfaite ? |
-| 30 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 4 — Reduction de Plotkin | Subsomption vs implication : le cas des clauses recursives ou elles divergent |
-| 31 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 1 — Etendre le schema (`marie_avec`) | Le mineur redecouvre la symetrie injectee par l'oracle : regle ou tautologie ? |
-| 32 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 2 — Politique de conflit a sources | *Truth discovery* : estimer la fiabilite des sources en meme temps que les faits |
-| 33 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 3 — Le bon seuil n'existe pas | Vraie et fausse regle a confiance egale (0.67) : quel signal au-dela du seuil ? |
-| 34 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 4 — Empoisonnement bout-en-bout | Classer les defenses par etage du pipeline ; ou s'arrete la provenance ? |
+| 5 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 5 — La consistance sans Occam (aima) | Echantillonner les graines ne prouve pas la minimalite : quel algorithme exact le ferait ? |
+| 6 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 1 — EBL differentiation symbolique | Exhiber une variabilisation trop agressive qui produit une regle compilee fausse |
+| 7 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 2 — Filtrage des regles (operationnalite) | Deux distributions de requetes qui inversent le classement d'utilite des regles |
+| 8 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 3 — Speedup EBL | Le *utility problem* (Minton 1990) : pourquoi apprendre plus finit par ralentir |
+| 9 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 1 — Determinations meteo | Une observation bruitee : quelle determination minimale survit ? |
+| 10 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 2 — RBL vs selection aleatoire | Trouver le point de croisement ou la selection statistique bat le RBL |
+| 11 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 3 — Selecteur hybride | Quelles garanties votre hybride herite-t-il vraiment ? Contre-exemple construit |
+| 12 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 1 — `sibling` avec FOIL | Le role du biais de langage : que se passe-t-il sans le litteral `X != Y` ? |
+| 13 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 2 — Operateur W | Generalisation consistante mais fausse : pourquoi le bottom-up y est expose |
+| 14 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 3 — Regles sur mini-KG | Monde clos vs PCA (cf SL-6) : quelle confiance est la bonne pour VOTRE KG ? |
+| 15 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 4 — `grandparent` avec Popper | Sans negatif arriere-grand-parent, quel programme plus court devient consistant ? |
+| 16 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 2 — LTN frere/oncle | Retirer les axiomes negatifs : pourquoi une LTN a besoin de negatifs explicites |
+| 17 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 3 — Regle transitive `ancestor` | Le modele trivial « vrai partout » sature la regle : qu'est-ce qui l'evite ? |
+| 18 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 4 — T-norm de Lukasiewicz | Gradients exactement nuls : qu'est-ce qu'une semantique floue *apprenable* ? |
+| 19 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 5 — Ablation de l'axiome 4 (LTNtorch) | Le negatif difficile (Marie, Pierre) est-il indispensable ? Contraste avec clingo (SL-6) |
+| 20 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 1 — Nouvelle relation au KG | Regles redondantes (meme extension, syntaxe differente) : comment AMIE les evite |
+| 21 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 2 — PCA confidence | Construire un mini-KG ou la PCA confidence est trompeuse |
+| 22 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 3 — Regles a 3 atomes | Explosion combinatoire : pourquoi AMIE impose des regles fermees, a quel prix |
+| 23 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 4 — Reparation minimale (clingo) | Les reparations optimales sont ex-aequo : departager par des poids de confiance |
+| 24 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 1 — Prompt personnalise | Changer de modele LLM : que garantit vraiment l'oracle symbolique ? |
+| 25 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 2 — Prompt direct vs CoT | Validation oracle vs plausibilite du texte : les deux metriques peuvent diverger |
+| 26 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 3 — Detection d'hallucinations | Le detecteur suppose un monde clos : que devient-il en monde ouvert (cf SL-6) ? |
+| 27 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 4 — Taux d'hallucination du vrai LLM | Maximiser le taux de validation ou le nombre de regles validees par appel ? |
+| 28 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 1 — Le langage « contient abb » | Certificat de minimalite : un suffixe distinguant pour chaque paire d'etats (Myhill-Nerode) |
+| 29 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 2 — Fiabilite de l'EQ echantillonnee | Relier le taux de reussite empirique a la borne PAC ; construire une distribution adverse |
+| 30 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 3 — Contre-exemples : prefixes vs suffixes | Le pire cas qui fait exploser la table d'observation (Rivest-Schapire) |
+| 31 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 4 — Oracle bruite | Reparer L* par vote majoritaire : surcout en requetes et probabilite residuelle d'erreur |
+| 32 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 1 — Apprendre `grandmother/2` | Pourquoi `grandparent/2` (sans sexe) est *plus facile* — role des negatifs |
+| 33 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 2 — Profondeur de la clause bottom | Croissance de la clause bottom avec la profondeur ; la cible reste-t-elle dans le treillis ? |
+| 34 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 3 — Tolerance au bruit | Le score `p - n - L` comme argument MDL : quand prefere-t-il une clause imparfaite ? |
+| 35 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 4 — Reduction de Plotkin | Subsomption vs implication : le cas des clauses recursives ou elles divergent |
+| 36 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 5 — Aleph face au bruit | Memoriser l'exception, sur-generaliser ou payer L dans f : trois frontieres face au meme bruit |
+| 37 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 1 — Etendre le schema (`marie_avec`) | Le mineur redecouvre la symetrie injectee par l'oracle : regle ou tautologie ? |
+| 38 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 2 — Politique de conflit a sources | *Truth discovery* : estimer la fiabilite des sources en meme temps que les faits |
+| 39 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 3 — Le bon seuil n'existe pas | Vraie et fausse regle a confiance egale (0.67) : quel signal au-dela du seuil ? |
+| 40 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 4 — Empoisonnement bout-en-bout | Classer les defenses par etage du pipeline ; ou s'arrete la provenance ? |
 
-Note : dans SL-5, le premier exercice de la numerotation interne est un exemple guide ; les exercices a piocher sont Ex. 2 a Ex. 4.
+Note : dans SL-5, le premier exercice de la numerotation interne est un exemple guide ; les exercices a piocher sont Ex. 2 a Ex. 5.
 
 ## Notebooks
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "6b0e8fee",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T11:11:05.017064",
+     "duration": 0.00445,
+     "end_time": "2026-06-10T14:02:23.861956",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.013064",
+     "start_time": "2026-06-10T14:02:23.857506",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "2b4d29e4",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-06-10T11:11:05.024064",
+     "duration": 0.004515,
+     "end_time": "2026-06-10T14:02:23.870984",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.021064",
+     "start_time": "2026-06-10T14:02:23.866469",
      "status": "completed"
     },
     "tags": []
@@ -92,16 +92,16 @@
    "id": "dc85e1f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.032576Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.031576Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.043762Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.043133Z"
+     "iopub.execute_input": "2026-06-10T14:02:23.879552Z",
+     "iopub.status.busy": "2026-06-10T14:02:23.879552Z",
+     "iopub.status.idle": "2026-06-10T14:02:23.905132Z",
+     "shell.execute_reply": "2026-06-10T14:02:23.904010Z"
     },
     "papermill": {
-     "duration": 0.0164,
-     "end_time": "2026-06-10T11:11:05.044464",
+     "duration": 0.031551,
+     "end_time": "2026-06-10T14:02:23.905650",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.028064",
+     "start_time": "2026-06-10T14:02:23.874099",
      "status": "completed"
     },
     "tags": []
@@ -183,10 +183,10 @@
    "id": "62d393f1",
    "metadata": {
     "papermill": {
-     "duration": 0.003546,
-     "end_time": "2026-06-10T11:11:05.051432",
+     "duration": 0.003146,
+     "end_time": "2026-06-10T14:02:23.913299",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.047886",
+     "start_time": "2026-06-10T14:02:23.910153",
      "status": "completed"
     },
     "tags": []
@@ -210,10 +210,10 @@
    "id": "ee8b228d",
    "metadata": {
     "papermill": {
-     "duration": 0.0055,
-     "end_time": "2026-06-10T11:11:05.061882",
+     "duration": 0.004625,
+     "end_time": "2026-06-10T14:02:23.921995",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.056382",
+     "start_time": "2026-06-10T14:02:23.917370",
      "status": "completed"
     },
     "tags": []
@@ -241,16 +241,16 @@
    "id": "4b2b04b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.071145Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.071145Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.090628Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.090064Z"
+     "iopub.execute_input": "2026-06-10T14:02:23.930885Z",
+     "iopub.status.busy": "2026-06-10T14:02:23.930885Z",
+     "iopub.status.idle": "2026-06-10T14:02:23.950870Z",
+     "shell.execute_reply": "2026-06-10T14:02:23.949706Z"
     },
     "papermill": {
-     "duration": 0.026202,
-     "end_time": "2026-06-10T11:11:05.092142",
+     "duration": 0.025727,
+     "end_time": "2026-06-10T14:02:23.951391",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.065940",
+     "start_time": "2026-06-10T14:02:23.925664",
      "status": "completed"
     },
     "tags": []
@@ -334,10 +334,10 @@
    "id": "3fcf13d2",
    "metadata": {
     "papermill": {
-     "duration": 0.003368,
-     "end_time": "2026-06-10T11:11:05.099387",
+     "duration": 0.003645,
+     "end_time": "2026-06-10T14:02:23.959204",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.096019",
+     "start_time": "2026-06-10T14:02:23.955559",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "3fb92770",
    "metadata": {
     "papermill": {
-     "duration": 0.00371,
-     "end_time": "2026-06-10T11:11:05.106018",
+     "duration": 0.003742,
+     "end_time": "2026-06-10T14:02:23.967137",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.102308",
+     "start_time": "2026-06-10T14:02:23.963395",
      "status": "completed"
     },
     "tags": []
@@ -398,16 +398,16 @@
    "id": "e4d6947a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.116708Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.115367Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.136913Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.135910Z"
+     "iopub.execute_input": "2026-06-10T14:02:23.977894Z",
+     "iopub.status.busy": "2026-06-10T14:02:23.977894Z",
+     "iopub.status.idle": "2026-06-10T14:02:23.997424Z",
+     "shell.execute_reply": "2026-06-10T14:02:23.995908Z"
     },
     "papermill": {
-     "duration": 0.02779,
-     "end_time": "2026-06-10T11:11:05.137910",
+     "duration": 0.025686,
+     "end_time": "2026-06-10T14:02:23.997943",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.110120",
+     "start_time": "2026-06-10T14:02:23.972257",
      "status": "completed"
     },
     "tags": []
@@ -508,10 +508,10 @@
    "id": "b1a2400b",
    "metadata": {
     "papermill": {
-     "duration": 0.005545,
-     "end_time": "2026-06-10T11:11:05.149773",
+     "duration": 0.006916,
+     "end_time": "2026-06-10T14:02:24.012216",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.144228",
+     "start_time": "2026-06-10T14:02:24.005300",
      "status": "completed"
     },
     "tags": []
@@ -537,10 +537,10 @@
    "id": "77fbb6ab",
    "metadata": {
     "papermill": {
-     "duration": 0.006013,
-     "end_time": "2026-06-10T11:11:05.163250",
+     "duration": 0.006793,
+     "end_time": "2026-06-10T14:02:24.026349",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.157237",
+     "start_time": "2026-06-10T14:02:24.019556",
      "status": "completed"
     },
     "tags": []
@@ -584,16 +584,16 @@
    "id": "ebd916fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.177800Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.175897Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.198179Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.196672Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.043799Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.043270Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.058208Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.057190Z"
     },
     "papermill": {
-     "duration": 0.028792,
-     "end_time": "2026-06-10T11:11:05.198179",
+     "duration": 0.025496,
+     "end_time": "2026-06-10T14:02:24.059266",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.169387",
+     "start_time": "2026-06-10T14:02:24.033770",
      "status": "completed"
     },
     "tags": []
@@ -710,10 +710,10 @@
    "id": "462c713b",
    "metadata": {
     "papermill": {
-     "duration": 0.005459,
-     "end_time": "2026-06-10T11:11:05.211041",
+     "duration": 0.007768,
+     "end_time": "2026-06-10T14:02:24.074412",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.205582",
+     "start_time": "2026-06-10T14:02:24.066644",
      "status": "completed"
     },
     "tags": []
@@ -742,10 +742,10 @@
    "id": "22c65a7f",
    "metadata": {
     "papermill": {
-     "duration": 0.006366,
-     "end_time": "2026-06-10T11:11:05.224240",
+     "duration": 0.007935,
+     "end_time": "2026-06-10T14:02:24.089818",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.217874",
+     "start_time": "2026-06-10T14:02:24.081883",
      "status": "completed"
     },
     "tags": []
@@ -790,16 +790,16 @@
    "id": "cf277e5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.236956Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.236956Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.258108Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.257604Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.107210Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.106202Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.118888Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.118301Z"
     },
     "papermill": {
-     "duration": 0.030304,
-     "end_time": "2026-06-10T11:11:05.259114",
+     "duration": 0.022231,
+     "end_time": "2026-06-10T14:02:24.119897",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.228810",
+     "start_time": "2026-06-10T14:02:24.097666",
      "status": "completed"
     },
     "tags": []
@@ -809,7 +809,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trace Version Space :\n",
+      "Trace Version Space :"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       " Ex | Label | |G| | |S|\n",
       "-------------------------\n",
       "  0 |     + |   1 |   1\n",
@@ -956,10 +963,10 @@
    "id": "98b8d953",
    "metadata": {
     "papermill": {
-     "duration": 0.006748,
-     "end_time": "2026-06-10T11:11:05.273082",
+     "duration": 0.007505,
+     "end_time": "2026-06-10T14:02:24.135501",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.266334",
+     "start_time": "2026-06-10T14:02:24.127996",
      "status": "completed"
     },
     "tags": []
@@ -996,10 +1003,10 @@
    "id": "e4ab2892",
    "metadata": {
     "papermill": {
-     "duration": 0.006697,
-     "end_time": "2026-06-10T11:11:05.285921",
+     "duration": 0.006993,
+     "end_time": "2026-06-10T14:02:24.149419",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.279224",
+     "start_time": "2026-06-10T14:02:24.142426",
      "status": "completed"
     },
     "tags": []
@@ -1028,16 +1035,16 @@
    "id": "e5d20a7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.301953Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.301422Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.319559Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.318554Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.165789Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.165789Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.181543Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.180457Z"
     },
     "papermill": {
-     "duration": 0.026721,
-     "end_time": "2026-06-10T11:11:05.320065",
+     "duration": 0.027248,
+     "end_time": "2026-06-10T14:02:24.182541",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.293344",
+     "start_time": "2026-06-10T14:02:24.155293",
      "status": "completed"
     },
     "tags": []
@@ -1186,10 +1193,10 @@
    "id": "15fc8c86",
    "metadata": {
     "papermill": {
-     "duration": 0.006934,
-     "end_time": "2026-06-10T11:11:05.333564",
+     "duration": 0.007071,
+     "end_time": "2026-06-10T14:02:24.197368",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.326630",
+     "start_time": "2026-06-10T14:02:24.190297",
      "status": "completed"
     },
     "tags": []
@@ -1216,10 +1223,10 @@
    "id": "ccca7f32",
    "metadata": {
     "papermill": {
-     "duration": 0.00669,
-     "end_time": "2026-06-10T11:11:05.347309",
+     "duration": 0.007329,
+     "end_time": "2026-06-10T14:02:24.212501",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.340619",
+     "start_time": "2026-06-10T14:02:24.205172",
      "status": "completed"
     },
     "tags": []
@@ -1238,16 +1245,16 @@
    "id": "c68c743e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.363889Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.362884Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.380358Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.379259Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.228341Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.228341Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.243359Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.242268Z"
     },
     "papermill": {
-     "duration": 0.026575,
-     "end_time": "2026-06-10T11:11:05.381432",
+     "duration": 0.024922,
+     "end_time": "2026-06-10T14:02:24.243877",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.354857",
+     "start_time": "2026-06-10T14:02:24.218955",
      "status": "completed"
     },
     "tags": []
@@ -1385,10 +1392,10 @@
    "id": "de22cbc0",
    "metadata": {
     "papermill": {
-     "duration": 0.007466,
-     "end_time": "2026-06-10T11:11:05.396227",
+     "duration": 0.008962,
+     "end_time": "2026-06-10T14:02:24.260131",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.388761",
+     "start_time": "2026-06-10T14:02:24.251169",
      "status": "completed"
     },
     "tags": []
@@ -1415,10 +1422,10 @@
    "id": "f98934d2",
    "metadata": {
     "papermill": {
-     "duration": 0.006956,
-     "end_time": "2026-06-10T11:11:05.410104",
+     "duration": 0.007151,
+     "end_time": "2026-06-10T14:02:24.274883",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.403148",
+     "start_time": "2026-06-10T14:02:24.267732",
      "status": "completed"
     },
     "tags": []
@@ -1441,16 +1448,16 @@
    "id": "0ff352e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.425857Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.425857Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.439477Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.439477Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.291423Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.291423Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.305296Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.304715Z"
     },
     "papermill": {
-     "duration": 0.024064,
-     "end_time": "2026-06-10T11:11:05.441475",
+     "duration": 0.023915,
+     "end_time": "2026-06-10T14:02:24.306445",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.417411",
+     "start_time": "2026-06-10T14:02:24.282530",
      "status": "completed"
     },
     "tags": []
@@ -1496,10 +1503,10 @@
    "id": "ce6eb73f",
    "metadata": {
     "papermill": {
-     "duration": 0.006876,
-     "end_time": "2026-06-10T11:11:05.455229",
+     "duration": 0.007721,
+     "end_time": "2026-06-10T14:02:24.321719",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.448353",
+     "start_time": "2026-06-10T14:02:24.313998",
      "status": "completed"
     },
     "tags": []
@@ -1516,16 +1523,16 @@
    "id": "ad095fa3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.469884Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.469884Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.486258Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.485167Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.338287Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.338287Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.353871Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.352347Z"
     },
     "papermill": {
-     "duration": 0.025316,
-     "end_time": "2026-06-10T11:11:05.487333",
+     "duration": 0.024739,
+     "end_time": "2026-06-10T14:02:24.353871",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.462017",
+     "start_time": "2026-06-10T14:02:24.329132",
      "status": "completed"
     },
     "tags": []
@@ -1588,10 +1595,10 @@
    "id": "0ec254c5",
    "metadata": {
     "papermill": {
-     "duration": 0.006627,
-     "end_time": "2026-06-10T11:11:05.501838",
+     "duration": 0.0083,
+     "end_time": "2026-06-10T14:02:24.370659",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.495211",
+     "start_time": "2026-06-10T14:02:24.362359",
      "status": "completed"
     },
     "tags": []
@@ -1614,10 +1621,10 @@
    "id": "92096025",
    "metadata": {
     "papermill": {
-     "duration": 0.006803,
-     "end_time": "2026-06-10T11:11:05.515748",
+     "duration": 0.007167,
+     "end_time": "2026-06-10T14:02:24.384950",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.508945",
+     "start_time": "2026-06-10T14:02:24.377783",
      "status": "completed"
     },
     "tags": []
@@ -1659,16 +1666,16 @@
    "id": "927a1be6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.531765Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.531238Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.561165Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.560559Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.402425Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.402425Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.433781Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.432166Z"
     },
     "papermill": {
-     "duration": 0.039083,
-     "end_time": "2026-06-10T11:11:05.562217",
+     "duration": 0.041257,
+     "end_time": "2026-06-10T14:02:24.434779",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.523134",
+     "start_time": "2026-06-10T14:02:24.393522",
      "status": "completed"
     },
     "tags": []
@@ -1734,10 +1741,10 @@
    "id": "2c82c885",
    "metadata": {
     "papermill": {
-     "duration": 0.007278,
-     "end_time": "2026-06-10T11:11:05.577348",
+     "duration": 0.005312,
+     "end_time": "2026-06-10T14:02:24.447629",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.570070",
+     "start_time": "2026-06-10T14:02:24.442317",
      "status": "completed"
     },
     "tags": []
@@ -1777,10 +1784,10 @@
    "id": "affee29e",
    "metadata": {
     "papermill": {
-     "duration": 0.006832,
-     "end_time": "2026-06-10T11:11:05.592025",
+     "duration": 0.008584,
+     "end_time": "2026-06-10T14:02:24.463844",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.585193",
+     "start_time": "2026-06-10T14:02:24.455260",
      "status": "completed"
     },
     "tags": []
@@ -1798,10 +1805,10 @@
    "id": "23cff9a5",
    "metadata": {
     "papermill": {
-     "duration": 0.006542,
-     "end_time": "2026-06-10T11:11:05.605536",
+     "duration": 0.007285,
+     "end_time": "2026-06-10T14:02:24.478927",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.598994",
+     "start_time": "2026-06-10T14:02:24.471642",
      "status": "completed"
     },
     "tags": []
@@ -1818,16 +1825,16 @@
    "id": "d1ecd1cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.621590Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.621590Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.637828Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.637261Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.495788Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.495788Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.510968Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.510461Z"
     },
     "papermill": {
-     "duration": 0.025418,
-     "end_time": "2026-06-10T11:11:05.638882",
+     "duration": 0.025838,
+     "end_time": "2026-06-10T14:02:24.512487",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.613464",
+     "start_time": "2026-06-10T14:02:24.486649",
      "status": "completed"
     },
     "tags": []
@@ -1863,10 +1870,10 @@
    "id": "1266c022",
    "metadata": {
     "papermill": {
-     "duration": 0.006232,
-     "end_time": "2026-06-10T11:11:05.652403",
+     "duration": 0.006513,
+     "end_time": "2026-06-10T14:02:24.527262",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.646171",
+     "start_time": "2026-06-10T14:02:24.520749",
      "status": "completed"
     },
     "tags": []
@@ -1890,10 +1897,10 @@
    "id": "e767a280",
    "metadata": {
     "papermill": {
-     "duration": 0.007293,
-     "end_time": "2026-06-10T11:11:05.667022",
+     "duration": 0.008152,
+     "end_time": "2026-06-10T14:02:24.544255",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.659729",
+     "start_time": "2026-06-10T14:02:24.536103",
      "status": "completed"
     },
     "tags": []
@@ -1915,16 +1922,16 @@
    "id": "f2c3a922",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.682681Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.681686Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.699050Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.698044Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.562753Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.561746Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.573420Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.572791Z"
     },
     "papermill": {
-     "duration": 0.025575,
-     "end_time": "2026-06-10T11:11:05.700050",
+     "duration": 0.022648,
+     "end_time": "2026-06-10T14:02:24.574424",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.674475",
+     "start_time": "2026-06-10T14:02:24.551776",
      "status": "completed"
     },
     "tags": []
@@ -1956,10 +1963,10 @@
    "id": "4bfff412",
    "metadata": {
     "papermill": {
-     "duration": 0.008276,
-     "end_time": "2026-06-10T11:11:05.718589",
+     "duration": 0.007822,
+     "end_time": "2026-06-10T14:02:24.588614",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.710313",
+     "start_time": "2026-06-10T14:02:24.580792",
      "status": "completed"
     },
     "tags": []
@@ -1976,16 +1983,16 @@
    "id": "883aa023",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.734047Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.733047Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.744632Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.744061Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.606118Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.606118Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.621230Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.619660Z"
     },
     "papermill": {
-     "duration": 0.018714,
-     "end_time": "2026-06-10T11:11:05.744632",
+     "duration": 0.025547,
+     "end_time": "2026-06-10T14:02:24.621748",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.725918",
+     "start_time": "2026-06-10T14:02:24.596201",
      "status": "completed"
     },
     "tags": []
@@ -2026,10 +2033,10 @@
    "id": "a483cb1cf590",
    "metadata": {
     "papermill": {
-     "duration": 0.006507,
-     "end_time": "2026-06-10T11:11:05.758143",
+     "duration": 0.008883,
+     "end_time": "2026-06-10T14:02:24.638696",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.751636",
+     "start_time": "2026-06-10T14:02:24.629813",
      "status": "completed"
     },
     "tags": []
@@ -2048,16 +2055,16 @@
    "id": "a66db8dd23f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:05.773259Z",
-     "iopub.status.busy": "2026-06-10T11:11:05.773259Z",
-     "iopub.status.idle": "2026-06-10T11:11:05.775769Z",
-     "shell.execute_reply": "2026-06-10T11:11:05.775769Z"
+     "iopub.execute_input": "2026-06-10T14:02:24.656496Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.656496Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.667813Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.666780Z"
     },
     "papermill": {
-     "duration": 0.0113,
-     "end_time": "2026-06-10T11:11:05.776368",
+     "duration": 0.022875,
+     "end_time": "2026-06-10T14:02:24.668819",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.765068",
+     "start_time": "2026-06-10T14:02:24.645944",
      "status": "completed"
     },
     "tags": []
@@ -2084,10 +2091,10 @@
    "id": "ec85b3dd",
    "metadata": {
     "papermill": {
-     "duration": 0.003992,
-     "end_time": "2026-06-10T11:11:05.787372",
+     "duration": 0.008292,
+     "end_time": "2026-06-10T14:02:24.685289",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.783380",
+     "start_time": "2026-06-10T14:02:24.676997",
      "status": "completed"
     },
     "tags": []
@@ -2109,10 +2116,10 @@
    "id": "b7e4d1a9",
    "metadata": {
     "papermill": {
-     "duration": 0.003004,
-     "end_time": "2026-06-10T11:11:05.796273",
+     "duration": 0.007526,
+     "end_time": "2026-06-10T14:02:24.700320",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.793269",
+     "start_time": "2026-06-10T14:02:24.692794",
      "status": "completed"
     },
     "tags": []
@@ -2131,13 +2138,89 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8c843445",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008911,
+     "end_time": "2026-06-10T14:02:24.717517",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:24.708606",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 5 : La consistance sans Occam (aima-python)\n",
+    "\n",
+    "La section 9 a montre que `current_best_learning` est **stochastique** (shuffle\n",
+    "interne) et **sans biais de simplicite** : il retourne la premiere hypothese\n",
+    "consistante trouvee. Transformez ces deux observations en mesure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ef84c058",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T14:02:24.734456Z",
+     "iopub.status.busy": "2026-06-10T14:02:24.734456Z",
+     "iopub.status.idle": "2026-06-10T14:02:24.747474Z",
+     "shell.execute_reply": "2026-06-10T14:02:24.746471Z"
+    },
+    "papermill": {
+     "duration": 0.023945,
+     "end_time": "2026-06-10T14:02:24.748476",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:24.724531",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 5 : La consistance sans Occam\n",
+    "# TODO etudiant : echantillonnez la recherche stochastique de current_best_learning\n",
+    "# (section 9) sur 20 graines et mesurez la taille des hypotheses obtenues.\n",
+    "# Etape 1 : pour seed in range(20) : random.seed(seed), relancez\n",
+    "#           current_best_learning(aima_examples, initial_h) et stockez\n",
+    "#           (seed, len(h), sum(len(d) for d in h))  # disjonctions, contraintes\n",
+    "# Etape 2 : verifiez que CHAQUE hypothese reste a 12/12 d'accuracy (guess_value).\n",
+    "# Etape 3 : affichez la distribution des tailles (min, max, moyenne) et\n",
+    "#           l'hypothese la plus compacte trouvee.\n",
+    "# Etape 4 : toutes sont consistantes, aucune n'est privilegiee : quel critere\n",
+    "#           le rasoir d'Occam ajouterait-il, et lequel de nos algorithmes du\n",
+    "#           notebook (CBH, Version Space) l'implemente... ou pas ?\n",
+    "# Indice : initial_h depend du premier positif, il ne change pas d'une graine\n",
+    "#          a l'autre ; seule la recherche (shuffle des candidats) change.\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a464171c",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T11:11:05.804273",
+     "duration": 0.008523,
+     "end_time": "2026-06-10T14:02:24.766014",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.800273",
+     "start_time": "2026-06-10T14:02:24.757491",
      "status": "completed"
     },
     "tags": []
@@ -2175,10 +2258,10 @@
    "id": "410e5149",
    "metadata": {
     "papermill": {
-     "duration": 0.004017,
-     "end_time": "2026-06-10T11:11:05.812299",
+     "duration": 0.007513,
+     "end_time": "2026-06-10T14:02:24.782546",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.808282",
+     "start_time": "2026-06-10T14:02:24.775033",
      "status": "completed"
     },
     "tags": []
@@ -2195,7 +2278,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "315ebc46",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00952,
+     "end_time": "2026-06-10T14:02:24.799099",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:24.789579",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -2211,7 +2304,8 @@
     "| **Ex. 1 (CBH, ordre personnalise)** | Montrez deux ordres de presentation des exemples qui menent le CBH a des hypotheses finales differentes, puis changez la graine `random.seed(42)` de la section 9 (AIMA) : pourquoi l'hypothese change-t-elle alors que l'accuracy reste 12/12 ? |\n",
     "| **Ex. 2 (Version Space, sous-ensemble)** | Sur votre sous-ensemble, identifiez l'exemple dont l'ajout reduit le plus le Version Space. Qu'est-ce qui rend un exemple *informatif* (raisonnez avec les frontieres S et G) ? |\n",
     "| **Ex. 3 (regles avec couverture)** | Comparez vos regles a l'hypothese disjonctive AIMA de la section 9 : laquelle est la plus compacte ? Quel biais (rasoir d'Occam) ferait preferer l'une a l'autre, et lequel des deux algorithmes l'implemente ? |\n",
-    "| **Ex. 4 (reflexion)** | Donnez un domaine concret ou le biais conjonctif de ce notebook est le bon choix, et un ou il est catastrophique. Reliez votre reponse au theoreme *no free lunch*. |\n"
+    "| **Ex. 4 (reflexion)** | Donnez un domaine concret ou le biais conjonctif de ce notebook est le bon choix, et un ou il est catastrophique. Reliez votre reponse au theoreme *no free lunch*. |\n",
+    "| **Ex. 5 (consistance sans Occam)** | La section 8 prouve qu'aucune conjonction unique n'est consistante : la borne inferieure est donc 2 disjonctions. Votre echantillonnage de graines l'atteint-il ? Pourquoi un echantillonnage ne prouve jamais la minimalite, et quel type d'algorithme (exact, a la Popper de SL-4) fournirait ce certificat ? |\n"
    ]
   },
   {
@@ -2219,10 +2313,10 @@
    "id": "902a1f86",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T11:11:05.820303",
+     "duration": 0.008518,
+     "end_time": "2026-06-10T14:02:24.815631",
      "exception": false,
-     "start_time": "2026-06-10T11:11:05.816303",
+     "start_time": "2026-06-10T14:02:24.807113",
      "status": "completed"
     },
     "tags": []
@@ -2267,14 +2361,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.686484,
-   "end_time": "2026-06-10T11:11:06.067694",
+   "duration": 2.824695,
+   "end_time": "2026-06-10T14:02:25.046923",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-1-LogicalLearning.ipynb",
    "output_path": "SL-1-LogicalLearning.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T11:11:03.381210",
+   "start_time": "2026-06-10T14:02:22.222228",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
@@ -5,10 +5,10 @@
    "id": "266f89ed",
    "metadata": {
     "papermill": {
-     "duration": 0.003936,
-     "end_time": "2026-06-10T13:18:41.945398",
+     "duration": 0.004139,
+     "end_time": "2026-06-10T14:02:26.163241",
      "exception": false,
-     "start_time": "2026-06-10T13:18:41.941462",
+     "start_time": "2026-06-10T14:02:26.159102",
      "status": "completed"
     },
     "tags": []
@@ -42,16 +42,16 @@
    "id": "06eb2d41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:41.955811Z",
-     "iopub.status.busy": "2026-06-10T13:18:41.955638Z",
-     "iopub.status.idle": "2026-06-10T13:18:41.959652Z",
-     "shell.execute_reply": "2026-06-10T13:18:41.958856Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.171944Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.171661Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.176277Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.175425Z"
     },
     "papermill": {
-     "duration": 0.009144,
-     "end_time": "2026-06-10T13:18:41.957359",
+     "duration": 0.013219,
+     "end_time": "2026-06-10T14:02:26.180164",
      "exception": false,
-     "start_time": "2026-06-10T13:18:41.948215",
+     "start_time": "2026-06-10T14:02:26.166945",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "5136dc92",
    "metadata": {
     "papermill": {
-     "duration": 0.003002,
-     "end_time": "2026-06-10T13:18:41.963360",
+     "duration": 0.005793,
+     "end_time": "2026-06-10T14:02:26.191691",
      "exception": false,
-     "start_time": "2026-06-10T13:18:41.960358",
+     "start_time": "2026-06-10T14:02:26.185898",
      "status": "completed"
     },
     "tags": []
@@ -142,10 +142,10 @@
    "id": "934f66f1",
    "metadata": {
     "papermill": {
-     "duration": 0.003442,
-     "end_time": "2026-06-10T13:18:41.970352",
+     "duration": 0.00465,
+     "end_time": "2026-06-10T14:02:26.199476",
      "exception": false,
-     "start_time": "2026-06-10T13:18:41.966910",
+     "start_time": "2026-06-10T14:02:26.194826",
      "status": "completed"
     },
     "tags": []
@@ -177,16 +177,16 @@
    "id": "4bc27cf5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:41.980784Z",
-     "iopub.status.busy": "2026-06-10T13:18:41.980622Z",
-     "iopub.status.idle": "2026-06-10T13:18:41.989606Z",
-     "shell.execute_reply": "2026-06-10T13:18:41.988790Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.210331Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.210141Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.220757Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.219638Z"
     },
     "papermill": {
-     "duration": 0.01396,
-     "end_time": "2026-06-10T13:18:41.988062",
+     "duration": 0.01902,
+     "end_time": "2026-06-10T14:02:26.224295",
      "exception": false,
-     "start_time": "2026-06-10T13:18:41.974102",
+     "start_time": "2026-06-10T14:02:26.205275",
      "status": "completed"
     },
     "tags": []
@@ -350,10 +350,10 @@
    "id": "bcb1f969",
    "metadata": {
     "papermill": {
-     "duration": 0.002998,
-     "end_time": "2026-06-10T13:18:41.994442",
+     "duration": 0.005789,
+     "end_time": "2026-06-10T14:02:26.236615",
      "exception": false,
-     "start_time": "2026-06-10T13:18:41.991444",
+     "start_time": "2026-06-10T14:02:26.230826",
      "status": "completed"
     },
     "tags": []
@@ -377,10 +377,10 @@
    "id": "cec859d5",
    "metadata": {
     "papermill": {
-     "duration": 0.004517,
-     "end_time": "2026-06-10T13:18:42.002059",
+     "duration": 0.006247,
+     "end_time": "2026-06-10T14:02:26.249054",
      "exception": false,
-     "start_time": "2026-06-10T13:18:41.997542",
+     "start_time": "2026-06-10T14:02:26.242807",
      "status": "completed"
     },
     "tags": []
@@ -422,16 +422,16 @@
    "id": "bad9e00d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.016952Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.016741Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.023960Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.023003Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.259669Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.259484Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.266039Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.265277Z"
     },
     "papermill": {
-     "duration": 0.014745,
-     "end_time": "2026-06-10T13:18:42.022448",
+     "duration": 0.014105,
+     "end_time": "2026-06-10T14:02:26.269471",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.007703",
+     "start_time": "2026-06-10T14:02:26.255366",
      "status": "completed"
     },
     "tags": []
@@ -551,10 +551,10 @@
    "id": "15c74a56",
    "metadata": {
     "papermill": {
-     "duration": 0.005438,
-     "end_time": "2026-06-10T13:18:42.033525",
+     "duration": 0.006758,
+     "end_time": "2026-06-10T14:02:26.280935",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.028087",
+     "start_time": "2026-06-10T14:02:26.274177",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "2c67b535",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.049030Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.048778Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.055519Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.054093Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.292199Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.292017Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.296867Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.295941Z"
     },
     "papermill": {
-     "duration": 0.015756,
-     "end_time": "2026-06-10T13:18:42.053788",
+     "duration": 0.01275,
+     "end_time": "2026-06-10T14:02:26.300144",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.038032",
+     "start_time": "2026-06-10T14:02:26.287394",
      "status": "completed"
     },
     "tags": []
@@ -654,10 +654,10 @@
    "id": "a621e158",
    "metadata": {
     "papermill": {
-     "duration": 0.003648,
-     "end_time": "2026-06-10T13:18:42.063097",
+     "duration": 0.007311,
+     "end_time": "2026-06-10T14:02:26.315199",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.059449",
+     "start_time": "2026-06-10T14:02:26.307888",
      "status": "completed"
     },
     "tags": []
@@ -672,16 +672,16 @@
    "id": "a3200acb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.077307Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.077040Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.086295Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.084922Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.327519Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.327335Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.334427Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.333612Z"
     },
     "papermill": {
-     "duration": 0.017341,
-     "end_time": "2026-06-10T13:18:42.085362",
+     "duration": 0.015581,
+     "end_time": "2026-06-10T14:02:26.337540",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.068021",
+     "start_time": "2026-06-10T14:02:26.321959",
      "status": "completed"
     },
     "tags": []
@@ -808,10 +808,10 @@
    "id": "f1ebd7f3",
    "metadata": {
     "papermill": {
-     "duration": 0.005842,
-     "end_time": "2026-06-10T13:18:42.097006",
+     "duration": 0.005004,
+     "end_time": "2026-06-10T14:02:26.349223",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.091164",
+     "start_time": "2026-06-10T14:02:26.344219",
      "status": "completed"
     },
     "tags": []
@@ -839,10 +839,10 @@
    "id": "0630919b",
    "metadata": {
     "papermill": {
-     "duration": 0.006316,
-     "end_time": "2026-06-10T13:18:42.108027",
+     "duration": 0.005,
+     "end_time": "2026-06-10T14:02:26.358732",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.101711",
+     "start_time": "2026-06-10T14:02:26.353732",
      "status": "completed"
     },
     "tags": []
@@ -877,16 +877,16 @@
    "id": "e1385825",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.124327Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.124087Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.133656Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.132117Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.371162Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.370978Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.378442Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.377687Z"
     },
     "papermill": {
-     "duration": 0.018675,
-     "end_time": "2026-06-10T13:18:42.132669",
+     "duration": 0.016103,
+     "end_time": "2026-06-10T14:02:26.381854",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.113994",
+     "start_time": "2026-06-10T14:02:26.365751",
      "status": "completed"
     },
     "tags": []
@@ -1044,10 +1044,10 @@
    "id": "f4c90f47",
    "metadata": {
     "papermill": {
-     "duration": 0.004077,
-     "end_time": "2026-06-10T13:18:42.142993",
+     "duration": 0.006999,
+     "end_time": "2026-06-10T14:02:26.397882",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.138916",
+     "start_time": "2026-06-10T14:02:26.390883",
      "status": "completed"
     },
     "tags": []
@@ -1070,10 +1070,10 @@
    "id": "65c8458f",
    "metadata": {
     "papermill": {
-     "duration": 0.006614,
-     "end_time": "2026-06-10T13:18:42.154882",
+     "duration": 0.007078,
+     "end_time": "2026-06-10T14:02:26.410482",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.148268",
+     "start_time": "2026-06-10T14:02:26.403404",
      "status": "completed"
     },
     "tags": []
@@ -1092,16 +1092,16 @@
    "id": "474df76d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.171782Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.171535Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.189741Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.188306Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.422302Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.422114Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.435099Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.434014Z"
     },
     "papermill": {
-     "duration": 0.027132,
-     "end_time": "2026-06-10T13:18:42.188629",
+     "duration": 0.022687,
+     "end_time": "2026-06-10T14:02:26.439169",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.161497",
+     "start_time": "2026-06-10T14:02:26.416482",
      "status": "completed"
     },
     "tags": []
@@ -1279,10 +1279,10 @@
    "id": "824ba714",
    "metadata": {
     "papermill": {
-     "duration": 0.005775,
-     "end_time": "2026-06-10T13:18:42.200851",
+     "duration": 0.004,
+     "end_time": "2026-06-10T14:02:26.449387",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.195076",
+     "start_time": "2026-06-10T14:02:26.445387",
      "status": "completed"
     },
     "tags": []
@@ -1325,10 +1325,10 @@
    "id": "da423029",
    "metadata": {
     "papermill": {
-     "duration": 0.005775,
-     "end_time": "2026-06-10T13:18:42.212475",
+     "duration": 0.006023,
+     "end_time": "2026-06-10T14:02:26.461918",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.206700",
+     "start_time": "2026-06-10T14:02:26.455895",
      "status": "completed"
     },
     "tags": []
@@ -1365,16 +1365,16 @@
    "id": "d4641c82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.229724Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.229449Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.236614Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.235551Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.470982Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.470776Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.476429Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.475678Z"
     },
     "papermill": {
-     "duration": 0.016479,
-     "end_time": "2026-06-10T13:18:42.235310",
+     "duration": 0.012955,
+     "end_time": "2026-06-10T14:02:26.480865",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.218831",
+     "start_time": "2026-06-10T14:02:26.467910",
      "status": "completed"
     },
     "tags": []
@@ -1405,18 +1405,18 @@
       "\n",
       "2. Transitivite de localisation :\n",
       "   livesIn(X, Z) :- livesIn(X, Y), locatedIn(Y, Z).\n",
-      "   Diana livesIn Paris, Paris locatedIn France => Diana livesIn France [IMPLICITE (infere)]\n",
-      "   Alice livesIn Paris, Paris locatedIn France => Alice livesIn France [IMPLICITE (infere)]\n",
       "   Charlie livesIn Lyon, Lyon locatedIn France => Charlie livesIn France [IMPLICITE (infere)]\n",
       "   Bob livesIn Paris, Paris locatedIn France => Bob livesIn France [IMPLICITE (infere)]\n",
+      "   Diana livesIn Paris, Paris locatedIn France => Diana livesIn France [IMPLICITE (infere)]\n",
+      "   Alice livesIn Paris, Paris locatedIn France => Alice livesIn France [IMPLICITE (infere)]\n",
       "   Total inferences possibles : 4\n",
       "\n",
       "3. Co-residence des epoux :\n",
       "   livesIn(X, L) :- marriedTo(X, Y), livesIn(Y, L).\n",
+      "   Bob marriedTo Alice, Alice livesIn Paris => Bob livesIn Paris [EXPLICITE]\n",
+      "   Diana marriedTo Charlie, Charlie livesIn Lyon => Diana livesIn Lyon [NON VERIFIE]\n",
       "   Charlie marriedTo Diana, Diana livesIn Paris => Charlie livesIn Paris [NON VERIFIE]\n",
       "   Alice marriedTo Bob, Bob livesIn Paris => Alice livesIn Paris [EXPLICITE]\n",
-      "   Diana marriedTo Charlie, Charlie livesIn Lyon => Diana livesIn Lyon [NON VERIFIE]\n",
-      "   Bob marriedTo Alice, Alice livesIn Paris => Bob livesIn Paris [EXPLICITE]\n",
       "   Total inferences : 4\n"
      ]
     }
@@ -1492,10 +1492,10 @@
    "id": "3e601ecb",
    "metadata": {
     "papermill": {
-     "duration": 0.00574,
-     "end_time": "2026-06-10T13:18:42.247394",
+     "duration": 0.006012,
+     "end_time": "2026-06-10T14:02:26.497577",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.241654",
+     "start_time": "2026-06-10T14:02:26.491565",
      "status": "completed"
     },
     "tags": []
@@ -1519,10 +1519,10 @@
    "id": "d5be334e",
    "metadata": {
     "papermill": {
-     "duration": 0.006109,
-     "end_time": "2026-06-10T13:18:42.259860",
+     "duration": 0.007041,
+     "end_time": "2026-06-10T14:02:26.511619",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.253751",
+     "start_time": "2026-06-10T14:02:26.504578",
      "status": "completed"
     },
     "tags": []
@@ -1536,10 +1536,10 @@
    "id": "77f0ac97",
    "metadata": {
     "papermill": {
-     "duration": 0.006289,
-     "end_time": "2026-06-10T13:18:42.272605",
+     "duration": 0.005489,
+     "end_time": "2026-06-10T14:02:26.522732",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.266316",
+     "start_time": "2026-06-10T14:02:26.517243",
      "status": "completed"
     },
     "tags": []
@@ -1576,16 +1576,16 @@
    "id": "8022039d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.286599Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.286361Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.302677Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.301195Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.530905Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.530729Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.543955Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.542420Z"
     },
     "papermill": {
-     "duration": 0.023998,
-     "end_time": "2026-06-10T13:18:42.300826",
+     "duration": 0.018797,
+     "end_time": "2026-06-10T14:02:26.546803",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.276828",
+     "start_time": "2026-06-10T14:02:26.528006",
      "status": "completed"
     },
     "tags": []
@@ -1596,7 +1596,13 @@
      "output_type": "stream",
      "text": [
       "Python : 3.12.3 (Linux)\n",
-      "swipl  : /usr/bin/swipl\n",
+      "swipl  : /usr/bin/swipl\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "clingo : 5.8.0\n",
       "Popper : v4.4.0 -- pret\n"
      ]
@@ -1636,16 +1642,16 @@
    "id": "878ee645",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.318483Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.318238Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.580873Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.580128Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.559397Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.559195Z",
+     "iopub.status.idle": "2026-06-10T14:02:26.836171Z",
+     "shell.execute_reply": "2026-06-10T14:02:26.834616Z"
     },
     "papermill": {
-     "duration": 0.27129,
-     "end_time": "2026-06-10T13:18:42.579354",
+     "duration": 0.285674,
+     "end_time": "2026-06-10T14:02:26.840144",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.308064",
+     "start_time": "2026-06-10T14:02:26.554470",
      "status": "completed"
     },
     "tags": []
@@ -1657,8 +1663,8 @@
      "text": [
       "Programme appris par Popper :\n",
       "\n",
-      "ancestor(V0,V1):- parent(V0,V2),ancestor(V2,V1).\n",
       "ancestor(V0,V1):- parent(V0,V1).\n",
+      "ancestor(V0,V1):- parent(V0,V2),ancestor(V2,V1).\n",
       "\n",
       "Score : 9 tp, 0 fn, 10 tn, 0 fp -- taille 5 litteraux\n"
      ]
@@ -1722,16 +1728,16 @@
    "id": "bacc8d6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.595338Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.595195Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.813849Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.812949Z"
+     "iopub.execute_input": "2026-06-10T14:02:26.852109Z",
+     "iopub.status.busy": "2026-06-10T14:02:26.851836Z",
+     "iopub.status.idle": "2026-06-10T14:02:27.214329Z",
+     "shell.execute_reply": "2026-06-10T14:02:27.212815Z"
     },
     "papermill": {
-     "duration": 0.226125,
-     "end_time": "2026-06-10T13:18:42.812243",
+     "duration": 0.371669,
+     "end_time": "2026-06-10T14:02:27.218986",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.586118",
+     "start_time": "2026-06-10T14:02:26.847317",
      "status": "completed"
     },
     "tags": []
@@ -1743,9 +1749,9 @@
      "text": [
       "Sans enable_recursion :\n",
       "\n",
+      "ancestor(V0,V1):- parent(V2,V1),parent(V3,V2),parent(V0,V3).\n",
+      "ancestor(V0,V1):- parent(V0,V2),parent(V2,V1).\n",
       "ancestor(V0,V1):- parent(V0,V1).\n",
-      "ancestor(V0,V1):- parent(V3,V2),parent(V0,V3),parent(V2,V1).\n",
-      "ancestor(V0,V1):- parent(V2,V1),parent(V0,V2).\n",
       "\n",
       "Score : 9 tp, 0 fn, 10 tn, 0 fp -- taille 9 litteraux\n",
       "\n",
@@ -1788,10 +1794,10 @@
    "id": "eb7b46ef",
    "metadata": {
     "papermill": {
-     "duration": 0.004012,
-     "end_time": "2026-06-10T13:18:42.819764",
+     "duration": 0.007042,
+     "end_time": "2026-06-10T14:02:27.233962",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.815752",
+     "start_time": "2026-06-10T14:02:27.226920",
      "status": "completed"
     },
     "tags": []
@@ -1835,10 +1841,10 @@
    "id": "18e8e42f",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-06-10T13:18:42.828769",
+     "duration": 0.007601,
+     "end_time": "2026-06-10T14:02:27.247688",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.824770",
+     "start_time": "2026-06-10T14:02:27.240087",
      "status": "completed"
     },
     "tags": []
@@ -1865,16 +1871,16 @@
    "id": "4e6e75a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.840591Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.840437Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.843476Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.842740Z"
+     "iopub.execute_input": "2026-06-10T14:02:27.259900Z",
+     "iopub.status.busy": "2026-06-10T14:02:27.259621Z",
+     "iopub.status.idle": "2026-06-10T14:02:27.264210Z",
+     "shell.execute_reply": "2026-06-10T14:02:27.263002Z"
     },
     "papermill": {
-     "duration": 0.009409,
-     "end_time": "2026-06-10T13:18:42.842178",
+     "duration": 0.014741,
+     "end_time": "2026-06-10T14:02:27.269153",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.832769",
+     "start_time": "2026-06-10T14:02:27.254412",
      "status": "completed"
     },
     "tags": []
@@ -1914,10 +1920,10 @@
    "id": "d5bb07b4",
    "metadata": {
     "papermill": {
-     "duration": 0.004508,
-     "end_time": "2026-06-10T13:18:42.850686",
+     "duration": 0.007882,
+     "end_time": "2026-06-10T14:02:27.283555",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.846178",
+     "start_time": "2026-06-10T14:02:27.275673",
      "status": "completed"
     },
     "tags": []
@@ -1932,16 +1938,16 @@
    "id": "498d3825",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.865309Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.865147Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.869387Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.868318Z"
+     "iopub.execute_input": "2026-06-10T14:02:27.296134Z",
+     "iopub.status.busy": "2026-06-10T14:02:27.295865Z",
+     "iopub.status.idle": "2026-06-10T14:02:27.300210Z",
+     "shell.execute_reply": "2026-06-10T14:02:27.299004Z"
     },
     "papermill": {
-     "duration": 0.012233,
-     "end_time": "2026-06-10T13:18:42.867783",
+     "duration": 0.013301,
+     "end_time": "2026-06-10T14:02:27.304374",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.855550",
+     "start_time": "2026-06-10T14:02:27.291073",
      "status": "completed"
     },
     "tags": []
@@ -1978,10 +1984,10 @@
    "id": "403bc426",
    "metadata": {
     "papermill": {
-     "duration": 0.004998,
-     "end_time": "2026-06-10T13:18:42.876919",
+     "duration": 0.007328,
+     "end_time": "2026-06-10T14:02:27.319122",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.871921",
+     "start_time": "2026-06-10T14:02:27.311794",
      "status": "completed"
     },
     "tags": []
@@ -1996,16 +2002,16 @@
    "id": "fa814830",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T13:18:42.894282Z",
-     "iopub.status.busy": "2026-06-10T13:18:42.894128Z",
-     "iopub.status.idle": "2026-06-10T13:18:42.897736Z",
-     "shell.execute_reply": "2026-06-10T13:18:42.896831Z"
+     "iopub.execute_input": "2026-06-10T14:02:27.330755Z",
+     "iopub.status.busy": "2026-06-10T14:02:27.330565Z",
+     "iopub.status.idle": "2026-06-10T14:02:27.334530Z",
+     "shell.execute_reply": "2026-06-10T14:02:27.333701Z"
     },
     "papermill": {
-     "duration": 0.01198,
-     "end_time": "2026-06-10T13:18:42.895942",
+     "duration": 0.014165,
+     "end_time": "2026-06-10T14:02:27.339047",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.883962",
+     "start_time": "2026-06-10T14:02:27.324882",
      "status": "completed"
     },
     "tags": []
@@ -2061,10 +2067,10 @@
    "id": "d7fb32ee",
    "metadata": {
     "papermill": {
-     "duration": 0.00772,
-     "end_time": "2026-06-10T13:18:42.910147",
+     "duration": 0.007607,
+     "end_time": "2026-06-10T14:02:27.354341",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.902427",
+     "start_time": "2026-06-10T14:02:27.346734",
      "status": "completed"
     },
     "tags": []
@@ -2110,13 +2116,86 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0762f5f5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007281,
+     "end_time": "2026-06-10T14:02:27.368964",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:27.361683",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : grandparent avec Popper\n",
+    "\n",
+    "La section Popper a appris `ancestor/2` (recursif). A vous d'apprendre\n",
+    "`grandparent/2` (non recursif) avec la meme machinerie `run_popper`, sur la\n",
+    "meme famille."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "972eb4bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T14:02:27.378696Z",
+     "iopub.status.busy": "2026-06-10T14:02:27.378519Z",
+     "iopub.status.idle": "2026-06-10T14:02:27.382740Z",
+     "shell.execute_reply": "2026-06-10T14:02:27.381786Z"
+    },
+    "papermill": {
+     "duration": 0.012578,
+     "end_time": "2026-06-10T14:02:27.387375",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:27.374797",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : grandparent avec Popper\n",
+    "# TODO etudiant : faites apprendre grandparent(X, Y) a Popper a partir des memes\n",
+    "# faits parent que la section Popper, et verifiez le programme appris en Prolog.\n",
+    "# Etape 1 : definissez GP_POS (les paires grand-parent de la famille) et GP_NEG\n",
+    "#           (paires variees : parents directs, arriere-grands-parents, inverses).\n",
+    "# Etape 2 : construisez un repertoire de tache comme la cellule Popper :\n",
+    "#           bk.pl identique, exs.pl avec pos(grandparent(...))/neg(grandparent(...)),\n",
+    "#           bias.pl : max_vars(3). max_body(2). max_clauses(1).\n",
+    "#                     head_pred(grandparent,2). body_pred(parent,2).\n",
+    "#           (pas de enable_recursion : grandparent n'en a pas besoin)\n",
+    "# Etape 3 : result_gp = run_popper(task_gp) ; affichez programme + score.\n",
+    "# Etape 4 : verifiez avec janus (cf. cellule ablation) que le programme derive\n",
+    "#           exactement GP_POS et aucun GP_NEG.\n",
+    "# Indice : si Popper retourne un programme errone trop general, regardez vos\n",
+    "#          negatifs : couvrent-ils la frontiere (arriere-grands-parents) ?\n",
+    "\n",
+    "if HAS_POPPER:\n",
+    "    print(\"Exercice a completer\")\n",
+    "else:\n",
+    "    print(\"Popper indisponible : exercice a faire sur le kernel python3-wsl.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fc9bb0dd",
    "metadata": {
     "papermill": {
-     "duration": 0.007521,
-     "end_time": "2026-06-10T13:18:42.923672",
+     "duration": 0.007042,
+     "end_time": "2026-06-10T14:02:27.402771",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.916151",
+     "start_time": "2026-06-10T14:02:27.395729",
      "status": "completed"
     },
     "tags": []
@@ -2135,7 +2214,8 @@
     "|----------|----------------------------------|\n",
     "| **Ex. 1 (sibling avec FOIL)** | FOIL trouve-t-il le litteral `X != Y` tout seul ? Montrez ce qui se passe s'il est absent du langage des hypotheses, et reliez cela au role du *biais de langage* en ILP. |\n",
     "| **Ex. 2 (operateur W)** | Sur votre domaine, exhibez une generalisation produite par W qui est consistante avec vos exemples mais fausse dans le monde reel. Pourquoi le bottom-up est-il particulierement expose a ce risque ? |\n",
-    "| **Ex. 3 (mini-KG)** | Evaluez la meme regle sous hypothese du monde clos (vos negatifs explicites) puis sous monde ouvert (PCA, cf SL-6) : laquelle des deux confiances est la bonne pour VOTRE KG, et pourquoi ? |\n"
+    "| **Ex. 3 (mini-KG)** | Evaluez la meme regle sous hypothese du monde clos (vos negatifs explicites) puis sous monde ouvert (PCA, cf SL-6) : laquelle des deux confiances est la bonne pour VOTRE KG, et pourquoi ? |\n",
+    "| **Ex. 4 (grandparent avec Popper)** | Retirez de GP_NEG toute paire arriere-grand-parent et relancez : quel programme plus court (et faux) devient consistant ? Popper garantit l'optimalite *par rapport aux exemples fournis* : que dit cette experience du role des negatifs proches de la frontiere ? |\n"
    ]
   },
   {
@@ -2143,10 +2223,10 @@
    "id": "f519236c",
    "metadata": {
     "papermill": {
-     "duration": 0.007441,
-     "end_time": "2026-06-10T13:18:42.937962",
+     "duration": 0.007538,
+     "end_time": "2026-06-10T14:02:27.416820",
      "exception": false,
-     "start_time": "2026-06-10T13:18:42.930521",
+     "start_time": "2026-06-10T14:02:27.409282",
      "status": "completed"
     },
     "tags": []
@@ -2189,14 +2269,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.771395,
-   "end_time": "2026-06-10T13:18:43.075696",
+   "duration": 3.334853,
+   "end_time": "2026-06-10T14:02:27.670062",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-4-InductiveLogicProgramming.ipynb",
    "output_path": "SL-4-InductiveLogicProgramming.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T13:18:40.304301",
+   "start_time": "2026-06-10T14:02:24.335209",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
@@ -5,10 +5,10 @@
    "id": "b727b480",
    "metadata": {
     "papermill": {
-     "duration": 0.003095,
-     "end_time": "2026-06-10T11:11:09.178774",
+     "duration": 0.006269,
+     "end_time": "2026-06-10T14:02:28.418809",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.175679",
+     "start_time": "2026-06-10T14:02:28.412540",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "c9962789",
    "metadata": {
     "papermill": {
-     "duration": 0.002048,
-     "end_time": "2026-06-10T11:11:09.184331",
+     "duration": 0.005294,
+     "end_time": "2026-06-10T14:02:28.429315",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.182283",
+     "start_time": "2026-06-10T14:02:28.424021",
      "status": "completed"
     },
     "tags": []
@@ -70,16 +70,16 @@
    "id": "56964821",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:09.191786Z",
-     "iopub.status.busy": "2026-06-10T11:11:09.190456Z",
-     "iopub.status.idle": "2026-06-10T11:11:09.281822Z",
-     "shell.execute_reply": "2026-06-10T11:11:09.281822Z"
+     "iopub.execute_input": "2026-06-10T14:02:28.440748Z",
+     "iopub.status.busy": "2026-06-10T14:02:28.440748Z",
+     "iopub.status.idle": "2026-06-10T14:02:28.550223Z",
+     "shell.execute_reply": "2026-06-10T14:02:28.550223Z"
     },
     "papermill": {
-     "duration": 0.095519,
-     "end_time": "2026-06-10T11:11:09.282848",
+     "duration": 0.116715,
+     "end_time": "2026-06-10T14:02:28.551196",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.187329",
+     "start_time": "2026-06-10T14:02:28.434481",
      "status": "completed"
     },
     "tags": []
@@ -109,10 +109,10 @@
    "id": "ec77af60",
    "metadata": {
     "papermill": {
-     "duration": 0.005001,
-     "end_time": "2026-06-10T11:11:09.292861",
+     "duration": 0.005107,
+     "end_time": "2026-06-10T14:02:28.562026",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.287860",
+     "start_time": "2026-06-10T14:02:28.556919",
      "status": "completed"
     },
     "tags": []
@@ -128,10 +128,10 @@
    "id": "32df7b08",
    "metadata": {
     "papermill": {
-     "duration": 0.003003,
-     "end_time": "2026-06-10T11:11:09.298367",
+     "duration": 0.004627,
+     "end_time": "2026-06-10T14:02:28.572647",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.295364",
+     "start_time": "2026-06-10T14:02:28.568020",
      "status": "completed"
     },
     "tags": []
@@ -159,16 +159,16 @@
    "id": "a01933cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:09.304871Z",
-     "iopub.status.busy": "2026-06-10T11:11:09.304871Z",
-     "iopub.status.idle": "2026-06-10T11:11:09.312883Z",
-     "shell.execute_reply": "2026-06-10T11:11:09.312883Z"
+     "iopub.execute_input": "2026-06-10T14:02:28.584864Z",
+     "iopub.status.busy": "2026-06-10T14:02:28.584864Z",
+     "iopub.status.idle": "2026-06-10T14:02:28.598441Z",
+     "shell.execute_reply": "2026-06-10T14:02:28.597439Z"
     },
     "papermill": {
-     "duration": 0.012859,
-     "end_time": "2026-06-10T11:11:09.314227",
+     "duration": 0.021802,
+     "end_time": "2026-06-10T14:02:28.599450",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.301368",
+     "start_time": "2026-06-10T14:02:28.577648",
      "status": "completed"
     },
     "tags": []
@@ -232,10 +232,10 @@
    "id": "ad12fe5d",
    "metadata": {
     "papermill": {
-     "duration": 0.005511,
-     "end_time": "2026-06-10T11:11:09.324743",
+     "duration": 0.006506,
+     "end_time": "2026-06-10T14:02:28.608961",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.319232",
+     "start_time": "2026-06-10T14:02:28.602455",
      "status": "completed"
     },
     "tags": []
@@ -256,10 +256,10 @@
    "id": "6a1fad49",
    "metadata": {
     "papermill": {
-     "duration": 0.001997,
-     "end_time": "2026-06-10T11:11:09.330743",
+     "duration": 0.004506,
+     "end_time": "2026-06-10T14:02:28.618470",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.328746",
+     "start_time": "2026-06-10T14:02:28.613964",
      "status": "completed"
     },
     "tags": []
@@ -276,16 +276,16 @@
    "id": "918f263e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:09.337250Z",
-     "iopub.status.busy": "2026-06-10T11:11:09.337250Z",
-     "iopub.status.idle": "2026-06-10T11:11:09.342758Z",
-     "shell.execute_reply": "2026-06-10T11:11:09.342758Z"
+     "iopub.execute_input": "2026-06-10T14:02:28.630483Z",
+     "iopub.status.busy": "2026-06-10T14:02:28.630483Z",
+     "iopub.status.idle": "2026-06-10T14:02:28.644576Z",
+     "shell.execute_reply": "2026-06-10T14:02:28.644000Z"
     },
     "papermill": {
-     "duration": 0.00951,
-     "end_time": "2026-06-10T11:11:09.343760",
+     "duration": 0.0216,
+     "end_time": "2026-06-10T14:02:28.644576",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.334250",
+     "start_time": "2026-06-10T14:02:28.622976",
      "status": "completed"
     },
     "tags": []
@@ -332,10 +332,10 @@
    "id": "3b49a998",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-06-10T11:11:09.349758",
+     "duration": 0.003503,
+     "end_time": "2026-06-10T14:02:28.652590",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.346757",
+     "start_time": "2026-06-10T14:02:28.649087",
      "status": "completed"
     },
     "tags": []
@@ -351,10 +351,10 @@
    "id": "9e4bbd02",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-06-10T11:11:09.355267",
+     "duration": 0.004,
+     "end_time": "2026-06-10T14:02:28.661594",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.352267",
+     "start_time": "2026-06-10T14:02:28.657594",
      "status": "completed"
     },
     "tags": []
@@ -371,16 +371,16 @@
    "id": "639acc57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:09.362270Z",
-     "iopub.status.busy": "2026-06-10T11:11:09.361270Z",
-     "iopub.status.idle": "2026-06-10T11:11:09.374125Z",
-     "shell.execute_reply": "2026-06-10T11:11:09.373543Z"
+     "iopub.execute_input": "2026-06-10T14:02:28.669610Z",
+     "iopub.status.busy": "2026-06-10T14:02:28.669610Z",
+     "iopub.status.idle": "2026-06-10T14:02:28.690634Z",
+     "shell.execute_reply": "2026-06-10T14:02:28.690634Z"
     },
     "papermill": {
-     "duration": 0.015853,
-     "end_time": "2026-06-10T11:11:09.374125",
+     "duration": 0.027046,
+     "end_time": "2026-06-10T14:02:28.691640",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.358272",
+     "start_time": "2026-06-10T14:02:28.664594",
      "status": "completed"
     },
     "tags": []
@@ -462,10 +462,10 @@
    "id": "e76b2686",
    "metadata": {
     "papermill": {
-     "duration": 0.002256,
-     "end_time": "2026-06-10T11:11:09.380312",
+     "duration": 0.002999,
+     "end_time": "2026-06-10T14:02:28.699638",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.378056",
+     "start_time": "2026-06-10T14:02:28.696639",
      "status": "completed"
     },
     "tags": []
@@ -497,10 +497,10 @@
    "id": "e1560747",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-06-10T11:11:09.386311",
+     "duration": 0.003016,
+     "end_time": "2026-06-10T14:02:28.705654",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.383311",
+     "start_time": "2026-06-10T14:02:28.702638",
      "status": "completed"
     },
     "tags": []
@@ -517,16 +517,16 @@
    "id": "60775122",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:09.392820Z",
-     "iopub.status.busy": "2026-06-10T11:11:09.392820Z",
-     "iopub.status.idle": "2026-06-10T11:11:09.404819Z",
-     "shell.execute_reply": "2026-06-10T11:11:09.404819Z"
+     "iopub.execute_input": "2026-06-10T14:02:28.715676Z",
+     "iopub.status.busy": "2026-06-10T14:02:28.714675Z",
+     "iopub.status.idle": "2026-06-10T14:02:28.723292Z",
+     "shell.execute_reply": "2026-06-10T14:02:28.722676Z"
     },
     "papermill": {
-     "duration": 0.017509,
-     "end_time": "2026-06-10T11:11:09.405821",
+     "duration": 0.013124,
+     "end_time": "2026-06-10T14:02:28.723292",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.388312",
+     "start_time": "2026-06-10T14:02:28.710168",
      "status": "completed"
     },
     "tags": []
@@ -589,10 +589,10 @@
    "id": "7bffc423",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T11:11:09.412328",
+     "duration": 0.005513,
+     "end_time": "2026-06-10T14:02:28.732817",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.408328",
+     "start_time": "2026-06-10T14:02:28.727304",
      "status": "completed"
     },
     "tags": []
@@ -615,10 +615,10 @@
    "id": "7a1c36be",
    "metadata": {
     "papermill": {
-     "duration": 0.001999,
-     "end_time": "2026-06-10T11:11:09.417907",
+     "duration": 0.005006,
+     "end_time": "2026-06-10T14:02:28.744824",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.415908",
+     "start_time": "2026-06-10T14:02:28.739818",
      "status": "completed"
     },
     "tags": []
@@ -635,16 +635,16 @@
    "id": "4028d94f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:09.424915Z",
-     "iopub.status.busy": "2026-06-10T11:11:09.423907Z",
-     "iopub.status.idle": "2026-06-10T11:11:09.435426Z",
-     "shell.execute_reply": "2026-06-10T11:11:09.435426Z"
+     "iopub.execute_input": "2026-06-10T14:02:28.757340Z",
+     "iopub.status.busy": "2026-06-10T14:02:28.756340Z",
+     "iopub.status.idle": "2026-06-10T14:02:28.768868Z",
+     "shell.execute_reply": "2026-06-10T14:02:28.768868Z"
     },
     "papermill": {
-     "duration": 0.01552,
-     "end_time": "2026-06-10T11:11:09.436429",
+     "duration": 0.019446,
+     "end_time": "2026-06-10T14:02:28.769869",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.420909",
+     "start_time": "2026-06-10T14:02:28.750423",
      "status": "completed"
     },
     "tags": []
@@ -742,10 +742,10 @@
    "id": "93b3b181",
    "metadata": {
     "papermill": {
-     "duration": 0.002442,
-     "end_time": "2026-06-10T11:11:09.441868",
+     "duration": 0.005,
+     "end_time": "2026-06-10T14:02:28.778868",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.439426",
+     "start_time": "2026-06-10T14:02:28.773868",
      "status": "completed"
     },
     "tags": []
@@ -773,10 +773,10 @@
    "id": "6b9341f0",
    "metadata": {
     "papermill": {
-     "duration": 0.003244,
-     "end_time": "2026-06-10T11:11:09.448628",
+     "duration": 0.003512,
+     "end_time": "2026-06-10T14:02:28.788391",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.445384",
+     "start_time": "2026-06-10T14:02:28.784879",
      "status": "completed"
     },
     "tags": []
@@ -813,16 +813,16 @@
    "id": "4b4e4ecb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:09.455626Z",
-     "iopub.status.busy": "2026-06-10T11:11:09.455626Z",
-     "iopub.status.idle": "2026-06-10T11:11:13.928691Z",
-     "shell.execute_reply": "2026-06-10T11:11:13.927687Z"
+     "iopub.execute_input": "2026-06-10T14:02:28.799390Z",
+     "iopub.status.busy": "2026-06-10T14:02:28.799390Z",
+     "iopub.status.idle": "2026-06-10T14:02:33.435808Z",
+     "shell.execute_reply": "2026-06-10T14:02:33.434663Z"
     },
     "papermill": {
-     "duration": 4.477065,
-     "end_time": "2026-06-10T11:11:13.928691",
+     "duration": 4.64394,
+     "end_time": "2026-06-10T14:02:33.436330",
      "exception": false,
-     "start_time": "2026-06-10T11:11:09.451626",
+     "start_time": "2026-06-10T14:02:28.792390",
      "status": "completed"
     },
     "tags": []
@@ -994,10 +994,10 @@
    "id": "1eca8959",
    "metadata": {
     "papermill": {
-     "duration": 0.003216,
-     "end_time": "2026-06-10T11:11:13.936391",
+     "duration": 0.004005,
+     "end_time": "2026-06-10T14:02:33.443921",
      "exception": false,
-     "start_time": "2026-06-10T11:11:13.933175",
+     "start_time": "2026-06-10T14:02:33.439916",
      "status": "completed"
     },
     "tags": []
@@ -1037,10 +1037,10 @@
    "id": "7422dd81",
    "metadata": {
     "papermill": {
-     "duration": 0.00691,
-     "end_time": "2026-06-10T11:11:13.947642",
+     "duration": 0.002533,
+     "end_time": "2026-06-10T14:02:33.450983",
      "exception": false,
-     "start_time": "2026-06-10T11:11:13.940732",
+     "start_time": "2026-06-10T14:02:33.448450",
      "status": "completed"
     },
     "tags": []
@@ -1061,10 +1061,10 @@
    "id": "c4b87086",
    "metadata": {
     "papermill": {
-     "duration": 0.006,
-     "end_time": "2026-06-10T11:11:13.958085",
+     "duration": 0.005031,
+     "end_time": "2026-06-10T14:02:33.461019",
      "exception": false,
-     "start_time": "2026-06-10T11:11:13.952085",
+     "start_time": "2026-06-10T14:02:33.455988",
      "status": "completed"
     },
     "tags": []
@@ -1085,10 +1085,10 @@
    "id": "b7545afb",
    "metadata": {
     "papermill": {
-     "duration": 0.006014,
-     "end_time": "2026-06-10T11:11:13.968606",
+     "duration": 0.004004,
+     "end_time": "2026-06-10T14:02:33.468520",
      "exception": false,
-     "start_time": "2026-06-10T11:11:13.962592",
+     "start_time": "2026-06-10T14:02:33.464516",
      "status": "completed"
     },
     "tags": []
@@ -1128,16 +1128,16 @@
    "id": "d6a2c3fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:13.979112Z",
-     "iopub.status.busy": "2026-06-10T11:11:13.978109Z",
-     "iopub.status.idle": "2026-06-10T11:11:13.989831Z",
-     "shell.execute_reply": "2026-06-10T11:11:13.989078Z"
+     "iopub.execute_input": "2026-06-10T14:02:33.480532Z",
+     "iopub.status.busy": "2026-06-10T14:02:33.480532Z",
+     "iopub.status.idle": "2026-06-10T14:02:33.498053Z",
+     "shell.execute_reply": "2026-06-10T14:02:33.497049Z"
     },
     "papermill": {
-     "duration": 0.017231,
-     "end_time": "2026-06-10T11:11:13.990837",
+     "duration": 0.025524,
+     "end_time": "2026-06-10T14:02:33.498053",
      "exception": false,
-     "start_time": "2026-06-10T11:11:13.973606",
+     "start_time": "2026-06-10T14:02:33.472529",
      "status": "completed"
     },
     "tags": []
@@ -1235,10 +1235,10 @@
    "id": "cd9f3d77",
    "metadata": {
     "papermill": {
-     "duration": 0.005517,
-     "end_time": "2026-06-10T11:11:14.002360",
+     "duration": 0.005523,
+     "end_time": "2026-06-10T14:02:33.512588",
      "exception": false,
-     "start_time": "2026-06-10T11:11:13.996843",
+     "start_time": "2026-06-10T14:02:33.507065",
      "status": "completed"
     },
     "tags": []
@@ -1255,16 +1255,16 @@
    "id": "b7c8387b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:14.011904Z",
-     "iopub.status.busy": "2026-06-10T11:11:14.011904Z",
-     "iopub.status.idle": "2026-06-10T11:11:14.020407Z",
-     "shell.execute_reply": "2026-06-10T11:11:14.020407Z"
+     "iopub.execute_input": "2026-06-10T14:02:33.526107Z",
+     "iopub.status.busy": "2026-06-10T14:02:33.525107Z",
+     "iopub.status.idle": "2026-06-10T14:02:33.544701Z",
+     "shell.execute_reply": "2026-06-10T14:02:33.543700Z"
     },
     "papermill": {
-     "duration": 0.014673,
-     "end_time": "2026-06-10T11:11:14.021577",
+     "duration": 0.0261,
+     "end_time": "2026-06-10T14:02:33.544701",
      "exception": false,
-     "start_time": "2026-06-10T11:11:14.006904",
+     "start_time": "2026-06-10T14:02:33.518601",
      "status": "completed"
     },
     "tags": []
@@ -1292,10 +1292,10 @@
    "id": "8fcfd862",
    "metadata": {
     "papermill": {
-     "duration": 0.003017,
-     "end_time": "2026-06-10T11:11:14.028499",
+     "duration": 0.006012,
+     "end_time": "2026-06-10T14:02:33.557219",
      "exception": false,
-     "start_time": "2026-06-10T11:11:14.025482",
+     "start_time": "2026-06-10T14:02:33.551207",
      "status": "completed"
     },
     "tags": []
@@ -1312,16 +1312,16 @@
    "id": "b2483326",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:14.035494Z",
-     "iopub.status.busy": "2026-06-10T11:11:14.035494Z",
-     "iopub.status.idle": "2026-06-10T11:11:14.052069Z",
-     "shell.execute_reply": "2026-06-10T11:11:14.051065Z"
+     "iopub.execute_input": "2026-06-10T14:02:33.567732Z",
+     "iopub.status.busy": "2026-06-10T14:02:33.566732Z",
+     "iopub.status.idle": "2026-06-10T14:02:33.575747Z",
+     "shell.execute_reply": "2026-06-10T14:02:33.574742Z"
     },
     "papermill": {
-     "duration": 0.021572,
-     "end_time": "2026-06-10T11:11:14.053066",
+     "duration": 0.013522,
+     "end_time": "2026-06-10T14:02:33.576747",
      "exception": false,
-     "start_time": "2026-06-10T11:11:14.031494",
+     "start_time": "2026-06-10T14:02:33.563225",
      "status": "completed"
     },
     "tags": []
@@ -1352,10 +1352,10 @@
    "id": "f8c58c48",
    "metadata": {
     "papermill": {
-     "duration": 0.003505,
-     "end_time": "2026-06-10T11:11:14.059570",
+     "duration": 0.00451,
+     "end_time": "2026-06-10T14:02:33.584256",
      "exception": false,
-     "start_time": "2026-06-10T11:11:14.056065",
+     "start_time": "2026-06-10T14:02:33.579746",
      "status": "completed"
     },
     "tags": []
@@ -1395,16 +1395,16 @@
    "id": "e2b9c7aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:11:14.068088Z",
-     "iopub.status.busy": "2026-06-10T11:11:14.068088Z",
-     "iopub.status.idle": "2026-06-10T11:11:14.083090Z",
-     "shell.execute_reply": "2026-06-10T11:11:14.082087Z"
+     "iopub.execute_input": "2026-06-10T14:02:33.591764Z",
+     "iopub.status.busy": "2026-06-10T14:02:33.591764Z",
+     "iopub.status.idle": "2026-06-10T14:02:33.606785Z",
+     "shell.execute_reply": "2026-06-10T14:02:33.605782Z"
     },
     "papermill": {
-     "duration": 0.019514,
-     "end_time": "2026-06-10T11:11:14.083090",
+     "duration": 0.020528,
+     "end_time": "2026-06-10T14:02:33.607783",
      "exception": false,
-     "start_time": "2026-06-10T11:11:14.063576",
+     "start_time": "2026-06-10T14:02:33.587255",
      "status": "completed"
     },
     "tags": []
@@ -1456,13 +1456,82 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fe7ce2cb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006004,
+     "end_time": "2026-06-10T14:02:33.618291",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:33.612287",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 5 : L'ablation de l'axiome 4 (LTNtorch)\n",
+    "\n",
+    "L'interpretation de la section 7 affirme que l'axiome 4 (negatifs closed-world\n",
+    "sur `grandparent`) est indispensable : sans lui, l'implication de l'axiome 3 se\n",
+    "satisfait trivialement en rendant `Grandparent` vrai partout. Transformez cette\n",
+    "affirmation en experience."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "dee9a21b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T14:02:33.629301Z",
+     "iopub.status.busy": "2026-06-10T14:02:33.629301Z",
+     "iopub.status.idle": "2026-06-10T14:02:33.637814Z",
+     "shell.execute_reply": "2026-06-10T14:02:33.636812Z"
+    },
+    "papermill": {
+     "duration": 0.014017,
+     "end_time": "2026-06-10T14:02:33.637814",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:33.623797",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 5 : L'ablation de l'axiome 4\n",
+    "# TODO etudiant : re-entrainez le modele LTNtorch de la section 7 SANS l'axiome 4\n",
+    "# et mesurez ce que devient le predicat grandparent.\n",
+    "# Etape 1 : re-instanciez des predicats frais (Parent2, Grandparent2 : deux\n",
+    "#           nouveaux ltn.Predicate(PairPredicate())) et torch.manual_seed(42),\n",
+    "#           pour ne pas reutiliser les poids deja entraines.\n",
+    "# Etape 2 : recopiez la boucle d'entrainement de la section 7 avec SEULEMENT\n",
+    "#           les axiomes 1, 2 et 3 (supprimez le Forall sur gpn_s/gpn_o).\n",
+    "# Etape 3 : interrogez Grandparent2 sur (Marie, Paul) ET sur les 6 paires de\n",
+    "#           gp_negative : comparez avec les valeurs de la section 7.\n",
+    "# Etape 4 : la satisfaction globale est-elle meilleure ou pire qu'avec 4 axiomes ?\n",
+    "#           Pourquoi une satisfaction elevee peut-elle cacher un predicat inutile ?\n",
+    "# Indice : un predicat constant a 1 satisfait parfaitement A => B quel que soit A.\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "367f1c08",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T11:11:14.091597",
+     "duration": 0.006011,
+     "end_time": "2026-06-10T14:02:33.647330",
      "exception": false,
-     "start_time": "2026-06-10T11:11:14.087597",
+     "start_time": "2026-06-10T14:02:33.641319",
      "status": "completed"
     },
     "tags": []
@@ -1491,7 +1560,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "92a946c0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005512,
+     "end_time": "2026-06-10T14:02:33.658459",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:33.652947",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1514,10 +1593,10 @@
    "id": "afb393b9",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-06-10T11:11:14.097597",
+     "duration": 0.005016,
+     "end_time": "2026-06-10T14:02:33.669475",
      "exception": false,
-     "start_time": "2026-06-10T11:11:14.094597",
+     "start_time": "2026-06-10T14:02:33.664459",
      "status": "completed"
     },
     "tags": []
@@ -1542,6 +1621,37 @@
     "\n",
     "**Navigation** : [Index](./README.md) | [<< SL-4 ILP](SL-4-InductiveLogicProgramming.ipynb) | [Suivant >> SL-6 KG-ILP](SL-6-KnowledgeGraphs-ILP.ipynb)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b170b7b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005507,
+     "end_time": "2026-06-10T14:02:33.679983",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:33.674476",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Defi presentation (seance du 17 juin)\n",
+    "\n",
+    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
+    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
+    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
+    "Elle fait partie integrante de la presentation attendue.\n",
+    "\n",
+    "| Exercice | Question-twist a traiter en plus |\n",
+    "|----------|----------------------------------|\n",
+    "| **Ex. 2 (LTN frere/oncle)** | Retirez les axiomes negatifs de votre entrainement : pourquoi une LTN a-t-elle besoin de negatifs explicites la ou un moteur logique exact (SL-6) n'en demande pas ? |\n",
+    "| **Ex. 3 (regle transitive ancestor)** | Le modele trivial « vrai partout » sature votre regle transitive : qu'est-ce qui l'evite dans votre formulation, et que se passe-t-il si vous l'enlevez ? |\n",
+    "| **Ex. 4 (t-norm de Lukasiewicz)** | Sur quelles plages la t-norm de Lukasiewicz a-t-elle des gradients exactement nuls ? Qu'est-ce que cela implique pour une semantique floue *apprenable* par descente de gradient ? |\n",
+    "| **Ex. 5 (ablation de l'axiome 4)** | Remplacez les 6 negatifs closed-world par les seules paires « faciles » (aucun lien parent direct) : le negatif difficile (Marie, Pierre) est-il indispensable pour que grandparent ne degenere pas en « parent-de » ? Que dit ce besoin de negatifs choisis de la difference avec la derivation exacte de clingo (SL-6) ? |"
+   ]
   }
  ],
  "metadata": {
@@ -1564,14 +1674,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 7.499358,
-   "end_time": "2026-06-10T11:11:14.864362",
+   "duration": 8.068687,
+   "end_time": "2026-06-10T14:02:34.681072",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-5-NeuroSymbolic.ipynb",
    "output_path": "SL-5-NeuroSymbolic.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T11:11:07.365004",
+   "start_time": "2026-06-10T14:02:26.612385",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
@@ -5,10 +5,10 @@
    "id": "cc001308",
    "metadata": {
     "papermill": {
-     "duration": 0.004892,
-     "end_time": "2026-06-10T12:35:02.271478",
+     "duration": 0.00819,
+     "end_time": "2026-06-10T14:04:45.741074",
      "exception": false,
-     "start_time": "2026-06-10T12:35:02.266586",
+     "start_time": "2026-06-10T14:04:45.732884",
      "status": "completed"
     },
     "tags": []
@@ -46,10 +46,10 @@
    "id": "a521d3e8",
    "metadata": {
     "papermill": {
-     "duration": 0.004004,
-     "end_time": "2026-06-10T12:35:02.279010",
+     "duration": 0.005212,
+     "end_time": "2026-06-10T14:04:45.755211",
      "exception": false,
-     "start_time": "2026-06-10T12:35:02.275006",
+     "start_time": "2026-06-10T14:04:45.749999",
      "status": "completed"
     },
     "tags": []
@@ -93,10 +93,10 @@
    "id": "fb76430f",
    "metadata": {
     "papermill": {
-     "duration": 0.003497,
-     "end_time": "2026-06-10T12:35:02.285514",
+     "duration": 0.007317,
+     "end_time": "2026-06-10T14:04:45.769804",
      "exception": false,
-     "start_time": "2026-06-10T12:35:02.282017",
+     "start_time": "2026-06-10T14:04:45.762487",
      "status": "completed"
     },
     "tags": []
@@ -115,16 +115,16 @@
    "id": "6422a73a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:02.294528Z",
-     "iopub.status.busy": "2026-06-10T12:35:02.294528Z",
-     "iopub.status.idle": "2026-06-10T12:35:03.755204Z",
-     "shell.execute_reply": "2026-06-10T12:35:03.754615Z"
+     "iopub.execute_input": "2026-06-10T14:04:45.782966Z",
+     "iopub.status.busy": "2026-06-10T14:04:45.782966Z",
+     "iopub.status.idle": "2026-06-10T14:04:47.436758Z",
+     "shell.execute_reply": "2026-06-10T14:04:47.435252Z"
     },
     "papermill": {
-     "duration": 1.466798,
-     "end_time": "2026-06-10T12:35:03.756314",
+     "duration": 1.661148,
+     "end_time": "2026-06-10T14:04:47.437273",
      "exception": false,
-     "start_time": "2026-06-10T12:35:02.289516",
+     "start_time": "2026-06-10T14:04:45.776125",
      "status": "completed"
     },
     "tags": []
@@ -157,10 +157,10 @@
    "id": "859f5cfd",
    "metadata": {
     "papermill": {
-     "duration": 0.007176,
-     "end_time": "2026-06-10T12:35:03.770582",
+     "duration": 0.007233,
+     "end_time": "2026-06-10T14:04:47.450788",
      "exception": false,
-     "start_time": "2026-06-10T12:35:03.763406",
+     "start_time": "2026-06-10T14:04:47.443555",
      "status": "completed"
     },
     "tags": []
@@ -177,16 +177,16 @@
    "id": "1cd6d433",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:03.785859Z",
-     "iopub.status.busy": "2026-06-10T12:35:03.785859Z",
-     "iopub.status.idle": "2026-06-10T12:35:03.911392Z",
-     "shell.execute_reply": "2026-06-10T12:35:03.910841Z"
+     "iopub.execute_input": "2026-06-10T14:04:47.467398Z",
+     "iopub.status.busy": "2026-06-10T14:04:47.466882Z",
+     "iopub.status.idle": "2026-06-10T14:04:47.591032Z",
+     "shell.execute_reply": "2026-06-10T14:04:47.589957Z"
     },
     "papermill": {
-     "duration": 0.134314,
-     "end_time": "2026-06-10T12:35:03.912397",
+     "duration": 0.133734,
+     "end_time": "2026-06-10T14:04:47.592089",
      "exception": false,
-     "start_time": "2026-06-10T12:35:03.778083",
+     "start_time": "2026-06-10T14:04:47.458355",
      "status": "completed"
     },
     "tags": []
@@ -325,10 +325,10 @@
    "id": "c7f62d31",
    "metadata": {
     "papermill": {
-     "duration": 0.00651,
-     "end_time": "2026-06-10T12:35:03.924934",
+     "duration": 0.007377,
+     "end_time": "2026-06-10T14:04:47.605244",
      "exception": false,
-     "start_time": "2026-06-10T12:35:03.918424",
+     "start_time": "2026-06-10T14:04:47.597867",
      "status": "completed"
     },
     "tags": []
@@ -358,10 +358,10 @@
    "id": "09e1dbc5",
    "metadata": {
     "papermill": {
-     "duration": 0.007032,
-     "end_time": "2026-06-10T12:35:03.938556",
+     "duration": 0.007561,
+     "end_time": "2026-06-10T14:04:47.620725",
      "exception": false,
-     "start_time": "2026-06-10T12:35:03.931524",
+     "start_time": "2026-06-10T14:04:47.613164",
      "status": "completed"
     },
     "tags": []
@@ -380,16 +380,16 @@
    "id": "135b849e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:03.953121Z",
-     "iopub.status.busy": "2026-06-10T12:35:03.952117Z",
-     "iopub.status.idle": "2026-06-10T12:35:03.974037Z",
-     "shell.execute_reply": "2026-06-10T12:35:03.972952Z"
+     "iopub.execute_input": "2026-06-10T14:04:47.637418Z",
+     "iopub.status.busy": "2026-06-10T14:04:47.637418Z",
+     "iopub.status.idle": "2026-06-10T14:04:47.652322Z",
+     "shell.execute_reply": "2026-06-10T14:04:47.651161Z"
     },
     "papermill": {
-     "duration": 0.030975,
-     "end_time": "2026-06-10T12:35:03.975058",
+     "duration": 0.025597,
+     "end_time": "2026-06-10T14:04:47.653391",
      "exception": false,
-     "start_time": "2026-06-10T12:35:03.944083",
+     "start_time": "2026-06-10T14:04:47.627794",
      "status": "completed"
     },
     "tags": []
@@ -475,10 +475,10 @@
    "id": "4e7a7a8e",
    "metadata": {
     "papermill": {
-     "duration": 0.006436,
-     "end_time": "2026-06-10T12:35:03.987880",
+     "duration": 0.00645,
+     "end_time": "2026-06-10T14:04:47.666477",
      "exception": false,
-     "start_time": "2026-06-10T12:35:03.981444",
+     "start_time": "2026-06-10T14:04:47.660027",
      "status": "completed"
     },
     "tags": []
@@ -502,10 +502,10 @@
    "id": "2ebba873",
    "metadata": {
     "papermill": {
-     "duration": 0.006019,
-     "end_time": "2026-06-10T12:35:04.001012",
+     "duration": 0.007537,
+     "end_time": "2026-06-10T14:04:47.681998",
      "exception": false,
-     "start_time": "2026-06-10T12:35:03.994993",
+     "start_time": "2026-06-10T14:04:47.674461",
      "status": "completed"
     },
     "tags": []
@@ -538,16 +538,16 @@
    "id": "91350691",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.016761Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.015762Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.036868Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.035749Z"
+     "iopub.execute_input": "2026-06-10T14:04:47.698666Z",
+     "iopub.status.busy": "2026-06-10T14:04:47.698129Z",
+     "iopub.status.idle": "2026-06-10T14:04:47.714101Z",
+     "shell.execute_reply": "2026-06-10T14:04:47.712987Z"
     },
     "papermill": {
-     "duration": 0.028824,
-     "end_time": "2026-06-10T12:35:04.036868",
+     "duration": 0.026384,
+     "end_time": "2026-06-10T14:04:47.715152",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.008044",
+     "start_time": "2026-06-10T14:04:47.688768",
      "status": "completed"
     },
     "tags": []
@@ -559,7 +559,7 @@
      "text": [
       "Test de compute_body_pairs :\n",
       "  r1 = {('C', 'D'), ('A', 'B')}\n",
-      "  r2 = {('D', 'F'), ('B', 'E')}\n",
+      "  r2 = {('B', 'E'), ('D', 'F')}\n",
       "  JOIN result = {('A', 'E'), ('C', 'F')}\n",
       "  Attendu : (('A', 'E'), ('C', 'F'))\n",
       "  Correct : True\n"
@@ -650,10 +650,10 @@
    "id": "2f9e5ce7",
    "metadata": {
     "papermill": {
-     "duration": 0.006861,
-     "end_time": "2026-06-10T12:35:04.051646",
+     "duration": 0.007828,
+     "end_time": "2026-06-10T14:04:47.730810",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.044785",
+     "start_time": "2026-06-10T14:04:47.722982",
      "status": "completed"
     },
     "tags": []
@@ -677,10 +677,10 @@
    "id": "55e6358c",
    "metadata": {
     "papermill": {
-     "duration": 0.006937,
-     "end_time": "2026-06-10T12:35:04.064812",
+     "duration": 0.007236,
+     "end_time": "2026-06-10T14:04:47.745825",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.057875",
+     "start_time": "2026-06-10T14:04:47.738589",
      "status": "completed"
     },
     "tags": []
@@ -699,16 +699,16 @@
    "id": "93a15c8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.078477Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.078477Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.098223Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.097532Z"
+     "iopub.execute_input": "2026-06-10T14:04:47.763058Z",
+     "iopub.status.busy": "2026-06-10T14:04:47.762052Z",
+     "iopub.status.idle": "2026-06-10T14:04:47.775144Z",
+     "shell.execute_reply": "2026-06-10T14:04:47.774020Z"
     },
     "papermill": {
-     "duration": 0.028323,
-     "end_time": "2026-06-10T12:35:04.099739",
+     "duration": 0.022566,
+     "end_time": "2026-06-10T14:04:47.775675",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.071416",
+     "start_time": "2026-06-10T14:04:47.753109",
      "status": "completed"
     },
     "tags": []
@@ -822,10 +822,10 @@
    "id": "f171e286",
    "metadata": {
     "papermill": {
-     "duration": 0.007013,
-     "end_time": "2026-06-10T12:35:04.113804",
+     "duration": 0.007689,
+     "end_time": "2026-06-10T14:04:47.791183",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.106791",
+     "start_time": "2026-06-10T14:04:47.783494",
      "status": "completed"
     },
     "tags": []
@@ -858,10 +858,10 @@
    "id": "d17f08c2",
    "metadata": {
     "papermill": {
-     "duration": 0.006916,
-     "end_time": "2026-06-10T12:35:04.127216",
+     "duration": 0.007716,
+     "end_time": "2026-06-10T14:04:47.806774",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.120300",
+     "start_time": "2026-06-10T14:04:47.799058",
      "status": "completed"
     },
     "tags": []
@@ -880,16 +880,16 @@
    "id": "e5d644f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.142783Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.142275Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.161562Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.160969Z"
+     "iopub.execute_input": "2026-06-10T14:04:47.824224Z",
+     "iopub.status.busy": "2026-06-10T14:04:47.824224Z",
+     "iopub.status.idle": "2026-06-10T14:04:47.836610Z",
+     "shell.execute_reply": "2026-06-10T14:04:47.835577Z"
     },
     "papermill": {
-     "duration": 0.029345,
-     "end_time": "2026-06-10T12:35:04.163088",
+     "duration": 0.023405,
+     "end_time": "2026-06-10T14:04:47.838162",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.133743",
+     "start_time": "2026-06-10T14:04:47.814757",
      "status": "completed"
     },
     "tags": []
@@ -1005,10 +1005,10 @@
    "id": "5dc0af7c",
    "metadata": {
     "papermill": {
-     "duration": 0.007065,
-     "end_time": "2026-06-10T12:35:04.177097",
+     "duration": 0.007668,
+     "end_time": "2026-06-10T14:04:47.853448",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.170032",
+     "start_time": "2026-06-10T14:04:47.845780",
      "status": "completed"
     },
     "tags": []
@@ -1037,10 +1037,10 @@
    "id": "16b4761d",
    "metadata": {
     "papermill": {
-     "duration": 0.007107,
-     "end_time": "2026-06-10T12:35:04.190792",
+     "duration": 0.008012,
+     "end_time": "2026-06-10T14:04:47.868826",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.183685",
+     "start_time": "2026-06-10T14:04:47.860814",
      "status": "completed"
     },
     "tags": []
@@ -1059,16 +1059,16 @@
    "id": "b1263c6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.205417Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.205417Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.223207Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.222136Z"
+     "iopub.execute_input": "2026-06-10T14:04:47.886018Z",
+     "iopub.status.busy": "2026-06-10T14:04:47.885488Z",
+     "iopub.status.idle": "2026-06-10T14:04:47.897302Z",
+     "shell.execute_reply": "2026-06-10T14:04:47.896212Z"
     },
     "papermill": {
-     "duration": 0.026383,
-     "end_time": "2026-06-10T12:35:04.224249",
+     "duration": 0.021717,
+     "end_time": "2026-06-10T14:04:47.898362",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.197866",
+     "start_time": "2026-06-10T14:04:47.876645",
      "status": "completed"
     },
     "tags": []
@@ -1184,10 +1184,10 @@
    "id": "1a969bc5",
    "metadata": {
     "papermill": {
-     "duration": 0.007421,
-     "end_time": "2026-06-10T12:35:04.237743",
+     "duration": 0.007846,
+     "end_time": "2026-06-10T14:04:47.914172",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.230322",
+     "start_time": "2026-06-10T14:04:47.906326",
      "status": "completed"
     },
     "tags": []
@@ -1219,10 +1219,10 @@
    "id": "d71be242",
    "metadata": {
     "papermill": {
-     "duration": 0.00653,
-     "end_time": "2026-06-10T12:35:04.251840",
+     "duration": 0.007875,
+     "end_time": "2026-06-10T14:04:47.930279",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.245310",
+     "start_time": "2026-06-10T14:04:47.922404",
      "status": "completed"
     },
     "tags": []
@@ -1241,16 +1241,16 @@
    "id": "4022209e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.268934Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.268421Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.287012Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.286010Z"
+     "iopub.execute_input": "2026-06-10T14:04:47.947067Z",
+     "iopub.status.busy": "2026-06-10T14:04:47.946534Z",
+     "iopub.status.idle": "2026-06-10T14:04:47.958610Z",
+     "shell.execute_reply": "2026-06-10T14:04:47.957474Z"
     },
     "papermill": {
-     "duration": 0.027614,
-     "end_time": "2026-06-10T12:35:04.287012",
+     "duration": 0.022083,
+     "end_time": "2026-06-10T14:04:47.959655",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.259398",
+     "start_time": "2026-06-10T14:04:47.937572",
      "status": "completed"
     },
     "tags": []
@@ -1295,9 +1295,9 @@
       "  Claire -- grandparentOf --> Thomas\n",
       "  Claire -- grandparentOf --> Emma\n",
       "  Jean -- grandparentOf --> Hugo\n",
+      "  Jean -- grandparentOf --> Julie\n",
       "  Jean -- grandparentOf --> Lea\n",
       "  Jean -- grandparentOf --> Marc\n",
-      "  Jean -- grandparentOf --> Julie\n",
       "  Marie -- grandparentOf --> Luc\n",
       "  Marie -- grandparentOf --> Sophie\n",
       "  Marie -- grandparentOf --> Paul\n",
@@ -1355,10 +1355,10 @@
    "id": "e22df85d",
    "metadata": {
     "papermill": {
-     "duration": 0.007376,
-     "end_time": "2026-06-10T12:35:04.302518",
+     "duration": 0.009028,
+     "end_time": "2026-06-10T14:04:47.976302",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.295142",
+     "start_time": "2026-06-10T14:04:47.967274",
      "status": "completed"
     },
     "tags": []
@@ -1383,10 +1383,10 @@
    "id": "f1e0ba93",
    "metadata": {
     "papermill": {
-     "duration": 0.007079,
-     "end_time": "2026-06-10T12:35:04.316856",
+     "duration": 0.007912,
+     "end_time": "2026-06-10T14:04:47.992243",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.309777",
+     "start_time": "2026-06-10T14:04:47.984331",
      "status": "completed"
     },
     "tags": []
@@ -1405,16 +1405,16 @@
    "id": "6759ffea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.332618Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.332618Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.349445Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.348761Z"
+     "iopub.execute_input": "2026-06-10T14:04:48.010108Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.010108Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.020091Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.018973Z"
     },
     "papermill": {
-     "duration": 0.026586,
-     "end_time": "2026-06-10T12:35:04.350958",
+     "duration": 0.02097,
+     "end_time": "2026-06-10T14:04:48.021141",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.324372",
+     "start_time": "2026-06-10T14:04:48.000171",
      "status": "completed"
     },
     "tags": []
@@ -1492,10 +1492,10 @@
    "id": "c00743ef",
    "metadata": {
     "papermill": {
-     "duration": 0.007023,
-     "end_time": "2026-06-10T12:35:04.364924",
+     "duration": 0.005876,
+     "end_time": "2026-06-10T14:04:48.035383",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.357901",
+     "start_time": "2026-06-10T14:04:48.029507",
      "status": "completed"
     },
     "tags": []
@@ -1520,10 +1520,10 @@
    "id": "a6ccf734",
    "metadata": {
     "papermill": {
-     "duration": 0.004698,
-     "end_time": "2026-06-10T12:35:04.376545",
+     "duration": 0.00802,
+     "end_time": "2026-06-10T14:04:48.047043",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.371847",
+     "start_time": "2026-06-10T14:04:48.039023",
      "status": "completed"
     },
     "tags": []
@@ -1542,16 +1542,16 @@
    "id": "092cac51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.387404Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.387404Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.395424Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.395424Z"
+     "iopub.execute_input": "2026-06-10T14:04:48.064470Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.063945Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.081801Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.080599Z"
     },
     "papermill": {
-     "duration": 0.015645,
-     "end_time": "2026-06-10T12:35:04.396430",
+     "duration": 0.027683,
+     "end_time": "2026-06-10T14:04:48.082867",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.380785",
+     "start_time": "2026-06-10T14:04:48.055184",
      "status": "completed"
     },
     "tags": []
@@ -1561,7 +1561,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ILP Classique (SL-4) vs Rule Mining sur KG (SL-6)\n",
+      "ILP Classique (SL-4) vs Rule Mining sur KG (SL-6)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "=================================================================\n",
       "\n",
       "  Donnees d'entree          | Facts + BK           | RDF triples\n",
@@ -1620,10 +1627,10 @@
    "id": "01ea5c6c",
    "metadata": {
     "papermill": {
-     "duration": 0.004084,
-     "end_time": "2026-06-10T12:35:04.406512",
+     "duration": 0.006553,
+     "end_time": "2026-06-10T14:04:48.098311",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.402428",
+     "start_time": "2026-06-10T14:04:48.091758",
      "status": "completed"
     },
     "tags": []
@@ -1647,10 +1654,10 @@
    "id": "671bff9b",
    "metadata": {
     "papermill": {
-     "duration": 0.00451,
-     "end_time": "2026-06-10T12:35:04.414531",
+     "duration": 0.006067,
+     "end_time": "2026-06-10T14:04:48.110896",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.410021",
+     "start_time": "2026-06-10T14:04:48.104829",
      "status": "completed"
     },
     "tags": []
@@ -1668,10 +1675,10 @@
    "id": "b26804b3",
    "metadata": {
     "papermill": {
-     "duration": 0.003523,
-     "end_time": "2026-06-10T12:35:04.422062",
+     "duration": 0.005728,
+     "end_time": "2026-06-10T14:04:48.121929",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.418539",
+     "start_time": "2026-06-10T14:04:48.116201",
      "status": "completed"
     },
     "tags": []
@@ -1709,16 +1716,16 @@
    "id": "454852af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.433097Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.433097Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.458105Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.457111Z"
+     "iopub.execute_input": "2026-06-10T14:04:48.133446Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.133446Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.158124Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.157482Z"
     },
     "papermill": {
-     "duration": 0.031549,
-     "end_time": "2026-06-10T12:35:04.458611",
+     "duration": 0.031702,
+     "end_time": "2026-06-10T14:04:48.158635",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.427062",
+     "start_time": "2026-06-10T14:04:48.126933",
      "status": "completed"
     },
     "tags": []
@@ -1749,16 +1756,16 @@
    "id": "8b0a3dcf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.470145Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.470145Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.488692Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.488692Z"
+     "iopub.execute_input": "2026-06-10T14:04:48.172657Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.171657Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.188894Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.187773Z"
     },
     "papermill": {
-     "duration": 0.025092,
-     "end_time": "2026-06-10T12:35:04.489704",
+     "duration": 0.025255,
+     "end_time": "2026-06-10T14:04:48.188894",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.464612",
+     "start_time": "2026-06-10T14:04:48.163639",
      "status": "completed"
     },
     "tags": []
@@ -1832,16 +1839,16 @@
    "id": "871be88a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.500712Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.499710Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.520742Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.519744Z"
+     "iopub.execute_input": "2026-06-10T14:04:48.201373Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.200372Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.218893Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.218893Z"
     },
     "papermill": {
-     "duration": 0.02604,
-     "end_time": "2026-06-10T12:35:04.520742",
+     "duration": 0.025084,
+     "end_time": "2026-06-10T14:04:48.220457",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.494702",
+     "start_time": "2026-06-10T14:04:48.195373",
      "status": "completed"
     },
     "tags": []
@@ -1901,16 +1908,16 @@
    "id": "f9414515",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.531265Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.530265Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.551777Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.551273Z"
+     "iopub.execute_input": "2026-06-10T14:04:48.236777Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.236242Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.250894Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.249887Z"
     },
     "papermill": {
-     "duration": 0.027526,
-     "end_time": "2026-06-10T12:35:04.552791",
+     "duration": 0.022685,
+     "end_time": "2026-06-10T14:04:48.250894",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.525265",
+     "start_time": "2026-06-10T14:04:48.228209",
      "status": "completed"
     },
     "tags": []
@@ -1921,7 +1928,13 @@
      "output_type": "stream",
      "text": [
       "Coherent (acyclique) : True\n",
-      "ancestorOf derive : 40 paires (a partir de 14 parentOf)\n",
+      "ancestorOf derive : 40 paires (a partir de 14 parentOf)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "Avec le fait cyclique parentof(Emma, Marie) : UNSAT\n",
       "UNSAT = le solveur REFUSE tout modele : la contrainte d'integrite\n",
@@ -1973,10 +1986,10 @@
    "id": "5966b66d",
    "metadata": {
     "papermill": {
-     "duration": 0.004515,
-     "end_time": "2026-06-10T12:35:04.561296",
+     "duration": 0.005009,
+     "end_time": "2026-06-10T14:04:48.260900",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.556781",
+     "start_time": "2026-06-10T14:04:48.255891",
      "status": "completed"
     },
     "tags": []
@@ -2021,10 +2034,10 @@
    "id": "4c400b44",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T12:35:04.569296",
+     "duration": 0.005015,
+     "end_time": "2026-06-10T14:04:48.270921",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.565296",
+     "start_time": "2026-06-10T14:04:48.265906",
      "status": "completed"
     },
     "tags": []
@@ -2038,10 +2051,10 @@
    "id": "341c7bfb",
    "metadata": {
     "papermill": {
-     "duration": 0.004509,
-     "end_time": "2026-06-10T12:35:04.577806",
+     "duration": 0.005814,
+     "end_time": "2026-06-10T14:04:48.280735",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.573297",
+     "start_time": "2026-06-10T14:04:48.274921",
      "status": "completed"
     },
     "tags": []
@@ -2064,16 +2077,16 @@
    "id": "409ababa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.586815Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.586815Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.598326Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.597333Z"
+     "iopub.execute_input": "2026-06-10T14:04:48.297763Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.297763Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.312431Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.311795Z"
     },
     "papermill": {
-     "duration": 0.017512,
-     "end_time": "2026-06-10T12:35:04.599326",
+     "duration": 0.023699,
+     "end_time": "2026-06-10T14:04:48.312943",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.581814",
+     "start_time": "2026-06-10T14:04:48.289244",
      "status": "completed"
     },
     "tags": []
@@ -2118,10 +2131,10 @@
    "id": "719920a9",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T12:35:04.608332",
+     "duration": 0.007001,
+     "end_time": "2026-06-10T14:04:48.327488",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.603332",
+     "start_time": "2026-06-10T14:04:48.320487",
      "status": "completed"
     },
     "tags": []
@@ -2147,16 +2160,16 @@
    "id": "89b763a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.617834Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.617834Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.628832Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.628832Z"
+     "iopub.execute_input": "2026-06-10T14:04:48.341044Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.341044Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.359541Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.359033Z"
     },
     "papermill": {
-     "duration": 0.01851,
-     "end_time": "2026-06-10T12:35:04.629834",
+     "duration": 0.026018,
+     "end_time": "2026-06-10T14:04:48.360546",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.611324",
+     "start_time": "2026-06-10T14:04:48.334528",
      "status": "completed"
     },
     "tags": []
@@ -2220,10 +2233,10 @@
    "id": "44737d28",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-06-10T12:35:04.638341",
+     "duration": 0.004151,
+     "end_time": "2026-06-10T14:04:48.370260",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.634342",
+     "start_time": "2026-06-10T14:04:48.366109",
      "status": "completed"
     },
     "tags": []
@@ -2249,16 +2262,16 @@
    "id": "d20502d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:35:04.647341Z",
-     "iopub.status.busy": "2026-06-10T12:35:04.647341Z",
-     "iopub.status.idle": "2026-06-10T12:35:04.659848Z",
-     "shell.execute_reply": "2026-06-10T12:35:04.659848Z"
+     "iopub.execute_input": "2026-06-10T14:04:48.379631Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.379631Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.389366Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.389366Z"
     },
     "papermill": {
-     "duration": 0.018508,
-     "end_time": "2026-06-10T12:35:04.660849",
+     "duration": 0.016436,
+     "end_time": "2026-06-10T14:04:48.390362",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.642341",
+     "start_time": "2026-06-10T14:04:48.373926",
      "status": "completed"
     },
     "tags": []
@@ -2306,13 +2319,92 @@
   },
   {
    "cell_type": "markdown",
+   "id": "32d86549",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004005,
+     "end_time": "2026-06-10T14:04:48.399867",
+     "exception": false,
+     "start_time": "2026-06-10T14:04:48.395862",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : Reparation minimale avec clingo\n",
+    "\n",
+    "La section clingo a montre la **detection** : avec le fait cyclique\n",
+    "`parentof(Emma, Marie)`, la contrainte d'integrite rend le programme UNSAT.\n",
+    "Mais UNSAT ne dit pas *quoi reparer*. L'ASP sait faire mieux : enumerer les\n",
+    "reparations minimales."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "e85c35a4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T14:04:48.409881Z",
+     "iopub.status.busy": "2026-06-10T14:04:48.409881Z",
+     "iopub.status.idle": "2026-06-10T14:04:48.420475Z",
+     "shell.execute_reply": "2026-06-10T14:04:48.420475Z"
+    },
+    "papermill": {
+     "duration": 0.018611,
+     "end_time": "2026-06-10T14:04:48.421981",
+     "exception": false,
+     "start_time": "2026-06-10T14:04:48.403370",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : Reparation minimale avec clingo\n",
+    "# TODO etudiant : trouvez le(s) plus petit(s) ensemble(s) de faits parentof dont\n",
+    "# la suppression restaure la coherence du KG corrompu par parentof(Emma, Marie).\n",
+    "# Etape 1 : reecrivez les faits parentof du programme en parentof_raw(...) et\n",
+    "#           ajoutez le fait corrompu parentof_raw(\"Emma\",\"Marie\").\n",
+    "# Etape 2 : ajoutez le programme de reparation :\n",
+    "#           { drop(X,Y) } :- parentof_raw(X,Y).\n",
+    "#           parentof(X,Y) :- parentof_raw(X,Y), not drop(X,Y).\n",
+    "#           ancestorof(X,Y) :- parentof(X,Y).\n",
+    "#           ancestorof(X,Y) :- parentof(X,Z), ancestorof(Z,Y).\n",
+    "#           :- ancestorof(X,X).\n",
+    "#           #minimize { 1,X,Y : drop(X,Y) }.\n",
+    "#           #show drop/2.\n",
+    "# Etape 3 : resolvez avec clingo.Control([\"--opt-mode=optN\", \"0\"]) et collectez\n",
+    "#           les modeles optimaux (handle avec yield_=True, model.cost).\n",
+    "# Etape 4 : combien de reparations a cout 1 existent ? Le fait injecte est-il\n",
+    "#           la seule option ? Tracez le cycle pour expliquer.\n",
+    "# Indice : toute arete du cycle cree par Emma->Marie est une reparation valable ;\n",
+    "#          la minimalite ne designe pas un coupable unique.\n",
+    "\n",
+    "import importlib\n",
+    "if importlib.util.find_spec(\"clingo\") is not None:\n",
+    "    print(\"Exercice a completer\")\n",
+    "else:\n",
+    "    print(\"clingo indisponible : pip install clingo\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a1ba5b56",
    "metadata": {
     "papermill": {
-     "duration": 0.003506,
-     "end_time": "2026-06-10T12:35:04.668355",
+     "duration": 0.005014,
+     "end_time": "2026-06-10T14:04:48.431632",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.664849",
+     "start_time": "2026-06-10T14:04:48.426618",
      "status": "completed"
     },
     "tags": []
@@ -2359,10 +2451,10 @@
    "id": "c4b6e83b",
    "metadata": {
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-06-10T12:35:04.676356",
+     "duration": 0.007515,
+     "end_time": "2026-06-10T14:04:48.444729",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.672355",
+     "start_time": "2026-06-10T14:04:48.437214",
      "status": "completed"
     },
     "tags": []
@@ -2382,10 +2474,10 @@
    "id": "5bb1e4b9",
    "metadata": {
     "papermill": {
-     "duration": 0.004509,
-     "end_time": "2026-06-10T12:35:04.684864",
+     "duration": 0.008001,
+     "end_time": "2026-06-10T14:04:48.460241",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.680355",
+     "start_time": "2026-06-10T14:04:48.452240",
      "status": "completed"
     },
     "tags": []
@@ -2404,7 +2496,8 @@
     "|----------|----------------------------------|\n",
     "| **Ex. 1 (nouvelle relation au KG)** | Votre nouvelle relation engendre-t-elle des regles *redondantes* avec les existantes (meme extension, syntaxe differente) ? Comment un mineur comme AMIE evite-t-il d'enumerer ces doublons ? |\n",
     "| **Ex. 2 (PCA confidence)** | Construisez un mini-KG ou la PCA confidence est trompeuse (regle fausse avec PCA elevee). Quelle hypothese de completude partielle est violee dans votre construction ? |\n",
-    "| **Ex. 3 (regles a 3 atomes)** | Comptez les candidats a 2 vs 3 atomes sur votre KG, extrapolez a 4. Pourquoi AMIE impose-t-il des *regles fermees* (closed rules), et que perd-on en expressivite a ce prix ? |\n"
+    "| **Ex. 3 (regles a 3 atomes)** | Comptez les candidats a 2 vs 3 atomes sur votre KG, extrapolez a 4. Pourquoi AMIE impose-t-il des *regles fermees* (closed rules), et que perd-on en expressivite a ce prix ? |\n",
+    "| **Ex. 4 (reparation minimale)** | Vos reparations optimales sont ex-aequo : toute arete du cycle coute 1. Comment departager ? Ponderez chaque fait par une confiance (par exemple la PCA confidence de la regle qui l'a derive, ou 1.0 pour un fait observe) et adaptez le #minimize : la reparation designe-t-elle maintenant le fait injecte ? |\n"
    ]
   },
   {
@@ -2412,10 +2505,10 @@
    "id": "cf1b23f7",
    "metadata": {
     "papermill": {
-     "duration": 0.005008,
-     "end_time": "2026-06-10T12:35:04.693872",
+     "duration": 0.008215,
+     "end_time": "2026-06-10T14:04:48.474063",
      "exception": false,
-     "start_time": "2026-06-10T12:35:04.688864",
+     "start_time": "2026-06-10T14:04:48.465848",
      "status": "completed"
     },
     "tags": []
@@ -2462,14 +2555,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.430307,
-   "end_time": "2026-06-10T12:35:04.924004",
+   "duration": 4.792891,
+   "end_time": "2026-06-10T14:04:48.821178",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-6-KnowledgeGraphs-ILP.ipynb",
    "output_path": "SL-6-KnowledgeGraphs-ILP.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T12:35:00.493697",
+   "start_time": "2026-06-10T14:04:44.028287",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "097196f2",
    "metadata": {
     "papermill": {
-     "duration": 0.004854,
-     "end_time": "2026-06-10T11:40:10.999492",
+     "duration": 0.008533,
+     "end_time": "2026-06-10T14:02:44.514829",
      "exception": false,
-     "start_time": "2026-06-10T11:40:10.994638",
+     "start_time": "2026-06-10T14:02:44.506296",
      "status": "completed"
     },
     "tags": []
@@ -48,16 +48,16 @@
    "id": "3dc32d19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:10.999492Z",
-     "iopub.status.busy": "2026-06-10T11:40:10.999492Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.027003Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.026423Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.528886Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.527887Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.538998Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.538215Z"
     },
     "papermill": {
-     "duration": 0.028516,
-     "end_time": "2026-06-10T11:40:11.028008",
+     "duration": 0.018683,
+     "end_time": "2026-06-10T14:02:44.540045",
      "exception": false,
-     "start_time": "2026-06-10T11:40:10.999492",
+     "start_time": "2026-06-10T14:02:44.521362",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "23731406",
    "metadata": {
     "papermill": {
-     "duration": 0.004017,
-     "end_time": "2026-06-10T11:40:11.035796",
+     "duration": 0.006871,
+     "end_time": "2026-06-10T14:02:44.553665",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.031779",
+     "start_time": "2026-06-10T14:02:44.546794",
      "status": "completed"
     },
     "tags": []
@@ -144,16 +144,16 @@
    "id": "f1d96718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.045415Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.045415Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.057924Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.057924Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.568602Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.568602Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.585167Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.584168Z"
     },
     "papermill": {
-     "duration": 0.01911,
-     "end_time": "2026-06-10T11:40:11.058928",
+     "duration": 0.025677,
+     "end_time": "2026-06-10T14:02:44.585672",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.039818",
+     "start_time": "2026-06-10T14:02:44.559995",
      "status": "completed"
     },
     "tags": []
@@ -236,10 +236,10 @@
    "id": "3827f67e",
    "metadata": {
     "papermill": {
-     "duration": 0.004926,
-     "end_time": "2026-06-10T11:40:11.071021",
+     "duration": 0.008528,
+     "end_time": "2026-06-10T14:02:44.601709",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.066095",
+     "start_time": "2026-06-10T14:02:44.593181",
      "status": "completed"
     },
     "tags": []
@@ -261,10 +261,10 @@
    "id": "59e172f2",
    "metadata": {
     "papermill": {
-     "duration": 0.007835,
-     "end_time": "2026-06-10T11:40:11.084502",
+     "duration": 0.006782,
+     "end_time": "2026-06-10T14:02:44.615574",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.076667",
+     "start_time": "2026-06-10T14:02:44.608792",
      "status": "completed"
     },
     "tags": []
@@ -299,16 +299,16 @@
    "id": "581df035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.097492Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.097492Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.104490Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.104490Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.632904Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.632379Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.646433Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.645928Z"
     },
     "papermill": {
-     "duration": 0.014811,
-     "end_time": "2026-06-10T11:40:11.105491",
+     "duration": 0.023443,
+     "end_time": "2026-06-10T14:02:44.647437",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.090680",
+     "start_time": "2026-06-10T14:02:44.623994",
      "status": "completed"
     },
     "tags": []
@@ -381,10 +381,10 @@
    "id": "72e21fc7",
    "metadata": {
     "papermill": {
-     "duration": 0.00801,
-     "end_time": "2026-06-10T11:40:11.122529",
+     "duration": 0.007052,
+     "end_time": "2026-06-10T14:02:44.658511",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.114519",
+     "start_time": "2026-06-10T14:02:44.651459",
      "status": "completed"
     },
     "tags": []
@@ -408,16 +408,16 @@
    "id": "eed948cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.136183Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.136183Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.152441Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.151436Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.670034Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.670034Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.678653Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.678046Z"
     },
     "papermill": {
-     "duration": 0.023221,
-     "end_time": "2026-06-10T11:40:11.152441",
+     "duration": 0.014638,
+     "end_time": "2026-06-10T14:02:44.679162",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.129220",
+     "start_time": "2026-06-10T14:02:44.664524",
      "status": "completed"
     },
     "tags": []
@@ -507,10 +507,10 @@
    "id": "85c22afd",
    "metadata": {
     "papermill": {
-     "duration": 0.004704,
-     "end_time": "2026-06-10T11:40:11.162556",
+     "duration": 0.004706,
+     "end_time": "2026-06-10T14:02:44.688493",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.157852",
+     "start_time": "2026-06-10T14:02:44.683787",
      "status": "completed"
     },
     "tags": []
@@ -529,16 +529,16 @@
    "id": "1c109513",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.173246Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.172247Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.183584Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.182900Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.704333Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.703813Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.724701Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.724196Z"
     },
     "papermill": {
-     "duration": 0.017008,
-     "end_time": "2026-06-10T11:40:11.184588",
+     "duration": 0.030748,
+     "end_time": "2026-06-10T14:02:44.725704",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.167580",
+     "start_time": "2026-06-10T14:02:44.694956",
      "status": "completed"
     },
     "tags": []
@@ -651,10 +651,10 @@
    "id": "bf930a24",
    "metadata": {
     "papermill": {
-     "duration": 0.006998,
-     "end_time": "2026-06-10T11:40:11.198788",
+     "duration": 0.006524,
+     "end_time": "2026-06-10T14:02:44.736226",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.191790",
+     "start_time": "2026-06-10T14:02:44.729702",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +685,10 @@
    "id": "d6bb9fe1",
    "metadata": {
     "papermill": {
-     "duration": 0.007001,
-     "end_time": "2026-06-10T11:40:11.212297",
+     "duration": 0.00575,
+     "end_time": "2026-06-10T14:02:44.747747",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.205296",
+     "start_time": "2026-06-10T14:02:44.741997",
      "status": "completed"
     },
     "tags": []
@@ -715,16 +715,16 @@
    "id": "2c0873ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.222975Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.222079Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.230186Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.230186Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.762473Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.761948Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.771502Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.771502Z"
     },
     "papermill": {
-     "duration": 0.013806,
-     "end_time": "2026-06-10T11:40:11.231189",
+     "duration": 0.018971,
+     "end_time": "2026-06-10T14:02:44.773507",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.217383",
+     "start_time": "2026-06-10T14:02:44.754536",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +846,10 @@
    "id": "0f9984a1",
    "metadata": {
     "papermill": {
-     "duration": 0.005513,
-     "end_time": "2026-06-10T11:40:11.241208",
+     "duration": 0.007934,
+     "end_time": "2026-06-10T14:02:44.788959",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.235695",
+     "start_time": "2026-06-10T14:02:44.781025",
      "status": "completed"
     },
     "tags": []
@@ -882,16 +882,16 @@
    "id": "9a30e01b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.254240Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.253718Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.261409Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.260806Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.800471Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.799947Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.818511Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.817921Z"
     },
     "papermill": {
-     "duration": 0.015494,
-     "end_time": "2026-06-10T11:40:11.262452",
+     "duration": 0.025403,
+     "end_time": "2026-06-10T14:02:44.819570",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.246958",
+     "start_time": "2026-06-10T14:02:44.794167",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +974,10 @@
    "id": "74c02d03",
    "metadata": {
     "papermill": {
-     "duration": 0.007295,
-     "end_time": "2026-06-10T11:40:11.276597",
+     "duration": 0.004521,
+     "end_time": "2026-06-10T14:02:44.828145",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.269302",
+     "start_time": "2026-06-10T14:02:44.823624",
      "status": "completed"
     },
     "tags": []
@@ -1013,16 +1013,16 @@
    "id": "83e5f5eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.287406Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.287406Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.309082Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.307484Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.838161Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.838161Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.848559Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.847962Z"
     },
     "papermill": {
-     "duration": 0.027738,
-     "end_time": "2026-06-10T11:40:11.309610",
+     "duration": 0.016962,
+     "end_time": "2026-06-10T14:02:44.849617",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.281872",
+     "start_time": "2026-06-10T14:02:44.832655",
      "status": "completed"
     },
     "tags": []
@@ -1187,10 +1187,10 @@
    "id": "3653b321",
    "metadata": {
     "papermill": {
-     "duration": 0.006575,
-     "end_time": "2026-06-10T11:40:11.323430",
+     "duration": 0.005244,
+     "end_time": "2026-06-10T14:02:44.859070",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.316855",
+     "start_time": "2026-06-10T14:02:44.853826",
      "status": "completed"
     },
     "tags": []
@@ -1223,16 +1223,16 @@
    "id": "dc08268f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.338734Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.338734Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.355333Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.354509Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.870098Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.869571Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.878712Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.878712Z"
     },
     "papermill": {
-     "duration": 0.025939,
-     "end_time": "2026-06-10T11:40:11.356362",
+     "duration": 0.016466,
+     "end_time": "2026-06-10T14:02:44.879712",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.330423",
+     "start_time": "2026-06-10T14:02:44.863246",
      "status": "completed"
     },
     "tags": []
@@ -1308,10 +1308,10 @@
    "id": "a575226a",
    "metadata": {
     "papermill": {
-     "duration": 0.006585,
-     "end_time": "2026-06-10T11:40:11.370493",
+     "duration": 0.004843,
+     "end_time": "2026-06-10T14:02:44.889062",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.363908",
+     "start_time": "2026-06-10T14:02:44.884219",
      "status": "completed"
     },
     "tags": []
@@ -1342,10 +1342,10 @@
    "id": "1bd557a0",
    "metadata": {
     "papermill": {
-     "duration": 0.006788,
-     "end_time": "2026-06-10T11:40:11.385187",
+     "duration": 0.005641,
+     "end_time": "2026-06-10T14:02:44.899517",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.378399",
+     "start_time": "2026-06-10T14:02:44.893876",
      "status": "completed"
     },
     "tags": []
@@ -1385,16 +1385,16 @@
    "id": "f9d67f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.400735Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.400735Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.417194Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.416051Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.914944Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.914421Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.924861Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.924861Z"
     },
     "papermill": {
-     "duration": 0.025577,
-     "end_time": "2026-06-10T11:40:11.418249",
+     "duration": 0.020095,
+     "end_time": "2026-06-10T14:02:44.926422",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.392672",
+     "start_time": "2026-06-10T14:02:44.906327",
      "status": "completed"
     },
     "tags": []
@@ -1537,10 +1537,10 @@
    "id": "2f9d2c01",
    "metadata": {
     "papermill": {
-     "duration": 0.007512,
-     "end_time": "2026-06-10T11:40:11.432975",
+     "duration": 0.004048,
+     "end_time": "2026-06-10T14:02:44.935780",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.425463",
+     "start_time": "2026-06-10T14:02:44.931732",
      "status": "completed"
     },
     "tags": []
@@ -1569,16 +1569,16 @@
    "id": "8917b738",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.449331Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.448820Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.463251Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.462017Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.945902Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.944917Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.956904Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.955903Z"
     },
     "papermill": {
-     "duration": 0.023899,
-     "end_time": "2026-06-10T11:40:11.464277",
+     "duration": 0.016617,
+     "end_time": "2026-06-10T14:02:44.956904",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.440378",
+     "start_time": "2026-06-10T14:02:44.940287",
      "status": "completed"
     },
     "tags": []
@@ -1626,10 +1626,10 @@
    "id": "a2edb6e2",
    "metadata": {
     "papermill": {
-     "duration": 0.007942,
-     "end_time": "2026-06-10T11:40:11.478754",
+     "duration": 0.005516,
+     "end_time": "2026-06-10T14:02:44.967438",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.470812",
+     "start_time": "2026-06-10T14:02:44.961922",
      "status": "completed"
     },
     "tags": []
@@ -1662,16 +1662,16 @@
    "id": "54a6b7c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.495448Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.494921Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.509791Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.508582Z"
+     "iopub.execute_input": "2026-06-10T14:02:44.978493Z",
+     "iopub.status.busy": "2026-06-10T14:02:44.978493Z",
+     "iopub.status.idle": "2026-06-10T14:02:44.987488Z",
+     "shell.execute_reply": "2026-06-10T14:02:44.986629Z"
     },
     "papermill": {
-     "duration": 0.024362,
-     "end_time": "2026-06-10T11:40:11.510848",
+     "duration": 0.01459,
+     "end_time": "2026-06-10T14:02:44.988028",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.486486",
+     "start_time": "2026-06-10T14:02:44.973438",
      "status": "completed"
     },
     "tags": []
@@ -1732,10 +1732,10 @@
    "id": "d74db354",
    "metadata": {
     "papermill": {
-     "duration": 0.007417,
-     "end_time": "2026-06-10T11:40:11.526204",
+     "duration": 0.004185,
+     "end_time": "2026-06-10T14:02:44.996962",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.518787",
+     "start_time": "2026-06-10T14:02:44.992777",
      "status": "completed"
     },
     "tags": []
@@ -1759,10 +1759,10 @@
    "id": "3c2e7728",
    "metadata": {
     "papermill": {
-     "duration": 0.007447,
-     "end_time": "2026-06-10T11:40:11.541081",
+     "duration": 0.004745,
+     "end_time": "2026-06-10T14:02:45.005867",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.533634",
+     "start_time": "2026-06-10T14:02:45.001122",
      "status": "completed"
     },
     "tags": []
@@ -1787,16 +1787,16 @@
    "id": "dada4cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.558123Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.557117Z",
-     "iopub.status.idle": "2026-06-10T11:40:11.570768Z",
-     "shell.execute_reply": "2026-06-10T11:40:11.569756Z"
+     "iopub.execute_input": "2026-06-10T14:02:45.017515Z",
+     "iopub.status.busy": "2026-06-10T14:02:45.016812Z",
+     "iopub.status.idle": "2026-06-10T14:02:45.034099Z",
+     "shell.execute_reply": "2026-06-10T14:02:45.033589Z"
     },
     "papermill": {
-     "duration": 0.022361,
-     "end_time": "2026-06-10T11:40:11.570768",
+     "duration": 0.025025,
+     "end_time": "2026-06-10T14:02:45.035100",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.548407",
+     "start_time": "2026-06-10T14:02:45.010075",
      "status": "completed"
     },
     "tags": []
@@ -1922,10 +1922,10 @@
    "id": "3cc1a67b",
    "metadata": {
     "papermill": {
-     "duration": 0.007334,
-     "end_time": "2026-06-10T11:40:11.586158",
+     "duration": 0.004515,
+     "end_time": "2026-06-10T14:02:45.044804",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.578824",
+     "start_time": "2026-06-10T14:02:45.040289",
      "status": "completed"
     },
     "tags": []
@@ -1953,10 +1953,10 @@
    "id": "74eec2fe",
    "metadata": {
     "papermill": {
-     "duration": 0.007296,
-     "end_time": "2026-06-10T11:40:11.600808",
+     "duration": 0.004505,
+     "end_time": "2026-06-10T14:02:45.052825",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.593512",
+     "start_time": "2026-06-10T14:02:45.048320",
      "status": "completed"
     },
     "tags": []
@@ -1994,16 +1994,16 @@
    "id": "a916457d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:11.617429Z",
-     "iopub.status.busy": "2026-06-10T11:40:11.617429Z",
-     "iopub.status.idle": "2026-06-10T11:40:12.372709Z",
-     "shell.execute_reply": "2026-06-10T11:40:12.372148Z"
+     "iopub.execute_input": "2026-06-10T14:02:45.063086Z",
+     "iopub.status.busy": "2026-06-10T14:02:45.062565Z",
+     "iopub.status.idle": "2026-06-10T14:02:45.962658Z",
+     "shell.execute_reply": "2026-06-10T14:02:45.961515Z"
     },
     "papermill": {
-     "duration": 0.764524,
-     "end_time": "2026-06-10T11:40:12.373225",
+     "duration": 0.90633,
+     "end_time": "2026-06-10T14:02:45.963664",
      "exception": false,
-     "start_time": "2026-06-10T11:40:11.608701",
+     "start_time": "2026-06-10T14:02:45.057334",
      "status": "completed"
     },
     "tags": []
@@ -2051,16 +2051,16 @@
    "id": "426133ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:12.393458Z",
-     "iopub.status.busy": "2026-06-10T11:40:12.393458Z",
-     "iopub.status.idle": "2026-06-10T11:40:30.699008Z",
-     "shell.execute_reply": "2026-06-10T11:40:30.698012Z"
+     "iopub.execute_input": "2026-06-10T14:02:45.976698Z",
+     "iopub.status.busy": "2026-06-10T14:02:45.976194Z",
+     "iopub.status.idle": "2026-06-10T14:03:15.036048Z",
+     "shell.execute_reply": "2026-06-10T14:03:15.034940Z"
     },
     "papermill": {
-     "duration": 18.315317,
-     "end_time": "2026-06-10T11:40:30.699008",
+     "duration": 29.067373,
+     "end_time": "2026-06-10T14:03:15.036558",
      "exception": false,
-     "start_time": "2026-06-10T11:40:12.383691",
+     "start_time": "2026-06-10T14:02:45.969185",
      "status": "completed"
     },
     "tags": []
@@ -2072,35 +2072,32 @@
      "text": [
       "Reponse brute (google/gemini-3.5-flash) :\n",
       "============================================================\n",
-      "En tant qu'expert en apprentissage symbolique (notamment via des algorithmes de type CN2 ou FOIL qui cherchent à maximiser la couverture et la pureté des règles), voici un ensemble de 4 règles logiques sous forme de clauses de Horn. \n",
+      "En tant qu'expert en apprentissage symbolique (notamment via des algorithmes d'induction de règles comme CN2 ou la conversion d'arbres de décision ID3/C4.5), j'ai analysé vos données pour en extraire les motifs les plus discriminants. \n",
       "\n",
-      "Ces règles permettent d'expliquer parfaitement les décisions de classification (généralisation cohérente sans surapprentissage) :\n",
+      "Voici un ensemble de **5 règles logiques (clauses de Horn)** qui expliquent parfaitement et sans contradiction l'intégralité de vos exemples positifs et négatifs.\n",
       "\n",
-      "### Règles pour décider d'attendre (WillWait = True)\n",
+      "### Règles générées :\n",
       "\n",
-      "1. **Patrons = Some AND Hungry = Yes => WillWait**\n",
-      "   *(Explication : S'il y a quelques clients et que l'on a faim, on attend toujours. Couvre les exemples positifs 1, 4 et 5. Aucun faux positif.)*\n",
-      "\n",
-      "2. **Patrons = Full AND Hungry = Yes AND Price = $ => WillWait**\n",
-      "   *(Explication : Si le restaurant est plein et qu'on a faim, on accepte d'attendre uniquement si le prix est très abordable ($). Couvre les exemples positifs 2, 3 et 6. Aucun faux positif.)*\n",
+      "1. `Hungry=No => NOT WillWait`\n",
+      "2. `Patrons=None => NOT WillWait`\n",
+      "3. `Patrons=Full AND Price=$$$ => NOT WillWait`\n",
+      "4. `Patrons=Some AND Hungry=Yes => WillWait`\n",
+      "5. `Patrons=Full AND Hungry=Yes AND Price=$ => WillWait`\n",
       "\n",
       "---\n",
       "\n",
-      "### Règles pour décider de ne pas attendre (NOT WillWait)\n",
-      "\n",
-      "3. **Hungry = No => NOT WillWait**\n",
-      "   *(Explication : Si on n'a pas faim, on n'attend jamais. Couvre les exemples négatifs 1, 2, 3, 4 et 6.)*\n",
-      "\n",
-      "4. **Patrons = None => NOT WillWait**\n",
-      "   *(Explication : Si le restaurant est vide, c'est suspect ou fermé, on n'at\n",
+      "### Explications de la couverture des données :\n",
+      "* **Règle 1 & 2 (Négatives fortes) :** Si le client n'a pas faim (`Hungry=No`) ou s'il n'y a personne dans le restaurant (`Patrons=None`), le client n'attend jamais (couvre les exemples négatifs 1, 2, 3, 4, 6).\n",
+      "* **Règle 3 (Négative contextuelle) :** Même si le client a faim, si le restaurant est plein (`Patrons=Full`) et très cher (`Price=$$$`), il refuse d'attendre (couvre l'exemple négatif 5 et le négatif 2).\n",
+      "* **Règle 4 (Positive simple) :** S'il y a quelques clients (`Patrons=Some`) et que le clie\n",
       "============================================================\n",
       "\n",
       "Regles parsees : 5\n",
-      "  R1: Patrons = Some AND Hungry = Yes => WillWait\n",
-      "  R2: Patrons = Full AND Hungry = Yes AND Price = $ => WillWait\n",
-      "  R3: Hungry = No => NOT WillWait\n",
-      "  R4: Patrons = None => NOT WillWait\n",
-      "  R5: Patrons = Full AND Price = $$$ => NOT WillWait\n"
+      "  R1: Hungry=No => NOT WillWait\n",
+      "  R2: Patrons=None => NOT WillWait\n",
+      "  R3: Patrons=Full AND Price=$$$ => NOT WillWait\n",
+      "  R4: Patrons=Some AND Hungry=Yes => WillWait\n",
+      "  R5: Patrons=Full AND Hungry=Yes AND Price=$ => WillWait\n"
      ]
     }
    ],
@@ -2181,16 +2178,16 @@
    "id": "6e670307",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:30.709518Z",
-     "iopub.status.busy": "2026-06-10T11:40:30.708518Z",
-     "iopub.status.idle": "2026-06-10T11:40:30.714748Z",
-     "shell.execute_reply": "2026-06-10T11:40:30.714028Z"
+     "iopub.execute_input": "2026-06-10T14:03:15.048260Z",
+     "iopub.status.busy": "2026-06-10T14:03:15.048260Z",
+     "iopub.status.idle": "2026-06-10T14:03:15.066795Z",
+     "shell.execute_reply": "2026-06-10T14:03:15.065793Z"
     },
     "papermill": {
-     "duration": 0.011238,
-     "end_time": "2026-06-10T11:40:30.714748",
+     "duration": 0.025534,
+     "end_time": "2026-06-10T14:03:15.067793",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.703510",
+     "start_time": "2026-06-10T14:03:15.042259",
      "status": "completed"
     },
     "tags": []
@@ -2204,11 +2201,11 @@
       "==============================================================================\n",
       "Regle                                            |  TP |  FP |  Prec |  OK\n",
       "------------------------------------------------------------------------------\n",
-      "Patrons = Some AND Hungry = Yes => WillWait      |   3 |   0 |  1.00 | OUI\n",
-      "Patrons = Full AND Hungry = Yes AND Price = $ => |   3 |   0 |  1.00 | OUI\n",
-      "Hungry = No => NOT WillWait                      |   5 |   0 |  1.00 | OUI\n",
-      "Patrons = None => NOT WillWait                   |   2 |   0 |  1.00 | OUI\n",
-      "Patrons = Full AND Price = $$$ => NOT WillWait   |   2 |   0 |  1.00 | OUI\n",
+      "Hungry=No => NOT WillWait                        |   5 |   0 |  1.00 | OUI\n",
+      "Patrons=None => NOT WillWait                     |   2 |   0 |  1.00 | OUI\n",
+      "Patrons=Full AND Price=$$$ => NOT WillWait       |   2 |   0 |  1.00 | OUI\n",
+      "Patrons=Some AND Hungry=Yes => WillWait          |   3 |   0 |  1.00 | OUI\n",
+      "Patrons=Full AND Hungry=Yes AND Price=$ => WillW |   3 |   0 |  1.00 | OUI\n",
       "\n",
       "Bilan LLM reel  : 5/5 regles validees par l'oracle\n",
       "Bilan simulateur: 2/5 regles validees (section 3)\n",
@@ -2247,10 +2244,10 @@
    "id": "d4216022",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T11:40:30.722796",
+     "duration": 0.005508,
+     "end_time": "2026-06-10T14:03:15.080812",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.718796",
+     "start_time": "2026-06-10T14:03:15.075304",
      "status": "completed"
     },
     "tags": []
@@ -2288,10 +2285,10 @@
    "id": "ba9beb92",
    "metadata": {
     "papermill": {
-     "duration": 0.004004,
-     "end_time": "2026-06-10T11:40:30.730800",
+     "duration": 0.004913,
+     "end_time": "2026-06-10T14:03:15.091726",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.726796",
+     "start_time": "2026-06-10T14:03:15.086813",
      "status": "completed"
     },
     "tags": []
@@ -2307,10 +2304,10 @@
    "id": "3c800f32",
    "metadata": {
     "papermill": {
-     "duration": 0.004002,
-     "end_time": "2026-06-10T11:40:30.739317",
+     "duration": 0.007508,
+     "end_time": "2026-06-10T14:03:15.107099",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.735315",
+     "start_time": "2026-06-10T14:03:15.099591",
      "status": "completed"
     },
     "tags": []
@@ -2333,16 +2330,16 @@
    "id": "5101d0d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:30.749315Z",
-     "iopub.status.busy": "2026-06-10T11:40:30.748315Z",
-     "iopub.status.idle": "2026-06-10T11:40:30.761250Z",
-     "shell.execute_reply": "2026-06-10T11:40:30.760615Z"
+     "iopub.execute_input": "2026-06-10T14:03:15.117671Z",
+     "iopub.status.busy": "2026-06-10T14:03:15.117671Z",
+     "iopub.status.idle": "2026-06-10T14:03:15.130302Z",
+     "shell.execute_reply": "2026-06-10T14:03:15.129680Z"
     },
     "papermill": {
-     "duration": 0.018982,
-     "end_time": "2026-06-10T11:40:30.762305",
+     "duration": 0.020162,
+     "end_time": "2026-06-10T14:03:15.131309",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.743323",
+     "start_time": "2026-06-10T14:03:15.111147",
      "status": "completed"
     },
     "tags": []
@@ -2389,10 +2386,10 @@
    "id": "2936e442",
    "metadata": {
     "papermill": {
-     "duration": 0.004165,
-     "end_time": "2026-06-10T11:40:30.772820",
+     "duration": 0.009001,
+     "end_time": "2026-06-10T14:03:15.145307",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.768655",
+     "start_time": "2026-06-10T14:03:15.136306",
      "status": "completed"
     },
     "tags": []
@@ -2414,16 +2411,16 @@
    "id": "174aa8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:30.781872Z",
-     "iopub.status.busy": "2026-06-10T11:40:30.781872Z",
-     "iopub.status.idle": "2026-06-10T11:40:30.791134Z",
-     "shell.execute_reply": "2026-06-10T11:40:30.791134Z"
+     "iopub.execute_input": "2026-06-10T14:03:15.162675Z",
+     "iopub.status.busy": "2026-06-10T14:03:15.161677Z",
+     "iopub.status.idle": "2026-06-10T14:03:15.177054Z",
+     "shell.execute_reply": "2026-06-10T14:03:15.175938Z"
     },
     "papermill": {
-     "duration": 0.015262,
-     "end_time": "2026-06-10T11:40:30.792134",
+     "duration": 0.02496,
+     "end_time": "2026-06-10T14:03:15.177611",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.776872",
+     "start_time": "2026-06-10T14:03:15.152651",
      "status": "completed"
     },
     "tags": []
@@ -2467,10 +2464,10 @@
    "id": "0962260b",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-06-10T11:40:30.803134",
+     "duration": 0.010711,
+     "end_time": "2026-06-10T14:03:15.191853",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.799135",
+     "start_time": "2026-06-10T14:03:15.181142",
      "status": "completed"
     },
     "tags": []
@@ -2492,16 +2489,16 @@
    "id": "3548d43c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:40:30.815884Z",
-     "iopub.status.busy": "2026-06-10T11:40:30.815363Z",
-     "iopub.status.idle": "2026-06-10T11:40:30.823866Z",
-     "shell.execute_reply": "2026-06-10T11:40:30.823224Z"
+     "iopub.execute_input": "2026-06-10T14:03:15.208380Z",
+     "iopub.status.busy": "2026-06-10T14:03:15.208380Z",
+     "iopub.status.idle": "2026-06-10T14:03:15.224405Z",
+     "shell.execute_reply": "2026-06-10T14:03:15.223403Z"
     },
     "papermill": {
-     "duration": 0.016269,
-     "end_time": "2026-06-10T11:40:30.824914",
+     "duration": 0.026052,
+     "end_time": "2026-06-10T14:03:15.224909",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.808645",
+     "start_time": "2026-06-10T14:03:15.198857",
      "status": "completed"
     },
     "tags": []
@@ -2563,13 +2560,86 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3818d99f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007509,
+     "end_time": "2026-06-10T14:03:15.240422",
+     "exception": false,
+     "start_time": "2026-06-10T14:03:15.232913",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : Mesurer le taux d'hallucination du vrai LLM\n",
+    "\n",
+    "La section 7 a valide UN lot de regles du vrai LLM. Un seul tirage ne mesure\n",
+    "rien : la generation est stochastique. Estimez le **taux de validation oracle**\n",
+    "du generateur, et son evolution avec la temperature."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "b1ef475c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T14:03:15.252635Z",
+     "iopub.status.busy": "2026-06-10T14:03:15.252635Z",
+     "iopub.status.idle": "2026-06-10T14:03:15.271579Z",
+     "shell.execute_reply": "2026-06-10T14:03:15.270586Z"
+    },
+    "papermill": {
+     "duration": 0.026172,
+     "end_time": "2026-06-10T14:03:15.272579",
+     "exception": false,
+     "start_time": "2026-06-10T14:03:15.246407",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer (LLM reel configure)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : Taux d'hallucination du vrai LLM\n",
+    "# TODO etudiant : repetez la generation de la section 7 et mesurez quelle fraction\n",
+    "# des regles produites survit a l'oracle symbolique.\n",
+    "# Etape 1 : ecrivez generate_rules(temperature) qui rejoue l'appel LLM de la\n",
+    "#           section 7 (meme prompt, parse_llm_rules) avec ce parametre.\n",
+    "# Etape 2 : pour temperature dans (0.2, 0.9), faites 5 tirages chacun ;\n",
+    "#           pour chaque tirage, comptez n_generees et n_validees (verify_rule\n",
+    "#           sur EXAMPLES, garder is_consistent).\n",
+    "# Etape 3 : affichez par temperature : total genere, total valide, taux de\n",
+    "#           validation. La temperature elevee produit-elle plus de regles\n",
+    "#           valides au total, ou seulement plus de bruit ?\n",
+    "# Etape 4 : l'oracle rend-il le pipeline insensible a la temperature ? Qu'est-ce\n",
+    "#           qui change vraiment entre les deux reglages (cout, diversite) ?\n",
+    "# Indice : sans .env, utilisez le simulateur en faisant varier la graine plutot\n",
+    "#          que la temperature -- la question (stochasticite vs oracle) est la meme.\n",
+    "\n",
+    "if LLM_AVAILABLE:\n",
+    "    print(\"Exercice a completer (LLM reel configure)\")\n",
+    "else:\n",
+    "    print(\"Exercice a completer (pas de .env : variante simulateur, cf. indice)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7cb00ad4",
    "metadata": {
     "papermill": {
-     "duration": 0.004702,
-     "end_time": "2026-06-10T11:40:30.836230",
+     "duration": 0.004639,
+     "end_time": "2026-06-10T14:03:15.284257",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.831528",
+     "start_time": "2026-06-10T14:03:15.279618",
      "status": "completed"
     },
     "tags": []
@@ -2618,7 +2688,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "227e37ae",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005703,
+     "end_time": "2026-06-10T14:03:15.295641",
+     "exception": false,
+     "start_time": "2026-06-10T14:03:15.289938",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -2633,7 +2713,8 @@
     "|----------|----------------------------------|\n",
     "| **Ex. 1 (prompt personnalise)** | Changez de modele dans le `.env` (un modele plus petit via OpenRouter) et comparez le taux de validation oracle avec Gemini 3.5 Flash sur le meme prompt. Que conclure sur la dependance du pipeline au generateur --- et sur ce que l'oracle garantit vraiment ? |\n",
     "| **Ex. 2 (prompt direct vs CoT)** | Le CoT ameliore-t-il le taux de validation *oracle* ou seulement la plausibilite du texte ? Les deux metriques peuvent diverger : montrez (ou construisez) un cas. |\n",
-    "| **Ex. 3 (detection d'hallucinations)** | Votre detecteur s'appuie sur un oracle a donnees completes (monde clos). Que devient-il si les donnees sont incompletes (monde ouvert, cf SL-6) ? Proposez et justifiez une adaptation. |\n"
+    "| **Ex. 3 (detection d'hallucinations)** | Votre detecteur s'appuie sur un oracle a donnees completes (monde clos). Que devient-il si les donnees sont incompletes (monde ouvert, cf SL-6) ? Proposez et justifiez une adaptation. |\n",
+    "| **Ex. 4 (taux d'hallucination)** | Le taux d'hallucination est-il un defaut du generateur ou un parametre d'exploration ? Cherchez le reglage qui maximise le nombre de regles VALIDEES par appel (et non le taux de validation) : pourquoi ces deux objectifs divergent-ils, et lequel l'architecture generateur+oracle permet-elle d'assumer sans risque ? |\n"
    ]
   },
   {
@@ -2641,10 +2722,10 @@
    "id": "b2e6b9c6",
    "metadata": {
     "papermill": {
-     "duration": 0.004219,
-     "end_time": "2026-06-10T11:40:30.844534",
+     "duration": 0.008826,
+     "end_time": "2026-06-10T14:03:15.312834",
      "exception": false,
-     "start_time": "2026-06-10T11:40:30.840315",
+     "start_time": "2026-06-10T14:03:15.304008",
      "status": "completed"
     },
     "tags": []
@@ -2686,14 +2767,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 22.103717,
-   "end_time": "2026-06-10T11:40:31.418231",
+   "duration": 33.081054,
+   "end_time": "2026-06-10T14:03:15.766444",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-7-LLM-SymbolicLearning.ipynb",
    "output_path": "SL-7-LLM-SymbolicLearning.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T11:40:09.314514",
+   "start_time": "2026-06-10T14:02:42.685390",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Suite de #2769 (Aleph dans SL-9) et des 4 integrations precedentes (aima SL-1, Popper SL-4, LTNtorch SL-5, clingo SL-6, LLM reel SL-7) : chaque integration de bibliotheque reelle gagne **un exercice dedie** qui la met entre les mains des etudiants, au lieu de rester une demo instructeur.

| NB | Nouvel exercice | Levier pedagogique |
|----|-----------------|--------------------|
| SL-1 | Ex5 — La consistance sans Occam | Echantillonner les graines de `current_best_learning` (aima) : toutes les hypotheses sont consistantes 12/12, leurs tailles varient — le biais de simplicite n'existe pas dans CBH |
| SL-4 | Ex4 — `grandparent` avec Popper | Reutiliser `run_popper` avec un bias non-recursif + verification janus, comme la cellule ablation |
| SL-5 | Ex5 — Ablation de l'axiome 4 | Transformer l'affirmation d'interpretation (negatifs closed-world indispensables) en experience reproductible |
| SL-6 | Ex4 — Reparation minimale | Choice rules + `#minimize` sur le KG cyclique UNSAT de la section : de la detection a la reparation ; les reparations optimales sont ex-aequo |
| SL-7 | Ex4 — Taux d'hallucination | Generations multiples a 2 temperatures, taux de validation oracle ; fallback simulateur sans .env |

Egalement :
- **SL-5 : table « Defi presentation » ajoutee** (seul notebook de la serie qui n'en avait pas) avec twists Ex2-Ex5
- Lignes defi ajoutees aux tables existantes SL-1/SL-4/SL-6/SL-7
- **README : table de pioche 34 -> 40** (6 nouvelles lignes dont SL-9 Ex5 Aleph de #2769, renumerotation complete, note SL-5 « Ex. 2 a Ex. 5 »)

## Validation (regle D)

- Papermill end-to-end **5/5 notebooks**, exit 0 : SL-1 48/48 cells, SL-4 39/39 (kernel `python3-wsl`, `HAS_POPPER=True`), SL-5 38/38, SL-6 51/51, SL-7 48/48 (LLM reel appele, cle jamais affichee)
- Forensic H.3 : `exec_count` non-null sur 100% des cellules code, **0 output error**, exec_counts sequentiels
- C.1 : `grep raise NotImplementedError|assert False|1/0` = 0 hit ; tous les stubs impriment leur sortie reelle (`Exercice a completer`)
- Anti-regression : insertions uniquement, aucune cellule existante supprimee (verif ordre cellule-par-cellule autour de chaque insertion)
- Un bug d'ancrage SL-6 (Ex4 insere entre le md et le code d'Ex3) detecte par la verif d'ordre, corrige, notebook re-execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)