### PR TITLE
docs(symbolicai): restore French accents in SymbolicAI series READMEs (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -7,13 +7,13 @@ breakdown: Planners=13
 maturity: PRODUCTION=13
 -->
 
-Cette serie de notebooks introduit la **Planification Automatique**, une branche fondamentale de l'IA qui genere des sequences d'actions pour atteindre des objectifs.
+Cette série de notebooks introduit la **Planification Automatique**, une branche fondamentale de l'IA qui génère des sequences d'actions pour atteindre des objectifs.
 
-La planification repond a une question differente de celle de l'apprentissage : non pas « que predire ? » mais « **que faire ?** ». A partir d'un modele du monde — un etat initial, des actions avec leurs preconditions et effets, un but — un planificateur cherche automatiquement une suite d'actions qui mene au but. C'est une technologie eprouvee : elle pilote des robots (manipulation, navigation), optimise la logistique et l'ordonnancement, et a dirige des engins spatiaux autonomes (Remote Agent sur Deep Space 1, planification d'activites des rovers martiens). Le langage **PDDL** a standardise la maniere de decrire ces problemes, donnant naissance a tout un ecosysteme de solveurs comparables. La planification connait aujourd'hui un regain d'interet avec les LLMs, comme moyen de doter les modeles de langage d'une capacite d'action verifiable et orientee vers un but.
+La planification répond a une question differente de celle de l'apprentissage : non pas « que predire ? » mais « **que faire ?** ». A partir d'un modele du monde — un etat initial, des actions avec leurs preconditions et effets, un but — un planificateur cherche automatiquement une suite d'actions qui mene au but. C'est une technologie éprouvée : elle pilote des robots (manipulation, navigation), optimise la logistique et l'ordonnancement, et a dirige des engins spatiaux autonomes (Remote Agent sur Deep Space 1, planification d'activites des rovers martiens). Le langage **PDDL** a standardise la maniere de décrire ces problemes, donnant naissance a tout un ecosysteme de solveurs comparables. La planification connaît aujourd'hui un regain d'intérêt avec les LLMs, comme moyen de doter les modeles de langage d'une capacite d'action verifiable et orientee vers un but.
 
 **13 notebooks** | **5 parties** | **~8h**
 
-**A qui s'adresse cette serie** : etudiants en IA, ingenieurs en robotique et logistique, developpeurs souhaitant integrer la planification symbolique dans leurs applications. Aucun prerequis en planification : les concepts sont introduits progressivement depuis les fondements STRIPS jusqu'aux approches neuro-symboliques modernes.
+**A qui s'adresse cette série** : étudiants en IA, ingenieurs en robotique et logistique, développeurs souhaitant intégrer la planification symbolique dans leurs applications. Aucun prerequis en planification : les concepts sont introduits progressivement depuis les fondements STRIPS jusqu'aux approches neuro-symboliques modernes.
 
 ## Vue d'ensemble
 
@@ -30,19 +30,19 @@ La planification repond a une question differente de celle de l'apprentissage : 
 
 ### Phase 1 : Fondations (Notebooks 1-3, ~2h)
 
-La serie debute par le notebook Setup (0) qui configure automatiquement l'environnement : installation de `unified-planning`, OR-Tools, verification de Docker et lancement du conteneur Fast Downward. Le notebook 1 (Introduction) presente le triptyque fondamental Etat-Action-But, le modele STRIPS (1971) avec ses hypotheses — statique, deterministe, observable, discret, instantane — et le contexte historique depuis Fikes & Nilsson jusqu'aux LLMs modernes. Le notebook 2 (PDDL-Basics) plonge dans la syntaxe PDDL : domaines, problemes, types, predicats, actions, preconditions et effets. Le notebook 3 (State-Space) explore l'explosion combinatoire ($O(2^n)$ predicats) et la necessite des heuristiques pour guider la recherche dans l'espace d'etats. A l'issue de cette phase, vous savez modeliser un probleme en PDDL et comprendre pourquoi la recherche aveugle ne suffit pas.
+La série débute par le notebook Setup (0) qui configure automatiquement l'environnement : installation de `unified-planning`, OR-Tools, verification de Docker et lancement du conteneur Fast Downward. Le notebook 1 (Introduction) présente le triptyque fondamental Etat-Action-But, le modele STRIPS (1971) avec ses hypotheses — statique, deterministe, observable, discret, instantane — et le contexte historique depuis Fikes & Nilsson jusqu'aux LLMs modernes. Le notebook 2 (PDDL-Basics) plonge dans la syntaxe PDDL : domaines, problemes, types, predicats, actions, preconditions et effets. Le notebook 3 (State-Space) explore l'explosion combinatoire ($O(2^n)$ predicats) et la necessite des heuristiques pour guider la recherche dans l'espace d'etats. A l'issue de cette phase, vous savez modeliser un probleme en PDDL et comprendre pourquoi la recherche aveugle ne suffit pas.
 
 ### Phase 2 : Planification Classique (Notebooks 4-6, ~3h)
 
-Les notebooks 4 a 6 constituent le coeur technique de la serie. Le notebook 4 (Fast-Downward) presente l'architecture en trois etapes de Fast Downward (translator PDDL→SAS+, preprocessor C++, search C++) et montre comment l'executer via Docker et unified-planning. Les algorithmes de recherche (A*, Greedy, EHC) y sont testes sur Blocks World et Logistics. Le notebook 5 (Heuristics) approfondit la theorie : classification admissible/non-admissible ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), comparaison experimentale des heuristiques sur le nombre de noeuds expanses, et guide de selection. Le notebook 6 (Domains) couvre les domaines standards de l'IPC (Blocks World, Logistics, Gripper, Satellite) avec des problemes de complexite croissante. A l'issue, vous pouvez configurer un planificateur optimal, choisir l'heuristique adequat, et modeliser n'importe quel domaine IPC.
+Les notebooks 4 a 6 constituent le coeur technique de la série. Le notebook 4 (Fast-Downward) présente l'architecture en trois étapes de Fast Downward (translator PDDL→SAS+, preprocessor C++, search C++) et montre comment l'executer via Docker et unified-planning. Les algorithmes de recherche (A*, Greedy, EHC) y sont testes sur Blocks World et Logistics. Le notebook 5 (Heuristics) approfondit la theorie : classification admissible/non-admissible ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), comparaison expérimentale des heuristiques sur le nombre de noeuds expanses, et guide de selection. Le notebook 6 (Domains) couvre les domaines standards de l'IPC (Blocks World, Logistics, Gripper, Satellite) avec des problemes de complexite croissante. A l'issue, vous pouvez configurer un planificateur optimal, choisir l'heuristique adequat, et modeliser n'importe quel domaine IPC.
 
 ### Phase 3 : Approches Avancees (Notebooks 7-9, ~3h)
 
-La planification classique epuise ses limites des que les problemes deviennent trop grands pour l'exploration d'etats. Les notebooks 7 a 6 proposent des alternatives. Le notebook 7 (OR-Tools) introduce la programmation par contraintes avec CP-SAT de Google OR-Tools : modelisation de contraintes (all-different, cumulative, table), scheduling, et optimisation multi-objectif. Le notebook 8 (Temporal) etend au domaine temporel avec PDDL 2.1 : durées d'actions, parallelisme, contraintes temporelles simples et denses, ordonnancement de taches. Le notebook 9 (HTN) presente la planification hierarchique (Task Networks) : taches primitives vs abstraites, methodes de decomposition, langage HDDL, solveur inspire de SHOP2, et comparaison avec STRIPS. A l'issue, vous disposez de trois paradigmes complementaires pour les problemes qui depassent la planification classique.
+La planification classique epuise ses limites des que les problemes deviennent trop grands pour l'exploration d'etats. Les notebooks 7 a 6 proposent des alternatives. Le notebook 7 (OR-Tools) introduce la programmation par contraintes avec CP-SAT de Google OR-Tools : modelisation de contraintes (all-different, cumulative, table), scheduling, et optimisation multi-objectif. Le notebook 8 (Temporal) etend au domaine temporel avec PDDL 2.1 : durées d'actions, parallelisme, contraintes temporelles simples et denses, ordonnancement de taches. Le notebook 9 (HTN) présente la planification hierarchique (Task Networks) : taches primitives vs abstraites, méthodes de decomposition, langage HDDL, solveur inspire de SHOP2, et comparaison avec STRIPS. A l'issue, vous disposez de trois paradigmes complementaires pour les problemes qui depassent la planification classique.
 
 ### Phase 4 : Neuro-Symbolique (Notebooks 10-12, ~3h)
 
-La derniere partie explore la frontier entre IA symbolique et apprentissage profond. Le notebook 10 (LLM-Planning) montre comment les Large Language Models peuvent genérer des plans a partir de descriptions en langage naturel, le prompting pour la planification, et le plan repair. Le notebook 11 (Unified-Planning) detaille l'interface unifiee `unified-planning` : connection a plusieurs solveurs en quelques lignes, comparaison croisée des performances, et portabilite du modele PDDL entre moteurs. Le notebook 12 (LOOP) introduit le paradigme **Learning to Plan** : architecture LOOP (state encoder, policy network, value network), encodage PDDL en tenseurs (one-hot, GNN), entraînement par imitation et renforcement, resultats sur benchmarks IPC (85.8% coverage), et comparison avec KRCL. Ce notebook conclut la serie avec les tendances futures : foundation models, meta-learning, inverse reinforcement learning.
+La dernière partie explore la frontier entre IA symbolique et apprentissage profond. Le notebook 10 (LLM-Planning) montre comment les Large Language Models peuvent genérer des plans a partir de descriptions en langage naturel, le prompting pour la planification, et le plan repair. Le notebook 11 (Unified-Planning) detaille l'interface unifiee `unified-planning` : connection a plusieurs solveurs en quelques lignes, comparaison croisée des performances, et portabilité du modele PDDL entre moteurs. Le notebook 12 (LOOP) introduit le paradigme **Learning to Plan** : architecture LOOP (state encoder, policy network, value network), encodage PDDL en tenseurs (one-hot, GNN), entraînement par imitation et renforcement, résultats sur benchmarks IPC (85.8% coverage), et comparison avec KRCL. Ce notebook conclut la série avec les tendances futures : foundation models, meta-learning, inverse reinforcement learning.
 
 ### Parcours alternatifs
 
@@ -73,18 +73,18 @@ Pour les approches combinees apprentissage profond + symbolique :
 ### Si vous débutez en planification
 **Commencez par les fondations.** Le notebook 1 (Introduction) pose le vocabulaire (etat, action, but, STRIPS) et le contexte historique. Le notebook 2 (PDDL-Basics) apprend la syntaxe standard du domaine. Sans ces bases, les notebooks suivants seront difficiles a suivre.
 
-**Passez a la planification classique quand :** vous avez un domaine PDDL defini et voulez trouver un plan optimal rapidement. Fast Downward + LM-cut est le choix par defaut.
+**Passez a la planification classique quand :** vous avez un domaine PDDL defini et voulez trouver un plan optimal rapidement. Fast Downward + LM-cut est le choix par défaut.
 
-### Si vous venez de la recherche operationnelle
+### Si vous venez de la recherche opérationnelle
 **Commencez par OR-Tools (notebook 7).** Le CP-SAT est familier aux optimiseurs : modelisation par contraintes, fonctions objectif, solveur commercial (ou open-source). La transition vers la planification est naturelle.
 
-**Passez a PDDL quand :** vous avez besoin de la portabilite du modele (meme domaine, solveurs multiples) ou que vous voulez exploiter les heuristiques specialisees de Fast Downward.
+**Passez a PDDL quand :** vous avez besoin de la portabilité du modele (même domaine, solveurs multiples) ou que vous voulez exploiter les heuristiques specialisees de Fast Downward.
 
 ### Si vous ne savez pas quoi choisir
 
 | Critere | Recommandation |
 |---------|----------------|
-| Juste decouvrir la planification | **Planners-0-Setup** + **Planners-1-Introduction** |
+| Juste découvrir la planification | **Planners-0-Setup** + **Planners-1-Introduction** |
 | Un premier planificateur qui marche | **Planners-4-Fast-Downward** (Docker + Blocks World) |
 | Optimisation de scheduling | **Planners-7-OR-Tools** |
 | Planification hierarchique | **Planners-9-HTN** (SHOP2, decomposition) |
@@ -121,7 +121,7 @@ SymbolicAI/Planners/
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, vous saurez :
+A l'issue de cette série, vous saurez :
 
 1. **Modeliser** des problemes de planification en PDDL (Planning Domain Definition Language)
 2. **Utiliser** les planificateurs modernes (Fast Downward, OR-Tools, unified-planning)
@@ -138,20 +138,20 @@ A l'issue de cette serie, vous saurez :
 
 ## Contenu detaille des notebooks
 
-Chaque notebook introduit un concept ou modele specifique. Le tableau ci-dessous resume en une ligne l'apport pedagogique de chacun — au-dela du titre, c'est le **concept cle** qu'il enseigne.
+Chaque notebook introduit un concept ou modele spécifique. Le tableau ci-dessous resume en une ligne l'apport pédagogique de chacun — au-dela du titre, c'est le **concept cle** qu'il enseigne.
 
-| # | Notebook | Apport pedagogique |
+| # | Notebook | Apport pédagogique |
 |---|----------|-------------------|
 | 0 | Setup | Boucle environnement : verification Python → installation packages → Docker → premier PDDL |
 | 1 | Introduction | Triptyque Etat-Action-But, hypotheses STRIPS (1971), taxonomie des paradigmes |
 | 2 | PDDL-Basics | Syntaxe PDDL : domaines, problemes, types, predicats, actions, preconditions, effets |
 | 3 | State-Space | Explosion combinatoire $O(2^n)$, necessite des heuristiques, graphe d'etats |
-| 4 | Fast-Downward | Architecture 3 etapes (translator/preprocessor/search), A* vs Greedy vs EHC via Docker |
+| 4 | Fast-Downward | Architecture 3 étapes (translator/preprocessor/search), A* vs Greedy vs EHC via Docker |
 | 5 | Heuristics | Classification admissible/non-admissible : $h^{add}$, $h^{max}$, $h^{FF}$, LM-cut, comparison expériméntale |
 | 6 | Domains | Domaines IPC standards (Blocks, Logistics, Gripper, Satellite), complexité croissante |
 | 7 | OR-Tools | CP-SAT, programmation par contraintes, modelisation de scheduling, contraintes alldifferent |
 | 8 | Temporal | PDDL 2.1, durations d'actions, parallelisme, contraintes temporelles, ordonnancement |
-| 9 | HTN | Planification hierarchique : taches primitives/abstraites, methodes, HDDL, SHOP2 |
+| 9 | HTN | Planification hierarchique : taches primitives/abstraites, méthodes, HDDL, SHOP2 |
 | 10 | LLM-Planning | Planification avec LLMs, prompting, plan repair, limites et avantages |
 | 11 | Unified-Planning | Interface multi-solveurs, comparaison croisée, portabilité du modele |
 | 12 | LOOP | Learning to Plan : state encoder, policy network, value network, 85.8% IPC coverage |
@@ -187,8 +187,8 @@ Chaque notebook introduit un concept ou modele specifique. Le tableau ci-dessous
 | # | Notebook | Kernel | Contenu | Duree |
 |---|----------|--------|---------|-------|
 | 7 | [Planners-7-OR-Tools](03-Advanced/Planners-7-OR-Tools.ipynb) | Python | CP-SAT, programmation par contraintes, scheduling | 45 min |
-| 8 | [Planners-8-Temporal](03-Advanced/Planners-8-Temporal.ipynb) | Python | PDDL 2.1, durees, parallelisme, ordonnancement | 40 min |
-| 9 | [Planners-9-HTN](03-Advanced/Planners-9-HTN.ipynb) | Python | Hierarchical Task Networks, methodes, decomposition | 45 min |
+| 8 | [Planners-8-Temporal](03-Advanced/Planners-8-Temporal.ipynb) | Python | PDDL 2.1, durées, parallelisme, ordonnancement | 40 min |
+| 9 | [Planners-9-HTN](03-Advanced/Planners-9-HTN.ipynb) | Python | Hierarchical Task Networks, méthodes, decomposition | 45 min |
 
 ### Partie 4 : Neuro-Symbolique (04-NeuroSymbolic/)
 
@@ -207,7 +207,7 @@ Chaque notebook introduit un concept ou modele specifique. Le tableau ci-dessous
 | **Entree** | Etat initial + modele du domaine + condition but |
 | **Sortie** | Sequence d'actions (plan) executable |
 | **Hypothese** | Deterministe, observable, discret (STRIPS classique) |
-| **Complexite** | NP-complet en general ($O(2^n)$ etats possibles) |
+| **Complexite** | NP-complet en général ($O(2^n)$ etats possibles) |
 | **Garantie** | Optimal si heuristique admissible (A*) |
 
 ## Prerequis
@@ -218,10 +218,10 @@ Chaque notebook introduit un concept ou modele specifique. Le tableau ci-dessous
 - **Algorithmique de base** : graphes (BFS, DFS, A*), recherche
 - **Logique propositionnelle** : predicats, connecteurs logiques, quantificateurs
 
-### Pour les notebooks avances
+### Pour les notebooks avancés
 
-- **Bases en machine learning** (notebooks 10-12) : reseaux de neurones, loss, backpropagation
-- **API OpenAI/Anthropic** (notebook 10) : prompts LLM, generation de texte
+- **Bases en machine learning** (notebooks 10-12) : réseaux de neurones, loss, backpropagation
+- **API OpenAI/Anthropic** (notebook 10) : prompts LLM, génération de texte
 - **Connaissance de PDDL** (notebooks 8-9) : domains, problems, types
 
 ### Pour les notebooks pratiques
