### PR TITLE
feat(z3-python): NB06 Pareto-front visualization + SMT chapeau series count (See #1206)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
@@ -17,7 +17,7 @@ Un solveur **SAT** décide si une formule booléenne est satisfiable. Un solveur
 | Série | Langage / Binding | Style | Notebooks | Statut |
 |-------|-------------------|-------|-----------|--------|
 | [**Z3/**](Z3/README.md) | C# .NET 9 / **Z3.Linq** | Déclaratif borné : on traduit des expressions LINQ en formules SMT | 5 (`01` -> `05`) | PRODUCTION / BETA |
-| [**Z3-Python/**](Z3-Python/README.md) | Python / **z3-py** | Impératif complet : accès à l'API intégrale du solveur | 3 (`01` -> `03`, en cours) | PRODUCTION |
+| [**Z3-Python/**](Z3-Python/README.md) | Python / **z3-py** | Impératif complet : accès à l'API intégrale du solveur | 6 (`01` -> `06`, série complète) | PRODUCTION |
 
 ### Z3.Linq (C#) — la porte d'entrée déclarative
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-06-Advanced-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-06-Advanced-Optimization.ipynb
@@ -5,10 +5,10 @@
    "id": "nb06-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002691,
-     "end_time": "2026-06-13T10:56:40.825892+00:00",
+     "duration": 0.00359,
+     "end_time": "2026-06-14T12:24:15.152097",
      "exception": false,
-     "start_time": "2026-06-13T10:56:40.823201+00:00",
+     "start_time": "2026-06-14T12:24:15.148507",
      "status": "completed"
     },
     "tags": []
@@ -47,16 +47,16 @@
    "id": "nb06-imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T10:56:40.832615Z",
-     "iopub.status.busy": "2026-06-13T10:56:40.832426Z",
-     "iopub.status.idle": "2026-06-13T10:56:40.863727Z",
-     "shell.execute_reply": "2026-06-13T10:56:40.862647Z"
+     "iopub.execute_input": "2026-06-14T12:24:15.159504Z",
+     "iopub.status.busy": "2026-06-14T12:24:15.159504Z",
+     "iopub.status.idle": "2026-06-14T12:24:15.186824Z",
+     "shell.execute_reply": "2026-06-14T12:24:15.186320Z"
     },
     "papermill": {
-     "duration": 0.035654,
-     "end_time": "2026-06-13T10:56:40.864474+00:00",
+     "duration": 0.032311,
+     "end_time": "2026-06-14T12:24:15.187829",
      "exception": false,
-     "start_time": "2026-06-13T10:56:40.828820+00:00",
+     "start_time": "2026-06-14T12:24:15.155518",
      "status": "completed"
     },
     "tags": []
@@ -85,10 +85,10 @@
    "id": "nb06-s1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002454,
-     "end_time": "2026-06-13T10:56:40.869596+00:00",
+     "duration": 0.002017,
+     "end_time": "2026-06-14T12:24:15.193346",
      "exception": false,
-     "start_time": "2026-06-13T10:56:40.867142+00:00",
+     "start_time": "2026-06-14T12:24:15.191329",
      "status": "completed"
     },
     "tags": []
@@ -138,10 +138,10 @@
    "id": "nb06-s2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004721,
-     "end_time": "2026-06-13T10:56:40.877405+00:00",
+     "duration": 0.003508,
+     "end_time": "2026-06-14T12:24:15.200671",
      "exception": false,
-     "start_time": "2026-06-13T10:56:40.872684+00:00",
+     "start_time": "2026-06-14T12:24:15.197163",
      "status": "completed"
     },
     "tags": []
@@ -174,16 +174,16 @@
    "id": "nb06-s2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T10:56:40.885999Z",
-     "iopub.status.busy": "2026-06-13T10:56:40.885655Z",
-     "iopub.status.idle": "2026-06-13T10:56:40.962142Z",
-     "shell.execute_reply": "2026-06-13T10:56:40.961220Z"
+     "iopub.execute_input": "2026-06-14T12:24:15.209240Z",
+     "iopub.status.busy": "2026-06-14T12:24:15.209240Z",
+     "iopub.status.idle": "2026-06-14T12:24:15.227932Z",
+     "shell.execute_reply": "2026-06-14T12:24:15.227424Z"
     },
     "papermill": {
-     "duration": 0.082935,
-     "end_time": "2026-06-13T10:56:40.963688+00:00",
+     "duration": 0.02325,
+     "end_time": "2026-06-14T12:24:15.227932",
      "exception": false,
-     "start_time": "2026-06-13T10:56:40.880753+00:00",
+     "start_time": "2026-06-14T12:24:15.204682",
      "status": "completed"
     },
     "tags": []
@@ -278,10 +278,10 @@
    "id": "nb06-s2-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.002548,
-     "end_time": "2026-06-13T10:56:40.969215+00:00",
+     "duration": 0.003123,
+     "end_time": "2026-06-14T12:24:15.235718",
      "exception": false,
-     "start_time": "2026-06-13T10:56:40.966667+00:00",
+     "start_time": "2026-06-14T12:24:15.232595",
      "status": "completed"
     },
     "tags": []
@@ -311,10 +311,10 @@
    "id": "nb06-s3-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002479,
-     "end_time": "2026-06-13T10:56:40.974256+00:00",
+     "duration": 0.003265,
+     "end_time": "2026-06-14T12:24:15.242035",
      "exception": false,
-     "start_time": "2026-06-13T10:56:40.971777+00:00",
+     "start_time": "2026-06-14T12:24:15.238770",
      "status": "completed"
     },
     "tags": []
@@ -342,16 +342,16 @@
    "id": "nb06-s3-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T10:56:40.980693Z",
-     "iopub.status.busy": "2026-06-13T10:56:40.980475Z",
-     "iopub.status.idle": "2026-06-13T10:56:40.992585Z",
-     "shell.execute_reply": "2026-06-13T10:56:40.991529Z"
+     "iopub.execute_input": "2026-06-14T12:24:15.252286Z",
+     "iopub.status.busy": "2026-06-14T12:24:15.251721Z",
+     "iopub.status.idle": "2026-06-14T12:24:15.261890Z",
+     "shell.execute_reply": "2026-06-14T12:24:15.261890Z"
     },
     "papermill": {
-     "duration": 0.016462,
-     "end_time": "2026-06-13T10:56:40.993247+00:00",
+     "duration": 0.016336,
+     "end_time": "2026-06-14T12:24:15.262896",
      "exception": false,
-     "start_time": "2026-06-13T10:56:40.976785+00:00",
+     "start_time": "2026-06-14T12:24:15.246560",
      "status": "completed"
     },
     "tags": []
@@ -426,10 +426,10 @@
    "id": "nb06-s3-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.002564,
-     "end_time": "2026-06-13T10:56:40.998555+00:00",
+     "duration": 0.002998,
+     "end_time": "2026-06-14T12:24:15.269895",
      "exception": false,
-     "start_time": "2026-06-13T10:56:40.995991+00:00",
+     "start_time": "2026-06-14T12:24:15.266897",
      "status": "completed"
     },
     "tags": []
@@ -458,10 +458,10 @@
    "id": "nb06-s4-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.00267,
-     "end_time": "2026-06-13T10:56:41.004032+00:00",
+     "duration": 0.005012,
+     "end_time": "2026-06-14T12:24:15.277908",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.001362+00:00",
+     "start_time": "2026-06-14T12:24:15.272896",
      "status": "completed"
     },
     "tags": []
@@ -493,16 +493,16 @@
    "id": "nb06-s4-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T10:56:41.010886Z",
-     "iopub.status.busy": "2026-06-13T10:56:41.010679Z",
-     "iopub.status.idle": "2026-06-13T10:56:41.046743Z",
-     "shell.execute_reply": "2026-06-13T10:56:41.045771Z"
+     "iopub.execute_input": "2026-06-14T12:24:15.287313Z",
+     "iopub.status.busy": "2026-06-14T12:24:15.287313Z",
+     "iopub.status.idle": "2026-06-14T12:24:15.326349Z",
+     "shell.execute_reply": "2026-06-14T12:24:15.326349Z"
     },
     "papermill": {
-     "duration": 0.040678,
-     "end_time": "2026-06-13T10:56:41.047483+00:00",
+     "duration": 0.04404,
+     "end_time": "2026-06-14T12:24:15.326349",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.006805+00:00",
+     "start_time": "2026-06-14T12:24:15.282309",
      "status": "completed"
     },
     "tags": []
@@ -600,13 +600,108 @@
   },
   {
    "cell_type": "markdown",
+   "id": "382a21b8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003999,
+     "end_time": "2026-06-14T12:24:15.336237",
+     "exception": false,
+     "start_time": "2026-06-14T12:24:15.332238",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Visualiser le front de Pareto\n",
+    "\n",
+    "Un tableau de nombres ne rend pas justice au concept de **compromis**. En projetant chaque point Pareto-optimal dans le plan (qualité, coût), le front devient une courbe descendante : chaque pas vers un coût plus bas coûte de la qualité. La droite `coût_min = 2 × qualité` (la frontière de faisabilité imposée par le modèle) apparaît en pointillés : on voit immédiatement que certains points Pareto-optimaux sont *strictement au-dessus* de cette borne minimale — Z3 les a choisis parce qu'à qualité fixée, plusieurs coûts sont Pareto-équivalents, et le solveur en échantillonne un. C'est précisément ce que le front de Pareto révèle qu'un simple « minimiser le coût » cacherait."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3793c9d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T12:24:15.344699Z",
+     "iopub.status.busy": "2026-06-14T12:24:15.344699Z",
+     "iopub.status.idle": "2026-06-14T12:24:15.851829Z",
+     "shell.execute_reply": "2026-06-14T12:24:15.851829Z"
+    },
+    "papermill": {
+     "duration": 0.513582,
+     "end_time": "2026-06-14T12:24:15.852834",
+     "exception": false,
+     "start_time": "2026-06-14T12:24:15.339252",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArAAAAG4CAYAAAC9/9RGAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAn0JJREFUeJzt3Qd4U2UXB/ADXZSyV8veu+y9914iooLKFBRFQHEAslFwgXsgigMHiLL3lCF7U/beLWWVAi2d3/M/fDekIW1TmjZJ+/89RpqbcW9yM07OPe95M8TGxsYKEREREZGLyOjoDSAiIiIiSgoGsERERETkUhjAEhEREZFLYQBLRERERC6FASwRERERuRQGsERERETkUhjAEhEREZFLYQBLRERERC6FASwREVEqOH/+vIwfP14OHjwoacH169dlwoQJsnfvXkdvCqVDDGCJXNDPP/8sGTJkkLNnzzp6U4ge8e+//+rrE/+6MgSbeBzmihUrJn369EnyfUVGRsrTTz8tBw4ckIoVK0paMGTIEPnzzz/l2WeflbCwMEdvDqUzDGAp3QR71k4jRoxI1W25d++efik62xe7EXAYJw8PDylRooT06tVLTp8+nerb46zPE5Glw4cP62s1sR+Tb7/9tri5ucnvv/8uGTO6/lfvokWLZOfOnXqqUqWKjB49+pHrbNmyRZ+bW7duOWQbKW1zd/QGEKWWiRMnSvHixeMs8/f3T/XADIfcoGnTpuKMGZVatWpptmjPnj3y/fffy9KlS/WQZ4ECBVJtO5z9eaKENW7cWDNynp6ektYcO3YsTgCKABavVbxOkZ21BgFczpw5Nejz9vaWtODKlSsyb948yZo1q8yYMUO+/PJL3efmjw8BLJ4bZKxz5Mjh0O2ltIcBLKUb7dq1k5o1a9p03fDwcP3yTQuZkqRo1KiRPPXUU/p33759pUyZMhrU/vLLLzJy5MjHvt/Y2Fh9TtPKl7erSe3XM9aTKVMmSYu8vLySfBsEb2PHjpW05KWXXjL9nT17dqsZWKKUlL6+nYkSOHw+e/Zs/RAuWLCgZM6cWW7fvq2Xz507V2rUqKHBV548eeT555+XS5cuxbkPZBiyZMmiy5944gn9O2/evPLmm29KdHS0XgeHGLEMkJUwDtfjEFtCDh06JM2bN9f1FypUSN577z2JiYmxet3ly5drEOrj46OZkQ4dOujtHxfWC2fOnNF/f/rpJ12WL18+/SKvUKGCfPvtt4/cDpmojh07ysqVK/VHA7Z9+vTppmzUsGHDpHDhwnofpUqVkg8//ND0mGx5ntatW2d6nAgOunTpIkeOHLF5IM3Ro0dtDvywXgTyCMjy588vTz75pJw6dcp0nbt378rw4cNNj6ds2bLyySefaNBuDo9h8ODB+nrC84bnpF69eqYBPXh+8FxgPcjmWR6SxjIcMdi9e7fUr19fb48jCt99912KvZ7xXGE/4m/cz9dff62XY5vxOsDzX7RoUfnjjz+sboN5CciJEyekW7du4ufnp48Rr2XUToaEhCS6H3AkoGTJkrrNtWvXlk2bNunzYZ6dj68u3Nq24Pbdu3eXIkWK6D7Dvnv99ddtquM0r4HFOnE/0KxZM9Nr1Xxd9n5PPi57vZbx/OIx4rFbMn+f4t+33npL/8br1HhuWLdP9sIMLKUb+KK8du1anGX4AjdMmjRJs1QIOu/fv69/40MamUgcVp8yZYoEBQXJ559/Lv/995+OvDU/LIZAtU2bNlKnTh390F+zZo1MnTpVv3gHDRqkQRmCPfzdtWtX/fKAypUrx7vNgYGB+sUYFRWl9br4EsSXubVM5qxZs6R37966DQgIcRge62vYsKFua3yHNxNifLnlzp1b/8X9YQBK586dxd3dXRYvXiyvvPKKBp+vvvrqI4dae/TooZmaAQMG6JchtqlJkyYaMGE5AggcZkR2F4ckP/vss0SfJzyvyKajRhdfkgg6cPiyQYMGWvaQ2ONEXe+GDRseCTAtYX8ieFu7dq0GWkOHDpXQ0FBZvXq1BAQE6H7FfeC5WL9+vfTv31+qVq2qQTu+uPEYP/300zj3icAJh5GN5wqvKawD9ZHffPONPpc3b96Ujz76SPr166eBujlc1r59ex0MhOf2r7/+0ucJr1Vc35w9Xs94nlEOgO1B7SYCcLwG3333XXnuued03yCAxnOKYNyyRMcQERGhr0tsx2uvvaZBLJ6fJUuW6A8aZPDi8+OPP+prBUE7fvigJhvPea5cuTTQehwI4vFaxHOH1/aOHTv0NXTx4kW9zFZ4bnCE4osvvpBRo0ZJ+fLldbnxrz3ek9iejRs36vaZw2H7c+fO6Q/axKTEazkxeG0cP35cB3nhtsZnrfHjlCjZYonSuJ9++gmRitUTrF+/Xv8uUaJE7L1790y3i4iIiM2XL1+sv79/bFhYmGn5kiVL9Ppjx441Levdu7cumzhxYpx1V6tWLbZGjRqm88HBwXq9cePG2bTtw4YN0+tv377dtOzq1aux2bNn1+VnzpzRZaGhobE5cuSIHTBgQJzbBwYG6nUtl1synoOZM2fqNl6+fDl26dKlscWKFYvNkCFD7M6dO/V65s+PoU2bNvrcmStatKje34oVK+IsnzRpUqyPj0/s8ePH4ywfMWJErJubW+z58+cTfZ6qVq2q++X69eumZfv374/NmDFjbK9evWIT06RJE9O+TwieC1xv2rRpj1wWExOj/y5YsECv895778W5/KmnntLn7eTJk6ZluJ6Xl5dpn8H06dN1uZ+fX+zt27dNy0eOHBln/5pv99SpU03L7t+/b3o+8Hq19+t58uTJpmU3b96M9fb21sc1e/Zs0/KjR48+sq+MbcC/sHfvXj0/d+7c2KQwthmPEY/V8P333+v94TmxfJ+bP2fWtiW+1/GUKVP0sZ07d860DI/J8rWC1zaeHwMek+X92+M9Cf/880+su7t77HPPPRcbHR0d5zK8DrDeCRMmpOprGc8vrofn25Ll6+Djjz+2uk+I7IElBJRu4PAnMg7mJ3PIlJhnNnft2iVXr17VrJh5PR8OAZYrV04HN1l6+eWX45zHocPkjOJftmyZ1K1bVw+bGpDBQPbLHB4LMlnIyiHLbJww6hkZYWRVbIEsHu4fA7bwOHFIEfWvRu2w+fNjZLSRUcVjtDwUjGwcMk+W2SQ8JxjQYr6dLVu21CwRMk0JQZZ23759eggXGTgDsrOtWrXS5ysxOLybWPYV/vnnH80aIWNoyWithPXhOUYWzhwOw2IdOHxsrkWLFnGybtg3gEPrOLxsudzytYOst3ntIbKqOI/XKUoL7P16fvHFF01/IzuLLDoysMgAG7AMlyX0OjcyrMjoIQtpK2Ob8b4yHxCG/Z9Q1jYx5s8LXuN4DSLDi31mr56myX1P4ugGsqXYPygvQRYbZQDGCfsRdbXjxo3T7G5qv5aJHI0lBJRuIAhMaBCX5eFPHJ4zvqAt4Qt/8+bNcZYhKLA8PIZADYd9Hxe2wQhmzFluE+oLzWtWLWXLls2m9eELEQEmvsjwhYdDoQiaDDjUjC/MrVu3PhKIIIA1DyqsHU7GdqIPZnyHERGsJCShfYJtRYCEgARBVnKhfALrMX/81rYHwb558Glsi/n2GlAyYc54viwPhRvLLV87WJflY0NNI6C2ED92UvL1jO1C7aplb1QsT+h1jm154403ZNq0aVqKgNcYDlej/jahQNTY5tKlS8dZbrR5e1yo7cVrHeUcltttS02uLZLznsRrGIMp0Q1k4cKFWoOcEJQXYT0oDUmt1zKRozGAJfq/5I6QR9DnKMYAKNTcob7QUkJfXOYqVaqk2dD4vgSRQUSwg0AEQReyYsjcoMbNcmCZtecT10GmFDWf1hjBWFoV32skvuW2ZIpT+/X8uNuKenBkThGQrVq1SjN9qMPdtm2bBsXJZRlUG4xBlObn8Rq8ceOGvPPOO/p6xo8C1Hli++IbIJma70kMukNwP3PmTK1dRYbeGmTdv/rqK62pxcDA1GDr80yU0hjAEsUDo6uNwUiWWRQsMy63x4d/QttgZHIs128OgzAA3QHiC0CTC4c0MQgHWSvzTKKt5QnGdt65cyfRbYzveTLfJ5bQWQBZY3tkX41t3b59u2bBkPGLb3swqAwDYswzV0aXg8d5jSTk8uXLj2SYMVAGEhsQlBKv56TCDySc0B0Bg/cw8A6DwOIbiGRsE94D5tuMfYLOGGigb360Ayyb5ltmDtFBAc8ZSmMw+MxgWVJkq/heq8l5T+I+MUgLgzeRsUY5iNHezrB//349vI/Bc/gRmdDr3p6vZVufZ+NxEKUU1sASxQPlBvjywRcsAjcDasHQsgm1aUmFzArYOjMNRpwjQ4VR0obg4GD9UjOHWlMckpw8ebJ+SVnCbZLLyLyZZ9pwuBWttWyF2kmUH+BQvyU8J/jCTuh5QusfjI5G8GF+GUZSI6uH58tebbSQ9ULNIjJcloznAOtD5snyOshI48sbo/jtCc+P0Y4MUBeJ8zjUj9ZYqf16thVaeBn71oBAFv1izbfF2jbjsWGb8VgN6KZg+dowAkbzOmrsG3TtSOx1jL/RjeFxGIGj5fYk9z2J5wbvrWeeeUY7SlhmOHEUBGUU2H+Wh/1T8rWMx4Qfipb16uiiYetzQ2QPzMASxQOZCgyOQNshDFTCYAyj7RCyXegb+TiHdXGob86cOXq4HAOR0NszvhnBcKgdhyDbtm2rrW+MNlrIhqCW1IAvFbTneeGFF6R69eo6+ANf/AjWMDgHmS5rX15J0bp1ay0Z6NSpkw4cQiYVWSIERRhcZQu05EEGF4dFcbgWQRcyisiK/f3331rHiS/HhJ6njz/+WL9MkXlCux+jjRZqKRPrqZuUNlq43q+//qq1m/gBgbpNbCuyVBhAg96zeC7Q5gxtpbDtyAgikMZhcrR8MoIqe0GNIl6TWBeeFzw/GNSG10R8mbWUfD3bCu3A0IILPVOx3Qhm8bpGMBnf4XFjm5GdxesNGVgEc8i8IrCzrIFFezfUAKMlG8oD8JpBL1zLwBklA9gvaC+GsgG8dzDI6XFr1fGDCo8Dzy1+0KF/qtErObnvSQSxeA1i2yxLN7DP8dq3ZTCbvV/LGNz3wQcf6L/4kYFg1jgSYM74UYX7xOPH/sR67HWUhNI5u/QyIHJiRnsdoxWUJaPNTnwtfubMmaPtsNACKVeuXNrS5uLFi3Gug7Y6aA9lyVobni1btmhrLU9PT5taah04cEDbBWXKlCm2YMGC2orqxx9/jLdlENpaoU0Prl+yZMnYPn36xO7atSvBdST2HBgWLVoUW7lyZb1vtNj68MMPTS16zLcFrYY6dOhg9T7QXghtokqVKqXPQZ48eWLr168f+8knn5haQSX2PK1Zsya2QYMG2tYpW7ZssZ06dYo9fPhwrC1sbaNltFt69913Y4sXLx7r4eGh7a7QVujUqVNxHs/rr78eW6BAAb1O6dKltX2Q0Z7IgHW++uqrcZYZLYlw/cT2B7a7YsWKui/r1aun+wDP81dffZXobe31eja2wZLl/rZsXXX69OnYfv366esR2431NmvWTPejLb755hvdB9jmmjVrxm7cuFG3xbyNFmC/tGzZUq/n6+sbO2rUqNjVq1c/0uYKrxVcL0uWLPr6Q0srtGKzbA9lSxstmDFjhrYtQys4y3U97nvS3uz5WsZ99e/fXx9T1qxZY59++mlt72ft8wyfV/jcQps7ttQie8qA/zk6iCYiooRh1ikcBka5BD14PsB81isiSj9YA0tERERELoUBLBERERG5FAawRERERORSWANLRERERC6FGVgiIiIicikMYImIiIjIpTCAJSIiIiKXwpm4rIiJidE5xzE9H+dyJiIiInoIw6dCQ0N1dkDMGOcIDGCtQPBauHBhR28GERERkdO6cOGCFCpUyBQ7YapqTEWMKZVLly4t3333nU6hDCdOnJDevXvrhCyYAvnnn3/WKaAB0xtjuuPixYvbvG52IbAC81nnyJFDdwzmyU7pbG9wcLDuYEf9iqHEcT+5Du4r18D95Dq4r9Leftq9e7eMHz9eFi9erOdPnjwpYWFhsmDBArl796588MEHpuv++eef8scff+hliI8aN24sP/30k7Rs2VJu3bqlwSgEBQVpkNqwYUM9/9Zbb+n2IFCF5s2bS69evaRPnz7y999/y4cffig7d+7Uy3Df8+bN0yDWVszAWmGUDSB4TY0ANjw8XNfDDwbnxf3kOrivXAP3k+vgvkp7++m3337TYNKIcapXr67/rl69WiIjI+PEPosWLZJBgwZJzpw59fTss8/KihUr9DLzMktfX189GerUqSNfffWV/n316lXZtWuXrFq1Ss9369ZNBg8erIFzqVKlpEOHDjJgwAANkI2AODF8JRIRERGlI//++68GmLY4f/68FC1a1HS+WLFicvHixQRvEx0drcFrly5d9DyOaOfPn1/c3d1NgW+RIkX0vsHDw0MqVaokmzZtsvkxMIAlIiIiSkcuXrwYJ1tqT6hMfeWVVzRbO3ToUJtv5+fnl2hgbI4BLBEREVE6kjlzZi03sAUypefOnTOdxyAtY+CWNUOGDNGM65w5c0ylDBgYf+XKFYmKijIFuci+4r4N2B5vb2+bHwNrYJMBKXLUiiS3ZgX3gR3H2iLnxf1kXzhc5Obm5ujNICJKlypXrizHjh2zqeNS9+7dZcaMGfovalQRmM6ePVs++eQTHQS2cuVK0+ArBK+oa8WgLE9PT9N95MuXT+tsUXuLQVz//POPBsGofzUcOXJExo4da/NjYAD7GPDLITAwUEff2eO+EByhnxp7zjov7if7Q6cPHDLi80lElLqeeuopDTzRSQDWrl2rLa5u376t33foEvDNN99I586d5YUXXtBuAWiLhc/rN954w9T+6tSpU6YBX//99598+eWXUq5cOVN9LdpizZ8/X/+ePn26Bq+TJ0/W26CTgXlWF0nBKlWq2PwY2EbLCuxAjILDLw1rXQiQBkfwil8USMMn5wsYTz9S6ihs5he58+J+su9zee/ePR2ViiAWhf32hB8auG+8P5ktd17cT66D+yrt7ac7d+5I/fr1ZevWreLj4/PYcRK6B2CwFgZ2JceIESM0G/viiy/afBtmYJMIvxCM4DV37tzJvj8GRq6B+8m+jDon48OW5QRERKknS5Ys8umnn8qZM2fE39//se8H/WHt0W4UM3r169cvSbdhAJtERs0rMq9E9PiM9xDeUwxgiYgeT3hktCw7eEVWHgqU4Ft3JW+Oi9Kmop+0r5RfMnnE/9naokULcRaonU0qhx4LmDJlitSqVUuyZs2qWZgnnnhCi4rNYdDMq6++qtlO/GJA81vM9pBYtgyFwDg0iUwPajwwO4Q9MQtHlDx8DxERJc/qw0FSe/IaeeOv/fr3nkt39F+cx/I1hxOOl1yZQwPYDRs2aHC6bds20+wPrVu31mnMDK+//rqOcps7d65eH3PtPvnkkwne70cffSRffPGFzsG7fft2re9o06aNzS0jKH443PDee+/J/fv3Hb0p5MT27dsnH3/8sallChER2dfqw0EycNYuCQ178Dkb8/8RTca/WD5g1i69Xlrk0AAWU5FhRBpGs2HkGebLRV8wzNELGET1448/yrRp03QO3Ro1auiotS1btmjQG1/29bPPPpPRo0frDBBoFYH2Dgh80daBHh+eWxRYb968WSZMmOCw7UCxOPYxpQzMj121alXTebxHcXTEVjdu3NAjJeXLlzfNukJERPYtGxg+d59IrP5nlS6PFXlz7j69flrjVMMJEbBCrly59F8EssjKGm0eAO0Z0PgWI+fiyxCixZX5bTBSDi0d4rsN2QYtMFDsvWTJEp3ube/evQ4JLNHOY+DAgeIoeE2+8847Ou0dsvsoPsec0viRlBZ9/vnn+uPS0LRpUxk2bFi8P3LwXOD56dixYypuJRFR+rHs4BW5HRYVb/BqwOUhYVGyPOCKpDXuztT+AV+KDRo0MI2IQyCKRrhotWMO05/hMmuM5ZZTpCV0GxwONz8kjvYQxjbhZLmd+JI2TvZg3I+zdzR76aWXTH9v3LjR6jbb83mJT548eayuO6UZ60OJy549ezTLjyMHN2/e1Ncu+uUhuE4I+uTVrl1bG/mbO3z4sNZ5p9TUfsl5PRojTM2f74T2M0p+LK8f33qM/rqW77PkMN6j9rxPsj/uJ9fBfeV8Vh4KlIwZHpYLJATXWxEQKF2qFLDb+p3hteA0ASxqYQMCAvTwtCMGk1k7JB4cHPxI3Syyb9hxqO2zR30fPhTQmiulB7Vgm1GKgZIMTPGGQAnlACNHjtTLDx48KMOHD9fSDIwO79q1q9YwYuAcIKONYG3q1Kmm+8RhYvy4wH3ickw1hwbHOEFERESC24TSDqwT2b23335b50Bu27atlomgifKkSZM0K//cc8/pjB/GSHU0U37ttddMoxbxIwf1zsuWLdNa6oIFC8qHH34onTp1stvzZ76fkHXFuswh84yeeqdPn44zNZ7lPsDrHL3ufv/9d9PjwcBFPH+YM/rNN9+MdxsQOA8ePFhLYTDwEfXhS5cujbNf8FygXhzlM4a8efPq5ciMAvb5woUL5dKlSzqRwLPPPqvBuBFUG19Wxuu7f//+2joOM6fgb9Si44Q6czh+/Lhm3/H+xX3jPYznCI8J+834wWEJ9491Xb9+/ZGAPjlwn3jd4DGwZ6Xz4n5yHdxXzif41l2bglfA9YJD7mrbQnvBpD6O5hQBLL6UcVgaWT3z+XXx5YogCF+e5llYdCHAZdYYy3Ed8wbpOG9e12cOX7pG0GVkYDG9Gr74LfubIaDFjkNtn2V9X0IBG9705tc3vy4CI1xuZKwQyJp/oVu7X/Mp2myBQ7o//PCDBrENGzbUyRiOHj2q24TACId769WrJzt27NAX+YABAzRAMmbKwDbhZP4YsM3G45o3b54+v7gdTpBY/SNui4b2mO0D09LheUVQ/PTTT+v+RnCGgBAzhmCbn3nmmXifTwwsQ9CKgAkzgWBGEczsYZSjWHr55Zc1iEzqGzS+QAtNofH8IFhL6HEj8G3SpIkGggjgUfKCAYYIONHIOSF4naJ0AwEsuna8++67WsaB5918nQiMLbfB/PlCSQ1+NKD0AT9cUI6BZfgRYVzXfF+b72cErZgmEHXrEydO1MvxPsFzhceBx4XegmFhYfp48OMDM7xYg/vD/SLznClTJrHnly22H9vFL1vnxf3kOrivnI+n1xmbr4sMbN7sPvq9YS/2/Mx2yQAWARsyaZhm7N9//9Upx8xh0BYCBnwBIrAxslUY6IVgyxrcB4JY3MYIWBGQohvBoEGDrN7Gy8tLT5aML27LZUYwZ5kxRSY3Psga4svcgEAL2VzjsIxxv4BsFgbOmNcgItCzHGhjKwQXCDwwW4Zxv8gCNmrUSP/+888/NTBHQGXMyIHrIoOJoNA4rG3tMRvLEYQgcELAb+vMSrgdnoNvv/1WSpYsqcsQrM6aNUt/cCD7i0CpWbNm+vpAptD8tubbgsfVs2dP035AEIvD+cjoWoPs7ltvvZXo9hmwn4zzls8BnjsEaz169NBAMCHIDq9bt06fe7weUJeNTCUyyAll4BEgz5w5U+eRNuq7f/nlF/3BZ/lcWNtP5svGjBkT5/2CDCp+QOBHjvnjs3Yf+GGBH094nZjv56+//lqqVasW5z2A7cUPQbSwK1OmzCOPydgma++z5Eqp+yX74n5yHdxXzuHWvQj5YNlh2Xb6hs23QQa2rb+fXfedM7wOHBrA4nAqZnHA4UwcEjVqVBEEoH8r/kVGB9lRZNIQHCHgRfBat27dOAO78MWJw954k6EeERk5BI34gsYXNrJNSRlJnZYcOXJEa3zja1qMy3EY2nw6OdQiI7DGD4aUrMtEuYIRvALWhQDeKF0wliV26APdJgx4HHitJHQb/BK1x69RBODIGCPARSBuC5QYIEhHJrZEiRJagpFY+Qjmm0Ym3phfGvCeKFu2bJK3ec6cOfqDBveJwBiH8pM7k8r+/ftl/fr1cfab+bZbC2CJiMg2MTGx8se20/LBsqNyJwnVixkwjsHbXdr523fKbmfg0ADW+MLHqGZzOGxtZApxOBKRPjKwCMJwmBKHnM0hyDI6GAAOheKwOA6NovwAh5/RsiulU96jRo2y+deKkf2zNkWpZTAT34jvpE7bmRzmJQ6Ws5Ilh+UhecvyCWNZYgXjSb0NSgiQzUwIgjtbglfU/iKramsQiOwyXpvIcCNLjFINZIztAY87of2EjC8yv6j5xnsJPxKRfTWvbX4ceK6MjL0lWzPyRET0qEOXQuSNP3bIsesPywkzuWeQTlUKyN97LsXbSksjiQwiU7tXTXBGLlfl8BKCxCDoxOFJnGy9H3yJoz7PqNFLLUmpSzWuaxTFmwewyblfa5CJRhCLsgoM3LKEfp2oiUTQb2RhMVoe22Vk+FD7hLpZ87pdDNrB4X3z7TQGOjk7vDYSGjCVGCN4xeFxZB5RQmGLa9euaSYczzkGW+HwPX7AoYQFZSXxQZYaQTpKYYxBYuh+gNsjk2uw3E/YPvPyE/RQLlq0qNbPGhCAJ4W1/Vy9enUd5IXsOXu/EhEl3+3wSHlvwT6Zuy9IYh+Eo6ppiWwy5Zmakj+7t7SumF/7vKJVltGVwPgXmVcEry0rOL67TUrgN006gB8BqG9EZhrBB8oD0GHh0KFDWqKBjNy4ceN04BNqa3EZSjVeeOEFU/kAJpJAKQcGViGYwmAwZLfNIXjBQDzUqiIgi2/0uTNITgkBglfU6qKVFgYfIpgzyl9wWD++HxzICLdr104DSBzGR6BXoUIF7ZyA5xf1scjGWoND89hXyNwjWDYGcVlm9nE/qF9GmQ22C/vdPDuNHzOoIUfWFdM4Y3+iBj0psJ8RSGOQHLYLjxnlQDNmzNA6YLzOsAyDvbAeDB40Oi4QEVHCkNiat+eSTFi4X25r0vVB8JrfJ6N8+HR1aVz2YUDaqoKvbB/VUvu8olUWug1gwBZqXlE2kBYzrwYGsOkE6oARMI0dO1Yb7uOwLg6jG3WoK1eu1DZOCGpwHiUbCFIN/fr10zpHtGLC/SDQMs++GllN9IpFgItyD2fva/u40H5q0aJF+rdlZwtkYy1LYgwINidPnqwDuMyDXNQfr1mzRrOnCUFbM+NQPWrG0YLMvHQGUArQt29fXQfqvjEA0JjZDtCrFvsOnT+wjzp06KCvjaQMCkTmGj92EHyj2wA6KSCoRdYeATOmg8Z9I1DHIDpnKPYnInIFxwJDZczCANlx5uEgLY8MsTKocTF5tVV58XJ/NCDN5OEmXasV0j6vGPuBBEd6+NzNEJtWo4xkQNcC1AYiOLDWRgtf2BgcZo+aWms1sOR8nHU/IVhGEO2KU+va+71knulOTx/iror7yXVwX6W8O/ejZPKi/TJnT6BEm0VlDYtmkQ971JaCObydaj/dTiBOSi3MwBIRERE5KDkyf88FmbjooNx6OCGoFM2dWcZ3rijNytqvd2tawwCWUgzqPdF4P76ODQl1bSAiIkrLTgaFyvA/d8j+wIczfrpniJVXmpWSV5qVTtP1q/bAAJZSDAbvoEbSmvhmyKKkwQQPRETkOu5FRMlHSw7IrJ2XJTr2YUlancKZ5eNn60iR3Jkdun2uggEspRiMqiciIqIH5QIrDwXK2AUH5KrORvAgeM2dKYO8/2QVaVuZ35lJwQCWiIiIKAWduXZXxi06JBuPB5uWuWWIlb51C8nwdpXE25PlAknFAJaIiIgoBYRFRMvU5Qfl522XJMqsu0CDkjll0hOVpUTeR6ffJtswgCUiIiKysxUHL8noefvlWtjDyDV/9kwytmMFnWjAmVoyuiI2dCMiIiKKR/fu3WXr1q36d1BQkDz55JNSuXJlnRLcWg/uCzfuybNf/ytP9x0k+6b1lXMfdpTIoFPSu3Z+WTu8ibSrlF+WL1+uU3Cjj7e/v7/88ssvcdaHab8pYczAEhEREVmxY8cOuXHjhk7PDZhSHbMQzps3T+7evatTs+OEWSzDI6Pli1WH5fvN5yQqNoNkLttAstXuJjdmvyPfPF9DurSobhrM9fzzz2sXGQTCmJa7XLlyGhhjlkVMEz5kyBCdmp3ixwysA+BFPm/PRXl51m559vtt8uqf+3TeYyxPKXjDDBw4UNtX4bDFvn37xBnhjezM25eaIiIipFSpUinyS7xu3bryzz//2P1+iYjSkunTp0vPnj1N5zGlevv27fVvHx8fady4scyaNUv+PXZV2n62Ub7ZdF6DV/At6S9f9G8m+bJlkqK5feLcL77nbt26ZZrVKnfu3OLl5aXnkZUNDg6WI0eOpOIjdT0MYFPZ6sNBUnvyGnnjr/2y6nCgbD9zQ9YcuSrD5+7X5WsOB6XIelesWCE///yzLFmyRK5cuaKHLFIS3pwLFiwQR8CvWqzfOPn6+kq3bt3k9OnTKb5uez7u7777TqdZrV+/vp7v06dPnMdleTIOQSEzULNmTcmRI4d+wOLDEB+w5kaPHi0jRozQqQeJiCj+75M6deqYzteoUUP++OMP/exEkLl0+QpZuHmf9Plpp5y9fk+vk1FipWcNX9k8qrU8WaPII/eJz+s5c+ZoxrVo0aLSsGFD/fz29PQ0XQcZ37Vr16bSo3RNDGBTOXgdOGuXhIah/5tIzP/ruo1/sXzArF16PXs7deqU5M+fX4MhPz8/cXd3t5rxS0uOHTsmly9flrlz58qhQ4ekU6dOEh39eFnuyMhISU3ImH/11VfSv39/07LPP/9cf3xYnlq2bCnFihWTDh066PWQZcchKNRsHThwQPr27aunlStXxpklLTQ0VOuwiIjIuosXL2oSxDB16lS5c+eOVK1aTRq26SzXspSQ4LsPvtOhdrFcsmxYY5ncvaZkzeRh9T6joqLkvffe02TDuXPnNFB94YUX5Nq1a6br4Hsa66b4MYBNJSgPGD53n0is/meVLo8VeXPuPruWEyBz99prr8n58+f1lx+CHWjatKkMHjxYhg0bJnny5JE2bdro8g0bNkjt2rX1cAaCXmTq8IYz4Haoz3n77bc1WMIbbfz48abLjfvv2rVrnPXFV19UrVo1yZQpk2YN9+7d+8h1AgICNODKkiWLfpBYvtHjky9fPt1+HOIZO3asHD58WE6ePCk7d+6UVq1a6WPOnj27NGnSRPbs2RPnttjub7/9Vjp37qxZzPfff1+XL1y4UAvvsb0lSpSQCRMmmJ6bhB437qtkyZL6C7ts2bKPZEQt7d69W390GEEpYFvxXJuffvzxRw1UkfXF4zH2D7YBAwywzqFDh2qd1ebNm0335ebmpofBZs+enejzSESUXmXOnFnCwx9O9YrP2X6jPhKf7h/I/dajJUYyiGfuIpLbx0OmPV1F5rxUV8r5ZUvwPlEih+QKvpsA9bOFChWK8/2HdXp7e6fgI3N9DGBTybKDV+R2WFS8wasBl4eERcnygCt2WzcydxMnTtQ3CDJ2COAMxmGL//77Tw9ZX7p0SQMbvKFQ64PAC0ESfi2aw+0Q2G3fvl0++ugjvf/Vq1frZcb9//TTT4+szxx+xXbs2FEL4hGwIQh+880341wHNULNmzfXIHfXrl1aCoFRoE8//XSSngPjgwBZZmQee/furQHdtm3bpHTp0vqYsdwctgeB4MGDB6Vfv356fdwOASGCYdRGoSzDCG7je9zz58/X2wwfPlyD8ZdeekkzouvXr493ezdt2iRlypTRgv74oBwEgTnWV6VKlXgzufh1j2y08WFpwI8UrIeIiKzDj398fkJgSLj0+HSJvDBjq1y5GyMRQafk3olt0uOFXrLuzWZSKOqyHhFLTOHChfU7wqhxRWIFCQskNwy4LL7PdXqAXQjspNOXmyU49H68l9+8l7TD8yP+OSgfLn/wpolP3qxesvi1honeFzJ3CISQdUPWzhyCNwSgBhx6xpsLh6+RRcTISPxSfOeddzRYypgxo+lNPW7cONN94PoIlJDZzJs3ry5HDabl+swZdUQIkJHRrFixoh4yGTRokOk6uF8Er5MnTzYtmzlzpm7j8ePHNchLDD4oPvnkE53aFh8QlSpVinP5999/r9uKzDMCagMK9xFoGoEgglg8DwhiARnYSZMmaSYaz0V8jxvrRhb8lVdeMY1iReCM5c2aNbO6zTisVKBAgXgf09GjR+W5556TkSNHassVSyEhIfp479+/r/v9m2++0X1jDvd/4cIF3QfGfiUiooeeeuopWb58hRyTQvLFupNy68RuubF2ukgGN8ns4yMzf/ldendrbxqEbJ41RbJi6dKlEhgYqEc48T2MYBVHEvG9g0QMPnvxGYzvuiJFHtTLorsBEie2BMPpGQNYO0HwGnj74WGG5LofFWPX+4sPCtLN4VcfisfNGyyjRQiypQgujTcYAlhzOFR/9erVJK0b68L9IHg1GK1KDMgCI1OJ8gFL+MWaUACLjDMCz3v37ukvWYy6R7YZGVwMYkJxPrYZdbG4DkoszKGkwRzqSdERwDyYxm1xqAe3x6Gm+B4nOkCYw3OKzHh8wsLC4jwvlsHpE088oaUPCKCtwQclDlNhv+GHBYJmBNwoLzDggxYfnAhyeaiKiOhRFZt2llFtmkvO2HqS0TOTeJesKWXL1ZQR7cpJz7olJGPGh9+VSIKg5M6Ao3Tx6dGjh56sQYkZkh7WvvfoIQawdoJsaEKQgUVQaisv94ySM7NnstZpC5QBPA4Pj7jF6Qh4U2JEOwIwDL768MMPH7kMQXNCcHg8W7ZsWgtrfigeGdTr169rAIkRoKj1ReBsOYjN8rnBtqCsAB0NLMUXbD4u1FnhF7glPMfIDONX+++//x7vTC64HC24AF0IEERPmTIlTgCL3oZ4jAxeiYjiuhoaLuPm7ZPlR65L5sb9JCokULzyFpMnKuWRcV2rSQ4r389ff/21XdaNz28cXaOEMYC1k8QO5aPvK1pn2eqDbpWka7VCktow8AeZSmQujeAI9bEIAJHRTEqAm9iIf6wLvzSRwTQCQBxaN4cBU9geDIiy1jkhIWhBhcP5lvB4cEjd6OWHw+i2DApDKQNqoYzA0NbHjceJdRqlB8Y2oPY3oXWh/th8PwAyx8gCY/BbQvWxloxMqznU42I9RETpBQZIY0zKqkNBcutehAairSv6SvtK+SWTh5tERcfIDxuOy2drT0p49IPPXu9iVaVyoewyqYu/VCn86HeKvVkesSPrGMCmErw5xi8+pK2yEhrIhbdLNm93aeefcHYxpaBOE1PjoWsBOhQgYEN9Jw5BJ6VOEgEnDl3jUDkynDlz5nzkOsgkouZ2wIAB+msT9UOoCzX36quvyowZM/RQi9H1ADVEGD3/ww8/aH1nUqFmF4EzSgTQQPqtt96yKQuJbcWhe2RtUReF5wMlDggEjUFu1h437h+1TggWUdO0ePFibZ+yZs2aeNeF2lhkfNH+y+jZ+9dff8kHH3ygg7YQvKKuyhwON+GETCseGzoQIGhdtmyZPl4ExJYZ6tatWyf5+SMickVoUYluQBhQjSP/aGGJf1ccCtTv50GNS8rsbSflXAiSEA+CVx8PkVEd/eXZWkXEzaxcgByPIzdSCX7ZTeteVd8T8b0FdHkGkandq+r1HQEDfxDwIMOHutGXX35Ze5Ei85cU6JWHrgQYbBVflg/BFoI5HCrHdRAgWpYKYKARspXIaiLYwgAstP1CZvVxBx5h0NjNmzc1u4uWXGgJhjKDxGD92N5Vq1ZplwbMZvXpp59qQJvQ40bQi3IFBOcYqIa6KASh5ofzLWFWFnRAQJmAwcjIojYK5ROWJyP4xwAA/BDBuhBII4P922+/yYsvvmi6L3SbQCbXGKRGRJSe+7AjqP1w5bH/B68PdKyQSza+01Keq1OUwasTyhCLb0SKA1k5jNzHYBnUUJrD4e4zZ87o4enHqXvEmwh9XkMsfgHi3+ze7hq8tqzwsGkyOQe8TdDvFWUM8dWd2hsGjaFzAAar2buYH90UEMRjJKyjJPe9lFC5BAbn4UcJuys4L+4n1+Hq+wplA5jpMrEjoIYi2dxkWs9aUrNYbnElMam4nxKKk1ILSwhSWasKvrJ9VEvt87oy4EENDkoG2vrnN9XgEAE6NCAjjSDPsvVXcuEDDmUhRETppQ+7rYa28Xe54DU9YgDrAAhSMUALJ0dk9sh1oFwgJWBSBSKi9AADtowjnYnB9XCktFuN1B9ETUnjescCiIiIyClhYhVMbw3BwcHaBhFHk9CNBZ1Y0OPaGoxFwCBYJHLQw9qAlodoBWic0PsbCR+0ATTWh3r++Pqz/7Xzgmw/c92m4BVwvVthSZt4iByDGVgiIiJKNgz+RWBpTEiDabbR9QWDXzEQt0OHDjqA1ZiV0Bw6u6DTTMOGDR8Z0Goe0GKwKiYMQEcawOBfBL8bN27UI5rHgkJlzeEgWXPkquy/eEuSOsoHGdgc3gn3YCfnwACWiIiIkg0dVtAe0YBsamhoqA4uwkQxmLEwvn7ijRs3trmLDFoFGir4V5ZzlwLl1a8Xyb7QLHLplvUMr62QgW3jz4HUroAlBI8pJWadIkpP+B4iSlswPXedOnVM58eMGaN9u/38/HTgKMoIOnfu/Nj3j1IBdE9p0Ky1Tg70yu+7pfqk1XLdp6j8uWDZI8FrqbyZpbL7FWnjcUQ8JfFBXBiFkt2BfdjJhTKwSPl//PHHsnv3brly5YrMnz9fe2Ya4hvU9NFHH2lzeGsw1eeECRPiLCtbtqwcPXrULtvs6emp7SkuX74sefPm1fPJGXzFQVyugfvJvs8lsjGoj8N7Ce8hInJ9Fy9eFF/fh9lLTDiDGQcxaQuyrwheMQGNeU9qWz8zTgXflbfe/1SyV24hdT5YH6em1c0np0SHXhcPtwxSt0RuaVEun7Qo7yuFc2WWJUvuSlhYdulQorIM/fuwoI9WrJP2YScXCmDRcB3N8vv16ydPPvnkI5cjqDW3fPlybapvbS56c2jgbj7LUVKnIE0IvnDRtxLbhiA2ufDGRCYK98vAyHlxP9lf5syZpUiRIi7ZV5KIrL+n0d/ZgCm70WsaMyZi9kDUua5fv96mABZTuu48e1PWHkE9a5CcvnJdLq5ZKvl7TRMPswg0R2YPyZ3LU8oV9ZNJL1eT//5dI+3LlZLcuTLr5Zgy3PiM8fbOHG8fdrSzZB921+LQALZdu3Z6ig8OO5hbuHChTrFZokSJBO8XAavlbe0JGSN88SIjZznvfVIhKMIoSxSq84vceXE/2Re+0JjNJkpb0G0A049jJkLAd/WKFSukfv36EhkZKStXrjQN8MKAL0whjqm3DSFhkRIWES0frTgqAQuC5Hb4w8P+d49sEs+8xcUjd2EpkddHWpX31Sxr9SI5pEP7qVIqb0n57acZ+lmN2RIx/TiYf14/0oc9LEIHbKHmFWUDzLy6FpcZxBUUFCRLly6VX375JdHrnjhxQqcgxew+eLOg4BsBZ3wwXzxO5jNMAN4ICdXp4UsYp+TA/eOL3ChNIOfE/ZQyWe2UmAgQ+8rImJPz4n5Ke/sKR0cRsDZv3lzPY6rtQYMG6UQsSPZg+u2hQ4fq/Zw+fVq/o88Eh8rao1flg3eHy9l9myX6zk2ZM2mQZPT0loIvzdD7wTSuGY6vk2ee7yVj32gsxfP46HJs086dO2T79u06NTg+n8uVKydt2rSJd1s93TJIlyoF9GTtcbqymFR8TznDc+U0U8kiE2NZA2tZ9/rBBx/oYfuEpp1EmcGdO3e07hWH+VEPi3nfAwIC9BCGrXWzcPz48XhvY88XAaZiw5RsDIycF/eT6+C+cg3cT2lvX6EsEH1flyxZouUE1kTHxEpA4F15d9RIiS7eQG5mL231elk83aRusWzSqEQO/Td7prj5tmvXrsm6deu0RRc6HXTs2FED58SO0KZlMan4nsJzjp68nErWBjNnzpTnnnsu0TnTzUsScDgDIyKLFi0qf/31l9bPWoPDGObTaiIDi0MgGKSV0jsGLzgE71gXP8SdF/eT6+C+cg3cT2lzX33++eeaRMKkBIY796Nk04lrsu7oVVl/9KrcuBcpUvXRWQaL5PKW5uXyScvyvlKrWE7xcIt/XUgwoawLgfLrr78uLVu2tOt4F1cUk4rvqcRisdTgEnt706ZNWlczZ86cJN82R44c+isBrTzi4+XlpSdLeAGkxgcrXnCptS56fNxProP7yjVwPzm38MhoWXbwiqw8FCjBt+5K3hyXpE1FP2lfKf560VatWum/aGn1YADWVdl26rpERD96yBkl8NWL5NSAtWX5fFIqX5Z46+JxsBizeBmZ3QYNGmgWcNiwYZIzZ067Pm5XliGV3lPO8J51iQAWjYtr1KihHQuSCr8ET506JS+88EKKbBsREVFas/pwkAyfu09um4/Yv3xHVh4KkvGLD8k0ixH7MTGxcuBSiAatuO3RwFCr9+vj6SaNSufV2zYrm1dyZ3k0eWQJmVaUB+Lo6EsvvWQaf4KZvSj9cmgAi+DSPDN65swZnTIOU8QZg67wgp07d65MnTrV6n20aNFCunbtKoMHD9bzb775ptbgoGwA9bLjxo3TF7oxIpGIiIjihwB04KxdpoapMRb/hoZFyYBZu+SrHtXF0z2jBq0YiBUc+nAwtLkC2TNpxwAErXVL5BIvd9sGP6NzwebNm/WEQWD4LseYloQGZVP64dAAdteuXdoWy2DUofbu3Vt+/vlnUyNkHDqILwBFdhXF3OaNlHFd/GJDHQjmVd62bZv+TURERAmXDSDzGl/Df9DlsSKv/rEn3vupUij7g6C1vK+Uz581yS3zUDaIrOutW7f0fKlSpXSMC1oZEjk8gG3atGmibXQGDhyop/icPXs2znkEvERERJR0qHlF2UBSZfLIKA1L5dGAFQOx8mV7vEE+aGk5b948DWABA6nbtm2r09CybzS5XA0sERERpbxVh4JMNa+2KJTTWyZ0rij1S+YRb8/kTwSAXq6YahqDhDABQuPGjTndNFnFAJaIiIjUrXsRNgevRgCLUoHkwFiYQoUKaWsmZFnR0xUtoVj6RwlhAEtEREQqOglzGyFTi6lYHxea4GPmriNHjmjPdqOPO+tcyRYMYImIiNK5oNvh8t7SI7Lz7E2bb4NMbRv/pGdf0VFg69atsmHDBu00gHIBTEKAMTGscyVbMYAlIiJKpyKjY+SXLWfl09XH5W5EtM23Q5iZzdtd2vnnT9L6Tp8+LcuWLTN1D0LLy/bt24uvb/LKECj9YQBLRESUDm0/fV3GLjwkx4IeTjqQM7OHdK5SQH7ddi7eVlqaI80gMrV71Xhn5IqvdeaSJUv0bx8fH2ndurVO+c6sKz0OBrBERETpCCYcmLLsiMzbe8m0DDHks7WKyNttykpOH09pWDqvvDl3n4SYz8T1/3+ReZ1qMROXLdAKa926dVKpUiXtAY9BW0SPiwEsERFROhAVHSO/bz8vn6w6JqHhD3u9ViqYXSY94S9VC+cwLWtVwVe2j2opywOuyIqAQAkOuSt5s/tIW38/LRuwJfOKPu3o59qmTRtT1nXIkCEMXMkuGMASERGlcbvP3ZQxCwLk8JXbpmXZvT3krTZlpUftIuKG9KoFBKldqxWSLlUKyNWrVyVfvnw64MqWaeJXrVolBw4c0PPFixeXMmXKPLhPBq9kJwxgiYiI0qjrd+7LhyuOyl+7LsZZ/nTNQvJO23KSO4uX3daF3q07d+7UMgHMqIXa1ho1akjhwoXttg4iAwNYIiKiNCY6JlZm7zwvH604JiFhkabl5fNnk/eeqCg1iuay6/ouXLggS5culcDAQD1foEAB6dChgxQsWNCu6yEyMIAlIiJKQ/ZfuCVjFgbIgYshpmVZvdzljdZl5IW6RcXdLfEygKRmXufNmyc3b94Ub29vadGihVSvXt2mcgOix8UAloiIKI1MA/vRymPy547zYj6hVtdqBWVk+3KSL2smuwatgCAVJ8yihRm1WrZsqYO1iFIaA1giIiIXFhMTK3/vvigfrDgqN+5GmJaX8c0ik7r4S50S9p2a9dKlS1ouUK1aNalVq9aDdZUpYxqoRZQaGMASERG5qEOXQ7S7wJ7zt0zLfDzdZFjLMtKnQTHxsGO5wL1792T9+vWyZ88enfYV5zFIi6UC5AgMYImIiFwMBmZh+tdft57VyQUMHSvnl9EdKohfdvuVCyBYRUusvXv3SlhYmC6rUqWKtGrVisErOQwDWCIiIheBYHL+3ksyedlRuXbnvml5ybw+MrGLvzQolceu60P/1wULFsjx48e1ttXX11e7CxQtWtSu6yFKKgawRERELuBo4G0Zu+CQ7Dh7w7TM28NNhrQoLf0bFhdPd/tnQ6Ojo+Xy5cvi6ekprVu3lrp164qbW+KzcBGlNOb+iYiIHKB79+6ydetW/fvVV1+VqlWrmk6YseqLL77Qy+7cj5L3lhyWDl9s1uD1xprpcvHbfnLuw47yeescMqhpSVPwWqxYMSlbtqzpfubMmWNaX6NGjeTMmTOJZnivXLliOp8/f37p0qWL9OvXT+rVq8fglZwGM7BERESpbMeOHXLjxg0NCuHrr782XYbJADD9KgLcRfsvy/tLD0vQ7YflAsVrNZfRUyfKW72fsNoaC0ErgldLw4cPl3Hjxsmvv/5qdZuCgoK0u8DFixdl0KBBkjdvXlO9K0oJiJwJA1giIqJUNn36dOnZs6fVy3755Rdp2LSFDF9yTracum5a7uWeUV5tVkoGNm4rmTzc5K0krhO1qwMGDJCQkBDJnj27aTmmfUV3AQTV6O/q4eGhAasRwBI5IwawREREqezff/+V119//ZHl9yKi5JMvvxOP+r3E0yx4bVk+n4zrVFEK58qc6H336tVLSwFq164tH3zwgSkQRWBaqVIl2bRpk3Ts2FGvExAQICtXrpQ7d+7odSpUqCBt2rSJE+ASOSMGsERERKkMh+kxot+AYHJFQKC89eUcuRlyWwoWq6HLC+X0lvGdKkrLCg+vm5CNGzdKkSJFJDIyUkaPHi29e/eWZcuWmS738/PTdWN9s2fPlmPHjuny3Llz62xapUqVsvtjJUoJDGCJiIhSWebMmSU8PFz/PnPtroxbdEg2Hg+Wa1uXiI9/c/Hy8JCXm5SQV5qV0nIBWyF4NbKtw4YNe2R2LKzT29tbMmTIoK2wTp06JY0bN5b69euLuztDAnIdfLUSERGlssqVK8uBgMPy15F7Mn3DaYmIjpGY+/fk3rH/pMuEWfLpgMZSLI+PXhe1qSNHjpS1a9cmeJ93797VzGuOHDn0/J9//qnTvQIyrkeOHNEJCcaOHavL6tSpoyUDxvWJXAkDWCIiolTm37C1DPxgpnjU62Va5nF2i1SsXFXmjeimGVLD2bNnNWtqeOmll7RbALoVoF41a9ascvLkSe0i0K1bN+3dioC1RIkS2nHg+vXrWkawe/duuX37tvj7++v9oCUWg1dyVQxgiYiIUsn56/dkwuJDsjqsrAQf+UH8ajwtXt7e8mKjEvLaxDaS2fPRr+UNGzbIiBEj4nQwsAYBK6Z7NSAbiwFb//33nwa1e/bs0ZpYorSAASwREVEyhUdGy7KDV2TVoSC5dS9CcmT2lNYVfaV9pfxaw4rLUSrwzb8n5X5UjGT09JaczV8U/2zh8sUrbaRUvizx3rd5j1hbIPuKwVkrVqyQW7du6bLSpUuLl5eXvPPOO5IxI+cwItfHAJaIiCgZVh8OkuFz98ntsCjJmEEkJlb03xWHAmX84kPSt35xWbDvkpy7fs90G99sXjJ6ZF/pWDl/nHIBezh37px2GAC0w0J3AczOZe/1EDmSQ3+God1Hp06dpECBAvrGWrBgQZzL+/Tpo8vNT23btk30fvFrFdPpYSo+FKmjAJ6IiCglgteBs3ZJaFiUnkfwav4vgtrP154wBa9uGTPIgEbFZe3wptKpyoPvPntDdwF0H8DUsZiitly5cgxeKc1xaACLEZOYoi6hwyMIWDEvs3HCqMqEYAq9N954Q6fLQ70P7h9F7pwGj4iI7AllAci8Sqz+l6iaRXPKsiGN5N0OFSSLl/0OgJ44cUJ++OEHCQsL0/MIVnv06CEtWrQQT09Pu62HyJk4tIQAhzVwSghqdtB42VbTpk3TqfL69u2r57/77jsdrTlz5sw4RfBERETJgZpXZFht1bNOESnrl9Vu60d9K+pcjx49quc3b94srVq10r+ZcaW0zt0VptvLly+f5MyZU5o3by7vvfeezhhiTUREhLYJQb88A4rVW7ZsKVu3bo13HZgHGicD2owA5oTGKSXh/lFwn9LroeThfnId3FeuIS3sp5WHAk01r4nB9XD9J6oWSPZ6o6Ki9DsNHQbQaQDfcyiXa9iwYYo8n2lhX6UHMam4n5zhteDUASzKB5588kkpXry4zhYyatQozdjijYv+dZauXbumrULMp+cDnDd+oVozZcoUmTBhwiPLg4ODTTOlpOSLICQkRF90HBnqvLifXAf3lWtIC/sp+NZdm4JXwPWCQ+4mu5wNPWExocHNmzf1fOHChbVUIE+ePPp8poS0sK/Sg5hU3E+hoaHiaE4dwD777LOmvytVqqQzl5QsWVKzsnjD2gsytqibNc/A4kMhb968ki1bNknpFxwO9WBd/GBwXtxProP7yjWkhf3k5nHa5usiA5s3u48eUUyObdu26dFGJGZQLoDvxpQuF0gL+yo9SM39hEHyjubUAay1Js34lYkZR6wFsLgMmVnMRmIO5xOqo0WdLU6W8AJIjTcrXnCptS56fNxProP7yjW46n66Ghouk5cekZ1nH2RBbc3AtvX3S/JjxVFFlLhlzpxZz7du3Vp8fHy0w0BqBhGuuq/SmwyptJ+c4XXg+C1IgosXL+qUePnz57d6OUZb1qhRI8580fhFgvP16tVLxS0lIqK0Jio6RmZuPiMtPtkgC/Zdtvl2yI9m93aXdv7Wv7vic+bMGR2IPH/+fD0sDAhkkXl1hgwYUbrNwN65c0ezqeZv1n379kmuXLn0hLpUzOuM7ClqYN9++20pVaqUtsUyIBPbtWtXGTx4sJ5HKQCmyqtZs6bUrl1bPvvsM23XZXQlICIiSqpdZ2/I6AUBcjTwYe1fjswe0qlyAflt+7l4W2npwf0MIlO7V9UZuWytL1y1apUcPHhQz9+7d0+XpXRJG5ErcWgAu2vXLmnWrJnpvFGHigD022+/lQMHDsgvv/yirUIw2QEOnUyaNCnO4X4Ethi8ZXjmmWd08NXYsWMlMDBQqlatqm1GLAd2ERERJebanfvywfKj8vfui3GWP1ursLzdtpzk8vGUxmXyyptz90mIxUxc+Debt7sGry0rJP4dhCOGmHhn/fr1WjaAw8FIxqADj7e3dwo+SiLXkyHWOC5BcQZxYfo9jOZLjUFcGJWKwn5nqCkh67ifXAf3lWtw9v0UHRMrf2w/Jx+vPCa3wx/2eq1YIJtMesJfqhfJ+cikBssDrsjKgCC5FRYhObw9pY2/r5YN2JJ5RaIGE/UYYzgKFiwoHTp00OSNozn7vqLU30+pGSeliUFcREREKW3v+ZsyZmGABFx60BMcsmZyl7falJXn6hTV6WAtIUjtWq2Qnh5HlixZtKcrMq3oXV69enVORkCUAAawREREInLzboR8tPKozN55QcyPTXarXkhGtCsnebM+2q0mOdmygIAA8ff312yZu7u7PP3005rNMjoOEFH8GMASEVG6FhMTK3N2XZAPVxyVW/ciTcvL+WWViV38pXbxXHbvqIMpzq9cuaIDtOrWravLkzJtOlF6xwCWiIjSrYMXQ2T0wgDZf+GWaVkWL3d5vVUZ6V2vqLi72a+WEMHqmjVrZM+ePXoerbCs9SAnosQxgCUionQn5F6kfLLqmLbAMi8X6FK1gIxqX158s9mvzyrGSiNoRfAaFhamy9AhB/1cMSkBESUdA1giIkpX5QL/7LmorbGu340wLS+VL4tM7FJR6pfMY/d1Ll++XNtjAVo6ortAkSJF7L4eovSEASwREaULR67cljELAmTXuYdTwGb2dJOhLUpL3wbFxdM9ZVoPYYZITErQtGlTqVWrFltREdkBA1giIkrTbodHyqerj8uvW89pf1dD+0p+MqZjBcmf3duu5QKYURJ9Mps0aWLKumKiHg8PD7uthyi9YwBLRERpEoLJhfsuy/vLjkhw6H3T8uJ5fGRC54o6g5Y9YfZHdBe4cOGCZlnLly+vTeWBwSuRfTGAJSKiNOd4UKiWC2w/c8O0LJNHRnmteWl5sVFx8XJPfHYsW4WHh+v0r6hzRdDs6emp5QK5c+e22zqIKC4GsERE5PS6d++uh+Hr1aun5//55x8ZP368BoywZMkSKVasmNy5HyVfrD0hMzefkaiYWAmeP1nuXz4q0XduyMHTl8S/+IOpWe/evSvNmzfX4BPy588v3333nd4HljVo0EDWrVun02XGB+tGbeuqVavkzp07uqxixYrSpk0bh02vSZRePFYAe/78eTl37pz2tMubN6++YdnLjoiIUgIymzdu3DAFr3v37pV3331XA8wCBQpIaGioHrJfcuCyvLfkiATefhCUQonGXWV8n7byVMNKUijnwxmuMGUr2lplzZpVz3/66acydOhQWbhwofZnfeGFF2Tq1KkyceLEeLcL34EoGbh//75mW9FdoESJEin6XBBREgPYs2fPyrfffiuzZ8/WWUSMX72AwyWNGjWSgQMHSrdu3TjCkoiI7Gb69OnSs2dP03kElsjGIniFq+EZZNzCANl88prpOugo8ErTkvJyk7aSyePRcgF8TxnBK77PMOgqQ4YMpsufffZZqVatmkyYMCHO8qioKJ32FdDDFb1c0dsVwbWxnIhSnk2R5pAhQ6RKlSpy5swZee+99+Tw4cMSEhIiERERWrS+bNkyadiwoYwdO1YqV64sO3fuTPktJyKidOHff/+VOnXqmM7jOwhHAhs1biwFS1aQWl0HyKbjQabLm5XNK6tfbyzDWpaxGryaa9mypU7hOnfuXPn6669Ny7EMWdpDhw6Zglz8/cUXX8jJkydN16tZs6YmcBi8EqUum95x+JV5+vRpqwXpGGGJOiKcxo0bJytWrNARmOh1R0RElFw46odWVOZZ0FUbt0nGViPF7eY9CZs3UWTvMinf4mkZ16mCtKrgGydrmhCUEcTExMj777+vp2+++SZOEIt1418kavA9CNu2bZNSpUqlwCMlIrsGsFOmTDH9jV+9CFpRI2RN27ZtbV45ERFRYjJnzmwabHXu+l25mSGbhGWpKFnuxkhGz0ySpWwDKRx5Uda80US8PZPeXQDlBAMGDJDSpUvHCWBRGoBsL44qRkdHa5YV2VYM8CIix0pSsSp+peJXJzKsREREqQGlaQcPHZZpq49Lq083SnjRehJ2Zq/ExsZIgxI5pGrGc9KjXSMNXufPny+9evVK9D5R/nbz5sMZuebMmaPrMRw7dkyOHj0qQUFBGryWKVNGXn31VZ2cgOUCRI7nntRfqfiFev36df2XiIgopVVq2FoGTpkp7vUeBKaZyzcW95vnJGbuG7I/s5dmRdFBAE6cOBGnhRU6A+zfv1//RsccfHehphZHE1966SUNTlHfWrJkSfntt99Mt9u+fbu21sKpXbt2UrZs2VR/3EQUvyT/jPzggw/krbfe0o4E/v7+Sb05ERGRTS7cuCcTFh+WVWFl5eqRH8SvxtPimclb+jcqJUMm/iE+Xo9+hW3ZskU+++wz03m0ubKmdu3a2o7LEBkZKcHBwabzqHl9++23pX///pxFiygtBLA4NIPed+hKgPZZGKVpDr36iIiIHtf9qGj5fsNp+Wr9SbkfhTpXb8nZ/EWpkDVMvnyltZT2fdD+ypoFCxYkeX3Hjx+X5cuXa53ta6+9pkcbUSrw8ssvJ/OREJHTBLDmv2yJiIiSIjwyWpYdvCIrDwVK8K27kjfHRWlT0U/aV8qvLa82Hg+WcYsOyZlrd023yZfVS94d0Uc6Vylgc3cBW6AGFp1zUO8KKD3AsoIFC8qgQYPsth4icoIAtnfv3imwGURElNatPhwkw+fuk9thUZIxg0hMrEjGy3dk5aEgDVpL58sie87fMl3fLWMG6V2vmLzeqrRkzWS/w/how/Xff//Jpk2b9G9kXDERAbKuOLJIRM7vsYZSnjp1Sn766Sf99/PPP9e2Wjj8UqRIES2SJyIisgxeB87aJfL/SRxjLP4NDY+KE7zWKpZTJnbxl/L5Hw7IsgfUumJmr2vXHszaVbx4cWnfvr1Oi05EriPJc75u2LBBKlWqpCM0582bJ3fu3NHlGOWJiQyIiIgsywaQeUXw+nAScutQIDDlyUry10v17B68AgZkIWjFNLKY+hzjOhi8EqWDAHbEiBE6nezq1avjHGrBTFyYnYSIiMgcal5RNpBY8Aq4TiaPjHardUWbrM2bN5syrtCiRQsZPHiwJmPsWVNLRE4cwB48eFC6du36yHKUEZh/QBAREcGqQ0Fa82oLXG9lQJBd1oupX9HyEdPFoswN/V4BM0l6eXnZZR1E5CI1sDly5JArV67oIRhz6KeHkZtERETmbt2LMNW6JgbXuxUWkaz13b59W1atWiUBAQF63sfHJ84sW0SUDgPYZ599Vt555x2ZO3euHnrB9LIYzfnmm2/aNH0fERGlH8Gh9+X8zXs2Xx8Z2Bzeno9dLrBjxw5Zv369RERE6HdUrVq1tMQNWVciSscB7OTJk3U+6MKFC+uHRYUKFfTfnj17yujRo1NmK4mIyKVERcfI79vPyyerjmmHAVshA9vG3/ex1okjgStXrtS/CxUqpNPIYipYIkp7klwDi4FbM2bM0NqiJUuW6NzRR48elVmzZombm1uS7mvjxo3SqVMnKVDgQXNq8xlU0OoEmV4U2ePwD66DDO/ly5cTvM/x48frfZmfypUrl9SHSUREj2n3uZvS+av/tLdrUoJXlMlm93aXdv62B51GXStUq1ZN2zl27txZp4Bl8EqUdj1WH1hABtbIwmJgF2YvyZkzZ5Lu4+7duzolbb9+/eTJJ5+Mcxmmq92zZ4+MGTNGr4P7Hzp0qH4w7dq1K8H7RS9aFO0b3N0f+2ESEZGNrt+5Lx+uOCp/7boYZ3n3GoWkfsnc8sbc/fG20tIxXhlEpnavqjNyJQblazt37tQ61z59+mgCBae+ffuyswBROpDkyG7YsGGaFcWvWwSvmLlky5YtkjlzZs3INm3a1Ob7ateunZ6syZ49u7bqMvfVV19J7dq15fz58/orOz4IWP38/JLwqIiI6HFFx8TK7J3n5aMVxyQkLNK0HH1cJ3WpKDWL5dLzWTJ5yJtz90mI+Uxc//83m7e7Bq8tKyRePnDhwgVZunSpBAYG6vkDBw5o9hUYvBKlD0kOYP/++295/vnn9e/FixdrKYFRQvDuu+/qgK6UEhISoh9O6ISQkBMnTmjJAYr2MT3glClTEgx4iYjo8ey/cEvGLAyQAxdDTMuyernLG63LyAt1i4q728NKtVYVfGX7qJayPOCKrAgIlOCQu5I3u4+09ffTsoHEMq84aoeja6h1BW9vb+3piqN0RJS+JDmARa9XI7u5bNkyefrpp6VMmTJaBoBpZVNKeHi41sT26NFDsmWLf3aWOnXqyM8//yxly5bVdl8TJkyQRo0a6WEmzLxizf379/Vk3oLFOESFU0rC/aOGK6XXQ8nD/eQ6uK9SrzXWx6uOy+ydF8SsDFWeqFpARrYrJ3mzPuizarkfPN0ySJcqBaRTJT8JDg7WWbAyZnwQ5Ma3z7A/d+/eLevWrZOwsDBdVrVqVWnZsqWOkUjotpR8fE+5hphU3E/O8FpIcgDr6+srhw8f1uL4FStWaJNoo2Y1qYO4bIUBXQiUsWOM9cXHvCQBff8Q0BYtWlT++usvLXuwBhlaBLqW8OGKwDmlXwTILOOxGR/i5Hy4n1wH91XKiomNlaWHr8vXmy/JrbCHA7RK5M4kbzUrItUKZZXYsBC5Gma//YTrYKZHJFAQ8CJwRd9xZGRxopTF95RriEnF/RQaGiouF8CiQB7BJAJYHM7HBwls3749RUb7G8HruXPn9Nd3QtlXa1BugAzxyZMn473OyJEj5Y033oiTgcUANXxQJnV9j/OCw/NonoUg58P95Dq4r1LO4cu3ZeyiQ7Ln/C3TMh9PNxnaorT0rl9UPMzKBZK7n5AUwXKjf+szzzyjJWvo68r9mrr4nnINMam4n5yhr3KSA1i0qfL399ci+u7du5um40P2dcSIESkSvKKmFY2pc+fOneT7uHPnjpw6dUpeeOGFeK+Dx2BtWkG8AFLjzYoXXGqtix4f95Pr4L6yLwzM+nT1cfl169k4M2p1rJxfRneoIH7ZM9ltPyF7hBpX1LpiwLBxVA1H/3Aix+B7yjVkSKX95Ayvg8fqL/XUU089sqx3796PFVyaZ0bPnDkj+/btk1y5cmmGF+tBKy10N0DHA2PEKS5HP1pAAX/Xrl1l8ODBeh4zgqG3LMoG0DN23LhxGlyjdpaIiGyHYHL+3ksyedlRuXbn4TiBEnl9ZGJnf2lYOo9d14dxC+gucPHigzZcOPIWFRXFVohE9AibPhW++OILGThwoKaM8XdChgwZIrZCP9dmzZqZzhuH8REMI9O7aNEiU7G+OWRjjXZdyK6iLsqADz4Eq9evX9c0esOGDbV2Cn8TEZFtjgbelrELDsmOszdMy7w93OS1FqXkxYYlxNPdfhkYjDVAiRj6uiJoRoICn/EYw5BSYyuIyLVliDWfxiQexYsX12ATh/Dxd7x3liGD1ii5OtTAog8tiqFTowb26tWrki9fPqdIyZN13E+ug/sqeULDI+XzNSfkpy1ntb+roW1FPxnTqYIUzOFt1/2E4HXu3LmmwVgoUWvdunWKf/aS7fiecg0xqbifUjNOSlYGFof2rf1NRERpA3IZiw9ckfeWHJaroQ/LBYrmziwTOleUpmXzpch6kRhBiViePHmkffv2UqJEiRRZDxGlLSwsIiJK505eDZWxCw/JllPXTcu83DPKq81KycDGJWya2tVW6Ll96NAhU2kY+riibAxZI5YLEFGKBbD4lY7ZuFCHilS1ZTPbefPmJfUuiYjITtAdBuMJMAshxhJ8/fXX2jMVKlasKL///rvpuvciouSLtSflx82n5fLf78v9y0cl+s4Nef7rtTL52bpSOFdmvR4G1GLKcAyyunnzpmk2RBz+b9Cggdav4nBiYt8dmFBm1apV2kMSs2jlzJlTL8OgXSKipEhykcSwYcO0JRVKCbJkyaIfWuYnIiJyjB07dsiNGzc0eDU899xz2t0FJyN4RTC5/OAVaTl1g3y34ZRERsdKlmrtpfqw7/XyL3tWNwWv8PLLL+vtLWFgL74Ppk6dmuB2YVKYX3/9Vf755x8NXtFJxlrrQiKiFMvAzpo1S7OsqFUiIiLnMX36dOnZs2eC1zlz7a6MW3RINh4PNi3zdMsoQ/o9JYOalpLM7z16G2PCGmueffZZqVatms5miIG85iIiImTDhg2ydetWPVqHdliNGzeW+vXr6yATHMUjIkqVABZZVhbZExE5n3///Vdef/31OMswwh8lXzlz5ZLy7frI2pB8EhH9sPSrcZm8OkireB6fx1qnn5+flgOgrhUdBMwh44terlC2bFlp27atqWzAGeZSJ6J0VEKAmir80g4LS2SiayIiSlXog20+WxUO/Z89e1Y++XOV3CjXVb6fMFTu3XgwIUyB7Jnku+eryy99az128GoexBqTD5hDfSwCVmSF0Z/bCF6JiFI9A4upXf/8808dMVqsWDHx8PCIczlmziIiotSXOXNmHVhliPDIJi//vk/WHr0qkr2keOYrIdFXT8prXerJa81LSWZP+zSiwTrxXWAM5qpRo4YuL1OmjB6x40xaRGRvSf5UQbuT3bt3y/PPP6+/9C1rnoiIyDEqV64sx44dk7x+BWT6htPy+aJtEpM5l14WeeOSxF4/K7+++ZS0qldO5s+frycMrkoOTPV64sQJnfEwMjJSB3ZVqFBBywqAwSsRpYQkf7JgnuqVK1fqFK1EROQ80O5qxp/zZdJeNzl3/Z5cW/+zRASeFA93d8mf00dm/ThdWtWrptdF0Gk+g06HDh1k//79pnZbpUuX1prahC5DS61p06bpVN0IXpF9RZ0rglgiIqcKYAsXLswp/oiInMylW2GyN1MVmb94mvhlby4ZPTOJb6fh0q9BMRnasoxk8Yr7cY++rp999lmc5ER8LC9D1hUB7ObNmzWL26hRI9PJ09MzBR4dEVEyA1j0+3v77bflu+++0xpYIiJynIioGJmx6bR8ue6EhEfGSM7mL0pUSKA0rF1dJnXxl7J+Wa3ebsGCBY+9zmvXrml7LGRdUe+K7wVMBUtE5LQBLGpf7927JyVLltQBA5aDuNBEm4iIki88MlqWHbwiqw4Fya17EZIjs6e0rugr7Svl1+ldN5+4JmMXBcjp4Lum2xT2ryPvdignT1QtaNcxCpgC1ph8AF0HmjZtKrlz59aSAo6FICKnD2DNDzkREVHKWH04SIbP3Se3w6IkYwaRmFjRf1ccCtSJCJBZ3XX2pun6uKxXvWLyeqsykt07bmIhOVAugIkI/vvvP+nfv7/Wu0KTJk3stg4iolTpQkBERCkbvA6ctUsk9sH5GIt/Q8Oj4gSv1YvkkElP+EvFAvadzvvUqVOybNkyuX79up7fu3evtG7d2q7rICJKsQD29u3bpoFb+DshHOBFRJS8sgFkXhG8/j9ejRcO3L/3hL/0qF1EMiIFayf4nEe3GcyuBVmyZNHAtVKlSnZbBxFRigewmD3lypUrOnlBjhw5rNY7xcbG6vLo6OhkbRARUXqGmleUDdgCAW5mLze7Bq87duyQNWvWSEREhH6m165dW5o1a8bWWETkegEsZlfJletBM2zMqU1ERCkDA7aMmtfE4HorA4Kka7VCdq15RfCKlono/4oBW0RELhnAmhfrs3CfiCjloNuALcEr4Hq3wiKStb7Q0FC5e/euKVCtU6eOTkiA2bTYXYCInNVjzfF369YtPcx09epViYmJiXNZr1697LVtRETpyrU79+XCzTCbr48MbA7vx5s4AJ/d+BzHUbWsWbPKyy+/rNO+urm5aWssIqI0FcAuXrxYnnvuOblz544O2DL/hY6/GcASESVNdEys/LH9nHy88pjcDret/tXIwLbx903y+s6fP6+zawUFBel5TEKA/t4chEtEaTaAHT58uPTr108mT56sExkQEdHj23fhloxZECAHL4Uk6XZIHWTzdpd2/vltvg1KBVavXi379u3T897e3tKyZUupXr06ywWIKG0HsJcuXZIhQ4YweCUiSoabdyPko5VHZfbOCxJrVvP6ZPWC0qBkHnnz7/3xttLSUDODyNTuVXVGLltLvzAFeHh4uJ7HFLAtWrTgZzkRpY8Atk2bNrJr1y4pUaJEymwREVEaFhMTK3/tuiAfrjgqN+9FmpaX9c2qkxHULv6g40s2bw95c+4+CbGYiQv/IvOK4LVlBdvLBzAwq2DBgloqgO4ChQrZr3MBEZHTB7D44Hvrrbfk8OHD2tTawyPulIWdO3e25/YREaUZAZdCZPSCAC0bMGTxctfpX3vVKyoebhlNy1tV8JXto1rK8oAr2ioL3QYwYAs1rygbSCzzikB148aN2jkGpQIoEejWrZv2c82Y8eF6iIjSRQA7YMAA/XfixImPXMaJDIiIHhVyL1I+WXVMftt+Lk65QOcqBeTdDuXFN5v1SQIQpKLHa1L6vGJSmT179uhkBGFhYdrXtWPHjnoZywWIKN0GsJZts4iIKP5g8p89l2TKsiNy/e7Dfq0l8/rIpC7+Ur9UHruu7/Lly9pdAGMVwNfXl9O/ElGa9Fh9YImIKGFHrtyWsQsDZOfZm6Zl3h5uMrRlaenXoLh4utvvMD4yrZgxEeMTEDR7eXnp9K+YBpblAkSUbgPYL774QgYOHKi1U/g7IehQQESUXoWGR8qnq0/IL1vPan9XQ/tKfjK6QwUpkMPb7uvcsGGD7Ny5U/9GxrV169Y6OQERUboOYD/99FOdvAABLP6OD2pgkxLAYoDBxx9/LLt375YrV67I/Pnz5YknnjBdjkzCuHHjZMaMGdoCpkGDBvLtt99K6dKlE7zfr7/+Wu83MDBQqlSpIl9++aVmIoiIUgo+rxbtvyzvLT0iwaH3TcuL5/GR8Z0rSpMyee2+PqN3a+PGjfUztGnTplK8eHG7roeIyGUD2DNnzlj9O7nQVBsBJiZGePLJJx+5/KOPPtKM7y+//KIfymPGjNE2XuiAgGDamjlz5sgbb7yh/Q4xp/dnn32mtzl27Jjky5fPbttORGQ4ERQqYxYGyLbTN0zLMnlklMHNSsmAxiXEy922Xq22QB/Xf//9V27cuCE9evTQIBaDs/r27Wu3dRAROTuH1sC2a9dOT/FlFxB8jh49Wrp06aLLfv31Vx2UsGDBAnn22Wet3m7atGnaKcH4MEcgi0ENM2fOlBEjRqTgoyGi9Obu/Sj5Yu0J+XHzGYkyKxdAC6yxHStI4Vz2G/WPz8SDBw/KqlWrdCpvwGAt9nMlovTI/XE+RP/++29Zv369XL169ZGuBPPmzbPLhiHTixIATHNo3ogbWdWtW7daDWAjIiK0HGHkyJGmZRjAgPvAbYiI7AGfg8sOBsqkJYcl8PaDma2gcC5vmdC5ojQvZ/sEA7bAZ+2yZcvk7Nmzej537tzSvn17Bq9ElG4lOYAdNmyYTJ8+XUe4IhuaUvNnI3gFrMMczhuXWbp27Zr2obV2m6NHj8a7rvv37+vJcPv2bf0XwXlKtw3D/ePLkO3JnBv3k+tI6X11OviOjF98WDafvG5aho4CLzcuIS83KaG9W+217sjISE0WbN++Xe8TE8c0atRI6tWrJ+7u7i79euR7ynVwX7mGmFTcT87wWkhyADtr1izNsuLXf1oxZcoUmTBhwiPLg4ODTfOGp+SLICQkRF90bHfjvLif0ua+QrnRSy+9JDVr1ozzQxg/0GvUqCE///yzaXl4ZIz8tOOK/L47SEJP7pJbm2ZJbHSUZPPJLJ9/+rG0qJxdbt+8Ls8MGKBdW2rVqpXsx4JJCNAaKzQ0VEqVKqXbhSNRqH91dXxPuQ7uK9cQk4r7CZ9JLhfA4sOzRIkSktL8/Pz036CgIMmfP79pOc5XrVrV6m3y5Mkjbm5ueh1zOG/cnzUoOcDAL/MMbOHChSVv3rySLVs2SekXHLLYWBc/GJwX91Pa21c7duzQ6VYtf4y//PLL0qlTJ7l+/boO/MSXweojV2XikiNy+Va4RIffkWuLP5FKL38qH/RvL5muHZPBgwdLjwMH9Pb4MYwjVRho9Tiw3pw5c5q2vWfPnpqJTaz7iqvhe8p1cF+5hphU3E/xDaR36gB2/Pjx+gGNQVGYXzuloOsAgs61a9eaAlYEljiUNmjQIKu38fT01KwJbmO048IOxXl8wcQHTb9xsoQXQGq8WfGCS6110ePjfkpb+wrt+RAcml/nxx9/1B/olStX1sGiF26GyfhFh2T9seCHN7wdKLly55ItH/aWzJ74CM0v58+fl3379kn16tX1hKM36HxSvnx5m7cZNfybNm2SLVu2SKtWraRu3bq6PDUSBo7C95Tr4L5yDRlSaT85w+sgyVvw9NNPy82bNzUzgYbZxge2cUoKjKTFhz5OxsAt/I0vA+wEZDHee+89WbRokY6+7dWrlxQoUCBOr9gWLVrIV199ZTqPTCq+mNB668iRIxrsol0XW8wQkTlkSDEo1IDPH3Qtef/99yUyOkZOXb0jrT7dGCd4bVgqjyx+9ymJCQuVfbt26DJ8PuFwmjHAClCjih/OtkCGF59V6F+NABZ1/BcvXrTrYyUiSmuSnIHt3bu3jvR//vnnkz2IC7VdqOkyGIfxsQ7Unr399tsafKKeDBMZNGzYUFasWBEndX3q1CmtWTM888wzmv0YO3asDvZC9ha3sRzYRUTpG4JE43MBQST6UePH8NZzt+WTlcfkwrW7ki/qwUAFv2yZZEzHCjqbFj7z0IkFpUf4EY5gtUKFCjqoyoCjR7YEoahlXb58uZw4cULP58iRQ9q2bStly5ZNscdNRJQWZIjFJ3cS+Pj4yMqVKzWYTKtQqoBaXxRDp0YNLFrkIKPtDCl5so77Ke3tK9SZHjhwQOvd8V4vVryERLl5SVhEtMRGhkts5H3JVLCcjPnmTxnSorT4eFn/vY8OJghYMZUrBloZP8bxGYKZBOOzf/9+Wbx4sQ7UQu1+/fr1dUYtdBpID/iech3cV64hJhX3U2rGSXbLwOLD3lEbS0RkL6hz1Rn68heQWbuviu+rv2mnAbhzcI1kurRb1q1cKmV8s+qAL2RcjbIATNtqDC6dNGmSNG/e3BS8AkoC0N0gIQh68YVTsmRJHUiG3q5ERJRCAezUqVP10D5qxYoVK5bUmxMROYWnnnpKfvxzvry/z13OXLtrWp43q5d0rlNEzu85o8EroL7VfNAqSpRQr4rsKUoIMPjLgLIn1OybT8ICKIPC/RiDUlG+gCAX2ZKU6qdNRJRWJTmARe0rWs8ga4D5ty0Pd6WF/oRElLZdCQmTA5mryj+Lp4lf9uaS0TOTuGXMIL3rFZPXW5WWrJkQfL5uuv6GDRviTEWNgaIJ9cru06ePZMmSRc8jyEVngY0bN2rGFZlbo/aWtflERKkUwH722WePuSoiIseKiIqRmf+dkS/WnpB7EdGSs/mLEhUSKPVrVpOJXfylQgHr5VHoEGAr1J4Z01mfPHlSp4A1ftjjqJX5YC8iIkrFLgRERM4mPDJalh28IisPBUrwrbuSN8dFaVPRT9pXyq/Tu245dU3GLjwkJ6/eMd2mUMXaMrJ9eXmyWkHJmNE+h/HRNQUDG/766y85fPiwLsuaNau0bt1a/P39WS5ARGQHTAUQkctbfThIhs/dJ7fDogRxaEysSMbLd2TloSAZt+iQlPfLJjvOPixvwnWer1tUhrcqK9kz23fUP/q4/vDDD9obFtlY9Jpt2rSp1clSiIjo8TCAJSKXD14Hztol8v+GgDEW/4aGR8UJXqsWziHvPeEv/gWzp8j2oCUW2gweOnRIOnTowDpXIqIUwACWiFy6bACZVwSviTW0xoH7iV0qynN1itqtXACQaV21apVUqVLF1EqrVq1aUrt2bZYLEBGlEAawROSyUPOKsgFbIMDNksndbsErSgXQH3b9+vUSEREhly9flldffZXzxRMRpQIGsETkslYdCjLVvCYG11sZECRdqxVK9nrPnTun3QWCgoL0fKFChbRcgIErEZETB7C7du3SEbbnz5/XzIO5efPm2WvbiIgSdOtehE3BK+B6t8Lifl4l1Z07d2T16tU6DSygFzYmLKhWrRrLBYiIUlGS0wWzZ8/WObsxVeL8+fMlMjJSByusW7dO58UlIkoNN+5GyMWbYTZfHxnYHN6eyVrnxYsXNXhFsFqjRg0ZPHiwVK9encErEZGzZmCvXbsmefLkkcmTJ8unn36qtV7obfj5559L8eLFdUpEY25wIqKUEhMTK7N3XpCPVh6VW/cibb9drEgb/6R3BAgLCzNNI1u2bFlp0KCBVKhQQQoWLJjk+yIiolTMwGIaxRYtWujfp06d0lov8PT01Hm/kX14/fXX5fvvv7fTZhERPerAxVvS9Zv/ZNT8g0kKXpEfze7tLu38bf+Rjc+2hQsXypdffqnTZ+v9ZMggrVq1YvBKROTsGVjUuo4dO1aWLFmi53PmzKltYwAf4gEBAVKpUiW5deuW6UOeiMjeta4frzwmf+w4L7FmNa9dqxWUhqVyy5t/H4i3lZYe3M8gMrV7VZ2RKzExMTGyZ88eWbt2rWZf4fjx41K1alU7PiIiIkrRABaHzjZt2iR58+bV840bN9ZBDAhau3fvLkOHDtX6VywzsrRERPYqF/h7z0X5YPlRrXk1lPHNIhO7+EvdErn1fDZvT3lz7j4JMZ+J6///ZvN21+C1ZYXEywcuXbokS5cu1ZZY4OfnJ+3bt5ciRYqk4KMkIiK7B7CdOnWKc/6rr76S8PBw/fvdd98VDw8P2bJli3Tr1k1Gjx6d5A0gIrLm0OUQGbvwkOw+d9O0zMfTTYa1LCN9GhQTD7eHFVCtKvjK9lEtZXnAFVkRECjBIXclb3Yfaevvp2UDiWVeY2NjtS0WOqzgb0z72rx5c52QgK2xiIjSQButXLlymf7GB/uIESPsvU1ElI7dDo+UaauOy69bz8ZpkdWxcn4Z3aGC+GXPZPV2CFLR47VLlQJy9epVyZcvn83Bp9FFAMFr5cqVpXXr1pIlSxb7PCAiInJMAIvBDD4+PjbfaVKvT0SE4HHBvkvy/tKjcu3OfdPyEnl9ZGJnf2lYOo9d13flyhUdiJo794MyBGRcK1asKMWKFbPreoiIyP5sSk9gfu8PPvhAP/AT+vJBHWy7du3kiy++sOc2ElEadywwVJ75fpu8Pme/KXj19nCTt9uWleVDG9k1eEUJFMoF0DUF9a747NL1eXszeCUiSksZ2H///VdGjRol48ePlypVqkjNmjWlQIECkilTJrl586YcPnxYtm7dKu7u7jJy5EjtCUtElJg796Pk8zXHZeZ/ZyXarF6gTUVfGdupohTM8aD/qj0gUD1w4ID+0MaMWsZMWlFRUVrLT0REaSyARfPuf/75R6eOnTt3rnYlwMAttJjB5AaYRnHGjBmafXVzS7xNDRGlbwgmlxy4Iu8tPSxBtx+WCxTNnVnGd64ozcrms+v6UBOLbOu5c+f0PD630F2gRIkSdl0PERE54SAutJIZPny4noiIHsfJq3dk3KIA+e/kddMyL/eM8mqzUjKwcQmberUmxZkzZ2TWrFna3xWZ1iZNmki9evX4Y5uIKD11ISAiehz3IqLky3Un5YdNpyUy+mG5QIty+WRcp4pSJHfmFFkvfnijewq6ErRp00ayZ8+eIushIqLUwwCWiFK8XGDloUCZuPiwXA550EMaCuX0lvGdKto0wUBSBAcHy6pVq6RHjx7aRguZ1hdffFFr9omIKG1gAEtEKebMtbsyftEh2XA82LTM0y2jvNSkhLzStJR4e9rvMH5ERIRs3LhR6/Nv376t9a0NGzbUyxi8EhGlLQxgicgmmDr6jTfe0PrRr7/+Wr777jvNbmIU/8CBA2XIkCGm64ZHRss360/K53PXypVFn5iWe0aHi3t0uAx//4aeb9Sokfz6669SvHjxZGV4jxw5IitWrNDAFedLliwp5cuXT+YjJiKiNBPAohNB4cKFTTPXGPClceHCBc4ZTpQG7dixQ27cuKHBKzz//PPy6quv6t8IGv39/TUYRUeSNYeDZPziQ3LxZphkyF1UCvT9UvJnzyRjO1aQJd+9F2d2LAwIHTdunAaxj+P69euyfPlyOXnypJ7PkSOH1rnmzJlTT0RElDYlOYBFpgQTGmBAhDl8ueGy6Ohoe24fETmB6dOnS8+ePU3nzQdCYea9yMhICQwJkxd/2Slrjlw1XeaeMYO82KiEDGlRSjLGREnPP/6Q9evXmy7v0KGDDBgwQEJCQh5rcBWyrghekQlGuQBO+Btts4iIKO2ybaJwi0yrZfYV0Bg8JerMMDMO1md5MrI/ln7++edHrsv6N6LkwWQmderUibPs77//Nk29WqdLbxm2JiRO8Fq/ZG5ZMayRjGhXTjJ7usu8efO0LrVq1aqm66CtVaVKlbS3tK3MfyS3bt1aypQpI6+88oo0a9aMExIQEaUTNmdgUfsGCAjHjBmjM9iYf6Fs3749zheTvezcuTPOF1ZAQIC0atVK6/Hiky1bNjl27JjpvLWAm4hsd/HiRfH1jdst4KmnnpI8lRrLiJ/XyrKZoyVv5+LikbuQ+GbzktEdKkjHyvnjvPd+/PFH6d+//yP37efnp/efGMz6h3IBlAlgEgLImzdvnMwwERGlDzYHsHv37jVlYA8ePCienp6my/A3pph988037b6B+IIy98EHH+gADTQjjw++NPGlSET2gR+s4eEPW2BduhUmkxYflhWHAvGTUbwKlJHw0ztlUJdGMqxVGcni5f7IZALbtm3TGf0s4X69veOfMhaDxP777z/N0uJvTFnduHFjyZIli50fJRERpbkA1qhb69u3r3z++eea5UxtaJPz22+/aTY4oawqyhmKFi2qM+9Ur15dJk+erIc6iejxVK5cWY9q+OYvKD9sPi2fzF4rMTkK6WXR90JELh+Sj0a8JP07VpD58+fryXxg1syZM6Vr166aPbWEDgJjx461ut4TJ05o1hU19oA6e9TNMnglIkrfkjyI66effhJHWbBggdy6dUv69OkT73XKli2rX5b4wsXAkE8++UTq168vhw4dkkKFHnzhWrp//76eDBhVDQiAcUpJuH9ktVN6PZQ86X0/devWTX78c75M3ucup6/dlevbFsj9i4fE3cND8mX1kilj3pa+3Tvr83P8+HHJmjWr6bnCv6hNx8ny+Tt79qyWCKEO1vyy0NBQWbp0qakUCPeHelf8EMWP14T2Q3rfV66C+8l1cF+5htTcT87wWsgQi0ebBM2bN0/w8nXr1klKQXsclCssXrzY5ttgdDT6QWJWnkmTJlm9zvjx42XChAmPLDe+iFP6RWCMwDZvL0TOJT3vp6t3ImTqquPy5/gB4vf8J5LRM5NkzCDSrUpeGVi3gGTNFPd3MH5g4r2GdnuJef/993UQ2HPPPRdn+b1797RmFu9fHEVB+y4vLy+btjc97ytXwv3kOrivXENMKu4nJBkwgBbrc8QR+SRlYJctW6YDJ1Drag5fMPv27dPBVb1795aUcu7cOVmzZo2OZE4KjEpGb0qjT6Q1I0eONA1SMzKw+PJF/W1K7xi84JBRwrr4weC80uN+ioyOkV+2nJPP156QuxHRkrP5ixIVEih1a1SViZ0rSoUC2eL9rLBVqVKltKMInlO058ufP7/pMvSaRS9Xy5Z9iUmP+8oVcT+5Du4r1xCTivvJGbo7udvSKBwz7CBQRQD76aefxpvFRO1pSkHpAr7IUP+WFDg8iUFnxqhla5DZsZbdwQsgNd6seMGl1rro8aWV/YRZspYdvCKrDgXJrXsRkiOzp7Su6CvtK+WXTB4Ppnbddvq6jF0YIMeDHr6nC1asLSPalpOnahSSjEjB2sHQoUP1B+PKlSu1zAdHSlAGBMmZSSut7Ku0jvvJdXBfuYYMqbSfnOF1kGgAiykjUXeKerSEIFtSu3ZtrTlNiV8VCGCR4cUIZHO9evWSggULypQpU/T8xIkTpW7duprZwXZ//PHHmr198cUX7b5dRK5m9eEgGT53n9wOi9IygJhY0X/RTQCzZ43rWEE2n7wu8/deMt0G4yV71i4ib7Upq8GuvRjt99BjFgM08cGLCQiMAJaIiOixA1hkX19//XV58sknEzx8v3Xr1hRLKaN0AFPY9uvX75HLsNz8lwB6RWJmn8DAQD38WKNGDdmyZYtUqFAhRbaNyJWC14Gzdon8v+o9xuJfBLXD5x6Ic5vKhbLLpC7+UqXwo90DkgODt1BqYMyYhZIdHF1h+zsiIrJLAIu2N8h+4hAfIJA1hzFgqF3btWuXTnCQEjD6OL6xZsjemEOJQ3xlDkTpFcoGkHlF8GrLqM1smdzlnXbl5NlaRcTNTuUC5j9IN2/ebOovi4lJMAkKJxwhIiK7D+JCBwCwnK8c2U8c8sOhewSaROR8UPOKDKutUC7wXJ2iKbItRYoU0WC1Zs2a2tUkoUkMiIiIXL4PLBE9HgzYMmpeE4Pr/XfyurxQr5hd1o0yH7RcMSYTQeuVwYMHS+7cue1y/0RElP4kOYA17N69W2fQAXwxoVUVETkndBuwJXgFXO9WWESy13n37l1ZvXq1ttlDfTxmxzNm0GLwSkREqRrAYtDFs88+q7WnxrSQGO3frFkzmT17tvYfIyLngu4BScnA5vD2TFbXEPzAXbt2rYSHh+syDKJ0hrYrRESUNiT5G+W1117Tw4Ho2Yj5yXHCJAbo5YiOBUTkfNDnNSkZ2Db+vo+1nosXL8qMGTO07R6CV0xMgBZ2nTt31gFbREREDsnArlixQkcRmzcZR3YF/WI5iIvIOV29/SATmhj0Acjm7S7t/B/OiGUr/IidOXOmZmBRMoABWhioxcwrERE5PIDFlxOmZ7WEZbiMiJxHTEysfLjiqEzfeDrR62oTqwwiU7tXNc3IlRSYdhmTmYSFhWlrLKPelYiIyN6SnBpBVgXTP16+fNm07NKlSzrZQYsWLey9fUT0mCKjY+TNv/fHCV47VymgGVYw2rsa/2L5jBdqSssKtpUPoP8zMq7GZARGu72uXbsyeCUiIufKwH711Vdaz1asWDGdPQcuXLgg/v7+8ttvv6XENhJREt2LiJJXft8j/x4LNgWpk57w196umNRgecAVWRkQpN0GMGALNa8oG7Al84oM67p163TyEkwwgpKinj176mWcjICIiJwygEXQumfPHv3SOnr0qC5DPWzLli1TYvuIKIlu3o2Qvj/vlH0Xbul5T/eM8sWzVaXt/+taEaR2rVZIT0mBYHX//v3aGgstsqBSpUqsfSciItfoA4ssC2rccCIi53HpVpj0+nG7nAp+EGBm9XKXGb1rSt0Syeu7GhQUpJ0FMCkBoF1e+/btpXjx4nbZbiIiohSpgcUhQ3QbwEhjSyEhITqZwaZNm5K0ciKyn2OBofLkN/+Zgtd8Wb3kr5frJTt4hdOnT2vw6unpqT9cX375ZQavRETk/BnYzz77TAYMGKAjjS1lz55dXnrpJZk2bZo0atTI3ttIRInYefaG9P95p9wOj9LzJfL4yC/9akvhXI/XexXlAigTMAZjobsAfrzWrVtX3+9EREQukYFF7Vvbtm3jvRx1cJh9h4hS1+rDQfL8D9tNwWuVQtll7sv1Hjt4DQ4Oll9++UV++ukniYp6cJ9ubm7aYYDBKxERuVQGFjVw1vq/mu7I3V2/+Igo9czecV5GzT9ommWrUek88t3zNcTHK+nl7REREbJhwwbZunWrqd8zWmUZ3UaIiIichc3fcgULFtQpY0uVKmX18gMHDui0kUSU8nCI/+v1J+WTVcdNy56oWkA+eqqKdh1I6n0dPnxYVq5caapxL1eunB5xyZEjh923nYiIKNUCWIw4HjNmjH6pYZpIy76Q48aNk44dOyZ7g4go8dm1Jiw+JL9sPWda1r9hcXm3fXnJaMxKkISs65w5c+TUqVN6PmfOnNKuXTspU6aM3bebiIgo1QPY0aNHy7x58/SLbfDgwVK2bFldjl6wX3/9tURHR8u7775rtw0jokfdj4qWN/7aL0sPXDEtG9munAxsXOKxJhEwyoJQAtSwYUNp0KBBgqVCRERELhXA+vr6ypYtW2TQoEEycuRIPewI+NLE4A4EsbgOEaWM0PBIeWnWbtly6rqed8uYQT7qVlm61bB9QgK8b48dOyZFihSRzJkz6/sXR06wPFeuXCm49URERPaTpJEeRYsWlWXLlsnNmzfl5MmT+qVXunRpPexIRCknOPS+9Plphxy6/KBGNZNHRvn2uRrSrFw+m+/jxo0bsnz5cjlx4oTUrFnTVPLD9y8REaWLmbjwhVerVi37bw0RPeLc9bvSa+YOOXf9np7PkdlDZvapJdWL2BZ4RkZGyn///SebN2/WtlhoiYXsK36APk7ZARERkUsGsESUOgIuhWjm9dqdCD1fIHsm+bV/bSmVL6tNtz9+/LhmXXHUBEqWLKkDMnPnTv7sXERERI7CAJbISW05eU0Gztotd+4/mEygjG8WnV0rf3Zvm26/c+dOWbp0qf6NGfRQq47poJl1JSIiV8cAlsgJLTlwWd6Ys18iomP0fM2iOeXH3rUke2bbOwRUrFhRJyaoUqWKNGnSRDw9PVNwi4mIiFIPA1giJ/PLlrMyfvEh+X+jD2lZ3le+6llNMnm4JXg79HJFWzuUCCDLijrXIUOGMHAlIqI0hwEskZPAoKqpq47LV+tPmpY9U7OwvN/VX9zd4p9dC7NnrVixQmfTMupcMZMWMHglIqK0iAEskROIio6Rd+cHyJxdF0zLBjcrJcNbl4m3ZhWTh2zbtk3LBDCjVsaMGaV27dpSvHjxVNxyIiKi1McAlsjBwiOjZfAfe2XNkSA9j3h1XMcK0qdB/IHomTNntCdzcHCwnsfEBB06dOBkIkRElC4wgCVyoJB7kfLirztl59kHba483DLItKerSqcqBeK9TUxMjCxZskSuX78uPj4+0qpVKx2oxe4CRESUXjCAJXKQwJBw6T1zhxwLCtXzPp5uMv2FmtKwdB6rQSugTAAnDNTClLDNmzeXTJkypfq2ExEROVL8I0OcwPjx4zWrZH4yBqfEZ+7cuXodfKlXqlRJD7MSOZuTV+9It2+3mILXPFk8Zc5L9awGr+fOnZPp06fL9u3bTcuMCQkYvBIRUXrk1AGs0cvyypUrphOmw4zPli1bpEePHtK/f3/Zu3evPPHEE3oKCAhI1W0mSsje8zel+3db5NKtMD1fJFdm+fvl+uJfMHuc6925c0fmz58vP/30kwQFBcmOHTtMmVgiIqL0zOlLCNzd3cXPz8+m637++efStm1beeutt/T8pEmTZPXq1fLVV1/Jd999l8JbSpS49ceuyiu/7ZGwyGg9XyF/Nvm5Xy3Jl/VhJhVB6q5du2TdunUSHh6uRx6qV68uLVq00PIBIiKi9M7pA9gTJ05IgQIF9FBpvXr1ZMqUKTri2pqtW7fKG2+8EWcZps9csGBBguu4f/++nsz7ahqBREpnvHD/6P/JzJpzs8d+mrfnkrwz76BExzyYoaBeidzy3fPVJGsmD9P9BgYG6usVGVfInz+/dhcoWLCgaTsoYXxPuQbuJ9fBfeUaYlJxPznDa8GpA9g6derIzz//LGXLltXygQkTJkijRo20JCBr1qyPXB9f/pZthHAeyxOCoBj3bQktipABS+kXQUhIiL7omF1zXkndTwMGDJCXXnpJatasKT/88IN8NeNnuXEvSntkZavTTbo88aSMa1NEwm7flLAHv5fUjRs35OzZszopwdKlS+XHH38UDw8PuXr1qt7nwIEDpVatWin7YF0c31OugfvJdXBfuYaYVNxPoaEPxm84klMHsO3atTP9XblyZQ1oixYtKn/99ZfWudrLyJEj42RukYEtXLiw5M2bV7JlyyYp/YLDIWKsix8Mzisp+wm1qvfu3dNBVjExsXIqQwHxfHKyFPDykajbwXLjt9flrU8GSqECfnq/ly5d0tcb5MuXTzsLYHKCunXrSo4cOXQZ4EfWsGHD5N9//02Vx+yq+J5yDdxProP7yjXEpOJ+coYBxE4dwFrCl3mZMmXk5MmHU22aQ62scejVgPOJ1dB6eXnpyZLRsiil4QWXWuuilN9PM2bMkJ49e0p0rMjb/xyU9aG+kvH/L693ujWQ6RsLSuCVy5ItaxbNsl6+fFmztXid4gPok08+kW+++UaGDx8eZ32og8VRAbTPKl++fGo8ZJfF95Rr4H5yHdxXriFDKu0nZ3gdOH4LkgCjsk+dOqV1gdagRnbt2rVxlmEQF5YTpRZkSCtVqyH9f9kl8/de0mUZM4h88GQlKR97TssErl27poEusq+enp66DKZNmyYNGjSQGjVq2PwaJyIiSm+cOgP75ptvSqdOnbRsAFmqcePGiZubm7bKgl69eungFtSwwtChQ6VJkyYydepUHfgye/ZsHc39/fffO/iRUHpy8eJFGbvqohy99WBmLC/3jPJlj2riF31VWnd+Xrp27Wpq7YbSGMykhZpuLPvnn39k48aN8d43srS4fyIiovTMqQNYfFEjWMWUmajpaNiwoWzbtk3/hvPnz8dJY9evX1/++OMPGT16tIwaNUpKly6tI7r9/f0d+CgoPblw457EuHlKwPlr4p4tr2TL5C4/9K4lPveuSJPmzbWuGwML8RrGj6xixYqZbrtp0yYdwIXXLWDwIQZtYQDjoEGDdBkGFWbPHrdfLBERUXrj1AEsMqgJsTaYpXv37noiSm1HrtzWqWHd8hSTyBuXpGChQvJLv9oSe/OStOvQQcaMGSN3796Vpk2b6oBEHE3AgC8MIkRZAIJUI1AFXA+DtjAZh2kdR45ovSwREVF65lI1sETOavvp6/L09K1yNfS+ZC7bQLwCD8r7zXKJ571rMmTIEG1tghm18KPslVdekTVr1ujtkHH19va2aR0Ifg8ePCgtW7ZM4UdDRETk3Jw6A0vkClYeCpTX/twrEVEPGjvXbtlFDn45UNYt/lsO+/nJ8uXLdUY5a9Aua8SIETYdYZg1a5b06dNHsmTJkgKPgoiIyHUwgCVKhj+2n5fRCw7K/yfXEv9cGaRa2G7J17yZds1A6yu0NYnP119/bfO6UO+NcgMiIqL0jgEsUQLCI6Nl2cErmmUNvnVX8ua4KG0q+kl7fz/5ftMZmbb6uOm6Zb1CpPrdE5IxQ6wO0Grbtq1dB1xhQBcRERExgCWK1+rDQTJ87j65HRalfVyRZc14+Y6sPBQkI/45KBHRD+eCruh2RWrKRcmdO5fOwFWqVCmHbjsREVFaxgCWKJ7gdeCsXSL/Lw2IsfjXPHgd1b6c5Ay6J/nyldZJCOKrdyUiIiL74DctkZWyAWReEbz+P16Nl7eHm/SqV0y83EskWOtKRERE9sM2WkQWUPOKsoHEglcIi4yW5QFXGLwSERGlIgawRBZWHQrSmldb4HorA4JSepOIiIjIDANYIgu37kWYal0Tg+vdCotI6U0iIiIiMwxgiSzkyOyZpAxsDm/PlN4kIiIiMsMAlshMVFSUNC6ZI0kZ2Db+vim9WURERGSGXQiI/u/kyZOybNky8cmWQ7Jl8pXQ8IQHciFJm83bXdr550/FrSQiIiIGsJTuhYSEyIoVK+TIkSN6PjIyUt7r1EiG/n1YMsTTSksrDDKITO1eVTJ5uKX2JhMREaVrDGAp3YqOjpatW7fKhg0bNGjNmDGj1K1bV5o0aSJeXl7i7Z1Z3py7T0LMZ+L6/7/IvCJ4bVmB5QNERESpjQEspUs3b96U33//Xa5du6bnixYtKh06dJB8+fKZrtOqgq9sH9VS+7yuCAiU4JC7kje7j7T199OyAWZeiYiIHIMBLKVL2bJl08kHfHx8pHXr1lK5cmWrkxEgSO1arZB0qVJArl69qgEuMrVERETkOAxgKd2UC+zbt0+qVq0qbm5uenr66acla9askilTJkdvHhERESUBA1hK886ePavdBZBBDQ8PlwYNGujyvHnzOnrTiIiI6DEwgKU0686dO7Jq1So5cOCAns+cObNmXImIiMi1MYClNCcmJkZ27Ngh69evl/v372tta40aNaRFixbi7e3t6M0jIiKiZGIAS2nO8uXLZefOnfp3gQIFtLtAwYIFHb1ZREREZCcMYCnNqV27tk5K0LRpU6levTq7BhAREaUxDGDJ5csFdu/eLbdv39YSAWNw1rBhw8TdnS9vIiKitIjf8OSyLl26JEuXLpXLly9rnau/v7/4+j6YGYvBKxERUdrFb3lyOffu3ZO1a9fKnj17JDY2Vvu4Nm/enG2xiIiI0gkGsOQyEKzu3btX1qxZo0EsVKlSRVq1aiVZsmRx9OYRERFRKmEASy4jLCxM+7piMgJM6YruAkWLFnX0ZhEREVEqYwBLTi0iIkI8PT1NExG0adNGA1h0GsB0sERERJT+OHV/oSlTpkitWrV09iRk3J544gk5duxYgrf5+eefdUCP+Ylz3btmucC+ffvk888/j7PPq1WrJvXq1WPwSkRElI45dQZ2w4YN8uqrr2oQGxUVJaNGjZLWrVvL4cOHxcfHJ97bZcuWLU7QgyCWXEdQUJB2Fzh//rye37Vrl5QtW9bRm0VEREROwqkD2BUrVjySXUUmFn0/GzduHO/tELD6+fmlwhaSPWHaV0z/imlg0d8VpQNNmjSRunXrOnrTiIiIyIk4dQBrKSQkRP/NlStXgte7c+eODu5BEISZmCZPniwVK1ZMMHDCyYCm+IDb45SScP84XJ7S63F2yJgvWbJE9x2UL19e612zZ8+u5x39/HA/uQ7uK9fA/eQ6uK9cQ0wq7idneC24TACLJwuzKzVo0EAb1scHh5pnzpwplStX1oD3k08+kfr168uhQ4ekUKFC8dbaTpgw4ZHlwcHBOmAopR8XthMvuvQ85enNmze1dCBnzpza07V48eL6o+Lq1aviDLifXAf3lWvgfnId3FeuISYV91NoaKg4WoZYPFIXMGjQIFm+fLls3rw53kDUmsjISM3m9ejRQyZNmmRzBrZw4cIaVKGeNqVfcAiU0YQ/PX0woLtAYGCgFClSxLQMPzLwA8QZZ9FKr/vJFXFfuQbuJ9fBfeUaYlJxPyFOQsIJAXNKx0nxcb5IwYrBgwfr4eWNGzcmKXgFDw8PHbl+8uTJeK/j5eWlJ0t4AaTGmxU1u6m1LkfD7yUMwlu5cqX+aHjttddMkxBUqlRJnFl62k+ujvvKNXA/uQ7uK9eQIZX2kzO8DtydPdhBgDN//nz5999/9bByUkVHR8vBgwelffv2KbKNZLtr165pFv3UqVN6Hr/e8CuOs2gRERFRmglg0ULrjz/+kIULF2ovWBxyBgzs8fb21r979eolBQsW1DpWmDhxoo5aL1WqlNy6dUs+/vhjOXfunLz44osOfSzpGco4kD3fsmWL/qBAiQBqmRs2bKgZciIiIqI0E8B+++23+m/Tpk3jLP/pp5+kT58++jd6hZqnslG3OmDAAA12keGrUaOGBk4VKlRI5a0nI3j95ptvdL9A6dKlpV27dol2kiAiIiJyyQDWlvFlKC0w9+mnn+qJnAMyrBiYdeTIEQ1c8TcnliAiIqI0G8CS68GMaegUgYw3Jp0AtMXCCRMTEBERESUXA1iymxMnTsiyZcu0XODMmTNa5oFsKwNXIiIisicGsJRsGCyHaX+PHj2q59ETrnbt2o7eLCIiIkqjGMBSssoFtm7dqh0GMFgLg+nQAaJJkyZW++oSERER2QMDWHps+/fvl7Vr1+rfxYoV0167Rt0rERERUUphAEtJ7gxhdBGoWrWqzqpVpUoVnUWL3QWIiIgoNTCAJZtgAoJt27ZJQECA9O/fXycjcHNzkxdeeMHRm0ZERETpDANYShQ6CqC7QHBwsJ7H1LzVqlVz9GYRERFROsUAluIVGhoqq1at0oAVfHx8pFWrVloyQEREROQoDGDJap3r9u3bZf369XL//n2tba1Vq5Y0a9ZMvL29Hb15RERElM4xgCWrTp48qcFrwYIFpWPHjpI/f35HbxIRERGRYgBL6s6dOzooCxlWZFzbtWsnZ8+elerVq7O7ABERETkVBrDpXExMjOzatUvWrVsnFStWlE6dOuny3Llz64mIiIjI2TCATccuXrwoS5culStXruh5/IvZtdAii4iIiMhZMVJJh+7duydr1qyRPXv26PlMmTJJixYtpEaNGjodLBEREZEzYwCbzpw7d05mz54tYWFhptm00BoLLbKIiIiIXAED2HQmb968OijL19dXOnToIEWKFHH0JhERERElCQPYNA6Z1gMHDkjt2rU1cM2cObP06dNH8uTJw3IBIiIickkMYNPwZAT79u2T1atXa81rtmzZpHz58npZvnz5HL15RERERI+NAWwaFBgYqN0FLly4YCobYI0rERERpRUMYNOQ8PBwnf51x44dmoH19PSUpk2bSp06dXSSAiIiIqK0gAFsGvLnn39qlwHApARt2rTR0gEiIiKitIQBbBrSuHFjWb58ubRv315KlCjh6M0hIiIiShEMYF3U/fv3ZcOGDZI9e3YtEYCSJUvKK6+8wu4CRERElKYxgHUxqG09dOiQrFy5UkJDQ7XOtXLlyuLt7a2XM3glIiKitI4BrAu5du2aLFu2TE6fPq3nc+XKJe3atTMFr0RERETpAQNYFxARESEbN26UrVu3SnR0tLi7u0vDhg31hL+JiIiI0hNGPy4gJCREtmzZIjExMVKmTBnNuubMmdPRm0VERETkEAxgnXgKWKM0ABMRtGzZUksGypYtq1PCEhEREaVXLjHi5+uvv5ZixYpJpkyZdMQ9GvUnZO7cuVKuXDm9fqVKlbRu1FVERkbKunXrZNq0aTqjlqF+/fr6mBi8EhERUXrn9AHsnDlz5I033pBx48bJnj17pEqVKtqg/+rVq1avj0PtPXr0kP79+8vevXvliSee0FNAQIA4u2PHjmmwjnpXBLIHDx509CYREREROZ0MsejL5MSQca1Vq5Z89dVXeh51oIULF5bXXntNRowY8cj1n3nmGbl7964sWbLEtKxu3bpStWpV+e6772xa5+3bt7W/KmpPU3omKzye48ePy+7du+XEiRO6DOts27atlC9fnhlXJ4H9hB9N+fLlY6syJ8d95Rq4n1wH95VrSM39lJpxkkvWwGL0PQK7kSNHmpZhp6AeFCPyrcFyZGzNIWO7YMECcUbY3kWLFmm5g5ubm5YKYEYt9HclIiIiIhcLYNH3FG2jfH194yzH+aNHj1q9DepGrV3fvJ7U2qxWOJn/sjB+zeCU0qKioqRo0aLSoUMHHbBlrJucB/YHDlZwvzg/7ivXwP3kOrivXENMKu4nZ3gtOHUAm1qmTJkiEyZMeGR5cHCwhIeHp+i6Ebi2aNFCa3vxwouvtpccC29WHCrBPuIhNOfGfeUauJ9cB/eVa4hJxf2EmUAdzakD2Dx58uhh9aCgoDjLcd7Pz8/qbbA8KdcHlCiYlx0gA4s6W2RDU6MGFo8R6+IHg/PCfkI9MveT8+O+cg3cT66D+8o1xKTifkLZo6M5dQCLOtAaNWrI2rVrtZOAsYNwfvDgwVZvU69ePb182LBhpmWrV6/W5fHx8vLSkyW8AFLjzYoXXGqtix4f95Pr4L5yDdxProP7yjVkSKX95AyvA6cOYAGZ0d69e0vNmjWldu3a8tlnn2mXgb59++rlvXr1koIFC2oZAAwdOlSaNGkiU6dO1ZrS2bNny65du+T777938CMhIiIionQRwKItFmpRx44dqwOx0A5rxYoVpoFa58+fj/NLAKP4//jjDxk9erSMGjVKSpcurR0I/P39HfgoiIiIiCjd9IF1hNTuA8v+es6P+8l1cF+5Bu4n18F95Rpi0lkfWL4SiYiIiMilMIAlIiIiIpfCAJaIiIiIXAoDWCIiIiJyKQxgiYiIiMilMIAlIiIiIpfCAJaIiIiIXAoDWCIiIiJyKQxgiYiIiMilOP1Uso5gTE6GmSZSY+aM0NBQyZQpE2c4cWLcT66D+8o1cD+5Du4r1xCTivvJiI8cOZkrA1gr8AKAwoULO3pTiIiIiJw2XsqePbtD1p0h1pHhsxP/irl8+bJkzZpVMmTIkOK/YhAoX7hwwWHzCVPiuJ9cB/eVa+B+ch3cV67hdiruJ4SOCF4LFCjgsKw8M7BWYGcUKlQoVdeJFxs/GJwf95Pr4L5yDdxProP7yjVkS6X95KjMq4HFLERERETkUhjAEhEREZFLYQDrYF5eXjJu3Dj9l5wX95Pr4L5yDdxProP7yjV4pbP9xEFcRERERORSmIElIiIiIpfCAJaIiIiIXAoDWCIiIiJyKQxgHejrr7+WYsWK6bRvderUkR07djh6k8jClClTpFatWjqpRb58+eSJJ56QY8eOOXqzKBEffPCBTkIybNgwR28KWXHp0iV5/vnnJXfu3OLt7S2VKlWSXbt2OXqzyEx0dLSMGTNGihcvrvuoZMmSMmnSJIdOHUoPbNy4UTp16qSTCOBzbsGCBXEuxz4aO3as5M+fX/ddy5Yt5cSJE5LWMIB1kDlz5sgbb7yhIwb37NkjVapUkTZt2sjVq1cdvWlkZsOGDfLqq6/Ktm3bZPXq1RIZGSmtW7eWu3fvOnrTKB47d+6U6dOnS+XKlR29KWTFzZs3pUGDBuLh4SHLly+Xw4cPy9SpUyVnzpyO3jQy8+GHH8q3334rX331lRw5ckTPf/TRR/Lll186etPSPXz/VKlSRZNg1mA/ffHFF/Ldd9/J9u3bxcfHR+OL8PBwSUvYhcBBkHFFZg8fDsb0tZgC7rXXXpMRI0Y4evMoHsHBwZqJRWDbuHFjR28OWbhz545Ur15dvvnmG3nvvfekatWq8tlnnzl6s8gMPt/+++8/2bRpk6M3hRLQsWNH8fX1lR9//NG0rFu3bprR++233xy6bfQQMrDz58/Xo4OAkA6Z2eHDh8ubb76py0JCQnRf/vzzz/Lss89KWsEMrANERETI7t27Na1vPn0tzm/dutWh20YJwwcB5MqVy9GbQlYgW96hQ4c47y1yLosWLZKaNWtK9+7d9cdgtWrVZMaMGY7eLLJQv359Wbt2rRw/flzP79+/XzZv3izt2rVz9KZRAs6cOSOBgYFxPgMx5SuSZmktvnB39AakR9euXdP6IvwiMofzR48eddh2UcKQJUdNJQ5/+vv7O3pzyMLs2bO1HAclBOS8Tp8+rYemUUI1atQo3V9DhgwRT09P6d27t6M3j8wy5bdv35Zy5cqJm5ubfme9//778txzzzl60ygBgYGB+q+1+MK4LK1gAEuUhOxeQECAZiHIuVy4cEGGDh2qdcoYFEnO/UMQGdjJkyfreWRg8b5CvR4DWOfx119/ye+//y5//PGHVKxYUfbt26c/4HF4mvuJnAFLCBwgT548+os2KCgoznKc9/Pzc9h2UfwGDx4sS5YskfXr10uhQoUcvTlkASU5GACJ+ld3d3c9oU4ZAxnwN7JH5BwwMrpChQpxlpUvX17Onz/vsG2iR7311luahUXNJLpEvPDCC/L6669rZxZyXn7/jyHSQ3zBANYBcKisRo0aWl9knpXA+Xr16jl02yguFMQjeEWR/Lp167SlDDmfFi1ayMGDBzVLZJyQ5cPhTvyNH4zkHFCCY9mKDnWWRYsWddg20aPu3bunYzPM4X2E7ypyXsWLF9dA1Ty+QCkIuhGktfiCJQQOgvovHIbBl2zt2rV1pDRaY/Tt29fRm0YWZQM4hLZw4ULtBWvUEKEoHqNxyTlg31jWJaN1DPqMsl7ZuSCLhwFCKCF4+umntf/1999/rydyHugziprXIkWKaAnB3r17Zdq0adKvXz9Hb1q6h24rJ0+ejDNwCz/UMbgY+wulHujCUrp0aQ1o0c8XpR9Gp4I0A220yDG+/PLL2CJFisR6enrG1q5dO3bbtm2O3iSygLeItdNPP/3k6E2jRDRp0iR26NChjt4MsmLx4sWx/v7+sV5eXrHlypWL/f777x29SWTh9u3b+v7Bd1SmTJliS5QoEfvuu+/G3r9/39Gblu6tX7/e6vdS79699fKYmJjYMWPGxPr6+up7rEWLFrHHjh2LTWvYB5aIiIiIXAprYImIiIjIpTCAJSIiIiKXwgCWiIiIiFwKA1giIiIicikMYImIiIjIpTCAJSIiIiKXwgCWiIiIiFwKA1gioiTAjDcff/yxREVFJfm2ISEhMnHixEfmKScioqRhAEtE6cb48eOlatWqpvN9+vRJ0vSKN27ckG7dukn58uXF3T3xmbhfeOEFnTLVgCmIM2fOLM8//7zTzylv+Vw9jrNnz0qGDBk06E9JdevWlX/++SdF10FEzoUzcRGRQ124cEHGjRsnK1askGvXrkn+/Pk1qBw7dqzkzp3b7kHZggULTAEVMqL4CMyRI4eeb9q0qQZtn3322SO3xfUwP3znzp1l4MCBia5r//790rx5czl37pxkyZIlzmWDBw8WPz8/GT16tDjzfOv3799P1j6Ijo6W4OBgyZMnj00B/+NasmSJvP7663Ls2DHJmJF5GaL0IOU+UYiIEnH69GmpV6+elClTRv78808pXry4HDp0SN566y1Zvny5bNu2TXLlypVi60dG1FbIJCJQstWXX34p3bt3fyR4ha+++kqcHbbb2rYnhZubmwbqKSUiIkI8PT2lXbt28uKLL+prpkOHDim2PiJyHvypSkQO8+qrr2oAsmrVKmnSpIkUKVJEg5E1a9bIpUuX5N13340TQCJ7ag6Z059//tl0/p133tFgGIfpS5QoIWPGjJHIyMh4129eQoC/N2zYIJ9//rmuCyccAoeAgADdLgR0vr6+WhqAbHFCmce///5bM7bmZs2aJTVr1pSsWbNqYNezZ0+5evVqgs9RsWLF5L333pNevXrp+osWLSqLFi3SzGaXLl10WeXKlWXXrl2m21y/fl169OghBQsW1OeiUqVK+gPBgNti/eblDVu2bNF9sXbt2gTLLXAbPAd47lHPi1pg/ODAD41ChQrJTz/9FG8Jwc2bN+W5556TvHnzire3t5QuXTrO9ZGNf/rpp/W+cX94fMY+MN+G999/XwoUKCBly5Y1Bcrt27eX2bNnJ/hcElHawQCWiBwC9aQrV66UV155RYMZcwiuEOjMmTNHD93bCoEhAtrDhw9rIDpjxgz59NNPbbotro9s8IABA+TKlSt6Kly4sNy6dUtLAapVq6ZBIkodMAgLgVZ8Dhw4oOUJCFbNIZieNGmSlhcgGEdwhqAsMXgMDRo0kL1792qGEQE0AlrU0u7Zs0dKliyp543nKjw8XGrUqCFLly7V4BslD7jNjh079HIEkDNnztQgFY8pNDRUL0dpQ4sWLeLdjnXr1snly5dl48aNMm3aNC396Nixo+TMmVO2b98uL7/8srz00kty8eJFq7fHDwrsG2RKjxw5It9++62WFxjPTZs2bXQfbtq0Sf777z8Nztu2bauZVgMCbJQKrF69Ok5GvHbt2no7IkonUANLRJTatm3bhmgrdv78+VYvnzZtml4eFBSk561dN3v27LE//fRTvOv4+OOPY2vUqGE6P27cuNgqVaqYzvfu3Tu2S5cupvNNmjSJHTp0aJz7mDRpUmzr1q3jLLtw4YJuz7Fjx6yuF9vp5uYWGxMTE5uQnTt36v2EhobGe52iRYvGPv/886bzV65c0duMGTPGtGzr1q26DJfFp0OHDrHDhw+Ps+yVV16JLVOmTGzPnj1jK1WqFBseHp7gc4VtiY6ONi0rW7ZsbKNGjUzno6KiYn18fGL//PNPPX/mzBndrr179+r5Tp06xfbt29fq9s2aNUvvz/w5u3//fqy3t3fsypUrTdvg6+uryy0tXLgwNmPGjHG2j4jSLtbAEpFDJZZhxWFtWyFj+8UXX8ipU6d0EBIOb2fLli1Z24ds6fr1663Wg2I9KFmwFBYWJl5eXnr43Nzu3bs164n7xOF0oxPB+fPnpUKFCvFuA0oEDDh8DygLsFyGcgRkr1HCgEP9f/31l5ZiIIOJAVkoJzD3ySefiL+/v8ydO1e3DduckIoVK8YZJIX14vYGHMrHoK/4yiIGDRqkXRyQNW7durWWA9SvX18vw3Ny8uRJzcCaQzYZz7MBj9vaawJZfDyfeJyWGX0iSnsYwBKRQ5QqVUoDPBxK7tq16yOXYzkOdRsdAnBdy2DXvL5169atWnYwYcIEPRSNAVqoiZw6dWqythOBMGpZP/zww0cuQ8cEa3BY/N69e6ZBRnD37l3dLpx+//13fWwIXHHe/BC5NR4eHqa/jaDY2jIjIEafWpREoJsCAj4fHx8ZNmzYI+tBYIiSANwO5QzmQXFi22Gs19qy+FqEoY4YXRmWLVumJQAoV0AdNAJpPM8oe8BzYwnPlQGPJb6SFFzG4JUofWAAS0QOgUxdq1at5JtvvtEWSOaBR2BgoAYyCG7MgxjUpRpOnDihQaL5ICQMcDIf+IVgKSkQbCJ7aa569eraYxSDqWxtBWUMfkK9p/H30aNHdXDVBx98oLW1YD7wyp5QP4oBUKiRBQSUx48fj5PlRTCLy5955hkdDIVR/AcPHpR8+fJJSsJ+7N27t54aNWqkA8AQwOJ5RgYd63+crDlqfVGnTETpAwdxEZHDoJ0UDvkiC4mBQRiFjkFSCGxxaB69YA0YSIXrYyATAj8MGDLP/mFEOzKayLois4hSgvnz5ydpexCkYjASspHoMoDAD0E0snsY1b9z5069bww+69u37yPBrnmQhoBs8+bNpmXosIAAGe210D4MnQQwoCsl4LlAhhNBPTLZGFhlOfsXAn0MNMPzZHRv6Nevn6Qk7M+FCxdqqQDapWEQFiaFAGTPkblG4I3BWGfOnJF///1XhgwZEu+gMHO4DcoSiCh9YABLRA6DQAtBIVpeYVQ/Mqg4zIxgyhiFbkApADKXyNqh/dSbb74Zp6YTEwwgk4uR9Mh6InjDqPekwH2ijhOZSuMQP9o1YVsQrCJAwmF2HI5HaUNCTfOR0TQ/HI77Q4cE1Jvi/pGJReYxJWCCBATQ+GGAyRlQF2s+4xgCQ5QXoK0Xsp14HPgbQSA6A6QUBPAjR47Umt7GjRvrc220vsK+xI8YBPpPPvmkBrb9+/fXGtjEMrKo88X+xo8KIkofOBMXETkVtGZCiyZkEDFFqKvCQC4cmsdhcbTnopSDDDIGxX3//feO3hQiSiWsgSUip4JBWDiUj1m40NvTVacGRU3vr7/+muCEB2QfqJt94403HL0ZRJSKmIElIiIiIpfimqkNIiIiIkq3GMASERERkUthAEtERERELoUBLBERERG5FAawRERERORSGMASERERkUthAEtERERELoUBLBERERG5FAawRERERORSGMASERERkbiS/wGA3MYamF/jvQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 700x450 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Le front comporte 9 compromis Pareto-optimaux.\n",
+      "La pente descendante illustre le trade-off : baisser le coût dégrade la qualité.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Visualisation du front de Pareto : qualite (x) vs cout (y).\n",
+    "# On distingue les points Pareto-optimaux de la borne minimale cout = 2 * qualite.\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# front est calcule par la cellule precedente (enumerer_front_pareto)\n",
+    "qualites = [q for (q, _) in front]\n",
+    "couts = [c for (_, c) in front]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 4.5))\n",
+    "\n",
+    "# Borne de faisabilite : cout_min = 2 * qualite (frontiere inferieure du modele)\n",
+    "q_line = range(0, 11)\n",
+    "ax.plot(list(q_line), [2 * q for q in q_line], \"k--\", alpha=0.5, label=\"coût_min = 2 × qualité\")\n",
+    "\n",
+    "# Front de Pareto : les compromis optimaux enumeres par Z3\n",
+    "ax.plot(qualites, couts, \"o-\", color=\"#1f77b4\", linewidth=2, markersize=8,\n",
+    "        label=\"front de Pareto (Z3)\")\n",
+    "\n",
+    "# Annoter chaque point pour rendre le compromis lisible\n",
+    "for q, c in zip(qualites, couts):\n",
+    "    ax.annotate(f\"({q},{c})\", (q, c), textcoords=\"offset points\", xytext=(6, 6), fontsize=8)\n",
+    "\n",
+    "ax.set_xlabel(\"Qualité (à maximiser)\")\n",
+    "ax.set_ylabel(\"Coût (à minimiser)\")\n",
+    "ax.set_title(\"Front de Pareto : compromis qualité ↔ coût\")\n",
+    "ax.legend(loc=\"upper left\")\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Le front comporte {len(front)} compromis Pareto-optimaux.\")\n",
+    "print(\"La pente descendante illustre le trade-off : baisser le coût dégrade la qualité.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "nb06-s4-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.002549,
-     "end_time": "2026-06-13T10:56:41.053723+00:00",
+     "duration": 0.003145,
+     "end_time": "2026-06-14T12:24:15.860078",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.051174+00:00",
+     "start_time": "2026-06-14T12:24:15.856933",
      "status": "completed"
     },
     "tags": []
@@ -635,10 +730,10 @@
    "id": "nb06-ex1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002563,
-     "end_time": "2026-06-13T10:56:41.058983+00:00",
+     "duration": 0.004,
+     "end_time": "2026-06-14T12:24:15.868078",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.056420+00:00",
+     "start_time": "2026-06-14T12:24:15.864078",
      "status": "completed"
     },
     "tags": []
@@ -664,20 +759,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "nb06-ex1-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T10:56:41.065339Z",
-     "iopub.status.busy": "2026-06-13T10:56:41.065123Z",
-     "iopub.status.idle": "2026-06-13T10:56:41.069239Z",
-     "shell.execute_reply": "2026-06-13T10:56:41.068235Z"
+     "iopub.execute_input": "2026-06-14T12:24:15.876587Z",
+     "iopub.status.busy": "2026-06-14T12:24:15.876587Z",
+     "iopub.status.idle": "2026-06-14T12:24:15.881093Z",
+     "shell.execute_reply": "2026-06-14T12:24:15.880587Z"
     },
     "papermill": {
-     "duration": 0.00844,
-     "end_time": "2026-06-13T10:56:41.069970+00:00",
+     "duration": 0.009014,
+     "end_time": "2026-06-14T12:24:15.881093",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.061530+00:00",
+     "start_time": "2026-06-14T12:24:15.872079",
      "status": "completed"
     },
     "tags": []
@@ -727,10 +822,10 @@
    "id": "nb06-s5-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002555,
-     "end_time": "2026-06-13T10:56:41.075696+00:00",
+     "duration": 0.004986,
+     "end_time": "2026-06-14T12:24:15.890100",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.073141+00:00",
+     "start_time": "2026-06-14T12:24:15.885114",
      "status": "completed"
     },
     "tags": []
@@ -755,20 +850,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "nb06-s5-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T10:56:41.082282Z",
-     "iopub.status.busy": "2026-06-13T10:56:41.082078Z",
-     "iopub.status.idle": "2026-06-13T10:56:41.101544Z",
-     "shell.execute_reply": "2026-06-13T10:56:41.100644Z"
+     "iopub.execute_input": "2026-06-14T12:24:15.899773Z",
+     "iopub.status.busy": "2026-06-14T12:24:15.899773Z",
+     "iopub.status.idle": "2026-06-14T12:24:15.917922Z",
+     "shell.execute_reply": "2026-06-14T12:24:15.916916Z"
     },
     "papermill": {
-     "duration": 0.024029,
-     "end_time": "2026-06-13T10:56:41.102183+00:00",
+     "duration": 0.025587,
+     "end_time": "2026-06-14T12:24:15.918846",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.078154+00:00",
+     "start_time": "2026-06-14T12:24:15.893259",
      "status": "completed"
     },
     "tags": []
@@ -857,10 +952,10 @@
    "id": "nb06-s5-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.002403,
-     "end_time": "2026-06-13T10:56:41.107236+00:00",
+     "duration": 0.004681,
+     "end_time": "2026-06-14T12:24:15.927279",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.104833+00:00",
+     "start_time": "2026-06-14T12:24:15.922598",
      "status": "completed"
     },
     "tags": []
@@ -891,10 +986,10 @@
    "id": "nb06-ex2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002552,
-     "end_time": "2026-06-13T10:56:41.112186+00:00",
+     "duration": 0.004442,
+     "end_time": "2026-06-14T12:24:15.936321",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.109634+00:00",
+     "start_time": "2026-06-14T12:24:15.931879",
      "status": "completed"
     },
     "tags": []
@@ -925,20 +1020,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "nb06-ex2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T10:56:41.118759Z",
-     "iopub.status.busy": "2026-06-13T10:56:41.118554Z",
-     "iopub.status.idle": "2026-06-13T10:56:41.122978Z",
-     "shell.execute_reply": "2026-06-13T10:56:41.121928Z"
+     "iopub.execute_input": "2026-06-14T12:24:15.946234Z",
+     "iopub.status.busy": "2026-06-14T12:24:15.946234Z",
+     "iopub.status.idle": "2026-06-14T12:24:15.950141Z",
+     "shell.execute_reply": "2026-06-14T12:24:15.950141Z"
     },
     "papermill": {
-     "duration": 0.008911,
-     "end_time": "2026-06-13T10:56:41.123622+00:00",
+     "duration": 0.010647,
+     "end_time": "2026-06-14T12:24:15.951148",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.114711+00:00",
+     "start_time": "2026-06-14T12:24:15.940501",
      "status": "completed"
     },
     "tags": []
@@ -984,10 +1079,10 @@
    "id": "nb06-s6-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002752,
-     "end_time": "2026-06-13T10:56:41.129244+00:00",
+     "duration": 0.00425,
+     "end_time": "2026-06-14T12:24:15.960087",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.126492+00:00",
+     "start_time": "2026-06-14T12:24:15.955837",
      "status": "completed"
     },
     "tags": []
@@ -1012,20 +1107,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "nb06-s6-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T10:56:41.136085Z",
-     "iopub.status.busy": "2026-06-13T10:56:41.135882Z",
-     "iopub.status.idle": "2026-06-13T10:56:41.363315Z",
-     "shell.execute_reply": "2026-06-13T10:56:41.362111Z"
+     "iopub.execute_input": "2026-06-14T12:24:15.970141Z",
+     "iopub.status.busy": "2026-06-14T12:24:15.970141Z",
+     "iopub.status.idle": "2026-06-14T12:24:16.221897Z",
+     "shell.execute_reply": "2026-06-14T12:24:16.221897Z"
     },
     "papermill": {
-     "duration": 0.232063,
-     "end_time": "2026-06-13T10:56:41.363977+00:00",
+     "duration": 0.258678,
+     "end_time": "2026-06-14T12:24:16.222902",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.131914+00:00",
+     "start_time": "2026-06-14T12:24:15.964224",
      "status": "completed"
     },
     "tags": []
@@ -1144,10 +1239,10 @@
    "id": "nb06-s6-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.002928,
-     "end_time": "2026-06-13T10:56:41.370231+00:00",
+     "duration": 0.004093,
+     "end_time": "2026-06-14T12:24:16.230995",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.367303+00:00",
+     "start_time": "2026-06-14T12:24:16.226902",
      "status": "completed"
     },
     "tags": []
@@ -1178,10 +1273,10 @@
    "id": "nb06-ex3-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002808,
-     "end_time": "2026-06-13T10:56:41.375968+00:00",
+     "duration": 0.004005,
+     "end_time": "2026-06-14T12:24:16.238521",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.373160+00:00",
+     "start_time": "2026-06-14T12:24:16.234516",
      "status": "completed"
     },
     "tags": []
@@ -1211,20 +1306,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "nb06-ex3-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T10:56:41.383366Z",
-     "iopub.status.busy": "2026-06-13T10:56:41.383147Z",
-     "iopub.status.idle": "2026-06-13T10:56:41.388112Z",
-     "shell.execute_reply": "2026-06-13T10:56:41.386718Z"
+     "iopub.execute_input": "2026-06-14T12:24:16.247815Z",
+     "iopub.status.busy": "2026-06-14T12:24:16.247815Z",
+     "iopub.status.idle": "2026-06-14T12:24:16.251831Z",
+     "shell.execute_reply": "2026-06-14T12:24:16.251831Z"
     },
     "papermill": {
-     "duration": 0.010048,
-     "end_time": "2026-06-13T10:56:41.388855+00:00",
+     "duration": 0.01024,
+     "end_time": "2026-06-14T12:24:16.252835",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.378807+00:00",
+     "start_time": "2026-06-14T12:24:16.242595",
      "status": "completed"
     },
     "tags": []
@@ -1277,10 +1372,10 @@
    "id": "nb06-conclusion",
    "metadata": {
     "papermill": {
-     "duration": 0.003283,
-     "end_time": "2026-06-13T10:56:41.395342+00:00",
+     "duration": 0.003591,
+     "end_time": "2026-06-14T12:24:16.260427",
      "exception": false,
-     "start_time": "2026-06-13T10:56:41.392059+00:00",
+     "start_time": "2026-06-14T12:24:16.256836",
      "status": "completed"
     },
     "tags": []
@@ -1325,18 +1420,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.759985,
-   "end_time": "2026-06-13T10:56:41.621691+00:00",
+   "duration": 2.539392,
+   "end_time": "2026-06-14T12:24:16.497786",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-06-Advanced-Optimization.ipynb",
-   "output_path": "/tmp/Z3-Python-06-Advanced-Optimization_wsl_output.ipynb",
+   "input_path": "Z3-Python-06-Advanced-Optimization.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/z3_reexec/NB06_with_viz.ipynb",
    "parameters": {},
-   "start_time": "2026-06-13T10:56:39.861706+00:00",
+   "start_time": "2026-06-14T12:24:13.958394",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

**Z3-Python #1206 — track Python finalization (ai-01 directive 14/06, reunion Nicolas 15/06).** The 6-notebook Z3-Python series is already PRODUCTION on main (NB04/05/06 merged via #2896/#2900/#2905); this PR adds the one visualization the series lacked outside NB02, plus a stale chapeau count fix.

## Changes (2 files, atomic)

**1. NB06 (Optimisation avancee) — Pareto-front visualization.** A matplotlib plot of the enumerated Pareto front (qualite vs cout) with the `cout_min = 2*qualite` feasibility bound as a dashed line. The plot makes the multi-objective trade-off geometrically visible: points strictly above the minimal-cost bound are Pareto-equivalent solutions Z3 sampled, which a bare "minimize cost" would hide. Added 2 cells (markdown interpretation + code) immediately after the existing Pareto enumeration cell (`nb06-s4-code`).

**2. `SMT/README.md` chapeau — stale count fix.** The Z3-Python row read `3 (01 -> 03, en cours)` while 6 notebooks have been PRODUCTION on main for days. Corrected to `6 (01 -> 06, serie complete)`. (Stale since the SMT regrouping PR #2886, predating NB04/05/06 merges.)

## §D Notebook PR body (pr-review-discipline)

**1. Papermill execution (real, end-to-end)** — all 6 notebooks re-executed on kernel `python3`, fresh on this branch:
```
Z3-Python-01-Introduction      PASS
Z3-Python-02-Sudoku            PASS
Z3-Python-03-Tactics           PASS
Z3-Python-04-Strings-Regex     PASS
Z3-Python-05-Quantifiers-Proofs PASS
Z3-Python-06-Advanced-Optimization PASS   ← contains the new viz cell
=== FINAL SERIES: PASS=6 FAIL=0, TRUE EXIT 0 ===
```

**2. C.1 — 0 forbidden patterns.** `grep -cE "raise NotImplementedError|assert False|1 ?/ ?0"` = 0 across the modified notebook. The 3 exercise stubs use the conformant `print("Exercice N - a completer")` + `return None` pattern.

**3. C.2 — outputs present.** NB06: 10 code cells, `execution_count` contiguous `[1..10]`, 0 errors. The new viz cell (exec 5) emits a real PNG image (~54 KB). No cell lacks outputs.

**4. Anti-regression (rule D) — no content deleted.** G.1 verification (cell signature diff before/after):
```
BEFORE: 25 cells (9 code, 16 md)
AFTER:  27 cells (10 code, 17 md)
cell delta: +2 (exactly the 2 new viz cells)
ORIGINAL source cells MISSING from after: 0
NEW cells added: 2  (markdown 'Visualiser le front de Pareto', code viz)
```
The -122 in `git diff --stat` is **papermill JSON re-serialization** of regenerated outputs on the 9 pre-existing code cells (output metadata refreshed, JSON repacked) — not content loss. 3 exercises preserved (#2161 ✓).

## Scope

`git diff --stat`: `README.md +2/-1`, `NB06 +216/-121`. One subject (Z3-Python finalization), catalog byte-identical to main, no submodule churn included.

See #1206 (epic stays open — track Python finalization; C# Z3.Linq track is a separate lane).
