### PR TITLE
feat(lean): GT-Lean phase 4 — value of information, Blackwell monotonicity, info-can-hurt counterexample (See #2610)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian.lean
@@ -18,8 +18,16 @@
                           certified by `decide` (phase 2)
   - `Bayesian.Vickrey`  — second-price auction: truthful bidding weakly
                           dominant, BNE for every `n` (phase 3)
+  - `Bayesian.Max`      — finite maxima over `Fin (n + 1)`, max-of-sum
+                          vs sum-of-maxima (phase 4)
+  - `Bayesian.Information` — value of information for a single decision
+                          maker: signals as partitions, Blackwell
+                          monotonicity, no-info ≤ signal ≤ perfect (phase 4)
+  - `Bayesian.InfoGames` — counterexample: in a *game*, more information
+                          can strictly hurt the informed player (unique
+                          BNE payoffs 3 < 5, kernel-checked) (phase 4)
 
-  See #2610 (GT-Lean formalization, phases 1-3: Bayesian games).
+  See #2610 (GT-Lean formalization, phases 1-4: Bayesian games).
 -/
 
 import Bayesian.Sum
@@ -28,3 +36,6 @@ import Bayesian.BNE
 import Bayesian.Examples
 import Bayesian.Auction
 import Bayesian.Vickrey
+import Bayesian.Max
+import Bayesian.Information
+import Bayesian.InfoGames

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/InfoGames.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/InfoGames.lean
@@ -1,0 +1,222 @@
+/-
+  Information Can Hurt in Games (counterexample, kernel-checked)
+  ==============================================================
+
+  `Information.lean` proves that a *single* decision maker never loses
+  by observing a signal (Blackwell monotonicity). This file shows the
+  result is genuinely one-player: in a game, giving one player strictly
+  more information can strictly *lower* their equilibrium payoff.
+
+  The example (a classic two-state, 2x2 construction): a state
+  θ ∈ {0, 1} is drawn with equal weights. Player 1 (row, actions T/B)
+  never observes θ. We compare two scenarios for player 2 (column,
+  actions l/r):
+
+  - `gNoInfo`: player 2 does not observe θ either. Payoffs are the
+    fold of the state-dependent tables over θ (an ex-ante reduction:
+    one type per player, payoffs summed over states — see
+    `infoHurts_reduction`).
+  - `gInfo`: player 2 privately observes θ (two types).
+
+  State-dependent payoffs (player 1, player 2):
+
+            θ = 0:  l        r            θ = 1:  l        r
+        T        (2, 3)   (0, 0)      T        (2, 2)   (0, 3)
+        B        (0, 2)   (0, 0)      B        (0, 0)   (4, 1)
+
+  Uninformed, `l` strictly dominates for player 2 (3+2 > 0+3 against T,
+  2+0 > 0+1 against B), so the unique BNE is (T, l): player 2 collects
+  weight-total 5. Informed, type θ=1 cannot commit to `l` anymore — `r`
+  is strictly dominant for that type (3 > 2 against T, 1 > 0 against
+  B), and type θ=0 keeps `l`. Player 2's action now reveals the state,
+  and player 1's best response flips from T to B (2+0 < 0+4), leaving
+  player 2 with 2+1 = 3 < 5. Knowledge destroys the ability to commit:
+  player 2 would pay to NOT see the signal.
+
+  Both games carry the same total prior weight scale (each value below
+  is twice the true expectation), so the payoffs 3 and 5 are directly
+  comparable.
+
+  Equilibrium uniqueness is established for *all* strategy profiles by
+  reducing an arbitrary strategy to a canonical constructor
+  (`mkS1g`/`mkS2g`, an eta-expansion over `Fin` literals) and then
+  deciding the resulting finite statement by kernel computation.
+
+  See #2610 (GT-Lean formalization, Bayesian phase 4).
+-/
+
+import Bayesian.BNE
+
+/-- The informed game: player 2 privately observes the state θ (their
+    type), player 1 has a single type. Equal prior weights. -/
+def gInfo : BayesGame2 where
+  nT1 := 1
+  nT2 := 2
+  nA1 := 2
+  nA2 := 2
+  w := fun _ _ => 1
+  u1 := fun _ t2 a1 a2 =>
+    if t2.val = 0 then
+      (if a1.val = 0 then (if a2.val = 0 then 2 else 0) else 0)
+    else
+      (if a1.val = 0 then (if a2.val = 0 then 2 else 0)
+       else (if a2.val = 0 then 0 else 4))
+  u2 := fun _ t2 a1 a2 =>
+    if t2.val = 0 then
+      (if a1.val = 0 then (if a2.val = 0 then 3 else 0)
+       else (if a2.val = 0 then 2 else 0))
+    else
+      (if a1.val = 0 then (if a2.val = 0 then 2 else 3)
+       else (if a2.val = 0 then 0 else 1))
+
+/-- The uninformed benchmark: nobody observes θ, so both players have a
+    single type and payoffs are summed over the two states (ex-ante
+    reduction of `gInfo` for an uninformed player 2). -/
+def gNoInfo : BayesGame2 where
+  nT1 := 1
+  nT2 := 1
+  nA1 := 2
+  nA2 := 2
+  w := fun _ _ => 1
+  u1 := fun _ _ a1 a2 =>
+    if a1.val = 0 then (if a2.val = 0 then 4 else 0)
+    else (if a2.val = 0 then 0 else 4)
+  u2 := fun _ _ a1 a2 =>
+    if a1.val = 0 then (if a2.val = 0 then 5 else 3)
+    else (if a2.val = 0 then 2 else 1)
+
+/-- Sanity check: `gNoInfo`'s payoffs are exactly `gInfo`'s summed over
+    the two states — the uninformed game is the faithful ex-ante
+    reduction, not an unrelated game. -/
+theorem infoHurts_reduction :
+    ∀ a1 a2 : Fin 2,
+      gNoInfo.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
+        gInfo.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 +
+        gInfo.u1 ⟨0, by decide⟩ ⟨1, by decide⟩ a1 a2 ∧
+      gNoInfo.u2 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
+        gInfo.u2 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 +
+        gInfo.u2 ⟨0, by decide⟩ ⟨1, by decide⟩ a1 a2 := by
+  decide
+
+/-! ### Canonical strategy constructors (informed game) -/
+
+/-- Player 1's strategies in `gInfo` are constants (one type). -/
+def mkS1g (x : Fin 2) : Strategy1 gInfo := fun _ => x
+
+/-- Player 2's strategies in `gInfo`, from the two type-contingent
+    actions. -/
+def mkS2g (y z : Fin 2) : Strategy2 gInfo :=
+  fun t2 => if t2.val = 0 then y else z
+
+/-- Every strategy of player 1 is a canonical constant. -/
+theorem s1g_eta (s1 : Strategy1 gInfo) : s1 = mkS1g (s1 ⟨0, by decide⟩) := by
+  funext t1
+  cases t1 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+/-- Every strategy of player 2 is determined by its two values. -/
+theorem s2g_eta (s2 : Strategy2 gInfo) :
+    s2 = mkS2g (s2 ⟨0, by decide⟩) (s2 ⟨1, by decide⟩) := by
+  funext t2
+  cases t2 using Fin.cases with
+  | zero => rfl
+  | succ j =>
+    cases j using Fin.cases with
+    | zero => rfl
+    | succ j' => exact j'.elim0
+
+/-! ### Equilibrium analysis of the informed game -/
+
+/-- (B, follow-the-state) is a BNE of the informed game. -/
+theorem gInfo_bne :
+    isBNE gInfo (mkS1g ⟨1, by decide⟩) (mkS2g ⟨0, by decide⟩ ⟨1, by decide⟩) := by
+  decide
+
+/-- Over canonical strategies, the BNE of `gInfo` is unique: player 1
+    plays B and player 2 plays l on θ=0, r on θ=1. -/
+theorem gInfo_unique_aux :
+    ∀ x y z : Fin 2,
+      isBNE gInfo (mkS1g x) (mkS2g y z) →
+        x = ⟨1, by decide⟩ ∧ y = ⟨0, by decide⟩ ∧ z = ⟨1, by decide⟩ := by
+  decide
+
+/-- Over canonical strategies, every BNE of `gInfo` pays player 2
+    exactly 3. -/
+theorem gInfo_exAnteU2_aux :
+    ∀ x y z : Fin 2,
+      isBNE gInfo (mkS1g x) (mkS2g y z) →
+        exAnteU2 gInfo (mkS1g x) (mkS2g y z) = 3 := by
+  decide
+
+/-- The informed game has an essentially unique BNE. -/
+theorem gInfo_unique (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
+    (h : isBNE gInfo s1 s2) :
+    s1 = mkS1g ⟨1, by decide⟩ ∧ s2 = mkS2g ⟨0, by decide⟩ ⟨1, by decide⟩ := by
+  rw [s1g_eta s1, s2g_eta s2] at h
+  have hu := gInfo_unique_aux _ _ _ h
+  exact ⟨by rw [s1g_eta s1, hu.1], by rw [s2g_eta s2, hu.2.1, hu.2.2]⟩
+
+/-- In every BNE of the informed game, player 2 earns 3. -/
+theorem gInfo_bne_payoff (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
+    (h : isBNE gInfo s1 s2) : exAnteU2 gInfo s1 s2 = 3 := by
+  rw [s1g_eta s1, s2g_eta s2] at h ⊢
+  exact gInfo_exAnteU2_aux _ _ _ h
+
+/-! ### Equilibrium analysis of the uninformed game -/
+
+/-- Player 1's strategies in `gNoInfo` are constants. -/
+def mkS1n (x : Fin 2) : Strategy1 gNoInfo := fun _ => x
+
+/-- Player 2's strategies in `gNoInfo` are constants. -/
+def mkS2n (y : Fin 2) : Strategy2 gNoInfo := fun _ => y
+
+theorem s1n_eta (s1 : Strategy1 gNoInfo) : s1 = mkS1n (s1 ⟨0, by decide⟩) := by
+  funext t1
+  cases t1 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+theorem s2n_eta (s2 : Strategy2 gNoInfo) : s2 = mkS2n (s2 ⟨0, by decide⟩) := by
+  funext t2
+  cases t2 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+/-- (T, l) is a BNE of the uninformed game. -/
+theorem gNoInfo_bne :
+    isBNE gNoInfo (mkS1n ⟨0, by decide⟩) (mkS2n ⟨0, by decide⟩) := by
+  decide
+
+/-- Over canonical strategies, every BNE of `gNoInfo` pays player 2
+    exactly 5 (the BNE (T, l) is in fact unique, by strict dominance
+    of l). -/
+theorem gNoInfo_exAnteU2_aux :
+    ∀ x y : Fin 2,
+      isBNE gNoInfo (mkS1n x) (mkS2n y) →
+        exAnteU2 gNoInfo (mkS1n x) (mkS2n y) = 5 := by
+  decide
+
+/-- In every BNE of the uninformed game, player 2 earns 5. -/
+theorem gNoInfo_bne_payoff (s1 : Strategy1 gNoInfo) (s2 : Strategy2 gNoInfo)
+    (h : isBNE gNoInfo s1 s2) : exAnteU2 gNoInfo s1 s2 = 5 := by
+  rw [s1n_eta s1, s2n_eta s2] at h ⊢
+  exact gNoInfo_exAnteU2_aux _ _ h
+
+/-! ### Punchline -/
+
+/-- **Information can hurt in games.** In every equilibrium, the
+    informed player 2 earns strictly less (3) than in every equilibrium
+    of the game where nobody observes the state (5): observing the
+    signal destroys player 2's ability to commit to `l`, reveals the
+    state through their action, and triggers a best-response switch by
+    player 1 that costs more than the informational gain. Contrast with
+    `valueNoInfo_le_valueSignal` (`Information.lean`): with a single
+    decision maker, information never hurts. -/
+theorem information_hurts
+    (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
+    (t1 : Strategy1 gNoInfo) (t2 : Strategy2 gNoInfo)
+    (hI : isBNE gInfo s1 s2) (hN : isBNE gNoInfo t1 t2) :
+    exAnteU2 gInfo s1 s2 < exAnteU2 gNoInfo t1 t2 := by
+  rw [gInfo_bne_payoff s1 s2 hI, gNoInfo_bne_payoff t1 t2 hN]
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information.lean
@@ -1,0 +1,226 @@
+/-
+  Value of Information in Decision Problems (Blackwell, deterministic case)
+  =========================================================================
+
+  A single decision maker faces a finite set of states with an
+  unnormalized `Nat` prior (same encoding as `BayesGame2`) and picks one
+  action from a nonempty finite set. A *deterministic signal* is a map
+  from states to signal realizations — equivalently, a finite partition
+  of the state space. We formalize three benchmark values:
+
+  - `valueNoInfo`:   choose one action before learning anything;
+  - `valueSignal σ`: observe `σ`'s realization, then choose an action
+    optimally inside each cell of the partition;
+  - `valuePerfect`:  learn the state exactly, then choose.
+
+  Main theorems (all by the master lemma `maxFin_sumFin_le` plus the
+  double-counting identity `sumFin_partition`):
+
+  - `valueNoInfo_le_valueSignal`: information never hurts a single
+    decision maker (the value of any signal is nonnegative);
+  - `valueSignal_mono`: Blackwell monotonicity for partitions — if `σ`
+    is a coarsening of `τ` (i.e. `σ = h ∘ τ`), then `τ` is worth at
+    least as much as `σ`;
+  - `valueSignal_le_valuePerfect`: perfect information is the best
+    deterministic signal.
+
+  The companion file `InfoGames.lean` shows by contrast that in a
+  *game*, more information can strictly hurt the player who receives
+  it — monotonicity is a one-player phenomenon.
+
+  See #2610 (GT-Lean formalization, Bayesian phase 4).
+-/
+
+import Bayesian.Max
+
+/-- A finite single-agent decision problem with an unnormalized prior.
+    There are `nS` states and `nA + 1` actions (the `+ 1` keeps the
+    action set nonempty without carrying a positivity hypothesis). -/
+structure DecisionProblem where
+  /-- Number of states of the world -/
+  nS : Nat
+  /-- Number of actions minus one (actions are `Fin (nA + 1)`) -/
+  nA : Nat
+  /-- Unnormalized prior weight of each state -/
+  w : Fin nS → Nat
+  /-- Payoff of taking an action in a state -/
+  u : Fin nS → Fin (nA + 1) → Int
+
+/-- Prior-weighted payoff of action `a` in state `s`. -/
+def wu (D : DecisionProblem) (s : Fin D.nS) (a : Fin (D.nA + 1)) : Int :=
+  (D.w s : Int) * D.u s a
+
+/-- A deterministic signal with `m + 1` possible realizations: it
+    announces a realization in each state, i.e. partitions the state
+    space into (at most) `m + 1` cells. -/
+def Signal (D : DecisionProblem) (m : Nat) := Fin D.nS → Fin (m + 1)
+
+/-- Expected payoff (unnormalized) of an uninformed decision maker:
+    pick the single action with the best prior-weighted payoff. -/
+def valueNoInfo (D : DecisionProblem) : Int :=
+  maxFin D.nA (fun a => sumFin D.nS (fun s => wu D s a))
+
+/-- Expected payoff of a decision maker observing signal `σ`: inside
+    each cell `k` of the partition, pick the best action for the prior
+    restricted to that cell, then add up over cells. -/
+def valueSignal (D : DecisionProblem) {m : Nat} (σ : Signal D m) : Int :=
+  sumFin (m + 1) (fun k => maxFin D.nA (fun a =>
+    sumFin D.nS (fun s => if σ s = k then wu D s a else 0)))
+
+/-- Expected payoff of a fully informed decision maker: pick the best
+    action separately in every state. -/
+def valuePerfect (D : DecisionProblem) : Int :=
+  sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a))
+
+/-- The totally uninformative signal (a single realization) is worth
+    exactly the no-information value. -/
+theorem valueSignal_const (D : DecisionProblem) :
+    valueSignal D (fun _ => (0 : Fin 1)) = valueNoInfo D := by
+  unfold valueSignal valueNoInfo
+  simp
+
+/-- Fiber decomposition: summing `f` over the states classified by the
+    composite map `h ∘ τ` into cell `k` equals summing, over the
+    realizations `j` of `τ` that `h` sends to `k`, the `τ`-cell sums. -/
+theorem sumFin_fiber {n m p : Nat} (τ : Fin n → Fin p) (h : Fin p → Fin m)
+    (k : Fin m) (f : Fin n → Int) :
+    sumFin n (fun s => if h (τ s) = k then f s else 0) =
+    sumFin p (fun j => if h j = k then
+      sumFin n (fun s => if τ s = j then f s else 0) else 0) := by
+  have push : ∀ j : Fin p,
+      (if h j = k then sumFin n (fun s => if τ s = j then f s else 0) else 0) =
+      sumFin n (fun s => if h j = k then (if τ s = j then f s else 0) else 0) :=
+    fun j => (sumFin_if_distrib _ _).symm
+  rw [sumFin_congr push, sumFin_comm]
+  apply sumFin_congr
+  intro s
+  have swap : ∀ j : Fin p,
+      (if h j = k then (if τ s = j then f s else 0) else 0) =
+      (if τ s = j then (if h j = k then f s else 0) else 0) := by
+    intro j
+    by_cases h1 : h j = k <;> by_cases h2 : τ s = j <;> simp [h1, h2]
+  rw [sumFin_congr swap, sumFin_single (τ s) (fun j => if h j = k then f s else 0)]
+
+/-- **Blackwell monotonicity (deterministic case).** If the signal `σ`
+    is a coarsening of `τ` — every realization of `σ` is computed from
+    the realization of `τ` via `h` — then observing the finer signal
+    `τ` is worth at least as much as observing `σ`. -/
+theorem valueSignal_mono (D : DecisionProblem) {m p : Nat}
+    (σ : Signal D m) (τ : Signal D p) (h : Fin (p + 1) → Fin (m + 1))
+    (hfactor : ∀ s, σ s = h (τ s)) :
+    valueSignal D σ ≤ valueSignal D τ := by
+  unfold valueSignal
+  -- Rewrite each σ-cell sum as a sum over the τ-cells it contains.
+  have hcell : ∀ (k : Fin (m + 1)) (a : Fin (D.nA + 1)),
+      sumFin D.nS (fun s => if σ s = k then wu D s a else 0) =
+      sumFin (p + 1) (fun j => if h j = k then
+        sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0) := by
+    intro k a
+    rw [sumFin_congr (fun s => by rw [hfactor s]),
+        sumFin_fiber τ h k (fun s => wu D s a)]
+  -- Bound the max over each σ-cell by the sum of maxima over its τ-cells.
+  have hk : ∀ k : Fin (m + 1),
+      maxFin D.nA (fun a =>
+        sumFin D.nS (fun s => if σ s = k then wu D s a else 0)) ≤
+      sumFin (p + 1) (fun j => if h j = k then
+        maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0)) else 0) := by
+    intro k
+    have step1 := maxFin_sumFin_le (fun j a => if h j = k then
+      sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0)
+    have step2 : ∀ j : Fin (p + 1),
+        maxFin D.nA (fun a => if h j = k then
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0) =
+        (if h j = k then maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0)) else 0) :=
+      fun j => maxFin_if_distrib _ _
+    calc maxFin D.nA (fun a =>
+            sumFin D.nS (fun s => if σ s = k then wu D s a else 0))
+        = maxFin D.nA (fun a =>
+            sumFin (p + 1) (fun j => if h j = k then
+              sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0)) := by
+          exact congrArg (maxFin D.nA) (funext (fun a => hcell k a))
+      _ ≤ sumFin (p + 1) (fun j =>
+            maxFin D.nA (fun a => if h j = k then
+              sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0)) := step1
+      _ = sumFin (p + 1) (fun j => if h j = k then
+            maxFin D.nA (fun a =>
+              sumFin D.nS (fun s => if τ s = j then wu D s a else 0)) else 0) :=
+          sumFin_congr step2
+  -- Sum the per-cell bounds, then undo the double counting over k.
+  calc sumFin (m + 1) (fun k => maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if σ s = k then wu D s a else 0)))
+      ≤ sumFin (m + 1) (fun k => sumFin (p + 1) (fun j => if h j = k then
+          maxFin D.nA (fun a =>
+            sumFin D.nS (fun s => if τ s = j then wu D s a else 0)) else 0)) :=
+        sumFin_mono hk
+    _ = sumFin (p + 1) (fun j => maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0))) :=
+        (sumFin_partition h (fun j => maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0)))).symm
+
+/-- **Information never hurts a single decision maker**: any signal is
+    worth at least the no-information value (every signal refines the
+    trivial one). -/
+theorem valueNoInfo_le_valueSignal (D : DecisionProblem) {m : Nat}
+    (σ : Signal D m) :
+    valueNoInfo D ≤ valueSignal D σ := by
+  rw [← valueSignal_const D]
+  exact valueSignal_mono D (fun _ => (0 : Fin 1)) σ (fun _ => 0) (fun _ => rfl)
+
+/-- Perfect information dominates any signal: knowing the state exactly
+    is the finest deterministic signal. -/
+theorem valueSignal_le_valuePerfect (D : DecisionProblem) {m : Nat}
+    (σ : Signal D m) :
+    valueSignal D σ ≤ valuePerfect D := by
+  unfold valueSignal valuePerfect
+  have hk : ∀ k : Fin (m + 1),
+      maxFin D.nA (fun a =>
+        sumFin D.nS (fun s => if σ s = k then wu D s a else 0)) ≤
+      sumFin D.nS (fun s => if σ s = k then
+        maxFin D.nA (fun a => wu D s a) else 0) := by
+    intro k
+    have step1 := maxFin_sumFin_le (fun s a => if σ s = k then wu D s a else 0)
+    have step2 : ∀ s : Fin D.nS,
+        maxFin D.nA (fun a => if σ s = k then wu D s a else 0) =
+        (if σ s = k then maxFin D.nA (fun a => wu D s a) else 0) :=
+      fun s => maxFin_if_distrib _ _
+    exact Int.le_trans step1 (Int.le_of_eq (sumFin_congr step2))
+  calc sumFin (m + 1) (fun k => maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if σ s = k then wu D s a else 0)))
+      ≤ sumFin (m + 1) (fun k => sumFin D.nS (fun s => if σ s = k then
+          maxFin D.nA (fun a => wu D s a) else 0)) := sumFin_mono hk
+    _ = sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a)) :=
+        (sumFin_partition σ (fun s => maxFin D.nA (fun a => wu D s a))).symm
+
+/-- No information is at most perfect information (composition of the
+    two comparisons, stated directly for convenience). -/
+theorem valueNoInfo_le_valuePerfect (D : DecisionProblem) :
+    valueNoInfo D ≤ valuePerfect D :=
+  Int.le_trans (valueNoInfo_le_valueSignal D (fun _ => (0 : Fin 1)))
+    (valueSignal_le_valuePerfect D _)
+
+/-
+  Concrete check: the umbrella problem. Two equally likely states
+  (rain, sun), two actions (take the umbrella, leave it). Payoffs:
+  umbrella = 2 in rain, 0 in sun; no umbrella = -3 in rain, 3 in sun.
+-/
+
+/-- Rain-or-sun decision problem used as a kernel-checked example. -/
+def umbrella : DecisionProblem where
+  nS := 2
+  nA := 1
+  w := fun _ => 1
+  u := fun s a =>
+    if s.val = 0 then (if a.val = 0 then 2 else -3)
+    else (if a.val = 0 then 0 else 3)
+
+/-- Uninformed, the best plan (always take the umbrella) is worth 2. -/
+theorem umbrella_valueNoInfo : valueNoInfo umbrella = 2 := by decide
+
+/-- Perfectly informed (umbrella iff rain), the plan is worth 5. -/
+theorem umbrella_valuePerfect : valuePerfect umbrella = 5 := by decide
+
+/-- The value of perfect information is strictly positive here. -/
+theorem umbrella_strict_gain : valueNoInfo umbrella < valuePerfect umbrella := by
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Max.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Max.lean
@@ -1,0 +1,75 @@
+/-
+  Finite maxima over `Fin (n + 1)` (core Lean 4 only, no Mathlib)
+  ===============================================================
+
+  Maximum of an `Int`-valued function over a nonempty finite domain,
+  mirroring the `sumFin` infrastructure of `Sum.lean`. The key result
+  for the value-of-information development (`Information.lean`) is
+  `maxFin_sumFin_le`: the max of a sum is at most the sum of the
+  groupwise maxima — adapting a decision to each group separately can
+  only improve on choosing one action for all groups at once.
+
+  See #2610 (GT-Lean formalization, Bayesian phase 4).
+-/
+
+import Bayesian.Sum
+
+/-- Maximum of `f` over all of `Fin (n + 1)` (nonempty domain), by
+    structural recursion on `n`. -/
+def maxFin : (n : Nat) → (Fin (n + 1) → Int) → Int
+  | 0, f => f 0
+  | n + 1, f => max (f 0) (maxFin n (fun i => f i.succ))
+
+@[simp] theorem maxFin_zero (f : Fin 1 → Int) : maxFin 0 f = f 0 := rfl
+
+@[simp] theorem maxFin_succ (n : Nat) (f : Fin (n + 2) → Int) :
+    maxFin (n + 1) f = max (f 0) (maxFin n (fun i => f i.succ)) := rfl
+
+/-- Every value of `f` is at most its maximum. -/
+theorem le_maxFin : ∀ {n : Nat} (f : Fin (n + 1) → Int) (i : Fin (n + 1)),
+    f i ≤ maxFin n f
+  | 0, f, i => by
+    cases i using Fin.cases with
+    | zero => exact Int.le_refl _
+    | succ j => exact j.elim0
+  | n + 1, f, i => by
+    cases i using Fin.cases with
+    | zero =>
+      simp only [maxFin_succ]
+      omega
+    | succ j =>
+      have h := le_maxFin (fun i => f i.succ) j
+      simp only [maxFin_succ]
+      omega
+
+/-- The maximum is at most any pointwise upper bound. -/
+theorem maxFin_le : ∀ {n : Nat} {f : Fin (n + 1) → Int} {b : Int},
+    (∀ i, f i ≤ b) → maxFin n f ≤ b
+  | 0, _, _, h => h 0
+  | n + 1, f, b, h => by
+    have h1 := h 0
+    have h2 := maxFin_le (f := fun i => f i.succ) (fun i => h i.succ)
+    simp only [maxFin_succ]
+    omega
+
+/-- The maximum of the zero function vanishes. -/
+@[simp] theorem maxFin_zero_fun (n : Nat) :
+    maxFin n (fun _ => (0 : Int)) = 0 := by
+  induction n with
+  | zero => rfl
+  | succ n ih => simp [ih]
+
+/-- Master lemma: the max of a sum is at most the sum of the groupwise
+    maxima. Choosing one action `a` for every group `j` at once cannot
+    beat choosing the best action separately inside each group. -/
+theorem maxFin_sumFin_le {nA m : Nat} (F : Fin m → Fin (nA + 1) → Int) :
+    maxFin nA (fun a => sumFin m (fun j => F j a)) ≤
+    sumFin m (fun j => maxFin nA (fun a => F j a)) :=
+  maxFin_le (fun a => sumFin_mono (fun j => le_maxFin (F j) a))
+
+/-- An `if` whose condition does not depend on the index pulls out of
+    the maximum (the `else 0` branch matches the zero function). -/
+theorem maxFin_if_distrib {n : Nat} (c : Prop) [Decidable c]
+    (f : Fin (n + 1) → Int) :
+    maxFin n (fun a => if c then f a else 0) = if c then maxFin n f else 0 := by
+  by_cases h : c <;> simp [h]

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Sum.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Sum.lean
@@ -54,3 +54,60 @@ theorem sumFin_mul_left {n : Nat} (c : Int) (f : Fin n → Int) :
   | succ n ih =>
     simp only [sumFin_succ]
     rw [ih, Int.mul_add]
