### PR TITLE
fix(docs): restore French diacritics in CaseStudies README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -1,4 +1,4 @@
-# CaseStudies - Etudes de cas interdisciplinaires
+# CaseStudies - Études de cas interdisciplinaires
 
 <!-- CATALOG-STATUS
 series: CaseStudies
@@ -9,39 +9,39 @@ maturity: BETA=2, PRODUCTION=2
 
 [← Notebooks](../README.md) | [↑ ..](../README.md) | [→ QuantConnect](../QuantConnect/README.md)
 
-Etudes de cas interdisciplinaires combinant plusieurs domaines de l'IA dans des projets appliques.
+Études de cas interdisciplinaires combinant plusieurs domaines de l'IA dans des projets appliqués.
 
-La force des etudes de cas reside dans leur capacite a **fusionner les techniques apprises en silos** : un solveur SMT (Search), un algorithme genetique (Sudoku), une ontologie OWL (SemanticWeb) et un modele bayesien (Probas) ne valent pas grand chose isolement face a une question reelle. C'est leur combinaison, orchestree autour d'un probleme metier (diagnostic medical, protocole oncologique), qui transforme un catalogue d'outils en **systeme decisionnel coherent**. Les deux projets de cette serie illustrent ce passage : chacun mobilise 3 a 4 paradigmes IA differents qui se renforcent mutuellement plutot que de se concurrencer.
+La force des études de cas réside dans leur capacité à **fusionner les techniques apprises en silos** : un solveur SMT (Search), un algorithme génétique (Sudoku), une ontologie OWL (SemanticWeb) et un modèle bayésien (Probas) ne valent pas grand chose isolément face à une question réelle. C'est leur combinaison, orchestrée autour d'un problème métier (diagnostic médical, protocole oncologique), qui transforme un catalogue d'outils en **système décisionnel cohérent**. Les deux projets de cette série illustrent ce passage : chacun mobilise 3 à 4 paradigmes IA différents qui se renforcent mutuellement plutôt que de se concurrencer.
 
-## A qui s'adresse cette serie
+## À qui s'adresse cette série
 
-Cette serie s'adresse aux **etudiants en fin de cycle** (M1/M2 ou equivalent ingenieur) ayant deja parcouru les series fondamentales (Search, SymbolicAI, Probas, SemanticWeb). Elle constitue typiquement un **devoir de controle continu integrateur** ou un projet de groupe couvrant plusieurs paradigmes IA dans un meme livrable. La pedagogie privilegie l'**autonomie** : chaque projet propose un template etudiant minimal et une solution de reference pour autoevaluation.
+Cette série s'adresse aux **étudiants en fin de cycle** (M1/M2 ou équivalent ingénieur) ayant déjà parcouru les séries fondamentales (Search, SymbolicAI, Probas, SemanticWeb). Elle constitue typiquement un **devoir de contrôle continu intégrateur** ou un projet de groupe couvrant plusieurs paradigmes IA dans un même livrable. La pédagogie privilégie l'**autonomie** : chaque projet propose un template étudiant minimal et une solution de référence pour autoévaluation.
 
-Les profils types vises :
+Les profils types visés :
 
-- Etudiants en informatique ou IA construisant un portefeuille de projets multi-paradigmes
-- Developpeurs/data scientists explorant l'integration de techniques heterogenes (symbolique + probabiliste)
-- Enseignants cherchant des **devoirs d'integration** mobilisant 3-4 series du cursus
+- Étudiants en informatique ou IA construisant un portefeuille de projets multi-paradigmes
+- Développeurs/data scientists explorant l'intégration de techniques hétérogènes (symbolique + probabiliste)
+- Enseignants cherchant des **devoirs d'intégration** mobilisant 3-4 séries du cursus
 
-## Pourquoi des etudes de cas interdisciplinaires ?
+## Pourquoi des études de cas interdisciplinaires ?
 
