### PR TITLE
refactor(argument-analysis): -0-init consumes argumentation_lib shim (Phase 2 #2137)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
@@ -1,14 +1,42 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "34e4559f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T03:39:05.780246Z",
+     "iopub.status.busy": "2026-06-14T03:39:05.777867Z",
+     "iopub.status.idle": "2026-06-14T03:39:05.812232Z",
+     "shell.execute_reply": "2026-06-14T03:39:05.805605Z"
+    },
+    "papermill": {
+     "duration": 0.176701,
+     "end_time": "2026-06-14T03:39:05.815169+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T03:39:05.638468+00:00",
+     "status": "completed"
+    },
+    "tags": [
+     "injected-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "BATCH_MODE = \"true\"\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "6196daf0",
    "metadata": {
     "papermill": {
-     "duration": 0.037092,
-     "end_time": "2026-05-31T19:06:45.983155+00:00",
+     "duration": 0.076469,
+     "end_time": "2026-06-14T03:39:05.921912+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:06:45.946063+00:00",
+     "start_time": "2026-06-14T03:39:05.845443+00:00",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +70,10 @@
    "id": "80571e1e",
    "metadata": {
     "papermill": {
-     "duration": 0.005635,
-     "end_time": "2026-05-31T19:06:46.002547+00:00",
+     "duration": 0.019945,
+     "end_time": "2026-06-14T03:39:05.990709+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:06:45.996912+00:00",
+     "start_time": "2026-06-14T03:39:05.970764+00:00",
      "status": "completed"
     },
     "tags": []
@@ -62,20 +90,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "a3661e07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:06:46.018556Z",
-     "iopub.status.busy": "2026-05-31T19:06:46.018207Z",
-     "iopub.status.idle": "2026-05-31T19:06:49.924562Z",
-     "shell.execute_reply": "2026-05-31T19:06:49.915963Z"
+     "iopub.execute_input": "2026-06-14T03:39:06.063995Z",
+     "iopub.status.busy": "2026-06-14T03:39:06.062432Z",
+     "iopub.status.idle": "2026-06-14T03:39:18.191398Z",
+     "shell.execute_reply": "2026-06-14T03:39:18.189931Z"
     },
     "papermill": {
-     "duration": 3.923832,
-     "end_time": "2026-05-31T19:06:49.931622+00:00",
+     "duration": 12.173566,
+     "end_time": "2026-06-14T03:39:18.192661+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:06:46.007790+00:00",
+     "start_time": "2026-06-14T03:39:06.019095+00:00",
      "status": "completed"
     },
     "tags": []
@@ -148,10 +176,10 @@
    "id": "pmpm31xh56",
    "metadata": {
     "papermill": {
-     "duration": 0.02229,
-     "end_time": "2026-05-31T19:06:49.990096+00:00",
+     "duration": 0.029739,
+     "end_time": "2026-06-14T03:39:18.240430+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:06:49.967806+00:00",
+     "start_time": "2026-06-14T03:39:18.210691+00:00",
      "status": "completed"
     },
     "tags": []
@@ -170,20 +198,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "dd1eb173",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:06:50.040231Z",
-     "iopub.status.busy": "2026-05-31T19:06:50.039893Z",
-     "iopub.status.idle": "2026-05-31T19:07:46.898334Z",
-     "shell.execute_reply": "2026-05-31T19:07:46.896028Z"
+     "iopub.execute_input": "2026-06-14T03:39:18.277614Z",
+     "iopub.status.busy": "2026-06-14T03:39:18.277020Z",
+     "iopub.status.idle": "2026-06-14T03:39:49.465193Z",
+     "shell.execute_reply": "2026-06-14T03:39:49.463127Z"
     },
     "papermill": {
-     "duration": 56.890288,
-     "end_time": "2026-05-31T19:07:46.898965+00:00",
+     "duration": 31.205103,
+     "end_time": "2026-06-14T03:39:49.466789+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:06:50.008677+00:00",
+     "start_time": "2026-06-14T03:39:18.261686+00:00",
      "status": "completed"
     },
     "tags": []
@@ -194,70 +222,67 @@
      "output_type": "stream",
      "text": [
       "ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "agent-framework-devui 1.0.0b260507 requires fastapi<0.133.1,>=0.115.0, which is not installed.\n",
+      "mem0ai 1.0.11 requires qdrant-client>=1.9.1, which is not installed.\n",
+      "pyknotid 0.5.3 requires appdirs, which is not installed.\n",
+      "pyknotid 0.5.3 requires planarity, which is not installed.\n",
+      "pyknotid 0.5.3 requires vispy, which is not installed.\n",
       "litellm 1.83.14 requires openai==2.24.0, but you have openai 2.38.0 which is incompatible.\n",
       "litellm 1.83.14 requires pydantic==2.12.5, but you have pydantic 2.13.4 which is incompatible.\n",
-      "agent-framework-foundry 1.3.0 requires azure-ai-projects<3.0,>=2.1.0, but you have azure-ai-projects 1.0.0 which is incompatible.\n",
+      "agent-framework-devui 1.0.0b260507 requires uvicorn[standard]<0.42.0,>=0.30.0, but you have uvicorn 0.49.0 which is incompatible.\n",
       "datasets 4.8.5 requires fsspec[http]<=2026.2.0,>=2023.1.0, but you have fsspec 2026.3.0 which is incompatible.\n",
-      "21:07:45 [INFO] [Orchestration.Setup] --- Vérification des dépendances ---\n"
+      "05:39:47 [INFO] [Orchestration.Setup] --- Vérification des dépendances ---\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:45 [INFO] [Orchestration.Setup] ✔️ Dépendance 'jpype' trouvée.\n"
+      "05:39:47 [INFO] [Orchestration.Setup] ✔️ Dépendance 'jpype' trouvée.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:45 [INFO] [Orchestration.Setup] ✔️ Dépendance 'semantic_kernel' trouvée.\n"
+      "05:39:47 [INFO] [Orchestration.Setup] ✔️ Dépendance 'semantic_kernel' trouvée.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:45 [INFO] [Orchestration.Setup] ✔️ Dépendance 'dotenv' trouvée.\n"
+      "05:39:47 [INFO] [Orchestration.Setup] ✔️ Dépendance 'dotenv' trouvée.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: semantic-kernel in C:\\ProgramData\\miniconda3\\Lib\\site-packages (1.22.1)\n",
+      "Requirement already satisfied: semantic-kernel in C:\\ProgramData\\miniconda3\\Lib\\site-packages (1.42.0)\n",
       "Collecting semantic-kernel\n",
-      "  Downloading semantic_kernel-1.42.0-py3-none-any.whl.metadata (14 kB)\n",
+      "  Downloading semantic_kernel-1.43.0-py3-none-any.whl.metadata (14 kB)\n",
       "Requirement already satisfied: python-dotenv in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (1.2.2)\n",
-      "Requirement already satisfied: ipywidgets in C:\\ProgramData\\miniconda3\\Lib\\site-packages (8.1.5)\n",
-      "Collecting ipywidgets\n",
-      "  Using cached ipywidgets-8.1.8-py3-none-any.whl.metadata (2.4 kB)\n",
+      "Requirement already satisfied: ipywidgets in C:\\ProgramData\\miniconda3\\Lib\\site-packages (8.1.8)\n",
       "Requirement already satisfied: jpype1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (1.7.1)\n",
-      "Requirement already satisfied: requests in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (2.33.1)\n",
-      "Collecting requests\n",
-      "  Downloading requests-2.34.2-py3-none-any.whl.metadata (4.8 kB)\n",
+      "Requirement already satisfied: requests in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (2.34.2)\n",
       "Requirement already satisfied: tqdm in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (4.67.3)\n",
-      "Requirement already satisfied: pandas in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (3.0.2)\n",
-      "Collecting pandas\n",
-      "  Downloading pandas-3.0.3-cp313-cp313-win_amd64.whl.metadata (19 kB)\n",
-      "Collecting azure-ai-projects~=1.0.0b12 (from semantic-kernel)\n",
-      "  Using cached azure_ai_projects-1.0.0-py3-none-any.whl.metadata (21 kB)\n",
-      "Collecting azure-ai-agents>=1.2.0b3 (from semantic-kernel)\n",
-      "  Using cached azure_ai_agents-1.2.0b6-py3-none-any.whl.metadata (74 kB)\n",
+      "Collecting tqdm\n",
+      "  Downloading tqdm-4.68.2-py3-none-any.whl.metadata (58 kB)\n",
+      "Requirement already satisfied: pandas in C:\\ProgramData\\miniconda3\\Lib\\site-packages (3.0.3)\n",
+      "Requirement already satisfied: azure-ai-projects~=1.0.0b12 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (1.0.0)\n",
+      "Requirement already satisfied: azure-ai-agents>=1.2.0b3 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (1.2.0b6)\n",
       "Requirement already satisfied: aiohttp~=3.8 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (3.13.4)\n",
       "Requirement already satisfied: cloudevents~=1.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (1.12.1)\n",
       "Requirement already satisfied: pydantic!=2.10.0,!=2.10.1,!=2.10.2,!=2.10.3,<2.14,>=2.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (2.13.4)\n",
-      "Requirement already satisfied: pydantic-settings~=2.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (2.12.0)\n",
-      "Requirement already satisfied: defusedxml~=0.7 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (0.7.1)\n",
+      "Requirement already satisfied: pydantic-settings~=2.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (2.14.1)\n",
+      "Requirement already satisfied: defusedxml~=0.7 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (0.7.1)\n",
       "Requirement already satisfied: azure-identity>=1.13 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (1.25.3)\n",
       "Requirement already satisfied: numpy>=1.26.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (2.4.4)\n",
       "Requirement already satisfied: openai>=2.0.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (2.38.0)\n",
       "Requirement already satisfied: openapi_core<0.20,>=0.18 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (0.19.5)\n",
-      "Collecting websockets<16,>=13 (from semantic-kernel)\n",
-      "  Using cached websockets-15.0.1-cp313-cp313-win_amd64.whl.metadata (7.0 kB)\n",
-      "Collecting aiortc>=1.9.0 (from semantic-kernel)\n",
-      "  Using cached aiortc-1.14.0-py3-none-any.whl.metadata (4.9 kB)\n",
+      "Requirement already satisfied: websockets<16,>=13 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (15.0.1)\n",
+      "Requirement already satisfied: aiortc>=1.9.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (1.14.0)\n",
       "Requirement already satisfied: opentelemetry-api~=1.24 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (1.41.1)\n",
       "Requirement already satisfied: opentelemetry-sdk~=1.24 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (1.41.1)\n",
       "Requirement already satisfied: prance<25.4.9,>=23.6.21 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (23.6.21.0)\n",
@@ -266,7 +291,7 @@
       "Requirement already satisfied: nest-asyncio~=1.6 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (1.6.0)\n",
       "Requirement already satisfied: scipy>=1.15.1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (1.17.1)\n",
       "Requirement already satisfied: typing-extensions>=4.13 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (4.15.0)\n",
-      "Requirement already satisfied: mcp>=1.26.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from semantic-kernel) (1.27.0)\n",
+      "Requirement already satisfied: mcp>=1.26.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from semantic-kernel) (1.27.2)\n",
       "Requirement already satisfied: aiohappyeyeballs>=2.5.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from aiohttp~=3.8->semantic-kernel) (2.6.1)\n",
       "Requirement already satisfied: aiosignal>=1.4.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from aiohttp~=3.8->semantic-kernel) (1.4.0)\n",
       "Requirement already satisfied: attrs>=17.3.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from aiohttp~=3.8->semantic-kernel) (26.1.0)\n",
@@ -276,8 +301,7 @@
       "Requirement already satisfied: yarl<2.0,>=1.17.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from aiohttp~=3.8->semantic-kernel) (1.23.0)\n",
       "Requirement already satisfied: isodate>=0.6.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from azure-ai-projects~=1.0.0b12->semantic-kernel) (0.7.2)\n",
       "Requirement already satisfied: azure-core>=1.30.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from azure-ai-projects~=1.0.0b12->semantic-kernel) (1.41.0)\n",
-      "Collecting azure-storage-blob>=12.15.0 (from azure-ai-projects~=1.0.0b12->semantic-kernel)\n",
-      "  Downloading azure_storage_blob-12.29.0-py3-none-any.whl.metadata (26 kB)\n",
+      "Requirement already satisfied: azure-storage-blob>=12.15.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from azure-ai-projects~=1.0.0b12->semantic-kernel) (12.29.0)\n",
       "Requirement already satisfied: deprecation<3.0,>=2.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from cloudevents~=1.0->semantic-kernel) (2.1.0)\n",
       "Requirement already satisfied: packaging in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from deprecation<3.0,>=2.0->cloudevents~=1.0->semantic-kernel) (26.0)\n",
       "Requirement already satisfied: MarkupSafe>=2.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from jinja2~=3.1->semantic-kernel) (3.0.3)\n",
@@ -319,22 +343,15 @@
       "Requirement already satisfied: colorama in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from tqdm) (0.4.6)\n",
       "Requirement already satisfied: python-dateutil>=2.8.2 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2.9.0.post0)\n",
       "Requirement already satisfied: tzdata in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2025.3)\n",
-      "Collecting aioice<1.0.0,>=0.10.1 (from aiortc>=1.9.0->semantic-kernel)\n",
-      "  Using cached aioice-0.10.2-py3-none-any.whl.metadata (4.1 kB)\n",
-      "Collecting av<17.0.0,>=14.0.0 (from aiortc>=1.9.0->semantic-kernel)\n",
-      "  Using cached av-16.1.0-cp313-cp313-win_amd64.whl.metadata (4.7 kB)\n",
+      "Requirement already satisfied: aioice<1.0.0,>=0.10.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from aiortc>=1.9.0->semantic-kernel) (0.10.2)\n",
+      "Requirement already satisfied: av<17.0.0,>=14.0.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from aiortc>=1.9.0->semantic-kernel) (16.1.0)\n",
       "Requirement already satisfied: cryptography>=44.0.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from aiortc>=1.9.0->semantic-kernel) (48.0.0)\n",
       "Requirement already satisfied: google-crc32c>=1.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from aiortc>=1.9.0->semantic-kernel) (1.8.0)\n",
-      "Collecting pyee>=13.0.0 (from aiortc>=1.9.0->semantic-kernel)\n",
-      "  Using cached pyee-13.0.1-py3-none-any.whl.metadata (3.0 kB)\n",
-      "Collecting pylibsrtp>=0.10.0 (from aiortc>=1.9.0->semantic-kernel)\n",
-      "  Using cached pylibsrtp-1.0.0-cp310-abi3-win_amd64.whl.metadata (4.2 kB)\n",
-      "Collecting pyopenssl>=25.0.0 (from aiortc>=1.9.0->semantic-kernel)\n",
-      "  Downloading pyopenssl-26.2.0-py3-none-any.whl.metadata (19 kB)\n",
-      "Collecting dnspython>=2.0.0 (from aioice<1.0.0,>=0.10.1->aiortc>=1.9.0->semantic-kernel)\n",
-      "  Using cached dnspython-2.8.0-py3-none-any.whl.metadata (5.7 kB)\n",
-      "Collecting ifaddr>=0.2.0 (from aioice<1.0.0,>=0.10.1->aiortc>=1.9.0->semantic-kernel)\n",
-      "  Using cached ifaddr-0.2.0-py3-none-any.whl.metadata (4.9 kB)\n",
+      "Requirement already satisfied: pyee>=13.0.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from aiortc>=1.9.0->semantic-kernel) (13.0.1)\n",
+      "Requirement already satisfied: pylibsrtp>=0.10.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from aiortc>=1.9.0->semantic-kernel) (1.0.0)\n",
+      "Requirement already satisfied: pyopenssl>=25.0.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from aiortc>=1.9.0->semantic-kernel) (26.2.0)\n",
+      "Requirement already satisfied: dnspython>=2.0.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from aioice<1.0.0,>=0.10.1->aiortc>=1.9.0->semantic-kernel) (2.8.0)\n",
+      "Requirement already satisfied: ifaddr>=0.2.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from aioice<1.0.0,>=0.10.1->aiortc>=1.9.0->semantic-kernel) (0.2.0)\n",
       "Requirement already satisfied: msal>=1.35.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from azure-identity>=1.13->semantic-kernel) (1.36.0)\n",
       "Requirement already satisfied: msal-extensions>=1.2.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from azure-identity>=1.13->semantic-kernel) (1.3.1)\n",
       "Requirement already satisfied: cffi>=2.0.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from cryptography>=44.0.0->aiortc>=1.9.0->semantic-kernel) (2.0.0)\n",
@@ -350,16 +367,16 @@
       "Requirement already satisfied: wcwidth in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets) (0.7.0)\n",
       "Requirement already satisfied: parso<0.9.0,>=0.8.6 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from jedi>=0.18.2->ipython>=6.1.0->ipywidgets) (0.8.7)\n",
       "Requirement already satisfied: anyio>=4.5 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from mcp>=1.26.0->semantic-kernel) (4.13.0)\n",
-      "Requirement already satisfied: httpx-sse>=0.4 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from mcp>=1.26.0->semantic-kernel) (0.4.3)\n",
-      "Requirement already satisfied: httpx>=0.27.1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from mcp>=1.26.0->semantic-kernel) (0.28.1)\n",
-      "Requirement already satisfied: pyjwt>=2.10.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyjwt[crypto]>=2.10.1->mcp>=1.26.0->semantic-kernel) (2.10.1)\n",
-      "Requirement already satisfied: python-multipart>=0.0.9 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from mcp>=1.26.0->semantic-kernel) (0.0.27)\n",
+      "Requirement already satisfied: httpx-sse>=0.4 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from mcp>=1.26.0->semantic-kernel) (0.4.3)\n",
+      "Requirement already satisfied: httpx<1.0.0,>=0.27.1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from mcp>=1.26.0->semantic-kernel) (0.28.1)\n",
+      "Requirement already satisfied: pyjwt>=2.10.1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pyjwt[crypto]>=2.10.1->mcp>=1.26.0->semantic-kernel) (2.13.0)\n",
+      "Requirement already satisfied: python-multipart>=0.0.9 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from mcp>=1.26.0->semantic-kernel) (0.0.32)\n",
       "Requirement already satisfied: pywin32>=310 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from mcp>=1.26.0->semantic-kernel) (311)\n",
-      "Requirement already satisfied: sse-starlette>=1.6.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from mcp>=1.26.0->semantic-kernel) (3.4.1)\n",
-      "Requirement already satisfied: starlette>=0.27 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from mcp>=1.26.0->semantic-kernel) (0.50.0)\n",
-      "Requirement already satisfied: uvicorn>=0.31.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from mcp>=1.26.0->semantic-kernel) (0.41.0)\n",
-      "Requirement already satisfied: httpcore==1.* in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from httpx>=0.27.1->mcp>=1.26.0->semantic-kernel) (1.0.9)\n",
-      "Requirement already satisfied: h11>=0.16 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from httpcore==1.*->httpx>=0.27.1->mcp>=1.26.0->semantic-kernel) (0.16.0)\n",
+      "Requirement already satisfied: sse-starlette>=1.6.1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from mcp>=1.26.0->semantic-kernel) (3.4.4)\n",
+      "Requirement already satisfied: starlette>=0.27 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from mcp>=1.26.0->semantic-kernel) (1.3.0)\n",
+      "Requirement already satisfied: uvicorn>=0.31.1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from mcp>=1.26.0->semantic-kernel) (0.49.0)\n",
+      "Requirement already satisfied: httpcore==1.* in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from httpx<1.0.0,>=0.27.1->mcp>=1.26.0->semantic-kernel) (1.0.9)\n",
+      "Requirement already satisfied: h11>=0.16 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from httpcore==1.*->httpx<1.0.0,>=0.27.1->mcp>=1.26.0->semantic-kernel) (0.16.0)\n",
       "Requirement already satisfied: distro<2,>=1.7.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai>=2.0.0->semantic-kernel) (1.9.0)\n",
       "Requirement already satisfied: jiter<1,>=0.10.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai>=2.0.0->semantic-kernel) (0.14.0)\n",
       "Requirement already satisfied: sniffio in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai>=2.0.0->semantic-kernel) (1.3.1)\n",
@@ -368,303 +385,88 @@
       "Requirement already satisfied: asttokens>=2.1.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (3.0.1)\n",
       "Requirement already satisfied: pure-eval in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (0.2.3)\n",
       "Requirement already satisfied: click>=7.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from uvicorn>=0.31.1->mcp>=1.26.0->semantic-kernel) (8.1.8)\n",
-      "Downloading semantic_kernel-1.42.0-py3-none-any.whl (926 kB)\n",
-      "   ---------------------------------------- 0.0/926.1 kB ? eta -:--:--\n",
-      "   ---------------------------------------- 926.1/926.1 kB 17.8 MB/s  0:00:00\n",
-      "Using cached azure_ai_projects-1.0.0-py3-none-any.whl (115 kB)\n",
-      "Downloading requests-2.34.2-py3-none-any.whl (73 kB)\n",
+      "Downloading semantic_kernel-1.43.0-py3-none-any.whl (926 kB)\n",
+      "   ---------------------------------------- 0.0/926.8 kB ? eta -:--:--\n",
+      "   --------------------------------- ------ 786.4/926.8 kB 6.1 MB/s eta 0:00:01\n",
+      "   ---------------------------------------- 926.8/926.8 kB 3.2 MB/s  0:00:00\n",
       "Using cached referencing-0.36.2-py3-none-any.whl (26 kB)\n",
-      "Using cached websockets-15.0.1-cp313-cp313-win_amd64.whl (176 kB)\n",
-      "Using cached ipywidgets-8.1.8-py3-none-any.whl (139 kB)\n",
-      "Downloading pandas-3.0.3-cp313-cp313-win_amd64.whl (9.8 MB)\n",
-      "   ---------------------------------------- 0.0/9.8 MB ? eta -:--:--\n",
-      "   ---------------------------------------- 9.8/9.8 MB 63.5 MB/s  0:00:00\n",
-      "Using cached aiortc-1.14.0-py3-none-any.whl (93 kB)\n",
-      "Using cached aioice-0.10.2-py3-none-any.whl (24 kB)\n",
-      "Using cached av-16.1.0-cp313-cp313-win_amd64.whl (31.7 MB)\n",
-      "Using cached azure_ai_agents-1.2.0b6-py3-none-any.whl (217 kB)\n",
-      "Downloading azure_storage_blob-12.29.0-py3-none-any.whl (434 kB)\n",
-      "Using cached dnspython-2.8.0-py3-none-any.whl (331 kB)\n",
-      "Using cached ifaddr-0.2.0-py3-none-any.whl (12 kB)\n",
-      "Using cached pyee-13.0.1-py3-none-any.whl (15 kB)\n",
-      "Using cached pylibsrtp-1.0.0-cp310-abi3-win_amd64.whl (1.6 MB)\n",
-      "Downloading pyopenssl-26.2.0-py3-none-any.whl (55 kB)\n",
-      "Installing collected packages: ifaddr, websockets, requests, referencing, pyee, dnspython, av, pylibsrtp, pandas, aioice, pyopenssl, ipywidgets, azure-storage-blob, azure-ai-agents, azure-ai-projects, aiortc, semantic-kernel\n",
+      "Downloading tqdm-4.68.2-py3-none-any.whl (78 kB)\n",
+      "Installing collected packages: tqdm, referencing, semantic-kernel\n",
       "\n",
-      "   ----------------------------------------  0/17 [ifaddr]\n",
-      "  Attempting uninstall: websockets\n",
-      "   ----------------------------------------  0/17 [ifaddr]\n",
-      "    Found existing installation: websockets 16.0\n",
-      "   ----------------------------------------  0/17 [ifaddr]\n",
-      "    Uninstalling websockets-16.0:\n",
-      "   ----------------------------------------  0/17 [ifaddr]\n",
-      "   -- -------------------------------------  1/17 [websockets]\n",
-      "      Successfully uninstalled websockets-16.0\n",
-      "   -- -------------------------------------  1/17 [websockets]\n",
-      "   -- -------------------------------------  1/17 [websockets]\n",
-      "   -- -------------------------------------  1/17 [websockets]\n",
-      "   -- -------------------------------------  1/17 [websockets]\n",
-      "  Attempting uninstall: requests\n",
-      "   -- -------------------------------------  1/17 [websockets]\n",
-      "    Found existing installation: requests 2.33.1\n",
-      "   -- -------------------------------------  1/17 [websockets]\n",
-      "    Uninstalling requests-2.33.1:\n",
-      "   -- -------------------------------------  1/17 [websockets]\n",
-      "      Successfully uninstalled requests-2.33.1\n",
-      "   -- -------------------------------------  1/17 [websockets]\n",
-      "   ---- -----------------------------------  2/17 [requests]\n",
-      "   ---- -----------------------------------  2/17 [requests]\n",
+      "  Attempting uninstall: tqdm\n",
+      "\n",
+      "    Found existing installation: tqdm 4.67.3\n",
+      "\n",
+      "    Uninstalling tqdm-4.67.3:\n",
+      "\n",
+      "      Successfully uninstalled tqdm-4.67.3\n",
+      "\n",
+      "   ---------------------------------------- 0/3 [tqdm]\n",
+      "   ---------------------------------------- 0/3 [tqdm]\n",
       "  Attempting uninstall: referencing\n",
-      "   ---- -----------------------------------  2/17 [requests]\n",
+      "   ---------------------------------------- 0/3 [tqdm]\n",
       "    Found existing installation: referencing 0.37.0\n",
-      "   ---- -----------------------------------  2/17 [requests]\n",
+      "   ---------------------------------------- 0/3 [tqdm]\n",
+      "   ------------- -------------------------- 1/3 [referencing]\n",
       "    Uninstalling referencing-0.37.0:\n",
-      "   ---- -----------------------------------  2/17 [requests]\n",
+      "   ------------- -------------------------- 1/3 [referencing]\n",
       "      Successfully uninstalled referencing-0.37.0\n",
-      "   ---- -----------------------------------  2/17 [requests]\n",
-      "   ------- --------------------------------  3/17 [referencing]\n",
-      "   --------- ------------------------------  4/17 [pyee]\n",
-      "   ----------- ----------------------------  5/17 [dnspython]\n",
-      "   ----------- ----------------------------  5/17 [dnspython]\n",
-      "   ----------- ----------------------------  5/17 [dnspython]\n",
-      "   ----------- ----------------------------  5/17 [dnspython]\n",
-      "   ----------- ----------------------------  5/17 [dnspython]\n",
-      "   ----------- ----------------------------  5/17 [dnspython]\n",
-      "   ----------- ----------------------------  5/17 [dnspython]\n",
-      "   ----------- ----------------------------  5/17 [dnspython]\n",
-      "   ----------- ----------------------------  5/17 [dnspython]\n",
-      "   -------------- -------------------------  6/17 [av]\n",
-      "   -------------- -------------------------  6/17 [av]\n",
-      "   -------------- -------------------------  6/17 [av]\n",
-      "   -------------- -------------------------  6/17 [av]\n",
-      "   -------------- -------------------------  6/17 [av]\n",
-      "   -------------- -------------------------  6/17 [av]\n",
-      "   ---------------- -----------------------  7/17 [pylibsrtp]\n",
-      "  Attempting uninstall: pandas\n",
-      "   ---------------- -----------------------  7/17 [pylibsrtp]\n",
-      "    Found existing installation: pandas 3.0.2\n",
-      "   ---------------- -----------------------  7/17 [pylibsrtp]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "    Uninstalling pandas-3.0.2:\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "      Successfully uninstalled pandas-3.0.2\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   ------------------ ---------------------  8/17 [pandas]\n",
-      "   --------------------- ------------------  9/17 [aioice]\n",
-      "  Attempting uninstall: ipywidgets\n",
-      "   --------------------- ------------------  9/17 [aioice]\n",
-      "   ------------------------- -------------- 11/17 [ipywidgets]\n",
-      "    Found existing installation: ipywidgets 8.1.5\n",
-      "   ------------------------- -------------- 11/17 [ipywidgets]\n",
-      "    Uninstalling ipywidgets-8.1.5:\n",
-      "   ------------------------- -------------- 11/17 [ipywidgets]\n",
-      "      Successfully uninstalled ipywidgets-8.1.5\n",
-      "   ------------------------- -------------- 11/17 [ipywidgets]\n",
-      "   ------------------------- -------------- 11/17 [ipywidgets]\n",
-      "   ------------------------- -------------- 11/17 [ipywidgets]\n",
-      "   ------------------------- -------------- 11/17 [ipywidgets]\n",
-      "   ------------------------- -------------- 11/17 [ipywidgets]\n",
-      "   ---------------------------- ----------- 12/17 [azure-storage-blob]\n",
-      "   ---------------------------- ----------- 12/17 [azure-storage-blob]\n",
-      "   ---------------------------- ----------- 12/17 [azure-storage-blob]\n",
-      "   ---------------------------- ----------- 12/17 [azure-storage-blob]\n",
-      "   ---------------------------- ----------- 12/17 [azure-storage-blob]\n",
-      "   ---------------------------- ----------- 12/17 [azure-storage-blob]\n",
-      "   ---------------------------- ----------- 12/17 [azure-storage-blob]\n",
-      "   ------------------------------ --------- 13/17 [azure-ai-agents]\n",
-      "   ------------------------------ --------- 13/17 [azure-ai-agents]\n",
-      "   ------------------------------ --------- 13/17 [azure-ai-agents]\n",
-      "  Attempting uninstall: azure-ai-projects\n",
-      "   ------------------------------ --------- 13/17 [azure-ai-agents]\n",
-      "    Found existing installation: azure-ai-projects 2.1.0\n",
-      "   ------------------------------ --------- 13/17 [azure-ai-agents]\n",
-      "    Uninstalling azure-ai-projects-2.1.0:\n",
-      "   ------------------------------ --------- 13/17 [azure-ai-agents]\n",
-      "      Successfully uninstalled azure-ai-projects-2.1.0\n",
-      "   ------------------------------ --------- 13/17 [azure-ai-agents]\n",
-      "   -------------------------------- ------- 14/17 [azure-ai-projects]\n",
-      "   -------------------------------- ------- 14/17 [azure-ai-projects]\n",
-      "   -------------------------------- ------- 14/17 [azure-ai-projects]\n",
-      "   ----------------------------------- ---- 15/17 [aiortc]\n",
-      "   ----------------------------------- ---- 15/17 [aiortc]\n",
+      "   ------------- -------------------------- 1/3 [referencing]\n",
+      "   ------------- -------------------------- 1/3 [referencing]\n",
       "  Attempting uninstall: semantic-kernel\n",
-      "   ----------------------------------- ---- 15/17 [aiortc]\n",
-      "    Found existing installation: semantic-kernel 1.22.1\n",
-      "   ----------------------------------- ---- 15/17 [aiortc]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "    Uninstalling semantic-kernel-1.22.1:\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "      Successfully uninstalled semantic-kernel-1.22.1\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ------------------------------------- -- 16/17 [semantic-kernel]\n",
-      "   ---------------------------------------- 17/17 [semantic-kernel]\n",
+      "   ------------- -------------------------- 1/3 [referencing]\n",
+      "    Found existing installation: semantic-kernel 1.42.0\n",
+      "   ------------- -------------------------- 1/3 [referencing]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "    Uninstalling semantic-kernel-1.42.0:\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "      Successfully uninstalled semantic-kernel-1.42.0\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   -------------------------- ------------- 2/3 [semantic-kernel]\n",
+      "   ---------------------------------------- 3/3 [semantic-kernel]\n",
       "\n",
-      "Successfully installed aioice-0.10.2 aiortc-1.14.0 av-16.1.0 azure-ai-agents-1.2.0b6 azure-ai-projects-1.0.0 azure-storage-blob-12.29.0 dnspython-2.8.0 ifaddr-0.2.0 ipywidgets-8.1.8 pandas-3.0.2 pyee-13.0.1 pylibsrtp-1.0.0 pyopenssl-26.2.0 referencing-0.36.2 requests-2.33.1 semantic-kernel-1.42.0 websockets-15.0.1\n",
+      "Successfully installed referencing-0.36.2 semantic-kernel-1.43.0 tqdm-4.67.3\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     },
@@ -672,21 +474,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:46 [INFO] [Orchestration.Setup] ✔️ Dépendance 'pandas' trouvée.\n"
+      "05:39:49 [INFO] [Orchestration.Setup] ✔️ Dépendance 'pandas' trouvée.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:46 [INFO] [Orchestration.Setup] ✔️ Dépendance 'requests' trouvée.\n"
+      "05:39:49 [INFO] [Orchestration.Setup] ✔️ Dépendance 'requests' trouvée.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:46 [INFO] [Orchestration.Setup] \n",
+      "05:39:49 [INFO] [Orchestration.Setup] \n",
       "✅ Dépendances principales vérifiées.\n"
      ]
     },
@@ -694,21 +496,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:46 [INFO] [Orchestration.Setup] --- Chargement Configuration LLM ---\n"
+      "05:39:49 [INFO] [Orchestration.Setup] --- Chargement Configuration LLM ---\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:46 [INFO] [Orchestration.Setup] ✅ Configuration OpenAI standard détectée (Modèle: gpt-5-mini). Org ID: Non fourni.\n"
+      "05:39:49 [INFO] [Orchestration.Setup] ✅ Configuration OpenAI standard détectée (Modèle: gpt-5-mini). Org ID: Non fourni.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:46 [INFO] [Orchestration.Setup] --- Fin Configuration Initiale ---\n"
+      "05:39:49 [INFO] [Orchestration.Setup] --- Fin Configuration Initiale ---\n"
      ]
     }
    ],
