### PR TITLE
feat(qc): add Value Factor Z-Score pedagogical notebook (See #1405)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-08-ValueFactor-ZScore.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-08-ValueFactor-ZScore.ipynb
@@ -1,0 +1,292 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-Cloud-07-TemporalCNN <<](./QC-Py-Cloud-07-TemporalCNN.ipynb)\n",
+    "\n",
+    "# Value Factor Z-Score — Selection multi-facteurs fondamentaux\n",
+    "\n",
+    "**Source** : Projet etudiant ESGF 2026 (QC `31932810`), anonymise et adapte.\n",
+    "**Type** : `doc cloud` — resultats obtenus sur [QuantConnect Cloud](https://www.quantconnect.com/lab).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Objectifs d’apprentissage\n",
+    "\n",
+    "1. Comprendre le **Z-Score factoriel** : normaliser des fondamentaux hétérogènes en un score composite.\n",
+    "2. Distinguer **8 facteurs fondamentaux** et leur sens économique (value vs growth, qualité vs rendement).\n",
+    "3. Analyser pourquoi une stratégie value peut **sous-performer** pendant une décennie growth-dominée (2015-2024).\n",
+    "4. Interpréter les limites d’un backtest : Sharpe faible, PSR < 1%, drawdown élevé.\n",
+    "\n",
+    "**Prérequis** : Concepts de value investing, ratios financiers (P/E, ROE, FCF yield).\n",
+    "\n",
+    "**Durée estimée** : 30 min"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Concept : Le Z-Score multi-facteurs fondamental\n",
+    "\n",
+    "L’idée est simple : au lieu de trier les actions sur un seul critère (ex: P/E le plus bas), on combine **plusieurs facteurs fondamentaux** en un score unique.\n",
+    "\n",
+    "### Les 8 facteurs\n",
+    "\n",
+    "| Facteur | chemin fondamental | Sens | Direction favorisée |\n",
+    "|---------|-------------------|------|---------------------|\n",
+    "| Revenue Growth | `operation_ratios.revenue_growth` | Croissance du chiffre d’affaires | Supérieur = mieux |\n",
+    "| Gross Margin | `operation_ratios.gross_margin` | Marge brute | Supérieur = mieux |\n",
+    "| ROE | `operation_ratios.roe` | Retour sur capitaux propres | Supérieur = mieux |\n",
+    "| Operating Margin | `operation_ratios.operation_margin` | Marge opérationnelle | Supérieur = mieux |\n",
+    "| P/E Ratio | `valuation_ratios.pe_ratio` | Prix / bénéfices | **Inférieur = mieux** (value) |\n",
+    "| Book Yield | `valuation_ratios.book_value_yield` | Valeur comptable / prix | Supérieur = mieux |\n",
+    "| Earning Yield | `valuation_ratios.earning_yield` | Bénéfices / prix | Supérieur = mieux |\n",
+    "| FCF Yield | `valuation_ratios.fcf_yield` | Flux de trésorerie libres / prix | Supérieur = mieux |\n",
+    "\n",
+    "### Méthode\n",
+    "\n",
+    "1. **Sélection** : prendre les N actions les plus liquides (top 50 par dollar volume).\n",
+    "2. **Z-Score** : pour chaque facteur, calculer `(valeur - moyenne) / écart-type`.\n",
+    "3. **Inversion** : le P/E est inversé (`-z`) car un P/E bas = value.\n",
+    "4. **Composite** : moyenne des Z-Scores = score global.\n",
+    "5. **Sélection finale** : garder les top 10.\n",
+    "6. **Allocation** : équipondérée, rééquilibrage mensuel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Calcul du Z-Score composite\n",
+    "\n",
+    "Le Z-Score normalise chaque facteur pour les rendre comparables. Pour un vecteur de valeurs $x_1, \\ldots, x_n$ :\n",
+    "\n",
+    "$$z_i = \\frac{x_i - \\mu}{\\sigma}$$\n",
+    "\n",
+    "Implémentez la fonction `zscore_composite` qui prend une matrice de facteurs (lignes = actifs, colonnes = facteurs) et retourne le score composite pour chaque actif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exercice 1 : Calcul du Z-Score composite\n",
+    "# TODO etudiant : implémenter zscore_composite(factors_matrix, invert_cols=None)\n",
+    "# Indice : np.nanmean + np.nanstd sur axis=0, puis moyenne sur axis=1\n",
+    "# invert_cols : liste des indices de colonnes à inverser (ex: PE ratio)\n",
+    "def zscore_composite(factors_matrix, invert_cols=None):\n",
+    "    pass  # TODO etudiant : implémenter le Z-Score composite\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Le piège du value investing (2015-2024)\n",
+    "\n",
+    "La période 2015-2024 a été dominée par les **growth stocks** (FAANG/Mag7, tech, IA). Les facteurs value (P/E bas, book yield élevé) ont systématiquement sous-performé.\n",
+    "\n",
+    "### Pourquoi ?\n",
+    "\n",
+    "- **Taux bas** : l’argent gratuit favorise les entreprises en croissance rapide.\n",
+    "- **Concentration** : les Mag7 (Apple, Microsoft, Amazon, Google, Meta, Nvidia, Tesla) ont accaparé les rendements.\n",
+    "- **Intangibles** : les fondamentaux comptables traditionnels sous-évaluent les actifs incorporels (R&D, marques, réseaux).\n",
+    "- **Momentum croissance** : les actions growth ont bénéficié d’un cercle vertueux (appréciation → inflow → appréciation).\n",
+    "\n",
+    "### Résultat : la stratégie value Z-Score sur 2015-2024\n",
+    "\n",
+    "| Métrique | Valeur | Benchmark SPY (~) | Interprétation |\n",
+    "|----------|--------|--------------------|----------------|\n",
+    "| Sharpe | 0.227 | ~0.80-1.00 | **Sous-performance nette** |\n",
+    "| CAGR | 6.41% | ~15% | La moitié du marché |\n",
+    "| MaxDD | -36.5% | ~-25% (COVID) | Drawdown plus sévère |\n",
+    "| PSR | 0.8% | > 50% | **Non significatif** statistiquement |\n",
+    "\n",
+    "> **Leçon** : une stratégie value à fondamentaux solides (8 facteurs diversifiés) peut tout de même sous-performer pendant une décennie entière. Le value n’est pas un signal universel — il est **régime-dépendant**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Identifier les facteurs défavorisés dans un contexte growth\n",
+    "\n",
+    "Certains de nos 8 facteurs sont particulièrement pénalisés en période growth. Identifiez lesquels et pourquoi."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Analyse des facteurs en contexte growth\n",
+    "# TODO etudiant : pour chaque facteur, indiquer si il est favorisé ou pénalisé\n",
+    "# en période growth (2015-2024) avec une courte justification\n",
+    "factors_analysis = {\n",
+    "    \"revenue_growth\": None,  # TODO etudiant : \"favorisé\" ou \"pénalisé\" + raison\n",
+    "    \"gross_margin\": None,\n",
+    "    \"roe\": None,\n",
+    "    \"op_margin\": None,\n",
+    "    \"pe_ratio\": None,\n",
+    "    \"book_yield\": None,\n",
+    "    \"earning_yield\": None,\n",
+    "    \"fcf_yield\": None,\n",
+    "}\n",
+    "# Indice : les facteurs de valorisation (P/E, book yield) pénalisent les growth stocks\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Le code QC Cloud\n",
+    "\n",
+    "La stratégie `FundamentalZScoreAlgorithm` (projet QC `31932810`) :\n",
+    "\n",
+    "```python\n",
+    "class FundamentalZScoreAlgorithm(QCAlgorithm):\n",
+    "    def initialize(self):\n",
+    "        self.set_start_date(2015, 1, 1)\n",
+    "        self.set_end_date(2024, 12, 31)\n",
+    "        self.set_cash(100_000)\n",
+    "        \n",
+    "        # 8 facteurs fondamentaux\n",
+    "        self._factor_names = [\n",
+    "            \"revenue_growth\", \"gross_margin\", \"roe\", \"op_margin\",\n",
+    "            \"pe_ratio\", \"book_yield\", \"earning_yield\", \"fcf_yield\",\n",
+    "        ]\n",
+    "        # Sélection : top 50 par liquidité, puis top 10 par Z-Score composite\n",
+    "        self._liquid_universe_size = 50\n",
+    "        self._final_universe_size = 10\n",
+    "```\n",
+    "\n",
+    "Le cœur de la stratégie est dans `_select_assets` :\n",
+    "1. Tri par dollar_volume → top 50 liquides.\n",
+    "2. Extraction des 8 fondamentaux → matrice $50 \\times 8$.\n",
+    "3. Z-Score par colonne (inversion du P/E).\n",
+    "4. Composite = moyenne des Z-Scores.\n",
+    "5. Top 10 → équipondérée, rééquilibrage mensuel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Résultats QC Cloud\n",
+    "\n",
+    "**Projet QC Cloud** : `31932810` (\"Clone of Equity Aroon Trend\" — nom trompeur, la classe est `FundamentalZScoreAlgorithm`).\n",
+    "**Période** : 2015-01-01 → 2024-12-31 (10 ans).\n",
+    "\n",
+    "| Métrique | Valeur |\n",
+    "|----------|--------|\n",
+    "| **Sharpe** | 0.227 |\n",
+    "| **CAGR** | 6.41% |\n",
+    "| **MaxDD** | -36.5% |\n",
+    "| **PSR** | 0.8% |\n",
+    "| **Tradeable days** | 2516 |\n",
+    "\n",
+    "### Interprétation\n",
+    "\n",
+    "**Sharpe 0.227** : en dessous du seuil de rentabilité ajustée au risque. SPY a un Sharpe ~0.8-1.0 sur la même période. La stratégie ne compense pas le risque pris.\n",
+    "\n",
+    "**CAGR 6.41%** : moins de la moitié du rendement du marché (~15%). En termes réels (après inflation), le rendement est marginal.\n",
+    "\n",
+    "**MaxDD -36.5%** : pire que le benchmark. La diversification sur 10 actions value n’a pas protégé pendant les crises (COVID 2020, taux montants 2022).\n",
+    "\n",
+    "**PSR 0.8%** : le Probabilistic Sharpe Ratio est proche de zéro. Cela signifie que le Sharpe observé (0.227) n’est **statistiquement pas distinguishable de zéro**. Le signal est du bruit, pas de l’alpha.\n",
+    "\n",
+    "> **Conclusion** : la stratégie fonctionne en théorie (value factor académiquement valide), mais **échoue en pratique** sur cette décennie spécifique. C’est un cas d’école du risque de **régime dependency**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Proposer une amélioration régime-aware\n",
+    "\n",
+    "Une stratégie value ne fonctionne pas dans tous les régimes de marché. Proposez un mécanisme simple pour désactiver le signal value quand le régime est défavorable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Amélioration régime-aware\n",
+    "# TODO etudiant : implémenter detect_growth_regime(spy_prices, lookback=252) -> bool\n",
+    "# Indice : comparer le rendement de SPY vs un proxy value (ex: VTV ETF)\n",
+    "# Si SPY >> VTV sur lookback jours, le régime est growth -> désactiver le signal value\n",
+    "def detect_growth_regime(spy_prices, lookback=252):\n",
+    "    return False  # TODO etudiant : implémenter la détection de régime\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Leçon principale : Le value n’est pas un signal universel\n",
+    "\n",
+    "### Points clés\n",
+    "\n",
+    "1. **Le value factor est régime-dépendant** : il fonctionne sur de longues périodes (Fama-French, 1992-2020) mais peut sous-performer pendant une décennie entière.\n",
+    "\n",
+    "2. **Le Z-Score composite ne corrige pas le problème** : normaliser des fondamentaux ne change pas le fait que le marché préfère la croissance à la valeur comptable.\n",
+    "\n",
+    "3. **Le PSR est un filtre essentiel** : un Sharpe de 0.227 avec PSR < 1% = signal non significatif. Toujours vérifier la **significativité statistique** avant de déployer.\n",
+    "\n",
+    "4. **L’équipondérée sur 10 actions** concentre le risque : en période de stress, les corrélations montent et la diversification s’évapore.\n",
+    "\n",
+    "5. **Les fondamentaux traditionnels** (P/E, book value) sous-évaluent les entreprises à actifs incorporels dominants (tech, plateforme, IA).\n",
+    "\n",
+    "### Pour aller plus loin\n",
+    "\n",
+    "- **Fama-French 5-factor model** : ajouter size, profitability, investment aux facteurs value et marché.\n",
+    "- **Regime detection** : utiliser le momentum relatif (growth vs value ETFs) comme filtre.\n",
+    "- **Dynamic weighting** : adapter l’allocation aux régimes détectés (value en régime value, growth en régime growth).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-Cloud-07-TemporalCNN <<](./QC-Py-Cloud-07-TemporalCNN.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Add `QC-Py-Cloud-08-ValueFactor-ZScore.ipynb` — a pedagogical notebook covering multi-factor fundamental Z-Score selection strategy.

