### PR TITLE
feat(lean): Knots Phase 5 diagnostic — certified counter-example to tricolorable_invariant

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -114,22 +114,57 @@ theorem tricolorable_invariant :
       ReidemeisterEquiv d₁ d₂ →
       IsTricolorable d₁ ↔ IsTricolorable d₂ := by
   exact sorry
-  -- BLOCKED (Phase 4 update): `triColorConditionAt` now implements the real Fox
-  -- condition with edge-index extraction (`colorAtNat` + `localStrands`), and
-  -- `trefoil_tricolorable` / `unknot_not_tricolorable` are re-proved under it.
-  -- The remaining blocker is the *transfer lemma*: a Reidemeister move changes
-  -- `d.numEdges` (R1 +2, R2 +4, R3 =), so `TriColoring d₁ = Fin d₁.numEdges → TriColor`
-  -- and `TriColoring d₂` have different types. Lifting a coloring across a move
-  -- requires a constructive edge-map `Fin d₂.numEdges → Fin d₁.numEdges` describing
-  -- how the move re-labels edges (the R1 twist adds a curl whose new edges inherit
-  -- the colour of the strand they sit on, etc.). The concrete moves in
-  -- Reidemeister.lean are *symmetric existentials* over PD-code surgery, not yet
-  -- carrying that edge-map — so there is no data to transfer the coloring along.
-  -- Dependency: equip Reidemeister1/2/3 with an explicit edge-renaming, then prove
-  --   (a) each move preserves the Fox condition at the affected crossings,
-  --   (b) the ≥2-colors condition is preserved (non-trivial for R1/R2: the new
-  --       edges must not collapse a 3-coloring to a 1-coloring).
-  -- Reference: Fox (1962); standard textbook proof (e.g. Adams, "The Knot Book").
+  -- BLOCKED (Phase 5 diagnosis — statement is FALSE under the current move model).
+  -- The Phase 4 diagnosis ("remaining blocker = transfer lemma") was INCOMPLETE.
+  -- The deeper blocker, established by the certified counter-example below
+  -- (`tricolorable_invariant_is_false_under_current_model`), is that the
+  -- Reidemeister moves are *too weakly specified* to make the theorem true:
+  --
+  --   `Reidemeister1 d₁ d₂ := ∃ c : PDCrossing, d₂ = {d₁ with
+  --      crossings := d₁.crossings ++ [c], numEdges := d₁.numEdges + 2 } ∨ ...`
+  --
+  -- The witness `c` is ARBITRARY — its PD labels (e1,e2,e3,e4) are unconstrained.
+  -- In particular one may pick `c` with a label OUT of range `[1, numEdges d₂]`,
+  -- e.g. `⟨7,8,9,10⟩` when `numEdges d₂ = 8`. Then `triColorConditionAt d₂ _ c`
+  -- fails its well-formedness conjunct (`1 ≤ e3 ≤ numEdges` is `1 ≤ 9 ≤ 8` = false),
+  -- so `IsTriColoring d₂` is false regardless of the coloring, hence
+  -- `IsTricolorable d₂` is false. But `IsTricolorable d₁` (trefoil) is true, so
+  -- the biconditional `IsTricolorable d₁ ↔ IsTricolorable d₂` is `(true ↔ false)`
+  -- = false, while `ReidemeisterEquiv d₁ d₂` holds (one R1 step). The universal
+  -- statement `tricolorable_invariant` is therefore REFUTED by that pair.
+  --
+  -- What this means for the project: proving `tricolorable_invariant` is NOT a
+  -- matter of finding a transfer lemma — the statement must first be made TRUE by
+  -- STRENGTHENING the move model. Phase 5 prerequisite (re-modeling):
+  --   (1) Replace the symmetric-existential `Reidemeister1/2/3` by constructors
+  --       that carry an explicit *geometric edge-renaming*
+  --       `Fin d₂.numEdges ↪ Fin d₁.numEdges` (R1: the new curl's two edges
+  --       inherit the colour of the strand they sit on; R2: the four new edges
+  --       pair up along the two poked strands; R3: a permutation at one crossing).
+  --   (2) Add a well-formedness predicate on KnotDiagram (each PD label in
+  --       `[1, numEdges]`, each label appears exactly twice) so that malformed
+  --       witnesses like `⟨7,8,9,10⟩` are excluded at the type level.
+  --   (3) Then re-state `tricolorable_invariant` over the well-formed quotient
+  --       and prove the transfer lemma (the original Phase 4 sub-goal) along the
+  --       edge-renaming. The ≥2-colours preservation is the delicate case (R1/R2
+  --       must not collapse a 3-colouring to a 1-colouring).
+  -- Reference: Fox (1962); Adams, "The Knot Book"; for the certified refutation
+  -- see `tricolorable_invariant_is_false_under_current_model` below.
+
+/- Certified refutation of `tricolorable_invariant` under the Phase 3 move model.
+
+This is a *positive* diagnostic result (not a gap): it PROVES that the current
+symmetric-existential model of Reidemeister moves is too weak to admit the
+tricolorability-invariant theorem. The trefoil diagram is tricolorable, but a
+single R1 step can reach a diagram whose added crossing has an out-of-range PD
+label, which is therefore NOT tricolorable. Since `ReidemeisterEquiv` holds
+between them but tricolorability does not transfer, the universal biconditional
+fails.
+
+This lemma is the evidence that Phase 5 requires re-modeling the moves (see the
+diagnostic on `tricolorable_invariant` above), not merely a transfer lemma. It
+is stated and proven below `trefoil_tricolorable` as
+`tricolorable_invariant_fails_under_current_model`. -/
 
 /-! ## 3. The trefoil is tricolorable
 
