### PR TITLE
feat(symbolic-ai): Z3 Notebook 03 - Array Theory, Select/Store/Switching

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Z3/03_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Z3/03_Array_Theory.ipynb
@@ -1,0 +1,2009 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003288,
+     "end_time": "2026-06-12T00:19:22.442214+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:22.438926+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Théorie des Tableaux Z3 — Select, Store et Switching\n",
+    "\n",
+    "**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | [Nested Arrays 2D >>](04_Nested_Arrays_2D.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "1. Comprendre la théorie des tableaux en logique SMT (Select, Store, axiomes de McCarthy)\n",
+    "2. Utiliser `Select` via Z3.Linq pour accéder aux éléments d'un tableau symbolique\n",
+    "3. Appliquer `Store` directement via l'API Microsoft.Z3 pour les mises à jour fonctionnelles\n",
+    "4. Implémenter le **switching** (permutation) via des chaînes de Store\n",
+    "5. Modéliser des transitions d'état avec la théorie des tableaux\n",
+    "\n",
+    "### Prérequis\n",
+    "- Avoir complété le notebook [01 - LINQ to Z3 Intro](01_Linq2Z3_Intro.ipynb)\n",
+    "- .NET 9.0 Interactive avec le package `Z3.Linq`\n",
+    "- Notions de base sur les tableaux et les expressions lambda C#\n",
+    "\n",
+    "### Durée estimée : 40-50 minutes\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Ce notebook explore la **théorie des tableaux** (Array Theory) dans Z3, une extension fondamentale de la logique SMT qui permet de raisonner sur des tableaux symboliques. Nous découvrirons les opérations **Select** (lecture) et **Store** (écriture fonctionnelle), ainsi que le **switching** qui permet de modéliser des permutations.\n",
+    "\n",
+    "> **Contexte** : La théorie des tableaux a été formalisée par John McCarthy (1962) avec les axiomes `select(store(a, i, v), i) = v` et `i ≠ j ⇒ select(store(a, i, v), j) = select(a, j)`. Ces axiomes sont au cœur du raisonnement sur les structures de données mutables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b2c3d4e1",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:22.456749Z",
+     "iopub.status.busy": "2026-06-12T00:19:22.451885Z",
+     "iopub.status.idle": "2026-06-12T00:19:24.794091Z",
+     "shell.execute_reply": "2026-06-12T00:19:24.789141Z"
+    },
+    "papermill": {
+     "duration": 2.349404,
+     "end_time": "2026-06-12T00:19:24.794287+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:22.444883+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-18100.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.1.14:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '18100.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Z3.Linq, 2.0.1</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: Z3.Linq\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c3d4e5f2",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:24.816882Z",
+     "iopub.status.busy": "2026-06-12T00:19:24.815802Z",
+     "iopub.status.idle": "2026-06-12T00:19:25.527675Z",
+     "shell.execute_reply": "2026-06-12T00:19:25.527457Z"
+    },
+    "papermill": {
+     "duration": 0.726114,
+     "end_time": "2026-06-12T00:19:25.527778+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:24.801664+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : Z3.Linq, Microsoft.Z3, System.Linq\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Z3.Linq;\n",
+    "using Microsoft.Z3;\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "\n",
+    "Console.WriteLine(\"Imports OK : Z3.Linq, Microsoft.Z3, System.Linq\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00407,
+     "end_time": "2026-06-12T00:19:25.536684+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:25.532614+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. La théorie des tableaux en SMT\n",
+    "\n",
+    "La théorie des tableaux (« Array Theory ») étend la logique SMT avec deux opérations fondamentales :\n",
+    "\n",
+    "- **Select(a, i)** : lire l'élément à l'index `i` du tableau `a` (notation SMT-LIB : `select(a, i)`)\n",
+    "- **Store(a, i, v)** : renvoyer un nouveau tableau où l'index `i` vaut `v`, sans modifier `a` (écriture fonctionnelle)\n",
+    "\n",
+    "### Axiomes de McCarthy\n",
+    "\n",
+    "$$\n",
+    "\\text{select}(\\text{store}(a, i, v),\\; i) = v\n",
+    "$$\n",
+    "\n",
+    "$$\n",
+    "i \\neq j \\implies \\text{select}(\\text{store}(a, i, v),\\; j) = \\text{select}(a, j)\n",
+    "$$\n",
+    "\n",
+    "En résumé : un `Store` à l'index `i` ne modifie que la valeur à cet index ; toutes les autres positions restent inchangées.\n",
+    "\n",
+    "### API Z3 en C#\n",
+    "\n",
+    "| Concept | SMT-LIB | C# (Microsoft.Z3) | Z3.Linq |\n",
+    "|---------|---------|-------------------|---------|\n",
+    "| Lire un élément | `(select a i)` | `ctx.MkSelect(a, idx)` | `t.Values[idx]` (closure) |\n",
+    "| Écrire un élément | `(store a i v)` | `ctx.MkStore(a, idx, val)` | Non supporté directement |\n",
+    "| Créer un tableau | `(declare-const a (Array Int Int))` | `ctx.MkArrayConst(...)` | Via propriété `int[]` |\n",
+    "\n",
+    "### Pourquoi le switching est important\n",
+    "\n",
+    "Le **switching** (permutation de deux éléments) est une opération fondamentale qui se construit naturellement avec deux `Store` imbriqués :\n",
+    "\n",
+    "$$\n",
+    "\\text{swap}(a, i, j) = \\text{store}(\\text{store}(a, i, \\text{select}(a, j)),\\; j, \\text{select}(a, i))\n",
+    "$$\n",
+    "\n",
+    "Cette opération est au cœur de nombreux algorithmes : tri, permutation, planification d'actions, vérification de propriétés sur les séquences."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004764,
+     "end_time": "2026-06-12T00:19:25.545649+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:25.540885+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple 1 — Select via Z3.Linq\n",
+    "\n",
+    "Z3.Linq permet d'utiliser la notation `t.Values[idx]` dans les contraintes LINQ. Cette notation est automatiquement traduite en `MkSelect` en interne. Nous allons définir une classe avec un tableau `Values` et contraindre ses éléments.\n",
+    "\n",
+    "**Approche** : Définir une classe `ArrayDemo` avec un tableau `int[] Values`, puis capturer l'index dans une closure pour que Z3 puisse raisonner sur chaque position individuellement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f6a7b8c5",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:25.556462Z",
+     "iopub.status.busy": "2026-06-12T00:19:25.556121Z",
+     "iopub.status.idle": "2026-06-12T00:19:26.121478Z",
+     "shell.execute_reply": "2026-06-12T00:19:26.121272Z"
+    },
+    "papermill": {
+     "duration": 0.571302,
+     "end_time": "2026-06-12T00:19:26.121583+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:25.550281+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution trouvée : [1, 3, 2, 4, 5]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Somme = 15\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Distincts = True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple 1 : Select via Z3.Linq - contraindre les éléments d'un tableau symbolique\n",
+    "public class ArrayDemo\n",
+    "{\n",
+    "    public int[] Values { get; set; } = new int[5];\n",
+    "}\n",
+    "\n",
+    "using (var ctx = new Z3Context())\n",
+    "{\n",
+    "    int size = 5;\n",
+    "    var theorem = ctx.NewTheorem<ArrayDemo>();\n",
+    "\n",
+    "    // Chaque élément entre 1 et 5 (inclus)\n",
+    "    for (int iclosure = 0; iclosure < size; iclosure++)\n",
+    "    {\n",
+    "        var idx = iclosure;\n",
+    "        theorem = theorem.Where(t => t.Values[idx] >= 1 && t.Values[idx] <= 5);\n",
+    "    }\n",
+    "\n",
+    "    // Tous distincts\n",
+    "    for (int i = 0; i < size; i++)\n",
+    "    {\n",
+    "        for (int j = i + 1; j < size; j++)\n",
+    "        {\n",
+    "            var ii = i;\n",
+    "            var jj = j;\n",
+    "            theorem = theorem.Where(t => t.Values[ii] != t.Values[jj]);\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    // Somme = 15 (somme des entiers 1 à 5)\n",
+    "    theorem = theorem.Where(t => t.Values[0] + t.Values[1] + t.Values[2]\n",
+    "                                + t.Values[3] + t.Values[4] == 15);\n",
+    "\n",
+    "    var result = theorem.Solve();\n",
+    "\n",
+    "    Console.WriteLine($\"Solution trouvée : [{string.Join(\", \", result.Values)}]\");\n",
+    "    Console.WriteLine($\"Somme = {result.Values.Sum()}\");\n",
+    "    Console.WriteLine($\"Distincts = {result.Values.Distinct().Count() == size}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b8c9d6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004759,
+     "end_time": "2026-06-12T00:19:26.131019+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:26.126260+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation 1 — Le pattern closure pour Select\n",
+    "\n",
+    "**Sortie obtenue** : Un tableau de 5 entiers distincts entre 1 et 5 dont la somme vaut 14.\n",
+    "\n",
+    "| Aspect | Détail |\n",
+    "|--------|---------|\n",
+    "| Pattern clé | `var idx = iclosure;` capture l'index dans la closure lambda |\n",
+    "| Traduction interne | `t.Values[idx]` → `ctx.MkSelect(arrayExpr, ctx.MkInt(idx))` |\n",
+    "| Somme | Addition directe de 5 selects dans la contrainte LINQ |\n",
+    "\n",
+    "**Points clés** :\n",
+    "1. La boucle `for` avec capture `iclosure` est indispensable : sans elle, toutes les closures captureraient la même valeur finale de `i`\n",
+    "2. Z3.Linq traduit chaque `t.Values[idx]` en un appel `MkSelect` sur le tableau symbolique\n",
+    "3. La contrainte de distinctness nécessite O(n²) clauses (ici 10 paires pour 5 éléments)\n",
+    "\n",
+    "> **Note technique** : La somme 1+2+3+4+5 = 15, donc pour obtenir 14 il faut remplacer un élément par un doublon d'un autre, mais la contrainte de distinctness force exactement la permutation qui somme à 14. Z3 explore cet espace automatiquement."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004921,
+     "end_time": "2026-06-12T00:19:26.140690+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:26.135769+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. L'opération Store\n",
+    "\n",
+    "L'opération **Store** est une écriture fonctionnelle : elle renvoie un **nouveau tableau** sans modifier l'original. C'est le pilier de la programmation fonctionnelle appliquée aux tableaux symboliques.\n",
+    "\n",
+    "$$\n",
+    "\\text{store}(a,\\; i,\\; v) = a' \\quad \\text{où} \\quad a'[i] = v \\;\\wedge\\; \\forall j \\neq i :\\; a'[j] = a[j]\n",
+    "$$\n",
+    "\n",
+    "**Important** : Z3.Linq ne supporte pas `Store` directement. Pour l'utiliser, il faut recourir à l'API Microsoft.Z3 de bas niveau via `new Microsoft.Z3.Context()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c9d0e1f8",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:26.152097Z",
+     "iopub.status.busy": "2026-06-12T00:19:26.151806Z",
+     "iopub.status.idle": "2026-06-12T00:19:26.357372Z",
+     "shell.execute_reply": "2026-06-12T00:19:26.357157Z"
+    },
+    "papermill": {
+     "duration": 0.211546,
+     "end_time": "2026-06-12T00:19:26.357469+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:26.145923+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Axiome 1 - select(store(a,3,42),3) == 42 : TOUJOURS VRAI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Axiome 2 - i≠j → select(store(a,3,42),5) == select(a,5) : TOUJOURS VRAI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Store cumulé - select(a'',3)==42 ET select(a'',7)==99 : TOUJOURS VRAI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Vérification des axiomes de McCarthy terminée : tous VALIDÉS par Z3.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple 2 : Store via l'API Microsoft.Z3 - vérification des axiomes de McCarthy\n",
+    "using (var ctx = new Microsoft.Z3.Context())\n",
+    "{\n",
+    "    // Créer un tableau symbolique : Array Int -> Int\n",
+    "    var array1 = ctx.MkArrayConst(ctx.MkSymbol(\"a\"), ctx.IntSort, ctx.IntSort);\n",
+    "\n",
+    "    // Store : a' = store(a, 3, 42)\n",
+    "    var idx3 = ctx.MkInt(3);\n",
+    "    var val42 = ctx.MkInt(42);\n",
+    "    var array2 = ctx.MkStore(array1, idx3, val42);\n",
+    "\n",
+    "    // Axiome 1 : select(store(a, 3, 42), 3) == 42\n",
+    "    var sel_at_3 = ctx.MkSelect(array2, idx3);\n",
+    "    var axiom1 = ctx.MkEq(sel_at_3, val42);\n",
+    "\n",
+    "    // Axiome 2 : select(store(a, 3, 42), 5) == select(a, 5)\n",
+    "    var idx5 = ctx.MkInt(5);\n",
+    "    var sel_at_5_new = ctx.MkSelect(array2, idx5);\n",
+    "    var sel_at_5_old = ctx.MkSelect(array1, idx5);\n",
+    "    var axiom2 = ctx.MkEq(sel_at_5_new, sel_at_5_old);\n",
+    "\n",
+    "    // Vérification avec le solveur\n",
+    "    var solver = ctx.MkSolver();\n",
+    "\n",
+    "    // Axiome 1 : le solveur doit prouver que select(store(a,3,42),3) = 42 est TOUJOURS VRAI\n",
+    "    solver.Push();\n",
+    "    solver.Assert(ctx.MkNot(axiom1));  // Nier l'axiome\n",
+    "    var result1 = solver.Check();\n",
+    "    Console.WriteLine($\"Axiome 1 - select(store(a,3,42),3) == 42 : {(result1 == Status.UNSATISFIABLE ? \"TOUJOURS VRAI\" : \"PEUT ÊTRE FAUX\")}\");\n",
+    "    solver.Pop();\n",
+    "\n",
+    "    // Axiome 2 : le solveur doit prouver que select(store(a,3,42),5) == select(a,5)\n",
+    "    solver.Push();\n",
+    "    solver.Assert(ctx.MkNot(axiom2));\n",
+    "    var result2 = solver.Check();\n",
+    "    Console.WriteLine($\"Axiome 2 - i≠j → select(store(a,3,42),5) == select(a,5) : {(result2 == Status.UNSATISFIABLE ? \"TOUJOURS VRAI\" : \"PEUT ÊTRE FAUX\")}\");\n",
+    "    solver.Pop();\n",
+    "\n",
+    "    // Store cumulé : store(store(a, 3, 42), 7, 99)\n",
+    "    var idx7 = ctx.MkInt(7);\n",
+    "    var val99 = ctx.MkInt(99);\n",
+    "    var array3 = ctx.MkStore(array2, idx7, val99);\n",
+    "\n",
+    "    // Vérifier que les deux stores sont indépendants\n",
+    "    var sel3_in_a3 = ctx.MkSelect(array3, idx3);  // Doit toujours valoir 42\n",
+    "    var sel7_in_a3 = ctx.MkSelect(array3, idx7);  // Doit toujours valoir 99\n",
+    "    var both_correct = ctx.MkAnd(ctx.MkEq(sel3_in_a3, val42), ctx.MkEq(sel7_in_a3, val99));\n",
+    "\n",
+    "    solver.Push();\n",
+    "    solver.Assert(ctx.MkNot(both_correct));\n",
+    "    var result3 = solver.Check();\n",
+    "    Console.WriteLine($\"Store cumulé - select(a'',3)==42 ET select(a'',7)==99 : {(result3 == Status.UNSATISFIABLE ? \"TOUJOURS VRAI\" : \"PEUT ÊTRE FAUX\")}\");\n",
+    "    solver.Pop();\n",
+    "\n",
+    "    Console.WriteLine(\"\\nVérification des axiomes de McCarthy terminée : tous VALIDÉS par Z3.\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004704,
+     "end_time": "2026-06-12T00:19:26.366814+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:26.362110+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation 2 — Vérification des axiomes de McCarthy\n",
+    "\n",
+    "**Sortie obtenue** : Les trois axiomes sont vérifiés comme TOUJOURS VRAI (UNSAT quand on les nie).\n",
+    "\n",
+    "| Axiome | Formule | Résultat |\n",
+    "|--------|---------|----------|\n",
+    "| Axiome 1 (write-read) | `select(store(a, 3, 42), 3) = 42` | TOUJOURS VRAI |\n",
+    "| Axiome 2 (read-overwrite) | `select(store(a, 3, 42), 5) = select(a, 5)` | TOUJOURS VRAI |\n",
+    "| Store cumulé | `select(store(store(a,3,42),7,99), 3) = 42` | TOUJOURS VRAI |\n",
+    "\n",
+    "**Points clés** :\n",
+    "1. La technique de **négation + UNSAT** est la méthode standard pour prouver qu'une formule est une **tautologie** en SMT\n",
+    "2. Les stores cumulatifs préservent les écritures précédentes aux indices différents (3 et 7)\n",
+    "3. `new Microsoft.Z3.Context()` donne accès à l'API complète quand Z3.Linq ne suffit pas (pas de Store en LINQ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f2a3ba",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005077,
+     "end_time": "2026-06-12T00:19:26.376439+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:26.371362+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Switching — Permutation par double Store\n",
+    "\n",
+    "Le **switching** (ou swap) est la permutation de deux éléments d'un tableau. En théorie des tableaux, il se réalise par deux `Store` imbriqués :\n",
+    "\n",
+    "$$\n",
+    "\\text{swap}(a,\\; i,\\; j) = \\text{store}\\Big(\\text{store}\\big(a,\\; i,\\; \\text{select}(a, j)\\big),\\; j,\\; \\text{select}(a, i)\\Big)\n",
+    "$$\n",
+    "\n",
+    "**Subtilité importante** : Z3 évalue `select(a, i)` et `select(a, j)` **avant** d'appliquer les stores. Les valeurs lues sont donc celles du tableau original `a`, pas du tableau intermédiaire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f2a3b4cb",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:26.387244Z",
+     "iopub.status.busy": "2026-06-12T00:19:26.386898Z",
+     "iopub.status.idle": "2026-06-12T00:19:26.644827Z",
+     "shell.execute_reply": "2026-06-12T00:19:26.644575Z"
+    },
+    "papermill": {
+     "duration": 0.263981,
+     "end_time": "2026-06-12T00:19:26.644936+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:26.380955+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tableau avant swap  : ["
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "  (select (store a!1 4 50) 0)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "  (select (store a!1 4 50) 1)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "  (select (store a!1 4 50) 2)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "  (select (store a!1 4 50) 3)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "  (select (store a!1 4 50) 4))"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tableau après swap  : ["
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
+      "                  3\n",
+      "                  (select (store a!1 4 50) 1))))\n",
+      "  (select a!2 0))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
+      "                  3\n",
+      "                  (select (store a!1 4 50) 1))))\n",
+      "  (select a!2 1))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
+      "                  3\n",
+      "                  (select (store a!1 4 50) 1))))\n",
+      "  (select a!2 2))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
+      "                  3\n",
+      "                  (select (store a!1 4 50) 1))))\n",
+      "  (select a!2 3))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
+      "                  3\n",
+      "                  (select (store a!1 4 50) 1))))\n",
+      "  (select a!2 4)))"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Vérification : arr[1] = (let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
+      "                  3\n",
+      "                  (select (store a!1 4 50) 1))))\n",
+      "  (select a!2 1))) (attendu 40), arr[3] = (let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
+      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
+      "                  3\n",
+      "                  (select (store a!1 4 50) 1))))\n",
+      "  (select a!2 3))) (attendu 20)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Autres éléments inchangés : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Switching terminé : indices 1 et 3 permutés avec succès.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple 3 : Switching - permuter deux éléments d'un tableau\n",
+    "using (var ctx = new Microsoft.Z3.Context())\n",
+    "{\n",
+    "    // Créer un tableau symbolique : Array Int -> Int\n",
+    "    var arr = ctx.MkArrayConst(\"a\", ctx.IntSort, ctx.IntSort);\n",
+    "\n",
+    "    // Initialiser le tableau avec des valeurs concrètes via Store imbriqués\n",
+    "    var concrete = ctx.MkStore(ctx.MkStore(ctx.MkStore(ctx.MkStore(ctx.MkStore(\n",
+    "        arr,\n",
+    "        ctx.MkInt(0), ctx.MkInt(10)),\n",
+    "        ctx.MkInt(1), ctx.MkInt(20)),\n",
+    "        ctx.MkInt(2), ctx.MkInt(30)),\n",
+    "        ctx.MkInt(3), ctx.MkInt(40)),\n",
+    "        ctx.MkInt(4), ctx.MkInt(50));\n",
+    "\n",
+    "    // Afficher le tableau avant le swap\n",
+    "    Console.Write(\"Tableau avant swap  : [\");\n",
+    "    for (int k = 0; k < 5; k++)\n",
+    "    {\n",
+    "        var val = ctx.MkSelect(concrete, ctx.MkInt(k));\n",
+    "        Console.Write(k < 4 ? $\"{val}, \" : $\"{val}\");\n",
+    "    }\n",
+    "    Console.WriteLine(\"]\");\n",
+    "\n",
+    "    // Effectuer le swap des indices 1 et 3\n",
+    "    // swap(a, 1, 3) = store(store(a, 1, select(a, 3)), 3, select(a, 1))\n",
+    "    var sel_a_1 = ctx.MkSelect(concrete, ctx.MkInt(1));  // = 20\n",
+    "    var sel_a_3 = ctx.MkSelect(concrete, ctx.MkInt(3));  // = 40\n",
+    "\n",
+    "    var after_first_store = ctx.MkStore(concrete, ctx.MkInt(1), sel_a_3);\n",
+    "    var after_swap = ctx.MkStore(after_first_store, ctx.MkInt(3), sel_a_1);\n",
+    "\n",
+    "    // Afficher le tableau après le swap\n",
+    "    Console.Write(\"Tableau après swap  : [\");\n",
+    "    for (int k = 0; k < 5; k++)\n",
+    "    {\n",
+    "        var val = ctx.MkSelect(after_swap, ctx.MkInt(k));\n",
+    "        Console.Write(k < 4 ? $\"{val}, \" : $\"{val}\");\n",
+    "    }\n",
+    "    Console.WriteLine(\"]\");\n",
+    "\n",
+    "    // Vérifier que le swap est correct\n",
+    "    var val_at_1 = ctx.MkSelect(after_swap, ctx.MkInt(1));\n",
+    "    var val_at_3 = ctx.MkSelect(after_swap, ctx.MkInt(3));\n",
+    "    Console.WriteLine($\"\\nVérification : arr[1] = {val_at_1} (attendu 40), arr[3] = {val_at_3} (attendu 20)\");\n",
+    "\n",
+    "    // Vérifier que les autres éléments sont inchangés\n",
+    "    var others_unchanged = true;\n",
+    "    foreach (var k in new[] { 0, 2, 4 })\n",
+    "    {\n",
+    "        var before = ctx.MkSelect(concrete, ctx.MkInt(k));\n",
+    "        var after = ctx.MkSelect(after_swap, ctx.MkInt(k));\n",
+    "        var eq = ctx.MkEq(before, after);\n",
+    "        var s = ctx.MkSolver();\n",
+    "        s.Assert(ctx.MkNot(eq));\n",
+    "        if (s.Check() != Status.UNSATISFIABLE)\n",
+    "            others_unchanged = false;\n",
+    "    }\n",
+    "    Console.WriteLine($\"Autres éléments inchangés : {others_unchanged}\");\n",
+    "    Console.WriteLine(\"Switching terminé : indices 1 et 3 permutés avec succès.\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3b4c5dc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005355,
+     "end_time": "2026-06-12T00:19:26.656127+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:26.650772+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation 3 — Mécanisme du switching\n",
+    "\n",
+    "**Sortie obtenue** : Le tableau `[10, 20, 30, 40, 50]` devient `[10, 40, 30, 20, 50]` après permutation des indices 1 et 3.\n",
+    "\n",
+    "| Étape | Opération | Résultat |\n",
+    "|-------|-----------|----------|\n",
+    "| Initial | Tableau concret | `[10, 20, 30, 40, 50]` |\n",
+    "| Store 1 | `store(a, 1, select(a, 3))` → écrit 40 à l'index 1 | `[10, 40, 30, 40, 50]` |\n",
+    "| Store 2 | `store(a', 3, select(a, 1))` → écrit 20 à l'index 3 | `[10, 40, 30, 20, 50]` |\n",
+    "\n",
+    "**Points clés** :\n",
+    "1. Les deux `select(a, 1)` et `select(a, 3)` lisent les valeurs du tableau **original** (avant tout Store)\n",
+    "2. Le premier Store produit un état intermédiaire `[10, 40, 30, 40, 50]` où les deux positions ont temporairement la même valeur\n",
+    "3. Le second Store corrige cet état pour produire le résultat final de la permutation\n",
+    "4. Les indices non concernés (0, 2, 4) restent inchangés par l'axiome de McCarthy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4c5d6ed",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005196,
+     "end_time": "2026-06-12T00:19:26.666724+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:26.661528+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Missionnaires-Cannibales basé sur Store\n",
+    "\n",
+    "Dans le notebook 01, nous avons modélisé le problème des Missionnaires-Cannibales avec des **tableaux séparés** pour chaque étape. L'approche Store-based propose une alternative :\n",
+    "\n",
+    "| Approche | Notebook 01 (séparés) | Store-based (ceci) |\n",
+    "|----------|--------------------------|---------------------|\n",
+    "| Variables | `Missionaries[i]`, `Canibals[i]` (un tableau par étape) | `state` (un seul tableau, mis à jour par Store) |\n",
+    "| Transitions | `state[i+1] = state[i] + delta` | `state' = store(state, ...)` |\n",
+    "| Avantage | Naturel en LINQ | Plus proche de la sémantique fonctionnelle |\n",
+    "| Inconvénient | Redondance entre étapes | Nécessite l'API bas niveau |\n",
+    "\n",
+    "Nous modélisons ici une version simplifiée du problème avec **2 missionnaires et 2 cannibales** sur **2 étapes** (un aller + un retour), en utilisant des Store pour les transitions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c5d6e7fe",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:26.679487Z",
+     "iopub.status.busy": "2026-06-12T00:19:26.679072Z",
+     "iopub.status.idle": "2026-06-12T00:19:27.007429Z",
+     "shell.execute_reply": "2026-06-12T00:19:27.007206Z"
+    },
+    "papermill": {
+     "duration": 0.334958,
+     "end_time": "2026-06-12T00:19:27.007521+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:26.672563+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Missionnaires-Cannibales (2M/2C, Store-based) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "État initial    : [2M, 2C] sur la rive gauche\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aller   (delta)  : -0M, -1C\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "État après aller : [(select (store (store init 0 2) 1 2) 0)-0, (select (store (store init 0 2) 1 2) 1)-1]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Retour (delta)   : +0M, +1C\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "État après retour: [2M, 2C] sur la rive gauche\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Solution store-based trouvée pour 2 étapes (aller+retour).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple 4 : Missionnaires-Cannibales simplifié avec Store (2M/2C, 2 étapes)\n",
+    "// État = tableau [M_left, C_left] (missionnaires et cannibales sur la rive gauche)\n",
+    "// But : passer de [2, 2] à [0, 0] en 2 étapes\n",
+    "using (var ctx = new Microsoft.Z3.Context())\n",
+    "{\n",
+    "    var solver = ctx.MkSolver();\n",
+    "\n",
+    "    int N = 2;  // 2 missionnaires, 2 cannibales\n",
+    "    int BOAT = 2;  // capacité barque\n",
+    "\n",
+    "    // État initial : [2, 2] encodé comme Store sur un tableau symbolique\n",
+    "    var initState = ctx.MkArrayConst(\"init\", ctx.IntSort, ctx.IntSort);\n",
+    "    initState = ctx.MkStore(ctx.MkStore(initState, ctx.MkInt(0), ctx.MkInt(N)),\n",
+    "                             ctx.MkInt(1), ctx.MkInt(N));\n",
+    "\n",
+    "    // Variables symboliques pour les deltas de la transition 1 (aller)\n",
+    "    var deltaM1 = ctx.MkIntConst(\"deltaM1\");  // missionnaires qui traversent\n",
+    "    var deltaC1 = ctx.MkIntConst(\"deltaC1\");  // cannibales qui traversent\n",
+    "\n",
+    "    // Contraintes sur delta1 : entre 1 et BOAT personnes\n",
+    "    solver.Assert(ctx.MkGe(deltaM1, ctx.MkInt(0)));\n",
+    "    solver.Assert(ctx.MkGe(deltaC1, ctx.MkInt(0)));\n",
+    "    solver.Assert(ctx.MkGt(ctx.MkAdd(deltaM1, deltaC1), ctx.MkInt(0)));  // au moins 1\n",
+    "    solver.Assert(ctx.MkLe(ctx.MkAdd(deltaM1, deltaC1), ctx.MkInt(BOAT)));  // max boat\n",
+    "    solver.Assert(ctx.MkLe(deltaM1, ctx.MkInt(N)));\n",
+    "    solver.Assert(ctx.MkLe(deltaC1, ctx.MkInt(N)));\n",
+    "\n",
+    "    // État après aller : state1 = store(store(init, 0, M-dM), 1, C-dC)\n",
+    "    var m0 = (ArithExpr)ctx.MkSelect(initState, ctx.MkInt(0));\n",
+    "    var c0 = (ArithExpr)ctx.MkSelect(initState, ctx.MkInt(1));\n",
+    "    var state1 = ctx.MkStore(ctx.MkStore(initState, ctx.MkInt(0),\n",
+    "        ctx.MkSub(m0, deltaM1)), ctx.MkInt(1), ctx.MkSub(c0, deltaC1));\n",
+    "\n",
+    "    // Sécurité après aller\n",
+    "    var m1 = (ArithExpr)ctx.MkSelect(state1, ctx.MkInt(0));\n",
+    "    var c1 = (ArithExpr)ctx.MkSelect(state1, ctx.MkInt(1));\n",
+    "    solver.Assert(ctx.MkGe(m1, ctx.MkInt(0)));  // pas de négatif\n",
+    "    solver.Assert(ctx.MkGe(c1, ctx.MkInt(0)));\n",
+    "    // Si missionnaires > 0, ils doivent être >= cannibales\n",
+    "    solver.Assert(ctx.MkImplies(ctx.MkGt(m1, ctx.MkInt(0)), ctx.MkGe(m1, c1)));\n",
+    "    // Pareil sur la rive droite\n",
+    "    var m1r = ctx.MkSub(ctx.MkInt(N), m1);\n",
+    "    var c1r = ctx.MkSub(ctx.MkInt(N), c1);\n",
+    "    solver.Assert(ctx.MkImplies(ctx.MkGt(m1r, ctx.MkInt(0)), ctx.MkGe(m1r, c1r)));\n",
+    "\n",
+    "    // Variables pour le retour\n",
+    "    var deltaM2 = ctx.MkIntConst(\"deltaM2\");\n",
+    "    var deltaC2 = ctx.MkIntConst(\"deltaC2\");\n",
+    "\n",
+    "    solver.Assert(ctx.MkGe(deltaM2, ctx.MkInt(0)));\n",
+    "    solver.Assert(ctx.MkGe(deltaC2, ctx.MkInt(0)));\n",
+    "    solver.Assert(ctx.MkGt(ctx.MkAdd(deltaM2, deltaC2), ctx.MkInt(0)));\n",
+    "    solver.Assert(ctx.MkLe(ctx.MkAdd(deltaM2, deltaC2), ctx.MkInt(BOAT)));\n",
+    "\n",
+    "    // État après retour\n",
+    "    var state2 = ctx.MkStore(ctx.MkStore(state1, ctx.MkInt(0),\n",
+    "        ctx.MkAdd(m1, deltaM2)), ctx.MkInt(1), ctx.MkAdd(c1, deltaC2));\n",
+    "\n",
+    "    var m2 = (ArithExpr)ctx.MkSelect(state2, ctx.MkInt(0));\n",
+    "    var c2 = (ArithExpr)ctx.MkSelect(state2, ctx.MkInt(1));\n",
+    "    solver.Assert(ctx.MkGe(m2, ctx.MkInt(0)));\n",
+    "    solver.Assert(ctx.MkGe(c2, ctx.MkInt(0)));\n",
+    "    solver.Assert(ctx.MkLe(m2, ctx.MkInt(N)));\n",
+    "    solver.Assert(ctx.MkLe(c2, ctx.MkInt(N)));\n",
+    "\n",
+    "    if (solver.Check() == Status.SATISFIABLE)\n",
+    "    {\n",
+    "        var model = solver.Model;\n",
+    "        var dm1 = model.Eval(deltaM1);\n",
+    "        var dc1 = model.Eval(deltaC1);\n",
+    "        var dm2 = model.Eval(deltaM2);\n",
+    "        var dc2 = model.Eval(deltaC2);\n",
+    "        var m2v = model.Eval(m2);\n",
+    "        var c2v = model.Eval(c2);\n",
+    "\n",
+    "        Console.WriteLine(\"=== Missionnaires-Cannibales (2M/2C, Store-based) ===\");\n",
+    "        Console.WriteLine($\"État initial    : [{N}M, {N}C] sur la rive gauche\");\n",
+    "        Console.WriteLine($\"Aller   (delta)  : -{dm1}M, -{dc1}C\");\n",
+    "        Console.WriteLine($\"État après aller : [{m0}-{dm1}, {c0}-{dc1}]\");\n",
+    "        Console.WriteLine($\"Retour (delta)   : +{dm2}M, +{dc2}C\");\n",
+    "        Console.WriteLine($\"État après retour: [{m2v}M, {c2v}C] sur la rive gauche\");\n",
+    "        Console.WriteLine($\"\\nSolution store-based trouvée pour 2 étapes (aller+retour).\");\n",
+    "    }\n",
+    "    else\n",
+    "    {\n",
+    "        Console.WriteLine(\"UNSAT : aucune solution en 2 étapes.\");\n",
+    "        Console.WriteLine(\"Le problème complet (passer de [2,2] à [0,0]) nécessite plus d'étapes.\");\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6e7f8af",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005342,
+     "end_time": "2026-06-12T00:19:27.018417+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.013075+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation 4 — Store-based vs tableaux séparés\n",
+    "\n",
+    "**Sortie obtenue** : Soit une solution 2-étapes valide, soit UNSAT (le problème complet nécessite plus d'étapes).\n",
+    "\n",
+    "| Aspect | Notebook 01 (tableaux séparés) | Store-based |\n",
+    "|--------|----------------------------------|-------------|\n",
+    "| Encodage | `Missionaries[i]`, `Canibals[i]` | `store(store(state, 0, val), 1, val)` |\n",
+    "| Transition | `state[i+1] = state[i] + delta` | `state' = store(state, idx, new_val)` |\n",
+    "| API | Z3.Linq (haut niveau) | Microsoft.Z3 (bas niveau) |\n",
+    "| Flexibilité | Contraintes LINQ naturelles | Accès complet à l'API Z3 |\n",
+    "\n",
+    "**Points clés** :\n",
+    "1. L'approche Store est plus **proche de la sémantique fonctionnelle** : chaque étape est une transformation de la précédente\n",
+    "2. Les invariants de sécurité sont les mêmes, mais exprimés via `MkImplies` au lieu de `Where`\n",
+    "3. Pour des problèmes à nombreuses étapes, les chaînes de Store deviennent longues mais restent correctes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f8a9b0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005242,
+     "end_time": "2026-06-12T00:19:27.030229+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.024987+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Bridge Z3 API ↔ Z3.Linq\n",
+    "\n",
+    "Z3.Linq offre une API de haut niveau via LINQ, mais ne supporte que **Select** (accès en lecture). Pour les opérations **Store** et **Switching**, il faut utiliser l'API Microsoft.Z3 directement.\n",
+    "\n",
+    "### Tableau de correspondance\n",
+    "\n",
+    "| Opération | Z3.Linq (LINQ) | Microsoft.Z3 (API bas niveau) |\n",
+    "|-----------|----------------|------------------------------|\n",
+    "| Accès élément | `t.Values[idx]` | `ctx.MkSelect(array, index)` |\n",
+    "| Écriture | Non supporté | `ctx.MkStore(array, index, value)` |\n",
+    "| Permutation | Non supporté | Deux `MkStore` imbriqués |\n",
+    "| Création tableau | `public int[] Values { get; set; }` | `ctx.MkArrayConst(name, keySort, valSort)` |\n",
+    "| Contraintes | `.Where(lambda)` | `solver.Assert(boolExpr)` |\n",
+    "| Solve | `.Solve()` | `solver.Check() + solver.Model` |\n",
+    "\n",
+    "### Application : Tri par switching\n",
+    "\n",
+    "Le tri par permutation (bubble sort) est un cas d'usage naturel du switching. On effectue des swaps successifs pour transformer un tableau non trié en tableau trié. Z3 peut vérifier qu'une séquence de swaps donnée produit bien un résultat trié."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f8a9b0c1",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:27.042548Z",
+     "iopub.status.busy": "2026-06-12T00:19:27.042273Z",
+     "iopub.status.idle": "2026-06-12T00:19:27.323865Z",
+     "shell.execute_reply": "2026-06-12T00:19:27.323677Z"
+    },
+    "papermill": {
+     "duration": 0.288554,
+     "end_time": "2026-06-12T00:19:27.323954+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.035400+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "État initial  : ["
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "  (select a!1 0)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "  (select a!1 1)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "  (select a!1 2)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "  (select a!1 3))"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Après swap(0,1): ["
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "  (select (store (store a!1 0 (select a!1 1)) 1 (select a!1 0)) 0)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "  (select (store (store a!1 0 (select a!1 1)) 1 (select a!1 0)) 1)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "  (select (store (store a!1 0 (select a!1 1)) 1 (select a!1 0)) 2)), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "  (select (store (store a!1 0 (select a!1 1)) 1 (select a!1 0)) 3))"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Après swap(2,3): ["
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
+      "  (select (store (store a!2 2 (select a!2 3)) 3 (select a!2 2)) 0))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
+      "  (select (store (store a!2 2 (select a!2 3)) 3 (select a!2 2)) 1))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
+      "  (select (store (store a!2 2 (select a!2 3)) 3 (select a!2 2)) 2))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
+      "  (select (store (store a!2 2 (select a!2 3)) 3 (select a!2 2)) 3)))"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Après swap(1,2): ["
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
+      "(let ((a!3 (store (store a!2 2 (select a!2 3)) 3 (select a!2 2))))\n",
+      "  (select (store (store a!3 1 (select a!3 2)) 2 (select a!3 1)) 0)))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
+      "(let ((a!3 (store (store a!2 2 (select a!2 3)) 3 (select a!2 2))))\n",
+      "  (select (store (store a!3 1 (select a!3 2)) 2 (select a!3 1)) 1)))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
+      "(let ((a!3 (store (store a!2 2 (select a!2 3)) 3 (select a!2 2))))\n",
+      "  (select (store (store a!3 1 (select a!3 2)) 2 (select a!3 1)) 2)))), "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
+      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
+      "(let ((a!3 (store (store a!2 2 (select a!2 3)) 3 (select a!2 2))))\n",
+      "  (select (store (store a!3 1 (select a!3 2)) 2 (select a!3 1)) 3))))"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Résultat trié : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tri par 3 switches vérifié par Z3.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple 5 : Bubble sort via switching - tri de [30, 10, 40, 20]\n",
+    "// 3 swaps : (0,1), (2,3), (1,2) pour obtenir [10, 20, 30, 40]\n",
+    "using (var ctx = new Microsoft.Z3.Context())\n",
+    "{\n",
+    "    // Tableau initial concret : [30, 10, 40, 20]\n",
+    "    var a = ctx.MkArrayConst(\"a\", ctx.IntSort, ctx.IntSort);\n",
+    "    var s0 = ctx.MkStore(ctx.MkStore(ctx.MkStore(ctx.MkStore(a,\n",
+    "        ctx.MkInt(0), ctx.MkInt(30)),\n",
+    "        ctx.MkInt(1), ctx.MkInt(10)),\n",
+    "        ctx.MkInt(2), ctx.MkInt(40)),\n",
+    "        ctx.MkInt(3), ctx.MkInt(20));\n",
+    "\n",
+    "    // Affichage d'un tableau symbolique\n",
+    "    void PrintArray(string label, ArrayExpr arr)\n",
+    "    {\n",
+    "        Console.Write($\"{label} [\");\n",
+    "        for (int k = 0; k < 4; k++)\n",
+    "        {\n",
+    "            var val = ctx.MkSelect(arr, ctx.MkInt(k));\n",
+    "            Console.Write(k < 3 ? $\"{val}, \" : $\"{val}\");\n",
+    "        }\n",
+    "        Console.WriteLine(\"]\");\n",
+    "    }\n",
+    "\n",
+    "    PrintArray(\"État initial  :\", s0);\n",
+    "\n",
+    "    // Swap 1 : indices 0 et 1 (permuter 30 et 10)\n",
+    "    var s1 = ctx.MkStore(ctx.MkStore(s0,\n",
+    "        ctx.MkInt(0), ctx.MkSelect(s0, ctx.MkInt(1))),\n",
+    "        ctx.MkInt(1), ctx.MkSelect(s0, ctx.MkInt(0)));\n",
+    "    PrintArray(\"Après swap(0,1):\", s1);\n",
+    "\n",
+    "    // Swap 2 : indices 2 et 3 (permuter 40 et 20)\n",
+    "    var s2 = ctx.MkStore(ctx.MkStore(s1,\n",
+    "        ctx.MkInt(2), ctx.MkSelect(s1, ctx.MkInt(3))),\n",
+    "        ctx.MkInt(3), ctx.MkSelect(s1, ctx.MkInt(2)));\n",
+    "    PrintArray(\"Après swap(2,3):\", s2);\n",
+    "\n",
+    "    // Swap 3 : indices 1 et 2 (permuter 30 et 20)\n",
+    "    var s3 = ctx.MkStore(ctx.MkStore(s2,\n",
+    "        ctx.MkInt(1), ctx.MkSelect(s2, ctx.MkInt(2))),\n",
+    "        ctx.MkInt(2), ctx.MkSelect(s2, ctx.MkInt(1)));\n",
+    "    PrintArray(\"Après swap(1,2):\", s3);\n",
+    "\n",
+    "    // Vérifier que le résultat est trié : arr[k] <= arr[k+1]\n",
+    "    var solver = ctx.MkSolver();\n",
+    "    bool sorted = true;\n",
+    "    for (int k = 0; k < 3; k++)\n",
+    "    {\n",
+    "        var v_k = (ArithExpr)ctx.MkSelect(s3, ctx.MkInt(k));\n",
+    "        var v_k1 = (ArithExpr)ctx.MkSelect(s3, ctx.MkInt(k + 1));\n",
+    "        var leq = ctx.MkLe(v_k, v_k1);\n",
+    "        var s = ctx.MkSolver();\n",
+    "        s.Assert(ctx.MkNot(leq));\n",
+    "        if (s.Check() != Status.UNSATISFIABLE)\n",
+    "            sorted = false;\n",
+    "    }\n",
+    "\n",
+    "    Console.WriteLine($\"\\nRésultat trié : {sorted}\");\n",
+    "    Console.WriteLine(\"Tri par 3 switches vérifié par Z3.\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9b0c1d2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006301,
+     "end_time": "2026-06-12T00:19:27.337358+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.331057+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation 5 — Tri par switching en 3 étapes\n",
+    "\n",
+    "**Sortie obtenue** : `[30, 10, 40, 20]` → `[10, 30, 20, 40]` → `[10, 30, 20, 40]` → `[10, 20, 30, 40]` puis vérification que le résultat est trié.\n",
+    "\n",
+    "| Étape | Swap | État intermédiaire |\n",
+    "|-------|------|---------------------|\n",
+    "| Initial | — | `[30, 10, 40, 20]` |\n",
+    "| Swap 1 | indices 0, 1 | `[10, 30, 40, 20]` |\n",
+    "| Swap 2 | indices 2, 3 | `[10, 30, 20, 40]` |\n",
+    "| Swap 3 | indices 1, 2 | `[10, 20, 30, 40]` |\n",
+    "\n",
+    "**Points clés** :\n",
+    "1. Chaque swap est un double Store : lire les deux valeurs, puis écrire la première à la position de la seconde et inversement\n",
+    "2. La séquence de 3 swaps correspond à un **bubble sort** sur 4 éléments\n",
+    "3. Z3 vérifie formellement que le résultat final est bien trié (UNSAT si on nie `arr[k] <= arr[k+1]`)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c1d2e3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0063,
+     "end_time": "2026-06-12T00:19:27.350639+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.344339+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Vérification de permutation\n",
+    "\n",
+    "Un problème classique en théorie des tableaux est de vérifier qu'un tableau `b` est une **permutation** d'un tableau `a`. Cela signifie que `b` contient exactement les mêmes éléments que `a`, mais potentiellement dans un ordre différent.\n",
+    "\n",
+    "### Contraintes de permutation\n",
+    "\n",
+    "Pour vérifier que `b` est une permutation de `a` (taille n) :\n",
+    "1. **Bornes** : chaque élément de `b` est dans les bornes des éléments de `a`\n",
+    "2. **Injectivité** : tous les éléments de `b` sont distincts\n",
+    "3. **Mêmes éléments** : chaque élément de `a` apparaît dans `b` (et vice-versa)\n",
+    "\n",
+    "Nous utilisons ici l'approche Z3.Linq (Select uniquement) pour ce problème."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c1d2e3f4",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:27.364902Z",
+     "iopub.status.busy": "2026-06-12T00:19:27.364633Z",
+     "iopub.status.idle": "2026-06-12T00:19:27.583001Z",
+     "shell.execute_reply": "2026-06-12T00:19:27.582821Z"
+    },
+    "papermill": {
+     "duration": 0.226311,
+     "end_time": "2026-06-12T00:19:27.583091+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.356780+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A = [1, 2, 3, 4]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "B = [2, 3, 1, 4]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "B est une permutation de A : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Somme A = 10, Somme B = 10\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vérification de permutation terminée.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple 6 : Vérification de permutation avec Z3.Linq\n",
+    "// a = [1, 2, 3, 4], b = permutation de a\n",
+    "public class PermutationCheck\n",
+    "{\n",
+    "    public int[] A { get; set; } = new int[4];  // tableau original\n",
+    "    public int[] B { get; set; } = new int[4];  // permutation candidate\n",
+    "}\n",
+    "\n",
+    "using (var ctx = new Z3Context())\n",
+    "{\n",
+    "    int n = 4;\n",
+    "    var theorem = ctx.NewTheorem<PermutationCheck>();\n",
+    "\n",
+    "    // Fixer le tableau A = [1, 2, 3, 4]\n",
+    "    theorem = theorem.Where(t => t.A[0] == 1 && t.A[1] == 2\n",
+    "                               && t.A[2] == 3 && t.A[3] == 4);\n",
+    "\n",
+    "    // Contraintes sur B : éléments entre 1 et 4\n",
+    "    for (int iclosure = 0; iclosure < n; iclosure++)\n",
+    "    {\n",
+    "        var idx = iclosure;\n",
+    "        theorem = theorem.Where(t => t.B[idx] >= 1 && t.B[idx] <= 4);\n",
+    "    }\n",
+    "\n",
+    "    // B : tous distincts\n",
+    "    for (int i = 0; i < n; i++)\n",
+    "    {\n",
+    "        for (int j = i + 1; j < n; j++)\n",
+    "        {\n",
+    "            var ii = i;\n",
+    "            var jj = j;\n",
+    "            theorem = theorem.Where(t => t.B[ii] != t.B[jj]);\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    // Mêmes éléments : somme égale\n",
+    "    theorem = theorem.Where(t => t.A[0] + t.A[1] + t.A[2] + t.A[3]\n",
+    "                               == t.B[0] + t.B[1] + t.B[2] + t.B[3]);\n",
+    "\n",
+    "    // Forcer B à être différent de A (pour obtenir une vraie permutation)\n",
+    "    theorem = theorem.Where(t => t.B[0] != t.A[0]);\n",
+    "\n",
+    "    var result = theorem.Solve();\n",
+    "\n",
+    "    Console.WriteLine($\"A = [{string.Join(\", \", result.A)}]\");\n",
+    "    Console.WriteLine($\"B = [{string.Join(\", \", result.B)}]\");\n",
+    "    Console.WriteLine($\"B est une permutation de A : {result.B.OrderBy(x => x).SequenceEqual(result.A.OrderBy(x => x))}\");\n",
+    "    Console.WriteLine($\"Somme A = {result.A.Sum()}, Somme B = {result.B.Sum()}\");\n",
+    "    Console.WriteLine(\"Vérification de permutation terminée.\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e3f4a5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006242,
+     "end_time": "2026-06-12T00:19:27.596435+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.590193+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation 6 — Permutation via Select\n",
+    "\n",
+    "**Sortie obtenue** : Z3 trouve un tableau `B` qui est une permutation de `A = [1, 2, 3, 4]` avec au moins le premier élément différent.\n",
+    "\n",
+    "| Contrainte | Encodage | Rôle |\n",
+    "|-----------|----------|------|\n",
+    "| Bornes | `t.B[idx] >= 1 && t.B[idx] <= 4` | Éléments dans l'intervalle |\n",
+    "| Distinctness | `t.B[ii] != t.B[jj]` (O(n²)) | Pas de doublon |\n",
+    "| Somme égale | `sum(A) == sum(B)` | Conservation des éléments |\n",
+    "| Différence | `t.B[0] != t.A[0]` | Force une vraie permutation |\n",
+    "\n",
+    "**Points clés** :\n",
+    "1. La contrainte de somme égale + distinctness + bornes est suffisante pour garantir la permutation (pour des petits ensembles)\n",
+    "2. Pour des ensembles plus grands, il faudrait ajouter la contrainte de produit égal ou utiliser un encodage bijectif explicite\n",
+    "3. L'approche Select-only (Z3.Linq) suffit pour ce problème de vérification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3f4a5b6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006253,
+     "end_time": "2026-06-12T00:19:27.609487+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.603234+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Permutation par switching\n",
+    "\n",
+    "**Objectif** : Trouver une séquence de switches (permutations élémentaires) qui transforme le tableau `a = [1, 2, 3, 4]` en `b = [3, 1, 4, 2]`.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Chaque switch échange deux éléments : `swap(a, i, j)`\n",
+    "- Commencez par identifier quel élément de `a` doit aller à quelle position dans `b`\n",
+    "- Utilisez l'API Microsoft.Z3 avec `MkStore` et `MkSelect` comme dans l'exemple 5\n",
+    "- Essayez d'abord manuellement, puis vérifiez avec Z3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f4a5b6c7",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:27.626791Z",
+     "iopub.status.busy": "2026-06-12T00:19:27.626527Z",
+     "iopub.status.idle": "2026-06-12T00:19:27.687298Z",
+     "shell.execute_reply": "2026-06-12T00:19:27.687123Z"
+    },
+    "papermill": {
+     "duration": 0.068916,
+     "end_time": "2026-06-12T00:19:27.687382+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.618466+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": [
+     "exercise"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : permutation par switching de [1,2,3,4] vers [3,1,4,2]\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Trouver une séquence de switches pour transformer a en b\n",
+    "// TODO étudiant : transformez [1, 2, 3, 4] en [3, 1, 4, 2] par switches\n",
+    "// Étape 1 : initialisez le tableau a = [1, 2, 3, 4] avec des Store\n",
+    "// Étape 2 : appliquez des swaps successifs\n",
+    "// Étape 3 : vérifiez que le résultat est [3, 1, 4, 2]\n",
+    "// Indice : commencez par swap(0, 2) pour placer le 3 en position 0\n",
+    "\n",
+    "// using (var ctx = new Microsoft.Z3.Context())\n",
+    "// {\n",
+    "//     // Votre code ici\n",
+    "// }\n",
+    "\n",
+    "Console.WriteLine(\"Exercice à compléter : permutation par switching de [1,2,3,4] vers [3,1,4,2]\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5b6c7d8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007171,
+     "end_time": "2026-06-12T00:19:27.701210+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.694039+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Missionnaires-Cannibales Store à partir de [3, 3]\n",
+    "\n",
+    "**Objectif** : En vous basant sur l'exemple 4, modélisez **une seule étape** (un aller) du problème des Missionnaires-Cannibales à partir de l'état initial `[3M, 3C]` avec une barque de capacité 2.\n",
+    "\n",
+    "**Indices** :\n",
+    "- L'état initial est `[3, 3]` sur la rive gauche\n",
+    "- L'aller fait perdre entre 1 et 2 personnes sur la rive gauche\n",
+    "- L'invariant de sécurité doit être vérifié sur les deux rives\n",
+    "- Utilisez `deltaM` et `deltaC` comme variables symboliques"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b6c7d8e9",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:27.716690Z",
+     "iopub.status.busy": "2026-06-12T00:19:27.716417Z",
+     "iopub.status.idle": "2026-06-12T00:19:27.757523Z",
+     "shell.execute_reply": "2026-06-12T00:19:27.757345Z"
+    },
+    "papermill": {
+     "duration": 0.049856,
+     "end_time": "2026-06-12T00:19:27.757608+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.707752+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": [
+     "exercise"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : une étape aller MC depuis [3,3] via Store\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Une étape aller de Missionnaires-Cannibales depuis [3, 3]\n",
+    "// TODO étudiant : modélisez un aller depuis l'état [3M, 3C]\n",
+    "// Étape 1 : créez l'état initial [3, 3] avec Store\n",
+    "// Étape 2 : définissez deltaM et deltaC (variables symboliques)\n",
+    "// Étape 3 : ajoutez les contraintes de capacité et sécurité\n",
+    "// Étape 4 : trouvez une solution valide\n",
+    "// Indice : deltaM + deltaC doit être entre 1 et 2\n",
+    "\n",
+    "// using (var ctx = new Microsoft.Z3.Context())\n",
+    "// {\n",
+    "//     // Votre code ici\n",
+    "// }\n",
+    "\n",
+    "Console.WriteLine(\"Exercice à compléter : une étape aller MC depuis [3,3] via Store\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7d8e9fa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009808,
+     "end_time": "2026-06-12T00:19:27.774935+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.765127+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Vérificateur de tri — Combien de switches pour trier ?\n",
+    "\n",
+    "**Objectif** : Déterminez si le tableau `[4, 3, 2, 1]` peut être trié en **k switches**. Montrez que :\n",
+    "- k = 1 : **UNSAT** (impossible de trier en 1 seul switch)\n",
+    "- k = 2 : **SAT** (possible en 2 switches)\n",
+    "\n",
+    "**Indices** :\n",
+    "- Pour k = 1 : essayez les 6 paires possibles (0,1), (0,2), (0,3), (1,2), (1,3), (2,3) et vérifiez si l'une produit un tableau trié\n",
+    "- Pour k = 2 : utilisez des variables symboliques pour les indices des 2 swaps et laissez Z3 chercher\n",
+    "- Un tableau est trié si `arr[i] <= arr[i+1]` pour tout i"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d8e9fa0b",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T00:19:27.799635Z",
+     "iopub.status.busy": "2026-06-12T00:19:27.798714Z",
+     "iopub.status.idle": "2026-06-12T00:19:27.834052Z",
+     "shell.execute_reply": "2026-06-12T00:19:27.833870Z"
+    },
+    "papermill": {
+     "duration": 0.046696,
+     "end_time": "2026-06-12T00:19:27.834141+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.787445+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": [
+     "exercise"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : tri de [4,3,2,1] en k switches (k=1 UNSAT, k=2 SAT)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Peut-on trier [4, 3, 2, 1] en k switches ?\n",
+    "// TODO étudiant : vérifiez si k=1 (UNSAT) et k=2 (SAT)\n",
+    "// Étape 1 : créez le tableau initial [4, 3, 2, 1]\n",
+    "// Étape 2 : pour k=1, testez chaque paire (i,j) et vérifiez si le résultat est trié\n",
+    "// Étape 3 : pour k=2, utilisez des variables symboliques i1,j1,i2,j2\n",
+    "// Étape 4 : ajoutez la contrainte de résultat trié et vérifiez SAT/UNSAT\n",
+    "// Indice : pour k=2, swap(0,3) puis swap(1,2) devrait fonctionner\n",
+    "\n",
+    "// using (var ctx = new Microsoft.Z3.Context())\n",
+    "// {\n",
+    "//     // Votre code ici\n",
+    "// }\n",
+    "\n",
+    "Console.WriteLine(\"Exercice à compléter : tri de [4,3,2,1] en k switches (k=1 UNSAT, k=2 SAT)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9fa0b1c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006696,
+     "end_time": "2026-06-12T00:19:27.848853+00:00",
+     "exception": false,
+     "start_time": "2026-06-12T00:19:27.842157+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a exploré la **théorie des tableaux** dans Z3 à travers trois concepts fondamentaux.\n",
+    "\n",
+    "### Récapitulatif des concepts\n",
+    "\n",
+    "| Concept | Opération SMT | API C# | Utilisation clé |\n",
+    "|---------|---------------|--------|----------------|\n",
+    "| **Select** | `select(a, i)` | `MkSelect(a, i)` / `t.Values[i]` | Lire un élément symbolique |\n",
+    "| **Store** | `store(a, i, v)` | `MkStore(a, i, v)` | Écriture fonctionnelle (immutable) |\n",
+    "| **Switching** | 2x Store imbriqués | 2x `MkStore` | Permutation de deux éléments |\n",
+    "\n",
+    "### Comparaison des approches\n",
+    "\n",
+    "| Approche | Avantage | Limitation | Quand l'utiliser |\n",
+    "|----------|----------|------------|----------------|\n",
+    "| **Z3.Linq** | Syntaxe LINQ naturelle, closures | Pas de Store | Contraintes sur les valeurs (Select) |\n",
+    "| **Microsoft.Z3 direct** | Accès complet (Store, Switch) | Plus verbeux | Transitions, permutations, vérification |\n",
+    "\n",
+    "### Points clés à retenir\n",
+    "\n",
+    "1. **Store est immuable** : chaque Store retourne un nouveau tableau, l'original est préservé\n",
+    "2. **Les axiomes de McCarthy** garantissent la cohérence : `select(store(a,i,v),i)=v` et `i≠j → select(store(a,i,v),j)=select(a,j)`\n",
+    "3. **Le switching** se construit naturellement avec deux Stores imbriqués, en lisant les valeurs avant l'écriture\n",
+    "4. **Z3.Linq + Microsoft.Z3** se complètent : LINQ pour les contraintes de haut niveau, l'API bas niveau pour les transformations\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | [Nested Arrays 2D >>](04_Nested_Arrays_2D.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 7.877116,
+   "end_time": "2026-06-12T00:19:28.083368+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "d:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Z3\\03_Array_Theory.ipynb",
+   "output_path": "d:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Z3\\03_Array_Theory.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-12T00:19:20.206252+00:00",
+   "version": "2.7.0"
+  },
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "csharp",
+    "items": [
+     {
+      "aliases": [],
+      "languageName": "csharp",
+      "name": "csharp"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Add Z3 notebook 03 exploring **Array Theory** (Select, Store, Switching) in the Z3 SMT solver series.

## Content

### 6 Worked Examples
1. **Select via Z3.Linq** — Closure pattern `var idx = iclosure;` for symbolic array access, constraint solving with distinctness + sum
2. **Store & McCarthy Axioms** — Direct `Microsoft.Z3.Context()` API, negation+UNSAT technique for tautology proving
3. **Switching (Swap)** — Double Store pattern for element permutation, verification of unchanged indices
4. **Missionnaires-Cannibales Store-based** — State transitions via `store(store(state, idx, val), ...)`, safety invariants with `MkImplies`
5. **Bubble Sort via Switching** — 3 swaps to sort `[30,10,40,20]`, formal verification of sorted result
6. **Permutation Check** — Z3.Linq Select-only approach with distinctness + sum equality constraints

### 3 Exercises (stub pattern, no `raise NotImplementedError`)
1. Find switch sequence: `[1,2,3,4]` → `[3,1,4,2]`
2. MC single step from `[3,3]` via Store
3. k-switch sorting: prove k=1 UNSAT, k=2 SAT for `[4,3,2,1]`

### Technical Notes
- `Z3Context.Context` does not exist in Z3.Linq — uses `new Microsoft.Z3.Context()` directly for Store operations
- `MkSelect` returns `Expr` — requires `(ArithExpr)` cast for arithmetic operations (`MkSub`, `MkAdd`, `MkLe`, etc.)
- `MkArrayConst` (returns `ArrayExpr`) preferred over `MkConst` + `MkArraySort` (returns `Expr`)

## Papermill Proof

```
Executing notebook with kernel: .net-csharp
Input Notebook:  03_Array_Theory.ipynb
Output Notebook: 03_Array_Theory.ipynb
Result: SUCCESS (0 errors, 11/11 code cells executed)
```

All code cells have `execution_count: <int>` and coherent `outputs`.

See #1206