+
+/-- Sums distribute over pointwise addition. -/
+theorem sumFin_add {n : Nat} (f g : Fin n → Int) :
+    sumFin n (fun i => f i + g i) = sumFin n f + sumFin n g := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [sumFin_succ]
+    rw [ih]
+    omega
+
+/-- Double sums commute (Fubini for finite sums). -/
+theorem sumFin_comm {n m : Nat} (F : Fin n → Fin m → Int) :
+    sumFin n (fun i => sumFin m (fun j => F i j)) =
+    sumFin m (fun j => sumFin n (fun i => F i j)) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [sumFin_succ]
+    rw [ih (fun i j => F i.succ j), ← sumFin_add]
+
+/-- An `if` whose condition does not depend on the index pulls out of
+    the sum (the `else 0` branch matches the empty sum). -/
+theorem sumFin_if_distrib {n : Nat} (c : Prop) [Decidable c] (f : Fin n → Int) :
+    sumFin n (fun i => if c then f i else 0) = if c then sumFin n f else 0 := by
+  by_cases h : c <;> simp [h]
+
+/-- Summing an indicator of a single point picks out that point's value. -/
+theorem sumFin_single : ∀ {n : Nat} (c : Fin n) (x : Fin n → Int),
+    sumFin n (fun j => if c = j then x j else 0) = x c
+  | 0, c, _ => c.elim0
+  | n + 1, c, x => by
+    cases c using Fin.cases with
+    | zero =>
+      have htail : ∀ i : Fin n, (if (0 : Fin (n + 1)) = i.succ then x i.succ else 0) = 0 :=
+        fun i => if_neg (fun h => Fin.succ_ne_zero i h.symm)
+      simp only [sumFin_succ]
+      rw [sumFin_congr htail, sumFin_zero_fun, Int.add_zero]
+      simp
+    | succ j =>
+      simp only [sumFin_succ]
+      rw [if_neg (Fin.succ_ne_zero j), Int.zero_add]
+      have hcond : ∀ i : Fin n,
+          (if j.succ = i.succ then x i.succ else 0) =
+          (if j = i then x i.succ else 0) := by
+        intro i
+        by_cases h : j = i
+        · rw [if_pos (by rw [h]), if_pos h]
+        · rw [if_neg (fun hs => h (Fin.succ_inj.mp hs)), if_neg h]
+      rw [sumFin_congr hcond, sumFin_single j (fun i => x i.succ)]
+
+/-- Decompose a sum over states into groups indexed by the value of a
+    classifying map (finite double counting). -/
+theorem sumFin_partition {n m : Nat} (σ : Fin n → Fin m) (f : Fin n → Int) :
+    sumFin n f = sumFin m (fun k => sumFin n (fun s => if σ s = k then f s else 0)) := by
+  rw [sumFin_comm]
+  exact (sumFin_congr (fun s => sumFin_single (σ s) (fun _ => f s))).symm

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md
@@ -16,6 +16,9 @@ l'epic #2610.
 | `Bayesian/Examples.lean` | Bataille des sexes à information incomplète (Harsanyi) : BNE du manuel certifié par `decide` |
 | `Bayesian/Auction.lean` | Enchère au premier prix sous pli scellé (discrète, 2 enchérisseurs, prior uniforme) : enchérir sa valeur rapporte exactement 0 (théorème général en `n`), le *bid shading* `b(v) = v/2` est un BNE certifié par `decide` (n = 2, 3), enchérir sa valeur n'est PAS un BNE (phase 2) |
 | `Bayesian/Vickrey.lean` | Enchère au second prix (Vickrey) : enchérir sa valeur **domine faiblement** toute autre enchère (argument pointwise classique), donc BNE sincère **pour tout `n`** (théorème général, sans `decide`) ; rente d'information strictement positive du type haut, en contraste avec le premier prix (phase 3) |
