### PR TITLE
docs(readme): restore French accents in Search series READMEs (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -2,29 +2,29 @@
 
 C'est ici que la série Search se confronte au réel. Les 21 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents.
 
-Sous-serie de **21 notebooks** | **~14h05** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`)
+Sous-série de **21 notebooks** | **~14h05** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`)
 
-## Pourquoi cette sous-serie
+## Pourquoi cette sous-série
 
 Un algorithme compris sur un exemple jouet n'est pas encore un algorithme maîtrisé. Les applications servent trois apprentissages que les parties théoriques ne peuvent pas donner. D'abord la confrontation des méthodes : le même problème y est régulièrement résolu plusieurs fois — N-Queens en backtracking, en Min-Conflicts et en OR-Tools ; le TSP en recuit simulé, en génétique, en colonies de fourmis et en solveur de routage — et la comparaison chiffrée vaut tous les discours. Ensuite l'ordre de grandeur : voir un solveur de Picross gagner un facteur de plusieurs millions en passant au CP-SAT imprime durablement ce que « propagation » veut dire. Enfin la modélisation, qui est souvent toute la difficulté : le démineur devient un CSP doublé de probabilités, Wordle un problème de théorie de l'information, la génération procédurale de niveaux un Wave Function Collapse encodé en contraintes — autant de cas où trouver la bonne formulation est l'essentiel du travail.
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette sous-serie, vous serez capable de :
+À l'issue de cette sous-série, vous serez capable de :
 
-1. **Transposer** les algorithmes de Search et CSP vers des problemes reels (logistique, ordonnancement, jeux)
-2. **Comparer** les approches (backtracking vs CP-SAT vs metaheuristiques) sur des instances concretes
-3. **Evaluer** les compromis performance/qualite entre methodes exactes et approchees
+1. **Transposer** les algorithmes de Search et CSP vers des problèmes réels (logistique, ordonnancement, jeux)
+2. **Comparer** les approches (backtracking vs CP-SAT vs métaheuristiques) sur des instances concrètes
+3. **Évaluer** les compromis performance/qualité entre méthodes exactes et approchées
 
 ## FAQ / Troubleshooting
 
-| Probleme | Solution |
+| Problème | Solution |
 |----------|----------|
-| `ModuleNotFoundError: minizinc` | `pip install minizinc` — necessaire pour App-5 (Timetabling) et App-8 (MiniZinc). Requiert aussi l'installation du solver MiniZinc |
-| `ModuleNotFoundError: optuna` | `pip install optuna` — necessaire pour App-18 (Hyperparameter Tuning) |
-| `ModuleNotFoundError: pygad` | `pip install pygad` — necessaire pour App-9/10 (EdgeDetection, Portfolio) |
+| `ModuleNotFoundError: minizinc` | `pip install minizinc` — nécessaire pour App-5 (Timetabling) et App-8 (MiniZinc). Requiert aussi l'installation du solver MiniZinc |
+| `ModuleNotFoundError: optuna` | `pip install optuna` — nécessaire pour App-18 (Hyperparameter Tuning) |
+| `ModuleNotFoundError: pygad` | `pip install pygad` — nécessaire pour App-9/10 (EdgeDetection, Portfolio) |
 | App-9b/10b (.NET) : kernel non disponible | Installer .NET Interactive : `dotnet tool install --global Microsoft.dotnet-interactive` |
-| Certains solveurs sont lents (>30s) | Les instances sont intentionally petites pour le pedagogique. Pour des instances plus grandes, activer les timeouts dans CP-SAT (`model.parameters.max_time_in_seconds`) |
+| Certains solveurs sont lents (>30s) | Les instances sont intentionnellement petites pour le pédagogique. Pour des instances plus grandes, activer les timeouts dans CP-SAT (`model.parameters.max_time_in_seconds`) |
 
 ## Structure
 
@@ -41,10 +41,10 @@ Applications/
 
 Deux notebooks autour du Puissance 4, le banc d'essai idéal de la recherche adversariale : assez simple pour être résolu, assez riche pour départager les approches. Le premier construit les joueurs (Minimax, MCTS, et un agent DQN appris), le second les fait s'affronter en benchmark systématique.
 
-| # | Notebook | Duree | Contenu | Source |
+| # | Notebook | Durée | Contenu | Source |
 |---|----------|-------|---------|--------|
-| 1 | [App-12-ConnectFour](Search/App-12-ConnectFour.ipynb) | ~50 min | Puissance 4 : Minimax, MCTS, DQN-RL | Projet etudiant |
-| 2 | [App-14-ConnectFour-Adversarial](Search/App-14-ConnectFour-Adversarial.ipynb) | ~45 min | Benchmark adversarial : Minimax, Alpha-Beta, MCTS | Projet etudiant |
+| 1 | [App-12-ConnectFour](Search/App-12-ConnectFour.ipynb) | ~50 min | Puissance 4 : Minimax, MCTS, DQN-RL | Projet étudiant |
+| 2 | [App-14-ConnectFour-Adversarial](Search/App-14-ConnectFour-Adversarial.ipynb) | ~45 min | Benchmark adversarial : Minimax, Alpha-Beta, MCTS | Projet étudiant |
 
 ---
 
@@ -52,40 +52,40 @@ Deux notebooks autour du Puissance 4, le banc d'essai idéal de la recherche adv
 
 Le gros de la sous-série, et un panorama de ce que la programmation par contraintes sait faire dès qu'on sort du manuel : des classiques fondateurs (N-Queens, coloration de graphes) aux problèmes d'ordonnancement réalistes (infirmiers, job-shop, emplois du temps, calendriers sportifs), en passant par des terrains plus inattendus — le démineur qui mêle contraintes et probabilités, Wordle lu comme un problème d'information, le Picross qui sert de leçon de vitesse, et la génération procédurale de niveaux par Wave Function Collapse.
 
-| # | Notebook | Duree | Contenu | Source |
+| # | Notebook | Durée | Contenu | Source |
 |---|----------|-------|---------|--------|
 | 1 | [App-1-NQueens](CSP/App-1-NQueens.ipynb) | ~30 min | Backtracking, Min-Conflicts, OR-Tools | Classique |
-| 2 | [App-2-GraphColoring](CSP/App-2-GraphColoring.ipynb) | ~45 min | Greedy, DSATUR, CP-SAT, departements | Projet etudiant |
-| 3 | [App-3-NurseScheduling](CSP/App-3-NurseScheduling.ipynb) | ~60 min | Hard/soft constraints, CP-SAT | Projet etudiant |
-| 4 | [App-4-JobShopScheduling](CSP/App-4-JobShopScheduling.ipynb) | ~60 min | Intervalles, precedences, makespan | Projet etudiant |
-| 5 | [App-5-Timetabling](CSP/App-5-Timetabling.ipynb) | ~50 min | MiniZinc + OR-Tools | Projet etudiant |
-| 6 | [App-6-Minesweeper](CSP/App-6-Minesweeper.ipynb) | ~50 min | CSP + probabilites + LLM | Projet etudiant |
-| 7 | [App-7-Wordle](CSP/App-7-Wordle.ipynb) | ~45 min | Filtrage CSP + theorie de l'information | Projet etudiant |
+| 2 | [App-2-GraphColoring](CSP/App-2-GraphColoring.ipynb) | ~45 min | Greedy, DSATUR, CP-SAT, départements | Projet étudiant |
+| 3 | [App-3-NurseScheduling](CSP/App-3-NurseScheduling.ipynb) | ~60 min | Hard/soft constraints, CP-SAT | Projet étudiant |
+| 4 | [App-4-JobShopScheduling](CSP/App-4-JobShopScheduling.ipynb) | ~60 min | Intervalles, précédences, makespan | Projet étudiant |
+| 5 | [App-5-Timetabling](CSP/App-5-Timetabling.ipynb) | ~50 min | MiniZinc + OR-Tools | Projet étudiant |
+| 6 | [App-6-Minesweeper](CSP/App-6-Minesweeper.ipynb) | ~50 min | CSP + probabilités + LLM | Projet étudiant |
+| 7 | [App-7-Wordle](CSP/App-7-Wordle.ipynb) | ~45 min | Filtrage CSP + théorie de l'information | Projet étudiant |
 | 8 | [App-8-MiniZinc](CSP/App-8-MiniZinc.ipynb) | ~50 min | Syntaxe MiniZinc, contraintes globales | Nouveau |
-| 9 | [App-11-Picross](CSP/App-11-Picross.ipynb) | ~40 min | Nonogrammes : 27Mx speedup CP-SAT | Projet etudiant |
-| 10 | [App-15-SportsScheduling](CSP/App-15-SportsScheduling.ipynb) | ~55 min | Calendrier sportif : contraintes TV, equite, deplacements | Projet etudiant |
-| 11 | [App-16-Crossword-CSP](CSP/App-16-Crossword-CSP.ipynb) | ~45 min | Mots croises : backtracking, OR-Tools, generation | Projet etudiant |
-| 12 | [App-19-ProceduralGeneration-WFC](CSP/App-19-ProceduralGeneration-WFC.ipynb) | ~45 min | Generation procedurale : Wave Function Collapse via CP-SAT | Projet etudiant |
+| 9 | [App-11-Picross](CSP/App-11-Picross.ipynb) | ~40 min | Nonogrammes : 27Mx speedup CP-SAT | Projet étudiant |
+| 10 | [App-15-SportsScheduling](CSP/App-15-SportsScheduling.ipynb) | ~55 min | Calendrier sportif : contraintes TV, équité, déplacements | Projet étudiant |
+| 11 | [App-16-Crossword-CSP](CSP/App-16-Crossword-CSP.ipynb) | ~45 min | Mots croisés : backtracking, OR-Tools, génération | Projet étudiant |
+| 12 | [App-19-ProceduralGeneration-WFC](CSP/App-19-ProceduralGeneration-WFC.ipynb) | ~45 min | Génération procédurale : Wave Function Collapse via CP-SAT | Projet étudiant |
 
 ---
 
