### PR TITLE
feat(z3): rewire NB-03 Array Theory from NuGet to fork .deploy/ (See #1206)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
@@ -50,10 +50,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:22.456749Z",
-     "iopub.status.busy": "2026-06-12T00:19:22.451885Z",
-     "iopub.status.idle": "2026-06-12T00:19:24.794091Z",
-     "shell.execute_reply": "2026-06-12T00:19:24.789141Z"
+     "iopub.execute_input": "2026-06-14T14:51:15.062829Z",
+     "iopub.status.busy": "2026-06-14T14:51:15.055894Z",
+     "iopub.status.idle": "2026-06-14T14:51:16.326480Z",
+     "shell.execute_reply": "2026-06-14T14:51:16.323039Z"
     },
     "papermill": {
      "duration": 2.349404,
@@ -73,7 +73,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-18100.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-2908.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -118,12 +118,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.14:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.1.14:2050/\", \"http://172.19.64.1:2050/\", \"http://172.28.176.1:2050/\", \"http://127.0.0.1:2050/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '18100.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '2908.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -184,55 +184,18 @@
      "output_type": "display_data"
     },
     {
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Z3.Linq, 2.0.1</span></li></ul></div></div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "#r \"nuget: Z3.Linq\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "c3d4e5f2",
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    },
-    "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:24.816882Z",
-     "iopub.status.busy": "2026-06-12T00:19:24.815802Z",
-     "iopub.status.idle": "2026-06-12T00:19:25.527675Z",
-     "shell.execute_reply": "2026-06-12T00:19:25.527457Z"
-    },
-    "papermill": {
-     "duration": 0.726114,
-     "end_time": "2026-06-12T00:19:25.527778+00:00",
-     "exception": false,
-     "start_time": "2026-06-12T00:19:24.801664+00:00",
-     "status": "completed"
-    },
-    "polyglot_notebook": {
-     "kernelName": "csharp"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports OK : Z3.Linq, Microsoft.Z3, System.Linq\r\n"
+      "Imports OK : Z3.Linq (.deploy, CollectionHandling câblé), Microsoft.Z3, System.Linq\r\n"
      ]
     }
    ],
    "source": [
+    "#r \"../Z3.Linq/.deploy/Microsoft.Z3.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/ExpressionUtils.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/Z3.Linq.dll\"\n",
+    "\n",
     "using Z3.Linq;\n",
     "using Microsoft.Z3;\n",
     "using System;\n",
@@ -240,7 +203,7 @@
     "using System.Linq;\n",
     "using System.Text;\n",
     "\n",
-    "Console.WriteLine(\"Imports OK : Z3.Linq, Microsoft.Z3, System.Linq\");"
+    "Console.WriteLine(\"Imports OK : Z3.Linq (.deploy, CollectionHandling câblé), Microsoft.Z3, System.Linq\");"
    ]
   },
   {
@@ -318,17 +281,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "f6a7b8c5",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:25.556462Z",
-     "iopub.status.busy": "2026-06-12T00:19:25.556121Z",
-     "iopub.status.idle": "2026-06-12T00:19:26.121478Z",
-     "shell.execute_reply": "2026-06-12T00:19:26.121272Z"
+     "iopub.execute_input": "2026-06-14T14:51:16.332170Z",
+     "iopub.status.busy": "2026-06-14T14:51:16.331045Z",
+     "iopub.status.idle": "2026-06-14T14:51:17.101957Z",
+     "shell.execute_reply": "2026-06-14T14:51:17.101679Z"
     },
     "papermill": {
      "duration": 0.571302,
@@ -466,17 +429,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "c9d0e1f8",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:26.152097Z",
-     "iopub.status.busy": "2026-06-12T00:19:26.151806Z",
-     "iopub.status.idle": "2026-06-12T00:19:26.357372Z",
-     "shell.execute_reply": "2026-06-12T00:19:26.357157Z"
+     "iopub.execute_input": "2026-06-14T14:51:17.104274Z",
+     "iopub.status.busy": "2026-06-14T14:51:17.103815Z",
+     "iopub.status.idle": "2026-06-14T14:51:17.366349Z",
+     "shell.execute_reply": "2026-06-14T14:51:17.365925Z"
     },
     "papermill": {
      "duration": 0.211546,
@@ -637,17 +600,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "f2a3b4cb",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:26.387244Z",
-     "iopub.status.busy": "2026-06-12T00:19:26.386898Z",
-     "iopub.status.idle": "2026-06-12T00:19:26.644827Z",
-     "shell.execute_reply": "2026-06-12T00:19:26.644575Z"
+     "iopub.execute_input": "2026-06-14T14:51:17.369345Z",
+     "iopub.status.busy": "2026-06-14T14:51:17.368877Z",
+     "iopub.status.idle": "2026-06-14T14:51:17.749312Z",
+     "shell.execute_reply": "2026-06-14T14:51:17.748958Z"
     },
     "papermill": {
      "duration": 0.263981,
@@ -941,17 +904,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "c5d6e7fe",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:26.679487Z",
-     "iopub.status.busy": "2026-06-12T00:19:26.679072Z",
-     "iopub.status.idle": "2026-06-12T00:19:27.007429Z",
-     "shell.execute_reply": "2026-06-12T00:19:27.007206Z"
+     "iopub.execute_input": "2026-06-14T14:51:17.751560Z",
+     "iopub.status.busy": "2026-06-14T14:51:17.751173Z",
+     "iopub.status.idle": "2026-06-14T14:51:18.107170Z",
+     "shell.execute_reply": "2026-06-14T14:51:18.106804Z"
     },
     "papermill": {
      "duration": 0.334958,
@@ -1176,17 +1139,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "f8a9b0c1",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:27.042548Z",
-     "iopub.status.busy": "2026-06-12T00:19:27.042273Z",
-     "iopub.status.idle": "2026-06-12T00:19:27.323865Z",
-     "shell.execute_reply": "2026-06-12T00:19:27.323677Z"
+     "iopub.execute_input": "2026-06-14T14:51:18.109785Z",
+     "iopub.status.busy": "2026-06-14T14:51:18.109352Z",
+     "iopub.status.idle": "2026-06-14T14:51:18.563277Z",
+     "shell.execute_reply": "2026-06-14T14:51:18.562379Z"
     },
     "papermill": {
      "duration": 0.288554,
@@ -1538,17 +1501,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "c1d2e3f4",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:27.364902Z",
-     "iopub.status.busy": "2026-06-12T00:19:27.364633Z",
-     "iopub.status.idle": "2026-06-12T00:19:27.583001Z",
-     "shell.execute_reply": "2026-06-12T00:19:27.582821Z"
+     "iopub.execute_input": "2026-06-14T14:51:18.566589Z",
+     "iopub.status.busy": "2026-06-14T14:51:18.566035Z",
+     "iopub.status.idle": "2026-06-14T14:51:18.914159Z",
+     "shell.execute_reply": "2026-06-14T14:51:18.913146Z"
     },
     "papermill": {
      "duration": 0.226311,
@@ -1710,17 +1673,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "f4a5b6c7",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:27.626791Z",
-     "iopub.status.busy": "2026-06-12T00:19:27.626527Z",
-     "iopub.status.idle": "2026-06-12T00:19:27.687298Z",
-     "shell.execute_reply": "2026-06-12T00:19:27.687123Z"
+     "iopub.execute_input": "2026-06-14T14:51:18.917269Z",
+     "iopub.status.busy": "2026-06-14T14:51:18.916705Z",
+     "iopub.status.idle": "2026-06-14T14:51:19.017124Z",
+     "shell.execute_reply": "2026-06-14T14:51:19.016716Z"
     },
     "papermill": {
      "duration": 0.068916,
@@ -1788,17 +1751,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "b6c7d8e9",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:27.716690Z",
-     "iopub.status.busy": "2026-06-12T00:19:27.716417Z",
-     "iopub.status.idle": "2026-06-12T00:19:27.757523Z",
-     "shell.execute_reply": "2026-06-12T00:19:27.757345Z"
+     "iopub.execute_input": "2026-06-14T14:51:19.019827Z",
+     "iopub.status.busy": "2026-06-14T14:51:19.019361Z",
+     "iopub.status.idle": "2026-06-14T14:51:19.081523Z",
+     "shell.execute_reply": "2026-06-14T14:51:19.080625Z"
     },
     "papermill": {
      "duration": 0.049856,
@@ -1868,17 +1831,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "d8e9fa0b",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-12T00:19:27.799635Z",
-     "iopub.status.busy": "2026-06-12T00:19:27.798714Z",
-     "iopub.status.idle": "2026-06-12T00:19:27.834052Z",
-     "shell.execute_reply": "2026-06-12T00:19:27.833870Z"
+     "iopub.execute_input": "2026-06-14T14:51:19.084205Z",
+     "iopub.status.busy": "2026-06-14T14:51:19.083724Z",
+     "iopub.status.idle": "2026-06-14T14:51:19.134142Z",
+     "shell.execute_reply": "2026-06-14T14:51:19.133417Z"
     },
     "papermill": {
      "duration": 0.046696,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -51,10 +51,10 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 | **.NET 9.0 SDK** | [Download](https://dotnet.microsoft.com/download/dotnet/9.0) |
 | **.NET Interactive** | `dotnet tool install --global Microsoft.dotnet-interactive` |
 | **Kernel Jupyter** | `.net-csharp` (installe automatiquement par .NET Interactive) |
-| **Package NuGet** | `Z3.Linq` (NB-01, 02, 03 : charge automatiquement via `#r nuget:...`) |
-| **NB-02b, 04, 05 — fork** | Les notebooks 02b, 04 et 05 utilisent le fork [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) : NB-04 pour le support `int[][]` (absent du NuGet public endjin), NB-02b et NB-05 pour la feature `CollectionHandling` (mode `Constants` ressuscité, câblée le 14/06/2026). Exécuter **une fois** : [`scripts/environment/z3-build-deploy.ps1`](../../../../scripts/environment/z3-build-deploy.ps1) (Windows) ou [`.sh`](../../../../scripts/environment/z3-build-deploy.sh) (Linux/macOS) — compile uniquement le wrapper (~1,5 s) et rassemble les 4 DLL dans `.deploy/`. |
+| **Package NuGet** | `Z3.Linq` (NB-01, 02 : charge automatiquement via `#r nuget:...`) |
+| **NB-02b, 03, 04, 05 — fork** | Les notebooks 02b, 03, 04 et 05 utilisent le fork [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) : NB-04 pour le support `int[][]` (absent du NuGet public endjin), NB-02b, NB-03 et NB-05 pour la feature `CollectionHandling` (mode `Constants` ressuscité, câblée le 14/06/2026). Exécuter **une fois** : [`scripts/environment/z3-build-deploy.ps1`](../../../../scripts/environment/z3-build-deploy.ps1) (Windows) ou [`.sh`](../../../../scripts/environment/z3-build-deploy.sh) (Linux/macOS) — compile uniquement le wrapper (~1,5 s) et rassemble les 4 DLL dans `.deploy/`. |
 
-> Les notebooks sont autonomes : le restore NuGet et l'initialisation du contexte Z3 sont inclus dans les cellules de setup de chaque notebook. **Exception** : les notebooks 02b, 04 et 05 chargent le fork via `#r "../Z3.Linq/.deploy/..."`, d'où le pré-requis du script de build ci-dessus (décision ai-01 [DECISION COORD] 2026-06-13, option (b), étendue à 02b/05 le 14/06/2026 pour `CollectionHandling`).
+> Les notebooks sont autonomes : le restore NuGet et l'initialisation du contexte Z3 sont inclus dans les cellules de setup de chaque notebook. **Exception** : les notebooks 02b, 03, 04 et 05 chargent le fork via `#r "../Z3.Linq/.deploy/..."`, d'où le pré-requis du script de build ci-dessus (décision ai-01 [DECISION COORD] 2026-06-13, option (b), étendue à 02b/03/05 le 14/06/2026 pour `CollectionHandling`).
 
 ### Configuration : NuGet public vs fork
 
@@ -62,8 +62,8 @@ La série suit une stratégie à deux volets selon le besoin en tableaux imbriqu
 
 | Notebooks      | Source                 | Chargement                    | Pré-requis      |
 |----------------|------------------------|-------------------------------|-----------------|
-| 01, 02, 03     | NuGet public `Z3.Linq` | `#r nuget:Z3.Linq,...`        | Aucun (auto)    |
-| 02b, 04, 05    | Fork (voir ci-dessus)  | `#r "../Z3.Linq/.deploy/..."` | Script de build |
+| 01, 02         | NuGet public `Z3.Linq` | `#r nuget:Z3.Linq,...`        | Aucun (auto)    |
+| 02b, 03, 04, 05| Fork (voir ci-dessus)  | `#r "../Z3.Linq/.deploy/..."` | Script de build |
 
 **Pourquoi un fork pour le notebook 04 ?** Le support des tableaux imbriqués `int[][]` (construction de sort Z3 `Array Int (Array Int Int)`, extraction récursive `ExtractCollection`) provient de [Z3.LinqBinding@EPFdevelopment](https://github.com/MyIntelligenceAgency/Z3.LinqBinding/tree/EPFdevelopment) et n'existe pas dans le NuGet public endjin (`Z3.Linq` 2.0.1, qui ne gère qu'un seul niveau de collection). Publier un NuGet forké n'est pas possible (nous ne sommes pas propriétaires du *package-id*), d'où le script qui compile **uniquement** le wrapper fin et rassemble le solveur natif + les dépendances managées depuis le cache NuGet.
 


### PR DESCRIPTION
## Summary

NB-03 was the **last notebook on the Z3 main series still loading the public endjin NuGet** (`#r "nuget: Z3.Linq"`). Migrated to the fork `.deploy/` mechanism (documented in #2925) so it consumes the CollectionHandling-wired Z3.Linq — bringing NB-03 in line with NB-02b/04/05 and the user mandate *"basculer sur notre fork z3.Linq partout"*.

User verdict (14/06, via ai-01): « il faudrait réparer cette enum pour que tout soit correctement pris en charge (…) basculer sur notre fork z3.Linq partout où c'est utile (…) on le ressuscite ! »

## Scope (2 files, atomic)

- **NB-03 `03_Array_Theory.ipynb`**: import cell rewired `#r "nuget: Z3.Linq"` → 3× `#r "../Z3.Linq/.deploy/*.dll"`; the redundant standalone `using` cell merged into it (matches NB-05 layout).
- **README**: NB-03 moved from the "NuGet public" row to the "fork" row in both the prereqs table and the configuration table (02b/03/04/05 now all on fork).

## What this is NOT (anti-régression + pedagogical honesty)

The raw `Microsoft.Z3` API usage in NB-03 (**Store/Switching in Exemples 2-5**) is **intentional and preserved**. Z3.Linq does not express `Store`, and the notebook's §5 explicitly teaches the *"Z3 API ↔ Z3.Linq bridge"* — that duality is the pedagogical point. This PR is a **package-loading migration**, not a DSL rewrite.

The ai-01 dispatch mentioned "~200 raw Z3 calls → LINQ" — the honest reading is that `CollectionHandling.Array` concerns *collection encoding*, not the Store operation. Converting the Store cells to LINQ would be technically impossible (no Store in the DSL) and would destroy the §5 bridge lesson. The real debt was that NB-03 ran on the NuGet-without-CollectionHandling while 02b/04/05 had moved on — that gap is now closed.

## Verification

- **Default `CollectionHandling.Array` reproduces NuGet public behavior** for flat `int[]`: Exemple 1 (Select) and Exemple 6 (permutation) both green on the fork — anti-régression confirmed.
- Re-executed `.net-csharp` kernel: **10/10 code cells**, `execution_count` 1–10 contiguous, **0 null-exec, 0 error** (H.1/H.3).
- **C.1**: 0 `raise NotImplementedError` / `assert False` / `1/0`.
- 0 catalog files touched.

`See #1206`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)