### PR TITLE
docs(readme): develop pedagogical prose along the visitor descent path (batch 1)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/README.md
@@ -13,6 +13,20 @@ Quatre projets complets, bout en bout, illustrent la diversite des applications 
 
 Ces notebooks sont le point d'entree ideal pour decouvrir les capacites de l'IA generative avant d'approfondir dans les series thematiques ([Texte](../Texte/README.md), [SemanticKernel](../SemanticKernel/README.md), [Image](../Image/README.md)).
 
+## Pourquoi ces projets
+
+Les séries thématiques de GenAI démontent chaque composant ; ces quatre projets montrent les composants remontés. Adaptés de réalisations étudiantes, ils ont la taille exacte d'un bon projet de fin de module : assez complets pour exiger une vraie architecture — des rôles, une orchestration, des conditions d'arrêt —, assez courts pour être lus en entier. Lire un système complet apprend ce qu'aucun tutoriel ne montre : où placer la logique métier, comment empêcher deux agents de tourner en rond, quand arrêter une conversation. C'est aussi ce qui en fait de bons sujets d'extension, chaque projet se concluant par trois exercices qui ajoutent une contrainte, un agent ou une stratégie.
+
+## Les quatre projets
+
+**[Fort-Boyard](Fort-Boyard/README.md)** est le meilleur point de départ : un Père Fouras qui fait deviner, un candidat qui propose, et l'API OpenAI sans couche d'orchestration. C'est l'occasion de comprendre les stratégies de terminaison à nu — comment décider qu'un dialogue entre deux LLM est terminé — avant de les retrouver enrobées dans Semantic Kernel.
+
+**[Barbie-Schreck](Barbie-Schreck/README.md)** est le plus visuel : deux personnages que tout oppose sont forcés de débattre sous contraintes, pendant que DALL-E illustre la joute. Sous le jeu, la mécanique est sérieuse : c'est un vrai dialogue multi-agent Semantic Kernel, avec ses prompts système rivaux et l'intégration image-dans-conversation.
+
+**[Recipe-Maker](Recipe-Maker/README.md)** fait collaborer plusieurs agents pour produire une recette personnalisée et l'exporter en PDF. Son intérêt est la chaîne complète : de la conversation entre agents jusqu'au livrable final, en passant par la division du travail entre rôles.
+
+**[Medical-Chatbot](Medical-Chatbot/README.md)** est le plus proche d'un système de production : ses plugins de vérification, de journalisation et de terminaison intelligente montrent comment on encadre un LLM dans un domaine sensible. La leçon dépasse le cas médical — la valeur n'est pas dans la réponse du modèle, mais dans les garde-fous qui l'entourent.
+
 ## Objectifs d'apprentissage
 
 A l'issue de ces projets, vous serez capable de :

--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -17,19 +17,27 @@ Dernière mise à jour : 2026-06-11
 
 ## Vue d'ensemble
 
