### PR TITLE
fix(qc): remove inline fee hacks, rely on brokerage model fees (#2801 Lot 2)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/main.py
@@ -44,9 +44,6 @@ class MyEnhancedCryptoMlAlgorithm(QCAlgorithm):
     CONFIDENCE_LONG_THRESHOLD = 0.56   # Si proba > 0.56: long (relaxed from 0.58 for more trades)
     CONFIDENCE_EXIT_THRESHOLD = 0.40   # Si proba < 0.40: liquidation (relaxed from 0.42)
 
-    # Transaction costs
-    TRANSACTION_FEE = 0.001  # 0.1% per trade (Binance fee)
-
     # Retraining periodique
     RETRAIN_INTERVAL_DAYS = 60  # Increased from 30 for more stable model
     RETRAIN_LOOKBACK_DAYS = 730  # 2 years lookback for regime diversity
@@ -351,7 +348,7 @@ class MyEnhancedCryptoMlAlgorithm(QCAlgorithm):
 
             if not self.Portfolio[self.symbol].Invested:
                 # Account for transaction fees
-                self.SetHoldings(self.symbol, position_size * (1 - self.TRANSACTION_FEE))
+                self.SetHoldings(self.symbol, position_size)
                 self.entry_price = current_price
                 self.Debug(f"{self.Time} => LONG @ {current_price:.2f} | Confidence: {confidence_up:.2%} | Size: {position_size:.2%}")
             else:

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/main.py
@@ -34,7 +34,6 @@ class OptimizedCryptoAlgorithm(QCAlgorithm):
         self.trailing_stop_pct = 0.92  # Optimized from 0.90
         self.fixed_stop_pct = 0.88     # Optimized from 0.85
         self.take_profit_pct = 1.25    # Optimized from 1.30
-        self.transaction_fee = 0.001   # 0.1% transaction fee
 
     def OnData(self, data):
         # Volatility filter: skip trading if BTC volatility > 60%


### PR DESCRIPTION
## Summary

Remove dead inline fee workarounds from 2 strategies, now that all strategies have explicit brokerage models (Lot 1, PR #2812) which apply realistic fees natively.

## Changes

| Strategy | Change | Rationale |
|----------|--------|-----------|
| Multi-Layer-EMA | Remove unused `self.transaction_fee = 0.001` (line 37) | Variable defined but never referenced in any order call |
| BTC-ML | Remove `TRANSACTION_FEE = 0.001` constant + `position_size * (1 - self.TRANSACTION_FEE)` sizing hack | Brokerage model Binance Cash handles fees; the position sizing workaround is incorrect |

## Why no `SetFeeModel` needed

QC applies realistic fee schedules based on the brokerage model:
- **IBKR Margin**: ~0.35bps for small accounts
- **Binance/Coinbase Cash**: ~0.1% per trade
- **OANDA**: Spread-based

For standard broker fees, no custom `SetFeeModel` is necessary. Only non-standard fee structures would require one.

See #2801