### PR TITLE
feat(qc): add Option Wheel risk-education notebook (See #1405)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-09-OptionWheel.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-09-OptionWheel.ipynb
@@ -1,0 +1,308 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-Cloud-08-ValueFactor-ZScore <<](./QC-Py-Cloud-08-ValueFactor-ZScore.ipynb)\n",
+    "\n",
+    "# Option Wheel — Le paradoxe du win-rate eleve\n",
+    "\n",
+    "**Source** : Projet etudiant ESGF 2026 (QC `31846074`), anonymise et adapte.\n",
+    "**Type** : `doc cloud` — resultats obtenus sur [QuantConnect Cloud](https://www.quantconnect.com/lab).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. Comprendre la **strategie Wheel** : cycle put nu -> assignment -> covered call -> cession.\n",
+    "2. Distinguer **win-rate eleve** et **esperance de gain positive** (le piege fondamental).\n",
+    "3. Analyser le **risque de queue** : pourquoi une strategie qui gagne 90% du temps peut etre perdante.\n",
+    "4. Interpreter un drawdown catastrophique (-100%+) et son origine (concentration, levier implicite).\n",
+    "\n",
+    "**Prerequis** : Options de base (call/put, strike, premium), QC-Py-06-Options-Trading.\n",
+    "\n",
+    "**Duree estimee** : 35 min"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Concept : La strategie Wheel\n",
+    "\n",
+    "Le **Wheel** (roue) est une strategie d'options income populaire chez les investisseurs particuliers. Elle vise a generer un revenu regulier par la vente d'options, en faisant \"tourner\" un cycle.\n",
+    "\n",
+    "### Le cycle en 4 etapes\n",
+    "\n",
+    "```\n",
+    "  (1) Vendre PUT nu (cash-secured)          (3) Vendre COVERED CALL\n",
+    "      sur un sous-jacent que l'on                 sur les actions detenues\n",
+    "      est pret a acheter                          pour generer un revenu\n",
+    "            |                                          ^\n",
+    "            v                                          |\n",
+    "  (2) Si assigne : acheter 100 actions        (4) Si call exerce : vendre\n",
+    "      au strike (devenir actionnaire)            les actions -> retour a (1)\n",
+    "```\n",
+    "\n",
+    "### La promesse\n",
+    "\n",
+    "- **Revenu regulier** : on encaisse les premiums (time decay theta).\n",
+    "- **Win-rate eleve** : la plupart des options expirent sans valeur (~70-85% si OTM).\n",
+    "- **Recuperation** : si assigne, on garde les actions et on vend des calls.\n",
+    "\n",
+    "### La realite cachee\n",
+    "\n",
+    "> **Le piege** : un win-rate de 85% ne veut rien dire si les 15% de pertes sont 10x plus grandes que les gains. La vente d'options a un **profil de payoff asymetrique** : petits gains frequents, pertes rares mais catastrophiques."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Le paradoxe du win-rate\n",
+    "\n",
+    "### Esperance mathematique\n",
+    "\n",
+    "$$E[G] = p_{win} \\times gain_{moyen} - p_{loss} \\times perte_{moyenne}$$\n",
+    "\n",
+    "Exemple typique d'un put OTM :\n",
+    "\n",
+    "| Scenario | Probabilite | P&L par contrat |\n",
+    "|----------|-------------|------------------|\n",
+    "| Option expire sans valeur | 85% | +200$ (premium garde) |\n",
+    "| Option assignee (crash) | 15% | -1 800$ (achat a strike > marche) |\n",
+    "\n",
+    "$$E[G] = 0.85 \\times 200 - 0.15 \\times 1800 = 170 - 270 = -60$$$\n",
+    "\n",
+    "**Esperance NEGATIVE** malgre un win-rate de 85% ! C'est le paradoxe fondamental.\n",
+    "\n",
+    "### Pourquoi c'est seduisant psychologiquement\n",
+    "\n",
+    "1. **Renforcement positif frequent** : on encaisse des premiums presque chaque semaine.\n",
+    "2. **Recence bias** : les grosses pertes sont rares, donc oubliees.\n",
+    "3. **Illusion de competence** : \"ca marche\", donc on augmente la taille.\n",
+    "4. **Vente de volatilite** : on parie que le marche sera calme — jusqu'a ce qu'il ne le soit plus."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Calculer l'esperance de gain\n",
+    "\n",
+    "Implementez la fonction `expected_value` qui calcule l'esperance d'une vente de put, etant donnes la probabilite d'assignment, la premium et la perte moyenne si assigne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exercice 1 : Calculer l'esperance de gain d'une vente de put\n",
+    "# TODO etudiant : implementer expected_value(p_assignment, premium, avg_loss) -> float\n",
+    "# Indice : E[G] = (1 - p_assignment) * premium - p_assignment * avg_loss\n",
+    "def expected_value(p_assignment, premium, avg_loss):\n",
+    "    return 0.0  # TODO etudiant : calculer l'esperance\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Le code QC Cloud\n",
+    "\n",
+    "La strategie `WheelTechSimple` (projet QC `31846074`) implemente le cycle sur 5 actions tech (NVDA, ORCL, CSCO, AMD, QCOM) :\n",
+    "\n",
+    "```python\n",
+    "class WheelTechSimple(QCAlgorithm):\n",
+    "    def Initialize(self):\n",
+    "        self.SetStartDate(2020, 1, 1)\n",
+    "        self.SetEndDate(2024, 12, 31)\n",
+    "        self.SetCash(50000)\n",
+    "        self.SetBenchmark(\"VGT\")  # Tech ETF\n",
+    "        \n",
+    "        # Parametres du wheel\n",
+    "        self.days_to_expiry = 30    # DTE cible\n",
+    "        self.otm_threshold = 0.05   # 5% OTM minimum\n",
+    "        self.max_exposure = 0.20    # 20% du capital par trade\n",
+    "        \n",
+    "        # Univers : 5 actions tech volatiles\n",
+    "        self.eq_names = ['NVDA', 'ORCL', 'CSCO', 'AMD', 'QCOM']\n",
+    "```\n",
+    "\n",
+    "### Logique du cycle\n",
+    "\n",
+    "- `OnData` verifie chaque action : si pas de position -> vendre put ; si on a les actions -> vendre covered call.\n",
+    "- `_sell_put` : calcule le strike OTM, trouve le contrat, vend la quantite (max 20% cash).\n",
+    "- `_sell_covered_call` : vend des calls couverts sur les actions detenues.\n",
+    "- `_find_option` : filtre la chaine d'options par DTE et strike."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Resultats QC Cloud — Le piege revele\n",
+    "\n",
+    "**Projet QC Cloud** : `31846074` (VGT tech wheel, 2020-2024).\n",
+    "\n",
+    "| Metrique | Valeur | Benchmark VGT (~) | Interpretation |\n",
+    "|----------|--------|--------------------|----------------|\n",
+    "| Sharpe | -0.51 | ~0.70 | **Nettement negatif** |\n",
+    "| CAGR | 0% | ~18% | Aucun rendement |\n",
+    "| MaxDD | -103.5% | ~-30% | **Catastrophique** (perte virtuelle totale) |\n",
+    "| PSR | 0.004% | > 50% | Signal inexistant |\n",
+    "| Tradeable days | 1258 | — | 5 ans de donnees |\n",
+    "\n",
+    "### Diagnostic\n",
+    "\n",
+    "**Sharpe -0.51** : la strategie detrui de la valeur. La vente de premiums ne compense pas les pertes d'assignment.\n",
+    "\n",
+    "**MaxDD -103.5%** : anormal. Un drawdown theorique > 100% indique un **levier implicite** ou une **concentration extreme** : si plusieurs puts sont assignes simultanement pendant un crash (ex: COVID mars 2020, bear market 2022), le capital ne suffit pas a couvrir les achats forces au-dessus du marche.\n",
+    "\n",
+    "**CAGR 0% avec Sharpe negatif** : le cash reste immobilise en collateral (cash-secured puts), generant peu de rendement, tandis que les assignments successifs erodent le capital.\n",
+    "\n",
+    "> **Lecon** : le wheel sur actions tech volatiles pendant une periode de crash (2020 COVID + 2022 bear market) illustre exactement le paradoxe. Les premiums etaient petits, les assignments frequents et couteux."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Identifier les scenarii defavorables\n",
+    "\n",
+    "Le wheel perd de l'argent dans des conditions specifiques. Identifiez les 3 principaux scenarii de perte et proposez une mitigation pour chacun."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Identifier les scenarii de perte du wheel\n",
+    "# TODO etudiant : pour chaque scenario, decrire le mecanisme de perte + 1 mitigation\n",
+    "loss_scenarios = {\n",
+    "    \"crash_concurrent\": None,    # TODO etudiant : description + mitigation\n",
+    "    \"action_devaluee\": None,     # ex: action assignee qui continue de chuter\n",
+    "    \"volatilite_implose\": None,  # IV crush apres un evenement\n",
+    "}\n",
+    "# Indice : la diversification et le position sizing sont les premieres mitigations\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Lecons de gestion du risque\n",
+    "\n",
+    "### 1. Le win-rate n'est pas une metrique de performance\n",
+    "\n",
+    "Une strategie a 90% de win-rate peut etre perdante. La vraie question est l'**esperance** et le **rapport gain/perte**. Un Sharpe positif est plus informatif qu'un win-rate eleve.\n",
+    "\n",
+    "### 2. Le risque de queue est real\n",
+    "\n",
+    "La vente d'options vend de l'assurance. Comme un assureur, on encaisse des petites primes jusqu'au sinistre — puis on paie gros. Les evenements extremes (COVID, crash, faillite) surviennent plus souvent que le modele gaussien ne le predit (fat tails).\n",
+    "\n",
+    "### 3. La concentration tue\n",
+    "\n",
+    "Le wheel sur 5 actions tech (NVDA, AMD, ...) concentre le risque sectoriel. Un crash tech = assignments multiples simultanes = perte disproportionnee. Diversifier sur 20-50 sous-jacents non correlates reduit ce risque.\n",
+    "\n",
+    "### 4. Le position sizing est critique\n",
+    "\n",
+    "Vouloir \"maximiser le revenu\" pousse a vendre trop de contrats. La regle prudente : ne jamais risquer plus de 1-2% du capital par trade, et garder 50%+ de cash disponible pour les assignments.\n",
+    "\n",
+    "### 5. Le regime de volatilite compte\n",
+    "\n",
+    "Le wheel performe mieux en marche stable/haussier avec volatilite moderee. En bear market ou haute volatilite, les puts sont assignes et les covered calls limitent la recuperation. Adapter la taille au regime VIX."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Concevoir un wheel defensif\n",
+    "\n",
+    "Proposez 3 modifications pour transformer ce wheel agressif en une strategie plus defensive, en justifiant l'impact attendu sur le risque."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Concevoir un wheel defensif\n",
+    "# TODO etudiant : 3 modifications avec justification de l'impact risque\n",
+    "defensive_modifications = {\n",
+    "    \"diversification\": None,  # TODO etudiant : ex: 20+ sous-jacents non correlates\n",
+    "    \"position_sizing\": None,  # ex: max 1% capital par trade\n",
+    "    \"regime_filter\": None,    # ex: desactiver si VIX > 30\n",
+    "}\n",
+    "# Indice : chaque modification reduit le revenu mais protege contre le risque de queue\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Conclusion : Le wheel n'est pas un revenu gratuit\n",
+    "\n",
+    "### Points cles\n",
+    "\n",
+    "1. **Le wheel vend de l'assurance** : revenu regulier en echange d'un risque de queue asymetrique.\n",
+    "\n",
+    "2. **Win-rate != esperance** : 85% de reussite peut cacher une esperance negative si les pertes sont 10x les gains.\n",
+    "\n",
+    "3. **La concentration sectorielle amplifie le risque** : le wheel sur tech pendant 2020-2022 a expose a des assignments multiples.\n",
+    "\n",
+    "4. **Le drawdown > 100% revele un levier implicite** : le collateral cash ne suffit pas quand plusieurs puts sont assignes simultanement.\n",
+    "\n",
+    "5. **Le regime de volatilite est decisif** : adapter la taille et la frequence au VIX, et non viser un revenu fixe.\n",
+    "\n",
+    "### Pour aller plus loin\n",
+    "\n",
+    "- **Backtester avec regime filter** : desactiver la vente de puts quand VIX > 30 ou trend SPY < 200-MA.\n",
+    "- **Comparer a un buy-and-hold** : le wheel doit battre le benchmark APRES couts et taxes, pas juste en premiums brutes.\n",
+    "- **Diversifier l'univers** : 20-50 sous-jacents non correlates vs 5 actions tech.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-Cloud-08-ValueFactor-ZScore <<](./QC-Py-Cloud-08-ValueFactor-ZScore.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Add `QC-Py-Cloud-09-OptionWheel.ipynb` — a risk-education notebook covering the Option Wheel strategy and its fundamental win-rate paradox.

