### PR TITLE
docs(genai): harmonize 00-GenAI-Environment + FineTuning sub-READMEs per gabarit #2651

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/README.md
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/README.md
@@ -7,42 +7,39 @@ breakdown: 00-GenAI-Environment=6
 maturity: BETA=4, PRODUCTION=2
 -->
 
-[← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Docker Services](00-2-Docker-Services-Management.ipynb)
+[← GenAI](../README.md) | [↑ ..](../README.md) | [→ Image](../Image/README.md)
 
-## Introduction : Pourquoi cet setup est crucial
+Ce module configure l'environnement technique avant toute exploration GenAI. Les notebooks couvrent le setup Python, la gestion des conteneurs Docker (ComfyUI, Whisper, MusicGen), la configuration des endpoints API, et un test complet de validation.
 
-Avant de plonger dans l'univers des modèles de génération IA, prenez un moment pour comprendre pourquoi une configuration rigoureuse évite 80% des problèmes techniques. Les notebooks GenAI font appel à des services externes, des conteneurs Docker et des modèles complexes – une seule variable d'environnement manquante peut bloquer toute votre exploration. Ce module vous guide pas à pas pour créer une base solide, vous permettant de vous concentrer sur l'essentiel : apprendre et expérimenter avec l'IA.
+## Objectifs d'apprentissage
 
-## Vue d'Ensemble
-[GREEN] Setup et Configuration
+A l'issue de ce module, vous serez capable de :
 
