### PR TITLE
docs(symbolicai): restore French accents on 12 SymbolicAI READMEs (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -7,17 +7,17 @@ breakdown: Argument_Analysis=6
 maturity: PRODUCTION=5, ALPHA=1
 -->
 
-Pipeline complet d'analyse argumentative combinant Semantic Kernel, TweetyProject et programmation logique pour l'identification et l'evaluation d'arguments dans des textes.
+Pipeline complet d'analyse argumentative combinant Semantic Kernel, TweetyProject et programmation logique pour l'identification et l'évaluation d'arguments dans des textes.
 
-## Pourquoi cette serie
+## Pourquoi cette série
 
-Distinguer un argument valide d'un sophisme est un acte essentiel dans une societe sature de discours generes a la chaine. Lorsque les LLMs produisent des textes plausibles a la demande, la frontiere entre persuasion legitime et manipulation rhetorique se brouille : raisonnements circulaires, faux dilemmes, appels a l'autorite mal calibres deviennent indetectables par simple lecture rapide. La verification formelle, autrefois reservee aux logiciens, devient un service de masse : moderation de plateformes, journalisme assiste, education critique, audit de contenus pedagogiques generes par IA.
+Distinguer un argument valide d'un sophisme est un acte essentiel dans une société saturée de discours générés à la chaîne. Lorsque les LLMs produisent des textes plausibles à la demande, la frontière entre persuasion légitime et manipulation rhétorique se brouille : raisonnements circulaires, faux dilemmes, appels à l'autorité mal calibrés deviennent indétectables par simple lecture rapide. La vérification formelle, autrefois réservée aux logiciens, devient un service de masse : modération de plateformes, journalisme assisté, éducation critique, audit de contenus pédagogiques générés par IA.
 
-Cette serie pose une question concrete : peut-on construire un pipeline qui prend un texte argumentatif en entree et qui en restitue une carte logique formelle, validee par un solveur SAT, avec detection systematique des sophismes connus ? La reponse passe par un assemblage soigne de trois competences distinctes : un LLM pour extraire le tissu argumentatif informel (premisses, conclusions, transitions), un solveur logique (TweetyProject, Java via JPype) pour verifier la coherence des formalisations propositionnelles obtenues, et une couche d'orchestration agentique (Semantic Kernel) qui transforme cette chaine en pipeline reproductible. Le travail pedagogique consiste a maitriser chacune de ces briques *et* leur composition : ou s'arrete le LLM, ou commence le verificateur formel, comment une boucle informel/formel converge vers un verdict.
+Cette série pose une question concrète : peut-on construire un pipeline qui prend un texte argumentatif en entrée et qui en restitue une carte logique formelle, validée par un solveur SAT, avec détection systématique des sophismes connus ? La réponse passe par un assemblage soigné de trois compétences distinctes : un LLM pour extraire le tissu argumentatif informel (prémisses, conclusions, transitions), un solveur logique (TweetyProject, Java via JPype) pour vérifier la cohérence des formalisations propositionnelles obtenues, et une couche d'orchestration agentique (Semantic Kernel) qui transforme cette chaîne en pipeline reproductible. Le travail pédagogique consiste à maîtriser chacune de ces briques *et* leur composition : où s'arrête le LLM, où commence le vérificateur formel, comment une boucle informel/formel converge vers un verdict.
 
-Le contexte de recherche actuel rend cette competence particulierement pertinente. Les frameworks de raisonnement structure (ASPIC+, ABA, DeLP) sont implementes en JVM et accessibles via les memes ponts JPype que ceux utilises ici. Les LLMs de 2025-2026 sont assez fiables pour la phase d'extraction informelle mais restent faibles sur la verification formelle, ce qui motive precisement le pattern hybride documente dans la serie. Les ponts vers [Tweety](../Tweety/) (semantiques de Dung, revision de croyances AGM, preferences de Tweety-9) et [Lean](../Lean/) (preuves formelles, tactiques) permettent d'aller plus loin pour qui veut depasser la simple verification SAT.
+Le contexte de recherche actuel rend cette compétence particulièrement pertinente. Les frameworks de raisonnement structuré (ASPIC+, ABA, DeLP) sont implémentés en JVM et accessibles via les mêmes ponts JPype que ceux utilisés ici. Les LLMs de 2025-2026 sont assez fiables pour la phase d'extraction informelle mais restent faibles sur la vérification formelle, ce qui motive précisément le pattern hybride documenté dans la série. Les ponts vers [Tweety](../Tweety/) (sémantiques de Dung, révision de croyances AGM, préférences de Tweety-9) et [Lean](../Lean/) (preuves formelles, tactiques) permettent d'aller plus loin pour qui veut dépasser la simple vérification SAT.
 
-**A qui s'adresse cette serie** : enseignants en pensee critique, equipes editoriales construisant des outils de fact-checking, etudiants en philosophie computationnelle ou en linguistique formelle, et ingenieurs explorant les architectures hybrides LLM + solveur. La maitrise prealable supposee est moderee : Python intermediate, intuition logique propositionnelle, familiarite minimale avec les LLMs et l'OpenAI API. Les notebooks (~4-5h total) s'enchainent dans l'ordre 0 → 1 → 2 → 3, avec l'`Executor` comme point d'entree pour une execution batch reproducible (Papermill / MCP).
+**À qui s'adresse cette série** : enseignants en pensée critique, équipes éditoriales construisant des outils de fact-checking, étudiants en philosophie computationnelle ou en linguistique formelle, et ingénieurs explorant les architectures hybrides LLM + solveur. La maîtrise préalable supposée est modérée : Python intermediate, intuition logique propositionnelle, familiarité minimale avec les LLMs et l'OpenAI API. Les notebooks (~4-5h total) s'enchaînent dans l'ordre 0 → 1 → 2 → 3, avec l'`Executor` comme point d'entrée pour une exécution batch reproductible (Papermill / MCP).
 
 ## Vue d'ensemble
 
@@ -25,62 +25,62 @@ Le contexte de recherche actuel rend cette competence particulierement pertinent
 |-------------|--------|
 | Notebooks | 6 |
 | Kernel | Python 3 |
-| Duree estimee | ~4-5h |
+| Durée estimée | ~4-5h |
 | API requise | OpenAI |
 
 ## Notebooks
 
-| # | Notebook | Contenu | Role |
+| # | Notebook | Contenu | Rôle |
 |---|----------|---------|------|
 | 0 | [Agentic-0-init](Argument_Analysis_Agentic-0-init.ipynb) | Configuration, chargement API | Setup |
-| 1 | [Agentic-1-informal_agent](Argument_Analysis_Agentic-1-informal_agent.ipynb) | Agent analyse informelle | Detection d'arguments |
+| 1 | [Agentic-1-informal_agent](Argument_Analysis_Agentic-1-informal_agent.ipynb) | Agent analyse informelle | Détection d'arguments |
 | 2 | [Agentic-2-pl_agent](Argument_Analysis_Agentic-2-pl_agent.ipynb) | Agent logique propositionnelle | Formalisation |
 | 3 | [Agentic-3-orchestration](Argument_Analysis_Agentic-3-orchestration.ipynb) | Orchestration multi-agents | Coordination |
 | UI | [UI_configuration](Argument_Analysis_UI_configuration.ipynb) | Interface utilisateur widgets | Interaction |
-| Exec | [Executor](Argument_Analysis_Executor.ipynb) | Orchestrateur principal | Execution |
+| Exec | [Executor](Argument_Analysis_Executor.ipynb) | Orchestrateur principal | Exécution |
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, vous serez capable de :
+À l'issue de cette série, vous serez capable de :
 
-1. **Extraire le tissu argumentatif** d'un texte en identifiant premisses, conclusions et transitions a l'aide d'un agent LLM (Semantic Kernel)
-2. **Formaliser des arguments** en logique propositionnelle et verifier leur coherence avec un solveur SAT (TweetyProject)
-3. **Detecter les sophismes** courants (homme de paille, faux dilemme, ad hominem, appel a l'autorite) de maniere systematique
+1. **Extraire le tissu argumentatif** d'un texte en identifiant prémisses, conclusions et transitions à l'aide d'un agent LLM (Semantic Kernel)
+2. **Formaliser des arguments** en logique propositionnelle et vérifier leur cohérence avec un solveur SAT (TweetyProject)
+3. **Détecter les sophismes** courants (homme de paille, faux dilemme, ad hominem, appel à l'autorité) de manière systématique
 4. **Orchestrer un pipeline multi-agents** combinant extraction informelle, formalisation logique et validation formelle
 5. **Comparer les approches** LLM-only vs hybride (LLM + solveur formel) et comprendre les limites de chaque couche
 
 ## Ce que chaque notebook apporte
 
-| Notebook | Competence clee | Temps |
+| Notebook | Compétence clé | Temps |
 |----------|----------------|-------|
-| **0-init** | Configurer l'environnement Python + Java, charger les cles API, verifier la connexion Tweety/JVM | 30 min |
+| **0-init** | Configurer l'environnement Python + Java, charger les clés API, vérifier la connexion Tweety/JVM | 30 min |
 | **1-informal_agent** | Construire un agent LLM qui identifie et annote les arguments dans un texte naturel | 60 min |
-| **2-pl_agent** | Convertir les arguments informels en formules propositionnelles et les verifier via SAT | 60 min |
-| **3-orchestration** | Composer les agents precedents en pipeline coordonne avec rapport de sortie structure | 50 min |
-| **UI_configuration** | Creer une interface interactive (ipywidgets) pour piloter le pipeline en mode exploratoire | 30 min |
-| **Executor** | Executer le pipeline complet en mode batch (Papermill/MCP) avec configuration .env | 20 min |
+| **2-pl_agent** | Convertir les arguments informels en formules propositionnelles et les vérifier via SAT | 60 min |
+| **3-orchestration** | Composer les agents précédents en pipeline coordonné avec rapport de sortie structuré | 50 min |
+| **UI_configuration** | Créer une interface interactive (ipywidgets) pour piloter le pipeline en mode exploratoire | 30 min |
+| **Executor** | Exécuter le pipeline complet en mode batch (Papermill/MCP) avec configuration .env | 20 min |
 
 ## FAQ / Troubleshooting
 
-| Probleme | Solution |
+| Problème | Solution |
 |----------|----------|
-| **`ModuleNotFoundError: semantic_kernel`** | `pip install semantic-kernel`. Verifier le kernel Jupyter actif (`jupyter kernelspec list`). |
-| **`OPENAI_API_KEY not set`** | Copier `.env.example` en `.env` et renseigner la cle. Verifier que le notebook 0 charge bien le `.env`. |
-| **`JVM not found`** au demarrage | JDK 17+ requis. Executer `python install_jdk_portable.py` dans le repertoire. |
-| **`FileNotFoundException` sur un JAR Tweety** | Les JARs doivent etre dans `libs/`. Re-executer le notebook 0 qui les telecharge. |
-| **`BATCH_MODE` ignore** | Verifier que `.env` contient `BATCH_MODE="true"` (avec guillemets) et que le fichier est au meme niveau que les notebooks. |
-| **Erreur `dotnet` ou `.NET`** | Cette serie est 100% Python. Seul Semantic Kernel (package Python) est utilise, pas le SDK .NET. |
-| **Sortie `PARTIAL_VALIDATED`** | Le pipeline n'a pas convergé. Verifier les logs de l'agent PL (formalisation incomplete). Relancer avec un texte plus court. |
-| **`OutOfMemoryError` JVM** | Augmenter le heap dans la cellule de demarrage : ajouter `-Xmx2g` aux arguments JPype. |
+| **`ModuleNotFoundError: semantic_kernel`** | `pip install semantic-kernel`. Vérifier le kernel Jupyter actif (`jupyter kernelspec list`). |
+| **`OPENAI_API_KEY not set`** | Copier `.env.example` en `.env` et renseigner la clé. Vérifier que le notebook 0 charge bien le `.env`. |
+| **`JVM not found`** au démarrage | JDK 17+ requis. Exécuter `python install_jdk_portable.py` dans le répertoire. |
+| **`FileNotFoundException` sur un JAR Tweety** | Les JARs doivent être dans `libs/`. Re-exécuter le notebook 0 qui les télécharge. |
+| **`BATCH_MODE` ignoré** | Vérifier que `.env` contient `BATCH_MODE="true"` (avec guillemets) et que le fichier est au même niveau que les notebooks. |
+| **Erreur `dotnet` ou `.NET`** | Cette série est 100% Python. Seul Semantic Kernel (package Python) est utilisé, pas le SDK .NET. |
+| **Sortie `PARTIAL_VALIDATED`** | Le pipeline n'a pas convergé. Vérifier les logs de l'agent PL (formalisation incomplète). Relancer avec un texte plus court. |
+| **`OutOfMemoryError` JVM** | Augmenter le heap dans la cellule de démarrage : ajouter `-Xmx2g` aux arguments JPype. |
 
 ## Quel parcours choisir ?
 
-| Profil | Parcours recommande | Notebooks |
+| Profil | Parcours recommandé | Notebooks |
 |--------|-------------------|-----------|
-| **Decouvreur de l'analyse argumentative** | Pipeline complet en ordre | 0 → 1 → 2 → 3 (~3h) |
-| **Enseignant en pensee critique** | Extraction + detection sophismes | 0 → 1 → UI_configuration (~1h30) |
-| **Ingenieur ML/LLM** | Architecture multi-agents | 0 → 3 → Executor (~1h30) |
-| **Chercheur en logique formelle** | Formalisation + verification SAT | 0 → 2 (~1h) |
+| **Découvreur de l'analyse argumentative** | Pipeline complet en ordre | 0 → 1 → 2 → 3 (~3h) |
+| **Enseignant en pensée critique** | Extraction + détection sophismes | 0 → 1 → UI_configuration (~1h30) |
+| **Ingénieur ML/LLM** | Architecture multi-agents | 0 → 3 → Executor (~1h30) |
+| **Chercheur en logique formelle** | Formalisation + vérification SAT | 0 → 2 (~1h) |
 
 ---
 
@@ -110,29 +110,29 @@ A l'issue de cette serie, vous serez capable de :
 
 1. **Extraction** - Identification des arguments dans le texte
 2. **Formalisation** - Conversion en logique propositionnelle
-3. **Validation** - Verification coherence via Tweety
-4. **Evaluation** - Detection de sophismes et faiblesses
-5. **Rapport** - Generation conclusion structuree
+3. **Validation** - Vérification cohérence via Tweety
+4. **Évaluation** - Détection de sophismes et faiblesses
+5. **Rapport** - Génération conclusion structurée
 
 ## Domaines d'application
 
-L'analyse argumentative outillee s'inscrit dans plusieurs cas concrets ou la distinction "argument valide / sophisme" doit etre rendue automatique ou semi-automatique :
+L'analyse argumentative outillée s'inscrit dans plusieurs cas concrets où la distinction "argument valide / sophisme" doit être rendue automatique ou semi-automatique :
 
-- **Moderation de discussions en ligne** : detection des sophismes recurrents (homme de paille, faux dilemmes, glissement, ad hominem) dans des fils de commentaires longs, avec un rapport agrege par utilisateur ou par fil. Le pattern LLM-extracteur + verificateur formel est calibre precisement pour cet usage.
-- **Fact-checking et journalisme assiste** : decomposition d'un editorial ou d'un discours politique en chaine de premisses et conclusions, marquage des transitions logiquement faibles, identification des affirmations factuelles a verifier externement. La phase "formalisation" cree un livrable inspectable, contrairement aux jugements opaques d'un LLM seul.
-- **Education a la pensee critique** : production d'exercices d'analyse a partir de textes reels (discours, essais, posts), avec correction automatisee partielle. L'enseignant valide la decomposition, l'eleve apprend a justifier chaque etape.
-- **Audit de contenus IA** : verification de la coherence interne des reponses LLM longues sur sujets sensibles (medical, juridique, financier). Un LLM peut produire un raisonnement plausible mais incoherent ; le solveur formel detecte les contradictions internes.
-- **Recherche en argumentation structuree** : terrain experimental pour les frameworks Dung, ASPIC+, ABA, accessibles via les ponts Tweety. La serie sert de support a des explorations academiques (memoires, theses) sur les semantiques d'acceptabilite, la revision de croyances AGM, ou les preferences entre arguments.
+- **Modération de discussions en ligne** : détection des sophismes récurrents (homme de paille, faux dilemmes, glissement, ad hominem) dans des fils de commentaires longs, avec un rapport agrégé par utilisateur ou par fil. Le pattern LLM-extracteur + vérificateur formel est calibré précisément pour cet usage.
+- **Fact-checking et journalisme assisté** : décomposition d'un éditorial ou d'un discours politique en chaîne de prémisses et conclusions, marquage des transitions logiquement faibles, identification des affirmations factuelles à vérifier externellement. La phase "formalisation" crée un livrable inspectable, contrairement aux jugements opaques d'un LLM seul.
+- **Éducation à la pensée critique** : production d'exercices d'analyse à partir de textes réels (discours, essais, posts), avec correction automatisée partielle. L'enseignant valide la décomposition, l'élève apprend à justifier chaque étape.
+- **Audit de contenus IA** : vérification de la cohérence interne des réponses LLM longues sur sujets sensibles (médical, juridique, financier). Un LLM peut produire un raisonnement plausible mais incohérent ; le solveur formel détecte les contradictions internes.
+- **Recherche en argumentation structurée** : terrain expérimental pour les frameworks Dung, ASPIC+, ABA, accessibles via les ponts Tweety. La série sert de support à des explorations académiques (mémoires, thèses) sur les sémantiques d'acceptabilité, la révision de croyances AGM, ou les préférences entre arguments.
 
 ## Mode batch
 
-Pour execution automatisee (Papermill/MCP) :
+Pour exécution automatisée (Papermill/MCP) :
 
 ```bash
 # Dans .env
 BATCH_MODE="true"
-# Optionnel : texte personnalise
-# BATCH_TEXT="Votre texte a analyser..."
+# Optionnel : texte personnalisé
+# BATCH_TEXT="Votre texte à analyser..."
 ```
 
 ## Technologies
@@ -147,18 +147,18 @@ BATCH_MODE="true"
 ## Quick Start
 
 ```bash
-# 1. Installer les dependances Python
+# 1. Installer les dépendances Python
 pip install semantic-kernel openai python-dotenv jpype1
 
 # 2. Configurer les API keys
 cp .env.example .env
-# Editer .env : OPENAI_API_KEY, BATCH_MODE=true
+# Éditer .env : OPENAI_API_KEY, BATCH_MODE=true
 
 # 3. Lancer le premier notebook
 jupyter notebook Argument_Analysis_Agentic-0-init.ipynb
 ```
 
-> **Note** : JDK 17+ est requis mais auto-telecharge via `install_jdk_portable.py` (pas d'installation systeme).
+> **Note** : JDK 17+ est requis mais auto-télécharge via `install_jdk_portable.py` (pas d'installation système).
 
 ---
 
@@ -172,7 +172,7 @@ pip install semantic-kernel openai python-dotenv jpype1
 
 ### Java
 
-JDK 17+ requis (auto-telecharge via `install_jdk_portable.py`).
+JDK 17+ requis (auto-télécharge via `install_jdk_portable.py`).
 
 ### Configuration
 
@@ -190,18 +190,18 @@ Argument_Analysis/
 ├── *.ipynb                    # 6 notebooks
 ├── .env / .env.example        # Configuration
 ├── install_jdk_portable.py    # Installation JDK
-├── data/                      # Donnees (taxonomie sophismes)
+├── data/                      # Données (taxonomie sophismes)
 ├── ext_tools/                 # Outils externes
-├── jdk-17-portable/           # JDK (ignore git)
+├── jdk-17-portable/           # JDK (ignoré git)
 ├── libs/                      # JARs Tweety
 ├── ontologies/                # Ontologies OWL
-├── output/                    # Resultats analyses
+├── output/                    # Résultats analyses
 └── resources/                 # Ressources Tweety
 ```
 
 ## Sortie
 
-Le pipeline genere un rapport JSON dans `output/analysis_report.json` :
+Le pipeline génère un rapport JSON dans `output/analysis_report.json` :
 
 ```json
 {
@@ -217,37 +217,37 @@ Le pipeline genere un rapport JSON dans `output/analysis_report.json` :
 }
 ```
 
-## Concepts cles
+## Concepts clés
 
 | Concept | Description |
 |---------|-------------|
-| **Argument** | Premisses + Conclusion |
+| **Argument** | Prémisses + Conclusion |
 | **Sophisme** | Raisonnement fallacieux |
-| **Belief Set** | Ensemble de croyances formalisees |
-| **SAT** | Satisfaisabilite logique |
+| **Belief Set** | Ensemble de croyances formalisées |
+| **SAT** | Satisfaisabilité logique |
 
-## Ponts avec les autres series
+## Ponts avec les autres séries
 
-| Serie | Connection | Details |
+| Série | Connexion | Détails |
 | ----- | ---------- | ------- |
-| **[Tweety](../Tweety/)** | Backend argumentatif | Utilise directement TweetyProject (JPype) pour le raisonnement formel. Les semantiques de Dung (Tweety-5) et la revision de croyances (Tweety-4) sont au coeur du pipeline. |
-| **[Lean](../Lean/)** | Preuves formelles | La formalisation logique des arguments (Agentic-2) suit le meme paradigme que les tactiques Lean. La verification de coherence via SAT est analogue aux proof checkers. |
-| **[Tweety-9](../Tweety/Tweety-9-Preferences.ipynb)** | Preferences et vote | L'analyse d'arguments de valeur croise les modeles de preference et la theorie du choix social (GameTheory/social_choice_lean/). |
+| **[Tweety](../Tweety/)** | Backend argumentatif | Utilise directement TweetyProject (JPype) pour le raisonnement formel. Les sémantiques de Dung (Tweety-5) et la révision de croyances (Tweety-4) sont au cœur du pipeline. |
+| **[Lean](../Lean/)** | Preuves formelles | La formalisation logique des arguments (Agentic-2) suit le même paradigme que les tactiques Lean. La vérification de cohérence via SAT est analogue aux proof checkers. |
+| **[Tweety-9](../Tweety/Tweety-9-Preferences.ipynb)** | Préférences et vote | L'analyse d'arguments de valeur croise les modèles de préférence et la théorie du choix social (GameTheory/social_choice_lean/). |
 
-[La mer qui monte](../../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du depot — l'analyse d'argumentation comme changement de representation vers le verifiable : du langage naturel aux semantiques formelles qu'on peut interroger.
+[La mer qui monte](../../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du dépôt — l'analyse d'argumentation comme changement de représentation vers le vérifiable : du langage naturel aux sémantiques formelles qu'on peut interroger.
 
-> **Note** : Cette serie est en statut DRAFT — les notebooks definissent l'architecture mais n'ont pas encore d'execution complete. Voir [RECONSTRUCTION_PLAN.md](RECONSTRUCTION_PLAN.md) pour le statut.
+> **Note** : Cette série est en statut DRAFT — les notebooks définissent l'architecture mais n'ont pas encore d'exécution complète. Voir [RECONSTRUCTION_PLAN.md](RECONSTRUCTION_PLAN.md) pour le statut.
 
 ## Ressources
 
-### References academiques
+### Références académiques
 
-| Reference | Couverture |
+| Référence | Couverture |
 |-----------|------------|
-| Dung, "On the Acceptability of Arguments and its Fundamental Role in Nonmonotonic Reasoning" (1995) | Argumentation abstraite, semantiques |
-| Modgil & Prakken, "The ASPIC+ Framework for Structured Argumentation" (2014) | Argumentation structuree |
-| Alchourron, Gardenfors & Makinson, "On the Logic of Theory Change" (1985) | Revision de croyances AGM |
-| Besnard & Hunter, *Elements of Argumentation* (2008) | Cadre general argumentation |
+| Dung, "On the Acceptability of Arguments and its Fundamental Role in Nonmonotonic Reasoning" (1995) | Argumentation abstraite, sémantiques |
+| Modgil & Prakken, "The ASPIC+ Framework for Structured Argumentation" (2014) | Argumentation structurée |
+| Alchourron, Gardenfors & Makinson, "On the Logic of Theory Change" (1985) | Révision de croyances AGM |
+| Besnard & Hunter, *Elements of Argumentation* (2008) | Cadre général argumentation |
 | Walton, *Argumentation Schemes for Presumptive Reasoning* (1996) | Taxonomie des sophismes |
 
 ### Ressources en ligne

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts Lean
 
-Ce repertoire contient les scripts de configuration, validation et maintenance pour les notebooks Lean.
+Ce répertoire contient les scripts de configuration, validation et maintenance pour les notebooks Lean.
 
 ## Structure
 
@@ -33,11 +33,11 @@ python scripts/validate_lean_setup.py
 python scripts/validate_lean_setup.py --wsl
 ```
 
-**Verifie** : Python, elan, Lean 4, Lake, packages (lean4-jupyter, openai, anthropic), kernels Jupyter, .env, lean_runner.py
+**Vérifie** : Python, elan, Lean 4, Lake, packages (lean4-jupyter, openai, anthropic), kernels Jupyter, .env, lean_runner.py
 
 ### verify_lean.py
 
-Verification complete avec execution de notebooks.
+Vérification complète avec exécution de notebooks.
 
 ```bash
 # Verification rapide (structure uniquement)
@@ -85,7 +85,7 @@ python scripts/notebook_utils.py get-output ../Lean-9-SK-Multi-Agents.ipynb 39
 
 ### demo_manager.py
 
-Gestion centralisee des demonstrations Lean-9.
+Gestion centralisée des démonstrations Lean-9.
 
 ```bash
 # Afficher la configuration actuelle
@@ -101,7 +101,7 @@ python scripts/demo_manager.py update --dry-run
 python scripts/demo_manager.py reorder 2 3
 ```
 
-**Pour modifier les DEMOs** : Editer `DEFAULT_DEMOS` dans `demo_manager.py`, puis executer `update`.
+**Pour modifier les DEMOs** : Éditer `DEFAULT_DEMOS` dans `demo_manager.py`, puis exécuter `update`.
 
 ### setup_wsl_python.sh
 
@@ -115,11 +115,11 @@ bash scripts/setup_wsl_python.sh
 
 ### lean4-kernel-wrapper.py
 
-Wrapper pour le kernel Lean4 via WSL. Utilise automatiquement par Jupyter.
+Wrapper pour le kernel Lean4 via WSL. Utilisé automatiquement par Jupyter.
 
 ## Utilisation Typique
 
-### Premiere Installation
+### Première Installation
 
 ```bash
 # 1. Ouvrir et executer Lean-1-Setup.ipynb (toutes les cellules)
@@ -134,7 +134,7 @@ bash scripts/setup_wsl_python.sh
 python scripts/validate_lean_setup.py --wsl
 ```
 
-### Verification Quotidienne
+### Vérification Quotidienne
 
 ```bash
 # Verifier que tout est OK avant de lancer les notebooks
@@ -171,14 +171,14 @@ python -m pytest scripts/tests/test_leandojo_basic.py
 
 ## Archive
 
-Le dossier `archive/` contient 32 scripts temporaires utilises pendant le developpement :
+Le dossier `archive/` contient 32 scripts temporaires utilisés pendant le développement :
 
 - `fix_*.py` - Corrections ponctuelles
 - `update_demos_*.py` - Anciennes versions de demo_manager
 - `test_*.py` - Tests ponctuels
 - Autres scripts one-shot
 
-Ces scripts sont conserves pour reference mais ne sont plus necessaires.
+Ces scripts sont conservés pour référence mais ne sont plus nécessaires.
 
 ## Structure du Projet
 
@@ -195,10 +195,10 @@ MyIA.AI.Notebooks/SymbolicAI/Lean/
 ├── Lean-9-SK-Multi-Agents.ipynb    # Python WSL requis
 ├── lean_runner.py                  # Backend Python pour Lean
 ├── .env                            # Configuration API
-└── scripts/                        # CE REPERTOIRE
+└── scripts/                        # CE RÉPERTOIRE
 ```
 
-## Dependances Python
+## Dépendances Python
 
 ### Windows (kernel Python standard)
 
@@ -209,7 +209,7 @@ MyIA.AI.Notebooks/SymbolicAI/Lean/
 
 ### WSL (kernel Python 3 WSL)
 
-- Installees dans `~/.python3-wsl-venv/`
+- Installées dans `~/.python3-wsl-venv/`
 - `ipykernel` - Kernel Jupyter
 - `python-dotenv` - Chargement .env
 - `openai` - API OpenAI
@@ -238,7 +238,7 @@ Tous les composants OK (12/12)
 
 ## Troubleshooting
 
-### anthropic non installe
+### anthropic non installé
 
 ```bash
 pip install anthropic
@@ -251,7 +251,7 @@ rm -rf ~/.python3-wsl-venv
 bash scripts/setup_wsl_python.sh
 ```
 
-### Kernel Python 3 (WSL) ne demarre pas
+### Kernel Python 3 (WSL) ne démarre pas
 
 ```bash
 # Verifier les logs wrapper
@@ -261,7 +261,7 @@ wsl cat ~/.python3-wrapper.log
 python scripts/validate_lean_setup.py
 ```
 
-### .env non charge dans notebooks 7-9
+### .env non chargé dans notebooks 7-9
 
 ```bash
 wsl ~/.python3-wsl-venv/bin/python3 -c "import dotenv; print(dotenv.__version__)"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -7,20 +7,20 @@ breakdown: Planners=13
 maturity: PRODUCTION=13
 -->
 
-Cette série de notebooks introduit la **Planification Automatique**, une branche fondamentale de l'IA qui génère des sequences d'actions pour atteindre des objectifs.
+Cette série de notebooks introduit la **Planification Automatique**, une branche fondamentale de l'IA qui génère des séquences d'actions pour atteindre des objectifs.
 
-La planification répond a une question differente de celle de l'apprentissage : non pas « que predire ? » mais « **que faire ?** ». A partir d'un modele du monde — un etat initial, des actions avec leurs preconditions et effets, un but — un planificateur cherche automatiquement une suite d'actions qui mene au but. C'est une technologie éprouvée : elle pilote des robots (manipulation, navigation), optimise la logistique et l'ordonnancement, et a dirige des engins spatiaux autonomes (Remote Agent sur Deep Space 1, planification d'activites des rovers martiens). Le langage **PDDL** a standardise la maniere de décrire ces problemes, donnant naissance a tout un ecosysteme de solveurs comparables. La planification connaît aujourd'hui un regain d'intérêt avec les LLMs, comme moyen de doter les modeles de langage d'une capacite d'action verifiable et orientee vers un but.
+La planification répond à une question différente de celle de l'apprentissage : non pas « que prédire ? » mais « **que faire ?** ». À partir d'un modèle du monde — un état initial, des actions avec leurs préconditions et effets, un but — un planificateur cherche automatiquement une suite d'actions qui mène au but. C'est une technologie éprouvée : elle pilote des robots (manipulation, navigation), optimise la logistique et l'ordonnancement, et a dirigé des engins spatiaux autonomes (Remote Agent sur Deep Space 1, planification d'activités des rovers martiens). Le langage **PDDL** a standardisé la manière de décrire ces problèmes, donnant naissance à tout un écosystème de solveurs comparables. La planification connaît aujourd'hui un regain d'intérêt avec les LLMs, comme moyen de doter les modèles de langage d'une capacité d'action vérifiable et orientée vers un but.
 
 **13 notebooks** | **5 parties** | **~8h**
 
-**A qui s'adresse cette série** : étudiants en IA, ingenieurs en robotique et logistique, développeurs souhaitant intégrer la planification symbolique dans leurs applications. Aucun prerequis en planification : les concepts sont introduits progressivement depuis les fondements STRIPS jusqu'aux approches neuro-symboliques modernes.
+**À qui s'adresse cette série** : étudiants en IA, ingénieurs en robotique et logistique, développeurs souhaitant intégrer la planification symbolique dans leurs applications. Aucun prérequis en planification : les concepts sont introduits progressivement depuis les fondements STRIPS jusqu'aux approches neuro-symboliques modernes.
 
 ## Vue d'ensemble
 
 | Statistique | Valeur |
 |-------------|--------|
 | Notebooks | 13 (1 setup + 3 foundation + 3 classical + 3 advanced + 3 neuro-symbolic) |
-| Duree totale | ~8h |
+| Durée totale | ~8h |
 | Langage | Python 3.9+ |
 | Kernel | Python 3 |
 | Solveurs | Fast Downward, OR-Tools CP-SAT, unified-planning |
@@ -30,31 +30,31 @@ La planification répond a une question differente de celle de l'apprentissage :
 
 ### Phase 1 : Fondations (Notebooks 1-3, ~2h)
 
-La série débute par le notebook Setup (0) qui configure automatiquement l'environnement : installation de `unified-planning`, OR-Tools, verification de Docker et lancement du conteneur Fast Downward. Le notebook 1 (Introduction) présente le triptyque fondamental Etat-Action-But, le modele STRIPS (1971) avec ses hypotheses — statique, deterministe, observable, discret, instantane — et le contexte historique depuis Fikes & Nilsson jusqu'aux LLMs modernes. Le notebook 2 (PDDL-Basics) plonge dans la syntaxe PDDL : domaines, problemes, types, predicats, actions, preconditions et effets. Le notebook 3 (State-Space) explore l'explosion combinatoire ($O(2^n)$ predicats) et la necessite des heuristiques pour guider la recherche dans l'espace d'etats. A l'issue de cette phase, vous savez modeliser un probleme en PDDL et comprendre pourquoi la recherche aveugle ne suffit pas.
+La série débute par le notebook Setup (0) qui configure automatiquement l'environnement : installation de `unified-planning`, OR-Tools, vérification de Docker et lancement du conteneur Fast Downward. Le notebook 1 (Introduction) présente le triptyque fondamental État-Action-But, le modèle STRIPS (1971) avec ses hypothèses — statique, déterministe, observable, discret, instantané — et le contexte historique depuis Fikes & Nilsson jusqu'aux LLMs modernes. Le notebook 2 (PDDL-Basics) plonge dans la syntaxe PDDL : domaines, problèmes, types, prédicats, actions, préconditions et effets. Le notebook 3 (State-Space) explore l'explosion combinatoire ($O(2^n)$ prédicats) et la nécessité des heuristiques pour guider la recherche dans l'espace d'états. À l'issue de cette phase, vous savez modéliser un problème en PDDL et comprendre pourquoi la recherche aveugle ne suffit pas.
 
 ### Phase 2 : Planification Classique (Notebooks 4-6, ~3h)
 
-Les notebooks 4 a 6 constituent le coeur technique de la série. Le notebook 4 (Fast-Downward) présente l'architecture en trois étapes de Fast Downward (translator PDDL→SAS+, preprocessor C++, search C++) et montre comment l'executer via Docker et unified-planning. Les algorithmes de recherche (A*, Greedy, EHC) y sont testes sur Blocks World et Logistics. Le notebook 5 (Heuristics) approfondit la theorie : classification admissible/non-admissible ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), comparaison expérimentale des heuristiques sur le nombre de noeuds expanses, et guide de selection. Le notebook 6 (Domains) couvre les domaines standards de l'IPC (Blocks World, Logistics, Gripper, Satellite) avec des problemes de complexite croissante. A l'issue, vous pouvez configurer un planificateur optimal, choisir l'heuristique adequat, et modeliser n'importe quel domaine IPC.
+Les notebooks 4 à 6 constituent le cœur technique de la série. Le notebook 4 (Fast-Downward) présente l'architecture en trois étapes de Fast Downward (translator PDDL→SAS+, preprocessor C++, search C++) et montre comment l'exécuter via Docker et unified-planning. Les algorithmes de recherche (A*, Greedy, EHC) y sont testés sur Blocks World et Logistics. Le notebook 5 (Heuristics) approfondit la théorie : classification admissible/non-admissible ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), comparaison expérimentale des heuristiques sur le nombre de nœuds expansés, et guide de sélection. Le notebook 6 (Domains) couvre les domaines standards de l'IPC (Blocks World, Logistics, Gripper, Satellite) avec des problèmes de complexité croissante. À l'issue, vous pouvez configurer un planificateur optimal, choisir l'heuristique adéquate, et modéliser n'importe quel domaine IPC.
 
 ### Phase 3 : Approches Avancees (Notebooks 7-9, ~3h)
 
-La planification classique epuise ses limites des que les problemes deviennent trop grands pour l'exploration d'etats. Les notebooks 7 a 6 proposent des alternatives. Le notebook 7 (OR-Tools) introduce la programmation par contraintes avec CP-SAT de Google OR-Tools : modelisation de contraintes (all-different, cumulative, table), scheduling, et optimisation multi-objectif. Le notebook 8 (Temporal) etend au domaine temporel avec PDDL 2.1 : durées d'actions, parallelisme, contraintes temporelles simples et denses, ordonnancement de taches. Le notebook 9 (HTN) présente la planification hierarchique (Task Networks) : taches primitives vs abstraites, méthodes de decomposition, langage HDDL, solveur inspire de SHOP2, et comparaison avec STRIPS. A l'issue, vous disposez de trois paradigmes complementaires pour les problemes qui depassent la planification classique.
+La planification classique épuise ses limites dès que les problèmes deviennent trop grands pour l'exploration d'états. Les notebooks 7 à 9 proposent des alternatives. Le notebook 7 (OR-Tools) introduit la programmation par contraintes avec CP-SAT de Google OR-Tools : modélisation de contraintes (all-different, cumulative, table), scheduling, et optimisation multi-objectif. Le notebook 8 (Temporal) étend au domaine temporel avec PDDL 2.1 : durées d'actions, parallélisme, contraintes temporelles simples et denses, ordonnancement de tâches. Le notebook 9 (HTN) présente la planification hiérarchique (Task Networks) : tâches primitives vs abstraites, méthodes de décomposition, langage HDDL, solveur inspiré de SHOP2, et comparaison avec STRIPS. À l'issue, vous disposez de trois paradigmes complémentaires pour les problèmes qui dépassent la planification classique.
 
 ### Phase 4 : Neuro-Symbolique (Notebooks 10-12, ~3h)
 
-La dernière partie explore la frontier entre IA symbolique et apprentissage profond. Le notebook 10 (LLM-Planning) montre comment les Large Language Models peuvent genérer des plans a partir de descriptions en langage naturel, le prompting pour la planification, et le plan repair. Le notebook 11 (Unified-Planning) detaille l'interface unifiee `unified-planning` : connection a plusieurs solveurs en quelques lignes, comparaison croisée des performances, et portabilité du modele PDDL entre moteurs. Le notebook 12 (LOOP) introduit le paradigme **Learning to Plan** : architecture LOOP (state encoder, policy network, value network), encodage PDDL en tenseurs (one-hot, GNN), entraînement par imitation et renforcement, résultats sur benchmarks IPC (85.8% coverage), et comparison avec KRCL. Ce notebook conclut la série avec les tendances futures : foundation models, meta-learning, inverse reinforcement learning.
+La dernière partie explore la frontière entre IA symbolique et apprentissage profond. Le notebook 10 (LLM-Planning) montre comment les Large Language Models peuvent générer des plans à partir de descriptions en langage naturel, le prompting pour la planification, et le plan repair. Le notebook 11 (Unified-Planning) détaille l'interface unifiée `unified-planning` : connexion à plusieurs solveurs en quelques lignes, comparaison croisée des performances, et portabilité du modèle PDDL entre moteurs. Le notebook 12 (LOOP) introduit le paradigme **Learning to Plan** : architecture LOOP (state encoder, policy network, value network), encodage PDDL en tenseurs (one-hot, GNN), entraînement par imitation et renforcement, résultats sur benchmarks IPC (85.8% coverage), et comparaison avec KRCL. Ce notebook conclut la série avec les tendances futures : foundation models, meta-learning, inverse reinforcement learning.
 
 ### Parcours alternatifs
 
 #### Parcours rapide (4h, minimum viable)
 Pour découvrir l'essentiel rapidement :
-1. `0-Setup` (20 min) : installer et verifier l'environnement
+1. `0-Setup` (20 min) : installer et vérifier l'environnement
 2. `1-Introduction` (30 min) : comprendre les concepts
-3. `4-Fast-Downward` (45 min) : executer un vrai planificateur
+3. `4-Fast-Downward` (45 min) : exécuter un vrai planificateur
 4. `11-Unified-Planning` (40 min) : comparer les solveurs
 
-#### Parcours classique (5h, optimalite)
-Pour maitriser les planificateurs optimaux :
+#### Parcours classique (5h, optimalité)
+Pour maîtriser les planificateurs optimaux :
 1. `0-Setup` → `1-Introduction` → `2-PDDL-Basics` → `3-State-Space`
 2. `4-Fast-Downward` → `5-Heuristics` → `6-Domains`
 
@@ -64,31 +64,31 @@ Pour les applications de planification par contraintes et temporelles :
 2. `7-OR-Tools` → `8-Temporal` → `9-HTN`
 
 #### Parcours neuro-symbolique (5h, recherche)
-Pour les approches combinees apprentissage profond + symbolique :
+Pour les approches combinées apprentissage profond + symbolique :
 1. `0-Setup` → `1-Introduction` → `4-Fast-Downward`
 2. `10-LLM-Planning` → `11-Unified-Planning` → `12-LOOP`
 
 ## Quel parcours choisir ?
 
 ### Si vous débutez en planification
-**Commencez par les fondations.** Le notebook 1 (Introduction) pose le vocabulaire (etat, action, but, STRIPS) et le contexte historique. Le notebook 2 (PDDL-Basics) apprend la syntaxe standard du domaine. Sans ces bases, les notebooks suivants seront difficiles a suivre.
+**Commencez par les fondations.** Le notebook 1 (Introduction) pose le vocabulaire (état, action, but, STRIPS) et le contexte historique. Le notebook 2 (PDDL-Basics) apprend la syntaxe standard du domaine. Sans ces bases, les notebooks suivants seront difficiles à suivre.
 
-**Passez a la planification classique quand :** vous avez un domaine PDDL defini et voulez trouver un plan optimal rapidement. Fast Downward + LM-cut est le choix par défaut.
+**Passez à la planification classique quand :** vous avez un domaine PDDL défini et voulez trouver un plan optimal rapidement. Fast Downward + LM-cut est le choix par défaut.
 
 ### Si vous venez de la recherche opérationnelle
-**Commencez par OR-Tools (notebook 7).** Le CP-SAT est familier aux optimiseurs : modelisation par contraintes, fonctions objectif, solveur commercial (ou open-source). La transition vers la planification est naturelle.
+**Commencez par OR-Tools (notebook 7).** Le CP-SAT est familier aux optimiseurs : modélisation par contraintes, fonctions objectif, solveur commercial (ou open-source). La transition vers la planification est naturelle.
 
-**Passez a PDDL quand :** vous avez besoin de la portabilité du modele (même domaine, solveurs multiples) ou que vous voulez exploiter les heuristiques specialisees de Fast Downward.
+**Passez à PDDL quand :** vous avez besoin de la portabilité du modèle (même domaine, solveurs multiples) ou que vous voulez exploiter les heuristiques spécialisées de Fast Downward.
 
 ### Si vous ne savez pas quoi choisir
 
-| Critere | Recommandation |
+| Critère | Recommandation |
 |---------|----------------|
 | Juste découvrir la planification | **Planners-0-Setup** + **Planners-1-Introduction** |
 | Un premier planificateur qui marche | **Planners-4-Fast-Downward** (Docker + Blocks World) |
 | Optimisation de scheduling | **Planners-7-OR-Tools** |
-| Planification hierarchique | **Planners-9-HTN** (SHOP2, decomposition) |
-| Frontier LLM + IA | **Planners-10-LLM-Planning** |
+| Planification hiérarchique | **Planners-9-HTN** (SHOP2, decomposition) |
+| Frontière LLM + IA | **Planners-10-LLM-Planning** |
 | Approche neuro-symbolique avancée | **Planners-12-LOOP** (85.8% IPC coverage) |
 | Comparer tous les solveurs | **Planners-11-Unified-Planning** |
 
@@ -102,7 +102,7 @@ SymbolicAI/Planners/
 ├── 01-Foundation/
 │   ├── Planners-1-Introduction.ipynb    # Concepts, STRIPS
 │   ├── Planners-2-PDDL-Basics.ipynb     # Syntaxe PDDL
-│   └── Planners-3-State-Space.ipynb     # Espaces d'etats
+│   └── Planners-3-State-Space.ipynb     # Espaces d'états
 ├── 02-Classical/
 │   ├── Planners-4-Fast-Downward.ipynb   # A*, heuristiques
 │   ├── Planners-5-Heuristics.ipynb      # h-add, h-max, h-FF
@@ -110,25 +110,25 @@ SymbolicAI/Planners/
 ├── 03-Advanced/
 │   ├── Planners-7-OR-Tools.ipynb        # CP-SAT
 │   ├── Planners-8-Temporal.ipynb        # Planification temporelle
-│   └── Planners-9-HTN.ipynb             # Planification hierarchique
+│   └── Planners-9-HTN.ipynb             # Planification hiérarchique
 ├── 04-NeuroSymbolic/
 │   ├── Planners-10-LLM-Planning.ipynb   # LLM + Planning
-│   ├── Planners-11-Unified-Planning.ipynb # Interface unifiee
+│   ├── Planners-11-Unified-Planning.ipynb # Interface unifiée
 │   └── Planners-12-LOOP.ipynb           # Learning to Plan
 └── archive/
-    └── Fast-Downward-Legacy.ipynb       # Version archivee
+    └── Fast-Downward-Legacy.ipynb       # Version archivée
 ```
 
 ## Objectifs d'apprentissage
 
 A l'issue de cette série, vous saurez :
 
-1. **Modeliser** des problemes de planification en PDDL (Planning Domain Definition Language)
+1. **Modéliser** des problèmes de planification en PDDL (Planning Domain Definition Language)
 2. **Utiliser** les planificateurs modernes (Fast Downward, OR-Tools, unified-planning)
 3. **Comprendre** les heuristiques de recherche ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut)
-4. **Etendre** la planification au temporel, hierarchique et neuro-symbolique
+4. **Étendre** la planification au temporel, hiérarchique et neuro-symbolique
 
-## Niveaux de difficulte
+## Niveaux de difficulté
 
 | Niveau | Description | Notebooks |
 |--------|-------------|-----------|
@@ -138,22 +138,22 @@ A l'issue de cette série, vous saurez :
 
 ## Contenu detaille des notebooks
 
-Chaque notebook introduit un concept ou modele spécifique. Le tableau ci-dessous resume en une ligne l'apport pédagogique de chacun — au-dela du titre, c'est le **concept cle** qu'il enseigne.
+Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun — au-delà du titre, c'est le **concept clé** qu'il enseigne.
 
 | # | Notebook | Apport pédagogique |
 |---|----------|-------------------|
-| 0 | Setup | Boucle environnement : verification Python → installation packages → Docker → premier PDDL |
-| 1 | Introduction | Triptyque Etat-Action-But, hypotheses STRIPS (1971), taxonomie des paradigmes |
-| 2 | PDDL-Basics | Syntaxe PDDL : domaines, problemes, types, predicats, actions, preconditions, effets |
-| 3 | State-Space | Explosion combinatoire $O(2^n)$, necessite des heuristiques, graphe d'etats |
+| 0 | Setup | Boucle environnement : vérification Python → installation packages → Docker → premier PDDL |
+| 1 | Introduction | Triptyque État-Action-But, hypothèses STRIPS (1971), taxonomie des paradigmes |
+| 2 | PDDL-Basics | Syntaxe PDDL : domaines, problèmes, types, prédicats, actions, préconditions, effets |
+| 3 | State-Space | Explosion combinatoire $O(2^n)$, nécessité des heuristiques, graphe d'états |
 | 4 | Fast-Downward | Architecture 3 étapes (translator/preprocessor/search), A* vs Greedy vs EHC via Docker |
-| 5 | Heuristics | Classification admissible/non-admissible : $h^{add}$, $h^{max}$, $h^{FF}$, LM-cut, comparison expériméntale |
+| 5 | Heuristics | Classification admissible/non-admissible : $h^{add}$, $h^{max}$, $h^{FF}$, LM-cut, comparaison expérimentale |
 | 6 | Domains | Domaines IPC standards (Blocks, Logistics, Gripper, Satellite), complexité croissante |
-| 7 | OR-Tools | CP-SAT, programmation par contraintes, modelisation de scheduling, contraintes alldifferent |
-| 8 | Temporal | PDDL 2.1, durations d'actions, parallelisme, contraintes temporelles, ordonnancement |
-| 9 | HTN | Planification hierarchique : taches primitives/abstraites, méthodes, HDDL, SHOP2 |
+| 7 | OR-Tools | CP-SAT, programmation par contraintes, modélisation de scheduling, contraintes alldifferent |
+| 8 | Temporal | PDDL 2.1, durées d'actions, parallélisme, contraintes temporelles, ordonnancement |
+| 9 | HTN | Planification hiérarchique : tâches primitives/abstraites, méthodes, HDDL, SHOP2 |
 | 10 | LLM-Planning | Planification avec LLMs, prompting, plan repair, limites et avantages |
-| 11 | Unified-Planning | Interface multi-solveurs, comparaison croisée, portabilité du modele |
+| 11 | Unified-Planning | Interface multi-solveurs, comparaison croisée, portabilité du modèle |
 | 12 | LOOP | Learning to Plan : state encoder, policy network, value network, 85.8% IPC coverage |
 
 ---
@@ -162,41 +162,41 @@ Chaque notebook introduit un concept ou modele spécifique. Le tableau ci-dessou
 
 ### Partie 0 : Environnement (00-Environment/)
 
-| # | Notebook | Kernel | Contenu | Duree |
+| # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
 | 0 | [Planners-0-Setup](00-Environment/Planners-0-Setup.ipynb) | Python | Installation unified-planning, OR-Tools, Docker Fast Downward | 20 min |
 
 ### Partie 1 : Fondations (01-Foundation/)
 
-| # | Notebook | Kernel | Contenu | Duree |
+| # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
-| 1 | [Planners-1-Introduction](01-Foundation/Planners-1-Introduction.ipynb) | Python | Concepts, modele STRIPS, triptyque Etat-Action-But | 30 min |
-| 2 | [Planners-2-PDDL-Basics](01-Foundation/Planners-2-PDDL-Basics.ipynb) | Python | Syntaxe PDDL, domaines, problemes, predicats, actions | 40 min |
-| 3 | [Planners-3-State-Space](01-Foundation/Planners-3-State-Space.ipynb) | Python | Espaces d'etats, graphes de recherche, explosion combinatoire | 35 min |
+| 1 | [Planners-1-Introduction](01-Foundation/Planners-1-Introduction.ipynb) | Python | Concepts, modèle STRIPS, triptyque État-Action-But | 30 min |
+| 2 | [Planners-2-PDDL-Basics](01-Foundation/Planners-2-PDDL-Basics.ipynb) | Python | Syntaxe PDDL, domaines, problèmes, prédicats, actions | 40 min |
+| 3 | [Planners-3-State-Space](01-Foundation/Planners-3-State-Space.ipynb) | Python | Espaces d'états, graphes de recherche, explosion combinatoire | 35 min |
 
 ### Partie 2 : Planification Classique (02-Classical/)
 
-| # | Notebook | Kernel | Contenu | Duree |
+| # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
 | 4 | [Planners-4-Fast-Downward](02-Classical/Planners-4-Fast-Downward.ipynb) | Python | Architecture FD, Docker, A*, GBFS, EHC, heuristiques | 45 min |
 | 5 | [Planners-5-Heuristics](02-Classical/Planners-5-Heuristics.ipynb) | Python | h-add, h-max, h-FF, landmarks | 40 min |
 | 6 | [Planners-6-Domains](02-Classical/Planners-6-Domains.ipynb) | Python | Blocks World, Logistics, Gripper, Ferry, Hanoi | 50 min |
 
-### Partie 3 : Approches Avancees (03-Advanced/)
+### Partie 3 : Approches Avancées (03-Advanced/)
 
-| # | Notebook | Kernel | Contenu | Duree |
+| # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
 | 7 | [Planners-7-OR-Tools](03-Advanced/Planners-7-OR-Tools.ipynb) | Python | CP-SAT, programmation par contraintes, scheduling | 45 min |
-| 8 | [Planners-8-Temporal](03-Advanced/Planners-8-Temporal.ipynb) | Python | PDDL 2.1, durées, parallelisme, ordonnancement | 40 min |
-| 9 | [Planners-9-HTN](03-Advanced/Planners-9-HTN.ipynb) | Python | Hierarchical Task Networks, méthodes, decomposition | 45 min |
+| 8 | [Planners-8-Temporal](03-Advanced/Planners-8-Temporal.ipynb) | Python | PDDL 2.1, durées, parallélisme, ordonnancement | 40 min |
+| 9 | [Planners-9-HTN](03-Advanced/Planners-9-HTN.ipynb) | Python | Hierarchical Task Networks, méthodes, décomposition | 45 min |
 
 ### Partie 4 : Neuro-Symbolique (04-NeuroSymbolic/)
 
-| # | Notebook | Kernel | Contenu | Duree |
+| # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
 | 10 | [Planners-10-LLM-Planning](04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb) | Python | LLMs pour la planification, prompting, plan repair | 50 min |
-| 11 | [Planners-11-Unified-Planning](04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb) | Python | Interface unifiee, multi-solveurs, comparaisons | 40 min |
-| 12 | [Planners-12-LOOP](04-NeuroSymbolic/Planners-12-LOOP.ipynb) | Python | Learning to Plan, modeles neuronaux pour heuristiques | 45 min |
+| 11 | [Planners-11-Unified-Planning](04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb) | Python | Interface unifiée, multi-solveurs, comparaisons | 40 min |
+| 12 | [Planners-12-LOOP](04-NeuroSymbolic/Planners-12-LOOP.ipynb) | Python | Learning to Plan, modèles neuronaux pour heuristiques | 45 min |
 
 ---
 
@@ -204,19 +204,19 @@ Chaque notebook introduit un concept ou modele spécifique. Le tableau ci-dessou
 
 | Aspect | Description |
 |--------|-------------|
-| **Entree** | Etat initial + modele du domaine + condition but |
-| **Sortie** | Sequence d'actions (plan) executable |
-| **Hypothese** | Deterministe, observable, discret (STRIPS classique) |
-| **Complexite** | NP-complet en général ($O(2^n)$ etats possibles) |
+| **Entrée** | État initial + modèle du domaine + condition but |
+| **Sortie** | Séquence d'actions (plan) exécutable |
+| **Hypothèse** | Déterministe, observable, discret (STRIPS classique) |
+| **Complexité** | NP-complet en général ($O(2^n)$ états possibles) |
 | **Garantie** | Optimal si heuristique admissible (A*) |
 
-## Prerequis
+## Prérequis
 
 ### Connaissances requises
 
-- **Python 3.9+** : programmation orientee objet, types, dataclasses
+- **Python 3.9+** : programmation orientée objet, types, dataclasses
 - **Algorithmique de base** : graphes (BFS, DFS, A*), recherche
-- **Logique propositionnelle** : predicats, connecteurs logiques, quantificateurs
+- **Logique propositionnelle** : prédicats, connecteurs logiques, quantificateurs
 
 ### Pour les notebooks avancés
 
@@ -226,37 +226,37 @@ Chaque notebook introduit un concept ou modele spécifique. Le tableau ci-dessou
 
 ### Pour les notebooks pratiques
 
-- **Docker** (notebooks 4-6) : execution du conteneur Fast Downward sur le port 8200
-- **OR-Tools** (notebook 7) : modelisation de contraintes, solveur CP-SAT
+- **Docker** (notebooks 4-6) : exécution du conteneur Fast Downward sur le port 8200
+- **OR-Tools** (notebook 7) : modélisation de contraintes, solveur CP-SAT
 
-## Prerequis techniques
+## Prérequis techniques
 
 ### 1. Environnement Python
 
 ```bash
-# Creer un environnement virtuel
+# Créer un environnement virtuel
 python -m venv venv
 source venv/bin/activate  # Linux/Mac
 # ou venv\Scripts\activate  # Windows
 
-# Installer les dependances
+# Installer les dépendances
 pip install unified-planning ortools numpy matplotlib networkx
 ```
 
-### 2. Docker pour Fast Downward (recommande)
+### 2. Docker pour Fast Downward (recommandé)
 
 ```bash
-# Telecharger l'image Docker Fast Downward (serveur HTTP port 8200)
+# Télécharger l'image Docker Fast Downward (serveur HTTP port 8200)
 docker pull jsboige/coursia-fast-downward:latest
 ```
 
 L'image fournit un serveur API HTTP sur le port 8200. Les notebooks appellent l'endpoint `/plan` avec un payload JSON `{domain, problem, search}` et reçoivent le plan optimal.
 
-### 3. Verification
+### 3. Vérification
 
 ```bash
 python -c "import unified_planning; from ortools.sat.python import cp_model; print('OK')"
-# Verifier le serveur Fast Downward (port 8200)
+# Vérifier le serveur Fast Downward (port 8200)
 curl -s http://localhost:8200/health
 ```
 
@@ -264,30 +264,30 @@ curl -s http://localhost:8200/health
 
 | Outil | Description | Notebooks |
 |-------|-------------|-----------|
-| **unified-planning** | Interface Python unifiee pour planificateurs PDDL | Tous |
+| **unified-planning** | Interface Python unifiée pour planificateurs PDDL | Tous |
 | **Fast Downward** | Planificateur optimal IPC winner (A*, LM-cut) | 4, 5, 6 |
 | **OR-Tools CP-SAT** | Solveur de contraintes Google (scheduling) | 7 |
 | **PDDL** | Planning Domain Definition Language (standard IPC) | 2-9 |
 | **HDDL** | Hierarchical Domain Definition Language (HTN) | 9 |
 | **OpenAI/Anthropic API** | LLMs pour génération de plans | 10 |
-| **PyTorch** | Reseaux de neurones pour heuristiques (LOOP) | 12 |
+| **PyTorch** | Réseaux de neurones pour heuristiques (LOOP) | 12 |
 
 ## Domaines PDDL classiques
 
 Les notebooks utilisent les domaines standards de l'IPC (International Planning Competition) :
 
-| Domaine | Description | Complexite | Notebooks |
+| Domaine | Description | Complexité | Notebooks |
 |---------|-------------|------------|-----------|
 | **Blocks World** | Empiler des blocs pour une tour | Simple | 1, 2, 4, 5, 6 |
-| **Gripper** | Robot avec pinces deplace des balles | Simple | 4, 6, 12 |
-| **Logistics** | Transport de colis entre lieux avec vehicules | Moyen | 4, 6, 8, 9 |
-| **Depots** | Gestion d'entrepot avec grues | Moyen | 6 |
+| **Gripper** | Robot avec pinces déplace des balles | Simple | 4, 6, 12 |
+| **Logistics** | Transport de colis entre lieux avec véhicules | Moyen | 4, 6, 8, 9 |
+| **Depots** | Gestion d'entrepôt avec grues | Moyen | 6 |
 | **Satellite** | Planification d'observations spatiales | Complexe | 6 |
-| **Hanoi** | Tour de Hanoi (recursivite naturelle) | Moyen | 6 |
+| **Hanoi** | Tour de Hanoi (récursivité naturelle) | Moyen | 6 |
 
 ## PDDL - Planning Domain Definition Language
 
-PDDL est le langage standard pour décrire des problemes de planification.
+PDDL est le langage standard pour décrire des problèmes de planification.
 
 ### Domaine (domain.pddl)
 
@@ -309,7 +309,7 @@ PDDL est le langage standard pour décrire des problemes de planification.
 )
 ```
 
-### Probleme (problem.pddl)
+### Problème (problem.pddl)
 
 ```lisp
 (define (problem blocks-tower)
@@ -326,25 +326,25 @@ PDDL est le langage standard pour décrire des problemes de planification.
 
 ## Comparaison des approches
 
-| Approche | Optimalite | Vitesse | Expressivite |
+| Approche | Optimalité | Vitesse | Expressivité |
 |----------|------------|---------|--------------|
 | **A* + LM-cut** | Admissible | Rapide | STRIPS |
-| **A* + FF** | Non garanti | Tres rapide | STRIPS+ |
-| **GBFS + FF** | Non | Tres rapide | STRIPS+ |
+| **A* + FF** | Non garanti | Très rapide | STRIPS+ |
+| **GBFS + FF** | Non | Très rapide | STRIPS+ |
 | **CP-SAT** | Optimal | Variable | Contraintes |
-| **HTN** | Variable | Rapide | Hierarchique |
-| **LOOP** | Non | Variable | Generalise |
+| **HTN** | Variable | Rapide | Hiérarchique |
+| **LOOP** | Non | Variable | Généralisé |
 
 ## Fast Downward
 
-Planificateur optimal développe a l'Universite de Bale :
+Planificateur optimal développé à l'Université de Bâle :
 
-| Caracteristique | Description |
+| Caractéristique | Description |
 |-----------------|-------------|
 | **Architectures** | Translator (PDDL→SAS+) → Preprocessor → Search |
 | **Algorithmes** | A*, GBFS (eager/lazy), EHC, LAMA |
 | **Heuristiques** | FF, add, hmax, LM-cut, merge-and-shrink |
-| **Performance** | Gagnant IPC multiple fois |
+| **Performance** | Gagnant IPC plusieurs fois |
 
 ### Utilisation via Docker (serveur HTTP)
 
@@ -352,7 +352,7 @@ Planificateur optimal développe a l'Universite de Bale :
 # Lancer le conteneur Fast Downward (port 8200)
 docker run -d --name coursia-fast-downward -p 8200:8200 jsboige/coursia-fast-downward:latest
 
-# Soumettre un probleme via l'API HTTP
+# Soumettre un problème via l'API HTTP
 curl -X POST http://localhost:8200/plan \
   -H "Content-Type: application/json" \
   -d '{"domain": "<domain.pddl>", "problem": "<problem.pddl>", "search": "astar(lmcut())"}'
@@ -364,84 +364,84 @@ curl -X POST http://localhost:8200/plan \
 from unified_planning.shortcuts import *
 from up_fast_downward import FastDownwardPDDLPlanner
 
-# Definir le probleme avec unified-planning
+# Définir le problème avec unified-planning
 problem = Problem('my-problem')
-# ... (voir notebooks pour details)
+# ... (voir notebooks pour détails)
 
-# Resoudre avec Fast Downward
+# Résoudre avec Fast Downward
 planner = FastDownwardPDDLPlanner()
 result = planner.solve(problem)
 ```
 
-## HTN - Planification Hierarchique
+## HTN - Planification Hiérarchique
 
-La planification HTN (Hierarchical Task Network) structure la recherche par decomposition de taches :
+La planification HTN (Hierarchical Task Network) structure la recherche par décomposition de tâches :
 
-| Concept | Definition |
+| Concept | Définition |
 |---------|------------|
-| **Tache primitive** | Action directement executable (ex: `drive(truck, A, B)`) |
-| **Tache abstraite** | Tache a decomposer (ex: `deliver(pkg, A, B)`) |
-| **Methode** | Regle de decomposition avec preconditions et sous-taches |
+| **Tâche primitive** | Action directement exécutable (ex: `drive(truck, A, B)`) |
+| **Tâche abstraite** | Tâche à décomposer (ex: `deliver(pkg, A, B)`) |
+| **Méthode** | Règle de décomposition avec préconditions et sous-tâches |
 | **HDDL** | Langage standard pour domaines HTN (extension de PDDL) |
 
 ### Algorithme SHOP2
 
-SHOP2 (Simple Hierarchical Ordered Planner 2) utilise la decomposition ordonnee :
+SHOP2 (Simple Hierarchical Ordered Planner 2) utilise la décomposition ordonnée :
 
-1. Traiter la première tache de la liste
-2. Si primitive : verifier preconditions, appliquer, passer a la suivante
-3. Si abstraite : choisir une méthode applicable, remplacer par sous-taches
-4. Backtracking : essayer la méthode suivante si echec
+1. Traiter la première tâche de la liste
+2. Si primitive : vérifier préconditions, appliquer, passer à la suivante
+3. Si abstraite : choisir une méthode applicable, remplacer par sous-tâches
+4. Backtracking : essayer la méthode suivante si échec
 
-## Concepts cles
+## Concepts clés
 
-| Concept | Definition |
+| Concept | Définition |
 |---------|------------|
-| **STRIPS** | Modele de planification avec preconditions/add/delete (1971) |
+| **STRIPS** | Modèle de planification avec préconditions/add/delete (1971) |
 | **PDDL** | Planning Domain Definition Language - standard IPC depuis 1998 |
 | **Heuristique** | Fonction estimant le coût pour atteindre le but |
 | **A*** | Algorithme de recherche optimale avec heuristique admissible |
-| **Landmark** | Fait qui doit être vrai a un moment du plan |
-| **HTN** | Hierarchical Task Network - decomposition de taches |
-| **LM-cut** | Heuristique admissible basee sur les landmarks |
+| **Landmark** | Fait qui doit être vrai à un moment du plan |
+| **HTN** | Hierarchical Task Network - décomposition de tâches |
+| **LM-cut** | Heuristique admissible basée sur les landmarks |
 | **CP-SAT** | Constraint Programming-Satisfiability (OR-Tools) |
-| **Learning to Plan** | Apprentissage de heuristiques par réseaux de neurones |
+| **Learning to Plan** | Apprentissage d'heuristiques par réseaux de neurones |
 | **LOOP** | Framework neuro-symbolique, 85.8% coverage IPC |
 
-## Caracteristiques de la série
+## Caractéristiques de la série
 
-| Caracteristique | Description |
+| Caractéristique | Description |
 |-----------------|-------------|
-| **Progression** | Fondations → Classique → Avance → Neuro-symbolique |
-| **Pratique** | Chaque notebook contient des exemples executes et des exercices |
+| **Progression** | Fondations → Classique → Avancé → Neuro-symbolique |
+| **Pratique** | Chaque notebook contient des exemples exécutés et des exercices |
 | **Outils réels** | Fast Downward (IPC winner), OR-Tools (Google), unified-planning |
-| **Domaines IPC** | Blocks World, Logistics, Gripper — les mêmes que les competitions |
-| **Output verify** | Tous les notebooks sont executes avec outputs inclus |
+| **Domaines IPC** | Blocks World, Logistics, Gripper — les mêmes que les compétitions |
+| **Output verify** | Tous les notebooks sont exécutés avec outputs inclus |
 | **Navigation** | Headers avec liens précédent/suivant dans chaque notebook |
 
 ## Quick Start
 
 ```bash
-# 1. Installer les dependances Python
+# 1. Installer les dépendances Python
 pip install unified-planning ortools numpy matplotlib networkx
 
-# 2. Verifier l'installation
+# 2. Vérifier l'installation
 python -c "import unified_planning; from ortools.sat.python import cp_model; print('OK')"
 
 # 3. Premier notebook (introduction aux concepts)
 jupyter notebook 01-Foundation/Planners-1-Introduction.ipynb
 ```
 
-Pour les notebooks 4-6 (Fast Downward), l'image Docker `jsboige/coursia-fast-downward` fournit un serveur API HTTP sur le port 8200 : `docker pull jsboige/coursia-fast-downward:latest`. Les notebooks théoriques (1-3, 7-12) ne necessitent que Python.
+Pour les notebooks 4-6 (Fast Downward), l'image Docker `jsboige/coursia-fast-downward` fournit un serveur API HTTP sur le port 8200 : `docker pull jsboige/coursia-fast-downward:latest`. Les notebooks théoriques (1-3, 7-12) ne nécessitent que Python.
 
 ## Navigation guide
 
-### Progression recommandee
+### Progression recommandée
 
-1. **Debutants** : Commencer par `00-Environment/Planners-0-Setup.ipynb`
+1. **Débutants** : Commencer par `00-Environment/Planners-0-Setup.ipynb`
 2. **Fondations** : Suivre `01-Foundation/` dans l'ordre
 3. **Pratique** : Explorer `02-Classical/` pour les outils
-4. **Avance** : `03-Advanced/` et `04-NeuroSymbolic/` selon intérêts
+4. **Avancé** : `03-Advanced/` et `04-NeuroSymbolic/` selon intérêts
 
 ### Liens de navigation
 
@@ -453,7 +453,7 @@ Chaque notebook contient :
 ## Tests et validation
 
 ```bash
-# Verifier la structure des notebooks
+# Vérifier la structure des notebooks
 python scripts/notebook_tools/notebook_tools.py validate MyIA.AI.Notebooks/SymbolicAI/Planners --quick
 
 # Execution complete (mode batch)
@@ -464,23 +464,23 @@ BATCH_MODE=true python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.
 
 ### Documentation
 
-- [unified-planning](https://github.com/aiplan4eu/unified-planning) - Bibliotheque Python
+- [unified-planning](https://github.com/aiplan4eu/unified-planning) - Bibliothèque Python
 - [Fast Downward](https://www.fast-downward.org/) - Planificateur de référence
 - [PDDL Reference](https://planning.wiki/) - Documentation PDDL complète
 - [OR-Tools CP-SAT](https://developers.google.com/optimization/cp/cp_sat) - Documentation Google
 
-### Cours et tutorials
+### Cours et tutoriels
 
 - [AI Planning - University of Edinburgh](https://www.coursera.org/learn/ai-planning)
 - [Classical Planning - Stanford](https://www.youtube.com/watch?v=WEDagb6TsK8)
-- [IPC Benchmarks](https://github.com/aibasel/downward-benchmarks) - Problemes standards
+- [IPC Benchmarks](https://github.com/aibasel/downward-benchmarks) - Problèmes standards
 
 ### Publications
 
-| Reference | Couverture |
+| Référence | Couverture |
 |-----------|------------|
 | Ghallab, Nau & Traverso, *Automated Planning: Theory and Practice* (2004) | Textbook de référence, toute la série |
-| Russell & Norvig, *AIMA* 4e ed., ch. 10-11 | Cadre général planification |
+| Russell & Norvig, *AIMA* 4e éd., ch. 10-11 | Cadre général planification |
 | Helmert, "The Fast Downward Planning System" (2006) | Notebooks 4-6 |
 | Hoffmann & Nebel, "The FF Planning System" (2001) | Heuristique h-FF, notebook 5 |
 | Richter & Westphal, "LAMA: Planner" (2010) | Landmarks, notebook 5 |
@@ -492,51 +492,51 @@ BATCH_MODE=true python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.
 
 La planification automatique est une branche de l'IA symbolique :
 
-- Raisonnement sur actions et etats
-- Recherche dans espace d'etats
-- Heuristiques admissibles pour optimalite
+- Raisonnement sur actions et états
+- Recherche dans espace d'états
+- Heuristiques admissibles pour optimalité
 
 ### Ponts avec les autres séries
 
-| Serie | Connection | Details |
+| Série | Connection | Détails |
 | ----- | ---------- | ------- |
-| **[Tweety](../Tweety/)** | Logique et argumentation | Les solveurs SAT/CSP de Tweety complementent les planificateurs PDDL. Les dialogues argumentatifs (Tweety-8) sont des instances de planification multi-agents. |
-| **[Lean](../Lean/)** | Verification formelle | Les plans generes peuvent être verifies formellement. Les heuristiques d'admissibilite (h-max, LM-cut) reposent sur des preuves de correction similaires aux tactiques Lean. |
-| **[SmartContracts](../SmartContracts/)** | Execution planifiee | Les smart contracts DeFi (liquidations, arbitrage) sont des problemes de planification sous contraintes temporelles et de gaz. Le notebook SC-14 (verification formelle) croise OR-Tools (Planners-7). |
-| **[GameTheory](../../GameTheory/)** | Jeux sequentiels | La recherche adversariale (A*, minimax) est commune a la planification classique et a la theorie des jeux. Les jeux cooperatifs (Shapley) sont des problemes d'allocation de taches planifiables. |
-| **[Search](../../Search/)** | Fondements communs | La série Search couvre les algorithmes de base (BFS, DFS, A*) utilises dans les planificateurs. CSP (Search Part2) correspond a OR-Tools CP-SAT (Planners-7). |
-| Lecture transversale | [La mer qui monte](../../../docs/grothendieckian-lens.md) | Grille de lecture grothendieckienne du depot : changement de representation, certification A/B/C |
+| **[Tweety](../Tweety/)** | Logique et argumentation | Les solveurs SAT/CSP de Tweety complètent les planificateurs PDDL. Les dialogues argumentatifs (Tweety-8) sont des instances de planification multi-agents. |
+| **[Lean](../Lean/)** | Vérification formelle | Les plans générés peuvent être vérifiés formellement. Les heuristiques d'admissibilité (h-max, LM-cut) reposent sur des preuves de correction similaires aux tactiques Lean. |
+| **[SmartContracts](../SmartContracts/)** | Exécution planifiée | Les smart contracts DeFi (liquidations, arbitrage) sont des problèmes de planification sous contraintes temporelles et de gaz. Le notebook SC-14 (vérification formelle) croise OR-Tools (Planners-7). |
+| **[GameTheory](../../GameTheory/)** | Jeux séquentiels | La recherche adversariale (A*, minimax) est commune à la planification classique et à la théorie des jeux. Les jeux coopératifs (Shapley) sont des problèmes d'allocation de tâches planifiables. |
+| **[Search](../../Search/)** | Fondements communs | La série Search couvre les algorithmes de base (BFS, DFS, A*) utilisés dans les planificateurs. CSP (Search Part2) correspond à OR-Tools CP-SAT (Planners-7). |
+| Lecture transversale | [La mer qui monte](../../../docs/grothendieckian-lens.md) | Grille de lecture grothendieckienne du dépôt : changement de représentation, certification A/B/C |
 
 ## Cross-séries Bridges
 
-| Serie | Lien | Connection |
+| Série | Lien | Connection |
 | ------- | ------ | ----------- |
-| [Lean](../Lean/README.md) | Verification formelle | Les plans PDDL generes peuvent être verifies formellement dans Lean |
-| [Tweety](../Tweety/README.md) | Logique et argumentation | Les solveurs SAT de Tweety peuvent resoudre des sous-problemes de planification |
-| [SmartContracts](../SmartContracts/README.md) | Ordonnancement | Les liquidations DeFi sont des problemes de planification temporelle (notebook 8) |
-| [GameTheory](../../GameTheory/README.md) | Recherche sequentielle | A* en planification et minimax en jeux partagent la même structure de graphe |
+| [Lean](../Lean/README.md) | Vérification formelle | Les plans PDDL générés peuvent être vérifiés formellement dans Lean |
+| [Tweety](../Tweety/README.md) | Logique et argumentation | Les solveurs SAT de Tweety peuvent résoudre des sous-problèmes de planification |
+| [SmartContracts](../SmartContracts/README.md) | Ordonnancement | Les liquidations DeFi sont des problèmes de planification temporelle (notebook 8) |
+| [GameTheory](../../GameTheory/README.md) | Recherche séquentielle | A* en planification et minimax en jeux partagent la même structure de graphe |
 | [Search](../../Search/README.md) | Fondations algorithmiques | A*, BFS, DFS de Search sont les bases des planificateurs classiques |
 
 ## FAQ / Troubleshooting
 
 ### 1. Le conteneur Docker Fast Downward ne répond pas sur le port 8200
 
-**Symptome** : `ConnectionRefusedError` ou timeout dans les notebooks 4-6.
+**Symptôme** : `ConnectionRefusedError` ou timeout dans les notebooks 4-6.
 
 **Causes et solutions** :
 
 ```bash
-# Verifier que le conteneur tourne
+# Vérifier que le conteneur tourne
 docker ps | grep coursia-fast-downward
 
-# S'il n'apparait pas, le lancer
+# S'il n'apparaît pas, le lancer
 docker run -d --name coursia-fast-downward -p 8200:8200 jsboige/coursia-fast-downward:latest
 
-# Verifier que le port est accessible
+# Vérifier que le port est accessible
 curl -s http://localhost:8200/health
 ```
 
-Si le port 8200 est déjà pris par un autre service, utiliser un port different :
+Si le port 8200 est déjà pris par un autre service, utiliser un port différent :
 ```bash
 docker run -d --name coursia-fast-downward -p 8201:8200 jsboige/coursia-fast-downward:latest
 ```
@@ -544,11 +544,11 @@ Dans ce cas, adapter l'URL dans les notebooks de `localhost:8200` vers `localhos
 
 ### 2. unified-planning ne détecte pas Fast Downward
 
-**Symptome** : `up_fast_downward` importe mais `FastDownwardPDDLPlanner()` echoue avec une erreur de chemin.
+**Symptôme** : `up_fast_downward` importé mais `FastDownwardPDDLPlanner()` échoue avec une erreur de chemin.
 
-**Cause** : `unified-planning` attend l'executable `downward` dans le PATH ou dans le repertoire configure. Avec Docker, ce n'est pas necessaire — les notebooks utilisent l'API HTTP a la place.
+**Cause** : `unified-planning` attend l'exécutable `downward` dans le PATH ou dans le répertoire configuré. Avec Docker, ce n'est pas nécessaire — les notebooks utilisent l'API HTTP à la place.
 
-**Solution** : Les notebooks 4-6 utilisent le serveur Docker (endpoint `/plan`), pas l'executable local. Verifier que les appels HTTP fonctionnent :
+**Solution** : Les notebooks 4-6 utilisent le serveur Docker (endpoint `/plan`), pas l'exécutable local. Vérifier que les appels HTTP fonctionnent :
 ```python
 import requests
 resp = requests.post("http://localhost:8200/plan",
@@ -558,64 +558,64 @@ print(resp.status_code, resp.json())
 
 ### 3. Erreurs PDDL "undeclared variable" ou "type mismatch"
 
-**Symptome** : Le solveur rejette le domaine ou le probleme PDDL avec une erreur de parsing.
+**Symptôme** : Le solveur rejette le domaine ou le problème PDDL avec une erreur de parsing.
 
 **Causes fréquentes** :
 
 | Erreur | Cause | Correction |
 | ------ | ----- | ---------- |
-| `undeclared variable '?x'` | Parametre non declare dans `:parameters` | Ajouter `?x - type` dans la signature de l'action |
-| `type mismatch` | Type de parametre incorrect | Verifier que le type existe dans `:types` |
-| `unsupported requirement` | Requirement non supporte par le solveur | Retirer `:adl`, `:quantified-preconditions` ou utiliser un solveur compatible |
-| `precondition false` | Conjonction vide ou variable non initialisee | Verifier les noms de predicats dans `:predicates` |
+| `undeclared variable '?x'` | Paramètre non déclaré dans `:parameters` | Ajouter `?x - type` dans la signature de l'action |
+| `type mismatch` | Type de paramètre incorrect | Vérifier que le type existe dans `:types` |
+| `unsupported requirement` | Requirement non supporté par le solveur | Retirer `:adl`, `:quantified-preconditions` ou utiliser un solveur compatible |
+| `precondition false` | Conjonction vide ou variable non initialisée | Vérifier les noms de prédicats dans `:predicates` |
 
 **Astuce** : Valider le PDDL avec [planning.wiki](https://planning.wiki/) avant de le soumettre au solveur. Le notebook 2 (PDDL-Basics) couvre la syntaxe complète.
 
-### 4. OR-Tools CP-SAT : "model is infeasible" sur un probleme simple
+### 4. OR-Tools CP-SAT : "model is infeasible" sur un problème simple
 
-**Symptome** : Le solveur CP-SAT retourne `INFEASIBLE` alors que le probleme devrait avoir une solution.
+**Symptôme** : Le solveur CP-SAT retourne `INFEASIBLE` alors que le problème devrait avoir une solution.
 
 **Causes** :
 
 1. **Contradiction entre contraintes** : deux contraintes `model.Add(x == 1)` et `model.Add(x == 2)` sur la même variable.
 2. **Domaine vide** : `model.NewIntVar(5, 3, "x")` (borne inférieure > supérieure).
-3. **Contraintes cumulatives** : la capacite cumulee est inférieure a la demande totale.
+3. **Contraintes cumulatives** : la capacité cumulée est inférieure à la demande totale.
 
 **Diagnostic** :
 ```python
-# Activer le log du solveur pour comprendre l'infeasibilite
+# Activer le log du solveur pour comprendre l'infeasibilité
 solver = cp_model.CpSolver()
 solver.parameters.max_time_in_seconds = 30.0
 status = solver.Solve(model)
 if status == cp_model.INFEASIBLE:
-    # Verifier les contraintes une par une en les desactivant
+    # Vérifier les contraintes une par une en les désactivant
     for i, ct in enumerate(model.proto.constraint):
         print(f"Constraint {i}: {ct}")
 ```
 
-### 5. Explication combinatoire : le solveur ne termine pas
+### 5. Explosion combinatoire : le solveur ne termine pas
 
-**Symptome** : Le planificateur tourne indefiniment sur un probleme de taille moyenne.
+**Symptôme** : Le planificateur tourne indéfiniment sur un problème de taille moyenne.
 
-**Cause** : L'espace d'etats explose ($O(2^n)$ pour $n$ predicats). Les domaines comme Logistics ou Satellite avec beaucoup d'objets sont particulierement sensibles.
+**Cause** : L'espace d'états explose ($O(2^n)$ pour $n$ prédicats). Les domaines comme Logistics ou Satellite avec beaucoup d'objets sont particulièrement sensibles.
 
 **Solutions** :
 
-| Strategie | Configuration | Quand l'utiliser |
+| Stratégie | Configuration | Quand l'utiliser |
 | --------- | ------------- | ---------------- |
-| **Limiter le temps** | `solver.parameters.max_time_in_seconds = 60` | Probleme trop grand |
-| **Heuristique rapide** | Utiliser `eager_greedy([ff()])` au lieu de `astar(lmcut())` | Solution rapide, pas forcement optimale |
-| **Reduire le probleme** | Moins d'objets dans `:objects` | Prototypage, validation du modele |
-| **Sous-optimal** | `astar(ff())` avec weight > 1 | Bon compromis qualite/temps |
+| **Limiter le temps** | `solver.parameters.max_time_in_seconds = 60` | Problème trop grand |
+| **Heuristique rapide** | Utiliser `eager_greedy([ff()])` au lieu de `astar(lmcut())` | Solution rapide, pas forcément optimale |
+| **Réduire le problème** | Moins d'objets dans `:objects` | Prototypage, validation du modèle |
+| **Sous-optimal** | `astar(ff())` avec weight > 1 | Bon compromis qualité/temps |
 
 ### 6. Docker sur Windows : "permission denied" ou "daemon not running"
 
-**Symptome** : Les commandes `docker` echouent sur Windows.
+**Symptôme** : Les commandes `docker` échouent sur Windows.
 
 **Solutions** :
 
-1. Verifier que Docker Desktop est lance (icone dans la barre de taches).
-2. Sur Windows, utiliser PowerShell en mode Administrateur si necessaire.
+1. Vérifier que Docker Desktop est lancé (icône dans la barre des tâches).
+2. Sur Windows, utiliser PowerShell en mode Administrateur si nécessaire.
 3. Alternative sans Docker : installer Fast Downward nativement (Linux/WSL uniquement) :
    ```bash
    # Dans WSL
@@ -624,14 +624,14 @@ if status == cp_model.INFEASIBLE:
    # Puis pointer unified-planning vers le binaire
    ```
 
-Les notebooks théoriques (1-3, 7-12) ne necessitent **pas** Docker et fonctionnent avec uniquement `pip install unified-planning ortools`.
+Les notebooks théoriques (1-3, 7-12) ne nécessitent **pas** Docker et fonctionnent avec uniquement `pip install unified-planning ortools`.
 
 ## Contribution
 
-Pour contribuer a cette série :
+Pour contribuer à cette série :
 
 1. Suivre les conventions de [CLAUDE.md](../../../CLAUDE.md)
-2. Respecter la structure pédagogique (header, objectifs, interpretations)
+2. Respecter la structure pédagogique (header, objectifs, interprétations)
 3. Utiliser `scripts/notebook_tools/notebook_helpers.py` pour la manipulation
 4. Tester avec `python scripts/notebook_tools/notebook_tools.py validate`
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
@@ -1,42 +1,42 @@
 # SMT - Satisfiability Modulo Theories
 
-**Navigation** : [Index SymbolicAI](../README.md) | [Index general](../../README.md)
+**Navigation** : [Index SymbolicAI](../README.md) | [Index général](../../README.md)
 
 ## En quelques mots
 
-Ce repertoire regroupe les series consacrees aux **solveurs SMT** (*Satisfiability Modulo Theories*) et, en pratique, au solveur de reference **Z3** (Microsoft Research). On y aborde le meme changement de paradigme — passer de l'imperatif (ecrire l'algorithme de resolution) au declaratif (decrire les contraintes, laisser le solveur resoudre) — sous deux angles complementaires : une approche **C# declarative bornee** (Z3.Linq) et une approche **Python imperative complete** (z3-py).
+Ce répertoire regroupe les séries consacrées aux **solveurs SMT** (*Satisfiability Modulo Theories*) et, en pratique, au solveur de référence **Z3** (Microsoft Research). On y aborde le même changement de paradigme — passer de l'impératif (écrire l'algorithme de résolution) au déclaratif (décrire les contraintes, laisser le solveur résoudre) — sous deux angles complémentaires : une approche **C# déclarative bornée** (Z3.Linq) et une approche **Python impérative complète** (z3-py).
 
 ## Qu'est-ce que SMT ?
 
-Un solveur **SAT** decide si une formule booleenne est satisfiable. Un solveur **SMT** etend SAT en raisonnant directement sur des *theories* : arithmetique lineaire sur les entiers et les reels, tableaux (`Array`), vecteurs de bits (`BitVec`), chaines de caracteres, fonctions non interpretees. Plutot que d'encoder un Sudoku ou un planificateur de repas en variables booleennes a la main, on exprime les contraintes dans le langage naturel de la theorie concernee, et le solveur retourne un modele (`sat`) ou prouve l'impossibilite (`unsat`).
+Un solveur **SAT** décide si une formule booléenne est satisfiable. Un solveur **SMT** étend SAT en raisonnant directement sur des *théories* : arithmétique linéaire sur les entiers et les réels, tableaux (`Array`), vecteurs de bits (`BitVec`), chaînes de caractères, fonctions non interprétées. Plutôt que d'encoder un Sudoku ou un planificateur de repas en variables booléennes à la main, on exprime les contraintes dans le langage naturel de la théorie concernée, et le solveur retourne un modèle (`sat`) ou prouve l'impossibilité (`unsat`).
 
-**Z3** est le solveur SMT le plus utilise en recherche comme en industrie (verification de programmes, planification, synthese, securite). Les deux series ci-dessous l'exploitent via deux bindings differents.
+**Z3** est le solveur SMT le plus utilisé en recherche comme en industrie (vérification de programmes, planification, synthèse, sécurité). Les deux séries ci-dessous l'exploitent via deux bindings différents.
 
-## Les deux series
+## Les deux séries
 
-| Serie | Langage / Binding | Style | Notebooks | Statut |
+| Série | Langage / Binding | Style | Notebooks | Statut |
 |-------|-------------------|-------|-----------|--------|
-| [**Z3/**](Z3/README.md) | C# .NET 9 / **Z3.Linq** | Declaratif borne : on traduit des expressions LINQ en formules SMT | 5 (`01` -> `05`) | PRODUCTION / BETA |
-| [**Z3-Python/**](Z3-Python/README.md) | Python / **z3-py** | Imperatif complet : acces a l'API integrale du solveur | 3 (`01` -> `03`, en cours) | PRODUCTION |
+| [**Z3/**](Z3/README.md) | C# .NET 9 / **Z3.Linq** | Déclaratif borné : on traduit des expressions LINQ en formules SMT | 5 (`01` -> `05`) | PRODUCTION / BETA |
+| [**Z3-Python/**](Z3-Python/README.md) | Python / **z3-py** | Impératif complet : accès à l'API intégrale du solveur | 3 (`01` -> `03`, en cours) | PRODUCTION |
 
-### Z3.Linq (C#) — la porte d'entree declarative
+### Z3.Linq (C#) — la porte d'entrée déclarative
 
-`Z3.Linq` traduit des expressions LINQ C# en formules SMT. On ecrit une requete proche de la syntaxe metier (`from ... where ... select ...`) et la couche cache les appels Z3 bas niveau. L'avantage pedagogique est la lisibilite : un theoreme s'enonce presque comme une specification. La contrepartie est une **couverture bornee** de l'API (pas de tactiques, pas de theories exotiques) et une montee en charge limitee sur les tres grandes instances.
+`Z3.Linq` traduit des expressions LINQ C# en formules SMT. On écrit une requête proche de la syntaxe métier (`from ... where ... select ...`) et la couche cache les appels Z3 bas niveau. L'avantage pédagogique est la lisibilité : un théorème s'énonce presque comme une spécification. La contrepartie est une **couverture bornée** de l'API (pas de tactiques, pas de théories exotiques) et une montée en charge limitée sur les très grandes instances.
 
-### z3-py (Python) — l'API complete
+### z3-py (Python) — l'API complète
 
-`z3-py` n'impose aucune couche declarative restrictive : tactiques (`simplify`, `Then`, `OrElse`), theories `BitVec` et `Array`, `Optimize`, quantificateurs, `SolverFor(...)` specialises. C'est l'outil de reference pour aller au-dela de la modelisation introductive et explorer les ressorts internes du solveur.
+`z3-py` n'impose aucune couche déclarative restrictive : tactiques (`simplify`, `Then`, `OrElse`), théories `BitVec` et `Array`, `Optimize`, quantificateurs, `SolverFor(...)` spécialisés. C'est l'outil de référence pour aller au-delà de la modélisation introductive et explorer les ressorts internes du solveur.
 
-## Quelle serie choisir ?
+## Quelle série choisir ?
 
-- **Decouvrir le paradigme declaratif en C# / .NET** : commencer par [Z3/](Z3/README.md). Ideal si vous venez de l'ecosysteme .NET (Sudoku, Search/CSP du depot).
-- **Exploiter toute la puissance de Z3 en Python** : aller vers [Z3-Python/](Z3-Python/README.md). Ideal pour la recherche, le prototypage rapide et les theories avancees (BitVec, Array, tactiques).
+- **Découvrir le paradigme déclaratif en C# / .NET** : commencer par [Z3/](Z3/README.md). Idéal si vous venez de l'écosystème .NET (Sudoku, Search/CSP du dépôt).
+- **Exploiter toute la puissance de Z3 en Python** : aller vers [Z3-Python/](Z3-Python/README.md). Idéal pour la recherche, le prototypage rapide et les théories avancées (BitVec, Array, tactiques).
 
-Les deux series traitent volontairement des **memes problemes phares** (theoremes lineaires, Sudoku comme CSP) afin de rendre la comparaison declaratif/imperatif explicite d'un binding a l'autre.
+Les deux séries traitent volontairement des **mêmes problèmes phares** (théorèmes linéaires, Sudoku comme CSP) afin de rendre la comparaison déclaratif/impératif explicite d'un binding à l'autre.
 
 ## Voir aussi
 
-- [Serie Sudoku](../../Sudoku/README.md) — compare Z3 a une dizaine d'autres approches algorithmiques
-- [Search / CSP](../../Search/README.md) — programmation par contraintes et automates symboliques (predicats Z3)
-- [Z3 Prover (upstream)](https://github.com/Z3Prover/z3) — le solveur SMT lui-meme
-- [Z3.Linq (endjin)](https://github.com/endjin/Z3.Linq) — le binding C# declaratif
+- [Série Sudoku](../../Sudoku/README.md) — compare Z3 à une dizaine d'autres approches algorithmiques
+- [Search / CSP](../../Search/README.md) — programmation par contraintes et automates symboliques (prédicats Z3)
+- [Z3 Prover (upstream)](https://github.com/Z3Prover/z3) — le solveur SMT lui-même
+- [Z3.Linq (endjin)](https://github.com/endjin/Z3.Linq) — le binding C# déclaratif

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -1,63 +1,63 @@
-# Serie Z3-Python - Resolution de contraintes SMT en Python
+# Série Z3-Python - Résolution de contraintes SMT en Python
 
-**Navigation** : [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C# (Z3.Linq)](../Z3/README.md) | [Index general](../../../README.md)
+**Navigation** : [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Série Z3 C# (Z3.Linq)](../Z3/README.md) | [Index général](../../../README.md)
 
-## Serie en quelques mots
+## Série en quelques mots
 
 **4 notebooks (en cours) | 1 kernel | z3-solver (Python) | matplotlib**
 
-**A qui s'adresse cette serie** : etudiants en IA, developpeurs Python souhaitant decouvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un probleme non pas comme un algorithme de resolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prerequis en logique formelle n'est suppose : les notebooks partent de la syntaxe de base de z3-py pour monter progressivement vers l'optimisation et la modelisation de problemes combinatoires.
+**À qui s'adresse cette série** : étudiants en IA, développeurs Python souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de la syntaxe de base de z3-py pour monter progressivement vers l'optimisation et la modélisation de problèmes combinatoires.
 
-## Presentation
+## Présentation
 
-**Z3** (Microsoft Research) est un solveur SMT (*Satisfiability Modulo Theories*) qui resout des systemes de contraintes sur des entiers, des reels, des booleens, des vecteurs de bits, des tableaux et des chaines. Cette serie utilise **z3-py** (package pip `z3-solver`), le binding Python officiel qui expose **l'integralite** de l'API Z3 : `Solver`, `Optimize`, theories (BitVec, Array, String, Real), tactiques et quantificateurs.
+**Z3** (Microsoft Research) est un solveur SMT (*Satisfiability Modulo Theories*) qui résout des systèmes de contraintes sur des entiers, des réels, des booléens, des vecteurs de bits, des tableaux et des chaînes. Cette série utilise **z3-py** (package pip `z3-solver`), le binding Python officiel qui expose **l'intégralité** de l'API Z3 : `Solver`, `Optimize`, théories (BitVec, Array, String, Real), tactiques et quantificateurs.
 
-L'interet pedagogique : au lieu d'ecrire un algorithme de backtracking pour un Sudoku ou un planificateur, on decrit les contraintes (une seule valeur par case, pas de doublon par ligne) et le solveur trouve les solutions. Ce changement de paradigme — de l'imperatif au declaratif — est au coeur de cette serie.
+L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour un Sudoku ou un planificateur, on décrit les contraintes (une seule valeur par case, pas de doublon par ligne) et le solveur trouve les solutions. Ce changement de paradigme — de l'impératif au déclaratif — est au cœur de cette série.
 
 ### Python (z3-py) vs C# (Z3.Linq)
 
-Une serie sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basee sur le binding **Z3.Linq** qui traduit des expressions LINQ en formules SMT. La serie Python presente ici va plus loin : z3-py n'impose **aucune couche declarative restrictive**, ce qui donne acces a l'API complete (tactiques, `Optimize`, theories de bas niveau).
+Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le binding **Z3.Linq** qui traduit des expressions LINQ en formules SMT. La série Python présentée ici va plus loin : z3-py n'impose **aucune couche déclarative restrictive**, ce qui donne accès à l'API complète (tactiques, `Optimize`, théories de bas niveau).
 
-| Aspect | Z3.Linq (C#) | z3-py (Python, cette serie) |
+| Aspect | Z3.Linq (C#) | z3-py (Python, cette série) |
 |--------|--------------|------------------------------|
-| **Binding** | LINQ -> Z3 (declaratif) | API Z3 directe (impératif-symbolique) |
+| **Binding** | LINQ -> Z3 (déclaratif) | API Z3 directe (impératif-symbolique) |
 | **Theories** | Entiers, arrays (via lambdas) | BitVec, Array, String, Real, quantificateurs |
-| **Optimisation** | Limitee | `Optimize` complet (maximize/minimize) |
-| **Tactiques** | Non exposees | `Tactic`, `Then`, `Repeat` |
-| **Courbe** | Syntaxe C# familiere | API Python explicite, plus de controle |
+| **Optimisation** | Limitée | `Optimize` complet (maximize/minimize) |
+| **Tactiques** | Non exposées | `Tactic`, `Then`, `Repeat` |
+| **Courbe** | Syntaxe C# familière | API Python explicite, plus de contrôle |
 
-### Declaratif vs Imperatif
+### Déclaratif vs Impératif
 
-| Aspect | Imperatif (classique) | Declaratif (Z3) |
+| Aspect | Impératif (classique) | Déclaratif (Z3) |
 |--------|----------------------|---------------------|
-| **Approche** | Ecrire l'algorithme de resolution | Decrire les contraintes, laisser le solveur resoudre |
-| **Complexite** | Backtracking, heuristiques, pruning | Syntaxe Python naturelle |
-| **Evolution** | Modifier l'algorithme pour chaque nouveau probleme | Ajouter des contraintes, le solveur s'adapte |
-| **Verification** | Tester les solutions | Les solutions satisfont les contraintes par construction |
-| **Limite** | Difficile a generaliser | Performance sur les tres grandes instances |
+| **Approche** | Écrire l'algorithme de résolution | Décrire les contraintes, laisser le solveur résoudre |
+| **Complexité** | Backtracking, heuristiques, pruning | Syntaxe Python naturelle |
+| **Évolution** | Modifier l'algorithme pour chaque nouveau problème | Ajouter des contraintes, le solveur s'adapte |
+| **Vérification** | Tester les solutions | Les solutions satisfont les contraintes par construction |
+| **Limite** | Difficile à généraliser | Performance sur les très grandes instances |
 
 ## Vue d'ensemble
 
-| # | Notebook | Sujet | Duree | Statut |
+| # | Notebook | Sujet | Durée | Statut |
 |---|----------|-------|------|--------|
 | 01 | [Introduction](Z3-Python-01-Introduction.ipynb) | `Solver`, `Int`/`Bool`/`Real`, sat/unsat, `Optimize` | ~30 min | PRODUCTION |
 | 02 | [Sudoku](Z3-Python-02-Sudoku.ipynb) | Sudoku comme CSP, `Distinct`, visualisation matplotlib | ~25 min | PRODUCTION |
-| 03 | [Tactiques et theories](Z3-Python-03-Tactics.ipynb) | `Tactic`, `BitVec`, `Array` | ~35 min | PRODUCTION |
-| 04 | [Chaines et expressions regulieres](Z3-Python-04-Strings-Regex.ipynb) | `String`, `Re` (theorie des chaines Z3) | ~30 min | PRODUCTION |
-| 05 | *(a venir)* Quantificateurs et preuves | `ForAll`, `Exists`, proofs, modele checking | — | Planifie |
-| 06 | *(a venir)* Optimisation avancee | Pareto, objectifs multiples, `Optimize` hierarchique | — | Planifie |
+| 03 | [Tactiques et théories](Z3-Python-03-Tactics.ipynb) | `Tactic`, `BitVec`, `Array` | ~35 min | PRODUCTION |
+| 04 | [Chaînes et expressions régulières](Z3-Python-04-Strings-Regex.ipynb) | `String`, `Re` (théorie des chaînes Z3) | ~30 min | PRODUCTION |
+| 05 | *(à venir)* Quantificateurs et preuves | `ForAll`, `Exists`, proofs, model checking | — | Planifié |
+| 06 | *(à venir)* Optimisation avancée | Pareto, objectifs multiples, `Optimize` hiérarchique | — | Planifié |
 
-### Fil pedagogique
+### Fil pédagogique
 
-1. **Notebook 01** pose les bases : le patron `Solver()`, les types de base (`Int`, `Bool`, `Real`), les reponses `sat`/`unsat`/`unknown`, et l'optimisation avec `Optimize`
-2. **Notebook 02** applique l'approche declarative au Sudoku : modelisation par `Distinct`, resolution et visualisation (donne en noir / resolu en bleu)
-3. **Notebook 03** explore les tactiques (`simplify`, `Then`, `OrElse`), les theories `BitVec` (arithmetique modulaire) et `Array` (tableaux symboliques)
-4. **Notebook 04** introduit la theorie des chaines : `String`, `Contains`, `IndexOf`, `Replace`, et les expressions regulieres (`Re`, `Star`, `Range`, `InRe`)
-5. **Notebooks suivants (planifies)** : quantificateurs et optimisation avancee
+1. **Notebook 01** pose les bases : le patron `Solver()`, les types de base (`Int`, `Bool`, `Real`), les réponses `sat`/`unsat`/`unknown`, et l'optimisation avec `Optimize`
+2. **Notebook 02** applique l'approche déclarative au Sudoku : modélisation par `Distinct`, résolution et visualisation (donné en noir / résolu en bleu)
+3. **Notebook 03** explore les tactiques (`simplify`, `Then`, `OrElse`), les théories `BitVec` (arithmétique modulaire) et `Array` (tableaux symboliques)
+4. **Notebook 04** introduit la théorie des chaînes : `String`, `Contains`, `IndexOf`, `Replace`, et les expressions régulières (`Re`, `Star`, `Range`, `InRe`)
+5. **Notebooks suivants (planifiés)** : quantificateurs et optimisation avancée
 
-## Prerequis
+## Prérequis
 
-| Besoin | Detail |
+| Besoin | Détail |
 |--------|--------|
 | **Python 3.10+** | [Download](https://www.python.org/downloads/) |
 | **z3-solver** | `pip install z3-solver` |
@@ -73,25 +73,25 @@ pip install -r requirements.txt
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, l'etudiant sera capable de :
+À l'issue de cette série, l'étudiant sera capable de :
 
-1. **Modeliser** un probleme de satisfaction de contraintes en Python avec z3-py
-2. **Utiliser** les types et theories Z3 (`Int`, `Real`, `Bool`, `BitVec`, `Array`, `String`)
+1. **Modéliser** un problème de satisfaction de contraintes en Python avec z3-py
+2. **Utiliser** les types et théories Z3 (`Int`, `Real`, `Bool`, `BitVec`, `Array`, `String`)
 3. **Optimiser** une fonction objectif sous contraintes (`Optimize`)
-4. **Comparer** l'approche declarative (Z3) aux approches imperatives (backtracking, CP)
-5. **Appliquer** la resolution SMT a des problemes concrets (Sudoku, ordonnancement, allocation)
+4. **Comparer** l'approche déclarative (Z3) aux approches impératives (backtracking, CP)
+5. **Appliquer** la résolution SMT à des problèmes concrets (Sudoku, ordonnancement, allocation)
 
 ## Contexte technique
 
 **z3-py** combine deux technologies :
 
-- **Z3** : solveur SMT (*Satisfiability Modulo Theories*) capable de resoudre des contraintes sur des entiers, reels, booleens, vecteurs de bits, tableaux et chaines
-- **Python** : le binding `z3-solver` expose l'API C++ de Z3 via des wrappers Python, avec surcharge des operateurs (`==`, `+`, `*`) pour construire des formules symboliques de facon naturelle
+- **Z3** : solveur SMT (*Satisfiability Modulo Theories*) capable de résoudre des contraintes sur des entiers, réels, booléens, vecteurs de bits, tableaux et chaînes
+- **Python** : le binding `z3-solver` expose l'API C++ de Z3 via des wrappers Python, avec surcharge des opérateurs (`==`, `+`, `*`) pour construire des formules symboliques de façon naturelle
 
 ### Liens
 
 - [Z3 Guide (officiel)](https://microsoft.github.io/z3guide/) — documentation et tutoriels
-- [Z3 Python API](https://z3prover.github.io/api/html/namespacez3py.html) — reference de l'API z3-py
+- [Z3 Python API](https://z3prover.github.io/api/html/namespacez3py.html) — référence de l'API z3-py
 - [PyPI : z3-solver](https://pypi.org/project/z3-solver/) — package pip
-- [Serie Z3 C# (Z3.Linq)](../Z3/README.md) — serie sœur en .NET 9
-- [Serie Sudoku](../../../Sudoku/README.md) — compare Z3 a 10 autres approches algorithmiques
+- [Série Z3 C# (Z3.Linq)](../Z3/README.md) — série sœur en .NET 9
+- [Série Sudoku](../../../Sudoku/README.md) — compare Z3 à 10 autres approches algorithmiques

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -1,50 +1,50 @@
-# Serie Z3 - Programmation Declarative avec Z3.Linq
+# Série Z3 - Programmation Déclarative avec Z3.Linq
 
-**Navigation** : [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Index general](../../../README.md)
+**Navigation** : [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md)
 
-## Serie en quelques mots
+## Série en quelques mots
 
 **5 notebooks** | **1 kernel** | **~4h de travail** | **Z3.Linq (.NET 9)**
 
-**A qui s'adresse cette serie** : etudiants en IA, developpeurs C# souhaitant decouvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un probleme non pas comme un algorithme de resolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prerequis en logique formelle n'est suppose : les notebooks partent de theoremes lineaires simples pour monter progressivement vers les theories de tableaux et l'optimisation hierarchique.
+**À qui s'adresse cette série** : étudiants en IA, développeurs C# souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de théorèmes linéaires simples pour monter progressivement vers les théories de tableaux et l'optimisation hiérarchique.
 
-## Presentation
+## Présentation
 
-**Z3** (Microsoft Research) est un solveur SMT (*Satisfiability Modulo Theories*) qui resout des systemes de contraintes sur des entiers, des reels, des booleens et des tableaux. **Z3.Linq** est un binding qui traduit des expressions LINQ C# en formules SMT, permettant de modeliser des problemes declarativement sans ecrire les appels Z3 bas niveau.
+**Z3** (Microsoft Research) est un solveur SMT (*Satisfiability Modulo Theories*) qui résout des systèmes de contraintes sur des entiers, des réels, des booléens et des tableaux. **Z3.Linq** est un binding qui traduit des expressions LINQ C# en formules SMT, permettant de modéliser des problèmes déclarativement sans écrire les appels Z3 bas niveau.
 
-L'interet pedagogique : au lieu d'ecrire un algorithme de backtracking pour un Sudoku ou un planificateur de repas, on decrit les contraintes (une seule valeur par case, pas de doublon par ligne, apports nutritionnels requis) et le solveur trouve les solutions. Ce changement de paradigme — de l'imperatif au declaratif — est au coeur de cette serie.
+L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour un Sudoku ou un planificateur de repas, on décrit les contraintes (une seule valeur par case, pas de doublon par ligne, apports nutritionnels requis) et le solveur trouve les solutions. Ce changement de paradigme — de l'impératif au déclaratif — est au cœur de cette série.
 
-### Declaratif vs Imperatif
+### Déclaratif vs Impératif
 
-| Aspect | Imperatif (classique) | Declaratif (Z3.Linq) |
+| Aspect | Impératif (classique) | Déclaratif (Z3.Linq) |
 |--------|----------------------|---------------------|
-| **Approche** | Ecrire l'algorithme de resolution | Decrire les contraintes, laisser le solveur resoudre |
-| **Complexite** | Backtracking, heuristiques, pruning | Syntaxe LINQ naturelle en C# |
-| **Evolution** | Modifier l'algorithme pour chaque nouveau probleme | Ajouter des contraintes, le solveur s'adapte |
-| **Verification** | Tester les solutions | Les solutions satisfont les contraintes par construction |
-| **Limite** | Difficile a generaliser | Performance sur les tres grandes instances |
+| **Approche** | Écrire l'algorithme de résolution | Décrire les contraintes, laisser le solveur résoudre |
+| **Complexité** | Backtracking, heuristiques, pruning | Syntaxe LINQ naturelle en C# |
+| **Évolution** | Modifier l'algorithme pour chaque nouveau problème | Ajouter des contraintes, le solveur s'adapte |
+| **Vérification** | Tester les solutions | Les solutions satisfont les contraintes par construction |
+| **Limite** | Difficile à généraliser | Performance sur les très grandes instances |
 
 ## Vue d'ensemble
 
-| # | Notebook | Sujet | Duree | Statut |
+| # | Notebook | Sujet | Durée | Statut |
 |---|----------|-------|------|--------|
-| 01 | [Linq2Z3 Intro](01_Linq2Z3_Intro.ipynb) | Theoremes lineaires, Missionnaires-Cannibales, optimisation | ~45 min | PRODUCTION |
-| 02 | [Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | Sudoku explicite (81 proprietes) vs implicite (`List<int>` + lambdas/closures) | ~50 min | PRODUCTION |
+| 01 | [Linq2Z3 Intro](01_Linq2Z3_Intro.ipynb) | Théorèmes linéaires, Missionnaires-Cannibales, optimisation | ~45 min | PRODUCTION |
+| 02 | [Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | Sudoku explicite (81 propriétés) vs implicite (`List<int>` + lambdas/closures) | ~50 min | PRODUCTION |
 | 03 | [Array Theory](03_Array_Theory.ipynb) | Z3 array theory : Select/Store, switching dynamique | ~45 min | BETA |
-| 04 | [Nested Arrays 2D](04_Nested_Arrays_2D.ipynb) | Tableaux imbriques, grilles 2D, Sudoku 4x4, carre magique | ~40 min | BETA |
-| 05 | [Meal Planner Hierarchical](05_Meal_Planner_Hierarchical.ipynb) | Planificateur de repas : data fusion LINQ + theoreme hierarchique | ~50 min | BETA |
+| 04 | [Nested Arrays 2D](04_Nested_Arrays_2D.ipynb) | Tableaux imbriqués, grilles 2D, Sudoku 4x4, carré magique | ~40 min | BETA |
+| 05 | [Meal Planner Hierarchical](05_Meal_Planner_Hierarchical.ipynb) | Planificateur de repas : data fusion LINQ + théorème hiérarchique | ~50 min | BETA |
 
-### Fil pedagogique
+### Fil pédagogique
 
-1. **Notebook 01** pose les bases : le patron `Theorem<T>` de Z3.Linq, les theoremes lineaires, la recherche de plus court chemin, et le classique Missionnaires-Cannibales
-2. **Notebook 02** compare deux approches du Sudoku : 81 proprietes explicites vs modelisation implicite via arrays et lambdas
-3. **Notebook 03** plonge dans la theorie des tableaux Z3 (Select/Store), avec switching dynamique entre representations
-4. **Notebook 04** generalise aux tableaux imbriques (2D) : grilles, carres magiques, Sudoku 4x4
-5. **Notebook 05** integre tout : data fusion LINQ + theoreme hierarchique multi-niveaux pour un planificateur de repas realiste
+1. **Notebook 01** pose les bases : le patron `Theorem<T>` de Z3.Linq, les théorèmes linéaires, la recherche de plus court chemin, et le classique Missionnaires-Cannibales
+2. **Notebook 02** compare deux approches du Sudoku : 81 propriétés explicites vs modélisation implicite via arrays et lambdas
+3. **Notebook 03** plonge dans la théorie des tableaux Z3 (Select/Store), avec switching dynamique entre représentations
+4. **Notebook 04** généralise aux tableaux imbriqués (2D) : grilles, carrés magiques, Sudoku 4x4
+5. **Notebook 05** intègre tout : data fusion LINQ + théorème hiérarchique multi-niveaux pour un planificateur de repas réaliste
 
-## Prerequis
+## Prérequis
 
-| Besoin | Detail |
+| Besoin | Détail |
 |--------|--------|
 | **.NET 9.0 SDK** | [Download](https://dotnet.microsoft.com/download/dotnet/9.0) |
 | **.NET Interactive** | `dotnet tool install --global Microsoft.dotnet-interactive` |
@@ -55,33 +55,33 @@ L'interet pedagogique : au lieu d'ecrire un algorithme de backtracking pour un S
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, l'etudiant sera capable de :
+À l'issue de cette série, l'étudiant sera capable de :
 
-1. **Modeliser** un probleme de satisfaction de contraintes en C# via LINQ
-2. **Comparer** les approches explicites (proprietes) vs implicites (arrays/lambdas)
-3. **Utiliser** la theorie des tableaux Z3 (Select/Store) pour des structures de donnees dynamiques
-4. **Construire** des modeles imbriques (tableaux 2D, grilles)
-5. **Integrer** des sources de donnees heterogenes dans un theoreme hierarchique
+1. **Modéliser** un problème de satisfaction de contraintes en C# via LINQ
+2. **Comparer** les approches explicites (propriétés) vs implicites (arrays/lambdas)
+3. **Utiliser** la théorie des tableaux Z3 (Select/Store) pour des structures de données dynamiques
+4. **Construire** des modèles imbriqués (tableaux 2D, grilles)
+5. **Intégrer** des sources de données hétérogènes dans un théorème hiérarchique
 
 ## Contexte technique
 
 **Z3.Linq** combine deux technologies :
 
-- **Z3** : solveur SMT (*Satisfiability Modulo Theories*) capable de resoudre des contraintes sur des entiers, reels, booleens, tableaux et structures de donnees
-- **LINQ** : syntaxe C# pour exprimer des requetes declarativement, automatiquement traduites en formules SMT par le binding
+- **Z3** : solveur SMT (*Satisfiability Modulo Theories*) capable de résoudre des contraintes sur des entiers, réels, booléens, tableaux et structures de données
+- **LINQ** : syntaxe C# pour exprimer des requêtes déclarativement, automatiquement traduites en formules SMT par le binding
 
 ### Historique du projet
 
-| Periode | Acteur | Contribution |
+| Période | Acteur | Contribution |
 |---------|--------|-------------|
 | 2015 | Ricardo Niepel | Base Z3.LinqBinding (LINQ -> Z3 binding) |
 | 2018-2023 | jsboige | Arrays, hierarchical objects, nested arrays, meal planner |
 | 2022-2023 | endjin | Modernisation .NET, CI, structure professionnelle |
-| 2026 | MyIntelligenceAgency | Reintegration EPFdevelopment + serie pedagogique |
+| 2026 | MyIntelligenceAgency | Réintégration EPFdevelopment + série pédagogique |
 
 ### Liens
 
 - [endjin/Z3.Linq](https://github.com/endjin/Z3.Linq) (upstream)
-- [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) (fork cette serie)
+- [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) (fork cette série)
 - [MyIntelligenceAgency/Z3.LinqBinding@EPFdevelopment](https://github.com/MyIntelligenceAgency/Z3.LinqBinding/tree/EPFdevelopment) (branche contributions jsboige)
 - [Issue upstream #29](https://github.com/endjin/Z3.Linq/issues/29) (discussion contributions)

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -1,4 +1,4 @@
-# Web Semantique - Semantic Web
+# Web Sémantique - Semantic Web
 
 <!-- CATALOG-STATUS
 series: SymbolicAI-SemanticWeb
@@ -7,35 +7,35 @@ breakdown: SemanticWeb=18
 maturity: PRODUCTION=18
 -->
 
-Le Web Semantique est la promesse d'un Web ou les machines comprennent la signification des donnees, pas seulement leur syntaxe. RDF, SPARQL, OWL, SHACL : ces standards du W3C definissent un langage commun pour decrire, interroger, valider et raisonner sur des graphes de connaissances. Cette serie vous mene des fondations (.NET C# avec dotNetRDF) aux applications modernes (Python avec rdflib, pySHACL, GraphRAG), en passant par les ontologies, les donnees liees et les standards emergents (RDF 1.2, JSON-LD 1.1).
+Le Web Sémantique est la promesse d'un Web où les machines comprennent la signification des données, pas seulement leur syntaxe. RDF, SPARQL, OWL, SHACL : ces standards du W3C définissent un langage commun pour décrire, interroger, valider et raisonner sur des graphes de connaissances. Cette série vous mène des fondations (.NET C# avec dotNetRDF) aux applications modernes (Python avec rdflib, pySHACL, GraphRAG), en passant par les ontologies, les données liées et les standards émergents (RDF 1.2, JSON-LD 1.1).
 
 **18 notebooks** | **2 langages** | **~10h**
 
-**A qui s'adresse cette serie** : developpeurs web curieux du sens cache dans leurs donnees, data scientists voulant structurer leurs pipelines, et etudiants en IA souhaitant comprendre comment les graphes de connaissances ancrent les LLMs. Aucun prerequis en logique formelle.
+**À qui s'adresse cette série** : développeurs web curieux du sens caché dans leurs données, data scientists voulant structurer leurs pipelines, et étudiants en IA souhaitant comprendre comment les graphes de connaissances ancrent les LLMs. Aucun prérequis en logique formelle.
 
-## Pourquoi cette serie
+## Pourquoi cette série
 
-Le Web Semantique a traverse des cycles de hype et de desillusion. En 2001, Tim Berners-Lee en faisait la couverture de *Scientific American*. En 2010, les donnees liees semblaient une niche academique. En 2024, GraphRAG (Microsoft) a montre que les graphes de connaissances RDF pouvaient ancrer les LLMs sur des faits verifiables : le Web Semantique devenait un garde-fou pour l'IA generative.
+Le Web Sémantique a traversé des cycles de hype et de désillusion. En 2001, Tim Berners-Lee en faisait la couverture de *Scientific American*. En 2010, les données liées semblaient une niche académique. En 2024, GraphRAG (Microsoft) a montré que les graphes de connaissances RDF pouvaient ancrer les LLMs sur des faits vérifiables : le Web Sémantique devenait un garde-fou pour l'IA générative.
 
-Cette serie couvre le spectre complet parce que les briques s'articulent : RDF definit les donnees, SPARQL les interroge, RDFS/OWL structurent le raisonnement, SHACL valide la qualite, JSON-LD ponte vers le Web, RDF-Star ajoute la provenance, et les KG+LLMs ferment la boucle. Chaque standard est une couche qui s'appuie sur les precedentes.
+Cette série couvre le spectre complet parce que les briques s'articulent : RDF définit les données, SPARQL les interroge, RDFS/OWL structurent le raisonnement, SHACL valide la qualité, JSON-LD ponte vers le Web, RDF-Star ajoute la provenance, et les KG+LLMs ferment la boucle. Chaque standard est une couche qui s'appuie sur les précédentes.
 
-La serie propose deliberement deux stacks : **.NET C#** (SW-1 a SW-7) pour les fondations avec dotNetRDF (typed, performant, integre a l'ecosysteme CoursIA), et **Python** (SW-8 a SW-13) pour les standards modernes et l'IA. Les sidetracks Python (SW-2b, 4b, 5b, 7b) offrent un miroir des notebooks C# en Python.
+La série propose délibérément deux stacks : **.NET C#** (SW-1 à SW-7) pour les fondations avec dotNetRDF (typed, performant, intégré à l'écosystème CoursIA), et **Python** (SW-8 à SW-13) pour les standards modernes et l'IA. Les sidetracks Python (SW-2b, 4b, 5b, 7b) offrent un miroir des notebooks C# en Python.
 
-## Concepts cles
+## Concepts clés
 
 | Concept | En une phrase | Notebook |
 |---------|---------------|----------|
-| **Triplet RDF** | Un fait elementaire : sujet-predicat-objet (comme une phrase simple) | SW-2 |
-| **Graphe RDF** | Un ensemble de triplets formant un reseau semantique | SW-3 |
-| **SPARQL** | Le SQL du Web Semantique : interroger des graphes avec des patterns | SW-4 |
-| **Linked Data** | Des donnees publiees sur le Web avec des URIs resolvables | SW-5 |
-| **RDFS** | Un vocabulaire pour definir des hierarchies de classes et proprietes | SW-6 |
+| **Triplet RDF** | Un fait élémentaire : sujet-prédicat-objet (comme une phrase simple) | SW-2 |
+| **Graphe RDF** | Un ensemble de triplets formant un réseau sémantique | SW-3 |
+| **SPARQL** | Le SQL du Web Sémantique : interroger des graphes avec des patterns | SW-4 |
+| **Linked Data** | Des données publiées sur le Web avec des URIs résolvables | SW-5 |
+| **RDFS** | Un vocabulaire pour définir des hiérarchies de classes et propriétés | SW-6 |
 | **OWL** | Une logique de description pour le raisonnement automatique | SW-7 |
-| **SHACL** | Des contraintes de validation sur les graphes (comme des schemas JSON) | SW-8 |
-| **JSON-LD** | Du JSON avec un contexte semantique (le pont Web classique ↔ Web Semantique) | SW-9 |
-| **RDF-Star** | Des metadonnees sur les triplets (provenance, confiance, annotations) | SW-10 |
-| **Graphe de connaissances** | Un RDF riche, visualisable, requetable, ancre dans une ontologie | SW-11 |
-| **GraphRAG** | Un KG ancre dans un LLM pour du RAG structure (anti-hallucination) | SW-12 |
+| **SHACL** | Des contraintes de validation sur les graphes (comme des schémas JSON) | SW-8 |
+| **JSON-LD** | Du JSON avec un contexte sémantique (le pont Web classique ↔ Web Sémantique) | SW-9 |
+| **RDF-Star** | Des métadonnées sur les triplets (provenance, confiance, annotations) | SW-10 |
+| **Graphe de connaissances** | Un RDF riche, visualisable, requêtable, ancré dans une ontologie | SW-11 |
+| **GraphRAG** | Un KG ancré dans un LLM pour du RAG structuré (anti-hallucination) | SW-12 |
 
 ## Vue d'ensemble
 
@@ -43,11 +43,11 @@ La serie propose deliberement deux stacks : **.NET C#** (SW-1 a SW-7) pour les f
 |-------------|--------|
 | Notebooks principaux | 12 + 1 bonus |
 | Sidetracks Python | 4 optionnels |
-| Duree totale | ~10h + 45min (bonus) |
+| Durée totale | ~10h + 45min (bonus) |
 | Langages | .NET C# (1-7), Python (8-13) |
-| Niveau | Debutant a avance |
+| Niveau | Débutant à avancé |
 
-> **Nouvelle convention** : Tous les noms de notebooks incluent explicitement le langage (`CSharp` ou `Python`) pour une identification immediate.
+> **Nouvelle convention** : Tous les noms de notebooks incluent explicitement le langage (`CSharp` ou `Python`) pour une identification immédiate.
 
 ---
 
@@ -60,24 +60,24 @@ pip install rdflib pySHACL owlready2 kglab SPARQLWrapper
 # .NET (notebooks SW-1 a SW-7)
 dotnet restore
 
-# Premier notebook recommande (Python) :
+# Premier notebook recommandé (Python) :
 jupyter notebook SW-2b-Python-RDFBasics.ipynb
 
 # Ou en .NET :
 jupyter notebook SW-1-CSharp-Setup.ipynb
 ```
 
-Aucune API key requise pour les notebooks fondamentaux (SW-1 a SW-11). SW-12 (GraphRAG) necessite une cle LLM.
+Aucune API key requise pour les notebooks fondamentaux (SW-1 à SW-11). SW-12 (GraphRAG) nécessite une clé LLM.
 
 ---
 
-## Progression recommandee
+## Progression recommandée
 
 ### Parcours principal
-Suivez les notebooks **SW-1 a SW-12** dans l'ordre numerique pour une progression logique des concepts.
+Suivez les notebooks **SW-1 à SW-12** dans l'ordre numérique pour une progression logique des concepts.
 
 ### Sidetracks Python (optionnels)
-Les sidetracks marques `b-Python` sont des notebooks complementaires qui presentent l'equivalent Python des concepts .NET. Ils sont **optionnels** mais recommandes si vous souhaitez travailler avec Python plutot qu'avec .NET.
+Les sidetracks marqués `b-Python` sont des notebooks complémentaires qui présentent l'équivalent Python des concepts .NET. Ils sont **optionnels** mais recommandés si vous souhaitez travailler avec Python plutôt qu'avec .NET.
 
 | Sidetrack | Notebook principal | Contenu |
 |-----------|-------------------|---------|
@@ -88,57 +88,57 @@ Les sidetracks marques `b-Python` sont des notebooks complementaires qui present
 
 ---
 
-## Structure detaillee des notebooks
+## Structure détaillée des notebooks
 
 ### Partie 1 : Fondations RDF (.NET C#)
 
-Cette partie pose les fondations du Web Semantique en utilisant l'ecosysteme .NET avec la bibliotheque **dotNetRDF**.
+Cette partie pose les fondations du Web Sémantique en utilisant l'écosystème .NET avec la bibliothèque **dotNetRDF**.
 
-| # | Notebook | Duree | Sidetrack Python |
+| # | Notebook | Durée | Sidetrack Python |
 |---|----------|-------|------------------|
 | 1 | **SW-1-CSharp-Setup** | 20 min | - |
 | 2 | **SW-2-CSharp-RDFBasics** | 45 min | SW-2b-Python-RDFBasics |
 | 3 | **SW-3-CSharp-GraphOperations** | 50 min | - |
 | 4 | **SW-4-CSharp-SPARQL** | 45 min | SW-4b-Python-SPARQL |
 
-#### SW-1-CSharp-Setup : Premier pas dans le Web Semantique (20 min)
+#### SW-1-CSharp-Setup : Premier pas dans le Web Sémantique (20 min)
 
-Ce notebook d'introduction vous guide a travers l'installation de dotNetRDF et decouvre la vision historique du Web Semantique. Vous creerez votre premier graphe RDF "Hello World" et comprendrez l'architecture en couches du W3C.
+Ce notebook d'introduction vous guide à travers l'installation de dotNetRDF et découvre la vision historique du Web Sémantique. Vous créerez votre premier graphe RDF "Hello World" et comprendrez l'architecture en couches du W3C.
 
-**Points cles appris** :
+**Points clés appris** :
 - La pile technologique W3C : Unicode → URI → RDF → RDFS → OWL → SPARQL
 - Installation de dotNetRDF via NuGet dans .NET Interactive
-- Creation d'un graphe et assertion de triplets (sujet-predicat-objet)
-- Les differents types de noeuds : URI, blank nodes, litteraux
+- Création d'un graphe et assertion de triplets (sujet-prédicat-objet)
+- Les différents types de nœuds : URI, blank nodes, littéraux
 
-#### SW-2-CSharp-RDFBasics : Triples, Noeuds et Serialisation (45 min)
+#### SW-2-CSharp-RDFBasics : Triples, Nœuds et Sérialisation (45 min)
 
-Dans ce notebook, vous approfondirez votre comprehension du modele de donnees RDF. Vous manipulerez les differents types de noeuds et decouvrirez les principaux formats de serialisation.
+Dans ce notebook, vous approfondirez votre compréhension du modèle de données RDF. Vous manipulerez les différents types de nœuds et découvrirez les principaux formats de sérialisation.
 
-**Points cles appris** :
-- Structure d'un triplet RDF : sujet (URI/blank), predicat (URI), objet (URI/blank/literal)
-- Litteraux typés (xsd:integer, xsd:dateTime) et avec tags de langue ("Bonjour"@fr)
-- Formats de serialisation : Turtle, N-Triples, RDF/XML
-- Creation de namespaces pour simplifier l'ecriture
+**Points clés appris** :
+- Structure d'un triplet RDF : sujet (URI/blank), prédicat (URI), objet (URI/blank/literal)
+- Littéraux typés (xsd:integer, xsd:dateTime) et avec tags de langue ("Bonjour"@fr)
+- Formats de sérialisation : Turtle, N-Triples, RDF/XML
+- Création de namespaces pour simplifier l'écriture
 
 > **Sidetrack Python disponible** : [SW-2b-Python-RDFBasics](SW-2b-Python-RDFBasics.ipynb) - Equivalent Python avec rdflib
 
-#### SW-3-CSharp-GraphOperations : Manipulation Avancee de Graphes (50 min)
+#### SW-3-CSharp-GraphOperations : Manipulation Avancée de Graphes (50 min)
 
-Ce notebook couvre les operations quotidiennes sur les graphes RDF : lecture/ecriture, fusion, et selection avancee avec LINQ.
+Ce notebook couvre les opérations quotidiennes sur les graphes RDF : lecture/écriture, fusion, et sélection avancée avec LINQ.
 
-**Points cles appris** :
+**Points clés appris** :
 - Parsers (`TurtleParser`, `NTriplesParser`) et Writers (`CompressingTurtleWriter`, `RdfXmlWriter`)
-- Fusion de graphes avec `Merge()` : deduplication automatique, renommage des blank nodes
-- Methodes `GetTriplesWithXxx()` pour la selection pattern-based
-- Utilisation de LINQ pour des requetes complexes sur les triplets
+- Fusion de graphes avec `Merge()` : déduplication automatique, renommage des blank nodes
+- Méthodes `GetTriplesWithXxx()` pour la sélection pattern-based
+- Utilisation de LINQ pour des requêtes complexes sur les triplets
 - Listes RDF : `AssertList()`, `GetListItems()`, `AddToList()`
 
-#### SW-4-CSharp-SPARQL : Le Langage de Requete (45 min)
+#### SW-4-CSharp-SPARQL : Le Langage de Requête (45 min)
 
-SPARQL est au RDF ce que SQL est aux bases de donnees relationnelles. Ce notebook vous apprendra a interroger vos graphes avec le Query Builder de dotNetRDF.
+SPARQL est au RDF ce que SQL est aux bases de données relationnelles. Ce notebook vous apprendra à interroger vos graphes avec le Query Builder de dotNetRDF.
 
-**Points cles appris** :
+**Points clés appris** :
 - SELECT SPARQL : projections, patterns de base
 - Filtrage : `FILTER`, comparaisons, regex, tests d'existence
 - Jointures implicites et `OPTIONAL` (LEFT JOIN semantics)
@@ -149,46 +149,46 @@ SPARQL est au RDF ce que SQL est aux bases de donnees relationnelles. Ce noteboo
 
 ---
 
-### Partie 2 : Donnees Liees et Ontologies (.NET C#)
+### Partie 2 : Données Liées et Ontologies (.NET C#)
 
-Cette partie etend vos competences aux donnees du Web ouvert et aux ontologies qui permettent le raisonnement automatique.
+Cette partie étend vos compétences aux données du Web ouvert et aux ontologies qui permettent le raisonnement automatique.
 
-| # | Notebook | Duree | Sidetrack Python |
+| # | Notebook | Durée | Sidetrack Python |
 |---|----------|-------|------------------|
 | 5 | **SW-5-CSharp-LinkedData** | 50 min | SW-5b-Python-LinkedData |
 | 6 | **SW-6-CSharp-RDFS** | 40 min | - |
 | 7 | **SW-7-CSharp-OWL** | 50 min | SW-7b-Python-OWL |
 
-#### SW-5-CSharp-LinkedData : DBpedia, Wikidata et Requetes Federees (50 min)
+#### SW-5-CSharp-LinkedData : DBpedia, Wikidata et Requêtes Fédérées (50 min)
 
-Decouvrez le Web de donnees liees en interrogeant des endpoints publics comme DBpedia et Wikidata.
+Découvrez le Web de données liées en interrogeant des endpoints publics comme DBpedia et Wikidata.
 
-**Points cles appris** :
+**Points clés appris** :
 - Endpoint SPARQL public vs. graphe local
-- `SparqlRemoteEndpoint` pour executer des requetes distantes
-- Requetes federees avec `SERVICE` : interroger plusieurs endpoints simultanement
-- Exploration de DBpedia : sujets, categories, liens inter-langues
+- `SparqlRemoteEndpoint` pour exécuter des requêtes distantes
+- Requêtes fédérées avec `SERVICE` : interroger plusieurs endpoints simultanément
+- Exploration de DBpedia : sujets, catégories, liens inter-langues
 - Wikidata et ses Q-items/P-properties
 
 > **Sidetrack Python disponible** : [SW-5b-Python-LinkedData](SW-5b-Python-LinkedData.ipynb) - DBpedia/Wikidata avec SPARQLWrapper
 
-#### SW-6-CSharp-RDFS : Schema et Inference (40 min)
+#### SW-6-CSharp-RDFS : Schema et Inférence (40 min)
 
-RDFS (RDF Schema) est la couche vocabulaire du Web Semantique. Ce notebook vous montre comment definir des classes, des proprietes et comment l'inference fonctionne.
+RDFS (RDF Schema) est la couche vocabulaire du Web Sémantique. Ce notebook vous montre comment définir des classes, des propriétés et comment l'inférence fonctionne.
 
-**Points cles appris** :
+**Points clés appris** :
 - Vocabulaire RDFS : `rdfs:Class`, `rdfs:subClassOf`, `rdfs:domain`, `rdfs:range`
-- Hierarchies de classes et transitivite de `subClassOf`
-- Inference RDFS : deduction automatique de types et de relations
-- `OntologyGraph` de dotNetRDF pour activer l'inference
+- Hiérarchies de classes et transitivité de `subClassOf`
+- Inférence RDFS : déduction automatique de types et de relations
+- `OntologyGraph` de dotNetRDF pour activer l'inférence
 
-#### SW-7-CSharp-OWL : Ontologies et Raisonnement Avance (50 min)
+#### SW-7-CSharp-OWL : Ontologies et Raisonnement Avancé (50 min)
 
-OWL (Web Ontology Language) etend RDFS avec des constructeurs logiques puissants. Ce notebook presente les profils OWL 2 et le raisonnement.
+OWL (Web Ontology Language) étend RDFS avec des constructeurs logiques puissants. Ce notebook présente les profils OWL 2 et le raisonnement.
 
-**Points cles appris** :
-- OWL 2 vs. RDFS : expressivite accrue (restrictions, cardinalites, disjonction)
-- Profils OWL 2 : EL (grandes ontologies), QL (query rewriting), RL (regles)
+**Points clés appris** :
+- OWL 2 vs. RDFS : expressivité accrue (restrictions, cardinalités, disjonction)
+- Profils OWL 2 : EL (grandes ontologies), QL (query rewriting), RL (règles)
 - Constructeurs clés : `owl:equivalentClass`, `owl:unionOf`, `owl:intersectionOf`
 - Restrictions : `owl:someValuesFrom` (∃), `owl:allValuesFrom` (∀)
 - Raisonnement avec `OntologyGraph`
@@ -199,41 +199,41 @@ OWL (Web Ontology Language) etend RDFS avec des constructeurs logiques puissants
 
 ### Partie 3 : Standards Modernes (Python uniquement)
 
-Cette partie couvre les standards modernes du Web Semantique, exclusivement en Python (ecosystem dominant pour l'IA).
+Cette partie couvre les standards modernes du Web Sémantique, exclusivement en Python (écosystème dominant pour l'IA).
 
-| # | Notebook | Duree | Contenu |
+| # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
-| 8 | **SW-8-Python-SHACL** | 45 min | Validation de donnees avec pySHACL |
-| 9 | **SW-9-Python-JSONLD** | 40 min | Donnees structurees pour le web |
+| 8 | **SW-8-Python-SHACL** | 45 min | Validation de données avec pySHACL |
+| 9 | **SW-9-Python-JSONLD** | 40 min | Données structurées pour le web |
 | 10 | **SW-10-Python-RDFStar** | 40 min | RDF 1.2, annotations et provenance |
 
-#### SW-8-Python-SHACL : Validation de Qualite des Donnees (45 min)
+#### SW-8-Python-SHACL : Validation de Qualité des Données (45 min)
 
-SHACL (Shapes Constraint Language) est le standard W3C pour valider la conformite des donnees RDF. Ce notebook utilise pySHACL pour definir des shapes et valider des graphes.
+SHACL (Shapes Constraint Language) est le standard W3C pour valider la conformité des données RDF. Ce notebook utilise pySHACL pour définir des shapes et valider des graphes.
 
-**Points cles appris** :
+**Points clés appris** :
 - Concepts SHACL : `NodeShape`, `PropertyShape`, contraintes
 - Contraintes communes : `sh:minCount`, `sh:maxCount`, `sh:datatype`, `sh:nodeKind`
-- `sh:property` pour valider les proprietes d'un noeud
+- `sh:property` pour valider les propriétés d'un nœud
 - `sh:pattern` (regex), `sh:in` (enum), `sh:class` (type checking)
 - Validation avec pySHACL : `Validate(graph, data_graph)`
 
-#### SW-9-Python-JSONLD : Donnees Structurees pour le Web (40 min)
+#### SW-9-Python-JSONLD : Données Structurées pour le Web (40 min)
 
-JSON-LD est le pont entre le monde JSON des developpeurs web et le Web Semantique. Ce notebook montre comment utiliser JSON-LD avec Schema.org pour le SEO.
+JSON-LD est le pont entre le monde JSON des développeurs web et le Web Sémantique. Ce notebook montre comment utiliser JSON-LD avec Schema.org pour le SEO.
 
-**Points cles appris** :
+**Points clés appris** :
 - Format JSON-LD : `@context`, `@id`, `@type` pour mapper JSON vers RDF
-- Integration Schema.org (vocabulaire Google, Bing, Yahoo)
+- Intégration Schema.org (vocabulaire Google, Bing, Yahoo)
 - Compactage et expansion JSON-LD avec `jsonld` Python
-- Rich snippets Google : 73% des resultats utilisent des donnees structurees
+- Rich snippets Google : 73% des résultats utilisent des données structurées
 - Cas d'usage : e-commerce (Produit), articles (Article), organisations (Organization)
 
 #### SW-10-Python-RDFStar : Annotations et Provenance (40 min)
 
-RDF-Star (RDF 1.2) permet d'exprimer des statements a propos de statements, essentiel pour les annotations, la provenance et la confiance.
+RDF-Star (RDF 1.2) permet d'exprimer des statements à propos de statements, essentiel pour les annotations, la provenance et la confiance.
 
-**Points cles appris** :
+**Points clés appris** :
 - Quoted triples : `<<<:s :p :o>>> :confidence 0.9`
 - Use cases : annotations, provenance, confiance, probabilites
 - Syntaxe Turtle-Star et N-Triples-Star
@@ -244,9 +244,9 @@ RDF-Star (RDF 1.2) permet d'exprimer des statements a propos de statements, esse
 
 ### Partie 4 : Graphes de Connaissances et IA (Python)
 
-Cette partie connecte le Web Semantique avec l'IA moderne, notamment les LLMs et les graphes de connaissances.
+Cette partie connecte le Web Sémantique avec l'IA moderne, notamment les LLMs et les graphes de connaissances.
 
-| # | Notebook | Duree | Contenu |
+| # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 11 | **SW-11-Python-KnowledgeGraphs** | 55 min | Construction et visualisation de KGs |
 | 12 | **SW-12-Python-GraphRAG** | 50 min | KG + LLMs pour le RAG |
@@ -254,50 +254,50 @@ Cette partie connecte le Web Semantique avec l'IA moderne, notamment les LLMs et
 
 #### SW-11-Python-KnowledgeGraphs : Construction et Visualisation (55 min)
 
-Ce notebook pratique vous guide dans la construction d'un graphe de connaissances complet, depuis des donnees brutes jusqu'a la visualisation interactive.
+Ce notebook pratique vous guide dans la construction d'un graphe de connaissances complet, depuis des données brutes jusqu'à la visualisation interactive.
 
-**Points cles appris** :
+**Points clés appris** :
 - kglab : abstraction haut niveau pour les KGs (Pandas + NetworkX + rdflib)
 - Import depuis CSV/JSON vers RDF
 - OWLReady2 : manipulation d'ontologies Python, raisonnement HermiT
 - Visualisation avec NetworkX et pyvis : graphes interactifs HTML
-- Patterns de modelling : entites, relations, attributs
+- Patterns de modélisation : entités, relations, attributs
 
 #### SW-12-Python-GraphRAG : KG + LLMs pour le RAG (50 min)
 
-GraphRAG combine les graphes de connaissances avec les LLMs pour un Retrieval-Augmented Generation structure. Ce notebook presente l'approche de Microsoft GraphRAG.
+GraphRAG combine les graphes de connaissances avec les LLMs pour un Retrieval-Augmented Generation structuré. Ce notebook présente l'approche de Microsoft GraphRAG.
 
-**Points cles appris** :
+**Points clés appris** :
 - RAP (Retrieval-Augmented Generation) : limiter les hallucinations LLM
-- GraphRAG Microsoft : extraction d'entites, construction de communautes
+- GraphRAG Microsoft : extraction d'entités, construction de communautés
 - LeMay-Huan framework : KG + LLM pour question answering
-- Implementation avec OpenAI/Anthropic APIs
-- Comparaison RAP vectoriel vs. RAP structure (GraphRAG)
+- Implémentation avec OpenAI/Anthropic APIs
+- Comparaison RAP vectoriel vs. RAP structuré (GraphRAG)
 
 #### SW-13-Python-Reasoners (Bonus) : Benchmarks et Performances (45 min)
 
-Ce notebook bonus compare differents raisonneurs OWL (owlrl, HermiT, reasonable, Growl) sur des criteres de performance et de facilite d'integration.
+Ce notebook bonus compare différents raisonneurs OWL (owlrl, HermiT, reasonable, Growl) sur des critères de performance et de facilité d'intégration.
 
-**Points cles appris** :
-- owlrl : Python pur, OWL 2 RL, facile a installer
+**Points clés appris** :
+- owlrl : Python pur, OWL 2 RL, facile à installer
 - OWLReady2 + HermiT : Java bridge, OWL 2 DL complet
 - reasonable : Rust + Python bindings, OWL 2 RL, performance native
-- Growl : C (verifie Z3), OWL 2 RL, installation manuelle
-- Benchmark temps d'execution : Python vs. compile
+- Growl : C (vérifié Z3), OWL 2 RL, installation manuelle
+- Benchmark temps d'exécution : Python vs. compilé
 
 ---
 
 ## Acquis d'apprentissage
 
-A l'issue de cette serie, l'apprenant est capable de :
+À l'issue de cette série, l'apprenant est capable de :
 
-- **Modeliser un domaine en RDF** (triplets, IRIs, litteraux typees, namespaces) et manipuler des graphes en C# avec dotNetRDF (`SW-2-CSharp-RDFBasics.ipynb`, `SW-3-CSharp-GraphOperations.ipynb`) ou en Python avec rdflib (`SW-2b-Python-RDFBasics.ipynb`).
-- **Interroger un graphe en SPARQL 1.1** (SELECT, CONSTRUCT, ASK, DESCRIBE, federations via SERVICE) cote .NET (`SW-4-CSharp-SPARQL.ipynb`) et Python (`SW-4b-Python-SPARQL.ipynb`), puis publier des donnees Linked Data resolvables (`SW-5-CSharp-LinkedData.ipynb`, `SW-5b-Python-LinkedData.ipynb`).
-- **Formaliser une ontologie en RDFS puis OWL** (classes, proprietes, restrictions, hierarchies) et tirer parti d'un raisonneur pour materialiser les inferences (`SW-6-CSharp-RDFS.ipynb`, `SW-7-CSharp-OWL.ipynb`, `SW-7b-Python-OWL.ipynb`, `SW-13-Python-Reasoners.ipynb`).
-- **Valider la conformite d'un graphe** avec SHACL (NodeShapes/PropertyShapes, contraintes de cardinalite et de type, rapport de validation) via pySHACL (`SW-8-Python-SHACL.ipynb`).
-- **Serialiser et echanger des donnees RDF en JSON-LD** (`@context`, framing, compaction/expansion) pour interoperer avec les APIs Web modernes (`SW-9-Python-JSONLD.ipynb`).
-- **Annoter des assertions avec RDF-Star / SPARQL-Star** (citations de triplets, provenance, niveau de confiance) pour modeliser metadonnees et reification compacte (`SW-10-Python-RDFStar.ipynb`).
-- **Construire et exploiter un graphe de connaissances integre a un LLM** (extraction de triplets, embeddings, GraphRAG) pour ancrer les reponses generatives sur des donnees structurees (`SW-11-Python-KnowledgeGraphs.ipynb`, `SW-12-Python-GraphRAG.ipynb`).
+- **Modéliser un domaine en RDF** (triplets, IRIs, littéraux typés, namespaces) et manipuler des graphes en C# avec dotNetRDF (`SW-2-CSharp-RDFBasics.ipynb`, `SW-3-CSharp-GraphOperations.ipynb`) ou en Python avec rdflib (`SW-2b-Python-RDFBasics.ipynb`).
+- **Interroger un graphe en SPARQL 1.1** (SELECT, CONSTRUCT, ASK, DESCRIBE, federations via SERVICE) côté .NET (`SW-4-CSharp-SPARQL.ipynb`) et Python (`SW-4b-Python-SPARQL.ipynb`), puis publier des données Linked Data résolvables (`SW-5-CSharp-LinkedData.ipynb`, `SW-5b-Python-LinkedData.ipynb`).
+- **Formaliser une ontologie en RDFS puis OWL** (classes, propriétés, restrictions, hiérarchies) et tirer parti d'un raisonneur pour matérialiser les inférences (`SW-6-CSharp-RDFS.ipynb`, `SW-7-CSharp-OWL.ipynb`, `SW-7b-Python-OWL.ipynb`, `SW-13-Python-Reasoners.ipynb`).
+- **Valider la conformité d'un graphe** avec SHACL (NodeShapes/PropertyShapes, contraintes de cardinalité et de type, rapport de validation) via pySHACL (`SW-8-Python-SHACL.ipynb`).
+- **Sérialiser et échanger des données RDF en JSON-LD** (`@context`, framing, compaction/expansion) pour interopérer avec les APIs Web modernes (`SW-9-Python-JSONLD.ipynb`).
+- **Annoter des assertions avec RDF-Star / SPARQL-Star** (citations de triplets, provenance, niveau de confiance) pour modéliser métadonnées et réification compacte (`SW-10-Python-RDFStar.ipynb`).
+- **Construire et exploiter un graphe de connaissances intégré à un LLM** (extraction de triplets, embeddings, GraphRAG) pour ancrer les réponses génératives sur des données structurées (`SW-11-Python-KnowledgeGraphs.ipynb`, `SW-12-Python-GraphRAG.ipynb`).
 
 ---
 
@@ -314,47 +314,47 @@ Si vous n'avez pas d'environnement .NET, vous pouvez suivre uniquement les noteb
 
 Pour les praticiens qui veulent aller vite :
 
-1. **SW-2b** (RDF en 5 min) → **SW-4b** (SPARQL) → **SW-8** (SHACL : valider vos donnees) → **SW-9** (JSON-LD : exposer en API) → **SW-12** (GraphRAG : connecter aux LLMs).
+1. **SW-2b** (RDF en 5 min) → **SW-4b** (SPARQL) → **SW-8** (SHACL : valider vos données) → **SW-9** (JSON-LD : exposer en API) → **SW-12** (GraphRAG : connecter aux LLMs).
 
 ### Parcours ontologue (~4h)
 
-Pour les personnes creant des ontologies et des vocabulaires :
+Pour les personnes créant des ontologies et des vocabulaires :
 
-1. **SW-6** (RDFS) → **SW-7** (OWL) → **SW-7b** (OWL Python) → **SW-8** (SHACL : contraintes sur les donnees) → **SW-13** (comparaison raisonneurs).
+1. **SW-6** (RDFS) → **SW-7** (OWL) → **SW-7b** (OWL Python) → **SW-8** (SHACL : contraintes sur les données) → **SW-13** (comparaison raisonneurs).
 
 ## FAQ / Troubleshooting
 
-| Probleme | Solution |
+| Problème | Solution |
 |----------|----------|
-| `dotNetRDF` NuGet restore echoue | Verifier .NET SDK 9.0+ (`dotnet --version`). Relancer la cellule d'import. |
-| Endpoint DBpedia/Wikidata timeout | Les endpoints publics ont des limites. Ajouter `LIMIT 100` aux requetes. Reessayer hors heures de pointe. |
-| pySHACL validation vide | Verifier que les prefixes du graphe de donnees correspondent aux shapes (meme `ex:` namespace). |
+| `dotNetRDF` NuGet restore échoue | Vérifier .NET SDK 9.0+ (`dotnet --version`). Relancer la cellule d'import. |
+| Endpoint DBpedia/Wikidata timeout | Les endpoints publics ont des limites. Ajouter `LIMIT 100` aux requêtes. Réessayer hors heures de pointe. |
+| pySHACL validation vide | Vérifier que les préfixes du graphe de données correspondent aux shapes (même `ex:` namespace). |
 | OWLReady2 Java bridge error | Installer JDK 11+ (OWlReady2 utilise HermiT en Java). Sur Windows : `winget install EclipseAdoptium.Temurin.11.JDK`. |
-| RDF-Star syntax non reconnue | rdflib 7.x supporte RDF-Star en mode experimental. Verifier `rdflib.__version__ >= 7.0`. |
-| GraphRAG : `OPENAI_API_KEY` manquant | SW-12 requiert une cle LLM (OpenAI ou Anthropic). Configurer `.env` (voir `.env.example`). Les notebooks SW-1 a SW-11 n'ont pas besoin de cle. |
+| RDF-Star syntax non reconnue | rdflib 7.x supporte RDF-Star en mode expérimental. Vérifier `rdflib.__version__ >= 7.0`. |
+| GraphRAG : `OPENAI_API_KEY` manquant | SW-12 requiert une clé LLM (OpenAI ou Anthropic). Configurer `.env` (voir `.env.example`). Les notebooks SW-1 à SW-11 n'ont pas besoin de clé. |
 
 ## Lecture transversale
 
-La serie SemanticWeb illustre un mouvement profond du depot CoursIA : **prendre des donnees non-structurees et les re-representer dans un cadre verifiable**. RDF donne un sens formel a du JSON, OWL ajoute le raisonnement, SHACL ajoute la validation, GraphRAG ancre les LLMs sur des faits. Ce geste — trouver la representation ou le probleme se dissout — traverse toutes les series du depot, des CSP (Search) aux preuves Lean (SymbolicAI). La cle de lecture [La mer qui monte](../../../docs/grothendieckian-lens.md) developpe ce fil conducteur.
+La série SemanticWeb illustre un mouvement profond du dépôt CoursIA : **prendre des données non-structurées et les re-représenter dans un cadre vérifiable**. RDF donne un sens formel à du JSON, OWL ajoute le raisonnement, SHACL ajoute la validation, GraphRAG ancre les LLMs sur des faits. Ce geste — trouver la représentation où le problème se dissout — traverse toutes les séries du dépôt, des CSP (Search) aux preuves Lean (SymbolicAI). La clé de lecture [La mer qui monte](../../../docs/grothendieckian-lens.md) développe ce fil conducteur.
 
 ---
 
 ## Prerequisites
 
-### Pour les notebooks .NET (SW-1 a SW-7)
+### Pour les notebooks .NET (SW-1 à SW-7)
 
 - .NET SDK 9.0+
 - .NET Interactive (Jupyter kernel)
-- VS Code avec Polyglot Notebooks (recommande)
+- VS Code avec Polyglot Notebooks (recommandé)
 
-### Pour les notebooks Python (SW-8 a SW-13 et sidetracks)
+### Pour les notebooks Python (SW-8 à SW-13 et sidetracks)
 
 - Python 3.10+
 - pip install -r requirements.txt
 
 ### Pour le notebook 12 (GraphRAG)
 
-- Cle API OpenAI ou Anthropic (voir `.env.example`)
+- Clé API OpenAI ou Anthropic (voir `.env.example`)
 
 ## Installation
 
@@ -377,18 +377,18 @@ pip install -r requirements.txt
 
 ```bash
 cp .env.example .env
-# Editer .env avec vos cles API
+# Éditer .env avec vos clés API
 ```
 
 ## Technologies et versions
 
 | Technologie | Version | Notebooks | Role |
 |-------------|---------|-----------|------|
-| dotNetRDF | 3.4.1 | SW-1 a SW-7 | Core RDF/SPARQL en .NET |
-| rdflib | 7.5.0 | Sidetracks, SW-8 a SW-12 | Core RDF/SPARQL en Python |
+| dotNetRDF | 3.4.1 | SW-1 à SW-7 | Core RDF/SPARQL en .NET |
+| rdflib | 7.5.0 | Sidetracks, SW-8 à SW-12 | Core RDF/SPARQL en Python |
 | pySHACL | 0.27.0 | SW-8 | Validation SHACL |
 | OWLReady2 | 0.50+ | SW-7b, SW-11 | Manipulation ontologies |
-| SPARQLWrapper | 2.0+ | SW-5b | Requetes endpoints distants |
+| SPARQLWrapper | 2.0+ | SW-5b | Requêtes endpoints distants |
 | kglab | 0.6.1+ | SW-11 | Abstraction graphes de connaissances |
 | owlrl | 6.0+ | SW-13 | Raisonneur OWL 2 RL Python pur |
 | reasonable | 0.1+ | SW-13 | Raisonneur OWL 2 RL Rust |
@@ -413,10 +413,10 @@ SemanticWeb/
 ├── .env.example
 ├── data/
 │   ├── Example.ttl          # Exemple Turtle
-│   ├── animals.ttl          # Hierarchie RDFS
+│   ├── animals.ttl          # Hiérarchie RDFS
 │   ├── university.owl       # Ontologie OWL 2
 │   ├── person-shape.ttl     # Shapes SHACL
-│   ├── person-data.ttl      # Donnees test (avec erreurs)
+│   ├── person-data.ttl      # Données test (avec erreurs)
 │   └── movies.csv           # Dataset pour KG
 ├── SW-1-CSharp-Setup.ipynb
 ├── SW-2-CSharp-RDFBasics.ipynb
@@ -436,27 +436,27 @@ SemanticWeb/
 ├── SW-12-Python-GraphRAG.ipynb
 ├── SW-13-Python-Reasoners.ipynb     # Bonus
 ├── movie_kg_interactive.html        # Livrable interactif SW-11 (pyvis)
-└── RDF.Net-Legacy/                  # Archive C# RDF.NET (pre-migration Python)
+└── RDF.Net-Legacy/                  # Archive C# RDF.NET (pré-migration Python)
     ├── RDF.Net.ipynb                # Notebook .NET historique
-    ├── Example.ttl                  # Donnees Turtle
-    ├── example.srj                  # Resultats SPARQL JSON
-    └── example.srx                  # Resultats SPARQL XML
+    ├── Example.ttl                  # Données Turtle
+    ├── example.srj                  # Résultats SPARQL JSON
+    └── example.srx                  # Résultats SPARQL XML
 ```
 
 > **Note** — `RDF.Net-Legacy/` conserve l'ancien notebook C# (kernel .NET Interactive)
-> avant la bascule pedagogique vers Python (`SW-2b-Python-RDFBasics.ipynb` et suivants).
-> Archive de reference, non maintenue. Pour le RDF actuel, voir SW-2 / SW-2b.
+> avant la bascule pédagogique vers Python (`SW-2b-Python-RDFBasics.ipynb` et suivants).
+> Archive de référence, non maintenue. Pour le RDF actuel, voir SW-2 / SW-2b.
 
 ## Ressources
 
-### References academiques
+### Références académiques
 
-| Reference | Couverture |
+| Référence | Couverture |
 |-----------|------------|
 | Berners-Lee, Hendler & Lassila, "The Semantic Web", *Scientific American* (2001) | Vision originale, introduction |
-| Russell & Norvig, *AIMA* 4e ed., ch. 12 "Knowledge Representation" | Cadre general IA symbolique |
+| Russell & Norvig, *AIMA* 4e ed., ch. 12 "Knowledge Representation" | Cadre général IA symbolique |
 | Hitzler et al., *Foundations of Semantic Web Technologies* (2010) | OWL, RDF, raisonnement |
-| Allemang & Hendler, *Semantic Web for the Working Ontologist* (2011) | Modelisation OWL/RDFS |
+| Allemang & Hendler, *Semantic Web for the Working Ontologist* (2011) | Modélisation OWL/RDFS |
 | Harris & Seaborne, "SPARQL 1.1 Query Language", W3C Rec. (2013) | Standard SPARQL |
 | Cyganiak, Wood & Lanthaler, "RDF 1.1 Concepts", W3C Rec. (2014) | Standard RDF |
 | Knublauch et al., "SHACL Shapes Constraint Language", W3C Rec. (2017) | Standard SHACL |
@@ -464,47 +464,47 @@ SemanticWeb/
 
 ### Ressources en ligne
 
-- [dotNetRDF](https://dotnetrdf.org/) - Bibliotheque .NET pour RDF
-- [rdflib](https://rdflib.readthedocs.io/) - Bibliotheque Python pour RDF
+- [dotNetRDF](https://dotnetrdf.org/) - Bibliothèque .NET pour RDF
+- [rdflib](https://rdflib.readthedocs.io/) - Bibliothèque Python pour RDF
 - [W3C RDF](https://www.w3.org/RDF/) - Standard RDF
 - [W3C SPARQL](https://www.w3.org/TR/sparql11-overview/) - Standard SPARQL
 - [W3C OWL](https://www.w3.org/OWL/) - Standard OWL
 - [W3C SHACL](https://www.w3.org/TR/shacl/) - Standard SHACL
-- [JSON-LD](https://json-ld.org/) - JSON pour les donnees liees
-- [DBpedia](https://dbpedia.org/) - Donnees structurees de Wikipedia
+- [JSON-LD](https://json-ld.org/) - JSON pour les données liées
+- [DBpedia](https://dbpedia.org/) - Données structurées de Wikipedia
 - [Wikidata](https://www.wikidata.org/) - Base de connaissances libre
 
 ## Connections cross-series
 
 ### SemanticWeb et Planners (Planification Automatique)
 
-Les graphes de connaissances RDF/OWL (SW-1 a SW-6) fournissent des representations riches du monde que les planificateurs PDDL (Planners-2 a Planners-9) peuvent exploiter :
+Les graphes de connaissances RDF/OWL (SW-1 à SW-6) fournissent des représentations riches du monde que les planificateurs PDDL (Planners-2 à Planners-9) peuvent exploiter :
 
-- **Ontologies OWL (SW-4/5) et domaines PDDL (Planners-6)** : les ontologies definissent les types et relations du domaine ; les fichiers PDDL definissent les actions et contraintes. Les deux formalisent la semantique d'un domaine pour le raisonnement automatique.
-- **SPARQL (SW-3) + planification** : les requetes SPARQL sur un graphe de connaissances peuvent generer les etats initiaux et buts d'un probleme de planification.
-- **GraphRAG (SW-12) + LLM Planning (Planners-10)** : le RAG base sur les graphes de connaissances ameliore la generation de plans par les LLMs en fournissant un contexte structure.
+- **Ontologies OWL (SW-4/5) et domaines PDDL (Planners-6)** : les ontologies définissent les types et relations du domaine ; les fichiers PDDL définissent les actions et contraintes. Les deux formalisent la sémantique d'un domaine pour le raisonnement automatique.
+- **SPARQL (SW-3) + planification** : les requêtes SPARQL sur un graphe de connaissances peuvent générer les états initiaux et buts d'un problème de planification.
+- **GraphRAG (SW-12) + LLM Planning (Planners-10)** : le RAG basé sur les graphes de connaissances améliore la génération de plans par les LLMs en fournissant un contexte structuré.
 
 ### SemanticWeb et Tweety (Logique et Argumentation)
 
 Les logiques de description (OWL) et les logiques classiques (Tweety) partagent des fondements communs :
 
-- **OWL-DL (SW-4/5) et logique propositionnelle/FOL (Tweety-2/3)** : OWL-DL est une logique de description decidable, fragment de la logique du premier ordre. Les SAT solvers de Tweety completent les raisonneurs OWL (HermiT, Pellet).
-- **SHACL (SW-7) et validation** : les contraintes SHACL sur les graphes RDF sont analogues aux contraintes logiques de Tweety. Les deux approches valident la coherence de bases de connaissances.
-- **Raisonnement monotone (OWL) vs non-monotone (Tweety-6/7)** : les ontologies OWL font du raisonnement monotone (ajout de faits ne retracte rien) ; Tweety explore le raisonnement non-monotone (defeasible, priorite).
+- **OWL-DL (SW-4/5) et logique propositionnelle/FOL (Tweety-2/3)** : OWL-DL est une logique de description décidable, fragment de la logique du premier ordre. Les SAT solvers de Tweety complètent les raisonneurs OWL (HermiT, Pellet).
+- **SHACL (SW-7) et validation** : les contraintes SHACL sur les graphes RDF sont analogues aux contraintes logiques de Tweety. Les deux approches valident la cohérence de bases de connaissances.
+- **Raisonnement monotone (OWL) vs non-monotone (Tweety-6/7)** : les ontologies OWL font du raisonnement monotone (ajout de faits ne rétracte rien) ; Tweety explore le raisonnement non-monotone (defeasible, priorité).
 
-### SemanticWeb et Lean (Verification Formelle)
+### SemanticWeb et Lean (Vérification Formelle)
 
-La verification de coherence des ontologies OWL est une forme de verification formelle :
+La vérification de cohérence des ontologies OWL est une forme de vérification formelle :
 
-- **OWL consistency checking** : les raisonneurs OWL prouvent la coherence d'une ontologie, similaire aux preuves Lean de correction de programmes.
-- **SHACL shapes** : les shapes SHACL sont des invariants sur les donnees RDF, analogues aux types dependants Lean comme specifications.
+- **OWL consistency checking** : les raisonneurs OWL prouvent la cohérence d'une ontologie, similaire aux preuves Lean de correction de programmes.
+- **SHACL shapes** : les shapes SHACL sont des invariants sur les données RDF, analogues aux types dépendants Lean comme spécifications.
 
 ### SemanticWeb et SmartContracts
 
-Les smart contracts et le web semantique convergent dans les donnees decentralisees :
+Les smart contracts et le web sémantique convergent dans les données décentralisées :
 
-- **Graphes de connaissances on-chain** : les NFTs ERC-721 (SC-7) avec metadonnees JSON-LD (SW-8) creent des graphes de connaissances decentraux. Les DID (Decentralized Identifiers) utilisent RDF pour l'identite auto-souveraine.
-- **Oracle data integration** : les oracles blockchain (SC-8 DeFi) peuvent servir de sources RDF pour enrichir les graphes de connaissances en temps reel.
+- **Graphes de connaissances on-chain** : les NFTs ERC-721 (SC-7) avec métadonnées JSON-LD (SW-8) créent des graphes de connaissances décentralisés. Les DID (Decentralized Identifiers) utilisent RDF pour l'identité auto-souveraine.
+- **Oracle data integration** : les oracles blockchain (SC-8 DeFi) peuvent servir de sources RDF pour enrichir les graphes de connaissances en temps réel.
 
 ---
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -7,27 +7,27 @@ breakdown: SmartContracts=27
 maturity: PRODUCTION=27
 -->
 
-Serie de notebooks educatifs couvrant les fondements cryptographiques, le développement Solidity, les tests, la cryptographie avancée (ZKP, HE, vote verifiable), et les blockchains alternatives.
+Série de notebooks éducatifs couvrant les fondements cryptographiques, le développement Solidity, les tests, la cryptographie avancée (ZKP, HE, vote vérifiable), et les blockchains alternatives.
 
-Un smart contract est un programme qui s'execute tout seul sur une blockchain : une fois déployé, son code fait foi, transfere de la valeur et applique des règles sans intermédiaire ni possibilite de revenir en arrière. C'est ce qui fait sa puissance — des ecosystemes entiers (DeFi, NFT, DAO) reposent dessus — et son danger : un bug n'est pas un patch a pousser le lendemain, c'est une faille immuable qui peut couter des millions (le hack de The DAO en 2016, les exploits de ponts cross-chain). D'ou le poids accorde dans cette série aux **tests, au fuzzing et a la verification formelle** autant qu'au développement.
+Un smart contract est un programme qui s'exécute tout seul sur une blockchain : une fois déployé, son code fait foi, transfère de la valeur et applique des règles sans intermédiaire ni possibilité de revenir en arrière. C'est ce qui fait sa puissance — des écosystèmes entiers (DeFi, NFT, DAO) reposent dessus — et son danger : un bug n'est pas un patch à pousser le lendemain, c'est une faille immuable qui peut coûter des millions (le hack de The DAO en 2016, les exploits de ponts cross-chain). D'où le poids accordé dans cette série aux **tests, au fuzzing et à la vérification formelle** autant qu'au développement.
 
-Le parcours suit le fil annonce par le titre : on part des **primitives cryptographiques** des cypherpunks (hachage, arbres de Merkle, preuve de travail, signatures) pour comprendre *pourquoi* une blockchain tient, puis on construit en **Solidity** (types, heritage, standards ERC, DeFi, gouvernance), on **sécurise** (Foundry, invariants, verification formelle), on explore la **cryptographie pour la vie privee** (ZKP, chiffrement homomorphique, vote verifiable de bout en bout), avant d'élargir aux **chaines alternatives** (Vyper, XRP, Bitcoin Script, Move/Sui, Solana) et au **déploiement réel** sur testnet puis mainnet. L'objectif final n'est pas seulement de savoir ecrire un contrat, mais de savoir le rendre digne de confiance.
+Le parcours suit le fil annoncé par le titre : on part des **primitives cryptographiques** des cypherpunks (hachage, arbres de Merkle, preuve de travail, signatures) pour comprendre *pourquoi* une blockchain tient, puis on construit en **Solidity** (types, héritage, standards ERC, DeFi, gouvernance), on **sécurise** (Foundry, invariants, vérification formelle), on explore la **cryptographie pour la vie privée** (ZKP, chiffrement homomorphique, vote vérifiable de bout en bout), avant d'élargir aux **chaînes alternatives** (Vyper, XRP, Bitcoin Script, Move/Sui, Solana) et au **déploiement réel** sur testnet puis mainnet. L'objectif final n'est pas seulement de savoir écrire un contrat, mais de savoir le rendre digne de confiance.
 
 ---
 
 **27 notebooks** | **Kernel Python 3** | **~22 heures**
 
-**A qui s'adresse cette série** : développeurs Solidity, ingenieurs DeFi, specialistes security/blockchain, étudiants en IA symbolique interesses par la verification formelle. Un niveau intermédiaire en programmation est recommande — les bases de Python sont suffisantes, mais les concepts blockchain/cryptographie sont introduits progressivement.
+**À qui s'adresse cette série** : développeurs Solidity, ingénieurs DeFi, spécialistes security/blockchain, étudiants en IA symbolique intéressés par la vérification formelle. Un niveau intermédiaire en programmation est recommandé — les bases de Python sont suffisantes, mais les concepts blockchain/cryptographie sont introduits progressivement.
 
 ## Objectifs d'apprentissage
 
 A l'issue de cette série, vous serez capable de :
 
-1. **Construire** des smart contracts Solidity fonctionnels (types, fonctions, heritage, standards ERC)
-2. **Deployer** et interagir avec des contrats sur des blockchains réelles (Anvil, Sepolia, XRP testnet)
+1. **Construire** des smart contracts Solidity fonctionnels (types, fonctions, héritage, standards ERC)
+2. **Déployer** et interagir avec des contrats sur des blockchains réelles (Anvil, Sepolia, XRP testnet)
 3. **Tester** rigoureusement (unit tests, fuzzing, invariants) avec Foundry
 4. **Vérifier** formellement la correction de contrats (SMT solvers, Certora)
-5. **Implementer** des primitives cryptographiques from scratch (ZKP, chiffrement homomorphique, signatures)
+5. **Implémenter** des primitives cryptographiques from scratch (ZKP, chiffrement homomorphique, signatures)
 6. **Explorer** les blockchains alternatives (Vyper, XRP, Bitcoin Script, Move/Sui, Solana)
 7. **Déployer** en production sur testnet et mainnet
 
@@ -35,53 +35,53 @@ A l'issue de cette série, vous serez capable de :
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 27 (SC-0 a SC-26) |
-| Duree totale | ~22 heures |
+| Notebooks | 27 (SC-0 à SC-26) |
+| Durée totale | ~22 heures |
 | Langage | Python (kernel Jupyter) |
 | Kernels | Python 3 |
 | Outils | Foundry (forge/cast/anvil), web3.py, py-solcx |
 | Cryptographie | pycryptodome, phe, TenSEAL |
-| Niveaux | Debutant a Avance (Parties 0-6) |
+| Niveaux | Débutant à Avancé (Parties 0-6) |
 
 ## Parcours d'apprentissage
 
 ### Phase 1 : Fondations (~2h10)
 
-Les notebooks 0-2 posent les bases historiques et techniques. Le notebook 0 explore les primitives cryptographiques qui fondent la blockchain (hash, arbres de Merkle, preuve de travail, signatures, DHT). Le notebook 1 installe Foundry — forge, cast, anvil — l'outil de développement principal. Le notebook 2 configure web3.py + py-solcx pour compiler et déployer des contrats Solidity réellement sur Anvil (blockchain locale). A l'issue de cette phase, vous avez un environnement fonctionnel et deployez votre premier contrat.
+Les notebooks 0-2 posent les bases historiques et techniques. Le notebook 0 explore les primitives cryptographiques qui fondent la blockchain (hash, arbres de Merkle, preuve de travail, signatures, DHT). Le notebook 1 installe Foundry — forge, cast, anvil — l'outil de développement principal. Le notebook 2 configure web3.py + py-solcx pour compiler et déployer des contrats Solidity réellement sur Anvil (blockchain locale). À l'issue de cette phase, vous avez un environnement fonctionnel et déployez votre premier contrat.
 
 ### Phase 2 : Solidity Fondements (~2h30)
 
-Les notebooks 3-6 couvrent les bases de Solidity : types et variables (SC-3), fonctions et état (SC-4), heritage et interfaces (SC-5), erreurs et events (SC-6). Chaque notebook inclut un déploiement réel sur Anvil. Cette phase vise la maitrise du langage de base — pas de code Solidity ne peut être ecrit sans ces fondamentaux.
+Les notebooks 3-6 couvrent les bases de Solidity : types et variables (SC-3), fonctions et état (SC-4), héritage et interfaces (SC-5), erreurs et events (SC-6). Chaque notebook inclut un déploiement réel sur Anvil. Cette phase vise la maîtrise du langage de base — pas de code Solidity ne peut être écrit sans ces fondamentaux.
 
-### Phase 3 : Solidity Avance (~4h30)
+### Phase 3 : Solidity Avancé (~4h30)
 
-Les notebooks 7-11 abordent les standards token (ERC-20, ERC-721, ERC-1155), les primitives DeFi (AMM, lending, oracles), la gouvernance DAO, l'account abstraction (ERC-4337), et l'assistance LLM pour les smart contracts. C'est le coeur technique de la série — chaque concept est illustré par un contrat deployable.
+Les notebooks 7-11 abordent les standards token (ERC-20, ERC-721, ERC-1155), les primitives DeFi (AMM, lending, oracles), la gouvernance DAO, l'account abstraction (ERC-4337), et l'assistance LLM pour les smart contracts. C'est le cœur technique de la série — chaque concept est illustré par un contrat déployable.
 
-### Phase 4 : Testing et Securite (~2h15)
+### Phase 4 : Testing et Sécurité (~2h15)
 
-Les notebooks 12-14 traitent de la sécurité : tests unitaires Foundry (SC-12), fuzz testing et invariants (SC-13), verification formelle (SC-14). Cette phase est cruciale — un smart contract non teste est un contrat non deploable en production. La verification formelle (SMT solvers, Certora) represente le pont vers la preuve mathématique de correction.
+Les notebooks 12-14 traitent de la sécurité : tests unitaires Foundry (SC-12), fuzz testing et invariants (SC-13), vérification formelle (SC-14). Cette phase est cruciale — un smart contract non testé est un contrat non déployable en production. La vérification formelle (SMT solvers, Certora) représente le pont vers la preuve mathématique de correction.
 
-### Phase 5 : Cryptographie et Vie Privee (~3h)
+### Phase 5 : Cryptographie et Vie Privée (~3h)
 
-Les notebooks 15-17 construisent des primitives cryptographiques from scratch : preuves a connaissance nulle (Schnorr, Fiat-Shamir, sigma protocols), chiffrement homomorphique (Paillier, CKKS/TenSEAL), et un système de vote verifiable de bout en bout (ElectionGuard). Cette partie est la plus théorique mais la plus puissante — elle montre comment proteger la vie privee sur des blockchains transparentes.
+Les notebooks 15-17 construisent des primitives cryptographiques from scratch : preuves à connaissance nulle (Schnorr, Fiat-Shamir, sigma protocols), chiffrement homomorphique (Paillier, CKKS/TenSEAL), et un système de vote vérifiable de bout en bout (ElectionGuard). Cette partie est la plus théorique mais la plus puissante — elle montre comment protéger la vie privée sur des blockchains transparentes.
 
 ### Phase 6 : Blockchains Alternatives (~4h)
 
-Les notebooks 18-22 explorent cinq blockchains non-EVM : Vyper (smart contracts Python-like), XRP Ledger (xrpl-py, trust lines), Bitcoin Script (UTXO model), Move/Sui (modele objet), et Solana avec le framework Anchor. Chaque notebook est autonome et illustre un paradigme de programmation different.
+Les notebooks 18-22 explorent cinq blockchains non-EVM : Vyper (smart contracts Python-like), XRP Ledger (xrpl-py, trust lines), Bitcoin Script (UTXO model), Move/Sui (modèle objet), et Solana avec le framework Anchor. Chaque notebook est autonome et illustre un paradigme de programmation différent.
 
-### Phase 7 : Deploiement Reel (~3h45)
+### Phase 7 : Déploiement Réel (~3h45)
 
-Les notebooks 23-26 couvrent l'interoperabilite cross-chain, le déploiement sur testnet (Sepolia + XRP testnet), le déploiement mainnet (L2 Base/Polygon), et le projet capstone intègre. C'est la phase de transition vers le monde réel — tout le travail précédent sert a construire, tester et déployer un projet complet.
+Les notebooks 23-26 couvrent l'interopérabilité cross-chain, le déploiement sur testnet (Sepolia + XRP testnet), le déploiement mainnet (L2 Base/Polygon), et le projet capstone intégré. C'est la phase de transition vers le monde réel — tout le travail précédent sert à construire, tester et déployer un projet complet.
 
-## Parcours alternatives
+## Parcours alternatifs
 
 ### Parcours Solidity intensif (~8h)
 
-Se concentrer sur les phases 1-3 + phase 4 (testing) : SC-0, SC-1-2, SC-3 a SC-6, SC-7 a SC-11, SC-12-14. Idéal pour développeurs souhaitant maitriser rapidement le développement Ethereum.
+Se concentrer sur les phases 1-3 + phase 4 (testing) : SC-0, SC-1-2, SC-3 à SC-6, SC-7 à SC-11, SC-12-14. Idéal pour développeurs souhaitant maîtriser rapidement le développement Ethereum.
 
 ### Parcours Cryptographie (~3h)
 
-Les notebooks 15-17 : ZKP, chiffrement homomorphique, vote verifiable. Prerequis : notions de base en algèbre et probabilites. Pas necessaire de passer par les phases 1-4 (les primitives sont introduites in-context).
+Les notebooks 15-17 : ZKP, chiffrement homomorphique, vote vérifiable. Prérequis : notions de base en algèbre et probabilités. Pas nécessaire de passer par les phases 1-4 (les primitives sont introduites in-context).
 
 ### Parcours Blockchains alternatives (~4h)
 
@@ -89,18 +89,18 @@ Les notebooks 18-22 : Vyper, XRP, Bitcoin, Move, Solana. Chaque notebook est aut
 
 ### Parcours Security-first (~7h)
 
-Fondations (SC-0-2) + Solidity basique (SC-3-6) + Testing avancé (SC-12-14) + Verification formelle (SC-14). Pour développeurs souhaitant se specialiser en smart contract auditing.
+Fondations (SC-0-2) + Solidity basique (SC-3-6) + Testing avancé (SC-12-14) + Vérification formelle (SC-14). Pour développeurs souhaitant se spécialiser en smart contract auditing.
 
 ## Quel parcours choisir ?
 
-| Objectif | Parcours recommande | Duree |
+| Objectif | Parcours recommandé | Durée |
 |----------|-------------------|-------|
-| Decouvrir la blockchain | SC-0 → SC-1 → SC-2 → SC-3 | 3h |
+| Découvrir la blockchain | SC-0 → SC-1 → SC-2 → SC-3 | 3h |
 | Devenir développeur Solidity | Parcours Solidity intensif | 8h |
-| Specialiser en security | Parcours Security-first | 7h |
+| Spécialiser en sécurité | Parcours Security-first | 7h |
 | Cryptographie avancée | Parcours Cryptographie | 3h |
 | Explorer les chains non-EVM | Parcours alternatives | 4h |
-| De déployer en production | Parcours complet + SC-23-26 | 22h |
+| Se déployer en production | Parcours complet + SC-23-26 | 22h |
 | Comprendre DeFi | SC-7-8-9 | 2h30 |
 | Gouvernance DAO | SC-9-10-17 | 2h |
 
@@ -110,12 +110,12 @@ Fondations (SC-0-2) + Solidity basique (SC-3-6) + Testing avancé (SC-12-14) + V
 SmartContracts/
 ├── 00-Foundations/              # Histoire + Setup (3 notebooks)
 ├── 01-Solidity-Foundation/     # Fondements Solidity (4 notebooks)
-├── 02-Solidity-Advanced/       # Solidity avance (5 notebooks)
-├── 03-Foundry-Testing/         # Tests et securite (3 notebooks)
+├── 02-Solidity-Advanced/       # Solidity avancé (5 notebooks)
+├── 03-Foundry-Testing/         # Tests et sécurité (3 notebooks)
 ├── 04-Privacy-Cryptography/    # ZKP, HE, Vote E2E (3 notebooks)
 ├── 05-Alternative-Chains/      # Vyper, XRP, Bitcoin, Move, Solana (5 notebooks)
 ├── 06-Real-World/              # Cross-chain, deploy testnet/mainnet (4 notebooks)
-└── requirements.txt            # Dependances Python
+└── requirements.txt            # Dépendances Python
 ```
 
 ## Parcours recommande
@@ -150,20 +150,20 @@ SmartContracts/
 | Partie | Objectif principal | Livrable attendu |
 |--------|-------------------|------------------|
 | 0 | Installer l'environnement + comprendre les bases | Anvil en marche + 1er contrat déployé |
-| 1 | Maitriser le langage Solidity | Contrats types, fonctions, heritage fonctionnels |
-| 2 | Construire des protocoles DeFi complets | Token ERC-20 + AMM + DAO deployes |
-| 3 | Tester et verifier un contrat | Suite de tests, fuzzing, verification formelle |
+| 1 | Maîtriser le langage Solidity | Contrats types, fonctions, héritage fonctionnels |
+| 2 | Construire des protocoles DeFi complets | Token ERC-20 + AMM + DAO déployés |
+| 3 | Tester et vérifier un contrat | Suite de tests, fuzzing, vérification formelle |
 | 4 | Cacher des données sur blockchain publique | ZKP + chiffrement homomorphique fonctionnels |
-| 5 | Comprendre les architectures alternatives | Contracts deployes sur Vyper/XRP/Bitcoin/Move/Solana |
-| 6 | Deployer en production | Contrat sur testnet/mainnet + projet capstone |
+| 5 | Comprendre les architectures alternatives | Contracts déployés sur Vyper/XRP/Bitcoin/Move/Solana |
+| 6 | Déployer en production | Contrat sur testnet/mainnet + projet capstone |
 
 ## Progression
 
 ### Partie 0 : Fondations et Histoire (~2h10)
 
-| # | Notebook | Duree | Contenu |
+| # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
-| 0 | [SC-0-Cypherpunk-Origins](00-Foundations/SC-0-Cypherpunk-Origins.ipynb) | 60 min | Hash, Merkle, PoW, signatures, DHT - code executable |
+| 0 | [SC-0-Cypherpunk-Origins](00-Foundations/SC-0-Cypherpunk-Origins.ipynb) | 60 min | Hash, Merkle, PoW, signatures, DHT - code exécutable |
 | 1 | [SC-1-Setup-Foundry](00-Foundations/SC-1-Setup-Foundry.ipynb) | 30 min | Installation Foundry (forge, cast, anvil) |
 | 2 | [SC-2-Setup-Web3py](00-Foundations/SC-2-Setup-Web3py.ipynb) | 40 min | web3.py + py-solcx + compile/deploy réel |
 
@@ -171,18 +171,18 @@ SmartContracts/
 
 ### Partie 1 : Solidity Fondements (~2h30)
 
-| # | Notebook | Duree | Contenu |
+| # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 3 | [SC-3-Solidity-Basics](01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) | 40 min | Types, variables, structure |
 | 4 | [SC-4-Functions-State](01-Solidity-Foundation/SC-4-Functions-State.ipynb) | 45 min | Fonctions, modifiers, storage |
-| 5 | [SC-5-Inheritance](01-Solidity-Foundation/SC-5-Inheritance.ipynb) | 35 min | Heritage, interfaces |
+| 5 | [SC-5-Inheritance](01-Solidity-Foundation/SC-5-Inheritance.ipynb) | 35 min | Héritage, interfaces |
 | 6 | [SC-6-Errors-Events](01-Solidity-Foundation/SC-6-Errors-Events.ipynb) | 30 min | Erreurs, events |
 
-**Objectifs** : Maitriser les bases de Solidity avec déploiement réel sur anvil
+**Objectifs** : Maîtriser les bases de Solidity avec déploiement réel sur anvil
 
-### Partie 2 : Solidity Avance (~4h30)
+### Partie 2 : Solidity Avancé (~4h30)
 
-| # | Notebook | Duree | Contenu |
+| # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 7 | [SC-7-Token-Standards](02-Solidity-Advanced/SC-7-Token-Standards.ipynb) | 50 min | ERC-20, ERC-721, ERC-1155 |
 | 8 | [SC-8-DeFi-Primitives](02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb) | 55 min | AMM, lending, oracles |
@@ -194,46 +194,46 @@ SmartContracts/
 
 ### Partie 3 : Testing (~2h15)
 
-| # | Notebook | Duree | Contenu |
+| # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 12 | [SC-12-Foundry-Testing](03-Foundry-Testing/SC-12-Foundry-Testing.ipynb) | 45 min | Tests unitaires, cheatcodes |
 | 13 | [SC-13-Fuzz-Invariants](03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb) | 40 min | Fuzz testing, invariants |
-| 14 | [SC-14-Formal-Verification](03-Foundry-Testing/SC-14-Formal-Verification.ipynb) | 50 min | Verification formelle |
+| 14 | [SC-14-Formal-Verification](03-Foundry-Testing/SC-14-Formal-Verification.ipynb) | 50 min | Vérification formelle |
 
-**Objectifs** : Tests Solidity, fuzzing, verification formelle
+**Objectifs** : Tests Solidity, fuzzing, vérification formelle
 
-### Partie 4 : Cryptographie et Vie Privee (~3h)
+### Partie 4 : Cryptographie et Vie Privée (~3h)
 
-| # | Notebook | Duree | Contenu |
+| # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 15 | [SC-15-Zero-Knowledge-Proofs](04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb) | 60 min | Schnorr, Fiat-Shamir, Sigma protocols |
 | 16 | [SC-16-Homomorphic-Encryption](04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb) | 50 min | Paillier, CKKS/TenSEAL, Shamir |
-| 17 | [SC-17-E2E-Verifiable-Voting](04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb) | 70 min | Vote anonyme verifiable, ElectionGuard |
+| 17 | [SC-17-E2E-Verifiable-Voting](04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb) | 70 min | Vote anonyme vérifiable, ElectionGuard |
 
-**Objectifs** : ZKP from scratch, chiffrement homomorphique, vote E2E verifiable
+**Objectifs** : ZKP from scratch, chiffrement homomorphique, vote E2E vérifiable
 
 ### Partie 5 : Blockchains Alternatives (~4h)
 
-| # | Notebook | Duree | Contenu |
+| # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 18 | [SC-18-Vyper](05-Alternative-Chains/SC-18-Vyper.ipynb) | 45 min | Smart contracts Python-like |
 | 19 | [SC-19-Ripple-XRP](05-Alternative-Chains/SC-19-Ripple-XRP.ipynb) | 50 min | xrpl-py, testnet, trust lines |
 | 20 | [SC-20-Bitcoin-Scripting](05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb) | 50 min | UTXO, Script, python-bitcoinlib |
-| 21 | [SC-21-Move-Sui](05-Alternative-Chains/SC-21-Move-Sui.ipynb) | 50 min | Move, modele objet Sui |
+| 21 | [SC-21-Move-Sui](05-Alternative-Chains/SC-21-Move-Sui.ipynb) | 50 min | Move, modèle objet Sui |
 | 22 | [SC-22-Solana-Anchor](05-Alternative-Chains/SC-22-Solana-Anchor.ipynb) | 55 min | Solana, Anchor framework |
 
 **Objectifs** : Vyper, XRP, Bitcoin scripting, Move, Solana
 
 ### Partie 6 : Real-World (~3h45)
 
-| # | Notebook | Duree | Contenu |
+| # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
-| 23 | [SC-23-Cross-Chain](06-Real-World/SC-23-Cross-Chain.ipynb) | 45 min | Bridges, interoperabilite |
+| 23 | [SC-23-Cross-Chain](06-Real-World/SC-23-Cross-Chain.ipynb) | 45 min | Bridges, interopérabilité |
 | 24 | [SC-24-Testnet-Deploy](06-Real-World/SC-24-Testnet-Deploy.ipynb) | 50 min | Deploy Sepolia + XRP testnet |
 | 25 | [SC-25-Mainnet-Deploy](06-Real-World/SC-25-Mainnet-Deploy.ipynb) | 40 min | Deploy L2 (Base/Polygon) |
 | 26 | [SC-26-Final-Project](06-Real-World/SC-26-Final-Project.ipynb) | 90 min | Projet capstone complet |
 
-**Objectifs** : Deploiement réel, testnets, mainnet, projet intègre
+**Objectifs** : Déploiement réel, testnets, mainnet, projet intégré
 
 ## Technologies
 
@@ -248,27 +248,27 @@ SmartContracts/
 | **vyper** | Smart contracts Python-like | `pip install vyper` |
 | **python-bitcoinlib** | Bitcoin scripting | `pip install python-bitcoinlib` |
 
-## Concepts cles
+## Concepts clés
 
 | Concept | Description | Notebooks |
 |---------|-------------|-----------|
 | **Smart Contract** | Programme autonome sur blockchain, code = loi | Partout (SC-3+) |
 | **EVM** | Machine virtuelle Ethereum : stack-based, bytecode | SC-1, SC-3, SC-23-26 |
-| **Gas** | Mecanisme de tarification du calcul | SC-3, SC-4 |
+| **Gas** | Mécanisme de tarification du calcul | SC-3, SC-4 |
 | **Storage / Memory / Calldata** | Three tiers de données Solidity | SC-3, SC-4 |
-| **Inheritance & Interfaces** | Heritage multiple, abstract contracts | SC-5 |
+| **Inheritance & Interfaces** | Héritage multiple, abstract contracts | SC-5 |
 | **ERC Standards** | ERC-20 (fungible), ERC-721 (NFT), ERC-1155 (multi), ERC-4337 (AA) | SC-7, SC-10 |
 | **AMM** | Automated Market Maker — uniswap V2/V3 model | SC-8 |
 | **Oracle** | Pont de données externes vers on-chain | SC-8 |
-| **Fuzz Testing** | Testing avec generateur d'inputs aleatoires | SC-13 |
+| **Fuzz Testing** | Testing avec générateur d'inputs aléatoires | SC-13 |
 | **Formal Verification** | Preuve mathématique de correction (SMT, Certora) | SC-14 |
-| **Zero-Knowledge Proof** | Prouver sans reveler (Schnorr, Fiat-Shamir) | SC-15 |
+| **Zero-Knowledge Proof** | Prouver sans révéler (Schnorr, Fiat-Shamir) | SC-15 |
 | **Homomorphic Encryption** | Calculer sur données chiffrées (Paillier, CKKS) | SC-16 |
-| **Vote E2E Verifiable** | Secret + verifiable + comptable automatiquement | SC-17 |
-| **UTXO Model** | Modele transactionel de Bitcoin (non account-based) | SC-20 |
-| **Move Language** | Language de smart contracts a objets (Sui) | SC-21 |
-| **Cross-Chain Bridge** | Interoperabilite entre blockchains | SC-23 |
-| **Account Abstraction** | ERC-4337 : wallets sans cle privee traditionnelle | SC-10 |
+| **Vote E2E Verifiable** | Secret + vérifiable + comptable automatiquement | SC-17 |
+| **UTXO Model** | Modèle transactionnel de Bitcoin (non account-based) | SC-20 |
+| **Move Language** | Langage de smart contracts à objets (Sui) | SC-21 |
+| **Cross-Chain Bridge** | Interopérabilité entre blockchains | SC-23 |
+| **Account Abstraction** | ERC-4337 : wallets sans clé privée traditionnelle | SC-10 |
 
 ## Outils couverts
 
@@ -276,46 +276,46 @@ SmartContracts/
 |-------|------|----------------|--------------|
 | **Foundry (forge)** | Framework dev | Compilation, tests, déploiement Solidity | `curl -L https://foundry.paradigm.xyz | bash` |
 | **anvil** | Node Ethereum local | Blockchain locale pour dev | Inclus dans Foundry |
-| **cast** | CLI Ethereum | Lect/écriture sur chaines | Inclus dans Foundry |
-| **web3.py** | Bibliotheque Python | Interaction avec EVM | `pip install web3` |
+| **cast** | CLI Ethereum | Lect/écriture sur chaînes | Inclus dans Foundry |
+| **web3.py** | Bibliothèque Python | Interaction avec EVM | `pip install web3` |
 | **py-solcx** | Compilateur Solidity | Compilation Solidity pour Python | `pip install py-solcx` |
-| **pycryptodome** | Bibliotheque crypto | Hash, signatures, AES, Merkle | `pip install pycryptodome` |
+| **pycryptodome** | Bibliothèque crypto | Hash, signatures, AES, Merkle | `pip install pycryptodome` |
 | **phe** | Chiffrement homomorphique | Paillier (additif) | `pip install phe` |
 | **xrpl-py** | Client Ripple | Connexion XRP Ledger | `pip install xrpl-py` |
 | **vyper** | Compilateur Vyper | Smart contracts Python-like | `pip install vyper` |
-| **python-bitcoinlib** | Bibliotheque Bitcoin | Manipulation UTXO/Script | `pip install python-bitcoinlib` |
+| **python-bitcoinlib** | Bibliothèque Bitcoin | Manipulation UTXO/Script | `pip install python-bitcoinlib` |
 | **TenSEAL** | Homomorphic encryption | CKKS (multiplicatif) sur tensors | `pip install tensile` |
 
-## Prerequis
+## Prérequis
 
 ### Niveau en programmation attendu
 
 Cette série suppose un **niveau intermédiaire en programmation** :
 
-| Competence | Utilite dans la série | Niveau requis |
+| Compétence | Utilité dans la série | Niveau requis |
 |------------|---------------------|---------------|
 | **Python de base** (fonctions, classes, modules) | Tous les notebooks (kernel Jupyter) | Intermédiaire |
 | **Lignes de commande** (bash, git) | Setup (SC-1), testing (SC-12-14) | Intermédiaire |
-| **Concepts d'API / HTTP** | Interaction web3.py (SC-2, SC-24) | Elementaire |
+| **Concepts d'API / HTTP** | Interaction web3.py (SC-2, SC-24) | Élémentaire |
 | **Structures de données** (tables de hachage, listes) | Algorithmes crypto (SC-0, SC-15) | Intermédiaire |
-| **Notions de base en probabilites** | ZKP (SC-15), HE (SC-16) | Elementaire |
-| **Notions de base en algèbre** | Cryptographie (SC-0, SC-15-16) | Elementaire |
+| **Notions de base en probabilités** | ZKP (SC-15), HE (SC-16) | Élémentaire |
+| **Notions de base en algèbre** | Cryptographie (SC-0, SC-15-16) | Élémentaire |
 
-**Pas necessaire en pre-requis** : Solidity (enseigne dans la série), cryptography avancée (introduite in-context), connaissance des blockchains (introduite SC-0).
+**Pas nécessaire en prérequis** : Solidity (enseigné dans la série), cryptographie avancée (introduite in-context), connaissance des blockchains (introduite SC-0).
 
 ### Setup technique
 
-Toutes les dependances sont decrites dans `requirements.txt` et les scripts de setup `scripts/`. Un environnement Python 3.10+ est requis. Foundry est installe via le script d'installation inclut.
+Toutes les dépendances sont décrites dans `requirements.txt` et les scripts de setup `scripts/`. Un environnement Python 3.10+ est requis. Foundry est installé via le script d'installation inclus.
 
 ```bash
-# Installation des dependances Python
+# Installation des dépendances Python
 pip install -r requirements.txt
 
-# Verification
+# Vérification
 python setup_env.py --check
 ```
 
-## Demarrage Rapide
+## Démarrage Rapide
 
 ### macOS / Linux (natif)
 
@@ -330,7 +330,7 @@ python setup_env.py --setup
 python setup_env.py --start-anvil
 # ou directement: anvil
 
-# Ouvrir les notebooks et selectionner le kernel "Python (SmartContracts + Foundry)"
+# Ouvrir les notebooks et sélectionner le kernel "Python (SmartContracts + Foundry)"
 ```
 
 ### Windows (via WSL)
@@ -339,17 +339,17 @@ python setup_env.py --start-anvil
 # Depuis PowerShell, lance le setup dans WSL Ubuntu
 wsl -d Ubuntu -- bash /mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/setup.sh
 
-# Ou alternative en 2 etapes (WSL puis PowerShell)
-# Etape 1: dans WSL Ubuntu
+# Ou alternative en 2 étapes (WSL puis PowerShell)
+# Étape 1: dans WSL Ubuntu
 bash scripts/setup_wsl_smartcontracts.sh
-# Etape 2: dans PowerShell
+# Étape 2: dans PowerShell
 .\scripts\setup_wsl_kernel.ps1
 
 # Lancer anvil
 python setup_env.py --start-anvil
 ```
 
-### Verifier l'installation
+### Vérifier l'installation
 
 ```bash
 python setup_env.py --check
@@ -357,9 +357,9 @@ python setup_env.py --check
 
 ## Ressources Externes
 
-### References academiques
+### Références académiques
 
-| Reference | Couverture |
+| Référence | Couverture |
 |-----------|------------|
 | Nakamoto, "Bitcoin: A Peer-to-Peer Electronic Cash System" (2008) | SC-0, SC-20 |
 | Buterin, "Ethereum White Paper" (2014) | Fondements Ethereum, SC-1 a SC-10 |
@@ -381,30 +381,30 @@ python setup_env.py --check
 
 ## Cross-séries Bridges
 
-| Serie | Lien | Connection |
+| Série | Lien | Connection |
 | ------- | ------ | ----------- |
 | [Lean](../Lean/README.md) | Formal verification | Les SMT solvers (SC-14) et les preuves Lean 4 sont deux facettes de la même vérité -- la correction mathématique |
-| [GameTheory](../../GameTheory/README.md) | Voting & DAO | SC-9 (DAO) et SC-17 (vote E2E) sont des instances de theorie du choix social (Arrow, Sen) |
+| [GameTheory](../../GameTheory/README.md) | Voting & DAO | SC-9 (DAO) et SC-17 (vote E2E) sont des instances de théorie du choix social (Arrow, Sen) |
 | [Probas](../../Probas/README.md) | Decision & Risk | Minimax Regret (PyMC-19) s'applique aux smart contracts pour la gestion des incertitudes on-chain |
-| [SymbolicAI/SemanticWeb](../SemanticWeb/README.md) | Ontologies & Verification | Les ontologies peuvent formaliser les proprietes de contrats pour verification formelle |
-| [SymbolicAI/Tweety](../Tweety/README.md) | Non-monotonic reasoning | Le raisonnement non-monotone s'applique a la governance DAO (propositions retractables) |
+| [SymbolicAI/SemanticWeb](../SemanticWeb/README.md) | Ontologies & Verification | Les ontologies peuvent formaliser les propriétés de contrats pour vérification formelle |
+| [SymbolicAI/Tweety](../Tweety/README.md) | Non-monotonic reasoning | Le raisonnement non-monotone s'applique à la gouvernance DAO (propositions rétractables) |
 | [GenAI/Texte](../../GenAI/Texte/README.md) | LLM-assisted | SC-11 applique le même paradigme d'assistance LLM que la série GenAI Texte |
 
 ## Connections cross-séries
 
-### SmartContracts et Lean (Verification Formelle)
+### SmartContracts et Lean (Vérification Formelle)
 
-Les techniques de verification formelle presentees dans cette série (SC-14, fuzzing SC-13) complementent les méthodes de preuve formelle de la série Lean :
+Les techniques de vérification formelle présentées dans cette série (SC-14, fuzzing SC-13) complètent les méthodes de preuve formelle de la série Lean :
 
-- **SC-14 Formal Verification** (Certora, SMTChecker) vs. **Lean 4** : deux approches de la même idee -- prouver mathematiquement la correction d'un programme. Les SMT solvers (Z3, CVC5) sont automatiques mais bornes ; Lean est interactif mais expressif ( Curry-Howard, types dependants).
-- **SC-11 LLM-Assisted Contracts** : le même paradigme d'assistance LLM que les notebooks [Lean-7/8/9](../Lean/), applique a la génération de smart contracts.
+- **SC-14 Formal Verification** (Certora, SMTChecker) vs. **Lean 4** : deux approches de la même idée -- prouver mathématiquement la correction d'un programme. Les SMT solvers (Z3, CVC5) sont automatiques mais bornés ; Lean est interactif mais expressif ( Curry-Howard, types dépendants).
+- **SC-11 LLM-Assisted Contracts** : le même paradigme d'assistance LLM que les notebooks [Lean-7/8/9](../Lean/), appliqué à la génération de smart contracts.
 
-### SmartContracts et Theorie des Jeux (GameTheory)
+### SmartContracts et Théorie des Jeux (GameTheory)
 
-Les mecanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instances concretes des résultats formels de la série GameTheory :
+Les mécanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instances concrètes des résultats formels de la série GameTheory :
 
-- **SC-9 DAO Governance** : les systèmes de vote on-chain sont soumis aux mêmes limitations que le **theoreme d'Arrow** (formalise dans `social_choice_lean/Arrow.lean`, 0 sorry).
-- **SC-17 E2E Verifiable Voting** : les proprietes des systèmes de vote (Banks sets, monotonicite STV) sont étudiées formellement dans `social_choice_lean/Voting.lean`. Le chiffrement homomorphique (SC-16) et les ZKP (SC-15) sont les briques cryptographiques qui rendent le vote E2E possible.
+- **SC-9 DAO Governance** : les systèmes de vote on-chain sont soumis aux mêmes limitations que le **théorème d'Arrow** (formalisé dans `social_choice_lean/Arrow.lean`, 0 sorry).
+- **SC-17 E2E Verifiable Voting** : les propriétés des systèmes de vote (Banks sets, monotonie STV) sont étudiées formellement dans `social_choice_lean/Voting.lean`. Le chiffrement homomorphique (SC-16) et les ZKP (SC-15) sont les briques cryptographiques qui rendent le vote E2E possible.
 
 ### Lecture transversale
 
@@ -412,9 +412,9 @@ Les mecanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instanc
 
 ## FAQ / Troubleshooting
 
-### 1. Foundry non détecte ou `forge: command not found`
+### 1. Foundry non détecté ou `forge: command not found`
 
-**Symptome** : Les notebooks SC-1/SC-12 echouent avec `forge not found` ou `anvil not found`.
+**Symptôme** : Les notebooks SC-1/SC-12 échouent avec `forge not found` ou `anvil not found`.
 
 **Solutions** :
 
@@ -423,16 +423,16 @@ Les mecanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instanc
 curl -L https://foundry.paradigm.xyz | bash
 foundryup
 
-# Verifier l'installation
+# Vérifier l'installation
 forge --version
 anvil --version
 
-# Si deja installe mais non dans le PATH
+# Si déjà installé mais non dans le PATH
 export PATH="$HOME/.foundry/bin:$PATH"
 # Ajouter au ~/.bashrc ou ~/.zshrc pour persistance
 ```
 
-Sur **Windows**, Foundry s'execute via WSL. Verifier que les notebooks utilisent le bon kernel Python configuré pour WSL :
+Sur **Windows**, Foundry s'exécute via WSL. Vérifier que les notebooks utilisent le bon kernel Python configuré pour WSL :
 
 ```bash
 # Dans WSL
@@ -441,36 +441,36 @@ which forge && which anvil
 
 ### 2. `py-solcx` : erreur de compilation Solidity
 
-**Symptome** : `solcx` retourne une erreur de compilation ou "solc binary not found".
+**Symptôme** : `solcx` retourne une erreur de compilation ou "solc binary not found".
 
-**Cause** : `py-solcx` télécharge le compilateur `solc` a la première utilisation. Si le téléchargement echoue (proxy, pare-feu), la compilation echoue.
+**Cause** : `py-solcx` télécharge le compilateur `solc` à la première utilisation. Si le téléchargement échoue (proxy, pare-feu), la compilation échoue.
 
 **Solution** :
 
 ```python
 import solcx
-# Forcer l'installation d'une version specifique
+# Forcer l'installation d'une version spécifique
 solcx.install_solc("0.8.20")
-# Verifier les versions disponibles
+# Vérifier les versions disponibles
 print(solcx.get_installed_solc_versions())
-# Utiliser une version installee
+# Utiliser une version installée
 solcx.set_solc_version("0.8.20")
 ```
 
-Si le téléchargement est bloque, télécharger manuellement le binaire depuis [github.com/ethereum/solidity/releases](https://github.com/ethereum/solidity/releases) et le placer dans le repertoire indique par `solcx.get_solcx_install_folder()`.
+Si le téléchargement est bloqué, télécharger manuellement le binaire depuis [github.com/ethereum/solidity/releases](https://github.com/ethereum/solidity/releases) et le placer dans le répertoire indiqué par `solcx.get_solcx_install_folder()`.
 
-### 3. Anvil ne demarre pas ou port 8545 déjà pris
+### 3. Anvil ne démarre pas ou port 8545 déjà pris
 
-**Symptome** : `ConnectionRefusedError` lors des deploiements dans les notebooks SC-2/SC-3+.
+**Symptôme** : `ConnectionRefusedError` lors des déploiements dans les notebooks SC-2/SC-3+.
 
 **Diagnostic** :
 
 ```bash
-# Verifier si Anvil tourne deja
+# Vérifier si Anvil tourne déjà
 ps aux | grep anvil    # macOS/Linux
 tasklist | findstr anvil  # Windows/WSL
 
-# Verifier si le port 8545 est occupe
+# Vérifier si le port 8545 est occupé
 lsof -i :8545          # macOS/Linux
 netstat -ano | findstr 8545  # Windows
 ```
@@ -481,37 +481,37 @@ netstat -ano | findstr 8545  # Windows
 # Tuer un processus Anvil existant
 pkill anvil
 
-# Ou utiliser un port different
+# Ou utiliser un port différent
 anvil --port 8546
 # Adapter les notebooks: w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8546"))
 ```
 
 ### 4. Erreurs `web3.py` : "insufficient funds" ou "nonce too low"
 
-**Symptome** : Les transactions echouent lors du déploiement dans les notebooks.
+**Symptôme** : Les transactions échouent lors du déploiement dans les notebooks.
 
 **Causes et solutions** :
 
 | Erreur | Cause | Solution |
 | ------ | ----- | -------- |
-| `insufficient funds` | Compte Anvil non finance | Redemarrer Anvil (les comptes sont reinitialises) ou utiliser `anvil --accounts 10 --balance 10000` |
-| `nonce too low` | Transaction envoyee avec un nonce déjà utilise | Appeler `w3.eth.get_transaction_count(address)` pour obtenir le nonce courant |
+| `insufficient funds` | Compte Anvil non financé | Redémarrer Anvil (les comptes sont réinitialisés) ou utiliser `anvil --accounts 10 --balance 10000` |
+| `nonce too low` | Transaction envoyée avec un nonce déjà utilisé | Appeler `w3.eth.get_transaction_count(address)` pour obtenir le nonce courant |
 | `replacement fee too low` | Remplacement de transaction avec gas insuffisant | Augmenter `gasPrice` de 10% minimum |
-| `execution reverted` | Erreur dans le contrat Solidity | Verifier les `require()` et les conditions dans le code Solidity |
+| `execution reverted` | Erreur dans le contrat Solidity | Vérifier les `require()` et les conditions dans le code Solidity |
 
-**Astuce** : Les comptes Anvil par défaut ont 10000 ETH chacun. Si les fonds semblent manquants, redemarrer Anvil pour reinitialiser l'etat.
+**Astuce** : Les comptes Anvil par défaut ont 10000 ETH chacun. Si les fonds semblent manquants, redémarrer Anvil pour réinitialiser l'état.
 
-### 5. Erreurs d'import des bibliotheques cryptographiques
+### 5. Erreurs d'import des bibliothèques cryptographiques
 
-**Symptome** : `ImportError` pour `Crypto`, `phe`, `tensile` ou `xrpl`.
+**Symptôme** : `ImportError` pour `Crypto`, `phe`, `tensile` ou `xrpl`.
 
-**Cause** : Dependances non installees ou conflit de nom de package.
+**Cause** : Dépendances non installées ou conflit de nom de package.
 
 **Solutions** :
 
 ```bash
-# pycryptodome (attention: pas pycrypto qui est obsolete)
-pip uninstall pycrypto   # si installe par erreur
+# pycryptodome (attention: pas pycrypto qui est obsolète)
+pip uninstall pycrypto   # si installé par erreur
 pip install pycryptodome
 
 # TenSEAL (chiffrement homomorphique, SC-16)
@@ -524,27 +524,27 @@ pip install phe
 pip install xrpl-py
 ```
 
-**Conflit connu** : si `import Crypto` echoue alors que `pycryptodome` est installe, verifier que `pycrypto` n'est pas installe en parallele (il ecrase le namespace). Desinstaller `pycrypto` et reinstalle `pycryptodome`.
+**Conflit connu** : si `import Crypto` échoue alors que `pycryptodome` est installé, vérifier que `pycrypto` n'est pas installé en parallèle (il écrase le namespace). Désinstaller `pycrypto` et réinstaller `pycryptodome`.
 
 ### 6. WSL : scripts de setup inaccessible ou permission denied
 
-**Symptome** : Les scripts `setup.sh` ou `setup_wsl_smartcontracts.sh` echouent sur Windows.
+**Symptôme** : Les scripts `setup.sh` ou `setup_wsl_smartcontracts.sh` échouent sur Windows.
 
 **Solutions** :
 
 ```bash
-# Verifier que WSL Ubuntu est installe
+# Vérifier que WSL Ubuntu est installé
 wsl --list --verbose
 
-# Donner les permissions d'execution
+# Donner les permissions d'exécution
 wsl -d Ubuntu -- chmod +x /mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/setup.sh
 
-# Executer le setup
+# Exécuter le setup
 wsl -d Ubuntu -- bash /mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/setup.sh
 ```
 
-Si le chemin contient des espaces, encapsuler dans des guillemets. Alternative : cloner le depot directement dans WSL (`~/CoursIA/`) plutot que d'utiliser `/mnt/c/`.
+Si le chemin contient des espaces, encapsuler dans des guillemets. Alternative : cloner le dépôt directement dans WSL (`~/CoursIA/`) plutôt que d'utiliser `/mnt/c/`.
 
 ---
 
-*Serie creee pour CoursIA - Issue #129*
+*Série créée pour CoursIA - Issue #129*

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/README.md
@@ -1,10 +1,10 @@
 # Mon Premier Projet Foundry — Counter
 
-Projet Foundry cree dans le cadre du notebook [SC-1-Setup-Foundry](../00-Foundations/SC-1-Setup-Foundry.ipynb). Premier contrat Solidity avec tests unitaires.
+Projet Foundry créé dans le cadre du notebook [SC-1-Setup-Foundry](../00-Foundations/SC-1-Setup-Foundry.ipynb). Premier contrat Solidity avec tests unitaires.
 
 ## Contrat : Counter.sol
 
-Compteur simple en Solidity 0.8.28 avec protection contre le underflow.
+Compteur simple en Solidity 0.8.28 avec protection contre l'underflow.
 
 | Fonction | Type | Description |
 |----------|------|-------------|
@@ -13,7 +13,7 @@ Compteur simple en Solidity 0.8.28 avec protection contre le underflow.
 | `getCount()` | `public view` | Retourne la valeur de `count` |
 | `count()` | `public view` | Getter automatique (variable `public`) |
 
-**Protection underflow** : `require(count > 0, "Cannot decrement below zero")` empêche le decrement en dessous de zero. Solidity 0.8+ a des checks natifs pour l'underflow arithmetique, mais le require explicite fournit un message d'erreur clair.
+**Protection underflow** : `require(count > 0, "Cannot decrement below zero")` empêche le décrément en dessous de zéro. Solidity 0.8+ a des checks natifs pour l'underflow arithmétique, mais le require explicite fournit un message d'erreur clair.
 
 ## Tests : Counter.t.sol
 
@@ -21,10 +21,10 @@ Compteur simple en Solidity 0.8.28 avec protection contre le underflow.
 
 | Test | Cas de test |
 |------|-------------|
-| `testIncrement` | Incrementation successive (0 -> 1 -> 2) |
-| `testDecrement` | Decrementation (2 -> 1) |
+| `testIncrement` | Incrémentation successive (0 -> 1 -> 2) |
+| `testDecrement` | Décrémentation (2 -> 1) |
 | `testDecrementZero` | Revert attendu quand `count == 0` |
-| `testPublicGetter` | Coherence entre `count()` (auto) et `getCount()` (explicite) |
+| `testPublicGetter` | Cohérence entre `count()` (auto) et `getCount()` (explicite) |
 
 ## Utilisation
 
@@ -48,7 +48,7 @@ mon-premier-projet/
 ├── test/
 │   └── Counter.t.sol        # Tests Foundry
 ├── script/
-│   └── Counter.s.sol        # Script de deploiement
+│   └── Counter.s.sol        # Script de déploiement
 ├── foundry.toml              # Configuration Foundry
 └── README.md
 ```

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/README.md
@@ -1,56 +1,56 @@
 # Scripts SmartContracts
 
-Ce repertoire contient les scripts de configuration de l'environnement pour la serie SmartContracts (Solidity + Foundry + analyse symbolique). L'environnement principal est cross-plateforme (Mac/Linux natif, Windows via WSL) et utilise un kernel Jupyter dedie `smartcontracts`.
+Ce répertoire contient les scripts de configuration de l'environnement pour la série SmartContracts (Solidity + Foundry + analyse symbolique). L'environnement principal est cross-plateforme (Mac/Linux natif, Windows via WSL) et utilise un kernel Jupyter dédié `smartcontracts`.
 
 ## Scripts disponibles
 
 ### Setup principal
 
-- [setup.sh](setup.sh) — Setup cross-plateforme : installe Foundry (`forge`, `cast`, `anvil`), cree un venv Python `~/.smartcontracts-venv`, installe les dependances, enregistre le kernel Jupyter `smartcontracts`. Detecte automatiquement l'OS (Mac natif / Linux natif / WSL).
+- [setup.sh](setup.sh) — Setup cross-plateforme : installe Foundry (`forge`, `cast`, `anvil`), crée un venv Python `~/.smartcontracts-venv`, installe les dépendances, enregistre le kernel Jupyter `smartcontracts`. Détecte automatiquement l'OS (Mac natif / Linux natif / WSL).
 
   ```bash
   # Mac/Linux (natif)
   bash scripts/setup.sh
 
-  # Windows (depuis PowerShell, delegue a WSL)
+  # Windows (depuis PowerShell, délègue à WSL)
   wsl -d Ubuntu -- bash /mnt/d/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/setup.sh
   ```
 
 ### Setup alternatif (Python)
 
-- `setup_env.py` (niveau parent) — Orchestrateur Python cross-plateforme. Detecte l'OS, installe les dependances, gere le cycle de vie anvil (natif sur Mac/Linux, via WSL sur Windows).
+- `setup_env.py` (niveau parent) — Orchestrateur Python cross-plateforme. Détecte l'OS, installe les dépendances, gère le cycle de vie anvil (natif sur Mac/Linux, via WSL sur Windows).
 
   ```bash
-  # Verification complete de l'environnement
+  # Vérification complète de l'environnement
   python setup_env.py --check
 
   # Setup complet (Mac/Linux natif, Windows via WSL)
   python setup_env.py --setup
 
-  # Demarrer/Arreter anvil
+  # Démarrer/Arrêter anvil
   python setup_env.py --start-anvil
   python setup_env.py --stop-anvil
   ```
 
 ### Setup WSL (Windows uniquement)
 
-- [setup_wsl_smartcontracts.sh](setup_wsl_smartcontracts.sh) — Variante WSL-only de `setup.sh` : installe Foundry, le venv Python avec les paquets Linux-only, et le wrapper de kernel `~/.smartcontracts-kernel-wrapper.sh` qui gere la conversion des chemins Windows -> WSL (workaround pour le bug Jupyter qui mange les backslashes).
+- [setup_wsl_smartcontracts.sh](setup_wsl_smartcontracts.sh) — Variante WSL-only de `setup.sh` : installe Foundry, le venv Python avec les paquets Linux-only, et le wrapper de kernel `~/.smartcontracts-kernel-wrapper.sh` qui gère la conversion des chemins Windows -> WSL (workaround pour le bug Jupyter qui mange les backslashes).
 
   ```bash
-  # A executer dans WSL Ubuntu
+  # À exécuter dans WSL Ubuntu
   bash setup_wsl_smartcontracts.sh
   ```
 
-- [setup_wsl_kernel.ps1](setup_wsl_kernel.ps1) — Enregistre le kernel Jupyter `SmartContracts (WSL)` cote Windows, pointe vers le wrapper installe par `setup_wsl_smartcontracts.sh`. A executer **apres** le script WSL.
+- [setup_wsl_kernel.ps1](setup_wsl_kernel.ps1) — Enregistre le kernel Jupyter `SmartContracts (WSL)` côté Windows, pointe vers le wrapper installé par `setup_wsl_smartcontracts.sh`. À exécuter **après** le script WSL.
 
   ```powershell
-  # PowerShell Windows, apres le setup WSL
+  # PowerShell Windows, après le setup WSL
   .\setup_wsl_kernel.ps1
   ```
 
 ### Template
 
-- [_wrapper_template.sh](_wrapper_template.sh) — Template de wrapper de kernel WSL. Gere le bug de conversion des chemins Windows transmis par Jupyter (backslashes manges par WSL) en recherchant le fichier de connexion dans les locations temp connues. Reference pour creer d'autres wrappers WSL (Tweety, Lean, etc.). **Ne pas executer directement** — utilise comme modele par `setup_wsl_smartcontracts.sh`.
+- [_wrapper_template.sh](_wrapper_template.sh) — Template de wrapper de kernel WSL. Gère le bug de conversion des chemins Windows transmis par Jupyter (backslashes mangés par WSL) en recherchant le fichier de connexion dans les locations temp connues. Référence pour créer d'autres wrappers WSL (Tweety, Lean, etc.). **Ne pas exécuter directement** — utilisé comme modèle par `setup_wsl_smartcontracts.sh`.
 
 ## Architecture des kernels
 
@@ -59,38 +59,38 @@ Ce repertoire contient les scripts de configuration de l'environnement pour la s
 | Mac/Linux natif | `smartcontracts` | Aucun (direct `~/.smartcontracts-venv/bin/python`) |
 | Windows (via WSL) | `SmartContracts (WSL)` | `~/.smartcontracts-kernel-wrapper.sh` (conversion chemins) |
 
-## Sequence d'installation Windows complete
+## Séquence d'installation Windows complète
 
 ```bash
-# Etape 1 : WSL Ubuntu
+# Étape 1 : WSL Ubuntu
 cd /mnt/d/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts
 bash setup_wsl_smartcontracts.sh
 ```
 
 ```powershell
-# Etape 2 : PowerShell Windows
+# Étape 2 : PowerShell Windows
 cd D:\CoursIA\MyIA.AI.Notebooks\SymbolicAI\SmartContracts\scripts
 .\setup_wsl_kernel.ps1
 ```
 
 ```text
-# Etape 3 : Redemarrer VSCode pour que le kernel soit detecte
+# Étape 3 : Redémarrer VSCode pour que le kernel soit détecté
 ```
 
-## Dependances installees
+## Dépendances installées
 
 - **Foundry** : `forge` (compilation), `cast` (interaction RPC), `anvil` (local node)
-- **Python** : voir `requirements.txt` au niveau de la serie SmartContracts (`web3`, `slither-analyzer`, `mythril` sous Linux)
+- **Python** : voir `requirements.txt` au niveau de la série SmartContracts (`web3`, `slither-analyzer`, `mythril` sous Linux)
 - **JDK 17+** : requis pour certains outils d'analyse symbolique JVM-based
 
 ## Troubleshooting
 
-- **Kernel ne demarre pas (Windows)** : verifier `wsl -d Ubuntu -- cat /tmp/smartcontracts-kernel-wrapper.log` pour les erreurs de conversion de chemin.
-- **`forge` introuvable** : le PATH peut ne pas etre charge ; lancer `source ~/.bashrc` dans WSL avant de demarrer Jupyter.
-- **Erreur d'installation `mythril` sur Mac** : `mythril` est Linux-only ; l'installation echoue silencieusement sur Mac, c'est attendu.
+- **Kernel ne démarre pas (Windows)** : vérifier `wsl -d Ubuntu -- cat /tmp/smartcontracts-kernel-wrapper.log` pour les erreurs de conversion de chemin.
+- **`forge` introuvable** : le PATH peut ne pas être chargé ; lancer `source ~/.bashrc` dans WSL avant de démarrer Jupyter.
+- **Erreur d'installation `mythril` sur Mac** : `mythril` est Linux-only ; l'installation échoue silencieusement sur Mac, c'est attendu.
 
 ## Voir aussi
 
-- [SmartContracts/README.md](../README.md) — Vue d'ensemble de la serie SmartContracts
-- [SymbolicAI/scripts/README.md](../../scripts/README.md) — Scripts SymbolicAI niveau serie
-- [.claude/rules/wsl-kernels.md](../../../../.claude/rules/wsl-kernels.md) — Regles HARD pour les kernels WSL
+- [SmartContracts/README.md](../README.md) — Vue d'ensemble de la série SmartContracts
+- [SymbolicAI/scripts/README.md](../../scripts/README.md) — Scripts SymbolicAI niveau série
+- [.claude/rules/wsl-kernels.md](../../../../.claude/rules/wsl-kernels.md) — Règles HARD pour les kernels WSL

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -1,4 +1,4 @@
-# TweetyProject - Serie de Notebooks Jupyter
+# TweetyProject - Série de Notebooks Jupyter
 
 <!-- CATALOG-STATUS
 series: SymbolicAI-Tweety
@@ -7,43 +7,43 @@ breakdown: Tweety=10
 maturity: PRODUCTION=10
 -->
 
-Serie complete de 10 notebooks pour explorer [TweetyProject](https://tweetyproject.org/), une bibliotheque Java pour l'intelligence artificielle symbolique.
+Série complète de 10 notebooks pour explorer [TweetyProject](https://tweetyproject.org/), une bibliothèque Java pour l'intelligence artificielle symbolique.
 
-## Serie en quelques mots
+## Série en quelques mots
 
 **10 notebooks** | **1 kernel** | **~6h de travail** | **Tweety 1.30**
 
-**A qui s'adresse cette serie** : etudiants en IA, chercheurs en argumentation computationnelle, developpeurs interesses par le raisonnement formel, et tout curieux souhaitant comprendre les bases mathematiques derriere le raisonnement explicite. Aucun prerequis en logique formelle n'est suppose : les concepts sont introduces progressivement, des operateurs propositionnels de base jusqu'aux semantiques d'argumentation les plus avancees.
+**À qui s'adresse cette série** : étudiants en IA, chercheurs en argumentation computationnelle, développeurs intéressés par le raisonnement formel, et tout curieux souhaitant comprendre les bases mathématiques derrière le raisonnement explicite. Aucun prérequis en logique formelle n'est supposé : les concepts sont introduits progressivement, des opérateurs propositionnels de base jusqu'aux sémantiques d'argumentation les plus avancées.
 
-## Presentation
+## Présentation
 
-TweetyProject est une collection de bibliotheques Java couvrant plusieurs domaines :
+TweetyProject est une collection de bibliothèques Java couvrant plusieurs domaines :
 
 - **Logiques formelles** : Propositionnelle, Premier ordre, Modale, Description, QBF
 - **Argumentation computationnelle** : Dung, ASPIC+, DeLP, ABA, ADF
-- **Revision de croyances** : AGM, Mesures d'incoherence, MUS/MCS
+- **Révision de croyances** : AGM, Mesures d'incohérence, MUS/MCS
 - **Agents et dialogues** : Multi-agents, Protocoles argumentatifs
-- **Preferences et vote** : Ordres de preference, Agregation
+- **Préférences et vote** : Ordres de préférence, Agrégation
 
-Les notebooks utilisent **JPype** pour integrer Java dans Python, permettant un apprentissage interactif.
+Les notebooks utilisent **JPype** pour intégrer Java dans Python, permettant un apprentissage interactif.
 
-A l'heure des modeles statistiques et des LLMs, pourquoi etudier ces logiques symboliques ? Parce qu'elles apportent ce que l'apprentissage seul ne garantit pas : un raisonnement **explicite, verifiable et explicable**. L'argumentation computationnelle (cadres de Dung, ASPIC+, ABA) modelise la facon dont des agents confrontent des arguments, gerent les contradictions et aboutissent a des conclusions justifiees — avec des applications en raisonnement juridique, en aide a la decision, en negociation multi-agents, et de plus en plus comme couche de controle au-dessus des LLMs (detecter les incoherences, structurer un debat). La revision de croyances (AGM) formalise comment un agent rationnel met a jour ses connaissances face a une information nouvelle ou contradictoire. L'interet de TweetyProject est de reunir tous ces formalismes sous un meme toit : on experimente d'une logique a l'autre sans avoir a reimplementer chaque solveur.
+À l'heure des modèles statistiques et des LLMs, pourquoi étudier ces logiques symboliques ? Parce qu'elles apportent ce que l'apprentissage seul ne garantit pas : un raisonnement **explicite, vérifiable et explicable**. L'argumentation computationnelle (cadres de Dung, ASPIC+, ABA) modélise la façon dont des agents confrontent des arguments, gèrent les contradictions et aboutissent à des conclusions justifiées — avec des applications en raisonnement juridique, en aide à la décision, en négociation multi-agents, et de plus en plus comme couche de contrôle au-dessus des LLMs (détecter les incohérences, structurer un débat). La révision de croyances (AGM) formalise comment un agent rationnel met à jour ses connaissances face à une information nouvelle ou contradictoire. L'intérêt de TweetyProject est de réunir tous ces formalismes sous un même toit : on expérimente d'une logique à l'autre sans avoir à réimplémenter chaque solveur.
 
 ## Symbolique vs. Statistique
 
-Pour comprendre ou se positionne cette serie, voici une comparaison entre les approches symbolique et statistique de l'IA :
+Pour comprendre où se positionne cette série, voici une comparaison entre les approches symbolique et statistique de l'IA :
 
 | Aspect | IA Symbolique (TweetyProject) | IA Statistique (ML/LLMs) |
 |--------|-------------------------------|--------------------------|
 | **Représentation** | Logiques formelles (PL, FOL, DL) | Vecteurs embeddings, poids neuronaux |
-| **Raisonnement** | Deduction formelle, verification | Inference probabiliste, approximation |
-| **Verifiabilite** | Preuves mathematiques, solveurs | Benchmarks empiriques, statistiques |
-| **Explicabilite** | Chaines de raisonnement lisibles | Boite noire, attention maps |
-| **Incoherence** | Detection MUS/MCS, SAT solver | Gradient instability, divergence |
-| **Force** | Garanties de correction | Adaptabilite, generalisation |
-| **Limite** | Complexe a escala | Manque de garanties formelles |
+| **Raisonnement** | Déduction formelle, vérification | Inférence probabiliste, approximation |
+| **Vérifiabilité** | Preuves mathématiques, solveurs | Benchmarks empiriques, statistiques |
+| **Explicabilité** | Chaînes de raisonnement lisibles | Boîte noire, attention maps |
+| **Incohérence** | Détection MUS/MCS, SAT solver | Gradient instability, divergence |
+| **Force** | Garanties de correction | Adaptabilité, généralisation |
+| **Limite** | Complexe à grande échelle | Manque de garanties formelles |
 
-Cette serie ne propose pas de choisir l'un ou l'autre, mais de **comprendre les deux**. L'intersection est d'ailleurs le front actif de la recherche : argumentation pour controler les LLMs, logiques neuronales, verification formelle de modeles generatifs.
+Cette série ne propose pas de choisir l'un ou l'autre, mais de **comprendre les deux**. L'intersection est d'ailleurs le front actif de la recherche : argumentation pour contrôler les LLMs, logiques neuronales, vérification formelle de modèles génératifs.
 
 ## Vue d'ensemble
 
@@ -51,9 +51,9 @@ Cette serie ne propose pas de choisir l'un ou l'autre, mais de **comprendre les 
 |-------------|--------|
 | Notebooks | 10 |
 | Cellules totales | ~375 |
-| Duree estimee | ~6h (tutorat) |
+| Durée estimée | ~6h (tutorat) |
 | Kernel | Python 3 (JPype/Java) |
-| Version Tweety | 1.30 recommande |
+| Version Tweety | 1.30 recommandée |
 | Solveurs externes | Clingo, SPASS, EProver, Z3, PySAT |
 | JARs Java | ~35 modules |
 
@@ -61,23 +61,23 @@ Cette serie ne propose pas de choisir l'un ou l'autre, mais de **comprendre les 
 
 ### Phase 1 : Fondations (Notebooks 1-3, ~1.5h)
 
-La serie debute avec le notebook 1 (Setup) qui configure toute l'environnement : telechargement automatique du JDK Zulu, des 35 JARs TweetyProject, et des outils externes (Clingo pour ASP, SPASS pour la logique modale, EProver pour le premier ordre). Une fois la JVM initialisee via JPype, le notebook 2 plonge dans les logiques fondamentales : la logique propositionnelle avec les operateurs booleens, la satisfaisabilite (SAT) via pySAT, et la logique du premier ordre avec la construction de signatures et le raisonnement avec EProver. Le notebook 3 etend ces fondations aux logiques de Description (DL) pour les ontologies, la logique modale (necessite/possibilite) pour le raisonnement sur les mondes possibles, les formules boolean quantifiees (QBF), et la logique conditionnelle pour le raisonnement defeasible. A l'issue de cette phase, vous maitrisez les outils de base du raisonnement formel.
+La série débute avec le notebook 1 (Setup) qui configure toute l'environnement : téléchargement automatique du JDK Zulu, des 35 JARs TweetyProject, et des outils externes (Clingo pour ASP, SPASS pour la logique modale, EProver pour le premier ordre). Une fois la JVM initialisée via JPype, le notebook 2 plonge dans les logiques fondamentales : la logique propositionnelle avec les opérateurs booléens, la satisfaisabilité (SAT) via pySAT, et la logique du premier ordre avec la construction de signatures et le raisonnement avec EProver. Le notebook 3 étend ces fondations aux logiques de Description (DL) pour les ontologies, la logique modale (nécessité/possibilité) pour le raisonnement sur les mondes possibles, les formules booléennes quantifiées (QBF), et la logique conditionnelle pour le raisonnement defeasible. À l'issue de cette phase, vous maîtrisez les outils de base du raisonnement formel.
 
-### Phase 2 : Revision de Croyances (Notebook 4, ~45 min)
+### Phase 2 : Révision de Croyances (Notebook 4, ~45 min)
 
-Ce notebook unique introduit la gestion de l'incoherence dans les systemes intelligents. Plutot que d'echouer face a des connaissances contradictoires, un systeme rationnel doit identifier les sources de conflit (MUS - Minimal Unsatisfiable Subsets), mesurer l'incoherence (scores et indices), et reelaborer ses croyances (revision AGM). Les outils pratiques incluent MaxSAT pour l'optimisation sous contraintes et le raisonnement multi-agents avec CrMas. C'est un pont entre les logiques pures et les systemes multi-agents.
+Ce notebook unique introduit la gestion de l'incohérence dans les systèmes intelligents. Plutôt que d'échouer face à des connaissances contradictoires, un système rationnel doit identifier les sources de conflit (MUS - Minimal Unsatisfiable Subsets), mesurer l'incohérence (scores et indices), et réélaborer ses croyances (révision AGM). Les outils pratiques incluent MaxSAT pour l'optimisation sous contraintes et le raisonnement multi-agents avec CrMas. C'est un pont entre les logiques pures et les systèmes multi-agents.
 
-### Phase 3 : Argumentation — De l'abstrait au structure (Notebooks 5-6, ~2h)
+### Phase 3 : Argumentation — De l'abstrait au structuré (Notebooks 5-6, ~2h)
 
-Les notebooks 5 et 6 constituent le cœur de la serie. Le notebook 5 introduit l'argumentation abstraite de Dung (1995) : un cadre ou des arguments s'attaquent mutuellement sans regarder leur contenu interne. On y explore les semantiques classiques (grounded, preferred, stable, semi-stable), la semantique CF2 pour les cycles, et les nouveautes 1.30 (equivalence de frameworks, explications, raisonnement causal). Le notebook 6 monte d'un cran de granularite avec l'argumentation structuree : ASPIC+ (arguments construits a partir de regles defeasibles), DeLP (logique defeasible programmee), ABA (argumentation par hypothese), et l'Answer Set Programming (ASP) via Clingo. La comparaison entre ces cadres montre que chacun offre un compromis different entre expressivite et calculabilite.
+Les notebooks 5 et 6 constituent le cœur de la série. Le notebook 5 introduit l'argumentation abstraite de Dung (1995) : un cadre où des arguments s'attaquent mutuellement sans regarder leur contenu interne. On y explore les sémantiques classiques (grounded, preferred, stable, semi-stable), la sémantique CF2 pour les cycles, et les nouveautés 1.30 (équivalence de frameworks, explications, raisonnement causal). Le notebook 6 monte d'un cran de granularité avec l'argumentation structurée : ASPIC+ (arguments construits à partir de règles defeasibles), DeLP (logique defeasible programmée), ABA (argumentation par hypothèse), et l'Answer Set Programming (ASP) via Clingo. La comparaison entre ces cadres montre que chacun offre un compromis différent entre expressivité et calculabilité.
 
 ### Phase 4 : Frameworks avances et probabilistes (Notebooks 7a-7b, ~1h)
 
-Le notebook 7a explore les extensions du cadre de Dung : ADF (Abstract Dialectical Frameworks, ou les arguments peuvent avoir plusieurs preconditions), les frameworks bipolaires (support + attaque), les WAF (Weighted Argument Frameworks avec attaques ponderees), les SAF (Social Argumentation Frameworks), les SetAF (attaques collectives), et les frameworks extends (attaques recursives sur des attaques). Le notebook 7b aborde deux axes differs : les semantiques de classement (ranking) qui assignent un niveau de credibilite a chaque argument plutot que des extensions binaires, et l'argumentation probabiliste ou les arguments portent des probabilities.
+Le notebook 7a explore les extensions du cadre de Dung : ADF (Abstract Dialectical Frameworks, où les arguments peuvent avoir plusieurs preconditions), les frameworks bipolaires (support + attaque), les WAF (Weighted Argument Frameworks avec attaques pondérées), les SAF (Social Argumentation Frameworks), les SetAF (attaques collectives), et les frameworks étendus (attaques récursives sur des attaques). Le notebook 7b aborde deux axes différents : les sémantiques de classement (ranking) qui assignent un niveau de crédibilité à chaque argument plutôt que des extensions binaires, et l'argumentation probabiliste où les arguments portent des probabilités.
 
 ### Phase 5 : Applications multi-agents (Notebooks 8-9, ~1h)
 
-La serie se conclut par deux notebooks applicatifs. Le notebook 8 modelise les dialogues argumentatifs entre agents : protocoles d'echange, jeux grounded, et loteries argumentatives. Le notebook 9 traite des preferences et de la theorie du vote : ordres de preference, regles d'agregation (Borda, Condorcet, Copeland), et leur connexion avec l'argumentation. C'est la passerelle vers la theorie des jeux et le choix social.
+La série se conclut par deux notebooks applicatifs. Le notebook 8 modélise les dialogues argumentatifs entre agents : protocoles d'échange, jeux grounded, et loteries argumentatives. Le notebook 9 traite des préférences et de la théorie du vote : ordres de préférence, règles d'agrégation (Borda, Condorcet, Copeland), et leur connexion avec l'argumentation. C'est la passerelle vers la théorie des jeux et le choix social.
 
 ### Parcours alternatifs
 
@@ -85,66 +85,66 @@ La serie se conclut par deux notebooks applicatifs. Le notebook 8 modelise les d
 
 Pour ceux qui souhaitent une base solide en logiques formelles avant l'argumentation :
 
-1. **Setup** (1) → **Logiques de base** (2) → **Logiques avancees** (3) → **Revision** (4)
-2. Puis choisir : **Argumentation abstraite** (5) pour la theorie pure, ou **Applications** (8-9) pour les cas d'usage
+1. **Setup** (1) → **Logiques de base** (2) → **Logiques avancées** (3) → **Révision** (4)
+2. Puis choisir : **Argumentation abstraite** (5) pour la théorie pure, ou **Applications** (8-9) pour les cas d'usage
 
 #### Parcours argumentation intensive (focus 5-7b, ~3.5h)
 
-Pour les etudiants en argumentation computationnelle, aller droit au but :
+Pour les étudiants en argumentation computationnelle, aller droit au but :
 
 1. **Setup rapide** (1) : ne garder que la partie configuration JVM
-2. **Logiques de base** (2) : section PL uniquement, skip FOL si deja connu
-3. **Argumentation abstraite** (5) : Dung + semantiques
-4. **Argumentation structuree** (6) : ASPIC+ et DeLP
-5. **Frameworks avances** (7a) : ADF + bipolarite
-6. **Ranking et probabiliste** (7b) : semantiques de classement
+2. **Logiques de base** (2) : section PL uniquement, skip FOL si déjà connu
+3. **Argumentation abstraite** (5) : Dung + sémantiques
+4. **Argumentation structurée** (6) : ASPIC+ et DeLP
+5. **Frameworks avancés** (7a) : ADF + bipolarité
+6. **Ranking et probabiliste** (7b) : sémantiques de classement
 
 #### Parcours applications (focus 8-9, ~1h)
 
-Pour les praticiens interessés par les applications multi-agents :
+Pour les praticiens intéressés par les applications multi-agents :
 
 1. **Setup** (1) + **Logiques de base** (2) : juste pour l'environnement
-2. **Argumentation abstraite** (5) : semantiques de Dung essentielles
+2. **Argumentation abstraite** (5) : sémantiques de Dung essentielles
 3. **Dialogues multi-agents** (8) : protocoles et jeux grounded
-4. **Preferences et vote** (9) : theorie du vote et aggregation
+4. **Préférences et vote** (9) : théorie du vote et agrégation
 
 ## Structure
 
-| # | Notebook | Theme | Duree |
+| # | Notebook | Thème | Durée |
 |---|----------|-------|-------|
 | **Fondations** |
 | 1 | [Tweety-1-Setup](Tweety-1-Setup.ipynb) | Configuration JVM, JARs, outils externes | 20 min |
 | 2 | [Tweety-2-Basic-Logics](Tweety-2-Basic-Logics.ipynb) | Logique Propositionnelle et FOL | 45 min |
 | 3 | [Tweety-3-Advanced-Logics](Tweety-3-Advanced-Logics.ipynb) | DL, Modale, QBF, Conditionnelle | 40 min |
-| **Revision de Croyances** |
-| 4 | [Tweety-4-Belief-Revision](Tweety-4-Belief-Revision.ipynb) | CrMas, MUS, MaxSAT, Mesures d'incoherence | 50 min |
+| **Révision de Croyances** |
+| 4 | [Tweety-4-Belief-Revision](Tweety-4-Belief-Revision.ipynb) | CrMas, MUS, MaxSAT, Mesures d'incohérence | 50 min |
 | **Argumentation** |
-| 5 | [Tweety-5-Abstract-Argumentation](Tweety-5-Abstract-Argumentation.ipynb) | Dung AF, Semantiques, CF2, Generation | 55 min |
+| 5 | [Tweety-5-Abstract-Argumentation](Tweety-5-Abstract-Argumentation.ipynb) | Dung AF, Sémantiques, CF2, Génération | 55 min |
 | 6 | [Tweety-6-Structured-Argumentation](Tweety-6-Structured-Argumentation.ipynb) | ASPIC+, DeLP, ABA, ASP | 60 min |
 | 7a | [Tweety-7a-Extended-Frameworks](Tweety-7a-Extended-Frameworks.ipynb) | ADF, Bipolar, WAF, SAF, SetAF, Extended | 50 min |
 | 7b | [Tweety-7b-Ranking-Probabilistic](Tweety-7b-Ranking-Probabilistic.ipynb) | Ranking Semantics, Probabiliste | 40 min |
 | **Applications** |
 | 8 | [Tweety-8-Agent-Dialogues](Tweety-8-Agent-Dialogues.ipynb) | Agents, Dialogues argumentatifs, Loteries | 35 min |
-| 9 | [Tweety-9-Preferences](Tweety-9-Preferences.ipynb) | Preferences, Theorie du vote | 30 min |
+| 9 | [Tweety-9-Preferences](Tweety-9-Preferences.ipynb) | Préférences, Théorie du vote | 30 min |
 
-**Duree totale estimee** : ~7 heures
+**Durée totale estimée** : ~7 heures
 
 ## En quoi chaque notebook est unique
 
-Chaque notebook introduit un concept ou cadre theorique specifique. Le tableau ci-dessous resume en une ligne l'apport pedagogique de chacun :
+Chaque notebook introduit un concept ou cadre théorique spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun :
 
-| # | Notebook | Concept clé enseigne |
+| # | Notebook | Concept clé enseigné |
 |---|----------|---------------------|
 | 1 | Setup | Boucle configuration : JVM → JPype → JARs → solveurs externes |
 | 2 | Basic Logics | SAT solving en pratique (pySAT) + formalisme FOL avec EProver |
 | 3 | Advanced Logics | Ontologies OWL (DL) + raisonnement modale (SPASS) + QBF |
-| 4 | Belief Revision | Identification de conflits (MUS) + revision AGM + MaxSAT |
-| 5 | Abstract Argumentation | Semantiques de Dung (grounded/stable/CF2) + frameworks aleatoires |
+| 4 | Belief Revision | Identification de conflits (MUS) + révision AGM + MaxSAT |
+| 5 | Abstract Argumentation | Sémantiques de Dung (grounded/stable/CF2) + frameworks aléatoires |
 | 6 | Structured Argumentation | Comparaison ASPIC+/DeLP/ABA/ASP — le cadre idéal selon le domaine |
-| 7a | Extended Frameworks | Au-dela de Dung : ADF, bipolarite, attaques ponderees et collectives |
+| 7a | Extended Frameworks | Au-delà de Dung : ADF, bipolarité, attaques pondérées et collectives |
 | 7b | Ranking & Probabilistic | Classement graduel des arguments + incertitude sur les arguments |
-| 8 | Agent Dialogues | Protocoles d'echange entre agents + negociation argumentative |
-| 9 | Preferences | Agrégation de preferences (Borda, Condorcet) + theorie du vote |
+| 8 | Agent Dialogues | Protocoles d'échange entre agents + négociation argumentative |
+| 9 | Preferences | Agrégation de préférences (Borda, Condorcet) + théorie du vote |
 
 ## Quick Start
 
@@ -152,33 +152,33 @@ Chaque notebook introduit un concept ou cadre theorique specifique. Le tableau c
 # 1. Installer les packages Python
 pip install jpype1 requests tqdm clingo z3-solver python-sat
 
-# 2. Ouvrir le notebook de setup (auto-telecharge JDK + JARs)
+# 2. Ouvrir le notebook de setup (auto-télécharge JDK + JARs)
 jupyter notebook Tweety-1-Setup.ipynb
 
-# 3. Executer toutes les cellules, puis passer a Tweety-2
+# 3. Exécuter toutes les cellules, puis passer à Tweety-2
 ```
 
-JDK 17 et les 35 JARs TweetyProject sont telecharges automatiquement par le notebook de setup. Aucune installation systeme requise.
+JDK 17 et les 35 JARs TweetyProject sont téléchargés automatiquement par le notebook de setup. Aucune installation système requise.
 
-## Prerequis
+## Prérequis
 
-### Niveau mathematique attendu
+### Niveau mathématique attendu
 
-Cette serie suppose une **maîtrise de base en logique et raisonnement** :
+Cette série suppose une **maîtrise de base en logique et raisonnement** :
 
-| Concept | Utilisation dans la serie | Notes de révision |
+| Concept | Utilisation dans la série | Notes de révision |
 |---------|--------------------------|-------------------|
-| Logique propositionnelle (ET, OU, NON, →) | Notebook 2 (PL), 5+ (argumentation) | Tables de verite, DNF/CNF, satisfaisabilite |
-| Logique du premier ordre (quantificateurs) | Notebook 2 (FOL), 3 (DL) | ∀, ∃, variables, predicats |
-| Graphes (noeuds, aretes) | Notebook 5 (Dung AF), 7a (SetAF) | Chemins, cycles, orientes |
+| Logique propositionnelle (ET, OU, NON, →) | Notebook 2 (PL), 5+ (argumentation) | Tables de vérité, DNF/CNF, satisfaisabilité |
+| Logique du premier ordre (quantificateurs) | Notebook 2 (FOL), 3 (DL) | ∀, ∃, variables, prédicats |
+| Graphes (nœuds, arêtes) | Notebook 5 (Dung AF), 7a (SetAF) | Chemins, cycles, orientés |
 | Ensembles (inclusion, union, intersection) | Partout (extensions, bases) | Ensembles finis, parties |
-| Raisonnement par recurrence | Notebook 3 (DL), 5 (semantiques) | Principe de recurrence bien-fondee |
+| Raisonnement par récurrence | Notebook 3 (DL), 5 (sémantiques) | Principe de récurrence bien-fondée |
 
-**Inutile de maitriser** : theorie de la preuve formelle, complexité computationnelle avancée (la complexite des semantiques de Dung est expliquee en contexte). Les concepts logiques sont introduits progressivement dans chaque notebook.
+**Inutile de maîtriser** : théorie de la preuve formelle, complexité computationnelle avancée (la complexité des sémantiques de Dung est expliquée en contexte). Les concepts logiques sont introduits progressivement dans chaque notebook.
 
-### Prerequis techniques
+### Prérequis techniques
 
-#### Python et dependances
+#### Python et dépendances
 
 ```bash
 pip install jpype1 requests tqdm clingo z3-solver python-sat
@@ -258,7 +258,7 @@ python scripts/download_tweety_tools.py --help
 | **EProver** | FOL haute performance | Non | Oui (installation complète) |
 | **Z3** | SMT solver, MARCO | `pip install z3-solver` | N/A (package Python) |
 | **PySAT** | SAT/MaxSAT moderne | `pip install python-sat` | N/A (package Python) |
-| **Native SAT** | Bibliotheques SAT JNI | Oui | Oui (DLLs Minisat, Lingeling) |
+| **Native SAT** | Bibliothèques SAT JNI | Oui | Oui (DLLs Minisat, Lingeling) |
 | **JDK 17** | JVM pour JPype | Oui (Zulu) | Non (trop volumineux) |
 | **JARs Tweety** | Bibliothèques Java | Oui (Maven Central) | Non (trop volumineux) |
 | **Resources** | Fichiers exemples | Oui (GitHub) | Non (fichiers de données) |
@@ -301,11 +301,11 @@ python scripts/download_tweety_tools.py --help
 
 | Limitation | Impact | Contournement |
 |------------|--------|---------------|
-| **CrMas/InformationObject** | Section revision multi-agents echoue | API refactorisee, classe supprimee |
-| **SimpleMlReasoner** | Bloque indefiniment | Utiliser SPASS externe |
-| **AF Learning** | ClassCastException | Bug interne, section desactivee |
-| **ADF natif SAT** | Raisonnement ADF incomplet | Necessite solveur SAT natif (non JPype) |
-| **FOL avec egalite** | Heap space sur grandes requetes | Utiliser EProver externe |
+| **CrMas/InformationObject** | Section révision multi-agents échoue | API refactorisée, classe supprimée |
+| **SimpleMlReasoner** | Bloque indéfiniment | Utiliser SPASS externe |
+| **AF Learning** | ClassCastException | Bug interne, section désactivée |
+| **ADF natif SAT** | Raisonnement ADF incomplet | Nécessite solveur SAT natif (non JPype) |
+| **FOL avec égalité** | Heap space sur grandes requêtes | Utiliser EProver externe |
 
 ## Modules TweetyProject Couverts
 
@@ -320,12 +320,12 @@ python scripts/download_tweety_tools.py --help
 | `logics.qbf` | Quantified Boolean Formulas | 3 |
 | `logics.cl` | Logique Conditionnelle | 3 |
 
-### Revision de Croyances (Notebook 4)
+### Révision de Croyances (Notebook 4)
 
 | Module | Description |
 |--------|-------------|
-| `beliefdynamics` | Operateurs de revision AGM |
-| `logics.pl.analysis` | Mesures d'incoherence |
+| `beliefdynamics` | Opérateurs de révision AGM |
+| `logics.pl.analysis` | Mesures d'incohérence |
 | `logics.pl.sat` | MUS, MaxSAT |
 
 ### Argumentation (Notebooks 5-7)
@@ -342,11 +342,11 @@ python scripts/download_tweety_tools.py --help
 | `arg.weighted` | Frameworks Pondérés | 7a |
 | `arg.social` | Argumentation Sociale | 7a |
 | `arg.setaf` | Attaques Collectives | 7a |
-| `arg.extended` | Attaques Recursives | 7a |
-| `arg.rankings` | Semantiques de Classement | 7b |
+| `arg.extended` | Attaques Récursives | 7a |
+| `arg.rankings` | Sémantiques de Classement | 7b |
 | `arg.prob` | Argumentation Probabiliste | 7b |
 
-### Agents et Preferences (Notebooks 8-9)
+### Agents et Préférences (Notebooks 8-9)
 
 | Module | Description | Notebook |
 |--------|-------------|----------|
@@ -354,7 +354,7 @@ python scripts/download_tweety_tools.py --help
 | `agents.dialogues` | Dialogues argumentatifs | 8 |
 | `agents.dialogues.oppmodels` | Jeux grounded (ArguingAgent) | 8 |
 | `agents.dialogues.lotteries` | Loteries argumentatives | 8 |
-| `preferences` | Ordres de preference, agregation | 9 |
+| `preferences` | Ordres de préférence, agrégation | 9 |
 
 ## Concepts clés
 
@@ -366,7 +366,7 @@ python scripts/download_tweety_tools.py --help
 | **Logique Modale** | Nécessité (□) et possibilité (◇), mondes possibles |
 | **Argumentation de Dung** | Frameworks abstraits, attaques, sémantiques (grounded, stable) |
 | **Argumentation structurée** | Arguments construits à partir de prémisses et règles |
-| **Revision AGM** | Mise à jour rationnelle de croyances face à l'information contradictoire |
+| **Révision AGM** | Mise à jour rationnelle de croyances face à l'information contradictoire |
 | **MUS/MCS** | Sous-ensembles insatisfaisables/maximaux — identifier les conflits |
 | **Answer Set Programming** | Programmation par modèles (ASP) via Clingo |
 | **Agrégation de préférences** | Borda, Condorcet, Copeland — combiner des opinions |
@@ -375,22 +375,22 @@ python scripts/download_tweety_tools.py --help
 
 | Domaine | Notebooks | Exemple concret |
 |---------|-----------|----------------|
-| **Juridique** | 5, 6, 8 | Argumentation légale, debats en cour, preuve par argument |
-| **Aide a la decision** | 4, 9 | Diagnostic médical, planification de ressources, vote |
-| **Multi-agents** | 8 | Negociation automatique, protocoles de dialogue |
-| **Ontologies** | 3 | Representations de connaissances, OWL, Web semantique |
-| **Verification formelle** | 2, 3, 4 | SAT/SMT solving, proof checking, model checking |
-| **LLM control** | 5, 6, 7b | Detection d'incoherences, structuration de debats, argumentation probabiliste |
+| **Juridique** | 5, 6, 8 | Argumentation légale, débats en cour, preuve par argument |
+| **Aide à la décision** | 4, 9 | Diagnostic médical, planification de ressources, vote |
+| **Multi-agents** | 8 | Négociation automatique, protocoles de dialogue |
+| **Ontologies** | 3 | Représentations de connaissances, OWL, Web sémantique |
+| **Vérification formelle** | 2, 3, 4 | SAT/SMT solving, proof checking, model checking |
+| **LLM control** | 5, 6, 7b | Détection d'incohérences, structuration de débats, argumentation probabiliste |
 
 ### Exemples concrets
 
-Derriere chaque cadre de la serie se cache une application reelle ou un probleme de recherche actif :
+Derrière chaque cadre de la série se cache une application réelle ou un problème de recherche actif :
 
-- **L'argumentation de Dung** (notebook 5) est le fondement mathématique de nombreux systemes d'aide a la decision juridique : des arguments se confrontent, les semantiques determinent quels arguments sont "acceptables", et le resultat guide la conclusion. C'est aussi la base des frameworks d'explicabilite des LLMs — detecter les incoherences entre reponses d'un modele.
-- **ASPIC+ et DeLP** (notebook 6) modelisent des debats ou les arguments ont une structure interne : premisses, regles defeasibles, et priorités. Applications en aide a la decision medicale, en gestion de conflits de regles, et en verification de contrats.
-- **La revision de croyances AGM** (notebook 4) formalise comment un systeme rationnel met a jour ses connaissances quand une information contradictoire arrive. Applications en integration de donnees, diagnostic de bases de connaissance, et fusion de sources d'information.
-- **Les frameworks etendus** (notebook 7a) generalisent Dung pour capturer des situations réelles ou des arguments ont plusieurs preconditions (ADF), ou des attaques ont des poids varies (WAF), ou des groupes d'arguments attaquent collectivement (SetAF).
-- **La theorie du vote** (notebook 9) est au cœur des systemes de recommandation collective, de l'agregation de preferences en intelligence artificielle, et des mechanisms d'incitation (mechanism design).
+- **L'argumentation de Dung** (notebook 5) est le fondement mathématique de nombreux systèmes d'aide à la décision juridique : des arguments se confrontent, les sémantiques déterminent quels arguments sont "acceptables", et le résultat guide la conclusion. C'est aussi la base des frameworks d'explicabilité des LLMs — détecter les incohérences entre réponses d'un modèle.
+- **ASPIC+ et DeLP** (notebook 6) modélisent des débats où les arguments ont une structure interne : prémisses, règles defeasibles, et priorités. Applications en aide à la décision médicale, en gestion de conflits de règles, et en vérification de contrats.
+- **La révision de croyances AGM** (notebook 4) formalise comment un système rationnel met à jour ses connaissances quand une information contradictoire arrive. Applications en intégration de données, diagnostic de bases de connaissance, et fusion de sources d'information.
+- **Les frameworks étendus** (notebook 7a) généralisent Dung pour capturer des situations réelles où des arguments ont plusieurs preconditions (ADF), où des attaques ont des poids variés (WAF), ou des groupes d'arguments attaquent collectivement (SetAF).
+- **La théorie du vote** (notebook 9) est au cœur des systèmes de recommandation collective, de l'agrégation de préférences en intelligence artificielle, et des mécanismes d'incitation (mechanism design).
 
 ## Installation
 
@@ -400,40 +400,40 @@ Derriere chaque cadre de la serie se cache une application reelle ou un probleme
 pip install jpype1 requests tqdm clingo z3-solver python-sat
 ```
 
-### Verification de l'environnement
+### Vérification de l'environnement
 
 ```bash
 # Lancer le notebook de setup
 jupyter notebook Tweety-1-Setup.ipynb
-# Executer toutes les cellules — il telecharge JDK, JARs, outils externes
+# Exécuter toutes les cellules — il télécharge JDK, JARs, outils externes
 
 # Ou utiliser le script de validation
 cd scripts
 python verify_all_tweety.py --quick
 ```
 
-JDK 17 et les 35 JARs TweetyProject sont telecharges automatiquement par le notebook de setup. Aucune installation systeme requise.
+JDK 17 et les 35 JARs TweetyProject sont téléchargés automatiquement par le notebook de setup. Aucune installation système requise.
 
 ## Validation des Notebooks
 
-### Script de verification
+### Script de vérification
 
 ```bash
 cd MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts
 
-# Verification structurelle rapide
+# Vérification structurelle rapide
 python verify_all_tweety.py --quick
 
-# Verification environnement
+# Vérification environnement
 python verify_all_tweety.py --check-env
 
 # Analyse des sorties existantes
 python verify_all_tweety.py --analyze-outputs --verbose
 
-# Execution complete (lent)
+# Exécution complète (lent)
 python verify_all_tweety.py --execute --verbose
 
-# Notebook specifique
+# Notebook spécifique
 python verify_all_tweety.py --notebook Tweety-2 --analyze-outputs
 ```
 
@@ -442,22 +442,22 @@ python verify_all_tweety.py --notebook Tweety-2 --analyze-outputs
 | Option | Description |
 |--------|-------------|
 | `--quick` | Validation structure uniquement |
-| `--check-env` | Verifier JDK, JARs, outils |
+| `--check-env` | Vérifier JDK, JARs, outils |
 | `--analyze-outputs` | Analyser sorties existantes |
-| `--execute` | Execution Papermill complete |
-| `--cell-by-cell` | Execution cellule par cellule |
-| `--execute-missing` | Executer cellules sans output |
+| `--execute` | Exécution Papermill complète |
+| `--cell-by-cell` | Exécution cellule par cellule |
+| `--execute-missing` | Exécuter cellules sans output |
 | `--clean-errors` | Nettoyer sorties en erreur |
-| `--verbose` | Sortie detaillee |
+| `--verbose` | Sortie détaillée |
 | `--json` | Format JSON (CI/CD) |
 
 ## FAQ / Troubleshooting
 
-### `JPypeError` ou JVM deja démarree
+### `JPypeError` ou JVM déjà démarrée
 
-Tweety utilise JPype pour integrer la JVM. Si un notebook signale que la JVM est deja démarree, c'est que le notebook precedent ne l'a pas arreee proprement. Relancer Jupyter et executer depuis le notebook 1.
+Tweety utilise JPype pour intégrer la JVM. Si un notebook signale que la JVM est déjà démarrée, c'est que le notebook précédent ne l'a pas arrêtée proprement. Relancer Jupyter et exécuter depuis le notebook 1.
 
-### Clingo non trouve
+### Clingo non trouvé
 
 Si `clingo` n'est pas dans le PATH, utiliser le script de téléchargement :
 
@@ -465,51 +465,51 @@ Si `clingo` n'est pas dans le PATH, utiliser le script de téléchargement :
 python scripts/download_tweety_tools.py --clingo
 ```
 
-Le binaire Windows sera telecharge dans `ext_tools/`.
+Le binaire Windows sera téléchargé dans `ext_tools/`.
 
-### EProver ne repond pas ou heap space
+### EProver ne répond pas ou heap space
 
-EProver peut bloquer sur des formules FOL complexes avec egalité. La solution est d'utiliser un solveur plus léger ou de réduire la taille de la base de connaissances. Voir la section "Limitations connues" ci-dessus.
+EProver peut bloquer sur des formules FOL complexes avec égalité. La solution est d'utiliser un solveur plus léger ou de réduire la taille de la base de connaissances. Voir la section "Limitations connues" ci-dessus.
 
 ### Erreur de chargement d'un JAR Tweety
 
-Verifier que la version Tweety dans `Tweety-1-Setup.ipynb` correspond a la version telechargee. La version recommandeée est 1.30. Pour changer de version, modifier la variable `TWEETY_VERSION` puis relancer le notebook 1.
+Vérifier que la version Tweety dans `Tweety-1-Setup.ipynb` correspond à la version téléchargée. La version recommandée est 1.30. Pour changer de version, modifier la variable `TWEETY_VERSION` puis relancer le notebook 1.
 
 ### `ClassCastException` en argumentation
 
-Le notebook 5 signale un bug connu (AF Learning — ClassCastException). La section correspondante est desactivée. Suivre les autres sections sans probleme.
+Le notebook 5 signale un bug connu (AF Learning — ClassCastException). La section correspondante est désactivée. Suivre les autres sections sans problème.
 
 ### JPype lent au premier appel
 
-Le premier appel a un module Java déclenche le chargement de la JVM et des classes Tweety. Attendez 5-10 secondes avant la premiere reponse. Les appels suivants sont rapides.
+Le premier appel à un module Java déclenche le chargement de la JVM et des classes Tweety. Attendez 5-10 secondes avant la première réponse. Les appels suivants sont rapides.
 
-### Comment passer d'un notebook a l'autre ?
+### Comment passer d'un notebook à l'autre ?
 
-Chaque notebook presuppose la configuration faite dans Tweety-1-Setup (JDK, JARs, JVM). Une fois le notebook 1 execute, les notebooks 2-9 peuvent etre executes dans l'ordre logique de la serie. Les outils externes (Clingo, SPASS, EProver) sont configures par le notebook 1.
+Chaque notebook présuppose la configuration faite dans Tweety-1-Setup (JDK, JARs, JVM). Une fois le notebook 1 exécuté, les notebooks 2-9 peuvent être exécutés dans l'ordre logique de la série. Les outils externes (Clingo, SPASS, EProver) sont configurés par le notebook 1.
 
 ## Versions TweetyProject
 
-| Version | Date | Nouveautes |
+| Version | Date | Nouveautés |
 |---------|------|------------|
 | **1.28** | Janvier 2025 | arg.caf, k-admissibility, API refactoring |
 | **1.29** | Juillet 2025 | arg.eaf (Epistemic AF), graph rendering |
 | **1.30** | Janvier 2026 | causal reasoning, arg.explanations, equivalence checking |
 
-La version est configurable dans `Tweety-1-Setup.ipynb` (variable `TWEETY_VERSION`). La version 1.30 est recommandeée — elle inclut les semantiques de causalite, les explications en argumentation, et le checking d'equivalence de frameworks.
+La version est configurable dans `Tweety-1-Setup.ipynb` (variable `TWEETY_VERSION`). La version 1.30 est recommandée — elle inclut les sémantiques de causalité, les explications en argumentation, et le checking d'équivalence de frameworks.
 
 ## Ressources
 
-### References academiques
+### Références académiques
 
-| Reference | Couverture |
+| Référence | Couverture |
 |-----------|------------|
-| Dung, "On the Acceptability of Arguments" (1995) | Notebook 5, semantiques de Dung |
-| Modgil & Prakken, "The ASPIC+ Framework" (2014) | Notebook 6, argumentation structuree |
-| Alchourron, Gardenfors & Makinson, "On the Logic of Theory Change" (1985) | Notebook 4, revision AGM |
+| Dung, "On the Acceptability of Arguments" (1995) | Notebook 5, sémantiques de Dung |
+| Modgil & Prakken, "The ASPIC+ Framework" (2014) | Notebook 6, argumentation structurée |
+| Alchourron, Gardenfors & Makinson, "On the Logic of Theory Change" (1985) | Notebook 4, révision AGM |
 | Enderton, *A Mathematical Introduction to Logic* (2001) | Notebooks 2-3, logiques formelles |
-| Besnard & Hunter, *Elements of Argumentation* (2008) | Notebooks 5-7, theorie argumentation |
+| Besnard & Hunter, *Elements of Argumentation* (2008) | Notebooks 5-7, théorie argumentation |
 | Brewka, Eiter & Truszczynski, "Answer Set Programming at a Glance" (2011) | Notebook 6, ASP/Clingo |
-| Russell & Norvig, *AIMA* 4e ed., ch. 7-8 | Cadre general logique et SAT |
+| Russell & Norvig, *AIMA* 4e éd., ch. 7-8 | Cadre général logique et SAT |
 
 ### Ressources en ligne
 
@@ -518,28 +518,28 @@ La version est configurable dans `Tweety-1-Setup.ipynb` (variable `TWEETY_VERSIO
 - **GitHub** : https://github.com/TweetyProjectTeam/TweetyProject
 - **JPype** : https://jpype.readthedocs.io/
 
-## Ponts avec les autres series
+## Ponts avec les autres séries
 
-| Serie | Connection | Details |
+| Série | Connection | Détails |
 |-------|------------|---------|
-| **[Argument_Analysis](../Argument_Analysis/)** | Argumentation agentique | Utilise Tweety comme backend Java pour le raisonnement argumentatif. Les semantiques de Dung (notebook 5) sont directement appliquees dans l'analyse de textes. |
-| **[Lean](../Lean/)** | Verification formelle | Les logiques propositionnelles et FOL (notebooks 2-3) correspondent aux tactiques de preuve Lean. Les SAT solvers de Tweety completent la verification Lean. |
-| **[SmartContracts](../SmartContracts/)** | Methods formelles | La verification formelle SC-14 (Certora/SMTChecker) utilise les memes solveurs SAT/SMT. La logique propositionnelle de Tweety est la base des invariants Solidity. |
-| **[GameTheory](../../GameTheory/)** | Theorie du vote | Le notebook 9 (Preferences/Vote) couvre les concepts de choix social formalises dans `social_choice_lean/` (Arrow, Sen, Voting). |
-| **[Planners](../Planners/)** | Planification argumentative | Les dialogues argumentatifs (notebook 8) peuvent etre modelises comme des problemes de planification PDDL. |
-| Lecture transversale | [La mer qui monte](../../../docs/grothendieckian-lens.md) | Grille de lecture grothendieckienne du depot : changement de representation, certification A/B/C |
+| **[Argument_Analysis](../Argument_Analysis/)** | Argumentation agentique | Utilise Tweety comme backend Java pour le raisonnement argumentatif. Les sémantiques de Dung (notebook 5) sont directement appliquées dans l'analyse de textes. |
+| **[Lean](../Lean/)** | Vérification formelle | Les logiques propositionnelles et FOL (notebooks 2-3) correspondent aux tactiques de preuve Lean. Les SAT solvers de Tweety complètent la vérification Lean. |
+| **[SmartContracts](../SmartContracts/)** | Méthodes formelles | La vérification formelle SC-14 (Certora/SMTChecker) utilise les mêmes solveurs SAT/SMT. La logique propositionnelle de Tweety est la base des invariants Solidity. |
+| **[GameTheory](../../GameTheory/)** | Théorie du vote | Le notebook 9 (Préférences/Vote) couvre les concepts de choix social formalisés dans `social_choice_lean/` (Arrow, Sen, Voting). |
+| **[Planners](../Planners/)** | Planification argumentative | Les dialogues argumentatifs (notebook 8) peuvent être modélisés comme des problèmes de planification PDDL. |
+| Lecture transversale | [La mer qui monte](../../../docs/grothendieckian-lens.md) | Grille de lecture grothendieckienne du dépôt : changement de représentation, certification A/B/C |
 
 ## Cross-series Bridges
 
-| Serie | Lien | Connection |
+| Série | Lien | Connection |
 | ------- | ------ | ----------- |
-| [SymbolicAI/SemanticWeb](../SemanticWeb/README.md) | OWL reasoning | La logique de Description (Tweety-3) est le fondement de l'OWL reasoning — les ontologies OWL DL utilisent les memes solveurs DL que Tweety |
-| [IIT](../../IIT/README.md) | Argumentation pour la consciousness | L'analyse argumentative des systemes complexes (notebooks 5-7) partage des concepts avec l'analyse IIT — identification de sous-ensembles causaux |
-| [SymbolicAI/Planners/](../Planners/README.md) | Planification logique | Les logiques formelles (notebooks 2-3) sont la base de la planification automate PDDL |
-| [ML/](../../ML/README.md) | Neuro-symbolic AI | L'intersection logiques + apprentissage : verifier les predictions de modeles neuronaux avec des contraintes logiques |
-| [Search](../../Search/README.md) | SAT-based search | Le solving SAT (notebook 2) partage les memes algorithmes que la recherche par contraintes (CSP) |
+| [SymbolicAI/SemanticWeb](../SemanticWeb/README.md) | OWL reasoning | La logique de Description (Tweety-3) est le fondement de l'OWL reasoning — les ontologies OWL DL utilisent les mêmes solveurs DL que Tweety |
+| [IIT](../../IIT/README.md) | Argumentation pour la consciousness | L'analyse argumentative des systèmes complexes (notebooks 5-7) partage des concepts avec l'analyse IIT — identification de sous-ensembles causaux |
+| [SymbolicAI/Planners/](../Planners/README.md) | Planification logique | Les logiques formelles (notebooks 2-3) sont la base de la planification automatisée PDDL |
+| [ML/](../../ML/README.md) | Neuro-symbolic AI | L'intersection logiques + apprentissage : vérifier les prédictions de modèles neuronaux avec des contraintes logiques |
+| [Search](../../Search/README.md) | SAT-based search | Le solving SAT (notebook 2) partage les mêmes algorithmes que la recherche par contraintes (CSP) |
 
 ## Licence
 
-Les notebooks sont distribues sous licence MIT.
+Les notebooks sont distribués sous licence MIT.
 TweetyProject est sous licence LGPL 3.0.

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/README.md
@@ -1,12 +1,12 @@
 # Scripts Tweety
 
-Ce repertoire contient les scripts utilitaires pour la serie Tweety (`Tweety-1-Setup` a `Tweety-9b-*` + `Tweety-Defeasible-Reasoning`). Ils couvrent le telechargement des dependances (JARs TweetyProject, Clingo, JDK Zulu portable), la calibration des solveurs SAT, et la verification de l'integrite des notebooks.
+Ce répertoire contient les scripts utilitaires pour la série Tweety (`Tweety-1-Setup` à `Tweety-9b-*` + `Tweety-Defeasible-Reasoning`). Ils couvrent le téléchargement des dépendances (JARs TweetyProject, Clingo, JDK Zulu portable), la calibration des solveurs SAT, et la vérification de l'intégrité des notebooks.
 
 ## Scripts disponibles
 
-### Telechargement des dependances
+### Téléchargement des dépendances
 
-- [download_tweety_tools.py](download_tweety_tools.py) — Telecharge les JARs TweetyProject depuis Maven Central, les ressources (`*.txt`, `*.aba`, `*.aspic`), Clingo (Windows/Linux), SPASS (Linux), JDK Zulu 17 portable, et les bibliotheques natives SAT (Minisat, Lingeling, Picosat). Mode selectif via flags `--jars`/`--resources`/`--clingo`/`--jdk`/`--native-sat` ou `--all`.
+- [download_tweety_tools.py](download_tweety_tools.py) — Télécharge les JARs TweetyProject depuis Maven Central, les ressources (`*.txt`, `*.aba`, `*.aspic`), Clingo (Windows/Linux), SPASS (Linux), JDK Zulu 17 portable, et les bibliothèques natives SAT (Minisat, Lingeling, Picosat). Mode sélectif via flags `--jars`/`--resources`/`--clingo`/`--jdk`/`--native-sat` ou `--all`.
 
   ```bash
   python scripts/download_tweety_tools.py --all
@@ -14,46 +14,46 @@ Ce repertoire contient les scripts utilitaires pour la serie Tweety (`Tweety-1-S
 
 ### Calibration et comparaison SAT
 
-- [sat_calibration.py](sat_calibration.py) — Recherche des configurations de problemes SAT ou chaque solveur (Minisat, Glucose, Lingeling, Picosat, ...) gagne au moins un test. Utilise `pysat`, timeouts par test, et un budget configurable. Sert de base pour calibrer les exemples pedagogiques.
+- [sat_calibration.py](sat_calibration.py) — Recherche des configurations de problèmes SAT où chaque solveur (Minisat, Glucose, Lingeling, Picosat, ...) gagne au moins un test. Utilise `pysat`, timeouts par test, et un budget configurable. Sert de base pour calibrer les exemples pédagogiques.
 
   ```bash
   python scripts/sat_calibration.py
   ```
 
-- [sat_comparison_demo.py](sat_comparison_demo.py) — Demonstration pedagogique de comparaison de performance des solveurs SAT sur des problemes classiques de difficulte croissante. Sortie textuelle utilisable directement dans une cellule notebook.
+- [sat_comparison_demo.py](sat_comparison_demo.py) — Démonstration pédagogique de comparaison de performance des solveurs SAT sur des problèmes classiques de difficulté croissante. Sortie textuelle utilisable directement dans une cellule notebook.
 
   ```bash
   python scripts/sat_comparison_demo.py
   ```
 
-### Validation et verification
+### Validation et vérification
 
-- [validate_syntax.py](validate_syntax.py) — Parcourt les cellules de code Python des notebooks Tweety et signale les erreurs de syntaxe (`ast.parse`) avec numero de ligne et identifiant de cellule. Utile en pre-commit ou apres une edition manuelle.
+- [validate_syntax.py](validate_syntax.py) — Parcourt les cellules de code Python des notebooks Tweety et signale les erreurs de syntaxe (`ast.parse`) avec numéro de ligne et identifiant de cellule. Utile en pre-commit ou après une édition manuelle.
 
   ```bash
   python scripts/validate_syntax.py
   ```
 
-- [verify_all_tweety.py](verify_all_tweety.py) — Verification complete de la serie : structure JSON, configuration kernel (`python3`), presence de cellules markdown/code, prerequis (JDK, JPype, JARs Tweety), et execution optionnelle via Papermill ou cell-by-cell. Sortie structuree (JSON ou texte) selon les flags.
+- [verify_all_tweety.py](verify_all_tweety.py) — Vérification complète de la série : structure JSON, configuration kernel (`python3`), présence de cellules markdown/code, prérequis (JDK, JPype, JARs Tweety), et exécution optionnelle via Papermill ou cell-by-cell. Sortie structurée (JSON ou texte) selon les flags.
 
   ```bash
-  # Verification structurelle seule
+  # Vérification structurelle seule
   python scripts/verify_all_tweety.py --structure-only
 
-  # Verification + execution Papermill (long)
+  # Vérification + exécution Papermill (long)
   python scripts/verify_all_tweety.py --execute
   ```
 
-## Dependances
+## Dépendances
 
 - Python 3.10+
 - `pysat` (calibration/comparaison SAT)
-- `JPype1` (notebooks Tweety executes)
+- `JPype1` (notebooks Tweety exécutés)
 - JDK 17+ (Zulu portable installable via `download_tweety_tools.py --jdk`)
 - Clingo (optionnel, pour notebooks ASP) — installable via `download_tweety_tools.py --clingo`
 
 ## Voir aussi
 
-- [Tweety/README.md](../README.md) — Vue d'ensemble de la serie Tweety
-- [SymbolicAI/scripts/README.md](../../scripts/README.md) — Scripts SymbolicAI niveau serie (extraction notebook, installation Clingo)
-- [scripts/notebook_tools/](../../../../scripts/notebook_tools/) — Outils generiques (validate / execute / skeleton / analyze)
+- [Tweety/README.md](../README.md) — Vue d'ensemble de la série Tweety
+- [SymbolicAI/scripts/README.md](../../scripts/README.md) — Scripts SymbolicAI niveau série (extraction notebook, installation Clingo)
+- [scripts/notebook_tools/](../../../../scripts/notebook_tools/) — Outils génériques (validate / execute / skeleton / analyze)


### PR DESCRIPTION
## Summary

Cluster **SymbolicAI/** de #2876 (restauration des accents français sur les README). Restauration pure d'accents (curée) sur 12 READMEs :

- `Tweety/README.md` (+ `scripts/`)
- `Planners/README.md`
- `SmartContracts/README.md` (+ `scripts/`, `mon-premier-projet/`)
- `SemanticWeb/README.md`
- `Argument_Analysis/README.md`
- `SMT/README.md` (+ `Z3/`, `Z3-Python/`)
- `Lean/scripts/README.md`

See #2876 (contribution partielle au cluster SymbolicAI). Clusters déjà livrés : Search (#2880), Lean (#2885), Probas (#2888), GameTheory (#2899). Reste après : README racine CoursIA.

## Validation

- **Diff symétrique** : 868 insertions / 868 suppressions, soit exactement 1-pour-1 (signature d'une restauration d'accents sans changement de contenu).
- **Résiduel ASCII** : 0 par fichier après filtrage des faux positifs légitimes (termes techniques anglais, titres de notebooks, clés YAML `series:`).
- **Préservé** (règle anti-#1214 — pas de find-replace aveugle) :
  - Blocs `<!-- CATALOG-STATUS -->` byte-identiques à main
  - Code fences, inline code, URLs, chemins de fichiers
  - Titres de notebooks : `SC-14-Formal-Verification`, `Tweety-9-Preferences`
  - Termes anglais : PDDL, HDDL, SMT, Z3, SAT, OWL, RDF, SPARQL, Foundry, OpenZeppelin, Formal Verification, Forge CLI
  - Expansions officielles : « Planning Domain Definition Language »
  - Noms propres : Godel, Tarski, Appel, Borda, Condorcet, Dung, Berners-Lee

## Méthodologie

Curé manuelle par contexte (lecture ligne par ligne, correction mot à mot) — pas de find-replace global, cf incident #1214. Deux lots délégués à sous-agents sonnet, puis cross-check parent (G.1) + corrections résiduelles manuelles sur 4 fichiers (Problème, déploiement, Références académiques, Déclaratif/Impératif/Limitée/exposées/familière/contrôle).

Co-Authored-By: Claude <noreply@anthropic.com>
