### PR TITLE
feat(symbolic-ai): Z3-Python NB03 Tactics, BitVec, Array (See #1206)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/README.md
@@ -4,7 +4,7 @@
 
 ## Serie en quelques mots
 
-**2 notebooks (en cours) | 1 kernel | z3-solver (Python) | matplotlib**
+**3 notebooks (en cours) | 1 kernel | z3-solver (Python) | matplotlib**
 
 **A qui s'adresse cette serie** : etudiants en IA, developpeurs Python souhaitant decouvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un probleme non pas comme un algorithme de resolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prerequis en logique formelle n'est suppose : les notebooks partent de la syntaxe de base de z3-py pour monter progressivement vers l'optimisation et la modelisation de problemes combinatoires.
 
@@ -42,7 +42,7 @@ Une serie sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basee sur le b
 |---|----------|-------|------|--------|
 | 01 | [Introduction](Z3-Python-01-Introduction.ipynb) | `Solver`, `Int`/`Bool`/`Real`, sat/unsat, `Optimize` | ~30 min | PRODUCTION |
 | 02 | [Sudoku](Z3-Python-02-Sudoku.ipynb) | Sudoku comme CSP, `Distinct`, visualisation matplotlib | ~25 min | PRODUCTION |
-| 03 | *(a venir)* Tactiques et theories | `Tactic`, `BitVec`, `Array` | — | Planifie |
+| 03 | [Tactiques et theories](Z3-Python-03-Tactics.ipynb) | `Tactic`, `BitVec`, `Array` | ~35 min | PRODUCTION |
 | 04 | *(a venir)* Chaines et expressions regulieres | `String`, `Re` (theorie des chaines Z3) | — | Planifie |
 | 05 | *(a venir)* Quantificateurs et preuves | `ForAll`, `Exists`, proofs, modele checking | — | Planifie |
 | 06 | *(a venir)* Optimisation avancee | Pareto, objectifs multiples, `Optimize` hierarchique | — | Planifie |
@@ -51,7 +51,8 @@ Une serie sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basee sur le b
 
 1. **Notebook 01** pose les bases : le patron `Solver()`, les types de base (`Int`, `Bool`, `Real`), les reponses `sat`/`unsat`/`unknown`, et l'optimisation avec `Optimize`
 2. **Notebook 02** applique l'approche declarative au Sudoku : modelisation par `Distinct`, resolution et visualisation (donne en noir / resolu en bleu)
-3. **Notebooks suivants (planifies)** : tactiques, theories de chaines, quantificateurs et optimisation avancee
+3. **Notebook 03** explore les tactiques (`simplify`, `Then`, `OrElse`), les theories `BitVec` (arithmetique modulaire) et `Array` (tableaux symboliques)
+4. **Notebooks suivants (planifies)** : theories de chaines, quantificateurs et optimisation avancee
 
 ## Prerequis
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-03-Tactics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-03-Tactics.ipynb
@@ -1,0 +1,1467 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "024ee023",
+   "metadata": {
+    "papermill": {
+     "duration": 0.026375,
+     "end_time": "2026-06-13T02:45:11.749625+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:11.723250+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Z3-Python 03 — Tactiques et theories\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< Z3-Python-02 Sudoku](Z3-Python-02-Sudoku.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. **Utiliser** les tactiques Z3 pour simplifier et pretraiter les contraintes avant resolution\n",
+    "2. **Composer** des tactiques avec `Then`, `OrElse`, `Repeat` pour creer des pipelines de resolution\n",
+    "3. **Manipuler** des vecteurs de bits (`BitVec`) et comprendre la difference entre arithmetic signee et non signee\n",
+    "4. **Modeliser** des tableaux fonctionnels (`Array`) avec `Select` et `Store`\n",
+    "5. **Choisir** un solveur specialise (`SolverFor`) adapte au type de contraintes\n",
+    "\n",
+    "### Prerequis\n",
+    "- Z3-Python 01 (Introduction) : `Solver`, `Int`, `Bool`, `Real`, `Optimize`\n",
+    "- Notions de representation binaire des entiers\n",
+    "\n",
+    "### Duree estimee : ~40 min\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Les notebooks precedents ont utilise le solveur Z3 de maniere directe : on ajoute des contraintes, on appelle `check()`, on obtient un modele. En pratique, les problemes reels contiennent des centaines ou milliers de contraintes, et la **strategie de resolution** peut faire la difference entre une reponse instantanee et un timeout. Z3 offre les **tactiques** (*tactics*) pour controler finement cette strategie.\n",
+    "\n",
+    "Ce notebook explore egalement deux theories supplementaires de Z3 : les **vecteurs de bits** (`BitVec`), essentiels pour la verification de circuits et l'analyse cryptographique, et les **tableaux** (`Array`), qui modelisent des fonctions a acces indexe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bea962f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:11.804643Z",
+     "iopub.status.busy": "2026-06-13T02:45:11.803895Z",
+     "iopub.status.idle": "2026-06-13T02:45:12.138416Z",
+     "shell.execute_reply": "2026-06-13T02:45:12.125323Z"
+    },
+    "papermill": {
+     "duration": 0.348751,
+     "end_time": "2026-06-13T02:45:12.141061+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:11.792310+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : z3-solver version 4.16.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports et verification de l'environnement\n",
+    "from z3 import *\n",
+    "\n",
+    "print(f\"Imports OK : z3-solver version {get_version_string()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9de875ab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019944,
+     "end_time": "2026-06-13T02:45:12.183190+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:12.163246+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Tactiques Z3 : controler la strategie de resolution\n",
+    "\n",
+    "Une **tactique** Z3 est une fonction de transformation qui prend un ensemble de contraintes (un *goal*) et produit zero, un ou plusieurs sous-problemes (*subgoals*). Les tactiques permettent de :\n",
+    "\n",
+    "- **Simplifier** les contraintes avant resolution (eliminer les redondances, normaliser les expressions)\n",
+    "- **Decomposer** un probleme en sous-problemes independants (parallelisme)\n",
+    "- **Pretraiter** les contraintes pour les rendre plus digestes pour le solveur\n",
+    "\n",
+    "Le flux de travail typique avec les tactiques :\n",
+    "\n",
+    "1. Creer un `Goal` et y ajouter des contraintes\n",
+    "2. Appliquer une ou plusieurs tactiques au goal\n",
+    "3. Convertir le resultat en `Solver` avec `solver()` ou iterer sur les sous-but"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d01c7b84",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:12.218172Z",
+     "iopub.status.busy": "2026-06-13T02:45:12.217494Z",
+     "iopub.status.idle": "2026-06-13T02:45:12.383446Z",
+     "shell.execute_reply": "2026-06-13T02:45:12.378318Z"
+    },
+    "papermill": {
+     "duration": 0.184296,
+     "end_time": "2026-06-13T02:45:12.386264+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:12.201968+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Goal avant simplification :\n",
+      "  x + x + x == 3*x\n",
+      "  x > 0\n",
+      "  x > 0\n",
+      "  y == x + 1\n",
+      "\n",
+      "Apres Tactic('simplify') : 1 sous-goal(s)\n",
+      "  Sous-goal 0 : 2 contrainte(s)\n",
+      "    Not(x <= 0)\n",
+      "    y == 1 + x\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tactique simplify : simplification syntaxique de base\n",
+    "x = Int('x')\n",
+    "y = Int('y')\n",
+    "\n",
+    "g = Goal()\n",
+    "g.add(x + x + x == 3 * x)  # Trivialement vrai apres simplification\n",
+    "g.add(And(x > 0, x > 0))   # Doublon\n",
+    "g.add(y == x + 1)\n",
+    "\n",
+    "# Appliquer la tactique simplify\n",
+    "result = Tactic('simplify')(g)\n",
+    "print(\"Goal avant simplification :\")\n",
+    "for c in g:\n",
+    "    print(f\"  {c}\")\n",
+    "print(f\"\\nApres Tactic('simplify') : {len(result)} sous-goal(s)\")\n",
+    "for i in range(len(result)):\n",
+    "    sg = result[i]\n",
+    "    print(f\"  Sous-goal {i} : {sg.size()} contrainte(s)\")\n",
+    "    for j in range(sg.size()):\n",
+    "        print(f\"    {sg[j]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af77a485",
+   "metadata": {
+    "papermill": {
+     "duration": 0.016965,
+     "end_time": "2026-06-13T02:45:12.423082+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:12.406117+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : simplify\n",
+    "\n",
+    "**Sortie obtenue** : la tactique `simplify` a elimine la tautologie `x + x + x == 3 * x` (toujours vraie), fusionne le doublon `And(x > 0, x > 0)` en une seule contrainte, et normalise les expressions.\n",
+    "\n",
+    "| Tactique | Effet | Cout |\n",
+    "|----------|-------|------|\n",
+    "| `simplify` | Simplification syntaxique locale (propagation, elimination de `True`/`False`) | Tres faible |\n",
+    "| `ctx-solver-simplify` | Simplification contextuelle (tient compte des relations entre contraintes) | Plus eleve |\n",
+    "| `solve-eqs` | Elimine les variables par substitution d'equations | Moyen |\n",
+    "| `propagate-values` | Propage les constantes | Faible |\n",
+    "\n",
+    "> **Note technique** : `simplify` est rapide mais superficielle ; `ctx-solver-simplify` est plus puissante mais plus couteuse. Le choix depend de la taille du probleme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c641f58e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:12.452436Z",
+     "iopub.status.busy": "2026-06-13T02:45:12.451512Z",
+     "iopub.status.idle": "2026-06-13T02:45:12.642499Z",
+     "shell.execute_reply": "2026-06-13T02:45:12.633226Z"
+    },
+    "papermill": {
+     "duration": 0.206133,
+     "end_time": "2026-06-13T02:45:12.645426+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:12.439293+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Goal original :\n",
+      "  x > 10\n",
+      "  x > 5\n",
+      "  x + 2 > 7\n",
+      "\n",
+      "Apres 'simplify' :\n",
+      "  Not(x <= 10)\n",
+      "  Not(x <= 5)\n",
+      "\n",
+      "Apres 'ctx-solver-simplify' :\n",
+      "  Not(x <= 10)\n",
+      "  x > 5\n",
+      "  x + 2 > 7\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tactique ctx-solver-simplify : simplification contextuelle\n",
+    "# Cette tactique utilise le contexte global pour simplifier davantage.\n",
+    "\n",
+    "x = Int('x')\n",
+    "g = Goal()\n",
+    "g.add(x > 10)\n",
+    "g.add(x > 5)     # Redondant sachant x > 10\n",
+    "g.add(x + 2 > 7) # Redondant sachant x > 10\n",
+    "\n",
+    "# Comparaison des deux tactiques\n",
+    "res_simple = Tactic('simplify')(g)\n",
+    "res_ctx = Tactic('ctx-solver-simplify')(g)\n",
+    "\n",
+    "print(\"Goal original :\")\n",
+    "for c in g:\n",
+    "    print(f\"  {c}\")\n",
+    "\n",
+    "print(\"\\nApres 'simplify' :\")\n",
+    "for i in range(len(res_simple)):\n",
+    "    sg = res_simple[i]\n",
+    "    for j in range(sg.size()):\n",
+    "        print(f\"  {sg[j]}\")\n",
+    "\n",
+    "print(\"\\nApres 'ctx-solver-simplify' :\")\n",
+    "for i in range(len(res_ctx)):\n",
+    "    sg = res_ctx[i]\n",
+    "    for j in range(sg.size()):\n",
+    "        print(f\"  {sg[j]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2296f1db",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023177,
+     "end_time": "2026-06-13T02:45:12.689046+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:12.665869+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : simplification contextuelle\n",
+    "\n",
+    "**Sortie obtenue** : la tactique `simplify` normalise les contraintes (par exemple `x > 10` devient `Not(x <= 10)`) mais ne detecte pas les redundances. La tactique `ctx-solver-simplify` raisonne sur le contexte mais peut conserver certaines contraintes selon la version de Z3.\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `simplify` traite chaque contrainte isolement et normalise les expressions.\n",
+    "2. `ctx-solver-simplify` tient compte du **contexte global** pour eliminer les redundances detectees.\n",
+    "3. Sur de gros problemes, le pretraitement peut reduire significativement le nombre de contraintes utiles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbe4ea6a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.035144,
+     "end_time": "2026-06-13T02:45:12.746474+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:12.711330+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 1.1 Composer des tactiques : `Then`, `OrElse`, `Repeat`, `TryFor`\n",
+    "\n",
+    "Z3 permet de **composer** des tactiques pour creer des pipelines de resolution. Les combinateurs principaux :\n",
+    "\n",
+    "| Combinateur | Effet |\n",
+    "|-------------|-------|\n",
+    "| `Then(t1, t2)` | Applique t1, puis t2 sur chaque sous-but issu de t1 |\n",
+    "| `OrElse(t1, t2)` | Essaie t1, si echec essaie t2 |\n",
+    "| `Repeat(t)` | Applique t jusqu'a point fixe |\n",
+    "| `TryFor(t, ms)` | Applique t avec un timeout (en millisecondes) |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f23d0402",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:12.799940Z",
+     "iopub.status.busy": "2026-06-13T02:45:12.799050Z",
+     "iopub.status.idle": "2026-06-13T02:45:13.054535Z",
+     "shell.execute_reply": "2026-06-13T02:45:13.050119Z"
+    },
+    "papermill": {
+     "duration": 0.281397,
+     "end_time": "2026-06-13T02:45:13.057410+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:12.776013+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Goal original :\n",
+      "  y == x + 5\n",
+      "  z == y*2\n",
+      "  x > 0\n",
+      "  z < 30\n",
+      "\n",
+      "Apres Then(simplify, solve-eqs) : 1 sous-goal(s)\n",
+      "  Sous-goal 0 (2 contrainte(s)) :\n",
+      "    Not(y <= 5)\n",
+      "    Not(y >= 15)\n",
+      "\n",
+      "Expression du sous-but : And(Not(y <= 5), Not(y >= 15))\n",
+      "Resolution complete : sat\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  x = 1, y = 6, z = 12\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Composition de tactiques : pipeline simplifier -> substituer -> resoudre\n",
+    "x = Int('x')\n",
+    "y = Int('y')\n",
+    "z = Int('z')\n",
+    "\n",
+    "g = Goal()\n",
+    "g.add(y == x + 5)\n",
+    "g.add(z == y * 2)\n",
+    "g.add(x > 0)\n",
+    "g.add(z < 30)\n",
+    "\n",
+    "# Pipeline : simplifier puis eliminer les equations\n",
+    "pipeline = Then(Tactic('simplify'), Tactic('solve-eqs'))\n",
+    "result = pipeline(g)\n",
+    "\n",
+    "print(\"Goal original :\")\n",
+    "for c in g:\n",
+    "    print(f\"  {c}\")\n",
+    "\n",
+    "print(f\"\\nApres Then(simplify, solve-eqs) : {len(result)} sous-goal(s)\")\n",
+    "for i in range(len(result)):\n",
+    "    sg = result[i]\n",
+    "    print(f\"  Sous-goal {i} ({sg.size()} contrainte(s)) :\")\n",
+    "    for j in range(sg.size()):\n",
+    "        print(f\"    {sg[j]}\")\n",
+    "\n",
+    "# Convertir le sous-but en expression et resoudre avec un Solver classique\n",
+    "expr = result[0].as_expr()\n",
+    "print(f\"\\nExpression du sous-but : {expr}\")\n",
+    "\n",
+    "# Pour obtenir un modele avec toutes les variables, on utilise le Solver d'origine\n",
+    "s = Solver()\n",
+    "for c in g:\n",
+    "    s.add(c)\n",
+    "print(f\"Resolution complete : {s.check()}\")\n",
+    "if s.check() == sat:\n",
+    "    m = s.model()\n",
+    "    print(f\"  x = {m[x]}, y = {m[y]}, z = {m[z]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e889366e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017224,
+     "end_time": "2026-06-13T02:45:13.099040+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.081816+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : composition de tactiques\n",
+    "\n",
+    "**Sortie obtenue** : le pipeline `Then(simplify, solve-eqs)` a d'abord simplifie les contraintes, puis elimine les equations `y == x + 5` et `z == y * 2` par substitution. Les variables `x` et `z` ont ete remplacees dans les inequations restantes, ne laissant que des contraintes sur `y`. On utilise ensuite un `Solver` classique pour obtenir un modele complet.\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `solve-eqs` detecte les equations de la forme `var == expr` et substitue `var` partout.\n",
+    "2. La composition `Then` execute les tactiques **en sequence** : la sortie de l'une alimente l'autre.\n",
+    "3. `as_expr()` convertit un sous-but en expression Z3 (conjonction de ses contraintes).\n",
+    "4. Les tactiques transforment les contraintes mais ne resolvent pas ; la resolution finale se fait via un `Solver`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "eafa4e42",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:13.158771Z",
+     "iopub.status.busy": "2026-06-13T02:45:13.157994Z",
+     "iopub.status.idle": "2026-06-13T02:45:13.205374Z",
+     "shell.execute_reply": "2026-06-13T02:45:13.200295Z"
+    },
+    "papermill": {
+     "duration": 0.08765,
+     "end_time": "2026-06-13T02:45:13.209079+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.121429+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apres Repeat(simplify + propagate-values) :\n",
+      "  Sous-goal 0 : 0 contrainte(s)\n",
+      "\n",
+      "Apres OrElse(ctx-solver-simplify, simplify) :\n",
+      "  Not(x <= 5)\n",
+      "  x < 10\n",
+      "\n",
+      "1 sous-goal(s) traite(s) avec succes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# OrElse et Repeat : essayer plusieurs strategies et iterer\n",
+    "x = Int('x')\n",
+    "\n",
+    "# Repeat : appliquer une tactique jusqu'a point fixe\n",
+    "g = Goal()\n",
+    "g.add(x + 0 == x)\n",
+    "g.add(x * 1 == x)\n",
+    "\n",
+    "repeat_tac = Repeat(Then(Tactic('simplify'), Tactic('propagate-values')))\n",
+    "result = repeat_tac(g)\n",
+    "print(\"Apres Repeat(simplify + propagate-values) :\")\n",
+    "for i in range(len(result)):\n",
+    "    sg = result[i]\n",
+    "    print(f\"  Sous-goal {i} : {sg.size()} contrainte(s)\")\n",
+    "    for j in range(sg.size()):\n",
+    "        print(f\"    {sg[j]}\")\n",
+    "\n",
+    "# OrElse : fallback entre tactiques\n",
+    "g2 = Goal()\n",
+    "g2.add(x > 5)\n",
+    "g2.add(x < 10)\n",
+    "\n",
+    "# Essaye ctx-solver-simplify, sinon simplify en fallback\n",
+    "fallback = OrElse(Tactic('ctx-solver-simplify'), Tactic('simplify'))\n",
+    "result2 = fallback(g2)\n",
+    "print(\"\\nApres OrElse(ctx-solver-simplify, simplify) :\")\n",
+    "for i in range(len(result2)):\n",
+    "    sg = result2[i]\n",
+    "    for j in range(sg.size()):\n",
+    "        print(f\"  {sg[j]}\")\n",
+    "\n",
+    "print(f\"\\n{len(result2)} sous-goal(s) traite(s) avec succes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "308b1bc3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023551,
+     "end_time": "2026-06-13T02:45:13.262228+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.238677+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : combinateurs\n",
+    "\n",
+    "**Sortie obtenue** : les expressions triviales `x + 0 == x` et `x * 1 == x` sont reduites par le pipeline repete. Le combinateur `OrElse` tente la premiere tactique et bascule sur la seconde en cas d'echec.\n",
+    "\n",
+    "| Combinateur | Analogie | Usage typique |\n",
+    "|-------------|----------|---------------|\n",
+    "| `Then` | Pipeline (pipe `\\|`) | Pretraitement en etapes successives |\n",
+    "| `OrElse` | Try-catch | Tactique rapide d'abord, robuste en fallback |\n",
+    "| `Repeat` | Boucle while | Raffiner iterativement jusqu'a stabilite |\n",
+    "| `TryFor` | Timeout | Limiter le temps passe dans une tactique couteuse |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80403e3e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022454,
+     "end_time": "2026-06-13T02:45:13.313401+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.290947+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Theorie des vecteurs de bits : `BitVec`\n",
+    "\n",
+    "Un **vecteur de bits** (*bitvector*) est une sequence de n bits representant un entier modulo $2^n$. Contrairement a `Int` (entiers mathematiques non bornes), les `BitVec` modelisent le comportement exact du materiel informatique : debordement, arithmetic modulaire, operations bit a bit.\n",
+    "\n",
+    "Applications : verification de circuits, analyse cryptographique, emulation de processeurs.\n",
+    "\n",
+    "| Aspect | `Int` | `BitVec(n)` |\n",
+    "|--------|-------|-------------|\n",
+    "| Domaine | $\\mathbb{Z}$ (entiers infinis) | $\\{0, \\ldots, 2^n - 1\\}$ (modulo $2^n$) |\n",
+    "| Debordement | Pas de debordement | Wrapping modulaire |\n",
+    "| Operations bit a bit | Non disponibles | `&`, `|`, `^`, `~`, `<<`, `>>` |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "db8a4ca1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:13.381314Z",
+     "iopub.status.busy": "2026-06-13T02:45:13.380563Z",
+     "iopub.status.idle": "2026-06-13T02:45:13.475435Z",
+     "shell.execute_reply": "2026-06-13T02:45:13.471384Z"
+    },
+    "papermill": {
+     "duration": 0.121422,
+     "end_time": "2026-06-13T02:45:13.478705+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.357283+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resolution : sat\n",
+      "  x = 255 (valeur entiere : 255)\n",
+      "  y = x + 1 = 0 (valeur entiere : 0)\n",
+      "  255 + 1 modulo 256 = 0\n",
+      "\n",
+      "Cas XOR/AND : sat\n",
+      "  a = 254 (binaire : 11111110)\n",
+      "  b =   1 (binaire : 00000001)\n",
+      "  a XOR b = 11111111\n",
+      "  a AND b = 00000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# BitVec : creation, arithmetic modulaire et operations bit a bit\n",
+    "x = BitVec('x', 8)  # Vecteur de 8 bits (0 a 255)\n",
+    "y = BitVec('y', 8)\n",
+    "\n",
+    "s = Solver()\n",
+    "\n",
+    "# Arithmetic modulaire : 255 + 1 = 0 en 8 bits (wrapping)\n",
+    "s.add(x == BitVecVal(255, 8))\n",
+    "s.add(y == x + 1)  # 255 + 1 = 0 (mod 256)\n",
+    "\n",
+    "print(f\"Resolution : {s.check()}\")\n",
+    "m = s.model()\n",
+    "print(f\"  x = {m[x]} (valeur entiere : {m[x].as_long()})\")\n",
+    "print(f\"  y = x + 1 = {m[y]} (valeur entiere : {m[y].as_long()})\")\n",
+    "print(f\"  255 + 1 modulo 256 = {(255 + 1) % 256}\")\n",
+    "\n",
+    "# Operations bit a bit\n",
+    "s2 = Solver()\n",
+    "a = BitVec('a', 8)\n",
+    "b = BitVec('b', 8)\n",
+    "\n",
+    "# Trouver a et b tels que a XOR b = 0xFF mais a AND b = 0\n",
+    "s2.add(a ^ b == BitVecVal(0xFF, 8))  # Tous les bits differents\n",
+    "s2.add(a & b == BitVecVal(0, 8))      # Aucun bit en commun\n",
+    "\n",
+    "print(f\"\\nCas XOR/AND : {s2.check()}\")\n",
+    "m2 = s2.model()\n",
+    "print(f\"  a = {m2[a].as_long():3d} (binaire : {m2[a].as_long():08b})\")\n",
+    "print(f\"  b = {m2[b].as_long():3d} (binaire : {m2[b].as_long():08b})\")\n",
+    "print(f\"  a XOR b = {m2[a].as_long() ^ m2[b].as_long():08b}\")\n",
+    "print(f\"  a AND b = {m2[a].as_long() & m2[b].as_long():08b}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ca6be92",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009815,
+     "end_time": "2026-06-13T02:45:13.604095+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.594280+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : vecteurs de bits\n",
+    "\n",
+    "**Sortie obtenue** : l'addition modulaire montre le wrapping caracteristique (255 + 1 = 0). L'exemple XOR/AND illustre les operations bit a bit.\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Les operations arithmetiques sur `BitVec` sont **automatiquement modulaires** : pas de debordement, le resultat \"wraps\" autour de $2^n$.\n",
+    "2. Les operateurs Python `&`, `|`, `^`, `~`, `<<`, `>>` sont surcharges pour construire des expressions symboliques Z3.\n",
+    "3. `BitVecVal(255, 8)` cree une constante ; `BitVec('x', 8)` cree une variable symbolique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b80a09c5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:13.658161Z",
+     "iopub.status.busy": "2026-06-13T02:45:13.657407Z",
+     "iopub.status.idle": "2026-06-13T02:45:13.699871Z",
+     "shell.execute_reply": "2026-06-13T02:45:13.694547Z"
+    },
+    "papermill": {
+     "duration": 0.077935,
+     "end_time": "2026-06-13T02:45:13.703189+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.625254+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "200 (unsigned) > 100 ? sat\n",
+      "  a = 200 (unsigned) = -56 (signed)\n",
+      "\n",
+      "Operateurs signes vs non signes :\n",
+      "| Operation     | Signe     | Non signe  |\n",
+      "|---------------|-----------|------------|\n",
+      "| a < b         | a < b     | ULT(a, b)  |\n",
+      "| a <= b        | a <= b    | ULE(a, b)  |\n",
+      "| a > b         | a > b     | UGT(a, b)  |\n",
+      "| a >= b        | a >= b    | UGE(a, b)  |\n",
+      "| a / b         | a / b     | UDiv(a, b) |\n",
+      "| a % b         | a % b     | URem(a, b) |\n",
+      "| a >> b        | arith.    | LShR(a, b) |\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Arithmetic signee vs non signee sur les BitVec\n",
+    "# Un meme vecteur de bits peut etre interprete comme signe ou non signe.\n",
+    "\n",
+    "a = BitVec('a', 8)\n",
+    "b = BitVec('b', 8)\n",
+    "\n",
+    "# Comparaisons signees : traite le bit de poids fort comme signe\n",
+    "# -128 a 127 en signe, 0 a 255 en non signe\n",
+    "s = Solver()\n",
+    "s.add(a == BitVecVal(200, 8))  # 200 en non signe = -56 en signe\n",
+    "\n",
+    "# En non signe : 200 > 100 est vrai\n",
+    "s.add(UGT(a, BitVecVal(100, 8)))  # UGT = Unsigned Greater Than\n",
+    "\n",
+    "# En signe : -56 > 100 est faux\n",
+    "print(f\"200 (unsigned) > 100 ? {s.check()}\")\n",
+    "if s.check() == sat:\n",
+    "    m = s.model()\n",
+    "    print(f\"  a = {m[a].as_long()} (unsigned) = {m[a].as_signed_long()} (signed)\")\n",
+    "\n",
+    "# Tableau des operateurs de comparaison\n",
+    "print(\"\\nOperateurs signes vs non signes :\")\n",
+    "print(\"| Operation     | Signe     | Non signe  |\")\n",
+    "print(\"|---------------|-----------|------------|\")\n",
+    "print(\"| a < b         | a < b     | ULT(a, b)  |\")\n",
+    "print(\"| a <= b        | a <= b    | ULE(a, b)  |\")\n",
+    "print(\"| a > b         | a > b     | UGT(a, b)  |\")\n",
+    "print(\"| a >= b        | a >= b    | UGE(a, b)  |\")\n",
+    "print(\"| a / b         | a / b     | UDiv(a, b) |\")\n",
+    "print(\"| a % b         | a % b     | URem(a, b) |\")\n",
+    "print(\"| a >> b        | arith.    | LShR(a, b) |\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e03bab00",
+   "metadata": {
+    "papermill": {
+     "duration": 0.034954,
+     "end_time": "2026-06-13T02:45:13.773889+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.738935+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : signe vs non signe\n",
+    "\n",
+    "**Sortie obtenue** : la valeur 200 est positive en non signe mais negative en signe (-56). Les operateurs `UGT`, `ULT`, etc. permettent de specifier l'interpretation souhaitee.\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Les operateurs Python `<`, `>`, `<=`, `>=` sont **signes** par defaut dans Z3.\n",
+    "2. Pour les comparaisons non signees, utiliser `UGT`, `ULT`, `UGE`, `ULE`.\n",
+    "3. La division et le decalage existent aussi en versions signees et non signees."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8989b5f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:13.813350Z",
+     "iopub.status.busy": "2026-06-13T02:45:13.812598Z",
+     "iopub.status.idle": "2026-06-13T02:45:13.863411Z",
+     "shell.execute_reply": "2026-06-13T02:45:13.859557Z"
+    },
+    "papermill": {
+     "duration": 0.072037,
+     "end_time": "2026-06-13T02:45:13.868025+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.795988+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Palindrome binaire : sat\n",
+      "  x = 66 (binaire : 01000010)\n",
+      "  Verification : 01000010 se lit identiquement dans les deux sens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Casse-tete BitVec : trouver un nombre dont les bits sont un palindrome\n",
+    "# Un palindrome binaire 8 bits se lit de la meme facon de gauche a droite et de droite a gauche.\n",
+    "# Exemple : 10011001 (= 153) est un palindrome binaire.\n",
+    "\n",
+    "def reverse_bits_8(val):\n",
+    "    \"\"\"Inverse l'ordre des 8 bits d'un BitVec 8 bits.\"\"\"\n",
+    "    result = BitVecVal(0, 8)\n",
+    "    for i in range(8):\n",
+    "        # Extraire le bit i et le placer en position (7 - i)\n",
+    "        bit_i = Extract(i, i, val)\n",
+    "        result = result | Concat(BitVecVal(0, 7), bit_i) << (7 - i)\n",
+    "    return result\n",
+    "\n",
+    "x = BitVec('x', 8)\n",
+    "s = Solver()\n",
+    "\n",
+    "# x doit etre un palindrome binaire : x == reverse(x)\n",
+    "s.add(x == reverse_bits_8(x))\n",
+    "# Exclure 0 et 255 pour trouver un cas non trivial\n",
+    "s.add(x != BitVecVal(0, 8))\n",
+    "s.add(x != BitVecVal(255, 8))\n",
+    "# Preferer un palindrome pair (bit 0 = 0)\n",
+    "s.add((x & BitVecVal(1, 8)) == BitVecVal(0, 8))\n",
+    "\n",
+    "print(f\"Palindrome binaire : {s.check()}\")\n",
+    "if s.check() == sat:\n",
+    "    m = s.model()\n",
+    "    val = m[x].as_long()\n",
+    "    print(f\"  x = {val} (binaire : {val:08b})\")\n",
+    "    print(f\"  Verification : {val:08b} se lit identiquement dans les deux sens\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1122d983",
+   "metadata": {
+    "papermill": {
+     "duration": 0.027912,
+     "end_time": "2026-06-13T02:45:13.936491+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.908579+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Theorie des tableaux : `Array`\n",
+    "\n",
+    "En Z3, un **tableau** (*Array*) est une fonction totale des index vers des valeurs. Les deux operations fondamentales :\n",
+    "\n",
+    "- **`Select(a, i)`** : lecture de la valeur a l'index `i` dans le tableau `a` (equivalent de `a[i]`)\n",
+    "- **`Store(a, i, v)`** : ecriture de la valeur `v` a l'index `i`, renvoyant un **nouveau** tableau (immutabilite)\n",
+    "\n",
+    "La theorie des tableaux est essentielle pour modeliser des memoires, des caches, des registres ou des mappings.\n",
+    "\n",
+    "| Propriete | Description |\n",
+    "|-----------|-------------|\n",
+    "| Immutabilite | `Store` ne modifie pas le tableau ; il en renvoie un nouveau |\n",
+    "| Totalite | Tout index a une valeur (la valeur par defaut si non initialise) |\n",
+    "| Axiome de selection | `Select(Store(a, i, v), i) == v` |\n",
+    "| Axiome de non-selection | `i != j => Select(Store(a, i, v), j) == Select(a, j)` |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7b839b11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:14.013384Z",
+     "iopub.status.busy": "2026-06-13T02:45:14.012681Z",
+     "iopub.status.idle": "2026-06-13T02:45:14.103116Z",
+     "shell.execute_reply": "2026-06-13T02:45:14.099123Z"
+    },
+    "papermill": {
+     "duration": 0.124397,
+     "end_time": "2026-06-13T02:45:14.108301+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:13.983904+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resolution : sat\n",
+      "  a[0] = 10\n",
+      "  a[1] = 20\n",
+      "  a[2] = 30\n",
+      "  a[0] + a[1] = 30\n",
+      "\n",
+      "Store : sat\n",
+      "  b[0] = 99 (modifie par Store)\n",
+      "  b[1] = 20 (inchange par Store)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Array : lecture, ecriture et raisonnement sur les tableaux\n",
+    "# Modelisons un tableau d'entiers indexe par des entiers.\n",
+    "\n",
+    "a = Array('a', IntSort(), IntSort())  # Tableau : Int -> Int\n",
+    "\n",
+    "s = Solver()\n",
+    "\n",
+    "# Contraintes sur le tableau initial\n",
+    "s.add(Select(a, 0) == 10)\n",
+    "s.add(Select(a, 1) == 20)\n",
+    "s.add(Select(a, 2) == 30)\n",
+    "\n",
+    "# Demonstration : a[0] + a[1] == 30\n",
+    "somme = Select(a, 0) + Select(a, 1)\n",
+    "s.add(somme == 30)\n",
+    "\n",
+    "print(f\"Resolution : {s.check()}\")\n",
+    "if s.check() == sat:\n",
+    "    m = s.model()\n",
+    "    print(f\"  a[0] = {m.evaluate(Select(a, 0))}\")\n",
+    "    print(f\"  a[1] = {m.evaluate(Select(a, 1))}\")\n",
+    "    print(f\"  a[2] = {m.evaluate(Select(a, 2))}\")\n",
+    "    print(f\"  a[0] + a[1] = {m.evaluate(somme)}\")\n",
+    "\n",
+    "# Store : creer un nouveau tableau avec une modification\n",
+    "b = Store(a, 0, 99)  # b est un tableau ou l'index 0 vaut 99\n",
+    "s2 = Solver()\n",
+    "s2.add(Select(a, 0) == 10)\n",
+    "s2.add(Select(b, 0) == 99)       # b[0] = 99 (modifie)\n",
+    "s2.add(Select(b, 1) == 20)       # b[1] = 20 (inchange)\n",
+    "\n",
+    "print(f\"\\nStore : {s2.check()}\")\n",
+    "if s2.check() == sat:\n",
+    "    m2 = s2.model()\n",
+    "    print(f\"  b[0] = {m2.evaluate(Select(b, 0))} (modifie par Store)\")\n",
+    "    print(f\"  b[1] = {m2.evaluate(Select(b, 1))} (inchange par Store)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "431cda4c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.041091,
+     "end_time": "2026-06-13T02:45:14.177374+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.136283+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : tableaux Z3\n",
+    "\n",
+    "**Sortie obtenue** : le solveur trouve un modele coherent pour le tableau. L'operation `Store` cree un nouveau tableau ou seul l'index specifie est modifie ; les autres valeurs sont preservees.\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Les tableaux Z3 sont des **fonctions pures** : `Store` ne mute pas, il produit une nouvelle fonction.\n",
+    "2. `Select(a, i)` equivaut a l'application fonctionnelle `a(i)`.\n",
+    "3. L'axiome fondamental : `Select(Store(a, i, v), j)` vaut `v` si `i == j`, sinon `Select(a, j)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0ece8020",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:14.251026Z",
+     "iopub.status.busy": "2026-06-13T02:45:14.250315Z",
+     "iopub.status.idle": "2026-06-13T02:45:14.314988Z",
+     "shell.execute_reply": "2026-06-13T02:45:14.310361Z"
+    },
+    "papermill": {
+     "duration": 0.113341,
+     "end_time": "2026-06-13T02:45:14.324951+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.211610+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conservation du total : sat\n",
+      "  Avant  : c0=100, c1=200, c2=50\n",
+      "  Apres  : c0=130, c1=170, c2=50\n",
+      "  Total avant = 350\n",
+      "  Total apres = 350\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Array avance : contraintes sur un tableau avec Store successifs\n",
+    "# Scenario : un tableau represente les soldes de comptes.\n",
+    "# On effectue des operations et on veut verifier des proprietes.\n",
+    "\n",
+    "comptes = Array('comptes', IntSort(), IntSort())\n",
+    "\n",
+    "s = Solver()\n",
+    "\n",
+    "# Etat initial : comptes[0] = 100, comptes[1] = 200, comptes[2] = 50\n",
+    "s.add(Select(comptes, 0) == 100)\n",
+    "s.add(Select(comptes, 1) == 200)\n",
+    "s.add(Select(comptes, 2) == 50)\n",
+    "\n",
+    "# Operation 1 : transfer de 30 du compte 1 vers le compte 0\n",
+    "apres_transfer = Store(\n",
+    "    Store(comptes, 1, Select(comptes, 1) - 30),\n",
+    "    0, Select(comptes, 0) + 30\n",
+    ")\n",
+    "\n",
+    "# Verifier que le total est conserve\n",
+    "total_avant = Select(comptes, 0) + Select(comptes, 1) + Select(comptes, 2)\n",
+    "total_apres = Select(apres_transfer, 0) + Select(apres_transfer, 1) + Select(apres_transfer, 2)\n",
+    "\n",
+    "s.add(total_avant == total_apres)\n",
+    "\n",
+    "print(f\"Conservation du total : {s.check()}\")\n",
+    "if s.check() == sat:\n",
+    "    m = s.model()\n",
+    "    print(f\"  Avant  : c0={m.evaluate(Select(comptes, 0))}, \"\n",
+    "          f\"c1={m.evaluate(Select(comptes, 1))}, \"\n",
+    "          f\"c2={m.evaluate(Select(comptes, 2))}\")\n",
+    "    print(f\"  Apres  : c0={m.evaluate(Select(apres_transfer, 0))}, \"\n",
+    "          f\"c1={m.evaluate(Select(apres_transfer, 1))}, \"\n",
+    "          f\"c2={m.evaluate(Select(apres_transfer, 2))}\")\n",
+    "    print(f\"  Total avant = {m.evaluate(total_avant)}\")\n",
+    "    print(f\"  Total apres = {m.evaluate(total_apres)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b527b9ed",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02637,
+     "end_time": "2026-06-13T02:45:14.376543+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.350173+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Solveurs specialises : `SolverFor`\n",
+    "\n",
+    "Z3 dispose de solveurs optimises pour des **fragments** specifiques de la logique. Plutot que d'utiliser le solveur generique `Solver()`, on peut selectionner un solveur adapte a la theorie concernee :\n",
+    "\n",
+    "| Logique | Description | Types principaux |\n",
+    "|---------|-------------|------------------|\n",
+    "| `QF_LIA` | Quantifier-Free Linear Integer Arithmetic | `Int` (lineaire) |\n",
+    "| `QF_LRA` | Quantifier-Free Linear Real Arithmetic | `Real` (lineaire) |\n",
+    "| `QF_BV` | Quantifier-Free BitVectors | `BitVec` |\n",
+    "| `QF_UFLIA` | QF_LIA + fonctions non interpretees | `Int` + `Array` |\n",
+    "\n",
+    "Le prefixe **QF** signifie *Quantifier-Free* (sans quantificateurs `ForAll`/`Exists`). Les solveurs specialises sont souvent **plus rapides** car ils exploitent la structure du fragment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c1e96389",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:14.425437Z",
+     "iopub.status.busy": "2026-06-13T02:45:14.424612Z",
+     "iopub.status.idle": "2026-06-13T02:45:14.609706Z",
+     "shell.execute_reply": "2026-06-13T02:45:14.606110Z"
+    },
+    "papermill": {
+     "duration": 0.214354,
+     "end_time": "2026-06-13T02:45:14.614824+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.400470+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solveur generique : sat en 18.4 ms\n",
+      "SolverFor QF_LIA  : sat en 17.2 ms\n",
+      "Rapport (generic / specialized) : 1.1x\n",
+      "\n",
+      "Configuration globale avec set_option :\n",
+      "  verbose=0, timeout=10000 ms configures\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Comparaison : Solver generique vs SolverFor specialise\n",
+    "import time\n",
+    "\n",
+    "# Generer un systeme de contraintes lineaires entieres\n",
+    "n_vars = 50\n",
+    "variables = [Int(f'x{i}') for i in range(n_vars)]\n",
+    "\n",
+    "constraints = []\n",
+    "# Chaque variable entre 0 et 100\n",
+    "for v in variables:\n",
+    "    constraints.append(v >= 0)\n",
+    "    constraints.append(v <= 100)\n",
+    "# Contraintes lineaires entre variables consecutives\n",
+    "for i in range(n_vars - 1):\n",
+    "    constraints.append(variables[i] + variables[i + 1] <= 150)\n",
+    "    constraints.append(variables[i] + variables[i + 1] >= 50)\n",
+    "\n",
+    "# Solveur generique\n",
+    "s_generic = Solver()\n",
+    "for c in constraints:\n",
+    "    s_generic.add(c)\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "result_generic = s_generic.check()\n",
+    "time_generic = time.perf_counter() - t0\n",
+    "\n",
+    "# Solveur specialise QF_LIA\n",
+    "s_specialized = SolverFor('QF_LIA')\n",
+    "for c in constraints:\n",
+    "    s_specialized.add(c)\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "result_specialized = s_specialized.check()\n",
+    "time_specialized = time.perf_counter() - t0\n",
+    "\n",
+    "print(f\"Solveur generique : {result_generic} en {time_generic*1000:.1f} ms\")\n",
+    "print(f\"SolverFor QF_LIA  : {result_specialized} en {time_specialized*1000:.1f} ms\")\n",
+    "print(f\"Rapport (generic / specialized) : {time_generic / max(time_specialized, 1e-9):.1f}x\")\n",
+    "\n",
+    "# Configuration globale avec set_option\n",
+    "print(\"\\nConfiguration globale avec set_option :\")\n",
+    "set_option('verbose', 0)       # Niveau de verbosite (0 = silencieux)\n",
+    "set_option('timeout', 10000)   # Timeout en millisecondes\n",
+    "print(\"  verbose=0, timeout=10000 ms configures\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a304cd8b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032129,
+     "end_time": "2026-06-13T02:45:14.690375+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.658246+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : solveurs specialises\n",
+    "\n",
+    "**Sortie obtenue** : les deux solveurs trouvent `sat`, mais le solveur specialise `QF_LIA` est generalement plus rapide sur les contraintes lineaires entieres sans quantificateurs.\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `SolverFor('QF_LIA')` selectionne le moteur optimise pour l'arithmetic lineaire entiere sans quantificateurs.\n",
+    "2. `SolverFor('QF_BV')` est adapte aux problemes de vecteurs de bits.\n",
+    "3. `set_option('timeout', ms)` permet de limiter le temps de calcul global.\n",
+    "4. Le gain de performance depend du probleme ; sur de petites instances, la difference est souvent negligeable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d935da62",
+   "metadata": {
+    "papermill": {
+     "duration": 0.026194,
+     "end_time": "2026-06-13T02:45:14.736703+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.710509+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : Composer un pipeline de tactiques\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "On dispose du systeme de contraintes suivant :\n",
+    "- `a == b + 1`\n",
+    "- `c == a * 2`\n",
+    "- `b > 5`\n",
+    "- `c < 20`\n",
+    "\n",
+    "Creez un pipeline de tactiques `Then(simplify, solve-eqs)` et appliquez-le a un `Goal` contenant ces contraintes. Affichez les sous-but obtenus, puis resolvez le systeme avec un `Solver` pour obtenir les valeurs de `a`, `b` et `c`.\n",
+    "\n",
+    "### Indices\n",
+    "- Creez un `Goal()`, ajoutez les 4 contraintes.\n",
+    "- Construisez `Then(Tactic('simplify'), Tactic('solve-eqs'))` et appliquez-le au goal.\n",
+    "- Utilisez `len(result)` pour le nombre de sous-but et `result[i].size()` pour le nombre de contraintes.\n",
+    "- Pour obtenir les valeurs, ajoutez les contraintes originales a un `Solver` et appelez `check()` puis `model()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d679f119",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:14.803475Z",
+     "iopub.status.busy": "2026-06-13T02:45:14.802667Z",
+     "iopub.status.idle": "2026-06-13T02:45:14.829264Z",
+     "shell.execute_reply": "2026-06-13T02:45:14.823529Z"
+    },
+    "papermill": {
+     "duration": 0.064684,
+     "end_time": "2026-06-13T02:45:14.832109+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.767425+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat du pipeline : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 1 : Pipeline de tactiques.\n",
+    "\n",
+    "def pipeline_tactiques() -> dict:\n",
+    "    \"\"\"Applique Then(simplify, solve-eqs) et retourne le resultat.\n",
+    "\n",
+    "    Retourne : {'a': val, 'b': val, 'c': val, 'nb_contraintes_final': int}\n",
+    "\n",
+    "    # Indice : creez un Goal, ajoutez les 4 contraintes, appliquez le pipeline.\n",
+    "    # Etape 1 : declarer a, b, c comme Int\n",
+    "    # Etape 2 : creer le Goal et ajouter les contraintes\n",
+    "    # Etape 3 : construire Then(Tactic('simplify'), Tactic('solve-eqs'))\n",
+    "    # Etape 4 : utiliser len(result) et result[0].size() pour le nombre de contraintes\n",
+    "    # Etape 5 : ajouter les contraintes a un Solver pour obtenir les valeurs\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implémentez le pipeline\n",
+    "    return None  # TODO etudiant : remplacer par le résultat\n",
+    "\n",
+    "resultat = pipeline_tactiques()\n",
+    "print(\"Resultat du pipeline :\", resultat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27d2e260",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015476,
+     "end_time": "2026-06-13T02:45:14.874794+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.859318+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 : Clef cryptographique avec BitVec\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Un message de 8 bits a ete chiffre par XOR avec une clef `k`. Le message chiffre est `0xA5` (165 en decimal). On sait que le message original est un multiple de 4 (en valeur entiere non signee).\n",
+    "\n",
+    "Trouvez la clef `k` (8 bits) telle que `message ^ k == 0xA5` et `message` soit un multiple de 4.\n",
+    "\n",
+    "### Indices\n",
+    "- Un multiple de 4 en binaire se termine par `00` (les 2 bits de poids faible sont nuls).\n",
+    "- Contrainte : `(message & BitVecVal(3, 8)) == BitVecVal(0, 8)`.\n",
+    "- Le chiffrement XOR est reversible : `message = 0xA5 ^ k`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e6f8fc07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:14.910531Z",
+     "iopub.status.busy": "2026-06-13T02:45:14.909773Z",
+     "iopub.status.idle": "2026-06-13T02:45:14.927040Z",
+     "shell.execute_reply": "2026-06-13T02:45:14.918410Z"
+    },
+    "papermill": {
+     "duration": 0.043755,
+     "end_time": "2026-06-13T02:45:14.930887+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.887132+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Clef trouvee : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 2 : Trouver la clef XOR.\n",
+    "\n",
+    "def trouver_clef_xor() -> dict:\n",
+    "    \"\"\"Trouve la clef k telle que message ^ k == 0xA5 et message est multiple de 4.\n",
+    "\n",
+    "    Retourne : {'clef': int, 'message': int}\n",
+    "\n",
+    "    # Indice : k = BitVec('k', 8), message = 0xA5 ^ k.\n",
+    "    # Etape 1 : declarer k (BitVec 8 bits)\n",
+    "    # Etape 2 : message = BitVecVal(0xA5, 8) ^ k\n",
+    "    # Etape 3 : ajouter la contrainte (message & 3) == 0\n",
+    "    # Etape 4 : resoudre et extraire k et message\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implémentez la recherche de clef\n",
+    "    return None  # TODO etudiant : remplacer par le résultat\n",
+    "\n",
+    "clef = trouver_clef_xor()\n",
+    "print(\"Clef trouvee :\", clef)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0aa5c18a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.047044,
+     "end_time": "2026-06-13T02:45:15.002075+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:14.955031+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 : Verifier une mise a jour de tableau\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "On dispose d'un tableau `scores` indexe par des entiers. On veut verifier la propriete suivante : si on effectue deux `Store` successifs sur des index differents `i` et `j` (avec `i != j`), l'ordre des Store n'a pas d'importance sur le resultat final.\n",
+    "\n",
+    "Autrement dit, prouvez que pour tout tableau `a`, index `i != j` et valeurs `v1`, `v2` :\n",
+    "$$\\text{Store}(\\text{Store}(a, i, v_1), j, v_2) \\text{ est equivalent a } \\text{Store}(\\text{Store}(a, j, v_2), i, v_1)$$\n",
+    "\n",
+    "Verifiez cette propriete en tentant de trouver un contre-exemple (le solveur doit repondre `unsat`).\n",
+    "\n",
+    "### Indices\n",
+    "- Creez deux tableaux : `seq1 = Store(Store(a, i, v1), j, v2)` et `seq2 = Store(Store(a, j, v2), i, v1)`.\n",
+    "- Ajoutez la contrainte `i != j`.\n",
+    "- Ajoutez `Select(seq1, k) != Select(seq2, k)` pour un index `k` quelconque.\n",
+    "- Si `unsat`, la propriete est prouvee."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "2b4b4d43",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T02:45:15.066072Z",
+     "iopub.status.busy": "2026-06-13T02:45:15.065286Z",
+     "iopub.status.idle": "2026-06-13T02:45:15.086508Z",
+     "shell.execute_reply": "2026-06-13T02:45:15.081901Z"
+    },
+    "papermill": {
+     "duration": 0.044215,
+     "end_time": "2026-06-13T02:45:15.090393+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:15.046178+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Commutativite des Store : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 3 : Commutativite des Store sur des index differents.\n",
+    "\n",
+    "def verifier_commutativite_store() -> str:\n",
+    "    \"\"\"Prouve que Store(a, i, v1) puis Store(..., j, v2) commute si i != j.\n",
+    "\n",
+    "    Retourne : 'prouve' si unsat, 'non_prouve' sinon.\n",
+    "\n",
+    "    # Indice : creez a, i, j, v1, v2, k comme variables.\n",
+    "    # Etape 1 : declarer a = Array('a', IntSort(), IntSort()) et i, j, v1, v2, k comme Int\n",
+    "    # Etape 2 : seq1 = Store(Store(a, i, v1), j, v2)\n",
+    "    # Etape 3 : seq2 = Store(Store(a, j, v2), i, v1)\n",
+    "    # Etape 4 : ajouter i != j et Select(seq1, k) != Select(seq2, k)\n",
+    "    # Etape 5 : si unsat -> 'prouve'\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implémentez la vérification\n",
+    "    return None  # TODO etudiant : remplacer par 'prouve' ou 'non_prouve'\n",
+    "\n",
+    "resultat = verifier_commutativite_store()\n",
+    "print(\"Commutativite des Store :\", resultat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f2dfa5a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019101,
+     "end_time": "2026-06-13T02:45:15.134440+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T02:45:15.115339+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Recapitulatif\n",
+    "\n",
+    "Ce notebook a explore les mecanismes avances de Z3 au-dela du solveur de base :\n",
+    "\n",
+    "| Concept | API Z3 | Usage |\n",
+    "|---------|--------|-------|\n",
+    "| Tactiques | `Tactic`, `Goal`, `Then`, `OrElse`, `Repeat` | Pretraiter, simplifier, decomposer les contraintes |\n",
+    "| Simplification | `simplify`, `ctx-solver-simplify` | Eliminer les redundances (syntaxique ou contextuelle) |\n",
+    "| Vecteurs de bits | `BitVec`, `UGT`, `ULT`, `Extract`, `Concat` | Arithmetic modulaire, operations bit a bit, circuits |\n",
+    "| Tableaux | `Array`, `Select`, `Store` | Memoires fonctionnelles, mappings, verification de transitions |\n",
+    "| Solveurs specialises | `SolverFor('QF_LIA')`, `SolverFor('QF_BV')` | Exploiter la structure du probleme pour accelerer la resolution |\n",
+    "\n",
+    "**Points essentiels a retenir** :\n",
+    "1. Les **tactiques** offrent un controle fin sur la strategie de resolution ; elles sont composees en pipelines.\n",
+    "2. Les `BitVec` modelisent le comportement exact du materiel (wrapping modulaire, operations bit a bit, signe vs non signe).\n",
+    "3. Les `Array` sont des fonctions pures ; `Store` est immutable et `Select` lit la valeur.\n",
+    "4. `SolverFor` permet de selectionner un solveur adapte au fragment logique du probleme.\n",
+    "\n",
+    "Les prochains notebooks exploreront les theories de chaines (`String`, `Re`), les quantificateurs (`ForAll`, `Exists`) et l'optimisation avancee (objectifs multiples, Pareto)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 10.460397,
+   "end_time": "2026-06-13T02:45:16.183163+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-03-Tactics.ipynb",
+   "output_path": "/tmp/Z3-Python-03-Tactics_wsl_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-13T02:45:05.722766+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Add **Z3-Python-03-Tactics.ipynb** (NB03) to the Z3-Python series, covering Tactiques et theories.

### Content (32 cells, 14 code)

| Section | Concepts | Cellules |
|---------|----------|----------|
| Tactiques | `simplify`, `ctx-solver-simplify`, `Then`/`OrElse`/`Repeat`/`TryFor` | 2-11 |
| BitVec | Arithmetique modulaire 8-bit, signe vs non-signe (`UGT`/`ULT`), palindrome | 12-17 |
| Array | `Select`/`Store`, tableaux symboliques, comptes/soldes | 18-21 |
| SolverFor | `SolverFor('QF_LIA')` benchmark vs `Solver()` generique | 22-24 |
| Exercices | 3 stubs (pipeline tactiques, clef XOR BitVec, commutativite Store) | 25-30 |

### Validation

- **Papermill**: 14/14 cells executed, 0 errors (14.7s)
- **C.1**: 0 `raise NotImplementedError` / `assert False` / `1/0`
- **C.2**: All 14 code cells have `execution_count` + outputs
- **#2161**: 3 exercises present (cells 26, 28, 30)
- **Exercise stubs**: `return None  # TODO` pattern, proper indices/etapes

### Files

- `Z3-Python-03-Tactics.ipynb` — new notebook (32 cells, ~35 min)
- `README.md` — NB03 status bumped to PRODUCTION, count 2->3

See #1206