### PR TITLE
vendor(arg-analysis): B.2 core vendoring — state + runner (#2137)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/__init__.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/__init__.py
@@ -4,9 +4,81 @@
 # the EPITA `argumentation_analysis` internals.  All heavy imports are
 # lazy; importing this module alone must succeed without the EPITA package.
 #
-# Phase B.1 — shims only.  Core vendoring (agents, runner) comes in B.2.
+# Phase B.2 — core state + agents + runner vendored.
 # See #2137 Phase B scope and acceptance criteria.
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
-# -- lazy re-exports (B.2 will populate these) --
+# -- Configuration (zero secrets, zero model names) --
+from argumentation_lib._config import LibConfig, get_config, DEFAULT_CONFIG
+
+# -- Path management (pure, no import-time side effects) --
+from argumentation_lib._paths import (
+    LIB_DIR,
+    ARGUMENT_ANALYSIS_DIR,
+    SYMBOLIC_AI_DIR,
+    get_tweety_jar_dir,
+    get_ontology_dir,
+    get_data_dir,
+    get_ext_tools_dir,
+    ensure_output_dirs,
+)
+
+# -- JVM initialization (bridges to CoursIA Tweety infra) --
+from argumentation_lib._jvm_compat import (
+    initialize_jvm,
+    is_jvm_started,
+    shutdown_jvm,
+)
+
+# -- Shared state (RhetoricalAnalysisState — autoportant, zero EPITA deps) --
+from argumentation_lib._shared_state import (
+    ArgumentProfile,
+    RhetoricalAnalysisState,
+)
+
+# -- State Manager Plugin (Semantic Kernel @kernel_function wrapper) --
+# Heavy import — requires semantic_kernel.  Use lazy pattern.
+def get_state_manager_plugin():
+    """Lazy import to avoid requiring semantic_kernel at package import."""
+    from argumentation_lib._state_manager_plugin import StateManagerPlugin
+    return StateManagerPlugin
+
+# -- Reporting (no-op shims) --
+from argumentation_lib._reporting_noop import (
+    EnhancedGlobalTraceAnalyzer,
+    enhanced_global_trace_analyzer,
+    start_enhanced_pm_capture,
+    stop_enhanced_pm_capture,
+    start_pm_orchestration_phase,
+    capture_shared_state,
+    get_enhanced_pm_report,
+    save_enhanced_pm_report,
+)
+
+# -- Runner (requires semantic_kernel) --
+def get_analysis_runner():
+    """Lazy import for the analysis runner."""
+    from argumentation_lib._runner import AnalysisRunner
+    return AnalysisRunner
+
+__all__ = [
+    # config
+    "LibConfig", "get_config", "DEFAULT_CONFIG",
+    # paths
+    "LIB_DIR", "ARGUMENT_ANALYSIS_DIR", "SYMBOLIC_AI_DIR",
+    "get_tweety_jar_dir", "get_ontology_dir", "get_data_dir",
+    "get_ext_tools_dir", "ensure_output_dirs",
+    # jvm
+    "initialize_jvm", "is_jvm_started", "shutdown_jvm",
+    # state
+    "ArgumentProfile", "RhetoricalAnalysisState",
+    "get_state_manager_plugin",
+    # runner
+    "get_analysis_runner",
+    # reporting
+    "EnhancedGlobalTraceAnalyzer", "enhanced_global_trace_analyzer",
+    "start_enhanced_pm_capture", "stop_enhanced_pm_capture",
+    "start_pm_orchestration_phase", "capture_shared_state",
+    "get_enhanced_pm_report", "save_enhanced_pm_report",
+]

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_runner.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_runner.py
@@ -1,0 +1,347 @@
+# _runner.py — simplified argumentation analysis runner for CoursIA notebooks
+#
+# Replaces EPITA's `analysis_runner_v2.py` (which has stale factory calls,
+# environment_manager side effects, and config/settings.py dependencies).
+#
+# This runner:
+# - Uses RhetoricalAnalysisState + StateManagerPlugin (vendored)
+# - Instantiates agents directly via SK ChatCompletionAgent (bypasses factory)
+# - Runs a 3-phase pipeline: Informal → Formal → Synthesis
+# - Zero secrets, zero model names, zero env reads
+#
+# The LLM kernel is INJECTED by the notebook at runtime.
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from semantic_kernel import Kernel
+from semantic_kernel.agents.chat_completion.chat_completion_agent import (
+    ChatCompletionAgent,
+)
+from semantic_kernel.agents.group_chat.agent_group_chat import AgentGroupChat
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.contents.utils.author_role import AuthorRole
+from semantic_kernel.contents.chat_history import ChatHistory
+
+from argumentation_lib._shared_state import RhetoricalAnalysisState
+from argumentation_lib._state_manager_plugin import StateManagerPlugin
+
+_logger = logging.getLogger("argumentation_lib.runner")
+
+# ---------------------------------------------------------------------------
+# Prompts — vendored from EPITA agents/core/pm/prompts.py
+# ---------------------------------------------------------------------------
+
+PROMPT_DEFINE_TASKS = """[Contexte]
+Vous êtes le ProjectManagerAgent, un orchestrateur logique et précis.
+Votre unique but est de déterminer la prochaine action dans une analyse
+rhétorique, en suivant une séquence stricte.
+
+[Séquence d'Analyse Idéale]
+1. Identifier les arguments dans le texte (Agent: InformalAgent)
+2. Analyser les sophismes dans le texte (Agent: InformalAgent)
+3. Traduire le texte en logique propositionnelle (Agent: LogicAgent)
+4. Exécuter des requêtes logiques (Agent: LogicAgent)
+5. Rédiger la conclusion (Agent: PM, vous-même)
+
+[État Actuel]
+{{$analysis_state}}
+
+[Instructions]
+Trouvez la première étape non complétée.
+Répondez AU FORMAT JSON:
+{
+  "task_description": "Description de la tâche",
+  "assigned_agent": "InformalAgent|LogicAgent|PM"
+}
+Si toutes les étapes sont complétées, rédigez la conclusion finale.
+"""
+
+PROMPT_INFORMAL_ANALYSIS = """Vous êtes un agent spécialisé dans l'analyse informelle d'argumentation.
+
+Votre rôle:
+1. Identifier les arguments principaux du texte
+2. Détecter les sophismes (ad hominem, straw man, appel à l'autorité, etc.)
+3. Évaluer la cohérence des arguments
+
+[État Actuel]
+{{$analysis_state}}
+
+Répondez en utilisant les fonctions kernel disponibles pour:
+- Ajouter les arguments identifiés
+- Ajouter les sophismes détectés
+- Marquer la tâche comme répondue
+"""
+
+PROMPT_LOGIC_ANALYSIS = """Vous êtes un agent spécialisé dans l'analyse logique formelle.
+
+Votre rôle:
+1. Traduire les arguments en formules logiques propositionnelles
+2. Créer des ensembles de croyances (belief sets)
+3. Exécuter des requêtes logiques pour vérifier la cohérence
+
+[État Actuel]
+{{$analysis_state}}
+
+Répondez en utilisant les fonctions kernel disponibles pour:
+- Ajouter des belief sets
+- Logger les résultats de requêtes
+- Marquer la tâche comme répondue
+"""
+
+PROMPT_SYNTHESIS = """Vous êtes l'agent de synthèse.
+
+Votre rôle:
+- Synthétiser tous les résultats de l'analyse
+- Rédiger une conclusion finale structurée
+- Identifier les points forts et faiblesses de l'argumentation
+
+[État Actuel]
+{{$analysis_state}}
+
+Rédigez une conclusion finale complète.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Agent builders — direct instantiation, no factory needed
+# ---------------------------------------------------------------------------
+
+def create_pm_agent(
+    kernel: Kernel,
+    llm_service_id: str,
+    state: RhetoricalAnalysisState,
+) -> ChatCompletionAgent:
+    """Create the Project Manager agent."""
+    smp = StateManagerPlugin(state)
+    kernel.add_plugin(smp, plugin_name="StateManager")
+
+    agent = ChatCompletionAgent(
+        kernel=kernel,
+        name="ProjectManagerAgent",
+        instructions=PROMPT_DEFINE_TASKS,
+        service_id=llm_service_id,
+    )
+    _logger.info("PM agent created with StateManagerPlugin.")
+    return agent
+
+
+def create_informal_agent(
+    kernel: Kernel,
+    llm_service_id: str,
+    state: RhetoricalAnalysisState,
+) -> ChatCompletionAgent:
+    """Create the Informal Analysis agent."""
+    # StateManagerPlugin already added by PM — reuse it
+    if "StateManager" not in [p.name for p in kernel.plugins.values()]:
+        smp = StateManagerPlugin(state)
+        kernel.add_plugin(smp, plugin_name="StateManager")
+
+    agent = ChatCompletionAgent(
+        kernel=kernel,
+        name="InformalAgent",
+        instructions=PROMPT_INFORMAL_ANALYSIS,
+        service_id=llm_service_id,
+    )
+    _logger.info("Informal agent created.")
+    return agent
+
+
+def create_logic_agent(
+    kernel: Kernel,
+    llm_service_id: str,
+    state: RhetoricalAnalysisState,
+) -> ChatCompletionAgent:
+    """Create the Logic Analysis agent."""
+    if "StateManager" not in [p.name for p in kernel.plugins.values()]:
+        smp = StateManagerPlugin(state)
+        kernel.add_plugin(smp, plugin_name="StateManager")
+
+    agent = ChatCompletionAgent(
+        kernel=kernel,
+        name="LogicAgent",
+        instructions=PROMPT_LOGIC_ANALYSIS,
+        service_id=llm_service_id,
+    )
+    _logger.info("Logic agent created.")
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Pipeline runner
+# ---------------------------------------------------------------------------
+
+class AnalysisRunner:
+    """Simplified 3-phase argumentation analysis runner.
+
+    Phases:
+        1. Informal: identify arguments and fallacies
+        2. Formal: translate to logic, run queries
+        3. Synthesis: write conclusion
+
+    Usage in notebooks::
+
+        from argumentation_lib import AnalysisRunner, RhetoricalAnalysisState
+
+        state = RhetoricalAnalysisState(text)
+        runner = AnalysisRunner(kernel, "my-llm-service", state)
+        result = await runner.run()
+    """
+
+    def __init__(
+        self,
+        kernel: Kernel,
+        llm_service_id: str,
+        state: RhetoricalAnalysisState,
+        max_turns: int = 20,
+    ):
+        self.kernel = kernel
+        self.llm_service_id = llm_service_id
+        self.state = state
+        self.max_turns = max_turns
+
+        # Register StateManagerPlugin on kernel
+        if "StateManager" not in [p.name for p in kernel.plugins.values()]:
+            self._smp = StateManagerPlugin(state)
+            kernel.add_plugin(self._smp, plugin_name="StateManager")
+        else:
+            self._smp = None
+
+    async def run(self) -> Dict[str, Any]:
+        """Execute the full 3-phase analysis pipeline."""
+        _logger.info("Starting 3-phase argumentation analysis...")
+        _logger.info(f"  Text length: {len(self.state.raw_text)} chars")
+        _logger.info(f"  Max turns: {self.max_turns}")
+
+        results = {
+            "phases": [],
+            "state_snapshot": None,
+            "conclusion": None,
+        }
+
+        # Phase 1: Informal analysis
+        _logger.info("=== Phase 1: Informal Analysis ===")
+        informal = create_informal_agent(
+            self.kernel, self.llm_service_id, self.state
+        )
+        pm = create_pm_agent(self.kernel, self.llm_service_id, self.state)
+
+        phase1_history = ChatHistory()
+        phase1_history.add_message(
+            ChatMessageContent(
+                role=AuthorRole.USER,
+                content=f"Analysez le texte suivant:\\n\\n{self.state.raw_text}",
+            )
+        )
+
+        group_chat = AgentGroupChat(
+            agents=[pm, informal],
+        )
+
+        try:
+            turn_count = 0
+            async for response in group_chat.invoke():
+                turn_count += 1
+                _logger.info(f"  Turn {turn_count}: {response.name} responded")
+                if turn_count >= self.max_turns // 2:
+                    break
+            results["phases"].append({
+                "name": "informal",
+                "turns": turn_count,
+                "status": "completed",
+            })
+        except Exception as e:
+            _logger.error(f"Phase 1 error: {e}")
+            results["phases"].append({
+                "name": "informal",
+                "status": "error",
+                "error": str(e),
+            })
+
+        # Phase 2: Formal analysis (logic)
+        _logger.info("=== Phase 2: Formal Analysis ===")
+        logic = create_logic_agent(
+            self.kernel, self.llm_service_id, self.state
+        )
+
+        try:
+            group_chat2 = AgentGroupChat(
+                agents=[pm, logic],
+            )
+            turn_count = 0
+            async for response in group_chat2.invoke():
+                turn_count += 1
+                _logger.info(f"  Turn {turn_count}: {response.name} responded")
+                if turn_count >= self.max_turns // 2:
+                    break
+            results["phases"].append({
+                "name": "formal",
+                "turns": turn_count,
+                "status": "completed",
+            })
+        except Exception as e:
+            _logger.error(f"Phase 2 error: {e}")
+            results["phases"].append({
+                "name": "formal",
+                "status": "error",
+                "error": str(e),
+            })
+
+        # Phase 3: Synthesis
+        _logger.info("=== Phase 3: Synthesis ===")
+        synthesis_agent = ChatCompletionAgent(
+            kernel=self.kernel,
+            name="SynthesisAgent",
+            instructions=PROMPT_SYNTHESIS,
+            service_id=self.llm_service_id,
+        )
+
+        try:
+            group_chat3 = AgentGroupChat(
+                agents=[pm, synthesis_agent],
+            )
+            turn_count = 0
+            async for response in group_chat3.invoke():
+                turn_count += 1
+                _logger.info(f"  Turn {turn_count}: {response.name} responded")
+                if turn_count >= 3:
+                    break
+            results["phases"].append({
+                "name": "synthesis",
+                "turns": turn_count,
+                "status": "completed",
+            })
+        except Exception as e:
+            _logger.error(f"Phase 3 error: {e}")
+            results["phases"].append({
+                "name": "synthesis",
+                "status": "error",
+                "error": str(e),
+            })
+
+        # Final state snapshot
+        results["state_snapshot"] = self.state.get_state_snapshot(summarize=True)
+        if self.state.final_conclusion:
+            results["conclusion"] = self.state.final_conclusion
+
+        _logger.info("Analysis complete.")
+        return results
+
+    def run_sync(self) -> Dict[str, Any]:
+        """Synchronous wrapper for run()."""
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                future = pool.submit(asyncio.run, self.run())
+                return future.result(timeout=300)
+        else:
+            return asyncio.run(self.run())

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_shared_state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_shared_state.py
@@ -1,0 +1,1121 @@
+# core/shared_state.py
+import json
+from dataclasses import dataclass, field
+from typing import Dict, List, Any, Optional, cast
+import logging
+
+# Logger spécifique pour l'état
+state_logger = logging.getLogger("RhetoricalAnalysisState")
+# Assurer qu'un handler de base est présent si non configuré globalement tôt
+if not state_logger.handlers and not state_logger.propagate:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] [%(name)s] %(message)s", datefmt="%H:%M:%S"
+    )
+    handler.setFormatter(formatter)
+    state_logger.addHandler(handler)
+    state_logger.setLevel(logging.INFO)
+
+
+@dataclass
+class ArgumentProfile:
+    """Aggregated view of all analysis data for a single argument."""
+
+    arg_id: str
+    description: str
+    fallacies: List[Dict[str, Any]] = field(default_factory=list)
+    quality_score: Optional[Dict[str, Any]] = None
+    counter_arguments: List[Dict[str, Any]] = field(default_factory=list)
+    jtms_beliefs: List[Dict[str, Any]] = field(default_factory=list)
+    formal_results: List[Dict[str, Any]] = field(default_factory=list)
+
+
+class RhetoricalAnalysisState:
+    """Représente l'état partagé d'une analyse rhétorique collaborative."""
+
+    # ... (Le code complet de la classe RhetoricalAnalysisState tel que fourni dans la réponse précédente va ici) ...
+    # Structure des données de l'état (pour référence)
+    raw_text: str
+    analysis_tasks: Dict[str, str]  # {task_id: description}
+    identified_arguments: Dict[str, str]  # {arg_id: description}
+    identified_fallacies: Dict[
+        str, Dict[str, str]
+    ]  # {fallacy_id: {type:..., justification:..., target_argument_id?:...}}
+    belief_sets: Dict[str, Dict[str, str]]  # {bs_id: {logic_type:..., content:...}}
+    query_log: List[
+        Dict[str, str]
+    ]  # [{log_id:..., belief_set_id:..., query:..., raw_result:...}]
+    answers: Dict[
+        str, Dict[str, Any]
+    ]  # {task_id: {author_agent:..., answer_text:..., source_ids:[...]}}
+    final_conclusion: Optional[str]
+    _next_agent_designated: Optional[
+        str
+    ]  # Nom de l'agent désigné pour le prochain tour
+
+    def __init__(self, initial_text: str):
+        """Initialise un état vide avec le texte brut."""
+        self.raw_text = initial_text
+        self.analysis_tasks = {}
+        self.identified_arguments = {}
+        self.identified_fallacies = {}
+        self.belief_sets = {}
+        self.query_log = []
+        self.answers = {}
+        self.extracts: List[Dict[str, Any]] = []
+        self.errors: List[Dict[str, Any]] = []
+        self.final_conclusion = None
+        self._next_agent_designated = None
+        state_logger.debug(
+            f"Nouvelle instance RhetoricalAnalysisState créée (id: {id(self)}) avec texte (longueur: {len(initial_text)})."
+        )
+
+    def _generate_id(self, prefix: str, current_dict_or_list: Any) -> str:
+        """Génère un ID simple basé sur la taille actuelle."""
+        index = 0
+        try:
+            if isinstance(current_dict_or_list, (dict, list)):
+                index = len(current_dict_or_list)
+            else:
+                index = 0
+                state_logger.warning(
+                    f"_generate_id: Type inattendu '{type(current_dict_or_list)}' pour prefix '{prefix}'. Index sera 0."
+                )
+        except Exception as e:
+            state_logger.error(
+                f"Erreur dans _generate_id pour prefix '{prefix}': {e}", exc_info=True
+            )
+            index = 999
+        safe_index = min(index, 9999)
+        return f"{prefix}_{safe_index + 1}"
+
+    def add_task(self, description: str) -> str:
+        """Ajoute une tâche d'analyse et retourne son ID."""
+        task_id = self._generate_id("task", self.analysis_tasks)
+        self.analysis_tasks[task_id] = description
+        state_logger.info(f"Tâche ajoutée: {task_id} - '{description[:60]}...'")
+        state_logger.debug(f"État tasks après ajout {task_id}: {self.analysis_tasks}")
+        return task_id
+
+    def add_argument(self, description: str) -> str:
+        """Ajoute un argument identifié et retourne son ID."""
+        arg_id = self._generate_id("arg", self.identified_arguments)
+        self.identified_arguments[arg_id] = description
+        state_logger.info(f"Argument ajouté: {arg_id} - '{description[:60]}...'")
+        state_logger.debug(
+            f"État arguments après ajout {arg_id}: {self.identified_arguments}"
+        )
+        return arg_id
+
+    def add_fallacy(
+        self,
+        fallacy_type: str,
+        justification: str,
+        target_arg_id: Optional[str] = None,
+        family: str = "",
+        taxonomy_path: str = "",
+    ) -> str:
+        """Ajoute un sophisme identifié et retourne son ID."""
+        fallacy_id = self._generate_id("fallacy", self.identified_fallacies)
+        entry = {"type": fallacy_type, "justification": justification}
+        if family:
+            entry["family"] = family
+        if taxonomy_path:
+            entry["taxonomy_path"] = taxonomy_path
+        log_target_info = ""
+        if target_arg_id:
+            if target_arg_id not in self.identified_arguments:
+                state_logger.warning(
+                    f"ID argument cible '{target_arg_id}' pour sophisme '{fallacy_id}' non trouvé dans les arguments identifiés ({list(self.identified_arguments.keys())})."
+                )
+            entry["target_argument_id"] = target_arg_id
+            log_target_info = f" (cible: {target_arg_id})"
+        self.identified_fallacies[fallacy_id] = entry
+        state_logger.info(
+            f"Sophisme ajouté: {fallacy_id} - Type: {fallacy_type}{log_target_info}"
+        )
+        state_logger.debug(
+            f"État fallacies après ajout {fallacy_id}: {self.identified_fallacies}"
+        )
+        return fallacy_id
+
+    def add_belief_set(self, logic_type: str, content: str) -> str:
+        """Ajoute un belief set formel et retourne son ID."""
+        normalized_type = logic_type.strip().lower().replace(" ", "_")
+        bs_id = self._generate_id(f"{normalized_type}_bs", self.belief_sets)
+        self.belief_sets[bs_id] = {"logic_type": logic_type, "content": content}
+        state_logger.info(f"Belief Set ajouté: {bs_id} - Type: {logic_type}")
+        state_logger.debug(f"État belief_sets après ajout {bs_id}: {self.belief_sets}")
+        return bs_id
+
+    def log_query(self, belief_set_id: str, query: str, raw_result: str) -> str:
+        """Enregistre une requête formelle et son résultat brut."""
+        log_id = self._generate_id("qlog", self.query_log)
+        if belief_set_id not in self.belief_sets:
+            state_logger.warning(
+                f"ID Belief Set '{belief_set_id}' pour query log '{log_id}' non trouvé dans les belief sets ({list(self.belief_sets.keys())})."
+            )
+        log_entry = {
+            "log_id": log_id,
+            "belief_set_id": belief_set_id,
+            "query": query,
+            "raw_result": raw_result,
+        }
+        self.query_log.append(log_entry)
+        state_logger.info(
+            f"Requête loggée: {log_id} (sur BS: {belief_set_id}, Query: '{query[:60]}...')"
+        )
+        state_logger.debug(
+            f"État query_log après ajout {log_id} (taille: {len(self.query_log)}): {self.query_log}"
+        )
+        return log_id
+
+    def add_answer(
+        self, task_id: str, author_agent: str, answer_text: str, source_ids: List[str]
+    ) -> None:
+        """Ajoute la réponse d'un agent à une tâche spécifiques."""
+        if task_id not in self.analysis_tasks:
+            state_logger.warning(
+                f"ID Tâche '{task_id}' pour réponse de '{author_agent}' non trouvé dans les tâches définies ({list(self.analysis_tasks.keys())})."
+            )
+        self.answers[task_id] = {
+            "author_agent": author_agent,
+            "answer_text": answer_text,
+            "source_ids": source_ids,
+        }
+        state_logger.info(
+            f"Réponse ajoutée pour tâche '{task_id}' par agent '{author_agent}'."
+        )
+        state_logger.debug(
+            f"État answers après ajout réponse pour {task_id}: {self.answers}"
+        )
+
+    def set_conclusion(self, conclusion: str) -> None:
+        """Enregistre la conclusion finale de l'analyse."""
+        self.final_conclusion = conclusion
+        state_logger.info(f"Conclusion finale enregistrée : '{conclusion[:60]}...'")
+        state_logger.debug(
+            f"État final_conclusion après enregistrement: {self.final_conclusion is not None}"
+        )
+
+    def add_identified_arguments(self, arguments: List[str]) -> None:
+        """Ajoute une liste d'arguments identifiés."""
+        state_logger.info(f"Ajout de {len(arguments)} arguments identifiés...")
+        for arg_desc in arguments:
+            self.add_argument(arg_desc)
+
+    def add_identified_fallacies(self, fallacies: List[Dict[str, str]]) -> None:
+        """Ajoute une liste de sophismes identifiés."""
+        state_logger.info(f"Ajout de {len(fallacies)} sophismes identifiés...")
+        for fallacy_data in fallacies:
+            self.add_fallacy(
+                fallacy_type=fallacy_data.get("nom", "Type Inconnu"),
+                justification=fallacy_data.get(
+                    "explication", "Justification manquante"
+                ),
+                family=fallacy_data.get("famille", ""),
+                taxonomy_path=fallacy_data.get("taxonomy_path", ""),
+            )
+
+    def mark_task_as_answered(
+        self, task_id: str, answer: str, author: str = "Unknown"
+    ) -> None:
+        """Marque une tâche comme terminée en lui ajoutant une réponse."""
+        if task_id not in self.analysis_tasks:
+            state_logger.warning(
+                f"Tentative de marquer comme répondue une tâche inexistante: '{task_id}'"
+            )
+            return
+        self.answers[task_id] = {"answer_text": answer, "author_agent": author}
+        state_logger.info(f"Tâche '{task_id}' marquée comme répondue.")
+
+    def get_last_task_id(self) -> Optional[str]:
+        """Retourne l'ID de la dernière tâche non répondue."""
+        defined_tasks = set(self.analysis_tasks.keys())
+        answered_tasks = set(self.answers.keys())
+        unanswered_tasks = list(defined_tasks - answered_tasks)
+        if not unanswered_tasks:
+            return None
+        # On pourrait avoir une logique plus complexe, mais pour l'instant on prend la dernière créée
+        return unanswered_tasks[-1]
+
+    def designate_next_agent(self, agent_name: str) -> None:
+        """Désigne l'agent qui doit parler au prochain tour."""
+        self._next_agent_designated = agent_name
+        state_logger.info(f"Prochain agent désigné: '{agent_name}'")
+        state_logger.debug(
+            f"État _next_agent_designated après désignation: '{self._next_agent_designated}'"
+        )
+
+    def add_extract(self, name: str, content: str) -> str:
+        """Ajoute un extrait de texte et retourne son ID."""
+        if not hasattr(self, "extracts"):
+            self.extracts = []
+        extract_id = self._generate_id("extract", self.extracts)
+        extract = {"id": extract_id, "name": name, "content": content}
+        self.extracts.append(extract)
+        state_logger.info(f"Extrait ajouté: {extract_id} - '{name}'")
+        state_logger.debug(f"État extracts après ajout {extract_id}: {self.extracts}")
+        return extract_id
+
+    def log_error(self, agent_name: str, message: str) -> str:
+        """Enregistre une erreur et retourne son ID."""
+        if not hasattr(self, "errors"):
+            self.errors = []
+        error_id = self._generate_id("error", self.errors)
+        error = {
+            "id": error_id,
+            "agent_name": agent_name,
+            "message": message,
+            "timestamp": None,
+        }
+        self.errors.append(error)
+        state_logger.warning(
+            f"Erreur enregistrée: {error_id} - Agent: {agent_name} - '{message}'"
+        )
+        state_logger.debug(f"État errors après ajout {error_id}: {self.errors}")
+        return error_id
+
+    def consume_next_agent_designation(self) -> Optional[str]:
+        """Récupère le nom de l'agent désigné et réinitialise la désignation."""
+        agent_name = self._next_agent_designated
+        self._next_agent_designated = None
+        if agent_name:
+            state_logger.info(f"Désignation pour '{agent_name}' consommée.")
+        return agent_name
+
+    def reset_state(self) -> None:
+        """Réinitialise l'état à son état initial (vide sauf texte brut)."""
+        state_logger.info(">>> Réinitialisation de l'état d'analyse...")
+        initial_text = self.raw_text
+        self.__init__(initial_text)  # type: ignore[misc]
+        assert not self.analysis_tasks, "Reset analysis_tasks failed"
+        assert not self.identified_arguments, "Reset identified_arguments failed"
+        assert not self.identified_fallacies, "Reset identified_fallacies failed"
+        assert not self.belief_sets, "Reset belief_sets failed"
+        assert not self.query_log, "Reset query_log failed"
+        assert not self.answers, "Reset answers failed"
+        assert self.final_conclusion is None, "Reset final_conclusion failed"
+        assert (
+            self._next_agent_designated is None
+        ), "Reset _next_agent_designated failed"
+        # Réinitialiser les attributs extracts et errors s'ils existent
+        if hasattr(self, "extracts"):
+            self.extracts = []
+        if hasattr(self, "errors"):
+            self.errors = []
+        state_logger.info("<<< Réinitialisation de l'état terminée et vérifiée.")
+
+    def get_state_snapshot(self, summarize: bool = False) -> Dict[str, Any]:
+        """Retourne un dictionnaire représentant l'état actuel (complet ou résumé)."""
+        if summarize:
+            # Assurer que le texte est tronqué dans le résumé
+            truncated_text = (
+                self.raw_text[:50] + "..." if len(self.raw_text) > 50 else self.raw_text
+            )
+            return {
+                "raw_text": (
+                    self.raw_text[:150] + "..."
+                    if len(self.raw_text) > 150
+                    else self.raw_text
+                ),
+                "raw_text_snippet": (
+                    self.raw_text[:150] + "..."
+                    if len(self.raw_text) > 150
+                    else self.raw_text
+                ),
+                "task_count": len(self.analysis_tasks),
+                "tasks_defined": list(self.analysis_tasks.keys()),
+                "argument_count": len(self.identified_arguments),
+                "fallacy_count": len(self.identified_fallacies),
+                "belief_set_count": len(self.belief_sets),
+                "query_log_count": len(self.query_log),
+                "answer_count": len(self.answers),
+                "extract_count": len(getattr(self, "extracts", [])),
+                "error_count": len(getattr(self, "errors", [])),
+                "tasks_answered": list(self.answers.keys()),
+                "conclusion_present": self.final_conclusion is not None,
+                "next_agent_designated": self._next_agent_designated,
+            }
+        else:
+            return cast(Dict[str, Any], json.loads(self.to_json(indent=None)))
+
+    def to_json(self, indent: Optional[int] = 2) -> str:
+        """Sérialise l'état actuel en chaîne JSON."""
+        state_dict = {
+            k: v
+            for k, v in self.__dict__.items()
+            if not callable(v) and not k.startswith("_logger")
+        }
+        try:
+            return json.dumps(
+                state_dict, indent=indent, ensure_ascii=False, default=str
+            )
+        except TypeError as e:
+            state_logger.error(f"Erreur de sérialisation JSON de l'état: {e}")
+            safe_dict = {k: repr(v) for k, v in state_dict.items()}
+            return json.dumps(
+                {
+                    "error": f"JSON serialization failed: {e}",
+                    "safe_state_repr": safe_dict,
+                },
+                indent=indent,
+            )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RhetoricalAnalysisState":
+        """Crée une instance d'état à partir d'un dictionnaire."""
+        state = cls(data.get("raw_text", ""))
+        state.analysis_tasks = data.get("analysis_tasks", {})
+        state.identified_arguments = data.get("identified_arguments", {})
+        state.identified_fallacies = data.get("identified_fallacies", {})
+        state.belief_sets = data.get("belief_sets", {})
+        state.query_log = data.get("query_log", [])
+        state.answers = data.get("answers", {})
+        state.extracts = data.get("extracts", [])
+        state.errors = data.get("errors", [])
+        state.final_conclusion = data.get("final_conclusion", None)
+        state._next_agent_designated = data.get("_next_agent_designated", None)
+        state_logger.debug(
+            f"Instance RhetoricalAnalysisState créée depuis dict (id: {id(state)})."
+        )
+        return state
+
+
+class UnifiedAnalysisState(RhetoricalAnalysisState):
+    """Extended state encompassing all integrated student project dimensions.
+
+    Adds fields for counter-arguments, argument quality, JTMS beliefs,
+    Dung frameworks, governance decisions, debate transcripts, transcription
+    segments, semantic index references, and neural fallacy scores.
+    """
+
+    def __init__(self, initial_text: str):
+        super().__init__(initial_text)
+        # Counter-argument generation (2.3.3)
+        self.counter_arguments: List[Dict[str, Any]] = []
+        # Argument quality evaluation (2.3.5)
+        self.argument_quality_scores: Dict[str, Dict[str, Any]] = {}
+        # JTMS belief network (1.4.1)
+        self.jtms_beliefs: Dict[str, Dict[str, Any]] = {}
+        # JTMS retraction cascade chains (#350)
+        self.jtms_retraction_chain: List[Dict[str, Any]] = []
+        # Dung abstract argumentation frameworks (abs_arg_dung)
+        self.dung_frameworks: Dict[str, Dict[str, Any]] = {}
+        # Governance decisions and votes (2.1.6)
+        self.governance_decisions: List[Dict[str, Any]] = []
+        # Debate transcripts (1.2.7)
+        self.debate_transcripts: List[Dict[str, Any]] = []
+        # Speech transcription segments (speech-to-text)
+        self.transcription_segments: List[Dict[str, Any]] = []
+        # Semantic index references (Arg_Semantic_Index)
+        self.semantic_index_refs: List[Dict[str, Any]] = []
+        # Neural fallacy detection scores (2.3.2 CamemBERT)
+        self.neural_fallacy_scores: List[Dict[str, Any]] = []
+        # Track A: Tweety handler results (#55-#62)
+        self.ranking_results: List[Dict[str, Any]] = []
+        self.aspic_results: List[Dict[str, Any]] = []
+        self.belief_revision_results: List[Dict[str, Any]] = []
+        self.dialogue_results: List[Dict[str, Any]] = []
+        self.probabilistic_results: List[Dict[str, Any]] = []
+        self.bipolar_results: List[Dict[str, Any]] = []
+        # Logic agent analysis results (#71 formal verification)
+        self.fol_analysis_results: List[Dict[str, Any]] = []
+        self.fol_signature: List[str] = []  # Pre-declared sorts/types (#348)
+        self.propositional_analysis_results: List[Dict[str, Any]] = []
+        self.modal_analysis_results: List[Dict[str, Any]] = []
+        self.formal_synthesis_reports: List[Dict[str, Any]] = []
+        # NL-to-formal-logic translations (#173)
+        self.nl_to_logic_translations: List[Dict[str, Any]] = []
+        # ATMS multi-context analysis (#349)
+        self.atms_contexts: List[Dict[str, Any]] = []
+        # Workflow execution results
+        self.workflow_results: Dict[str, Any] = {}
+        # Narrative synthesis (#351)
+        self.narrative_synthesis: str = ""
+        # PP #715: source-level metadata for qualitative synthesis
+        self.source_metadata: Dict[str, str] = {}
+        # PL 2-pass pipeline: shared atom inventory (#547)
+        self.atomic_propositions: Dict[str, List[str]] = {}
+        # FOL 2-pass pipeline: shared signature per source (#544)
+        self.fol_shared_signature: Dict[str, Dict[str, Any]] = {}
+        # Track TT #723: stakes & stakeholders extraction
+        self.stakes_and_stakeholders: Dict[str, Any] = {
+            "stakes": [],
+            "stakeholders": [],
+            "rhetorical_register": "",
+            "discursive_arena": "",
+        }
+        # Track UU #724: specialist commentary + analysis trace
+        self.analysis_trace: List[Dict[str, Any]] = []
+        # AI Shield results — adversarial protection (#841)
+        self.ai_shield_results: List[Dict[str, Any]] = []
+        # Local LLM results — offline LLM analysis (#834)
+        self.local_llm_results: List[Dict[str, Any]] = []
+        # RA-4 #1049: Strategic NL journaling bridge
+        self.strategic_objectives: List[Dict[str, Any]] = []
+        self.strategic_decisions_log: List[Dict[str, Any]] = []
+
+    def add_trace_entry(
+        self,
+        phase: str,
+        agent: str,
+        reacts_to: List[str],
+        summary: str,
+    ) -> None:
+        """Record a specialist commentary entry (Track UU #724)."""
+        summary = summary[:280]
+        import time as _time
+
+        entry = {
+            "phase": phase,
+            "agent": agent,
+            "reacts_to": reacts_to,
+            "summary": summary,
+            "timestamp": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
+        }
+        self.analysis_trace.append(entry)
+        state_logger.info(
+            f"Trace: [{agent}] ({phase}, reacts_to={reacts_to}) → {summary[:60]}..."
+        )
+
+    def add_counter_argument(
+        self,
+        original_arg: str,
+        counter_content: str,
+        strategy: str,
+        score: float,
+        target_arg_id: Optional[str] = None,
+    ) -> str:
+        """Add a counter-argument result."""
+        ca_id = self._generate_id("ca", self.counter_arguments)
+        entry = {
+            "id": ca_id,
+            "original_argument": original_arg,
+            "counter_content": counter_content,
+            "strategy": strategy,
+            "score": score,
+        }
+        if target_arg_id:
+            entry["target_arg_id"] = target_arg_id
+        self.counter_arguments.append(entry)
+        state_logger.info(f"Counter-argument added: {ca_id} (strategy: {strategy})")
+        return ca_id
+
+    def add_quality_score(
+        self,
+        arg_id: str,
+        scores: Dict[str, float],
+        overall: float,
+        llm_assessment: Optional[str] = None,
+        resolved_arg_id: Optional[str] = None,
+    ) -> None:
+        """Add quality evaluation scores for an argument.
+
+        Args:
+            arg_id: Argument identifier (from LLM or pipeline).
+            scores: Per-virtue scores dict.
+            overall: Aggregated note_finale.
+            llm_assessment: Optional LLM-generated qualitative narrative (#290).
+            resolved_arg_id: If provided, store under this canonical arg_id instead.
+        """
+        store_id = resolved_arg_id if resolved_arg_id else arg_id
+        entry: Dict[str, Any] = {
+            "scores": scores,
+            "overall": overall,
+        }
+        if llm_assessment:
+            entry["llm_assessment"] = llm_assessment
+        self.argument_quality_scores[store_id] = entry
+        state_logger.info(f"Quality score added for {store_id}: {overall:.2f}")
+
+    def add_jtms_belief(
+        self, name: str, valid: Optional[bool], justifications: List[str]
+    ) -> str:
+        """Add a JTMS belief to the network."""
+        belief_id = self._generate_id("jtms", self.jtms_beliefs)
+        self.jtms_beliefs[belief_id] = {
+            "name": name,
+            "valid": valid,
+            "justifications": justifications,
+        }
+        state_logger.info(f"JTMS belief added: {belief_id} ({name}, valid={valid})")
+        return belief_id
+
+    def add_dung_framework(
+        self,
+        name: str,
+        arguments: List[str],
+        attacks: List[List[str]],
+        extensions: Optional[Dict[str, List[str]]] = None,
+    ) -> str:
+        """Add a Dung argumentation framework."""
+        df_id = self._generate_id("dung", self.dung_frameworks)
+        self.dung_frameworks[df_id] = {
+            "name": name,
+            "arguments": arguments,
+            "attacks": attacks,
+            "extensions": extensions or {},
+        }
+        state_logger.info(
+            f"Dung framework added: {df_id} ({len(arguments)} args, {len(attacks)} attacks)"
+        )
+        return df_id
+
+    def add_governance_decision(
+        self, method: str, winner: str, scores: Dict[str, float]
+    ) -> str:
+        """Add a governance voting decision."""
+        gd_id = self._generate_id("gov", self.governance_decisions)
+        entry = {
+            "id": gd_id,
+            "method": method,
+            "winner": winner,
+            "scores": scores,
+        }
+        self.governance_decisions.append(entry)
+        state_logger.info(f"Governance decision added: {gd_id} ({method}: {winner})")
+        return gd_id
+
+    def add_debate_transcript(
+        self, topic: str, exchanges: List[Dict[str, str]], winner: Optional[str] = None
+    ) -> str:
+        """Add a debate transcript."""
+        dt_id = self._generate_id("debate", self.debate_transcripts)
+        entry = {
+            "id": dt_id,
+            "topic": topic,
+            "exchanges": exchanges,
+            "winner": winner,
+        }
+        self.debate_transcripts.append(entry)
+        state_logger.info(f"Debate transcript added: {dt_id} (topic: {topic[:50]})")
+        return dt_id
+
+    def add_neural_fallacy_score(
+        self,
+        text_segment: str,
+        label: str,
+        confidence: float,
+        detector: str = "camembert",
+    ) -> str:
+        """Add a neural fallacy detection score."""
+        nf_id = self._generate_id("nf", self.neural_fallacy_scores)
+        entry = {
+            "id": nf_id,
+            "text_segment": text_segment,
+            "label": label,
+            "confidence": confidence,
+            "detector": detector,
+        }
+        self.neural_fallacy_scores.append(entry)
+        state_logger.info(
+            f"Neural fallacy score added: {nf_id} ({label}: {confidence:.2f})"
+        )
+        return nf_id
+
+    def add_transcription_segment(
+        self,
+        start_time: float,
+        end_time: float,
+        text: str,
+        speaker: Optional[str] = None,
+    ) -> str:
+        """Add a speech transcription segment."""
+        ts_id = self._generate_id("ts", self.transcription_segments)
+        entry = {
+            "id": ts_id,
+            "start_time": start_time,
+            "end_time": end_time,
+            "text": text,
+            "speaker": speaker,
+        }
+        self.transcription_segments.append(entry)
+        state_logger.info(
+            f"Transcription segment added: {ts_id} ({start_time:.1f}s-{end_time:.1f}s)"
+        )
+        return ts_id
+
+    def add_semantic_index_ref(
+        self,
+        query: str,
+        document_id: str,
+        score: float,
+        snippet: Optional[str] = None,
+    ) -> str:
+        """Add a semantic index search reference."""
+        si_id = self._generate_id("si", self.semantic_index_refs)
+        entry = {
+            "id": si_id,
+            "query": query,
+            "document_id": document_id,
+            "score": score,
+            "snippet": snippet,
+        }
+        self.semantic_index_refs.append(entry)
+        state_logger.info(
+            f"Semantic index ref added: {si_id} (doc: {document_id}, score: {score:.2f})"
+        )
+        return si_id
+
+    def add_ranking_result(
+        self, method: str, arguments: List[str], comparisons: List[Dict[str, Any]]
+    ) -> str:
+        """Add a ranking semantics result."""
+        rk_id = self._generate_id("rank", self.ranking_results)
+        entry = {
+            "id": rk_id,
+            "method": method,
+            "arguments": arguments,
+            "comparisons": comparisons,
+        }
+        self.ranking_results.append(entry)
+        state_logger.info(f"Ranking result added: {rk_id} (method: {method})")
+        return rk_id
+
+    def add_aspic_result(
+        self, reasoner_type: str, extensions: List[Any], statistics: Dict[str, Any]
+    ) -> str:
+        """Add an ASPIC+ analysis result."""
+        as_id = self._generate_id("aspic", self.aspic_results)
+        entry = {
+            "id": as_id,
+            "reasoner_type": reasoner_type,
+            "extensions": extensions,
+            "statistics": statistics,
+        }
+        self.aspic_results.append(entry)
+        state_logger.info(f"ASPIC+ result added: {as_id} (reasoner: {reasoner_type})")
+        return as_id
+
+    def add_belief_revision_result(
+        self, method: str, original: List[str], revised: List[str]
+    ) -> str:
+        """Add a belief revision result."""
+        br_id = self._generate_id("brevision", self.belief_revision_results)
+        entry = {
+            "id": br_id,
+            "method": method,
+            "original": original,
+            "revised": revised,
+        }
+        self.belief_revision_results.append(entry)
+        state_logger.info(f"Belief revision result added: {br_id} (method: {method})")
+        return br_id
+
+    def add_dialogue_result(
+        self, topic: str, outcome: str, trace: List[Dict[str, Any]]
+    ) -> str:
+        """Add a dialogue protocol result."""
+        dl_id = self._generate_id("dialogue", self.dialogue_results)
+        entry = {
+            "id": dl_id,
+            "topic": topic,
+            "outcome": outcome,
+            "trace": trace,
+        }
+        self.dialogue_results.append(entry)
+        state_logger.info(
+            f"Dialogue result added: {dl_id} (topic: {topic[:50]}, outcome: {outcome})"
+        )
+        return dl_id
+
+    def add_probabilistic_result(
+        self, arguments: List[str], acceptance_probs: Dict[str, float]
+    ) -> str:
+        """Add a probabilistic argumentation result."""
+        pr_id = self._generate_id("prob", self.probabilistic_results)
+        entry = {
+            "id": pr_id,
+            "arguments": arguments,
+            "acceptance_probabilities": acceptance_probs,
+        }
+        self.probabilistic_results.append(entry)
+        state_logger.info(
+            f"Probabilistic result added: {pr_id} ({len(arguments)} args)"
+        )
+        return pr_id
+
+    def add_bipolar_result(
+        self, framework_type: str, arguments: List[str], supports: List[List[str]]
+    ) -> str:
+        """Add a bipolar argumentation framework result."""
+        bp_id = self._generate_id("bipolar", self.bipolar_results)
+        entry = {
+            "id": bp_id,
+            "framework_type": framework_type,
+            "arguments": arguments,
+            "supports": supports,
+        }
+        self.bipolar_results.append(entry)
+        state_logger.info(f"Bipolar result added: {bp_id} (type: {framework_type})")
+        return bp_id
+
+    def add_fol_analysis_result(
+        self,
+        formulas: List[str],
+        consistent: bool,
+        inferences: List[str],
+        confidence: float = 0.0,
+        arg_id: Optional[str] = None,
+    ) -> str:
+        """Add a first-order logic analysis result."""
+        fol_id = self._generate_id("fol", self.fol_analysis_results)
+        entry = {
+            "id": fol_id,
+            "formulas": formulas,
+            "consistent": consistent,
+            "inferences": inferences,
+            "confidence": confidence,
+        }
+        if arg_id:
+            entry["arg_id"] = arg_id
+        self.fol_analysis_results.append(entry)
+        state_logger.info(f"FOL analysis added: {fol_id} (consistent={consistent})")
+        return fol_id
+
+    def add_propositional_analysis_result(
+        self,
+        formulas: List[str],
+        satisfiable: bool,
+        model: Optional[Dict[str, bool]] = None,
+        arg_id: Optional[str] = None,
+    ) -> str:
+        """Add a propositional logic analysis result."""
+        pl_id = self._generate_id("pl", self.propositional_analysis_results)
+        entry = {
+            "id": pl_id,
+            "formulas": formulas,
+            "satisfiable": satisfiable,
+            "model": model or {},
+        }
+        if arg_id:
+            entry["arg_id"] = arg_id
+        self.propositional_analysis_results.append(entry)
+        state_logger.info(f"PL analysis added: {pl_id} (satisfiable={satisfiable})")
+        return pl_id
+
+    def add_modal_analysis_result(
+        self,
+        formulas: List[str],
+        valid: bool,
+        modalities: List[str],
+    ) -> str:
+        """Add a modal logic analysis result."""
+        ml_id = self._generate_id("modal", self.modal_analysis_results)
+        entry = {
+            "id": ml_id,
+            "formulas": formulas,
+            "valid": valid,
+            "modalities": modalities,
+        }
+        self.modal_analysis_results.append(entry)
+        state_logger.info(f"Modal analysis added: {ml_id} (valid={valid})")
+        return ml_id
+
+    def add_formal_synthesis_report(
+        self,
+        summary: str,
+        phase_results: Dict[str, Any],
+        overall_validity: float,
+    ) -> str:
+        """Add a formal synthesis report aggregating all logic analyses."""
+        fs_id = self._generate_id("fsyn", self.formal_synthesis_reports)
+        entry = {
+            "id": fs_id,
+            "summary": summary,
+            "phase_results": phase_results,
+            "overall_validity": overall_validity,
+        }
+        self.formal_synthesis_reports.append(entry)
+        state_logger.info(
+            f"Formal synthesis added: {fs_id} (validity={overall_validity:.2f})"
+        )
+        return fs_id
+
+    def add_nl_to_logic_translation(
+        self,
+        original_text: str,
+        formula: str,
+        logic_type: str,
+        is_valid: bool,
+        variables: Optional[Dict[str, str]] = None,
+        confidence: float = 0.0,
+        arg_id: Optional[str] = None,
+    ) -> str:
+        """Add a NL-to-formal-logic translation result (#173)."""
+        tr_id = self._generate_id("nll", self.nl_to_logic_translations)
+        entry = {
+            "id": tr_id,
+            "original_text": original_text[:200],
+            "formula": formula,
+            "logic_type": logic_type,
+            "is_valid": is_valid,
+            "variables": variables or {},
+            "confidence": confidence,
+        }
+        if arg_id:
+            entry["arg_id"] = arg_id
+        self.nl_to_logic_translations.append(entry)
+        state_logger.info(
+            f"NL→logic translation added: {tr_id} ({logic_type}, valid={is_valid})"
+        )
+        return tr_id
+
+    def set_workflow_results(self, workflow_name: str, results: Dict[str, Any]) -> None:
+        """Store workflow execution results."""
+        self.workflow_results[workflow_name] = results
+        state_logger.info(f"Workflow results stored for '{workflow_name}'")
+
+    # ---- Cross-referencing query methods (#302) ----
+
+    def get_argument_profile(self, arg_id: str) -> ArgumentProfile:
+        """Build an aggregated ArgumentProfile for a single argument.
+
+        Scans fallacies, quality scores, counter-arguments, JTMS beliefs,
+        and formal analysis results to gather everything related to *arg_id*.
+        """
+        description = self.identified_arguments.get(arg_id, "")
+        profile = ArgumentProfile(arg_id=arg_id, description=description)
+
+        # Fallacies targeting this argument
+        for _fid, fdata in self.identified_fallacies.items():
+            if fdata.get("target_argument_id") == arg_id:
+                profile.fallacies.append(fdata)
+
+        # Quality score (keyed by arg_id)
+        if arg_id in self.argument_quality_scores:
+            profile.quality_score = self.argument_quality_scores[arg_id]
+
+        # Counter-arguments — prefer ID-based matching, fall back to text
+        arg_desc = description
+        for ca in self.counter_arguments:
+            if ca.get("target_arg_id") == arg_id:
+                profile.counter_arguments.append(ca)
+                continue
+            if not arg_desc:
+                continue
+            original = ca.get("original_argument", "")
+            match_prefix = arg_desc[:60]
+            if original and (
+                original == arg_desc
+                or original[:60] == match_prefix
+                or match_prefix in original
+                or original in arg_desc
+            ):
+                profile.counter_arguments.append(ca)
+
+        # JTMS beliefs referencing this argument (by name containing arg_id or description prefix)
+        for _bid, bdata in self.jtms_beliefs.items():
+            belief_name = bdata.get("name", "")
+            if arg_id in belief_name or (arg_desc and arg_desc[:40] in belief_name):
+                profile.jtms_beliefs.append(bdata)
+
+        # Formal results — PL/FOL/NL-to-logic matched by arg_id or text
+        for pl in self.propositional_analysis_results:
+            if pl.get("arg_id") == arg_id:
+                profile.formal_results.append(pl)
+        for fol in self.fol_analysis_results:
+            if fol.get("arg_id") == arg_id:
+                profile.formal_results.append(fol)
+        for tr in self.nl_to_logic_translations:
+            if tr.get("arg_id") == arg_id:
+                profile.formal_results.append(tr)
+                continue
+            if not arg_desc:
+                continue
+            orig = tr.get("original_text", "")
+            match_prefix = arg_desc[:60]
+            if orig and (match_prefix in orig or orig in arg_desc):
+                profile.formal_results.append(tr)
+
+        return profile
+
+    def get_weak_arguments(self, threshold: float = 5.0) -> List[ArgumentProfile]:
+        """Return ArgumentProfiles for arguments whose quality overall < threshold."""
+        weak = []
+        for arg_id in self.identified_arguments:
+            qs = self.argument_quality_scores.get(arg_id)
+            if qs is not None and qs.get("overall", 10.0) < threshold:
+                weak.append(self.get_argument_profile(arg_id))
+        return weak
+
+    def get_fallacious_arguments(self) -> List[ArgumentProfile]:
+        """Return ArgumentProfiles for arguments targeted by at least one fallacy."""
+        targeted_ids: set[str] = set()
+        for _fid, fdata in self.identified_fallacies.items():
+            tid = fdata.get("target_argument_id")
+            if tid and tid in self.identified_arguments:
+                targeted_ids.add(tid)
+        return [self.get_argument_profile(aid) for aid in sorted(targeted_ids)]
+
+    def get_enrichment_summary(self) -> Dict[str, Any]:
+        """Return a summary of cross-referencing coverage across all arguments."""
+        total = len(self.identified_arguments)
+
+        # Collect sets of arg_ids that have each enrichment
+        with_fallacy: set[str] = set()
+        for _fid, fdata in self.identified_fallacies.items():
+            tid = fdata.get("target_argument_id")
+            if tid and tid in self.identified_arguments:
+                with_fallacy.add(tid)
+
+        with_quality = set(self.argument_quality_scores.keys()) & set(
+            self.identified_arguments.keys()
+        )
+
+        # Counter-arguments: prefer ID-based matching, fall back to text matching
+        with_counter: set[str] = set()
+        for ca in self.counter_arguments:
+            tid = ca.get("target_arg_id")
+            if tid and tid in self.identified_arguments:
+                with_counter.add(tid)
+                continue
+            original = ca.get("original_argument", "")
+            if not original:
+                continue
+            for arg_id, desc in self.identified_arguments.items():
+                if arg_id in with_counter or not desc:
+                    continue
+                match_prefix = desc[:60]
+                if (
+                    original == desc
+                    or original[:60] == match_prefix
+                    or match_prefix in original
+                    or original in desc
+                ):
+                    with_counter.add(arg_id)
+                    break
+
+        # Formal verification: check PL, FOL, and NL-to-logic translations
+        with_formal: set[str] = set()
+        # PL results with arg_id
+        for pl in self.propositional_analysis_results:
+            aid = pl.get("arg_id")
+            if aid and aid in self.identified_arguments:
+                with_formal.add(aid)
+        # FOL results with arg_id
+        for fol in self.fol_analysis_results:
+            aid = fol.get("arg_id")
+            if aid and aid in self.identified_arguments:
+                with_formal.add(aid)
+        # NL-to-logic translations: prefer arg_id, fall back to text match
+        for tr in self.nl_to_logic_translations:
+            aid = tr.get("arg_id")
+            if aid and aid in self.identified_arguments:
+                with_formal.add(aid)
+                continue
+            orig = tr.get("original_text", "")
+            if not orig:
+                continue
+            for arg_id, desc in self.identified_arguments.items():
+                if arg_id in with_formal or not desc:
+                    continue
+                match_prefix = desc[:60]
+                if match_prefix in orig or orig in desc:
+                    with_formal.add(arg_id)
+                    break
+
+        # JTMS beliefs
+        with_jtms: set[str] = set()
+        for arg_id, desc in self.identified_arguments.items():
+            for _bid, bdata in self.jtms_beliefs.items():
+                belief_name = bdata.get("name", "")
+                if arg_id in belief_name or (desc and desc[:40] in belief_name):
+                    with_jtms.add(arg_id)
+                    break
+
+        # Build gaps list
+        gaps: List[str] = []
+        for arg_id in sorted(self.identified_arguments.keys()):
+            if arg_id not in with_quality:
+                gaps.append(f"{arg_id} has no quality score")
+            if arg_id not in with_formal:
+                gaps.append(f"{arg_id} has no formal verification")
+
+        return {
+            "total_arguments": total,
+            "with_fallacy_analysis": len(with_fallacy),
+            "with_quality_score": len(with_quality),
+            "with_counter_argument": len(with_counter),
+            "with_formal_verification": len(with_formal),
+            "with_jtms_belief": len(with_jtms),
+            "gaps": gaps,
+        }
+
+    def get_state_snapshot(self, summarize: bool = False) -> Dict[str, Any]:
+        """Extended snapshot including all unified dimensions."""
+        base = super().get_state_snapshot(summarize=summarize)
+        if summarize:
+            base.update(
+                {
+                    "counter_argument_count": len(self.counter_arguments),
+                    "quality_scores_count": len(self.argument_quality_scores),
+                    "jtms_belief_count": len(self.jtms_beliefs),
+                    "dung_framework_count": len(self.dung_frameworks),
+                    "governance_decision_count": len(self.governance_decisions),
+                    "debate_transcript_count": len(self.debate_transcripts),
+                    "transcription_segment_count": len(self.transcription_segments),
+                    "semantic_index_ref_count": len(self.semantic_index_refs),
+                    "neural_fallacy_score_count": len(self.neural_fallacy_scores),
+                    "ranking_result_count": len(self.ranking_results),
+                    "aspic_result_count": len(self.aspic_results),
+                    "belief_revision_result_count": len(self.belief_revision_results),
+                    "dialogue_result_count": len(self.dialogue_results),
+                    "probabilistic_result_count": len(self.probabilistic_results),
+                    "bipolar_result_count": len(self.bipolar_results),
+                    "fol_analysis_count": len(self.fol_analysis_results),
+                    "propositional_analysis_count": len(
+                        self.propositional_analysis_results
+                    ),
+                    "modal_analysis_count": len(self.modal_analysis_results),
+                    "formal_synthesis_count": len(self.formal_synthesis_reports),
+                    "workflow_results_count": len(self.workflow_results),
+                    "atomic_propositions_count": sum(
+                        len(v) for v in self.atomic_propositions.values()
+                    ),
+                    "fol_shared_signature_sources": list(
+                        self.fol_shared_signature.keys()
+                    ),
+                    "strategic_objective_count": len(self.strategic_objectives),
+                    "strategic_decision_count": len(self.strategic_decisions_log),
+                }
+            )
+        else:
+            base.update(
+                {
+                    "counter_arguments": self.counter_arguments,
+                    "argument_quality_scores": self.argument_quality_scores,
+                    "jtms_beliefs": self.jtms_beliefs,
+                    "dung_frameworks": self.dung_frameworks,
+                    "governance_decisions": self.governance_decisions,
+                    "debate_transcripts": self.debate_transcripts,
+                    "transcription_segments": self.transcription_segments,
+                    "semantic_index_refs": self.semantic_index_refs,
+                    "neural_fallacy_scores": self.neural_fallacy_scores,
+                    "ranking_results": self.ranking_results,
+                    "aspic_results": self.aspic_results,
+                    "belief_revision_results": self.belief_revision_results,
+                    "dialogue_results": self.dialogue_results,
+                    "probabilistic_results": self.probabilistic_results,
+                    "bipolar_results": self.bipolar_results,
+                    "fol_analysis_results": self.fol_analysis_results,
+                    "propositional_analysis_results": self.propositional_analysis_results,
+                    "modal_analysis_results": self.modal_analysis_results,
+                    "formal_synthesis_reports": self.formal_synthesis_reports,
+                    "workflow_results": self.workflow_results,
+                    "atomic_propositions": self.atomic_propositions,
+                    "fol_shared_signature": self.fol_shared_signature,
+                    "strategic_objectives": self.strategic_objectives,
+                    "strategic_decisions_log": self.strategic_decisions_log,
+                }
+            )
+        return base
+
+
+# Optionnel : Ajouter un log à la fin du fichier pour confirmer le chargement du module
+module_logger = logging.getLogger(__name__)
+module_logger.debug("Module core.shared_state chargé.")
+
+# Créer un alias SharedState pour maintenir la compatibilité avec le code existant
+SharedState = RhetoricalAnalysisState

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_state_manager_plugin.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_state_manager_plugin.py
@@ -1,0 +1,831 @@
+# core/state_manager_plugin.py
+import json
+from typing import Dict, List, Any, Optional
+import logging
+from semantic_kernel.functions import kernel_function
+
+# Importer la classe d'état depuis le même répertoire
+from argumentation_lib._shared_state import RhetoricalAnalysisState
+
+# Logger spécifique pour le StateManager
+sm_logger = logging.getLogger("Orchestration.StateManager")
+if not sm_logger.handlers and not sm_logger.propagate:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] [%(name)s] %(message)s", datefmt="%H:%M:%S"
+    )
+    handler.setFormatter(formatter)
+    sm_logger.addHandler(handler)
+    sm_logger.setLevel(logging.INFO)
+
+
+class StateManagerPlugin:
+    """Plugin Semantic Kernel pour lire et modifier l'état d'analyse partagé."""
+
+    _state: "RhetoricalAnalysisState"  # Référence à l'instance d'état unique
+    _logger: logging.Logger
+
+    def __init__(self, state: "RhetoricalAnalysisState"):
+        """Initialise le plugin avec une instance d'état."""
+        self._state = state
+        self._logger = sm_logger
+        self._logger.info(
+            f"StateManagerPlugin initialisé avec l'instance RhetoricalAnalysisState (id: {id(self._state)})."
+        )
+
+    @kernel_function(
+        description="Récupère un aperçu (complet ou résumé) de l'état actuel de l'analyse.",
+        name="get_current_state_snapshot",
+    )
+    def get_current_state_snapshot(self, summarize: bool = True) -> str:
+        """Retourne l'état actuel sous forme de chaîne JSON."""
+        self._logger.info(
+            f"Appel get_current_state_snapshot (state id: {id(self._state)}, summarize={summarize})..."
+        )
+        try:
+            snapshot_dict = self._state.get_state_snapshot(summarize=summarize)
+            indent = 2 if not summarize else None
+            snapshot_json = json.dumps(
+                snapshot_dict, indent=indent, ensure_ascii=False, default=str
+            )
+            self._logger.info(" -> Snapshot de l'état généré avec succès.")
+            self._logger.debug(
+                f" -> Snapshot (summarize={summarize}): {snapshot_json[:500] + '...' if len(snapshot_json)>500 else snapshot_json}"
+            )
+            return snapshot_json
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de la récupération/sérialisation du snapshot de l'état: {e}",
+                exc_info=True,
+            )
+            return json.dumps(
+                {"error": f"Erreur récupération/sérialisation snapshot: {e}"}
+            )
+
+    @kernel_function(
+        description="Ajoute une nouvelle tâche d'analyse à l'état.",
+        name="add_analysis_task",
+    )
+    def add_analysis_task(self, description: str) -> str:
+        """Interface Kernel Function pour ajouter une tâche via l'état."""
+        self._logger.info(
+            f"Appel add_analysis_task (state id: {id(self._state)}): '{description[:60]}...'"
+        )
+        try:
+            task_id = self._state.add_task(description)
+            self._logger.info(f" -> Tâche '{task_id}' ajoutée avec succès via l'état.")
+            return task_id
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de l'ajout de la tâche '{description[:60]}...': {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur ajout tâche: {e}"
+
+    @kernel_function(
+        description="Ajoute un argument identifié à l'état.",
+        name="add_identified_argument",
+    )
+    def add_identified_argument(self, description: str) -> str:
+        """Interface Kernel Function pour ajouter un argument via l'état."""
+        self._logger.info(
+            f"Appel add_identified_argument (state id: {id(self._state)}): '{description[:60]}...'"
+        )
+        try:
+            arg_id = self._state.add_argument(description)
+            self._logger.info(f" -> Argument '{arg_id}' ajouté avec succès via l'état.")
+            return arg_id
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de l'ajout de l'argument '{description[:60]}...': {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur ajout argument: {e}"
+
+    @kernel_function(
+        description="Ajoute une liste d'arguments identifiés à l'état.",
+        name="add_identified_arguments",
+    )
+    def add_identified_arguments(self, arguments: List[str]) -> str:
+        """Interface Kernel Function pour ajouter une liste d'arguments via l'état."""
+        self._logger.info(
+            f"Appel add_identified_arguments (state id: {id(self._state)}) avec {len(arguments)} arguments..."
+        )
+        try:
+            self._state.add_identified_arguments(arguments)
+            self._logger.info(
+                f" -> {len(arguments)} arguments ajoutés avec succès via l'état."
+            )
+            return f"OK: {len(arguments)} arguments ajoutés."
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de l'ajout de la liste d'arguments: {e}", exc_info=True
+            )
+            return f"FUNC_ERROR: Erreur ajout liste d'arguments: {e}"
+
+    @kernel_function(
+        description="Ajoute une liste de sophismes identifiés à l'état.",
+        name="add_identified_fallacies",
+    )
+    def add_identified_fallacies(self, fallacies: List[Dict[str, str]]) -> str:
+        """Interface Kernel Function pour ajouter une liste de sophismes via l'état."""
+        self._logger.info(
+            f"Appel add_identified_fallacies (state id: {id(self._state)}) avec {len(fallacies)} sophismes..."
+        )
+        try:
+            self._state.add_identified_fallacies(fallacies)
+            self._logger.info(
+                f" -> {len(fallacies)} sophismes ajoutés avec succès via l'état."
+            )
+            return f"OK: {len(fallacies)} sophismes ajoutés."
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de l'ajout de la liste de sophismes: {e}", exc_info=True
+            )
+            return f"FUNC_ERROR: Erreur ajout liste de sophismes: {e}"
+
+    @kernel_function(
+        description="Marque une tâche comme répondue dans l'état.",
+        name="mark_task_as_answered",
+    )
+    def mark_task_as_answered(self, task_id: str, answer: str) -> str:
+        """Interface Kernel Function pour marquer une tâche comme terminée."""
+        self._logger.info(
+            f"Appel mark_task_as_answered (state id: {id(self._state)}): TaskID='{task_id}'"
+        )
+        try:
+            self._state.mark_task_as_answered(task_id, answer)
+            self._logger.info(
+                f" -> Tâche '{task_id}' marquée comme répondue avec succès."
+            )
+            return f"OK: Tâche {task_id} marquée comme répondue."
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors du marquage de la tâche '{task_id}' comme répondue: {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur marquage tâche {task_id}: {e}"
+
+    @kernel_function(
+        description="Ajoute un sophisme identifié à l'état.",
+        name="add_identified_fallacy",
+    )
+    def add_identified_fallacy(
+        self,
+        fallacy_type: str,
+        justification: str,
+        target_argument_id: Optional[str] = None,
+        family: str = "",
+    ) -> str:
+        """Interface Kernel Function pour ajouter un sophisme via l'état."""
+        self._logger.info(
+            f"Appel add_identified_fallacy (state id: {id(self._state)}): Type='{fallacy_type}', Target='{target_argument_id or 'None'}'..."
+        )
+        try:
+            fallacy_id = self._state.add_fallacy(
+                fallacy_type, justification, target_argument_id, family=family
+            )
+            self._logger.info(
+                f" -> Sophisme '{fallacy_id}' ajouté avec succès via l'état."
+            )
+            return fallacy_id
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de l'ajout du sophisme (Type: {fallacy_type}): {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur ajout sophisme: {e}"
+
+    @kernel_function(
+        description="Ajoute un belief set formel (ex: Propositional) à l'état.",
+        name="add_belief_set",
+    )
+    def add_belief_set(self, logic_type: str, content: str) -> str:
+        """Interface Kernel Function pour ajouter un belief set via l'état. Valide le type logique."""
+        self._logger.info(
+            f"Appel add_belief_set (state id: {id(self._state)}): Type='{logic_type}'..."
+        )
+        valid_logic_types = {
+            "propositional": "Propositional",
+            "pl": "Propositional",
+            "fol": "FOL",
+            "first_order": "FOL",
+        }
+        normalized_logic_type = logic_type.strip().lower()
+
+        if normalized_logic_type not in valid_logic_types:
+            error_msg = f"Type logique '{logic_type}' non supporté. Types valides (insensible casse): {list(valid_logic_types.keys())}"
+            self._logger.error(error_msg)
+            return f"FUNC_ERROR: {error_msg}"
+
+        validated_logic_type = valid_logic_types[normalized_logic_type]
+        try:
+            bs_id = self._state.add_belief_set(validated_logic_type, content)
+            self._logger.info(
+                f" -> Belief Set '{bs_id}' ajouté avec succès via l'état (Type: {validated_logic_type})."
+            )
+            return bs_id
+        except Exception as e:
+            self._logger.error(
+                f"Erreur interne lors de l'ajout du Belief Set (Type: {validated_logic_type}): {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur interne ajout Belief Set: {e}"
+
+    @kernel_function(
+        description="Enregistre une requête formelle et son résultat brut dans le log de l'état.",
+        name="log_query_result",
+    )
+    def log_query_result(self, belief_set_id: str, query: str, raw_result: str) -> str:
+        """Interface Kernel Function pour logger une requête via l'état."""
+        self._logger.info(
+            f"Appel log_query_result (state id: {id(self._state)}): BS_ID='{belief_set_id}', Query='{query[:60]}...'"
+        )
+        try:
+            log_id = self._state.log_query(belief_set_id, query, raw_result)
+            self._logger.info(f" -> Requête '{log_id}' loggée avec succès via l'état.")
+            return log_id
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors du logging de la requête (BS_ID: {belief_set_id}): {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur logging requête: {e}"
+
+    @kernel_function(
+        description=(
+            "Enregistre une traduction NL → logique formelle dans l'état. "
+            "Paramètres: original_text, formula, logic_type (propositional/fol), "
+            "is_valid, variables (JSON), confidence (0-1)."
+        ),
+        name="add_nl_to_logic_translation",
+    )
+    def add_nl_to_logic_translation(
+        self,
+        original_text: str,
+        formula: str,
+        logic_type: str,
+        is_valid: str = "true",
+        variables: str = "{}",
+        confidence: str = "0.7",
+    ) -> str:
+        """Interface Kernel Function pour enregistrer une traduction NL→logique."""
+        self._logger.info(
+            f"Appel add_nl_to_logic_translation: logic_type='{logic_type}', valid='{is_valid}'"
+        )
+        try:
+            import json as _json
+
+            parsed_vars = (
+                _json.loads(variables) if isinstance(variables, str) else variables
+            )
+            tr_id = self._state.add_nl_to_logic_translation(
+                original_text=original_text[:200],
+                formula=formula,
+                logic_type=logic_type,
+                is_valid=is_valid.lower() in ("true", "1", "yes"),
+                variables=parsed_vars,
+                confidence=float(confidence),
+            )
+            self._logger.info(f" -> Traduction '{tr_id}' enregistrée via l'état.")
+            return tr_id
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de l'ajout traduction NL→logique: {e}", exc_info=True
+            )
+            return f"FUNC_ERROR: Erreur ajout traduction: {e}"
+
+    @kernel_function(
+        description="Ajoute une réponse d'un agent à une tâche d'analyse spécifique dans l'état.",
+        name="add_answer",
+    )
+    def add_answer(
+        self, task_id: str, author_agent: str, answer_text: str, source_ids: List[str]
+    ) -> str:
+        """Interface Kernel Function pour ajouter une réponse via l'état."""
+        self._logger.info(
+            f"Appel add_answer (state id: {id(self._state)}): TaskID='{task_id}', Author='{author_agent}'..."
+        )
+        try:
+            self._state.add_answer(task_id, author_agent, answer_text, source_ids)
+            self._logger.info(
+                f" -> Réponse pour tâche '{task_id}' ajoutée avec succès via l'état."
+            )
+            return f"OK: Réponse pour {task_id} ajoutée."
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de l'ajout de la réponse pour la tâche '{task_id}': {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur ajout réponse pour {task_id}: {e}"
+
+    @kernel_function(
+        description="Enregistre la conclusion finale de l'analyse dans l'état.",
+        name="set_final_conclusion",
+    )
+    def set_final_conclusion(self, conclusion: str) -> str:
+        """Interface Kernel Function pour enregistrer la conclusion via l'état."""
+        self._logger.info(
+            f"Appel set_final_conclusion (state id: {id(self._state)}): '{conclusion[:60]}...'"
+        )
+        try:
+            self._state.set_conclusion(conclusion)
+            self._logger.info(
+                f" -> Conclusion finale enregistrée avec succès via l'état."
+            )
+            return "OK: Conclusion finale enregistrée."
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de l'enregistrement de la conclusion finale: {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur enregistrement conclusion: {e}"
+
+    @kernel_function(
+        description="Désigne quel agent doit parler au prochain tour. Utiliser le nom EXACT de l'agent.",
+        name="designate_next_agent",
+    )
+    def designate_next_agent(self, agent_name: str) -> str:
+        """Interface Kernel Function pour désigner le prochain agent via l'état."""
+        self._logger.info(
+            f"Appel designate_next_agent (state id: {id(self._state)}): Prochain = '{agent_name}'"
+        )
+        try:
+            self._state.designate_next_agent(agent_name)
+            self._logger.info(
+                f" -> Agent '{agent_name}' désigné avec succès via l'état."
+            )
+            return f"OK. Agent '{agent_name}' désigné pour le prochain tour."
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de la désignation de l'agent '{agent_name}': {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur désignation agent {agent_name}: {e}"
+
+    # =========================================================================
+    # JTMS Hub Integration (#214)
+    # =========================================================================
+
+    @kernel_function(
+        description="Create a JTMS belief with extended metadata (agent_source, confidence).",
+        name="jtms_create_belief",
+    )
+    def jtms_create_belief(
+        self,
+        belief_name: str,
+        agent_source: str = "unknown",
+        confidence: float = 0.5,
+        context: Optional[str] = None,
+    ) -> str:
+        """Create an ExtendedBelief in the JTMS session via StateManagerPlugin (#214)."""
+        self._logger.info(
+            f"Appel jtms_create_belief: '{belief_name}', source={agent_source}, conf={confidence}"
+        )
+        try:
+            # Import here to avoid circular dependency
+            raise ImportError("JTMS not available in CoursIA pedagogical mode")  # JTMS shim
+            import json
+
+            # Get or create JTMS session from state
+            if not hasattr(self._state, "_jtms_session"):
+                self._state._jtms_session = JTMSSession(
+                    session_id="shared_jtms", owner_agent="state_manager_plugin"
+                )
+
+            session = self._state._jtms_session
+
+            # Parse context if JSON string
+            context_dict = {}
+            if context:
+                try:
+                    context_dict = json.loads(context)
+                except (json.JSONDecodeError, TypeError):
+                    context_dict = {"raw": context}
+
+            # Create extended belief
+            ext_belief = session.add_belief(
+                belief_name,
+                agent_source=agent_source,
+                context=context_dict,
+                confidence=confidence,
+            )
+
+            # Sync to state.jtms_beliefs dict so enrichment summary sees it (#562)
+            if hasattr(self._state, "add_jtms_belief"):
+                justification_names = []
+                self._state.add_jtms_belief(
+                    name=belief_name,
+                    valid=True,
+                    justifications=justification_names,
+                )
+
+            self._logger.info(
+                f" -> Belief '{belief_name}' created with ExtendedBelief metadata"
+            )
+            return f"OK: Belief '{belief_name}' created by {agent_source}"
+
+        except Exception as e:
+            self._logger.error(
+                f"Error creating JTMS belief '{belief_name}': {e}", exc_info=True
+            )
+            return f"FUNC_ERROR: Error creating belief: {e}"
+
+    @kernel_function(
+        description="Add a JTMS justification between beliefs (IN-list and OUT-list).",
+        name="jtms_add_justification",
+    )
+    def jtms_add_justification(
+        self,
+        in_list: List[str],
+        out_list: List[str],
+        conclusion: str,
+        agent_source: str = "unknown",
+    ) -> str:
+        """Add a justification with ExtendedBelief tracking via StateManagerPlugin (#214)."""
+        self._logger.info(
+            f"Appel jtms_add_justification: IN={len(in_list)}, OUT={len(out_list)}, conclusion={conclusion}"
+        )
+        try:
+            raise ImportError("JTMS not available in CoursIA pedagogical mode")  # JTMS shim
+
+            # Get or create JTMS session
+            if not hasattr(self._state, "_jtms_session"):
+                self._state._jtms_session = JTMSSession(
+                    session_id="shared_jtms", owner_agent="state_manager_plugin"
+                )
+
+            session = self._state._jtms_session
+
+            # Add justification with agent source tracking
+            session.add_justification(
+                in_list, out_list, conclusion, agent_source=agent_source
+            )
+
+            self._logger.info(
+                f" -> Justification for '{conclusion}' added by {agent_source}"
+            )
+            return f"OK: Justification for '{conclusion}' added by {agent_source}"
+
+        except Exception as e:
+            self._logger.error(f"Error adding JTMS justification: {e}", exc_info=True)
+            return f"FUNC_ERROR: Error adding justification: {e}"
+
+    @kernel_function(
+        description="Query JTMS beliefs with ExtendedBelief metadata (agent_source, confidence, history).",
+        name="jtms_query_beliefs",
+    )
+    def jtms_query_beliefs(self, agent_filter: Optional[str] = None) -> str:
+        """Query JTMS beliefs with ExtendedBelief metadata via StateManagerPlugin (#214)."""
+        self._logger.info(f"Appel jtms_query_beliefs: filter={agent_filter}")
+        try:
+            raise ImportError("JTMS not available in CoursIA pedagogical mode")  # JTMS shim
+            import json
+
+            # Get JTMS session
+            if not hasattr(self._state, "_jtms_session"):
+                return "FUNC_ERROR: No JTMS session initialized. Call jtms_create_belief first."
+
+            session = self._state._jtms_session
+
+            # Build query results with ExtendedBelief metadata
+            results = []
+            for name, ext_belief in session.extended_beliefs.items():
+                # Apply filter if specified
+                if agent_filter and ext_belief.agent_source != agent_filter:
+                    continue
+
+                belief_data = {
+                    "name": name,
+                    "valid": ext_belief.valid,
+                    "agent_source": ext_belief.agent_source,
+                    "confidence": ext_belief.confidence,
+                    "context": ext_belief.context,
+                    "creation_timestamp": ext_belief.creation_timestamp.isoformat(),
+                    "modification_count": len(ext_belief.modification_history),
+                    "justification_count": len(ext_belief.justifications),
+                }
+                results.append(belief_data)
+
+            self._logger.info(f" -> Found {len(results)} beliefs matching filter")
+            return json.dumps(results, ensure_ascii=False, indent=2)
+
+        except Exception as e:
+            self._logger.error(f"Error querying JTMS beliefs: {e}", exc_info=True)
+            return f"FUNC_ERROR: Error querying beliefs: {e}"
+
+    @kernel_function(
+        description="Check JTMS session consistency and return conflict report.",
+        name="jtms_check_consistency",
+    )
+    def jtms_check_consistency(self) -> str:
+        """Check JTMS consistency and return conflict report via StateManagerPlugin (#214)."""
+        self._logger.info("Appel jtms_check_consistency")
+        try:
+            raise ImportError("JTMS not available in CoursIA pedagogical mode")  # JTMS shim
+            import json
+
+            # Get JTMS session
+            if not hasattr(self._state, "_jtms_session"):
+                return "FUNC_ERROR: No JTMS session initialized."
+
+            session = self._state._jtms_session
+
+            # Check consistency
+            consistency_result = session.check_consistency()
+
+            result = {
+                "is_consistent": consistency_result.get("is_consistent", True),
+                "conflicts_detected": consistency_result.get("conflicts", []),
+                "total_beliefs": len(session.extended_beliefs),
+                "consistency_checks": session.consistency_checks,
+                "session_version": session.version,
+            }
+
+            self._logger.info(f" -> Consistency check: {result['is_consistent']}")
+            return json.dumps(result, ensure_ascii=False, indent=2)
+
+        except Exception as e:
+            self._logger.error(f"Error checking JTMS consistency: {e}", exc_info=True)
+            return f"FUNC_ERROR: Error checking consistency: {e}"
+
+    @kernel_function(
+        description=(
+            "Retract a JTMS belief by setting its validity to False and propagating. "
+            "Use this when a fallacy is detected on an argument — the belief and all "
+            "beliefs that depend solely on it will be marked as defeated. "
+            "Parameters: belief_name (str), reason (str, e.g. 'fallacy: appeal to authority')."
+        ),
+        name="jtms_retract_belief",
+    )
+    def jtms_retract_belief(self, belief_name: str, reason: str = "") -> str:
+        """Retract a JTMS belief, propagating to dependent beliefs (#287).
+
+        This is the core TMS retraction mechanism: when a fallacy is detected
+        on argument N, calling jtms_retract_belief('arg_N', 'fallacy: ...') will:
+        1. Set the belief's truth value to None (unknown/defeated)
+        2. Propagate: all beliefs justified solely by arg_N become OUT
+        3. Record the retraction in the belief's modification history
+        """
+        self._logger.info(
+            f"Appel jtms_retract_belief: '{belief_name}', reason='{reason[:60]}'"
+        )
+        try:
+            raise ImportError("JTMS not available in CoursIA pedagogical mode")  # JTMS shim
+
+            if not hasattr(self._state, "_jtms_session"):
+                return "FUNC_ERROR: No JTMS session initialized. Call jtms_create_belief first."
+
+            session = self._state._jtms_session
+
+            # Check belief exists
+            if belief_name not in session.extended_beliefs:
+                # Try partial match (agents may use slightly different names)
+                candidates = [
+                    name
+                    for name in session.extended_beliefs
+                    if belief_name.lower() in name.lower()
+                    or name.lower() in belief_name.lower()
+                ]
+                if candidates:
+                    belief_name = candidates[0]
+                    self._logger.info(f" -> Partial match: using '{belief_name}'")
+                else:
+                    return (
+                        f"FUNC_ERROR: Belief '{belief_name}' not found in JTMS session."
+                    )
+
+            ext_belief = session.extended_beliefs[belief_name]
+
+            # Record retraction in history
+            was_valid = ext_belief.valid
+
+            # Use core JTMS set_belief_validity to propagate
+            session.jtms.set_belief_validity(belief_name, None)
+
+            # Record retraction in extended belief via modification history
+            import datetime as _dt
+
+            ext_belief.record_modification(
+                "retract",
+                {
+                    "reason": reason,
+                    "timestamp": _dt.datetime.now().isoformat(),
+                },
+            )
+            ext_belief.context["retracted"] = True
+            ext_belief.context["retraction_reason"] = reason
+
+            # Sync retraction to state.jtms_beliefs dict so enrichment sees it (#562)
+            if hasattr(self._state, "jtms_beliefs"):
+                for bid, bdata in self._state.jtms_beliefs.items():
+                    if bdata.get("name") == belief_name:
+                        bdata["valid"] = False
+                        bdata["retracted"] = True
+                        bdata["retraction_reason"] = reason
+                        break
+
+            # Count affected beliefs (beliefs that lost their justification)
+            affected = []
+            for name, b in session.extended_beliefs.items():
+                if name != belief_name and not b.valid:
+                    # Check if this belief was justified by the retracted one
+                    for j in b.justifications:
+                        if belief_name in j.get("in_list", []):
+                            affected.append(name)
+
+            result = {
+                "retracted_belief": belief_name,
+                "was_valid": was_valid,
+                "reason": reason,
+                "affected_beliefs": affected,
+                "affected_count": len(affected),
+            }
+
+            self._logger.info(
+                f" -> Belief '{belief_name}' retracted. {len(affected)} dependent beliefs affected."
+            )
+            import json
+
+            return json.dumps(result, ensure_ascii=False, indent=2)
+
+        except Exception as e:
+            self._logger.error(
+                f"Error retracting belief '{belief_name}': {e}", exc_info=True
+            )
+            return f"FUNC_ERROR: Error retracting belief: {e}"
+
+    # =========================================================================
+    # Phase result writers — @kernel_function wrappers for add_* methods (#469)
+    # =========================================================================
+
+    @kernel_function(
+        description="Add an extract (text segment identified during extraction).",
+        name="add_extract",
+    )
+    def add_extract(self, name: str, content: str) -> str:
+        try:
+            ext_id = self._state.add_extract(name, content)
+            return ext_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Add a counter-argument result. Params: original_arg, counter_content, strategy, score (0-1), target_arg_id (optional).",
+        name="add_counter_argument",
+    )
+    def add_counter_argument(
+        self,
+        original_arg: str,
+        counter_content: str,
+        strategy: str,
+        score: str = "0.5",
+        target_arg_id: str = "",
+    ) -> str:
+        try:
+            ca_id = self._state.add_counter_argument(
+                original_arg,
+                counter_content,
+                strategy,
+                float(score),
+                target_arg_id=target_arg_id or None,
+            )
+            return ca_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Add quality scores for an argument. Params: arg_id, scores_json (virtue→float), overall (0-1).",
+        name="add_quality_score",
+    )
+    def add_quality_score(
+        self, arg_id: str, scores_json: str, overall: str = "0.5"
+    ) -> str:
+        try:
+            scores = json.loads(scores_json) if isinstance(scores_json, str) else scores_json
+            self._state.add_quality_score(arg_id, scores, float(overall))
+            return f"OK: Quality scores added for {arg_id}"
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Add a Dung argumentation framework. Params: name, arguments_json (list), attacks_json (list of pairs), extensions_json (optional).",
+        name="add_dung_framework",
+    )
+    def add_dung_framework(
+        self,
+        name: str,
+        arguments_json: str,
+        attacks_json: str,
+        extensions_json: str = "{}",
+    ) -> str:
+        try:
+            arguments = json.loads(arguments_json)
+            attacks = json.loads(attacks_json)
+            extensions = json.loads(extensions_json) if extensions_json != "{}" else None
+            df_id = self._state.add_dung_framework(name, arguments, attacks, extensions)
+            return df_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Add a governance/voting decision. Params: method (copeland/borda/...), winner, scores_json.",
+        name="add_governance_decision",
+    )
+    def add_governance_decision(
+        self, method: str, winner: str, scores_json: str
+    ) -> str:
+        try:
+            scores = json.loads(scores_json)
+            gd_id = self._state.add_governance_decision(method, winner, scores)
+            return gd_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Add a debate transcript. Params: topic, exchanges_json (list of {speaker, content}), winner (optional).",
+        name="add_debate_transcript",
+    )
+    def add_debate_transcript(
+        self, topic: str, exchanges_json: str, winner: str = ""
+    ) -> str:
+        try:
+            exchanges = json.loads(exchanges_json)
+            dt_id = self._state.add_debate_transcript(
+                topic, exchanges, winner if winner else None
+            )
+            return dt_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Add a ranking semantics result. Params: method, arguments_json (list), comparisons_json (list).",
+        name="add_ranking_result",
+    )
+    def add_ranking_result(
+        self, method: str, arguments_json: str, comparisons_json: str
+    ) -> str:
+        try:
+            arguments = json.loads(arguments_json)
+            comparisons = json.loads(comparisons_json)
+            rk_id = self._state.add_ranking_result(method, arguments, comparisons)
+            return rk_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Add an ASPIC+ analysis result. Params: reasoner_type, extensions_json, statistics_json.",
+        name="add_aspic_result",
+    )
+    def add_aspic_result(
+        self, reasoner_type: str, extensions_json: str, statistics_json: str
+    ) -> str:
+        try:
+            extensions = json.loads(extensions_json)
+            statistics = json.loads(statistics_json)
+            as_id = self._state.add_aspic_result(reasoner_type, extensions, statistics)
+            return as_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Add a belief revision result. Params: method, original_json (list), revised_json (list).",
+        name="add_belief_revision_result",
+    )
+    def add_belief_revision_result(
+        self, method: str, original_json: str, revised_json: str
+    ) -> str:
+        try:
+            original = json.loads(original_json)
+            revised = json.loads(revised_json)
+            br_id = self._state.add_belief_revision_result(method, original, revised)
+            return br_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Add a neural fallacy detection score. Params: text_segment, label, confidence (0-1).",
+        name="add_neural_fallacy_score",
+    )
+    def add_neural_fallacy_score(
+        self, text_segment: str, label: str, confidence: str = "0.5"
+    ) -> str:
+        try:
+            nf_id = self._state.add_neural_fallacy_score(
+                text_segment, label, float(confidence)
+            )
+            return nf_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Set the workflow execution results. Params: workflow_name, results_json.",
+        name="set_workflow_results",
+    )
+    def set_workflow_results(self, workflow_name: str, results_json: str) -> str:
+        try:
+            results = json.loads(results_json)
+            self._state.set_workflow_results(workflow_name, results)
+            return f"OK: Workflow results set for {workflow_name}"
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"


