### PR TITLE
docs(ml): consolidate ladder #1409 final verdicts (REGISTRY + README + ml-trading-state)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -422,21 +422,26 @@ Dry-run results (CPU, Python 3.13, torch 2.11.0+cpu):
 
 Note: dry-run uses synthetic random data. FAILS baseline is expected with random walks. Real-data results are in `results/` and on the cluster dashboard.
 
-## Ladder #1409 — Action vs Forecast (2026-05-27)
+## Ladder #1409 — Final Verdicts (2026-06-12, COMPLETE)
 
-Systematic evaluation of trading signal generation approaches on 25-26 crypto+ETF symbols, walk-forward 5-fold, 4+ seeds. B&H SPY 2015-2025 Sharpe = 1.15 baseline.
+Systematic evaluation of trading signal generation approaches, 7 hard disciplines (walk-forward 5-fold expanding, multi-seed >= 4, anti-FAANG universe, explicit tx costs + 50bps stress, deflated Sharpe, honest verdict).
 
-| Ladder | Model | Approach | Verdict | Signal/Total | Median AUC | Combos | Time |
-|--------|-------|----------|---------|-------------|------------|--------|------|
-| L1 | TSMOM | Time-series momentum | NO BEATS | 0/25 | — | — | 1s |
-| L2 | CS+DM | Carry+DualMomentum | NO BEATS | 0/25 | — | 252d best | 27s |
-| L3 | Trend | Regime+trend long-horizon | NO BEATS | 0/75 | 0.509 | 300 | 874s |
-| **L4** | **Decision Transformer** | **Action-based (buy/hold/sell)** | **BEATS** | **24/26** | **0.558** | **104** | **3714s** |
-| L5 | PatchTST | Forecast-based (return prediction) | NO BEATS | 0/26 | 0.501 | 104 | 2844s |
+| Rung | Model | Approach | Verdict | Key metric | Doc |
+|------|-------|----------|---------|------------|-----|
+| L1 | TSMOM | Time-series momentum | NO BEATS | net Sharpe -2.26 to -2.56 (costs kill the signal) | `docs/L1_tsmom.md` |
+| L2 | CS+DM | Carry + dual momentum | NO BEATS | best CS 252d delta -0.153 | `docs/L2_dual_momentum.md` |
+| L3 | Trend | Regime + trend long-horizon | NO BEATS | 0/75 signal, median AUC 0.509, 300 combos | `results/l3_trend_long_horizon/` |
+| **L4** | **Decision Transformer** | **Action-based (buy/hold/sell)** | **BEATS** | **24/26, median AUC 0.558** | `docs/STAGE7_DECISION_TRANSFORMER.md` |
+| L5 | Vol-targeted composite | Trend filter + 10% vol-targeting on S7 composite | NO BEATS | delta -0.236 vs S4 v2 (t=-2.49), DSR 0.074 | `docs/L5_vol_targeted_composite.md` |
+| (side) | PatchTST | Forecast-based (return prediction) — mislabeled "L5" before 2026-06-12 | NO BEATS | 0/26, median AUC 0.501 | `results/l5_patchtst/` |
 
-**Key finding**: Action-based models (DT classifies buy/hold/sell) massively outperform forecast-based models (PatchTST predicts return magnitude). Forecasting returns is necessary but not sufficient — the portfolio translation layer (forecast -> position) destroys the signal via transaction costs and discretization errors.
+**Key findings**:
 
-Results: `scripts/results/{l1_tsmom,l2_dual_momentum,l3_trend_long_horizon,l4_decision_transformer,l5_patchtst}/results.json`
+1. **Action-based >> forecast-based**: DT (classifies buy/hold/sell) massively outperforms PatchTST (predicts return magnitude). The portfolio translation layer (forecast -> position) destroys forecast signal via transaction costs and discretization errors.
+2. **Trend overlays are systematically destructive** on this universe/period: L1, L2, L3 all NO BEATS, and the L5 ablation isolates the 12-1 TSMOM filter as the cause of its deficit (-0.260 alone vs -0.025 for vol-targeting alone).
+3. **Vol-targeting is a risk tool, not alpha**: L5's 10% vol-target hits its risk objective (realised vol 10.3% vs 16.6%, reduced MaxDD) at ~zero Sharpe cost. Keep it as a risk overlay on production candidates (S3 + S4 v2 KEEPERS), not as a signal.
+
+Results: `scripts/results/{l1_tsmom,l2_dual_momentum,l3_trend_long_horizon,l4_decision_transformer,l5_vol_targeted,l5_patchtst}/results.json`. Next: L4 DT extended multi-seed (ai-01 BG run), then QC Cloud migration.
 
 ## Reproducibility
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
@@ -2,8 +2,29 @@
 
 Auto-generated: 2026-05-03 22:29
 Updated: 2026-05-06 — Stage -1 Panier baselines: 18 BEATS, 32 FAILS across 50 experiments (26 symbols x 2 models)