@@ -250,7 +250,7 @@ pip install unified-planning ortools numpy matplotlib networkx
 docker pull jsboige/coursia-fast-downward:latest
 ```
 
-L'image fournit un serveur API HTTP sur le port 8200. Les notebooks appellent l'endpoint `/plan` avec un payload JSON `{domain, problem, search}` et recoivent le plan optimal.
+L'image fournit un serveur API HTTP sur le port 8200. Les notebooks appellent l'endpoint `/plan` avec un payload JSON `{domain, problem, search}` et reçoivent le plan optimal.
 
 ### 3. Verification
 
@@ -269,7 +269,7 @@ curl -s http://localhost:8200/health
 | **OR-Tools CP-SAT** | Solveur de contraintes Google (scheduling) | 7 |
 | **PDDL** | Planning Domain Definition Language (standard IPC) | 2-9 |
 | **HDDL** | Hierarchical Domain Definition Language (HTN) | 9 |
-| **OpenAI/Anthropic API** | LLMs pour generation de plans | 10 |
+| **OpenAI/Anthropic API** | LLMs pour génération de plans | 10 |
 | **PyTorch** | Reseaux de neurones pour heuristiques (LOOP) | 12 |
 
 ## Domaines PDDL classiques
@@ -287,7 +287,7 @@ Les notebooks utilisent les domaines standards de l'IPC (International Planning 
 
 ## PDDL - Planning Domain Definition Language
 
-PDDL est le langage standard pour decrire des problemes de planification.
+PDDL est le langage standard pour décrire des problemes de planification.
 
 ### Domaine (domain.pddl)
 
@@ -337,7 +337,7 @@ PDDL est le langage standard pour decrire des problemes de planification.
 
 ## Fast Downward
 
-Planificateur optimal developpe a l'Universite de Bale :
+Planificateur optimal développe a l'Universite de Bale :
 
 | Caracteristique | Description |
 |-----------------|-------------|
@@ -388,10 +388,10 @@ La planification HTN (Hierarchical Task Network) structure la recherche par deco
 
 SHOP2 (Simple Hierarchical Ordered Planner 2) utilise la decomposition ordonnee :
 
-1. Traiter la premiere tache de la liste
+1. Traiter la première tache de la liste
 2. Si primitive : verifier preconditions, appliquer, passer a la suivante
-3. Si abstraite : choisir une methode applicable, remplacer par sous-taches
-4. Backtracking : essayer la methode suivante si echec
+3. Si abstraite : choisir une méthode applicable, remplacer par sous-taches
+4. Backtracking : essayer la méthode suivante si echec
 
 ## Concepts cles
 
@@ -399,25 +399,25 @@ SHOP2 (Simple Hierarchical Ordered Planner 2) utilise la decomposition ordonnee 
 |---------|------------|
 | **STRIPS** | Modele de planification avec preconditions/add/delete (1971) |
 | **PDDL** | Planning Domain Definition Language - standard IPC depuis 1998 |
-| **Heuristique** | Fonction estimant le cout pour atteindre le but |
+| **Heuristique** | Fonction estimant le coût pour atteindre le but |
 | **A*** | Algorithme de recherche optimale avec heuristique admissible |
-| **Landmark** | Fait qui doit etre vrai a un moment du plan |
+| **Landmark** | Fait qui doit être vrai a un moment du plan |
 | **HTN** | Hierarchical Task Network - decomposition de taches |
 | **LM-cut** | Heuristique admissible basee sur les landmarks |
 | **CP-SAT** | Constraint Programming-Satisfiability (OR-Tools) |
-| **Learning to Plan** | Apprentissage de heuristiques par reseaux de neurones |
+| **Learning to Plan** | Apprentissage de heuristiques par réseaux de neurones |
 | **LOOP** | Framework neuro-symbolique, 85.8% coverage IPC |
 
-## Caracteristiques de la serie
+## Caracteristiques de la série
 
 | Caracteristique | Description |
 |-----------------|-------------|
 | **Progression** | Fondations → Classique → Avance → Neuro-symbolique |
 | **Pratique** | Chaque notebook contient des exemples executes et des exercices |
-| **Outils reels** | Fast Downward (IPC winner), OR-Tools (Google), unified-planning |
-| **Domaines IPC** | Blocks World, Logistics, Gripper — les memes que les competitions |
+| **Outils réels** | Fast Downward (IPC winner), OR-Tools (Google), unified-planning |
+| **Domaines IPC** | Blocks World, Logistics, Gripper — les mêmes que les competitions |
 | **Output verify** | Tous les notebooks sont executes avec outputs inclus |
-| **Navigation** | Headers avec liens precedent/suivant dans chaque notebook |
+| **Navigation** | Headers avec liens précédent/suivant dans chaque notebook |
 
 ## Quick Start
 
@@ -432,7 +432,7 @@ python -c "import unified_planning; from ortools.sat.python import cp_model; pri
 jupyter notebook 01-Foundation/Planners-1-Introduction.ipynb
 ```
 
-Pour les notebooks 4-6 (Fast Downward), l'image Docker `jsboige/coursia-fast-downward` fournit un serveur API HTTP sur le port 8200 : `docker pull jsboige/coursia-fast-downward:latest`. Les notebooks theoriques (1-3, 7-12) ne necessitent que Python.
+Pour les notebooks 4-6 (Fast Downward), l'image Docker `jsboige/coursia-fast-downward` fournit un serveur API HTTP sur le port 8200 : `docker pull jsboige/coursia-fast-downward:latest`. Les notebooks théoriques (1-3, 7-12) ne necessitent que Python.
 
 ## Navigation guide
 
@@ -441,12 +441,12 @@ Pour les notebooks 4-6 (Fast Downward), l'image Docker `jsboige/coursia-fast-dow
 1. **Debutants** : Commencer par `00-Environment/Planners-0-Setup.ipynb`
 2. **Fondations** : Suivre `01-Foundation/` dans l'ordre
 3. **Pratique** : Explorer `02-Classical/` pour les outils
-4. **Avance** : `03-Advanced/` et `04-NeuroSymbolic/` selon interets
+4. **Avance** : `03-Advanced/` et `04-NeuroSymbolic/` selon intérêts
 
 ### Liens de navigation
 
 Chaque notebook contient :
-- Header avec liens vers precedent/suivant
+- Header avec liens vers précédent/suivant
 - Navigation vers cet index
 - Ancres internes pour les sections
 
