### PR TITLE
docs(readme): #2651 P2 lot 1 — Search Part1/Part2 + GenAI CaseStudies vers le gabarit

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/README.md
@@ -7,55 +7,52 @@ breakdown: CaseStudies=4
 maturity: PRODUCTION=3, BETA=1
 -->
 
-Projets etudiants en IA generative : generation d'images, agents conversationnels, et jeux interactifs.
+[← GenAI](../README.md)
 
-**4 notebooks** | **4 projets** | **~4-6h**
+Quatre projets complets, bout en bout, illustrent la diversite des applications de l'IA generative : un duel verbal multi-agent avec generation d'images, un generateur de recettes orchestre par agents, un chatbot medical multi-agent avec plugins, et un jeu interactif inspire de Fort Boyard. Chaque projet combine appel a un LLM (OpenAI) avec une architecture agentique (Semantic Kernel ou API directe), et inclut des exercices pour etendre le systeme.
 
-## Structure
+Ces notebooks sont le point d'entree ideal pour decouvrir les capacites de l'IA generative avant d'approfondir dans les series thematiques ([Texte](../Texte/README.md), [SemanticKernel](../SemanticKernel/README.md), [Image](../Image/README.md)).
 
-```text
-CaseStudies/
-├── Barbie-Schreck/     # Generation d'images hybrides (DALL-E)
-├── Recipe-Maker/       # Generateur de recettes (Semantic Kernel)
-├── Medical-Chatbot/    # Chatbot medical (Semantic Kernel)
-└── Fort-Boyard/        # Jeu interactif (OpenAI GPT)
-```
+## Objectifs d'apprentissage
+
+A l'issue de ces projets, vous serez capable de :
+
+1. **Orchestrer** des agents conversationnels multi-role avec Semantic Kernel ou l'API OpenAI
+2. **Integrer** la generation d'images (DALL-E) dans un dialogue automatise
+3. **Concevoir** des strategies de terminaison et des plugins specialises pour des agents
+4. **Etendre** un projet existant en ajoutant des contraintes, des agents ou des fonctionnalites (exercices inclus)
 
 ## Projets
 
-| Projet | Notebook | Technologies | Difficulte |
-|--------|----------|-------------|-----------|
-| [Barbie-Schreck](Barbie-Schreck/README.md) | barbie-schreck.ipynb | OpenAI DALL-E, PIL | Intermédiaire |
-| [Recipe-Maker](Recipe-Maker/README.md) | receipe_maker.ipynb | Semantic Kernel, OpenAI | Intermédiaire |
-| [Medical-Chatbot](Medical-Chatbot/README.md) | medical_chatbot.ipynb | Semantic Kernel, OpenAI | Avance |
-| [Fort-Boyard](Fort-Boyard/README.md) | fort-boyard-python.ipynb | OpenAI GPT | Intermédiaire |
+| # | Projet | Notebook | Technologies | Contenu |
+|---|--------|----------|-------------|---------|
+| 1 | [Barbie-Schreck](Barbie-Schreck/README.md) | [barbie-schreck.ipynb](Barbie-Schreck/barbie-schreck.ipynb) | Semantic Kernel, OpenAI DALL-E | Duel verbal contraint entre Barbie et l'Ane de Shrek avec generation d'images |
+| 2 | [Recipe-Maker](Recipe-Maker/README.md) | [receipe_maker.ipynb](Recipe-Maker/receipe_maker.ipynb) | Semantic Kernel, OpenAI, PDF | Collaboration multi-agents pour generer une recette personnalisee avec export PDF |
+| 3 | [Medical-Chatbot](Medical-Chatbot/README.md) | [medical_chatbot.ipynb](Medical-Chatbot/medical_chatbot.ipynb) | Semantic Kernel, OpenAI, plugins | Chatbot medical avec plugins de verification, logging et terminaison intelligente |
+| 4 | [Fort-Boyard](Fort-Boyard/README.md) | [fort-boyard-python.ipynb](Fort-Boyard/fort-boyard-python.ipynb) | OpenAI GPT | Jeu de devinettes entre le Pere Fouras et un candidat, avec strategies de terminaison |
 
-## Prerequis communs
+Chaque projet contient 3 exercices permettant d'etendre le systeme (ajout de contraintes, nouveaux agents, strategies de terminaison personnalisees).
 
-```bash
-pip install openai pandas numpy semantic-kernel
-```
+## Prerequis & environnement
+
+| Besoin | Detail |
+|--------|--------|
+| Python | 3.10+ |
+| `openai` | Requis pour les 4 projets |
+| `semantic-kernel` | Requis pour Barbie-Schreck, Recipe-Maker et Medical-Chatbot |
+| Cle API | `OPENAI_API_KEY` dans `GenAI/.env` (voir [00-GenAI-Environment](../00-GenAI-Environment/README.md)) |
+| `fpdf` | Recipe-Maker uniquement (generation PDF) |
 
 ## FAQ
 
-### Quelle cle API est requise pour les projets ?
+### Quelle cle API est requise ?
 
