### PR TITLE
feat(qc): Phase 2 unified MultiAlphaModel backtest IBKR+Binance 2018-2025

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
@@ -41,39 +41,46 @@ Stratégie composite multi-broker associant un sleeve actions/ETFs (IBKR compte 
 - Métriques : Sharpe net (après costs), CAGR, MaxDD, Calmar, Sortino, Beta SPY/BTC
 - Comparaison à benchmarks : SPY B&H, 60/40 SPY/TLT, BTC B&H
 
-#### Résultats v5 (livré, `main.py`)
+#### Résultats v6 (livré, `main.py`) — coûts réalistes 5/10/5 bps
 
-Backtest `715fb722` sur QC Cloud project 31717642, 2018-01-01 → 2025-12-01
-(2892 tradeable dates, status Completed, 0 runtime error).
+Backtest `19ea0d6c` sur QC Cloud project 31717642, 2018-01-01 → 2025-12-01
+(2892 tradeable dates, status Completed, 0 runtime error). Coût explicite via
+`PercentFeeModel` + `PercentSlippageModel` : 5bps commission equities, 10bps
+commission crypto, 5bps slippage (base de coûts énoncée ci-dessus).
 
-| Métrique | v5 | Cible #1027 | Verdict |
-|----------|----|-------------|---------|
-| Sharpe Ratio | **0.765** | 1.0-1.3 net | **MISS** (sous le seuil) |
-| CAGR | **17.27 %** | ~14 % | **BEATS** |
-| Max Drawdown | **-21.5 %** | ~-22 % | **MEETS** |
-| Probabilistic Sharpe | **43.4 %** | >50 % | sous le seuil de signification |
-| Alpha / Beta (vs SPY) | 0.08 / 0.186 | — | corrélation faible (diversification OK) |
-| Annual Std Dev | 12.4 % | — | — |
-| Win Rate | 64 % | — | — |
-| Total Fees | ₮1549.08 (USDT) | — | confirme currency USDT + trading actif |
+| Métrique | v5 (brokerage défaut) | **v6 (5/10/5 bps)** | Cible #1027 |
+|----------|----------------------|---------------------|-------------|
+| Sharpe Ratio | 0.765 | **0.551** | 1.0-1.3 net → **MISS** |
+| CAGR | 17.27 % | **13.28 %** | ~14 % → ~MEETS |
+| Max Drawdown | -21.5 % | **-22.0 %** | ~-22 % → MEETS |
+| Probabilistic Sharpe | 43.4 % | **21.1 %** | >50 % → **très sous le seuil** |
+| Information Ratio | +0.078 | **-0.071** | >0 → **négatif (sous-performe benchmark)** |
+| Sortino | — | 0.597 | — |
+| Annual Std Dev | 12.4 % | 12.4 % | — |
+| Win Rate | 64 % | 62 % | — |
+| Total Fees | ₮1549 | **₮32279** | ×20 (les coûts comptent massivement) |
 
-**Verdict honnête : INCONCLUSIVE (partial).** Le framework unifié tourne de bout
-en bout sur 8 ans sans erreur (jalon technique Phase 2 atteint), le CAGR dépasse
-la cible et le drawdown est contrôlé. **Mais le Sharpe (0.765) reste sous la
-cible nette 1.0-1.3 et le PSR (43.4 %) sous le seuil de signification** → l'edge
-n'est pas statistiquement robuste dans cette configuration single-pass. Pas de
-BEATS sans walk-forward + multi-seed (Phase 3).
+**Verdict honnête : NO BEATS (coût-ajusté).** Les coûts réalistes confirment et
+aggravent le caveat de v5 : le Sharpe tombe à **0.551** (-28 %), le **PSR
+s'effondre à 21.1 %** (très sous le seuil de signification 50 %), et l'
+**information ratio devient négatif** (-0.071) — la stratégie sous-performe son
+benchmark après coûts. L'edge borderline de v5 était en majeure partie
+artificiel (coûts sous-modélisés : ₮1549 → ₮32279, ×20). Le framework fonctionne
+techniquement (8 ans sans erreur, CAGR 13.3 % ~ cible, drawdown -22 % contrôlé),
+**mais ne génère pas de rendements ajustés au risque statistiquement robustes
+après coûts réalistes dans cette configuration single-pass.**
 
 Caveats honnêtes :
-- **Brokerage par défaut** (IBKR retiré : `Unsupported security type: Crypto`).
-  Le modèle 2-broker réel (IBKR + Binance sur nœuds séparés) est Phase 5. Le
-  cost model est celui du brokerage par défaut, **moins strict** que 5bps IBKR +
-  10bps Binance + 5bps slippage → Sharpe 0.765 vraisemblablement optimiste.
 - **Crypto strats = proxys simplifiés** (MultiCanalProxy, HarrvjKellyProxy), pas
   les vrais M12 HAR-RV-J / MultiCanal du ML-Training-Pipeline. La contribution du
-  sleeve crypto est un placeholder.
-- Single backtest, single seed. `totalOrders=0` au top-level = gap connu QC API
-  (phantom-orders) ; trading actif confirmé par les fees ₮1549 + win rate 64 %.
+  sleeve crypto est un placeholder — les vrais modèles ML pourraient changer le
+  verdict, mais exigeraient walk-forward + multi-seed (Phase 3).
+- **Single backtest, single seed.** Une validation walk-forward + multi-seed ≥4
+  (Phase 3) reste nécessaire pour confirmer le NO BEATS ou le renverser ; ce
+  verdict est la lecture honnête de cette configuration unique.
+- `totalOrders=0` au top-level = gap connu QC API (phantom-orders) ; trading
+  actif confirmé par les fees ₮32279 + win rate 62 %.
+- Le 2-broker réel (IBKR + Binance sur nœuds séparés) reste Phase 5.
 
 ### Phase 3 — Walk-forward + multi-seed (S2-S3)
 - Walk-forward annual : train 5 ans → OOS 1 an, roll forward
@@ -117,9 +124,12 @@ Voir [`.env.template`](./.env.template) pour la liste des variables nécessaires
 - **Phase 1** : livrée — `research.ipynb` (sleeve crypto seul, PR #1179) puis `quantbook.ipynb`
   (portefeuille complet 8 sous-stratégies : sleeve IBKR + matrice de corrélation mensuelle 8×8
   + blend net de coûts, exécuté via lean research container avec données QC réelles)
-- **Phase 2** : livrée (jalon technique) — `main.py` framework MultiAlphaModel unifié,
-  backtest QC Cloud 2018-2025 Completed. Sharpe 0.765 / CAGR 17.3 % / MaxDD -21.5 %.
-  Verdict INCONCLUSIVE (Sharpe sous cible nette, single-pass) → Phase 3 requise.
+- **Phase 2** : livrée (jalon technique, verdict honnête) — `main.py` framework
+  MultiAlphaModel unifié, backtest QC Cloud 2018-2025 Completed. Après coûts
+  réalistes (5/10/5 bps) : Sharpe **0.551** / CAGR **13.3 %** / MaxDD **-22 %** /
+  PSR **21.1 %** / IR **-0.071**. **Verdict NO BEATS coût-ajusté** (PSR très sous
+  seuil, IR négatif, single-pass) → la validation walk-forward + multi-seed
+  Phase 3 est requise pour confirmer ou renverser ce verdict.
 - Issue tracker : [#1027](https://github.com/jsboige/CoursIA/issues/1027)
 
 ## Liens

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
@@ -41,6 +41,40 @@ Stratégie composite multi-broker associant un sleeve actions/ETFs (IBKR compte 
 - Métriques : Sharpe net (après costs), CAGR, MaxDD, Calmar, Sortino, Beta SPY/BTC
 - Comparaison à benchmarks : SPY B&H, 60/40 SPY/TLT, BTC B&H
 
+#### Résultats v5 (livré, `main.py`)
+
+Backtest `715fb722` sur QC Cloud project 31717642, 2018-01-01 → 2025-12-01
+(2892 tradeable dates, status Completed, 0 runtime error).
+
+| Métrique | v5 | Cible #1027 | Verdict |
+|----------|----|-------------|---------|
+| Sharpe Ratio | **0.765** | 1.0-1.3 net | **MISS** (sous le seuil) |
+| CAGR | **17.27 %** | ~14 % | **BEATS** |
+| Max Drawdown | **-21.5 %** | ~-22 % | **MEETS** |
+| Probabilistic Sharpe | **43.4 %** | >50 % | sous le seuil de signification |
+| Alpha / Beta (vs SPY) | 0.08 / 0.186 | — | corrélation faible (diversification OK) |
+| Annual Std Dev | 12.4 % | — | — |
+| Win Rate | 64 % | — | — |
+| Total Fees | ₮1549.08 (USDT) | — | confirme currency USDT + trading actif |
+
+**Verdict honnête : INCONCLUSIVE (partial).** Le framework unifié tourne de bout
+en bout sur 8 ans sans erreur (jalon technique Phase 2 atteint), le CAGR dépasse
+la cible et le drawdown est contrôlé. **Mais le Sharpe (0.765) reste sous la
+cible nette 1.0-1.3 et le PSR (43.4 %) sous le seuil de signification** → l'edge
+n'est pas statistiquement robuste dans cette configuration single-pass. Pas de
+BEATS sans walk-forward + multi-seed (Phase 3).
+
+Caveats honnêtes :
+- **Brokerage par défaut** (IBKR retiré : `Unsupported security type: Crypto`).
+  Le modèle 2-broker réel (IBKR + Binance sur nœuds séparés) est Phase 5. Le
+  cost model est celui du brokerage par défaut, **moins strict** que 5bps IBKR +
+  10bps Binance + 5bps slippage → Sharpe 0.765 vraisemblablement optimiste.
+- **Crypto strats = proxys simplifiés** (MultiCanalProxy, HarrvjKellyProxy), pas
+  les vrais M12 HAR-RV-J / MultiCanal du ML-Training-Pipeline. La contribution du
+  sleeve crypto est un placeholder.
+- Single backtest, single seed. `totalOrders=0` au top-level = gap connu QC API
+  (phantom-orders) ; trading actif confirmé par les fees ₮1549 + win rate 64 %.
+
 ### Phase 3 — Walk-forward + multi-seed (S2-S3)
 - Walk-forward annual : train 5 ans → OOS 1 an, roll forward
 - Multi-seed >= 4 sur sous-strats ML (HAR-RV-J vol-target en particulier)
@@ -83,7 +117,9 @@ Voir [`.env.template`](./.env.template) pour la liste des variables nécessaires
 - **Phase 1** : livrée — `research.ipynb` (sleeve crypto seul, PR #1179) puis `quantbook.ipynb`
   (portefeuille complet 8 sous-stratégies : sleeve IBKR + matrice de corrélation mensuelle 8×8
   + blend net de coûts, exécuté via lean research container avec données QC réelles)
-- **Phase 2** : à faire — backtest unifié 2018-2025 via framework QC (MultiAlphaModel, cf `main.py`)
+- **Phase 2** : livrée (jalon technique) — `main.py` framework MultiAlphaModel unifié,
+  backtest QC Cloud 2018-2025 Completed. Sharpe 0.765 / CAGR 17.3 % / MaxDD -21.5 %.
+  Verdict INCONCLUSIVE (Sharpe sous cible nette, single-pass) → Phase 3 requise.
 - Issue tracker : [#1027](https://github.com/jsboige/CoursIA/issues/1027)
 
 ## Liens

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
@@ -1,59 +1,530 @@
 # region imports
 from AlgorithmImports import *
+import numpy as np
 # endregion
 
-class PortfolioHybridIBKRBinance(QCAlgorithm):
-    """Portfolio Hybride IBKR (50%) + Binance (50%).
+# ===========================================================================
+# Portfolio Hybride IBKR (50%) + Binance (50%) - Phase 2
+# ---------------------------------------------------------------------------
+# Unified backtest 2018-2025 aggregating 8 sub-strategies as AlphaModels:
+#   Sleeve IBKR 50%: TrendStocks 30%, EMACross 25%, SectorMomentum 20%,
+#                    AllWeather 15%, EMAEquity 10%
+#   Sleeve Binance 50%: EMACrypto 50%, MultiCanalProxy 30%, HarrvjProxy 20%
+#
+# Signal logic faithfully reproduced from the 8 source projects (see #1027),
+# with two documented proxies for the event-driven/ML strategies
+# (Crypto-MultiCanal channel geometry, HAR-RV-J OLS volatility forecast).
+# ===========================================================================
 
-    Phase 1 skeleton — signal aggregation from sub-strategies.
-    Phase 2 will implement full backtest with walk-forward.
+
+def _resolve_equity(algorithm, ticker):
+    """Return the symbol of an equity already added in Initialize().
+    QC's add_equity is idempotent, but we avoid re-calling it from AlphaModels
+    to keep a single source of truth for universe subscription.
+    """
+    symbol = Symbol.create(ticker, SecurityType.EQUITY, Market.USA)
+    if symbol not in algorithm.securities:
+        algorithm.add_equity(ticker, Resolution.DAILY)
+    return symbol
+
+
+def _resolve_crypto(algorithm, ticker):
+    """Return the symbol of a crypto pair already added in Initialize()."""
+    symbol = Symbol.create(ticker, SecurityType.CRYPTO, Market.BINANCE)
+    if symbol not in algorithm.securities:
+        algorithm.add_crypto(ticker, Resolution.DAILY, Market.BINANCE)
+    return symbol
+
+
+# ---------------------------------------------------------------------------
+# Sub-strategy AlphaModels (equity sleeve)
+# ---------------------------------------------------------------------------
+
+class TrendStocksAlphaModel(AlphaModel):
+    """TrendStocks: long when Price > SMA200 AND EMA20 > EMA50.
+    Weighted by 3-month momentum (ROC63). Source: Framework_Composite_TrendWeather.
+    """
+
+    def __init__(self, tickers, resolution=Resolution.DAILY):
+        self.tickers = tickers
+        self.resolution = resolution
+        self.name = self.__class__.__name__
+        self.indicators = {}
+
+    def update(self, algorithm, data):
+        insights = []
+        for ticker in self.tickers:
+            if ticker not in self.indicators:
+                symbol = _resolve_equity(algorithm, ticker)
+                self.indicators[ticker] = {
+                    "symbol": symbol,
+                    "sma200": algorithm.sma(symbol, 200, self.resolution),
+                    "ema20": algorithm.ema(symbol, 20, self.resolution),
+                    "ema50": algorithm.ema(symbol, 50, self.resolution),
+                }
+            ind = self.indicators[ticker]
+            symbol = ind["symbol"]
+            if symbol not in algorithm.securities:
+                continue
+            sma200, ema20, ema50 = ind["sma200"], ind["ema20"], ind["ema50"]
+            if not (sma200.is_ready and ema20.is_ready and ema50.is_ready):
+                continue
+            price = algorithm.securities[symbol].price
+            if not (price > sma200.current.value and ema20.current.value > ema50.current.value):
+                insights.append(Insight.price(symbol, timedelta(days=35), InsightDirection.FLAT, source_model=self.name))
+                continue
+            history = algorithm.history(symbol, 63, self.resolution)
+            if history.empty:
+                continue
+            roc = (price / float(history["close"].iloc[0])) - 1.0
+            if roc <= 0:
+                continue
+            insights.append(Insight.price(symbol, timedelta(days=35), InsightDirection.UP, weight=roc, source_model=self.name))
+        return insights
+
+
+class EMACrossAlphaModel(AlphaModel):
+    """EMACross + TrendStocks composite (Framework_Composite_EMATrend pattern):
+    long when EMA20 > EMA50, with SMA200 trend filter. Weekly emission.
+    """
+
+    def __init__(self, tickers, resolution=Resolution.DAILY):
+        self.tickers = tickers
+        self.resolution = resolution
+        self.name = self.__class__.__name__
+        self.indicators = {}
+        self._last_emit = datetime.min
+
+    def update(self, algorithm, data):
+        if (algorithm.time - self._last_emit) < timedelta(days=6):
+            return []
+        self._last_emit = algorithm.time
+        insights = []
+        for ticker in self.tickers:
+            if ticker not in self.indicators:
+                symbol = _resolve_equity(algorithm, ticker)
+                self.indicators[ticker] = {
+                    "symbol": symbol,
+                    "ema20": algorithm.ema(symbol, 20, self.resolution),
+                    "ema50": algorithm.ema(symbol, 50, self.resolution),
+                    "sma200": algorithm.sma(symbol, 200, self.resolution),
+                }
+            ind = self.indicators[ticker]
+            symbol = ind["symbol"]
+            if symbol not in algorithm.securities:
+                continue
+            ema20, ema50, sma200 = ind["ema20"], ind["ema50"], ind["sma200"]
+            if not (ema20.is_ready and ema50.is_ready and sma200.is_ready):
+                continue
+            price = algorithm.securities[symbol].price
+            if ema20.current.value > ema50.current.value and price > sma200.current.value:
+                insights.append(Insight.price(symbol, timedelta(days=35), InsightDirection.UP, source_model=self.name))
+            else:
+                insights.append(Insight.price(symbol, timedelta(days=35), InsightDirection.FLAT, source_model=self.name))
+        return insights
+
+
+class SectorMomentumAlphaModel(AlphaModel):
+    """Dual momentum rotation on SPY/TLT/GLD (SectorMomentum v3.2).
+    Composite momentum (1m/3m/6m/12m weighted), 100% to the winner with
+    SPY bull filter (price > SMA200). Monthly entry, defensive rotation.
+    """
+
+    def __init__(self, resolution=Resolution.DAILY):
+        self.tickers = ["SPY", "TLT", "GLD"]
+        self.resolution = resolution
+        self.name = self.__class__.__name__
+        self.indicators = {}
+        self.weights_mom = [0.4, 0.2, 0.2, 0.2]
+        self.windows = [21, 63, 126, 252]
+        self._last_rebalance = datetime.min
+
+    def _ensure(self, algorithm):
+        for ticker in self.tickers:
+            if ticker not in self.indicators:
+                symbol = _resolve_equity(algorithm, ticker)
+                self.indicators[ticker] = {
+                    "symbol": symbol,
+                    "sma200": algorithm.sma(symbol, 200, self.resolution),
+                }
+
+    def update(self, algorithm, data):
+        self._ensure(algorithm)
+        spy_ind = self.indicators.get("SPY")
+        if spy_ind is None or spy_ind["symbol"] not in algorithm.securities:
+            return []
+        sma200_spy = spy_ind["sma200"]
+        if not sma200_spy.is_ready:
+            return []
+
+        scores = {}
+        for ticker, ind in self.indicators.items():
+            symbol = ind["symbol"]
+            if symbol not in algorithm.securities:
+                continue
+            history = algorithm.history(symbol, 260, self.resolution)
+            if len(history) < 252:
+                continue
+            closes = history["close"].values
+            price_now = float(algorithm.securities[symbol].price)
+            score = 0.0
+            for w, window in zip(self.weights_mom, self.windows):
+                if len(closes) > window:
+                    score += w * ((price_now / float(closes[-window])) - 1.0)
+            scores[ticker] = score
+        if not scores:
+            return []
+
+        spy_symbol = spy_ind["symbol"]
+        spy_price = float(algorithm.securities[spy_symbol].price)
+        spy_below_sma = spy_price < sma200_spy.current.value
+        spy_score = scores.get("SPY", 0.0)
+
+        if spy_score > 0 and not spy_below_sma and spy_score >= max(
+            scores.get("TLT", -1e9), scores.get("GLD", -1e9)
+        ):
+            winner = "SPY"
+        else:
+            defensive = {"TLT": scores.get("TLT", -1e9), "GLD": scores.get("GLD", -1e9)}
+            winner = max(defensive, key=defensive.get)
+
+        insights = []
+        for ticker, ind in self.indicators.items():
+            symbol = ind["symbol"]
+            direction = InsightDirection.UP if ticker == winner else InsightDirection.FLAT
+            insights.append(Insight.price(symbol, timedelta(days=35), direction, source_model=self.name))
+        return insights
+
+
+class AllWeatherAlphaModel(AlphaModel):
+    """Static AllWeather v5: SPY 30%, IEF 30%, GLD 30%, XLP 10%. Always long.
+    Source: AllWeather/main.py:63-68.
+    """
+
+    TARGET_WEIGHTS = {"SPY": 0.30, "IEF": 0.30, "GLD": 0.30, "XLP": 0.10}
+
+    def __init__(self, resolution=Resolution.DAILY):
+        self.resolution = resolution
+        self.name = self.__class__.__name__
+        self.symbols = {}
+        self._last_emit = datetime.min
+
+    def update(self, algorithm, data):
+        if (algorithm.time - self._last_emit) < timedelta(days=85):
+            return []
+        self._last_emit = algorithm.time
+        insights = []
+        for ticker, w in self.TARGET_WEIGHTS.items():
+            if ticker not in self.symbols:
+                self.symbols[ticker] = _resolve_equity(algorithm, ticker)
+            insights.append(Insight.price(self.symbols[ticker], timedelta(days=95), InsightDirection.UP, weight=w, source_model=self.name))
+        return insights
+
+
+class EMAEquityCrossAlphaModel(AlphaModel):
+    """Pure EMA20/EMA50 crossover on tech tickers. EMA-Cross-Alpha.
+    Source: EMA-Cross-Alpha/alpha_models.py:43-54.
+    """
+
+    def __init__(self, tickers, resolution=Resolution.DAILY):
+        self.tickers = tickers
+        self.resolution = resolution
+        self.name = self.__class__.__name__
+        self.indicators = {}
+
+    def update(self, algorithm, data):
+        insights = []
+        for ticker in self.tickers:
+            if ticker not in self.indicators:
+                symbol = _resolve_equity(algorithm, ticker)
+                self.indicators[ticker] = {
+                    "symbol": symbol,
+                    "ema20": algorithm.ema(symbol, 20, self.resolution),
+                    "ema50": algorithm.ema(symbol, 50, self.resolution),
+                }
+            ind = self.indicators[ticker]
+            symbol = ind["symbol"]
+            if symbol not in algorithm.securities:
+                continue
+            ema20, ema50 = ind["ema20"], ind["ema50"]
+            if not (ema20.is_ready and ema50.is_ready):
+                continue
+            direction = InsightDirection.UP if ema20.current.value > ema50.current.value else InsightDirection.FLAT
+            insights.append(Insight.price(symbol, timedelta(days=7), direction, source_model=self.name))
+        return insights
+
+
+# ---------------------------------------------------------------------------
+# Sub-strategy AlphaModels (crypto sleeve) - Binance Cash
+# ---------------------------------------------------------------------------
+
+class EMACrossCryptoAlphaModel(AlphaModel):
+    """EMA-Cross-Crypto on BTC/ETH: long when EMA20>EMA50 AND price>SMA200.
+    Internalizes the 10% trailing stop as a FLAT when drawdown from rolling
+    peak exceeds 10%. Source: EMA-Cross-Crypto/main.py:72-100.
+    """
+
+    def __init__(self, tickers, resolution=Resolution.DAILY):
+        self.tickers = tickers
+        self.resolution = resolution
+        self.name = self.__class__.__name__
+        self.indicators = {}
+        self.peak = {}
+
+    def update(self, algorithm, data):
+        insights = []
+        for ticker in self.tickers:
+            if ticker not in self.indicators:
+                symbol = _resolve_crypto(algorithm, ticker)
+                self.indicators[ticker] = {
+                    "symbol": symbol,
+                    "ema20": algorithm.ema(symbol, 20, self.resolution),
+                    "ema50": algorithm.ema(symbol, 50, self.resolution),
+                    "sma200": algorithm.sma(symbol, 200, self.resolution),
+                }
+                self.peak[symbol] = 0.0
+            ind = self.indicators[ticker]
+            symbol = ind["symbol"]
+            if symbol not in algorithm.securities:
+                continue
+            ema20, ema50, sma200 = ind["ema20"], ind["ema50"], ind["sma200"]
+            if not (ema20.is_ready and ema50.is_ready and sma200.is_ready):
+                continue
+            price = float(algorithm.securities[symbol].price)
+            invested = algorithm.securities[symbol].invested
+            if invested and price > self.peak[symbol]:
+                self.peak[symbol] = price
+            direction = InsightDirection.FLAT
+            if invested:
+                if self.peak[symbol] > 0 and price <= self.peak[symbol] * 0.90:
+                    direction = InsightDirection.FLAT
+                    self.peak[symbol] = 0.0
+                elif ema20.current.value < ema50.current.value:
+                    direction = InsightDirection.FLAT
+                    self.peak[symbol] = 0.0
+                else:
+                    direction = InsightDirection.UP
+            else:
+                if ema20.current.value > ema50.current.value and price > sma200.current.value:
+                    direction = InsightDirection.UP
+                    self.peak[symbol] = price
+            insights.append(Insight.price(symbol, timedelta(days=7), direction, source_model=self.name))
+        return insights
+
+
+class CryptoMultiCanalProxyAlphaModel(AlphaModel):
+    """SIMPLIFIED PROXY of Crypto-MultiCanal (channel geometry is O(n^2)
+    envelope fitting + async SL/TP state, not reproducible as target weights).
+    Proxy: long BTC when price > SMA50 (trend filter) AND near 20d support band
+    (within 3% of 20d low). FLAT otherwise. Source: Crypto-MultiCanal/main.py:427-487.
+    """
+
+    def __init__(self, tickers, resolution=Resolution.DAILY):
+        self.tickers = tickers
+        self.resolution = resolution
+        self.name = self.__class__.__name__
+        self.indicators = {}
+
+    def update(self, algorithm, data):
+        insights = []
+        for ticker in self.tickers:
+            if ticker not in self.indicators:
+                symbol = _resolve_crypto(algorithm, ticker)
+                self.indicators[ticker] = {
+                    "symbol": symbol,
+                    "sma50": algorithm.sma(symbol, 50, self.resolution),
+                }
+            ind = self.indicators[ticker]
+            symbol = ind["symbol"]
+            if symbol not in algorithm.securities:
+                continue
+            sma50 = ind["sma50"]
+            if not sma50.is_ready:
+                continue
+            history = algorithm.history(symbol, 21, self.resolution)
+            if len(history) < 20:
+                continue
+            if "low" in history:
+                low20 = float(history["low"].min())
+            else:
+                low20 = float(history["close"].min())
+            price = float(algorithm.securities[symbol].price)
+            support_zone = low20 * 1.03
+            direction = InsightDirection.UP if (price > sma50.current.value and price <= support_zone) else InsightDirection.FLAT
+            insights.append(Insight.price(symbol, timedelta(days=7), direction, source_model=self.name))
+        return insights
+
+
+class HarrvjKellyProxyAlphaModel(AlphaModel):
+    """SIMPLIFIED PROXY of HAR-RV-J-Kelly (the OLS volatility forecast is an
+    ML model re-fit every 22d, not reproducible trivially). Proxy: rolling
+    22d variance + 1/4-Kelly sizing, direction = sign(5d momentum).
+    Source: HAR-RV-J-Kelly/main.py:77-131 (ML forecast replaced by rolling var).
+    """
+
+    def __init__(self, tickers, resolution=Resolution.DAILY):
+        self.tickers = tickers
+        self.resolution = resolution
+        self.name = self.__class__.__name__
+        self.symbols = {}
+        self._last_emit = datetime.min
+
+    def update(self, algorithm, data):
+        if (algorithm.time - self._last_emit) < timedelta(days=6):
+            return []
+        self._last_emit = algorithm.time
+        insights = []
+        for ticker in self.tickers:
+            if ticker not in self.symbols:
+                self.symbols[ticker] = _resolve_crypto(algorithm, ticker)
+            symbol = self.symbols[ticker]
+            if symbol not in algorithm.securities:
+                continue
+            history = algorithm.history(symbol, 260, self.resolution)
+            if len(history) < 252:
+                continue
+            closes = history["close"].values.astype(float)
+            log_returns = np.diff(np.log(closes))
+            var_forecast = float(np.var(log_returns[-22:])) * 252.0
+            mu_ann = float(np.mean(log_returns[-20:])) * 252.0
+            momentum5 = float(np.sum(log_returns[-5:]))
+            if momentum5 <= 0 or var_forecast <= 0:
+                insights.append(Insight.price(symbol, timedelta(days=8), InsightDirection.FLAT, source_model=self.name))
+                continue
+            kelly_full = mu_ann / var_forecast
+            weight = min(max(kelly_full * 0.25, 0.0), 0.30)
+            insights.append(Insight.price(symbol, timedelta(days=8), InsightDirection.UP, weight=weight, source_model=self.name))
+        return insights
+
+
+# ---------------------------------------------------------------------------
+# Portfolio Construction Model: aggregate 8 alpha sources with sleeve weights
+# ---------------------------------------------------------------------------
+
+class HybridPortfolioPCM(PortfolioConstructionModel):
+    """Aggregates 8 sub-strategy alpha models into the target sleeve weights:
+    IBKR 50%: {TrendStocks 0.30, EMACross 0.25, SectorMomentum 0.20,
+               AllWeather 0.15, EMAEquity 0.10}
+    Binance 50%: {EMACrypto 0.50, MultiCanalProxy 0.30, HarrvjProxy 0.20}
+    Each alpha's insights are scaled by (sleeve * intra-sleeve weight).
+    Reuses the MultiStrategyPCM aggregation pattern from Framework_Composite_TrendWeather.
+    """
+
+    def __init__(self, alpha_weights, resolution=Resolution.DAILY):
+        super().__init__()
+        self.alpha_weights = alpha_weights
+        self.resolution = resolution
+        self._last_rebalance = datetime.min
+        self._rebalance_period = timedelta(days=7)
+
+    def determine_target_percent(self, active_insights):
+        result = {}
+        if not active_insights:
+            return result
+        by_alpha = {}
+        for insight in active_insights:
+            source = insight.source_model or "Unknown"
+            by_alpha.setdefault(source, []).append(insight)
+        for alpha_name, insights in by_alpha.items():
+            capital_slice = self.alpha_weights.get(alpha_name, 0.0)
+            for insight in insights:
+                if insight.direction == InsightDirection.FLAT:
+                    result[insight] = 0.0
+            active = [i for i in insights if i.direction != InsightDirection.FLAT]
+            if capital_slice <= 0 or not active:
+                continue
+            has_weights = all((i.weight is not None and i.weight > 0) for i in active)
+            if has_weights:
+                total_weight = sum(i.weight for i in active)
+                for insight in active:
+                    # Normalize relative weights within the alpha, scale by capital slice
+                    normalized = insight.weight / total_weight
+                    result[insight] = float(int(insight.direction)) * normalized * capital_slice
+            else:
+                per_symbol = capital_slice / len(active)
+                for insight in active:
+                    result[insight] = float(int(insight.direction)) * per_symbol
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Main algorithm
+# ---------------------------------------------------------------------------
+
+class PortfolioHybridIBKRBinance(QCAlgorithm):
+    """Phase 2: unified backtest 2018-2025, 8 sub-strategies aggregated via
+    CompositeAlphaModel + HybridPortfolioPCM. Sleeve IBKR 50% (USD) + Binance 50%.
     """
 
     def initialize(self):
-        self.set_start_date(2020, 1, 1)
-        self.set_end_date(2025, 6, 1)
+        self.set_start_date(2018, 1, 1)
+        self.set_end_date(2025, 12, 1)
+
+        # Account currency MUST be USDT so the Binance crypto sleeve (BTCUSDT,
+        # ETHUSDT) can settle. Equities (USD) are auto-converted via the USD/USDT
+        # FX rate (~1:1). set_account_currency BEFORE set_cash (canonical order).
+        self.set_account_currency("USDT")
         self.set_cash(100000)
 
-        # Brokerage: dual IBKR (equities) + Binance (crypto) model
-        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
-        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
-        if self._brokerage_mode != "none":
-            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+        # Brokerage: use the DEFAULT brokerage model (no set_brokerage_model).
+        # IBKR margin (used in Phase 1) REJECTS Crypto securities with
+        # "Unsupported security type: Crypto" — IBKR does not trade crypto spot.
+        # For a unified multi-asset backtest (equities + crypto) the default
+        # brokerage model authorizes both security types. The true 2-broker
+        # hybrid (IBKR + Binance on separate nodes) is Phase 5.
 
-        # Rebalancing
-        self.rebalance_freq = 30  # monthly
-        self.days_since_rebalance = 0
+        trend_tickers = ["AAPL", "MSFT", "GOOGL", "AMZN", "NVDA"]
+        sector_tickers = ["SPY", "TLT", "GLD", "IEF", "XLP"]
+        crypto_tickers = ["BTCUSDT", "ETHUSDT"]
 
-        # IBKR sleeve (equities)
-        self.ibkr_tickers = ["SPY", "IEF", "GLD", "XLP", "XLK", "XLF", "XLE"]
-        self.ibkr_symbols = {}
-        for ticker in self.ibkr_tickers:
-            equity = self.add_equity(ticker, Resolution.DAILY)
-            self.ibkr_symbols[ticker] = equity.symbol
+        # IMPORTANT: add ALL securities upfront in Initialize(). QC's algorithm
+        # framework needs the universe subscribed from the start; adding securities
+        # lazily inside AlphaModel.Update() is unreliable (data may never feed),
+        # which produced 0 tradeable dates / 0 orders in the first backtest run.
+        for t in trend_tickers + sector_tickers:
+            self.add_equity(t, Resolution.DAILY)
+        for t in crypto_tickers:
+            self.add_crypto(t, Resolution.DAILY, Market.BINANCE)
 
-        # Binance sleeve (crypto)
-        self.crypto_tickers = ["BTCUSDT", "ETHUSDT"]
-        self.crypto_symbols = {}
-        for ticker in self.crypto_tickers:
-            crypto = self.add_crypto(ticker, Resolution.DAILY, Market.BINANCE)
-            self.crypto_symbols[ticker] = crypto.symbol
+        # Build alpha models
+        self.trend_stocks = TrendStocksAlphaModel(trend_tickers)
+        self.ema_composite = EMACrossAlphaModel(trend_tickers)
+        self.sector_mom = SectorMomentumAlphaModel()
+        self.all_weather = AllWeatherAlphaModel()
+        self.ema_equity = EMAEquityCrossAlphaModel(trend_tickers)
+        self.ema_crypto = EMACrossCryptoAlphaModel(crypto_tickers)
+        self.multic_proxy = CryptoMultiCanalProxyAlphaModel(["BTCUSDT"])
+        self.harrvj_proxy = HarrvjKellyProxyAlphaModel(crypto_tickers)
 
-        # Schedule rebalancing
-        self.schedule.on(
-            self.date_rules.month_start(),
-            self.time_rules.at(9, 31),
-            self.rebalance
+        self.set_alpha(
+            CompositeAlphaModel(
+                self.trend_stocks,
+                self.ema_composite,
+                self.sector_mom,
+                self.all_weather,
+                self.ema_equity,
+                self.ema_crypto,
+                self.multic_proxy,
+                self.harrvj_proxy,
+            )
         )
 
-    def rebalance(self):
-        # Placeholder for Phase 2 — equal weight within sleeves
-        ibkr_weight = 0.50 / len(self.ibkr_symbols)
-        for ticker, symbol in self.ibkr_symbols.items():
-            self.set_holdings(symbol, ibkr_weight)
+        # Sleeve weights (IBKR 50% * intra, Binance 50% * intra)
+        alpha_weights = {
+            self.trend_stocks.name: 0.50 * 0.30,
+            self.ema_composite.name: 0.50 * 0.25,
+            self.sector_mom.name: 0.50 * 0.20,
+            self.all_weather.name: 0.50 * 0.15,
+            self.ema_equity.name: 0.50 * 0.10,
+            self.ema_crypto.name: 0.50 * 0.50,
+            self.multic_proxy.name: 0.50 * 0.30,
+            self.harrvj_proxy.name: 0.50 * 0.20,
+        }
+        self.set_portfolio_construction(HybridPortfolioPCM(alpha_weights))
 
-        crypto_weight = 0.50 / len(self.crypto_symbols)
-        for ticker, symbol in self.crypto_symbols.items():
-            self.set_holdings(symbol, crypto_weight)
+        # Phase 2 uses brokerage-default costs (IBKR fees for equities, Binance
+        # fees for crypto). Explicit 5bps/10bps equity/crypto + 5bps slippage
+        # modeling is deferred to Phase 3 (walk-forward), documented in README.
 
     def on_data(self, data):
         pass

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
@@ -37,6 +37,43 @@ def _resolve_crypto(algorithm, ticker):
 
 
 # ---------------------------------------------------------------------------
+# Reality models: explicit transaction costs (README Phase 2 cost basis).
+# The default brokerage (used because IBKR rejects Crypto) applies no
+# meaningful fee model, so the first backtest (Sharpe 0.765) was OPTIMISTIC.
+# These models apply the cost basis the README commits to:
+#   5bps equity commission + 10bps crypto commission + 5bps slippage.
+# Mirrors the repo's SpreadSlippageModel idiom (TradingCosts-Optimization).
+# ---------------------------------------------------------------------------
+
+class PercentFeeModel(FeeModel):
+    """Charges a fixed percent of the order notional value as commission."""
+
+    def __init__(self, percent: float):
+        super().__init__()
+        self.percent = percent
+
+    def get_order_fee(self, parameters):
+        security = parameters.security
+        order = parameters.order
+        notional = abs(order.quantity) * float(security.price)
+        return OrderFee(CashAmount(self.percent * notional, security.quote_currency.symbol))
+
+
+class PercentSlippageModel:
+    """Constant percent slippage on fill price (market-impact approximation).
+
+    Duck-typed (no base class) to match the repo's SpreadSlippageModel style;
+    QC accepts any object exposing get_slippage_approximation(asset, order).
+    """
+
+    def __init__(self, percent: float):
+        self.percent = percent
+
+    def get_slippage_approximation(self, asset, order):
+        return self.percent * float(asset.price)
+
+
+# ---------------------------------------------------------------------------
 # Sub-strategy AlphaModels (equity sleeve)
 # ---------------------------------------------------------------------------
 
@@ -481,10 +518,18 @@ class PortfolioHybridIBKRBinance(QCAlgorithm):
         # framework needs the universe subscribed from the start; adding securities
         # lazily inside AlphaModel.Update() is unreliable (data may never feed),
         # which produced 0 tradeable dates / 0 orders in the first backtest run.
+        # Apply the README Phase 2 cost basis explicitly: 5bps equity commission +
+        # 5bps slippage, 10bps crypto commission + 5bps slippage. The default
+        # brokerage (no set_brokerage_model, because IBKR rejects Crypto) applies
+        # no meaningful fee, so without these models the Sharpe is optimistic.
         for t in trend_tickers + sector_tickers:
-            self.add_equity(t, Resolution.DAILY)
+            sec = self.add_equity(t, Resolution.DAILY)
+            sec.set_fee_model(PercentFeeModel(0.0005))
+            sec.set_slippage_model(PercentSlippageModel(0.0005))
         for t in crypto_tickers:
-            self.add_crypto(t, Resolution.DAILY, Market.BINANCE)
+            sec = self.add_crypto(t, Resolution.DAILY, Market.BINANCE)
+            sec.set_fee_model(PercentFeeModel(0.001))
+            sec.set_slippage_model(PercentSlippageModel(0.0005))
 
         # Build alpha models
         self.trend_stocks = TrendStocksAlphaModel(trend_tickers)
@@ -522,9 +567,9 @@ class PortfolioHybridIBKRBinance(QCAlgorithm):
         }
         self.set_portfolio_construction(HybridPortfolioPCM(alpha_weights))
 
-        # Phase 2 uses brokerage-default costs (IBKR fees for equities, Binance
-        # fees for crypto). Explicit 5bps/10bps equity/crypto + 5bps slippage
-        # modeling is deferred to Phase 3 (walk-forward), documented in README.
+        # Transaction costs applied above via PercentFeeModel + PercentSlippageModel
+        # (5bps equity / 10bps crypto commission + 5bps slippage), matching the
+        # README Phase 2 cost basis. Walk-forward + multi-seed is Phase 3.
 
     def on_data(self, data):
         pass

--- a/scripts/qc-mcp-lite/server.py
+++ b/scripts/qc-mcp-lite/server.py
@@ -82,7 +82,11 @@ def _api_post(path: str, data: Optional[dict] = None) -> dict:
 
 def _extract_stats(bt: dict) -> dict:
     stats = bt.get("statistics", {}) or {}
-    return {
+    # Surface runtime errors so a failed backtest is diagnosable without a
+    # separate raw dump (QC returns 'error' + 'stacktrace' on Runtime Error).
+    error = bt.get("error") or ""
+    stacktrace = bt.get("stacktrace") or ""
+    result = {
         "backtestId": bt.get("backtestId", ""),
         "name": bt.get("name", ""),
         "status": bt.get("status", ""),
@@ -102,6 +106,11 @@ def _extract_stats(bt: dict) -> dict:
         },
         "progress": bt.get("progress", 0),
     }
+    if error or stacktrace:
+        # 'error' and 'stacktrace' are often identical; keep both but cap size.
+        result["error"] = error[:1200]
+        result["stacktrace"] = stacktrace[:1200]
+    return result
 
 
 # ─── Compile ──────────────────────────────────────────────────────────

--- a/scripts/qc-mcp-lite/tests/test_server.py
+++ b/scripts/qc-mcp-lite/tests/test_server.py
@@ -232,6 +232,35 @@ class TestExtractStats:
         result = _extract_stats({"totalOrders": None})
         assert result["totalOrders"] == 0
 
+    def test_surfaces_runtime_error(self):
+        """A failed backtest must surface error/stacktrace for diagnosis."""
+        bt = {
+            "backtestId": "fail1",
+            "status": "Runtime Error",
+            "error": "Unsupported security type: Crypto",
+            "stacktrace": "  at PythonException.cs:line 52",
+        }
+        result = _extract_stats(bt)
+        assert result["error"] == "Unsupported security type: Crypto"
+        assert result["stacktrace"] == "  at PythonException.cs:line 52"
+
+    def test_no_error_field_when_clean(self):
+        """A clean backtest should not carry empty error/stacktrace keys."""
+        result = _extract_stats({"backtestId": "ok", "status": "Completed"})
+        assert "error" not in result
+        assert "stacktrace" not in result
+
+    def test_error_capped_to_1200_chars(self):
+        """Oversized error/stacktrace must be capped to bound response size."""
+        bt = {
+            "backtestId": "big",
+            "error": "E" * 5000,
+            "stacktrace": "S" * 5000,
+        }
+        result = _extract_stats(bt)
+        assert len(result["error"]) == 1200
+        assert len(result["stacktrace"]) == 1200
+
 
 # --- _api_post ---
 


### PR DESCRIPTION
## Summary

Phase 2 of the #1027 Portfolio Hybride IBKR+Binance roadmap: the unified
backtest framework aggregating 8 sub-strategies, run on QC Cloud 2018-2025
with realistic transaction costs.

- `main.py` — full MultiAlphaModel framework: 8 sub-strategy AlphaModels
  under a `CompositeAlphaModel` + custom `HybridPortfolioPCM`. Explicit
  cost basis via `PercentFeeModel` (5bps equity / 10bps crypto) +
  `PercentSlippageModel` (5bps), matching the repo's SpreadSlippageModel idiom.
- `scripts/qc-mcp-lite/server.py` — wrapper fix: surface runtime `error` /
  `stacktrace` in `read_backtest` (the root diagnostic gap that forced blind
  debugging across 4 failed backtest runs).

## Backtest results — cost realism (v6, `19ea0d6c`, project 31717642)

2018-01-01 → 2025-12-01, 2892 tradeable dates, status Completed, 0 runtime error.

| Metric | v5 (default brokerage) | **v6 (5/10/5 bps)** | Target #1027 |
|--------|------------------------|---------------------|--------------|
| Sharpe Ratio | 0.765 | **0.551** | 1.0-1.3 net → **MISS** |
| CAGR | 17.27% | **13.28%** | ~14% → ~MEETS |
| Max Drawdown | -21.5% | **-22.0%** | ~-22% → MEETS |
| Probabilistic Sharpe | 43.4% | **21.1%** | >50% → **far below significance** |
| Information Ratio | +0.078 | **-0.071** | >0 → **negative (underperforms benchmark)** |
| Sortino | — | 0.597 | — |
| Win Rate | 64% | 62% | — |
| Total Fees | ₮1549 | **₮32279** | x20 (costs matter massively) |

## Honest verdict: NO BEATS (cost-adjusted)

The first backtest (Sharpe 0.765) used the default brokerage fee model, which
the README had flagged as optimistic. Adding the explicit 5/10/5 bps cost basis
confirms and worsens the caveat: Sharpe drops to **0.551** (-28%), **PSR
collapses to 21.1%** (far below the 50% significance threshold), and the
**information ratio flips negative** (-0.071) — the strategy underperforms its
benchmark after costs. The borderline edge of v5 was largely artificial
(under-modeled fees: ₮1549 → ₮32279, x20).

The framework works technically (8 years no error, CAGR ~meets target, drawdown
controlled), **but does not produce statistically robust risk-adjusted returns
after realistic costs in this single-pass configuration.**

### Honest caveats
- **Crypto strats are simplified proxies** (MultiCanalProxy, HarrvjKellyProxy),
  not the real M12 HAR-RV-J / MultiCanal from the ML-Training-Pipeline. The real
  ML models could change the verdict, but require walk-forward + multi-seed.
- **Single backtest, single seed.** Walk-forward 5-fold + multi-seed >=4
  (Phase 3) is required to confirm the NO BEATS or reverse it; this verdict is
  the honest reading of this single configuration.
- `totalOrders=0` top-level = known QC API gap (phantom-orders); active trading
  confirmed by fees ₮32279 + 62% win rate.
- The true 2-broker hybrid (IBKR + Binance on separate nodes) is Phase 5.

## Validation

- QC backtest v6: `create_compile` (BuildSuccess) → `create_backtest` →
  `read_backtest`, Completed status, 0 runtime error, 2892 tradeable dates.
- qc-mcp-lite test suite: 41/41 green (38 existing + 3 new error-surfacing cases).
- Cost realism is the final honest step of Phase 2 before any sweep allocation
  on an unrealistic cost base would be misleading.

See #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)
