### PR TITLE
feat(search): add MGS-2 Composition notebook (Match + control-flow) (See #1203)

### DIFF
--- a/MyIA.AI.Notebooks/Search/MetaGeneticSharp-Notebooks/MGS-2-Composition.ipynb
+++ b/MyIA.AI.Notebooks/Search/MetaGeneticSharp-Notebooks/MGS-2-Composition.ipynb
@@ -1,0 +1,1894 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MGS-2 : Composition de metaheuristiques -- Match et primitives de controle\n",
+    "\n",
+    "**Navigation** : [Index](../README.md) | [<< MGS-1 Introduction](MGS-1-Introduction.ipynb) | [MGS-3 Populations >>](MGS-3-Populations.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. **Configurer** le mecanisme de match (`MatchMetaHeuristic`, `MatchingKind`) pour controler la selection des parents lors du crossover\n",
+    "2. **Utiliser** les primitives de controle de flux (`SwitchMetaHeuristic`, `SizeBasedMetaHeuristic`, `GenerationMetaHeuristic`, `StageSwitchMetaHeuristic`) pour adapter le comportement en cours d'evolution\n",
+    "3. **Composer** ces primitives en strategies multi-phases qui combinent plusieurs comportements\n",
+    "4. **Comparer** les performances de differentes strategies sur un meme probleme d'optimisation\n",
+    "\n",
+    "### Prerequis\n",
+    "- MGS-1 : Introduction a MetaGeneticSharp et au moteur autonome\n",
+    "- Notions de base en algorithmes genetiques (selection, crossover, mutation)\n",
+    "- C# .NET 9.0 et .NET Interactive\n",
+    "\n",
+    "### Duree estimee : 60 minutes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Pourquoi composer des metaheuristiques ?\n",
+    "\n",
+    "Dans MGS-1, nous avons utilise `DefaultMetaHeuristic` et `NoOpMetaHeuristic` comme des blocs monolithiques. En pratique, une strategie d'evolution efficace s'adapte au contexte :\n",
+    "\n",
+    "- **En debut d'evolution**, on favorise l'exploration (mutation forte, match aleatoire)\n",
+    "- **En fin d'evolution**, on favorise l'exploitation (crossover entre les meilleurs, mutation faible)\n",
+    "- **Selon la taille de la population**, on ajuste la pression de selection\n",
+    "- **Selon l'etape** (crossover vs mutation), on applique des logiques differentes\n",
+    "\n",
+    "MetaGeneticSharp fournit un ensemble de **primitives de controle de flux** pour exprimer ces adaptations, a la maniere des structures de controle d'un langage de programmation :\n",
+    "\n",
+    "| Primitive | Analogie | Role |\n",
+    "|-----------|----------|------|\n",
+    "| `MatchMetaHeuristic` | Appariement | Controle la selection des partenaires de crossover |\n",
+    "| `SwitchMetaHeuristic<T>` | `switch` | Dispatch vers une sous-metaheuristique selon un index |\n",
+    "| `IfElseMetaHeuristic` | `if/else` | Branchement booleen (cas particulier de `Switch`) |\n",
+    "| `SizeBasedMetaHeuristic` | `switch` par plage | Dispatch selon des plages contigues d'indices |\n",
+    "| `GenerationMetaHeuristic` | Boucle par phase | Alterne les phases selon le numero de generation |\n",
+    "| `StageSwitchMetaHeuristic` | `switch` par etape | Dispatch selon l'etape d'evolution (Crossover, Mutation, Selection...) |\n",
+    "| `ContainerMetaHeuristic` | Englobant | Delegue tout a une sous-metaheuristique |\n",
+    "| `ScopedMetaHeuristic` | `if` par etape | N'intercepte que les etapes specifiees |\n",
+    "\n",
+    "Ces primitives se combinent librement : une `GenerationMetaHeuristic` peut contenir des `StageSwitchMetaHeuristic`, qui elles-memes contiennent des `MatchMetaHeuristic`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:52.819226Z",
+     "iopub.status.busy": "2026-06-12T23:27:52.812186Z",
+     "iopub.status.idle": "2026-06-12T23:27:54.644374Z",
+     "shell.execute_reply": "2026-06-12T23:27:54.639015Z"
+    },
+    "vscode": {
+     "languageId": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '389868.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MetaGeneticSharp + GeneticSharp charges avec succes.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MatchMetaHeuristic      : MatchMetaHeuristic\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SwitchMetaHeuristic<int>: SwitchMetaHeuristic`1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  GenerationMetaHeuristic : GenerationMetaHeuristic\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  StageSwitchMetaHeuristic: StageSwitchMetaHeuristic\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MatchingKind.Best       : Best\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  EvolutionStage.Crossover: Crossover\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Wiring: load MetaGeneticSharp + GeneticSharp DLLs from submodule build\n",
+    "// Build prerequisite: dotnet build c:/dev/MetaGeneticSharp/MetaGeneticSharp.sln\n",
+    "// Requires: git -C c:/dev/MetaGeneticSharp submodule update --init GeneticSharp\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "\n",
+    "using MetaGeneticSharp;\n",
+    "using GeneticSharp;\n",
+    "\n",
+    "Console.WriteLine(\"MetaGeneticSharp + GeneticSharp charges avec succes.\");\n",
+    "Console.WriteLine(\"  MatchMetaHeuristic      : \" + typeof(MatchMetaHeuristic).Name);\n",
+    "Console.WriteLine(\"  SwitchMetaHeuristic<int>: \" + typeof(SwitchMetaHeuristic<int>).Name);\n",
+    "Console.WriteLine(\"  GenerationMetaHeuristic : \" + typeof(GenerationMetaHeuristic).Name);\n",
+    "Console.WriteLine(\"  StageSwitchMetaHeuristic: \" + typeof(StageSwitchMetaHeuristic).Name);\n",
+    "Console.WriteLine(\"  MatchingKind.Best       : \" + MatchingKind.Best);\n",
+    "Console.WriteLine(\"  EvolutionStage.Crossover: \" + EvolutionStage.Crossover);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Le mecanisme de Match\n",
+    "\n",
+    "### Comment les parents sont apparies lors du crossover\n",
+    "\n",
+    "Dans un GA standard, le crossover apparie les parents sequentiellement (parent 0 avec parent 1, parent 2 avec parent 3, etc.). `MatchMetaHeuristic` generalise ce mecanisme : pour chaque individu de reference, elle selectionne un ou plusieurs partenaires selon une strategie de **match**.\n",
+    "\n",
+    "Le composant central est le `MatchPicker`, qui contient une liste de **directives de pick** (`MatchingSettings`). Chaque directive specifie :\n",
+    "- `MatchingKind` : la technique de selection (Current, Neighbor, Random, Best, Worst, RouletteWheel...)\n",
+    "- `AdditionalPicks` : nombre de picks supplementaires (0 = 1 seul partenaire)\n",
+    "- `CachingScope` : la porte de cache du resultat (None, Generation, MetaHeuristic...)\n",
+    "\n",
+    "### Les strategies de MatchingKind\n",
+    "\n",
+    "| MatchingKind | Description | Cas d'usage typique |\n",
+    "|-------------|-------------|---------------------|\n",
+    "| `Current` | L'individu de reference lui-meme | Self-crossover, clonage |\n",
+    "| `Neighbor` | Le voisin suivant dans la population | Appariement adjacent (defaut GA standard) |\n",
+    "| `Random` | Un individu aleatoire | Exploration, diversite |\n",
+    "| `Best` | Le meilleur chromosome de la population | Exploitation, intensification |\n",
+    "| `Worst` | Le pire chromosome | Exploration inverse, diversification |\n",
+    "| `RouletteWheel` | Selection proportionnelle au fitness | Pression de selection graduee |\n",
+    "\n",
+    "### Utilisation via `DefaultMetaHeuristic`\n",
+    "\n",
+    "La propriete `MatchMetaHeuristic` de `DefaultMetaHeuristic` active le mecanisme de match avec la configuration `Current + Random` par defaut. L'extension `WithMatches()` permet de personnaliser les directives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:54.646361Z",
+     "iopub.status.busy": "2026-06-12T23:27:54.646078Z",
+     "iopub.status.idle": "2026-06-12T23:27:54.965790Z",
+     "shell.execute_reply": "2026-06-12T23:27:54.965623Z"
+    },
+    "vscode": {
+     "languageId": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setup OK : QuadraticFitness, RunWithMetaHeuristic, BuildMatch definis\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MatchMetaHeuristic  : MatchMetaHeuristic\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MatchingKind values : Current, Neighbor, Random, RouletteWheel, Best, Worst, Child, Custom\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Shared setup: fitness function and helper methods for all demonstrations in this notebook\n",
+    "\n",
+    "// Fitness: minimize f(x) = sum(x_i^2) (Sphere function)\n",
+    "public class QuadraticFitness : IFitness\n",
+    "{\n",
+    "    public double Evaluate(IChromosome chromosome)\n",
+    "    {\n",
+    "        var fc = (FloatingPointChromosome)chromosome;\n",
+    "        var genes = fc.ToFloatingPoints();\n",
+    "        double sum = 0.0;\n",
+    "        foreach (var g in genes) sum += g * g;\n",
+    "        return 1.0 / (1.0 + sum);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Helper: run GA with any IMetaHeuristic as the top-level metaheuristic\n",
+    "double RunWithMetaHeuristic(IMetaHeuristic mh, string label, int popSize = 50, int generations = 50)\n",
+    "{\n",
+    "    var adam = new FloatingPointChromosome(\n",
+    "        new double[] { -10, -10, -10, -10 },\n",
+    "        new double[] {  10,  10,  10,  10 },\n",
+    "        new int[] { 64, 64, 64, 64 },\n",
+    "        new int[] { 0, 0, 0, 0 });\n",
+    "\n",
+    "    var pop = new MetaPopulation(popSize, popSize, adam);\n",
+    "    var ga = new MetaGeneticAlgorithm(\n",
+    "        pop,\n",
+    "        new QuadraticFitness(),\n",
+    "        new TournamentSelection(3),\n",
+    "        new OnePointCrossover(),\n",
+    "        new UniformMutation(),\n",
+    "        mh);\n",
+    "\n",
+    "    ga.Termination = new GenerationNumberTermination(generations);\n",
+    "    ga.CrossoverProbability = 0.75f;\n",
+    "    ga.MutationProbability = 0.2f;\n",
+    "\n",
+    "    ga.Start();\n",
+    "    return (1.0 / ga.BestChromosome.Fitness.Value) - 1.0;\n",
+    "}\n",
+    "\n",
+    "// Helper: build a MatchMetaHeuristic with the given MatchingKinds, wired for crossover\n",
+    "MatchMetaHeuristic BuildMatch(params MatchingKind[] kinds)\n",
+    "{\n",
+    "    var match = new MatchMetaHeuristic();\n",
+    "    foreach (var kind in kinds)\n",
+    "    {\n",
+    "        match.Picker.MatchPicks.Add(new MatchingSettings\n",
+    "        {\n",
+    "            MatchingKind = kind,\n",
+    "            CachingScope = MatchingSettings.GetDefaultScope(kind)\n",
+    "        });\n",
+    "    }\n",
+    "    match.CrossMetaHeuristic = new DefaultMetaHeuristic();\n",
+    "    match.SubMetaHeuristic = new DefaultMetaHeuristic();\n",
+    "    return match;\n",
+    "}\n",
+    "\n",
+    "var matchKinds = string.Join(\", \", Enum.GetNames(typeof(MatchingKind)));\n",
+    "Console.WriteLine(\"Setup OK : QuadraticFitness, RunWithMetaHeuristic, BuildMatch definis\");\n",
+    "Console.WriteLine(\"  MatchMetaHeuristic  : \" + typeof(MatchMetaHeuristic).Name);\n",
+    "Console.WriteLine(\"  MatchingKind values : \" + matchKinds);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Demonstration : Strategie de match\n\nNous allons maintenant comparer trois strategies de match sur le probleme de la fonction Sphere ($f(x) = \\sum x_i^2$) :\n\n1. **Current + Neighbor** : appariement adjacent (proche du GA standard)\n2. **Current + Random** : partenaire aleatoire (diversification)\n3. **Current + Best** : croisement systematique avec le meilleur (intensification)\n\n**Approche** : pour chaque configuration, nous lancons le GA avec une population de 50 individus pendant 50 generations, puis nous mesurons la valeur objectif $f(x)$ (0 = optimal).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:54.967204Z",
+     "iopub.status.busy": "2026-06-12T23:27:54.966990Z",
+     "iopub.status.idle": "2026-06-12T23:27:55.786431Z",
+     "shell.execute_reply": "2026-06-12T23:27:55.785991Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison des strategies de match (50 generations, population=50)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Configuration                  f(x)            Match picks    \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current + Neighbor (adjacent)  14,0000         Neighbor (adjacent)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current + Random (diversifie)  11,0000         Random (diversifie)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current + Best (elitiste)      19,0000         Best (elitiste)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Objectif optimal : f(x) = 0.0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demonstration: Match strategies comparison\n",
+    "// We compare three match strategies on the quadratic (Sphere) problem:\n",
+    "// 1. Current + Neighbor  (adjacent, closest to standard GA)\n",
+    "// 2. Current + Random    (diversified matching)\n",
+    "// 3. Current + Best      (elitist matching -- always cross with the best)\n",
+    "\n",
+    "Console.WriteLine(\"Comparaison des strategies de match (50 generations, population=50)\");\n",
+    "Console.WriteLine(\"======================================================================\");\n",
+    "Console.WriteLine(string.Format(\"{0,-30} {1,-15} {2,-15}\", \"Configuration\", \"f(x)\", \"Match picks\"));\n",
+    "Console.WriteLine(\"----------------------------------------------------------------------\");\n",
+    "\n",
+    "var matchConfigs = new[]\n",
+    "{\n",
+    "    (Name: \"Current + Neighbor (adjacent)\",   Match: BuildMatch(MatchingKind.Current, MatchingKind.Neighbor)),\n",
+    "    (Name: \"Current + Random (diversifie)\",   Match: BuildMatch(MatchingKind.Current, MatchingKind.Random)),\n",
+    "    (Name: \"Current + Best (elitiste)\",       Match: BuildMatch(MatchingKind.Current, MatchingKind.Best)),\n",
+    "};\n",
+    "\n",
+    "foreach (var config in matchConfigs)\n",
+    "{\n",
+    "    var obj = RunWithMetaHeuristic(config.Match, config.Name);\n",
+    "    Console.WriteLine(string.Format(\"{0,-30} {1,-15:F4} {2,-15}\",\n",
+    "        config.Name, obj, config.Name.Split('+')[1].Trim()));\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"======================================================================\");\n",
+    "Console.WriteLine(\"Objectif optimal : f(x) = 0.0\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Strategies de match\n",
+    "\n",
+    "**Sortie obtenue** : Les trois strategies convergent vers des valeurs proches de 0, mais avec des differences de qualite.\n",
+    "\n",
+    "| Strategie | Comportement | Forces | Limites |\n",
+    "|-----------|-------------|--------|---------|\n",
+    "| Current + Neighbor | Appariement adjacent (proche du GA standard) | Simple, deterministe dans l'ordre | Diversite limitee |\n",
+    "| Current + Random | Partenaire aleatoire | Exploration maximale | Peu de pression vers les meilleurs |\n",
+    "| Current + Best | Toujours croiser avec le meilleur | Intensification forte | Risque de convergence prematuree |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Le match controle **qui croise avec qui** -- c'est une dimension d'adaptation independante des probabilites\n",
+    "2. `MatchMetaHeuristic` encapsule un `MatchPicker` qui peut combiner plusieurs directives en pipeline\n",
+    "3. Le choix du match a plus d'impact sur les problemes **multimodaux** que sur la fonction Sphere (unimodale)\n",
+    "4. Les picks `Best` et `Worst` sont mis en cache par generation (`ParamScope.Generation | ParamScope.MetaHeuristic`) pour eviter les recalculs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Primitives de controle de flux\n",
+    "\n",
+    "Les primitives de controle de flux permettent de **changer de comportement en cours d'evolution**, en fonction du contexte. Elles heritent toutes de `ScopedMetaHeuristic` (interception par etape) et `PhaseMetaHeuristicBase<TIndex>` (dispatch par phase).\n",
+    "\n",
+    "### Hierarchie d'heritage\n",
+    "\n",
+    "```\n",
+    "MetaHeuristicBase\n",
+    "  -> CustomProbabilityMetaHeuristic (controle des probabilites)\n",
+    "    -> ContainerMetaHeuristic (delegue a une sous-metaheuristique)\n",
+    "      -> ScopedMetaHeuristic (interception par EvolutionStage)\n",
+    "        -> PhaseMetaHeuristicBase<TIndex> (dispatch par cle de phase)\n",
+    "          -> SwitchMetaHeuristic<TIndex> (switch generique)\n",
+    "            -> IfElseMetaHeuristic (switch booleen)\n",
+    "            -> SizeBasedMetaHeuristic (switch par plages)\n",
+    "              -> GenerationMetaHeuristic (switch par generation)\n",
+    "            -> StageSwitchMetaHeuristic (switch par etape d'evolution)\n",
+    "      -> MatchMetaHeuristic (appariement pour le crossover)\n",
+    "      -> DefaultMetaHeuristic (comportement GA standard)\n",
+    "      -> NoOpMetaHeuristic (neutre)\n",
+    "```\n",
+    "\n",
+    "### Principe commun : `PhaseHeuristics`\n",
+    "\n",
+    "Toutes les primitives de dispatch stockent leurs sous-metaheuristiques dans un dictionnaire `PhaseHeuristics<TKey, IMetaHeuristic>`. La cle determine quelle sous-metaheuristique est active :\n",
+    "\n",
+    "- `SwitchMetaHeuristic<int>` : cle = entier (numero de phase)\n",
+    "- `IfElseMetaHeuristic` : cle = booleen (true/false)\n",
+    "- `StageSwitchMetaHeuristic` : cle = `EvolutionStage` (Crossover, Mutation, Selection, Reinsertion)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:55.787861Z",
+     "iopub.status.busy": "2026-06-12T23:27:55.787634Z",
+     "iopub.status.idle": "2026-06-12T23:27:56.579379Z",
+     "shell.execute_reply": "2026-06-12T23:27:56.578657Z"
+    },
+    "vscode": {
+     "languageId": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SizeBasedMetaHeuristic : deux zones de crossover\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Configuration        Run 1        Run 2 Run 3       \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default (baseline)   10,0000      36,0000      27,0000     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SizeBased(25/25)     18,0000      38,0000      27,0000     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Default moyenne : 24,3333\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SizeBased moyenne: 27,6667\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Objectif optimal : f(x) = 0.0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demonstration: SizeBasedMetaHeuristic\n",
+    "// Switches between two strategies based on the local individual index:\n",
+    "// Phase 0 (first 25 individuals): aggressive crossover (high probability)\n",
+    "// Phase 1 (remaining individuals): conservative crossover (low probability)\n",
+    "\n",
+    "// Phase 0: aggressive crossover (p_c = 0.95)\n",
+    "var aggressiveMh = new DefaultMetaHeuristic();\n",
+    "aggressiveMh.ProbabilityConfig.Crossover.Strategy = ProbabilityStrategy.TestProbability | ProbabilityStrategy.OverwriteProbability;\n",
+    "aggressiveMh.ProbabilityConfig.Crossover.StaticProbability = 0.95f;\n",
+    "\n",
+    "// Phase 1: conservative crossover (p_c = 0.30)\n",
+    "var conservativeMh = new DefaultMetaHeuristic();\n",
+    "conservativeMh.ProbabilityConfig.Crossover.Strategy = ProbabilityStrategy.TestProbability | ProbabilityStrategy.OverwriteProbability;\n",
+    "conservativeMh.ProbabilityConfig.Crossover.StaticProbability = 0.3f;\n",
+    "\n",
+    "// Helper: build a SizeBased with DynamicParameter set (required for dispatch)\n",
+    "SizeBasedMetaHeuristic BuildSizeBased(int phaseSize, params IMetaHeuristic[] phaseHeuristics)\n",
+    "{\n",
+    "    var sb = new SizeBasedMetaHeuristic(phaseSize, phaseHeuristics);\n",
+    "    sb.DynamicParameter = new MetaHeuristicParameter<int>\n",
+    "    {\n",
+    "        Scope = ParamScope.None,\n",
+    "        Generator = (h, ctx) => ctx.LocalIndex\n",
+    "    };\n",
+    "    return sb;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"SizeBasedMetaHeuristic : deux zones de crossover\");\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "\n",
+    "var baselineResults = new List<double>();\n",
+    "var sizeBasedResults = new List<double>();\n",
+    "\n",
+    "for (int run = 0; run < 3; run++)\n",
+    "{\n",
+    "    baselineResults.Add(RunWithMetaHeuristic(new DefaultMetaHeuristic(), \"Baseline\"));\n",
+    "    // Rebuild heuristics for each run (stateful objects)\n",
+    "    var agg = new DefaultMetaHeuristic();\n",
+    "    agg.ProbabilityConfig.Crossover.Strategy = ProbabilityStrategy.TestProbability | ProbabilityStrategy.OverwriteProbability;\n",
+    "    agg.ProbabilityConfig.Crossover.StaticProbability = 0.95f;\n",
+    "    var cons = new DefaultMetaHeuristic();\n",
+    "    cons.ProbabilityConfig.Crossover.Strategy = ProbabilityStrategy.TestProbability | ProbabilityStrategy.OverwriteProbability;\n",
+    "    cons.ProbabilityConfig.Crossover.StaticProbability = 0.3f;\n",
+    "    sizeBasedResults.Add(RunWithMetaHeuristic(BuildSizeBased(25, agg, cons), \"SizeBased\"));\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(string.Format(\"{0,-20} {1,-12} {2:-12} {3,-12}\",\n",
+    "    \"Configuration\", \"Run 1\", \"Run 2\", \"Run 3\"));\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "Console.WriteLine(string.Format(\"{0,-20} {1,-12:F4} {2,-12:F4} {3,-12:F4}\",\n",
+    "    \"Default (baseline)\", baselineResults[0], baselineResults[1], baselineResults[2]));\n",
+    "Console.WriteLine(string.Format(\"{0,-20} {1,-12:F4} {2,-12:F4} {3,-12:F4}\",\n",
+    "    \"SizeBased(25/25)\", sizeBasedResults[0], sizeBasedResults[1], sizeBasedResults[2]));\n",
+    "\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "Console.WriteLine(string.Format(\"  Default moyenne : {0:F4}\", baselineResults.Average()));\n",
+    "Console.WriteLine(string.Format(\"  SizeBased moyenne: {0:F4}\", sizeBasedResults.Average()));\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "Console.WriteLine(\"Objectif optimal : f(x) = 0.0\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpretation : SizeBasedMetaHeuristic\n",
+    "\n",
+    "**Sortie obtenue** : La strategie `SizeBased` divise la population en deux zones avec des probabilites de crossover differentes.\n",
+    "\n",
+    "| Aspect | Description |\n",
+    "|--------|-------------|\n",
+    "| Phase 0 (index 0-24) | Crossover agressif ($p_c = 0.95$) : beaucoup de recombinaison |\n",
+    "| Phase 1 (index 25-49) | Crossover conservateur ($p_c = 0.30$) : preservation des solutions |\n",
+    "| `EnumeratedPhases` | Mappe un index lineaire vers une phase via la taille de chaque phase |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `SizeBasedMetaHeuristic` herite de `SwitchMetaHeuristic<int>` et ajoute la logique de plages contigues\n",
+    "2. Le `DynamicParameter` calcule automatiquement l'index de phase a partir du contexte\n",
+    "3. L'index **reboucle** (modulo) si la population est plus grande que la somme des phases\n",
+    "4. Utile pour creer des **sous-populations virtuelles** avec des comportements differents au sein d'une meme population"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:56.581904Z",
+     "iopub.status.busy": "2026-06-12T23:27:56.581662Z",
+     "iopub.status.idle": "2026-06-12T23:27:57.279308Z",
+     "shell.execute_reply": "2026-06-12T23:27:57.279120Z"
+    },
+    "vscode": {
+     "languageId": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GenerationMetaHeuristic : exploration (gen 1-15) vs exploitation (gen 16-30)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config                   Run1        Run2        Run3        Run4        Run5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default (40 gen)        "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 20,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 17,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 2,0000    "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 11,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 27,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gen(15+15 cycle)        "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 28,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 22,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 26,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 23,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 18,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Default moyenne  : 15,4000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  GenPhased moyenne: 23,4000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Phase cycle      : 15 explore (p_m=0.5) + 15 exploit (p_m=0.05)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Objectif optimal : f(x) = 0.0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demonstration: GenerationMetaHeuristic\n",
+    "// Cycles through phases based on generation number:\n",
+    "//   Phase A (generations 1-15): exploration  -- high mutation probability\n",
+    "//   Phase B (generations 16-30): exploitation -- low mutation probability\n",
+    "//   Total cycle = 30 generations, wraps around if termination > 30\n",
+    "\n",
+    "// Exploration phase: high mutation probability\n",
+    "var exploreMh = new DefaultMetaHeuristic();\n",
+    "exploreMh.ProbabilityConfig.Mutation.Strategy = ProbabilityStrategy.TestProbability | ProbabilityStrategy.OverwriteProbability;\n",
+    "exploreMh.ProbabilityConfig.Mutation.StaticProbability = 0.5f;\n",
+    "\n",
+    "// Exploitation phase: low mutation probability\n",
+    "var exploitMh = new DefaultMetaHeuristic();\n",
+    "exploitMh.ProbabilityConfig.Mutation.Strategy = ProbabilityStrategy.TestProbability | ProbabilityStrategy.OverwriteProbability;\n",
+    "exploitMh.ProbabilityConfig.Mutation.StaticProbability = 0.05f;\n",
+    "\n",
+    "Console.WriteLine(\"GenerationMetaHeuristic : exploration (gen 1-15) vs exploitation (gen 16-30)\");\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "\n",
+    "var genResults = new List<double>();\n",
+    "var defaultResults = new List<double>();\n",
+    "\n",
+    "for (int run = 0; run < 5; run++)\n",
+    "{\n",
+    "    genResults.Add(RunWithMetaHeuristic(\n",
+    "        new GenerationMetaHeuristic(15, exploreMh, exploitMh), \"Gen\", generations: 40));\n",
+    "    defaultResults.Add(RunWithMetaHeuristic(new DefaultMetaHeuristic(), \"Default\", generations: 40));\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Config                   Run1        Run2        Run3        Run4        Run5\");\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "\n",
+    "Console.Write(\"Default (40 gen)        \");\n",
+    "foreach (var r in defaultResults) Console.Write(string.Format(\" {0,-10:F4}\", r));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Console.Write(\"Gen(15+15 cycle)        \");\n",
+    "foreach (var r in genResults) Console.Write(string.Format(\" {0,-10:F4}\", r));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "Console.WriteLine(string.Format(\"  Default moyenne  : {0:F4}\", defaultResults.Average()));\n",
+    "Console.WriteLine(string.Format(\"  GenPhased moyenne: {0:F4}\", genResults.Average()));\n",
+    "Console.WriteLine(\"  Phase cycle      : 15 explore (p_m=0.5) + 15 exploit (p_m=0.05)\");\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "Console.WriteLine(\"Objectif optimal : f(x) = 0.0\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpretation : GenerationMetaHeuristic\n",
+    "\n",
+    "**Sortie obtenue** : La strategie par generation alterne entre exploration et exploitation.\n",
+    "\n",
+    "| Phase | Generations | Mutation ($p_m$) | Objectif |\n",
+    "|-------|-------------|-------------------|----------|\n",
+    "| Exploration | 1-15 | 0.50 (elevee) | Diversifier la population, eviter les minima locaux |\n",
+    "| Exploitation | 16-30 | 0.05 (faible) | Affiner les meilleures solutions |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `GenerationMetaHeuristic` herite de `SizeBasedMetaHeuristic` et remplace `DynamicParameter` par un calcul base sur le numero de generation\n",
+    "2. La formule `(GenerationsNumber - 1) % TotalPhaseSize` assure un **cycle rebouclant** : apres la generation 30, la phase d'exploration recommence\n",
+    "3. Le cycle est utile pour les evolutions longues : exploration/exploitation alternent naturellement\n",
+    "4. La mise en cache a la porte `ParamScope.Generation` garantit que la meme phase est utilisee pour tous les individus d'une meme generation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:57.280654Z",
+     "iopub.status.busy": "2026-06-12T23:27:57.280477Z",
+     "iopub.status.idle": "2026-06-12T23:27:58.369803Z",
+     "shell.execute_reply": "2026-06-12T23:27:58.369534Z"
+    },
+    "vscode": {
+     "languageId": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "StageSwitchMetaHeuristic : crossover elitiste + mutation conservatrice\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config                   Run1        Run2        Run3        Run4        Run5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default                 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 15,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 55,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 13,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 18,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 15,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "StageSwitch(CX=Best)    "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 15,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 18,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 15,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 13,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 21,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Default moyenne     : 23,2000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  StageSwitch moyenne : 16,4000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note : StageSwitch dispatche par EvolutionStage (Crossover/Mutation/Selection/Reinsertion)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       Le DynamicParameter lit ctx.CurrentStage avec ParamScope.None (pas de cache)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demonstration: StageSwitchMetaHeuristic\n",
+    "// Applies different metaheuristics depending on the evolution stage:\n",
+    "//   Crossover stage: MatchMetaHeuristic with Best matching (elitist)\n",
+    "//   Mutation stage: DefaultMetaHeuristic with low mutation probability\n",
+    "//   Other stages (Selection, Reinsertion): DefaultMetaHeuristic (passthrough)\n",
+    "\n",
+    "Console.WriteLine(\"StageSwitchMetaHeuristic : crossover elitiste + mutation conservatrice\");\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "\n",
+    "var stageResults = new List<double>();\n",
+    "var plainDefault = new List<double>();\n",
+    "\n",
+    "for (int run = 0; run < 5; run++)\n",
+    "{\n",
+    "    // Build a StageSwitch for each run (heuristics are stateful)\n",
+    "    var ss = new StageSwitchMetaHeuristic();\n",
+    "    // Crossover: elitist (Current + Best)\n",
+    "    ss.PhaseHeuristics[EvolutionStage.Crossover] = BuildMatch(MatchingKind.Current, MatchingKind.Best);\n",
+    "\n",
+    "    // Mutation: conservative (p_m = 0.1)\n",
+    "    var mut = new DefaultMetaHeuristic();\n",
+    "    mut.ProbabilityConfig.Mutation.Strategy = ProbabilityStrategy.TestProbability | ProbabilityStrategy.OverwriteProbability;\n",
+    "    mut.ProbabilityConfig.Mutation.StaticProbability = 0.1f;\n",
+    "    ss.PhaseHeuristics[EvolutionStage.Mutation] = mut;\n",
+    "\n",
+    "    // Selection + Reinsertion: default passthrough\n",
+    "    ss.PhaseHeuristics[EvolutionStage.Selection] = new DefaultMetaHeuristic();\n",
+    "    ss.PhaseHeuristics[EvolutionStage.Reinsertion] = new DefaultMetaHeuristic();\n",
+    "\n",
+    "    stageResults.Add(RunWithMetaHeuristic(ss, \"StageSwitch\"));\n",
+    "    plainDefault.Add(RunWithMetaHeuristic(new DefaultMetaHeuristic(), \"Default\"));\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Config                   Run1        Run2        Run3        Run4        Run5\");\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "\n",
+    "Console.Write(\"Default                 \");\n",
+    "foreach (var r in plainDefault) Console.Write(string.Format(\" {0,-10:F4}\", r));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Console.Write(\"StageSwitch(CX=Best)    \");\n",
+    "foreach (var r in stageResults) Console.Write(string.Format(\" {0,-10:F4}\", r));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "Console.WriteLine(string.Format(\"  Default moyenne     : {0:F4}\", plainDefault.Average()));\n",
+    "Console.WriteLine(string.Format(\"  StageSwitch moyenne : {0:F4}\", stageResults.Average()));\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "Console.WriteLine(\"Note : StageSwitch dispatche par EvolutionStage (Crossover/Mutation/Selection/Reinsertion)\");\n",
+    "Console.WriteLine(\"       Le DynamicParameter lit ctx.CurrentStage avec ParamScope.None (pas de cache)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpretation : StageSwitchMetaHeuristic\n",
+    "\n",
+    "**Sortie obtenue** : Le `StageSwitch` combine un crossover elitiste (match avec le meilleur) et une mutation conservatrice.\n",
+    "\n",
+    "| Etape | Metaheuristique | Comportement |\n",
+    "|-------|----------------|-------------|\n",
+    "| Selection | `DefaultMetaHeuristic` | Selection par tournoi standard |\n",
+    "| Crossover | `MatchMetaHeuristic(Current+Best)` | Croise toujours avec le meilleur chromosome |\n",
+    "| Mutation | `DefaultMetaHeuristic` ($p_m = 0.1$) | Mutation faible pour ne pas detruire les bonnes solutions |\n",
+    "| Reinsertion | `DefaultMetaHeuristic` | Elitisme standard |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `StageSwitchMetaHeuristic` utilise `ctx.CurrentStage` comme cle de dispatch -- le moteur renseigne cette propriete a chaque etape\n",
+    "2. Le `DynamicParameter` a `ParamScope.None` (pas de cache) car l'etape change a chaque appel au sein d'une meme generation\n",
+    "3. Cette primitive est la plus **granulaire** : elle permet de specialiser independamment chaque etape de la boucle d'evolution\n",
+    "4. Le crossover elitiste (Best) couplie a une mutation faible favorise une convergence rapide mais peut reduire la diversite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Composition en action\n",
+    "\n",
+    "La puissance de MetaGeneticSharp reside dans la **composition libre** des primitives. Nous allons construire une strategie multi-niveaux qui combine :\n",
+    "\n",
+    "1. **Niveau generation** : alterner exploration (gen 1-20) et exploitation (gen 21-40)\n",
+    "2. **Niveau etape** : pendant l'exploration, utiliser un crossover diversifie ; pendant l'exploitation, utiliser un crossover elitiste\n",
+    "3. **Niveau mutation** : probabilité adaptative selon la phase\n",
+    "\n",
+    "### Architecture de la strategie composee\n",
+    "\n",
+    "```\n",
+    "GenerationMetaHeuristic(20, [explorePhase, exploitPhase])\n",
+    "  |\n",
+    "  +-- explorePhase (gen 1-20):\n",
+    "  |     StageSwitchMetaHeuristic\n",
+    "  |       Crossover -> MatchMetaHeuristic(Current + Random)  [diversifie]\n",
+    "  |       Mutation  -> DefaultMetaHeuristic (p_m = 0.4)      [agressive]\n",
+    "  |\n",
+    "  +-- exploitPhase (gen 21-40):\n",
+    "        StageSwitchMetaHeuristic\n",
+    "          Crossover -> MatchMetaHeuristic(Current + Best)    [elitiste]\n",
+    "          Mutation  -> DefaultMetaHeuristic (p_m = 0.05)    [conservatrice]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:58.371473Z",
+     "iopub.status.busy": "2026-06-12T23:27:58.371214Z",
+     "iopub.status.idle": "2026-06-12T23:27:59.301521Z",
+     "shell.execute_reply": "2026-06-12T23:27:59.298285Z"
+    },
+    "vscode": {
+     "languageId": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Strategie composee : Generation + StageSwitch + Match\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Explore (gen 1-20)  : CX=Current+Random, p_m=0.4\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exploit (gen 21-40) : CX=Current+Best,   p_m=0.05\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config                   Run1        Run2        Run3        Run4        Run5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default (40 gen)        "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 8,0000    "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 23,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 41,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 22,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 4,0000    "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Composed(20+20)         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 23,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 22,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 20,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 6,0000    "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 25,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Default moyenne   : 19,6000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Composed moyenne  : 19,2000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Amelioration      : 2,0%\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "La strategie composee combine 3 niveaux de primitives :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1. GenerationMetaHeuristic -> exploration/exploitation par generation\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2. StageSwitchMetaHeuristic -> comportement different par etape (CX vs M)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3. MatchMetaHeuristic -> selection des partenaires de crossover\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Composed strategy: GenerationMetaHeuristic containing StageSwitchMetaHeuristic\n",
+    "// containing MatchMetaHeuristic\n",
+    "\n",
+    "IMetaHeuristic BuildExplorePhase()\n",
+    "{\n",
+    "    var stageSwitch = new StageSwitchMetaHeuristic();\n",
+    "    // Crossover: diversified (Current + Random)\n",
+    "    stageSwitch.PhaseHeuristics[EvolutionStage.Crossover] = BuildMatch(MatchingKind.Current, MatchingKind.Random);\n",
+    "\n",
+    "    // Mutation: aggressive (p_m = 0.4)\n",
+    "    var mutExplore = new DefaultMetaHeuristic();\n",
+    "    mutExplore.ProbabilityConfig.Mutation.Strategy = ProbabilityStrategy.TestProbability | ProbabilityStrategy.OverwriteProbability;\n",
+    "    mutExplore.ProbabilityConfig.Mutation.StaticProbability = 0.4f;\n",
+    "    stageSwitch.PhaseHeuristics[EvolutionStage.Mutation] = mutExplore;\n",
+    "\n",
+    "    stageSwitch.PhaseHeuristics[EvolutionStage.Selection] = new DefaultMetaHeuristic();\n",
+    "    stageSwitch.PhaseHeuristics[EvolutionStage.Reinsertion] = new DefaultMetaHeuristic();\n",
+    "    return stageSwitch;\n",
+    "}\n",
+    "\n",
+    "IMetaHeuristic BuildExploitPhase()\n",
+    "{\n",
+    "    var stageSwitch = new StageSwitchMetaHeuristic();\n",
+    "    // Crossover: elitist (Current + Best)\n",
+    "    stageSwitch.PhaseHeuristics[EvolutionStage.Crossover] = BuildMatch(MatchingKind.Current, MatchingKind.Best);\n",
+    "\n",
+    "    // Mutation: conservative (p_m = 0.05)\n",
+    "    var mutExploit = new DefaultMetaHeuristic();\n",
+    "    mutExploit.ProbabilityConfig.Mutation.Strategy = ProbabilityStrategy.TestProbability | ProbabilityStrategy.OverwriteProbability;\n",
+    "    mutExploit.ProbabilityConfig.Mutation.StaticProbability = 0.05f;\n",
+    "    stageSwitch.PhaseHeuristics[EvolutionStage.Mutation] = mutExploit;\n",
+    "\n",
+    "    stageSwitch.PhaseHeuristics[EvolutionStage.Selection] = new DefaultMetaHeuristic();\n",
+    "    stageSwitch.PhaseHeuristics[EvolutionStage.Reinsertion] = new DefaultMetaHeuristic();\n",
+    "    return stageSwitch;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Strategie composee : Generation + StageSwitch + Match\");\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "Console.WriteLine(\"Explore (gen 1-20)  : CX=Current+Random, p_m=0.4\");\n",
+    "Console.WriteLine(\"Exploit (gen 21-40) : CX=Current+Best,   p_m=0.05\");\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "\n",
+    "var composedResults = new List<double>();\n",
+    "var simpleResults = new List<double>();\n",
+    "\n",
+    "for (int run = 0; run < 5; run++)\n",
+    "{\n",
+    "    composedResults.Add(RunWithMetaHeuristic(\n",
+    "        new GenerationMetaHeuristic(20, BuildExplorePhase(), BuildExploitPhase()),\n",
+    "        \"Composed\", generations: 40));\n",
+    "    simpleResults.Add(RunWithMetaHeuristic(new DefaultMetaHeuristic(), \"Default\", generations: 40));\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Config                   Run1        Run2        Run3        Run4        Run5\");\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "\n",
+    "Console.Write(\"Default (40 gen)        \");\n",
+    "foreach (var r in simpleResults) Console.Write(string.Format(\" {0,-10:F4}\", r));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Console.Write(\"Composed(20+20)         \");\n",
+    "foreach (var r in composedResults) Console.Write(string.Format(\" {0,-10:F4}\", r));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "Console.WriteLine(string.Format(\"  Default moyenne   : {0:F4}\", simpleResults.Average()));\n",
+    "Console.WriteLine(string.Format(\"  Composed moyenne  : {0:F4}\", composedResults.Average()));\n",
+    "Console.WriteLine(string.Format(\"  Amelioration      : {0:F1}%\",\n",
+    "    (simpleResults.Average() - composedResults.Average()) / simpleResults.Average() * 100));\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "Console.WriteLine(\"La strategie composee combine 3 niveaux de primitives :\");\n",
+    "Console.WriteLine(\"  1. GenerationMetaHeuristic -> exploration/exploitation par generation\");\n",
+    "Console.WriteLine(\"  2. StageSwitchMetaHeuristic -> comportement different par etape (CX vs M)\");\n",
+    "Console.WriteLine(\"  3. MatchMetaHeuristic -> selection des partenaires de crossover\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Strategie composee\n",
+    "\n",
+    "**Sortie obtenue** : La strategie composee combine les avantages de chaque primitive.\n",
+    "\n",
+    "| Niveau | Primitive | Parametres | Effet |\n",
+    "|--------|-----------|------------|-------|\n",
+    "| Generation | `GenerationMetaHeuristic(20, ...)` | Cycle de 40 generations | Alterne exploration et exploitation |\n",
+    "| Etape | `StageSwitchMetaHeuristic` | Crossover vs Mutation | Specifique a chaque operateur |\n",
+    "| Match | `MatchMetaHeuristic` | Random ou Best | Diversifie ou intensifie le crossover |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. La composition est **hierarchique** : chaque niveau delegue aux niveaux inferieurs\n",
+    "2. Le moteur appelle `RegisterParameters()` recursivement sur toute la hierarchie, garantissant que les caches de chaque niveau sont initialises\n",
+    "3. La strategie composee est un objet C# ordinaire -- elle peut etre parametree, serialisee, testee unitairement\n",
+    "4. Sur un probleme unimodale comme Sphere, l'avantage peut etre marginal ; c'est sur les problemes **multimodaux** et **contraints** que la composition montre tout son potentiel\n",
+    "\n",
+    "> **Note technique** : `GenerationMetaHeuristic` wrappe l'index avec `(GenerationsNumber - 1) % TotalPhaseSize`, donc le cycle se repete au-dela de 40 generations. Pour une evolution de 80 generations, on aurait deux cycles complets exploration -> exploitation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. Resume\n",
+    "\n",
+    "Ce notebook a introduit les mecanismes de composition de MetaGeneticSharp :\n",
+    "\n",
+    "| Concept | Role | Parametres cles |\n",
+    "|---------|------|-----------------|\n",
+    "| **MatchMetaHeuristic** | Controle l'appariement des parents lors du crossover | `MatchingKind` (Current, Random, Best, Worst, Neighbor, RouletteWheel) |\n",
+    "| **MatchPicker** | Pipeline de directives de selection | `MatchingSettings` (kind, picks, caching) |\n",
+    "| **SwitchMetaHeuristic&lt;T&gt;** | Dispatch generique par cle | `DynamicParameter`, `PhaseHeuristics` |\n",
+    "| **SizeBasedMetaHeuristic** | Dispatch par plages d'indices contigues | `EnumeratedPhases` (tailles de phases) |\n",
+    "| **GenerationMetaHeuristic** | Alternance par numero de generation | Taille de phase, sous-metaheuristiques |\n",
+    "| **StageSwitchMetaHeuristic** | Dispatch par etape d'evolution | `EvolutionStage` comme cle |\n",
+    "| **Composition** | Combinaison hierarchique des primitives | Imbriquer les niveaux librement |\n",
+    "\n",
+    "### Principes de conception\n",
+    "\n",
+    "1. **Separation des preoccupations** : chaque primitive controle un seul aspect (generation, etape, match)\n",
+    "2. **Composition ouverte** : les primitives s'imbriquent librement, sans restriction d'arbre\n",
+    "3. **Cache par porte** : les valeurs calculees sont mises en cache selon `ParamScope` (None, Generation, MetaHeuristic...)\n",
+    "4. **Rebouclage** : les phases cyclent naturellement via modulo\n",
+    "\n",
+    "### Pour aller plus loin\n",
+    "\n",
+    "- **Notebook suivant** : [MGS-3 Populations](MGS-3-Populations.ipynb) -- populations structurees (iles, sous-populations)\n",
+    "- **Reference** : Sorensen, K. (2015). *Metaheuristics -- The Metaphor Exposed*.\n",
+    "- **Code source** : https://github.com/jsboige/MetaGeneticSharp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercice 1 : Adapter le match selon le numero de generation\n",
+    "\n",
+    "L'objectif est de creer une strategie qui utilise un match **Random** (diversifie) pendant les 10 premieres generations, puis un match **Best** (elitiste) pour les generations suivantes.\n",
+    "\n",
+    "**Enonce** : Utilisez `GenerationMetaHeuristic` avec deux phases : une phase d'exploration contenant un `MatchMetaHeuristic(Current + Random)` et une phase d'exploitation contenant un `MatchMetaHeuristic(Current + Best)`.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `GenerationMetaHeuristic(10, exploreMh, exploitMh)` cree un cycle de 20 generations (10+10)\n",
+    "- Pour les generations 11-20, le cycle reboucle sur la phase 0 -- ce n'est pas ideal. Utilisez une seule phase d'exploration de 10 et une phase d'exploitation de 30 pour couvrir 40 generations\n",
+    "- Utilisez le constructeur `SizeBasedMetaHeuristic((int, IMetaHeuristic)[])` pour des phases de tailles differentes\n",
+    "- `new SizeBasedMetaHeuristic(new[] { (10, exploreMh), (30, exploitMh) })` cree 10+30 = 40"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:59.303158Z",
+     "iopub.status.busy": "2026-06-12T23:27:59.302886Z",
+     "iopub.status.idle": "2026-06-12T23:27:59.371435Z",
+     "shell.execute_reply": "2026-06-12T23:27:59.371215Z"
+    },
+    "vscode": {
+     "languageId": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : Match adaptatif par generation\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Adapter le match selon le numero de generation\n",
+    "// TODO: Creez une strategie GenerationMetaHeuristic qui utilise\n",
+    "//       - Phase explore (10 gen) : MatchMetaHeuristic(Current + Random)\n",
+    "//       - Phase exploit (30 gen) : MatchMetaHeuristic(Current + Best)\n",
+    "// Indice: GenerationMetaHeuristic herite de SizeBasedMetaHeuristic\n",
+    "// Indice: new SizeBasedMetaHeuristic(new[] { (10, exploreMh), (30, exploitMh) })\n",
+    "\n",
+    "// Etape 1 : Definir la phase d'exploration\n",
+    "// var exploreMh = ... (MatchMetaHeuristic avec Current + Random)\n",
+    "\n",
+    "// Etape 2 : Definir la phase d'exploitation\n",
+    "// var exploitMh = ... (MatchMetaHeuristic avec Current + Best)\n",
+    "\n",
+    "// Etape 3 : Composez avec SizeBasedMetaHeuristic pour des phases asymetriques\n",
+    "// var strategy = new SizeBasedMetaHeuristic(new[] { (10, exploreMh), (30, exploitMh) });\n",
+    "\n",
+    "// Etape 4 : Executez et comparez avec DefaultMetaHeuristic\n",
+    "// var result = RunWithMetaHeuristic(strategy, \"GenMatch\", generations: 40);\n",
+    "\n",
+    "object result = null; // TODO etudiant : lancer la strategie et afficher le resultat\n",
+    "Console.WriteLine(\"Exercice a completer : Match adaptatif par generation\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 : Combiner SizeBased et Match pour une strategie hybride\n",
+    "\n",
+    "L'objectif est de creer une strategie qui traite differemment les **premiers individus** de la population (index 0-19) et les **suivants** (index 20-49).\n",
+    "\n",
+    "**Enonce** : Utilisez `SizeBasedMetaHeuristic(20, ...)` avec deux sous-metaheuristiques :\n",
+    "- Zone 1 (index 0-19) : `MatchMetaHeuristic(Current + Best)` pour intensifier\n",
+    "- Zone 2 (index 20-49) : `MatchMetaHeuristic(Current + Random)` pour diversifier\n",
+    "\n",
+    "**Indices** :\n",
+    "- `SizeBasedMetaHeuristic(20, zone1Mh, zone2Mh)` divise en phases de 20 chacune\n",
+    "- Pour une population de 50, les index 40-49 rebouclent sur la zone 1 (modulo 40)\n",
+    "- Ajustez la taille de phase si vous voulez couvrir exactement 50 : `SizeBasedMetaHeuristic(new[] { (20, zone1), (30, zone2) })`\n",
+    "- Observez comment les deux zones interagissent dans la population globale"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:59.373279Z",
+     "iopub.status.busy": "2026-06-12T23:27:59.373061Z",
+     "iopub.status.idle": "2026-06-12T23:27:59.421397Z",
+     "shell.execute_reply": "2026-06-12T23:27:59.421146Z"
+    },
+    "vscode": {
+     "languageId": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : SizeBased + Match hybride\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Combiner SizeBased et Match pour une strategie hybride\n",
+    "// TODO: Creez une SizeBasedMetaHeuristic avec deux zones:\n",
+    "//       - Zone 1 (index 0-19) : Match(Current + Best) -- intensification\n",
+    "//       - Zone 2 (index 20-49) : Match(Current + Random) -- diversification\n",
+    "// Indice: new SizeBasedMetaHeuristic(new[] { (20, zone1Mh), (30, zone2Mh) })\n",
+    "\n",
+    "// Etape 1 : Definir la zone d'intensification\n",
+    "// var zone1Mh = ... (MatchMetaHeuristic avec Current + Best)\n",
+    "\n",
+    "// Etape 2 : Definir la zone de diversification\n",
+    "// var zone2Mh = ... (MatchMetaHeuristic avec Current + Random)\n",
+    "\n",
+    "// Etape 3 : Composez avec SizeBasedMetaHeuristic\n",
+    "// var strategy = new SizeBasedMetaHeuristic(new[] { (20, zone1Mh), (30, zone2Mh) });\n",
+    "\n",
+    "// Etape 4 : Executez et comparez\n",
+    "// var result = RunWithMetaHeuristic(strategy, \"Hybrid\", popSize: 50, generations: 50);\n",
+    "\n",
+    "object result = null; // TODO etudiant : lancer la strategie et afficher le resultat\n",
+    "Console.WriteLine(\"Exercice a completer : SizeBased + Match hybride\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : Strategie multi-phases avec Generation + StageSwitch\n",
+    "\n",
+    "L'objectif est de creer une strategie en **trois phases** avec un comportement different pour le crossover et la mutation a chaque phase.\n",
+    "\n",
+    "**Enonce** : Construisez une strategie avec trois phases de 15 generations chacune :\n",
+    "- **Phase 1 (gen 1-15)** -- Exploration : crossover diversifie (Random), mutation agressive ($p_m = 0.5$)\n",
+    "- **Phase 2 (gen 16-30)** -- Equilibrage : crossover par tour de roulette (RouletteWheel), mutation moderee ($p_m = 0.2$)\n",
+    "- **Phase 3 (gen 31-45)** -- Exploitation : crossover elitiste (Best), mutation conservatrice ($p_m = 0.02$)\n",
+    "\n",
+    "**Indices** :\n",
+    "- Utilisez `GenerationMetaHeuristic(15, phase1, phase2, phase3)` pour un cycle de 45 generations\n",
+    "- Chaque phase est un `StageSwitchMetaHeuristic` avec un `MatchMetaHeuristic` different pour le crossover\n",
+    "- `MatchingKind.RouletteWheel` utilise la selection proportionnelle au fitness pour choisir le partenaire\n",
+    "- Executez avec 45 generations pour couvrir exactement un cycle\n",
+    "- Comparez avec la strategie composee de la section 4 (qui n'a que 2 phases)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-12T23:27:59.423147Z",
+     "iopub.status.busy": "2026-06-12T23:27:59.422924Z",
+     "iopub.status.idle": "2026-06-12T23:27:59.458209Z",
+     "shell.execute_reply": "2026-06-12T23:27:59.458023Z"
+    },
+    "vscode": {
+     "languageId": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : Strategie trois phases (Generation + StageSwitch)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Strategie multi-phases avec Generation + StageSwitch\n",
+    "// TODO: Construisez 3 phases de 15 generations chacune\n",
+    "// Indice: GenerationMetaHeuristic(15, phase1, phase2, phase3)\n",
+    "// Indice: chaque phase = StageSwitchMetaHeuristic avec Match + mutation custom\n",
+    "\n",
+    "// Etape 1 : Phase exploration (gen 1-15)\n",
+    "//   Crossover: MatchMetaHeuristic(Current + Random)\n",
+    "//   Mutation: p_m = 0.5 (agressive)\n",
+    "// var phase1 = ... ;\n",
+    "\n",
+    "// Etape 2 : Phase equilibrage (gen 16-30)\n",
+    "//   Crossover: MatchMetaHeuristic(Current + RouletteWheel)\n",
+    "//   Mutation: p_m = 0.2 (moderee)\n",
+    "// var phase2 = ... ;\n",
+    "\n",
+    "// Etape 3 : Phase exploitation (gen 31-45)\n",
+    "//   Crossover: MatchMetaHeuristic(Current + Best)\n",
+    "//   Mutation: p_m = 0.02 (conservatrice)\n",
+    "// var phase3 = ... ;\n",
+    "\n",
+    "// Etape 4 : Composez et executez\n",
+    "// var strategy = new GenerationMetaHeuristic(15, phase1, phase2, phase3);\n",
+    "// var result = RunWithMetaHeuristic(strategy, \"ThreePhase\", generations: 45);\n",
+    "\n",
+    "object result = null; // TODO etudiant : lancer la strategie et afficher le resultat\n",
+    "Console.WriteLine(\"Exercice a completer : Strategie trois phases (Generation + StageSwitch)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "**Navigation** : [Index](../README.md) | [<< MGS-1 Introduction](MGS-1-Introduction.ipynb) | [MGS-3 Populations >>](MGS-3-Populations.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Second pedagogical notebook for MetaGeneticSharp (Epic #1203, Phase 3). Builds on NB-A (PR #2873, merged) to demonstrate the composition primitives that make MetaGeneticSharp expressive: Match machinery + control-flow primitives.

### Notebook content

- **26 cells** (10 code + 16 markdown), kernel `.net-csharp`
- **Section 1**: Motivation — why compose metaheuristics, primitives palette (8 primitives with analogies)
- **Section 2**: Match machinery — `MatchMetaHeuristic`, `MatchPicker`, `MatchingSettings`, all 8 `MatchingKind` values; demo comparing Current+Neighbor/Random/Best on Sphere
- **Section 3**: Control-flow primitives — `SizeBasedMetaHeuristic` (two crossover zones), `GenerationMetaHeuristic` (exploration/exploitation cycle), `StageSwitchMetaHeuristic` (elitist crossover + conservative mutation)
- **Section 4**: Composition — multi-level hierarchy (Generation → StageSwitch → Match), 5-run comparison vs DefaultMetaHeuristic
- **Section 5**: Summary — 7-concept recap + design principles

### Validation (H.1)

- `jupyter nbconvert --execute` — 10/10 code cells, 0 errors
- `execution_count` + coherent outputs for all code cells (C.2)
- C.1 verified: 0 `NotImplementedException`, 0 `throw`, 0 `1/0`
- #2161: 3 exercises (Match adaptive by generation, SizeBased+Match hybrid, three-phase strategy)
- No emojis, French markdown, English code comments
- No catalog files touched

### Context

- Base: NB-A merged (`0337e0b3`)
- Wiring pattern identical to NB-A (4 `#r` DLLs from submodule build)
- Next: NB-C (Eukaryote/sub-population) after merge

See #1203