### PR TITLE
feat(lean): P4 base case k=0 proven in general inside main theorem (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -819,92 +819,6 @@ theorem p4_ext_bridge (c : MacroCell) (k : Nat)
   unfold restrictGridTo
   exact (canonical_evolve_of_pos (Nat.two_pow_pos k) _).filter _
 
-/-- For a level-`k` MacroCell `c` with `k ≥ 2`, the centered region of
-    `hashlifeResultAux (k+2) c` (viewed at offset `(2^k, 2^k)`) equals
-    `evolve (2^k)` applied to `c.toGrid (0, 0)` and restricted to the
-    centered `[2^k, 2^k + 2^(k+1)) × [2^k, 2^k + 2^(k+1))` region.
-
-    **Statement correction**: offset `(2^k, 2^k)` accounts for centering.
-
-    **Proof strategy** (P4, difficulty: hard, compositional):
-    Strong induction on `k`.
-    - Base `k = 0`: `hashlifeResultAux 2 c` reduces to `step4x4 c`, which
-      is the direct B3/S23 computation on a 4x4 grid. The centered 2x2
-      result at offset `(1, 1)` matches `evolve 1` restricted to `[1,3)×[1,3)`.
-    - Inductive step `k → k+1`: the recursive Hashlife makes 9 sub-calls on
-      level-`(k+1)` cells, then 4 sub-calls on the resulting level-`k`
-      supercells. Each sub-call uses the IH at level `k`. The composition
-      matches `step^[2^(k+1)]` by the light-cone lemma P2 applied 2^(k-1)
-      times (once per "half-step" in the double-nine decomposition). -/
-theorem hashlifeResult_central_correct (c : MacroCell) (k : Nat)
-    (hwf : c.wf = true) (hk : c.level = k + 2) :
-    let result := hashlifeResultAux (k + 2) c
-    let resultGrid := result.toGrid ((2^k : Nat), (2^k : Nat))
-    let expected := evolve (2^k) (c.toGrid (0, 0))
-    resultGrid = restrictGridTo expected (2^k : Int) (2^(k+1)) := by
-  -- P4 TARGET: central Hashlife correctness, by induction on level.
-  -- `p4_ext_bridge` has discharged the canonical-list bookkeeping: the
-  -- remaining goal is the pointwise membership biconditional, where the
-  -- light-cone (P2) and double-nine decomposition arguments live.
-  exact p4_ext_bridge c k (fun p => by sorry)
-
-/-! ## P4 witnesses: base case k=0 (native_decide)
-
-Concrete level-2 MacroCells verifying that the corrected P4 statement
-holds on the base case `k = 0` (level-2 input, offset `(1,1)`, 1 generation).
-Each `native_decide` confirms the theorem is satisfiable. -/
-
-/-- Level-2 cell with the block pattern at positions (1,1)-(2,2). -/
-private def blockCell : MacroCell :=
-  MacroCell.node (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf true))
-                 (MacroCell.node (leaf false) (leaf false) (leaf true)  (leaf false))
-                 (MacroCell.node (leaf false) (leaf true)  (leaf false) (leaf false))
-                 (MacroCell.node (leaf true)  (leaf false) (leaf false) (leaf false))
-
-/-- Level-2 cell with a horizontal blinker at positions (0,1),(1,1),(2,1). -/
-private def blinkerHCell : MacroCell :=
-  MacroCell.node (MacroCell.node (leaf false) (leaf true) (leaf false) (leaf true))
-                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
-                 (MacroCell.node (leaf false) (leaf true) (leaf false) (leaf false))
-                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
-
-/-- Level-2 cell with the glider pattern at positions (0,1),(1,2),(2,0),(2,1),(2,2). -/
-private def gliderCell : MacroCell :=
-  MacroCell.node (MacroCell.node (leaf false) (leaf true)  (leaf false) (leaf false))
-                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf true))
-                 (MacroCell.node (leaf true)  (leaf true)  (leaf false) (leaf false))
-                 (MacroCell.node (leaf true)  (leaf false) (leaf false) (leaf false))
-
-/-- P4 base case k=0 on block (still life): centered 2x2 matches after 1 step. -/
-theorem p4_base_block :
-    (hashlifeResultAux 2 blockCell).toGrid (1, 1)
-    = restrictGridTo (evolve 1 (blockCell.toGrid (0, 0))) 1 2 := by
-  native_decide
-
-/-- P4 base case k=0 on all-dead: trivially empty. -/
-private def deadCell : MacroCell :=
-  MacroCell.node (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
-                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
-                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
-                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
-
-theorem p4_base_dead :
-    (hashlifeResultAux 2 deadCell).toGrid (1, 1)
-    = restrictGridTo (evolve 1 (deadCell.toGrid (0, 0))) 1 2 := by
-  native_decide
-
-/-- P4 base case k=0 on glider: centered 2x2 matches after 1 step. -/
-theorem p4_base_glider :
-    (hashlifeResultAux 2 gliderCell).toGrid (1, 1)
-    = restrictGridTo (evolve 1 (gliderCell.toGrid (0, 0))) 1 2 := by
-  native_decide
-
-/-- P4 base case k=0 on blinker: key test — cell (1,0) is outside center. -/
-theorem p4_base_blinker :
-    (hashlifeResultAux 2 blinkerHCell).toGrid (1, 1)
-    = restrictGridTo (evolve 1 (blinkerHCell.toGrid (0, 0))) 1 2 := by
-  native_decide
-
 /-! ## P4 base case, proven in general
 
 The base case `k = 0` of the (corrected) P4 statement, proven for **all**
@@ -996,6 +910,96 @@ theorem hashlifeResult_central_correct_base (c : MacroCell)
   obtain ⟨v16, rfl⟩ := shape_of_level_zero e4 hle4
   exact p4_base_exhaustive v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12 v13 v14
     v15 v16
+
+/-- For a level-`k` MacroCell `c` with `k ≥ 2`, the centered region of
+    `hashlifeResultAux (k+2) c` (viewed at offset `(2^k, 2^k)`) equals
+    `evolve (2^k)` applied to `c.toGrid (0, 0)` and restricted to the
+    centered `[2^k, 2^k + 2^(k+1)) × [2^k, 2^k + 2^(k+1))` region.
+
+    **Statement correction**: offset `(2^k, 2^k)` accounts for centering.
+
+    **Proof strategy** (P4, difficulty: hard, compositional):
+    Strong induction on `k`.
+    - Base `k = 0`: `hashlifeResultAux 2 c` reduces to `step4x4 c`, which
+      is the direct B3/S23 computation on a 4x4 grid. The centered 2x2
+      result at offset `(1, 1)` matches `evolve 1` restricted to `[1,3)×[1,3)`.
+    - Inductive step `k → k+1`: the recursive Hashlife makes 9 sub-calls on
+      level-`(k+1)` cells, then 4 sub-calls on the resulting level-`k`
+      supercells. Each sub-call uses the IH at level `k`. The composition
+      matches `step^[2^(k+1)]` by the light-cone lemma P2 applied 2^(k-1)
+      times (once per "half-step" in the double-nine decomposition). -/
+theorem hashlifeResult_central_correct (c : MacroCell) (k : Nat)
+    (hwf : c.wf = true) (hk : c.level = k + 2) :
+    let result := hashlifeResultAux (k + 2) c
+    let resultGrid := result.toGrid ((2^k : Nat), (2^k : Nat))
+    let expected := evolve (2^k) (c.toGrid (0, 0))
+    resultGrid = restrictGridTo expected (2^k : Int) (2^(k+1)) := by
+  -- P4 TARGET: central Hashlife correctness, by induction on level.
+  -- Base case k = 0 holds in full generality (shape lemmas + 2^16
+  -- native_decide). `p4_ext_bridge` discharges the canonical-list
+  -- bookkeeping of the remaining arm: the goal left is the pointwise
+  -- membership biconditional, where the light-cone (P2) and double-nine
+  -- decomposition arguments live.
+  cases k with
+  | zero => exact hashlifeResult_central_correct_base c hwf hk
+  | succ k => exact p4_ext_bridge c (k + 1) (fun p => by sorry)
+
+/-! ## P4 witnesses: base case k=0 (native_decide)
+
+Concrete level-2 MacroCells verifying that the corrected P4 statement
+holds on the base case `k = 0` (level-2 input, offset `(1,1)`, 1 generation).
+Each `native_decide` confirms the theorem is satisfiable. -/
+
+/-- Level-2 cell with the block pattern at positions (1,1)-(2,2). -/
+private def blockCell : MacroCell :=
+  MacroCell.node (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf true))
+                 (MacroCell.node (leaf false) (leaf false) (leaf true)  (leaf false))
+                 (MacroCell.node (leaf false) (leaf true)  (leaf false) (leaf false))
+                 (MacroCell.node (leaf true)  (leaf false) (leaf false) (leaf false))
+
+/-- Level-2 cell with a horizontal blinker at positions (0,1),(1,1),(2,1). -/
+private def blinkerHCell : MacroCell :=
+  MacroCell.node (MacroCell.node (leaf false) (leaf true) (leaf false) (leaf true))
+                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
+                 (MacroCell.node (leaf false) (leaf true) (leaf false) (leaf false))
+                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
+
+/-- Level-2 cell with the glider pattern at positions (0,1),(1,2),(2,0),(2,1),(2,2). -/
+private def gliderCell : MacroCell :=
+  MacroCell.node (MacroCell.node (leaf false) (leaf true)  (leaf false) (leaf false))
+                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf true))
+                 (MacroCell.node (leaf true)  (leaf true)  (leaf false) (leaf false))
+                 (MacroCell.node (leaf true)  (leaf false) (leaf false) (leaf false))
+
+/-- P4 base case k=0 on block (still life): centered 2x2 matches after 1 step. -/
+theorem p4_base_block :
+    (hashlifeResultAux 2 blockCell).toGrid (1, 1)
+    = restrictGridTo (evolve 1 (blockCell.toGrid (0, 0))) 1 2 := by
+  native_decide
+
+/-- P4 base case k=0 on all-dead: trivially empty. -/
+private def deadCell : MacroCell :=
+  MacroCell.node (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
+                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
+                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
+                 (MacroCell.node (leaf false) (leaf false) (leaf false) (leaf false))
+
+theorem p4_base_dead :
+    (hashlifeResultAux 2 deadCell).toGrid (1, 1)
+    = restrictGridTo (evolve 1 (deadCell.toGrid (0, 0))) 1 2 := by
+  native_decide
+
+/-- P4 base case k=0 on glider: centered 2x2 matches after 1 step. -/
+theorem p4_base_glider :
+    (hashlifeResultAux 2 gliderCell).toGrid (1, 1)
+    = restrictGridTo (evolve 1 (gliderCell.toGrid (0, 0))) 1 2 := by
+  native_decide
+
+/-- P4 base case k=0 on blinker: key test — cell (1,0) is outside center. -/
+theorem p4_base_blinker :
+    (hashlifeResultAux 2 blinkerHCell).toGrid (1, 1)
+    = restrictGridTo (evolve 1 (blinkerHCell.toGrid (0, 0))) 1 2 := by
+  native_decide
 
 /-! ## P4 witnesses: recursive arms (k = 1, k = 2)
 


### PR DESCRIPTION
## Summary

Restructure du theoreme principal P4 `hashlifeResult_central_correct` (HashlifeCorrectness.lean) : induction sur le niveau via `cases k`, avec **le cas de base k=0 desormais prouve en toute generalite** a l'interieur du theoreme principal (plus derriere le sorry).

- La section "P4 base case, proven in general" (`shape_of_level_zero`, `shape_of_level_succ`, `wf_node_elim`, `p4_base_exhaustive` [16 booleens de feuilles -> 2^16 `native_decide`], `hashlifeResult_central_correct_base`) est **relocalisee au-dessus** du theoreme principal pour que le bras `zero` puisse la fermer par `exact` (accepte par defeq : `0+2 ≡ 2`, `2^0 ≡ 1`, `(2^0:Int) ≡ 1`, `2^(0+1) ≡ 2`).
- Le bras `succ` conserve `p4_ext_bridge c (k+1) (fun p => by sorry)` — le sorry P4 est maintenant **scope a k ≥ 1 uniquement**, sous forme de bicondition d'appartenance (la ou vivent les arguments light-cone P2 + double-nine).
- **Enonce du theoreme principal inchange** (aucune modification de Statement, pas de regression).

See #2162

## Preuves (regle B)

1. **`grep -c sorry` avant/apres** : 2 -> 2 declarations (`HashlifeCorrectness.lean:931` bras succ P4, `:1055` P5). Le compte est stable mais le perimetre du sorry P4 se reduit : le cas de base k=0 n'est plus sorrie.
2. **Lake build SUCCESS local (WSL)** :
   ```
   warning: Conway/Life/HashlifeCorrectness.lean:931:8: declaration uses `sorry`
   warning: Conway/Life/HashlifeCorrectness.lean:1055:8: declaration uses `sorry`
   ✔ [3351/3352] Built Conway (9.0s)
   Build completed successfully (3352 jobs).
   ```
3. **Proof integrity** : axiomes attendus inchanges ([propext, Classical.choice, Quot.sound] — `native_decide` via `Lean.ofReduceBool` sur le cas de base, deja present dans les witnesses #2790/#2797).
4. **Pas de refactor Python** : diff limite a `HashlifeCorrectness.lean` (90+/86-, relocalisation de section + restructuration `cases k`).

## Note coordination

ai-01 a lance un BG prover iter sur le sorry P4 (L849 pre-restructure). Apres merge, la cible vivante est le bras succ L931 (forme membership via `p4_ext_bridge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