-L'IA reelle ne fonctionne quasi-jamais avec un seul paradigme. Un assistant diagnostic exploite a la fois des **regles symboliques** (contre-indications absolues), des **modeles probabilistes** (incertitude sur les symptomes), des **algorithmes de recherche** (exploration de l'arbre de diagnostics) et des **contraintes formelles** (validation par solveur). Reduire ce probleme a une seule technique conduit a des systemes brittle (regles only), opaques (deep learning only) ou inutilisables (probabiliste only sans contraintes dures).
+L'IA réelle ne fonctionne quasi-jamais avec un seul paradigme. Un assistant diagnostic exploite à la fois des **règles symboliques** (contre-indications absolues), des **modèles probabilistes** (incertitude sur les symptômes), des **algorithmes de recherche** (exploration de l'arbre de diagnostics) et des **contraintes formelles** (validation par solveur). Réduire ce problème à une seule technique conduit à des systèmes brittle (règles only), opaques (deep learning only) ou inutilisables (probabiliste only sans contraintes dures).
 
-### Le principe d'integration
+### Le principe d'intégration
 
-| Couche | Role | Techniques | Exemple OncoPlan |
+| Couche | Rôle | Techniques | Exemple OncoPlan |
 |--------|------|-----------|------------------|
-| **Connaissances metier** | Representer le domaine | Ontologies OWL, regles | Medicaments, interactions, contre-indications |
-| **Contraintes dures** | Filtrer l'impossible | CSP, SMT, OR-Tools | Doses cumulees, delais entre cures |
-| **Incertitude** | Modeliser l'aleatoire | Bayesien, Pyro, Infer.NET | Reponse patient, toxicite predite |
-| **Optimisation** | Choisir la meilleure option | A*, genetique, RL | Calendrier optimal de cures |
-| **Decision finale** | Synthese et explication | Workflow, scoring | Recommandation justifiee au clinicien |
+| **Connaissances métier** | Représenter le domaine | Ontologies OWL, règles | Médicaments, interactions, contre-indications |
+| **Contraintes dures** | Filtrer l'impossible | CSP, SMT, OR-Tools | Doses cumulées, délais entre cures |
+| **Incertitude** | Modéliser l'aléatoire | Bayésien, Pyro, Infer.NET | Réponse patient, toxicité prédite |
+| **Optimisation** | Choisir la meilleure option | A*, génétique, RL | Calendrier optimal de cures |
+| **Décision finale** | Synthèse et explication | Workflow, scoring | Recommandation justifiée au clinicien |
 
-Une seule couche ne suffit pas, et l'**ordre de composition** importe : on filtre avant d'optimiser, on modelise l'incertitude avant de valider sous contraintes. Les etudes de cas materialisent ces patterns d'architecture.
+Une seule couche ne suffit pas, et l'**ordre de composition** importe : on filtre avant d'optimiser, on modélise l'incertitude avant de valider sous contraintes. Les études de cas matérialisent ces patterns d'architecture.
 
-### Le pattern "twin numerique"
+### Le pattern "twin numérique"
 
-Les deux projets reposent sur un **modele de patient simule** : un objet logiciel qui represente l'etat clinique (symptomes, antecedents, parametres biologiques) et reagit a des interventions (diagnostic propose, traitement applique). Ce pattern, appele **jumeau numerique** (digital twin), est devenu central en sante numerique, en industrie 4.0 et en simulation environnementale. L'apprendre sur 10 patients diabetiques (Diagnostic-Medical) ou un cas oncologique (Oncology-Planning) prepare directement aux applications professionnelles.
+Les deux projets reposent sur un **modèle de patient simulé** : un objet logiciel qui représente l'état clinique (symptômes, antécédents, paramètres biologiques) et réagit à des interventions (diagnostic proposé, traitement appliqué). Ce pattern, appelé **jumeau numérique** (digital twin), est devenu central en santé numérique, en industrie 4.0 et en simulation environnementale. L'apprendre sur 10 patients diabétiques (Diagnostic-Medical) ou un cas oncologique (Oncology-Planning) prépare directement aux applications professionnelles.
 
 ## Structure
 
@@ -60,93 +60,93 @@ CaseStudies/
 
 ## Projets
 
-### Diagnostic Medical
+### Diagnostic Médical
 
-Systeme de diagnostic medical combinant recherche informee (A*), algorithmes genetiques, et validation par contraintes (Z3). Application au diabete de type 2 avec 10 patients de test.
+Système de diagnostic médical combinant recherche informée (A*), algorithmes génétiques, et validation par contraintes (Z3). Application au diabète de type 2 avec 10 patients de test.
 
 - **Technologies** : Python, z3-solver, heapq, pandas
