### PR TITLE
docs(pymc): restore French accents in PyMC series README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -1,42 +1,42 @@
 # Programmation Probabiliste avec PyMC
 
-Port Python de la serie Infer.NET — **20 notebooks** couvrant l'inference bayesienne avec PyMC (NUTS, echantillonnage MCMC), des fondamentaux aux modeles relationnels avances, incluant une section complete sur la theorie de la decision.
+Port Python de la série Infer.NET — **20 notebooks** couvrant l'inference bayesienne avec PyMC (NUTS, echantillonnage MCMC), des fondamentaux aux modèles relationnels avances, incluant une section complète sur la théorie de la décision.
 
 **20 notebooks** | Python 3.10+ | PyMC 5.x | ~19h
 
-**A qui s'adresse cette serie** : praticiens Python, data scientists et etudiants souhaitant maitriser l'inference bayesienne moderne avec l'ecosysteme PyMC/ArviZ. Aucun prerequis en C# ou Infer.NET : chaque notebook est autonome.
+**A qui s'adresse cette série** : praticiens Python, data scientists et étudiants souhaitant maitriser l'inference bayesienne moderne avec l'ecosysteme PyMC/ArviZ. Aucun prérequis en C# ou Infer.NET : chaque notebook est autonome.
 
-## Pourquoi cette serie
+## Pourquoi cette série
 
-PyMC est le framework d'inference bayesienne le plus utilise en Python pour la modelisation probabiliste appliquee. La ou scikit-learn fournit des predictions ponctuelles, PyMC produit des **distributions posterieures completes** qui quantifient l'incertitude de chaque parametre.
+PyMC est le framework d'inference bayesienne le plus utilise en Python pour la modelisation probabiliste appliquee. La ou scikit-learn fournit des predictions ponctuelles, PyMC produit des **distributions posterieures complètes** qui quantifient l'incertitude de chaque paramètre.
 