**Source**: ESGF 2026 student project QC `31932810` (FundamentalZScoreAlgorithm), anonymized and adapted.
**Issue**: See #1405 (Tier 2 — risk education)

### Content

- **8 fundamental factors**: revenue growth, gross margin, ROE, operating margin, P/E ratio, book yield, earning yield, FCF yield
- **Method**: Z-Score normalization + composite scoring + equal-weighted monthly rebalancing
- **Educational angle**: value factor NEGATIVE over 2015-2024 growth decade — regime dependency lesson

### QC Cloud Backtest Results (project 31932810)

| Metric | Value |
|--------|-------|
| Sharpe | 0.227 |
| CAGR | 6.41% |
| MaxDD | -36.5% |
| PSR | 0.8% |
| Period | 2015-01-01 → 2024-12-31 |

### Structure

- 12 cells (9 markdown, 3 code)
- 3 exercises: Z-Score implementation, factor analysis in growth context, regime-aware improvement
- C.1 compliant (pass/return None/print stubs, no raise NotImplementedError)
- Doc cloud format with real QC Cloud backtest metrics

### Validation

- `check_docs_links.py --check --quiet` = PASS
- C.1 convention verified (0 violations)
- 3 exercises >= 3 minimum per convention

Co-Authored-By: Claude <noreply@anthropic.com>