-- **Concepts** : Recherche A*, algorithmes genetiques, CSP, validation par contraintes
+- **Concepts** : Recherche A*, algorithmes génétiques, CSP, validation par contraintes
 
 [README complet](Diagnostic-Medical/README.md) | 2 notebooks (student + solution) | ~3-4h
 
 ### Oncology Planning (OncoPlan)
 
-Protocole oncologique adaptatif combinant IA symbolique (ontologie, CSP/OR-Tools) et programmation probabiliste (Pyro) pour l'aide a la decision en oncologie. Modele de jumeau numerique patient.
+Protocole oncologique adaptatif combinant IA symbolique (ontologie, CSP/OR-Tools) et programmation probabiliste (Pyro) pour l'aide à la décision en oncologie. Modèle de jumeau numérique patient.
 
 - **Technologies** : Python, pyro-ppl, ortools, pandas
-- **Concepts** : Ontologies, planification CSP, infarence bayesienne, programmation probabiliste
+- **Concepts** : Ontologies, planification CSP, inférence bayésienne, programmation probabiliste
 
 [README complet](Oncology-Planning/README.md) | 2 notebooks (student + solution) | ~3-4h
 
 ## Acquis d'apprentissage
 
-A l'issue de cette serie, l'etudiant est capable de :
+À l'issue de cette série, l'étudiant est capable de :
 
-### Competences techniques
+### Compétences techniques
 
-- **Concevoir une architecture IA hybride** combinant raisonnement symbolique (regles, ontologies, contraintes) et apprentissage statistique (modeles probabilistes, optimisation evolutionnaire)
-- **Modeliser un domaine metier** avec un vocabulaire formel (classes, proprietes, axiomes) sans confondre representation et inference
-- **Decomposer un probleme complexe** en sous-problemes adresses par la technique la plus adaptee (filtrage par contraintes, recherche heuristique, inference bayesienne)
-- **Composer plusieurs solveurs** (Z3, OR-Tools, Pyro, A*) dans un pipeline coherent ou la sortie de l'un alimente l'autre
-- **Valider un systeme decisionnel** sur des cas reels (patients diabetiques, protocoles oncologiques) avec metriques de qualite et explicabilite
+- **Concevoir une architecture IA hybride** combinant raisonnement symbolique (règles, ontologies, contraintes) et apprentissage statistique (modèles probabilistes, optimisation évolutionnaire)
+- **Modéliser un domaine métier** avec un vocabulaire formel (classes, propriétés, axiomes) sans confondre représentation et inférence
+- **Décomposer un problème complexe** en sous-problèmes adressés par la technique la plus adaptée (filtrage par contraintes, recherche heuristique, inférence bayésienne)
+- **Composer plusieurs solveurs** (Z3, OR-Tools, Pyro, A*) dans un pipeline cohérent où la sortie de l'un alimente l'autre
+- **Valider un système décisionnel** sur des cas réels (patients diabétiques, protocoles oncologiques) avec métriques de qualité et explicabilité
 
-### Competences methodologiques
+### Compétences méthodologiques
 
-- **Identifier les couches d'un systeme IA** (donnees -> connaissances -> contraintes -> modeles -> decision) et leur ordre de composition
-- **Choisir entre approches deterministes et probabilistes** selon que les contraintes sont absolues ou negociables
-- **Justifier le recours a l'IA hybride** plutot qu'a un seul paradigme : robustesse, explicabilite, conformite reglementaire
-- **Documenter un projet IA interdisciplinaire** : architecture, choix algorithmiques, limites connues, perimetre de validation
+- **Identifier les couches d'un système IA** (données -> connaissances -> contraintes -> modèles -> décision) et leur ordre de composition
+- **Choisir entre approches déterministes et probabilistes** selon que les contraintes sont absolues ou négociables
+- **Justifier le recours à l'IA hybride** plutôt qu'à un seul paradigme : robustesse, explicabilité, conformité réglementaire
+- **Documenter un projet IA interdisciplinaire** : architecture, choix algorithmiques, limites connues, périmètre de validation
 
-### Competences applicatives (domaine medical)
+### Compétences applicatives (domaine médical)
 
