### PR TITLE
feat(lean): Lean-15 Finiteness-Derivatives — Brzozowski derivatives notebook (See #2978)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Finiteness-Derivatives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Finiteness-Derivatives.ipynb
@@ -1,0 +1,425 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "abb4bf69",
+   "metadata": {},
+   "source": [
+    "# Lean-15 — Dérivées symboliques de Brzozowski : la finitude qui garantit le *matching* linéaire\n",
+    "\n",
+    "**Série SymbolicAI/Lean** — Pont vers l'Epic #2978 (*le Sudoku comme regex symbolique*), livrable **C (Lean)**. See #2978 (partial), See #2162 (homonymie Conway).\n",
+    "\n",
+    "> *Note d'homonymie posée d'entrée.* Le héros de notre Epic Lean `conway_lean` (#2162) est **John Horton Conway**, mathématicien, créateur du *Game of Life*. Le célèbre *sudoku en regex Perl* (Perlmonks, 2002) est l'œuvre de **Damian Conway**, linguiste-informaticien. **Deux Conway distincts.** Les deux se « rencontrent » dans cette série : l'un par la reconnaissance par regex, l'autre par la formalisation du Jeu de la Vie. Ce notebook documente ce clin d'œil, pas une confusion."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c3d28bf",
+   "metadata": {},
+   "source": [
+    "## 1. Le problème : pourquoi un reconnaisseur regex *devrait* être linéaire\n",
+    "\n",
+    "Un reconnaisseur d'expressions régulières (*regex matcher*) lit un mot caractère par caractère. Deux familles :\n",
+    "\n",
+    "- **Backtracking** (PCRE, moteurs « NFA traditionnels ») : en cas d'échec, le moteur *revient en arrière* et essaie une autre branche. Simple à implémenter, mais la complexité peut devenir **exponentielle** (catastrophic backtracking). C'est la famille du *sudoku en regex* de Damian Conway — un monstre de lookaheads gigantesques.\n",
+    "- **Non-backtracking** (DFA / dérivées) : on consomme **chaque caractère une seule fois**, sans retour. Complexité **linéaire** en la longueur du mot. C'est la famille de `.NET RegexOptions.NonBacktracking` (PLDI 2023), de **RE#** (POPL 2025) et de SymPy.\n",
+    "\n",
+    "La question de fond : **comment garantir qu'un reconnaisseur non-backtracking termine ?** Réponse : si l'ensemble des « états » qu'il peut visiter est **fini**. Et cet ensemble d'états, c'est exactement l'ensemble des **dérivées** de la regex — un concept dû à Janusz Brzozowski en 1964."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6eb658f",
+   "metadata": {},
+   "source": [
+    "## 2. La dérivée de Brzozowski (1964)\n",
+    "\n",
+    "Soit une regex $r$ et un caractère $a$. La **dérivée** $D_a(r)$ est la regex qui reconnaît exactement les mots $w$ tels que le mot $a{\\cdot}w$ est reconnu par $r$ :\n",
+    "\n",
+    "$$L(D_a(r)) = \\{\\, w \\mid a{\\cdot}w \\in L(r) \\,\\}$$\n",
+    "\n",
+    "Intuition : *« j'ai lu $a$, que me reste-t-il à reconnaître ? »* La définition est récursive sur la structure de $r$ :\n",
+    "\n",
+    "| $r$ | $D_a(r)$ |\n",
+    "|-----|----------|\n",
+    "| $\\emptyset$ | $\\emptyset$ |\n",
+    "| $\\varepsilon$ | $\\emptyset$ |\n",
+    "| $b$ (un caractère) | $\\varepsilon$ si $a = b$, sinon $\\emptyset$ |\n",
+    "| $r{\\cdot}s$ | $D_a(r){\\cdot}s \\;\\cup\\; (\\varepsilon \\in L(r) ? D_a(s) : \\emptyset)$ |\n",
+    "| $r \\cup s$ | $D_a(r) \\cup D_a(s)$ |\n",
+    "| $r^*$ | $D_a(r){\\cdot}r^*$ |\n",
+    "\n",
+    "Le *matching* non-backtracking s'écrit alors trivialement : un mot $w = a_1 a_2 \\dots a_n$ est reconnu par $r$ **ssi** la dérivée itérée $D_{a_n}(\\dots D_{a_1}(r)\\dots)$ est **nullable** (reconnaît le mot vide $\\varepsilon$). On lit chaque caractère une seule fois, en avant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99edfb4f",
+   "metadata": {},
+   "source": [
+    "## 3. Le théorème de finitude — *le* résultat qui garantit la terminaison\n",
+    "\n",
+    "> **Théorème (Brzozowski, 1964).** L'ensemble des dérivées itérées $\\{D_w(r) \\mid w \\in \\Sigma^*\\}$ d'une expression régulière $r$ est **fini** — modulo l'équivalence ACI (Associativité, Commutativité, Idempotence) des unions.\n",
+    "\n",
+    "C'est ce théorème qui transforme la dérivée d'un concept élégant en un **algorithme qui termine** : comme l'espace des dérivées est fini, un reconnaisseur qui passe d'une dérivée à la suivante ne peut visiter qu'un nombre borné d'états distincts. D'où la complexité **linéaire** des moteurs RE# et `.NonBacktracking`.\n",
+    "\n",
+    "Ci-dessous, nous illustrons ce concept sur un **mini-projet Lean autonome** (sans dépendance Mathlib)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "115a3011",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T01:18:32.003299Z",
+     "iopub.status.busy": "2026-06-15T01:18:32.003299Z",
+     "iopub.status.idle": "2026-06-15T01:18:32.106638Z",
+     "shell.execute_reply": "2026-06-15T01:18:32.106638Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Toolchain: leanprover/lean4:v4.30.0-rc2\n",
+      "WSL bridge: OK\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Le mini-projet Lake no-Mathlib (autonome, a cote des autres projets Lean de la serie)\n",
+    "LEAN_PROJECT = '/mnt/c/dev/CoursIA-2/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean'\n",
+    "\n",
+    "def wsl(cmd, timeout=180):\n",
+    "    \"\"\"Execute une commande bash dans WSL Ubuntu.\"\"\"\n",
+    "    full = ['wsl', '-d', 'Ubuntu', '--', 'bash', '-lc', cmd]\n",
+    "    try:\n",
+    "        r = subprocess.run(full, capture_output=True, text=True, timeout=timeout)\n",
+    "        return r.returncode, r.stdout, r.stderr\n",
+    "    except subprocess.TimeoutExpired:\n",
+    "        return -1, '', f'TIMEOUT after {timeout}s'\n",
+    "\n",
+    "rc, out, err = wsl(f'cat {LEAN_PROJECT}/lean-toolchain')\n",
+    "print('Toolchain:', out.strip())\n",
+    "print('WSL bridge: OK')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e91d349e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T01:18:32.109248Z",
+     "iopub.status.busy": "2026-06-15T01:18:32.109248Z",
+     "iopub.status.idle": "2026-06-15T01:18:32.677871Z",
+     "shell.execute_reply": "2026-06-15T01:18:32.677344Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ℹ [2/4] Replayed Finiteness.Basic\n",
+      "info: Finiteness/Basic.lean:99:0: true\n",
+      "info: Finiteness/Basic.lean:100:0: false\n",
+      "info: Finiteness/Basic.lean:106:0: true\n",
+      "info: Finiteness/Basic.lean:107:0: false\n",
+      "info: Finiteness/Basic.lean:108:0: false\n",
+      "Build completed successfully (4 jobs).\n",
+      "\n",
+      "\n",
+      "[exit=0]  Build complet du projet Finiteness (inductive Regex + deriv + exemples).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Construction du mini-projet Lean (no-Mathlib : rapide, ~10s)\n",
+    "rc, out, err = wsl(f'cd {LEAN_PROJECT} && lake build Finiteness 2>&1')\n",
+    "print(out)\n",
+    "if rc != 0:\n",
+    "    print('STDERR:', err)\n",
+    "print(f'\\n[exit={rc}]  Build complet du projet Finiteness (inductive Regex + deriv + exemples).')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ead1b606",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T01:18:32.679996Z",
+     "iopub.status.busy": "2026-06-15T01:18:32.679480Z",
+     "iopub.status.idle": "2026-06-15T01:18:32.762936Z",
+     "shell.execute_reply": "2026-06-15T01:18:32.761927Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/-! # Dérivées symboliques de Brzozowski — démonstration pédagogique autonome\n",
+      "\n",
+      "Soit une expression régulière `r` sur un alphabet `α`. La **dérivée** de `r`\n",
+      "par un caractère `a` (Janusz Brzozowski, *Derivatives of Regular Expressions*,\n",
+      "JACM 1964) est l'expression `D_a(r)` qui reconnaît exactement les mots `w` tels\n",
+      "que le mot `a :: w` est reconnu par `r`. Itérée sur les caractères d'un mot, la\n",
+      "dérivée calcule la correspondance (*matching*) **sans reculer**\n",
+      "(non-backtracking) : un mot `w` est reconnu par `r` si et seulement si la\n",
+      "dérivée de `r` par `w` est *nullable* (reconnaît le mot vide ε).\n",
+      "\n",
+      "## Le théorème de finitude\n",
+      "\n",
+      "Brzozowski (1964) démontre que l'ensemble des dérivées itérées d'une expression\n",
+      "régulière est **fini** — modulo l'équivalence ACI (Associativité, Commutativité,\n",
+      "Idempotence) des unions. C'est cette finitude qui garantit la **terminaison** et\n",
+      "la complexité **linéaire** des reconnaisseurs modernes :\n",
+      "  * .NET `RegexOptions.NonBacktracking` (PLDI 2023),\n",
+      "  * **RE#** (POPL 2025, Varatalu/Veanes/Ernits),\n",
+      "  * SymPy.\n",
+      "\n",
+      "## La formalisation Lean constructive (ITP 2025)\n",
+      "\n",
+      "La formalisation **constructive** complète en Lean 4 — on construit un ensemble\n",
+      "fini majorant l'espace des dérivées (modulo équivalence) — est due à **Ekaterina\n",
+      "Zhuchko, Hendrik Maarand, Margus Veanes, Gabriel Ebner** (*Finiteness of\n",
+      "Symbolic Derivatives in Lean*, ITP 2025), dépôt\n",
+      "[`ezhuchko/finiteness-derivatives`](https://github.com/ezhuchko/finiteness-derivatives).\n",
+      "Sa licence amont n'étant pas confirmée, **ce fichier ne vendore pas leur code** :\n",
+      "il en illustre l'intuition par des définitions et exemples **originaux**, sans\n",
+      "dépendance (pas de Mathlib). Le notebook\n",
+      "[`Lean-15-Finiteness-Derivatives.ipynb`](../../Lean-15-Finiteness-Derivatives.ipynb)\n",
+      "développe la présentation pédagogique et le pont vers l'epic Conway #2162. -/\n",
+      "\n",
+      "\n",
+      "/-- Une expression régulière minimale sur l'alphabet `α`.\n",
+      "    * `empty` : langage vide ∅\n",
+      "    * `eps`   : langage du mot vide {ε}\n",
+      "    * `char a`: singleton {a}\n",
+      "    * `concat r s` : concaténation r·s\n",
+      "    * `union r s`  : union r ∪ s\n",
+      "    * `star r`     : étoile de Kleene r* -/\n",
+      "inductive Regex (α : Type) where\n",
+      "  | empty : Regex α\n",
+      "  | eps   : Regex α\n",
+      "  | char  : α → Regex α\n",
+      "  | concat : Regex α → Regex α → Regex α\n",
+      "  | union  : Regex α → Regex α → Regex α\n",
+      "  | star   : Regex α → Regex α\n",
+      "  deriving Repr\n",
+      "\n",
+      "open Regex\n",
+      "\n",
+      "/-- `nullable r` : la regex `r` reconnaît-elle le mot vide ε ?\n",
+      "    (Point fixe de la reconnaissance : une dérivée nullable ⇒ le mot lu est\n",
+      "    accepté.) -/\n",
+      "def nullable {α : Type} : Regex α → Bool\n",
+      "  | empty => false\n",
+      "  | eps => true\n",
+      "  | char _ => false\n",
+      "  | concat r s => nullable r && nullable s\n",
+      "  | union r s => nullable r || nullable s\n",
+      "  | star _ => true\n",
+      "\n",
+      "/-- La **dérivée de Brzozowski** `D_a(r)` : reconnaît les mots `w` tels que\n",
+      "    `a :: w ∈ L(r)`. Définition récursive standard ; le cas `concat` fait\n",
+      "    apparaître une union quand le facteur gauche est nullable — c'est cette\n",
+      "    union qui, modulo ACI, borne l'espace des dérivées. -/\n",
+      "def deriv {α : Type} [BEq α] (a : α) : Regex α → Regex α\n",
+      "  | empty => empty\n",
+      "  | eps => empty\n",
+      "  | char b => if a == b then eps else empty\n",
+      "  | concat r s => if nullable r then union (concat (deriv a r) s) (deriv a s)\n",
+      "                  else concat (deriv a r) s\n",
+      "  | union r s => union (deriv a r) (deriv a s)\n",
+      "  | star r => concat (deriv a r) (star r)\n",
+      "\n",
+      "/-- Dérivée par un mot (liste de caractères) : pliée de gauche à droite. -/\n",
+      "def derivWord {α : Type} [BEq α] (w : List α) (r : Regex α) : Regex α :=\n",
+      "  w.foldl (fun r' c => deriv c r') r\n",
+      "\n",
+      "/-- Un mot `w` est reconnu par `r` ssi sa dérivée est nullable. C'est le\n",
+      "    *matching* non-backtracking : on consomme chaque caractère une seule fois,\n",
+      "    sans retour en arrière. (`matches` est un mot réservé en Lean 4, d'où le\n",
+      "    nom `accepts`.) -/\n",
+      "def accepts {α : Type} [BEq α] (w : List α) (r : Regex α) : Bool :=\n",
+      "  nullable (derivWord w r)\n",
+      "\n",
+      "/-! ## Exemples : la finitude en action\n",
+      "\n",
+      "On observe sur des exemples concrets que l'espace des dérivées reste fini (et\n",
+      "souvent minuscule) — c'est précisément le théorème de Brzozowski. -/\n",
+      "\n",
+      "/-- Le langage `a*` (étoile sur le caractère 'a'). -/\n",
+      "def aStar : Regex Char := star (char 'a')\n",
+      "\n",
+      "/- `a*` est un **point fixe** de sa dérivée par 'a' : `D_a(a*) ≡ a*`.\n",
+      "   L'espace des dérivées est donc réduit à un singleton — d'où la reconnaissance\n",
+      "   en temps linéaire. -/\n",
+      "#eval accepts ['a', 'a', 'a', 'a'] aStar   -- \"aaaa\" ∈ a*  → true\n",
+      "#eval accepts ['a', 'b'] aStar              -- \"ab\"  ∉ a*  → false\n",
+      "\n",
+      "/-- Le langage `ab` (le mot \"ab\"). Les dérivées successives par les préfixes\n",
+      "    forment l'ensemble fini {ab, b, ε, ∅}. -/\n",
+      "def abWord : Regex Char := concat (char 'a') (char 'b')\n",
+      "\n",
+      "#eval accepts ['a', 'b'] abWord   -- \"ab\" ∈ ab → true\n",
+      "#eval accepts ['a'] abWord        -- \"a\"  ∉ ab → false\n",
+      "#eval accepts ['a', 'b', 'c'] abWord -- \"abc\" ∉ ab → false\n",
+      "\n",
+      "/- Dérivée concrète : `D_a(char a) = ε` (le singleton est « consommé »). -/\n",
+      "example : deriv 'a' (char 'a') = eps := by\n",
+      "  simp [deriv]\n",
+      "\n",
+      "/- Dérivée concrète : `D_b(char a) = ∅` (caractères distincts). -/\n",
+      "example : deriv 'b' (char 'a') = empty := by\n",
+      "  simp [deriv]\n",
+      "\n",
+      "/-! ## Note d'homonymie (footnote pédagogique)\n",
+      "\n",
+      "Le pont vers l'Epic Conway #2162 appelle une clarification : **Damian Conway**\n",
+      "(auteur du célèbre *sudoku en regex Perl*, Perlmonks 2002) n'est pas **John\n",
+      "Horton Conway** (mathématicien, créateur du *Game of Life* — le héros de notre\n",
+      "Epic Lean `conway_lean`). Les deux Conway « se rencontrent » dans cette série\n",
+      "SymbolicAI/Lean : l'un par la reconnaissance par regex, l'autre par la\n",
+      "formalisation du Jeu de la Vie. Clin d'œil à documenter, pas une confusion. -/\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le source Lean original (concept public de Brzozowski 1964 -- PAS le code d'ezhuchko)\n",
+    "rc, out, err = wsl(f'cat {LEAN_PROJECT}/Finiteness/Basic.lean')\n",
+    "print(out)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9fbf7ee",
+   "metadata": {},
+   "source": [
+    "### Lecture des sorties\n",
+    "\n",
+    "Les `#eval` du fichier compilent et s'exécutent (capturées dans la sortie `lake build` ci-dessus) :\n",
+    "\n",
+    "- `accepts ['a','a','a','a'] aStar` → **`true`** : le mot \"aaaa\" appartient a `a*` (l'étoile reconnaît toute répétition de 'a').\n",
+    "- `accepts ['a','b'] aStar` → **`false`** : \"ab\" n'appartient pas a `a*` (le 'b' casse la répétition).\n",
+    "- `accepts ['a','b'] abWord` → **`true`**, `accepts ['a'] abWord` → **`false`**, `accepts ['a','b','c'] abWord` → **`false`** : le mot \"ab\" et lui seul.\n",
+    "\n",
+    "Ces résultats sont obtenus par **dérivation itérée + test de nullabilité** — la définition même du *matching* non-backtracking. Les deux `example` (`deriv 'a' (char 'a') = eps`, `deriv 'b' (char 'a') = empty`) sont **prouvés** par `simp [deriv]` : on consomme un caractère singleton, ou on échoue."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67b8fb95",
+   "metadata": {},
+   "source": [
+    "## 4. Le point fixe — pourquoi l'espace des dérivées est minuscule\n",
+    "\n",
+    "Considérez `r = a*` (l'étoile sur le caractère 'a'). Calculons sa dérivée par 'a' :\n",
+    "\n",
+    "$$D_a(a^*) = D_a(a){\\cdot}a^* = \\varepsilon{\\cdot}a^* \\equiv a^*$$\n",
+    "\n",
+    "**La dérivée de `a*` par 'a' est `a*` elle-même** : c'est un *point fixe*. L'espace des dérivées de `a*` est donc réduit au **singleton {a*}**. Le reconnaisseur n'a qu'un seul état a visiter — d'où une reconnaissance en temps strictement linéaire, sans aucune structure de données auxiliaire.\n",
+    "\n",
+    "C'est cette propriété — *finitude de l'espace des dérivées* — que Brzozowski (1964) a démontrée en général, et qui sous-tend tous les moteurs linéaires modernes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c03c0a7",
+   "metadata": {},
+   "source": [
+    "## 5. La formalisation Lean constructive — Zhuchko, Maarand, Veanes, Ebner (ITP 2025)\n",
+    "\n",
+    "La formalisation **complète** en Lean 4 du théorème de finitude est due a **Ekaterina Zhuchko, Hendrik Maarand, Margus Veanes, Gabriel Ebner** :\n",
+    "\n",
+    "> E. Zhuchko, H. Maarand, M. Veanes, G. Ebner. *Finiteness of Symbolic Derivatives in Lean*. ITP 2025. Dépôt : [`ezhuchko/finiteness-derivatives`](https://github.com/ezhuchko/finiteness-derivatives).\n",
+    "\n",
+    "La preuve est **constructive** : étant donnée une expression $R$, on **construit** un ensemble fini qui surestime (modulo l'équivalence des dérivées) l'ensemble des dérivées de $R$. Elle réutilise l'infrastructure de formalisation des expressions régulières en Lean 4, illustrant la réutilisabilité du cadre.\n",
+    "\n",
+    "> ⚠️ **Licence amont non confirmée.** Conformément a l'issue #2978, ce notebook **ne vendore pas** le code d'ezhuchko. Le mini-projet `finiteness_lean/` ci-dessus est **entièrement original** : il illustre le concept public de Brzozowski (1964) par des définitions et exemples écrits spécifiquement pour cette série pédagogique, sans aucune dépendance (Mathlib exclu). Toute réutilisation du dépôt `ezhuchko/finiteness-derivatives` est subordonnée a la confirmation de sa licence.\n",
+    "\n",
+    "**Companion** : CPP 2024 (extended regex matching with lookarounds, Zhuchko/Veanes/Ebner) — même lignée de recherche."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1fe6bb8",
+   "metadata": {},
+   "source": [
+    "## 6. Le pont vers l'Epic Conway #2162\n",
+    "\n",
+    "Ce notebook est le **troisième pilier** du triptyque #2978 :\n",
+    "\n",
+    "| Pilier | Outil | Rôle |\n",
+    "|--------|-------|------|\n",
+    "| **Résoudre** (produire une grille) | Z3 (lignée Rex / `RegexToSMT`) | Le résolveur — génère un témoin |\n",
+    "| **Vérifier** (valider une grille) | RE# / `.NonBacktracking` | Le vérificateur — reconnaissance en temps linéaire |\n",
+    "| **Prouver** (garantir la terminaison) | Lean — dérivées de Brzozowski | Ce notebook — la finitude sous-jacente |\n",
+    "\n",
+    "Les trois opérations distinctes du paysage regex symbolique : **résoudre ≠ vérifier ≠ prouver**. La reconnaissance non-backtracking de RE# *est* la finitude des dérivées, rendue algorithmique.\n",
+    "\n",
+    "Et le clin d'œil final : le héros de notre Epic Lean `conway_lean` — la formalisation du *Game of Life* de **John Horton Conway** — « croise » ici le *sudoku en regex* de **Damian Conway**. Deux Conway, deux génies, une même série SymbolicAI/Lean.\n",
+    "\n",
+    "Voir [`conway_lean`](conway_lean/) (Epic #2162, preuve de correction Hashlife) et le notebook [`Lean-14-Conway-Tribute`](Lean-14-Conway-Tribute.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0ac26b6",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les exercices suivants se complètent dans le fichier `Finiteness/Basic.lean` du mini-projet, puis se valident par `lake build Finiteness` (cellule ci-dessus).\n",
+    "\n",
+    "**Exercice 1 (dérivée).** Ajoutez un constructeur `Regex.plus : Regex α → Regex α` (le langage $r^+$ = une occurrence ou plus). Définissez son cas dans `nullable` et dans `deriv`. *Indice : $r^+ = r{\\cdot}r^*$, donc $D_a(r^+) = D_a(r){\\cdot}r^*$.*\n",
+    "\n",
+    "```lean\n",
+    "-- TODO étudiant : constructor + nullable case + deriv case\n",
+    "-- def nullable ... | plus r => ...\n",
+    "-- def deriv   ... | plus r => ...\n",
+    "```\n",
+    "\n",
+    "**Exercice 2 (reconnaissance).** Construisez la regex du langage « les mots sur {a,b} contenant au moins un 'a' », puis vérifiez par `#eval accepts` que \"ba\" est reconnu mais \"bb\" ne l'est pas. *Indice : `(a∪b)* · a · (a∪b)*`.*\n",
+    "\n",
+    "```lean\n",
+    "-- TODO étudiant\n",
+    "-- def hasA : Regex Char := ...\n",
+    "-- #eval accepts ['b','a'] hasA   -- attendu : true\n",
+    "-- #eval accepts ['b','b'] hasA   -- attendu : false\n",
+    "```\n",
+    "\n",
+    "**Exercice 3 (finitude explicite).** Montrez par le calcul (une série de `#eval` de `deriv` itérés) que l'espace des dérivées de `concat (char 'a') (char 'b')` est bien fini : partez de `abWord`, dérivez par 'a', puis par 'b', et observez que la dérivée finale est nullable (`eps`) puis devient `empty` si on dérive encore. *Indice : `#eval deriv 'a' abWord`, `#eval deriv 'b' (deriv 'a' abWord)`.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/Finiteness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/Finiteness.lean
@@ -1,0 +1,1 @@
+import Finiteness.Basic

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/Finiteness/Basic.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/Finiteness/Basic.lean
@@ -1,0 +1,125 @@
+/-! # Dérivées symboliques de Brzozowski — démonstration pédagogique autonome
+
+Soit une expression régulière `r` sur un alphabet `α`. La **dérivée** de `r`
+par un caractère `a` (Janusz Brzozowski, *Derivatives of Regular Expressions*,
+JACM 1964) est l'expression `D_a(r)` qui reconnaît exactement les mots `w` tels
+que le mot `a :: w` est reconnu par `r`. Itérée sur les caractères d'un mot, la
+dérivée calcule la correspondance (*matching*) **sans reculer**
+(non-backtracking) : un mot `w` est reconnu par `r` si et seulement si la
+dérivée de `r` par `w` est *nullable* (reconnaît le mot vide ε).
+
+## Le théorème de finitude
+
+Brzozowski (1964) démontre que l'ensemble des dérivées itérées d'une expression
+régulière est **fini** — modulo l'équivalence ACI (Associativité, Commutativité,
+Idempotence) des unions. C'est cette finitude qui garantit la **terminaison** et
+la complexité **linéaire** des reconnaisseurs modernes :
+  * .NET `RegexOptions.NonBacktracking` (PLDI 2023),
+  * **RE#** (POPL 2025, Varatalu/Veanes/Ernits),
+  * SymPy.
+
+## La formalisation Lean constructive (ITP 2025)
+
+La formalisation **constructive** complète en Lean 4 — on construit un ensemble
+fini majorant l'espace des dérivées (modulo équivalence) — est due à **Ekaterina
+Zhuchko, Hendrik Maarand, Margus Veanes, Gabriel Ebner** (*Finiteness of
+Symbolic Derivatives in Lean*, ITP 2025), dépôt
+[`ezhuchko/finiteness-derivatives`](https://github.com/ezhuchko/finiteness-derivatives).
+Sa licence amont n'étant pas confirmée, **ce fichier ne vendore pas leur code** :
+il en illustre l'intuition par des définitions et exemples **originaux**, sans
+dépendance (pas de Mathlib). Le notebook
+[`Lean-15-Finiteness-Derivatives.ipynb`](../../Lean-15-Finiteness-Derivatives.ipynb)
+développe la présentation pédagogique et le pont vers l'epic Conway #2162. -/
+
+
+/-- Une expression régulière minimale sur l'alphabet `α`.
+    * `empty` : langage vide ∅
+    * `eps`   : langage du mot vide {ε}
+    * `char a`: singleton {a}
+    * `concat r s` : concaténation r·s
+    * `union r s`  : union r ∪ s
+    * `star r`     : étoile de Kleene r* -/
+inductive Regex (α : Type) where
+  | empty : Regex α
+  | eps   : Regex α
+  | char  : α → Regex α
+  | concat : Regex α → Regex α → Regex α
+  | union  : Regex α → Regex α → Regex α
+  | star   : Regex α → Regex α
+  deriving Repr
+
+open Regex
+
+/-- `nullable r` : la regex `r` reconnaît-elle le mot vide ε ?
+    (Point fixe de la reconnaissance : une dérivée nullable ⇒ le mot lu est
+    accepté.) -/
+def nullable {α : Type} : Regex α → Bool
+  | empty => false
+  | eps => true
+  | char _ => false
+  | concat r s => nullable r && nullable s
+  | union r s => nullable r || nullable s
+  | star _ => true
+
+/-- La **dérivée de Brzozowski** `D_a(r)` : reconnaît les mots `w` tels que
+    `a :: w ∈ L(r)`. Définition récursive standard ; le cas `concat` fait
+    apparaître une union quand le facteur gauche est nullable — c'est cette
+    union qui, modulo ACI, borne l'espace des dérivées. -/
+def deriv {α : Type} [BEq α] (a : α) : Regex α → Regex α
+  | empty => empty
+  | eps => empty
+  | char b => if a == b then eps else empty
+  | concat r s => if nullable r then union (concat (deriv a r) s) (deriv a s)
+                  else concat (deriv a r) s
+  | union r s => union (deriv a r) (deriv a s)
+  | star r => concat (deriv a r) (star r)
+
+/-- Dérivée par un mot (liste de caractères) : pliée de gauche à droite. -/
+def derivWord {α : Type} [BEq α] (w : List α) (r : Regex α) : Regex α :=
+  w.foldl (fun r' c => deriv c r') r
+
+/-- Un mot `w` est reconnu par `r` ssi sa dérivée est nullable. C'est le
+    *matching* non-backtracking : on consomme chaque caractère une seule fois,
+    sans retour en arrière. (`matches` est un mot réservé en Lean 4, d'où le
+    nom `accepts`.) -/
+def accepts {α : Type} [BEq α] (w : List α) (r : Regex α) : Bool :=
+  nullable (derivWord w r)
+
+/-! ## Exemples : la finitude en action
+
+On observe sur des exemples concrets que l'espace des dérivées reste fini (et
+souvent minuscule) — c'est précisément le théorème de Brzozowski. -/
+
+/-- Le langage `a*` (étoile sur le caractère 'a'). -/
+def aStar : Regex Char := star (char 'a')
+
+/- `a*` est un **point fixe** de sa dérivée par 'a' : `D_a(a*) ≡ a*`.
+   L'espace des dérivées est donc réduit à un singleton — d'où la reconnaissance
+   en temps linéaire. -/
+#eval accepts ['a', 'a', 'a', 'a'] aStar   -- "aaaa" ∈ a*  → true
+#eval accepts ['a', 'b'] aStar              -- "ab"  ∉ a*  → false
+
+/-- Le langage `ab` (le mot "ab"). Les dérivées successives par les préfixes
+    forment l'ensemble fini {ab, b, ε, ∅}. -/
+def abWord : Regex Char := concat (char 'a') (char 'b')
+
+#eval accepts ['a', 'b'] abWord   -- "ab" ∈ ab → true
+#eval accepts ['a'] abWord        -- "a"  ∉ ab → false
+#eval accepts ['a', 'b', 'c'] abWord -- "abc" ∉ ab → false
+
+/- Dérivée concrète : `D_a(char a) = ε` (le singleton est « consommé »). -/
+example : deriv 'a' (char 'a') = eps := by
+  simp [deriv]
+
+/- Dérivée concrète : `D_b(char a) = ∅` (caractères distincts). -/
+example : deriv 'b' (char 'a') = empty := by
+  simp [deriv]
+
+/-! ## Note d'homonymie (footnote pédagogique)
+
+Le pont vers l'Epic Conway #2162 appelle une clarification : **Damian Conway**
+(auteur du célèbre *sudoku en regex Perl*, Perlmonks 2002) n'est pas **John
+Horton Conway** (mathématicien, créateur du *Game of Life* — le héros de notre
+Epic Lean `conway_lean`). Les deux Conway « se rencontrent » dans cette série
+SymbolicAI/Lean : l'un par la reconnaissance par regex, l'autre par la
+formalisation du Jeu de la Vie. Clin d'œil à documenter, pas une confusion. -/

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lakefile.lean
@@ -1,0 +1,27 @@
+import Lake
+open Lake DSL
+
+/-! # Mini-projet Lean pédagogique : dérivées symboliques de Brzozowski
+
+Projet **autonome, sans dépendance Mathlib**, illustrant le concept de dérivée
+symbolique d'une expression régulière et le théorème de finitude de Brzozowski
+(1964) — la base théorique de la terminaison des reconnaisseurs non-backtracking
+(RE#, .NET `RegexOptions.NonBacktracking`).
+
+La formalisation constructive *complète* en Lean 4 est due à Zhuchko, Maarand,
+Veanes, Ebner (ITP 2025) — dépôt `ezhuchko/finiteness-derivatives`. Sa licence
+amont n'étant pas confirmée, ce projet **ne vendore pas** leur code : il en
+illustre l'intuition par des définitions et exemples originaux. Voir le notebook
+[`Lean-15-Finiteness-Derivatives.ipynb`](../Lean-15-Finiteness-Derivatives.ipynb)
+pour la présentation pédagogique complète, et l'issue #2978 (livrable C). -/
+
+package «finiteness» where
+  leanOptions := #[
+    ⟨`pp.unicode.fun, true⟩,
+    ⟨`autoImplicit, false⟩
+  ]
+
+@[default_target]
+lean_lib «Finiteness» where
+  -- `Finiteness.Basic` : inductive Regex minimale + dérivée de Brzozowski +
+  -- exemples illustrant la finitude de l'espace des dérivées.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.30.0-rc2


### PR DESCRIPTION
## Summary

**Deliverable C (Lean) of Epic #2978** (*the Sudoku as symbolic regex*). A pedagogical notebook + self-contained mini Lean project illustrating **Brzozowski's symbolic derivatives (1964)** and the **finiteness theorem** — the termination guarantee behind non-backtracking regex matchers (RE#, .NET `NonBacktracking`).

### Cite-not-vendor (per #2978 acceptance criteria)

The full constructive Lean formalization is due to **Zhuchko, Maarand, Veanes, Ebner** (*Finiteness of Symbolic Derivatives in Lean*, ITP 2025, [`ezhuchko/finiteness-derivatives`](https://github.com/ezhuchko/finiteness-derivatives)). Its upstream license is **unconfirmed** → this PR **does not vendor their code**. The `finiteness_lean/` mini-project is **entirely original**: it illustrates the public Brzozowski 1964 concept with definitions and examples written specifically for this series, with **no Mathlib dependency**.

### Files

- `finiteness_lean/` — no-Mathlib Lake project (toolchain `v4.30.0-rc2`)
  - `Finiteness/Basic.lean` (125 lines): inductive `Regex` (∅, ε, char, concat, union, star) + `nullable` + `deriv` (Brzozowski derivative) + `derivWord` + `accepts`, `#eval` examples (`a*`, `ab`), 2 **proven** examples (`deriv 'a' (char 'a') = eps`, `deriv 'b' (char 'a') = empty`)
- `Lean-15-Finiteness-Derivatives.ipynb` — 12 cells (9 markdown + 3 code), kernel `python3`, orchestrates the Lake build via WSL. Pedagogy: backtracking vs non-backtracking, the derivative definition (table), the finiteness theorem, the `a*` fixed-point, citation of ITP 2025, the resolve-vs-verify-vs-prove triptych, **Conway homonymy footnote** (Damian ≠ John), bridge to #2162.

## Lean PR discipline (§B)

| Item | Proof |
|------|-------|
| `grep -cE '^\s*sorry\b'` | `Finiteness/Basic.lean`: **0 sorry, 0 axiom** (new project, no proofs replaced) |
| Lake build SUCCESS | `lake build Finiteness` → **Build completed successfully (4 jobs)**, 0 error (no-Mathlib, ~10s) |
| Proof integrity | 0 axiom: `deriv`/`nullable` defs + `example ... := by simp [deriv]` only |
| No prover refactor | N/A — new standalone project + notebook |

## Notebook validation (C.2 / H.3)

- Executed via `nbconvert --execute` (kernel `python3` Windows-side; the notebook's `wsl()` cells orchestrate the Lake build, matching the `Lean-13b`/`Lean-14` series pattern)
- **3 code cells, 0 error, all with `execution_count` + `outputs`** (C.2 OK)
- Captured output shows `Build completed successfully (4 jobs)` + the `#eval` results (`true`/`false`) + `[exit=0]`

## Acceptance criteria (#2978 deliverable C)

- [x] notebook/section `finiteness-derivatives` (terminaison reconnaisseur)
- [x] licence amont confirmée avant tout vendoring → **no vendoring, cite-only** (license unconfirmed, per #2978)
- [x] lien #2162
- [x] Footnote homonymie Damian/John Conway posée dans la série Lean

## Test plan

- [x] `lake build Finiteness` SUCCESS (WSL, v4.30.0-rc2, no-Mathlib)
- [x] notebook executed end-to-end, 0 error, outputs captured
- [x] diff coherent: 579 insertions, 0 deletions (pure addition, new project + new notebook)

See #2978 (partial contribution — deliverable C; does not close the epic: deliverables A/B are tracked separately). Bridge to #2162 (Conway homonymy).