### PR TITLE
docs(lean): knot_lean README — verified Phase 5 state + tricolorability counter-example history (See #2874)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
@@ -3,40 +3,104 @@
 Scaffolding pour la formalisation de résultats de théorie des nœuds en Lean 4,
 avec sorry stratégiques commentés (références papier + prérequis Mathlib).
 
+Epic #2874 (Phase 5 en cours). Toolchain `v4.31.0-rc1`.
+
+## État des sorries (vérifié 2026-06-14)
+
+Deux comptes, selon le filtre :
+
+| Fichier | sorry réels | sorry (prose, CI) |
+|---------|------------|-------------------|
+| `Knots/Basic.lean` | 0 | 1 |
+| `Knots/Reidemeister.lean` | 2 | 2 |
+| `Knots/Invariant.lean` | 3 | 4 |
+| `Knots/Conway.lean` | 8 | 11 |
+| `Knots/Lidman.lean` | 3 | 5 |
+| `Knots/MathlibPrerequisites.lean` | 0 | 2 |
+| **Total** | **16** | **25** |
+
+- **sorry réels** (`exact sorry`, `:= sorry`, `:= by sorry`) = ce qui manque
+  vraiment comme preuve. **16** au total.
+- **sorry prose** (toute ligne contenant `sorry`, filtre CI `prose-header`) =
+  **baseline CI 25** (workflow `lean-knot.yml`). Ce compte inclut les
+  occurrences dans les commentaires de diagnostic (ex. le commentaire sur
+  `KnotDiagram.wf` dans `Basic.lean`).
+
+La CI `.github/workflows/lean-knot.yml` gate sur le **prose-header baseline 25** :
+toute PR qui ajoute un sorry réel fait monter les deux comptes et échoue la CI,
+sauf justification documentée dans le body PR.
+
+## Résultats par statut réel (vérifié contre le code)
+
+### Prouvés (axiomes `[propext, Quot.sound]` seulement, pas `sorryAx`)
+
+- [x] `trefoil_tricolorable` — le trèfle est 3-colorable (`Invariant.lean`)
+- [x] `unknot_not_tricolorable` — l'unknot n'est PAS 3-colorable (`Invariant.lean`)
+- [x] `trefoil_crossing_number` — nombre de croisements du trèfle = 3 (`Invariant.lean`,
+  sous la définition provisionnelle `crossingNumberOfDiagram`)
+- [x] `Reidemeister1.symm` / `Reidemeister2.symm` / `Reidemeister3.symm`,
+  `reidemeister_equiv_symm`, `reidemeister_equiv_equivalence` — symétrie des
+  moves et clôture réflexive-transitive (`Reidemeister.lean`)
+- [x] `tricolorable_invariant_fails_under_pr1_model` — **contre-exemple certifié**
+  réfutant `tricolorable_invariant` sous le modèle PR1 (diagnostic, cf. § Phase 5)
+- [x] `trefoil_wf`, `unknot_wf`, `figureEight_wf` — les 3 diagrammes nommés satisfont la parité PD de `KnotDiagram.wf`
+
+### Scaffolding (sorry, cible formelle)
+
+- [ ] `tricolorable_invariant` — la 3-colorabilité est invariante par Reidemeister
+  (**GATED sur PR1.5**, cf. § Phase 5)
+- [ ] `trefoil_not_unknot` — corollaire : le trèfle n'est pas l'unknot (dépend de
+  `tricolorable_invariant`)
+- [ ] `unknottingNumber` — définition + calcul (nécessite minimisation sur classes
+  d'équivalence, Phase 4+)
+- [ ] Conway (11n34) : `conway_not_smoothly_slice` (Piccirillo 2018/Annals 2020),
+  `conway_topologically_slice` (Freedman 1982), mutation Kinoshita-Terasaka —
+  8 sorry, scaffolding permanent
+- [ ] Lidman 11n102 : unknotting number = 2 (Heegaard-Floer) — 3 sorry, scaffolding
+- [ ] `reidemeister_theorem` — équivalence Reidemeister ↔ isotopie ambiante
+  (topologie PL des 3-variétés, hors portée Mathlib actuel) — 2 sorry, permanent
+
+## Phase 5 — Re-modélisation des mouvements de Reidemeister
+
+**Marquee theorem** : `tricolorable_invariant` (la 3-colorabilité est un invariant).
+Résiste depuis plusieurs cycles. La leçon clé (pattern « intractable = énoncé
+faux », cf. conway P4 / `feedback-lean-false-statement-counterexample`) : avant
+de prouver, vérifier que l'énoncé est *vrai* sous le modèle courant.
+
+**Historique (certifié, par contre-exemples prouvés) :**
+
+1. **Modèle Phase 3** (symétrique existentiel `∃ c, surgery`) — réfuté par
+   `tricolorable_invariant_fails_under_current_model` (#2915) : témoin malformé
+   `⟨7,8,9,10⟩` (labels hors `[1, numEdges]`).
+2. **PR1 (#2929)** — re-modélisation : `KnotDiagram.wf` (parité PD, Bool) sur les
+   deux diagrammes + renommage d'edges `ρ : Fin(min) ↪ Fin(max)` swap-invariant.
+   Exclut le témoin malformé. **MAIS** réfuté à nouveau par
+   `tricolorable_invariant_fails_under_pr1_model` (#2938) : `wf` force le twist R1
+   à n'utiliser que les 2 edges fraîches, et `ρ` est une injection libre non liée
+   aux labels du nouveau crossing `c` → le twist peut CRÉER la 3-colorabilité
+   ex nihilo (témoin `d₁={[⟨1,2,1,2⟩],2}` non-tricolorable ↔
+   `d₂={[⟨1,2,1,2⟩,⟨3,4,3,4⟩],4}` tricolorable, connectés par un twist R1).
+
+**PR1.5 (prochain, cible).** Renforcer les constructeurs de move pour que `ρ`
+*DÉTERMINE* les labels de `c` — un vrai curl R1 sur l'arc `a` attache le nouveau
+crossing à l'arc existant `a` (pas seulement aux edges fraîches), dont la
+condition Fox lie les nouveaux edges à `color a`. C'est ce qui rend le lemme de
+transfert (PR2) prouvable. La géométrie PD-code du curl (relabelling/split de
+l'arc sous la parité `wf`) nécessite un soin justifié (conventions Adams "The
+Knot Book" / shua/leanknot) — non trivial, cible multi-cycle.
+
+Référence : Fox (1962), A quick trip through knot theory ; Adams, *The Knot Book*.
+
 ## Structure
 
-| Fichier | Contenu | sorry | Phase |
-|---------|---------|-------|-------|
-| `Knots/Basic.lean` | Définitions (Knot, Link, PD-code, nœuds nommés) | 3 | 1 |
-| `Knots/Reidemeister.lean` | Mouvements de Reidemeister R1/R2/R3, équivalence | 8 | 1 |
-| `Knots/Invariant.lean` | 3-colorabilité, crossing number, unknotting number | 7 | 1–2 |
-| `Knots/Conway.lean` | Nœud de Conway (11n34), Piccirillo, dichotomie lisse/topologique | 10 | 1 (permanent) |
-| `Knots/Lidman.lean` | 11n102, unknotting number = 2 | 3 | 1 (permanent) |
-| `Knots/MathlibPrerequisites.lean` | Index des prérequis Mathlib manquants par tier | 0 | 1 |
-
-**Total sorry : ~31** (dont ~15 permanents = résultats hors de portée de Mathlib actuel)
-
-## Résultats principaux (scaffolding)
-
-### Phase 2 — Accessible (sorry → 0 possible)
-
-- [ ] Le trèfle est 3-colorable
-- [ ] L'unknot n'est PAS 3-colorable
-- [ ] La 3-colorabilité est invariante par Reidemeister
-- [ ] Corollaire : le trèfle n'est pas l'unknot
-
-### Phase 3–4 — Modéré
-
-- [ ] Nombre de croisements du trèfle = 3
-- [ ] Polynôme d'Alexander trivial pour Conway et K-T
-- [ ] Polynôme de Jones
-
-### Phase 5+ — Permanent (décennies)
-
-- [x] `conway_not_smoothly_slice` — Piccirillo (2018), Annals 2020
-- [x] `conway_topologically_slice` — Freedman (1982)
-- [x] `unknotting_11n102` — Lidman (2026), arXiv:2606.12431
-- [x] `reidemeister_theorem` — Reidemeister (1927)
+| Fichier | Contenu | sorry réels |
+|---------|---------|-------------|
+| `Knots/Basic.lean` | Définitions (Knot, Link, PD-code, nœuds nommés), `KnotDiagram.wf` | 0 |
+| `Knots/Reidemeister.lean` | Mouvements R1/R2/R3 (modèle Phase 5), `ReidemeisterEquiv`, symétries | 2 |
+| `Knots/Invariant.lean` | 3-colorabilité (Fox), crossing number, unknotting number, contre-exemple PR1 | 3 |
+| `Knots/Conway.lean` | Nœud de Conway (11n34), Piccirillo, dichotomie lisse/topologique | 8 |
+| `Knots/Lidman.lean` | 11n102, unknotting number = 2 | 3 |
+| `Knots/MathlibPrerequisites.lean` | Index des prérequis Mathlib manquants par tier | 0 |
 
 ## Dépendances externes
 
@@ -61,16 +125,19 @@ avec sorry stratégiques commentés (références papier + prérequis Mathlib).
 - **Lidman (2026)** : *The unknotting number of 11n102 is 2*. [arXiv:2606.12431](https://arxiv.org/abs/2606.12431)
 - **Reidemeister (1927)** : Elementare Begründung der Knotentheorie
 - **Fox (1962)** : A quick trip through knot theory
+- **Adams** : *The Knot Book* (conventions PD-code pour les curls R1)
 - **Conway (1970)** : An enumeration of knots and links
 - **Freedman (1982)** : The topology of four-dimensional manifolds, J. Differential Geom.
+- **Doll & Hoste (1991)** : A tabulation of oriented links (parité PD-code)
 - **Prathamesh (2015)** : *Formalising Knot Theory in Isabelle/HOL*, LNCS 9250
 - **Lean AI Leaderboard** : [Conway knot not smoothly slice](https://lean-lang.org/eval/problems/conway_knot_not_smoothly_slice/)
 
 ## Voir aussi
 
-- **Epic #2874** — Cette Epic
+- **Epic #2874** — Cette Epic (Phase 5)
 - **#1647** Conway Phase 2 (jeux combinatoires, GoL)
 - **#1646** Grothendieck Phase 1
 - **`conway_cgt_lean/`** — Tour des résultats `vihdzp/combinatorial-games`
 - **`social_choice_lean/`** — Pattern scaffolding avec sorry résolus (Arrow, Sen)
-- **`conway_lean/`** — Jeu de Conway en Lean
+- **`conway_lean/`** — Jeu de Conway en Lean (cf. `MacroCell.wf`, pattern de la
+  ré-modélisation Phase 5 `KnotDiagram.wf`)


### PR DESCRIPTION
## Summary

The `knot_lean/README.md` was **factually stale and actively misleading**, claiming sorries that are proven and totals that don't match the CI baseline. This PR rewrites it to verified Phase 5 state.

### What was wrong (verified against the code)

| Claim in old README | Reality |
|---|---|
| "Total sorry ~31" | **16 real / 25 prose-header** (CI baseline) |
| `Basic.lean` = 3 sorry | **0 real** |
| `Reidemeister.lean` = 8 sorry | **2 real** (`reidemeister_theorem` ×2, PL topology) |
| `Invariant.lean` = 7 sorry | **3 real** |
| `[x] reidemeister_theorem` (proven) | **still `sorry`** — false claim of proven |
| `[x] conway_not_smoothly_slice` | **still `sorry`** — false claim |
| `[x] conway_topologically_slice` | **still `sorry`** — false claim |
| `[x] unknotting_11n102` | **still `sorry`** — false claim |

A README that marks a `sorry`'d theorem as `[x]` proven misleads reviewers, indexers, and the Lean AI Leaderboard mapping.

### What the rewrite adds

- **Two-count sorry table** (real 16 / prose 25) — matches `lean-knot.yml` prose-header baseline 25 exactly, so a reviewer can cross-check at a glance.
- **Results split by REAL status**: proven (axioms `[propext, Quot.sound]` only, no `sorryAx`) vs scaffolding (sorry, target). The 4 false `[x]` removed; genuinely-proven theorems (`trefoil_tricolorable`, `unknot_not_tricolorable`, `trefoil_crossing_number`, the `*.symm` lemmas, `tricolorable_invariant_fails_under_pr1_model`) correctly marked.
- **New "Phase 5" section** documenting the move re-modeling history by certified counter-example:
  - Phase 3 model refuted (#2915) — malformed witness `⟨7,8,9,10⟩`.
  - PR1 `wf`-model refuted again (#2938) — `ρ` free injection, twist creates tricolorability ex nihilo.
  - **PR1.5 next step**: `ρ`-determined R1 curl constructors (new crossing tied to existing arc `a`, Fox condition ties new edges to `color a`) — the prerequisite for the transfer lemma PR2.
- Toolchain `v4.31.0-rc1`, Doll & Hoste (1991) + Adams (*The Knot Book*) references added for the PD parity / R1-curl geometry.

## Scope

| File | Change |
|------|--------|
| `knot_lean/README.md` | +101/-34 (rewrite of the status table + results checklist + new Phase 5 section) |

`Knots/*.lean`, `lakefile`, `lean-toolchain`, catalog — **untouched**.

## Verification

- **Catalog byte-identical to `origin/main`** (`git diff origin/main --stat -- COURSE_CATALOG.generated.*` = empty) — catalog-pr-hygiene: doc-only PR, no regen on feature branch.
- **Fresh base**: `git rev-list --count HEAD..origin/main` = 0.
- **No `.lean` change** → no lake build / sorry-delta applicable (docs-only).
- Sorry counts in the new table re-verified by `grep -cE '^\s*(exact )?sorry|:=\s*by\s+sorry|:=\s*sorry'` per file (real=16) and `grep -cE 'sorry'` (prose=25) = CI baseline.

See #2874 (epic — not closed; this is doc hygiene while PR #2938 awaits review and PR1.5 is the next formal step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)