@@ -833,10 +635,10 @@
    "id": "c689b59e",
    "metadata": {
     "papermill": {
-     "duration": 0.019018,
-     "end_time": "2026-05-31T19:07:46.937372+00:00",
+     "duration": 0.016531,
+     "end_time": "2026-06-14T03:39:49.500878+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:46.918354+00:00",
+     "start_time": "2026-06-14T03:39:49.484347+00:00",
      "status": "completed"
     },
     "tags": []
@@ -849,20 +651,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "ab60fc96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:07:46.976849Z",
-     "iopub.status.busy": "2026-05-31T19:07:46.976109Z",
-     "iopub.status.idle": "2026-05-31T19:07:46.987861Z",
-     "shell.execute_reply": "2026-05-31T19:07:46.986175Z"
+     "iopub.execute_input": "2026-06-14T03:39:49.545148Z",
+     "iopub.status.busy": "2026-06-14T03:39:49.544568Z",
+     "iopub.status.idle": "2026-06-14T03:39:49.556805Z",
+     "shell.execute_reply": "2026-06-14T03:39:49.555470Z"
     },
     "papermill": {
-     "duration": 0.031491,
-     "end_time": "2026-05-31T19:07:46.988802+00:00",
+     "duration": 0.040065,
+     "end_time": "2026-06-14T03:39:49.558567+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:46.957311+00:00",
+     "start_time": "2026-06-14T03:39:49.518502+00:00",
      "status": "completed"
     },
     "tags": []
