### PR TITLE
feat(lean): Knots Phase 5 PR2 API -- Reidemeister1Connected.crossings_eq surgery equation (See #2874)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -275,6 +275,24 @@ theorem Reidemeister1Connected.shares_edge {d₁ d₂ : KnotDiagram}
   obtain ⟨_hwf₁, _hwf₂, _i, a, _Y', _ρ, hr1, hr2, hmem, _hrename, _hsurg⟩ := h
   exact ⟨a, hmem, hr1, hr2⟩
 
+/-- The surgery equation on crossings in directly-usable form: `d₂.crossings`
+    is `d₁.crossings` with the endpoint crossing at index `i` rewritten to `Y'`
+    (via `List.set`), then the monogon kink
+    `⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩` appended. The PR2
+    transfer lemma rewrites with this equation to analyse the Fox condition at
+    exactly the two crossings touched by the move (the relabelled `Y'` at
+    index `i`, and the appended kink `C` whose `e3 = e4 = c` self-loop means
+    arc `c` is a closed strand). -/
+theorem Reidemeister1Connected.crossings_eq {d₁ d₂ : KnotDiagram}
+    (h : Reidemeister1Connected d₁ d₂) :
+    ∃ (i : ℕ) (Y' : PDCrossing) (a : Nat),
+      i < d₁.crossings.length ∧
+      d₂.crossings = d₁.crossings.set i Y' ++
+        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := by
+  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, _hr1, _hr2, _hmem, _hrename, hsurg⟩ := h
+  refine ⟨i.val, Y', a, i.isLt, ?_⟩
+  simpa using congrArg (·.crossings) hsurg
+
 /-- R2 (Poke/Unpoke): add or remove two consecutive crossings of opposite sign.
 
 Two parallel strands can pass through each other:


### PR DESCRIPTION
## Summary

4th API lemma for `Reidemeister1Connected` (option C, base of PR #2980 now merged), consumed by the upcoming **PR2 transfer lemma** (`Reidemeister1Connected d1 d2 -> (IsTricolorable d1 <-> IsTricolorable d2)`).

Under `Reidemeister1Connected d1 d2`, the lemma exposes the surgery equation on crossings in directly-usable form:

```
d2.crossings = d1.crossings.set i Y' ++ [<a, n+1, n+2, n+2>]
```

with `i < d1.crossings.length`. PR2 rewrites once with this equation and analyses the Fox (tricolorability) condition at exactly the two crossings touched by the move:
- the relabelled endpoint crossing `Y'` (at index `i`),
- the appended monogon kink `C = <a, n+1, n+2, n+2>` whose `e3 = e4 = c` self-loop means arc `c` is a closed strand.

This mirrors the projection-API style of the 3 existing lemmas (`numEdges_succ`, `numCrossings_succ`, `shares_edge`) added in #2980.

## Verification (lean-merge-discipline section B)

| Element | Status |
|---------|--------|
| **sorry count** | Reidemeister.lean `1 -> 1` (only `reidemeister_theorem` PL-topology OOS sorry, unchanged). The new lemma `crossings_eq` is **sorry-free**. |
| **Lake build SUCCESS** | `lake build Knots` -> EXIT 0, 0 error. `.olean` deleted then regenerated (genuine build, not cached). |
| **Proof integrity (axiom check)** | 0 axiom added -- `obtain` + `refine` + `simpa` + `congrArg`, no `sorryAx`. |
| **No prover Python refactor** | N/A -- Lean-only. |

### Proof sketch

```
obtain <_hwf1, _hwf2, i, a, Y', _rho, ..., hsurg> := h
refine <i.val, Y', a, i.isLt, ?_>
simpa using congrArg (.crossings) hsurg
```

## Scope / honesty (G.9)

This is an **infrastructure lemma**, not the transfer lemma itself. The full transfer lemma (`IsTricolorable d1 <-> IsTricolorable d2` under `Reidemeister1Connected`) is research-level and will land in a dedicated cycle (or via the prover BG). This lemma is the last piece of the "API for PR2" block (L241 of the module) so PR2 can be built on solid, named projections rather than re-deriving the surgery equation each time.

## Diff coherence

`+18/-0`, additive API lemma only (inserted after `shares_edge`, before the `Reidemeister2` docstring). No sorry regression, no deletion of proven material.

See #2874

Generated with Claude Code