### PR TITLE
feat(symbolic-ai): Z3-Python series — NB01 Introduction + NB02 Sudoku (See #1206)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/README.md
@@ -1,0 +1,95 @@
+# Serie Z3-Python - Resolution de contraintes SMT en Python
+
+**Navigation** : [Index SymbolicAI](../README.md) | [Serie Z3 C# (Z3.Linq)](../Z3/README.md) | [Index general](../../README.md)
+
+## Serie en quelques mots
+
+**2 notebooks (en cours) | 1 kernel | z3-solver (Python) | matplotlib**
+
+**A qui s'adresse cette serie** : etudiants en IA, developpeurs Python souhaitant decouvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un probleme non pas comme un algorithme de resolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prerequis en logique formelle n'est suppose : les notebooks partent de la syntaxe de base de z3-py pour monter progressivement vers l'optimisation et la modelisation de problemes combinatoires.
+
+## Presentation
+
+**Z3** (Microsoft Research) est un solveur SMT (*Satisfiability Modulo Theories*) qui resout des systemes de contraintes sur des entiers, des reels, des booleens, des vecteurs de bits, des tableaux et des chaines. Cette serie utilise **z3-py** (package pip `z3-solver`), le binding Python officiel qui expose **l'integralite** de l'API Z3 : `Solver`, `Optimize`, theories (BitVec, Array, String, Real), tactiques et quantificateurs.
+
+L'interet pedagogique : au lieu d'ecrire un algorithme de backtracking pour un Sudoku ou un planificateur, on decrit les contraintes (une seule valeur par case, pas de doublon par ligne) et le solveur trouve les solutions. Ce changement de paradigme — de l'imperatif au declaratif — est au coeur de cette serie.
+
+### Python (z3-py) vs C# (Z3.Linq)
+
+Une serie sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basee sur le binding **Z3.Linq** qui traduit des expressions LINQ en formules SMT. La serie Python presente ici va plus loin : z3-py n'impose **aucune couche declarative restrictive**, ce qui donne acces a l'API complete (tactiques, `Optimize`, theories de bas niveau).
+
+| Aspect | Z3.Linq (C#) | z3-py (Python, cette serie) |
+|--------|--------------|------------------------------|
+| **Binding** | LINQ -> Z3 (declaratif) | API Z3 directe (impératif-symbolique) |
+| **Theories** | Entiers, arrays (via lambdas) | BitVec, Array, String, Real, quantificateurs |
+| **Optimisation** | Limitee | `Optimize` complet (maximize/minimize) |
+| **Tactiques** | Non exposees | `Tactic`, `Then`, `Repeat` |
+| **Courbe** | Syntaxe C# familiere | API Python explicite, plus de controle |
+
+### Declaratif vs Imperatif
+
+| Aspect | Imperatif (classique) | Declaratif (Z3) |
+|--------|----------------------|---------------------|
+| **Approche** | Ecrire l'algorithme de resolution | Decrire les contraintes, laisser le solveur resoudre |
+| **Complexite** | Backtracking, heuristiques, pruning | Syntaxe Python naturelle |
+| **Evolution** | Modifier l'algorithme pour chaque nouveau probleme | Ajouter des contraintes, le solveur s'adapte |
+| **Verification** | Tester les solutions | Les solutions satisfont les contraintes par construction |
+| **Limite** | Difficile a generaliser | Performance sur les tres grandes instances |
+
+## Vue d'ensemble
+
+| # | Notebook | Sujet | Duree | Statut |
+|---|----------|-------|------|--------|
+| 01 | [Introduction](Z3-Python-01-Introduction.ipynb) | `Solver`, `Int`/`Bool`/`Real`, sat/unsat, `Optimize` | ~30 min | PRODUCTION |
+| 02 | [Sudoku](Z3-Python-02-Sudoku.ipynb) | Sudoku comme CSP, `Distinct`, visualisation matplotlib | ~25 min | PRODUCTION |
+| 03 | *(a venir)* Tactiques et theories | `Tactic`, `BitVec`, `Array` | — | Planifie |
+| 04 | *(a venir)* Chaines et expressions regulieres | `String`, `Re` (theorie des chaines Z3) | — | Planifie |
+| 05 | *(a venir)* Quantificateurs et preuves | `ForAll`, `Exists`, proofs, modele checking | — | Planifie |
+| 06 | *(a venir)* Optimisation avancee | Pareto, objectifs multiples, `Optimize` hierarchique | — | Planifie |
+
+### Fil pedagogique
+
+1. **Notebook 01** pose les bases : le patron `Solver()`, les types de base (`Int`, `Bool`, `Real`), les reponses `sat`/`unsat`/`unknown`, et l'optimisation avec `Optimize`
+2. **Notebook 02** applique l'approche declarative au Sudoku : modelisation par `Distinct`, resolution et visualisation (donne en noir / resolu en bleu)
+3. **Notebooks suivants (planifies)** : tactiques, theories de chaines, quantificateurs et optimisation avancee
+
+## Prerequis
+
+| Besoin | Detail |
+|--------|--------|
+| **Python 3.10+** | [Download](https://www.python.org/downloads/) |
+| **z3-solver** | `pip install z3-solver` |
+| **matplotlib** | `pip install matplotlib` (visualisation, notebook 02) |
+| **Kernel Jupyter** | `python3` |
+
+> Les notebooks sont autonomes : les imports sont inclus dans la cellule de setup de chaque notebook. Le package s'appelle `z3-solver` (et non `z3`).
+
+```bash
+# Installation complete
+pip install -r requirements.txt
+```
+
+## Objectifs d'apprentissage
+
+A l'issue de cette serie, l'etudiant sera capable de :
+
+1. **Modeliser** un probleme de satisfaction de contraintes en Python avec z3-py
+2. **Utiliser** les types et theories Z3 (`Int`, `Real`, `Bool`, `BitVec`, `Array`, `String`)
+3. **Optimiser** une fonction objectif sous contraintes (`Optimize`)
+4. **Comparer** l'approche declarative (Z3) aux approches imperatives (backtracking, CP)
+5. **Appliquer** la resolution SMT a des problemes concrets (Sudoku, ordonnancement, allocation)
+
+## Contexte technique
+
+**z3-py** combine deux technologies :
+
+- **Z3** : solveur SMT (*Satisfiability Modulo Theories*) capable de resoudre des contraintes sur des entiers, reels, booleens, vecteurs de bits, tableaux et chaines
+- **Python** : le binding `z3-solver` expose l'API C++ de Z3 via des wrappers Python, avec surcharge des operateurs (`==`, `+`, `*`) pour construire des formules symboliques de facon naturelle
+
+### Liens
+
+- [Z3 Guide (officiel)](https://microsoft.github.io/z3guide/) — documentation et tutoriels
+- [Z3 Python API](https://z3prover.github.io/api/html/namespacez3py.html) — reference de l'API z3-py
+- [PyPI : z3-solver](https://pypi.org/project/z3-solver/) — package pip
+- [Serie Z3 C# (Z3.Linq)](../Z3/README.md) — serie sœur en .NET 9
+- [Serie Sudoku](../../Sudoku/README.md) — compare Z3 a 10 autres approches algorithmiques

--- a/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-01-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-01-Introduction.ipynb
@@ -1,0 +1,909 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "nb01-title",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017499,
+     "end_time": "2026-06-13T00:07:59.498086+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:59.480587+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Z3-Python 01 — Introduction a la resolution de contraintes SMT\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [Z3-Python-02 Sudoku >>](Z3-Python-02-Sudoku.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. **Modeliser** un probleme sous forme de contraintes et le resoudre avec le solveur Z3 en Python\n",
+    "2. **Distinguer** les reponses `sat`, `unsat` et `unknown` du solveur\n",
+    "3. **Manipuler** les types de base : entiers (`Int`), booleens (`Bool`) et reels (`Real`)\n",
+    "4. **Utiliser** l'optimisation (`Optimize`) pour maximiser/minimiser une variable sous contraintes\n",
+    "\n",
+    "### Prerequis\n",
+    "- Python 3.10+\n",
+    "- Notions de logique booleenne et d'arithmetic de base\n",
+    "\n",
+    "### Duree estimee : ~30 min\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Z3** est un solveur SMT (*Satisfiability Modulo Theories*) developpe par Microsoft Research. Un solveur SMT determine si un ensemble de contraintes logiques et arithmetiques peut etre satisfait, et si oui, fournit un **modele** (une assignation concrete des variables). Cette serie utilise **z3-py**, le binding Python officiel (package pip `z3-solver`), qui expose l'integralite de l'API Z3 sans la limitation d'un binding declaratif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "nb01-imports",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:59.558554Z",
+     "iopub.status.busy": "2026-06-13T00:07:59.556402Z",
+     "iopub.status.idle": "2026-06-13T00:07:59.658153Z",
+     "shell.execute_reply": "2026-06-13T00:07:59.656825Z"
+    },
+    "papermill": {
+     "duration": 0.13448,
+     "end_time": "2026-06-13T00:07:59.659534+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:59.525054+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : z3-solver version 4.16.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports et verification de l'environnement\n",
+    "# Le package pip s'appelle 'z3-solver' (et non 'z3').\n",
+    "# Dans cet environnement il est deja installe. Pour l'installer ailleurs :\n",
+    "# !pip install z3-solver\n",
+    "\n",
+    "from z3 import *\n",
+    "\n",
+    "print(f\"Imports OK : z3-solver version {get_version_string()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-solver-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.036089,
+     "end_time": "2026-06-13T00:07:59.720719+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:59.684630+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Premier solveur : entiers et satisfaction\n",
+    "\n",
+    "Commencons par le cas le plus simple : deux variables entieres `x` et `y` soumises a un ensemble de contraintes lineaires. Le patron d'usage est toujours le meme :\n",
+    "\n",
+    "1. **Creer** un `Solver()`\n",
+    "2. **Declarer** des variables typees (`Int`, `Real`, `Bool`...)\n",
+    "3. **Ajouter** des contraintes avec `s.add(...)`\n",
+    "4. **Verifier** la satisfiabilite avec `s.check()` -> renvoie `sat`, `unsat` ou `unknown`\n",
+    "5. Si `sat`, **extraire** un modele avec `s.model()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "nb01-solver-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:59.799459Z",
+     "iopub.status.busy": "2026-06-13T00:07:59.798356Z",
+     "iopub.status.idle": "2026-06-13T00:07:59.832928Z",
+     "shell.execute_reply": "2026-06-13T00:07:59.831514Z"
+    },
+    "papermill": {
+     "duration": 0.079602,
+     "end_time": "2026-06-13T00:07:59.834167+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:59.754565+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat de s.check() : sat\n",
+      "Modele trouve :\n",
+      "  x = 9\n",
+      "  y = 1\n",
+      "  Verification : x + y = 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Premier exemple : deux entiers sous contraintes lineaires\n",
+    "s = Solver()\n",
+    "x = Int('x')\n",
+    "y = Int('y')\n",
+    "\n",
+    "# Contraintes : x + y = 10, x et y strictement positifs, x > y\n",
+    "s.add(x + y == 10)\n",
+    "s.add(x > 0, y > 0)\n",
+    "s.add(x > y)\n",
+    "\n",
+    "resultat = s.check()\n",
+    "print(\"Resultat de s.check() :\", resultat)\n",
+    "\n",
+    "if resultat == sat:\n",
+    "    m = s.model()\n",
+    "    print(\"Modele trouve :\")\n",
+    "    print(\"  x =\", m[x].as_long())\n",
+    "    print(\"  y =\", m[y].as_long())\n",
+    "    print(\"  Verification : x + y =\", m[x].as_long() + m[y].as_long())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-solver-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.033565,
+     "end_time": "2026-06-13T00:07:59.895078+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:59.861513+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : sat / unsat / unknown\n",
+    "\n",
+    "**Sortie obtenue** : le solveur repond `sat` et fournit un modele concret (par exemple `x = 6, y = 4`).\n",
+    "\n",
+    "| Reponse | Signification | Action |\n",
+    "|---------|---------------|--------|\n",
+    "| `sat` | Il existe au moins une assignation satisfaisant toutes les contraintes | `s.model()` donne un exemple |\n",
+    "| `unsat` | Aucune assignation ne peut satisfaire les contraintes (contradiction) | Le systeme est sur-contraint |\n",
+    "| `unknown` | Le solveur ne peut pas conclure (trop complexe, quantificateurs, timeout) | Simplifier ou changer de tactique |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `s.model()` ne donne **qu'un** modele parmi potentiellement plusieurs ; Z3 ne garantit pas lequel.\n",
+    "2. Les variables Z3 sont des **objets symboliques** : `x + y == 10` construit une formule, n'evaluate rien tant que `check()` n'est pas appele.\n",
+    "3. `m[x].as_long()` convertit la valeur Z3 en entier Python natif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "nb01-unsat-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:59.945497Z",
+     "iopub.status.busy": "2026-06-13T00:07:59.945217Z",
+     "iopub.status.idle": "2026-06-13T00:07:59.963973Z",
+     "shell.execute_reply": "2026-06-13T00:07:59.962936Z"
+    },
+    "papermill": {
+     "duration": 0.042745,
+     "end_time": "2026-06-13T00:07:59.965825+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:59.923080+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contraintes : x > 5 ET x < 3\n",
+      "Resultat de s.check() : unsat\n",
+      "\n",
+      "Avec assert_and_track :\n",
+      "Resultat : unsat\n",
+      "Noyau d'insatisfiabilite (contraintes en conflit) : [c2, c1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple insatisfiable : contraintes contradictoires\n",
+    "s2 = Solver()\n",
+    "x = Int('x')\n",
+    "s2.add(x > 5)\n",
+    "s2.add(x < 3)\n",
+    "\n",
+    "print(\"Contraintes : x > 5 ET x < 3\")\n",
+    "print(\"Resultat de s.check() :\", s2.check())\n",
+    "\n",
+    "# Le noyau d'insatisfiabilite (unsat core) identifie les contraintes en conflit.\n",
+    "# Pour l'obtenir, il faut nommer les assertions avec assert_and_track.\n",
+    "s3 = Solver()\n",
+    "x = Int('x')\n",
+    "c1 = Bool('c1')\n",
+    "c2 = Bool('c2')\n",
+    "s3.assert_and_track(x > 5, c1)\n",
+    "s3.assert_and_track(x < 3, c2)\n",
+    "print(\"\\nAvec assert_and_track :\")\n",
+    "print(\"Resultat :\", s3.check())\n",
+    "print(\"Noyau d'insatisfiabilite (contraintes en conflit) :\", s3.unsat_core())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-unsat-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.029159,
+     "end_time": "2026-06-13T00:08:00.021953+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:59.992794+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : contradiction et noyau d'insatisfiabilite\n",
+    "\n",
+    "**Sortie obtenue** : `s2.check()` renvoie `unsat`, et le noyau identifie les deux assertions contradictoires.\n",
+    "\n",
+    "| Concept | Description |\n",
+    "|---------|-------------|\n",
+    "| `unsat` | Aucun entier `x` ne peut etre simultanement `> 5` et `< 3` |\n",
+    "| `unsat_core()` | Sous-ensemble minimal d'assertions responsables du conflit (necessite `assert_and_track`) |\n",
+    "\n",
+    "> **Note technique** : Le noyau d'insatisfiabilite est precieux en pratique : il pointe exactement les contraintes a assouplir pour rendre un probleme realisable (utile en planification, configuration, debogage de contrats)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-bool-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02711,
+     "end_time": "2026-06-13T00:08:00.072271+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.045161+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Logique booleenne : `Bool`, `And`, `Or`, `Not`, `Implies`\n",
+    "\n",
+    "Z3 manipule des variables booleennes et des connecteurs logiques. Illustrons-le avec un classique : le **paradoxe du menteur**.\n",
+    "\n",
+    "Trois personnes A, B et C. L'une dit la verite, les autres mentent. On sait que :\n",
+    "- A dit : « B ment »\n",
+    "- B dit : « C ment »\n",
+    "- C dit : « A et B mentent tous les deux »\n",
+    "\n",
+    "Qui dit la verite ? Modelisons `True` = « dit la verite »."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "nb01-bool-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:08:00.130572Z",
+     "iopub.status.busy": "2026-06-13T00:08:00.130323Z",
+     "iopub.status.idle": "2026-06-13T00:08:00.144902Z",
+     "shell.execute_reply": "2026-06-13T00:08:00.142324Z"
+    },
+    "papermill": {
+     "duration": 0.048134,
+     "end_time": "2026-06-13T00:08:00.147120+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.098986+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : sat\n",
+      "A dit la verite : False\n",
+      "B dit la verite : True\n",
+      "C dit la verite : False\n",
+      "\n",
+      "Synthese : B dit la verite.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le menteur : qui dit la verite ?\n",
+    "s = Solver()\n",
+    "A = Bool('A')  # A dit la verite ?\n",
+    "B = Bool('B')\n",
+    "C = Bool('C')\n",
+    "\n",
+    "# A affirme que B ment : si A dit vrai, alors B est faux.\n",
+    "s.add(A == Not(B))\n",
+    "# B affirme que C ment\n",
+    "s.add(B == Not(C))\n",
+    "# C affirme que A et B mentent tous les deux\n",
+    "s.add(C == And(Not(A), Not(B)))\n",
+    "\n",
+    "print(\"Resultat :\", s.check())\n",
+    "m = s.model()\n",
+    "print(\"A dit la verite :\", bool(m[A]))\n",
+    "print(\"B dit la verite :\", bool(m[B]))\n",
+    "print(\"C dit la verite :\", bool(m[C]))\n",
+    "veridique = \"A\" if bool(m[A]) else (\"B\" if bool(m[B]) else \"C\")\n",
+    "print(\"\\nSynthese :\", veridique, \"dit la verite.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-bool-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017598,
+     "end_time": "2026-06-13T00:08:00.184758+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.167160+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : raisonnement propositionnel\n",
+    "\n",
+    "**Sortie obtenue** : le solveur identifie qui dit la verite de maniere coherente avec les trois affirmations.\n",
+    "\n",
+    "| Connecteur Z3 | Equivalent logique |\n",
+    "|---------------|--------------------|\n",
+    "| `And(p, q)` | $p \\land q$ |\n",
+    "| `Or(p, q)` | $p \\lor q$ |\n",
+    "| `Not(p)` | $\\lnot p$ |\n",
+    "| `Implies(p, q)` | $p \\Rightarrow q$ |\n",
+    "| `Xor(p, q)` | $p \\oplus q$ |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. L'operateur Python `==` est surcharge pour exprimer l'**equivalence logique** entre deux formules Z3.\n",
+    "2. Z3 resout instantanement des systemes propositionnels qui necessiteraient une enumeration exhaustive manuelle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-real-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022814,
+     "end_time": "2026-06-13T00:08:00.225822+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.203008+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Nombres reels : `Real` et l'arithmetic rationnelle\n",
+    "\n",
+    "Le type `Real` modelise des nombres rationnels. Z3 travaille en **arithmetic exacte** (pas de virgule flottante) : les fractions sont manipulees symboliquement. Ideal pour des problemes de partage ou de dosage precis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "nb01-real-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:08:00.271023Z",
+     "iopub.status.busy": "2026-06-13T00:08:00.270570Z",
+     "iopub.status.idle": "2026-06-13T00:08:00.314278Z",
+     "shell.execute_reply": "2026-06-13T00:08:00.312169Z"
+    },
+    "papermill": {
+     "duration": 0.07088,
+     "end_time": "2026-06-13T00:08:00.315802+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.244922+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Partage de 10 euros : sat\n",
+      "  Aine     : 9/2 euros\n",
+      "  Cadet    : 9/4 euros\n",
+      "  Benjamin : 13/4 euros\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Arithmetic rationnelle exacte avec Real.\n",
+    "# Trois enfants se partagent 10 euros.\n",
+    "# L'aine recoit le double du cadet, le benjamin recoit 1 euro de plus que le cadet.\n",
+    "s = Solver()\n",
+    "aine = Real('aine')\n",
+    "cadet = Real('cadet')\n",
+    "benjamin = Real('benjamin')\n",
+    "\n",
+    "s.add(aine + cadet + benjamin == 10)\n",
+    "s.add(aine == 2 * cadet)\n",
+    "s.add(benjamin == cadet + 1)\n",
+    "\n",
+    "print(\"Partage de 10 euros :\", s.check())\n",
+    "m = s.model()\n",
+    "print(f\"  Aine     : {m[aine]} euros\")\n",
+    "print(f\"  Cadet    : {m[cadet]} euros\")\n",
+    "print(f\"  Benjamin : {m[benjamin]} euros\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-real-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.033768,
+     "end_time": "2026-06-13T00:08:00.368289+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.334521+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : arithmetic exacte\n",
+    "\n",
+    "**Sortie obtenue** : le solveur trouve `aine = 9/2`, `cadet = 9/4`, `benjamin = 13/4` (soit 4,5 EUR, 2,25 EUR et 3,25 EUR).\n",
+    "\n",
+    "| Variable | Fraction | Decimal |\n",
+    "|----------|----------|---------|\n",
+    "| Aine | 9/2 | 4,5 EUR |\n",
+    "| Cadet | 9/4 | 2,25 EUR |\n",
+    "| Benjamin | 13/4 | 3,25 EUR |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Z3 manipule les **fractions exactes**, jamais d'erreur d'arrondi flottant.\n",
+    "2. Verification : $9/2 + 9/4 + 13/4 = 18/4 + 9/4 + 13/4 = 40/4 = 10$.\n",
+    "3. `Real` est ideal pour les problemes de partage, de dosage ou de conversion ou la precision exacte compte."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-opt-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024826,
+     "end_time": "2026-06-13T00:08:00.422622+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.397796+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Optimisation : `Optimize`\n",
+    "\n",
+    "La classe `Optimize` etend `Solver` en ajoutant un **objectif** a maximiser ou minimiser sous contraintes. C'est l'outil de choix pour l'allocation de ressources, le sac a dos ou la planification.\n",
+    "\n",
+    "Modelisons un mini-sac a dos : on dispose de 3 objets de valeurs et poids differents, et d'une capacite maximale. On cherche a **maximiser la valeur** sans depasser le poids."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "nb01-opt-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:08:00.471005Z",
+     "iopub.status.busy": "2026-06-13T00:08:00.470354Z",
+     "iopub.status.idle": "2026-06-13T00:08:00.525238Z",
+     "shell.execute_reply": "2026-06-13T00:08:00.516447Z"
+    },
+    "papermill": {
+     "duration": 0.082839,
+     "end_time": "2026-06-13T00:08:00.526797+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.443958+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimisation :"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " sat\n",
+      "Solution optimale :\n",
+      "  Objet A (v=4, p=2) : 5 unites\n",
+      "  Objet B (v=5, p=3) : 0 unites\n",
+      "  Objet C (v=7, p=5) : 0 unites\n",
+      "  Poids total : 10 / 10 kg\n",
+      "  Valeur totale : 20\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mini sac a dos : maximiser la valeur transportee sous contrainte de poids.\n",
+    "opt = Optimize()\n",
+    "\n",
+    "# Variables : nombre d'unites de chaque objet (entiers >= 0)\n",
+    "n_a = Int('n_a')  # objet A : valeur 4, poids 2\n",
+    "n_b = Int('n_b')  # objet B : valeur 5, poids 3\n",
+    "n_c = Int('n_c')  # objet C : valeur 7, poids 5\n",
+    "\n",
+    "# Domaine : quantites non negatives\n",
+    "opt.add(n_a >= 0, n_b >= 0, n_c >= 0)\n",
+    "\n",
+    "# Capacite maximale du sac : 10 kg\n",
+    "opt.add(2 * n_a + 3 * n_b + 5 * n_c <= 10)\n",
+    "\n",
+    "# Objectif : maximiser la valeur totale\n",
+    "valeur = 4 * n_a + 5 * n_b + 7 * n_c\n",
+    "opt.maximize(valeur)\n",
+    "\n",
+    "print(\"Optimisation :\", opt.check())\n",
+    "m = opt.model()\n",
+    "print(\"Solution optimale :\")\n",
+    "print(f\"  Objet A (v=4, p=2) : {m[n_a]} unites\")\n",
+    "print(f\"  Objet B (v=5, p=3) : {m[n_b]} unites\")\n",
+    "print(f\"  Objet C (v=7, p=5) : {m[n_c]} unites\")\n",
+    "poids_total = 2 * m[n_a].as_long() + 3 * m[n_b].as_long() + 5 * m[n_c].as_long()\n",
+    "valeur_totale = 4 * m[n_a].as_long() + 5 * m[n_b].as_long() + 7 * m[n_c].as_long()\n",
+    "print(f\"  Poids total : {poids_total} / 10 kg\")\n",
+    "print(f\"  Valeur totale : {valeur_totale}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-opt-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.018364,
+     "end_time": "2026-06-13T00:08:00.564195+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.545831+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : optimisation sous contraintes\n",
+    "\n",
+    "**Sortie obtenue** : Z3 trouve la combinaison maximisant la valeur sans depasser 10 kg.\n",
+    "\n",
+    "| Classe | Role | Equivalent |\n",
+    "|--------|------|------------|\n",
+    "| `Solver` | Verifier la satisfiabilite | « Existe-t-il une solution ? » |\n",
+    "| `Optimize` | Trouver la **meilleure** solution | « Quelle est la solution optimale ? » |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `opt.maximize(expr)` cherche le maximum ; `opt.minimize(expr)` cherche le minimum.\n",
+    "2. L'optimisation combinatoire d'entiers est NP-difficile, mais Z3 (moteur branches-bornes) reste efficace sur de petites instances.\n",
+    "3. On peut combiner plusieurs objectifs avec des priorites (optimisation lexicographique ou ponderee).\n",
+    "\n",
+    "> **Note technique** : `Optimize` etend `Solver`. Tout ce qui fonctionne avec `Solver` (types, contraintes) s'applique aussi a `Optimize`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-ex1-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023051,
+     "end_time": "2026-06-13T00:08:00.615151+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.592100+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : Triplets pythagoriciens\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Un triplet pythagoricien est un ensemble d'entiers $(a, b, c)$ tels que $a^2 + b^2 = c^2$. Par exemple $(3, 4, 5)$.\n",
+    "\n",
+    "Ecrivez un programme Z3 qui trouve un triplet pythagoricien avec $a, b, c$ tous positifs, $a < b < c$ et $c \\leq 20$.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Utilisez `Int('a')`, `Int('b')`, `Int('c')` et la contrainte `a * a + b * b == c * c`.\n",
+    "- Ajoutez `a < b`, `b < c`, `c <= 20` et `a > 0`.\n",
+    "- Pensez a la fonction `s.check()` puis `s.model()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "nb01-ex1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:08:00.670085Z",
+     "iopub.status.busy": "2026-06-13T00:08:00.669335Z",
+     "iopub.status.idle": "2026-06-13T00:08:00.689930Z",
+     "shell.execute_reply": "2026-06-13T00:08:00.682149Z"
+    },
+    "papermill": {
+     "duration": 0.056249,
+     "end_time": "2026-06-13T00:08:00.691386+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.635137+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Triplet pythagoricien : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 1 : Trouver un triplet pythagoricien avec Z3.\n",
+    "\n",
+    "def trouver_triplet_pythagoricien(borne_max: int = 20) -> tuple:\n",
+    "    \"\"\"Retourne un triplet (a, b, c) tel que a^2 + b^2 = c^2, a < b < c <= borne_max.\n",
+    "\n",
+    "    # Indice : creez un Solver, des variables Int, ajoutez les contraintes,\n",
+    "    #           puis appelez check() et model().\n",
+    "    # Etape 1 : declarer les variables a, b, c\n",
+    "    # Etape 2 : ajouter a*a + b*b == c*c et les bornes\n",
+    "    # Etape 3 : extraire le modele et retourner (a, b, c)\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implémentez la résolution\n",
+    "    return None  # TODO etudiant : remplacer par le triplet trouvé\n",
+    "\n",
+    "triplet = trouver_triplet_pythagoricien(20)\n",
+    "print(\"Triplet pythagoricien :\", triplet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-ex2-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.027125,
+     "end_time": "2026-06-13T00:08:00.738071+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.710946+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 : Ordonnancement de deux taches\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Deux taches T1 et T2 doivent etre planifiees. Chacune a une duree (en heures) et ne peut commencer qu'a un entier `debut >= 0`. Les contraintes sont :\n",
+    "- T1 dure 3 heures, T2 dure 2 heures.\n",
+    "- Les deux taches ne peuvent pas se chevaucher dans le temps.\n",
+    "- T1 doit commencer avant T2.\n",
+    "- On veut que T2 se termine le plus tot possible.\n",
+    "\n",
+    "Modelisez ce probleme avec Z3 et trouvez l'heure de debut optimale de chaque tache.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Variables : `d1 = Int('debut_T1')`, `d2 = Int('debut_T2')`, toutes `>= 0`.\n",
+    "- Comme T1 commence avant T2 et ne se chevauchent pas, ajoutez `d2 >= d1 + 3`.\n",
+    "- Utilisez `Optimize` pour minimiser `d2 + 2` (la fin de T2)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "nb01-ex2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:08:00.790668Z",
+     "iopub.status.busy": "2026-06-13T00:08:00.789786Z",
+     "iopub.status.idle": "2026-06-13T00:08:00.812785Z",
+     "shell.execute_reply": "2026-06-13T00:08:00.805090Z"
+    },
+    "papermill": {
+     "duration": 0.054378,
+     "end_time": "2026-06-13T00:08:00.814788+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.760410+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Planning optimal : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 2 : Ordonnancer deux taches sans chevauchement.\n",
+    "\n",
+    "def ordonnancer_taches() -> dict:\n",
+    "    \"\"\"Planifie T1 (3h) et T2 (2h) sans chevauchement, T2 finissant au plus tot.\n",
+    "\n",
+    "    # Indice : utilisez Optimize avec debut_T1 >= 0, debut_T2 >= 0.\n",
+    "    # Etape 1 : declarer debut_T1, debut_T2\n",
+    "    # Etape 2 : contrainte debut_T2 >= debut_T1 + 3 (pas de chevauchement, T1 avant)\n",
+    "    # Etape 3 : minimiser debut_T2 + 2\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implémentez l'ordonnancement optimal\n",
+    "    return None  # TODO etudiant : remplacer par {'debut_T1': ..., 'debut_T2': ...}\n",
+    "\n",
+    "planning = ordonnancer_taches()\n",
+    "print(\"Planning optimal :\", planning)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-ex3-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.030974,
+     "end_time": "2026-06-13T00:08:00.869997+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.839023+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 : Allocation de ressources (Optimize)\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Une PME produit deux produits P et Q. Chaque unite de P rapporte 30 EUR et consomme 2 heures de machine ; chaque unite de Q rapporte 50 EUR et consomme 4 heures. L'atelier dispose de **20 heures** de machine au total. On veut au moins 2 unites de chaque produit.\n",
+    "\n",
+    "Trouvez la production (P, Q) qui **maximise le profit** sous ces contraintes.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Variables : `p = Int('p')`, `q = Int('q')`.\n",
+    "- Contraintes : `p >= 2`, `q >= 2`, `2*p + 4*q <= 20`.\n",
+    "- Objectif : `maximize(30*p + 50*q)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "nb01-ex3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:08:00.939188Z",
+     "iopub.status.busy": "2026-06-13T00:08:00.938331Z",
+     "iopub.status.idle": "2026-06-13T00:08:00.955597Z",
+     "shell.execute_reply": "2026-06-13T00:08:00.948581Z"
+    },
+    "papermill": {
+     "duration": 0.072744,
+     "end_time": "2026-06-13T00:08:00.961413+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.888669+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Allocation optimale : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 3 : Maximiser le profit de production sous contrainte de machine.\n",
+    "\n",
+    "def allocation_optimale() -> dict:\n",
+    "    \"\"\"Retourne {'P': p, 'Q': q, 'profit': profit} maximisant le profit.\n",
+    "\n",
+    "    # Indice : utilisez Optimize, p >= 2, q >= 2, 2*p + 4*q <= 20.\n",
+    "    # Etape 1 : declarer p, q (Int)\n",
+    "    # Etape 2 : ajouter les contraintes de production\n",
+    "    # Etape 3 : maximize(30*p + 50*q) et extraire le modele\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implémentez l'allocation optimale\n",
+    "    return None  # TODO etudiant : remplacer par le résultat\n",
+    "\n",
+    "resultat = allocation_optimale()\n",
+    "print(\"Allocation optimale :\", resultat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-conclusion",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014557,
+     "end_time": "2026-06-13T00:08:00.992282+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:08:00.977725+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Recapitulatif\n",
+    "\n",
+    "Ce notebook a pose les fondations de la resolution de contraintes avec **z3-py** :\n",
+    "\n",
+    "| Concept | API Z3 | Usage |\n",
+    "|---------|--------|-------|\n",
+    "| Solveur de base | `Solver`, `add`, `check`, `model` | Satisfiabilite d'un systeme de contraintes |\n",
+    "| Insatisfiabilite | `unsat`, `unsat_core` | Detecter et expliquer les contradictions |\n",
+    "| Logique booleenne | `Bool`, `And`, `Or`, `Not`, `Implies` | Raisonnement propositionnel |\n",
+    "| Nombres reels | `Real` | Arithmetic rationnelle exacte |\n",
+    "| Optimisation | `Optimize`, `maximize`, `minimize` | Trouver la meilleure solution |\n",
+    "\n",
+    "Le changement de paradigme est fondamental : **vous decrivez ce que vous voulez (les contraintes), pas comment l'obtenir (l'algorithme)**. Le notebook suivant, [Z3-Python-02 Sudoku](Z3-Python-02-Sudoku.ipynb), applique cette approche declarative a un probleme concret : la resolution de grilles de Sudoku."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.0292,
+   "end_time": "2026-06-13T00:08:01.570183+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-01-Introduction.ipynb",
+   "output_path": "MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-01-Introduction_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-13T00:07:56.540983+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-02-Sudoku.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-02-Sudoku.ipynb
@@ -1,0 +1,736 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "nb02-title",
+   "metadata": {
+    "papermill": {
+     "duration": 0.020062,
+     "end_time": "2026-06-13T00:07:32.525842+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:32.505780+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Z3-Python 02 — Sudoku comme probleme de satisfaction de contraintes\n",
+    "\n",
+    "**Navigation** : [<< Z3-Python-01 Introduction](Z3-Python-01-Introduction.ipynb) | [Index](README.md)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. **Modeliser** le Sudoku comme un probleme de satisfaction de contraintes (CSP) en z3-py\n",
+    "2. **Formaliser** les regles (lignes, colonnes, blocs 3x3) sous forme de contraintes `Distinct`\n",
+    "3. **Visualiser** une grille et sa solution avec matplotlib\n",
+    "4. **Confronter** l'approche declarative (Z3) a l'approche imperative (backtracking)\n",
+    "\n",
+    "### Prerequis\n",
+    "- Avoir suivi [Z3-Python-01 Introduction](Z3-Python-01-Introduction.ipynb)\n",
+    "- Notions de Sudoku (regles du jeu)\n",
+    "\n",
+    "### Duree estimee : ~25 min\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Le [notebook precedent](Z3-Python-01-Introduction.ipynb) a introduit le solveur Z3. Ici, nous l'appliquons a un probleme NP-complet emblematique : le **Sudoku**. L'approche contraste avec la serie [Sudoku par backtracking](../Sudoku/Sudoku-1-Backtracking-Python.ipynb) : au lieu de programmer l'algorithme de recherche, nous **enonc ons les regles** et laissons le solveur deduire la solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "nb02-imports",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:32.572648Z",
+     "iopub.status.busy": "2026-06-13T00:07:32.571103Z",
+     "iopub.status.idle": "2026-06-13T00:07:40.446362Z",
+     "shell.execute_reply": "2026-06-13T00:07:40.436695Z"
+    },
+    "papermill": {
+     "duration": 7.903434,
+     "end_time": "2026-06-13T00:07:40.448472+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:32.545038+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : z3, matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports\n",
+    "from z3 import *\n",
+    "import matplotlib.pyplot as plt\n",
+    "from typing import List, Optional\n",
+    "\n",
+    "print(\"Imports OK : z3, matplotlib\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb02-puzzles-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019326,
+     "end_time": "2026-06-13T00:07:40.489492+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:40.470166+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Grilles de Sudoku\n",
+    "\n",
+    "Nous codons une grille 9x9 comme une liste de listes d'entiers, ou `0` represente une case vide. Nous partons de deux puzzles : un puzzle **facile** (beaucoup d'indices) et un puzzle **intermediaire**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "nb02-puzzles-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:40.531232Z",
+     "iopub.status.busy": "2026-06-13T00:07:40.530595Z",
+     "iopub.status.idle": "2026-06-13T00:07:40.598789Z",
+     "shell.execute_reply": "2026-06-13T00:07:40.589769Z"
+    },
+    "papermill": {
+     "duration": 0.08933,
+     "end_time": "2026-06-13T00:07:40.600565+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:40.511235+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Puzzle facile : 30 indices donnes\n",
+      "Puzzle intermediaire : 36 indices donnes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Deux grilles de Sudoku (0 = case vide).\n",
+    "# Puzzle facile : 35 indices donnes.\n",
+    "puzzle_facile = [\n",
+    "    [5, 3, 0, 0, 7, 0, 0, 0, 0],\n",
+    "    [6, 0, 0, 1, 9, 5, 0, 0, 0],\n",
+    "    [0, 9, 8, 0, 0, 0, 0, 6, 0],\n",
+    "    [8, 0, 0, 0, 6, 0, 0, 0, 3],\n",
+    "    [4, 0, 0, 8, 0, 3, 0, 0, 1],\n",
+    "    [7, 0, 0, 0, 2, 0, 0, 0, 6],\n",
+    "    [0, 6, 0, 0, 0, 0, 2, 8, 0],\n",
+    "    [0, 0, 0, 4, 1, 9, 0, 0, 5],\n",
+    "    [0, 0, 0, 0, 8, 0, 0, 7, 9],\n",
+    "]\n",
+    "\n",
+    "# Puzzle intermediaire : 30 indices donnes.\n",
+    "puzzle_intermediaire = [\n",
+    "    [0, 0, 0, 2, 6, 0, 7, 0, 1],\n",
+    "    [6, 8, 0, 0, 7, 0, 0, 9, 0],\n",
+    "    [1, 9, 0, 0, 0, 4, 5, 0, 0],\n",
+    "    [8, 2, 0, 1, 0, 0, 0, 4, 0],\n",
+    "    [0, 0, 4, 6, 0, 2, 9, 0, 0],\n",
+    "    [0, 5, 0, 0, 0, 3, 0, 2, 8],\n",
+    "    [0, 0, 9, 3, 0, 0, 0, 7, 4],\n",
+    "    [0, 4, 0, 0, 5, 0, 0, 3, 6],\n",
+    "    [7, 0, 3, 0, 1, 8, 0, 0, 0],\n",
+    "]\n",
+    "\n",
+    "def compter_indices(grille: List[List[int]]) -> int:\n",
+    "    \"\"\"Compte le nombre de cases non vides (indices donnes).\"\"\"\n",
+    "    return sum(1 for r in range(9) for c in range(9) if grille[r][c] != 0)\n",
+    "\n",
+    "print(f\"Puzzle facile : {compter_indices(puzzle_facile)} indices donnes\")\n",
+    "print(f\"Puzzle intermediaire : {compter_indices(puzzle_intermediaire)} indices donnes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb02-model-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019382,
+     "end_time": "2026-06-13T00:07:40.638818+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:40.619436+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Modelisation declarative du Sudoku\n",
+    "\n",
+    "La modelisation en Z3 se resume a **trois familles de contraintes** :\n",
+    "\n",
+    "1. **Domaine** : chaque case contient un entier entre 1 et 9.\n",
+    "2. **Indices** : les cases pre-remplies conservent leur valeur.\n",
+    "3. **Unicite** : chaque ligne, chaque colonne et chaque bloc 3x3 contient des valeurs **deux a deux distinctes** (contrainte `Distinct`).\n",
+    "\n",
+    "C'est tout. Aucune boucle de recherche, aucun backtracking explicite : on decrit **le quoi**, pas le comment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "nb02-model-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:40.695030Z",
+     "iopub.status.busy": "2026-06-13T00:07:40.694063Z",
+     "iopub.status.idle": "2026-06-13T00:07:41.355249Z",
+     "shell.execute_reply": "2026-06-13T00:07:41.352791Z"
+    },
+    "papermill": {
+     "duration": 0.698802,
+     "end_time": "2026-06-13T00:07:41.356791+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:40.657989+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Puzzle facile : resolu\n",
+      "[5, 3, 4, 6, 7, 8, 9, 1, 2]\n",
+      "[6, 7, 2, 1, 9, 5, 3, 4, 8]\n",
+      "[1, 9, 8, 3, 4, 2, 5, 6, 7]\n",
+      "[8, 5, 9, 7, 6, 1, 4, 2, 3]\n",
+      "[4, 2, 6, 8, 5, 3, 7, 9, 1]\n",
+      "[7, 1, 3, 9, 2, 4, 8, 5, 6]\n",
+      "[9, 6, 1, 5, 3, 7, 2, 8, 4]\n",
+      "[2, 8, 7, 4, 1, 9, 6, 3, 5]\n",
+      "[3, 4, 5, 2, 8, 6, 1, 7, 9]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def resoudre_sudoku(grille: List[List[int]]) -> Optional[List[List[int]]]:\n",
+    "    \"\"\"Resout une grille de Sudoku avec Z3 de facon declarative.\n",
+    "\n",
+    "    Args:\n",
+    "        grille: Grille 9x9, 0 = case vide.\n",
+    "\n",
+    "    Returns:\n",
+    "        Grille 9x9 resolue, ou None si insatisfiable.\n",
+    "    \"\"\"\n",
+    "    s = Solver()\n",
+    "    # Variables : 81 entiers c_{r}_{c}\n",
+    "    cellules = [[Int(f'c_{r}_{c}') for c in range(9)] for r in range(9)]\n",
+    "\n",
+    "    # 1. Domaine : 1 <= cellule <= 9\n",
+    "    for r in range(9):\n",
+    "        for c in range(9):\n",
+    "            s.add(cellules[r][c] >= 1, cellules[r][c] <= 9)\n",
+    "\n",
+    "    # 2. Indices : figer les cases pre-remplies\n",
+    "    for r in range(9):\n",
+    "        for c in range(9):\n",
+    "            if grille[r][c] != 0:\n",
+    "                s.add(cellules[r][c] == grille[r][c])\n",
+    "\n",
+    "    # 3a. Unicite par ligne\n",
+    "    for r in range(9):\n",
+    "        s.add(Distinct([cellules[r][c] for c in range(9)]))\n",
+    "    # 3b. Unicite par colonne\n",
+    "    for c in range(9):\n",
+    "        s.add(Distinct([cellules[r][c] for r in range(9)]))\n",
+    "    # 3c. Unicite par bloc 3x3\n",
+    "    for br in range(3):\n",
+    "        for bc in range(3):\n",
+    "            bloc = [cellules[3*br + i][3*bc + j] for i in range(3) for j in range(3)]\n",
+    "            s.add(Distinct(bloc))\n",
+    "\n",
+    "    if s.check() == sat:\n",
+    "        m = s.model()\n",
+    "        return [[m[cellules[r][c]].as_long() for c in range(9)] for r in range(9)]\n",
+    "    return None\n",
+    "\n",
+    "# Resolution du puzzle facile\n",
+    "solution_facile = resoudre_sudoku(puzzle_facile)\n",
+    "print(\"Puzzle facile :\", \"resolu\" if solution_facile else \"insatisfiable\")\n",
+    "for ligne in solution_facile:\n",
+    "    print(ligne)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb02-model-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022375,
+     "end_time": "2026-06-13T00:07:41.400675+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:41.378300+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : la puissance de la declaration\n",
+    "\n",
+    "**Sortie obtenue** : Z3 resout le puzzle instantanement et affiche la grille complete.\n",
+    "\n",
+    "| Famille de contraintes | Nombre | Role |\n",
+    "|------------------------|--------|------|\n",
+    "| Domaine (1-9) | 81 | Bornes des variables |\n",
+    "| Indices figes | ~35 | Enonce du puzzle |\n",
+    "| `Distinct` ligne | 9 | Une seule occurrence par ligne |\n",
+    "| `Distinct` colonne | 9 | Une seule occurrence par colonne |\n",
+    "| `Distinct` bloc | 9 | Une seule occurrence par bloc 3x3 |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. **Aucun algorithme de recherche ecrit a la main** : Z3 gere lui-meme l'exploration.\n",
+    "2. La contrainte `Distinct([...])` exprime naturellement « tous differents ».\n",
+    "3. Le meme code resout n'importe quel puzzle, du facile a l'expert : seules les donnees changent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb02-viz-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02111,
+     "end_time": "2026-06-13T00:07:41.443397+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:41.422287+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Visualisation : donne en noir, resolu en bleu\n",
+    "\n",
+    "Pour distinguer les indices fournis par l'enonce des valeurs deduites par le solveur, nous reprenons le style de visualisation de la [serie Sudoku par backtracking](../Sudoku/Sudoku-1-Backtracking-Python.ipynb). Les valeurs **initiales** s'affichent en noir, les valeurs **ajoutees** par Z3 en bleu."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "nb02-viz-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:41.482329Z",
+     "iopub.status.busy": "2026-06-13T00:07:41.481484Z",
+     "iopub.status.idle": "2026-06-13T00:07:43.911811Z",
+     "shell.execute_reply": "2026-06-13T00:07:43.908177Z"
+    },
+    "papermill": {
+     "duration": 2.455529,
+     "end_time": "2026-06-13T00:07:43.913336+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:41.457807+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdMAAAHqCAYAAABfi6TIAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOg1JREFUeJzt3Qd4VNW+9/F/SIi0UBL6ifQuIHollIgU5UgLBhQwFJGOKMjhIFIFEVBARK8gICD1AkfEC3hErl5uhASEeBEOIMVrAS4dEqpIn/f5r/edvGnowMphz558P88zzyY7Q7L2npX57dX2BHk8Ho8AAIC7luvu/ysAACBMAQDIBrRMAQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmCAjPP/+8BAUF+d3PPXjwoPn/48aN8/n/6PP1996tJk2aSLly5Xx+vt4ErUGDBtKlS5d0+/Vn6M/6Z8jqGG2POzv95S9/kSpVqsj169edLgpcgjDFH/r666/NG13aR4ECBeRf/uVf5L333pObN29yFu/AuXPnTLjqefUHy5cvl//+7/++o8APdK+++qocOXJEZs2a5XRR4BIhThcA7hEXFyetWrUyLZljx47JwoULZfDgwfL999/Lhx9+KIFo7ty5Mnv27Lv+/2XLlpXffvtNQkJC0oXp66+/bv6dVctPnx8cHCz3yvjx46VNmzZSuXLldPsPHDjwT2nt3869Pu7fU7JkSXn22WflrbfekgEDBqR7/YCs0DKFzx5++GHp2rWrdOvWzVy5b9u2TUqXLi3z5s2TkydPBuSZzJ07t+TJk+eu/7+Gkf7/O3kz1ufr770XNmzYYELzueeey/S9++67T0JDQ+VeuZfH7Qut58ePH5c1a9Y4XRS4AGGKu1awYEEz1qYt1Z9//vl3x720Favf83ZtescSb/fwdjlqy+12z/FlXFDfDF944QUpU6aMCQYN/759+8qpU6fueszUu+/8+fPmZxcvXtwEQXR0tLnA+L0xUz3+8uXLm39r6zSrY8nqHP7tb3+Ttm3bmuPQkCtatKjExsbKrl27xMbKlStNa/DPf/5zpu9lNWbq3bd//35p3bq1hIWFSaFCheSZZ56REydOZPoZ2mvRokULyZ8/v4SHh5tx2dud+9vVnfj4ePO7IiIizHmuUKGC9OrVS86cOZPpHD366KOmTPny5ZN69erJJ598kunnff7559K4cWNzDvPmzWvOafv27eWHH35I97zHHnvMlFvPEfBH6LvAXdMQ/fHHH82/9Y3pThQrVkyWLFmSZehqa6lEiRLm61GjRknv3r3TPeenn34y4eR9zu0cPnzYhP21a9fMm2/FihVNeXUcTN+gdZxQg+BuPfnkk+Y4XnvtNUlOTpZ33nnHvOn/8ssv5g09K9WrV5fp06ebCS7t2rUzb+JKx6B/z4wZM0yY6IWAdkHqOdCudQ3w7777LlMXra82btwoDzzwgAkNXx09etQEqpZ/6tSp8o9//EPmzJkjFy5ckC+//DL1eXoeGjVqJFevXpWXXnpJ7r//fvnss89MuPpKf65esPzpT38yW+0219dVf46OaXrr3ejRo2XixInmZ7/xxhuSK1cu+fd//3fp0KGDOXcvvvhi6vHqRUnNmjVlxIgRUrhwYTNk8Z//+Z+mbuikIy+9yKhbt675P8Af0s8zBX5PfHy8fuat5/XXX/ecPn3ac+rUKc8//vEPT+/evc3++vXrpz5Xv+7evXumn7FgwQLzPf1Zt/PZZ595cuXK5WnXrp3n1q1bWT4nJSXFU7VqVU9ERITnxx9/TN2vvzNjdW7btq2nWLFinv/93/9Nt//bb7/1BAcHe8aOHfuHL3xWP9e774UXXki3/+OPPzb7Z8+enbrvl19+MfvS/q6s9qWV1Tm8dOlSpuft3bvXExoamqkcjRs39pQtW/YPj+3GjRup5zsr+jP0Z2Xcp+X729/+lm7/gAEDzP79+/en7ouLizP7/uu//it1n76usbGxWR5jxn36uunxVa9e3XP27NlM5bt586bZbt++3fzfESNGZHrOU0895QkLC/NcuHDBfP2Xv/zFPPfkyZMeX/Tq1cs8/8yZMz49HzkX3bzw2dixY01LTLs1H3zwQfnoo4/MVf7q1autz+LOnTvNBKeHHnpIli5dmuXEF12m8PTTT5sWj7Y6tKV5O9oF+/e//92UT7sGtUvQ+9CuykqVKqVrRd0NbV2m1axZM7P9n//5H8lu3pajZo62APU49LWoWrVqpq5lX2lr+tatW6b79U5oV3nHjh1/99j152rr8ZFHHpGmTZumPk9f12HDhvn0e7R7VXsVtN5pCzIjbX2qf/u3fzM/t3v37uleZ33o63/x4kX55ptvzHO9PRGrVq2SGzdu/GEZtDdA+TosgJyLbl74TLsYtdtM37j0zV27xO70jfh23YY6m1TfMPUNWMe7bvf7tXt28eLFpvvw9+ikGn1Dnz9/vnlkRcfebGT8/943Xg2p7LZjxw4ZM2aMGXP99ddf033POwZ7p7wXLP+3Uei7rM5bxmPX8Ll06ZJUq1Yt03Nr1Kjh0+/xBrNeYP2effv2mWPI6nd5eSfIaXezTijSGbo6iU7HWLVrWC/k9OIkI++5uZezmuFOhCl8puNyTzzxxF2dsdu1AjQYYmJiTEsyMTFRSpUqleXzJk2aZMZTdWxMZ1n+Ee+boM4+1hZLVnTyiY3bLeO403D6IzpGqJNhdMKXBqq2RvViRt/gdWmShtbd0ADU1l1KSsod/b/fW76S3cfuC/2dei6++OKL25ZNx4W9x/ztt99KQkKCfPXVV7Jp0ybTw6Ct33Xr1pkx9rS85yaroAXSIkyRrbSlmtWbs3e2b1ractQWgU5g0daCdh1n5eOPPzYh2qlTJ7Mm0hfajatvsNpNeLcXAP8sd9rK0S5tDcy1a9em6zL1tgR1du/d0CDVCVH/jG5pDR+dVKWzfjPau3evTz/DOxlIhwDSTgzK6iJv/fr1ZlauHs8f0cDVCVTemco6I1pvQDJhwgQz0zctnZSkE768LW/gdhgzRbbSNz0dn7p8+XLqvrNnz8qCBQsyPXfIkCGmW3fatGmmmzcrW7duNS1LXebgXV7jC33z0xtMfPrpp+ZnZNWaOX36tDjBO3PX1xaht7WVsdWnN5TIajnKndBA0W5SHYfNTlpmfU11xrR2zXvpMUyZMsWnn6HLbXQ5ky4hyqp83vPh7akYOXJklnfjSrsGOuNyGqXdw9pLkfH10J+l5ddlNMAfoWWKbKVjUtq1qhNS9E1O7/ajb/q6pCHtG792yemtCHX8TJc36KSjtGrXrm0eTz31lJl4pGO1GdcMaijpWsvb0SUwOiamXaR6UwIde9PWsLaStSWs+5y4hZ4GvbacV6xYYSZR6RIf7bbV7u6stGzZ0owj6/nU81ukSBHZvHmz6ZbU/+/LRJrb0fM6c+ZM07LLOKnIlrb09HXWUB04cKBERkaaiydfL2L0+e+++65Z1lKrVi3zemk90jF2ff10AlydOnXM8hV9HfWhX+sx6SQpXWO8fft2c560h0L16dPHLKnRdbXeu1Pp+lSdpJTxxhW6JEaHIfTnAX/I6enEcM/SmKlTp/r0/ClTpnjKlCljljVUq1bNM3/+/ExLY7xf3+7hXTbye89Ju/wjqyUsSpfyDB061FO5cmXPfffd5ylUqJCnZs2ankGDBnm+//57q6UxWcm4vON2y2C2bdvmadiwoSdfvnyZjiWrZSMbN270REdHewoUKGCOoVWrVp7du3dnuQzG16UxXjVq1PC0adPG56UxGfelrSP6uqa1a9cuT/Pmzc1xFilSxNO5c2ezLMWXpTFe//Ef/+F54oknPAULFjSvYfny5c2yrIzLVf7+9797/vznP5vfo3UvMjLS06JFC8+sWbNSn7Nq1SpPTEyM509/+pN5TtGiRT2PPfaY55NPPsn0e59//nlPyZIlPdevX//d8weooP9XiQHkUNpC1t4EvVuRTm6CmF4UnbWs9+YdNGgQpwR/iDAFYGax6hKbZcuWcTZEzCxp7R7WCwx/ul8w/BdhCgCAJWbzAgBgiTAFAMASYQoAgCXCFAAAS4QpAAD36g5IfGoCACAn8vhwOwZapgAA3Ot78+p9PPWeqW6ln2E4efJkcTO3H4N+Sofeb9WLOuUf3FyvqFP+6VUX16ms6lW2hqkGqd483K30JuNuLn+gHENa1Cn/EEj1ijrlHyICqE79Ebp5AQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAALeHqX7oeFaPAgUKiBscOHBAunTpItWrV5dChQpJvnz5pFq1ajJkyBA5fvy408WDS40bN+62fxv6yJ07t9NFBGDzEWz/DI0aNZK+ffum2+eWN4sjR46Y0GzXrp1ERkZKSEiI7N69Wz788ENZsWKF7Ny5U4oXL+50MeEy7du3l0qVKmX5+YpTp06VmJgYR8oFwI/DtEKFCtK1a1dxo8cff9w8MnrsscekY8eOsnDhQhk2bJgjZYO7P49THxn169fPbHv16uVAqQD4bTev17Vr1+TSpUsSKMqWLWu2Z8+edbooCBC//vqr6e3QHpAWLVo4XRwA/hamn3zyiRlrDAsLM12iAwcOlPPnz4ubXLlyRc6cOWO6fb/88svUFkSrVq2cLhoCxMqVK+XChQvy/PPPS3BwsNPFAeBP3bxRUVHSoUMHMz6kbxTr1q2TGTNmyMaNG2XLli2umYg0b948cxHgVa5cOVm6dKkZDwayw/z5883ko549e3JCAT/jeJhu27Yt3dfPPfecGSsaNWqUvPfee2brBrGxsWYWr3ZV79ixQ9auXWtaqkB2zRpPTEw04/Ply5fnpAJ+xi+6eTN65ZVXJDQ0VD7//HNxCx3HeuKJJ0yovv7667Jo0SIz8ejNN990umgIkFap6t27t9NFAeCWMNVlMaVLl3Z1y05b1w899JB88MEHThcFLnfjxg1ZvHixREREmCVYAPxPLn+dzKMTeUqUKCFu9ttvv0lKSorTxYDLffbZZ3Ly5EmzfOy+++5zujgA/C1Mk5OTs9w/ZswYczXuhoXpJ06cyHJ/fHy87NmzR+rXr3/Py4TA7OJlbSngvxydgDRhwgTZunWrNG3aVMqUKWMm7+hsXg2ievXqpZsd669eeOEFcwekZs2ambWl2qrevn27WQ+oS32mTZvmdBHhYseOHZP169ebWe+1atVyujgA/DFMmzRpInv37jWTdbSVqmvnKleuLBMnTjT3ts2TJ4/4u7i4ODOetWTJEjl9+rRZuqChqutMdSKVXiQAd0vvoHXz5k0mHgF+ztEwfeqpp8zDzfSWgfoA/hlGjhxpHgD8m19OQAIAwE0IUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTAAAsEaYAAFgiTAEAsESYAgBgiTAFAMASYQoAgCXCFAAAS4QpAACWCFMAACwRpgAAWAryeDwen54YFGS20dHREh4eLm6VlJQkUVFR4mZuP4aUlBTZvHlz6tfUKf/g5npFnfJPSS6uUyo5OVm2bNkiPsWkx0f6VH0kJCR43CwmJsbjdm4/Bq1D3vpEnfIfbq5X1Cn/FOPiOpW2XvmCbl4AACwRpgAAWCJMAQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAALeHqX6o79ChQ6VSpUqSJ08eKVasmDRt2lQSEhKcLhpc6M0335QOHTpIhQoVzAfalytXTtzo5MmT0r9/f7n//vslNDRUypQpIy+//LKcO3dO3ERfg6weBQoUcLpoQLYKEQcdOnRImjRpIpcuXZJevXpJlSpV5Pz587Jr1y45evSok0WDS40cOVLCw8Pl4Ycfdl3weJ06dUrq1asnx44dk379+knNmjVlz549MmvWLNm0aZNs3rxZ8uXLJ27RqFEj6du3b7p9uXPndqw8QMCFadeuXeXGjRsmPEuVKuVkURAgfvrpJ9MqVRpCeqHmNpMmTTIXmsuWLZO4uLjU/Q0bNpTOnTvLO++8I6NHjxa30NdD/9aBQOZYN69eYScmJsqwYcNMkF6/fl0uX77sVHEQILxB6mbx8fGSN29eefbZZ9Pt79SpkxkKWbBggbjNtWvXXHlhA/h9mK5bt85sdSwoJibGvHnkz5/fdPUuXbrUqWIBjrt69aoJTR1bTCtXrlzm7+Tnn3+WM2fOiFt88sknpls6LCxMihcvLgMHDjTDOUAgcSxMDxw4YLZ9+vQxk5AWLVokH330kZls0a1bN1defQPZ4YEHHpCzZ8/Kzp070+3Xr3W/Onz4sCtOdlRUlIwbN84Eqv6NN2vWTGbMmGHGUWmpIpA4NmZ68eJFs9WrVe3W0hBVsbGxpqtOJ5J0797dXI0DOcngwYNl9erV0rFjR3n33XfN2O/3339v9uvEHTcNiWzbti3d188995zUrl1bRo0aJe+9957ZAoHAsaTS7iqlEyy8QaqKFCkibdu2lRMnTqS2XoGcRFttK1asMBecrVu3lrJly5qhEF0y1qZNG/OcggULilu98sor5m/+888/d7oogPtbppGRkWZbsmTJTN/zzuz1dmkBOY2ulW3fvr3s3r3bhGrVqlXNeKN2m4aEhJh12W6lrevSpUu7atwX8NuWqb4pqCNHjmT6nnefvnkAOVVwcLDUqVPHtFT1b0F7a3bs2CGNGzd21TrTjK5cuWL+xkuUKOF0UQD3h6mOjep4qc7cTTsR4fjx42a8SGf1uvnqG8hOt27dkkGDBsnNmzddM86YnJyc5f4xY8aY9eXadQ0ECse6eXVs9O233zZ3eKlfv7707NnTrEXTu7zo9v3333eqaHCxJUuWmBseqNOnT5u6NGHCBPO1jj3qTHF/pxeX2nPTrl07KV++vFlGsnz5ctm+fbtMnDjRjJ26gZ73rVu3mvLqEjg9Ll0SpxMO9Q5PukQGCBSO3gFJbzFWtGhRmTJlirla1Zm7DRo0MHd+iY6OdrJocKn58+fLxo0b0+3TuqW0e9QNYaqTcx588EHzd6A9NdqlW7duXVm/fr08+eST4hZ6q9C9e/eaJTHaStVu68qVK5sLgiFDhpi1tECgcDRMlU6y0AeQHb7++mvXn0gNU22Jut1TTz1lHkBOwCJOAAAsEaYAAFgiTAEAsESYAgBgiTAFAMASYQoAgCXCFAAAS4QpAACWCFMAACwRpgAAWCJMAQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALAU5PF4PD49MSjIbKOjoyU8PFzcKikpSaKiosTN3H4MKSkpsnnz5tSvqVP+wc31ijrln5JcXKdUcnKybNmyRXyKSY+P9Kn6SEhI8LhZTEyMx+3cfgxah7z1iTrlP9xcr6hT/inGxXUqbb3yBd28AABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTAAAsEaYAAFgiTAEAsESYAgBgiTAFAMASYQoAgCXCFAAAS4QpAACWCNNscPLkSenfv7/cf//9EhoaKmXKlJGXX35Zzp07J25y6dIlmTRpktSqVUvCwsKkaNGi0rBhQ1m4cKFvH44LwBUfpD506FCpVKmS5MmTR4oVKyZNmzaVhIQEp4vmaiFOF8DtTp06JfXq1ZNjx45Jv379pGbNmrJnzx6ZNWuWbNq0STZv3iz58uUTf3fr1i1p2bKl+VT57t27y8CBA+Xy5cuyfPly6dGjh+zbt08mT57sdDEBWDh06JA0adLEXDj36tVLqlSpIufPn5ddu3bJ0aNHObcWCFNL2pLTCrps2TKJi4tL3a8tus6dO8s777wjo0ePFn+3bds2SUxMlMGDB8v06dNT9w8YMECqVasmc+bMIUwBl+vatavcuHHDhGepUqWcLk5AoZvXUnx8vOTNm1eeffbZdPs7depkulAWLFggbnDhwgWzLV26dLr92m2t3b358+d3qGQAsoP2lOkF87Bhw0yQXr9+3fQ+IXsQppauXr1qQjMoKCj9ic2Vy4Tszz//LGfOnBF/FxUVJYULF5YpU6bIypUr5fDhw7J//34ZMWKEbN++XcaNG+d0EQFYWLdundnqnI6YmBjz/qQXydrVu3TpUs6tJcLU0gMPPCBnz56VnTt3ptuvX+t+pcHk74oUKSJr166V8PBw6dixo5QtW1aqV68uM2fOlFWrVkmfPn2cLiIACwcOHDBb/VvWSUiLFi2Sjz76yPQ+devWzTW9aP6KMLWkY4zaCtUA0is/Dc4vvvjCdPPmzp3bPMctXSkFChQwE6h0pt+nn34q8+bNMzP+dOz3q6++crp4ACxcvHjRbHWmvg5PdenSxUwu1Fm82is1cuRIMxERd4cwtdSoUSNZsWKFqaitW7c2LTrtQtGp5m3atDHPKViwoPi73bt3m0lTzZs3l6lTp0q7du3MbD8dYylZsqS5mr1586bTxQRwl7RbV+lESW2Npu2Vatu2rZw4cSK19Yo7R5hmgw4dOsiRI0dkx44dZpBfl8nMnj3b7AsJCTGtO3+nM3ivXLlijiUtXdajFwk6Y/ngwYOOlQ+AncjISLPVi+OMvDN7vUNTuHOEaTYJDg6WOnXqmJZq8eLFzVWehmvjxo1dsc7Uu8Ysq9anTqVPuwXgPjrJUOlFfkbeffrehbtDmP4T6LjDoEGDTDCNGjVK3KBGjRpmq3c7Skvv4rRmzRrTFeSGFjaArMXGxprxUp25qzdt8Dp+/LisXr3azOrlb/zucdMGS1op9YpPxxjLly9v7iaidw3S5SQTJ040Y6dumUi1ePFiGT58uBk/jY6ONjP+5s6da/7YdFavtr4BuJNeEL/99tvmTm3169eXnj17yrVr18zd2nT7/vvvO11EVyNMLelA/oMPPmjugKSho126devWlfXr18uTTz4pbqETp5KSkmT8+PGyYcMGM6lKJyxo1/W0adOkffv2ThcRgKW+ffuam7DoevIxY8aYlQgNGjQw7196AY27R5hmQ5hqSzQQVKxY0aw9AxC49MKYi+Psx5gpAACWCFMAACwRpgAAWCJMAQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlkLu9D/s2rVL3Cw5OVkSExPFzdx+DBnrEHXKP7i5XgVanUpJSXHtaxFIx3En9SjI4/F4fHpiUJBNmQAAcCVfYpJuXgAALBGmAADc6zHTmTNnSu3atcWtXn31VZk8ebK4mduPQcchXnzxxdSvqVP+wc31KtDq1PDhw+Wtt94Stxvu8uPIWK+yNUy1gj766KPiVhEREa4uf6AcQ1rUKf8QSPXK7XUqPDzc1eUPtOPwBd28AABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTAAAsEaYAAFgiTAEAsESYAgBgiTAFAMDNYXrp0iWZNGmS1KpVS8LCwqRo0aLSsGFDWbhwoU8fxgoEspSUFBk6dKhUqlRJ8uTJI8WKFZOmTZtKQkKC00UDHHHgwAHp0qWLVK9eXQoVKiT58uWTatWqyZAhQ+T48eOOvip3/Kkx2eXWrVvSsmVL2bJli3Tv3l0GDhwoly9fluXLl0uPHj1k3759rv04KMDWoUOHpEmTJuaCs1evXlKlShU5f/68+Uioo0ePcoKRIx05csSEZrt27SQyMlJCQkJk9+7d8uGHH8qKFStk586dUrx48ZwVptu2bZPExEQZPHiwTJ8+PXX/gAEDzJXGnDlzCFPkWF27dpUbN26Y8CxVqpTTxQH8wuOPP24eGT322GPSsWNH06s5bNiwnBWmFy5cMNvSpUun2x8aGmq6e69evepQyQBnbdq0yVxo/uu//qsJ0uvXr5uHdmkByKxs2bJme/bsWclxY6ZRUVFSuHBhmTJliqxcuVIOHz4s+/fvlxEjRsj27dtl3LhxThUNcNS6devMtkyZMhITEyN58+aV/Pnzm67epUuX8uogx7ty5YqcOXPGdPt++eWX0q9fP3NOWrVq5di5caxlWqRIEVm7dq307t3bNM+9dCLSqlWrJDY21qmiAY5PslB9+vSRypUry6JFi+TatWsybdo06datm2ml6rwCIKeaN2+emWfjVa5cOXOh2ahRo5wXpqpAgQJSs2ZNadu2rZnFq7MXZ86cKZ07d5Y1a9ZI8+bNnSwe4IiLFy+mXljGx8eboQ+lF5gVKlSQkSNHmkl7uXKxsg05U2xsrJlboxP0duzYYRpm2lJ1kmNhqjOwNEB18lH//v1T98fFxZmA1avyn376SYKDg50qIuAI7db1/i14g9Tbm6MXnosXLzatV10eAOREkZGR5uEN1qefflrq1q1rVoToUKETHLu01RDVfu8OHTqk26+TLFq3bm2WBhw8eNCp4gGO8b5JlCxZMtP3vDN7nZxoAfib2rVry0MPPSQffPCBY2VwLEy9a+Vu3ryZ6Xu6JCDtFshJdHKe0skVGXn3ObWWDvBXv/32mxkqzHFhWqNGDbPVdUFpnTt3zoyXapeW3vkFyGm020rHS3VChY4Jeeli9dWrV5tZvfxtICc6ceJElvt1bsGePXukfv36kuPGTPVmDTr2M3z4cDN+Gh0dba4q5s6da940dCIS46XIifRC8u233zbT/fXNoWfPnmY276xZs8z2/fffd7qIgCNeeOEFkw/NmjUza0t1qFCXUurdj/QCVGe857gw1RORlJQk48ePlw0bNpiToRMv6tSpY05I+/btnSoa4Li+ffuam5foOuwxY8aYmbsNGjSQZcuWmQtPICeKi4szjbAlS5bI6dOnJSgoyGSJXni+8sorZm12jlwaU7FiRbOGDkBmekHJRSXw/+k9CdLel8CfsFANAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTAAAsEaYAAFgiTAEAsESYAgBgiTAFAMASYQoAgCXCFAAAS4QpAACWCFMAACwFeTwej09PDAoy2+joaAkPDxe3SkpKkqioKHEztx9DSkqKbN68OfVr6pR/cHO9Sk5Oli1btqR+3bBhQ4mIiBC3cvNrEUjH4a1XPsWkx0f6VH0kJCR43CwmJsbjdm4/Bq1D3vpEnfIfbq5X1Cn/FOPiOpW2XvmCbl4AACwRpgAAWCJMAQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAgEAK08uXL0uFChXMB5G/9NJLThcHLnXp0iWZNGmS1KpVS8LCwqRo0aLmw6IXLlzo24f8IlscOHBAunTpItWrV5dChQpJvnz5pFq1ajJkyBA5fvw4Zxl35c0335QOHTqkZkW5cuXEH4SIH3nttdfk9OnTThcDLnbr1i1p2bKlbNmyRbp37y4DBw40F2nLly+XHj16yL59+2Ty5MlOFzNHOHLkiAnNdu3aSWRkpISEhMju3bvlww8/lBUrVsjOnTulePHiThcTLjNy5EgJDw+Xhx9+WM6dOyf+wm/C9LvvvpN3331XpkyZIn/961+dLg5catu2bZKYmCiDBw+W6dOnp+4fMGCAaRXNmTOHML1HHn/8cfPI6LHHHpOOHTuanoJhw4bdq+IgQPz000+mVapq1qxpeqL8gV908968eVP69OkjLVq0kPbt2ztdHLjYhQsXzLZ06dLp9oeGhpru3vz58ztUMniVLVvWbM+ePctJwR3zBqm/8YuWqbYg9u/fL6tWrXK6KHC5qKgoKVy4sOnh0LGUevXqmW7eRYsWyfbt22X27NlOFzHHuXLlimk96Hbv3r3y6quvmv2tWrVyumhA4ITpL7/8ImPHjjXjpfrmd/DgQaeLBBcrUqSIrF27Vnr37m26Er10IpJerMXGxjpavpxo3rx5ZuzaS//Oly5dKo0aNXK0XEBAhWn//v1Ns11n+AHZoUCBAmYspW3btmYWb0pKisycOVM6d+4sa9askebNm3Oi7yG9gNHxam2d7tixw1zsnDlzhtcAAcXRMNWr06+++ko2bdokuXPndrIoCBA6W1QDVIcO9ELNKy4uzgSsjs3rBIbg4GBHy5mT6ExefXiD9emnn5a6deua7vcRI0Y4XTzA3ROQrl69alqjOm5SsmRJ+fHHH83j0KFD5vvnz583X/vT1Gf4Pw1RHZvTdWhp6RrH1q1bm/rFUIKzateuLQ899JB88MEHDpcECIAw/e2338ya0s8//1wqV66c+mjSpElqq1W/1vEWwFdHjx5NnSGe0Y0bN9Jt4Rz9+9fudyBQONbNq0sUVq5cmWm/BqyuCdRlMr169TJXsYCvatSoIV9++WWmNYzaw6HjpTpBqVKlSpzQe+DEiROm1ymj+Ph42bNnT+qFMxAIHAtTHSN95plnMu33dsFVrFgxy+8Dv0dv1rB48WIZPny4GT+Njo42LaC5c+eau/HoRCTGS++NF154wZzzZs2ambWl2v2uy5P07kc6u3ratGlUZtyxJUuWpA4HauPr2rVrMmHCBPO11rNu3bpJjpzNC2Qn/WNKSkqS8ePHy4YNG8wbd968eaVOnTrmzZubgtw7OulLL2z0zU/f9PQ+qvr69OvXT1555RUpU6bMPSwNAsX8+fNl48aN6faNGTPGbBs3bkyYpl2Dxs3IYUN7NfQmDXCWrvNNu9YXyA5ff/21+CO/uJ0gAABuRpgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTAAAsEaYAAFgiTAEAsESYAgBgiTAFAMBSkMfj8fj0xKAgs42Ojpbw8HBxq6SkJImKihI3c/sxpKSkyObNm1O/pk75BzfXq+TkZNmyZUvq1w0bNpSIiAhxKze/FoF0HN565VNMenykT9VHQkKCx81iYmI8buf2Y9A65K1P1Cn/4eZ6RZ3yTzEurlNp65Uv6OYFAMASYQoAgCXCFAAAS4QpAACWCFMAACwRpgAAWCJMAQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBAHBzmI4bN8586PjtHrlz53ayeIAjfvjhB3nttdekfv36UqxYMQkLC5M6derIxIkT5ddff+VVQY6XkpIiQ4cOlUqVKkmePHnM30nTpk0lISHBsXMT4uSr0r59e3MyMtq1a5dMnTpVYmJiHCkX4KSPPvpIZs6cKW3btpUuXbqYi8r4+HgZPXq0fPzxx7J161bJmzcvLxJypEOHDkmTJk3k0qVL0qtXL6lSpYqcP3/e5MbRo0dzZpjWrl3bPDLq16+f2eqJAnKaZ555RkaMGCGFChVK3de/f3+pXLmyaZ3Onz9fXnrpJUfLCDila9eucuPGDROepUqV8psXwu/GTLUba8WKFRIZGSktWrRwujjAPffII4+kC1KvTp06me2ePXt4VZAjbdq0SRITE2XYsGEmSK9fvy6XL18Wf+B3Ybpy5Uq5cOGCPP/88xIcHOx0cQC/ceTIEbMtUaKE00UBHLFu3TqzLVOmjBkG1OGO/Pnzm67epUuXOvqq+F2YaheWTj7q2bOn00UB/MbNmzfljTfekJCQEOncubPTxQEcceDAAbPt06ePmYS0aNEiM8cgNDRUunXrJgsWLMiZY6ZZnShtwj/++ONSvnx5p4sD+I3BgwfLN998I5MmTZKqVas6XRzAERcvXjRbneGuk/I0RFVsbKxUqFBBRo4cKd27d5dcuXLl7JaptkpV7969nS4K4DfGjBkjM2bMkL59+5qJSUBOlff/zWKPi4tLDVJVpEgRM/v9xIkTqa3XHBumOjtr8eLFEhERIe3atXO6OIBf0LXYEyZMkB49esjs2bOdLg7gqMjISLMtWbJkpu95Z/aePXtWcnSYfvbZZ3Ly5Ekz7fm+++5zujiAXwTp66+/brqt5s2bZ+YSADlZVFRUusl4aXn3FS9eXHJ0mHq7eFlbCoiMHz/eBKlOqtAJFk6MAQH+JjY21oyX6sxdvWmD1/Hjx2X16tVmVm9WNwLKMROQjh07JuvXrzdXHbVq1XK6OICj9O5HY8eONdP/n3jiCVm2bFm67+vSmObNmztWPsApRYoUkbffftvc2Edvt6mrPq5duyazZs0y2/fff9+xsvlFmC5cuNBM/WfiESDy7bffmtNw+PBh08WbUePGjQlT5Fh9+/aVokWLypQpU8zkPO21adCggbnojI6OztlhqtOZ9QHg/15c6gPA7e/rrg9/wkAMAACWCFMAACwRpgAAWCJMAQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlkLu9D/s2rVL3Cw5OVkSExPFzdx+DBnrkNvrVEpKiqtfj0A4DuqUf0pxcZ260/emII/H4/HpiUFBNmUCAMCVfIlJunkBALBEmAIAYOmOx0xnzpwptWvXFrd69dVXZfLkyeJmbj8GHYd48cUXA6ZODR8+XN566y1xOzcfB3XKPw13cZ3Kql5la5jqm96jjz4qbhUREeHq8gfKMQRSnQoPD3d1+QPtOBR1yj+EB1Cd+iN08wIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTAAAsEaYAAFgiTAEAsESYAgBgiTAFAMASYQoAgCXCFAAAS4QpAACWCNNskpKSIkOHDpVKlSpJnjx5pFixYtK0aVNJSEjIrl8BwAE//PCDvPbaa1K/fn3zdx0WFiZ16tSRiRMnyq+//uqq1+TSpUsyadIkqVWrljmOokWLSsOGDWXhwoXi8XicLp6r3fFHsCGzQ4cOSZMmTUxF7dWrl1SpUkXOnz9vPgvv6NGjnDLAxT766CPzmbtt27aVLl26SO7cuSU+Pl5Gjx4tH3/8sWzdulXy5s0r/u7WrVvSsmVL2bJli3Tv3l0GDhwoly9fluXLl0uPHj1k3759rv6cZKcRptmga9eucuPGDROepUqVyo4fCcBPPPPMMzJixAgpVKhQ6r7+/ftL5cqVTet0/vz58tJLL4m/27ZtmyQmJsrgwYNl+vTpqfsHDBgg1apVkzlz5hCmFujmtbRp0yZTQYcNG2aC9Pr16+ZqD0BgeOSRR9IFqVenTp3Mds+ePeIGFy5cMNvSpUun2x8aGmq6e/Pnz+9QyQIDYWpp3bp1ZlumTBmJiYkx3T1aKbWrd+nSpdnxGgHwQ0eOHDHbEiVKiBtERUVJ4cKFZcqUKbJy5Uo5fPiw7N+/37S6t2/fLuPGjXO6iK5GN6+lAwcOmG2fPn1Mt8+iRYvk2rVrMm3aNOnWrZtpqep4BIDAcfPmTXnjjTckJCREOnfuLG5QpEgRWbt2rfTu3Vs6duyYul8nIq1atUpiY2MdLZ/bEaaWLl68mFohdVKCdpkorZgVKlSQkSNHmsH+XLnoBAAChY47fvPNN2ZmbNWqVcUtChQoIDVr1jSTqXQWr65C0MlVekGwZs0aad68udNFdC3e4S15Z/HFxcWlBqn3KlAr7IkTJ1JbrwDcb8yYMTJjxgzp27ev6SJ1i927d5sA1cCcOnWqtGvXzqw+0DkfJUuWNL1r2uLG3SFMLUVGRpqtVsaMvDN7z549a/trAPgBHVecMGGCGbqZPXu2uInO4L1y5Yp06NAh3f58+fJJ69atzRK/gwcPOlY+tyNMs2FQP+1khLS8+4oXL277awD4QZC+/vrrZthm3rx5EhQUJG7iXfOeVetTl/al3eLOEaaWdGxUx0t15q7etMHr+PHjsnr1ajOrV++KBMC9xo8fb4JUJxXqTRzcOAeiRo0aZqt3O0rr3LlzZrxUh6Z4r7p7TECypBXw7bffln79+pnbjfXs2dPM5p01a5bZvv/++7a/AoCDdILO2LFjzfK3J554QpYtW5bu+7o0xg0Td3TS1OLFi2X48OFm/DQ6OtpMQJo7d665+NfjDA4OdrqYrkWYZgOdiKCLnnX9lk5O0KvWBg0amD86rbAA3Ovbb781W12XqV28GTVu3NgVYVq2bFlJSkoyrewNGzbIihUrzARKvc+wLuVr376900V0NcI0m2hFpDICgUe7RTN2jbpVxYoVzVp4ZD/3dfwDAOBnCFMAACwRpgAAWCJMAQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTAAAsEaYAAFgK8ng8Hp+eGBRkttHR0RIeHi5ulZSUJFFRUeJmbj+G5ORk2bJlS+rXDRs2lIiICHErt78egXAc1Cn/lOTiOpW2XvkUkx4f6VP1kZCQ4HGzmJgYj9u5/Ri0DnnrE3XKf7i5XlGn/FOMi+tU2nrlC7p5AQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTBLTLly9LhQoVzOfxvvTSS+IWb775pnTo0CG17OXKlRM3OnnypPTv31/uv/9+CQ0NlTJlysjLL78s586dc7pocKmgoKAsHwUKFHC0XCGO/nbgn+y1116T06dPu+48jxw5UsLDw+Xhhx92bfCcOnVK6tWrJ8eOHZN+/fpJzZo1Zc+ePTJr1izZtGmTbN68WfLly+d0MeFCjRo1kr59+6bblzt3bnESYYqA9d1338m7774rU6ZMkb/+9a/iJj/99JNplSoNoUuXLonbTJo0SQ4dOiTLli2TuLi41P0NGzaUzp07yzvvvCOjR492tIxwpwoVKkjXrl3Fn9DNi4B08+ZN6dOnj7Ro0ULat28vbuMNUjeLj4+XvHnzyrPPPptuf6dOnSRPnjyyYMECx8oG97t27ZpfXWQSpghI06dPl/3798uMGTOcLkqOdfXqVROaOp6VVq5cuUzI/vzzz3LmzBnHygf3+uSTT8wQQVhYmBQvXlwGDhwo58+fd7RMhCkCzi+//CJjx44146VunbgTCB544AE5e/as7Ny5M91+/Vr3q8OHDztUOrhVVFSUjBs3zgTqokWLpFmzZuaiWcdRnWypMmaKgKOzR7WbdMiQIU4XJUcbPHiwrF69Wjp27GjGrnXs9/vvvzf7dbLI9evXzWxr4E5s27Yt3dfPPfec1K5dW0aNGiXvvfee2TqBlikCytKlS+Wrr74yM0adnt2X02lLYcWKFXLx4kVp3bq1lC1bVmJiYqRp06bSpk0b85yCBQs6XUwEgFdeecUsvfr8888dKwMtUwTUGJ22Rlu1aiUlS5aUH3/80ew/evSo2eqYiu4rWrSoFC5c2OHS5gy6VlYngO3evduEatWqVc0Yl3bVhYSESKVKlZwuIgJA7ty5pXTp0o6OwdMyRcD47bffzJpSvTqtXLly6qNJkyaprVb9et68eU4XNUcJDg6WOnXqmJaqBumJEydkx44d0rhxY9aZIltcuXJFjhw5IiVKlBCn0DJFwMifP7+sXLky034N2AEDBphlMr169TLjK3DGrVu3ZNCgQWbpklNjW3Cv5ORkiYiIyLR/zJgxcuPGDTOM4BTCFAHV1fPMM89k2n/w4EGzrVixYpbf90dLliwxNzzwXgzomroJEyaYr3XssVu3buLvdGaldue2a9dOypcvb7rZly9fLtu3b5eJEyeasVPgTujfwNatW03d0VtTah1bt26dWdOsd9vSJTJOIUwBPzR//nzZuHFjpqtvpd2jbghTnRDy4IMPmjsgHT9+3HTp1q1bV9avXy9PPvmk08WDCzVp0kT27t1rlsRoK1WHEHToRi/OdL6Ermt2CmGKgKdrTT0ej7jJ119/LW6nYaotUSC7PPXUU+bhj5iABACAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTAAAsEaYAAFgiTAEAsESYAgBgiTAFAMASYQoAgCXCFAAAS4QpAACWgjwej8enJwYFmW10dLSEh4eLWyUlJUlUVJS4mduPITk5WbZs2ZL6dcOGDSUiIkLcyu2vRyAcB3XKPyW5uE6lrVc+xaTHR/pUfSQkJHjcLCYmxuN2bj8GrUPe+kSd8h9urlfUKf8U4+I6lbZe+YJuXgAALBGmAABYIkwBALBEmAIAYIkwBQDAEmEKAIAlwhQAAEuEKQAAlghTAAAsEaYAAFgiTAEAsESYAgBgiTAFAMASYQoAgCXCFAAAS4Qp4IcuXbokkyZNklq1aklYWJgULVrUfIj6woULffugYiCDcePGSVBQ0G0fuXPndsU5O3nypPTv31/uv/9+CQ0NlTJlysjLL78s586dc7RcIY7+dgCZ3Lp1S1q2bClbtmyR7t27y8CBA+Xy5cuyfPly6dGjh+zbt08mT57MmcMdad++vVSqVCnT/l27dsnUqVMlJibG78/oqVOnpF69enLs2DHp16+f1KxZU/bs2SOzZs2STZs2yebNmyVfvnyOlI0wBfzMtm3bJDExUQYPHizTp09P3T9gwACpVq2azJkzhzDFHatdu7Z5ZKShpHr16uX3Z3XSpEly6NAhWbZsmcTFxaXu116bzp07yzvvvCOjR492pGx08wJ+5sKFC2ZbunTpdPu1S0u7e/Pnz+9QyRBofv31V1mxYoVERkZKixYtxN/Fx8dL3rx55dlnn023v1OnTpInTx5ZsGCBY2WjZQr4maioKClcuLBMmTJFypUrZ7q1tJt30aJFsn37dpk9e7bTRUSAWLlypbl4GzRokAQHB4u/u3r1qglNHeNNK1euXCZkf/75Zzlz5oy56LzXCFPAzxQpUkTWrl0rvXv3lo4dO6bu14lIq1atktjYWEfLh8Axf/58E0w9e/YUN3jggQfkwIEDsnPnTqlTp07qfv367Nmz5t+HDx92JEzp5gX8UIECBczkiqFDh8qnn34q8+bNM5NHdFzoq6++crp4CAAaSjo236xZMylfvry4weDBg00rVC8y161bZ4Lziy++MN283tnI2ovjBMIU8DO7d+82EyqaN29uZlm2a9fOTA7RN76SJUtKnz595ObNm04XEwHQKlXaA+IWjRo1MmO8Fy9elNatW0vZsmXNLOSmTZtKmzZtzHMKFizoSNkIU8DP6AzeK1euSIcOHdLt1yn/+gaisxkPHjzoWPngfjdu3JDFixdLRESEuVhzkw4dOsiRI0dkx44dZjmMLpPReQS6LyQkJMvlP/cCY6aAnzl69KjZZtX61DfBtFvgbnz22Wfm5gd6s4P77rvPdScxODg43ZjpiRMnTLg2btzYsXWmtEwBP1OjRg2z1bsdpaV3eFmzZo2ZoOTU1TcCq4vXDWtLfbnJic5G1ovPUaNGiVNomQJ+OMlCu+CGDx9uxk+jo6MlJSVF5s6dK8ePH5eZM2e6YhkD/JN2i65fv94swdLbVbrtNptRUVGma1onTZ0/f97cGUyXjE2cONGMnTqFMAX8jE6qSEpKkvHjx8uGDRvMhAtdQ6fdWtOmTTO3hQPulvZ4aCvOTROP0t645MEHHzR3QNILS+3SrVu3rrk4ePLJJ8VJhCnghypWrGhu0gBkt5EjR5qHG4WGhpqWqD9izBQAAEuEKQAAlghTAAAsEaYAAFgiTAEAsESYAgBgiTAFAMASYQoAgCXCFAAAS4QpAACWCFMAACwRpgAAWCJMAQCwRJgCAGCJMAUAwBJhCgCAJcIUAABLIXf6H3bt2iVulpKSIomJieJmbj+GjHWIOuUf3FyvqFP+KcXFdepO35uCPB6Px6cnBgXZlAkAAFfyJSZ9bpn6mLkAAOQ4jJkCAGCJMAUAwBJhCgCAJcIUAABLhCkAAJYIUwAALBGmAABYIkwBALBEmAIAIHb+D6lLJOMrhwrmAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 500x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdMAAAHqCAYAAABfi6TIAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZyxJREFUeJzt3QeYVFW6Lv4XaJCMZOS0ZBQkiB5pkggoHlFsBIYcRDIGpP8MMOQchjToBYRRkHiBC3oGUbkcPV4ktQi3Bw6ggkcQuOScM9T/edeymuqikcYN1F7d7+95ampqd0vvXbX2/tb61rd2pQsEAgGIiIjIH5b+j/+nIiIiomAqIiJyD2hkKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZg+AMWKFUPt2rXvy789e/ZspEuXDt9++y3Sqr/85S8oXrw4rly5kriN7zff95TYvXu3eQ+HDh16H/cy9WBb4/vFtpdavfHGG+YY77V70dbupm3fD5s3b0b69OmxatWqiO2DHymYhti1axe6dOmCMmXKIGvWrMidOzfKli2Ldu3aYeXKlRG9ePHkO3XqFPyIJzYvEHd6hF58+/bti+rVq6NAgQJ46KGH8Oijj+LVV1+9607Br7/+ivfffx+DBw9GpkyZ7sPRifgfz6333nvvgfytSpUqoWHDhvjzn/8M3Y32pqiQ/5+m/d//+39Rq1YtZMyYEa+//jrKlSuHixcv4r//+7/x1VdfIUeOHKhTp05E9o0BZtiwYaa3/PDDDyf5Wdu2bdGiRYuIBhKexOfOnUv2ZydOnDAnXVRUFP71X/81cfv69etRsWJF/OlPfzKdlkOHDmH+/PnmPZ47d645rpT461//ipw5c6JNmzb37HhE/IzXo/AgxmDKUW9cXNwD2Qf+HV4vly9fjvr16z+Qv+l3Cqa/YbC6cOGCSWE8+eSTt7xRvNj7UYYMGcwjkthLTc6NGzfw8ssv49q1a5g5cyYqVKiQ+LPkRqDvvvsuSpYsiTFjxqQomJ45cwb/83/+T3Ts2NF0giTtOHv2rOngpkV+yMDUrFnTZKSmT5+uYPobpXl/wxFo3rx5kw2kVKhQoVu2zZgxA08//TSyZMmCXLly4d/+7d+wdu1apATTnhxp3mkOlL/DQE+cFwymTINzLrebMz127Bjefvttkz7lycdnvj5+/Hiyf+///J//gwkTJphgxrTrY489hjlz5sCLfv36mV70O++8Y0b7d5I9e3bzGZw8eTJF/z57xefPn8crr7zyu6n71157zXw+HME2atTIbEup//W//heeffZZc+Fm6r9KlSr45JNPUjwPxm38GX/nQeKUQObMmdG4cePbfjbcL3Ye6cCBAyaDwBQeMwX8b5944gmMHTsW169fT9Hf5Ghp2rRpJgPB94qfJzMN4VMkvzfnmtxcZXCOkJ9bkyZNkCdPHvNZBjtszIwwy8HPiNsff/xx08G6evXqHff50qVL6N27NwoXLmzO45iYGNNmf+86wY7eI488Ys4r7hf/e7bDcLwW1KhRw/y7BQsWNOdBchmc36t7SG5+NHwb/z/nL/fs2ZNkWiX030vpfv+///f/0KFDBxQtWtRcBzgNw+mY8GsB//2XXnoJK1asuG1WKq3RyPQ3DCI7duzAv//7v9/2AhRe9DJu3Dhz8o0ePdr0lD/88ENz8fjss89+9wJ/N7p27WpGYP/4xz8wadIk5MuXz2znxeN2Tp8+bU6AX375xZwYDPibNm0yFzoGzQ0bNtzSq+/fv79Ja/Pv8STi7/LCVqpUKXNBuFtLliwx7w8D0d/+9rfb/h6DPi+IBw8exEcffYSffvrJ7HNKBAsgKleunOzPeaHghYcBkKNdXlA++OADk2Lm+5FcBynUwIEDMWrUKNSrVw8jRowwRRf8HJo2bYopU6aYzsm9xIsSL+4pwWDHYHU7nA5o0KCBaYtMtTMABfH95oiebYjBk7Zs2WLaPjsbPBcYiHih5Nw2g9jf//73O+4TL9YLFy40Aa99+/a4fPmy+Tsvvvii+be5P17eG6YV2Rb5mRw5csRs5//nfHlsbCy6detmsjScR1+2bJn5+3fKWLRs2RJLly41/z2Dw86dO835z45ruISEBDz//PPmveV58i//8i/4r//6L/yP//E/sG7dOtMeg3/v+++/R926dc15xmsF/5tFixalqFN5t9iZYOeI5xKvEUGs97ib/WYGiZ/V/v378dZbb5kONa8lbBtr1qwxtSOhqlWrZtoFOw316tW758flHH6fqQQC8fHxgYwZM3IiIlC6dOlA+/btAx988EHgxx9/vOXt2b59eyBdunSBGjVqBC5fvpy4ff/+/YFcuXIFihYtGrh27Vridr6uVatWkn+Df6ddu3a3/NuzZs0yP1u5cmXitiFDhphtv/76a4p+v3///mbb1KlTk/zulClTzPaBAwfe8t9XqlQpybHs27cvkClTpkCLFi3uunls2bIlkC1btkDhwoUDBw8evO3vnT171vzt4CNLliyBLl26BM6dO5eiv/Pcc88FcufOnezP+H7z3+zRo0eS7f/+7/9utnft2jVxG99XbuP7HJSQkGC29evX75Z/+7XXXgvkyJEjcObMmdv+9yn57MKxPYS+H7/3SK7thPviiy+SbQf/+Z//abZPnDgxcduFCxcCN27cuOXfaNOmTSB9+vSBAwcOJG5jW+N/z7YT/r7+/e9/T/LfX716NfCv//qvgWLFiiX++8n99+HvQXKf5YABA275/aeeeipQtmzZwB/xH//xH8m+l//4xz8S3+dQFStWDDz++OOJn3v4sYceT7Vq1cz1ZMeOHYnbeH5Vrlz5lraS3Dkceuy8fvyRbXe73//1X/9lXo8dOzaQEmvWrDG/P2HChBT9fmqnNG9IL4s9OPa+2BubNWuW6Z0x1fXcc88lSQ2yt8942KdPnyTzF0wVsUfOdAtHPpHC0VP+/PlNZXIo9kq5nT8Px2MNPRb2Xtkz5WjubjBFy9ENRzZMh/7e6I/pr6+//hr/+3//bzP38swzz5gRCOeuU+Lo0aNJRlzJ4cgqFPeNaUCORn4PR1RMZbE9sMcf+uAIi5mI7777DvcS2xPfj5Q8+Lt3wpEW04ss6ArF1ywIa926dZLPIphe5RIjjmZ5rPw3OJJlgd7vYfEYR2GcPw99r5hu5qiPae67bUvhevXqdcs2pu85kkrp9EqoYBtgujMUj4FtJNTWrVvNCK1Vq1ZmxBt6jMy+ZMuWLTE9zFEz2wanF3gOBfH8+v/+v/8PD9Ld7DffS2JaPjjy/z2ckqGU/G5aoDRvCBbIBOdxGBCZ/uC8KFMcPDEYbHlCMI1ErPgNF9zG4MvgEAncP/5tXjBD8TVP7n/+85+3/DclSpRI9mTh+5BSvOjypGWqjMGRHZTfw5QcU2FBnTp1MmlZpqS4j3dK0fHi/3ul+UxrJRfMmf7ihZRpYF5MksN0M/9tLpO6ncOHD+NeYseNj3slGDCZZv/555/NZ89jZsqV8/sMtEFM8bEymoGW0wPh7+ud5rH5frGDEfpvJvd+hQaXu8FOYHglO3GKhcGPBTHszLL9sLqUqeY7FerwHGXqPrl9YhvhtE/o8dGQIUPM4/faQ7DjnVzbuZefb0rczX5znnTAgAFmSoRzq5wCeOGFF8y0RnJTKcE2cj/W47pIwfQ22LA4v8F5IJ6onFvgXCN7c/cTL2qRcLuK4LtZR8Y5Rs6zsfiDo+A/sg+8+L/55ptYvXq1OZHvdIHl3M/9wOPmRYKj5tu9N8GO0+9dTO7m82RGhPPWKREsersTtmEGUwbJkSNHmkDK0X/4/FfPnj0xefJkNG/e3FxQWXjCzgw7NZzzY0fpTu8XP48FCxbc9nfKly//h98vFjQlhx02dt7+4z/+w4yo+OA+8Fg5Wr1T5iKlgucBi7RuNz/Iwq0/4l61n3ux33zfWLPw5ZdfmkEEBxPjx483mRAWo4Vi9oL4uYuCaYoaOgtYGEyZTgodxf3www+mWCPUjz/+mOR3bocnebAxhkqu0vRue3782+xV80QMHZ3yNUcod9q3P4IXaY5s2IOdOnXqH/53gsEkufcmuYszswdMWQULs0IxxcglTeGjU/bWGSxuNyql0qVLm45BkSJFEgs5bid4wU7p53k7PXr0SHEFNYNhSu5AxOp0PpiGZREVg2qwOCnUvHnzzHQGi2RCcZSaEny/2LaqVq36u4VR9/L9CuLf43plPohFZiwO43Ks8BRuKJ4H7CRwv8OzTMERXejxJZdNSU6weGn79u23/Cx4fUjp+8EsU0qWfd3uGnE3+x36vnTv3t08WBDHVD+LCRmQed6Et41gJymt05zpbzgPlVwvkBf34JxCMEXDCxEbL3tsoeX3rEjlXCtHtU899dTvvvFMLXFeJXR+kKk0/vfhghenlAQYYtqL84nsVYZitSy3c97wXuIFghd3BjQGVVYD/x4eZ+it/4KYguQFkKk3VknfSfAWjazOvR0G+FCcL2ZH43ZrY4OC61xZ5Zzc0pDQFC/nChmwWSkdOpJnYLjT3Oz9nDMN4mfDdD1HbNxHjj5ZDRyKF9vwLAQ/j9Dq0DuNgBmYWFWanND3i8GGnbz//M//TPI78fHxv/tZJocdqXCsXk/J+cKpG+J5HIqfWWiKl3g+M2hw+iK5gM9rR/DvMdXNTgVrKxiog9jmk3s/g2nm8PeDldFcspQSvEbwvAr/DO9mv5kZCV9OxHYS7EyGp/r5WfFz/CPV/qmR0ry/YWEA12AyUHLulGklrrniBYgnBC8WwZsOsDiBPV721tib58UpuDSGKTQWr9zpRgpcc8a79nB+kBdujqIY7BiIw28QwROTmG5jGpQNnCfI7XqEvNByaQp750zT8YRiQRQDFff9bi7Ed8LOAAMTj5vLDH7vdoAcxTMtx9Ek08AcSXDpDYMRe+AcHe3bt8/M7fB9uBOmrfjfcr0pb0UYLhjceUFi4A0ujeHF7k73RuUIm7/DB+eOOG/EOTl2mDh3zr8Z2iHg58k0N29SwfeDf5MXMH5GGzduRCTmTIPYZviZs8iMAS88xUucY+QyB7ZljmAY/D7++OPEIpM7CS6H4ZIhtjl+Hnz/+Xmy08hRTPBizgs/l12xs8c2E/xs2JHkcp27Sd3zQs/zg9mj4OfD85Dzpbwz2O/hiIvFUcwGMKCwPTFlzPeBn9u2bdsSf5edZ7ZPnq/cR6ZCOZpl++exsZ1xrjG4dpypdR4XAw3Pw+DSmOQ67Dwn+Z7z7zIYsr1x/S87fjw/UrJelu/BF198Ydohl8Xx+sN95UgypfvNFDmLFnlecp/4ObGt83Pi+xtalMX9ZOaG79mdMhFpRqTLif2CZfJvvfWWKSPPmzdvIEOGDIE8efIEateuHZg5c2bg+vXrt/w3H374oVlS8tBDD5mlEnXr1g2sXr36lt9LbmkMjRs3LlCkSBGzBKVMmTLm79yuTJ7l6sWLFw9ERUUlKa2/3e8fOXIk8Oabbwb+5V/+xfw3fObxHT16NMnv3W1ZfrjgspC7Wc7xyy+/BDp27GiWNOTMmdPsX8GCBQOvvvqqWc5xN3iM/JxCl/WE7vvOnTsDDRo0MJ9P9uzZzf//7//+72SPIbmlLdyff/u3fzNLcPg5RUdHB+rVqxeYNm3aLUtAevfuHShUqJBpD1yysWzZsrtaGnM/8b0NLvtKzvnz5wO9evUy7ZH7X6pUqcCYMWMSl9GELvv4vaUtc+fODTz77LPm/ea/w8+gUaNGgUWLFt2yLIptgJ8dl0Txv1m3bt1tl8bcrh1yH2vWrBnInz9/4ufTpEkTs7QpJbgkqGfPnqb9Zc6c2Sxd4bUguf2g3bt3m2VV3B8ufeH+P/3004G+ffsG9u7dm+R3V61aZZbI8H0oUKCAOf+2bt2abFvjEjLuN983LitjG+OyvJQug+Hn16FDB/N3uJQp/JxOyX7v2rXL/A6vRdyPrFmzmv8/aNCgwKlTp5L8vW+//db8jbs9X1OzdPyfSAd0kT+KSy5YNckREauBReT+41QRM3fMuqia11IwFedxLSlTaEzH++G+pSKpGaeMeMtIpoV5VyqxFExFREQ8UjWviIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIyIO6A5LWEomISFoUSMHtGDQyFRERedD35uU3gvAej67i/W3Dv0rINa4fA7+smPcrDVKb8geX25XalD/9xeE2lVy7uqfBlIH0fn+n5/3EG3e7vP+p5RhCqU35Q2pqV2pT/pA3FbWpO1GaV0RExCMFUxEREY8UTEVERDxSMBUREfFIwVRERMQjBVMRERGPFExFREQ8UjAVERHxSMFURETEIwVTERERjxRMRUREPFIwFRER8UjBVERExPVgyi8dT+6RPXt2uGDHjh1o3bo1ypYti1y5ciFr1qwoU6YMevbsiYMHD8JlFy4AJUrwMwLeeQdOOXEC6NULKFUKyJwZyJ8fqFMHWLMGThg6dOhtzw0+MmbMCBecOweMHg1UqADkyAHkywdUrw7Mns0vXIYzDh8GunUDHn0UyJQJKFIE6NEDOHUKzhgzBmja9OY5XawYnPPzz8DgwUDVqvacZpuqVAkYNQo4fz6y+3bXX8F2P9SsWRNdunRJss2Vi8W+fftM0GzUqBGio6MRFRWFrVu34sMPP8SiRYuwefNmFChQAC5ioz16FM7ZsweoXdteyDt2BB57DDh9mt9NCOzfDyc0btwYpdgTSOb7FcePH4/Y2Fj43Y0bwMsvA/HxQLt2QPfutoO2cCHQvj3w00+AC191eeQIUKUKcOAA0LUrUL48sG0bMG0asHo1sG4dkDUrfK9/fyBPHuDpp93qBIT6+GN+/zHQoAHQujXjBLByJTBwILB4MbB+PZAlC9JuMC1RogTatGkDF73wwgvmEe65555Ds2bNMHv2bPTp0weu+ec/gffeA8aNA/78ZziFTenaNRs8H3kEzn4fJx/huvJqDnYSOsLvvv8eWLsWiIsDJk26uf2tt4AyZYC//92NYMqRNTtoCxYALVve3M4RdqtWwN/+Zi/mfrdzpx2VEjsE7Gy6pkkToF8/IFeum9uYMShd2o5OZ86MXBYt4mneoCtXruCci5/ubRQtWtQ8nzx5Eq65fh3o3BmoV48jJDiFIwVewNl/YSC9etWOhlKD8+fPm2wHMyD1+OH43Jkz9rlw4aTbmSZlujdbNjiBIx+Odlq0SLq9eXM7hTBrFpwQDKQue+aZpIE09LMgZgwixRfB9JNPPjFzjTly5DAp0e7du+M083IOuXTpEo4dO2bSvl999VXiCOKVV16BaziK2L4dmDIFzlm+3D5zTouZUF4EedFmqnf+fDhtyZIlOHPmDN544w1kyJABfhcTAzz8sM1uLFkC7N1r2xVHFgkJnBeGEy5ftkGT84yh0qe37WvXLuDYsUjtndC+feYJBQsiYiKe5o2JiUHTpk3N/BAvFMuXL8eUKVOwatUqxMfHO1OINGPGDNMJCCpWrBjmz59v5oNd8uuvwJAhdr6UBQq7d8MpO3bYZ46smfqZM4dZD2DiRKBtWztS5Xydi2bOnGmKjzp06AAX5M4NLFsGdOoENGt2czuLRj79FGjYEE4oV862q82bbbFLEF8HE0/sKHC0LZHJpI0YAURF2bR7mg2m33NiJcTrr79u5ooGDBiA999/3zy7oGHDhqaKl6nqTZs2YdmyZWak6hrOPzAd1LMnnHT27M0LNtNzTCkSL9w8LhZhsBiGowqXsGp87dq1Zn6+ePHicAX7wpyfY8EI5xhZZc0CEl70PvsMePFF+B7nfJcutR0C1hHweH74wW5nAUxqmkpwUVwc8N13dm778ccjtx++vKT07t0bmTJlwpdffglXcB6rbt26JqgOGzYMc+bMMYVHY1iP7gimQb/+2lYpOlJMfYtgJR8LRYKBNDhK4gX90KGbo1fXRqXUicM8R2zdagMoA+b48UCjRra6mnPahQrZ7AFHFX7H5NKiRbajVr8+6yHsFAKXWr36qv2dnDkjvZdp06BBdjqKi0E4fRBJvgymXBZTuHBhJ0d2QRxdP/XUU/jggw/gyrwQR6Oc4uWF7pdf7INVjMQpbL72e0l9dLR95jGEC1b2ulYTdu3aNcydOxd58+Y1S7Bcmnu/dMmubQzFZSQMSmxbrkwj8Bg4L7dpky1y4zKZ6dPtNqYXk1nFJPcZ59xHjrTTNvwsIi29X4t5WMhTMJKzyffAxYsXcYJ5LQdcvGjXlDIZwLnG4IPrNYOjVr6eMQO+L3oJLUgIFdzm2rLfzz//HIcPHzbLxx566CG4IrimN7nRJ5cuhT67gDVfnDPlSJVtiFkOBtdatdxYZ5raAumwYXbKhtek8OKwNBdMjx8/nuz2QYMGmd64CwvTD/GMSsbKlSuxbds2VOWtOhzAildWXIY/ggNrrsTga6ZK/Yxzo5wvZfAPXWnFm1Fx3otVva6NIoIpXhfWloZ64gn7zLsdhWJ2g/OlTL279lmE3pDi3XdtR8GRso5UY/hwG0hZUMibOPil/iGiBUgjR47E+vXrUadOHRQpUsQU77Cal4GoSpUqSapj/erNN980d0B6/vnnzdpSjqoTEhLMekAu9ZnIMlIHcI6UC6LDBdNwJUsm/3O/4QV6wgR7pxr2Y1j4ympezgPzefJkOOXAgQNYsWKFqXqvwHvyOVYYMncu0LevnT+tUcMWIH30ke3csBDJgRU+plPGjAcz7Kz94pQH7+LE5T28UQDnTl0wb97NaRtmoXg+ME1KnAdmcPK7qVPtagMufatb195IIxSTmZEqaotoMK1duzZ+/PFHU6zDUSrXzpUuXRqjRo0y97bNzMVdPteyZUsznzVv3jwcPXrULF1gUOU6UxZSsZMgDxaLEbhMgesbWaDAnmu1avbE4wXdJbyD1vXr150qPAriBXrDBjuS+OYbW8TDAjGmStnHdOWGICxke/JJ237YCWBKt3JlYMUK4KWX4AwmOFatSrqN5wcxVe1CMN248eZSJKZ4w/E40mQwfe2118zDZbxlIB+pFdeaunRD8iBeqF25WP+e/v37m4ermNHgWl+XMZhyJOq6b7+F82bPvnXawC98km0WERFxl4KpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh6lCwQCgRT9Yrp05rlGjRrIkycPXLVhwwbExMTAZa4fw4kTJ7Bu3brE12pT/uByu1Kb8qcNDrcpOn78OOLj45GiMBlIIf4qH2vWrAm4LDY2NuA614+BbSjYntSm/MPldqU25U+xDrep0HaVEkrzioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiOvBlF/q26tXL5QqVQqZM2dG/vz5UadOHaxZswYuGDqUX5x++0fGjHDCzz8DgwcDVasC+fMDOXIAlSoBo0YB58/DGWPGjEHTpk1RokQJ84X2xYoVg4sOHz6Mbt264dFHH0WmTJlQpEgR9OjRA6dOnYJL+Bkk98iePTtcsWMH0Lo1ULYskCsXkDUrUKYM0LMncPAgnHXhAlCihL1OvfMOnHHuHDB6NFChgr1O5csHVK8OzJ7NLx6N3H5FRe5PA3v27EHt2rVx7tw5dOzYEY899hhOnz6NLVu2YP/+/XBB48ZAqVK3bt+yBRg/HoiNhRM+/hiYOhVo0MBeONgJWLkSGDgQWLwYWL8eyJIFvte/f3/kyZMHTz/9tHOBJ+jIkSOoUqUKDhw4gK5du6J8+fLYtm0bpk2bhtWrV2PdunXIyiu6I2rWrIkuXbok2ZbRlV4mgH37bNBs1AiIjgaiooCtW4EPPwQWLQI2bwYKFIBz2Hk+ehROuXEDePllID4eaNcO6N7ddgoWLgTatwd++gkYOzYNBtM2bdrg2rVrJng+8sgjcFHFivYRrmtX+9yxI5zQpAnQr5/teQd16waULm1HpzNnutF73blzpxmVEoMQO2quGT16tOloLliwAC1btkzcXr16dbRq1Qp/+9vfMJC9HEfw8+C57qoXXrCPcM89BzRrZkdEffrAKf/8J/Dee8C4ccCf/wxnfP89sHYtEBcHTJp0c/tbb9lswd//HrlgGrE0L3vYa9euRZ8+fUwgvXr1Ki6wi5EKMC3KHit7sfXqwQnPPJM0kAY1b26ft22DE4KB1GUrV65ElixZ0KJFiyTbmzdvbqZCZs2aBddcuXLFyY7N7yla1D6fPAmnXL8OdO5sr03MrLnkzBn7XLhw0u2ZMtl0b7ZsiJiIBdPly5ebZ84FxcbGmotHtmzZTKp3/vz5cNmSJfZDf+MNIEMGOI0pLipYMNJ7knZcvnzZBE3OLYZKnz69OU927dqFY8eOwRWffPKJSUvnyJEDBQoUQPfu3c10jmsuXQL4tvOc+Oqrm9mnV16BUzii274dmDIFzomJAR5+2I6oeZ3du9ceC7NqCQm2hiVSIpbm3cFZfbCH1BmlS5fGnDlzTO914sSJaNu2rRmptmcS3EFMifI62KEDnMYe7IgRdo6oVatI703aUa5cOXN+bN68GZVYBfYbvj752zBo7969yMeuuM/FxMSYgjAWGJ45c8Z0oqdMmYJVq1YhPj7eqUKkGTPsHF0Qa9vY769ZE8749VdgyBA7X8r9370bTsmdG1i2DOjUyabYg1iI9OmnQMOGaTCYnj171jyzt8q0FisWqWHDhiZVx0KSdu3amd64S9hHYE6fcyzFi8NpnJf47jtbOff445Hem7QjLi4OS5cuRbNmzfDee++Zud8ffvjBbGfhjktTIt9zkivE66+/jooVK2LAgAF4//33zbMreKHmvByz1Zs22Yu6QwmCxDoIzoSwEtlV2bOzHsIWS7KK98QJWzzJDv9nnwEvvhiZ/YpYpGK6ilhgEQyklDt3bjRo0ACHDh1KHL26Niol9pxcNmiQTQOxCJMpFHmw1a+LFi0yHc769eujaNGiZiqES8ZeffVV8zs5c+Z09iPp3bu3Oee//PJLuIQ1EHXr2qA6bBgwZ44tPBozBk7gKPrrr4Fp09xZsheOVdQMoAyYXC3BCmsWeXIAU6iQnQtmRi1NBdNotkzwDSh0y8+Clb3BlJYrrl0D5s4F8ua1H7KrOO8wcqQtNZ8+PdJ7kzYxNbpv3z5s2rTJFOtxmcz06dPNtqioKJM2dRVH14ULF3Zq3jc5rOJ/6inggw/ge5cv29Eo53d5yf3lF/vYs8f+nFPYfO331WSTJtm566ZNk27nSrH69e3xRCp1nT6ScynEi0O44DYWK7jk88+52J5LfoCHHoKzgZS9bq7h4hxRWA2MPEAZMmQwc6YcqfJcYLaGwbVWrVpOrTMNd+nSJXOOF0wFVW0XL9o0owv7yTWlTAZwuVvwUbv2zVErX/Oc97P9v91+ILnRJwczoc9pJphybpTzpazcDS2ZP3jwoJkvYlWva73vYIrXlbWl4YYPt4G0bVt7EwfHpqtTtRs3buDdd9/F9evXnZlnPH78eLLbBw0aZNaXM3XtgkOHkt/Om5pwyRjvGuZ3XDLC6tfwR3BUzWUyfM15SD974gn7zLW9oTii5nwpC5QiFTYiVoDEudEJEyaYO7xUrVoVHTp0MNW8vMsLnydPngyXHDgArFhhS7d5myvXcAKfVX5Fith5oQULkv6cg4hITezfjXnz5pkbHtDRo0dNWxrJnLVZF1jUVIr7HTuXzNw0atQIxYsXN8tIFi5ciISEBIwaNcrMnbqA7/v69evN/nIJHI+L1bwsOOQdnrhExgVvvmnvgPT883ZtKdOMXIbBteSsIp04Eb7HOVLemCVcMCVasmTyP/djUeTcuUDfvnb+tEYNmxn46CP7GfE6FqnliBG9AxJvMcby/nHjxpneKit3q1WrZu78UoPvkkPYU2LqwdXCo40b7TPXbTHFG65WLTeC6cyZM82yi1BsW8T0qAvBlMU5Tz75pDkPmKlhSrdy5cpYsWIFXnrpJbiCtwr98ccfzbI3jlKZtuYyOHYIevbsadbSuoA3oeIFfN48myrl1AeDKteZ9u5tO6DyYPB937DBZtG++cZ2aFjLyhVk7NRE8iYUEQ2m1LhxY/NwXf/+9uEqdgbCUycu+vbbb+E6BlOORF332muvmYfruJ4xdE1jasK1ppG8OfwfwVE0K6n9RrNiIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuJRukAgEEjRL6ZLZ55r1KiBPHnywFUbNmxATEwMXOb6MZw4cQLr1q1LfK025Q8utyu1KX/a4HCbouPHjyM+Ph4pCpOBFOKv8rFmzZqAy2JjYwOuc/0Y2IaC7Ultyj9cbldqU/4U63CbCm1XKaE0r4iIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiLgcTMeMAZo2BUqU4JePA8WKwUmHDx9Gt27d8OijjyJTpkwoUqQIevTogVOnTsEl586dw+jRo1GhQgXkyJED+fLlQ/Xq1TF79uyUfTmuD+zYAbRuDZQtC+TKBWTNCpQpA/TsCRw8CGdduHDzPHnnHTjh55+BwYOBqlWB/PmBHDmASpWAUaOA8+fhFL7vyT2yZ4eTX6Teq1cvlCpVCpkzZ0b+/PlRp04drFmzBi4YOvT2nwcfGTNGZr+iEEH9+wN58gBPPw04FncSHTlyBFWqVMGBAwfQtWtXlC9fHtu2bcO0adOwevVqrFu3Dll5Rfe5Gzdu4OWXXzbfKt+uXTt0794dFy5cwMKFC9G+fXv89NNPGDt2LPxu3z4bNBs1AqKjgagoYOtW4MMPgUWLgM2bgQIF4BwGpaNH4ZSPPwamTgUaNLAdHF7kVq4EBg4EFi8G1q8HsmSBM2rWBLp0SbotUhfuP2rPnj2oXbu26Th37NgRjz32GE6fPo0tW7Zg//79cEHjxkCpUrdu37IFGD8eiI2NxF6l9CvE7bDEPPjN4/fKzp03/3+5coFA0aIB5775vUePHuZ9WbBgQZLtfM3tI0aMCLjw7fXx8fFmf+Pi4pJsv3z5cqB48eKBXLly3fNvr78fbep2Fi9mGw4Exo4NOPF5hEpICAQyZAgEJk60x/D22/fn79zr49i4MRA4derW7QMG2OOYPDngTJvi/rZrF3hg7lebevbZZwPR0dGBAwcOBB6E2Pt8boTq0sV+Tl98ce/bVUpENM3LtJXrVq5ciSxZsqBFixZJtjdv3tykUGbNmgUXnDlzxjwXLlw4yXamrZnuzZYtG1xWtKh9PnkSTrl+HejcGahXz/bIXfLMMzbVHq55c/u8bRucc+UKp0PgJGbK1q5diz59+uCRRx7B1atXTfYpNTh/3maemI3iuRIJKkDy6PLlyyZopmOyPvSNTZ/eBNldu3bh2LFj8LuYmBg8/PDDGDduHJYsWYK9e/di+/bt6NevHxISEjCUExUOuXQJ4NvOtO9XXwFdu9rtr7wCp0yaBGzfDkyZglSDnwkVLAinfPKJnYPn3C+nCrp3B06fhjOWL19unlnTERsba65P7CQz1Tt//ny4bMkSDgiAN94AMmRIg3OmqUG5cuWwY8cObN68GZVYXfEbvj752zCIgYmjOz/LnTs3li1bhk6dOqFZs2aJ21mI9Omnn6Jhw4ZwyYwZ9mIXxOI2Xi847+WKX38Fhgyx86Xc/9274TyOtEeMsHPZrVrBGTExtliSc3W8aDMusYOzahUQH+9GIRKvU9S5c2eULl0ac+bMwZUrVzBx4kS0bdvWjFRZH+GimTNt8VGHDpHbBwVTj+Li4rB06VITgN577z1TgPTDDz+Y7RkzZnQqlZI9e3az/w0aNDBVvKz6mzp1Klq1aoXPPvsML774IlzB2M8qXqbkNm0Cli2zI1WXdOtmp0JYiZxaxMUB330HjB4NPP44nPH990lfv/46ULEiMGAA8P779tnvzp49m9hB5vQUp3CIHeUSJUqgf//+pviQWTWX7NgBrF0LvPACULx45PbDrXfNh2rWrIlFixaZhlq/fn0ULVrUpFBYav7qq6+a38mZMyf8buvWrSaAMmCOHz8ejRo1MtV+nGMpVKiQ6c1e57DCEZw7qVvXBtVhw4A5c4A+fexyLBdwFP3118C0ae5VjN7OoEF2NMeK2H794LzevVlTAHz5JZzAtC61bNkyMZAGs1LsQB86dChx9OraqJQ6dUJEKZjeA02bNsW+ffuwadMmM8nPZTLTp08326Kiosx6Lr+bNGkSLl26ZI4lFJf1sJPAkvrdDucZOYp46inggw/ge5cv29Eo53cLFQJ++cU+9uyxP+c8HV+7tJyMU+4jRwLMIk6fHum9uTfYyWG9nisZj2j2MME2VeiWn7EgiYJTU664dg2YOxfIm9cuh4skBdN7JEOGDGbOlCPVAgUKmF4eg2utWrWcWGcaXGOW3OjzGltsyLOrLl7kgnU4sZ9cU8oRT+nSNx+1a98ctfI154VdCaTMDrRrZ/c5rFbPWSxyYzGVK4VULDIkdvLDBbfx2uWSzz/nTXOANm2Ahx6K7L4omN6nGyC8++67JjANcGEyBcATTzxhnnm3o1C8ixPnS5kKcmGEfehQ8tt5swAuxeDdePyOq5BYnRj+CI6qWfrP17wZgt8NH24Dadu29iYOjk3HGceP3z5tzf5lxG4ScJc4N8r5Ulbu8qYNQQcPHjR1H6zqdeEcTy7F27EjIi6iBUjz5t1MXbEnzjVcTAUF1wXyBPQ7Nkr2+DjHWLx4cXM3Ed41iMtJRo0aZeZOXcCCqblz56Jv375m/rRGjRqmAOmjjz4yJxsLkTj69rs337R3QHr+eduGOHpISLBr0LikYeJEOJE+bNLk1u3BLHvJksn/3G949yNWIxcpYuevFyxI+nOO6FyoaeM1iXdr4qnMY2EcYjUvO2hVqiStGvczdognTJhg7tRWtWpVdOjQwVTz8m5tfJ48eTJccuAAsGKFrbSuUCGNB1P2KlhaHt7bo1q13AimnMh/8sknsWDBAhN0mNKtXLkyVqxYgZdeegmuYOHUhg0bMHz4cHzzzTemqIoFC0xds3S+sSN3DGjZ0s6hsKPGDhpTigyqXGfKghFeDOXB2LjRPu/da1O84XiOuxBMmV7/8UdbxMZRKvuUTLPzHsOc286cGc7o0qWLWabH9eSDBg0ylbvVqlUz1y92oF0ye7ZdahXpwiNfBNNvv4XzGEw5Ek0NSpYsadaeuYxLZEOWyaYqXGvqyPcNJF7swmYNnPTaa/aRWrBj7Ern+E73dufDLxycwRAREfEXBVMRERGPFExFREQ8UjAVERHxSMFURETEIwVTERERjxRMRUREPFIwFRER8UjBVERExCMFUxEREY8UTEVERDxSMBUREfFIwVRERMQjBVMRERGPFExFREQ8UjAVERHxSMFURETEo6i7/Q+2bNkClx0/fhxr166Fy1w/hvA2pDblDy63q9TWpk6cOOHsZ5GajuNu2lG6QCAQSNEvpkvnZZ9ERESclJIwqTSviIiIRwqmIiIiD3rOdOrUqahYsSJc9Ze//AVjx46Fy1w/Bs5DvP3224mv1ab8weV2ldraVN++ffHXv/4Vruvr+HGEt6t7GkzZQJ999lm4Km/evE7vf2o5hlBqU/6QmtqV620qT548Tu9/ajuOlFCaV0RExCMFUxEREY8UTEVERDxSMBUREfFIwVRERMQjBVMRERGPFExFREQ8UjAVERHxSMFURETEIwVTERERjxRMRUREPFIwFRERcTmYnjt3DqNHj0aFChWQI0cO5MuXD9WrV8fs2bNT9GWsfsHvTU/ukT07nHL4MNCtG/Doo0CmTECRIkCPHsCpU3DG0KG3/zz4yJgRzjhx4gR69eqFUqVKIXPmzMifPz/q1KmDNWvWwBVjxgBNmwIlStj3v1gxpAoXLtw8pnfegRN+/hkYPBioWhXInx/IkQOoVAkYNQo4fx5O2LFjB1q3bo2yZcsiV65cyJo1K8qUKYOePXvi4MGDEd23u/7WmHvlxo0bePnllxEfH4927dqhe/fuuHDhAhYuXIj27dvjp59+curroGrWBLp0SbrNpQv3kSNAlSrAgQNA165A+fLAtm3AtGnA6tXAunVA1qzwvcaNgVKlbt2+ZQswfjwQGwsn7NmzB7Vr1zYdzo4dO+Kxxx7D6dOnzVdC7d+/H67o35/fHAI8/bRbnbI7YVA6ehRO+fhjfjUd0KAB0Lq1vT6tXAkMHAgsXgysXw9kyQJf27dvnwmajRo1QnR0NKKiorB161Z8+OGHWLRoETZv3owCBQpEZucCKcRf5WPNmjWBeyE+Pt78e3FxcUm2X758OVC8ePFArly5AvdDbGzsPf83+S62axd4YO7HMfToYY9jwYKk2/ma20eMuHd/i20o2J7uZZv6PV262OP44gs3Po9nn302EB0dHThw4EDgQbkfx7Fz583/X65cIFC0aOC+eJBtKiEhEMiQIRCYONG2qbffduOz2LgxEDh16tbtAwbY45g82Y3jSM7ixYvN5z527NjA/WhXKRGxNO+ZM2fMc+HChZNsz5Qpk0n3ZsuWDa65coWpaziJPVT2Slu0SLq9eXMgc2Zg1iw4iymsRYuA6GigXj343urVq7F27Vr06dMHjzzyCK5evWqyNi5iKjQ1uX4d6NzZtiNmQVzyzDNArly3buc5TsxEuapo0aLm+eTJkxHbh4gF05iYGDz88MMYN24clixZgr1792L79u3o168fEhISMJSTXw755BObBuU8BLMM3bsDp0/DGZcv26DJOaBQ6dPbILtrF3DsGJy0ZAk7b8AbbwAZMsD3li9fbp6LFCmC2NhYZMmSxXQumeqdP39+pHcvTZs0Cdi+HZgyBanGvn32uWBBOOPSpUs4duyYSft+9dVX6Mq5KQCvvPJK2pszzZ07N5YtW4ZOnTqhWbNmidtZiPTpp5+iYcOGcEVMjC2y4FwdL9q8FvJkW7UKiI93oxCpXDlO7gObN9uihCC+Dnb29u4F8uWDc2bOtJ2EDh3gTJEFde7cGaVLl8acOXNw5coVTJw4EW3btjUjVdYVyIP166/AkCF2vpSFVLt3p46R9ogRQFQU0KoVnDFjxgxTZxNUrFgx09GsyeKVtBZMKXv27ChfvjwaNGhgqnhZvTh16lS0atUKn332GV588UW44Pvvk75+/XWgYkVgwADg/ffts9/FxQFLlwLs17z3ni1A+uEHu52FClev2gpG1zAurV0LvPACULw4nHD27NnEjuXKlSvN1Aexg1miRAn079/fFO2lZ9pAHhhWujNt3bNn6nnTeX5/9x0wejTw+ONwRsOGDU0VLwv0Nm3aZAZmHKlGUsSCKSuwGEAnTZqEbmylv2nZsqUJsOyV79y5ExlcyMslo3dvYNgw4Msv3Qim7NBxXvHdd4H69e02vvWdOtlR6z/+AeTMCSdHpcTjcAXTusFzIRhIg9kcdjznzp1rRq9cHiAPBrPrX39tK9tdqtL/PYMG2QwaVyH06wenREdHm0cwsP7pT39C5cqVTW0BpwojIWJdWwZR5r2bMj8aguuG6tevb5YG7HY4j8ITjrVVLs0z8qPg/MmmTfaiwWUy06fbbUwDJbfkxM+uXQPmzgXy5gUaNYIzgheJQoUK3fIzFiRFutAirWE9AUejnI7jR/LLL/axZ4/9OWsj+NqlpT8sSRk5EuBsAc9x11WsWBFPPfUUPvjgg4jtQ8SCaXCt3HUm7cNc41Uw5NlFly7ZIOTSpH5wNMo5U45UWUh16JANrrVqubHONNTnn9sbUbRpAzz0EJzB4jxicUW44LaIraVLgy5etGtKmWUqXfrmo3btm6NWvp4xA84EUmbN2rWz+xxedOiqixcvmqnCNBdMn3jiCfPMux2FOnXqlJkvZUqLd37xu+PHb59CYV/AlZsEJOfGDZv2ZX/HhVT17VK8HTvCKUxbcb6UBRWcEwriYvWlS5eaql4Xzo3Ugqv0WBEe/ggOgrhMhq95MwS/Gz7cBtK2be1NHFybdj/E3n0yWFuwbds2VOXtndLanGlcXJyZ++nbt6+ZP61Ro4bpVXz00UfmosFCJBfmS5kq4Z1D6tSxt9/jtY/VvFy3yTsKhRSc+Rr3mwMipkNZqMPU1cKFQEKCvd0Yj88lTFGvWGGPqUIFOIUdyQkTJphyf14cOnToYKp5p02bZp4nT54MV8ybdzMdytEd12LznCEuDeRF3YUpmyZNbt0enIUqWTL5n/sN737EamRep+rWBRYsSPpzZtH8XvP55ptvmvjw/PPPm7WlnCrkUkre/YgdUFa8p7lgyjdiw4YNGD58OL755hvzZrDwolKlSuYNaezIimimen78EZgzx45SGf+Z8mEA4jwL1266gHUuTz5pTzDe4pIp3cqVbUB66SU4hwkPjqhdKjwK1aVLF3PzEq7DHjRokKncrVatGhYsWGA6ni5lB7hELDxrQ5w6cCGYphYbN95c4sYUbzh+Hn4Ppi1btjSDsHnz5uHo0aNIly6diSXsePbu3duszU6TS2NKlixp1tC57LXX7MN1DKYciaYWvCcsHy5jh9KVTuXtfPstUi2uNXXo+zhMBzNsVs05zZo1S3JfAj9xLGMuIiLiPwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHiULhAIBFL0i+nSmecaNWogT548cNWGDRsQExMDl7l+DCdOnMC6desSX6tN+YPL7er48eOIj49PfF29enXkzZsXrnL5s0hNxxFsVykKk4EU4q/ysWbNmoDLYmNjA65z/RjYhoLtSW3KP1xuV2pT/hTrcJsKbVcpoTSviIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHimYioiIpKZgeuHCBZQoUcJ8Efk777wDF/z8MzB4MFC1KpA/P5AjB1CpEjBqFHD+PJxz4gTQqxdQqhSQObM9pjp1gDVr4Ixz585h9OjRqFChAnLkyIF8+fKZL4uePXt2yr7k1yfSpUv+kT07nLBjxw60bt0aZcuWRa5cuZA1a1aUKVMGPXv2xMGDB+GKoUNv/1nwkTEjnHD4MNCtG/Doo0CmTECRIkCPHsCpU3DKmDFj0LRp08RYUaxYMfhBFHxk8ODBOHr0KFzy8cfA1KlAgwZA69b2xFq5Ehg4EFi8GFi/HsiSBU7YsweoXZvBCOjYEXjsMeD0aWDLFmD/fjjhxo0bePnllxEfH4927dqhe/fuppO2cOFCtG/fHj/99BPGjh0LV9SsCXTpknSbKxfvffv2maDZqFEjREdHIyoqClu3bsWHH36IRYsWYfPmzShQoAD8rnFj27kMx/Ni/HggNha+d+QIUKUKcOAA0LUrUL48sG0bMG0asHo1sG4dkDUrnNC/f3/kyZMHTz/9NE75qSeQ0m8c56/ywW8evx8SEhICGTJkCEycONH8nbffftuJb37fuDEQOHXq1u0DBvA9CwQmTw448+31zz4bCERHBwIHDgQeyLfX3482FR8fb/7NuLi4JNsvX74cKF68eCBXrlwBVz4Ptp927QIPzP06jnCLFy82n9HYsWOdaFO306WL/Yy++ML/n0WPHnZfFyxIup2vuX3EiIAzbWrnzp2J/79cuXKBokWLBu6XYLtKCV+kea9fv47OnTujXr16aMxuoEOeeQbIlevW7c2b22f2/lzA3unatUCfPsAjjwBXrzLtDuecOXPGPBcuXDjJ9kyZMpl0b7Zs2eCaK1dstiC1KFq0qHk+efIkXMUpnEWLgOhooF49+B6zZcyQtWhx63WK0zmzZsEZJUqUgB/5IphOmjQJ27dvx5QpU5Ba7NtnnwsWhBOWL7fPnEdh2oonHuMOU73z58MZMTExePjhhzFu3DgsWbIEe/fuNW2rX79+SEhIwFBOgDnkk09s+o1z8cyIdu9uU+8uuXTpEo4dO2bSvl999RW6Ms8I4JVXXoGrlixhxw144w0gQwb43uXLNmhyjjdU+vT2XN+1Czh2LFJ7lzpEfM70119/xZAhQ8x8KSeSd+/eDdddvw6MGAFERQGtWsEJO3bY586dgdKlgTlz7Iho4kSgbVs7Um3fHr6XO3duLFu2DJ06dUKzZs0St7MQ6dNPP0XDhg3hipgYoGlTO1/HCzc7POxvrloFxMe7U4g0Y8YMM3cdxPN8/vz5qMkJYUfNnGkDU4cOcEK5cvYc37zZFkgG8XUwQbB3L5AvX8R20XkRD6bdunUzw3ZW+KUWcXHAd98Bo0cDjz8OJ5w9a585AmJKiNV+xNjDrEr//kC7drYn63fZs2dH+fLl0aBBA1PFe+LECUydOhWtWrXCZ599hhdffBEu+P77pK9ffx2oWBEYMAB4/3377AJ2YFjFyyrrTZs2mc4OR6quYlDilMgLLwDFi8OZa9LSpQD7l++9ZwuQfvjBbmdBm6vTOn4S0WDK3unXX3+N1atXI6MrJYp3MGiQHT2wArNfPzgjWHHcsuXNQEq5c9tK5blz7UWkbFn4GqtFGUA5dcCOWlDLli1NgOXc/M6dO5HBhdxcMnr3BoYNA7780p1gykpePoKB9U9/+hMqV65sqqyZfndxVEqdOsEZTAJwjvfdd4H69e02ngI8Bo5a//EPIGfOSO+l2yI2zrh8+bIZjXLepFChQvjll1/MYw/XZ4DzQqfNa1+VPt8Bp+NGjrTp0OnT4ZTfrnUoVOjWn7EgiVyoF2EQ5Rwd16GF4hrH+vXrm/bl8lQC+5ysrXJ4YIeKFSviqaeewgcffADXXLtmO5Z58wKNGsEpPCVYy7Fpky045DIZXqe4jVNSyS3/EQeC6cWLF82a0i+//BKlS5dOfNTmQsffRq18zfkWVwIpRwxMhXKXwyf6XZifCy2cChXc5sCSQOz/bUEsK8TDXeOVMOTZRZcu2c/DlcK23zv/mX53zeef25sftGkDPPQQnMPRKOdMOVLl+XzokA2utWq5s87UryIWTLlEgdWW4Y9gb5XLZPia815+N3y4DaQs1OFNHFyYVwzHuVHOl7JyN3QZBm9Uw7kWVvW60HN94oknzDPvdhSKGQ7Ol7JAqZQDB3L8+O2nEdgXcOFGAYd4pU7GypUrsW3bNlTlbcMcTfHypiauu3HDpn3Z73RlysDPIjZnyjnSJk2a3LI9mIIrWbJksj/3G979aMgQu6Skbl1gwYKkP+cIwoV6F86NTphg747CaxyrFFnNyzuk8HnyZDghLi4Oc+fORd++fc38aY0aNcwI6KOPPjJ342EhkgvzpZwu4N2zeCtHti12cFjNy+Iw3skmpDjWt958803znj///PNmbSnT71yexLsfsbp6IkvFHcK06IoVNotToQKcwvbD/WZqmkVTXF61cCGQkGBvfcp25op58+YlTgcyu3nlyhWM5Anz2xrmthzVpMVqXtdt3HizrJwp3nBMn7gQTIlFUyyNHzfOjoA4wq5WzXYQatSAE3gybdiwAcOHD8c333xjLtxZsmRBpUqVzMXblZuCcLbjxx/tEiWOUhn/uWSJFz4WvnPNoN+x6IsdG178eNHjfVT5+XCdae/evVGEvQSHMNnBUZxLhUdBLCp88kl7LjPbxJRu5cq2c/DSS3DKzJkzsYrrw0IM4gXLXG9rKZiGrkFz6WbkPMHCMopOY6xxJN7cFrMacxiFHPbaa/bhMq7zDV3r6zouD+PDRQymHImmBt9++y38yMHZPREREX9RMBUREfFIwVRERMQjBVMRERGPFExFREQ8UjAVERHxSMFURETEIwVTERERjxRMRUREPFIwFRER8UjBVERExCMFUxEREY8UTEVERDxSMBUREfFIwVRERMQjBVMRERGPFExFREQ8UjAVERHxSMFURETEo3SBQCCQol9Ml84816hRA3ny5IGrNmzYgJiYGLjM9WM4ceIE1q1bl/habcofXG5Xx48fR3x8fOLr6tWrI2/evHCVy59FajqOYLtKUZgMpBB/lY81a9YEXBYbGxtwnevHwDYUbE9qU/7hcrtSm/KnWIfbVGi7SgmleUVERDxSMBUREfFIwVRERMQjBVMRERGPFExFREQ8UjAVERHxSMFURETEIwVTERERjxRMRUREPFIwFRER8UjBVERExCMFUxEREY8UTEVERDxSMBUREfFIwVRERMTlYDp06FDzpeO3e2TMmBEuGDMGaNoUKFGCX6IOFCsG5+zYAbRuDZQtC+TKBWTNCpQpA/TsCRw8CGccPgx06wY8+iiQKRNQpAjQowdw6hSc8fPPP2Pw4MGoWrUq8ufPjxw5cqBSpUoYNWoUzp8/D5dduHDzPHnnHTjj3Dlg9GigQgUgRw4gXz5+ATkweza/7BLO4Pue3CN7djjlxIkT6NWrF0qVKoXMmTOb86ROnTpYs2ZNxPYpKmJ/GUDjxo3NmxFuy5YtGD9+PGJjY+GC/v2BPHmAp59266Idat8+GzQbNQKio4GoKGDrVuDDD4FFi4DNm4ECBeBrR44AVaoABw4AXbsC5csD27YB06YBq1cD69bZToLfffzxx5g6dSoaNGiA1q1bm07lypUrMXDgQCxevBjr169HlixZ4KLBg4GjR+GUGzeAl18G4uOBdu2A7t1tp2DhQqB9e+Cnn4CxY+GMmjWBLl2SbnNk3GLs2bMHtWvXxrlz59CxY0c89thjOH36tIkb+/fvR5oMphUrVjSPcF15JQTMG+WCnTttb5t4AWcv1jUvvGAf4Z57DmjWzPbA+/SBr3HksGcPsGAB0LLlze0cQbRqBfztb8DAgfC9Jk2aoF+/fsjFFMFvunXrhtKlS5vR6cyZM/GOS8O63/zzn8B77wHjxgF//jOc8f33wNq1QFwcMGnSze1vvWWzN3//u1vBlNeqNm3grDZt2uDatWsmeD7yyCPwC9/NmTKNtWjRIkRHR6NevXpwQTCQpkZFi9rnkyfheytXAhywtWiRdHvz5kDmzMCsWXDCM888kySQBjXngYCj7W1wzfXrQOfOAE/pxo3hlDNn7HPhwkm3cxqB6d5s2eCcK1fc7PSvXr0aa9euRZ8+fUwgvXr1Ki4wTeADvgumS5YswZkzZ/DGG28gQ4YMkd6dNOfSJeDYMZv2/eormy6lV16B712+bIMm54BCpU9vg+yuXfbYXLWPHwqAggULwjUc0W3fDkyZAufExAAPP2xH1EuWAHv32mPp1w9ISGDtB5zyySd2uoNzv5y6Ydr69Gk4Yfny5ea5SJEiZhqQ0x3ZsmUzqd758+dHdN8imuZNDlNYLD7q0KFDpHclTZoxw55cQSymYhvlPIvflStnC6k4v1up0s3tfB0cWfNCyNGEa65fv44RI0YgKioKrZizdsivvwJDhtj5Uran3bvhlNy5gWXLgE6d7JRHEIPRp58CDRvCqY4BiyVZqsIRN2MTOzirVtk5Yb8XIu3gCQ5mOTqbaY85c+bgypUrmDhxItq2bWtGqu05kZ3WgynfKA7hX3jhBRQvXjzSu5Mm8cLAeSCmgDZtshcRV0ZznNNautRe8Dg3x/nrH36w21lgcfWqLRxxUVxcHL777juMHj0ajz/+OFzC6mpOhbAy3FUMMmxPDRrYOfgTJ4CpU+1c/GefAS++CGfmf0O9/jprV4ABA4D337fPfnb27FnzzAp3FuVlYq7dXLcaokSJEujfvz/atWuH9ExHpeU0L0el1IldQIkIVvLWrWuD6rBhwJw5tvCIy3/8jqNnVh7zfKtf3873siC8Th3g1Vft7+TMCecMGjQIU6ZMQZcuXUxhkkuY1fj6a1tR7VLFaChWtTOAMmCOH28r3lkbyaKkQoXsXDDnhF3Vu7ed//3yS/helt+q2Fu2bJkYSCl37tym+v3QoUOJo9c0G0xZnTV37lzkzZsXjdhaxRfYa33qKeCDD+AEprA4tchRNZfDcJnM9Ol2G5f7JLMSy9e4FnvkyJEmdTWdB+IQzmFzNMr5dgadX36xD1ZcE+fp+Nrvy8k438taAratUJx3ZKeNx+Na6joUOzksrnIhAxXN3j7Yngrd8rNgZe/JCFVL+iaYfv755zh8+LApe37ooYcivTsS4uJFm9ZyBevWOGfKkSoLLA4dssG1Vi031pmGBtJhw4aZtNWMGTNMLYFr7YZrSjniKV365qN27ZujVr7mPL2fBZcuJjf6vHYt6bOL2FFgZ9OFurYYTvqGFOOFCm4rEKEF8en9luJ1ZW1pasOAc7vlJlyJUbUqnMQF9+++ay+Efp8PCjV8+HATSFlUwZs4RGIOyCsuGWH1a/gjmOXgMhm+5jyknz3xhH3mWutQHFFzvpQFSi5kPI4fT377oEG2M+DCPXIaNmxo5ktZucubNgQdPHgQS5cuNVW9yd0IKM0UIB04cAArVqwwvY4KvF+XY+bNu5m6Yk+ca7hGjrSvOW/Xti1878037R2Qnn/e7jN7qyz75xwkqxYnToTv8dxix5WzBKxfYxqRd6nhcYwaZedOXcC7Hw0ZMsSU/9etWxcLeBeKEFwa86IDFS9MHzZpcuv2YEq0ZMnkf+43LGCbOxfo29fOn9aoYTM1H31kzxkWIrmwio/XpPXr7XnA22zyfGE1LzvMvHNYaBW/X+XOnRsTJkwwN/bh7Ta56oPVvNOmTTPPkydPjti++SKYzp4925T+u1p4xEE1S8vDe3vE1KILwZR3DOIFgx0DdgiYUWRQ5TpTFijw5PM71iM8+aS9AxIvckzpVq4MrFgBvPQSnLFx40bzvHfvXpPiDVerVi0ngmlqwfNgwwZmC4BvvrEdTNbBcCqBnUxXbkLB9PqPP9qiQo5S2QFgmp0dTc5tc422C7p06YJ8+fJh3LhxpjiPWZtq1aqZTmcN9nTScjBlOTMfrvr2WziPy0lC19C5iMGUI1HXsXPJR2rFtaYu3Rw+OIpmEHLZa6/ZR2rQuHFj8/AT9yZiREREfEbBVERExCMFUxEREY8UTEVERDxSMBUREfFIwVRERMQjBVMRERGPFExFREQ8UjAVERHxSMFURETEIwVTERERjxRMRUREPFIwFRER8UjBVERExCMFUxEREY8UTEVERDxSMBUREfEo6m7/gy1btsBlx48fx9q1a+Ey148hvA253qZOnDjh9OeRGo5DbcqfTjjcpu722pQuEAgEUvSL6dJ52ScREREnpSRMKs0rIiLikYKpiIiIR3c9Zzp16lRUrFgRrvrLX/6CsWPHwmWuHwPnId5+++1U06b69u2Lv/71r3Cdy8ehNuVPfR1uU8m1q3saTHnRe/bZZ+GqvHnzOr3/qeUYUlObypMnj9P7n9qOg9Sm/CFPKmpTd6I0r4iIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiMvB9PBhoFs34NFHgUyZgCJFgB49gFOn4JwTJ06gV69eKFWqFDJnzoz8+fOjTp06WLNmDVwxZgzQtClQogSQLh1QrBicxH1P7pE9O5ywYwfQujVQtiyQKxeQNStQpgzQsydw8CCcMXTo7T8LPjJmhBN+/vlnDB48GFWrVjXndY4cOVCpUiWMGjUK58+fh0vOnTuH0aNHo0KFCuY48uXLh+rVq2P27NkIBAJw0YULN69Z77wTuf24669gu1eOHAGqVAEOHAC6dgXKlwe2bQOmTQNWrwbWrbMXERfs2bMHtWvXNg21Y8eOeOyxx3D69GnzXXj79++HK/r351cmAU8/7WaHJlTNmkCXLkm3uXLx3rfPBs1GjYDoaCAqCti6FfjwQ2DRImDzZqBAAfhe48ZAqVK3bt+yBRg/HoiNhRM+/vhj8527DRo0QOvWrZExY0asXLkSAwcOxOLFi7F+/XpkyZIFfnfjxg28/PLLiI+PR7t27dC9e3dcuHABCxcuRPv27fHTTz85+T3JgwcDR49Gei8A9kZShL/Kx5o1awL3Qo8e/DcDgQULkm7na24fMSJwX8TGxt7zf/PZZ58NREdHBw4cOBB4EO7HMdDOnTf/f7lygUDRovflz5g2FGxP97JNBbH9tGsXeGDu1+cRbvFie2xjx7p9HF262OP44gs32tTGjRsDp06dumX7gAEDzN+aPHlywIXPIj4+3uxvXFxcku2XL18OFC9ePJArVy7n2lRCQiCQIUMgMHGibVNvv31v//1gu0qJiKV5V64E2Jlr0SLp9ubNgcyZgVmz4ITVq1dj7dq16NOnDx555BFcvXrV9PZcxFRJanLlCtNaSDWKFrXPJ0/CWcyKcnTNEXe9enDCM888g1zMt4dpzosVmFHbBhecOXPGPBcuXDjJ9kyZMpl0b7Zs2eCS69eBzp1tO2IWJNIiFkwvX7ZBk3nuJDuU3gbZXbuAY8fge8uXLzfPRYoUQWxsrEn3sFEy1Tt//vxI716a9ckndpogRw6bEu3eHTh9Gk65dMmeA0z7fvWVnQ6hV16Bs5Ys4UUdeOMNIEMGOG0fPxgABQsWhAtiYmLw8MMPY9y4cViyZAn27t2L7du3o1+/fkhISMBQTnI7ZNIkYPt2YMoU+ELE5kzLlbOFFpz/qVTp5na+Dva89+4F8uWDr+3gQYA9pM4oXbo05syZgytXrmDixIlo27atGalyPkIenJgYW0jF+TpeuNnf4Qm3ahUQH+9OIdKMGbYTEMSCMPbPOB/sqpkzbQe6Qwc47fr16xgxYgSioqLQqlUruCB37txYtmwZOnXqhGbNmiVuZyHSp59+ioYNG8IVv/4KDBli50t5XuzenYaDaVwcsHQpwM/0vfdsAdIPP9jtLBS5etVWafnd2bNnExskixKYMiE2zBIlSqB///5msj89h9zyQHz/fdLXr78OVKwIDBgAvP++fXYBr22s4mWqetMmYNkyN7I1t8N+59q1wAsvAMWLw2lxcXH47rvvTGXs448/Dldkz54d5cuXN8VUrOLlKgQWV7FD8Nlnn+HFF1+EC7p1s9NSrHD3i4hd4dm75twJY1H9+nY+iNV9deoAr75qfydnTvhesIqvZcuWiYE02Atkgz106FDi6FUip3dvu/zqyy/d+RQ4r1i3rg2qw4YBc+YAffrYJUyujkqpUyc4bdCgQZgyZQq6dOliUqSu2Lp1qwmgDJjjx49Ho0aNzOoD1nwUKlTIZNc44va7+fOBr7+2Kz/8VKEf0eESU3GcdmCvm8thuExm+nS7jcsBkiur95toXvEA0xjDsSCJTrpcMZJK8KRj3YXLIzuOrp96CvjgAzjn2jVg7lwgb1675MdVnFccOXKkmbqZzouVQyZNmoRLly6hKS+8IbJmzYr69eubJX67/ZAvvUOtDUejrBvgJfeXX+xjzx77c9ZF8HUklvZFPPfIIgTOmXKkykKRQ4dscK1Vy411ppzUDy1GCBXcVsCFRYGpHIt5+HE4UityWxcv8gYhcM7nn9ubtLRpAzz0EJwNpMOGDTPTNjNmzEC68OpJnwuueU9u9HmNvZ2QZz+3/6NHbYapdOmbj9q1b45a+Zr1BmkumIa6cQN4911b8uzOvFZDM1/Kyl3etCHo4MGDWLp0qanq5V2R5ME4fjz57YMG2dGRCzcKYIfydsvJuAqjalU4m+Lt2BFOGj58uAmkLCrkTRxcrIF44oknzDPvdhTq1KlTZr6UU1N+v1Zly2YrwsMfwWwNl8nwdYMGaagAiXGHgzqmfFiMwOH5woVAQgIwapSdO3UBG+CECRPQtWtXc7uxDh06mGreadOmmefJkyfDFfPm3UyXsPfHdZojR9rXnNNu2xa+x/1dv962H96eku2M1bwMRLzjVmh1rF+9+aa9A9Lzz9v3naNqnhesMeBSn4kT4RRO36xYYc/3ChXgHBboDBkyxCx/q1u3LhYsWJDk51wa40LhDoum5s6di759+5r50xo1apgCpI8++sh0/nmcGXy+XiljRqBJk1u3B7PTJUsm//NUHUxZDPLkkwDbJS8cTOlWrmxPupdeglNYiMBFz1y/xeIE9lqrVatmTjo2WJdGD1w+Ej6iI6bdXQimTPf8+KMt1uEoldcGpn3YQeNcC9c2+13LlnZ+kZ0bdmqYTWRQ5TpTFlKxk+ASDoSYbXK18Gjjxo3mmesymeINV6tWLSeCadGiRbFhwwYzyv7mm2+waNEiU0DJ+wxzKV9jP9z5wGERDaYciaYWbIiuN8Zvv4XzXnvNPlzG5WIhywCdx3s+8+EqpkXDU6OuKlmypFkLn9oUK8Z7/kV2H9xL/IuIiPiMgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHqULBAKBFP1iunTmuUaNGsiTJw9ctWHDBsTExMBlrh/D8ePHER8fn/i6evXqyJs3L1zl+ueRGo5DbcqfNjjcpkLbVYrCZCCF+Kt8rFmzJuCy2NjYgOtcPwa2oWB7UpvyD5fbldqUP8U63KZC21VKKM0rIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIq8H055+BwYOBqlWB/PmBHDmASpWAUaOA8+fhlHPngNGjgQoV7HHky8fv6ARmz+Z398AJQ4fyO2tv/8iYEU66cOECSpQoYb6P95133oErxowZg6ZNmybue7FixeCiw4cPo1u3bnj00UeRKVMmFClSBD169MCpU6fgmhMngF69gFKlgMyZ7XWrTh1gzRo4YccOoHVroGxZIFcuIGtWoEwZoGdP4OBBOCNdunTJPrJnzx7R/YqK1B/++GNg6lSgQQP7AfNivXIlMHAgsHgxsH49kCULfO/GDeDllwF+13W7dkD37ryAAwsXAu3bAz/9BIwdC99r3NheJMJt2QKMHw/ExsJJgwcPxtGjR+Ga/v37I0+ePHj66aedDDx05MgRVKlSBQcOHEDXrl1Rvnx5bNu2DdOmTcPq1auxbt06ZOUV3QF79gC1a9uOc8eOwGOPAadP2/Nj/344Yd8+GzQbNQKio4GoKGDrVuDDD4FFi4DNm4ECBeCEmjVrokuXLkm2ZYxwjz9iwbRJE6BfP9tDCurWDShd2o5OZ84EXBhIfP89sHYtEBcHTJp0c/tbb9le39//7kYwrVjRPsJ17WqfeQFxzT//+U+89957GDduHP785z/DJTt37jSjUmIQOseruGNGjx6NPXv2YMGCBWjZsmXi9urVq6NVq1b429/+hoHsPTugTRvg2jUbPB95BE564QX7CPfcc0CzZjaT1qcPnFCiRAm04YfiIxFL8z7zTNJAGtS8uX3etg1OOHPGPhcunHR7pkw23ZstG5zFdDt7rOzF1qsHp1y/fh2dO3dGvXr10JjDbscEA6nLVq5ciSxZsqBFixZJtjdv3hyZM2fGrFmz4ILVq22HmYGGgfTqVZt9Si2KFrXPJ0/CKVeuXPFVJzO9H1MRVLAgnBATAzz8MDBuHLBkCbB3L7B9ux11JyTYuUhX8XjYWXjjDSBDBjhl0qRJ2L59O6ZMmRLpXUmzLl++bIIm57NCpU+f3gTZXbt24dixY/C75cvtc5EidrqD00/sJDPVO38+nHPpEsC3ndfar766mX165RU445NPPjFTBDly5ECBAgXQvXt3nGbePS2meZNz/TowYoTN5bdqBSfkzg0sWwZ06mRTJUEsRPr0U6BhQziLqXZeBzt0gFN+/fVXDBkyxMyXsnBn9+7dkd6lNKlcuXLYsWMHNm/ejEqsLvwNX5/8bRi0d+9e5GMKx+eFO9S5s52GmjOHoyJg4kSgbVs7UmV9hCtmzLC1HUGsbWOnoGZNOCEmJsYU55UqVQpnzpzB8uXLTad51apViI+Pj1ghkq+CKecdv/vOVsY+/nik9ybl+NmVL2+LqVjFy6o/FlexQ/DZZ8CLL8I5vIAwtcU5luLF4RRWjzJN2pNlihIxcXFxWLp0KZo1a2bmrjn3+8MPP5jtLBa5evWqqbb2u7Nnb3aQWSTJKRxiR5nZ+P79bfFhet/l+ZLH/WY9BzOkmzbZwYADCYJE37NQJcTrr7+OihUrYsCAAXj//ffNcyT45uMfNAhgRo4FWkyRuoLVcAygDJisemWlHIt1GIgKFbK9WY64XRyVEkfcLpk/fz6+/vprUzEa6eq+tI4Vl4sWLcLZs2dRv359FC1aFLGxsahTpw5effVV8zs5c+aE3wVXFbCGKhhIg1kpdqAPHbo5enUBayDq1rVBddgwO9LmfPCYMXBW7969zdKrL7/8MmL74ItgynnFkSNtqmT6dDiFFbycg2jaNOl2VvzXr29L6l3LMrJqce5cIG9e2zlwaY6Oo9FXXnkFhQoVwi+//GIerCglzqnwtatLTVzEdNy+ffuwadMmsxyGy2SmT59utkVFRZlUnQvBh9g5Dhes7HWteCcUq/ifegr44AM4K2PGjChcuHBE5+DT+yGQsnfENAlz+WG1Cr4XXGOW3OiTQSn02RWff87F9nY5wEMPwRkXL140a0rZOy1dunTiozYXCP42auXrGWxo8sBkyJDBzJlypMpikUOHDpngWqtWLSfWmbLIMLQ4MlRwmyvrM2/n4kU7PeWqS5cumQ5awQhWrkZ0znT4cBtIOYnPmzi4MucQ6oknbEVc+BotDn44X8pUkAOd72RTvK6tLc2WLRuWsAQ5DAPsW2+9ZZbJdOzY0cyvSGTcuHED7777rlm6FKm5rbvFdGiPHrZIh8tig/UtvAHC0qW2qteFc5zp6ORG15wH5lLE3/qcvnb8+HHkZcoszKBBg3Dt2jUzjZDmgikLdIYMseXmzN8vWJD05+xguFC4w6IppkT79rXzpzVq2B7eRx/Zk43H6dKykgMHgBUrbG+ct0d0LdXThHcDCROs5i1ZsmSyP/ejefPmJaan2RngmrqRnAsx6wKLoi17oD7HNYCsvGzUqBGKFy9u0uwLFy5EQkICRo0aZeZOXcAO8YQJdgkJb3/K6nZW806bZp8nT4YT3nzTXpOef96uLeX0FJfvcS05i6tYnex3I0eOxPr1603b4a0p2cZYzcs1zbzbFpfIpLlgunGjfea6TKZ4w9Wq5UYwZaPcsMGOsr/5xjZMFixwJQAbp2v3C+AImylr1wqPUpuZM2eaUv/w3jcxPepCMGVByJNPPmnugHTw4EGT0q1cuTJWrFiBl156CS5hYSRX8HA9OT8GZtGqVbODAHagXcACKnb8581jB81OqfH6xU5C7952YON3tWvXxo8//og5c+aYUSqnEDh1w84Z6yW4rjnNBVNetPlIDUqWtBVxqQHL/PlITbjWNODKNw785ttvv4XrGEw5Ek0t2DF2rXMciuvgQ9fCu+i1114zDz9ycJZSRETEXxRMRUREPFIwFRER8UjBVERExCMFUxEREY8UTEVERDxSMBUREfFIwVRERMQjBVMRERGPFExFREQ8UjAVERHxSMFURETEIwVTERERjxRMRUREPFIwFRER8UjBVERExCMFUxEREY8UTEVERDxSMBUREfEoXSAQCKToF9OlM881atRAnjx54KoNGzYgJiYGLnP9GI4fP474+PjE19WrV0fevHnhKtc/j9RwHGpT/rTB4TYV2q5SFCYDKcRf5WPNmjUBl8XGxgZc5/oxsA0F25PalH+43K7Upvwp1uE2FdquUkJpXhEREY8UTEVERDxSMBUREfFIwVRERMQjBVMRERGPFExFREQ8UjAVERHxSMFURETEIwVTERERjxRMRUREPFIwFRER8UjBVERExCMFUxEREY8UTEVERDxSMBUREXE1mO7YAbRuDZQtC+TKBWTNCpQpA/TsCRw8CKdduACUKMEvVAfeeQfO4P4m98ieHc74+Wdg8GCgalUgf34gRw6gUiVg1Cjg/Hk449y5cxg9ejQqVKiAHDlyIF++fOZL1GfPnp2yLyr2kRMngF69gFKlgMyZ7edSpw6wZg2cMWYM0LTpzfO6WDE4Z+jQoUiXLt1tHxkzZoQLDh8+jG7duuHRRx9FpkyZUKRIEfTo0QOnTp2K6H5FReoP79tng2ajRkB0NBAVBWzdCnz4IbBoEbB5M1CgAJzEi/nRo3BSzZpAly5JtzlyjhkffwxMnQo0aGA7a9z3lSuBgQOBxYuB9euBLFngazdu3MDLL7+M+Ph4tGvXDt27d8eFCxewcOFCtG/fHj/99BPGjh0LF+zZA9Suzc4B0LEj8NhjwOnTwJYtwP79cEb//kCePMDTTwMRvmb/YY0bN0Yp9mjCbNmyBePHj0dsbCz87siRI6hSpQoOHDiArl27onz58ti2bRumTZuG1atXY926dcjKkVkkpPQbx/mrfPCbx++nxYv5twKBsWPd/Ob3hIRAIEOGQGDiRHscb7/tzjFwf9u1Czywb6+/H21q48ZA4NSpW7cPGGCPb/LkgO8/j/j4ePO+xMXFJdl++fLlQPHixQO5cuUK3A/3o109+2wgEB0dCBw4EHC2TdHOnTf/f7lygUDRooH76n5fp0J16dLFvGdffPGF74+jR48eZl8XLFiQZDtfc/uIESPuS7tKCd/NmRYtap9PnoRzrl8HOncG6tVjLxDOunLFjiRc9MwzdtogXPPm9nnbNvjemTNnzHPhwoWTbGdKi+nebNmywQWrVwNr1wJ9+gCPPAJcvWqnQFzE9G5qdP78eSxatAjR0dGoxwuXz61cuRJZsmRBixYtkmxv3rw5MmfOjFmzZkVs3yIeTC9dAo4ds2nfr74Cuna12195Bc6ZNAnYvh2YMgXO+uQTO3/NuUam2bt3t2k517F9UcGC8L2YmBg8/PDDGDduHJYsWYK9e/di+/bt6NevHxISEszclwuWL7fPRYoAzCAyvc5+AFO98+dHeu+E2L7YeXvjjTeQIUMG378ply9fNkGTc7yh0qdPb4Lsrl27cIwBJS3NmQbNmGEv2EGc2OeJxrk7l/z6KzBkiJ0v5THs3g3nxMTYIgtOq3BwxIshOwarVgHx8W4VIoVnDEaMsPPyrVrB93Lnzo1ly5ahU6dOaNasWeJ2FiJ9+umnaNiwIVzAIkNitqZ0aWDOHJv1mDgRaNvWjlTbt4/0XqZtM2fONIGpQ4cOcEG5cuWwY8cObN68GZVYWfgbvj75WzqTnU9mcNJcMOV1gVW8TCtu2gQsW2ZHqq7p1s2mgliN7Krvv0/6+vXXgYoVgQEDgPfft88uiosDvvsOGD0aePxxOCF79uymuKJBgwamivfEiROYOnUqWrVqhc8++wwvvvgi/O7sWfvMLAeLwDJlunnO81xhUU+7dhxVRHQ30ywGpbVr1+KFF15A8eLF4YK4uDgsXbrUdDLfe+89c4788MMPZjurka9evWqK9SIh4s2Ylbx169oTbNgw23vlHAtL0V3BkfTXXwPTprlV+ZoSvXvbi+CXX8JJgwbZ0TUrlPv1gxO2bt1qAigDJqssGzVqhI4dO5oLX6FChdC5c2dc53Db54JV0y1b3gyklDu3rbY+dOjm6FUiMyolZkBcUbNmTTPHe/bsWdSvXx9FixY1Vch16tTBq6++an4nZ86caTOYhuNI6KmngA8+gBMuX7ajUc7xFioE/PKLfXBJAHG+ka9dLadn54B1MC5mCzi1OHKkTSVOnw5nTJo0CZcuXUJT5txDsOSfF5A9e/ZgtwPzCOwoE8+LcCxIcrXQMDW4du0a5s6di7x585rOmkuaNm2Kffv2YdOmTWY5DJfJTJ8+3WyLiopKdvlPmgymdPGiXejtAu4r15Ry5MZ5oeCDa+uCo1a+5tywi1ggxuIdFwp3wgMpMx1MI/K9D6tX8LX9vy3ATG70yYtg6LPf5+BDi79CBbe5upbcdZ9//rm5+UGbNm3w0EMPwTUZMmQwc6YcqRYoUACHDh0ywbVWrVoRW2casWDKFE9yOLfC5Qu8g40LWJ24ZMmtj+DImtXmfM20lp8dP377NCmv2w6s5040fLgNpCxy4U0cXJuTe+KJJ8wz73YUind44XwpC5Qi1fu+G5y64XwpO5ShS614s5alS21VrwOHkapTvJw+cN2NGzfw7rvvms7ngAgWdkSsAOnNN+1J9fzzdm0pR0AJCfbuRzwBWfHnShq0SZNbtwezcCVLJv9zv2E6lHcH4m3euJSBFz9W87JzU6VK0oprP+Pdj1hVzWPgXPyCBUl/zhG232t3WEzBFFzfvn3N/GmNGjVMAdJHH32EgwcPmkIkF5YxcG50wgS73I2dYxaMspqXtQV8njwZzpg37+bUDTNR3H+eM8TrFzturmBadMWKFWYJFm9X6ZJz586Z/WZqmkVTp0+fNncG45KxUaNGmbnTNBdMWZQwd65tpGycTMOxUfLEY9ELL4by4DAt/eOPtgCMo1Req5me5j1tOSfMe6q6YONG+7x3r03xhqtVy//BlEUVGzZswPDhw/HNN9+YgguuoWNaa+LEiea2cK5g4RdXKYwbZ7MczBJUq2Y7OTVqwBkcyHGJWCgeT7BNuRRMmfHgKM6lwqPQG5c8+eSTWLBggelYMqVbuXJl0zl46aWXEEkRC6ZcPheyhC7V4VpTl+5H/tpr9uE6ZkbDsqNOKlmyJOawZ5MKMPY7FP+T9e23SDX69+9vHi7KlCmTGYn6kWOzSSIiIv6jYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4pGAqIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIuKRgqmIiIhHCqYiIiIeKZiKiIh4FHW3/8GWLVvgshMnTmDt2rVwmevHEN6G1Kb8weV2pTblTyccblN3e21KFwgEAin6xXTpvOyTiIiIk1ISJlM8Mk1hzBUREUlzNGcqIiLikYKpiIiIRwqmIiIiHimYioiIeKRgKiIi4pGCqYiIiEcKpiIiIh4pmIqIiHikYCoiIgJv/n8xEkc8XPEgywAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 500x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def plot_sudoku(grid: List[List[int]], title: str = \"Sudoku\",\n",
+    "                initial: Optional[List[List[int]]] = None):\n",
+    "    \"\"\"Affiche une grille 9x9 avec matplotlib.\n",
+    "\n",
+    "    Args:\n",
+    "        grid: Grille 9x9 a afficher.\n",
+    "        title: Titre du graphique.\n",
+    "        initial: Grille initiale (0 = vide). Si fournie, les cases ou\n",
+    "                 initial[r][c] == 0 (resolues par le solveur) sont affichees\n",
+    "                 en bleu, les indices donnes en noir.\n",
+    "    \"\"\"\n",
+    "    fig, ax = plt.subplots(figsize=(5, 5))\n",
+    "    ax.set_xlim(0, 9)\n",
+    "    ax.set_ylim(0, 9)\n",
+    "    ax.set_aspect('equal')\n",
+    "    ax.axis('off')\n",
+    "    ax.set_title(title, fontsize=13)\n",
+    "\n",
+    "    # Lignes : epaisses sur les separateurs de blocs 3x3\n",
+    "    for i in range(10):\n",
+    "        lw = 2.5 if i % 3 == 0 else 0.5\n",
+    "        ax.axhline(i, color='black', linewidth=lw)\n",
+    "        ax.axvline(i, color='black', linewidth=lw)\n",
+    "\n",
+    "    # Valeurs\n",
+    "    for r in range(9):\n",
+    "        for c in range(9):\n",
+    "            val = grid[r][c]\n",
+    "            if val != 0:\n",
+    "                if initial is not None and initial[r][c] == 0:\n",
+    "                    color = 'blue'   # valeur ajoutee par le solveur\n",
+    "                else:\n",
+    "                    color = 'black'  # indice donne\n",
+    "                ax.text(c + 0.5, 8.5 - r, str(val),\n",
+    "                        ha='center', va='center', fontsize=13, color=color)\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "\n",
+    "# Puzzle initial : tout en noir (indices)\n",
+    "plot_sudoku(puzzle_facile, \"Puzzle initial (indices)\")\n",
+    "\n",
+    "# Solution : indices en noir, valeurs deduites en bleu\n",
+    "plot_sudoku(solution_facile, \"Solution Z3 (bleu = valeurs deduites)\", puzzle_facile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb02-viz-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01045,
+     "end_time": "2026-06-13T00:07:43.935805+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:43.925355+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : declaratif vs imperatif\n",
+    "\n",
+    "La visualisation met en evidence la difference fondamentale d'approche.\n",
+    "\n",
+    "| Aspect | Backtracking (serie Sudoku) | Z3 declaratif (ce notebook) |\n",
+    "|--------|------------------------------|------------------------------|\n",
+    "| **Ce qu'on ecrit** | L'algorithme de recherche (DFS, retour-arriere) | Les regles du jeu (`Distinct`, domaines) |\n",
+    "| **Strategie** | MRV, elagage, heuristiques codees a la main | Deleguee au solveur |\n",
+    "| **Adaptation** | Reecrire l'algorithme pour chaque variante | Ajouter une contrainte |\n",
+    "| **Lecture du code** | Comment on explore | Ce qu'on veut obtenir |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. En bleu apparaissent les valeurs que Z3 a deduites : aucun retour-arriere manuel.\n",
+    "2. Ajouter une regle (anti-diagonale, variante X-Sudoku) se resume a **une contrainte supplementaire**.\n",
+    "3. Le cout : on perd le controle fin sur la strategie de recherche (mais Z3 est tres optimise).\n",
+    "\n",
+    "> **Note technique** : Z3 combine en interne resolution SAT, propagation et theories arithmetiques. Sur le Sudoku (instance petite), la resolution est quasi instantanee (< 10 ms)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb02-ex1-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012409,
+     "end_time": "2026-06-13T00:07:43.961752+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:43.949343+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : Variante anti-diagonale\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Certains Sudokus imposent une regle supplementaire : l'**anti-diagonale** (du coin haut-droit au coin bas-gauche) doit elle aussi contenir les chiffres 1 a 9 sans repetition.\n",
+    "\n",
+    "Modifiez la fonction de resolution pour ajouter cette contrainte et resoudre le puzzle facile.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- L'anti-diagonale correspond aux cases `(r, 8 - r)` pour `r` de 0 a 8.\n",
+    "- Ajoutez un `Distinct([cellules[r][8 - r] for r in range(9)])`.\n",
+    "- Attention : selon le puzzle, cette contrainte supplementaire peut le rendre `unsat`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "nb02-ex1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:43.990092Z",
+     "iopub.status.busy": "2026-06-13T00:07:43.989576Z",
+     "iopub.status.idle": "2026-06-13T00:07:44.003491Z",
+     "shell.execute_reply": "2026-06-13T00:07:43.999715Z"
+    },
+    "papermill": {
+     "duration": 0.030711,
+     "end_time": "2026-06-13T00:07:44.005344+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:43.974633+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution anti-diagonale : insatisfiable\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 1 : Resoudre le Sudoku avec une contrainte d'anti-diagonale.\n",
+    "\n",
+    "def resoudre_sudoku_anti_diagonale(grille: List[List[int]]) -> Optional[List[List[int]]]:\n",
+    "    \"\"\"Resout le Sudoku avec la regle supplementaire :\n",
+    "    l'anti-diagonale (cases (r, 8-r)) contient 1 a 9 sans repetition.\n",
+    "\n",
+    "    # Indice : reprenez resoudre_sudoku et ajoutez la contrainte d'anti-diagonale.\n",
+    "    # Etape 1 : recopier la modelisation de base (domaine, indices, lignes, colonnes, blocs)\n",
+    "    # Etape 2 : ajouter Distinct([cellules[r][8 - r] for r in range(9)])\n",
+    "    # Etape 3 : verifier sat et retourner la solution\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implémentez la variante anti-diagonale\n",
+    "    return None  # TODO etudiant : remplacer par la solution\n",
+    "\n",
+    "sol_ad = resoudre_sudoku_anti_diagonale(puzzle_facile)\n",
+    "print(\"Solution anti-diagonale :\", \"trouvée\" if sol_ad else \"insatisfiable\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb02-ex2-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012124,
+     "end_time": "2026-06-13T00:07:44.028901+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:44.016777+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 : Resoudre le puzzle intermediaire\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Utilisez la fonction `resoudre_sudoku` pour resoudre `puzzle_intermediaire`, puis visualisez la solution avec `plot_sudoku`. Verifiez visuellement la coherence.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Appelez `resoudre_sudoku(puzzle_intermediaire)`.\n",
+    "- Affichez le puzzle initial puis la solution avec `plot_sudoku(..., initial=puzzle_intermediaire)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "nb02-ex2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:44.052937Z",
+     "iopub.status.busy": "2026-06-13T00:07:44.052461Z",
+     "iopub.status.idle": "2026-06-13T00:07:44.062947Z",
+     "shell.execute_reply": "2026-06-13T00:07:44.061037Z"
+    },
+    "papermill": {
+     "duration": 0.023253,
+     "end_time": "2026-06-13T00:07:44.064559+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:44.041306+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 : à compléter (la fonction ne fait rien)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 2 : Resoudre et visualiser le puzzle intermediaire.\n",
+    "\n",
+    "def resoudre_et_visualiser(grille: List[List[int]]):\n",
+    "    \"\"\"Resout la grille puis affiche le puzzle et sa solution.\n",
+    "\n",
+    "    # Indice : utilisez resoudre_sudoku puis plot_sudoku.\n",
+    "    # Etape 1 : appeler resoudre_sudoku(grille)\n",
+    "    # Etape 2 : afficher plot_sudoku(grille, \"Puzzle\")\n",
+    "    # Etape 3 : afficher plot_sudoku(solution, \"Solution\", initial=grille)\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : résolvez et visualisez\n",
+    "    pass\n",
+    "\n",
+    "resultat_ex2 = resoudre_et_visualiser(puzzle_intermediaire)\n",
+    "print(\"Exercice 2 :\", \"résolu et visualisé\" if resultat_ex2 is not None else \"à compléter (la fonction ne fait rien)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb02-ex3-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013911,
+     "end_time": "2026-06-13T00:07:44.088757+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:44.074846+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 : Detecter les solutions multiples\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Un puzzle de Sudoku bien forme possede une **solution unique**. Une grille trop peu remplie peut en admettre plusieurs. Ecrivez une fonction qui compte le nombre de solutions (borne a 2) en ajoutant une **clause bloquante** apres chaque solution trouvee.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Apres avoir trouve un modele, construisez une clause qui interdit exactement cette solution : `Or([cellules[r][c] != val pour toutes les cases])`.\n",
+    "- Ajoutez cette clause avec `s.add(...)` et rappelez `s.check()`.\n",
+    "- Arretez des que 2 solutions sont trouvees ou que `check()` renvoie `unsat`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "nb02-ex3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T00:07:44.124345Z",
+     "iopub.status.busy": "2026-06-13T00:07:44.123642Z",
+     "iopub.status.idle": "2026-06-13T00:07:44.136791Z",
+     "shell.execute_reply": "2026-06-13T00:07:44.134229Z"
+    },
+    "papermill": {
+     "duration": 0.029974,
+     "end_time": "2026-06-13T00:07:44.138435+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:44.108461+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre de solutions du puzzle facile : 0 (attendu : 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 3 : Compter le nombre de solutions (jusqu'a 2).\n",
+    "\n",
+    "def compter_solutions(grille: List[List[int]], max_solutions: int = 2) -> int:\n",
+    "    \"\"\"Compte le nombre de solutions, borne a max_solutions.\n",
+    "\n",
+    "    # Indice : apres chaque modele, bloquez cette solution avec une clause\n",
+    "    #           Or([cellules[r][c] != valeur_trouvee, ...]) puis re-iterz.\n",
+    "    # Etape 1 : modeliser le Sudoku (comme dans resoudre_sudoku)\n",
+    "    # Etape 2 : boucler sur s.check() == sat, extraire le modele, incrementer\n",
+    "    # Etape 3 : ajouter la clause bloquante et continuer\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implémentez le comptage de solutions\n",
+    "    return 0  # TODO etudiant : remplacer par le nombre de solutions trouvées\n",
+    "\n",
+    "# Test : le puzzle facile bien forme doit avoir exactement 1 solution.\n",
+    "nb = compter_solutions(puzzle_facile)\n",
+    "print(f\"Nombre de solutions du puzzle facile : {nb} (attendu : 1)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb02-conclusion",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008565,
+     "end_time": "2026-06-13T00:07:44.156256+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T00:07:44.147691+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Recapitulatif\n",
+    "\n",
+    "Ce notebook a montre comment **trois familles de contraintes** (domaine, indices, unicite) suffisent a modeliser et resoudre le Sudoku de facon entierement declarative.\n",
+    "\n",
+    "| Element | Approche Z3 | Benefice |\n",
+    "|---------|-------------|----------|\n",
+    "| Modelisation | `Int` + `Distinct` | Code court, lisible |\n",
+    "| Resolution | `s.check()` automatique | Aucun algorithme a ecrire |\n",
+    "| Variante (anti-diagonale) | Une contrainte de plus | Evolutivite immediate |\n",
+    "| Visualisation | matplotlib (noir = donne, bleu = resolu) | Verification visuelle |\n",
+    "\n",
+    "La force du paradigme declaratif est l'**evolutivite** : chaque nouvelle regle se traduit par une contrainte, sans reecrire la logique de recherche. Pour aller plus loin, consultez la [documentation z3-py](https://microsoft.github.io/z3guide/) et la serie [Sudoku par approches multiples](../Sudoku/README.md) qui compare Z3 a dix autres techniques algorithmiques."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 15.467677,
+   "end_time": "2026-06-13T00:07:44.740658+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-02-Sudoku.ipynb",
+   "output_path": "MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-02-Sudoku_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-13T00:07:29.272981+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/requirements.txt
+++ b/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/requirements.txt
@@ -1,0 +1,2 @@
+z3-solver>=4.12
+matplotlib>=3.7


### PR DESCRIPTION
## Summary

New series `MyIA.AI.Notebooks/SymbolicAI/Z3-Python/` — Python SMT constraint solving with z3-solver.

### Deliverables

| File | Content |
|------|---------|
| `README.md` | Series scope, Python-vs-C# contrast table, prerequis, references (z3guide, API docs) |
| `Z3-Python-01-Introduction.ipynb` | `Solver`/`Int`/`Bool`/`Real`, sat/unsat/unknown, liar puzzle, sharing problem, knapsack-lite via `Optimize` |
| `Z3-Python-02-Sudoku.ipynb` | Sudoku as CSP via `Distinct`, `plot_sudoku()` (given=BLACK, solved=BLUE), 3 exercises |
| `requirements.txt` | `z3-solver>=4.12`, `matplotlib>=3.7` |

### Validation

| Check | NB 01 | NB 02 |
|-------|-------|-------|
| Papermill SUCCESS | 23/23 cells | 17/17 cells |
| `execution_count` set on all code | 9/9 | 7/7 |
| `outputs` on all code | 9/9 | 7/7 |
| Errors | 0 | 0 |
| Forbidden patterns (`raise NotImplementedError`/`assert False`/`1/0`) | none | none |
| Exercise stubs (`# TODO etudiant`) | 3 | 3 |
| Consecutive code without markdown | 0 | 0 |

### Design decisions

- **Sudoku viz**: reuses `plot_sudoku()` pattern from `Sudoku/Sudoku-1-Backtracking-Python.ipynb` — given clues in BLACK, solver-added values (where `initial[r][c]==0`) in BLUE
- **No Mathematica dependency**: all computation via `z3-solver` (pip install)
- **Exercises use stubs** conformant to C.1: `return None  # TODO etudiant`, `pass`, `return 0`

See #1206 (REVISION 2026-06-13: new Python Z3 series alongside existing C# Z3.Linq series)