-- **Manipuler des donnees patient** (CSV structures, anonymisation, integrite des CSP)
-- **Encoder un protocole therapeutique** sous forme d'ontologie + contraintes (delais, doses, interactions)
-- **Estimer une incertitude clinique** via inference bayesienne et amplification (`poutine.scale` en Pyro)
-- **Construire un jumeau numerique** simulant la reaction d'un patient a une intervention
+- **Manipuler des données patient** (CSV structurées, anonymisation, intégrité des CSP)
+- **Encoder un protocole thérapeutique** sous forme d'ontologie + contraintes (délais, doses, interactions)
+- **Estimer une incertitude clinique** via inférence bayésienne et amplification (`poutine.scale` en Pyro)
+- **Construire un jumeau numérique** simulant la réaction d'un patient à une intervention
 
-## Concepts cles transversaux
+## Concepts clés transversaux
 
-Cette serie consolide cinq concepts qui reviennent dans tous les systemes IA appliques modernes :
+Cette série consolide cinq concepts qui reviennent dans tous les systèmes IA appliqués modernes :
 
-| Concept | Definition | Manifestation dans CaseStudies | Cours connexes |
+| Concept | Définition | Manifestation dans CaseStudies | Cours connexes |
 |---------|------------|--------------------------------|----------------|
 | **Architecture hybride** | Pipeline combinant techniques symboliques et statistiques | Diagnostic : A* + GA + Z3 / OncoPlan : Ontologie + CSP + Pyro | [SymbolicAI](../SymbolicAI/README.md), [Probas](../Probas/README.md) |
-| **Jumeau numerique** | Modele logiciel d'un objet/personne reagissant a des interventions | Modele patient (etat, parametres bio, reponse au traitement) | [RL](../RL/README.md), [Probas](../Probas/README.md) |
-| **Knowledge engineering** | Formalisation explicite des connaissances metier en classes/regles | Ontologie oncologique, regles de diagnostic | [SemanticWeb](../SymbolicAI/SemanticWeb/README.md) |
-| **Inference sous contraintes** | Resolution conjointe d'un probleme avec contraintes dures et incertitudes | OncoPlan : calendrier valide ET probable | [Search](../Search/README.md), [SymbolicAI/Tweety](../SymbolicAI/Tweety/README.md) |
-| **Decision sous incertitude** | Choisir entre options avec resultats probabilistes et regret asymetrique | OncoPlan : adapter ou non un protocole | [Probas](../Probas/README.md), [GameTheory](../GameTheory/README.md) |
+| **Jumeau numérique** | Modèle logiciel d'un objet/personne réagissant à des interventions | Modèle patient (état, paramètres bio, réponse au traitement) | [RL](../RL/README.md), [Probas](../Probas/README.md) |
+| **Knowledge engineering** | Formalisation explicite des connaissances métier en classes/règles | Ontologie oncologique, règles de diagnostic | [SemanticWeb](../SymbolicAI/SemanticWeb/README.md) |
+| **Inférence sous contraintes** | Résolution conjointe d'un problème avec contraintes dures et incertitudes | OncoPlan : calendrier valide ET probable | [Search](../Search/README.md), [SymbolicAI/Tweety](../SymbolicAI/Tweety/README.md) |
+| **Décision sous incertitude** | Choisir entre options avec résultats probabilistes et regret asymétrique | OncoPlan : adapter ou non un protocole | [Probas](../Probas/README.md), [GameTheory](../GameTheory/README.md) |
 
-Ces concepts ne sont pas exclusifs au domaine medical : on les retrouve a l'identique en **finance algorithmique** (jumeau de marche + contraintes reglementaires + signaux probabilistes), **logistique** (jumeau de flotte + planification + previsions) et **maintenance predictive** (jumeau equipement + regles metier + Bayesien). Le choix du medical est pedagogique : domaine riche en contraintes formelles et en incertitude irreductible.
+Ces concepts ne sont pas exclusifs au domaine médical : on les retrouve à l'identique en **finance algorithmique** (jumeau de marché + contraintes réglementaires + signaux probabilistes), **logistique** (jumeau de flotte + planification + prévisions) et **maintenance prédictive** (jumeau équipement + règles métier + Bayésien). Le choix du médical est pédagogique : domaine riche en contraintes formelles et en incertitude irréductible.
 
 ## Pour aller plus loin
 
