### PR TITLE
ci(lean): add knot_lean CI dispatcher (See #2874)

### DIFF
--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -1,0 +1,55 @@
+name: Lean Knot CI
+
+# CI for knot_lean (SymbolicAI/Lean/knot_lean).
+# Knot theory formalization (PD-codes, Reidemeister moves, tricolorability,
+# Conway knot, Lidman unknotting number). Epic #2874.
+# Rule lean-merge-discipline: lake build SUCCESS local OBLIGATOIRE avant merge.
+#
+# Follows the "Pattern identique aux projets existants" (conway_lean,
+# social_choice_lean, ...) documented in Epic #2874. knot_lean was the only
+# Lean project without a dispatcher — this closes that gap so future Knots
+# PRs (Phase 5 re-modeling and beyond) are CI-gated like the other 13.
+#
+# Uses the shared lean-build.yml reusable workflow.
+#
+# Sorry profile (verified 2026-06-14, prose-header mode, baseline=25):
+# knot_lean's real sorries are INLINE (`exact sorry`, `:= sorry`,
+# `sorry -- comment`), never bare `sorry` on its own line. The standalone-tactic
+# filter (`^\s*sorry\s*$`) counts 0 here and would catch no regression, so we
+# use prose-header (excludes only "sorries"/"sorry's"), which captures every
+# real sorry and fails on any addition. Breakdown of the 25:
+#   - Basic.lean:                1 (prose: TODO comment on well-formedness)
+#   - Reidemeister.lean:         2 (reidemeister_theorem ×2 — PL topology, OOS)
+#   - Invariant.lean:            4 (tricolorable_invariant, trefoil_not_unknot,
+#                                  unknottingNumber + prose)
+#   - Conway.lean:              11 (Conway knot 11n34, Kinoshita-Terasaka,
+#                                  mutation — scaffolding)
+#   - Lidman.lean:               5 (11n102 unknotting number = 2 — Heegaard-Floer)
+#   - MathlibPrerequisites.lean: 2 (prose: index of missing Mathlib)
+# Raising this baseline requires a documented justification in the PR body.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean
+      display-name: knot_lean
+      sorry-baseline: "25"
+      sorry-filter-mode: prose-header


### PR DESCRIPTION
## Summary

`knot_lean` was the **only Lean project without a CI dispatcher** — the other 13 (`lean-conway.yml`, `lean-social-choice.yml`, `lean-grothendieck.yml`, ...) all have one. Epic #2874 specifies **"Pattern identique aux projets existants"** (`conway_lean/`, `social_choice_lean/`, `conway_cgt_lean/`), so this closes the gap so future Knots PRs (Phase 5 re-modeling #2929 and beyond) are CI-gated like the rest.

Non-collisioning with **#2929** (Phase 5 PR1): this PR touches only `.github/workflows/lean-knot.yml` (new file); #2929 touches `Knots/*.lean`. Independent atomic concerns.

## What it does

New file `.github/workflows/lean-knot.yml` dispatches the shared `lean-build.yml` reusable workflow for `knot_lean`, matching the `lean-conway.yml` template exactly:
- Same `push`/`pull_request` path triggers (`knot_lean/**.lean`, lakefile, toolchain)
- Same `uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main` reusable ref
- `project-path`, `display-name`, `sorry-baseline`, `sorry-filter-mode` inputs

## Sorry profile (verified 2026-06-14)

knot_lean's real sorries are **inline** (`exact sorry`, `:= sorry`, `sorry -- comment`) — never bare `sorry` on its own line. So `standalone-tactic` (which `conway_lean` uses) counts **0** here and would catch no regression. **`prose-header`** (excludes only `sorries`/`sorry's`) captures every real sorry and fails on any addition.

Baseline **25**, stable across #2929 (sorry delta 0 — verified on both `origin/main` and the #2929 branch):

| File | Count | Nature |
|------|-------|--------|
| `Basic.lean` | 1 | prose (TODO comment) |
| `Reidemeister.lean` | 2 | `reidemeister_theorem` (PL topology, OOS) |
| `Invariant.lean` | 4 | `tricolorable_invariant`, `trefoil_not_unknot`, `unknottingNumber` + prose |
| `Conway.lean` | 11 | scaffolding (Conway knot 11n34, Kinoshita-Terasaka, mutation) |
| `Lidman.lean` | 5 | 11n102 unknotting number = 2 (Heegaard-Floer) |
| `MathlibPrerequisites.lean` | 2 | prose (index of missing Mathlib) |

## Verification

- YAML valid (`python -c yaml.safe_load`).
- Project path has `lakefile.lean` + `lean-toolchain`.
- Reusable workflow ref matches `lean-conway.yml` exactly.
- No Lean source touched — `lake build` unaffected.

Note: this dispatcher will run on the NEXT push to any open Knots PR (e.g. #2929 if re-pushed), not retroactively on its current state.

See #2874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)