### PR TITLE
feat(lean): Grothendieck Part 19 -- conservative families of points + Part 18 ConstantSheaf (See #2159)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -35,3 +35,5 @@ import Grothendieck.LeftExact
 import Grothendieck.Subcanonical
 import Grothendieck.SitePoints
 import Grothendieck.SheafHom
+import Grothendieck.ConstantSheaf
+import Grothendieck.Conservative

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Conservative.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Conservative.lean
@@ -1,0 +1,226 @@
+/-
+Grothendieck Part 19 -- Conservative families of points
+
+Part 18 (ConstantSheaf.lean) introduced the constant sheaf functor and its
+adjunction with global sections.
+
+This module introduces **conservative families of points** (SGA 4 IV 6.5):
+a family P of points of a site (C, J) is conservative if the corresponding
+fiber functors Sheaf J (Type w) ⥤ Type w jointly reflect isomorphisms.
+This is the abstract formulation of the principle that "enough points detect
+everything" -- the categorical generalization of "enough stalks detect
+isomorphisms/monos/epis".
+
+Key constructions bridged from Mathlib (`CategoryTheory.Sites.Point.Conservative`):
+
+  - `ObjectProperty.IsConservativeFamilyOfPoints` : the core structure
+  - `jointlyReflectIsomorphisms` : fiber functors jointly reflect isos (general A)
+  - `jointlyReflectMonomorphisms` : fiber functors jointly reflect monos
+  - `jointlyReflectEpimorphisms` : fiber functors jointly reflect epis
+  - `jointlyFaithful` : fiber functors are jointly faithful
+  - `mk'` : constructor via covering sieve condition (SGA 4 IV 6.5 (a))
+  - `jointly_reflect_ofArrows_mem` : detection of covering sieves via points
+  - `GrothendieckTopology.HasEnoughPoints` : site has enough points
+
+Plus skyscraper sheaves from `CategoryTheory.Sites.Point.Skyscraper`:
+  - `skyscraperPresheaf` / `skyscraperSheaf` : skyscraper constructions
+  - `skyscraperSheafAdjunction` : fiber ⊣ skyscraper adjunction
+  - `presheafToSheafCompSheafFiberIso` : fiber as localization
+
+This is a key ingredient for understanding when a topos has "enough points"
+and for the theory of stalkwise detection of morphism properties.
+
+Epic #1646, See #2159. All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.Point.Conservative
+
+universe v v' u u' w
+
+namespace Grothendieck.Conservative
+
+open CategoryTheory Category Opposite Limits
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+variable (P : ObjectProperty (GrothendieckTopology.Point.{w} J))
+
+/-! ## 1. Conservative families of points
+
+A family P of points is "conservative" if the fiber functors
+`Sheaf J (Type w) ⥤ Type w` corresponding to the points in P
+jointly reflect isomorphisms. This is `ObjectProperty.IsConservativeFamilyOfPoints`
+from Mathlib, tagged as Stacks 00YK (1).
+
+Intuitively: a morphism f : F ⟶ G between sheaves is an iso iff
+it induces an iso on every stalk (fiber) at every point in P.
+-/
+
+-- A conservative family of points: fiber functors jointly reflect isomorphisms.
+#check @ObjectProperty.IsConservativeFamilyOfPoints
+
+/-! ## 2. Consequences for general coefficient categories
+
+When the coefficient category A has suitable properties (concrete, AB5, etc.),
+conservativity implies that the fiber functors Sheaf J A ⥤ A jointly
+reflect isomorphisms, monomorphisms, and epimorphisms, and are jointly faithful.
+-/
+
+-- Fiber functors jointly reflect isomorphisms (general A).
+#check @ObjectProperty.IsConservativeFamilyOfPoints.jointlyReflectIsomorphisms
+
+-- Fiber functors jointly reflect monomorphisms (AB5 coefficient category).
+#check @ObjectProperty.IsConservativeFamilyOfPoints.jointlyReflectMonomorphisms
+
+-- Fiber functors jointly reflect epimorphisms (with sheafify + products).
+#check @ObjectProperty.IsConservativeFamilyOfPoints.jointlyReflectEpimorphisms
+
+-- Fiber functors are jointly faithful.
+#check @ObjectProperty.IsConservativeFamilyOfPoints.jointlyFaithful
+
+/-! ## 3. Detection via covering sieves (SGA 4 IV 6.5 (a))
+
+The constructor `mk'` shows that P is a conservative family if:
+for any sieve S on X, if for every point Phi in P the maps in S
+are jointly surjective on fibers, then S is J-covering.
+
+This is the practical criterion: to check conservativity, verify
+the covering sieve condition pointwise.
+-/
+
+-- Constructor: conservative family via covering sieve condition.
+#check @ObjectProperty.IsConservativeFamilyOfPoints.mk'
+
+/-! ## 4. Detection of covering sieves via points
+
+When P is conservative, a family of arrows {f_i : U_i ⟶ X} covers X
+(ie. generates a J-covering sieve) iff for every point Phi in P
+and every x in the fiber of X, some f_i hits x.
+-/
+
+-- Covering sieves detected via fiberwise joint surjectivity.
+#check @ObjectProperty.IsConservativeFamilyOfPoints.jointly_reflect_ofArrows_mem
+
+-- Variant for small families of points.
+#check @ObjectProperty.IsConservativeFamilyOfPoints.jointly_reflect_ofArrows_mem_of_small
+
+/-! ## 5. Local surjectivity detection
+
+A morphism of presheaves is locally surjective iff it is surjective
+on fibers at every point in a conservative family.
+-/
+
+-- Local surjectivity detected fiberwise via conservative family.
+#check @ObjectProperty.IsConservativeFamilyOfPoints.jointly_reflect_isLocallySurjective
+
+/-! ## 6. W iff iso on all fibers
+
+For a morphism f : F ⟶ G of presheaves, f belongs to J.W (the class
+of morphisms inverted by sheafification) iff f induces an iso on
+fibers at every point in the conservative family.
+-/
+
+-- J.W membership detected fiberwise.
+#check @ObjectProperty.IsConservativeFamilyOfPoints.W_iff
+
+/-! ## 7. HasEnoughPoints
+
+A site (C, J) "has enough points" if there exists a small conservative
+family of points. This is the condition ensuring that stalkwise reasoning
+is complete: everything detectable stalkwise is true.
+-/
+
+-- A site has enough points if there exists a small conservative family.
+#check @GrothendieckTopology.HasEnoughPoints
+
+/-! ## 8. Skyscraper sheaves and the fiber-skyscraper adjunction
+
+Given a point Phi and an object M : A, the skyscraper sheaf at M
+(with respect to Phi) is the sheaf that sends X : C to the product
+of copies of M indexed by Phi.fiber.obj X. The skyscraper sheaf
+functor is right adjoint to the sheaf fiber functor:
+
+  Phi.sheafFiber ⊣ Phi.skyscraperSheafFunctor
+-/
+
+-- The skyscraper presheaf functor.
+#check @GrothendieckTopology.Point.skyscraperPresheafFunctor
+
+-- The skyscraper presheaf with value M.
+#check @GrothendieckTopology.Point.skyscraperPresheaf
+
+-- The skyscraper presheaf is a sheaf.
+#check @GrothendieckTopology.Point.isSheaf_skyscraperPresheaf
+
+-- The skyscraper sheaf functor: A ⥤ Sheaf J A.
+#check @GrothendieckTopology.Point.skyscraperSheafFunctor
+
+-- The skyscraper sheaf with value M.
+#check @GrothendieckTopology.Point.skyscraperSheaf
+
+-- The adjunction: fiber functor ⊣ skyscraper sheaf functor (presheaf level).
+#check @GrothendieckTopology.Point.skyscraperPresheafAdjunction
+
+-- The adjunction: fiber functor ⊣ skyscraper sheaf functor (sheaf level).
+#check @GrothendieckTopology.Point.skyscraperSheafAdjunction
+
+/-! ## 9. Fiber functor as localization
+
+The fiber functor on sheaves is obtained from the fiber functor on presheaves
+by localization with respect to J.W. The isomorphism
+`presheafToSheafCompSheafFiberIso` witnesses this.
+-/
+
+-- The fiber functor on sheaves as a localization of the presheaf fiber.
+#check @GrothendieckTopology.Point.presheafToSheafCompSheafFiberIso
+
+-- J.W is inverted by the presheaf fiber functor.
+#check @GrothendieckTopology.Point.W_isInvertedBy_presheafFiber
+
+/-! ## 10. Bridge theorems
+
+Bridge theorems connecting conservative families to concrete verification.
+-/
+
+/-- Bridge theorem: when P is a conservative family of points, the fiber
+    functors at points in P jointly reflect isomorphisms for sheaves with
+    values in a general category A (given suitable assumptions on A).
+    This is the primary consequence of conservativity. -/
+theorem jointly_reflect_iso_bridge {A : Type u'} [Category.{v'} A]
+    [LocallySmall.{w} C] [HasColimitsOfSize.{w, w} A]
+    {FC : A → A → Type*} {CC : A → Type w}
+    [∀ (X Y : A), FunLike (FC X Y) (CC X) (CC Y)]
+    [ConcreteCategory.{w} A FC]
+    [(forget A).ReflectsIsomorphisms]
+    [PreservesFilteredColimitsOfSize.{w, w} (forget A)]
+    [J.HasSheafCompose (forget A)]
+    (hP : P.IsConservativeFamilyOfPoints) :
+    JointlyReflectIsomorphisms
+      (fun (Φ : P.FullSubcategory) ↦ Φ.obj.sheafFiber (A := A)) :=
+  hP.jointlyReflectIsomorphisms A
+
+/-- Bridge theorem: a conservative family of points makes the fiber functors
+    jointly faithful. This means: if two morphisms agree on all stalks
+    (fibers at all points in P), they are equal. -/
+theorem jointly_faithful_bridge {A : Type u'} [Category.{v'} A]
+    [LocallySmall.{w} C] [HasColimitsOfSize.{w, w} A]
+    {FC : A → A → Type*} {CC : A → Type w}
+    [∀ (X Y : A), FunLike (FC X Y) (CC X) (CC Y)]
+    [ConcreteCategory.{w} A FC]
+    [(forget A).ReflectsIsomorphisms]
+    [PreservesFilteredColimitsOfSize.{w, w} (forget A)]
+    [J.HasSheafCompose (forget A)]
+    [AB5OfSize.{w, w} A] [HasFiniteLimits A]
+    (hP : P.IsConservativeFamilyOfPoints) :
+    JointlyFaithful
+      (fun (Φ : P.FullSubcategory) ↦ Φ.obj.sheafFiber (A := A)) :=
+  hP.jointlyFaithful A
+
+/-- Bridge construction: the skyscraper sheaf adjunction for a point Phi.
+    Phi.sheafFiber is left adjoint to Phi.skyscraperSheafFunctor. -/
+noncomputable def skyscraper_adjunction_bridge {A : Type u'} [Category.{v'} A]
+    [HasProducts.{w} A] [HasColimitsOfSize.{w, w} A]
+    (Φ : GrothendieckTopology.Point.{w} J) :
+    Φ.sheafFiber (A := A) ⊣ Φ.skyscraperSheafFunctor :=
+  Φ.skyscraperSheafAdjunction
+
+end Grothendieck.Conservative

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/ConstantSheaf.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/ConstantSheaf.lean
@@ -1,0 +1,185 @@
+/-
+Grothendieck Part 18 — The constant sheaf
+
+Part 17 (SheafHom.lean) introduced the internal hom of sheaves, the first step
+toward Cartesian closed structure on Sheaf J (Type _).
+
+This module introduces the **constant sheaf functor** `constantSheaf J D`,
+defined as the sheafification of the constant presheaf. It is left adjoint
+to evaluation at a terminal object (constantSheafAdj), establishing a
+fundamental adjunction in Grothendieck topos theory.
+
+Key constructions bridged from Mathlib (`CategoryTheory.Sites.ConstantSheaf`):
+
+  - `constantPresheafAdj` : constant presheaf ⊣ evaluation at terminal object
+  - `constantSheaf J D` : the constant sheaf functor D ⥤ Sheaf J D
+  - `constantSheafAdj` : constantSheaf ⊣ sheafSections at terminal object
+  - `Sheaf.IsConstant` : predicate for sheaves in the essential image
+  - `Sheaf.isConstant_iff_isIso_counit_app` : constancy ↔ counit is iso
+  - `Sheaf.isConstant_iff_of_equivalence` : constancy invariant under equivalence
+  - `Sheaf.isConstant_iff_forget` : constancy through forgetful functors
+
+This is a key ingredient for understanding the "locally constant" nature of
+sheaves and for connecting sheaf theory to cohomology (SGA 4 II, IV).
+
+Epic #1646, See #2159. All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.ConstantSheaf
+
+universe v v' u u'
+
+namespace Grothendieck.ConstantSheaf
+
+open CategoryTheory Category Opposite Limits Functor Sheaf Adjunction
+
+variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
+variable {D : Type u'} [Category.{v'} D]
+
+/-! ## 1. The constant presheaf adjunction
+
+The constant presheaf functor `Functor.const Cᵒᵖ` sends an object X : D to the
+constant presheaf at X. When C has a terminal object T, this functor is left
+adjoint to evaluation at T (i.e., taking global sections).
+
+This adjunction lifts to sheaves via sheafification.
+-/
+
+-- The constant presheaf functor is left adjoint to evaluation at a terminal object.
+-- constantPresheafAdj : Functor.const Cᵒᵖ ⊣ (evaluation Cᵒᵖ D).obj (op T)
+#check @constantPresheafAdj
+
+/-! ## 2. The constant sheaf functor
+
+The constant sheaf functor `constantSheaf J D` is defined as the composition
+of the constant presheaf functor with sheafification:
+
+  constantSheaf J D = Functor.const Cᵒᵖ ⋙ presheafToSheaf J D
+
+It sends an object X : D to the sheafification of the constant presheaf at X.
+This requires `HasWeakSheafify J D` (existence of sheafification).
+-/
+
+-- The constant sheaf functor: sheafification of the constant presheaf.
+#check @constantSheaf
+
+/-- Bridge construction: the constant sheaf at an object X : D, defined as the
+    sheafification of the constant presheaf at X. -/
+noncomputable def constantSheafObj (X : D) [HasWeakSheafify J D] :
+    Sheaf J D :=
+  (constantSheaf J D).obj X
+
+/-! ## 3. The constant sheaf adjunction
+
+When C has a terminal object T, the constant sheaf functor is left adjoint
+to the "global sections" functor `sheafSections J D`.obj (op T):
+
+  constantSheaf J D ⊣ (sheafSections J D).obj (op T)
+
+This means: morphisms from the constant sheaf at X to a sheaf F correspond
+naturally to morphisms X ⟶ F.obj.obj (op T) in D.
+-/
+
+-- The constant sheaf adjunction: constantSheaf ⊣ evaluation at terminal object.
+#check @constantSheafAdj
+
+/-- Bridge theorem: given a terminal object T, the constant sheaf functor is
+    left adjoint to evaluation of sheaf sections at T. This is the fundamental
+    adjunction underlying constant sheaf theory. -/
+noncomputable def constantSheafAdjBridge {T : C} (hT : IsTerminal T)
+    [HasWeakSheafify J D] :
+    constantSheaf J D ⊣ (sheafSections J D).obj (op T) :=
+  constantSheafAdj J D hT
+
+/-! ## 4. The IsConstant predicate
+
+A sheaf F is "constant" if it lies in the essential image of the constant
+sheaf functor: there exists X : D such that F ≅ constantSheaf J D.obj X.
+
+This is a property, not structure — constancy is a proposition.
+-/
+
+-- A sheaf is constant if it is in the essential image of constantSheaf.
+#check @Sheaf.IsConstant
+
+-- If F is constant, it lies in the essential image of constantSheaf.
+#check @Sheaf.mem_essImage_of_isConstant
+
+-- Isomorphisms preserve constancy.
+#check @Sheaf.isConstant_congr
+
+-- An iso with a constant sheaf witnesses constancy.
+#check @Sheaf.isConstant_of_iso
+
+/-! ## 5. Characterization via the counit
+
+When the constant sheaf functor is fully faithful, a sheaf F is constant
+if and only if the counit of the constant sheaf adjunction applied to F
+is an isomorphism. This gives a practical criterion for constancy.
+-/
+
+-- When constantSheaf is fully faithful, constancy ↔ counit is iso.
+#check @Sheaf.isConstant_iff_isIso_counit_app
+
+/-- Bridge theorem: when the constant sheaf functor is fully faithful and
+    C has a terminal object T, a sheaf is constant iff the counit of the
+    adjunction applied to it is an isomorphism. -/
+theorem isConstant_iff_counit_iso [HasWeakSheafify J D]
+    [(constantSheaf J D).Faithful] [(constantSheaf J D).Full]
+    (F : Sheaf J D) {T : C} (hT : IsTerminal T) :
+    Sheaf.IsConstant J F ↔
+      IsIso ((constantSheafAdj J D hT).counit.app F) :=
+  CategoryTheory.Sheaf.isConstant_iff_isIso_counit_app J F hT
+
+/-! ## 6. Invariance under equivalence
+
+The property of being constant is invariant under equivalences of sheaf
+categories induced by dense subsites. If G : C ⥤ C' is a dense subsite
+morphism, then a sheaf on (C', K) is constant iff its pullback to (C, J)
+is constant.
+-/
+
+-- Constancy is invariant under equivalence of sheaf categories.
+#check @Sheaf.isConstant_iff_of_equivalence
+
+/-! ## 7. Constancy through forgetful functors
+
+Given a "forgetful" functor U : D ⥤ B, the property of being constant
+is detected by postcomposing with U (when U preserves sheafification and
+sheafCompose reflects isomorphisms).
+-/
+
+-- Constancy detected through forgetful functors.
+#check @Sheaf.isConstant_iff_forget
+
+/-! ## 8. Commutation with sheafCompose
+
+The constant sheaf functor commutes with `sheafCompose J U` up to
+isomorphism, provided that U preserves sheafification.
+-/
+
+-- constantSheaf commutes with sheafCompose up to iso.
+#check @constantCommuteCompose
+
+/-! ## 9. Bridge theorems: essential image and roundtrips
+
+The essential image characterization gives roundtrip properties connecting
+the IsConstant predicate to explicit witnesses.
+-/
+
+/-- Construction bridge: from an isomorphism with a constant sheaf, obtain
+    a witness that the sheaf is constant. Uses `Sheaf.isConstant_of_iso`. -/
+theorem isConstant_of_iso_bridge [HasWeakSheafify J D]
+    {F : Sheaf J D} {X : D}
+    (i : F ≅ (constantSheaf J D).obj X) :
+    Sheaf.IsConstant J F := by
+  exact CategoryTheory.Sheaf.isConstant_of_iso J i
+
+/-- Construction bridge: constancy is preserved by isomorphism.
+    Uses `Sheaf.isConstant_congr`. -/
+theorem isConstant_congr_bridge [HasWeakSheafify J D]
+    {F G : Sheaf J D} (i : F ≅ G) [Sheaf.IsConstant J F] :
+    Sheaf.IsConstant J G := by
+  exact CategoryTheory.Sheaf.isConstant_congr J i
+
+end Grothendieck.ConstantSheaf


### PR DESCRIPTION
## Summary

Part 19 of the Grothendieck Lean formalization series (#2159, Epic #1646).

### New module: `Grothendieck/Conservative.lean` (Part 19)

Bridges Mathlib `CategoryTheory.Sites.Point.Conservative` into the Grothendieck namespace.

**Key constructions:**
- `ObjectProperty.IsConservativeFamilyOfPoints` — fiber functors jointly reflect isomorphisms (Stacks 00YK)
- `jointlyReflectIsomorphisms` / `jointlyReflectMonomorphisms` / `jointlyReflectEpimorphisms` / `jointlyFaithful` — consequences for general coefficient categories
- `mk` — constructor via covering sieve condition (SGA 4 IV 6.5 (a))
- `jointly_reflect_ofArrows_mem` — detection of covering sieves via points
- `jointly_reflect_isLocallySurjective` — local surjectivity detection
- `W_iff` — J.W membership detected fiberwise
- `GrothendieckTopology.HasEnoughPoints` — sites with enough points
- Skyscraper sheaves: `skyscraperPresheaf`, `skyscraperSheaf`, `skyscraperSheafAdjunction`
- `presheafToSheafCompSheafFiberIso` — fiber functor as localization

**Bridge theorems:**
- `jointly_reflect_iso_bridge` — primary consequence of conservativity
- `jointly_faithful_bridge` — joint faithfulness
- `skyscraper_adjunction_bridge` — fiber ⊣ skyscraper adjunction

### Included: `Grothendieck/ConstantSheaf.lean` (Part 18)

Carried over from PR #2843 (not yet merged into main). Constant sheaf functor, adjunction with global sections, IsConstant predicate.

## Validation

```
lake build Grothendieck.Conservative  # 1347 jobs SUCCESS
lake build Grothendieck               # 2566 jobs SUCCESS
grep -cE "^\s*sorry\b" Conservative.lean  # 0
grep -cE "^\s*sorry\b" ConstantSheaf.lean # 0
```

All `sorry`s eliminated at creation. See #2159.