### PR TITLE
feat(lean): Grothendieck Part 17 -- internal hom of sheaves (See #2159)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -33,3 +33,5 @@ import Grothendieck.DenseTopology
 import Grothendieck.Sheafification
 import Grothendieck.LeftExact
 import Grothendieck.Subcanonical
+import Grothendieck.SitePoints
+import Grothendieck.SheafHom

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
@@ -1,0 +1,140 @@
+/-
+Grothendieck Part 17 — Internal hom of sheaves
+
+Part 16 (Subcanonical.lean) showed that when a topology is subcanonical,
+representable presheaves are already sheaves, and the Yoneda embedding
+descends to the sheaf category.
+
+This module introduces the **internal hom of sheaves** (SheafHom): given two
+sheaves F and G on a site (C, J) with values in a category A, the sheaf
+`sheafHom F G` sends an object X : C to the type of morphisms between the
+restrictions of F and G to the slice category Over X.
+
+Key constructions bridged from Mathlib (`CategoryTheory.Sites.SheafHom`):
+
+  - `presheafHom F G` : the presheaf-of-types underlying the internal hom
+  - `presheafHomSectionsEquiv` : sections of presheafHom ≃ morphisms F ⟶ G
+  - `Presheaf.IsSheaf.hom` : when G is a sheaf, presheafHom F G is a sheaf
+  - `sheafHom F G` : the internal hom as a Sheaf J (Type _)
+  - `sheafHomSectionsEquiv` : sections of sheafHom ≃ sheaf morphisms F ⟶ G
+  - `sheafHom'Iso` : the canonical iso between sheafHom' and presheafHom
+
+This is the first step towards Cartesian closed structure on Sheaf J (Type _),
+a fundamental property of Grothendieck toposes (SGA 4 II).
+
+Epic #1646, See #2159. All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.SheafHom
+
+universe v v' u u'
+
+namespace Grothendieck.SheafHom
+
+open CategoryTheory Category Opposite Limits
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+  {A : Type u'} [Category.{v'} A]
+
+/-! ## 1. Presheaf-level internal hom
+
+Given presheaves F and G, `presheafHom F G` is a presheaf of types whose
+sections over X are natural transformations between the restrictions of
+F and G to Over X. Its global sections are exactly morphisms F ⟶ G.
+-/
+
+-- The presheaf internal hom: sections over X are morphisms between
+-- restrictions of F and G to the slice category Over X.
+#check @presheafHom
+
+-- The sections of the presheaf internal hom identify to morphisms F ⟶ G.
+-- (presheafHom F G).sections ≃ (F ⟶ G)
+#check @presheafHomSectionsEquiv
+
+/-! ## 2. Sheaf condition for the internal hom
+
+When G is a sheaf, the presheaf internal hom `presheafHom F G` is itself
+a sheaf. This is the key technical fact enabling the sheaf-level internal hom.
+-/
+
+-- When G is a sheaf, the presheaf internal hom presheafHom F G is a sheaf.
+#check @Presheaf.IsSheaf.hom
+
+/-- Bridge theorem: when G is a sheaf, presheafHom F G satisfies the sheaf
+condition (via the isSheaf_of_type equivalence). -/
+theorem presheafHom_isSheaf_of_isSheaf (F G : Cᵒᵖ ⥤ A)
+    (hG : Presheaf.IsSheaf J G) :
+    Presheaf.IsSheaf J (presheafHom F G) :=
+  Presheaf.IsSheaf.hom F G hG
+
+/-! ## 3. Sheaf-level internal hom
+
+The sheaf internal hom `sheafHom F G` is the sheafification-ready version
+living in Sheaf J (Type _). Its sections identify to sheaf morphisms F ⟶ G.
+-/
+
+-- The sheaf internal hom: sheafHom F G sends X to the morphisms between
+-- restrictions of F and G to Over X, as a Sheaf J (Type _).
+#check @sheafHom
+
+-- The sections of the sheaf internal hom identify to sheaf morphisms F ⟶ G.
+#check @sheafHomSectionsEquiv
+
+-- The underlying presheaf of the sheaf internal hom.
+#check @sheafHom'
+
+-- The canonical isomorphism between sheafHom' and presheafHom.
+#check @sheafHom'Iso
+
+/-! ## 4. Bridge theorems: internal hom as a Sheaf
+
+The internal hom construction preserves the sheaf condition, making the
+category of sheaves enriched over itself. This is the first step toward
+the Cartesian closed structure of Sheaf J (Type _).
+-/
+
+/-- Construction bridge: from a sheaf morphism F ⟶ G, obtain a section
+of the sheaf internal hom. This is the inverse direction of
+sheafHomSectionsEquiv. -/
+noncomputable def sheafHomSectionOfHom (F G : Sheaf J A) (φ : F ⟶ G) :
+    (sheafHom F G).1.sections :=
+  (sheafHomSectionsEquiv F G).symm φ
+
+/-- Construction bridge: from a section of the sheaf internal hom, obtain
+a sheaf morphism F ⟶ G. This is the forward direction of
+sheafHomSectionsEquiv. -/
+noncomputable def sheafHomOfSection (F G : Sheaf J A)
+    (s : (sheafHom F G).1.sections) : F ⟶ G :=
+  (sheafHomSectionsEquiv F G) s
+
+/-- The sheaf internal hom sheafHom F G is indeed a sheaf (by construction). -/
+theorem sheafHom_isSheaf (F G : Sheaf J A) :
+    Presheaf.IsSheaf J (sheafHom F G).1 :=
+  (sheafHom F G).2
+
+/-- The underlying presheaf of sheafHom is isomorphic to presheafHom. -/
+theorem sheafHom'_iso_presheafHom (F G : Sheaf J A) :
+    Nonempty (sheafHom' F G ≅ presheafHom F.1 G.1) :=
+  ⟨sheafHom'Iso F G⟩
+
+/-! ## 5. Section-morphism roundtrips
+
+The equivalence between sections and morphisms gives us roundtrip lemmas
+that witness the bijection (sheafHom F G).sections ≃ (F ⟶ G).
+-/
+
+/-- Roundtrip: section → morphism → section is the identity. -/
+theorem sheafHomSectionsEquiv_roundtrip (F G : Sheaf J A)
+    (s : (sheafHom F G).1.sections) :
+    sheafHomSectionOfHom F G (sheafHomOfSection F G s) = s := by
+  dsimp [sheafHomSectionOfHom, sheafHomOfSection]
+  exact (sheafHomSectionsEquiv F G).left_inv s
+
+/-- Roundtrip: morphism → section → morphism is the identity. -/
+theorem sheafHomSectionsEquiv_roundtrip_symm (F G : Sheaf J A)
+    (φ : F ⟶ G) :
+    sheafHomOfSection F G (sheafHomSectionOfHom F G φ) = φ := by
+  dsimp [sheafHomSectionOfHom, sheafHomOfSection]
+  exact (sheafHomSectionsEquiv F G).right_inv φ
+
+end Grothendieck.SheafHom


### PR DESCRIPTION
## Summary

Grothendieck Part 17 -- Internal hom of sheaves (SheafHom.lean).

New module bridging Mathlib CategoryTheory.Sites.SheafHom into the Grothendieck pedagogical namespace. Introduces the **internal hom of sheaves** sheafHom F G, which sends an object X to morphisms between restrictions of F and G to the slice category Over X.

### Bridge theorems/defs (6)

| Theorem/def | Description |
|---|---|
| presheafHom_isSheaf_of_isSheaf | Sheaf condition propagates: when G is a sheaf, presheafHom F G is a sheaf |
| sheafHomSectionOfHom | Convert sheaf morphism F -> G to section of sheafHom F G |
| sheafHomOfSection | Convert section to sheaf morphism |
| sheafHom_isSheaf | sheafHom F G is a sheaf (by construction) |
| sheafHom_iso_presheafHom | Underlying presheaf isomorphic to presheafHom |
| sheafHomSectionsEquiv_roundtrip / _symm | Roundtrip lemmas witnessing the bijection |

### #check bridges (7)

presheafHom, presheafHomSectionsEquiv, Presheaf.IsSheaf.hom, sheafHom, sheafHomSectionsEquiv, sheafHom prime, sheafHom prime Iso

### Umbrella fix

Added missing SitePoints import + new SheafHom import to Grothendieck.lean umbrella.

## Proof evidence

- lake build SUCCESS (2558 jobs, all modules)
- grep -cE sorry = 0 (SheafHom.lean)
- No regression on existing modules

Epic #1646, See #2159.