### PR TITLE
docs(genai): document service_wake.py wake-on-demand in genai-services.md

### DIFF
--- a/docs/genai/genai-services.md
+++ b/docs/genai/genai-services.md
@@ -200,6 +200,28 @@ BATCH_MODE=false
 - `vllm-zimage`, `tts-fishaudio` — `service_idle_monitor.py` (stops container)
 - `sd-forge-main` — `service_idle_monitor.py` with HTTP Basic Auth (Caddy reverse proxy)
 
+**Wake-on-demand** (`shared/service_wake.py`): a stopped container has no
+listener, so a notebook hitting an idle-stopped service gets HTTP 502 until a
+manual `docker start` + warm-up. `service_wake.py` is the demand-side counterpart
+to `service_idle_monitor.py` — it probes `/health` and, if down, issues
+`docker start <container>` then polls until healthy:
+
+```bash
+python docker-configurations/services/shared/service_wake.py musicgen-api \
+  --health-url http://localhost:8192/health -v
+```
+
+```python
+from service_wake import ensure_service_up
+if ensure_service_up("musicgen-api", "http://localhost:8192/health"):
+    # safe to call POST /v1/generate (transparent warm-up done)
+    ...
+```
+
+VRAM economy is preserved: the idle monitor still re-stops the service after
+`idle_timeout`. See issue #2982 for the A/B/C/D decision rationale (caller-side
+wake chosen over reverse-proxy / always-on / native-sleep).
+
 **No idle handling (low VRAM or always-on):**
 - `tts-kokoro` (~1-2 GB), `forge-turbo` (~6-10 GB), `whisper-webui` (varies)
 


### PR DESCRIPTION
## What

Documents the wake-on-demand helper `service_wake.py` (delivered in #2998, merged) in the GenAI services reference. The helper was referenced **nowhere** in the docs — a notebook author or the next agent hitting a 502 on an idle-stopped service would not discover it.

## Context

`docs/genai/genai-services.md` "Idle Management" section (L193-204) documents the idle **monitors** that auto-stop services (`service_idle_monitor.py`, `comfyui_idle_monitor.py`) but said nothing about the **wake** side. After #2998, the mechanism exists but was invisible.

## Change

Add a "Wake-on-demand" paragraph right after the idle-monitor sidecar list, mirroring the existing structure:
- One-line rationale (stopped container has no listener → 502 → wake helper probes + `docker start` + polls).
- CLI usage (`python service_wake.py musicgen-api --health-url ...`).
- Python usage (`ensure_service_up(...)`).
- VRAM-economy note (monitor still re-stops after `idle_timeout`).
- Pointer to #2982 for the A/B/C/D decision rationale.

## Validation

- Markdown-only (C.2 exception — no notebook re-exec needed).
- Additive +22/-0, 0 deletions (anti-régression safe).
- Catalogue byte-identical to `origin/main`.
- Secrets-scan clean.

See #2982
