### PR TITLE
docs(lean): sync GT-15b stable_marriage_lean sorry state -- 4->0 (See #2839)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
@@ -61,8 +61,8 @@
     "| `stable_marriage_lean/StableMarriage/Definitions.lean` | Preferences, matching, stabilite | 0 |\n",
     "| `stable_marriage_lean/StableMarriage/GSState.lean` | Etat intermediaire Gale-Shapley | 0 |\n",
     "| `stable_marriage_lean/StableMarriage/Lemmas.lean` | Invariants et lemmes | 0 |\n",
-    "| `stable_marriage_lean/StableMarriage/GaleShapley.lean` | Theoremes GS (stable, optimal) | 1 (man_optimal) |\n",
-    "| `stable_marriage_lean/StableMarriage/Lattice.lean` | Treillis de Knuth (join/meet) | 3 |\n",
+    "| `stable_marriage_lean/StableMarriage/GaleShapley.lean` | Theoremes GS (stable, optimal, pessimal) | 0 |\n",
+    "| `stable_marriage_lean/StableMarriage/Lattice.lean` | Treillis de Knuth (join/meet) | 0 |\n",
     "\n",
     "---\n",
     "\n",
@@ -3408,10 +3408,10 @@
     "> - `Definitions.lean` : PrefProfile, Matching, IsStable, IsManOptimal (117 lignes)\n",
     "> - `GSState.lean` : GSMatching, GSState, gsStep, gsRunSteps, gsGaleShapley (168 lignes)\n",
     "> - `Lemmas.lean` : 14 invariants prouves (GSConsistent, proposedCount, womenBestState, menProposedDownward...) - **0 sorry** (651 lignes)\n",
-    "> - `GaleShapley.lean` : theoremes GS - `gale_shapley_stable` **PROUVE** (PR #1194), `gale_shapley_woman_pessimal` **PROUVE** (PR #1320), `gale_shapley_man_optimal` **1 sorry** INTRACTABLE\n",
-    "> - `Lattice.lean` : Treillis des mariages stables (Knuth 1976) - **3 sorry** (joinSpouse \"different women\", meetSpouse symmetric, doctor_optimal)\n",
+    "> - `GaleShapley.lean` : theoremes GS - `gale_shapley_stable` **PROUVE** (PR #1194), `gale_shapley_woman_pessimal` **PROUVE** (PR #1320), `gale_shapley_man_optimal` **PROUVE** (PR #2790, via `exists_isManOptimal`)\n",
+    "> - `Lattice.lean` : Treillis des mariages stables (Knuth 1976) - **0 sorry** (PR #2790 : `meetSpouse_injective` prouve, 3 enonces faux refutes par contre-exemple kernel-checked 3x3)\n",
     ">\n",
-    "> Total stable_marriage_lean : **4 sorry** (1 man_optimal + 3 Lattice). Le sorry `gale_shapley_man_optimal` est marque `INTRACTABLE_UNTIL_RURAL_HOSPITALS` : sa preuve constructive necessite le theoreme des hopitaux ruraux et un port complet de l'algorithme GS (~1000 LOC). Les 14 lemmes d'invariants sont tous prouves."
+    "> Total stable_marriage_lean : **0 sorry** -- port entierement prouve. PR #2790 (11/06) a clos les derniers sorries residuels (`gale_shapley_man_optimal` via `exists_isManOptimal`, Lattice `meetSpouse_injective` prouve + 3 enonces anciennement `sorry` refutes car faux tels qu'enonces, rephrases). Les 14 lemmes d'invariants sont tous prouves. Lake build SUCCESS 755 jobs.\n"
    ]
   },
   {
@@ -3602,7 +3602,7 @@
     "\n",
     "4. **Terminaison** : L'algorithme fait au plus $n^2$ propositions. Pour $n=3$, au plus 9 propositions suffisent. Le theoreme `gale_shapley_terminates` capture cette propriete.\n",
     "\n",
-    "> **Connexion Lean** : Les trois exemples ci-dessus correspondent aux theoremes du port : `gale_shapley_stable` (preuve complete), `gale_shapley_man_optimal` (sorry restant), `gale_shapley_woman_pessimal` (prouve dans PR #1320). La formalisation prouve que ces proprietes sont valables pour **tout** $n$, pas seulement les exemples numeriques."
+    "> **Connexion Lean** : Les trois exemples ci-dessus correspondent aux theoremes du port : `gale_shapley_stable` (preuve complete), `gale_shapley_man_optimal` (prouve via PR #2790), `gale_shapley_woman_pessimal` (prouve dans PR #1320). La formalisation prouve que ces proprietes sont valables pour **tout** $n$, pas seulement les exemples numeriques.\n"
    ]
   },
   {
@@ -3628,8 +3628,8 @@
     "| `Definitions.lean` | 117 | Types `PrefProfile`, `Matching`, predicats `IsStable`, `IsManOptimal` | 0 |\n",
     "| `GSState.lean` | 168 | Etat intermediaire `GSMatching`, `GSState`, fonction de step `gsStep` | 0 |\n",
     "| `Lemmas.lean` | 651 | 14 invariants prouves (GSConsistent, proposedCount, womenBestState...) | 0 |\n",
-    "| `GaleShapley.lean` | 157 | Theoremes principaux (stable, optimal, pessimal) | 1 |\n",
-    "| `Lattice.lean` | 800+ | Treillis de Knuth (join, meet, distributivite) | 3 |\n",
+    "| `GaleShapley.lean` | 157 | Theoremes principaux (stable, optimal, pessimal) | 0 |\n",
+    "| `Lattice.lean` | 800+ | Treillis de Knuth (join, meet, distributivite) | 0 |\n",
     "\n",
     "**Points cles de l'architecture** :\n",
     "\n",


### PR DESCRIPTION
## Sync famille Cooperative Games (GT-15b) -- Epic #2839

`stable_marriage_lean` est maintenant **entierement prouve (0 sorry)** via PR **#2790** (11/06), mais le notebook GT-15b citait encore l'etat pre-#2790 (4 sorry).

### Drift detecte et corrige

| Cellule | Ancien (stale) | Nouveau (verifie) |
|---------|----------------|-------------------|
| cell0 (intro table) | GaleShapley `1 (man_optimal)`, Lattice `3` | GaleShapley `0`, Lattice `0` |
| cell38 (etat du port) | man_optimal `1 sorry INTRACTABLE`, total `4 sorry` | man_optimal **PROUVE** #2790 (via `exists_isManOptimal`), total `0 sorry` |
| cell42 | man_optimal `(sorry restant)` | `(prouve via PR #2790)` |
| cell43 (table detail) | GaleShapley `1`, Lattice `3` | GaleShapley `0`, Lattice `0` |

### Verification (G.1, code = verite)

```
grep -cE '^\s*sorry\s*$' stable_marriage_lean/StableMarriage/*.lean
  Definitions.lean: 0 | GSState.lean: 0 | Lemmas.lean: 0
  GaleShapley.lean: 0 | Lattice.lean: 0 | StableMarriage.lean: 0
```
Les 3 occurrences du mot `sorry` dans Lattice.lean (lignes 138/149/780) sont en **commentaires/prose** (historique de preuve), pas des tactics.

- `gale_shapley_man_optimal` = `exists_isManOptimal prof (gale_shapley_stable prof)` (prouve, ligne 98 de GaleShapley.lean)
- `gale_shapley_woman_pessimal` = preuve constructive `by_contra` (prouve)
- PR #2790 : "Lattice.lean 7 sorry -> 0. Refuted 3 false statements (kernel-checked 3x3 latin-square). Proved honest exists_isManOptimal + meetSpouse_injective. Lake build SUCCESS 755 jobs."

### Critere d'acceptation #2839

1. **Execution** : edit **markdown-only** -> exception C.2 (outputs precedents valides). Les 20 code cells (kernel `lean4-wsl`) sont des illustrations pedagogiques cooperatives avec `sorry` intentionnel (stubs d'exercices, marqueurs alectryon 🟨) -- non touchees, outputs intacts. 0 violation H.3.
2. **Sorry counts verifies** : cf ci-dessus (0 partout).
3. **Pas de regression de contenu** : claims Bondareva-Shapley (`cooperative_games_lean/Basic.lean`, 1 sorry) laisses inchanges -- toujours accurates.
4. Convention 3 exercices : GT-15b deja enrichie (#2629 mergee).
5. Body : `See #2839` (issue de sync, epic reste ouverte).

Diff : 8 insertions / 8 deletions, 1 fichier, markdown-only.