### PR TITLE
feat(lean): Conway P5 Gap2 -- ceilLog2_spec arithmetic lemma (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -151,6 +151,22 @@ def ceilLog2 (k : Nat) : Nat :=
   | 1     => 0
   | k + 2 => 1 + ceilLog2 ((k + 2 + 1) / 2)
 
+/-- `ceilLog2 k` is large enough that `2 ^ ceilLog2 k >= k`. This is the
+    arithmetic heart of the `gridFrame` containment lemma. -/
+theorem ceilLog2_spec (k : Nat) : 2 ^ ceilLog2 k >= k := by
+  induction k using Nat.strongInductionOn with
+  | ind k ih =>
+    match k with
+    | 0 => simp [ceilLog2]
+    | 1 => simp [ceilLog2]
+    | m + 2 =>
+      show 2 ^ (1 + ceilLog2 ((m + 2 + 1) / 2)) >= m + 2
+      have h : 2 ^ ceilLog2 ((m + 2 + 1) / 2) >= (m + 2 + 1) / 2 :=
+        ih ((m + 2 + 1) / 2) (by omega)
+      have h2 : 2 * 2 ^ ceilLog2 ((m + 2 + 1) / 2) >= m + 2 := by omega
+      rw [Nat.pow_add, Nat.pow_one]
+      exact h2
+
 /-- Build a `MacroCell` of level `n` covering the square `[r0, r0 + 2^n) x
     [c0, c0 + 2^n)`, with live cells given by membership test in `g`. -/
 def buildFromGrid (g : Grid) (r0 c0 : Int) : Nat -> MacroCell


### PR DESCRIPTION
## Summary

Second atomic step toward the Conway P5 Gap2 round-trip theorem (#2162). Following the core membership lemma `mem_toCellsAux_buildFromGrid` (PR #2914, under review), this PR delivers its **arithmetic prerequisite**: the correctness spec of the `ceilLog2` helper.

### What's added (MacroCell.lean, +16 lines, 0 deletions)

```lean
theorem ceilLog2_spec (k : Nat) : 2 ^ ceilLog2 k >= k
```

This is the pure-`Nat` arithmetic heart of the upcoming `gridFrame` containment lemma — which will assert that the level `lvl` chosen by `gridFrame g` makes the covered square `2^lvl × 2^lvl` strictly contain `g`'s bounding box plus a 2-cell padding. Without `ceilLog2_spec`, that containment cannot be discharged.

### Why strong induction

The recursion `ceilLog2 (k+2) = 1 + ceilLog2 ((k+3)/2)` recurses on `(k+3)/2`, which is **not** a structural subterm of `k+2`. Plain `induction k with | zero | succ` therefore does not apply. The proof uses `Nat.strongInductionOn`, applies the IH at the strictly-smaller `(m+3)/2` (decrease proved by `omega`), and closes the floor-division arithmetic `2 * ((m+3)/2) >= m+2` via `omega`.

## Lean discipline (per .claude/rules/lean-merge-discipline.md)

**`grep -cE '^\s*sorry\b'` before/after:**
- MacroCell.lean: `0 → 0` (pure addition)
- HashlifeCorrectness.lean: baseline unchanged (not touched)

**`lake build` (local, WSL Ubuntu, Lean 4.30.0-rc2, Mathlib cold-build DONE):**
```
$ rm -f .lake/build/lib/lean/Conway/Life/MacroCell.olean   # force genuine recompile
$ lake build Conway.Life.MacroCell
ℹ [3317/3317] Built Conway.Life.MacroCell (13s)
Build completed successfully (3317 jobs).
$ grep -cE '^\s*sorry\b' Conway/Life/MacroCell.lean
0
```
**Genuine fresh compile** (olean deleted first, 13s build) — not a replayed/replayed verdict.

**Downstream integrity:**
```
$ lake build Conway.Life.HashlifeCorrectness
Build completed successfully (3319 jobs).
```
Sorry count in HashlifeCorrectness unchanged (P4 inline L945 + P5 L1105 = baseline). No regression.

**Proof integrity:** no `axiom`, no `sorry`, no `admit`. Standard Lean + Mathlib + `omega`.

## Scope

One file, one theorem (+16 lines). Atomique. Does **not** close #2162 — it is a building block. The remaining Gap2 work:
- `gridFrame_contains_g` (bounding box + padding containment, combines this lemma with `gridRowMinMax` ≤ `p`),
- assembly of the full round-trip via `mem_toCellsAux_buildFromGrid` (#2914) + `Canonical.ext`.

Hence `See #2162` (partial contribution to an epic), not `Closes`.

## Independence note

This lemma is on a **fresh branch from `origin/main`** and does **not** depend on PR #2914 (`mem_toCellsAux_buildFromGrid`, still under review). It can be merged independently and in any order relative to #2914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)