### PR TITLE
fix(vllm): update model name qwen3.5 → qwen3.6-35b-a3b

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/.env.example
@@ -146,7 +146,7 @@ OPENAI_ENDPOINT_NAME=OpenAI
 # OPENAI_ENDPOINT_NAME_3=local-medium-Qwen3.5
 # OPENAI_API_KEY_3=your_vllm_api_key_here
 # OPENAI_BASE_URL_3=https://api.medium.text-generation-webui.myia.io/v1
-# OPENAI_CHAT_MODEL_ID_3=qwen3.5-35b-a3b
+# OPENAI_CHAT_MODEL_ID_3=qwen3.6-35b-a3b
 
 # ============================================================================
 # SECTION 2b : Hugging Face
@@ -294,7 +294,7 @@ TGWUI_MEDIUM_API_URL=https://api.medium.text-generation-webui.myia.io/v1
 # dans la section 2 ci-dessus, ou directement :
 # OPENAI_BASE_URL=https://api.medium.text-generation-webui.myia.io/v1
 # OPENAI_API_KEY=your_vllm_api_key_here
-# OPENAI_CHAT_MODEL_ID=qwen3.5-35b-a3b
+# OPENAI_CHAT_MODEL_ID=qwen3.6-35b-a3b
 
 # ============================================================================
 # SECTION 10b : Docker Local (optionnel)

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/.env.example
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/.env.example
@@ -21,7 +21,7 @@ OPENROUTER_MODEL=openai/gpt-4.1
 # vLLM via Reverse Proxy (Modele local heberge)
 # ============================================================
 VLLM_BASE_URL=https://your-vllm-endpoint.com/v1
-VLLM_MODEL=qwen3.5-35b-a3b
+VLLM_MODEL=qwen3.6-35b-a3b
 VLLM_API_KEY=your-key-if-needed
 
 # ============================================================

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/config/providers.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/config/providers.py
@@ -47,7 +47,7 @@ class ProviderConfig(BaseModel):
             "base_url": "https://openrouter.ai/api/v1"
         },
         ProviderType.VLLM: {
-            "model": "qwen3.5-35b-a3b",
+            "model": "qwen3.6-35b-a3b",
             "base_url": "http://localhost:8000/v1"
         },
         ProviderType.LMSTUDIO: {
@@ -84,7 +84,7 @@ class Settings(BaseSettings):
 
     # vLLM (reverse proxy)
     vllm_base_url: Optional[str] = None
-    vllm_model: str = "qwen3.5-35b-a3b"
+    vllm_model: str = "qwen3.6-35b-a3b"
     vllm_api_key: Optional[str] = None
 
     # LM Studio

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/.env.example
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/.env.example
@@ -45,7 +45,7 @@ QWEN_LOCAL_BASE_URL="http://localhost:5002/v1"
 # QWEN_LOCAL_API_KEY=...
 
 # Modele expose par vLLM
-QWEN_LOCAL_CHAT_MODEL_ID="qwen3.5-35b-a3b"
+QWEN_LOCAL_CHAT_MODEL_ID="qwen3.6-35b-a3b"
 
 # Mode thinking (laisser le modele raisonner verbalement avant de produire la sortie finale)
 QWEN_LOCAL_THINKING_MODE="true"

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/.env.example
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/.env.example
@@ -18,4 +18,4 @@ OPENAI_CHAT_MODEL_ID=google/gemini-3.5-flash
 # --- Option C : modele auto-heberge (vLLM / Ollama, API OpenAI-compatible) ---
 # OPENAI_API_KEY=<token-local>
 # OPENAI_BASE_URL=http://localhost:5002/v1
-# OPENAI_CHAT_MODEL_ID=qwen3.5-35b-a3b
+# OPENAI_CHAT_MODEL_ID=qwen3.6-35b-a3b


### PR DESCRIPTION
Fix 43 failing vLLM requests (404) — model served is now `qwen3.6-35b-a3b` since 2026-04-17.

Updated: providers.py (2 occurrences) + 4 .env.example files.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>