### PR TITLE
feat(search): MGS-6 TSP -- representation-agnostic composition on permutations

### DIFF
--- a/MyIA.AI.Notebooks/Search/MetaGeneticSharp-Notebooks/MGS-6-TSP.ipynb
+++ b/MyIA.AI.Notebooks/Search/MetaGeneticSharp-Notebooks/MGS-6-TSP.ipynb
@@ -1,0 +1,868 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bafc5427",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003449,
+     "end_time": "2026-06-14T18:22:23.443937+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:23.440488+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# MGS-6 : TSP combinatoire -- la grammaire de composition est agnostique à la représentation\n",
+    "\n",
+    "[← MGS-5 Benchmarks](MGS-5-Benchmarks.ipynb) | [↑ Série MGS](../Part4-Metaheuristics/README.md)\n",
+    "\n",
+    "**Question centrale.** MGS-5 a montré que les métaheuristiques composées géométriques (WOA) se reconstruisent depuis des primitives sur des surfaces **continues** (gènes en `double`). Mais la grammaire de composition (`Match`, `Container`, `Scoped`, `Islands`) vit *sous* la couche géométrique. Cette couche fait-elle une hypothèse sur le type des gènes ?\n",
+    "\n",
+    "Ce notebook le vérifie : la même grammaire structure la recherche sur un problème de **permutation** — le Voyageur de Commerce (TSP), où les gènes sont des index de villes entiers — **sans aucune adaptation**. Si les primitives de composition n'avaient pas été conçues de façon agnostique à la représentation (comme le sont les opérateurs de GeneticSharp : bit, permutation, arbre, flottant), on ne pourrait pas réutiliser `IslandMetaHeuristic` tel quel sur TSP. C'est « components over metaphors » en pratique : les briques ne présument pas du domaine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "81cca472",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:22:23.465364Z",
+     "iopub.status.busy": "2026-06-14T18:22:23.455875Z",
+     "iopub.status.idle": "2026-06-14T18:22:25.292293Z",
+     "shell.execute_reply": "2026-06-14T18:22:25.287356Z"
+    },
+    "papermill": {
+     "duration": 1.843692,
+     "end_time": "2026-06-14T18:22:25.293014+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:23.449322+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:2545:5f43:5adb:da74:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1023572.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DLLs chargées (incluant GeneticSharp.Extensions = TSP).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  TspFitness          : TspFitness\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  TspChromosome       : TspChromosome\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IslandMetaHeuristic : IslandMetaHeuristic\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MigrationMode       : MigrationMode\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Wiring : charge MetaGeneticSharp + GeneticSharp + GeneticSharp.Extensions (TSP).\n",
+    "// Prérequis : dotnet build c:/dev/MetaGeneticSharp/MetaGeneticSharp.sln\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/GeneticSharp.Extensions.dll\"\n",
+    "\n",
+    "using MetaGeneticSharp;\n",
+    "using GeneticSharp;\n",
+    "using GeneticSharp.Extensions;\n",
+    "\n",
+    "Console.WriteLine(\"DLLs chargées (incluant GeneticSharp.Extensions = TSP).\");\n",
+    "Console.WriteLine($\"  TspFitness          : {typeof(TspFitness).Name}\");\n",
+    "Console.WriteLine($\"  TspChromosome       : {typeof(TspChromosome).Name}\");\n",
+    "Console.WriteLine($\"  IslandMetaHeuristic : {typeof(IslandMetaHeuristic).Name}\");\n",
+    "Console.WriteLine($\"  MigrationMode       : {typeof(MigrationMode).Name}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f73b773",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002525,
+     "end_time": "2026-06-14T18:22:25.298753+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:25.296228+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Le problème : 20 villes, gènes = index entiers\n",
+    "\n",
+    "`TspFitness` génère N villes dans un carré et mesure la longueur totale du tour — les gènes sont l'ordre de visite, c'est-à-dire une permutation des index `0..N-1`. GeneticSharp *maximise* le fitness, donc `TspFitness.Evaluate` renvoie `1 - longueur/(N*1000)` (tour court ⇒ fitness élevé). La métrique qu'on surveille est la **longueur du tour** (`TspChromosome.Distance`), qu'on minimise.\n",
+    "\n",
+    "On fixe le générateur aléatoire (`BasicRandomization.ResetSeed`) pour que les villes et les populations initiales soient reproductibles d'une configuration à l'autre — comparaison équitable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "25f7d6f6",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:22:25.305759Z",
+     "iopub.status.busy": "2026-06-14T18:22:25.305481Z",
+     "iopub.status.idle": "2026-06-14T18:22:25.494230Z",
+     "shell.execute_reply": "2026-06-14T18:22:25.494047Z"
+    },
+    "papermill": {
+     "duration": 0.192813,
+     "end_time": "2026-06-14T18:22:25.494315+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:25.301502+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TSP : 20 villes chargées dans [0,100]².\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Reproductibilité : graine fixe. Les villes sont générées une fois (partagées entre configs).\n",
+    "void ResetRng(int seed) => BasicRandomization.ResetSeed(seed);\n",
+    "\n",
+    "const int N = 20;\n",
+    "ResetRng(42);\n",
+    "var fitness = new TspFitness(N, 0, 100, 0, 100);\n",
+    "Console.WriteLine($\"TSP : {N} villes chargées dans [0,100]².\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c55e107",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002619,
+     "end_time": "2026-06-14T18:22:25.500341+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:25.497722+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Un harness commun\n",
+    "\n",
+    "Les trois configurations (baseline, îles, exercices) partagent le même moteur `MetaGeneticAlgorithm`. On factorise l'exécution dans un helper qui enregistre, à chaque génération, la **longueur du meilleur tour**. C'est ici que l'agnosticité se manifeste concrètement : le helper ne sait pas que les gènes sont des permutations — il pilote le moteur sur des `IChromosome` génériques et ne lit le type concret (`TspChromosome`) que pour extraire la métrique métier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e6775a65",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:22:25.507107Z",
+     "iopub.status.busy": "2026-06-14T18:22:25.506914Z",
+     "iopub.status.idle": "2026-06-14T18:22:25.919342Z",
+     "shell.execute_reply": "2026-06-14T18:22:25.919189Z"
+    },
+    "papermill": {
+     "duration": 0.416258,
+     "end_time": "2026-06-14T18:22:25.919422+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:25.503164+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Helper Run prêt.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "record RunResult(string Label, double FinalTourLength, double[] BestPerGen);\n",
+    "\n",
+    "RunResult Run(string label, int generations, int popSize,\n",
+    "              ICrossover crossover, IMutation mutation, IMetaHeuristic meta)\n",
+    "{\n",
+    "    ResetRng(7); // population initiale reproductible : mêmes villes, même départ pour chaque config.\n",
+    "    var adam = new TspChromosome(N);\n",
+    "    var population = new MetaPopulation(popSize, popSize, adam);\n",
+    "    var ga = new MetaGeneticAlgorithm(population, fitness,\n",
+    "        new EliteSelection(), crossover, mutation, meta)\n",
+    "    {\n",
+    "        Termination = new GenerationNumberTermination(generations)\n",
+    "    };\n",
+    "\n",
+    "    var best = new List<double>();\n",
+    "    ga.GenerationRan += (_, _) =>\n",
+    "    {\n",
+    "        // MetaPopulation est order-preserving : BestChromosome n'est pas peuplé au moment de l'event.\n",
+    "        // On déduit le meilleur depuis Chromosomes par fitness (toujours fixé par Evaluate).\n",
+    "        // Fitness max <=> tour le plus court ; ce chromosome a son .Distance fixé (même Evaluate).\n",
+    "        var bestChrom = ga.Population.CurrentGeneration.Chromosomes\n",
+    "            .OrderByDescending(c => c.Fitness).First();\n",
+    "        best.Add(((TspChromosome)bestChrom).Distance);\n",
+    "    };\n",
+    "    ga.Start();\n",
+    "\n",
+    "    double final = best.Count > 0 ? best[^1] : double.NaN;\n",
+    "    return new RunResult(label, final, best.ToArray());\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Helper Run prêt.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcbc1d6a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002604,
+     "end_time": "2026-06-14T18:22:25.925187+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:25.922583+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Config 1 — baseline : GA classique\n",
+    "\n",
+    "La `DefaultMetaHeuristic` reproduit le comportement GA standard : sélection élitiste → croisement (`OrderedCrossover`, OX1) → mutation (`ReverseSequenceMutation`) → réinsertion élitiste. Population panmictique : aucun partitionnement, tous les chromosomes interagissent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f3f82314",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:22:25.931634Z",
+     "iopub.status.busy": "2026-06-14T18:22:25.931449Z",
+     "iopub.status.idle": "2026-06-14T18:22:26.072196Z",
+     "shell.execute_reply": "2026-06-14T18:22:26.072026Z"
+    },
+    "papermill": {
+     "duration": 0.144367,
+     "end_time": "2026-06-14T18:22:26.072279+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:25.927912+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Baseline (panmictic)       tour final = 429,4\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var baseline = Run(\"Baseline (panmictic)\", 100, 40,\n",
+    "    new OrderedCrossover(), new ReverseSequenceMutation(),\n",
+    "    new DefaultMetaHeuristic());\n",
+    "Console.WriteLine($\"{baseline.Label,-26} tour final = {baseline.FinalTourLength:F1}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bd50e53",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00366,
+     "end_time": "2026-06-14T18:22:26.079403+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.075743+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Config 2 — modèle insulaire sur permutations\n",
+    "\n",
+    "Mêmes opérateurs, mais `IslandMetaHeuristic(10, 4, ...)` partitionne les 40 chromosomes en **4 îles de 10**. Chaque île évolue indépendamment ; la migration (mode `Static`, période 5) échange des chromosomes **entiers** entre îles. Point clé : **aucune arithmétique sur les gènes** — la migration déplace des permutations complètes, pas des positions réinterpolées. C'est précisément pourquoi le modèle fonctionne aussi bien sur des permutations que sur des vecteurs continus (MGS-4)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a4fd5c9e",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:22:26.087369Z",
+     "iopub.status.busy": "2026-06-14T18:22:26.087166Z",
+     "iopub.status.idle": "2026-06-14T18:22:26.286425Z",
+     "shell.execute_reply": "2026-06-14T18:22:26.286226Z"
+    },
+    "papermill": {
+     "duration": 0.203626,
+     "end_time": "2026-06-14T18:22:26.286509+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.082883+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Islands (4 x 10, Static)   tour final = 480,7\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var islandMeta = new IslandMetaHeuristic(10, 4, new DefaultMetaHeuristic())\n",
+    "{\n",
+    "    MigrationMode = MigrationMode.Static,\n",
+    "    MigrationsGenerationPeriod = 5,\n",
+    "};\n",
+    "var island = Run(\"Islands (4 x 10, Static)\", 100, 40,\n",
+    "    new OrderedCrossover(), new ReverseSequenceMutation(),\n",
+    "    islandMeta);\n",
+    "Console.WriteLine($\"{island.Label,-26} tour final = {island.FinalTourLength:F1}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d32ca4b9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003043,
+     "end_time": "2026-06-14T18:22:26.293103+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.290060+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Comparaison\n",
+    "\n",
+    "On rapporte la longueur finale du meilleur tour (plus court = meilleur) et la dynamique de convergence échantillonnée. Attendu : les îles convergent plus lentement par génération (sous-populations plus petites) mais maintiennent la diversité plus longtemps, ce qui peut éviter des optima locaux. Le résultat exact dépend du tirage des villes et de la taille du problème — on le rapporte honnêtement, sans trier les victoires."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5e4329ca",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:22:26.300659Z",
+     "iopub.status.busy": "2026-06-14T18:22:26.300457Z",
+     "iopub.status.idle": "2026-06-14T18:22:26.460365Z",
+     "shell.execute_reply": "2026-06-14T18:22:26.460180Z"
+    },
+    "papermill": {
+     "duration": 0.164239,
+     "end_time": "2026-06-14T18:22:26.460464+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.296225+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config                     | Tour final |  vs baseline\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Baseline (panmictic)       |      429,4 |        0,0 %\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Islands (4 x 10, Static)   |      480,7 |      -12,0 %\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Convergence (longueur du meilleur tour, échantillonnée) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Baseline (panmictic)    g1=825  g26=542  g51=463  g76=447  g100=429\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Islands (4 x 10, Static)g1=842  g26=545  g51=517  g76=517  g100=481\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var results = new[] { baseline, island };\n",
+    "Console.WriteLine($\"{\"Config\",-26} | {\"Tour final\",10} | {\"vs baseline\",12}\");\n",
+    "Console.WriteLine(new string('-', 54));\n",
+    "double refLen = baseline.FinalTourLength;\n",
+    "foreach (var r in results)\n",
+    "{\n",
+    "    double impr = refLen > 0 ? (refLen - r.FinalTourLength) / refLen * 100.0 : 0.0;\n",
+    "    Console.WriteLine($\"{r.Label,-26} | {r.FinalTourLength,10:F1} | {impr,+10:F1} %\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Convergence (longueur du meilleur tour, échantillonnée) :\");\n",
+    "foreach (var r in results)\n",
+    "{\n",
+    "    var samples = Enumerable.Range(0, r.BestPerGen.Length)\n",
+    "        .Where(i => i % 25 == 0 || i == r.BestPerGen.Length - 1)\n",
+    "        .Select(i => \"g\" + (i + 1) + \"=\" + r.BestPerGen[i].ToString(\"F0\"));\n",
+    "    Console.WriteLine(\"  \" + r.Label.PadRight(24) + string.Join(\"  \", samples));\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6179941",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004941,
+     "end_time": "2026-06-14T18:22:26.469981+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.465040+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Lecture\n",
+    "\n",
+    "La grammaire de composition (`IslandMetaHeuristic` ici) s'est appliquée à un chromosome de permutation **sans aucune adaptation**. C'est la preuve que la couche de composition est agnostique à la représentation : elle opère sur `IChromosome`, ne lit jamais `Gene.Value`, et n'a donc pas besoin de savoir si les gènes sont des `double` (MGS-5) ou des index de villes (`int`, ici).\n",
+    "\n",
+    "Les métaheuristiques géométriques (WOA, EO), elles, nécessitent un `GeometricConverter<double>` précisément parce qu'elles *font* de l'arithmétique sur les gènes — c'est leur travail (centroïde, spirale, opérateur géométrique), pas celui de la couche de composition. La séparation est nette : **la composition est agnostique, les composés géométriques sont typés**. Composer ne présuppose pas le domaine.\n",
+    "\n",
+    "Le fait que le modèle insulaire batte, égalise ou perde sur ce TSP de taille 20 est secondaire ; le point est ailleurs : **la même brique structure des recherches sur des représentations disjointes**. C'est ce qui distingue un composant réutilisable d'une métaphore monolithique attachée à un type de problème."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b00ffa1e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004652,
+     "end_time": "2026-06-14T18:22:26.479923+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.475271+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 — Changer d'opérateur de croisement\n",
+    "\n",
+    "`OrderedCrossover` (OX1) est l'opérateur canonique du TSP. GeneticSharp en fournit d'autres pour permutations : `PartiallyMappedCrossover` (PMX), `CycleCrossover` (CX), `OrderBasedCrossover` (OX2). Relancez le baseline avec `PartiallyMappedCrossover` et comparez la longueur finale du tour. La performance relative dépend-elle de la taille du problème ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "02492166",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:22:26.490476Z",
+     "iopub.status.busy": "2026-06-14T18:22:26.490249Z",
+     "iopub.status.idle": "2026-06-14T18:22:26.537970Z",
+     "shell.execute_reply": "2026-06-14T18:22:26.537800Z"
+    },
+    "papermill": {
+     "duration": 0.053739,
+     "end_time": "2026-06-14T18:22:26.538059+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.484320+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Exercice 1] À compléter. Référence : baseline-OX1 = 429,4.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : comparez OrderedCrossover (OX1) vs PartiallyMappedCrossover (PMX).\n",
+    "// # Indice : remplacez new OrderedCrossover() par new PartiallyMappedCrossover() dans l'appel Run(...).\n",
+    "// # Étape 1 : appelez Run(\"Baseline (PMX)\", 100, 40, new PartiallyMappedCrossover(), new ReverseSequenceMutation(), new DefaultMetaHeuristic()).\n",
+    "// # Étape 2 : affichez la longueur finale et comparez à baseline-OX1.\n",
+    "// TODO étudiant\n",
+    "Console.WriteLine($\"[Exercice 1] À compléter. Référence : baseline-OX1 = {baseline.FinalTourLength:F1}.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bdcaaf7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003622,
+     "end_time": "2026-06-14T18:22:26.545501+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.541879+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 — Mode de migration\n",
+    "\n",
+    "Le modèle insulaire supporte plusieurs `MigrationMode` : `Static`, `RandomRing`, `RandomPermutation`, `Reinforced`. Chaque mode détermine quelles îles échangent des chromosomes. Relancez la configuration îles avec `MigrationMode.RandomRing` et comparez la longueur finale à `Static`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b57733c3",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:22:26.554757Z",
+     "iopub.status.busy": "2026-06-14T18:22:26.554533Z",
+     "iopub.status.idle": "2026-06-14T18:22:26.618575Z",
+     "shell.execute_reply": "2026-06-14T18:22:26.618404Z"
+    },
+    "papermill": {
+     "duration": 0.069194,
+     "end_time": "2026-06-14T18:22:26.618710+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.549516+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Exercice 2] À compléter. Référence : islands-Static = 480,7.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : comparez MigrationMode.Static vs MigrationMode.RandomRing.\n",
+    "// # Indice : recréez IslandMetaHeuristic(10, 4, new DefaultMetaHeuristic()) avec MigrationMode = MigrationMode.RandomRing.\n",
+    "// TODO étudiant\n",
+    "Console.WriteLine($\"[Exercice 2] À compléter. Référence : islands-Static = {island.FinalTourLength:F1}.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28693e46",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003444,
+     "end_time": "2026-06-14T18:22:26.626064+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.622620+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 — Topologie des îles\n",
+    "\n",
+    "La partition `(islandSize, islandNb)` doit satisfaire `islandSize × islandNb = popSize`. Pour une population de 40, les partitions valides incluent `(20, 2)`, `(10, 4)`, `(5, 8)`, `(4, 10)`. Testez l'effet de la granularité — peu d'îles grandes vs beaucoup de petites — sur la diversité maintenue et la qualité de la convergence. Quelle granularité évite le mieux la convergence prématurée ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6b33c457",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:22:26.634450Z",
+     "iopub.status.busy": "2026-06-14T18:22:26.634225Z",
+     "iopub.status.idle": "2026-06-14T18:22:26.669977Z",
+     "shell.execute_reply": "2026-06-14T18:22:26.669817Z"
+    },
+    "papermill": {
+     "duration": 0.040352,
+     "end_time": "2026-06-14T18:22:26.670060+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.629708+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Exercice 3] À compléter. Comparez les longueurs finales selon la granularité.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : testez plusieurs partitions (islandSize, islandNb) de produit 40.\n",
+    "// # Indice : (20,2), (10,4), (5,8), (4,10). Relancez Run(...) avec un IslandMetaHeuristic par partition.\n",
+    "// # Étape 1 : bouclez sur les partitions et appelez Run pour chacune.\n",
+    "// # Étape 2 : affichez la longueur finale de chaque partition.\n",
+    "// TODO étudiant\n",
+    "Console.WriteLine(\"[Exercice 3] À compléter. Comparez les longueurs finales selon la granularité.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcd7ca59",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00338,
+     "end_time": "2026-06-14T18:22:26.677089+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T18:22:26.673709+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Le même moteur `MetaGeneticAlgorithm` et les mêmes primitives de composition (`IslandMetaHeuristic`) ont structuré une recherche sur des **permutations**, alors que MGS-5 les utilisait sur des surfaces **continues**. La couche de composition ne fait aucune hypothèse sur le type des gènes : elle orchestre des `IChromosome`. C'est l'agnosticité de représentation héritée de GeneticSharp (bit, permutation, arbre, flottant), étendue à la couche métaheuristique.\n",
+    "\n",
+    "Les métaheuristiques géométriques (WOA, EO) restent attachées aux gènes `double` — non par limitation de la composition, mais parce que leur *mécanisme* (opérateur géométrique, centroïde, spirale) est de l'arithmétique sur des positions continues. La séparation est nette : **la composition est agnostique, les composés géométriques sont typés**.\n",
+    "\n",
+    "Suite logique : combiner cette agnosticité avec la structuration — un modèle insulaire où chaque île utiliserait un opérateur différent (configuration hétérogène), via la surcharge `IslandMetaHeuristic(params (int, IMetaHeuristic)[])`.\n",
+    "\n",
+    "[← MGS-5 Benchmarks](MGS-5-Benchmarks.ipynb) | [↑ Série MGS](../Part4-Metaheuristics/README.md) | [Fork jsboige/MetaGeneticSharp →](https://github.com/jsboige/MetaGeneticSharp)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.792182,
+   "end_time": "2026-06-14T18:22:26.909321+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MGS-6-TSP.ipynb",
+   "output_path": "MGS-6-TSP.output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-14T18:22:20.117139+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Queue item 4 (Epic #1203, dispatch ai-01 \"QUEUES PROFONDES\" 15:08Z). Adds the 6th notebook in the MetaGeneticSharp series: **MGS-6 TSP** — a demonstration that the composition grammar is agnostic to the gene representation.

MGS-4 (Islands) and MGS-5 (Benchmarks) ran the composition primitives on continuous surfaces (genes = `double`). The thesis \"components over metaphors\" predicts that the composition layer — `Match`, `Container`, `Scoped`, `Islands` — makes NO assumption on the gene type, because it orchestrates `IChromosome` and never reads `Gene.Value`. This notebook verifies the prediction: the **same** `IslandMetaHeuristic` that structured continuous search now structures a permutation problem (TSP, genes = city indexes = `int`), with **zero adaptation**.

The geometric compounds (WOA, EO) DO need a `GeometricConverter<double>` — but that is because their *mechanism* (centroid, spiral, geometric operator) is arithmetic on continuous positions. That requirement lives in the compound, not in the composition layer. The separation is clean: **composition is agnostic, geometric compounds are typed**.

## Setup

- `TspFitness(20, 0, 100, 0, 100)` — 20 random cities in [0,100]², fixed seed (reproducible)
- `TspChromosome(20)` — genes = visiting order = permutation of city indexes
- Operators: `OrderedCrossover` (OX1) + `ReverseSequenceMutation` + `EliteSelection`
- Same `MetaGeneticAlgorithm` engine as MGS-5
- 100 generations, population 40

## Comparison (honest, G.9)

| Config | Final tour | vs baseline |
|--------|-----------|-------------|
| Baseline (panmictic) | **429.4** | — |
| Islands (4x10, Static) | 480.7 | -12% (worse) |

For this 20-city instance the panmictic baseline wins. Islands converge slower per generation because each subpopulation (10) is smaller — expected behavior, same No-Free-Lunch theme as MGS-5's Schwefel divergence. The point is NOT that islands win; it is that the composition grammar **transferred to permutations without any adaptation**. Win/loss is secondary; representation-agnostic composition is the finding.

3 exercises: crossover operator (PMX vs OX1), migration mode (RandomRing vs Static), island topology (granularity sweep over valid partitions).

## Validation

- Executed end-to-end via papermill (`.net-csharp` kernel): **9 code cells, `execution_count` 1-9 contiguous, 0 errors** (C.2)
- 3 exercise stubs use `Console.WriteLine(... À compléter)` / `// TODO étudiant` — no `raise NotImplementedError`/`assert False`/`1/0` (C.1)
- Notebook loads `GeneticSharp.Extensions.dll` (TspFitness/TspChromosome) on top of the MGS DLLs, via local fork checkout `c:/dev/MetaGeneticSharp` (same convention as MGS-1..5)
- 0 catalog churn (single new notebook file, no regenerated artifacts)

## What this does NOT change

- No change to any library (MetaGeneticSharp fork). This is a pedagogical notebook only.
- No submodule bump — the notebook consumes the already-merged fork `main` local checkout.
- README series table updated separately (PR #2976), to avoid conflict; NB6 row added in a follow-up.

## Note on the harness

`MetaPopulation` is order-preserving (unlike stock GeneticSharp `Population`, it never sorts by fitness), so `CurrentGeneration.BestChromosome` is `null` at the `GenerationRan` event time. The harness derives the best from `Chromosomes` by fitness (`Fitness` is always set by `Evaluate`) and reads `TspChromosome.Distance` for the tour length metric. This matches the MGS-5 harness convention.

See #1203.