### PR TITLE
fix(lean): Conway evolveHashlifeFastAux_zero_n rfl fails — UNBLOCKS P5 lane (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1055,7 +1055,12 @@ call path when `n > 0` — remains open and is documented in `hashlife_correct`.
     fuel-invariant behaviour of `evolveHashlifeFast`. -/
 theorem evolveHashlifeFastAux_zero_n (fuel : Nat) (g : Grid) :
     evolveHashlifeFastAux fuel 0 g = g := by
-  rfl
+  -- The `n = 0` pattern (`| _, 0, g => g`) is the FIRST arm of
+  -- `evolveHashlifeFastAux`, so it fires regardless of `fuel`. But `rfl`
+  -- fails with `fuel` a free variable: the pattern-matcher inspects `fuel`
+  -- first and blocks on the unknown constructor. Splitting on `fuel`
+  -- (`0` or `succ`) lets the first arm reduce definitionally in each case.
+  cases fuel <;> rfl
 
 /-! ## P5. Main theorem: bounded correctness
 


### PR DESCRIPTION
## Summary

**Fixes the sole compile error of `Conway.Life.HashlifeCorrectness` on `origin/main`**, unblocking the entire Conway P5 lane.

The proof of `evolveHashlifeFastAux_zero_n` (HashlifeCorrectness.lean:1056) used `:= by rfl`, which fails: `evolveHashlifeFastAux` (Hashlife.lean:326) pattern-matches on its **first** argument (`fuel`) before its second (`n`). With `fuel` a free variable, the function does not reduce definitionally, so `rfl` is stuck.

```lean
theorem evolveHashlifeFastAux_zero_n (fuel : Nat) (g : Grid) :
    evolveHashlifeFastAux fuel 0 g = g := by
  cases fuel <;> rfl   -- was: rfl
```

**Why `cases fuel <;> rfl` works:** the first arm of `evolveHashlifeFastAux` is `| _, 0, g => g` (n=0 returns `g` regardless of `fuel`). With `fuel` concrete (`0` or `succ`), this arm reduces definitionally in each case.

## Impact — unblocks the lane

`Conway.Life.HashlifeCorrectness` was **non-compiling on origin/main** (verified genuine: `.olean` deleted first, cold recompile). This blocked:
- Any work on the P4/P5 sorries (they live in this file).
- The downstream `Canonical.ext` + `mem_toCellsAux_buildFromGrid` assembly (#2162 round-trip).
- Measuring the sorry baseline via build.

The non-compile was likely masked by a **stale cached `.olean`** in earlier \"Build completed (3319)\" reports (cycle 16 / PR #2922 body) — the exact trap `lean-merge-discipline` §B warns against: *\"lake build SUCCESS Xs in the PR body is NOT sufficient, trust but verify with olean deleted.\"*

## Diagnostic honesty (G.1)

The first investigation (cycle 17) reported \"5 error zones\" — that was **incorrect**: it captured warning lines (L397-409 / L585 unused-simp-args, L931/L1100 `declaration uses sorry`) alongside the single real error. **L1058 is the only actual error.** Corrected by grepping `^error:` specifically (count = 1) rather than all `file:line:col` flags.

## lean-merge-discipline §B

| # | Element | Result |
|---|---------|--------|
| 1 | `grep -c sorry` diff | **HashlifeCorrectness 1→1** (P4/P5 stubs unchanged, robust pattern `^\s*sorry\b`) |
| 2 | `lake build SUCCESS` | ✅ `Conway.Life.HashlifeCorrectness` genuine recompile, **3320 jobs**, olean deleted first |
| 3 | Axiom check | 0 axiom (pure structural case-split) |
| 4 | Pure Lean / diff coherent | **+6/−1**, 1 file, only L1058 proof tactic changed |

## Anti-regression D

No `sorry` added. No definition/theorem statement modified — only the proof tactic of an existing theorem (same statement, same semantics, just now compiles). The fix is the standard remedy for this pattern-matching-ordering defeq issue.

## Priority request

**Please merge promptly** (`gh auth switch -u jsboige`): this unblocks the whole Conway P5 lane (#2162), not just one theorem. Once merged, the next cycle can resume the `Canonical.ext` assembly on a compiling base.

See #2162