### PR TITLE
feat(lean): Conway P5 -- toCellsAux_shift offset-shift identity (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -276,6 +276,44 @@ theorem mem_toCellsAux_buildFromGrid (g : Grid) (lvl : Nat) (r0 c0 : Int)
         · left; right; unfold inRegion; refine ⟨⟨?_, ?_, ?_, ?_⟩, hpg⟩ <;> omega
         · right; unfold inRegion; refine ⟨⟨?_, ?_, ?_, ?_⟩, hpg⟩ <;> omega
 
+/-- **Offset-shift identity for `toCellsAux`**: enumerating `c`'s live cells
+    with the top-left corner anchored at `(r0, c0)` equals the
+    origin-anchored enumeration `(c.toCellsAux 0 0)` translated pointwise by
+    `(r0, c0)`. Pure structural induction on `MacroCell` — no Hashlife, no
+    `evolve`, no light-cone. This is the bookkeeping bridge that will align an
+    offset-`(r0, c0)` `toCellsAux` / `toGrid` membership goal with an
+    origin-anchored induction hypothesis in the eventual P4
+    central-correctness assembly (`hashlifeResult_central_correct`). -/
+theorem toCellsAux_shift (c : MacroCell) (r0 c0 : Int) :
+    c.toCellsAux r0 c0 =
+      (c.toCellsAux 0 0).map (fun p => (p.1 + r0, p.2 + c0)) := by
+  induction c generalizing r0 c0 with
+  | leaf b =>
+    -- `toCellsAux r0 c0 (leaf b)` reduces to `[(r0, c0)]` / `[]`, but
+    -- `List.map f [(0, 0)] = [(0 + r0, 0 + c0)]` is NOT defeq to `[(r0, c0)]`
+    -- (`Int.add 0 _` does not reduce definitionally), so `rfl` fails — close
+    -- by `zero_add` instead.
+    cases b
+    · simp only [toCellsAux, List.map_nil]
+    · simp only [toCellsAux, List.map_singleton, zero_add]
+  | node nw ne sw se ihw ine isw ise =>
+    simp only [toCellsAux]
+    -- Apply the IH to each LHS quadrant, anchoring at the origin:
+    rw [ihw r0 c0, ine r0 (c0 + (2 ^ nw.level : Nat)),
+        isw (r0 + (2 ^ nw.level : Nat)) c0,
+        ise (r0 + (2 ^ nw.level : Nat)) (c0 + (2 ^ nw.level : Nat))]
+    -- Distribute the RHS map over the concatenation, then fold the
+    -- origin-anchored quadrants back through the IH (forward) so each RHS
+    -- segment becomes a composition of two shifts; `map_map` flattens it.
+    simp only [List.map_append, zero_add]
+    rw [ine 0 (2 ^ nw.level : Nat), isw (2 ^ nw.level : Nat) 0,
+        ise (2 ^ nw.level : Nat) (2 ^ nw.level : Nat)]
+    simp only [List.map_map, zero_add]
+    -- Both sides are now concatenations of `map (shift_i) (toCellsAux 0 0 sub_i)`,
+    -- differing only by AC rearrangements of addition; normalise and close.
+    simp only [add_zero, add_assoc, add_comm, add_left_comm]
+    rfl
+
 end MacroCell
 
 /-! ## High-level Grid -> MacroCell


### PR DESCRIPTION
## Summary

Adds the **offset-shift identity** for `MacroCell` enumeration to `Conway/Life/MacroCell.lean`:

```lean
theorem toCellsAux_shift (c : MacroCell) (r0 c0 : Int) :
    c.toCellsAux r0 c0 =
      (c.toCellsAux 0 0).map (fun p => (p.1 + r0, p.2 + c0))
```

Pure structural induction on `MacroCell` — **no Hashlife, no `evolve`, no light-cone**. This is the **bookkeeping bridge** that aligns an offset-`(r0, c0)` `toCellsAux` / `toGrid` membership goal with an origin-anchored induction hypothesis. It is the prerequisite infrastructure for the **P4 central-correctness assembly** (`Canonical.ext` + `mem_toCellsAux_buildFromGrid`) that bridges Grid↔MacroCell containment in the Conway P5 (#2162) round-trip.

This is a *stepping stone*, not a sorry-closer: the residual P4/P5 sorries (`HashlifeCorrectness.lean` L945/L1105) remain **RESEARCH-level** (light-cone P2 + double-nine decomposition) and are NOT addressed by this PR. This PR banks the reusable offset-shift lemma that the eventual inductive proof will lean on.

## lean-merge-discipline §B (4 elements)

| # | Element | Result |
|---|---------|--------|
| 1 | `grep -c sorry` diff | **MacroCell 0→0** (robust pattern `^\s*sorry\b`; pure addition, no sorry/axiom added) |
| 2 | `lake build SUCCESS` | ✅ `Conway.Life.MacroCell` genuine recompile, **3317 jobs**, olean deleted first (no cached Replayed) |
| 3 | Axiom check | 0 axiom (pure Lean, structural induction) |
| 4 | Pure Lean / diff coherent | +38 / −0, **1 file**, no catalog drift |

## Downstream regression note (honest)

`Conway.Life.HashlifeCorrectness` does **NOT** build on current `origin/main` — pre-existing `Tactic rfl failed` at **L1058** (`evolveHashlifeFastAux_zero_n`). This is **independent of this PR**: verified via stash test (build on clean main → identical L1058 error). The dashboard's "main FIXED" status (PR #2922) covered `MacroCell.lean` only, not `HashlifeCorrectness`. Flagging for coordinator awareness as a separate fix item.

## Anti-regression D

Pure addition (0 deletions). No existing definition/theorem/proof modified. New theorem name `toCellsAux_shift` verified absent from codebase (grep) before addition — no shadowing.

See #2162