### PR TITLE
feat(lean): Conway P5 -- level_hashlifeResult_of_level_two (P4 structural input) (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -851,6 +851,60 @@ private theorem wf_node_elim {nw ne sw se : MacroCell}
   simp only [MacroCell.wf, Bool.and_eq_true, beq_iff_eq] at h
   tauto
 
+/-! ## P4 structural input: level preservation (level-2 base)
+
+`hashlifeResult` on a well-formed level-`k` cell is documented to return a
+level-`(k-1)` cell (the centered `2^(k-1) × 2^(k-1)` region after `2^(k-2)`
+generations). This level shape is a structural input to the P4
+central-correctness assembly: both `result.toGrid (2^k, 2^k)` and the
+`restrictGridTo` window presuppose the result is level-`(k+1)` (in the
+level-`(k+2)` input's coordinates). The general statement
+`(hashlifeResult c).level = c.level - 1` requires a strong-induction on the
+double-nine recursion; the level-2 base case below is closed directly by
+shape reduction to 16 leaves + definitional evaluation of `hashlifeResultAux`
+(the `level == 2` arm yields `step4x4`, a `node` of four leaves → level 1). -/
+
+/-- **Level-2 base of level-preservation**: a well-formed level-2
+    `MacroCell` maps under `hashlifeResult` to a level-1 cell. -/
+theorem level_hashlifeResult_of_level_two (c : MacroCell)
+    (hwf : c.wf = true) (hk : c.level = 2) :
+    (hashlifeResult c).level = 1 := by
+  obtain ⟨a, b, d, e, rfl, ha⟩ := shape_of_level_succ c 1 hk
+  obtain ⟨hwa, hwb, hwd, hwe, hlb, hld, hle⟩ := wf_node_elim hwf
+  rw [ha] at hlb hld hle
+  obtain ⟨a1, a2, a3, a4, rfl, ha1⟩ := shape_of_level_succ a 0 ha
+  obtain ⟨b1, b2, b3, b4, rfl, hb1⟩ := shape_of_level_succ b 0 hlb
+  obtain ⟨d1, d2, d3, d4, rfl, hd1⟩ := shape_of_level_succ d 0 hld
+  obtain ⟨e1, e2, e3, e4, rfl, he1⟩ := shape_of_level_succ e 0 hle
+  obtain ⟨_, _, _, _, hla2, hla3, hla4⟩ := wf_node_elim hwa
+  obtain ⟨_, _, _, _, hlb2, hlb3, hlb4⟩ := wf_node_elim hwb
+  obtain ⟨_, _, _, _, hld2, hld3, hld4⟩ := wf_node_elim hwd
+  obtain ⟨_, _, _, _, hle2, hle3, hle4⟩ := wf_node_elim hwe
+  rw [ha1] at hla2 hla3 hla4
+  rw [hb1] at hlb2 hlb3 hlb4
+  rw [hd1] at hld2 hld3 hld4
+  rw [he1] at hle2 hle3 hle4
+  obtain ⟨v1, rfl⟩ := shape_of_level_zero a1 ha1
+  obtain ⟨v2, rfl⟩ := shape_of_level_zero a2 hla2
+  obtain ⟨v3, rfl⟩ := shape_of_level_zero a3 hla3
+  obtain ⟨v4, rfl⟩ := shape_of_level_zero a4 hla4
+  obtain ⟨v5, rfl⟩ := shape_of_level_zero b1 hb1
+  obtain ⟨v6, rfl⟩ := shape_of_level_zero b2 hlb2
+  obtain ⟨v7, rfl⟩ := shape_of_level_zero b3 hlb3
+  obtain ⟨v8, rfl⟩ := shape_of_level_zero b4 hlb4
+  obtain ⟨v9, rfl⟩ := shape_of_level_zero d1 hd1
+  obtain ⟨v10, rfl⟩ := shape_of_level_zero d2 hld2
+  obtain ⟨v11, rfl⟩ := shape_of_level_zero d3 hld3
+  obtain ⟨v12, rfl⟩ := shape_of_level_zero d4 hld4
+  obtain ⟨v13, rfl⟩ := shape_of_level_zero e1 he1
+  obtain ⟨v14, rfl⟩ := shape_of_level_zero e2 hle2
+  obtain ⟨v15, rfl⟩ := shape_of_level_zero e3 hle3
+  obtain ⟨v16, rfl⟩ := shape_of_level_zero e4 hle4
+  -- c is now a concrete level-2 node of 16 leaves; `hashlifeResult` =
+  -- `hashlifeResultAux 2 c`, the `level == 2` arm yields `step4x4 c` =
+  -- `node (leaf _) (leaf _) (leaf _) (leaf _)` of level 1, by computation.
+  rfl
+
 /-- Exhaustive check of the P4 base case over the 16 leaf booleans of a
     (fully explicit) level-2 cell: `2^16` instances by `native_decide`. -/
 private theorem p4_base_exhaustive :


### PR DESCRIPTION
## Summary

Adds the **level-2 base case of MacroCell level-preservation** under `hashlifeResult` to `Conway/Life/HashlifeCorrectness.lean`:

```lean
theorem level_hashlifeResult_of_level_two (c : MacroCell)
    (hwf : c.wf = true) (hk : c.level = 2) :
    (hashlifeResult c).level = 1
```

`hashlifeResult` is documented (Hashlife.lean wrapper docstring) to take a level-`k` cell and return a level-`(k-1)` cell — the centered `2^(k-1) × 2^(k-1)` region after `2^(k-2)` generations. **This level shape is a structural input to the P4 central-correctness assembly**: both `result.toGrid (2^k, 2^k)` and the `restrictGridTo` window (in the level-`(k+2)` input's coordinates) presuppose the result is level-`(k+1)`.

**This PR closes the level-2 base case directly.** The general statement `(hashlifeResult c).level = c.level - 1` requires strong induction on the double-nine recursion (9+4 sub-calls per level, fuel=level invariant) — that is future work. The level-2 base is closed here via shape reduction to 16 leaves (`shape_of_level_succ`/`shape_of_level_zero` + `wf_node_elim`) plus **definitional evaluation** of `hashlifeResultAux`: the `c.level == 2` arm yields `step4x4 c = node (leaf _) (leaf _) (leaf _) (leaf _)` of level 1.

**Stepping stone toward full level-preservation and P4, NOT a sorry-closer** — P4 (L999) and P5 (L1164) remain open and RESEARCH-level (double-nine composition).

## Honesty correction (this cycle's investigation)

While scoping this lemma, G.1 verification corrected an imprecision in earlier cycle reports: **`step_light_cone` (P2) is FULLY PROVEN** (induction on `t` via `step_local` + `mem_lightCone_of_manhattan_le` + `manhattan_triangle`, closed by `omega`; HashlifeCorrectness L544). The entire P0/P2 light-cone infrastructure is proven. So P4 is blocked by the **double-nine compositional argument** itself, not by "light-cone P2". This PR is a genuine structural input toward P4; P2 is not the gap.

## lean-merge-discipline §B

| # | Element | Result |
|---|---------|--------|
| 1 | `grep -c` sorry diff | **HashlifeCorrectness 2→2** (P4 L999, P5 L1164 unchanged; lemma is sorry-free, pure addition) |
| 2 | `lake build SUCCESS` | ✅ `Conway.Life.HashlifeCorrectness` genuine (3320 jobs, olen deleted first, EXIT=0) |
| 3 | Axiom check | 0 axiom (rfl-based: shape reduction + definitional iota of `hashlifeResultAux`/`step4x4`) |
| 4 | Diff coherent | +54/0, 1 file, 0 catalog drift |

## Anti-regression D

Pure addition (+54/0, 1 file). No existing definition/theorem modified. New theorem name `level_hashlifeResult_of_level_two` verified absent from codebase before addition. Proof uses only existing private helpers (`shape_of_level_succ`, `shape_of_level_zero`, `wf_node_elim`) + `rfl` — no new axioms, no `sorry`.

See #2162