### PR TITLE
feat(lean): Conway P5 -- centerInLevelPlus2 level+wf (P4 centering input) (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -914,6 +914,57 @@ private theorem wf_padToLevelPlus1 {nw ne sw se : MacroCell}
              MacroCell.level, he_lvl, hla, hlb, hld]
   decide
 
+/-! ## P4 structural input: centerInLevelPlus2 level + wf
+
+`centerInLevelPlus2 c` embeds `c` (any level `n`) in a level-`(n+2)` cell,
+one copy of `c` per quadrant, the rest all-dead padding of level `n`. This
+is the centering helper P4 calls before running `hashlifeResult` on the
+padded cell. Its level and well-formedness are P4 structural inputs: the
+level-`(n+2)` shape is what makes `box_assez_grand` + the centered
+`toGrid (2^k, 2^k)` window meaningful, and the well-formedness is the
+missing hypothesis of P4 (the algorithm's well-formed arm). -/
+
+/-- `centerInLevelPlus2 c` has level `c.level + 2`: its `nw` sub-cell
+    `(node e e e c)` has level `1 + e.level = 1 + c.level` (with
+    `e = emptyOfLevel c.level`), so the outer node has level
+    `1 + (1 + c.level)`. -/
+theorem level_centerInLevelPlus2 (c : MacroCell) :
+    (centerInLevelPlus2 c).level = c.level + 2 := by
+  show (MacroCell.node
+          (MacroCell.node (MacroCell.emptyOfLevel c.level) (MacroCell.emptyOfLevel c.level)
+                          (MacroCell.emptyOfLevel c.level) c)
+          (MacroCell.node (MacroCell.emptyOfLevel c.level) (MacroCell.emptyOfLevel c.level)
+                          c (MacroCell.emptyOfLevel c.level))
+          (MacroCell.node (MacroCell.emptyOfLevel c.level) c
+                          (MacroCell.emptyOfLevel c.level) (MacroCell.emptyOfLevel c.level))
+          (MacroCell.node c (MacroCell.emptyOfLevel c.level)
+                          (MacroCell.emptyOfLevel c.level) (MacroCell.emptyOfLevel c.level))).level
+        = c.level + 2
+  simp only [MacroCell.level, emptyOfLevel_level]
+  omega
+
+/-- `centerInLevelPlus2` preserves well-formedness: from a well-formed `c`
+    it produces a well-formed level-`(c.level+2)` cell. Each quadrant is
+    `(node e e e c)` (or a rotation) — three wf equal-level empties plus
+    `c` (wf, same level `c.level`), so all four quadrants are wf at the same
+    level `1 + c.level`, and the outer node's `wf` conjunction holds. -/
+theorem wf_centerInLevelPlus2 (c : MacroCell) (h : c.wf = true) :
+    (centerInLevelPlus2 c).wf = true := by
+  show (MacroCell.node
+          (MacroCell.node (MacroCell.emptyOfLevel c.level) (MacroCell.emptyOfLevel c.level)
+                          (MacroCell.emptyOfLevel c.level) c)
+          (MacroCell.node (MacroCell.emptyOfLevel c.level) (MacroCell.emptyOfLevel c.level)
+                          c (MacroCell.emptyOfLevel c.level))
+          (MacroCell.node (MacroCell.emptyOfLevel c.level) c
+                          (MacroCell.emptyOfLevel c.level) (MacroCell.emptyOfLevel c.level))
+          (MacroCell.node c (MacroCell.emptyOfLevel c.level)
+                          (MacroCell.emptyOfLevel c.level) (MacroCell.emptyOfLevel c.level))).wf
+        = true
+  simp only [MacroCell.wf, Bool.and_eq_true, beq_iff_eq]
+  simp only [MacroCell.wf, Bool.and_eq_true, beq_iff_eq,
+             emptyOfLevel_wf, h, MacroCell.level, emptyOfLevel_level]
+  decide
+
 /-! ## P4 structural input: level preservation (level-2 base)
 
 `hashlifeResult` on a well-formed level-`k` cell is documented to return a


### PR DESCRIPTION
## Summary

Adds the level + well-formedness preservation facts for `centerInLevelPlus2`, the centering helper P4 calls before `hashlifeResult`:

```lean
theorem level_centerInLevelPlus2 (c : MacroCell) :
    (centerInLevelPlus2 c).level = c.level + 2
theorem wf_centerInLevelPlus2 (c : MacroCell) (h : c.wf = true) :
    (centerInLevelPlus2 c).wf = true
```

`centerInLevelPlus2` embeds `c` (any level `n`) in a level-`(n+2)` cell, one copy of `c` per quadrant, the rest all-dead padding of level `n`. **This is the centering helper P4 calls before `hashlifeResult`.** The level-`(c.level+2)` shape is what makes `box_assez_grand` + the centered `toGrid (2^k, 2^k)` window meaningful, and the well-formedness is the missing hypothesis of P4 (the algorithm's well-formed arm).

## Stacked on #2960

This branch is based on `feature/conway-p5-level-preserv-general-2162` (PR **#2960**, `emptyOfLevel_wf` + `level/wf_padToLevelPlus1`, currently OPEN). It reuses `emptyOfLevel_wf`/`emptyOfLevel_level` from #2960's diff. **Once #2960 merges, rebase to `main`.** Diff vs #2960 base = +51/0 (these 2 lemmas only).

**Suggested merge order:** #2960 first, then rebase + merge this.

## Proof outline

- `level_centerInLevelPlus2`: `show` the expanded node, `simp only [MacroCell.level, emptyOfLevel_level]`, then `omega` closes `1 + (1 + c.level) = c.level + 2`.
- `wf_centerInLevelPlus2`: `show` the expanded node, double `simp only [MacroCell.wf, Bool.and_eq_true, beq_iff_eq, emptyOfLevel_wf, h, MacroCell.level, emptyOfLevel_level]` reduces each quadrant's `wf`/`level` (3 wf equal-level empties + wf `c` at level `c.level`), then `decide` closes the literal Bool conjunction.

## lean-merge-discipline §B

| # | Element | Result |
|---|---------|--------|
| 1 | `grep -c` sorry diff | **HashlifeCorrectness 2→2** (P4 L1099, P5 L1273 unchanged; lemmas sorry-free) |
| 2 | `lake build SUCCESS` | ✅ `Conway.Life.HashlifeCorrectness` genuine (3320 jobs, olen deleted first, EXIT=0) |
| 3 | Axiom check | 0 axiom (`simp only` + `omega` + `decide`) |
| 4 | Diff coherent | +51/0 (vs #2960 base), 1 file, 0 catalog drift |

## Anti-regression D

Pure addition (+51/0, 1 file). No existing definition/theorem modified. New theorem names (`level_centerInLevelPlus2`, `wf_centerInLevelPlus2`) verified absent from codebase before addition. Proof reuses existing helpers + decidable tactics — no `sorry`, no new axioms.

See #2162