### PR TITLE
enrich(IIT): interpret uniform cause/effect repertoire in IIT-2 (See #1943, #2161)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
@@ -513,6 +513,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2f73fae8",
+   "source": "### Interpretation : un mecanisme qui ne specifie aucune information\n\nLes deux repertoires sont **uniformes** (`[0.5, 0.5]`) : le mecanisme {A, B} dans son etat actuel ne contraint **ni** le passe **ni** le futur du purview {A}.\n\n- En **cause**, savoir que {A, B} = (0, 1) ne modifie pas la probabilite des etats anterieurs de A : les deux restent equiprobables.\n- En **effet**, ce meme mecanisme ne biaise pas davantage l'etat futur de A.\n\nAutrement dit, ce couple (mecanisme, purview) **ne specifie aucune information** : son repertoire contraint est identique au repertoire non-perturbe (uniforme). C'est exactement ce que la section suivante va quantifier — la distance EMD entre le repertoire contraint et le repertoire non-perturbe sera **nulle**, confirmant l'absence d'information specifiee.\n\n> A l'inverse, un purview informatif produirait une distribution **non uniforme** (par exemple `[0.75, 0.25]`), revelant que le mecanisme penche vers un etat particulier du purview. C'est ce contraste qui fonde la notion de *small phi* ($\\varphi$) etudiee plus loin.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "657313aa",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

Adds one **interpretation markdown cell** to `MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb`, after the cause/effect repertoire computation (cells `57384b10` / `fcf92c26`).

Item 8 of the po-2025 Python deep-queue (#2161 rollout fallback): *"notebooks IIT/PyPhi a cellules-code-consecutives sans interpretation"*. The cause/effect repertoire results were computed but left uninterpreted before §3.2.

## Why

Both repertoires for mechanism `{A,B}` -> purview `{A}` come out **uniform `[0.5, 0.5]`** — a pedagogically meaningful result: this mechanism specifies **no information** about A's past or future. The notebook jumps straight to §3.2 (unconstrained repertoire) and shows `EMD = 0.0000` without prose tying it back. The new cell:

- Reads the actual computed values (`[0.5, 0.5]`), not a generic transition.
- Explains the cause/effect symmetry and the "no information specified" meaning.
- Bridges to §3.2 (predicts the EMD=0 result) and forward to *small phi* ($\varphi$).

## Validation

- **Markdown-only** insertion: `git diff --stat` = `1 file changed, 6 insertions(+)`, **0 deletions**, **0 code/output structural lines** added or removed.
- Existing outputs preserved per **C.2** (markdown-only exception -> no re-execution required).
- `nbformat.validate` PASS (39 cells).
- 3 exercise stubs intact (cells 15/23/36), all C.1-conform (`return None` / `print("...a completer")`, no `NotImplementedError`).
- Catalog **byte-identical to main** (not regenerated on branch, per catalog-pr-hygiene).
- One notebook, one subject (atomic).

See #1943
See #2161