### PR TITLE
feat(lean): Conway P5 Gap2 -- gridFrame_contains_g containment bridge (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -495,6 +495,40 @@ def gridFrame (g : Grid) : (Int × Int) × Nat :=
     let lvl    := MacroCell.ceilLog2 side
     ((r0, c0), lvl)
 
+/-- For every live cell `p ∈ g`, the frame chosen by `gridFrame g` contains `p`:
+    `inRegion p r0 c0 lvl` where `((r0, c0), lvl) = gridFrame g`. This is the
+    containment bridge for the Grid↔MacroCell round trip (issue #2162, Gap 2). -/
+theorem gridFrame_contains_g (g : Grid) (p : Int × Int) (hp : p ∈ g) :
+    let ((r0, c0), lvl) := gridFrame g
+    MacroCell.inRegion p r0 c0 lvl := by
+  cases g with
+  | nil => simp at hp
+  | cons p₀ ps =>
+    have hrMin : gridRowMin (p₀ :: ps) ≤ p.1 := gridRowMin_le_of_mem _ _ hp
+    have hrMax : p.1 ≤ gridRowMax (p₀ :: ps) := le_gridRowMax_of_mem _ _ hp
+    have hcMin : gridColMin (p₀ :: ps) ≤ p.2 := gridColMin_le_of_mem _ _ hp
+    have hcMax : p.2 ≤ gridColMax (p₀ :: ps) := le_gridColMax_of_mem _ _ hp
+    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
+      gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
+    have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
+      gridColMin_le_gridColMax _ (List.cons_ne_nil _ _)
+    simp only [gridFrame]
+    set rMin := gridRowMin (p₀ :: ps)
+    set rMax := gridRowMax (p₀ :: ps)
+    set cMin := gridColMin (p₀ :: ps)
+    set cMax := gridColMax (p₀ :: ps)
+    set height := (rMax - rMin + 5).toNat
+    set width := (cMax - cMin + 5).toNat
+    set side := max height width
+    set lvl := MacroCell.ceilLog2 side
+    have hspec : (2 ^ lvl : Nat) ≥ side := MacroCell.ceilLog2_spec side
+    have hh : height ≤ side := Nat.le_max_left _ _
+    have hw : width ≤ side := Nat.le_max_right _ _
+    have hnn_r : 0 ≤ rMax - rMin + 5 := by omega
+    have hnn_c : 0 ≤ cMax - cMin + 5 := by omega
+    unfold MacroCell.inRegion
+    refine ⟨?_, ?_, ?_, ?_⟩ <;> omega
+
 /-- Convert a `Grid` to a `MacroCell`, returning the chosen offset so that
     `MacroCell.toGrid offset (gridToMacroCell g) = g`. -/
 def gridToMacroCellWithOffset (g : Grid) : (Int × Int) × MacroCell :=


### PR DESCRIPTION
## Summary

The Grid->MacroCell **containment bridge**: for every live cell `p in g`, the frame chosen by `gridFrame g` strictly contains `p`. This is the key lemma toward the Grid<->MacroCell round trip (Gap 2 of the Conway P5 proof, #2162).

```lean
theorem gridFrame_contains_g (g : Grid) (p : Int x Int) (hp : p in g) :
    let ((r0, c0), lvl) := gridFrame g
    MacroCell.inRegion p r0 c0 lvl
```

## Proof outline

Case split on `g`:
- **Empty `[]`**: vacuous (`p not in []`).
- **Non-empty `_ :: _`**: unfold `gridFrame` via `simp only` + `set` for the let-values, then prove the 4 `inRegion` conjuncts. Each conjunct chains:
  - bounding-box membership lemmas (`gridRowMin_le_of_mem`, `le_gridRowMax_of_mem`, and column variants) — all from #2919,
  - `ceilLog2_spec` bound (`2^lvl >= side >= height/width`) — from #2916/#2922,
  - `toNat` non-negativity (from `gridRowMin_le_gridRowMax`, #2919).
  - `omega` closes all 4 conjuncts once given `ceilLog2_spec` + max bounds + the `toNat` hypotheses.

## Dependencies (all merged to origin/main)

| Dep | Source |
|-----|--------|
| `ceilLog2_spec` | #2916 (repaired by #2922) |
| bbox membership suite (`gridRowMin/Max/ColMin/ColMax_le_of_mem`, `gridRowMin_le_gridRowMax`) | #2919 |
| `inRegion`, `gridFrame` defs | pre-existing |

## lean-merge-discipline §B (4 elements)

| # | Check | Result |
|---|-------|--------|
| 1 | `grep -c sorry` before/after | MacroCell.lean **0 -> 0** (pure addition, no proof replaced by sorry) |
| 2 | `lake build SUCCESS` (local, genuine) | MacroCell **Built (13s)** after `.olean` deletion (not cached "Replayed"), 0 error |
| 3 | Proof integrity | no `sorry`/`admit`/`axiom` added |
| 4 | No prover-Python refactor | pure Lean, single concern |

## Additional verification

- `lake build Conway.Life.HashlifeCorrectness`: Built (2.7s), 0 error (downstream unaffected)
- HashlifeCorrectness sorry baseline: **2** unchanged (P4 inline L945 + P5 main L1105, research-level, untouched)
- Diff vs origin/main: **+34 lines, 1 file** (MacroCell.lean only, pure addition)
- Catalog drift: none
- Fresh branch from `origin/main` (no stale-base, no accumulated churn)

## No BG iter prover

This PR adds a new proven theorem; it does not attack any residual `sorry`. The 2 research-level sorries in HashlifeCorrectness (P4 recursive arm, P5 main) remain untouched and out of scope for this Gap 2 lemma.

See #2162.