### PR TITLE
feat(lean): Conway P5 -- mem_toCellsAux_shift membership companion (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -314,6 +314,27 @@ theorem toCellsAux_shift (c : MacroCell) (r0 c0 : Int) :
     simp only [add_zero, add_assoc, add_comm, add_left_comm]
     rfl
 
+/-- **Membership form of the offset-shift identity**: `p` lies in the
+    offset-`(r0, c0)` enumeration of `c` iff `p` translated back to the origin
+    `(p.1 - r0, p.2 - c0)` lies in the origin-anchored enumeration. This is the
+    form directly usable inside membership biconditionals (e.g. the P4
+    central-correctness goal `p ∈ (hashlifeResultAux …).toGrid off ↔ …`), where
+    the list-equality `toCellsAux_shift` is less convenient. -/
+theorem mem_toCellsAux_shift {c : MacroCell} {r0 c0 : Int} {p : Int × Int} :
+    p ∈ c.toCellsAux r0 c0 ↔ (p.1 - r0, p.2 - c0) ∈ c.toCellsAux 0 0 := by
+  rw [toCellsAux_shift, List.mem_map]
+  constructor
+  · rintro ⟨q, hqmem, hpq⟩
+    -- `q` is a free variable, so we rewrite the membership to speak of `q`
+    -- directly (cannot `subst` on `q.1`/`q.2`, which are field accesses).
+    have hqeq : q = (p.1 - r0, p.2 - c0) := by
+      rw [Prod.ext_iff] at hpq; ext <;> omega
+    rw [hqeq] at hqmem
+    exact hqmem
+  · intro hq
+    refine ⟨(p.1 - r0, p.2 - c0), hq, ?_⟩
+    ext <;> omega
+
 end MacroCell
 
 /-! ## High-level Grid -> MacroCell


### PR DESCRIPTION
## Summary

Adds the **membership-form corollary** of the offset-shift identity to `Conway/Life/MacroCell.lean`:

```lean
theorem mem_toCellsAux_shift {c : MacroCell} {r0 c0 : Int} {p : Int × Int} :
    p ∈ c.toCellsAux r0 c0 ↔ (p.1 - r0, p.2 - c0) ∈ c.toCellsAux 0 0
```

This is the form directly usable inside **membership biconditionals** (e.g. the P4 central-correctness goal `p ∈ (hashlifeResultAux …).toGrid off ↔ …`), where the list-equality `toCellsAux_shift` (PR #2937, merged) is less convenient. It is a direct corollary: `rw [toCellsAux_shift, List.mem_map]` then `omega` bookkeeping for the pointwise translation.

**Stepping stone for the P4 assembly** (`Canonical.ext` + `mem_toCellsAux_buildFromGrid`), NOT a sorry-closer — the P4/P5 sorries (`HashlifeCorrectness.lean` L931/L1105) remain RESEARCH-level (light-cone P2 + double-nine decomposition) and are not addressed here.

## Rebased onto main (2026-06-14)

This branch was originally stacked on #2941 (the L1058 `evolveHashlifeFastAux_zero_n` fix). **#2941 was squash-merged as `e7cacd99`**, so the branch has been **rebased onto a fresh `origin/main`** — the duplicate L1058 commit was dropped by git's cherry-pick detection, and the diff is now **lemma-only (+21 MacroCell.lean, 1 file, 0 deletions)**, exactly the intended scope.

## lean-merge-discipline §B

| # | Element | Result |
|---|---------|--------|
| 1 | `grep -c sorry` diff | **MacroCell 0→0** (pure addition, no sorry/axiom added) |
| 2 | `lake build SUCCESS` | ✅ **`Build completed successfully (3352 jobs)`, TRUE EXIT 0** (post-rebase, 2026-06-14) |
| 3 | Downstream regression | ✅ `Conway.Life.HashlifeCorrectness` built clean; only the 2 baseline sorries (L931/L1105) flagged |
| 4 | Axiom check | 0 axiom (`rw` + `List.mem_map` + `Prod.ext_iff` + `omega`) |

Build detail (rebased tip `0b425ffa`): `MacroCell` rebuilt (140s), `HashlifeCorrectness` rebuilt (140s), full 3352-job build green. No `set -o pipefail` masking — the exit code captured directly.

## Anti-regression D

Pure addition (+21/0, 1 file). No existing definition/theorem modified. New theorem name `mem_toCellsAux_shift` verified absent from codebase before addition. Proof uses only standard lemmas (`toCellsAux_shift`, `List.mem_map`, `Prod.ext_iff`, `omega`) — no new axioms, no `sorry`.

See #2162
