### PR TITLE
feat(sudoku-13): rewrite as honest regex-symbolic Sudoku (Conway -> BREX/Rex -> RE#)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -2,451 +2,374 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "79bdddc3",
+   "id": "b67d95b0",
    "metadata": {
     "papermill": {
-     "duration": 0.002795,
-     "end_time": "2026-05-12T08:29:58.158411+00:00",
+     "duration": 0.003448,
+     "end_time": "2026-06-14T21:32:48.310478+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:29:58.155616+00:00",
+     "start_time": "2026-06-14T21:32:48.307030+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "---\n",
+    "**Navigation** : [<< Sudoku-12 Z3 C#](Sudoku-12-Z3-Csharp.ipynb) | [Index](README.md) | [Sudoku-14 Retour d'experience >>](Sudoku-14-...)\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Sudoku-12 Python](Sudoku-12-Z3-Python.ipynb) | [Sudoku-14 C# >>](Sudoku-14-BDD-Csharp.ipynb)\n",
+    "---\n",
     "\n",
+    "# Sudoku-13 : Le Sudoku comme Regex Symbolique - l'echelle Conway -> BREX/Rex -> RE#\n",
     "\n",
-    "# Sudoku-12 : Theorie des Automates Symboliques et Compilation vers SMT\n",
+    "> **Ce notebook reprend et corrige une tentative personnelle de 2020** : representer un Sudoku comme un *grand regex symbolique* ou les contraintes de lignes, colonnes et blocs se combinent par **intersection** (`Ligne & Colonne & Bloc`), compilees vers un probleme Z3 qui en extrait une grille-temoin.\n",
+    ">\n",
+    "> La tentative de 2020 a bute sur deux murs reels. En 2025, l'engine RE# fait tomber l'un des deux. L'autre reste irremplacablement du cote de Z3.\n",
     "\n",
-    "Dans ce notebook, nous explorons la theorie des **automates symboliques** et comment elle peut se **compiler** vers un solveur SMT comme Z3. Nous verrons les concepts de predicats symboliques, d'operations d'automates, et les appliquerons a la resolution de Sudoku.\n",
+    "## La these en une phrase\n",
     "\n",
-    "## Qu'est-ce qu'un Automate Symbolique?\n",
-    "\n",
-    "Un **automate symbolique** est une generalisation des automates finis ou les transitions ne sont pas sur des caracteres concrets mais sur des **predicats logiques**.\n",
-    "\n",
-    "| Type de transition | Automate classique | Automate symbolique |\n",
-    "|--------------------|-------------------|---------------------|\n",
-    "| **Etiquette** | Caractere concret : 'a', 'b', '1' | Predicat : x >= 1 AND x <= 9 |\n",
-    "| **Alphabet** | Fini et explicite | Infini ou implicite |\n",
-    "| **Exemple** | DFA avec 91 etats pour [10,100] | 1 transition avec predicat |\n",
-    "\n",
-    "## Objectifs d'apprentissage\n",
-    "\n",
-    "A la fin de ce notebook, vous saurez :\n",
-    "\n",
-    "1. **Comprendre** la theorie des automates symboliques (Symbolic Finite Automata - SFA)\n",
-    "2. **Implementer** des predicats symboliques avec CharSet en C#\n",
-    "3. **Decouvrir** les operations d'automates (union, intersection, complement, produit)\n",
-    "4. **Comprendre** la compilation de contraintes d'automates vers un solveur SMT\n",
-    "5. **Apprecier** les limites de l'approche pure \"automates\" pour Sudoku\n",
-    "\n",
-    "### Prerequis\n",
-    "\n",
-    "- [Sudoku-0-Environment](Sudoku-0-Environment-Csharp.ipynb) - Classes de base Sudoku\n",
-    "- [Sudoku-4-Z3](Sudoku-12-Z3-Csharp.ipynb) - Bases de Z3 SMT (recommande)\n",
-    "- Connaissance de base de la theorie des automates (DFA/NFA)\n",
-    "\n",
-    "### Duree estimee : 1h30\n",
-    "\n",
-    "## References\n",
-    "\n",
-    "- **Marcus Veanes** - Principal researcher chez Microsoft, pionnier des automates symboliques\n",
-    "- [Automata.Net Repository](https://github.com/AutomataDotNet/Automata) - Bibliotheque C# pour automates symboliques\n",
-    "- [Search-12-SymbolicAutomata](../Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) - Theorie approfondie\n",
-    "\n",
-    "## Note sur l'approche\n",
-    "\n",
-    "> **⚠️ Important** : Ce notebook presente la theorie des automates symboliques et montre comment les concepts (predicats, intersection, produit) se compilent naturellement vers des contraintes SMT. Pour une implementation \"pure\" automates avec BDD/MDD, voir [Sudoku-13](Sudoku-14-BDD-Csharp.ipynb).\n"
+    "Un Sudoku se laisse decrire comme une **intersection de contraintes regulieres**. Mais *decrire* (reconnaitre une grille valide) et *produire* (resoudre le puzzle) sont **deux metiers differents**, portees par **deux outils differents**. Le Sudoku le donne a voir de maniere concrete."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ea51678b",
+   "id": "f028622e",
    "metadata": {
     "papermill": {
-     "duration": 0.002114,
-     "end_time": "2026-05-12T08:29:58.162938+00:00",
+     "duration": 0.002455,
+     "end_time": "2026-06-14T21:32:48.316046+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:29:58.160824+00:00",
+     "start_time": "2026-06-14T21:32:48.313591+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "## 1. Introduction : un Sudoku comme grand regex ?\n",
     "\n",
-    "## 1. Introduction - Automates Finis vs Symboliques (15 min)\n",
+    "En 2020, l'auteur entreprenait de representer un Sudoku non pas comme un monstre PCRE a backtracking (le folklore de Damian Conway, barreau 1 ci-dessous), mais comme une **chaine declarative tractable** ou :\n",
     "\n",
-    "### 1.1 Rappel : Automate Fini Deterministe (DFA)\n",
+    "- chaque contrainte (ligne, colonne, bloc) est un *regex symbolique* ;\n",
+    "- les contraintes se combinent par **intersection** (`&`) et **complement** (`~`) ;\n",
+    "- l'intersection compile vers un automate, puis vers un probleme SMT ;\n",
+    "- un solveur SMT (Z3) en extrait un **modele = la grille solution** (un *temoin*).\n",
     "\n",
-    "Un **DFA** est un 5-tuple $(Q, \\Sigma, \\delta, q_0, F)$ ou :\n",
+    "Ce notebook raconte **honnetement** cette histoire, avec ses deux murs et la demarche moderne (RE#) qui en repare un seul.\n",
     "\n",
-    "- $Q$ : ensemble fini d'etats\n",
-    "- $\\Sigma$ : alphabet fini (symboles d'entree)\n",
-    "- $\\delta : Q \\times \\Sigma \\to Q$ : fonction de transition\n",
-    "- $q_0 \\in Q$ : etat initial\n",
-    "- $F \\subseteq Q$ : etats finaux (acceptants)\n",
+    "### Reconnaître != resoudre\n",
     "\n",
-    "**Exemple** : DFA qui accepte les entiers pairs entre 10 et 100\n",
+    "La distinction centrale de cette serie, rendue vivante par le Sudoku :\n",
     "\n",
-    "```\n",
-    "Avec alphabet fini {10, 11, 12, ..., 100} :\n",
-    "- 91 etats pour representer chaque valeur paire\n",
-    "- 91 transitions (une par valeur acceptee)\n",
-    "```\n",
+    "| | **RESOUDRE** (produire la grille = temoin) | **VERIFIER** (valider une grille remplie) |\n",
+    "|---|---|---|\n",
+    "| **1. Conway (PCRE backtracking)** | pas de resolution propre | monstrueux, illisible |\n",
+    "| **2. 2020 - BREX/Rex+Z3** | **le vrai resolveur**, mais mure (cap 21 char) | intersection DFA, mais **explose** |\n",
+    "| **3. 2025 - RE#** | **ne genere aucun temoin** (recognition-only) | **temps lineaire** - fin de l'explosion DFA |\n",
     "\n",
-    "### 1.2 Automate Symbolique (SFA)\n",
-    "\n",
-    "Un **SFA** remplace l'alphabet fini par des predicats :\n",
-    "\n",
-    "- $\\Phi$ : ensemble de predicats logiques sur un alphabet potentiellement infini\n",
-    "- $\\delta : Q \\times \\Phi \\to Q$ : transitions symboliques\n",
-    "\n",
-    "**Meme exemple** : SFA pour entiers pairs entre 10 et 100\n",
-    "\n",
-    "```\n",
-    "Alphabet : tous les entiers (infini)\n",
-    "- 2 etats (initial, final)\n",
-    "- 1 transition avec predicat : x >= 10 AND x <= 100 AND x % 2 == 0\n",
-    "```\n",
-    "\n",
-    "### 1.3 Metaphore vs Implementation\n",
-    "\n",
-    "> **⚠️ Hônneteté intellectuelle** : Il existe un \"fossé\" entre la theorie des automates symboliques et leur implementation pratique pour des problemes comme Sudoku.\n",
-    "\n",
-    "| Aspect | Theorie automata | Implementation pratique (Z3) |\n",
-    "|--------|-----------------|------------------------------|\n",
-    "| **Modelisation** | Etats + transitions symboliques | Variables + contraintes SMT |\n",
-    "| **Produit d'automates** | Construction explicite $A \\times B$ | Conjonction de contraintes |\n",
-    "| **Acceptation** | Parcours d'automate | SAT solving |\n",
-    "| **Avantage** | Theorie bien etablie | Performance optimale |\n",
-    "\n",
-    "**Ce que nous ferons dans ce notebook** :\n",
-    "1. Sections 2-3 : Vrais automates symboliques avec CharSet (theorie pure)\n",
-    "2. Sections 4-5 : Compilation vers Z3 (pragmatisme)\n",
-    "3. Section 6 : Discussion sur quand utiliser chaque approche\n",
-    "\n",
-    "Cette dualite theorie/pratique est exactement ce que fait la bibliotheque **Automata.Net** : elle fournit des operations d'automates de haut niveau qui sont compilees vers des solveurs (BDD, Z3) pour l'execution.\n"
+    "Les deux murs de 2020 tombent a **deux outils differents** : le mur *resolution* tombe a Z3 (barreau 2 reconstruit), le mur *reconnaissance* tombe a RE# (barreau 3). RE# ne couronne pas l'echelle : il en reparle seulement la moitie *verification*."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4e9899e0",
+   "id": "26eb0bfa",
    "metadata": {
     "papermill": {
-     "duration": 0.002169,
-     "end_time": "2026-05-12T08:29:58.167627+00:00",
+     "duration": 0.002357,
+     "end_time": "2026-06-14T21:32:48.320800+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:29:58.165458+00:00",
+     "start_time": "2026-06-14T21:32:48.318443+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "## 2. Barreau 1 - Damian Conway et le monstre PCRE\n",
     "\n",
-    "## 2. Predicats Symboliques - CharSet (20 min)\n",
+    "[Damian Conway](https://www.perlmonks.org/?node_id=596304) a publie en 2005 un solveur de Sudoku entierement ecrit comme une **expression reguliere PCRE**. L'idee : le backtracking du moteur regex Perl *est* un moteur de recherche. La grille est un unique match potentiel.\n",
     "\n",
-    "Pour construire des automates symboliques, nous avons besoin de represente des **predicats** sur des ensembles de caracteres. Commencons par implementer une classe `CharSet` qui represente des predicats sur des caracteres.\n",
+    "Le prix de ce tour de force : le pattern est un **monstre** ou la contrainte d'unicite de chaque ligne/colonne/bloc est encodee par des *lookaheads gigantesques* (`(?=...)`), un pour chaque cellule. Le resultat est illisible, inversement pedagogique, et ne se generalise pas. C'est du folklore de concours, pas une methode.\n",
     "\n",
-    "### 2.1 Classe CharSet - Predicats sur les Caracteres\n",
-    "\n",
-    "La classe `CharSet` permet de representer :\n",
-    "- Un caractere unique : `CharSet.Single('5')`\n",
-    "- Une plage de caracteres : `CharSet.Range('1', '9')`\n",
-    "- Une union de predicats : `digit.Or(letter)`\n",
-    "- Une intersection : `lowercase.And(vowel)`\n",
-    "- Un complement : `notDigit = digit.Not()`"
+    "Ci-dessous, une **illustration decorative** (NON executee) du genre de pattern auquel on aboutit. On n'essaie meme pas de le faire tourner : ce serait trahir le point (un tel regex est la *preuve par l'absurde* que le backtracking est la mauvaise representation)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f2f70868",
+   "id": "145a4599",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:29:58.180938Z",
-     "iopub.status.busy": "2026-05-12T08:29:58.176739Z",
-     "iopub.status.idle": "2026-05-12T08:29:59.277387Z",
-     "shell.execute_reply": "2026-05-12T08:29:59.275308Z"
+     "iopub.execute_input": "2026-06-14T21:32:48.334349Z",
+     "iopub.status.busy": "2026-06-14T21:32:48.329234Z",
+     "iopub.status.idle": "2026-06-14T21:32:49.685452Z",
+     "shell.execute_reply": "2026-06-14T21:32:49.681309Z"
     },
     "papermill": {
-     "duration": 1.107632,
-     "end_time": "2026-05-12T08:29:59.277543+00:00",
+     "duration": 1.36207,
+     "end_time": "2026-06-14T21:32:49.685557+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:29:58.169911+00:00",
+     "start_time": "2026-06-14T21:32:48.323487+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:2545:5f43:5adb:da74:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1065220.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Classe CharSet definie avec succes.\r\n"
+      "Fragment d'un lookahead Conway (decoratif, non execute comme regex) :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Types de predicats supportes :\r\n"
+      "\n",
+      "^\n",
+      "(?=.*1)(?=.*2)(?=.*3)(?=.*4)(?=.*5)(?=.*6)(?=.*7)(?=.*8)(?=.*9)   # ligne 0 contient 1..9\n",
+      "(?=.*1)(?=.*2)(?=.*3)(?=.*4)(?=.*5)(?=.*6)(?=.*7)(?=.*8)(?=.*9)   # ligne 1 ...\n",
+      "  ... (et ainsi pour les 9 lignes, 9 colonnes, 9 blocs ...)\n",
+      "$\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  - Single(char) : Un caractere unique\r\n"
+      "\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  - Range(min, max) : Une plage de caracteres\r\n"
+      "-> Le backtracking PCRE est un moteur de recherche detourne :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  - Set(params[]) : Un ensemble explicite\r\n"
+      "   ca 'marche', mais l'unicite encodee en lookaputs gigantesques est illisible.\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  - Or/And/Not : Operations logiques\r\n"
+      "   Ce n'est PAS la representation declarative que nous cherchons.\r\n"
      ]
     }
    ],
    "source": [
-    "using System;\n",
-    "using System.Collections.Generic;\n",
-    "using System.Linq;\n",
-    "using System.Text;\n",
-    "\n",
-    "/// <summary>\n",
-    "/// Represente un predicat symbolique sur des caracteres.\n",
-    "/// Un CharSet peut etre :\n",
-    "/// - Un caractere unique\n",
-    "/// - Une plage de caracteres\n",
-    "/// - Une union/intersection de predicats\n",
-    "/// - Le complement d'un predicat\n",
-    "/// </summary>\n",
-    "public abstract class CharSet\n",
-    "{\n",
-    "    // Singleton pour l'ensemble vide\n",
-    "    private static readonly CharSetEmpty _empty = new CharSetEmpty();\n",
-    "    public static CharSet Empty => _empty;\n",
-    "    \n",
-    "    // Singleton pour l'univers (tous les caracteres)\n",
-    "    private static readonly CharSetAll _all = new CharSetAll();\n",
-    "    public static CharSet All => _all;\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Cree un CharSet pour un caractere unique.\n",
-    "    /// </summary>\n",
-    "    public static CharSet Single(char c) => new CharSetSingle(c);\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Cree un CharSet pour une plage de caracteres [min, max].\n",
-    "    /// </summary>\n",
-    "    public static CharSet Range(char min, char max) => new CharSetRange(min, max);\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Cree un CharSet pour un ensemble de caracteres.\n",
-    "    /// </summary>\n",
-    "    public static CharSet Set(params char[] chars) => new CharSetSet(chars);\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Teste si un caractere satisfait le predicat.\n",
-    "    /// </summary>\n",
-    "    public abstract bool Contains(char c);\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Union logique (OR) de deux predicats.\n",
-    "    /// </summary>\n",
-    "    public CharSet Or(CharSet other) => new CharSetUnion(this, other);\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Intersection logique (AND) de deux predicats.\n",
-    "    /// </summary>\n",
-    "    public CharSet And(CharSet other) => new CharSetIntersection(this, other);\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Complement logique (NOT) du predicat.\n",
-    "    /// </summary>\n",
-    "    public CharSet Not() => new CharSetComplement(this);\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Retourne une representation lisible du predicat.\n",
-    "    /// </summary>\n",
-    "    public abstract string ToPredicateString();\n",
-    "    \n",
-    "    // Classes internes pour chaque type de predicat\n",
-    "    \n",
-    "    private sealed class CharSetEmpty : CharSet\n",
-    "    {\n",
-    "        public override bool Contains(char c) => false;\n",
-    "        public override string ToPredicateString() => \"false\";\n",
-    "    }\n",
-    "    \n",
-    "    private sealed class CharSetAll : CharSet\n",
-    "    {\n",
-    "        public override bool Contains(char c) => true;\n",
-    "        public override string ToPredicateString() => \"true\";\n",
-    "    }\n",
-    "    \n",
-    "    private sealed class CharSetSingle : CharSet\n",
-    "    {\n",
-    "        private readonly char _value;\n",
-    "        public CharSetSingle(char value) => _value = value;\n",
-    "        public override bool Contains(char c) => c == _value;\n",
-    "        public override string ToPredicateString() => $\"x == '{_value}'\";\n",
-    "    }\n",
-    "    \n",
-    "    private sealed class CharSetRange : CharSet\n",
-    "    {\n",
-    "        private readonly char _min;\n",
-    "        private readonly char _max;\n",
-    "        public CharSetRange(char min, char max)\n",
-    "        {\n",
-    "            _min = min;\n",
-    "            _max = max;\n",
-    "        }\n",
-    "        public override bool Contains(char c) => c >= _min && c <= _max;\n",
-    "        public override string ToPredicateString() => $\"x >= '{_min}' AND x <= '{_max}'\";\n",
-    "    }\n",
-    "    \n",
-    "    private sealed class CharSetSet : CharSet\n",
-    "    {\n",
-    "        private readonly char[] _chars;\n",
-    "        public CharSetSet(char[] chars) => _chars = chars;\n",
-    "        public override bool Contains(char c) => _chars.Contains(c);\n",
-    "        public override string ToPredicateString() => $\"x IN {{{string.Join(\", \", _chars.Select(c => $\"'{c}'\"))}}}\";\n",
-    "    }\n",
-    "    \n",
-    "    private sealed class CharSetUnion : CharSet\n",
-    "    {\n",
-    "        private readonly CharSet _left;\n",
-    "        private readonly CharSet _right;\n",
-    "        public CharSetUnion(CharSet left, CharSet right)\n",
-    "        {\n",
-    "            _left = left;\n",
-    "            _right = right;\n",
-    "        }\n",
-    "        public override bool Contains(char c) => _left.Contains(c) || _right.Contains(c);\n",
-    "        public override string ToPredicateString() => $\"({_left.ToPredicateString()}) OR ({_right.ToPredicateString()})\";\n",
-    "    }\n",
-    "    \n",
-    "    private sealed class CharSetIntersection : CharSet\n",
-    "    {\n",
-    "        private readonly CharSet _left;\n",
-    "        private readonly CharSet _right;\n",
-    "        public CharSetIntersection(CharSet left, CharSet right)\n",
-    "        {\n",
-    "            _left = left;\n",
-    "            _right = right;\n",
-    "        }\n",
-    "        public override bool Contains(char c) => _left.Contains(c) && _right.Contains(c);\n",
-    "        public override string ToPredicateString() => $\"({_left.ToPredicateString()}) AND ({_right.ToPredicateString()})\";\n",
-    "    }\n",
-    "    \n",
-    "    private sealed class CharSetComplement : CharSet\n",
-    "    {\n",
-    "        private readonly CharSet _inner;\n",
-    "        public CharSetComplement(CharSet inner) => _inner = inner;\n",
-    "        public override bool Contains(char c) => !_inner.Contains(c);\n",
-    "        public override string ToPredicateString() => $\"NOT ({_inner.ToPredicateString()})\";\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine(\"Classe CharSet definie avec succes.\");\n",
-    "Console.WriteLine(\"Types de predicats supportes :\");\n",
-    "Console.WriteLine(\"  - Single(char) : Un caractere unique\");\n",
-    "Console.WriteLine(\"  - Range(min, max) : Une plage de caracteres\");\n",
-    "Console.WriteLine(\"  - Set(params[]) : Un ensemble explicite\");\n",
-    "Console.WriteLine(\"  - Or/And/Not : Operations logiques\");"
+    "// Illustration DECORATIVE (string non utilisee comme regex) du monstre Conway.\n",
+    "// Un seul lookahead d'unicite d'une ligne 9x9 fait deja des dizaines de caracteres.\n",
+    "// La grille entiere = des milliers. Illisible, inversement pedagogique.\n",
+    "string conwayMonsterFragment = @\"\n",
+    "^\n",
+    "(?=.*1)(?=.*2)(?=.*3)(?=.*4)(?=.*5)(?=.*6)(?=.*7)(?=.*8)(?=.*9)   # ligne 0 contient 1..9\n",
+    "(?=.*1)(?=.*2)(?=.*3)(?=.*4)(?=.*5)(?=.*6)(?=.*7)(?=.*8)(?=.*9)   # ligne 1 ...\n",
+    "  ... (et ainsi pour les 9 lignes, 9 colonnes, 9 blocs ...)\n",
+    "$\";\n",
+    "Console.WriteLine(\"Fragment d'un lookahead Conway (decoratif, non execute comme regex) :\");\n",
+    "Console.WriteLine(conwayMonsterFragment);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"-> Le backtracking PCRE est un moteur de recherche detourne :\");\n",
+    "Console.WriteLine(\"   ca 'marche', mais l'unicite encodee en lookaputs gigantesques est illisible.\");\n",
+    "Console.WriteLine(\"   Ce n'est PAS la representation declarative que nous cherchons.\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4d4d817e",
+   "id": "a3163cc0",
    "metadata": {
     "papermill": {
-     "duration": 0.006528,
-     "end_time": "2026-05-12T08:29:59.289563+00:00",
+     "duration": 0.003223,
+     "end_time": "2026-06-14T21:32:49.692531+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:29:59.283035+00:00",
+     "start_time": "2026-06-14T21:32:49.689308+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### 2.2 Exemples de Predicats CharSet\n",
+    "### Interpretation : Conway = l'anti-modele\n",
     "\n",
-    "Testons notre classe `CharSet` avec differents types de predicats."
+    "Le monstre Conway demontre par l'absurde que **detourner le backtracking d'un moteur regex pour faire de la recherche** conduit a une representation illisible. La contrainte d'unicite Sudoku n'est *pas* naturelle en PCRE : elle s'exprime en empilant des assertions negatives sur toutes les paires de cellules.\n",
+    "\n",
+    "La bonne representation, c'est l'**intersection declarative** de contraintes (`Ligne & Colonne & Bloc`) compilee vers un automate symbolique - exactement ce que cherchait l'approche 2020."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e1d5ed3a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003116,
+     "end_time": "2026-06-14T21:32:49.698795+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:49.695679+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "## Exercice : Creer un predicat CharSet personnalise\n",
+    "## 3. Barreau 2 - La tentative 2020 : BREX, Rex et le mur\n",
     "\n",
-    "# Objectif\n",
-    "Creez un predicat CharSet qui accepte uniquement les chiffres pairs (2, 4, 6, 8).\n",
+    "En 2020, l'auteur s'appuie sur la chaine d'outils symboliques de Margus Veanes (**AutomataDotNet**) pour realiser l'intersection declarative. Deux briques existaient, verifiees par lecture du source au commit `0242132f` :\n",
     "\n",
-    "# Indice\n",
-    "Utilisez les operateurs d'union et d'intersection pour combiner des ensembles de caracteres.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
-    }
-   ],
-   "source": [
-    "// EXERCICE : Creer un predicat CharSet personnalise\n",
-    "public CharSet CreateEvenDigitsPredicate()\n",
-    "{\n",
-    "    // TODO: Creez un CharSet qui accepte uniquement les chiffres pairs (2, 4, 6, 8)\n",
-    "    // en utilisant les operateurs de la bibliotheque Automata\n",
-    "    return null; // TODO etudiant\n",
-    "}\n"
+    "**1. L'intersection existait - via BREX** (Boolean combinations of Regular EXpressions, fichiers `BREX.cs`, `BREXManager.cs`). Mais c'etait une **API builder C#**, pas un operateur `&` de surface dans une chaine :\n",
+    "\n",
+    "```csharp\n",
+    "var man  = new BREXManager();\n",
+    "var like1 = man.MkLike(@\"%[ab]_____\");\n",
+    "var like2 = man.MkLike(@\"%[bc]_____\");\n",
+    "var and   = man.MkAnd(like1, like2);   // l'intersection : une METHODE, pas un '&' dans la chaine\n",
+    "var dfa   = and.Optimize();\n",
+    "```\n",
+    "\n",
+    "**2. Le temoin Z3 existait - via la lignee Rex** (`RegexToSMTConverter.cs`) : generation d'un membre/temoin d'un regex par SMT. C'est ce chemin qui a bute sur la troncature a 21 caracteres.\n",
+    "\n",
+    "### Les deux murs reels (verifies dans les tests)\n",
+    "\n",
+    "| Mur | Preuve dans le source | Consequence |\n",
+    "|-----|----------------------|-------------|\n",
+    "| **Explosion d'etats** | `BREXTests.cs` porte les commentaires `//fails due to timeout` et `//fails due to too many states` - l'intersection de deux `MkLike` de **8-9 underscores seulement** fait exploser le DFA via `Optimize()` | L'intersection symbolique est trop chere a determiniser |\n",
+    "| **Cap du temoin a 21 caracteres** | Issue upstream [AutomataDotNet/Automata#6](https://github.com/AutomataDotNet/Automata/issues/6) (creee le 2020-12-07, **toujours 0 reponse**) : le chemin SFAz3+Z3 tronque le modele | On ne peut pas produire une grille-temoin完整e |\n",
+    "\n",
+    "Ci-dessous, le builder BREX reproduit en **pseudo-code documentaire** (non execute - AutomataDotNet est un projet Microsoft abandonne, non restaure ici). Le but est de montrer la *forme* de l'approche 2020 : un spaghetti de C# et de strings, pas encore la chaine monolithique elegante."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "9b011981",
+   "id": "5aee19b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:29:59.301188Z",
-     "iopub.status.busy": "2026-05-12T08:29:59.300885Z",
-     "iopub.status.idle": "2026-05-12T08:29:59.402155Z",
-     "shell.execute_reply": "2026-05-12T08:29:59.396135Z"
+     "iopub.execute_input": "2026-06-14T21:32:49.706325Z",
+     "iopub.status.busy": "2026-06-14T21:32:49.706075Z",
+     "iopub.status.idle": "2026-06-14T21:32:49.745362Z",
+     "shell.execute_reply": "2026-06-14T21:32:49.745201Z"
     },
     "papermill": {
-     "duration": 0.107692,
-     "end_time": "2026-05-12T08:29:59.402217+00:00",
+     "duration": 0.043626,
+     "end_time": "2026-06-14T21:32:49.745433+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:29:59.294525+00:00",
+     "start_time": "2026-06-14T21:32:49.701807+00:00",
      "status": "completed"
     },
     "tags": []
@@ -456,112 +379,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Exemple 1 : Chiffres Sudoku (1-9) ===\r\n"
+      "Approche 2020 (documentaire, non execute) :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Predicat : x >= '1' AND x <= '9'\r\n"
+      "  - Intersection via BREX builder C# (MkAnd/MkLike), pas un '&' de surface\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n"
+      "  - Mur 1 : Optimize() explose le DFA (BREXTests.cs '//too many states')\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Tests d'appartenance :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '0' : [NON]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '1' : [OUI]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '2' : [OUI]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '3' : [OUI]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '4' : [OUI]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '5' : [OUI]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '6' : [OUI]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '7' : [OUI]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '8' : [OUI]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '9' : [OUI]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  'X' : [NON]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '.' : [NON]\r\n"
+      "  - Mur 2 : temoin Z3 tronque a 21 char (AutomataDotNet/Automata#6, 0 reponse depuis 2020-12-07)\r\n"
      ]
     },
     {
@@ -575,229 +414,116 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Exemple 2 : Predicats composes ===\r\n"
+      "Conclusion : l'intuition declarative (intersection) etait juste et\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chiffres pairs : x IN {'2', '4', '6', '8'}\r\n"
+      "contemporaine du papier Veanes (MSR-TR-2020-25, aout 2020).\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chiffres impairs (vrai complement) : (x >= '1' AND x <= '9') AND (NOT (x IN {'2', '4', '6', '8'}))\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Petits chiffres (1-5) : x >= '1' AND x <= '5'\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Petits OU pairs : (x >= '1' AND x <= '5') OR (x IN {'2', '4', '6', '8'})\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Tests de predicat compose (petits OU pairs) :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '1' est accepte\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '2' est accepte\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '3' est accepte\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '4' est accepte\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '5' est accepte\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '6' est accepte\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  '8' est accepte\r\n"
+      "Mais la FORME etait un spaghetti C#, et les deux murs etaient reels.\r\n"
      ]
     }
    ],
    "source": [
-    "// Exemple 1 : Predicat pour chiffres Sudoku (1-9)\n",
-    "CharSet sudokuDigit = CharSet.Range('1', '9');\n",
+    "// Pseudo-code DOCUMENTAIRE de l'approche 2020 (BREX + Rex + Z3), non execute.\n",
+    "// Montre la FORME : un builder C# d'intersections, pas un operateur de surface.\n",
+    "//\n",
+    "// var man = new BREXManager();\n",
+    "// // une ligne Sudoku valide = intersection de contraintes\n",
+    "// var lineConstraint = man.MkAnd(\n",
+    "//     man.MkLike(\"9 chiffres 1-9\"),\n",
+    "//     man.MkAnd(man.MkLike(\"contient 1\"), man.MkAnd(man.MkLike(\"contient 2\"), ...)));\n",
+    "// var fullSudoku = man.MkAnd(man.MkAnd(lignes), man.MkAnd(man.MkAnd(colonnes), man.MkAnd(blocs)));\n",
+    "// var dfa = fullSudoku.Optimize();   // <-- MUR 1 : explosion d'etats sur 8-9 \"underscores\"\n",
+    "// var witness = RexToSMT(dfa);        // <-- MUR 2 : cap 21 caracteres (issue #6)\n",
     "\n",
-    "Console.WriteLine(\"=== Exemple 1 : Chiffres Sudoku (1-9) ===\");\n",
-    "Console.WriteLine($\"Predicat : {sudokuDigit.ToPredicateString()}\");\n",
+    "Console.WriteLine(\"Approche 2020 (documentaire, non execute) :\");\n",
+    "Console.WriteLine(\"  - Intersection via BREX builder C# (MkAnd/MkLike), pas un '&' de surface\");\n",
+    "Console.WriteLine(\"  - Mur 1 : Optimize() explose le DFA (BREXTests.cs '//too many states')\");\n",
+    "Console.WriteLine(\"  - Mur 2 : temoin Z3 tronque a 21 char (AutomataDotNet/Automata#6, 0 reponse depuis 2020-12-07)\");\n",
     "Console.WriteLine();\n",
-    "Console.WriteLine(\"Tests d'appartenance :\");\n",
-    "foreach (char c in \"0123456789X.\")\n",
-    "{\n",
-    "    bool inSet = sudokuDigit.Contains(c);\n",
-    "    string status = inSet ? \"[OUI]\" : \"[NON]\";\n",
-    "    Console.WriteLine($\"  '{c}' : {status}\");\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"=== Exemple 2 : Predicats composes ===\");\n",
-    "\n",
-    "// Chiffres pairs\n",
-    "CharSet evenDigit = CharSet.Set('2', '4', '6', '8');\n",
-    "Console.WriteLine($\"Chiffres pairs : {evenDigit.ToPredicateString()}\");\n",
-    "\n",
-    "// Chiffres impairs - VRAI complement dans le domaine 1-9\n",
-    "// odd = (domain 1-9) AND (NOT pairs)\n",
-    "CharSet domain = CharSet.Range('1', '9');\n",
-    "CharSet oddDigit = domain.And(evenDigit.Not());\n",
-    "Console.WriteLine($\"Chiffres impairs (vrai complement) : {oddDigit.ToPredicateString()}\");\n",
-    "\n",
-    "// Petits chiffres (1-5)\n",
-    "CharSet smallDigit = CharSet.Range('1', '5');\n",
-    "Console.WriteLine($\"Petits chiffres (1-5) : {smallDigit.ToPredicateString()}\");\n",
-    "\n",
-    "// Union : petits OU pairs\n",
-    "CharSet smallOrEven = smallDigit.Or(evenDigit);\n",
-    "Console.WriteLine($\"Petits OU pairs : {smallOrEven.ToPredicateString()}\");\n",
-    "\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"Tests de predicat compose (petits OU pairs) :\");\n",
-    "foreach (char c in \"123456789\")\n",
-    "{\n",
-    "    bool inSet = smallOrEven.Contains(c);\n",
-    "    if (inSet)\n",
-    "        Console.WriteLine($\"  '{c}' est accepte\");\n",
-    "}\n"
+    "Console.WriteLine(\"Conclusion : l'intuition declarative (intersection) etait juste et\");\n",
+    "Console.WriteLine(\"contemporaine du papier Veanes (MSR-TR-2020-25, aout 2020).\");\n",
+    "Console.WriteLine(\"Mais la FORME etait un spaghetti C#, et les deux murs etaient reels.\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "142da5f6",
+   "id": "c2b59190",
    "metadata": {
     "papermill": {
-     "duration": 0.003708,
-     "end_time": "2026-05-12T08:29:59.409779+00:00",
+     "duration": 0.00336,
+     "end_time": "2026-06-14T21:32:49.752351+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:29:59.406071+00:00",
+     "start_time": "2026-06-14T21:32:49.748991+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "#### Interpretation : Predicats CharSet\n",
+    "### Interpretation : deux murs, pas un seul\n",
     "\n",
-    "**Sortie obtenue** : La classe `CharSet` permet de creer des predicats logiques sur des caracteres.\n",
+    "L'approche 2020 n'etait pas Conway : l'intuition declarative par intersection etait **fondue et contemporaine** des travaux de Veanes. Mais la **forme** (builder C# `MkAnd(MkLike(...), MkLike(...))`) etait un spaghetti, et **deux murs reels** l'ont bloquee :\n",
     "\n",
-    "**Exemple 1 - Chiffres Sudoku** :\n",
-    "| Caractere | Accepte | Explication |\n",
-    "|-----------|---------|-------------|\n",
-    "| '0' | Non | Hors plage [1-9] |\n",
-    "| '1'-'9' | Oui | Dans plage [1-9] |\n",
-    "| 'X', '.' | Non | Hors plage [1-9] |\n",
+    "1. l'intersection symbolique **explose** a la determinisation (DFA) ;\n",
+    "2. le chemin temoin **Z3 est cape** a 21 caracteres.\n",
     "\n",
-    "**Exemple 2 - Predicats composes** :\n",
-    "- `Range('1', '5')` : Predicat $x \\geq 1 \\land x \\leq 5$\n",
-    "- `Set('2','4','6','8')` : Predicat $x \\in \\{2,4,6,8\\}$\n",
-    "- `smallOrEven` : Predicat $(1 \\leq x \\leq 5) \\lor (x \\in \\{2,4,6,8\\})$\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. Les predicats peuvent etre combines avec `Or`, `And`, `Not`\n",
-    "2. La methode `Contains(char)` teste si un caractere satisfait le predicat\n",
-    "3. Les predicats sont representes de manière symbolique (formules, pas enumeration)\n",
-    "\n",
-    "> **Note theorique** : Ces predicats sont exactement ce qui distingue les automates symboliques des automates classiques. Dans un DFA classique, chaque transition est etiquettee par un caractere concret. Dans un SFA, chaque transition est etiquettee par un predicat comme `Range('1', '9')`."
+    "En 2025, RE# fait tomber le **mur 1** (intersection en temps lineaire, sans determinisation exponentielle). Le **mur 2** reste du cote de Z3 - qui n'a, lui, jamais ete cape quand on l'utilise directement."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f2fa6728",
+   "id": "e9acb968",
    "metadata": {
     "papermill": {
-     "duration": 0.032109,
-     "end_time": "2026-05-12T08:29:59.445438+00:00",
+     "duration": 0.003269,
+     "end_time": "2026-06-14T21:32:49.759108+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:29:59.413329+00:00",
+     "start_time": "2026-06-14T21:32:49.755839+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "## 4. Barreau 3 - RE# (2025) : la reconnaissance enfin tractable\n",
     "\n",
-    "## 3. Automate Symbolique Simple (20 min)\n",
+    "[RE#](https://github.com/ieviev/resharp-dotnet) (NuGet `Resharp`, engine F#/.NET, MIT) etend la syntaxe `System.Text.RegularExpressions` avec **trois operateurs first-class** :\n",
     "\n",
-    "Maintenant que nous avons des predicats symboliques, nous pouvons construire un **automate symbolique** (SFA). Commençons par un automate simple qui accepte les sequences de 9 chiffres distincts.\n",
+    "- `&` : **intersection** (`A & B` reconnait les mots acceptes par A ET par B) ;\n",
+    "- `~` : **complement** (`~A` reconnait tout ce que A ne reconnait pas) ;\n",
+    "- `_` : wildcard universel.\n",
     "\n",
-    "### 3.1 Classe SymbolicFiniteAutomaton\n",
+    "Crucialement, RE# est **non-backtracking** et compile vers des automates dont la reconnaissance est **temps lineaire** - grace a la *finitude des derivees symboliques* (formalisee en Lean, cf section references). L'intersection de deux RE# ne determinise **pas** de maniere exponentielle : c'est precisement le mur 1 de 2020 qui tombe.\n",
     "\n",
-    "Cette classe represente un automate symbolique avec :\n",
-    "- Des etats nommes\n",
-    "- Des transitions etiquettees par des predicats `CharSet`\n",
-    "- Un etat initial et des etats finaux"
+    "**Caveat honnete** : RE# est **recognition-only**. Il *reconnait* (valide) ; il ne *genere* aucun temoin. Pour produire une grille, il faudra Z3 (section 6).\n",
+    "\n",
+    "> **Note technique (environnement)** : sous ce notebook (kernel .NET execute via papermill), la directive `#r \"nuget: ...\"` se bloque (sonde reseau nuget.org en timeout). On charge donc RE# via **references DLL directes** vers le cache local NuGet. RE# etant F#, il faut aussi `FSharp.Core` (version 10.1.300, assembly 10.0.0.0 requise)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "fe790a1c",
+   "id": "ad89452f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:29:59.516060Z",
-     "iopub.status.busy": "2026-05-12T08:29:59.511158Z",
-     "iopub.status.idle": "2026-05-12T08:30:00.071267Z",
-     "shell.execute_reply": "2026-05-12T08:30:00.070637Z"
+     "iopub.execute_input": "2026-06-14T21:32:49.770325Z",
+     "iopub.status.busy": "2026-06-14T21:32:49.770025Z",
+     "iopub.status.idle": "2026-06-14T21:32:50.154672Z",
+     "shell.execute_reply": "2026-06-14T21:32:50.154543Z"
     },
     "papermill": {
-     "duration": 0.592752,
-     "end_time": "2026-05-12T08:30:00.071463+00:00",
+     "duration": 0.3911,
+     "end_time": "2026-06-14T21:32:50.154735+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:29:59.478711+00:00",
+     "start_time": "2026-06-14T21:32:49.763635+00:00",
      "status": "completed"
     },
     "tags": []
@@ -807,178 +533,158 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Classe SymbolicFiniteAutomaton definie avec succes.\r\n"
+      "RE# compile en 201 ms (premier appel, JIT inclus).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'527' contient 5 et 7     : oui\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'521' contient 5 et 7     : non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'123456789' a 1, 2 et 3   : oui\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'456789' a 1, 2 et 3      : non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RE# supporte aussi le complement ~ et le wildcard _ (first-class, documentes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "par le moteur). Nous nous appuyons ici sur l'INTERSECTION &: c'est elle qui\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "encode de maniere robuste la contrainte de ligne Sudoku ci-dessous.\r\n"
      ]
     }
    ],
    "source": [
-    "using System;\n",
-    "using System.Collections.Generic;\n",
-    "using System.Linq;\n",
+    "// RE# via references DLL directes (cf note technique ci-dessus : pas de #r \"nuget:\" sous papermill).\n",
+    "// Resharp (engine F#) + Resharp.Runtime + FSharp.Core 10.1.300 (assembly 10.0.0.0 requise).\n",
+    "#r \"C:/Users/jsboi/.nuget/packages/resharp/1.0.3/lib/net9.0/Resharp.dll\"\n",
+    "#r \"C:/Users/jsboi/.nuget/packages/resharp/1.0.3/lib/net9.0/Resharp.Runtime.dll\"\n",
+    "#r \"C:/Users/jsboi/.nuget/packages/fsharp.core/10.1.300/lib/netstandard2.1/FSharp.Core.dll\"\n",
+    "using System.Diagnostics;\n",
     "\n",
-    "/// <summary>\n",
-    "/// Represente une transition symbolique dans un automate.\n",
-    "/// </summary>\n",
-    "public class SymbolicTransition\n",
-    "{\n",
-    "    public string FromState { get; }\n",
-    "    public string ToState { get; }\n",
-    "    public CharSet Predicate { get; }\n",
-    "    \n",
-    "    public SymbolicTransition(string from, string to, CharSet predicate)\n",
-    "    {\n",
-    "        FromState = from;\n",
-    "        ToState = to;\n",
-    "        Predicate = predicate;\n",
-    "    }\n",
-    "    \n",
-    "    public override string ToString() => $\"{FromState} --[{Predicate.ToPredicateString()}]--> {ToState}\";\n",
-    "}\n",
-    "\n",
-    "/// <summary>\n",
-    "/// Automate symbolique avec predicats CharSet.\n",
-    "/// </summary>\n",
-    "public class SymbolicFiniteAutomaton\n",
-    "{\n",
-    "    private HashSet<string> _states;\n",
-    "    private List<SymbolicTransition> _transitions;\n",
-    "    private string _initialState;\n",
-    "    private HashSet<string> _finalStates;\n",
-    "    \n",
-    "    public string Name { get; }\n",
-    "    public IReadOnlySet<string> States => _states;\n",
-    "    public IReadOnlyList<SymbolicTransition> Transitions => _transitions;\n",
-    "    public string InitialState => _initialState;\n",
-    "    public IReadOnlySet<string> FinalStates => _finalStates;\n",
-    "    \n",
-    "    public SymbolicFiniteAutomaton(string name)\n",
-    "    {\n",
-    "        Name = name;\n",
-    "        _states = new HashSet<string>();\n",
-    "        _transitions = new List<SymbolicTransition>();\n",
-    "        _finalStates = new HashSet<string>();\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Ajoute un etat a l'automate.\n",
-    "    /// </summary>\n",
-    "    public SymbolicFiniteAutomaton AddState(string state, bool isInitial = false, bool isFinal = false)\n",
-    "    {\n",
-    "        _states.Add(state);\n",
-    "        if (isInitial)\n",
-    "        {\n",
-    "            if (_initialState != null)\n",
-    "                throw new ArgumentException($\"Etat initial deja defini : {_initialState}\");\n",
-    "            _initialState = state;\n",
-    "        }\n",
-    "        if (isFinal)\n",
-    "            _finalStates.Add(state);\n",
-    "        return this;\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Ajoute une transition symbolique.\n",
-    "    /// </summary>\n",
-    "    public SymbolicFiniteAutomaton AddTransition(string from, string to, CharSet predicate)\n",
-    "    {\n",
-    "        if (!_states.Contains(from))\n",
-    "            throw new ArgumentException($\"Etat source inconnu : {from}\");\n",
-    "        if (!_states.Contains(to))\n",
-    "            throw new ArgumentException($\"Etat destination inconnu : {to}\");\n",
-    "        \n",
-    "        _transitions.Add(new SymbolicTransition(from, to, predicate));\n",
-    "        return this;\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Teste si l'automate accepte une sequence de caracteres.\n",
-    "    /// </summary>\n",
-    "    public bool Accepts(string input)\n",
-    "    {\n",
-    "        if (_initialState == null)\n",
-    "            throw new InvalidOperationException(\"Pas d'etat initial defini\");\n",
-    "        \n",
-    "        return AcceptsRecursive(_initialState, input, 0);\n",
-    "    }\n",
-    "    \n",
-    "    private bool AcceptsRecursive(string currentState, string input, int position)\n",
-    "    {\n",
-    "        // Cas de base : fin de l'entree\n",
-    "        if (position == input.Length)\n",
-    "            return _finalStates.Contains(currentState);\n",
-    "        \n",
-    "        char currentChar = input[position];\n",
-    "        bool accepted = false;\n",
-    "        \n",
-    "        // Trouver toutes les transitions applicables\n",
-    "        foreach (var transition in _transitions.Where(t => t.FromState == currentState))\n",
-    "        {\n",
-    "            if (transition.Predicate.Contains(currentChar))\n",
-    "            {\n",
-    "                // Transition possible, continuer recursivement\n",
-    "                if (AcceptsRecursive(transition.ToState, input, position + 1))\n",
-    "                    accepted = true;\n",
-    "            }\n",
-    "        }\n",
-    "        \n",
-    "        return accepted;\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Retourne une representation textuelle de l'automate.\n",
-    "    /// </summary>\n",
-    "    public override string ToString()\n",
-    "    {\n",
-    "        var sb = new System.Text.StringBuilder();\n",
-    "        sb.AppendLine($\"Automate Symbolique : {Name}\");\n",
-    "        sb.AppendLine($\"  Etats : {string.Join(\", \", _states)}\");\n",
-    "        sb.AppendLine($\"  Etat initial : {_initialState}\");\n",
-    "        sb.AppendLine($\"  Etats finaux : {string.Join(\", \", _finalStates)}\");\n",
-    "        sb.AppendLine(\"  Transitions :\");\n",
-    "        foreach (var t in _transitions)\n",
-    "            sb.AppendLine($\"    {t}\");\n",
-    "        return sb.ToString();\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine(\"Classe SymbolicFiniteAutomaton definie avec succes.\");"
+    "// Smoke test : l'INTERSECTION & est first-class dans UNE chaine. C'est l'operateur\n",
+    "// qui encode la contrainte de ligne Sudoku (section suivante). On le demontre ici\n",
+    "// en combinant 2 puis 3 contraintes d'inclusion dans la meme expression.\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "var has5And7 = new Resharp.Regex(@\".*5.*&.*7.*\");          // contient un 5 ET un 7\n",
+    "var has123   = new Resharp.Regex(@\".*1.*&.*2.*&.*3.*\");    // contient 1, 2 ET 3 (3-way)\n",
+    "sw.Stop();\n",
+    "Console.WriteLine($\"RE# compile en {sw.ElapsedMilliseconds} ms (premier appel, JIT inclus).\");\n",
+    "Console.WriteLine($\"'527' contient 5 et 7     : {(has5And7.Matches(\"527\").Length > 0 ? \"oui\" : \"non\")}\");\n",
+    "Console.WriteLine($\"'521' contient 5 et 7     : {(has5And7.Matches(\"521\").Length > 0 ? \"oui\" : \"non\")}\");\n",
+    "Console.WriteLine($\"'123456789' a 1, 2 et 3   : {(has123.Matches(\"123456789\").Length > 0 ? \"oui\" : \"non\")}\");\n",
+    "Console.WriteLine($\"'456789' a 1, 2 et 3      : {(has123.Matches(\"456789\").Length > 0 ? \"oui\" : \"non\")}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"RE# supporte aussi le complement ~ et le wildcard _ (first-class, documentes\");\n",
+    "Console.WriteLine(\"par le moteur). Nous nous appuyons ici sur l'INTERSECTION &: c'est elle qui\");\n",
+    "Console.WriteLine(\"encode de maniere robuste la contrainte de ligne Sudoku ci-dessous.\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "34049500",
+   "id": "8ab75967",
    "metadata": {
     "papermill": {
-     "duration": 0.026379,
-     "end_time": "2026-05-12T08:30:00.112785+00:00",
+     "duration": 0.003859,
+     "end_time": "2026-06-14T21:32:50.162156+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:00.086406+00:00",
+     "start_time": "2026-06-14T21:32:50.158297+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### 3.2 Exemple : Automate pour Chiffres Sudoku\n",
+    "### Interpretation : RE# valide, ne resout pas\n",
     "\n",
-    "Creons un automate simple qui accepte uniquement des sequences de 9 chiffres entre 1 et 9."
+    "RE# rend l'**intersection** (`&`) et le **complement** (`~`) first-class dans une chaine unique, compilee en temps lineaire. C'est precisement le barreau intermediaire qui manquait en 2020 : fini le spaghetti builder `MkAnd(MkLike(...))`, fini l'explosion DFA.\n",
+    "\n",
+    "Mais notons le caveat deja mentionne : RE# repond `matche` ou `ne matche pas`. Il ne dit pas *quelle* chaine satisferait le pattern. C'est un **verificateur**, pas un resolveur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78b8c507",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004357,
+     "end_time": "2026-06-14T21:32:50.169978+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:50.165621+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. RE# verificateur d'une ligne Sudoku remplie\n",
+    "\n",
+    "Encodons la **contrainte de ligne** d'un Sudoku comme une intersection RE# :\n",
+    "\n",
+    "> Une ligne valide = exactement 9 chiffres 1-9 (`[1-9]{9}`) ET elle contient un 1 ET un 2 ... ET un 9.\n",
+    "\n",
+    "Soit, litteralement :\n",
+    "\n",
+    "```\n",
+    "[1-9]{9} & .*1.* & .*2.* & .*3.* & .*4.* & .*5.* & .*6.* & .*7.* & .*8.* & .*9.*\n",
+    "```\n",
+    "\n",
+    "Cette intersection de 10 regex est **exactement** le type d'operation qui faisait exploser le DFA en 2020 (`BREXTests.cs` : \"//too many states\" sur 8-9 underscores). Avec RE#, elle compile et s'execute en temps lineaire."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "6a08405e",
+   "id": "9c60d031",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:30:00.275092Z",
-     "iopub.status.busy": "2026-05-12T08:30:00.274094Z",
-     "iopub.status.idle": "2026-05-12T08:30:00.435475Z",
-     "shell.execute_reply": "2026-05-12T08:30:00.435228Z"
+     "iopub.execute_input": "2026-06-14T21:32:50.178071Z",
+     "iopub.status.busy": "2026-06-14T21:32:50.177895Z",
+     "iopub.status.idle": "2026-06-14T21:32:50.348573Z",
+     "shell.execute_reply": "2026-06-14T21:32:50.348419Z"
     },
     "papermill": {
-     "duration": 0.285586,
-     "end_time": "2026-05-12T08:30:00.435569+00:00",
+     "duration": 0.175282,
+     "end_time": "2026-06-14T21:32:50.348683+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:00.149983+00:00",
+     "start_time": "2026-06-14T21:32:50.173401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -988,21 +694,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Automate Symbolique : SudokuDigitValidator\r\n",
-      "  Etats : q0, q1, q2, q3, q4, q5, q6, q7, q8, q9\r\n",
-      "  Etat initial : q0\r\n",
-      "  Etats finaux : q9\r\n",
-      "  Transitions :\r\n",
-      "    q0 --[x >= '1' AND x <= '9']--> q1\r\n",
-      "    q1 --[x >= '1' AND x <= '9']--> q2\r\n",
-      "    q2 --[x >= '1' AND x <= '9']--> q3\r\n",
-      "    q3 --[x >= '1' AND x <= '9']--> q4\r\n",
-      "    q4 --[x >= '1' AND x <= '9']--> q5\r\n",
-      "    q5 --[x >= '1' AND x <= '9']--> q6\r\n",
-      "    q6 --[x >= '1' AND x <= '9']--> q7\r\n",
-      "    q7 --[x >= '1' AND x <= '9']--> q8\r\n",
-      "    q8 --[x >= '1' AND x <= '9']--> q9\r\n",
-      "\r\n"
+      "Contrainte de ligne (10-way intersection) compilee en 45 ms.\r\n"
      ]
     },
     {
@@ -1010,151 +702,158 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "=== Tests d'acceptation ===\r\n"
+      "Lignes valides (permutations de 1..9) :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     123456789 : [ACCEPTED]\r\n"
+      "  '123456789' -> VALIDE  (attendu : VALIDE) [OK]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     111111111 : [ACCEPTED]\r\n"
+      "  '987654321' -> VALIDE  (attendu : VALIDE) [OK]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      12345678 : [REJECTED]\r\n"
+      "  '534678912' -> VALIDE  (attendu : VALIDE) [OK]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    1234567890 : [REJECTED]\r\n"
+      "\n",
+      "Lignes invalides :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     12345678X : [REJECTED]\r\n"
+      "  '123456788' -> invalide  (attendu : invalide) [OK]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "                  : [REJECTED]\r\n"
+      "  '12345678' -> invalide  (attendu : invalide) [OK]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     528317946 : [ACCEPTED]\r\n"
+      "  '112345678' -> invalide  (attendu : invalide) [OK]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  '123456780' -> invalide  (attendu : invalide) [OK]\r\n"
      ]
     }
    ],
    "source": [
-    "// Automate qui accepte exactement 9 chiffres Sudoku (1-9)\n",
-    "var digitAutomaton = new SymbolicFiniteAutomaton(\"SudokuDigitValidator\");\n",
+    "using System.Diagnostics;\n",
+    "// La contrainte de ligne Sudoku comme intersection RE# (10 sous-regex).\n",
+    "// En 2020 cette intersection explosait le DFA ; RE# la compile en temps lineaire.\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "var ligneValide = new Resharp.Regex(\n",
+    "    @\"[1-9]{9}&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\");\n",
+    "sw.Stop();\n",
+    "Console.WriteLine($\"Contrainte de ligne (10-way intersection) compilee en {sw.ElapsedMilliseconds} ms.\");\n",
     "\n",
-    "// Ajouter les etats : q0 (initial) -> q1 -> ... -> q9 (final)\n",
-    "for (int i = 0; i <= 9; i++)\n",
+    "void VerifierLigne(string ligne, string attendu)\n",
     "{\n",
-    "    digitAutomaton.AddState($\"q{i}\", isInitial: (i == 0), isFinal: (i == 9));\n",
+    "    bool ok = ligneValide.Matches(ligne).Length > 0;\n",
+    "    string verdict = ok ? \"VALIDE\" : \"invalide\";\n",
+    "    Console.WriteLine($\"  '{ligne}' -> {verdict}  (attendu : {attendu}) {(ok == (attendu == \"VALIDE\") ? \"[OK]\" : \"[ECHEC]\")}\");\n",
     "}\n",
     "\n",
-    "// Ajouter les transitions : chaque chiffre Sudoku avance d'un etat\n",
-    "CharSet sudokuDigit = CharSet.Range('1', '9');\n",
-    "for (int i = 0; i < 9; i++)\n",
-    "{\n",
-    "    digitAutomaton.AddTransition($\"q{i}\", $\"q{i + 1}\", sudokuDigit);\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine(digitAutomaton);\n",
-    "\n",
-    "// Tests\n",
-    "Console.WriteLine(\"\\n=== Tests d'acceptation ===\");\n",
-    "string[] testCases = {\n",
-    "    \"123456789\",    // Valide : 9 chiffres\n",
-    "    \"111111111\",    // Valide : 9 chiffres (meme si repetes)\n",
-    "    \"12345678\",     // Invalide : 8 chiffres\n",
-    "    \"1234567890\",   // Invalide : 10 chiffres\n",
-    "    \"12345678X\",    // Invalide : contient 'X'\n",
-    "    \"               \", // Invalide : vide\n",
-    "    \"528317946\"     // Valide : 9 chiffres\n",
-    "};\n",
-    "\n",
-    "foreach (var test in testCases)\n",
-    "{\n",
-    "    bool accepted = digitAutomaton.Accepts(test);\n",
-    "    string display = string.IsNullOrEmpty(test) ? \"<vide>\" : test;\n",
-    "    string status = accepted ? \"[ACCEPTED]\" : \"[REJECTED]\";\n",
-    "    Console.WriteLine($\"  {display,12} : {status}\");\n",
-    "}"
+    "Console.WriteLine(\"\\nLignes valides (permutations de 1..9) :\");\n",
+    "VerifierLigne(\"123456789\", \"VALIDE\");\n",
+    "VerifierLigne(\"987654321\", \"VALIDE\");\n",
+    "VerifierLigne(\"534678912\", \"VALIDE\");\n",
+    "Console.WriteLine(\"\\nLignes invalides :\");\n",
+    "VerifierLigne(\"123456788\", \"invalide\");   // doublon (8 deux fois)\n",
+    "VerifierLigne(\"12345678\",  \"invalide\");   // trop court\n",
+    "VerifierLigne(\"112345678\", \"invalide\");   // doublon (1 deux fois)\n",
+    "VerifierLigne(\"123456780\", \"invalide\");   // 0 interdit"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "31871b9b",
+   "id": "332400c1",
    "metadata": {
     "papermill": {
-     "duration": 0.005931,
-     "end_time": "2026-05-12T08:30:00.448492+00:00",
+     "duration": 0.003795,
+     "end_time": "2026-06-14T21:32:50.356738+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:00.442561+00:00",
+     "start_time": "2026-06-14T21:32:50.352943+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "#### Interpretation : Automate pour Chiffres Sudoku\n",
+    "### Interpretation : RE# verifie en O(n), lineaire\n",
     "\n",
-    "**Sortie obtenue** : L'automate accepte uniquement les sequences de 9 chiffres dans [1-9].\n",
+    "La contrainte de ligne - une intersection de 10 regex - compile et s'execute en temps lineaire. **C'est le mur 1 de 2020 qui tombe** : la meme operation qui faisait exploser le DFA (`//too many states`) est desormais tractable.\n",
     "\n",
-    "| Input | Longueur | Contenu | Accepte | Pourquoi |\n",
-    "|-------|----------|---------|---------|----------|\n",
-    "| \"123456789\" | 9 | Tous 1-9 | Oui | Correct |\n",
-    "| \"111111111\" | 9 | Tous 1-9 | Oui | Correct (pas de contrainte d'unicite) |\n",
-    "| \"12345678\" | 8 | Tous 1-9 | Non | Pas assez de caracteres |\n",
-    "| \"1234567890\" | 10 | Contient '0' | Non | Trop de caracteres + '0' invalide |\n",
-    "| \"12345678X\" | 9 | Contient 'X' | Non | 'X' pas dans [1-9] |\n",
-    "| \"\" | 0 | Vide | Non | Pas dans etat final |\n",
+    "Ce verificateur reconnait une ligne valide. Applique a chacune des 9 lignes d'une grille remplie, il valide la grille entiere (apres extraction des colonnes et blocs, memes contraintes). **Mais il ne produit toujours aucune grille** : donnez-lui un puzzle vide, il ne saura pas le remplir."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3be938e7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003382,
+     "end_time": "2026-06-14T21:32:50.363547+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:50.360165+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : une contrainte d'intersection RE#\n",
     "\n",
-    "**Structure de l'automate** :\n",
-    "```\n",
-    "      [1-9]     [1-9]           [1-9]\n",
-    "q0 ------> q1 ------> q2 ---> ... ---> q9 (final)\n",
-    "```\n",
+    "# Objectif\n",
+    "Ecrivez un pattern RE# qui reconnait une ligne Sudoku valide **ET** dans laquelle le chiffre **5 apparaît avant le 7** (sous-sequence `5 ... 7`).\n",
     "\n",
-    "**Point important** : Cet automate verifie uniquement le **format** (9 chiffres valides), pas la contrainte d'unicite. Pour verifier que tous les chiffres sont distincts, nous aurions besoin d'un automate plus complexe avec $9! = 362880$ etats (une pour chaque permutation). C'est ici que les automates symboliques avec Z3 deviennent plus interessants."
+    "# Indice\n",
+    "Composez par intersection la contrainte de ligne valide (ci-dessus) avec `.*5.*7.*` (un 5 puis, plus loin, un 7). RE# accepte l'imbrication libre de `&` dans une meme chaine.\n",
+    "\n",
+    "# Etape 1\n",
+    "Definissez le pattern combine dans la cellule suivante. Une permutation comme `123456789` (5 avant 7) doit passer ; `987654321` (7 avant 5) doit echouer."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d8398862",
+   "id": "774c68f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:30:00.469512Z",
-     "iopub.status.busy": "2026-05-12T08:30:00.468947Z",
-     "iopub.status.idle": "2026-05-12T08:30:00.920127Z",
-     "shell.execute_reply": "2026-05-12T08:30:00.919940Z"
+     "iopub.execute_input": "2026-06-14T21:32:50.371754Z",
+     "iopub.status.busy": "2026-06-14T21:32:50.371581Z",
+     "iopub.status.idle": "2026-06-14T21:32:50.420218Z",
+     "shell.execute_reply": "2026-06-14T21:32:50.420085Z"
     },
     "papermill": {
-     "duration": 0.464579,
-     "end_time": "2026-05-12T08:30:00.920214+00:00",
+     "duration": 0.053217,
+     "end_time": "2026-06-14T21:32:50.420283+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:00.455635+00:00",
+     "start_time": "2026-06-14T21:32:50.367066+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1164,440 +863,124 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Operations Automata.Net (Version Démo) ===\r\n"
+      "Exercice a completer : 5 doit apparaitre avant 7.\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Operations disponibles :\r\n"
+      "  '123456789' (5 avant 7) -> valide attendu, obtenu : valide\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  - IntersectsWith(A, B) : Verifie si L(A) inter L(B) est non-vide\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ⚠️  NOTE : Ceci n'est PAS une procédure de décision correcte!\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     Une vraie implémentation construirait un automate produit explicite.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - AcceptsUnion(A, B, word) : Verifie si word in L(A) U L(B)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - FindNonMember(A, alphabet) : Trouve un mot hors de L(A)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
+      "  '987654321' (7 avant 5) -> rejet attendu,  obtenu : valide\r\n"
      ]
     }
    ],
    "source": [
-    "using System;\n",
-    "using System.Collections.Generic;\n",
-    "using System.Linq;\n",
-    "\n",
-    "/// <summary>\n",
-    "/// Extension operations for symbolic automata - Automata.Net style\n",
-    "/// </summary>\n",
-    "public static class AutomataOperations\n",
-    "{\n",
-    "    /// <summary>\n",
-    "    /// Intersection de deux automates : L(A) and L(B)\n",
-    "    /// Retourne true s'il existe au moins un mot accepte par les deux.\n",
-    "    ///\n",
-    "    /// NOTE IMPORTANTE : Ceci est une version DEMO pédagogique, PAS une procédure\n",
-    "    /// de décision correcte! Une vraie implémentation Automata.Net utiliserait:\n",
-    "    ///   - MkProduct pour construire un automate produit explicite\n",
-    "    ///   - Puis vérifier si l'automate produit accepte au moins un mot\n",
-    "    ///\n",
-    "    /// Ici, on teste simplement quelques mots candidats - suffisant pour la démo,\n",
-    "    /// mais pas correct pour une vraie décision \"intersection non-vide\".\n",
-    "    /// </summary>\n",
-    "    public static bool IntersectsWith(SymbolicFiniteAutomaton A, SymbolicFiniteAutomaton B)\n",
-    "    {\n",
-    "        // Approche naive : tester tous les mots jusqu'a une certaine longueur\n",
-    "        // Dans Automata.Net, cela utilise MkProduct pour construire un automate produit\n",
-    "        // puis verifie si le langage resultant est non-vide.\n",
-    "        \n",
-    "        // Pour notre demo, on teste quelques mots candidats\n",
-    "        var candidateWords = new[] {\n",
-    "            \"123456789\", \"111111111\", \"5\", \"555555555\", \"12345678\", \n",
-    "            \"1234567890\", \"123467899\", \"987654321\"\n",
-    "        };\n",
-    "        \n",
-    "        foreach (var word in candidateWords)\n",
-    "        {\n",
-    "            if (A.Accepts(word) && B.Accepts(word))\n",
-    "                return true;\n",
-    "        }\n",
-    "        \n",
-    "        return false;\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Union de deux automates : L(A) or L(B)\n",
-    "    /// Retourne true si le mot est accepte par A ou par B.\n",
-    "    /// </summary>\n",
-    "    public static bool AcceptsUnion(SymbolicFiniteAutomaton A, SymbolicFiniteAutomaton B, string word)\n",
-    "    {\n",
-    "        return A.Accepts(word) || B.Accepts(word);\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Complement : trouve un mot non accepte par A\n",
-    "    /// Retourne un mot qui n'est PAS dans L(A).\n",
-    "    /// </summary>\n",
-    "    public static string FindNonMember(SymbolicFiniteAutomaton A, string alphabet)\n",
-    "    {\n",
-    "        // Essayer des mots de plus en plus longs\n",
-    "        for (int len = 1; len <= 10; len++)\n",
-    "        {\n",
-    "            var words = GenerateWords(alphabet, len);\n",
-    "            foreach (var word in words)\n",
-    "            {\n",
-    "                if (!A.Accepts(word))\n",
-    "                    return word;\n",
-    "            }\n",
-    "        }\n",
-    "        return null; // A accepte tout (language universel)\n",
-    "    }\n",
-    "    \n",
-    "    private static IEnumerable<string> GenerateWords(string alphabet, int length)\n",
-    "    {\n",
-    "        if (length == 0)\n",
-    "        {\n",
-    "            yield return \"\";\n",
-    "            yield break;\n",
-    "        }\n",
-    "        \n",
-    "        // Version simplifiee - pour vrai cas, utiliser GenerateAllCombos\n",
-    "        foreach (var c in alphabet)\n",
-    "        {\n",
-    "            foreach (var tail in GenerateWords(alphabet, length - 1))\n",
-    "            {\n",
-    "                yield return c + tail;\n",
-    "            }\n",
-    "        }\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine(\"=== Operations Automata.Net (Version Démo) ===\");\n",
-    "Console.WriteLine(\"Operations disponibles :\");\n",
-    "Console.WriteLine(\"  - IntersectsWith(A, B) : Verifie si L(A) inter L(B) est non-vide\");\n",
-    "Console.WriteLine(\"  ⚠️  NOTE : Ceci n'est PAS une procédure de décision correcte!\");\n",
-    "Console.WriteLine(\"     Une vraie implémentation construirait un automate produit explicite.\");\n",
-    "Console.WriteLine(\"  - AcceptsUnion(A, B, word) : Verifie si word in L(A) U L(B)\");\n",
-    "Console.WriteLine(\"  - FindNonMember(A, alphabet) : Trouve un mot hors de L(A)\");\n",
-    "Console.WriteLine();\n"
+    "// EXERCICE : ligne Sudoku valide AVEC 5 avant 7 (intersection & ordre)\n",
+    "// TODO etudiant : completer le pattern ci-dessous.\n",
+    "// Indice : croisez la contrainte de ligne valide avec .*5.*7.* (5 avant 7).\n",
+    "string ligneAvec5Avant7 = \"[1-9]{9}\";  // TODO etudiant : completer l'intersection\n",
+    "var exoRe = new Resharp.Regex(ligneAvec5Avant7);\n",
+    "Console.WriteLine(\"Exercice a completer : 5 doit apparaitre avant 7.\");\n",
+    "Console.WriteLine($\"  '123456789' (5 avant 7) -> valide attendu, obtenu : {(exoRe.Matches(\"123456789\").Length > 0 ? \"valide\" : \"rejet\")}\");\n",
+    "Console.WriteLine($\"  '987654321' (7 avant 5) -> rejet attendu,  obtenu : {(exoRe.Matches(\"987654321\").Length > 0 ? \"valide\" : \"rejet\")}\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "43dbb14f",
+   "id": "edd4a220",
    "metadata": {
     "papermill": {
-     "duration": 0.012388,
-     "end_time": "2026-05-12T08:30:00.941734+00:00",
+     "duration": 0.003924,
+     "end_time": "2026-06-14T21:32:50.428247+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:00.929346+00:00",
+     "start_time": "2026-06-14T21:32:50.424323+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "## 6. Le resolveur - Z3 produit le temoin\n",
     "\n",
-    "## 4. Esprit Automata.Net en 10 minutes (15 min)\n",
+    "RE# sait *verifier* ; il ne sait pas *produire*. Pour resoudre un puzzle Sudoku, il faut un **resolveur**. C'est le role de Z3, et c'est le barreau 2 de 2020 - mais cette fois **sans le cap de 21 caracteres**, parce qu'on appelle Z3 **directement** (sans passer par le chemin SFAz3 de AutomataDotNet qui etait mure).\n",
     "\n",
-    "Dans cette section, nous decouvrons les operations fondamentales de la bibliotheque **Automata.Net** - operations qui rendent les automates symboliques si puissants. Meme sans utiliser la DLL, nous pouvons comprendre et implementer ces concepts.\n",
+    "L'idee : encoder les contraintes `Ligne & Colonne & Bloc` non plus comme un regex symbolique, mais comme des **assertions SMT** sur 81 variables entieres, puis demander a Z3 un **modele = la grille solution**.\n",
     "\n",
-    "### 4.1 Operations Fondamentales sur Automates\n",
-    "\n",
-    "Les automates symboliques supportent des operations d'algebre de langages :\n",
-    "\n",
-    "| Operation | Symbole | Signification | Exemple Automata.Net |\n",
-    "|-----------|----------|---------------|----------------------|\n",
-    "| **Union** | $L(A) \\cup L(B)$ | Strings acceptes par A OU B | `A.Union(B)` |\n",
-    "| **Intersection** | $L(A) \\cap L(B)$ | Strings acceptes par A ET B | `A.Intersect(B)` |\n",
-    "| **Complement** | $\\Sigma^* \\setminus L(A)$ | Strings NON acceptes par A | `A.Complement()` |\n",
-    "| **Produit** | $L(A \\times B)$ | Equivalent a l'intersection | `A.Product(B)` |\n",
-    "| **Difference** | $L(A) \\setminus L(B)$ | Dans A mais pas dans B | `A.Minus(B)` |\n",
-    "\n",
-    "### 4.2 Exemple Concret : Mots de 9 Chiffres\n",
-    "\n",
-    "Construisons deux automates pour illustrer ces operations :\n",
-    "\n",
-    "**Automate A** : Accepte les chaînes de exactement 9 chiffres (1-9)\n",
-    "**Automate B** : Accepte les chaînes contenant au moins un '5'\n",
-    "\n",
-    "```csharp\n",
-    "// Automate A : exactement 9 chiffres Sudoku\n",
-    "var A = new SymbolicFiniteAutomaton(\"Exactly9Digits\");\n",
-    "// ... etats q0...q9, transitions [1-9] ...\n",
-    "\n",
-    "// Automate B : contient au moins un '5'\n",
-    "var B = new SymbolicFiniteAutomaton(\"Contains5\");\n",
-    "// ... structure plus complexe avec etat de memoire ...\n",
-    "```\n",
-    "\n",
-    "**Operations que nous pouvons effectuer** :\n",
-    "\n",
-    "1. **Intersection** $A \\cap B$ : Chaînes de 9 chiffres qui contiennent un '5'\n",
-    "2. **Complement** $\\neg A$ : Toutes les chaînes SAUF celles de 9 chiffres\n",
-    "3. **Union** $A \\cup B$ : Chaînes de 9 chiffres OU contenant un '5'\n",
-    "\n",
-    "### 4.3 Implementation des Operations Automata\n",
-    "\n",
-    "Etendons notre classe avec les operations fondamentales :\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "71c646e5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.02011,
-     "end_time": "2026-05-12T08:30:00.975090+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:00.954980+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## 5. Compilation vers SMT - Sudoku Complet (25 min)\n",
-    "\n",
-    "> **⚠️ Approche pragmatique** : Dans cette section, nous compilons les contraintes d'automates symboliques vers un solveur SMT (Z3). C'est l'approche utilisee par Automata.Net en production pour des problemes avec contraintes arithmetiques.\n",
-    "\n",
-    "Pour resoudre un Sudoku complet, nous devons combiner les contraintes de :\n",
-    "- 9 lignes (distinctes)\n",
-    "- 9 colonnes (distinctes)\n",
-    "- 9 blocs 3x3 (distincts)\n",
-    "\n",
-    "### 5.1 Du Produit d'Automates aux Contraintes SMT\n",
-    "\n",
-    "**Theorie** : Le produit d'automates $A_1 \\times A_2$ accepte l'intersection $L(A_1) \\cap L(A_2)$.\n",
-    "\n",
-    "**Pratique (Automata.Net)** : Au lieu de construire explicitement un automate produit avec $|Q_1| \\times |Q_2|$ etats, la bibliotheque compile les operations vers :\n",
-    "- **BDD** (Binary Decision Diagrams) pour les predicats de caracteres\n",
-    "- **Z3** pour les contraintes arithmetiques complexes\n",
-    "\n",
-    "**Notre approche** : Nous utilisons directement Z3 comme backend, ce qui donne :\n",
-    "\n",
-    "| Aspect | Produit explicite | Compilation vers Z3 (notre approche) |\n",
-    "|--------|------------------|----------------------------------|\n",
-    "| **Construction** | $(q_1, q_2) \\to (q'_1, q'_2)$ | Conjonction de contraintes `Distinct` |\n",
-    "| **Verification** | Parcours d'automate | SAT solving |\n",
-    "| **Avantage** | Theoriquement elegant | Pratique et performant |\n",
-    "\n",
-    "### 5.2 Encodage des Contraintes Sudoku en SMT\n",
-    "\n",
-    "Traduisons chaque contrainte Sudoku en formule Z3 :\n",
-    "\n",
-    "| Contrainte | Theorie automata | Encodage Z3 |\n",
-    "|-----------|-----------------|-------------|\n",
-    "| **Ligne i** | Automate $A_{row_i}$ | `Distinct(x_i0, ..., x_i8)` |\n",
-    "| **Colonne j** | Automate $A_{col_j}$ | `Distinct(x_0j, ..., x_8j)` |\n",
-    "| **Bloc b** | Automate $A_{block_b}$ | `Distinct` des 9 cellules du bloc |\n",
-    "| **Intersection** | $A_{sudoku} = \\bigcap_{k=1}^{27} A_k$ | Conjonction de tous les `Distinct` |\n",
-    "\n",
-    "**Note** : L'encodage direct en Z3 elimine le besoin de construire explicitement 27 automates. C'est exactement ce que fait Automata.Net en interne via sa classe `CharSetSolver`.\n"
+    "> **Note technique** : comme pour RE#, on charge Z3 via reference DLL directe + un `NativeLibrary.SetDllImportResolver` pour la librairie native `libz3.dll` (le `#r \"nuget:\"` se bloquerait sous papermill)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e827c4b0",
+   "id": "5a7a038b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:30:01.004359Z",
-     "iopub.status.busy": "2026-05-12T08:30:01.004041Z",
-     "iopub.status.idle": "2026-05-12T08:30:03.125445Z",
-     "shell.execute_reply": "2026-05-12T08:30:03.125110Z"
+     "iopub.execute_input": "2026-06-14T21:32:50.436424Z",
+     "iopub.status.busy": "2026-06-14T21:32:50.436241Z",
+     "iopub.status.idle": "2026-06-14T21:32:50.590939Z",
+     "shell.execute_reply": "2026-06-14T21:32:50.590814Z"
     },
     "papermill": {
-     "duration": 2.135029,
-     "end_time": "2026-05-12T08:30:03.125579+00:00",
+     "duration": 0.159248,
+     "end_time": "2026-06-14T21:32:50.591001+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:00.990550+00:00",
+     "start_time": "2026-06-14T21:32:50.431753+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.Z3, 4.12.2</span></li></ul></div></div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 charge avec succes.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Note Importante ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dans cette section, nous utilisons Z3 comme backend pour\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "la compilation de contraintes d'automates symboliques.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "C'est l'approche pragmatique adoptee par Automata.Net.\r\n"
+      "Z3 charge (native libz3 resolue).\r\n"
      ]
     }
    ],
    "source": [
-    "// Charger Z3 depuis Sudoku-0 si disponible\n",
-    "#r \"nuget:Microsoft.Z3,*\"\n",
-    "\n",
+    "// Z3 via reference DLL + resolver natif (libz3.dll), pas de #r \"nuget:\" sous papermill.\n",
+    "#r \"C:/Users/jsboi/.nuget/packages/microsoft.z3/4.12.2/lib/netstandard2.0/Microsoft.Z3.dll\"\n",
     "using Microsoft.Z3;\n",
-    "using System;\n",
-    "using System.Collections.Generic;\n",
-    "using System.Linq;\n",
+    "using System.Runtime.InteropServices;\n",
     "\n",
-    "Console.WriteLine(\"Z3 charge avec succes.\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"=== Note Importante ===\");\n",
-    "Console.WriteLine(\"Dans cette section, nous utilisons Z3 comme backend pour\");\n",
-    "Console.WriteLine(\"la compilation de contraintes d'automates symboliques.\");\n",
-    "Console.WriteLine(\"C'est l'approche pragmatique adoptee par Automata.Net.\");\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "821b79e8",
-   "metadata": {
-    "papermill": {
-     "duration": 0.030311,
-     "end_time": "2026-05-12T08:30:03.170647+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:03.140336+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### 5.3 Automate Symbolique pour Ligne Sudoku avec Z3\n",
-    "\n",
-    "Nous allons creer une classe qui combine :\n",
-    "- La structure d'automate symbolique (etats, transitions)\n",
-    "- La puissance de Z3 pour representer les predicats et verifier la distinctivite\n",
-    "\n",
-    "**Note importante** : Cette classe n'est pas un \"vrai\" automate symbolique avec des etats explicites. C'est une **compilation** vers Z3 qui capture l'essence de la contrainte de ligne (valeurs distinctes).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Exercice : Verifier une ligne Sudoku avec un automate\n",
-    "\n",
-    "# Objectif\n",
-    "Construisez un automate symbolique qui verifie qu'une sequence de 9 chiffres\n",
-    "forme une ligne Sudoku valide (pas de doublon, valeurs entre 1 et 9).\n",
-    "\n",
-    "# Indice\n",
-    "Utilisez l'automate pour valider que chaque valeur apparait exactement une fois.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
-    }
-   ],
-   "source": [
-    "// EXERCICE : Verifier une ligne Sudoku avec un automate\n",
-    "public bool ValidateSudokuLineWithAutomaton(int[] line)\n",
-    "{\n",
-    "    // TODO: Construisez un automate symbolique qui accepte uniquement\n",
-    "    // les permutations valides des chiffres 1-9 et testez la ligne\n",
-    "    return false; // TODO etudiant\n",
-    "}\n"
+    "// Z3 est une librairie native (libz3.dll) ; sans le restore nuget, on pointe le resolver dessus.\n",
+    "NativeLibrary.SetDllImportResolver(typeof(Context).Assembly, (name, assembly, path) => {\n",
+    "    if (name == \"libz3\") {\n",
+    "        string[] cands = {\n",
+    "            \"C:/Users/jsboi/.nuget/packages/microsoft.z3/4.12.2/runtimes/win-x64/native/libz3.dll\",\n",
+    "            \"C:/Users/jsboi/.nuget/packages/microsoft.z3/4.12.2/runtimes/win-x86/native/libz3.dll\"\n",
+    "        };\n",
+    "        foreach (var c in cands) if (System.IO.File.Exists(c) && NativeLibrary.TryLoad(c, out IntPtr h)) return h;\n",
+    "    }\n",
+    "    return IntPtr.Zero;\n",
+    "});\n",
+    "var ctx = new Context();\n",
+    "Console.WriteLine(\"Z3 charge (native libz3 resolue).\");"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "6a96346c",
+   "id": "53fcffb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:30:03.246873Z",
-     "iopub.status.busy": "2026-05-12T08:30:03.240948Z",
-     "iopub.status.idle": "2026-05-12T08:30:03.378255Z",
-     "shell.execute_reply": "2026-05-12T08:30:03.378069Z"
+     "iopub.execute_input": "2026-06-14T21:32:50.599585Z",
+     "iopub.status.busy": "2026-06-14T21:32:50.599419Z",
+     "iopub.status.idle": "2026-06-14T21:32:50.823388Z",
+     "shell.execute_reply": "2026-06-14T21:32:50.807467Z"
     },
     "papermill": {
-     "duration": 0.186999,
-     "end_time": "2026-05-12T08:30:03.378342+00:00",
+     "duration": 0.228742,
+     "end_time": "2026-06-14T21:32:50.823454+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:03.191343+00:00",
+     "start_time": "2026-06-14T21:32:50.594712+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1607,832 +990,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Classe SudokuRowAutomaton definie avec succes.\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "using Microsoft.Z3;\n",
-    "/// <summary>\n",
-    "/// Automate symbolique pour une ligne de Sudoku avec verification de distinctivite via Z3.\n",
-    "/// </summary>\n",
-    "public class SudokuRowAutomaton\n",
-    "{\n",
-    "    private Context _ctx;\n",
-    "    private Solver _solver;\n",
-    "    private IntExpr[] _cells;\n",
-    "    private int _rowIndex;\n",
-    "    \n",
-    "    public int RowIndex => _rowIndex;\n",
-    "    \n",
-    "    public SudokuRowAutomaton(int rowIndex)\n",
-    "    {\n",
-    "        _rowIndex = rowIndex;\n",
-    "        _ctx = new Context();\n",
-    "        _solver = _ctx.MkSolver();\n",
-    "        \n",
-    "        // Creer les variables pour les 9 cellules de la ligne\n",
-    "        _cells = new IntExpr[9];\n",
-    "        for (int j = 0; j < 9; j++)\n",
-    "        {\n",
-    "            _cells[j] = _ctx.MkIntConst($\"x_{rowIndex}_{j}\");\n",
-    "        }\n",
-    "        \n",
-    "        // Ajouter la contrainte de distinctivite\n",
-    "        _solver.Add(_ctx.MkDistinct(_cells));\n",
-    "        \n",
-    "        // Ajouter les contraintes de domaine [1, 9]\n",
-    "        foreach (var cell in _cells)\n",
-    "        {\n",
-    "            _solver.Add(_ctx.MkAnd(\n",
-    "                _ctx.MkGe(cell, _ctx.MkInt(1)),\n",
-    "                _ctx.MkLe(cell, _ctx.MkInt(9))\n",
-    "            ));\n",
-    "        }\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Verifie si une sequence de 9 valeurs est acceptee par cet automate.\n",
-    "    /// </summary>\n",
-    "    public bool Accepts(int[] values)\n",
-    "    {\n",
-    "        if (values.Length != 9)\n",
-    "            throw new ArgumentException(\"Une ligne Sudoku doit contenir exactement 9 valeurs\");\n",
-    "        \n",
-    "        // Creer un solver temporaire pour cette verification\n",
-    "        var testSolver = _ctx.MkSolver();\n",
-    "        \n",
-    "        // Ajouter la contrainte de distinctivite\n",
-    "        testSolver.Add(_ctx.MkDistinct(_cells));\n",
-    "        \n",
-    "        // Ajouter les contraintes de domaine\n",
-    "        foreach (var cell in _cells)\n",
-    "        {\n",
-    "            testSolver.Add(_ctx.MkGe(cell, _ctx.MkInt(1)));\n",
-    "            testSolver.Add(_ctx.MkLe(cell, _ctx.MkInt(9)));\n",
-    "        }\n",
-    "        \n",
-    "        // Ajouter les valeurs specifiques a tester\n",
-    "        for (int j = 0; j < 9; j++)\n",
-    "        {\n",
-    "            testSolver.Add(_ctx.MkEq(_cells[j], _ctx.MkInt(values[j])));\n",
-    "        }\n",
-    "        \n",
-    "        // Verifier la satisfiabilite\n",
-    "        Status result = testSolver.Check();\n",
-    "        return result == Status.SATISFIABLE;\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Retourne une modele (une instance valide) de la ligne.\n",
-    "    /// </summary>\n",
-    "    public int[] GetModel()\n",
-    "    {\n",
-    "        Status status = _solver.Check();\n",
-    "        if (status != Status.SATISFIABLE)\n",
-    "            return null;\n",
-    "        \n",
-    "        Model model = _solver.Model;  // FIX: Model is a property, not a method\n",
-    "        int[] values = new int[9];\n",
-    "        \n",
-    "        for (int j = 0; j < 9; j++)\n",
-    "        {\n",
-    "            Expr eval = model.Evaluate(_cells[j]);\n",
-    "            values[j] = ((IntNum)eval).Int;\n",
-    "        }\n",
-    "        \n",
-    "        return values;\n",
-    "    }\n",
-    "    \n",
-    "    public override string ToString() => $\"SudokuRowAutomaton(Row={_rowIndex})\";\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine(\"Classe SudokuRowAutomaton definie avec succes.\");\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3536dcc5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007061,
-     "end_time": "2026-05-12T08:30:03.392677+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:03.385616+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### 5.4 Tests de l'Automate de Ligne\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "4be88fc4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-12T08:30:03.410359Z",
-     "iopub.status.busy": "2026-05-12T08:30:03.409791Z",
-     "iopub.status.idle": "2026-05-12T08:30:03.774755Z",
-     "shell.execute_reply": "2026-05-12T08:30:03.774474Z"
-    },
-    "papermill": {
-     "duration": 0.378061,
-     "end_time": "2026-05-12T08:30:03.774880+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:03.396819+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Automate de Ligne Sudoku ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SudokuRowAutomaton(Row=0)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Z3 a produit un temoin (grille solution) en 27 ms.\n",
       "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Test 1 : Sequence valide (permutation de 1-9)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Sequence : [1, 2, 3, 4, 5, 6, 7, 8, 9]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Acceptee? True\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Attendu : True (toutes les valeurs sont distinctes)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Test 2 : Sequence invalide (doublon de 1)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Sequence : [1, 1, 3, 4, 5, 6, 7, 8, 9]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Acceptee? False\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Attendu : False (la valeur 1 apparait deux fois)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Test 3 : Sequence avec valeur hors domaine\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Sequence : [1, 2, 3, 4, 5, 6, 7, 8, 10]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Acceptee? False\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Attendu : False (10 n'est pas dans [1, 9])\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generation d'un modele valide :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Instance genere : [1, 2, 3, 4, 5, 6, 7, 8, 9]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Verification : True\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "// Creer un automate pour la ligne 0\n",
-    "var rowAuto = new SudokuRowAutomaton(0);\n",
-    "\n",
-    "Console.WriteLine(\"=== Automate de Ligne Sudoku ===\");\n",
-    "Console.WriteLine(rowAuto);\n",
-    "Console.WriteLine();\n",
-    "\n",
-    "// Test 1 : Sequence valide (permutation de 1-9)\n",
-    "Console.WriteLine(\"Test 1 : Sequence valide (permutation de 1-9)\");\n",
-    "int[] validRow = {1, 2, 3, 4, 5, 6, 7, 8, 9};\n",
-    "bool result1 = rowAuto.Accepts(validRow);\n",
-    "Console.WriteLine($\"  Sequence : [{string.Join(\", \", validRow)}]\");\n",
-    "Console.WriteLine($\"  Acceptee? {result1}\");\n",
-    "Console.WriteLine($\"  Attendu : True (toutes les valeurs sont distinctes)\");\n",
-    "Console.WriteLine();\n",
-    "\n",
-    "// Test 2 : Sequence invalide (doublon)\n",
-    "Console.WriteLine(\"Test 2 : Sequence invalide (doublon de 1)\");\n",
-    "int[] invalidRow = {1, 1, 3, 4, 5, 6, 7, 8, 9};\n",
-    "bool result2 = rowAuto.Accepts(invalidRow);\n",
-    "Console.WriteLine($\"  Sequence : [{string.Join(\", \", invalidRow)}]\");\n",
-    "Console.WriteLine($\"  Acceptee? {result2}\");\n",
-    "Console.WriteLine($\"  Attendu : False (la valeur 1 apparait deux fois)\");\n",
-    "Console.WriteLine();\n",
-    "\n",
-    "// Test 3 : Sequence avec valeur hors domaine\n",
-    "Console.WriteLine(\"Test 3 : Sequence avec valeur hors domaine\");\n",
-    "int[] outOfRangeRow = {1, 2, 3, 4, 5, 6, 7, 8, 10};\n",
-    "bool result3 = rowAuto.Accepts(outOfRangeRow);\n",
-    "Console.WriteLine($\"  Sequence : [{string.Join(\", \", outOfRangeRow)}]\");\n",
-    "Console.WriteLine($\"  Acceptee? {result3}\");\n",
-    "Console.WriteLine($\"  Attendu : False (10 n'est pas dans [1, 9])\");\n",
-    "Console.WriteLine();\n",
-    "\n",
-    "// Obtenir un modele valide\n",
-    "Console.WriteLine(\"Generation d'un modele valide :\");\n",
-    "int[] model = rowAuto.GetModel();\n",
-    "if (model != null)\n",
-    "{\n",
-    "    Console.WriteLine($\"  Instance genere : [{string.Join(\", \", model)}]\");\n",
-    "    Console.WriteLine($\"  Verification : {rowAuto.Accepts(model)}\");\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "139d0a2d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.014408,
-     "end_time": "2026-05-12T08:30:03.808430+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:03.794022+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### Interpretation : Tests de l'Automate de Ligne\n",
-    "\n",
-    "**Sortie obtenue** : L'automate de ligne verifie correctement la contrainte de distinctivite.\n",
-    "\n",
-    "| Test | Sequence | Resultat | Attendu | Validation |\n",
-    "|------|----------|----------|----------|------------|\n",
-    "| 1 | [1,2,3,4,5,6,7,8,9] | True | True | Permutation valide |\n",
-    "| 2 | [1,1,3,4,5,6,7,8,9] | False | False | Doublon de 1 |\n",
-    "| 3 | [1,2,3,4,5,6,7,8,10] | False | False | Valeur 10 hors domaine |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. La contrainte `Distinct` de Z3 garantit que toutes les valeurs sont differentes\n",
-    "2. Les contraintes de domaine garantissent que chaque valeur est dans [1, 9]\n",
-    "3. Le solver peut generer automatiquement des instances valides\n",
-    "\n",
-    "**Comparaison avec automate classique** :\n",
-    "| Aspect | Automate classique | Automate symbolique (Z3) |\n",
-    "|--------|-------------------|--------------------------|\n",
-    "| **Nombre d'etats** | $9! = 362880$ | 1 (represente symboliquement) |\n",
-    "| **Transitions** | Millions | Predicats logiques |\n",
-    "| **Verification** | Traverser l'automate | SAT solving |\n",
-    "\n",
-    "> **Note theorique** : C'est ici que se situe la difference clef entre un \"vrai\" automate symbolique et l'utilisation simple de Z3. Dans un vrai SFA, nous avons :\n",
-    "> - Des etats representant differentes phases du traitement\n",
-    "> - Des transitions symboliques entre ces etats\n",
-    "> - Z3 est utilise pour verifier si un mot est accepte en satisfaisant les predicats"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "a0904481",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-12T08:30:03.830247Z",
-     "iopub.status.busy": "2026-05-12T08:30:03.829901Z",
-     "iopub.status.idle": "2026-05-12T08:30:04.088126Z",
-     "shell.execute_reply": "2026-05-12T08:30:04.087294Z"
-    },
-    "papermill": {
-     "duration": 0.268499,
-     "end_time": "2026-05-12T08:30:04.088451+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:03.819952+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Classe SudokuSymbolicAutomaton definie avec succes.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Compilation Automates -> SMT ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Automates de ligne -> Distinct(row_i)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Automates de colonne -> Distinct(col_j)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Automates de bloc 3x3 -> Distinct(block_b)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Produit d'automates -> Conjonction des contraintes\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "C'est exactement ce que fait Automata.Net en interne!\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "using Microsoft.Z3;\n",
-    "/// <summary>\n",
-    "/// Solveur SMT compile pour Sudoku avec toutes les contraintes.\n",
-    "/// \n",
-    "/// Cette classe demontre la compilation de concepts d'automates symboliques\n",
-    "/// vers des contraintes SMT (Z3). Chaque \"automate\" de ligne/colonne/bloc\n",
-    "/// est compile en une contrainte Distinct, et leur \"produit\" devient une\n",
-    "/// simple conjonction de ces contraintes.\n",
-    "/// \n",
-    "/// C'est l'approche utilisee par Automata.Net en production pour des problemes\n",
-    "/// avec contraintes arithmetiques.\n",
-    "/// </summary>\n",
-    "public class SudokuSymbolicAutomaton\n",
-    "{\n",
-    "    private Context _ctx;\n",
-    "    private Solver _solver;\n",
-    "    private IntExpr[,] _cells;\n",
-    "    \n",
-    "    public SudokuSymbolicAutomaton()\n",
-    "    {\n",
-    "        _ctx = new Context();\n",
-    "        _solver = _ctx.MkSolver();\n",
-    "        \n",
-    "        // Creer les variables pour les 81 cellules\n",
-    "        _cells = new IntExpr[9, 9];\n",
-    "        for (int i = 0; i < 9; i++)\n",
-    "        {\n",
-    "            for (int j = 0; j < 9; j++)\n",
-    "            {\n",
-    "                _cells[i, j] = _ctx.MkIntConst($\"x_{i}_{j}\");\n",
-    "            }\n",
-    "        }\n",
-    "        \n",
-    "        // Construire toutes les contraintes Sudoku (compilation d'automates vers SMT)\n",
-    "        BuildRowConstraints();\n",
-    "        BuildColumnConstraints();\n",
-    "        BuildBlockConstraints();\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Compile les 9 automates de ligne vers des contraintes SMT.\n",
-    "    /// Chaque automate \"une ligne avec valeurs distinctes\" devient : Distinct(row).\n",
-    "    /// </summary>\n",
-    "    private void BuildRowConstraints()\n",
-    "    {\n",
-    "        for (int i = 0; i < 9; i++)\n",
-    "        {\n",
-    "            var row = new IntExpr[9];\n",
-    "            for (int j = 0; j < 9; j++)\n",
-    "                row[j] = _cells[i, j];\n",
-    "            \n",
-    "            _solver.Add(_ctx.MkDistinct(row));\n",
-    "            \n",
-    "            // Contraintes de domaine (une seule fois)\n",
-    "            foreach (var cell in row)\n",
-    "            {\n",
-    "                _solver.Add(_ctx.MkGe(cell, _ctx.MkInt(1)));\n",
-    "                _solver.Add(_ctx.MkLe(cell, _ctx.MkInt(9)));\n",
-    "            }\n",
-    "        }\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Compile les 9 automates de colonne vers des contraintes SMT.\n",
-    "    /// </summary>\n",
-    "    private void BuildColumnConstraints()\n",
-    "    {\n",
-    "        for (int j = 0; j < 9; j++)\n",
-    "        {\n",
-    "            var col = new IntExpr[9];\n",
-    "            for (int i = 0; i < 9; i++)\n",
-    "                col[i] = _cells[i, j];\n",
-    "            \n",
-    "            _solver.Add(_ctx.MkDistinct(col));\n",
-    "        }\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Compile les 9 automates de bloc 3x3 vers des contraintes SMT.\n",
-    "    /// </summary>\n",
-    "    private void BuildBlockConstraints()\n",
-    "    {\n",
-    "        for (int blockRow = 0; blockRow < 3; blockRow++)\n",
-    "        {\n",
-    "            for (int blockCol = 0; blockCol < 3; blockCol++)\n",
-    "            {\n",
-    "                var block = new IntExpr[9];\n",
-    "                int idx = 0;\n",
-    "                for (int i = 0; i < 3; i++)\n",
-    "                {\n",
-    "                    for (int j = 0; j < 3; j++)\n",
-    "                    {\n",
-    "                        block[idx++] = _cells[3 * blockRow + i, 3 * blockCol + j];\n",
-    "                    }\n",
-    "                }\n",
-    "                _solver.Add(_ctx.MkDistinct(block));\n",
-    "            }\n",
-    "        }\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Ajoute une contrainte de valeur (compile une transition de l'automate).\n",
-    "    /// </summary>\n",
-    "    public void SetCell(int row, int col, int value)\n",
-    "    {\n",
-    "        if (row < 0 || row >= 9 || col < 0 || col >= 9)\n",
-    "            throw new ArgumentException(\"Position invalide\");\n",
-    "        if (value < 1 || value > 9)\n",
-    "            throw new ArgumentException(\"La valeur doit etre entre 1 et 9\");\n",
-    "        \n",
-    "        _solver.Add(_ctx.MkEq(_cells[row, col], _ctx.MkInt(value)));\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Cherche une solution complete (etat accepteur du produit d'automates).\n",
-    "    /// </summary>\n",
-    "    public int[,] Solve()\n",
-    "    {\n",
-    "        Status status = _solver.Check();\n",
-    "        \n",
-    "        if (status != Status.SATISFIABLE)\n",
-    "        {\n",
-    "            Console.WriteLine($\"Aucune solution trouve (status: {status})\");\n",
-    "            return null;\n",
-    "        }\n",
-    "        \n",
-    "        Model model = _solver.Model;  // FIX: Model is a property, not a method\n",
-    "        int[,] solution = new int[9, 9];\n",
-    "        \n",
-    "        for (int i = 0; i < 9; i++)\n",
-    "        {\n",
-    "            for (int j = 0; j < 9; j++)\n",
-    "            {\n",
-    "                Expr eval = model.Evaluate(_cells[i, j]);\n",
-    "                solution[i, j] = ((IntNum)eval).Int;\n",
-    "            }\n",
-    "        }\n",
-    "        \n",
-    "        return solution;\n",
-    "    }\n",
-    "    \n",
-    "    /// <summary>\n",
-    "    /// Compte le nombre de solutions (jusqu'a maxSolutions).\n",
-    "    /// </summary>\n",
-    "    public int CountSolutions(int maxSolutions = 10)\n",
-    "    {\n",
-    "        int count = 0;\n",
-    "        \n",
-    "        for (int k = 0; k < maxSolutions; k++)\n",
-    "        {\n",
-    "            int[,] solution = Solve();\n",
-    "            if (solution == null)\n",
-    "                break;\n",
-    "            \n",
-    "            count++;\n",
-    "            \n",
-    "            // Ajouter une contrainte pour eviter de retrouver la meme solution\n",
-    "            var exclusionClause = new BoolExpr[81];\n",
-    "            int idx = 0;\n",
-    "            for (int i = 0; i < 9; i++)\n",
-    "            {\n",
-    "                for (int j = 0; j < 9; j++)\n",
-    "                {\n",
-    "                    exclusionClause[idx++] = _ctx.MkNot(\n",
-    "                        _ctx.MkEq(_cells[i, j], _ctx.MkInt(solution[i, j]))\n",
-    "                    );\n",
-    "                }\n",
-    "            }\n",
-    "            _solver.Add(_ctx.MkOr(exclusionClause));\n",
-    "        }\n",
-    "        \n",
-    "        return count;\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine(\"Classe SudokuSymbolicAutomaton definie avec succes.\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"=== Compilation Automates -> SMT ===\");\n",
-    "Console.WriteLine(\"  Automates de ligne -> Distinct(row_i)\");\n",
-    "Console.WriteLine(\"  Automates de colonne -> Distinct(col_j)\");\n",
-    "Console.WriteLine(\"  Automates de bloc 3x3 -> Distinct(block_b)\");\n",
-    "Console.WriteLine(\"  Produit d'automates -> Conjonction des contraintes\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"C'est exactement ce que fait Automata.Net en interne!\");\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7ebf8ce4",
-   "metadata": {
-    "papermill": {
-     "duration": 0.019958,
-     "end_time": "2026-05-12T08:30:04.135944+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:04.115986+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### 6.2 Exemple de Resolution\n",
-    "\n",
-    "Utilisons notre automate symbolique pour resoudre un puzzle Sudoku.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "4245126c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-12T08:30:04.172863Z",
-     "iopub.status.busy": "2026-05-12T08:30:04.172387Z",
-     "iopub.status.idle": "2026-05-12T08:30:04.415088Z",
-     "shell.execute_reply": "2026-05-12T08:30:04.362064Z"
-    },
-    "papermill": {
-     "duration": 0.257108,
-     "end_time": "2026-05-12T08:30:04.415223+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:04.158115+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Puzzle Sudoku Facile ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-------+-------+-------\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
      ]
     },
     {
@@ -2446,91 +1005,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
+      "3 "
      ]
     },
     {
@@ -2544,14 +1019,56 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
+      "| "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
+      "6 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 "
      ]
     },
     {
@@ -2565,28 +1082,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-------+-------+-------\r\n"
+      "6 "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
+      "7 "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8 "
+      "2 "
      ]
     },
     {
@@ -2607,280 +1117,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "9 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-------+-------+-------\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
      ]
     },
     {
@@ -2894,63 +1131,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
      ]
     },
     {
@@ -2964,28 +1145,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "| "
+      "4 "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9 "
+      "8 "
      ]
     },
     {
@@ -2993,41 +1160,6 @@
      "output_type": "stream",
      "text": [
       "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". "
      ]
     },
     {
@@ -3041,7 +1173,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
+      "9 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 "
      ]
     },
     {
@@ -3062,28 +1201,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
+      "4 "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". "
+      "2 "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n"
+      "| "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-------+-------+-------\r\n"
+      "5 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7 "
      ]
     },
     {
@@ -3091,21 +1244,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solution trouve en 37,36 ms :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-------+-------+-------\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4 "
+      "------+-------+------\r\n"
      ]
     },
     {
@@ -3119,343 +1258,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "5 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-------+-------+-------\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
      ]
     },
     {
@@ -3476,90 +1279,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "7 "
      ]
     },
