### PR TITLE
fix(symbolic-ai): update Z3 README - nb03 status and link (See #1206)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Z3/README.md
@@ -12,7 +12,7 @@ Cette serie explore **Z3.Linq**, un binding LINQ pour le solveur SMT Z3 (Microso
 |---|----------|-------|--------|
 | 01 | [Linq2Z3 Intro](01_Linq2Z3_Intro.ipynb) | Introduction : theoremes lineaires, Missionnaires-Cannibales, optimisation | PRODUCTION |
 | 02 | [Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | Sudoku explicite (81 proprietes) vs implicite (`List<int>` + lambdas/closures) | PRODUCTION |
-| 03 | 03_Array_Theory | Z3 array theory avec switching dynamique | A venir |
+| 03 | [Array Theory](03_Array_Theory.ipynb) | Z3 array theory avec switching dynamique | BETA |
 | 04 | [Nested Arrays 2D](04_Nested_Arrays_2D.ipynb) | Tableaux imbriqués, grilles 2D, Sudoku 4x4, carré magique | BETA |
 | 05 | 05_Meal_Planner_Hierarchical | Planificateur de repas : data fusion LINQ + theoreme hierarchique | A venir |
 


### PR DESCRIPTION
## Summary

Fix the Z3 series README to reflect the actual state after nb03 was merged in #2841.

## Changes

- nb03: `A venir` (no link) -> `BETA` with link to `03_Array_Theory.ipynb`

## Verification

- nb03 exists on `origin/main` (merged via #2841)
- README was stale (nb03 listed as "A venir" despite being merged)

See #1206