### PR TITLE
feat(lean): canonical grid forms + P4 ext bridge (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
@@ -20,6 +20,7 @@ import Conway.DoomsdayLemmas
 import Conway.LookAndSayLemmas
 import Conway.Angel
 import Conway.Life
+import Conway.Life.GridCanonical
 import Conway.Life.Spaceships
 import Conway.Life.Oscillators
 import Conway.Life.RLE

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
@@ -94,9 +94,31 @@ def aliveNext (g : Grid) (p : Int × Int) : Bool :=
 def candidates (g : Grid) : List (Int × Int) :=
   g ++ g.flatMap mooreNeighbors
 
-/-- Sort a list lexicographically and remove duplicates. -/
+/-- Reflexive closure of `lexLt`: a **total** comparator for `mergeSort`.
+    On distinct pairs it decides exactly like `lexLt`; on equal pairs it is
+    `true`. Totality is what `List.pairwise_mergeSort` needs to certify that
+    the output is sorted (see `Conway.Life.GridCanonical`). -/
+def lexLe (a b : Int × Int) : Bool :=
+  lexLt a b || a == b
+
+/-- Sort a list lexicographically and remove duplicates.
+
+    The comparator is the total `lexLe` and deduplication uses Mathlib's
+    `List.dedup`, so the canonical-form lemmas (`sortedness`, `Nodup`,
+    membership, extensionality) are all derivable — see
+    `Conway.Life.GridCanonical`. The output is the same as with the strict
+    comparator + `eraseDups`: the comparators agree on all distinct pairs,
+    ties are *equal values* (so any tie-breaking yields the same list), and
+    on a sorted list both dedup flavours collapse each run of equal values
+    to a single copy. -/
 def sortDedup (l : List (Int × Int)) : List (Int × Int) :=
-  (l.mergeSort (fun a b => lexLt a b = true)).eraseDups
+  (l.mergeSort lexLe).dedup
+
+/-- `sortDedup` preserves membership. -/
+theorem mem_sortDedup {p : Int × Int} {l : List (Int × Int)} :
+    p ∈ sortDedup l ↔ p ∈ l := by
+  unfold sortDedup
+  rw [List.mem_dedup, List.mem_mergeSort]
 
 /-- One step of Conway's Game of Life (B3/S23 rule). -/
 def step (g : Grid) : Grid :=

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## Canonical grid forms — the `sortDedup` specification
+
+Every grid manipulated by the Life engine is a `sortDedup` image:
+`step`, `evolve (n+1)`, `shift` and `MacroCell.toGrid` all post-compose
+with `sortDedup`, and `restrictGridTo` is a `filter` of such an image.
+This module proves that `sortDedup` outputs are **canonical** — lex-sorted
+and duplicate-free — and that canonical lists are **rigid**: determined by
+their membership predicate alone (`Canonical.ext`).
+
+This is the bridge that turns the list-equality goals of the Hashlife
+correctness theorems (P4/P5, `HashlifeCorrectness.lean`) into pointwise
+membership goals, where the actual combinatorics of the B3/S23 rule and
+the macrocell recursion can be argued cell by cell.
+
+The order theory is elementary: `lexLe` (reflexive closure of `lexLt`)
+is total, transitive and antisymmetric on `Int × Int`, all by `omega`
+after unfolding to linear integer arithmetic.
+
+This module is fully proven (no `sorry`).
+-/
+
+import Conway.Life
+
+namespace Conway
+namespace Life
+
+/-! ## The lexicographic comparator: order axioms -/
+
+/-- `lexLt` in terms of linear integer arithmetic. -/
+theorem lexLt_iff {a b : Int × Int} :
+    lexLt a b = true ↔ a.1 < b.1 ∨ (a.1 = b.1 ∧ a.2 < b.2) := by
+  unfold lexLt
+  split_ifs <;> simp <;> omega
+
+/-- `lexLe` in terms of linear integer arithmetic. -/
+theorem lexLe_iff {a b : Int × Int} :
+    lexLe a b = true ↔ a.1 < b.1 ∨ (a.1 = b.1 ∧ a.2 ≤ b.2) := by
+  simp only [lexLe, Bool.or_eq_true, lexLt_iff, beq_iff_eq, Prod.ext_iff]
+  omega
+
+/-- `lexLe` is total — the hypothesis `List.pairwise_mergeSort` needs. -/
+theorem lexLe_total (a b : Int × Int) : (lexLe a b || lexLe b a) = true := by
+  simp only [Bool.or_eq_true, lexLe_iff]
+  omega
+
+/-- `lexLe` is transitive. -/
+theorem lexLe_trans (a b c : Int × Int)
+    (hab : lexLe a b = true) (hbc : lexLe b c = true) : lexLe a c = true := by
+  simp only [lexLe_iff] at *
+  omega
+
+/-- `lexLe` is antisymmetric — what makes sorted Nodup lists rigid. -/
+theorem lexLe_antisymm (a b : Int × Int)
+    (hab : lexLe a b = true) (hba : lexLe b a = true) : a = b := by
+  simp only [lexLe_iff] at hab hba
+  rw [Prod.ext_iff]
+  omega
+
+/-! ## Canonical grids -/
+
+/-- A grid in canonical form: lexicographically sorted and duplicate-free.
+    Invariant of every `sortDedup` image, preserved by `filter`. -/
+def Canonical (g : Grid) : Prop :=
+  g.Pairwise (fun a b => lexLe a b = true) ∧ g.Nodup
+
+/-- `sortDedup` always produces a canonical grid: sortedness comes from
+    `pairwise_mergeSort` (using totality and transitivity of `lexLe`) and
+    survives `dedup` because `dedup` yields a sublist; freedom from
+    duplicates is `nodup_dedup`. -/
+theorem canonical_sortDedup (l : List (Int × Int)) : Canonical (sortDedup l) := by
+  unfold sortDedup
+  exact ⟨List.Pairwise.sublist (List.dedup_sublist _)
+          (List.pairwise_mergeSort lexLe_trans lexLe_total l),
+        List.nodup_dedup _⟩
+
+/-- Filtering preserves canonical form (`filter` yields a sublist). -/
+theorem Canonical.filter {g : Grid} (h : Canonical g) (q : (Int × Int) → Bool) :
+    Canonical (g.filter q) :=
+  ⟨List.Pairwise.sublist List.filter_sublist h.1,
+   List.Nodup.sublist List.filter_sublist h.2⟩
+
+/-- **Rigidity of canonical grids**: two canonical grids with the same
+    members are equal as lists. Same-membership gives a permutation
+    (`perm_ext_iff_of_nodup`), and a permutation between two lex-sorted
+    lists is the identity by antisymmetry (`Perm.eq_of_pairwise`). -/
+theorem Canonical.ext {g₁ g₂ : Grid} (h₁ : Canonical g₁) (h₂ : Canonical g₂)
+    (h : ∀ p, p ∈ g₁ ↔ p ∈ g₂) : g₁ = g₂ :=
+  List.Perm.eq_of_pairwise (fun a b _ _ hab hba => lexLe_antisymm a b hab hba)
+    h₁.1 h₂.1 ((List.perm_ext_iff_of_nodup h₁.2 h₂.2).mpr h)
+
+/-- The workhorse corollary: two `sortDedup` images are equal **iff** their
+    input lists have the same members. List equality of canonical grids is
+    exactly set equality. -/
+theorem sortDedup_eq_sortDedup_iff {l₁ l₂ : List (Int × Int)} :
+    sortDedup l₁ = sortDedup l₂ ↔ ∀ p, p ∈ l₁ ↔ p ∈ l₂ := by
+  constructor
+  · intro h p
+    rw [← mem_sortDedup (l := l₁), h, mem_sortDedup]
+  · intro h
+    exact Canonical.ext (canonical_sortDedup _) (canonical_sortDedup _)
+      (fun p => by rw [mem_sortDedup, mem_sortDedup]; exact h p)
+
+/-! ## Canonicity of the Life-engine grids -/
+
+/-- `step` produces canonical grids. -/
+theorem canonical_step (g : Grid) : Canonical (step g) :=
+  canonical_sortDedup _
+
+/-- `evolve n` produces canonical grids for `n ≥ 1` (for `n = 0` the
+    output is the input, which need not be canonical). -/
+theorem canonical_evolve_of_pos {n : Nat} (hn : 0 < n) (g : Grid) :
+    Canonical (evolve n g) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  rw [evolve_succ]
+  exact canonical_step _
+
+/-- `shift` produces canonical grids. -/
+theorem canonical_shift (v : Int × Int) (g : Grid) : Canonical (shift v g) :=
+  canonical_sortDedup _
+
+/-- Membership in a `step` image, unfolded to the rule: `p` is in `step g`
+    iff it is a candidate and `aliveNext` accepts it. -/
+theorem mem_step_iff {g : Grid} {p : Int × Int} :
+    p ∈ step g ↔ p ∈ candidates g ∧ aliveNext g p = true := by
+  unfold step
+  rw [mem_sortDedup, List.mem_filter]
+
+end Life
+end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -66,6 +66,7 @@ See `agent_tests/prover/RUNBOOK.md` for iteration protocol.
 -/
 
 import Conway.Life
+import Conway.Life.GridCanonical
 import Conway.Life.MacroCell
 import Conway.Life.Hashlife
 
@@ -487,8 +488,8 @@ theorem isAlive_step_eq_aliveNext (g : Grid) (p : Int × Int) :
   by_cases h : aliveNext g p = true
   · -- aliveNext g p = true case: must have p ∈ step g.
     rw [h]
-    unfold isAlive step sortDedup
-    rw [List.elem_iff, List.mem_eraseDups, List.mem_mergeSort, List.mem_filter]
+    unfold isAlive step
+    rw [List.elem_iff, mem_sortDedup, List.mem_filter]
     exact ⟨aliveNext_true_mem_candidates g p h, h⟩
   · -- aliveNext g p = false case: p ∉ filter, hence p ∉ step g.
     have h_false : aliveNext g p = false := by
@@ -496,15 +497,13 @@ theorem isAlive_step_eq_aliveNext (g : Grid) (p : Int × Int) :
       · rfl
       · exact absurd h_iA h
     rw [h_false]
-    unfold isAlive step sortDedup
+    unfold isAlive step
     -- Need: (sortDedup ...).elem p = false. Show p ∉ sortDedup, then elem = false.
-    have h_ne : p ∉ (((candidates g).filter (aliveNext g)).mergeSort
-                      (fun a b => lexLt a b = true)).eraseDups := by
-      rw [List.mem_eraseDups, List.mem_mergeSort, List.mem_filter]
+    have h_ne : p ∉ sortDedup ((candidates g).filter (aliveNext g)) := by
+      rw [mem_sortDedup, List.mem_filter]
       rintro ⟨_, h_alive⟩
       exact h h_alive
-    cases h_e : ((((candidates g).filter (aliveNext g)).mergeSort
-                    (fun a b => lexLt a b = true)).eraseDups).elem p
+    cases h_e : (sortDedup ((candidates g).filter (aliveNext g))).elem p
     · rfl
     · exact absurd (List.elem_iff.mp h_e) h_ne
 
@@ -780,6 +779,46 @@ theorem p4_unrestricted_counterexample :
             (2 ^ 0 : Int) (2 ^ (0 + 1))) := by
   native_decide
 
