### PR TITLE
enrich(ml): Lab1-PythonForDataScience -- fix malformed Exercice 2 + dedupe Ex3 (3-exos #2161)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb
@@ -5,10 +5,10 @@
    "id": "835f4a3b",
    "metadata": {
     "papermill": {
-     "duration": 0.015557,
-     "end_time": "2026-05-13T00:05:26.403991+00:00",
+     "duration": 0.0025,
+     "end_time": "2026-06-14T23:04:47.757549+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:26.388434+00:00",
+     "start_time": "2026-06-14T23:04:47.755049+00:00",
      "status": "completed"
     },
     "tags": []
@@ -40,10 +40,10 @@
    "id": "15325427",
    "metadata": {
     "papermill": {
-     "duration": 0.009563,
-     "end_time": "2026-05-13T00:05:26.427257+00:00",
+     "duration": 0.002001,
+     "end_time": "2026-06-14T23:04:47.762411+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:26.417694+00:00",
+     "start_time": "2026-06-14T23:04:47.760410+00:00",
      "status": "completed"
     },
     "tags": []
@@ -60,16 +60,16 @@
    "id": "b8135e93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T00:05:26.456018Z",
-     "iopub.status.busy": "2026-05-13T00:05:26.455658Z",
-     "iopub.status.idle": "2026-05-13T00:05:26.960469Z",
-     "shell.execute_reply": "2026-05-13T00:05:26.959638Z"
+     "iopub.execute_input": "2026-06-14T23:04:47.768309Z",
+     "iopub.status.busy": "2026-06-14T23:04:47.768072Z",
+     "iopub.status.idle": "2026-06-14T23:04:49.525861Z",
+     "shell.execute_reply": "2026-06-14T23:04:49.524709Z"
     },
     "papermill": {
-     "duration": 0.520959,
-     "end_time": "2026-05-13T00:05:26.961133+00:00",
+     "duration": 1.762571,
+     "end_time": "2026-06-14T23:04:49.527279+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:26.440174+00:00",
+     "start_time": "2026-06-14T23:04:47.764708+00:00",
      "status": "completed"
     },
     "tags": []
@@ -277,10 +277,10 @@
    "id": "dc7197a5",
    "metadata": {
     "papermill": {
-     "duration": 0.010096,
-     "end_time": "2026-05-13T00:05:26.982596+00:00",
+     "duration": 0.001944,
+     "end_time": "2026-06-14T23:04:49.531774+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:26.972500+00:00",
+     "start_time": "2026-06-14T23:04:49.529830+00:00",
      "status": "completed"
     },
     "tags": []
@@ -297,16 +297,16 @@
    "id": "ab6b41dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T00:05:27.004329Z",
-     "iopub.status.busy": "2026-05-13T00:05:27.004075Z",
-     "iopub.status.idle": "2026-05-13T00:05:27.031141Z",
-     "shell.execute_reply": "2026-05-13T00:05:27.030334Z"
+     "iopub.execute_input": "2026-06-14T23:04:49.537401Z",
+     "iopub.status.busy": "2026-06-14T23:04:49.537189Z",
+     "iopub.status.idle": "2026-06-14T23:04:49.560441Z",
+     "shell.execute_reply": "2026-06-14T23:04:49.559482Z"
     },
     "papermill": {
-     "duration": 0.039316,
-     "end_time": "2026-05-13T00:05:27.032049+00:00",
+     "duration": 0.027242,
+     "end_time": "2026-06-14T23:04:49.561220+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:26.992733+00:00",
+     "start_time": "2026-06-14T23:04:49.533978+00:00",
      "status": "completed"
     },
     "tags": []
@@ -381,10 +381,10 @@
    "id": "3d48fe3e",
    "metadata": {
     "papermill": {
-     "duration": 0.013644,
-     "end_time": "2026-05-13T00:05:27.058743+00:00",
+     "duration": 0.002303,
+     "end_time": "2026-06-14T23:04:49.566194+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:27.045099+00:00",
+     "start_time": "2026-06-14T23:04:49.563891+00:00",
      "status": "completed"
     },
     "tags": []
@@ -401,16 +401,16 @@
    "id": "ca121e84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T00:05:27.090881Z",
-     "iopub.status.busy": "2026-05-13T00:05:27.090476Z",
-     "iopub.status.idle": "2026-05-13T00:05:27.104573Z",
-     "shell.execute_reply": "2026-05-13T00:05:27.103674Z"
+     "iopub.execute_input": "2026-06-14T23:04:49.572238Z",
+     "iopub.status.busy": "2026-06-14T23:04:49.572058Z",
+     "iopub.status.idle": "2026-06-14T23:04:49.586139Z",
+     "shell.execute_reply": "2026-06-14T23:04:49.585376Z"
     },
     "papermill": {
-     "duration": 0.033211,
-     "end_time": "2026-05-13T00:05:27.105438+00:00",
+     "duration": 0.018814,
+     "end_time": "2026-06-14T23:04:49.587335+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:27.072227+00:00",
+     "start_time": "2026-06-14T23:04:49.568521+00:00",
      "status": "completed"
     },
     "tags": []
@@ -468,10 +468,10 @@
    "id": "1130c5f1",
    "metadata": {
     "papermill": {
-     "duration": 0.011894,
-     "end_time": "2026-05-13T00:05:27.132076+00:00",
+     "duration": 0.002139,
+     "end_time": "2026-06-14T23:04:49.594347+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:27.120182+00:00",
+     "start_time": "2026-06-14T23:04:49.592208+00:00",
      "status": "completed"
     },
     "tags": []
@@ -488,16 +488,16 @@
    "id": "0a68ef7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T00:05:27.159352Z",
-     "iopub.status.busy": "2026-05-13T00:05:27.159127Z",
-     "iopub.status.idle": "2026-05-13T00:05:28.397154Z",
-     "shell.execute_reply": "2026-05-13T00:05:28.396344Z"
+     "iopub.execute_input": "2026-06-14T23:04:49.599710Z",
+     "iopub.status.busy": "2026-06-14T23:04:49.599517Z",
+     "iopub.status.idle": "2026-06-14T23:04:51.282469Z",
+     "shell.execute_reply": "2026-06-14T23:04:51.281759Z"
     },
     "papermill": {
-     "duration": 1.25309,
-     "end_time": "2026-05-13T00:05:28.398012+00:00",
+     "duration": 1.686807,
+     "end_time": "2026-06-14T23:04:51.283403+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:27.144922+00:00",
+     "start_time": "2026-06-14T23:04:49.596596+00:00",
      "status": "completed"
     },
     "tags": []
@@ -544,10 +544,10 @@
    "id": "fcfbcab7",
    "metadata": {
     "papermill": {
-     "duration": 0.017974,
-     "end_time": "2026-05-13T00:05:28.435895+00:00",
+     "duration": 0.002137,
+     "end_time": "2026-06-14T23:04:51.288177+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:28.417921+00:00",
+     "start_time": "2026-06-14T23:04:51.286040+00:00",
      "status": "completed"
     },
     "tags": []
@@ -564,16 +564,16 @@
    "id": "35c17584",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T00:05:28.473784Z",
-     "iopub.status.busy": "2026-05-13T00:05:28.473363Z",
-     "iopub.status.idle": "2026-05-13T00:05:30.610003Z",
-     "shell.execute_reply": "2026-05-13T00:05:30.608959Z"
+     "iopub.execute_input": "2026-06-14T23:04:51.294723Z",
+     "iopub.status.busy": "2026-06-14T23:04:51.294458Z",
+     "iopub.status.idle": "2026-06-14T23:05:11.289095Z",
+     "shell.execute_reply": "2026-06-14T23:05:11.286948Z"
     },
     "papermill": {
-     "duration": 2.156511,
-     "end_time": "2026-05-13T00:05:30.610963+00:00",
+     "duration": 19.999639,
+     "end_time": "2026-06-14T23:05:11.290492+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:28.454452+00:00",
+     "start_time": "2026-06-14T23:04:51.290853+00:00",
      "status": "completed"
     },
     "tags": []
@@ -640,10 +640,10 @@
    "id": "usehv1a6pxl",
    "metadata": {
     "papermill": {
-     "duration": 0.02008,
-     "end_time": "2026-05-13T00:05:30.645553+00:00",
+     "duration": 0.005098,
+     "end_time": "2026-06-14T23:05:11.302324+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:30.625473+00:00",
+     "start_time": "2026-06-14T23:05:11.297226+00:00",
      "status": "completed"
     },
     "tags": []
@@ -667,16 +667,16 @@
    "id": "zbon5l0ll6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T00:05:30.678149Z",
-     "iopub.status.busy": "2026-05-13T00:05:30.677520Z",
-     "iopub.status.idle": "2026-05-13T00:05:30.683883Z",
-     "shell.execute_reply": "2026-05-13T00:05:30.682969Z"
+     "iopub.execute_input": "2026-06-14T23:05:11.313774Z",
+     "iopub.status.busy": "2026-06-14T23:05:11.313273Z",
+     "iopub.status.idle": "2026-06-14T23:05:11.318032Z",
+     "shell.execute_reply": "2026-06-14T23:05:11.317057Z"
     },
     "papermill": {
-     "duration": 0.020721,
-     "end_time": "2026-05-13T00:05:30.684920+00:00",
+     "duration": 0.012273,
+     "end_time": "2026-06-14T23:05:11.318807+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:30.664199+00:00",
+     "start_time": "2026-06-14T23:05:11.306534+00:00",
      "status": "completed"
     },
     "tags": []
@@ -721,19 +721,58 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "jwndxchh3x9",
    "metadata": {
     "papermill": {
-     "duration": 0.019265,
-     "end_time": "2026-05-13T00:05:30.725039+00:00",
+     "duration": 0.002222,
+     "end_time": "2026-06-14T23:05:11.323979+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:30.705774+00:00",
+     "start_time": "2026-06-14T23:05:11.321757+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "source": [
+    "### Exercice 2 : Filtrage conditionnel et statistiques\n",
+    "\n",
+    "À partir du DataFrame `df`, identifiez les transactions « exceptionnelles » de la catégorie **Electronique** :\n",
+    "\n",
+    "1. Calculez la moyenne globale des ventes sur tout le dataset\n",
+    "2. Créez un DataFrame filtré contenant uniquement les transactions de catégorie `Electronique` dont les ventes sont **strictement supérieures** à cette moyenne globale\n",
+    "3. Affichez le nombre d'enregistrements filtrés et un aperçu du résultat\n",
+    "\n",
+    "**Indices** : Utilisez `df[\"Ventes\"].mean()` pour la moyenne, et combinez les deux conditions avec l'opérateur `&` (pensez aux parenthèses autour de chaque condition)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "p6vxw85pwk",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T23:05:11.330330Z",
+     "iopub.status.busy": "2026-06-14T23:05:11.330042Z",
+     "iopub.status.idle": "2026-06-14T23:05:11.334127Z",
+     "shell.execute_reply": "2026-06-14T23:05:11.333513Z"
+    },
+    "papermill": {
+     "duration": 0.008773,
+     "end_time": "2026-06-14T23:05:11.335028+00:00",
+     "exception": false,
+     "start_time": "2026-06-14T23:05:11.326255+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : calculez la moyenne et filtrez le DataFrame\n"
+     ]
+    }
+   ],
    "source": [
     "# Votre code pour l'Exercice 2\n",
     "\n",
@@ -751,74 +790,7 @@
     "    print(\"DataFrame filtré (Electronique avec ventes > moyenne) :\")\n",
     "    print(df_filtre.head())\n",
     "else:\n",
-    "    print(\"Exercice à compléter : calculez la moyenne et filtrez le DataFrame\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "p6vxw85pwk",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-13T00:05:30.762892Z",
-     "iopub.status.busy": "2026-05-13T00:05:30.762695Z",
-     "iopub.status.idle": "2026-05-13T00:05:30.768131Z",
-     "shell.execute_reply": "2026-05-13T00:05:30.767337Z"
-    },
-    "papermill": {
-     "duration": 0.025259,
-     "end_time": "2026-05-13T00:05:30.768818+00:00",
-     "exception": false,
-     "start_time": "2026-05-13T00:05:30.743559+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice à compléter : filtrez les DataFrames et entraînez les modèles\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Votre code pour l'Exercice 3\n",
-    "\n",
-    "from sklearn.linear_model import LinearRegression\n",
-    "from sklearn.model_selection import train_test_split\n",
-    "import numpy as np\n",
-    "\n",
-    "# TODO: Créez deux DataFrames, un pour chaque produit (Widget A et Gadget X)\n",
-    "df_widget_a = None  # Filtrez df où Produit == \"Widget A\"\n",
-    "df_gadget_x = None  # Filtrez df où Produit == \"Gadget X\"\n",
-    "\n",
-    "# TODO: Préparez les features (X = Jour) et target (y = Ventes) pour Widget A\n",
-    "X_a = None  # df_widget_a[[\"Jour\"]].values\n",
-    "y_a = None  # df_widget_a[\"Ventes\"].values\n",
-    "\n",
-    "# TODO: Préparez les features et target pour Gadget X\n",
-    "X_x = None\n",
-    "y_x = None\n",
-    "\n",
-    "# TODO: Entraînez un modèle pour chaque produit\n",
-    "model_a = LinearRegression()\n",
-    "model_x = LinearRegression()\n",
-    "\n",
-    "# Appelez model.fit(X, y) pour chaque modèle\n",
-    "\n",
-    "# TODO: Prédisez les ventes pour le jour 90 (31 mars)\n",
-    "prediction_a = None  # model_a.predict([[90]])[0]\n",
-    "prediction_x = None\n",
-    "\n",
-    "# Affichage des résultats\n",
-    "if prediction_a is not None and prediction_x is not None:\n",
-    "    print(f\"Prédiction jour 90 - Widget A : {prediction_a:.2f}\")\n",
-    "    print(f\"Prédiction jour 90 - Gadget X : {prediction_x:.2f}\")\n",
-    "    print(f\"Différence de prédictions : {abs(prediction_a - prediction_x):.2f}\")\n",
-    "else:\n",
-    "    print(\"Exercice à compléter : filtrez les DataFrames et entraînez les modèles\")\n"
+    "    print(\"Exercice à compléter : calculez la moyenne et filtrez le DataFrame\")"
    ]
   },
   {
@@ -826,10 +798,10 @@
    "id": "i2y3q9gnxge",
    "metadata": {
     "papermill": {
-     "duration": 0.011084,
-     "end_time": "2026-05-13T00:05:30.797906+00:00",
+     "duration": 0.00225,
+     "end_time": "2026-06-14T23:05:11.339943+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:30.786822+00:00",
+     "start_time": "2026-06-14T23:05:11.337693+00:00",
      "status": "completed"
     },
     "tags": []
@@ -848,16 +820,16 @@
    "id": "vqzr58prbl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T00:05:30.824063Z",
-     "iopub.status.busy": "2026-05-13T00:05:30.823801Z",
-     "iopub.status.idle": "2026-05-13T00:05:30.829682Z",
-     "shell.execute_reply": "2026-05-13T00:05:30.828783Z"
+     "iopub.execute_input": "2026-06-14T23:05:11.345897Z",
+     "iopub.status.busy": "2026-06-14T23:05:11.345713Z",
+     "iopub.status.idle": "2026-06-14T23:05:11.350367Z",
+     "shell.execute_reply": "2026-06-14T23:05:11.349582Z"
     },
     "papermill": {
-     "duration": 0.018393,
-     "end_time": "2026-05-13T00:05:30.830380+00:00",
+     "duration": 0.008782,
+     "end_time": "2026-06-14T23:05:11.350997+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:30.811987+00:00",
+     "start_time": "2026-06-14T23:05:11.342215+00:00",
      "status": "completed"
     },
     "tags": []
@@ -914,10 +886,10 @@
    "id": "c90eacd2",
    "metadata": {
     "papermill": {
-     "duration": 0.015,
-     "end_time": "2026-05-13T00:05:30.861508+00:00",
+     "duration": 0.002165,
+     "end_time": "2026-06-14T23:05:11.355795+00:00",
      "exception": false,
-     "start_time": "2026-05-13T00:05:30.846508+00:00",
+     "start_time": "2026-06-14T23:05:11.353630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -958,18 +930,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.722388,
-   "end_time": "2026-05-13T00:05:31.347099+00:00",
+   "duration": 26.150765,
+   "end_time": "2026-06-14T23:05:11.808082+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb",
-   "output_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience_output.ipynb",
+   "input_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\PythonAgentsForDataScience\\Day1\\Labs\\Lab1-PythonForDataScience.ipynb",
+   "output_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\PythonAgentsForDataScience\\Day1\\Labs\\Lab1-PythonForDataScience_output_20260615_010445.ipynb",
    "parameters": {},
-   "start_time": "2026-05-13T00:05:24.624711+00:00",
+   "start_time": "2026-06-14T23:04:45.657317+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

`Lab1-PythonForDataScience.ipynb` (ML/DataScienceWithAgents, Day1 Labs) had a **cell-order bug** leaving it at 2 properly-structured exercises — below the ≥3 threshold of convention **#2161**:

- **Exercice 2** existed only as a malformed *code-comment-style markdown cell* (no `### Exercice 2` header, no code stub — the task description was written as Python comments inside a markdown cell).
- The **Exercice 3** code stub was **duplicated** (`cell14` == `cell16`, identical content), with one copy misplaced *before* the Ex3 header.

Net effect: only Ex1 and Ex3 were properly structured (header + stub). Ex2 was invisible to any exercise-counting tool and had no runnable stub.

## Fix (additive — 0 pedagogical content loss, 0 cells deleted)

| Cell | Before | After |
|------|--------|-------|
| `cell13` (md) | malformed code-comment Ex2 (no header) | proper `### Exercice 2 : Filtrage conditionnel et statistiques` enoncé |
| `cell14` (code) | duplicate Ex3 stub (== cell16) | **Ex2 code stub** (repurposed — C.1-conformant: `None` + conditional `print`, no `raise NotImplementedError`) |
| all md cells | invalid `execution_count`/`outputs` fields (papermill cruft, nbformat-invalid) | stripped → nbformat VALID |

The Ex2 task (filter `Categorie == "Electronique"` with `Ventes > moyenne_globale`) was **already described** in the old malformed cell — I extracted it into a clean enoncé + moved its code into the repurposed stub. No invented content, no deleted enoncé.

## Validation (gate H.4)

- **Papermill SUCCESS**: 8/8 code cells executed, 0 failed, 26s, kernel `python3` (pure pandas/sklearn, deterministic `seed=42`).
- **C.2**: `execution_count` contiguous `[1..8]`, 0 errors, real outputs.
- **C.1**: 0 forbidden patterns (`raise NotImplementedError` / `assert False` / `1/0`).
- **#2161**: 3 exercises (Ex1 stats-by-product / Ex2 conditional-filter / Ex3 per-product regression), all header+stub structured.
- **nbformat**: VALID (post papermill-cruft strip).
- **Anti-regression (rule D)**: cell count unchanged (18), all 3 enoncés + stubs present, Ex3 canonical stub preserved (duplicate eliminated 2→1), catalog byte-identical to `main`.

## Scope

1 file, +112/-140 (the −140 = duplicate Ex3 removal + invalid markdown-field strip + papermill output re-serialization — **not** pedagogical content loss, verified cell-by-cell). Atomic, single subject.

See #2161 (convention rollout — partial, not closing the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