+Updated: 2026-06-12 — Ladder #1409 verdicts consolidated; legacy SPY-single checkpoints marked ARCHIVED
 
-Total checkpoints: 70 (20 legacy + 50 panier baselines)
+Total checkpoints: 70 (20 legacy ARCHIVED + 50 panier baselines)
+
+## Ladder #1409 — Final Verdicts (2026-06-12)
+
+Systematic signal-generation ladder, 7 hard disciplines (walk-forward 5-fold expanding,
+multi-seed >= 4, anti-FAANG universe, explicit tx costs + 50bps stress, deflated Sharpe,
+honest verdict). Full method + results per rung: `docs/L<n>_*.md` + `scripts/results/`.
+
+| Rung | Strategy | Verdict | Key metric | Doc |
+|------|----------|---------|------------|-----|
+| L1 | TSMOM multi-asset | NO BEATS | net Sharpe -2.26 to -2.56 (costs kill) | `docs/L1_tsmom.md` |
+| L2 | Carry + dual momentum | NO BEATS | best CS 252d delta -0.153 | `docs/L2_dual_momentum.md` |
+| L3 | Trend long-horizon | NO BEATS | 0/75 signal, median AUC 0.509 | `results/l3_trend_long_horizon/` |
+| **L4** | **Decision Transformer (action-based)** | **BEATS** | **24/26, median AUC 0.558** | `docs/STAGE7_DECISION_TRANSFORMER.md` |
+| L5 | Vol-targeted trend composite | NO BEATS | delta -0.236 vs S4 v2, t=-2.49, DSR 0.074 | `docs/L5_vol_targeted_composite.md` |
+| (side) | PatchTST forecast-based (mislabeled "L5" before 2026-06-12) | NO BEATS | 0/26, median AUC 0.501 | `results/l5_patchtst/` |
+
+Conclusion: alpha on this universe comes from learned action policies (L4), not trend
+overlays or vol conditioning on risk-based allocation. Vol-targeting achieves its 10%
+risk target at ~zero Sharpe cost — keep as a *risk* overlay on production candidates
+(S3 HMM + S4 v2 Ridge KEEPERS), not as an alpha source.
 
 ## Anti-Bias Audit (2026-05-04)
 
