### PR TITLE
feat(lean): GT-Lean phase 5 - reputation & entry deterrence (See #2610)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian.lean
@@ -26,8 +26,11 @@
   - `Bayesian.InfoGames` — counterexample: in a *game*, more information
                           can strictly hurt the informed player (unique
                           BNE payoffs 3 < 5, kernel-checked) (phase 4)
+  - `Bayesian.Reputation` — entry deterrence / chain-store reputation:
+                          unique credible BNE with and without type
+                          uncertainty, reputation pays 5 > 4 (phase 5)
 
-  See #2610 (GT-Lean formalization, phases 1-4: Bayesian games).
+  See #2610 (GT-Lean formalization, phases 1-5: Bayesian games).
 -/
 
 import Bayesian.Sum
@@ -39,3 +42,4 @@ import Bayesian.Vickrey
 import Bayesian.Max
 import Bayesian.Information
 import Bayesian.InfoGames
+import Bayesian.Reputation

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Reputation.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Reputation.lean
@@ -1,0 +1,332 @@
+/-
+  Reputation and Entry Deterrence (chain-store, kernel-checked)
+  =============================================================
+
+  A reduced strategic form of the classic two-period entry-deterrence
+  story (Kreps-Wilson / Milgrom-Roberts): an incumbent faces entry in
+  period 1, responds Fight or Accommodate, and a second entrant decides
+  whether to enter in period 2 *after observing* the period-1 response.
+
+  The incumbent (player 1) is one of two types:
+  - type 0, "rational": fighting costs in every period taken in
+    isolation (stage payoffs: Fight 0 < Accommodate 2);
+  - type 1, "tough" (commitment type): fighting is intrinsically
+    preferred (Fight 3 > Accommodate 0).
+
+  Equal prior weights (1, 1). Period-2 monopoly (entrant stays out)
+  pays the incumbent 5.
+
+  Action encodings (reduced plans, `Fin 4`, bit 0 = Accommodate/Out,
+  bit 1 = Fight/In):
+  - incumbent plan `a1`: `a1.val = 2*r1 + r2` where `r1` is the
+    period-1 response and `r2` the period-2 response if entry occurs;
+  - entrant plan `a2`: `a2.val = 2*eF + eA` where `eF` (resp. `eA`) is
+    the period-2 entry decision after observing Fight (resp.
+    Accommodate) in period 1.
+
+  Because raw normal-form equilibrium also admits non-credible threats
+  ("I will fight in period 2" by the rational type — never carried out
+  if tested), we impose a decidable *credibility* refinement standing
+  in for sequential rationality in the last period: each type's
+  period-2 response must be a stage best reply (rational accommodates,
+  tough fights).
+
+  Results (all by `decide` + eta-expansion of strategies):
+  - `gRep` (incomplete information, reputation possible) has a unique
+    credible BNE: the rational type *pools* with the tough type and
+    fights in period 1, the entrant stays out after a fight. The
+    rational incumbent earns 5.
+  - `gNoRep` (complete information benchmark: the incumbent is known
+    rational) has a unique credible BNE: accommodate, entry occurs,
+    payoff 4.
+  - `reputation_pays`: 4 < 5 in every credible equilibrium pair — the
+    incumbent's incentive to fight comes *only* from the entrant's
+    uncertainty about its type, i.e. from reputation. The rational type
+    fights in period 1 even though fighting is myopically dominated
+    (`rational_fights_in_equilibrium`).
+
+  See #2610 (GT-Lean formalization, Bayesian phase 5).
+-/
+
+import Bayesian.BNE
+
+/-! ### Plan decoders -/
+
+/-- Period-1 response encoded in an incumbent plan
+    (0 = Accommodate, 1 = Fight). -/
+def planR1 (a : Fin 4) : Nat := a.val / 2
+
+/-- Period-2 response (if entry occurs) encoded in an incumbent plan
+    (0 = Accommodate, 1 = Fight). -/
+def planR2 (a : Fin 4) : Nat := a.val % 2
+
+/-- The entrant's period-2 entry decision on path: the component of
+    its plan selected by the observed period-1 response
+    (0 = Out, 1 = In). -/
+def entryOf (a1 a2 : Fin 4) : Nat :=
+  if planR1 a1 = 1 then a2.val / 2 else a2.val % 2
+
+/-! ### Stage payoffs -/
+
+/-- Two-period payoff of the *rational* incumbent: fighting costs in
+    period 1 (0 vs 2), monopoly pays 5, and the period-2 response is
+    paid at stage values (Fight 0, Accommodate 2). -/
+def incRational (a1 a2 : Fin 4) : Int :=
+  (if planR1 a1 = 1 then 0 else 2) +
+  (if entryOf a1 a2 = 0 then 5
+   else if planR2 a1 = 1 then 0 else 2)
+
+/-- Two-period payoff of the *tough* (commitment) incumbent: fighting
+    is intrinsically preferred (3 vs 0) in both periods. -/
+def incTough (a1 a2 : Fin 4) : Int :=
+  (if planR1 a1 = 1 then 3 else 0) +
+  (if entryOf a1 a2 = 0 then 5
+   else if planR2 a1 = 1 then 3 else 0)
+
+/-- Period-2 entrant's payoff: 0 out, 2 if it enters and the incumbent
+    accommodates, -3 if it enters and the incumbent fights. -/
+def entrantU (a1 a2 : Fin 4) : Int :=
+  if entryOf a1 a2 = 0 then 0
+  else if planR2 a1 = 1 then -3 else 2
+
+/-! ### The two games -/
+
+/-- The reputation game: the entrant does not know the incumbent's
+    type (rational or tough, equal weights). -/
+def gRep : BayesGame2 where
+  nT1 := 2
+  nT2 := 1
+  nA1 := 4
+  nA2 := 4
+  w := fun _ _ => 1
+  u1 := fun t1 _ a1 a2 =>
+    if t1.val = 0 then incRational a1 a2 else incTough a1 a2
+  u2 := fun _ _ a1 a2 => entrantU a1 a2
+
+/-- The complete-information benchmark: the incumbent is known to be
+    rational (a single type). Same actions, same payoff tables. -/
+def gNoRep : BayesGame2 where
+  nT1 := 1
+  nT2 := 1
+  nA1 := 4
+  nA2 := 4
+  w := fun _ _ => 1
+  u1 := fun _ _ a1 a2 => incRational a1 a2
+  u2 := fun _ _ a1 a2 => entrantU a1 a2
+
+/-- Sanity check: the benchmark is exactly the reputation game
+    restricted to the rational type — not an unrelated game. -/
+theorem gNoRep_restriction :
+    ∀ a1 a2 : Fin 4,
+      gNoRep.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
+        gRep.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 ∧
+      gNoRep.u2 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
+        gRep.u2 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 := by
+  decide
+
+/-! ### Credibility refinement
+
+Normal-form BNE admits non-credible period-2 threats (e.g. in the
+benchmark, "rational fights period 2 / entrant stays out" is a Nash
+profile paying the incumbent 7 — but the threat would never be carried
+out). Sequential rationality in the *last* period is a finite,
+decidable condition on plans: each type's period-2 response must be a
+stage best reply. -/
+
+/-- Credibility in the reputation game: the rational type accommodates
+    in period 2 (2 > 0), the tough type fights (3 > 0). -/
+@[reducible] def credRep (s1 : Strategy1 gRep) : Prop :=
+  planR2 (s1 ⟨0, by decide⟩) = 0 ∧ planR2 (s1 ⟨1, by decide⟩) = 1
+
+/-- Credibility in the benchmark: the (rational) incumbent
+    accommodates in period 2. -/
+@[reducible] def credNoRep (s1 : Strategy1 gNoRep) : Prop :=
+  planR2 (s1 ⟨0, by decide⟩) = 0
+
+/-! ### Canonical strategy constructors (reputation game) -/
+
+/-- Incumbent strategies in `gRep`, from the two type-contingent
+    plans. -/
+def mkRepS1 (x y : Fin 4) : Strategy1 gRep :=
+  fun t1 => if t1.val = 0 then x else y
+
+/-- Entrant strategies in `gRep` are constants (one type). -/
+def mkRepS2 (z : Fin 4) : Strategy2 gRep := fun _ => z
+
+/-- Every incumbent strategy is determined by its two values. -/
+theorem repS1_eta (s1 : Strategy1 gRep) :
+    s1 = mkRepS1 (s1 ⟨0, by decide⟩) (s1 ⟨1, by decide⟩) := by
+  funext t1
+  cases t1 using Fin.cases with
+  | zero => rfl
+  | succ j =>
+    cases j using Fin.cases with
+    | zero => rfl
+    | succ j' => exact j'.elim0
+
+/-- Every entrant strategy is a canonical constant. -/
+theorem repS2_eta (s2 : Strategy2 gRep) :
+    s2 = mkRepS2 (s2 ⟨0, by decide⟩) := by
+  funext t2
+  cases t2 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+/-! ### Equilibrium analysis of the reputation game
+
+Target profile: rational plays plan 2 = (Fight, Accommodate), tough
+plays plan 3 = (Fight, Fight), entrant plays plan 1 = (Out after
+Fight, In after Accommodate). -/
+
+/-- The pooling profile is a BNE of the reputation game. -/
+theorem gRep_bne :
+    isBNE gRep (mkRepS1 ⟨2, by decide⟩ ⟨3, by decide⟩)
+      (mkRepS2 ⟨1, by decide⟩) := by
+  decide
+
+/-- The pooling profile is credible. -/
+theorem gRep_bne_credible :
+    credRep (mkRepS1 ⟨2, by decide⟩ ⟨3, by decide⟩) := by
+  decide
+
+/-- Over canonical strategies, the credible BNE of `gRep` is unique:
+    both incumbent types fight in period 1 (the rational type pools),
+    and the entrant enters iff it observed Accommodate. -/
+theorem gRep_unique_aux :
+    ∀ x y z : Fin 4,
+      isBNE gRep (mkRepS1 x y) (mkRepS2 z) →
+      credRep (mkRepS1 x y) →
+        x = ⟨2, by decide⟩ ∧ y = ⟨3, by decide⟩ ∧ z = ⟨1, by decide⟩ := by
+  decide
+
+/-- Over canonical strategies, every credible BNE of `gRep` pays the
+    rational incumbent exactly 5 (deterrence: 0 in period 1, monopoly
+    5 in period 2). -/
+theorem gRep_payoff_aux :
+    ∀ x y z : Fin 4,
+      isBNE gRep (mkRepS1 x y) (mkRepS2 z) →
+      credRep (mkRepS1 x y) →
+        interimU1 gRep ⟨0, by decide⟩ x (mkRepS2 z) = 5 := by
+  decide
+
+/-- The reputation game has an essentially unique credible BNE. -/
+theorem gRep_unique (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (h : isBNE gRep s1 s2) (hc : credRep s1) :
+    s1 = mkRepS1 ⟨2, by decide⟩ ⟨3, by decide⟩ ∧
+    s2 = mkRepS2 ⟨1, by decide⟩ := by
+  rw [repS1_eta s1] at h hc
+  rw [repS2_eta s2] at h
+  have hu := gRep_unique_aux _ _ _ h hc
+  exact ⟨by rw [repS1_eta s1, hu.1, hu.2.1],
+         by rw [repS2_eta s2, hu.2.2]⟩
+
+/-- In every credible BNE of the reputation game, the rational
+    incumbent earns 5. -/
+theorem gRep_credible_payoff (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (h : isBNE gRep s1 s2) (hc : credRep s1) :
+    interimU1 gRep ⟨0, by decide⟩ (s1 ⟨0, by decide⟩) s2 = 5 := by
+  rw [repS1_eta s1] at h hc
+  rw [repS2_eta s2] at h ⊢
+  exact gRep_payoff_aux _ _ _ h hc
+
+/-- In every credible BNE of the reputation game the *rational* type
+    fights in period 1, even though fighting is myopically dominated
+    (stage value 0 < 2): the pooling/signaling motive. -/
+theorem rational_fights_in_equilibrium
+    (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (h : isBNE gRep s1 s2) (hc : credRep s1) :
+    planR1 (s1 ⟨0, by decide⟩) = 1 := by
+  rw [repS1_eta s1] at h hc
+  rw [repS2_eta s2] at h
+  have hu := gRep_unique_aux _ _ _ h hc
+  rw [hu.1]
+  decide
+
+/-- In every credible BNE of the reputation game, period-2 entry is
+    deterred against both types: the entrant observes Fight on path
+    and stays out. -/
+theorem reputation_deters_entry
+    (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (h : isBNE gRep s1 s2) (hc : credRep s1) :
+    entryOf (s1 ⟨0, by decide⟩) (s2 ⟨0, by decide⟩) = 0 ∧
+    entryOf (s1 ⟨1, by decide⟩) (s2 ⟨0, by decide⟩) = 0 := by
+  rw [repS1_eta s1] at h hc
+  rw [repS2_eta s2] at h
+  have hu := gRep_unique_aux _ _ _ h hc
+  rw [hu.1, hu.2.1, hu.2.2]
+  decide
+
+/-! ### Equilibrium analysis of the benchmark -/
+
+/-- Incumbent strategies in `gNoRep` are constants. -/
+def mkNoS1 (x : Fin 4) : Strategy1 gNoRep := fun _ => x
+
+/-- Entrant strategies in `gNoRep` are constants. -/
+def mkNoS2 (z : Fin 4) : Strategy2 gNoRep := fun _ => z
+
+theorem noS1_eta (s1 : Strategy1 gNoRep) :
+    s1 = mkNoS1 (s1 ⟨0, by decide⟩) := by
+  funext t1
+  cases t1 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+theorem noS2_eta (s2 : Strategy2 gNoRep) :
+    s2 = mkNoS2 (s2 ⟨0, by decide⟩) := by
+  funext t2
+  cases t2 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+/-- (Accommodate, Accommodate) / (In, In) is a credible BNE of the
+    benchmark. -/
+theorem gNoRep_bne :
+    isBNE gNoRep (mkNoS1 ⟨0, by decide⟩) (mkNoS2 ⟨3, by decide⟩) := by
+  decide
+
+/-- Over canonical strategies, the credible BNE of the benchmark is
+    unique: a known-rational incumbent cannot deter entry. -/
+theorem gNoRep_unique_aux :
+    ∀ x z : Fin 4,
+      isBNE gNoRep (mkNoS1 x) (mkNoS2 z) →
+      credNoRep (mkNoS1 x) →
+        x = ⟨0, by decide⟩ ∧ z = ⟨3, by decide⟩ := by
+  decide
+
+/-- Over canonical strategies, every credible BNE of the benchmark
+    pays the incumbent exactly 4 (accommodation in both periods). -/
+theorem gNoRep_payoff_aux :
+    ∀ x z : Fin 4,
+      isBNE gNoRep (mkNoS1 x) (mkNoS2 z) →
+      credNoRep (mkNoS1 x) →
+        interimU1 gNoRep ⟨0, by decide⟩ x (mkNoS2 z) = 4 := by
+  decide
+
+/-- In every credible BNE of the benchmark, the incumbent earns 4. -/
+theorem gNoRep_credible_payoff
+    (s1 : Strategy1 gNoRep) (s2 : Strategy2 gNoRep)
+    (h : isBNE gNoRep s1 s2) (hc : credNoRep s1) :
+    interimU1 gNoRep ⟨0, by decide⟩ (s1 ⟨0, by decide⟩) s2 = 4 := by
+  rw [noS1_eta s1] at h hc
+  rw [noS2_eta s2] at h ⊢
+  exact gNoRep_payoff_aux _ _ h hc
+
+/-! ### Punchline -/
+
+/-- **Reputation pays.** In every credible equilibrium, the rational
+    incumbent earns strictly more under incomplete information (5,
+    entry deterred by pooling with the tough type) than under complete
+    information (4, entry occurs and is accommodated). The value of
+    reputation is exactly the entrant's uncertainty about the
+    incumbent's type: with the type known, the same incumbent with the
+    same payoffs cannot deter anything. -/
+theorem reputation_pays
+    (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (t1 : Strategy1 gNoRep) (t2 : Strategy2 gNoRep)
+    (hR : isBNE gRep s1 s2) (hcR : credRep s1)
+    (hN : isBNE gNoRep t1 t2) (hcN : credNoRep t1) :
+    interimU1 gNoRep ⟨0, by decide⟩ (t1 ⟨0, by decide⟩) t2 <
+      interimU1 gRep ⟨0, by decide⟩ (s1 ⟨0, by decide⟩) s2 := by
+  rw [gRep_credible_payoff s1 s2 hR hcR,
+      gNoRep_credible_payoff t1 t2 hN hcN]
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md
@@ -19,6 +19,7 @@ l'epic #2610.
 | `Bayesian/Max.lean` | Maxima finis sur `Fin (n + 1)` (`maxFin`) : bornes `le_maxFin`/`maxFin_le`, et le lemme maître `maxFin_sumFin_le` (max d'une somme ≤ somme des maxima par groupe) (phase 4) |
 | `Bayesian/Information.lean` | Valeur de l'information pour un décideur seul : signaux déterministes = partitions des états, `valueNoInfo ≤ valueSignal ≤ valuePerfect`, **monotonie de Blackwell** (`valueSignal_mono` : un signal plus fin vaut toujours au moins autant, via factorisation σ = h ∘ τ), exemple parapluie chiffré par `decide` (phase 4) |
 | `Bayesian/InfoGames.lean` | **L'information peut nuire dans un jeu** : contre-exemple 2 états / 2×2 où le BNE est unique dans chaque scénario (certifié `decide` + eta-expansion des stratégies) et le joueur informé gagne strictement moins (3 < 5) que s'il ne voyait rien — contraste kernel-checked avec la monotonie à un joueur (phase 4) |
+| `Bayesian/Reputation.lean` | **Réputation et dissuasion d'entrée** (chain-store à 2 périodes, forme stratégique réduite) : incumbent à 2 types (rationnel / *tough*), raffinement décidable de crédibilité (rationalité séquentielle en dernière période), BNE crédible **unique** dans chaque scénario — avec incertitude le type rationnel *poole* (il combat alors que combattre est myopiquement dominé) et dissuade l'entrée (paiement 5) ; en information complète l'entrée a lieu (paiement 4) : `reputation_pays` 5 > 4 (phase 5) |
 
 ## Choix de conception
 
@@ -49,5 +50,6 @@ Kuhn poker — cf #2748 / PR #2752) reste le socle « phase 0 ». Ce
 projet-ci accueille les extensions de l'epic #2610 (phases livrées :
 2 — enchère au premier prix discret, 3 — enchère de Vickrey et
 dominance faible, 4 — valeur de l'information : monotonie de Blackwell
-à un joueur + contre-exemple « l'information nuit » en jeu) ; phases
-suivantes prévues : jeux de réputation simplifiés.
+à un joueur + contre-exemple « l'information nuit » en jeu,
+5 — réputation et dissuasion d'entrée, BNE crédible unique et
+`reputation_pays`).


### PR DESCRIPTION
## Summary

Phase 5 of epic #2610 (GT-Lean Bayesian formalization): **reputation and entry deterrence** (two-period chain-store a la Kreps-Wilson / Milgrom-Roberts) in `lean_game_defs_ext` (core Lean 4, no Mathlib, toolchain v4.30.0-rc2).

New module `Bayesian/Reputation.lean` (+ root import in `Bayesian.lean`, README row + phases paragraph):

- **Reduced strategic form**: incumbent plans `Fin 4` = (period-1 response, period-2 response if entry); entrant plans `Fin 4` = (entry after Fight, entry after Accommodate). Decoders `planR1`/`planR2`/`entryOf`.
- **Two types of incumbent**: rational (fighting myopically dominated, 0 < 2) and tough commitment (prefers fighting, 3 > 0), equal prior weights.
- **Decidable credibility refinement** (`credRep`/`credNoRep`): sequential rationality in the last period — rules out non-credible period-2 threats that plain normal-form BNE admits.
- **`gRep`** (incomplete information): unique credible BNE certified by `decide` + eta-expansion — the rational type **pools** with the tough type and fights in period 1, entry is deterred, interim payoff **5** (`gRep_unique`, `gRep_credible_payoff`, `rational_fights_in_equilibrium`, `reputation_deters_entry`).
- **`gNoRep`** (complete-information benchmark, sanity-checked as the exact restriction of `gRep` to the rational type via `gNoRep_restriction`): unique credible BNE — accommodate, entry occurs, payoff **4**.
- **Punchline `reputation_pays`**: in every credible equilibrium pair, 4 < 5 — the entire value of fighting comes from the entrant''s uncertainty about the incumbent''s type.

## Rule-B verification (Lean PR body)

1. **sorry count**: `\bsorry\b` word-boundary grep over `Bayesian.lean` + `Bayesian/*.lean` = **0 before / 0 after** (project has never had a sorry).
2. **Lake build**: `Build completed successfully (13 jobs)` — WSL `lake build` (Windows-native `lake.exe` currently re-blocked by app-control policy, os error 4551 — flagged as user-blocker). New jobs: `✔ [11/13] Built Bayesian.Reputation (14s)`, `✔ [12/13] Built Bayesian (13s)`.
3. **Proof integrity / axiom check** (`lake env lean` on `#print axioms` for all 8 public theorems):
   ```
   ''reputation_pays'' depends on axioms: [propext, Quot.sound]
   ''gRep_unique'' depends on axioms: [propext, Quot.sound]
   ''gRep_credible_payoff'' depends on axioms: [propext, Quot.sound]
   ''gNoRep_credible_payoff'' depends on axioms: [propext, Quot.sound]
   ''rational_fights_in_equilibrium'' depends on axioms: [propext, Quot.sound]
   ''reputation_deters_entry'' depends on axioms: [propext, Quot.sound]
   ''gRep_bne'' depends on axioms: [propext]
   ''gNoRep_bne'' depends on axioms: [propext]
   ```
   No `sorryAx`, no `Classical.choice`.
4. **No Python prover refactor** in this PR — pure Lean content + docs.

CI: covered automatically by `lean-game-defs-ext.yml` (caller of reusable `lean-build.yml`, builds the `Bayesian` lib + sorry baseline 0).

Catalog untouched (byte-identical to main). See #2610 (partial: phase 5 of the epic — epic stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)