-| Domaine | Description |
-|---------|-------------|
-| **GenAI** | Generation d'images (SDXL, Flux, Qwen-VL), audio (FishAudio S2-Pro, STT/TTS), video, LLMs, RAG, fine-tuning LoRA, orchestration via Semantic Kernel |
-| **QuantConnect** | Trading algorithmique progressif : cours Python pas-a-pas, 49 strategies backtestees (GARCH, Kelly, ensemble), pipeline ML thermal-safe |
-| **SymbolicAI** | Preuve formelle Lean 4 (theoremes d'Arrow, Conway, Kochen-Specker), logiques argumentaires (Tweety), SmartContracts Solidity, Web semantique RDF/SPARQL, apprentissage symbolique (ILP, neuro-symbolique, automates) |
-| **Search** | Satisfaction de contraintes (CSP), recherche operationnelle, metaheuristiques (recuit, genetiques), planification PDDL avec Fast-Downward |
-| **Probas** | Programmation probabiliste : modeles graphiques en Infer.NET (.NET C#), inference bayesienne en PyMC (Python), volet Lean 4 (indice de Gittins) |
-| **Sudoku** | Resolution de contraintes en .NET C# : backtracking, propagation, modeles CNN/MLP, etude comparative d'architectures |
-| **GameTheory** | Theorie des jeux combinatoire (OpenSpiel), choix social formel (theoremes d'Arrow, Sen, Shapley portes en Lean 4), von Neumann |
-| **ML** | Machine Learning .NET (ML.NET) + Python Agents for Data Science : classification, regression, clustering, pipelines |
-| **RL** | Reinforcement Learning avec Stable-Baselines3 : environnements OpenAI Gym, PPO, SAC, evaluation de politiques |
-| **CaseStudies** | Etudes de cas interdisciplinaires : diagnostic medical par LLM, planification oncologique, analyse de sentiments |
-| **IIT** | Integrated Information Theory : mesures Phi avec PyPhi, neurones logiques, conscience et complexite |
+**[GenAI](GenAI/README.md)** — Tout ce qui se génère : images (SDXL, Flux, Qwen), audio — du TTS au pipeline complet d'audiobook —, vidéo, et le travail des LLMs (RAG, raisonnement, fine-tuning LoRA). La série a un parti pris d'atelier : on ne se contente pas d'appeler des APIs, on héberge les modèles soi-même sur une stack Docker dédiée ([00-GenAI-Environment](GenAI/00-GenAI-Environment/README.md)), ce qui change tout à ce qu'on comprend de leurs coûts et de leurs limites. Elle culmine avec l'orchestration Semantic Kernel, quatre études de cas étudiantes et les ateliers de vibe-coding (Claude Code, Roo Code).
+
+**[QuantConnect](QuantConnect/README.md)** — Le ML appliqué à un domaine qui ne pardonne pas : les marchés. Un cours Python progressif mène du premier backtest à un portefeuille de 49 stratégies (GARCH, Kelly, ensembles), implémentant 18 des 19 exemples du livre *Hands-On AI Trading*. La leçon transversale vaut bien au-delà de la finance : une discipline de validation — walk-forward, multi-seed, coûts de transaction — sans laquelle tout résultat de ML est une illusion d'optique.
+
+**[SymbolicAI](SymbolicAI/README.md)** — Le pôle « comprendre et prouver » du dépôt, et sa série la plus vaste : preuves formelles Lean 4 (théorème d'Arrow, Kochen-Specker, hommages à Grothendieck et Conway), smart contracts Solidity testés et déployés sur testnet, Web sémantique RDF/SPARQL, logiques d'argumentation (Tweety), planification PDDL et apprentissage symbolique (ILP, automates, neuro-symbolique). C'est ici que la dualité simulation / preuve prend sa forme la plus aboutie : ce que les autres séries calculent, celle-ci cherche à le certifier.
+
+**[Search](Search/README.md)** — Comment trouver une aiguille dans une botte de foin exponentielle ? Des algorithmes classiques (BFS, A*, Minimax, MCTS) à la programmation par contraintes (CP-SAT) et aux métaheuristiques, la série déroule un fil unique — réduire l'espace de recherche — et le confronte à 21 applications réelles adaptées de projets étudiants, de la planification d'infirmiers à la génération procédurale de niveaux.
+
+**[Probas](Probas/README.md)** — Raisonner avec l'incertitude plutôt que contre elle. La série a une particularité unique dans le dépôt : les mêmes modèles probabilistes y vivent deux fois, en Infer.NET (graphes de facteurs, C#) et en PyMC (MCMC, Python) — deux langues pour une même théorie bayésienne, dont la comparaison est elle-même instructive. Un volet Lean 4 (indice de Gittins) pousse jusqu'à la preuve.
+
+**[Sudoku](Sudoku/README.md)** — Et si l'on prenait un seul problème et qu'on lui appliquait toutes les méthodes ? Backtracking, propagation de contraintes, Dancing Links, jusqu'aux réseaux de neurones (CNN et MLP comparés à budget de paramètres comparable) : le Sudoku sert de banc d'essai contrôlé où approches symboliques et neuronales se mesurent sur exactement le même terrain.
+
+**[GameTheory](GameTheory/README.md)** — Que devient l'optimisation quand les autres aussi optimisent ? Jeux combinatoires avec OpenSpiel, équilibres à la von Neumann, et un volet formel singulier : les théorèmes du choix social (Arrow, Sen, la valeur de Shapley) portés en Lean 4 — démontrés mécaniquement, pas seulement énoncés.
+
+**[ML](ML/README.md)** — Le machine learning classique, sans folklore : tutoriels ML.NET (classification, régression, clustering) côté C#, agents Python pour la data science côté Python. C'est le socle de méthode sur lequel GenAI et QuantConnect construisent.
+
+**[RL](RL/README.md)** — Apprendre en agissant : Stable-Baselines3, environnements Gym, PPO et SAC — et l'évaluation honnête de ce que valent réellement les politiques apprises.
+
+**[CaseStudies](CaseStudies/README.md)** — Des études de cas interdisciplinaires où plusieurs séries convergent sur un même problème : diagnostic médical assisté par LLM, planification oncologique, analyse de sentiments.
+
+**[IIT](IIT/README.md)** — La plus spéculative : la théorie de l'information intégrée et la mesure Phi (PyPhi) appliquées à des réseaux logiques — où l'on calcule, littéralement, des candidats quantitatifs à une mesure de la conscience.
 
 ### Progression pedagogique
 
@@ -88,22 +96,6 @@ SymbolicAI
 - **Symbolic**: RDF, Z3 SMT, Lean 4, SmartContracts
 - **Optimization**: CSP, metaheuristiques, recherche operationnelle
 
-## Liens vers les sous-domaines
-
-| Domaine | Lien |
-|---------|------|
-| **GenAI** | [GenAI/](GenAI/README.md) |
-| **QuantConnect** | [QuantConnect/](QuantConnect/README.md) |
-| **SymbolicAI** | [SymbolicAI/](SymbolicAI/README.md) |
-| **Search** | [Search/](Search/README.md) |
-| **Probas** | [Probas/](Probas/README.md) |
-| **Sudoku** | [Sudoku/](Sudoku/README.md) |
-| **GameTheory** | [GameTheory/](GameTheory/README.md) |
-| **ML** | [ML/](ML/README.md) |
-| **RL** | [RL/](RL/README.md) |
-| **CaseStudies** | [CaseStudies/](CaseStudies/README.md) |
-| **IIT** | [IIT/](IIT/README.md) |
-
 ## Configuration requise
 
 ### Environnement
@@ -133,18 +125,27 @@ docker-compose up -d
 ## Parcours recommande
 
 ### Debutant (30h)
+
+L'objectif de ces premières heures n'est pas l'exhaustivité mais le déclic : produire ses premières images et ses premiers backtests, et installer une bonne fois l'environnement qui resservira partout.
+
 1. **GenAI/00-Environment** - Setup complet
 2. **GenAI/Image/01-Foundation** - Bases images
 3. **GenAI/Audio/01-Foundation** - Bases audio
 4. **QuantConnect/Python/** - Cours QC-Py-01 a 10
 
 ### Intermediaire (60h)
+
+On élargit le spectre : tous les médias génératifs, le ML classique des deux côtés (.NET et Python), les premiers pas symboliques — c'est le moment où les ponts entre séries commencent à apparaître.
+
 1. **GenAI** - Toutes les series sauf Orchestration
 2. **ML** - Tutoriels .NET + Python Agents
 3. **SymbolicAI** - SmartContracts, SemanticWeb
 4. **QuantConnect/partner-course-quant-trading/** - Exercices trading
 
 ### Expert (120h+)
+
+Le cœur formel et les stratégies avancées : les notebooks les plus exigeants, mais ceux où le dépôt dit ce qu'il a de plus singulier — prouver ce qu'on a calculé, et valider sans complaisance ce qu'on a appris.
+
 1. **GenAI/03-Orchestration** + **04-Applications**
 2. **SymbolicAI** - Lean, Planners, Tweety avance
 3. **Search**, **GameTheory**, **Probas** - Domaines avances

--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -1,14 +1,12 @@
 # Search - Applications
 
-Les 21 notebooks d'application illustrent chaque concept de la serie Search sur des **problemes reels** adaptes de projets etudiants. Chaque application combine une ou plusieurs techniques abordees dans les Parties 1-2 et montre comment elles se comportent sur des instances concretes.
-
-Les applications sont organisees en trois categories : **Search pur** (jeux combinatoires), **CSP** (problemes de satisfaction de contraintes : N-Queens, ordonnancement, demineur, mots croises, generation procedurale), et **Hybride** (metaheuristiques et GA : detection de contours, optimisation de portefeuille, TSP, VRP). La plupart des notebooks sont autonomes et pointent vers les pre-requis pertinents.
+C'est ici que la série Search se confronte au réel. Les 21 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents.
 
 Sous-serie de **21 notebooks** | **~14h05** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`)
 
 ## Pourquoi cette sous-serie
 
-Les notebooks d'application sont le laboratoire pratique de la serie Search : chaque probleme reel (N-Queens, ordonnancement, VRP, TSP, detection de contours) combine une ou plusieurs techniques des Parties 1-2 et montre comment elles se comportent sur des instances concretes issues de projets etudiants. La diversite des approches (backtracking, CP-SAT, metaheuristiques, GA, hybridation) permet de comparer les methodes sur un meme probleme et de developper le sens critique pour choisir l'algorithme adapte.
+Un algorithme compris sur un exemple jouet n'est pas encore un algorithme maîtrisé. Les applications servent trois apprentissages que les parties théoriques ne peuvent pas donner. D'abord la confrontation des méthodes : le même problème y est régulièrement résolu plusieurs fois — N-Queens en backtracking, en Min-Conflicts et en OR-Tools ; le TSP en recuit simulé, en génétique, en colonies de fourmis et en solveur de routage — et la comparaison chiffrée vaut tous les discours. Ensuite l'ordre de grandeur : voir un solveur de Picross gagner un facteur de plusieurs millions en passant au CP-SAT imprime durablement ce que « propagation » veut dire. Enfin la modélisation, qui est souvent toute la difficulté : le démineur devient un CSP doublé de probabilités, Wordle un problème de théorie de l'information, la génération procédurale de niveaux un Wave Function Collapse encodé en contraintes — autant de cas où trouver la bonne formulation est l'essentiel du travail.
 
 ## Objectifs d'apprentissage
 
@@ -41,6 +39,8 @@ Applications/
 
 ## Applications Search (`Search/`)
 
+Deux notebooks autour du Puissance 4, le banc d'essai idéal de la recherche adversariale : assez simple pour être résolu, assez riche pour départager les approches. Le premier construit les joueurs (Minimax, MCTS, et un agent DQN appris), le second les fait s'affronter en benchmark systématique.
+
 | # | Notebook | Duree | Contenu | Source |
 |---|----------|-------|---------|--------|
 | 1 | [App-12-ConnectFour](Search/App-12-ConnectFour.ipynb) | ~50 min | Puissance 4 : Minimax, MCTS, DQN-RL | Projet etudiant |
@@ -49,6 +49,8 @@ Applications/
 ---
 
 ## Applications CSP (`CSP/`)
+
+Le gros de la sous-série, et un panorama de ce que la programmation par contraintes sait faire dès qu'on sort du manuel : des classiques fondateurs (N-Queens, coloration de graphes) aux problèmes d'ordonnancement réalistes (infirmiers, job-shop, emplois du temps, calendriers sportifs), en passant par des terrains plus inattendus — le démineur qui mêle contraintes et probabilités, Wordle lu comme un problème d'information, le Picross qui sert de leçon de vitesse, et la génération procédurale de niveaux par Wave Function Collapse.
 
 | # | Notebook | Duree | Contenu | Source |
 |---|----------|-------|---------|--------|
@@ -68,6 +70,8 @@ Applications/
 ---
 
 ## Applications Hybrid / Metaheuristiques (`Hybrid/`)
+
+Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes exactes, place aux métaheuristiques : détection de contours et optimisation de portefeuille par algorithmes génétiques (avec leurs doublons C#/GeneticSharp en side-track .NET), TSP et VRP attaqués par quatre méthodes concurrentes, et le réglage d'hyperparamètres ML — où la boucle se referme : on optimise l'optimiseur.
 
 | # | Notebook | Duree | Contenu | Source |
 |---|----------|-------|---------|--------|

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -4,7 +4,15 @@
 
 Comment passer d'une enumeration exhaustive a une exploration intelligemment guidee d'un espace d'etats ? Cette premiere partie couvre les trois grands paradigmes de la recherche en IA : systematique (BFS, A*), locale (Hill Climbing, recuit simule) et evolutive (algorithmes genetiques, PSO). Le fil rouge est la reduction progressive de l'espace de recherche, depuis la formalisation du probleme jusqu'aux metaheuristiques comparees sur des benchmarks.
 
-Vous commencerez par poser le cadre formel (S, A, T, G) dans Search-1, puis decouvrirez les algorithmes non informes et informes, la recherche locale et genetique, la recherche adversariale (Minimax, MCTS) et les extensions que sont la programmation lineaire, les automates symboliques et les metaheuristiques.
+Le parcours s'ouvre sur une idée simple et étonnamment puissante : avant de résoudre un problème, il faut le poser. Search-1 montre qu'un taquin, un aspirateur-robot et une recherche d'itinéraire sont un seul et même objet mathématique — un espace d'états (S, A, T, G) — et que cette formalisation suffit à rendre le problème calculable. Search-2 lance alors l'exploration à l'aveugle : BFS garantit l'optimal mais explose en mémoire, DFS file droit mais peut se perdre, et leurs variantes (UCS, IDDFS) négocient chacune un compromis différent entre garantie et coût. Search-3 apporte la réponse classique à cette explosion : une heuristique — une estimation du chemin restant — et l'algorithme A*, dont l'optimalité tient à une propriété fine, l'admissibilité, que le notebook prend le temps d'éprouver plutôt que de la postuler.
+
+La suite change deux fois de point de vue. Quand seule la destination compte — pas le chemin —, la recherche locale (Search-4) abandonne l'arbre d'exploration pour naviguer de voisin en voisin dans un paysage de fitness, quitte à accepter temporairement de moins bonnes solutions pour s'échapper des optima locaux (recuit simulé, recherche tabou). Les algorithmes génétiques (Search-5) généralisent le procédé : une population entière explore en parallèle, sélection et croisement faisant émerger les bonnes solutions. Et quand l'environnement riposte — un adversaire joue contre vous —, la recherche devient un jeu : Minimax et l'élagage Alpha-Beta (Search-6), puis Monte Carlo Tree Search (Search-7), qui remplace l'évaluation experte par la simulation statistique et mène jusqu'à l'architecture d'AlphaGo.
+
+Trois extensions complètent le panorama. La couverture exacte et les Dancing Links de Knuth (Search-8), structure de données spectaculaire qui résout Sudoku, N-Queens et Pentominoes par simple manipulation de pointeurs. La programmation linéaire (Search-9), qui troque le discret pour le continu et résout en quelques lignes de PuLP des problèmes de transport et de régime alimentaire. Les automates symboliques (Search-10), où les transitions deviennent des prédicats Z3 — premier pont vers l'IA symbolique. Search-11 referme la partie en confrontant les métaheuristiques (PSO, ABC, recuit) sur des benchmarks communs : l'occasion de constater qu'aucune ne domine partout, et d'apprendre à choisir.
+
+## Pourquoi cette partie
+
+Cette partie est l'alphabet de toute la série : la formalisation en espace d'états, le backtracking et les heuristiques qu'on y construit sont réutilisés tels quels par la programmation par contraintes (Partie 2) et par les 21 notebooks d'application. Mais son véritable enseignement est un réflexe d'ingénieur : chaque algorithme y est présenté comme un compromis — complétude contre mémoire, garantie contre temps de calcul, exploration contre exploitation — et jamais comme une recette. C'est ce réflexe, plus que tel ou tel algorithme, qui distingue celui qui applique une bibliothèque de celui qui choisit une stratégie.
 
 ## Objectifs d'apprentissage
 
@@ -34,7 +42,7 @@ A l'issue de cette partie, vous serez capable de :
 
 ## Progression
 
-Les notebooks 1 a 3 forment le socle commun (formalisation, recherche systematique). A partir de Search-2, le parcours se divise en quatre branches :
+Les trois premiers notebooks forment le socle commun — on y apprend à poser un problème, puis à l'explorer systématiquement — et tout le reste s'y greffe. Au-delà, le parcours n'est pas linéaire : quatre branches indépendantes s'ouvrent, à prendre dans l'ordre de vos curiosités :
 
 - **Recherche locale et evolutive** : Search-4 (LocalSearch) puis Search-5 (GeneticAlgorithms) puis Search-11 (Metaheuristics)
 - **Recherche dans les jeux** : Search-3 puis Search-6 (AdversarialSearch) puis Search-7 (MCTS)
@@ -55,6 +63,10 @@ Les fondamentaux de cette partie (formalisation, backtracking, heuristiques) son
 | OpenSpiel | Search-7 (MCTS) : requiert WSL ou Linux |
 
 Pour le setup complet, voir le [README de la serie Search](../README.md).
+
+## Ponts vers les autres séries
+
+Cette partie irrigue le reste du dépôt : les Dancing Links de Search-8 sont à l'œuvre dans la série [Sudoku](../../Sudoku/README.md), Minimax et MCTS (Search-6/7) se prolongent dans [GameTheory](../../GameTheory/README.md) avec OpenSpiel puis dans [RL](../../RL/README.md) côté politiques apprises, et les prédicats Z3 de Search-10 ouvrent sur [SymbolicAI](../../SymbolicAI/README.md).
 
 ## FAQ
 

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
@@ -4,7 +4,15 @@
 
 Au lieu de concevoir un algorithme d'exploration, que se passe-t-il si l'on declare les contraintes du probleme et que l'on laisse le solveur trouver les solutions ? La programmation par contraintes (CSP) represente ce changement de paradigme : on ne cherche plus, on contraint. Ce modele declaratif est au coeur des outils industriels (ordonnancement, logistique, verification) et s'applique naturellement aux problemes NP-difficiles.
 
-Le parcours va des fondamentaux du modele (X, D, C) et du backtracking (CSP-1) a la propagation de contraintes (AC-3, MAC en CSP-2), puis aux extensions avancees : contraintes globales (CSP-3), ordonnancement industriel (CSP-4), optimisation combinatoire (CSP-5), hybridation avec SAT/ML/LLM (CSP-6). Les trois derniers notebooks explorent les frontieres : contraintes souples, temporelles et distribuees.
+Les deux premiers notebooks installent le socle. CSP-1 pose le modèle (X, D, C) — variables, domaines, contraintes — et montre que le backtracking de la Partie 1, enrichi de deux heuristiques de bon sens (choisir d'abord la variable la plus contrainte, essayer d'abord la valeur la moins contraignante), résout déjà des problèmes non triviaux. CSP-2 introduit l'idée qui fait la puissance du paradigme : la propagation. Plutôt que de découvrir une impasse en s'y enfonçant, AC-3 et MAC élaguent les valeurs impossibles avant même de les essayer — l'espace de recherche se réduit de lui-même, par simple déduction locale.
+
+La montée en puissance occupe les quatre notebooks suivants. CSP-3 passe aux contraintes globales (AllDifferent, Cumulative, Circuit), ces contraintes de haut niveau pour lesquelles les solveurs embarquent des propagateurs spécialisés — c'est là que CP-SAT se met à résoudre en quelques millisecondes ce qu'un backtracking naïf mettrait des heures à parcourir. CSP-4 et CSP-5 appliquent l'arsenal aux deux grands classiques industriels : l'ordonnancement (Job-Shop, RCPSP, planification d'infirmiers) et l'optimisation combinatoire (Bin Packing, Knapsack, portefeuille). CSP-6, le notebook le plus avancé, ouvre le capot : la Lazy Clause Generation explique pourquoi CP-SAT s'appelle ainsi — un solveur CP qui apprend des clauses SAT en cours de route — et les hybridations CP+ML et LLM+CSP esquissent ce que devient la discipline à l'ère des grands modèles : le langage naturel comme interface de modélisation, le solveur comme garant.
+
+Les trois derniers notebooks desserrent chacun une hypothèse du cadre classique : et si toutes les contraintes n'avaient pas le même poids (CSP-7, contraintes souples) ? Et si les variables étaient des intervalles de temps (CSP-8, algèbre d'Allen) ? Et si personne ne détenait le problème en entier (CSP-9, résolution distribuée et préservation de la vie privée) ?
+
+## Pourquoi cette partie
+
+Si la Partie 1 enseigne à chercher, celle-ci enseigne à modéliser — et c'est un art plus subtil qu'il n'y paraît. Le même problème, déclaré avec des contraintes binaires ou avec une contrainte globale équivalente, peut passer de plusieurs heures de calcul à quelques millisecondes : le solveur n'a pas changé, seule la formulation a changé. Cette sensibilité à la modélisation est la compétence centrale du praticien, et la raison pour laquelle ces techniques équipent les outils d'ordonnancement, de logistique et de vérification utilisés en production. C'est aussi le premier contact de la série avec le raisonnement déclaratif — celui qu'approfondissent Z3 et la planification PDDL côté SymbolicAI.
 
 ## Objectifs d'apprentissage
 
@@ -32,7 +40,7 @@ A l'issue de cette partie, vous serez capable de :
 
 ## Progression
 
-CSP-1 et CSP-2 forment le socle (modele + propagation). A partir de CSP-3, le parcours se divise :
+CSP-1 et CSP-2 sont incontournables : tout le paradigme — un modèle déclaratif, une propagation qui élague — tient dans ces deux notebooks. Au-delà, trois chemins s'offrent selon votre objectif :
 
 - **Applications industrielles** : CSP-3 puis CSP-4 (Scheduling) et/ou CSP-5 (Optimization)
 - **Frontieres** : CSP-6 (Hybridization, le notebook le plus avance), puis CSP-7/8/9 (Soft/Temporal/Distributed)
@@ -61,4 +69,4 @@ Pour le setup complet, voir le [README de la serie Search](../README.md).
 
 ## Ponts vers SymbolicAI
 
-La programmation par contraintes est le passage naturel vers l'IA symbolique : OR-Tools CP-SAT rejoint Z3 (SMT solving) dans la serie [SymbolicAI](../../SymbolicAI/README.md), l'ordonnancement mene a la planification PDDL (SymbolicAI/Planning), et les contraintes temporelles (CSP-8) se retrouvent dans le planning temporel. Le notebook CSP-6 (LCG) detaille ces passerelles.
+La programmation par contraintes est le passage naturel vers l'IA symbolique : OR-Tools CP-SAT rejoint Z3 (SMT solving) dans la serie [SymbolicAI](../../SymbolicAI/README.md), l'ordonnancement mene a la planification PDDL (SymbolicAI/Planners), et les contraintes temporelles (CSP-8) se retrouvent dans le planning temporel. Le notebook CSP-6 (LCG) detaille ces passerelles.


### PR DESCRIPTION
## Summary

User mandate (2026-06-11): the narration that opens the repository (root README, SymbolicLearning README) must keep developing as a visitor explores deeper — yet most READMEs are "well structured but rather empty of pedagogical explanation". This batch targets where the narration actually breaks on the main descent path: the hub (level 1) and the Search/GenAI sub-parts (level 3). The Search series README (level 2) is already at the bar and is untouched.

### Files

- **MyIA.AI.Notebooks/README.md (hub)** — the dry "Vue d'ensemble" table becomes eleven narrative paragraphs, one per domain, each linking its series README and saying what is distinctive about it (GenAI self-hosting bias, QuantConnect validation discipline, SymbolicAI simulation/proof duality, Probas double Infer.NET/PyMC life, Sudoku as controlled benchmark, GameTheory mechanized social choice...). The "Liens vers les sous-domaines" table is **removed**: it was pure duplication once every paragraph links its domain. Each recommended pathway (Debutant / Intermediaire / Expert) gets a sentence of intent before its list.
- **Search/Part1-Foundations/README.md** — narrative walk-through of Search-1..11 as a story (formalization -> blind search -> heuristics -> local/evolutionary -> adversarial -> extensions), new "Pourquoi cette partie" (algorithms as trade-offs, not recipes), narrated progression, new "Ponts vers les autres series" section (Sudoku, GameTheory, RL, SymbolicAI).
- **Search/Part2-CSP/README.md** — narrative walk-through of CSP-1..9 (model+propagation socle, global-constraints power-up, the three frontier notebooks as questions), "Pourquoi cette partie" (modeling as the core skill), narrated progression. Also fixes a factual error: `SymbolicAI/Planning` -> `SymbolicAI/Planners`.
- **Search/Applications/README.md** — rewritten intro, de-redunded "Pourquoi cette sous-serie" around the three things applications teach (method confrontation, orders of magnitude, modeling), and a narrative intro before each of the three category tables.
- **GenAI/CaseStudies/README.md** — new "Pourquoi ces projets" (components reassembled, the value of reading a complete system) and one paragraph per project in pedagogical order (Fort-Boyard -> Barbie-Schreck -> Recipe-Maker -> Medical-Chatbot).

### Guardrails respected

- `CATALOG-STATUS` markers untouched everywhere (bot-owned, catalog-pr-hygiene rule); catalog files byte-identical to main.
- No invented facts: prose stays at the level of detail already documented in the existing tables (e.g. no claim that `hashlife_correct` is proven; "27Mx" softened to "un facteur de plusieurs millions").
- All relative links mechanically checked (regex + Test-Path): 0 broken.

See #1925 (visitor navigation track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)