### PR TITLE
ci(lean): propagate lake build exit code through tail pipe (set -o pipefail)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -111,5 +111,9 @@ jobs:
     - name: Lake build
       working-directory: ${{ inputs.project-path }}
       run: |
+        set -o pipefail   # propagate lake's exit code through `| tail` — without this a
+                          # FAILED lake build reports exit 0 (tail always succeeds), and the
+                          # CI step passes regardless. See incident conway_lean HashlifeCorrectness
+                          # L1058 (rfl fail masked as CI PASS, 2026-06-14).
         lake exe cache get || true
         lake -R build 2>&1 | tail -20

--- a/.github/workflows/lean-game-theory.yml
+++ b/.github/workflows/lean-game-theory.yml
@@ -93,6 +93,7 @@ jobs:
 
     - name: Lake build
       run: |
+        set -o pipefail   # propagate lake's exit code through `| tail` (see lean-build.yml fix, 2026-06-14)
         lake exe cache get || true
         lake -R build 2>&1 | tail -20
 
@@ -154,5 +155,6 @@ jobs:
 
     - name: Lake build
       run: |
+        set -o pipefail   # propagate lake's exit code through `| tail` (see lean-build.yml fix, 2026-06-14)
         lake exe cache get || true
         lake -R build 2>&1 | tail -20

--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -91,5 +91,6 @@ jobs:
 
     - name: Lake build
       run: |
+        set -o pipefail   # propagate lake's exit code through `| tail` (see lean-build.yml fix, 2026-06-14)
         lake exe cache get || true
         lake -R build 2>&1 | tail -20


### PR DESCRIPTION
## Summary

**Critical CI defect found while reconciling ai-01's G.1 question** about conway_lean (`HashlifeCorrectness` builds in CI but not locally — #2937 review thread). Root cause: a **build-failure-masking bug in the Lean Lake build CI step**, present in **4 workflows**.

### The bug

The Lake build step was:

```yaml
- name: Lake build
  run: |
    lake exe cache get || true
    lake -R build 2>&1 | tail -20
```

In bash, a pipeline's exit status is that of the **last command** (`tail`), which always succeeds. So a FAILED `lake build` (exit 1) was reported as exit 0, and the CI step passed regardless of the actual build result. The "Lean CI PASS" signal for every Lean project did NOT prove `lake build` succeeded.

### Reproduced (2026-06-14)

Against conway_lean `HashlifeCorrectness.lean` L1058:
```lean
theorem evolveHashlifeFastAux_zero_n (fuel : Nat) (g : Grid) :
    evolveHashlifeFastAux fuel 0 g = g := by
  rfl
```
This `rfl` FAILS to reduce definitionally (the equation compiler splits `fuel : Nat` before confirming the first match arm fires):
```
error: Conway/Life/HashlifeCorrectness.lean:1058:2: Tactic `rfl` failed:
  evolveHashlifeFastAux fuel 0 g is not definitionally equal to g
error: build failed
--- PIPELINE EXIT (this is what CI sees): 0 ---
```
Despite `error: build failed`, the piped step returned exit 0, so `Lean CI (conway_lean)` reported PASS on recent PRs (#2937 and earlier). The clean local build (`rm .lake/.../HashlifeCorrectness.olean && lake build`) exits 1 deterministically — the real build is broken, the CI was hiding it.

### Fix

One line per step: `set -o pipefail` at the top of each Lake build step, so the pipeline fails if `lake` fails. Applied to all 4 affected workflows:

| Workflow | Scope | Jobs |
|---|---|---|
| `lean-build.yml` | reusable workflow | calibration, grothendieck, conway, knot, cooperative, stable_marriage, sensitivity, mathlib_examples, ... |
| `lean-game-theory.yml` | standalone | stable_marriage + cooperative (2 jobs) |
| `lean-social-choice.yml` | standalone | social_choice |

```diff
     - name: Lake build
       run: |
+        set -o pipefail   # propagate lake's exit code through `| tail`
       lake exe cache get || true
       lake -R build 2>&1 | tail -20
```

### ai-01 G.1 question — fully reconciled

- ❌ "HashlifeCorrectness hors target lakefile" — false: `Conway.lean:30` imports it, in `@[default_target] «Conway»`.
- ❌ "stash/dirty" — false: synced conway_lean to clean origin/main, fail persists on identical source + toolchain (v4.30.0-rc2).
- ✅ **The build IS broken; the CI was masking it.** PR #2943 fixes the masking.

### Scope & follow-up

- **This PR** = the CI fix only (4 workflows, +7 lines).
- **Separate (not here)**: the `HashlifeCorrectness` L1058 `rfl` defect — conway_lean content issue (#2162 P5).
- **⚠️ Caveat**: merging this WILL correctly turn conway_lean CI red (the now-detected build failure). That is intended. Options: (a) merge #2943 + fix L1058 together, or (b) #2943 first as infra fix and accept conway CI red as known-state signal. Decision = reviewer (ai-01).

## Verification

- All 4 affected `| tail` build steps now guarded by `set -o pipefail`.
- YAML syntax validated for all 4 workflows (`python -c "import yaml; yaml.safe_load(...)"` → VALID).
- Fresh base from `origin/main`, branch not shared (force-with-lease on own branch after amend).
- The masking reproduced locally: piped build → exit 0 despite `error: build failed`; `set -o pipefail` makes the same run exit 1.
- Scope: 3 files, +7 lines, workflow-only (no `.lean`, no catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)