### PR TITLE
enrich(Texte): add exercise stubs to 9 notebooks for >=3 convention (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -646,6 +646,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4b16d30e",
+   "source": "### Exercice 1 : Composer un system prompt pour un assistant specialise\n\nLe message `system` controle le comportement du modele. L'exemple ci-dessus utilise un system prompt \"poetique\". Votre mission est de creer un system prompt pour un **assistant de revision technique** qui doit repondre de maniere concise et structuree.\n\n**Objectif** : Definir un message system qui force le modele a :\n1. Repondre en francais\n2. Utiliser des listes a puces pour structurer sa reponse\n3. Limiter chaque reponse a 5 points maximum\n4. Toujours citer des sources ou des exemples concrets\n\n**Indices** :\n- Le message system doit commencer par \"Tu es un assistant de revision technique qui...\"\n- Testez avec la question : \"Explique-moi les avantages de Python pour la data science\"\n- Utilisez `max_completion_tokens=300` pour garder les reponses concises",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "b7fd1869",
+   "source": "# Exercice 1 : Composer un system prompt pour un assistant specialise\n# TODO etudiant : Creez un system prompt pour un assistant de revision technique\n\n# Etape 1 : Definir le message system avec les contraintes\n# system_prompt = \"Tu es un assistant de revision technique qui...\"\n\n# Etape 2 : Definir la question de test\n# test_question = \"Explique-moi les avantages de Python pour la data science\"\n\n# Etape 3 : Appeler le modele avec le system prompt\n# response_ex1 = client.chat.completions.create(\n#     messages=[\n#         {\"role\": \"system\", \"content\": system_prompt},\n#         {\"role\": \"user\", \"content\": test_question},\n#     ],\n#     model=DEFAULT_MODEL,\n#     max_completion_tokens=300,\n# )\n\n# Etape 4 : Afficher la reponse et verifier le respect des contraintes\n# print(\"Reponse de l'assistant technique :\")\n# print(response_ex1.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "4e6b17ae",
    "metadata": {
     "papermill": {
@@ -854,6 +868,20 @@
     "cout_estimé = prompt_tokens * PRIX_PAR_TOKEN\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ab548dc",
+   "source": "### Exercice 2 : Comparer la tokenisation de textes multilingues\n\nLa tokenisation varie selon la langue. Les mots frequents en anglais sont souvent decoupes en moins de tokens que les memes mots en francais, car les modeles sont principalement entraines sur des corpus anglais.\n\n**Objectif** : Comparez le nombre de tokens pour la meme phrase traduite en 3 langues (francais, anglais, espagnol) en utilisant `tiktoken`.\n\n**Indices** :\n- Utilisez `get_encoder(DEFAULT_MODEL)` pour obtenir l'encodeur (comme dans la cellule precedente)\n- Phrases suggerees : \"L'intelligence artificielle transforme le monde\" / \"Artificial intelligence is transforming the world\" / \"La inteligencia artificial esta transformando el mundo\"\n- Utilisez `len(encoder.encode(text))` pour compter les tokens de chaque phrase\n- Affichez un tableau comparatif avec `print()`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "43159264",
+   "source": "# Exercice 2 : Comparer la tokenisation de textes multilingues\n# TODO etudiant : Comparez le nombre de tokens pour la meme phrase en 3 langues\n\n# Etape 1 : Definir les phrases dans les 3 langues\n# phrases = {\n#     \"francais\": \"L'intelligence artificielle transforme le monde\",\n#     \"anglais\": \"Artificial intelligence is transforming the world\",\n#     \"espagnol\": \"La inteligencia artificial esta transformando el mundo\",\n# }\n\n# Etape 2 : Obtenir l'encodeur et compter les tokens pour chaque phrase\n# encoder = get_encoder(DEFAULT_MODEL)\n# for langue, texte in phrases.items():\n#     nb_tokens = len(encoder.encode(texte))\n#     print(f\"{langue}: {nb_tokens} tokens\")\n\n# Etape 3 : (optionnel) Afficher les tokens individuels pour une des phrases\n# tokens = encoder.encode(phrases[\"francais\"])\n# decoded = [encoder.decode([t]) for t in tokens]\n# print(f\"Tokens francais: {decoded}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1070,6 +1098,20 @@
     "\n",
     "**Leçon clé** : Les LLMs sont excellents pour générer du texte cohérent, mais ne distinguent pas intrinsèquement le vrai du faux. La vérification humaine reste essentielle."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "038d8330",
+   "source": "### Exercice 3 : Detecter et corriger une hallucination\n\nL'exemple ci-dessus montre comment un modele peut inventer des details plausibles. Votre mission est de creer un prompt qui demande au modele de decrire un evenement reel ET un evenement fictif, puis d'identifier lequel est invente.\n\n**Objectif** : Formuler un prompt contenant deux descriptions d'evenements historiques (un vrai, un invente), et demander au modele d'identifier l'imposteur en justifiant sa reponse.\n\n**Indices** :\n- Choisissez un evenement reel peu connu (ex: \"La premiere transmission radio transatlantique, 1901\")\n- Inventez un evenement similaire mais faux (ex: \"La premiere communication telephonique sous-marine, 1898\")\n- Demandez au modele : \"Lequel de ces deux evenements est invente ? Justifie.\"",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "4fd36c5b",
+   "source": "# Exercice 3 : Detecter et corriger une hallucination\n# TODO etudiant : Creez un prompt avec 2 evenements (1 vrai, 1 faux)\n# et demandez au modele d'identifier l'imposteur\n\n# Etape 1 : Formuler le prompt avec les deux evenements\n# hallucination_prompt = \"\"\"\n# Voici deux evenements historiques. L'un est vrai, l'autre est invente.\n# Evenement A: ...\n# Evenement B: ...\n# Lequel est invente ? Justifie ta reponse.\n# \"\"\"\n\n# Etape 2 : Appeler le modele\n# response_detect = client.chat.completions.create(\n#     messages=[{\"role\": \"user\", \"content\": hallucination_prompt}],\n#     model=DEFAULT_MODEL\n# )\n\n# Etape 3 : Afficher la reponse et verifier si le modele a correctement identifie l'imposteur\n# print(response_detect.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
@@ -1128,6 +1128,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ad0db32a",
+   "source": "### Exercice 3 : Chain-of-thought pour un probleme logique\n\nCreez un prompt qui utilise le chain-of-thought pour resoudre un probleme logique. Contrairement a l'exemple ci-dessus (ou le raisonnement etait demande sans etapes), vous devez **explicitement** demander au modele de detailler chaque etape.\n\n**Objectif** : Formuler un prompt CoT pour le probleme suivant :\n> \"Un train quitte Paris a 8h00 a 120 km/h. Un autre quitte Lyon a 9h00 a 100 km/h. La distance Paris-Lyon est de 470 km. A quelle heure se croisent-ils ?\"\n\n**Indices** :\n- Demandez au modele d'expliquer son raisonnement \"etape par etape\"\n- Precisez qu'il doit detailler les calculs intermediaires\n- Utilisez `max_completion_tokens=400` pour laisser suffisamment de place au raisonnement",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "76bae53c",
+   "source": "# Exercice 3 : Chain-of-thought pour un probleme logique\n# TODO etudiant : Creez un prompt CoT pour le probleme des trains\n\n# Etape 1 : Formuler le prompt avec demande explicite de raisonnement\n# cot_exercise_prompt = \"\"\"\n# ...\n# Explique ton raisonnement etape par etape.\n# \"\"\"\n\n# Etape 2 : Appeler le modele\n# response_cot_exercise = client.chat.completions.create(\n#     model=MODEL_NAME,\n#     messages=[{\"role\": \"user\", \"content\": cot_exercise_prompt}],\n#     max_completion_tokens=400,\n# )\n\n# Etape 3 : Afficher le raisonnement et la reponse finale\n# print(response_cot_exercise.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "730a6f88",
    "metadata": {
     "papermill": {
@@ -1372,6 +1386,20 @@
     "\n",
     "**Limite** : Chaque itération consomme des tokens et du temps. À utiliser pour des tâches critiques nécessitant haute qualité."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90e89c30",
+   "source": "### Exercice 2 : Few-shot pour la traduction technique\n\nEn vous inspirant de l'exemple few-shot de redaction d'e-mails ci-dessus, creez un prompt few-shot pour traduire des termes techniques du francais vers l'anglais avec leur contexte d'utilisation.\n\n**Objectif** : Fournir 2 exemples de traduction technique, puis demander au modele de traduire un nouveau terme.\n\n**Indices** :\n- Utilisez le meme format que l'exemple : `Q:` pour la question, `A:` pour la reponse\n- Incluez le contexte d'utilisation dans chaque exemple (ex: \"en devops\", \"en machine learning\")\n- Le modele doit reproduire la structure des exemples pour le nouveau terme",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "1118d04c",
+   "source": "# Exercice 2 : Few-shot pour la traduction technique\n# TODO etudiant : Creez un prompt few-shot avec 2 exemples de traduction technique\n# puis demandez la traduction de \"apprentissage par renforcement\" (en IA)\n\n# Etape 1 : Definir le prompt few_shot avec 2 exemples Q/A\n# few_shot_traduction = \"\"\"\n# ...\n# \"\"\"\n\n# Etape 2 : Appeler le modele avec le prompt\n# response_traduction = client.chat.completions.create(...)\n\n# Etape 3 : Afficher le resultat\n# print(response_traduction.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
@@ -669,6 +669,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "66f5fe01",
+   "source": "### Exercice 1 : Schema JSON pour un film\n\nEn vous basant sur l'exemple de recette ci-dessus, creez un JSON Schema manuel pour structurer les informations d'un film.\n\n**Objectif** : Definir un schema avec les champs titre, annee (integer), genre (enum parmi \"action\", \"comedie\", \"drame\", \"science-fiction\", \"thriller\"), realisateur, acteurs (liste de strings), et un resume. Appelez ensuite l'API avec ce schema.\n\n**Indices** :\n- Suivez exactement la meme structure que le schema `recette_schema` ci-dessus\n- N'oubliez pas `additionalProperties: False` dans le schema (requis par OpenAI)\n- Le champ `annee` doit etre de type `integer`\n- Utilisez `\"enum\"` pour contraindre le genre aux 5 valeurs proposees\n- Testez avec le prompt : \"Donne-moi les informations du film Interstellar\"",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "687c2ed4",
+   "source": "# Exercice 1 : Schema JSON pour un film\n# TODO etudiant : Creez un JSON Schema manuel pour structurer un film\n\n# Etape 1 : Definir le schema JSON manuellement\n# film_schema = {\n#     \"type\": \"object\",\n#     \"properties\": {\n#         \"titre\": {\"type\": \"string\"},\n#         \"annee\": {\"type\": \"integer\"},\n#         \"genre\": {\"type\": \"string\", \"enum\": [\"action\", \"comedie\", \"drame\", \"science-fiction\", \"thriller\"]},\n#         \"realisateur\": {\"type\": \"string\"},\n#         \"acteurs\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}},\n#         \"resume\": {\"type\": \"string\"},\n#     },\n#     \"required\": [...],  # TODO : listez tous les champs\n#     \"additionalProperties\": False,\n# }\n\n# Etape 2 : Appeler l'API avec le schema\n# response_film = client.chat.completions.create(\n#     model=DEFAULT_MODEL,\n#     messages=[{\"role\": \"user\", \"content\": \"Donne-moi les informations du film Interstellar\"}],\n#     response_format={\n#         \"type\": \"json_schema\",\n#         \"json_schema\": {\n#             \"name\": \"film_schema\",\n#             \"strict\": True,\n#             \"schema\": film_schema,\n#         }\n#     }\n# )\n\n# Etape 3 : Parser et afficher le resultat\n# film = json.loads(response_film.choices[0].message.content)\n# print(f\"Film: {film['titre']} ({film['annee']})\")\n# print(f\"Genre: {film['genre']} | Realisateur: {film['realisateur']}\")\n# print(f\"Acteurs: {', '.join(film['acteurs'])}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "7daf68cd",
    "metadata": {
     "papermill": {
@@ -956,6 +970,20 @@
     "\n",
     "> **Note** : Le schéma Pydantic sert de **contrat** entre l'API et le code. Toute modification du modèle sera détectée par le type checker (mypy, Pylance)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed4f3286",
+   "source": "### Exercice 2 : Extracteur d'evenements avec validation de dates\n\nCreez un modele Pydantic pour extraire des evenements depuis un texte, en incluant une validation pour s'assurer que les dates sont au format correct et que la priorite est parmi un ensemble de valeurs autorisees.\n\n**Objectif** : Definir un schema `EvenementExtrait` avec des contraintes de validation (enum pour le type, format date, priorite contrainte), puis extraire les evenements d'un texte descriptif.\n\n**Indices** :\n- Utilisez `enum` dans le JSON Schema pour contraindre le type d'evenement : `\"reunion\"`, `\"deadline\"`, `\"livraison\"`, `\"presentation\"`\n- Pour la priorite, utilisez `Field(description=...)` avec une valeur parmi `\"haute\"`, `\"moyenne\"`, `\"basse\"`\n- Ajoutez un champ `participants: List[str]` pour les personnes impliquees\n- Testez avec : \"Reunion de sprint lundi prochain a 14h avec l'equipe dev. Deadline rendu rapport vendredi. Presentation client le 30 mars.\"",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "2af530e9",
+   "source": "# Exercice 2 : Extracteur d'evenements avec validation de dates\n# TODO etudiant : Creez un modele Pydantic pour extraire des evenements\n\n# Etape 1 : Definir le modele Pydantic avec enum et contraintes\n# class EvenementExtrait(BaseModel):\n#     titre: str = Field(description=\"Titre de l'evenement\")\n#     type_evenement: str = Field(description=\"Type: reunion, deadline, livraison, presentation\")\n#     date: str = Field(description=\"Date au format YYYY-MM-DD ou texte relatif\")\n#     priorite: str = Field(description=\"Priorite: haute, moyenne, basse\")\n#     participants: List[str] = Field(description=\"Personnes impliquees\")\n#     description: str = Field(description=\"Description breve\")\n\n# Etape 2 : Tester avec un texte descriptif\n# texte_evenements = \"\"\"\n# Reunion de sprint lundi prochain a 14h avec l'equipe dev.\n# Deadline rendu rapport vendredi.\n# Presentation client le 30 mars.\n# \"\"\"\n# resultat = extract_structured(\n#     f\"Extrais les evenements de ce texte:\\n{texte_evenements}\",\n#     EvenementExtrait\n# )\n\n# Etape 3 : Afficher les evenements extraits\n# if resultat:\n#     print(f\"Evenement: {resultat.titre}\")\n#     print(f\"Type: {resultat.type_evenement} | Priorite: {resultat.priorite}\")\n#     print(f\"Participants: {', '.join(resultat.participants)}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1505,6 +1533,20 @@
     "\n",
     "> **Note production** : En contexte réel, ajouter une validation humaine pour les feedbacks haute priorité avant création automatique de tickets."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68eb1ada",
+   "source": "### Exercice 3 : Analyseur de produits e-commerce\n\nCreez un modele Pydantic pour extraire et structurer les informations d'une fiche produit e-commerce. Ce modele doit gerer des objets imbriques (caracteristiques techniques, avis clients) et utiliser des contraintes de validation.\n\n**Objectif** : Definir un schema `ProduitAnalyse` avec Pydantic, puis extraire les donnees d'une description produit non structuree.\n\n**Indices** :\n- Utilisez la fonction `extract_structured()` deja definie dans ce notebook\n- Le modele doit inclure : nom, prix (float avec `confloat(gt=0)`), categorie, liste de caracteristiques techniques (nom + valeur), note moyenne (0-5), et liste d'avis (auteur, commentaire, note)\n- Testez avec un texte de produit invente : \"MacBook Pro M4 - Ordinateur portable Apple avec puce M4 Pro, 18Go RAM, 512Go SSD. Ecran Liquid Retina XDR 14 pouces. Note : 4.7/5. Avis : 'Excellent pour le dev' par Alice (5/5), 'Un peu cher' par Bob (4/5).\"",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "e590981d",
+   "source": "# Exercice 3 : Analyseur de produits e-commerce\n# TODO etudiant : Creez un modele Pydantic pour extraire des donnees produit\n\n# Etape 1 : Definir les modeles Pydantic imbriques\n# from pydantic import confloat\n#\n# class Caracteristique(BaseModel):\n#     nom: str = Field(description=\"Nom de la caracteristique\")\n#     valeur: str = Field(description=\"Valeur de la caracteristique\")\n#\n# class Avis(BaseModel):\n#     auteur: str = Field(description=\"Nom de l'auteur de l'avis\")\n#     commentaire: str = Field(description=\"Contenu de l'avis\")\n#     note: conint(ge=1, le=5) = Field(description=\"Note sur 5\")\n#\n# class ProduitAnalyse(BaseModel):\n#     nom: str\n#     prix: confloat(gt=0)\n#     categorie: str\n#     caracteristiques: List[Caracteristique]\n#     note_moyenne: confloat(ge=0, le=5)\n#     avis: List[Avis]\n\n# Etape 2 : Tester avec un texte de produit\n# texte_produit = \"MacBook Pro M4 - 1499 EUR. Puce M4 Pro, 18Go RAM, 512Go SSD...\"\n# produit = extract_structured(f\"Extrais les infos de ce produit:\\n{texte_produit}\", ProduitAnalyse)\n\n# Etape 3 : Afficher le resultat structure\n# if produit:\n#     print(f\"Produit: {produit.nom} ({produit.prix} EUR)\")\n#     for carac in produit.caracteristiques:\n#         print(f\"  {carac.nom}: {carac.valeur}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -1424,6 +1424,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "16910de6",
+   "source": "### Exercice 4 : Analyseur de logs avec tool_choice\n\nCreez un outil d'analyse de logs qui utilise les differents modes de `tool_choice` pour controler le comportement du modele.\n\n**Objectif** : Definir un tool `analyze_log` qui detecte le niveau de severite d'un message de log (ERROR, WARNING, INFO), et tester les 3 modes de `tool_choice` (`auto`, `required`, `none`) sur differentes requetes pour observer comment le modele decide d'appeler ou non l'outil.\n\n**Indices** :\n- Inspirez-vous de la section 5 sur `tool_choice` pour les 3 modes\n- Le tool doit avoir un parametre `log_message` de type string\n- Implementez une fonction qui retourne un JSON avec le niveau detecte et un resume\n- Testez avec : un message d'erreur clair (mode auto), une question sans rapport (mode auto), et forcez l'appel (mode required)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "0a574db2",
+   "source": "# Exercice 4 : Analyseur de logs avec tool_choice\n# TODO etudiant : Creez un outil d'analyse de logs\n\n# Etape 1 : Definir le tool analyze_log avec JSON Schema\n# log_tool = [{\n#     \"type\": \"function\",\n#     \"function\": {\n#         \"name\": \"analyze_log\",\n#         \"description\": \"...\",\n#         \"parameters\": {\n#             \"type\": \"object\",\n#             \"properties\": {\n#                 \"log_message\": {\"type\": \"string\", \"description\": \"...\"}\n#             },\n#             \"required\": [\"log_message\"]\n#         }\n#     }\n# }]\n\n# Etape 2 : Implementer la fonction\n# def analyze_log(log_message: str) -> str:\n#     ...\n#     return json.dumps({\"severity\": ..., \"summary\": ...})\n\n# Etape 3 : Tester les 3 modes tool_choice\n# Test auto avec message d'erreur, auto avec question sans rapport, required\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "067f0c4d",
    "metadata": {
     "papermill": {
@@ -1704,6 +1718,20 @@
     "\n",
     "> **Pattern clé** : Le modèle transforme \"planifie ma journée\" en une séquence de 3 actions atomiques sans intervention humaine. C'est le cœur du paradigme **agentique**."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a42f73fc",
+   "source": "### Exercice 3 : Outil de conversion de devises\n\nCreez un outil de conversion de devises et integrez-le dans la boucle agentique. Le modele doit pouvoir convertir des montants entre differentes devises en utilisant un outil que vous definissez.\n\n**Objectif** : Definir un tool `convert_currency` avec les paramètres `amount` (montant), `from_currency` (devise source) et `to_currency` (devise cible), implementer la fonction simulee, et tester avec la question : \"Combien font 100 euros en dollars et en yen ?\"\n\n**Indices** :\n- Definissez le tool avec JSON Schema en vous inspirant de `get_weather`\n- Pour la fonction simulee, utilisez des taux fixes (EUR/USD = 1.10, EUR/JPY = 160, USD/JPY = 145)\n- Le modele peut appeler la fonction plusieurs fois si la question implique plusieurs conversions\n- Utilisez `run_safe_conversation()` pour gerer les erreurs",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "53225242",
+   "source": "# Exercice 3 : Outil de conversion de devises\n# TODO etudiant : Creez un outil de conversion de devises\n\n# Etape 1 : Definir le tool avec JSON Schema\n# currency_tool = [{\n#     \"type\": \"function\",\n#     \"function\": {\n#         \"name\": \"convert_currency\",\n#         ...\n#     }\n# }]\n\n# Etape 2 : Implementer la fonction simulee avec des taux fixes\n# def convert_currency(amount: float, from_currency: str, to_currency: str) -> str:\n#     rates = {\"EUR\": 1.0, \"USD\": 1.10, \"JPY\": 160.0, \"GBP\": 0.85}\n#     ...\n#     return json.dumps({\"amount\": ..., \"from\": ..., \"to\": ..., \"result\": ...})\n\n# Etape 3 : Tester avec une question multi-conversion\n# all_tools_with_currency = extended_tools + currency_tool\n# all_functions[\"convert_currency\"] = convert_currency\n# result = run_safe_conversation(\n#     \"Combien font 100 euros en dollars et en yen ?\",\n#     all_tools_with_currency,\n#     all_functions\n# )\n# print(result)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -883,6 +883,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9135cbc1",
+   "source": "### Exercice 1 - Strategie de chunking hybride\n\nLe chunking fixe coupe au milieu des phrases, le semantique produit des chunks de taille variable, et le recursif necessite de bons delimiteurs. Une strategie hybride combine les avantages de plusieurs approches.\n\n**Objectif** : Implementer une fonction `chunk_hybrid(text, target_size, tolerance, overlap)` qui decoupe un texte en chunks de taille cible tout en respectant les frontieres de phrases.\n\n**Indices** :\n- Le chunking hybride fonctionne en deux phases : decouper par phrases (comme le semantique), puis regrouper les phrases tant que la taille reste dans `[target_size - tolerance, target_size + tolerance]`\n- Utiliser `re.split(r'(?<=[.!?])\\s+', text)` pour obtenir les phrases\n- Pour chaque phrase, l'ajouter au chunk courant si `len(chunk) + len(phrase) <= target_size + tolerance`\n- Ajouter un overlap : conserver les N derniers caracteres du chunk precedent comme debut du suivant\n- `# Etape 1` : Decouper le texte en phrases avec `re.split()`\n- `# Etape 2` : Regrouper les phrases en chunks tout en respectant `target_size + tolerance`\n- `# Etape 3` : Ajouter l'overlap entre chunks consecutifs et retourner la liste\n- `# Indice` : Verifier votre resultat avec `len(chunk_hybrid(debate_text, 400, 100, 50))` et comparer avec les 51 chunks du chunking fixe",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "155481ca",
+   "source": "# Exercice 1 - Strategie de chunking hybride\n# TODO etudiant : implementer chunk_hybrid\n\nimport re\n\ndef chunk_hybrid(text: str, target_size: int = 400, tolerance: int = 100, overlap: int = 50) -> List[str]:\n    \"\"\"\n    Chunking hybride : decoupe par phrases tout en visant une taille cible.\n    \n    Args:\n        text: Texte a decouper\n        target_size: Taille cible en caracteres\n        tolerance: Ecart acceptable par rapport a la taille cible\n        overlap: Nombre de caracteres de chevauchement entre chunks\n    \n    Returns:\n        Liste de chunks texte\n    \"\"\"\n    return None  # TODO etudiant : implementer le chunking hybride\n\n# Etape 1 : Tester la fonction sur le texte du debat\n# hybrid_chunks = chunk_hybrid(debate_text, target_size=400, tolerance=100, overlap=50)\n# print(f\"Chunking hybride: {len(hybrid_chunks)} chunks\")\n\n# Etape 2 : Comparer avec le chunking fixe\n# print(f\"Chunking fixe: {len(chunks)} chunks\")\n# print(f\"Premier chunk hybride: {hybrid_chunks[0][:200]}...\")\n\n# Etape 3 : Verifier la taille des chunks\n# sizes = [len(c) for c in hybrid_chunks]\n# print(f\"Taille min: {min(sizes)}, max: {max(sizes)}, moyenne: {sum(sizes)/len(sizes):.0f}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "3u3zs9oas6e",
    "metadata": {
     "papermill": {
@@ -1663,6 +1677,20 @@
     "# Initialisation du VectorStore\n",
     "vector_store = VectorStore(df_chunks)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "682bc78f",
+   "source": "### Exercice 2 - Recherche vectorielle avec seuil de confiance\n\nLe VectorStore utilise k-NN pour trouver les chunks les plus proches, mais ne filtre pas les resultats peu pertinents. Dans un systeme de production, il est essentiel de ne retourner que les chunks dont la similarite depasse un seuil.\n\n**Objectif** : Implementer une fonction `search_with_confidence(vector_store, question, k, min_score)` qui effectue une recherche vectorielle et retourne uniquement les chunks dont le score depasse un seuil, avec un niveau de confiance global.\n\n**Indices** :\n- Reutiliser `create_embedding()` pour vectoriser la question, puis `vector_store.search()` pour la recherche\n- Filtrer les resultats avec `min_score` et calculer un niveau de confiance : \"haute\" si meilleur score > 0.7, \"moyenne\" si > 0.5, \"basse\" sinon\n- Retourner un dict `{\"results\": List[Dict], \"confidence\": str, \"total_found\": int, \"kept\": int}`\n- `# Etape 1` : Creer l'embedding de la question avec `create_embedding()`\n- `# Etape 2` : Appeler `vector_store.search(query_embedding, k=k)` et filtrer par `min_score`\n- `# Etape 3` : Determiner le niveau de confiance a partir du meilleur score des resultats filtres\n- `# Indice` : Si aucun resultat ne depasse le seuil, retourner confiance \"basse\" avec liste vide",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "1e982498",
+   "source": "# Exercice 2 - Recherche vectorielle avec seuil de confiance\n# TODO etudiant : implementer search_with_confidence\n\ndef search_with_confidence(vector_store: VectorStore, question: str, k: int = 5, min_score: float = 0.5) -> Dict[str, Any]:\n    \"\"\"\n    Recherche vectorielle avec filtrage par score et niveau de confiance.\n    \n    Args:\n        vector_store: Base vectorielle initiee\n        question: Question de l'utilisateur\n        k: Nombre de chunks a recuperer\n        min_score: Score minimum pour garder un chunk\n    \n    Returns:\n        Dict avec results, confidence, total_found, kept\n    \"\"\"\n    return None  # TODO etudiant : implementer la recherche avec confiance\n\n# Etape 1 : Tester avec une question specifique\n# result = search_with_confidence(vector_store, \"What was Lincoln's position on equality?\", k=5, min_score=0.5)\n\n# Etape 2 : Afficher les resultats et le niveau de confiance\n# print(f\"Confiance: {result['confidence']}\")\n# print(f\"Chunks trouves: {result['total_found']}, gardes: {result['kept']}\")\n# for r in result['results']:\n#     print(f\"  Score: {r['score']:.3f} - {r['text'][:100]}...\")\n\n# Etape 3 : Tester avec une question hors sujet pour observer confiance basse\n# result_off = search_with_confidence(vector_store, \"What is the recipe for chocolate cake?\", k=5, min_score=0.5)\n# print(f\"\\nQuestion hors sujet - Confiance: {result_off['confidence']}, gardes: {result_off['kept']}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -2630,6 +2658,20 @@
     "\n",
     "print(f\"\\nRéponse: {result_reranked['answer'][:500]}...\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9ac10ad",
+   "source": "### Exercice 3 - Evaluation de la qualite de retrieval\n\nLe pipeline RAG depend entierement de la qualite du retrieval. Sans bons chunks, meme le meilleur modele generera des reponses mediocre.\n\n**Objectif** : Implementer une fonction `evaluate_retrieval(questions_references, vector_store, k)` qui mesure la precision du retrieval sur un jeu de questions avec chunks de reference attendus.\n\n**Indices** :\n- Le parametre `questions_references` est une liste de dicts `{\"question\": str, \"expected_chunk_ids\": List[int]}`\n- Pour chaque question, effectuer la recherche k-NN et verifier si les `expected_chunk_ids` apparaissent dans les resultats\n- Calculer deux metriques : **precision** (fraction des chunks trouves qui sont pertinents) et **recall** (fraction des chunks pertinents qui ont ete trouves)\n- `# Etape 1` : Construire un petit jeu de 3 questions avec chunks attendus (utiliser les chunks 0, 9, 20 par exemple)\n- `# Etape 2` : Pour chaque question, appeler `vector_store.search()` et collecter les `chunk_id` trouves\n- `# Etape 3` : Comparer avec les `expected_chunk_ids` et calculer precision et recall\n- `# Indice` : precision = `len(trouves & attendus) / len(trouves)`, recall = `len(trouves & attendus) / len(attendus)`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7050cc5f",
+   "source": "# Exercice 3 - Evaluation de la qualite de retrieval\n# TODO etudiant : implementer evaluate_retrieval\n\ndef evaluate_retrieval(questions_references: List[Dict], vector_store: VectorStore, k: int = 3) -> Dict[str, float]:\n    \"\"\"\n    Evalue la qualite du retrieval sur un jeu de questions de reference.\n    \n    Args:\n        questions_references: Liste de dicts {\"question\": str, \"expected_chunk_ids\": List[int]}\n        vector_store: Base vectorielle initiee\n        k: Nombre de chunks a recuperer par recherche\n    \n    Returns:\n        Dict avec precision_moyenne, recall_moyen, details_par_question\n    \"\"\"\n    pass  # TODO etudiant : implementer l'evaluation du retrieval\n\n# Etape 1 : Definir un jeu de 3 questions avec chunks attendus\n# questions_references = [\n#     {\"question\": \"What did Lincoln say about a house divided?\", \"expected_chunk_ids\": [9]},\n#     {\"question\": \"What was the audience size?\", \"expected_chunk_ids\": [0]},\n#     {\"question\": \"What did Douglas say about popular sovereignty?\", \"expected_chunk_ids\": [20, 31]},\n# ]\n\n# Etape 2 : Appeler evaluate_retrieval\n# results = evaluate_retrieval(questions_references, vector_store, k=3)\n\n# Etape 3 : Afficher les resultats\n# print(f\"Precision moyenne: {results['precision_moyenne']:.2f}\")\n# print(f\"Recall moyen: {results['recall_moyen']:.2f}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
@@ -565,6 +565,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dd7a4652",
+   "source": "### Exercice 1 : Analyser une image personnalisee avec l'API Vision\n\nEn vous basant sur l'exemple d'analyse de rapport ci-dessus, creez votre propre image de test (un graphique ou un tableau de donnees) et demandez au modele d'en extraire les informations cles.\n\n**Objectif** : Generer une image avec PIL contenant un tableau de donnees (ventes mensuelles), l'encoder en base64, et demander au modele d'en extraire les valeurs et la tendance.\n\n**Indices** :\n- Utilisez `PIL.Image`, `PIL.ImageDraw` et `PIL.ImageFont` pour creer une image avec un tableau\n- Dessinez un tableau avec 4 lignes : \"Janvier: 120k\", \"Fevrier: 145k\", \"Mars: 160k\", \"Avril: 180k\"\n- Encodez l'image en base64 avec `base64.b64encode()`\n- Envoyez au modele avec le prompt : \"Extrais les ventes mensuelles de cette image et identifie la tendance\"",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "555f6bba",
+   "source": "# Exercice 1 : Analyser une image personnalisee avec l'API Vision\n# TODO etudiant : Creez une image avec un tableau de ventes et analysez-la\n\n# Etape 1 : Creer une image avec PIL contenant un tableau de ventes\n# from PIL import Image, ImageDraw, ImageFont\n# import io, base64\n#\n# img = Image.new('RGB', (600, 300), 'white')\n# draw = ImageDraw.Draw(img)\n# draw.text((50, 30), \"Ventes Mensuelles 2026\", fill='black')\n# draw.text((50, 80), \"Janvier: 120k EUR\", fill='black')\n# draw.text((50, 120), \"Fevrier: 145k EUR\", fill='black')\n# draw.text((50, 160), \"Mars: 160k EUR\", fill='black')\n# draw.text((50, 200), \"Avril: 180k EUR\", fill='black')\n#\n# buffer = io.BytesIO()\n# img.save(buffer, format='PNG')\n# img_b64 = base64.b64encode(buffer.getvalue()).decode()\n\n# Etape 2 : Envoyer l'image au modele Vision\n# response_vision = client.chat.completions.create(\n#     model=DEFAULT_MODEL,\n#     messages=[{\n#         \"role\": \"user\",\n#         \"content\": [\n#             {\"type\": \"text\", \"text\": \"Extrais les ventes mensuelles de cette image et identifie la tendance.\"},\n#             {\"type\": \"image_url\", \"image_url\": {\"url\": f\"data:image/png;base64,{img_b64}\"}}\n#         ]\n#     }],\n#     max_completion_tokens=300\n# )\n\n# Etape 3 : Afficher le resultat\n# print(response_vision.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "f9131c7f",
    "metadata": {
     "papermill": {
@@ -804,6 +818,20 @@
     "\n",
     "> **Attention** : Les informations financières de sources web peuvent avoir quelques minutes de retard. Pour du trading haute fréquence, utiliser des API financières spécialisées (Alpha Vantage, IEX Cloud)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7203a152",
+   "source": "### Exercice 2 : Comparaison multi-sources avec web search\n\nUtilisez le web search pour comparer les informations sur un meme sujet provenant de differentes sources. Le but est de synthetiser une reponse equilibree en citant au moins 3 sources distinctes.\n\n**Objectif** : Formuler une requete de recherche web qui demande au modele de presenter les differents points de vue sur un sujet debattu, avec les sources pour chaque position.\n\n**Indices** :\n- Utilisez `client.responses.create()` avec `tools=[{\"type\": \"web_search_preview\"}]`\n- Choisissez un sujet avec des debats actifs (ex: \"Faut-il reguler les modeles d'IA generative ?\")\n- Demandez explicitement au modele de \"presenter les arguments pour et contre avec des sources\"\n- Verifiez que les annotations (`annotations`) dans la reponse citent bien des sources differentes",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "eac64aba",
+   "source": "# Exercice 2 : Comparaison multi-sources avec web search\n# TODO etudiant : Creez une requete de recherche web comparee\n\n# Etape 1 : Formuler la requete avec demande de balance\n# query_debat = \"\"\"\n# Faut-il reguler les modeles d'IA generative ?\n# Presente les arguments pour et contre, en citant au moins 3 sources distinctes.\n# \"\"\"\n\n# Etape 2 : Appeler la Responses API avec web search\n# response_debat = client.responses.create(\n#     model=DEFAULT_MODEL,\n#     tools=[{\"type\": \"web_search_preview\"}],\n#     input=query_debat\n# )\n\n# Etape 3 : Extraire le texte et les citations\n# for item in response_debat.output:\n#     if hasattr(item, 'content'):\n#         for content in item.content:\n#             if hasattr(content, 'text'):\n#                 print(content.text)\n#                 print(f\"\\nSources citees: {len(content.annotations)}\")\n#                 for ann in content.annotations:\n#                     print(f\"  - {ann.title}: {ann.url}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1158,6 +1186,20 @@
     "\n",
     "> **Recommandation** : Toujours vérifier **manuellement** les citations fournies par le modèle. Le web search est un **outil d'aide**, pas un arbitre absolu de vérité."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9e38a38",
+   "source": "### Exercice 3 : Resume de recherche web sur un sujet technique\n\nCreez une fonction qui effectue une recherche web sur un sujet technique, extrait les points cles, et genere un resume structure avec les sources citees.\n\n**Objectif** : Utiliser la Responses API avec `web_search_preview` pour rechercher un sujet, puis formater la reponse avec les citations.\n\n**Indices** :\n- Utilisez `client.responses.create()` avec `tools=[{\"type\": \"web_search_preview\"}]`\n- Parcourez `response.output` pour trouver les items avec `hasattr(item, 'content')`\n- Pour chaque `ResponseOutputText`, le champ `text` contient le texte et `annotations` les citations\n- Formatez le resultat en listant : titre de la source, URL, et extrait pertinent",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "c05d92d4",
+   "source": "# Exercice 3 : Resume de recherche web sur un sujet technique\n# TODO etudiant : Creez une fonction de recherche web avec extraction des sources\n\n# Etape 1 : Definir la fonction de recherche\n# def search_and_summarize(query: str) -> str:\n#     response = client.responses.create(\n#         model=DEFAULT_MODEL,\n#         tools=[{\"type\": \"web_search_preview\"}],\n#         input=query\n#     )\n#     sources = []\n#     summary = \"\"\n#     for item in response.output:\n#         if hasattr(item, 'content'):\n#             for content in item.content:\n#                 if hasattr(content, 'text'):\n#                     summary = content.text\n#                     for ann in content.annotations:\n#                         sources.append({\"title\": ann.title, \"url\": ann.url})\n#     return summary, sources\n\n# Etape 2 : Tester avec un sujet technique\n# resume, sources = search_and_summarize(\n#     \"Quelles sont les differences entre RAG et fine-tuning pour les LLMs en 2026?\"\n# )\n\n# Etape 3 : Afficher le resume et les sources\n# print(\"=== Resume ===\")\n# print(resume)\n# print(\"\\n=== Sources ===\")\n# for i, src in enumerate(sources, 1):\n#     print(f\"{i}. {src['title']}: {src['url']}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
@@ -567,6 +567,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d0d9c4d2",
+   "source": "### Exercice 1 : Generation de code avec validation\n\nL'objectif est de creer une fonction `generate_and_validate` qui demande au modele de generer une fonction Python repondant a un cahier des charges, puis valide que le code genere est correct en l'executant avec des tests predefinis.\n\n**Indices :**\n- # Etape 1 : Definir un prompt qui demande une fonction Python specifique (ex: tri a bulles)\n- # Etape 2 : Appeler l'API Chat Completions pour generer le code\n- # Etape 3 : Extraire le bloc de code de la reponse (chercher les blocs ```python ... ```)\n- # Etape 4 : Executer le code extrait avec exec() et le tester avec des cas connus",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7f9078c9",
+   "source": "# Exercice 1 : Generation de code avec validation\n# TODO etudiant : Implementer generate_and_validate(spec, test_cases)\n# - spec : description en francais de la fonction a generer (ex: \"fonction qui inverse une chaine de caracteres\")\n# - test_cases : liste de tuples (input, expected_output) pour valider le code genere\n# - Etape 1 : Construire un prompt qui demande UNIQUEMENT le code Python (pas d'explications)\n# - Etape 2 : Appeler client.chat.completions.create() avec le prompt\n# - Etape 3 : Extraire le code entre ```python et ``` avec une regex ou un split\n# - Etape 4 : Executer le code avec exec() dans un namespace dedie, puis tester avec test_cases\n# - Retourner {\"code\": code_extrait, \"tests_passed\": nb_passed, \"tests_total\": len(test_cases)}\n\ndef generate_and_validate(spec, test_cases):\n    return None  # TODO etudiant : implementer\n\n# Indice : utiliser re.search(r'```python\\n(.*?)```', response, re.DOTALL) pour extraire le code\n# Test :\n# result = generate_and_validate(\n#     \"Fonction is_palindrome(s) qui retourne True si s est un palindrome\",\n#     [(\"radar\", True), (\"hello\", False), (\"\", True), (\"a\", True)]\n# )\n# print(result)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "e516932e",
    "metadata": {
     "papermill": {
@@ -1216,6 +1230,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a0a855c6",
+   "source": "### Exercice 2 : Visualisation personnalisee avec detection d'anomalies\n\nL'objectif est de creer une fonction qui genere un graphique en deux sous-figures : un histogramme avec la distribution des ventes et un boxplot par region, avec mise en evidence des outliers.\n\n**Indices :**\n- # Etape 1 : Creer la fonction plot_sales_analysis(df, value_col, group_col)\n- # Etape 2 : Utiliser plt.subplots(1, 2) pour les deux graphiques\n- # Etape 3 : Gauche : histogramme avec ax.hist() + lignes verticales pour moyenne et mediane\n- # Etape 4 : Droite : boxplot avec ax.boxplot() par groupe pour identifier les outliers",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "0f6795f0",
+   "source": "# Exercice 2 : Visualisation personnalisee avec detection d'anomalies\n# TODO etudiant : Implementer plot_sales_analysis(df, value_col, group_col)\n# - Sous-figure 1 : histogramme de value_col avec lignes verticales moyenne (rouge) et mediane (bleu)\n# - Sous-figure 2 : boxplot de value_col par group_col (pour detecter les outliers)\n# - Ajouter titre, legendes et labels\n# - Sauvegarder en PNG et afficher\n\ndef plot_sales_analysis(df, value_col, group_col):\n    pass  # TODO etudiant : implementer\n\n# Indice : utiliser plt.subplots(1, 2, figsize=(12, 5))\n# Test :\n# np.random.seed(42)\n# test_df = pd.DataFrame({\n#     'ventes': np.random.randint(100, 500, 100) + np.sin(np.arange(100)*0.1)*50,\n#     'region': np.random.choice(['Nord', 'Sud', 'Est', 'Ouest'], 100)\n# })\n# plot_sales_analysis(test_df, 'ventes', 'region')\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "48266a4f",
    "metadata": {
     "papermill": {
@@ -1569,6 +1597,20 @@
     "    except Exception as e:\n",
     "        print(f\"Erreur: {e}\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcc28b08",
+   "source": "### Exercice 3 : Analyse statistique personnalisee\n\nL'objectif est d'implementer une fonction `analyze_dataframe` qui prend un DataFrame et retourne un rapport statistique complet avec interpretation automatique.\n\n**Indices :**\n- # Etape 1 : Creer la fonction qui accepte un DataFrame et une liste de colonnes numeriques\n- # Etape 2 : Pour chaque colonne, calculer : moyenne, mediane, ecart-type, min, max, nb outliers (> 2 sigma)\n- # Etape 3 : Retourner un DataFrame recapitulatif avec une ligne par colonne analysee\n- # Etape 4 : Ajouter une colonne \"interpretation\" qui indique si la distribution est symetrique (moyenne proche de mediane)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "83bb0470",
+   "source": "# Exercice 3 : Analyse statistique personnalisee\n# TODO etudiant : Implementer analyze_dataframe(df, columns)\n# - Pour chaque colonne numerique : moyenne, mediane, ecart-type, min, max\n# - Compter les outliers (valeurs > moyenne + 2*ecart_type ou < moyenne - 2*ecart_type)\n# - Ajouter une interpretation : \"symetrique\" si |moyenne - mediane| < 0.1 * ecart_type, sinon \"asymetrique\"\n# - Retourner un DataFrame avec une ligne par colonne analysee\n\ndef analyze_dataframe(df, columns=None):\n    return None  # TODO etudiant : implementer\n\n# Test avec le dataset de ventes :\n# np.random.seed(42)\n# test_df = pd.DataFrame({\n#     'ventes': np.random.randint(100, 500, 100),\n#     'temperature': np.random.normal(20, 5, 100)\n# })\n# rapport = analyze_dataframe(test_df, ['ventes', 'temperature'])\n# print(rapport)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -769,6 +769,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4d155bb2",
+   "source": "### Exercice 1 : Chain-of-thought manuel vs automatique\n\nL'objectif est de comparer une resolution \"directe\" (sans reflexion) avec une resolution \"pas a pas\" (chain-of-thought) sur un probleme de calcul multi-etapes, en utilisant le mode chat standard.\n\n**Indices :**\n- # Etape 1 : Definir un probleme de calcul avec 3-4 etapes (ex: prix avec taxe, remise et frais de port)\n- # Etape 2 : Appeler le modele avec un prompt direct (\"Donne uniquement la reponse finale\")\n- # Etape 3 : Appeler le modele avec un prompt chain-of-thought (\"Resous etape par etape, montre chaque calcul\")\n- # Etape 4 : Comparer les deux reponses avec la reponse correcte et afficher les resultats",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "37f1fa82",
+   "source": "# Exercice 1 : Chain-of-thought manuel vs automatique\n# TODO etudiant : Comparer prompt direct vs prompt chain-of-thought sur un calcul multi-etapes\n# - Definir un probleme : \"Un article coute 80EUR. TVA 20%, puis remise 15% sur le prix TTC, puis frais de port 5EUR. Prix final?\"\n# - Prompt direct : \"Calcule le prix final. Donne uniquement le nombre.\"\n# - Prompt CoT : \"Resous etape par etape en montrant chaque calcul intermediaire.\"\n# - Comparer les deux reponses avec la reponse correcte (80*1.2*0.85+5 = 86.60 EUR)\n\ndirect_prompt = None  # TODO etudiant : definir le prompt direct\ncot_prompt = None     # TODO etudiant : definir le prompt chain-of-thought\n\n# Indice : reponse correcte = 80 * 1.20 * 0.85 + 5 = 86.60 EUR\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "d176d60e",
    "metadata": {
     "papermill": {
@@ -1244,6 +1258,20 @@
     "print(\"  2. Des tests complets couvrant les edge cases\")\n",
     "print(\"  3. Des commentaires expliquant la logique\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1af7ca21",
+   "source": "### Exercice 2 : Comparaison multi-niveau sur un probleme complexe\n\nL'objectif est de comparer les 3 niveaux de `reasoning_effort` sur un probleme de logique multi-etapes, et de mesurer le compromis temps/qualite.\n\n**Indices :**\n- # Etape 1 : Definir un probleme de logique a plusieurs etapes (ex: enigme des 3 portes, probleme de transvasement)\n- # Etape 2 : Boucler sur les 3 niveaux (\"low\", \"medium\", \"high\")\n- # Etape 3 : Pour chaque niveau, mesurer le temps de reponse et stocker le resultat\n- # Etape 4 : Afficher un tableau comparatif avec les temps, les reponses et la reponse correcte",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "8f3485d1",
+   "source": "# Exercice 2 : Comparaison multi-niveau sur un probleme complexe\n# TODO etudiant : Implementer un benchmark qui compare reasoning_effort low/medium/high\n# - Definir un probleme de logique (ex: \"Tu as un bidon de 5L et un de 3L. Comment obtenir exactement 4L?\")\n# - Boucler sur [\"low\", \"medium\", \"high\"]\n# - Pour chaque niveau : mesurer le temps, appeler le modele, extraire la reponse\n# - Stocker les resultats dans une liste de dicts {\"effort\", \"time\", \"answer\"}\n# - Afficher un tableau comparatif avec la reponse correcte\n\nresults = None  # TODO etudiant : implementer le benchmark\n\n# Indice : utiliser time.time() pour mesurer, et extra_body={\"reasoning_effort\": effort}\n# pour activer le mode reasoning\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1841,6 +1869,20 @@
     "print(\"  - Complexité O(2^n) due aux appels récursifs redondants\")\n",
     "print(\"  - Solution: mémoïsation ou approche itérative (O(n))\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fae1bc5c",
+   "source": "### Exercice 3 : Verification de reponse par raisonnement\n\nL'objectif est de creer une fonction qui demande au modele de **verifier** si une reponse donnee a un probleme mathematique est correcte, en utilisant le mode reasoning pour valider pas a pas.\n\n**Indices :**\n- # Etape 1 : Construire un prompt qui presente le probleme ET la reponse a verifier\n- # Etape 2 : Utiliser reasoning_effort='medium' pour permettre une verification approfondie\n- # Etape 3 : Demander au modele de repondre uniquement par \"CORRECT\" ou \"INCORRECT\" suivi de la justification\n- # Etape 4 : Parser la reponse pour extraire le verdict et l'explication",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7ad3a8ab",
+   "source": "# Exercice 3 : Verification de reponse par raisonnement\n# TODO etudiant : Implementer une fonction verify_answer(problem, claimed_answer)\n# - Construit un prompt : \"Verifie si cette reponse est correcte. Probleme: {problem}. Reponse proposee: {claimed_answer}\"\n# - Utilise le modele reasoning avec reasoning_effort='medium'\n# - Retourne un dict {\"verdict\": \"CORRECT\"|\"INCORRECT\", \"explanation\": \"...\"}\n\ndef verify_answer(problem, claimed_answer):\n    return None  # TODO etudiant : implementer\n\n# Test :\n# result = verify_answer(\"Combien font 17 * 23?\", \"391\")\n# print(f\"Verdict: {result['verdict']}, Explication: {result['explanation']}\")\n# result2 = verify_answer(\"Combien font 17 * 23?\", \"400\")\n# print(f\"Verdict: {result2['verdict']}, Explication: {result2['explanation']}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
@@ -1354,6 +1354,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "09b3f80f",
+   "source": "### Exercice 1 : Retry decorateur avec logging\n\nL'objectif est de creer un decorateur `@retry_with_log` qui wrappe n'importe quel appel API avec retry automatique ET logging structure de chaque tentative.\n\n**Indices :**\n- # Etape 1 : Definir le decorateur avec parametres (max_retries, backoff_base)\n- # Etape 2 : Dans le wrapper, boucler sur les tentatives avec try/except\n- # Etape 3 : Logger chaque tentative (numero, duree, succes/echec)\n- # Etape 4 : Utiliser time.sleep avec un delai exponentiel entre les tentatives",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "f948f8db",
+   "source": "# Exercice 1 : Retry decorateur avec logging\n# TODO etudiant : Implementer un decorateur @retry_with_log qui :\n# - Accepte max_retries (defaut 3) et backoff_base (defaut 2) en parametres\n# - Intercepte les exceptions et retente automatiquement\n# - Log chaque tentative avec : timestamp, numero de tentative, type d'exception, delai avant retry\n# - Retourne le resultat si succes, leve la derniere exception si echec total\n\ndef retry_with_log(max_retries=3, backoff_base=2):\n    pass  # TODO etudiant : implementer le decorateur\n\n# Test :\n# @retry_with_log(max_retries=3, backoff_base=2)\n# def call_api(prompt):\n#     return safe_completion(prompt)\n#\n# resultat = call_api(\"Test retry decorateur\")\n# print(resultat)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "14e08230",
    "metadata": {
     "papermill": {
@@ -1544,6 +1558,20 @@
     "print(f\"Tokens: {result2['input_tokens']} in / {result2['output_tokens']} out\")\n",
     "print(f\"Coût estimé: ${result2['estimated_cost']:.6f}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ee56bf6",
+   "source": "### Exercice 2 : Cache simple pour prompts repetes\n\nL'objectif est d'implementer un cache memoire qui stocke les resultats des appels API pour eviter de re-appeler le modele sur des prompts identiques.\n\n**Indices :**\n- # Etape 1 : Creer une classe SimpleCache avec un dictionnaire interne\n- # Etape 2 : Implementer get(key) qui retourne la valeur ou None si absente\n- # Etape 3 : Implementer set(key, value, ttl_seconds) avec un timestamp d'expiration\n- # Etape 4 : Implementer cached_completion(prompt) qui utilise le cache avant d'appeler l'API",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "0c26d9d8",
+   "source": "# Exercice 2 : Cache simple pour prompts repetes\n# TODO etudiant : Implementer un cache memoire pour optimiser les appels API\n# - Creer une classe SimpleCache avec un dict interne {\"key\": (value, expiry_timestamp)}\n# - get(key) : retourne la valeur si presente et non expiree, sinon None\n# - set(key, value, ttl_seconds=300) : stocke la valeur avec un TTL (defaut 5 min)\n# - cached_completion(prompt) : check le cache, si miss -> appeler safe_completion -> stocker -> retourner\n\nclass SimpleCache:\n    pass  # TODO etudiant : implementer le cache\n\n# Indice : utiliser hash(prompt) comme cle du cache\n# Test :\n# cache = SimpleCache()\n# r1 = cached_completion(\"Quelle est la capitale de la France?\")\n# r2 = cached_completion(\"Quelle est la capitale de la France?\")  # devrait utiliser le cache\n# print(f\"Cache hit? {r1 == r2}\")\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1755,6 +1783,20 @@
     "except Exception as e:\n",
     "    print(f\"Erreur capturée: {type(e).__name__}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "222ce9a3",
+   "source": "### Exercice 3 : Suivi des couts avec alerte budget\n\nL'objectif est de creer une classe `CostTracker` qui accumule les couts de chaque appel API et declenche une alerte quand un seuil est atteint.\n\n**Indices :**\n- # Etape 1 : Creer la classe avec un attribut total_cost et un budget_max\n- # Etape 2 : Implementer track(input_tokens, output_tokens, model) qui calcule le cout et l'ajoute au total\n- # Etape 3 : Verifier si total_cost depasse budget_max et afficher un warning si oui\n- # Etape 4 : Implementer summary() qui retourne un dict avec total_cost, nb_requetes, cout_moyen",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "e193b7b0",
+   "source": "# Exercice 3 : Suivi des couts avec alerte budget\n# TODO etudiant : Implementer une classe CostTracker qui :\n# - Stocke le cout total accumule et le nombre de requetes\n# - Accepte un budget_max en parametre (defaut $1.00)\n# - Implemente track(input_tokens, output_tokens, model) qui :\n#   * Calcule le cout avec les tarifs gpt-5-mini ($0.15/1M input, $0.60/1M output)\n#   * Ajoute au total et affiche un WARNING si budget depasse\n# - Implemente summary() qui retourne {\"total_cost\", \"nb_requetes\", \"avg_cost_per_request\"}\n\nclass CostTracker:\n    pass  # TODO etudiant : implementer la classe\n\n# Test :\n# tracker = CostTracker(budget_max=0.01)\n# tracker.track(input_tokens=100, output_tokens=50, model=\"gpt-5-mini\")\n# tracker.track(input_tokens=200, output_tokens=100, model=\"gpt-5-mini\")\n# print(tracker.summary())\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Add pedagogical exercise stubs to bring all 9 GenAI Texte notebooks to >=3 exercises per the #2161 convention.

## Changes

All stubs use C.1-compliant patterns (`pass`, `print("Exercice a completer")`, `return None`). No `raise NotImplementedError`, `assert False`, or `1/0`.

| Notebook | Before | Added | After | Topics |
|----------|--------|-------|-------|--------|
| 1_OpenAI_Intro | 0 | +3 | 3 | System prompts, tokenization, hallucination detection |
| 2_PromptEngineering | 1 | +2 | 3 | Few-shot translation, CoT logic problem |
| 3_Structured_Outputs | 0 | +3 | 3 | Film schema, event extractor, product analyzer |
| 4_Function_Calling | 2 | +1 | 3 | Log analyzer with tool_choice modes |
| 5_RAG_Modern | 0 | +3 | 3 | Hybrid chunking, confidence search, retrieval eval |
| 6_PDF_Web_Search | 0 | +3 | 3 | PIL vision, multi-source web search, web summary |
| 7_Code_Interpreter | 0 | +3 | 3 | Regex validation, data analysis histogram, stats report |
| 8_Reasoning_Models | 0 | +3 | 3 | CoT comparison, effort benchmark, math verification |
| 9_Production_Patterns | 0 | +3 | 3 | Retry decorator, TTL cache, CostTracker budget alerts |

**Total: 24 exercise stubs added across 9 notebooks. All now have >=3 exercises.**

## Validation

- C.1 compliance: 0 violations across all 9 notebooks (no `raise NotImplementedError`)
- Markdown-only insertions with stub code cells (null exec_count)
- No re-execution needed per C.3 (source = markdown scaffolding + stubs, no existing code modified)
- Diff: 350 insertions, 0 deletions (pure enrichment)

See #2161