### PR TITLE
feat(lean): Conway P4 -- wf_node_quad_level helper (depth-1 P4.1 ingredient) (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -851,6 +851,26 @@ private theorem wf_node_elim {nw ne sw se : MacroCell}
   simp only [MacroCell.wf, Bool.and_eq_true, beq_iff_eq] at h
   tauto
 
+/-- Combine a node's `level` and `wf` hypotheses to extract the **absolute**
+    level (not merely equality) and well-formedness of all four quadrants.
+    `wf_node_elim` yields only relative level equality (`ne.level = nw.level`
+    etc.); this lemma closes the gap by folding in `(node nw ne sw se).level
+    = n + 1` to pin each quadrant's level to `n`. This is the depth-1
+    ingredient of the P4 double-nine decomposition (`p4_double_nine_shape`),
+    which needs every depth-2 sub-component of a well-formed level-`(k+2)`
+    cell to carry a known level `k`. Reusable wherever a well-formed node's
+    quadrant levels must be pinned to an absolute value rather than a spine
+    offset. -/
+private theorem wf_node_quad_level {nw ne sw se : MacroCell} {n : Nat}
+    (hlevel : (node nw ne sw se).level = n + 1)
+    (hwf : (node nw ne sw se).wf = true) :
+    nw.level = n ∧ ne.level = n ∧ sw.level = n ∧ se.level = n ∧
+      nw.wf = true ∧ ne.wf = true ∧ sw.wf = true ∧ se.wf = true := by
+  obtain ⟨hnw, hne, hsw, hse, hne_eq, hsw_eq, hse_eq⟩ := wf_node_elim hwf
+  simp only [MacroCell.level] at hlevel
+  refine ⟨?_, ?_, ?_, ?_, hnw, hne, hsw, hse⟩
+  all_goals omega
+
 /-! ## P3/P4 structural input: empty + padding level/wf preservation
 
 `emptyOfLevel`, `padToLevelPlus1`, `padCenter2`, and `centerInLevelPlus2`


### PR DESCRIPTION
## Summary

Add a sorry-free structural lemma `wf_node_quad_level` that combines a node's `level = n+1` and `wf = true` hypotheses to pin **all four quadrants** to absolute level `n` and well-formedness.

### Why

`wf_node_elim` (existing) yields only **relative** level equality (`ne.level = nw.level`, etc.). The P4 double-nine decomposition (`p4_double_nine_shape`, currently a `: True := by sorry` placeholder) needs every depth-2 sub-component of a well-formed level-`(k+2)` cell to carry a **known absolute** level `k`. This lemma closes that gap with `omega`, and is the depth-1 ingredient reusable by P4.2 / P4.3 (IH instantiation on the sub-cells).

This is grignotage progress on #2162 P4 (the inductive-step pillar), delivered as a self-contained sorry-free lemma rather than touching the placeholder.

### Statement

```lean
private theorem wf_node_quad_level {nw ne sw se : MacroCell} {n : Nat}
    (hlevel : (node nw ne sw se).level = n + 1)
    (hwf : (node nw ne sw se).wf = true) :
    nw.level = n ∧ ne.level = n ∧ sw.level = n ∧ se.level = n ∧
      nw.wf = true ∧ ne.wf = true ∧ sw.wf = true ∧ se.wf = true := by
  obtain ⟨hnw, hne, hsw, hse, hne_eq, hsw_eq, hse_eq⟩ := wf_node_elim hwf
  simp only [MacroCell.level] at hlevel
  refine ⟨?_, ?_, ?_, ?_, hnw, hne, hsw, hse⟩
  all_goals omega
```

## Lean PR discipline (§B)

| Item | Proof |
|------|-------|
| `grep -cE '^\s*sorry\b'` before → after | `HashlifeCorrectness.lean`: **6 → 6** (additive lemma, no placeholder touched, no regression) |
| Lake build SUCCESS | `lake build Conway.Life.HashlifeCorrectness` → **[3320/3320] Built (175s)**, `grep -c '^error:' = 0` (olen deleted for genuine recompile) |
| Proof integrity | 0 axiom: proof uses only `wf_node_elim` (simp + tauto, sound) + `MacroCell.level` (def) + `omega` (sound) |
| No prover refactor | N/A — single additive lemma, no `agent_tests/prover/` change |

## Test plan

- [x] `lake build Conway.Life.HashlifeCorrectness` SUCCESS local (WSL, Lean 4.30.0-rc2)
- [x] sorry count unchanged (6 → 6)
- [x] diff coherent: 20 insertions, 0 deletions (pure addition)

See #2162 (partial contribution to the P4 pillar of the Conway Hashlife correctness epic — does not close the epic).