### PR TITLE
feat(lean): #2611 final step — sensitivity + mathlib_examples join shared mathlib group A (Closes #2611)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/MathLibExamples.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/MathLibExamples.lean
@@ -1,0 +1,1 @@
+import MathLibExamples.Basic

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/MathLibExamples/Basic.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/MathLibExamples/Basic.lean
@@ -1,6 +1,6 @@
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.Linarith
-import Mathlib.Tactic.Omega
+-- omega est fourni par Lean core (plus de module Mathlib.Tactic.Omega depuis v4.30)
 
 /-!
 # Basic Mathlib Examples
@@ -13,12 +13,12 @@ pour tester que l'installation fonctionne correctement.
 example (a b : ℤ) : (a + b)^2 = a^2 + 2*a*b + b^2 := by ring
 
 -- Exemple avec linarith
-example (x y : ℚ) (h1 : x ≤ 3*y) (h2 : 1 ≤ y) : x ≤ 3 := by linarith
+example (x y : ℚ) (h1 : x ≤ 3*y) (h2 : y ≤ 1) : x ≤ 3 := by linarith
 
 -- Exemple avec omega
 example (n : ℕ) : n < n + 1 := by omega
 
 -- Exemple combiné
-example (a b c : ℤ) (h1 : a = b) (h2 : b = c) : a + a = c + c := by
+example (a b c : ℤ) (h1 : a = b) (h2 : b = c) : a + a = 2 * c := by
   rw [h1, h2]
   ring

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lean-toolchain
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.27.0
+leanprover/lean4:v4.30.0-rc2

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.30.0-rc2",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "mathlib_examples",
+ "name": "sensitivity",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/scripts/lean/setup_shared_mathlib.ps1
+++ b/scripts/lean/setup_shared_mathlib.ps1
@@ -316,7 +316,10 @@ function Invoke-Apply {
                     Write-Host " FAILED — rollback de ce membre"
                     ($out | Select-Object -Last 15) | ForEach-Object { Write-Host "    $_" }
                     Restore-Member $m
-                    $stateMembers = $stateMembers | Where-Object { $_.relPath -ne $m.RelPath }
+                    # @(...) obligatoire : un pipeline a 0/1 element degraderait $stateMembers
+                    # en $null/scalaire, et `+= [ordered]@{}` sur un dictionnaire fusionne les
+                    # cles au lieu d'appender -> "Item has already been added: 'relPath'".
+                    $stateMembers = @($stateMembers | Where-Object { $_.relPath -ne $m.RelPath })
                 }
             }
         }


### PR DESCRIPTION
## Summary

Dernière étape du plan #2611 : alignement des 2 derniers projets alignables sur le **groupe A** (`v4.30.0-rc2` / mathlib `1c1dadbc`), junctions appliquées et vérifiées par build local, + fix d'un bug du script de mutualisation découvert en route. Le bilan chiffré final est posté sur l'issue.

Closes #2611

## Changes