@@ -872,7 +674,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:46 [INFO] [Orchestration.Config] ✅ Configuration OpenAI standard chargée (Modèle: gpt-5-mini). Org ID: Non fourni.\n"
+      "05:39:49 [INFO] [Orchestration.Config] ✅ Configuration OpenAI standard chargée (Modèle: gpt-5-mini). Org ID: Non fourni.\n"
      ]
     },
     {
@@ -936,10 +738,10 @@
    "id": "s3yp5wc2bg",
    "metadata": {
     "papermill": {
-     "duration": 0.016288,
-     "end_time": "2026-05-31T19:07:47.021577+00:00",
+     "duration": 0.017196,
+     "end_time": "2026-06-14T03:39:49.594826+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.005289+00:00",
+     "start_time": "2026-06-14T03:39:49.577630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -970,10 +772,10 @@
    "id": "478a85e7",
    "metadata": {
     "papermill": {
-     "duration": 0.016903,
-     "end_time": "2026-05-31T19:07:47.055900+00:00",
+     "duration": 0.017074,
+     "end_time": "2026-06-14T03:39:49.629679+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.038997+00:00",
+     "start_time": "2026-06-14T03:39:49.612605+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1001,10 +803,10 @@
    "id": "a59062ad",
    "metadata": {
     "papermill": {
-     "duration": 0.026701,
-     "end_time": "2026-05-31T19:07:47.095610+00:00",
+     "duration": 0.02072,
+     "end_time": "2026-06-14T03:39:49.668357+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.068909+00:00",
+     "start_time": "2026-06-14T03:39:49.647637+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1042,20 +844,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "cc5a8f2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:07:47.137608Z",
-     "iopub.status.busy": "2026-05-31T19:07:47.137356Z",
-     "iopub.status.idle": "2026-05-31T19:07:47.180381Z",
-     "shell.execute_reply": "2026-05-31T19:07:47.179189Z"
+     "iopub.execute_input": "2026-06-14T03:39:49.707224Z",
+     "iopub.status.busy": "2026-06-14T03:39:49.706645Z",
+     "iopub.status.idle": "2026-06-14T03:39:50.310866Z",
+     "shell.execute_reply": "2026-06-14T03:39:50.309380Z"
     },
     "papermill": {
-     "duration": 0.064342,
-     "end_time": "2026-05-31T19:07:47.181000+00:00",
+     "duration": 0.626404,
+     "end_time": "2026-06-14T03:39:50.311987+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.116658+00:00",
+     "start_time": "2026-06-14T03:39:49.685583+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1065,7 +867,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.JPype] \n",
+      "05:39:49 [INFO] [Orchestration.JPype] \n",
       "--- Configuration Auto-Suffisante de la JVM (Option B - Embarquée) ---\n"
      ]
     },
@@ -1073,92 +875,170 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.JPype] 🔍 Recherche JDK portable dans l'arborescence projet...\n"
+      "05:39:49 [INFO] [Orchestration.JPype] 🔍 Recherche JDK portable dans l'arborescence projet...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.JPype] ✅ JDK portable trouvé: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\jdk-17-portable\\zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+      "05:39:49 [WARNING] [Orchestration.JPype] ⚠️ JDK portable non trouvé dans les chemins standards\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.JPype] 🏠 JAVA_HOME configuré dynamiquement: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\jdk-17-portable\\zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+      "05:39:49 [ERROR] [Orchestration.JPype] ❌ Impossible de localiser un JDK portable - JVM pourrait échouer\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.JPype] 📦 Construction du classpath Tweety...\n"
+      "05:39:49 [INFO] [Orchestration.JPype] 📦 Construction du classpath Tweety...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.JPype]   Scan des JARs dans: libs\n"
+      "05:39:49 [INFO] [Orchestration.JPype]   Scan des JARs dans: libs\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.JPype]   Scan des JARs dans: ..\\libs\n"
+      "05:39:49 [INFO] [Orchestration.JPype]   Scan des JARs dans: ..\\libs\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [ERROR] [Orchestration.JPype] ❌ Aucun JAR Tweety trouvé dans les chemins standards\n"
+      "05:39:49 [INFO] [Orchestration.JPype]   ✅ 42 JARs trouvés dans ..\\libs\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [CRITICAL] [Orchestration.JPype] ❌ ERREUR CRITIQUE Configuration Java: Classpath Tweety vide - JARs manquants\n"
+      "05:39:49 [INFO] [Orchestration.JPype] ✅ Classpath construit: 42 JARs Tweety\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [CRITICAL] [Orchestration.JPype]    PropositionalLogicAgent fonctionnera en mode dégradé (LLM seulement)\n"
+      "05:39:49 [INFO] [Orchestration.JPype] 🚀 Démarrage JVM avec 42 JARs Tweety...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [WARNING] [Orchestration.JPype] \n",
-      "🔴 STATUT FINAL: JVM/Tweety NON OPÉRATIONNELS\n"
+      "05:39:50 [INFO] [Orchestration.JPype] ✅ JVM démarrée avec succès et domaines enregistrés\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [WARNING] [Orchestration.JPype]    Pipeline fonctionnera en mode dégradé (5/10)\n"
+      "05:39:50 [INFO] [Orchestration.JPype] ☕ Java 17.0.18 opérationnel\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.JPype] --- Fin Configuration JPype Auto-Suffisante ---\n"
+      "05:39:50 [INFO] [Orchestration.JPype] 🎯 Test des classes critiques Tweety...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [WARNING] [Orchestration.JPype] ⚠️ JVM non prête - PropositionalLogicAgent en mode dégradé\n"
+      "05:39:50 [INFO] [Orchestration.JPype]   ✅ InformationObject: Accessible\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype]   ✅ PlParser: Accessible\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype]   ✅ PlFormula: Accessible\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype]   ✅ BaseRevisionOperator: Accessible\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype] 🏆 Test Tweety RÉUSSI: 4/4 classes accessibles\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype] \n",
+      "🎉 🏆 SUCCÈS TOTAL - INFRASTRUCTURE TWEETY AUTO-SUFFISANTE! 🏆 🎉\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype] ✅ PropositionalLogicAgent prêt pour exécution native\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype] ✅ Pipeline argumentatif avec intégration formelle/informelle opérationnel\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype] \n",
+      "🟢 STATUT FINAL: JVM + Tweety OPÉRATIONNELS\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype]    Pipeline peut atteindre son potentiel maximal (8/10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype] --- Fin Configuration JPype Auto-Suffisante ---\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:39:50 [INFO] [Orchestration.JPype] ✅ Tweety opérationnel - PropositionalLogicAgent en mode natif\n"
      ]
     }
    ],
