### PR TITLE
docs(qc): document Phase 4 architectural constraint IBKR-rejects-Crypto (See #1027)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
@@ -51,6 +51,15 @@ Stratégie composite multi-broker associant un sleeve actions/ETFs (IBKR compte 
 - Connexion paper IBKR + Binance testnet
 - Logging quotidien : fills réels vs backtest, slippage, market impact
 - Comparison live drift vs expected returns/vol
+- **Contrainte architecturale (leçon Phase 2)** : `set_brokerage_model(IBKR)` REJETTE
+  le type Crypto ("Unsupported security type") → un backtest unifié 2-broker n'est pas
+  transposable tel quel en live unified. Deux approches pour Phase 4 :
+  1. **Binance-first** (recommandé, un seul nœud) : paper trader le sleeve crypto seul
+     sur Binance testnet (sleeve IBKR en backtest parallèle, agrégation manuelle) ;
+  2. **2 algorithms séparés** (Phase 5) : un algorithm IBKR (equities) + un algorithm
+     Binance (crypto), chacun sur son nœud QC Cloud, agrégation des P&L hors-pipeline.
+- **Gate** : credentials IBKR paper prêts côté user (mdp reset 12/06, cf #1199) ;
+  reste MAJ `.env` + test login IB Gateway avant exécution.
 
 ### Phase 5 — Live nodes QC (S4+)
 - Déploiement sur 2 nœuds QC Cloud (1 par broker)


### PR DESCRIPTION
## Summary

Phase 4 (paper trading) section of the Portfolio Hybride IBKR+Binance README was high-level ("Connexion paper IBKR + Binance testnet"). Enriched it with the **Phase 2 architectural lesson** that gates the whole Phase 4 design.

## What changed (+9 lines, 0 deletions, README only)

Added under `### Phase 4`:
- **Contrainte architecturale** : `set_brokerage_model(IBKR)` REJETTE le type Crypto ("Unsupported security type") — discovered during Phase 2 (#2950/#2952). A unified 2-broker backtest is therefore **not transposable to live unified**.
- **2 approches** documented: (1) **Binance-first** single-node (crypto sleeve paper-traded on Binance testnet, IBKR sleeve backtest-paralleled, manual P&L aggregation) — recommended; (2) **2 algorithms séparés** (Phase 5, 2 QC Cloud nodes, one per broker).
- **Gate** : credentials IBKR paper prêts côté user (mdp reset 12/06, cf #1199) ; reste MAJ `.env` + test login IB Gateway avant exécution.

## Why

Prepares the **Phase 4 architectural decision** for the 15/06 review (réunion Nicolas). The IBKR-rejects-Crypto constraint is the dominant design driver for Phase 4/5 — documenting it in the roadmap (not just in code comments / dashboard) makes the trade-off visible to anyone reading the project. Pure additive doc, no behavior change.

## Validation
- Diff: +9/-0, 1 file (README.md), section Phase 4 only
- Anti-régression (rule D): 0 deletions of existing content, additive enrichment
- Catalog byte-identical to main (only README touched)
- `See #1027` (partial — does not close the epic; Phase 4 not yet executed, gated on #1199)

See #1027