### PR TITLE
docs(z3): enrich NB-02b with interpretation + conclusion (See #1206)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02b_Sudoku_Modes_Comparison.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02b_Sudoku_Modes_Comparison.ipynb
@@ -415,6 +415,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6782ae48",
+   "source": "### Interprétation : pourquoi les deux modes convergent-ils vers la même solution ?\n\nVous aurez remarqué un fait frappant : les deux modes produisent **exactement la même grille** :\n\n```\n2 3 4 1\n3 4 1 2\n4 1 2 3\n1 2 3 4\n```\n\nCe n'est pas une coïncidence, et ce n'est pas non plus un défaut. C'est précisément ce que doit garantir une abstraction bien conçue :\n\n| Question | Réponse |\n|----------|---------|\n| Pourquoi la même solution ? | Les deux modes résolvent le **même théorème** (mêmes contraintes LINQ), Z3 explore donc le même espace de solutions et converge vers la même solution minimale. |\n| Le mode change-t-il la sémantique ? | **Non.** `CollectionHandling` est un paramètre d'*encodage*, pas de *signification*. Le CSP (carré latin 4x4) est invariant. |\n| Que change le mode alors ? | La **représentation interne** envoyée au solver : une `ArrayExpr` (mode Array) vs 16 constantes nommées (mode Constants). |\n\n> **Leçon clé** : c'est la **preuve que le mode `Constants` est bien vivant**. Si l'enum était encore du dead code non câblé (son état historique), le mode Constants aurait soit échoué silencieusement, soit reproduit le comportement Array par défaut. Ici, il résout réellement le CSP via des symboles séparés — le chemin d'exécution est distinct, le résultat est identique par correction.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "e382c909",
    "metadata": {},
    "source": [
@@ -533,6 +539,12 @@
     "// Indice : var sw = System.Diagnostics.Stopwatch.StartNew(); ... sw.Stop(); sw.ElapsedMilliseconds;\n",
     "Console.WriteLine(\"Exercice à compléter\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e8f3582",
+   "source": "---\n\n## Conclusion\n\nCe notebook a démontré que l'enum `CollectionHandling` — historiquement du *dead code* défini mais jamais câblé dans le fork — est désormais **fonctionnelle bout-en-bout**.\n\n### Récapitulatif\n\n| Concept | Rôle dans la démonstration |\n|---------|---------------------------|\n| **`CollectionHandling.Array`** (défaut) | Le mode existant : `int[][]` modélisé comme une `ArrayExpr` Z3 + `Select`/`Store`. Anti-régression (préserve le travail hand-typed). |\n| **`CollectionHandling.Constants`** | Le mode ressuscité : un constant Z3 par élément (`Cells_i_j`). Était du dead code, maintenant câblé. |\n| **Même théorème, 2 encodages** | `BuildSudoku` est réutilisé tel quel ; seul `Z3Context.DefaultCollectionHandling` change. Preuve de l'orthogonalité mode/sémantique. |\n| **Convergence des solutions** | Les 2 modes produisent le même carré latin valide = correction de l'implémentation Constants. |\n\n### Points clés à retenir\n\n1. **L'encodage n'est pas la sémantique** : `CollectionHandling` change comment Z3 *voit* les collections, pas ce que le théorème *exprime*.\n2. **Le mode Constants expose des symboles nommés** (`Cells_2_3 = 4`) — utile pour inspecter le modèle ou enseigner la notion d'inconnue.\n3. **Le mode Array est plus compact** et supporte nativement les index symboliques et le `int[][]` imbriqué (voir [Nested Arrays 2D](04_Nested_Arrays_2D.ipynb)).\n\n### Pour aller plus loin\n\n- Le notebook [05 — Meal Planner Hierarchical](05_Meal_Planner_Hierarchical.ipynb) applique la même comparaison des deux modes à un cas réel (planification de repas avec coûts).\n- Les exercices ci-dessus vous font manipuler les deux modes sur des instances plus grandes (9x9) et mesurer leur impact sur les performances.\n\n---\n\n**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | [Array Theory >>](03_Array_Theory.ipynb)",
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Item 2 of the ai-01 deep-queue dispatch (15:08Z): *« NB-02b valider/enrichir »*. NB-02b was already green (8/8 code cells, 0 error, 3 exercises, outputs present) — this PR adds the **pedagogical wrapping that was missing**.

## What's added (markdown-only, +2 cells)

1. **Interpretation cell** (after the Array/Constants verification): explains *why* both modes converge to the identical Latin square. Same theorem ⇒ same solution space; `CollectionHandling` is an **encoding** parameter, not a **semantic** one. Crucially frames the convergence as **proof the Constants mode is genuinely wired** — a still-dead enum would have failed or silently fallen back to Array behavior.

2. **Conclusion cell** (end of notebook): recap table of the two modes, key takeaways (*"l'encodage n'est pas la sémantique"*), and forward links to NB-05 (same comparison on a real meal-planner) + the exercises.

## Verification

- **Markdown-only edit**: 0 code cell outputs touched (verified cell-by-cell: `code cells with changed outputs: 0`). The existing `exec_count` 1-8 + outputs remain valid per the **C.2 markdown exception** — no re-execution needed.
- **0 catalog churn**, **0 accent regression**, **0 C.1 violation** (no `raise NotImplementedError`).
- 3 exercises preserved, anti-régression intact (no code logic touched).

Aligns with the #1206 mission narrative: *"dead code → vivant, lib+notebook co-évoluent"*. `See #1206`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)