-- **Barbie-Schreck** et **Fort-Boyard** : `OPENAI_API_KEY` uniquement (modeaux GPT et DALL-E).
-- **Recipe-Maker** et **Medical-Chatbot** : `OPENAI_API_KEY` + un service Semantic Kernel configure (Azure OpenAI ou OpenAI direct).
-
-Configurer les cles dans `GenAI/.env` (voir [00-GenAI-Environment](../00-GenAI-Environment/README.md) pour le setup complet).
+Les 4 projets necessitent `OPENAI_API_KEY`. Recipe-Maker et Medical-Chatbot utilisent en plus Semantic Kernel pour l'orchestration agentique. Configurer les cles dans `GenAI/.env` (voir [00-GenAI-Environment](../00-GenAI-Environment/README.md)).
 
 ### Peut-on executer Medical-Chatbot sans Semantic Kernel ?
 
 Medical-Chatbot utilise Semantic Kernel pour l'orchestration des plugins (requete vers API, parsing, formatage de reponse). Pour le faire sans SK, remplacer les appels `kernel.invoke()` par des appels directs `openai.chat.completions.create()` -- la logique metier reste la meme, seule la couche d'orchestration change.
 
-### Quelle difference entre CaseStudies et les autres series GenAI ?
+### Quelle difference avec les autres series GenAI ?
 
-| Serie | Focus | Prerequis |
-|-------|-------|-----------|
-| **CaseStudies** (ici) | Projets complets bout-en-bout | Python basique + cle API |
-| [Texte](../Texte/README.md) | Techniques NLL/prompting avancees | Python intermediaire |
-| [SemanticKernel](../SemanticKernel/README.md) | Orchestration agents multi-services | Python + concepts SK |
-| [Image](../Image/README.md) | Generation/edition d'images | Docker + GPU |
-
-CaseStudies est le point d'entree ideal pour decouvrir les capacites GenAI avant d'approfondir dans les series thematiques.
+CaseStudies rassemble des projets complets et autonomes, adaptes de realisations etudiantes. Les series thematiques approfondissent chaque composant : [Texte](../Texte/README.md) pour les techniques NLP avancees, [SemanticKernel](../SemanticKernel/README.md) pour le SDK d'orchestration, [Image](../Image/README.md) pour la generation et l'edition d'images.

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -1,16 +1,10 @@
 # Partie 1 : Search Fondamental
 
-Cette partie couvre les **algorithmes de recherche classiques**, depuis l'exploration systematique d'espaces d'etats (BFS, DFS, A*) jusqu'aux metaheuristiques inspirees de la nature (algorithmes genetiques, PSO). Le fil rouge est la reduction progressive de l'espace de recherche : comment passer d'une enumeration aveugle a une exploration intelligemment guidee.
+[↑ Serie Search](../README.md) | [Partie 2 : CSP →](../Part2-CSP/README.md)
 
-Vous commencerez par formaliser des problemes sous forme d'espaces d'etats (Search-1), puis decouvrirez les trois grands paradigmes : recherche systematique (BFS/A*), optimisation locale (Hill Climbing, recuit simule), et recherche dans les jeux (Minimax, MCTS). Les notebooks avances couvrent des extensions industrielles (programmation lineaire, automates symboliques, metaheuristiques comparees).
+Comment passer d'une enumeration exhaustive a une exploration intelligemment guidee d'un espace d'etats ? Cette premiere partie couvre les trois grands paradigmes de la recherche en IA : systematique (BFS, A*), locale (Hill Climbing, recuit simule) et evolutive (algorithmes genetiques, PSO). Le fil rouge est la reduction progressive de l'espace de recherche, depuis la formalisation du probleme jusqu'aux metaheuristiques comparees sur des benchmarks.
 
-**11 notebooks** | **~12h30** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `z3-solver`)
-
-## Pourquoi cette sous-serie
-
-La recherche est le pilier de l'IA classique : tout probleme peut se ramener a l'exploration d'un espace d'etats. Cette partie couvre les **trois grands paradigmes** (systematique, locale, evolutive) avec une progression qui va de la theorie (formalisation) a la pratique (benchmarks reels). Le fil rouge est la reduction progressive de l'espace de recherche : comment passer d'une enumeration aveugle a une exploration intelligemment guidee.
-
-Ces fondamentaux sont le prerequis de [Partie 2 (CSP)](../Part2-CSP/README.md) et des [Applications](../Applications/README.md) — maitriser les algorithmes de cette partie est essentiel avant de passer aux contraintes et aux projets.
+Vous commencerez par poser le cadre formel (S, A, T, G) dans Search-1, puis decouvrirez les algorithmes non informes et informes, la recherche locale et genetique, la recherche adversariale (Minimax, MCTS) et les extensions que sont la programmation lineaire, les automates symboliques et les metaheuristiques.
 
 ## Objectifs d'apprentissage
 
@@ -24,88 +18,47 @@ A l'issue de cette partie, vous serez capable de :
 
 ## Notebooks
 