@@ -240,7 +261,16 @@ SPY majority class baseline = **54.59%**. Values will be populated by `python ev
 | Panier anti-bias | `datasets/panier/` (26 symbols) | 2015-2026 | Available for Stage 0+ |
 | Forex FXCM/Oanda | `datasets/forex/` (10 pairs) | 2002-2025 | Available for Stage 1+ |
 
-## dqn
+## ARCHIVED — Legacy SPY-single checkpoints (2026-06-12)
+
+The 20 checkpoints below (dqn / lstm / rf / transformer, all `[SPY-ONLY]`) are **ARCHIVED /
+OBSOLETE** per #1409 cleanup. POST-FIX verdict above (0 BEATS, 14 FAILS) plus the anti-bias
+audit (SPY pathological, majority 54.6-58.7% up days) make them invalid as baselines and
+forbidden as production models. They are retained on disk under `checkpoints/` for forensic
+reproducibility only — do NOT load them for new work. Valid starting points are the
+Curriculum V2 KEEPERS (M12, M15, S3, S4 v2 — see README) and the L4 Decision Transformer.
+
+## dqn [ARCHIVED]
 
 Checkpoints: 5
 
@@ -288,7 +318,7 @@ Marked `[INVALID-NO-SPLIT]` until re-trained with `--test-ratio 0.2`.
 - Config: device=cpu, hidden_size=256, num_episodes=10, symbol=SPY
 - Files: metadata.json, model.pt
 
-## lstm
+## lstm [ARCHIVED]
 
 Checkpoints: 5
 
@@ -332,7 +362,7 @@ Checkpoints: 5
 - Config: device=cpu, epochs=2, hidden_size=128, num_layers=2, symbol=SPY
 - Files: metadata.json, model.pt
 
-## rf
+## rf [ARCHIVED]
 
 Checkpoints: 5
 
@@ -371,7 +401,7 @@ Checkpoints: 5
 - Config: symbol=SPY
 - Files: metadata.json, model.joblib
 
-## transformer
+## transformer [ARCHIVED]
 
 Checkpoints: 5
 

--- a/docs/archive/ml-trading-state.md
+++ b/docs/archive/ml-trading-state.md
@@ -41,12 +41,23 @@ MSE excellent en regression. DirAcc inferieur a la baseline majoritaire. Le mode
 
 **A abandonner** : ajouter d'autres architectures sequence-to-one log-RV pour la direction (DLinear, NLinear, PatchTST variants...). Le pattern est sature.
 
-**A poursuivre** :
-- Vol forecast pour position sizing (pas direction) : GARCH(1,1), HAR(1,5,22), HAR-RV-Kelly
-- Vol-targeting strategy : target vol annualisee (e.g. 15%), scale exposure inversely to forecast vol
-- Regime detection HMM : binary state (calm/volatile), gate les positions selon etat
-- Multi-asset universe : pas juste BTC/ETH univariate. Inclure SPY/EFA/EEM/TLT/GLD/DBC
-- Risk parity / vol parity : equiponderer en risque, pas en capital
+**Resultats V3 — ladder #1409 (2026-06, toutes les pistes "A poursuivre" testees)** :
+
+| Piste (V2) | Test V3 | Verdict |
+|------------|---------|---------|
+| Vol forecast pour sizing | M12 HAR-RV-J + M15 LSTM h=32 (Curriculum V2) | **KEEPERS** (p=7.9e-7 / p=0.0188) |
+| Regime detection HMM | S3 HMM 2-state daily | **KEEPER** (+0.669 Sharpe, 4/4 seeds, hardening 12/12) |
+| Risk parity / vol parity | S4 v2 inverse-vol Ridge + HMM | **KEEPER** (+0.325 Sharpe, 4/4 seeds) |
+| Vol-targeting strategy | L5 composite vol-targeted 10% (PR #2862) | **NO BEATS comme alpha** (delta -0.236 vs S4 v2, t=-2.49). Mais atteint sa cible de risque (vol realisee 10.3% vs 16.6%, MaxDD reduit) a cout Sharpe nul (-0.025 ablation VT-only) → **garder comme overlay de RISQUE, pas comme source d'alpha** |
+| Multi-asset universe | Panier anti-FAANG 11-26 symboles utilise partout (L1-L5, S1-S8) | **Acquis** (discipline 6) |
+
+Ladder #1409 complet : L1 TSMOM, L2 carry+dual-momentum, L3 trend long-horizon, L5 vol-targeted composite = **tous NO BEATS** ; **L4 Decision Transformer (action-based buy/hold/sell) = seul BEATS** (24/26). PatchTST forecast-based (mislabele "L5" un temps) = NO BEATS (0/26).
+
+**Conclusion V3** : sur cet univers/periode, l'alpha vient des **politiques d'action apprises** (L4), pas des overlays de trend ni du conditionnement vol par-dessus une allocation risk-based. Les overlays trend (12-1 TSMOM) sont systematiquement destructeurs (-0.260 en ablation L5) ; le vol-targeting est un outil de gestion du risque legitime mais Sharpe-neutre. Detail : `ML-Training-Pipeline/docs/L1_tsmom.md`, `L2_dual_momentum.md`, `L5_vol_targeted_composite.md`, `STAGE7_DECISION_TRANSFORMER.md`.
+
+**A poursuivre (post-ladder)** :
+- Industrialiser L4 DT : multi-seed etendu (run BG ai-01 en cours), puis migration QC Cloud
+- Production candidate = S3+S4 v2 (KEEPERS) avec vol-targeting 10% en overlay de risque
 
 ## Les 7 disciplines obligatoires (audit PR ML/trading)
 


### PR DESCRIPTION
## Summary

Documentation consolidation closing three open acceptance criteria of #1409 now that all ladder rungs are decided (L1/L2/L3/L5 NO BEATS, L4 DT only BEATS):

- **README (ML-Training-Pipeline)**: fixes the mislabeled ladder table — PatchTST was listed as "L5" but the real L5 per #1409 spec is the vol-targeted trend composite (PR #2862, merged 70b15e6b). New final table with verdicts, key metrics and doc links per rung, plus the 3 consolidated findings (action-based >> forecast-based; trend overlays destructive; vol-targeting = risk overlay, not alpha).
- **REGISTRY.md**: new "Ladder #1409 — Final Verdicts" section at top; the 20 legacy SPY-single checkpoints (dqn/lstm/rf/transformer) are marked **ARCHIVED** per the #1409 cleanup criterion (kept on disk for forensic reproducibility, forbidden for new work — POST-FIX verdict was already 0 BEATS / 14 FAILS).
- **docs/archive/ml-trading-state.md**: the V2 "A poursuivre" section is resolved — all 5 leads were tested in V3 (vol forecast KEEPERS, HMM regime KEEPER, inverse-vol Ridge KEEPER, vol-targeting NO BEATS as alpha, anti-FAANG universe acquired). New post-ladder "A poursuivre": industrialise L4 DT + S3/S4v2 production candidate with vol-targeting as risk overlay.

No code changes, no checkpoint files touched (documentation-level archiving only). Catalog files untouched (byte-identical to main).

See #1409 (partial: addresses the docs/REGISTRY/README acceptance criteria; remaining: m11*/s* script consolidation + L4 extended multi-seed run by ai-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)