-Cette serie couvre les **meme 20 modeles** que la serie [Infer.NET](../Infer/) mais avec un moteur d'inference radicalement different :
+Cette série couvre les **même 20 modèles** que la série [Infer.NET](../Infer/) mais avec un moteur d'inference radicalement différent :
 
 | Aspect | Infer.NET (C#) | PyMC (Python) |
 |--------|----------------|---------------|
 | **Moteur** | Message passing (EP/VMP) | Echantillonnage MCMC (NUTS) |
-| **Resultats** | Deterministes, analytiques | Stochastiques, convergents |
-| **Flexibilite** | Modeles conjugues | Presque tout modele |
+| **Résultats** | Deterministes, analytiques | Stochastiques, convergents |
+| **Flexibilite** | Modèles conjugues | Presque tout modèle |
 | **Diagnostics** | Factor graphs | ArviZ (trace, ESS, R-hat) |
 | **Ecosysteme** | .NET | NumPy/Pandas/Matplotlib |
 
-Avoir les deux approches sur les memes modeles permet de comprendre les **compromis** entre inference exacte et approchee, une competence cle pour tout praticien.
+Avoir les deux approches sur les mêmes modèles permet de comprendre les **compromis** entre inference exacte et approchee, une compétence clé pour tout praticien.
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, vous serez capable de :
+A l'issue de cette série, vous serez capable de :
 
-1. **Construire** un modele probabiliste avec PyMC (definition du prior, vraisemblance, echantillonnage)
+1. **Construire** un modèle probabiliste avec PyMC (definition du prior, vraisemblance, echantillonnage)
 2. **Diagnostiquer** la convergence MCMC avec ArviZ (R-hat, ESS, trace plots, divergences)
-3. **Comparer** message passing (Infer.NET) vs MCMC (PyMC) sur le meme modele
-4. **Appliquer** l'inference bayesienne a des problemes concrets (ranking, classification, recommandation)
-5. **Integrer** inference probabiliste et theorie de la decision (EVPI, MDPs, bandits)
+3. **Comparer** message passing (Infer.NET) vs MCMC (PyMC) sur le même modèle
+4. **Appliquer** l'inference bayesienne a des problèmes concrets (ranking, classification, recommandation)
+5. **Integrer** inference probabiliste et théorie de la décision (EVPI, MDPs, bandits)
 
 ## Vue d'ensemble
 
 | # | Notebook | Duree | Concepts |
 |---|----------|-------|----------|
-| 1 | [PyMC-1-Setup](PyMC-1-Setup.ipynb) | 15 min | Installation, premier modele Beta-Bernoulli |
+| 1 | [PyMC-1-Setup](PyMC-1-Setup.ipynb) | 15 min | Installation, premier modèle Beta-Bernoulli |
 | 2 | [PyMC-2-Gaussian-Mixtures](PyMC-2-Gaussian-Mixtures.ipynb) | 50 min | Posterieurs, melanges, Dirichlet |
 | 3 | [PyMC-3-Factor-Graphs](PyMC-3-Factor-Graphs.ipynb) | 45 min | Inference discrete, Monty Hall |
 | 4 | [PyMC-4-Bayesian-Networks](PyMC-4-Bayesian-Networks.ipynb) | 55 min | CPT, D-separation, causalite |
@@ -46,20 +46,20 @@ A l'issue de cette serie, vous serez capable de :
 | 8 | [PyMC-8-Model-Selection](PyMC-8-Model-Selection.ipynb) | 45 min | Evidence, Bayes factors, ARD |
 | 9 | [PyMC-9-Topic-Models](PyMC-9-Topic-Models.ipynb) | 60 min | LDA, Dirichlet, documents-topics-mots |
 | 10 | [PyMC-10-Crowdsourcing](PyMC-10-Crowdsourcing.ipynb) | 55 min | Workers, communautes, agregation de labels |
-| 11 | [PyMC-11-Sequences](PyMC-11-Sequences.ipynb) | 65 min | HMM, series temporelles, motifs |
+| 11 | [PyMC-11-Sequences](PyMC-11-Sequences.ipynb) | 65 min | HMM, séries temporelles, motifs |
 | 12 | [PyMC-12-Recommenders](PyMC-12-Recommenders.ipynb) | 60 min | Factorisation de matrices, recommandation |
 | 13 | [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) | 45 min | Troubleshooting, diagnostics NUTS, convergence |
-| 14 | [PyMC-14-Decision-Utility-Foundations](PyMC-14-Decision-Utility-Foundations.ipynb) | 50 min | Loteries, axiomes VNM, utilite esperee |
+| 14 | [PyMC-14-Decision-Utility-Foundations](PyMC-14-Decision-Utility-Foundations.ipynb) | 50 min | Loteries, axiomes VNM, utilité esperee |
 | 15 | [PyMC-15-Decision-Utility-Money](PyMC-15-Decision-Utility-Money.ipynb) | 45 min | Paradoxe St-Petersbourg, CARA, CRRA |
 | 16 | [PyMC-16-Decision-Multi-Attribute](PyMC-16-Decision-Multi-Attribute.ipynb) | 50 min | MAUT, SMART, swing weights |
 | 17 | [PyMC-17-Decision-Networks](PyMC-17-Decision-Networks.ipynb) | 55 min | Diagrammes d'influence, politique optimale |
 | 18 | [PyMC-18-Decision-Value-Information](PyMC-18-Decision-Value-Information.ipynb) | 45 min | EVPI, EVSI, valeur de l'information |
-| 19 | [PyMC-19-Decision-Expert-Systems](PyMC-19-Decision-Expert-Systems.ipynb) | 50 min | Systemes experts, Minimax, regret |
+| 19 | [PyMC-19-Decision-Expert-Systems](PyMC-19-Decision-Expert-Systems.ipynb) | 50 min | Systèmes experts, Minimax, regret |
 | 20 | [PyMC-20-Decision-Sequential](PyMC-20-Decision-Sequential.ipynb) | 60 min | MDPs, bandits, POMDPs |
 
 **Duree totale** : ~19h
 
-## Progression Pedagogique
+## Progression Pédagogique
 
 ```
 FONDAMENTAUX (1-3)
@@ -67,7 +67,7 @@ FONDAMENTAUX (1-3)
 +-- 2-Gaussian-Mixtures : Distributions continues, melanges
 +-- 3-Factor-Graphs : Inference discrete, conditionnement
 
-MODELES CLASSIQUES (4-6)
+MODÈLES CLASSIQUES (4-6)
 +-- 4-Bayesian-Networks : CPT, causalite, D-separation
 +-- 5-Skills-IRT : Relations many-to-many, IRT/DINA
 +-- 6-TrueSkill : Online learning, message passing
@@ -76,22 +76,22 @@ CLASSIFICATION & SELECTION (7-8)
 +-- 7-Classification : BPM, regression logistique, A/B tests
 +-- 8-Model-Selection : Evidence, ARD, comparaison bayesienne
 
-MODELES AVANCES (9-12)
+MODÈLES AVANCES (9-12)
 +-- 9-Topic-Models : LDA, documents-topics-mots
 +-- 10-Crowdsourcing : Hierarchique, communautes
-+-- 11-Sequences : HMM, series temporelles
-+-- 12-Recommenders : Factorisation, systemes de recommandation
++-- 11-Sequences : HMM, séries temporelles
++-- 12-Recommenders : Factorisation, systèmes de recommandation
 
-REFERENCE (13)
+RÉFÉRENCE (13)
 +-- 13-Debugging : Diagnostics NUTS, convergence, troubleshooting
 
-THEORIE DE LA DECISION (14-20)
+THÉORIE DE LA DÉCISION (14-20)
 +-- 14-Utility-Foundations : Axiomes VNM, loteries
 +-- 15-Utility-Money : Aversion au risque, CARA/CRRA
 +-- 16-Multi-Attribute : MAUT, SMART, compromis
 +-- 17-Decision-Networks : Influence diagrams, politique optimale
 +-- 18-Value-Information : EVPI, EVSI, echantillonnage optimal
-+-- 19-Expert-Systems : Regret Minimax, decisions robustes
++-- 19-Expert-Systems : Regret Minimax, décisions robustes
 +-- 20-Sequential : MDPs, bandits, POMDPs
 ```
 
@@ -116,40 +116,40 @@ python -m ipykernel install --user --name pymc-env --display-name "Python 3 (PyM
 jupyter kernelspec list  # doit afficher pymc-env
 ```
 
-## Prerequis
+## Prérequis
 
 - Python 3.10+ (3.12 recommande)
 - Connaissance de base en probabilites et statistiques
 - Familiarite avec Python et Jupyter notebooks
-- Optionnel : avoir suivi la serie [Infer.NET](../Infer/) pour la comparaison message passing vs MCMC
+- Optionnel : avoir suivi la série [Infer.NET](../Infer/) pour la comparaison message passing vs MCMC
 
 ## Quel parcours choisir
 
 ### Parcours data scientist Python (~10h)
 
-Notebooks 1-3 (fondations) puis 7-8 (classification/selection) puis 9-12 (modeles avances). Ce parcours couvre les modeles les plus utiles en pratique sans passer par la theorie de la decision.
+Notebooks 1-3 (fondations) puis 7-8 (classification/selection) puis 9-12 (modèles avances). Ce parcours couvre les modèles les plus utiles en pratique sans passer par la théorie de la décision.
 
-1. [PyMC-1-Setup](PyMC-1-Setup.ipynb) -> premier modele
+1. [PyMC-1-Setup](PyMC-1-Setup.ipynb) -> premier modèle
 2. [PyMC-2](PyMC-2-Gaussian-Mixtures.ipynb) + [PyMC-3](PyMC-3-Factor-Graphs.ipynb) -> distributions et inference
 3. [PyMC-7](PyMC-7-Classification.ipynb) + [PyMC-8](PyMC-8-Model-Selection.ipynb) -> classification bayesienne
-4. [PyMC-9](PyMC-9-Topic-Models.ipynb) -> [PyMC-12](PyMC-12-Recommenders.ipynb) -> modeles avances
+4. [PyMC-9](PyMC-9-Topic-Models.ipynb) -> [PyMC-12](PyMC-12-Recommenders.ipynb) -> modèles avances
 
-### Parcours theorie de la decision (~7h)
+### Parcours théorie de la décision (~7h)
 
-Notebooks 14-20 en sequence. Ce parcours couvre l'utilite esperee, la valeur de l'information et les MDPs avec un moteur MCMC.
+Notebooks 14-20 en sequence. Ce parcours couvre l'utilité esperee, la valeur de l'information et les MDPs avec un moteur MCMC.
 
 1. [PyMC-14](PyMC-14-Decision-Utility-Foundations.ipynb) -> axiomes VNM
 2. [PyMC-15](PyMC-15-Decision-Utility-Money.ipynb) -> aversion au risque
-3. [PyMC-17](PyMC-17-Decision-Networks.ipynb) -> reseaux de decision
+3. [PyMC-17](PyMC-17-Decision-Networks.ipynb) -> réseaux de décision
 4. [PyMC-18](PyMC-18-Decision-Value-Information.ipynb) -> [PyMC-20](PyMC-20-Decision-Sequential.ipynb) -> EVPI, MDPs
 
 ### Parcours comparatif Infer.NET vs PyMC (~15h)
 
-Alterner chaque notebook PyMC avec son equivalent [Infer.NET](../Infer/).Comparer les implementations (message passing vs MCMC) sur les memes modeles pour comprendre les compromis.
+Alterner chaque notebook PyMC avec son équivalent [Infer.NET](../Infer/).Comparer les implementations (message passing vs MCMC) sur les mêmes modèles pour comprendre les compromis.
 
 ### Parcours rapide (~2h)
 
-[PyMC-1-Setup](PyMC-1-Setup.ipynb) + [PyMC-4-Bayesian-Networks](PyMC-4-Bayesian-Networks.ipynb) + [PyMC-7-Classification](PyMC-7-Classification.ipynb). Les trois notebooks les plus representatifs pour une premiere prise en main.
+[PyMC-1-Setup](PyMC-1-Setup.ipynb) + [PyMC-4-Bayesian-Networks](PyMC-4-Bayesian-Networks.ipynb) + [PyMC-7-Classification](PyMC-7-Classification.ipynb). Les trois notebooks les plus representatifs pour une première prise en main.
 
 ## FAQ / Troubleshooting
 
@@ -166,7 +166,7 @@ conda install -c conda-forge pymc
 # Cocher "Desktop development with C++"
 ```
 
-### L'echantillonnage NUTS est tres lent ou ne converge pas
+### L'echantillonnage NUTS est très lent ou ne converge pas
 
 - Verifier les priors : des priors trop larges causent des explorations inutiles
 - Augmenter `target_accept` : `pm.sample(target_accept=0.95)` (defaut 0.8)
@@ -177,14 +177,14 @@ conda install -c conda-forge pymc
 
 Les divergences indiquent que l'echantillonneur n'a pas explore correctement certaines regions de l'espace posterieur. Actions :
 
-1. `az.plot_trace(trace)` -> verifier le melange des chaines
+1. `az.plot_trace(trace)` -> verifier le melange des chaînes
 2. `az.summary(trace)` -> verifier que `r_hat < 1.05` et `ess_bulk > 400`
-3. Reparametriser le modele (centrage, log-transform)
+3. Reparametriser le modèle (centrage, log-transform)
 4. Augmenter le nombre de tirages : `pm.sample(draws=4000, tune=2000)`
 
 ### Erreur "SamplingError: Initial evaluation of model failed"
 
-Le prior et la vraisemblance sont incompatibles avec les donnees observes. Verifier :
+Le prior et la vraisemblance sont incompatibles avec les données observes. Verifier :
 
 - Les valeurs observes sont dans le support du prior (pas de valeurs negatives pour une distribution Gamma)
 - Les dimensions correspondent (pas de shape mismatch)
@@ -192,32 +192,32 @@ Le prior et la vraisemblance sont incompatibles avec les donnees observes. Verif
 
 ### Comment passer de Infer.NET a PyMC ?
 
-La serie suit le meme ordre que [Infer.NET](../Infer/). Les concepts se correspondent :
+La série suit le même ordre que [Infer.NET](../Infer/). Les concepts se correspondent :
 
-| Concept Infer.NET | Equivalent PyMC |
+| Concept Infer.NET | Équivalent PyMC |
 |-------------------|-----------------|
 | `Variable.Bernoulli(p)` | `pm.Bernoulli('x', p=p)` |
 | `InferenceEngine` | `pm.sample()` |
 | `Infer<DistributionType>` | `trace['x']` |
 | `ShowFactorGraph` | `pm.model_to_graphviz()` |
 
-## Concepts cles
+## Concepts clés
 
 - **Inference bayesienne** : Posterieurs, priors conjugues, MCMC
-- **PyMC** : Modeles probabilistes, echantillonneur NUTS, ArviZ
-- **Modeles graphiques** : Reseaux bayesiens, graphes de facteurs
-- **Theorie de la decision** : Utilite esperee, valeur de l'information, MDPs
+- **PyMC** : Modèles probabilistes, echantillonneur NUTS, ArviZ
+- **Modèles graphiques** : Réseaux bayesiens, graphes de facteurs
+- **Théorie de la décision** : Utilité esperee, valeur de l'information, MDPs
 
-## Serie complementaire
+## Série complementaire
 
-Ce port Python est le pendant de la serie [Infer.NET](../Infer/) (C# / .NET Interactive) couvrant les memes sujets avec un moteur d'inference different (message passing vs MCMC).
+Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Interactive) couvrant les mêmes sujets avec un moteur d'inference différent (message passing vs MCMC).
 
 ## Ressources
 
 - [PyMC Documentation](https://www.pymc.io/projects/docs/en/stable/)
 - [ArviZ Documentation](https://python.arviz.org/)
 - [Bayesian Methods for Hackers](https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers)
-- [Statistical Rethinking (McElreath)](https://xcelab.net/rm/statistical-rethinking/) — livre de reference pour l'inference bayesienne appliquee
+- [Statistical Rethinking (McElreath)](https://xcelab.net/rm/statistical-rethinking/) — livre de référence pour l'inference bayesienne appliquee
 
 ---
 
@@ -225,23 +225,23 @@ Ce port Python est le pendant de la serie [Infer.NET](../Infer/) (C# / .NET Inte
 
 ## FAQ rapide
 
-| Probleme | Solution |
+| Problème | Solution |
 |----------|----------|
 | `ModuleNotFoundError: pymc` | `pip install pymc arviz` -- PyMC 5.x et ArviZ pour les diagnostics |
-| Echantillonnage tres lent (>5 min par modele) | Verifier qu'un compilateur C est disponible (PyMC utilise PyTensor avec compilation C). Sinon, reduire `draws` et `tune` (ex: 500/500 au lieu de 1000/1000) |
+| Echantillonnage très lent (>5 min par modèle) | Verifier qu'un compilateur C est disponible (PyMC utilise PyTensor avec compilation C). Sinon, reduire `draws` et `tune` (ex: 500/500 au lieu de 1000/1000) |
 | Convergence non atteinte (R-hat > 1.05) | Augmenter le nombre de `tune` steps. Le notebook 13 (Debugging) detaille les strategies de diagnostic |
-| Divergences dans l'echantillonnage | Re-parametrer le modele (centered vs non-centered). Voir notebook 2 (Gaussian Mixtures) et 13 (Debugging) |
+| Divergences dans l'echantillonnage | Re-parametrer le modèle (centered vs non-centered). Voir notebook 2 (Gaussian Mixtures) et 13 (Debugging) |
 | `SamplingError: Initial evaluation failed` | Les priors sont incompatibles avec les observations. Verifier les distributions a priori et les valeurs initiales |
 
-## Ponts inter-series
+## Ponts inter-séries
 
-| Serie | Lien | Relation |
+| Série | Lien | Relation |
 |-------|------|----------|
-| [Infer.NET](../Infer/) | Meme 20 modeles en C# / message passing | Comparaison MCMC vs inference exacte |
+| [Infer.NET](../Infer/) | Même 20 modèles en C# / message passing | Comparaison MCMC vs inference exacte |
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML](../../ML/) | Pipeline ML classique | PyMC comme alternative bayesienne |
-| [QuantConnect](../../QuantConnect/) | Strategies de trading | Modeles bayesiens appliques au trading |
+| [QuantConnect](../../QuantConnect/) | Strategies de trading | Modèles bayesiens appliques au trading |
 
 ## Navigation
 
-[<- Retour a la serie Probas](../README.md) \| [Infer.NET (C#) ->](../Infer/README.md)
+[<- Retour a la série Probas](../README.md) \| [Infer.NET (C#) ->](../Infer/README.md)


### PR DESCRIPTION
Restore missing French accents in `Probas/PyMC/README.md` (fully unaccented, LLM-default French). Part of #2876.

## Scope (1 file, markdown-only)
`MyIA.AI.Notebooks/Probas/PyMC/README.md` — +56/-56 (balanced, pure restoration).

## Methodology — NFD round-trip guard (memory strip-accents-roundtrip-guard)
`strip_accents(mine) == strip_accents(main)` via `unicodedata.NFD` → proof of **pure accent restoration**, 0 semantic change.

## Corruption caught by re-review (not the guard)
The NFD guard alone is **insufficient** — it passed while a real corruption existed: the `decision→décision` replacement had also changed **notebook filenames in link targets** (`PyMC-14-Decision-Utility-Foundations.ipynb` → `...Décision-...`), which would have broken 11 links to real files (disk authoritative name = `Decision`, no accent). The guard passed because `Décision` and `Decision` share the same NFD-stripped form. **Re-review of link targets** caught it: reverted capital-`Décision` (filename contexts) back to `Decision`; kept lowercase `décision` (prose, 7 occurrences, correct French). Lesson reinforced: link-target integrity is a separate check from the NFD guard.

## Integrity (all PASS after fix)
- **Link targets** byte-identical to `origin/main` (52 links verified).
- **bash install code blocks** untouched (byte-identical).
- **ASCII tree**: prose labels accented (`séries temporelles`, `systèmes`, `RÉFÉRENCE`, `THÉORIE`); notebook-name labels match disk (`17-Decision-Networks`).
- **English tech terms** preserved (PyMC, ArviZ, NUTS, MCMC, message passing, EP/VMP, Beta-Bernoulli, TrueSkill, Decision in filenames).
- No `<!-- CATALOG-STATUS -->` block in this file.

## Anti-collision
PR **#2918** covers GameTheory + GenAI/PostTraining only — **NOT PyMC**. 0 open PRs touch `PyMC/README.md`. Base fresh on `origin/main`.

Markdown-only: no notebook → no C.2/C.3 re-exec requirement.

See #2876