**Source**: ESGF 2026 student project QC `31846074` (WheelTechSimple), anonymized and adapted.
**Issue**: See #1405 (Tier 2 — risk education)

### Content

- **Wheel strategy**: cash-secured put → assignment → covered call → cession cycle on 5 tech stocks
- **Educational angle**: win-rate paradox — high win-rate (85%) masking negative expectancy
- **Risk lessons**: tail risk, sector concentration, implicit leverage, volatility regime

### QC Cloud Backtest Results (project 31846074, 2020-2024)

| Metric | Value |
|--------|-------|
| Sharpe | -0.51 |
| CAGR | 0% |
| MaxDD | -103.5% |
| PSR | 0.004% |
| Period | 2020-01-01 → 2024-12-31 |

The catastrophic results (-103.5% drawdown) illustrate the wheel's core trap during crash periods (2020 COVID + 2022 bear market) with tech sector concentration.

### Distinct from QC-Py-06

QC-Py-06 covers option basics (covered call, protective put, vertical spread, iron condor) but NOT the Wheel cycle. This notebook focuses on Wheel-specific risk management and the win-rate paradox — a fresh angle per #1405 Tier 2 criteria.

### Structure

- 13 cells (10 markdown, 3 code)
- 3 exercises: expected value calculation, loss scenario identification, defensive wheel design
- C.1 compliant (return None / print stubs, no raise NotImplementedError)
- Doc cloud format with real QC Cloud backtest metrics

### Validation

- `check_docs_links.py --check --quiet` = PASS
- C.1 convention verified (0 violations)
- 3 exercises >= 3 minimum per convention

Co-Authored-By: Claude <noreply@anthropic.com>
