### PR TITLE
feat(arganalysis): 2-formal rung — real Tweety PL/FOL/Modal/Dung verification (See #2137)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-2-formal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-2-formal.ipynb
@@ -1,0 +1,726 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-header",
+   "metadata": {},
+   "source": [
+    "# Argument_Analysis_Agentic-2-formal : Verification Logique Formelle avec Tweety\n",
+    "\n",
+    "**Navigation** : [<< 1-informal](./Argument_Analysis_Agentic-1-informal_agent.ipynb) | [README](./README.md) | [3-orchestration >>](./Argument_Analysis_Agentic-3-orchestration.ipynb)\n",
+    "\n",
+    "| Champ | Valeur |\n",
+    "|-------|--------|\n",
+    "| **Module** | SymbolicAI / Argument_Analysis |\n",
+    "| **Rung** | 2-formal (Epic #2137 Phase 2) |\n",
+    "| **Niveau** | Intermediaire |\n",
+    "| **Duree estimee** | 45 minutes |\n",
+    "| **Kernel** | Python 3 (JPype + JVM Tweety) |\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "\n",
+    "- [ ] Demarrer la JVM Tweety via JPype et verifier qu'elle est reellement operationnelle (anti-theatre)\n",
+    "- [ ] Construire un **belief set** en logique propositionnelle (PL) et interroger l'entaillement (modus ponens) avec le vrai raisonneur Java\n",
+    "- [ ] **Pre-declarer une signature** (Sort / Constant / Predicate) pour la logique du premier ordre (FOL), puis parser et interroger une formule quantifiee\n",
+    "- [ ] Manipuler les operateurs modaux `<>` (possible) et `[]` (necessaire) comme aparcu, en reutilisant une signature FOL\n",
+    "- [ ] Calculer une **extension basee (grounded)** d'un graphe d'attaque de Dung\n",
+    "- [ ] Distinguer le role du LLM (extraire une structure informelle) du role du solveur formel (prouver l'entaillement)\n",
+    "\n",
+    "### Prerequis\n",
+    "\n",
+    "- Notebook [0-init](./Argument_Analysis_Agentic-0-init.ipynb) : configuration de l'environnement (JVM, JDK portable)\n",
+    "- Bases de logique formelle (propositions, quantificateurs, modus ponens)\n",
+    "- Python 3.10+ ; le package `jpype` installe\n",
+    "\n",
+    "> **Note anti-theatre** : ce rung utilise **exclusivement le vrai raisonneur Java Tweety** via JPype. Aucune sortie n'est simulee. Si la JVM est absente, la cellule echoue explicitement (principe **fail-loud**) plutot que d'afficher un faux resultat. C'est le mandat coeur de l'Epic #2137 : la logique formelle se prouve, elle ne se raconte pas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-intro",
+   "metadata": {},
+   "source": [
+    "## 1. Introduction : pourquoi la verification formelle ?\n",
+    "\n",
+    "Dans le rung [1-informal](./Argument_Analysis_Agentic-1-informal_agent.ipynb), un LLM a extrait la **structure informelle** d'un argument (premisses, conclusion, schema). Mais un LLM peut halluciner un lien logique : il affirme \"donc\" la conclusion alors que l'entaillement ne tient pas formellement.\n",
+    "\n",
+    "Le rung present **delegue la preuve a un solveur formel** : on encode l'argument dans un formalisme logique (PL, FOL, modal), puis on demande a un raisonneur certify de dire si la conclusion est bien une consequence logique des premisses.\n",
+    "\n",
+    "| Etape | Outil | Garantie |\n",
+    "|-------|-------|----------|\n",
+    "| Texte naturel -> structure informelle | LLM (rung 1) | Aucune (probabiliste) |\n",
+    "| Structure informelle -> formules logiques | LLM ou ecriture manuelle | Syntaxique seulement |\n",
+    "| **Formules -> entaillement vrai/faux** | **Tweety (Java, ce rung)** | **Sound & complete** |\n",
+    "\n",
+    "### Stance anti-theatre\n",
+    "\n",
+    "L'ancien materiel EPITA (et le `RECONSTRUCTION_PLAN.md` \"cause #2\") admettait un **mode degrade** ou le LLM simulait le resultat d'une requete PL (`if not jvm_ready: print(\"simulated result ...\")`). **Ce mode est interdit dans cette serie.** Un resultat simule n'est pas une preuve : c'est du theatre qui s'affiche comme de la logique. Ce notebook echoue bruyamment si la JVM est absente, plutot que de mentir.\n",
+    "\n",
+    "**Confidentialite** : tous les exemples sont **synthetiques et neutres** (meteo : \"Si il pleut, alors le sol est mouille\" ; oiseaux : Tweety / pingouins ; syllogismes classiques de Socrate). Aucun corpus EPITA, aucun nom, aucun `raw_text`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-jvm-intro",
+   "metadata": {},
+   "source": [
+    "## 2. Demarrage de la JVM Tweety (prealable obligatoire)\n",
+    "\n",
+    "La cellule ci-dessous localise le dossier `Tweety/` (qui contient `libs/*.jar` et `jdk-17-portable/`), l'ajoute au `sys.path`, puis appelle `init_tweety()` qui :\n",
+    "\n",
+    "1. Detecte le JDK portable et fixe `JAVA_HOME`,\n",
+    "2. Construit le classpath a partir des 76 JARs Tweety sous `libs/`,\n",
+    "3. Demarre la JVM via `jpype.startJVM(...)`.\n",
+    "\n",
+    "Si l'initialisation echoue, on `raise RuntimeError` immediatement. **Aucun fallback silencieux.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "aa2f-jvm-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Initialisation Tweety ---\n",
+      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n",
+      "Bibliotheques natives: native/\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JVM demarree avec 76 JARs.\n",
+      "JVM operationnelle : True\n",
+      "Classpath Tweety charge depuis : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\libs\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [2] - Demarrage JVM Tweety (anti-theatre : fail-loud si JVM absente)\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Localiser le dossier SymbolicAI/Tweety (qui contient libs/ et jdk-17-portable/)\n",
+    "# On marche vers le haut depuis le cwd jusqu'a trouver Tweety/libs.\n",
+    "cwd = Path.cwd()\n",
+    "tweety_dir = None\n",
+    "candidate = cwd\n",
+    "for _ in range(6):\n",
+    "    if (candidate / \"Tweety\" / \"libs\").is_dir():\n",
+    "        tweety_dir = candidate / \"Tweety\"\n",
+    "        break\n",
+    "    if (candidate / \"libs\").is_dir() and (candidate / \"tweety_init.py\").exists():\n",
+    "        tweety_dir = candidate\n",
+    "        break\n",
+    "    if len(candidate.parts) > 1:\n",
+    "        candidate = candidate.parent\n",
+    "    else:\n",
+    "        break\n",
+    "\n",
+    "if tweety_dir is None:\n",
+    "    raise RuntimeError(\n",
+    "        \"Dossier Tweety/libs introuvable depuis %r. Lancez Papermill avec \"\n",
+    "        \"--cwd MyIA.AI.Notebooks/SymbolicAI ou executez depuis ce dossier.\" % cwd\n",
+    "    )\n",
+    "\n",
+    "# init_tweety() cherche libs/ et jdk-17-portable/ RELATIVEMENT au cwd :\n",
+    "# on se place donc dans le dossier Tweety avant l'appel.\n",
+    "import os\n",
+    "os.chdir(str(tweety_dir))\n",
+    "sys.path.insert(0, str(tweety_dir.parent))  # pour `from Tweety.tweety_init import ...`\n",
+    "sys.path.insert(0, str(tweety_dir))          # pour `from tweety_init import ...`\n",
+    "\n",
+    "from tweety_init import init_tweety\n",
+    "import jpype\n",
+    "\n",
+    "jvm_ok = init_tweety(verbose=True)\n",
+    "if not jvm_ok or not jpype.isJVMStarted():\n",
+    "    raise RuntimeError(\n",
+    "        \"JVM/Tweety non demarree. Verifiez jdk-17-portable/ et libs/*.jar \"\n",
+    "        \"sous MyIA.AI.Notebooks/SymbolicAI/Tweety/. Mode degrade (simulation LLM) \"\n",
+    "        \"INTERDIT dans cette serie (anti-theatre, mandat #2137).\"\n",
+    "    )\n",
+    "print(f\"JVM operationnelle : {jpype.isJVMStarted()}\")\n",
+    "print(f\"Classpath Tweety charge depuis : {tweety_dir / 'libs'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-jvm-interpret",
+   "metadata": {},
+   "source": [
+    "### Interpretation : sortie du demarrage JVM\n",
+    "\n",
+    "**Sortie attendue** : trois lignes informatives — `JDK portable: zulu17...`, `Bibliotheques natives: native/`, `JVM demarree avec 76 JARs.` — puis notre confirmation `JVM operationnelle : True`.\n",
+    "\n",
+    "| Element | Verifie que |\n",
+    "|---------|-------------|\n",
+    "| `JDK portable: zulu...` | Le JDK 17 a ete localise et `JAVA_HOME` fixe |\n",
+    "| `Bibliotheques natives: native/` | Les DLL/SO des SAT solvers sont sur le classpath |\n",
+    "| `JVM demarree avec N JARs` | `jpype.startJVM` a reussi avec le classpath complet |\n",
+    "| `JVM operationnelle : True` | `jpype.isJVMStarted()` confirme l'etat |\n",
+    "\n",
+    "> **Que signifie fail-loud ici ?** Si la JVM n'avait pas demarre, la cellule aurait leve `RuntimeError` et le notebook se serait arrete. C'est exactement l'inverse d'un `if not jvm_ready: print(\"simulated: True\")` qui aurait laisse croire que le modus ponens est valide alors que rien n'a ete calcule."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-pl-intro",
+   "metadata": {},
+   "source": [
+    "## 3. Logique propositionnelle (PL)\n",
+    "\n",
+    "La logique propositionnelle manipule des **propositions atomiques** (`rain`, `wet`) reliees par des connecteurs. Un **belief set** est un ensemble de formules considerées comme vraies ; on demande ensuite au raisonneur si une formule cible est **entailed** (consequence logique) par le belief set.\n",
+    "\n",
+    "**Syntaxe Tweety (extrait de la BNF du `PlParser`)** :\n",
+    "\n",
+    "| Operateur | Sens | Exemple |\n",
+    "|-----------|------|--------|\n",
+    "| `!` | negation | `!rain` (non rain) |\n",
+    "| `&&` | conjonction (et) | `rain && wind` |\n",
+    "| `||` | disjonction (ou) | `rain || snow` |\n",
+    "| `=>` | implication | `rain => wet` (si rain alors wet) |\n",
+    "| `<=>` | equivalence | `rain <=> wet` |\n",
+    "\n",
+    "> On evite l'operateur `>>` (redondant avec `=>`, source de confusion). Les atomes sont en minuscules.\n",
+    "\n",
+    "**Demo** : le modus ponens meteorologique. Premisses : `rain => wet` (s'il pleut, le sol est mouille) et `rain` (il pleut). Conclusion cible : `wet` (le sol est mouille)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "aa2f-pl-demo",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Logique propositionnelle (PL) : modus ponens ---\n",
+      "Belief set : {rain => wet, rain}\n",
+      "  wet   entailed ? True    (attendu : True)\n",
+      "  !wet  entailed ? False   (attendu : False)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [5] - PL : modus ponens meteorologique avec le vrai SimplePlReasoner\n",
+    "import jpype\n",
+    "JClass = jpype.JClass\n",
+    "\n",
+    "PlParser = JClass(\"org.tweetyproject.logics.pl.parser.PlParser\")\n",
+    "SimplePlReasoner = JClass(\"org.tweetyproject.logics.pl.reasoner.SimplePlReasoner\")\n",
+    "PlBeliefSet = JClass(\"org.tweetyproject.logics.pl.syntax.PlBeliefSet\")\n",
+    "\n",
+    "parser = PlParser()\n",
+    "bs = PlBeliefSet()\n",
+    "bs.add(parser.parseFormula(\"rain => wet\"))   # Si il pleut, alors le sol est mouille\n",
+    "bs.add(parser.parseFormula(\"rain\"))          # Il pleut\n",
+    "\n",
+    "reasoner = SimplePlReasoner()\n",
+    "entails_wet = bool(reasoner.query(bs, parser.parseFormula(\"wet\")))\n",
+    "entails_not_wet = bool(reasoner.query(bs, parser.parseFormula(\"!wet\")))\n",
+    "\n",
+    "print(\"--- Logique propositionnelle (PL) : modus ponens ---\")\n",
+    "print(f\"Belief set : {{rain => wet, rain}}\")\n",
+    "print(f\"  wet   entailed ? {entails_wet}    (attendu : True)\")\n",
+    "print(f\"  !wet  entailed ? {entails_not_wet}   (attendu : False)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-pl-interpret",
+   "metadata": {},
+   "source": [
+    "### Interpretation : resultat du modus ponens PL\n",
+    "\n",
+    "**Sortie obtenue** : `wet entailed ? True` et `!wet entailed ? False`.\n",
+    "\n",
+    "| Requete | Resultat | Lecture |\n",
+    "|---------|----------|---------|\n",
+    "| `wet` | True | Le sol est mouille est une consequence logique : `rain` + `rain=>wet` |\n",
+    "| `!wet` | False | La negation n'est PAS entailed : le belief set ne prouve pas qu'il ne pleut pas |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Le `SimplePlReasoner` decide via SAT solving ; la reponse est exacte (sound & complete pour PL).\n",
+    "2. Resultat `False` sur `!wet` ne veut **pas** dire que `wet` est faux — cela signifie que le belief set n'entraine pas `!wet`. La distinction entail/non-entail est centrale en logique formelle.\n",
+    "3. Si on retirait `rain` du belief set, ni `wet` ni `!wet` ne serait entailed (le systeme serait agnostique)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-pl-ex1-intro",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 (PL) : teste un autre schema d'inference\n",
+    "\n",
+    "**Contexte** : on vient de voir le modus ponens (`p`, `p=>q` |- `q`). Un autre schema classique est le **modus tollens** : si `p=>q` est vrai et `q` est faux, alors `p` doit etre faux.\n",
+    "\n",
+    "**Objectif** : dans la cellule ci-dessous, croyez `rain => wet` et `!wet`, puis interrogez le belief set pour savoir si `!rain` est entailed. Affichez le resultat booleen.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Etape 1 : creer un nouveau `PlBeliefSet` vide\n",
+    "- # Etape 2 : ajouter les deux formules `rain => wet` et `!wet`\n",
+    "- # Etape 3 : construire la requete `!rain` et l'executer via `reasoner.query(...)`\n",
+    "- # Etape 4 : convertir le resultat Java en `bool(...)` puis l'afficher"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "aa2f-pl-ex1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modus tollens : !rain entailed ? None\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (PL) : modus tollens\n",
+    "# TODO etudiant : croyez {rain => wet, !wet} et verifiez si !rain est entailed.\n",
+    "# Etape 1 : nouveau belief set\n",
+    "bs_ex1 = None  # TODO etudiant : PlBeliefSet()\n",
+    "# Etape 2 : ajouter les formules\n",
+    "# TODO etudiant\n",
+    "# Etape 3 : requete !rain\n",
+    "result_ex1 = None  # TODO etudiant : bool(reasoner.query(bs_ex1, parser.parseFormula(\"!rain\")))\n",
+    "# Etape 4 : afficher\n",
+    "print(f\"Modus tollens : !rain entailed ? {result_ex1}\")\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-fol-intro",
+   "metadata": {},
+   "source": [
+    "## 4. Logique du premier ordre (FOL) : la pre-declaration de signature\n",
+    "\n",
+    "La FOL introduit les **quantificateurs** (`forall X:` / `exists X:`) et les **predicats** appliques a des termes. Contrairement a PL ou les atomes sont libres, Tweety **exige une pre-declaration de signature** : on declare explicitement les sorts, les constantes et les predicats avant de parser la moindre formule.\n",
+    "\n",
+    "> **Point pedagogique cible** : c'est exactement le \"sanitizer + pre-declaration\" que fait le `fol_handler` EPITA. Un LLM qui genere `Bird(tweety)` ne suffit pas : il faut avoir declare le sort `thing`, la constante `tweety` de sort `thing`, et le predicat `Bird` d'arite 1 sur `thing`. Sinon, le parseur leve une `ParserException`.\n",
+    "\n",
+    "| Element | Classe Tweety | Role |\n",
+    "|---------|---------------|------|\n",
+    "| `Sort(\"thing\")` | `FolSignature.add` | Definit un type d'individu |\n",
+    "| `Constant(\"tweety\", thing)` | `FolSignature.add` | Definit un individu nomme |\n",
+    "| `Predicate(\"Bird\", [thing])` | `FolSignature.add` | Definit un predicat d'arite 1 sur `thing` |\n",
+    "\n",
+    "**Demo** : le syllogisme classique. Pour tout X, si X est un oiseau alors X vole ; Tweety est un oiseau ; donc Tweety vole."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "aa2f-fol-demo",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Logique du premier ordre (FOL) : syllogisme ---\n",
+      "Signature : Sort=thing, Constant=tweety, Predicates=Bird/1, Fly/1\n",
+      "Belief set : {Bird(tweety), forall X: (Bird(X) => Fly(X))}\n",
+      "  Fly(tweety) entailed ? True   (attendu : True)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [9] - FOL : syllogisme oiseau/vol avec pre-declaration de signature\n",
+    "import jpype\n",
+    "from java.util import ArrayList  # via jpype.imports\n",
+    "\n",
+    "JClass = jpype.JClass\n",
+    "FolParser = JClass(\"org.tweetyproject.logics.fol.parser.FolParser\")\n",
+    "FolSignature = JClass(\"org.tweetyproject.logics.fol.syntax.FolSignature\")\n",
+    "FolBeliefSet = JClass(\"org.tweetyproject.logics.fol.syntax.FolBeliefSet\")\n",
+    "SimpleFolReasoner = JClass(\"org.tweetyproject.logics.fol.reasoner.SimpleFolReasoner\")\n",
+    "Sort = JClass(\"org.tweetyproject.logics.commons.syntax.Sort\")\n",
+    "Constant = JClass(\"org.tweetyproject.logics.commons.syntax.Constant\")\n",
+    "Predicate = JClass(\"org.tweetyproject.logics.commons.syntax.Predicate\")\n",
+    "\n",
+    "# 1. Pre-declaration de la signature\n",
+    "sig = FolSignature()\n",
+    "thing = Sort(\"thing\"); sig.add(thing)\n",
+    "sig.add(Constant(\"tweety\", thing))\n",
+    "arg_sorts = ArrayList(); arg_sorts.add(thing)\n",
+    "sig.add(Predicate(\"Bird\", arg_sorts))\n",
+    "sig.add(Predicate(\"Fly\", arg_sorts))\n",
+    "\n",
+    "# 2. Parser + belief set partagent la signature\n",
+    "fparser = FolParser(); fparser.setSignature(sig)\n",
+    "fbs = FolBeliefSet(); fbs.setSignature(sig)\n",
+    "fbs.add(fparser.parseFormula(\"Bird(tweety)\"))\n",
+    "fbs.add(fparser.parseFormula(\"forall X: (Bird(X) => Fly(X))\"))\n",
+    "\n",
+    "# 3. Requete : Tweety vole-t-il ?\n",
+    "freasoner = SimpleFolReasoner()\n",
+    "entails_fly = bool(freasoner.query(fbs, fparser.parseFormula(\"Fly(tweety)\")))\n",
+    "print(\"--- Logique du premier ordre (FOL) : syllogisme ---\")\n",
+    "print(f\"Signature : Sort=thing, Constant=tweety, Predicates=Bird/1, Fly/1\")\n",
+    "print(f\"Belief set : {{Bird(tweety), forall X: (Bird(X) => Fly(X))}}\")\n",
+    "print(f\"  Fly(tweety) entailed ? {entails_fly}   (attendu : True)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-fol-interpret",
+   "metadata": {},
+   "source": [
+    "### Interpretation : syllogisme FOL\n",
+    "\n",
+    "**Sortie obtenue** : `Fly(tweety) entailed ? True`.\n",
+    "\n",
+    "**Ce qu'il faut retenir** :\n",
+    "\n",
+    "1. **La signature compte**. Si vous oubliez `sig.add(Predicate(\"Fly\", arg_sorts))`, le parseur refuse `Fly(tweety)` parce que le predicat n'existe pas. C'est volontaire : Tweety force une discipline declarationnelle qui evite les typos silencieuses.\n",
+    "2. **Le quantificateur `forall X:`** couvre toute la sous-formule parenthesee `(Bird(X) => Fly(X))`. La meme regle s'applique a tous les oiseaux, pas seulement a `tweety`.\n",
+    "3. Le `SimpleFolReasoner` decide l'entaillement via un theorem prover (herbrandisation + resolution) ; la reponse est exacte sur ce fragment.\n",
+    "\n",
+    "> **Lien avec l'agent LLM** : dans le pipeline complet (rung 3), c'est le LLM qui propose `forall X: (Bird(X) => Fly(X))` a partir du texte \"Tous les oiseaux volent\". Mais la preuve que Tweety vole est deleguee a Tweety — pas au LLM. C'est la frontiere nette entre extraction informelle et verification formelle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-fol-ex2-intro",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 (FOL) : le syllogisme de Socrates\n",
+    "\n",
+    "**Contexte** : syllogisme classique — \"Tous les hommes sont mortels. Socrate est un homme. Donc Socrate est mortel.\"\n",
+    "\n",
+    "**Objectif** : declarer une signature FOL (un sort, une constante `socrates`, deux predicats `Human` et `Mortal`), construire le belief set, et verifier que `Mortal(socrates)` est entailed.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Etape 1 : declarer le sort `person`, la constante `socrates`, les predicats `Human/1` et `Mortal/1`\n",
+    "- # Etape 2 : ajouter `Human(socrates)` et `forall X: (Human(X) => Mortal(X))`\n",
+    "- # Etape 3 : requete `Mortal(socrates)`\n",
+    "- # Etape 4 : afficher le booleen (attendu : True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "aa2f-fol-ex2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Syllogisme de Socrates : Mortal(socrates) entailed ? None\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (FOL) : syllogisme de Socrates\n",
+    "# TODO etudiant : declarer la signature puis interroger Mortal(socrates).\n",
+    "# Etape 1 : signature (sort person, constante socrates, predicats Human/1, Mortal/1)\n",
+    "sig_ex2 = None  # TODO etudiant : FolSignature()\n",
+    "# TODO etudiant : ajouter Sort, Constant, Predicates\n",
+    "\n",
+    "# Etape 2 : belief set\n",
+    "fbs_ex2 = None  # TODO etudiant : FolBeliefSet() + setSignature(sig_ex2)\n",
+    "# TODO etudiant : ajouter Human(socrates) et forall X: (Human(X) => Mortal(X))\n",
+    "\n",
+    "# Etape 3 : requete\n",
+    "result_ex2 = None  # TODO etudiant : bool(freasoner.query(fbs_ex2, fparser.parseFormula(\"Mortal(socrates)\")))\n",
+    "\n",
+    "# Etape 4 : afficher\n",
+    "print(f\"Syllogisme de Socrates : Mortal(socrates) entailed ? {result_ex2}\")\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-modal-intro",
+   "metadata": {},
+   "source": [
+    "## 5. Logique modale (aparcu) : possible `<>` et necessaire `[]`\n",
+    "\n",
+    "La logique modale etend PL/FOL avec deux operateurs :\n",
+    "\n",
+    "- `[](phi)` : **necessairement** `phi` (phi est vrai dans tous les mondes accessibles)\n",
+    "- `<>(phi)` : **possiblement** `phi` (phi est vrai dans au moins un monde accessible)\n",
+    "\n",
+    "> **Syntaxe Tweety** : l'argument de l'operateur modal doit etre **parenthese** — `[](p)`, pas `[]p`. Le parser `MlParser` leve une `ParserException` sinon (\"Unrecognized formula type... missing parentheses around modalized formula\").\n",
+    "\n",
+    "Le raisonner modal de Tweety implemente la logique **K** (le minimum : l'axiome de distribution `[](p=>q) => ([]p => []q)`). Il n'implemente **pas** l'axiome T (`[]p => p`) par defaut, donc `[](p)` n'entraine pas `p` tout seul.\n",
+    "\n",
+    "**Demo** : on croye `[](p => q)` (necessairement, p implique q) et `[](p)` (necessairement p). On interroge alors `[](q)` — l'axiome K doit nous donner `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "aa2f-modal-demo",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Logique modale (aparcu) : axiome K ---\n",
+      "Belief set : {[](p => q), [](p)}\n",
+      "  [](q) entailed ? True   (attendu : True, par K)\n",
+      "  q    entailed ? False   (attendu : False, sans axiome T)\n",
+      "Note : la logique K n'inclut pas T ([]p => p), donc [](p) n'entraine pas p.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [13] - Logique modale (aparcu) : axiome K sur des propositions 0-aires\n",
+    "# IMPORTANT : MlParser requiert une signature FOL (predicats 0-aires = propositions).\n",
+    "import jpype\n",
+    "from java.util import ArrayList\n",
+    "\n",
+    "JClass = jpype.JClass\n",
+    "FolSignature = JClass(\"org.tweetyproject.logics.fol.syntax.FolSignature\")\n",
+    "Sort = JClass(\"org.tweetyproject.logics.commons.syntax.Sort\")\n",
+    "Predicate = JClass(\"org.tweetyproject.logics.commons.syntax.Predicate\")\n",
+    "MlParser = JClass(\"org.tweetyproject.logics.ml.parser.MlParser\")\n",
+    "MlBeliefSet = JClass(\"org.tweetyproject.logics.ml.syntax.MlBeliefSet\")\n",
+    "SimpleMlReasoner = JClass(\"org.tweetyproject.logics.ml.reasoner.SimpleMlReasoner\")\n",
+    "\n",
+    "# Signature : deux propositions 0-aires p et q\n",
+    "sig_m = FolSignature()\n",
+    "thing = Sort(\"thing\"); sig_m.add(thing)\n",
+    "empty = ArrayList()  # arite 0\n",
+    "sig_m.add(Predicate(\"p\", empty))\n",
+    "sig_m.add(Predicate(\"q\", empty))\n",
+    "\n",
+    "mparser = MlParser(); mparser.setSignature(sig_m)\n",
+    "mbs = MlBeliefSet(); mbs.setSignature(sig_m)\n",
+    "mbs.add(mparser.parseFormula(\"[](p => q)\"))  # necessairement (p => q)\n",
+    "mbs.add(mparser.parseFormula(\"[](p)\"))       # necessairement p\n",
+    "\n",
+    "mreasoner = SimpleMlReasoner()\n",
+    "entails_boxq = bool(mreasoner.query(mbs, mparser.parseFormula(\"[](q)\")))\n",
+    "entails_q = bool(mreasoner.query(mbs, mparser.parseFormula(\"q\")))\n",
+    "print(\"--- Logique modale (aparcu) : axiome K ---\")\n",
+    "print(f\"Belief set : {{[](p => q), [](p)}}\")\n",
+    "print(f\"  [](q) entailed ? {entails_boxq}   (attendu : True, par K)\")\n",
+    "print(f\"  q    entailed ? {entails_q}   (attendu : False, sans axiome T)\")\n",
+    "print(\"Note : la logique K n'inclut pas T ([]p => p), donc [](p) n'entraine pas p.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-modal-interpret",
+   "metadata": {},
+   "source": [
+    "### Interpretation : resultat modal\n",
+    "\n",
+    "**Sortie obtenue** : `[](q) entailed ? True` (l'axiome K s'applique) ; `q entailed ? False` (sans axiome T, ce qui est necessaire n'est pas forcement actuel).\n",
+    "\n",
+    "| Requete | Resultat | Pourquoi |\n",
+    "|---------|----------|----------|\n",
+    "| `[](q)` | True | K : `[](p=>q)` + `[](p)` entraine `[](q)` dans tous les mondes accessibles |\n",
+    "| `q` | False | Sans T, le monde \"courant\" n'est pas forcement among les mondes accessibles |\n",
+    "\n",
+    "> **Aparku honnete** : la logique modale est un domaine vaste (systemes K, T, S4, S5, sementique de Kripke). Ce notebook donne uniquement le gout des operateurs `[]` / `<>`. Pour aller plus loin : la [documentation Tweety sur `MlReasoner`](https://tweetyproject.org/api/org/tweetyproject/logics/ml/reasoner/SimpleMlReasoner.html) et l'ouvrage de Hughes & Cresswell, *A New Introduction to Modal Logic*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-fol-ex3-intro",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 (FOL ouvert) : votre propre mini-theorie\n",
+    "\n",
+    "**Contexte** : vous avez maintenant tous les outils pour modeliser un mini-domaine en FOL.\n",
+    "\n",
+    "**Objectif** : choisissez un domaine neutre (ex : couleurs de feux, types de vehicules, statuts d'un dossier), declarer une signature FOL avec **au moins 2 predicats** et **au moins une regle universelle** (`forall X: (...)`), puis interroger un fait concret.\n",
+    "\n",
+    "**Exemple de depart (a adapter)** : \"Toute voiture est un vehicule. Toute moto est un vehicule. ma_voiture est une voiture. Donc ma_voiture est un vehicule.\"\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Etape 1 : choisir un sort (ex : `thing`), declarer 1-2 constantes, 2 predicats\n",
+    "- # Etape 2 : ecrire 1 fait concret + 1 regle `forall X: (...)`\n",
+    "- # Etape 3 : construire la requete sur la constante\n",
+    "- # Etape 4 : afficher le booleen avec un `print` explicatif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "aa2f-fol-ex3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ma mini-theorie : entaillement = None\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (FOL) : votre propre mini-theorie\n",
+    "# TODO etudiant : modelisez un petit domaine en FOL et verifiez un entaillement.\n",
+    "# Etape 1 : signature (sort, constante(s), predicats)\n",
+    "sig_ex3 = None  # TODO etudiant\n",
+    "\n",
+    "# Etape 2 : belief set (1 fait concret + 1 regle universelle)\n",
+    "fbs_ex3 = None  # TODO etudiant\n",
+    "\n",
+    "# Etape 3 : requete sur la constante\n",
+    "result_ex3 = None  # TODO etudiant\n",
+    "\n",
+    "# Etape 4 : affichage explicatif\n",
+    "print(f\"Ma mini-theorie : entaillement = {result_ex3}\")\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-dung-intro",
+   "metadata": {},
+   "source": [
+    "## 6. Aparcu : argumentation de Dung (extension grounded)\n",
+    "\n",
+    "La theorie de l'argumentation de **Dung** (1995) modelise un debat comme un **graphe d'attaque** : chaque noeud est un argument, chaque arc `A -> B` signifie \"A attaque B\". Une **semantique** definit quels ensembles d'arguments peuvent etre acceptes ensemble.\n",
+    "\n",
+    "La semantique la plus prudente est l'**extension grounded** : le plus petit ensemble d'arguments qui se defend mutuellement, construit itterativement a partir des arguments non attaques.\n",
+    "\n",
+    "**Exemple** : trois arguments `a`, `b`, `c` ou `a` attaque `b` et `b` attaque `c`.\n",
+    "- `a` est non attaque -> accepte\n",
+    "- `a` attaque `b` -> `b` rejete\n",
+    "- plus personne n'attaque `c` (car `b` est rejete) -> `c` reinstaure, accepte\n",
+    "- Extension grounded : `{a, c}`\n",
+    "\n",
+    "La cellule ci-dessous calcule cette extension avec le vrai `SimpleGroundedReasoner` de Tweety."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "aa2f-dung-demo",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Argumentation de Dung (aparcu) : extension grounded ---\n",
+      "Graphe d'attaque : a -> b, b -> c\n",
+      "Extension(s) grounded : ['{a,c}']\n",
+      "Attendu : {a, c}  (a non attaque, b rejet, c reinstaure)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [16] - Aparcu Dung : extension grounded avec SimpleGroundedReasoner\n",
+    "import jpype\n",
+    "JClass = jpype.JClass\n",
+    "DungTheory = JClass(\"org.tweetyproject.arg.dung.syntax.DungTheory\")\n",
+    "Attack = JClass(\"org.tweetyproject.arg.dung.syntax.Attack\")\n",
+    "Argument = JClass(\"org.tweetyproject.arg.dung.syntax.Argument\")\n",
+    "SimpleGroundedReasoner = JClass(\"org.tweetyproject.arg.dung.reasoner.SimpleGroundedReasoner\")\n",
+    "\n",
+    "theory = DungTheory()\n",
+    "a = Argument(\"a\"); b = Argument(\"b\"); c = Argument(\"c\")\n",
+    "theory.add(a); theory.add(b); theory.add(c)\n",
+    "theory.add(Attack(a, b))   # a attaque b\n",
+    "theory.add(Attack(b, c))   # b attaque c\n",
+    "\n",
+    "reasoner_d = SimpleGroundedReasoner()\n",
+    "models = reasoner_d.getModels(theory)   # Collection<Extension>\n",
+    "it = models.iterator()\n",
+    "extensions = []\n",
+    "while it.hasNext():\n",
+    "    extensions.append(str(it.next()))\n",
+    "\n",
+    "print(\"--- Argumentation de Dung (aparcu) : extension grounded ---\")\n",
+    "print(f\"Graphe d'attaque : a -> b, b -> c\")\n",
+    "print(f\"Extension(s) grounded : {extensions}\")\n",
+    "print(f\"Attendu : {{a, c}}  (a non attaque, b rejet, c reinstaure)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-dung-interpret",
+   "metadata": {},
+   "source": [
+    "### Interpretation : extension grounded\n",
+    "\n",
+    "**Sortie obtenue** : `[{a, c}]`.\n",
+    "\n",
+    "Ce resultat correspond a la construction pas-a-pas : `a` est accepte parce qu'aucun argument ne l'attaque ; `b` est rejete parce que `a` (accepte) l'attaque ; `c` est reinstaure parce que son seul attaquant (`b`) est rejete.\n",
+    "\n",
+    "> **Aparku honnete** : la theorie de Dung est considerablement plus riche (semantiques preferred, stable, complete ; AAF probabilistes ; bipolar argumentation ; ASPIC+ pour construire les arguments). Ce notebook ne fait qu'effleurer la semantique grounded. Pour approfondir : [Tweety arg.dung package](https://tweetyproject.org/api/org/tweetyproject/arg/dung/package-summary.html) et Dung, *On the Acceptability of Arguments and its Fundamental Role in Nonmonotonic Reasoning, Logic Programming and n-Person Games*, AIJ 1995."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2f-conclusion",
+   "metadata": {},
+   "source": [
+    "## 7. Conclusion et recapitulatif\n",
+    "\n",
+    "Ce rung a delegue la **preuve logique** a un vrai raisonneur Java (Tweety via JPype) plutot qu'a un LLM. Chaque cellule de code a produit un resultat certifie par le solveur — jamais simule.\n",
+    "\n",
+    "### Tableau recapitulatif\n",
+    "\n",
+    "| Formalisme | Ce qu'il prouve | Classes Tweety cles | Contrainte principale |\n",
+    "|------------|-----------------|---------------------|------------------------|\n",
+    "| **PL** | Entaillement propositionnel (modus ponens, tollens) | `PlParser`, `SimplePlReasoner`, `PlBeliefSet` | Syntaxe BNF `!` `&&` `||` `=>` ; eviter `>>` |\n",
+    "| **FOL** | Entaillement quantifie (syllogismes) | `FolParser`, `FolSignature`, `SimpleFolReasoner` | **Pre-declaration obligatoire** de Sort/Constant/Predicate |\n",
+    "| **Modal** | Axiome K (`[]`/`<>`) | `MlParser`, `MlBeliefSet`, `SimpleMlReasoner` | Argument entre parentheses : `[](p)` ; logique K (pas de T) |\n",
+    "| **Dung** | Extension grounded d'un graphe d'attaque | `DungTheory`, `Attack`, `SimpleGroundedReasoner` | Construction du graphe avant le `getModels` |\n",
+    "\n",
+    "### Points a retenir\n",
+    "\n",
+    "1. **Frontiere nette LLM / solveur** : le LLM extrait la structure informelle (rung 1) et propose l'encodage ; le solveur formel prouve l'entaillement (ce rung). Ne jamais melanger les deux roles.\n",
+    "\n",
+    "2. **Pre-declaration FOL = discipline** : exiger une signature explicite empeche les typos silencieuses qu'un LLM genere par habitude. C'est volontaire et pedagogique.\n",
+    "\n",
+    "3. **Anti-theatre est un choix d'ingenerie** : un mode degrade qui simulerait les sorties rendrait le notebook inutilisable pour enseigner la rigueur. Fail-loud est preferable a faux-succes.\n",
+    "\n",
+    "4. **Aparkus honnetes** : la logique modale et la theorie de Dung ont chacune ete survolees. Les notebooks de la serie SymbolicAI/Sudoku (Z3) et d'autres rungs approfondiront ces sujets.\n",
+    "\n",
+    "### Prochaines etapes\n",
+    "\n",
+    "- [3-orchestration](./Argument_Analysis_Agentic-3-orchestration.ipynb) : orchestration multi-agents ou un ProjectManagerAgent delegue au PL/FOL Agent (ce rung) et a l'Informal Agent (rung 1).\n",
+    "- Pour la modelisation FOL avancee (defeasible, ASPIC+), consulter les packages `org.tweetyproject.arg.delp` et `org.tweetyproject.arg.aspic`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -34,7 +34,8 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 |---|----------|---------|------|
 | 0 | [Agentic-0-init](Argument_Analysis_Agentic-0-init.ipynb) | Configuration, chargement API | Setup |
 | 1 | [Agentic-1-informal_agent](Argument_Analysis_Agentic-1-informal_agent.ipynb) | Agent analyse informelle | Détection d'arguments |
-| 2 | [Agentic-2-pl_agent](Argument_Analysis_Agentic-2-pl_agent.ipynb) | Agent logique propositionnelle | Formalisation |
+| 2 | [Agentic-2-formal](Argument_Analysis_Agentic-2-formal.ipynb) | Logique formelle réelle (PL + FOL + Modal + Dung via Tweety) | Formalisation |
+| 2* | [Agentic-2-pl_agent](Argument_Analysis_Agentic-2-pl_agent.ipynb) | *(legacy)* Agent logique propositionnelle | Formalisation |
 | 3 | [Agentic-3-orchestration](Argument_Analysis_Agentic-3-orchestration.ipynb) | Orchestration multi-agents | Coordination |
 | UI | [UI_configuration](Argument_Analysis_UI_configuration.ipynb) | Interface utilisateur widgets | Interaction |
 | Exec | [Executor](Argument_Analysis_Executor.ipynb) | Orchestrateur principal | Exécution |
@@ -55,7 +56,8 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 |----------|----------------|-------|
 | **0-init** | Configurer l'environnement Python + Java, charger les clés API, vérifier la connexion Tweety/JVM | 30 min |
 | **1-informal_agent** | Construire un agent LLM qui identifie et annote les arguments dans un texte naturel | 60 min |
-| **2-pl_agent** | Convertir les arguments informels en formules propositionnelles et les vérifier via SAT | 60 min |
+| **2-formal** | Vérifier des arguments en logique propositionnelle, du premier ordre et modale avec le solveur réel Tweety (JVM/JPype), apéru Dung — mode fail-loud, jamais simulé | 45 min |
+| **2-pl_agent** *(legacy)* | Convertir les arguments informels en formules propositionnelles et les vérifier via SAT | 60 min |
 | **3-orchestration** | Composer les agents précédents en pipeline coordonné avec rapport de sortie structuré | 50 min |
 | **UI_configuration** | Créer une interface interactive (ipywidgets) pour piloter le pipeline en mode exploratoire | 30 min |
 | **Executor** | Exécuter le pipeline complet en mode batch (Papermill/MCP) avec configuration .env | 20 min |


### PR DESCRIPTION
## Summary

Phase 2 rung-by-rung refonte of `Argument_Analysis` (Epic #2137). **Rung 2-formal** — first of the compact 5-NB arc (2-formal -> 1-informal -> 3-orchestration -> 4-capstone -> 0-init). Mapping rung-par-rung adopted as design authority (comment jsboigeEpita 00:29Z + ai-01 ancrage 00:34Z).

A new compact notebook teaching **formal logic verification with the REAL Tweety Java reasoner (JPype)** — not LLM-simulated logic. The source EPITA-IS project banned the simulated-PL mode this year (the old `RECONSTRUCTION_PLAN.md` "cause #2" degraded mode); this rung teaches the real thing.

## What it teaches (REAL Tweety, validated)
- **PL**: modus ponens (`rain => wet, rain |= wet`) via `SimplePlReasoner`
- **FOL**: syllogism (`Bird(tweety), forall X:(Bird(X)=>Fly(X)) |= Fly(tweety)`) via `SimpleFolReasoner` — with **pre-declared signature** (Sort/Constant/Predicate), the key pattern Tweety requires (unlike PL)
- **Modal**: diamond `<>`/box `[]` apéru via `SimpleMlReasoner` (logic K, honest note that modal is deeper)
- **Dung**: grounded extension apéru via `SimpleGroundedReasoner` (attack graph a->b->c => `{a,c}`)

## Garde-fous HARD (from the source, non-negotiable)
1. **Anti-théâtre / fail-loud**: every logic cell calls the Java reasoner and shows its REAL output. JVM startup `raise RuntimeError` if Tweety/JVM unavailable — never a simulated/fake result.
2. **Privacy**: all examples synthetic/neutral (weather, birds/Tweety, Socrates, abstract a/b/c). No EPITA corpus, no `raw_text`, no names.
3. **Compactness**: 24 cells (16 markdown + 8 code), distilled — not a port of the 678-file EPITA source.

## Validation (C.2 — real outputs)
Papermill `--cwd MyIA.AI.Notebooks/SymbolicAI`: **24/24 cells, 0 errors**, all 8 code cells with `execution_count` set (1-8) and real Tweety outputs:
- PL: `wet entailed ? True`, `!wet entailed ? False`
- FOL: `Fly(tweety) entailed ? True`
- Modal: `[](q) entailed ? True`, `q entailed ? False` (logic K, no T axiom)
- Dung: `Extension(s) grounded : ['{a,c}']`

## Conformity
- **C.1**: `grep -cE "raise NotImplementedError|assert False|1/0"` = **0**
- **#2161**: 3 exercise stubs (cells 9 PL/modus-tollens, 14 FOL/Socrates, 19 open-ended), distributed, preceded by markdown context + indices
- **Catalog**: byte-identical to `origin/main` (cron-owned, not regenerated here)
- **README**: updated to reference 2-formal as primary rung-2 entry; legacy `2-pl_agent` kept as `2*`

`See #2137` (partial — rung 2-formal of 5, epic remains open).

Co-Authored-By: Claude <noreply@anthropic.com>