-| # | Notebook | Duree | Contenu | Prerequis |
-|---|----------|-------|---------|-----------|
-| 1 | [Search-1-StateSpace](Search-1-StateSpace.ipynb) | ~40 min | Espaces d'etats, formalisation (S, A, T, G), taquin, aspirateur, route | Python basique |
-| 2 | [Search-2-Uninformed](Search-2-Uninformed.ipynb) | ~50 min | BFS, DFS, UCS, IDDFS, comparaison systematique | Search-1 |
-| 3 | [Search-3-Informed](Search-3-Informed.ipynb) | ~50 min | A*, Greedy, IDA*, heuristiques admissibles et consistantes | Search-2 |
-| 4 | [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) | ~45 min | Hill Climbing, Simulated Annealing, Tabu Search, paysages de fitness | Search-2 |
-| 5 | [Search-5-GeneticAlgorithms](Search-5-GeneticAlgorithms.ipynb) | ~50 min | Selection, crossover, mutation, DEAP/PyGAD, theorie unifiee | Search-4 |
-| 6 | [Search-6-AdversarialSearch](Search-6-AdversarialSearch.ipynb) | ~1h | Minimax, Alpha-Beta pruning, Null-window search, Transposition tables | Search-2, Search-3 |
-| 7 | [Search-7-MCTS-And-Beyond](Search-7-MCTS-And-Beyond.ipynb) | ~1h30 | MCTS, UCB1, OpenSpiel, AlphaGo-style (DQN+MCTS) | Search-6 |
-| 8 | [Search-8-DancingLinks](Search-8-DancingLinks.ipynb) | ~1h30 | Algorithme X, DLX, Sudoku, N-Queens, Pentominoes | Search-2 |
-| 9 | [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) | ~2h | PuLP, simplex, transport, diet, sensibilite, PLNE | Algebre lineaire |
-| 10 | [Search-10-SymbolicAutomata](Search-10-SymbolicAutomata.ipynb) | ~2h | DFA/NFA (automata-lib), predicats Z3, automates symboliques | Search-1, SymbolicAI/Z3 |
-| 11 | [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb) | ~1h30 | PSO, ABC, SA, BRO avec MEALPy, benchmark comparatif | Search-4, Search-5 |
+| # | Notebook | Kernel | Contenu | Duree |
+|---|----------|--------|---------|-------|
+| 1 | [Search-1-StateSpace](Search-1-StateSpace.ipynb) | Python 3 | Espaces d'etats, formalisation (S, A, T, G), taquin, aspirateur, recherche d'itineraire | ~40 min |
+| 2 | [Search-2-Uninformed](Search-2-Uninformed.ipynb) | Python 3 | BFS, DFS, UCS, IDDFS : comparaison des algorithmes non informes | ~50 min |
+| 3 | [Search-3-Informed](Search-3-Informed.ipynb) | Python 3 | A*, Greedy, IDA*, heuristiques admissibles et consistantes | ~50 min |
+| 4 | [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) | Python 3 | Hill Climbing, Simulated Annealing, Tabu Search, paysages de fitness | ~45 min |
+| 5 | [Search-5-GeneticAlgorithms](Search-5-GeneticAlgorithms.ipynb) | Python 3 | Selection, crossover, mutation, DEAP/PyGAD, theorie unifiee | ~50 min |
+| 6 | [Search-6-AdversarialSearch](Search-6-AdversarialSearch.ipynb) | Python 3 | Minimax, Alpha-Beta pruning, Null-window search, tables de transposition | ~1h |
+| 7 | [Search-7-MCTS-And-Beyond](Search-7-MCTS-And-Beyond.ipynb) | Python 3 | Monte Carlo Tree Search, UCB1, OpenSpiel, architecture AlphaGo (DQN+MCTS) | ~1h30 |
+| 8 | [Search-8-DancingLinks](Search-8-DancingLinks.ipynb) | Python 3 | Algorithme X de Knuth, Dancing Links (DLX), couverture exacte (Sudoku, N-Queens, Pentominoes) | ~1h30 |
+| 9 | [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) | Python 3 | Programmation lineaire avec PuLP, simplex, probleme du transport, diet problem, PLNE | ~2h |
+| 10 | [Search-10-SymbolicAutomata](Search-10-SymbolicAutomata.ipynb) | Python 3 | Automates finis (DFA/NFA) avec automata-lib, predicats Z3, automates symboliques | ~2h |
+| 11 | [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb) | Python 3 | PSO, ABC, SA, BRO avec MEALPy, benchmark comparatif de metaheuristiques | ~1h30 |
 
-### Ce que chaque notebook apporte
+## Progression
 
-**Search-1 (StateSpace)** pose les fondations : qu'est-ce qu'un probleme de recherche ? Vous apprendrez a definir un espace d'etats (etats initiaux, actions, transitions, buts) et a implementer le taquin, l'aspirateur et la recherche d'itineraire comme des instances de ce cadre general. Ce notebook est le prerequis de toute la serie.
+Les notebooks 1 a 3 forment le socle commun (formalisation, recherche systematique). A partir de Search-2, le parcours se divise en quatre branches :
 