+| `Bayesian/Max.lean` | Maxima finis sur `Fin (n + 1)` (`maxFin`) : bornes `le_maxFin`/`maxFin_le`, et le lemme maître `maxFin_sumFin_le` (max d'une somme ≤ somme des maxima par groupe) (phase 4) |
+| `Bayesian/Information.lean` | Valeur de l'information pour un décideur seul : signaux déterministes = partitions des états, `valueNoInfo ≤ valueSignal ≤ valuePerfect`, **monotonie de Blackwell** (`valueSignal_mono` : un signal plus fin vaut toujours au moins autant, via factorisation σ = h ∘ τ), exemple parapluie chiffré par `decide` (phase 4) |
+| `Bayesian/InfoGames.lean` | **L'information peut nuire dans un jeu** : contre-exemple 2 états / 2×2 où le BNE est unique dans chaque scénario (certifié `decide` + eta-expansion des stratégies) et le joueur informé gagne strictement moins (3 < 5) que s'il ne voyait rien — contraste kernel-checked avec la monotonie à un joueur (phase 4) |
 
 ## Choix de conception
 
@@ -45,5 +48,6 @@ standalone-tactic).
 Kuhn poker — cf #2748 / PR #2752) reste le socle « phase 0 ». Ce
 projet-ci accueille les extensions de l'epic #2610 (phases livrées :
 2 — enchère au premier prix discret, 3 — enchère de Vickrey et
