### PR TITLE
docs(rl): harmonize series headers — N/13 numbering + fix stale nav links (#295)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
@@ -15,9 +15,10 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](README.md) | [RL MDP/Q-Learning >>](rl_5_mdp_dp_qlearning.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [RL-2 Wrappers >>](rl_2_wrappers_sauvegarde_callbacks.ipynb)\n",
     "# Tutoriel Stable Baselines3 - Premiers pas\n",
     "\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 1/13 | **Duree estimee** : 25-30 min\n",
     "\n",
     "Stable-Baselines3 : https://github.com/DLR-RM/stable-baselines3\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb
@@ -14,8 +14,10 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](README.md) | [<< SB1 Intro](rl_1_intro_cartpole.ipynb) | [SB3 Experience Replay >>](rl_3_experience_replay_dqn.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-3 HER >>](rl_3_experience_replay_dqn.ipynb)\n",
     "# Notebook 2 – Wrappers Gym, Sauvegarde/Chargement, Multiprocessing, Callbacks et Environnements Personnalisés\n",
+    "\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 2/13 | **Duree estimee** : 35-40 min\n",
     "\n",
     "Ce notebook propose un survol des fonctionnalités avancées de la librairie [Stable Baselines3](https://github.com/DLR-RM/stable-baselines3) :\n",
     "1. **Utilisation de wrappers Gym** (limitation du nombre d’étapes, normalisation des actions, etc.)\n",

--- a/MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb
@@ -14,8 +14,10 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](README.md) | [<< SB2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [DQN/PPO >>](rl_6_dqn_policy_gradient.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-4 Bandits >>](rl_4_multi_armed_bandits.ipynb)\n",
     "# Notebook 3 – Hindsight Experience Replay (HER) et Sauvegarde Avancée\n",
+    "\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 3/13 | **Duree estimee** : 40-45 min\n",
     "\n",
     "Dans ce troisième notebook, nous allons aborder plusieurs sujets avancés :\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb
@@ -16,7 +16,9 @@
    "source": [
     "# PPO (Proximal Policy Optimization) depuis zero\n",
     "\n",
-    "**Navigation** : [[Notebook precedent] Actor-Critic (A2C)](rl_6b_actor_critic.ipynb) | [[Notebook suivant] Multi-Agent RL](rl_7_multi_agent_rl.ipynb)\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 6c/13 | **Duree estimee** : 45-50 min\n",
+    "\n",
+    "**Navigation** : [[Notebook precedent] Actor-Critic (A2C)](rl_6b_actor_critic.ipynb) | [Index](README.md) | [[Notebook suivant] Multi-Agent RL](rl_7_multi_agent_rl.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# SAC (Soft Actor-Critic) depuis zero\n",
     "\n",
+    "**Serie** : Reinforcement Learning | **Notebook** : 6d/13 | **Duree estimee** : 45-50 min\n",
+    "\n",
     "**Navigation** : [[Notebook precedent] PPO](rl_6c_ppo_from_scratch.ipynb) | [Index](README.md) | [[Notebook suivant] Multi-Agent RL](rl_7_multi_agent_rl.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",


### PR DESCRIPTION
## Scope

Finalisation **Axe 3** de #295 (passe cohérence série RL avant clôture). Les PRs de renumérotation (#2717/#2734/#2738/#2739) avaient laissé **deux demi-conventions** d'en-tête :

| Notebooks | Avant | Après |
|-----------|-------|-------|
| rl_4..rl_10 | `**Notebook** : N/13` mais pas de barre de navigation | inchangés |
| rl_1, rl_2, rl_3, rl_6c, rl_6d | barre de navigation mais **pas de N/13** | ligne `**Serie** : Reinforcement Learning \| **Notebook** : N/13 \| **Duree estimee** : X min` ajoutée (convention rl_4/rl_6b/rl_8, durées du README) |

**2 liens « suivant » périmés corrigés** (hérités de l'ordre pré-renumérotation) :
- rl_1 : `>>` pointait **rl_5**_mdp_dp_qlearning (sautait 2-3-4) → **rl_2**_wrappers
- rl_3 : `>>` pointait **rl_6**_dqn_policy_gradient (sautait 4-5) → **rl_4**_multi_armed_bandits

Plus : labels legacy `SB1/SB2/SB3` → `RL-1/RL-2/RL-3` dans les barres de nav, et lien `[Index](README.md)` ajouté à rl_6c (déjà présent partout ailleurs).

## Validation (markdown-only, exemption C.2)

- **Diff borné** : 5 fichiers, +13/−4 lignes, **uniquement des lignes `source` markdown de la cellule 0** — aucun `execution_count`, aucun `outputs` touché (vérifiable au diff JSON).
- Édition par script Python avec **asserts d'égalité stricte** sur chaque ligne remplacée + round-trip JSON byte-identique vérifié avant édition.
- **Post-édition (script, worktree)** : 13/13 notebooks numérotés N/13 ; exec_count complets (8/8, 20/20, 10/10, 13/13, 20/20, 18/18, 12/12, 9/9, 10/10, 12/12, 12/12, 11/11, 12/12) ; **0 lien relatif cassé** (tous les `rl_*.ipynb`/`README.md` référencés existent).
- 0 `NotImplementedError`/`assert False` (inchangé), 6-8 exercices par notebook (inchangé).

Refs #295