-**Search-2 (Uninformed)** et **Search-3 (Informed)** couvrent les deux faces de la recherche systematique. Le notebook 2 compare BFS, DFS, UCS et IDDFS sans aucune connaissance du domaine. Le notebook 3 introduit les heuristiques et montre comment A* garantie l'optimalite quand l'heuristique est admissible et consistante -- un resultat central.
+- **Recherche locale et evolutive** : Search-4 (LocalSearch) puis Search-5 (GeneticAlgorithms) puis Search-11 (Metaheuristics)
+- **Recherche dans les jeux** : Search-3 puis Search-6 (AdversarialSearch) puis Search-7 (MCTS)
+- **Couverture exacte** : Search-2 puis Search-8 (DancingLinks)
+- **Independants** : Search-9 (LinearProgramming, algebre lineaire requise) et Search-10 (SymbolicAutomata, liens avec SymbolicAI/Z3)
 
-**Search-4 (LocalSearch)** pivote vers l'optimisation locale : Hill Climbing (avec ses plateaux et creux), Simulated Annealing (recuit simule, parametres de temperature) et Tabu Search. Vous visualiserez les paysages de fitness pour comprendre pourquoi la recherche locale reste bloquee.
+Les fondamentaux de cette partie (formalisation, backtracking, heuristiques) sont le prerequis de la [Partie 2 (CSP)](../Part2-CSP/README.md).
 
-**Search-5 (GeneticAlgorithms)** passe a l'evolution : selection, crossover, mutation, remplacement. Implementations avec DEAP et PyGAD, avec une perspective unifiee reliant GA a l'optimisation locale.
+## Prerequis & environnement
 
-**Search-6 (AdversarialSearch)** et **Search-7 (MCTS)** couvrent la recherche dans les jeux a deux joueurs. Le notebook 6 traite Minimax, Alpha-Beta pruning et les tables de transposition. Le notebook 7 va plus loin avec Monte Carlo Tree Search (UCB1), l'integration OpenSpiel et l'architecture AlphaGo (DQN + MCTS).
+| Besoin | Detail |
+|--------|--------|
+| Python | 3.10+, environnement virtuel recommande |
+| `ortools` | Search-9 (Linear Programming) |
+| `deap` | Search-5 (Genetic Algorithms) |
+| `mealpy` | Search-11 (Metaheuristiques) |
+| `z3-solver` | Search-10 (Symbolic Automata) |
+| OpenSpiel | Search-7 (MCTS) : requiert WSL ou Linux |
 
-**Search-8 (DancingLinks)** explore l'algorithme X de Knuth et la structure de donnees DLX (Dancing Links) pour la couverture exacte -- au coeur de la resolution de Sudoku, N-Queens et Pentominoes.
+Pour le setup complet, voir le [README de la serie Search](../README.md).
 
-**Search-9 (LinearProgramming)** ouvre la boite a outils de l'optimisation lineaire (PuLP, simplex) : probleme du transport, diet problem, analyse de sensibilite, programmation lineaire en nombres entiers (PLNE). Notebook independant, utile pour les applications CSP et hybrides.
-
-**Search-10 (SymbolicAutomata)** croise la recherche avec l'IA symbolique : automates finis (DFA/NFA) avec la librairie `automata-lib`, puis automates symboliques avec predicats Z3. Connections naturelles vers la serie SymbolicAI.
-
-**Search-11 (Metaheuristiques)** compare PSO (Particle Swarm Optimization), ABC (Artificial Bee Colony), SA (recuit simule) et BRO avec MEALPy sur un benchmark. Conclusion pratique : quel algorithme choisir selon le probleme ?
-
-## FAQ / Troubleshooting
+## FAQ
 
 | Probleme | Solution |
 |----------|----------|
-| `ModuleNotFoundError: ortools` | `pip install ortools` — necessaire pour Search-9 (Linear Programming) et les applications CSP |
-| `ModuleNotFoundError: deap` | `pip install deap` — necessaire pour Search-5 (Genetic Algorithms) |
-| `ModuleNotFoundError: mealpy` | `pip install mealpy` — necessaire pour Search-11 (Metaheuristiques) |
-| `ModuleNotFoundError: z3-solver` | `pip install z3-solver` — necessaire pour Search-10 (Symbolic Automata) |
-| Search-7 (MCTS) : OpenSpiel ne s'installe pas sur Windows | OpenSpiel requiert WSL ou Linux. Les notebooks 1-6 et 8-11 fonctionnent sous Windows natif |
-| A* trop lent sur les grands graphes | Verifier que l'heuristique est admissible ET consistante. Essayer IDA* (notebook 3) qui consomme moins de memoire |
-| GA stagne sans amelioration | Augmenter le taux de mutation ou la taille de la population. Explorer le notebook 11 pour des metaheuristiques alternatives |
-
-## Progression recommandee
-
-```text
-Search-1 (StateSpace)
-    │
-    └──> Search-2 (Uninformed)
-              │
-              ├──> Search-3 (Informed)
-              │         │
-              │         └──> Search-6 (AdversarialSearch)
-              │                   │
-              │                   └──> Search-7 (MCTS-And-Beyond)
-              │
-              ├──> Search-4 (LocalSearch)
-              │        │
-              │        └──> Search-5 (GeneticAlgorithms)
-              │                  │
-              │                  └──> Search-11 (Metaheuristics)
-              │
-              └──> Search-8 (DancingLinks)
-
-Search-9 (LinearProgramming) - independant
-Search-10 (SymbolicAutomata) - liens avec SymbolicAI
-```
-
-## Ponts inter-series
-
-| Serie | Lien | Relation |
-| ------- | ------ | ---------- |
-| [Partie 2 : CSP](../Part2-CSP/README.md) | Programmation par contraintes | Suite naturelle : recherche declarative |
-| [Applications](../Applications/README.md) | 21 notebooks d'application | Mise en pratique des algorithmes |
-| [Search (parent)](../README.md) | Vue d'ensemble | Contexte et parcours global |
-| [Sudoku](../../Sudoku/) | Resolution par contraintes | Application DLX et CSP |
-| [SymbolicAI/Z3](../../SymbolicAI/) | Search-10 (SymbolicAutomata) | Automates + solveur SMT |
-| [GameTheory](../../GameTheory/) | Jeux combinatoires | MCTS et theorie des jeux |
-
-## Navigation
-
-[<- Retour a la serie Search](../README.md) | [Partie 2 : CSP ->](../Part2-CSP/README.md) | [Applications ->](../Applications/README.md)
+| A* trop lent sur les grands graphes | Verifier que l'heuristique est admissible ET consistante ; essayer IDA* (Search-3), qui consomme moins de memoire |
+| GA stagne sans amelioration | Augmenter le taux de mutation ou la taille de la population ; comparer avec les metaheuristiques de Search-11 |

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
@@ -1,22 +1,16 @@
 # Partie 2 : Programmation par Contraintes
 
