### PR TITLE
feat(lean): Knots Phase 5 PR1.5c -- Reidemeister1Connected API lemmas (See #2874)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -208,6 +208,43 @@ theorem reidemeister1Connected_satisfiable :
     -- that `omega` cannot see; `rfl` closes the definitional surgery equation.
     exact ⟨by decide, by decide, by decide, rfl⟩
 
+/-! ### API lemmas for `Reidemeister1Connected` (option C infrastructure for PR2)
+
+These projection-style lemmas expose the surgery's combinatorial shape, which the
+transfer lemma (PR2) consumes when pushing a tricoloring across a connected R1
+twist: the edge count grows by exactly 2 (same magnitude as the disjoint-kink
+append model, but reached by a connected splice), and the crossing count grows
+by exactly 1. They mirror the `trefoil_wf` / `unknot_wf` projection-API style of
+`Basic.lean`.
+-/
+
+/-- A connected R1 twist adds exactly two edges (the kink monogon `c` and the
+    renamed arc endpoint `b`), same magnitude as the disjoint-kink model but via
+    a connected splice. -/
+theorem Reidemeister1Connected.numEdges_succ {d₁ d₂ : KnotDiagram}
+    (h : Reidemeister1Connected d₁ d₂) : d₂.numEdges = d₁.numEdges + 2 := by
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, hsurg⟩ := h
+  have hne := congrArg (·.numEdges) hsurg
+  simpa using hne
+
+/-- A connected R1 twist adds exactly one crossing (the curl `C`); the existing
+    endpoint crossing `Y` is relabelled in place (`List.set` preserves length),
+    not duplicated. -/
+theorem Reidemeister1Connected.numCrossings_succ {d₁ d₂ : KnotDiagram}
+    (h : Reidemeister1Connected d₁ d₂) : d₂.crossings.length = d₁.crossings.length + 1 := by
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, hsurg⟩ := h
+  have hcl := congrArg (fun d => d.crossings.length) hsurg
+  simpa [List.length_set, List.length_append] using hcl
+
+/-- The arc `a` receiving the twist is a genuine edge of `d₁` (connectivity
+    hypothesis): the new crossing `C = ⟨a, b, c, c⟩` shares edge `a` with `d₁`,
+    which is what distinguishes a connected twist from a disjoint kink
+    `⟨n+1,n+1,n+2,n+2⟩` (which shares no edge with `d₁`). -/
+theorem Reidemeister1Connected.shares_edge {d₁ d₂ : KnotDiagram}
+    (h : Reidemeister1Connected d₁ d₂) : ∃ a : Nat, a ∈ d₁.edges ∧ 1 ≤ a ∧ a ≤ d₁.numEdges := by
+  obtain ⟨_hwf₁, _hwf₂, _i, a, _Y', _ρ, hr1, hr2, hmem, _hsurg⟩ := h
+  exact ⟨a, hmem, hr1, hr2⟩
+
 /-- R2 (Poke/Unpoke): add or remove two consecutive crossings of opposite sign.
 
 Two parallel strands can pass through each other:


### PR DESCRIPTION
## Summary

**Additive option-C API lemmas** for `Reidemeister1Connected`, the connected-surgery move merged in #2980. These projection-style lemmas expose the surgery's combinatorial shape — the exact edge/crossing deltas and the shared-edge connectivity guarantee — that the **PR2 transfer lemma** will consume when pushing a tricoloring across a connected R1 twist. They mirror the `trefoil_wf` / `unknot_wf` projection-API style of `Basic.lean`.

This is **follow-up infrastructure** to #2980 (de-risking option C for the coordinator's C/X modeling decision on the Knots tricolorability track, #2874). It does **not** modify `Reidemeister1` (free-ρ, #2929), `Reidemeister1'` (ρ-determined, #2956), or `Reidemeister1Connected` (the def merged in #2980) — purely additive lemmas alongside.

## Changes (1 file, +37/-0)

- **`Reidemeister1Connected.numEdges_succ`** — a connected R1 twist adds exactly 2 edges (the kink monogon `c = numEdges+2` and the renamed arc endpoint `b = numEdges+1`). Same magnitude as the disjoint-kink append model, but reached by a connected splice.
- **`Reidemeister1Connected.numCrossings_succ`** — a connected R1 twist adds exactly 1 crossing (the curl `C`); the existing endpoint crossing `Y` is relabelled in place (`List.set` preserves length), not duplicated.
- **`Reidemeister1Connected.shares_edge`** — the arc `a` receiving the twist is a genuine edge of `d₁` (the connectivity hypothesis): the new crossing `C = ⟨a, b, c, c⟩` shares edge `a` with `d₁`, which is what distinguishes a connected twist from a disjoint kink `⟨n+1,n+1,n+2,n+2⟩` (which shares no edge with `d₁`).

## lean-merge-discipline B (4 elements)

| Element | Result |
|---------|--------|
| **Sorry delta** | `Reidemeister.lean` **2 → 2** (`reidemeister_theorem` PL topology OOS, UNTOUCHED). The 3 new lemmas are sorry-free. |
| **Lake build** | `lake build Knots` SUCCESS genuine (**321 jobs, EXIT=0**, `set -o pipefail`). |
| **Axiom check** | `#print axioms` via `lake env lean`: `numEdges_succ` = no axioms; `numCrossings_succ` = `[propext]`; `shares_edge` = no axioms. All ⊂ baseline `[propext, Quot.sound]`. |
| **Scope diff** | `+37/-0`, 1 file (`Reidemeister.lean`), 0 catalog drift, **additive** (0 deletions, no existing def/theorem modified). |

Build log tail:
```
Build completed successfully (321 jobs).
```

## Scope guards

- `Reidemeister1Connected` (def) + `reidemeister1Connected_satisfiable` (theorem) — **already merged** in #2980, untouched here.
- `Basic.lean`, `Invariant.lean`, `Conway.lean`, `Lidman.lean`, `MathlibPrerequisites.lean` — **untouched**.
- No catalog regeneration on the branch (rule catalog-pr-hygiene).
- `See #2874` (epic open — additive follow-up to #2980, not a closer).

See #2874

Co-Authored-By: Claude <noreply@anthropic.com>