-### Articles de reference
+### Articles de référence
 
-- **Khan et al. (2021)** - *Hybrid AI for Clinical Decision Support: A Survey* — panorama des architectures hybrides en sante numerique
-- **Goodall et al. (2022)** - *Digital Twins in Healthcare: Trends, Applications, and Implementation Challenges* — etat de l'art jumeaux numeriques patient
-- **Hooker (2012)** - *Integrated Methods for Optimization* — fondements de la composition CP/SAT/MILP utilisee en OncoPlan
-- **Bingham et al. (2019)** - *Pyro: Deep Universal Probabilistic Programming* — paper de reference pour la couche probabiliste
+- **Khan et al. (2021)** - *Hybrid AI for Clinical Decision Support: A Survey* — panorama des architectures hybrides en santé numérique
+- **Goodall et al. (2022)** - *Digital Twins in Healthcare: Trends, Applications, and Implementation Challenges* — état de l'art jumeaux numériques patient
+- **Hooker (2012)** - *Integrated Methods for Optimization* — fondements de la composition CP/SAT/MILP utilisée en OncoPlan
+- **Bingham et al. (2019)** - *Pyro: Deep Universal Probabilistic Programming* — paper de référence pour la couche probabiliste
 
 ### Extensions possibles
 
-| Extension | Description | Techniques mobilisees |
+| Extension | Description | Techniques mobilisées |
 |-----------|-------------|----------------------|
-| **Apprentissage par renforcement** | Formuler OncoPlan en MDP : etat patient -> action protocole -> recompense survie | PPO, DQN ([RL](../RL/README.md) notebooks 5-6) |
-| **LLM en boucle** | Utiliser un LLM pour generer des hypotheses diagnostiques, valider par Z3 | [Sudoku](../Sudoku/README.md) notebook 17, Semantic Kernel |
-| **Multi-agent** | Plusieurs medecins virtuels delibererent (diagnostic, prescription, monitoring) | [RL](../RL/README.md) notebook 6, [GameTheory](../GameTheory/README.md) |
-| **Explicabilite** | Generer une trace narrative des decisions ontologie + contraintes + Bayesien | [SymbolicAI](../SymbolicAI/README.md), Tweety argumentation |
-| **Federated learning** | Entrainement reparti entre hopitaux sans partage des donnees patient | Adaptation [ML](../ML/README.md), considerations RGPD |
+| **Apprentissage par renforcement** | Formuler OncoPlan en MDP : état patient -> action protocole -> récompense survie | PPO, DQN ([RL](../RL/README.md) notebooks 5-6) |
+| **LLM en boucle** | Utiliser un LLM pour générer des hypothèses diagnostiques, valider par Z3 | [Sudoku](../Sudoku/README.md) notebook 17, Semantic Kernel |
+| **Multi-agent** | Plusieurs médecins virtuels délibèrent (diagnostic, prescription, monitoring) | [RL](../RL/README.md) notebook 6, [GameTheory](../GameTheory/README.md) |
+| **Explicabilité** | Générer une trace narrative des décisions ontologie + contraintes + Bayésien | [SymbolicAI](../SymbolicAI/README.md), Tweety argumentation |
+| **Federated learning** | Entraînement réparti entre hôpitaux sans partage des données patient | Adaptation [ML](../ML/README.md), considérations RGPD |
 
-### Aspects ethiques et reglementaires
+### Aspects éthiques et réglementaires
 
-Les systemes IA appliques au domaine medical sont soumis a des contraintes legales (RGPD, AI Act europeen, FDA aux US) et ethiques (explicabilite, biais, responsabilite). Les projets de cette serie sont **academiques** : ils utilisent des donnees synthetiques ou anonymisees et ne sont pas destines a un usage clinique. Toute transposition reelle exigerait :
+Les systèmes IA appliqués au domaine médical sont soumis à des contraintes légales (RGPD, AI Act européen, FDA aux US) et éthiques (explicabilité, biais, responsabilité). Les projets de cette série sont **académiques** : ils utilisent des données synthétiques ou anonymisées et ne sont pas destinés à un usage clinique. Toute transposition réelle exigerait :
 
