### PR TITLE
docs(ml): restore French accents in PythonAgentsForDataScience Labs READMEs (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/README.md
@@ -1,31 +1,31 @@
 # Lab 2 : De l'Appel d'Offre au PoC en 1 heure
 
-**Objectif :** Utiliser un agent d'IA simple pour lire un appel d'offre (RFP), en extraire les points cles et generer une ebauche de proposition technique.
+**Objectif :** Utiliser un agent d'IA simple pour lire un appel d'offre (RFP), en extraire les points clés et générer une ébauche de proposition technique.
 
-Ce laboratoire ouvre la **Journee 2** sur l'IA agentique appliquee a la pre-vente. Il demontre comment **LangChain** orchestre un LLM pour automatiser les taches chronophages d'analyse de documents non structures, tout en gardant l'humain dans la boucle pour la validation finale.
+Ce laboratoire ouvre la **Journée 2** sur l'IA agentique appliquée à la pré-vente. Il démontre comment **LangChain** orchestre un LLM pour automatiser les tâches chronophages d'analyse de documents non structurés, tout en gardant l'humain dans la boucle pour la validation finale.
 
 ## Objectifs d'apprentissage
 
-A la fin de ce lab, vous saurez :
+À la fin de ce lab, vous saurez :
 
-1. Utiliser LangChain pour orchestrer des taches d'analyse de documents
-2. Extraire automatiquement des informations structurees d'un texte libre
-3. Generer une proposition technique basee sur les besoins identifies
-4. Chainer plusieurs appels LLM dans un pipeline reproductible
+1. Utiliser LangChain pour orchestrer des tâches d'analyse de documents
+2. Extraire automatiquement des informations structurées d'un texte libre
+3. Générer une proposition technique basée sur les besoins identifiés
+4. Chaîner plusieurs appels LLM dans un pipeline reproductible
 
-## Donnees fournies
+## Données fournies
 
-- `appel_offre.txt` : exemple d'appel d'offre pour un projet data/IA, format libre representatif des RFP reels.
+- `appel_offre.txt` : exemple d'appel d'offre pour un projet data/IA, format libre représentatif des RFP réels.
 
-## Prerequis
+## Prérequis
 
-- [Lab 1 (Day 1)](../../../Day1/Labs/README.md) : bases Pandas + premiere classification ML
-- Cle API LLM configuree (`.env` racine)
+- [Lab 1 (Day 1)](../../../Day1/Labs/README.md) : bases Pandas + première classification ML
+- Clé API LLM configurée (`.env` racine)
 
 ## Notebook
 
-- [Lab2-RFP-Analysis.ipynb](Lab2-RFP-Analysis.ipynb) - notebook etudiant
-- `Lab2-RFP-Analysis_output.ipynb` - version executee de reference
+- [Lab2-RFP-Analysis.ipynb](Lab2-RFP-Analysis.ipynb) - notebook étudiant
+- `Lab2-RFP-Analysis_output.ipynb` - version exécutée de référence
 
 ## Navigation
 

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/README.md
@@ -1,32 +1,32 @@
-# Lab 3 : Pre-qualifier des Candidats avec l'IA
+# Lab 3 : Pré-qualifier des Candidats avec l'IA
 
-**Objectif :** Utiliser un agent d'IA pour analyser, noter et resumer des CVs par rapport a une offre d'emploi.
+**Objectif :** Utiliser un agent d'IA pour analyser, noter et résumer des CVs par rapport à une offre d'emploi.
 
-Ce laboratoire prolonge la logique du [Lab 2](../Lab2-RFP-Analysis/README.md) (analyse de RFP) en l'appliquant a un autre cas concret de l'avant-vente / RH : le **screening de candidatures**. L'objectif est de transformer une pile de CVs non structures en une grille de scoring exploitable, en gardant l'humain dans la boucle pour la decision finale.
+Ce laboratoire prolonge la logique du [Lab 2](../Lab2-RFP-Analysis/README.md) (analyse de RFP) en l'appliquant à un autre cas concret de l'avant-vente / RH : le **screening de candidatures**. L'objectif est de transformer une pile de CVs non structurés en une grille de scoring exploitable, en gardant l'humain dans la boucle pour la décision finale.
 
 ## Objectifs d'apprentissage
 
-A la fin de ce lab, vous saurez :
+À la fin de ce lab, vous saurez :
 
-1. Utiliser un LLM pour analyser des documents non structures (CVs en texte libre)
-2. Comparer plusieurs documents a une reference commune (offre d'emploi)
-3. Noter l'adequation candidat / offre selon des criteres explicites
-4. Generer un resume actionnable pour le recruteur
+1. Utiliser un LLM pour analyser des documents non structurés (CVs en texte libre)
+2. Comparer plusieurs documents à une référence commune (offre d'emploi)
+3. Noter l'adéquation candidat / offre selon des critères explicites
+4. Générer un résumé actionnable pour le recruteur
 
-## Donnees fournies
+## Données fournies
 
-- `offre_datascience.txt` : offre d'emploi de reference (Data Scientist)
-- `cv_candidat_A.txt`, `cv_candidat_B.txt` : deux CVs a comparer
+- `offre_datascience.txt` : offre d'emploi de référence (Data Scientist)
+- `cv_candidat_A.txt`, `cv_candidat_B.txt` : deux CVs à comparer
 
-## Prerequis
+## Prérequis
 
-- [Lab 2 (RFP)](../Lab2-RFP-Analysis/README.md) : meme pattern LangChain + extraction structuree
-- Cle API LLM configuree (`.env` racine)
+- [Lab 2 (RFP)](../Lab2-RFP-Analysis/README.md) : même pattern LangChain + extraction structurée
+- Clé API LLM configurée (`.env` racine)
 
 ## Notebook
 
-- [Lab3-CV-Screening.ipynb](Lab3-CV-Screening.ipynb) - notebook etudiant
-- `Lab3-CV-Screening_output.ipynb` - version executee de reference
+- [Lab3-CV-Screening.ipynb](Lab3-CV-Screening.ipynb) - notebook étudiant
+- `Lab3-CV-Screening_output.ipynb` - version exécutée de référence
 
 ## Navigation
 

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/README.md
@@ -1,32 +1,32 @@
 # Lab 6 : Construire son premier Agent
 
-**Objectif :** Comprendre et construire les 4 composants fondamentaux d'un agent d'IA avec LangChain : le **LLM**, les **Outils**, le **Prompt**, et l'**Executeur**.
+**Objectif :** Comprendre et construire les 4 composants fondamentaux d'un agent d'IA avec LangChain : le **LLM**, les **Outils**, le **Prompt**, et l'**Exécuteur**.
 
-Apres avoir utilise des chaines LangChain "fil tendu" dans les Labs 2 et 3, ce laboratoire passe a l'**agent** au sens strict : un programme qui utilise un LLM pour **raisonner**, **choisir** des actions parmi un ensemble d'outils, et **iterer** jusqu'a atteindre un objectif. C'est le pivot conceptuel de la Journee 3.
+Après avoir utilisé des chaînes LangChain "fil tendu" dans les Labs 2 et 3, ce laboratoire passe à l'**agent** au sens strict : un programme qui utilise un LLM pour **raisonner**, **choisir** des actions parmi un ensemble d'outils, et **itérer** jusqu'à atteindre un objectif. C'est le pivot conceptuel de la Journée 3.
 
 ## Objectifs d'apprentissage
 
-A la fin de ce lab, vous saurez :
+À la fin de ce lab, vous saurez :
 
 1. Assembler les 4 piliers d'un agent LangChain / LangGraph (LLM, Tools, Prompt, Executor)
-2. Creer un outil personnalise avec le decorateur `@tool`
+2. Créer un outil personnalisé avec le décorateur `@tool`
 3. Comprendre le cycle ReAct (Reason -> Act -> Observe -> Reason)
-4. Tracer les etapes intermediaires d'un agent pour le debogage
+4. Tracer les étapes intermédiaires d'un agent pour le débogage
 
-## Prerequis
+## Prérequis
 
-- [Lab 5 (Viz + ML)](../Lab5-Viz-ML/README.md) : bases scikit-learn (utilise comme outil par l'agent)
+- [Lab 5 (Viz + ML)](../Lab5-Viz-ML/README.md) : bases scikit-learn (utilisé comme outil par l'agent)
 - [Lab 2 / 3](../../../Day2/Labs/) : LangChain de base
-- Cle API LLM configuree (`.env` racine)
+- Clé API LLM configurée (`.env` racine)
 
 ## Notebook
 
-- [Lab6-First-Agent.ipynb](Lab6-First-Agent.ipynb) - notebook etudiant
-- `Lab6-First-Agent_output.ipynb` - version executee de reference
+- [Lab6-First-Agent.ipynb](Lab6-First-Agent.ipynb) - notebook étudiant
+- `Lab6-First-Agent_output.ipynb` - version exécutée de référence
 
 ## Suite
 
-[Lab 7](../Lab7-Data-Analysis-Agent/README.md) reutilise ce pattern et l'applique a un agent **specialise data science** capable de manipuler un DataFrame Pandas en langage naturel.
+[Lab 7](../Lab7-Data-Analysis-Agent/README.md) réutilise ce pattern et l'applique à un agent **spécialisé data science** capable de manipuler un DataFrame Pandas en langage naturel.
 
 ## Navigation
 

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab7-Data-Analysis-Agent/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab7-Data-Analysis-Agent/README.md
@@ -1,32 +1,32 @@
-# Lab 7 : L'Agent d'Analyse de Donnees
+# Lab 7 : L'Agent d'Analyse de Données
 
-**Objectif :** Construire un agent d'IA capable de comprendre et de repondre a des questions en langage naturel sur un DataFrame Pandas.
+**Objectif :** Construire un agent d'IA capable de comprendre et de répondre à des questions en langage naturel sur un DataFrame Pandas.
 
-Ce laboratoire **fusionne les deux mondes** explores precedemment : la **Data Science** (Pandas, Labs 1 / 4 / 5) et l'**IA Agentique** (LangChain, Labs 2 / 3 / 6). On obtient un agent specialise capable d'executer du code Pandas a la volee pour repondre a une question metier formulee en francais.
+Ce laboratoire **fusionne les deux mondes** explorés précédemment : la **Data Science** (Pandas, Labs 1 / 4 / 5) et l'**IA Agentique** (LangChain, Labs 2 / 3 / 6). On obtient un agent spécialisé capable d'exécuter du code Pandas à la volée pour répondre à une question métier formulée en français.
 
 ## Objectifs d'apprentissage
 
-A la fin de ce lab, vous saurez :
+À la fin de ce lab, vous saurez :
 
-1. Creer un agent specialise avec `create_pandas_dataframe_agent` de LangChain
-2. Exposer un DataFrame en entree d'un agent et controler son perimetre
-3. Comprendre les risques d'execution de code genere (verbose / sandbox)
-4. Comparer la productivite "agent analyste" vs analyse manuelle
+1. Créer un agent spécialisé avec `create_pandas_dataframe_agent` de LangChain
+2. Exposer un DataFrame en entrée d'un agent et contrôler son périmètre
+3. Comprendre les risques d'exécution de code généré (verbose / sandbox)
+4. Comparer la productivité "agent analyste" vs analyse manuelle
 
-## Prerequis
+## Prérequis
 
 - [Lab 4 (Data Wrangling)](../Lab4-DataWrangling/README.md) : Pandas manipulation
 - [Lab 6 (First Agent)](../Lab6-First-Agent/README.md) : pattern LLM + Tools + Executor
-- Cle API LLM configuree (`.env` racine)
+- Clé API LLM configurée (`.env` racine)
 
 ## Notebook
 
-- [Lab7-Data-Analysis-Agent.ipynb](Lab7-Data-Analysis-Agent.ipynb) - notebook etudiant
-- `Lab7-Data-Analysis-Agent_output.ipynb` - version executee de reference
+- [Lab7-Data-Analysis-Agent.ipynb](Lab7-Data-Analysis-Agent.ipynb) - notebook étudiant
+- `Lab7-Data-Analysis-Agent_output.ipynb` - version exécutée de référence
 
 ## Suite et transition
 
-Le Lab 7 termine la sous-serie **Python Agents for Data Science**. La suite logique est la sous-serie [AgenticDataScience](../../../../AgenticDataScience/README.md) (Day 4-7) qui passe a **Google ADK** (Agent Development Kit) pour des agents multi-tools, multi-step plus realistes.
+Le Lab 7 termine la sous-série **Python Agents for Data Science**. La suite logique est la sous-série [AgenticDataScience](../../../../AgenticDataScience/README.md) (Day 4-7) qui passe à **Google ADK** (Agent Development Kit) pour des agents multi-tools, multi-step plus réalistes.
 
 ## Navigation
 


### PR DESCRIPTION
## Summary

Restore French diacritics in **4 Lab READMEs** under `ML/DataScienceWithAgents/PythonAgentsForDataScience/` that were left stripped — these nested sub-READMEs were missed by the earlier top-level accent pass on the ML series (#2944, #2947, #2948).

**Files (4, +54/−54 balanced in-place):**
- `Day2/Labs/Lab2-RFP-Analysis/README.md` (+28/−28)
- `Day2/Labs/Lab3-CV-Screening/README.md` (+32/−32)
- `Day3/Labs/Lab6-First-Agent/README.md` (+22/−22)
- `Day3/Labs/Lab7-Data-Analysis-Agent/README.md` (+26/−26)

`Day1/Labs/README.md`, `Lab4-DataWrangling/`, `Lab5-Viz-ML/` were already accented (`données`, `modèle`, `nettoyer`, `prédictions`) → left untouched.

## Guards (4/4 PASS)

| Guard | Result |
|-------|--------|
| **NFD round-trip** (`strip_accents(new) == original`) | PASS — zero word corruption, only diacritics added |
| **Link-targets** byte-identical | PASS (18 links) |
| **Backtick-labels** (filenames/identifiers) byte-identical | PASS (14: `appel_offre.txt`, `offre_datascience.txt`, `Lab2-RFP-Analysis.ipynb`, `create_pandas_dataframe_agent`, `@tool`, etc.) |
| **G.2 ligatures** (œ/æ) | 0/0 — none in these files |

Non-whitespace char delta: **+0** per file (precomposed `é` replaces `e`, 1:1).

## Notes

- English technical terms preserved byte-identical: LangChain, LangGraph, Pandas, LLM, ReAct, DataFrame, scikit-learn, Google ADK, Agent Development Kit.
- All markdown links (relative navigation between Labs, index, AgenticDataScience) preserved byte-identical.
- Markdown-only → no C.2 (execution) / C.3 (re-exec scope) requirement.
- `See #2876` (partial contribution to the accents epic — epic remains open).

## Collision check

Verified no open PR touches these files. PR #2918 (external contributor `koteshyelamati`) touches `GameTheory/README.md` + `GenAI/PostTraining/README.md` only — **not** ML. My partition (CPU/.NET + Probas/ML), no overlap with po-2023 (GenAI) or po-2024 (Search/QC).

See #2876