### PR TITLE
feat(prosody-lab): add multi-engine A/B test scripts for #1877

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/ab_clone_test.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/ab_clone_test.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""A/B test: flat-clone vs expressive-clone for prosodie #1877 fix.
+
+Generates ~25s clips using:
+  A (AVANT) = v4_narrator_male_neutral (flat reference, ST~5.8)
+  B (APRES) = prosody_expr_voicedesign (expressive reference, ST~9.2)
+
+Then runs prosody_metrics.py on both to produce objective measurements.
+
+Usage:
+    cd v4/prosody_lab/
+    python ab_clone_test.py
+
+Output:
+    outputs/prosody_lab/ab_flat.mp3
+    outputs/prosody_lab/ab_expressive.mp3
+    outputs/prosody_lab/ab_metrics.json
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+# Add parent dirs to path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from fishaudio_client import fishaudio_tts
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+TEST_TEXT_FILE = Path(__file__).resolve().parent / "test_segment.txt"
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "outputs" / "prosody_lab"
+OUTPUT_DIR.mkdir(exist_ok=True, parents=True)
+
+FLAT_REF = "v4_narrator_male_neutral"       # ST~5.8 (MODERATE)
+EXPR_REF = "prosody_expr_voicedesign"       # ST~9.2 (EXPRESSIVE)
+
+# Temperature 0.8 matches run_matrix.py Stage 2 conditions
+TEMPERATURE = 0.8
+SEED = 42
+
+OUT_FLAT = OUTPUT_DIR / "ab_flat.mp3"
+OUT_EXPR = OUTPUT_DIR / "ab_expressive.mp3"
+OUT_METRICS = OUTPUT_DIR / "ab_metrics.json"
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    # Load test text
+    text = TEST_TEXT_FILE.read_text(encoding="utf-8").strip()
+    # Remove line number prefix if present
+    if text and text[0].isdigit():
+        lines = text.split("\n")
+        # Take the first substantive line (after line number)
+        text = "\n".join(
+            line.split("\t", 1)[-1] if line.strip() and line.strip()[0].isdigit() else line
+            for line in lines
+        ).strip()
+
+    print(f"Test text ({len(text)} chars): {text[:80]}...")
+    print(f"Flat ref: {FLAT_REF}")
+    print(f"Expressive ref: {EXPR_REF}")
+    print(f"Temperature: {TEMPERATURE}, Seed: {SEED}")
+    print()
+
+    # Generate A (flat)
+    print(f"[1/2] Generating FLAT clip (ref={FLAT_REF})...")
+    t0 = time.time()
+    audio_flat = fishaudio_tts(
+        text=text,
+        reference_id=FLAT_REF,
+        temperature=TEMPERATURE,
+        seed=SEED,
+        format="mp3",
+        timeout=300,
+    )
+    dt_flat = time.time() - t0
+    if audio_flat is None:
+        print("ERROR: Flat TTS failed.")
+        sys.exit(1)
+    OUT_FLAT.write_bytes(audio_flat)
+    print(f"  -> {OUT_FLAT.name}: {len(audio_flat)/1024:.0f} KB in {dt_flat:.1f}s")
+
+    # Generate B (expressive)
+    print(f"[2/2] Generating EXPRESSIVE clip (ref={EXPR_REF})...")
+    t0 = time.time()
+    audio_expr = fishaudio_tts(
+        text=text,
+        reference_id=EXPR_REF,
+        temperature=TEMPERATURE,
+        seed=SEED,
+        format="mp3",
+        timeout=300,
+    )
+    dt_expr = time.time() - t0
+    if audio_expr is None:
+        print("ERROR: Expressive TTS failed.")
+        sys.exit(1)
+    OUT_EXPR.write_bytes(audio_expr)
+    print(f"  -> {OUT_EXPR.name}: {len(audio_expr)/1024:.0f} KB in {dt_expr:.1f}s")
+
+    print()
+    print(f"Done! Files in {OUTPUT_DIR}/")
+    print(f"  {OUT_FLAT.name} (AVANT - flat clone)")
+    print(f"  {OUT_EXPR.name} (APRES - expressive clone)")
+    print()
+    print("Run prosody_metrics.py to measure ST/CV:")
+    print(f"  cd {Path(__file__).resolve().parent}")
+    print(f"  python prosody_metrics.py {OUT_FLAT} {OUT_EXPR} --json {OUT_METRICS}")
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/ab_dialogue_test.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/ab_dialogue_test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""A/B dialogue test: flat-clone vs expressive-clone for prosodie #1877 fix.
+
+Tests a DIALOGUE voice (not narrator) to validate the expressive reference fix.
+Uses Cornudet's lines from Boule de Suif — emotionally charged, good for prosody test.
+
+  A (AVANT) = v4_cornudet_mocking (current flat-clone reference)
+  B (APRES) = prosody_expr_voicedesign (expressive reference)
+
+Usage:
+    cd v4/prosody_lab/
+    python ab_dialogue_test.py
+
+Output:
+    outputs/prosody_lab/ab_dialogue_flat.mp3
+    outputs/prosody_lab/ab_dialogue_expr.mp3
+    outputs/prosody_lab/ab_dialogue_metrics.json
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from fishaudio_client import fishaudio_tts
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "outputs" / "prosody_lab"
+OUTPUT_DIR.mkdir(exist_ok=True, parents=True)
+
+# Cornudet's longest dialogue line — mocking, emotionally charged
+DIALOGUE_TEXT = (
+    "--La guerre est une barbarie quand on attaque un voisin paisible; "
+    "c'est un devoir sacré quand on défend la patrie. "
+    "Bravo, citoyenne! dit-il. "
+    "Voyons, vous êtes bête, qu'est-ce que ça vous fait?"
+)
+
+# Also test Elisabeth Rousset's fiery refusal (most emotional dialogue in the book)
+DIALOGUE_TEXT_ROUSSET = (
+    "Vous lui direz à cette crapule, à ce saligaud, à cette Charogne de Prussien, "
+    "que jamais je ne voudrai; vous entendez bien, jamais, jamais, jamais."
+)
+
+FLAT_REF = "v4_cornudet_mocking"              # Current flat-clone
+EXPR_REF = "prosody_expr_voicedesign"          # Expressive reference
+
+TEMPERATURE = 0.8
+SEED = 42
+
+OUT_FLAT = OUTPUT_DIR / "ab_dialogue_flat.mp3"
+OUT_EXPR = OUTPUT_DIR / "ab_dialogue_expr.mp3"
+OUT_METRICS = OUTPUT_DIR / "ab_dialogue_metrics.json"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    text = DIALOGUE_TEXT
+    print(f"Dialogue A/B test — Cornudet voice (#1877)")
+    print(f"Text ({len(text)} chars): {text[:80]}...")
+    print(f"Flat ref: {FLAT_REF}")
+    print(f"Expressive ref: {EXPR_REF}")
+    print(f"Temperature: {TEMPERATURE}, Seed: {SEED}")
+    print()
+
+    # Generate A (flat clone)
+    print(f"[1/2] Generating FLAT dialogue (ref={FLAT_REF})...")
+    t0 = time.time()
+    audio_flat = fishaudio_tts(
+        text=text,
+        reference_id=FLAT_REF,
+        temperature=TEMPERATURE,
+        seed=SEED,
+        format="mp3",
+        timeout=300,
+    )
+    dt_flat = time.time() - t0
+    if audio_flat is None:
+        print("ERROR: Flat dialogue TTS failed.")
+        sys.exit(1)
+    OUT_FLAT.write_bytes(audio_flat)
+    print(f"  -> {OUT_FLAT.name}: {len(audio_flat)/1024:.0f} KB in {dt_flat:.1f}s")
+
+    # Generate B (expressive reference)
+    print(f"[2/2] Generating EXPRESSIVE dialogue (ref={EXPR_REF})...")
+    t0 = time.time()
+    audio_expr = fishaudio_tts(
+        text=text,
+        reference_id=EXPR_REF,
+        temperature=TEMPERATURE,
+        seed=SEED,
+        format="mp3",
+        timeout=300,
+    )
+    dt_expr = time.time() - t0
+    if audio_expr is None:
+        print("ERROR: Expressive dialogue TTS failed.")
+        sys.exit(1)
+    OUT_EXPR.write_bytes(audio_expr)
+    print(f"  -> {OUT_EXPR.name}: {len(audio_expr)/1024:.0f} KB in {dt_expr:.1f}s")
+
+    print()
+    print(f"Done! Files in {OUTPUT_DIR}/")
+    print(f"  {OUT_FLAT.name} (AVANT - flat Cornudet clone)")
+    print(f"  {OUT_EXPR.name} (APRES - expressive reference)")
+    print()
+    print("Run prosody_metrics.py to measure ST/CV:")
+    print(f"  cd {Path(__file__).resolve().parent}")
+    print(f"  python prosody_metrics.py flat={OUT_FLAT} expr={OUT_EXPR} --json {OUT_METRICS} --plot {OUTPUT_DIR / 'ab_dialogue_contours.png'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/ab_engine_test.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/ab_engine_test.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Multi-engine A/B/C/D/E test for #1877 prosody comparison.
+
+Generates clips of the same Boule de Suif passage using different TTS engines,
+then measures prosody (ST-spread, CV, velocity) per engine.
+
+Engines:
+  A = FishAudio F5 (baseline, cloned voice, port 8197)
+  B = Kokoro TTS (native voice, port 8191)
+  C = Chatterbox TTS (native voice, port TBD — skip if unavailable)
+  D = Qwen TTS (via gateway, port 8196)
+  E = Higgs Audio v3 (sglang-omni, port 8199)
+
+Usage:
+    cd v4/prosody_lab/
+    python ab_engine_test.py
+
+Output:
+    outputs/prosody_lab/ab_engine_*.mp3   — one clip per engine
+    outputs/prosody_lab/ab_engine_metrics.json  — prosody measurements
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from fishaudio_client import fishaudio_tts
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+TEST_TEXT_FILE = Path(__file__).resolve().parent / "test_segment.txt"
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "outputs" / "prosody_lab"
+OUTPUT_DIR.mkdir(exist_ok=True, parents=True)
+
+# FishAudio config
+FISH_REF = "prosody_expr_voicedesign"  # expressive clone reference
+FISH_PORT = 8197
+
+# Kokoro config
+KOKORO_PORT = 8191
+KOKORO_KEY = os.getenv("KOKORO_API_KEY", "")
+KOKORO_VOICE = "af_bella"
+
+# Qwen TTS config (via gateway)
+QWEN_PORT = 8196
+QWEN_VOICE = "Chelsie"
+
+# Chatterbox config (skip if not running)
+CHATTERBOX_PORT = 8198
+CHATTERBOX_VOICE = "Emily.wav"
+
+# Higgs Audio v3 config (sglang-omni, skip if not running)
+HIGGS_PORT = 8199
+
+# FishAudio temperature/seed
+TEMPERATURE = 0.8
+SEED = 42
+
+OUT_METRICS = OUTPUT_DIR / "ab_engine_metrics.json"
+
+
+# ---------------------------------------------------------------------------
+# Engine callers
+# ---------------------------------------------------------------------------
+
+def call_fishaudio(text: str) -> bytes | None:
+    """Call FishAudio F5 TTS (port 8197)."""
+    print("  [FishAudio F5] Calling...")
+    t0 = time.time()
+    audio = fishaudio_tts(
+        text=text,
+        reference_id=FISH_REF,
+        temperature=TEMPERATURE,
+        seed=SEED,
+        format="mp3",
+        timeout=300,
+    )
+    dt = time.time() - t0
+    if audio:
+        print(f"  [FishAudio F5] OK: {len(audio)/1024:.0f} KB in {dt:.1f}s")
+    else:
+        print("  [FishAudio F5] FAILED")
+    return audio
+
+
+def call_kokoro(text: str) -> bytes | None:
+    """Call Kokoro TTS (port 8191, OpenAI-compat)."""
+    import requests
+    print("  [Kokoro] Calling...")
+    try:
+        t0 = time.time()
+        resp = requests.post(
+            f"http://localhost:{KOKORO_PORT}/v1/audio/speech",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {KOKORO_KEY}",
+            },
+            json={
+                "model": "kokoro",
+                "input": text,
+                "voice": KOKORO_VOICE,
+            },
+            timeout=120,
+        )
+        dt = time.time() - t0
+        if resp.status_code == 200:
+            audio = resp.content
+            print(f"  [Kokoro] OK: {len(audio)/1024:.0f} KB in {dt:.1f}s")
+            return audio
+        else:
+            print(f"  [Kokoro] FAILED: HTTP {resp.status_code} — {resp.text[:200]}")
+            return None
+    except Exception as e:
+        print(f"  [Kokoro] ERROR: {e}")
+        return None
+
+
+def call_qwen(text: str) -> bytes | None:
+    """Call Qwen TTS via gateway (port 8196)."""
+    import requests
+    print("  [Qwen TTS] Calling...")
+    try:
+        t0 = time.time()
+        resp = requests.post(
+            f"http://localhost:{QWEN_PORT}/qwen/v1/audio/speech",
+            headers={"Content-Type": "application/json"},
+            json={
+                "model": "qwen3",
+                "input": text,
+                "voice": QWEN_VOICE,
+            },
+            timeout=120,
+        )
+        dt = time.time() - t0
+        if resp.status_code == 200:
+            audio = resp.content
+            print(f"  [Qwen TTS] OK: {len(audio)/1024:.0f} KB in {dt:.1f}s")
+            return audio
+        else:
+            print(f"  [Qwen TTS] FAILED: HTTP {resp.status_code} — {resp.text[:200]}")
+            return None
+    except Exception as e:
+        print(f"  [Qwen TTS] ERROR: {e}")
+        return None
+
+
+def call_chatterbox(text: str) -> bytes | None:
+    """Call Chatterbox TTS (OpenAI-compat, port 8000 or as configured)."""
+    import requests
+    print("  [Chatterbox] Calling...")
+    try:
+        t0 = time.time()
+        # Chatterbox TTS Server uses OpenAI-compatible API
+        resp = requests.post(
+            f"http://localhost:{CHATTERBOX_PORT}/v1/audio/speech",
+            headers={"Content-Type": "application/json"},
+            json={
+                "model": "chatterbox",
+                "input": text,
+                "voice": CHATTERBOX_VOICE,
+            },
+            timeout=120,
+        )
+        dt = time.time() - t0
+        if resp.status_code == 200:
+            audio = resp.content
+            print(f"  [Chatterbox] OK: {len(audio)/1024:.0f} KB in {dt:.1f}s")
+            return audio
+        else:
+            print(f"  [Chatterbox] FAILED: HTTP {resp.status_code} — {resp.text[:200]}")
+            return None
+    except Exception as e:
+        print(f"  [Chatterbox] SKIP (not available): {e}")
+        return None
+
+
+def call_higgs(text: str) -> bytes | None:
+    """Call Higgs Audio v3 TTS (sglang-omni, OpenAI-compat, port 8199)."""
+    import requests
+    print("  [Higgs v3] Calling...")
+    try:
+        t0 = time.time()
+        resp = requests.post(
+            f"http://localhost:{HIGGS_PORT}/v1/audio/speech",
+            headers={"Content-Type": "application/json"},
+            json={"input": text},
+            timeout=120,
+        )
+        dt = time.time() - t0
+        if resp.status_code == 200:
+            audio = resp.content
+            print(f"  [Higgs v3] OK: {len(audio)/1024:.0f} KB in {dt:.1f}s")
+            return audio
+        else:
+            print(f"  [Higgs v3] FAILED: HTTP {resp.status_code} — {resp.text[:200]}")
+            return None
+    except Exception as e:
+        print(f"  [Higgs v3] SKIP (not available): {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def measure_prosody(audio_path: Path) -> dict | None:
+    """Run prosody_metrics on a single clip."""
+    try:
+        from prosody_metrics import compute_metrics
+        m = compute_metrics(str(audio_path))
+        return {
+            "file": audio_path.name,
+            "st_range": round(m.get("f0_semitone_range", 0), 2),
+            "f0_mean": round(m.get("f0_mean_hz", 0), 1),
+            "f0_cv": round(m.get("f0_cv", 0), 3),
+            "velocity": round(m.get("intonation_velocity_st_per_s", 0), 2),
+            "voiced_frac": round(m.get("voiced_fraction", 0), 3),
+            "duration_s": round(m.get("duration_s", 0), 2),
+        }
+    except Exception as e:
+        print(f"  [Metrics] ERROR on {audio_path.name}: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    # Load test text
+    text = TEST_TEXT_FILE.read_text(encoding="utf-8").strip()
+    print(f"Text ({len(text)} chars): {text[:80]}...")
+    print()
+
+    engines = [
+        ("A", "FishAudio F5", "ab_engine_A_fish.mp3", call_fishaudio),
+        ("B", "Kokoro", "ab_engine_B_kokoro.mp3", call_kokoro),
+        ("C", "Chatterbox", "ab_engine_C_chatterbox.mp3", call_chatterbox),
+        ("D", "Qwen TTS", "ab_engine_D_qwen.mp3", call_qwen),
+        ("E", "Higgs Audio v3", "ab_engine_E_higgs.mp3", call_higgs),
+    ]
+
+    results = []
+    metrics_all = []
+
+    for label, name, filename, caller in engines:
+        print(f"[{label}] {name}")
+        audio = caller(text)
+        if audio:
+            out_path = OUTPUT_DIR / filename
+            out_path.write_bytes(audio)
+            print(f"  -> {out_path}")
+            results.append({"label": label, "engine": name, "file": filename, "size_kb": len(audio) / 1024})
+        else:
+            print(f"  -> SKIPPED (engine unavailable)")
+            results.append({"label": label, "engine": name, "file": None, "error": "unavailable"})
+        print()
+
+    # Measure prosody on all generated clips
+    print("=" * 60)
+    print("PROSODY MEASUREMENTS")
+    print("=" * 60)
+    for r in results:
+        if r["file"]:
+            audio_path = OUTPUT_DIR / r["file"]
+            m = measure_prosody(audio_path)
+            if m:
+                metrics_all.append(m)
+                print(f"  [{r['label']}] {r['engine']:20s} | ST={m['st_range']:5.2f} | CV={m['f0_cv']:.3f} | vel={m['velocity']:5.2f} st/s | dur={m['duration_s']:.1f}s")
+            else:
+                print(f"  [{r['label']}] {r['engine']:20s} | METRICS FAILED")
+        else:
+            print(f"  [{r['label']}] {r['engine']:20s} | NO CLIP")
+
+    # Save
+    report = {
+        "test": "multi_engine_ab_prosody",
+        "issue": 1877,
+        "text_length": len(text),
+        "results": results,
+        "metrics": metrics_all,
+    }
+    OUT_METRICS.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"\nMetrics saved: {OUT_METRICS}")
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY — ST-spread ranking (higher = more expressive)")
+    print("=" * 60)
+    ranked = sorted(metrics_all, key=lambda x: x["st_range"], reverse=True)
+    for i, m in enumerate(ranked):
+        label = next((r["label"] for r in results if r["file"] == m["file"]), "?")
+        name = next((r["engine"] for r in results if r["file"] == m["file"]), "?")
+        print(f"  {i+1}. [{label}] {name:20s} — ST={m['st_range']:.2f}, CV={m['f0_cv']:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/ab_same_voice_test.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/ab_same_voice_test.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""A/B test: SAME voice identity, different temperature — #1877 prosody fix.
+
+The previous A/B tests were INVALID because they compared different voices
+(woman vs man) by changing reference_id. This test keeps the SAME reference_id
+and only varies the `temperature` parameter to measure prosody variation.
+
+  A (LOW TEMP)  = reference_id + temperature=0.3  → conservative, flatter prosody
+  B (HIGH TEMP) = reference_id + temperature=1.2  → expressive, wider prosody
+
+Both clips use the SAME voice identity (same timbre). If B is significantly
+more expressive than A, then temperature IS the prosody control knob.
+
+Tested on BOTH narrator and dialogue voices:
+  - Narrator: v4_narrator_male_neutral
+  - Dialogue: v4_cornudet_mocking
+
+Usage:
+    cd v4/prosody_lab/
+    python ab_same_voice_test.py
+
+Output:
+    outputs/prosody_lab/ab_sv_narrator_low.mp3
+    outputs/prosody_lab/ab_sv_narrator_high.mp3
+    outputs/prosody_lab/ab_sv_dialogue_low.mp3
+    outputs/prosody_lab/ab_sv_dialogue_high.mp3
+    outputs/prosody_lab/ab_same_voice_metrics.json
+    outputs/prosody_lab/ab_same_voice_contours.png
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from fishaudio_client import fishaudio_tts
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "outputs" / "prosody_lab"
+OUTPUT_DIR.mkdir(exist_ok=True, parents=True)
+
+# Test texts
+NARRATOR_TEXT = (
+    "Enfin, a trois heures, comme on se trouvait au milieu d'une plaine "
+    "interminable, Boule de Suif retira de sous la banquette un large panier "
+    "couvert d'une serviette blanche."
+)
+
+DIALOGUE_TEXT = (
+    "Vous lui direz a cette crapule, a ce saligaud, a cette Charogne de "
+    "Prussien, que jamais je ne voudrai; vous entendez bien, jamais, jamais."
+)
+
+# Voice identities (same for both A and B within each pair)
+NARRATOR_REF = "v4_narrator_male_neutral"
+DIALOGUE_REF = "v4_cornudet_mocking"
+
+# Temperature settings
+TEMP_LOW = 0.1    # Minimum → expected flatter
+TEMP_HIGH = 1.0   # Maximum → expected wider prosody
+
+SEED = 42
+
+# Output files
+FILES = {
+    "narrator_low":    OUTPUT_DIR / "ab_sv_narrator_low.mp3",
+    "narrator_high":   OUTPUT_DIR / "ab_sv_narrator_high.mp3",
+    "dialogue_low":    OUTPUT_DIR / "ab_sv_dialogue_low.mp3",
+    "dialogue_high":   OUTPUT_DIR / "ab_sv_dialogue_high.mp3",
+}
+OUT_METRICS = OUTPUT_DIR / "ab_same_voice_metrics.json"
+OUT_PLOT = OUTPUT_DIR / "ab_same_voice_contours.png"
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+def generate_pair(label: str, text: str, ref_id: str) -> tuple[bytes, bytes]:
+    """Generate low-temp and high-temp versions of the same text+voice."""
+    print(f"\n[{label}] Generating pair (ref={ref_id})...")
+
+    # Low temperature
+    print(f"  [A] temperature={TEMP_LOW} ...")
+    t0 = time.time()
+    audio_low = fishaudio_tts(
+        text=text, reference_id=ref_id,
+        temperature=TEMP_LOW, seed=SEED, format="mp3", timeout=300,
+    )
+    dt_low = time.time() - t0
+    if audio_low is None:
+        print(f"  ERROR: Low-temp generation failed for {label}")
+        sys.exit(1)
+    print(f"  -> {len(audio_low)/1024:.0f} KB in {dt_low:.1f}s")
+
+    # High temperature
+    print(f"  [B] temperature={TEMP_HIGH} ...")
+    t0 = time.time()
+    audio_high = fishaudio_tts(
+        text=text, reference_id=ref_id,
+        temperature=TEMP_HIGH, seed=SEED, format="mp3", timeout=300,
+    )
+    dt_high = time.time() - t0
+    if audio_high is None:
+        print(f"  ERROR: High-temp generation failed for {label}")
+        sys.exit(1)
+    print(f"  -> {len(audio_high)/1024:.0f} KB in {dt_high:.1f}s")
+
+    return audio_low, audio_high
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print("=" * 60)
+    print("A/B SAME VOICE TEST — #1877 prosody fix")
+    print(f"Same reference_id, varying temperature: {TEMP_LOW} vs {TEMP_HIGH}")
+    print(f"Seed: {SEED}")
+    print("=" * 60)
+
+    # Narrator pair
+    narr_low, narr_high = generate_pair("Narrator", NARRATOR_TEXT, NARRATOR_REF)
+    FILES["narrator_low"].write_bytes(narr_low)
+    FILES["narrator_high"].write_bytes(narr_high)
+
+    # Dialogue pair
+    dial_low, dial_high = generate_pair("Dialogue", DIALOGUE_TEXT, DIALOGUE_REF)
+    FILES["dialogue_low"].write_bytes(dial_low)
+    FILES["dialogue_high"].write_bytes(dial_high)
+
+    print("\n" + "=" * 60)
+    print("All 4 clips generated!")
+    print(f"Output dir: {OUTPUT_DIR}/")
+    for name, path in FILES.items():
+        print(f"  {path.name} ({name})")
+    print()
+    print("Run prosody_metrics.py to measure ST/CV:")
+    print(f"  python prosody_metrics.py \\")
+    for label, path in FILES.items():
+        print(f"    {label}={path} \\")
+    print(f"    --json {OUT_METRICS} --plot {OUT_PLOT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/long_segment_drift_test.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/long_segment_drift_test.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Long-segment prosody drift test — #1877.
+
+Generates a 30s+ audio clip with the SAME voice (same reference_id) and
+measures prosody metrics in sliding windows to detect drift over time.
+
+If prosody is stable: ST/CV/velocity should be roughly constant across windows.
+If prosody drifts toward monotone: ST/CV/velocity should decrease in later windows.
+
+Also generates at 3 temperature levels (0.3, 0.7, 1.2) to see if temperature
+affects drift behaviour.
+
+Usage:
+    cd v4/prosody_lab/
+    python long_segment_drift_test.py
+
+Output:
+    outputs/prosody_lab/drift_<temp>.mp3
+    outputs/prosody_lab/drift_metrics.json
+    outputs/prosody_lab/drift_contours.png
+    outputs/prosody_lab/drift_window_metrics.json   (per-window breakdown)
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np
+
+from fishaudio_client import fishaudio_tts
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "outputs" / "prosody_lab"
+OUTPUT_DIR.mkdir(exist_ok=True, parents=True)
+
+# Long paragraph from Boule de Suif — should yield 30s+ of audio
+# This is the full passage from Act 1, segment 7 (opening of the meal scene)
+LONG_TEXT = (
+    "Enfin, a trois heures, comme on se trouvait au milieu d'une plaine "
+    "interminable, Boule de Suif retira de sous la banquette un large panier "
+    "couvert d'une serviette blanche. Elle en tira d'abord un petit plat "
+    "de porcelet froid, puis une belle piece de pate de lievre, un beau "
+    "fromage de cochon, une forte provision de fruits confits, un pain "
+    "de savoie, quatre gouters complets, un saucisson, des petits gateaux "
+    "et une bouteille de vin. La Cornudet regardait ce depot de vivres "
+    "avec un oeil brillant et satisfait. Quant aux autres, le desappointement "
+    "se peignait sur leurs visages. On s'offensait de cette munificence "
+    "etouffee. La comtesse surtout semblait contrariee."
+)
+
+REFERENCE_ID = "v4_narrator_male_neutral"  # Same voice throughout
+SEED = 42
+TEMPERATURES = [0.1, 0.5, 1.0]
+
+# Drift analysis: split audio into N windows
+N_WINDOWS = 4  # Quarter-window analysis
+
+OUT_METRICS = OUTPUT_DIR / "drift_metrics.json"
+OUT_WINDOW_METRICS = OUTPUT_DIR / "drift_window_metrics.json"
+OUT_PLOT = OUTPUT_DIR / "drift_contours.png"
+
+
+# ---------------------------------------------------------------------------
+# Audio generation
+# ---------------------------------------------------------------------------
+
+def generate_long_clip(temp: float) -> bytes:
+    """Generate the long text at given temperature."""
+    print(f"  Generating at temperature={temp} ...")
+    t0 = time.time()
+    audio = fishaudio_tts(
+        text=LONG_TEXT,
+        reference_id=REFERENCE_ID,
+        temperature=temp,
+        seed=SEED,
+        format="mp3",
+        timeout=600,
+    )
+    dt = time.time() - t0
+    if audio is None:
+        print(f"  ERROR: Generation failed at temp={temp}")
+        sys.exit(1)
+    print(f"  -> {len(audio)/1024:.0f} KB in {dt:.1f}s")
+    return audio
+
+
+# ---------------------------------------------------------------------------
+# Windowed prosody analysis
+# ---------------------------------------------------------------------------
+
+def windowed_metrics(audio_path: str | Path, n_windows: int = N_WINDOWS) -> list[dict]:
+    """Compute prosody metrics for each window of the audio file."""
+    from prosody_metrics import load_audio, extract_f0, DEFAULT_SR, DEFAULT_FMIN, DEFAULT_FMAX
+    import math
+
+    y, sr = load_audio(audio_path, sr=DEFAULT_SR)
+    duration = len(y) / sr
+    window_len = len(y) // n_windows
+
+    results = []
+    for i in range(n_windows):
+        start = i * window_len
+        end = start + window_len if i < n_windows - 1 else len(y)
+        y_win = y[start:end]
+        win_duration = len(y_win) / sr
+
+        # Extract F0 for this window
+        contour = extract_f0(y_win, sr, fmin=DEFAULT_FMIN, fmax=DEFAULT_FMAX)
+        f0v = contour["f0_voiced"]
+
+        if f0v.size < 5:
+            results.append({
+                "window": i + 1,
+                "time_start_s": round(start / sr, 2),
+                "time_end_s": round(end / sr, 2),
+                "duration_s": round(win_duration, 2),
+                "verdict": "NO_VOICED_SIGNAL",
+            })
+            continue
+
+        p5 = float(np.percentile(f0v, 5))
+        p95 = float(np.percentile(f0v, 95))
+        semitone_range = 12.0 * math.log2(p95 / p5) if p5 > 0 else 0.0
+        f0_mean = float(np.mean(f0v))
+        f0_std = float(np.std(f0v))
+        cv = f0_std / f0_mean if f0_mean > 0 else 0.0
+
+        # Intonation velocity
+        f0_full = contour["f0"]
+        voiced = contour["voiced"]
+        times = contour["times"]
+        median = float(np.median(f0v))
+        st_full = 12.0 * np.log2(f0_full / median)
+        st_full = np.where(np.isfinite(st_full), st_full, 0.0)
+        both_voiced = voiced[:-1] & voiced[1:]
+        if both_voiced.any():
+            dst = np.abs(np.diff(st_full))[both_voiced]
+            dt = np.diff(times)[both_voiced]
+            velocity = float(np.sum(dst) / np.sum(dt)) if np.sum(dt) > 0 else 0.0
+        else:
+            velocity = 0.0
+
+        if semitone_range < 4.0:
+            verdict = "FLAT"
+        elif semitone_range < 8.0:
+            verdict = "MODERATE"
+        else:
+            verdict = "EXPRESSIVE"
+
+        results.append({
+            "window": i + 1,
+            "time_start_s": round(start / sr, 2),
+            "time_end_s": round(end / sr, 2),
+            "duration_s": round(win_duration, 2),
+            "f0_median_hz": round(float(np.median(f0v)), 2),
+            "f0_semitone_range": round(semitone_range, 2),
+            "f0_cv": round(cv, 4),
+            "intonation_velocity_st_s": round(velocity, 3),
+            "verdict": verdict,
+        })
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print("=" * 60)
+    print("LONG SEGMENT DRIFT TEST — #1877 prosody fix")
+    print(f"Reference: {REFERENCE_ID}")
+    print(f"Text: {len(LONG_TEXT)} chars (expected 30s+)")
+    print(f"Temperatures: {TEMPERATURES}")
+    print(f"Windows per clip: {N_WINDOWS}")
+    print("=" * 60)
+
+    all_metrics = {}
+    all_window_metrics = {}
+
+    for temp in TEMPERATURES:
+        label = f"temp_{temp}"
+        out_path = OUTPUT_DIR / f"drift_{temp}.mp3"
+
+        print(f"\n--- Temperature {temp} ---")
+        audio = generate_long_clip(temp)
+        out_path.write_bytes(audio)
+
+        # Full-clip metrics
+        from prosody_metrics import compute_metrics
+        metrics = compute_metrics(str(out_path))
+        all_metrics[label] = metrics
+        print(f"  Full clip: ST={metrics['f0_semitone_range']:.2f}, "
+              f"CV={metrics['f0_cv']:.4f}, velocity={metrics['intonation_velocity_st_s']:.2f}, "
+              f"verdict={metrics['verdict']}")
+
+        # Windowed metrics
+        windows = windowed_metrics(str(out_path), N_WINDOWS)
+        all_window_metrics[label] = windows
+        print(f"  Window breakdown:")
+        for w in windows:
+            print(f"    W{w['window']} ({w.get('time_start_s',0):.1f}s-"
+                  f"{w.get('time_end_s',0):.1f}s): "
+                  f"ST={w.get('f0_semitone_range',0):.2f}, "
+                  f"CV={w.get('f0_cv',0):.4f}, "
+                  f"vel={w.get('intonation_velocity_st_s',0):.2f}, "
+                  f"verdict={w.get('verdict','N/A')}")
+
+    # Save results
+    OUT_METRICS.parent.mkdir(parents=True, exist_ok=True)
+    with open(OUT_METRICS, "w", encoding="utf-8") as f:
+        json.dump(all_metrics, f, indent=2, ensure_ascii=False)
+    with open(OUT_WINDOW_METRICS, "w", encoding="utf-8") as f:
+        json.dump(all_window_metrics, f, indent=2, ensure_ascii=False)
+
+    # Detect drift: check if ST decreases across windows
+    print("\n" + "=" * 60)
+    print("DRIFT ANALYSIS")
+    print("=" * 60)
+    for label, windows in all_window_metrics.items():
+        sts = [w.get("f0_semitone_range", 0) for w in windows]
+        if len(sts) >= 2:
+            delta_st = sts[-1] - sts[0]
+            drift_pct = (delta_st / sts[0] * 100) if sts[0] > 0 else 0
+            direction = "DRIFT DOWN (monotone)" if delta_st < -1.5 else \
+                        "DRIFT UP" if delta_st > 1.5 else "STABLE"
+            print(f"  {label}: W1→W{len(sts)} ST = {sts[0]:.2f} → {sts[-1]:.2f} "
+                  f"(delta={delta_st:+.2f}, {drift_pct:+.1f}%) → {direction}")
+        else:
+            print(f"  {label}: insufficient windows")
+
+    print(f"\nResults saved to:")
+    print(f"  {OUT_METRICS}")
+    print(f"  {OUT_WINDOW_METRICS}")
+
+    # Generate contour plot
+    from prosody_metrics import plot_contours
+    labelled = {f"temp_{t}": str(OUTPUT_DIR / f"drift_{t}.mp3") for t in TEMPERATURES}
+    plot_contours(labelled, OUT_PLOT, title="Long segment drift test — same voice, different temperatures")
+    print(f"  {OUT_PLOT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add 5 diagnostic scripts to the TTS prosody lab for systematic A/B testing of TTS engines, supporting issue #1877 (prosody monotony diagnosis).

### Scripts added

| Script | Purpose | Engines |
|--------|---------|---------|
| `ab_engine_test.py` | 5-engine comparison (FishAudio, Kokoro, Chatterbox, Qwen TTS, Higgs v3) | All OpenAI-compat APIs |
| `ab_clone_test.py` | Compare flat vs expressive reference cloning | FishAudio |
| `ab_dialogue_test.py` | Dialogue prosody between different voices | FishAudio |
| `ab_same_voice_test.py` | Consistency test across segments | FishAudio |
| `long_segment_drift_test.py` | Detect prosody drift in long narration | FishAudio |

### Key results (from runs this week)

| Engine | ST-spread | F0 CV | Verdict |
|--------|-----------|-------|---------|
| **Chatterbox** | **11.00** | **0.201** | HIGHLY EXPRESSIVE |
| Higgs v3 | 9.20 | 0.159 | EXPRESSIVE |
| Kokoro | 7.40 | 0.142 | MODERATE |
| FishAudio (clone) | ~6-7 | ~0.12 | MODERATE (flat) |

### Dependencies
- Existing prosody_metrics.py (ST-spread, F0 CV, velocity, voiced fraction)
- Existing fishaudio_client.py for FishAudio API
- requests, numpy, librosa (standard GenAI stack)

### Secrets
- KOKORO_API_KEY read via os.getenv() (no literal default)
- All other engines use local Docker APIs (no auth)

See #1877