-dominance faible) ; phases suivantes prévues : valeur de
-l'information, jeux de réputation simplifiés.
+dominance faible, 4 — valeur de l'information : monotonie de Blackwell
+à un joueur + contre-exemple « l'information nuit » en jeu) ; phases
+suivantes prévues : jeux de réputation simplifiés.


### PR DESCRIPTION
## Summary

Phase 4 of the GT-Lean Bayesian epic (#2610): **value of information**, formalized in `MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/` (core Lean 4 only, **no Mathlib** — no checkout cost, cf #2611). One coherent feature, 3 new modules + extension of the sum infrastructure.

### Content

| Module | Delivers |
|--------|----------|
| `Bayesian/Sum.lean` (extended) | `sumFin_add`, `sumFin_comm` (Fubini), `sumFin_if_distrib`, `sumFin_single` (indicator), `sumFin_partition` (double counting along a classifying map) |
| `Bayesian/Max.lean` (new) | `maxFin` over `Fin (n+1)`, bounds `le_maxFin`/`maxFin_le`, master lemma `maxFin_sumFin_le` (max of a sum ≤ sum of groupwise maxima) |
| `Bayesian/Information.lean` (new) | `DecisionProblem` (unnormalized Nat prior, Int utilities), deterministic signals as partitions, `valueNoInfo ≤ valueSignal ≤ valuePerfect`, **Blackwell monotonicity** `valueSignal_mono` (a finer signal is always worth at least as much, via factorization σ = h ∘ τ + fiber decomposition `sumFin_fiber`), umbrella example certified by `decide` |
| `Bayesian/InfoGames.lean` (new) | **Information can hurt in games**: 2-state 2×2 counterexample where the BNE is unique in BOTH scenarios — uniqueness proved over *all* strategy profiles via eta-expansion to canonical constructors (`s1g_eta`/`s2g_eta`) + `decide` — and the informed player 2 earns strictly less: `information_hurts` (3 < 5). Sanity theorem `infoHurts_reduction` checks the uninformed game is the faithful ex-ante fold of the informed one. |

The pedagogical punchline is the kernel-checked contrast: one decision maker → information never hurts (`valueNoInfo_le_valueSignal`); a game → it can (`information_hurts`).

### Rule-B evidence

1. **sorry count before/after** (word-boundary grep, all `.lean` files): `0 → 0` — Auction 0, BNE 0, Examples 0, InfoGames 0, Information 0, Max 0, Sum 0, Types 0, Vickrey 0, Bayesian 0.
2. **Lake build SUCCESS** (local, native `lake.exe`, toolchain v4.30.0-rc2):
   ```
   ✔ [10/12] Built Bayesian.InfoGames (491ms)
   ✔ [11/12] Built Bayesian (418ms)
   Build completed successfully (12 jobs).
   ```
   CI also covers it: `.github/workflows/lean-game-defs-ext.yml` builds the whole `Bayesian` lib (sorry baseline 0), so the new modules are auto-covered.
3. **Proof integrity** — `#print axioms` on the 6 key theorems (`valueSignal_mono`, `valueNoInfo_le_valueSignal`, `valueSignal_le_valuePerfect`, `maxFin_sumFin_le`, `information_hurts`, `gInfo_unique`): all depend on `[propext, Quot.sound]` only — no `sorryAx`, not even `Classical.choice`.
4. **No prover-harness refactor** in this PR — pure Lean content + README/module-doc update.

`See #2610` — partial (phase 4 of the epic; reputation games remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)