-**Validation: 100% (6/6 notebooks)**
+1. **Configurer** un environnement Python complet pour le developpement GenAI (dependances, variables d'environnement, services Docker)
+2. **Gerer** des services Docker conteneurises (ComfyUI, modeles de langue) avec demarrage, arret et monitoring
+3. **Parametrer** les endpoints API pour les services IA (OpenAI, Anthropic, OpenRouter, services locaux)
+4. **Valider** que chaque composant fonctionne correctement via les scripts de diagnostic
+5. **Deployer** localement l'infrastructure GenAI complete sur un poste de travail
 
-## Notebooks du Module
+## Notebooks
 
-| # | Notebook | Description | Validation |
-|---|----------|-------------|------------|
-| 1 | [00-1-Environment-Setup](00-1-Environment-Setup.ipynb) | Configuration environnement complet | OK |
-| 2 | [00-2-Docker-Services-Management](00-2-Docker-Services-Management.ipynb) | Gestion services conteneurises | OK |
-| 3 | [00-3-API-Endpoints-Configuration](00-3-API-Endpoints-Configuration.ipynb) | Configuration endpoints API | OK |
-| 4 | [00-4-Environment-Validation](00-4-Environment-Validation.ipynb) | Tests et validation setup | OK |
-| 5 | [00-5-ComfyUI-Local-Test](00-5-ComfyUI-Local-Test.ipynb) | Test local des services ComfyUI | OK |
-| 6 | [00-6-Local-Docker-Deployment](00-6-Local-Docker-Deployment.ipynb) | Deploiement Docker local complet | OK |
+| # | Notebook | Contenu | Duree |
+|---|----------|---------|-------|
+| 1 | [00-1-Environment-Setup](00-1-Environment-Setup.ipynb) | Configuration environnement complet | 30 min |
+| 2 | [00-2-Docker-Services-Management](00-2-Docker-Services-Management.ipynb) | Gestion services conteneurises | 40 min |
+| 3 | [00-3-API-Endpoints-Configuration](00-3-API-Endpoints-Configuration.ipynb) | Configuration endpoints API | 25 min |
+| 4 | [00-4-Environment-Validation](00-4-Environment-Validation.ipynb) | Tests et validation setup | 30 min |
+| 5 | [00-5-ComfyUI-Local-Test](00-5-ComfyUI-Local-Test.ipynb) | Test local des services ComfyUI | 25 min |
+| 6 | [00-6-Local-Docker-Deployment](00-6-Local-Docker-Deployment.ipynb) | Deploiement Docker local complet | 45 min |
 
-## Prérequis
-- Configuration .env avec clés API
-- Python 3.11+ avec dépendances
-- Variables d'environnement OpenRouter
+## Prerequis & environnement
 
-## Ce que vous saurez faire
-
-À l'issue de ce module, vous serez capable de :
-- Configurer un environnement Python complet pour le développement GenAI
-- Gérer des services Docker conteneurisés (ComfyUI, modèles de langue)
-- Paramétrer les endpoints API pour les services IA
-- Valifier que chaque composant fonctionne correctement
-- Déployer localement l'ensemble de l'infrastructure GenAI
-- Résoudre les problèmes courants de configuration
+| Besoin | Detail |
+|--------|--------|
+| Python | 3.10+ avec dependances (`pip install -r requirements.txt`) |
+| Docker Desktop | v29.5+ recommande pour les notebooks GPU |
+| Cles API | `.env` dans `GenAI/` : `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `COMFYUI_BEARER_TOKEN` |
+| GPU | Optionnel pour ce module, requis pour les sous-domaines Image/Audio/Video |
 
 ## FAQ
 

--- a/MyIA.AI.Notebooks/GenAI/FineTuning/README.md
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/README.md
@@ -1,7 +1,5 @@
 # FineTuning - Adapter les LLMs a vos taches
 
-[← Documentation GenAI](../README.md)
-
 <!-- CATALOG-STATUS
 series: GenAI-FineTuning
 pedagogical_count: 5
@@ -9,9 +7,18 @@ breakdown: FineTuning=5
 maturity: PRODUCTION=4, BETA=1
 -->
 
-Serie progressive sur le fine-tuning des modeles de langue : des bases LoRA a la fusion de modeles, en passant par la quantization, l'instruction-following et l'alignement par preferences humaines.
+[← GenAI](../README.md) | [↑ ..](../README.md) | [→ PostTraining](../PostTraining/README.md)
 
-**5 notebooks** | **~2-3h** | **GPU recommande** (T4/V100 suffisent pour la plupart des exercices)
+Serie progressive sur le fine-tuning des modeles de langue : des bases LoRA a la fusion de modeles, en passant par la quantization, l'instruction-following et l'alignement par preferences humaines. GPU recommande (T4/V100 suffisent pour la plupart des exercices).
+
+## Objectifs d'apprentissage
+
+A l'issue de cette serie, vous serez capable de :
+
+1. **Appliquer** LoRA et QLoRA pour fine-tuner des modeles 7B sur un GPU consumer
+2. **Transformer** un base model en instruct model via SFT (format ChatML)
+3. **Aligner** les modeles sur les preferences humaines avec DPO
+4. **Fusionner** plusieurs adaptateurs fine-tunes en un seul modele unifie (TIES, DARE, MoE)
 
 ## Structure
 
@@ -94,13 +101,6 @@ Combine plusieurs adaptateurs LoRA fine-tunes sur des taches differentes en un s
 ### Avance (3-4h)
 1. FT-01 a FT-05 dans l'ordre + experimenter mergekit recipes
 
-## Ressources externes
-
-- **Hugging Face PEFT** : https://huggingface.co/docs/peft
-- **QLoRA paper** : https://arxiv.org/abs/2305.14314
-- **DPO paper** : https://arxiv.org/abs/2305.18290
-- **MergeKit** : https://github.com/arcee-ai/mergekit
-
 ## FAQ
 
 ### OOM pendant FT-04 (DPO) ou FT-05 (Model Merging)
@@ -174,8 +174,9 @@ Si le modele merge (FT-05) perd en qualite par rapport aux adaptateurs individue
 - DARE (Drop And Rescale) elimine les poids redondants — essayer si TIES ne converge pas.
 - Le routage MoE (Mixture of Experts) est une alternative au merge statique : chaque token est route vers l'adaptateur le plus competent. FT-05 couvre cette approche.
 
-## Liens
+## References
 
-- [← GenAI README](../README.md) - Vue d'ensemble GenAI
-- [SemanticKernel](../SemanticKernel/README.md) - Integration .NET pour LLMs fine-tunes
-- [Texte](../Texte/README.md) - Notebooks LLMs generaux
+- **Hugging Face PEFT** : https://huggingface.co/docs/peft
+- **QLoRA paper** : https://arxiv.org/abs/2305.14314
+- **DPO paper** : https://arxiv.org/abs/2305.18290
+- **MergeKit** : https://github.com/arcee-ai/mergekit


### PR DESCRIPTION
## Summary

Harmonize two GenAI sub-READMEs against the gabarit de reference (`docs/reference/readme-series-gabarit.md`) from #2651 Partie 2.

## Changes

### 00-GenAI-Environment

| Anti-pattern | Fix |
|---|---|
| `[GREEN] Setup et Configuration` marker | Removed (internal marker) |
| `**Validation: 100% (6/6 notebooks)**` | Removed (static count that rots) |
| Table column `Validation` (OK/OK) | Replaced with `Duree` per gabarit section 5 |
| Emphatic intro ("evite 80% des problemes") | Factual one-liner + link to child detail |
| Unnumbered learning objectives | 5 numbered action-verb objectives per gabarit section 4 |
| Prerequis as bullet list | Structured table per gabarit section 7 |
| Navigation `→ Docker Services` (notebook link) | `→ Image` (series link, consistent with other sub-READMEs) |

### FineTuning

| Anti-pattern | Fix |
|---|---|
| Incomplete navigation (no `→` link) | Added `→ PostTraining` |
| Bandeau `**5 notebooks** \| **~2-3h**` | Removed, info in pitch text |
| No learning objectives | Added 4 numbered action-verb objectives |
| `Ressources externes` + `Liens` duplicated | Merged into single `References` section |

## Verification

- Markdown-only (no notebook modified, no re-execution)
- CATALOG-STATUS untouched in both files
- 2 files, 41 insertions, 43 deletions

See #2651
