### PR TITLE
test(genai): lock api_key propagation contract in service_wake (#2982)

### DIFF
--- a/docker-configurations/services/shared/test_service_wake.py
+++ b/docker-configurations/services/shared/test_service_wake.py
@@ -116,6 +116,46 @@ def test_ensure_service_up_docker_start_fails():
         assert service_wake.ensure_service_up("svc", "http://h/health") is False
 
 
+def test_ensure_service_up_fast_path_forwards_api_key():
+    """Contrat sécurité (#16) : api_key doit atteindre probe_health même au
+    fast-path — sinon un service auth-actif renvoie 401 et le helper croit le
+    service down → déclenche un docker start inutile."""
+    received_keys = []
+
+    def fake_probe(url, api_key=None, timeout=5):
+        received_keys.append(api_key)
+        return True  # fast-path hit
+
+    with patch("service_wake.probe_health", side_effect=fake_probe):
+        assert service_wake.ensure_service_up(
+            "svc", "http://h/health", api_key="secret"
+        ) is True
+        assert received_keys == ["secret"], (
+            "api_key must propagate to probe_health on the fast-path"
+        )
+
+
+def test_ensure_service_up_cold_path_forwards_api_key():
+    """Contrat sécurité (#16) : api_key doit atteindre CHAQUE poll du cold-path
+    (fast-path down + post-start polls), pas seulement le 1er."""
+    received_keys = []
+
+    def fake_probe(url, api_key=None, timeout=5):
+        received_keys.append(api_key)
+        return len(received_keys) >= 3  # down, down, then healthy
+
+    with patch("service_wake.probe_health", side_effect=fake_probe), patch(
+        "service_wake.docker_start", return_value=True
+    ), patch("service_wake.time.sleep"):
+        assert service_wake.ensure_service_up(
+            "svc", "http://h/health", api_key="secret"
+        ) is True
+        # All probes (fast-path + cold-path polls) received the key.
+        assert received_keys == ["secret", "secret", "secret"], (
+            "api_key must propagate to every probe, not just the first"
+        )
+
+
 def test_ensure_service_up_times_out():
     """Service jamais healthy après start → False après timeout."""
 


### PR DESCRIPTION
## What

Pins the `api_key` propagation contract in `service_wake.py` (delivered #2998, merged). Two targeted unit tests that close a genuine coverage gap on a security-relevant helper.

## Gap

The 14 tests added with the helper cover `probe_health`'s Bearer-header wiring directly (`test_probe_health_sends_bearer_when_api_key`), but **none** assert that `ensure_service_up` forwards its `api_key` param through to `probe_health` — not on the fast-path, not on the cold-path polls. A future refactor could silently drop the arg.

**Why it matters (#16 security context):** with an auth-active service, a dropped `api_key` makes `probe_health` get HTTP 401 → the helper misreads the service as "down" → it triggers a spurious `docker start`. The wake helper must carry auth through every probe.

## Change

Two tests in `test_service_wake.py` (additive +40/-0):

- `test_ensure_service_up_fast_path_forwards_api_key` — fast-path hit, asserts the single probe received `api_key="secret"`.
- `test_ensure_service_up_cold_path_forwards_api_key` — cold path, asserts EVERY probe (fast-path down + post-start polls) received `api_key="secret"`, not just the first.

## Validation

```
16 passed in 0.23s   (14 existing + 2 new)
```

Plus a **real end-to-end cold-start** validated this cycle on po-2023 (not part of the PR — CI-runnable tests only — but confirms the cold path works in real conditions, previously mock-only):

- `demucs-api` idle-stopped (Exited 137, 6h) → `GET /health` connection-refused (the #2982 502 symptom).
- `python service_wake.py demucs-api --health-url http://localhost:8193/health -v` → `docker start` → **healthy in 7s**.
- `GET /v1/models` no-key → **401** (auth active) / with-key → **200** (model loaded).

## Scope

- Additive +40/-0, 0 deletions (anti-régression safe).
- CI-runnable (no docker/network dependency — pure unit, mocked).
- Catalogue byte-identical.

See #2982
