### PR TITLE
feat(qc): 4 new aligned baselines 2018-2025 — comparative table filled (See #1630)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -456,27 +456,28 @@ Après completion de cette série, vous maîtriserez :
 
 ## Stratégies Vérifiées — Baselines Comparatives
 
-Les 50+ projets du dossier `projects/` ont été backtestés sur des périodes standardisées via QC Cloud API. Le tableau ci-dessous présente les **meilleures performances vérifiées** (Sharpe, CAGR, MaxDD, PSR) : [catalogue complet](../../docs/archive/qc-comparative-backtests.md).
+Les 50+ projets du dossier `projects/` ont été backtestés sur des périodes standardisées via QC Cloud API. Le tableau ci-dessous présente les **meilleures performances vérifiées** (Sharpe, CAGR, MaxDD, PSR) : [catalogue complet](../../docs/qc/qc-comparative-backtests.md).
 
 ### Top 5 stratégies (Sharpe aligned, 2018-2025)
 
 | # | Stratégie | Type | Sharpe | CAGR% | MaxDD% | PSR% |
 |---|-----------|------|--------|-------|--------|------|
-| 1 | TrendFollowing | IND | **1.072** | 23.2 | 9.3 | 81.8 |
-| 2 | EMA-Cross-Stocks | IND | **0.891** | 26.2 | 35.7 | 40.5 |
-| 3 | VolTarget-Momentum | COMP | 0.648 | 14.7 | 21.2 | 22.3 |
-| 4 | AllWeather | RISK | 0.631 | 9.0 | 16.4 | 31.2 |
-| 5 | Crypto-MultiCanal | IND | 0.581 | 8.2 | 17.0 | 37.6 |
+| 1 | LeveragedETFMomentum* | IND | **1.779** | 126.4 | 53.3 | 79.8 |
+| 2 | TrendFollowing | IND | **1.072** | 23.2 | 9.3 | 81.8 |
+| 3 | Framework_Composite_TrendWeather | COMP | 0.948 | 24.6 | 27.5 | 56.6 |
+| 4 | EMA-Cross-Stocks | IND | **0.891** | 26.2 | 35.7 | 40.5 |
+| 5 | VolTarget-Momentum | COMP | 0.648 | 14.7 | 21.2 | 22.3 |
 
-**Lecture** : PSR (Probabilistic Sharpe Ratio) > 50% = statistiquement significatif. TrendFollowing est le seul leader confirmé (PSR 81.8%).
+**Lecture** : PSR (Probabilistic Sharpe Ratio) > 50% = statistiquement significatif. *LeveragedETFMomentum utilise des ETF à levier 3x : profil de risque extrême (MaxDD 53%), non comparable aux stratégies non-leveragées. TrendFollowing reste la référence risque-ajusté (PSR 81.8%, MaxDD 9.3%).
 
 **Enseignements clés** :
 - **TrendFollowing** domine : Sharpe 1.072 avec MaxDD 9.3% seulement. La tendance persiste sur longue période.
 - **EMA-Cross-Alpha** : Sharpe -0.010 en aligned (vs 0.996 en backtest court) = overfitting sever. Démonstration pédagogique du danger des backtests courts.
-- **Composites < single-strategies** : MomentumRegime (combinaison SectorMom + Regime) obtient seulement 0.185, confirmant le problème de "double-defense".
+- **Composites : tout dépend de l'architecture** : Framework_Composite_TrendWeather tient (0.948, PSR 56.6%) là où MomentumRegime (combinaison SectorMom + Regime) obtient seulement 0.185 ("double-defense").
+- **Les stars du catalogue ne survivent pas toutes à l'alignement** : PuppiesOfTheDow (1.99 → 0.302) et HighBookToMarketFScore (2.09 → 0.411) s'effondrent sur 2018-2025 — leurs Sharpe catalogue venaient d'une fenêtre glissante non standardisée.
 - **Crypto = diversification stable** : MaxDD maitrisé (~17%), rendement modéré.
 
-> Voir [docs/archive/qc-comparative-backtests.md](../../docs/archive/qc-comparative-backtests.md) pour les 17 baselines vérifiées, les comparaisons best-vs-aligned, et les diagnostics détaillés (See #1630).
+> Voir [docs/qc/qc-comparative-backtests.md](../../docs/qc/qc-comparative-backtests.md) pour les 21 baselines vérifiées, les comparaisons best-vs-aligned, et les diagnostics détaillés (See #1630).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ Documentation detailee de l'infrastructure GenAI (ComfyUI, Docker, modeles locau
 | Fichier | Description |
 |---------|-------------|
 | [qc/quantconnect.md](qc/quantconnect.md) | Backtests, structure, livre reference |
+| [qc/qc-comparative-backtests.md](qc/qc-comparative-backtests.md) | Baselines alignees + analyse comparative backtests (#1630) |
 
 ## Lean (docs/lean/)
 
@@ -90,7 +91,6 @@ Documents conserves pour reference mais inactifs. Index complet : [archive/INDEX
 | Fichier | Description |
 |---------|-------------|
 | [archive/ml-trading-state.md](archive/ml-trading-state.md) | Etat ML trading (historique) |
-| [archive/qc-comparative-backtests.md](archive/qc-comparative-backtests.md) | Analyse comparative backtests |
 | [archive/visitor-navigation-guide.md](archive/visitor-navigation-guide.md) | Carte du visiteur |
 | [archive/research/dl_predictability_finance_2026.md](archive/research/dl_predictability_finance_2026.md) | Predictibilite DL finance 2026 |
 | [archive/analysis/qc-notebooks-exec-classification.md](archive/analysis/qc-notebooks-exec-classification.md) | Classification execution notebooks QC |

--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -2,6 +2,7 @@
 
 **Issue** : See #1630
 **Generated** : 2026-06-04 (automated catalog, pending live backtests)
+**Updated** : 2026-06-10 — +4 Tier-1 aligned baselines (PuppiesOfTheDow, LeveragedETFMomentum, Framework_Composite_TrendWeather, HighBookToMarketFScore)
 **Methodology** : Period common 2018-01-01 → 2024-12-31 (US equities/multi-asset), 2020-01-01 → 2024-12-31 (crypto). Metrics from `projects/catalog.json` + prior backtest runs. Pending: standardized re-backtest via MCP qc-mcp.
 
 ---
@@ -198,6 +199,10 @@ Standardized backtest results from QC Cloud via MCP qc-mcp-lite. Period: 2018-01
 | MomentumRegime | 31243821 | 2018-2025 | 0.185 | 4.7 | 11.5 | 13.0 | `033834d8` | Double-defense |
 | ForexCarry | 28657908 | 2015-2025* | -1.108 | -0.5 | 19.2 | — | `c3afe374` | *Cannot restrict to 2018+ |
 | RL-Q-Learning | 32057969 | 2020-2021* | 0.584 | 18.2 | 33.2 | — | `fb1a6366` | *Hardcoded dates |
+| PuppiesOfTheDow-QC | 32732704 | 2018-2025 | 0.302 | 9.613 | 28.8 | 3.5 | `37266daa` | Collapse vs catalog 1.99 (period overfitting) |
+| LeveragedETFMomentum-QC | 32732756 | 2018-2025 | **1.779** | 126.388 | 53.3 | **79.8** | `2addf467` | Confirms catalog 1.80. Lev ETF: extreme CAGR, MaxDD 53% |
+| Framework_Composite_TrendWeather | 28825740 | 2018-2025 | 0.948 | 24.603 | 27.5 | 56.6 | `cd84c50b` | Close to catalog 1.16, best composite |
+| HighBookToMarketFScore-QC | 32732820 | 2018-2025 | 0.411 | 14.513 | 60.4 | 4.5 | `5ef58b0d` | Collapse vs catalog 2.09, MaxDD 60% |
 
 ### Student strategies (ESGF 5BD1 cohort, See #1405)
 
@@ -234,6 +239,10 @@ Standardized backtest results from QC Cloud via MCP qc-mcp-lite. Period: 2018-01
 12. **Student RiskParity: performance honnete**: Sharpe 0.514, CAGR 9.3%, MaxDD 20.7%. Inverse-vol simple mais efficace. PSR 16.3% (non significatif mais respectable).
 13. **Student OptionWheel: catastrophe pedagogique**: Sharpe -0.51, MaxDD 103.5%. Parfait comme etude de cas du "win-rate paradoxe".
 14. **Student ValueFactor: alpha negatif confirmee**: Sharpe 0.227, PSR 0.8%. Decennie growth-dominée = facteur value sous-performant.
+15. **LeveragedETFMomentum: confirme et significatif**: Sharpe 1.779 sur 2018-2025, PSR 79.8% (2e PSR significatif apres TrendFollowing). Mais MaxDD 53.3% et CAGR 126% typiques d'un levier 3x — profil risque extreme, pas comparable aux strategies non-leveragees.
+16. **PuppiesOfTheDow et HighBookToMarketFScore: effondrement sur periode alignee**: Sharpe catalog 1.99 et 2.09 (obtenus sur leur fenetre glissante par defaut `end_date - 12 ans`) tombent a 0.302 (PSR 3.5%) et 0.411 (PSR 4.5%, MaxDD 60.4%) sur 2018-2025. Les deux meilleures lignes ML/IND du Tier 1 ne sont pas reproductibles sur la fenetre standardisee.
+17. **TrendWeather: le composite qui tient**: Sharpe 0.948 (PSR 56.6%), proche du catalog 1.16. Contraste fort avec MomentumRegime (0.185) — toutes les architectures composites ne se valent pas.
+18. **Caveat reproductibilite Trend-Following**: le code du repo backteste sur 2018-2024 donne Sharpe 0.365 / MaxDD 13.8% (backtest `3748cb62`), loin du 1.072 publie ci-dessus (`7792ae0a`, 2018-2025, etat du code cloud anterieur). Periodes differentes (2025 inclus ou non) ET drift possible repo vs cloud — a investiguer avant de citer 1.072 comme reference du code versionne.
 
 ## Comparison: Best-vs-Aligned
 
@@ -247,6 +256,10 @@ Standardized backtest results from QC Cloud via MCP qc-mcp-lite. Period: 2018-01
 | TrendFollowing | ~0.8 | 1.072 | +0.272 | Ameliore sur longue periode |
 | Crypto-MultiCanal | ~0.6 | 0.581 | ~0 | Performance confirmee |
 | VolTarget-Momentum | ~0.65 | 0.648 | ~0 | Performance confirmee |
+| PuppiesOfTheDow-QC | 1.99 | 0.302 | -1.688 | Period overfitting severe (catalog = fenetre glissante 12 ans) |
+| LeveragedETFMomentum-QC | 1.80 | 1.779 | -0.021 | Performance confirmee (mais MaxDD 53%) |
+| Framework_Composite_TrendWeather | 1.16 | 0.948 | -0.212 | Legere degradation, composite robuste |
+| HighBookToMarketFScore-QC | 2.09 | 0.411 | -1.679 | Period overfitting severe + MaxDD 60% |
 
 ---
 
@@ -259,6 +272,7 @@ Standardized backtest results from QC Cloud via MCP qc-mcp-lite. Period: 2018-01
 5. ~~**Transaction cost re-backtest**: Add `SetBrokerageModel` + configurable brokerage parameter~~ — Done, #2575 + fee sweep EMA-Cross-Stocks + Crypto-MultiCanal (See #2471, #2575, #2588)
 6. **Cross-seed validation**: ≥4 seeds (0/1/7/42/99) for ML/DL/RL strategies
 7. **Edge vs σ**: Compute for all strategies vs B&H baseline
+8. **Trend-Following repo/cloud drift**: repo code gives Sharpe 0.365 on 2018-2024 vs published 1.072 (2018-2025, prior cloud state) — identify which code version produced 1.072 and align repo (see Key finding 18)
 
 ---
 


### PR DESCRIPTION
## Summary

Partial delivery on #1630 (issue stays open): 4 previously-unverified Tier-1 strategies backtested on the doc-standard aligned period **2018-01-01 → 2025-12-31** via QC Cloud REST API, results integrated into `docs/qc/qc-comparative-backtests.md` (verified baselines 17 → 21 rows).

Also moves the comparative doc out of `docs/archive/` to `docs/qc/` — it is actively maintained and was wrongly archived by the docs reorg (#2648). 3 links fixed (docs/README.md index + 2 in QuantConnect README).

## Backtest evidence (rule G — QC PRs)

| Strategy | QC Project | Backtest ID | Sharpe | CAGR% | MaxDD% | PSR% | vs catalog |
|---|---|---|---|---|---|---|---|
| PuppiesOfTheDow-QC | 32732704 | `37266daa31d8b73726a319964a9c4940` | 0.302 | 9.6 | 28.8 | 3.5 | collapse vs 1.99 |
| LeveragedETFMomentum-QC | 32732756 | `2addf4671975ec922e7d784d79b8f759` | **1.779** | 126.4 | 53.3 | **79.8** | confirms 1.80 |
| Framework_Composite_TrendWeather | 28825740 | `cd84c50b8a40852bedb479e4e7cf6015` | 0.948 | 24.6 | 27.5 | 56.6 | close to 1.16 |
| HighBookToMarketFScore-QC | 32732820 | `5ef58b0d83acf31739e6b766a039ddb8` | 0.411 | 14.5 | 60.4 | 4.5 | collapse vs 2.09 |

Method: repo `main.py` uploaded with dates patched to the aligned window, compile → backtest → stats read, throttled 7s/call (well under the 10 calls/min cluster limit). New projects created under `CoursIA-Baseline/` keep patched dates; the shared existing cloud project (28825740) plus the two touched earlier (28797562, 28789946) were restored to unpatched repo `main.py` afterwards.

## Key findings added to the doc

- PuppiesOfTheDow and HighBookToMarketFScore — the two best catalog lines (Sharpe 1.99 / 2.09) — are **not reproducible** on the standardized window: their catalog values came from a rolling `end_date - 12y` default window (period overfitting, PSR < 5%).
- LeveragedETFMomentum is confirmed (1.779, PSR 79.8% — 2nd significant PSR after TrendFollowing) but with a 3x-leveraged risk profile (MaxDD 53%).
- TrendWeather is the composite that holds (0.948, PSR 56.6%), in sharp contrast with MomentumRegime (0.185).
- Reproducibility caveat documented: repo Trend-Following code on 2018-2024 gives Sharpe 0.365 (bt `3748cb62`) vs the published aligned 1.072 — repo/cloud drift to investigate (next step 8).

## Scope

Docs only — no notebook, no strategy code, no catalog file touched (`COURSE_CATALOG.generated.*` byte-identical to main).

See #1630 (partial: 4 more Tier-1 verified; cross-seed + edge-vs-sigma still pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)