### PR TITLE
docs(z3): NB-03 cross-link vers NB-02b (modes Array vs Constants discoverability)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
@@ -383,7 +383,26 @@
     },
     "tags": []
    },
-   "source": "### Interprétation 1 — Le pattern closure pour Select\n\n**Sortie obtenue** : Un tableau de 5 entiers distincts entre 1 et 5 dont la somme vaut 14.\n\n| Aspect | Détail |\n|--------|---------|\n| Pattern clé | `var idx = iclosure;` capture l'index dans la closure lambda |\n| Traduction interne | `t.Values[idx]` → `ctx.MkSelect(arrayExpr, ctx.MkInt(idx))` |\n| Somme | Addition directe de 5 selects dans la contrainte LINQ |\n\n**Points clés** :\n1. La boucle `for` avec capture `iclosure` est indispensable : sans elle, toutes les closures captureraient la même valeur finale de `i`\n2. Z3.Linq traduit chaque `t.Values[idx]` en un appel `MkSelect` sur le tableau symbolique\n3. La contrainte de distinctness nécessite O(n²) clauses (ici 10 paires pour 5 éléments)\n\n> **Note technique** : La somme 1+2+3+4+5 = 15, donc pour obtenir 14 il faut remplacer un élément par un doublon d'un autre, mais la contrainte de distinctness force exactement la permutation qui somme à 14. Z3 explore cet espace automatiquement.\n\n> **Modes d'encodage des collections** : `int[] Values` est ici représenté via la **théorie des tableaux** Z3 — un seul `ArrayExpr` symbolique, et chaque `Values[i]` se traduit en `Select`. Z3.Linq offre une alternative, le mode **Constants** (`ctx.DefaultCollectionHandling = CollectionHandling.Constants`), qui crée un constant Z3 indépendant par élément au lieu d'un tableau symbolique. Les deux modes aboutissent à la même solution mais diffèrent dans la structure des formules SMT produites. Le notebook [02b — Sudoku Modes Comparison](02b_Sudoku_Modes_Comparison.ipynb) compare les deux modes côte à côte sur un Sudoku 4x4."
+   "source": [
+    "### Interprétation 1 — Le pattern closure pour Select\n",
+    "\n",
+    "**Sortie obtenue** : Un tableau de 5 entiers distincts entre 1 et 5 dont la somme vaut 14.\n",
+    "\n",
+    "| Aspect | Détail |\n",
+    "|--------|---------|\n",
+    "| Pattern clé | `var idx = iclosure;` capture l'index dans la closure lambda |\n",
+    "| Traduction interne | `t.Values[idx]` → `ctx.MkSelect(arrayExpr, ctx.MkInt(idx))` |\n",
+    "| Somme | Addition directe de 5 selects dans la contrainte LINQ |\n",
+    "\n",
+    "**Points clés** :\n",
+    "1. La boucle `for` avec capture `iclosure` est indispensable : sans elle, toutes les closures captureraient la même valeur finale de `i`\n",
+    "2. Z3.Linq traduit chaque `t.Values[idx]` en un appel `MkSelect` sur le tableau symbolique\n",
+    "3. La contrainte de distinctness nécessite O(n²) clauses (ici 10 paires pour 5 éléments)\n",
+    "\n",
+    "> **Note technique** : La somme 1+2+3+4+5 = 15, donc pour obtenir 14 il faut remplacer un élément par un doublon d'un autre, mais la contrainte de distinctness force exactement la permutation qui somme à 14. Z3 explore cet espace automatiquement.\n",
+    "\n",
+    "> **Modes d'encodage des collections** : `int[] Values` est ici représenté via la **théorie des tableaux** Z3 — un seul `ArrayExpr` symbolique, et chaque `Values[i]` se traduit en `Select`. Z3.Linq offre une alternative, le mode **Constants** (`ctx.DefaultCollectionHandling = CollectionHandling.Constants`), qui crée un constant Z3 indépendant par élément au lieu d'un tableau symbolique. Les deux modes aboutissent à la même solution mais diffèrent dans la structure des formules SMT produites. Le notebook [02b — Sudoku Modes Comparison](02b_Sudoku_Modes_Comparison.ipynb) compare les deux modes côte à côte sur un Sudoku 4x4."
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
@@ -383,24 +383,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation 1 — Le pattern closure pour Select\n",
-    "\n",
-    "**Sortie obtenue** : Un tableau de 5 entiers distincts entre 1 et 5 dont la somme vaut 14.\n",
-    "\n",
-    "| Aspect | Détail |\n",
-    "|--------|---------|\n",
-    "| Pattern clé | `var idx = iclosure;` capture l'index dans la closure lambda |\n",
-    "| Traduction interne | `t.Values[idx]` → `ctx.MkSelect(arrayExpr, ctx.MkInt(idx))` |\n",
-    "| Somme | Addition directe de 5 selects dans la contrainte LINQ |\n",
-    "\n",
-    "**Points clés** :\n",
-    "1. La boucle `for` avec capture `iclosure` est indispensable : sans elle, toutes les closures captureraient la même valeur finale de `i`\n",
-    "2. Z3.Linq traduit chaque `t.Values[idx]` en un appel `MkSelect` sur le tableau symbolique\n",
-    "3. La contrainte de distinctness nécessite O(n²) clauses (ici 10 paires pour 5 éléments)\n",
-    "\n",
-    "> **Note technique** : La somme 1+2+3+4+5 = 15, donc pour obtenir 14 il faut remplacer un élément par un doublon d'un autre, mais la contrainte de distinctness force exactement la permutation qui somme à 14. Z3 explore cet espace automatiquement."
-   ]
+   "source": "### Interprétation 1 — Le pattern closure pour Select\n\n**Sortie obtenue** : Un tableau de 5 entiers distincts entre 1 et 5 dont la somme vaut 14.\n\n| Aspect | Détail |\n|--------|---------|\n| Pattern clé | `var idx = iclosure;` capture l'index dans la closure lambda |\n| Traduction interne | `t.Values[idx]` → `ctx.MkSelect(arrayExpr, ctx.MkInt(idx))` |\n| Somme | Addition directe de 5 selects dans la contrainte LINQ |\n\n**Points clés** :\n1. La boucle `for` avec capture `iclosure` est indispensable : sans elle, toutes les closures captureraient la même valeur finale de `i`\n2. Z3.Linq traduit chaque `t.Values[idx]` en un appel `MkSelect` sur le tableau symbolique\n3. La contrainte de distinctness nécessite O(n²) clauses (ici 10 paires pour 5 éléments)\n\n> **Note technique** : La somme 1+2+3+4+5 = 15, donc pour obtenir 14 il faut remplacer un élément par un doublon d'un autre, mais la contrainte de distinctness force exactement la permutation qui somme à 14. Z3 explore cet espace automatiquement.\n\n> **Modes d'encodage des collections** : `int[] Values` est ici représenté via la **théorie des tableaux** Z3 — un seul `ArrayExpr` symbolique, et chaque `Values[i]` se traduit en `Select`. Z3.Linq offre une alternative, le mode **Constants** (`ctx.DefaultCollectionHandling = CollectionHandling.Constants`), qui crée un constant Z3 indépendant par élément au lieu d'un tableau symbolique. Les deux modes aboutissent à la même solution mais diffèrent dans la structure des formules SMT produites. Le notebook [02b — Sudoku Modes Comparison](02b_Sudoku_Modes_Comparison.ipynb) compare les deux modes côte à côte sur un Sudoku 4x4."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Résumé

