### PR TITLE
feat(lean): prove discount_monotone closed-form (Gittins, sorry 1->0)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/gittins_lean/Gittins/Discount.lean
+++ b/MyIA.AI.Notebooks/Probas/Infer/gittins_lean/Gittins/Discount.lean
@@ -45,9 +45,24 @@ theorem present_value_constant {γ r : ℝ} (hγ₁ : 0 < γ) (hγ₂ : γ < 1) 
   ring
 
 /-- Discount factor closer to 1 gives higher present value.
-    If γ₁ ≤ γ₂, then Σ γ₁^n ≤ Σ γ₂^n. -/
+    If γ₁ ≤ γ₂, then Σ γ₁^n ≤ Σ γ₂^n.
+
+    **Proof strategy**: rewrite both tsums via the closed-form geometric
+    identity `∑' n, γ^n = 1/(1-γ)` (`geometric_series_converges`), then reduce
+    the goal to `1/(1-γ₁) ≤ 1/(1-γ₂)`. Since `γ₁ ≤ γ₂` we have
+    `1-γ₂ ≤ 1-γ₁`, and both denominators are positive (`γ₂ < 1`), so
+    `one_div_le_one_div_of_le` closes the goal. This sidesteps the missing
+    `tsum_le_tsum` on `ℝ` (not available in Mathlib v4.30.0-rc2 for bare `ℝ`
+    series) by exploiting the closed form. -/
 theorem discount_monotone {γ₁ γ₂ : ℝ} (h₁ : 0 ≤ γ₁) (h₂ : γ₁ ≤ γ₂) (h₃ : γ₂ < 1) :
     ∑' n : ℕ, γ₁ ^ n ≤ ∑' n : ℕ, γ₂ ^ n := by
-  sorry  -- TODO: requires tsum_le_tsum with termwise comparison
+  have hγ₁_lt : γ₁ < 1 := lt_of_le_of_lt h₂ h₃
+  have hγ₂_nn : 0 ≤ γ₂ := le_trans h₁ h₂
+  rw [geometric_series_converges h₁ hγ₁_lt, geometric_series_converges hγ₂_nn h₃]
+  -- Goal: 1 / (1 - γ₁) ≤ 1 / (1 - γ₂)
+  -- Since γ₁ ≤ γ₂, we have 1 - γ₂ ≤ 1 - γ₁; both denominators are positive.
+  apply one_div_le_one_div_of_le
+  · exact sub_pos.mpr (by linarith)  -- 0 < 1 - γ₂
+  · linarith                        -- 1 - γ₂ ≤ 1 - γ₁
 
 end Gittins


### PR DESCRIPTION
## Summary

Replaces the `sorry` placeholder in `discount_monotone` (`Discount.lean`) with a complete proof, eliminating the **last tractable sorry** in the `gittins_lean` project. Part of #1452.

The 5 remaining sorries in `GittinsTheorem.lean` are RESEARCH-LEVEL (Gittins index definition + optimality, MDP/Bellman API absent from Mathlib) and out of scope for this PR.

## Proof strategy

Rewrite both tsums via the closed-form geometric identity `∑' n, γ^n = 1/(1-γ)` (from `geometric_series_converges`), then reduce the goal to `1/(1-γ₁) ≤ 1/(1-γ₂)`. Since `γ₁ ≤ γ₂` we have `1-γ₂ ≤ 1-γ₁`, and both denominators are positive (`γ₂ < 1`), so `one_div_le_one_div_of_le` closes the goal.

This **sidesteps the missing `tsum_le_tsum`** on bare `ℝ` (only available for `ENNReal` in Mathlib v4.30.0-rc2) by exploiting the closed form rather than attempting a termwise comparison.

```lean
theorem discount_monotone {γ₁ γ₂ : ℝ} (h₁ : 0 ≤ γ₁) (h₂ : γ₁ ≤ γ₂) (h₃ : γ₂ < 1) :
    ∑' n : ℕ, γ₁ ^ n ≤ ∑' n : ℕ, γ₂ ^ n := by
  have hγ₁_lt : γ₁ < 1 := lt_of_le_of_lt h₂ h₃
  have hγ₂_nn : 0 ≤ γ₂ := le_trans h₁ h₂
  rw [geometric_series_converges h₁ hγ₁_lt, geometric_series_converges hγ₂_nn h₃]
  apply one_div_le_one_div_of_le
  · exact sub_pos.mpr (by linarith)  -- 0 < 1 - γ₂
  · linarith                        -- 1 - γ₂ ≤ 1 - γ₁
```

## Validation (lean-merge-discipline §B)

| Check | Result |
|-------|--------|
| `grep -cE '^\s*sorry\b'` avant (origin/main) | **1** |
| `grep -cE '^\s*sorry\b'` après | **0** |
| `lake build Gittins` local | **SUCCESS** — `Discount.olean` built (106160 bytes) |
| Proof integrity (no new axioms) | ✅ no `sorry`, no `admit`, no `axiom` |
| Diff | 17 insertions / 2 deletions (`sorry` → real tactics + docstring) |

Cold Mathlib build (toolchain v4.30.0-rc2, Mathlib pinned `@ v4.30.0-rc2`, commit `5450b53e`). Build ran local in WSL Ubuntu, completed without errors.

## Scope

Single file, single theorem. No refactor, no other modules touched. Catalog and READMEs byte-identical to `origin/main` (rebased fresh before push).

See #1452