@@ -1426,10 +1306,10 @@
    "id": "7hq2u546fkr",
    "metadata": {
     "papermill": {
-     "duration": 0.01655,
-     "end_time": "2026-05-31T19:07:47.216279+00:00",
+     "duration": 0.020611,
+     "end_time": "2026-06-14T03:39:50.354118+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.199729+00:00",
+     "start_time": "2026-06-14T03:39:50.333507+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1466,10 +1346,10 @@
    "id": "d201514e",
    "metadata": {
     "papermill": {
-     "duration": 0.015923,
-     "end_time": "2026-05-31T19:07:47.248953+00:00",
+     "duration": 0.019171,
+     "end_time": "2026-06-14T03:39:50.394642+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.233030+00:00",
+     "start_time": "2026-06-14T03:39:50.375471+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1489,10 +1369,10 @@
    "id": "a13a208e",
    "metadata": {
     "papermill": {
-     "duration": 0.019253,
-     "end_time": "2026-05-31T19:07:47.285673+00:00",
+     "duration": 0.023305,
+     "end_time": "2026-06-14T03:39:50.441400+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.266420+00:00",
+     "start_time": "2026-06-14T03:39:50.418095+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1539,20 +1419,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "a303fa9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:07:47.326637Z",
-     "iopub.status.busy": "2026-05-31T19:07:47.326400Z",
-     "iopub.status.idle": "2026-05-31T19:07:47.356407Z",
-     "shell.execute_reply": "2026-05-31T19:07:47.354816Z"
+     "iopub.execute_input": "2026-06-14T03:39:50.489286Z",
+     "iopub.status.busy": "2026-06-14T03:39:50.488756Z",
+     "iopub.status.idle": "2026-06-14T03:39:50.511544Z",
+     "shell.execute_reply": "2026-06-14T03:39:50.510075Z"
     },
     "papermill": {
-     "duration": 0.053013,
-     "end_time": "2026-05-31T19:07:47.357385+00:00",
+     "duration": 0.048257,
+     "end_time": "2026-06-14T03:39:50.512555+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.304372+00:00",
+     "start_time": "2026-06-14T03:39:50.464298+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1562,205 +1442,31 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [root] Classe RhetoricalAnalysisState définie.\n"
+      "05:39:50 [INFO] [root] Classe RhetoricalAnalysisState définie (via argumentation_lib shim, Phase 2 #2137).\n"
      ]
     }
    ],
    "source": [
     "# %% CELLULE [3.1] - Définition Classe RhetoricalAnalysisState\n",
-    "# (Remplace une partie de l'ancienne cellule 24085a21)\n",
+    "# Phase 2 (#2137) : RhetoricalAnalysisState est désormais fournie par le shim vendored\n",
+    "# `argumentation_lib` (B.2 — argumentation_lib/_shared_state.py). L'ancienne définition\n",
+    "# inline (~190 lignes) est remplacée par un import. La shim est un SUR-ENSEMBLE\n",
+    "# rétro-compatible : 21 méthodes vs 15 inline, AUCUN gap (toutes les méthodes inline\n",
+    "# présentes), seules des params optionnels ajoutés (ex: add_fallacy +family +taxonomy_path).\n",
+    "# Décision ai-01 (See #2137) : Phase 2 = shim-only, zéro submodule EPITA.\n",
+    "# Anti-collision : la lib `argumentation_lib/` appartient à po-2023 ; ce notebook ne fait\n",
+    "# que la CONSOMMER.\n",
     "\n",
-    "import json\n",
-    "from typing import Dict, List, Any, Optional\n",
     "import logging\n",
     "\n",
-    "# Logger spécifique pour l'état\n",
+    "# RhetoricalAnalysisState provient désormais du shim (standalone, import OK sans EPITA).\n",
+    "from argumentation_lib import RhetoricalAnalysisState\n",
+    "\n",
+    "# Logger conservé pour rétro-compatibilité (les notebooks 1/2/3 et l'Executor y font\n",
+    "# potentiellement référence via l'API du shim qui logge en interne sous ce nom).\n",
     "state_logger = logging.getLogger(\"RhetoricalAnalysisState\")\n",
-    "if not state_logger.handlers and not state_logger.propagate:\n",
-    "    handler = logging.StreamHandler(); formatter = logging.Formatter('%(asctime)s [%(levelname)s] [%(name)s] %(message)s', datefmt='%H:%M:%S'); handler.setFormatter(formatter); state_logger.addHandler(handler); state_logger.setLevel(logging.INFO)\n",
     "\n",
-    "class RhetoricalAnalysisState:\n",
-    "    \"\"\"Représente l'état partagé d'une analyse rhétorique collaborative.\"\"\"\n",
-    "\n",
-    "    # ... (Le code complet de la classe RhetoricalAnalysisState tel que fourni dans la réponse précédente va ici) ...\n",
-    "    # Structure des données de l'état (pour référence)\n",
-    "    raw_text: str\n",
-    "    analysis_tasks: Dict[str, str] # {task_id: description}\n",
-    "    identified_arguments: Dict[str, str] # {arg_id: description}\n",
-    "    identified_fallacies: Dict[str, Dict[str, str]] # {fallacy_id: {type:..., justification:..., target_argument_id?:...}}\n",
-    "    belief_sets: Dict[str, Dict[str, str]] # {bs_id: {logic_type:..., content:...}}\n",
-    "    query_log: List[Dict[str, str]] # [{log_id:..., belief_set_id:..., query:..., raw_result:...}]\n",
-    "    answers: Dict[str, Dict[str, Any]] # {task_id: {author_agent:..., answer_text:..., source_ids:[...]}}\n",
-    "    final_conclusion: Optional[str]\n",
-    "    _next_agent_designated: Optional[str] # Nom de l'agent désigné pour le prochain tour\n",
-    "\n",
-    "    def __init__(self, initial_text: str):\n",
-    "        \"\"\"Initialise un état vide avec le texte brut.\"\"\"\n",
-    "        self.raw_text = initial_text\n",
-    "        self.analysis_tasks = {}\n",
-    "        self.identified_arguments = {}\n",
-    "        self.identified_fallacies = {}\n",
-    "        self.belief_sets = {}\n",
-    "        self.query_log = []\n",
-    "        self.answers = {}\n",
-    "        self.final_conclusion = None\n",
-    "        self._next_agent_designated = None\n",
-    "        state_logger.debug(f\"Nouvelle instance RhetoricalAnalysisState créée (id: {id(self)}) avec texte (longueur: {len(initial_text)}).\")\n",
-    "\n",
-    "    def _generate_id(self, prefix: str, current_dict_or_list: Any) -> str:\n",
-    "        \"\"\"Génère un ID simple basé sur la taille actuelle.\"\"\"\n",
-    "        index = 0\n",
-    "        try:\n",
-    "            if isinstance(current_dict_or_list, (dict, list)):\n",
-    "                index = len(current_dict_or_list)\n",
-    "            else:\n",
-    "                 index = 0\n",
-    "                 state_logger.warning(f\"_generate_id: Type inattendu '{type(current_dict_or_list)}' pour prefix '{prefix}'. Index sera 0.\")\n",
-    "        except Exception as e:\n",
-    "            state_logger.error(f\"Erreur dans _generate_id pour prefix '{prefix}': {e}\", exc_info=True)\n",
-    "            index = 999\n",
-    "        safe_index = min(index, 9999)\n",
-    "        return f\"{prefix}_{safe_index + 1}\"\n",
-    "\n",
-    "    def add_task(self, description: str) -> str:\n",
-    "        \"\"\"Ajoute une tâche d'analyse et retourne son ID.\"\"\"\n",
-    "        task_id = self._generate_id(\"task\", self.analysis_tasks)\n",
-    "        self.analysis_tasks[task_id] = description\n",
-    "        state_logger.info(f\"Tâche ajoutée: {task_id} - '{description[:60]}...'\")\n",
-    "        state_logger.debug(f\"État tasks après ajout {task_id}: {self.analysis_tasks}\")\n",
-    "        return task_id\n",
-    "\n",
-    "    def add_argument(self, description: str) -> str:\n",
-    "        \"\"\"Ajoute un argument identifié et retourne son ID.\"\"\"\n",
-    "        arg_id = self._generate_id(\"arg\", self.identified_arguments)\n",
-    "        self.identified_arguments[arg_id] = description\n",
-    "        state_logger.info(f\"Argument ajouté: {arg_id} - '{description[:60]}...'\")\n",
-    "        state_logger.debug(f\"État arguments après ajout {arg_id}: {self.identified_arguments}\")\n",
-    "        return arg_id\n",
-    "\n",
-    "    def add_fallacy(self, fallacy_type: str, justification: str, target_arg_id: Optional[str] = None) -> str:\n",
-    "        \"\"\"Ajoute un sophisme identifié et retourne son ID.\"\"\"\n",
-    "        fallacy_id = self._generate_id(\"fallacy\", self.identified_fallacies)\n",
-    "        entry = {\"type\": fallacy_type, \"justification\": justification}\n",
-    "        log_target_info = \"\"\n",
-    "        if target_arg_id:\n",
-    "             if target_arg_id not in self.identified_arguments:\n",
-    "                 state_logger.warning(f\"ID argument cible '{target_arg_id}' pour sophisme '{fallacy_id}' non trouvé dans les arguments identifiés ({list(self.identified_arguments.keys())}).\")\n",
-    "             entry[\"target_argument_id\"] = target_arg_id\n",
-    "             log_target_info = f\" (cible: {target_arg_id})\"\n",
-    "        self.identified_fallacies[fallacy_id] = entry\n",
-    "        state_logger.info(f\"Sophisme ajouté: {fallacy_id} - Type: {fallacy_type}{log_target_info}\")\n",
-    "        state_logger.debug(f\"État fallacies après ajout {fallacy_id}: {self.identified_fallacies}\")\n",
-    "        return fallacy_id\n",
-    "\n",
-    "    def add_belief_set(self, logic_type: str, content: str) -> str:\n",
-    "        \"\"\"Ajoute un belief set formel et retourne son ID.\"\"\"\n",
-    "        normalized_type = logic_type.strip().lower().replace(\" \", \"_\")\n",
-    "        bs_id = self._generate_id(f\"{normalized_type}_bs\", self.belief_sets)\n",
-    "        self.belief_sets[bs_id] = {\"logic_type\": logic_type, \"content\": content}\n",
-    "        state_logger.info(f\"Belief Set ajouté: {bs_id} - Type: {logic_type}\")\n",
-    "        state_logger.debug(f\"État belief_sets après ajout {bs_id}: {self.belief_sets}\")\n",
-    "        return bs_id\n",
-    "\n",
-    "    def log_query(self, belief_set_id: str, query: str, raw_result: str) -> str:\n",
-    "         \"\"\"Enregistre une requête formelle et son résultat brut.\"\"\"\n",
-    "         log_id = self._generate_id(\"qlog\", self.query_log)\n",
-    "         if belief_set_id not in self.belief_sets:\n",
-    "             state_logger.warning(f\"ID Belief Set '{belief_set_id}' pour query log '{log_id}' non trouvé dans les belief sets ({list(self.belief_sets.keys())}).\")\n",
-    "         log_entry = {\"log_id\": log_id, \"belief_set_id\": belief_set_id, \"query\": query, \"raw_result\": raw_result}\n",
-    "         self.query_log.append(log_entry)\n",
-    "         state_logger.info(f\"Requête loggée: {log_id} (sur BS: {belief_set_id}, Query: '{query[:60]}...')\")\n",
-    "         state_logger.debug(f\"État query_log après ajout {log_id} (taille: {len(self.query_log)}): {self.query_log}\")\n",
-    "         return log_id\n",
-    "\n",
-    "    def add_answer(self, task_id: str, author_agent: str, answer_text: str, source_ids: List[str]):\n",
-    "        \"\"\"Ajoute la réponse d'un agent à une tâche spécifiques.\"\"\"\n",
-    "        if task_id not in self.analysis_tasks:\n",
-    "            state_logger.warning(f\"ID Tâche '{task_id}' pour réponse de '{author_agent}' non trouvé dans les tâches définies ({list(self.analysis_tasks.keys())}).\")\n",
-    "        self.answers[task_id] = {\"author_agent\": author_agent, \"answer_text\": answer_text, \"source_ids\": source_ids}\n",
-    "        state_logger.info(f\"Réponse ajoutée pour tâche '{task_id}' par agent '{author_agent}'.\")\n",
-    "        state_logger.debug(f\"État answers après ajout réponse pour {task_id}: {self.answers}\")\n",
-    "\n",
-    "    def set_conclusion(self, conclusion: str):\n",
-    "        \"\"\"Enregistre la conclusion finale de l'analyse.\"\"\"\n",
-    "        self.final_conclusion = conclusion\n",
-    "        state_logger.info(f\"Conclusion finale enregistrée : '{conclusion[:60]}...'\")\n",
-    "        state_logger.debug(f\"État final_conclusion après enregistrement: {self.final_conclusion is not None}\")\n",
-    "\n",
-    "    def designate_next_agent(self, agent_name: str):\n",
-    "        \"\"\"Désigne l'agent qui doit parler au prochain tour.\"\"\"\n",
-    "        self._next_agent_designated = agent_name\n",
-    "        state_logger.info(f\"Prochain agent désigné: '{agent_name}'\")\n",
-    "        state_logger.debug(f\"État _next_agent_designated après désignation: '{self._next_agent_designated}'\")\n",
-    "\n",
-    "    def consume_next_agent_designation(self) -> Optional[str]:\n",
-    "        \"\"\"Récupère le nom de l'agent désigné et réinitialise la désignation.\"\"\"\n",
-    "        agent_name = self._next_agent_designated\n",
-    "        self._next_agent_designated = None\n",
-    "        if agent_name:\n",
-    "            state_logger.info(f\"Désignation pour '{agent_name}' consommée.\")\n",
-    "        return agent_name\n",
-    "\n",
-    "    def reset_state(self):\n",
-    "        \"\"\"Réinitialise l'état à son état initial (vide sauf texte brut).\"\"\"\n",
-    "        state_logger.info(\">>> Réinitialisation de l'état d'analyse...\")\n",
-    "        initial_text = self.raw_text\n",
-    "        self.__init__(initial_text)\n",
-    "        assert not self.analysis_tasks, \"Reset analysis_tasks failed\"\n",
-    "        assert not self.identified_arguments, \"Reset identified_arguments failed\"\n",
-    "        assert not self.identified_fallacies, \"Reset identified_fallacies failed\"\n",
-    "        assert not self.belief_sets, \"Reset belief_sets failed\"\n",
-    "        assert not self.query_log, \"Reset query_log failed\"\n",
-    "        assert not self.answers, \"Reset answers failed\"\n",
-    "        assert self.final_conclusion is None, \"Reset final_conclusion failed\"\n",
-    "        assert self._next_agent_designated is None, \"Reset _next_agent_designated failed\"\n",
-    "        state_logger.info(\"<<< Réinitialisation de l'état terminée et vérifiée.\")\n",
-    "\n",
-    "    def get_state_snapshot(self, summarize: bool = False) -> Dict[str, Any]:\n",
-    "        \"\"\"Retourne un dictionnaire représentant l'état actuel (complet ou résumé).\"\"\"\n",
-    "        if summarize:\n",
-    "             return {\n",
-    "                 \"raw_text_snippet\": self.raw_text[:150] + \"...\" if len(self.raw_text) > 150 else self.raw_text,\n",
-    "                 \"task_count\": len(self.analysis_tasks),\n",
-    "                 \"tasks_defined\": list(self.analysis_tasks.keys()),\n",
-    "                 \"argument_count\": len(self.identified_arguments),\n",
-    "                 \"fallacy_count\": len(self.identified_fallacies),\n",
-    "                 \"belief_set_count\": len(self.belief_sets),\n",
-    "                 \"query_log_count\": len(self.query_log),\n",
-    "                 \"answer_count\": len(self.answers),\n",
-    "                 \"tasks_answered\": list(self.answers.keys()),\n",
-    "                 \"conclusion_present\": self.final_conclusion is not None,\n",
-    "                 \"next_agent_designated\": self._next_agent_designated\n",
-    "             }\n",
-    "        else:\n",
-    "            return json.loads(self.to_json(indent=None))\n",
-    "\n",
-    "    def to_json(self, indent: Optional[int] = 2) -> str:\n",
-    "        \"\"\"Sérialise l'état actuel en chaîne JSON.\"\"\"\n",
-    "        state_dict = {k: v for k, v in self.__dict__.items() if not callable(v) and not k.startswith(\"_logger\")}\n",
-    "        try:\n",
-    "            return json.dumps(state_dict, indent=indent, ensure_ascii=False, default=str)\n",
-    "        except TypeError as e:\n",
-    "            state_logger.error(f\"Erreur de sérialisation JSON de l'état: {e}\")\n",
-    "            safe_dict = {k: repr(v) for k, v in state_dict.items()}\n",
-    "            return json.dumps({\"error\": f\"JSON serialization failed: {e}\", \"safe_state_repr\": safe_dict}, indent=indent)\n",
-    "\n",
-    "    @classmethod\n",
-    "    def from_dict(cls, data: Dict[str, Any]) -> 'RhetoricalAnalysisState':\n",
-    "        \"\"\"Crée une instance d'état à partir d'un dictionnaire.\"\"\"\n",
-    "        state = cls(data.get('raw_text', ''))\n",
-    "        state.analysis_tasks = data.get('analysis_tasks', {})\n",
-    "        state.identified_arguments = data.get('identified_arguments', {})\n",
-    "        state.identified_fallacies = data.get('identified_fallacies', {})\n",
-    "        state.belief_sets = data.get('belief_sets', {})\n",
-    "        state.query_log = data.get('query_log', [])\n",
-    "        state.answers = data.get('answers', {})\n",
-    "        state.final_conclusion = data.get('final_conclusion', None)\n",
-    "        state._next_agent_designated = data.get('_next_agent_designated', None)\n",
-    "        state_logger.debug(f\"Instance RhetoricalAnalysisState créée depuis dict (id: {id(state)}).\")\n",
-    "        return state\n",
-    "\n",
-    "logging.info(\"Classe RhetoricalAnalysisState définie.\")"
+    "logging.info(\"Classe RhetoricalAnalysisState définie (via argumentation_lib shim, Phase 2 #2137).\")"
    ]
   },
   {
@@ -1768,10 +1474,10 @@
    "id": "0d4166a2",
    "metadata": {
     "papermill": {
-     "duration": 0.020216,
-     "end_time": "2026-05-31T19:07:47.399771+00:00",
+     "duration": 0.021245,
+     "end_time": "2026-06-14T03:39:50.556077+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.379555+00:00",
+     "start_time": "2026-06-14T03:39:50.534832+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1822,20 +1528,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "61903410",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:07:47.439834Z",
-     "iopub.status.busy": "2026-05-31T19:07:47.439453Z",
-     "iopub.status.idle": "2026-05-31T19:07:47.471190Z",
-     "shell.execute_reply": "2026-05-31T19:07:47.467351Z"
+     "iopub.execute_input": "2026-06-14T03:39:50.610554Z",
+     "iopub.status.busy": "2026-06-14T03:39:50.609788Z",
+     "iopub.status.idle": "2026-06-14T03:39:50.625827Z",
+     "shell.execute_reply": "2026-06-14T03:39:50.624386Z"
     },
     "papermill": {
-     "duration": 0.053529,
-     "end_time": "2026-05-31T19:07:47.471664+00:00",
+     "duration": 0.051281,
+     "end_time": "2026-06-14T03:39:50.627562+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.418135+00:00",
+     "start_time": "2026-06-14T03:39:50.576281+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1845,163 +1551,33 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [root] Classe StateManagerPlugin définie.\n"
+      "05:39:50 [INFO] [root] Classe StateManagerPlugin définie (via argumentation_lib shim, Phase 2 #2137).\n"
      ]
     }
    ],
    "source": [
     "# %% CELLULE [3.2] - Définition Classe StateManagerPlugin\n",
-    "# (Remplace une partie de l'ancienne cellule 24085a21)\n",
+    "# Phase 2 (#2137) : StateManagerPlugin est désormais fournie par le shim vendored\n",
+    "# `argumentation_lib` (B.2 — argumentation_lib/_state_manager_plugin.py). L'ancienne\n",
+    "# définition inline (~150 lignes) est remplacée par un import. La shim est un\n",
+    "# SUR-ENSEMBLE rétro-compatible : 30 méthodes vs 10 inline, AUCUN gap. Le lazy import\n",
+    "# (`get_state_manager_plugin()`) est requis car la classe décore ses méthodes avec\n",
+    "# `@kernel_function` (dépendance semantic_kernel).\n",
     "\n",
-    "import json\n",
-    "from typing import Dict, List, Any, Optional\n",
     "import logging\n",
-    "from semantic_kernel.functions import kernel_function\n",
+    "from argumentation_lib import get_state_manager_plugin\n",
     "\n",
-    "# Récupérer les loggers et l'état (supposés définis)\n",
-    "# Assurer que le logger StateManager a un handler\n",
+    "# S'assurer que la classe état est définie (vient de la cellule [3.1] via le shim)\n",
+    "if 'RhetoricalAnalysisState' not in globals():\n",
+    "    raise NameError(\"Classe RhetoricalAnalysisState non définie (exécutez la cellule [3.1]).\")\n",
+    "\n",
+    "# Récupère la classe StateManagerPlugin depuis le shim (lazy import semantic_kernel).\n",
+    "StateManagerPlugin = get_state_manager_plugin()\n",
+    "\n",
+    "# Logger conservé pour rétro-compatibilité.\n",
     "sm_logger = logging.getLogger(\"Orchestration.StateManager\")\n",
-    "if not sm_logger.handlers and not sm_logger.propagate:\n",
-    "    handler = logging.StreamHandler(); formatter = logging.Formatter('%(asctime)s [%(levelname)s] [%(name)s] %(message)s', datefmt='%H:%M:%S'); handler.setFormatter(formatter); sm_logger.addHandler(handler); sm_logger.setLevel(logging.INFO)\n",
-    "# S'assurer que la classe état est définie\n",
-    "if 'RhetoricalAnalysisState' not in globals(): raise NameError(\"Classe RhetoricalAnalysisState non définie.\")\n",
     "\n",
-    "\n",
-    "class StateManagerPlugin:\n",
-    "    \"\"\"Plugin Semantic Kernel pour lire et modifier l'état d'analyse partagé.\"\"\"\n",
-    "    _state: 'RhetoricalAnalysisState' # Référence à l'instance d'état unique\n",
-    "    _logger: logging.Logger\n",
-    "\n",
-    "    def __init__(self, state: 'RhetoricalAnalysisState'):\n",
-    "        \"\"\"Initialise le plugin avec une instance d'état.\"\"\"\n",
-    "        self._state = state\n",
-    "        self._logger = sm_logger\n",
-    "        self._logger.info(f\"StateManagerPlugin initialisé avec l'instance RhetoricalAnalysisState (id: {id(self._state)}).\")\n",
-    "\n",
-    "    # ... (Le code complet de la classe StateManagerPlugin avec ses @kernel_function va ici) ...\n",
-    "    # ... (Reprendre le code de la réponse précédente pour cette classe) ...\n",
-    "    @kernel_function(description=\"Récupère un aperçu (complet ou résumé) de l'état actuel de l'analyse.\", name=\"get_current_state_snapshot\")\n",
-    "    def get_current_state_snapshot(self, summarize: bool = True) -> str:\n",
-    "        \"\"\"Retourne l'état actuel sous forme de chaîne JSON.\"\"\"\n",
-    "        self._logger.info(f\"Appel get_current_state_snapshot (state id: {id(self._state)}, summarize={summarize})...\")\n",
-    "        try:\n",
-    "            snapshot_dict = self._state.get_state_snapshot(summarize=summarize)\n",
-    "            indent = 2 if not summarize else None\n",
-    "            snapshot_json = json.dumps(snapshot_dict, indent=indent, ensure_ascii=False, default=str)\n",
-    "            self._logger.info(\" -> Snapshot de l'état généré avec succès.\")\n",
-    "            self._logger.debug(f\" -> Snapshot (summarize={summarize}): {snapshot_json[:500] + '...' if len(snapshot_json)>500 else snapshot_json}\")\n",
-    "            return snapshot_json\n",
-    "        except Exception as e:\n",
-    "            self._logger.error(f\"Erreur lors de la récupération/sérialisation du snapshot de l'état: {e}\", exc_info=True)\n",
-    "            return json.dumps({\"error\": f\"Erreur récupération/sérialisation snapshot: {e}\"})\n",
-    "\n",
-    "    @kernel_function(description=\"Ajoute une nouvelle tâche d'analyse à l'état.\", name=\"add_analysis_task\")\n",
-    "    def add_analysis_task(self, description: str) -> str:\n",
-    "        \"\"\"Interface Kernel Function pour ajouter une tâche via l'état.\"\"\"\n",
-    "        self._logger.info(f\"Appel add_analysis_task (state id: {id(self._state)}): '{description[:60]}...'\")\n",
-    "        try:\n",
-    "            task_id = self._state.add_task(description)\n",
-    "            self._logger.info(f\" -> Tâche '{task_id}' ajoutée avec succès via l'état.\")\n",
-    "            return task_id\n",
-    "        except Exception as e:\n",
-    "            self._logger.error(f\"Erreur lors de l'ajout de la tâche '{description[:60]}...': {e}\", exc_info=True)\n",
-    "            return f\"FUNC_ERROR: Erreur ajout tâche: {e}\"\n",
-    "\n",
-    "    @kernel_function(description=\"Ajoute un argument identifié à l'état.\", name=\"add_identified_argument\")\n",
-    "    def add_identified_argument(self, description: str) -> str:\n",
-    "        \"\"\"Interface Kernel Function pour ajouter un argument via l'état.\"\"\"\n",
-    "        self._logger.info(f\"Appel add_identified_argument (state id: {id(self._state)}): '{description[:60]}...'\")\n",
-    "        try:\n",
-    "            arg_id = self._state.add_argument(description)\n",
-    "            self._logger.info(f\" -> Argument '{arg_id}' ajouté avec succès via l'état.\")\n",
-    "            return arg_id\n",
-    "        except Exception as e:\n",
-    "            self._logger.error(f\"Erreur lors de l'ajout de l'argument '{description[:60]}...': {e}\", exc_info=True)\n",
-    "            return f\"FUNC_ERROR: Erreur ajout argument: {e}\"\n",
-    "\n",
-    "    @kernel_function(description=\"Ajoute un sophisme identifié à l'état.\", name=\"add_identified_fallacy\")\n",
-    "    def add_identified_fallacy(self, fallacy_type: str, justification: str, target_argument_id: Optional[str] = None) -> str:\n",
-    "        \"\"\"Interface Kernel Function pour ajouter un sophisme via l'état.\"\"\"\n",
-    "        self._logger.info(f\"Appel add_identified_fallacy (state id: {id(self._state)}): Type='{fallacy_type}', Target='{target_argument_id or 'None'}'...\")\n",
-    "        try:\n",
-    "            fallacy_id = self._state.add_fallacy(fallacy_type, justification, target_argument_id)\n",
-    "            self._logger.info(f\" -> Sophisme '{fallacy_id}' ajouté avec succès via l'état.\")\n",
-    "            return fallacy_id\n",
-    "        except Exception as e:\n",
-    "            self._logger.error(f\"Erreur lors de l'ajout du sophisme (Type: {fallacy_type}): {e}\", exc_info=True)\n",
-    "            return f\"FUNC_ERROR: Erreur ajout sophisme: {e}\"\n",
-    "\n",
-    "    @kernel_function(description=\"Ajoute un belief set formel (ex: Propositional) à l'état.\", name=\"add_belief_set\")\n",
-    "    def add_belief_set(self, logic_type: str, content: str) -> str:\n",
-    "        \"\"\"Interface Kernel Function pour ajouter un belief set via l'état. Valide le type logique.\"\"\"\n",
-    "        self._logger.info(f\"Appel add_belief_set (state id: {id(self._state)}): Type='{logic_type}'...\")\n",
-    "        valid_logic_types = {\"propositional\": \"Propositional\", \"pl\": \"Propositional\"}\n",
-    "        normalized_logic_type = logic_type.strip().lower()\n",
-    "\n",
-    "        if normalized_logic_type not in valid_logic_types:\n",
-    "            error_msg = f\"Type logique '{logic_type}' non supporté. Types valides (insensible casse): {list(valid_logic_types.keys())}\"\n",
-    "            self._logger.error(error_msg)\n",
-    "            return f\"FUNC_ERROR: {error_msg}\"\n",
-    "\n",
-    "        validated_logic_type = valid_logic_types[normalized_logic_type]\n",
-    "        try:\n",
-    "            bs_id = self._state.add_belief_set(validated_logic_type, content)\n",
-    "            self._logger.info(f\" -> Belief Set '{bs_id}' ajouté avec succès via l'état (Type: {validated_logic_type}).\")\n",
-    "            return bs_id\n",
-    "        except Exception as e:\n",
-    "            self._logger.error(f\"Erreur interne lors de l'ajout du Belief Set (Type: {validated_logic_type}): {e}\", exc_info=True)\n",
-    "            return f\"FUNC_ERROR: Erreur interne ajout Belief Set: {e}\"\n",
-    "\n",
-    "    @kernel_function(description=\"Enregistre une requête formelle et son résultat brut dans le log de l'état.\", name=\"log_query_result\")\n",
-    "    def log_query_result(self, belief_set_id: str, query: str, raw_result: str) -> str:\n",
-    "        \"\"\"Interface Kernel Function pour logger une requête via l'état.\"\"\"\n",
-    "        self._logger.info(f\"Appel log_query_result (state id: {id(self._state)}): BS_ID='{belief_set_id}', Query='{query[:60]}...'\")\n",
-    "        try:\n",
-    "            log_id = self._state.log_query(belief_set_id, query, raw_result)\n",
-    "            self._logger.info(f\" -> Requête '{log_id}' loggée avec succès via l'état.\")\n",
-    "            return log_id\n",
-    "        except Exception as e:\n",
-    "            self._logger.error(f\"Erreur lors du logging de la requête (BS_ID: {belief_set_id}): {e}\", exc_info=True)\n",
-    "            return f\"FUNC_ERROR: Erreur logging requête: {e}\"\n",
-    "\n",
-    "    @kernel_function(description=\"Ajoute une réponse d'un agent à une tâche d'analyse spécifique dans l'état.\", name=\"add_answer\")\n",
-    "    def add_answer(self, task_id: str, author_agent: str, answer_text: str, source_ids: List[str]) -> str:\n",
-    "        \"\"\"Interface Kernel Function pour ajouter une réponse via l'état.\"\"\"\n",
-    "        self._logger.info(f\"Appel add_answer (state id: {id(self._state)}): TaskID='{task_id}', Author='{author_agent}'...\")\n",
-    "        try:\n",
-    "            self._state.add_answer(task_id, author_agent, answer_text, source_ids)\n",
-    "            self._logger.info(f\" -> Réponse pour tâche '{task_id}' ajoutée avec succès via l'état.\")\n",
-    "            return f\"OK: Réponse pour {task_id} ajoutée.\"\n",
-    "        except Exception as e:\n",
-    "            self._logger.error(f\"Erreur lors de l'ajout de la réponse pour la tâche '{task_id}': {e}\", exc_info=True)\n",
-    "            return f\"FUNC_ERROR: Erreur ajout réponse pour {task_id}: {e}\"\n",
-    "\n",
-    "    @kernel_function(description=\"Enregistre la conclusion finale de l'analyse dans l'état.\", name=\"set_final_conclusion\")\n",
-    "    def set_final_conclusion(self, conclusion: str) -> str:\n",
-    "        \"\"\"Interface Kernel Function pour enregistrer la conclusion via l'état.\"\"\"\n",
-    "        self._logger.info(f\"Appel set_final_conclusion (state id: {id(self._state)}): '{conclusion[:60]}...'\")\n",
-    "        try:\n",
-    "            self._state.set_conclusion(conclusion)\n",
-    "            self._logger.info(f\" -> Conclusion finale enregistrée avec succès via l'état.\")\n",
-    "            return \"OK: Conclusion finale enregistrée.\"\n",
-    "        except Exception as e:\n",
-    "            self._logger.error(f\"Erreur lors de l'enregistrement de la conclusion finale: {e}\", exc_info=True)\n",
-    "            return f\"FUNC_ERROR: Erreur enregistrement conclusion: {e}\"\n",
-    "\n",
-    "    @kernel_function(description=\"Désigne quel agent doit parler au prochain tour. Utiliser le nom EXACT de l'agent.\", name=\"designate_next_agent\")\n",
-    "    def designate_next_agent(self, agent_name: str) -> str:\n",
-    "        \"\"\"Interface Kernel Function pour désigner le prochain agent via l'état.\"\"\"\n",
-    "        self._logger.info(f\"Appel designate_next_agent (state id: {id(self._state)}): Prochain = '{agent_name}'\")\n",
-    "        try:\n",
-    "            self._state.designate_next_agent(agent_name)\n",
-    "            self._logger.info(f\" -> Agent '{agent_name}' désigné avec succès via l'état.\")\n",
-    "            return f\"OK. Agent '{agent_name}' désigné pour le prochain tour.\"\n",
-    "        except Exception as e:\n",
-    "            self._logger.error(f\"Erreur lors de la désignation de l'agent '{agent_name}': {e}\", exc_info=True)\n",
-    "            return f\"FUNC_ERROR: Erreur désignation agent {agent_name}: {e}\"\n",
-    "\n",
-    "\n",
-    "logging.info(\"Classe StateManagerPlugin définie.\")\n"
+    "logging.info(\"Classe StateManagerPlugin définie (via argumentation_lib shim, Phase 2 #2137).\")"
    ]
   },
   {
@@ -2009,10 +1585,10 @@
    "id": "a754dbe1",
    "metadata": {
     "papermill": {
-     "duration": 0.047609,
-     "end_time": "2026-05-31T19:07:47.545327+00:00",
+     "duration": 0.022296,
+     "end_time": "2026-06-14T03:39:50.671493+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.497718+00:00",
+     "start_time": "2026-06-14T03:39:50.649197+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2052,20 +1628,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "95c09e20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:07:47.588200Z",
-     "iopub.status.busy": "2026-05-31T19:07:47.587787Z",
-     "iopub.status.idle": "2026-05-31T19:07:48.397892Z",
-     "shell.execute_reply": "2026-05-31T19:07:48.394617Z"
+     "iopub.execute_input": "2026-06-14T03:39:50.721620Z",
+     "iopub.status.busy": "2026-06-14T03:39:50.721159Z",
+     "iopub.status.idle": "2026-06-14T03:39:51.549942Z",
+     "shell.execute_reply": "2026-06-14T03:39:51.548788Z"
     },
     "papermill": {
-     "duration": 0.830638,
-     "end_time": "2026-05-31T19:07:48.398587+00:00",
+     "duration": 0.853994,
+     "end_time": "2026-06-14T03:39:51.550790+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:47.567949+00:00",
+     "start_time": "2026-06-14T03:39:50.696796+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2075,28 +1651,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.LLM] --- Configuration du Service LLM Global ---\n"
+      "05:39:50 [INFO] [Orchestration.LLM] --- Configuration du Service LLM Global ---\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:47 [INFO] [Orchestration.LLM] Configuration Service Global: OpenAIChatCompletion...\n"
+      "05:39:50 [INFO] [Orchestration.LLM] Configuration Service Global: OpenAIChatCompletion...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:48 [INFO] [Orchestration.LLM] Service LLM global OpenAI (gpt-5-mini) créé.\n"
+      "05:39:51 [INFO] [Orchestration.LLM] Service LLM global OpenAI (gpt-5-mini) créé.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:48 [INFO] [root] --- Fin Définitions Composants Partagés ---\n"
+      "05:39:51 [INFO] [root] --- Fin Définitions Composants Partagés ---\n"
      ]
     }
    ],
@@ -2158,10 +1734,10 @@
    "id": "76c485ec",
    "metadata": {
     "papermill": {
-     "duration": 0.018314,
-     "end_time": "2026-05-31T19:07:48.443234+00:00",
+     "duration": 0.01973,
+     "end_time": "2026-06-14T03:39:51.589582+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:48.424920+00:00",
+     "start_time": "2026-06-14T03:39:51.569852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2190,10 +1766,10 @@
    "id": "f7a615c6",
    "metadata": {
     "papermill": {
-     "duration": 0.019339,
-     "end_time": "2026-05-31T19:07:48.483278+00:00",
+     "duration": 0.017877,
+     "end_time": "2026-06-14T03:39:51.626937+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:48.463939+00:00",
+     "start_time": "2026-06-14T03:39:51.609060+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2241,20 +1817,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "8bafcee0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:07:48.525437Z",
-     "iopub.status.busy": "2026-05-31T19:07:48.525163Z",
-     "iopub.status.idle": "2026-05-31T19:07:48.537185Z",
-     "shell.execute_reply": "2026-05-31T19:07:48.535492Z"
+     "iopub.execute_input": "2026-06-14T03:39:51.667056Z",
+     "iopub.status.busy": "2026-06-14T03:39:51.666579Z",
+     "iopub.status.idle": "2026-06-14T03:39:51.675283Z",
+     "shell.execute_reply": "2026-06-14T03:39:51.674131Z"
     },
     "papermill": {
-     "duration": 0.033992,
-     "end_time": "2026-05-31T19:07:48.538004+00:00",
+     "duration": 0.031192,
+     "end_time": "2026-06-14T03:39:51.676228+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:48.504012+00:00",
+     "start_time": "2026-06-14T03:39:51.645036+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2264,7 +1840,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:48 [INFO] [Orchestration.AgentPM.Defs] Plugin PM (vide) et prompts semantiques (V17 - CODE-ONLY) definis.\n"
+      "05:39:51 [INFO] [Orchestration.AgentPM.Defs] Plugin PM (vide) et prompts semantiques (V17 - CODE-ONLY) definis.\n"
      ]
     }
    ],
@@ -2375,10 +1951,10 @@
    "id": "036e58ad",
    "metadata": {
     "papermill": {
-     "duration": 0.019608,
-     "end_time": "2026-05-31T19:07:48.574996+00:00",
+     "duration": 0.017712,
+     "end_time": "2026-06-14T03:39:51.712675+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:48.555388+00:00",
+     "start_time": "2026-06-14T03:39:51.694963+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2414,20 +1990,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "7a1a3c2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:07:48.617845Z",
-     "iopub.status.busy": "2026-05-31T19:07:48.617619Z",
-     "iopub.status.idle": "2026-05-31T19:07:48.632255Z",
-     "shell.execute_reply": "2026-05-31T19:07:48.631186Z"
+     "iopub.execute_input": "2026-06-14T03:39:51.748707Z",
+     "iopub.status.busy": "2026-06-14T03:39:51.748394Z",
+     "iopub.status.idle": "2026-06-14T03:39:51.763287Z",
+     "shell.execute_reply": "2026-06-14T03:39:51.761921Z"
     },
     "papermill": {
-     "duration": 0.033885,
-     "end_time": "2026-05-31T19:07:48.632981+00:00",
+     "duration": 0.034936,
+     "end_time": "2026-06-14T03:39:51.764373+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:48.599096+00:00",
+     "start_time": "2026-06-14T03:39:51.729437+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2596,10 +2172,10 @@
    "id": "1b9bb59a",
    "metadata": {
     "papermill": {
-     "duration": 0.017517,
-     "end_time": "2026-05-31T19:07:48.673363+00:00",
+     "duration": 0.018286,
+     "end_time": "2026-06-14T03:39:51.802304+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:48.655846+00:00",
+     "start_time": "2026-06-14T03:39:51.784018+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2641,20 +2217,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "f2a524ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T19:07:48.722430Z",
-     "iopub.status.busy": "2026-05-31T19:07:48.722047Z",
-     "iopub.status.idle": "2026-05-31T19:07:48.728355Z",
-     "shell.execute_reply": "2026-05-31T19:07:48.727201Z"
+     "iopub.execute_input": "2026-06-14T03:39:51.843902Z",
+     "iopub.status.busy": "2026-06-14T03:39:51.843465Z",
+     "iopub.status.idle": "2026-06-14T03:39:51.850527Z",
+     "shell.execute_reply": "2026-06-14T03:39:51.849140Z"
     },
     "papermill": {
-     "duration": 0.0325,
-     "end_time": "2026-05-31T19:07:48.729344+00:00",
+     "duration": 0.029568,
+     "end_time": "2026-06-14T03:39:51.852257+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:48.696844+00:00",
+     "start_time": "2026-06-14T03:39:51.822689+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2664,7 +2240,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "21:07:48 [INFO] [Orchestration.AgentPM.Instructions] Instructions Systeme PM_INSTRUCTIONS (V15 - CODE-ONLY) definies.\n"
+      "05:39:51 [INFO] [Orchestration.AgentPM.Instructions] Instructions Systeme PM_INSTRUCTIONS (V15 - CODE-ONLY) definies.\n"
      ]
     }
    ],
@@ -2716,10 +2292,10 @@
    "id": "61dwms8dzi",
    "metadata": {
     "papermill": {
-     "duration": 0.020968,
-     "end_time": "2026-05-31T19:07:48.768884+00:00",
+     "duration": 0.020904,
+     "end_time": "2026-06-14T03:39:51.895248+00:00",
      "exception": false,
-     "start_time": "2026-05-31T19:07:48.747916+00:00",
+     "start_time": "2026-06-14T03:39:51.874344+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2791,14 +2367,16 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 65.163106,
-   "end_time": "2026-05-31T19:07:49.438634+00:00",
+   "duration": 61.610892,
+   "end_time": "2026-06-14T03:39:52.806309+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb",
-   "output_path": "/tmp/aa0_exec.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-31T19:06:44.275528+00:00",
+   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Agentic-0-init.ipynb",
+   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Agentic-0-init_output.ipynb",
+   "parameters": {
+    "BATCH_MODE": "true"
+   },
+   "start_time": "2026-06-14T03:38:51.195417+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Phase 2 foundation refactor of `Argument_Analysis_Agentic-0-init.ipynb`: the notebook now **imports** `RhetoricalAnalysisState` + `StateManagerPlugin` from the vendored [`argumentation_lib`](https://github.com/jsboige/CoursIA/tree/main/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib) shim (B.2 — #2851 / vendoring faa10e74) instead of defining ~340 lines of inline classes.

This is the **foundation** step of the multi-agent notebook Phase 2 (consume the shim instead of duplicating its classes). `Argumentum` Epic, partial contribution.

### Cells changed (source only)

| Cell | Was | Now |
|------|-----|-----|
| `[3.1]` RhetoricalAnalysisState | 190-line inline class | `from argumentation_lib import RhetoricalAnalysisState` |
| `[3.2]` StateManagerPlugin | 150-line inline class | `StateManagerPlugin = get_state_manager_plugin()` (lazy import — needs `semantic_kernel`) |
| `[4.1]` ProjectManagerPlugin | inline class | **unchanged** (not part of the shim) |

## Why this is safe — G.1 verified: the shim is a backward-compatible SUPERSET

I diffed every inline class against the shim before touching the notebook (catching my own non-greedy-regex false gap in the process):

| Class | Inline methods | Shim methods | Gap |
|-------|---------------:|-------------:|-----|
| `RhetoricalAnalysisState` | 15 | **21** | **0** |
| `StateManagerPlugin` | 10 | **30** | **0** |

The shim only **adds** optional parameters (backward-compatible signature diffs):
- `add_fallacy(fallacy_type, justification, target_arg_id=None, family="", taxonomy_path="")`
- `add_identified_fallacy(...) +family=""`
- **`add_answer(task_id, author_agent, answer_text, source_ids)` — the OBLIGATOIRE FIN DE TÂCHE method — signature IDENTICAL** (G.1 spot-check).

Smoke-tested in `mcp-jupyter` (conda env with `semantic_kernel` + `jpype`): shim `RAS` + `SMP` instantiate; `add_argument`, `add_fallacy`, `add_answer`, `designate_next_agent`, `to_json` all functional. No `NameError`, no missing method.

## Validation — rule C.2 (notebook WITH outputs)

Full re-execution via `scripts/notebook_tools/notebook_tools.py execute` (kernel `python3` → `mcp-jupyter`):

```
Exit: 0 | Duration: 62.5s | 0 errors | 0 non-executed cells
cell[15] ec=6 → "Classe RhetoricalAnalysisState définie (via argumentation_lib shim, Phase 2 #2137)"
cell[17] ec=7 → "Classe StateManagerPlugin définie (via argumentation_lib shim, Phase 2 #2137)"
```

All 11 code cells executed with coherent `execution_count` + `outputs`. Committed WITH the regenerated outputs (C.2).

## Rule F (REPARER, ne JAMAIS contourner) — bonus

Before this PR the notebook ran Tweety in **degraded (LLM-only) mode** because the JARs were absent. Per Rule F I downloaded **42 Tweety JARs** to `SymbolicAI/libs/` (gitignored) + located JDK 17 via `JAVA_HOME`. The notebook now runs Tweety in **NATIVE mode**:

```
✅ 42 JARs trouvés dans ..\libs
✅ Classpath construit: 42 JARs Tweety
🏆 Test Tweety RÉUSSI: 4/4 classes accessibles
🟢 STATUT FINAL: JVM + Tweety OPÉRATIONNELS
```

This is a real upgrade visible in the committed outputs, not a workaround.

## Scope / anti-collision

- **`argumentation_lib/` belongs to po-2023** (B.2 vendoring owner). This PR only **consumes** the shim — no edits to the library itself.
- **One-subject PR**: foundation notebook only (`-0-init.ipynb`). Notebooks 1/2/3 + Executor (downstream consumers, inherit RAS/SMP via namespace / `Executor.ipynb %run`s 0→3) are **drop-in verified** but remain a separate follow-up PR if further changes are needed.

See #2137 (partial — epic stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)