-> **Pivot vers SymbolicAI** : Z3, Planning, Logic. Cette partie fait le pont entre les algorithmes de recherche et l'IA symbolique.
+[← Partie 1 : Search](../Part1-Foundations/README.md) | [↑ Serie Search](../README.md) | [Applications →](../Applications/README.md)
 
-La programmation par contraintes (CSP) represente un **changement de paradigme** : au lieu de concevoir un algorithme d'exploration, on declare les contraintes du probleme et le solveur trouve les solutions. Ce modele declaratif est au coeur des outils industriels (ordonnancement, logistique, verification) et s'applique naturellement aux problemes NP-difficiles.
+Au lieu de concevoir un algorithme d'exploration, que se passe-t-il si l'on declare les contraintes du probleme et que l'on laisse le solveur trouver les solutions ? La programmation par contraintes (CSP) represente ce changement de paradigme : on ne cherche plus, on contraint. Ce modele declaratif est au coeur des outils industriels (ordonnancement, logistique, verification) et s'applique naturellement aux problemes NP-difficiles.
 
-Le parcours va des fondamentaux du modele (X, D, C) et du backtracking (CSP-1) a la propagation de contraintes (AC-3, MAC en CSP-2), puis aux extensions avancees : contraintes globales (CSP-3), ordonnancement industriel (CSP-4), optimisation combinatoire (CSP-5), hybridation avec SAT/ML/LLM (CSP-6). Les trois derniers notebooks explorent les frontiers : contraintes souples, temporelles et distribuees.
-
-**9 notebooks** | **~9h** | Python 3.10+ (`ortools`)
-
-## Pourquoi cette sous-serie
-
-La programmation par contraintes represente un **changement de paradigme** fondamental : au lieu de concevoir un algorithme d'exploration, on declare les contraintes du probleme et le solveur trouve les solutions. Ce modele declaratif est au coeur des outils industriels (ordonnancement, logistique, verification) et s'applique naturellement aux problemes NP-difficiles. Cette sous-serie fait le pont entre les algorithmes de recherche (Partie 1) et l'IA symbolique (SymbolicAI), avec des notebooks couvrant les applications industrielles et les frontieres de la recherche.
+Le parcours va des fondamentaux du modele (X, D, C) et du backtracking (CSP-1) a la propagation de contraintes (AC-3, MAC en CSP-2), puis aux extensions avancees : contraintes globales (CSP-3), ordonnancement industriel (CSP-4), optimisation combinatoire (CSP-5), hybridation avec SAT/ML/LLM (CSP-6). Les trois derniers notebooks explorent les frontieres : contraintes souples, temporelles et distribuees.
 
 ## Objectifs d'apprentissage
 
 A l'issue de cette partie, vous serez capable de :
 
-1. **Modeliser** un problemeNP-difficile comme un CSP (variables, domaines, contraintes) et le resoudre avec OR-Tools CP-SAT
+1. **Modeliser** un probleme NP-difficile comme un CSP (variables, domaines, contraintes) et le resoudre avec OR-Tools CP-SAT
 2. **Maitriser** les techniques de propagation (AC-3, Forward Checking, MAC) pour reduire l'espace de recherche
 3. **Exploiter** les contraintes globales (AllDifferent, Cumulative, Circuit) pour les problemes industriels
 4. **Composer** CSP avec SAT, ML et LLM pour des solutions hybrides (LCG, CP+ML, LLM+CSP)
@@ -24,93 +18,47 @@ A l'issue de cette partie, vous serez capable de :
 
 ## Notebooks
 
