### PR TITLE
feat(qc): Phase 3 OOS strict + allocation sweep (See #1027)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
@@ -83,7 +83,21 @@ Voir [`.env.template`](./.env.template) pour la liste des variables nécessaires
 - **Phase 1** : livrée — `research.ipynb` (sleeve crypto seul, PR #1179) puis `quantbook.ipynb`
   (portefeuille complet 8 sous-stratégies : sleeve IBKR + matrice de corrélation mensuelle 8×8
   + blend net de coûts, exécuté via lean research container avec données QC réelles)
-- **Phase 2** : à faire — backtest unifié 2018-2025 via framework QC (MultiAlphaModel, cf `main.py`)
+- **Phase 2** : livrée (v1) — backtest unifié 2018-2025 (`main.py`, rebalance composite direct
+  des 8 sous-stratégies). Backtest QC Cloud `Phase2-DirectComposite-v7` : **Sharpe 0.916,
+  CAGR 29.2%, MaxDD -38.7%** (PSR 43.6%). Verdict : **NO BEATS** — Sharpe sous le target 1.0-1.3
+  et MaxDD au-delà du target -22% (mais dans la fourchette -35-40% anticipée, cf Caveats).
+  CAGR élevé tiré par le sleeve crypto 50%. Coûts explicites 5bps equity/10bps crypto + 5bps
+  slippage. Phase 3 = walk-forward annual + multi-seed HAR-RV-J + sweep allocation.
+- **Phase 3 (OOS)** : livrée — `main.py` paramétré (`ibkr_alloc`, `start`/`end`) pour sweep
+  sans duplication de code. **OOS strict 2023-2025** (params catalog frozen, jamais tunés sur
+  la fenêtre) : Sharpe **1.321**, CAGR 42.8%, MaxDD -16.4%, PSR 78%. Sweep allocation OOS :
+  60/40 → Sharpe 1.283 / MaxDD -15.2% ; 50/50 → 1.321 / -16.4% ; 40/60 → 1.347 / -18.8%.
+  **Verdict : INCONCLUSIVE (regime-dependent).** L'OOS BEATS le target, mais la fenêtre
+  2023-2025 est un bull crypto+equity sans crash ; le stress-inclusive IS (incluant l'hiver
+  crypto 2022) reste à Sharpe 0.916. L'allocation ne change que ~5% le Sharpe OOS — le levier
+  dominant est le régime, pas le mix. Multi-seed HAR-RV-J (passer du proxy au vrai modèle
+  seedé M12) reste à faire pour durcir le verdict.
 - Issue tracker : [#1027](https://github.com/jsboige/CoursIA/issues/1027)
 
 ## Liens

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
@@ -2,58 +2,320 @@
 from AlgorithmImports import *
 # endregion
 
-class PortfolioHybridIBKRBinance(QCAlgorithm):
-    """Portfolio Hybride IBKR (50%) + Binance (50%).
 
-    Phase 1 skeleton — signal aggregation from sub-strategies.
-    Phase 2 will implement full backtest with walk-forward.
+# ===========================================================================
+# Reality models: explicit transaction costs (README Phase 2 cost basis).
+# The default brokerage (required because IBKR rejects Crypto securities)
+# applies no meaningful fee, so without these models the backtest is
+# optimistic. Mirrors the repo's SpreadSlippageModel idiom.
+#   5bps equity commission + 10bps crypto commission + 5bps slippage.
+# ===========================================================================
+
+class PercentFeeModel(FeeModel):
+    """Charges a fixed percent of the order notional value as commission."""
+
+    def __init__(self, percent):
+        super().__init__()
+        self.percent = percent
+
+    def get_order_fee(self, parameters):
+        security = parameters.security
+        order = parameters.order
+        notional = abs(order.quantity) * float(security.price)
+        return OrderFee(CashAmount(self.percent * notional, security.quote_currency.symbol))
+
+
+class PercentSlippageModel:
+    """Constant percent slippage on fill price (market-impact approximation).
+
+    Duck-typed (no base class) to match the repo's SpreadSlippageModel style;
+    QC accepts any object exposing get_slippage_approximation(asset, order).
     """
 
+    def __init__(self, percent):
+        self.percent = percent
+
+    def get_slippage_approximation(self, asset, order):
+        return self.percent * float(asset.price)
+
+
+# ===========================================================================
+# Portfolio Hybride IBKR (50%) + Binance (50%) - Phase 2
+# ---------------------------------------------------------------------------
+# Unified backtest 2018-2025 aggregating 8 sub-strategies via a direct composite
+# rebalance. The 8 signal rules are transposed verbatim from the Phase 1 research
+# notebook (quantbook.ipynb), which validated the proxies over 2018-2025.
+#
+# Design choice (direct composite, NOT the QC Alpha framework): an earlier
+# Alpha-framework attempt (CompositeAlphaModel + HybridPortfolioPCM) produced
+# 0 total orders across 6 backtest iterations (v1-v6) -- the Insight -> PCM
+# plumbing never emitted trades. The direct composite calls set_holdings()
+# explicitly each month, so it trades by construction. This is the live
+# equivalent of the MultiAlphaModel aggregation in the Phase 1 bridge table
+# (cell 2581bd22): each strategy contributes its within-strategy target weights,
+# blended by the fixed portfolio weights.
+#
+# Brokerage: the DEFAULT model (no set_brokerage_model), because IBKR margin
+# REJECTS Crypto ("Unsupported security type: Crypto"). The default authorizes
+# both equities and crypto; explicit PercentFeeModel/PercentSlippageModel apply
+# the README cost basis. Account currency USDT so the Binance sleeve settles.
+#
+# See #1027.
+# ===========================================================================
+
+
+class PortfolioHybridIBKRBinance(QCAlgorithm):
+    """Phase 2/3 unified backtest, 8 research-faithful sub-strategies, monthly.
+
+    Phase 3 adds two backtest parameters (no code duplication across runs):
+    - ``ibkr_alloc`` (default 0.50): IBKR sleeve fraction; Binance = 1 - ibkr_alloc.
+      Drives the allocation sweep (60/40, 50/50, 40/60).
+    - ``start`` / ``end`` (default 2018-01-01 / 2025-06-01, format YYYY-MM-DD):
+      date window, so the OOS strict test (2023-2025) runs on the SAME code as
+      the in-sample (2018-2025) without a forked algorithm.
+    """
+
+    # Intra-sleeve weights (research allocation WITHIN each sleeve, fixed).
+    # The sleeve split (ibkr_alloc) is parameterized; intra weights are not
+    # (they are the catalog-research target, frozen for the OOS test).
+    INTRA_IBKR = {
+        "TrendWeather":    0.30,
+        "EMATrend":        0.25,
+        "SectorMomentum":  0.20,
+        "AllWeather":      0.15,
+        "EMA-Cross-Alpha": 0.10,
+    }
+    INTRA_BINANCE = {
+        "EMA-Cross-Crypto":  0.50,
+        "Crypto-MultiCanal": 0.30,
+        "HAR-RV-VolTarget":  0.20,
+    }
+
+    IBKR_SECTORS = ["XLK", "XLF", "XLE", "XLV", "XLY", "XLI", "XLB", "XLU", "XLP"]
+    CRYPTO_TICKERS = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "ADAUSDT", "LTCUSDT", "XRPUSDT"]
+
+    @staticmethod
+    def _parse_date(value, default):
+        """Parse a 'YYYY-MM-DD' backtest parameter into (year, month, day)."""
+        if not value:
+            return default
+        for fmt in ("%Y-%m-%d", "%Y/%m/%d"):
+            try:
+                parts = __import__("datetime").datetime.strptime(value, fmt)
+                return (parts.year, parts.month, parts.day)
+            except ValueError:
+                continue
+        return default
+
     def initialize(self):
-        self.set_start_date(2020, 1, 1)
-        self.set_end_date(2025, 6, 1)
+        # Backtest parameters (Phase 3): date window + sleeve allocation sweep.
+        start = self._parse_date(self.get_parameter("start"), (2018, 1, 1))
+        end = self._parse_date(self.get_parameter("end"), (2025, 6, 1))
+        self.set_start_date(*start)
+        self.set_end_date(*end)
+
+        ibkr_alloc = float(self.get_parameter("ibkr_alloc", "0.50"))
+        binance_alloc = 1.0 - ibkr_alloc
+        self.portfolio_weights = {}
+        for strat, w in self.INTRA_IBKR.items():
+            self.portfolio_weights[strat] = ibkr_alloc * w
+        for strat, w in self.INTRA_BINANCE.items():
+            self.portfolio_weights[strat] = binance_alloc * w
+
+        # Account currency USDT so the Binance crypto sleeve (BTCUSDT, ETHUSDT)
+        # settles natively. Equities (USD) auto-convert via the USD/USDT FX rate.
+        # Set BEFORE set_cash (canonical order).
+        self.set_account_currency("USDT")
         self.set_cash(100000)
 
-        # Brokerage: dual IBKR (equities) + Binance (crypto) model
-        # Configurable brokerage for fee sweep (default: IBKR margin with real fees)
-        self._brokerage_mode = self.get_parameter("brokerage", "ibkr")
-        if self._brokerage_mode != "none":
-            self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+        # DEFAULT brokerage (no set_brokerage_model): IBKR margin rejects Crypto.
+        # Explicit cost models below apply the README Phase 2 cost basis.
 
-        # Rebalancing
-        self.rebalance_freq = 30  # monthly
-        self.days_since_rebalance = 0
+        # IBKR sleeve (equities): 5bps commission + 5bps slippage.
+        self.spy = self.add_equity("SPY", Resolution.DAILY)
+        self.ief = self.add_equity("IEF", Resolution.DAILY)
+        self.gld = self.add_equity("GLD", Resolution.DAILY)
+        self.xlp = self.add_equity("XLP", Resolution.DAILY)
+        for sec in (self.spy, self.ief, self.gld, self.xlp):
+            sec.set_fee_model(PercentFeeModel(0.0005))
+            sec.set_slippage_model(PercentSlippageModel(0.0005))
+        self.spy, self.ief, self.gld, self.xlp = (s.symbol for s in (self.spy, self.ief, self.gld, self.xlp))
 
-        # IBKR sleeve (equities)
-        self.ibkr_tickers = ["SPY", "IEF", "GLD", "XLP", "XLK", "XLF", "XLE"]
-        self.ibkr_symbols = {}
-        for ticker in self.ibkr_tickers:
-            equity = self.add_equity(ticker, Resolution.DAILY)
-            self.ibkr_symbols[ticker] = equity.symbol
+        self.sector_symbols = {}
+        for ticker in self.IBKR_SECTORS:
+            sec = self.add_equity(ticker, Resolution.DAILY)
+            sec.set_fee_model(PercentFeeModel(0.0005))
+            sec.set_slippage_model(PercentSlippageModel(0.0005))
+            self.sector_symbols[ticker] = sec.symbol
 
-        # Binance sleeve (crypto)
-        self.crypto_tickers = ["BTCUSDT", "ETHUSDT"]
+        # Binance sleeve (crypto): 10bps commission + 5bps slippage.
+        # Only BTCUSDT has continuous data over the full window on QC; the basket
+        # rule falls back to whatever has data.
         self.crypto_symbols = {}
-        for ticker in self.crypto_tickers:
-            crypto = self.add_crypto(ticker, Resolution.DAILY, Market.BINANCE)
-            self.crypto_symbols[ticker] = crypto.symbol
+        for ticker in self.CRYPTO_TICKERS:
+            sec = self.add_crypto(ticker, Resolution.DAILY, Market.BINANCE)
+            sec.set_fee_model(PercentFeeModel(0.001))
+            sec.set_slippage_model(PercentSlippageModel(0.0005))
+            self.crypto_symbols[ticker] = sec.symbol
 
-        # Schedule rebalancing
+        # Warmup covers the longest signal lookback (vol-median 252 + EMA 200).
+        self.set_warm_up(252, Resolution.DAILY)
+
+        # Monthly rebalance at month start.
         self.schedule.on(
-            self.date_rules.month_start(),
+            self.date_rules.month_start(self.spy),
             self.time_rules.at(9, 31),
-            self.rebalance
+            self.rebalance,
         )
 
-    def rebalance(self):
-        # Placeholder for Phase 2 — equal weight within sleeves
-        ibkr_weight = 0.50 / len(self.ibkr_symbols)
-        for ticker, symbol in self.ibkr_symbols.items():
-            self.set_holdings(symbol, ibkr_weight)
+    # ---- data helper ----
+    def _close_series(self, symbol, lookback):
+        """Trailing daily close series for a single symbol, or None if no data."""
+        hist = self.history(symbol, lookback, Resolution.DAILY)
+        if hist is None or len(hist) == 0:
+            return None
+        # History(single Symbol, ...) is time-indexed; collapse any symbol level defensively.
+        if getattr(hist.index, "names", None) and \
+                "symbol" in [str(n).lower() for n in hist.index.names]:
+            try:
+                hist = hist.xs(symbol, level=0) if hist.index.nlevels > 1 else hist
+            except Exception:
+                pass
+        if "close" not in hist.columns:
+            return None
+        return hist["close"].dropna()
 
-        crypto_weight = 0.50 / len(self.crypto_symbols)
-        for ticker, symbol in self.crypto_symbols.items():
-            self.set_holdings(symbol, crypto_weight)
+    @staticmethod
+    def _ema_last(series, span):
+        return float(series.ewm(span=span, adjust=False).mean().iloc[-1])
+
+    # ---- the 8 sub-strategy signal rules ----
+    # Each returns {symbol: within-strategy weight} (sums to ~1.0 when invested, 0 when in cash).
+
+    def _trend_weather(self):
+        """SPY > SMA200 AND vol63 < 1.5 x median252 -> 70% SPY + 30% GLD ; else 60% IEF + 40% GLD."""
+        spy = self._close_series(self.spy, 400)
+        if spy is None or len(spy) < 316:
+            return {self.ief: 0.6, self.gld: 0.4}
+        rets = spy.pct_change().dropna()
+        sma200 = float(spy.iloc[-200:].mean())
+        vol63_series = (rets.rolling(63).std() * (252 ** 0.5)).dropna()
+        vol63 = float(vol63_series.iloc[-1]) if len(vol63_series) > 0 else 0.0
+        vol_med = float(vol63_series.iloc[-252:].median()) if len(vol63_series) > 0 else vol63
+        risk_on = (float(spy.iloc[-1]) > sma200) and (vol_med > 0 and vol63 < vol_med * 1.5)
+        if risk_on:
+            return {self.spy: 0.7, self.gld: 0.3}
+        return {self.ief: 0.6, self.gld: 0.4}
+
+    def _ema_trend(self):
+        """EMA50 > EMA200 on SPY -> 100% SPY ; else 100% IEF."""
+        spy = self._close_series(self.spy, 400)
+        if spy is None or len(spy) < 200:
+            return {self.ief: 1.0}
+        up = self._ema_last(spy, 50) > self._ema_last(spy, 200)
+        return {self.spy: 1.0} if up else {self.ief: 1.0}
+
+    def _sector_momentum(self):
+        """Top-3 sector ETFs by 126d momentum (positive only), equal-weight ; else IEF."""
+        moms = {}
+        for ticker, sym in self.sector_symbols.items():
+            s = self._close_series(sym, 130)
+            if s is not None and len(s) >= 127:
+                moms[sym] = float(s.iloc[-1] / s.iloc[-127] - 1.0)
+        positive = {sym: m for sym, m in moms.items() if m > 0}
+        if not positive:
+            return {self.ief: 1.0}
+        top = sorted(positive.items(), key=lambda kv: kv[1], reverse=True)[:3]
+        n = len(top)
+        return {sym: 1.0 / n for sym, _ in top}
+
+    def _all_weather(self):
+        """Static 30% SPY / 40% IEF / 15% GLD / 15% XLP."""
+        return {self.spy: 0.30, self.ief: 0.40, self.gld: 0.15, self.xlp: 0.15}
+
+    def _ema_cross_alpha(self):
+        """EMA20 > EMA50 on SPY -> 100% SPY ; else cash."""
+        spy = self._close_series(self.spy, 150)
+        if spy is None or len(spy) < 50:
+            return {}
+        up = self._ema_last(spy, 20) > self._ema_last(spy, 50)
+        return {self.spy: 1.0} if up else {}
+
+    def _ema_cross_crypto(self):
+        """SMA20 > SMA50 on BTC -> 100% BTC ; else cash."""
+        btc = self._close_series(self.crypto_symbols["BTCUSDT"], 60)
+        if btc is None or len(btc) < 50:
+            return {}
+        sma20 = float(btc.iloc[-20:].mean())
+        sma50 = float(btc.iloc[-50:].mean())
+        return {self.crypto_symbols["BTCUSDT"]: 1.0} if sma20 > sma50 else {}
+
+    def _crypto_multicanal(self):
+        """Equal-weight basket of cryptos with data."""
+        out = {}
+        for ticker, sym in self.crypto_symbols.items():
+            s = self._close_series(sym, 5)
+            if s is not None and len(s) > 0:
+                out[sym] = 1.0
+        n = len(out)
+        if n == 0:
+            return {}
+        return {sym: 1.0 / n for sym in out}
+
+    def _har_rv_voltarget(self):
+        """BTC weight = clip(0.15 / RV22, 0, 1), RV22 = std(returns, 22) x sqrt(252)."""
+        btc = self._close_series(self.crypto_symbols["BTCUSDT"], 30)
+        if btc is None or len(btc) < 23:
+            return {}
+        rets = btc.pct_change().dropna()
+        if len(rets) < 22:
+            return {}
+        rv22 = float(rets.iloc[-22:].std() * (252 ** 0.5))
+        if rv22 <= 0:
+            return {}
+        return {self.crypto_symbols["BTCUSDT"]: min(0.15 / rv22, 1.0)}
+
+    def rebalance(self):
+        if self.is_warming_up:
+            return
+
+        signals = {
+            "TrendWeather":      self._trend_weather(),
+            "EMATrend":          self._ema_trend(),
+            "SectorMomentum":    self._sector_momentum(),
+            "AllWeather":        self._all_weather(),
+            "EMA-Cross-Alpha":   self._ema_cross_alpha(),
+            "EMA-Cross-Crypto":  self._ema_cross_crypto(),
+            "Crypto-MultiCanal": self._crypto_multicanal(),
+            "HAR-RV-VolTarget":  self._har_rv_voltarget(),
+        }
+
+        # Composite: final per-symbol weight = sum over strats of (portfolio_weight x signal).
+        targets = {}
+        for strat, sig in signals.items():
+            strat_weight = self.portfolio_weights[strat]
+            for sym, w in sig.items():
+                targets[sym] = targets.get(sym, 0.0) + strat_weight * w
+
+        # Defensive log: confirms rebalance fires and produces targets (anti-0-orders).
+        self.log("Rebalance {}: {} targets, gross {:.1%}".format(
+            self.time.date(), len(targets), sum(targets.values())))
+
+        all_symbols = set([self.spy, self.ief, self.gld, self.xlp]) \
+            | set(self.sector_symbols.values()) \
+            | set(self.crypto_symbols.values())
+
+        # Liquidate anything not held this month, then apply targets. The default
+        # brokerage on a cash account cannot borrow, so total gross <= 1.0 is
+        # enforced by construction (portfolio weights sum to 1.0; cash-out strats
+        # reduce it). Sequential set_holdings is safe for gross <= 1.0.
+        for sym in all_symbols:
+            if sym not in targets or targets[sym] <= 0.001:
+                self.liquidate(sym)
+        for sym in sorted(targets, key=lambda s: str(s)):
+            w = targets[sym]
+            if w > 0.001:
+                self.set_holdings(sym, w)
 
     def on_data(self, data):
         pass


### PR DESCRIPTION
## Summary

Phase 3 OOS strict walk-forward + allocation sweep for the Portfolio Hybride IBKR/Binance (#1027). The Phase 2 composite-direct algorithm is **parametrized** so the OOS strict test runs on the **same code** as the in-sample — no forked algorithm, no duplication.

**Parametrization** (`main.py`):
- `ibkr_alloc` backtest param (default `0.50`): IBKR sleeve fraction; Binance = `1 - ibkr_alloc`. Drives the 60/40, 50/50, 40/60 allocation sweep.
- `start` / `end` backtest params (default `2018-01-01` / `2025-06-01`): date window for the OOS strict `2023-2025` run.
- `PORTFOLIO_WEIGHTS` dict → `INTRA_IBKR` / `INTRA_BINANCE` (intra-sleeve research targets, frozen) + `self.portfolio_weights` derived dynamically from `ibkr_alloc`.

The 8 signal rules and the cost basis (5bps equity / 10bps crypto + 5bps slippage) are **unchanged** — only the allocation/date plumbing moved to params.

## Validation

**IS-sanity** (`ibkr_alloc=0.50`, `2018-2025`) reproduces Phase 2 v7 **exactly** → the parametrization is behavior-preserving:

| Backtest | Sharpe | CAGR | MaxDD | PSR |
|---|---|---|---|---|
| Phase 2 v7 (pre-param) | 0.916 | 29.2% | -38.7% | 43.6% |
| Phase 3 IS-sanity (param, `0e5d9f7b`) | 0.916 | 29.2% | -38.7% | 43.6% |

**OOS strict 2023-2025** (catalog params frozen, **never tuned** on the OOS window):

| Allocation | Sharpe | CAGR | MaxDD | PSR | Backtest |
|---|---|---|---|---|---|
| 60/40 | **1.283** | 37.0% | -15.2% | 79.8% | `58db996f` |
| 50/50 | **1.321** | 42.8% | -16.4% | 78.0% | `63455524` |
| 40/60 | **1.347** | 48.5% | -18.8% | 76.0% | `aa072d45` |

## Regime decomposition (the regime-dependence proof)

To test whether the OOS edge is robust or a single-regime artifact, the composite was run **isolated on 2022** — the crypto-winter + equity-bear stress year (`064378f5`):

| Window | Sharpe | CAGR | MaxDD | Regime |
|---|---|---|---|---|
| **2022** (stress) | **-1.326** | **-32.3%** | **-34.3%** | crypto winter + equity bear |
| 2023-2025 (OOS) | 1.321 | +42.8% | -16.4% | bull crypto+equity |
| 2018-2025 (full IS) | 0.916 | +29.2% | -38.7% | mixed |

The full-period MaxDD (-38.7%) is **almost entirely the 2022 crash alone** (-34.3% in that single year). The strategy is **symmetric-and-fragile**: it loses ~32% in a crash year and gains ~43%/yr in a bull — the same magnitude, opposite sign. The OOS "BEATS" is a regime artifact, not a robust edge.

## Verdict: INCONCLUSIVE (regime-dependent)

The OOS **BEATS** the README target Sharpe (1.0–1.3) and MaxDD (≤ -22%). But it is **not robust**, now quantitatively confirmed by the 2022 isolation:

1. **Bull window.** 2023–2025 is a crypto+equity bull with **no crash**. Isolated 2022 shows Sharpe **-1.326** / MaxDD -34.3%. The stress-inclusive IS stays at Sharpe **0.916** — the conservative truth.
2. **Allocation is not the lever.** The sweep changes OOS Sharpe by only **~5%** (1.283 → 1.347). The dominant driver of the OOS outperformance is the **regime**, not the IBKR/Binance mix.
3. **No multi-seed.** The HAR-RV-J component is currently a proxy (`clip(0.15/RV22, 0, 1)`), not the real seeded M12 model. Per `feedback_multi_seed_required` / pr-review §C, the edge is not yet ≥ 2σ cross-seed.

## Remaining (Phase 3 sub-phases)

- **Multi-seed HAR-RV-J ≥ 4** (replace proxy with the real seeded M12 model) → edge ≥ 2σ cross-seed or flag noise.
- **Walk-forward annual** (train 5y → OOS 1y, roll forward) → confirms the OOS edge is not a single-window artifact (2022 isolation already shows the per-regime split).
- **Architecture bench** (composite-direct vs AlphaModel-if-repaired) under the OOS protocol.

## Notes

- The `totalOrders: 0` reported by `qc-mcp-lite read_backtest` is a known **summary artifact** (QC nests the order count below the summary level; documented in `qc-mcp-lite-totalorders-artifact` memory). Trades executed is proven by **cost-sensitivity**: the cost-applied variant (Sharpe 0.916) differs from the no-cost variant → fills happened. The 2022 MaxDD of -34.3% further confirms positions were held (a flat-cash backtest draws down ~0%).
- QC engineering preserved: default brokerage (IBKR margin rejects Crypto), account currency USDT, `PercentFeeModel`/`PercentSlippageModel` 5/10bps + 5bps.

See #1027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)