### PR TITLE
docs(genai-image): index Bonsai ternary 1.58-bit notebook in 02-Advanced README

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
@@ -2,18 +2,18 @@
 
 [← Image Foundation](../01-Foundation/) | [↑ Image](../README.md) | [→ Image Orchestration](../03-Orchestration/)
 
-Ce module explore les modèles de pointe : Qwen Image Edit avancé, FLUX, SD 3.5, et Z-Image/Lumina.
+Ce module explore les modèles de pointe : Qwen Image Edit avancé, FLUX, SD 3.5, Z-Image/Lumina, et la quantification extrême (Bonsai ternaire 1.58-bit).
 
-**Dans le cadre du fil rouge contenu visuel educatif** : un visuel de qualite demande des outils precis. [02-1](02-1-Qwen-Image-Edit-2509.ipynb) edite une image existante pour corriger ou enrichir un diagramme. [02-2](02-2-FLUX-1-Advanced-Generation.ipynb) genere des images haute qualite. [02-4](02-4-Z-Image-Lumina2.ipynb) offre une generation rapide pour le prototypage iteratif.
+**Dans le cadre du fil rouge contenu visuel educatif** : un visuel de qualite demande des outils precis. [02-1](02-1-Qwen-Image-Edit-2509.ipynb) edite une image existante pour corriger ou enrichir un diagramme. [02-2](02-2-FLUX-1-Advanced-Generation.ipynb) genere des images haute qualite. [02-4](02-4-Z-Image-Lumina2.ipynb) offre une generation rapide pour le prototypage iteratif. [02-5](02-5-Bonsai-Image-Ternary.ipynb) aborde la quantification ternaire 1.58-bit : un modèle 4B compressé à ~4 GB qui se genere en ~2s, parfait pour deployer la generation d'images sur du materiel modeste (formation, demos) sans sacrifier la qualite.
 
 ## Vue d'overview
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 4 |
+| Notebooks | 5 |
 | Kernel | Python 3 |
-| Duree estimee | ~4-6h |
-| GPU requis | 10-29GB |
+| Duree estimee | ~5-7h |
+| GPU requis | 5-29GB |
 
 ## Notebooks
 
@@ -23,6 +23,7 @@ Ce module explore les modèles de pointe : Qwen Image Edit avancé, FLUX, SD 3.5
 | 2 | [02-2-FLUX-1-Advanced-Generation](02-2-FLUX-1-Advanced-Generation.ipynb) | Génération FLUX | ComfyUI | Variable |
 | 3 | [02-3-Stable-Diffusion-3-5](02-3-Stable-Diffusion-3-5.ipynb) | SD 3.5 | ComfyUI | Variable |
 | 4 | [02-4-Z-Image-Lumina2](02-4-Z-Image-Lumina2.ipynb) | Z-Image/Lumina | ComfyUI | ~10GB |
+| 5 | [02-5-Bonsai-Image-Ternary](02-5-Bonsai-Image-Ternary.ipynb) | Quantification ternaire 1.58-bit (BitNet), custom node | ComfyUI (custom node) | ~5GB |
 
 ## Prérequis
 
@@ -45,6 +46,7 @@ pip install -r requirements-comfyui.txt
 2. **02-2-FLUX-1-Advanced-Generation** - Génération de haute qualité
 3. **02-3-Stable-Diffusion-3.5** - SD 3.5 pour contrôle fin
 4. **02-4-Z-Image-Lumina2** - Modèle léger et rapide
+5. **02-5-Bonsai-Image-Ternary** - Quantification extrême pour déploiement sobre en VRAM
 
 ## Technologies clés
 
@@ -68,6 +70,12 @@ pip install -r requirements-comfyui.txt
 - **Points forts** : Vitesse, qualité légère
 - **VRAM** : ~10GB
 
+### Bonsai-Image 4B (Ternary 1.58-bit)
+- **Architecture** : Transformer 4B quantifié ternaire (BitNet b1.58), Gemlite INT2 + HQQ 4-bit text encoder
+- **Points forts** : Modèle 4B compressé à ~4 GB (vs ~32 GB en FP16), génération ~2s en 4 steps, déploiable sur GPU d'entrée de gamme
+- **VRAM** : ~5GB
+- **Accès** : custom node ComfyUI `BonsaiTernaryNode` (modèle auto-téléchargé depuis HuggingFace au premier run)
+
 ## Comparatif
 
 | Modèle | Spécialité | VRAM | Qualité | Vitesse |
@@ -76,6 +84,7 @@ pip install -r requirements-comfyui.txt
 | FLUX | Génération | Variable | Exceptionnel | Moyen |
 | SD 3.5 | Polyvalent | Variable | Bon | Rapide |
 | Z-Image | Léger | ~10GB | Bon | Très rapide |
+| Bonsai | Quantifié (1.58-bit) | ~5GB | Bon | Très rapide |
 
 ## Ressources
 


### PR DESCRIPTION
## Summary

**Index drift fix**: the `02-5-Bonsai-Image-Ternary` notebook (added via #1746) was missing from the Image `02-Advanced` series README — the table listed 4 notebooks while 5 exist on disk.

## Context

Investigating queue item #3 (Bonsai env) on origin/main revealed:
- `COMFYUI_API_URL = http://127.0.0.1:8188` → Bonsai runs on **comfyui-qwen (GPU0 / 3080Ti)**, not the 3090 as the #1746 body stated. The custom node is installed and validated end-to-end (1024x1024, 4 steps, ~2s, H.3 PASS) — the "PARTIAL/router" concern is already resolved by the clean ComfyUI-API design.
- The real residual gap was **README drift**: the series index never got updated when #1746 merged the notebook.

## Changes

Single-file, markdown-only (+14/-5). Bonsai integrated across all README sections:

| Section | Change |
|---------|--------|
| Intro + fil rouge | Added Bonsai as the quantization angle (1.58-bit, ~4 GB, ~2s, deployable on modest GPU) |
| Stats | Notebooks 4→5, GPU 10-29GB→5-29GB, duration ~4-6h→~5-7h |
| Notebook table | Added row 5: Quantification ternaire 1.58-bit, ComfyUI (custom node), ~5GB |
| Progression | Added step 5: Quantification extrême pour déploiement sobre en VRAM |
| Technologies | Added Bonsai-Image 4B entry (BitNet b1.58, Gemlite INT2 + HQQ 4-bit text encoder) |
| Comparatif | Added Bonsai row (Quantifié 1.58-bit, ~5GB, Bon, Très rapide) |

## Validation

- **C.2 exception**: markdown-only (no notebook source touched) → no re-execution required.
- **Catalog hygiene**: `COURSE_CATALOG.generated.json` + `.md` byte-identical to `origin/main` (verified `git diff --stat` empty).
- **Link validity**: `02-5-Bonsai-Image-Ternary.ipynb` tracked on origin/main (blob `3021921f`).
- **Stale base**: fresh branch from `origin/main` (`81b09945`), <1 day old.
- **Anti-regression**: additive only (0 deletions of existing content; the 5 "deletions" are inline replacement of intro/stats lines to extend them, not removal).

## Scope

Atomic single-file doc PR. Does not touch the Bonsai notebook itself (already PRODUCTION via #1746) or any infra.

See #1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)