### PR TITLE
feat(lean): Conway P5 -- p5_small_n_fallback (P5.1) proven, sorry 8->7

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1393,13 +1393,32 @@ are ready.
 See `agent_tests/prover/RUNBOOK.md` for the iteration protocol. -/
 
 /-- **P5.1** (definitional, no P4 dependency): when the number of generations
-    `n` is smaller than `2^(k-2)` (the Hashlife jump size for a level-`k`
-    cell), `evolveHashlifeFast` does not make a recursive Hashlife jump — it
-    falls back to the reference `evolve`. This is pure definitional unfolding
-    of `evolveHashlifeFastAux`'s small-n arm. Difficulty: P5.1 (independent of
-    P4; provable now). -/
-theorem p5_small_n_fallback (n : Nat) (g : Grid) (h : BoxAssezGrand g n) : True := by
-  sorry
+    `n` is smaller than `jumpSize lvl` (the Hashlife jump size for the grid's
+    MacroCell level `lvl`), `evolveHashlifeFast` does not make a recursive
+    Hashlife jump — it falls back to the reference `evolve`. This is pure
+    definitional unfolding of `evolveHashlifeFastAux`'s small-n arm.
+
+    **PROVEN** (eliminates 1 sorry from the scaffolding). The `zero` case is
+    definitional (`evolve 0 g = g`). The `succ k` case splits the guard
+    `lvl ≥ 2 && (k+1) ≥ jumpSize lvl`: the guard-true branch contradicts the
+    hypothesis `k+1 < jumpSize lvl`, the guard-false branch is the `evolve`
+    fallback (definitional equality). -/
+theorem p5_small_n_fallback (n : Nat) (g : Grid)
+    (h : n < jumpSize (gridToMacroCellWithOffset g).2.level) :
+    evolveHashlifeFast n g = evolve n g := by
+  show evolveHashlifeFastAux n n g = evolve n g
+  cases n with
+  | zero => rfl
+  | succ k =>
+    simp only [evolveHashlifeFastAux]
+    split_ifs with hcond
+    · -- guard true (jump branch): impossible under h : k+1 < js
+      exfalso
+      obtain ⟨_hlvl, hnjs⟩ : (gridToMacroCellWithOffset g).2.level ≥ 2 ∧ k + 1 ≥
+          jumpSize (gridToMacroCellWithOffset g).2.level := by
+        simpa using hcond
+      exact absurd hnjs (Nat.not_le_of_lt h)
+    · rfl
 
 /-- **P5.2** (compositional, blocked on P4): when `n ≥ 2^(k-2)`,
     `evolveHashlifeFast n g` makes one Hashlife jump of `2^(k-2)` generations
@@ -1417,9 +1436,10 @@ theorem p5_large_n_jump (n : Nat) (g : Grid) (h : BoxAssezGrand g n) : True := b
     sub-lemmas are proven. -/
 theorem p5_inductive_step (n : Nat) (g : Grid) (h : BoxAssezGrand g n) :
     evolveHashlifeFast n g = evolve n g := by
-  have _h1 := p5_small_n_fallback n g h
-  have _h2 := p5_large_n_jump n g h
-  sorry
+  by_cases hsmall : n < jumpSize (gridToMacroCellWithOffset g).2.level
+  · exact p5_small_n_fallback n g hsmall
+  · sorry
+
 
 /-- **Hashlife correctness (bounded)**: under the padding hypothesis
     `box_assez_grand g n`, the exponential-speedup Hashlife implementation


### PR DESCRIPTION
## Summary

First grain of the Conway P5 scaffolding (#2975, now merged on `main`) eliminated. When the generation count `n` is smaller than `jumpSize lvl` (the Hashlife jump size for the grid's MacroCell level), `evolveHashlifeFast` does **not** make a recursive Hashlife jump -- it falls back to the reference `evolve`.

This is pure definitional unfolding of `evolveHashlifeFastAux`'s small-n arm (no P4 dependency):

- **zero case:** `evolve 0 g = g` (definitional, `rfl`).
- **succ k case:** `split_ifs with hcond` on the guard `(gridToMacroCellWithOffset g).2.level >= 2 /\ k+1 >= jumpSize lvl`:
  - **guard-true branch** contradicts the hypothesis `k+1 < jumpSize lvl` -> `exact absurd hnjs (Nat.not_le_of_lt h)`.
  - **guard-false branch** is the `evolve (k+1) g` fallback -> definitional equality, `rfl`.

`p5_inductive_step` is adapted to dispatch via `by_cases hsmall` on the two P5 sub-cases (P5.1 fallback vs P5.2 large-n jump).

## Verification (lean-merge-discipline section B)

| Element | Status |
|---------|--------|
| **sorry count** | `8 -> 7` -- `p5_small_n_fallback` now sorry-free (verified by `lake build`: only 7 "declaration uses sorry" warnings, `p5_small_n_fallback` not among them) |
| **Lake build SUCCESS** | `lake build Conway.Life.HashlifeCorrectness` -> EXIT 0, 0 error. `.olean` deleted then regenerated (genuine build, not cached). Warnings = the 7 remaining sorry only. |
| **Proof integrity (axiom check)** | 0 axiom added -- pure definitional unfolding (`cases`, `split_ifs`, `exact absurd`, `rfl`). No `sorryAx`, no new axioms. |
| **No prover Python refactor** | N/A -- this PR touches only the Lean proof module, no `agent_tests/prover/` change. |

### sorry delta (forensic signal)

```
Before: 8 sorry (p5_small_n_fallback was a placeholder)
After:  7 sorry
Delta:  -1 (p5_small_n_fallback PROVEN)

Remaining 7 sorry:
  - 4x P4 sub-lemmas (p4_double_nine_shape, p4_wave1_ih, p4_wave2_ih, p4_half_steps_compose)
  - p4_succ_membership
  - p5_large_n_jump (P5.2 -- research-level)
  - p5_inductive_step else-branch (P5.3 -- glue, lands once P5.1 + P5.2 done)
```

## Diff coherence

`+30 / -10`, proof addition only (`p5_small_n_fallback` body filled, docstring updated, `p5_inductive_step` dispatch adapted). No sorry regression, no deletion of proven material.

See #2162

Generated with Claude Code