### PR TITLE
docs(readme): restore residual French diacritics in IIT + ML READMEs (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -191,7 +191,7 @@ Oui, mais avec caveats. PyPhi est la référence pour IIT 3.0, mais IIT 4.0 (202
 - [PyPhi GitHub](https://github.com/wmayner/pyphi)
 - [Exemples PyPhi](https://github.com/wmayner/pyphi/tree/master/examples)
 
-### Fondements theoriques
+### Fondements théoriques
 
 - Tononi, G. (2008) - *Consciousness as Integrated Information*
 - Oizumi, M., Albantakis, L., Tononi, G. (2014) - *From the Phenomenology to the Mechanisms of Consciousness*

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -163,7 +163,7 @@ Documentation complète : [DataScienceWithAgents/README.md](DataScienceWithAgent
 
 | Section | Audience | Prérequis |
 |---------|----------|-----------|
-| **ML.NET** | Developpeurs C#/.NET, environnements enterprise | C# base, .NET SDK 9.0+ |
+| **ML.NET** | Développeurs C#/.NET, environnements enterprise | C# base, .NET SDK 9.0+ |
 | **Python Data Science (Days 1-3)** | Analystes, data scientists, débutants-intermédiaires | Python base, Jupyter |
 | **AI Agents (Days 4-7)** | Praticiens IA souhaitant intégrer LLMs | Days 1-3 ou expérience équivalente |
 
@@ -187,11 +187,11 @@ Documentation complète : [DataScienceWithAgents/README.md](DataScienceWithAgent
 1. [ML-1](ML.Net/ML-1-Introduction.ipynb) à [ML-4](ML.Net/ML-4-Evaluation.ipynb) : fondamentaux ML.NET
 1. [ML-5](ML.Net/ML-5-TimeSeries.ipynb) : séries temporelles
 1. [ML-6](ML.Net/ML-6-ONNX.ipynb) : interop Python → .NET
-1. [TP-prevision-ventes](ML.Net/TP-prevision-ventes.ipynb) : projet integre
+1. [TP-prevision-ventes](ML.Net/TP-prevision-ventes.ipynb) : projet intégré
 
 ## Quel parcours choisir
 
-| Profil | Parcours recommandé | Duree |
+| Profil | Parcours recommandé | Durée |
 | ------ | ------------------- | ----- |
 | Développeur C#/.NET en entreprise | Track A : ML.NET (ML-1 à ML-4 + TP) | ~6h |
 | Data scientist débutant | Track B (Days 1-3) : Python + scikit-learn | ~8h |
@@ -231,7 +231,7 @@ Les deux sous-séries sont indépendantes et peuvent être suivies dans n'import
 
 | Concept | Description |
 |---------|-------------|
-| **Pipeline ML** | Enchainement data loading → features → training → évaluation |
+| **Pipeline ML** | Enchaînement data loading → features → training → évaluation |
 | **Feature Engineering** | One-hot encoding, normalisation, concatenation |
 | **AutoML** | Recherche automatique d'hyperparamètres |
 | **Evaluation** | R², MAE, RMSE, cross-validation |


### PR DESCRIPTION
## Scope

Completes residual French diacritic misses left by the merged per-series #2876 PRs in two in-perimeter (Python: IIT/PyPhi + ML) series READMEs. Prose-only, docs-only.

## Changes (5 single-word fixes, verified in context)

| File | Before | After |
|------|--------|-------|
| `IIT/README.md` | Fondements **theoriques** | théoriques |
| `ML/README.md` | **Developpeurs** C#/.NET | Développeurs |
| `ML/README.md` | projet **integre** | intégré |
| `ML/README.md` | Parcours recommandé \| **Duree** | Durée |
| `ML/README.md` | **Enchainement** data loading | Enchaînement |

## False positives intentionally left untouched (G.1 context-verified)

- `Lazy Clause Generation` (Search) — English technical term
- `docs/reference/...` (ML) — markdown link path, not prose
- `enterprise` (ML) — English loanword (no French accents)
- `Evaluation` concept label (ML) — mixed-language concepts table

## Discipline

- Docs/markdown only: **no notebook re-execution** (C.2 N/A), **no catalog regeneration**, CATALOG-STATUS markers byte-identical.
- `git diff --stat`: 2 files, +5/-5.
- Search series already complete via merged #2880; IIT base via #2894; ML base via #2904/#2944/#2947/#2948/#2954 — this PR only closes the residual gaps those passes missed.

See #2876 (partial — issue spans the whole repo; remains open for any other-family residuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)