### PR TITLE
feat(rl): rl_9 offline RL — Behavior Cloning, erreur d'extrapolation, BCQ-lite (See #295)

### DIFF
--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -17,9 +17,9 @@ Cette serie couvre les **fondements theoriques** (bandits, MDP, equation de Bell
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 11 |
+| Notebooks | 12 |
 | Kernel | Python 3 |
-| Duree totale | ~450-520 min |
+| Duree totale | ~500-575 min |
 | Version | Stable Baselines3 2.0.0+ |
 
 ## Notebooks
@@ -37,6 +37,7 @@ Cette serie couvre les **fondements theoriques** (bandits, MDP, equation de Bell
 | 6d | [rl_6d_sac_from_scratch](rl_6d_sac_from_scratch.ipynb) | SAC depuis zero, maximum entropy RL, twin Q-networks, auto-temperature | 45-50 min |
 | 7 | [rl_7_multi_agent_rl](rl_7_multi_agent_rl.ipynb) | Multi-Agent RL, PettingZoo, IQL | 45-50 min |
 | 8 | [rl_8_model_based_dyna_q](rl_8_model_based_dyna_q.ipynb) | Model-based RL : Dyna-Q, Dyna-Q+, planification, rollouts | 45-50 min |
+| 9 | [rl_9_offline_rl](rl_9_offline_rl.ipynb) | RL offline : Behavior Cloning, erreur d'extrapolation, BCQ-lite | 50-55 min |
 
 ## Contenu detaille
 
@@ -150,6 +151,18 @@ Cette serie couvre les **fondements theoriques** (bandits, MDP, equation de Bell
 | Decision-time planning | Rollouts, pont vers MCTS / AlphaZero / MuZero |
 | Exercices | Shortcut Maze, prioritized sweeping, sensibilite de kappa |
 
+### Notebook 9 - RL offline : apprendre sans interagir
+
+| Section | Contenu |
+|---------|---------|
+| Online vs offline | Apprendre d'un dataset fige de transitions (logs), sans interaction |
+| Datasets | Trois politiques de comportement (expert/medium/random), couverture vs qualite |
+| Behavior Cloning | Imitation tabulaire par action majoritaire, plafond de la politique de comportement |
+| Erreur d'extrapolation | Q-learning naif sur dataset fige : bootstrap sur actions fantomes (Fujimoto 2019) |
+| BCQ-lite | Contrainte de support du dataset, stitching de trajectoires mediocres |
+| Pont RLHF/DPO | SFT = BC, contrainte KL = contrainte de support, DPO = preference learning offline |
+| Exercices | Ablation taille dataset, penalite CQL-lite, sensibilite au nombre de passes |
+
 ## Algorithmes couverts
 
 | Algorithme | Type | Notebook | Utilisation |
@@ -168,6 +181,8 @@ Cette serie couvre les **fondements theoriques** (bandits, MDP, equation de Bell
 | **Dyna-Q** | Model-based | 8 | Planification sur modele appris, sample efficiency |
 | **Dyna-Q+** | Model-based | 8 | Environnements non-stationnaires, bonus d'exploration |
 | **Rollout planning** | Decision-time | 8 | Simulation vers l'avant, porte vers MCTS |
+| **Behavior Cloning** | Offline (imitation) | 9 | Demonstrations expertes, baseline offline |
+| **BCQ-lite** | Offline (value-based) | 9 | Q-learning contraint au support du dataset |
 | **DQN** | Off-policy (deep) | 6 | Espaces continus |
 | **REINFORCE** | Policy gradient | 6 | Politique directe |
 | **IQL** | Multi-agent | 7 | Apprentissage independant |
@@ -183,7 +198,7 @@ Cette serie couvre les **fondements theoriques** (bandits, MDP, equation de Bell
 | FrozenLake-v1 | Grille discrete, stochastique | 5 |
 | CliffWalking-v1 | Grille, compromis risque/recompense | 5 |
 | TicTacToe-v3 | Jeu a somme nulle | 7 |
-| Dyna Maze / Blocking Maze | Grilles deterministes et changeantes (numpy pur) | 8 |
+| Dyna Maze / Blocking Maze | Grilles deterministes et changeantes (numpy pur) | 8, 9 |
 
 ## Prerequisites
 
@@ -269,7 +284,7 @@ Le notebook 4 pose la question fondatrice du RL : comment choisir entre explorer
 
 **Phase 4 : Les maths sous le capot (~4.5h, notebooks 5-7)**
 
-Les notebooks 5 a 7 quittent le framework pour implementer les algorithmes depuis zero. Le notebook 5 formalise le probleme RL (MDP, equation de Bellman, Value/Policy Iteration) et introduit le Q-Learning tabulaire sur FrozenLake et CliffWalking. Le notebook 6 passe a l'echelle avec les reseaux de neurones : DQN et REINFORCE implementes en PyTorch pur. Le notebook 6b introduit l'architecture Actor-Critic (A2C). Le notebook 6c pousse plus loin avec PPO et son mecanisme de clipping, introduit GAE, et compare les approches. Le notebook 6d approfondit avec SAC (Soft Actor-Critic) et le framework maximum entropy pour les actions continues. Le notebook 7 aborde le multi-agent : plusieurs agents qui apprennent simultanement, cooperent ou s'affrontent (TicTacToe avec self-play). Le notebook 8 ouvre la voie model-based : apprendre un modele du monde et planifier dessus (Dyna-Q, Dyna-Q+, rollouts), avec les ponts vers MCTS, AlphaZero et MuZero.
+Les notebooks 5 a 7 quittent le framework pour implementer les algorithmes depuis zero. Le notebook 5 formalise le probleme RL (MDP, equation de Bellman, Value/Policy Iteration) et introduit le Q-Learning tabulaire sur FrozenLake et CliffWalking. Le notebook 6 passe a l'echelle avec les reseaux de neurones : DQN et REINFORCE implementes en PyTorch pur. Le notebook 6b introduit l'architecture Actor-Critic (A2C). Le notebook 6c pousse plus loin avec PPO et son mecanisme de clipping, introduit GAE, et compare les approches. Le notebook 6d approfondit avec SAC (Soft Actor-Critic) et le framework maximum entropy pour les actions continues. Le notebook 7 aborde le multi-agent : plusieurs agents qui apprennent simultanement, cooperent ou s'affrontent (TicTacToe avec self-play). Le notebook 8 ouvre la voie model-based : apprendre un modele du monde et planifier dessus (Dyna-Q, Dyna-Q+, rollouts), avec les ponts vers MCTS, AlphaZero et MuZero. Le notebook 9 retire le droit d'interagir : apprendre d'un dataset fige (RL offline), avec le Behavior Cloning, l'erreur d'extrapolation du Q-learning naif, la contrainte de support (BCQ-lite) et le pont vers RLHF/DPO.
 
 ## Concepts cles
 
@@ -301,6 +316,9 @@ Les notebooks 5 a 7 quittent le framework pour implementer les algorithmes depui
 | **Dyna** | Entrelacement apprentissage direct / planification | 8 |
 | **Sample efficiency** | Echanger du calcul contre de l'experience reelle | 8 |
 | **Decision-time planning** | Rollouts et MCTS depuis l'etat courant | 8 |
+| **RL offline** | Apprendre d'un dataset fige, sans interaction | 9 |
+| **Erreur d'extrapolation** | Bootstrap sur actions hors du support des donnees | 9 |
+| **Stitching** | Recoudre un chemin optimal a partir de trajectoires mediocres | 9 |
 
 ## Caracteristiques
 
@@ -377,6 +395,7 @@ RL/
 ├── rl_6d_sac_from_scratch.ipynb
 ├── rl_7_multi_agent_rl.ipynb
 ├── rl_8_model_based_dyna_q.ipynb
+├── rl_9_offline_rl.ipynb
 └── README.md
 ```
 

--- a/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# RL-4 : Bandits Manchots et le Compromis Exploration-Exploitation\n",
     "\n",
-    "**Serie** : Reinforcement Learning | **Notebook** : 4/11 | **Duree estimee** : 40-45 min\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 4/12 | **Duree estimee** : 40-45 min\n",
     "\n",
     "Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | **RL-4 Bandits** | [RL-5 MDP/Q-Learning](rl_5_mdp_dp_qlearning.ipynb) | [RL-6 DQN/PG](rl_6_dqn_policy_gradient.ipynb) | [RL-7 Multi-Agent](rl_7_multi_agent_rl.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# RL-5 : MDP, Programmation Dynamique et Q-Learning Tabulaire\n",
     "\n",
-    "**Serie** : Reinforcement Learning | **Notebook** : 5/11 | **Duree estimee** : 45-50 min\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 5/12 | **Duree estimee** : 45-50 min\n",
     "\n",
     "Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-3 HER](rl_3_experience_replay_dqn.ipynb) | **RL-5** | [RL-6 DQN/PG](rl_6_dqn_policy_gradient.ipynb) | [RL-7 Multi-Agent](rl_7_multi_agent_rl.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# RL-6 : Deep Q-Network (DQN) et Policy Gradient\n",
     "\n",
-    "**Serie** : Reinforcement Learning | **Notebook** : 6/11 | **Duree estimee** : 50-55 min\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 6/12 | **Duree estimee** : 50-55 min\n",
     "\n",
     "Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-3 HER](rl_3_experience_replay_dqn.ipynb) | [RL-5 Tabulaire](rl_5_mdp_dp_qlearning.ipynb) | **RL-6** | [RL-7 Multi-Agent](rl_7_multi_agent_rl.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# RL-6b - Actor-Critic : unir valeur et politique\n",
     "\n",
-    "**Serie** : Reinforcement Learning | **Notebook** : 6b/11 | **Duree estimee** : 45-50 min\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 6b/12 | **Duree estimee** : 45-50 min\n",
     "\n",
     "Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-3 HER](rl_3_experience_replay_dqn.ipynb) | [RL-4 Bandits](rl_4_multi_armed_bandits.ipynb) | [RL-5 Tabulaire](rl_5_mdp_dp_qlearning.ipynb) | [RL-6 DQN/PG](rl_6_dqn_policy_gradient.ipynb) | **RL-6b** | [RL-7 Multi-Agent](rl_7_multi_agent_rl.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# RL-7 : Introduction a l'Apprentissage Multi-Agent\n",
     "\n",
-    "**Serie** : Reinforcement Learning | **Notebook** : 7/11 | **Duree estimee** : 45-50 min\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 7/12 | **Duree estimee** : 45-50 min\n",
     "\n",
     "Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-3 HER](rl_3_experience_replay_dqn.ipynb) | [RL-5 Tabulaire](rl_5_mdp_dp_qlearning.ipynb) | [RL-6 DQN/PG](rl_6_dqn_policy_gradient.ipynb) | **RL-7**\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# RL-8 : Model-Based RL — Dyna-Q et planification\n",
     "\n",
-    "**Serie** : Reinforcement Learning | **Notebook** : 8/11 | **Duree estimee** : 45-50 min\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 8/12 | **Duree estimee** : 45-50 min\n",
     "\n",
     "**Prerequis** : notebook 5 (MDP, programmation dynamique, Q-Learning tabulaire).\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb
@@ -1,0 +1,916 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b73f69f6",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# RL-9 : RL offline — Behavior Cloning et erreur d'extrapolation\n",
+    "\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 9/12 | **Duree estimee** : 50-55 min\n",
+    "\n",
+    "**Prerequis** : notebook 5 (Q-learning, politiques epsilon-greedy) ; le notebook 8 (Dyna-Q) aide pour le labyrinthe de Sutton & Barto mais n'est pas indispensable.\n",
+    "\n",
+    "## Objectifs pedagogiques\n",
+    "\n",
+    "- Comprendre la difference entre RL **online** (l'agent interagit) et RL **offline** (un dataset fige de transitions, aucune interaction possible) ;\n",
+    "- Implementer le **Behavior Cloning** (BC) tabulaire et constater qu'il est plafonne par la qualite de la politique de comportement ;\n",
+    "- Mettre en evidence l'**erreur d'extrapolation** : pourquoi le Q-learning applique naivement a un dataset fige echoue, meme avec des donnees expertes ;\n",
+    "- Implementer une correction de type **BCQ** (contraindre le bootstrap au support du dataset) et observer le **stitching** : extraire une politique quasi optimale de donnees mediocres ;\n",
+    "- Relier ces idees aux methodes modernes (BCQ, CQL) et a l'alignement des LLM (RLHF, DPO).\n",
+    "\n",
+    "## Plan\n",
+    "\n",
+    "1. Du RL online au RL offline\n",
+    "2. Fabriquer les datasets : trois politiques de comportement\n",
+    "3. Behavior Cloning\n",
+    "4. Q-learning offline naif : l'erreur d'extrapolation\n",
+    "5. Contraindre au support du dataset : BCQ-lite\n",
+    "6. Du tabulaire au deep : BCQ, CQL et le pont vers RLHF/DPO\n",
+    "7. Exercices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ddebb1f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 1. Du RL online au RL offline\n",
+    "\n",
+    "Tous les algorithmes vus jusqu'ici (Q-learning, DQN, policy gradient, Dyna-Q) sont **online** : l'agent choisit ses actions, observe les consequences, et corrige. Cette boucle d'essai-erreur est un luxe. En robotique, en sante, en conduite autonome ou en finance, laisser une politique non entrainee explorer librement est couteux, voire dangereux. En revanche, on dispose souvent de **journaux d'interactions passees** : trajectoires d'un operateur humain, logs d'un ancien controleur, historique de decisions cliniques.\n",
+    "\n",
+    "Le **RL offline** (ou *batch RL*) pose la question : peut-on apprendre une bonne politique **uniquement** a partir d'un dataset fige $\\mathcal{D} = \\{(s_i, a_i, r_i, s'_i)\\}$, collecte par une **politique de comportement** $\\pi_\\beta$ inconnue, sans jamais interagir avec l'environnement pendant l'apprentissage ?\n",
+    "\n",
+    "Deux familles de reponses naives, deux echecs instructifs :\n",
+    "\n",
+    "- **Imiter** : reproduire l'action majoritaire du dataset dans chaque etat (*Behavior Cloning*). Simple, mais on ne peut pas depasser $\\pi_\\beta$ — si les donnees sont mediocres, la copie l'est aussi.\n",
+    "- **Faire du Q-learning sur le dataset** : apres tout, le Q-learning est *off-policy*, il devrait digerer des donnees venues d'ailleurs. C'est vrai en apparence seulement : sans nouvelles interactions pour corriger les illusions, le $\\max_a Q(s', a)$ bootstrape sur des actions **jamais observees** et l'erreur s'auto-amplifie. C'est l'**erreur d'extrapolation** (Fujimoto et al., 2019), que nous allons reproduire pas a pas.\n",
+    "\n",
+    "Nous travaillons en tabulaire sur le labyrinthe 6x9 de Sutton & Barto (fig. 8.2) — le meme que le notebook 8 — avec une convention de recompense importante pour la suite : **-1 par pas, 0 en atteignant le but**. Maximiser le retour = minimiser la longueur du chemin, et surtout l'initialisation $Q = 0$ devient **optimiste** : une action jamais essayee semble meilleure que la realite. Retenez ce detail, c'est le carburant de l'erreur d'extrapolation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "95b63d59",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NumPy 2.2.6 — graine 42\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "SEED = 42\n",
+    "ALPHA, GAMMA, EPSILON = 0.5, 0.95, 0.1\n",
+    "MAX_STEPS = 200          # troncature des episodes (echec = retour -200)\n",
+    "\n",
+    "ACTIONS = [(-1, 0), (1, 0), (0, -1), (0, 1)]   # haut, bas, gauche, droite\n",
+    "ACTION_NAMES = [\"haut\", \"bas\", \"gauche\", \"droite\"]\n",
+    "\n",
+    "print(f\"NumPy {np.__version__} — graine {SEED}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7dcce77d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkcAAAGGCAYAAABxHyV7AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAANB5JREFUeJzt3Ql8VOW9//Ff2IKyRJBdNlEUAUFBwR0VXChScNdiRbS2WlAQtIor1GqwvaBWKKBV6FUpbgWXqyCKwK2CsogXRBEUJaKIKCaAGhHO//V9/vfkPjOZJJOQcDKTz7uvKc5kMnnO9pzveZYzGUEQBAYAAACn2v//BwAAAEI4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAKAyhKNPP/3UMjIy7D/+4z/2yd879dRT3aM8LViwwC3Ds88+a1VRTk6O1a5d2958882oi4JKbseOHfab3/zGmjVr5o6ZESNGFNQB06dPt3SwZs0aq1Gjhq1evdoquzFjxrh1v3XrVqsstB+oTNovUlHbtm3tiiuuqHJ/O11VK8vOu2zZMqtKZsyYYQ888EDUxbCvvvrKfve739lBBx3kQokOiKuuuqrMnzdx4kQ74ogjLDMz033myJEjbefOnUn//h//+Efr2bOnnXjiiTGvv/jii9arVy9r0qSJ7b///tauXTu76KKLbM6cOeW6/r/44gtXya9cudKi9OOPP9ro0aPd9tDydujQwW688cZSfYYqNh1b4UMn2VatWtkll1ziTrrlTZ+pdbevTkT33nuvqz+uvfZae/zxx+3Xv/617UvLly+3c845x4WzunXrWpcuXeyvf/2r7d69u9jf27Nnjyv3L3/5S7c96tSpY507d7Y//elPbrv7OnbsaP369bM777yzgpcGUXnrrbfccfPdd99Zunvqqafssssus/bt27s6KdnGhXvuuce9X8dJSgtKYdq0afoetmDp0qXB3tqwYYP7rL/85S/BvpCfn+8eZdGvX7+gTZs2hV5/44033DI888wzQUXbuHFj0KpVK/f44x//GDz66KPB3XffHfTv379Mn/eHP/zBlf2CCy4IJk+eHFx33XVBjRo1gjPPPDOp39+yZUtQs2bNYMaMGTGva3vqc3v16hVMmDAhmDJlSnDjjTcGRx11VDB48OByXf/aD/W3tF9G6frrr3fluPLKK4OpU6cGI0eODJo2bVqqz9C6yczMDB5//HH30DLdfvvtQaNGjYKsrKxg06ZN5Vpm7bMqs/bhfaFnz57BiSeeGPPanj17gh9++CH4+eefK/RvL1u2LKhVq1bQqVOngn1ywIABbvm17Yqzfft2977jjjsu+NOf/hQ8/PDDwZAhQ4Jq1aoFp556qlsG38svv+zev379+qAyu+uuu1w5v/7666Cy0H6g/SF+nVYmYf2m81e8H3/8Mfjpp58iKZfqx7LWr0Xp1atXULdu3eC0004LGjRo4J6XJCcnJ9h///2DOnXquOMtldWwNPf999+7q/latWpZKlOLkVoTli5dagceeOBefdaXX35pEyZMcFfv//mf/1nw+mGHHWbXXXeda/np379/sZ/xxBNPuPL47/v555/t7rvvtjPOOMNeffXVQr+zZcsWS0czZ860X/ziF/boo4/GtJSUltanrtR8xx13nGvx+K//+i+7+uqr97qsau2I4ljQtlfLik9Xl2oBrWhTp051/y5atMgaNmxYcDypdVOtQg8++GCRv6t1pW7jE044oeA1bQe1Et511132+uuvW58+fQp+pv9u0KCB/eMf/3Atq0he9erV3SNVqQU+nTz++OOuR6FatWpJtwKpxVx1llpkK1OXbaUYc/TTTz+5ZuXu3btbVlaWa4Y++eST7Y033ijyd+6//35r06aN7bfffq7C8vvsp02b5irRd999t9Dv6QSkg2nTpk3uuZr9tBHVhH7KKae4UHTrrbcW/MxvFgzHCz399NOuGbBly5auou7du7etX7++4H36HZ2YPvvss4IuD1WM8U3vxX1G6O2337azzz7brReVTcuazHidDz/80F555RW76aabXDDSCW7Xrl2F3vfBBx+4dXj55ZfHvP7vf//braebb77ZPV+8eLELMuqy8YXPdbIvyezZs12XmrooQjoY8vLyCnWzhdTNVtL4gnC76N/i1r9+fuyxx7r3DBkypOBn/viVZ555xu2HWieNGjVywSPcV/zuLC2DXh84cKD778aNG7uDvKQul5AqjyDQBWX5V5TqBgqDU+jbb7915TvyyCNdeevXr299+/a19957L+G61Pa8/fbbXUWn/U7dSRdeeKF7z2mnnVaw7sJ1Ln/729+sU6dObjlatGhhQ4cOLVNXQliGDRs2uO0Y/i1t96LGHGm7KUjpWNLxPGvWLLed4o+7ZGmf1GcdcMABMa83b97c7RvFUTjyg1Ho3HPPLTjmfDVr1nT77PPPP29RUp2hrmzty1rGww8/3G677bZC79M21brVulG9pGNJF5SJLobCY0kBU3WFxhz6wvr3f/7nf1zdpn3t0EMPLRiTuXDhQldnhOV57bXXYn4/UZ2gba6LA9VhPXr0cNtR3fT+RV1xNExg1KhRrktU+7L+rsa5xh+v+rvDhg2zJ5980r1Hf0fLq0AdUnea6mA5+OCDY/blRON+wuVR2a+//nq3LbSeFcx1ntS6V12tMK3HH/7wh0LlUlm1/6ne13pTmfZmjKsujLVvJDp/xGvVqpWr25KldaWylXYIin/e1rJqObV+p0yZUuZsoTpP76tXr56rH1VXFncRlFB5d6upmbZ58+aua0HdNX/+85+Dww8/3HXBvPvuu4W61Y488sigbdu2wX333ReMHTs2aNiwYdC4ceNg8+bN7n15eXnBfvvtF4waNarQ3+rYsWNw+umnFzxXs1+zZs3c76ubSF0cs2fPLviZ3ywYdokdffTRQffu3YP7778/GDNmjGsS7NGjR8H7Xn31VdclpO6NsMtj1qxZpfoMef31113T/vHHHx+MHz/evbdLly7utbfffrvY9f7QQw+5v/Pcc8+55dV/V69ePTj77LMLNe+Gzb7PP/+8e75jx47gkEMOcetKzb6irjC9Z/78+TG/u3PnTve6tldx1HSsbaJt7Nu9e7d7Xevim2++SWpfii9/uE7D7p6i1r/2D3Uv6r2//e1vC3728ccfx3z+scce69b1Lbfc4sqmfW3btm0Ff09N0bVr13ZNwOoW0z57/vnnu9/929/+FiRj9OjRQUZGhutSKSuVQ03ROn700PK99dZbwcknnxwceOCBrhszpONP21TLpH1c6+Gggw4q1P0Wrktte61DdSllZ2cH77//fkFX4K233lqw7sJjLuxy6dOnj9v3hg0b5vY3rcvSdhvoM/XZ2n4qQ/i3tF+GdYDfLfrSSy+5daljQ+W94447XJN+586dE3atJkPbVH/nN7/5TbBmzZrg008/da+pTnrggQfK9JnaL/WZ8d3Kou43dbvl5uYGUXjvvfeC+vXru/1G+6b2EXWjq64NhdtYddd5553n9nWtH72m98Yvj7bJxRdf7N6nelrbM/5YUv3aokUL1/V/0003uX1H+572nZkzZ7q6WfWj1nm4v6p+L65O0DZXfaRuau2rEydODLp16+bKs3r16mLXg7rnVF/qvVo2/a6GIehvjBgxIua9ek37mJZLx5POR/rbqjNWrVpVsF4vvfRS917VKf6+nKhrK1we7feqqydNmhT8+te/LljHJ510UvCrX/3KrdNzzjnHvf6Pf/wjplwtW7YMfv/737uy63jQeUXv03FSlm41vaeobsHidOrUqdhuNXWJ6pj93e9+557rvcl2q4X7TZMmTVxd89e//tWtG5VTw0dKmy3CY7N3795uneuhz73wwgtLtczlHo60kuLH9ugA0s6tk08orBi1833++ecFryso6PUbbrih4DXtkFp5OvmGVqxYUahi1UrWaxpTEK+ocHTEEUfElPfBBx90r4cHRDJjjkr6DB2k7du3D84666yY/vTvv/8+OPjgg4MzzjgjKE54IlNlp4PsqaeeciFI/cE6SSrUhLSOtGNpfW/dujUYOnSoG0vkb7Ply5e7z9OYJd+cOXPc6/rc4mg8hd6nyi/enXfe6X6mE33fvn2De+65x/29soajsow50glcB5oqO41hCKlC0ftVxvjKQhWiLwy8Jdm1a1dw2WWXuZCrZVagKYuwHPEPnUTi159Crn8siNajxiz5yxGuy3bt2rl9LZkxRwphWhaNPfP/hipnvf+xxx4r0/Jp+2k7xpc5fvvpBK4Tgsb6hBYsWODeV9ZwpDpJlaMq0XC96oStCrasFBwVQPxwEAovPkq66Kkop5xySlCvXr3gs88+i3ndr3vCcOTXyXLuuee6eiakIKl1pePYp7pN9Yr/elj/+oHxww8/dK8pLC5ZsqTg9blz5xba9kWFI722aNGimH1U+3qiC2afLoz1uwp3Po2zVGDyx4WF+4XGp4W0/nThpHWSzJijosJRfL2vC2T9/WuuuSZmH9V+Hx9A4o9b1W2q1/xGgUR/e1+Ho4kTJ7qwG17ElTYcqUxqNAjpfKpQqXo8vCBLNlsMHz7cHZt7O5ax3LvV1H0TjmlQd5O6ANSFc8wxx9iKFSsKvV9dGWruD6npVE2vL7/8csFranrUzCS/+UzNn2p+O//882M+T02nahpOlt7rj8FQM5188skn5fYZmk21bt06+9WvfmXffPON637SQ02+6oJTc6TWVXHToMMuFnVNqLlc3SqPPPKIffzxx242V0jNoGrO1e+oq0XdI5pJpfUf6tatm1vH9913n+u2VLOwuu3U3KtugR9++KHY5dUyiJqC440dO9aV5+ijj7a5c+e6pnw1b+pvxndBVBTNptQYl9///vcxY1o0k0gzybQO411zzTUxz7UNk9kH1BSudbdq1Sq3TjX2yJ89p2ZsNa3745GKorLOmzfPPbTuNFZG3Wb6zI8++ihmHw+bu9X1p+2h96k7INExNnjw4BK7j0Lq6lDztaba+03qGmej5ulE66686BjXetTx7nfXqotGzeJ7UycdcsghdtZZZ7mxQJqFo7FyGl+n7uHSUne+1tO4ceMKddX5x0UUYy6+/vprV59ceeWV1rp165ifaT9MZr/X/qSuSPnXv/7l6ibVOWG9pYfqIs1iiu/S0Hbzu+u1T2odaVasjo9Q+N/JHGPqYg3rVFH3lD63pN/VOUTbXl1aPnWzKQ/puPUdf/zxrq4Kaf0NGDDAHYvJdrEnohnF/rrXsuvv+zONVU7V0fHL5B+327Zts9zcXLcuEh3nydC5QX+7rF3UiWh/UXfXHXfc4bZNWWjYgM4/IZ1P9Vz1uLrbSpMttL/p3Kp6dG9UyIBsVUDjx48v1LepfsR4OsDiaWCwxgKFNMBX4wMUiBQmtGL++c9/uh1XfYo+Ba3SDDiNr0DCik07Ynl9hoJReJIqinb6RGHDP0BUQfknLI0b0aBqTS/VPWRCOhGE/ePqy9VOG++5556ziy++2FWi4Y6nqfwaF7B27dqklju+fzx06aWXuocqWI2z0gGpwKQTksaTVfQgXI1PElWg8RSONAbAp/LEH9TaFiXtAxqnpPE72dnZbp/ViVYn8jPPPNP++7//2/39cPycf2IoiraBP7hXFIx0jCjgapuJ9n/1nyv4aiyPX3EnGqyf6Lgr7brTMaWxHuHPK0L42RqnEk+vlfWEoBCj9aXjMAxdOpY03kpjqTSmxR/TVRwFK43f0olNtyUo7rhIFEZCCqCq3MtC2yIcWB4vPLkmO4C2uLpLYVjrTMuTqJ4WXUz5NO4yfrk1PkTjV+JfC/9OacsYlrOk39X+pPFy8ecIBbXw58mcizQGS6EzHP9XWvHlD5c90TqJX6aXXnrJ3TZCF1z5+fkFrxe3b+1rt99+u9sfdbFRVtpOGkMUv+5FF+8a5J1sttBFsfKDGgeUB1Qf63jXeN9Iw5EG7mlQmlqEdHLWIFxV+jqBqJWjLPT7anVRS4lOCBrErKvM+Jk9kuwVsv/ZpTnxl+Uzwlahv/zlL3bUUUclfK9/pZxox5GmTZsW+rs6GSaqJMLZYlpPSvbxB7Z2GoUEVX6bN292FYPeo78V7pRFCU/AJVVOqlwVbPVQJaodW2FJAaKog3tvrtDKqqwzZLQsKm944KoS1tWoBqQr5CggPfzww9a1a9cy3/NDJxsFFX9gqFouFHgVbDU7UBWTQrNaexK1QJb2mEg3qjNOP/30QseY7l2kCwJVvokCWTxdiapVSy2Q8YNFfeFxoUkARdEFjcJZWej48QfP741k6i4dq9qvE703fp0W9Xl7U8+WRx0dpdKsE3+ZVH9oH9XkIu3DaiBQParWfr+3IErr1q1zdZwGYetcEwonDenY0nmgqDBfEdlCrytMqsVP+60eWmc6dnUOiiwcabS6rjDVHOufADXtNZGwVcWnLoT4Zj8tmBKjpplrYXWlr2byfWFvU7packQ7SXzLQDLCpt74mVa6+lQTd3yrhypuVeSaQacdR82TRc2eUSgKr5h0Y0B1A5V0p1VdCemEq1aLZKnpUzumPt+/Qo2fAZWoZaKo9V/U65r5KGoB00nRp9fCn++t8O/7s3YUYHVQKiDpJPb555+7Y2FvqOk47FoNjzGdWOO76rQuizshJyp7cetOx7G/r2l7l2X/TVb4txPN9Ez0WmlunpoodIdXnlq/yQRhzVDTfqyr0uJamrSeFFaLu8hQYC5rs39RLcwSbrPyuku36i6dsHVlXtJFU2Wj/Undn9u3b49pPVKrQ/jzZM5FmnUX1rH7ssVGLcVq1VZ94s9+1Ym+sti0aZML0Oq6jO++FO03w4cPL3EGm4KVusL81qNwKEGYBUqTLdS6qp4KPVQ+tSZpmIIuKpO5EJIKGXMUn4BVsWj6eCLqivBP+u+88457v5rEfLqjrR5///vf3U6jfu1km8L3ljaYur3KSuFGlYymZfonuZCabEua6qg0rG5F/6686q5Spa+WGb9iVqrWWCzdxkB/84UXXihx6qt2II2fUUUQPw4hnq5edJKIv1O6mp+L2s5h/37YXRMGRr9FRMuiq5Bk1394IMUHLJVN60sh0W+KVhk07klX/uXhpJNOcpWWum386c9aNlUGGzdudE3lCkllpQpCQUUnU/8Yi79q1vT3+PBcnKLWncKPKhZ1F/p/Q0FM26C81l0iarVUC5v2Vf84UVevxiLF09ViMq3ROqkriIRj5cJ9TSFHJ81wXyzqM8N9RpW0ujlKaonTGAndBiHsPikq4Ghdl+Xhj4uJp5O4Whoee+wxt//tbUvLeeed5/Y3jSWM/30999dpZaMuaW1nfRNA/K1jdHKNP8eo7vK7bnXRo4tKdcuE57WijpuKoL+pcvrBXi0xZRknV5ap/MkIb7UR/9D+r4to/Xcy3+KgC5TwfmThxZiea38O9/dks0X8PqkLFWUH8c8HJSlTutCBl+irIJQQ1X+vZKerLFUoOlnrJKVBdYmCgVKcTjLqv1fBdVJRt41O1PHUehR+LUOiLrWKoo2jsQZqgte9ddSUXNJNEuM3jkKdDkbtNBrArW4tncw0oFEtSmoRK4pOwOqS05glVXwaZ6SKT+MoNDhPFVi406irRZX35MmT3WtqNVKY1LZRxRp20em5gpa6+XSgqJlWwVStO4n6+ONpvJcGW2tckcovCgi6T4W6mdS/qz51VSI6mNVErOZQDdQWrQe9T2NpNPZCza66N0Wiq/ii1r9Oahp8p/1LJzlVXBrbo6sVDTbXelYw0fgntR5ofekEd8MNN1h50IGrljmVSwOGte7VNanQqPWo5VNle8EFF7hgFj8+I56WXU3HYVhVRahl03/7V0c6xnSDQS2f1reCg4Kz39JTEm13VTZaTwo92sfUyqZQqW2ik6G2oZr1Fc7UrK917x936tpRC5bKpjFu5UFdhtq31PKm5VMXlU5uqoTj6w+NP5SSvgLllltuceXWvvHb3/7WHR8as6gQo/Ec/naJ/0y1OqiFWuXQRUf8gHTtgxrIG9KxpDCnK9WoKNiqTtUkCC2vjgctj8pe2q/a0fJpHWmf0GfoGNaxpnpdJz59fmm/KmdfUR2h/VP1lMquCwwNN1DgURe0H4pF+5i2tVpAdDxonxcdC6HwRK3P1AW69h39nfjxMuVB50/drFfHoYaVaHDypEmT3DlT95IqC21H1U3afiUNyl60aFHBxasu4NWyo31BdB7SQy3V2ifihS1FiX6WiM5Lqou0nXQxo/pe+6oulsPjM9lsofG3OqeoPtOwBPVGPPTQQ67OC8ebJaU0U9vCqYlFPXTrcE1ZvPfee93UQk231JRoTaHWFEJ/Kq7/9SGawqd7Y+j9uq+L7ieRyJdffummlR522GEJf17c9MGipvLHf/VHounFuo+F7kdxwAEHxEwpLs1niO7FoHuKaKqsllWfc9FFF7l7ICXjn//8Z9C1a1f3u5q+qOnJ/n1CwlsI6H5I8V89oqmNv/jFLwpeU9n0WZp+rmm/uidE/H2PivPVV1+5qby6z4c/rf2RRx4JBg4cWLD9dc8n7QPazvHTMHVPIk2JDpdH9zGZN29eoSnmRa1/0f2cdC8VlSV+neuWB/rb+nzdP2vQoEExt43w7y8UL5zqnAxNGdZ+q8/RrSmOOeYYN01cU0n1dROJpkwnM5Vf20zb5bXXXis0lV/TmHXPD/09fS3H4sWLk97HQ9pWmuavYyp+nWtqbocOHdz0d22ba6+9ttC09RdffLHIW2eUdSq/6J44+tvabpq2/MILL7h7T+m1+M9Mdnq/blOhdaP72OhWBbplQKJyx39mWMaiHvHTp1955RX3+rp164Io6R5AmoKuY0bT0XU/GN0zqqSvDynqFhuqU3SLEO3jemhb6DYha9euLbH+TbTtRX9Hn1Hc3y7qd+P39aLolhC6LYxuBaN9WbdUUV0U/xUlYVmeeOIJ957w3JXo63V0CxTdYkO3J/DLW9RU/vhb3xS17hPVRbrPT1gerXN9ZqK6qSKm8t/1v38n0UM/K05pp/LrvbqNgm5zoP1Vy6M6yJdstnj22WfdrUh0GwAd661bt3b3X1J+KI0M/Z+lCI2v0aC0cNogoqXmUnX7qFUIVY9ad9UCo/FAFf3VCbrqU0vd3k7PrWi6UlZXiFpVkDq0zTRzMb4LDhVPw0Z0bi+vcXLlpdzHHFWkcIzNvv5GbySm7hR911syX4GC9KMuYV2klGcwUrdUfNequu/01SjJfit4VDQ2SWOSNIMQQGpLiS+enT9/vptJpdlXujIrzxtYoew0NskfII6qRcG4vGkcnsbGaYyQxiFo8KjGFWgsV0kTBaKm8QzJzHwDUPmlRDjS4FPdF0SDNDWwCkB60iwuDXrVBAYNAtVAVw2+1IzARDe4BICKkFJjjgAAACpaSo05AgAAqGiEIwAAgFQbc1Qc3SBPtx7Xjckq05fxAQBQFQVB4G6gqkkV/pelp5KUD0cKRvHfbgwAAKKVk5Pj7lKdilI+HIVfKKiNEH6NBQAgvei7ItORvjIn3eTl5blGC/8Lf1NNyoejsCtNwYhwBADpqaLvwh6VdD5vZaTwUJfU7AwEAACoIIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAATw3/CQAASA9fbv/Spq+cbos2LrL3t7xv3/7wreXvzrc6NetYy/otrWPjjnZS65NsYIeB1jqrddTFrVQIRwAApJGfdv9kt71+mz349oO2a8+uQj/Pzc+13K9z7f2v37dn1jxjI+aMsF137LLq1apHUt7KiHAEAECa+PHnH+3sJ862hZ8tjHm9VvVadnSzo61p3ab2w64f7ONtH9sn2z5xPwv+93/4P4QjAADSxLCXhxUKRiOPG2l39LrDDqh9QKFut5mrZ9oDbz+wj0tZ+TEgGwCANLB6y2qbtnJazGt3nHKHjT9rfKFgJM3rNbcbjr/B1l+33mpUo63ERzgCACANqBVoT7Cn4Hnj/RvbrSffWuLv1axes4JLlnoqRTiaNGmStW3b1mrXrm09e/a0d955J+oiAQCQUt7KeSvmee92va12jdqRlSeVRd6O9tRTT9nIkSNtypQpLhg98MADdtZZZ9natWutSZMmURcPAICU8NXOr2Ket8lqU+g9LSe0tE3bNxV6fXDXwTZ94PQKLV8qibzlaMKECXb11VfbkCFDrGPHji4k7b///vbYY49FXTQAAFAFRRqOfvrpJ1u+fLn16dPn/wpUrZp7vnjx4oS/k5+fb3l5eTEPAACquqZ1msY835i7sdB7+rXvZ+cfcb4d0+KYfViy1BNpONq6davt3r3bmjaN3aB6vnnz5oS/k52dbVlZWQWPVq1a7aPSAgBQeZ3Q6oSY5/M3zLddu2NvAjm1/1R79qJnbeixQ/dx6VJL5N1qpTV69GjLzc0teOTk5ERdJAAAIndxp4stwzJixiDdv+T+SMuUqiINR40aNbLq1avbV1/FDiLT82bNmiX8nczMTKtfv37MAwCAqu7Ipkfa5V0vj3lt9Ouj7e6Fd7u7YiNFZqvVqlXLunfvbq+//roNHDjQvbZnzx73fNiwYVEWDQCAlDO532T76JuPbPHn/3/cru57dOeCO+2+N+9z44x0M8htP26zpZuWRl3USi3yqfyaxj948GA75phjrEePHm4q/86dO93sNQAAkLz9au5n8wfPt1FzR9nU5VNtd7Dbvb5z185CXysS0t2x2zdsv49LWrlFHo4uvvhi+/rrr+3OO+90g7CPOuoomzNnTqFB2gAAoGS68eOkfpPsphNvsmnvTnOhaO03a23bD9vcF8zWz6zv7oHUqUkn69Wml51z2DnWpA73FfRlBEGQ0l/Fq6n8mrWmwdmMPwKA9DRq1ChLR+PHj7d0k5cG5+WUm60GAABQkQhHAAAAHsIRAACAh3AEAADgIRwBAAB4CEcAAAAewhEAAICHcAQAAOAhHAEAAHgIRwAAAB7CEQAAgIdwBAAA4CEcAQAAeAhHAAAAHsIRAACAh3AEAADgIRwBAAB4CEcAAAAewhEAAICHcAQAAOCp4T8B9oVRo0ZZOho/fnzURQAAlANajgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAIDKFI4WLVpk/fv3txYtWlhGRobNnj076iIBAIAqLPJwtHPnTuvatatNmjQp6qIAAABYjagL0LdvX/cAAACoDCIPR6WVn5/vHqG8vLxIywMAANJL5N1qpZWdnW1ZWVkFj1atWkVdJAAAkEZSLhyNHj3acnNzCx45OTlRFwkAAKSRlOtWy8zMdA8AAICKkHItRwAAAGndcrRjxw5bv359wfMNGzbYypUrrWHDhta6detIywYAAKqeyMPRsmXL7LTTTit4PnLkSPfv4MGDbfr06RGWDAAAVEWRh6NTTz3VgiCIuhgAAAAOY44AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8NfwniLVjxw6bMmWKvfDCC7ZmzRrLzc21/fff3xo0aGBNmjSxTp062ZFHHmkXXHCBtW7dOuriAgCAckA4KsK6devsjDPOsM8++yzm9by8PPfQ60uXLnWvKShddtllEZUUAACUJ8JRAkEQ2CWXXBITjBo1amRdu3a1unXr2jfffONakr799ttIywkAAMof4SiBlStX2ooVKwqeDxgwwJ599lmrUaNGofc9/fTTLjgBAID0QDhK4KOPPop53qtXr0LBSI466ij3AAAA6YNwlECtWrVinmdnZ1vNmjXt7LPPtkMPPTSycgEAgDSfyq/Qceyxx1q9evXcoOaBAwfa2rVrLWrHHXdcTEvR119/bdddd521b9/ezVTr3bu3jRkzxlatWhVpOQEAQJqFo4ULF9rQoUNtyZIlNm/ePNu1a5edeeaZtnPnziiLZc2bN7dbb7014c++++47mz9/vo0dO9a6dOliv/zlL114AgAA6SHSbrU5c+bEPJ8+fbprQVq+fLmdcsopFiWFn7Zt27p/46fz+1588UU3YPvNN9+0jIyMfVpGAACQ5nfI1k0WpWHDhkW+Jz8/v+BeQ+GjogwZMsQ2bNhgixcvtnHjxrkQlKhs+rkeAAAg9VWacLRnzx4bMWKEnXjiida5c+dixyllZWUVPFq1alWh5VJrkMYg3XzzzTZ79mzXhaY7Zut+R74PPvigQssBAACqWDjS2KPVq1fbzJkzi33f6NGjXQtT+MjJySn3suhzv//++4Q/q1atmvXv39/dPdun2WwAACD1VYpwNGzYMHvppZfsjTfesJYtWxb73szMTKtfv37Mo7xpFpq+K02DshXY4m3cuNENIvfpe9YAAEDqqxH113RoivysWbNswYIFdvDBB1tloa8IUReeHroDtsKPuvH0lSFvv/22m1kXOvroo61bt26RlhcAAKRBOFJX2owZM+z555939zravHmze10hZL/99ousXPGzzrZu3epuO5CIWpjUFchMNQAA0kOk4Wjy5Mnu31NPPTXm9WnTptkVV1wRUanMDQrX96a9+uqrrpXoww8/tE2bNtmOHTvcmCPdCFItSeecc45dffXVhQZnAwCA1BV5t1pl1bVrV/cAAABVS6UYkA0AAFBZEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwFPDfwIAQGU0fvz4qIuAKoSWIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAKCyhKPJkydbly5drH79+u5x/PHH2yuvvBJlkQAAQBUXaThq2bKljRs3zpYvX27Lli2z008/3QYMGGDvv/9+lMUCAABVWI0o/3j//v1jnt9zzz2uNWnJkiXWqVOnyMoFAACqrkjDkW/37t32zDPP2M6dO133WlHy8/PdI5SXl7ePSggAAKqCyAdkr1q1yurWrWuZmZl2zTXX2KxZs6xjx45Fvj87O9uysrIKHq1atdqn5QUAAOkt8nB0+OGH28qVK+3tt9+2a6+91gYPHmxr1qwp8v2jR4+23NzcgkdOTs4+LS8AAEhvkXer1apVyw499FD33927d7elS5fagw8+aFOnTk34frUw6QEAAJCWLUfx9uzZEzOmCAAAoMq0HKmLrG/fvta6dWvbvn27zZgxwxYsWGBz586NslgAAKAKizQcbdmyxS6//HL78ssv3eBq3RBSweiMM86IslgAAKAKizQcPfroo1H+eQAAgMo/5ggAACBKhCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8NTwnwD7wvjx46MuAmCjRo2ydMTxBew9Wo4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAACAyhqOxo0bZxkZGTZixIioiwIAAKqoShOOli5dalOnTrUuXbpEXRQAAFCFVYpwtGPHDhs0aJA98sgj1qBBg6iLAwAAqrBKEY6GDh1q/fr1sz59+pT43vz8fMvLy4t5AAAAlJcaFrGZM2faihUrXLdaMrKzs23s2LEVXi4AAFA1RdpylJOTY8OHD7cnn3zSateundTvjB492nJzcwse+gwAAIC0aDlavny5bdmyxbp161bw2u7du23RokU2ceJE14VWvXr1mN/JzMx0DwAAgLQLR71797ZVq1bFvDZkyBDr0KGD3XzzzYWCEQAAQFqHo3r16lnnzp1jXqtTp44deOCBhV4HAACoMrPVAAAAKovIZ6vFW7BgQdRFAAAAVRgtRwAAAB7CEQAAgIdwBAAA4CEcAQAAeAhHAAAAHsIRAACAh3AEAADgIRwBAAB4CEcAAAAewhEAAICHcAQAAOAhHAEAAHgIRwAAAB7CEQAAgIdwBAAA4CEcAQAAeAhHAAAAHsIRAACAh3AEAADgIRwBAAB4avhPAKCqGD9+fNRFAFBJ0XIEAADgIRwBAAB4CEcAAAAewhEAAICHcAQAAOAhHAEAAHgIRwAAAB7CEQAAgIdwBAAA4CEcAQAAeAhHAAAAHsIRAACAh3AEAADgIRwBAAB4CEcAAAAewhEAAICHcAQAAOAhHAEAAHgIRwAAAB7CEQAAgIdwBAAA4CEcAQAAVJZwNGbMGMvIyIh5dOjQIcoiAQCAKq5G1AXo1KmTvfbaawXPa9SIvEgAAKAKizyJKAw1a9Ys6mIAAABUjjFH69atsxYtWli7du1s0KBBtnHjxmLfn5+fb3l5eTEPAACAtAhHPXv2tOnTp9ucOXNs8uTJtmHDBjv55JNt+/btRf5Odna2ZWVlFTxatWq1T8sMAADSW0YQBIFVEt999521adPGJkyYYFdddVWRLUd6hNRypICUm5tr9evX34elBQAA8XReVuNFKp+XIx9z5DvggAPssMMOs/Xr1xf5nszMTPcAAABIyzFHvh07dtjHH39szZs3j7ooAACgioo0HN144422cOFC+/TTT+2tt96yc88916pXr26XXnpplMUCAABVWKTdap9//rkLQt988401btzYTjrpJFuyZIn7bwAAgCoXjmbOnBnlnwcAAKjcY44AAACiRjgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAAP4QgAAMBDOAIAAPAQjgAAADw1LMUFQeD+zcvLi7ooAABUeXn/ez4Oz8+pKOXD0fbt292/rVq1irooAADAOz9nZWVZKsoIUjnamdmePXvsiy++sHr16llGRkaFp2GFsJycHKtfv76lC5YrtbBcqYXlSi0s195TrFAwatGihVWrlpqjd1K+5UgrvmXLlvv0b2rHSqeDJsRypRaWK7WwXKmF5do7qdpiFErNSAcAAFBBCEcAAAAewlEpZGZm2l133eX+TScsV2phuVILy5VaWC6kxYBsAACA8kTLEQAAgIdwBAAA4CEcAQAAeAhHAAAAHsJRkiZNmmRt27a12rVrW8+ePe2dd96xVLdo0SLr37+/u4up7i4+e/ZsS3XZ2dl27LHHujumN2nSxAYOHGhr1661VDd58mTr0qVLwQ3cjj/+eHvllVcs3YwbN87tiyNGjLBUNmbMGLcc/qNDhw6WDjZt2mSXXXaZHXjggbbffvvZkUceacuWLbNUpro9fnvpMXToUEtlu3fvtjvuuMMOPvhgt60OOeQQu/vuu1P6O8/2FcJREp566ikbOXKkmwa5YsUK69q1q5111lm2ZcsWS2U7d+50y6Lgly4WLlzoKrQlS5bYvHnzbNeuXXbmmWe6ZU1lugu8gsPy5cvdiej000+3AQMG2Pvvv2/pYunSpTZ16lQXAtNBp06d7Msvvyx4/Pvf/7ZUt23bNjvxxBOtZs2aLpyvWbPGxo8fbw0aNLBU3/f8baW6Qy688EJLZffdd5+7sJo4caJ98MEH7vmf//xne+ihh6IuWuWnqfwoXo8ePYKhQ4cWPN+9e3fQokWLIDs7O0gX2hVmzZoVpJstW7a4ZVu4cGGQbho0aBD8/e9/D9LB9u3bg/bt2wfz5s0LevXqFQwfPjxIZXfddVfQtWvXIN3cfPPNwUknnRSkO+1/hxxySLBnz54glfXr1y+48sorY14777zzgkGDBkVWplRBy1EJfvrpJ3e13qdPn5jvc9PzxYsXR1o2lCw3N9f927BhQ0sXaiqfOXOmaw1T91o6UGtfv379Yo6zVLdu3TrXZd2uXTsbNGiQbdy40VLdCy+8YMccc4xrUVG39dFHH22PPPKIpVud/8QTT9iVV15Z4V9mXtFOOOEEe/311+2jjz5yz9977z3Xgtm3b9+oi1bppfwXz1a0rVu3upNR06ZNY17X8w8//DCycqFke/bscWNX1A3QuXNnS3WrVq1yYejHH3+0unXr2qxZs6xjx46W6hT01F2tro10oXGJ06dPt8MPP9x104wdO9ZOPvlkW716tRsPl6o++eQT102jYQa33nqr22bXX3+91apVywYPHmzpQGMvv/vuO7viiiss1d1yyy2Wl5fnxrtVr17dncvuueceF9ZRPMIR0pZaI3QySoexHqIT7cqVK11r2LPPPutORhpjlcoBKScnx4YPH+7GeGiyQ7rwr8w1hkphqU2bNvb000/bVVddZal8waGWo3vvvdc9V8uRjrEpU6akTTh69NFH3fZTq1+q0/725JNP2owZM9wYONUfumDUsqXL9qoohKMSNGrUyCXur776KuZ1PW/WrFlk5ULxhg0bZi+99JKbkafBzOlAV+eHHnqo++/u3bu7q/YHH3zQDWJOVeqy1sSGbt26Fbymq1ttNw0izc/Pd8dfqjvggAPssMMOs/Xr11sqa968eaEwfsQRR9hzzz1n6eCzzz6z1157zf71r39ZOrjppptc69Ell1zinmtmoZZRs3oJR8VjzFESJySdiNRv61896Xm6jPdIJxpbrmCkLqf58+e7KazpSvuhwkMq6927t+su1BVt+FDLhJr99d/pEIxkx44d9vHHH7twkcrURR1/awyNZ1GrWDqYNm2aG0ul8W/p4Pvvv3djZH06plR3oHi0HCVB/etK2aq0e/ToYQ888IAbDDtkyBBL9Qrbv5LdsGGDOyFp8HLr1q0tVbvS1IT8/PPPu7Edmzdvdq9nZWW5+3ykqtGjR7umfm2X7du3u2VcsGCBzZ0711KZtlH8eLA6deq4e+ik8jixG2+80d1DTKHhiy++cLcB0Unp0ksvtVR2ww03uEG+6la76KKL3P3eHn74YfdIdQoMCkeq62vUSI9To/ZBjTFSvaFutXfffdcmTJjgBpujBFFPl0sVDz30UNC6deugVq1abmr/kiVLglT3xhtvuGnu8Y/BgwcHqSrR8ugxbdq0IJVpOm6bNm3c/te4ceOgd+/ewauvvhqko3SYyn/xxRcHzZs3d9vroIMOcs/Xr18fpIMXX3wx6Ny5c5CZmRl06NAhePjhh4N0MHfuXFdXrF27NkgXeXl57ljSuat27dpBu3btgttuuy3Iz8+PumiVXob+r6QABQAAUFUw5ggAAMBDOAIAAPAQjgAAADyEIwAAAA/hCAAAwEM4AgAA8BCOAAAAPIQjAAAAD+EIAADAQzgCAADwEI4AAAA8hCMAAAD7P/8PwQn65JdXejUAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "54 etats x 4 actions = 216 paires (s, a)\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Maze:\n",
+    "    \"\"\"Labyrinthe 6x9 de Sutton & Barto (fig. 8.2).\n",
+    "\n",
+    "    Recompense : -1 par pas, 0 en atteignant le but (episode termine).\n",
+    "    Le chemin optimal fait 14 pas, soit un retour de -13.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self.height, self.width = 6, 9\n",
+    "        self.start = (2, 0)\n",
+    "        self.goal = (0, 8)\n",
+    "        self.obstacles = {(1, 2), (2, 2), (3, 2), (4, 5), (0, 7), (1, 7), (2, 7)}\n",
+    "        self.n_states = self.height * self.width\n",
+    "        self.n_actions = 4\n",
+    "\n",
+    "    def idx(self, s):\n",
+    "        return s[0] * self.width + s[1]\n",
+    "\n",
+    "    def reset(self):\n",
+    "        return self.start\n",
+    "\n",
+    "    def step(self, s, a):\n",
+    "        dr, dc = ACTIONS[a]\n",
+    "        r2, c2 = s[0] + dr, s[1] + dc\n",
+    "        if not (0 <= r2 < self.height and 0 <= c2 < self.width) or (r2, c2) in self.obstacles:\n",
+    "            r2, c2 = s          # mur ou bord : on reste sur place\n",
+    "        s2 = (r2, c2)\n",
+    "        if s2 == self.goal:\n",
+    "            return s2, 0.0, True\n",
+    "        return s2, -1.0, False\n",
+    "\n",
+    "\n",
+    "env = Maze()\n",
+    "\n",
+    "grid = np.zeros((env.height, env.width))\n",
+    "for (r, c) in env.obstacles:\n",
+    "    grid[r, c] = 1.0\n",
+    "fig, ax = plt.subplots(figsize=(6, 4))\n",
+    "ax.imshow(grid, cmap=\"Greys\", vmin=0, vmax=1.6)\n",
+    "ax.text(env.start[1], env.start[0], \"S\", ha=\"center\", va=\"center\", fontsize=16, fontweight=\"bold\")\n",
+    "ax.text(env.goal[1], env.goal[0], \"G\", ha=\"center\", va=\"center\", fontsize=16, fontweight=\"bold\", color=\"green\")\n",
+    "ax.set_xticks(range(env.width)); ax.set_yticks(range(env.height))\n",
+    "ax.set_title(\"Labyrinthe 6x9 (Sutton & Barto, fig. 8.2) — chemin optimal : 14 pas\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"{env.n_states} etats x {env.n_actions} actions = {env.n_states * env.n_actions} paires (s, a)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba9f743f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 2. Fabriquer les datasets : trois politiques de comportement\n",
+    "\n",
+    "En RL offline, le dataset est une donnee du probleme — mais pour etudier le phenomene en laboratoire, nous le fabriquons nous-memes. Nous entrainons d'abord **online** (Q-learning classique du notebook 5) deux politiques de qualites differentes, puis nous enregistrons leurs trajectoires comme de simples logs :\n",
+    "\n",
+    "| Dataset | Politique de comportement | Analogue reel |\n",
+    "|---------|---------------------------|---------------|\n",
+    "| **expert** | Q-learning converge (300 episodes), $\\epsilon = 0.1$ | demonstrations d'un operateur competent |\n",
+    "| **medium** | Q-learning interrompu (20 episodes), $\\epsilon = 0.3$ | logs d'un ancien controleur mediocre |\n",
+    "| **random** | actions uniformes ($\\epsilon = 1$) | exploration aveugle, donnees de capteurs bruts |\n",
+    "\n",
+    "Pour chaque dataset nous mesurons deux choses : la **couverture** (fraction des paires $(s, a)$ presentes au moins une fois) et le **retour moyen** de la politique de comportement. Ces deux axes — qualite et couverture — sont orthogonaux, et chaque methode offline echoue sur un axe different."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a1c8e10e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Politique experte  (greedy, 300 ep online) : retour moyen -13.0  (optimal = -13)\n",
+      "Politique mediocre (greedy, 20 ep online)  : retour moyen -200.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "def epsilon_greedy(Q, s_idx, n_actions, eps, rng):\n",
+    "    if rng.random() < eps:\n",
+    "        return rng.integers(n_actions)\n",
+    "    q = Q[s_idx]\n",
+    "    return rng.choice(np.flatnonzero(q == q.max()))\n",
+    "\n",
+    "\n",
+    "def q_learning_online(env, n_episodes, seed=0):\n",
+    "    \"\"\"Q-learning online classique (notebook 5) — sert uniquement a fabriquer pi_beta.\"\"\"\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    Q = np.zeros((env.n_states, env.n_actions))\n",
+    "    for _ in range(n_episodes):\n",
+    "        s = env.reset()\n",
+    "        for _ in range(MAX_STEPS):\n",
+    "            si = env.idx(s)\n",
+    "            a = epsilon_greedy(Q, si, env.n_actions, EPSILON, rng)\n",
+    "            s2, r, done = env.step(s, a)\n",
+    "            target = r if done else r + GAMMA * Q[env.idx(s2)].max()\n",
+    "            Q[si, a] += ALPHA * (target - Q[si, a])\n",
+    "            if done:\n",
+    "                break\n",
+    "            s = s2\n",
+    "    return Q\n",
+    "\n",
+    "\n",
+    "def evaluate_policy(env, policy, n_episodes=20, seed=123):\n",
+    "    \"\"\"Deroule la politique deterministe policy[s] (action -1 = etat inconnu -> action aleatoire).\"\"\"\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    returns, successes = [], 0\n",
+    "    for _ in range(n_episodes):\n",
+    "        s, ret = env.reset(), 0.0\n",
+    "        for _ in range(MAX_STEPS):\n",
+    "            a = policy[env.idx(s)]\n",
+    "            if a < 0:\n",
+    "                a = rng.integers(env.n_actions)\n",
+    "            s, r, done = env.step(s, a)\n",
+    "            ret += r\n",
+    "            if done:\n",
+    "                successes += 1\n",
+    "                break\n",
+    "        returns.append(ret)\n",
+    "    return np.mean(returns), successes / n_episodes\n",
+    "\n",
+    "\n",
+    "Q_expert = q_learning_online(env, 300, seed=SEED)\n",
+    "Q_medium = q_learning_online(env, 20, seed=SEED)\n",
+    "\n",
+    "ret_expert, _ = evaluate_policy(env, Q_expert.argmax(axis=1))\n",
+    "ret_medium, _ = evaluate_policy(env, Q_medium.argmax(axis=1))\n",
+    "print(f\"Politique experte  (greedy, 300 ep online) : retour moyen {ret_expert:.1f}  (optimal = -13)\")\n",
+    "print(f\"Politique mediocre (greedy, 20 ep online)  : retour moyen {ret_medium:.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "82db8289",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dataset  transitions  couverture  retour comportement\n",
+      "expert           787        31%                -14.7\n",
+      "medium          7922        81%               -158.0\n",
+      "random          9735        85%               -194.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "def collect_dataset(env, Q_behavior, eps, n_episodes, seed=0):\n",
+    "    \"\"\"Enregistre les transitions (s, a, r, s', done) de la politique epsilon-greedy(Q_behavior).\"\"\"\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    data, ep_returns = [], []\n",
+    "    for _ in range(n_episodes):\n",
+    "        s, ret = env.reset(), 0.0\n",
+    "        for _ in range(MAX_STEPS):\n",
+    "            si = env.idx(s)\n",
+    "            a = epsilon_greedy(Q_behavior, si, env.n_actions, eps, rng)\n",
+    "            s2, r, done = env.step(s, a)\n",
+    "            data.append((si, a, r, env.idx(s2), done))\n",
+    "            ret += r\n",
+    "            if done:\n",
+    "                break\n",
+    "            s = s2\n",
+    "        ep_returns.append(ret)\n",
+    "    return data, np.mean(ep_returns)\n",
+    "\n",
+    "\n",
+    "def coverage(env, data):\n",
+    "    pairs = {(s, a) for s, a, *_ in data}\n",
+    "    return len(pairs) / (env.n_states * env.n_actions)\n",
+    "\n",
+    "\n",
+    "datasets, behavior_returns = {}, {}\n",
+    "for name, (Qb, eps, seed) in {\n",
+    "    \"expert\": (Q_expert, 0.1, 1),\n",
+    "    \"medium\": (Q_medium, 0.3, 2),\n",
+    "    \"random\": (Q_expert, 1.0, 3),    # eps=1 : Q ignore, actions uniformes\n",
+    "}.items():\n",
+    "    datasets[name], behavior_returns[name] = collect_dataset(env, Qb, eps, n_episodes=50, seed=seed)\n",
+    "\n",
+    "print(f\"{'dataset':<8} {'transitions':>11} {'couverture':>11} {'retour comportement':>20}\")\n",
+    "for name, d in datasets.items():\n",
+    "    print(f\"{name:<8} {len(d):>11} {coverage(env, d):>10.0%} {behavior_returns[name]:>20.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f781a6cf",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** Les deux axes sont bien decorreles :\n",
+    "\n",
+    "- Le dataset **expert** a un excellent retour mais une **couverture faible** (~30 %) : les trajectoires se concentrent sur le chemin optimal, l'immense majorite des paires $(s, a)$ n'est jamais observee.\n",
+    "- Le dataset **random** couvre ~85 % des paires, mais sa politique de comportement est catastrophique (la plupart des episodes n'atteignent jamais le but en 200 pas).\n",
+    "- Le dataset **medium** est mediocre sur les deux plans : couverture large mais trouee, comportement peu fiable.\n",
+    "\n",
+    "C'est exactement la situation reelle du RL offline : *les bonnes donnees couvrent peu, les donnees couvrantes sont mauvaises*. Voyons comment chaque methode encaisse ce dilemme."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8ac2b31",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 3. Behavior Cloning : imiter le dataset\n",
+    "\n",
+    "La methode la plus simple ignore completement les recompenses : dans chaque etat, jouer l'**action majoritaire** du dataset. C'est la version tabulaire du *Behavior Cloning* — en deep, on entrainerait un classifieur $s \\mapsto a$ par maximum de vraisemblance sur les paires $(s_i, a_i)$.\n",
+    "\n",
+    "$$\\pi_{BC}(s) = \\arg\\max_a \\; \\#\\{i : s_i = s,\\; a_i = a\\}$$\n",
+    "\n",
+    "Dans un etat jamais visite par le dataset, la politique n'a aucune information : nous tirons une action au hasard (c'est le *distribution shift* de l'imitation learning — des qu'on quitte les etats du dataset, on improvise)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "dbf50316",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dataset   retour BC   succes   (comportement)\n",
+      "expert        -13.0    100%            -14.7\n",
+      "medium       -200.0      0%           -158.0\n",
+      "random       -200.0      0%           -194.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "def bc_policy(env, data):\n",
+    "    \"\"\"Action majoritaire du dataset dans chaque etat (-1 si etat jamais visite).\"\"\"\n",
+    "    counts = np.zeros((env.n_states, env.n_actions))\n",
+    "    for s, a, *_ in data:\n",
+    "        counts[s, a] += 1\n",
+    "    policy = np.full(env.n_states, -1)\n",
+    "    visited = counts.sum(axis=1) > 0\n",
+    "    policy[visited] = counts[visited].argmax(axis=1)\n",
+    "    return policy\n",
+    "\n",
+    "\n",
+    "results_bc = {}\n",
+    "print(f\"{'dataset':<8} {'retour BC':>10} {'succes':>8} {'(comportement)':>16}\")\n",
+    "for name, d in datasets.items():\n",
+    "    ret, sr = evaluate_policy(env, bc_policy(env, d))\n",
+    "    results_bc[name] = ret\n",
+    "    print(f\"{name:<8} {ret:>10.1f} {sr:>7.0%} {behavior_returns[name]:>16.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87562bb8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Le plafond de verre de l'imitation.** Sur les donnees expertes, BC est imbattable : l'action majoritaire dans chaque etat du chemin est l'action experte (le bruit $\\epsilon$ est minoritaire), et le clone atteint le retour optimal. Mais sur **medium** et **random**, BC reproduit fidelement... une politique qui ne marche pas. L'imitation **filtre le bruit, pas la mediocrite** : elle ne peut pas depasser $\\pi_\\beta$, car elle n'utilise jamais les recompenses.\n",
+    "\n",
+    "En pratique, BC reste un *baseline* redoutable quand les demonstrations sont bonnes (c'est le coeur du *fine-tuning supervise* des LLM). Ses limites — accumulation d'erreurs des qu'on sort de la distribution — sont l'objet de DAgger (Ross et al., 2011), qui re-sollicite l'expert sur les etats visites par le clone... ce qui exige une interaction, donc n'est plus offline.\n",
+    "\n",
+    "Pour faire mieux que $\\pi_\\beta$, il faut exploiter les recompenses. Le candidat naturel est le Q-learning."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fab36682",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 4. Q-learning offline naif : l'erreur d'extrapolation\n",
+    "\n",
+    "Le Q-learning est *off-policy* : sa cible $r + \\gamma \\max_{a'} Q(s', a')$ ne depend pas de la politique qui a produit la transition. Il est donc tentant de le faire tourner directement sur le dataset, en rejouant les transitions en boucle (comme un replay buffer fige, sans jamais y ajouter de nouvelles experiences) :\n",
+    "\n",
+    "$$Q(s, a) \\leftarrow Q(s, a) + \\alpha\\,\\big[r + \\gamma \\max_{a'} Q(s', a') - Q(s, a)\\big] \\qquad (s, a, r, s') \\sim \\mathcal{D}$$\n",
+    "\n",
+    "Le piege est dans le $\\max_{a'}$ : il porte sur **toutes** les actions, y compris celles **jamais observees en $s'$**. Pour ces actions fantomes, $Q(s', a')$ garde sa valeur d'initialisation $0$ — qui, avec notre recompense de $-1$ par pas, est **optimiste** (la vraie valeur est negative partout sauf au but). Le bootstrap recopie alors cet optimisme : chaque cible vaut $-1 + \\gamma \\cdot 0 \\approx -1$, toutes les valeurs s'ecrasent vers $-1$, et la politique greedy prefere systematiquement les actions inconnues aux actions documentees. En ligne, l'agent essaierait ces actions, serait decu, et corrigerait. **Offline, rien ne vient jamais corriger l'illusion.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "164ab91c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dataset   retour Q naif   succes     (BC)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "expert           -200.0      0%    -13.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "medium           -200.0      0%   -200.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "random            -13.0    100%   -200.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "def offline_q(env, data, n_passes=300, constrain=False, seed=0, alpha=0.1):\n",
+    "    \"\"\"Q-learning sur dataset fige.\n",
+    "\n",
+    "    constrain=False : cible max sur TOUTES les actions (naif).\n",
+    "    constrain=True  : cible max restreinte aux actions observees en s' (BCQ-lite),\n",
+    "                      et politique greedy restreinte aux actions observees en s.\n",
+    "    \"\"\"\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    Q = np.zeros((env.n_states, env.n_actions))\n",
+    "    seen = [set() for _ in range(env.n_states)]\n",
+    "    for s, a, *_ in data:\n",
+    "        seen[s].add(a)\n",
+    "\n",
+    "    for _ in range(n_passes):\n",
+    "        for i in rng.permutation(len(data)):\n",
+    "            s, a, r, s2, done = data[i]\n",
+    "            if done:\n",
+    "                target = r\n",
+    "            elif constrain:\n",
+    "                acts = list(seen[s2])\n",
+    "                target = r + GAMMA * (max(Q[s2, aa] for aa in acts) if acts else 0.0)\n",
+    "            else:\n",
+    "                target = r + GAMMA * Q[s2].max()\n",
+    "            Q[s, a] += alpha * (target - Q[s, a])\n",
+    "\n",
+    "    policy = np.full(env.n_states, -1)\n",
+    "    for s in range(env.n_states):\n",
+    "        if seen[s]:\n",
+    "            if constrain:\n",
+    "                acts = list(seen[s])\n",
+    "                policy[s] = acts[int(np.argmax([Q[s, aa] for aa in acts]))]\n",
+    "            else:\n",
+    "                policy[s] = Q[s].argmax()\n",
+    "    return Q, policy\n",
+    "\n",
+    "\n",
+    "results_naive = {}\n",
+    "print(f\"{'dataset':<8} {'retour Q naif':>14} {'succes':>8} {'(BC)':>8}\")\n",
+    "for name, d in datasets.items():\n",
+    "    _, pol = offline_q(env, d, constrain=False)\n",
+    "    ret, sr = evaluate_policy(env, pol)\n",
+    "    results_naive[name] = ret\n",
+    "    print(f\"{name:<8} {ret:>14.1f} {sr:>7.0%} {results_bc[name]:>8.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "456cab8c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Un echec spectaculaire — et un succes revelateur.** Sur les donnees **expertes**, le Q-learning naif s'effondre (retour $-200$, 0 % de succes) alors que le simple BC etait optimal : utiliser les recompenses a *degrade* le resultat ! Sur **random**, en revanche, le naif retrouve la politique optimale. L'explication tient en un mot : **couverture**. Avec ~85 % des paires $(s, a)$ observees, presque aucune action fantome ne subsiste, et le Q-learning offline redevient du Q-learning ordinaire. L'erreur d'extrapolation n'est pas une fatalite du offline : c'est une maladie des **trous du dataset**, que le $\\max$ s'empresse d'exploiter.\n",
+    "\n",
+    "Mesurons l'ampleur du phenomene sur le dataset expert."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5622ad6c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etats visites par le dataset expert : 35\n",
+      "... dont la politique greedy naive choisit une action JAMAIS observee : 33 (94%)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAFUCAYAAADS/LOVAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAANrRJREFUeJzt3Qu8VPP+//FP6R67pFJRulERRSkl16JESg6nI11IcUhRONVJIYlEyCUdxyXK5egXCZFCpJKESoWKkIR01339H+/v/7HmMTPN7P3du31pptfz8Zh2s2bNrO+s9V3f9Vnf2xQKgiAwAAAAZKlw1qsAAABACJwAAAA8ETgBAAB4InACAADwROAEAADgicAJAADAE4ETAACAJwInAAAATwROAAAAngic0lzbtm2tZ8+edqAYMGCANW3atKCTYYUKFbLevXtnud6zzz7r1v3+++/zJV0HOu2LO+64ww5USpvS+Pvvvxd0UoAYKkOUN1WmFITnn3/e6tata0WLFrWyZcsWSBrSBYHTfggvqskec+fOdett27bNFegffPBBjrf1ySefuM/YsGGD93tmz55t7777rv3rX/+KLFuzZo1deeWVVqdOHTvssMPcCdSkSRN77rnnLLd+fWfFihVWokQJtw8+++yzmNduuukm+/LLL23KlCm5si3kvrfeeuuADo6AA9nEiRPtoYcesgPJsmXLrHv37larVi37z3/+Y+PGjcuT7axZs8aVHV988YWlsyIFnYB0cNddd1mNGjX2WV67du1I4HTnnXe6/5999tk5Dpz0Gcr8vncL999/v7Vs2TKSDtGd+E8//WR/+9vfrFq1arZr1y6bPn26+9zly5fbPffcY/vr5ptvtiJFitiOHTv2ea1SpUrWvn17GzVqlF188cX7vS3kTeD02GOPJQye/vrrL3dsASQPnBYvXuxuEqMdc8wx7vxRjU9+00373r177eGHH465HuRF4HTnnXda9erVrWHDhpauKAFzwQUXXGCNGze2A8m6devszTfftLFjx8YsP+mkk/ap+VKTVbt27eyRRx6xYcOG2SGHHJLj7b7zzjvucdttt9ndd9+dcJ3LL7/cLrvsMlu5cqXVrFkzx9tC/lNNIrKmi9TOnTtTdn/t3r3bfYdixYoVdFLShmrgCyo/6HogNNHlDprq8qFdu0KFCu7/isTDZrzwbv6rr75ytT0KIHRSqUbm6quvtj/++CPyGVr31ltvdf9XzVb4GZn1u1HQpMKvVatWXunUHYJqxlTY55Rqr/r27eseqhJOJkzT66+/bgVtwoQJrtlS+75Ro0Y2a9Ysr/e9/fbbdsYZZ1jp0qVdk+eFF15oS5YsiVlHtYuJahh1vLW/s7Jx40ZXxa6/WdG+VBqqVKlixYsXd/tfQfCePXv2WXfevHmu79vhhx/u0q9gWneiYdpU2yTRzc6Z9XFauHChu3nIyMiwQw891NVyhs3U8c3aaj7u16+fOye07UsuucR+++038zFz5szIPtcFQDWXS5cuTbiualYVoCtNRxxxhMuT27dvj1lHNa0tWrRwn6V0Kx8MGjQoZh3Vmg4dOtTdpWu/Vq1a1d0UxNemhn3mlJ9OOOEEt+4bb7xh5cqVs6uuumqf9G3atMnluVtuuSXb25IXXnjB5deSJUu6bXTq1Ml+/PFH25++N6oFVhOT8o62//XXX3vv92R5OuxzFk21Ln369LHy5cu7c0c1zz///HPCvKXlKg+PPPJIlybt26efftrreykP6PxRuZaVZ555xs4991yrWLGi287xxx9vTzzxRNJz/6yzznJpV/469dRTXS2T6HxX2fvDDz9Ezp1wvyTr4+Szf8P9+N1330VaHcqUKePyVlbfT9tXvhKdd9H72bfc0PeqX7++yxPnnHOOlSpVyo466igbOXJkZB3dkGtfiNIVfv/o7/u///0vkm91/NVtRMc4mr6fzsfVq1fbRRdd5P6vbYXl0qJFi9yx0v5SLV6476OpS4tq/HQO6XvpnLrvvvvczUCuCJBjzzzzjDoFBe+9917w22+/xTx+//13t86WLVuCJ554wq13ySWXBM8//7x7fPnll+71UaNGBWeccUZw1113BePGjQv69u0blCxZMmjSpEmwd+9et47W/cc//uE+Y/To0ZHP0Gcnc8011wRHHHFE0te3bdvm0rlq1arg2WefDUqXLh00b958v/bHyJEjg4oVKwYbN26M7Jv58+cnXLd27drBpZdeGhQUpa1+/fpB+fLl3b6/7777gmOOOcbt+0WLFkXWC7+H9lNo/PjxQaFChYI2bdoEY8aMce+tXr16ULZs2Zj1zjrrLPeI161bN7etrITb1t+sdOjQIbj88suD+++/3+W3yy67zL33lltuiVnv3XffDYoVK+a2P3ToULdunz59glatWrnXP/nkk+C8885z7w3zmR7R+03vCy1evNjlncqVKwfDhg0L7r333qBGjRpB8eLFg7lz5+7zXU4++eTg3HPPdfutf//+wSGHHOLSnZXp06cHRYoUCY477jiXz+6880537A4//PCYfa60aTsnnnhi0K5du+DRRx8NrrzySresS5cuMenWfmjcuHHw8MMPB2PHjnX76swzz4yss2fPnuD8888PSpUqFdx0003Bk08+GfTu3dulo3379jHp0+fXq1cvqFChgkvbY489FixcuDC4+uqrXb7YsWNHzPrPPfdczPmRnW3dfffdLv/9/e9/Dx5//PHIvlAe/PPPP4Ps0v5TWo4//vigZs2a7hiqnPnhhx+893uyPB0ej2g63uHx0H7S8wYNGuyTt9auXRscffTRQdWqVd05qrx68cUXR8rBrITbfv/997Nc99RTTw26d+/uPld5U8dC71X+iaZ8rH2vsmP48OEu/Sprw7yl86thw4ZuH4XnzuTJk2P2c/T5nN18rfOnY8eO7rhru1p22223ZfrdtH1de7Su9mH09ce33FA5VqVKFXcs+vbt67av81jrvvXWW5HjpeOkZb169Yp8/xUrVkT2nV7TvtZ+HjBggCtv4/Ot8lKJEiVcfrzuuuvcPta1Kdx3Ssett97qjtMJJ5zgypCVK1dG3r9169bgpJNOcte/QYMGuXO7a9eu7rgp7bmBwGk/hBkh0UMXjpAClPhCITqAiffiiy+69WfNmhVZpowdfwHPTIsWLYJGjRolfX3EiBEx6W3ZsmWwevXqIKd++eWX4LDDDnMFvmQVOKlg0oWmoITf+7PPPoss04VCJ6wKmWSB0+bNm92FsGfPnjGfp0KjTJkyMcvzM3BKlI+uvfZadyHevn27e757924X1Gjb8RfYMEiXG264YZ+LXSg+H6vgVQASFo6yZs0alxeig5DwuyhAi97WzTff7Aq+DRs2ZPr9dDFSUP7HH39ElqnwL1y4sCsU4y8wusBGu/76693y8IKhglvPdW4mo0Jfn//RRx/FLFdBrPfOnj07Zr9o3SVLlsSs+84777jX3njjjZjlbdu2dUFKdrf1/fffu/2li3Y0Bfu6AMcv9xFe0DMyMoJ169blaL/7Bk4LFixwzxUcRlPQEp+3evTo4QLy8CY01KlTJ3euJcrzOQ2cEn1W69atY46R8qjyddOmTYO//vorZt3oPH3hhRcm3BeJAqfs5msF4tFUVmV2gxz//vj87lNuiMoxvV83jSHdDFSqVCnmBljlfaIya+fOne57KuCM3ndTp0516w8ZMiQmL2nZPffcE1mm8kpBloKfl156KbJ82bJl++Qb3cDpZu6bb76JSYMCNZ07+3OdC9FUlwtUhahq/+iHqnN9qMoypKYEVS+fdtpp7vnnn3+e4zSpqU9NMcn84x//cOlUNecVV1wRqULPKY3cU3PjNddc47W+0lbQQ8abNWvmqo1D6iyvanL10UrUxCXaZ6oG1v5T+sOH+oVpmoX3338/19KnKmtdk/U3O/lo8+bNLk2q/lc1vporwia1VatWuSrs+L4O8c0pPrSPNGqzQ4cOMX3VKleu7PLUxx9/7JqkovXq1StmW0qjPkdNG8n88ssvbpSO9oOapUJqYjzvvPNcZ/Z4N9xwQ8zzG2+80f0N1w2/v5oqklXfq1mhXr16bgh39LFWM4HEH2s136iJJ5rWVZPEyy+/HFn2559/unz097//Pdvb+r//+z+XXjVDRq+nJv5jjz12v/LfpZdeGulWkNP9npVp06a5v9dff33C4xNSvp80aZLre6n/R3/X1q1bu+brrMpHNUfpvT4DcqLPH322tqPjqX6YYVO5jpnOLU2pEt9XKSfnT07273XXXRfzXOePyvr488yXT7kRUpOZmtZC6v+mEdnaR1nR6Gr1s9Jxj953aiZUnlfzZrzoa4nOVzWlq3lOeT+kZXotOg06l/QdwmtM+FAXEZU1vt0xMkPn8FygzJPTzuHr1693fZ9eeumlSAe+kE/flsxkNr2A2ob1EAUBuqApY2lkXfTJ5EP9WTRHyIwZM6xw4cLeacuqsNH3z2kwp/b/rL6HLjTxjjvuOFdoqN+NLkbxvv32W/c3vKDFU5+HgqD+VYMHD3b9JeIL0TAfaZoIUV+F3KB9pH2lwiueggBd4NXvRv1SooPTaGFwr2AimTCoSrYdBbpbt251hWqyY6u+G8qbYb9ABS1PPfWUK5x1IVS/rI4dO7rRpmEe1rFWX5PoYCJa/PmaaGStRiAqINENivoqqb+Fgh/1B4wOnHy3pfV07iTKu7I/I7bi05+T/Z4Vfab2b/y24kd6KW/pBkXD5pMNnY/f//tDfe/UD2jOnDn79BnS+aPyJLfPn5zs38zOn5yUPT7lRujoo4/ep8w+/PDDXT/d/fmuCpx0kxVNwVX8uaBjkCgNWh5dfugcUZp8z9ucIHAqYIqeNdWAOn9r+Kaiel1w2rRps18d2dQhNrOLUTxdMDS/h6Jx3dFlhzqwKsJXYRhemMLaJN1VqZNf/AmvtOlOPDPq0Kv5pXJCnT19amqyKzwmChQTBVbRQ/V1gicKXpPVZuWULjC6O1bBqakxFCSo4NEduWoCc61DZC5INmIzt+YQSya+sFVQrbyuGhrd7aomRLVCCohVi6Z0ar+deOKJ9uCDDyb8THU8jf/MRNRx+8knn3S10Kqde+WVV9zFokGDBpF1fLel9fRd9FmJ9qXKj5zK7g1TtGQ3QTnN62GeVQ1Ht27dEq6jmpncoIBIgbOOifa/9rVqU1TjM3r06LQ9f7JbbuTnuXtIkm35pEHpVo2drkuJ6OZ4fxE45YNkhYqCB9XSqMZpyJAh+9Rq+HxGMioEVNXtK6zZyUktlwIj3VEkuuPWiBndEcRP3Kkmo+gLRyLK+NFVw9kRXcuRTKL9/M0337gRI8nuVsLRghp9k9WIRd2NJarGzqxZKic0mkXV9arJOPPMM2P2caK0a46ZzNLum9e0j7SvVEsZT9X8qlmIDy5yIqwZTbYdBeDxtR46ttH5UaORVKBGj/xS+nTB1EMXTM1h9u9//9sFU9o/2l+arFWv56QpJqRjouZLBWYaxae7e20nmu+2tJ4uEvpuuXEByK39rryeaHLe+Lyuz9RxUN6MrjXT8YnPWxq1psDLd2RwTmn0o2oDNSlv9A1efLNn9PmT2VxIvnklJ/m6IMqN7CiU5LtHf9f42notC1/PDTpOW7ZsydN8Qx+nfKCLi8QXLGH0HB+xJ5p1NjyBfGcOV/8dBWbxF+5kQ7//+9//ukx/yimnWHapKn3y5Mkxj7DPgoY4a4h2NAVnustr3rx5pp+r/iLK/Dl56EKVFVXLR/eTULOS+rycf/75Se9sVBunOzRdZNXcEi96/+oEVgEYvUwXRzUL+PCdjiBRPtK0Eo8//njMejq2uuAqf8Xno+j3+uY1bVf7SvssemqMX3/91TVNKUjIjaZLHUvVxqr2MTpNuoCpdkhTK8QLhy6HxowZ4/5q2oSwiTxeOGFfOPxftcEaKq2a2EQ3GmpG8aEATTW6ukCrplLThEQ302VnW2pO1H7XzVZ8uaHn0dOY5Od+V15XPo1utlFts8qCaGFtdnzeDI9PSN9RTZy6+dP24vlMYeE7HUGi80ffRbXW0ZTXFcyNGDFin6kt4s8fnxvQnOTr3ORbbmRH6SRlh7qy6GZT8wpGT6+hmlM1UauvU27RuaSyXU2d8ZQunX/7ixqnXKCDH9+RThQYqNOsqsAVBOiOU3eJ6giodnI9FOlrLgxdhDVXhU6YRBF/2IlZd6qq+ldfBnWcTHZHooyoZqP33nvP9V8KDR8+3F241RSouytdQFQ4zZ8/3wU70XdSuiPRnB1q+8/sJzhUoMQLTxxVBcf3/1KadLKqI3ZB0v5XQa45ZdT3JCwwwlneE1EgoPldunTp4gIRHQvdHavWTU0+p59+uj366KNuXc0/o5oMbaNHjx6ubV0Fh2rDfDpz6qKj+VCyanZUPtMdv5o09F0UAOsCHX9h1QVcaVe+UYGtz1bhrbyrvg5hQRPmNX2W0q4CVt8zEU1yGs6HpI6fynNqllLhGD3Hy/7SLPgKenRDoH2pYEIXW9VmJsqbOodU26l8rkJU8x6pw3pYy6mmCTXV6TzR3a6OjY6/+lDou4iOsZrV1CFXtQ86tqoB0f7Scu0v376NCpSUXp1LapJTH5ZovttSgKJ9PnDgQBesqulPF3N9X+UXnevh3FC+529u7HflDzXvaF4u5RsFK8prKu+ib06UtxQQKXhXkKeBMB9++KGr6Y2vsbj33nvdvtCgC/3epspQlVf6PJUhiYLfaDoPdS7rMzLrIK7yS01zOi+uvfZaV1uhAFYXegV/0ee+mu7UL07zFSk/6bzTzZC+b9itQN9RZb3mK9N6aj7VZ+/P/s0LvuVGdtSqVct11lY5p3yp65OOn27YNI+SyhxdE9SvVjdYmj9OtcD6tYncom4vqj3UHFAqN3U8dOOh+Z9effVVd95k1U0kS/s9Lu8gltl0BPFDMjU/jqYH0NDt6OGTP/30kxtSqiHuGmKreTQ0nDvR9AUaZnnUUUe5oao+UxNoSLamGYimeUYuuugiNxdG0aJF3fDa008/3aU1ekitaAi1tqMh0TndN4mmI9D8M5ouoSApbRp2/8ILLwTHHnusmz5Cc6TED11ONI+TaD0NV9Yx0xQGtWrVckOqo6c3EH2+hjTruGvosYan58V0BBquftppp7khuzq2mtslHAof/50+/vhjN1eTjr2G7WrOE82JEtK0BTfeeKObk0jDf6OLiUT58vPPP3f74tBDD3XDmM855xyX333yg9LmO2Rc86Upr+o7aui85mn6+uuvEw671vK//e1v7jtqThzNiRQ9DHrGjBlufiTtKx0b/dVcafFDmDWMWvN0ab4Y5RF9ls5jzbej+cri81MyOrc0B47W0zxMifhuSyZNmuTOIR0/PerWreu2v3z58myfv+EweU15ktP9HpYtGm6u/VmnTh2X9xPN46R5dpTWcuXKuTyjKS2Ubq2nOaSi/frrr25d7TuVVxr+rjJNc95lJTvTEUyZMsWdBzqXNa+QjsPTTz+d8NzXuppXKNwfmnNPU8iENL/eFVdc4cp0vT881xNNR+C7f5NNJ5CsfEq2L+Lf71tuaDoC5ct43RKUZa+//rqbg0nTY8R/35dfftmVs8rfOv6dO3d218D4z1SejpcsDdq+poCIpmljBg4c6OYLVH7U3Fg6Zpo3UefZ/iqkf3Ir0sOB5aOPPnJ3WrprTTYKJ6s+Ri+++KLrf6Aamdywdu1ad/ehUYQFXeMEpLO8OH/ziobln3zyya5msHPnzgWdHCBT9HFKYxrppmronDaZqIr79ttvz9VCV1X0aqogaALyVl6cv7kh0RQjKhfUlBzdSRk4UFHjBADIN+p3tGDBAtf/Sn3i1EdUD/XPUv844EBH4AQAyDcaTKDgST8Yq47YGqSizvEa+BI9DxpwoEq5pjoNM1YvfE3Upd76n376aabra/p1zWmk9dVElJOfCQAA5A5NTqiZojUqTsPf1QdLI/8ImpAqUipwCod46iTTkFQNLdZw6WRTqGtGbg171DBP/U6Xhu7qkWheEAAAgLRqqlMNk+bFCOfJ0Qy0mplY8w/p96YSzZ2i+RumTp0aWaZ5QzSHjeaZAAAAyI6UqRtVla46FGrit5BGYWiWaE1wl4iWq4YqmmqoXnvttaTb0cR90TObKjhTlbJ++21/fnYBAAAcmFSHtHnzZqtSpUqWP1afMoGTps/XTLpHHnlkzHI9TzRrdzhnUKL1tTwZTaef2czRAAAgPemnt/QLAmkROOUX1WhF11LpN4c06kMjQDSFPJBdp90zo6CTcNCbO6hlnm+D45z+x5ljXPDy6hirtkk/6+NznU+ZwEm/LaPfzNLv20TT80qVKiV8j5ZnZ33RZHGJJozT78jlxg+W4uBTJGM/fxcJ+y2rO8jcwHFO/+PMMS54eXWMw98P9emSkzKj6vQjjPqxvhkzZsT0P9Jz/UBiIloevX44h0iy9QEAANKixknUhKZfctavhDdp0sRN069Rc/rFZenataurGVI/Jenbt6/7JeYHHnjA/Qq6fh/ts88+s3HjxhXwNwEAAKkopQInTS/w22+/2ZAhQ1wHb00rMG3atEgH8NWrV8f0hm/evLlNnDjRBg8ebIMGDXI/dKsRdfXr1y/AbwEAAFJVSgVO0rt3b/dI5IMPPthn2WWXXeYeAAAA+ytl+jgBAAAUNAInAAAATwROAAAAngicAAAAPBE4AQAAeCJwAgAA8ETgBAAA4InACQAAwBOBEwAAgCcCJwAAAE8ETgAAAJ4InAAAADwROAEAAHgicAIAAPBE4AQAAOCJwAkAAMATgRMAAIAnAicAAABPBE4AAACeCJwAAAA8ETgBAAB4InACAADwROAEAADgicAJAADAE4ETAACAJwInAAAATwROAAAAngicAAAAPBE4AQAAeCJwAgAA8ETgBAAA4InACQAAwBOBEwAAgCcCJwAAAE8ETgAAAJ4InAAAADwROAEAAHgicAIAAPBE4AQAAOCJwAkAAMATgRMAAEC6BU7r16+3zp07W0ZGhpUtW9Z69OhhW7ZsyXT9G2+80erUqWMlS5a0atWqWZ8+fWzjxo35mm4AAJA+UiZwUtC0ZMkSmz59uk2dOtVmzZplvXr1Srr+mjVr3GPUqFG2ePFie/bZZ23atGku4AIAAMiJIpYCli5d6oKe+fPnW+PGjd2yMWPGWNu2bV1gVKVKlX3eU79+fZs0aVLkea1atWz48OF25ZVX2u7du61IkZT46gAA4ACSEjVOc+bMcc1zYdAkrVq1ssKFC9u8efO8P0fNdGrqI2gCAAA5kRIRxNq1a61ixYoxyxT8lCtXzr3m4/fff7dhw4Zl2rwnO3bscI/Qpk2bcphqAACQbgq0xmnAgAFWqFChTB/Lli3b7+0o+Lnwwgvt+OOPtzvuuCPTdUeMGGFlypSJPKpWrbrf2wcAAOmhQGuc+vfvb927d890nZo1a1qlSpVs3bp1McvVT0kj5/RaZjZv3mxt2rSxww47zCZPnmxFixbNdP2BAwdav379YoIugicAAFDggVOFChXcIyvNmjWzDRs22IIFC6xRo0Zu2cyZM23v3r3WtGnTpO9T0NO6dWsrXry4TZkyxUqUKJHltrSuHgAAACnZObxevXqu1qhnz5726aef2uzZs613797WqVOnyIi6n3/+2erWreteD4Om888/37Zu3Wr//e9/3XP1h9Jjz549BfyNAABAKkqJzuEyYcIEFyy1bNnSjaa79NJL7ZFHHom8vmvXLlu+fLlt27bNPf/8888jI+5q164d81mrVq2y6tWr5/M3AAAAqS5lAieNoJs4cWLS1xUIBUEQeX722WfHPAcAADgomuoAAAAOBAROAAAAngicAAAAPBE4AQAAeCJwAgAA8ETgBAAA4InACQAAwBOBEwAAgCcCJwAAAE8ETgAAAJ4InAAAADwROAEAAHgicAIAAPBE4AQAAOCJwAkAAMATgRMAAIAnAicAAABPBE4AAACeCJwAAAA8ETgBAAB4InACAADwROAEAADgicAJAADAE4ETAACAJwInAAAATwROAAAAngicAAAAPBE4AQAAeCJwAgAA8ETgBAAA4InACQAAwBOBEwAAgCcCJwAAAE8ETgAAAJ4InAAAADwROAEAAHgicAIAAPBE4AQAAOCJwAkAAMATgRMAAIAnAicAAIB0C5zWr19vnTt3toyMDCtbtqz16NHDtmzZ4vXeIAjsggsusEKFCtlrr72W52kFAADpKWUCJwVNS5YssenTp9vUqVNt1qxZ1qtXL6/3PvTQQy5oAgAA2B9FLAUsXbrUpk2bZvPnz7fGjRu7ZWPGjLG2bdvaqFGjrEqVKknf+8UXX9gDDzxgn332mVWuXDkfUw0AANJNStQ4zZkzxzXPhUGTtGrVygoXLmzz5s1L+r5t27bZFVdcYY899phVqlQpn1ILAADSVUrUOK1du9YqVqwYs6xIkSJWrlw591oyN998szVv3tzat2/vva0dO3a4R2jTpk05TDUAAEg3BVrjNGDAANf3KLPHsmXLcvTZU6ZMsZkzZ7r+TdkxYsQIK1OmTORRtWrVHG0fAACknwKtcerfv791794903Vq1qzpmtnWrVsXs3z37t1upF2yJjgFTStWrHBNfNEuvfRSO+OMM+yDDz5I+L6BAwdav379YmqcCJ4AAECBB04VKlRwj6w0a9bMNmzYYAsWLLBGjRpFAqO9e/da06ZNk9ZmXXPNNTHLTjzxRBs9erS1a9cu6baKFy/uHgAAACnZx6levXrWpk0b69mzp40dO9Z27dplvXv3tk6dOkVG1P3888/WsmVLGz9+vDVp0sTVRCWqjapWrZrVqFGjAL4FAABIdSkxqk4mTJhgdevWdcGRpiFo0aKFjRs3LvK6gqnly5e7kXQAAAAHbY2TaATdxIkTk75evXp1N0N4ZrJ6HQAAIC1qnAAAAAoagRMAAIAnAicAAABPBE4AAACeCJwAAAA8ETgBAADkduDUsWPHyA/eapLJ6B/CBQAAOBh4B05Tp061rVu3uv9fddVVtnHjxrxMFwAAQOpOgKlZu/UDuOecc46bSPKVV16xjIyMhOt27do1N9MIAACQWoGTfiOuX79+9uabb1qhQoVs8ODB7m88LSNwAgAAB3Xg1Lx5c5s7d677f+HChe2bb76xihUr5mXaAAAAUn9U3apVq6xChQq5nxoAAIB0qHH66quvrH79+q62SR3DFy1alHTdk046KbfSBwAAkHqBU8OGDW3t2rWueU7/V18mdRIPhc/1d8+ePXmVXgAAgAM/cIpuntP/AQAADjbegdMxxxyT8P8AAAAHC+/AKZGvv/7aVq9ebTt37oxZfvHFF+9vugAAANIjcFq5cqVdcsklroN4dF+ncF4n+jgBAIB0lKPpCPr27Ws1atSwdevWWalSpWzJkiU2a9Ysa9y4sX3wwQe5n0oAAIBUrXGaM2eOzZw508qXL++mJ9CjRYsWNmLECOvTp48tXLgw91MKAACQijVOaoo77LDD3P8VPK1ZsybSaXz58uW5m0IAAIBUrnHSRJhffvmla65r2rSpjRw50ooVK2bjxo2zmjVr5n4qAQAAUjVw0g/8bt261f3/rrvusosuusjOOOMMO+KII+zll1/O7TQCAACkbuDUunXryP9r165ty5Yts/Xr19vhhx8eGVkHAACQbvZrHqdo5cqVy62PAgAASJ/ASc109957r82YMcNNSbB379595nkCAABINzkKnK655hr78MMPrUuXLla5cmWa5wAAwEEhR4HT22+/bW+++aadfvrpuZ8iAACAdJrHSZ3A6dMEAAAONjkKnIYNG2ZDhgyxbdu25X6KAAAA0qmp7oEHHrAVK1bYkUceadWrV7eiRYvGvP7555/nVvoAAABSO3Dq0KFD7qcEAAAgHQOnoUOH5n5KAAAA0rGPEwAAwMGIwAkAAMATgRMAAIAnAicAAID8CJx+//1327Rp0/58BAAAQPoGThs2bLAbbrjBypcv7+Zx0izilSpVsoEDBzIhJgAASGvZmo5g/fr11qxZM/v555+tc+fOVq9ePbf866+/tjFjxtj06dPt448/tq+++srmzp1rffr0yat0AwAAHNiB01133WXFihWLzBoe/9r5559vXbp0sXfffdceeeSR3E4rAABA6jTVvfbaazZq1Kh9giZRc93IkSNt0qRJ1q9fP+vWrVtuptPVdqmWKyMjw8qWLWs9evSwLVu2ZPm+OXPm2LnnnmulS5d27z3zzDPtr7/+ytW0AQCAg0O2AqdffvnFTjjhhKSv169f3woXLpwnM4sraFqyZIlrDpw6darNmjXLevXqlWXQ1KZNG1cT9umnn9r8+fOtd+/eLo0AAAB52lSnDuHff/+9HX300QlfX7VqlVWsWNFy29KlS23atGku8GncuLFbpj5Vbdu2dTVgVapUSfi+m2++2fWzGjBgQGRZnTp1cj19AADg4JCtqpfWrVvbv//9b9u5c+c+r+3YscNuv/12V8OT21RzpOa5MGiSVq1auZqjefPmJXzPunXr3GsK5Jo3b+6aF8866yzXeR0AACBfOocreDn22GPdlAR169a1IAhcjdDjjz/ugqfx48dbblu7du0+NVlFihSxcuXKudcSWblypft7xx13uFqphg0burS1bNnSFi9e7L5DIvoOeoSYpwoAAOSoxklNdKr9Of744928TR06dLBLLrnE1UJp2ezZs61atWren6cmtEKFCmX6WLZsmeXE3r173d9rr73WrrrqKjv55JNt9OjRrqnu6aefTvq+ESNGWJkyZSKPqlWr5mj7AADgIK9xkho1atjbb79tf/75p3377bduWe3atV3tT3b179/funfvnuk6NWvWdCP21PQWbffu3W6knV5LpHLlyu6vArpomntq9erVSbengFCjAqNrnAieAABAjgKnkGYMb9KkyX7txQoVKrhHVjTppmYsX7BggTVq1MgtmzlzpqtVatq0acL3VK9e3XUaX758eczyb775xi644IKk2ypevLh7AAAAxEuJcfmqJVKn8549e7ppBdQkqGkFOnXqFBlRp9nM1edKr4ua+W699VY3Eeerr75q3333neu8rqY/zQEFAACQbzVO+W3ChAkuWFLnbo2mu/TSS2NmJ9+1a5erXYr+vbybbrrJtm/f7qYlULNegwYN3DxQtWrVKqBvAQAAUlnKBE7qQzVx4sSkr6tpTiP8EnVAj57HCQAAIK2b6gAAAA4EBE4AAACeCJwAAAA8ETgBAAB4InACAADwROAEAADgicAJAADAE4ETAACAJwInAAAATwROAAAAngicAAAAPBE4AQAAeCJwAgAA8ETgBAAA4InACQAAwBOBEwAAgCcCJwAAAE8ETgAAAJ4InAAAADwROAEAAHgicAIAAPBE4AQAAOCJwAkAAMATgRMAAIAnAicAAABPBE4AAACeCJwAAAA8ETgBAAB4InACAADwROAEAADgicAJAADAE4ETAACAJwInAAAATwROAAAAngicAAAAPBE4AQAAeCJwAgAA8ETgBAAA4InACQAAwBOBEwAAgCcCJwAAAE8ETgAAAOkWOK1fv946d+5sGRkZVrZsWevRo4dt2bIl0/esXbvWunTpYpUqVbLSpUvbKaecYpMmTcq3NAMAgPSSMoGTgqYlS5bY9OnTberUqTZr1izr1atXpu/p2rWrLV++3KZMmWKLFi2yjh072uWXX24LFy7Mt3QDAID0kRKB09KlS23atGn21FNPWdOmTa1FixY2ZswYe+mll2zNmjVJ3/fJJ5/YjTfeaE2aNLGaNWva4MGDXW3VggUL8jX9AAAgPaRE4DRnzhwX8DRu3DiyrFWrVla4cGGbN29e0vc1b97cXn75ZdfMt3fvXhdobd++3c4+++yk79mxY4dt2rQp5gEAAJAygZP6KlWsWDFmWZEiRaxcuXLutWReeeUV27Vrlx1xxBFWvHhxu/baa23y5MlWu3btpO8ZMWKElSlTJvKoWrVqrn4XAACQugo0cBowYIAVKlQo08eyZcty/Pm33367bdiwwd577z377LPPrF+/fq6Pk/o7JTNw4EDbuHFj5PHjjz/mePsAACC9FCnIjffv39+6d++e6Trqm6RRcevWrYtZvnv3btcEp9cSWbFihT366KO2ePFiO+GEE9yyBg0a2EcffWSPPfaYjR07NuH7VDOlBwAAwAEVOFWoUME9stKsWTNXc6RO3Y0aNXLLZs6c6fotqbN4Itu2bXN/1Q8q2iGHHOLeBwAAkJZ9nOrVq2dt2rSxnj172qeffmqzZ8+23r17W6dOnaxKlSpunZ9//tnq1q3rXhf9X32Z1K9Jy1QD9cADD7jpDDp06FDA3wgAAKSilAicZMKECS4YatmypbVt29ZNSTBu3LjI6+oErjmbwpqmokWL2ltvveVqtNq1a2cnnXSSjR8/3p577jn3fgAAgJRqqssOjaCbOHFi0terV69uQRDELDv22GOZKRwAABx8NU4AAAAFjcAJAADAE4ETAACAJwInAAAATwROAAAAngicAAAAPBE4AQAAeCJwAgAA8ETgBAAA4InACQAAwBOBEwAAgCcCJwAAAE8ETgAAAJ4InAAAADwROAEAAHgicAIAAPBE4AQAAOCJwAkAAMATgRMAAIAnAicAAABPBE4AAACeCJwAAAA8ETgBAAB4InACAADwROAEAADgicAJAADAE4ETAACAJwInAAAATwROAAAAngicAAAAPBE4AQAAeCJwAgAA8ETgBAAA4InACQAAwBOBEwAAgCcCJwAAAE8ETgAAAJ4InAAAADwROAEAAHgicAIAAPBE4AQAAJBugdPw4cOtefPmVqpUKStbtqzXe4IgsCFDhljlypWtZMmS1qpVK/v222/zPK0AACA9pUzgtHPnTrvsssvsn//8p/d7Ro4caY888oiNHTvW5s2bZ6VLl7bWrVvb9u3b8zStAAAgPRWxFHHnnXe6v88++6x3bdNDDz1kgwcPtvbt27tl48ePtyOPPNJee+0169SpU56mFwAApJ+UqXHKrlWrVtnatWtd81yoTJky1rRpU5szZ07S9+3YscM2bdoU8wAAAEipGqfsUtAkqmGKpufha4mMGDEiUrsF5Ibv772woJOAfMBxTn8cYxR4jdOAAQOsUKFCmT6WLVuWr2kaOHCgbdy4MfL48ccf83X7AADgwFWgNU79+/e37t27Z7pOzZo1c/TZlSpVcn9//fVXN6oupOcNGzZM+r7ixYu7BwAAwAEVOFWoUME98kKNGjVc8DRjxoxIoKT+Shpdl52ReQAAACnXOXz16tX2xRdfuL979uxx/9djy5YtkXXq1q1rkydPdv9XM99NN91kd999t02ZMsUWLVpkXbt2tSpVqliHDh0K8JsAAIBUlTKdwzWR5XPPPRd5fvLJJ7u/77//vp199tnu/8uXL3f9kkK33Xabbd261Xr16mUbNmywFi1a2LRp06xEiRIF8A0AAECqKxRowiMkpeY9TWOggCwjI6OgkwMAAArwWp8yTXUAAAAFjcAJAADAE4ETAACAJwInAAAATwROAAAA6TYdQUEJBx3yY78AAKSn8BrvM9EAgVMWNm/e7P5WrVq1oJMCAADy+JqvaQkywzxOWdi7d6+tWbPGDjvsMDcbOWIjdAWU+iFk5rhKXxzn9McxTn8c48wpFFLQpF8XKVw4815M1DhlQTvw6KOPLuhkHNB0EnIipj+Oc/rjGKc/jnFyWdU0hegcDgAA4InACQAAwBOBE3KsePHiNnToUPcX6YvjnP44xumPY5x76BwOAADgiRonAAAATwROAAAAngicAAAAPBE4wTn77LPtpptuKuhkIB9xzJFd1atXt4ceeqigk4FcOn85njlD4IR80717d+vQoUNBJwMAYGbz58+3Xr16RZ7r1zFee+21Ak1TKmDmcAAA0sjOnTutWLFiWa5XoUKFfElPuqHGCTG/y3fbbbdZuXLlrFKlSnbHHXdEXnvwwQftxBNPtNKlS7vfO7r++utty5Ytkde1bsOGDWM+T1XAqgoOX3/uuefs9ddfd3c1enzwwQf5+O2QyO7du613797upwbKly9vt99+e+TXwZ9//nlr3Lix+51G5YcrrrjC1q1bF3nvn3/+aZ07d3aFb8mSJe3YY4+1Z555pgC/TXrT72hpf+scrFy5so0ePTqmuSar4/Xss89a2bJlYz5TtQvxv8H5xhtv2KmnnmolSpRweeKSSy6JeX3btm129dVXu+1Uq1bNxo0bF/O6fgvt8ssvd9tSWdK+fXv7/vvv82CPHDy2bt1qXbt2tUMPPdQd+wceeCDmdZWzw4YNc+vo51TCWqRJkybZCSec4OZu0jqJ3hc21YVltY638kT4XFRun3LKKS5P1KxZ0+68805XdhysCJwQocBGhfK8efNs5MiRdtddd9n06dMjv9n3yCOP2JIlS9x6M2fOdEGWr1tuucUVpm3atLFffvnFPZo3b56H3wY+dCyLFClin376qT388MMuQH7qqafca7t27XKF8ZdffukusLr4qbk1pCDr66+/trffftuWLl1qTzzxhLvQIm/069fPZs+ebVOmTHHn5UcffWSff/555PWsjpePN998010427ZtawsXLrQZM2ZYkyZNYtbRxVcBml7XDdQ///lPW758eSQNrVu3dkGV0qf06mKv8161IMiZW2+91T788EMXwLz77rvupjP62MuoUaOsQYMG7rjo3FywYIErczt16mSLFi1yN69argA6WbOd6OZH5XP4XMdRAVnfvn3d+f7kk0+6zxg+fLgdtDQBJnDWWWcFLVq0iFl26qmnBv/6178Srv+///0vOOKIIyLPhw4dGjRo0CBmndGjRwfHHHNM5Hm3bt2C9u3b53rakfNjXq9evWDv3r2RZTreWpbI/PnzVRUVbN682T1v165dcNVVV+Vbeg9mmzZtCooWLerOu9CGDRuCUqVKBX379vU6Xs8880xQpkyZmHUmT57s1gk1a9Ys6Ny5c9J06Hy+8sorI8+VdypWrBg88cQT7vnzzz8f1KlTJyZP7dixIyhZsmTwzjvv5Oi7H+x0/IoVKxa88sorkWV//PGH26fhsddx6dChQ8z7rrjiiuC8886LWXbrrbcGxx9/fOS53qdyOqS8oDwRrWXLlsE999wTs+z5558PKleuHBysqHFCxEknnRTzXFXCYVX/e++9Zy1btrSjjjrK3U126dLF/vjjD1dtj9R12mmnxTTVNGvWzL799lvbs2ePu2Nt166da47RMT/rrLPcOqtXr3Z/VdPw0ksvuSZa1T5+8sknBfY90t3KlStdbU507Y+aV+vUqRN5ntXx8vHFF1+489y3nFDeUbNgWE6otuu7775z21dNkx5qrtu+fbutWLEiW98Z/5/2m2rrmjZtGlmmfRp97EW1gNFUC3z66afHLNPz8Pz2pWOq1ofweB566KHWs2dPVyt1sJb/dA5HRNGiRWOeq1BUvydV+V900UXuQqnqWZ20H3/8sfXo0cOd0KVKlXJNefG/3qOCHqlJFzo1uegxYcIE149JF2A9D5tcLrjgAvvhhx/srbfeck1HuuDecMMNrskA+d8HJqvj5XOOqq9aTssJUb/HRo0auTTEoyNy3lI3i7ygY6o+TR07dtzntRIlStjBiBonZEl3sioY1bdBNRTHHXecrVmzZp9Cce3atTEFs+5eo2mUR3budJD31J8t2ty5c10n72XLlrkaxXvvvdfOOOMMq1u3bkxH4+jj3q1bN3vhhRdcJ9P4jsLIHeqQq4Al7HciGzdutG+++cb93+d46Vipg7mCrGTnqGqT1K8pp9SBWDUaFStWtNq1a8c8VEOG7KtVq5Y79tHnqgZmhMc+mXr16rk+ZtH0XOX3IYcckvA92k58Ga1jqj5s8cezdu3aLhg/GB2c3xrZohNEd6ZjxoxxTQYavTN27NiYdTS657fffnOdylW1/Nhjj7lOw9E0SuOrr75yJ+Hvv/9OjdQBQLUS6nSsY/Liiy+6Y6xOoGruUaAbHnN1SFbH42hDhgxxnVXVNKNBA1OnTnWFNXKfmr4UoKqT8Pvvv+/2t2p8deFSjY/P8VJTj2qHBw0a5M7RiRMn7tNReOjQoS4f6K+aetSp+L777vNOp0b9aYCARtKpU/GqVatcR+Y+ffrYTz/9lGv742CipjEdax17DcpZvHix6/SfVdDSv39/FwQrHyjI0kCQRx991A3USUZltN6jm2AFZ+F5Pn78eFfrpHy3dOlS10Q/ePBgO2gVdCcrHDgdheM7maojtzp0y4MPPug6A6pDYuvWrYPx48e7joR//vlnZH11EK1atWpQunTpoGvXrsHw4cNjOoevW7fOdVY89NBD3Xvff//9fPyGSHTMr7/++uC6664LMjIygsMPPzwYNGhQpGPvxIkTg+rVqwfFixd3nYanTJnijtvChQvd68OGDXMdyZUnypUr5/LLypUrC/hbpXcHcXX4VYfwSpUquXOySZMmwYABA7yOl6jjb+3atd0xu+iii4Jx48bFdA6XSZMmBQ0bNnQdksuXLx907NgxaWdi0aAQDQ4J/fLLL+7813uVlpo1awY9e/YMNm7cmId7J/07iKtTvo79kUceGYwcOTKmzE50XOTVV191ncE1sKBatWrB/fffH/N6/PuUZ5Q/ihQpElN2T5s2LWjevLnLNxkZGS7fKe8crArpn4IO3gAA2aMmNw3WUBO6aiQA5A86hwNACtD8POrLpJF16t+kkU6iZjEA+YfACQBShEYsqj+a+jNp9Jr6ETHpKJC/aKoDAADwxKg6AAAATwROAAAAngicAAAAPBE4AQAAeCJwAgAA8ETgBAAA4InACQAAwBOBEwAAgCcCJwAAAPPz/wDAdr2QyZbZxQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 600x350 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Q naif en (3, 4) : [ 0. -1. -1. -1.] — actions observees : ['bas', 'gauche', 'droite']\n"
+     ]
+    }
+   ],
+   "source": [
+    "d_exp = datasets[\"expert\"]\n",
+    "Q_naive, _ = offline_q(env, d_exp, constrain=False)\n",
+    "seen_exp = [set() for _ in range(env.n_states)]\n",
+    "for s, a, *_ in d_exp:\n",
+    "    seen_exp[s].add(a)\n",
+    "\n",
+    "visited = [s for s in range(env.n_states) if seen_exp[s]]\n",
+    "greedy_unseen = sum(1 for s in visited if int(Q_naive[s].argmax()) not in seen_exp[s])\n",
+    "print(f\"Etats visites par le dataset expert : {len(visited)}\")\n",
+    "print(f\"... dont la politique greedy naive choisit une action JAMAIS observee : \"\n",
+    "      f\"{greedy_unseen} ({greedy_unseen / len(visited):.0%})\")\n",
+    "\n",
+    "# Zoom sur un etat du chemin optimal : (3, 4)\n",
+    "s_zoom = env.idx((3, 4))\n",
+    "obs = sorted(int(a) for a in seen_exp[s_zoom])\n",
+    "colors = [\"tab:blue\" if a in obs else \"tab:red\" for a in range(4)]\n",
+    "fig, ax = plt.subplots(figsize=(6, 3.5))\n",
+    "ax.bar(ACTION_NAMES, Q_naive[s_zoom], color=colors)\n",
+    "ax.axhline(0, color=\"black\", lw=0.8)\n",
+    "ax.set_ylabel(\"Q naif\")\n",
+    "ax.set_title(\"Etat (3, 4) — bleu : action observee, rouge : action fantome\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "print(f\"Q naif en (3, 4) : {np.round(Q_naive[s_zoom], 2)} — actions observees : {[ACTION_NAMES[a] for a in obs]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96e866b1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "La figure resume toute la pathologie : en $(3, 4)$, l'action « haut » n'apparait nulle part dans le dataset, son $Q$ est reste a l'initialisation $0$ — strictement au-dessus des actions documentees, toutes ecrasees vers $\\approx -1$ par le bootstrap contamine. La politique greedy choisit donc l'action fantome dans **~94 % des etats visites** : elle ne suit jamais le chemin expert pourtant present sous ses yeux. Notez l'effet boule de neige : l'optimisme des actions fantomes ($Q = 0$) remonte dans les cibles $r + \\gamma \\max Q(s')$ des etats voisins, qui paraissent a leur tour meilleurs qu'ils ne sont. En deep RL, ou $Q$ est un reseau qui *generalise* aux actions non vues, le phenomene est encore plus violent — les valeurs divergent positivement (Fujimoto et al., 2019, fig. 1)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "258cc257",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 5. Contraindre au support du dataset : BCQ-lite\n",
+    "\n",
+    "Le diagnostic dicte le remede : interdire au $\\max$ de regarder les actions fantomes. On restreint le bootstrap **au support du dataset** :\n",
+    "\n",
+    "$$Q(s, a) \\leftarrow Q(s, a) + \\alpha\\,\\Big[r + \\gamma \\max_{a' \\,\\in\\, \\mathcal{A}_\\mathcal{D}(s')} Q(s', a') - Q(s, a)\\Big]$$\n",
+    "\n",
+    "ou $\\mathcal{A}_\\mathcal{D}(s') = \\{a' : (s', a') \\in \\mathcal{D}\\}$ est l'ensemble des actions effectivement observees en $s'$. La politique finale est elle aussi restreinte aux actions observees. C'est la version tabulaire de **BCQ** (*Batch-Constrained deep Q-learning*, Fujimoto et al., 2019) — en continu, un modele generatif estime $\\pi_\\beta(a|s)$ et le $\\max$ ne porte que sur des actions plausibles sous le comportement.\n",
+    "\n",
+    "L'enjeu : garder la capacite du Q-learning a **recombiner** des bouts de trajectoires (ce que BC ne sait pas faire), sans son optimisme hors support."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "50d31e5c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dataset   retour BCQ-lite   succes   (comportement)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "expert              -13.0    100%            -14.7\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "medium              -13.0    100%           -158.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "random              -13.0    100%           -194.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "results_bcq = {}\n",
+    "print(f\"{'dataset':<8} {'retour BCQ-lite':>16} {'succes':>8} {'(comportement)':>16}\")\n",
+    "for name, d in datasets.items():\n",
+    "    _, pol = offline_q(env, d, constrain=True)\n",
+    "    ret, sr = evaluate_policy(env, pol)\n",
+    "    results_bcq[name] = ret\n",
+    "    print(f\"{name:<8} {ret:>16.1f} {sr:>7.0%} {behavior_returns[name]:>16.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9900adc3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAG4CAYAAADYN3EQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAcDZJREFUeJzt3QW4FGX7x/Gb7m6kQxopQUKlBAVEFFCxQDFQQAlRMAhFAZWyAEWB1wITfUUBEVDSohEUkJSW7tr/9Xt8Z/97ipPLOWf3+7mugbMzs7PPzM7MPvc8lcbn8/kMAAAAABIhbWLeDAAAAABCYAEAAAAg0QgsAAAAACQagQUAAACARCOwAAAAAJBoBBYAAAAAEo3AAgAAAECiEVgAAAAASDQCCwAAAACJRmABJLM9e/ZYhw4dLF++fJYmTRobM2aMm79hwwZr0aKF5cqVy82fPn26TZ482f29ZcsW//sbN27spnCT1PvdpUsXK1WqVILeq++kR48edikkJp0x0fmkfXjllVcsXOgY6liGAu++8Ouvvwb9s8LhfhPdfTaphdL5BwQisEBY8X4wvCl9+vR22WWXuRv833//HWV9/YBWrVo1qGnq3bu3zZo1ywYMGGDvvfeeXX/99W5+586dbfXq1fbCCy+4+XXq1AlqOhD6vvnmGxs8eLClBidOnHBpnT9/fnInJcV488033T0MqetcTko7d+50+71ixQpLCcL1e0DM0l9kGRCynnvuOStdurSdOnXKli5d6n6sFy5caGvWrLHMmTNf0rTMnTvXbrrpJnv88cf9806ePGlLliyxp59+OtYn4bNnz74EqURK8fbbb9uFCxcSnAl44403UkVGQIHFkCFD3N/BeEL+xx9/WNq0aVNdYJE/f36edAf5XL777rvt9ttvt0yZMllKDCx0XajEo0aNGsmdnFR1T8GlQWCBsHTDDTf4SwDuv/9+92M9YsQI++qrr+zWW2+9pGnZu3ev5c6dO8K8ffv2uf8jz49OxowZLRQp83zmzJlLHuilVMePH7ds2bJZhgwZkjspKfr4xFVKzDQiOM6dO+fuJ3G9V6ZLl85NAOIvdT2uAYLk6quvdv9v2rQpybb5119/WceOHS1v3ryWNWtWu+qqq2zGjBlRqmX5fD73xMernqUnPyVLlnTr9OvXz827WJ36yHWeVXVE7/n4449dNapixYq5zHmzZs1s48aNUd7/008/uepXasuhdF577bW2aNGiOO3ja6+9ZlWqVHHvy5MnjwvWPvzww1jbA2gflcbo2il88MEHbpvK+M2cOdPi4/Tp0zZo0CArV66ce3/x4sXtiSeecPMTQm0OGjRo4Nq/ZMmSxWrXrm2ffvppjOsr7RUqVHDHW+v++OOP/mXz5s1z+/jFF19EeZ+OmZaplMo7btmzZ3fnY6tWrSxHjhx25513RntMA9tHvPXWW1a2bFm371deeaX98ssv/vX0Pp1nElgdMLKLbcOzfv161y5I57b2Vd+7gvK42LVrl3v/2bNnY1xH+1SgQAH3t57OBl4bsR0fBRh9+/Z13732Qd+Hjo2us4vVcVd69Fnly5d3+6TvvFGjRvbdd99ddH+861glno8++qhLtx4IPPTQQy4wPnTokN1zzz3u+tCk8zFyWpTpVdsqnff67EKFCrn3Hzx4MEJ6165daz/88IP/eEQuydF53qdPH5cGBVk333yz/yFF5JIP7xorWrSode/e3aUzpnNB537dunVtwYIFibrudCx1THV89P3pu3nqqacsvi52LgdeDzqm3rn8+++/+0uIdb/X8VE6VFq8bt26WNtYqP1Ky5Yt3UMoHQ+VeN93332xplXf9dChQ919WPfJJk2auO8xsgMHDrhS62rVqrljkzNnTvcAbOXKlRHu7bom5d577/Xvt1c9Tt+PfnNKlCjh/x5U1VYl4IF2797t3q80ab0iRYq44xC5Tcm3337rP1a6xlq3bh0h7bHdU6ZOnerug3qv9kf7Nnbs2FiPGVI3SiyA//0YiX74k6pBtjKkqs6hzIYyKVOmTLG2bdu6jKl+8K+55hrXdkLF7tddd53LfEj16tXdD55+EDp16uQyTvqhia/hw4e7qh76sTp8+LC99NJLLvOlQMKjH1n9eOnmr4yB1p80aZI1bdrU/UgpM3GxKjnaN2UwH3vsMVetbNWqVW77d9xxR4KOm9KjgEgBhn7A49NIWZkzHV9l8B588EGrVKmSa6MyevRo+/PPP13j9/jSj6C2qeOmTKJ+KPXD/fXXX7sf2UDK8E2bNs0dE/1YK/OmgO3nn3927XSUCdQPvYIPff+BNE8ZoPr160d4yqqMjDJiyiQpU3IxCk6OHj3qMqT6cdf3fcstt7gAV6Ucmq9qFMrc6bxLyDZEGYuGDRu6tkn9+/d3mQ59Z+3atbPPPvssyr5FprZEuhY2b94c4/erjPG4cePs4YcfdttTGrxr42LHR5k4fV8K4rp27eqqiqj9kgJ0taHSuRATBS3Dhg1zJZg6748cOeIyk8uWLXPXZ2x69uxphQsXdsGJqlcqU67rePHixS6j9+KLL7pqIy+//LI7H7zrXXS8lTlUZk/nj47N66+/bsuXL3dBvo69Msn6DN0LVEVSFIBEToPuYbqWdU/Te3Qt6bwM3E+lsXnz5u74qkqYjrUCSO+z5J133nHp0n2sV69e7hzQsVUwqfM4vtedzps2bdq471BVUXWN6EFHXB9iBIrLuaz7mO5JSpM+S+meM2eOu9+VKVPGHQdluPVwROezvueYzkeVKqsjDZ2XOuf1ver4fv7557GmdeDAgS6w0H1ckz5H29L9JJCOr46V7i8KWvQbMmHCBPegR0GRAkAdWx07bVP75T0Q03ckn3zyifvN0feq3xzde7R/O3bscMs87du3d9+Hzhfts/ZPx3Lbtm3+Y6DjqnZ+usZUmq/t6jzR9abzUutd7HvQPP1+6YGW3i8K4PR96/cCIcwHhJFJkybpUaFvzpw5vn379vm2b9/u+/TTT30FChTwZcqUyb0OdO211/qqVKkS78/p1auX+5wFCxb45x09etRXunRpX6lSpXznz5/3z9d63bt3j/D+zZs3u/kvv/xytOnX8sA0avLMmzfPrVOpUiXf6dOn/fPHjh3r5q9evdq9vnDhgq98+fK+li1bur89J06ccOm87rrrLrqPN910U6zHpnPnzr6SJUtGmT9o0CCXlkB6nTZtWt/atWt9cRF5v9977z33/sBjLuPHj3fbXrRoUbzTqmMR6MyZM76qVav6mjZtGiXtmn799Vf/vK1bt/oyZ87su/nmm/3zBgwY4M6zQ4cO+eft3bvXlz59endMAtOi7fXv3z/WdHrnSr58+XwHDhzwz//yyy/d/P/+97/+eTrPorvtx2cbzZo181WrVs136tQp/zydPw0aNHDnU2y8fQs8h6Oj61PrBR6X2I7P9OnT3fyhQ4dGmN+hQwdfmjRpfBs3bvTP0zHUdjxXXHGFr3Xr1r748q7JyNdR/fr13Wd269bNP+/cuXO+YsWKRThvdb7q/R988EGE7c6cOTPKfF1vge+NnIbmzZtHSEPv3r196dKl859vOtcyZszoa9GiRYR70Ouvv+7e/+677/rP84IFC/pq1KgR4R7y1ltvufUSct2NHj3avdb3mhRiO5dz5szp9jeQ9kf79c8///jnrVy50qX/nnvuifE++8UXX7jXv/zyS7zS6B1vnVeB38tTTz3lthd4/ul6CvxOvH3R/eK5557zz1Ma9F6lMbLI9ysZNmyYOw91P5KDBw9G+9sSSL9VuXPn9j3wwAMR5u/evduXK1euCPNj+h4ee+wx9x3onEd4oSoUwpKe1unpk5686Ym7nrqqKoeKhpOCnkzqqaee7nj0pFFPmfSkyyuWDyY9/QysU+w93dKTMVGvIurSVqUL//zzj+3fv99Nqkqip0yqxnOxRsJ6aqcnYdFVlUkoPZ2rXLlygt6rJ3J6olexYkX/vmhS6YvoKXZ8qcqDR9VSVPKj46injpGptEElPx49pVb1Aj0xP3/+vJunp9SqHhJYnUpPk/X0/a677oqyTT15jKvbbrstQolb5O87Kbah6hoqVVI7JJVseMdY54+ebOp8iq53tUB6Mq9YLCm6zI18fHTdqW68nvoHUtUofaaqdlzsfNZTXO1DQqiEJLAaSL169dxnar5HaVO1scDvROetqiGqVCTwvNW5pHtGfM5b3V8C06DvT+fe1q1b3Ws9sdeTcpVABDZcf+CBB1xVFa+qpkpq9BS7W7duEe4hqvqitCbkuvPai3355ZcJ7nwgPvRU3qtO51XB0z1P+6DSC49KUHTsde7ExEu7SiovVoUvMu94q2Qg8HvR8Y9MpSred6LvTNeUV10suvtNbPcr3cf1Pag0Q+ehShm8dfSdqlpVYFW7yKUNqhqnEofA71Tnr87ruJyTOmZKQ2xVCRF6CCwQllQvVDc8ZfBUPK2bZlI25tQPuX4QItMPsLc82JSxDeRlGL0fEy8DpeJu/QAHThMnTnQZYGWkY/Lkk0+6Hz4FUKqXrnraCanWEEhVABJK+6OMYeR9ufzyy91yZZTiSxkJtY1RvXdlRrwqOtEdFx2DyPTZqkLg1XNX5kt1pFX1yaO/9Rmqnx5IXSHHJ9CN7ftOim2o6ooyKc8++2yU46zqNwk9zgkR3fHRdaUqI6rTHd/rTlVMlJnSd6a64Ko+pap9CT12XgY8sNqQNz/wO9F5q/OpYMGCUY7psWPH4nU8Y/v+vP2PfG9SRlPVg7zl3v+Rz2lVk9J6CbnuFLSqypGqmqkKl3pdUhW6YAUZke8lMe27d354D1VieuChQEVVyFRFUw8MVNUqtrZbMR1HHZ/I1W51HFR9TOvqt0ifo/V0Dl7sPhxIVZm8wEn3Zr1faRdvG9q2qiYpyNb3oCq5qvKodhce77dBwWHk71W9EMblnHzkkUfcOaCqZ7pO1R4lvm3mkDrRxgJhSZlhr1co1Q1XyYKe3Ku+cULaM6REMfVq4jUc9X7QVec7pm4LL3Ys9GOs46XMt34wVL9e7QpU/9frJjS6xsHiPcG/2BO3+NL+KEM4atSoaJdHzuDFRm1MVHdcP7zaLzVwVMZKGYrABurxpVIL1TFWaY8yJqqPr/r0F3uCmRTfd1KeM2q3oxKK6EQOkIIlvscnNvqe1RhcT9SVeVJwrYze+PHjXWY4occuuvmB34mOqYKKwGAzUOBT90txDgTrutO1rVJQPe1WyYjuGSqtU+ZVxzupe2FKzL0kMt3H9BBK1+p///tfVwqpjPLIkSPdvKT4zVAbHAXs2u7zzz/vggOd3yrdiEvwpXuqSl5UqqiHPnqIoZJ4lSAq2AjchrZ54403ujYd2hd9rtoXqTSyZs2a/nXVbkLthqIL6mOjc1olRNq+ghhNunfq/qc2VghdBBYIe/pB001VvXUog6fGeYmlXp2U6Y5MveF4y5ObGguLqkCoalhC6IdLTyI1qchfjWzVE5Ua6Oopv57KRdfbTDBKbLQ/6kFF1bhiCmjiQ4GS9kE/jIGlWfpxjE50VWjUeFWNigMzh3pSq557PvroI9d4VMGKjt+lkNjj4j2tVpoTes4EM626rlT9RNW0Akst4nrdKTOnKoSaVFqgYEONfOMSWCTmvFWa9TQ/tsxwYr8/b/91bwosedC1qwbj3nfqradz2qvSJKoGpPWuuOKKBF13yihrPU0KRJSZVkN0BRvxPZ/ieywC9z0ynR8qIYitu2KVLGrSPU4PF9Spgzp0iOn8CDyOgcdbJZiRSxIVuOg3SI3mA+n+qbTFtt9qMK/7jTLtgR0DxFQVSd+bqghqUvr0cEmB0vvvv+//bVBwENv3crHvQSVhCmA0KVhRKYYapCuQuVQPIHDpURUK+F+XrSrFUC8q6kkksVS9Sj1yeN2HiorZ1VOM6pYntB1BUlIdbv2AqEcdZaIii66bykCqAxz5R0T7paejXj1kbV9F8IFVSlTXObouVxNL9f71dE69VUWmDHxM1RwuFnDqRzOwdEXtY2LqXUrfdWBd6O3bt7un3+oBJvBprDIJqh6gH3A9pVbPUYEZh2DyMk7RBXtxoYyGrhVlDvQ9xveciWt3s+L1ghWftOq60/cVuQRIJQ/6LnXc43o+6ym0Mj8J7ao4Puet0qyn1JGp7U3g/uv7S+h3J8ok6jp99dVXI5RiKDOr69Tr6UyluQqGVVoT2HuR2sdE/vy4Xnd6kh6ZV1KakGMc33NZJY76PGW8A9+jQVFVYqJzJyYKAiKX+sQl7TreCsLVM1Pg+/U7E5nuEZE/Q+1XIrdZimm/vXtM4Db0d+TuXVU1M/JvnO7TCsS9fVFppB44KfCL7joNvM5jSk/k60lBpderW7CvKSQvSiyA/1GdanX1px9PNVoMvImqu8Do6vB6fedHplIPPZFWRkYNSfUk1OtiU0/CU8KIv0qDqnsojerTXk9p1YWofsj0BFE/LCr2j4kyzCom15NW1dVVV4LK0Clz4j0t1tN5Fcury1AdB6/LQtW9jWuDxLhSt72qs63vTulXupRhUyZW81Xy4FV/iwvth56qKuOvanKqV6y2OcpsRlf3Xl2I6gc5sLtZ8aqFBdITRXUaINFlKIPFa1yuNCqtyozoO4oPHQNVHVT1FzX61ZNYdY2pwErVuwL73U9od7Oip/cKVFVdRueLriEdY00x0ZNRPfXVU3AFgXqyrkyjAjxV//CexEZHn6WgScdIn6UGzHqKrO5ag0l14NVtp0pNVXVE15Uyo3qKrIylMobeuaK06frR/UjnoQK9wBKF2ChY0PHXOanzWlX99ARf56ra/ngdCOjz9RlKl7avEjV9Xyqti9zGIq7XndqwqCqUris9ydf1pM9V/fvATi70Hajr5tiqbyXkXFa1T93v1NGCGtV73c2q3cvFRo7W+aq06j6mc0glYgqkdI+8WECi461qg/pu1dWu1lUjalULivwwQct1jHQfVoNrlUDowUPk463PV8NoBX26zypjrwbVqvqkZfo83cOVNv3WRC4ZUamGSowUEOqcV7UmPejRNewdP71X55m+21q1arn52he14VA1Nn3HXvAe0/egUhwFkzp/9B2rlFrHWgGZ1+YJISq5u6UCLiWvG8Houg1UV39ly5Z1k9dFnrpV9LoSjTyp282L2bRpk+vmUt32qdvRunXr+r7++uso6wWru9lPPvkk2m1G7qZw+fLlvltuucV1NaquDdUN56233ur7/vvvL7p/EyZM8F1zzTX+9+m49evXz3f48OEI682ePdt10apuFytUqOB7//33Y+xuNvJxuJjI++11kzlixAjXLafSlCdPHl/t2rV9Q4YMiZKuuHQ3+84777guVLWtihUrumN3sbRr37z1a9as6b6L6KgLT6VNXTeePHky2rRky5YtTumM6Vzx0hXYXavO6549e7ruldUFpbcf8dmGd26re87ChQv7MmTI4Lvssst8bdq0cV03J1V3s7J48WL3/encCUzHxY6PuspUN6tFixZ1adP3of0K7O4zuu5m1UWtrlFdr1myZHHf9wsvvODOqYTcU7zzJHL3qjGlXV25al/12Tly5HBd+j7xxBO+nTt3RujuU12Xanlgt68xpcG7F0Q+D9W9rPZPx6dQoUK+hx9+2HVDGtmbb77pup7W+VynTh3fjz/+mODrTvcTdVGt70Xfp/7v1KmT788//4ywLb1P51VsEnIui7oab9iwoTvO6g71xhtv9P3+++8Xvc8uW7bMpbVEiRJu/9Rlrc73wO6lY6LfFR2HIkWKuM9s3Lixb82aNVHOP3U327dvX/96SuOSJUuiPd7qBrpy5cqum+rAe7r2Q10OZ8+e3Zc/f37XLay60w1cZ//+/e5epe9f56HuQfXq1fN9/PHHUdKu80bdKGsd/YbpHt+lS5cI+x3T96B7gbo11rHS961j99BDD/l27doV6zFD6pZG/yR3cAMA4URVXNR7kZ6wR65TDYQrlQSotEhVhdTLHIDUJ/nrYwBAmFE7DVWxC2xkCYQ7VZVSdUxVsQOQOlFiAQCXyE8//eTaZ6hdhepYJ3U7EwAAkhMlFgBwiahBpEaLVqPb//znP8mdHAAAklTYBhbq2UQ9kqifevWooK5BASCY1OOY2leox6GL9W4EAEBqFJaBhbov1ABVgwYNclUR1CWhukmLyzD1AAAAAKIKyzYWKqFQn91eP8waEbJ48eLWs2fPJBl1GQAAAAg3YTdAnkYR/e2339wgQYEDhWmEzMBRkj0aITJwlEgFIRr0JV++fBcdyh4AAABI7VQGoe6g1U16bAP8hl1gsX//fjcqqEYKDqTXGik0Mo2YGd3IuQAAAEC42L59uxtJ/WLCLrCIL5VsqD2G5/Dhw1aiRAl3cDXsfXKoOmiWhZM1mbtaOLmq5MUv2lCy9I6lFiq4LkMb12XqxHUZusLpmkzu6/LIkSOuyUCOHDliXTfsAgv1HZ8uXTrbs2dPhPl6Xbhw4SjrZ8qUyU2RKahIrsAibaasFk5yZgqvKmfpsqSzcJFc11AwcF2GNq7L1InrMnSF0zWZUq7LuDQBCLteoTJmzGi1a9e277//PkK7Cb2uX79+sqYNAAAASK3CrsRCVLWpc+fOVqdOHatbt66NGTPGjh8/bvfee29yJw0AAABIlcIysLjtttts3759NnDgQNu9e7fVqFHDZs6cGaVBNwAAAIC4CcvAQnr06OEmAAAAAIkXdm0sAAAAACQ9AgsAAAAAiUZgAQAAACDRCCwAAAAAJBqBBQAAAIBEI7AAAAAAkGgEFgAAAAASjcACAAAAQKIRWAAAAABINAILAAAAAIlGYAEAAAAg0QgsAAAAACQagQUAAACARCOwAGJw9rwvuZMAAACQahBYANF4d/kZyz7sqPsfAAAAsUsfh3UQjbpv17V0WdJFmPfl7V9aubzlbOOBjXbT1Juifd/aR9a6/2dtnGV9ZveJsrxsnrL2Vaev3N9v/PyGvfnrm1HWOZChvOU9+8D//n7bTqVdHmWdHOdaWY7zbdzfezM+Z+fS7I6yTp6zXS3Lhdru752ZHok2vQXOPGMZfEXtbJqdti/j0GjXKXr63zSeTPubHczwTpTl6X2FreCZge7vo+m+tqPpv4myTuYLNWPcpyp2zP3/iGW07pbR/d3WTtgmuxBlO6Mss7X832ntvS+yLy2rlbO0ttEu2E12Isryg8t9tvsrn6m8outXp+wZO215aqaJsE5ZS2tfWVb39xt2xt60qAFIC0tvoy2z+7u3nbLZdi7KOtHt06a/N0RYp3DewpYjSw7394ZIyzwlCpawTBky2emzp23b3m3RrlP+svLu/6Mnj9ruA1HPh4zpM1rJQiXd3/8c+ccOHD0QZZ3sWbJbkbxF3N+7DuyyYyejHuO8OfJavpz53N9b92y1M+eiHpvAfaryZpVo03uprqcWZVrY6OtHu797z+xts/+aHWWdR+o8Yt3rdnd/t/2orW06uCnKOifT3pYqrqekukd411ds15Ostezu/1l2zvrYqSjLg3k9JdU9IvJ1mVKvp6S4R6SE62lUi1HWslzLRN8jzF5KFddTUt0jdE6nhuspKe4Rka/JlHo9HU2ie0RyXk/nT563uCKwSIW6Nixto69v7f7uPXOOzf4r6on/SJ2q1r3uv+u0/WiCbToY9QIb1aJewIn270Ud2Ze3Nwk40cZEu87aR/79nFkb01uf2dOiLC+bp5B91enfdd74eYu9+euPUdZpUeYi+7TXLhkFFbu+ilgFynsdObgIlrK5y0Z4Pap5HG4It8T+A7u68+qUk2kI2CcgNYh8XabU6ymp7hFIpQpWNMtT1ux/5579/IZZNOeelWlh9r9zz2b2Novm3LM6j5j979yzj9qaRXPuWYtRZt69PIZzz27/0ixvObMDG81iCgD/95DIdO5Fcz1Ft09lU9H11CeJ7hGpQRqfz0dF8ng4cuSI5cqVyw4fPmw5c+ZM7uSEh8G5LsnHqNrT/V+dciUVkSmkmNg2s91X89+nN0E1+HDwPwNJrlT/GRZOtmS+w8IK12WqFHbX5fB/H9AByZX3pY0FEEtQIZqv5bS5AAAAiB6BBcJebEGFh+ACAAAgZgQWsHDvUvbhGbEHFR6tp/XpihYAACAiAguEtQzp0ti41pldG4q40HpaX+8DAADA/yOwQNhTg2w1zI4tVLikDbgBAABSGQILIA7BBUEFAADAxRFYALEEFwQVAAAAsSOwAC4SXBBUAAAAxA0jbwOReEGEen9SQ22CCgAAgNgRWADRUDBxd/UM9P4EAAAQR1SFAmJAUAEAABB3BBYAAAAAEo3AAgAAAECiEVgAAAAASDQCCwAAAACJFjKBxZYtW6xr165WunRpy5Ili5UtW9YGDRpkZ86cibBOmjRpokxLly5N1rQDAAAAqV3IdDe7fv16u3Dhgk2YMMHKlStna9assQceeMCOHz9ur7zySoR158yZY1WqVPG/zpcvXzKkGAAAAAgdIRNYXH/99W7ylClTxv744w8bN25clMBCgUThwoWTIZUAAABAaAqZqlDROXz4sOXNmzfK/LZt21rBggWtUaNG9tVXXyVL2gAAAIBQEjIlFpFt3LjRXnvttQilFdmzZ7eRI0daw4YNLW3atPbZZ59Zu3btbPr06S7YiM7p06fd5Dly5MglST8AAACQmqT4Eov+/ftH2+A6cFL7ikB///23qxbVsWNH187Ckz9/fuvTp4/Vq1fPrrzyShs+fLjddddd9vLLL8f4+cOGDbNcuXL5p+LFiwd1fwEAAIDUKMWXWPTt29e6dOly0XXUnsKzc+dOa9KkiTVo0MDeeuutWLevIOO7776LcfmAAQNcMBJYYkFwAQAAAKSywKJAgQJuiguVVCioqF27tk2aNMlVd4rNihUrrEiRIjEuz5Qpk5sAAAAApOLAIq4UVDRu3NhKlizp2lXs27fPv8zrAWrKlCmWMWNGq1mzpnv9+eef27vvvmsTJ05MtnQDAAAAoSBkAgtVZ1KDbU3FihWLsMzn8/n/fv75523r1q2WPn16q1ixok2bNs06dOiQDCkGAAAAQkfIBBZqhxFbW4zOnTu7CQAAAECY9QoFAAAAIOUjsAAAAACQaAQWAAAAABKNwAIAAABAohFYAAAAAEg0AgsAAAAAiUZgAQAAACDRCCwAAAAAJBqBBQAAAIBEI7AAAAAAkGgEFgAAAAASjcACAAAAQKIRWAAAAABINAILAAAAAIlGYAEAAAAg0QgsAAAAACQagQUAAACARCOwAAAAAJBoBBYAAAAAEo3AAgAAAECiEVgAAAAASDQCCwAAAACJRmABAAAAINEILAAAAAAkGoEFAAAAgEQjsAAAAACQaAQWAAAAABKNwAIAAABAohFYAAAAAEg0AgsAAAAAiUZgAQAAACDRCCwAAAAAJBqBBQAAAIBEI7AAAAAAkGghFViUKlXK0qRJE2EaPnx4hHVWrVplV199tWXOnNmKFy9uL730UrKlFwAAAAgV6S3EPPfcc/bAAw/4X+fIkcP/95EjR6xFixbWvHlzGz9+vK1evdruu+8+y507tz344IPJlGIAAAAg9Qu5wEKBROHChaNd9sEHH9iZM2fs3XfftYwZM1qVKlVsxYoVNmrUKAILAAAAIBFCqiqUqOpTvnz5rGbNmvbyyy/buXPn/MuWLFli11xzjQsqPC1btrQ//vjDDh48GO32Tp8+7Uo6AicAAAAAIVxi8eijj1qtWrUsb968tnjxYhswYIDt2rXLlUjI7t27rXTp0hHeU6hQIf+yPHnyRNnmsGHDbMiQIZdoDwAAAIAwKrE4e/asbd++3T3pP3DggAVT//79ozTIjjytX7/erdunTx9r3LixVa9e3bp162YjR4601157zZU6JJSCk8OHD/sn7TcAAACABJZYHD161N5//32bOnWq/fzzz66tgs/ncxn7YsWKuUbRaqdw5ZVXWlLq27evdenS5aLrlClTJtr59erVc1WhtmzZYhUqVHBtL/bs2RNhHe91TO0yMmXK5CYAAAAAiQwsVJXohRdesLJly9qNN95oTz31lBUtWtSyZMniSizWrFljCxYscMGFMvMqJShfvrwlhQIFCrgpIdQwO23atFawYEH3un79+vb000+7EpcMGTK4ed99950LOqKrBgUAAAAgCQOLX375xX788UfXi1J06tat67ptVReukyZNckFGUgUWcaWG2T/99JM1adLE9Qyl171797a77rrLHzTccccdrr1E165d7cknn3QB0dixY2306NGXNK0AAABAWAYWH330UZw2pipDatuQHPTZqqY1ePBg16ZCjbQVWKjdhSdXrlw2e/Zs6969u9WuXdvy589vAwcOpKtZAAAAILl7hVL3q3PnznXViSpVqmTJRb1BLV26NNb11LBbJSoAAAAAkrFXqFtvvdVef/119/fJkyetTp06bp4y7J999lkSJg0AAABAyAYWamtx9dVXu7+/+OIL1zPUoUOH7NVXX7WhQ4cGI40AAAAAQi2w0FgOGoBOZs6cae3bt7esWbNa69atbcOGDcFIIwAAAIBQCyyKFy/uelw6fvy4CyzUxawcPHjQMmfOHIw0AgAAAAi1xtu9evWyO++807Jnz24lSpRwI117VaSqVasWjDQCAAAACLXA4pFHHnHjVmzfvt2uu+46NwCdN/o1bSwAAACA8JSg7mbVE5R6gdq8ebMbjTt9+vSujQUAAACA8BTvNhYnTpxwI1erwbZG4t62bZub37NnTxs+fHgw0ggAAAAg1AKLAQMG2MqVK23+/PkRGms3b97cpk2bltTpAwAAABCKVaGmT5/uAoirrrrK0qRJ45+v0otNmzYldfoAAAAAhGKJxb59+6xgwYJR5qv72cBAAwAAAED4SJuQhtszZszwv/aCiYkTJ1r9+vWTNnUAAAAAQrMq1Isvvmg33HCD/f7773bu3DkbO3as+3vx4sX2ww8/BCeVAAAAAEKrxKJRo0a2YsUKF1RoQLzZs2e7qlEajbt27drBSSUAAACA0BvHQmNXvP3220mfGgAAAAChG1gcOXIkzhvMmTNnYtIDAAAAIFQDi9y5c8e5x6fz588nNk0AAAAAQjGwmDdvnv/vLVu2WP/+/a1Lly7+XqDUvmLKlCk2bNiw4KUUAAAAQOoOLK699lr/388995yNGjXKOnXq5J/Xtm1b15D7rbfess6dOwcnpQAAAABCp1colU5oLIvINO/nn39OqnQBAAAACOXAonjx4tH2CKUB8rQMAAAAQPiJd3ezo0ePtvbt29u3335r9erVc/NUUrFhwwb77LPPgpFGAAAAAKFWYtGqVSsXRNx444124MABN+nvP//80y0DAAAAEH4SNEBesWLF7MUXX0z61AAAAAAIn8Di0KFD9s4779i6devc6ypVqth9991nuXLlSur0AQAAAAjFqlC//vqrlS1b1rW18KpCqftZzVu2bFlwUgkAAAAgtEosevfu7catUM9Q6dP/+/Zz587Z/fffb7169bIff/wxGOkEAAAAEEqBhUosAoMKt5H06e2JJ56IdnwLAAAAAKEv3lWhcubMadu2bYsyf/v27ZYjR46kShcAAACAUA4sbrvtNuvatatNmzbNBROapk6d6qpCderUKTipBAAAABBaVaFeeeUVS5Mmjd1zzz2ubYVkyJDBHn74YRs+fHgw0ggAAAAg1AKLjBkz2tixY23YsGG2adMmN089QmXNmjUY6QMAAAAQilWhPAokqlWrZiVLlrTZs2f7x7QAAAAAEH7iHVjceuut9vrrr7u/T5486XqC0rzq1avbZ599Zsll/vz5ropWdNMvv/zi1tmyZUu0y5cuXZps6QYAAADCMrDQOBVXX321+/uLL74wn8/nRuJ+9dVXbejQoZZcGjRoYLt27YowqUF56dKlo3SDO2fOnAjr1a5dO9nSDQAAAIRlG4vDhw9b3rx53d8zZ8609u3bu2pRrVu3tn79+llyUduPwoUL+1+fPXvWvvzyS+vZs6crlQiUL1++COsCAAAAuMQlFsWLF7clS5bY8ePHXWDRokULN//gwYOWOXNmSym++uor++eff+zee++NskwjhxcsWNAaNWrk1gMAAABwiUssevXqZXfeeadlz57dNdxu3Lixv4qUGnOnFO+88461bNnSihUr5p+nNI8cOdIaNmxoadOmdW1C2rVrZ9OnT3fBRnROnz7tJs+RI0cuSfoBAACAkA4sHnnkEatbt64bGO+6665zGXQpU6ZMUNpY9O/f30aMGHHRddQjVcWKFf2vd+zYYbNmzbKPP/44wnr58+e3Pn36+F9feeWVtnPnTnv55ZdjDCzUre6QIUMSvR8AAABAKIt3YCFqDB25QbTaWARD3759rUuXLhddR0FNoEmTJrl2FDEFC4Hq1atn3333XYzLBwwYECEYUYmFqoMBAAAAiGdgoYz1888/b9myZYuQyY7OqFGjLCkVKFDATXGlXqoUWGhkcI0IHpsVK1ZYkSJFYlyeKVMmNwEAAABIZGCxfPly18uS93dMIve+lBzmzp1rmzdvdl3NRjZlyhTXe1TNmjXd688//9zeffddmzhxYjKkFAAAAAizwGLevHnR/p0SqdG2xrQIbHMRSCUvW7dutfTp07t1pk2bZh06dLjk6QQAAAAs3NtYeNSAW1JSm4MPP/wwxmWdO3d2EwAAAIBkHsfi3Llz9uyzz1quXLmsVKlSbtLfzzzzjL+6FAAAAIDwEu8SC41krbYJL730ktWvX9/N04B5gwcPdgPSjRs3LhjpBAAAABBKgYWqGk2dOtVuuOEG/7zq1au76lCdOnUisAAAAADCULyrQqnrVVV/iqx06dKuxyUAAAAA4SfegUWPHj1cz0qnT5/2z9PfL7zwglsGAAAAIPzEuyqUxrH4/vvvrVixYnbFFVe4eStXrrQzZ85Ys2bN7JZbbvGvq7YYAAAAAEJfvAOL3LlzW/v27SPMS0ndzQIAAABIBYHFpEmTgpMSAAAAAOHTxsIby2LOnDk2YcIEO3r0qJu3c+dOO3bsWFKnDwAAAEAollhs3brVrr/+etu2bZtrtH3ddddZjhw5bMSIEe71+PHjg5NSAAAAAKFTYvHYY49ZnTp17ODBg5YlSxb//Jtvvtk16gYAAAAQfuJdYrFgwQJbvHhxlDErNLbF33//nZRpAwAAABCqJRYXLlyw8+fPR5m/Y8cOVyUKAAAAQPiJd2DRokULGzNmjP91mjRpXKPtQYMGWatWrZI6fQAAAABCsSrUyJEjrWXLlla5cmU7deqU3XHHHbZhwwbLnz+/ffTRR8FJJQAAAIDQCiw04rZG2p42bZr7X6UVXbt2tTvvvDNCY24AAAAA4SN9gt6UPr0LJDQBAAAAQIIGyAMAAACAQAQWAAAAABKNwAIAAABAohFYAAAAALj0jbfPnTtna9eutd27d7vXhQsXdl3PZsiQIfGpAQAAABDagYVG3B44cKC98cYbdvjw4QjLcuXKZT169LAhQ4ZY2rQUggAAAADhJs6BRf/+/W3y5Mk2fPhwN0BeoUKF3Pw9e/bY7Nmz7dlnn7UzZ87YiBEjgpleAAAAAKk5sPjPf/5j7733ngsqApUqVcoefPBBK1mypN1zzz0EFgAAAEAYinO9paNHj1rRokVjXF6kSBE7fvx4UqULAAAAQCgGFo0bN7bHH3/c9u/fH2WZ5j355JNuHQAAAADhJ85VocaPH2+tWrVyJRPVqlWL0MZi9erVrmeor7/+OphpBQAAAJDaA4vixYvbypUrbdasWbZ06VJ/d7N169a1F1980Vq0aEGPUAAAAECYitc4FgocbrjhBjcBAAAAgCfeRQwazyKm+du2bYvv5gAAAACEU2Bx5MgRu/XWWy1btmyufYUGyzt//rx/+b59+6x06dLBSicAAACAUKgKpQHw1MZCY1kcOnTIhg4dasuWLbPPP//cMmbM6Nbx+XzBTCsAAACA1F5iMX36dJswYYJ16NDB7r//fvv1119dKcWNN95op0+fduukSZMmmGkFAAAAkNoDCwURGl3bkz9/fpszZ44bOE/d0J44ccKC6YUXXrAGDRpY1qxZLXfu3NGuozYerVu3dusULFjQ+vXrZ+fOnYuwzvz5861WrVqWKVMmK1eunE2ePDmo6QYAAADCQZwDixIlSti6desizMuRI4fNnj3bTp48aTfffLMF05kzZ6xjx4728MMPR7tc7T0UVGi9xYsX25QpU1zQoLYgns2bN7t1mjRpYitWrLBevXq50hd1oQsAAADgEgQWGqdi0qRJUeZnz57dZcwzZ85swTRkyBDr3bu3G5wvOgpwfv/9d3v//fetRo0arkvc559/3t544w0XbHiD/KmB+ciRI61SpUrWo0cPV7Vr9OjRQU07AAAAEOrSxidjP3jw4GiXqeTiu+++s7lz51pyWbJkSYQRwaVly5auN6u1a9f612nevHmE92kdzY+J2o9oG4ETAAAAgAQGFnny5LEqVarEuFzBxbXXXmvJRSOBBwYV4r32RgmPaR0FC6rOFZ1hw4ZZrly5/JNGIAcAAACQgMBi6tSpFlfbt2+3RYsWxWnd/v37u56kLjatX7/ektOAAQPs8OHD/kn7BwAAACAB41iMGzfOVYW69957Xfeyap8QSBluBRNq36AqUe+8805cNmt9+/a1Ll26XHSdMmXKxGlbhQsXtp9//jnCvD179viXef978wLXyZkzp2XJkiXa7ar3KE0AAAAAEhlY/PDDD/bVV1/Za6+95p7ge6Nvq8H2wYMHXRUjdT+rIGHNmjVRqhvFpECBAm5KCvXr13dd0u7du9d1NSsKchQ0VK5c2b/ON998E+F9WkfzAQAAAFyCkbfbtm3rpv3799vChQtt69atrl2CAoqaNWu6KW3aODfZiDeNUXHgwAH3v7qWVXexorEo1DOVeq1SAHH33XfbSy+95IKdZ555xrp37+4vcejWrZu9/vrr9sQTT9h9993nGpt//PHHNmPGjKClGwAAAAgHcQ4sPAok2rVrZ5eaxqPQ2BQeBTIyb948a9y4saVLl86+/vprN86FSiBUqtK5c2d77rnn/O9RV7MKItRt7dixY61YsWI2ceJE1zMUAAAAgEsYWCQXDXYX2yjZGhk8clWnyBSELF++PIlTBwAAAIS34NVdAgAAABA2CCwAAAAAJBqBBQAAAIBEI7AAAAAAcOkbb6urVzWi/v77792YERcuXIiwXF24AgAAAAgv8Q4sHnvsMRdYtG7d2qpWrWpp0qQJTsoAAAAAhG5gMXXqVDeoXKtWrYKTIgAAAACh38YiY8aMbrRrAAAAAEhwYNG3b183arXP54vvWwEAAACEqHhXhVq4cKHNmzfPvv32W6tSpYplyJAhwvLPP/88KdMHAAAAIBQDi9y5c9vNN98cnNQAAAAASJXiHVhMmjQpOCkBAAAAEF4D5J07d87mzJljEyZMsKNHj7p5O3futGPHjiV1+gAAAACEYonF1q1b7frrr7dt27bZ6dOn7brrrrMcOXLYiBEj3Ovx48cHJ6UAAAAAQqfEQgPk1alTxw4ePGhZsmTxz1e7C43GDQAAACD8xLvEYsGCBbZ48WI3nkWgUqVK2d9//52UaQMAAAAQqiUWFy5csPPnz0eZv2PHDlclCgAAAED4iXdg0aJFCxszZoz/dZo0aVyj7UGDBlmrVq2SOn0AAAAAQrEq1MiRI61ly5ZWuXJlO3XqlN1xxx22YcMGy58/v3300UfBSSUAAACA0AosihUrZitXrrSpU6faqlWrXGlF165d7c4774zQmBsAAABA+Ih3YHH8+HHLli2b3XXXXcFJEQAAAIDQb2NRqFAhu++++2zhwoXBSREAAACA0A8s3n//fTtw4IA1bdrULr/8chs+fLgbdRsAAABA+Ip3YNGuXTubPn26G7OiW7du9uGHH1rJkiWtTZs29vnnn9u5c+eCk1IAAAAAoRNYeAoUKGB9+vRxDbhHjRplc+bMsQ4dOljRokVt4MCBduLEiaRNKQAAAIDQabzt2bNnj02ZMsUmT55sW7dudUGFeofSQHkjRoywpUuX2uzZs5M2tQAAAABCI7BQdadJkybZrFmz3FgWjzzyiOshKnfu3P51GjRoYJUqVUrqtAIAAAAIlcDi3nvvtdtvv90WLVpkV155ZbTrqDrU008/nRTpAwAAABCKgcWuXbssa9asF11HA+UNGjQoMekCAAAAEMqBhYKK8+fPu56h1q1b5+apStRNN91k6dKlC0YaAQAAAIRaYLFx40Zr1aqV6262QoUKbt6wYcOsePHiNmPGDCtbtmww0gkAAAAglLqbffTRR13wsH37dlu2bJmbtm3bZqVLl3bLAAAAAISfeJdY/PDDD64r2bx58/rn5cuXz43A3bBhw6ROHwAAAIBQLLHIlCmTHT16NMr8Y8eOWcaMGS1YXnjhBdeNrdp4BHZt61m5cqV16tTJVclS43F1dzt27NgI68yfP9/SpEkTZdq9e3fQ0g0AAACEg3iXWLRp08YefPBBe+edd6xu3bpu3k8//WTdunWztm3bWrCcOXPGOnbsaPXr13efHdlvv/1mBQsWtPfff98FF4sXL3bpVIPyHj16RFj3jz/+sJw5c/pf630AAAAALmFg8eqrr1rnzp1dBj9Dhgxu3rlz51xQEbmEICkNGTLE/a+RvqNz3333RXhdpkwZW7JkiRvQL3JgoUAiulIPAAAAAJcosFCG/Msvv7QNGzbY+vXr3TxVOypXrpylNIcPH47QFsRTo0YNO336tFWtWtUGDx5M2xAAAADgUgcWnvLly7sppVJVqGnTprkucD1FihSx8ePHW506dVxgMXHiRGvcuLGrylWrVq1ot6P1NHmOHDlySdIPAAAAhHRg4fP57NNPP7V58+bZ3r177cKFCxGWq+pRXPXv399GjBhx0XU0CF/FihXjlcY1a9a4Afs0+neLFi388zXuhjf2hqgx+KZNm2z06NH23nvvRbstjdHhVcMCAAAAkESBRa9evWzChAnWpEkTK1SokOtVKaH69u1rXbp0ueg6aisRH7///rs1a9bMNdx+5plnYl1fDdAXLlwY4/IBAwZYnz59IpRYqHE4AAAAgEQEFnqyr1IJjb6dWAUKFHBTUlm7dq01bdrUNS5X97RxsWLFCldF6mLd62oCAAAAkISBRa5cueJdipAUNLr3gQMH3P/nz593AYGo0Xj27Nld9ScFFS1btnQlDN7YFOpu1gtexowZ40YIr1Klip06dcq1sZg7d67Nnj37ku8PAAAAENaBhXpRUpuDd9991w1Ed6kMHDjQpkyZ4n9ds2ZN97/aeqgBttp97Nu3z41joclTsmRJ27Jli38sDFW/+vvvv91Ae9WrV7c5c+a4al0AAAAAEi6NT62x4+HkyZN2880326JFi6xUqVL+sSw8y5Yts1CmNhYqtVFXtoGD7CGIBueysDL4cHKnAAlQqv//90AXDrZkvsPCCtdlqhR21+Xw1smdBIR53jfeJRZqv6BRru+6665EN94GAAAAEBriHVhoXIhZs2ZZo0aNgpMiAAAAAKlO2vi+QV2tUgUIAAAAQKICi5EjR9oTTzzhbxANAAAAAPGuCqW2FSdOnLCyZcu6npUiN95Wl7AAAAAAwku8AwuNBQEAAAAAie4VCgAAAAAS1cYCAAAAACIjsAAAAACQaAQWAAAAABKNwAIAAADApQ0szp49a+nTp7c1a9Yk/pMBAAAAhGdgoTErSpQoYefPnw9eigAAAACEflWop59+2p566ikGwgMAAACQ8HEsXn/9ddu4caMVLVrUSpYsadmyZYuwfNmyZfHdJAAAAIBwCyzatWsXnJQAAAAACJ/AYtCgQcFJCQAAAIBUi+5mAQAAAFz6Eou0adNamjRpYlxOj1EAAABA+Il3YPHFF19EGdti+fLlNmXKFBsyZEhSpg0AAABAqAYWN910U5R5HTp0sCpVqti0adOsa9euSZU2AAAAAOHWxuKqq66y77//Pqk2BwAAACDcAouTJ0/aq6++apdddllSbA4AAABAqFeFypMnT4TG2z6fz44ePWpZs2a1999/P6nTBwAAACAUA4sxY8ZE6SWqQIECVq9ePRd0AAAAAAg/8Q4sOnfuHJyUAAAAAAifwEIOHTpk77zzjq1bt869Vo9Q9913n+XKlSup0wcAAAAgFBtv//rrr1a2bFkbPXq0HThwwE2jRo1y85YtWxacVAIAAAAIrRKL3r17W9u2be3tt9+29On/ffu5c+fs/vvvt169etmPP/4YjHQCAAAACKXAQiUWgUGF20j69PbEE09YnTp1kjp9AAAAAEKxKlTOnDlt27ZtUeZv377dcuTIkVTpAgAAABDKgcVtt91mXbt2tWnTprlgQtPUqVNdVahOnToFJ5UAAAAAQqsq1CuvvOIGyLvnnntc2wrJkCGDPfzwwzZ8+PBgpBEAAABAqAUWGTNmtLFjx9qwYcNs06ZNbp56hNLI2wAAAADCU7yrQmm8iqNHj7pAolq1am7S38ePH3fLguWFF16wBg0auM/KnTt3tOuoJCXypGpagebPn2+1atWyTJkyWbly5Wzy5MlBSzMAAAAQLuIdWEyZMsVOnjwZZb7m/ec//7FgOXPmjHXs2NFVubqYSZMm2a5du/xTu3bt/Ms2b95srVu3tiZNmtiKFStc97hqGzJr1qygpRsAAAAIB3GuCnXkyBHz+XxuUolF5syZ/cvOnz9v33zzjRUsWDBY6bQhQ4a4/2MrYVBpRuHChaNdNn78eCtdurSNHDnSva5UqZItXLjQDfbXsmXLIKQaAAAACA9xLrFQhj1v3ryuetHll19uefLk8U/58+d31aC6d+9uyU1pUHrq1q1r7777rguEPEuWLLHmzZtHWF8BhebH5PTp0y6oCpwAAAAAJLDEYt68eS6T3rRpU/vss89ckBHYoLtkyZJWtGhRS07PPfecS5/aYcyePdseeeQRO3bsmD366KNu+e7du61QoUIR3qPXChZUlStLlixRtqlG6l5pCQAASH4XLlxwVaRjc1mOdBZOTp06ldxJQCqlHl7TpUt36QKLa6+91t9OoUSJEq7kIrH69+9vI0aMuOg669ats4oVK8Zpe88++6z/75o1a7oG5S+//LI/sEiIAQMGWJ8+ffyvFYQUL148wdsDAAAJp4BCeREFF7EZ3CR4VbRTIh0XIKG85gSJyePHu7tZlUwsWLDAJkyYYH/99Zd98skndtlll9l7773n2i80atQoztvq27evdenS5aLrlClTxhKqXr169vzzz7vqTOoFSgdrz549EdbRa40mHl1pheh9mgAAQPJSzQl1zKInq3rIlzbtxWt0n8kSXtWXSxfOmdxJQCq9rk6cOGF79+51r4sUKXLpAgtVg7r77rvtzjvvtGXLlrlMuxw+fNhefPFF14g7rgoUKOCmYFHPT2oD4gUG9evXj5K+7777zs0HAAApmwbmVQZIVa/jMn5WmvThVTUosGMdID68B+wKLtQZU0KrRcW7u9mhQ4e63pXefvttVx/L07BhQxdoBMu2bdtcoKD/1QuV/takNhTy3//+1yZOnGhr1qyxjRs32rhx41yg07NnT/82unXr5kpZnnjiCVu/fr29+eab9vHHH1vv3r2Dlm4AAJA09Pvvte0EkLS8YP3s2bOXrsTijz/+sGuuuSbK/Fy5ctmhQ4csWAYOHOjG0AhsQ+E1Km/cuLELct544w0XJKhIR4PfjRo1yh544AH/e1RVa8aMGW4djR5erFgxF4zQ1SwAAKlHUrTzBJD011W8SyzUTkElApFpPIjEtIeIjcav8MbRCJwUVMj1119vy5cvd2NsqBRDpRkPPfRQlPqXWl/rqQrXpk2bYm3jAQAAkJwmvjbSnuzeNSjb3rJli8tQXuzh8NatW91QA17196T2wQcfuCr2SP3iHVioBOCxxx6zn376yZ2IO3fudCfE448/Huuo2AAAAIjZlx9/aLe2vDrCvPt79rURb7yTbGlSrRFVLY+pMxv11NWhQwcrVaqUyxtOnz49wnJVla9du7YbqkA9DzVo0MB+/PFH//JOnTrZzz//7B78IswCC3URe8cdd1izZs1cyYCqRd1///2udCCwPQMAAEnt7Pn/H/QUQPD9888/9vnnn8daoqBeQdVDqKqZR9ejqLahbR08eNA9jG7durUbQ0xUu0TbV9tXhFlgoUj06aeftgMHDriG0kuXLrV9+/a5bl29EwQAgKT27vIzln3YUfc/kJL9s2+v9Xv4Xmt8RTlrWa+qvTbiedejlfyyZKE1qlLSPpz0ljWrXdGa1qpgb44c5qp3r1uzyoY+1cc2rP/drqpQzE27/t5u40YNt15d/z9jf0XxPPbR5Lfs5qZXWb3LL7OnHnvIjhw6ZLfddpvrQl/tUNVJjUdtTsuXL285cuSwsmXL2uuvvx7nfZk1a5ZVqlQpwsDIkakxfa9evezqq6+OtjehfPnyueBCeUjtp9bRw2kNXOzRA2t1xIMwCywCT6LKlStb3bp1XcNpnbRqHA0AQFJTMHH/V6fszHlz/xNcICXr3/MBS58+vX2zeIVN+uwbmzv7G5s8bqx/+fFjx2zd6pX29cJl9s7H/7Xp0963/3461SpVrW7PvDjKylesbEv/2OGmIpdFPyjv/Nnf2uTPvrX//virLflxnt3XsbWrOaIHvzVq1HA9YHqUqZ87d64b5Fed1vTr188WLVoUp31Rm9W4DlQcG1WDUv6xXbt2ds8990TINypPqbHFNE4JUq849wqlBjuDBw924z7opNAJqxNj0qRJrgRD0SfdtgIAghVUeJWg9L9ey3016XYUZlXerBLt/BGN37MSOcvYtiN/2WPfRV+V54v2S9z/i3Z8b6/89EyU5cVzlrJXr/sozmnZs2un/bzoR5u77A/Lmi27mx7o0cfGjR7h2kqIRg3v9dRgy5Ilq5Uud7nd3uUB+/rzada2Y6c4f849D/awXHnyuL/rXNXQVSfyBinu2LGjPfjgg/5127dv7/+7SZMmrjfM+fPnu6ECYqOqSyoFSQpqIK7aLRoT7dSpiGOMeJ+hz0vMAG1IJYGFGu5otO3mzZvb4sWL3Ul77733uqpQKq3Q64QOpgEAQFyCCg/BBVKqPbt3WqZMmS1fgYL+ecVKlrK9u3b6X7vl+f9/gGCVSuzdHb8n9YHbz5w5i+XIlSvCeATeOF+iTnZGjhzpeoBSUKNBBuNay0QDDQdWWVqwYIHdcMMN/teBnxPXgdjuuusuq1KliisJ8YIhlaZ4n4cwCCw++eQT+89//mNt27Z1bSuqV6/u6guuXLmS/qQBAJcsqPAQXMCz9pG10c5ftePfLlRVauGVTMSkYbFmbkqsQoWL2unTp1w7Cy/z//f2bVawSFH/Om75/n3+4GL3zh1WsPC/T+kjd5OfWBpYuHPnzjZz5kzX5b6qaKnGido6xIWqVY0ZM8b/Wu0o4htMREeDsG3YsMEfWPz+++9WqFAhSitSuTifvTt27HBdhUnVqlVdl2Oq+kRQAQC41EFF5OCCNhdIKQoVKWpXNrjaRg591k6cOO4aX2scirYdbvevo+Dh1eHP2amTJ23Lpg02bcpEa9Wuo1uWN38B27d3j1uWFBQEKIgoWLCg+9xvvvnGZs+eHef3t2jRwtatW+eqKMVWZV7Vm/RZChr0tzdS+tdff22rVq1yD6RVWvLiiy+6fGXggMtqA6KeohAmgYVODrWt8CjizZ49e7DSBQAI4y5lH54Re1Dh0Xpan65okVIMf+1tO33qlN1wVXXrfPP1dnWzFtbl4cf8y7Nlz24VqlSz1o1q2r0dWlub9rf721fUbXiNVa9Zx667srLrPUqBSWKoUbTawjZt2tT1zjRt2jRX+ySu8ufPbzfffLOrTnUxFSpUcNWcVEJy6623ur/V/azs37/fVZlX4+0SJUq49rozZsxwPVSJqmdp+927d0/UviL5pfHFsSxMUa7q1HmDo6hLMJ2k2bJli7Ce+ikOZaoDmCtXLjt8+HCSNWZCLAb/f73RsDD4cHKnAAlQqv8MCydbMt+RIkosROXmE9tmDm51KK7LFEFPwTdv3uzaB2TOnDnW9b2qUCmJupvtff+dtnDt1iTfdvViuS0Y1DZDJRerV6+OcZC8xPjwww9doBFb8ILkub7ik/eNcxsL1c8LpIY3AAAEgxckxBZcXJKgAghzGlH7zz//DNr2NfCyJqR+cQ4s1K0sAAApJbggqACAlCVpux4AACAJKWhQ8BC5mxCCCqRWV9ZvFJRqUEBKQGABAEhVwQVBBQCk8qpQAAAkFy+IUO9P41oTVABASkRgAQBIFRRM3F09g2VIx/hJAJASURUKAJBqEFQAQMpFYAEAAAAg0QgsAABAWDl79qylVF9+/KHd2vJq/+ubm9W3H+bMjHH9ia+NtCe7d7WUokaNGjZ58uTkTgaSCYEFAAAIG19Mfd/qVyjm/k8Nvvh+iV3b/Ppogw65v2dfG/HGO8mUOnjmz59vuXMHZ+TzpBzocPr06UH9DBpvAwCAsKBgYvATj5r5fP/+rxKB2+9K7mQhlUvJJWCXGiUWAAAgrIIK53/BRTBKLm6oX93efvUVu+2Ga61BpRLW7c72tnf3Lv/ybZv/cvOurlraWjesae9PHHfRbc2dOcPWrVllQ5/qYxvW/25XVSjmpl1/b7dxo4Zbr653+tdfu3atXXXVVZYjRw5r0qSJPfHEE9a4cWO3bMuWLZYmTRo7dOiQf/1evXpZly5d/K83bdpkN954oxUoUMBKlixpQ4cOtQsXLsSYvtdff92KFy9u+fLls6effjrK8jlz5ljdunXd0/wqVarYV199FeO29DmvvvqqVaxY0aW/fPnyNnPmTH/mfcCAAVaiRAmXtttuu8327dvnf6/2S2mpXLmyZcuWze6++247ePCgWy9nzpxWs2ZNW79+fYSn9y+88ILVqlXLLW/ZsqXt3LnTv3zjxo1uXt68ea1s2bI2ZswY/zJV9VKVr0GDBlnhwoWtRYsWdsMNN9jhw4cte/bsblqwYEGs+6/j3rVrV+vQoYN7j5avWbPGJkyYYMWKFXP7+eabb0Y4RlOnTrXq1au77V155ZW2ePFi/zJ9zzpGSreOn/Zt9erVblnHjh1t27Zt1qlTJ/dZ3bp1s2AgsAAAAOEVVHiCGFx8PvU9G/7a2/b9svWWv2BBe+qxh9z8c+fOWc97b7cKlavYnF/X2eiJ79nkca/aN198ctHtVapa3Z55cZSVr1jZlv6xw01FLiseYR1tu23bttasWTP7559/7MUXX7SJEyfGOc0nTpxw79X0999/u8yxMrKTJk2Kdv25c+e6YOLjjz+2Xbv+DZyUMfasWrXKZWiHDx9uBw4ccBlmZfj/+OOPaLenwEAZ+A8++MCOHDli33//vQtuZNiwYfb111/bwoULbfPmzS6QuPPO/w+o5Msvv3TLN2zYYLNnz7Zrr73Wevbs6T5bgYCCrEA6Nh9++KHt3r3bBQh33XWX/zi2adPGrrjiChdsfPHFF/bSSy+5dT3az/Tp07vM+owZM+zbb7+1XLly2bFjx9x09dVXx2n/P/nkE+vdu7cL9hQo3HTTTS64++uvv9yx17I9e/a4db/55ht7/PHHXWCj7SmIUBCo79rz3nvvubQqqKpTp47bf+9zFJR99NFHLn3jx4+3YCCwAAAA4RdUBDm4uPXu+6x0ucstS5as1vupIfbL4gW2Z9fftnr5r7Z/727r0e8Zy5Q5s11eqard3uV++/KTjxL9mUuWLLH9+/fb4MGDLWPGjFa/fn33xD6ulEHOkyePK8XQ+5URfeyxxyJkqAMpAFDmXp+j9fW5Ki3wKCOtp/JNmza1tGnTWqNGjVyGXYFIdMaNG+e2Ubt2bRc46PMrVarkzzA/88wzbp6euI8aNcq+++67CKUMynSrhKFo0aIuqFAJgD5TAYAy+MuWLYvweQ8//LArHcmaNavLjM+bN8927NhhP/30kwuUVFqTOXNmV0LQo0ePCI3SFUQoqNJ+6/3RmRCH/W/durU1bNjQpfHWW291pUpDhgxx21WAp8/xSh3eeOMN69evnyuJ0PZuueUWl34FHB4FRwqItL3OnTvbb7/9ZpcSbSwAAEB4BhWeILS5CCxNyFegoGXMlMn27N5le3bttAKFiliGjP8/evxlJUrZjFhKLOJCmWxlqjNkyOCfpyf+69ati9P7lanVk/jARsiqnqSqTjF9nlfNSvS5RYoUibA9lWoElnioNEBVj6KzdetWV/0pOsrwq/qSR/uZKVMmN19/S6FChfzLldkP3A+91pP6QF5piPdebU8lNd42lbn3lClTxt5///+Dz8suu8xl7i9mSxz2P3KaVYUpS5Ys0aZb23vqqadcFSyPqogpzR6VvHgU5EXe52AjsAAAACFHGa4Xnuobe1Dh8fnc+m3a3xYhY55Qav/g+Wf/Pjtz+rQVKlzEzp87Z/v27HLp8z5n545tVrDwv5nji4ktI6vMsDL7gdtWVR2PnvR7VZ68TLeezHsZWQUQKi1YunRpnPZRn6dgwKPP9apEedtTiYeqAsWFMvpq26ASkMjU5kAZ63r16rnXqr50+vRpNz+hAtO+d+9etz0FDMr8Rz6O+uzAz4r8XUT33RSP5/7HRttT1aaEto+I7fxJClSFAgAAIUcZwqdfHKlWvXF7Q5o0bv2kCCrk0/cn25ZNG+zUyZM25sXBVrteAytU5DKrWqO25c1f0N4c+aILNtQY+6NJb1vbjrfHus28+QvYvr173Dajo0bbqgr0/PPP25kzZ1yVnmnTpvmX58+f31UlmjJliiuJUNWfwGo0qqaj+vxqMHzq1Ck7f/68aw+grlSjo4bAqg6lz9HnPffcc3b8+HH/8oceesg9rdfnaFvKuKu6VkwlKFpf1YBWrFhhPp/PBUXeuqriozYj27dvd0/h+/TpY82bN/eXViSEqipp/06ePGlPPvmkXXPNNS54UGNrlSQMHDjQpVmlOK+99pqrWhQTrX/06FEXoCR0/2PTvXt3e/nll131Jh0fBYhqHK4SlrhQGtV+I5gILAAAQEhStabBL70ae3CRJo1bLym7nm132532ZI/7rWmtCq5HqGGvveXmK3B5bfJU+33VSmtau4I91vUOu/uBR6xVu46xbrNuw2uses06dt2Vla1RlZIRSkW8bavXoVmzZrkAo3///nbfffdFWOfdd991mV3V3VfG+vbbb49QoqGMqhpNq9qRenq64447XOlAdJSxVxDTvn17VwVKwUrVqlX9y9UTkxoLq22EejhSacCzzz7rMtjRefTRR127B7U1UJUgbd8rcfF6O1JphtKm0oTAqkkJoWOj4EgZblUnUpDkHUc1FFcGXlWL1CBegYyORUwqVKjgenhSr1QqDVIj8vjuf2zUUFulHw888IBrC1O6dGkbO3bsRXvtCqRqVGogr/Q98sgjFgxpfAp5EGfqpUAXo7oUi6mOIJLY4FwWVgYfTu4UIAFK9Z9h4WRL5ph/YEMS12WKoKfo6hFIGSo1qo3Nqh2HYm9rEYSgQl3E9hs0zJpe39ouperFog7Qpl6WNChaTKUO4UrBiY5Nu3btkjspKf76ik/elxILAAAQniUXQQgqgHBGYAEAAMIvuCCoAJIcvUIBAICw4AUR6v1JDbWDFVR8u2SVpRQak0ITIlIvT0h6BBYAACBsKJhIqi5lAaTSqlAvvPCCNWjQIMqAJx6NhqhRGqObvK6/1HApuuUx9XYAAABCD0EFEOYlFuofWcOxq5uxd955J8pyDVl//fXXR5inYdTVwr1gwYIR5qvP4sBW7ZGXAwAAAAjRwEIDpnglE9HRqJGBQ6Dv27fPDaMeXRCiQCK6Ug8AAAAAIV4VKr7+85//uGpTHTp0iLKsRo0abiCX6667zhYtWpQs6QMAAABCSaopsYgvlVRohMTAUgwFE+PHj7c6deq4UQ8nTpxojRs3dkPR16pVK9rtaL3AERI1SAgAAACAFFRioaHmY2pw7U3r16+P93aXLFli69atc0OrRx5u/aGHHrLatWu7huAa1l7/jx49OsZtDRs2zI026E3FixdP0L4CAADExbhRw61X1zuDsu0XX3zROnXqZJfS4MGDk2yE6+RIP1JJiUXfvn1dA+uLKVOmTLy3q5IIVXdSABGbunXr2sKFC2NcPmDAAOvTp0+EEguCCwAAUo5S/WcE/TO+6tEwzut27djGVi77xdKnz+Aekha+rJg93PtJa9EmaTLXifHUU08l+TbPnz9vY8aMsUmTJtnmzZtdBzlXXHGF9evXz5o1a5bi048QCSwKFCjgpqR07Ngx+/jjj11JQ1ysWLHCVZGKSaZMmdwEAAAQV70GDLa77n/YfD6fLZg723o/cLdVrVHLihYrYanV2bNno+2q984777TVq1fbm2++aVdddZULpmbPnm2fffZZkgcWSNlSTePtbdu2uSBA/ysy1t+aFEgEmjZtmp07d87uuivqaJqKpr/88kvbuHGjrVmzxo1EqZ6junfvfgn3BAAAhAtlsq9p1tJy5MxlWzZt9M9ft3qldb31Rru6amlr06iWffbhlAjvO3/hvL34TD9rVKWktaxX1WZ+9bl/2eIf5lqnVk2sYeUS1qx2RTeS+KmTJ90yVe9u2rRplLxRxYoVo62WpDxRy5YtLW/evFa2bFmXV/KoJ07VABk0aJAVLlzYbr/99ij798MPP9gXX3xhX331lV177bXuYWzGjBmtTZs2LtCITlw+8/nnn3e9eBYqVCjC8sjp1/FV+9mqVau6kpK2bdva4cOH/ct//PFHq1atmuXIkcNuueUWV00+ttoyCIPAYuDAgVazZk13ciuY0N+afv311yiNtnXiRNedrMbCUPUrnWA6+VeuXGlz5swhmgYAAEFx4cIFmzfrGzt96pRVqFLNzdu/d489dMfNduvd99n8lRtt9MT3bdzI4fbTwh8iBA+16zWwH1b9ZT36PWNDnnjMjh876pZlzpzZBr401n5cvdmmfD7Tflmy0N57+w23TB3XqIr39u3b/dt677337O67746SNj2IVQCgaks7d+50AcJLL71kH374oX8dPYhNnz69e7Cr7UQ2a9YsV61cAUJcxOUz165d63r2/Pvvv11QpCpVmzZtinGbqqmiB8VK444dO/xtZw8ePOgCjd69e7u/77//fvvggw/ilE6EeGChCFbFiZEn9eoUaPHixTGeNE888YSLkk+ePGn//POPzZs3z5o0aXKJ9gAAAISLV4c/50obrrr8Muvz4N32wKN9LV/+f6t/f/35NKtVr4G1vPFmS5cunZWvWNluuvUO+2b6p/73V6p6hX95m/a32dmzZ2zrX/9mrvXeSlWru2XFSpayDnd2sV+X/tt9vp7wN2/e3J8X2rt3r3333XfRBhbqFXPXrl02dOhQF6xUr17devToEWHMMHVc8/TTT7tSCGX2I9O4YZdddlmcj0tcPjN//vzuQbCqXSmfV6pUKVdLJSbK33ljlLVv395+++23f4/z119bsWLF7L777nPBUatWrXiYHGSpJrAAAABILR7tP9AWrt1qP2/cZV/O/8X+++lU++T9SW7Zzu3bbOG871zg4U0fTnrL9u/d7X9//gIFI1T3USb8+PF/q3+vWbHMHuzUzprUvNwaVCphr4143g4e+Me//j333OMvXfjoo49cD5glSkRt26Gn+0WLFnVBQ2CnOZrvUdCQNm3M2UUFASpZiKu4fKaCo0DZsmWzo0f/La2JjqppRbeuSkQid7gT3XFA0iGwAAAACKISpctYoybX2Y/fz3KvCxW9zJq2bO0CD29asn67vfGfT+K0vf497rcr6zeyGYuW2+J126znk8+a+Xz+5TfddJPLqOvJfUzVoERP85X5VqNsz5YtW9x8z8WCClFbiZ9//tn++uuvOKU9Lp+ZVBTABFYJE1WXQvAQWAAAAATR3/8roShfobJ73eaW2+znxQtszjdfuQy2pvVrV7uSiLg4duyoawyeNWs2+2vDH/bxe+9GWK7BgTt06OCqMP3+++/WsWPHaLejthEqHVA7Vg0GrPYUr732mnXu3DnO+6aqSjfffLMLZhYsWOC2o/2ZOXNmtJ3jJMVnxlXr1q1dYKFqVmrboTSpLQaCh8ACAAAgiY0ZNtiuqlDMTV1uucHqNbrWHur1hFtWqEhRG/f+Z/bJ+5Otee2K1rTm5Tbsmcf9jbNj8+yw0TblrdfdtocO6GPXt70lyjqqDqWG1epBST0iRUdtGNQOQSUbqk6khs4au0sNwOND7TkUGHTr1s319KTqRmPHjnXtHYL1mXGhtEyfPt1eeeUV1/7irbfeckEWwwgETxqfWkAjzjRAnhoyqSszdWuGS2BwLgsrg/+/mzykHpdigK6UZEvmpM8EpGhclynCqVOn3ABspUuXdm0OYrNqxyELJ9WLRe0RE1Grbl1zzTWuNAdxu77ik/elxAIAAAAhSQP17d+/31WFmjp1qqsKpWEJEIIjbwMAAADBoipXGhn8xIkT7km8esmqVKlScicrZBFYAAAAICQNGDDATbg0qAoFAAAAINEILAAAAAAkGoEFAAAAgEQjsAAAAACQaAQWAAAAABKNwAIAACAV+OzDKdasdkU34va6NavswD/77f7b2lqDSiXs8W5dbPLkyVajRg3/+lWqVHGjXKc027Zts+zZs7sB1zwPPvigGylbo3Ej9aK7WQAAkLoNzhXt7OpJ+BGr7t8ar/WXLphv40ePsPVrV1u6dGntitp1reeTA61S1YSl6uzZszZiYH8b/8FnVqteAzfvrbGvWLp06Wzh2i2WNm1aWzZneoT3rF271lKiEiVK2LFjx/yvFy5caJ9++qkb9VkjPCP1osQCAAAgCc2f/Y31uv8uu7HD7fb9b+vs28WrrHa9BnZfh9aupCEh/tm3x06fPmXlKlbxz/t7+1Yre3lFF1SkZgooFGwQVKR+qftMBAAASEF8Pp+NGDzA7nukl7W/o7Nly57DcubObV179LEWbdrZ6BcGxvjebZv/sm53trerq5a21g1r2vsTx7n5CkZualzP/d2ibhW3TFWfvv5sqk37zzuuatTnU9+Lsr1SpUrZ9On/lmJ41aSef/55K1iwoBUqVMjGjBkTYf2pU6da9erVLXfu3HbllVfa4sWLY0xr48aN3cBzLVu2tBw5clitWrVs9erV/uWjRo2y8uXLu2Vly5a1119/3b9sy5YtliZNGjt06JC9+uqr9sADD7j3qnpUly5d4nW8kbIQWAAAACSRrX9ttJ3bt1mrdh2iLNO835YustOnTkVZdu7cOet57+1WoXIVm/PrOhs98T2bPO5V++aLT1z1qc+/X+LWm/3zWpuxaLm9Mn6ytWrX0W67p6st/WOH3XL73bGmTVWjsmbNan///bdNmzbN+vXrZ5s2bXLLvvnmG3v88cddAHLgwAEXNNx44432zz//xLi99957z1566SU7ePCg1alTx3r27OlfVrJkSZs7d64dOXLEJk6c6D5r0aJFUbbx6KOP2vjx461atWquepQ+H6kXgQUAAEASOXjg34x4gUJRGyFrngKIw4cORlm2evmvtn/vbuvR7xnLlDmzXV6pqt3e5X778pOPkixt+fPnt759+1qGDBlciYNKNFasWOGWvfHGGy7zr5IHVa265ZZbrGLFii7giMldd91lV1xxhaVPn946d+5sv/32m39Z+/btrXjx4q5kokmTJq5kY/78+Um2L0iZCCwAAACSSJ68+dz/+/bsjrJM85TR9tYJtGfXTitQqIhlyJjRP++yEqVs7+6dSZY2VX8KlC1bNjt69Ki/etJTTz3lqkF5k4IOlW7EJLAHJ20rsEH2Bx984IIU9fSkbSlA2b9/f5LtC1ImAgsAAIAkUrJMOStarLh9++WnUZZ9++VndkWduhGCB0+hIkVt355drvcnz84d26xg4aJ2Kah0YeTIka7dgzcdP37c+vfvn6DuZFWCoWpSe/fuddtq1aqVa3+C0EZgAQAAkERUIvH4wBftnTfGuAbVJ44fsyOHD9u7b46xGV987Ko6RadqjdqWN39Be3Pki3bm9GnbsP53+2jS29a24+2XJN3du3e3l19+2VVnUgBw4sQJmzNnju3YsSPe21LJhbahRuKqVqXSitmzZwcl3UhZGMcCAAAgCTW7oY1lyfofe2vsy/bSoAF28sRxy5Mvv70+eZpdWb9RtO9Ru4fXJk+1Yc88YU1rV7CcuXLb3Q884hpoXwpqqH3q1CnXQ9Nff/1lmTJlsrp167q2Fxdz4cKFKN3dVq5c2Z5++mlr2rSpnT9/3tq2besmhL40Psql4kW9G6ifZY0WmTNnzuROTlgPfBSyBv//SKRIPUr1n2HhZEvmOyyscF2mCMr4asyD0qVLW+bMmWNdf9WOQ5YSbPpzvXXt2Mb6DX7RWt98a9A+p3qx3HYpqc3E1q1bXQ9QahiO0Ly+4pP3pSoUAABAEGkQu9enfOy6oT1x4riFAgUVavCt59P6n4bZEKpCAQAABFnVGrXcFEpBRSDvNSUX4Y0SCwAAACQ4qPBQcgECCwAAACQqqPAQXIQ3AgsAAAAkOqjwEFyELwILAAAAXLRLWfX+FB9aX+9DeCGwAAAAQIw0ToW6lI0PrR95fAuEPr5xAAAAXJR6eypVqlSc1tV69A4VnggsAAAAkCTBBUFFeGMcCwAAkKpVm1It6J/xQbMFlhqkSZPGli9fbjVq1LAXX3zRVq9ebR999FGSbd8LGqJryE1QgVRRYqGTt2vXrm6I8SxZsljZsmVt0KBBdubMmQjrrVq1yq6++mo3DHnx4sXtpZdeirKtTz75xCpWrOjWqVatmn3zzTeXcE8AAECo69qxjdUpW8iuqlDM6lcsbjc3q2+zv57uX37o4AEbPvBJu/6qam6dG+pXt2d7P2Jb/troX+f3VSvskbs7WMPKJdw697ZvZT8t+jFe6XjqqaciBBUKOlasWBGUkguCCqSawGL9+vWuZ4EJEybY2rVrbfTo0TZ+/Hh3wXiOHDliLVq0cI2FfvvtN3v55Zdt8ODB9tZbb/nXWbx4sXXq1MkFKYrm27Vr56Y1a9Yk054BAIBQ1GvAYFv6xw5bvG6b9X5qsA149EHbuWObHT1y2O5p19J27dhu497/zC2fNnOBVatZ2xbNm+Peu3blcruvYxurVbe+fbt4lc1dtt5u7HC79ep6p/34/SxLCbzgQsEKQQVSVVWo66+/3k2eMmXK2B9//GHjxo2zV155xc374IMPXAnGu+++axkzZrQqVaq4qHzUqFH24IMPunXGjh3rttOvXz/3+vnnn7fvvvvOXn/9dReoAAAAJCVlvK9p1tJy5MxlWzZttFXLfnG9JY186z+WPv2/2bCcuXLZrfd09b9n1NBn7fq2t9j9Pfv6593S6R7bt2ePvTRogNteXOgBq/JC06dPt7p167p5DRo0cJ+vh7OaNm3aZL169bKlS5da1qxZ7YEHHnDz49Kjk4KJvHnz0vsT/FLtmXD48GF3MnuWLFli11xzjQsqPC1btnQByMGDB/3rNG/ePMJ2tI7mx+T06dOuNCRwAgAAiAvVuJg36xs7feqUVahSzRb/8L01b9XWH1REdvLkCVv28xK7oV2HKMtatetg27dutm2b/4p3On7++Wd/7Y1jx4654OHEiRPWrFkzN/3999+2YMECmzp1qk2aNCnO2yWoQKorsYhs48aN9tprr/lLK2T37t2uDUagQoUK+ZflyZPH/e/NC1xH82MybNgwGzJkSJLvA+Jh8OHkTgEQqy3DW1t44bpEeKleLHec182WKb29NuI5e2vMCPeAUjUq1JC6SY3ydvzwQatVqWyM2/v77+MuGLn6isutYqR1yuer6P7Pm+5UvNITkxkzZrj8kUospESJEvbYY4/Zhx9+6KqNA/GVrGFm//79XRHhxSa1rwikiFrVmTp27OiK64JtwIABrnTEm7Zv3x70zwQAAKmbHkweOnTITp486WpPTJkyxbUVVfUh5WViooy+SgF27twZZZk3r0CBAu7/7Nmz+yeVNiSkcxy1M82dO7d/6tu370UfuAIptsRCJ2+XLl0uuo7aUwReUE2aNHH1AwMbZUvhwoVtz549EeZ5r7XsYut4y6OTKVMmNwEAACREuXLlrFWrVvb111+7Ktgff/yx690yuupQaufQsGFD15tT06ZNIyzTPJUqqHdMUZWm+NAD20DqQbN27dqufQWQ6kssFHGr69eLTV6bCUX3jRs3dheA6v5FrtNXv359+/HHH+3s2bP+eWqYXaFCBRf9e+t8//33Ed6ndTQfAAAgGFQyoO7t1c1979697fz583brrbfan3/+6ao9qUbE22+/7TqZEfVsqSBixIgRrtRDAYQ6p1F1qhdeeCHB7RpU/VuNtT1t2rRxD1jffPNNO3XqlEuXSlfmz5+fZPuOMONLBXbs2OErV66cr1mzZu7vXbt2+SfPoUOHfIUKFfLdfffdvjVr1vimTp3qy5o1q2/ChAn+dRYtWuRLnz6975VXXvGtW7fON2jQIF+GDBl8q1evjnNaDh8+7NNh0/8AAODSOXnypO/33393/6dk1157rS9jxoy+bNmyuemyyy7z9ezZ05/u/fv3+3r06OErXry4y6uUKFHC17lzZ9+GDRv82/jll198LVu29OXIkcOXNm1aX+bMmV3eJjbKoyxfvtz9rXzOTTfd5F/29ttv+4oWLerLnTu3b9iwYW7exo0bfbfccovLQ+XKlctXq1Yt30cffRSEo4LUen3FJ++bRv9YCjd58mS79957o10WmHwNkNe9e3f75ZdfXB3Gnj172pNPPhllgLxnnnnGPT0oX768G0RPxZNxpV6hcuXK5Z4u5MyZMxF7BQAA4kNP1Tdv3uw6a9FAt+Fi165drhq4us9X20/gUl5f8cn7porAIiUhsAAAIHmEa2AhGzZscL01devWLUoPl0BKCSxSZXezAAAA4US1LNTgG0jJGNUEAAAAQKIRWAAAAABINAILAACQqtA8FEh66vo4sWhjAQAAUoUMGTK4Qd727dvnxsKKPOAbgIQF6mfOnHHXlcZI8caQSwgCCwAAkCqkS5fOihUrZjt27HDdxgNIOhr1XSO7J3QARiGwAAAAqUb27NldD0lnz55N7qQAIRW0p0+fPtGlgAQWAAAg1WWCNAFIWWi8DQAAACDRCCwAAAAAJBpVoRLYxZ2GNwcAAABC2ZH/5Xnj0s0zgUU8HT161P1fvHjx5E4KAAAAcMnywLly5broOml8jDIT78FDdu7caTly5KD/7BCPzhU8bt++3XLmzJncyQHAdQmkOFyT4cHn87mgomjRorF2RUuJRTzpgKoPbYQH3Si5WQIpC9clkLJwTYa+XLGUVHhovA0AAAAg0QgsAAAAACQagQUQjUyZMtmgQYPc/wBSBq5LIGXhmkRkNN4GAAAAkGiUWAAAAABINAILAAAAAIlGYAEAAAAg0QgsAAApXuPGja1Xr17+16VKlbIxY8Yka5oA/L8uXbpYu3btkjsZSGYMkAcE0ZYtW6x06dK2fPlyq1GjRnInBwgZv/zyi2XLli25kwEACEBgAQTJmTNnkjsJQMgqUKBAcicBSJW/SxkzZkzuZCCEURUKIeHChQs2bNgwVzqQJUsWu+KKK+zTTz819abcvHlza9mypftbDhw4YMWKFbOBAwe61/Pnz7c0adLYjBkzrHr16pY5c2a76qqrbM2aNRE+Y+HChXb11Ve77RcvXtweffRRO378eISqGc8//7zdc889ljNnTnvwwQddeqRmzZruM1SdAwglOqd79uzpqinlyZPHChUqZG+//ba7Nu69917LkSOHlStXzr799lv/e3Rt3XDDDZY9e3a3/t1332379+/3L9d7dR1peZEiRWzkyJFRPjewKpRKBnV9rVixwr/80KFDbp6u78DrfNasWe561HXctGlT27t3r0tbpUqV3HV7xx132IkTJ4J81IBLd3326NHDXZ/58+d3v4WjRo2yatWquRI//ZY98sgjduzYMf97Jk+ebLlz53bXiq4LXYfXX3+97dq1y7/O+fPnrU+fPm69fPny2RNPPOH/jfWcPn3a/U4WLFjQ/a42atTIlTR6uCZDlMaxAFK7oUOH+ipWrOibOXOmb9OmTb5Jkyb5MmXK5Js/f75vx44dvjx58vjGjBnj1u3YsaOvbt26vrNnz7rX8+bN093QV6lSJd/s2bN9q1at8rVp08ZXqlQp35kzZ9w6Gzdu9GXLls03evRo359//ulbtGiRr2bNmr4uXbr401CyZElfzpw5fa+88opbX9PPP//stj1nzhzfrl27fP/8808yHSEgOK699lpfjhw5fM8//7y7NvR/unTpfDfccIPvrbfecvMefvhhX758+XzHjx/3HTx40FegQAHfgAEDfOvWrfMtW7bMd9111/maNGni36bWL1GihLtuvOtRn/HYY49FuN50PcrmzZvddbZ8+XL/cn2O5un6DrzOr7rqKt/ChQvd55YrV86lv0WLFu71jz/+6NI5fPjwS3oMgWDR+Z09e3Zfv379fOvXr3eTrpu5c+e66+b777/3VahQwV1zHv1+ZsiQwde8eXPfL7/84vvtt9/c7+Mdd9zhX2fEiBHud/Wzzz7z/f77776uXbu6a/Smm27yr/Poo4/6ihYt6vvmm298a9eu9XXu3Nm9x/sd5JoMTQQWSPVOnTrly5o1q2/x4sUR5utG16lTJ/f3xx9/7MucObOvf//+LkBQZsfj3dymTp3qn6cbX5YsWXzTpk3zb+vBBx+MsP0FCxb40qZN6zt58qQ/o9OuXbsI60SX4QFCiTIBjRo18r8+d+6cu8buvvtu/zwF1boOlixZ4gIPZRoCbd++3S3/448/fEePHvVlzJjRXbORr8ekCCwUrHiGDRvm5ulhhOehhx7ytWzZMgmPEJC816cegl3MJ5984jLvgYGFrgs9HPO88cYbvkKFCvlfFylSxPfSSy/5X+tBXbFixfyBxbFjx1xw8sEHH/jX0YM6BRre+7gmQxNtLJDqbdy40RWTXnfddVHqkqp4VTp27GhffPGFDR8+3MaNG2fly5ePsp369ev7/86bN69VqFDB1q1b516vXLnSVq1aZR988IF/HQXmqoK1efNmV2QrderUCdp+AimVqhB60qVL56pGqKqFR9WdRFUcdC3NmzfPVa+IbNOmTXby5El37darVy/K9ZjUaVW6smbNamXKlIkw7+eff06SzwJSgtq1a0d4PWfOHFd1eP369XbkyBE7d+6cnTp1yv2O6noQ/V+2bFn/e1QlUdevHD582FWLCrxG06dP737/vOpQupbPnj1rDRs29K+TIUMGq1u3rv931cM1GVoILJDqeXVD1Ubisssui7AsU6ZM7n/dMH/77TeX6dmwYUOCPuOhhx5y9UUjK1GihP9veqlBOFKGIZDqTQfO02tRIK5r6cYbb7QRI0ZE2Y4yL3pQEF9p0/7bXDCwjrcyNbGlNXI6vXlKJxAqAn+X1B6pTZs29vDDD9sLL7zggna1H+zatasL6L3AIrrrInIbiqTCNRlaaLyNVK9y5cougNi2bZtrJBo4qWGa9O3b12U+1CDs1Vdftblz50bZztKlS/1/Hzx40P78809/SUStWrXs999/j7J9TRfrYcNbpoZuAP69ltauXesaX0e+lpQB0lNSZSx++umnKNdjbD1EBTYuDWzIDeBfesCmTLo6RFAnJZdffrnt3LkzXtvIlSuXewgQeI2q1EPb9ug61u/fokWLIgT7aryt32yELkoskOqp15nHH3/cevfu7W6Y6nlCRbW6oalHCfWE8e6779qSJUtcpqZfv37WuXNnV7VJvdh4nnvuOVeFQ8WuTz/9tHufN9jPk08+6W7C6l3j/vvvdxkgBRrfffedvf766zGmTb1hqKeLmTNnup6o1DOGbspAuOrevbvrNapTp06uJxk9MVUpxdSpU23ixImuipSenuo61fWoa0jXo1cqER1dY7o+VdVRPbGpysYzzzxzSfcLSA0UwCuD/9prr7mSQ/1Ojh8/Pt7beeyxx9z1pmrFFStWdD1NqSc2j34jVSqi61jXuEr2X3rpJVd7QNc3QhclFggJ6ub12WefdfVGVcqgrvFUNUpPRXUTGzx4sAsqZMiQIS546NatW4Rt6Capm6Xqo+7evdv++9//+kscVAf0hx9+cE9N1eWs2m6ou9qiRYteNF2qd6oSkgkTJrh1b7rppiAeBSDl03WgzIxK8Vq0aOHaYqgrTHVb6QUPL7/8srvOlPFRd9F6WBC5nnhkenigp6ZaT9sbOnToJdojIPVQV+wKAlQVsWrVqq7doH4340u1ANRNtB7SqX2iHvDdfPPNUX5T27dv79bT768eIKhr2cAHegg9adSCO7kTASQn9aXdpEkTV91CmRsAAADEHyUWAAAAABKNwAIAAABAolEVCgAAAECiUWIBAAAAINEILAAAAAAkGoEFAAAAgEQjsAAAAACQaAQWAAAAABKNwAIAAABAohFYAAAAAEg0AgsAAAAAiUZgAQAAAMAS6/8AZIF7DHYcOAMAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 800x450 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "methods = {\"Behavior Cloning\": results_bc, \"Q offline naif\": results_naive, \"BCQ-lite\": results_bcq}\n",
+    "names = list(datasets.keys())\n",
+    "x = np.arange(len(names))\n",
+    "width = 0.26\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 4.5))\n",
+    "for i, (label, res) in enumerate(methods.items()):\n",
+    "    ax.bar(x + (i - 1) * width, [res[n] for n in names], width, label=label)\n",
+    "ax.axhline(-13, color=\"green\", ls=\"--\", lw=1.2, label=\"optimal (-13)\")\n",
+    "ax.scatter(x, [behavior_returns[n] for n in names], color=\"black\", marker=\"D\", zorder=5,\n",
+    "           label=\"politique de comportement\")\n",
+    "ax.set_xticks(x); ax.set_xticklabels(names)\n",
+    "ax.set_ylabel(\"Retour moyen (20 episodes)\")\n",
+    "ax.set_title(\"RL offline sur le labyrinthe : trois methodes, trois datasets\")\n",
+    "ax.legend(loc=\"lower right\", fontsize=9)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d465cc5a",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du tableau final.**\n",
+    "\n",
+    "| Dataset | Comportement | BC | Q naif | BCQ-lite |\n",
+    "|---------|-------------:|----:|-------:|---------:|\n",
+    "| expert  | $\\approx -15$ | $-13$ | $-200$ | $-13$ |\n",
+    "| medium  | $\\approx -150$ | $-200$ | $-200$ | $-13$ |\n",
+    "| random  | $\\approx -190$ | $-200$ | $-13$ | $-13$ |\n",
+    "\n",
+    "- **BCQ-lite gagne sur les trois datasets** : il egale BC quand les donnees sont expertes, et il egale le Q-learning quand la couverture est totale. La contrainte de support ne coute rien quand elle est inutile.\n",
+    "- La ligne **medium** est la plus importante : la politique de comportement rate le but une fois sur deux (retour $\\approx -150$), BC la copie et echoue, le naif delire — mais BCQ-lite extrait un chemin **optimal** ($-13$). C'est le **stitching** : le dataset contient, eparpilles dans des episodes differents, tous les troncons du bon chemin ; la programmation dynamique les recoud, ce que l'imitation pure ne peut pas faire.\n",
+    "- Le RL offline qui fonctionne se resume ainsi : *etre aussi ambitieux que le Q-learning a l'interieur du support des donnees, aussi humble que BC en dehors*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f0f63fe",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 6. Du tabulaire au deep : BCQ, CQL et le pont vers RLHF/DPO\n",
+    "\n",
+    "En dimension reelle (etats continus, $Q$ approxime par un reseau), « l'ensemble des actions vues en $s'$ » n'existe plus litteralement — chaque etat est unique. Les methodes modernes traduisent la meme idee de trois facons :\n",
+    "\n",
+    "- **BCQ** (Fujimoto et al., 2019) : un auto-encodeur variationnel modelise $\\pi_\\beta(a|s)$ ; le $\\max$ ne porte que sur des actions echantillonnees de ce modele (contrainte de support *explicite*).\n",
+    "- **CQL** (*Conservative Q-Learning*, Kumar et al., 2020) : plutot que d'interdire, **penaliser** — un terme de regularisation pousse $Q$ vers le bas sur les actions hors distribution et vers le haut sur les actions du dataset. Le $Q$ appris est un *minorant* du vrai $Q$ : l'optimisme hors support devient du pessimisme (l'exercice 2 en construit la version tabulaire).\n",
+    "- **IQL, TD3+BC, Decision Transformer...** : la famille est riche, mais le principe est invariant — controler l'ecart entre la politique apprise et la politique de comportement.\n",
+    "\n",
+    "**Le pont vers les LLM.** L'alignement d'un modele de langage est un probleme de RL offline deguise. Le *fine-tuning supervise* (SFT) est exactement du Behavior Cloning sur des demonstrations humaines. **RLHF** optimise ensuite une recompense apprise, avec une penalite KL qui force la politique a rester proche du modele de reference — le meme role que la contrainte de support de BCQ : sans elle, la politique exploite les zones ou le modele de recompense extrapole mal (*reward hacking*, le jumeau de notre erreur d'extrapolation). **DPO** (Rafailov et al., 2023) pousse la logique au bout : il elimine le RL et reecrit l'objectif RLHF comme une simple classification de preferences sous contrainte KL — de l'offline pur, sans interaction. La boucle est bouclee : les idees nees sur des labyrinthes 6x9 gouvernent aujourd'hui l'entrainement des plus grands modeles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1310ca43",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Les trois exercices reutilisent les fonctions du notebook (`collect_dataset`, `bc_policy`, `offline_q`, `evaluate_policy`). Completez les cellules — elles doivent s'executer sans erreur meme incompletes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e440a0b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Combien de demonstrations faut-il ?\n",
+    "\n",
+    "La qualite des methodes offline depend de la **taille** du dataset, pas seulement de sa qualite. Collectez des datasets experts de tailles croissantes et comparez BC et BCQ-lite : lequel est le plus econome en donnees ? A partir de combien d'episodes chacun devient-il fiable ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "25c71989",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — Ablation de la taille du dataset expert\n",
+    "# Etape 1 : pour n_ep dans `tailles`, collecter un dataset expert (Q_expert, eps=0.1, seed=1)\n",
+    "# Etape 2 : entrainer BC et l'offline Q contraint (constrain=True) sur chaque dataset\n",
+    "# Etape 3 : tracer les retours moyens en fonction de n_ep (2 courbes + ligne optimale -13)\n",
+    "# Indice : collect_dataset renvoie (data, retour_moyen) — ne garder que data\n",
+    "\n",
+    "tailles = [1, 2, 5, 10, 50]\n",
+    "retours_bc_ex1 = None     # TODO etudiant : liste des retours BC, une valeur par taille\n",
+    "retours_bcq_ex1 = None    # TODO etudiant : liste des retours BCQ-lite\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc898e21",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Penalite conservatrice (CQL-lite tabulaire)\n",
+    "\n",
+    "CQL remplace l'interdiction stricte de BCQ par une **penalite** : les actions hors dataset gardent le droit d'exister, mais leur valeur est artificiellement abaissee. En tabulaire, la version la plus simple s'applique *apres* l'apprentissage naif :\n",
+    "\n",
+    "$$Q_{pen}(s, a) = Q_{naif}(s, a) - \\beta \\cdot \\mathbb{1}\\big[(s, a) \\notin \\mathcal{D}\\big]$$\n",
+    "\n",
+    "Evaluez la politique greedy sur $Q_{pen}$ pour plusieurs $\\beta$ sur le dataset **medium**. Que retrouve-t-on en $\\beta = 0$ ? Vers quoi tend le comportement quand $\\beta$ grandit ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "bdb2d48e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — CQL-lite : penaliser au lieu d'interdire\n",
+    "# Etape 1 : entrainer l'offline Q NAIF (constrain=False) sur datasets[\"medium\"]\n",
+    "# Etape 2 : construire Q_pen = Q - beta * masque, ou masque[s, a] = 1 si (s, a) jamais vu\n",
+    "# Etape 3 : evaluer la politique greedy Q_pen.argmax(axis=1) pour chaque beta\n",
+    "# Indice : construire le masque a partir de {(s, a) for s, a, *_ in data}\n",
+    "\n",
+    "betas = [0.0, 0.5, 2.0, 10.0]\n",
+    "retours_cql = None        # TODO etudiant : retour moyen pour chaque beta\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14aa6d84",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Convergence : combien de passes sur le dataset ?\n",
+    "\n",
+    "Un detail d'implementation qui n'en est pas un : `offline_q` rejoue le dataset `n_passes = 300` fois. Avec seulement 100 passes, BCQ-lite **echoue sur le dataset expert** alors que l'algorithme est correct. Reproduisez le phenomene et expliquez-le."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "7d88bc9b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — Sensibilite au nombre de passes\n",
+    "# Etape 1 : pour n_passes dans `liste_passes`, entrainer offline_q(constrain=True)\n",
+    "#           sur datasets[\"expert\"] et evaluer la politique\n",
+    "# Etape 2 : tracer le retour moyen en fonction de n_passes\n",
+    "# Etape 3 : afficher Q[env.idx(env.start)] pour n_passes=100 et 300 — quelle action\n",
+    "#           reste surevaluee trop longtemps, et pourquoi ?\n",
+    "# Indice : en (2, 0), l'action \"gauche\" cogne le mur (transition vers soi-meme).\n",
+    "#          Sa cible -1 + gamma * max Q(s) poursuit une cible mouvante : elle ne\n",
+    "#          converge qu'APRES les autres valeurs — un retard que 100 passes ne comblent pas.\n",
+    "\n",
+    "liste_passes = [10, 50, 100, 300]\n",
+    "retours_passes = None     # TODO etudiant : retour moyen pour chaque n_passes\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a70d5c7",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a parcouru le RL offline de bout en bout sur un probleme assez petit pour que chaque echec soit dissequable :\n",
+    "\n",
+    "- Le **Behavior Cloning** est optimal quand les demonstrations le sont, et exactement aussi mauvais qu'elles sinon — il n'exploite pas les recompenses.\n",
+    "- Le **Q-learning naif sur dataset fige** echoue meme sur des donnees parfaites : le $\\max$ bootstrape sur des actions jamais observees dont la valeur d'initialisation est optimiste, et aucune interaction ne vient corriger l'illusion. C'est l'**erreur d'extrapolation**, et elle disparait precisement quand la couverture devient quasi totale.\n",
+    "- La **contrainte de support** (BCQ-lite) reconcilie les deux mondes : aussi ambitieuse que la programmation dynamique dans le support des donnees, aussi prudente que l'imitation en dehors. Son fruit le plus precieux est le **stitching** — recoudre un chemin optimal a partir de trajectoires individuellement mediocres.\n",
+    "\n",
+    "### Passerelles\n",
+    "\n",
+    "- **Notebook 5** : le Q-learning online dont tout part ; **notebook 6** : le replay buffer de DQN est deja un mini-dataset offline (mais sans cesse rafraichi — c'est toute la difference) ;\n",
+    "- **Notebook 8** : Dyna-Q apprend un modele des transitions ; le RL offline *model-based* (MOPO, MOReL) suit la meme voie avec une penalite d'incertitude ;\n",
+    "- **Serie GenAI (FT-04)** : SFT = Behavior Cloning, RLHF = RL contraint par KL, DPO = preference learning offline — les notions de ce notebook, a l'echelle des LLM.\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Levine, Kumar, Tucker, Fu (2020), *Offline Reinforcement Learning: Tutorial, Review, and Perspectives on Open Problems*, arXiv:2005.01643\n",
+    "- Fujimoto, Meger, Precup (2019), *Off-Policy Deep Reinforcement Learning without Exploration* (BCQ), ICML\n",
+    "- Kumar, Zhou, Tucker, Levine (2020), *Conservative Q-Learning for Offline Reinforcement Learning* (CQL), NeurIPS\n",
+    "- Ross, Gordon, Bagnell (2011), *A Reduction of Imitation Learning and Structured Prediction to No-Regret Online Learning* (DAgger), AISTATS\n",
+    "- Rafailov et al. (2023), *Direct Preference Optimization: Your Language Model is Secretly a Reward Model*, NeurIPS\n",
+    "- Sutton & Barto (2018), *Reinforcement Learning: An Introduction*, chap. 8 (labyrinthe fig. 8.2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Nouveau notebook **rl_9_offline_rl.ipynb** (9/12, 50-55 min) : apprendre une politique depuis un dataset fige, sans interaction. CPU-pur numpy, labyrinthe 6x9 de Sutton & Barto.

**Stacked on #2784** (`feature/rl-8-model-based-dyna-q`) — merger APRES #2784 ; le diff GitHub se reduira alors au seul contenu rl_9.

### Contenu

- **3 datasets** (expert eps=0.1 / medium eps=0.3 / random eps=1.0, seeds explicites 1/2/3) — couverture 31% / 81% / 85%, retours comportement -14.7 / -158.0 / -194.6
- **Behavior Cloning** : plafond de la politique de comportement (-13 sur expert, -200 ailleurs)
- **Q-learning offline naif** : erreur d'extrapolation demontree — 94% des etats visites ont un argmax greedy sur une action jamais vue ; les valeurs s'effondrent vers ~-1 par bootstrap sur actions fantomes (init optimiste 0, recompense -1/pas). Visualisation barres bleu (vu) / rouge (fantome) sur l'etat (3,4)
- **BCQ-lite** (max contraint au support du dataset + politique contrainte) : **-13 sur les 3 datasets**, y compris **stitching** du chemin optimal depuis le dataset medium (comportement -158)
- **Pont** vers BCQ/CQL/IQL et RLHF/DPO (SFT = BC, contrainte KL = contrainte de support)
- **3 exercices** (stubs C.1 : `pass`/`return None`, pas de NotImplementedError) : ablation taille de dataset, penalite CQL-lite, convergence n_passes — conformes #2161

### Aussi dans cette PR

- Headers `/11 -> /12` sur 6 notebooks (edit markdown seul, outputs intacts — exemption C.2)
- README RL : stats (12 notebooks, ~500-575 min), ligne tableau, section dediee nb 9, concepts cles (RL offline / erreur d'extrapolation / stitching), algorithmes (BC, BCQ-lite), environnements, parcours Phase 4, arbre de structure

## Preuve d'execution (H.1/H.3)

- Papermill end-to-end : 29/29 cellules, ~88 s, kernel python3 (env `coursia-ml-training`)
- `execution_count` sequentiels 1..12, **0 erreur**, 0 pattern interdit (`raise NotImplementedError` / `assert False` / `1/0` : 0 occurrence)
- Metadata papermill strippees avant commit
- Resultats cles dans les outputs : BC -13/-200/-200 ; naif -200/-200/-13 ; BCQ-lite **-13/-13/-13** (optimal = -13)

## Catalogue

Catalogue byte-identique a main (aucune regen sur branche, blocs CATALOG-STATUS intacts) — la lane catalog-drift/cron inscrira l'entree rl_9.

See #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)