### PR TITLE
feat(qc-mcp-lite): surface runtime error/stacktrace in read_backtest

### DIFF
--- a/scripts/qc-mcp-lite/server.py
+++ b/scripts/qc-mcp-lite/server.py
@@ -82,7 +82,11 @@ def _api_post(path: str, data: Optional[dict] = None) -> dict:
 
 def _extract_stats(bt: dict) -> dict:
     stats = bt.get("statistics", {}) or {}
-    return {
+    # Surface runtime errors so a failed backtest is diagnosable without a
+    # separate raw dump (QC returns 'error' + 'stacktrace' on Runtime Error).
+    error = bt.get("error") or ""
+    stacktrace = bt.get("stacktrace") or ""
+    result = {
         "backtestId": bt.get("backtestId", ""),
         "name": bt.get("name", ""),
         "status": bt.get("status", ""),
@@ -102,6 +106,11 @@ def _extract_stats(bt: dict) -> dict:
         },
         "progress": bt.get("progress", 0),
     }
+    if error or stacktrace:
+        # 'error' and 'stacktrace' are often identical; keep both but cap size.
+        result["error"] = error[:1200]
+        result["stacktrace"] = stacktrace[:1200]
+    return result
 
 
 # ─── Compile ──────────────────────────────────────────────────────────

--- a/scripts/qc-mcp-lite/tests/test_server.py
+++ b/scripts/qc-mcp-lite/tests/test_server.py
@@ -232,6 +232,35 @@ class TestExtractStats:
         result = _extract_stats({"totalOrders": None})
         assert result["totalOrders"] == 0
 
+    def test_surfaces_runtime_error(self):
+        """A failed backtest must surface error/stacktrace for diagnosis."""
+        bt = {
+            "backtestId": "fail1",
+            "status": "Runtime Error",
+            "error": "Unsupported security type: Crypto",
+            "stacktrace": "  at PythonException.cs:line 52",
+        }
+        result = _extract_stats(bt)
+        assert result["error"] == "Unsupported security type: Crypto"
+        assert result["stacktrace"] == "  at PythonException.cs:line 52"
+
+    def test_no_error_field_when_clean(self):
+        """A clean backtest should not carry empty error/stacktrace keys."""
+        result = _extract_stats({"backtestId": "ok", "status": "Completed"})
+        assert "error" not in result
+        assert "stacktrace" not in result
+
+    def test_error_capped_to_1200_chars(self):
+        """Oversized error/stacktrace must be capped to bound response size."""
+        bt = {
+            "backtestId": "big",
+            "error": "E" * 5000,
+            "stacktrace": "S" * 5000,
+        }
+        result = _extract_stats(bt)
+        assert len(result["error"]) == 1200
+        assert len(result["stacktrace"]) == 1200
+
 
 # --- _api_post ---
 


### PR DESCRIPTION
## Summary

Atomic infra fix salvaged from #2950 (whose `main.py` was superseded by the composite-direct in #2952). This PR keeps only the `qc-mcp-lite` diagnostic improvement, which is independent of the strategy-architecture choice and valuable for every future QC backtest.

`_extract_stats` returned only the `statistics` block, so a backtest ending in **Runtime Error** gave zero diagnostic — the cause had to be inferred by blind reasoning across failed runs (exactly the gap that slowed the #1027 Phase 2 iterations where v2-v4 errored with no surfaced message).

QC's `/backtests/read` returns top-level `error` and `stacktrace` fields on a failed backtest. This surfaces them (capped to 1200 chars) when present, and omits the keys entirely when the backtest is clean.

## Scope (2 files, +39/-1, no catalogue churn)

```
scripts/qc-mcp-lite/server.py            | 11 +++++++++-
scripts/qc-mcp-lite/tests/test_server.py | 29 +++++++++++++++++++++++++++++
```

## Validation

`python -m pytest scripts/qc-mcp-lite/tests/test_server.py` → **41 passed** (38 existing + 3 new):
- `test_surfaces_runtime_error` — error/stacktrace present and surfaced.
- `test_no_error_field_when_clean` — clean backtest carries no empty error keys.
- `test_error_capped_to_1200_chars` — oversized fields bounded.

See #1027 (QC lane infra; resubmitted so #2950 can be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)