### PR TITLE
feat(lean): Conway P5 step4x4 unconditional level+wf shape (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -914,6 +914,31 @@ private theorem wf_padToLevelPlus1 {nw ne sw se : MacroCell}
              MacroCell.level, he_lvl, hla, hlb, hld]
   decide
 
+/-! ## P4 structural input: step4x4 shape
+
+`step4x4` is the Hashlife base case (level-2 input -> one generation). It
+always returns a level-1 cell, unconditionally: in the `level == 2` arm it
+returns `node (leaf _) (leaf _) (leaf _) (leaf _)`, and in the `else` arm it
+returns `emptyOfLevel 1`. This level-1 shape is a structural input to the
+`hashlifeResult` level-preservation invariant (the level-2 base of
+`level_hashlifeResult_of_level_two`). The well-formedness is unconditional
+too: four equal-level (level-0) leaves form a wf node, and `emptyOfLevel 1` is
+wf (a node of four level-0 empty leaves). -/
+
+private theorem level_step4x4 (c : MacroCell) : (step4x4 c).level = 1 := by
+  by_cases h : c.level == 2
+  · simp only [step4x4, if_pos h, MacroCell.level]
+  · simp only [step4x4, if_neg h, emptyOfLevel_level]
+
+private theorem wf_step4x4 (c : MacroCell) : (step4x4 c).wf = true := by
+  by_cases h : c.level == 2
+  · -- level-2 arm: node (leaf _) (leaf _) (leaf _) (leaf _). Four leaves are
+    -- all wf (= true) and all level 0, so the wf conjunction is trivially true.
+    simp only [step4x4, if_pos h, MacroCell.wf, MacroCell.level]
+    decide
+  · simp only [step4x4, if_neg h]
+    exact emptyOfLevel_wf 1
+
 /-! ## P4 structural input: level preservation (level-2 base)
 
 `hashlifeResult` on a well-formed level-`k` cell is documented to return a


### PR DESCRIPTION
## Summary

Two private theorems on the Hashlife base case `step4x4` (Conway P5 lane, #2162):

- `level_step4x4 : (step4x4 c).level = 1`
- `wf_step4x4 : (step4x4 c).wf = true`

Both hold **unconditionally** for all `c`. `step4x4`'s two arms both yield a level-1 cell:
- `level == 2` arm → `node (leaf _) (leaf _) (leaf _) (leaf _)` (four level-0 leaves ⇒ level 1)
- `else` arm → `emptyOfLevel 1` (level 1)

Well-formedness: four equal-level leaves form a wf node (the `wf` conjunction is trivially `true`, closed by `decide`); `emptyOfLevel 1` is wf by `emptyOfLevel_wf` (introduced in #2960).

**Structural input** to the `hashlifeResult` level-preservation invariant — the level-2 base of `level_hashlifeResult_of_level_two` (merged #2949). Stepping stone toward P4 central-correctness; does **not** close P4/P5 (those remain blocked by the double-nine compositional argument, research-level).

## Scope

1 file, +25 lines, 0 deletions, 0 new sorry, 0 new axiom. No functional change to definitions; pure additive lemmas.

## Lean §B verification

- `sorry` baseline: **2 → 2** (P4/P5 placeholders unchanged; `grep -ocE "sorry"` raw = 10, of which 8 are doc/comment text, 2 are the real proof placeholders at the P4 succ-case and the P5 theorem)
- `Lake build SUCCESS`: genuine `lake env lean Conway/Life/HashlifeCorrectness.lean` with `.olean` purged beforehand — **exit 0, 0 real compile errors** (`grep -cE "error:"` = 0)
- Proof integrity: 0 new axioms (theorems proved by `decide` / `emptyOfLevel_wf` / `emptyOfLevel_level`, no `sorry_axiom`)
- Diff coherent: additive only, no deletions

**Stacked on #2960** (uses `emptyOfLevel_wf`); rebases cleanly to main after #2960 merges.

## Verification commands

```bash
cd MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
rm -f .lake/build/lib/Conway/Life/HashlifeCorrectness.olean
lake env lean Conway/Life/HashlifeCorrectness.lean   # exit 0, 0 errors
grep -cE "declaration uses .sorry." <buildlog>        # 2 (baseline)
```

See #2162