### PR TITLE
docs(qc): add Cloud-08 + Cloud-09 to Python README navigation

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -78,12 +78,14 @@ Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Auc
 | QC-Py-Cloud-06-VolTargeting | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-06-PCA-StatArb | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-07-TemporalCNN | doc cloud | markdown-only — backtest sur QC Cloud |
+| QC-Py-Cloud-08-ValueFactor-ZScore | doc cloud | markdown-only — backtest sur QC Cloud |
+| QC-Py-Cloud-09-OptionWheel | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-33-RL-PPO-Trading | EXÉCUTÉ | 12/12 cellules avec outputs |
 | QC-Py-34-RL-SAC-A2C-Trading | EXÉCUTÉ | 11/11 cellules avec outputs |
 | QC-Py-35-RL-Portfolio-Construction | EXÉCUTÉ | 5/5 cellules avec outputs |
 | QC-Py-Dataset-Workflow | NON EXÉCUTÉ | 11 cellules code, 0 output |
 
-**Récapitulatif** : 51 notebooks total — 17 exécutés, 26 non exécutés, 8 doc cloud.
+**Récapitulatif** : 53 notebooks total — 17 exécutés, 26 non exécutés, 10 doc cloud.
 
 **Politique** : un notebook NON EXÉCUTÉ avec du code réel est préférable à un notebook avec des outputs théâtraux (print de métadonnées prétendant être une exécution). Les patterns théâtraux suivants sont désormais détectés comme erreur par [`scripts/validate_qc_notebooks.py`](../scripts/validate_qc_notebooks.py) :
 - `print("Algorithme charge : {len(qc_code)} caracteres")` — métadonnée d'une string, pas une exécution
@@ -189,6 +191,8 @@ Notebooks de recherche et strategies executees sur QuantConnect Cloud.
 | [QC-Py-Cloud-06-VolTargeting](QC-Py-Cloud-06-VolTargeting.ipynb) | Volatility Targeting |
 | [QC-Py-Cloud-06-PCA-StatArb](QC-Py-Cloud-06-PCA-StatArb.ipynb) | PCA Statistical Arbitrage |
 | [QC-Py-Cloud-07-TemporalCNN](QC-Py-Cloud-07-TemporalCNN.ipynb) | Temporal CNN |
+| [QC-Py-Cloud-08-ValueFactor-ZScore](QC-Py-Cloud-08-ValueFactor-ZScore.ipynb) | Value Factor Z-Score |
+| [QC-Py-Cloud-09-OptionWheel](QC-Py-Cloud-09-OptionWheel.ipynb) | Option Wheel (risk education) |
 
 ## Utilitaires
 


### PR DESCRIPTION
## Summary

Navigation fix — `QC-Py-Cloud-08-ValueFactor-ZScore` (#2853) and `QC-Py-Cloud-09-OptionWheel` (#2857) were **merged but orphaned**: they did not appear in the QC Python README tables. This PR wires them in.

## Changes (1 file, +6/-1)

`MyIA.AI.Notebooks/QuantConnect/Python/README.md`:
- **Status table** (audit): added Cloud-08 + Cloud-09 as `doc cloud` (markdown-only, backtest on QC Cloud) — consistent with Cloud-01..07.
- **Recap line**: `51 notebooks total — 8 doc cloud` → `53 notebooks total — 10 doc cloud`.
- **Navigation table**: added markdown links for both notebooks.

## Why this is a standalone (small) PR — not rule-E doc-churn

This is a **navigation-coherence fix for delivered notebooks** (#2853/#2857 merged this cycle), not arbitrary doc groupement. The two notebooks exist on `main` but are unreachable from the README. One subject = "wire Cloud-08/09 into README navigation".

## Validation

- `check_docs_links.py --check --quiet` → **exit 0 (PASS)**, baseline up to date.
- Both `.ipynb` targets verified present in `Python/`.
- No `CATALOG-STATUS` marker in this README (not a bot-owned catalog artifact).

## Scope

See #1405 — closes the navigation gap left by the Tier 2 notebooks (Value Factor + Option Wheel). #1405 Tier 1 + Tier 2 = 4 notebooks delivered (#2840, #2846, #2853, #2857).