-| # | Notebook | Duree | Contenu | Prerequis |
-|---|----------|-------|---------|-----------|
-| 1 | [CSP-1-Fundamentals](CSP-1-Fundamentals.ipynb) | ~50 min | Variables, domaines, contraintes, backtracking, MRV, LCV | Search-1, Search-2 |
-| 2 | [CSP-2-Consistency](CSP-2-Consistency.ipynb) | ~45 min | AC-3, Forward checking, MAC, propagation de contraintes | CSP-1 |
-| 3 | [CSP-3-Advanced](CSP-3-Advanced.ipynb) | ~50 min | AllDifferent, cumulative, circuit, symetries, LNS | CSP-2 |
-| 4 | [CSP-4-Scheduling](CSP-4-Scheduling.ipynb) | ~1h | Job-Shop (JSSP), RCPSP, Nurse Scheduling, IntervalVar, NoOverlap, Cumulative | CSP-3 |
-| 5 | [CSP-5-Optimization](CSP-5-Optimization.ipynb) | ~1h | Bin Packing, Knapsack, Cutting Stock, Portfolio Optimization, cardinalite | CSP-3, Search-11 |
-| 6 | [CSP-6-Hybridization](CSP-6-Hybridization.ipynb) | ~1h30 | Lazy Clause Generation (LCG), CP+SAT, CP+ML, LLM+CSP, parallelisation | CSP-4, CSP-5 |
-| 7 | [CSP-7-Soft](CSP-7-Soft.ipynb) | ~1h | Contraintes souples, Fuzzy CSP, Weighted CSP, Semiring-based CSP | CSP-1, CSP-2 |
-| 8 | [CSP-8-Temporal](CSP-8-Temporal.ipynb) | ~1h | Allen's Interval Algebra, STP, TCSP, raisonnement temporel | CSP-1, CSP-2 |
-| 9 | [CSP-9-Distributed](CSP-9-Distributed.ipynb) | ~1h30 | Asynchronous Backtracking (ABT), AWC, Privacy-preserving CSP | CSP-1, CSP-2, CSP-6 |
+| # | Notebook | Kernel | Contenu | Duree |
+|---|----------|--------|---------|-------|
+| 1 | [CSP-1-Fundamentals](CSP-1-Fundamentals.ipynb) | Python 3 | Modele CSP (X, D, C), backtracking, heuristiques MRV et LCV | ~50 min |
+| 2 | [CSP-2-Consistency](CSP-2-Consistency.ipynb) | Python 3 | AC-3, Forward Checking, MAC : propagation de contraintes | ~45 min |
+| 3 | [CSP-3-Advanced](CSP-3-Advanced.ipynb) | Python 3 | Contraintes globales OR-Tools : AllDifferent, Cumulative, Circuit, LNS | ~50 min |
+| 4 | [CSP-4-Scheduling](CSP-4-Scheduling.ipynb) | Python 3 | Job-Shop (JSSP), RCPSP, Nurse Scheduling, IntervalVar, NoOverlap | ~1h |
+| 5 | [CSP-5-Optimization](CSP-5-Optimization.ipynb) | Python 3 | Bin Packing, Knapsack, Cutting Stock, Portfolio Optimization | ~1h |
+| 6 | [CSP-6-Hybridization](CSP-6-Hybridization.ipynb) | Python 3 | Lazy Clause Generation (LCG), CP+SAT, CP+ML, LLM+CSP | ~1h30 |
+| 7 | [CSP-7-Soft](CSP-7-Soft.ipynb) | Python 3 | Contraintes souples : Fuzzy CSP, Weighted CSP, Semiring-based CSP | ~1h |
+| 8 | [CSP-8-Temporal](CSP-8-Temporal.ipynb) | Python 3 | Algebre d'intervalles d'Allen, Simple Temporal Problems (STP), TCSP | ~1h |
+| 9 | [CSP-9-Distributed](CSP-9-Distributed.ipynb) | Python 3 | Asynchronous Backtracking (ABT), AWC, Privacy-preserving CSP | ~1h30 |
 
-### Ce que chaque notebook apporte
+## Progression
 
-**CSP-1 (Fundamentals)** pose le cadre formel : un CSP = triplet (X, D, C) avec variables, domaines et contraintes. Vous implementerez le backtracking avec les heuristiques MRV (Minimum Remaining Values) et LCV (Least Constraining Value), et comparerez avec la recherche aveugle de Search-2.
+CSP-1 et CSP-2 forment le socle (modele + propagation). A partir de CSP-3, le parcours se divise :
 
-**CSP-2 (Consistency)** introduit la propagation de contraintes -- la cle qui transforme un backtracking naif en solveur efficace. AC-3 (Arc Consistency), Forward Checking et MAC (Maintaining Arc Consistency) sont implementes et compares sur des instances croissantes.
+- **Applications industrielles** : CSP-3 puis CSP-4 (Scheduling) et/ou CSP-5 (Optimization)
+- **Frontieres** : CSP-6 (Hybridization, le notebook le plus avance), puis CSP-7/8/9 (Soft/Temporal/Distributed)
+- **Independants** : CSP-7, CSP-8 et CSP-9 sont accessibles apres CSP-1 + CSP-2
 