-- Validation clinique sur cohorte representative et publication peer-reviewed
-- Certification dispositif medical (Classes I-IV selon risque)
-- Audit ethique (CER, CNIL pour les donnees patient en France)
-- Explicabilite documentee de chaque decision automatisee
+- Validation clinique sur cohorte représentative et publication peer-reviewed
+- Certification dispositif médical (Classes I-IV selon risque)
+- Audit éthique (CER, CNIL pour les données patient en France)
+- Explicabilité documentée de chaque décision automatisée
 
-Ces dimensions sont abordees en survol dans les notebooks mais meritent un module dedie pour une formation professionnelle complete.
+Ces dimensions sont abordées en survol dans les notebooks mais méritent un module dédié pour une formation professionnelle complète.
 
 ## Installation
 
@@ -154,33 +154,33 @@ Ces dimensions sont abordees en survol dans les notebooks mais meritent un modul
 pip install -r requirements.txt
 ```
 
-Dependances principales : numpy, pandas, matplotlib, seaborn, z3-solver, pyro-ppl, ortools
+Dépendances principales : numpy, pandas, matplotlib, seaborn, z3-solver, pyro-ppl, ortools
 
 ## FAQ
 
-### Faut-il avoir suivi toutes les series avant de commencer les etudes de cas ?
+### Faut-il avoir suivi toutes les séries avant de commencer les études de cas ?
 
-Non, mais les prerequis varient par projet. Le **Diagnostic Medical** necessite d'avoir vu Search Part 1 (recherche informee) et Search Part 2 (CSP/Z3). L'**Oncology Planning** necessite Probas (inference bayesienne) et ideallement Planners (CP-SAT). Chaque projet indique les prerequis specifiques dans sa section. Commencez par le projet dont vous maitrisez les prerequis.
+Non, mais les prérequis varient par projet. Le **Diagnostic Médical** nécessite d'avoir vu Search Part 1 (recherche informée) et Search Part 2 (CSP/Z3). L'**Oncology Planning** nécessite Probas (inférence bayésienne) et idéalement Planners (CP-SAT). Chaque projet indique les prérequis spécifiques dans sa section. Commencez par le projet dont vous maîtrisez les prérequis.
 
-### Qu'est-ce qu'un jumeau numerique patient ?
+### Qu'est-ce qu'un jumeau numérique patient ?
 
-Un **jumeau numerique** est un modele computationnel qui simule le comportement d'un patient virtuel face a un traitement. Dans OncoPlan, le modele probabiliste (Pyro) estime la reponse tumorale en fonction des parametres patient (age, stade, biomarqueurs) et du protocole propose. Le jumeau permet de tester des scenarios de traitement sans risque pour le patient reel.
+Un **jumeau numérique** est un modèle computationnel qui simule le comportement d'un patient virtuel face à un traitement. Dans OncoPlan, le modèle probabiliste (Pyro) estime la réponse tumorale en fonction des paramètres patient (âge, stade, biomarqueurs) et du protocole proposé. Le jumeau permet de tester des scénarios de traitement sans risque pour le patient réel.
 
-### Les donnees medicales sont-elles reelles ?
+### Les données médicales sont-elles réelles ?
 
-Les notebooks utilisent des **donnees synthetiques** (generees pour etre pedagogiquement realistes) ou des **donnees publiques anonymisees** (quand disponibles). Aucune donnee patient reelle n'est incluse. Les modeles sont simplifies pour rester comprehensible — un modele clinique reel aurait des dizaines de variables supplementaires.
+Les notebooks utilisent des **données synthétiques** (générées pour être pédagogiquement réalistes) ou des **données publiques anonymisées** (quand disponibles). Aucune donnée patient réelle n'est incluse. Les modèles sont simplifiés pour rester compréhensible — un modèle clinique réel aurait des dizaines de variables supplémentaires.
 
-### Quels packages Python sont necessaires ?
+### Quels packages Python sont nécessaires ?
 
-`pip install -r requirements.txt` installe tout : numpy, pandas, matplotlib, seaborn, z3-solver, pyro-ppl, ortools. Aucune dependance externe (API, Docker, GPU) n'est requise.
+`pip install -r requirements.txt` installe tout : numpy, pandas, matplotlib, seaborn, z3-solver, pyro-ppl, ortools. Aucune dépendance externe (API, Docker, GPU) n'est requise.
 
-### Quelle est la difference entre diagnostic medical et planification oncologique ?
+### Quelle est la différence entre diagnostic médical et planification oncologique ?
 
-Le **Diagnostic Medical** resout un probleme de classification : etant donne des symptomes, identifier la maladie (recherche dans un espace d'etats + contraintes Z3). L'**Oncology Planning** resout un probleme d'optimisation : etant donne un diagnostic, planifier le meilleur protocole de traitement sous contraintes de toxicite et delais (CP-SAT + modele probabiliste). Ce sont deux paradigmes distincts couverts par des series differentes.
+Le **Diagnostic Médical** résout un problème de classification : étant donné des symptômes, identifier la maladie (recherche dans un espace d'états + contraintes Z3). L'**Oncology Planning** résout un problème d'optimisation : étant donné un diagnostic, planifier le meilleur protocole de traitement sous contraintes de toxicité et délais (CP-SAT + modèle probabiliste). Ce sont deux paradigmes distincts couverts par des séries différentes.
 
-### Quelle est la difference entre le template etudiant et la solution ?
+### Quelle est la différence entre le template étudiant et la solution ?
 
-Le template etudiant (`student/`) contient le squelette du projet : classes avec methodes `pass` ou `return None` (`# TODO etudiant`), structures de donnees pre-remplies, et tests unitaires pour valider chaque composant. La solution (`solution/`) implemente chaque methode completement. La pedagogie recommande un parcours en 3 phases : (1) comprendre la solution de reference, (2) implementer le template en s'appuyant sur les tests, (3) etendre avec des variantes personnelles. Le template est executable end-to-end grace aux stubs conformes (pas de `raise NotImplementedError`).
+Le template étudiant (`student/`) contient le squelette du projet : classes avec méthodes `pass` ou `return None` (`# TODO étudiant`), structures de données pré-remplies, et tests unitaires pour valider chaque composant. La solution (`solution/`) implémente chaque méthode complètement. La pédagogie recommande un parcours en 3 phases : (1) comprendre la solution de référence, (2) implémenter le template en s'appuyant sur les tests, (3) étendre avec des variantes personnelles. Le template est exécutable end-to-end grâce aux stubs conformes (pas de `raise NotImplementedError`).
 
 ---
 


