### PR TITLE
feat(lean): Conway P5 Gap2 bounding-box membership lemmas (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -292,6 +292,172 @@ def gridColMax (g : Grid) : Int :=
   | []      => 0
   | p :: ps => ps.foldl (fun m q => max m q.2) p.2
 
+/-! ## Bounding-box membership lemmas
+
+These relate `gridRowMin` / `gridRowMax` / `gridColMin` / `gridColMax` to list
+membership: every live cell of `g` lies inside its bounding box. They form the
+arithmetic bridge for `gridFrame_contains_g` (P5 correctness, issue #2162,
+Gap 2 — the Grid↔MacroCell round trip).
+
+The four bounding-box helpers are `foldl`s over a coordinate projection, so we
+factor the reasoning through generic `proj`-parameterised lemmas and
+instantiate them for rows (`(·.1)`) and columns (`(·.2)`). We split
+`p ∈ head :: tail` via `by_cases` rather than `cases`/`subst` to avoid the
+direction-dependent substitution (which side gets eliminated) when both
+operands are local variables. -/
+
+/-- Generic helper: a `foldl` of `min` (via a projection `proj`) never exceeds
+    its seed accumulator. -/
+theorem foldl_proj_min_le_seed (ps : Grid) (proj : Int × Int → Int) (acc : Int) :
+    ps.foldl (fun m q => min m (proj q)) acc ≤ acc := by
+  induction ps generalizing acc with
+  | nil => simp
+  | cons q qs ih =>
+    simp only [List.foldl_cons]
+    have h := ih (min acc (proj q))
+    omega
+
+/-- Generic helper: a `foldl` of `min` (via `proj`) never exceeds the projected
+    coordinate of any cell in the list. -/
+theorem foldl_proj_min_le_of_mem (ps : Grid) (proj : Int × Int → Int) (acc : Int)
+    (p : Int × Int) (hp : p ∈ ps) :
+    ps.foldl (fun m q => min m (proj q)) acc ≤ proj p := by
+  induction ps generalizing acc p with
+  | nil => simp at hp
+  | cons q qs ih =>
+    simp only [List.foldl_cons]
+    by_cases heq : p = q
+    · rw [heq]
+      have h := foldl_proj_min_le_seed qs proj (min acc (proj q))
+      omega
+    · have hps : p ∈ qs := by
+        rcases List.mem_cons.mp hp with hhead | hps
+        · exact absurd hhead heq
+        · exact hps
+      exact ih (min acc (proj q)) p hps
+
+/-- Generic helper: a `foldl` of `max` (via a projection `proj`) is never below
+    its seed accumulator. -/
+theorem le_foldl_proj_max_seed (ps : Grid) (proj : Int × Int → Int) (acc : Int) :
+    acc ≤ ps.foldl (fun m q => max m (proj q)) acc := by
+  induction ps generalizing acc with
+  | nil => simp
+  | cons q qs ih =>
+    simp only [List.foldl_cons]
+    have h := ih (max acc (proj q))
+    omega
+
+/-- Generic helper: a `foldl` of `max` (via `proj`) is never below the projected
+    coordinate of any cell in the list. -/
+theorem le_foldl_proj_max_of_mem (ps : Grid) (proj : Int × Int → Int) (acc : Int)
+    (p : Int × Int) (hp : p ∈ ps) :
+    proj p ≤ ps.foldl (fun m q => max m (proj q)) acc := by
+  induction ps generalizing acc p with
+  | nil => simp at hp
+  | cons q qs ih =>
+    simp only [List.foldl_cons]
+    by_cases heq : p = q
+    · rw [heq]
+      have h := le_foldl_proj_max_seed qs proj (max acc (proj q))
+      omega
+    · have hps : p ∈ qs := by
+        rcases List.mem_cons.mp hp with hhead | hps
+        · exact absurd hhead heq
+        · exact hps
+      exact ih (max acc (proj q)) p hps
+
+/-- Every cell of `g` has row coordinate at least `gridRowMin g`. -/
+theorem gridRowMin_le_of_mem (g : Grid) (p : Int × Int) (hp : p ∈ g) :
+    gridRowMin g ≤ p.1 := by
+  cases g with
+  | nil => simp at hp
+  | cons p₀ ps =>
+    simp only [gridRowMin]
+    by_cases heq : p = p₀
+    · rw [heq]
+      exact foldl_proj_min_le_seed ps (·.1) p₀.1
+    · have hps : p ∈ ps := by
+        rcases List.mem_cons.mp hp with hhead | hps
+        · exact absurd hhead heq
+        · exact hps
+      exact foldl_proj_min_le_of_mem ps (·.1) p₀.1 p hps
+
+/-- Every cell of `g` has row coordinate at most `gridRowMax g`. -/
+theorem le_gridRowMax_of_mem (g : Grid) (p : Int × Int) (hp : p ∈ g) :
+    p.1 ≤ gridRowMax g := by
+  cases g with
+  | nil => simp at hp
+  | cons p₀ ps =>
+    simp only [gridRowMax]
+    by_cases heq : p = p₀
+    · rw [heq]
+      exact le_foldl_proj_max_seed ps (·.1) p₀.1
+    · have hps : p ∈ ps := by
+        rcases List.mem_cons.mp hp with hhead | hps
+        · exact absurd hhead heq
+        · exact hps
+      exact le_foldl_proj_max_of_mem ps (·.1) p₀.1 p hps
+
+/-- Every cell of `g` has column coordinate at least `gridColMin g`. -/
+theorem gridColMin_le_of_mem (g : Grid) (p : Int × Int) (hp : p ∈ g) :
+    gridColMin g ≤ p.2 := by
+  cases g with
+  | nil => simp at hp
+  | cons p₀ ps =>
+    simp only [gridColMin]
+    by_cases heq : p = p₀
+    · rw [heq]
+      exact foldl_proj_min_le_seed ps (·.2) p₀.2
+    · have hps : p ∈ ps := by
+        rcases List.mem_cons.mp hp with hhead | hps
+        · exact absurd hhead heq
+        · exact hps
+      exact foldl_proj_min_le_of_mem ps (·.2) p₀.2 p hps
+
+/-- Every cell of `g` has column coordinate at most `gridColMax g`. -/
+theorem le_gridColMax_of_mem (g : Grid) (p : Int × Int) (hp : p ∈ g) :
+    p.2 ≤ gridColMax g := by
+  cases g with
+  | nil => simp at hp
+  | cons p₀ ps =>
+    simp only [gridColMax]
+    by_cases heq : p = p₀
+    · rw [heq]
+      exact le_foldl_proj_max_seed ps (·.2) p₀.2
+    · have hps : p ∈ ps := by
+        rcases List.mem_cons.mp hp with hhead | hps
+        · exact absurd hhead heq
+        · exact hps
+      exact le_foldl_proj_max_of_mem ps (·.2) p₀.2 p hps
+
+/-- For any non-empty grid, the row bounding box is well-formed:
+    `gridRowMin g ≤ gridRowMax g`. -/
+theorem gridRowMin_le_gridRowMax (g : Grid) (hg : g ≠ []) :
+    gridRowMin g ≤ gridRowMax g := by
+  obtain ⟨p₀, ps, rfl⟩ : ∃ p₀ ps, g = p₀ :: ps := by
+    cases g with
+    | nil => exact absurd rfl hg
+    | cons p₀ ps => exact ⟨p₀, ps, rfl⟩
+  have hmin : gridRowMin (p₀ :: ps) ≤ p₀.1 :=
+    gridRowMin_le_of_mem _ _ (by simp)
+  have hmax : p₀.1 ≤ gridRowMax (p₀ :: ps) :=
+    le_gridRowMax_of_mem _ _ (by simp)
+  omega
+
+/-- For any non-empty grid, the column bounding box is well-formed:
+    `gridColMin g ≤ gridColMax g`. -/
+theorem gridColMin_le_gridColMax (g : Grid) (hg : g ≠ []) :
+    gridColMin g ≤ gridColMax g := by
+  obtain ⟨p₀, ps, rfl⟩ : ∃ p₀ ps, g = p₀ :: ps := by
+    cases g with
+    | nil => exact absurd rfl hg
+    | cons p₀ ps => exact ⟨p₀, ps, rfl⟩
+  have hmin : gridColMin (p₀ :: ps) ≤ p₀.2 :=
+    gridColMin_le_of_mem _ _ (by simp)
+  have hmax : p₀.2 ≤ gridColMax (p₀ :: ps) :=
+    le_gridColMax_of_mem _ _ (by simp)
+  omega
+
 /-- Compute a suitable `(offset, level)` so that the square of side
     `2 ^ level` placed at `offset` strictly contains the bounding box of
     `g` plus a 2-cell padding on each side. Returns `((0, 0), 0)` for the


### PR DESCRIPTION
## Summary

Part of **#2162** (Conway P5 `hashlife_correct`, Gap 2 — the Grid↔MacroCell round trip). **See #2162** (partial: bounding-box arithmetic bridge; the main `gridFrame_contains_g` theorem is deferred until #2916 `ceilLog2_spec` merges).

Adds **10 theorems** (+166 lines, 0 deletions) to `Conway/Life/MacroCell.lean`:

- **4 membership lemmas** — every live cell of a Grid lies inside its bounding box:
  - `gridRowMin_le_of_mem`, `le_gridRowMax_of_mem`
  - `gridColMin_le_of_mem`, `le_gridColMax_of_mem`
- **2 well-formedness lemmas** — the bounding box is ordered for non-empty grids:
  - `gridRowMin_le_gridRowMax`, `gridColMin_le_gridColMax`
- **4 generic supporting lemmas** (factored, `proj`-parameterised `foldl` over min/max × seed/of_mem), instantiated for rows `(·.1)` and columns `(·.2)`.

These are the arithmetic bridge that `gridFrame_contains_g` will use to prove `inRegion p r0 c0 lvl` for every `p ∈ g`, once #2916 (`ceilLog2_spec`) lands.

### Design notes
- Factored through `proj`-parameterised `foldl` lemmas to avoid 4× duplicated `foldl` inductions (row/col × min/max).
- Membership split via `by_cases` rather than `cases`/`subst`, to avoid the direction-dependent substitution (which operand gets eliminated) when both operands are local variables.

## Verification (Lean 4.30.0-rc2, Mathlib `5450b53e`)

### Sorry baseline (anti-regression D + lean-merge-discipline §B)
| File | before | after |
|------|--------|-------|
| `Conway/Life/MacroCell.lean` | 0 | **0** |
| `Conway/Life/HashlifeCorrectness.lean` (downstream) | 2 | **2** (unchanged) |

`grep -cE '^\s*sorry\b'` per file.

### Lake build SUCCESS — genuine fresh recompile (§B)
- **`lake build Conway.Life.MacroCell`** → `Built Conway.Life.MacroCell (16s)`. The `.olean` was **deleted first** so lake could not serve a cached `Replayed` — this confirms the proofs compile from scratch.
- **`lake build Conway.Life.HashlifeCorrectness`** (downstream consumer of MacroCell) → `Built (2.0s)`, sorry baseline **2** unchanged (P4 inline L945 + P5 main L1105 — research-level, untouched).
- **`lake build`** (full Conway project, all modules) → **SUCCESS**, no `error:` lines. Other importers (Hashlife, HashlifeMemo, Spaceships, Oscillators, Computation, RLE) all build.

### Proof integrity
No new axioms, no `sorry`, no `admit`. Proofs use only `induction ... generalizing`, `omega`, `List.foldl_cons`, `List.mem_cons`, `by_cases`, `simp`. Standard Lean core + Mathlib linear-arithmetic/`foldl` lemmas only.

### Prover refactor justification
N/A — this PR does not touch `agent_tests/prover/` or any prover Python.

## Why partial / what's next
Per the forensic (memory `grothendieck-lean-queue`), the full round-trip needs: this bounding-box suite (PR A, this PR) + `ceilLog2_spec` (#2916, under review) + the `gridFrame_contains_g` theorem (PR B, deferred to avoid merging a proof that calls an un-merged dependency) + assembly via `Canonical.ext` (`GridCanonical.lean:90`) + `mem_toCellsAux_buildFromGrid` (merged in #2914). This PR is the no-dependency, low-risk foundational piece.

`See #2162` (epic remains open; this is a partial contribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)