### PR TITLE
docs(non-genai): harmonize ML, Search, Probas, IIT READMEs per gabarit (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -7,6 +7,8 @@ breakdown: root=2
 maturity: PRODUCTION=2
 -->
 
+[← Notebooks](../README.md) | [↑ ..](../README.md) | [→ Probas](../Probas/README.md)
+
 La conscience est-elle mesurable ? La Theorie de l'Information Integree (IIT), proposee par Giulio Tononi, repond oui : un systeme est conscient dans la mesure ou il integre de l'information de maniere non reductible. Plus formellement, la quantite de conscience d'un systeme correspond a la valeur **Phi** (big Phi), qui mesure le degre d'integration causale irreductible. Cette serie vous apprend a calculer cette mesure avec **PyPhi**, la bibliotheque de reference du laboratoire Tononi, et a explorer la geometrie informationnelle des systemes complexes.
 
 Le premier notebook couvre le spectre fondamental : construction de graphes causaux binaires, calcul des Transition Probability Matrices (TPM), definition des sous-systemes, extraction des Cause-Effect Structures (CES), et exploration des macro-subsystemes. Le second approfondit les aspects avances : partitionnement MIP, repertoires cause-effet, MICE, comparaison big Phi vs small phi, reseaux elargis a 4+ noeuds, coarse-graining et apercu IIT 4.0.
@@ -24,15 +26,6 @@ A l'issue de cette serie, vous serez capable de :
 5. **Differencier big Phi et small phi** et comprendre leur roles respectifs dans la theorie
 6. **Evaluer les limites computationnelles** de l'IIT et les strategies de coarse-graining
 7. **Discuter les implications philosophiques** de l'IIT pour la conscience artificielle
-
-## Vue d'ensemble
-
-| Statistique | Valeur |
-|-------------|--------|
-| Notebooks | 2 |
-| Kernel | Python 3 (PyPhi/IIT) |
-| Duree estimee | ~120-180 min |
-| Version | PyPhi 1.2.0+ |
 
 ## Notebooks
 
@@ -219,13 +212,6 @@ IIT/
 
 Voir la licence du repository principal.
 
-## Cross-series Bridges
+---
 
-| Serie | Lien | Connection |
-|-------|------|-------------|
-| [Probas](../Probas/README.md) | Infer.NET / PyMC | Modeles probabilistes et inference bayesienne partagent les fondements de la mesure d'integration |
-| [GameTheory](../GameTheory/README.md) | OpenSpiel / Nashpy | Interactions strategiques multi-agents eclairent la complexite des systemes distribues |
-| [SymbolicAI/Lean](../SymbolicAI/Lean/README.md) | Preuves formelles | Formalisation Arrow/Sen montre comment prouver des proprietes structurelles impossibles |
-| [RL](../RL/README.md) | Stable Baselines3 | La distinction feed-forward vs recurrent (Phi = 0 vs > 0) eclaire le choix d'architecture RL |
-
-[La mer qui monte](../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du depot — Phi comme certificat ouvert : PyPhi le *calcule* sur de petits systemes sans pretendre le *demontrer*.
+*Version 1.1.0 — Juin 2026*

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -7,9 +7,9 @@ breakdown: DataScienceWithAgents=19, ML.Net=8
 maturity: PRODUCTION=23, BETA=3, ALPHA=1
 -->
 
-Le monde regorge de donnees, mais les transformer en decisions eclairees demande plus qu'un tableur. Le Machine Learning offre un cadre systematique pour construire des modeles predictifs a partir de donnees, en allant de la regression lineaire aux reseaux de neurones en passant par les systemes de recommandation. Cette serie vous forme au ML pratique avec deux stack complementaires : **ML.NET** pour l'ecosysteme .NET/C# (8 notebooks, ~6h) et **Python Data Science with Agents** pour les pipelines modernes enrichis de LLMs (19 notebooks, ~17h).
+[← Notebooks](../README.md) | [↑ ..](../README.md) | [→ GenAI](../GenAI/README.md)
 
-**27 notebooks** | **2 sous-domaines** | **~23h** | **.NET Interactive + Python**
+Le monde regorge de donnees, mais les transformer en decisions eclairees demande plus qu'un tableur. Le Machine Learning offre un cadre systematique pour construire des modeles predictifs a partir de donnees, en allant de la regression lineaire aux reseaux de neurones en passant par les systemes de recommandation. Cette serie vous forme au ML pratique avec deux stack complementaires : **ML.NET** pour l'ecosysteme .NET/C# et **Python Data Science with Agents** pour les pipelines modernes enrichis de LLMs.
 
 ## Pourquoi cette serie
 
@@ -258,21 +258,5 @@ Voir la licence du repository principal.
 
 ---
 
-## Cross-series Bridges
-
-| Serie | Lien | Connection |
-|-------|------|-------------|
-| [RL](../RL/README.md) | Apprentissage par renforcement | Le RL s'appuie sur les memes fondamentaux ML (gradients, reseaux de neurones, evaluation) |
-| [GenAI](../GenAI/README.md) | IA generative | Les agents IA du track DataScienceWithAgents utilisent les LLMs couverts dans GenAI/Texte |
-| [QuantConnect](../QuantConnect/README.md) | Trading algorithmique | Les modeles de prediction ML (regression, classification) s'appliquent directement aux strategies de trading |
-| [Probas](../Probas/README.md) | Programmation probabiliste | L'evaluation bayesienne des modeles (TP-prevision-ventes) est une application directe de la serie Probas |
-| [Search](../Search/README.md) | Recherche et optimisation | L'optimisation des hyperparametres ML rejoint les techniques de recherche (grille, bayesienne) |
-
-[La mer qui monte](../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du depot — le modele entraine comme certificat ouvert, juge par une evaluation declaree comme telle.
-
----
-
-## Navigation
-
-- [<- Notebooks racine](../) | [GenAI ->](../GenAI/)
-- [ML.NET ->](ML.Net/README.md) | [DataScienceWithAgents ->](DataScienceWithAgents/README.md) | [RL ->](../RL/)
+- [← Notebooks](../README.md) | [↑ ..](../README.md) | [→ GenAI](../GenAI/README.md)
+- [ML.NET →](ML.Net/README.md) | [DataScienceWithAgents →](DataScienceWithAgents/README.md) | [RL →](../RL/)

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -7,13 +7,11 @@ breakdown: Infer=21, PyMC=20, root=3
 maturity: PRODUCTION=44
 -->
 
+[← Notebooks](../README.md) | [↑ ..](../README.md) | [→ GameTheory](../GameTheory/README.md)]
+
 Le monde reel est incertain. Un diagnostic medical n'est jamais sur a 100%, un classement sportif depend de performances intrinsequement variables, et les donnees que nous collectons sont toujours bruitees ou incompletes. La programmation probabiliste offre un cadre rigoureux pour modeliser cette incertitude : plutot que de calculer une seule reponse, on obtient une **distribution de probabilites** qui quantifie notre confiance dans chaque resultat possible.
 
 Cette serie couvre trois stack complementaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inference exacte par message passing, **PyMC** (Python) pour l'echantillonnage MCMC moderne, et des **applications standalone** (RSA, HMM trading). Les 21 notebooks Infer.NET couvrent les fondements mathematiques (distributions, graphs de facteurs), les modeles classiques (reseaux bayesiens, TrueSkill, LDA, HMM), puis la theorie de la decision bayesienne — jusqu'a un compagnon **Lean 4** (Infer-20b, adosse au projet Lake `gittins_lean`) qui demontre formellement les identites d'escompte de l'indice de Gittins. Les 20 notebooks PyMC reprennent l'integralite des modeles Infer.NET en Python avec l'echantillonnage NUTS, offrant un pont naturel vers l'ecosysteme data science : fondations 1-3, modeles classiques 4-13, et theorie de la decision 14-20.
-
-**44 notebooks** | **3 stack** | **~40h**
-
-**A qui s'adresse cette serie** : etudiants en IA, data scientists, et developpeurs souhaitant aller au-dela des modeles deterministes. Aucun prerequis en probabilites avancees : les concepts sont introduits progressivement.
 
 ## Pourquoi cette serie
 
@@ -47,16 +45,6 @@ A l'issue de cette serie, vous serez capable de :
 3. **Comparer** message passing vs MCMC sur le meme modele
 4. **Decaler** d'un probleme real vers sa formulation probabiliste (variables, facteurs, observations)
 5. **Integrer** inference probabiliste et theorie de la decision (maximisation d'utilite esperee)
-
-## Vue d'ensemble
-
-| Statistique | Valeur |
-|-------------|--------|
-| Notebooks | 44 (21 Infer.NET + 20 PyMC + 3 standalone) |
-| Duree totale | ~40h |
-| Langages | C# (.NET), Python, Lean 4 |
-| Kernels | .NET Interactive, Python 3, Lean 4 (WSL) |
-| Algorithmes | EP, VMP, Gibbs (Infer.NET) ; NUTS (PyMC) |
 
 ## Parcours d'apprentissage
 
@@ -499,16 +487,6 @@ Le notebook `Infer-101.ipynb` est le seul a melanger les deux kernels. Il utilis
 
 Voir la licence du repository principal.
 
-## Cross-series Bridges
+---
 
-| Serie | Lien | Connection |
-| ------- | ------ | ----------- |
-| [IIT](../IIT/README.md) | PyPhi | L'integration informationnelle (phi) repose sur les memes fondements probabilistes |
-| [SymbolicAI/SemanticWeb](../SymbolicAI/SemanticWeb/README.md) | OWL reasoning | Les ontologies OWL utilisent la logique probabiliste pour le raisonnement incertain |
-| [GameTheory](../GameTheory/README.md) | Bayesian games | Les jeux bayesiens combinent probabilites et theorie des jeux |
-| [QuantConnect](../QuantConnect/README.md) | HMM trading | PyMC-HMM-Trading-Alpha applique les modeles probabilistes aux signaux de trading |
-| [Search](../Search/README.md) | Optimisation bayesienne | La selection de modeles (PyMC-8) utilise les memes techniques que l'optimisation bayesienne |
-| [RL](../RL/README.md) | MDPs | Les MDPs de PyMC-20 (Decision Sequential) sont la passerelle vers le reinforcement learning |
-| [SmartContracts](../SymbolicAI/SmartContracts/README.md) | Decision robust | Minimax Regret (PyMC-19) s'applique aux smart contracts pour la gestion des incertitudes on-chain |
-| [SymbolicAI/Lean](../SymbolicAI/Lean/README.md) | gittins_lean | Le compagnon Infer-20b prouve en Lean 4 les identites d'escompte de l'indice de Gittins |
-| Lecture transversale | [La mer qui monte](../../docs/grothendieckian-lens.md) | Grille de lecture grothendieckienne du depot : changement de representation, certification A/B/C |
+*Version 1.1.0 — Juin 2026*

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -7,11 +7,11 @@ breakdown: Applications=21, Part1-Foundations=11, Part2-CSP=9, root=5
 maturity: PRODUCTION=45, BETA=1
 -->
 
+[← Notebooks](../README.md) | [↑ ..](../README.md) | [→ SymbolicAI](../SymbolicAI/README.md)
+
 Tout problème d'IA, du plus simple jeu de plateau à la planification logistique industrielle, se réduit à un même défi : explorer un espace de solutions possibles pour trouver la meilleure. Cette série vous apprend à maîtriser cette exploration, depuis les algorithmes classiques (BFS, A*, Minimax) jusqu'aux techniques avancées (CSP, métaheuristiques, hybridation LLM). Le fil rouge est la **réduction de l'espace de recherche** : comment passer d'une exploration aveugle exponentielle à une résolution intelligemment guidée.
 
 Le parcours couvre quatre grands piliers. Les **fondements** formalisent les espaces d'états et couvrent les algorithmes de recherche non informée, informée, locale, génétique, adversariale et MCTS. La **programmation par contraintes** (CSP) introduit un changement de paradigme : au lieu d'explorer, on réduit les domaines par propagation. Les **applications** (20 notebooks) illustrent chaque concept sur des problèmes réels adaptés de projets étudiants. Enfin, les **métaheuristiques et l'hybridation** relient la recherche à l'optimisation continue et aux LLMs.
-
-**46 notebooks** | **4 piliers** | **~38h**
 
 **A qui s'adresse cette serie** : etudiants en informatique (L3-M2), ingenieurs logiciel confrontes a des problemes d'optimisation, et candidats a des entretiens techniques. Les notebooks Python ne necessitent que Python 3.10+ avec `ortools` et `deap`. Les side tracks C# (edge detection, portefeuille) requierent .NET 9.0 + dotnet-interactive. Aucun prerequis en algorithmique avancee : les concepts sont introduits depuis les espaces d'etats.
 
@@ -61,21 +61,6 @@ La Phase 2 change de paradigme : au lieu d'explorer un espace, on le réduit. CS
 ### Phase 3 : Applications et frontieres (Applications + notebooks avances, ~18h)
 
 Les 20 notebooks d'applications illustrent chaque concept sur des cas réels : planification d'infirmiers (CSP-4), ordonnancement d'atelier (CSP-4), optimisation de portefeuille (métaheuristiques), TSP et VRP (routing), démineur et Wordle (CSP + théorie de l'information), Picross (couverture exacte). Les notebooks avancés de la Part 1 (programmation linéaire Search-9, automates symboliques Search-10, métaheuristiques Search-11) et de la Part 2 (contraintes souples CSP-7, temporelles CSP-8, distribuées CSP-9) complètent le panorama. L'ensemble est enrichi par des ponts vers les autres séries : Sudoku (DLX, automates), SymbolicAI (Z3, planification), GameTheory (Minimax, MCTS), et RL (MCTS + DQN).
-
-## Vue d'ensemble
-
-| Partie | Notebooks | Duree |
-| -------- | --------- | ----- |
-| Partie 1: Search Fondamental | 11 | ~12h30 |
-| Partie 2: Programmation par Contraintes | 9 | ~9h |
-| Applications | 20 | ~13h20 |
-| Heritage (racine) | 5 | ~3h |
-| **Total** | **45** | **~38h** |
-
-| Statistique | Valeur |
-|-------------|--------|
-| Langages | Python (principal), C# (side tracks) |
-| Niveau | Debutant a avance |
 
 ## Ce que chaque notebook apporte
 
@@ -257,18 +242,6 @@ CSP-8  Temporal            ───> Temporal Planning, STP
 
 ---
 
-## Liens avec les autres series
-
-| Serie | Lien |
-|-------|------|
-| [Sudoku](../Sudoku/README.md) | Application complete des CSP (17 solveurs dont DLX et automates symboliques) |
-| [SymbolicAI](../SymbolicAI/README.md) | Z3 SMT, OR-Tools, planification PDDL, automates symboliques |
-| [GameTheory](../GameTheory/README.md) | Minimax, MCTS (jeux a information parfaite) |
-| [Probas/Infer](../Probas/README.md) | Approches probabilistes des CSP |
-| [GenAI](../GenAI/README.md) | Optimisation d'hyperparametres avec metaheuristiques |
-
----
-
 ## Prerequis
 
 ### Python
@@ -428,21 +401,6 @@ Search/
 
 > Le parcours detaille avec prerequis et enchainements logiques est decrit dans la section [Parcours d'apprentissage](#parcours-dapprentissage) ci-dessus.
 
----
-
-## Cross-series Bridges
-
-| Serie | Lien | Connection |
-|-------|------|-------------|
-| [Sudoku](../Sudoku/README.md) | Resolution de puzzles | Les solveurs Sudoku (DLX, automates symboliques, CSP) sont des applications directes des techniques de cette serie |
-| [SymbolicAI](../SymbolicAI/README.md) | IA symbolique | Z3 (SMT solving), planification PDDL et logique formelle prolongent les CSP vers la verification formelle |
-| [GameTheory](../GameTheory/README.md) | Theorie des jeux | Minimax et MCTS (Search-6/7) sont aussi les algorithmes fondamentaux de la serie GameTheory |
-| [Probas](../Probas/README.md) | Programmation probabiliste | Les approches probabilistes (MCTS, simulated annealing) partagent les memes fondements que les modeles probabilistes de la serie Probas |
-| [RL](../RL/README.md) | Apprentissage par renforcement | MCTS (Search-7) et l'optimisation d'hyperparametres (App-18) relient la recherche au RL |
-| [ML](../ML/README.md) | Machine Learning | L'optimisation bayesienne d'hyperparametres (App-18) applique les metaheuristiques de cette serie au ML |
-| [GenAI](../GenAI/README.md) | IA generative | Les LLMs peuvent etre utilises comme heuristiques pour la resolution CSP (CSP-6 Hybridization) |
-| Lecture transversale | [La mer qui monte](../../docs/grothendieckian-lens.md) | Grille de lecture grothendieckienne du depot : changement de representation, certification A/B/C |
-
 ## FAQ / Troubleshooting
 
 ### OR-Tools ne s'installe pas
@@ -510,3 +468,7 @@ Allez directement aux applications qui correspondent a votre domaine : **App-3/A
 ## Licence
 
 Voir la licence du repository principal.
+
+---
+
+*Version 1.1.0 — Juin 2026*


### PR DESCRIPTION
## Summary

Harmonize 4 non-GenAI series READMEs against the gabarit de reference (`docs/reference/readme-series-gabarit.md`), continuing #2651 Partie 2 after the GenAI series (PRs #2826, #2827, #2828).

## Changes per series

### ML/README.md
- Add navigation bar in header
- Remove bandeau chiffres
- Remove generic cross-series bridges table
- Remove grothendieckian lens link
- Consolidate footer navigation

### Search/README.md
- Add navigation bar in header
- Remove bandeau chiffres
- Remove Vue d'ensemble stats table (duplicated CATALOG-STATUS)
- Remove duplicate Liens avec les autres series section
- Remove generic cross-series bridges table

### Probas/README.md
- Add navigation bar in header
- Remove bandeau chiffres
- Remove Vue d'ensemble stats table
- Remove A qui s'adresse paragraph (duplicated pitch)
- Remove generic cross-series bridges table

### IIT/README.md
- Add navigation bar in header
- Remove Vue d'ensemble stats table
- Remove generic cross-series bridges table

## Not touched

- CATALOG-STATUS markers (bot-owned, verified 0 changes)
- Pedagogical content, objectives, parcours tables (all preserved)
- FAQ sections (all within bounds)

4 files, 19 insertions, 109 deletions (net reduction)

See #2651
