### PR TITLE
docs(genai): harmonize PostTraining, Vibe-Coding, Playwright-OWUI sub-READMEs (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/README.md
@@ -1,20 +1,10 @@
 # Playwright-OWUI - Tests E2E pedagogiques pour Open WebUI
 
-[← Retour GenAI](../README.md)
+[← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Vibe-Coding](../Vibe-Coding/README.md)
 
 Serie pedagogique complete pour apprendre **Playwright** (framework de tests E2E) en testant une application reelle : **Open WebUI**, une plateforme de chat IA generative.
 
 > **Format particulier** : Contrairement aux autres sous-domaines GenAI qui utilisent des Jupyter Notebooks (.ipynb), cette serie utilise des **fichiers TypeScript (.spec.ts)** executes par Playwright. Chaque module contient un `README.md` avec la theorie et les explications, et un fichier `.spec.ts` avec les tests commentes qui servent d'exercices pratiques. Les tests sont auto-documentes : chaque test contient des commentaires pedagogiques expliquant les concepts, et des exercices supplementaires a completer par l'etudiant.
-
-## Vue d'ensemble
-
-| Statistique | Valeur |
-|-------------|--------|
-| Modules | 5 |
-| Tests | 30+ |
-| Duree totale | ~13-16h |
-| Technologies | Playwright, TypeScript, Open WebUI |
-| Niveau | Debutant a Expert |
 
 ## Pourquoi cette serie ?
 
@@ -258,23 +248,6 @@ test('...', async ({ request }) => {
 **Probleme** : Certaines APIs (knowledge bases, functions) retournent du HTML au lieu de JSON quand le reverse proxy intercepte la requete ou la redirige.
 
 **Solution** : Verifier le Content-Type avant de parser, et utiliser `test.skip()` si l'API n'est pas disponible en JSON.
-
-## Resultats de validation
-
-Derniere execution : Mars 2026 (suite complete, OWUI v0.8.8)
-
-| Module | Pass | Skip | Fail | Temps |
-|--------|------|------|------|-------|
-| 01 - Decouverte | 5 | 0 | 0 | 11s |
-| 02 - Navigation | 9 | 0 | 0 | 14s |
-| 03 - Chat & Streaming | 7 | 1 | 0 | 42s |
-| 04 - RAG, MCP, Channels | 3 | 5 | 0 | 23s |
-| 05 - Multi-tenant & API | 6 | 3 | 0 | 8s |
-| **Total** | **30** | **9** | **0** | **~2 min** |
-
-Les 9 skips sont attendus : modele local indisponible (1), KBs/MCP non configures (5), APIs HTML (3).
-
-> **Compatibilite OWUI v0.9.1** (avril 2026) : la suite fonctionne sans modification sur OWUI v0.9.1. Les selecteurs CSS, l'editeur TipTap, l'auth et le rate-limit n'ont pas change. Les nouvelles surfaces v0.9.1 (Calendar, Automations, Desktop app) ne sont pas encore couvertes par les modules 01-05 mais peuvent etre utilisees comme exercices bonus. Voir `WHATS-NEW-v0.9.1.md`.
 
 ## Liens utiles
 

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
@@ -1,6 +1,6 @@
 # PostTraining - Techniques de post-training des Language Models (SOTA 2024-2025)
 
-[← Documentation GenAI](../README.md) · [Serie FineTuning (LoRA/QLoRA/SFT/DPO pratique)](../FineTuning/README.md)
+[← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ SemanticKernel](../SemanticKernel/README.md)
 
 <!-- CATALOG-STATUS
 series: GenAI-PostTraining
@@ -22,16 +22,6 @@ En janvier 2025, Deepseek-R1 a publiquement valide cette progression en montrant
 L'angle pedagogique est d'expliquer la **math du loss** avant le code pour chaque technique. Trop de tutoriels existants montrent une cellule `trainer.train()` qui converge sans donner l'intuition de pourquoi DPO marche, pourquoi GRPO economise la memoire, ou pourquoi RLVR contourne le besoin d'un Reward Model. Cette serie inverse l'ordre : d'abord la formule, puis l'intuition, puis l'implementation TRL/HuggingFace, puis les outputs reels d'entrainement.
 
 **A qui s'adresse cette serie** : ingenieurs ML curieux de comprendre la chaine post-training au-dela des annonces de presse, etudiants en NLP voulant reproduire les techniques Deepseek-R1 sans cluster H100, et formateurs ayant besoin de notebooks pedagogiques sur des modeles que leurs etudiants peuvent reellement faire tourner. Prerequis : Python intermediate, PyTorch elementaire, familiarite avec `transformers`, intuition de la backprop et de la cross-entropy. Le notebook PT-01 etablit le contexte theorique sans code execute ; PT-02 reprend les bases SFT ; les notebooks PT-03 a PT-06 ajoutent une technique par etape.
-
-## Vue d'ensemble
-
-| Statistique | Valeur |
-|-------------|--------|
-| Notebooks | **6 livres (PT-01 a PT-06) — serie COMPLETE** |
-| Kernel | Python 3 |
-| Duree estimee | ~8-12h total |
-| GPU cible | RTX 3070 8 Go (LOAD_MODEL_AND_TRAIN=False pour demo CPU) |
-| Statut | **PRODUCTION** (Epic #1742 clos) |
 
 ## Notebooks
 
@@ -155,16 +145,14 @@ Comparer SFT vs DPO vs GRPO vs RLVR de facon honnete requiert une discipline exp
 
 PT-06 documente le pipeline d'evaluation complet et produit un tableau comparatif final reproductible.
 
-## Conformite regles CoursIA
+## Qualite pedagogique
 
-| Regle | Application |
-|-------|-------------|
-| **C.1** (no NotImplementedError) | Stubs etudiants : `pass`, `print("Exercice a completer")`, `return None` |
-| **C.2** (outputs committed) | Tous les notebooks executes avec outputs reels avant commit |
-| **C.3** (scope strict re-exec) | Ne commit que les notebooks modifies, pas de re-exec massives |
-| **E** (no emojis) | Naming professionnel |
-| **F** (env reparer) | `coursia-ml-training` doit avoir TRL + bitsandbytes + datasets installes |
-| **Multi-seed ≥ 4** | Pour toute claim "GRPO outperforms DPO" → 4 seeds + ecart ≥ 2σ |
+| Aspect | Application |
+|--------|-------------|
+| Exercices | Stubs sans erreur (`pass`, `print(...)`, `return None`) : le notebook s'execute de bout en bout meme exercices non completes |
+| Outputs | Tous les notebooks committes avec outputs reels d'execution |
+| Environnement | `coursia-ml-training` requis (TRL + bitsandbytes + datasets) |
+| Methodologie | Toute claim comparative ("GRPO > DPO") verifiee sur >= 4 seeds avec ecart >= 2 sigma |
 
 ## Ponts avec les autres series
 
@@ -226,9 +214,9 @@ Pour les apprenants disposant de plus de VRAM (RTX 4090 24Go, A100 40Go), la ser
 
 ## Statut
 
-PRODUCTION — 6/6 notebooks livres (Epic #1742 COMPLETE). Tous executes avec outputs reels, C.1/C.2 conformes.
+Serie complete : 6 notebooks, tous executes avec outputs reels.
 
-Suivi : [Issue #1742](https://github.com/jsboige/CoursIA/issues/1742) (CLOSED).
+Suivi : [Issue #1742](https://github.com/jsboige/CoursIA/issues/1742).
 
 ## FAQ
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
@@ -9,7 +9,7 @@ maturity: PRODUCTION=4, BETA=1
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Claude Discovery](Claude-Code/01-decouverte/README.md)
 
-Bienvenue dans l'ère du **vibe-coding** - la compétence la plus demandée de 2026 ! Imaginez : vous décrivez ce que vous voulez construire en langage naturel, et l'IA écrit le code pour vous. Plus besoin de semaines de développement, mais des minutes pour transformer une idée en fonctionnalité réelle. Le vibe-coding révolutionne la programmation en rendant la barrière technique quasi invisible : votre seule limite est votre imagination.
+Cette serie couvre les ateliers de **vibe-coding** : decrire ce que vous voulez construire en langage naturel, et l'IA ecrit le code. Deux assistants majeurs sont couverts (Claude Code et Roo Code), avec des exercices progressifs allant de la decouverte a l'automatisation avancee, plus un module d'agents autonomes (Claw Systems).
 
 ## Structure du repertoire
 
@@ -121,22 +121,6 @@ Le repertoire `docs/` contient :
 - `INSTALLATION-ROO.md` - Guide d'installation
 - `ROO-GUIDED-PATH.md` - Parcours d'apprentissage guide
 
-## Comparaison Claude Code vs Roo Code
-
-| Aspect | Claude Code | Roo Code |
-|--------|-------------|----------|
-| **Interface** | CLI + VS Code | VS Code uniquement |
-| **Agents parallèles** | Jusqu'à 10 | Séquentiel |
-| **MCP** | Support complet | Partiel |
-| **Skills/Commands** | Écosystème standardisé | Configuration manuelle |
-| **Courbe d'apprentissage** | Moyenne | Facile |
-| **Idéal pour** | Projets complexes | Débutants |
-
-**Recommandation :**
-- **Debutants complets** : Commencer avec Roo Code
-- **Developpeurs** : Claude Code offre plus de puissance
-- **Les deux peuvent coexister** dans le meme environnement VS Code
-
 ## Prerequis techniques
 
 - **VS Code** 1.60.0+
@@ -144,17 +128,14 @@ Le repertoire `docs/` contient :
 - Un compte **OpenRouter** avec une cle API
 - Connaissances de base en programmation
 
-## Origine
+## Objectifs d'apprentissage
 
-## Ce que vous saurez faire
+A l'issue de cette serie, vous serez capable de :
 
-À travers ces ateliers pratiques, vous acquerrez la capacité de :
-
-- **Décrire vos projets** en langage naturel et voir l'IA les transformer en code fonctionnel
-- **Écrire, tester, debugger et déployer** des applications complètes grâce à l'assistance IA
-- **Orchestrer des workflows complexes** en multipliant les agents intelligents
-- **Générer automatiquement** la documentation, les tests et les configurations
-- **Automatiser des tâches complexes** allant du simple script au déploiement en production
+1. **Decrire** un projet en langage naturel et obtenir du code fonctionnel via l'IA
+2. **Orchestrer** des workflows multi-agents (recherche, planification, execution)
+3. **Automatiser** les taches courantes du developpeur (tests, documentation, deploiement)
+4. **Configurer** des agents autonomes conteneurises (Claw Systems)
 
 ## FAQ
 


### PR DESCRIPTION
## Summary

Round 3 of GenAI sub-README harmonization per gabarit #2651 Partie 2.

### PostTraining/README.md
- **Navigation**: `·` separator + partial links → full 3-part bar (`← | ↑ | →`)
- **Bandeau removed**: `Vue d'ensemble` stats table (6 notebooks, ~8-12h, PRODUCTION) — counts live in CATALOG-STATUS
- **Internal vocab removed**: "Conformité règles CoursIA" table with C.1/C.2/C.3/E/F/Multi-seed → reader-facing "Qualité pédagogique" table describing effects (stubs sans erreur, outputs réels, méthode comparative)
- **Status section**: removed operational markers (Epic #1742 COMPLETE, C.1/C.2 conformes)

### Vibe-Coding/README.md
- **Pitch**: marketing tone ("la compétence la plus demandée de 2026 !") → factual description
- **Objectifs d'apprentissage**: replaced bullet list "Ce que vous saurez faire" with 4 numbered action-verb objectives
- **Empty section removed**: `## Origine` with no content
- **Deduplication**: removed Claude Code vs Roo Code comparison table from body section (identical table preserved in FAQ Q2)

### Playwright-OWUI/README.md
- **Navigation**: single link → full 3-part bar (`← | ↑ | →`)
- **Bandeau removed**: `Vue d'ensemble` stats table (5 modules, 30+ tests, ~13-16h) — counts live in CATALOG-STATUS
- **Stale table removed**: `Résultats de validation` with exact pass/skip/fail counts (March 2026, OWUI v0.8.8) — these drift with every re-run

**Note**: Playwright-OWUI is missing a CATALOG-STATUS marker. Per gabarit rules, this is bot-owned and should be added via the catalog cron cycle, not manually.

## Diff stat

3 files changed, 18 insertions(+), 76 deletions(-)

See #2651
