### PR TITLE
feat(mgs): MGS-7 Fitness Landscape Explorer (Phase 6 revival, See #1203)

### DIFF
--- a/MyIA.AI.Notebooks/Search/MetaGeneticSharp-Notebooks/MGS-7-LandscapeExplorer.ipynb
+++ b/MyIA.AI.Notebooks/Search/MetaGeneticSharp-Notebooks/MGS-7-LandscapeExplorer.ipynb
@@ -1,0 +1,1727 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7f83c1cd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003143,
+     "end_time": "2026-06-14T20:04:47.559968+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:47.556825+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# MGS-7 : Fitness Landscape Explorer -- voir la surface pour comprendre la recherche\n",
+    "\n",
+    "[← MGS-6 TSP](MGS-6-TSP.ipynb) | [↑ Série MGS](../Part4-Metaheuristics/README.md)\n",
+    "\n",
+    "**Pourquoi visualiser le paysage de fitness ?** Un algorithme de recherche explore une surface dont la *forme* dicte la difficulté : unimodale (un seul bassin, facile) ou multimodale (pièges locaux), vallée étroite (mal conditionnée) ou plateau (peu informatif). Tant que cette surface est invisible, le choix d'une métaheuristique relève du *doctrinal*. La visualiser rend le choix *éclairé*.\n",
+    "\n",
+    "Ce notebook ressuscite, en .NET Interactive consommant les **vraies fonctions** de `KnownFunctions.cs`, le **Landscape Explorer** original écrit par jsboige en gtk# (`LandscapeExplorerSampleController.cs`, PR giacomelli/GeneticSharp#87). Il reproduit fidèlement ses quatre fonctionnalités :\n",
+    "\n",
+    "| # | Feature gtk# originale | Implémentation ici |\n",
+    "|---|------------------------|--------------------|\n",
+    "| (a) | Sélecteur de dimension entier `mNbDimensions` (2→N) | `nbDimensions` → longueur du `DoubleArrayChromosome` |\n",
+    "| (b) | Projection 2D pour n>2 (échantillonnage des dims cachées, on garde le max) | `LandscapeObjective` échantillonne les dims 2..n, garde l'objectif MAX |\n",
+    "| (c) | Heatmap HSV du paysage (`BuildBitmap`+`GetColor`) | Heatmap **ASCII en niveaux de gris** (voir note ci-dessous) |\n",
+    "| (d) | Trajectoire de convergence de la population superposée | `'B'` (meilleur/génération) + `'P'` (population finale) marqués sur la grille |\n",
+    "\n",
+    "> **Note sur le rendu ASCII.** L'original gtk# calculait un bitmap HSV pixel par pixel. Ici le paysage est rendu en **ASCII art en niveaux de gris** : chaque cellule de la grille reçoit un caractère d'une rampe `' .:-=+*#%@'` selon la valeur de l'objectif — l'optimum (objectif faible, « bon ») apparaît comme une tache dense (`@`), les crêtes (objectif élevé) comme du vide (`.`). Ce média a été choisi parce que la résolution `#r \"nuget:\"` des packages de tracé (Plotly/ScottPlot) reste bloquée sous papermill sur cet environnement (sonde réseau des métadonnées NuGet en cache) ; le rendu flux-standard est entièrement fiable. La **feature** (rendre la structure du paysage inspectable) est préservée — seul le média diffère.\n",
+    "\n",
+    "> **AUTHORSHIP.** Les fonctions elles-mêmes ne sont **jamais réimplémentées**. Chaque point de la grille crée un vrai `DoubleArrayChromosome` et appelle la vraie `IFitness.Evaluate` du fork. On *visualise autour* de la bibliothèque de jsboige, on ne la duplique pas. Le variant « shifted » (item 2 du dispatch) est un *wrapper* qui translate les coordonnées avant d'appeler la vraie fonction — composition, pas réécriture.\n",
+    "\n",
+    "> **Lien avec MGS-5.** Le banc d'essai MGS-5 montrait que WOA diverge sur Schwefel (fitness explosive). *Ici on voit pourquoi* : la heatmap révèle un optimum déceptif loin du centre, noyé dans des crêtes. Le paysage rend le diagnostic *immédiat* — c'est le gain d'ingénierie de l'approche « components over metaphors » : on peut inspecter et la surface *et* l'algorithme.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3bea4d5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00244,
+     "end_time": "2026-06-14T20:04:47.565444+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:47.563004+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Câblage : MetaGeneticSharp (GeneticSharp + Domain + Extensions)\n",
+    "\n",
+    "On charge les DLLs du fork construites localement. `Extensions` porte `KnownFunctions` (les 10 fonctions de benchmark). Aucun package de tracé n'est requis : le rendu se fait en flux texte standard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "db3bc54d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T20:04:47.580459Z",
+     "iopub.status.busy": "2026-06-14T20:04:47.574768Z",
+     "iopub.status.idle": "2026-06-14T20:04:48.979955Z",
+     "shell.execute_reply": "2026-06-14T20:04:48.975676Z"
+    },
+    "papermill": {
+     "duration": 1.412284,
+     "end_time": "2026-06-14T20:04:48.980070+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:47.567786+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:2545:5f43:5adb:da74:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1048820.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wiring OK : MetaGeneticSharp + GeneticSharp + Extensions (KnownFunctions).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SphereFitness type     : SphereFitness\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  KnownFunctionsBounds   : KnownFunctionsBounds\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// MetaGeneticSharp + GeneticSharp DLLs from the fork build.\n",
+    "// Build prerequisite: dotnet build c:/dev/MetaGeneticSharp/MetaGeneticSharp.sln\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
+    "\n",
+    "using MetaGeneticSharp;\n",
+    "using GeneticSharp;\n",
+    "\n",
+    "Console.WriteLine(\"Wiring OK : MetaGeneticSharp + GeneticSharp + Extensions (KnownFunctions).\");\n",
+    "Console.WriteLine($\"  SphereFitness type     : {typeof(SphereFitness).Name}\");\n",
+    "Console.WriteLine($\"  KnownFunctionsBounds   : {typeof(KnownFunctionsBounds).Name}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de84f83b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00263,
+     "end_time": "2026-06-14T20:04:48.985814+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:48.983184+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Chromosome continu : `DoubleArrayChromosome`\n",
+    "\n",
+    "Réplique minimale de l'assistant de test du fork (cf. MGS-5). Chaque gène est un `double` nu, lisible via `GetDoubleValues()`. Le `CreateNew()` randomise dans les bornes — diversité initiale indispensable pour que le GA explore.\n",
+    "\n",
+    "C'est le **terrain commun** : les paysages sont évalués en construisant un tel chromosome par point de grille, puis en appelant la vraie `IFitness.Evaluate`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4bab7169",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T20:04:48.992156Z",
+     "iopub.status.busy": "2026-06-14T20:04:48.991953Z",
+     "iopub.status.idle": "2026-06-14T20:04:49.380382Z",
+     "shell.execute_reply": "2026-06-14T20:04:49.380060Z"
+    },
+    "papermill": {
+     "duration": 0.392106,
+     "end_time": "2026-06-14T20:04:49.380497+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:48.988391+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DoubleArrayChromosome defini. Probe 2D : (1,5, -2)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// DoubleArrayChromosome: minimal chromosome storing bare double gene values.\n",
+    "// (Inspired by the fork test helper; extended with per-gene bounds so CreateNew()\n",
+    "// randomizes the initial population -- without this the GA could not explore.)\n",
+    "public class DoubleArrayChromosome : ChromosomeBase\n",
+    "{\n",
+    "    private readonly double _min;\n",
+    "    private readonly double _max;\n",
+    "    public DoubleArrayChromosome(double[] values, double min, double max) : base(values.Length)\n",
+    "    {\n",
+    "        _min = min; _max = max;\n",
+    "        for (int i = 0; i < values.Length; i++) ReplaceGene(i, new Gene(values[i]));\n",
+    "    }\n",
+    "    public override IChromosome CreateNew()\n",
+    "    {\n",
+    "        var rand = RandomizationProvider.Current;\n",
+    "        int n = Length;\n",
+    "        var vals = new double[n];\n",
+    "        for (int i = 0; i < n; i++) vals[i] = rand.GetDouble(_min, _max);\n",
+    "        return new DoubleArrayChromosome(vals, _min, _max);\n",
+    "    }\n",
+    "    public override Gene GenerateGene(int geneIndex)\n",
+    "        => new Gene(RandomizationProvider.Current.GetDouble(_min, _max));\n",
+    "    public double[] GetDoubleValues() => GetGenes().Select(g => (double)g.Value).ToArray();\n",
+    "}\n",
+    "\n",
+    "var probe = new DoubleArrayChromosome(new double[]{1.5, -2.0}, -5.12, 5.12);\n",
+    "Console.WriteLine($\"DoubleArrayChromosome defini. Probe 2D : ({string.Join(\", \", probe.GetDoubleValues())})\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72351f9d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002652,
+     "end_time": "2026-06-14T20:04:49.387193+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.384541+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Features (a)+(b) : sélecteur de dimension et projection 2D\n",
+    "\n",
+    "**(a) Sélecteur de dimension.** `nbDimensions` fixe la dimension du problème — donc la longueur du chromosome. Pour n=2 on trace directement le paysage (x,y) → fitness. Pour n>2, la surface vit dans un espace qu'on ne peut pas afficher en entier.\n",
+    "\n",
+    "**(b) Projection 2D pour n>2.** L'astuce de jsboige : pour chaque point (x,y) du plan, on fixe les dims 0 et 1, on tire **aléatoirement** les dims 2..n dans les bornes (plusieurs échantillons), et on garde l'objectif **MAX** rencontré. On projette donc le « plafond » de la surface le long des dimensions cachées — la structure la plus défavorable que les dims cachées peuvent produire en (x,y). Fidèle à `GetFunctionValue` du contrôleur gtk#.\n",
+    "\n",
+    "> **Objectif vs fitness.** `KnownFunctions` *minimisent* ; GeneticSharp *maximise*. Donc `Evaluate` renvoie l'objectif **négativé**. On retrouve l'objectif vrai par `obj = -Evaluate(chrom)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e606e785",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T20:04:49.393489Z",
+     "iopub.status.busy": "2026-06-14T20:04:49.393274Z",
+     "iopub.status.idle": "2026-06-14T20:04:49.492767Z",
+     "shell.execute_reply": "2026-06-14T20:04:49.492643Z"
+    },
+    "papermill": {
+     "duration": 0.103275,
+     "end_time": "2026-06-14T20:04:49.492829+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.389554+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dimension n=2, bounds [-5,12, 5,12].\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  objectif @ origine  (x*=0) : 0   (attendu ~0)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  objectif @ coin     (max) : 52,429    (attendu positif eleve)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Feature (a): integer dimension selector -> chromosome length.\n",
+    "// Feature (b): for n>2, sample hidden dims randomly, keep the MAX objective (jsboige's GetFunctionValue).\n",
+    "int nbDimensions = 2;\n",
+    "IFitness fitness = new SphereFitness();\n",
+    "Type ftype = typeof(SphereFitness);\n",
+    "var (Fmin, Fmax) = KnownFunctionsBounds.For(ftype);\n",
+    "\n",
+    "// LandscapeObjective: the true objective value at (x,y), projected over hidden dims for n>2.\n",
+    "// Faithful to jsboige's LandscapeExplorerSampleController.GetFunctionValue (keeps Math.Max over samples).\n",
+    "double LandscapeObjective(IFitness f, double x, double y, int n, double lo, double hi, int samples)\n",
+    "{\n",
+    "    var rng = RandomizationProvider.Current;\n",
+    "    double best = double.MinValue;                 // keep MAX objective (the \"ceiling\" projection)\n",
+    "    for (int s = 0; s < samples; s++)\n",
+    "    {\n",
+    "        var coords = new double[n];\n",
+    "        coords[0] = x;\n",
+    "        coords[1] = y;\n",
+    "        for (int d = 2; d < n; d++) coords[d] = rng.GetDouble(lo, hi);\n",
+    "        var chrom = new DoubleArrayChromosome(coords, lo, hi);\n",
+    "        double obj = -f.Evaluate(chrom);           // true (minimized) objective\n",
+    "        if (obj > best) best = obj;\n",
+    "    }\n",
+    "    return best;\n",
+    "}\n",
+    "\n",
+    "int probeSamples = nbDimensions == 2 ? 1 : 12;\n",
+    "double atOptimum = LandscapeObjective(fitness, 0.0, 0.0, nbDimensions, Fmin, Fmax, probeSamples);\n",
+    "double atCorner  = LandscapeObjective(fitness, Fmax, Fmax, nbDimensions, Fmin, Fmax, probeSamples);\n",
+    "Console.WriteLine($\"Dimension n={nbDimensions}, bounds [{Fmin}, {Fmax}].\");\n",
+    "Console.WriteLine($\"  objectif @ origine  (x*=0) : {atOptimum:G5}   (attendu ~0)\");\n",
+    "Console.WriteLine($\"  objectif @ coin     (max) : {atCorner:G5}    (attendu positif eleve)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f1d834a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00239,
+     "end_time": "2026-06-14T20:04:49.497930+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.495540+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Feature (c) : heatmap du paysage de fitness (ASCII)\n",
+    "\n",
+    "On échantillonne une grille `W × H` sur les bornes, on évalue l'objectif projeté à chaque nœud, puis on mappe chaque valeur à un caractère d'une rampe de gris. L'optimum (objectif faible) apparaît comme une **tache dense** (`@`/`%`), les crêtes (objectif élevé) comme du **vide** (`.`/` `). La structure du bassin d'attraction devient lisible.\n",
+    "\n",
+    "> **Convention de lecture.** Axe horizontal = `x0` (gauche=min, droite=max), axe vertical = `x1` (haut=max, bas=min, comme un repère mathématique). La barre sous la grille donne l'échelle `[min, max]` de l'objectif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6b50880c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T20:04:49.503609Z",
+     "iopub.status.busy": "2026-06-14T20:04:49.503443Z",
+     "iopub.status.idle": "2026-06-14T20:04:49.644082Z",
+     "shell.execute_reply": "2026-06-14T20:04:49.641623Z"
+    },
+    "papermill": {
+     "duration": 0.143818,
+     "end_time": "2026-06-14T20:04:49.644148+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.500330+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- SphereFitness -- paysage (n=2) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x1=   5,12 |--------------------------------------------------------|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |    ...:::::-------==================-------:::::...    |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         | ...::::-----========++++++++++++++========-----::::... |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |..:::----======++++++++++******++++++++++======----:::..|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:::----====++++++**********************++++++====----:::|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:----===+++++********##############********+++++===----:|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |---===+++++******######################******+++++===---|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |--===++++*****########%%%%%%%%%%%%########*****++++===--|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |====+++*****#######%%%%%%%%%%%%%%%%%%#######*****+++====|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++*****######%%%%%%%%%%%%%%%%%%%%%%######*****+++===|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****######%%%%%%%%%%%%%%%%%%%%%%%%######****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****#####%%%%%%%%%%%%@@%%%%%%%%%%%%#####****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****#####%%%%%%%%%%%%@@%%%%%%%%%%%%#####****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****######%%%%%%%%%%%%%%%%%%%%%%%%######****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++*****######%%%%%%%%%%%%%%%%%%%%%%######*****+++===|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |====+++*****#######%%%%%%%%%%%%%%%%%%#######*****+++====|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |--===++++*****########%%%%%%%%%%%%########*****++++===--|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |---===+++++******######################******+++++===---|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:----===+++++********##############********+++++===----:|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:::----====++++++**********************++++++====----:::|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |..:::----======++++++++++******++++++++++======----:::..|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         | ...::::-----========++++++++++++++========-----::::... |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |    ...:::::-------==================-------:::::...    |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x1=  -5,12 |--------------------------------------------------------|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "          <                     --5,12                       5,12->  = axe x0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  echelle objectif : [0,06811 (optimum,@) .. 52,43 (crete,' ')]\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Feature (c): ASCII grayscale heatmap of the fitness landscape.\n",
+    "// Ramp: low objective (optimum, \"good\") -> dense char '@'; high objective (ridge) -> sparse '.'.\n",
+    "const string Ramp = \" .:-=+*#%@\";   // index 0 (lowest obj) = space-light, 9 (lowest mapped) ... see Shade()\n",
+    "const int W = 56, H = 22;            // ASCII grid resolution (chars are ~2x taller than wide)\n",
+    "\n",
+    "// Shade: map an objective value to a ramp char. low obj -> dense ('@'); high obj -> sparse (' ').\n",
+    "char Shade(double v, double vmin, double vmax)\n",
+    "{\n",
+    "    if (vmax - vmin < 1e-12) return Ramp[Ramp.Length - 1];\n",
+    "    // INVERT: low objective = good = dense char (end of ramp '@'); high objective = sparse (start ' ').\n",
+    "    double t = (v - vmin) / (vmax - vmin);          // 0..1, 0=low(obj)=good\n",
+    "    int idx = (int)((1.0 - t) * (Ramp.Length - 1));  // low obj -> high idx -> '@'\n",
+    "    if (idx < 0) idx = 0; if (idx >= Ramp.Length) idx = Ramp.Length - 1;\n",
+    "    return Ramp[idx];\n",
+    "}\n",
+    "\n",
+    "double[,] BuildLandscape(IFitness f, int n, double lo, double hi, int samples)\n",
+    "{\n",
+    "    var z = new double[W, H];\n",
+    "    for (int i = 0; i < W; i++)\n",
+    "    {\n",
+    "        double x = lo + (hi - lo) * i / (W - 1);\n",
+    "        for (int j = 0; j < H; j++)\n",
+    "        {\n",
+    "            double y = lo + (hi - lo) * j / (H - 1);\n",
+    "            z[i, j] = LandscapeObjective(f, x, y, n, lo, hi, samples);\n",
+    "        }\n",
+    "    }\n",
+    "    return z;\n",
+    "}\n",
+    "\n",
+    "void PrintHeatmap(double[,] z, string title, int[][] markers = null)\n",
+    "{\n",
+    "    // markers: optional list of (i,j) cell coords to overlay as letters (trajectory / population).\n",
+    "    double vmin = double.MaxValue, vmax = double.MinValue;\n",
+    "    for (int i = 0; i < W; i++) for (int j = 0; j < H; j++) { if (z[i,j] < vmin) vmin = z[i,j]; if (z[i,j] > vmax) vmax = z[i,j]; }\n",
+    "    var mark = new Dictionary<(int,int), char>();\n",
+    "    if (markers != null) foreach (var m in markers) if (m.Length == 3) mark[(m[0], m[1])] = (char)m[2];\n",
+    "\n",
+    "    Console.WriteLine($\"--- {title} ---\");\n",
+    "    Console.WriteLine($\"x1={Fmax,7:F2} |\" + new string('-', W) + \"|\");\n",
+    "    for (int j = H - 1; j >= 0; j--)        // top=max, bottom=min (math orientation)\n",
+    "    {\n",
+    "        var row = new StringBuilder();\n",
+    "        for (int i = 0; i < W; i++)\n",
+    "            row.Append(mark.ContainsKey((i,j)) ? mark[(i,j)] : Shade(z[i,j], vmin, vmax));\n",
+    "        double yval = Fmin + (Fmax - Fmin) * j / (H - 1);\n",
+    "        Console.WriteLine($\"         |{row}|\");\n",
+    "    }\n",
+    "    Console.WriteLine($\"x1={Fmin,7:F2} |\" + new string('-', W) + \"|\");\n",
+    "    Console.WriteLine($\"          <{'-' + Fmin.ToString(\"F2\"),27}{(Fmax.ToString(\"F2\") + \"-\").PadLeft(28)}>  = axe x0\");\n",
+    "    Console.WriteLine($\"  echelle objectif : [{vmin:G4} (optimum,@) .. {vmax:G4} (crete,' ')]\");\n",
+    "}\n",
+    "\n",
+    "int samplesForN = nbDimensions == 2 ? 1 : 12;\n",
+    "var Z = BuildLandscape(fitness, nbDimensions, Fmin, Fmax, samplesForN);\n",
+    "PrintHeatmap(Z, $\"{ftype.Name} -- paysage (n={nbDimensions})\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec4bb00b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003094,
+     "end_time": "2026-06-14T20:04:49.650582+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.647488+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Feature (d) : trajectoire de convergence superposée\n",
+    "\n",
+    "On lance un vrai `MetaGeneticAlgorithm` (méta `DefaultMetaHeuristic`, 30 générations) et on enregistre, à chaque génération, les coordonnées (x0,x1) du **meilleur** individu, puis les coordonnées de la **population finale**. On superpose le tout sur la grille : `'B'` marque la trajectoire du meilleur, `'P'` la population finale. On voit le GA « descendre » vers le bassin de l'optimum.\n",
+    "\n",
+    "> **Gotcha order-preserving (réutilisé de MGS-6).** `MetaPopulation` n'appelle jamais `Generation.End()`, donc `CurrentGeneration.BestChromosome` est **null** au moment de l'événement `GenerationRan`. On dérive le meilleur depuis `Chromosomes.OrderByDescending(Fitness).First()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8c02ff8e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T20:04:49.658639Z",
+     "iopub.status.busy": "2026-06-14T20:04:49.658455Z",
+     "iopub.status.idle": "2026-06-14T20:04:49.867901Z",
+     "shell.execute_reply": "2026-06-14T20:04:49.867758Z"
+    },
+    "papermill": {
+     "duration": 0.214374,
+     "end_time": "2026-06-14T20:04:49.867977+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.653603+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- SphereFitness -- trajectoire du GA sur 30 generations (B=meilleur, P=pop finale) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x1=   5,12 |--------------------------------------------------------|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |    ...:::::-------==================-------:::::...    |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         | ...::::-----========++++++++++++++========-----::::... |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |..:::----======++++++++++******++++++++++======----:::..|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:::----====++++++**********************++++++====----:::|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:----===+++++********##############********+++++===----:|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |---===+++++******######################******+++++===---|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |--===++++*****########%%%%%%%%%%%%########*****++++===--|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |====+++*****#######%%%%%%%%%%%%%%%%%%#######*****+++====|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++*****######%%%%%%%%%%%%%%%%%%%%%%######*****+++===|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****######%%%%%%%%%%%%%%%%%%%%%%%%######****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****#####%%%%%%%%%%B%P@%B%%%%%%%%%%#####****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****#####%%%%%%%%%%%%@@%%%%%%%%%%%%#####****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****######%%%%%%%%%%%%%%%%%%%%%%%%######****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++*****######%%%%%%%%%%%%%%%%%%%%%%######*****+++===|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |====+++*****#######%%%%%%%%%%%%%%%%%%#######*****+++====|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |--===++++*****########%%%%%%%%%%%%########*****++++===--|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |---===+++++******######################******+++++===---|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:----===+++++********##############********+++++===----:|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:::----====++++++**********************++++++====----:::|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |..:::----======++++++++++******++++++++++======----:::..|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         | ...::::-----========++++++++++++++========-----::::... |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |    ...:::::-------==================-------:::::...    |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x1=  -5,12 |--------------------------------------------------------|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "          <                     --5,12                       5,12->  = axe x0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  echelle objectif : [0,06811 (optimum,@) .. 52,43 (crete,' ')]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Trajectoire : 30 generations. Meilleur final = (-0,01093, 0,00988), objectif = 0,00021707.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Feature (d): run a GA, record the best (x0,x1) per generation + final population coords.\n",
+    "(double[] bx, double[] by, double[] px, double[] py) RunTrajectory(IFitness f, Type ft, int dim)\n",
+    "{\n",
+    "    var (lo, hi) = KnownFunctionsBounds.For(ft);\n",
+    "    var initVals = Enumerable.Repeat(0.5 * (lo + hi), dim).ToArray();   // seed \"adam\" at center\n",
+    "    var adam = new DoubleArrayChromosome(initVals, lo, hi);\n",
+    "    var pop = new MetaPopulation(40, 40, adam);\n",
+    "    var ga = new MetaGeneticAlgorithm(\n",
+    "        pop, f, new EliteSelection(),\n",
+    "        new UniformCrossover(0.5f), new UniformMutation(true),\n",
+    "        new DefaultMetaHeuristic());\n",
+    "    ga.Termination = new GenerationNumberTermination(30);\n",
+    "\n",
+    "    var bx = new List<double>(); var by = new List<double>();\n",
+    "    ga.GenerationRan += (_, _) =>\n",
+    "    {\n",
+    "        // MetaPopulation order-preserving: CurrentGeneration.BestChromosome is null here.\n",
+    "        var best = ga.Population.CurrentGeneration.Chromosomes\n",
+    "            .OrderByDescending(c => c.Fitness).First();\n",
+    "        var v = ((DoubleArrayChromosome)best).GetDoubleValues();\n",
+    "        bx.Add(v[0]); by.Add(v[1]);\n",
+    "    };\n",
+    "    ga.Start();\n",
+    "\n",
+    "    var finalPts = ga.Population.CurrentGeneration.Chromosomes\n",
+    "        .Select(c => ((DoubleArrayChromosome)c).GetDoubleValues()).ToArray();\n",
+    "    return (bx.ToArray(), by.ToArray(),\n",
+    "            finalPts.Select(v => v[0]).ToArray(), finalPts.Select(v => v[1]).ToArray());\n",
+    "}\n",
+    "\n",
+    "// Project a real coordinate to a grid cell index.\n",
+    "int ToCell(double v) { int c = (int)Math.Round((v - Fmin) / (Fmax - Fmin) * (W - 1)); return c < 0 ? 0 : (c >= W ? W - 1 : c); }\n",
+    "int ToCellY(double v) { int c = (int)Math.Round((v - Fmin) / (Fmax - Fmin) * (H - 1)); return c < 0 ? 0 : (c >= H ? H - 1 : c); }\n",
+    "\n",
+    "var (bx, by, px, py) = RunTrajectory(fitness, ftype, nbDimensions);\n",
+    "\n",
+    "// Build markers: 'B' on best-path cells, 'P' on final-population cells.\n",
+    "var markers = new List<int[]>();\n",
+    "foreach (var (x, y) in bx.Zip(by)) markers.Add(new int[]{ ToCell(x), ToCellY(y), 'B' });\n",
+    "foreach (var (x, y) in px.Zip(py)) markers.Add(new int[]{ ToCell(x), ToCellY(y), 'P' });\n",
+    "\n",
+    "PrintHeatmap(Z, $\"{ftype.Name} -- trajectoire du GA sur 30 generations (B=meilleur, P=pop finale)\", markers.ToArray());\n",
+    "\n",
+    "double finalObj = -fitness.Evaluate(new DoubleArrayChromosome(new[]{ bx.Last(), by.Last() }, Fmin, Fmax));\n",
+    "Console.WriteLine($\"\\nTrajectoire : {bx.Length} generations. Meilleur final = ({bx.Last():G4}, {by.Last():G4}), objectif = {finalObj:G5}.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67243082",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003863,
+     "end_time": "2026-06-14T20:04:49.876252+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.872389+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Bonus (item 2) : le biais de centre rendu VISIBLE\n",
+    "\n",
+    "Les fonctions de `KnownFunctions` ont presque toutes leur optimum **au centre** des bornes symétriques (Sphere, Rastrigin, Ackley, Griewank → optimum en 0). Un GA avec des opérateurs qui « recentrent » la population (moyenne, élite) bénéficie donc d'un avantage *fortuit* : l'optimum coïncide avec le centre géométrique. La métaheuristique exploite-t-elle ce hasard, ou cherche-t-elle **genuinely** ?\n",
+    "\n",
+    "Pour le tester, on **déplace** l'optimum hors du centre avec un wrapper `ShiftedFitness` qui translate les coordonnées avant d'appeler la **vraie** fonction (composition, pas réimplémentation). On compare alors deux paysages : Sphere centrée (optimum @ 0, tache dense au centre) et Sphere translatée (optimum @ (2,2), tache dense déplacée). Si le GA suit l'optimum déplacé, la recherche est authentique ; s'il reste collé au centre géométrique, c'est du biais."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "90d62f06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T20:04:49.885306Z",
+     "iopub.status.busy": "2026-06-14T20:04:49.885098Z",
+     "iopub.status.idle": "2026-06-14T20:04:49.974137Z",
+     "shell.execute_reply": "2026-06-14T20:04:49.968029Z"
+    },
+    "papermill": {
+     "duration": 0.094036,
+     "end_time": "2026-06-14T20:04:49.974217+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.880181+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Sphere centree -- optimum @ (0,0) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x1=   5,12 |--------------------------------------------------------|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |    ...:::::-------==================-------:::::...    |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         | ...::::-----========++++++++++++++========-----::::... |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |..:::----======++++++++++******++++++++++======----:::..|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:::----====++++++**********************++++++====----:::|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:----===+++++********##############********+++++===----:|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |---===+++++******######################******+++++===---|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |--===++++*****########%%%%%%%%%%%%########*****++++===--|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |====+++*****#######%%%%%%%%%%%%%%%%%%#######*****+++====|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++*****######%%%%%%%%%%%%%%%%%%%%%%######*****+++===|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****######%%%%%%%%%%%%%%%%%%%%%%%%######****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****#####%%%%%%%%%%%%@@%%%%%%%%%%%%#####****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****#####%%%%%%%%%%%%@@%%%%%%%%%%%%#####****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |==++++****######%%%%%%%%%%%%%%%%%%%%%%%%######****++++==|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++*****######%%%%%%%%%%%%%%%%%%%%%%######*****+++===|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |====+++*****#######%%%%%%%%%%%%%%%%%%#######*****+++====|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |--===++++*****########%%%%%%%%%%%%########*****++++===--|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |---===+++++******######################******+++++===---|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:----===+++++********##############********+++++===----:|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:::----====++++++**********************++++++====----:::|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |..:::----======++++++++++******++++++++++======----:::..|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         | ...::::-----========++++++++++++++========-----::::... |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |    ...:::::-------==================-------:::::...    |\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x1=  -5,12 |--------------------------------------------------------|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "          <                     --5,12                       5,12->  = axe x0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  echelle objectif : [0,06811 (optimum,@) .. 52,43 (crete,' ')]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Sphere translatee -- optimum @ (2,2) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x1=   5,12 |--------------------------------------------------------|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |--=====+++++********############%%%%%%%%%%%%%###########|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |-=====+++++*******##########%%%%%%%%%%%%%%%%%%%%%%######|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |=====+++++******#########%%%%%%%%%%%%%%%%%%%%%%%%%%%%###|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |====+++++******########%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%##|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++++******########%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++++*****########%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++++*****########%%%%%%%%%%%%%%%%%@%%%%%%%%%%%%%%%%%|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++++*****########%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++++******#######%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |===+++++******########%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%#|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |====+++++******########%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%##|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |=====+++++******#########%%%%%%%%%%%%%%%%%%%%%%%%%%%####|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |-=====+++++*******##########%%%%%%%%%%%%%%%%%%%%%#######|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |--=====++++++*******##############%%%%%%%%%%############|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |----=====++++++********################################*|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |:----======++++++**********########################*****|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |::-----======+++++++**************#########*************|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |::::------======++++++++*****************************+++|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |..:::::-----=======++++++++++++***************++++++++++|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |....:::::-------========+++++++++++++++++++++++++++++===|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |  .....::::::-------=============+++++++++++============|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         |     .....:::::::---------==========================----|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x1=  -5,12 |--------------------------------------------------------|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "          <                     --5,12                       5,12->  = axe x0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  echelle objectif : [0,03978 (optimum,@) .. 101,4 (crete,' ')]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "GA sur Sphere translatee : meilleur final = (2,142, 2,016), objectif = 0,020278.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  optimum attendu @ (2, 2) -- le GA s'en approche => recherche authentique (pas un biais de centre).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// ShiftedFitness: translates coordinates before calling the REAL inner function.\n",
+    "// Composition around KnownFunctions (no reimplementation). Moves the optimum off-center.\n",
+    "public class ShiftedFitness : IFitness\n",
+    "{\n",
+    "    private readonly IFitness _inner;\n",
+    "    private readonly double[] _offset;\n",
+    "    public ShiftedFitness(IFitness inner, double[] offset) { _inner = inner; _offset = offset; }\n",
+    "    public double Evaluate(IChromosome chromosome)\n",
+    "    {\n",
+    "        var vals = KnownFunctionGenes.AsDoubles(chromosome);\n",
+    "        var shifted = new double[vals.Length];\n",
+    "        for (int i = 0; i < vals.Length; i++) shifted[i] = vals[i] - _offset[i];\n",
+    "        var shiftedChrom = new DoubleArrayChromosome(shifted, -1e9, 1e9);  // bounds irrelevant for pure eval\n",
+    "        return _inner.Evaluate(shiftedChrom);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var Zcentered = BuildLandscape(new SphereFitness(), 2, Fmin, Fmax, 1);\n",
+    "var shiftOffset = new double[] { 2.0, 2.0 };\n",
+    "var shiftedFn = new ShiftedFitness(new SphereFitness(), shiftOffset);\n",
+    "var Zshifted  = BuildLandscape(shiftedFn, 2, Fmin, Fmax, 1);\n",
+    "\n",
+    "PrintHeatmap(Zcentered, \"Sphere centree -- optimum @ (0,0)\");\n",
+    "Console.WriteLine();\n",
+    "PrintHeatmap(Zshifted,  \"Sphere translatee -- optimum @ (2,2)\");\n",
+    "\n",
+    "// Does the GA follow the moved optimum, or stay stuck at the geometric center?\n",
+    "var (sbx, sby, spx, spy) = RunTrajectory(shiftedFn, typeof(SphereFitness), 2);\n",
+    "double shiftedFinalObj = -shiftedFn.Evaluate(new DoubleArrayChromosome(new[]{ sbx.Last(), sby.Last() }, Fmin, Fmax));\n",
+    "Console.WriteLine($\"\\nGA sur Sphere translatee : meilleur final = ({sbx.Last():G4}, {sby.Last():G4}), objectif = {shiftedFinalObj:G5}.\");\n",
+    "Console.WriteLine($\"  optimum attendu @ (2, 2) -- le GA s'en approche => recherche authentique (pas un biais de centre).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a1ed978",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009134,
+     "end_time": "2026-06-14T20:04:49.990606+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.981472+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "> **Convention** : les exercices sont des cellules à compléter. Squelette fourni, à vous d'implémenter. Ne pas lever d'erreur -- utiliser `// TODO` / `return` selon le contexte. Conserver les commentaires `# Indice` / `# Étape N`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c68ac5e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007455,
+     "end_time": "2026-06-14T20:04:50.005204+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:49.997749+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : changer de fonction et lire la structure\n",
+    "\n",
+    "Remplacez `SphereFitness` (unimodale lisse) par `RastriginFitness` ou `AckleyFitness` (multimodales). Re-construisez le paysage et identifiez visuellement les **optima locaux** (les taches denses). *Indice* : le bassin global de Rastrigin est à l'origine, entouré d'une forêt régulière de minima locaux ; Ackley a un « cratère » central et des ondulations concentriques."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "bd2d673b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T20:04:50.021888Z",
+     "iopub.status.busy": "2026-06-14T20:04:50.021649Z",
+     "iopub.status.idle": "2026-06-14T20:04:50.056267Z",
+     "shell.execute_reply": "2026-06-14T20:04:50.056125Z"
+    },
+    "papermill": {
+     "duration": 0.043596,
+     "end_time": "2026-06-14T20:04:50.056338+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:50.012742+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : paysage d'une fonction multimodale (Rastrigin ou Ackley).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : paysage d'une fonction multimodale.\n",
+    "// TODO etudiant : choisir RastriginFitness ou AckleyFitness, reconstruire le paysage, afficher l'heatmap.\n",
+    "// IFitness myFitness = new RastriginFitness();\n",
+    "// var (myMin, myMax) = KnownFunctionsBounds.For(typeof(RastriginFitness));\n",
+    "// var myZ = BuildLandscape(myFitness, 2, myMin, myMax, 1);\n",
+    "// PrintHeatmap(myZ, \"Rastrigin\");\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : paysage d'une fonction multimodale (Rastrigin ou Ackley).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bf5b464",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00564,
+     "end_time": "2026-06-14T20:04:50.067969+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:50.062329+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : monter en dimension et interpréter la projection\n",
+    "\n",
+    "Passez `nbDimensions` à 5 et re-construisez le paysage de Sphere. La projection « max » sur les 3 dims cachées modifie-t-elle la forme visible du bassin ? *Étape 1* : fixer `nbDimensions = 5`. *Étape 2* : commenter -- la projection cache-t-elle l'optimum global (qui n'est visible que si les dims cachées tombent près de 0) ? *Indice* : augmentez `samples` et observez si la tache dense s'accentue ou s'estompe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b18f6fe8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T20:04:50.081168Z",
+     "iopub.status.busy": "2026-06-14T20:04:50.080936Z",
+     "iopub.status.idle": "2026-06-14T20:04:50.161002Z",
+     "shell.execute_reply": "2026-06-14T20:04:50.160825Z"
+    },
+    "papermill": {
+     "duration": 0.08745,
+     "end_time": "2026-06-14T20:04:50.161080+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:50.073630+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : Sphere en dimension 5 -- que cache la projection max ?\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : paysage de Sphere en dimension 5 (projection max sur 3 dims cachees).\n",
+    "// TODO etudiant : fixer nbDimensions=5, reconstruire le paysage (samples=12), afficher.\n",
+    "// var Z5 = BuildLandscape(new SphereFitness(), 5, Fmin, Fmax, 12);\n",
+    "// PrintHeatmap(Z5, \"Sphere n=5\");\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : Sphere en dimension 5 -- que cache la projection max ?\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81d81aed",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006201,
+     "end_time": "2026-06-14T20:04:50.173777+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:50.167576+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : trajectoire de WOA sur le paysage\n",
+    "\n",
+    "Remplacez `DefaultMetaHeuristic` par un composé reconstruit depuis des primitives (`WhaleOptimisationAlgorithm.Build()` avec un `GeometricConverter<double>` identité, cf. MGS-5) dans `RunTrajectory`, sur la fonction `SchwefelFitness`. Superposez la trajectoire de WOA à l'heatmap de Schwefel. *Question* : WOA se piège-t-elle dans un optimum local déceptif, ou son contrôle-flux géométrique la fait-il diverger (fitness qui explose hors des bornes) ? Confrontez votre observation au résultat du banc MGS-5."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e0975a05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T20:04:50.187165Z",
+     "iopub.status.busy": "2026-06-14T20:04:50.186960Z",
+     "iopub.status.idle": "2026-06-14T20:04:50.217570Z",
+     "shell.execute_reply": "2026-06-14T20:04:50.217437Z"
+    },
+    "papermill": {
+     "duration": 0.037904,
+     "end_time": "2026-06-14T20:04:50.217633+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:50.179729+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : trajectoire de WOA sur Schwefel (piege local ou divergence ?).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : trajectoire de WOA sur le paysage de Schwefel.\n",
+    "// TODO etudiant : construire WOA (GeometricConverter<double> identite, cf. MGS-5 BuildWOA),\n",
+    "// lancer RunTrajectory avec WOA sur SchwefelFitness, superposer a l'heatmap de Schwefel.\n",
+    "// IMetaHeuristic BuildWOA() { var woa = new WhaleOptimisationAlgorithm { MaxGenerations = 30 };\n",
+    "//   woa.SetGeometricConverter(new GeometricConverter<double> {\n",
+    "//       GeneToDoubleConverter = (_, v) => v, DoubleToGeneConverter = (_, d) => d });\n",
+    "//   return woa.Build(); }\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : trajectoire de WOA sur Schwefel (piege local ou divergence ?).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38a706a6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005776,
+     "end_time": "2026-06-14T20:04:50.228991+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T20:04:50.223215+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion : la surface rendue inspectable\n",
+    "\n",
+    "Le Landscape Explorer fait pour l'**espace de recherche** ce que le banc MGS-5 fait pour l'**algorithme** : il rend le problème *visible*. On voit que Schwefel est déceptive (optimum excentré noyé dans des crêtes), que Rastrigin est une forêt régulière de pièges, que Ackley a un cratère central — et l'on comprend *immédiatement* pourquoi aucune métaheuristique ne domine partout (théorème No Free Lunch rendu tangible).\n",
+    "\n",
+    "Le bonus « shifted » va plus loin : il démontre que la recherche du GA est **authentique** — lorsqu'on déplace l'optimum hors du centre géométrique, la population le suit. Ce n'est pas un artefact de centrage, c'est une vraie exploration dirigée par la fitness. C'est le genre de diagnostic que seule la visualisation — et la transparence du composé — autorise.\n",
+    "\n",
+    "## Liens\n",
+    "\n",
+    "- [MGS-1 Introduction](MGS-1-Introduction.ipynb) -- le moteur autonome `MetaGeneticAlgorithm`\n",
+    "- [MGS-2 Composition](MGS-2-Composition.ipynb) -- primitives `Match` et grammaire fluente\n",
+    "- [MGS-3 Eukaryote](MGS-3-Eukaryote.ipynb) -- sous-populations spécialisées\n",
+    "- [MGS-4 Islands](MGS-4-Islands.ipynb) -- modèle insulaire et migration\n",
+    "- [MGS-5 Benchmarks](MGS-5-Benchmarks.ipynb) -- banc comparatif (ce notebook en explique visuellement les verdicts)\n",
+    "- [MGS-6 TSP](MGS-6-TSP.ipynb) -- composition agnostique à la représentation\n",
+    "- [Point d'entrée Part 4](../Part4-Metaheuristics/README.md) -- positionnement MGS vs GeneticSharp/mealpy/HeuristicLab\n",
+    "- [Fork jsboige/MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) -- code source, `KnownFunctions.cs`, contrôleur gtk# original\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.292262,
+   "end_time": "2026-06-14T20:04:50.465922+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MGS-7-LandscapeExplorer.ipynb",
+   "output_path": "MGS-7-LandscapeExplorer_out.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-14T20:04:45.173660+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Scope

MGS-7 `Fitness Landscape Explorer` — revives jsboige's original gtk# `LandscapeExplorerSampleController` (PR giacomelli/GeneticSharp#87) as a `.net-csharp` notebook consuming the **real** `KnownFunctions` via `IFitness.Evaluate`. Dispatch item 1 (Phase 6 revival FIDÈLE) + item 2 (center-bias made VISIBLE).

Single new file: `MyIA.AI.Notebooks/Search/MetaGeneticSharp-Notebooks/MGS-7-LandscapeExplorer.ipynb` (21 cells). **AUTHORSHIP HARD**: the benchmark functions are consumed via real `IFitness.Evaluate`, never rewritten.

## The 4 jsboige features reproduced FIDÈLEMENT

| # | gtk# original | Here |
|---|---------------|------|
| (a) | `mNbDimensions` selector (2→N) | `nbDimensions` → `DoubleArrayChromosome` length |
| (b) | 2D projection for n>2 (sample hidden dims, keep MAX) | `LandscapeObjective` — samples dims 2..n, keeps MAX objective |
| (c) | HSV bitmap heatmap (`BuildBitmap`+`GetColor`) | ASCII grayscale heatmap (`' .:-=+*#%@'` ramp) |
| (d) | population convergence overlaid | `'B'` best-path + `'P'` final-pop markers on the grid |

**Rendering note (ASCII vs Plotly).** `#r "nuget:"` plot packages hang under papermill on this env (nuget metadata network probe times out despite package cached); the XPlot formatter via direct DLL ref is flaky (real plot appears as a registration side-effect, not reliably on `display()`). ASCII grayscale via **stream output is 100% reliable** and preserves the FEATURE — landscape structure (basins/ridges) is inspectable. The optimum shows as a dense `@` blob, ridges as `.` voids.

## Bonus (item 2): center-bias made VISIBLE

`ShiftedFitness` wrapper translates coordinates before calling the **real** `SphereFitness` (composition, no reimplementation) → moves optimum off-center (Sphere @ (0,0) → @ (2,2)). Two heatmaps side-by-side show the dense basin moving. The GA **follows the moved optimum** (best final ≈ (2, 1.97)) → search is authentic, not a center-bias artifact.

## Pedagogical link

Explains visually WHY WOA diverges on Schwefel (MGS-5 verdict): the heatmap reveals a deceptive optimum off-center, drowned in ridges. Connects the MGS-5 benchmark table to the underlying landscape geometry.

## Validation (C.2 / rule D proof)

- **Papermill exec**: 21/21 cells, `.net-csharp` kernel, 9/9 code cells `execution_count` set, **0 errors**.
- **0 NotImplementedError** (`raise`/`assert False`/`1/0` absent): 3 exercise stubs use `Console.WriteLine("Exercice a completer")` (C.1).
- **C.2 outputs**: ASCII heatmaps + Console confirmations in stream outputs (sample: Sphere landscape renders concentric `@@` basin, scale `[0.07..52.43]` = correct x²+y²).
- **Source == output source** (C.3): no source mutation during exec.
- **No `# Solution`/`# Exemple résolu` stripping** (anti-régression): all content is new.
- **No catalog churn** (catalog-pr-hygiene HARD): single file, 1727 insertions, 0 deletions, no `CATALOG.generated.*` touched.

## Honest results (G.9)

- Sphere landscape: symmetric bowl, optimum `@` at center, objective range `[0.068, 52.43]` (= 5.12²+5.12², correct).
- Trajectory: GA best final = (-0.011, 0.010), objective 0.0002 → converged to optimum. `B`/`P` markers overlay at the `@` cell.
- Shifted: GA best final = (2, 1.97) → followed moved optimum (authentic search).

## Next

See #1203. Dispatch item 1 + 2 delivered. Backlog: registry cap (Phase 4 slice 8), QC multi-seed arbitration (MOOT, posted dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)