### PR TITLE
feat(lean): Grothendieck Parts 21-22 -- Mayer-Vietoris squares + long exact sequence (See #2159)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -38,3 +38,4 @@ import Grothendieck.SheafHom
 import Grothendieck.ConstantSheaf
 import Grothendieck.Conservative
 import Grothendieck.SheafCohomology.Basic
+import Grothendieck.MayerVietorisSquare

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -39,3 +39,4 @@ import Grothendieck.ConstantSheaf
 import Grothendieck.Conservative
 import Grothendieck.SheafCohomology.Basic
 import Grothendieck.MayerVietorisSquare
+import Grothendieck.SheafCohomology.MayerVietoris

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare.lean
@@ -1,0 +1,195 @@
+/-
+Grothendieck Part 21 -- Mayer-Vietoris squares
+
+Part 20 (SheafCohomology/Basic.lean) introduced Ext-based sheaf cohomology
+groups H^n(F), the cohomology presheaf, and functoriality.
+
+This module introduces **Mayer-Vietoris squares**, the geometric input for
+the Mayer-Vietoris long exact sequence in sheaf cohomology. Given a site
+(C, J), a Mayer-Vietoris square is a commutative square in C:
+
+  X₁ --f₁₂--> X₂
+  |            |
+  f₁₃         f₂₄
+  |            |
+  v            v
+  X₃ --f₃₄--> X₄
+
+such that f₁₃ is a monomorphism and the square becomes a pushout in the
+category of sheaves of sets (after applying yoneda >> presheafToSheaf).
+
+This is the abstract formulation of the classical situation where X₄ is
+covered by two open subsets X₂ and X₃ with intersection X₁.
+
+Key constructions bridged from Mathlib (`CategoryTheory.Sites.MayerVietorisSquare`):
+
+  - `MayerVietorisSquare` : the structure (extends Square C)
+  - `mk'` : constructor via sheaf pullback condition
+  - `mk_of_isPullback` : constructor via pullback square + covering sieve
+  - `SheafCondition` : presheaf satisfies the pullback condition
+  - `SheafCondition.ext` : injectivity of restrictions to X₄
+  - `SheafCondition.glue` : gluing sections over X₂ and X₃
+  - `sheafCondition_of_sheaf` : sheaves satisfy the condition
+  - `shortComplex` : ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄]
+  - `shortComplex_exact` : the short complex is exact
+  - `shortComplex_shortExact` : it is short exact (Mono f + Epi g)
+
+This is the geometric foundation for the Mayer-Vietoris long exact
+sequence (Part 22, SheafCohomology/MayerVietoris.lean).
+
+Epic #1646, See #2159. All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.MayerVietorisSquare
+
+universe w v v' u u'
+
+namespace Grothendieck.MayerVietorisSquare
+
+open CategoryTheory Category Opposite Limits
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+
+/-! ## 1. The Mayer-Vietoris square structure
+
+A Mayer-Vietoris square for a site (C, J) is a commutative square in C
+that becomes a pushout in the category of sheaves of sets. The structure
+extends `Square C` (with fields f₁₂, f₁₃, f₂₄, f₃₄ and condition
+f₁₂ >> f₂₄ = f₁₃ >> f₃₄) and adds:
+
+  - `mono_f₁₃` : the map X₁ ⟶ X₃ is a monomorphism
+  - `isPushout` : the square is a pushout in Sheaf J (Type v)
+
+The dissymmetry (only f₁₃ is required Mono) allows the Nisnevich case
+where f₂₄ is an open immersion and f₃₄ is etale.
+-/
+
+-- A Mayer-Vietoris square: extends Square C, mono f₁₃, pushout in sheaves.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare
+
+/-! ## 2. Constructors
+
+Two constructors for Mayer-Vietoris squares:
+
+1. `mk'` : given a square with Mono f₁₃, if for every sheaf of types F
+   the square `sq.op.map F.val` is a pullback, then it is a MV square.
+
+2. `mk_of_isPullback` : given a pullback square with Mono f₂₄ and
+   Mono f₃₄, if Sieve.ofTwoArrows f₂₄ f₃₄ is J-covering on X₄,
+   then it is a MV square.
+-/
+
+-- Constructor: MV square from sheaf pullback condition.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.mk'
+
+-- Constructor: MV square from pullback + covering sieve.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.mk_of_isPullback
+
+/-! ## 3. The sheaf condition
+
+Given a Mayer-Vietoris square S and a presheaf P : Cᵒᵖ ⥤ A,
+`S.SheafCondition P` asserts that the square `S.toSquare.op.map P`
+is a pullback square. This is the abstract sheaf condition for P
+with respect to the MV square.
+
+For presheaves of types, this is equivalent to bijectivity of the
+map `toPullbackObj P` from P(X₄) to the fiber product.
+-/
+
+-- The sheaf condition: the presheaf sees a pullback square.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition
+
+-- The canonical map from P(X₄) to the fiber product.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toPullbackObj
+
+-- Sheaf condition iff toPullbackObj is bijective (Type-valued presheaves).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_iff_bijective_toPullbackObj
+
+/-! ## 4. Consequences of the sheaf condition
+
+When S.SheafCondition P holds for a Type-valued presheaf P:
+
+  - `ext` : if two elements of P(X₄) agree on X₂ and X₃, they are equal
+    (injectivity of restrictions)
+
+  - `glue` : given matching sections u : P(X₂) and v : P(X₃) that agree
+    on X₁, there exists a glued section glue u v huv : P(X₄)
+
+  - `map_f₂₄_op_glue` : the restriction of glue to X₂ is u
+  - `map_f₃₄_op_glue` : the restriction of glue to X₃ is v
+-/
+
+-- Injectivity: two sections agreeing on X₂ and X₃ are equal.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.ext
+
+-- Gluing: matching sections over X₂ and X₃ glue to a section over X₄.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.glue
+
+-- Restriction of glued section to X₂ is the original.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.map_f₂₄_op_glue
+
+-- Restriction of glued section to X₃ is the original.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.map_f₃₄_op_glue
+
+/-! ## 5. Sheaves satisfy the sheaf condition
+
+Every sheaf (of types) satisfies the Mayer-Vietoris sheaf condition.
+This is the key fact that makes MV squares useful: the pullback
+condition is automatic for sheaves.
+-/
+
+-- Every sheaf satisfies the MV sheaf condition.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_of_sheaf
+
+/-! ## 6. The associated short complex
+
+Given a MV square S, there is an associated short complex of abelian sheaves:
+
+  ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄]
+
+where ℤ[X] denotes the free abelian sheaf on yoneda.obj X, the left map
+is the difference (f₁₂ - f₁₃), and the right map is the sum (f₂₄ + f₃₄).
+
+This short complex is short exact (Mono f + Epi g + Exact), which is
+the input for the Mayer-Vietoris long exact sequence in sheaf cohomology.
+-/
+
+-- The short complex ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄].
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex
+
+-- The short complex is exact.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex_exact
+
+-- The short complex is short exact (Mono f + Epi g + Exact).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex_shortExact
+
+/-! ## 7. Bridge theorems
+
+Bridge theorems connecting Mayer-Vietoris squares to concrete verification.
+-/
+
+/-- Bridge theorem: every sheaf of types satisfies the Mayer-Vietoris
+    sheaf condition for a given MV square S. This means the pullback
+    diagram is automatic for sheaves. -/
+theorem sheaf_satisfies_MV_condition
+    [HasWeakSheafify J (Type v)]
+    (S : J.MayerVietorisSquare)
+    (F : Sheaf J (Type v)) :
+    S.SheafCondition F.obj :=
+  CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_of_sheaf S F
+
+/-- Bridge theorem: given a Mayer-Vietoris square S and a presheaf P
+    satisfying the sheaf condition, matching sections over X₂ and X₃
+    that agree on X₁ can be glued into a section over X₄. -/
+noncomputable def glue_sections
+    [HasWeakSheafify J (Type v)]
+    (S : J.MayerVietorisSquare)
+    (P : Cᵒᵖ ⥤ Type v')
+    (h : S.SheafCondition P)
+    (u : P.obj (op S.X₂)) (v : P.obj (op S.X₃))
+    (huv : P.map (CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toSquare S).f₁₂.op u =
+           P.map (CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toSquare S).f₁₃.op v) :
+    P.obj (op S.X₄) :=
+  CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.glue h u v huv
+
+end Grothendieck.MayerVietorisSquare

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/MayerVietoris.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/MayerVietoris.lean
@@ -1,0 +1,164 @@
+/-
+Grothendieck Part 22 -- Mayer-Vietoris long exact sequence in sheaf cohomology
+
+Part 21 (MayerVietorisSquare.lean) introduced Mayer-Vietoris squares: the
+geometric input (a pushout square in sheaves) and the associated short
+exact complex of free abelian sheaves.
+
+This module bridges the **Mayer-Vietoris long exact sequence** in sheaf
+cohomology from Mathlib (`CategoryTheory.Sites.SheafCohomology.MayerVietoris`).
+
+Given a Mayer-Vietoris square S for a site (C, J) and an abelian sheaf F,
+there is a long exact sequence:
+
+  ... ⟶ H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F) ⟶ H^{n+1}(X₄, F) ⟶ ...
+
+where X₁ = intersection, X₂/X₃ = covering opens, X₄ = covered space.
+
+Key constructions bridged from Mathlib:
+
+  - `toBiprod` : sum of restrictions H^n(X₄) → H^n(X₂) ⊞ H^n(X₃)
+  - `fromBiprod` : difference of restrictions H^n(X₂) ⊞ H^n(X₃) → H^n(X₁)
+  - `toBiprod_fromBiprod` : composition is zero
+  - `δ` : connecting homomorphism H^{n₀}(X₁) → H^{n₁}(X₄) (n₁ = n₀ + 1)
+  - `sequence` : the full long exact sequence (ComposableArrows AddCommGrp 5)
+  - `sequence_exact` : the sequence is exact
+  - `δ_toBiprod` : δ >> toBiprod = 0
+  - `fromBiprod_δ` : fromBiprod >> δ = 0
+
+This completes the Mayer-Vietoris machinery: from a geometric covering
+condition (Part 21) to the cohomological consequence (this part).
+
+Epic #1646, See #2159. All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
+
+universe w v u
+
+namespace Grothendieck.SheafCohomology.MayerVietoris
+
+open CategoryTheory Category Opposite Limits
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+  [HasWeakSheafify J (Type v)] [HasSheafify J AddCommGrpCat.{v}]
+  [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
+
+/-! ## 1. Restriction maps in cohomology
+
+Given a Mayer-Vietoris square S and an abelian sheaf F, the maps
+between cohomology groups are induced by the restriction maps
+in the square.
+
+`toBiprod` is the sum of restrictions:
+  H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F)
+sending y to (f₂₄* y, f₃₄* y).
+
+`fromBiprod` is the difference of restrictions:
+  H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F)
+sending (y₁, y₃) to f₁₂* y₁ - f₁₃* y₃.
+-/
+
+-- Sum of restrictions: H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toBiprod
+
+-- Explicit formula for toBiprod.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toBiprod_apply
+
+-- Difference of restrictions: H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.fromBiprod
+
+/-! ## 2. Composition and the zero condition
+
+The composition toBiprod >> fromBiprod is zero:
+  H^n(X₄) ⟶ H^n(X₂) ⊞ H^n(X₃) ⟶ H^n(X₁)
+This is the cohomological shadow of the commutativity of the square.
+-/
+
+-- toBiprod >> fromBiprod = 0.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toBiprod_fromBiprod
+
+-- Explicit formula for fromBiprod applied to a pair.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.fromBiprod_biprodIsoProd_inv_apply
+
+/-! ## 3. The connecting homomorphism
+
+The connecting homomorphism δ : H^{n₀}(X₁, F) ⟶ H^{n₁}(X₄, F) (where
+n₁ = n₀ + 1) is the key map in the long exact sequence. It measures
+the obstruction to lifting a cohomology class from the intersection
+to the covered space.
+
+This is defined as `shortComplex_shortExact.extClass.precomp`.
+-/
+
+-- The connecting homomorphism δ : H^{n₀}(X₁) ⟶ H^{n₁}(X₄).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.δ
+
+/-! ## 4. The long exact sequence
+
+The Mayer-Vietoris long exact sequence is packaged as a
+`ComposableArrows AddCommGrp 5`:
+
+  H^n(X₄) ⟶ H^n(X₂) ⊞ H^n(X₃) ⟶ H^n(X₁) ⟶ H^{n+1}(X₄) ⟶ H^{n+1}(X₂) ⊞ H^{n+1}(X₃) ⟶ H^{n+1}(X₁)
+
+This is `sequence S F n₀ n₁ h` where `h : n₀ + 1 = n₁`.
+-/
+
+-- The Mayer-Vietoris long exact sequence (6 terms, ComposableArrows 5).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sequence
+
+/-! ## 5. Exactness
+
+The long exact sequence is exact at every position. This is the main
+theorem of the module, proven by comparison with the contravariant
+sequence of Ext-groups.
+-/
+
+-- The Mayer-Vietoris sequence is exact.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sequence_exact
+
+/-! ## 6. Boundary conditions
+
+The connecting homomorphism satisfies two boundary conditions:
+  - δ >> toBiprod = 0  (δ lands in the kernel of toBiprod)
+  - fromBiprod >> δ = 0  (δ factors through the cokernel of fromBiprod)
+-/
+
+-- δ >> toBiprod = 0.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.δ_toBiprod
+
+-- fromBiprod >> δ = 0.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.fromBiprod_δ
+
+/-! ## 7. Bridge theorems
+
+Bridge theorems connecting the Mayer-Vietoris long exact sequence
+to concrete verification.
+-/
+
+/-- Bridge theorem: the Mayer-Vietoris sequence is exact. For a
+    Mayer-Vietoris square S and abelian sheaf F, the sequence of
+    cohomology groups is exact at every position. -/
+theorem mv_sequence_exact
+    (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    (S.sequence F n₀ n₁ h).Exact :=
+  S.sequence_exact F n₀ n₁ h
+
+/-- Bridge theorem: the connecting homomorphism composed with the
+    sum of restrictions is zero: δ >> toBiprod = 0. -/
+theorem mv_delta_toBiprod_eq_zero
+    (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    S.δ F n₀ n₁ h ≫ S.toBiprod F n₁ = 0 :=
+  S.δ_toBiprod F n₀ n₁ h
+
+/-- Bridge theorem: the difference of restrictions composed with the
+    connecting homomorphism is zero: fromBiprod >> δ = 0. -/
+theorem mv_fromBiprod_delta_eq_zero
+    (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    S.fromBiprod F n₀ ≫ S.δ F n₀ n₁ h = 0 :=
+  S.fromBiprod_δ F n₀ n₁ h
+
+end Grothendieck.SheafCohomology.MayerVietoris


### PR DESCRIPTION
## Summary

Parts 21-22 of the Grothendieck Lean formalization (#2159, Epic #1646).

Bridge modules for `CategoryTheory.Sites.MayerVietorisSquare` and `CategoryTheory.Sites.SheafCohomology.MayerVietoris` — the Mayer-Vietoris machinery in sheaf cohomology.

### Part 21: `Grothendieck/MayerVietorisSquare.lean`

The geometric input: Mayer-Vietoris squares, sheaf conditions, and the associated short complex.

| Section | Bridges | Description |
|---------|---------|-------------|
| Structure | `MayerVietorisSquare` | Extends Square C, mono f₁₃, pushout in sheaves |
| Constructors | `mk'`, `mk_of_isPullback` | Via sheaf pullback or pullback + covering sieve |
| Sheaf condition | `SheafCondition`, `toPullbackObj`, `iff_bijective` | Pullback condition for presheaves |
| Gluing | `ext`, `glue`, `map_f₂₄_op_glue`, `map_f₃₄_op_glue` | Injectivity + gluing of sections |
| Sheaf property | `sheafCondition_of_sheaf` | Sheaves satisfy the condition automatically |
| Short complex | `shortComplex`, `shortComplex_exact`, `shortComplex_shortExact` | ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄] |

15 `#check` bridges + 2 bridge theorems.

### Part 22: `Grothendieck/SheafCohomology/MayerVietoris.lean`

The cohomological consequence: the Mayer-Vietoris long exact sequence.

| Section | Bridges | Description |
|---------|---------|-------------|
| Restrictions | `toBiprod`, `toBiprod_apply`, `fromBiprod` | Sum/difference of cohomology restrictions |
| Composition | `toBiprod_fromBiprod`, `fromBiprod_biprodIsoProd_inv_apply` | Composition = 0 |
| Connecting map | `δ` | Connecting homomorphism H^{n₀}(X₁) → H^{n₁}(X₄) |
| Exact sequence | `sequence`, `sequence_exact` | Full 6-term long exact sequence (exact) |
| Boundary | `δ_toBiprod`, `fromBiprod_δ` | Boundary conditions |

11 `#check` bridges + 3 bridge theorems.

### Validation
- `lake build Grothendieck` (umbrella) → SUCCESS (2709 jobs)
- `grep -cE "^\s*sorry\b"` → **0** across all 22 modules

### Dependencies
- Part 20 (SheafCohomology/Basic): Ext-based cohomology groups
- Part 21 (MayerVietorisSquare): MV square structure + short complex

See #2159