### PR TITLE
feat(lean): Grothendieck Part 23 -- Cech cohomology bridge (See #2159)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -40,3 +40,4 @@ import Grothendieck.Conservative
 import Grothendieck.SheafCohomology.Basic
 import Grothendieck.MayerVietorisSquare
 import Grothendieck.SheafCohomology.MayerVietoris
+import Grothendieck.SheafCohomology.Cech

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech.lean
@@ -1,0 +1,123 @@
+/-
+Grothendieck Part 23 -- Čech cohomology
+
+Part 20 (SheafCohomology/Basic.lean) introduced Ext-based sheaf cohomology
+H^n(F) = Ext^n(constantSheaf ℤ, F).
+
+This module bridges **Čech cohomology** from Mathlib
+(`CategoryTheory.Sites.SheafCohomology.Cech`). Given a family of objects
+U : ι → C in a category C with finite products, the Čech complex functor
+sends a presheaf P : Cᵒᵖ ⥤ A to the cochain complex which in degree n
+consists of the product, indexed by i : Fin (n+1) → ι, of the value of
+P on the product of the objects U (i a) for a : Fin (n+1).
+
+This is the combinatorial cochain complex associated to a covering family.
+In good situations (e.g. sheaves on a site with enough structure), the
+cohomology of this complex computes the sheaf cohomology H^n.
+
+Key constructions bridged from Mathlib:
+
+  - `FormalCoproduct.cosimplicialObjectFunctor` :
+      Simplicial object in FormalCoproduct C ⟹ (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A
+  - `FormalCoproduct.cochainComplexFunctor` :
+      Simplicial object in FormalCoproduct C ⟹ (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+  - `cechComplexFunctor` :
+      (ι → C) ⟹ (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+
+The construction goes through the category `FormalCoproduct C` (the free
+formal coproduct completion of C), where a family U : ι → C is packaged
+as a single object, and its "Čech object" is a simplicial object whose
+degree-n part is indexed by Fin (n+1) → ι.
+
+Epic #1646, See #2159. All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.SheafCohomology.Cech
+
+universe w t v v' u u'
+
+namespace Grothendieck.SheafCohomology.Cech
+
+open CategoryTheory Category Opposite Limits
+
+variable {C : Type u} [Category.{v} C]
+
+/-! ## 1. The cosimplicial object functor
+
+Given a simplicial object `E` in the category `FormalCoproduct C` of
+formal coproducts, `cosimplicialObjectFunctor E` is the functor
+
+  (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A
+
+which sends a presheaf P : Cᵒᵖ ⥤ A to the cosimplicial object obtained
+by "evaluating" P on E (using the formal-coproduct structure).
+
+This is the input to the alternating-coface-map construction of the
+cochain complex.
+-/
+
+-- cosimplicialObjectFunctor: from a simplicial formal coproduct to a
+-- functor (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A.
+#check @CategoryTheory.Limits.FormalCoproduct.cosimplicialObjectFunctor
+
+/-! ## 2. The cochain complex functor
+
+Composing `cosimplicialObjectFunctor` with the alternating coface map
+construction (`AlgebraicTopology.alternatingCofaceMapComplex`) gives
+the cochain complex functor
+
+  (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+
+which sends a presheaf to the associated alternating cochain complex.
+-/
+
+-- cochainComplexFunctor: from a simplicial formal coproduct to a
+-- functor (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ.
+#check @CategoryTheory.Limits.FormalCoproduct.cochainComplexFunctor
+
+/-! ## 3. The Čech complex functor
+
+Given a family of objects U : ι → C in a category C with finite products,
+`cechComplexFunctor U` is the functor
+
+  (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+
+which sends a presheaf P : Cᵒᵖ ⥤ A to the Čech cochain complex. In
+degree n, this complex consists of the product, indexed by
+i : Fin (n + 1) → ι, of the value of P on the product of the objects
+U (i a) for a : Fin (n + 1).
+
+This is the classical Čech complex associated to the covering family {U j}.
+-/
+
+-- cechComplexFunctor: the Čech complex functor for a family U : ι → C.
+#check @CategoryTheory.cechComplexFunctor
+
+/-! ## 4. Bridge theorems
+
+Bridge theorems connecting the Čech complex functor to concrete
+verification.
+-/
+
+/-- Bridge construction: given a family of objects U : ι → C and a
+    presheaf P : Cᵒᵖ ⥤ A (in a preadditive category with products),
+    this is the degree-n part of the Čech complex of P with respect
+    to U, as an object of A. -/
+noncomputable def cechComplexObj
+    {A : Type u'} [Category.{v'} A] [HasProducts.{w} A] [Preadditive A]
+    [HasFiniteProducts C] {ι : Type w} (U : ι → C)
+    (P : Cᵒᵖ ⥤ A) (n : ℕ) : A :=
+  ((CategoryTheory.cechComplexFunctor U).obj P).X n
+
+/-- Bridge theorem (type restatement): the Čech complex functor sends a
+    presheaf P : Cᵒᵖ ⥤ A to a cochain complex indexed by ℕ. This is the
+    type-level restatement that `cechComplexFunctor U` has source
+    `(Cᵒᵖ ⥤ A)` and target `CochainComplex A ℕ`. Marked `noncomputable`
+    because it delegates to the noncomputable Mathlib definition. -/
+noncomputable def cechComplexFunctor_type
+    {A : Type u'} [Category.{v'} A] [HasProducts.{w} A] [Preadditive A]
+    [HasFiniteProducts C] {ι : Type w} (U : ι → C) :
+    (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ :=
+  CategoryTheory.cechComplexFunctor U
+
+end Grothendieck.SheafCohomology.Cech


### PR DESCRIPTION
## Summary

Part 23 of the Grothendieck Lean formalization series (#2159, Epic #1646). This adds a bridge module for **Cech cohomology**, exposing Mathlib's `CategoryTheory.Sites.SheafCohomology.Cech` API in the pedagogical Grothendieck namespace.

Given a family of objects `U : ι → C` in a category `C` with finite products, the **Cech complex functor** sends a presheaf `P : Cᵒᵖ ⥤ A` (in a preadditive category `A` with products) to the cochain complex whose degree-`n` part is the product, indexed by `i : Fin (n+1) → ι`, of `P` evaluated on the product of the objects `U (i a)` for `a : Fin (n+1)`. This is the combinatorial cochain complex associated to a covering family; in good situations its cohomology computes the sheaf cohomology `H^n`.

### Files
- **NEW** `Grothendieck/SheafCohomology/Cech.lean` — namespace `Grothendieck.SheafCohomology.Cech`
- **MOD** `Grothendieck.lean` — added `import Grothendieck.SheafCohomology.Cech`

### Bridges
- `#check @CategoryTheory.Limits.FormalCoproduct.cosimplicialObjectFunctor`
- `#check @CategoryTheory.Limits.FormalCoproduct.cochainComplexFunctor`
- `#check @CategoryTheory.cechComplexFunctor`
- `noncomputable def cechComplexObj` — degree-n object of the Cech complex (type `A`)
- `noncomputable def cechComplexFunctor_type` — type restatement `(Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ`

The construction goes through `FormalCoproduct C` (the free formal-coproduct completion): a family `U` is packaged as a single object, its "Cech object" is a simplicial object indexed by `Fin (n+1) → ι`, and the alternating-coface-map construction yields the cochain complex.

## Lean PR body (per `.claude/rules/pr-review-discipline.md` §B)

1. **`grep -c sorry` before/after:**
   - Before: `0` across `Grothendieck/`
   - After: `0` across `Grothendieck/` (new file `Cech.lean`: 0)
   - **Delta: 0** (baseline maintained, no regressions)
2. **Lake build SUCCESS:** `lake build Grothendieck` → `Build completed successfully (2730 jobs)`, `Built Grothendieck.SheafCohomology.Cech (6.1s)` + `Built Grothendieck (10s)`, exit 0.
3. **Proof integrity:** No `sorry`, no new axioms. All bridges are `#check` (type-level) or `noncomputable def` delegating directly to Mathlib's noncomputable `cechComplexFunctor` / `FormalCoproduct.cochainComplexFunctor`.
4. **No prover Python refactor** in this PR — pure Lean bridge module, `grothendieck_lean` lake-junction workspace unchanged.

## Technical notes
- `grothendieck_lean` uses a lake junction to share the Mathlib build cache; `lake update` was NOT run (forbidden).
- `#check` targets verified against Mathlib source `Mathlib/CategoryTheory/Sites/SheafCohomology/Cech.lean` (69 lines): all three fully-qualified names resolve.
- `cechComplexFunctor` and `FormalCoproduct.cochainComplexFunctor` are `noncomputable` in Mathlib, so the bridge wrappers are `noncomputable def` (an `example` cannot be marked `noncomputable`).

See #2159 (partial delivery, epic remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)