+/-! ## Canonical-form bridge: P4 list equality ⇔ pointwise membership
+
+Both sides of the P4 statement are **canonical** grids
+(`Conway.Life.GridCanonical`): the LHS is a `toGrid` (a `sortDedup` image),
+the RHS a `filter` of `evolve (2^k)` with `2^k ≥ 1` (a `step` image). By
+rigidity of canonical grids (`Canonical.ext`), proving the list equality is
+equivalent to proving membership pointwise — which is where the light-cone
+(P2) and double-nine decomposition arguments actually live. -/
+
+/-- `toGrid` images are canonical grids. -/
+theorem canonical_toGrid (offset : Int × Int) (c : MacroCell) :
+    Canonical (c.toGrid offset) := by
+  unfold MacroCell.toGrid
+  exact canonical_sortDedup _
+
+/-- Membership in a `toGrid` image, unfolded to the raw cell emission. -/
+theorem mem_toGrid {c : MacroCell} {offset : Int × Int} {p : Int × Int} :
+    p ∈ c.toGrid offset ↔ p ∈ c.toCellsAux offset.1 offset.2 := by
+  unfold MacroCell.toGrid
+  exact mem_sortDedup
+
+/-- Membership in a restricted grid: in the grid and inside the window. -/
+theorem mem_restrictGridTo {g : Grid} {lo : Int} {size : Nat} {p : Int × Int} :
+    p ∈ restrictGridTo g lo size ↔
+      p ∈ g ∧ lo ≤ p.1 ∧ p.1 < lo + (size : Int) ∧
+        lo ≤ p.2 ∧ p.2 < lo + (size : Int) := by
+  simp [restrictGridTo, List.mem_filter, and_assoc]
+
+/-- **The P4 ext bridge**: pointwise membership suffices for the P4 goal.
+    Reduces the list-equality statement of `hashlifeResult_central_correct`
+    to a per-cell biconditional. -/
+theorem p4_ext_bridge (c : MacroCell) (k : Nat)
+    (h : ∀ p, p ∈ (hashlifeResultAux (k + 2) c).toGrid ((2^k : Nat), (2^k : Nat)) ↔
+        p ∈ restrictGridTo (evolve (2^k) (c.toGrid (0, 0))) (2^k : Int) (2^(k+1))) :
+    (hashlifeResultAux (k + 2) c).toGrid ((2^k : Nat), (2^k : Nat)) =
+      restrictGridTo (evolve (2^k) (c.toGrid (0, 0))) (2^k : Int) (2^(k+1)) := by
+  apply Canonical.ext (canonical_toGrid _ _) _ h
+  unfold restrictGridTo
+  exact (canonical_evolve_of_pos (Nat.two_pow_pos k) _).filter _
+
 /-- For a level-`k` MacroCell `c` with `k ≥ 2`, the centered region of
     `hashlifeResultAux (k+2) c` (viewed at offset `(2^k, 2^k)`) equals
     `evolve (2^k)` applied to `c.toGrid (0, 0)` and restricted to the
