### PR TITLE
feat(lean): Knots Phase 5 PR1.5c step (a) -- strengthen Reidemeister1Connected (Y' rename constraint) for PR2 (See #2874)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -167,6 +167,24 @@ coordinator's C/X modeling decision (See #2874). It does NOT replace the
 merged moves (#2956) — both coexist so prior results stay valid.
 -/
 
+/-- `Y'` is obtained from `c` by renaming occurrences of `a` to `b`: each field of
+    `Y'` is either unchanged from `c`, or is `b` where `c` had `a`. This is the
+    constraint that makes the tricolorability transfer lemma (PR2) provable: under
+    a coloring extension with `col₂ b = col₁ a` and `col₂ = col₁` on the preserved
+    edges, every strand of `Y'` reads the same colour as the corresponding strand
+    of `c` under `col₁`, so the Fox condition at the modified crossing is preserved.
+
+    Without this constraint (the merged #2980 model) `Y'` is a free existential, so
+    the Fox condition at the modified crossing is decoupled from `d₁`'s coloring —
+    the transfer lemma cannot hold. This strengthening (option C, scoped step (a)) is
+    non-breaking: the #2980 witness `⟨5,2,3,4⟩ = rename(⟨1,2,3,4⟩, 1→5)` still
+    satisfies it (see `reidemeister1Connected_satisfiable`). -/
+def PDCrossing.isRenameOf (Y' c : PDCrossing) (a b : Nat) : Prop :=
+  (Y'.e1 = c.e1 ∨ (Y'.e1 = b ∧ c.e1 = a)) ∧
+  (Y'.e2 = c.e2 ∨ (Y'.e2 = b ∧ c.e2 = a)) ∧
+  (Y'.e3 = c.e3 ∨ (Y'.e3 = b ∧ c.e3 = a)) ∧
+  (Y'.e4 = c.e4 ∨ (Y'.e4 = b ∧ c.e4 = a))
+
 /-- **Reidemeister1Connected (option C)**: a CONNECTED R1 twist on arc `a`.
     The surgery modifies endpoint crossing `Y = d₁.crossings[i]` (one slot `a`
     renamed to `b = d₁.numEdges + 1`, materialised as the supplied `Y'`) and
@@ -174,13 +192,21 @@ merged moves (#2956) — both coexist so prior results stay valid.
     the `d₂.wf = true` premise is **satisfiable** — see
     `reidemeister1Connected_satisfiable`. The hypothesis `a ∈ d₁.edges` forces
     the move to be genuinely connected (arc `a` is a real edge of `d₁`), so the
-    new crossing shares an edge with `d₁` rather than being a disjoint kink. -/
+    new crossing shares an edge with `d₁` rather than being a disjoint kink.
+
+    The hypothesis `Y'.isRenameOf (d₁.crossings.get i) a (d₁.numEdges + 1)`
+    (strengthened in scoped step (a)) ties `Y'` to the endpoint crossing it
+    replaces — it is that crossing with `a`-occurrences renamed to `b`, nothing
+    else. This is what the PR2 transfer lemma needs to push a tricoloring across
+    the move (the modified crossing's Fox condition is preserved under
+    `col₂ b = col₁ a`). -/
 def Reidemeister1Connected (d₁ d₂ : KnotDiagram) : Prop :=
   d₁.wf = true ∧ d₂.wf = true ∧
   (∃ (i : Fin d₁.crossings.length) (a : Nat) (Y' : PDCrossing)
      (ρ : Fin d₁.numEdges ↪ Fin (d₁.numEdges + 2)),
      1 ≤ a ∧ a ≤ d₁.numEdges ∧
      a ∈ d₁.edges ∧
+     Y'.isRenameOf (d₁.crossings.get i) a (d₁.numEdges + 1) ∧
      d₂ = { d₁ with crossings := d₁.crossings.set i.val Y' ++
                        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩],
                     numEdges := d₁.numEdges + 2 })
@@ -203,10 +229,14 @@ theorem reidemeister1Connected_satisfiable :
   · -- ρ : Fin 4 ↪ Fin 6 (trivial embedding, first 4 → first 4 of 6).
     exact { toFun := fun j => ⟨j.val, by omega⟩,
             inj' := fun x y h => by injection h with hv; exact Fin.ext hv }
-  · -- body: 1 ≤ a, a ≤ numEdges, a ∈ d₁.edges, and the surgery equation.
-    -- `decide` (kernel reduction) handles the struct projections / flatMap
-    -- that `omega` cannot see; `rfl` closes the definitional surgery equation.
-    exact ⟨by decide, by decide, by decide, rfl⟩
+  · -- body: 1 ≤ a, a ≤ numEdges, a ∈ d₁.edges, Y' isRenameOf (rename 1→5 at e1),
+    --   and the surgery equation. `decide` (kernel reduction) handles the struct
+    --   projections / flatMap that `omega` cannot see; `rfl` closes the
+    --   definitional surgery equation. The isRenameOf holds: e1 renamed (1→5),
+    --   e2=e3=e4 unchanged. isRenameOf must be unfolded first — as a raw `def`
+    --   it has no `Decidable` instance, but the unfolded `∧∨=` on `Nat` does.
+    exact ⟨by decide, by decide, by decide,
+           by unfold PDCrossing.isRenameOf; decide, rfl⟩
 
 /-! ### API lemmas for `Reidemeister1Connected` (option C infrastructure for PR2)
 
@@ -223,7 +253,7 @@ by exactly 1. They mirror the `trefoil_wf` / `unknot_wf` projection-API style of
     a connected splice. -/
 theorem Reidemeister1Connected.numEdges_succ {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) : d₂.numEdges = d₁.numEdges + 2 := by
-  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, hsurg⟩ := h
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hrename, hsurg⟩ := h
   have hne := congrArg (·.numEdges) hsurg
   simpa using hne
 
@@ -232,7 +262,7 @@ theorem Reidemeister1Connected.numEdges_succ {d₁ d₂ : KnotDiagram}
     not duplicated. -/
 theorem Reidemeister1Connected.numCrossings_succ {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) : d₂.crossings.length = d₁.crossings.length + 1 := by
-  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, hsurg⟩ := h
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hrename, hsurg⟩ := h
   have hcl := congrArg (fun d => d.crossings.length) hsurg
   simpa [List.length_set, List.length_append] using hcl
 
@@ -242,7 +272,7 @@ theorem Reidemeister1Connected.numCrossings_succ {d₁ d₂ : KnotDiagram}
     `⟨n+1,n+1,n+2,n+2⟩` (which shares no edge with `d₁`). -/
 theorem Reidemeister1Connected.shares_edge {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) : ∃ a : Nat, a ∈ d₁.edges ∧ 1 ≤ a ∧ a ≤ d₁.numEdges := by
-  obtain ⟨_hwf₁, _hwf₂, _i, a, _Y', _ρ, hr1, hr2, hmem, _hsurg⟩ := h
+  obtain ⟨_hwf₁, _hwf₂, _i, a, _Y', _ρ, hr1, hr2, hmem, _hrename, _hsurg⟩ := h
   exact ⟨a, hmem, hr1, hr2⟩
 
 /-- R2 (Poke/Unpoke): add or remove two consecutive crossings of opposite sign.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -208,6 +208,43 @@ theorem reidemeister1Connected_satisfiable :
     -- that `omega` cannot see; `rfl` closes the definitional surgery equation.
     exact ⟨by decide, by decide, by decide, rfl⟩
 
+/-! ### API lemmas for `Reidemeister1Connected` (option C infrastructure for PR2)
+
+These projection-style lemmas expose the surgery's combinatorial shape, which the
+transfer lemma (PR2) consumes when pushing a tricoloring across a connected R1
+twist: the edge count grows by exactly 2 (same magnitude as the disjoint-kink
+append model, but reached by a connected splice), and the crossing count grows
+by exactly 1. They mirror the `trefoil_wf` / `unknot_wf` projection-API style of
+`Basic.lean`.
+-/
+
+/-- A connected R1 twist adds exactly two edges (the kink monogon `c` and the
+    renamed arc endpoint `b`), same magnitude as the disjoint-kink model but via
+    a connected splice. -/
+theorem Reidemeister1Connected.numEdges_succ {d₁ d₂ : KnotDiagram}
+    (h : Reidemeister1Connected d₁ d₂) : d₂.numEdges = d₁.numEdges + 2 := by
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, hsurg⟩ := h
+  have hne := congrArg (·.numEdges) hsurg
+  simpa using hne
+
+/-- A connected R1 twist adds exactly one crossing (the curl `C`); the existing
+    endpoint crossing `Y` is relabelled in place (`List.set` preserves length),
+    not duplicated. -/
+theorem Reidemeister1Connected.numCrossings_succ {d₁ d₂ : KnotDiagram}
+    (h : Reidemeister1Connected d₁ d₂) : d₂.crossings.length = d₁.crossings.length + 1 := by
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, hsurg⟩ := h
+  have hcl := congrArg (fun d => d.crossings.length) hsurg
+  simpa [List.length_set, List.length_append] using hcl
+
+/-- The arc `a` receiving the twist is a genuine edge of `d₁` (connectivity
+    hypothesis): the new crossing `C = ⟨a, b, c, c⟩` shares edge `a` with `d₁`,
+    which is what distinguishes a connected twist from a disjoint kink
+    `⟨n+1,n+1,n+2,n+2⟩` (which shares no edge with `d₁`). -/
+theorem Reidemeister1Connected.shares_edge {d₁ d₂ : KnotDiagram}
+    (h : Reidemeister1Connected d₁ d₂) : ∃ a : Nat, a ∈ d₁.edges ∧ 1 ≤ a ∧ a ≤ d₁.numEdges := by
+  obtain ⟨_hwf₁, _hwf₂, _i, a, _Y', _ρ, hr1, hr2, hmem, _hsurg⟩ := h
+  exact ⟨a, hmem, hr1, hr2⟩
+
 /-- R2 (Poke/Unpoke): add or remove two consecutive crossings of opposite sign.
 
 Two parallel strands can pass through each other:


### PR DESCRIPTION
## Summary

**Scoped step (a)** of ai-01's option-C decision (14/06 ~17:15Z, dashboard `[DÉCISION] Knot #2874 → Option C`): strengthen the `Reidemeister1Connected` surgery def so the **PR2 transfer lemma** (`IsTricolorable d₁ ↔ IsTricolorable d₂` under a connected R1 twist) becomes provable. Also bundles the 3 projection API lemmas that PR2 will consume (adapted to the strengthened conjunct order). **Supersedes #2987** (whose API lemmas are included here, re-fitted).

## Blast-radius finding (the reason this PR exists)

The merged `Reidemeister1Connected` (#2980, the option-C de-risking artifact) has `Y'` as a **free existential**: the def says "there exists a crossing `Y'` set at position `i`" but does **not** constrain `Y'` to be the endpoint crossing `d₁.crossings[i]` with an `a`-occurrence renamed to `b`. Consequently the Fox tricolorability condition at the *modified* crossing is **decoupled** from `d₁`'s coloring — the PR2 transfer lemma **cannot hold** on the merged def (a free `Y'` could introduce any local coloring structure).

This is exactly ai-01's scoped deliverable "(a) réécris la def surgery (connexe)": the def needs the `Y'`-renaming hypothesis.

## Strengthening (additive to the move model, non-breaking)

- **`def PDCrossing.isRenameOf (Y' c : PDCrossing) (a b : Nat) : Prop`** — `Y'` is `c` with `a`-occurrences renamed to `b`: each field of `Y'` is either unchanged from `c`, or is `b` where `c` had `a`.
- **`Reidemeister1Connected`** now additionally requires `Y'.isRenameOf (d₁.crossings.get i) a (d₁.numEdges + 1)`.

**Why this is sufficient for PR2.** Under the coloring extension `col₂ b = col₁ a`, `col₂ c = col₁ a` (kink), `col₂ = col₁` on the preserved edges: every strand of `Y'` reads the same colour as the corresponding strand of the original crossing under `col₁`. So the Fox condition at the modified crossing is preserved. The new crossing `⟨a, b, c, c⟩` reads `(col₁ a, col₁ a, col₁ a)` — all-equal, Fox-trivial. The transfer lemma (both directions) is now unblocked for the next cycle.

**Non-breaking.** The `#2980` witness `Y' = ⟨5,2,3,4⟩ = rename(⟨1,2,3,4⟩, 1→5 at e1)` still satisfies the strengthened def (`reidemeister1Connected_satisfiable` re-proven; `isRenameOf` discharged by `unfold PDCrossing.isRenameOf; decide`). No theorem depends on the def — it is unused by `tricolorable_invariant` (which is over `ReidemeisterEquiv` / `Reidemeister1/2/3`).

## Changes (1 file, +72/-5 vs main)

- `def PDCrossing.isRenameOf` (new helper).
- `def Reidemeister1Connected` (strengthened: +`isRenameOf` conjunct).
- `theorem reidemeister1Connected_satisfiable` (witness re-proven under the stronger def).
- `Reidemeister1Connected.numEdges_succ` / `.numCrossings_succ` / `.shares_edge` (3 projection API lemmas, adapted to the new conjunct order — from #2987, re-fitted).

## lean-merge-discipline B (4 elements)

| Element | Result |
|---------|--------|
| **Sorry delta** | `Reidemeister.lean` **2 → 2** (`reidemeister_theorem` PL topology OOS, UNTOUCHED). All new defs/lemmas/theorem sorry-free. |
| **Lake build** | `lake build Knots` SUCCESS genuine (**321 jobs, EXIT=0**, `set -o pipefail`). |
| **Axiom check** | `#print axioms` via `lake env lean`: `reidemeister1Connected_satisfiable` = `[propext, Quot.sound]`; `numEdges_succ` = none; `numCrossings_succ` = `[propext]`; `shares_edge` = none. All ⊆ baseline `[propext, Quot.sound]`. |
| **Scope diff** | `+72/-5`, 1 file (`Reidemeister.lean`), 0 catalog drift, strengthening of a pre-PR2 unused def (witness preserved, no dependent theorem). |

Build log tail:
```
Build completed successfully (321 jobs).
```

## Scope guards

- `Reidemeister1` (free-ρ, #2929), `Reidemeister1'` (ρ-determined, #2956), `Reidemeister2/3` — **untouched**.
- `Basic.lean`, `Invariant.lean`, `Conway.lean`, `Lidman.lean`, `MathlibPrerequisites.lean` — **untouched**.
- `tricolorable_invariant` (Invariant.lean) — **untouched** (still sorry; the transfer lemma proper = next cycle, gated on this strengthening merging).
- No catalog regeneration on the branch (rule catalog-pr-hygiene).
- **Supersedes #2987** (its API lemmas are included here, re-fitted to the strengthened conjunct order).
- `See #2874` (epic open — scoped step (a), not a closer).

See #2874

Co-Authored-By: Claude <noreply@anthropic.com>