@@ -465,8 +465,8 @@ BATCH_MODE=true python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.
 ### Documentation
 
 - [unified-planning](https://github.com/aiplan4eu/unified-planning) - Bibliotheque Python
-- [Fast Downward](https://www.fast-downward.org/) - Planificateur de reference
-- [PDDL Reference](https://planning.wiki/) - Documentation PDDL complete
+- [Fast Downward](https://www.fast-downward.org/) - Planificateur de référence
+- [PDDL Reference](https://planning.wiki/) - Documentation PDDL complète
 - [OR-Tools CP-SAT](https://developers.google.com/optimization/cp/cp_sat) - Documentation Google
 
 ### Cours et tutorials
@@ -479,8 +479,8 @@ BATCH_MODE=true python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.
 
 | Reference | Couverture |
 |-----------|------------|
-| Ghallab, Nau & Traverso, *Automated Planning: Theory and Practice* (2004) | Textbook de reference, toute la serie |
-| Russell & Norvig, *AIMA* 4e ed., ch. 10-11 | Cadre general planification |
+| Ghallab, Nau & Traverso, *Automated Planning: Theory and Practice* (2004) | Textbook de référence, toute la série |
+| Russell & Norvig, *AIMA* 4e ed., ch. 10-11 | Cadre général planification |
 | Helmert, "The Fast Downward Planning System" (2006) | Notebooks 4-6 |
 | Hoffmann & Nebel, "The FF Planning System" (2001) | Heuristique h-FF, notebook 5 |
 | Richter & Westphal, "LAMA: Planner" (2010) | Landmarks, notebook 5 |
@@ -496,30 +496,30 @@ La planification automatique est une branche de l'IA symbolique :
 - Recherche dans espace d'etats
 - Heuristiques admissibles pour optimalite
 
-### Ponts avec les autres series
+### Ponts avec les autres séries
 
 | Serie | Connection | Details |
 | ----- | ---------- | ------- |
 | **[Tweety](../Tweety/)** | Logique et argumentation | Les solveurs SAT/CSP de Tweety complementent les planificateurs PDDL. Les dialogues argumentatifs (Tweety-8) sont des instances de planification multi-agents. |
-| **[Lean](../Lean/)** | Verification formelle | Les plans generes peuvent etre verifies formellement. Les heuristiques d'admissibilite (h-max, LM-cut) reposent sur des preuves de correction similaires aux tactiques Lean. |
+| **[Lean](../Lean/)** | Verification formelle | Les plans generes peuvent être verifies formellement. Les heuristiques d'admissibilite (h-max, LM-cut) reposent sur des preuves de correction similaires aux tactiques Lean. |
 | **[SmartContracts](../SmartContracts/)** | Execution planifiee | Les smart contracts DeFi (liquidations, arbitrage) sont des problemes de planification sous contraintes temporelles et de gaz. Le notebook SC-14 (verification formelle) croise OR-Tools (Planners-7). |
 | **[GameTheory](../../GameTheory/)** | Jeux sequentiels | La recherche adversariale (A*, minimax) est commune a la planification classique et a la theorie des jeux. Les jeux cooperatifs (Shapley) sont des problemes d'allocation de taches planifiables. |
-| **[Search](../../Search/)** | Fondements communs | La serie Search couvre les algorithmes de base (BFS, DFS, A*) utilises dans les planificateurs. CSP (Search Part2) correspond a OR-Tools CP-SAT (Planners-7). |
+| **[Search](../../Search/)** | Fondements communs | La série Search couvre les algorithmes de base (BFS, DFS, A*) utilises dans les planificateurs. CSP (Search Part2) correspond a OR-Tools CP-SAT (Planners-7). |
 | Lecture transversale | [La mer qui monte](../../../docs/grothendieckian-lens.md) | Grille de lecture grothendieckienne du depot : changement de representation, certification A/B/C |
 
-## Cross-series Bridges
+## Cross-séries Bridges
 
 | Serie | Lien | Connection |
 | ------- | ------ | ----------- |
-| [Lean](../Lean/README.md) | Verification formelle | Les plans PDDL generes peuvent etre verifies formellement dans Lean |
+| [Lean](../Lean/README.md) | Verification formelle | Les plans PDDL generes peuvent être verifies formellement dans Lean |
 | [Tweety](../Tweety/README.md) | Logique et argumentation | Les solveurs SAT de Tweety peuvent resoudre des sous-problemes de planification |
 | [SmartContracts](../SmartContracts/README.md) | Ordonnancement | Les liquidations DeFi sont des problemes de planification temporelle (notebook 8) |
-| [GameTheory](../../GameTheory/README.md) | Recherche sequentielle | A* en planification et minimax en jeux partagent la meme structure de graphe |
+| [GameTheory](../../GameTheory/README.md) | Recherche sequentielle | A* en planification et minimax en jeux partagent la même structure de graphe |
 | [Search](../../Search/README.md) | Fondations algorithmiques | A*, BFS, DFS de Search sont les bases des planificateurs classiques |
 
 ## FAQ / Troubleshooting
 
-### 1. Le conteneur Docker Fast Downward ne repond pas sur le port 8200
+### 1. Le conteneur Docker Fast Downward ne répond pas sur le port 8200
 
 **Symptome** : `ConnectionRefusedError` ou timeout dans les notebooks 4-6.
 
@@ -536,13 +536,13 @@ docker run -d --name coursia-fast-downward -p 8200:8200 jsboige/coursia-fast-dow
 curl -s http://localhost:8200/health
 ```
 
-Si le port 8200 est deja pris par un autre service, utiliser un port different :
+Si le port 8200 est déjà pris par un autre service, utiliser un port different :
 ```bash
 docker run -d --name coursia-fast-downward -p 8201:8200 jsboige/coursia-fast-downward:latest
 ```
 Dans ce cas, adapter l'URL dans les notebooks de `localhost:8200` vers `localhost:8201`.
 
-### 2. unified-planning ne detecte pas Fast Downward
+### 2. unified-planning ne détecte pas Fast Downward
 
 **Symptome** : `up_fast_downward` importe mais `FastDownwardPDDLPlanner()` echoue avec une erreur de chemin.
 
@@ -560,7 +560,7 @@ print(resp.status_code, resp.json())
 
 **Symptome** : Le solveur rejette le domaine ou le probleme PDDL avec une erreur de parsing.
 
-**Causes frequentes** :
+**Causes fréquentes** :
 
 | Erreur | Cause | Correction |
 | ------ | ----- | ---------- |
@@ -569,7 +569,7 @@ print(resp.status_code, resp.json())
 | `unsupported requirement` | Requirement non supporte par le solveur | Retirer `:adl`, `:quantified-preconditions` ou utiliser un solveur compatible |
 | `precondition false` | Conjonction vide ou variable non initialisee | Verifier les noms de predicats dans `:predicates` |
 
-**Astuce** : Valider le PDDL avec [planning.wiki](https://planning.wiki/) avant de le soumettre au solveur. Le notebook 2 (PDDL-Basics) couvre la syntaxe complete.
+**Astuce** : Valider le PDDL avec [planning.wiki](https://planning.wiki/) avant de le soumettre au solveur. Le notebook 2 (PDDL-Basics) couvre la syntaxe complète.
 
 ### 4. OR-Tools CP-SAT : "model is infeasible" sur un probleme simple
 
@@ -577,9 +577,9 @@ print(resp.status_code, resp.json())
 
 **Causes** :
 
-1. **Contradiction entre contraintes** : deux contraintes `model.Add(x == 1)` et `model.Add(x == 2)` sur la meme variable.
-2. **Domaine vide** : `model.NewIntVar(5, 3, "x")` (borne inferieure > superieure).
-3. **Contraintes cumulatives** : la capacite cumulee est inferieure a la demande totale.
+1. **Contradiction entre contraintes** : deux contraintes `model.Add(x == 1)` et `model.Add(x == 2)` sur la même variable.
+2. **Domaine vide** : `model.NewIntVar(5, 3, "x")` (borne inférieure > supérieure).
+3. **Contraintes cumulatives** : la capacite cumulee est inférieure a la demande totale.
 
 **Diagnostic** :
 ```python
@@ -624,14 +624,14 @@ if status == cp_model.INFEASIBLE:
    # Puis pointer unified-planning vers le binaire
    ```
 
-Les notebooks theoriques (1-3, 7-12) ne necessitent **pas** Docker et fonctionnent avec uniquement `pip install unified-planning ortools`.
+Les notebooks théoriques (1-3, 7-12) ne necessitent **pas** Docker et fonctionnent avec uniquement `pip install unified-planning ortools`.
 
 ## Contribution
 
-Pour contribuer a cette serie :
+Pour contribuer a cette série :
 
 1. Suivre les conventions de [CLAUDE.md](../../../CLAUDE.md)
-2. Respecter la structure pedagogique (header, objectifs, interpretations)
+2. Respecter la structure pédagogique (header, objectifs, interpretations)
 3. Utiliser `scripts/notebook_tools/notebook_helpers.py` pour la manipulation
 4. Tester avec `python scripts/notebook_tools/notebook_tools.py validate`
 

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -45,7 +45,7 @@ La série SymbolicLearning (10 notebooks) suit le chapitre 19 d'AIMA : induction
 
 ## Quick Start
 
-**Premier notebook recommande par serie :**
+**Premier notebook recommande par série :**
 
 | Serie | Premier notebook | Commande rapide |
 |-------|-----------------|-----------------|
@@ -61,7 +61,7 @@ La série SymbolicLearning (10 notebooks) suit le chapitre 19 d'AIMA : induction
 
 ---
 
-## Prerequis par serie
+## Prerequis par série
 
 | Serie | Kernel | Environnement special | Packages principaux | API Keys |
 |-------|--------|----------------------|---------------------|----------|
@@ -97,9 +97,9 @@ Serie de **10 notebooks** sur [TweetyProject](https://tweetyproject.org/), bibli
 | 7b | [Tweety-7b-Ranking-Probabilistic](Tweety/Tweety-7b-Ranking-Probabilistic.ipynb) | Ranking semantics, argumentation probabiliste | 2 | Java/JPype |
 | **Applications** |
 | 8 | [Tweety-8-Agent-Dialogues](Tweety/Tweety-8-Agent-Dialogues.ipynb) | Agents argumentatifs, protocoles de dialogue, loteries | 2 | Java/JPype |
-| 9 | [Tweety-9-Preferences](Tweety/Tweety-9-Preferences.ipynb) | Ordres de preference, theorie du vote (Borda, Copeland) | 1 | Java/JPype |
+| 9 | [Tweety-9-Preferences](Tweety/Tweety-9-Preferences.ipynb) | Ordres de préférence, theorie du vote (Borda, Copeland) | 1 | Java/JPype |
 
-> 10/10 notebooks ont des exercices. La configuration de Tweety-1-Setup constitue l'exercice setup de la serie.
+> 10/10 notebooks ont des exercices. La configuration de Tweety-1-Setup constitue l'exercice setup de la série.
 
 ### Technologies
 
@@ -111,13 +111,13 @@ Serie de **10 notebooks** sur [TweetyProject](https://tweetyproject.org/), bibli
 | **SPASS** | Prouveur de theoremes pour logique modale |
 | **EProver** | Prouveur FOL haute performance |
 
-Documentation complete : [Tweety/README.md](Tweety/README.md)
+Documentation complète : [Tweety/README.md](Tweety/README.md)
 
 ---
 
 ## Lean - Verification Formelle
 
-Serie de **21 notebooks** sur **Lean 4**, proof assistant base sur la theorie des types dependants. Couvre des fondations theoriques jusqu'a l'integration des LLMs pour l'assistance automatique aux preuves, un tribut a Grothendieck (Lean-13/13b), les jeux de Conway (Lean-14a/14b/14c), et les theoremes de Kochen-Specker (Lean-15) et du Libre Arbitre (Lean-16).
+Serie de **21 notebooks** sur **Lean 4**, proof assistant base sur la theorie des types dependants. Couvre des fondations théoriques jusqu'a l'intégration des LLMs pour l'assistance automatique aux preuves, un tribut a Grothendieck (Lean-13/13b), les jeux de Conway (Lean-14a/14b/14c), et les theoremes de Kochen-Specker (Lean-15) et du Libre Arbitre (Lean-16).
 
 ### Structure detaillee
 
@@ -134,15 +134,15 @@ Serie de **21 notebooks** sur **Lean 4**, proof assistant base sur la theorie de
 | 7 | [Lean-7-LLM-Integration](Lean/Lean-7-LLM-Integration.ipynb) | Python WSL | AlphaProof, LeanCopilot, collaboration humain-LLM-Lean | 2 |
 | 7b | [Lean-7b-Examples](Lean/Lean-7b-Examples.ipynb) | Python WSL | Exemples progressifs, comparaison OpenAI vs Anthropic, Erdos | 8 |
 | 8 | [Lean-8-Agentic-Proving](Lean/Lean-8-Agentic-Proving.ipynb) | Python WSL | Agents autonomes, Harmonic Aristotle, Erdos #124 | 7 |
-| 9 | [Lean-9-SK-Multi-Agents](Lean/Lean-9-SK-Multi-Agents.ipynb) | Python WSL | Semantic Kernel, 5 agents specialises, ProofState | 2 |
+| 9 | [Lean-9-SK-Multi-Agents](Lean/Lean-9-SK-Multi-Agents.ipynb) | Python WSL | Semantic Kernel, 5 agents spécialisés, ProofState | 2 |
 | 10 | [Lean-10-LeanDojo](Lean/Lean-10-LeanDojo.ipynb) | Python WSL | LeanDojo, tracing, extraction theoremes, ML pour theorem proving | 2 |
-| 11 | [Lean-11-TorchLean](Lean/Lean-11-TorchLean.ipynb) | Lean 4 | Verification formelle de reseaux de neurones | 2 |
+| 11 | [Lean-11-TorchLean](Lean/Lean-11-TorchLean.ipynb) | Lean 4 | Verification formelle de réseaux de neurones | 2 |
 | 11py | [Lean-11-TorchLean-Python](Lean/Lean-11-TorchLean-Python.ipynb) | Python | IBP, certificats de robustesse, verification | 7 |
 | 12 | [Lean-12-Sensitivity-Theorem](Lean/Lean-12-Sensitivity-Theorem.ipynb) | Lean 4 | Port Lean du theoreme de sensibilite de Huang (2019), hypercube, signing matrix | 4 |
 | **Hommages et theoremes** |
 | 13 | [Lean-13-Grothendieck-Tribute](Lean/Lean-13-Grothendieck-Tribute.ipynb) | Lean 4 | Hommage a Grothendieck : tour Mathlib, micro-formalisations | 3 |
 | 13b | [Lean-13b-Lean-Grothendieck](Lean/Lean-13b-Lean-Grothendieck.ipynb) | Python WSL | Grothendieck en Lean, atelier pratique : sources `grothendieck_lean/`, snippets via WSL | 3 |
-| 14a | [Lean-14a-Conway-Man-and-Work](Lean/Lean-14a-Conway-Man-and-Work.ipynb) | Python WSL | Conway, l'homme et l'oeuvre : panorama des grands resultats, premieres formalisations executees depuis `conway_lean` | 3 |
+| 14a | [Lean-14a-Conway-Man-and-Work](Lean/Lean-14a-Conway-Man-and-Work.ipynb) | Python WSL | Conway, l'homme et l'oeuvre : panorama des grands résultats, premières formalisations executees depuis `conway_lean` | 3 |
 | 14b | [Lean-14b-Conway-Game-of-Life-Lean](Lean/Lean-14b-Conway-Game-of-Life-Lean.ipynb) | Python WSL | Game of Life as Computation : Doomsday, FRACTRAN, Look-and-Say, Nim, Angel | 4 |
 | 14c | [Lean-14c-Conway-Game-of-Life-Golly](Lean/Lean-14c-Conway-Game-of-Life-Golly.ipynb) | Python | Game of Life en images : les 3 piliers, compagnon Golly | 4 |
 | 15 | [Lean-15-Kochen-Specker](Lean/Lean-15-Kochen-Specker.ipynb) | Lean 4 | Theoreme de Kochen-Specker (1967), 18 vecteurs Cabello-Estebaranz-Garcia-Alcaine, contextuality quantique | 5 |
@@ -155,7 +155,7 @@ Serie de **21 notebooks** sur **Lean 4**, proof assistant base sur la theorie de
 
 > Note : Les kernels Windows ne fonctionnent pas (signal.SIGPIPE, problemes chemins)
 
-Documentation complete : [Lean/README.md](Lean/README.md)
+Documentation complète : [Lean/README.md](Lean/README.md)
 
 ---
 
@@ -175,7 +175,7 @@ Serie de **18 notebooks** sur le Web Semantique (dont 1 legacy deprecie), combin
 | 4 | [SW-4-CSharp-SPARQL](SemanticWeb/SW-4-CSharp-SPARQL.ipynb) | .NET C# | Query Builder, SELECT/FILTER, OPTIONAL, UNION | 7 |
 | 4b | [SW-4b-Python-SPARQL](SemanticWeb/SW-4b-Python-SPARQL.ipynb) | Python | Equivalent Python avec SPARQLWrapper | 5 |
 | **Partie 2 : Donnees Liees et Ontologies** |
-| 5 | [SW-5-CSharp-LinkedData](SemanticWeb/SW-5-CSharp-LinkedData.ipynb) | .NET C# | DBpedia, Wikidata, requetes federees SERVICE | 6 |
+| 5 | [SW-5-CSharp-LinkedData](SemanticWeb/SW-5-CSharp-LinkedData.ipynb) | .NET C# | DBpedia, Wikidata, requêtes federees SERVICE | 6 |
 | 5b | [SW-5b-Python-LinkedData](SemanticWeb/SW-5b-Python-LinkedData.ipynb) | Python | Equivalent Python | 5 |
 | 6 | [SW-6-CSharp-RDFS](SemanticWeb/SW-6-CSharp-RDFS.ipynb) | .NET C# | RDFS, inference automatique, OntologyGraph | 4 |
 | 7 | [SW-7-CSharp-OWL](SemanticWeb/SW-7-CSharp-OWL.ipynb) | .NET C# | OWL 2, profils (EL/QL/RL), restrictions | 5 |
@@ -189,13 +189,13 @@ Serie de **18 notebooks** sur le Web Semantique (dont 1 legacy deprecie), combin
 | 12 | [SW-12-Python-GraphRAG](SemanticWeb/SW-12-Python-GraphRAG.ipynb) | Python | GraphRAG, extraction entites LLM | 6 |
 | **Bonus** | [SW-13-Python-Reasoners](SemanticWeb/SW-13-Python-Reasoners.ipynb) | Python | Comparaison raisonneurs OWL (owlrl, HermiT, reasonable) | 3 (faible) |
 
-Documentation complete : [SemanticWeb/README.md](SemanticWeb/README.md)
+Documentation complète : [SemanticWeb/README.md](SemanticWeb/README.md)
 
 ---
 
 ## Planners - Planification Automatique
 
-Serie de **13 notebooks** sur la planification automatique, couvrant PDDL classique, CP-SAT (OR-Tools), VRP, planification temporelle, HTN, et integration LLM.
+Serie de **13 notebooks** sur la planification automatique, couvrant PDDL classique, CP-SAT (OR-Tools), VRP, planification temporelle, HTN, et intégration LLM.
 
 ### Structure detaillee
 
@@ -222,7 +222,7 @@ Serie de **13 notebooks** sur la planification automatique, couvrant PDDL classi
 
 > 12/13 notebooks ont des exercices. Seul Planners-0-Setup (configuration) n'en a pas.
 
-Documentation complete : [Planners/README.md](Planners/README.md)
+Documentation complète : [Planners/README.md](Planners/README.md)
 
 ---
 
@@ -242,34 +242,34 @@ Serie de **27 notebooks** sur les smart contracts et la blockchain, organisee en
 | **05-Alternative-Chains** | SC-18 (Vyper), SC-19 (Ripple), SC-20 (Bitcoin), SC-21 (Move/Sui), SC-22 (Solana) | Ecosystemes alternatifs |
 | **06-Real-World** | SC-23 (Cross-Chain), SC-24 (Testnet), SC-25 (Mainnet), SC-26 (Final Project) | Deploiement, interoperabilite, projet final |
 
-Documentation complete : [SmartContracts/README.md](SmartContracts/README.md)
+Documentation complète : [SmartContracts/README.md](SmartContracts/README.md)
 
 ---
 
 ## Argument Analysis - Analyse Argumentative LLM
 
-Pipeline d'analyse argumentative multi-agents avec **Semantic Kernel** et LLMs. Combine detection de sophismes, formalisation logique, et validation par TweetyProject.
+Pipeline d'analyse argumentative multi-agents avec **Semantic Kernel** et LLMs. Combine détection de sophismes, formalisation logique, et validation par TweetyProject.
 
-> **Note** : Cette serie est un projet/demo, pas un cours. Aucun exercice etudiant. Non adaptee en l'etat pour un cours structure.
+> **Note** : Cette série est un projet/demo, pas un cours. Aucun exercice étudiant. Non adaptee en l'etat pour un cours structure.
 
 ### Structure detaillee
 
 | # | Notebook | Role |
 |---|----------|------|
 | 0 | [Agentic-0-init](Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb) | Configuration LLM, JPype/Tweety, ProjectManagerAgent |
-| 1 | [Agentic-1-informal_agent](Argument_Analysis/Argument_Analysis_Agentic-1-informal_agent.ipynb) | InformalAnalysisAgent, detection sophismes |
+| 1 | [Agentic-1-informal_agent](Argument_Analysis/Argument_Analysis_Agentic-1-informal_agent.ipynb) | InformalAnalysisAgent, détection sophismes |
 | 2 | [Agentic-2-pl_agent](Argument_Analysis/Argument_Analysis_Agentic-2-pl_agent.ipynb) | PropositionalLogicAgent, formalisation PL |
 | 3 | [Agentic-3-orchestration](Argument_Analysis/Argument_Analysis_Agentic-3-orchestration.ipynb) | Orchestration multi-agents |
 | 4 | [Executor](Argument_Analysis/Argument_Analysis_Executor.ipynb) | Pipeline complet, rapport JSON |
 | 5 | [UI_configuration](Argument_Analysis/Argument_Analysis_UI_configuration.ipynb) | Interface widgets ipywidgets |
 
-Documentation complete : [Argument_Analysis/README.md](Argument_Analysis/README.md)
+Documentation complète : [Argument_Analysis/README.md](Argument_Analysis/README.md)
 
 ---
 
 ## SymbolicLearning - Apprentissage Symbolique
 
-Serie de **10 notebooks** Python sur l'apprentissage symbolique (AIMA ch. 19) : induction pure (Version Space), apprentissage guide par la connaissance (EBL, RBL), programmation logique inductive (FOIL, resolution inverse, Progol), apprentissage actif d'automates (L* d'Angluin), et integration neuro-symbolique jusqu'au capstone LLM + knowledge graph.
+Serie de **10 notebooks** Python sur l'apprentissage symbolique (AIMA ch. 19) : induction pure (Version Space), apprentissage guide par la connaissance (EBL, RBL), programmation logique inductive (FOIL, resolution inverse, Progol), apprentissage actif d'automates (L* d'Angluin), et intégration neuro-symbolique jusqu'au capstone LLM + knowledge graph.
 
 ### Structure detaillee
 
@@ -281,14 +281,14 @@ Serie de **10 notebooks** Python sur l'apprentissage symbolique (AIMA ch. 19) : 
 | 4 | [SL-4-InductiveLogicProgramming](SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb) | FOIL, resolution inverse, knowledge graphs, Popper (LFF) | 4 | SL-1 |
 | 5 | [SL-5-NeuroSymbolic](SymbolicLearning/SL-5-NeuroSymbolic.ipynb) | T-norms, predicats neuronaux, LTN, DeepProbLog | 4 | SL-1 |
 | 6 | [SL-6-KnowledgeGraphs-ILP](SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb) | rdflib, AMIE rule mining, completion KG, ASP avec clingo | 4 | SL-4 |
-| 7 | [SL-7-LLM-SymbolicLearning](SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb) | Extraction de regles LLM, verification symbolique (Gemini optionnel) | 4 | SL-1 |
-| 8 | [SL-8-ActiveAutomataLearning](SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb) | L* d'Angluin, table d'observation, requetes MQ/EQ, Myhill-Nerode | 4 | SL-1 |
+| 7 | [SL-7-LLM-SymbolicLearning](SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb) | Extraction de règles LLM, verification symbolique (Gemini optionnel) | 4 | SL-1 |
+| 8 | [SL-8-ActiveAutomataLearning](SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb) | L* d'Angluin, table d'observation, requêtes MQ/EQ, Myhill-Nerode | 4 | SL-1 |
 | 9 | [SL-9-InverseResolution](SymbolicLearning/SL-9-InverseResolution.ipynb) | LGG de Plotkin, theta-subsomption, clause bottom, recherche Progol | 5 | SL-4 |
-| 10 | [SL-10-Capstone-NeuroSymbolic](SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb) | Pipeline neuro-symbolique 6 etages, LLM reel aux deux extremites | 4 | SL-5 a SL-7 |
+| 10 | [SL-10-Capstone-NeuroSymbolic](SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb) | Pipeline neuro-symbolique 6 etages, LLM réel aux deux extremites | 4 | SL-5 a SL-7 |
 
 > 10/10 notebooks ont des exercices — 40 au total, organises en table de pioche pour la seance de restitution (chaque exercice est assorti d'une question-twist).
 
-Documentation complete : [SymbolicLearning/README.md](SymbolicLearning/README.md)
+Documentation complète : [SymbolicLearning/README.md](SymbolicLearning/README.md)
 
 ---
 
@@ -301,7 +301,7 @@ Documentation complete : [SymbolicLearning/README.md](SymbolicLearning/README.md
 | [OR-tools-Stiegler](OR-tools-Stiegler.ipynb) | .NET C# | Probleme de Stigler, programmation lineaire avec OR-Tools | 2 |
 | [01_Linq2Z3_Intro](SMT/Z3/01_Linq2Z3_Intro.ipynb) | .NET C# | SMT avec LINQ, Z3.Linq, Missionnaires et Cannibales | 3 |
 
-Le notebook Z3 inaugure la serie [SMT/Z3/](SMT/Z3/README.md) (SMT declaratif via Z3.Linq), regroupee avec la serie Python [SMT/Z3-Python/](SMT/Z3-Python/README.md) sous le chapeau [SMT/](SMT/README.md) (Satisfiability Modulo Theories).
+Le notebook Z3 inaugure la série [SMT/Z3/](SMT/Z3/README.md) (SMT declaratif via Z3.Linq), regroupee avec la série Python [SMT/Z3-Python/](SMT/Z3-Python/README.md) sous le chapeau [SMT/](SMT/README.md) (Satisfiability Modulo Theories).
 
 ---
 
@@ -396,15 +396,15 @@ dotnet interactive jupyter install
 
 **Status execution : 10/10 SUCCESS**
 
-Le setup est entierement automatise via `Tweety-1-Setup.ipynb` :
+Le setup est entierement automatisé via `Tweety-1-Setup.ipynb` :
 
-1. **JDK 17 portable** : Auto-telecharge dans `Tweety/jdk-17-portable/` (Azul Zulu, ~180MB). Aucune installation systeme requise, pas de UAC.
-2. **JARs TweetyProject** : Auto-telecharges dans `Tweety/libs/` depuis Maven Central (35 modules, ~50MB total).
+1. **JDK 17 portable** : Auto-télécharge dans `Tweety/jdk-17-portable/` (Azul Zulu, ~180MB). Aucune installation système requise, pas de UAC.
+2. **JARs TweetyProject** : Auto-télécharges dans `Tweety/libs/` depuis Maven Central (35 modules, ~50MB total).
 3. **Outils externes** : Clingo, SPASS, EProver dans `Tweety/ext_tools/` (inclus dans le depot).
 
 **Problemes connus :**
 - `asp-1.30.jar` et `rpcl-1.30.jar` : Modules absents de Maven Central pour la version 1.30. Non bloquant -- les notebooks gerent l'absence avec try/except.
-- Si un JAR fait 0 bytes ou ~554 bytes : re-telecharger manuellement depuis `https://repo1.maven.org/maven2/org/tweetyproject/`.
+- Si un JAR fait 0 bytes ou ~554 bytes : re-télécharger manuellement depuis `https://repo1.maven.org/maven2/org/tweetyproject/`.
 
 ### Planners
 
@@ -414,7 +414,7 @@ Le setup est entierement automatise via `Tweety-1-Setup.ipynb` :
 2. **Fast-Downward** (requis pour notebooks 2-6, 12) : Installer via WSL ou Docker
    - WSL : `sudo apt install fast-downward` ou compiler depuis source
    - Docker : Image `aiblazor/fast-downward` disponible
-3. **Notebooks theoriques** (7-11) : Ne necessitent que Python + les packages ci-dessus
+3. **Notebooks théoriques** (7-11) : Ne necessitent que Python + les packages ci-dessus
 
 ### SmartContracts
 
@@ -438,22 +438,22 @@ Le setup est entierement automatise via `Tweety-1-Setup.ipynb` :
    # Dans un terminal WSL
    anvil --host 0.0.0.0
    ```
-   Ou en arriere-plan : `wsl -d Ubuntu -- bash -c 'anvil --host 0.0.0.0 &'`
+   Ou en arrière-plan : `wsl -d Ubuntu -- bash -c 'anvil --host 0.0.0.0 &'`
 5. **Fichier `.env`** : Configurer dans `SmartContracts/.env` :
    - `ANVIL_RPC=http://127.0.0.1:8545` (local)
    - `LLM_API_KEY` pour SC-11 (via OpenRouter)
-   - `DEPLOYER_PRIVATE_KEY` : Mettre une cle de testnet reelle pour SC-24/25, ou laisser le placeholder (ces notebooks echoueront)
+   - `DEPLOYER_PRIVATE_KEY` : Mettre une cle de testnet réelle pour SC-24/25, ou laisser le placeholder (ces notebooks echoueront)
 
 **Problemes connus :**
 - **SC-3 a SC-10** : Echouent si anvil n'est pas lance sur le port 8545. Solution : lancer `anvil` avant l'execution.
-- **SC-15 Zero-Knowledge-Proofs** : SyntaxError f-string imbriquee (`{"CONVAINCU" if ...}`) -- incompatible Python 3.11. Fix : utiliser des parentheses ou une variable intermediaire.
+- **SC-15 Zero-Knowledge-Proofs** : SyntaxError f-string imbriquee (`{"CONVAINCU" if ...}`) -- incompatible Python 3.11. Fix : utiliser des parentheses ou une variable intermédiaire.
 - **SC-24/25** : `hexstr_to_bytes` erreur si `DEPLOYER_PRIVATE_KEY` contient un placeholder non-hex.
 
 ### Argument_Analysis
 
-**Status execution : 3/5 (demo, pas cours etudiant)**
+**Status execution : 3/5 (demo, pas cours étudiant)**
 
-1. **JDK 17 portable** : Partage avec Tweety (meme `jdk-17-portable/` si configure)
+1. **JDK 17 portable** : Partage avec Tweety (même `jdk-17-portable/` si configure)
 2. **Fichier `.env`** : Configurer dans `Argument_Analysis/.env` :
    - `OPENAI_API_KEY` (via OpenRouter : `sk-or-v1-...`)
    - `OPENAI_BASE_URL=https://openrouter.ai/api/v1`
@@ -462,7 +462,7 @@ Le setup est entierement automatise via `Tweety-1-Setup.ipynb` :
 3. **Packages** : `pip install semantic-kernel jpype1`
 
 **Problemes connus :**
-- **AA-3 orchestration** : Papermill ne preserve pas l'etat entre notebooks. Les definitions de AA-0/1/2 ne sont pas disponibles. Ce notebook doit etre execute manuellement apres les 3 precedents.
+- **AA-3 orchestration** : Papermill ne preserve pas l'etat entre notebooks. Les définitions de AA-0/1/2 ne sont pas disponibles. Ce notebook doit être execute manuellement après les 3 précédents.
 - **AA Executor** : Timeout a 300s (pipeline multi-agents long).
 
 ### Lean
@@ -523,7 +523,7 @@ Le setup est entierement automatise via `Tweety-1-Setup.ipynb` :
 | SymbolicLearning | 10 | 10 (100%) | 0 | Complet |
 | Argument Analysis | 6 | 0 (0%) | 6 (demo) | N/A |
 
-**Total** : 95/105 notebooks de contenu avec exercices (90%). Les notebooks sans exercices sont les notebooks de setup/configuration (SW-1, Planners-0, Lean-1), le notebook legacy (RDF.Net), et la serie demo Argument Analysis (6 notebooks).
+**Total** : 95/105 notebooks de contenu avec exercices (90%). Les notebooks sans exercices sont les notebooks de setup/configuration (SW-1, Planners-0, Lean-1), le notebook legacy (RDF.Net), et la série demo Argument Analysis (6 notebooks).
 
 ### Problemes restants
 
@@ -532,9 +532,9 @@ Le setup est entierement automatise via `Tweety-1-Setup.ipynb` :
 
 ---
 
-## Ponts cross-series
+## Ponts cross-séries
 
-Ces connexions entre series sont exploitees dans le curriculum IA Symbolique.
+Ces connexions entre séries sont exploitees dans le curriculum IA Symbolique.
 
 ### Lean <-> GameTheory (Choix social)
 
@@ -583,7 +583,7 @@ Ces connexions entre series sont exploitees dans le curriculum IA Symbolique.
 
 | Domaine | Reference | Couverture |
 |---------|-----------|------------|
-| IA Symbolique (general) | Russell & Norvig, *AIMA* 4e ed., ch. 7-12 | Recherche, logique, planification |
+| IA Symbolique (général) | Russell & Norvig, *AIMA* 4e ed., ch. 7-12 | Recherche, logique, planification |
 | Theorie des jeux / choix social | Osborne & Rubinstein, *A Course in Game Theory* (1994) | GameTheory, Lean social choice |
 | Logiques formelles | Enderton, *A Mathematical Introduction to Logic* (2001) | Tweety, Lean |
 | Argumentation | Dung, "On the Acceptability of Arguments" (1995) | Tweety-5, Argument Analysis |
@@ -619,37 +619,37 @@ Ces connexions entre series sont exploitees dans le curriculum IA Symbolique.
 
 ## FAQ
 
-### Qu'est-ce que l'IA symbolique et pourquoi l'etudier a l'ere des LLMs ?
+### Qu'est-ce que l'IA symbolique et pourquoi l'étudier a l'ere des LLMs ?
 
-L'IA symbolique repose sur la **manipulation explicite de symboles et de regles** (logique, ontologies, planification, contrats) plutot que sur l'apprentissage statistique. Les LLMs sont puissants mais opaques : ils ne garantissent pas la correction logique, ne peuvent pas verifier formellement un resultat, et hallucinent. L'IA symbolique apporte ce que les modeles statistiques ne fournissent pas : raisonnement **verifiable, explicable et certifie**. Les deux paradigmes sont complementaires — l'avenir est neuro-symbolique.
+L'IA symbolique repose sur la **manipulation explicite de symboles et de règles** (logique, ontologies, planification, contrats) plutot que sur l'apprentissage statistique. Les LLMs sont puissants mais opaques : ils ne garantissent pas la correction logique, ne peuvent pas verifier formellement un résultat, et hallucinent. L'IA symbolique apporte ce que les modeles statistiques ne fournissent pas : raisonnement **verifiable, explicable et certifie**. Les deux paradigmes sont complementaires — l'avenir est neuro-symbolique.
 
 ### Quelle est la difference entre Tweety et Z3 ?
 
-**TweetyProject** est une bibliotheque Java pour la logique formelle (propositionnelle, FOL, modale, argumentation, revision de croyances). Elle est utilisee via JPype en Python. **Z3** (Microsoft Research) est un solveur SMT (Satisfiability Modulo Theories) qui automatise la resolution de problemes logiques complexes. Tweety est oriente enseignement (comprendre les semantiques), Z3 est oriente resolution (prouver/infirmer des proprietes). Les deux apparaissent dans GameTheory (Arrow/SAT) et Search (CSP).
+**TweetyProject** est une bibliotheque Java pour la logique formelle (propositionnelle, FOL, modale, argumentation, revision de croyances). Elle est utilisee via JPype en Python. **Z3** (Microsoft Research) est un solveur SMT (Satisfiability Modulo Theories) qui automatisé la resolution de problemes logiques complexes. Tweety est oriente enseignement (comprendre les semantiques), Z3 est oriente resolution (prouver/infirmer des proprietes). Les deux apparaissent dans GameTheory (Arrow/SAT) et Search (CSP).
 
 ### Comment installer l'environnement Tweety ?
 
-Ouvrez le notebook `Tweety-1-Setup.ipynb` : il telecharge automatiquement JDK 17 et les 35 JARs TweetyProject. Vous pouvez aussi lancer `python scripts/download_tweety_tools.py --all` en ligne de commande. Les dependances Python sont `jpype1 requests tqdm clingo z3-solver python-sat`.
+Ouvrez le notebook `Tweety-1-Setup.ipynb` : il télécharge automatiquement JDK 17 et les 35 JARs TweetyProject. Vous pouvez aussi lancer `python scripts/download_tweety_tools.py --all` en ligne de commande. Les dependances Python sont `jpype1 requests tqdm clingo z3-solver python-sat`.
 
-### Par quelle sous-serie commencer si je n'ai pas de JDK installe ?
+### Par quelle sous-série commencer si je n'ai pas de JDK installe ?
 
-Les series **SemanticWeb** (notebooks Python), **Planners** (notebooks theoriques 7-11) et **Lean** (notebooks Python 1, 7-10) ne necessitent aucun JDK. **Tweety** et **Argument Analysis** utilisent JPype (bridge Java/Python) avec un JDK 17 portable auto-telecharge par le notebook de setup (pas d'installation systeme, pas de UAC). Si vous evitez les notebooks C# (qui requierent dotnet-interactive), vous pouvez travailler entierement en Python avec uniquement `pip install rdflib ortools unified_planning`.
+Les séries **SemanticWeb** (notebooks Python), **Planners** (notebooks théoriques 7-11) et **Lean** (notebooks Python 1, 7-10) ne necessitent aucun JDK. **Tweety** et **Argument Analysis** utilisent JPype (bridge Java/Python) avec un JDK 17 portable auto-télécharge par le notebook de setup (pas d'installation système, pas de UAC). Si vous evitez les notebooks C# (qui requierent dotnet-interactive), vous pouvez travailler entierement en Python avec uniquement `pip install rdflib ortools unified_planning`.
 
-### Pourquoi Tweety utilise-t-il JPype plutot que des implementations Python natives ?
+### Pourquoi Tweety utilise-t-il JPype plutot que des implémentations Python natives ?
 
-TweetyProject est la bibliotheque de reference pour l'IA symbolique formelle (argumentation de Dung, ASPIC+, revision de croyances, logiques modales). Elle couvre des domaines ou il n'existe pas d'equivalent Python mature : solveurs d'argumentation structures, frameworks d'agent dialogues, logiques epistemiques. JPype permet d'appeler directement les JARs Java depuis Python sans reimplementation. Les notebooks gerent la bridge de maniere transparente via `tweety_init.py`.
+TweetyProject est la bibliotheque de référence pour l'IA symbolique formelle (argumentation de Dung, ASPIC+, revision de croyances, logiques modales). Elle couvre des domaines ou il n'existe pas d'equivalent Python mature : solveurs d'argumentation structures, frameworks d'agent dialogues, logiques epistemiques. JPype permet d'appeler directement les JARs Java depuis Python sans reimplementation. Les notebooks gerent la bridge de maniere transparente via `tweety_init.py`.
 
 ### Quelle est la difference entre les notebooks C# et Python de SemanticWeb ?
 
-Les **notebooks Python** (SW-8 a SW-13) utilisent `rdflib`, `pySHACL`, `owlready2` et `kglab` — 10/10 s'executent sans probleme. Les **notebooks C#** (SW-1 a SW-7) utilisent `dotNetRDF` via .NET Interactive et peuvent echouer sous Windows si la policy d'execution bloque `dotnet-interactive.exe` (Win32Exception 4551). Les memes concepts (RDF, SPARQL, OWL, SHACL) sont couverts dans les deux stacks. Si vous n'avez pas besoin specifiquement de .NET, les notebooks Python suffisent pour le parcours complet.
+Les **notebooks Python** (SW-8 a SW-13) utilisent `rdflib`, `pySHACL`, `owlready2` et `kglab` — 10/10 s'executent sans probleme. Les **notebooks C#** (SW-1 a SW-7) utilisent `dotNetRDF` via .NET Interactive et peuvent echouer sous Windows si la policy d'execution bloque `dotnet-interactive.exe` (Win32Exception 4551). Les mêmes concepts (RDF, SPARQL, OWL, SHACL) sont couverts dans les deux stacks. Si vous n'avez pas besoin specifiquement de .NET, les notebooks Python suffisent pour le parcours complet.
 
-### Comment executer les notebooks Lean sans GPU ni installation systeme ?
+### Comment executer les notebooks Lean sans GPU ni installation système ?
 
-Les notebooks Lean utilisent **WSL (Windows Subsystem for Linux)** comme runtime — pas de GPU necessaire. Le notebook `Lean-1-Setup.ipynb` installe automatiquement `elan` (gestionnaire de toolchains Lean) et `lean4_jupyter` dans WSL. Les notebooks de preuves (2-6, 11) tournent sur le kernel `Lean 4 (WSL)` natif. Les notebooks LLM/prover (7-10) tournent sur `Python 3 (WSL)` et necessitent une cle API OpenRouter. Si WSL n'est pas disponible, les notebooks Python du meme domaine (1, 7-10) peuvent etre executes en Python natif.
+Les notebooks Lean utilisent **WSL (Windows Subsystem for Linux)** comme runtime — pas de GPU necessaire. Le notebook `Lean-1-Setup.ipynb` installe automatiquement `elan` (gestionnaire de toolchains Lean) et `lean4_jupyter` dans WSL. Les notebooks de preuves (2-6, 11) tournent sur le kernel `Lean 4 (WSL)` natif. Les notebooks LLM/prover (7-10) tournent sur `Python 3 (WSL)` et necessitent une cle API OpenRouter. Si WSL n'est pas disponible, les notebooks Python du même domaine (1, 7-10) peuvent être executes en Python natif.
 
-### Peut-on etudier les SmartContracts sans blockchain reelle ?
+### Peut-on étudier les SmartContracts sans blockchain réelle ?
 
-Oui, c'est l'approche pedagogique de la serie. **Anvil** (Foundry) fournit un simulateur Ethereum local qui tourne en une commande (`anvil --host 0.0.0.0`) sous WSL. Les notebooks SC-3 a SC-10 deploient et testent des contrats sur cette chaine locale — aucun ether reel, aucun testnet. Les notebooks theoriques (SC-0 a SC-2, SC-15 a SC-26) explorent les concepts (ZK proofs, DeFi, DAO, cross-chain) principalement via code Python/Solidity sans deploiement. Seuls SC-24 et SC-25 (deploiement reel) necessitent une cle testnet.
+Oui, c'est l'approche pédagogique de la série. **Anvil** (Foundry) fournit un simulateur Ethereum local qui tourne en une commande (`anvil --host 0.0.0.0`) sous WSL. Les notebooks SC-3 a SC-10 deploient et testent des contrats sur cette chaine locale — aucun ether réel, aucun testnet. Les notebooks théoriques (SC-0 a SC-2, SC-15 a SC-26) explorent les concepts (ZK proofs, DeFi, DAO, cross-chain) principalement via code Python/Solidity sans déploiement. Seuls SC-24 et SC-25 (déploiement réel) necessitent une cle testnet.
 
 ---
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -7,24 +7,24 @@ breakdown: SmartContracts=27
 maturity: PRODUCTION=27
 -->
 
-Serie de notebooks educatifs couvrant les fondements cryptographiques, le developpement Solidity, les tests, la cryptographie avancee (ZKP, HE, vote verifiable), et les blockchains alternatives.
+Serie de notebooks educatifs couvrant les fondements cryptographiques, le développement Solidity, les tests, la cryptographie avancée (ZKP, HE, vote verifiable), et les blockchains alternatives.
 
-Un smart contract est un programme qui s'execute tout seul sur une blockchain : une fois deploye, son code fait foi, transfere de la valeur et applique des regles sans intermediaire ni possibilite de revenir en arriere. C'est ce qui fait sa puissance — des ecosystemes entiers (DeFi, NFT, DAO) reposent dessus — et son danger : un bug n'est pas un patch a pousser le lendemain, c'est une faille immuable qui peut couter des millions (le hack de The DAO en 2016, les exploits de ponts cross-chain). D'ou le poids accorde dans cette serie aux **tests, au fuzzing et a la verification formelle** autant qu'au developpement.
+Un smart contract est un programme qui s'execute tout seul sur une blockchain : une fois déployé, son code fait foi, transfere de la valeur et applique des règles sans intermédiaire ni possibilite de revenir en arrière. C'est ce qui fait sa puissance — des ecosystemes entiers (DeFi, NFT, DAO) reposent dessus — et son danger : un bug n'est pas un patch a pousser le lendemain, c'est une faille immuable qui peut couter des millions (le hack de The DAO en 2016, les exploits de ponts cross-chain). D'ou le poids accorde dans cette série aux **tests, au fuzzing et a la verification formelle** autant qu'au développement.
 
-Le parcours suit le fil annonce par le titre : on part des **primitives cryptographiques** des cypherpunks (hachage, arbres de Merkle, preuve de travail, signatures) pour comprendre *pourquoi* une blockchain tient, puis on construit en **Solidity** (types, heritage, standards ERC, DeFi, gouvernance), on **securise** (Foundry, invariants, verification formelle), on explore la **cryptographie pour la vie privee** (ZKP, chiffrement homomorphique, vote verifiable de bout en bout), avant d'elargir aux **chaines alternatives** (Vyper, XRP, Bitcoin Script, Move/Sui, Solana) et au **deploiement reel** sur testnet puis mainnet. L'objectif final n'est pas seulement de savoir ecrire un contrat, mais de savoir le rendre digne de confiance.
+Le parcours suit le fil annonce par le titre : on part des **primitives cryptographiques** des cypherpunks (hachage, arbres de Merkle, preuve de travail, signatures) pour comprendre *pourquoi* une blockchain tient, puis on construit en **Solidity** (types, heritage, standards ERC, DeFi, gouvernance), on **sécurise** (Foundry, invariants, verification formelle), on explore la **cryptographie pour la vie privee** (ZKP, chiffrement homomorphique, vote verifiable de bout en bout), avant d'élargir aux **chaines alternatives** (Vyper, XRP, Bitcoin Script, Move/Sui, Solana) et au **déploiement réel** sur testnet puis mainnet. L'objectif final n'est pas seulement de savoir ecrire un contrat, mais de savoir le rendre digne de confiance.
 
 ---
 
 **27 notebooks** | **Kernel Python 3** | **~22 heures**
 
-**A qui s'adresse cette serie** : developpeurs Solidity, ingenieurs DeFi, specialistes security/blockchain, etudiants en IA symbolique interesses par la verification formelle. Un niveau intermediaire en programmation est recommande — les bases de Python sont suffisantes, mais les concepts blockchain/cryptographie sont introduits progressivement.
+**A qui s'adresse cette série** : développeurs Solidity, ingenieurs DeFi, specialistes security/blockchain, étudiants en IA symbolique interesses par la verification formelle. Un niveau intermédiaire en programmation est recommande — les bases de Python sont suffisantes, mais les concepts blockchain/cryptographie sont introduits progressivement.
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, vous serez capable de :
+A l'issue de cette série, vous serez capable de :
 
 1. **Construire** des smart contracts Solidity fonctionnels (types, fonctions, heritage, standards ERC)
-2. **Deployer** et interagir avec des contrats sur des blockchains reelles (Anvil, Sepolia, XRP testnet)
+2. **Deployer** et interagir avec des contrats sur des blockchains réelles (Anvil, Sepolia, XRP testnet)
 3. **Tester** rigoureusement (unit tests, fuzzing, invariants) avec Foundry
 4. **Vérifier** formellement la correction de contrats (SMT solvers, Certora)
 5. **Implementer** des primitives cryptographiques from scratch (ZKP, chiffrement homomorphique, signatures)
@@ -47,23 +47,23 @@ A l'issue de cette serie, vous serez capable de :
 
 ### Phase 1 : Fondations (~2h10)
 
-Les notebooks 0-2 posent les bases historiques et techniques. Le notebook 0 explore les primitives cryptographiques qui fondent la blockchain (hash, arbres de Merkle, preuve de travail, signatures, DHT). Le notebook 1 installe Foundry — forge, cast, anvil — l'outil de developpement principal. Le notebook 2 configure web3.py + py-solcx pour compiler et deployer des contrats Solidity reellement sur Anvil (blockchain locale). A l'issue de cette phase, vous avez un environnement fonctionnel et deployez votre premier contrat.
+Les notebooks 0-2 posent les bases historiques et techniques. Le notebook 0 explore les primitives cryptographiques qui fondent la blockchain (hash, arbres de Merkle, preuve de travail, signatures, DHT). Le notebook 1 installe Foundry — forge, cast, anvil — l'outil de développement principal. Le notebook 2 configure web3.py + py-solcx pour compiler et déployer des contrats Solidity réellement sur Anvil (blockchain locale). A l'issue de cette phase, vous avez un environnement fonctionnel et deployez votre premier contrat.
 
 ### Phase 2 : Solidity Fondements (~2h30)
 
-Les notebooks 3-6 couvrent les bases de Solidity : types et variables (SC-3), fonctions et état (SC-4), heritage et interfaces (SC-5), erreurs et events (SC-6). Chaque notebook inclut un deploiement reel sur Anvil. Cette phase vise la maitrise du langage de base — pas de code Solidity ne peut etre ecrit sans ces fondamentaux.
+Les notebooks 3-6 couvrent les bases de Solidity : types et variables (SC-3), fonctions et état (SC-4), heritage et interfaces (SC-5), erreurs et events (SC-6). Chaque notebook inclut un déploiement réel sur Anvil. Cette phase vise la maitrise du langage de base — pas de code Solidity ne peut être ecrit sans ces fondamentaux.
 
 ### Phase 3 : Solidity Avance (~4h30)
 
-Les notebooks 7-11 abordent les standards token (ERC-20, ERC-721, ERC-1155), les primitives DeFi (AMM, lending, oracles), la gouvernance DAO, l'account abstraction (ERC-4337), et l'assistance LLM pour les smart contracts. C'est le coeur technique de la serie — chaque concept est illustré par un contrat deployable.
+Les notebooks 7-11 abordent les standards token (ERC-20, ERC-721, ERC-1155), les primitives DeFi (AMM, lending, oracles), la gouvernance DAO, l'account abstraction (ERC-4337), et l'assistance LLM pour les smart contracts. C'est le coeur technique de la série — chaque concept est illustré par un contrat deployable.
 
 ### Phase 4 : Testing et Securite (~2h15)
 
-Les notebooks 12-14 traitent de la securite : tests unitaires Foundry (SC-12), fuzz testing et invariants (SC-13), verification formelle (SC-14). Cette phase est cruciale — un smart contract non teste est un contrat non deploable en production. La verification formelle (SMT solvers, Certora) represente le pont vers la preuve mathématique de correction.
+Les notebooks 12-14 traitent de la sécurité : tests unitaires Foundry (SC-12), fuzz testing et invariants (SC-13), verification formelle (SC-14). Cette phase est cruciale — un smart contract non teste est un contrat non deploable en production. La verification formelle (SMT solvers, Certora) represente le pont vers la preuve mathématique de correction.
 
 ### Phase 5 : Cryptographie et Vie Privee (~3h)
 
-Les notebooks 15-17 construisent des primitives cryptographiques from scratch : preuves a connaissance nulle (Schnorr, Fiat-Shamir, sigma protocols), chiffrement homomorphique (Paillier, CKKS/TenSEAL), et un systeme de vote verifiable de bout en bout (ElectionGuard). Cette partie est la plus theorique mais la plus puissante — elle montre comment proteger la vie privee sur des blockchains transparentes.
+Les notebooks 15-17 construisent des primitives cryptographiques from scratch : preuves a connaissance nulle (Schnorr, Fiat-Shamir, sigma protocols), chiffrement homomorphique (Paillier, CKKS/TenSEAL), et un système de vote verifiable de bout en bout (ElectionGuard). Cette partie est la plus théorique mais la plus puissante — elle montre comment proteger la vie privee sur des blockchains transparentes.
 
 ### Phase 6 : Blockchains Alternatives (~4h)
 
@@ -71,13 +71,13 @@ Les notebooks 18-22 explorent cinq blockchains non-EVM : Vyper (smart contracts 
 
 ### Phase 7 : Deploiement Reel (~3h45)
 
-Les notebooks 23-26 couvrent l'interoperabilite cross-chain, le deploiement sur testnet (Sepolia + XRP testnet), le deploiement mainnet (L2 Base/Polygon), et le projet capstone integre. C'est la phase de transition vers le monde reel — tout le travail precedent sert a construire, tester et deployer un projet complet.
+Les notebooks 23-26 couvrent l'interoperabilite cross-chain, le déploiement sur testnet (Sepolia + XRP testnet), le déploiement mainnet (L2 Base/Polygon), et le projet capstone intègre. C'est la phase de transition vers le monde réel — tout le travail précédent sert a construire, tester et déployer un projet complet.
 
 ## Parcours alternatives
 
 ### Parcours Solidity intensif (~8h)
 
-Se concentrer sur les phases 1-3 + phase 4 (testing) : SC-0, SC-1-2, SC-3 a SC-6, SC-7 a SC-11, SC-12-14. Idéal pour developpeurs souhaitant maitriser rapidement le developpement Ethereum.
+Se concentrer sur les phases 1-3 + phase 4 (testing) : SC-0, SC-1-2, SC-3 a SC-6, SC-7 a SC-11, SC-12-14. Idéal pour développeurs souhaitant maitriser rapidement le développement Ethereum.
 
 ### Parcours Cryptographie (~3h)
 
@@ -89,18 +89,18 @@ Les notebooks 18-22 : Vyper, XRP, Bitcoin, Move, Solana. Chaque notebook est aut
 
 ### Parcours Security-first (~7h)
 
-Fondations (SC-0-2) + Solidity basique (SC-3-6) + Testing avancé (SC-12-14) + Verification formelle (SC-14). Pour developpeurs souhaitant se specialiser en smart contract auditing.
+Fondations (SC-0-2) + Solidity basique (SC-3-6) + Testing avancé (SC-12-14) + Verification formelle (SC-14). Pour développeurs souhaitant se specialiser en smart contract auditing.
 
 ## Quel parcours choisir ?
 
 | Objectif | Parcours recommande | Duree |
 |----------|-------------------|-------|
 | Decouvrir la blockchain | SC-0 → SC-1 → SC-2 → SC-3 | 3h |
-| Devenir developpeur Solidity | Parcours Solidity intensif | 8h |
+| Devenir développeur Solidity | Parcours Solidity intensif | 8h |
 | Specialiser en security | Parcours Security-first | 7h |
-| Cryptographie avancee | Parcours Cryptographie | 3h |
+| Cryptographie avancée | Parcours Cryptographie | 3h |
 | Explorer les chains non-EVM | Parcours alternatives | 4h |
-| De deployer en production | Parcours complet + SC-23-26 | 22h |
+| De déployer en production | Parcours complet + SC-23-26 | 22h |
 | Comprendre DeFi | SC-7-8-9 | 2h30 |
 | Gouvernance DAO | SC-9-10-17 | 2h |
 
@@ -149,11 +149,11 @@ SmartContracts/
 
 | Partie | Objectif principal | Livrable attendu |
 |--------|-------------------|------------------|
-| 0 | Installer l'environnement + comprendre les bases | Anvil en marche + 1er contrat deploye |
+| 0 | Installer l'environnement + comprendre les bases | Anvil en marche + 1er contrat déployé |
 | 1 | Maitriser le langage Solidity | Contrats types, fonctions, heritage fonctionnels |
 | 2 | Construire des protocoles DeFi complets | Token ERC-20 + AMM + DAO deployes |
 | 3 | Tester et verifier un contrat | Suite de tests, fuzzing, verification formelle |
-| 4 | Cacher des donnees sur blockchain publique | ZKP + chiffrement homomorphique fonctionnels |
+| 4 | Cacher des données sur blockchain publique | ZKP + chiffrement homomorphique fonctionnels |
 | 5 | Comprendre les architectures alternatives | Contracts deployes sur Vyper/XRP/Bitcoin/Move/Solana |
 | 6 | Deployer en production | Contrat sur testnet/mainnet + projet capstone |
 
@@ -165,9 +165,9 @@ SmartContracts/
 |---|----------|-------|---------|
 | 0 | [SC-0-Cypherpunk-Origins](00-Foundations/SC-0-Cypherpunk-Origins.ipynb) | 60 min | Hash, Merkle, PoW, signatures, DHT - code executable |
 | 1 | [SC-1-Setup-Foundry](00-Foundations/SC-1-Setup-Foundry.ipynb) | 30 min | Installation Foundry (forge, cast, anvil) |
-| 2 | [SC-2-Setup-Web3py](00-Foundations/SC-2-Setup-Web3py.ipynb) | 40 min | web3.py + py-solcx + compile/deploy reel |
+| 2 | [SC-2-Setup-Web3py](00-Foundations/SC-2-Setup-Web3py.ipynb) | 40 min | web3.py + py-solcx + compile/deploy réel |
 
-**Objectifs** : Comprendre les origines Cypherpunk, installer l'environnement, deployer un premier contrat
+**Objectifs** : Comprendre les origines Cypherpunk, installer l'environnement, déployer un premier contrat
 
 ### Partie 1 : Solidity Fondements (~2h30)
 
@@ -178,7 +178,7 @@ SmartContracts/
 | 5 | [SC-5-Inheritance](01-Solidity-Foundation/SC-5-Inheritance.ipynb) | 35 min | Heritage, interfaces |
 | 6 | [SC-6-Errors-Events](01-Solidity-Foundation/SC-6-Errors-Events.ipynb) | 30 min | Erreurs, events |
 
-**Objectifs** : Maitriser les bases de Solidity avec deploiement reel sur anvil
+**Objectifs** : Maitriser les bases de Solidity avec déploiement réel sur anvil
 
 ### Partie 2 : Solidity Avance (~4h30)
 
@@ -233,7 +233,7 @@ SmartContracts/
 | 25 | [SC-25-Mainnet-Deploy](06-Real-World/SC-25-Mainnet-Deploy.ipynb) | 40 min | Deploy L2 (Base/Polygon) |
 | 26 | [SC-26-Final-Project](06-Real-World/SC-26-Final-Project.ipynb) | 90 min | Projet capstone complet |
 
-**Objectifs** : Deploiement reel, testnets, mainnet, projet integre
+**Objectifs** : Deploiement réel, testnets, mainnet, projet intègre
 
 ## Technologies
 
@@ -255,15 +255,15 @@ SmartContracts/
 | **Smart Contract** | Programme autonome sur blockchain, code = loi | Partout (SC-3+) |
 | **EVM** | Machine virtuelle Ethereum : stack-based, bytecode | SC-1, SC-3, SC-23-26 |
 | **Gas** | Mecanisme de tarification du calcul | SC-3, SC-4 |
-| **Storage / Memory / Calldata** | Three tiers de donnees Solidity | SC-3, SC-4 |
+| **Storage / Memory / Calldata** | Three tiers de données Solidity | SC-3, SC-4 |
 | **Inheritance & Interfaces** | Heritage multiple, abstract contracts | SC-5 |
 | **ERC Standards** | ERC-20 (fungible), ERC-721 (NFT), ERC-1155 (multi), ERC-4337 (AA) | SC-7, SC-10 |
 | **AMM** | Automated Market Maker — uniswap V2/V3 model | SC-8 |
-| **Oracle** | Pont de donnees externes vers on-chain | SC-8 |
+| **Oracle** | Pont de données externes vers on-chain | SC-8 |
 | **Fuzz Testing** | Testing avec generateur d'inputs aleatoires | SC-13 |
 | **Formal Verification** | Preuve mathématique de correction (SMT, Certora) | SC-14 |
 | **Zero-Knowledge Proof** | Prouver sans reveler (Schnorr, Fiat-Shamir) | SC-15 |
-| **Homomorphic Encryption** | Calculer sur donnees chiffrées (Paillier, CKKS) | SC-16 |
+| **Homomorphic Encryption** | Calculer sur données chiffrées (Paillier, CKKS) | SC-16 |
 | **Vote E2E Verifiable** | Secret + verifiable + comptable automatiquement | SC-17 |
 | **UTXO Model** | Modele transactionel de Bitcoin (non account-based) | SC-20 |
 | **Move Language** | Language de smart contracts a objets (Sui) | SC-21 |
@@ -274,7 +274,7 @@ SmartContracts/
 
 | Outil | Type | Usage principal | Installation |
 |-------|------|----------------|--------------|
-| **Foundry (forge)** | Framework dev | Compilation, tests, deploiement Solidity | `curl -L https://foundry.paradigm.xyz | bash` |
+| **Foundry (forge)** | Framework dev | Compilation, tests, déploiement Solidity | `curl -L https://foundry.paradigm.xyz | bash` |
 | **anvil** | Node Ethereum local | Blockchain locale pour dev | Inclus dans Foundry |
 | **cast** | CLI Ethereum | Lect/écriture sur chaines | Inclus dans Foundry |
 | **web3.py** | Bibliotheque Python | Interaction avec EVM | `pip install web3` |
@@ -290,18 +290,18 @@ SmartContracts/
 
 ### Niveau en programmation attendu
 
-Cette serie suppose un **niveau intermediaire en programmation** :
+Cette série suppose un **niveau intermédiaire en programmation** :
 
-| Competence | Utilite dans la serie | Niveau requis |
+| Competence | Utilite dans la série | Niveau requis |
 |------------|---------------------|---------------|
 | **Python de base** (fonctions, classes, modules) | Tous les notebooks (kernel Jupyter) | Intermédiaire |
 | **Lignes de commande** (bash, git) | Setup (SC-1), testing (SC-12-14) | Intermédiaire |
 | **Concepts d'API / HTTP** | Interaction web3.py (SC-2, SC-24) | Elementaire |
-| **Structures de donnees** (tables de hachage, listes) | Algorithmes crypto (SC-0, SC-15) | Intermédiaire |
+| **Structures de données** (tables de hachage, listes) | Algorithmes crypto (SC-0, SC-15) | Intermédiaire |
 | **Notions de base en probabilites** | ZKP (SC-15), HE (SC-16) | Elementaire |
 | **Notions de base en algèbre** | Cryptographie (SC-0, SC-15-16) | Elementaire |
 
-**Pas necessaire en pre-requis** : Solidity (enseigne dans la serie), cryptography avancee (introduite in-context), connaissance des blockchains (introduite SC-0).
+**Pas necessaire en pre-requis** : Solidity (enseigne dans la série), cryptography avancée (introduite in-context), connaissance des blockchains (introduite SC-0).
 
 ### Setup technique
 
@@ -379,32 +379,32 @@ python setup_env.py --check
 - [ElectionGuard](https://www.electionguard.vote/)
 - [XRP Ledger Docs](https://xrpl.org/docs.html)
 
-## Cross-series Bridges
+## Cross-séries Bridges
 
 | Serie | Lien | Connection |
 | ------- | ------ | ----------- |
-| [Lean](../Lean/README.md) | Formal verification | Les SMT solvers (SC-14) et les preuves Lean 4 sont deux facettes de la meme verite -- la correction mathématique |
+| [Lean](../Lean/README.md) | Formal verification | Les SMT solvers (SC-14) et les preuves Lean 4 sont deux facettes de la même vérité -- la correction mathématique |
 | [GameTheory](../../GameTheory/README.md) | Voting & DAO | SC-9 (DAO) et SC-17 (vote E2E) sont des instances de theorie du choix social (Arrow, Sen) |
 | [Probas](../../Probas/README.md) | Decision & Risk | Minimax Regret (PyMC-19) s'applique aux smart contracts pour la gestion des incertitudes on-chain |
 | [SymbolicAI/SemanticWeb](../SemanticWeb/README.md) | Ontologies & Verification | Les ontologies peuvent formaliser les proprietes de contrats pour verification formelle |
 | [SymbolicAI/Tweety](../Tweety/README.md) | Non-monotonic reasoning | Le raisonnement non-monotone s'applique a la governance DAO (propositions retractables) |
-| [GenAI/Texte](../../GenAI/Texte/README.md) | LLM-assisted | SC-11 applique le meme paradigme d'assistance LLM que la serie GenAI Texte |
+| [GenAI/Texte](../../GenAI/Texte/README.md) | LLM-assisted | SC-11 applique le même paradigme d'assistance LLM que la série GenAI Texte |
 
-## Connections cross-series
+## Connections cross-séries
 
 ### SmartContracts et Lean (Verification Formelle)
 
-Les techniques de verification formelle presentees dans cette serie (SC-14, fuzzing SC-13) complementent les methodes de preuve formelle de la serie Lean :
+Les techniques de verification formelle presentees dans cette série (SC-14, fuzzing SC-13) complementent les méthodes de preuve formelle de la série Lean :
 
-- **SC-14 Formal Verification** (Certora, SMTChecker) vs. **Lean 4** : deux approches de la meme idee -- prouver mathematiquement la correction d'un programme. Les SMT solvers (Z3, CVC5) sont automatiques mais bornes ; Lean est interactif mais expressif ( Curry-Howard, types dependants).
-- **SC-11 LLM-Assisted Contracts** : le meme paradigme d'assistance LLM que les notebooks [Lean-7/8/9](../Lean/), applique a la generation de smart contracts.
+- **SC-14 Formal Verification** (Certora, SMTChecker) vs. **Lean 4** : deux approches de la même idee -- prouver mathematiquement la correction d'un programme. Les SMT solvers (Z3, CVC5) sont automatiques mais bornes ; Lean est interactif mais expressif ( Curry-Howard, types dependants).
+- **SC-11 LLM-Assisted Contracts** : le même paradigme d'assistance LLM que les notebooks [Lean-7/8/9](../Lean/), applique a la génération de smart contracts.
 
 ### SmartContracts et Theorie des Jeux (GameTheory)
 
-Les mecanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instances concretes des resultats formels de la serie GameTheory :
+Les mecanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instances concretes des résultats formels de la série GameTheory :
 
-- **SC-9 DAO Governance** : les systemes de vote on-chain sont soumis aux memes limitations que le **theoreme d'Arrow** (formalise dans `social_choice_lean/Arrow.lean`, 0 sorry).
-- **SC-17 E2E Verifiable Voting** : les proprietes des systemes de vote (Banks sets, monotonicite STV) sont etudiees formellement dans `social_choice_lean/Voting.lean`. Le chiffrement homomorphique (SC-16) et les ZKP (SC-15) sont les briques cryptographiques qui rendent le vote E2E possible.
+- **SC-9 DAO Governance** : les systèmes de vote on-chain sont soumis aux mêmes limitations que le **theoreme d'Arrow** (formalise dans `social_choice_lean/Arrow.lean`, 0 sorry).
+- **SC-17 E2E Verifiable Voting** : les proprietes des systèmes de vote (Banks sets, monotonicite STV) sont étudiées formellement dans `social_choice_lean/Voting.lean`. Le chiffrement homomorphique (SC-16) et les ZKP (SC-15) sont les briques cryptographiques qui rendent le vote E2E possible.
 
 ### Lecture transversale
 
@@ -412,7 +412,7 @@ Les mecanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instanc
 
 ## FAQ / Troubleshooting
 
-### 1. Foundry non detecte ou `forge: command not found`
+### 1. Foundry non détecte ou `forge: command not found`
 
 **Symptome** : Les notebooks SC-1/SC-12 echouent avec `forge not found` ou `anvil not found`.
 
@@ -443,7 +443,7 @@ which forge && which anvil
 
 **Symptome** : `solcx` retourne une erreur de compilation ou "solc binary not found".
 
-**Cause** : `py-solcx` telecharge le compilateur `solc` a la premiere utilisation. Si le telechargement echoue (proxy, pare-feu), la compilation echoue.
+**Cause** : `py-solcx` télécharge le compilateur `solc` a la première utilisation. Si le téléchargement echoue (proxy, pare-feu), la compilation echoue.
 
 **Solution** :
 
@@ -457,9 +457,9 @@ print(solcx.get_installed_solc_versions())
 solcx.set_solc_version("0.8.20")
 ```
 
-Si le telechargement est bloque, telecharger manuellement le binaire depuis [github.com/ethereum/solidity/releases](https://github.com/ethereum/solidity/releases) et le placer dans le repertoire indique par `solcx.get_solcx_install_folder()`.
+Si le téléchargement est bloque, télécharger manuellement le binaire depuis [github.com/ethereum/solidity/releases](https://github.com/ethereum/solidity/releases) et le placer dans le repertoire indique par `solcx.get_solcx_install_folder()`.
 
-### 3. Anvil ne demarre pas ou port 8545 deja pris
+### 3. Anvil ne demarre pas ou port 8545 déjà pris
 
 **Symptome** : `ConnectionRefusedError` lors des deploiements dans les notebooks SC-2/SC-3+.
 
@@ -488,18 +488,18 @@ anvil --port 8546
 
 ### 4. Erreurs `web3.py` : "insufficient funds" ou "nonce too low"
 
-**Symptome** : Les transactions echouent lors du deploiement dans les notebooks.
+**Symptome** : Les transactions echouent lors du déploiement dans les notebooks.
 
 **Causes et solutions** :
 
 | Erreur | Cause | Solution |
 | ------ | ----- | -------- |
 | `insufficient funds` | Compte Anvil non finance | Redemarrer Anvil (les comptes sont reinitialises) ou utiliser `anvil --accounts 10 --balance 10000` |
-| `nonce too low` | Transaction envoyee avec un nonce deja utilise | Appeler `w3.eth.get_transaction_count(address)` pour obtenir le nonce courant |
+| `nonce too low` | Transaction envoyee avec un nonce déjà utilise | Appeler `w3.eth.get_transaction_count(address)` pour obtenir le nonce courant |
 | `replacement fee too low` | Remplacement de transaction avec gas insuffisant | Augmenter `gasPrice` de 10% minimum |
 | `execution reverted` | Erreur dans le contrat Solidity | Verifier les `require()` et les conditions dans le code Solidity |
 
-**Astuce** : Les comptes Anvil par defaut ont 10000 ETH chacun. Si les fonds semblent manquants, redemarrer Anvil pour reinitialiser l'etat.
+**Astuce** : Les comptes Anvil par défaut ont 10000 ETH chacun. Si les fonds semblent manquants, redemarrer Anvil pour reinitialiser l'etat.
 
 ### 5. Erreurs d'import des bibliotheques cryptographiques
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -7,36 +7,36 @@ breakdown: SymbolicLearning=10
 maturity: PRODUCTION=10
 -->
 
-Comment un agent peut-il apprendre a partir de connaissances existantes plutot que de donnees brutes ? Cette serie explore l'apprentissage symbolique tel que decrit dans le chapitre 19 d'AIMA (Russell & Norvig), depuis l'apprentissage inductif pur (CBH, Version Space) jusqu'aux methodes guidees par la connaissance (EBL, RBL).
+Comment un agent peut-il apprendre a partir de connaissances existantes plutot que de données brutes ? Cette série explore l'apprentissage symbolique tel que décrit dans le chapitre 19 d'AIMA (Russell & Norvig), depuis l'apprentissage inductif pur (CBH, Version Space) jusqu'aux méthodes guidees par la connaissance (EBL, RBL).
 
-Le premier notebook pose les bases : representation d'hypotheses comme conjonctions de contraintes, algorithmes Current-Best-Hypothesis et Candidate Elimination (Version Space), et leurs limites face au bruit et aux concepts disjonctifs. Le second notebook montre comment la connaissance du domaine accelere l'apprentissage : l'apprentissage base sur les explications (EBL) compile les theories en heuristiques operationnelles, et l'apprentissage base sur la pertinence (RBL) identifie les attributs determinant via les determinations. Le troisieme notebook approfondit le RBL avec le treillis des determinations, l'algorithme MINIMAL-CONSISTENT-DET et une comparaison avec sklearn. Le quatrieme notebook couvre la programmation logique inductive (ILP) : l'algorithme FOIL (top-down), la resolution inverse (bottom-up) et la connexion avec les knowledge graphs. Les notebooks SL-5 a SL-7 ouvrent vers des methodes contemporaines : SL-5 introduit le neuro-symbolique (T-norms differentiables, Logic Tensor Networks, DeepProbLog) ; SL-6 outille la decouverte de regles sur knowledge graphs reels avec rdflib et AMIE rule mining ; SL-7 boucle LLM et verification symbolique pour fiabiliser le raisonnement formel guide par modeles de langage. Trois notebooks etendent la serie : SL-8 change de paradigme avec l'apprentissage *actif* (l'algorithme L* d'Angluin interroge un oracle au lieu de subir un echantillon, et apprend des automates finis avec garanties de minimalite) ; SL-9 complete l'ILP de SL-4 par la voie bottom-up aboutie (LGG de Plotkin, theta-subsomption, clause bottom et recherche a la Progol) ; SL-10 est le capstone qui assemble toute la serie en un pipeline neuro-symbolique de bout en bout — du texte brut aux faits decouverts, avec un LLM reel (Gemini 3.5 Flash) aux deux extremites et le symbolique comme colonne vertebrale.
+Le premier notebook pose les bases : representation d'hypotheses comme conjonctions de contraintes, algorithmes Current-Best-Hypothesis et Candidate Elimination (Version Space), et leurs limites face au bruit et aux concepts disjonctifs. Le second notebook montre comment la connaissance du domaine accélère l'apprentissage : l'apprentissage base sur les explications (EBL) compile les theories en heuristiques operationnelles, et l'apprentissage base sur la pertinence (RBL) identifie les attributs determinant via les determinations. Le troisième notebook approfondit le RBL avec le treillis des determinations, l'algorithme MINIMAL-CONSISTENT-DET et une comparaison avec sklearn. Le quatrième notebook couvre la programmation logique inductive (ILP) : l'algorithme FOIL (top-down), la resolution inverse (bottom-up) et la connexion avec les knowledge graphs. Les notebooks SL-5 a SL-7 ouvrent vers des méthodes contemporaines : SL-5 introduit le neuro-symbolique (T-norms differentiables, Logic Tensor Networks, DeepProbLog) ; SL-6 outille la découverte de règles sur knowledge graphs réels avec rdflib et AMIE rule mining ; SL-7 boucle LLM et verification symbolique pour fiabiliser le raisonnement formel guide par modeles de langage. Trois notebooks etendent la série : SL-8 change de paradigme avec l'apprentissage *actif* (l'algorithme L* d'Angluin interroge un oracle au lieu de subir un echantillon, et apprend des automates finis avec garanties de minimalite) ; SL-9 complète l'ILP de SL-4 par la voie bottom-up aboutie (LGG de Plotkin, theta-subsomption, clause bottom et recherche a la Progol) ; SL-10 est le capstone qui assemble toute la série en un pipeline neuro-symbolique de bout en bout — du texte brut aux faits decouverts, avec un LLM réel (Gemini 3.5 Flash) aux deux extremites et le symbolique comme colonne vertebrale.
 
-**A qui s'adresse cette serie** : etudiants en IA, informaticiens interesses par le raisonnement symbolique, et chercheurs en apprentissage automatique souhaitant comprendre les approches non-statistiques. Les notebooks (~9h30 total) ne necessitent que Python 3.10+ standard library, sauf SL-3 (scikit-learn + numpy pour la comparaison RBL / information mutuelle) et SL-6 (rdflib pour les knowledge graphs) ; SL-7 et SL-10 acceptent une cle OpenRouter optionnelle (fichier `.env`) pour des appels LLM reels, avec un simulateur deterministe en repli. Une familiarite avec la logique propositionnelle suffit pour SL-1 a SL-4, SL-8 et SL-9 ; SL-5, SL-7 et SL-10 supposent une intuition des reseaux de neurones et des LLMs. Ils constituent un complement theorique aux series [Tweety](../Tweety/README.md) (argumentation computationnelle), [SemanticWeb](../SemanticWeb/README.md) (representation de connaissances) et [ML](../../ML/README.md) (apprentissage statistique - contraste avec l'inductif symbolique).
+**A qui s'adresse cette série** : étudiants en IA, informaticiens interesses par le raisonnement symbolique, et chercheurs en apprentissage automatique souhaitant comprendre les approches non-statistiques. Les notebooks (~9h30 total) ne necessitent que Python 3.10+ standard library, sauf SL-3 (scikit-learn + numpy pour la comparaison RBL / information mutuelle) et SL-6 (rdflib pour les knowledge graphs) ; SL-7 et SL-10 acceptent une cle OpenRouter optionnelle (fichier `.env`) pour des appels LLM réels, avec un simulateur deterministe en repli. Une familiarite avec la logique propositionnelle suffit pour SL-1 a SL-4, SL-8 et SL-9 ; SL-5, SL-7 et SL-10 supposent une intuition des réseaux de neurones et des LLMs. Ils constituent un complement théorique aux séries [Tweety](../Tweety/README.md) (argumentation computationnelle), [SemanticWeb](../SemanticWeb/README.md) (representation de connaissances) et [ML](../../ML/README.md) (apprentissage statistique - contraste avec l'inductif symbolique).
 
-## Pourquoi cette serie
+## Pourquoi cette série
 
-L'apprentissage symbolique represente la contrepartie theorique du machine learning statistique. Tandis que les methodes modernes (deep learning, ensembles d'arbres) excellent a extraire des patterns de grandes masses de donnees, elles souffrent de trois limites fondamentales que l'approche symbolique adresse directement :
+L'apprentissage symbolique represente la contrepartie théorique du machine learning statistique. Tandis que les méthodes modernes (deep learning, ensembles d'arbres) excellent a extraire des patterns de grandes masses de données, elles souffrent de trois limites fondamentales que l'approche symbolique adresse directement :
 
-- **Peu de donnees disponibles** : les methodes symboliques comme Candidate Elimination ou FOIL apprennent a partir de quelques exemples, voire d'un seul (EBL). Quand la collecte de donnees est couteuse ou impossible (diagnostic medical rare, validation formelle), l'induction pure ne fonctionne pas.
-- **Interpretabilité requise** : une regle logique `IF temperature > 38 AND toux THEN infection` est comprehensible par un humain. Un reseau de neurones de 100M de parametres ne l'est pas. Pour les applications critiques ou reglementees (medecine, finance, justice), l'interpretabilité n'est pas un luxe — c'est une exigence.
-- **Integration avec la connaissance existante** : les methodes symboliques combinent examples ET theorie du domaine. EBL compile un exemple prouve en une regle operationnelle generale ; RBL identifie les attributs determinants via des contraintes formelles. Aucune methode statistique ne peut exploiter cette connaissance a priori de la meme facon.
+- **Peu de données disponibles** : les méthodes symboliques comme Candidate Elimination ou FOIL apprennent a partir de quelques exemples, voire d'un seul (EBL). Quand la collecte de données est couteuse ou impossible (diagnostic medical rare, validation formelle), l'induction pure ne fonctionne pas.
+- **Interpretabilité requise** : une règle logique `IF temperature > 38 AND toux THEN infection` est comprehensible par un humain. Un réseau de neurones de 100M de parametres ne l'est pas. Pour les applications critiques ou réglementées (medecine, finance, justice), l'interpretabilité n'est pas un luxe — c'est une exigence.
+- **Integration avec la connaissance existante** : les méthodes symboliques combinent examples ET theorie du domaine. EBL compile un exemple prouve en une règle opérationnelle générale ; RBL identifie les attributs determinants via des contraintes formelles. Aucune méthode statistique ne peut exploiter cette connaissance a priori de la même façon.
 
-Cette serie montre que les deux approches ne s'opposent pas — elles se **complementent**. La phase finale (SL-5 a SL-7) explore explicitement cette integration : T-norms differentiables pour rendre la logique compatible avec l'entrainement neuronal, rule mining sur knowledge graphs reels, et boucles de verification symbolique pour fiabiliser les sorties LLM.
+Cette série montre que les deux approches ne s'opposent pas — elles se **complementent**. La phase finale (SL-5 a SL-7) explore explicitement cette intégration : T-norms differentiables pour rendre la logique compatible avec l'entrainement neuronal, rule mining sur knowledge graphs réels, et boucles de verification symbolique pour fiabiliser les sorties LLM.
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, vous serez capable de :
+A l'issue de cette série, vous serez capable de :
 
 1. **Implémenter** les algorithmes d'apprentissage inductif de base (CBH, Candidate Elimination, Version Space)
 2. **Compiler** des preuves en heuristiques operationnelles via EBL, et **identifier** les attributs determinants via RBL et les determinations
 3. **Construire** le treillis des determinations et appliquer MINIMAL-CONSISTENT-DET pour la selection guidee d'attributs
-4. **Apprendre** des regles logiques (clauses Horn) a partir d'exemples avec FOIL et la resolution inverse
+4. **Apprendre** des règles logiques (clauses Horn) a partir d'exemples avec FOIL et la resolution inverse
 5. **Intégrer** logique et apprentissage neuronal via T-norms, Logique Tensorielle, et DeepProbLog
-6. **Extraire** des regles de knowledge graphs reels avec rdflib et AMIE, et **effectuer** la completion de graphes
-7. **Concevoir** une boucle LLM-symbolique : extraction de regles IF-THEN depuis du texte, verification de coherence formelle, feedback pour l'amelioration
-8. **Implémenter** l'algorithme L* d'Angluin : table d'observation, requetes d'appartenance et d'equivalence, apprentissage actif d'automates minimaux
+6. **Extraire** des règles de knowledge graphs réels avec rdflib et AMIE, et **effectuer** la completion de graphes
+7. **Concevoir** une boucle LLM-symbolique : extraction de règles IF-THEN depuis du texte, verification de coherence formelle, feedback pour l'amelioration
+8. **Implémenter** l'algorithme L* d'Angluin : table d'observation, requêtes d'appartenance et d'equivalence, apprentissage actif d'automates minimaux
 9. **Construire** la chaine bottom-up de l'ILP : LGG de Plotkin, theta-subsomption, clause bottom et recherche de clause a la Progol
-10. **Assembler** un pipeline neuro-symbolique complet : extraction LLM, oracle de validation type, mining de regles, chainage avant avec provenance, et confrontation LLM vs KG
+10. **Assembler** un pipeline neuro-symbolique complet : extraction LLM, oracle de validation type, mining de règles, chainage avant avec provenance, et confrontation LLM vs KG
 
 ## Vue d'ensemble
 
@@ -52,87 +52,87 @@ A l'issue de cette serie, vous serez capable de :
 
 ### Phase 1 : Fondations inductives (SL-1, ~50 min)
 
-Le parcours commence par l'apprentissage inductif pur : un agent doit decouvrir une regle cachee a partir d'exemples. SL-1 presente les algorithmes fondamentaux — Current-Best-Hypothesis (ajuste une seule hypothese incrementalement) et Candidate Elimination (maintient l'ensemble complet des hypotheses consistantes, le "Version Space"). Vous experimentez leurs limites face au bruit et aux concepts disjonctifs, ce qui motive naturellement les approches plus riches introduites ensuite.
+Le parcours commence par l'apprentissage inductif pur : un agent doit découvrir une règle cachee a partir d'exemples. SL-1 présente les algorithmes fondamentaux — Current-Best-Hypothesis (ajuste une seule hypothese incrementalement) et Candidate Elimination (maintient l'ensemble complet des hypotheses consistantes, le "Version Space"). Vous experimentez leurs limites face au bruit et aux concepts disjonctifs, ce qui motive naturellement les approches plus riches introduites ensuite.
 
 ### Phase 2 : Apprentissage base sur la connaissance (SL-2 a SL-3, ~95 min)
 
-La deuxieme phase introduit l'idee centrale que **la connaissance accelere l'apprentissage**. EBL (SL-2) montre comment compiler un exemple prouve en une regle operationnelle generale, en quatre etapes : expliquer, variabiliser, extraire, simplifier. RBL (introduit en SL-2, approfondi en SL-3) explore une autre facette : identifier les attributs qui determinent vraiment la cible via le formalisme des determinations et le treillis des sous-ensembles d'attributs. La comparaison avec sklearn (information mutuelle) montre quand la connaissance du domaine bat la statistique brute.
+La deuxième phase introduit l'idee centrale que **la connaissance accélère l'apprentissage**. EBL (SL-2) montre comment compiler un exemple prouve en une règle opérationnelle générale, en quatre étapes : expliquer, variabiliser, extraire, simplifier. RBL (introduit en SL-2, approfondi en SL-3) explore une autre facette : identifier les attributs qui determinent vraiment la cible via le formalisme des determinations et le treillis des sous-ensembles d'attributs. La comparaison avec sklearn (information mutuelle) montre quand la connaissance du domaine bat la statistique brute.
 
 ### Phase 3 : Programmation logique inductive (SL-4, ~55 min)
 
-SL-4 fait le pont entre apprentissage automatique et intelligence artificielle symbolique classique en couvrant l'ILP : apprentissage de programmes logiques (clauses Horn) a partir d'exemples. L'algorithme FOIL (top-down) et la resolution inverse (bottom-up) sont implémentes de zero, puis appliques aux knowledge graphs — avec extraction de regles AMIE et requetes SPARQL CONSTRUCT. La section finale confronte le FOIL artisanal a l'ILP moderne : **Popper** (Learning From Failures) retrouve le programme recursif `ancestor` optimal sur les memes donnees, demontre l'apport de la recursion par ablation, et le programme appris est verifie independamment en SWI-Prolog.
+SL-4 fait le pont entre apprentissage automatique et intelligence artificielle symbolique classique en couvrant l'ILP : apprentissage de programmes logiques (clauses Horn) a partir d'exemples. L'algorithme FOIL (top-down) et la resolution inverse (bottom-up) sont implémentes de zero, puis appliques aux knowledge graphs — avec extraction de règles AMIE et requêtes SPARQL CONSTRUCT. La section finale confronte le FOIL artisanal a l'ILP moderne : **Popper** (Learning From Failures) retrouve le programme recursif `ancestor` optimal sur les mêmes données, demontre l'apport de la recursion par ablation, et le programme appris est verifie independamment en SWI-Prolog.
 
 ### Phase 4 : Integration neuro-symbolique (SL-5 a SL-7, ~160 min)
 
-La phase finale explore les methodes contemporaines a l'intersection du symbolique et du connexionniste. SL-5 introduit les T-norms differentiables, les predicats neuronaux et les Logics Tensor Networks qui rendent la logique operationnelle dans un gradient descent. SL-6 passe a l'echelle avec le rule mining reel sur des knowledge graphs construits avec rdflib (AMIE, completion de graphes). SL-7 ferme la boucle avec LLMs : extraction de regles depuis du texte naturel, verification symbolique des sorties, et boucles de retroaction pour fiabiliser le raisonnement.
+La phase finale explore les méthodes contemporaines a l'intersection du symbolique et du connexionniste. SL-5 introduit les T-norms differentiables, les predicats neuronaux et les Logics Tensor Networks qui rendent la logique opérationnelle dans un gradient descent. SL-6 passe a l'échelle avec le rule mining réel sur des knowledge graphs construits avec rdflib (AMIE, completion de graphes). SL-7 ferme la boucle avec LLMs : extraction de règles depuis du texte naturel, verification symbolique des sorties, et boucles de retroaction pour fiabiliser le raisonnement.
 
 ### Phase 5 : Apprentissage actif, ILP bottom-up et capstone (SL-8 a SL-10, ~210 min)
 
-Trois extensions concluent la serie. SL-8 inverse le rapport de l'apprenant aux donnees : au lieu de subir un echantillon, L* d'Angluin *choisit* ses questions (requetes d'appartenance et d'equivalence a un oracle MAT) et apprend des automates finis deterministes prouvablement minimaux — le cadre theorique (Myhill-Nerode, fermeture et coherence de la table d'observation) est implemente et verifie de zero. SL-9 reprend la promesse bottom-up esquissee en SL-4 et la mene a terme : LGG de Plotkin, theta-subsomption, clause bottom par entailment inverse, et recherche de clause a la Progol qui retrouve la definition de `grandfather/2` parmi 56 candidats. SL-10 est le capstone : un pipeline neuro-symbolique en 6 etages (extraction LLM -> oracle de validation -> knowledge graph -> mining de regles -> chainage avant avec provenance -> confrontation LLM vs KG) execute avec de vrais appels Gemini 3.5 Flash, ou chaque etage mobilise un notebook anterieur de la serie — y compris une lecon d'architecture decouverte dans les sorties reelles : le chainage avant peut violer les contraintes que l'oracle impose en amont.
+Trois extensions concluent la série. SL-8 inverse le rapport de l'apprenant aux données : au lieu de subir un echantillon, L* d'Angluin *choisit* ses questions (requêtes d'appartenance et d'equivalence a un oracle MAT) et apprend des automates finis deterministes prouvablement minimaux — le cadre théorique (Myhill-Nerode, fermeture et coherence de la table d'observation) est implémente et verifie de zero. SL-9 reprend la promesse bottom-up esquissee en SL-4 et la mene a terme : LGG de Plotkin, theta-subsomption, clause bottom par entailment inverse, et recherche de clause a la Progol qui retrouve la définition de `grandfather/2` parmi 56 candidats. SL-10 est le capstone : un pipeline neuro-symbolique en 6 etages (extraction LLM -> oracle de validation -> knowledge graph -> mining de règles -> chainage avant avec provenance -> confrontation LLM vs KG) execute avec de vrais appels Gemini 3.5 Flash, ou chaque etage mobilise un notebook anterieur de la série — y compris une lecon d'architecture découverte dans les sorties réelles : le chainage avant peut violer les contraintes que l'oracle impose en amont.
 
 ### Parcours alternatifs
 
 #### Parcours rapide (SL-1 + SL-5 + SL-7 + SL-10, ~4h)
 
-Pour ceux qui veulent saisir l'essence sans suivre toute la progression : les fondements inductifs (SL-1), l'integration neuro-symbolique (SL-5), la verification LLM (SL-7) et le capstone qui assemble le tout (SL-10). Donne une vue d'ensemble du spectre, de l'inductif pur au pipeline neuro-symbolique complet.
+Pour ceux qui veulent saisir l'essence sans suivre toute la progression : les fondements inductifs (SL-1), l'intégration neuro-symbolique (SL-5), la verification LLM (SL-7) et le capstone qui assemble le tout (SL-10). Donne une vue d'ensemble du spectre, de l'inductif pur au pipeline neuro-symbolique complet.
 
 #### Parcours ILP approfondi (SL-1 a SL-4 + SL-9, ~325 min)
 
-Pour les etudiants en logique et IA symbolique : suivre les quatre premiers notebooks dans l'ordre, puis SL-9 qui mene le bottom-up a terme — de Candidate Elimination a FOIL, puis LGG, theta-subsomption, clause bottom et Progol.
+Pour les étudiants en logique et IA symbolique : suivre les quatre premiers notebooks dans l'ordre, puis SL-9 qui mene le bottom-up a terme — de Candidate Elimination a FOIL, puis LGG, theta-subsomption, clause bottom et Progol.
 
 #### Parcours theorie des langages (SL-1 + SL-8, ~110 min)
 
-Pour les etudiants en informatique theorique : le cadre inductif general (SL-1), puis l'apprentissage actif d'automates avec ses garanties formelles (SL-8) — requetes, Myhill-Nerode, minimalite, bornes PAC de l'oracle d'equivalence echantillonne.
+Pour les étudiants en informatique théorique : le cadre inductif général (SL-1), puis l'apprentissage actif d'automates avec ses garanties formelles (SL-8) — requêtes, Myhill-Nerode, minimalite, bornes PAC de l'oracle d'equivalence echantillonne.
 
 #### Parcours knowledge graphs (SL-2, SL-3, SL-4, SL-6, ~220 min)
 
-Pour les professionnels du web semantique et des donnees structurees : EBL, RBL, FOIL sur clauses Horn, puis application directe sur des knowledge graphs reels avec rdflib et AMIE. Presuppose une familiarite avec RDF/SPARQL.
+Pour les professionnels du web semantique et des données structurees : EBL, RBL, FOIL sur clauses Horn, puis application directe sur des knowledge graphs réels avec rdflib et AMIE. Presuppose une familiarite avec RDF/SPARQL.
 
 ## Seance de restitution : la table de pioche (40 exercices)
 
-Modalite de la seance : chaque groupe choisit **un exercice** dans la table ci-dessous, le prepare, et le presente en seance. Resoudre l'exercice est le minimum attendu ; chaque exercice est assorti d'une **question-twist** (detaillee dans la cellule « Defi presentation » du notebook correspondant) qui fait partie integrante de la presentation. Premier arrive, premier servi : annoncez votre choix pour eviter les doublons.
+Modalite de la seance : chaque groupe choisit **un exercice** dans la table ci-dessous, le prepare, et le présente en seance. Resoudre l'exercice est le minimum attendu ; chaque exercice est assorti d'une **question-twist** (detaillee dans la cellule « Defi presentation » du notebook correspondant) qui fait partie integrante de la presentation. Premier arrive, premier servi : annoncez votre choix pour éviter les doublons.
 
 | # | Notebook | Exercice | Question-twist (en bref) |
 |---|----------|----------|--------------------------|
 | 1 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 1 — CBH avec ordre personnalise | Deux ordres d'exemples, deux hypotheses finales : pourquoi, a accuracy egale ? |
 | 2 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 2 — Version Space sur sous-ensemble | Qu'est-ce qui rend un exemple *informatif* (frontieres S et G) ? |
-| 3 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 3 — Regles avec couverture | Compacite vs hypothese AIMA : quel biais (rasoir d'Occam) prefere l'une a l'autre ? |
+| 3 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 3 — Regles avec couverture | Compacite vs hypothese AIMA : quel biais (rasoir d'Occam) préfère l'une a l'autre ? |
 | 4 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 4 — Reflexion sur le biais conjonctif | Un domaine ou ce biais est ideal, un ou il est catastrophique (no free lunch) |
 | 5 | [SL-1](SL-1-LogicalLearning.ipynb) | Ex. 5 — La consistance sans Occam (aima) | Echantillonner les graines ne prouve pas la minimalite : quel algorithme exact le ferait ? |
-| 6 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 1 — EBL differentiation symbolique | Exhiber une variabilisation trop agressive qui produit une regle compilee fausse |
-| 7 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 2 — Filtrage des regles (operationnalite) | Deux distributions de requetes qui inversent le classement d'utilite des regles |
+| 6 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 1 — EBL differentiation symbolique | Exhiber une variabilisation trop agressive qui produit une règle compilee fausse |
+| 7 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 2 — Filtrage des règles (operationnalite) | Deux distributions de requêtes qui inversent le classement d'utilite des règles |
 | 8 | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) | Ex. 3 — Speedup EBL | Le *utility problem* (Minton 1990) : pourquoi apprendre plus finit par ralentir |
 | 9 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 1 — Determinations meteo | Une observation bruitee : quelle determination minimale survit ? |
 | 10 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 2 — RBL vs selection aleatoire | Trouver le point de croisement ou la selection statistique bat le RBL |
 | 11 | [SL-3](SL-3-RelevanceLearning.ipynb) | Ex. 3 — Selecteur hybride | Quelles garanties votre hybride herite-t-il vraiment ? Contre-exemple construit |
-| 12 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 1 — `sibling` avec FOIL | Le role du biais de langage : que se passe-t-il sans le litteral `X != Y` ? |
+| 12 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 1 — `sibling` avec FOIL | Le rôle du biais de langage : que se passe-t-il sans le litteral `X != Y` ? |
 | 13 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 2 — Operateur W | Generalisation consistante mais fausse : pourquoi le bottom-up y est expose |
 | 14 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 3 — Regles sur mini-KG | Monde clos vs PCA (cf SL-6) : quelle confiance est la bonne pour VOTRE KG ? |
-| 15 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 4 — `grandparent` avec Popper | Sans negatif arriere-grand-parent, quel programme plus court devient consistant ? |
+| 15 | [SL-4](SL-4-InductiveLogicProgramming.ipynb) | Ex. 4 — `grandparent` avec Popper | Sans negatif arrière-grand-parent, quel programme plus court devient consistant ? |
 | 16 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 2 — LTN frere/oncle | Retirer les axiomes negatifs : pourquoi une LTN a besoin de negatifs explicites |
-| 17 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 3 — Regle transitive `ancestor` | Le modele trivial « vrai partout » sature la regle : qu'est-ce qui l'evite ? |
+| 17 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 3 — Regle transitive `ancestor` | Le modele trivial « vrai partout » sature la règle : qu'est-ce qui l'évite ? |
 | 18 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 4 — T-norm de Lukasiewicz | Gradients exactement nuls : qu'est-ce qu'une semantique floue *apprenable* ? |
 | 19 | [SL-5](SL-5-NeuroSymbolic.ipynb) | Ex. 5 — Ablation de l'axiome 4 (LTNtorch) | Le negatif difficile (Marie, Pierre) est-il indispensable ? Contraste avec clingo (SL-6) |
-| 20 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 1 — Nouvelle relation au KG | Regles redondantes (meme extension, syntaxe differente) : comment AMIE les evite |
+| 20 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 1 — Nouvelle relation au KG | Regles redondantes (même extension, syntaxe differente) : comment AMIE les évite |
 | 21 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 2 — PCA confidence | Construire un mini-KG ou la PCA confidence est trompeuse |
-| 22 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 3 — Regles a 3 atomes | Explosion combinatoire : pourquoi AMIE impose des regles fermees, a quel prix |
+| 22 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 3 — Regles a 3 atomes | Explosion combinatoire : pourquoi AMIE impose des règles fermees, a quel prix |
 | 23 | [SL-6](SL-6-KnowledgeGraphs-ILP.ipynb) | Ex. 4 — Reparation minimale (clingo) | Les reparations optimales sont ex-aequo : departager par des poids de confiance |
 | 24 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 1 — Prompt personnalise | Changer de modele LLM : que garantit vraiment l'oracle symbolique ? |
 | 25 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 2 — Prompt direct vs CoT | Validation oracle vs plausibilite du texte : les deux metriques peuvent diverger |
 | 26 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 3 — Detection d'hallucinations | Le detecteur suppose un monde clos : que devient-il en monde ouvert (cf SL-6) ? |
-| 27 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 4 — Taux d'hallucination du vrai LLM | Maximiser le taux de validation ou le nombre de regles validees par appel ? |
+| 27 | [SL-7](SL-7-LLM-SymbolicLearning.ipynb) | Ex. 4 — Taux d'hallucination du vrai LLM | Maximiser le taux de validation ou le nombre de règles validees par appel ? |
 | 28 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 1 — Le langage « contient abb » | Certificat de minimalite : un suffixe distinguant pour chaque paire d'etats (Myhill-Nerode) |
-| 29 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 2 — Fiabilite de l'EQ echantillonnee | Relier le taux de reussite empirique a la borne PAC ; construire une distribution adverse |
+| 29 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 2 — Fiabilite de l'EQ echantillonnee | Relier le taux de réussite empirique a la borne PAC ; construire une distribution adverse |
 | 30 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 3 — Contre-exemples : prefixes vs suffixes | Le pire cas qui fait exploser la table d'observation (Rivest-Schapire) |
-| 31 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 4 — Oracle bruite | Reparer L* par vote majoritaire : surcout en requetes et probabilite residuelle d'erreur |
-| 32 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 1 — Apprendre `grandmother/2` | Pourquoi `grandparent/2` (sans sexe) est *plus facile* — role des negatifs |
+| 31 | [SL-8](SL-8-ActiveAutomataLearning.ipynb) | Ex. 4 — Oracle bruite | Reparer L* par vote majoritaire : surcout en requêtes et probabilite residuelle d'erreur |
+| 32 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 1 — Apprendre `grandmother/2` | Pourquoi `grandparent/2` (sans sexe) est *plus facile* — rôle des negatifs |
 | 33 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 2 — Profondeur de la clause bottom | Croissance de la clause bottom avec la profondeur ; la cible reste-t-elle dans le treillis ? |
-| 34 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 3 — Tolerance au bruit | Le score `p - n - L` comme argument MDL : quand prefere-t-il une clause imparfaite ? |
+| 34 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 3 — Tolerance au bruit | Le score `p - n - L` comme argument MDL : quand préfère-t-il une clause imparfaite ? |
 | 35 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 4 — Reduction de Plotkin | Subsomption vs implication : le cas des clauses recursives ou elles divergent |
-| 36 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 5 — Aleph face au bruit | Memoriser l'exception, sur-generaliser ou payer L dans f : trois frontieres face au meme bruit |
-| 37 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 1 — Etendre le schema (`marie_avec`) | Le mineur redecouvre la symetrie injectee par l'oracle : regle ou tautologie ? |
-| 38 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 2 — Politique de conflit a sources | *Truth discovery* : estimer la fiabilite des sources en meme temps que les faits |
-| 39 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 3 — Le bon seuil n'existe pas | Vraie et fausse regle a confiance egale (0.67) : quel signal au-dela du seuil ? |
+| 36 | [SL-9](SL-9-InverseResolution.ipynb) | Ex. 5 — Aleph face au bruit | Memoriser l'exception, sur-generaliser ou payer L dans f : trois frontieres face au même bruit |
+| 37 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 1 — Etendre le schéma (`marie_avec`) | Le mineur redecouvre la symetrie injectee par l'oracle : règle ou tautologie ? |
+| 38 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 2 — Politique de conflit a sources | *Truth discovery* : estimer la fiabilite des sources en même temps que les faits |
+| 39 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 3 — Le bon seuil n'existe pas | Vraie et fausse règle a confiance egale (0.67) : quel signal au-dela du seuil ? |
 | 40 | [SL-10](SL-10-Capstone-NeuroSymbolic.ipynb) | Ex. 4 — Empoisonnement bout-en-bout | Classer les defenses par etage du pipeline ; ou s'arrete la provenance ? |
 
 Note : dans SL-5, le premier exercice de la numerotation interne est un exemple guide ; les exercices a piocher sont Ex. 2 a Ex. 5.
@@ -147,8 +147,8 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | 4 | [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb) | FOIL, resolution inverse, clauses Horn, knowledge graphs, Popper (LFF) | 55 min |
 | 5 | [SL-5 - Integration Neuro-Symbolique](SL-5-NeuroSymbolic.ipynb) | T-norms, predicats neuronaux, LTN, DeepProbLog | 55 min |
 | 6 | [SL-6 - ILP Moderne et Knowledge Graphs](SL-6-KnowledgeGraphs-ILP.ipynb) | rdflib, AMIE rule mining, completion KG, ASP avec clingo | 55 min |
-| 7 | [SL-7 - LLMs et Apprentissage Symbolique](SL-7-LLM-SymbolicLearning.ipynb) | Prompting, extraction de regles, verification symbolique (Gemini 3.5 Flash optionnel) | 50 min |
-| 8 | [SL-8 - Apprentissage Actif d'Automates](SL-8-ActiveAutomataLearning.ipynb) | L* d'Angluin, table d'observation, requetes MQ/EQ, Myhill-Nerode | 60 min |
+| 7 | [SL-7 - LLMs et Apprentissage Symbolique](SL-7-LLM-SymbolicLearning.ipynb) | Prompting, extraction de règles, verification symbolique (Gemini 3.5 Flash optionnel) | 50 min |
+| 8 | [SL-8 - Apprentissage Actif d'Automates](SL-8-ActiveAutomataLearning.ipynb) | L* d'Angluin, table d'observation, requêtes MQ/EQ, Myhill-Nerode | 60 min |
 | 9 | [SL-9 - Resolution Inverse et Progol](SL-9-InverseResolution.ipynb) | LGG de Plotkin, theta-subsomption, clause bottom, recherche Progol | 60 min |
 | 10 | [SL-10 - Capstone Neuro-Symbolique](SL-10-Capstone-NeuroSymbolic.ipynb) | Pipeline 6 etages : extraction LLM, oracle, KG, mining, inference avec provenance, QA | 90 min |
 
@@ -170,11 +170,11 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 
 | Section | Contenu |
 |---------|---------|
-| Cadre general | Contrainte d'entrainement, EBL vs RBL vs KBIL |
-| EBL - Principe | Exemple de Zog, 4 etapes (expliquer, variabiliser, extraire, simplifier) |
+| Cadre général | Contrainte d'entrainement, EBL vs RBL vs KBIL |
+| EBL - Principe | Exemple de Zog, 4 étapes (expliquer, variabiliser, extraire, simplifier) |
 | EBL - Arithmetique | Simplification d'expressions, arbre de preuve |
-| EBL - Implementation | Classe ArithmeticEBL complete |
-| EBL - Efficacite | Operationalite vs generalite, proliferation de regles |
+| EBL - Implementation | Classe ArithmeticEBL complète |
+| EBL - Efficacite | Operationalite vs generalite, proliferation de règles |
 | RBL - Introduction | Determinations, verification fonctionnelle, reduction d'espace (approfondi dans SL-3) |
 
 ### SL-3-RelevanceLearning.ipynb
@@ -183,7 +183,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 |---------|---------|
 | Determinations | Formalisme, monotonie, minimalite, `check_determination()` |
 | Treillis des determinations | `build_determination_lattice()`, visualisation ASCII, up-set |
-| MINIMAL-CONSISTENT-DET | Implementation detaillee, donnees moleculaires, cas d'echec disjonctif (restaurant) |
+| MINIMAL-CONSISTENT-DET | Implementation detaillee, données moleculaires, cas d'echec disjonctif (restaurant) |
 | Selection guidee | RBL vs sklearn (information mutuelle), comparaison |
 | Analyse PAC | Reduction exponentielle, bornes d'echantillonnage |
 | Web Semantique | Parallel RBL <-> OWL (FunctionalProperty, hasKey) |
@@ -198,7 +198,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | Resolution inverse | Operateurs V (absorption) et W (identification) |
 | Knowledge Graphs | Regles AMIE, triples RDF, SPARQL CONSTRUCT |
 | Popper (Learning From Failures) | Programme recursif optimal, ablation sans recursion, verification SWI-Prolog (kernel Linux/WSL) |
-| Exercices | sibling, operateur W, regles sur KG |
+| Exercices | sibling, operateur W, règles sur KG |
 
 ### SL-5-NeuroSymbolic.ipynb
 
@@ -215,16 +215,16 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | Section | Contenu |
 |---------|---------|
 | Knowledge Graphs | Construction avec rdflib |
-| AMIE rule mining | Decouverte de regles de Horn sur KG |
+| AMIE rule mining | Decouverte de règles de Horn sur KG |
 | Completion | Inference de nouveaux triples |
-| ASP avec clingo | Validation croisee de la completion, recursion (`ancestorOf`), contraintes d'integrite (pont serie Tweety) |
+| ASP avec clingo | Validation croisee de la completion, recursion (`ancestorOf`), contraintes d'integrite (pont série Tweety) |
 
 ### SL-7-LLM-SymbolicLearning.ipynb
 
 | Section | Contenu |
 |---------|---------|
 | LLMs et raisonnement | Forces et limites pour le raisonnement symbolique |
-| Parseur de regles | Extraction de regles IF-THEN depuis du texte |
+| Parseur de règles | Extraction de règles IF-THEN depuis du texte |
 | Verification symbolique | Coherence formelle des sorties LLM |
 | Boucle LLM-Symbolique | Generation + verification + feedback |
 
@@ -238,18 +238,18 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | L* | Algorithme complet d'Angluin (1987), construction de l'hypothese |
 | Contre-exemples | Traitement, raffinement, convergence vers le DFA minimal |
 | Oracle echantillonne | Equivalence approchee par tirage, lien PAC |
-| Theorie | Myhill-Nerode, minimalite, bornes sur le nombre de requetes |
+| Theorie | Myhill-Nerode, minimalite, bornes sur le nombre de requêtes |
 
 ### SL-9-InverseResolution.ipynb
 
 | Section | Contenu |
 |---------|---------|
 | Clauses et couverture | `covers()` par backtracking, validation de la cible `grandfather/2` |
-| LGG de Plotkin | Anti-unification, generalisation la moins generale, sur-specialisation |
+| LGG de Plotkin | Anti-unification, generalisation la moins générale, sur-specialisation |
 | Theta-subsomption | `subsumes()` par skolemisation, le treillis de generalite |
 | Clause bottom | Saturation bornee, entailment inverse, variabilisation |
 | Recherche Progol | Sous-ensembles connectes du corps de bottom, score `f = p - L`, consistance dure |
-| Cover-set | Boucle d'apprentissage de theorie complete |
+| Cover-set | Boucle d'apprentissage de theorie complète |
 
 ### SL-10-Capstone-NeuroSymbolic.ipynb
 
@@ -259,9 +259,9 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | Etage 1 - Extraction | LLM (Gemini 3.5 Flash) ou simulateur : texte -> triples candidats |
 | Etage 2 - Oracle | Validation typee + contraintes fonctionnelles (cf SL-7) |
 | Etage 3 - KG | Knowledge graph valide (cf SL-6) |
-| Etage 4 - Mining | AMIE-lite : decouverte de regles avec confiance standard (cf SL-4/SL-6) |
+| Etage 4 - Mining | AMIE-lite : découverte de règles avec confiance standard (cf SL-4/SL-6) |
 | Etage 5 - Inference | Chainage avant avec provenance ; le derive peut violer l'oracle (lecon d'architecture) |
-| Etage 6 - QA | Question 2 sauts : reponse KG (derivation citee) vs reponse LLM seule |
+| Etage 6 - QA | Question 2 sauts : réponse KG (derivation citee) vs réponse LLM seule |
 
 ## Concepts cles
 
@@ -270,7 +270,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | **Hypothese FOL** | Conjonction de contraintes sur les attributs | SL-1 |
 | **Version Space** | Ensemble de toutes les hypotheses consistantes | SL-1 |
 | **CBH** | Maintient une seule hypothese ajustee incrementalement | SL-1 |
-| **EBL** | Extrait une regle generale d'un seul exemple par deduction | SL-2 |
+| **EBL** | Extrait une règle générale d'un seul exemple par déduction | SL-2 |
 | **RBL** | Identifie les attributs pertinents via les determinations | SL-2 |
 | **Determination** | Relation fonctionnelle entre attributs | SL-2, SL-3 |
 | **KBIL** | Apprentissage inductif guide par la connaissance | SL-2 |
@@ -291,9 +291,9 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | **MAT** | Minimally Adequate Teacher : oracle d'appartenance + equivalence | SL-8 |
 | **Table d'observation** | Structure (S, E, T) fermee et coherente dont on lit un DFA | SL-8 |
 | **Myhill-Nerode** | Classes d'equivalence de suffixes = etats du DFA minimal | SL-8 |
-| **LGG** | Generalisation la moins generale de deux clauses (Plotkin) | SL-9 |
+| **LGG** | Generalisation la moins générale de deux clauses (Plotkin) | SL-9 |
 | **Theta-subsomption** | Ordre de generalite decidable entre clauses (∃θ : Cθ ⊆ D) | SL-9 |
-| **Clause bottom** | Clause la plus specifique couvrant un exemple (entailment inverse) | SL-9 |
+| **Clause bottom** | Clause la plus spécifique couvrant un exemple (entailment inverse) | SL-9 |
 | **Progol** | Recherche de clause guidee par la clause bottom | SL-9 |
 | **Provenance** | Trace de derivation attachee a chaque fait infere | SL-10 |
 | **Pipeline neuro-symbolique** | LLM aux extremites, validation et inference symboliques au centre | SL-10 |
@@ -308,7 +308,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 
 ### Environnement Python
 
-Aucune dependance externe pour SL-1, SL-2, SL-5, SL-8 et SL-9 (bibliotheque standard Python 3.10+ uniquement). SL-3 utilise `scikit-learn` et `numpy` pour la comparaison avec la selection statistique. SL-6 utilise `rdflib` et `clingo` (module Python officiel Potassco, installe silencieusement par le notebook — meme moteur ASP que le binaire utilise par la serie Tweety via `scripts/install_clingo.py`). SL-7 et SL-10 utilisent `python-dotenv` et `openai` pour les appels LLM optionnels via OpenRouter (Gemini 3.5 Flash) : copiez `.env.example` vers `.env` et renseignez `OPENROUTER_API_KEY` ; sans cle, un simulateur deterministe prend le relais et le notebook s'execute integralement.
+Aucune dependance externe pour SL-1, SL-2, SL-5, SL-8 et SL-9 (bibliotheque standard Python 3.10+ uniquement). SL-3 utilise `scikit-learn` et `numpy` pour la comparaison avec la selection statistique. SL-6 utilise `rdflib` et `clingo` (module Python officiel Potassco, installe silencieusement par le notebook — même moteur ASP que le binaire utilise par la série Tweety via `scripts/install_clingo.py`). SL-7 et SL-10 utilisent `python-dotenv` et `openai` pour les appels LLM optionnels via OpenRouter (Gemini 3.5 Flash) : copiez `.env.example` vers `.env` et renseignez `OPENROUTER_API_KEY` ; sans cle, un simulateur deterministe prend le relais et le notebook s'execute integralement.
 
 SL-4 est en bibliotheque standard pour l'essentiel, mais sa section finale **Popper** requiert un environnement Unix : Popper utilise `signal.SIGALRM`, absent de Windows — le notebook s'execute donc sur un kernel Python **Linux** (kernel `python3-wsl` via WSL sous Windows, kernel natif sous Linux/macOS). Dependances de la section (installees silencieusement par le notebook) : SWI-Prolog >= 9.1.12 (`ppa:swi-prolog/stable`), `popper-ilp` epingle a **v4.4.0** (la 5.0 exige Python >= 3.14), `janus_swi`, `clingo`, `setuptools < 81`. Si Popper est indisponible, les cellules de la section l'indiquent et se sautent proprement — le reste du notebook tourne sur n'importe quel kernel Python.
 
@@ -340,13 +340,13 @@ Le treillis des determinations croit exponentiellement avec le nombre d'attribut
 
 - Limitez l'analyse aux 20-30 attributs les plus informatifs en premier
 - Utilisez `check_determination()` pour filtrer avant de construire le treillis complet
-- Le notebook inclut un parametre `max_attributes` pour controler cette taille
+- Le notebook inclut un parametre `max_attributes` pour contrôler cette taille
 
 ### Jupyter / kernels Python
 
-- Si le kernel Python n'apparait pas : `python -m ipykernel install --user --name python3 --display-name "Python 3"`
+- Si le kernel Python n'apparaît pas : `python -m ipykernel install --user --name python3 --display-name "Python 3"`
 - Si Papermill ne tourne pas les notebooks : `pip install papermill`
-- En cas de conflit de sortie entre cellules : redemarrez le kernel avant execution complete
+- En cas de conflit de sortie entre cellules : redemarrez le kernel avant execution complète
 
 ## Ressources
 
@@ -354,7 +354,7 @@ Le treillis des determinations croit exponentiellement avec le nombre d'attribut
 
 - Russell & Norvig, *Artificial Intelligence: A Modern Approach*, 3e/4e ed., Chapitre 19
 - Tom Mitchell, *Machine Learning*, Chapitres 2 (Concept Learning) et 11 (EBL)
-- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de reference
+- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de référence
 
 ## Structure des fichiers
 
@@ -377,12 +377,12 @@ SymbolicLearning/
 └── README.md                                # Cette documentation
 ```
 
-## Cross-series Bridges
+## Cross-séries Bridges
 
 | Serie | Lien | Connection |
 |-------|------|-------------|
 | [Tweety](../Tweety/README.md) | Argumentation | Les logiques formelles de Tweety (propositionnelle, FOL) sont le fondement des hypotheses symboliques |
 | [SemanticWeb](../SemanticWeb/README.md) | Representation de connaissances | RDFS/OWL formalisent les determinations et les hierarchies de generalite |
-| [Planners](../Planners/README.md) | Planification | EBL compile les theories en regles operationnelles, similaire aux heuristiques de planification |
+| [Planners](../Planners/README.md) | Planification | EBL compile les theories en règles operationnelles, similaire aux heuristiques de planification |
 | [Lean](../Lean/README.md) | Preuves formelles | L'arbre de preuve EBL est analogue aux arbres de preuve Lean 4 |
 | Lecture transversale | [La mer qui monte](../../../docs/grothendieckian-lens.md) | Grille de lecture grothendieckienne du depot : changement de representation, certification A/B/C |


### PR DESCRIPTION
## Summary

Pure French accent restoration across 4 SymbolicAI series READMEs, addressing the systemic no-accents problem tracked in #2876.

**Files modified:**
- `MyIA.AI.Notebooks/SymbolicAI/README.md` (series root)
- `MyIA.AI.Notebooks/SymbolicAI/Planners/README.md`
- `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md`
- `MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md`

## What changed

Restored French diacritics in prose: « théorique », « pédagogique », « série », « développement », « méthodes », « génération », « intermédiaire », « implémente », « références », « sécurité », « itération », « procédure », « spécialisé », etc.

## Validation (G.1)

| Check | Result |
|-------|--------|
| Diff balance | **229 insertions / 229 deletions** (pure accent restoration, no content change) |
| CATALOG-STATUS blocks | **byte-identical to main** on all 4 files (catalog-pr-hygiene HARD 1 respected) |
| Internal markdown link targets | **all identical to HEAD** (verified via `diff <(git show HEAD:f | grep -oE '\]\([^)]+\)')`) |
| `.ipynb` references | preserved (131/29/27/70 counts unchanged) |
| Inline code spans (`` `...` ``) | untouched (split-and-skip in the script) |
| Code fences (` ``` `) | untouched |

## Scope

These 4 READMEs were the remaining orphan families on my partition (CPU/.NET + SymbolicAI/OR-tools) with no collision against the other accent PRs in flight:
- Root → #2890 (done)
- Search → #2880 (merged), Probas → #2888 (merged), Lean → #2885 (merged)
- GameTheory → #2899, IIT → #2894 (po-2024)

No content, no link, no code, no path was modified — only diacritics in French prose. Branche `feature/symbolicai-readme-accents-2876` rebased fresh on `origin/main`.

See #2876