-## Applications Hybrid / Metaheuristiques (`Hybrid/`)
+## Applications Hybrid / Métaheuristiques (`Hybrid/`)
 
 Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes exactes, place aux métaheuristiques : détection de contours et optimisation de portefeuille par algorithmes génétiques (avec leurs doublons C#/GeneticSharp en side-track .NET), TSP et VRP attaqués par quatre méthodes concurrentes, et le réglage d'hyperparamètres ML — où la boucle se referme : on optimise l'optimiseur.
 
-| # | Notebook | Duree | Contenu | Source |
+| # | Notebook | Durée | Contenu | Source |
 |---|----------|-------|---------|--------|
 | 1 | [App-9-EdgeDetection](Hybrid/App-9-EdgeDetection.ipynb) | ~40 min | GA pour filtres de convolution | Existant |
 | 2 | [App-9b-EdgeDetection-CSharp](Hybrid/App-9b-EdgeDetection-CSharp.ipynb) | ~35 min | GeneticSharp (C#) | Existant |
-| 3 | [App-10-Portfolio](Hybrid/App-10-Portfolio.ipynb) | ~40 min | Multi-objectif, frontiere de Pareto | Existant |
+| 3 | [App-10-Portfolio](Hybrid/App-10-Portfolio.ipynb) | ~40 min | Multi-objectif, frontière de Pareto | Existant |
 | 4 | [App-10b-Portfolio-CSharp](Hybrid/App-10b-Portfolio-CSharp.ipynb) | ~30 min | GeneticSharp (C#) | Existant |
 | 5 | [App-13-TSP-Metaheuristics](Hybrid/App-13-TSP-Metaheuristics.ipynb) | ~50 min | TSP : SA, GA, ACO, OR-Tools routing | Classique |
-| 6 | [App-17-VRP-Logistics](Hybrid/App-17-VRP-Logistics.ipynb) | ~60 min | Vehicle Routing : SA, GA, ACO, CP-SAT | Projet etudiant |
-| 7 | [App-18-HyperparameterTuning](Hybrid/App-18-HyperparameterTuning.ipynb) | ~40 min | Optimisation ML : Bayesienne, GA, PSO, Optuna | Nouveau |
+| 6 | [App-17-VRP-Logistics](Hybrid/App-17-VRP-Logistics.ipynb) | ~60 min | Vehicle Routing : SA, GA, ACO, CP-SAT | Projet étudiant |
+| 7 | [App-18-HyperparameterTuning](Hybrid/App-18-HyperparameterTuning.ipynb) | ~40 min | Optimisation ML : Bayésienne, GA, PSO, Optuna | Nouveau |
 
 ---
 
-## Prerequis par notebook
+## Prérequis par notebook
 
 ### Applications Search
 
@@ -96,7 +96,7 @@ Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes 
 
 ### Applications CSP
 
-| Notebook | Fondations requises | Dependances |
+| Notebook | Fondations requises | Dépendances |
 |----------|--------------------|-------------|
 | App-1 NQueens | CSP-1 (Fundamentals) | - |
 | App-2 GraphColoring | CSP-1, CSP-2 | networkx |
@@ -113,7 +113,7 @@ Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes 
 
 ### Applications Hybrid
 
-| Notebook | Fondations requises | Dependances |
+| Notebook | Fondations requises | Dépendances |
 |----------|--------------------|-------------|
 | App-9 EdgeDetection | Search-5 (GA) | pygad, scikit-image |
 | App-9b EdgeDetection | Search-5 (GA) | GeneticSharp (.NET) |
@@ -127,21 +127,21 @@ Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes 
 
 ## Origine des projets
 
-La plupart des notebooks d'application sont adaptes de projets etudiants realises dans le cadre de cours d'IA. Les references specifics sont indiquees dans chaque notebook.
+La plupart des notebooks d'application sont adaptés de projets étudiants réalisés dans le cadre de cours d'IA. Les références spécifiques sont indiquées dans chaque notebook.
 
 ---
 
-## Ponts inter-series
+## Ponts inter-séries
 
-| Serie | Lien | Relation |
+| Série | Lien | Relation |
 | ------- | ------ | ---------- |
-| [Partie 1 : Search](../Part1-Foundations/README.md) | Fondamentaux | Source des algorithmes utilises |
+| [Partie 1 : Search](../Part1-Foundations/README.md) | Fondamentaux | Source des algorithmes utilisés |
 | [Partie 2 : CSP](../Part2-CSP/README.md) | Programmation par contraintes | Solveurs CP-SAT, MiniZinc |
 | [Search (parent)](../README.md) | Vue d'ensemble | Contexte et parcours global |
-| [ML/ML.Net](../../ML/ML.Net/) | App-18 (HyperparameterTuning) | Optimisation bayesienne + GA |
-| [Sudoku](../../Sudoku/) | App-11 (Picross), App-1 (NQueens) | Problemes combinatoires similaires |
-| [GameTheory](../../GameTheory/) | App-12/14 (ConnectFour) | Jeux a deux joueurs, MCTS |
+| [ML/ML.Net](../../ML/ML.Net/) | App-18 (HyperparameterTuning) | Optimisation bayésienne + GA |
+| [Sudoku](../../Sudoku/) | App-11 (Picross), App-1 (NQueens) | Problèmes combinatoires similaires |
+| [GameTheory](../../GameTheory/) | App-12/14 (ConnectFour) | Jeux à deux joueurs, MCTS |
 
 ## Navigation
 
-[<- Partie 1 : Search](../Part1-Foundations/README.md) | [Partie 2 : CSP](../Part2-CSP/README.md) | [Retour a la serie Search](../README.md)
+[<- Partie 1 : Search](../Part1-Foundations/README.md) | [Partie 2 : CSP](../Part2-CSP/README.md) | [Retour à la série Search](../README.md)

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -1,8 +1,8 @@
 # Partie 1 : Search Fondamental
 
-[↑ Serie Search](../README.md) | [Partie 2 : CSP →](../Part2-CSP/README.md)
+[↑ Série Search](../README.md) | [Partie 2 : CSP →](../Part2-CSP/README.md)
 
-Comment passer d'une enumeration exhaustive a une exploration intelligemment guidee d'un espace d'etats ? Cette premiere partie couvre les trois grands paradigmes de la recherche en IA : systematique (BFS, A*), locale (Hill Climbing, recuit simule) et evolutive (algorithmes genetiques, PSO). Le fil rouge est la reduction progressive de l'espace de recherche, depuis la formalisation du probleme jusqu'aux metaheuristiques comparees sur des benchmarks.
+Comment passer d'une énumération exhaustive à une exploration intelligemment guidée d'un espace d'états ? Cette première partie couvre les trois grands paradigmes de la recherche en IA : systématique (BFS, A*), locale (Hill Climbing, recuit simulé) et évolutive (algorithmes génétiques, PSO). Le fil rouge est la réduction progressive de l'espace de recherche, depuis la formalisation du problème jusqu'aux métaheuristiques comparées sur des benchmarks.
 
 Le parcours s'ouvre sur une idée simple et étonnamment puissante : avant de résoudre un problème, il faut le poser. Search-1 montre qu'un taquin, un aspirateur-robot et une recherche d'itinéraire sont un seul et même objet mathématique — un espace d'états (S, A, T, G) — et que cette formalisation suffit à rendre le problème calculable. Search-2 lance alors l'exploration à l'aveugle : BFS garantit l'optimal mais explose en mémoire, DFS file droit mais peut se perdre, et leurs variantes (UCS, IDDFS) négocient chacune un compromis différent entre garantie et coût. Search-3 apporte la réponse classique à cette explosion : une heuristique — une estimation du chemin restant — et l'algorithme A*, dont l'optimalité tient à une propriété fine, l'admissibilité, que le notebook prend le temps d'éprouver plutôt que de la postuler.
 
@@ -16,53 +16,53 @@ Cette partie est l'alphabet de toute la série : la formalisation en espace d'é
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette partie, vous serez capable de :
+À l'issue de cette partie, vous serez capable de :
 
-1. **Formaliser** un probleme sous forme d'espace d'etats (S, A, T, G) et l'implementer en Python
-2. **Choisir** l'algorithme de recherche adapte au probleme : systematique (BFS, A*), locale (SA, Tabu), ou evolutive (GA, PSO)
-3. **Concevoir et evaluer** des heuristiques admissibles et consistantes pour guider la recherche
-4. **Appliquer** la recherche adversariale (Minimax, Alpha-Beta, MCTS) aux jeux a deux joueurs
-5. **Comparer** les metaheuristiques sur des benchmarks reels et justifier le choix d'un algorithme
+1. **Formaliser** un problème sous forme d'espace d'états (S, A, T, G) et l'implémenter en Python
+2. **Choisir** l'algorithme de recherche adapté au problème : systématique (BFS, A*), locale (SA, Tabu), ou évolutive (GA, PSO)
+3. **Concevoir et évaluer** des heuristiques admissibles et consistantes pour guider la recherche
+4. **Appliquer** la recherche adversariale (Minimax, Alpha-Beta, MCTS) aux jeux à deux joueurs
+5. **Comparer** les métaheuristiques sur des benchmarks réels et justifier le choix d'un algorithme
 
 ## Notebooks
 
-| # | Notebook | Kernel | Contenu | Duree |
+| # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
-| 1 | [Search-1-StateSpace](Search-1-StateSpace.ipynb) | Python 3 | Espaces d'etats, formalisation (S, A, T, G), taquin, aspirateur, recherche d'itineraire | ~40 min |
-| 2 | [Search-2-Uninformed](Search-2-Uninformed.ipynb) | Python 3 | BFS, DFS, UCS, IDDFS : comparaison des algorithmes non informes | ~50 min |
+| 1 | [Search-1-StateSpace](Search-1-StateSpace.ipynb) | Python 3 | Espaces d'états, formalisation (S, A, T, G), taquin, aspirateur, recherche d'itinéraire | ~40 min |
+| 2 | [Search-2-Uninformed](Search-2-Uninformed.ipynb) | Python 3 | BFS, DFS, UCS, IDDFS : comparaison des algorithmes non informés | ~50 min |
 | 3 | [Search-3-Informed](Search-3-Informed.ipynb) | Python 3 | A*, Greedy, IDA*, heuristiques admissibles et consistantes | ~50 min |
 | 4 | [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) | Python 3 | Hill Climbing, Simulated Annealing, Tabu Search, paysages de fitness | ~45 min |
-| 5 | [Search-5-GeneticAlgorithms](Search-5-GeneticAlgorithms.ipynb) | Python 3 | Selection, crossover, mutation, DEAP/PyGAD, theorie unifiee | ~50 min |
+| 5 | [Search-5-GeneticAlgorithms](Search-5-GeneticAlgorithms.ipynb) | Python 3 | Sélection, crossover, mutation, DEAP/PyGAD, théorie unifiée | ~50 min |
 | 6 | [Search-6-AdversarialSearch](Search-6-AdversarialSearch.ipynb) | Python 3 | Minimax, Alpha-Beta pruning, Null-window search, tables de transposition | ~1h |
 | 7 | [Search-7-MCTS-And-Beyond](Search-7-MCTS-And-Beyond.ipynb) | Python 3 | Monte Carlo Tree Search, UCB1, OpenSpiel, architecture AlphaGo (DQN+MCTS) | ~1h30 |
 | 8 | [Search-8-DancingLinks](Search-8-DancingLinks.ipynb) | Python 3 | Algorithme X de Knuth, Dancing Links (DLX), couverture exacte (Sudoku, N-Queens, Pentominoes) | ~1h30 |
-| 9 | [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) | Python 3 | Programmation lineaire avec PuLP, simplex, probleme du transport, diet problem, PLNE | ~2h |
-| 10 | [Search-10-SymbolicAutomata](Search-10-SymbolicAutomata.ipynb) | Python 3 | Automates finis (DFA/NFA) avec automata-lib, predicats Z3, automates symboliques | ~2h |
-| 11 | [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb) | Python 3 | PSO, ABC, SA, BRO avec MEALPy, benchmark comparatif de metaheuristiques | ~1h30 |
+| 9 | [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) | Python 3 | Programmation linéaire avec PuLP, simplex, problème du transport, diet problem, PLNE | ~2h |
+| 10 | [Search-10-SymbolicAutomata](Search-10-SymbolicAutomata.ipynb) | Python 3 | Automates finis (DFA/NFA) avec automata-lib, prédicats Z3, automates symboliques | ~2h |
+| 11 | [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb) | Python 3 | PSO, ABC, SA, BRO avec MEALPy, benchmark comparatif de métaheuristiques | ~1h30 |
 
 ## Progression
 
 Les trois premiers notebooks forment le socle commun — on y apprend à poser un problème, puis à l'explorer systématiquement — et tout le reste s'y greffe. Au-delà, le parcours n'est pas linéaire : quatre branches indépendantes s'ouvrent, à prendre dans l'ordre de vos curiosités :
 
-- **Recherche locale et evolutive** : Search-4 (LocalSearch) puis Search-5 (GeneticAlgorithms) puis Search-11 (Metaheuristics)
+- **Recherche locale et évolutive** : Search-4 (LocalSearch) puis Search-5 (GeneticAlgorithms) puis Search-11 (Metaheuristics)
 - **Recherche dans les jeux** : Search-3 puis Search-6 (AdversarialSearch) puis Search-7 (MCTS)
 - **Couverture exacte** : Search-2 puis Search-8 (DancingLinks)
-- **Independants** : Search-9 (LinearProgramming, algebre lineaire requise) et Search-10 (SymbolicAutomata, liens avec SymbolicAI/Z3)
+- **Indépendants** : Search-9 (LinearProgramming, algèbre linéaire requise) et Search-10 (SymbolicAutomata, liens avec SymbolicAI/Z3)
 
-Les fondamentaux de cette partie (formalisation, backtracking, heuristiques) sont le prerequis de la [Partie 2 (CSP)](../Part2-CSP/README.md).
+Les fondamentaux de cette partie (formalisation, backtracking, heuristiques) sont le prérequis de la [Partie 2 (CSP)](../Part2-CSP/README.md).
 
-## Prerequis & environnement
+## Prérequis & environnement
 
-| Besoin | Detail |
+| Besoin | Détail |
 |--------|--------|
-| Python | 3.10+, environnement virtuel recommande |
+| Python | 3.10+, environnement virtuel recommandé |
 | `ortools` | Search-9 (Linear Programming) |
 | `deap` | Search-5 (Genetic Algorithms) |
-| `mealpy` | Search-11 (Metaheuristiques) |
+| `mealpy` | Search-11 (Métaheuristiques) |
 | `z3-solver` | Search-10 (Symbolic Automata) |
 | OpenSpiel | Search-7 (MCTS) : requiert WSL ou Linux |
 
-Pour le setup complet, voir le [README de la serie Search](../README.md).
+Pour le setup complet, voir le [README de la série Search](../README.md).
 
 ## Ponts vers les autres séries
 
@@ -70,7 +70,7 @@ Cette partie irrigue le reste du dépôt : les Dancing Links de Search-8 sont à
 
 ## FAQ
 
-| Probleme | Solution |
+| Problème | Solution |
 |----------|----------|
-| A* trop lent sur les grands graphes | Verifier que l'heuristique est admissible ET consistante ; essayer IDA* (Search-3), qui consomme moins de memoire |
-| GA stagne sans amelioration | Augmenter le taux de mutation ou la taille de la population ; comparer avec les metaheuristiques de Search-11 |
+| A* trop lent sur les grands graphes | Vérifier que l'heuristique est admissible ET consistante ; essayer IDA* (Search-3), qui consomme moins de mémoire |
+| GA stagne sans amélioration | Augmenter le taux de mutation ou la taille de la population ; comparer avec les métaheuristiques de Search-11 |

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
@@ -1,8 +1,8 @@
 # Partie 2 : Programmation par Contraintes
 
-[← Partie 1 : Search](../Part1-Foundations/README.md) | [↑ Serie Search](../README.md) | [Applications →](../Applications/README.md)
+[← Partie 1 : Search](../Part1-Foundations/README.md) | [↑ Série Search](../README.md) | [Applications →](../Applications/README.md)
 
-Au lieu de concevoir un algorithme d'exploration, que se passe-t-il si l'on declare les contraintes du probleme et que l'on laisse le solveur trouver les solutions ? La programmation par contraintes (CSP) represente ce changement de paradigme : on ne cherche plus, on contraint. Ce modele declaratif est au coeur des outils industriels (ordonnancement, logistique, verification) et s'applique naturellement aux problemes NP-difficiles.
+Au lieu de concevoir un algorithme d'exploration, que se passe-t-il si l'on déclare les contraintes du problème et que l'on laisse le solveur trouver les solutions ? La programmation par contraintes (CSP) représente ce changement de paradigme : on ne cherche plus, on contraint. Ce modèle déclaratif est au coeur des outils industriels (ordonnancement, logistique, vérification) et s'applique naturellement aux problèmes NP-difficiles.
 
 Les deux premiers notebooks installent le socle. CSP-1 pose le modèle (X, D, C) — variables, domaines, contraintes — et montre que le backtracking de la Partie 1, enrichi de deux heuristiques de bon sens (choisir d'abord la variable la plus contrainte, essayer d'abord la valeur la moins contraignante), résout déjà des problèmes non triviaux. CSP-2 introduit l'idée qui fait la puissance du paradigme : la propagation. Plutôt que de découvrir une impasse en s'y enfonçant, AC-3 et MAC élaguent les valeurs impossibles avant même de les essayer — l'espace de recherche se réduit de lui-même, par simple déduction locale.
 
@@ -16,26 +16,26 @@ Si la Partie 1 enseigne à chercher, celle-ci enseigne à modéliser — et c'es
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette partie, vous serez capable de :
+À l'issue de cette partie, vous serez capable de :
 
-1. **Modeliser** un probleme NP-difficile comme un CSP (variables, domaines, contraintes) et le resoudre avec OR-Tools CP-SAT
-2. **Maitriser** les techniques de propagation (AC-3, Forward Checking, MAC) pour reduire l'espace de recherche
-3. **Exploiter** les contraintes globales (AllDifferent, Cumulative, Circuit) pour les problemes industriels
+1. **Modéliser** un problème NP-difficile comme un CSP (variables, domaines, contraintes) et le résoudre avec OR-Tools CP-SAT
+2. **Maîtriser** les techniques de propagation (AC-3, Forward Checking, MAC) pour réduire l'espace de recherche
+3. **Exploiter** les contraintes globales (AllDifferent, Cumulative, Circuit) pour les problèmes industriels
 4. **Composer** CSP avec SAT, ML et LLM pour des solutions hybrides (LCG, CP+ML, LLM+CSP)
-5. **Etendre** le cadre classique aux contraintes souples, temporelles et distribuees
+5. **Étendre** le cadre classique aux contraintes souples, temporelles et distribuées
 
 ## Notebooks
 
-| # | Notebook | Kernel | Contenu | Duree |
+| # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
-| 1 | [CSP-1-Fundamentals](CSP-1-Fundamentals.ipynb) | Python 3 | Modele CSP (X, D, C), backtracking, heuristiques MRV et LCV | ~50 min |
+| 1 | [CSP-1-Fundamentals](CSP-1-Fundamentals.ipynb) | Python 3 | Modèle CSP (X, D, C), backtracking, heuristiques MRV et LCV | ~50 min |
 | 2 | [CSP-2-Consistency](CSP-2-Consistency.ipynb) | Python 3 | AC-3, Forward Checking, MAC : propagation de contraintes | ~45 min |
 | 3 | [CSP-3-Advanced](CSP-3-Advanced.ipynb) | Python 3 | Contraintes globales OR-Tools : AllDifferent, Cumulative, Circuit, LNS | ~50 min |
 | 4 | [CSP-4-Scheduling](CSP-4-Scheduling.ipynb) | Python 3 | Job-Shop (JSSP), RCPSP, Nurse Scheduling, IntervalVar, NoOverlap | ~1h |
 | 5 | [CSP-5-Optimization](CSP-5-Optimization.ipynb) | Python 3 | Bin Packing, Knapsack, Cutting Stock, Portfolio Optimization | ~1h |
 | 6 | [CSP-6-Hybridization](CSP-6-Hybridization.ipynb) | Python 3 | Lazy Clause Generation (LCG), CP+SAT, CP+ML, LLM+CSP | ~1h30 |
 | 7 | [CSP-7-Soft](CSP-7-Soft.ipynb) | Python 3 | Contraintes souples : Fuzzy CSP, Weighted CSP, Semiring-based CSP | ~1h |
-| 8 | [CSP-8-Temporal](CSP-8-Temporal.ipynb) | Python 3 | Algebre d'intervalles d'Allen, Simple Temporal Problems (STP), TCSP | ~1h |
+| 8 | [CSP-8-Temporal](CSP-8-Temporal.ipynb) | Python 3 | Algèbre d'intervalles d'Allen, Simple Temporal Problems (STP), TCSP | ~1h |
 | 9 | [CSP-9-Distributed](CSP-9-Distributed.ipynb) | Python 3 | Asynchronous Backtracking (ABT), AWC, Privacy-preserving CSP | ~1h30 |
 
 ## Progression
@@ -43,29 +43,29 @@ A l'issue de cette partie, vous serez capable de :
 CSP-1 et CSP-2 sont incontournables : tout le paradigme — un modèle déclaratif, une propagation qui élague — tient dans ces deux notebooks. Au-delà, trois chemins s'offrent selon votre objectif :
 
 - **Applications industrielles** : CSP-3 puis CSP-4 (Scheduling) et/ou CSP-5 (Optimization)
-- **Frontieres** : CSP-6 (Hybridization, le notebook le plus avance), puis CSP-7/8/9 (Soft/Temporal/Distributed)
-- **Independants** : CSP-7, CSP-8 et CSP-9 sont accessibles apres CSP-1 + CSP-2
+- **Frontières** : CSP-6 (Hybridization, le notebook le plus avancé), puis CSP-7/8/9 (Soft/Temporal/Distributed)
+- **Indépendants** : CSP-7, CSP-8 et CSP-9 sont accessibles après CSP-1 + CSP-2
 
-Les notebooks CSP presupposent les bases de la Partie 1 : formalisation en espace d'etats ([Search-1](../Part1-Foundations/Search-1-StateSpace.ipynb)) et backtracking ([Search-2](../Part1-Foundations/Search-2-Uninformed.ipynb)).
+Les notebooks CSP présupposent les bases de la Partie 1 : formalisation en espace d'états ([Search-1](../Part1-Foundations/Search-1-StateSpace.ipynb)) et backtracking ([Search-2](../Part1-Foundations/Search-2-Uninformed.ipynb)).
 
-## Prerequis & environnement
+## Prérequis & environnement
 
-| Besoin | Detail |
+| Besoin | Détail |
 |--------|--------|
-| Python | 3.10+, environnement virtuel recommande |
-| `ortools` | Dependence principale de toute la serie (CP-SAT) |
-| Cle API (optionnel) | CSP-6, section LLM+CSP uniquement ; le reste du notebook fonctionne sans |
+| Python | 3.10+, environnement virtuel recommandé |
+| `ortools` | Dépendance principale de toute la série (CP-SAT) |
+| Clé API (optionnel) | CSP-6, section LLM+CSP uniquement ; le reste du notebook fonctionne sans |
 
-Pour le setup complet, voir le [README de la serie Search](../README.md).
+Pour le setup complet, voir le [README de la série Search](../README.md).
 
 ## FAQ
 
-| Probleme | Solution |
+| Problème | Solution |
 |----------|----------|
-| Solveur CP-SAT trop lent sur les grandes instances | Preferer les contraintes globales (AllDifferent, Cumulative) aux contraintes binaires equivalentes ; utiliser LNS (CSP-3) |
-| Comment choisir entre CP-SAT et un solveur SAT ? | CP-SAT pour les contraintes globales et l'optimisation (objectif), SAT pour la decision pure ; CSP-6 detaille les compromis |
-| CSP-9 : les algorithmes distribues ne convergent pas | Verifier que le reseau de contraintes est un arbre, ou utiliser AWC (Weak-Commitment) au lieu d'ABT |
-| Ou sont les applications concretes ? | Voir [Applications](../Applications/README.md) : 21 notebooks (N-Queens, Nurse Scheduling, VRP, TSP...) |
+| Solveur CP-SAT trop lent sur les grandes instances | Préférer les contraintes globales (AllDifferent, Cumulative) aux contraintes binaires équivalentes ; utiliser LNS (CSP-3) |
+| Comment choisir entre CP-SAT et un solveur SAT ? | CP-SAT pour les contraintes globales et l'optimisation (objectif), SAT pour la décision pure ; CSP-6 détaille les compromis |
+| CSP-9 : les algorithmes distribués ne convergent pas | Vérifier que le réseau de contraintes est un arbre, ou utiliser AWC (Weak-Commitment) au lieu d'ABT |
+| Où sont les applications concrètes ? | Voir [Applications](../Applications/README.md) : 21 notebooks (N-Queens, Nurse Scheduling, VRP, TSP...) |
 
 ## Ponts vers SymbolicAI
 
@@ -100,17 +100,17 @@ CSP-1 (Fundamentals) ──> CSP-2 (Consistency) ──> CSP-3 (Advanced)
 | Constraint logic | Tweety (Formal Logic) |
 | Temporal CSP | Temporal Planning, STP |
 
-## Ponts inter-series
+## Ponts inter-séries
 
-| Serie | Lien | Relation |
+| Série | Lien | Relation |
 | ------- | ------ | ---------- |
-| [Partie 1 : Search](../Part1-Foundations/README.md) | Fondamentaux | Prerequis : backtracking, heuristiques |
+| [Partie 1 : Search](../Part1-Foundations/README.md) | Fondamentaux | Prérequis : backtracking, heuristiques |
 | [Applications](../Applications/README.md) | 21 notebooks d'application | Mise en pratique des CSP |
 | [Search (parent)](../README.md) | Vue d'ensemble | Contexte et parcours global |
-| [Sudoku](../../Sudoku/) | Resolution par contraintes | Application directe des CSP |
+| [Sudoku](../../Sudoku/) | Résolution par contraintes | Application directe des CSP |
 | [SymbolicAI/Z3](../../SymbolicAI/) | Solveur SMT | CSP-6 (LCG) et automates symboliques |
-| [Probas/Infer](../../Probas/Infer/) | Infer.NET | Modeles graphiques et contraintes |
+| [Probas/Infer](../../Probas/Infer/) | Infer.NET | Modèles graphiques et contraintes |
 
 ## Navigation
 
-[<- Partie 1 : Search Fondamental](../Part1-Foundations/README.md) | [Retour a la serie Search](../README.md) | [Applications ->](../Applications/README.md)
+[<- Partie 1 : Search Fondamental](../Part1-Foundations/README.md) | [Retour à la série Search](../README.md) | [Applications ->](../Applications/README.md)

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -13,40 +13,40 @@ Tout problème d'IA, du plus simple jeu de plateau à la planification logistiqu
 
 Le parcours couvre quatre grands piliers. Les **fondements** formalisent les espaces d'états et couvrent les algorithmes de recherche non informée, informée, locale, génétique, adversariale et MCTS. La **programmation par contraintes** (CSP) introduit un changement de paradigme : au lieu d'explorer, on réduit les domaines par propagation. Les **applications** (20 notebooks) illustrent chaque concept sur des problèmes réels adaptés de projets étudiants. Enfin, les **métaheuristiques et l'hybridation** relient la recherche à l'optimisation continue et aux LLMs.
 
-**A qui s'adresse cette serie** : etudiants en informatique (L3-M2), ingenieurs logiciel confrontes a des problemes d'optimisation, et candidats a des entretiens techniques. Les notebooks Python ne necessitent que Python 3.10+ avec `ortools` et `deap`. Les side tracks C# (edge detection, portefeuille) requierent .NET 9.0 + dotnet-interactive. Aucun prerequis en algorithmique avancee : les concepts sont introduits depuis les espaces d'etats.
+**À qui s'adresse cette série** : étudiants en informatique (L3-M2), ingénieurs logiciel confrontés à des problèmes d'optimisation, et candidats à des entretiens techniques. Les notebooks Python ne nécessitent que Python 3.10+ avec `ortools` et `deap`. Les side tracks C# (edge detection, portefeuille) requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en algorithmique avancée : les concepts sont introduits depuis les espaces d'états.
 
-## Pourquoi cette serie
+## Pourquoi cette série
 
-La recherche et l'optimisation sont au coeur de l'informatique : tout probleme, du plus simple jeu de plateau a la planification logistique industrielle, se reduit a explorer un espace de solutions. Cette serie couvre **l'integralite du spectre algorithmique** — de la recherche aveugle (BFS) a l'hybridation LLM+CSP — en construisant une comprehension progressive des compromis fondamentaux.
+La recherche et l'optimisation sont au coeur de l'informatique : tout problème, du plus simple jeu de plateau à la planification logistique industrielle, se réduit à explorer un espace de solutions. Cette série couvre **l'intégralité du spectre algorithmique** — de la recherche aveugle (BFS) à l'hybridation LLM+CSP — en construisant une compréhension progressive des compromis fondamentaux.
 
-Cette serie repose sur une **double approche**, delibement juxtaposee :
+Cette série repose sur une **double approche**, délibérément juxtaposée :
 
-- **Exploration systematique** (recherche classique) : BFS, DFS, A*, Minimax — des algorithmes qui garantissent de trouver une solution optimale si elle existe, mais dont le cout peut etre exponentiel. C'est le domaine des espaces d'etats, des heuristiques admissibles, de la complétude.
-- **Reduction de l'espace** (programmation par contraintes) : au lieu d'explorer betement, on elague les domaines impossibles par propagation (AC-3, Forward Checking, CP-SAT). C'est un changement de paradigme : on ne cherche plus, on contraint. Avantage : resolution de problemes industriels (ordonnancement, emploi du temps) en quelques millisecondes. Limite : la modelisation est un art.
+- **Exploration systématique** (recherche classique) : BFS, DFS, A*, Minimax — des algorithmes qui garantissent de trouver une solution optimale si elle existe, mais dont le coût peut être exponentiel. C'est le domaine des espaces d'états, des heuristiques admissibles, de la complétude.
+- **Réduction de l'espace** (programmation par contraintes) : au lieu d'explorer bêtement, on élague les domaines impossibles par propagation (AC-3, Forward Checking, CP-SAT). C'est un changement de paradigme : on ne cherche plus, on contraint. Avantage : résolution de problèmes industriels (ordonnancement, emploi du temps) en quelques millisecondes. Limite : la modélisation est un art.
 
-Avoir les deux approches permet de comprendre **quand explorer, quand contraindre, et quand les combiner** — une competence cruciale pour tout ingenieur confronte a des problemes combinatoires.
+Avoir les deux approches permet de comprendre **quand explorer, quand contraindre, et quand les combiner** — une compétence cruciale pour tout ingénieur confronté à des problèmes combinatoires.
 
-Au-dela de la methodologie, cette serie couvre des **applications reelles** adaptees de projets etudiants : planification d'infirmiers (CHU), ordonnancement d'atelier (industrie), optimisation de portefeuille (finance), TSP/VRP (logistique), demineur (CSP + probabilites), Picross (couverture exacte). Chaque application est une brique construite sur les concepts precedents.
+Au-delà de la méthodologie, cette série couvre des **applications réelles** adaptées de projets étudiants : planification d'infirmiers (CHU), ordonnancement d'atelier (industrie), optimisation de portefeuille (finance), TSP/VRP (logistique), démineur (CSP + probabilités), Picross (couverture exacte). Chaque application est une brique construite sur les concepts précédents.
 
 ## Qu'est-ce que la recherche en IA ?
 
-| Aspect | Exploration systematique | Programmation par contraintes | Metaheuristiques |
+| Aspect | Exploration systématique | Programmation par contraintes | Métaheuristiques |
 |--------|--------------------------|-------------------------------|-----------------|
-| **Philosophie** | Enumerer methodiquement | Reduire les domaines impossibles | S'inspirer de la nature |
-| **Garantie** | Solution optimale (si temps) | Solution optimale (si modelisable) | Aucune garantie |
-| **Modelisation** | Espace d'etats (S, A, T, G) | Variables, domaines, contraintes | Fonction objectif, voisinage |
-| **Complexite** | Exponentielle (mais heuristiques) | Exponentielle (mais propagation) | Polynomiale par iteration |
-| **Quand l'utiliser** | Problemes bien definis, heuristique connue | Contraintes claires, domaine discret | Grands espaces, approximation acceptable |
+| **Philosophie** | Énumérer méthodiquement | Réduire les domaines impossibles | S'inspirer de la nature |
+| **Garantie** | Solution optimale (si temps) | Solution optimale (si modélisable) | Aucune garantie |
+| **Modélisation** | Espace d'états (S, A, T, G) | Variables, domaines, contraintes | Fonction objectif, voisinage |
+| **Complexité** | Exponentielle (mais heuristiques) | Exponentielle (mais propagation) | Polynomiale par itération |
+| **Quand l'utiliser** | Problèmes bien définis, heuristique connue | Contraintes claires, domaine discret | Grands espaces, approximation acceptable |
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, vous serez capable de :
+À l'issue de cette série, vous serez capable de :
 
-1. **Formaliser** un probleme reel en espace d'etats (S, s0, A, T, G) et choisir l'algorithme de recherche adapte
-2. **Comparer** recherche systematique (A*), contraintes (CSP) et metaheuristiques (GA, SA) sur un meme probleme
-3. **Modeliser** un probleme industriel en CSP (ordonnancement, routing, emploi du temps) avec OR-Tools CP-SAT
-4. **Evaluer** les compromis garantie vs performance vs generalisation pour choisir une strategie algorithmique
-5. **Combiner** approches complementaires (CP+SAT, LLM+CSP, MCTS+DQN) pour des problemes complexes
+1. **Formaliser** un problème réel en espace d'états (S, s0, A, T, G) et choisir l'algorithme de recherche adapté
+2. **Comparer** recherche systématique (A*), contraintes (CSP) et métaheuristiques (GA, SA) sur un même problème
+3. **Modéliser** un problème industriel en CSP (ordonnancement, routing, emploi du temps) avec OR-Tools CP-SAT
+4. **Évaluer** les compromis garantie vs performance vs généralisation pour choisir une stratégie algorithmique
+5. **Combiner** approches complémentaires (CP+SAT, LLM+CSP, MCTS+DQN) pour des problèmes complexes
 
 ## Parcours d'apprentissage
 
@@ -58,85 +58,85 @@ Le parcours commence par Search-1 (StateSpace) qui formalise les problèmes sous
 
 La Phase 2 change de paradigme : au lieu d'explorer un espace, on le réduit. CSP-1 (Fundamentals) introduit le modèle (X, D, C) et le backtracking. CSP-2 (Consistency) couvre la propagation de contraintes (AC-3, Forward Checking, MAC). CSP-3 à CSP-6 montent en complexité : contraintes globales (AllDifferent, Cumulative), ordonnancement (Job-Shop, RCPSP), optimisation (Bin Packing, Knapsack), et hybridation (LCG, CP+SAT, CP+ML, LLM+CSP). Cette phase présuppose les bases de la Phase 1 (formalisation, backtracking = DFS) et constitue le cœur pratique de la série.
 
-### Phase 3 : Applications et frontieres (Applications + notebooks avances, ~18h)
+### Phase 3 : Applications et frontières (Applications + notebooks avancés, ~18h)
 
 Les 20 notebooks d'applications illustrent chaque concept sur des cas réels : planification d'infirmiers (CSP-4), ordonnancement d'atelier (CSP-4), optimisation de portefeuille (métaheuristiques), TSP et VRP (routing), démineur et Wordle (CSP + théorie de l'information), Picross (couverture exacte). Les notebooks avancés de la Part 1 (programmation linéaire Search-9, automates symboliques Search-10, métaheuristiques Search-11) et de la Part 2 (contraintes souples CSP-7, temporelles CSP-8, distribuées CSP-9) complètent le panorama. L'ensemble est enrichi par des ponts vers les autres séries : Sudoku (DLX, automates), SymbolicAI (Z3, planification), GameTheory (Minimax, MCTS), et RL (MCTS + DQN).
 
 ## Ce que chaque notebook apporte
 
-Chaque notebook introduit un concept ou algorithme specifique. Le tableau ci-dessous resume en une ligne l'apport pedagogique de chacun.
+Chaque notebook introduit un concept ou algorithme spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun.
 
 ### Partie 1 : Search Fondamental
 
-| # | Notebook | Apport pedagogique |
+| # | Notebook | Apport pédagogique |
 |---|----------|-------------------|
-| 1 | StateSpace | Formaliser un probleme en espace d'etats (S, s0, A, T, G) |
-| 2 | Uninformed | BFS vs DFS : comment l'ordre d'exploration change la complexite |
+| 1 | StateSpace | Formaliser un problème en espace d'états (S, s0, A, T, G) |
+| 2 | Uninformed | BFS vs DFS : comment l'ordre d'exploration change la complexité |
 | 3 | Informed | Heuristiques admissibles et A* : guider la recherche vers la solution |
-| 4 | LocalSearch | Abandonner la garantie pour l'efficacite : paysages de fitness et optima locaux |
-| 5 | GeneticAlgorithms | Populations, crossover, mutation : l'evolution comme metaheuristique |
-| 6 | AdversarialSearch | Minimax, Alpha-Beta : chercher dans les jeux a deux joueurs |
-| 7 | MCTS-And-Beyond | Monte Carlo Tree Search et la revolution AlphaGo (MCTS + DQN) |
-| 8 | DancingLinks | Couverture exacte de Knuth : une structure de donnees transforme un algorithme |
-| 9 | LinearProgramming | Programmation lineaire (PuLP) : relaxer les contraintes entieres |
+| 4 | LocalSearch | Abandonner la garantie pour l'efficacité : paysages de fitness et optima locaux |
+| 5 | GeneticAlgorithms | Populations, crossover, mutation : l'évolution comme métaheuristique |
+| 6 | AdversarialSearch | Minimax, Alpha-Beta : chercher dans les jeux à deux joueurs |
+| 7 | MCTS-And-Beyond | Monte Carlo Tree Search et la révolution AlphaGo (MCTS + DQN) |
+| 8 | DancingLinks | Couverture exacte de Knuth : une structure de données transforme un algorithme |
+| 9 | LinearProgramming | Programmation linéaire (PuLP) : relaxer les contraintes entières |
 | 10 | SymbolicAutomata | Automates finis + Z3 : raisonner sur des alphabets infinis |
-| 11 | Metaheuristiques | PSO, ABC, BRO avec MEALPy : comparer 160+ algorithmes |
+| 11 | Métaheuristiques | PSO, ABC, BRO avec MEALPy : comparer 160+ algorithmes |
 
 ### Partie 2 : Programmation par Contraintes
 
-| # | Notebook | Apport pedagogique |
+| # | Notebook | Apport pédagogique |
 |---|----------|-------------------|
-| 1 | CSP Fundamentals | Modele (X, D, C) : declarer le probleme plutot que l'algorithme |
-| 2 | CSP Consistency | AC-3, Forward Checking : reduire l'espace par propagation avant la recherche |
+| 1 | CSP Fundamentals | Modèle (X, D, C) : déclarer le problème plutôt que l'algorithme |
+| 2 | CSP Consistency | AC-3, Forward Checking : réduire l'espace par propagation avant la recherche |
 | 3 | CSP Advanced | Contraintes globales (AllDifferent, Cumulative, Circuit) |
 | 4 | CSP Scheduling | Job-Shop, RCPSP, Nurse : l'ordonnancement industriel par contraintes |
 | 5 | CSP Optimization | Bin Packing, Knapsack, Portfolio : optimiser sous contraintes |
 | 6 | CSP Hybridization | LCG, CP+SAT, CP+ML, LLM+CSP : combiner les paradigmes |
-| 7 | CSP Soft | Contraintes souples, Fuzzy CSP : quand toutes les contraintes ne sont pas egales |
+| 7 | CSP Soft | Contraintes souples, Fuzzy CSP : quand toutes les contraintes ne sont pas égales |
 | 8 | CSP Temporal | Allen's Interval Algebra, STP : raisonner sur le temps |
-| 9 | CSP Distributed | ABT, AWC : resoudre des CSP repartis entre agents |
+| 9 | CSP Distributed | ABT, AWC : résoudre des CSP répartis entre agents |
 
 ### Applications
 
-| # | Notebook | Apport pedagogique |
+| # | Notebook | Apport pédagogique |
 |---|----------|-------------------|
 | App-1 | NQueens | Le benchmark classique CSP : backtracking vs min-conflicts vs CP-SAT |
-| App-2 | GraphColoring | Coloration de cartes : DSATUR vs CP-SAT, departements francais |
-| App-3 | NurseScheduling | Planning infirmiers : contraintes hard/soft, modele CP-SAT |
+| App-2 | GraphColoring | Coloration de cartes : DSATUR vs CP-SAT, départements français |
+| App-3 | NurseScheduling | Planning infirmiers : contraintes hard/soft, modèle CP-SAT |
 | App-4 | JobShopScheduling | Ordonnancement industriel : IntervalVar, NoOverlap, makespan |
-| App-5 | Timetabling | Emploi du temps : MiniZinc + CP-SAT, une modelisation declarative |
-| App-6 | Minesweeper | Demineur : propagation CSP + probabilites + hybridation LLM |
-| App-7 | Wordle | Solveur Wordle : filtrage CSP + theorie de l'information (entropy) |
-| App-8 | MiniZinc | Modelisation declarative : syntaxe MiniZinc, contraintes globales |
-| App-9 | EdgeDetection | Detection de bords par GA : PyGAD, filtres de convolution |
-| App-10 | Portfolio | Frontiere de Pareto : optimisation multi-objectif de portefeuille |
-| App-11 | Picross | Nonogrammes : speedup 27Mx CP-SAT vs naive |
+| App-5 | Timetabling | Emploi du temps : MiniZinc + CP-SAT, une modélisation déclarative |
+| App-6 | Minesweeper | Démineur : propagation CSP + probabilités + hybridation LLM |
+| App-7 | Wordle | Solveur Wordle : filtrage CSP + théorie de l'information (entropy) |
+| App-8 | MiniZinc | Modélisation déclarative : syntaxe MiniZinc, contraintes globales |
+| App-9 | EdgeDetection | Détection de bords par GA : PyGAD, filtres de convolution |
+| App-10 | Portfolio | Frontière de Pareto : optimisation multi-objectif de portefeuille |
+| App-11 | Picross | Nonogrammes : speedup 27Mx CP-SAT vs naïve |
 | App-12 | ConnectFour | Puissance 4 : 8 algorithmes IA (Minimax, MCTS, DQN-RL) |
 | App-13 | TSP | Voyageur de commerce : SA, GA, ACO, OR-Tools routing |
 | App-14 | ConnectFour-Adversarial | Benchmark adversarial : Minimax vs Alpha-Beta vs MCTS |
-| App-15 | SportsScheduling | Calendrier sportif : contraintes TV, equite, deplacements |
-| App-16 | Crossword | Mots croises : backtracking, OR-Tools, generation |
+| App-15 | SportsScheduling | Calendrier sportif : contraintes TV, équité, déplacements |
+| App-16 | Crossword | Mots croisés : backtracking, OR-Tools, génération |
 | App-17 | VRP-Logistics | Vehicle Routing : SA, GA, ACO, CP-SAT |
-| App-18 | HyperparameterTuning | Optimisation bayesienne de hyperparams : Optuna vs GA vs PSO |
+| App-18 | HyperparameterTuning | Optimisation bayésienne de hyperparams : Optuna vs GA vs PSO |
 
 ---
 
 ## Partie 1 : Search Fondamental (`Part1-Foundations/`)
 
-Algorithmes de recherche classiques, recherche adversariale et metaheuristiques.
+Algorithmes de recherche classiques, recherche adversariale et métaheuristiques.
 
-| # | Notebook | Duree | Contenu | Prerequis |
+| # | Notebook | Durée | Contenu | Prérequis |
 |---|----------|-------|---------|-----------|
-| 1 | [Search-1-StateSpace](Part1-Foundations/Search-1-StateSpace.ipynb) | ~40 min | Espaces d'etats, formalisation (S, A, T, G), taquin, aspirateur, route | Python basique |
-| 2 | [Search-2-Uninformed](Part1-Foundations/Search-2-Uninformed.ipynb) | ~50 min | BFS, DFS, UCS, IDDFS, comparaison systematique | Search-1 |
+| 1 | [Search-1-StateSpace](Part1-Foundations/Search-1-StateSpace.ipynb) | ~40 min | Espaces d'états, formalisation (S, A, T, G), taquin, aspirateur, route | Python basique |
+| 2 | [Search-2-Uninformed](Part1-Foundations/Search-2-Uninformed.ipynb) | ~50 min | BFS, DFS, UCS, IDDFS, comparaison systématique | Search-1 |
 | 3 | [Search-3-Informed](Part1-Foundations/Search-3-Informed.ipynb) | ~50 min | A*, Greedy, IDA*, heuristiques admissibles et consistantes | Search-2 |
 | 4 | [Search-4-LocalSearch](Part1-Foundations/Search-4-LocalSearch.ipynb) | ~45 min | Hill Climbing, Simulated Annealing, Tabu Search, paysages de fitness | Search-2 |
-| 5 | [Search-5-GeneticAlgorithms](Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | ~50 min | Selection, crossover, mutation, DEAP/PyGAD, theorie unifiee | Search-4 |
+| 5 | [Search-5-GeneticAlgorithms](Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | ~50 min | Sélection, crossover, mutation, DEAP/PyGAD, théorie unifiée | Search-4 |
 | 6 | [Search-6-AdversarialSearch](Part1-Foundations/Search-6-AdversarialSearch.ipynb) | ~1h | Minimax, Alpha-Beta pruning, Null-window search, Transposition tables | Search-2, Search-3 |
 | 7 | [Search-7-MCTS-And-Beyond](Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb) | ~1h30 | MCTS, UCB1, OpenSpiel, AlphaGo-style (DQN+MCTS) | Search-6 |
 | 8 | [Search-8-DancingLinks](Part1-Foundations/Search-8-DancingLinks.ipynb) | ~1h30 | Algorithme X, DLX, Sudoku, N-Queens, Pentominoes | Search-2 |
-| 9 | [Search-9-LinearProgramming](Part1-Foundations/Search-9-LinearProgramming.ipynb) | ~2h | PuLP, simplex, transport, diet, sensibilite, PLNE | Algebre lineaire |
-| 10 | [Search-10-SymbolicAutomata](Part1-Foundations/Search-10-SymbolicAutomata.ipynb) | ~2h | DFA/NFA (automata-lib), predicats Z3, automates symboliques | Search-1, SymbolicAI/Z3 |
+| 9 | [Search-9-LinearProgramming](Part1-Foundations/Search-9-LinearProgramming.ipynb) | ~2h | PuLP, simplex, transport, diet, sensibilité, PLNE | Algèbre linéaire |
+| 10 | [Search-10-SymbolicAutomata](Part1-Foundations/Search-10-SymbolicAutomata.ipynb) | ~2h | DFA/NFA (automata-lib), prédicats Z3, automates symboliques | Search-1, SymbolicAI/Z3 |
 | 11 | [Search-11-Metaheuristics](Part1-Foundations/Search-11-Metaheuristics.ipynb) | ~1h30 | PSO, ABC, SA, BRO avec MEALPy, benchmark comparatif | Search-4, Search-5 |
 
 ---
@@ -145,68 +145,68 @@ Algorithmes de recherche classiques, recherche adversariale et metaheuristiques.
 
 > **Pivot vers SymbolicAI** : Z3, Planning, Logic. Cette partie fait le pont entre les algorithmes de recherche et l'IA symbolique.
 
-| # | Notebook | Duree | Contenu | Prerequis |
+| # | Notebook | Durée | Contenu | Prérequis |
 |---|----------|-------|---------|-----------|
 | 1 | [CSP-1-Fundamentals](Part2-CSP/CSP-1-Fundamentals.ipynb) | ~50 min | Variables, domaines, contraintes, backtracking, MRV, LCV | Search-1, Search-2 |
 | 2 | [CSP-2-Consistency](Part2-CSP/CSP-2-Consistency.ipynb) | ~45 min | AC-3, Forward checking, MAC, propagation de contraintes | CSP-1 |
-| 3 | [CSP-3-Advanced](Part2-CSP/CSP-3-Advanced.ipynb) | ~50 min | AllDifferent, cumulative, circuit, symetries, LNS | CSP-2 |
+| 3 | [CSP-3-Advanced](Part2-CSP/CSP-3-Advanced.ipynb) | ~50 min | AllDifferent, cumulative, circuit, symétries, LNS | CSP-2 |
 | 4 | [CSP-4-Scheduling](Part2-CSP/CSP-4-Scheduling.ipynb) | ~1h | Job-Shop (JSSP), RCPSP, Nurse Scheduling, IntervalVar, NoOverlap, Cumulative | CSP-3 |
-| 5 | [CSP-5-Optimization](Part2-CSP/CSP-5-Optimization.ipynb) | ~1h | Bin Packing, Knapsack, Cutting Stock, Portfolio Optimization, cardinalite | CSP-3, Search-9 |
-| 6 | [CSP-6-Hybridization](Part2-CSP/CSP-6-Hybridization.ipynb) | ~1h30 | Lazy Clause Generation (LCG), CP+SAT, CP+ML, LLM+CSP, parallelisation | CSP-4, CSP-5 |
+| 5 | [CSP-5-Optimization](Part2-CSP/CSP-5-Optimization.ipynb) | ~1h | Bin Packing, Knapsack, Cutting Stock, Portfolio Optimization, cardinalité | CSP-3, Search-9 |
+| 6 | [CSP-6-Hybridization](Part2-CSP/CSP-6-Hybridization.ipynb) | ~1h30 | Lazy Clause Generation (LCG), CP+SAT, CP+ML, LLM+CSP, parallélisation | CSP-4, CSP-5 |
 | 7 | [CSP-7-Soft](Part2-CSP/CSP-7-Soft.ipynb) | ~1h | Contraintes souples, Fuzzy CSP, Weighted CSP, Semiring-based CSP | CSP-1, CSP-2 |
 | 8 | [CSP-8-Temporal](Part2-CSP/CSP-8-Temporal.ipynb) | ~1h | Allen's Interval Algebra, STP, TCSP, raisonnement temporel | CSP-1, CSP-2 |
 | 9 | [CSP-9-Distributed](Part2-CSP/CSP-9-Distributed.ipynb) | ~1h30 | Asynchronous Backtracking (ABT), AWC, Privacy-preserving CSP | CSP-1, CSP-2, CSP-6 |
 
-### Prerequis CSP
+### Prérequis CSP
 
-Les notebooks CSP necessitent une comprehension prealable de :
-- **Search-1 (StateSpace)** : formalisation des problemes
-- **Search-2 (Uninformed)** : backtracking = DFS avec retour arriere
+Les notebooks CSP nécessitent une compréhension préalable de :
+- **Search-1 (StateSpace)** : formalisation des problèmes
+- **Search-2 (Uninformed)** : backtracking = DFS avec retour arrière
 
 ---
 
 ## Applications (`Applications/`)
 
-Problemes du monde reel adaptes de projets etudiants.
+Problèmes du monde réel adaptés de projets étudiants.
 
 ### Applications Search (`Applications/Search/`)
 
-| # | Notebook | Duree | Contenu | Source |
+| # | Notebook | Durée | Contenu | Source |
 |---|----------|-------|---------|--------|
-| 1 | [App-12-ConnectFour](Applications/Search/App-12-ConnectFour.ipynb) | ~50 min | Puissance 4 : 8 algorithmes IA (Minimax, MCTS, DQN-RL) | Projet etudiant |
-| 2 | [App-14-ConnectFour-Adversarial](Applications/Search/App-14-ConnectFour-Adversarial.ipynb) | ~45 min | Benchmark adversarial : Minimax, Alpha-Beta, MCTS | Projet etudiant |
+| 1 | [App-12-ConnectFour](Applications/Search/App-12-ConnectFour.ipynb) | ~50 min | Puissance 4 : 8 algorithmes IA (Minimax, MCTS, DQN-RL) | Projet étudiant |
+| 2 | [App-14-ConnectFour-Adversarial](Applications/Search/App-14-ConnectFour-Adversarial.ipynb) | ~45 min | Benchmark adversarial : Minimax, Alpha-Beta, MCTS | Projet étudiant |
 
 ### Applications CSP (`Applications/CSP/`)
 
-| # | Notebook | Duree | Contenu | Source |
+| # | Notebook | Durée | Contenu | Source |
 |---|----------|-------|---------|--------|
 | 1 | [App-1-NQueens](Applications/CSP/App-1-NQueens.ipynb) | ~30 min | Benchmark classique CSP : backtracking, min-conflicts, OR-Tools | Classique |
-| 2 | [App-2-GraphColoring](Applications/CSP/App-2-GraphColoring.ipynb) | ~45 min | Coloration de cartes : Greedy, DSATUR, CP-SAT, departements francais | Projet etudiant |
-| 3 | [App-3-NurseScheduling](Applications/CSP/App-3-NurseScheduling.ipynb) | ~60 min | Planning infirmiers : contraintes hard/soft, OR-Tools CP-SAT | Projet etudiant |
-| 4 | [App-4-JobShopScheduling](Applications/CSP/App-4-JobShopScheduling.ipynb) | ~60 min | Ordonnancement industriel : intervalles, precedences, makespan | Projet etudiant |
-| 5 | [App-5-Timetabling](Applications/CSP/App-5-Timetabling.ipynb) | ~50 min | Emploi du temps universitaire : MiniZinc + OR-Tools | Projet etudiant |
-| 6 | [App-6-Minesweeper](Applications/CSP/App-6-Minesweeper.ipynb) | ~50 min | Demineur CSP : propagation, probabilites, hybride CSP+LLM | Projet etudiant |
-| 7 | [App-7-Wordle](Applications/CSP/App-7-Wordle.ipynb) | ~45 min | Solveur Wordle : filtrage CSP + theorie de l'information | Projet etudiant |
-| 8 | [App-8-MiniZinc](Applications/CSP/App-8-MiniZinc.ipynb) | ~50 min | Modelisation declarative : syntaxe MiniZinc, contraintes globales | Nouveau |
-| 9 | [App-11-Picross](Applications/CSP/App-11-Picross.ipynb) | ~40 min | Nonogrammes : speedup 27Mx CP-SAT vs naive | Projet etudiant |
-| 10 | [App-15-SportsScheduling](Applications/CSP/App-15-SportsScheduling.ipynb) | ~55 min | Calendrier sportif : contraintes TV, equite, deplacements | Projet etudiant |
-| 11 | [App-16-Crossword-CSP](Applications/CSP/App-16-Crossword-CSP.ipynb) | ~45 min | Mots croises : backtracking, OR-Tools, generation | Projet etudiant |
+| 2 | [App-2-GraphColoring](Applications/CSP/App-2-GraphColoring.ipynb) | ~45 min | Coloration de cartes : Greedy, DSATUR, CP-SAT, départements français | Projet étudiant |
+| 3 | [App-3-NurseScheduling](Applications/CSP/App-3-NurseScheduling.ipynb) | ~60 min | Planning infirmiers : contraintes hard/soft, OR-Tools CP-SAT | Projet étudiant |
+| 4 | [App-4-JobShopScheduling](Applications/CSP/App-4-JobShopScheduling.ipynb) | ~60 min | Ordonnancement industriel : intervalles, précédences, makespan | Projet étudiant |
+| 5 | [App-5-Timetabling](Applications/CSP/App-5-Timetabling.ipynb) | ~50 min | Emploi du temps universitaire : MiniZinc + OR-Tools | Projet étudiant |
+| 6 | [App-6-Minesweeper](Applications/CSP/App-6-Minesweeper.ipynb) | ~50 min | Démineur CSP : propagation, probabilités, hybride CSP+LLM | Projet étudiant |
+| 7 | [App-7-Wordle](Applications/CSP/App-7-Wordle.ipynb) | ~45 min | Solveur Wordle : filtrage CSP + théorie de l'information | Projet étudiant |
+| 8 | [App-8-MiniZinc](Applications/CSP/App-8-MiniZinc.ipynb) | ~50 min | Modélisation déclarative : syntaxe MiniZinc, contraintes globales | Nouveau |
+| 9 | [App-11-Picross](Applications/CSP/App-11-Picross.ipynb) | ~40 min | Nonogrammes : speedup 27Mx CP-SAT vs naïve | Projet étudiant |
+| 10 | [App-15-SportsScheduling](Applications/CSP/App-15-SportsScheduling.ipynb) | ~55 min | Calendrier sportif : contraintes TV, équité, déplacements | Projet étudiant |
+| 11 | [App-16-Crossword-CSP](Applications/CSP/App-16-Crossword-CSP.ipynb) | ~45 min | Mots croisés : backtracking, OR-Tools, génération | Projet étudiant |
 
-### Applications Hybrides / Metaheuristiques (`Applications/Hybrid/`)
+### Applications Hybrides / Métaheuristiques (`Applications/Hybrid/`)
 
-| # | Notebook | Duree | Contenu | Source |
+| # | Notebook | Durée | Contenu | Source |
 |---|----------|-------|---------|--------|
-| 1 | [App-9-EdgeDetection](Applications/Hybrid/App-9-EdgeDetection.ipynb) | ~40 min | Detection de bords par GA : PyGAD, filtres de convolution | Existant (refonte) |
+| 1 | [App-9-EdgeDetection](Applications/Hybrid/App-9-EdgeDetection.ipynb) | ~40 min | Détection de bords par GA : PyGAD, filtres de convolution | Existant (refonte) |
 | 2 | [App-9b-EdgeDetection-CSharp](Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb) | ~35 min | Side track C# : GeneticSharp pour detection de bords | Existant |
-| 3 | [App-10-Portfolio](Applications/Hybrid/App-10-Portfolio.ipynb) | ~40 min | Optimisation de portefeuille : frontiere de Pareto, multi-objectif | Existant (refonte) |
+| 3 | [App-10-Portfolio](Applications/Hybrid/App-10-Portfolio.ipynb) | ~40 min | Optimisation de portefeuille : frontière de Pareto, multi-objectif | Existant (refonte) |
 | 4 | [App-10b-Portfolio-CSharp](Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb) | ~30 min | Side track C# : GeneticSharp pour portefeuille | Existant |
 | 5 | [App-13-TSP-Metaheuristics](Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb) | ~50 min | TSP : SA, GA, ACO, OR-Tools routing | Classique |
-| 6 | [App-17-VRP-Logistics](Applications/Hybrid/App-17-VRP-Logistics.ipynb) | ~60 min | Vehicle Routing : SA, GA, ACO, CP-SAT | Projet etudiant |
-| 7 | [App-18-HyperparameterTuning](Applications/Hybrid/App-18-HyperparameterTuning.ipynb) | ~40 min | Optimisation ML : Bayesienne, GA, PSO, Optuna | Nouveau |
+| 6 | [App-17-VRP-Logistics](Applications/Hybrid/App-17-VRP-Logistics.ipynb) | ~60 min | Vehicle Routing : SA, GA, ACO, CP-SAT | Projet étudiant |
+| 7 | [App-18-HyperparameterTuning](Applications/Hybrid/App-18-HyperparameterTuning.ipynb) | ~40 min | Optimisation ML : Bayésienne, GA, PSO, Optuna | Nouveau |
 
 ---
 
-## Navigation entre sous-series
+## Navigation entre sous-séries
 
 ```text
 Part1-Foundations/              Part2-CSP/                  Applications/
@@ -242,7 +242,7 @@ CSP-8  Temporal            ───> Temporal Planning, STP
 
 ---
 
-## Prerequis
+## Prérequis
 
 ### Python
 
@@ -275,56 +275,56 @@ dotnet --version
 
 ---
 
-## Concepts cles
+## Concepts clés
 
 | Concept | Description |
 |---------|-------------|
-| **Espace d'etats** | Formalisation (S, s0, A, T, G) d'un probleme de recherche |
-| **BFS/DFS/A*** | Algorithmes de recherche non informee et informee |
-| **Heuristique** | Fonction h(n) estimant le cout restant (f = g + h pour A*) |
+| **Espace d'états** | Formalisation (S, s0, A, T, G) d'un problème de recherche |
+| **BFS/DFS/A*** | Algorithmes de recherche non informée et informée |
+| **Heuristique** | Fonction h(n) estimant le coût restant (f = g + h pour A*) |
 | **Recherche locale** | Hill Climbing, Simulated Annealing, Tabu Search |
 | **Recherche adversariale** | Minimax, Alpha-Beta pruning, Null-window search |
-| **MCTS** | Monte Carlo Tree Search : Selection, Expansion, Simulation, Backpropagation |
-| **Metaheuristiques** | PSO, ABC, SA, BRO - optimisation sans derivees |
+| **MCTS** | Monte Carlo Tree Search : Sélection, Expansion, Simulation, Backpropagation |
+| **Métaheuristiques** | PSO, ABC, SA, BRO - optimisation sans dérivées |
 | **CSP** | Constraint Satisfaction Problem : (X, D, C) |
-| **Backtracking** | Exploration systematique avec retour arriere |
+| **Backtracking** | Exploration systématique avec retour arrière |
 | **MRV/LCV** | Heuristiques de choix de variable/valeur |
-| **Arc Consistency** | Reduction des domaines par propagation (AC-3) |
-| **Algorithme Genetique** | Evolution de population : selection, crossover, mutation |
-| **Dancing Links (DLX)** | Algorithme X avec listes doublement liees pour couverture exacte |
-| **Programmation Lineaire** | Optimisation lineaire avec contraintes (PuLP, simplex) |
-| **Automates Symboliques** | Predicats Z3 pour alphabets infinis |
+| **Arc Consistency** | Réduction des domaines par propagation (AC-3) |
+| **Algorithme Génétique** | Évolution de population : sélection, crossover, mutation |
+| **Dancing Links (DLX)** | Algorithme X avec listes doublement liées pour couverture exacte |
+| **Programmation Linéaire** | Optimisation linéaire avec contraintes (PuLP, simplex) |
+| **Automates Symboliques** | Prédicats Z3 pour alphabets infinis |
 | **OR-Tools CP-SAT** | Solveur de programmation par contraintes de Google |
 
 ---
 
 ## Ressources
 
-### Livres de reference
+### Livres de référence
 
 - [AIMA - Russell & Norvig (4th ed.)](http://aima.cs.berkeley.edu/) - Chapitres 3-6
 - [Constraint Processing - Rina Dechter (2003)](https://www.cambridge.org/core/books/constraint-processing/)
 - [Handbook of Constraint Programming (2006)](https://www.elsevier.com/books/handbook-of-constraint-programming/)
 - [The CP-SAT Primer (2023)](https://pganalyze.com/blog/cp-sat-primer) - Guide pratique OR-Tools
 
-### Bibliotheques
+### Bibliothèques
 
 - [Google OR-Tools](https://developers.google.com/optimization) - Solveur CP-SAT
 - [python-constraint](https://pypi.org/project/python-constraint/) - CSP basique
 - [Z3 Theorem Prover](https://github.com/Z3Prover/z3) - Solveur SMT
 - [DEAP](https://deap.readthedocs.io/) - Framework GA
-- [PyGAD](https://pygad.readthedocs.io/) - GA simplifie
-- [MEALPy](https://github.com/thieu1995/mealpy) - Metaheuristiques (160+ algorithmes)
-- [PuLP](https://github.com/coin-or/pulp) - Programmation lineaire
+- [PyGAD](https://pygad.readthedocs.io/) - GA simplifié
+- [MEALPy](https://github.com/thieu1995/mealpy) - Métaheuristiques (160+ algorithmes)
+- [PuLP](https://github.com/coin-or/pulp) - Programmation linéaire
 - [automata-lib](https://pypi.org/project/automata-lib/) - Automates finis
-- [MiniZinc](https://www.minizinc.org/) - Modelisation declarative
+- [MiniZinc](https://www.minizinc.org/) - Modélisation déclarative
 - [GeneticSharp](https://github.com/giacomelli/GeneticSharp) - GA en C#
-- [MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) - Couche metaheuristiques composables au-dessus de GeneticSharp (sous-module `MetaGeneticSharp/`, projet enfant ravivant giacomelli/GeneticSharp#87)
+- [MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) - Couche métaheuristiques composables au-dessus de GeneticSharp (sous-module `MetaGeneticSharp/`, projet enfant ravivant giacomelli/GeneticSharp#87)
 - [OpenSpiel](https://github.com/deepmind/open_spiel) - Framework de jeux et RL
 
-### Projets etudiants sources
+### Projets étudiants sources
 
-Les applications sont adaptees de projets etudiants. Les references specifics sont indiquees dans chaque notebook d'application.
+Les applications sont adaptées de projets étudiants. Les références spécifiques sont indiquées dans chaque notebook d'application.
 
 ---
 
@@ -400,71 +400,71 @@ Search/
 └── PyGad-EdgeDetection.ipynb              # Ancien notebook (conserve)
 ```
 
-## Progression recommandee
+## Progression recommandée
 
-> Le parcours detaille avec prerequis et enchainements logiques est decrit dans la section [Parcours d'apprentissage](#parcours-dapprentissage) ci-dessus.
+> Le parcours détaillé avec prérequis et enchaînements logiques est décrit dans la section [Parcours d'apprentissage](#parcours-dapprentissage) ci-dessus.
 
 ## FAQ / Troubleshooting
 
 ### OR-Tools ne s'installe pas
 
-OR-Tools necessite une version Python compatible. Sur Windows :
-- Verifiez votre version Python : `python --version` (3.10-3.12 recommande)
-- Installez avec : `pip install ortools` (les wheels precompiles sont disponibles pour la plupart des plateformes)
-- Si echec : essayez `conda install -c conda-forge ortools-python`
+OR-Tools nécessite une version Python compatible. Sur Windows :
+- Vérifiez votre version Python : `python --version` (3.10-3.12 recommandé)
+- Installez avec : `pip install ortools` (les wheels précompilés sont disponibles pour la plupart des plateformes)
+- Si échec : essayez `conda install -c conda-forge ortools-python`
 
 ### MiniZinc ne trouve pas son solveur
 
 Le notebook App-8 utilise MiniZinc qui requiert l'installation de l'IDE :
-- Telechargez depuis [minizinc.org](https://www.minizinc.org/software.html)
-- Le solveur Gecode est inclus par defaut
-- Verifiez : `minizinc --version` dans un terminal
+- Téléchargez depuis [minizinc.org](https://www.minizinc.org/software.html)
+- Le solveur Gecode est inclus par défaut
+- Vérifiez : `minizinc --version` dans un terminal
 
-### Les notebooks C# (.NET Interactive) ne s'executent pas
+### Les notebooks C# (.NET Interactive) ne s'exécutent pas
 
-- Verifiez que .NET SDK 9.0+ est installe : `dotnet --version`
+- Vérifiez que .NET SDK 9.0+ est installé : `dotnet --version`
 - Installez le kernel : `dotnet tool install -g Microsoft.dotnet-interactive && dotnet interactive jupyter install`
-- Verifiez : `jupyter kernelspec list` doit afficher `.net-csharp`
-- Les notebooks C# (App-9b, App-10b) utilisent GeneticSharp et SkiaSharp, installes automatiquement via `#r` dans les cellules
+- Vérifiez : `jupyter kernelspec list` doit afficher `.net-csharp`
+- Les notebooks C# (App-9b, App-10b) utilisent GeneticSharp et SkiaSharp, installés automatiquement via `#r` dans les cellules
 
 ### DEAP ou PyGAD provoquent des erreurs d'import
 
 - DEAP : `pip install deap` — compatible Python 3.8+
 - PyGAD : `pip install pygad` — requiert numpy. Si conflit : `pip install --upgrade numpy pygad`
-- MEALPy (Search-11) : `pip install mealpy` — dependances nombreuses, preferez un env dedie
+- MEALPy (Search-11) : `pip install mealpy` — dépendances nombreuses, préférez un env dédié
 
-### Les solveurs CP-SAT sont lents sur mon probleme
+### Les solveurs CP-SAT sont lents sur mon problème
 
-- Verifiez que vous utilisez `model.parameters.max_time_in_seconds` pour limiter le temps
-- Les contraintes globales (AllDifferent, Cumulative) sont beaucoup plus efficaces que des contraintes binaires equivalentes
-- Activez la parallelisation : `solver.parameters.num_workers = 8`
+- Vérifiez que vous utilisez `model.parameters.max_time_in_seconds` pour limiter le temps
+- Les contraintes globales (AllDifferent, Cumulative) sont beaucoup plus efficaces que des contraintes binaires équivalentes
+- Activez la parallélisation : `solver.parameters.num_workers = 8`
 - Consultez le [CP-SAT Primer](https://github.com/google/or-tools/blob/stable/ortools/sat/docs/CP-SAT_Primer.md) pour les bonnes pratiques
 
-### Comment choisir entre A*, CSP et metaheuristiques ?
+### Comment choisir entre A*, CSP et métaheuristiques ?
 
-- **Espace d'etats petit, solution optimale requise** : A* avec heuristique admissible
+- **Espace d'états petit, solution optimale requise** : A* avec heuristique admissible
 - **Contraintes complexes, domaine discret** : CP-SAT (OR-Tools)
-- **Grands espaces, approximation acceptable** : Metaheuristiques (GA, SA, PSO)
-- **Probleme de jeux, deux adversaires** : Minimax / Alpha-Beta / MCTS
-- **Probleme NP-difficile, temps limite** : LNS (Large Neighborhood Search) dans CP-SAT
+- **Grands espaces, approximation acceptable** : Métaheuristiques (GA, SA, PSO)
+- **Problème de jeux, deux adversaires** : Minimax / Alpha-Beta / MCTS
+- **Problème NP-difficile, temps limite** : LNS (Large Neighborhood Search) dans CP-SAT
 
 ## Quel parcours choisir ?
 
-### Si vous decouvrez la recherche en IA
+### Si vous découvrez la recherche en IA
 
-Commencez par **Search-1 (StateSpace)** et **Search-2 (Uninformed)** pour comprendre la formalisation des problemes et les algorithmes fondamentaux (BFS, DFS). Puis **Search-3 (Informed)** pour decouvrir A* et les heuristiques. C'est le socle commun a toute la serie.
+Commencez par **Search-1 (StateSpace)** et **Search-2 (Uninformed)** pour comprendre la formalisation des problèmes et les algorithmes fondamentaux (BFS, DFS). Puis **Search-3 (Informed)** pour découvrir A* et les heuristiques. C'est le socle commun à toute la série.
 
 ### Si vous venez de la programmation par contraintes
 
-Commencez par **CSP-1 (Fundamentals)** et **CSP-2 (Consistency)** si vous connaissez deja les espaces d'etats. Puis montez en complexite avec **CSP-3-6** et les applications industrielles (**App-3 NurseScheduling**, **App-4 JobShop**).
+Commencez par **CSP-1 (Fundamentals)** et **CSP-2 (Consistency)** si vous connaissez déjà les espaces d'états. Puis montez en complexité avec **CSP-3-6** et les applications industrielles (**App-3 NurseScheduling**, **App-4 JobShop**).
 
-### Si vous preparez un entretien technique
+### Si vous préparez un entretien technique
 
-Concentrez-vous sur **Search-1 a Search-3** (espaces d'etats, BFS/DFS, A*), **Search-6 (AdversarialSearch)** (Minimax) et **CSP-1-2** (backtracking, propagation). Ce sont les algorithmes les plus frequemment demandes.
+Concentrez-vous sur **Search-1 à Search-3** (espaces d'états, BFS/DFS, A*), **Search-6 (AdversarialSearch)** (Minimax) et **CSP-1-2** (backtracking, propagation). Ce sont les algorithmes les plus fréquemment demandés.
 
-### Si vous voulez resoudre un probleme industriel
+### Si vous voulez résoudre un problème industriel
 
-Allez directement aux applications qui correspondent a votre domaine : **App-3/App-4** (ordonnancement), **App-13/App-17** (routing/logistique), **App-5** (emploi du temps), ou **App-10** (optimisation portefeuille). Chaque application est autonome avec les prerequis indiques.
+Allez directement aux applications qui correspondent à votre domaine : **App-3/App-4** (ordonnancement), **App-13/App-17** (routing/logistique), **App-5** (emploi du temps), ou **App-10** (optimisation portefeuille). Chaque application est autonome avec les prérequis indiqués.
 
 ---
 


### PR DESCRIPTION
## Summary

Restauration des accents français dans les 4 READMEs du **cluster Search** (See #2876 — contribution partielle, l'épic couvre d'autres clusters) :

- `MyIA.AI.Notebooks/Search/README.md` (~140 lignes)
- `MyIA.AI.Notebooks/Search/Part1-Foundations/README.md` (26 lignes)
- `MyIA.AI.Notebooks/Search/Part2-CSP/README.md` (30 lignes)
- `MyIA.AI.Notebooks/Search/Applications/README.md` (41 lignes)

Cluster CLAIMED sur le dashboard workspace. Les clusters ML/, IIT/, GenAI/01-Foundation/ (ai-01, #2651) et les autres lanes sont exclus.

## Méthodologie (anti-#1214, pas de find-replace aveugle)

1. Dictionnaire curé : phrases vérifiées en contexte d'abord, puis mots non-ambigus uniquement (word-boundary, case-sensitive). Mots ambigus (`a`/`à` isolé, `installe`, `limite`, `confronte`, `detection` minuscule, `resume`) exclus du dict et traités manuellement.
2. Guards structurels : code fences, spans `...`, cibles de liens markdown `](...)`, URLs, commentaires HTML (dont le bloc CATALOG-STATUS bot-owned) jamais touchés.
3. Revue manuelle du diff complet + retouches (ex. terme anglais «Lazy Clause Generation» ×3 préservé tel quel).

## Preuve de validation (machine-checkable)

`strip_accents(new) == HEAD` (NFD + suppression des combining marks), modulo 4 corrections de typos documentées :

```
PASS MyIA.AI.Notebooks/Search/README.md
PASS MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
PASS MyIA.AI.Notebooks/Search/Part2-CSP/README.md
PASS MyIA.AI.Notebooks/Search/Applications/README.md
```

Exceptions typo (corrigées en plus des accents, listées explicitement) :
- `delibement juxtaposee` → `délibérément juxtaposée`
- `references specifics sont indiquees` → `références spécifiques sont indiquées`
- `Dependence principale` → `Dépendance principale`
- `intentionally petites` → `intentionnellement petites`

## Vérifications complémentaires

- **Ancres internes** : grep repo-wide des anciens slugs des titres modifiés — seul lien interne trouvé : `#parcours-dapprentissage` (Search/README.md:405), dont le titre était déjà accentué → slug inchangé. Aucun lien cassé.
- **Bloc CATALOG-STATUS** : byte-identique à main (catalogue bot-owned, non régénéré).
- **«coeur»** laissé sans ligature : œ est une ligature, hors scope accents (et casserait la validation strip).
- Diff strictement docs : 238 insertions / 238 deletions, aucun fichier code ni notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
