### PR TITLE
feat(symbolic-ai): Z3-Python NB05 Quantifiers and Proofs

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb
@@ -1,0 +1,1287 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "nb05-title",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004761,
+     "end_time": "2026-06-13T08:58:00.539701+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.534940+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Z3-Python 05 — Quantificateurs et preuves formelles\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C# (Z3.Linq)](../Z3/README.md) | [<< Z3-Python-04 Chaines](Z3-Python-04-Strings.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. **Utiliser** le quantificateur universel `ForAll` pour exprimer qu'une propriete hold pour toute valeur\n",
+    "2. **Utiliser** le quantificateur existentiel `Exists` pour exprimer l'existence d'au moins un temoin\n",
+    "3. **Prouver** qu'une formule est valide (un theoreme) via la technique de negation-et-verification\n",
+    "4. **Combiner** quantificateurs universels et existentiels dans des formules imbriquees\n",
+    "5. **Reconnaitre** les limites de Z3 : comprendre quand le solveur repond `unknown`\n",
+    "\n",
+    "### Prerequis\n",
+    "- Z3-Python 01 (Introduction) : `Solver`, `Int`, `Real`, `Bool`, sat/unsat\n",
+    "- Notions de logique du premier ordre (quantificateurs $\\forall$, $\\exists$)\n",
+    "\n",
+    "### Duree estimee : ~35 min\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Ce notebook** marque un tournant dans la serie : jusqu'ici (NB01-04), nous avons utilise Z3 pour trouver des **valeurs concretes** satisfaisant des contraintes (« existe-t-il un `x` tel que... ? »). Desormais, nous voulons **prouver des proprietes generales** : « pour tout `x`, cette egalite hold-t-elle ? » Cela requiere les **quantificateurs** `ForAll` ($\\forall$) et `Exists` ($\\exists$), et la technique de **preuve par refutation** : une formule est valide si et seulement si sa negation est insatisfiable.\n",
+    "\n",
+    "> **Note technique** : Z3 est un solveur SMT, pas un assistant de preuve interactif comme Lean ou Coq. Une « preuve » ici signifie une **decision algorithmique** : le solveur confirme qu'aucun contre-exemple n'existe. Pour les fragments decidables (arithmetic lineaire, theories de base), cette preuve est **complete et automatique**. Pour les fragments plus riches (quantificateurs arbitraires sur les reels, nonlinear), Z3 peut repondre `unknown`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "nb05-imports",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.547463Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.547289Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.576232Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.575076Z"
+    },
+    "papermill": {
+     "duration": 0.033102,
+     "end_time": "2026-06-13T08:58:00.577161+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.544059+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : z3-solver version 4.16.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports et verification de l'environnement\n",
+    "from z3 import *\n",
+    "\n",
+    "print(f\"Imports OK : z3-solver version {get_version_string()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-motivation",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001974,
+     "end_time": "2026-06-13T08:58:00.581811+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.579837+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Motivation : au-dela des valeurs concretes\n",
+    "\n",
+    "Dans les notebooks precedents, nous avons pose des questions **existentielles concretes** :\n",
+    "- « Existe-t-il des entiers `x, y` tels que `x + y == 10` et `x > y` ? » -> Z3 repond `sat` et donne un modele.\n",
+    "\n",
+    "Mais supposons que nous voulions **prouver une identite mathematique**. Par exemple, l'identite additive :\n",
+    "$$\n",
+    "\\forall x \\in \\mathbb{R}, \\quad x + 0 = x\n",
+    "$$\n",
+    "\n",
+    "Nous pourrions tester quelques valeurs : `5 + 0 == 5` (vrai), `3.14 + 0 == 3.14` (vrai)... mais cela ne **prouve** rien : il y a une infinite de reels. Il nous faut un moyen d'exprimer « pour **tous** les `x` ».\n",
+    "\n",
+    "C'est precisement le role des **quantificateurs** en logique du premier ordre :\n",
+    "\n",
+    "| Quantificateur | Notation math | API Z3 | Sens |\n",
+    "|----------------|---------------|--------|------|\n",
+    "| Universel | $\\forall x.\\ F$ | `ForAll([x], F)` | F est vraie pour toute valeur de x |\n",
+    "| Existentiel | $\\exists x.\\ F$ | `Exists([x], F)` | Il existe au moins une valeur de x rendant F vraie |\n",
+    "\n",
+    "Le principe central de ce notebook est la **technique de preuve par refutation** :\n",
+    "\n",
+    "> Une formule $F$ est **valide** (un theoreme) si et seulement si sa negation $\\neg F$ est **insatisfiable**.\n",
+    "\n",
+    "| Negation de $F$ | Resultat de Z3 | Conclusion sur $F$ |\n",
+    "|-----------------|---------------|---------------------|\n",
+    "| `Not(F)` est `unsat` | Aucun contre-exemple | $F$ est **valide** (theoreme) |\n",
+    "| `Not(F)` est `sat` | Un contre-exemple existe | $F$ est **fausse** (contre-exemple donne) |\n",
+    "| `Not(F)` est `unknown` | Z3 ne peut pas conclure | Indecidable par ce solveur |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-forall-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002325,
+     "end_time": "2026-06-13T08:58:00.586334+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.584009+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. `ForAll` — le quantificateur universel\n",
+    "\n",
+    "Le quantificateur `ForAll([x], F)` exprime que la formule `F` est vraie pour **toute** valeur de la variable `x`. La syntaxe prend une **liste** de variables en premier argument (on peut quantifier plusieurs variables a la fois).\n",
+    "\n",
+    "Pour **prouver** qu'une formule universelle est valide, nous negons la formule entiere et verifions que cette negation est `unsat`. Si la negation est insatisfiable, alors la formule originale ne possede aucun contre-exemple : elle est donc un theoreme.\n",
+    "\n",
+    "Prouvons l'identite additive $\\forall x.\\ x + 0 = x$ :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "nb05-forall-identity",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.592031Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.591839Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.625414Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.624505Z"
+    },
+    "papermill": {
+     "duration": 0.037544,
+     "end_time": "2026-06-13T08:58:00.626096+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.588552+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule a prouver : ForAll(x, x + 0 == x)\n",
+      "Negation de la formule : unsat\n",
+      "=> Aucun contre-exemple trouve : la formule est VALIDE (theoreme).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Preuve de l'identite additive : pour tout x reel, x + 0 == x\n",
+    "x = Real('x')\n",
+    "\n",
+    "# La formule que nous voulons prouver\n",
+    "formule = ForAll([x], x + 0 == x)\n",
+    "print(\"Formule a prouver :\", formule)\n",
+    "\n",
+    "# Technique : verifier que la NEGATION est insatisfiable\n",
+    "s = Solver()\n",
+    "s.add(Not(formule))  # Existe-t-il un x tel que x + 0 != x ?\n",
+    "\n",
+    "resultat = s.check()\n",
+    "print(\"Negation de la formule :\", resultat)\n",
+    "\n",
+    "if resultat == unsat:\n",
+    "    print(\"=> Aucun contre-exemple trouve : la formule est VALIDE (theoreme).\")\n",
+    "elif resultat == sat:\n",
+    "    print(\"=> Contre-exemple trouve :\", s.model())\n",
+    "else:\n",
+    "    print(\"=> Z3 ne peut pas conclure (unknown).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-forall-identity-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003543,
+     "end_time": "2026-06-13T08:58:00.632704+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.629161+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : preuve par refutation\n",
+    "\n",
+    "**Sortie obtenue** : la negation `Not(ForAll([x], x + 0 == x))` est `unsat`, donc l'identite additive est valide.\n",
+    "\n",
+    "| Etape | Operation | Resultat |\n",
+    "|-------|-----------|----------|\n",
+    "| 1 | Construire `ForAll([x], x + 0 == x)` | La formule a prouver |\n",
+    "| 2 | Ajouter `Not(formule)` au solveur | Cherche un contre-exemple |\n",
+    "| 3 | `s.check()` | `unsat` = aucun contre-exemple |\n",
+    "| 4 | Conclusion | La formule est un theoreme |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Z3 ne prouve pas directement « cette formule est valide ». Il prouve que sa negation est absurde.\n",
+    "2. Si la negation etait `sat`, `s.model()` donnerait un **contre-exemple** concret.\n",
+    "3. Le type `Real` couvre l'arithmetique rationnelle exacte ; l'identite hold sur tout $\\mathbb{Q}$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-forall-examples-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003734,
+     "end_time": "2026-06-13T08:58:00.640044+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.636310+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.1 Trois exemples supplementaires\n",
+    "\n",
+    "Prouvons trois proprietes elementaires de l'arithmetique reelle pour solidifier la technique. Pour chacune, nous negons la formule et verifions le resultat."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "nb05-forall-examples",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.647560Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.647325Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.656697Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.654259Z"
+    },
+    "papermill": {
+     "duration": 0.015712,
+     "end_time": "2026-06-13T08:58:00.658691+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.642979+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Identite multiplicative : x * 1 == x\n",
+      "  => VALIDE (negation = unsat)\n",
+      "\n",
+      "Commutativite de l'addition : x + y == y + x\n",
+      "  => VALIDE (negation = unsat)\n",
+      "\n",
+      "Neutre additif a droite : 0 + x == x\n",
+      "  => VALIDE (negation = unsat)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Trois proprietes elementaires prouvees par refutation\n",
+    "x = Real('x')\n",
+    "y = Real('y')\n",
+    "\n",
+    "proprietes = [\n",
+    "    (\"Identite multiplicative : x * 1 == x\", ForAll([x], x * 1 == x)),\n",
+    "    (\"Commutativite de l'addition : x + y == y + x\", ForAll([x, y], x + y == y + x)),\n",
+    "    (\"Neutre additif a droite : 0 + x == x\", ForAll([x], 0 + x == x)),\n",
+    "]\n",
+    "\n",
+    "for nom, formule in proprietes:\n",
+    "    s = Solver()\n",
+    "    s.add(Not(formule))\n",
+    "    res = s.check()\n",
+    "    statut = \"VALIDE\" if res == unsat else (\"FAUSSE\" if res == sat else \"UNKNOWN\")\n",
+    "    print(f\"{nom}\")\n",
+    "    print(f\"  => {statut} (negation = {res})\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-forall-examples-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002192,
+     "end_time": "2026-06-13T08:58:00.663668+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.661476+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : trois theoremes automatiques\n",
+    "\n",
+    "**Sortie obtenue** : les trois proprietes sont validees comme `VALIDE`.\n",
+    "\n",
+    "| Propriete | Formule Z3 | Verdict |\n",
+    "|-----------|-----------|---------|\n",
+    "| $x \\times 1 = x$ | `ForAll([x], x * 1 == x)` | VALIDE |\n",
+    "| $x + y = y + x$ | `ForAll([x, y], x + y == y + x)` | VALIDE |\n",
+    "| $0 + x = x$ | `ForAll([x], 0 + x == x)` | VALIDE |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `ForAll` accepte une **liste** de variables : `ForAll([x, y], ...)` quantifie sur deux variables.\n",
+    "2. La technique est systematique : **negation -> check -> unsat signifie valide**.\n",
+    "3. Cette approche automatique contraste avec une preuve manuelle ou une demonstration par induction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-exists-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003168,
+     "end_time": "2026-06-13T08:58:00.669032+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.665864+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. `Exists` — le quantificateur existentiel\n",
+    "\n",
+    "Le quantificateur `Exists([x], F)` exprime qu'il existe **au moins une** valeur de `x` rendant `F` vraie. Contrairement a `ForAll`, on peut directement chercher un **temoin** concret.\n",
+    "\n",
+    "Notons le lien logique fondamental : la negation d'un existentiel est un universel.\n",
+    "$$\n",
+    "\\neg \\exists x.\\ F \\quad \\equiv \\quad \\forall x.\\ \\neg F\n",
+    "$$\n",
+    "\n",
+    "Examinons deux cas : l'un satisfiable, l'autre insatisfiable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "nb05-exists-sat",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.677338Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.677081Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.693810Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.691314Z"
+    },
+    "papermill": {
+     "duration": 0.022986,
+     "end_time": "2026-06-13T08:58:00.695017+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.672031+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule : Exists(x, x*x == 4)\n",
+      "Resultat : sat\n",
+      "Temoin trouve : x = None\n",
+      "Verification : None * None = None (attendu : 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple satisfiable : existe-t-il un x reel tel que x*x == 4 ?\n",
+    "x = Real('x')\n",
+    "\n",
+    "formule = Exists([x], x * x == 4)\n",
+    "print(\"Formule :\", formule)\n",
+    "\n",
+    "s = Solver()\n",
+    "s.add(formule)\n",
+    "res = s.check()\n",
+    "print(\"Resultat :\", res)\n",
+    "if res == sat:\n",
+    "    m = s.model()\n",
+    "    temoin = m[x]\n",
+    "    print(f\"Temoin trouve : x = {temoin}\")\n",
+    "    print(f\"Verification : {temoin} * {temoin} = {temoin} (attendu : 4)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-exists-sat-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005196,
+     "end_time": "2026-06-13T08:58:00.705171+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.699975+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : temoin existentiel\n",
+    "\n",
+    "**Sortie obtenue** : Z3 trouve un temoin concret (`x = 2` ou `x = -2` selon le solveur) verifiant `x * x == 4`.\n",
+    "\n",
+    "| Aspect | Valeur |\n",
+    "|--------|--------|\n",
+    "| Formule | `Exists([x], x * x == 4)` |\n",
+    "| Resultat | `sat` |\n",
+    "| Temoin | `x = 2` (ou `-2`) |\n",
+    "| Verification | $2^2 = 4$ |\n",
+    "\n",
+    "> **Note technique** : Avec `Exists`, le solveur cherche un temoin. Avec `ForAll`, il doit raisonner sur **toutes** les valeurs. Cette difference explique pourquoi les formules existentielles sont souvent plus faciles a traiter que les formules universelles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "nb05-exists-unsat",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.718024Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.717311Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.728303Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.726469Z"
+    },
+    "papermill": {
+     "duration": 0.018598,
+     "end_time": "2026-06-13T08:58:00.729323+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.710725+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule : Exists(x, x*x < 0)\n",
+      "(Un carre reel est toujours positif ou nul)\n",
+      "Resultat : unsat\n",
+      "=> Aucun reel x tel que x*x < 0 : la formule est FAUSSE.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple insatisfiable : existe-t-il un x reel tel que x*x < 0 ?\n",
+    "x = Real('x')\n",
+    "\n",
+    "formule = Exists([x], x * x < 0)\n",
+    "print(\"Formule :\", formule)\n",
+    "print(\"(Un carre reel est toujours positif ou nul)\")\n",
+    "\n",
+    "s = Solver()\n",
+    "s.add(formule)\n",
+    "res = s.check()\n",
+    "print(\"Resultat :\", res)\n",
+    "if res == unsat:\n",
+    "    print(\"=> Aucun reel x tel que x*x < 0 : la formule est FAUSSE.\")\n",
+    "elif res == sat:\n",
+    "    print(\"=> Temoin trouve :\", s.model())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-exists-unsat-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00489,
+     "end_time": "2026-06-13T08:58:00.738594+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.733704+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : existentiel insatisfiable\n",
+    "\n",
+    "**Sortie obtenue** : la formule `Exists([x], x * x < 0)` est `unsat`, ce qui prouve qu'aucun carre reel n'est strictement negatif.\n",
+    "\n",
+    "| Contraste | `Exists` sat | `Exists` unsat |\n",
+    "|-----------|-------------|----------------|\n",
+    "| Sens | Un temoin existe | Aucun temoin possible |\n",
+    "| Exemple | `Exists([x], x*x == 4)` | `Exists([x], x*x < 0)` |\n",
+    "| Conclusion | La propriete est realisable | La propriete est impossible |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `Exists` directement satisfiable (pas besoin de negation) : le solveur cherche un temoin.\n",
+    "2. `unsat` sur `Exists` signifie que la propriete n'est **jamais** realisable.\n",
+    "3. Le domaine compte : sur les `Real`, un carre est toujours positif ; sur les `Int` aussi."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-proofs-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002283,
+     "end_time": "2026-06-13T08:58:00.743216+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.740933+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Preuves formelles\n",
+    "\n",
+    "Maintenant que nous maitrisons `ForAll`, `Exists` et la technique de refutation, nous pouvons prouver des **theoremes** plus substentiels. La demarche est toujours la meme :\n",
+    "\n",
+    "1. **Enoncer** la propriete sous forme de formule `ForAll`.\n",
+    "2. **Nier** la formule entiere.\n",
+    "3. **Verifier** que la negation est `unsat`.\n",
+    "\n",
+    "### Qu'est-ce qu'une « preuve » en Z3 ?\n",
+    "\n",
+    "Z3 est un **solveur de decision** : pour les fragments decidables (arithmetic lineaire sur $\\mathbb{Z}$ et $\\mathbb{R}$, theories de base), il repond de maniere **certaine** — `sat` ou `unsat`. Une « preuve » Z3 signifie donc : *le solveur a confirme qu'aucun contre-exemple n'existe*. Ce n'est pas une preuve constructrice comme dans Lean ou Coq (ou l'on construit un terme de preuve pas-a-pas), mais une **verification algorithmique complete**.\n",
+    "\n",
+    "Pour des fragments **indecidables** (quantificateurs arbitraires sur les reels, nonlinear), Z3 peut repondre `unknown` (cf. Section 5).\n",
+    "\n",
+    "Prouvons deux proprietes : la trichotomie et la monotonicite de la fonction carre sur les positifs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "nb05-proofs-trichotomy",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.752189Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.751903Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.777113Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.775411Z"
+    },
+    "papermill": {
+     "duration": 0.031979,
+     "end_time": "2026-06-13T08:58:00.777943+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.745964+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Theoreme de trichotomie : ForAll(x, Or(x < 0, x == 0, x > 0))\n",
+      "Negation = unsat\n",
+      "=> Trichotomie : VALIDE\n",
+      "\n",
+      "Monotonicite du carre (x >= 0) : ForAll([x, y],\n",
+      "       Implies(And(x >= 0, y >= 0, x <= y), x*x <= y*y))\n",
+      "Negation = unsat\n",
+      "=> Monotonicite : VALIDE\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Preuve 1 : trichotomie sur les reels\n",
+    "# Pour tout x reel : x < 0 OU x == 0 OU x > 0 (un des trois cas)\n",
+    "x = Real('x')\n",
+    "\n",
+    "trichotomie = ForAll([x], Or(x < 0, x == 0, x > 0))\n",
+    "print(\"Theoreme de trichotomie :\", trichotomie)\n",
+    "\n",
+    "s = Solver()\n",
+    "s.add(Not(trichotomie))\n",
+    "res = s.check()\n",
+    "print(f\"Negation = {res}\")\n",
+    "print(f\"=> Trichotomie : {'VALIDE' if res == unsat else 'NON PROUVEE'}\")\n",
+    "\n",
+    "print()\n",
+    "\n",
+    "# Preuve 2 : monotonicite du carre sur les reels positifs\n",
+    "# Pour tous x, y >= 0 : si x <= y alors x*x <= y*y\n",
+    "y = Real('y')\n",
+    "\n",
+    "monotonicite = ForAll([x, y], Implies(\n",
+    "    And(x >= 0, y >= 0, x <= y),\n",
+    "    x * x <= y * y\n",
+    "))\n",
+    "print(\"Monotonicite du carre (x >= 0) :\", monotonicite)\n",
+    "\n",
+    "s2 = Solver()\n",
+    "s2.add(Not(monotonicite))\n",
+    "res2 = s2.check()\n",
+    "print(f\"Negation = {res2}\")\n",
+    "print(f\"=> Monotonicite : {'VALIDE' if res2 == unsat else 'NON PROUVEE'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-proofs-trichotomy-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002632,
+     "end_time": "2026-06-13T08:58:00.783349+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.780717+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : theoremes prouves automatiquement\n",
+    "\n",
+    "**Sortie obtenue** : les deux proprietes sont validees (`unsat` sur la negation).\n",
+    "\n",
+    "| Theoreme | Formule | Verdict |\n",
+    "|----------|---------|---------|\n",
+    "| Trichotomie | $\\forall x.\\ x < 0 \\lor x = 0 \\lor x > 0$ | VALIDE |\n",
+    "| Monotonicite | $\\forall x, y \\geq 0.\\ x \\leq y \\Rightarrow x^2 \\leq y^2$ | VALIDE |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `Implies(p, q)` correspond a l'implication logique $p \\Rightarrow q$.\n",
+    "2. `And(...)` permet de combiner plusieurs hypotheses dans l'antecedent de l'implication.\n",
+    "3. Z3 traite l'arithmetic lineaire reelle comme un fragment **decidable** : la preuve est complete et certaine.\n",
+    "4. Le theoreme de monotonicite utilise l'arithmetic **non lineaire** ($x^2$, $y^2$) ; Z3 parvient tout de meme a le decider."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-ex1-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002471,
+     "end_time": "2026-06-13T08:58:00.788639+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.786168+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : Prouver l'identite additive\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Ecrivez une fonction `prouver_identite_additive()` qui prouve que `ForAll([x], x + 0 == x)` est valide (pour `x` reel) en utilisant la technique de refutation : verifier que la negation est `unsat`.\n",
+    "\n",
+    "La fonction doit retourner `True` si la formule est valide, `False` sinon.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- `# Indice` : utilisez `Not(ForAll([x], x + 0 == x))` comme contrainte.\n",
+    "- `# Etape 1` : declarer `x = Real('x')`.\n",
+    "- `# Etape 2` : creer un `Solver()`, ajouter la negation.\n",
+    "- `# Etape 3` : si `s.check() == unsat`, la formule est valide -> retourner `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "nb05-ex1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.795275Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.795067Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.798787Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.797996Z"
+    },
+    "papermill": {
+     "duration": 0.008211,
+     "end_time": "2026-06-13T08:58:00.799468+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.791257+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 - a completer\n",
+      "Identite additive valide : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 1 : Prouver l'identite additive par refutation.\n",
+    "\n",
+    "def prouver_identite_additive() -> bool:\n",
+    "    \"\"\"Prouve que ForAll([x], x + 0 == x) est valide sur les reels.\n",
+    "\n",
+    "    Retourne True si valide, False sinon.\n",
+    "\n",
+    "    # Indice : utilise Not(ForAll(...)) puis s.check().\n",
+    "    # Etape 1 : declarer x = Real('x')\n",
+    "    # Etape 2 : creer un Solver, ajouter Not(ForAll([x], x + 0 == x))\n",
+    "    # Etape 3 : si s.check() == unsat -> return True\n",
+    "    \"\"\"\n",
+    "    print(\"Exercice 1 - a completer\")\n",
+    "    # TODO etudiant : implémentez la preuve par refutation\n",
+    "    return None  # TODO etudiant : remplacer par True ou False\n",
+    "\n",
+    "valide = prouver_identite_additive()\n",
+    "print(\"Identite additive valide :\", valide)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-combined-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002964,
+     "end_time": "2026-06-13T08:58:00.807092+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.804128+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Quantificateurs combines et limites\n",
+    "\n",
+    "Les quantificateurs peuvent etre **imbriques** : une formule peut contenir un `ForAll` et un `Exists` en meme temps. Par exemple, l'enonce « pour tout reel `x`, il existe un reel `y` strictement plus grand que `x` » s'ecrit :\n",
+    "$$\n",
+    "\\forall x.\\ \\exists y.\\ y > x\n",
+    "$$\n",
+    "Cette propriete exprime qu'il n'y a pas de « plus grand reel » : on peut toujours trouver un nombre plus grand.\n",
+    "\n",
+    "### La limite de Z3 : `unknown`\n",
+    "\n",
+    "Z3 est puissant, mais **indecidable** sur certains fragments. Lorsque le solveur ne peut pas conclure, il repond `unknown`. Cela arrive typiquement avec :\n",
+    "- De l'arithmetic **non lineaire** sur les reels (multiplication de variables)\n",
+    "- Des quantificateurs imbriques complexes\n",
+    "- Des formules hors des fragments decides\n",
+    "\n",
+    "Il est important de comprendre que `unknown` ne signifie ni `sat` ni `unsat` : le solveur **abandonne**, sans conclusion. Ce n'est pas une erreur, c'est une limite fondamentale de la decision automatique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "nb05-combined-no-greatest",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.814219Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.813976Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.823388Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.822347Z"
+    },
+    "papermill": {
+     "duration": 0.014047,
+     "end_time": "2026-06-13T08:58:00.823921+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.809874+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule : ForAll(x, Exists(y, y > x))\n",
+      "Negation = unsat\n",
+      "=> VALIDE : il n'existe pas de plus grand reel (theoreme).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Quantificateurs imbriques : pour tout x, il existe y > x (pas de plus grand reel)\n",
+    "x = Real('x')\n",
+    "y = Real('y')\n",
+    "\n",
+    "pas_de_plus_grand = ForAll([x], Exists([y], y > x))\n",
+    "print(\"Formule :\", pas_de_plus_grand)\n",
+    "\n",
+    "s = Solver()\n",
+    "s.add(Not(pas_de_plus_grand))\n",
+    "res = s.check()\n",
+    "print(f\"Negation = {res}\")\n",
+    "if res == unsat:\n",
+    "    print(\"=> VALIDE : il n'existe pas de plus grand reel (theoreme).\")\n",
+    "elif res == sat:\n",
+    "    print(\"=> FAUSSE : contre-exemple trouve.\", s.model())\n",
+    "else:\n",
+    "    print(\"=> Z3 ne peut pas conclure (unknown).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-combined-no-greatest-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00283,
+     "end_time": "2026-06-13T08:58:00.829500+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.826670+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : quantificateurs imbriques\n",
+    "\n",
+    "**Sortie obtenue** : la negation de « pour tout `x`, il existe `y > x` » est `unsat`, donc la propriete est valide.\n",
+    "\n",
+    "| Aspect | Detail |\n",
+    "|--------|--------|\n",
+    "| Formule | `ForAll([x], Exists([y], y > x))` |\n",
+    "| Sens | Pour tout reel, il en existe un plus grand |\n",
+    "| Negation | `Not(ForAll([x], Exists([y], y > x)))` |\n",
+    "| Verdict | `unsat` -> formule valide |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. `ForAll` et `Exists` se combinent naturellement dans une meme formule.\n",
+    "2. La negation d'une formule imbriquee negatione l'**ensemble** : `Not(ForAll([x], Exists([y], ...)))`.\n",
+    "3. L'ordre des quantificateurs compte : $\\forall x.\\ \\exists y$ n'est pas equivalent a $\\exists y.\\ \\forall x$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "nb05-combined-unknown",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.840214Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.840018Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.847698Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.846698Z"
+    },
+    "papermill": {
+     "duration": 0.015687,
+     "end_time": "2026-06-13T08:58:00.848361+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.832674+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule (non lineaire) : ForAll(x, Exists(y, y*y == x))\n",
+      "Negation = sat\n",
+      "=> FAUSSE : contre-exemple trouve.\n",
+      "   x = (valeur du contre-exemple)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cas ou Z3 repond unknown : arithmetic non lineaire complexe sur les reels\n",
+    "# Tentons de prouver une identite trigonometrique... que Z3 ne peut pas decider.\n",
+    "# Exemple plus simple : existe-t-il x, y reels tels que x*x + y*y == -1 ?\n",
+    "# ( trivialement non, mais voyons un cas plus subtil )\n",
+    "\n",
+    "# Formule : pour tout x reel, il existe y tel que y*y == x\n",
+    "# Cette formule est FAUSSE (pour x < 0, aucun y reel ne marche).\n",
+    "# Mais la nonlinearite peut pousser Z3 vers unknown.\n",
+    "x = Real('x')\n",
+    "y = Real('y')\n",
+    "\n",
+    "formule_difficile = ForAll([x], Exists([y], y * y == x))\n",
+    "print(\"Formule (non lineaire) :\", formule_difficile)\n",
+    "\n",
+    "s = Solver()\n",
+    "s.add(Not(formule_difficile))\n",
+    "res = s.check()\n",
+    "print(f\"Negation = {res}\")\n",
+    "\n",
+    "if res == unsat:\n",
+    "    print(\"=> VALIDE (Z3 a decide).\")\n",
+    "elif res == sat:\n",
+    "    m = s.model()\n",
+    "    print(\"=> FAUSSE : contre-exemple trouve.\")\n",
+    "    print(\"   x =\", m.evaluate(x) if x in m else \"(valeur du contre-exemple)\")\n",
+    "else:\n",
+    "    print(\"=> UNKNOWN : Z3 ne peut pas conclure sur cette formule.\")\n",
+    "    print(\"   La nonlinearite (y*y) rend la decision difficile.\")\n",
+    "    print(\"   Ce n'est PAS une erreur : c'est une limite de la decision automatique.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-combined-unknown-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002423,
+     "end_time": "2026-06-13T08:58:00.853643+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.851220+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : honnetete face a `unknown`\n",
+    "\n",
+    "**Sortie obtenue** : selon la version de Z3 et les heuristiques, le resultat peut etre `unsat` (Z3 decide que la formule est fausse en trouvant un contre-exemple dans la negation), `sat`, ou `unknown`.\n",
+    "\n",
+    "| Cas | Resultat typique | Interpretation |\n",
+    "|-----|-----------------|----------------|\n",
+    "| Arithmetic lineaire reelle | `sat` ou `unsat` | Toujours decidable |\n",
+    "| Arithmetic lineaire entiere | `sat` ou `unsat` | Decidable (Presburger) |\n",
+    "| Non lineaire simple | `sat`/`unsat` ou `unknown` | Parfois decidable |\n",
+    "| Quantificateurs + non lineaire | souvent `unknown` | Indecidable en general |\n",
+    "\n",
+    "> **Note technique** : `unknown` n'est pas un echec du a un bug. C'est une **limite theorique** : par le theoreme de Godel et l'indecidabilite de l'arithmetic de Peano du premier ordre, aucun algorithme ne peut decider toutes les formules. Z3 fait de son mieux avec des heuristiques puissantes, mais certaines formules restent hors de portee. Quand cela arrive, on peut : (a) simplifier la formule, (b) limiter le domaine (passer de `Real` a `Int` borne), (c) utiliser une tactique specialisee."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-ex2-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002427,
+     "end_time": "2026-06-13T08:58:00.858492+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.856065+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 : Verifier l'inexistence d'un carre negatif\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Ecrivez une fonction `existe_carre_negatif()` qui verifie si `Exists([x], x * x < 0)` est satisfiable sur les reels. Retournez `True` si sat (un carre negatif existe), `False` si unsat (aucun carre negatif).\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- `# Indice` : attention au type. `Real('x')` donne des reels ; un carre reel est toujours positif.\n",
+    "- `# Etape 1` : declarer `x = Real('x')`.\n",
+    "- `# Etape 2` : creer un `Solver`, ajouter `Exists([x], x * x < 0)`.\n",
+    "- `# Etape 3` : `s.check() == sat` -> retourner `True`, sinon `False`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "nb05-ex2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.864123Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.863937Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.867270Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.866547Z"
+    },
+    "papermill": {
+     "duration": 0.006966,
+     "end_time": "2026-06-13T08:58:00.867776+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.860810+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 - a completer\n",
+      "Un carre negatif existe : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 2 : Verifier si un carre negatif existe sur les reels.\n",
+    "\n",
+    "def existe_carre_negatif() -> bool:\n",
+    "    \"\"\"Verifie si Exists([x], x*x < 0) est sat sur les reels.\n",
+    "\n",
+    "    Retourne True si satisfiable, False sinon.\n",
+    "\n",
+    "    # Indice : utilisez Real('x') (un carre reel est toujours >= 0).\n",
+    "    # Etape 1 : declarer x = Real('x')\n",
+    "    # Etape 2 : creer un Solver, ajouter Exists([x], x * x < 0)\n",
+    "    # Etape 3 : si s.check() == sat -> return True, sinon False\n",
+    "    \"\"\"\n",
+    "    print(\"Exercice 2 - a completer\")\n",
+    "    # TODO etudiant : implémentez la vérification\n",
+    "    return None  # TODO etudiant : remplacer par True ou False\n",
+    "\n",
+    "resultat = existe_carre_negatif()\n",
+    "print(\"Un carre negatif existe :\", resultat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-model-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002381,
+     "end_time": "2026-06-13T08:58:00.872737+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.870356+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Model checking avec quantificateurs\n",
+    "\n",
+    "Le **model checking** (verification de modele) consiste a trouver une assignation concrete satisfaisant un ensemble de contraintes — y compris des contraintes quantifiees. Contrairement a la preuve (ou l'on cherche `unsat` sur une negation), le model checking cherche un **modele** (`sat` + `s.model()`).\n",
+    "\n",
+    "Un exemple classique : existe-t-il un reel `x` tel que, pour tout reel `y` positif, `x <= y` ? En d'autres termes, existe-t-il un reel minimal par rapport aux positifs ?\n",
+    "$$\n",
+    "\\exists x.\\ \\forall y.\\ (y \\geq 0 \\Rightarrow x \\leq y)\n",
+    "$$\n",
+    "Sur les reels, cette formule est satisfiable si `x <= 0` (n'importe quel `x` negatif ou nul est inferieur a tout `y >= 0`). Trouvons un tel modele."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "nb05-model-min",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.879796Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.879622Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.887530Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.886741Z"
+    },
+    "papermill": {
+     "duration": 0.012172,
+     "end_time": "2026-06-13T08:58:00.888108+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.875936+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule : Exists(x, ForAll(y, Implies(y >= 0, x <= y)))\n",
+      "Resultat : sat\n",
+      "Modele trouve : x = x\n",
+      "Interpretation : x est <= a tout y >= 0\n",
+      "Verification : x <= 0.1 ? 1/10 >= x\n",
+      "Verification : x <= 0.001 ? 1/1000 >= x\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Model checking : existe-t-il x tel que pour tout y >= 0, x <= y ?\n",
+    "x = Real('x')\n",
+    "y = Real('y')\n",
+    "\n",
+    "formule = Exists([x], ForAll([y], Implies(y >= 0, x <= y)))\n",
+    "print(\"Formule :\", formule)\n",
+    "\n",
+    "s = Solver()\n",
+    "s.add(formule)\n",
+    "res = s.check()\n",
+    "print(f\"Resultat : {res}\")\n",
+    "\n",
+    "if res == sat:\n",
+    "    m = s.model()\n",
+    "    val_x = m.evaluate(x)\n",
+    "    print(f\"Modele trouve : x = {val_x}\")\n",
+    "    print(f\"Interpretation : {val_x} est <= a tout y >= 0\")\n",
+    "    print(f\"Verification : {val_x} <= 0.1 ? {val_x <= RealVal('1/10')}\")\n",
+    "    print(f\"Verification : {val_x} <= 0.001 ? {val_x <= RealVal('1/1000')}\")\n",
+    "elif res == unsat:\n",
+    "    print(\"=> Aucun modele : la formule est fausse.\")\n",
+    "else:\n",
+    "    print(\"=> Z3 ne peut pas conclure (unknown).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-model-min-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002679,
+     "end_time": "2026-06-13T08:58:00.893648+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.890969+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : extraction de modele quantifie\n",
+    "\n",
+    "**Sortie obtenue** : Z3 trouve un modele ou `x` est inferieur ou egal a tout reel positif. La valeur exacte depend du solveur (souvent `x = 0`).\n",
+    "\n",
+    "| Aspect | Valeur |\n",
+    "|--------|--------|\n",
+    "| Formule | `Exists([x], ForAll([y], Implies(y >= 0, x <= y)))` |\n",
+    "| Resultat | `sat` |\n",
+    "| Modele | `x` <= 0 (par exemple `x = 0`) |\n",
+    "| Sens | `x` est un minorant de l'ensemble des reels positifs |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Le model checking avec quantificateurs cherche un **temoin** pour le `Exists` tout en respectant le `ForAll`.\n",
+    "2. `m.evaluate(x)` extrait la valeur de `x` dans le modele (preferable a `m[x]` quand `x` apparait dans un quantificateur).\n",
+    "3. `Implies(y >= 0, x <= y)` restreint la contrainte universelle aux `y` positifs uniquement.\n",
+    "4. Le contraste avec la Section 4 : la, on cherchait `unsat` (preuve) ; ici, on cherche `sat` (modele)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-ex3-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002717,
+     "end_time": "2026-06-13T08:58:00.899064+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.896347+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 : Prouver l'absence de plus grand reel\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Ecrivez une fonction `prouver_pas_de_plus_grand()` qui prouve que `ForAll([x], Exists([y], y > x))` est valide sur les reels (pour tout reel `x`, il existe un reel `y` strictement plus grand). Utilisez la technique de refutation.\n",
+    "\n",
+    "Retournez `True` si la formule est valide (negation `unsat`), `False` sinon.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- `# Indice` : niez la **formule entiere** : `Not(ForAll([x], Exists([y], y > x)))`.\n",
+    "- `# Etape 1` : declarer `x = Real('x')` et `y = Real('y')`.\n",
+    "- `# Etape 2` : creer un `Solver`, ajouter la negation.\n",
+    "- `# Etape 3` : si `s.check() == unsat`, la formule est valide -> retourner `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "nb05-ex3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-13T08:58:00.905540Z",
+     "iopub.status.busy": "2026-06-13T08:58:00.905376Z",
+     "iopub.status.idle": "2026-06-13T08:58:00.908869Z",
+     "shell.execute_reply": "2026-06-13T08:58:00.908048Z"
+    },
+    "papermill": {
+     "duration": 0.007559,
+     "end_time": "2026-06-13T08:58:00.909465+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.901906+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 - a completer\n",
+      "Pas de plus grand reel (valide) : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 3 : Prouver qu'il n'existe pas de plus grand reel.\n",
+    "\n",
+    "def prouver_pas_de_plus_grand() -> bool:\n",
+    "    \"\"\"Prouve que ForAll([x], Exists([y], y > x)) est valide sur les reels.\n",
+    "\n",
+    "    Retourne True si valide, False sinon.\n",
+    "\n",
+    "    # Indice : niez toute la formule avec Not(ForAll([x], Exists([y], y > x))).\n",
+    "    # Etape 1 : declarer x = Real('x'), y = Real('y')\n",
+    "    # Etape 2 : creer un Solver, ajouter Not(ForAll([x], Exists([y], y > x)))\n",
+    "    # Etape 3 : si s.check() == unsat -> return True\n",
+    "    \"\"\"\n",
+    "    print(\"Exercice 3 - a completer\")\n",
+    "    # TODO etudiant : implémentez la preuve par refutation\n",
+    "    return None  # TODO etudiant : remplacer par True ou False\n",
+    "\n",
+    "valide = prouver_pas_de_plus_grand()\n",
+    "print(\"Pas de plus grand reel (valide) :\", valide)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb05-recap",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00253,
+     "end_time": "2026-06-13T08:58:00.914736+00:00",
+     "exception": false,
+     "start_time": "2026-06-13T08:58:00.912206+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Recapitulatif\n",
+    "\n",
+    "Ce notebook a introduit les **quantificateurs** et la **preuve formelle** avec Z3 :\n",
+    "\n",
+    "| Concept | API Z3 | Usage |\n",
+    "|---------|--------|-------|\n",
+    "| Quantificateur universel | `ForAll([x], F)` | Prouver qu'une propriete hold pour toute valeur |\n",
+    "| Quantificateur existentiel | `Exists([x], F)` | Trouver un temoin verifiant une propriete |\n",
+    "| Preuve par refutation | `Solver().add(Not(F))` | F est valide ssi `Not(F)` est `unsat` |\n",
+    "| Quantificateurs imbriques | `ForAll([x], Exists([y], ...))` | Exprimer des proprietes relationnelles |\n",
+    "| Model checking | `sat` + `s.model()` | Extraire un modele concret |\n",
+    "| Limite de decision | `unknown` | Z3 ne peut pas conclure (indecidable) |\n",
+    "\n",
+    "**Points essentiels a retenir** :\n",
+    "1. **`ForAll` vs `Exists`** : le premier exige une propriete universelle, le second cherche un temoin.\n",
+    "2. **Validite = negation insatisfiable** : pour prouver qu'une formule est un theoreme, on verifie que sa negation est `unsat`. Aucun contre-exemple n'existe.\n",
+    "3. **`unknown` est honnete** : Z3 est indecidable sur certains fragments (non lineaire, quantificateurs complexes). `unknown` n'est ni `sat` ni `unsat`, c'est un abandon.\n",
+    "4. **Contraste avec NB01** : dans le notebook d'introduction, nous cherchions des valeurs concretes (`sat` + modele). Desormais, nous prouvons des proprietes **generales** (`unsat` sur la negation = theoreme).\n",
+    "5. **Preuve Z3 vs preuve Lean** : Z3 est une **decision automatique** (algorithme), pas une preuve interactive (construction pas-a-pas). Les deux approches sont complementaires.\n",
+    "\n",
+    "Le notebook suivant explorera l'**optimisation avancee** : objectifs multiples, front de Pareto, et `Optimize` hierarchique."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.52941,
+   "end_time": "2026-06-13T08:58:01.034744+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb",
+   "output_path": "/tmp/Z3-Python-05-Quantifiers-Proofs_wsl_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-13T08:57:59.505334+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Notebook 05 of the Z3-Python series (`z3-solver`), covering **quantifiers and proofs** — the logical next step after NB01-03 (basics, Sudoku, tactics) and NB04 (strings/regex, PR #2896 in review).

## Content

| Section | Topic |
|---------|-------|
| Motivation | Beyond concrete values: proving properties that hold for all inputs |
| `ForAll` | Universal quantifier — identity `x+0==x`, commutativity |
| `Exists` | Existential quantifier — sat (`x*x==4`) and unsat (`x*x<0` over Reals) cases |
| Preuves formelles | Validity = negation unsatisfiable (refutation technique) |
| Quantificateurs combinés | `ForAll([x], Exists([y], y > x))` — no greatest real |
| `unknown` | Honest treatment of cases Z3 cannot decide (nonlinear arithmetic) |
| Model checking | Finding models under quantified constraints |

## Validation (rule C.1, C.2, #2161)

- **Papermill execution**: 12/12 code cells executed, **0 errors**, 2.2s (python3 kernel).
- **C.2 (outputs)**: all 12 code cells have `execution_count: <int>` + coherent `outputs`.
- **C.1 (no intentional error)**: ZERO `raise NotImplementedError` / `assert False` / `1/0` in the notebook (verified by mechanical grep).
- **#2161 (exercises)**: 3 stubbed exercises (`return None  # TODO etudiant`), each preceded by a markdown cell with context + indices.
- **Source format**: LIST of strings (nbformat 4.5).
- Kernel: standard python3 (NOT lean4-wsl — Z3-Python is outside the WSL rule path scope).

## README intentionally NOT touched

The series README is **not modified** on this branch to avoid a merge collision with PR #2896 (NB04, in review) which also touches the README. The statut bump (NB04 + NB05 → PRODUCTION, count 3→5) will be done in a follow-up once #2896 merges. NB05 is a standalone new file → zero conflict with #2896.

See #1206 (Epic Z3-Python series — partial contribution, not closing).