### PR TITLE
feat(search): add MetaGeneticSharp submodule under Search

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/foundry-lib/lib/account-abstraction"]
 	path = MyIA.AI.Notebooks/SymbolicAI/SmartContracts/foundry-lib/lib/account-abstraction
 	url = https://github.com/eth-infinitism/account-abstraction
+[submodule "MyIA.AI.Notebooks/Search/MetaGeneticSharp"]
+	path = MyIA.AI.Notebooks/Search/MetaGeneticSharp
+	url = https://github.com/jsboige/MetaGeneticSharp

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -319,6 +319,7 @@ dotnet --version
 - [automata-lib](https://pypi.org/project/automata-lib/) - Automates finis
 - [MiniZinc](https://www.minizinc.org/) - Modelisation declarative
 - [GeneticSharp](https://github.com/giacomelli/GeneticSharp) - GA en C#
+- [MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) - Couche metaheuristiques composables au-dessus de GeneticSharp (sous-module `MetaGeneticSharp/`, projet enfant ravivant giacomelli/GeneticSharp#87)
 - [OpenSpiel](https://github.com/deepmind/open_spiel) - Framework de jeux et RL
 
 ### Projets etudiants sources
@@ -386,6 +387,8 @@ Search/
 │       ├── App-13-TSP-Metaheuristics.ipynb
 │       ├── App-17-VRP-Logistics.ipynb
 │       └── App-18-HyperparameterTuning.ipynb
+│
+├── MetaGeneticSharp/                      # Sous-module : metaheuristiques composables sur GeneticSharp (jsboige/MetaGeneticSharp)
 │
 ├── Foundations/                           # (deprecated) Ancien repertoire
 │   └── README.md


### PR DESCRIPTION
## Summary

Adds **jsboige/MetaGeneticSharp** as a git submodule at `MyIA.AI.Notebooks/Search/MetaGeneticSharp`, pinned at `08552e0` — the commit closing Phase 2 of the port. Natural home: the Search series already hosts the GeneticSharp notebooks (`GeneticSharp-EdgeDetection`, `Portfolio_Optimization_GeneticSharp`, `App-9b`/`App-10b`) and `Search-11-Metaheuristics`.

MetaGeneticSharp revives giacomelli/GeneticSharp#87 (+17161/-2844, 2020-2022, validated by @giacomelli as a "child project"): a composable-metaheuristics layer ("primitives over bestiary", Sorensen 2015) as an autonomous engine over a vanilla GeneticSharp 3.1.4 submodule — zero upstream patches.

**State at the pinned commit** (Phases 0-2 complete, suite 35/35 green):
- Phase 0: scaffolding, submodule pinned 3.1.4, smoke tests
- Phase 1: autonomous engine (`MetaGeneticAlgorithm`, `MetaPopulation` order-preserving, evolution contexts, base primitives, Linear/Tpl strategies)
- Phase 2: Match machinery, Eukaryote sub-populations, control-flow primitives, operator wrappers, Island migrations

**Remaining phases** (Phase 3 parameters + fluent grammar, Phase 4 compounds WOA/EO/FBI, Phase 5 extensions + center-bias benchmarks, Phase 6 Landscape Explorer) are documented in the child repo's `ROADMAP.md` for coordinator dispatch.

## Changes

- `.gitmodules` + gitlink: submodule at `MyIA.AI.Notebooks/Search/MetaGeneticSharp`
- `MyIA.AI.Notebooks/Search/README.md`: 1 line in the libraries list + 1 line in the file tree

No catalog files touched (catalog-pr-hygiene). No notebook modified (no execution requirement).

See #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)