@@ -166,6 +201,63 @@ theorem trefoil_tricolorable : Knot.isTricolorable trefoil := by
   · decide
   -- At least 2 colors: edge 0 = red, edge 2 = blue, red ≠ blue
   · exact ⟨⟨0, by decide⟩, ⟨2, by decide⟩, by decide⟩
+
+/-! ## 3b. Certified counter-example: the invariant theorem needs a stronger model
+
+This is a *positive* diagnostic result (not a gap). It PROVES that the current
+symmetric-existential model of Reidemeister moves (Phase 3) is too weak to admit
+the tricolorability-invariant theorem `tricolorable_invariant` stated in §2.
+
+The trefoil diagram is tricolorable (proven just above), but a single R1 step
+can reach a diagram whose added crossing has an out-of-range PD label, which is
+therefore NOT tricolorable. Since `ReidemeisterEquiv` holds between them but
+tricolorability does not transfer, any universal biconditional
+`∀ d₁ d₂, ReidemeisterEquiv d₁ d₂ → IsTricolorable d₁ ↔ IsTricolorable d₂`
+is refuted by that pair. See the diagnostic on `tricolorable_invariant` (§2) for
+the Phase 5 prerequisite: re-model the moves with explicit geometric edge-
+renaming + a well-formedness predicate, so that malformed witnesses like the
+`⟨7,8,9,10⟩` below are excluded at the type level. -/
+theorem tricolorable_invariant_fails_under_current_model :
+    ∃ (d₁ d₂ : KnotDiagram),
+      ReidemeisterEquiv d₁ d₂ ∧
+      IsTricolorable d₁ ∧
+      ¬ IsTricolorable d₂ := by
+  -- Counter-example pair: d₁ = trefoilDiagram (tricolorable, proven above), and
+  -- d₂ = trefoilDiagram with one malformed crossing ⟨7,8,9,10⟩ appended and
+  -- numEdges = 6 + 2 = 8. A single R1 step connects them (existential witness
+  -- c = ⟨7,8,9,10⟩), but d₂ is NOT tricolorable because the added crossing
+  -- fails the label-range well-formedness conjunct of `triColorConditionAt`
+  -- (e3 = 9 > numEdges d₂ = 8).
+  refine' ⟨trefoilDiagram,
+           { crossings := trefoilDiagram.crossings ++ [⟨7, 8, 9, 10⟩]
+             numEdges := trefoilDiagram.numEdges + 2
+             hwell := by trivial }, ?_, ?_, ?_⟩
+  -- (a) ReidemeisterEquiv d₁ d₂ holds: one R1 step with witness ⟨7,8,9,10⟩.
+  · exact ReidemeisterEquiv.step (ReidemeisterStep.r1
+      ⟨⟨7, 8, 9, 10⟩, Or.inl rfl⟩)
+  -- (b) d₁ (the trefoil) is tricolorable: `trefoil_tricolorable` proves
+  -- `Knot.isTricolorable trefoil`, which is definitionally
+  -- `IsTricolorable trefoil.diagram = IsTricolorable trefoilDiagram`.
+  · exact trefoil_tricolorable
+  -- (c) d₂ is NOT tricolorable: any coloring fails the Fox condition at the
+  -- malformed crossing ⟨7,8,9,10⟩, because e3 = 9 > numEdges d₂ = 8.
+  · rintro ⟨coloring, hcond, hedges, htwocolors⟩
+    -- The malformed crossing is in d₂.crossings (it was appended).
+    have hmem : (⟨7, 8, 9, 10⟩ : PDCrossing) ∈
+        (trefoilDiagram.crossings ++ [⟨7, 8, 9, 10⟩]) := by
+      simp [List.mem_append]
+    -- The Fox condition must hold at every crossing, including the malformed one.
+    have hfox := hcond ⟨7, 8, 9, 10⟩ hmem
+    -- But its well-formedness conjunct requires 1 ≤ e3 = 9 ≤ numEdges d₂ = 8,
+    -- i.e. 9 ≤ 8, which is false. Extract the well-formedness half and close.
+    -- hfox : (1≤7 ∧ 7≤n ∧ 1≤8 ∧ 8≤n ∧ 1≤9 ∧ 9≤n) ∧ (Fox disjunction)
+    have hwf := hfox.1
+    -- hwf : 1 ≤ 7 ∧ 7 ≤ trefoilDiagram.numEdges + 2 ∧
+    --        1 ≤ 8 ∧ 8 ≤ trefoilDiagram.numEdges + 2 ∧
+    --        1 ≤ 9 ∧ 9 ≤ trefoilDiagram.numEdges + 2
+    -- trefoilDiagram.numEdges = 6 by definition, so the last conjunct is 9 ≤ 8.
+    simp only [trefoilDiagram] at hwf   -- reduces numEdges to 6, then 6 + 2 = 8
+    omega
 
 /-! ## 4. The unknot is NOT tricolorable
 


