### PR TITLE
feat(lean): Conway P5 -- empty/pad wf+level preservation (P3/P4 input) (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -851,6 +851,69 @@ private theorem wf_node_elim {nw ne sw se : MacroCell}
   simp only [MacroCell.wf, Bool.and_eq_true, beq_iff_eq] at h
   tauto
 
+/-! ## P3/P4 structural input: empty + padding level/wf preservation
+
+`emptyOfLevel`, `padToLevelPlus1`, `padCenter2`, and `centerInLevelPlus2`
+build larger well-formed cells from smaller ones, used by P3 (frame
+correctness) and P4 (centering before the Hashlife result). The level and
+well-formedness of these results are structural inputs to both pillars:
+P3's frame lemma and P4's centering both presuppose the padded cell is
+well-formed at the expected level. The `emptyOfLevel_wf` and
+`padToLevelPlus1` level+wf facts below are the foundational steps;
+`padCenter2`/`centerInLevelPlus2` lift by composition. -/
+
+/-- `(emptyOfLevel n)` is well-formed — induction over `n`. The base case
+    `n = 0` is `deadLeaf.wf = true` (a leaf). The successor case: four
+    equal-level wf subtrees (each `emptyOfLevel n`, wf by IH, same level by
+    `emptyOfLevel_level`), so the node's `wf` conjunction holds. -/
+private theorem emptyOfLevel_wf (n : Nat) : (MacroCell.emptyOfLevel n).wf = true := by
+  induction n with
+  | zero => rfl
+  | succ n ih =>
+    show (MacroCell.node (MacroCell.emptyOfLevel n) (MacroCell.emptyOfLevel n)
+              (MacroCell.emptyOfLevel n) (MacroCell.emptyOfLevel n)).wf = true
+    simp only [MacroCell.wf, Bool.and_eq_true, beq_iff_eq, ih, emptyOfLevel_level]
+    trivial
+
+/-- `padToLevelPlus1 (node nw ne sw se)` has level `1 + nw.level + 1`: its
+    `nw` sub-cell `(node e e e nw)` has level `1 + e.level = 1 + nw.level`
+    (since `e = emptyOfLevel nw.level`), so the outer node has level
+    `1 + (1 + nw.level)`. -/
+private theorem level_padToLevelPlus1 {nw ne sw se : MacroCell} :
+    (padToLevelPlus1 (node nw ne sw se)).level = 1 + nw.level + 1 := by
+  simp only [padToLevelPlus1, MacroCell.level, emptyOfLevel_level]
+  omega
+
+/-- `padToLevelPlus1` preserves well-formedness: from a well-formed node it
+    produces a well-formed node one level higher. Each of the four sub-cells
+    `(node e e e nw)` etc. is well-formed (three wf equal-level empties plus
+    one original subtree) at the same level `1 + nw.level`, so the outer
+    node's `wf` conjunction holds. -/
+private theorem wf_padToLevelPlus1 {nw ne sw se : MacroCell}
+    (h : (node nw ne sw se).wf = true) :
+    (padToLevelPlus1 (node nw ne sw se)).wf = true := by
+  obtain ⟨hwa, hwb, hwd, hwe, hla, hlb, hld⟩ := wf_node_elim h
+  -- emptyOfLevel nw.level : wf, level = nw.level
+  have he_wf : (MacroCell.emptyOfLevel nw.level).wf = true := emptyOfLevel_wf nw.level
+  have he_lvl : (MacroCell.emptyOfLevel nw.level).level = nw.level := emptyOfLevel_level nw.level
+  -- The 4 outer sub-cells are all (node e e e nw) etc. Each has level 1+nw.level
+  -- and is wf (3 empties + 1 original, all wf, all equal-level). Build wf directly.
+  show (MacroCell.node
+          (MacroCell.node (MacroCell.emptyOfLevel nw.level) (MacroCell.emptyOfLevel nw.level)
+                          (MacroCell.emptyOfLevel nw.level) nw)
+          (MacroCell.node (MacroCell.emptyOfLevel nw.level) (MacroCell.emptyOfLevel nw.level)
+                          ne (MacroCell.emptyOfLevel nw.level))
+          (MacroCell.node (MacroCell.emptyOfLevel nw.level) sw
+                          (MacroCell.emptyOfLevel nw.level) (MacroCell.emptyOfLevel nw.level))
+          (MacroCell.node se (MacroCell.emptyOfLevel nw.level)
+                          (MacroCell.emptyOfLevel nw.level) (MacroCell.emptyOfLevel nw.level))).wf = true
+  simp only [MacroCell.wf, Bool.and_eq_true, beq_iff_eq]
+  -- each inner node's wf: 3 empties (wf, same level) + 1 original (wf by hwa/etc.)
+  -- and inner level equality (1 + nw.level everywhere)
+  simp only [MacroCell.wf, Bool.and_eq_true, beq_iff_eq, he_wf, hwa, hwb, hwd, hwe,
+             MacroCell.level, he_lvl, hla, hlb, hld]
+  decide
+
 /-! ## P4 structural input: level preservation (level-2 base)
 
 `hashlifeResult` on a well-formed level-`k` cell is documented to return a


### PR DESCRIPTION
## Summary

Adds three structural preservation lemmas for the padding helpers that **P3 (frame correctness) and P4 (centering) both presuppose**:

```lean
private theorem emptyOfLevel_wf (n : Nat) : (MacroCell.emptyOfLevel n).wf = true
private theorem level_padToLevelPlus1 {nw ne sw se : MacroCell} :
    (padToLevelPlus1 (node nw ne sw se)).level = 1 + nw.level + 1
private theorem wf_padToLevelPlus1 {nw ne sw se : MacroCell}
    (h : (node nw ne sw se).wf = true) :
    (padToLevelPlus1 (node nw ne sw se)).wf = true
```

These are the foundational level/wf facts for `emptyOfLevel` and `padToLevelPlus1` — the recursive pad step used by `padCenter2` and `centerInLevelPlus2` (the centering helpers P4 calls before `hashlifeResult`). Both pillars need the padded cell to be well-formed at the expected level: P3's frame lemma and P4's centering presuppose it. `padCenter2`/`centerInLevelPlus2` lift by composition (future work).

**Stacks on #2949** (level-2 base `level_hashlifeResult_of_level_two`, merged `3496909f`). Together these establish the level/wf shape inputs P4 needs, leaving **only the double-nine compositional argument** (the actual research-level block) as the open P4 target.

**Stepping stone, NOT a sorry-closer** — P4 (L1062) and P5 (L1227) remain open.

## Proof outline

- `emptyOfLevel_wf`: induction on `n`. Base = `deadLeaf.wf = true` (leaf). Succ: 4 equal-level wf subtrees (each `emptyOfLevel n`, wf by IH, same level by `emptyOfLevel_level`) → node `wf` conjunction.
- `level_padToLevelPlus1`: `simp only` the `padToLevelPlus1`/`level`/`emptyOfLevel_level`, then `omega` closes `1 + (1 + nw.level) = 1 + nw.level + 1`.
- `wf_padToLevelPlus1`: `wf_node_elim` discharges the input, build the outer node's 4 wf/equal-level sub-cells (3 empties + 1 original each), double `simp only` + `decide`.

## lean-merge-discipline §B

| # | Element | Result |
|---|---------|--------|
| 1 | `grep -c` sorry diff | **HashlifeCorrectness 2→2** (P4 L1062, P5 L1227 unchanged; lemmas sorry-free, pure addition) |
| 2 | `lake build SUCCESS` | ✅ `Conway.Life.HashlifeCorrectness` genuine (3320 jobs, olen deleted first, EXIT=0) |
| 3 | Axiom check | 0 axiom (`simp only` + `omega` + `decide`, all decidable) |
| 4 | Diff coherent | +63/0, 1 file, 0 catalog drift |

## Anti-regression D

Pure addition (+63/0, 1 file). No existing definition/theorem modified. New theorem names (`emptyOfLevel_wf`, `level_padToLevelPlus1`, `wf_padToLevelPlus1`) verified absent from codebase before addition. Proof uses only existing helpers (`wf_node_elim`, `emptyOfLevel_level`) + decidable tactics — no `sorry`, no new axioms.

See #2162