### PR TITLE
feat(genai): wake-on-demand helper for idle-stopped services (#2982)

### DIFF
--- a/docker-configurations/services/shared/service_wake.py
+++ b/docker-configurations/services/shared/service_wake.py
@@ -1,0 +1,181 @@
+"""service_wake.py — Réveille à la demande les services GenAI idle-stoppés.
+
+Contrepartie de `service_idle_monitor.py` : le monitor auto-STOPPE les services
+après `idle_timeout` (20 min) pour libérer la VRAM GPU ; ce module auto-START le
+service à la demande afin qu'un notebook/script obtienne un warm-up transparent
+au lieu d'un HTTP 502 / connection-refused.
+
+## Pourquoi wake-and-retry côté appelant (décision #2982)
+
+Aucun des 16 services ne configure `idle_action=sleep` (grep vérifié 2026-06-14) :
+ils font tous `docker stop`. Un container stoppé n'a AUCUN listener sur son port,
+donc le wake-on-request DOIT originates de l'appelant (ou d'un proxy persistant).
+
+- Un helper côté appelant est **low-blast** (additif, ne modifie pas le monitor
+  en cours d'exécution) et fonctionne uniformément pour les 16 services.
+- Un reverse-proxy (approche A de l'issue) serait **over-engineering** pour une
+  stack dev/teaching : il faudrait un process persistant par service + de la
+  config de routing.
+- **Économie VRAM préservée** : les services s'auto-stoppent toujours après
+  20 min d'inactivité ; le helper ne lance `docker start` qu'en cas de demande
+  réelle.
+
+## Usage (Python)
+
+    from service_wake import ensure_service_up
+    if ensure_service_up("musicgen-api", "http://localhost:8192/health"):
+        # sûr pour POST http://localhost:8192/v1/generate
+        ...
+
+## Usage (CLI)
+
+    python service_wake.py musicgen-api --health-url http://localhost:8192/health
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import sys
+import time
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger("service_wake")
+
+# Marges calibrées sur po-2023 : musicgen lazy-load ~18s, modèles lourds jusqu'à ~2min.
+DEFAULT_TIMEOUT = 180
+DEFAULT_POLL_INTERVAL = 2
+_HEALTH_PROBE_TIMEOUT = 5
+
+
+def probe_health(
+    health_url: str, api_key: Optional[str] = None, timeout: float = _HEALTH_PROBE_TIMEOUT
+) -> bool:
+    """GET health_url ; True si HTTP 200 (service UP et prêt)."""
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    try:
+        resp = requests.get(health_url, headers=headers, timeout=timeout)
+        return resp.status_code == 200
+    except requests.exceptions.RequestException:
+        return False
+
+
+def docker_start(container: str) -> bool:
+    """`docker start <container>` ; True si la commande réussit (exit 0).
+
+    Via subprocess (docker CLI universelle sur po-2023). Ne présume pas de l'état
+    précédent : `docker start` est idempotente (noop si déjà démarré).
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "start", container],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.error(
+                "docker start %s failed (exit %s): %s",
+                container,
+                result.returncode,
+                result.stderr.strip(),
+            )
+            return False
+        return True
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:
+        logger.error("docker start %s error: %s", container, exc)
+        return False
+
+
+def ensure_service_up(
+    container: str,
+    health_url: str,
+    api_key: Optional[str] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    poll_interval: int = DEFAULT_POLL_INTERVAL,
+) -> bool:
+    """S'assure que le service est UP et healthy ; le (re)démarre si besoin.
+
+    Étapes :
+      1. Fast-path : si `/health` répond 200, retour immédiat (service déjà actif).
+      2. Sinon : `docker start <container>` puis poll de `/health` jusqu'à 200
+         ou `timeout` écoulé.
+      3. Retourne True si healthy dans le délai, False sinon (l'appelant gère
+         l'erreur — pas d'exception pour laisser place à un fallback métier).
+
+    Préserve l'économie VRAM : le monitor re-stoppera le service après
+    `idle_timeout` s'il reste inactif.
+    """
+    if probe_health(health_url, api_key):
+        logger.info("Service %s already healthy (fast-path)", container)
+        return True
+
+    logger.info("Service %s down/idle — issuing docker start", container)
+    if not docker_start(container):
+        return False
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if probe_health(health_url, api_key):
+            logger.info("Service %s healthy after warm-up", container)
+            return True
+        time.sleep(poll_interval)
+
+    logger.error(
+        "Service %s not healthy within %ss after docker start", container, timeout
+    )
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Réveille un service GenAI idle-stoppé à la demande (#2982)."
+    )
+    parser.add_argument("container", help="Nom du container Docker (ex: musicgen-api)")
+    parser.add_argument(
+        "--health-url",
+        required=True,
+        help="URL de health (ex: http://localhost:8192/health)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="Clé API (Bearer) si le service a l'auth active (lus depuis .env sinon)",
+    )
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--poll-interval", type=int, default=DEFAULT_POLL_INTERVAL)
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Logs détaillés (INFO+)"
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    ok = ensure_service_up(
+        args.container,
+        args.health_url,
+        api_key=args.api_key,
+        timeout=args.timeout,
+        poll_interval=args.poll_interval,
+    )
+    if ok:
+        print(f"OK: {args.container} is up at {args.health_url}")
+        return 0
+    # La cause précise (docker start failed vs warm-up timeout) est dans les logs.
+    print(
+        f"FAIL: {args.container} could not be brought up "
+        f"(see logs above for docker start error or warm-up timeout of {args.timeout}s)",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker-configurations/services/shared/test_service_wake.py
+++ b/docker-configurations/services/shared/test_service_wake.py
@@ -1,0 +1,160 @@
+"""Tests unitaires pour service_wake.py (#2982).
+
+Déterministes : mockent `subprocess.run` et `requests.get` (pas de docker réel,
+pas de réseau). Conformité H.1 — validation logique pure.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+import service_wake
+
+
+# --- probe_health -----------------------------------------------------------
+
+
+def test_probe_health_ok():
+    resp = MagicMock(status_code=200)
+    with patch("service_wake.requests.get", return_value=resp):
+        assert service_wake.probe_health("http://localhost:8192/health") is True
+
+
+def test_probe_health_non_200():
+    resp = MagicMock(status_code=503)
+    with patch("service_wake.requests.get", return_value=resp):
+        assert service_wake.probe_health("http://localhost:8192/health") is False
+
+
+def test_probe_health_connection_refused():
+    with patch(
+        "service_wake.requests.get",
+        side_effect=requests.exceptions.ConnectionError("refused"),
+    ):
+        assert service_wake.probe_health("http://localhost:8192/health") is False
+
+
+def test_probe_health_sends_bearer_when_api_key():
+    resp = MagicMock(status_code=200)
+    with patch("service_wake.requests.get", return_value=resp) as mock_get:
+        service_wake.probe_health("http://h/health", api_key="secret")
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer secret"
+
+
+# --- docker_start -----------------------------------------------------------
+
+
+def test_docker_start_success():
+    result = MagicMock(returncode=0, stderr="")
+    with patch("service_wake.subprocess.run", return_value=result):
+        assert service_wake.docker_start("musicgen-api") is True
+
+
+def test_docker_start_nonzero_exit():
+    result = MagicMock(returncode=1, stderr="No such container")
+    with patch("service_wake.subprocess.run", return_value=result):
+        assert service_wake.docker_start("ghost") is False
+
+
+def test_docker_start_invokes_correct_args():
+    result = MagicMock(returncode=0)
+    with patch("service_wake.subprocess.run", return_value=result) as mock_run:
+        service_wake.docker_start("musicgen-api")
+        assert mock_run.call_args.args[0] == ["docker", "start", "musicgen-api"]
+
+
+def test_docker_start_handles_subprocess_error():
+    with patch(
+        "service_wake.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
+    ):
+        assert service_wake.docker_start("musicgen-api") is False
+
+
+# --- ensure_service_up ------------------------------------------------------
+
+
+def test_ensure_service_up_fast_path_no_docker_start():
+    """Service déjà healthy → on n'appelle jamais docker start."""
+    resp = MagicMock(status_code=200)
+    with patch("service_wake.requests.get", return_value=resp), patch(
+        "service_wake.docker_start"
+    ) as mock_start:
+        assert service_wake.ensure_service_up("svc", "http://h/health") is True
+        mock_start.assert_not_called()
+
+
+def test_ensure_service_up_cold_start_succeeds():
+    """Service down → docker start → poll devient 200 → True."""
+    # 1er probe (fast-path) = connection refused, puis probes post-start = 200.
+    probe_sequence = [
+        False,  # fast-path: down
+        False,  # 1er poll après start (warm-up pas fini)
+        True,  # 2e poll: healthy
+    ]
+
+    def fake_probe(url, api_key=None, timeout=5):
+        return probe_sequence.pop(0)
+
+    with patch("service_wake.probe_health", side_effect=fake_probe), patch(
+        "service_wake.docker_start", return_value=True
+    ) as mock_start, patch("service_wake.time.sleep"):
+        assert service_wake.ensure_service_up("svc", "http://h/health") is True
+        mock_start.assert_called_once_with("svc")
+
+
+def test_ensure_service_up_docker_start_fails():
+    """docker start échoue → False immédiat (pas de poll)."""
+    with patch("service_wake.probe_health", return_value=False), patch(
+        "service_wake.docker_start", return_value=False
+    ):
+        assert service_wake.ensure_service_up("svc", "http://h/health") is False
+
+
+def test_ensure_service_up_times_out():
+    """Service jamais healthy après start → False après timeout."""
+
+    # Fast-path down, puis tous les polls down.
+    def fake_probe(url, api_key=None, timeout=5):
+        return False
+
+    # Force le timeout en simulant le temps qui s'écoule.
+    clock = [0.0]
+
+    def fake_monotonic():
+        return clock[0]
+
+    def fake_sleep(seconds):
+        clock[0] += seconds
+
+    with patch("service_wake.probe_health", side_effect=fake_probe), patch(
+        "service_wake.docker_start", return_value=True
+    ), patch("service_wake.time.monotonic", side_effect=fake_monotonic), patch(
+        "service_wake.time.sleep", side_effect=fake_sleep
+    ):
+        result = service_wake.ensure_service_up(
+            "svc", "http://h/health", timeout=10, poll_interval=2
+        )
+        assert result is False
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_returns_0_when_healthy():
+    with patch("service_wake.ensure_service_up", return_value=True), patch(
+        "sys.argv", ["service_wake.py", "svc", "--health-url", "http://h/health"]
+    ):
+        assert service_wake.main() == 0
+
+
+def test_cli_returns_1_when_not_healthy():
+    with patch("service_wake.ensure_service_up", return_value=False), patch(
+        "sys.argv", ["service_wake.py", "svc", "--health-url", "http://h/health"]
+    ):
+        assert service_wake.main() == 1


### PR DESCRIPTION
## What

Wake-on-demand helper for idle-stopped GenAI services — closes the gap identified in #2982.

`docker-configurations/services/shared/service_idle_monitor.py` auto-**STOPs** services after 20 min idle to free GPU VRAM (valuable, kept). But it has no auto-**START**: a notebook hitting a stopped service gets HTTP 502 / connection-refused until a manual `docker start` + warm-up.

This PR adds the demand-side counterpart: **`service_wake.py`**.

## Decision on approach (criterion #3 of #2982)

Chose **client-side wake-and-retry** over the 4 options in the issue:

| Approach | Verdict |
|----------|---------|
| A. Reverse-proxy wake-on-request | **Rejected** — over-engineering for a dev/teaching stack (persistent process + routing config per service) |
| B. `idle_timeout` tuning | **Rejected** — reduces 502 frequency, doesn't eliminate it; consumes VRAM longer |
| C. Always-on | **Rejected** — defeats VRAM economy; OOM risk on shared GPU (Higgs GPU1-exclusive) |
| **D. Wake helper (this PR)** | **Chosen** — low-blast, additive, uniform across all 16 services |

**Key finding (grep-verified)**: none of the 16 services configure `idle_action=sleep` — they all do `docker stop`. A stopped container has **no listener** on its port, so wake-on-request *must* originate from the caller (or a persistent proxy). A caller-side helper is the minimal, uniform fix; it works for every stopped service without per-service `/wake_up` routes.

**VRAM economy preserved**: services still auto-stop after 20 min idle. The helper only `docker start`s on actual demand.

## Usage

```python
from service_wake import ensure_service_up
if ensure_service_up("musicgen-api", "http://localhost:8192/health"):
    # safe to POST http://localhost:8192/v1/generate
    ...
```

```bash
python service_wake.py musicgen-api --health-url http://localhost:8192/health -v
# OK: musicgen-api is up at http://localhost:8192/health  (exit 0)
```

## Logic

`ensure_service_up(container, health_url, api_key=None, timeout=180)`:
1. **Fast-path**: `GET /health` → 200 means already active → return immediately (no docker call).
2. **Cold path**: `docker start <container>` (idempotent), then poll `/health` every 2s until 200 or `timeout`.
3. Returns `True` if healthy in time, `False` otherwise (caller decides fallback — no exception).

## Validation (H.1)

**14 unit tests** (`test_service_wake.py`, deterministic — mocked `subprocess.run` + `requests.get`):
- `probe_health`: 200 / non-200 / connection-refused / Bearer header wiring
- `docker_start`: success / non-zero exit / correct args / subprocess error
- `ensure_service_up`: fast-path (no docker start) / cold-start success / docker-start-fail / timeout
- CLI: exit 0 on healthy, exit 1 on not

```
14 passed in 0.27s
```

**Real smoke tests** on po-2023:
- Fast-path vs live `tts-api` (:8191) → `exit 0` (health probe works against a real service).
- Failure-path vs dead port :9999 + non-existent container → `exit 1` with `docker start ... No such container` logged.

## Scope

- 2 new files, +341 lines, **0 deletions** (additive — anti-régression safe).
- No change to the running `service_idle_monitor.py` or any service image.
- Catalogue byte-identical to `origin/main`; markdown/n/a.
- Security perimeter (#16) unchanged — idle services already have auth active (401, verified on musicgen/demucs this cycle). This is an availability fix, not an auth change.

See #2982
