### PR TITLE
feat(lean): Conway P5 fuel-invariant lemma (Gap 1, n=0 case) proven

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1034,6 +1034,29 @@ theorem p4_wf_witness_k2 :
           4 8 := by
   native_decide
 
+/-! ## P5. Fuel-exhaustion invariant (Gap 1)
+
+A definitional building block toward the full P5 theorem. The auxiliary
+`evolveHashlifeFastAux` has a defensive branch `| 0, _, g => g` (fuel exhausted,
+return the grid unchanged) which is only sound when `n = 0` has also been
+reached. The lemma below discharges the relevant case directly: when `n = 0`,
+the **first** pattern (`| _, 0, g => g`) fires regardless of the fuel value,
+so the result is `g` independently of the fuel-exhaustion arm.
+
+This is the first half of the Gap-1 invariant (the `n = 0` guard takes
+priority over the fuel guard); the second half — proving the fuel-exhaustion
+arm is unreachable on the real `evolveHashlifeFast n g = evolveHashlifeFastAux n n g`
+call path when `n > 0` — remains open and is documented in `hashlife_correct`. -/
+
+/-- When `n = 0`, `evolveHashlifeFastAux` returns `g` independently of the fuel
+    value: the `n = 0` pattern (`| _, 0, g => g`) is matched before the
+    fuel-exhaustion pattern (`| 0, _, g => g`). This discharges the fuel arm
+    in the trivial case and is a prerequisite for reasoning about the
+    fuel-invariant behaviour of `evolveHashlifeFast`. -/
+theorem evolveHashlifeFastAux_zero_n (fuel : Nat) (g : Grid) :
+    evolveHashlifeFastAux fuel 0 g = g := by
+  rfl
+
 /-! ## P5. Main theorem: bounded correctness
 
 The top-level theorem composing P2, P3, P4. -/


### PR DESCRIPTION
## Summary

Adds the **first half of the Gap-1 definitional invariant** toward the full Conway P5 `hashlife_correct` theorem (#2162).

The auxiliary `evolveHashlifeFastAux` carries a defensive fuel-exhaustion branch `| 0, _, g => g` (return the grid unchanged when fuel runs out). This is only sound when `n = 0` has also been reached. The new lemma discharges the relevant case directly:

```lean
theorem evolveHashlifeFastAux_zero_n (fuel : Nat) (g : Grid) :
    evolveHashlifeFastAux fuel 0 g = g := by
  rfl
```

When `n = 0`, the **first** pattern (`| _, 0, g => g`) fires before the fuel-exhaustion pattern, so the result is `g` independently of fuel. This is the `n = 0` guard taking priority over the fuel guard — the definitional prerequisite for reasoning about the fuel-invariant behaviour of `evolveHashlifeFast n g = evolveHashlifeFastAux n n g`.

The second half (proving the fuel-exhaustion arm is unreachable on the real call path when `n > 0`, because each iteration reduces `n` by at least `js >= 4` or terminates via `evolve n g`) remains open and is documented in the `hashlife_correct` docstring.

## Lean PR discipline (per .claude/rules/lean-merge-discipline.md §B)

- **`grep -cE '^\s*sorry\b'` before/after**: 1 → 1 (unchanged). No new sorry introduced.
- **`lake build Conway.Life.HashlifeCorrectness`**: SUCCESS, 3319 jobs, exit 0.
- **Proof tactic**: `rfl` (definitional — no axioms added).
- **Proof integrity**: pure addition (23 insertions, 0 deletions), anti-regression safe.

## Context

This continues the Conway P5 per-01 fallback dispatch (#2162). The forensic identified 3 independent blockers:
- **Gap 1** (definitional, easy): fuel-exhaustion branch — *this PR addresses the n=0 half*
- **Gap 2** (medium): Grid↔MacroCell round-trip lemma (only #eval-verified)
- **Gap 3** (hard): P4 recursive arm sorry

Full P5 remains a multi-week research task (compositional). This PR delivers a verified, anti-regression-safe building block.

See #2162