-**CSP-3 (Advanced)** entre dans le monde industriel avec les contraintes globales d'OR-Tools CP-SAT : AllDifferent, Cumulative, Circuit. Vous decouvrirez aussi la recherche dans les voisinages larges (LNS) pour les problemes a grande echelle.
+Les notebooks CSP presupposent les bases de la Partie 1 : formalisation en espace d'etats ([Search-1](../Part1-Foundations/Search-1-StateSpace.ipynb)) et backtracking ([Search-2](../Part1-Foundations/Search-2-Uninformed.ipynb)).
 
-**CSP-4 (Scheduling)** applique les contraintes globales aux problemes d'ordonnancement : Job-Shop (JSSP), RCPSP (Resource-Constrained Project Scheduling), et Nurse Scheduling. Les intervalles (IntervalVar), les contraintes NoOverlap et Cumulative deviennent vos outils quotidiens.
+## Prerequis & environnement
 
-**CSP-5 (Optimization)** couvre les classiques de l'optimisation combinatoire : Bin Packing, Knapsack, Cutting Stock, Portfolio Optimization. Les contraintes de cardinalite et les objectifs multi-criteres completent la boite a outils.
+| Besoin | Detail |
+|--------|--------|
+| Python | 3.10+, environnement virtuel recommande |
+| `ortools` | Dependence principale de toute la serie (CP-SAT) |
+| Cle API (optionnel) | CSP-6, section LLM+CSP uniquement ; le reste du notebook fonctionne sans |
 
-**CSP-6 (Hybridization)** est le notebook le plus avance : Lazy Clause Generation (LCG) qui combine CP et SAT, l'hybridation CP+ML pour guider la recherche, et meme LLM+CSP pour la generation de contraintes a partir de langage naturel. Un pont vers la recherche contemporaine.
+Pour le setup complet, voir le [README de la serie Search](../README.md).
 
-**CSP-7 (Soft Constraints)** etend le cadre aux problemes ou toutes les contraintes ne peuvent etre satisfaites simultanement : Fuzzy CSP, Weighted CSP, et le cadre theorique des Semirings. Essentiel pour les applications reelles ou les compromis sont inevitables.
-
-**CSP-8 (Temporal)** specialise les CSP au raisonnement temporel : algebre d'intervalles d'Allen (13 relations), Simple Temporal Problems (STP), et Temporal CSP (TCSP). Applications en planification et diagnostic.
-
-**CSP-9 (Distributed)** explore les CSP multi-agents : Asynchronous Backtracking (ABT), Asynchronous Weak-Commitment (AWC), et les approches preservant la confidentialite. Connecte avec les systemes multi-agents et la planification distribuee.
-
-## FAQ / Troubleshooting
+## FAQ
 
 | Probleme | Solution |
 |----------|----------|
-| `ModuleNotFoundError: ortools` | `pip install ortools` — seul dependency externe de la serie |
-| Solveur CP-SAT trop lent sur les grandes instances | Activer les contraintes globales (AllDifferent, Cumulative) plutot que des contraintes binaires. Utiliser LNS (CSP-3) |
-| CSP-6 : LLM+CSP necessite une cle API | La section LLM est optionnelle. Les sections LCG et CP+ML fonctionnent sans API |
-| CSP-9 : les algorithmes distribues ne convergent pas | Verifier que le reseau de contraintes est un arbre ou utiliser AWC (Weak-Commitment) au lieu d'ABT |
-| Comment choisir entre CP-SAT et SAT solver ? | CP-SAT pour les contraintes globales et l'optimisation (objectif). SAT pour la decision pure (satisfiabilite). CSP-6 detaille les compromis |
-| Ou sont les applications concretes ? | Voir [Applications/](../Applications/) pour 21 notebooks d'application (N-Queens, Nurse Scheduling, VRP, TSP, etc.) |
+| Solveur CP-SAT trop lent sur les grandes instances | Preferer les contraintes globales (AllDifferent, Cumulative) aux contraintes binaires equivalentes ; utiliser LNS (CSP-3) |
+| Comment choisir entre CP-SAT et un solveur SAT ? | CP-SAT pour les contraintes globales et l'optimisation (objectif), SAT pour la decision pure ; CSP-6 detaille les compromis |
+| CSP-9 : les algorithmes distribues ne convergent pas | Verifier que le reseau de contraintes est un arbre, ou utiliser AWC (Weak-Commitment) au lieu d'ABT |
+| Ou sont les applications concretes ? | Voir [Applications](../Applications/README.md) : 21 notebooks (N-Queens, Nurse Scheduling, VRP, TSP...) |
 
-## Prerequis
+## Ponts vers SymbolicAI
 