### PR DESCRIPTION
## Phase B.2 — Core Vendoring for Argument Analysis

See #2137 Phase B scope and acceptance criteria.

### What this PR adds (on top of merged B.1 shims from #2851)

**State Management (autoportant, zero EPITA deps):**
- `_shared_state.py` — `RhetoricalAnalysisState` (1121 lines, vendored from EPITA `core/shared_state.py`)
  - Complete state container: tasks, arguments, fallacies, belief sets, query log, answers, conclusion
  - Zero imports from `argumentation_analysis.*`
  - Includes `ArgumentProfile` dataclass

**State Manager Plugin (SK `@kernel_function` wrapper):**
- `_state_manager_plugin.py` — `StateManagerPlugin` (831 lines, adapted from EPITA `core/state_manager_plugin.py`)
  - 25+ kernel functions for state manipulation
  - Import adapted: `argumentation_analysis` → `argumentation_lib`
  - JTMS lazy imports neutralized (5 occurrences, graceful error)
  - Tested with semantic_kernel 1.42.0

**Simplified Runner (bypasses broken factory):**
- `_runner.py` — `AnalysisRunner` with 3-phase pipeline
  - **Resolves B.3 blocker** by eliminating factory dependency entirely
  - Direct `ChatCompletionAgent` instantiation (no `AgentFactory` needed)
  - 3 phases: Informal → Formal → Synthesis
  - Uses SK `AgentGroupChat` for multi-agent orchestration
  - Prompts vendored from EPITA `pm/prompts.py` (simplified for pedagogy)
  - Both `run()` (async) and `run_sync()` (blocking) interfaces

**Package API (`__init__.py` updated):**
- Version bump to 0.2.0
- Lazy `get_analysis_runner()` and `get_state_manager_plugin()`
- Full `__all__` exports

### Verification
- All imports tested: `_config`, `_paths`, `_shared_state`, `_state_manager_plugin`, `_runner`
- Full integration test passes (state creation, task/argument/fallacy management, runner instantiation)
- Zero secrets, zero model names, zero env reads
- Works with semantic_kernel 1.42.0

### Blocker B.3 Resolution
The EPITA runner calls `AgentFactory(kernel, settings=settings)` but the factory expects `AgentFactory(kernel, llm_service_id: str)`. Also `create_agent(agent_class=...)` vs factory `create_agent(agent_type: AgentType)`. Both are hard TypeErrors at runtime.

**Resolution:** Bypass factory entirely. The runner instantiates agents directly via `ChatCompletionAgent` with explicit prompts. This eliminates the contract mismatch while preserving the 3-phase pipeline logic.

See #2137