### PR TITLE
fix(ci): scope ML Pipeline Tests job to the ML pipeline test suite

### DIFF
--- a/.github/workflows/ml-tests.yml
+++ b/.github/workflows/ml-tests.yml
@@ -38,7 +38,12 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Run tests
-        run: pytest --tb=short -v --continue-on-collection-errors
+        # Scope to the ML pipeline suite this job is named for. The repo-wide
+        # pytest.ini testpaths pull in scripts/ suites (genai, wsl, catalog)
+        # whose deps (requests, bcrypt, jupyter_client) are not installed here
+        # and which have been failing on main since 2026-06-03 — tracked
+        # separately; they need their own properly-provisioned workflow.
+        run: pytest MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests --tb=short -v
 
   prover-tests:
     name: Prover Tests (placeholder)


### PR DESCRIPTION
## Summary

Single-line fix: the **ML Pipeline Tests (CPU)** job ran bare `pytest`, so `pytest.ini` testpaths pulled in **all 8 repo test suites (3707 items)** while the job installs only ML deps. This PR scopes the invocation to the suite the job is named for:

```
pytest MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests --tb=short -v
```

## Why now

The check has been **red on main since 2026-06-03** (last green 2026-05-29), flagging every ML PR UNSTABLE for failures unrelated to their diffs (#2862 was merged red; #2866 is currently flagged red).

Evidence (run 27428519237, head `ac42e06f`): `25 failed, 3663 passed, 21 skipped, 11 errors` — **zero failures under ML-Training-Pipeline**. All failures are in `scripts/` + `scripts/notebook_tools/` suites from the mutation-test wave (See #2149): 11 collection errors from missing deps (`requests`, `bcrypt`, `jupyter_client`) + 25 ubuntu failures (genai x16, wsl x7, catalog x1, notebook_tools x1).

## Scope

- This PR only restores a meaningful green/red signal for ML PRs — it does not silence real failures: those suites were never green in this job's env (deps not installed), and their breakage is now tracked in #2871 with a per-lane triage plan and a dedicated properly-provisioned workflow as the fix.
- Trigger paths unchanged (already scoped to `ML-Training-Pipeline/scripts/**`, `tests/**`, `pytest.ini`, the workflow file).

## Validation

- CI on this PR itself runs the scoped invocation — expect green (the 469 ML-Pipeline tests pass: 0 failures in run 27428519237).

This is the mitigation only (intentionally not a `Closes`): the scripts-suite workflow is the remaining work on the tracking issue.

See #2871

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