### PR DESCRIPTION
## Summary

Pure accent restoration in `MyIA.AI.Notebooks/CaseStudies/README.md` (See #2876 — batch per family). CaseStudies family was orphan (interdisciplinary, not in po-2025 Probas/ML/Sudoku nor po-2023 GenAI nor po-2026 Lean partitions).

### Validation

- **Balanced diff**: 82 insertions / 82 délétions (1:1 = pure diacritics, 0 net content change)
- **CATALOG-STATUS marker**: byte-for-byte identical (grep-verified, no output)
- **Code blocks** (`text` directory tree, `bash` install): untouched
- **Internal links**: 13/13 OK (9 cross-series + Diagnostic-Medical + Oncology-Planning + 2 sub-refs, URLs pristine)
- **Identifiers preserved**: SMT, OWL, z3-solver, pyro-ppl, ortools, poutine.scale, `student/`, `solution/` — as-is
- **English terms preserved**: brittle, deep learning, peer-reviewed digital twin — as-is (not translated)
- **Verb-ambiguity review** (leçon #2902): manual diff read confirmed `réside` (present), `délibèrent` (present), `complètement` (adverb) correct; `valide` (adjective) deliberately left without accent (conservative — not a participle). Sub-agent reverted 4 non-accent typography changes (grand-chose, guillemets, inclusive phrasing, agreement) to stay strictly pure-accent — kept only `inférence` (the accent restoration IS the correct spelling).

### Pattern

Same as #2894 (IIT), #2903 (PostTraining), #2908 (RL), #2888 (Probas), #2904 (ML): pure diacritics, leave code/catalogue/paths/English intact. Per #2876: 1 PR per family.

### Families #2876 status

Covered: IIT ✅ PostTraining ✅ Probas ✅ ML ✅ SymbolicAI ✅ Lean ✅ Search ✅ GameTheory ✅ RL (review) **CaseStudies (this PR)**. Remaining: root (#2890 OPEN, CONFLICTING), GenAI/* (po-2023), QuantConnect (shared), docs/.