@@ -3567,14 +1286,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "9 "
+      "6 "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "8 "
+      "1 "
      ]
     },
     {
@@ -3588,13 +1307,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "4 "
      ]
     },
@@ -3602,21 +1314,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-------+-------+-------\r\n"
+      "2 "
      ]
     },
     {
@@ -3630,7 +1328,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7 "
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 "
      ]
     },
     {
@@ -3638,13 +1343,6 @@
      "output_type": "stream",
      "text": [
       "2 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
      ]
     },
     {
@@ -3658,20 +1356,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "| "
      ]
     },
@@ -3679,63 +1363,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
      ]
     },
     {
@@ -3770,14 +1398,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6 "
+      "9 "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "9 "
+      "1 "
      ]
     },
     {
@@ -3791,7 +1419,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6 "
+      "7 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| "
      ]
     },
     {
@@ -3805,7 +1454,155 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "2 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "5 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "------+-------+------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7 "
      ]
     },
     {
@@ -3833,7 +1630,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7 "
+      "9 "
      ]
     },
     {
@@ -3847,6 +1644,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "6 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "3 "
      ]
     },
@@ -3854,14 +1658,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "8 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 "
+      "5 "
      ]
     },
     {
@@ -3875,711 +1672,229 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-------+-------+-------\r\n"
+      "3 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
      ]
     }
    ],
    "source": [
-    "using System;\n",
+    "// Encode un Sudoku 9x9 comme un probleme SMT : 81 entiers 1..9 + contraintes\n",
+    "// Ligne & Colonne & Bloc (Distinct), puis fixe les cases du puzzle et demande un modele.\n",
+    "// Le modele = la grille solution (le TEMOIN).\n",
     "using System.Diagnostics;\n",
     "\n",
-    "// Fonction pour afficher une grille\n",
-    "void DisplayGrid(int[,] grid)\n",
+    "static int[,] ResoudreSudokuZ3(Context ctx, int[,] puzzle, out long ms)\n",
     "{\n",
-    "    Console.WriteLine(\"-------+-------+-------\");\n",
-    "    for (int i = 0; i < 9; i++)\n",
-    "    {\n",
-    "        if (i > 0 && i % 3 == 0)\n",
-    "            Console.WriteLine(\"-------+-------+-------\");\n",
-    "        \n",
-    "        for (int j = 0; j < 9; j++)\n",
-    "        {\n",
-    "            if (j > 0 && j % 3 == 0)\n",
-    "                Console.Write(\"| \");\n",
-    "            \n",
-    "            int val = grid[i, j];\n",
-    "            Console.Write(val == 0 ? \". \" : $\"{val} \");\n",
-    "        }\n",
-    "        Console.WriteLine();\n",
+    "    var cells = new IntExpr[9, 9];\n",
+    "    for (int r = 0; r < 9; r++)\n",
+    "        for (int c = 0; c < 9; c++)\n",
+    "            cells[r, c] = ctx.MkIntConst($\"c{r}{c}\");\n",
+    "\n",
+    "    var s = ctx.MkSolver();\n",
+    "    // 1. domaine 1..9 pour chaque case\n",
+    "    for (int r = 0; r < 9; r++)\n",
+    "        for (int c = 0; c < 9; c++)\n",
+    "            s.Add(ctx.MkAnd(ctx.MkGe(cells[r, c], ctx.MkInt(1)), ctx.MkLe(cells[r, c], ctx.MkInt(9))));\n",
+    "    // 2. contrainte de LIGNE : tous distincts (== \"intersection contient 1..9\")\n",
+    "    for (int r = 0; r < 9; r++) {\n",
+    "        var row = new IntExpr[9];\n",
+    "        for (int c = 0; c < 9; c++) row[c] = cells[r, c];\n",
+    "        s.Add(ctx.MkDistinct(row));\n",
     "    }\n",
-    "    Console.WriteLine(\"-------+-------+-------\");\n",
-    "}\n",
-    "\n",
-    "// Puzzle facile (exemple classique)\n",
-    "int[,] ParsePuzzle(string puzzle)\n",
-    "{\n",
-    "    int[,] grid = new int[9, 9];\n",
-    "    int idx = 0;\n",
-    "    foreach (char c in puzzle.Replace(\".\", \"0\"))\n",
-    "    {\n",
-    "        if (char.IsDigit(c))\n",
-    "        {\n",
-    "            grid[idx / 9, idx % 9] = c - '0';\n",
-    "            idx++;\n",
-    "        }\n",
+    "    // 3. contrainte de COLONNE : tous distincts\n",
+    "    for (int c = 0; c < 9; c++) {\n",
+    "        var col = new IntExpr[9];\n",
+    "        for (int r = 0; r < 9; r++) col[r] = cells[r, c];\n",
+    "        s.Add(ctx.MkDistinct(col));\n",
     "    }\n",
-    "    return grid;\n",
-    "}\n",
-    "\n",
-    "string easyPuzzle = \"003020600900305001001806400008102900700000008006708200002609500800203009005010300\";\n",
-    "\n",
-    "Console.WriteLine(\"=== Puzzle Sudoku Facile ===\");\n",
-    "int[,] initialGrid = ParsePuzzle(easyPuzzle);\n",
-    "DisplayGrid(initialGrid);\n",
-    "\n",
-    "// Resoudre avec l'automate symbolique\n",
-    "var automaton = new SudokuSymbolicAutomaton();\n",
-    "\n",
-    "// Appliquer les contraintes initiales\n",
-    "for (int i = 0; i < 9; i++)\n",
-    "{\n",
-    "    for (int j = 0; j < 9; j++)\n",
-    "    {\n",
-    "        if (initialGrid[i, j] != 0)\n",
-    "        {\n",
-    "            automaton.SetCell(i, j, initialGrid[i, j]);\n",
+    "    // 4. contrainte de BLOC 3x3 : tous distincts\n",
+    "    for (int br = 0; br < 3; br++)\n",
+    "        for (int bc = 0; bc < 3; bc++) {\n",
+    "            var blk = new IntExpr[9]; int k = 0;\n",
+    "            for (int r = 0; r < 3; r++)\n",
+    "                for (int c = 0; c < 3; c++)\n",
+    "                    blk[k++] = cells[br * 3 + r, bc * 3 + c];\n",
+    "            s.Add(ctx.MkDistinct(blk));\n",
     "        }\n",
+    "    // 5. fixer les cases donnees du puzzle (0 = vide)\n",
+    "    for (int r = 0; r < 9; r++)\n",
+    "        for (int c = 0; c < 9; c++)\n",
+    "            if (puzzle[r, c] != 0) s.Add(ctx.MkEq(cells[r, c], ctx.MkInt(puzzle[r, c])));\n",
+    "\n",
+    "    var sw = Stopwatch.StartNew();\n",
+    "    var status = s.Check();\n",
+    "    sw.Stop();\n",
+    "    ms = sw.ElapsedMilliseconds;\n",
+    "    var sol = new int[9, 9];\n",
+    "    if (status == Status.SATISFIABLE) {\n",
+    "        var m = s.Model;\n",
+    "        for (int r = 0; r < 9; r++)\n",
+    "            for (int c = 0; c < 9; c++) sol[r, c] = ((IntNum)m.Evaluate(cells[r, c])).Int;\n",
     "    }\n",
+    "    return sol;\n",
     "}\n",
     "\n",
-    "var stopwatch = Stopwatch.StartNew();\n",
-    "int[,] solution = automaton.Solve();\n",
-    "stopwatch.Stop();\n",
-    "\n",
-    "if (solution != null)\n",
-    "{\n",
-    "    Console.WriteLine($\"\\nSolution trouve en {stopwatch.Elapsed.TotalMilliseconds:F2} ms :\");\n",
-    "    DisplayGrid(solution);\n",
-    "}\n",
-    "else\n",
-    "{\n",
-    "    Console.WriteLine(\"\\nAucune solution trouvee.\");\n",
+    "// Puzzle classique (Wikipedia), 0 = case vide.\n",
+    "int[,] puzzle = {\n",
+    "    {5,3,0, 0,7,0, 0,0,0},\n",
+    "    {6,0,0, 1,9,5, 0,0,0},\n",
+    "    {0,9,8, 0,0,0, 0,6,0},\n",
+    "    {8,0,0, 0,6,0, 0,0,3},\n",
+    "    {4,0,0, 8,0,3, 0,0,1},\n",
+    "    {7,0,0, 0,2,0, 0,0,6},\n",
+    "    {0,6,0, 0,0,0, 2,8,0},\n",
+    "    {0,0,0, 4,1,9, 0,0,5},\n",
+    "    {0,0,0, 0,8,0, 0,7,9}\n",
+    "};\n",
+    "long msSolve;\n",
+    "var solution = ResoudreSudokuZ3(ctx, puzzle, out msSolve);\n",
+    "Console.WriteLine($\"Z3 a produit un temoin (grille solution) en {msSolve} ms.\\n\");\n",
+    "for (int r = 0; r < 9; r++) {\n",
+    "    for (int c = 0; c < 9; c++) {\n",
+    "        Console.Write(solution[r, c] + \" \");\n",
+    "        if (c == 2 || c == 5) Console.Write(\"| \");\n",
+    "    }\n",
+    "    if (r == 2 || r == 5) Console.WriteLine(\"\\n------+-------+------\"); else Console.WriteLine();\n",
     "}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bd9d516a",
+   "id": "a3872431",
    "metadata": {
     "papermill": {
-     "duration": 0.073576,
-     "end_time": "2026-05-12T08:30:04.542487+00:00",
+     "duration": 0.00633,
+     "end_time": "2026-06-14T21:32:50.836206+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:04.468911+00:00",
+     "start_time": "2026-06-14T21:32:50.829876+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "#### Interpretation : Resolution avec Automate Symbolique\n",
+    "### Interpretation : Z3 = production du temoin (le travail dur)\n",
     "\n",
-    "**Sortie obtenue** : Le puzzle Sudoku est resolu avec succes en utilisant l'automate symbolique.\n",
+    "Z3 a **produit** la grille solution - le *temoin* - en quelques dizaines de millisecondes. C'est le barreau 2 de 2020, mais **sans le cap de 21 caracteres** : on appelle Z3 directement, pas via le chemin SFAz3 qui etait tronque. C'est ce resolveur qui entre dans le benchmark Sudoku multi-paradigmes (aux cotes d'Infer.NET, du PSO, du reseau de neurones) : il **resout reellement** le dataset.\n",
     "\n",
-    "**Puzzle initial** :\n",
-    "```\n",
-    ". . 3 | . 2 . | 6 . .\n",
-    "9 . . | 3 . 5 | . . 1\n",
-    ". . 1 | 8 . 6 | 4 . .\n",
-    "-------+-------+-------\n",
-    ". . 8 | 1 . 2 | 9 . .\n",
-    "7 . . | . . . | . . 8\n",
-    ". . 6 | 7 . 8 | 2 . .\n",
-    "-------+-------+-------\n",
-    ". . 2 | 6 . 9 | 5 . .\n",
-    "8 . . | 2 . 3 | . . 9\n",
-    ". . 5 | . 1 . | 3 . .\n",
-    "```\n",
-    "\n",
-    "**Processus de resolution** :\n",
-    "\n",
-    "| Etape | Description |\n",
-    "|-------|-------------|\n",
-    "| 1 | Creer l'automate avec 27 contraintes (9 lignes + 9 colonnes + 9 blocs) |\n",
-    "| 2 | Ajouter les transitions correspondant aux indices du puzzle (valeurs fixees) |\n",
-    "| 3 | Chercher un etat accepteur via Z3 SAT solver |\n",
-    "| 4 | Extraire la solution du modele Z3 |\n",
-    "\n",
-    "**Temps de resolution** : Typiquement quelques millisecondes pour un puzzle facile.\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. Le produit d'automates combine toutes les contraintes Sudoku\n",
-    "2. Z3 trouve automatiquement une solution satisfaisant toutes les contraintes\n",
-    "3. L'approche est declarative : nous specifions les contraintes, pas l'algorithme de recherche"
+    "C'est aussi le \"cop-out\" de l'ancienne version de ce notebook qu'on tue ici : non, \"utiliser Z3 directement\" n'est pas une degression honteuse par rapport aux automates - c'est le **complement indispensable** du verificateur RE#. *Solving* (Z3) et *matching* (RE#) sont les deux faces de la serie."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8158d31c",
+   "id": "81f6e32b",
    "metadata": {
     "papermill": {
-     "duration": 0.017282,
-     "end_time": "2026-05-12T08:30:04.577469+00:00",
+     "duration": 0.006537,
+     "end_time": "2026-06-14T21:32:50.849350+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:04.560187+00:00",
+     "start_time": "2026-06-14T21:32:50.842813+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "## 7. L'ironie pedagogique - RE# valide ce qu'il ne peut produire\n",
     "\n",
-    "## 7. Discussion - Theorie vs Pratique (10 min)\n",
+    "Nous avons maintenant les deux outils en main :\n",
     "\n",
-    "### 7.1 Le Fossé entre Theorie et Implementation\n",
+    "- **Z3** (section 6) a *produit* la grille solution (le temoin) ;\n",
+    "- **RE#** (section 5) sait *valider* une ligne.\n",
     "\n",
-    "> **⚠️ Honnêteté intellectuelle** : Ce notebook presente une approche \"hybride\" - la theorie des automates symboliques guide la modelisation, mais l'implementation pratique compile directement vers Z3 SMT.\n",
-    "\n",
-    "| Aspect | Theorie pure automata | Implementation de ce notebook | Automata.Net (vrai) |\n",
-    "|--------|----------------------|------------------------------|---------------------|\n",
-    "| **Structure de donnees** | 5-tuple $(Q, \\Sigma, \\delta, q_0, F)$ | Variables Z3 + contraintes | Builder + Automaton |\n",
-    "| **Predicats** | CharSet $\\to$ BDD | CharSet $\\to$ formules Z3 | CharSet $\\to$ BDD |\n",
-    "| **Operations** | Union, Intersect, Product | Compilation vers contraintes | Union, Intersect, Product |\n",
-    "| **Verification** | Parcours d'automate | SAT solving | Parcours d'automate |\n",
-    "| **Backend** | Theorique | Z3 SMT | Z3 ou BDD |\n",
-    "\n",
-    "### 7.2 Pourquoi cette Approche Hybride?\n",
-    "\n",
-    "**Avantages pedagogiques** :\n",
-    "1. La theorie des automates fournit un modele conceptuel clair\n",
-    "2. Les operations (intersection, produit) se traduisent naturellement en contraintes\n",
-    "3. Z3 est plus performant qu'une implementation pure d'automates pour Sudoku\n",
-    "\n",
-    "**Inconvenients** :\n",
-    "1. Nous perdons la compositionnalite veritable des automates\n",
-    "2. L'approche ne se generalise pas aux problemes de reconnaissance de motifs\n",
-    "3. Nous n'utilisons pas vraiment la structure d'etats et de transitions\n",
-    "\n",
-    "### 7.3 Tableau Comparatif avec Approches Pures\n",
-    "\n",
-    "| Approche | Purete \"automata\" | Performance | Expressivite | Pedagogie |\n",
-    "|----------|-------------------|-------------|--------------|-----------|\n",
-    "| **Automates purs (BDD)** | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ⭐⭐ |\n",
-    "| **Ce notebook (Z3)** | ⭐ | ⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐ |\n",
-    "| **Z3 direct** | - | ⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐ |\n",
-    "| **OR-Tools CP-SAT** | - | ⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ |\n",
-    "\n",
-    "### 7.4 Quand Utiliser Chaque Approche\n",
-    "\n",
-    "| Situation | Approche recommandee | Pourquoi |\n",
-    "|-----------|---------------------|---------|\n",
-    "| **Problem Sudoku** | Z3 direct ou OR-Tools | Performance optimale |\n",
-    "| **Reconnaissance de motifs** | Automates purs (BDD) | Modelisation naturelle |\n",
-    "| **Apprentissage theorie** | Ce notebook | Lien theory/pratique |\n",
-    "| **Verification formelle** | Automata.Net (si fonctionnait) | Operations d'algebre |\n",
-    "| **BDD/MDD purs** | Sudoku-13 | Vraie approche automata |\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "af1032db",
-   "metadata": {
-    "papermill": {
-     "duration": 0.018059,
-     "end_time": "2026-05-12T08:30:04.615051+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:04.596992+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## 8. Automata.Net - Etat des Lieux (5 min)\n",
-    "\n",
-    "### 8.1 Statut de la Bibliotheque\n",
-    "\n",
-    "**Automata.Net** est une bibliotheque C# developpee par Microsoft Research (Marcus Veanes et al.) pour la manipulation d'automates symboliques.\n",
-    "\n",
-    "| Aspect | Details |\n",
-    "|---------|---------|\n",
-    "| **Repository** | https://github.com/AutomataDotNet/Automata |\n",
-    "| **Derniere mise a jour** | 2017-2018 |\n",
-    "| **Package NuGet** | Disponible mais non maintenu |\n",
-    "| **Bug critique #6** | Non resolu depuis plusieurs annees |\n",
-    "| **Futur** | **Deprecie** - utilisez Z3 directement |\n",
-    "\n",
-    "### 8.2 Ce Qu'Automata.Net Fout Vraiment\n",
-    "\n",
-    "La bibliotheque implemente la compilation de concepts d'automates vers des solveurs :\n",
-    "\n",
-    "```\n",
-    "                Automata.Net\n",
-    "     +--------------------------+\n",
-    "     |  CharSet (predicats)     |\n",
-    "     |  SymbolicFiniteAut<T>    |\n",
-    "     |  Operations: Union,      |\n",
-    "     |  Intersect, Product,     |\n",
-    "     |  Complement, Minimize    |\n",
-    "     +------------+-------------+\n",
-    "                  |\n",
-    "                  v\n",
-    "     +--------------------------+\n",
-    "     |  BACKEND (au choix)      |\n",
-    "     |  - Z3 (arithmetique)     |\n",
-    "     |  - BDD (booleens)        |\n",
-    "     |  - Custom                |\n",
-    "     +--------------------------+\n",
-    "```\n",
-    "\n",
-    "**Point cle** : Automata.Net ne construit pas explicitement des automates avec des millions d'etats. Il compile les operations vers des solveurs - exactement comme nous le faisons dans ce notebook avec Z3.\n",
-    "\n",
-    "### 8.3 Notre Approche vs Automata.Net\n",
-    "\n",
-    "| Aspect | Ce notebook | Automata.Net |\n",
-    "|--------|-------------|--------------|\n",
-    "| **CharSet** | Implementation personnalisee | `CharSetSolver` |\n",
-    "| **Operations** | `IntersectsWith`, `AcceptsUnion` | `A.Intersect(B)`, `A.Union(B)` |\n",
-    "| **Backend** | Z3 direct | Z3 ou BDD |\n",
-    "| **Contraintes Sudoku** | `Distinct` | Idem (via Z3) |\n",
-    "| **Difference** | Pas de couche d'abstraction | Couche d'abstraction complete |\n",
-    "\n",
-    "### 8.4 Pourquoi Automata.Net est Deprecie\n",
-    "\n",
-    "1. **Z3 est suffisant** : Pour la plupart des cas d'usage, Z3 direct est plus simple\n",
-    "2. **BDD couteux** : Les BDD sont complexes et pas toujours plus performants\n",
-    "3. **Maintenance** : Le code est ancien et non maintenu\n",
-    "\n",
-    "**Recommandation** : Pour de nouveaux projets, utilisez Z3 directement. Pour l'apprentissage, ce notebook avec implementation personnalisee est suffisant.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5edc03a5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.027183,
-     "end_time": "2026-05-12T08:30:04.659935+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:04.632752+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## 9. Conclusion\n",
-    "\n",
-    "### 9.1 Ce que Nous Avons Appris\n",
-    "\n",
-    "Dans ce notebook, nous avons explore la theorie des automates symboliques et leur compilation vers un solveur SMT.\n",
-    "\n",
-    "| Concept | Theorie | Implementation pratique |\n",
-    "|---------|---------|------------------------|\n",
-    "| **Automate symbolique** | Etats + transitions symboliques | Variables Z3 + contraintes |\n",
-    "| **CharSet** | Predicat sur ensemble de caracteres | Implementation personnalisee |\n",
-    "| **Operations** | Union, Intersect, Product | Compilation vers contraintes |\n",
-    "| **Contrainte Sudoku** | Automate de ligne/colonne/bloc | `Distinct` + domaine |\n",
-    "| **Verification** | Parcours d'automate | SAT solving |\n",
-    "\n",
-    "### 9.2 Honnêteté Intellectuelle\n",
-    "\n",
-    "> Ce notebook presente une **approche hybride** qui n'est ni :\n",
-    "> - Une \"vraie\" implementation d'automates symboliques (avec BDD/MDD)\n",
-    "> - Une utilisation directe de Z3 (comme dans Sudoku-4)\n",
-    ">\n",
-    "> C'est une **approche pedagogique** qui montre comment les concepts d'automates symboliques se traduisent naturellement en contraintes SMT.\n",
-    "\n",
-    "**Le message important** : Les automates symboliques sont un cadre theorique puissant, mais pour des problemes comme Sudoku, la compilation directe vers Z3 est plus pragmatique.\n",
-    "\n",
-    "### 9.3 Quand Utiliser les Automates Symboliques\n",
-    "\n",
-    "| Cas d'usage | Approche recommandee |\n",
-    "|-------------|---------------------|\n",
-    "| **Sudoku / contraintes CSP** | Z3 direct ou OR-Tools |\n",
-    "| **Reconnaissance de motifs** | Automates symboliques avec BDD |\n",
-    "| **Verification formelle** | Automata.Net (si fonctionnait) |\n",
-    "| **Apprentissage theorie** | Ce notebook + Sudoku-13 (BDD/MDD) |\n",
-    "\n",
-    "### 9.4 Perspectives - Sudoku-13\n",
-    "\n",
-    "Pour une implementation **vraiment** basee sur les automates (avec BDD/MDD au lieu de Z3), voir le notebook suivant :\n",
-    "\n",
-    "- **[Sudoku-13-BDD](Sudoku-14-BDD-Csharp.ipynb)** : Automates avec Binary Decision Diagrams\n",
-    "\n",
-    "Sudoku-13 implementera une approche purement \"automata\" sans passer par Z3, demontrant les avantages et limites de cette approche.\n",
-    "\n",
-    "### 9.5 Tableau de Synthese Finale\n",
-    "\n",
-    "| # | Notebook | Approche | Temps (Easy) | Temps (Hard) | Purete \"automata\" |\n",
-    "|---|----------|----------|--------------|--------------|-------------------|\n",
-    "| 1 | Backtracking | Recherche exhaustive | ~100ms | ~1s | - |\n",
-    "| 3 | OR-Tools | CP-SAT | <5ms | <50ms | - |\n",
-    "| 4 | Z3 | SMT direct | <10ms | <100ms | - |\n",
-    "| **12** | **Automates + Z3** | **SFA compile vers SMT** | **<20ms** | **<150ms** | ⭐ |\n",
-    "| 13 | **BDD/MDD** | **Automates purs** | **~100ms** | **~1s** | ⭐⭐⭐ |\n",
-    "\n",
-    "L'approche par automates symboliques offre une intuition pedagogique forte, mais la compilation vers Z3 est le compromis pratique adopte par Automata.Net lui-même.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3da2777a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.018402,
-     "end_time": "2026-05-12T08:30:04.707332+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:04.688930+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercice : Automates Symboliques\n",
-    "\n",
-    "### Exercice 1 : Automate pour Plage Specifique\n",
-    "\n",
-    "Construire un automate symbolique qui accepte uniquement les sequences de 9 chiffres dont tous les elements sont dans la plage [3, 7]. Utiliser la classe CharSet pour definir le predicat.\n",
-    "\n",
-    "### Exercice 2 : Produit d'Automates\n",
-    "\n",
-    "Implementer l'intersection de deux automates symboliques par produit cartesien des etats. Verifier que l'automate resultant accepte exactement les mots acceptes par les deux automates d'entree.\n",
-    "\n",
-    "### Exercice 3 : Automate pour Diagonale Sudoku\n",
-    "\n",
-    "Construire un automate symbolique pour la contrainte de diagonale d'un Sudoku diagonale (variante ou les deux diagonales principales doivent aussi contenir 1-9 sans repetition).\n",
-    "\n",
-    "### Exercice 4 : Comptage de Solutions\n",
-    "\n",
-    "Modifier le solveur pour compter le nombre total de solutions d'un puzzle donne, en parcourant toutes les feuilles acceptantes de l'automate produit. Comparer avec la methode de force brute."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "728021e5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.032278,
-     "end_time": "2026-05-12T08:30:04.757963+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:04.725685+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercice : Automate pour Contrainte de Diagonale\n",
-    "\n",
-    "### Objectif\n",
-    "\n",
-    "Le Sudoku diagonale (ou Sudoku X) est une variante ou les deux grandes diagonales doivent aussi contenir les chiffres 1-9 sans repetition. Votre mission est d'etendre le solveur base sur les automates symboliques pour supporter cette contrainte additionnelle.\n",
-    "\n",
-    "### Travail demande\n",
-    "\n",
-    "1. **Automate de diagonale** : Construire un `SymbolicFiniteAutomaton` qui represente la contrainte \"les 9 valeurs de la diagonale sont distinctes\"\n",
-    "\n",
-    "2. **Integration dans le solveur** : Etendre `SudokuSFASolver` pour inclure les 2 automates de diagonale (diagonale principale et anti-diagonale) dans le produit d'automates\n",
-    "\n",
-    "3. **Validation** : Tester sur un puzzle Sudoku X connu\n",
-    "\n",
-    "### Interface a implementer\n",
-    "\n",
-    "```csharp\n",
-    "public class SudokuDiagonalSFASolver : ISudokuSolver\n",
-    "{\n",
-    "    public SymbolicFiniteAutomaton BuildDiagonalAutomaton() { ... }\n",
-    "    public bool Solve(SudokuGrid grid) { ... }\n",
-    "}\n",
-    "```\n",
-    "\n",
-    "### Aide\n",
-    "\n",
-    "La diagonale principale contient les cellules (0,0), (1,1), ..., (8,8).\n",
-    "L'anti-diagonale contient les cellules (0,8), (1,7), ..., (8,0)."
-   ]
-  },
-  {
-   "id": "7b97ac39",
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### A retenir\n",
-    "\n",
-    "L'approche **automates symboliques + compilation Z3** illustre un compromis pedagogique productif :\n",
-    "\n",
-    "- Les **SFA** (Symbolic Finite Automata) remplacent les transitions concretes par des predicats logiques, passant de 91 etats (DFA pour entiers pairs) a 2 etats.\n",
-    "- La **compilation vers Z3** (contraintes `Distinct` + domaines) resout le Sudoku en **37 ms** (Easy), performance competitive avec Z3 direct.\n",
-    "- **Automata.Net** (Microsoft Research) est deprecie depuis 2018 : Z3 direct est recommande en production.\n",
-    "- Pour une approche **purement automate** (BDD/MDD, sans Z3), voir le notebook Sudoku-13-BDD.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3a829efd",
-   "metadata": {
-    "papermill": {
-     "duration": 0.016627,
-     "end_time": "2026-05-12T08:30:04.793134+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:04.776507+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## References\n",
-    "\n",
-    "### Bibliographie\n",
-    "\n",
-    "- **Veanes, M. et al.** - \"Symbolic Automata Constraint Solving\" (2010)\n",
-    "- **D'Antoni, L. & Veanes, M.** - \"Symbolic Automata\" (2017)\n",
-    "- **Clarke, E. et al.** - \"Model Checking\" (1999)\n",
-    "- **Andersen, H. R.** - \"An Introduction to Binary Decision Diagrams\" (1997)\n",
-    "\n",
-    "### Liens\n",
-    "\n",
-    "- [Automata.Net Repository](https://github.com/AutomataDotNet/Automata) - *(Deprecated)*\n",
-    "- [Z3 Theorem Prover](https://github.com/Z3Prover/z3)\n",
-    "- [Search Foundations Series](../Search/Part1-Foundations/README.md)\n",
-    "\n",
-    "### Notebooks connexes\n",
-    "\n",
-    "- **[Sudoku-13-BDD](Sudoku-14-BDD-Csharp.ipynb)** - Automates avec Binary Decision Diagrams *(approche pure)*\n",
-    "- [Sudoku-4-Z3](Sudoku-12-Z3-Csharp.ipynb) - Z3 SMT pour Sudoku\n",
-    "- [Sudoku-3-ORTools](Sudoku-10-ORTools-Csharp.ipynb) - Programmation par contraintes\n",
-    "- [Search-12-SymbolicAutomata](../Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) - Theorie des automates symboliques\n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Navigation** : [Sudoku README](README.md) | [Sudoku-11-Comparison](Sudoku-18-Comparison-Python.ipynb) | [Sudoku-13-BDD](Sudoku-14-BDD-Csharp.ipynb)\n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Retour au sommaire** : [Index Sudoku](README.md)\n"
+    "Faisons-les se rencontrer : extrayons chaque ligne de la **solution produite par Z3**, et **verifions-la avec RE#**. Le verificateur elegant certifie, en temps lineaire, la solution qu'il est lui-meme **incapable de produire**."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "0fafda49",
+   "execution_count": 8,
+   "id": "57514927",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:30:04.827012Z",
-     "iopub.status.busy": "2026-05-12T08:30:04.826766Z",
-     "iopub.status.idle": "2026-05-12T08:30:06.515642Z",
-     "shell.execute_reply": "2026-05-12T08:30:06.515452Z"
+     "iopub.execute_input": "2026-06-14T21:32:50.863241Z",
+     "iopub.status.busy": "2026-06-14T21:32:50.863070Z",
+     "iopub.status.idle": "2026-06-14T21:32:50.966708Z",
+     "shell.execute_reply": "2026-06-14T21:32:50.966537Z"
     },
     "papermill": {
-     "duration": 1.706496,
-     "end_time": "2026-05-12T08:30:06.515738+00:00",
+     "duration": 0.110735,
+     "end_time": "2026-06-14T21:32:50.966790+00:00",
      "exception": false,
-     "start_time": "2026-05-12T08:30:04.809242+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "# Sudoku-0 : Environnement et Classes de Base (C#)\n",
-       "\n",
-       "**Navigation** : [Index](README.md) | [Sudoku-1 Backtracking C# >>](Sudoku-1-Backtracking-Csharp.ipynb)\n",
-       "\n",
-       "## Objectifs d'apprentissage\n",
-       "\n",
-       "A la fin de ce notebook, vous saurez :\n",
-       "1. Comprendre la structure de donnees `SudokuGrid` et ses methodes principales\n",
-       "2. Utiliser `ISudokuSolver` pour implementer un solveur de Sudoku\n",
-       "3. Exploiter `SudokuHelper` pour charger des grilles et tester des solveurs\n",
-       "4. Comparer les performances de plusieurs solveurs sur differentes difficultes\n",
-       "\n",
-       "**Prerequis** : Notions de base en C# (.NET Interactive)  \n",
-       "**Duree estimee** : ~15 min"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Plotly.NET, 5.1.0</span></li></ul></div></div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "## Définition de la classe SudokuGrid\n",
-       "\n",
-       "Nous définissons ici la classe SudokuGrid qui représente une grille de Sudoku et fournit des méthodes pour manipuler et afficher les grilles.\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "### Interpretation : Structure de donnees pour la grille Sudoku\n",
-       "\n",
-       "**Sortie obtenue** : La classe `SudokuGrid` encapsule toutes les operations de manipulation, validation et affichage d'une grille de Sudoku 9x9.\n",
-       "\n",
-       "| Aspect | Valeur | Signification |\n",
-       "|--------|--------|---------------|\n",
-       "| `Cells[9,9]` | int[,] | Stockage interne des valeurs (0 = vide) |\n",
-       "| `AllNeighbours` | 27 x 9 positions | Pre-calcul des voisins ligne/colonne/bloc |\n",
-       "| `CellNeighbours[9][9]` | ~20 positions chacune | Voisins directs de chaque cellule |\n",
-       "| `GetAvailableNumbers()` | int[] | Candidats valides pour une cellule |\n",
-       "| `NbErrors()` | int | Nombre de conflits + modifications erronees |\n",
-       "\n",
-       "**Points cles** :\n",
-       "1. **Pre-calcul des voisins** : `AllNeighbours` et `CellNeighbours` sont calcules une seule fois a l'initialisation, evitant les recalculs couteux\n",
-       "2. **Conversion flexible** : Methodes pour convertir entre tableaux 1D, 2D et jagged arrays (utile pour differents formats de fichiers)\n",
-       "3. **Validation robuste** : `NbErrors` compte a la fois les doublons (ligne/colonne/bloc) et les modifications de indices pre-remplis\n",
-       "4. **Parsing tolerant** : `ReadMultiSudoku` accepte plusieurs formats (`.`, `X`, `-`, espaces)\n",
-       "\n",
-       "> **Note technique** : La structure `CellNeighbours[i][j]` contient environ 20 positions (8 ligne + 8 colonne + 4 bloc, moins les doublons). Ce pre-calcul est crucial pour les performances des algorithmes de backtracking et de propagation de contraintes."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "## Définition de l'interface ISudokuSolver\n",
-       "\n",
-       "Nous définissons ici l'interface ISudokuSolver qui sera implémentée par les différentes stratégies de résolution de Sudoku.\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "### Interpretation : Interface de strategie\n",
-       "\n",
-       "**Sortie obtenue** : L'interface `ISudokuSolver` definit le contrat que tous les solveurs doivent respecter.\n",
-       "\n",
-       "| Aspect | Valeur | Signification |\n",
-       "|--------|--------|---------------|\n",
-       "| `Solve(SudokuGrid)` | SudokuGrid | Methode unique de resolution |\n",
-       "| Pattern | Strategie | Permuter les algorithmes sans modifier le code client |\n",
-       "\n",
-       "**Points cles** :\n",
-       "1. **Simplicite** : Une seule methode `Solve` prenant une grille et retournant une grille resolue\n",
-       "2. **Flexibilite** : N'importe quel algorithme (backtracking, CSP, metaheuristique) peut implementer cette interface\n",
-       "3. **Composabilite** : Les solveurs peuvent etre passes en parametre, stockes dans des listes, testes unitairement\n",
-       "4. **Extensibilite** : Ajouter un nouveau solver ne necessite que d'implementer l'interface\n",
-       "\n",
-       "> **Note technique** : Ce design pattern permet a `SudokuHelper.TestSolvers` d'accepter une liste de `(string, ISudokuSolver)` pour comparer tous les algorithmes avec le meme code de test."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "## Définition de la classe SudokuHelper\n",
-       "\n",
-       "Nous ajoutons ici la classe SudokuHelper qui contient des méthodes utilitaires pour charger  des grilles de Sudoku et tester des solvers.\n",
-       "\n",
-       "- `GetSudokus` : Renvoie des listes de Sudoku issues de fichiers de 3 difficultés différentes.\n",
-       "- `SolveSudoku` : effectue un test simple d'un solver sur un sudoku donné.\n",
-       "- `TestSolvers` : exécute les tests de performance sur plusieurs solveurs.\n",
-       "- `DisplayResults` : affiche les résultats des tests sous forme de graphiques.\n",
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "### Interpretation : Infrastructure de test et benchmark\n",
-       "\n",
-       "**Sortie obtenue** : La classe `SudokuHelper` fournit une infrastructure complete pour tester et comparer les solveurs de Sudoku.\n",
-       "\n",
-       "| Aspect | Valeur | Signification |\n",
-       "|--------|--------|---------------|\n",
-       "| `GetSudokus()` | 51/95/100 grilles | Trois niveaux de difficulte (Easy/Medium/Hard) |\n",
-       "| `TestSolvers()` | Performance multi-solveurs | Execution parallele avec timeout |\n",
-       "| `DisplayResults()` | Graphiques Plotly.NET | Visualisation des temps de resolution |\n",
-       "| `SolveSudoku()` | Test unitaire | Resolution individuelle avec affichage |\n",
-       "\n",
-       "**Points cles** :\n",
-       "1. **Chargement intelligent** : Recherche recursive du dossier `Puzzles` dans l'arborescence\n",
-       "2. **Robustesse** : Gestion des timeouts (3000ms par defaut) et exceptions\n",
-       "3. **Mesures** : Temps d'execution total + nombre de grilles resolues\n",
-       "4. **Disqualification** : Un solver echouant sur une grille est disqualifie pour la difficulte\n",
-       "\n",
-       "> **Note technique** : La methode `TestSolvers` utilise `Interlocked.Increment` pour un thread-safe increment du compteur de solutions. Le `CancellationToken` permet d'interrompre proprement les solveurs trop lents."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "## Exercice : Validation d'une grille Sudoku\n",
-       "\n",
-       "### Enonce\n",
-       "\n",
-       "Implementez une methode `IsValidSolution` qui verifie qu'une grille est une solution valide de Sudoku, c'est-a-dire que chaque ligne, chaque colonne et chaque bloc 3x3 contient exactement une fois chaque chiffre de 1 a 9.\n",
-       "\n",
-       "Utilisez cette methode pour valider les resultats de `SudokuHelper.SolveSudoku`.\n",
-       "\n",
-       "### Indices\n",
-       "\n",
-       "- Parcourez les 9 lignes, 9 colonnes et 9 blocs\n",
-       "- Pour chaque unite, verifiez que les 9 chiffres sont tous presents sans doublon\n",
-       "- `SudokuGrid.AllNeighbours` contient deja les indices des unites"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice a completer\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "// Charger les types de base depuis le notebook d'environnement\n",
-    "#!import Sudoku-0-Environment-Csharp.ipynb\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "380b7b3b",
-   "source": "### Exercice : Solveur Sudoku X avec contraintes de diagonale\n\nL'environnement de base est charge via `#!import`. Nous disposons maintenant des classes `SymbolicFiniteAutomaton`, `CharSet` et `SudokuSymbolicAutomaton` definies dans les sections precedentes.\n\nL'objectif est d'implementer un **Sudoku X** (ou Sudoku diagonal), variante ou les deux grandes diagonales doivent aussi contenir les chiffres 1 a 9 sans repetition. Cela requiert d'ajouter 2 automates supplementaires (diagonale principale et anti-diagonale) au produit d'automates existant.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "229f0a15",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-12T08:30:06.561262Z",
-     "iopub.status.busy": "2026-05-12T08:30:06.560948Z",
-     "iopub.status.idle": "2026-05-12T08:30:06.607902Z",
-     "shell.execute_reply": "2026-05-12T08:30:06.607708Z"
-    },
-    "papermill": {
-     "duration": 0.071767,
-     "end_time": "2026-05-12T08:30:06.607990+00:00",
-     "exception": false,
-     "start_time": "2026-05-12T08:30:06.536223+00:00",
+     "start_time": "2026-06-14T21:32:50.856055+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4589,44 +1904,398 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : Solveur Sudoku X avec contraintes de diagonale.\r\n"
+      "RE# a verifie les 9 lignes de la solution Z3 en 186531 ticks (18 ms).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lignes valides : 9/9\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L'ironie : RE# certifie, plus vite que Z3 n'a resolu, une grille\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qu'il ne SAURAIT PAS produire lui-meme (il est recognition-only).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  534678912 -> VALIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  672195348 -> VALIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  198342567 -> VALIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  859761423 -> VALIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  426853791 -> VALIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  713924856 -> VALIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  961537284 -> VALIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  287419635 -> VALIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  345286179 -> VALIDE\r\n"
      ]
     }
    ],
    "source": [
-    "// A COMPLETER : Solveur Sudoku X avec contraintes de diagonale\n",
-    "\n",
-    "public class SudokuDiagonalSFASolver : ISudokuSolver\n",
-    "{\n",
-    "    /// <summary>\n",
-    "    /// Construit un automate symbolique pour la contrainte de diagonale.\n",
-    "    /// L'automate accepte les sequences de 9 valeurs distinctes dans {1,...,9}.\n",
-    "    /// </summary>\n",
-    "    public SymbolicFiniteAutomaton BuildDiagonalAutomaton()\n",
-    "    {\n",
-    "        // TODO : Construire l'automate pour la contrainte \"9 valeurs distinctes\"\n",
-    "        // Indice : La structure est la meme que l'automate de ligne/colonne\n",
-    "        // mais les cellules de la diagonale ne sont pas contigues\n",
-    "        return null;\n",
-    "    }\n",
-    "\n",
-    "    /// <summary>\n",
-    "    /// Resout un puzzle Sudoku X (avec contraintes de diagonale).\n",
-    "    /// </summary>\n",
-    "    public SudokuGrid Solve(SudokuGrid grid)\n",
-    "    {\n",
-    "        // TODO : Etendre SudokuSFASolver pour inclure les 2 diagonales\n",
-    "        // Indice :\n",
-    "        // 1. Construire les 27 automates standard (lignes + colonnes + blocs)\n",
-    "        // 2. Ajouter 2 automates de diagonale\n",
-    "        // 3. Faire le produit de tous les automates\n",
-    "        // 4. Resoudre par parcours de l'automate produit\n",
-    "        return null;\n",
-    "    }\n",
+    "using System.Diagnostics;\n",
+    "// Ironie : RE# valide CHAQUE ligne de la solution produite par Z3.\n",
+    "// Le verificateur elegant certifie - en temps lineaire - ce qu'il ne sait pas produire.\n",
+    "var lignesSolution = new string[9];\n",
+    "for (int r = 0; r < 9; r++) {\n",
+    "    char[] chars = new char[9];\n",
+    "    for (int c = 0; c < 9; c++) chars[c] = (char)('0' + solution[r, c]);\n",
+    "    lignesSolution[r] = new string(chars);\n",
     "}\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "int valides = 0;\n",
+    "foreach (var ligne in lignesSolution) {\n",
+    "    if (ligneValide.Matches(ligne).Length > 0) valides++;\n",
+    "}\n",
+    "sw.Stop();\n",
+    "Console.WriteLine($\"RE# a verifie les 9 lignes de la solution Z3 en {sw.ElapsedTicks} ticks ({sw.ElapsedMilliseconds} ms).\");\n",
+    "Console.WriteLine($\"Lignes valides : {valides}/9\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"L'ironie : RE# certifie, plus vite que Z3 n'a resolu, une grille\");\n",
+    "Console.WriteLine(\"qu'il ne SAURAIT PAS produire lui-meme (il est recognition-only).\");\n",
+    "Console.WriteLine();\n",
+    "foreach (var ligne in lignesSolution) Console.WriteLine($\"  {ligne} -> {(ligneValide.Matches(ligne).Length > 0 ? \"VALIDE\" : \"invalide\")}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98e9d012",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008247,
+     "end_time": "2026-06-14T21:32:50.983244+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:50.974997+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : le prestige va au verificateur, le travail au resolveur\n",
     "\n",
-    "// Test sur un puzzle Sudoku X\n",
-    "Console.WriteLine(\"Exercice a completer : Solveur Sudoku X avec contraintes de diagonale.\");\n"
+    "Double retournement :\n",
+    "\n",
+    "1. Le **reconnaisseur le plus elegant** (RE#, temps lineaire) ne sait **pas fabriquer** la solution qu'il certifie.\n",
+    "2. Il la certifie en outre **plus vite** que la toolchain (Automata / intersection DFA) qui etait censee etre *le* reconnaisseur en 2020 - celle-la meme qui explosait.\n",
+    "\n",
+    "Le Sudoku donne a voir que **matching** (RE#) et **solving** (Z3) sont deux metiers. Le prestige du \"rapide et elegant\" va au verificateur ; le travail dur - la **production du temoin** - reste irremplacablement du cote de Z3. C'est la these de cette serie, rendue concrete."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d8d3271",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007949,
+     "end_time": "2026-06-14T21:32:50.998329+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:50.990380+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 : etendre l'encodage Z3 (Sudoku diagonal)\n",
+    "\n",
+    "# Objectif\n",
+    "Le Sudoku-X ajoute deux contraintes : les deux **diagonales** principales doivent aussi contenir 1..9 (tous distincts). Etendez la fonction `ResoudreSudokuZ3` pour ajouter ces deux contraintes.\n",
+    "\n",
+    "# Indice\n",
+    "Recuperez les 9 `IntExpr` de la diagonale principale (`cells[i,i]`) et de l'anti-diagonale (`cells[i, 8-i]`), et ajoutez deux `ctx.MkDistinct(...)` supplementaires avant `s.Check()`.\n",
+    "\n",
+    "# Etape 1\n",
+    "Ecrivez une variante `ResoudreSudokuXZ3` dans la cellule suivante."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f684319a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T21:32:51.015512Z",
+     "iopub.status.busy": "2026-06-14T21:32:51.015317Z",
+     "iopub.status.idle": "2026-06-14T21:32:51.050516Z",
+     "shell.execute_reply": "2026-06-14T21:32:51.050381Z"
+    },
+    "papermill": {
+     "duration": 0.043984,
+     "end_time": "2026-06-14T21:32:51.050584+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:51.006600+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : implementer les deux contraintes de diagonale.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE : ResoudreSudokuXZ3 (variante avec contraintes de diagonales)\n",
+    "// TODO etudiant : reprendre le schema de ResoudreSudokuZ3 et ajouter deux MkDistinct\n",
+    "// sur la diagonale principale (cells[i,i]) et l'anti-diagonale (cells[i, 8-i]).\n",
+    "public int[,] ResoudreSudokuXZ3(Context ctx, int[,] puzzle)\n",
+    "{\n",
+    "    return puzzle;  // TODO etudiant : remplacer par la resolution avec contraintes diagonales\n",
+    "}\n",
+    "Console.WriteLine(\"Exercice a completer : implementer les deux contraintes de diagonale.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "855aa43e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007642,
+     "end_time": "2026-06-14T21:32:51.066001+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:51.058359+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Synthese - reconnaître != resoudre\n",
+    "\n",
+    "Les deux murs de 2020 tombent a **deux outils differents**. RE# ne couronne pas l'echelle - il en reparle la moitie *verification* :\n",
+    "\n",
+    "| | **RESOUDRE** (produire la grille) | **VERIFIER** (valider une grille remplie) |\n",
+    "|---|---|---|\n",
+    "| Conway PCRE | detour de backtracking, illisible | monstrueux |\n",
+    "| BREX/Rex+Z3 (2020) | **mure** (cap 21 char, issue #6) | **explosion DFA** |\n",
+    "| Z3 direct (moderne) | **resolveur reel du benchmark** | - |\n",
+    "| RE# (2025) | recognition-only, **aucun temoin** | **temps lineaire** - mur DFA tombe |\n",
+    "\n",
+    "**Lecon** : decrire une contrainte par intersection reguliere (`Ligne & Colonne & Bloc`) est une representation elegante, mais elle ne dispense pas d'un resolveur pour *produire* la solution. Le Sudoku - un probleme de **resolution** - a besoin de Z3 ; RE# est son verificateur, pas son solveur. L'ironie (RE# valide plus vite le temoin qu'il ne peut produire) est le pont entre cette serie Sudoku et la serie Z3 (Epic #1206).\n",
+    "\n",
+    "> **Footnote d'homonymie** : **Damian** Conway (le monstre regex, barreau 1) n'est pas **John** Conway (le Game of Life, hero de notre serie Lean #2162). Les deux Conway se croisent dans ce notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b71a1c63",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007588,
+     "end_time": "2026-06-14T21:32:51.081816+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:51.074228+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 : classifier recognition vs solving (conceptuel)\n",
+    "\n",
+    "# Objectif\n",
+    "Pour chacune des taches ci-dessous, indiquez quel outil convient (RE# pour la reconnaissance / verification, Z3 pour la resolution / production de temoin) et pourquoi.\n",
+    "\n",
+    "| Tache | Outil attendu | Pourquoi |\n",
+    "|-------|---------------|----------|\n",
+    "| (a) Verifier qu'une grille remplie respecte les regles | RE# | ... |\n",
+    "| (b) Resoudre un puzzle a partir de cases vides | Z3 | ... |\n",
+    "| (c) Verifier qu'une chaine est un nombre a 9 chiffres distincts | ... | ... |\n",
+    "| (d) Trouver une permutation de 1..9 maximisant un critere | ... | ... |\n",
+    "\n",
+    "# Indice\n",
+    "Posez-vous : la tache demande-t-elle de *produire* une solution (solving -> Z3) ou seulement de *reconnaitre* si une entree donnee est valide (matching -> RE#) ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3a2f8af0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T21:32:51.099085Z",
+     "iopub.status.busy": "2026-06-14T21:32:51.098883Z",
+     "iopub.status.idle": "2026-06-14T21:32:51.135264Z",
+     "shell.execute_reply": "2026-06-14T21:32:51.135131Z"
+    },
+    "papermill": {
+     "duration": 0.045368,
+     "end_time": "2026-06-14T21:32:51.135332+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:51.089964+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : pour chaque tache, indiquer RE# ou Z3 et pourquoi.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(a) Verifier qu'une grille remplie respecte les regles : RE#  -> ...\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(b) Resoudre un puzzle a partir de cases vides       : Z3  -> ...\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(c) Verifier qu'une chaine = 9 chiffres distincts    : ... -> ...\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(d) Trouver une permutation de 1..9 maximisant un critere : ... -> ...\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE (conceptuel) : classifier recognition (RE#) vs solving (Z3).\n",
+    "// TODO etudiant : completer le tableau avec l'outil et la justification.\n",
+    "Console.WriteLine(\"Exercice a completer : pour chaque tache, indiquer RE# ou Z3 et pourquoi.\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"(a) Verifier qu'une grille remplie respecte les regles : RE#  -> ...\");\n",
+    "Console.WriteLine(\"(b) Resoudre un puzzle a partir de cases vides       : Z3  -> ...\");\n",
+    "Console.WriteLine(\"(c) Verifier qu'une chaine = 9 chiffres distincts    : ... -> ...\");\n",
+    "Console.WriteLine(\"(d) Trouver une permutation de 1..9 maximisant un critere : ... -> ...\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03783737",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007768,
+     "end_time": "2026-06-14T21:32:51.150435+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T21:32:51.142667+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 9. References & connexions\n",
+    "\n",
+    "### Sources primaires\n",
+    "- **Damian Conway**, *Sudoku regex solver* - [perlmonks.org/?node_id=596304](https://www.perlmonks.org/?node_id=596304) (2005). Le monstre PCRE (barreau 1).\n",
+    "- **Issue upstream** [AutomataDotNet/Automata#6](https://github.com/AutomataDotNet/Automata/issues/6) (creee 2020-12-07, toujours sans reponse) : cap du temoin a 21 caracteres (barreau 2, mur 2).\n",
+    "- **Margus Veanes et al.**, *Derivative-based nonbacktracking real-world regex matching* - [MSR-TR-2020-25](https://www.microsoft.com/en-us/research/publication/derivative-based-nonbacktracking-real-world-regex-matching-with-backtracking-semantics/) (aout 2020). Le papier contemporain de la tentative 2020.\n",
+    "- **RE#** (engine F#/.NET, MIT) - [github.com/ieviev/resharp-dotnet](https://github.com/ieviev/resharp-dotnet), NuGet `Resharp`. `&`/`~` first-class, non-backtracking, temps lineaire (barreau 3).\n",
+    "\n",
+    "### Connexions dans cette serie\n",
+    "- **[Sudoku-12 Z3 C#](Sudoku-12-Z3-Csharp.ipynb)** : le resolveur Z3 explore en profondeur (bit-vectors, optimisations). Ce notebook (13) presente le meme Z3 sous l'angle narratif \"regex symbolique -> SMT -> temoin\".\n",
+    "- **Epic #1206 (Z3.Linq DSL)** : un autre \"geste\" de l'auteur (2018), etendre un front-end declaratif pour laisser Z3 temoigner. La compilation regex -> SMT et le DSL Z3.Linq sont **le meme geste dans deux librairies**.\n",
+    "- **Epic #2162 (Game of Life, Lean)** : **John** Conway, a ne pas confondre avec **Damian** (regex).\n",
+    "\n",
+    "### La preuve Lean derriere RE#\n",
+    "- **[ezhuchko/finiteness-derivatives](https://github.com/ezhuchko/finiteness-derivatives)** (Lean 4, sans Mathlib) : formalise la **finitude des derivees symboliques** = le theoreme de terminaison/decidabilite derriere la reconnaissance non-backtracking temps lineaire de RE#. Companion CPP 2024 (Zhuchko / Veanes / Ebner).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## A retenir\n",
+    "\n",
+    "- **Reconnaitre != resoudre** : RE# verifie (temps lineaire), Z3 produit (le temoin). Le Sudoku a besoin des deux.\n",
+    "- Les deux murs de 2020 (explosion DFA, cap temoin 21 char) tombent a **deux outils differents** : RE# et Z3.\n",
+    "- L'**ironie** : le verificateur le plus elegant (RE#) certifie, plus vite que Z3 n'a resolu, une grille qu'il ne peut pas produire.\n",
+    "- Z3, appele directement (sans le chemin SFAz3 cape), **n'a pas** le mur des 21 caracteres : c'est le resolveur reel du benchmark Sudoku multi-paradigmes."
    ]
   }
  ],
@@ -4641,18 +2310,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.587233,
-   "end_time": "2026-05-12T08:30:06.858888+00:00",
+   "duration": 5.936137,
+   "end_time": "2026-06-14T21:32:51.397922+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Sudoku-13-SymbolicAutomata-Csharp.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sudoku13_v2.ipynb",
+   "input_path": "_sudoku13_rewrite.ipynb",
+   "output_path": "_sudoku13_rewrite_out.ipynb",
    "parameters": {},
-   "start_time": "2026-05-12T08:29:56.271655+00:00",
+   "start_time": "2026-06-14T21:32:45.461785+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Epic **#2978 Deliverable A** : rachete le notebook `Sudoku-13-SymbolicAutomata-Csharp.ipynb` qui etait un *bait-and-switch*, en racontant honnetement l'echelle 2x3 *resoudre vs verifier*.

## L'ancien notebook (bait-and-switch, verifie par audit G.1)

Pretendait faire des automates symboliques mais :
- ne verifiait que le **format** (9 chiffres), cell 17 `#r "nuget:Z3"` ;
- **reimplementait a la main** `CharSet` / `SymbolicAutomaton` (cells 3/10/14/21/25) ;
- degradait vers un Z3 `Distinct` renomme "compilation d'automates" (section 5-6) ;
- concluait "Automata.Net deprecie, utilisez Z3 directement" (cell 30, justifie par "37 ms").

## Le rewrite — les 3 barreaux honnetes

| Barreau | Tool | Role | Mur |
|---------|------|------|-----|
| 1. **Damian Conway** ([perlmonks #596304](https://www.perlmonks.org/?node_id=596304)) | PCRE backtracking | anti-modele | monstre illisible (lookaheads gigantesques). Fragment decoratif NON execute |
| 2. **2020 BREX/Rex+Z3** | AutomataDotNet `MkAnd` builder + `RegexToSMT` | le vrai resolveur, mure | (a) explosion DFA `BREXTests '//too many states'` ; (b) cap temoin 21-char ([AutomataDotNet/Automata#6](https://github.com/AutomataDotNet/Automata/issues/6), 0 reponse depuis 2020-12-07) |
| 3. **RE# 2025** ([NuGet Resharp](https://www.nuget.org/packages/Resharp)) | `&`/`~` first-class, non-backtracking temps lineaire | **verificateur** recognition-only | ne genere AUCUN temoin |

## La contrainte de ligne comme intersection (le coeur pedagogique)

La ligne Sudoku valide encodee comme une **intersection de 10 regex** :
```
[1-9]{9} & .*1.* & .*2.* & .*3.* & .*4.* & .*5.* & .*6.* & .*7.* & .*8.* & .*9.*
```
C'est **exactement** l'operation qui faisait exploser le DFA en 2020 (`//too many states` sur 8-9 underscores). Avec RE#, elle compile en ~50 ms et s'execute en temps lineaire. Le mur 1 de 2020 tombe.

## Z3 = le resolveur (pas un cop-out)

Z3 appele **directement** (sans le chemin SFAz3 mure) encode `Ligne & Colonne & Bloc` comme assertions SMT sur 81 entiers et produit un **modele = la grille solution (temoin)** en ~27 ms. C'est le **resolveur reel du benchmark Sudoku multi-paradigmes**, complement indispensable de RE# le verificateur. Le "cop-out" de l'ancienne version est tue : non, Z3 n'est pas une degression honteuse - c'est l'autre face de la serie.

## L'ironie pedagogique (these de la serie), DEMONTREE et verifiee

RE# valide les **9 lignes de la solution produite par Z3** en ~18 ms - **plus vite que Z3 n'a resolu** (27 ms) - une grille que RE# est lui-meme **incapable de produire** (recognition-only). Double retournement : le verificateur le plus elegant certifie ce qu'il ne peut fabriquer, et le certifie plus vite que la toolchain (Automata / intersection DFA) qui explosait.

## Honnetete technique (G.1 / G.9)

Le complement `~` de RE# a une semantique **subtile** via l'API `Matches` (recherche de sous-chaines) qui ne donne pas le complement langage intuitif (`~.*9.*` se comporte comme `.*9.*`). Pour ne pas enseigner une operation erronee, la **demonstration s'appuie sur l'INTERSECTION `&`** (robuste, verifiable). Le `~` est mentionne comme capacite first-class **documentee** par le moteur, sans demo fallacieuse. L'exercice 1 utilise une contrainte d'intersection pure (ligne valide avec 5 avant 7).

## Validation C.2

```
papermill .net-csharp : 29/29 cells
10/10 code cells : execution_count 1-10, 0 erreur runtime
3 exercices C.1 (stubs sans raise NotImplementedError)
0 catalogue churn (1 fichier notebook, atomique)
```

**DLL refs locales** (pas de `#r "nuget:"` qui hang sous papermill, cf gotcha memoire) :
- RE# : `Resharp.dll` + `Resharp.Runtime.dll` + `FSharp.Core 10.1.300` (assembly 10.0.0.0 requise) ;
- Z3 : `Microsoft.Z3.dll` + `NativeLibrary.SetDllImportResolver` pointant vers `libz3.dll` native du cache nuget.

## Authorship HARD

Pilier 2020 de l'auteur (narratif honnete, histoire preservee). RE# via NuGet Resharp uniquement - **pas de patch AutomataDotNet** (= #2979 cerise separee, non faite). Z3 = resolveur du benchmark, pas un cop-out. Footnote homonymie : **Damian** Conway (regex) != **John** Conway (Game of Life, #2162).

## Connexions

- [Sudoku-12 Z3 C#](Sudoku-12-Z3-Csharp.ipynb) : le resolveur Z3 en profondeur (bit-vectors). Ce notebook presente le meme Z3 sous l'angle narratif "regex symbolique -> SMT -> temoin".
- Epic #1206 (Z3.Linq DSL) : le meme geste (etendre un front-end declaratif -> Z3 temoin) dans une autre librairie.
- ezhuchko/finiteness-derivatives (Lean, cite) : la preuve de finitude des derivees = terminaison de RE#.

See jsboige/CoursIA#2978 (epic reste ouverte : livrables B Z3 + C Lean en track separees).