### PR TITLE
fix(sl): harmonize section order across SL series (user-reported SL-4 Ex4 bug + audit)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
@@ -1288,37 +1288,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sl10-32",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006593,
-     "end_time": "2026-06-10T12:11:06.044589",
-     "exception": false,
-     "start_time": "2026-06-10T12:11:06.037996",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## Defi presentation (seance du 17 juin)\n",
-    "\n",
-    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
-    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
-    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
-    "Elle fait partie integrante de la presentation attendue.\n",
-    "\n",
-    "| Exercice | Question-twist a traiter en plus |\n",
-    "|----------|----------------------------------|\n",
-    "| **Ex. 1 (etendre le schema)** | Le mineur va decouvrir `marie_avec(X,Y) :- marie_avec(Y,X)` avec confiance 1.0 : une regle qui ne fait que refleter votre propre completion d'oracle. Comment distinguer mecaniquement une regle *apprise des donnees* d'une regle qui reapprend le *schema* qu'on y a injecte ? |\n",
-    "| **Ex. 2 (politique de conflit)** | Votre politique a sources suppose les fiabilites connues a priori. En *truth discovery*, on les estime en meme temps que les faits (une source est fiable si elle affirme des faits confirmes...). Esquissez l'algorithme de point fixe correspondant et son cas pathologique. |\n",
-    "| **Ex. 3 (seuils)** | `grandparent :- parent o parent` (vraie) et `travaille_pour :- parent o travaille_pour` (fausse) ont la meme confiance 0.67 : aucun seuil ne les separe. Quelle information NON presente dans le KG les separerait (contre-exemples ? intervention ? texte ?) --- et lequel des dix notebooks de la serie fournit l'outil le plus proche ? |\n",
-    "| **Ex. 4 (empoisonnement)** | Classez les defenses par etage (modalite epistemique a l'extraction, contraintes temporelles a l'oracle, pedigree a l'inference) et defendez la these : « la provenance est la seule defense qui passe a l'echelle ». Quelle requete d'apprentissage *actif* (SL-8) le pipeline devrait-il poser pour trancher `travaille_pour(henri, atelier_verne)` ? |\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "sl10-33",
    "metadata": {
     "papermill": {
@@ -1369,6 +1338,37 @@
     "Knowledge Vault), les mineurs de regles sur KG massifs (AMIE+ sur Wikidata), et\n",
     "la generation augmentee par graphe (GraphRAG). Les ingredients sont les memes ;\n",
     "seules les echelles changent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl10-32",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006593,
+     "end_time": "2026-06-10T12:11:06.044589",
+     "exception": false,
+     "start_time": "2026-06-10T12:11:06.037996",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Defi presentation (seance du 17 juin)\n",
+    "\n",
+    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
+    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
+    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
+    "Elle fait partie integrante de la presentation attendue.\n",
+    "\n",
+    "| Exercice | Question-twist a traiter en plus |\n",
+    "|----------|----------------------------------|\n",
+    "| **Ex. 1 (etendre le schema)** | Le mineur va decouvrir `marie_avec(X,Y) :- marie_avec(Y,X)` avec confiance 1.0 : une regle qui ne fait que refleter votre propre completion d'oracle. Comment distinguer mecaniquement une regle *apprise des donnees* d'une regle qui reapprend le *schema* qu'on y a injecte ? |\n",
+    "| **Ex. 2 (politique de conflit)** | Votre politique a sources suppose les fiabilites connues a priori. En *truth discovery*, on les estime en meme temps que les faits (une source est fiable si elle affirme des faits confirmes...). Esquissez l'algorithme de point fixe correspondant et son cas pathologique. |\n",
+    "| **Ex. 3 (seuils)** | `grandparent :- parent o parent` (vraie) et `travaille_pour :- parent o travaille_pour` (fausse) ont la meme confiance 0.67 : aucun seuil ne les separe. Quelle information NON presente dans le KG les separerait (contre-exemples ? intervention ? texte ?) --- et lequel des dix notebooks de la serie fournit l'outil le plus proche ? |\n",
+    "| **Ex. 4 (empoisonnement)** | Classez les defenses par etage (modalite epistemique a l'extraction, contraintes temporelles a l'oracle, pedigree a l'inference) et defendez la these : « la provenance est la seule defense qui passe a l'echelle ». Quelle requete d'apprentissage *actif* (SL-8) le pipeline devrait-il poser pour trancher `travaille_pour(henri, atelier_verne)` ? |\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
@@ -5,10 +5,10 @@
    "id": "266f89ed",
    "metadata": {
     "papermill": {
-     "duration": 0.004139,
-     "end_time": "2026-06-10T14:02:26.163241",
+     "duration": 0.004082,
+     "end_time": "2026-06-10T15:10:58.527599",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.159102",
+     "start_time": "2026-06-10T15:10:58.523517",
      "status": "completed"
     },
     "tags": []
@@ -42,16 +42,16 @@
    "id": "06eb2d41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.171944Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.171661Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.176277Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.175425Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.540024Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.539852Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.543811Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.542921Z"
     },
     "papermill": {
-     "duration": 0.013219,
-     "end_time": "2026-06-10T14:02:26.180164",
+     "duration": 0.009308,
+     "end_time": "2026-06-10T15:10:58.539900",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.166945",
+     "start_time": "2026-06-10T15:10:58.530592",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "5136dc92",
    "metadata": {
     "papermill": {
-     "duration": 0.005793,
-     "end_time": "2026-06-10T14:02:26.191691",
+     "duration": 0.003036,
+     "end_time": "2026-06-10T15:10:58.546548",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.185898",
+     "start_time": "2026-06-10T15:10:58.543512",
      "status": "completed"
     },
     "tags": []
@@ -142,10 +142,10 @@
    "id": "934f66f1",
    "metadata": {
     "papermill": {
-     "duration": 0.00465,
-     "end_time": "2026-06-10T14:02:26.199476",
+     "duration": 0.003417,
+     "end_time": "2026-06-10T15:10:58.553068",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.194826",
+     "start_time": "2026-06-10T15:10:58.549651",
      "status": "completed"
     },
     "tags": []
@@ -177,16 +177,16 @@
    "id": "4bc27cf5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.210331Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.210141Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.220757Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.219638Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.566886Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.566621Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.577333Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.576160Z"
     },
     "papermill": {
-     "duration": 0.01902,
-     "end_time": "2026-06-10T14:02:26.224295",
+     "duration": 0.016357,
+     "end_time": "2026-06-10T15:10:58.573101",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.205275",
+     "start_time": "2026-06-10T15:10:58.556744",
      "status": "completed"
     },
     "tags": []
@@ -350,10 +350,10 @@
    "id": "bcb1f969",
    "metadata": {
     "papermill": {
-     "duration": 0.005789,
-     "end_time": "2026-06-10T14:02:26.236615",
+     "duration": 0.004031,
+     "end_time": "2026-06-10T15:10:58.582060",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.230826",
+     "start_time": "2026-06-10T15:10:58.578029",
      "status": "completed"
     },
     "tags": []
@@ -377,10 +377,10 @@
    "id": "cec859d5",
    "metadata": {
     "papermill": {
-     "duration": 0.006247,
-     "end_time": "2026-06-10T14:02:26.249054",
+     "duration": 0.004275,
+     "end_time": "2026-06-10T15:10:58.589061",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.242807",
+     "start_time": "2026-06-10T15:10:58.584786",
      "status": "completed"
     },
     "tags": []
@@ -422,16 +422,16 @@
    "id": "bad9e00d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.259669Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.259484Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.266039Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.265277Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.602795Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.602610Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.610688Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.609266Z"
     },
     "papermill": {
-     "duration": 0.014105,
-     "end_time": "2026-06-10T14:02:26.269471",
+     "duration": 0.013996,
+     "end_time": "2026-06-10T15:10:58.607056",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.255366",
+     "start_time": "2026-06-10T15:10:58.593060",
      "status": "completed"
     },
     "tags": []
@@ -551,10 +551,10 @@
    "id": "15c74a56",
    "metadata": {
     "papermill": {
-     "duration": 0.006758,
-     "end_time": "2026-06-10T14:02:26.280935",
+     "duration": 0.005852,
+     "end_time": "2026-06-10T15:10:58.617266",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.274177",
+     "start_time": "2026-06-10T15:10:58.611414",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "2c67b535",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.292199Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.292017Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.296867Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.295941Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.634441Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.634268Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.639685Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.638528Z"
     },
     "papermill": {
-     "duration": 0.01275,
-     "end_time": "2026-06-10T14:02:26.300144",
+     "duration": 0.012571,
+     "end_time": "2026-06-10T15:10:58.636110",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.287394",
+     "start_time": "2026-06-10T15:10:58.623539",
      "status": "completed"
     },
     "tags": []
@@ -654,10 +654,10 @@
    "id": "a621e158",
    "metadata": {
     "papermill": {
-     "duration": 0.007311,
-     "end_time": "2026-06-10T14:02:26.315199",
+     "duration": 0.004953,
+     "end_time": "2026-06-10T15:10:58.644498",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.307888",
+     "start_time": "2026-06-10T15:10:58.639545",
      "status": "completed"
     },
     "tags": []
@@ -672,16 +672,16 @@
    "id": "a3200acb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.327519Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.327335Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.334427Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.333612Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.657291Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.657124Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.664192Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.663311Z"
     },
     "papermill": {
-     "duration": 0.015581,
-     "end_time": "2026-06-10T14:02:26.337540",
+     "duration": 0.011858,
+     "end_time": "2026-06-10T15:10:58.660003",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.321959",
+     "start_time": "2026-06-10T15:10:58.648145",
      "status": "completed"
     },
     "tags": []
@@ -808,10 +808,10 @@
    "id": "f1ebd7f3",
    "metadata": {
     "papermill": {
-     "duration": 0.005004,
-     "end_time": "2026-06-10T14:02:26.349223",
+     "duration": 0.004661,
+     "end_time": "2026-06-10T15:10:58.668710",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.344219",
+     "start_time": "2026-06-10T15:10:58.664049",
      "status": "completed"
     },
     "tags": []
@@ -839,10 +839,10 @@
    "id": "0630919b",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T14:02:26.358732",
+     "duration": 0.003,
+     "end_time": "2026-06-10T15:10:58.675021",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.353732",
+     "start_time": "2026-06-10T15:10:58.672021",
      "status": "completed"
     },
     "tags": []
@@ -877,16 +877,16 @@
    "id": "e1385825",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.371162Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.370978Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.378442Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.377687Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.688947Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.688694Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.695756Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.695019Z"
     },
     "papermill": {
-     "duration": 0.016103,
-     "end_time": "2026-06-10T14:02:26.381854",
+     "duration": 0.013501,
+     "end_time": "2026-06-10T15:10:58.692041",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.365751",
+     "start_time": "2026-06-10T15:10:58.678540",
      "status": "completed"
     },
     "tags": []
@@ -1044,10 +1044,10 @@
    "id": "f4c90f47",
    "metadata": {
     "papermill": {
-     "duration": 0.006999,
-     "end_time": "2026-06-10T14:02:26.397882",
+     "duration": 0.002511,
+     "end_time": "2026-06-10T15:10:58.698163",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.390883",
+     "start_time": "2026-06-10T15:10:58.695652",
      "status": "completed"
     },
     "tags": []
@@ -1070,10 +1070,10 @@
    "id": "65c8458f",
    "metadata": {
     "papermill": {
-     "duration": 0.007078,
-     "end_time": "2026-06-10T14:02:26.410482",
+     "duration": 0.002998,
+     "end_time": "2026-06-10T15:10:58.705183",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.403404",
+     "start_time": "2026-06-10T15:10:58.702185",
      "status": "completed"
     },
     "tags": []
@@ -1092,16 +1092,16 @@
    "id": "474df76d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.422302Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.422114Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.435099Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.434014Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.718179Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.718017Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.728669Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.727955Z"
     },
     "papermill": {
-     "duration": 0.022687,
-     "end_time": "2026-06-10T14:02:26.439169",
+     "duration": 0.015107,
+     "end_time": "2026-06-10T15:10:58.723795",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.416482",
+     "start_time": "2026-06-10T15:10:58.708688",
      "status": "completed"
     },
     "tags": []
@@ -1279,10 +1279,10 @@
    "id": "824ba714",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T14:02:26.449387",
+     "duration": 0.003998,
+     "end_time": "2026-06-10T15:10:58.731823",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.445387",
+     "start_time": "2026-06-10T15:10:58.727825",
      "status": "completed"
     },
     "tags": []
@@ -1325,10 +1325,10 @@
    "id": "da423029",
    "metadata": {
     "papermill": {
-     "duration": 0.006023,
-     "end_time": "2026-06-10T14:02:26.461918",
+     "duration": 0.003,
+     "end_time": "2026-06-10T15:10:58.738334",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.455895",
+     "start_time": "2026-06-10T15:10:58.735334",
      "status": "completed"
     },
     "tags": []
@@ -1365,16 +1365,16 @@
    "id": "d4641c82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.470982Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.470776Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.476429Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.475678Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.751387Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.751195Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.756351Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.755600Z"
     },
     "papermill": {
-     "duration": 0.012955,
-     "end_time": "2026-06-10T14:02:26.480865",
+     "duration": 0.010016,
+     "end_time": "2026-06-10T15:10:58.752350",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.467910",
+     "start_time": "2026-06-10T15:10:58.742334",
      "status": "completed"
     },
     "tags": []
@@ -1405,18 +1405,18 @@
       "\n",
       "2. Transitivite de localisation :\n",
       "   livesIn(X, Z) :- livesIn(X, Y), locatedIn(Y, Z).\n",
-      "   Charlie livesIn Lyon, Lyon locatedIn France => Charlie livesIn France [IMPLICITE (infere)]\n",
       "   Bob livesIn Paris, Paris locatedIn France => Bob livesIn France [IMPLICITE (infere)]\n",
-      "   Diana livesIn Paris, Paris locatedIn France => Diana livesIn France [IMPLICITE (infere)]\n",
       "   Alice livesIn Paris, Paris locatedIn France => Alice livesIn France [IMPLICITE (infere)]\n",
+      "   Diana livesIn Paris, Paris locatedIn France => Diana livesIn France [IMPLICITE (infere)]\n",
+      "   Charlie livesIn Lyon, Lyon locatedIn France => Charlie livesIn France [IMPLICITE (infere)]\n",
       "   Total inferences possibles : 4\n",
       "\n",
       "3. Co-residence des epoux :\n",
       "   livesIn(X, L) :- marriedTo(X, Y), livesIn(Y, L).\n",
       "   Bob marriedTo Alice, Alice livesIn Paris => Bob livesIn Paris [EXPLICITE]\n",
       "   Diana marriedTo Charlie, Charlie livesIn Lyon => Diana livesIn Lyon [NON VERIFIE]\n",
-      "   Charlie marriedTo Diana, Diana livesIn Paris => Charlie livesIn Paris [NON VERIFIE]\n",
       "   Alice marriedTo Bob, Bob livesIn Paris => Alice livesIn Paris [EXPLICITE]\n",
+      "   Charlie marriedTo Diana, Diana livesIn Paris => Charlie livesIn Paris [NON VERIFIE]\n",
       "   Total inferences : 4\n"
      ]
     }
@@ -1492,10 +1492,10 @@
    "id": "3e601ecb",
    "metadata": {
     "papermill": {
-     "duration": 0.006012,
-     "end_time": "2026-06-10T14:02:26.497577",
+     "duration": 0.003507,
+     "end_time": "2026-06-10T15:10:58.759857",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.491565",
+     "start_time": "2026-06-10T15:10:58.756350",
      "status": "completed"
     },
     "tags": []
@@ -1519,10 +1519,10 @@
    "id": "d5be334e",
    "metadata": {
     "papermill": {
-     "duration": 0.007041,
-     "end_time": "2026-06-10T14:02:26.511619",
+     "duration": 0.003504,
+     "end_time": "2026-06-10T15:10:58.766869",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.504578",
+     "start_time": "2026-06-10T15:10:58.763365",
      "status": "completed"
     },
     "tags": []
@@ -1536,10 +1536,10 @@
    "id": "77f0ac97",
    "metadata": {
     "papermill": {
-     "duration": 0.005489,
-     "end_time": "2026-06-10T14:02:26.522732",
+     "duration": 0.003,
+     "end_time": "2026-06-10T15:10:58.772875",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.517243",
+     "start_time": "2026-06-10T15:10:58.769875",
      "status": "completed"
     },
     "tags": []
@@ -1576,16 +1576,16 @@
    "id": "8022039d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.530905Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.530729Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.543955Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.542420Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.785683Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.785521Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.796271Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.795582Z"
     },
     "papermill": {
-     "duration": 0.018797,
-     "end_time": "2026-06-10T14:02:26.546803",
+     "duration": 0.015633,
+     "end_time": "2026-06-10T15:10:58.792506",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.528006",
+     "start_time": "2026-06-10T15:10:58.776873",
      "status": "completed"
     },
     "tags": []
@@ -1596,13 +1596,7 @@
      "output_type": "stream",
      "text": [
       "Python : 3.12.3 (Linux)\n",
-      "swipl  : /usr/bin/swipl\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "swipl  : /usr/bin/swipl\n",
       "clingo : 5.8.0\n",
       "Popper : v4.4.0 -- pret\n"
      ]
@@ -1642,16 +1636,16 @@
    "id": "878ee645",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.559397Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.559195Z",
-     "iopub.status.idle": "2026-06-10T14:02:26.836171Z",
-     "shell.execute_reply": "2026-06-10T14:02:26.834616Z"
+     "iopub.execute_input": "2026-06-10T15:10:58.805609Z",
+     "iopub.status.busy": "2026-06-10T15:10:58.805452Z",
+     "iopub.status.idle": "2026-06-10T15:10:58.998885Z",
+     "shell.execute_reply": "2026-06-10T15:10:58.997886Z"
     },
     "papermill": {
-     "duration": 0.285674,
-     "end_time": "2026-06-10T14:02:26.840144",
+     "duration": 0.199553,
+     "end_time": "2026-06-10T15:10:58.995109",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.554470",
+     "start_time": "2026-06-10T15:10:58.795556",
      "status": "completed"
     },
     "tags": []
@@ -1663,8 +1657,8 @@
      "text": [
       "Programme appris par Popper :\n",
       "\n",
-      "ancestor(V0,V1):- parent(V0,V1).\n",
       "ancestor(V0,V1):- parent(V0,V2),ancestor(V2,V1).\n",
+      "ancestor(V0,V1):- parent(V0,V1).\n",
       "\n",
       "Score : 9 tp, 0 fn, 10 tn, 0 fp -- taille 5 litteraux\n"
      ]
@@ -1728,16 +1722,16 @@
    "id": "bacc8d6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:26.852109Z",
-     "iopub.status.busy": "2026-06-10T14:02:26.851836Z",
-     "iopub.status.idle": "2026-06-10T14:02:27.214329Z",
-     "shell.execute_reply": "2026-06-10T14:02:27.212815Z"
+     "iopub.execute_input": "2026-06-10T15:10:59.008300Z",
+     "iopub.status.busy": "2026-06-10T15:10:59.008137Z",
+     "iopub.status.idle": "2026-06-10T15:10:59.219984Z",
+     "shell.execute_reply": "2026-06-10T15:10:59.219231Z"
     },
     "papermill": {
-     "duration": 0.371669,
-     "end_time": "2026-06-10T14:02:27.218986",
+     "duration": 0.21687,
+     "end_time": "2026-06-10T15:10:59.216159",
      "exception": false,
-     "start_time": "2026-06-10T14:02:26.847317",
+     "start_time": "2026-06-10T15:10:58.999289",
      "status": "completed"
     },
     "tags": []
@@ -1750,10 +1744,16 @@
       "Sans enable_recursion :\n",
       "\n",
       "ancestor(V0,V1):- parent(V2,V1),parent(V3,V2),parent(V0,V3).\n",
-      "ancestor(V0,V1):- parent(V0,V2),parent(V2,V1).\n",
       "ancestor(V0,V1):- parent(V0,V1).\n",
+      "ancestor(V0,V1):- parent(V2,V1),parent(V0,V2).\n",
       "\n",
-      "Score : 9 tp, 0 fn, 10 tn, 0 fp -- taille 9 litteraux\n",
+      "Score : 9 tp, 0 fn, 10 tn, 0 fp -- taille 9 litteraux\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "Verification SWI-Prolog du programme recursif :\n",
       "  9/9 positifs derives, 0/10 negatifs derives\n"
@@ -1794,10 +1794,10 @@
    "id": "eb7b46ef",
    "metadata": {
     "papermill": {
-     "duration": 0.007042,
-     "end_time": "2026-06-10T14:02:27.233962",
+     "duration": 0.003649,
+     "end_time": "2026-06-10T15:10:59.223951",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.226920",
+     "start_time": "2026-06-10T15:10:59.220302",
      "status": "completed"
     },
     "tags": []
@@ -1841,10 +1841,10 @@
    "id": "18e8e42f",
    "metadata": {
     "papermill": {
-     "duration": 0.007601,
-     "end_time": "2026-06-10T14:02:27.247688",
+     "duration": 0.00261,
+     "end_time": "2026-06-10T15:10:59.230277",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.240087",
+     "start_time": "2026-06-10T15:10:59.227667",
      "status": "completed"
     },
     "tags": []
@@ -1871,16 +1871,16 @@
    "id": "4e6e75a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:27.259900Z",
-     "iopub.status.busy": "2026-06-10T14:02:27.259621Z",
-     "iopub.status.idle": "2026-06-10T14:02:27.264210Z",
-     "shell.execute_reply": "2026-06-10T14:02:27.263002Z"
+     "iopub.execute_input": "2026-06-10T15:10:59.243641Z",
+     "iopub.status.busy": "2026-06-10T15:10:59.243479Z",
+     "iopub.status.idle": "2026-06-10T15:10:59.246883Z",
+     "shell.execute_reply": "2026-06-10T15:10:59.246071Z"
     },
     "papermill": {
-     "duration": 0.014741,
-     "end_time": "2026-06-10T14:02:27.269153",
+     "duration": 0.008394,
+     "end_time": "2026-06-10T15:10:59.243262",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.254412",
+     "start_time": "2026-06-10T15:10:59.234868",
      "status": "completed"
     },
     "tags": []
@@ -1920,10 +1920,10 @@
    "id": "d5bb07b4",
    "metadata": {
     "papermill": {
-     "duration": 0.007882,
-     "end_time": "2026-06-10T14:02:27.283555",
+     "duration": 0.003638,
+     "end_time": "2026-06-10T15:10:59.250588",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.275673",
+     "start_time": "2026-06-10T15:10:59.246950",
      "status": "completed"
     },
     "tags": []
@@ -1938,16 +1938,16 @@
    "id": "498d3825",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:27.296134Z",
-     "iopub.status.busy": "2026-06-10T14:02:27.295865Z",
-     "iopub.status.idle": "2026-06-10T14:02:27.300210Z",
-     "shell.execute_reply": "2026-06-10T14:02:27.299004Z"
+     "iopub.execute_input": "2026-06-10T15:10:59.263424Z",
+     "iopub.status.busy": "2026-06-10T15:10:59.263262Z",
+     "iopub.status.idle": "2026-06-10T15:10:59.266150Z",
+     "shell.execute_reply": "2026-06-10T15:10:59.265533Z"
     },
     "papermill": {
-     "duration": 0.013301,
-     "end_time": "2026-06-10T14:02:27.304374",
+     "duration": 0.008055,
+     "end_time": "2026-06-10T15:10:59.262349",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.291073",
+     "start_time": "2026-06-10T15:10:59.254294",
      "status": "completed"
     },
     "tags": []
@@ -1984,10 +1984,10 @@
    "id": "403bc426",
    "metadata": {
     "papermill": {
-     "duration": 0.007328,
-     "end_time": "2026-06-10T14:02:27.319122",
+     "duration": 0.003511,
+     "end_time": "2026-06-10T15:10:59.269740",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.311794",
+     "start_time": "2026-06-10T15:10:59.266229",
      "status": "completed"
     },
     "tags": []
@@ -2002,16 +2002,16 @@
    "id": "fa814830",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:27.330755Z",
-     "iopub.status.busy": "2026-06-10T14:02:27.330565Z",
-     "iopub.status.idle": "2026-06-10T14:02:27.334530Z",
-     "shell.execute_reply": "2026-06-10T14:02:27.333701Z"
+     "iopub.execute_input": "2026-06-10T15:10:59.282518Z",
+     "iopub.status.busy": "2026-06-10T15:10:59.282366Z",
+     "iopub.status.idle": "2026-06-10T15:10:59.285727Z",
+     "shell.execute_reply": "2026-06-10T15:10:59.284953Z"
     },
     "papermill": {
-     "duration": 0.014165,
-     "end_time": "2026-06-10T14:02:27.339047",
+     "duration": 0.008529,
+     "end_time": "2026-06-10T15:10:59.282284",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.324882",
+     "start_time": "2026-06-10T15:10:59.273755",
      "status": "completed"
     },
     "tags": []
@@ -2064,13 +2064,86 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0762f5f5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003527,
+     "end_time": "2026-06-10T15:10:59.289315",
+     "exception": false,
+     "start_time": "2026-06-10T15:10:59.285788",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : grandparent avec Popper\n",
+    "\n",
+    "La section Popper a appris `ancestor/2` (recursif). A vous d'apprendre\n",
+    "`grandparent/2` (non recursif) avec la meme machinerie `run_popper`, sur la\n",
+    "meme famille."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "972eb4bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T15:10:59.301421Z",
+     "iopub.status.busy": "2026-06-10T15:10:59.301292Z",
+     "iopub.status.idle": "2026-06-10T15:10:59.304081Z",
+     "shell.execute_reply": "2026-06-10T15:10:59.303440Z"
+    },
+    "papermill": {
+     "duration": 0.007523,
+     "end_time": "2026-06-10T15:10:59.300337",
+     "exception": false,
+     "start_time": "2026-06-10T15:10:59.292814",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : grandparent avec Popper\n",
+    "# TODO etudiant : faites apprendre grandparent(X, Y) a Popper a partir des memes\n",
+    "# faits parent que la section Popper, et verifiez le programme appris en Prolog.\n",
+    "# Etape 1 : definissez GP_POS (les paires grand-parent de la famille) et GP_NEG\n",
+    "#           (paires variees : parents directs, arriere-grands-parents, inverses).\n",
+    "# Etape 2 : construisez un repertoire de tache comme la cellule Popper :\n",
+    "#           bk.pl identique, exs.pl avec pos(grandparent(...))/neg(grandparent(...)),\n",
+    "#           bias.pl : max_vars(3). max_body(2). max_clauses(1).\n",
+    "#                     head_pred(grandparent,2). body_pred(parent,2).\n",
+    "#           (pas de enable_recursion : grandparent n'en a pas besoin)\n",
+    "# Etape 3 : result_gp = run_popper(task_gp) ; affichez programme + score.\n",
+    "# Etape 4 : verifiez avec janus (cf. cellule ablation) que le programme derive\n",
+    "#           exactement GP_POS et aucun GP_NEG.\n",
+    "# Indice : si Popper retourne un programme errone trop general, regardez vos\n",
+    "#          negatifs : couvrent-ils la frontiere (arriere-grands-parents) ?\n",
+    "\n",
+    "if HAS_POPPER:\n",
+    "    print(\"Exercice a completer\")\n",
+    "else:\n",
+    "    print(\"Popper indisponible : exercice a faire sur le kernel python3-wsl.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d7fb32ee",
    "metadata": {
     "papermill": {
-     "duration": 0.007607,
-     "end_time": "2026-06-10T14:02:27.354341",
+     "duration": 0.004175,
+     "end_time": "2026-06-10T15:10:59.308041",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.346734",
+     "start_time": "2026-06-10T15:10:59.303866",
      "status": "completed"
     },
     "tags": []
@@ -2116,86 +2189,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0762f5f5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007281,
-     "end_time": "2026-06-10T14:02:27.368964",
-     "exception": false,
-     "start_time": "2026-06-10T14:02:27.361683",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice 4 : grandparent avec Popper\n",
-    "\n",
-    "La section Popper a appris `ancestor/2` (recursif). A vous d'apprendre\n",
-    "`grandparent/2` (non recursif) avec la meme machinerie `run_popper`, sur la\n",
-    "meme famille."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "972eb4bf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:27.378696Z",
-     "iopub.status.busy": "2026-06-10T14:02:27.378519Z",
-     "iopub.status.idle": "2026-06-10T14:02:27.382740Z",
-     "shell.execute_reply": "2026-06-10T14:02:27.381786Z"
-    },
-    "papermill": {
-     "duration": 0.012578,
-     "end_time": "2026-06-10T14:02:27.387375",
-     "exception": false,
-     "start_time": "2026-06-10T14:02:27.374797",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Exercice 4 : grandparent avec Popper\n",
-    "# TODO etudiant : faites apprendre grandparent(X, Y) a Popper a partir des memes\n",
-    "# faits parent que la section Popper, et verifiez le programme appris en Prolog.\n",
-    "# Etape 1 : definissez GP_POS (les paires grand-parent de la famille) et GP_NEG\n",
-    "#           (paires variees : parents directs, arriere-grands-parents, inverses).\n",
-    "# Etape 2 : construisez un repertoire de tache comme la cellule Popper :\n",
-    "#           bk.pl identique, exs.pl avec pos(grandparent(...))/neg(grandparent(...)),\n",
-    "#           bias.pl : max_vars(3). max_body(2). max_clauses(1).\n",
-    "#                     head_pred(grandparent,2). body_pred(parent,2).\n",
-    "#           (pas de enable_recursion : grandparent n'en a pas besoin)\n",
-    "# Etape 3 : result_gp = run_popper(task_gp) ; affichez programme + score.\n",
-    "# Etape 4 : verifiez avec janus (cf. cellule ablation) que le programme derive\n",
-    "#           exactement GP_POS et aucun GP_NEG.\n",
-    "# Indice : si Popper retourne un programme errone trop general, regardez vos\n",
-    "#          negatifs : couvrent-ils la frontiere (arriere-grands-parents) ?\n",
-    "\n",
-    "if HAS_POPPER:\n",
-    "    print(\"Exercice a completer\")\n",
-    "else:\n",
-    "    print(\"Popper indisponible : exercice a faire sur le kernel python3-wsl.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "fc9bb0dd",
    "metadata": {
     "papermill": {
-     "duration": 0.007042,
-     "end_time": "2026-06-10T14:02:27.402771",
+     "duration": 0.003542,
+     "end_time": "2026-06-10T15:10:59.314582",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.395729",
+     "start_time": "2026-06-10T15:10:59.311040",
      "status": "completed"
     },
     "tags": []
@@ -2223,10 +2223,10 @@
    "id": "f519236c",
    "metadata": {
     "papermill": {
-     "duration": 0.007538,
-     "end_time": "2026-06-10T14:02:27.416820",
+     "duration": 0.004514,
+     "end_time": "2026-06-10T15:10:59.322095",
      "exception": false,
-     "start_time": "2026-06-10T14:02:27.409282",
+     "start_time": "2026-06-10T15:10:59.317581",
      "status": "completed"
     },
     "tags": []
@@ -2269,14 +2269,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.334853,
-   "end_time": "2026-06-10T14:02:27.670062",
+   "duration": 2.615739,
+   "end_time": "2026-06-10T15:10:59.461848",
    "environment_variables": {},
    "exception": null,
    "input_path": "SL-4-InductiveLogicProgramming.ipynb",
    "output_path": "SL-4-InductiveLogicProgramming.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T14:02:24.335209",
+   "start_time": "2026-06-10T15:10:56.846109",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
@@ -1560,6 +1560,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "afb393b9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005016,
+     "end_time": "2026-06-10T14:02:33.669475",
+     "exception": false,
+     "start_time": "2026-06-10T14:02:33.664459",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Perspectives\n",
+    "\n",
+    "Ce notebook a explore l'integration neuro-symbolique, qui vise a combiner les forces complementaires des reseaux de neurones (apprentissage a partir de donnees, tolerance au bruit) et du raisonnement symbolique (garanties formelles, interpretabilite). Les operateurs logiques differentiables (t-norms) transforment les connecteurs binaires AND, OR, NOT en fonctions continues derivables sur [0, 1], permettant leur integration dans des graphes de calcul optimisables par descente de gradient. Les predicats neuronaux implementent des fonctions P(x) -> [0, 1] via des reseaux de neurones, et la Logique Tensorielle (LTN) combine ces predicats avec une semantique logique pour entrainer des modeles guides par des regles.\n",
+    "\n",
+    "L'implementation du raisonnement guide par regle a illustre un resultat remarquable : le predicat `grandparent` a ete appris sans aucun exemple direct de grand-parent, uniquement a partir de la regle logique `parent(X,Y) AND parent(Y,Z) => grandparent(X,Z)`. Le systeme DeepProbLog simplifie a ensuite unifie la programmation logique probabiliste et les predicats neuronaux, permettant de resoudre des requetes par chainage arriere. L'exemple guide de l'operateur OR parametrique a demontre comment un parametre de combinaison convexe (alpha) peut etre appris pour choisir automatiquement entre la semantique de Godel (max) et la semantique probabiliste (a+b-a*b).\n",
+    "\n",
+    "L'integration neuro-symbolique reste un domaine de recherche actif. Les approches LTN, Neural Theorem Prover et DeepProbLog chacune proposent des compromis differents entre expressivite logique, passage a l'echelle et facilite d'entrainement. Le notebook suivant, [SL-6 - Knowledge Graphs et ILP](SL-6-KnowledgeGraphs-ILP.ipynb), aborde une autre dimension de l'apprentissage symbolique moderne : le minage de regles dans les Knowledge Graphs, ou les triples RDF remplacent les faits logiques traditionnels et l'echelle atteint des milliards de donnees.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "92a946c0",
    "metadata": {
     "papermill": {
@@ -1585,33 +1610,14 @@
     "|----------|----------------------------------|\n",
     "| **Ex. 2 (LTN frere/oncle)** | Retirez les axiomes negatifs (closed-world) de l'entrainement et montrez ce qui casse dans les predictions. Pourquoi une LTN a-t-elle besoin de negatifs explicites la ou Prolog s'en passe ? |\n",
     "| **Ex. 3 (regle transitive ancestor)** | La regle transitive seule admet le modele trivial « ancestor vrai partout » (satisfaction 1.0). Votre apprentissage y tombe-t-il ? Identifiez ce qui l'en empeche --- ou ce qui l'y pousse. |\n",
-    "| **Ex. 4 (t-norm de Lukasiewicz)** | Avec Lukasiewicz, les gradients peuvent etre exactement nuls (zones plates de `max(0, .)`). Exhibez une configuration ou l'apprentissage stagne avec Lukasiewicz mais pas avec le produit ; qu'en conclure pour le choix d'une semantique floue *apprenable* ? |\n"
+    "| **Ex. 4 (t-norm de Lukasiewicz)** | Avec Lukasiewicz, les gradients peuvent etre exactement nuls (zones plates de `max(0, .)`). Exhibez une configuration ou l'apprentissage stagne avec Lukasiewicz mais pas avec le produit ; qu'en conclure pour le choix d'une semantique floue *apprenable* ? |\n",
+    "| **Ex. 5 (ablation de l'axiome 4)** | Remplacez les 6 negatifs closed-world par les seules paires « faciles » (aucun lien parent direct) : le negatif difficile (Marie, Pierre) est-il indispensable pour que grandparent ne degenere pas en « parent-de » ? Que dit ce besoin de negatifs choisis de la difference avec la derivation exacte de clingo (SL-6) ? |\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "afb393b9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005016,
-     "end_time": "2026-06-10T14:02:33.669475",
-     "exception": false,
-     "start_time": "2026-06-10T14:02:33.664459",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
-    "### Perspectives\n",
-    "\n",
-    "Ce notebook a explore l'integration neuro-symbolique, qui vise a combiner les forces complementaires des reseaux de neurones (apprentissage a partir de donnees, tolerance au bruit) et du raisonnement symbolique (garanties formelles, interpretabilite). Les operateurs logiques differentiables (t-norms) transforment les connecteurs binaires AND, OR, NOT en fonctions continues derivables sur [0, 1], permettant leur integration dans des graphes de calcul optimisables par descente de gradient. Les predicats neuronaux implementent des fonctions P(x) -> [0, 1] via des reseaux de neurones, et la Logique Tensorielle (LTN) combine ces predicats avec une semantique logique pour entrainer des modeles guides par des regles.\n",
-    "\n",
-    "L'implementation du raisonnement guide par regle a illustre un resultat remarquable : le predicat `grandparent` a ete appris sans aucun exemple direct de grand-parent, uniquement a partir de la regle logique `parent(X,Y) AND parent(Y,Z) => grandparent(X,Z)`. Le systeme DeepProbLog simplifie a ensuite unifie la programmation logique probabiliste et les predicats neuronaux, permettant de resoudre des requetes par chainage arriere. L'exemple guide de l'operateur OR parametrique a demontre comment un parametre de combinaison convexe (alpha) peut etre appris pour choisir automatiquement entre la semantique de Godel (max) et la semantique probabiliste (a+b-a*b).\n",
-    "\n",
-    "L'integration neuro-symbolique reste un domaine de recherche actif. Les approches LTN, Neural Theorem Prover et DeepProbLog chacune proposent des compromis differents entre expressivite logique, passage a l'echelle et facilite d'entrainement. Le notebook suivant, [SL-6 - Knowledge Graphs et ILP](SL-6-KnowledgeGraphs-ILP.ipynb), aborde une autre dimension de l'apprentissage symbolique moderne : le minage de regles dans les Knowledge Graphs, ou les triples RDF remplacent les faits logiques traditionnels et l'echelle atteint des milliards de donnees.\n",
-    "\n",
-    "---\n",
-    "\n",
     "## Ressources\n",
     "\n",
     "- Serafini & Garcez, \"Logic Tensor Networks\" (2016)\n",
@@ -1620,38 +1626,8 @@
     "- Russell & Norvig, *AIMA*, 4e ed., Chapitre 19\n",
     "\n",
     "**Navigation** : [Index](./README.md) | [<< SL-4 ILP](SL-4-InductiveLogicProgramming.ipynb) | [Suivant >> SL-6 KG-ILP](SL-6-KnowledgeGraphs-ILP.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3b170b7b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005507,
-     "end_time": "2026-06-10T14:02:33.679983",
-     "exception": false,
-     "start_time": "2026-06-10T14:02:33.674476",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## Defi presentation (seance du 17 juin)\n",
-    "\n",
-    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
-    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
-    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
-    "Elle fait partie integrante de la presentation attendue.\n",
-    "\n",
-    "| Exercice | Question-twist a traiter en plus |\n",
-    "|----------|----------------------------------|\n",
-    "| **Ex. 2 (LTN frere/oncle)** | Retirez les axiomes negatifs de votre entrainement : pourquoi une LTN a-t-elle besoin de negatifs explicites la ou un moteur logique exact (SL-6) n'en demande pas ? |\n",
-    "| **Ex. 3 (regle transitive ancestor)** | Le modele trivial « vrai partout » sature votre regle transitive : qu'est-ce qui l'evite dans votre formulation, et que se passe-t-il si vous l'enlevez ? |\n",
-    "| **Ex. 4 (t-norm de Lukasiewicz)** | Sur quelles plages la t-norm de Lukasiewicz a-t-elle des gradients exactement nuls ? Qu'est-ce que cela implique pour une semantique floue *apprenable* par descente de gradient ? |\n",
-    "| **Ex. 5 (ablation de l'axiome 4)** | Remplacez les 6 negatifs closed-world par les seules paires « faciles » (aucun lien parent direct) : le negatif difficile (Marie, Pierre) est-il indispensable pour que grandparent ne degenere pas en « parent-de » ? Que dit ce besoin de negatifs choisis de la difference avec la derivation exacte de clingo (SL-6) ? |"
-   ]
+   ],
+   "id": "782353e4"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
@@ -1259,37 +1259,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sl8-28",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00262,
-     "end_time": "2026-06-10T11:53:41.753654",
-     "exception": false,
-     "start_time": "2026-06-10T11:53:41.751034",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## Defi presentation (seance du 17 juin)\n",
-    "\n",
-    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
-    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
-    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
-    "Elle fait partie integrante de la presentation attendue.\n",
-    "\n",
-    "| Exercice | Question-twist a traiter en plus |\n",
-    "|----------|----------------------------------|\n",
-    "| **Ex. 1 (langage 'abb')** | Verifiez que le DFA appris est *minimal* en exhibant, pour chaque paire d'etats, un suffixe qui les distingue (certificat de Myhill-Nerode). Pourquoi L* est-il structurellement incapable de retourner un DFA non minimal ? |\n",
-    "| **Ex. 2 (fiabilite de l'EQ)** | Reliez votre taux de reussite empirique a la borne PAC : combien d'echantillons la theorie exige-t-elle pour $\\varepsilon = 0.01, \\delta = 0.05$ ? Construisez une distribution de tirage qui fait echouer l'echantillonnage quel que soit $N$ raisonnable. |\n",
-    "| **Ex. 3 (prefixes vs suffixes)** | Exhibez le pire cas : une famille de langages ou les contre-exemples sont longs et ou la variante prefixes fait exploser $|S|$. La variante de Rivest-Schapire n'ajoute qu'UN suffixe trouve par dichotomie sur le contre-exemple : quel est son cout en MQ et pourquoi est-ce le bon compromis ? |\n",
-    "| **Ex. 4 (oracle bruite)** | Peut-on reparer L* par vote majoritaire (poser chaque MQ 2k+1 fois) ? Calculez le surcout en requetes et la probabilite residuelle d'erreur ; comparez avec la degradation *graduelle* d'un classifieur statistique sous le meme bruit. Que conclure sur le contrat exactitude-contre-robustesse du symbolique ? |\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "sl8-29",
    "metadata": {
     "papermill": {
@@ -1346,6 +1315,37 @@
     "| Suite | Resolution inverse, Progol | [SL-9](SL-9-InverseResolution.ipynb) |\n",
     "| Capstone | LLM professeur / oracle symbolique | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) |\n",
     "| Automates & verification | Model checking | Serie SymbolicAI |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8-28",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00262,
+     "end_time": "2026-06-10T11:53:41.753654",
+     "exception": false,
+     "start_time": "2026-06-10T11:53:41.751034",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Defi presentation (seance du 17 juin)\n",
+    "\n",
+    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
+    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
+    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
+    "Elle fait partie integrante de la presentation attendue.\n",
+    "\n",
+    "| Exercice | Question-twist a traiter en plus |\n",
+    "|----------|----------------------------------|\n",
+    "| **Ex. 1 (langage 'abb')** | Verifiez que le DFA appris est *minimal* en exhibant, pour chaque paire d'etats, un suffixe qui les distingue (certificat de Myhill-Nerode). Pourquoi L* est-il structurellement incapable de retourner un DFA non minimal ? |\n",
+    "| **Ex. 2 (fiabilite de l'EQ)** | Reliez votre taux de reussite empirique a la borne PAC : combien d'echantillons la theorie exige-t-elle pour $\\varepsilon = 0.01, \\delta = 0.05$ ? Construisez une distribution de tirage qui fait echouer l'echantillonnage quel que soit $N$ raisonnable. |\n",
+    "| **Ex. 3 (prefixes vs suffixes)** | Exhibez le pire cas : une famille de langages ou les contre-exemples sont longs et ou la variante prefixes fait exploser $|S|$. La variante de Rivest-Schapire n'ajoute qu'UN suffixe trouve par dichotomie sur le contre-exemple : quel est son cout en MQ et pourquoi est-ce le bon compromis ? |\n",
+    "| **Ex. 4 (oracle bruite)** | Peut-on reparer L* par vote majoritaire (poser chaque MQ 2k+1 fois) ? Calculez le surcout en requetes et la probabilite residuelle d'erreur ; comparez avec la degradation *graduelle* d'un classifieur statistique sous le meme bruit. Que conclure sur le contrat exactitude-contre-robustesse du symbolique ? |\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-9-InverseResolution.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-9-InverseResolution.ipynb
@@ -1508,38 +1508,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sl9-27",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007085,
-     "end_time": "2026-06-10T13:49:39.791338",
-     "exception": false,
-     "start_time": "2026-06-10T13:49:39.784253",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## Defi presentation (seance du 17 juin)\n",
-    "\n",
-    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
-    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
-    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
-    "Elle fait partie integrante de la presentation attendue.\n",
-    "\n",
-    "| Exercice | Question-twist a traiter en plus |\n",
-    "|----------|----------------------------------|\n",
-    "| **Ex. 1 (grandmother)** | Apprenez maintenant `grandparent/2` (sans contrainte de sexe) : pourquoi est-ce *plus facile* que grandfather, et qu'est-ce que cela dit du role des exemples negatifs comme porteurs du signal d'apprentissage ? |\n",
-    "| **Ex. 2 (profondeur de bottom)** | Estimez la croissance de $|\\bot(e)|$ en fonction de la profondeur $i$ et du degre moyen du graphe de faits. A partir de quelle profondeur l'enumeration par sous-ensembles devient-elle intraitable, et comment les *declarations de modes* de Progol (types + recall) repoussent-elles cette limite ? |\n",
-    "| **Ex. 3 (bruit)** | Le score $f = p - n - L$ est un argument de longueur de description minimale (MDL). Construisez un jeu d'exemples ou ce score prefere une clause *fausse* a la cible, et expliquez quel terme du compromis (couverture, consistance, longueur) a ete trompe. |\n",
-    "| **Ex. 4 (reduction)** | Subsomption et implication ne coincident pas : la clause recursive $p(f(X)) \\leftarrow p(X)$ implique $p(f(f(X))) \\leftarrow p(X)$ sans la subsumer. Verifiez-le a la main, et expliquez pourquoi l'ILP travaille quand meme avec la subsomption (decidabilite, theoreme de Gottlob). |\n",
-    "| **Ex. 5 (Aleph et le bruit)** | Trois reponses au meme positif bruite : memoriser l'exception (defaut strict), sur-generaliser (`noise(1)`), arbitrer par $f = p - n - L$ (ex. 3). `aleph_set(minacc, 0.9)` introduit un 4e levier : un seuil *relatif* de precision par clause. Pourquoi un budget *absolu* de bruit et un seuil *relatif* de precision ne tracent-ils pas la meme frontiere quand la couverture des clauses varie ? |\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "sl9-28",
    "metadata": {
     "papermill": {
@@ -1593,6 +1561,38 @@
     "| Prerequis | Clauses de Horn, unification, FOIL, V/W | [SL-4](SL-4-InductiveLogicProgramming.ipynb) |\n",
     "| Regles sur graphes | AMIE, PCA | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) |\n",
     "| Capstone | pipeline LLM -> oracle -> ILP -> KG | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl9-27",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007085,
+     "end_time": "2026-06-10T13:49:39.791338",
+     "exception": false,
+     "start_time": "2026-06-10T13:49:39.784253",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Defi presentation (seance du 17 juin)\n",
+    "\n",
+    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
+    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
+    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
+    "Elle fait partie integrante de la presentation attendue.\n",
+    "\n",
+    "| Exercice | Question-twist a traiter en plus |\n",
+    "|----------|----------------------------------|\n",
+    "| **Ex. 1 (grandmother)** | Apprenez maintenant `grandparent/2` (sans contrainte de sexe) : pourquoi est-ce *plus facile* que grandfather, et qu'est-ce que cela dit du role des exemples negatifs comme porteurs du signal d'apprentissage ? |\n",
+    "| **Ex. 2 (profondeur de bottom)** | Estimez la croissance de $|\\bot(e)|$ en fonction de la profondeur $i$ et du degre moyen du graphe de faits. A partir de quelle profondeur l'enumeration par sous-ensembles devient-elle intraitable, et comment les *declarations de modes* de Progol (types + recall) repoussent-elles cette limite ? |\n",
+    "| **Ex. 3 (bruit)** | Le score $f = p - n - L$ est un argument de longueur de description minimale (MDL). Construisez un jeu d'exemples ou ce score prefere une clause *fausse* a la cible, et expliquez quel terme du compromis (couverture, consistance, longueur) a ete trompe. |\n",
+    "| **Ex. 4 (reduction)** | Subsomption et implication ne coincident pas : la clause recursive $p(f(X)) \\leftarrow p(X)$ implique $p(f(f(X))) \\leftarrow p(X)$ sans la subsumer. Verifiez-le a la main, et expliquez pourquoi l'ILP travaille quand meme avec la subsomption (decidabilite, theoreme de Gottlob). |\n",
+    "| **Ex. 5 (Aleph et le bruit)** | Trois reponses au meme positif bruite : memoriser l'exception (defaut strict), sur-generaliser (`noise(1)`), arbitrer par $f = p - n - L$ (ex. 3). `aleph_set(minacc, 0.9)` introduit un 4e levier : un seuil *relatif* de precision par clause. Pourquoi un budget *absolu* de bruit et un seuil *relatif* de precision ne tracent-ils pas la meme frontiere quand la couverture des clauses varie ? |\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

User-reported insertion bug (« Exercice 4 : grandparent avec Popper est après la conclusion ») + full ordering audit of all 10 SL notebooks. Target order everywhere: **exercices -> Conclusion/Résumé (-> Perspectives) -> Défi présentation (séance du 17 juin) -> Ressources**.

- **SL-4**: Exercice 4 (Popper, md+code) moved before `## 8. Conclusion` + **full papermill re-run** (`python3-wsl`, 39/39 cells, `PAPERMILL_EXIT=0`)
- **SL-5**: duplicate `## Défi présentation` cells merged — original twists Ex2-4 preserved verbatim, Ex5 ablation row appended; combined Perspectives//Ressources cell split in two
- **SL-8/9/10**: défi cell swapped after Conclusion (was before)

SL-5/8/9/10 are markdown-only changes (C.2 exception — outputs preserved untouched).

## Validation (rule D / H.3)

Final series-wide validation script (structure + forensic + README), result **PASS**:
- ordre sections **10/10 OK** (`exercices < conclusion < defi < ressources` verified par index de cellule)
- H.3 forensic 10/10 : 0 `execution_count: null`, 0 error output, exec_counts séquentiels 1..N
- C.1 grep clean (0 `raise NotImplementedError|assert False|1/0`)
- exactly 1 défi cell + 1 Ressources cell per notebook ; chaque ligne défi correspond à un exercice existant
- README pioche : 40 lignes numérotées 1..40, tous liens valides, chaque entrée pointe un exercice existant

## Anti-régression

`git diff --stat`: 363 insertions / 387 deletions — delta = SL-5 dedup (cellule défi dupliquée supprimée après merge de son contenu) + déplacements de cellules. Aucun contenu pédagogique supprimé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)