@@ -803,8 +842,11 @@ theorem hashlifeResult_central_correct (c : MacroCell) (k : Nat)
     let resultGrid := result.toGrid ((2^k : Nat), (2^k : Nat))
     let expected := evolve (2^k) (c.toGrid (0, 0))
     resultGrid = restrictGridTo expected (2^k : Int) (2^(k+1)) := by
-  -- P4 TARGET: central Hashlife correctness, by induction on level
-  sorry
+  -- P4 TARGET: central Hashlife correctness, by induction on level.
+  -- `p4_ext_bridge` has discharged the canonical-list bookkeeping: the
+  -- remaining goal is the pointwise membership biconditional, where the
+  -- light-cone (P2) and double-nine decomposition arguments live.
+  exact p4_ext_bridge c k (fun p => by sorry)
 
 /-! ## P4 witnesses: base case k=0 (native_decide)
 


### PR DESCRIPTION
## Summary

**Canonical-form infrastructure for the P4 inductive step** (`hashlifeResult_central_correct`, the remaining "noix Knuth" of HashlifeCorrectness). New module `Conway/Life/GridCanonical.lean` (133 lines, **fully proven, 0 sorry**) establishes that every grid the Life engine produces is *canonical* (lex-sorted + duplicate-free) and that canonical grids are *rigid* (determined by membership alone). The P4 goal — a list equality between two canonical grids — is now reduced via `p4_ext_bridge` to a **pointwise membership biconditional**, which is where the light-cone (P2) and double-nine decomposition arguments actually live.

