### PR TITLE
docs(harness): coordinate both workspace dashboards as independent lanes

### DIFF
--- a/.claude/rules/coordinator-discipline.md
+++ b/.claude/rules/coordinator-discipline.md
@@ -30,6 +30,18 @@ Bonus G.9 : "qu'est-ce que le user a demande que je n'ai pas encore fait ?" est 
 
 Workflow batch merge complet (commandes + audit pre-merge) + triage detail + incident origine : [docs/secrets-and-coord-detail.md](../../docs/reference/secrets-and-coord-detail.md#2-coordinator-discipline-ai-01).
 
+## Regle 3 : coordonner CHAQUE lane (dashboard) independamment
+
+Il existe **deux dashboards workspace** : `workspace-CoursIA` et `workspace-CoursIA-2`. **Aucun n'est "le dashboard du coordinateur"** — ce sont deux lanes co-egales. Un `lane` = **machine x workspace** : chaque machine worker qui a une lane CoursIA-2 a **AUSSI** une lane CoursIA (po-2026:CoursIA Lean / po-2026:CoursIA-2 Grothendieck ; po-2024:CoursIA QC / po-2024:CoursIA-2 MGS-.NET ; po-2025:CoursIA Python-ML / po-2025:CoursIA-2 .NET-Argumentum).
+
+Chaque cycle `/coordinate`, ai-01 doit **LIRE *et* POSTER une coordination lane-specific sur LES DEUX**, independamment :
+- **Lire** `section:"all"` des deux dashboards (pas un seul) — sinon les ASKs/blockers d'une lane restent invisibles.
+- **Poster** un contenu **propre a chaque lane** (ses ASKs, ses merges, ses dispositions) — **jamais de broadcast miroir** (copier-coller identique des deux cotes).
+- **Anti-pattern interdit** : traiter `workspace-CoursIA` comme « le mien » et `workspace-CoursIA-2` comme « celui des workers ». Les deux portent du travail worker a coordonner.
+- **Piege duplication cross-lane** : un worker peut dedoubler une livraison sur ses deux lanes (ex #2950 sur CoursIA + #2952 sur CoursIA-2 pour le meme #1027). Reconcilier explicitement : 1 canonique mergee, l'autre disposee.
+
+Source : mandat user 2026-06-14. Incident : un cycle entier ou seule la lane CoursIA-2 a ete coordonnee (broadcast miroir), ratant l'ASK greenlight PR1.5 Knot #2874 de po-2026:CoursIA et le rapport C.2 de #2953 (po-2025:CoursIA).
+
 ## Voir aussi
 
 - [.claude/rules/git-workflow.md](git-workflow.md) — branches feature/, no force push

--- a/.claude/skills/coordinate/SKILL.md
+++ b/.claude/skills/coordinate/SKILL.md
@@ -29,6 +29,7 @@ Read the following memory files to restore full situational awareness:
 
 ### Phase 2 - Gather Live State
 
+0. **Dashboards (PRIMARY channel) — read BOTH, independently**: `roosync_dashboard(action:"read", type:"workspace", section:"all")` for `workspace-CoursIA` **and** for `workspace-CoursIA-2`. These are two co-equal lanes; **neither is "the coordinator's dashboard"**. Each carries its own worker lanes (a `lane` = machine × workspace: every machine with a CoursIA-2 lane also has a CoursIA lane). Read each separately so ASKs/blockers on one lane are not missed.
 1. **RooSync inbox**: `roosync_read(mode: "inbox", status: "unread")` - Check for new messages from agents
 2. **GitHub issues**: `gh issue list --state open --limit 30 --json number,title,labels` - Current open issues
 3. **Git status**: `git log --oneline -5` - Recent commits on main
@@ -139,6 +140,6 @@ roosync_send(
 
 - **Never force push** - See CLAUDE.md rules
 - **Coordination via RooSync only** - No coordination files in git
-- **po-2023 has TWO workspaces** - GenAI_Series vs CoursIA, never conflate
+- **Two workspace dashboards, coordinated independently** - `workspace-CoursIA` and `workspace-CoursIA-2` are co-equal lanes; a `lane` = machine × workspace. Every machine with a CoursIA-2 lane ALSO has a CoursIA lane (e.g. po-2026:CoursIA = Lean Conway/Knot vs po-2026:CoursIA-2 = Grothendieck; po-2024:CoursIA = QC vs po-2024:CoursIA-2 = MGS/.NET; po-2025:CoursIA = Python/ML vs po-2025:CoursIA-2 = .NET/Argumentum). READ and POST a lane-specific coordination on EACH dashboard every cycle — never mirror-broadcast identical content, never treat one as "mine vs the workers'".
 - **Issues + PRs** - Each task = issue, each delivery = PR with review
 - **Prioritize by deadline** - QC/slides > SmartContracts > Sudoku > GenAI


### PR DESCRIPTION
Coordinator harness fix per user mandate 2026-06-14.

**Problem.** ai-01 treated `workspace-CoursIA` as "its" dashboard and `workspace-CoursIA-2` as "the workers'", then mirror-broadcast identical content. Result: the CoursIA lane was never coordinated in its own right — missed po-2026:CoursIA's PR1.5 Knot #2874 greenlight ASK and #2953's C.2 delivery report.

**Fix.** Two co-equal workspace dashboards; a `lane` = machine x workspace; every machine with a CoursIA-2 lane also has a CoursIA lane. Read AND post lane-specific coordination on BOTH every cycle, never mirror.

- `.claude/skills/coordinate/SKILL.md`: Phase 2 step 0 (read both dashboards, primary channel) + replace stale `po-2023 GenAI_Series vs CoursIA` Important-Rules line.
- `.claude/rules/coordinator-discipline.md`: new Regle 3 (per-lane coordination, anti-mirror, cross-lane duplication reconciliation e.g. #2950/#2952).

Harness-only (`.claude/`), no catalog/notebook changes. Atomic.