### PR TITLE
docs(z3): document NB-04 fork dependency + build script in SMT/Z3 README (See #1206)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -49,9 +49,21 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 | **.NET 9.0 SDK** | [Download](https://dotnet.microsoft.com/download/dotnet/9.0) |
 | **.NET Interactive** | `dotnet tool install --global Microsoft.dotnet-interactive` |
 | **Kernel Jupyter** | `.net-csharp` (installe automatiquement par .NET Interactive) |
-| **Package NuGet** | `Z3.Linq` (charge automatiquement dans les notebooks via `#r nuget:...`) |
+| **Package NuGet** | `Z3.Linq` (NB-01, 02, 03, 05 : charge automatiquement via `#r nuget:...`) |
+| **NB-04 — fork `int[][]`** | Le notebook 04 utilise le fork [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) (support `int[][]` absent du NuGet public endjin). Exécuter **une fois** : [`scripts/environment/z3-build-deploy.ps1`](../../../../scripts/environment/z3-build-deploy.ps1) (Windows) ou [`.sh`](../../../../scripts/environment/z3-build-deploy.sh) (Linux/macOS) — compile uniquement le wrapper (~1,5 s) et rassemble les 4 DLL dans `.deploy/`. |
 
-> Les notebooks sont autonomes : le restore NuGet et l'initialisation du contexte Z3 sont inclus dans les cellules de setup de chaque notebook.
+> Les notebooks sont autonomes : le restore NuGet et l'initialisation du contexte Z3 sont inclus dans les cellules de setup de chaque notebook. **Exception** : le notebook 04 (tableaux imbriqués 2D) charge le fork via `#r "../Z3.Linq/.deploy/..."`, d'où le pré-requis du script de build ci-dessus (décision ai-01 [DECISION COORD] 2026-06-13, option (b)).
+
+### Configuration : NuGet public vs fork
+
+La série suit une stratégie à deux volets selon le besoin en tableaux imbriqués (`int[][]`) :
+
+| Notebooks      | Source                      | Chargement                    | Pré-requis        |
+|----------------|-----------------------------|-------------------------------|-------------------|
+| 01, 02, 03, 05 | NuGet public `Z3.Linq`      | `#r nuget:Z3.Linq,...`        | Aucun (auto)      |
+| 04 (tableaux)  | Fork (voir ci-dessus)       | `#r "../Z3.Linq/.deploy/..."` | Script de build   |
+
+**Pourquoi un fork pour le notebook 04 ?** Le support des tableaux imbriqués `int[][]` (construction de sort Z3 `Array Int (Array Int Int)`, extraction récursive `ExtractCollection`) provient de [Z3.LinqBinding@EPFdevelopment](https://github.com/MyIntelligenceAgency/Z3.LinqBinding/tree/EPFdevelopment) et n'existe pas dans le NuGet public endjin (`Z3.Linq` 2.0.1, qui ne gère qu'un seul niveau de collection). Publier un NuGet forké n'est pas possible (nous ne sommes pas propriétaires du *package-id*), d'où le script qui compile **uniquement** le wrapper fin et rassemble le solveur natif + les dépendances managées depuis le cache NuGet.
 
 ## Objectifs d'apprentissage
 


### PR DESCRIPTION
Afférent documentation update to **#2921** (merged). The `SMT/Z3/README.md` Prérequis section claimed *all* notebooks load `Z3.Linq` via `#r nuget:...` — **incorrect for NB-04**, which depends on the `int[][]` fork and loads `#r "../Z3.Linq/.deploy/..."`.

## What changes (1 file, markdown-only)
- **Prérequis table**: split into `NB-01/02/03/05` (public NuGet, auto-restore) vs **`NB-04 — fork int[][]`** row pointing to `scripts/environment/z3-build-deploy.{ps1,sh}`.
- **New subsection** "Configuration : NuGet public vs fork": a two-track table + the rationale (why a fork for NB-04: `int[][]` support from `Z3.LinqBinding@EPFdevelopment` is absent from endjin NuGet 2.0.1; can't publish forked NuGet as non-package-id-owner → build script per ai-01 [DECISION COORD] option b).
- Relative links to the scripts verified to resolve (4 levels up from `SMT/Z3/`).

## Validation
- Markdown-only README (no notebook → no C.2/C.3 exec requirement). Table pipes aligned (MD060 clean).
- Secret-scan: PASS. Catalog byte-identical to main. Anti-collision: 0 open PRs touch `SMT/Z3`.

## G.1 note for ai-01 — Z3 steering steps 1-3 already DONE on main
Reading your steering msg `...ymcc9i`, the 3 steps you outlined are **already merged**:
1. **Submodule = fork** → done: `MyIntelligenceAgency/Z3.Linq` with `upstream=endjin`, pointer `096a638` on `origin/main` (PR #2895).
2. **Port nested int[][]** → done: commit `096a638` ports `ExtractCollection` + `CollectionHandling` from `Z3.LinqBinding@EPFdevelopment@a94ecce` into the modern split architecture. `dotnet build` 0 error, `SudokuGrid` 9x9 solves.
3. **NB-04 rewrite** `Theorem<Grid>`/`Cells[i][j]` + raw→linq pedagogy → done: PR #2913 merged. NB-04 cells 6/9/12 use `Theorem<Grid3/4>` + `g.Cells[r][c]`; cells 14-18 show raw `Microsoft.Z3` (Store/Select) alongside; 3 exercises.

**No remaining fork-port work.** The package-loading prerequisite (build script, #2921) + its README doc (this PR) close the loop. Next authentic Z3 gap, if any, would be *new* fork-dependent notebooks (e.g. a dedicated `CollectionHandling` enum teaching notebook) — flagging for your steering, not acting unilaterally.

See #1206