This does NOT close P4. Sorry declarations unchanged **2 → 2** (P4, P5). It converts P4's goal from list bookkeeping + combinatorics into pure combinatorics, for the next prover/manual iteration.

See #2162

## Why a `sortDedup` pivot was needed

The toolchain's `List.eraseDups` has **no lemma API** (no `Sublist`, no `Nodup` — verified by `exact?`), and `List.pairwise_mergeSort` requires a **total** comparator while `lexLt` is strict. Without those, no sortedness/Nodup/extensionality facts about `sortDedup` outputs are derivable.

Pivot in `Life.lean`: `sortDedup l = (l.mergeSort lexLe).dedup` with `lexLe := lexLt a b || a == b` (total), `dedup` = Mathlib's (full API: `nodup_dedup`, `mem_dedup`, `dedup_sublist`).

**Extensionally neutral**: the comparators agree on all distinct pairs; ties are *equal values* (any tie-break gives the same list); on a sorted list both dedup flavours collapse each run of equal values to one copy. Empirically confirmed: all ~40 pre-existing `native_decide` grid-equality witnesses across Life/Spaceships/Oscillators/Pillars/HashlifeCorrectness re-evaluated and passed at build.

## Changes (3 files modified +77/−12, 1 new file)

- **`Conway/Life.lean`**: `lexLe` (total comparator) + `sortDedup` pivot + `mem_sortDedup` (proven).
- **`Conway/Life/GridCanonical.lean`** (new, fully proven): order axioms `lexLt_iff`/`lexLe_iff`/`lexLe_total`/`lexLe_trans`/`lexLe_antisymm` (all by `omega`); `Canonical` predicate; `canonical_sortDedup` (via `pairwise_mergeSort` + `dedup_sublist`); `Canonical.filter`; **`Canonical.ext`** (rigidity, via `perm_ext_iff_of_nodup` + `Perm.eq_of_pairwise`); `sortDedup_eq_sortDedup_iff`; canonicity of `step`/`evolve (n≥1)`/`shift`; `mem_step_iff`.
- **`Conway/Life/HashlifeCorrectness.lean`**: `isAlive_step_eq_aliveNext` proof updated to the new internals (`mem_sortDedup` instead of `mem_eraseDups` — shorter); new `canonical_toGrid`, `mem_toGrid`, `mem_restrictGridTo`, **`p4_ext_bridge`** (all proven); P4 body now `exact p4_ext_bridge c k (fun p => by sorry)` — the sorry'd goal is the membership biconditional.
- **`Conway.lean`**: import wiring.

