### PR TITLE
docs(lens): cross-links La mer qui monte dans les 6 series citees restantes (#2065)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -227,3 +227,5 @@ Voir la licence du repository principal.
 | [GameTheory](../GameTheory/README.md) | OpenSpiel / Nashpy | Interactions strategiques multi-agents eclairent la complexite des systemes distribues |
 | [SymbolicAI/Lean](../SymbolicAI/Lean/README.md) | Preuves formelles | Formalisation Arrow/Sen montre comment prouver des proprietes structurelles impossibles |
 | [RL](../RL/README.md) | Stable Baselines3 | La distinction feed-forward vs recurrent (Phi = 0 vs > 0) eclaire le choix d'architecture RL |
+
+[La mer qui monte](../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du depot — Phi comme certificat ouvert : PyPhi le *calcule* sur de petits systemes sans pretendre le *demontrer*.

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -268,6 +268,8 @@ Voir la licence du repository principal.
 | [Probas](../Probas/README.md) | Programmation probabiliste | L'evaluation bayesienne des modeles (TP-prevision-ventes) est une application directe de la serie Probas |
 | [Search](../Search/README.md) | Recherche et optimisation | L'optimisation des hyperparametres ML rejoint les techniques de recherche (grille, bayesienne) |
 
+[La mer qui monte](../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du depot — le modele entraine comme certificat ouvert, juge par une evaluation declaree comme telle.
+
 ---
 
 ## Navigation

--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -492,6 +492,8 @@ Les 50+ projets du dossier `projects/` ont été backtestés sur des périodes s
 | [Search](../Search/README.md) | Recherche et optimisation | L'optimisation des hyperparametres de strategies (grid search, bayesienne) rejoint les techniques de recherche |
 | [ML](../ML/ML.Net/README.md) | Series temporelles ML.NET | L'analyse technique (QC-4 a QC-7) partage les memes fondements que le forecasting par SSA (ML-5) |
 
+[La mer qui monte](../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du depot — le backtest hors-echantillon comme certificat ouvert : Sharpe, CAGR et drawdown reportes sans fard, sans pretendre a la preuve.
+
 ---
 
 **Bon trading algorithmique avec QuantConnect + CoursIA !**

--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -447,6 +447,8 @@ RL/
 | [Probas](../Probas/README.md) | Decision bayesienne (notebooks 17-20) | Les MDP du RL generalisent les processus decisionnels de Markov de la serie Probas |
 | [Search](../Search/README.md) | Optimisation combinatoire | La planification RL (value/policy iteration) ressemble a la recherche dans un espace d'etats |
 
+[La mer qui monte](../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du depot — la politique apprise comme certificat ouvert, dont la seule caution est le rendement mesure sur des episodes, declare comme tel.
+
 ## Licence
 
 Voir la licence du repository principal.

--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -432,6 +432,8 @@ Sudoku-0-Csharp (Environment - comprendre les structures)
 | [GameTheory](../GameTheory/README.md) | Theorie des jeux | Minimax et MCTS (Niveau 3) sont partages avec les jeux combinatoires ; les arbres de recherche sont structures semblablement |
 | [ML](../ML/README.md) | Machine Learning | Les solveurs neuronaux (Niveau 6) et l'evaluation LLM (Niveau 7) prolongent les techniques ML/DL pour la resolution de puzzles |
 
+[La mer qui monte](../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du depot — le Sudoku comme cas d'ecole du changement de representation : contraintes, SAT ou recherche pure, trois langues pour une meme grille.
+
 ## Prerequis
 
 ### C# (.NET Interactive)

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -234,6 +234,8 @@ Le pipeline genere un rapport JSON dans `output/analysis_report.json` :
 | **[Lean](../Lean/)** | Preuves formelles | La formalisation logique des arguments (Agentic-2) suit le meme paradigme que les tactiques Lean. La verification de coherence via SAT est analogue aux proof checkers. |
 | **[Tweety-9](../Tweety/Tweety-9-Preferences.ipynb)** | Preferences et vote | L'analyse d'arguments de valeur croise les modeles de preference et la theorie du choix social (GameTheory/social_choice_lean/). |
 
+[La mer qui monte](../../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du depot — l'analyse d'argumentation comme changement de representation vers le verifiable : du langage naturel aux semantiques formelles qu'on peut interroger.
+
 > **Note** : Cette serie est en statut DRAFT — les notebooks definissent l'architecture mais n'ont pas encore d'execution complete. Voir [RECONSTRUCTION_PLAN.md](RECONSTRUCTION_PLAN.md) pour le statut.
 
 ## Ressources


### PR DESCRIPTION
## Summary

Complete le critere d'acceptation 4 de #2065 (« Quelques liens depuis les series citees ») : 10 des 16 series citees par [docs/grothendieckian-lens.md](https://github.com/jsboige/CoursIA/blob/main/docs/grothendieckian-lens.md) portaient deja le cross-link une-ligne ; cette PR ajoute les 6 manquantes.

| Serie | Ligne ajoutee (angle, fidele au doc) |
|-------|--------------------------------------|
| RL | politique apprise = certificat ouvert (rendement sur episodes) |
| IIT | Phi *calcule* sans pretendre *demontrer* |
| Sudoku | cas d'ecole du changement de representation (contraintes / SAT / recherche) |
| ML | modele entraine = certificat ouvert, evaluation declaree comme telle |
| QuantConnect | backtest hors-echantillon = certificat ouvert (Sharpe/CAGR/MaxDD sans fard) |
| Argument_Analysis | langage naturel -> semantiques formelles interrogeables |

## Scope

- 6 fichiers, 12 lignes ajoutees (1 ligne de prose + 1 ligne vide chacun), 0 suppression.
- Markdown only — aucune cellule de notebook, aucun bloc CATALOG-STATUS, aucun fichier genere touche.
- Format identique a la convention existante (GameTheory/README.md:591, GenAI/README.md:338) : ligne de prose apres le bloc Cross-series Bridges, contenu specifique par serie (pas de copie-colle generique).

## Verification

- `docs/grothendieckian-lens.md` existe a la racine docs/ : chemins relatifs `../../docs/` (series niveau 1) et `../../../docs/` (Argument_Analysis, niveau 2) verifies.
- `git diff` : 6 files changed, 12 insertions(+), 0 deletions.

Closes #2065 (avec les autres criteres deja en place : doc consolide et indexe dans docs/README.md, conclusion Lean-13 cell 28, annexe A/B/C, PR #2064 mergee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)