### PR TITLE
feat(search): add MGS-3 Eukaryote notebook (sub-population) (See #1203)

### DIFF
--- a/MyIA.AI.Notebooks/Search/MetaGeneticSharp-Notebooks/MGS-3-Eukaryote.ipynb
+++ b/MyIA.AI.Notebooks/Search/MetaGeneticSharp-Notebooks/MGS-3-Eukaryote.ipynb
@@ -1,0 +1,1740 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "nav-header",
+   "metadata": {},
+   "source": [
+    "# MGS-3 : L'Eukaryote -- sous-populations et chromosomes composites\n",
+    "\n",
+    "**Navigation** : [Index](../README.md) | [<< MGS-2 Composition](MGS-2-Composition.ipynb) | [MGS-4 Populations >>](MGS-4-Populations.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. **Comprendre** le concept d'eukaryote : des individus multi-chromosomes dont chaque partie est evoluee independamment\n",
+    "2. **Utiliser** `EukaryoteChromosome` pour decouper un genome en sous-chromosomes (caryotype) et les reconstruire\n",
+    "3. **Configurer** des sous-populations isolees avec des strategies differentes (agressive vs conservatrice)\n",
+    "4. **Orchestrer** l'ensemble avec `EukaryoteMetaHeuristic` et comparer avec une approche uniforme\n",
+    "\n",
+    "### Prerequis\n",
+    "- MGS-1 : Introduction a MetaGeneticSharp et au moteur autonome\n",
+    "- MGS-2 : Composition de metaheuristiques (Match, primitives de controle)\n",
+    "- Notions de base en algorithmes genetiques (selection, crossover, mutation)\n",
+    "- C# .NET 9.0 et .NET Interactive\n",
+    "\n",
+    "### Duree estimee : 45 minutes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section-1-architecture",
+   "metadata": {},
+   "source": [
+    "## 1. Architecture eucaryote\n",
+    "\n",
+    "### Types fondamentaux\n",
+    "\n",
+    "Le concept eucaryote repose sur trois types fondamentaux qui collaboraient pour decomposer un genome, isoler l'evolution de chaque partie, puis reagreger les resultats :\n",
+    "\n",
+    "| Type | Role | Parent dans la hierarchie |\n",
+    "|------|------|--------------------------|\n",
+    "| `EukaryoteChromosome` | Sous-chromosome : vue sur une partition du genome parent | `ChromosomeBase` |\n",
+    "| `SubPopulation` | Population isolee pour une partition, avec contexte independant | `MetaPopulation` |\n",
+    "| `EukaryoteMetaHeuristic` | Orchestrateur : cree les sous-populations et applique les sous-heuristiques | `SubPopulationMetaHeuristicBase<SubPopulation>` |\n",
+    "\n",
+    "### Flux de donnees\n",
+    "\n",
+    "```\n",
+    "Population parente (N individus x G genes)\n",
+    "  |\n",
+    "  | EukaryoteChromosome.GetSubPopulations(parents, [k1, k2])\n",
+    "  v\n",
+    "Sous-population 0          Sous-population 1\n",
+    "  (N x k1 genes)             (N x k2 genes)\n",
+    "  Strategie A                Strategie B\n",
+    "  |                          |\n",
+    "  +-------- PerformSubOperator --------+\n",
+    "                                       |\n",
+    "                                       v\n",
+    "                              EukaryoteChromosome.GetNewIndividuals()\n",
+    "                                       |\n",
+    "                                       v\n",
+    "                              Population evoluee (N individus x G genes)\n",
+    "```\n",
+    "\n",
+    "### Analogie biologique\n",
+    "\n",
+    "En biologie, une **cellule eucaryote** contient un noyau et des organites, chacun avec un role specialise. De meme, l'eukaryote de MetaGeneticSharp decompose le genome d'un individu en **chromosomes enfants** (le caryotype), chacun evolue dans une sous-population avec sa propre strategie, avant d'etre recombine en un individu complet.\n",
+    "\n",
+    "| Concept biologique | Equivalent MetaGeneticSharp |\n",
+    "|---------------------|----------------------------|\n",
+    "| Cellule eucaryote | Individu avec genome composite |\n",
+    "| Chromosome | `EukaryoteChromosome` (partition du genome) |\n",
+    "| Caryotype (ensemble des chromosomes) | Liste des sous-chromosomes |\n",
+    "| Tissu specialise | `SubPopulation` avec sa strategie |\n",
+    "| Organisme complet | Individu reconstruit via `GetNewIndividuals()` |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "wiring-cell",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T01:30:40.513377Z",
+     "iopub.status.busy": "2026-06-13T01:30:40.507666Z",
+     "iopub.status.idle": "2026-06-13T01:30:42.534915Z",
+     "shell.execute_reply": "2026-06-13T01:30:42.529117Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '416684.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MetaGeneticSharp + GeneticSharp charges avec succes.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  EukaryoteChromosome       : EukaryoteChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SubPopulation              : SubPopulation\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SubPopulationContext       : SubPopulationContext\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  EukaryoteMetaHeuristic     : EukaryoteMetaHeuristic\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  EvolutionStage.Crossover   : Crossover\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  EvolutionStage.Mutation    : Mutation\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Wiring: load MetaGeneticSharp + GeneticSharp DLLs from submodule build\n",
+    "// Build prerequisite: dotnet build c:/dev/MetaGeneticSharp/MetaGeneticSharp.sln\n",
+    "// Requires: git -C c:/dev/MetaGeneticSharp submodule update --init GeneticSharp\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "\n",
+    "using MetaGeneticSharp;\n",
+    "using GeneticSharp;\n",
+    "\n",
+    "Console.WriteLine(\"MetaGeneticSharp + GeneticSharp charges avec succes.\");\n",
+    "Console.WriteLine($\"  EukaryoteChromosome       : {typeof(EukaryoteChromosome).Name}\");\n",
+    "Console.WriteLine($\"  SubPopulation              : {typeof(SubPopulation).Name}\");\n",
+    "Console.WriteLine($\"  SubPopulationContext       : {typeof(SubPopulationContext).Name}\");\n",
+    "Console.WriteLine($\"  EukaryoteMetaHeuristic     : {typeof(EukaryoteMetaHeuristic).Name}\");\n",
+    "Console.WriteLine($\"  EvolutionStage.Crossover   : {EvolutionStage.Crossover}\");\n",
+    "Console.WriteLine($\"  EvolutionStage.Mutation    : {EvolutionStage.Mutation}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a530ae80",
+   "metadata": {},
+   "source": [
+    "### Chargement des DLL et configuration du notebook\n",
+    "\n",
+    "La cellule suivante charge les DLL MetaGeneticSharp et GeneticSharp depuis le build du sous-module. Assurez-vous que le build est a jour avant d'executer ce notebook.\n",
+    "\n",
+    "> **Note** : si le wiring echoue, verifiez que le sous-module GeneticSharp est initialise (`git submodule update --init GeneticSharp`) et que le build est a jour (`dotnet build` depuis `c:/dev/MetaGeneticSharp`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "setup-cell",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T01:30:42.537530Z",
+     "iopub.status.busy": "2026-06-13T01:30:42.537283Z",
+     "iopub.status.idle": "2026-06-13T01:30:42.911560Z",
+     "shell.execute_reply": "2026-06-13T01:30:42.911351Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setup OK : PositionVelocityFitness, BuildEukaryote, RunWithEukaryote definis\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  EukaryoteChromosome       : EukaryoteChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SubPopulation              : SubPopulation\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SubPopulationContext       : SubPopulationContext\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  EukaryoteMetaHeuristic     : EukaryoteMetaHeuristic\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SubPopulationMetaHeuristicBase : SubPopulationMetaHeuristicBase`1\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Setup: fitness function, helpers, and EukaryoteMetaHeuristic factory\n",
+    "\n",
+    "// Fitness: minimize distance to targets (position=50, velocity=25)\n",
+    "// f(x, v) = -(|x - 50| + |v - 25|)  -- GeneticSharp maximizes, so we negate\n",
+    "public class PositionVelocityFitness : IFitness\n",
+    "{\n",
+    "    public double Evaluate(IChromosome chromosome)\n",
+    "    {\n",
+    "        var fc = (FloatingPointChromosome)chromosome;\n",
+    "        var genes = fc.ToFloatingPoints();\n",
+    "        return -(Math.Abs(genes[0] - 50) + Math.Abs(genes[1] - 25));\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Helper: build an EukaryoteMetaHeuristic with heterogeneous strategies\n",
+    "// Sub-population 0 (position): DefaultMetaHeuristic (crossover + mutation actifs)\n",
+    "// Sub-population 1 (velocity): NoOpMetaHeuristic (parents pass through unchanged)\n",
+    "// NOTE: Eukaryote calls MatchParentsAndCross with probability=1 internally.\n",
+    "// Setting ProbabilityConfig.Crossover.OverwriteProbability on sub-heuristics\n",
+    "// can cause NullReferenceException in GetNewIndividuals if it rejects some crossovers.\n",
+    "// Instead, we use DefaultMetaHeuristic (active) vs NoOpMetaHeuristic (no-op).\n",
+    "IMetaHeuristic BuildEukaryote()\n",
+    "{\n",
+    "    // Sub-pop 0: DefaultMetaHeuristic (standard crossover + mutation)\n",
+    "    var active = new DefaultMetaHeuristic();\n",
+    "\n",
+    "    // Sub-pop 1: NoOpMetaHeuristic (crossover and mutation are no-ops)\n",
+    "    var noOp = new NoOpMetaHeuristic();\n",
+    "\n",
+    "    return new EukaryoteMetaHeuristic(16, active, noOp)\n",
+    "    {\n",
+    "        Scope = EvolutionStage.Crossover | EvolutionStage.Mutation\n",
+    "    };\n",
+    "}\n",
+    "\n",
+    "// Helper: build an EukaryoteMetaHeuristic with two DefaultMetaHeuristic (same strategy)\n",
+    "IMetaHeuristic BuildEukaryoteUniform()\n",
+    "{\n",
+    "    return new EukaryoteMetaHeuristic(16, new DefaultMetaHeuristic(), new DefaultMetaHeuristic())\n",
+    "    {\n",
+    "        Scope = EvolutionStage.Crossover | EvolutionStage.Mutation\n",
+    "    };\n",
+    "}\n",
+    "\n",
+    "// Helper: run GA with any IMetaHeuristic on the position-velocity problem\n",
+    "// Uses FuncFitness + EliteSelection (canonical pattern from EukaryoteMetaHeuristicTests)\n",
+    "double RunWithEukaryote(IMetaHeuristic mh, string label, int popSize = 40, int generations = 50)\n",
+    "{\n",
+    "    var adam = new FloatingPointChromosome(\n",
+    "        new double[] { 0, 0 },\n",
+    "        new double[] { 100, 100 },\n",
+    "        new int[] { 16, 16 },\n",
+    "        new int[] { 2, 2 });\n",
+    "\n",
+    "    var pop = new MetaPopulation(popSize, popSize, adam);\n",
+    "    var ga = new MetaGeneticAlgorithm(\n",
+    "        pop,\n",
+    "        new FuncFitness(c =>\n",
+    "        {\n",
+    "            var values = ((FloatingPointChromosome)c).ToFloatingPoints();\n",
+    "            return -(Math.Abs(values[0] - 50) + Math.Abs(values[1] - 25));\n",
+    "        }),\n",
+    "        new EliteSelection(),\n",
+    "        new UniformCrossover(0.5f),\n",
+    "        new UniformMutation(true),\n",
+    "        mh);\n",
+    "\n",
+    "    ga.Termination = new GenerationNumberTermination(generations);\n",
+    "\n",
+    "    ga.Start();\n",
+    "\n",
+    "    var best = ((FloatingPointChromosome)ga.BestChromosome).ToFloatingPoints();\n",
+    "    return Math.Abs(best[0] - 50) + Math.Abs(best[1] - 25);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Setup OK : PositionVelocityFitness, BuildEukaryote, RunWithEukaryote definis\");\n",
+    "Console.WriteLine(\"  EukaryoteChromosome       : \" + typeof(EukaryoteChromosome).Name);\n",
+    "Console.WriteLine(\"  SubPopulation              : \" + typeof(SubPopulation).Name);\n",
+    "Console.WriteLine(\"  SubPopulationContext       : \" + typeof(SubPopulationContext).Name);\n",
+    "Console.WriteLine(\"  EukaryoteMetaHeuristic     : \" + typeof(EukaryoteMetaHeuristic).Name);\n",
+    "Console.WriteLine(\"  SubPopulationMetaHeuristicBase : \" + typeof(SubPopulationMetaHeuristicBase<SubPopulation>).Name);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section-2-intro",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. EukaryoteChromosome : le chromosome composite\n",
+    "\n",
+    "Le coeur du concept eucaryote est le **chromosome composite** : un individu dont le genome est decoupe en **caryotypes** (partitions). Chaque partition est un `EukaryoteChromosome` qui reference son parent et connait son decalage dans le genome complet.\n",
+    "\n",
+    "### Cycle de vie d'un EukaryoteChromosome\n",
+    "\n",
+    "```\n",
+    "1. Creation du parent\n",
+    "   FloatingPointChromosome([0,0], [100,100], [16,16], [2,2])\n",
+    "   -> 2 genes = 32 bits au total\n",
+    "\n",
+    "2. Decoupage en karyotype (GetKaryotype)\n",
+    "   EukaryoteChromosome.GetKaryotype(parent, [16, 16])\n",
+    "   -> Karyotype[0] : genes [0..15]  (position)\n",
+    "   -> Karyotype[1] : genes [16..31] (vitesse)\n",
+    "\n",
+    "3. Evolution independante de chaque sous-chromosome\n",
+    "   (chaque sous-population applique sa strategie)\n",
+    "\n",
+    "4. Resynchronisation (UpdateParent)\n",
+    "   Les genes modifies du sous-chromosome sont ecrits dans le parent\n",
+    "\n",
+    "5. Reconstruction (GetNewIndividual)\n",
+    "   Un nouvel individu complet est cree a partir du caryotype evolue\n",
+    "```\n",
+    "\n",
+    "### Methodes cles\n",
+    "\n",
+    "| Methode | Role |\n",
+    "|---------|------|\n",
+    "| `GetKaryotype(parent, lengths)` | Decoupe un parent en sous-chromosomes |\n",
+    "| `GetSubPopulations(parents, lengths)` | Decoupe une population entiere, groupee par position |\n",
+    "| `UpdateParent()` | Resynchronise les genes du sous-chromosome vers le parent |\n",
+    "| `GetNewIndividual(karyotype)` | Cree un nouvel individu a partir d'un caryotype evolue |\n",
+    "| `GetNewIndividuals(subPops)` | Reconstruit une population complete a partir de sous-populations |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "karyotype-demo",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T01:30:42.913097Z",
+     "iopub.status.busy": "2026-06-13T01:30:42.912896Z",
+     "iopub.status.idle": "2026-06-13T01:30:43.143190Z",
+     "shell.execute_reply": "2026-06-13T01:30:43.142965Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chromosome parent :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Type          : FloatingPointChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Longueur      : 32 genes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Valeurs       : [57,30, 55,96]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fitness       : -38,2600\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Karyotype (2 sous-chromosomes) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Karyotype[0] :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Type            : EukaryoteChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    StartGeneIndex  : 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Longueur        : 16 genes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Meme reference  : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Fitness herite  : -38,2600\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Karyotype[1] :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Type            : EukaryoteChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    StartGeneIndex  : 16\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Longueur        : 16 genes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Meme reference  : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Fitness herite  : -38,2600\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Individu reconstruit :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Type    : FloatingPointChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Valeurs : [57,30, 55,96]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Genes identiques au parent : True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demonstration: EukaryoteChromosome karyotype decomposition\n",
+    "// We create a parent chromosome and slice it into 2 sub-chromosomes\n",
+    "\n",
+    "// Parent: 2 floating-point genes, each 16 bits with 2 decimal places, range [0, 100]\n",
+    "var parent = new FloatingPointChromosome(\n",
+    "    new double[] { 0, 0 },\n",
+    "    new double[] { 100, 100 },\n",
+    "    new int[] { 16, 16 },\n",
+    "    new int[] { 2, 2 });\n",
+    "\n",
+    "// Evaluate fitness so the children inherit it\n",
+    "var fitnessDemo = new PositionVelocityFitness();\n",
+    "parent.Fitness = fitnessDemo.Evaluate(parent);\n",
+    "\n",
+    "// Get karyotype: split into 2 sub-chromosomes of 16 genes each\n",
+    "// (each FloatingPoint gene uses 16 bits, so subChromosomeLengths = [16, 16])\n",
+    "var karyotype = EukaryoteChromosome.GetKaryotype(parent, new List<int> { 16, 16 });\n",
+    "\n",
+    "Console.WriteLine(\"Chromosome parent :\");\n",
+    "var parentGenes = ((FloatingPointChromosome)parent).ToFloatingPoints();\n",
+    "Console.WriteLine(string.Format(\"  Type          : {0}\", parent.GetType().Name));\n",
+    "Console.WriteLine(string.Format(\"  Longueur      : {0} genes\", parent.Length));\n",
+    "Console.WriteLine(string.Format(\"  Valeurs       : [{0:F2}, {1:F2}]\", parentGenes[0], parentGenes[1]));\n",
+    "Console.WriteLine(string.Format(\"  Fitness       : {0:F4}\", parent.Fitness));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Console.WriteLine(\"Karyotype (2 sous-chromosomes) :\");\n",
+    "for (int i = 0; i < karyotype.Count; i++)\n",
+    "{\n",
+    "    var sub = (EukaryoteChromosome)karyotype[i];\n",
+    "    Console.WriteLine(string.Format(\"  Karyotype[{0}] :\", i));\n",
+    "    Console.WriteLine(string.Format(\"    Type            : {0}\", sub.GetType().Name));\n",
+    "    Console.WriteLine(string.Format(\"    StartGeneIndex  : {0}\", sub.StartGeneIndex));\n",
+    "    Console.WriteLine(string.Format(\"    Longueur        : {0} genes\", sub.Length));\n",
+    "    Console.WriteLine(string.Format(\"    Meme reference  : {0}\", object.ReferenceEquals(sub.ParentIndividual, parent)));\n",
+    "    Console.WriteLine(string.Format(\"    Fitness herite  : {0:F4}\", sub.Fitness));\n",
+    "}\n",
+    "\n",
+    "// Rebuild a new individual from the karyotype\n",
+    "var rebuilt = EukaryoteChromosome.GetNewIndividual(karyotype.Cast<EukaryoteChromosome>().ToList());\n",
+    "var rebuiltGenes = ((FloatingPointChromosome)rebuilt).ToFloatingPoints();\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Individu reconstruit :\");\n",
+    "Console.WriteLine(string.Format(\"  Type    : {0}\", rebuilt.GetType().Name));\n",
+    "Console.WriteLine(string.Format(\"  Valeurs : [{0:F2}, {1:F2}]\", rebuiltGenes[0], rebuiltGenes[1]));\n",
+    "Console.WriteLine(string.Format(\"  Genes identiques au parent : {0}\",\n",
+    "    parent.GetGenes().SequenceEqual(rebuilt.GetGenes())));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-karyotype",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Karyotype et sous-chromosomes\n",
+    "\n",
+    "**Sortie obtenue** : Le chromosome parent (2 genes, 32 bits) est decoupe en deux sous-chromosomes de 16 genes chacun. Chaque sous-chromosome reference son parent via `ParentIndividual` et connait son decalage via `StartGeneIndex`.\n",
+    "\n",
+    "| Propriete | Karyotype[0] (Position) | Karyotype[1] (Vitesse) |\n",
+    "|-----------|-------------------------|------------------------|\n",
+    "| `StartGeneIndex` | 0 | 16 |\n",
+    "| `Length` | 16 | 16 |\n",
+    "| `ParentIndividual` | Le chromosome parent | Le meme chromosome parent |\n",
+    "| Genes copies | Genes [0..15] du parent | Genes [16..31] du parent |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Le karyotype cree des **vues** sur le chromosome parent : les genes sont copies mais le parent est reference\n",
+    "2. `UpdateParent()` resynchronise les genes du sous-chromosome vers le parent -- c'est le mecanisme de retour apres evolution\n",
+    "3. `GetNewIndividual(karyotype)` cree un **nouvel individu** a partir du caryotype, en copiant les genes de chaque sous-chromosome\n",
+    "4. Le fitness du parent est herite par les sous-chromosomes (utilise pour la selection dans les sous-populations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section-3-intro",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Sub-Population : isolation et contexte\n",
+    "\n",
+    "La sous-population (`SubPopulation`) est le mecanisme d'isolation de l'eukaryote. Elle encapsule une projection de la population parente (un sous-chromosome par individu) dans un objet `IPopulation` autonome, avec son propre contexte d'evolution.\n",
+    "\n",
+    "### Architecture de l'isolation\n",
+    "\n",
+    "```\n",
+    "Population parente (40 individus x 32 genes)\n",
+    "  |\n",
+    "  +-- GetSubPopulations([16, 16])\n",
+    "  |     |\n",
+    "  |     +-- SubPopulation 0 : 40 EukaryoteChromosome (genes [0..15])\n",
+    "  |     |     Contexte isole (SubPopulationContext)\n",
+    "  |     |     Strategie : DefaultMetaHeuristic (crossover + mutation actifs)\n",
+    "  |     |\n",
+    "  |     +-- SubPopulation 1 : 40 EukaryoteChromosome (genes [16..31])\n",
+    "  |           Contexte isole (SubPopulationContext)\n",
+    "  |           Strategie : NoOpMetaHeuristic (parents inchanges)\n",
+    "  |\n",
+    "  +-- PerformSubOperator() : applique chaque sous-heuristique a sa sous-population\n",
+    "  |\n",
+    "  +-- GetNewIndividuals() : reconstruit les individus complets\n",
+    "```\n",
+    "\n",
+    "### Cycle de vie d'une generation eucaryote\n",
+    "\n",
+    "1. **Selection** : les parents sont selectionnes dans la population parente, puis decomposes en sous-chromosomes\n",
+    "2. **Crossover** : chaque sous-population applique son crossover via sa sous-metaheuristique (`DefaultMetaHeuristic` ou `NoOpMetaHeuristic`)\n",
+    "3. **Mutation** : chaque sous-chromosome est mute independamment selon la strategie de sa sous-population\n",
+    "4. **Reinsertion** : les individus reconstruits sont reinseres dans la population parente (reinsertion globale, non scopee)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "subpop-demo",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T01:30:43.144591Z",
+     "iopub.status.busy": "2026-06-13T01:30:43.144392Z",
+     "iopub.status.idle": "2026-06-13T01:30:43.370734Z",
+     "shell.execute_reply": "2026-06-13T01:30:43.370461Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Decomposition en sous-populations :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Population parente       : 40 individus\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Nombre de sous-populations : 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sous-population 0 :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Taille            : 40 chromosomes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Type              : EukaryoteChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    StartGeneIndex    : 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Longueur (genes)  : 16\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sous-population 1 :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Taille            : 40 chromosomes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Type              : EukaryoteChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    StartGeneIndex    : 16\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Longueur (genes)  : 16\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SubPopulation isolees :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SubPop[0].MinSize = 40, ParentPopulation = MetaPopulation(40)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SubPop[1].MinSize = 40, ParentPopulation = MetaPopulation(40)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Individus reconstruits : 40\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Premier individu type : FloatingPointChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Genes : [80,92, 59,24]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (Identiques aux genes du parent -- aucune evolution n'a encore eu lieu)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demonstration: SubPopulation creation and isolation\n",
+    "// We create a population, slice it into sub-populations, and inspect the structure\n",
+    "\n",
+    "// Create parent population\n",
+    "var adamSub = new FloatingPointChromosome(\n",
+    "    new double[] { 0, 0 },\n",
+    "    new double[] { 100, 100 },\n",
+    "    new int[] { 16, 16 },\n",
+    "    new int[] { 2, 2 });\n",
+    "\n",
+    "var parentPop = new MetaPopulation(40, 40, adamSub);\n",
+    "parentPop.CreateInitialGeneration();\n",
+    "// Assign fitness to all chromosomes (required for sub-population creation)\n",
+    "foreach (var c in parentPop.CurrentGeneration.Chromosomes)\n",
+    "{\n",
+    "    c.Fitness = new PositionVelocityFitness().Evaluate(c);\n",
+    "}\n",
+    "\n",
+    "// Slice into 2 sub-populations of 16 genes each\n",
+    "var subChromosomes = EukaryoteChromosome.GetSubPopulations(\n",
+    "    parentPop.CurrentGeneration.Chromosomes,\n",
+    "    new List<int> { 16, 16 });\n",
+    "\n",
+    "Console.WriteLine(\"Decomposition en sous-populations :\");\n",
+    "Console.WriteLine(string.Format(\"  Population parente       : {0} individus\", parentPop.CurrentGeneration.Chromosomes.Count));\n",
+    "Console.WriteLine(string.Format(\"  Nombre de sous-populations : {0}\", subChromosomes.Count));\n",
+    "\n",
+    "for (int i = 0; i < subChromosomes.Count; i++)\n",
+    "{\n",
+    "    Console.WriteLine();\n",
+    "    Console.WriteLine(string.Format(\"  Sous-population {0} :\", i));\n",
+    "    Console.WriteLine(string.Format(\"    Taille            : {0} chromosomes\", subChromosomes[i].Count));\n",
+    "    Console.WriteLine(string.Format(\"    Type              : {0}\", subChromosomes[i][0].GetType().Name));\n",
+    "    var firstSub = (EukaryoteChromosome)subChromosomes[i][0];\n",
+    "    Console.WriteLine(string.Format(\"    StartGeneIndex    : {0}\", firstSub.StartGeneIndex));\n",
+    "    Console.WriteLine(string.Format(\"    Longueur (genes)  : {0}\", firstSub.Length));\n",
+    "}\n",
+    "\n",
+    "// Create SubPopulation objects with isolated contexts\n",
+    "var subPops = new List<SubPopulation>();\n",
+    "for (int i = 0; i < subChromosomes.Count; i++)\n",
+    "{\n",
+    "    subPops.Add(new SubPopulation(parentPop, subChromosomes[i].Cast<IChromosome>().ToList()));\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"SubPopulation isolees :\");\n",
+    "for (int i = 0; i < subPops.Count; i++)\n",
+    "{\n",
+    "    Console.WriteLine(string.Format(\"  SubPop[{0}].MinSize = {1}, ParentPopulation = MetaPopulation({2})\",\n",
+    "        i, subPops[i].MinSize, subPops[i].ParentPopulation.MinSize));\n",
+    "}\n",
+    "\n",
+    "// Rebuild complete individuals from sub-populations\n",
+    "var rebuilt = EukaryoteChromosome.GetNewIndividuals(\n",
+    "    subPops.Select(sp => sp.CurrentGeneration.Chromosomes).Cast<IList<IChromosome>>().ToList());\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(string.Format(\"Individus reconstruits : {0}\", rebuilt.Count));\n",
+    "Console.WriteLine(string.Format(\"  Premier individu type : {0}\", rebuilt[0].GetType().Name));\n",
+    "var rebuiltGenes = ((FloatingPointChromosome)rebuilt[0]).ToFloatingPoints();\n",
+    "Console.WriteLine(string.Format(\"  Genes : [{0:F2}, {1:F2}]\", rebuiltGenes[0], rebuiltGenes[1]));\n",
+    "Console.WriteLine(\"  (Identiques aux genes du parent -- aucune evolution n'a encore eu lieu)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-subpop",
+   "metadata": {},
+   "source": [
+    "### Interpretation : SubPopulation et contexte isole\n",
+    "\n",
+    "**Sortie obtenue** : La population parente de 40 individus est decomposee en 2 sous-populations de 40 `EukaryoteChromosome` chacune, puis reconstruite en individus complets.\n",
+    "\n",
+    "| Aspect | Valeur | Signification |\n",
+    "|--------|--------|---------------|\n",
+    "| Population parente | 40 individus | La population complete du GA |\n",
+    "| Sous-population 0 | 40 sous-chromosomes | Un `EukaryoteChromosome` par individu, contenant les genes [0..15] |\n",
+    "| Sous-population 1 | 40 sous-chromosomes | Un `EukaryoteChromosome` par individu, contenant les genes [16..31] |\n",
+    "| `SubPopulationContext` | Independant par sous-pop | Cache de parametres isole, pas de partage avec le parent |\n",
+    "| Reconstruction | `GetNewIndividuals()` | Les genes des sous-chromosomes sont resynchronises dans les parents |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `SubPopulation` herite de `MetaPopulation` : pas de tri implicite par fitness, l'ordre est stable\n",
+    "2. `SubPopulationContext` herite de `SubEvolutionContext` : il delegue les proprietes non-locales (generation, stage) au contexte parent, mais le cache de parametres et la population sont locaux\n",
+    "3. Le `GenerationsNumber` de la sous-population est aligne sur celui de la population parente\n",
+    "4. Chaque sous-population peut utiliser des operateurs differents via les `PhaseHeuristics` de `SizeBasedMetaHeuristic`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section-4-intro",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. EukaryoteMetaHeuristic : execution complete\n",
+    "\n",
+    "Nous allons maintenant executer un GA complet avec `EukaryoteMetaHeuristic` sur un probleme a deux dimensions :\n",
+    "\n",
+    "- **Position** (gene 0, cible = 50) : evoluee par une sous-population avec `DefaultMetaHeuristic` (crossover et mutation actifs)\n",
+    "- **Vitesse** (gene 1, cible = 25) : evoluee par une sous-population avec `NoOpMetaHeuristic` (les parents passent inchanges, seul l'elitisme agit)\n",
+    "\n",
+    "Le fitness est : $f(x, v) = -(|x - 50| + |v - 25|)$ (a maximiser).\n",
+    "\n",
+    "**Configuration** :\n",
+    "- Chromosome : `FloatingPointChromosome` a 2 genes dans $[0, 100]$\n",
+    "- Sous-chromosomes : 2 partitions de 16 genes chacune\n",
+    "- Selection : `EliteSelection`\n",
+    "- Crossover : `UniformCrossover(0.5)` (le crossover est applique dans chaque sous-population)\n",
+    "- Mutation : `UniformMutation(true)`\n",
+    "- Terminaison : 50 generations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "eukaryote-run",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T01:30:43.372295Z",
+     "iopub.status.busy": "2026-06-13T01:30:43.372097Z",
+     "iopub.status.idle": "2026-06-13T01:30:43.545242Z",
+     "shell.execute_reply": "2026-06-13T01:30:43.544990Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Execution EukaryoteMetaHeuristic (2 sous-populations, 50 generations)...\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sous-pop 0 (position) : DefaultMetaHeuristic (crossover actif)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sous-pop 1 (vitesse)  : NoOpMetaHeuristic (parents inchanges)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Scope : Crossover | Mutation\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Meilleur chromosome : position=50,00, vitesse=24,91\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cibles              : position=50, vitesse=25\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Distance totale     : 0,0900\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Generations         : 50\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Etat                : TerminationReached\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Run EukaryoteMetaHeuristic with 2 sub-populations on the position-velocity problem\n",
+    "// Sub-population 0 (position): DefaultMetaHeuristic (crossover + mutation actifs)\n",
+    "// Sub-population 1 (velocity): NoOpMetaHeuristic (parents pass through unchanged)\n",
+    "// Uses same pattern as EukaryoteMetaHeuristicTests (EliteSelection, UniformCrossover, UniformMutation)\n",
+    "\n",
+    "var eukaryoteMh = BuildEukaryote();\n",
+    "\n",
+    "var adamEuk = new FloatingPointChromosome(\n",
+    "    new double[] { 0, 0 },\n",
+    "    new double[] { 100, 100 },\n",
+    "    new int[] { 16, 16 },\n",
+    "    new int[] { 2, 2 });\n",
+    "\n",
+    "var popEuk = new MetaPopulation(40, 40, adamEuk);\n",
+    "\n",
+    "// Use FuncFitness for the GA-level fitness (same pattern as tests)\n",
+    "var gaEuk = new MetaGeneticAlgorithm(\n",
+    "    popEuk,\n",
+    "    new FuncFitness(c =>\n",
+    "    {\n",
+    "        var values = ((FloatingPointChromosome)c).ToFloatingPoints();\n",
+    "        return -(Math.Abs(values[0] - 50) + Math.Abs(values[1] - 25));\n",
+    "    }),\n",
+    "    new EliteSelection(),\n",
+    "    new UniformCrossover(0.5f),\n",
+    "    new UniformMutation(true),\n",
+    "    eukaryoteMh);\n",
+    "\n",
+    "gaEuk.Termination = new GenerationNumberTermination(50);\n",
+    "\n",
+    "Console.WriteLine(\"Execution EukaryoteMetaHeuristic (2 sous-populations, 50 generations)...\");\n",
+    "Console.WriteLine(\"  Sous-pop 0 (position) : DefaultMetaHeuristic (crossover actif)\");\n",
+    "Console.WriteLine(\"  Sous-pop 1 (vitesse)  : NoOpMetaHeuristic (parents inchanges)\");\n",
+    "Console.WriteLine(\"  Scope : Crossover | Mutation\");\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "gaEuk.Start();\n",
+    "\n",
+    "var bestEuk = ((FloatingPointChromosome)gaEuk.BestChromosome).ToFloatingPoints();\n",
+    "var bestObjEuk = Math.Abs(bestEuk[0] - 50) + Math.Abs(bestEuk[1] - 25);\n",
+    "\n",
+    "Console.WriteLine(string.Format(\"  Meilleur chromosome : position={0:F2}, vitesse={1:F2}\", bestEuk[0], bestEuk[1]));\n",
+    "Console.WriteLine(string.Format(\"  Cibles              : position=50, vitesse=25\"));\n",
+    "Console.WriteLine(string.Format(\"  Distance totale     : {0:F4}\", bestObjEuk));\n",
+    "Console.WriteLine(string.Format(\"  Generations         : {0}\", gaEuk.GenerationsNumber));\n",
+    "Console.WriteLine(string.Format(\"  Etat                : {0}\", gaEuk.State));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-eukaryote-run",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Premier run avec EukaryoteMetaHeuristic\n",
+    "\n",
+    "**Sortie obtenue** : L'EukaryoteMetaHeuristic decompose le chromosome en deux sous-chromosomes de 16 genes chacun, applique des strategies differentes, puis reconstruit un individu complet.\n",
+    "\n",
+    "| Aspect | Valeur | Signification |\n",
+    "|--------|--------|---------------|\n",
+    "| Sous-populations | 2 | Caryotype : [0..15] pour la position, [16..31] pour la vitesse |\n",
+    "| Strategie gene 0 | `DefaultMetaHeuristic` | Crossover et mutation actifs sur la position |\n",
+    "| Strategie gene 1 | `NoOpMetaHeuristic` | Les parents passent inchanges, seul l'elitisme agit sur la vitesse |\n",
+    "| Scope | `Crossover | Mutation` | Seuls crossover et mutation passent par les sous-populations |\n",
+    "| Reinsertion | Globale (par defaut) | L'elitisme s'applique sur les individus reconstruits |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. L'EukaryoteMetaHeuristic cree des `SubPopulation` isolees avec des `SubPopulationContext` independants\n",
+    "2. `NoOpMetaHeuristic` sur la vitesse signifie que cette dimension n'evolue pas par crossover/mutation : elle s'appuie uniquement sur la selection d'elitisme pour converger\n",
+    "3. La reinsertion n'est **pas** scopee a l'eukaryote : `ScopedReinsert` leve une exception. Le scope canonique est `Crossover | Mutation`\n",
+    "4. Les resultats des sous-populations sont reagreges via `EukaryoteChromosome.GetNewIndividuals()` qui reconstruit des individus complets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "comparison-intro",
+   "metadata": {},
+   "source": [
+    "### Demonstration : Eukaryote heterogene vs uniforme\n",
+    "\n",
+    "Nous comparons deux configurations d'`EukaryoteMetaHeuristic` :\n",
+    "- **Heterogene** : `DefaultMetaHeuristic` (position) + `NoOpMetaHeuristic` (vitesse) -- seule la position evolue par crossover\n",
+    "- **Uniforme** : `DefaultMetaHeuristic` + `DefaultMetaHeuristic` -- les deux dimensions evoluent activement\n",
+    "\n",
+    "Le probleme position-vitesse a deux dimensions avec des cibles differentes : la position (gene 0) cible 50 et la vitesse (gene 1) cible 25."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "comparison-run",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T01:30:43.547291Z",
+     "iopub.status.busy": "2026-06-13T01:30:43.547026Z",
+     "iopub.status.idle": "2026-06-13T01:30:44.148678Z",
+     "shell.execute_reply": "2026-06-13T01:30:44.148041Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison Eukaryote heterogene vs uniforme (5 runs, 50 generations)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config                    Run1         Run2         Run3         Run4         Run5        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uniform (Default+Default)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1,2500     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1,2000     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,6900     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0000     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0900     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Heterogen (Default+NoOp) "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 3,5700     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 8,0000     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1,4500     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1,4600     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1,2500     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Uniforme moyenne  : 0,6460\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Heterogene moyenne: 3,1460\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Amelioration      : -387,0%\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Position-Velocity fitness : f(x) = -(|x - 50| + |v - 25|)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Heterogene: gene 0 (position) DefaultMetaHeuristic, gene 1 (vitesse) NoOpMetaHeuristic\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Compare: EukaryoteMetaHeuristic (heterogeneous: Default + NoOp) vs uniform (Default + Default)\n",
+    "// We use 5 runs to smooth out randomness\n",
+    "\n",
+    "Console.WriteLine(\"Comparaison Eukaryote heterogene vs uniforme (5 runs, 50 generations)\");\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "Console.WriteLine(string.Format(\"{0,-25} {1,-12} {2,-12} {3,-12} {4,-12} {5,-12}\",\n",
+    "    \"Config\", \"Run1\", \"Run2\", \"Run3\", \"Run4\", \"Run5\"));\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "\n",
+    "var eukResults = new List<double>();\n",
+    "var uniResults = new List<double>();\n",
+    "\n",
+    "for (int run = 0; run < 5; run++)\n",
+    "{\n",
+    "    eukResults.Add(RunWithEukaryote(BuildEukaryote(), \"Eukaryote\"));\n",
+    "    uniResults.Add(RunWithEukaryote(BuildEukaryoteUniform(), \"Uniform\"));\n",
+    "}\n",
+    "\n",
+    "Console.Write(string.Format(\"{0,-25}\", \"Uniform (Default+Default)\"));\n",
+    "foreach (var r in uniResults) Console.Write(string.Format(\" {0,-11:F4}\", r));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Console.Write(string.Format(\"{0,-25}\", \"Heterogen (Default+NoOp)\"));\n",
+    "foreach (var r in eukResults) Console.Write(string.Format(\" {0,-11:F4}\", r));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Console.WriteLine(\"-----------------------------------------------------------------\");\n",
+    "Console.WriteLine(string.Format(\"  Uniforme moyenne  : {0:F4}\", uniResults.Average()));\n",
+    "Console.WriteLine(string.Format(\"  Heterogene moyenne: {0:F4}\", eukResults.Average()));\n",
+    "Console.WriteLine(string.Format(\"  Amelioration      : {0:F1}%\",\n",
+    "    (uniResults.Average() - eukResults.Average()) / uniResults.Average() * 100));\n",
+    "Console.WriteLine(\"=================================================================\");\n",
+    "Console.WriteLine(\"Position-Velocity fitness : f(x) = -(|x - 50| + |v - 25|)\");\n",
+    "Console.WriteLine(\"  Heterogene: gene 0 (position) DefaultMetaHeuristic, gene 1 (vitesse) NoOpMetaHeuristic\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-comparison",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Eukaryote heterogene vs uniforme\n",
+    "\n",
+    "**Sortie obtenue** : L'EukaryoteMetaHeuristic uniforme (Default+Default) converge mieux que la version heterogene (Default+NoOp).\n",
+    "\n",
+    "| Configuration | Sous-pop 0 (position) | Sous-pop 1 (vitesse) | Resultat |\n",
+    "|---------------|----------------------|---------------------|----------|\n",
+    "| Uniforme (Default+Default) | Crossover actif | Crossover actif | Meilleure convergence globale |\n",
+    "| Heterogene (Default+NoOp) | Crossover actif | Parents inchanges | La vitesse converge moins bien |\n",
+    "\n",
+    "**Pourquoi l'uniforme est meilleur ici** : la version heterogene utilise `NoOpMetaHeuristic` sur la vitesse, ce qui signifie que cette dimension ne beneficie ni de crossover ni de mutation -- seul l'elitisme la fait evoluer. Sur un probleme simple ou les deux dimensions ont le meme comportement (fonction de distance), l'uniforme est naturellement avantagé.\n",
+    "\n",
+    "**Quand l'heterogene est pertinente** :\n",
+    "1. L'eukaryote montre tout son potentiel sur des problemes ou les dimensions ont des **caracteristiques tres differentes** (ex: une dimension avec un paysage rugueux qui beneficie d'une exploration forte, et une dimension lisse qui profite de l'exploitation)\n",
+    "2. Le `Scope = EvolutionStage.Crossover | EvolutionStage.Mutation` assure que seuls le crossover et la mutation passent par les sous-populations ; la reinsertion reste globale\n",
+    "3. Les sous-populations sont recalculees a chaque generation (cache `ParamScope.Generation`) pour refleter les changements de la population parente"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section-5-summary",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. Resume\n",
+    "\n",
+    "Ce notebook a introduit le concept eucaryote de MetaGeneticSharp : des individus multi-chromosomes dont chaque partie est evoluee independamment par des sous-populations specialisees.\n",
+    "\n",
+    "| Concept | Role | Point cle |\n",
+    "|---------|------|-----------|\n",
+    "| **EukaryoteChromosome** | Decoupe un chromosome parent en sous-chromosomes (caryotype) | `GetKaryotype()` decoupe, `UpdateParent()` resync |\n",
+    "| **SubPopulation** | Population isolee pour une partition du genome | Herite de `MetaPopulation`, contextes separe |\n",
+    "| **SubPopulationContext** | Contexte d'evolution local a une sous-population | Cache de parametres independant |\n",
+    "| **EukaryoteMetaHeuristic** | Orchestrateur : applique une sous-heuristique par partition | Scope canonique : `Crossover | Mutation` |\n",
+    "| **PerformSubOperator** | Recombine les resultats de chaque sous-population | Reconstruit des individus complets |\n",
+    "\n",
+    "### Principes de conception\n",
+    "\n",
+    "1. **Partition du genome** : chaque sous-chromosome represente une dimension semantique differente du probleme\n",
+    "2. **Strategies heterogenes** : chaque sous-population peut utiliser ses propres parametres (crossover, mutation, match)\n",
+    "3. **Isolation + recombinaison** : les sous-populations evoluent independamment, puis les resultats sont reagreges en individus complets\n",
+    "4. **Scope restreint** : la reinsertion n'est pas supportee par l'eukaryote -- elle tombe sur la sous-metaheuristique par defaut\n",
+    "\n",
+    "### Pour aller plus loin\n",
+    "\n",
+    "- **Notebook suivant** : [MGS-4 Populations](MGS-4-Populations.ipynb) -- populations structurees (iles, migration)\n",
+    "- **Code source** : https://github.com/jsboige/MetaGeneticSharp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exercise-1-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercice 1 : Creer un chromosome eucaryote a 3 parties\n",
+    "\n",
+    "L'objectif est d'etendre le concept eucaryote a trois sous-chromosomes : **position**, **vitesse** et **acceleration**, chacun avec une strategie d'evolution differente.\n",
+    "\n",
+    "**Enonce** : Definissez un `FloatingPointChromosome` a 3 genes, un fitness qui minimise la distance a des cibles differentes pour chaque variable, et un `EukaryoteMetaHeuristic` avec 3 sous-populations.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Le chromosome Adam a 3 genes, chacun dans $[0, 100]$, avec 16 bits et 2 decimales par gene\n",
+    "- `EukaryoteMetaHeuristic(16, mh1, mh2, mh3)` cree 3 sous-populations de 16 genes chacune\n",
+    "- Le fitness peut etre : $f(x, v, a) = -(|x - 50| + |v - 25| + |a - 10|)$ (cibles differentes par variable)\n",
+    "- Chaque sous-metaheuristique peut avoir des probabilites differentes (exploration forte pour la position, moderee pour la vitesse, exploitation pour l'acceleration)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "exercise-1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T01:30:44.150580Z",
+     "iopub.status.busy": "2026-06-13T01:30:44.150374Z",
+     "iopub.status.idle": "2026-06-13T01:30:44.202130Z",
+     "shell.execute_reply": "2026-06-13T01:30:44.201908Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : chromosome eucaryote a 3 parties\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Creer un chromosome eucaryote a 3 parties\n",
+    "// TODO: Definir un chromosome a 3 genes (position, vitesse, acceleration)\n",
+    "// TODO: Creer un EukaryoteMetaHeuristic avec 3 sous-populations de tailles egales\n",
+    "// TODO: Attribuer des strategies differentes a chaque sous-population\n",
+    "// Indice: EukaryoteMetaHeuristic(subChromosomeSize, mh1, mh2, mh3) avec subChromosomeSize = geneCount / 3\n",
+    "// Indice: Pour un FloatingPointChromosome a 3 genes, chaque gene = 16 bits -> subChromosomeSize = 16\n",
+    "// Indice: Adaptez le fitness pour 3 variables : f(x, v, a) = -(|x-50| + |v-25| + |a-10|)\n",
+    "\n",
+    "// Etape 1 : Definir le chromosome Adam (3 genes dans [0, 100])\n",
+    "// var adam = new FloatingPointChromosome(\n",
+    "//     new double[] { 0, 0, 0 },\n",
+    "//     new double[] { 100, 100, 100 },\n",
+    "//     new int[] { 16, 16, 16 },\n",
+    "//     new int[] { 2, 2, 2 });\n",
+    "\n",
+    "// Etape 2 : Definir le fitness\n",
+    "// public class ThreePartFitness : IFitness { ... }\n",
+    "\n",
+    "// Etape 3 : Configurer les 3 sous-metaheuristiques\n",
+    "// var mh1 = new DefaultMetaHeuristic(); // position : exploration\n",
+    "// var mh2 = ... ; // vitesse : equilibrage\n",
+    "// var mh3 = ... ; // acceleration : exploitation\n",
+    "\n",
+    "// Etape 4 : Creer et executer l'EukaryoteMetaHeuristic\n",
+    "// var eukaryote = new EukaryoteMetaHeuristic(16, mh1, mh2, mh3)\n",
+    "// {\n",
+    "//     Scope = EvolutionStage.Crossover | EvolutionStage.Mutation\n",
+    "// };\n",
+    "\n",
+    "object result = null; // TODO etudiant : lancer le GA et afficher le resultat\n",
+    "Console.WriteLine(\"Exercice a completer : chromosome eucaryote a 3 parties\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exercise-2-header",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 : Comparer Eukaryote avec 2 sous-pops vs 4 sous-pops\n",
+    "\n",
+    "L'objectif est de comparer l'impact du nombre de sous-populations sur la convergence. Avec plus de sous-populations, chaque partition est plus petite et peut utiliser une strategie plus specialisee, mais la complexite de coordination augmente.\n",
+    "\n",
+    "**Enonce** : Configurez un chromosome a 32 genes et comparez :\n",
+    "- **Configuration 2 sous-pops** : deux partitions de 16 genes chacune\n",
+    "- **Configuration 4 sous-pops** : quatre partitions de 8 genes chacune\n",
+    "\n",
+    "**Indices** :\n",
+    "- Le chromosome Adam doit avoir 32 genes pour les deux tests\n",
+    "- Pour 2 sous-pops : `EukaryoteMetaHeuristic(16, mh1, mh2)` -- deux partitions egales\n",
+    "- Pour 4 sous-pops : `EukaryoteMetaHeuristic(8, mh1, mh2, mh3, mh4)` -- quatre partitions egales\n",
+    "- Adaptez le fitness pour un chromosome a 4 variables (ex: $f(x) = -\\sum |x_i - c_i|$ pour des cibles differentes)\n",
+    "- Observez si plus de sous-populations ameliore ou degrade la convergence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "exercise-2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T01:30:44.204297Z",
+     "iopub.status.busy": "2026-06-13T01:30:44.204077Z",
+     "iopub.status.idle": "2026-06-13T01:30:44.266525Z",
+     "shell.execute_reply": "2026-06-13T01:30:44.266286Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : 2 sous-pops vs 4 sous-pops\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Comparer Eukaryote avec 2 sous-pops vs 4 sous-pops\n",
+    "// TODO: Creez un chromosome a 4 genes (32 bits par gene, 4 x 8 bits par sous-pop en mode 4)\n",
+    "// TODO: Comparez la convergence de 2 sous-populations vs 4 sous-populations\n",
+    "// Indice: EukaryoteMetaHeuristic(16, mh1, mh2) pour 2 sous-pops (16+16 genes)\n",
+    "// Indice: EukaryoteMetaHeuristic(8, mh1, mh2, mh3, mh4) pour 4 sous-pops (8+8+8+8 genes)\n",
+    "// Indice: Le chromosome Adam doit avoir 32 genes pour les deux cas\n",
+    "\n",
+    "// Etape 1 : Definir le fitness (reutilisez PositionVelocityFitness ou un nouveau)\n",
+    "// var fitness = new PositionVelocityFitness();\n",
+    "\n",
+    "// Etape 2 : Configurer 2 sous-populations\n",
+    "// var mh_aggressive = new DefaultMetaHeuristic(); ...\n",
+    "// var mh_conservative = new DefaultMetaHeuristic(); ...\n",
+    "// var eukaryote2 = new EukaryoteMetaHeuristic(16, mh_aggressive, mh_conservative) { ... };\n",
+    "\n",
+    "// Etape 3 : Configurer 4 sous-populations\n",
+    "// var eukaryote4 = new EukaryoteMetaHeuristic(8, mh1, mh2, mh3, mh4) { ... };\n",
+    "\n",
+    "// Etape 4 : Comparer les deux configurations sur plusieurs runs\n",
+    "\n",
+    "object result = null; // TODO etudiant : lancer les comparaisons\n",
+    "Console.WriteLine(\"Exercice a completer : 2 sous-pops vs 4 sous-pops\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exercise-3-header",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : Implementer un SubPopulationMetaHeuristic personnalise avec des Match differents\n",
+    "\n",
+    "L'objectif est de creer une metaheuristique qui combine l'approche eucaryote avec des strategies de match differentes pour chaque sous-population : un match **Random** pour la premiere sous-population (exploration de la position) et un match **Best** pour la seconde (exploitation de la vitesse).\n",
+    "\n",
+    "**Enonce** : Composez un `EukaryoteMetaHeuristic` avec deux sous-metaheuristiques utilisant chacune un `MatchMetaHeuristic` different.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `MatchMetaHeuristic` peut etre utilise comme sous-metaheuristique dans `EukaryoteMetaHeuristic`\n",
+    "- Construisez un `MatchMetaHeuristic` avec `Current + Random` pour le gene 0 et `Current + Best` pour le gene 1\n",
+    "- `EukaryoteMetaHeuristic(16, matchRandom, matchBest)` cree deux sous-populations de 16 genes chacune\n",
+    "- Comparez avec l'Eukaryote standard (DefaultMetaHeuristic pour les deux sous-populations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "exercise-3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T01:30:44.268503Z",
+     "iopub.status.busy": "2026-06-13T01:30:44.268190Z",
+     "iopub.status.idle": "2026-06-13T01:30:44.305660Z",
+     "shell.execute_reply": "2026-06-13T01:30:44.305402Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : SubPopulationMetaHeuristic personnalise\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Implementer un SubPopulationMetaHeuristic personnalise\n",
+    "// TODO: Creez une classe qui utilise des strategies Match differentes par sous-population\n",
+    "// Indice: Heritez d'une classe existante ou composez avec MatchMetaHeuristic\n",
+    "// Indice: L'idee est d'avoir un match Random sur le premier gene et Best sur le second\n",
+    "\n",
+    "// Etape 1 : Definir la classe personnalisee\n",
+    "// public class CustomMatchEukaryote : ... { ... }\n",
+    "\n",
+    "// Etape 2 : L'utiliser avec EukaryoteMetaHeuristic\n",
+    "// var mh = new CustomMatchEukaryote(...);\n",
+    "\n",
+    "// Etape 3 : Executer et comparer avec l'Eukaryote standard\n",
+    "// var result = RunWithEukaryote(mh, \"CustomMatch\", generations: 50);\n",
+    "\n",
+    "object result = null; // TODO etudiant : implementer et tester\n",
+    "Console.WriteLine(\"Exercice a completer : SubPopulationMetaHeuristic personnalise\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nav-footer",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "**Navigation** : [Index](../README.md) | [<< MGS-2 Composition](MGS-2-Composition.ipynb) | [MGS-4 Populations >>](MGS-4-Populations.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Third pedagogical notebook for MetaGeneticSharp (Epic #1203, Phase 3). Introduces the Eukaryote concept — multi-chromosome individuals where different genome partitions are evolved by isolated sub-populations with different strategies.

### Notebook content

- **25 cells** (9 code + 16 markdown), kernel `.net-csharp`
- **EukaryoteChromosome**: karyotype decomposition, `GetKaryotype`, `UpdateParent`, `GetNewIndividual`
- **SubPopulation**: isolated population slices with independent `SubPopulationContext`
- **EukaryoteMetaHeuristic**: orchestrator with scope `Crossover | Mutation`, comparison Default+NoOp vs Default+Default
- **Gotcha documented**: `ProbabilityConfig.Crossover.OverwriteProbability` on sub-heuristics causes `NullReferenceException` in `GetNewIndividuals`
- **3 exercises** (#2161): 3-part chromosome, 2 vs 4 sub-pops convergence, custom MatchMetaHeuristic per sub-pop

### Validation (H.1)

- `jupyter nbconvert --execute` — 9/9 code cells, 0 errors
- C.1: stubs use `// TODO` + `result = null` + `Console.WriteLine("Exercice a completer")`, no `NotImplementedException`
- C.2: all code cells have `execution_count` + outputs
- No emojis, French markdown, English code comments
- No catalog files touched

### Context

- Prerequisites: MGS-1 (Introduction), MGS-2 (Composition)
- Next: MGS-4 (Islands & migration)

See #1203