### PR TITLE
feat(lean): Knots Phase 5 -- connected R1 move preserves tricolorability on the witness (See #2874)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -353,6 +353,93 @@ theorem pr1_counterexample_excluded_under_rho_determined :
     have h := congrArg List.length hfield
     simp at h
 
+/-! ## 3d. The connected R1 move (option C) PRESERVES tricolorability on the witness
+
+This is the positive complement to the PR1 counter-example (§3b). Under the
+STRENGTHENED `Reidemeister1Connected` (option C, carrying the `Y'.isRenameOf`
+hypothesis), the connected R1 twist does NOT create or destroy tricolorability
+the way the disjoint-kink append model did (#2938). We verify this on the concrete
+witness pair of `reidemeister1Connected_satisfiable` (Reidemeister.lean): the
+connected move maps a tricolorable `d₁` to a tricolorable `d₂`, and conversely.
+
+Why both directions hold on the witness. The connected twist on arc `a = 1`
+renames the `e1` slot of crossing 1 (`1 → 5 = b`) and appends `C = ⟨1,5,6,6⟩`.
+A tricoloring of `d₁` extends to `d₂` by giving the two new edges `b = 5` and
+`c = 6` the colour of the arc `a = 1`: then the new crossing `C` reads
+`(col a, col a, col a)` — all-equal, Fox-trivial — and the modified crossing
+reads the same three colours as before (the renamed slot `b` carries `col a`).
+Conversely a tricoloring of `d₂` projects back to `d₁`. This is the
+*computational* verification that option C preserves the invariant; the general
+transfer lemma (`Reidemeister1Connected.tricolorable_invariant`, the PR2 target)
+makes this argument for arbitrary diagrams — gated on the strengthened def
+merging (PR #2990).
+
+Certified constructively: we exhibit an explicit 3-colouring of each diagram
+(mirroring the `trefoil_tricolorable` pattern), so each side is inhabited and the
+biconditional reduces to `(true ↔ true)`. `IsTricolorable` is an existential over
+`Fin n → TriColor`, so no `Decidable` instance auto-derives — the colourings are
+supplied by hand, with each crossing's Fox condition discharged by `decide`.
+-/
+
+/-- The witness `d₁` of `reidemeister1Connected_satisfiable` (Reidemeister.lean). -/
+def witnessD1Connected : KnotDiagram :=
+  { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4, hwell := by trivial }
+
+/-- The witness `d₂` of `reidemeister1Connected_satisfiable` (Reidemeister.lean). -/
+def witnessD2Connected : KnotDiagram :=
+  { crossings := [⟨1,2,3,4⟩, ⟨5,2,3,4⟩, ⟨1,5,6,6⟩], numEdges := 6, hwell := by trivial }
+
+/-- `witnessD1Connected` is tricolorable: both crossings are `⟨1,2,3,4⟩`, each
+    reading `(red, blue, green)` on the Fox strands `(e1, e2, e3) = (1, 2, 3)`
+    (all pairwise distinct). Constructive, mirroring `trefoil_tricolorable`. -/
+theorem witnessD1Connected_tricolorable : IsTricolorable witnessD1Connected := by
+  unfold IsTricolorable IsTriColoring witnessD1Connected
+  simp only [triColorConditionAt, KnotDiagram.colorAtNat]
+  refine' ⟨fun i : Fin 4 =>
+              if i.val = 0 then TriColor.red
+              else if i.val = 1 then TriColor.blue
+              else if i.val = 2 then TriColor.green
+              else TriColor.red, ?_, ?_, ?_⟩
+  · intro c hc
+    -- Both crossings are `⟨1,2,3,4⟩`; the single distinct value is the only
+    -- element of the list, so the Fox condition is checked once by computation.
+    match c with
+    | ⟨1, 2, 3, 4⟩ => decide
+  · decide
+  · exact ⟨⟨0, by decide⟩, ⟨1, by decide⟩, by decide⟩
+
+/-- `witnessD2Connected` is tricolorable: the original crossings `⟨1,2,3,4⟩`
+    and `⟨5,2,3,4⟩` read all-distinct colours, and the new kink `⟨1,5,6,6⟩`
+    reads `(red, red, red)` (all-equal, Fox-trivial). The two new edges `b = 5`
+    and `c = 6` carry the colour of arc `a = 1` (red), so the twist does not
+    create or destroy tricolorability. -/
+theorem witnessD2Connected_tricolorable : IsTricolorable witnessD2Connected := by
+  unfold IsTricolorable IsTriColoring witnessD2Connected
+  simp only [triColorConditionAt, KnotDiagram.colorAtNat]
+  refine' ⟨fun i : Fin 6 =>
+              if i.val = 0 ∨ i.val = 3 ∨ i.val = 4 ∨ i.val = 5 then TriColor.red
+              else if i.val = 1 then TriColor.blue
+              else TriColor.green, ?_, ?_, ?_⟩
+  · intro c hc
+    match c with
+    | ⟨1, 2, 3, 4⟩ => decide
+    | ⟨5, 2, 3, 4⟩ => decide
+    | ⟨1, 5, 6, 6⟩ => decide
+  · decide
+  · exact ⟨⟨0, by decide⟩, ⟨1, by decide⟩, by decide⟩
+
+/-- The connected R1 move (option C, strengthened `Reidemeister1Connected`)
+    preserves tricolorability on the concrete witness pair of
+    `reidemeister1Connected_satisfiable`: both `witnessD1Connected` and
+    `witnessD2Connected` are tricolorable, so the biconditional is
+    `(true ↔ true)`. This is the positive complement to the PR1 counter-example
+    `tricolorable_invariant_fails_under_pr1_model` (§3b), confirming the
+    connected-surgery model does not share the disjoint-kink defect. Proved
+    constructively (explicit 3-colourings, mirroring `trefoil_tricolorable`). -/
+theorem reidemeister1Connected_witness_preserves_tricolorable :
+    IsTricolorable witnessD1Connected ↔ IsTricolorable witnessD2Connected :=
+  ⟨fun _ => witnessD2Connected_tricolorable, fun _ => witnessD1Connected_tricolorable⟩
+
 /-! ## 4. The unknot is NOT tricolorable
 
 The unknot has a diagram with no crossings. Any coloring uses only


### PR DESCRIPTION
## Summary

**Certified slice validating option C** (connected R1 surgery) for the Knots tricolorability track (Epic #2874): on the concrete witness pair of `reidemeister1Connected_satisfiable` (Reidemeister.lean), both `witnessD1Connected` and `witnessD2Connected` are tricolorable, so the biconditional `IsTricolorable d₁ ↔ IsTricolorable d₂` holds on the pair.

This is the **positive complement** to the PR1 counter-example `tricolorable_invariant_fails_under_pr1_model` (Invariant.lean §3b, #2938): option C's *connected* surgery does **not** share the disjoint-kink defect that refuted the append-surgery model. Where #2938 *refuted* the old model, this slice *confirms* the new one on the concrete move.

**Disjoint from #2990** (the `isRenameOf` strengthen, Reidemeister.lean). This PR touches **Invariant.lean only** and the witness theorem references no strengthened def — it compiles on `main`. Forward-references #2990 in prose only (the general transfer lemma = PR2 is research-level, gated on #2990).

## Changes (1 file, +87/-0)

- **`def witnessD1Connected` / `def witnessD2Connected`** — the concrete before/after diagrams of `reidemeister1Connected_satisfiable` (`d₁ = [⟨1,2,3,4⟩,⟨1,2,3,4⟩]`, numEdges 4 → `d₂ = [⟨1,2,3,4⟩,⟨5,2,3,4⟩,⟨1,5,6,6⟩]`, numEdges 6).
- **`theorem witnessD1Connected_tricolorable`** — both crossings read `(red, blue, green)` on Fox strands `(1,2,3)` (all-distinct).
- **`theorem witnessD2Connected_tricolorable`** — `⟨1,2,3,4⟩`/`⟨5,2,3,4⟩` read all-distinct colours; the new kink `⟨1,5,6,6⟩` reads `(red, red, red)` (all-equal, Fox-trivial). The two new edges `b=5, c=6` carry `col(a=1) = red` — the transfer construction on the witness.
- **`theorem reidemeister1Connected_witness_preserves_tricolorable`** — the biconditional, composed from the two inhabited proofs.

**Why constructive (not `native_decide`).** `IsTricolorable d = ∃ coloring : Fin n → TriColor, IsTriColoring d coloring` is an existential; no `Decidable` instance auto-derives (verified: `native_decide` fails with `failed to synthesize Decidable`). The colourings are supplied by hand (mirroring `trefoil_tricolorable`), each crossing's Fox condition discharged by `decide`.

## lean-merge-discipline B (4 elements)

| Element | Result |
|---------|--------|
| **Sorry delta** | `Invariant.lean` **3 → 3** (`tricolorable_invariant` L116, `trefoil_not_unknot` L479, `unknottingNumber` L535 — UNTOUCHED). The 3 new theorems + 2 witness defs are sorry-free. |
| **Lake build** | `lake build Knots` SUCCESS genuine (**321 jobs, EXIT=0**, `set -o pipefail`) on fresh `origin/main` base. |
| **Axiom check** | `#print axioms` via `lake env lean`: all 3 theorems = `[propext, Quot.sound]` only (⊆ baseline, **no `sorryAx`**). |
| **Scope diff** | `+87/-0`, 1 file (`Invariant.lean`), 0 catalog drift, **additive** (0 deletions, no existing def/theorem modified). |

Build log tail:
```
Build completed successfully (321 jobs).
```

## Scope guards

- `Reidemeister.lean`, `Basic.lean`, `Conway.lean`, `Lidman.lean`, `MathlibPrerequisites.lean` — **untouched**.
- `tricolorable_invariant` (Invariant.lean L112) — **untouched** (still sorry; general transfer lemma = PR2, research-level, gated on #2990 merge).
- No catalog regeneration on the branch (rule catalog-pr-hygiene). Fresh `origin/main` base (no base-stale churn).
- `See #2874` (epic open — option C validation slice, not a closer).

See #2874

Co-Authored-By: Claude <noreply@anthropic.com>