## Rule-B evidence (Lean PR discipline)

1. **sorry count before/after** (`grep -cE "\bsorry\b"`): `HashlifeCorrectness.lean` **9 → 9** (prose mentions included); `GridCanonical.lean` 1 mention (the "no sorry" docstring), **0 declarations**. Actual sorry **declarations: 2 → 2** (build warnings L798 P4 membership form, L1007 P5). Honest accounting: this is infrastructure, not a sorry reduction.
2. **Lake build SUCCESS (local WSL, at branch tip = origin/main + this diff)**:
   ```
   warning: Conway/Life/HashlifeCorrectness.lean:798:8: declaration uses `sorry`
   warning: Conway/Life/HashlifeCorrectness.lean:1007:8: declaration uses `sorry`
   Build completed successfully (3319 jobs).
   ```
   (only pre-existing linter warnings + exactly these 2 sorry warnings — P4 and P5)
3. **Proof integrity / axiom check** (`#print axioms` via `lake env lean`): all new theorems (`mem_sortDedup`, `canonical_sortDedup`, `Canonical.ext`, `sortDedup_eq_sortDedup_iff`, `canonical_step`, `canonical_evolve_of_pos`, `mem_step_iff`, `canonical_toGrid`, `mem_toGrid`, `mem_restrictGridTo`, `p4_ext_bridge`) depend only on `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `native_decide`** in the new infrastructure. `isAlive_step_eq_aliveNext` (patched) likewise.
4. **No prover-harness refactor** — Lean files only.

## Anti-regression

No proof deleted or weakened. `isAlive_step_eq_aliveNext` re-proven (same statement, shorter proof through `mem_sortDedup`). The P4 sorry is *refined* (its goal is now strictly closer to the mathematical content), not moved or duplicated. All pre-existing theorems rebuilt SUCCESS. Catalogue untouched (byte-identical to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
