### PR TITLE
feat(lean): Conway P5 step4x4 unconditional level+wf (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -965,6 +965,31 @@ theorem wf_centerInLevelPlus2 (c : MacroCell) (h : c.wf = true) :
              emptyOfLevel_wf, h, MacroCell.level, emptyOfLevel_level]
   decide
 
+/-! ## P4 structural input: step4x4 shape
+
+`step4x4` is the Hashlife base case (level-2 input -> one generation). It
+always returns a level-1 cell, unconditionally: in the `level == 2` arm it
+returns `node (leaf _) (leaf _) (leaf _) (leaf _)`, and in the `else` arm it
+returns `emptyOfLevel 1`. This level-1 shape is a structural input to the
+`hashlifeResult` level-preservation invariant (the level-2 base of
+`level_hashlifeResult_of_level_two`). The well-formedness is unconditional
+too: four equal-level (level-0) leaves form a wf node, and `emptyOfLevel 1` is
+wf (a node of four level-0 empty leaves). -/
+
+private theorem level_step4x4 (c : MacroCell) : (step4x4 c).level = 1 := by
+  by_cases h : c.level == 2
+  · simp only [step4x4, if_pos h, MacroCell.level]
+  · simp only [step4x4, if_neg h, emptyOfLevel_level]
+
+private theorem wf_step4x4 (c : MacroCell) : (step4x4 c).wf = true := by
+  by_cases h : c.level == 2
+  · -- level-2 arm: node (leaf _) (leaf _) (leaf _) (leaf _). Four leaves are
+    -- all wf (= true) and all level 0, so the wf conjunction is trivially true.
+    simp only [step4x4, if_pos h, MacroCell.wf, MacroCell.level]
+    decide
+  · simp only [step4x4, if_neg h]
+    exact emptyOfLevel_wf 1
+
 /-! ## P4 structural input: level preservation (level-2 base)
 
 `hashlifeResult` on a well-formed level-`k` cell is documented to return a


### PR DESCRIPTION
## Summary

Rebases #2974 (CONFLICTING after #2973 merged) onto fresh `origin/main`.

`step4x4` is the Hashlife base case (level-2 input → one generation). It always returns a level-1 cell, **unconditionally**: in the `level == 2` arm it returns `node (leaf _) (leaf _) (leaf _) (leaf _)`, and in the `else` arm it returns `emptyOfLevel 1`. This level-1 shape is a structural input to the `hashlifeResult` level-preservation invariant (the level-2 base of `level_hashlifeResult_of_level_two`, merged #2949).

Two private theorems, unconditional (hold for every `c`):
- `level_step4x4 : (step4x4 c).level = 1`
- `wf_step4x4 : (step4x4 c).wf = true`

## Conflict resolution (cherry-pick rebase, no force-push)

`#2974` was CONFLICTING on `HashlifeCorrectness.lean` after `#2973` (`centerInLevelPlus2`) merged — both PRs insert a distinct section at the same anchor point. Resolution: keep **both** sections side by side (centerInLevelPlus2 already on main, untouched; step4x4 appended after). Pure additive — +25 insertions, 0 deletions, 0 content overlap.

Created fresh branch from `origin/main` (4440cb34a), cherry-picked commit `a657987a8`, resolved the single conflict. Old PR #2974 to be closed.

## Verification §B (lean-merge-discipline)

- `lake build Conway.Life.HashlifeCorrectness` **SUCCESS local** (olen regenerated, 0 compile error, stale olen purged).
- **sorry baseline 8 → 8** unchanged (step4x4 contributes only proven theorems — `decide`/`simp`, no sorry).
- **0 axiom added**.
- Diff coherent: +25 insertions pure, 0 deletion. 0 catalog churn.

Does NOT close P4/P5 (still blocked by the double-nine compositional argument, now decomposed into 8 named grains by #2975). This is a structural-input theorem feeding the level-preservation invariant.

See #2162.