### PR TITLE
feat(z3): resurrect CollectionHandling — co-évolution lib+notebook (#1206)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02b_Sudoku_Modes_Comparison.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02b_Sudoku_Modes_Comparison.ipynb
@@ -1,0 +1,554 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "02bb7e6d",
+   "metadata": {},
+   "source": [
+    "# Sudoku 4x4 : comparaison des modes `Array` et `Constants`\n",
+    "\n",
+    "**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | [Array Theory >>](03_Array_Theory.ipynb)\n",
+    "\n",
+    "## Objectif\n",
+    "\n",
+    "Ce notebook démontre les **deux modes de modélisation des collections** offerts par le fork `Z3.Linq`, en résolvant le **même** Sudoku 4x4 (`int[][]`) des deux façons. C'est la démonstration directe que l'enum `CollectionHandling` — historiquement du *dead code* défini mais jamais câblé — est désormais **vivante** et fonctionnelle bout-en-bout.\n",
+    "\n",
+    "| Mode | Modélisation Z3 | Avantage |\n",
+    "|------|----------------|----------|\n",
+    "| **`Array`** (défaut) | Une seule `ArrayExpr` Z3 + `Select`/`Store` (théorie des tableaux) | Compact, supporte les index symboliques, `int[][]` imbriqué |\n",
+    "| **`Constants`** | Un constant Z3 par élément (`Cells_0_0`, `Cells_0_1`, …) | Modèle « un symbole = une inconnue », proche du raisonnement humain, lisible dans le solver |\n",
+    "\n",
+    "Les deux modes produisent une solution valide ; le choix est **pédagogique** et dépend de ce qu'on veut illustrer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62647528",
+   "metadata": {},
+   "source": [
+    "### Configuration de l'environnement\n",
+    "\n",
+    "Chargement du **fork Z3.Linq** (avec `CollectionHandling` câblé) depuis le sous-module local. Les DLL sont produites par le script `scripts/environment/z3-build-deploy.ps1` (décision ai-01 2026-06-13, option b)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f642f637",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T14:05:38.869430Z",
+     "iopub.status.busy": "2026-06-14T14:05:38.861176Z",
+     "iopub.status.idle": "2026-06-14T14:05:40.029359Z",
+     "shell.execute_reply": "2026-06-14T14:05:40.026309Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-35364.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.1.14:2050/\", \"http://172.19.64.1:2050/\", \"http://172.28.176.1:2050/\", \"http://127.0.0.1:2050/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '35364.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Z3.Linq chargé. CollectionHandling disponible : Array, Constants\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"../Z3.Linq/.deploy/Microsoft.Z3.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/ExpressionUtils.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/Z3.Linq.dll\"\n",
+    "\n",
+    "using Z3.Linq;\n",
+    "using Microsoft.Z3;\n",
+    "using System;\n",
+    "using System.Linq;\n",
+    "\n",
+    "Console.WriteLine($\"Z3.Linq chargé. CollectionHandling disponible : {nameof(CollectionHandling.Array)}, {nameof(CollectionHandling.Constants)}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3cec73d",
+   "metadata": {},
+   "source": [
+    "### Type de grille et théorème Sudoku 4x4\n",
+    "\n",
+    "On définit une grille 4x4 comme un `int[][]`. Le théorème impose : chaque cellule dans `[1,4]`, chaque ligne et chaque colonne a 4 valeurs distinctes (carré latin)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "71f09d1d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T14:05:40.033613Z",
+     "iopub.status.busy": "2026-06-14T14:05:40.032993Z",
+     "iopub.status.idle": "2026-06-14T14:05:40.472097Z",
+     "shell.execute_reply": "2026-06-14T14:05:40.471373Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "public class SudokuGrid4\n",
+    "{\n",
+    "    public int[][] Cells { get; set; } = new int[4][];\n",
+    "    public SudokuGrid4()\n",
+    "    {\n",
+    "        for (int i = 0; i < 4; i++) Cells[i] = new int[4];\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Construit le théorème Sudoku 4x4 (sans contraintes d'indices) sur un Z3Context donné.\n",
+    "// Le mode de collection est hérité du contexte (Array ou Constants).\n",
+    "public static Theorem<SudokuGrid4> BuildSudoku(Z3Context ctx)\n",
+    "{\n",
+    "    var t = ctx.NewTheorem<SudokuGrid4>();\n",
+    "    for (int i = 0; i < 4; i++)\n",
+    "        for (int j = 0; j < 4; j++)\n",
+    "        {\n",
+    "            int i1 = i, j1 = j;\n",
+    "            t = t.Where(g => g.Cells[i1][j1] >= 1 && g.Cells[i1][j1] <= 4);\n",
+    "        }\n",
+    "    for (int r = 0; r < 4; r++)\n",
+    "    {\n",
+    "        int r1 = r;\n",
+    "        t = t.Where(g => Z3Methods.Distinct(g.Cells[r1][0], g.Cells[r1][1], g.Cells[r1][2], g.Cells[r1][3]));\n",
+    "    }\n",
+    "    for (int c = 0; c < 4; c++)\n",
+    "    {\n",
+    "        int c1 = c;\n",
+    "        t = t.Where(g => Z3Methods.Distinct(g.Cells[0][c1], g.Cells[1][c1], g.Cells[2][c1], g.Cells[3][c1]));\n",
+    "    }\n",
+    "    return t;\n",
+    "}\n",
+    "\n",
+    "public static string GridToString(SudokuGrid4 g) =>\n",
+    "    string.Join(\"\\n\", Enumerable.Range(0, 4).Select(r => string.Join(\" \", g.Cells[r])));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d0c2f52",
+   "metadata": {},
+   "source": [
+    "### Résolution en mode `Array` (théorie des tableaux Z3)\n",
+    "\n",
+    "C'est le mode par défaut. `Cells` est modélisé comme **une seule** `ArrayExpr` Z3 (avec une dimension imbriquée pour `int[][]`). L'accès `Cells[i][j]` se traduit par `Select(Select(arr, i), j)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d80a1c4c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T14:05:40.475070Z",
+     "iopub.status.busy": "2026-06-14T14:05:40.474618Z",
+     "iopub.status.idle": "2026-06-14T14:05:40.763532Z",
+     "shell.execute_reply": "2026-06-14T14:05:40.763127Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mode actif : Array\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution (mode Array) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 3 4 1\n",
+      "3 4 1 2\n",
+      "4 1 2 3\n",
+      "1 2 3 4\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var ctxArray = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array };\n",
+    "Console.WriteLine($\"Mode actif : {ctxArray.DefaultCollectionHandling}\");\n",
+    "\n",
+    "var solArray = BuildSudoku(ctxArray).Solve();\n",
+    "Console.WriteLine(\"Solution (mode Array) :\");\n",
+    "Console.WriteLine(GridToString(solArray));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed64899c",
+   "metadata": {},
+   "source": [
+    "### Résolution en mode `Constants` (un constant Z3 par cellule)\n",
+    "\n",
+    "Ici, `Cells` est représenté par **un constant Z3 par élément** : `Cells_0_0`, `Cells_0_1`, …, `Cells_3_3` (16 symboles). C'est le modèle classique de la librairie historique, ressuscité dans le fork. L'accès `Cells[i][j]` crée paresseusement le constant `Cells_i_j` lors de sa première utilisation.\n",
+    "\n",
+    "Le **même** code `BuildSudoku` est réutilisé — seule la configuration du `Z3Context` change. C'est la preuve que les deux modes coexistent proprement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9c0b25e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T14:05:40.766439Z",
+     "iopub.status.busy": "2026-06-14T14:05:40.766003Z",
+     "iopub.status.idle": "2026-06-14T14:05:40.887673Z",
+     "shell.execute_reply": "2026-06-14T14:05:40.886869Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mode actif : Constants\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution (mode Constants) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 3 4 1\n",
+      "3 4 1 2\n",
+      "4 1 2 3\n",
+      "1 2 3 4\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var ctxConst = new Z3Context { DefaultCollectionHandling = CollectionHandling.Constants };\n",
+    "Console.WriteLine($\"Mode actif : {ctxConst.DefaultCollectionHandling}\");\n",
+    "\n",
+    "var solConst = BuildSudoku(ctxConst).Solve();\n",
+    "Console.WriteLine(\"Solution (mode Constants) :\");\n",
+    "Console.WriteLine(GridToString(solConst));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09a6e45a",
+   "metadata": {},
+   "source": [
+    "### Vérification : les deux solutions sont des carrés latins valides\n",
+    "\n",
+    "Indépendamment du mode, le résultat doit satisfaire les contraintes (lignes et colonnes = permutations de 1..4)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "734abd31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T14:05:40.890402Z",
+     "iopub.status.busy": "2026-06-14T14:05:40.890010Z",
+     "iopub.status.idle": "2026-06-14T14:05:41.053147Z",
+     "shell.execute_reply": "2026-06-14T14:05:41.052540Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Array     valide ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Constants valide ? True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "bool IsLatinSquare(SudokuGrid4 g)\n",
+    "{\n",
+    "    var expected = new int[] { 1, 2, 3, 4 };\n",
+    "    for (int r = 0; r < 4; r++)\n",
+    "        if (!g.Cells[r].OrderBy(v => v).SequenceEqual(expected)) return false;\n",
+    "    for (int c = 0; c < 4; c++)\n",
+    "    {\n",
+    "        var col = Enumerable.Range(0, 4).Select(r => g.Cells[r][c]).OrderBy(v => v);\n",
+    "        if (!col.SequenceEqual(expected)) return false;\n",
+    "    }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine($\"Array     valide ? {IsLatinSquare(solArray)}\");\n",
+    "Console.WriteLine($\"Constants valide ? {IsLatinSquare(solConst)}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e382c909",
+   "metadata": {},
+   "source": [
+    "### Indice pédagogique : quand utiliser quel mode ?\n",
+    "\n",
+    "- **`Array`** : quand on veut un modèle compact ou qu'on manipule des index symboliques (ex. « existe-t-il un index `k` tel que… »). C'est aussi le seul mode qui supporte nativement le `int[][]` imbriqué via la théorie des tableaux.\n",
+    "- **`Constants`** : quand on veut qu'apparaissent dans le solver des symboles nommés explicites (`Cells_2_3 = 4`), par exemple pour inspecter le modèle, pour enseigner la notion d'inconnue, ou quand la taille de la collection est fixe et petite.\n",
+    "\n",
+    "Les deux se valent en puissance d'expression pour les CSP statiques comme le Sudoku ; c'est une question de lisibilité et de stratégie de résolution.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Exercices\n",
+    "\n",
+    "### Exercice 1 — Hint dans les deux modes\n",
+    "\n",
+    "Ajoutez la contrainte `g.Cells[0][0] == 2` au théorème et vérifiez que la solution la respecte **dans les deux modes**. Affichez les deux grilles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6a6cf646",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T14:05:41.055983Z",
+     "iopub.status.busy": "2026-06-14T14:05:41.055564Z",
+     "iopub.status.idle": "2026-06-14T14:05:41.109861Z",
+     "shell.execute_reply": "2026-06-14T14:05:41.109010Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 à compléter\n",
+    "// Indice : reprenez BuildSudoku, ajoutez .Where(g => g.Cells[0][0] == 2), solvez dans les deux contextes.\n",
+    "Console.WriteLine(\"Exercice à compléter\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7ea01c5",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Sudoku 9x9 en mode `Constants`\n",
+    "\n",
+    "Définissez un `SudokuGrid9` (9x9) et un théorème avec contraintes de lignes, colonnes **et blocs 3x3**. Résolvez-le en mode `Constants`. *Indice : un bloc partant en `(br, bc)` contient les cellules `Cells[br*3 + di][bc*3 + dj]` pour `di, dj ∈ {0,1,2}`.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "25c06388",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T14:05:41.112786Z",
+     "iopub.status.busy": "2026-06-14T14:05:41.112373Z",
+     "iopub.status.idle": "2026-06-14T14:05:41.161520Z",
+     "shell.execute_reply": "2026-06-14T14:05:41.160949Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 à compléter\n",
+    "Console.WriteLine(\"Exercice à compléter\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7cb39e3",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Comparaison empirique des deux modes\n",
+    "\n",
+    "Mesurez le temps de résolution d'un Sudoku 9x9 (avec quelques indices fixés) en mode `Array` puis en mode `Constants` avec `System.Diagnostics.Stopwatch`. Que constatez-vous ? Quelle hypothèse pouvez-vous formuler sur l'impact du nombre de symboles Z3 sur le temps de résolution ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "09a29341",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T14:05:41.164680Z",
+     "iopub.status.busy": "2026-06-14T14:05:41.164003Z",
+     "iopub.status.idle": "2026-06-14T14:05:41.231021Z",
+     "shell.execute_reply": "2026-06-14T14:05:41.230257Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 à compléter\n",
+    "// Indice : var sw = System.Diagnostics.Stopwatch.StartNew(); ... sw.Stop(); sw.ElapsedMilliseconds;\n",
+    "Console.WriteLine(\"Exercice à compléter\");"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
@@ -42,10 +42,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T03:26:13.179360Z",
-     "iopub.status.busy": "2026-06-12T03:26:13.170855Z",
-     "iopub.status.idle": "2026-06-12T03:26:16.058721Z",
-     "shell.execute_reply": "2026-06-12T03:26:16.055237Z"
+     "iopub.execute_input": "2026-06-14T14:05:18.978330Z",
+     "iopub.status.busy": "2026-06-14T14:05:18.961593Z",
+     "iopub.status.idle": "2026-06-14T14:05:21.474067Z",
+     "shell.execute_reply": "2026-06-14T14:05:21.467886Z"
     },
     "papermill": {
      "duration": 2.909871,
@@ -65,7 +65,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-51308.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-86656.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -110,12 +110,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.14:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.1.14:2050/\", \"http://172.19.64.1:2050/\", \"http://172.28.176.1:2050/\", \"http://127.0.0.1:2050/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '51308.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '86656.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -176,30 +176,23 @@
      "output_type": "display_data"
     },
     {
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Z3.Linq, 2.0.1</span></li></ul></div></div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports OK : Z3.Linq, Microsoft.Z3, System.Linq\r\n"
+      "Imports OK : Z3.Linq (.deploy, CollectionHandling câblé), Microsoft.Z3, System.Linq\r\n"
      ]
     }
    ],
    "source": [
-    "#r \"nuget: Z3.Linq\"\n",
+    "#r \"../Z3.Linq/.deploy/Microsoft.Z3.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/ExpressionUtils.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/Z3.Linq.dll\"\n",
     "using Z3.Linq;\n",
     "using Microsoft.Z3;\n",
     "using System;\n",
     "using System.Collections.Generic;\n",
     "using System.Linq;\n",
-    "Console.WriteLine(\"Imports OK : Z3.Linq, Microsoft.Z3, System.Linq\");"
+    "Console.WriteLine(\"Imports OK : Z3.Linq (.deploy, CollectionHandling câblé), Microsoft.Z3, System.Linq\");"
    ]
   },
   {
@@ -266,10 +259,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T03:26:16.086712Z",
-     "iopub.status.busy": "2026-06-12T03:26:16.086419Z",
-     "iopub.status.idle": "2026-06-12T03:26:16.526543Z",
-     "shell.execute_reply": "2026-06-12T03:26:16.526329Z"
+     "iopub.execute_input": "2026-06-14T14:05:21.477557Z",
+     "iopub.status.busy": "2026-06-14T14:05:21.477014Z",
+     "iopub.status.idle": "2026-06-14T14:05:22.105036Z",
+     "shell.execute_reply": "2026-06-14T14:05:22.104555Z"
     },
     "papermill": {
      "duration": 0.446275,
@@ -383,10 +376,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T03:26:16.562334Z",
-     "iopub.status.busy": "2026-06-12T03:26:16.561033Z",
-     "iopub.status.idle": "2026-06-12T03:26:16.992241Z",
-     "shell.execute_reply": "2026-06-12T03:26:16.991986Z"
+     "iopub.execute_input": "2026-06-14T14:05:22.108237Z",
+     "iopub.status.busy": "2026-06-14T14:05:22.107664Z",
+     "iopub.status.idle": "2026-06-14T14:05:22.733732Z",
+     "shell.execute_reply": "2026-06-14T14:05:22.732811Z"
     },
     "papermill": {
      "duration": 0.439535,
@@ -527,10 +520,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T03:26:17.024581Z",
-     "iopub.status.busy": "2026-06-12T03:26:17.024310Z",
-     "iopub.status.idle": "2026-06-12T03:26:17.195793Z",
-     "shell.execute_reply": "2026-06-12T03:26:17.195471Z"
+     "iopub.execute_input": "2026-06-14T14:05:22.737167Z",
+     "iopub.status.busy": "2026-06-14T14:05:22.736585Z",
+     "iopub.status.idle": "2026-06-14T14:05:22.979856Z",
+     "shell.execute_reply": "2026-06-14T14:05:22.979350Z"
     },
     "papermill": {
      "duration": 0.176983,
@@ -703,10 +696,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T03:26:17.227354Z",
-     "iopub.status.busy": "2026-06-12T03:26:17.227066Z",
-     "iopub.status.idle": "2026-06-12T03:26:17.662791Z",
-     "shell.execute_reply": "2026-06-12T03:26:17.662573Z"
+     "iopub.execute_input": "2026-06-14T14:05:22.983161Z",
+     "iopub.status.busy": "2026-06-14T14:05:22.982607Z",
+     "iopub.status.idle": "2026-06-14T14:05:23.576431Z",
+     "shell.execute_reply": "2026-06-14T14:05:23.575976Z"
     },
     "papermill": {
      "duration": 0.441403,
@@ -915,10 +908,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T03:26:17.701111Z",
-     "iopub.status.busy": "2026-06-12T03:26:17.700790Z",
-     "iopub.status.idle": "2026-06-12T03:26:18.117453Z",
-     "shell.execute_reply": "2026-06-12T03:26:18.117265Z"
+     "iopub.execute_input": "2026-06-14T14:05:23.579470Z",
+     "iopub.status.busy": "2026-06-14T14:05:23.578985Z",
+     "iopub.status.idle": "2026-06-14T14:05:24.123699Z",
+     "shell.execute_reply": "2026-06-14T14:05:24.122872Z"
     },
     "papermill": {
      "duration": 0.423831,
@@ -1132,6 +1125,123 @@
   },
   {
    "cell_type": "markdown",
+   "id": "46e98e84",
+   "metadata": {},
+   "source": [
+    "## 8. La feature ressuscitee : `CollectionHandling` (mode Array vs Constants)\n",
+    "\n",
+    "Jusqu'ici, ce notebook utilisait le fork `Z3.Linq` charge depuis NuGet. Depuis le **14/06/2026**, le fork embarque une enum `CollectionHandling` qui etait **definie mais jamais câblee** (dead code). Elle est desormais **vivante** : le meme code LINQ peut resoudre un CSP en modelisant les collections de deux facons differentes.\n",
+    "\n",
+    "| Mode | Modelisation Z3 | Avantage pedagogique |\n",
+    "|------|----------------|----------------------|\n",
+    "| **`Array`** (défaut) | Une seule `ArrayExpr` Z3 + `Select`/`Store` (theorie des tableaux) | Compact, supporte les index symboliques |\n",
+    "| **`Constants`** | Un constant Z3 par element (`TotalCal_0`, `TotalCal_1`, ...) | « un symbole = une inconnue », lisible dans le modele |\n",
+    "\n",
+    "Pour illustrer concretement, modelisons une **assiette de 3 plats** (entree, plat, dessert) comme un `int[]` de couts, et resolvons un mini-theoreme dans les **deux modes** avec le **meme** code. C'est la preuve que `CollectionHandling` est fonctionnelle bout-en-bout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b6203e70",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T14:05:24.126692Z",
+     "iopub.status.busy": "2026-06-14T14:05:24.126204Z",
+     "iopub.status.idle": "2026-06-14T14:05:24.539139Z",
+     "shell.execute_reply": "2026-06-14T14:05:24.537587Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mode Array     : Array\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mode Constants : Constants\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Solution (mode Array)     : 100, 102, 101\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution (mode Constants) : 100, 101, 102\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demonstration CollectionHandling : un meme theoreme resolu en mode Array puis Constants.\n",
+    "// Plate = assiette de 3 couts (entree, plat, dessert). On impose : chaque cout dans [100, 800],\n",
+    "// et les 3 couts distincts (un menu varie ne repet pas le meme prix).\n",
+    "\n",
+    "public class Plate\n",
+    "{\n",
+    "    public int[] Costs { get; set; } = new int[3];\n",
+    "}\n",
+    "\n",
+    "public static Theorem<Plate> BuildPlate(Z3Context ctx)\n",
+    "{\n",
+    "    var t = ctx.NewTheorem<Plate>();\n",
+    "    for (int i = 0; i < 3; i++)\n",
+    "    {\n",
+    "        int i1 = i;\n",
+    "        t = t.Where(p => p.Costs[i1] >= 100 && p.Costs[i1] <= 800);\n",
+    "    }\n",
+    "    // 3 couts distincts = menu varie\n",
+    "    t = t.Where(p => Z3Methods.Distinct(p.Costs[0], p.Costs[1], p.Costs[2]));\n",
+    "    return t;\n",
+    "}\n",
+    "\n",
+    "var ctxArray = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array };\n",
+    "var ctxConst = new Z3Context { DefaultCollectionHandling = CollectionHandling.Constants };\n",
+    "\n",
+    "Console.WriteLine($\"Mode Array     : {ctxArray.DefaultCollectionHandling}\");\n",
+    "Console.WriteLine($\"Mode Constants : {ctxConst.DefaultCollectionHandling}\");\n",
+    "\n",
+    "var solArray = BuildPlate(ctxArray).Solve();\n",
+    "var solConst = BuildPlate(ctxConst).Solve();\n",
+    "\n",
+    "Console.WriteLine(\"\\nSolution (mode Array)     : \" + string.Join(\", \", solArray.Costs));\n",
+    "Console.WriteLine(\"Solution (mode Constants) : \" + string.Join(\", \", solConst.Costs));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "800c9569",
+   "metadata": {},
+   "source": [
+    "### Interpretation — dead code ressuscite\n",
+    "\n",
+    "Le **meme** code `BuildPlate` resout le CSP dans les deux modes. La seule difference est la configuration du `Z3Context` :\n",
+    "\n",
+    "- **Mode Array** : `Cells`/`Costs` est une seule `ArrayExpr` Z3. L'acces `Costs[i]` genere un `Select(arr, i)`. Compact.\n",
+    "- **Mode Constants** : chaque element `Costs[i]` est un constant Z3 nomme (`Costs_0`, `Costs_1`, `Costs_2`). Si on inspectait le modele Z3, on verrait ces 3 symboles explicites = modele « humain ».\n",
+    "\n",
+    "| Aspect | Array | Constants |\n",
+    "|--------|-------|-----------|\n",
+    "| Symboles Z3 crees | 1 (l'array) | N (1 par element) |\n",
+    "| Index symbolique | supporte | non (taille fixe) |\n",
+    "| Lisibilite modele | - | « un symbole = une inconnue » |\n",
+    "\n",
+    "C'est la preuve directe que l'enum `CollectionHandling` — historiquement du dead code defini mais jamais câble — est desormais **fonctionnelle bout-en-bout** (construction d'environnement → visite des contraintes → extraction du modele) dans les deux modes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b1a22ae3",
    "metadata": {
     "papermill": {
@@ -1174,17 +1284,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "21080ada",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T03:26:18.183316Z",
-     "iopub.status.busy": "2026-06-12T03:26:18.183025Z",
-     "iopub.status.idle": "2026-06-12T03:26:18.298552Z",
-     "shell.execute_reply": "2026-06-12T03:26:18.298267Z"
+     "iopub.execute_input": "2026-06-14T14:05:24.544494Z",
+     "iopub.status.busy": "2026-06-14T14:05:24.543735Z",
+     "iopub.status.idle": "2026-06-14T14:05:24.643835Z",
+     "shell.execute_reply": "2026-06-14T14:05:24.643140Z"
     },
     "papermill": {
      "duration": 0.12672,
@@ -1247,17 +1357,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "3b5286f9",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T03:26:18.325899Z",
-     "iopub.status.busy": "2026-06-12T03:26:18.325602Z",
-     "iopub.status.idle": "2026-06-12T03:26:18.378888Z",
-     "shell.execute_reply": "2026-06-12T03:26:18.378619Z"
+     "iopub.execute_input": "2026-06-14T14:05:24.646859Z",
+     "iopub.status.busy": "2026-06-14T14:05:24.646322Z",
+     "iopub.status.idle": "2026-06-14T14:05:24.715137Z",
+     "shell.execute_reply": "2026-06-14T14:05:24.714717Z"
     },
     "papermill": {
      "duration": 0.060405,
@@ -1317,17 +1427,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "3b1388df",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T03:26:18.409134Z",
-     "iopub.status.busy": "2026-06-12T03:26:18.408812Z",
-     "iopub.status.idle": "2026-06-12T03:26:18.456076Z",
-     "shell.execute_reply": "2026-06-12T03:26:18.455791Z"
+     "iopub.execute_input": "2026-06-14T14:05:24.718736Z",
+     "iopub.status.busy": "2026-06-14T14:05:24.718212Z",
+     "iopub.status.idle": "2026-06-14T14:05:24.776260Z",
+     "shell.execute_reply": "2026-06-14T14:05:24.775778Z"
     },
     "papermill": {
      "duration": 0.056005,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -4,7 +4,7 @@
 
 ## Série en quelques mots
 
-**5 notebooks** | **1 kernel** | **~4h de travail** | **Z3.Linq (.NET 9)**
+**6 notebooks** | **1 kernel** | **~4h30 de travail** | **Z3.Linq (.NET 9)**
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs C# souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de théorèmes linéaires simples pour monter progressivement vers les théories de tableaux et l'optimisation hiérarchique.
 
@@ -30,6 +30,7 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 |---|----------|-------|------|--------|
 | 01 | [Linq2Z3 Intro](01_Linq2Z3_Intro.ipynb) | Théorèmes linéaires, Missionnaires-Cannibales, optimisation | ~45 min | PRODUCTION |
 | 02 | [Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | Sudoku explicite (81 propriétés) vs implicite (`List<int>` + lambdas/closures) | ~50 min | PRODUCTION |
+| 02b | [Sudoku Modes Comparison](02b_Sudoku_Modes_Comparison.ipynb) | **`CollectionHandling`** ressuscité : même Sudoku 4x4 résolu en mode `Array` vs `Constants` | ~25 min | BETA |
 | 03 | [Array Theory](03_Array_Theory.ipynb) | Z3 array theory : Select/Store, switching dynamique | ~45 min | BETA |
 | 04 | [Nested Arrays 2D](04_Nested_Arrays_2D.ipynb) | Tableaux imbriqués, grilles 2D, Sudoku 4x4, carré magique | ~40 min | BETA |
 | 05 | [Meal Planner Hierarchical](05_Meal_Planner_Hierarchical.ipynb) | Planificateur de repas : data fusion LINQ + théorème hiérarchique | ~50 min | BETA |
@@ -38,9 +39,10 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 
 1. **Notebook 01** pose les bases : le patron `Theorem<T>` de Z3.Linq, les théorèmes linéaires, la recherche de plus court chemin, et le classique Missionnaires-Cannibales
 2. **Notebook 02** compare deux approches du Sudoku : 81 propriétés explicites vs modélisation implicite via arrays et lambdas
-3. **Notebook 03** plonge dans la théorie des tableaux Z3 (Select/Store), avec switching dynamique entre représentations
-4. **Notebook 04** généralise aux tableaux imbriqués (2D) : grilles, carrés magiques, Sudoku 4x4
-5. **Notebook 05** intègre tout : data fusion LINQ + théorème hiérarchique multi-niveaux pour un planificateur de repas réaliste
+3. **Notebook 02b** démontre la feature ressuscitée `CollectionHandling` (mode `Array` vs `Constants`) sur un même Sudoku 4x4, preuve directe que l'enum précédemment morte est désormais câblée bout-en-bout
+4. **Notebook 03** plonge dans la théorie des tableaux Z3 (Select/Store), avec switching dynamique entre représentations
+5. **Notebook 04** généralise aux tableaux imbriqués (2D) : grilles, carrés magiques, Sudoku 4x4
+6. **Notebook 05** intègre tout : data fusion LINQ + théorème hiérarchique multi-niveaux pour un planificateur de repas réaliste, et démontre le mode `CollectionHandling.Constants` (feature ressuscitée du fork)
 
 ## Prérequis
 
@@ -49,19 +51,19 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 | **.NET 9.0 SDK** | [Download](https://dotnet.microsoft.com/download/dotnet/9.0) |
 | **.NET Interactive** | `dotnet tool install --global Microsoft.dotnet-interactive` |
 | **Kernel Jupyter** | `.net-csharp` (installe automatiquement par .NET Interactive) |
-| **Package NuGet** | `Z3.Linq` (NB-01, 02, 03, 05 : charge automatiquement via `#r nuget:...`) |
-| **NB-04 — fork `int[][]`** | Le notebook 04 utilise le fork [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) (support `int[][]` absent du NuGet public endjin). Exécuter **une fois** : [`scripts/environment/z3-build-deploy.ps1`](../../../../scripts/environment/z3-build-deploy.ps1) (Windows) ou [`.sh`](../../../../scripts/environment/z3-build-deploy.sh) (Linux/macOS) — compile uniquement le wrapper (~1,5 s) et rassemble les 4 DLL dans `.deploy/`. |
+| **Package NuGet** | `Z3.Linq` (NB-01, 02, 03 : charge automatiquement via `#r nuget:...`) |
+| **NB-02b, 04, 05 — fork** | Les notebooks 02b, 04 et 05 utilisent le fork [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) : NB-04 pour le support `int[][]` (absent du NuGet public endjin), NB-02b et NB-05 pour la feature `CollectionHandling` (mode `Constants` ressuscité, câblée le 14/06/2026). Exécuter **une fois** : [`scripts/environment/z3-build-deploy.ps1`](../../../../scripts/environment/z3-build-deploy.ps1) (Windows) ou [`.sh`](../../../../scripts/environment/z3-build-deploy.sh) (Linux/macOS) — compile uniquement le wrapper (~1,5 s) et rassemble les 4 DLL dans `.deploy/`. |
 
-> Les notebooks sont autonomes : le restore NuGet et l'initialisation du contexte Z3 sont inclus dans les cellules de setup de chaque notebook. **Exception** : le notebook 04 (tableaux imbriqués 2D) charge le fork via `#r "../Z3.Linq/.deploy/..."`, d'où le pré-requis du script de build ci-dessus (décision ai-01 [DECISION COORD] 2026-06-13, option (b)).
+> Les notebooks sont autonomes : le restore NuGet et l'initialisation du contexte Z3 sont inclus dans les cellules de setup de chaque notebook. **Exception** : les notebooks 02b, 04 et 05 chargent le fork via `#r "../Z3.Linq/.deploy/..."`, d'où le pré-requis du script de build ci-dessus (décision ai-01 [DECISION COORD] 2026-06-13, option (b), étendue à 02b/05 le 14/06/2026 pour `CollectionHandling`).
 
 ### Configuration : NuGet public vs fork
 
 La série suit une stratégie à deux volets selon le besoin en tableaux imbriqués (`int[][]`) :
 
-| Notebooks      | Source                      | Chargement                    | Pré-requis        |
-|----------------|-----------------------------|-------------------------------|-------------------|
-| 01, 02, 03, 05 | NuGet public `Z3.Linq`      | `#r nuget:Z3.Linq,...`        | Aucun (auto)      |
-| 04 (tableaux)  | Fork (voir ci-dessus)       | `#r "../Z3.Linq/.deploy/..."` | Script de build   |
+| Notebooks      | Source                 | Chargement                    | Pré-requis      |
+|----------------|------------------------|-------------------------------|-----------------|
+| 01, 02, 03     | NuGet public `Z3.Linq` | `#r nuget:Z3.Linq,...`        | Aucun (auto)    |
+| 02b, 04, 05    | Fork (voir ci-dessus)  | `#r "../Z3.Linq/.deploy/..."` | Script de build |
 
 **Pourquoi un fork pour le notebook 04 ?** Le support des tableaux imbriqués `int[][]` (construction de sort Z3 `Array Int (Array Int Int)`, extraction récursive `ExtractCollection`) provient de [Z3.LinqBinding@EPFdevelopment](https://github.com/MyIntelligenceAgency/Z3.LinqBinding/tree/EPFdevelopment) et n'existe pas dans le NuGet public endjin (`Z3.Linq` 2.0.1, qui ne gère qu'un seul niveau de collection). Publier un NuGet forké n'est pas possible (nous ne sommes pas propriétaires du *package-id*), d'où le script qui compile **uniquement** le wrapper fin et rassemble le solveur natif + les dépendances managées depuis le cache NuGet.
 


### PR DESCRIPTION
## What

Resurrects the previously-dead `CollectionHandling` enum across the Z3 notebook series. The fork ([MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq)) now wires the **Constants mode end-to-end** (environment construction → constraint visiting → model extraction) alongside the existing Array mode, with **default = Array** preserving the current behavior.

This is a **lib+notebook co-évolution** PR: the fork feature (PR [#1](https://github.com/MyIntelligenceAgency/Z3.Linq/pull/1), merged) lands first, then the CoursIA notebooks demonstrate it.

## Why

North (user, via ai-01 2026-06-14): *"il faudrait réparer cette enum pour que tout soit correctement pris en charge (...) basculer sur notre fork z3.Linq partout (...) on le ressuscite !"*

The `CollectionHandling { Constants, Array }` enum and `MultipleEnvironment` class were **defined but never wired** — pure dead code. The user asked to resurrect it (not teach around it). Deadline: réunion Nicolas **15/06**.

## Changes

| File | Change |
|------|--------|
| Submodule `Z3.Linq` | `096a638` → `62c277f` (fork PR #1: Constants mode wired + xUnit tests) |
| `02b_Sudoku_Modes_Comparison.ipynb` (new) | Sudoku 4x4 solved in Array vs Constants modes — most direct proof the enum is now functional |
| `05_Meal_Planner_Hierarchical.ipynb` | Recabled cell 1 from `#r "nuget: Z3.Linq"` to `.deploy/` (fork DLL). Added §8 demonstrating both modes on the meal-planner Plate model |
| `README.md` | Documents the fork dependency (02b, 04, 05) + the feature |

## Verification (real execution, not keywords)

- **`dotnet test` fork** → `6/6 PASS` (Sudoku 4x4 in **both** Array + Constants modes, flat `int[]` Constants, hint honored both modes, default=Array guard)
- **NB-02b** → `8/8` cells executed via `.net-csharp` kernel, `0 errors`, `0 null-exec`. Output shows both modes produce a valid 4x4 Latin square.
- **NB-05** → `10/10` cells executed, `0 errors`, `0 null-exec`. §8 output shows Array=`100, 102, 101`, Constants=`100, 101, 102` (both valid distinct-cost plates).
- **NB-04 (nested-array, Array mode)** → untouched, `0` source change = **anti-régression confirmed** (the user's hand-typed `int[][]` support preserved byte-identical).
- **H.3 pre-commit** → `null_exec=0`, `errors=0`, C.1 OK (no `raise NotImplementedError`) on both notebooks.
- **`.deploy/` rebuilt** via `scripts/environment/z3-build-deploy.ps1 -Force` → `CollectionHandling present (fork feature OK)`.

## Anti-régression (HARD)

- Default mode = `Array` = behavior unchanged. The Array mode + nested-array Object branch in the fork are untouched.
- No example/solution cell removed (NB-05 diff: only source change is the cell-1 import rewire; "deletions" are the old `#r "nuget: Z3.Linq"` line).

See #1206 (epic — partial delivery: fork feature + 2 demonstrator notebooks; NB-05 raw-Z3 cells (§3, §5) not yet converted to LINQ DSL = future work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>