### PR TITLE
feat(argumentation): vendoring shim layer for Argument Analysis (Phase B.1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/__init__.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/__init__.py
@@ -1,0 +1,12 @@
+# argumentation_lib — vendored shim layer for Argument Analysis notebooks
+#
+# Provides the public API consumed by CoursIA notebooks, decoupled from
+# the EPITA `argumentation_analysis` internals.  All heavy imports are
+# lazy; importing this module alone must succeed without the EPITA package.
+#
+# Phase B.1 — shims only.  Core vendoring (agents, runner) comes in B.2.
+# See #2137 Phase B scope and acceptance criteria.
+
+__version__ = "0.1.0"
+
+# -- lazy re-exports (B.2 will populate these) --

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_config.py
@@ -1,0 +1,53 @@
+# _config.py — static configuration defaults for argumentation_lib
+#
+# Replaces EPITA's `config/settings.py` which reads `.env` and contains
+# hardcoded model names like `gpt-5-mini`. This shim provides ONLY static
+# defaults with ZERO secrets, ZERO model names, ZERO env reads.
+#
+# The actual LLM service is INJECTED at runtime (kernel SK + Config/settings.json).
+# This module never touches credentials.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class LibConfig:
+    """Static defaults for the argumentation library.
+
+    No secrets. No model names. No env reads.
+    The LLM kernel is built inline in notebooks and injected into agents.
+    """
+
+    # --- Tweety / JVM ---
+    tweety_jar_dir: Optional[str] = None  # auto-detected by _jvm_compat
+
+    # --- Pipeline ---
+    max_turns_per_phase: int = 5
+    max_conversation_turns: int = 20
+
+    # --- Agents ---
+    enable_tracing: bool = False
+    trace_log_dir: str = "logs"
+
+    # --- Reporting ---
+    enable_enhanced_reporting: bool = False
+
+    # --- Paths ---
+    ontology_dir: str = "ontologies"
+    data_dir: str = "data"
+
+
+# Singleton default config
+DEFAULT_CONFIG = LibConfig()
+
+
+def get_config() -> LibConfig:
+    """Return the default static configuration.
+
+    Future: could be extended to read from a notebook-local config file,
+    but NEVER from env vars with secret fallbacks.
+    """
+    return DEFAULT_CONFIG

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_jvm_compat.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_jvm_compat.py
@@ -1,0 +1,71 @@
+# _jvm_compat.py — JVM initialization shim
+#
+# Bridges EPITA's `initialize_jvm` / `shutdown_jvm` / `is_jvm_started`
+# contract to CoursIA's `init_tweety()` (Tweety/tweety_init.py).
+#
+# CoursIA's Tweety infrastructure is SUPERIOR to EPITA's jvm_setup.py
+# (idempotent init, 35+ modules v1.30, Clingo/SPASS/EProver/SAT/JDK17).
+# We REUSE CoursIA infra, NOT vendor jvm_setup.py.
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+_logger = logging.getLogger("argumentation_lib._jvm_compat")
+
+# Cache: was the JVM initialized by us?
+_jvm_initialized: bool = False
+
+
+def initialize_jvm() -> bool:
+    """Initialize the JVM via CoursIA's Tweety infrastructure.
+
+    Compatible with EPITA's ``core.jvm_setup.initialize_jvm`` contract:
+    returns True on success, False on failure.
+
+    Delegates to ``Tweety.tweety_init.init_tweety`` which is idempotent
+    (safe to call multiple times).
+    """
+    global _jvm_initialized
+    if _jvm_initialized:
+        _logger.debug("JVM already initialized (cached).")
+        return True
+
+    try:
+        # Import relative to SymbolicAI parent — notebooks add this to sys.path
+        from Tweety.tweety_init import init_tweety
+        result = init_tweety(verbose=False)
+        if result:
+            _jvm_initialized = True
+            _logger.info("JVM initialized via CoursIA Tweety infrastructure.")
+        return result
+    except Exception as e:
+        _logger.error("Failed to initialize JVM via Tweety: %s", e)
+        return False
+
+
+def is_jvm_started() -> bool:
+    """Check if the JVM is currently running."""
+    try:
+        import jpype
+        return jpype.isJVMStarted()
+    except ImportError:
+        return _jvm_initialized
+
+
+def shutdown_jvm() -> None:
+    """Shut down the JVM.
+
+    Warning: once shut down, it cannot be restarted in the same process.
+    Only call this at process exit.
+    """
+    global _jvm_initialized
+    try:
+        import jpype
+        if jpype.isJVMStarted():
+            jpype.shutdownJVM()
+            _jvm_initialized = False
+            _logger.info("JVM shut down.")
+    except Exception as e:
+        _logger.warning("Failed to shut down JVM: %s", e)

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_paths.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_paths.py
@@ -1,0 +1,61 @@
+# _paths.py — path management for argumentation_lib
+#
+# Replaces EPITA's path manipulation (sys.path.insert, environment_manager,
+# ensure_directories_exist side-effects). This module provides path resolution
+# WITHOUT import-time side effects. All functions are pure.
+
+from __future__ import annotations
+
+import pathlib
+from typing import Optional
+
+
+# Base directory = parent of argumentation_lib/ = Argument_Analysis/
+LIB_DIR = pathlib.Path(__file__).parent.resolve()
+ARGUMENT_ANALYSIS_DIR = LIB_DIR.parent
+SYMBOLIC_AI_DIR = ARGUMENT_ANALYSIS_DIR.parent
+
+
+def get_tweety_jar_dir() -> Optional[pathlib.Path]:
+    """Find the directory containing Tweety JAR files.
+
+    Search order:
+    1. Argument_Analysis/libs/ (local)
+    2. Tweety/libs/ (sibling series)
+    """
+    candidates = [
+        ARGUMENT_ANALYSIS_DIR / "libs",
+        SYMBOLIC_AI_DIR / "Tweety" / "libs",
+    ]
+    for d in candidates:
+        if d.exists() and any(d.glob("*.jar")):
+            return d
+    return None
+
+
+def get_ontology_dir() -> pathlib.Path:
+    """Return the ontology directory path."""
+    return ARGUMENT_ANALYSIS_DIR / "ontologies"
+
+
+def get_data_dir() -> pathlib.Path:
+    """Return the data directory path."""
+    return ARGUMENT_ANALYSIS_DIR / "data"
+
+
+def get_ext_tools_dir() -> pathlib.Path:
+    """Return the external tools directory path."""
+    return ARGUMENT_ANALYSIS_DIR / "ext_tools"
+
+
+def ensure_output_dirs(*dir_names: str) -> dict[str, pathlib.Path]:
+    """Create output directories on demand (NOT at import time).
+
+    Returns a dict of name -> resolved Path for each created directory.
+    """
+    result = {}
+    for name in dir_names:
+        p = ARGUMENT_ANALYSIS_DIR / name
+        p.mkdir(parents=True, exist_ok=True)
+        result[name] = p
+    return result

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_reporting_noop.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_reporting_noop.py
@@ -1,0 +1,64 @@
+# _reporting_noop.py — no-op reporting shims
+#
+# Replaces the 7 symbols imported from
+# ``argumentation_analysis.reporting.enhanced_real_time_trace_analyzer``.
+#
+# The real reporting system writes trace files to disk and captures
+# orchestration metadata — useful for EPITA's research pipeline but
+# unnecessary for CoursIA pedagogical notebooks.  These stubs let the
+# runner code import without error and produce clean no-ops.
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class EnhancedGlobalTraceAnalyzer:
+    """No-op trace analyzer."""
+
+    def get_report(self) -> dict[str, Any]:
+        return {}
+
+
+# Singleton matching EPITA's module-level instance
+enhanced_global_trace_analyzer = EnhancedGlobalTraceAnalyzer()
+
+
+def start_enhanced_pm_capture() -> None:
+    """No-op: start trace capture."""
+    pass
+
+
+def stop_enhanced_pm_capture() -> None:
+    """No-op: stop trace capture."""
+    pass
+
+
+def start_pm_orchestration_phase(
+    phase_id: str,
+    phase_name: str = "",
+    assigned_agents: Optional[List[str]] = None,
+) -> None:
+    """No-op: mark the start of an orchestration phase."""
+    pass
+
+
+def capture_shared_state(
+    phase_id: str = "",
+    tour_number: int = 0,
+    agent_active: str = "",
+    state_variables: Optional[Dict[str, Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """No-op: capture a shared-state snapshot."""
+    pass
+
+
+def get_enhanced_pm_report() -> dict[str, Any]:
+    """No-op: return the trace report."""
+    return {}
+
+
+def save_enhanced_pm_report(path: str) -> bool:
+    """No-op: save trace report to disk."""
+    return False


### PR DESCRIPTION
## Summary

Phase B.1 of #2137 — creates the `argumentation_lib/` shim layer that decouples the EPITA `argumentation_analysis` package from CoursIA notebooks.

### Files added (5, +261 lines)

| File | Role |
|------|------|
| `__init__.py` | Package entry, lazy re-exports |
| `_jvm_compat.py` | Bridges `initialize_jvm`/shutdown_jvm` → CoursIA `init_tweety()` |
| `_config.py` | Static defaults, 0 secrets, 0 model names, 0 env reads |
| `_paths.py` | Pure path resolution without import-time side effects |
| `_reporting_noop.py` | 7 no-op symbols replacing EPITA's trace analyzer |

### Acceptance B.1 partial

- [x] `python -c "import argumentation_lib"` → 0 `ModuleNotFoundError`
- [x] `grep gpt-5-mini / os.getenv(…," / tests.mocks` in executable code = **0**
- [x] Tweety JARs auto-detected via `_paths.get_tweety_jar_dir()`
- [x] No import-time side effects (no `sys.path.insert`, no `ensure_directories`)

### Next: B.2 (core vendoring)

The shims are infrastructure for B.2 which will vendor the actual agents, state management, and runner code.

See #2137