### PR TITLE
fix(lean): Conway ceilLog2_spec does not compile in Lean 4.30.0-rc2 [URGENT, main broken] (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -154,13 +154,13 @@ def ceilLog2 (k : Nat) : Nat :=
 /-- `ceilLog2 k` is large enough that `2 ^ ceilLog2 k >= k`. This is the
     arithmetic heart of the `gridFrame` containment lemma. -/
 theorem ceilLog2_spec (k : Nat) : 2 ^ ceilLog2 k >= k := by
-  induction k using Nat.strongInductionOn with
-  | ind k ih =>
+  induction k using Nat.strong_induction_on with
+  | _ k ih =>
     match k with
     | 0 => simp [ceilLog2]
     | 1 => simp [ceilLog2]
     | m + 2 =>
-      show 2 ^ (1 + ceilLog2 ((m + 2 + 1) / 2)) >= m + 2
+      simp only [ceilLog2]
       have h : 2 ^ ceilLog2 ((m + 2 + 1) / 2) >= (m + 2 + 1) / 2 :=
         ih ((m + 2 + 1) / 2) (by omega)
       have h2 : 2 * 2 ^ ceilLog2 ((m + 2 + 1) / 2) >= m + 2 := by omega


### PR DESCRIPTION
## URGENT regression fix — origin/main does not build

PR #2916 (merged 2026-06-13 16:54 UTC) introduced `ceilLog2_spec` using **`Nat.strongInductionOn`**, which **does not exist** in Lean 4.30.0-rc2 core (it lives in Mathlib as `Nat.strong_induction_on`). **origin/main's `Conway.Life.MacroCell` currently fails to compile from source** — the `lake build SUCCESS` / "cold-build DONE" that accompanied #2916 relied on a stale cached `.olean`.

### Genuine recompile of origin/main (pristine, `.olean` deleted)

```
error: Conway/Life/MacroCell.lean:157:20: Unknown constant `Nat.strongInductionOn`
error: Lean exited with code 1
error: build failed
```

This is a **lean-merge-discipline violation** (#2916 merged without genuine local `lake build SUCCESS`). It silently broke main: any fresh checkout / clean build of Conway fails.

## The fix (minimal, mechanical, no proof weakening)

| Line | Before | After | Reason |
|------|--------|-------|--------|
| 157 | `induction k using Nat.strongInductionOn` | `Nat.strong_induction_on` | Core name -> Mathlib name |
| 158 | `\| ind k ih =>` | `\| _ k ih =>` | Case name follows the Mathlib recursor |
| 163 | `show 2 ^ (1 + ceilLog2 ((m + 2 + 1) / 2)) >= m + 2` | `simp only [ceilLog2]` | `show` relied on a defeq the `k + 2` match pattern does not reduce; the generated equational lemma does the same rewrite |

The proof body (`have h`, `have h2`, `rw [Nat.pow_add, Nat.pow_one]`, `exact h2`) is **unchanged** — same induction, same hypotheses, same arithmetic. Pure toolchain-compatibility repair, no logical weakening.

## Verification (genuine recompile, `.olean` deleted each time)

| Check | Result |
|-------|--------|
| `lake build Conway.Life.MacroCell` | **Built (14s), 0 error** |
| `lake build Conway.Life.HashlifeCorrectness` | Build completed (3319 jobs) |
| `lake build` (full Conway) | Build completed (3350 jobs) |
| `grep -cE '^\s*sorry\b'` MacroCell.lean | **0** (0 -> 0, no regression) |
| HashlifeCorrectness sorry baseline | 2 (unchanged) |
| Diff vs origin/main | 3 insertions / 3 deletions, 1 file (MacroCell.lean only) |
| Catalog drift | none |

## lean-merge-discipline §B (4 elements)

1. **`grep -c sorry` before/after**: MacroCell.lean `0 -> 0`. No new sorry, no proof replaced by sorry.
2. **`lake build SUCCESS`**: proven above (genuine recompile after `.olean` deletion, 14s). NOT a cached "Replayed".
3. **Proof integrity**: no `sorry`/`admit`/`axiom` added. The `simp only [ceilLog2]` rewrite is semantically identical to the original `show`.
4. **No prover-Python refactor**: pure Lean fix, single concern.

## Request to reviewer (ai-01)

This **unblocks main** (currently broken). Please merge with priority. After merge, the `gridFrame_contains_g` theorem (depends on `ceilLog2_spec`) becomes buildable on a non-broken main.

See #2162 (Conway P5, Gap 2).