### PR DESCRIPTION
## Summary

Knots Phase 5 diagnostic PR. The Phase 4 diagnosis left `tricolorable_invariant` open, attributing the blocker to a missing "transfer lemma". **This is incomplete: the statement is mathematically FALSE under the current symmetric-existential move model.** This PR adds a certified counter-example that proves it, and corrects the diagnostic to point at the real Phase 5 prerequisite (re-model the moves).

Same nature as the conway P4 breakthrough: the "intractable" target is a false statement under the current model.

## Change

**Single file: `Knots/Invariant.lean` (+108/-16).**

1. **New PROVEN theorem** `tricolorable_invariant_fails_under_current_model`:
   ```
   ∃ (d₁ d₂ : KnotDiagram),
     ReidemeisterEquiv d₁ d₂ ∧ IsTricolorable d₁ ∧ ¬ IsTricolorable d₂
   ```
   - `d₁ = trefoilDiagram` (tricolorable, proven just above as `trefoil_tricolorable`).
   - `d₂ = trefoilDiagram` with malformed crossing `⟨7,8,9,10⟩` appended, `numEdges = 8`.
   - `ReidemeisterEquiv d₁ d₂` via one R1 step (the witness `c` in `Reidemeister1` is *arbitrary* — that is the root cause).
   - `¬ IsTricolorable d₂` because the malformed crossing's `e3 = 9 > numEdges d₂ = 8` fails the well-formedness conjunct of `triColorConditionAt`.
2. **Corrected diagnostic** on the existing `tricolorable_invariant` sorry: the "transfer lemma" framing was incomplete. Real blocker = the move model is too weak; Phase 5 prerequisite is to STRENGTHEN it (geometric edge-renaming constructors + `KnotDiagram` well-formedness predicate) so malformed witnesses are excluded at the type level.

This is **pure strengthening**: a new proven theorem + a corrected comment. No existing proof is touched, none replaced by sorry.

## §B Lean validation (lean-merge-discipline)

### 1. `grep -c sorry` before/after (real declarations only)
```
grep -cE '^\s*(exact )?sorry|:=\s*by\s+sorry|:=\s*sorry' Invariant.lean
before (main fdd0f1c7): 3
after  (this branch)   : 3
```
Same 3 residual sorries as main: `tricolorable_invariant`, `trefoil_not_unknot`, `Knot.unknottingNumber`. **No regression.** The new theorem is genuinely proven.

### 2. Lake build SUCCESS
```
~/.elan/bin/lake build Knots   (Lean v4.31.0-rc1, WSL Ubuntu)
Build completed successfully (8 jobs).
```
No new errors. The 3 sorries above are the only `declaration uses sorry` warnings.

### 3. Proof integrity (axiom check)
```
#print axioms tricolorable_invariant_fails_under_current_model
> [propext, Quot.sound]
```
Lean core axioms only — no `sorry`, no custom axiom. The counter-example is a sound proof.

### 4. No prover refactor
Pure Lean, 1 file, 1 subject. Tactics: `simp`, `omega`, `refine'`, `exact`, `rfl`. No `decide`-on-opaque, no `sorry`-bridging.

## Why this matters (decision for ai-01)

ai-01 cycle 4 dispatch offered: "transfer lemma `tricolorable_invariant` (blocker cited: numEdges change by move) OU Conway P5 Gap2. Un seul item/wakeup (G.5)."

This PR establishes that the **transfer lemma is not the blocker** — the statement is false as written. Two paths forward for Phase 5 (ai-01's call):
- **(A)** Authorize re-modeling R1/R2/R3 with geometric edge-renaming + add `KnotDiagram.wf` predicate (substantial, multi-cycle, but unblocks the invariant properly).
- **(B)** Defer Knots Phase 5 and pivot to Conway P5 Gap2 (round-trip Grid↔MacroCell).

I'm not starting (A) without sign-off (it is large scope, G.4/G.5). This PR converts an under-specified blocker into a diagnosed, certified one.

See #2874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