-Les notebooks CSP necessitent une comprehension prealable de :
-- **[Search-1 (StateSpace)](../Part1-Foundations/Search-1-StateSpace.ipynb)** : formalisation des problemes
-- **[Search-2 (Uninformed)](../Part1-Foundations/Search-2-Uninformed.ipynb)** : backtracking = DFS avec retour arriere
-
-## Progression recommandee
-
-```text
-CSP-1 (Fundamentals) ──> CSP-2 (Consistency) ──> CSP-3 (Advanced)
-                                                    │
-                                    ┌───────────────┼───────────────┐
-                                    │               │               │
-                              CSP-4           CSP-5           CSP-6
-                            (Scheduling)   (Optimization)  (Hybridization)
-                                    │               │
-                                    └───────────────┘
-                                            │
-                              ┌─────────────┼─────────────┐
-                              │             │             │
-                         CSP-7         CSP-8         CSP-9
-                         (Soft)      (Temporal)   (Distributed)
-```
-
-## Transition vers SymbolicAI
-
-| CSP Concept | SymbolicAI Counterpart |
-|-------------|------------------------|
-| OR-Tools CP-SAT | Z3/01_Linq2Z3_Intro (SMT solving) |
-| Scheduling/Planning | Planners (PDDL, HTN) |
-| Constraint logic | Tweety (Formal Logic) |
-| Temporal CSP | Temporal Planning, STP |
-
-## Ponts inter-series
-
-| Serie | Lien | Relation |
-| ------- | ------ | ---------- |
-| [Partie 1 : Search](../Part1-Foundations/README.md) | Fondamentaux | Prerequis : backtracking, heuristiques |
-| [Applications](../Applications/README.md) | 21 notebooks d'application | Mise en pratique des CSP |
-| [Search (parent)](../README.md) | Vue d'ensemble | Contexte et parcours global |
-| [Sudoku](../../Sudoku/) | Resolution par contraintes | Application directe des CSP |
-| [SymbolicAI/Z3](../../SymbolicAI/) | Solveur SMT | CSP-6 (LCG) et automates symboliques |
-| [Probas/Infer](../../Probas/Infer/) | Infer.NET | Modeles graphiques et contraintes |
-
-## Navigation
-
-[<- Partie 1 : Search Fondamental](../Part1-Foundations/README.md) | [Retour a la serie Search](../README.md) | [Applications ->](../Applications/README.md)
+La programmation par contraintes est le passage naturel vers l'IA symbolique : OR-Tools CP-SAT rejoint Z3 (SMT solving) dans la serie [SymbolicAI](../../SymbolicAI/README.md), l'ordonnancement mene a la planification PDDL (SymbolicAI/Planning), et les contraintes temporelles (CSP-8) se retrouvent dans le planning temporel. Le notebook CSP-6 (LCG) detaille ces passerelles.


### PR DESCRIPTION
## Summary

Premier lot d'application du gabarit [docs/reference/readme-series-gabarit.md](https://github.com/jsboige/CoursIA/blob/main/docs/reference/readme-series-gabarit.md) (#2651 Partie 2), sur les 3 cibles prioritaires listees par le gabarit lui-meme (bimodalite niveau 2) :

- `Search/Part1-Foundations/README.md`
- `Search/Part2-CSP/README.md`
- `GenAI/CaseStudies/README.md`

## Changements par le gabarit

- **Barre de navigation** en tete (parent / precedent / suivant) — element le plus absent du recensement.
- **Pitch ouvert par une question**, plus de bandeau de chiffres (les decomptes vivent dans le catalogue genere).
- **Table notebooks normalisee** `# | Notebook | Kernel | Contenu | Duree` (durees per-notebook conservees).
- **Progression en prose par branches** (remplace les arbres ASCII).
- **Prerequis & environnement** en table bornee (absorbe les rows pip-install des anciennes FAQ).
- **FAQ bornees** (2-4 entrees substantielles conservees : A*→IDA*, CP-SAT→LNS, ABT→AWC, Medical-Chatbot sans SK) au lieu des blocs hypertrophies.
- **Ponts cross-series specifiques en prose** ; tables de ponts generiques d'une ligne retirees (anti-pattern 3 du gabarit).
- **CaseStudies enrichi** : objectifs d'apprentissage ajoutes, colonne Contenu rapprochee du contenu reel des notebooks, **description Barbie-Schreck corrigee** (duel verbal Semantic Kernel AgentGroupChat avec illustration DALL-E — etait decrit a tort comme un projet data-viz/pandas).

## Hors scope, a noter

- **CATALOG-STATUS** : bloc CaseStudies intact (bot-owned) ; les sous-series Search n'en ont pas — l'ajout passe par le cycle bot (regle dure du gabarit).
- **`Search/Part3-Advanced` n'existe pas** : la 3e sous-serie reelle est `Search/Applications/` (21 notebooks). La cartographie de CLAUDE.md est a corriger (suivi separement).
- **Incoherence du sous-README `Barbie-Schreck/README.md`** (decrit encore data-viz/pandas) : flaggee, non corrigee ici (1 livrable par PR).

## Validation

- Tous les liens relatifs verifies (cibles existantes : notebooks, READMEs parents, Applications).
- Aucun notebook touche ; docs-only.
- Review anti-regression du diff : contenu substantiel des FAQ et durees per-notebook restaures apres la passe de condensation initiale ; seules les duplications verbatim (prose per-notebook redondante avec la table, ponts generiques) ont ete retirees.

Refs #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)