- **`SymbolicAI/Lean/sensitivity_lean/lake-manifest.json`** (nouveau) : le projet n'avait AUCUN manifest committé (`require mathlib from git` sans rev = dépendance flottante — cause racine de son checkout physique hors-groupe à `84af651f`, 6.39 GB, invisible du scan). Manifest copié du donneur groupe A (`social_choice_lean`), nom racine ajusté → `sensitivity`, 9 packages strictement identiques au donneur (diff champ-par-champ : 0 divergence).
- **`SymbolicAI/Lean/mathlib_examples/lean-toolchain`** : `v4.27.0` → `v4.30.0-rc2` (rejoint la famille des groupes).
- **`SymbolicAI/Lean/mathlib_examples/lake-manifest.json`** : mathlib `48f66c08` → `1c1dadbc` + deps transitives alignées (dérivé programmatiquement du manifest donneur, root name préservé).
- **`SymbolicAI/Lean/mathlib_examples/MathLibExamples.lean`** (nouveau, 1 ligne) : module racine agrégateur `import MathLibExamples.Basic`. La lib `lean_lib «MathLibExamples»` n'avait pas de module racine (seul `MathLibExamples/Basic.lean` existait) → `lake build` n'avait jamais pu passer, même sous v4.27. Aucun contenu de preuve ajouté/modifié.
- **`SymbolicAI/Lean/mathlib_examples/MathLibExamples/Basic.lean`** : 3 fixes minimaux révélés par le premier build réel du projet (jamais compilé auparavant, faute de module racine) :
  1. import obsolète `Mathlib.Tactic.Omega` retiré (module supprimé de mathlib, `omega` est dans Lean core) ;
  2. exemple linarith **mathématiquement faux** corrigé : `x ≤ 3*y ∧ 1 ≤ y → x ≤ 3` est réfutable (y=2, x=6) → hypothèse changée en `y ≤ 1` ;
  3. exemple combiné : `rw [h1, h2]` fermait le but par rfl, laissant `ring` sans goal (`No goals to be solved`) → but changé en `a + a = 2 * c` pour que `ring` soit réellement exercé.

  Les 4 tactiques démontrées (`ring`, `linarith`, `omega`, `rw`+`ring`) sont toutes conservées.
- **`scripts/lean/setup_shared_mathlib.ps1`** : fix crash `Item has already been added. Key in dictionary: 'relPath'` — après un rollback de membre, `$stateMembers = $stateMembers | Where-Object {...}` dégénérait en `$null`/scalaire (pipeline 0/1 élément), et `+= [ordered]@{}` sur un dictionnaire **fusionne les clés** au lieu d'appender. Wrap `@(...)`. Reproduit puis vérifié corrigé sur run réel.

## Validation (builds locaux à travers les junctions, 2026-06-11)

```text
=== Apply groupe leanprover_lean4_v4.30.0-rc2-1c1dadbc (0 a traiter, 5 deja junctionne(s)) ===
Cache existant reutilise : C:\dev\CoursIA\.mathlib-cache\leanprover_lean4_v4.30.0-rc2-1c1dadbc\mathlib
  lake build MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean ... SUCCESS
  backup supprime (espace recupere).
  lake build MyIA.AI.Notebooks/GameTheory/cooperative_games_lean ... SUCCESS
  lake build MyIA.AI.Notebooks/GameTheory/social_choice_lean ... SUCCESS
  lake build MyIA.AI.Notebooks/GameTheory/stable_marriage_lean ... SUCCESS
  lake build MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples ... SUCCESS  (810 jobs)
  backup supprime (espace recupere).
```

Scan final : **8 projets junctionnés** (5 groupe A `1c1dadbc` + 3 groupe B `54f98fd6`), 3 isolés by-design, économie résiduelle 0 GB.

- Les preuves Huang (`Sensitivity/*.lean`, 4 fichiers, dust-off de mathlib4/Archive) compilent contre `1c1dadbc` **sans aucune modification de source**. Côté mathlib_examples, seuls les 3 fixes ci-dessus (import obsolète + 2 exemples cassés). `grep -c sorry` : **0 partout, avant comme après** (Hypercube/MainTheorem/Operator/VectorSpace/Basic).
- Junction = partage du checkout+build mathlib uniquement ; les petites deps (aesop, batteries, Cli…) sont re-matérialisées fraîches aux revs du manifest.
- Espace libéré ce cycle après `-RemoveBackups` : **~12.7 GB** (6.39 + 6.29). Cumul #2611 : **~33 GB**.

## Non-alignables (documentés dans le bilan sur l'issue)

- `social_choice_lean_peters` : dépend de l'upstream `DominikPeters/SocialChoiceLean` qui pinne lui-même mathlib `8cb93191` (v4.27.0-rc1) — bumper casserait la dep externe. Isolé by-design.
- `conway_cgt_lean` (v4.31.0-rc1) et `stable_marriage/upstream` (v4.25.0, snapshot référence read-only) : isolés by-design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
