### PR TITLE
feat(lean): Conway P5 hashlife_correct base case (n=0) proven

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1038,6 +1038,23 @@ theorem p4_wf_witness_k2 :
 
 The top-level theorem composing P2, P3, P4. -/
 
+
+/-! ### P5 base case (n = 0)
+
+The trivial case `n = 0`: both `evolveHashlifeFast` and `evolve` return the
+grid unchanged. This is the first proven building block toward the full P5
+theorem. The remaining work is the inductive step (small `n` fallback + large
+`n` jump), documented in `hashlife_correct` below. -/
+
+/-- Base case `n = 0` of `hashlife_correct`: no evolution means no change on
+    either side. Both `evolveHashlifeFast 0 g` (via `evolveHashlifeFastAux 0 0 g`)
+    and `evolve 0 g` reduce to `g` definitionally. -/
+theorem hashlife_correct_base_zero (g : Grid) :
+    evolveHashlifeFast 0 g = evolve 0 g := by
+  -- evolveHashlifeFast 0 g = evolveHashlifeFastAux 0 0 g = g  (second pattern: 0, _, g => g)
+  -- evolve 0 g = g                                           (evolve_zero : rfl)
+  rfl
+
 /-- **Hashlife correctness (bounded)**: under the padding hypothesis
     `box_assez_grand g n`, the exponential-speedup Hashlife implementation
     `evolveHashlifeFast n g` agrees with the reference `evolve n g`.
@@ -1051,10 +1068,17 @@ The top-level theorem composing P2, P3, P4. -/
       of the MacroCell doesn't interfere with the live region during the
       jump. The padding hypothesis `box_assez_grand` is preserved through
       the recursion because the jump preserves bounding box up to light-cone
-      expansion. -/
+      expansion.
+
+    **Status (2026-06-13)**: base case `n = 0` proven above
+    (`hashlife_correct_base_zero`). The inductive step remains open (the
+    `sorry` below). See `hashlife_correct_implies_block_4` /
+    `hashlife_correct_implies_glider_8` for sanity witnesses. -/
 theorem hashlife_correct (n : Nat) (g : Grid) (h : BoxAssezGrand g n) :
     evolveHashlifeFast n g = evolve n g := by
   -- P5 TARGET: main theorem, composition of P2-P4
+  -- Base case n = 0: see hashlife_correct_base_zero.
+  -- Inductive step (fallback + jump): open.
   sorry
 
 /-! ## Sanity witnesses (native_decide)


### PR DESCRIPTION
## Summary

Add the first **proven building block** toward Conway P5 `hashlife_correct` (#2162). The full P5 theorem remains open (sorry preserved), but the trivial base case `n = 0` is now proven and documented as the first step of the documented induction strategy.

## Change
- **New theorem** `hashlife_correct_base_zero`: `evolveHashlifeFast 0 g = evolve 0 g`
  - Proof: `rfl` (both sides reduce to `g` definitionally)
    - `evolveHashlifeFast 0 g = evolveHashlifeFastAux 0 0 g = g` (first pattern `| _, 0, g => g`)
    - `evolve 0 g = step^[0] g = g` (`evolve_zero`)
- **Documentation**: P5 docstring updated with status (2026-06-13) — base case proven, inductive step open.

## B-criteria (Lean PR discipline)

1. **`grep -c sorry` avant/après**: `1` → `1` (unchanged). The main P5 `sorry` at `hashlife_correct` is preserved; I added a proven theorem, did not touch the open proof.
2. **Lake build SUCCESS**: `lake build Conway.Life.HashlifeCorrectness` → exit 0, olean regenerated (timestamp confirmed). Local build on WSL (elan 4.1.2, Lean v4.30.0-rc2).
3. **Proof integrity**: `rfl` proof, no axioms, no `sorry`.
4. **No prover refactor** — pure Lean theorem addition.

## Anti-regression D compliance
- Added a proof (not replaced/removed any existing proof).
- Diff: 25 insertions, 1 deletion (the deletion is a docstring line rewrap, not code).

## Forensic context (prover-forensic subagent, archived)
P5 is **NOT pure composition** — 3 independent blockers remain before the full theorem:
- **Gap 1** (definitional): `evolveHashlifeFastAux` fuel-exhaustion branch needs an invariant lemma.
- **Gap 2** (unproven): Grid↔MacroCell round-trip only verified by `#eval`, no theorem.
- **Gap 3** (hard): P4 recursive arm has its own sorry at L945 (double-nine decomposition).

**Honest verdict**: P5 full proof = multi-week research task. This PR delivers the safe, verified `n=0` base case as the first concrete step — not a closure of P5.

See #2162 (Conway Epic, P5 hashlife_correct). Not `Closes` — P5 remains open.