Ajout d'une note pédagogique dans l'Interprétation 1 de NB-03 (Array Theory) qui introduit le mode alternatif `Constants` (`ctx.DefaultCollectionHandling`) et pointe vers NB-02b qui compare les deux modes côte à côte. **Cross-link discoverability, additif et non-duplicatif.**

## Contexte — réponse partielle à la directive ai-01 (#1206 co-evolution)

Analyse G.1 (verify contre source) avant action a révélé que la directive est basée sur un état **stale** :

1. **Lib CollectionHandling = DÉJÀ câblée** bout-en-bout par #2968 (MERGED) :
   - `Theorem.cs:67` setter `DefaultCollectionHandling` (default Array)
   - `Theorem.cs:217` switch Constants dans GetEnvironment
   - `Z3Context.cs:43,60,80` API propagée
   - `Environment.cs` + `ExpressionVisitor.cs` : MultipleEnvironment câblé
   - **Tests `dotnet test --filter CollectionHandling` : 6/6 PASS** (vérifié ce cycle)
2. **Modes Array vs Constants = DÉJÀ ENSEIGNÉS** dans NB-02b (#2985 merged) via `new Z3Context { DefaultCollectionHandling = ... }`.
3. **Bridge Microsoft.Z3 (Store/Switching) de NB-03 = irremplaçable en LINQ** : Store n'existe pas dans la DSL (table §1 de NB-03). Effacer = anti-régression d'un choix pédagogique conscient (§5).

→ Ce cross-link est l'option **additive sûre** : rendre les modes Constants découvrables depuis NB-03 **sans** dupliquer NB-02b ni effacer le bridge Store.

## Changement

Cellule `a7b8c9d6` (Interprétation 1, markdown) — ajout d'une note `> **Modes d'encodage des collections**` après l'explication de l'encodage Array (`t.Values[idx]` → `MkSelect`). La note mentionne le mode Constants + lien relatif vers NB-02b.

**Markdown-only** (exception C.2) : aucun code touché, aucun output modifié. 28→28 cells, 10→10 code cells.

## Validation

| Critère | Preuve |
|---------|--------|
| Markdown-only (C.2 exception) | 0 cellule code modifiée, outputs intacts |
| Lien relatif valide | `test -f 02b_Sudoku_Modes_Comparison.ipynb` = OK |
| 0 catalogue churn | `git diff --name-only \| grep catalog` = NO churn |
| Anti-duplication | Pointe vers NB-02b au lieu de recréer la démo |
| Anti-régression | Bridge Microsoft.Z3 (Store/Switching) préservé intégralement |

[ASK posté à ai-01 sur le dashboard] pour la décision finale sur NB-03 (R1=accepter co-evolution déjà faite / R2=ce cross-link / R3=gap technique précis à préciser).

See #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)