### PR TITLE
chore(probas): PyMC provenance unification slice 2a/2 -- PyMC-13 + PyMC-15 onto coursia-ml-training

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Debugging.ipynb
@@ -5,10 +5,10 @@
    "id": "a09b80c5",
    "metadata": {
     "papermill": {
-     "duration": 0.008606,
-     "end_time": "2026-06-05T11:10:57.785766",
+     "duration": 0.004477,
+     "end_time": "2026-06-15T04:25:17.992620+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:10:57.777160",
+     "start_time": "2026-06-15T04:25:17.988143+00:00",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "81322ef1",
    "metadata": {
     "papermill": {
-     "duration": 0.011043,
-     "end_time": "2026-06-05T11:10:57.810496",
+     "duration": 0.004002,
+     "end_time": "2026-06-15T04:25:18.000622+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:10:57.799453",
+     "start_time": "2026-06-15T04:25:17.996620+00:00",
      "status": "completed"
     },
     "tags": []
@@ -63,16 +63,16 @@
    "id": "8bffbe67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:10:57.829910Z",
-     "iopub.status.busy": "2026-06-05T11:10:57.829397Z",
-     "iopub.status.idle": "2026-06-05T11:10:59.914153Z",
-     "shell.execute_reply": "2026-06-05T11:10:59.909156Z"
+     "iopub.execute_input": "2026-06-15T04:25:18.006620Z",
+     "iopub.status.busy": "2026-06-15T04:25:18.006620Z",
+     "iopub.status.idle": "2026-06-15T04:25:21.509007Z",
+     "shell.execute_reply": "2026-06-15T04:25:21.509007Z"
     },
     "papermill": {
-     "duration": 2.114832,
-     "end_time": "2026-06-05T11:10:59.933073",
+     "duration": 3.505518,
+     "end_time": "2026-06-15T04:25:21.510139+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:10:57.818241",
+     "start_time": "2026-06-15T04:25:18.004621+00:00",
      "status": "completed"
     },
     "tags": []
@@ -82,7 +82,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PyMC version : 5.25.1\n",
+      "PyMC version : 5.28.5\n",
       "ArviZ version : 0.23.4\n",
       "PyMC pret !\n"
      ]
@@ -111,10 +111,10 @@
    "id": "340483a5",
    "metadata": {
     "papermill": {
-     "duration": 0.020049,
-     "end_time": "2026-06-05T11:10:59.981503",
+     "duration": 0.004,
+     "end_time": "2026-06-15T04:25:21.518180+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:10:59.961454",
+     "start_time": "2026-06-15T04:25:21.514180+00:00",
      "status": "completed"
     },
     "tags": []
@@ -140,10 +140,10 @@
    "id": "26ffedb5",
    "metadata": {
     "papermill": {
-     "duration": 0.009956,
-     "end_time": "2026-06-05T11:11:00.003763",
+     "duration": 0.004191,
+     "end_time": "2026-06-15T04:25:21.527372+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:10:59.993807",
+     "start_time": "2026-06-15T04:25:21.523181+00:00",
      "status": "completed"
     },
     "tags": []
@@ -165,10 +165,10 @@
    "id": "a1d2727b",
    "metadata": {
     "papermill": {
-     "duration": 0.017548,
-     "end_time": "2026-06-05T11:11:00.036401",
+     "duration": 0.004001,
+     "end_time": "2026-06-15T04:25:21.536372+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:00.018853",
+     "start_time": "2026-06-15T04:25:21.532371+00:00",
      "status": "completed"
     },
     "tags": []
@@ -193,21 +193,28 @@
    "id": "36b607cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:11:00.061649Z",
-     "iopub.status.busy": "2026-06-05T11:11:00.060561Z",
-     "iopub.status.idle": "2026-06-05T11:11:11.866467Z",
-     "shell.execute_reply": "2026-06-05T11:11:11.865276Z"
+     "iopub.execute_input": "2026-06-15T04:25:21.545937Z",
+     "iopub.status.busy": "2026-06-15T04:25:21.545937Z",
+     "iopub.status.idle": "2026-06-15T04:25:33.673513Z",
+     "shell.execute_reply": "2026-06-15T04:25:33.673513Z"
     },
     "papermill": {
-     "duration": 11.822509,
-     "end_time": "2026-06-05T11:11:11.866467",
+     "duration": 12.133142,
+     "end_time": "2026-06-15T04:25:33.673513+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:00.043958",
+     "start_time": "2026-06-15T04:25:21.540371+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -218,13 +225,6 @@
       "  -> La densite du prior a x=50 est quasi-nulle\n",
       "\n",
       "SOLUTION : Elargir le prior\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -245,7 +245,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 9 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 10 seconds.\n"
      ]
     },
     {
@@ -301,10 +301,10 @@
    "id": "f52a622f",
    "metadata": {
     "papermill": {
-     "duration": 0.02463,
-     "end_time": "2026-06-05T11:11:11.891097",
+     "duration": 0.0,
+     "end_time": "2026-06-15T04:25:33.675554+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:11.866467",
+     "start_time": "2026-06-15T04:25:33.675554+00:00",
      "status": "completed"
     },
     "tags": []
@@ -323,9 +323,9 @@
    "metadata": {
     "papermill": {
      "duration": 0.0,
-     "end_time": "2026-06-05T11:11:11.902348",
+     "end_time": "2026-06-15T04:25:33.685201+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:11.902348",
+     "start_time": "2026-06-15T04:25:33.685201+00:00",
      "status": "completed"
     },
     "tags": []
@@ -342,16 +342,16 @@
    "id": "65e3c067",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:11:11.929139Z",
-     "iopub.status.busy": "2026-06-05T11:11:11.929139Z",
-     "iopub.status.idle": "2026-06-05T11:11:21.492973Z",
-     "shell.execute_reply": "2026-06-05T11:11:21.491859Z"
+     "iopub.execute_input": "2026-06-15T04:25:33.685201Z",
+     "iopub.status.busy": "2026-06-15T04:25:33.685201Z",
+     "iopub.status.idle": "2026-06-15T04:25:44.393027Z",
+     "shell.execute_reply": "2026-06-15T04:25:44.392012Z"
     },
     "papermill": {
-     "duration": 9.580877,
-     "end_time": "2026-06-05T11:11:21.494034",
+     "duration": 10.707826,
+     "end_time": "2026-06-15T04:25:44.393027+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:11.913157",
+     "start_time": "2026-06-15T04:25:33.685201+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,7 +398,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 9 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 10 seconds.\n"
      ]
     },
     {
@@ -458,10 +458,10 @@
    "id": "55b10e08",
    "metadata": {
     "papermill": {
-     "duration": 0.009154,
-     "end_time": "2026-06-05T11:11:21.512071",
+     "duration": 0.004596,
+     "end_time": "2026-06-15T04:25:44.403307+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:21.502917",
+     "start_time": "2026-06-15T04:25:44.398711+00:00",
      "status": "completed"
     },
     "tags": []
@@ -489,16 +489,16 @@
    "id": "22538dbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:11:21.523790Z",
-     "iopub.status.busy": "2026-06-05T11:11:21.523790Z",
-     "iopub.status.idle": "2026-06-05T11:11:21.555198Z",
-     "shell.execute_reply": "2026-06-05T11:11:21.555198Z"
+     "iopub.execute_input": "2026-06-15T04:25:44.413766Z",
+     "iopub.status.busy": "2026-06-15T04:25:44.413766Z",
+     "iopub.status.idle": "2026-06-15T04:25:44.417029Z",
+     "shell.execute_reply": "2026-06-15T04:25:44.417029Z"
     },
     "papermill": {
-     "duration": 0.039376,
-     "end_time": "2026-06-05T11:11:21.558153",
+     "duration": 0.010734,
+     "end_time": "2026-06-15T04:25:44.418040+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:21.518777",
+     "start_time": "2026-06-15T04:25:44.407306+00:00",
      "status": "completed"
     },
     "tags": []
@@ -537,10 +537,10 @@
    "id": "f9d4a6d8",
    "metadata": {
     "papermill": {
-     "duration": 0.003054,
-     "end_time": "2026-06-05T11:11:21.571341",
+     "duration": 0.005005,
+     "end_time": "2026-06-15T04:25:44.427044+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:21.568287",
+     "start_time": "2026-06-15T04:25:44.422039+00:00",
      "status": "completed"
     },
     "tags": []
@@ -564,10 +564,10 @@
    "id": "7f697f0e",
    "metadata": {
     "papermill": {
-     "duration": 0.008468,
-     "end_time": "2026-06-05T11:11:21.596960",
+     "duration": 0.004001,
+     "end_time": "2026-06-15T04:25:44.435379+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:21.588492",
+     "start_time": "2026-06-15T04:25:44.431378+00:00",
      "status": "completed"
     },
     "tags": []
@@ -589,10 +589,10 @@
    "id": "9a6f1cae",
    "metadata": {
     "papermill": {
-     "duration": 0.012835,
-     "end_time": "2026-06-05T11:11:21.622875",
+     "duration": 0.004577,
+     "end_time": "2026-06-15T04:25:44.444957+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:21.610040",
+     "start_time": "2026-06-15T04:25:44.440380+00:00",
      "status": "completed"
     },
     "tags": []
@@ -614,21 +614,28 @@
    "id": "b51fae2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:11:21.645846Z",
-     "iopub.status.busy": "2026-06-05T11:11:21.645846Z",
-     "iopub.status.idle": "2026-06-05T11:11:41.297510Z",
-     "shell.execute_reply": "2026-06-05T11:11:41.296304Z"
+     "iopub.execute_input": "2026-06-15T04:25:44.449748Z",
+     "iopub.status.busy": "2026-06-15T04:25:44.449748Z",
+     "iopub.status.idle": "2026-06-15T04:26:01.503736Z",
+     "shell.execute_reply": "2026-06-15T04:26:01.503736Z"
     },
     "papermill": {
-     "duration": 19.666103,
-     "end_time": "2026-06-05T11:11:41.300283",
+     "duration": 17.054994,
+     "end_time": "2026-06-15T04:26:01.504742+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:21.634180",
+     "start_time": "2026-06-15T04:25:44.449748+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -638,13 +645,6 @@
       "Observations : [2.1 1.9 2.3 2.  1.8 2.2]\n",
       "Moyenne empirique : 2.050\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -665,7 +665,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 9 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 10 seconds.\n"
      ]
     },
     {
@@ -695,7 +695,7 @@
      "text": [
       "Resultats sur le parametre 'mean' :\n",
       "  NUTS : mean = 2.044, std = 0.1321\n",
-      "  ADVI : mean = 1.598, std = 1.0057\n",
+      "  ADVI : mean = 1.556, std = 0.9984\n",
       "\n",
       "Note : ADVI tend a avoir une variance plus faible (sous-estime l'incertitude)\n",
       "       car il approxime par une distribution gaussienne factorisee.\n"
@@ -752,10 +752,10 @@
    "id": "565c2293",
    "metadata": {
     "papermill": {
-     "duration": 0.00944,
-     "end_time": "2026-06-05T11:11:41.321895",
+     "duration": 0.005689,
+     "end_time": "2026-06-15T04:26:01.515237+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:41.312455",
+     "start_time": "2026-06-15T04:26:01.509548+00:00",
      "status": "completed"
     },
     "tags": []
@@ -787,10 +787,10 @@
    "id": "8d8cbdfe",
    "metadata": {
     "papermill": {
-     "duration": 0.008123,
-     "end_time": "2026-06-05T11:11:41.343169",
+     "duration": 0.004547,
+     "end_time": "2026-06-15T04:26:01.526021+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:41.335046",
+     "start_time": "2026-06-15T04:26:01.521474+00:00",
      "status": "completed"
     },
     "tags": []
@@ -814,34 +814,34 @@
    "id": "a162ffb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:11:41.371920Z",
-     "iopub.status.busy": "2026-06-05T11:11:41.371920Z",
-     "iopub.status.idle": "2026-06-05T11:12:00.179780Z",
-     "shell.execute_reply": "2026-06-05T11:12:00.178774Z"
+     "iopub.execute_input": "2026-06-15T04:26:01.540574Z",
+     "iopub.status.busy": "2026-06-15T04:26:01.540574Z",
+     "iopub.status.idle": "2026-06-15T04:26:22.804778Z",
+     "shell.execute_reply": "2026-06-15T04:26:22.804778Z"
     },
     "papermill": {
-     "duration": 18.822879,
-     "end_time": "2026-06-05T11:12:00.181797",
+     "duration": 21.272218,
+     "end_time": "2026-06-15T04:26:22.805793+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:11:41.358918",
+     "start_time": "2026-06-15T04:26:01.533575+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "=== Outils de Diagnostic ===\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -862,7 +862,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 18 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 19 seconds.\n"
      ]
     },
     {
@@ -925,10 +925,10 @@
    "id": "8513ab02",
    "metadata": {
     "papermill": {
-     "duration": 0.016928,
-     "end_time": "2026-06-05T11:12:00.217735",
+     "duration": 0.005394,
+     "end_time": "2026-06-15T04:26:22.815768+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:12:00.200807",
+     "start_time": "2026-06-15T04:26:22.810374+00:00",
      "status": "completed"
     },
     "tags": []
@@ -950,10 +950,10 @@
    "id": "bcec3882",
    "metadata": {
     "papermill": {
-     "duration": 0.017105,
-     "end_time": "2026-06-05T11:12:00.255360",
+     "duration": 0.005009,
+     "end_time": "2026-06-15T04:26:22.826315+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:12:00.238255",
+     "start_time": "2026-06-15T04:26:22.821306+00:00",
      "status": "completed"
     },
     "tags": []
@@ -977,34 +977,34 @@
    "id": "86a0797a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:12:00.303654Z",
-     "iopub.status.busy": "2026-06-05T11:12:00.303654Z",
-     "iopub.status.idle": "2026-06-05T11:12:20.042484Z",
-     "shell.execute_reply": "2026-06-05T11:12:20.040754Z"
+     "iopub.execute_input": "2026-06-15T04:26:22.828317Z",
+     "iopub.status.busy": "2026-06-15T04:26:22.828317Z",
+     "iopub.status.idle": "2026-06-15T04:26:47.489350Z",
+     "shell.execute_reply": "2026-06-15T04:26:47.489350Z"
     },
     "papermill": {
-     "duration": 19.762564,
-     "end_time": "2026-06-05T11:12:20.044482",
+     "duration": 24.662039,
+     "end_time": "2026-06-15T04:26:47.490356+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:12:00.281918",
+     "start_time": "2026-06-15T04:26:22.828317+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "=== Visualisation des diagnostics ===\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -1025,7 +1025,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 18 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 21 seconds.\n"
      ]
     },
     {
@@ -1092,10 +1092,10 @@
    "id": "93bd1e0e",
    "metadata": {
     "papermill": {
-     "duration": 0.020568,
-     "end_time": "2026-06-05T11:12:20.092495",
+     "duration": 0.006999,
+     "end_time": "2026-06-15T04:26:47.505195+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:12:20.071927",
+     "start_time": "2026-06-15T04:26:47.498196+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1124,10 +1124,10 @@
    "id": "607ab2fb",
    "metadata": {
     "papermill": {
-     "duration": 0.012626,
-     "end_time": "2026-06-05T11:12:20.121139",
+     "duration": 0.007018,
+     "end_time": "2026-06-15T04:26:47.519554+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:12:20.108513",
+     "start_time": "2026-06-15T04:26:47.512536+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1162,10 +1162,10 @@
    "id": "6edacfe6",
    "metadata": {
     "papermill": {
-     "duration": 0.013983,
-     "end_time": "2026-06-05T11:12:20.149123",
+     "duration": 0.008453,
+     "end_time": "2026-06-15T04:26:47.535514+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:12:20.135140",
+     "start_time": "2026-06-15T04:26:47.527061+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1188,21 +1188,28 @@
    "id": "0e2648db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:12:20.182456Z",
-     "iopub.status.busy": "2026-06-05T11:12:20.182456Z",
-     "iopub.status.idle": "2026-06-05T11:13:08.740050Z",
-     "shell.execute_reply": "2026-06-05T11:13:08.740050Z"
+     "iopub.execute_input": "2026-06-15T04:26:47.551855Z",
+     "iopub.status.busy": "2026-06-15T04:26:47.551855Z",
+     "iopub.status.idle": "2026-06-15T04:27:41.774536Z",
+     "shell.execute_reply": "2026-06-15T04:27:41.774536Z"
     },
     "papermill": {
-     "duration": 48.570773,
-     "end_time": "2026-06-05T11:13:08.740050",
+     "duration": 54.231022,
+     "end_time": "2026-06-15T04:27:41.774536+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:12:20.169277",
+     "start_time": "2026-06-15T04:26:47.543514+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1218,13 +1225,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "Multiprocess sampling (2 chains in 2 jobs)\n"
      ]
     },
@@ -1239,7 +1239,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 11 seconds.\n"
      ]
     },
     {
@@ -1247,6 +1247,13 @@
      "output_type": "stream",
      "text": [
       "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -1260,13 +1267,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "Multiprocess sampling (2 chains in 2 jobs)\n"
      ]
     },
@@ -1292,17 +1292,17 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Centre Beta(2,2)               -> Posterior : mean = 0.549\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
       "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Centre Beta(2,2)               -> Posterior : mean = 0.549\n"
      ]
     },
     {
@@ -1323,7 +1323,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 12 seconds.\n"
      ]
     },
     {
@@ -1365,7 +1365,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 9 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 11 seconds.\n"
      ]
     },
     {
@@ -1427,10 +1427,10 @@
    "id": "5993b7ed",
    "metadata": {
     "papermill": {
-     "duration": 0.063354,
-     "end_time": "2026-06-05T11:13:08.819082",
+     "duration": 0.009264,
+     "end_time": "2026-06-15T04:27:41.792668+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:08.755728",
+     "start_time": "2026-06-15T04:27:41.783404+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1465,10 +1465,10 @@
    "id": "a40e9009",
    "metadata": {
     "papermill": {
-     "duration": 0.123663,
-     "end_time": "2026-06-05T11:13:09.060127",
+     "duration": 0.009755,
+     "end_time": "2026-06-15T04:27:41.809724+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:08.936464",
+     "start_time": "2026-06-15T04:27:41.799969+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1501,10 +1501,10 @@
    "id": "9dcde343",
    "metadata": {
     "papermill": {
-     "duration": 0.10634,
-     "end_time": "2026-06-05T11:13:09.198822",
+     "duration": 0.008557,
+     "end_time": "2026-06-15T04:27:41.826525+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:09.092482",
+     "start_time": "2026-06-15T04:27:41.817968+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1521,16 +1521,16 @@
    "id": "5256a0c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:13:09.396178Z",
-     "iopub.status.busy": "2026-06-05T11:13:09.385108Z",
-     "iopub.status.idle": "2026-06-05T11:13:28.454327Z",
-     "shell.execute_reply": "2026-06-05T11:13:28.454327Z"
+     "iopub.execute_input": "2026-06-15T04:27:41.845070Z",
+     "iopub.status.busy": "2026-06-15T04:27:41.845070Z",
+     "iopub.status.idle": "2026-06-15T04:28:03.431168Z",
+     "shell.execute_reply": "2026-06-15T04:28:03.431168Z"
     },
     "papermill": {
-     "duration": 19.139933,
-     "end_time": "2026-06-05T11:13:28.456411",
+     "duration": 21.596596,
+     "end_time": "2026-06-15T04:28:03.431168+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:09.316478",
+     "start_time": "2026-06-15T04:27:41.834572+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1561,7 +1561,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 18 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 20 seconds.\n"
      ]
     },
     {
@@ -1643,10 +1643,10 @@
    "id": "5f9fed59",
    "metadata": {
     "papermill": {
-     "duration": 0.074724,
-     "end_time": "2026-06-05T11:13:28.597633",
+     "duration": 0.0086,
+     "end_time": "2026-06-15T04:28:03.449427+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:28.522909",
+     "start_time": "2026-06-15T04:28:03.440827+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1674,16 +1674,16 @@
    "id": "fdc5e10e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:13:28.629819Z",
-     "iopub.status.busy": "2026-06-05T11:13:28.616138Z",
-     "iopub.status.idle": "2026-06-05T11:13:28.647408Z",
-     "shell.execute_reply": "2026-06-05T11:13:28.645762Z"
+     "iopub.execute_input": "2026-06-15T04:28:03.466385Z",
+     "iopub.status.busy": "2026-06-15T04:28:03.466385Z",
+     "iopub.status.idle": "2026-06-15T04:28:03.469567Z",
+     "shell.execute_reply": "2026-06-15T04:28:03.469567Z"
     },
     "papermill": {
-     "duration": 0.033624,
-     "end_time": "2026-06-05T11:13:28.647408",
+     "duration": 0.013143,
+     "end_time": "2026-06-15T04:28:03.470572+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:28.613784",
+     "start_time": "2026-06-15T04:28:03.457429+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1722,10 +1722,10 @@
    "id": "c441d144",
    "metadata": {
     "papermill": {
-     "duration": 0.123737,
-     "end_time": "2026-06-05T11:13:28.805288",
+     "duration": 0.009522,
+     "end_time": "2026-06-15T04:28:03.488093+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:28.681551",
+     "start_time": "2026-06-15T04:28:03.478571+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1771,10 +1771,10 @@
    "id": "098d43bf",
    "metadata": {
     "papermill": {
-     "duration": 0.021205,
-     "end_time": "2026-06-05T11:13:28.860513",
+     "duration": 0.008021,
+     "end_time": "2026-06-15T04:28:03.505412+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:28.839308",
+     "start_time": "2026-06-15T04:28:03.497391+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1793,34 +1793,34 @@
    "id": "c1b60f75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:13:28.883075Z",
-     "iopub.status.busy": "2026-06-05T11:13:28.883075Z",
-     "iopub.status.idle": "2026-06-05T11:13:50.174918Z",
-     "shell.execute_reply": "2026-06-05T11:13:50.172917Z"
+     "iopub.execute_input": "2026-06-15T04:28:03.525680Z",
+     "iopub.status.busy": "2026-06-15T04:28:03.525680Z",
+     "iopub.status.idle": "2026-06-15T04:28:27.748116Z",
+     "shell.execute_reply": "2026-06-15T04:28:27.747449Z"
     },
     "papermill": {
-     "duration": 21.30026,
-     "end_time": "2026-06-05T11:13:50.178539",
+     "duration": 24.234147,
+     "end_time": "2026-06-15T04:28:27.748590+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:28.878279",
+     "start_time": "2026-06-15T04:28:03.514443+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "=== Exemple : Modele bien specifie ===\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -1841,7 +1841,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 19 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 20 seconds.\n"
      ]
     },
     {
@@ -1918,10 +1918,10 @@
    "id": "d8874600",
    "metadata": {
     "papermill": {
-     "duration": 0.026551,
-     "end_time": "2026-06-05T11:13:50.251533",
+     "duration": 0.007507,
+     "end_time": "2026-06-15T04:28:27.763609+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:50.224982",
+     "start_time": "2026-06-15T04:28:27.756102+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1936,34 +1936,34 @@
    "id": "a4e92b89",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:13:50.302897Z",
-     "iopub.status.busy": "2026-06-05T11:13:50.302897Z",
-     "iopub.status.idle": "2026-06-05T11:14:00.352265Z",
-     "shell.execute_reply": "2026-06-05T11:14:00.334558Z"
+     "iopub.execute_input": "2026-06-15T04:28:27.781509Z",
+     "iopub.status.busy": "2026-06-15T04:28:27.781509Z",
+     "iopub.status.idle": "2026-06-15T04:28:39.182103Z",
+     "shell.execute_reply": "2026-06-15T04:28:39.182103Z"
     },
     "papermill": {
-     "duration": 10.070511,
-     "end_time": "2026-06-05T11:14:00.354486",
+     "duration": 11.409335,
+     "end_time": "2026-06-15T04:28:39.182103+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:13:50.283975",
+     "start_time": "2026-06-15T04:28:27.772768+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "=== Exercice : Debugger ce modele ===\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -1984,7 +1984,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 9 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 11 seconds.\n"
      ]
     },
     {
@@ -2064,10 +2064,10 @@
    "id": "818b9439",
    "metadata": {
     "papermill": {
-     "duration": 0.025555,
-     "end_time": "2026-06-05T11:14:00.402174",
+     "duration": 0.006012,
+     "end_time": "2026-06-15T04:28:39.197589+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:14:00.376619",
+     "start_time": "2026-06-15T04:28:39.191577+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2091,10 +2091,10 @@
    "id": "c47c65da",
    "metadata": {
     "papermill": {
-     "duration": 0.051943,
-     "end_time": "2026-06-05T11:14:00.474723",
+     "duration": 0.0,
+     "end_time": "2026-06-15T04:28:39.205605+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:14:00.422780",
+     "start_time": "2026-06-15T04:28:39.205605+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2121,10 +2121,10 @@
    "id": "de9bcce9",
    "metadata": {
     "papermill": {
-     "duration": 0.035081,
-     "end_time": "2026-06-05T11:14:00.543698",
+     "duration": 0.016094,
+     "end_time": "2026-06-15T04:28:39.238702+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:14:00.508617",
+     "start_time": "2026-06-15T04:28:39.222608+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2155,10 +2155,10 @@
    "id": "95970d75",
    "metadata": {
     "papermill": {
-     "duration": 0.008069,
-     "end_time": "2026-06-05T11:14:00.571223",
+     "duration": 0.00076,
+     "end_time": "2026-06-15T04:28:39.254614+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:14:00.563154",
+     "start_time": "2026-06-15T04:28:39.253854+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2182,16 +2182,16 @@
    "id": "3fb79ac6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:14:00.618909Z",
-     "iopub.status.busy": "2026-06-05T11:14:00.618909Z",
-     "iopub.status.idle": "2026-06-05T11:14:00.635368Z",
-     "shell.execute_reply": "2026-06-05T11:14:00.634741Z"
+     "iopub.execute_input": "2026-06-15T04:28:39.274750Z",
+     "iopub.status.busy": "2026-06-15T04:28:39.274750Z",
+     "iopub.status.idle": "2026-06-15T04:28:39.284262Z",
+     "shell.execute_reply": "2026-06-15T04:28:39.284262Z"
     },
     "papermill": {
-     "duration": 0.033176,
-     "end_time": "2026-06-05T11:14:00.635368",
+     "duration": 0.013618,
+     "end_time": "2026-06-15T04:28:39.284262+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:14:00.602192",
+     "start_time": "2026-06-15T04:28:39.270644+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2235,10 +2235,10 @@
    "id": "3fef01be",
    "metadata": {
     "papermill": {
-     "duration": 0.038622,
-     "end_time": "2026-06-05T11:14:00.703262",
+     "duration": 0.014803,
+     "end_time": "2026-06-15T04:28:39.302070+00:00",
      "exception": false,
-     "start_time": "2026-06-05T11:14:00.664640",
+     "start_time": "2026-06-15T04:28:39.287267+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2270,18 +2270,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 185.607445,
-   "end_time": "2026-06-05T11:14:01.702586",
+   "duration": 204.064147,
+   "end_time": "2026-06-15T04:28:40.194429+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Debugging.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Debugging.ipynb",
+   "input_path": "d:/dev/CoursIA/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Debugging.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice2a/PyMC-13-Debugging.out.ipynb",
    "parameters": {},
-   "start_time": "2026-06-05T11:10:56.095141",
+   "start_time": "2026-06-15T04:25:16.130282+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.012065,
-     "end_time": "2026-06-06T14:30:53.874087",
+     "duration": 0.025586,
+     "end_time": "2026-06-15T04:28:45.050760+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:53.862022",
+     "start_time": "2026-06-15T04:28:45.025174+00:00",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.008,
-     "end_time": "2026-06-06T14:30:53.889350",
+     "duration": 0.008172,
+     "end_time": "2026-06-15T04:28:45.062944+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:53.881350",
+     "start_time": "2026-06-15T04:28:45.054772+00:00",
      "status": "completed"
     },
     "tags": []
@@ -70,10 +70,10 @@
    "id": "cell-2",
    "metadata": {
     "papermill": {
-     "duration": 0.007996,
-     "end_time": "2026-06-06T14:30:53.905374",
+     "duration": 0.017868,
+     "end_time": "2026-06-15T04:28:45.089480+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:53.897378",
+     "start_time": "2026-06-15T04:28:45.071612+00:00",
      "status": "completed"
     },
     "tags": []
@@ -88,16 +88,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:30:53.924025Z",
-     "iopub.status.busy": "2026-06-06T14:30:53.924025Z",
-     "iopub.status.idle": "2026-06-06T14:30:56.067880Z",
-     "shell.execute_reply": "2026-06-06T14:30:56.066868Z"
+     "iopub.execute_input": "2026-06-15T04:28:45.104716Z",
+     "iopub.status.busy": "2026-06-15T04:28:45.104716Z",
+     "iopub.status.idle": "2026-06-15T04:28:47.961857Z",
+     "shell.execute_reply": "2026-06-15T04:28:47.961857Z"
     },
     "papermill": {
-     "duration": 2.154853,
-     "end_time": "2026-06-06T14:30:56.068878",
+     "duration": 2.864663,
+     "end_time": "2026-06-15T04:28:47.962863+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:53.914025",
+     "start_time": "2026-06-15T04:28:45.098200+00:00",
      "status": "completed"
     },
     "tags": []
@@ -107,7 +107,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PyMC version : 5.25.1\n",
+      "PyMC version : 5.28.5\n",
       "ArviZ version : 0.23.4\n"
      ]
     }
@@ -136,10 +136,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.007977,
-     "end_time": "2026-06-06T14:30:56.083870",
+     "duration": 0.005449,
+     "end_time": "2026-06-15T04:28:47.975177+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:56.075893",
+     "start_time": "2026-06-15T04:28:47.969728+00:00",
      "status": "completed"
     },
     "tags": []
@@ -156,16 +156,16 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:30:56.100368Z",
-     "iopub.status.busy": "2026-06-06T14:30:56.099368Z",
-     "iopub.status.idle": "2026-06-06T14:30:56.365942Z",
-     "shell.execute_reply": "2026-06-06T14:30:56.365942Z"
+     "iopub.execute_input": "2026-06-15T04:28:47.992156Z",
+     "iopub.status.busy": "2026-06-15T04:28:47.992156Z",
+     "iopub.status.idle": "2026-06-15T04:28:48.182312Z",
+     "shell.execute_reply": "2026-06-15T04:28:48.181809Z"
     },
     "papermill": {
-     "duration": 0.27607,
-     "end_time": "2026-06-06T14:30:56.367454",
+     "duration": 0.19967,
+     "end_time": "2026-06-15T04:28:48.183316+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:56.091384",
+     "start_time": "2026-06-15T04:28:47.983646+00:00",
      "status": "completed"
     },
     "tags": []
@@ -235,16 +235,16 @@
    "id": "a74b4b7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:30:56.387843Z",
-     "iopub.status.busy": "2026-06-06T14:30:56.387843Z",
-     "iopub.status.idle": "2026-06-06T14:30:58.669911Z",
-     "shell.execute_reply": "2026-06-06T14:30:58.669151Z"
+     "iopub.execute_input": "2026-06-15T04:28:48.197823Z",
+     "iopub.status.busy": "2026-06-15T04:28:48.196824Z",
+     "iopub.status.idle": "2026-06-15T04:28:49.105051Z",
+     "shell.execute_reply": "2026-06-15T04:28:49.105051Z"
     },
     "papermill": {
-     "duration": 2.307461,
-     "end_time": "2026-06-06T14:30:58.684920",
+     "duration": 0.91523,
+     "end_time": "2026-06-15T04:28:49.105051+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:56.377459",
+     "start_time": "2026-06-15T04:28:48.189821+00:00",
      "status": "completed"
     },
     "tags": []
@@ -255,13 +255,7 @@
      "output_type": "stream",
      "text": [
       "Evolution du gain moyen et de l'equivalent certain\n",
-      "============================================================\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "============================================================\n",
       "       N |      Moyenne |      CE (ln) | Ratio Moy/CE\n",
       "---------+--------------+--------------+-------------\n",
       "      10 |         57.2 |         6.50 |          8.8\n",
@@ -347,10 +341,10 @@
    "id": "277c2867",
    "metadata": {
     "papermill": {
-     "duration": 0.137179,
-     "end_time": "2026-06-06T14:30:58.938109",
+     "duration": 0.00704,
+     "end_time": "2026-06-15T04:28:49.120243+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:58.800930",
+     "start_time": "2026-06-15T04:28:49.113203+00:00",
      "status": "completed"
     },
     "tags": []
@@ -368,10 +362,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.028434,
-     "end_time": "2026-06-06T14:30:59.087722",
+     "duration": 0.006727,
+     "end_time": "2026-06-15T04:28:49.134486+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:59.059288",
+     "start_time": "2026-06-15T04:28:49.127759+00:00",
      "status": "completed"
     },
     "tags": []
@@ -389,10 +383,10 @@
    "id": "cell-7",
    "metadata": {
     "papermill": {
-     "duration": 0.131474,
-     "end_time": "2026-06-06T14:30:59.286450",
+     "duration": 0.006997,
+     "end_time": "2026-06-15T04:28:49.149484+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:59.154976",
+     "start_time": "2026-06-15T04:28:49.142487+00:00",
      "status": "completed"
     },
     "tags": []
@@ -409,16 +403,16 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:30:59.458416Z",
-     "iopub.status.busy": "2026-06-06T14:30:59.452838Z",
-     "iopub.status.idle": "2026-06-06T14:31:02.202043Z",
-     "shell.execute_reply": "2026-06-06T14:31:02.193004Z"
+     "iopub.execute_input": "2026-06-15T04:28:49.165010Z",
+     "iopub.status.busy": "2026-06-15T04:28:49.165010Z",
+     "iopub.status.idle": "2026-06-15T04:28:49.581274Z",
+     "shell.execute_reply": "2026-06-15T04:28:49.581274Z"
     },
     "papermill": {
-     "duration": 2.844866,
-     "end_time": "2026-06-06T14:31:02.216493",
+     "duration": 0.424793,
+     "end_time": "2026-06-15T04:28:49.581274+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:30:59.371627",
+     "start_time": "2026-06-15T04:28:49.156481+00:00",
      "status": "completed"
     },
     "tags": []
@@ -496,10 +490,10 @@
    "id": "cell-9",
    "metadata": {
     "papermill": {
-     "duration": 0.021566,
-     "end_time": "2026-06-06T14:31:02.297164",
+     "duration": 0.008037,
+     "end_time": "2026-06-15T04:28:49.597587+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:02.275598",
+     "start_time": "2026-06-15T04:28:49.589550+00:00",
      "status": "completed"
     },
     "tags": []
@@ -523,16 +517,16 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:02.384281Z",
-     "iopub.status.busy": "2026-06-06T14:31:02.384281Z",
-     "iopub.status.idle": "2026-06-06T14:31:02.466146Z",
-     "shell.execute_reply": "2026-06-06T14:31:02.457588Z"
+     "iopub.execute_input": "2026-06-15T04:28:49.615028Z",
+     "iopub.status.busy": "2026-06-15T04:28:49.615028Z",
+     "iopub.status.idle": "2026-06-15T04:28:49.622044Z",
+     "shell.execute_reply": "2026-06-15T04:28:49.622044Z"
     },
     "papermill": {
-     "duration": 0.151737,
-     "end_time": "2026-06-06T14:31:02.474851",
+     "duration": 0.014943,
+     "end_time": "2026-06-15T04:28:49.622044+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:02.323114",
+     "start_time": "2026-06-15T04:28:49.607101+00:00",
      "status": "completed"
     },
     "tags": []
@@ -624,10 +618,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.038567,
-     "end_time": "2026-06-06T14:31:02.641422",
+     "duration": 0.007602,
+     "end_time": "2026-06-15T04:28:49.638683+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:02.602855",
+     "start_time": "2026-06-15T04:28:49.631081+00:00",
      "status": "completed"
     },
     "tags": []
@@ -643,10 +637,10 @@
    "id": "cell-12",
    "metadata": {
     "papermill": {
-     "duration": 0.016412,
-     "end_time": "2026-06-06T14:31:02.694236",
+     "duration": 0.007489,
+     "end_time": "2026-06-15T04:28:49.655790+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:02.677824",
+     "start_time": "2026-06-15T04:28:49.648301+00:00",
      "status": "completed"
     },
     "tags": []
@@ -671,16 +665,16 @@
    "id": "cell-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:02.731902Z",
-     "iopub.status.busy": "2026-06-06T14:31:02.731902Z",
-     "iopub.status.idle": "2026-06-06T14:31:04.578947Z",
-     "shell.execute_reply": "2026-06-06T14:31:04.574044Z"
+     "iopub.execute_input": "2026-06-15T04:28:49.672828Z",
+     "iopub.status.busy": "2026-06-15T04:28:49.672828Z",
+     "iopub.status.idle": "2026-06-15T04:28:49.990049Z",
+     "shell.execute_reply": "2026-06-15T04:28:49.990049Z"
     },
     "papermill": {
-     "duration": 1.887479,
-     "end_time": "2026-06-06T14:31:04.596759",
+     "duration": 0.32828,
+     "end_time": "2026-06-15T04:28:49.992069+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:02.709280",
+     "start_time": "2026-06-15T04:28:49.663789+00:00",
      "status": "completed"
     },
     "tags": []
@@ -775,10 +769,10 @@
    "id": "a7b8fa7d",
    "metadata": {
     "papermill": {
-     "duration": 0.155425,
-     "end_time": "2026-06-06T14:31:04.893618",
+     "duration": 0.008531,
+     "end_time": "2026-06-15T04:28:50.009566+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:04.738193",
+     "start_time": "2026-06-15T04:28:50.001035+00:00",
      "status": "completed"
     },
     "tags": []
@@ -809,16 +803,16 @@
    "id": "7877d00f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:05.008833Z",
-     "iopub.status.busy": "2026-06-06T14:31:05.008833Z",
-     "iopub.status.idle": "2026-06-06T14:31:05.025178Z",
-     "shell.execute_reply": "2026-06-06T14:31:05.024565Z"
+     "iopub.execute_input": "2026-06-15T04:28:50.027162Z",
+     "iopub.status.busy": "2026-06-15T04:28:50.027162Z",
+     "iopub.status.idle": "2026-06-15T04:28:50.031087Z",
+     "shell.execute_reply": "2026-06-15T04:28:50.031087Z"
     },
     "papermill": {
-     "duration": 0.031414,
-     "end_time": "2026-06-06T14:31:05.025178",
+     "duration": 0.01409,
+     "end_time": "2026-06-15T04:28:50.032096+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:04.993764",
+     "start_time": "2026-06-15T04:28:50.018006+00:00",
      "status": "completed"
     },
     "tags": []
@@ -868,10 +862,10 @@
    "id": "cell-14",
    "metadata": {
     "papermill": {
-     "duration": 0.035691,
-     "end_time": "2026-06-06T14:31:05.060869",
+     "duration": 0.009915,
+     "end_time": "2026-06-15T04:28:50.049565+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:05.025178",
+     "start_time": "2026-06-15T04:28:50.039650+00:00",
      "status": "completed"
     },
     "tags": []
@@ -894,10 +888,10 @@
    "id": "cell-15",
    "metadata": {
     "papermill": {
-     "duration": 0.12048,
-     "end_time": "2026-06-06T14:31:05.210050",
+     "duration": 0.010035,
+     "end_time": "2026-06-15T04:28:50.067619+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:05.089570",
+     "start_time": "2026-06-15T04:28:50.057584+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,16 +916,16 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:05.482524Z",
-     "iopub.status.busy": "2026-06-06T14:31:05.478558Z",
-     "iopub.status.idle": "2026-06-06T14:31:05.601894Z",
-     "shell.execute_reply": "2026-06-06T14:31:05.592855Z"
+     "iopub.execute_input": "2026-06-15T04:28:50.087508Z",
+     "iopub.status.busy": "2026-06-15T04:28:50.087508Z",
+     "iopub.status.idle": "2026-06-15T04:28:50.094819Z",
+     "shell.execute_reply": "2026-06-15T04:28:50.094819Z"
     },
     "papermill": {
-     "duration": 0.262675,
-     "end_time": "2026-06-06T14:31:05.607980",
+     "duration": 0.017177,
+     "end_time": "2026-06-15T04:28:50.094819+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:05.345305",
+     "start_time": "2026-06-15T04:28:50.077642+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1029,16 +1023,16 @@
    "id": "79be8518",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:05.844157Z",
-     "iopub.status.busy": "2026-06-06T14:31:05.844157Z",
-     "iopub.status.idle": "2026-06-06T14:31:08.929625Z",
-     "shell.execute_reply": "2026-06-06T14:31:08.928336Z"
+     "iopub.execute_input": "2026-06-15T04:28:50.112176Z",
+     "iopub.status.busy": "2026-06-15T04:28:50.112176Z",
+     "iopub.status.idle": "2026-06-15T04:28:50.432556Z",
+     "shell.execute_reply": "2026-06-15T04:28:50.432556Z"
     },
     "papermill": {
-     "duration": 3.189608,
-     "end_time": "2026-06-06T14:31:08.932529",
+     "duration": 0.328407,
+     "end_time": "2026-06-15T04:28:50.432556+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:05.742921",
+     "start_time": "2026-06-15T04:28:50.104149+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1130,10 +1124,10 @@
    "id": "54e25556",
    "metadata": {
     "papermill": {
-     "duration": 0.024771,
-     "end_time": "2026-06-06T14:31:08.981499",
+     "duration": 0.010059,
+     "end_time": "2026-06-15T04:28:50.450643+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:08.956728",
+     "start_time": "2026-06-15T04:28:50.440584+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1151,10 +1145,10 @@
    "id": "cell-17",
    "metadata": {
     "papermill": {
-     "duration": 0.013348,
-     "end_time": "2026-06-06T14:31:09.011860",
+     "duration": 0.012943,
+     "end_time": "2026-06-15T04:28:50.469603+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:08.998512",
+     "start_time": "2026-06-15T04:28:50.456660+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1175,10 +1169,10 @@
    "id": "cell-18",
    "metadata": {
     "papermill": {
-     "duration": 0.019223,
-     "end_time": "2026-06-06T14:31:09.059849",
+     "duration": 0.008971,
+     "end_time": "2026-06-15T04:28:50.488276+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:09.040626",
+     "start_time": "2026-06-15T04:28:50.479305+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1199,16 +1193,16 @@
    "id": "cell-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:09.095382Z",
-     "iopub.status.busy": "2026-06-06T14:31:09.095382Z",
-     "iopub.status.idle": "2026-06-06T14:31:09.512312Z",
-     "shell.execute_reply": "2026-06-06T14:31:09.511508Z"
+     "iopub.execute_input": "2026-06-15T04:28:50.510058Z",
+     "iopub.status.busy": "2026-06-15T04:28:50.510058Z",
+     "iopub.status.idle": "2026-06-15T04:28:50.674012Z",
+     "shell.execute_reply": "2026-06-15T04:28:50.674012Z"
     },
     "papermill": {
-     "duration": 0.432568,
-     "end_time": "2026-06-06T14:31:09.512312",
+     "duration": 0.175718,
+     "end_time": "2026-06-15T04:28:50.674012+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:09.079744",
+     "start_time": "2026-06-15T04:28:50.498294+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1310,10 +1304,10 @@
    "id": "8be1aeac",
    "metadata": {
     "papermill": {
-     "duration": 0.022624,
-     "end_time": "2026-06-06T14:31:09.552412",
+     "duration": 0.011487,
+     "end_time": "2026-06-15T04:28:50.694922+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:09.529788",
+     "start_time": "2026-06-15T04:28:50.683435+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1344,16 +1338,16 @@
    "id": "d35f27b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:09.596013Z",
-     "iopub.status.busy": "2026-06-06T14:31:09.596013Z",
-     "iopub.status.idle": "2026-06-06T14:31:09.612830Z",
-     "shell.execute_reply": "2026-06-06T14:31:09.611583Z"
+     "iopub.execute_input": "2026-06-15T04:28:50.730886Z",
+     "iopub.status.busy": "2026-06-15T04:28:50.730886Z",
+     "iopub.status.idle": "2026-06-15T04:28:50.735679Z",
+     "shell.execute_reply": "2026-06-15T04:28:50.735178Z"
     },
     "papermill": {
-     "duration": 0.035797,
-     "end_time": "2026-06-06T14:31:09.613947",
+     "duration": 0.030801,
+     "end_time": "2026-06-15T04:28:50.736187+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:09.578150",
+     "start_time": "2026-06-15T04:28:50.705386+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1399,10 +1393,10 @@
    "id": "cell-20",
    "metadata": {
     "papermill": {
-     "duration": 0.025858,
-     "end_time": "2026-06-06T14:31:09.656736",
+     "duration": 0.01053,
+     "end_time": "2026-06-15T04:28:50.756791+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:09.630878",
+     "start_time": "2026-06-15T04:28:50.746261+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1422,10 +1416,10 @@
    "id": "cell-21",
    "metadata": {
     "papermill": {
-     "duration": 0.011117,
-     "end_time": "2026-06-06T14:31:09.697226",
+     "duration": 0.01061,
+     "end_time": "2026-06-15T04:28:50.777402+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:09.686109",
+     "start_time": "2026-06-15T04:28:50.766792+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1442,16 +1436,16 @@
    "id": "cell-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:09.753875Z",
-     "iopub.status.busy": "2026-06-06T14:31:09.753875Z",
-     "iopub.status.idle": "2026-06-06T14:31:09.797520Z",
-     "shell.execute_reply": "2026-06-06T14:31:09.795848Z"
+     "iopub.execute_input": "2026-06-15T04:28:50.798967Z",
+     "iopub.status.busy": "2026-06-15T04:28:50.798967Z",
+     "iopub.status.idle": "2026-06-15T04:28:50.813648Z",
+     "shell.execute_reply": "2026-06-15T04:28:50.813648Z"
     },
     "papermill": {
-     "duration": 0.067559,
-     "end_time": "2026-06-06T14:31:09.797520",
+     "duration": 0.02646,
+     "end_time": "2026-06-15T04:28:50.814655+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:09.729961",
+     "start_time": "2026-06-15T04:28:50.788195+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1468,8 +1462,8 @@
       "   0.5 |     202.9797 |     207.2375 |     204.9243 |         Actions\n",
       "   1.0 |       9.2398 |       9.2763 |       8.3266 |         Actions\n",
       "   2.0 |      -0.0001 |      -0.0001 | -277600000.0002 |         Actions\n",
-      "   5.0 |      -0.0000 |      -0.0000 | -69399999999999995830927718934443458560.0000 |     Obligations\n",
-      "  10.0 |      -0.0000 |      -0.0000 | -3084444444444443422101909430118853692283137005944821625958949576739495809486461660561408.0000 |     Obligations\n",
+      "   5.0 |      -0.0000 |      -0.0000 | -69400000000000005275660684673733885952.0000 |     Obligations\n",
+      "  10.0 |      -0.0000 |      -0.0000 | -3084444444444442538678377040926688900634386634485563712217001138930016748683361014251520.0000 |     Obligations\n",
       "\n",
       "Statistiques des rendements simules (50000 tirages) :\n",
       "  Obligations  : E=+3.0%, sigma=2.0%, P(perte)=6.7%\n",
@@ -1530,16 +1524,16 @@
    "id": "852f3a8c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:09.843095Z",
-     "iopub.status.busy": "2026-06-06T14:31:09.831547Z",
-     "iopub.status.idle": "2026-06-06T14:31:16.762178Z",
-     "shell.execute_reply": "2026-06-06T14:31:16.762178Z"
+     "iopub.execute_input": "2026-06-15T04:28:50.834468Z",
+     "iopub.status.busy": "2026-06-15T04:28:50.834468Z",
+     "iopub.status.idle": "2026-06-15T04:28:52.054927Z",
+     "shell.execute_reply": "2026-06-15T04:28:52.053825Z"
     },
     "papermill": {
-     "duration": 6.958482,
-     "end_time": "2026-06-06T14:31:16.778024",
+     "duration": 1.230753,
+     "end_time": "2026-06-15T04:28:52.055443+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:09.819542",
+     "start_time": "2026-06-15T04:28:50.824690+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1610,10 +1604,10 @@
    "id": "b60863ff",
    "metadata": {
     "papermill": {
-     "duration": 0.09602,
-     "end_time": "2026-06-06T14:31:17.016688",
+     "duration": 0.012507,
+     "end_time": "2026-06-15T04:28:52.080729+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:16.920668",
+     "start_time": "2026-06-15T04:28:52.068222+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1631,10 +1625,10 @@
    "id": "cell-23",
    "metadata": {
     "papermill": {
-     "duration": 0.199717,
-     "end_time": "2026-06-06T14:31:17.349999",
+     "duration": 0.012939,
+     "end_time": "2026-06-15T04:28:52.106081+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:17.150282",
+     "start_time": "2026-06-15T04:28:52.093142+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1656,10 +1650,10 @@
    "id": "cell-24",
    "metadata": {
     "papermill": {
-     "duration": 0.145241,
-     "end_time": "2026-06-06T14:31:17.561280",
+     "duration": 0.012508,
+     "end_time": "2026-06-15T04:28:52.132113+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:17.416039",
+     "start_time": "2026-06-15T04:28:52.119605+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1678,16 +1672,16 @@
    "id": "cell-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:17.602675Z",
-     "iopub.status.busy": "2026-06-06T14:31:17.602675Z",
-     "iopub.status.idle": "2026-06-06T14:31:17.696421Z",
-     "shell.execute_reply": "2026-06-06T14:31:17.695284Z"
+     "iopub.execute_input": "2026-06-15T04:28:52.153712Z",
+     "iopub.status.busy": "2026-06-15T04:28:52.153712Z",
+     "iopub.status.idle": "2026-06-15T04:28:52.164025Z",
+     "shell.execute_reply": "2026-06-15T04:28:52.164025Z"
     },
     "papermill": {
-     "duration": 0.116915,
-     "end_time": "2026-06-06T14:31:17.698020",
+     "duration": 0.020169,
+     "end_time": "2026-06-15T04:28:52.164025+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:17.581105",
+     "start_time": "2026-06-15T04:28:52.143856+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1780,10 +1774,10 @@
    "id": "cell-26",
    "metadata": {
     "papermill": {
-     "duration": 0.025546,
-     "end_time": "2026-06-06T14:31:17.765100",
+     "duration": 0.012731,
+     "end_time": "2026-06-15T04:28:52.188335+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:17.739554",
+     "start_time": "2026-06-15T04:28:52.175604+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1806,16 +1800,16 @@
    "id": "cell-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:31:17.952782Z",
-     "iopub.status.busy": "2026-06-06T14:31:17.952782Z",
-     "iopub.status.idle": "2026-06-06T14:32:00.788254Z",
-     "shell.execute_reply": "2026-06-06T14:32:00.787356Z"
+     "iopub.execute_input": "2026-06-15T04:28:52.217120Z",
+     "iopub.status.busy": "2026-06-15T04:28:52.217120Z",
+     "iopub.status.idle": "2026-06-15T04:29:16.240650Z",
+     "shell.execute_reply": "2026-06-15T04:29:16.240650Z"
     },
     "papermill": {
-     "duration": 42.948061,
-     "end_time": "2026-06-06T14:32:00.791274",
+     "duration": 24.042115,
+     "end_time": "2026-06-15T04:29:16.241656+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:31:17.843213",
+     "start_time": "2026-06-15T04:28:52.199541+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1855,7 +1849,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 31 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 21 seconds.\n"
      ]
     },
     {
@@ -1987,16 +1981,16 @@
    "id": "e6514730",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:32:00.890615Z",
-     "iopub.status.busy": "2026-06-06T14:32:00.889924Z",
-     "iopub.status.idle": "2026-06-06T14:32:04.173224Z",
-     "shell.execute_reply": "2026-06-06T14:32:04.173224Z"
+     "iopub.execute_input": "2026-06-15T04:29:16.269697Z",
+     "iopub.status.busy": "2026-06-15T04:29:16.266880Z",
+     "iopub.status.idle": "2026-06-15T04:29:17.062847Z",
+     "shell.execute_reply": "2026-06-15T04:29:17.061332Z"
     },
     "papermill": {
-     "duration": 3.344111,
-     "end_time": "2026-06-06T14:32:04.173224",
+     "duration": 0.807621,
+     "end_time": "2026-06-15T04:29:17.062847+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:00.829113",
+     "start_time": "2026-06-15T04:29:16.255226+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2080,10 +2074,10 @@
    "id": "68d79778",
    "metadata": {
     "papermill": {
-     "duration": 0.031969,
-     "end_time": "2026-06-06T14:32:04.222098",
+     "duration": 0.015728,
+     "end_time": "2026-06-15T04:29:17.089644+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:04.190129",
+     "start_time": "2026-06-15T04:29:17.073916+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2107,10 +2101,10 @@
    "id": "cell-28",
    "metadata": {
     "papermill": {
-     "duration": 0.063231,
-     "end_time": "2026-06-06T14:32:04.317195",
+     "duration": 0.016069,
+     "end_time": "2026-06-15T04:29:17.131428+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:04.253964",
+     "start_time": "2026-06-15T04:29:17.115359+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2135,10 +2129,10 @@
    "id": "p15b-md-00",
    "metadata": {
     "papermill": {
-     "duration": 0.096218,
-     "end_time": "2026-06-06T14:32:04.538330",
+     "duration": 0.015678,
+     "end_time": "2026-06-15T04:29:17.163234+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:04.442112",
+     "start_time": "2026-06-15T04:29:17.147556+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2157,10 +2151,10 @@
    "id": "p15b-md-01",
    "metadata": {
     "papermill": {
-     "duration": 0.092303,
-     "end_time": "2026-06-06T14:32:04.651533",
+     "duration": 0.015127,
+     "end_time": "2026-06-15T04:29:17.194356+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:04.559230",
+     "start_time": "2026-06-15T04:29:17.179229+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2177,21 +2171,31 @@
    "id": "p15b-code-01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:32:04.845881Z",
-     "iopub.status.busy": "2026-06-06T14:32:04.835858Z",
-     "iopub.status.idle": "2026-06-06T14:32:05.811751Z",
-     "shell.execute_reply": "2026-06-06T14:32:05.809441Z"
+     "iopub.execute_input": "2026-06-15T04:29:17.227802Z",
+     "iopub.status.busy": "2026-06-15T04:29:17.227802Z",
+     "iopub.status.idle": "2026-06-15T04:29:17.488709Z",
+     "shell.execute_reply": "2026-06-15T04:29:17.488709Z"
     },
     "papermill": {
-     "duration": 1.120631,
-     "end_time": "2026-06-06T14:32:05.813730",
+     "duration": 0.278099,
+     "end_time": "2026-06-15T04:29:17.490013+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:04.693099",
+     "start_time": "2026-06-15T04:29:17.211914+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<>:32: SyntaxWarning: invalid escape sequence '\\ '\n",
+      "<>:32: SyntaxWarning: invalid escape sequence '\\ '\n",
+      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_26796\\1665164268.py:32: SyntaxWarning: invalid escape sequence '\\ '\n",
+      "  _col = \"w0 \\ rho\"\n"
+     ]
+    },
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1UAAAJOCAYAAABfmS0qAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzsnQd4HNX19t9d9V4tq1jVkmUVy5blXsHdYBsDNr33ngAJCf8vCSQkEAIhlCS00MGA6WBwN8a9qViS1Xvvva9293vONSskWbJXmpFmpT0/nkHW7uzdM3dmV/fMOec9Kr1erwfDMAzDMAzDMAwzLNTDexnDMAzDMAzDMAzDThXDMAzDMAzDMIxEOFLFMAzDMAzDMAwjAXaqGIZhGIZhGIZhJMBOFcMwDMMwDMMwjATYqWIYhmEYhmEYhpEAO1UMwzAMwzAMwzASYKeKYRiGYRiGYRhGAuxUMQzDMAzDMAzDSICdKoZhzmHHjh2YMWMGbG1toVKp0NDQMCZmiWx98sknZRsvKCgIt9xyC0wJOj46TlNn//79wk76OZ7eazT4xz/+galTp0Kn08HUmDdvHh577DGlzWAYhjE52KlimDFASkoKNm3ahMDAQOHo+Pn5YeXKlXjllVdkf6/a2lpcddVVsLOzw3/+8x988MEHcHBwkP19GIY5l6amJjz77LP43e9+B7X6lz/R5DQOtt1zzz09+1100UWIjo4ecGpramrOufHw7rvv9hnL0tJSfL/QzYTS0tJzxiC76HuhoqKCTx/DMEwvLHv/wjCM6XHkyBFcfPHFCAgIwJ133glvb28UFxfj2LFjeOmll/Dggw/K+n4nT55Ec3MznnrqKaxYsULWsRnp/OEPf8Dvf/97nspeLFmyBO3t7bC2th7z8/L222+ju7sb11577TnP0Y2Um2666ZzHp0yZIvl9//KXvyA4OBgdHR3iu4WcrUOHDiE1NVXcyDFw2WWXwdnZGf/973/FaxiGYZizsFPFMCbO3/72N7i4uAhnx9XVtc9zVVVVsr1Pa2uriEgZxuz/XoyyGM4PRRJoYyAcAHKkKKLTe+E/lnnnnXewYcOGAY+HnKcbbrhhRN537dq1mDVrlvj3HXfcAU9PTxEx+/bbb0Xk2gDNNUXN33//ffz5z38eE6moDMMwowGn/zGMiZObm4uoqKgBnRwvL6+efxcUFIgFDt1h7k//lB9DXU5aWhquu+46uLm5YdGiRSJ16Oabbxb7zJ49W+xjqCk6ePAgNm/eLCJmNjY28Pf3x8MPPywiBP3JyMgQC7EJEyaINMLw8HD8v//3//rsQ6lFt912GyZOnCjGo2Oku/TG0NnZKd6bxndychKL0JKSkgH3lfI+/amrq8NvfvMbTJs2DY6OjuKOPS1GT58+bdTraT4feOABfPTRR2JOaOEcFxeHAwcO9NlvsPPT+7mBxv3ss88QGRkp5nz+/PkibZR4/fXXERoaKt6PzjFdK/05fvw41qxZIxx4e3t7LF26FIcPHzbquGjuN27cKJw+uibp3NA5Gojhvo+hbuqTTz4R0TpKUaPXU7rcQDVV2dnZuPLKK0Vkl4570qRJuOaaa9DY2HjB66j/54U+A1RfZ2x924cffijOK50Hd3d38b4UXb4Q+fn5SE5ONokI8eLFi3u+fwaKmBUWFiIpKUkByxiGYUwTvt3JMCYO1VEdPXpUpOEMVisxXMhJCgsLw9NPPw29Xi/+TYv9N954oycdaPLkyWJfWrC3tbXh3nvvhYeHB06cOCFqumgRSs8ZoEUhLcisrKxw1113icUoLcy+++47EXUjKisrRcG7wRmgRe327dtx++23i0Xyr3/96/PaTXfSaeFKDseCBQuwb98+XHrppefsJ/V9+pOXl4evv/5azBvNDY1PDgs5BuQA+fr6XnCMn376CZ9++ikeeugh4eRRGhU5GTSf/c9v//NzPsjppajC/fffL35/5plnsG7dOiEqQO9x3333ob6+XoggkJNJc2aA/k3OITkCTzzxhIhGUMRk2bJlYtw5c+YM+r7kVC9fvhxFRUXimGgOqA6v9/hyvI8BSkul6BQ5t+QUDZTy19XVhdWrV4vnKT2WHCtyrrdt2yZEV8ihG8p1NBToGv/jH/8obirQ+NXV1eJzQimKiYmJ540AU6ovMXPmzEEjc1QX1R9y7uVOfTQ43uTQ94fOH0HOcGxsrKzvyzAMM2bRMwxj0uzatUtvYWEhtvnz5+sfe+wx/c6dO/VdXV199svPz6dVt/6dd945Zwx6/Iknnuj5nf5Nj1177bXn7Euvp+dOnjzZ5/G2trZz9n3mmWf0KpVKX1hY2PPYkiVL9E5OTn0eI3Q6Xc+/b7/9dr2Pj4++pqamzz7XXHON3sXFZcD3MpCUlCTsu++++/o8ft11151znFLehwgMDNTffPPNPb93dHTotVrtOfNuY2Oj/8tf/qK/EGQfbadOnep5jObJ1tZWf/nllxt1fgzP9R+XbCBbDLz++uvicW9vb31TU1PP448//rh43LAvnZewsDD96tWr+5wjmpvg4GD9ypUrz3tML774ohhv69atPY+1trbqQ0NDxeM//vijLO9D49B4ISEh55w3w3OG90pMTBS/f/bZZ7JcR3QN0LVwoXNRUFAgPqd/+9vf+uyXkpKit7S0POfx/vzhD38Q4zU3Nw967Qy0ffzxxz37LV26VB8VFTXg+NXV1eccm+HzvmfPHvF8cXGx/vPPP9dPmDBBXFP0+0BYW1vr77333vMeD8MwjDnB6X8MY+JQqg1Fqig1idLMKNJAd+Ep/YkiE1LorRp2ISiVqXd9D90xp7v7tN6jO/AE3ZWnVDaKhFCaYG8MaVK0/xdffIH169eLf9M4ho2Oi9KzEhISBrXjhx9+ED8pKtKb/lEnqe8zEBRZMiiyabVaoZRIaYAU3TN2LErLM9zpJ2ieqPh/586dYszhnh+KFvVOUZs7d674SSlwlNrW/3GKuhGUwkWpchStoeMxzBGdYxqTzuf5pL3pfPj4+Ig6GwOUlkdRyt5IfR8DlJ7a+1ocCEMkiuaUoquD2W3MdTQUvvzyS3EMFKXqfb1RpIwijj/++ON5X0/zQvVydE0NBF0nu3fvPmcjIRupUMohRXIprZfOJaVy0vcLpU0OBEWwBoqaMQzDmCuc/scwYwCqb6IFG6U1kWP11Vdf4V//+pdY/NBilepohgOlsBkLpXf96U9/EgstSiPrjaFOxbBQP1+aIjlelIJFKYa0DcT5BDioloMcG0NaogFybOR8n4GgBTMpLlI6HdW/9HaCKCXSGGhxPZAAAS3+yWZagA/n/PR3Yg2OBS2SB3rccA7J0SEMtXQDQed3oDQww/mgeq3+tUX9z4fU9xnKnNA+jzzyCF544QVRv0bpqHRTgkQeDMdv7HU0FOgYDWm0A0EpsVIgB0eOequB6sBIJp2uQzoHVHNITi7dRBgMOk4WqWAYhvkFdqoYZgxBdRPkYNFGC6Bbb71V1DNRfcpgC5z+0Y/eXOiOf+8xKGJGQg3Up4Yak9KdbKpToSL+oTQpNexLC9zBFtgxMTFGjzea70O1TVQvQ5E4qu0hEQJamFN0YyQatRp7fggLC4shPW6o0TLY/dxzz4mGzwMxWORkKMj1PsbOyT//+U9xbX7zzTfYtWuXiEhRnRnJhQ8WfRkMYz9bdIy0L9XtDTTvFzo+csxJTp1aGvSOLg4FEuUYSDyGMETtBlIWpHo2g/ofiY6QMApFFTMzMwe0m25YkEIgwzAMcxZ2qhhmjGJYAJWXl4ufhjv8tNjpDd2RlwqpyGVlZeG9997r0yeHUo96ExISIn6SqMZgGJTWaEE6nLvuJNxBi1cSv+gdVaDFn5zvMxCff/65SLV66623hr3ANERsekNzSylzZPNoY4jUkNjBcM8Hne/+kYv+50Pq+wwHUmmkjdQCSQRi4cKFeO211/DXv/7V6OvI8Nnq/7ka6LNFx0jzQJGy4fSOopsVBEVBh3tjgY6LBDfIservgBqOjfY5H+QQkgNK1/q///3vc/qi0c0UippHREQMy0aGYZjxCNdUMYyJQ3UYAym/GWpCDAtCWqzSwr6/PDelqknFcNe9tx30b0qF6w05BaRyRulDlC7YG8NraSyq86F6p4GcL0qBOx+kHke8/PLLfR5/8cUXz7FZyvsMBI3Z/1xQpJAWmcZC9XG9669IapuiKatWrRo0qjSSUH0XOQPPP/88WlpahjxPl1xyCcrKyoTD2Tsi0j/lUur7DAVSdqSIT2/IuaKookHq3djriCC7KS2OlC0N0M0MSsPtzRVXXCHOIfVv6n+d0O9UM3Whejvi1KlTGC50PjQajVCl7A05kK+++qqIdlMN24Ug6X2KXtF8kOpgb+Lj48VPqqlkGIZhzsKRKoYxcUgSmhapl19+ubiTTXeI6a47yXKTMAGlABogCee///3v4idFssjBoiiIVOh9aWFJMtbkQJADR85K/9oqwyKVUodIFprECuiuPckzf//99z19bchGchZJNOHOO+8UNWGUWkjOxp49e8S/B4NSx6699lrhLNJClxZ2e/fuRU5Ozjn7SnmfgSCJcpKapzmn96UIHtXsGCJ0xkD1ZiSU0VtSnaCFuBKQo/G///1POBnUw4uOjURQ6DzT3NG5Jjn8waB5pWgGRTBpsU2iFSSpTpE3Od9nKFCkhiT0SZKeIkbkYJFNBkd7qNcR9ZmitFf6DNJ5o88jOSg0dm8HmT4jFAV7/PHHxTVPaXQULaXIEzlg9Hmgz9Bg0HVE1wddm5Ri2h/6LJMEfH+oBxul5xIkzEIOOvXfIpl+Oi6yl2ohSQKd7DM2Ivrb3/5WzCH1vustmkIRaqrhYzl1hmGYXigtP8gwzPnZvn27/rbbbtNPnTpV7+joKKSMSa76wQcf1FdWVvbZl6SmSUac5MJJ1vyqq67SV1VVDSqpThLKxkqqp6Wl6VesWCFs8PT01N95553606dPDyjjnpqaKiTCXV1dhVx4eHi4/o9//GOffcj2+++/X+/v76+3srIS0t/Lly/Xv/HGGxe8JNrb2/UPPfSQ3sPDQ+/g4KBfv369kH7uf5xS32cgSfVHH31UyLTb2dnpFy5cqD969KiQsabtQpB9ZMuHH34o5MVJsjo2NrZHCtyY8zOYpDqNO5DE/nPPPTeg/Hh/uXGSIb/iiivEnJJddOx0/ezdu/eCx0Wy8Bs2bNDb29uLa+NXv/qVfseOHX1kzqW+z2B2937O8F55eXniMzN58mRx/bm7u+svvvhiIRs+3OuIWhtER0eLzx9dz3QOBzoXxBdffKFftGiRGJM2+uzS+cnMzLzgXL7wwgviM9ZfNv58kur9rz26Tp988knxvjTHZMO8efOEzcZ+3glqH0BzSFt3d3fPY3T9k/w7wzAM8wsq+l9vJ4thGIYZGajmiJrzUmSHMe3zROIvTz755Ki/N0XNKGJFrROoSbWpQc2vScCCatEoKskwDMOchWuqGIZhGMZEIMn3xx57TKgkjoSipFSeffZZkVrJDhXDMExfuKaKYRiGYUwIqt+izRQhoRWGYRjmXDhSxTAMwzAMwzAMIwGuqWIYhmEYhmEYhpEAR6oYhmEYhmEYhmEkwE4VwzAMwzAMwzCMBNipYphhQM0wSXaZGnyaGmSXElLQIwHNLx0PzTejHHQ90XlgGIZhGGZg2KlimFFmy5YtePHFF3nezYgzZ85g8+bNov+Qvb09PD09sWTJEnz33XcD7p+eno41a9bA0dER7u7uuPHGG1FdXd1nn4aGBlx//fVwc3MT47711lvnjHPq1Cnxfvn5+RgvGDM3o8Ett9wiHM3+29SpU8/Zl6TRqe9UcHAwbG1tERMTg48//njAHlD0epJVX79+PcrKys7ZZ8OGDbjrrruGbO8rr7wixtVoNEN+7auvviqu34CAAHGMdOyDQdcl2TdhwgQ4ODjg4osvRkJCQp99qD3mn//8Z/j5+cHLywu//vWv0dXV1WeflpYW8Tx9XzIMw4wFWFKdYUYZWiSkpqaKhcRI0N7eDkvL8fHRDgwMFMdjZWWFsUxhYSGam5tx8803w9fXF21tbfjiiy/EAvn111/vs0guKSkRDhctgJ9++mmxuHz++eeRkpKCEydOwNraWuz3m9/8Bvv37xeL05ycHNx5552IiIjAggULehauDz30kLjOaDE/HjB2bkYLGxsb/O9//+vzGNnWn//3//4f/v73v4tzNHv2bHzzzTeigS45KNdcc43YJy8vD1dffbXY5s+fL2683Hrrrdi5c2fPOPTvAwcOIDs7e8i2fv/991i1atWwPkvUm4qu3zlz5qC8vHzQ/ch5vPTSS3H69Gn89re/FTcP/vvf/+Kiiy5CfHw8wsLCxH4fffSROH8kG0+O19/+9jdMnDgRjz/+eM9Y9FhQUJCYJ4ZhmDGBnmGYIfPOO+/o6eOTn58/5Ndeeuml+sDAQFlnXavV6tvb22UdkxlZuru79dOnT9eHh4f3efzee+/V29nZ6QsLC3se2717t7jeXn/99Z7HJk6cqH/vvfd6fl+6dKn+97//fc/vH3zwgd7X11ff3Nws2dYnnnhCvL/SGDs3UqHx6DN+Pm6++Wa9g4PDBccqKSnRW1lZ6e+///6ex3Q6nX7x4sX6SZMmieuAePXVV/UhISHiOeLHH3/Uq1Sqns+1RqPRR0RE6P/5z38O+XhaW1v1tra2FzymwSgoKOixi46Zjn0gPv30UzF3n332Wc9jVVVVeldXV/21117b89jVV1+tv/XWW/tcX/Pmzev5PScnR5znkydPDstehmEYJeD0P4aREborGxUVJe5gU0Ti/vvvF+kwBuiOLd0xpsiFIV2I7sYa6OzsxBNPPIHQ0FAxhr+/Px577DHxeG/odQ888IC442t4vx07dgxaU1VaWorbbrtN3A2mfek1b7/9tlHHVFNTg4yMDBFdMYYPP/wQcXFxsLOzE+lZdCe+uLi4zz40D9HR0UhLSxPpQZSiRqk+lCJlTE0V2bNp0yYxPqVTzZo1C99++61RdUCmUg9nYWEhzm/v64OgCNa6detEqpWBFStWYMqUKdi6dWvPYxTBo9Q/AzQXhnPU2tqK3//+93jmmWdEmtxQOHTokIim0LxOnjxZRNKknOv+JCcni/nvfb4oikGPzZw5s8++a9euxdy5c4c8N6OJVqtFU1PToM9TVIpS7u67776ex+hY7733XhF5MzTTpfPp6urac83SfJJ/R48T//73v8V7Pfjgg0O2ce/eveI7hOZzuBFjY2rqPv/8c/Edc8UVV/Q8RmmAV111lZgHw/fY+a5d4tFHHxXXEn2uGYZhxgrsVDGMTNAinpwocqb++c9/4sorrxQLUkq5MdQxUBrQjBkzRFrMBx98IDZDfRWlzlA6GKUzUT0F1UBs3LgR//rXv0RKUH/27duHhx9+WDz30ksv9XHOelNZWYl58+Zhz549whGjfclpu/32242q7aLFHKWVUXrVhaCUnZtuukmk+bzwwgsi9YwWdJSy1d95qK+vF7Ux06dPF/NFtSSUDrR9+/YL1ifR8VBtDTkO9FpKIaK5+uqrryAXtAAkh9KYzVjI2aH9c3NzxXmlY12+fHkf57eqqmrAxSSlXiUmJvb8To4PzTGlglFaGDnVtA9BqVXkpFK90VCgNDq6XskGup4p/Yyc/IHmdSjnujfkTJPzQGlsBg4ePAi1Wi3SxgwOCn0ejhw5IsYb6tyMFuQIODs7i5Q/cgzo808pib0hu+j6pM9QbwznymA3nU/6N9VaUQ0czS99Tsn5oJoxSvOkeR5O+t4PP/wgnF9yeEYSsp8cYzqX/Y+V5iorK6vnWOk4jx07Jq45+p40zMfu3bvFdxtdwwzDMGMKReJjDDPO0v8oxcXa2lq/atUqkYpn4N///rfY7+23375g+h+la6nVav3Bgwf7PP7aa6+JMQ4fPtzzGP1O+545c+acceg5SqcxcPvtt+t9fHz0NTU1ffa75ppr9C4uLvq2tjajUr8oHelCKUIWFhb6v/3tb30eT0lJ0VtaWvZ5nFLVaMz333+/57HOzk69t7e3/sorr+x5jOa3fyrW8uXL9dOmTdN3dHT0PEapSQsWLNCHhYWdY/dwUzcN+xmzGcvdd9/d8xo6f5s2bdLX1dX1PE/pTv3nxcBvf/tb8ZzhuJOTk0X6mGE8mje69vLy8kTq1NGjR/VDZePGjSJNrHd6XVpamjivvY9zKOd6IOgzMGfOnJ7fr7jiCrHRmNu3bxePJSQkiPf85ptvhjw3o5H+R6mWv/vd70TK28cffyxS4uh1CxcuFKl6vY+V0voGSsmj/XunbD700EM959Pd3V2/b98+8fidd96pX7NmzbCPJyAgoM93ghTOl/5Hz912223nPP7999+LY9qxY4f4vampSb9o0aKeY42KihJpkjRvkZGR+r///e+y2MowDDOacKSKYWSAokCkXkV363vfpaXCdLqTTSl/F+Kzzz4Td7MpYtM7CrJs2TLx/I8//thn/6VLlyIyMvK8Y9L6kFKmKPJF/+497urVq9HY2HiOMld/KGJBr6WUvfPx5ZdfiugCpfr0fh9vb28RzehvP6Wl3XDDDT2/k8gA3a2mgv3BqKurE3ex6T2ocN7wHrW1teJ4KGpDEQ05oPHorrkxm7HQ9UH7v/feeyIVi9K5equeGVK9KEWzP5SO13ufadOmieM9efKk+EmpV3TtUeoURUkpmkfnhCKBJFTxl7/8RZzHwSBbKOJFEb/e6XV0TdJcSDnX/Vm8eLG47ihyZ0g5vOSSS0QUl6JWBP2klLNFixYNeW6GAkVQBoo8UsSp92MUWe0NpVaS+ATNAaWqUVopRZcOHz4szoUBsslYmymKTKnBx48fFz8pNTYpKQnvv/++iGzS55U+MxSFpM8jRWsvBIniFBUVCQGJkcbYY3VycsJPP/0kos50fLTRMVH6NEWIKQJvSA2mx+mYz5diyTAMYwqMD4kwhlEYWgAR4eHhfR4nR4Hkrg3Pnw9aGNMiiWoQBoJSn3pjjKIbpQ1RKtYbb7whNmPGHS5kPy3aDQpf/emftjRp0qRz6jQo1YlqbgaDVO7oPf74xz+KbbDjoYWYVHx8fMQmJ+QwGyS3KXWOUu3I4aVFNM0F1SYR/WvoiI6ODvHTsA9hqCczQA7nrl27kJmZKTZa7FNqFaWGXnvttaKGi1L6BrtWaNE70Pmj65pSyIZ7rgdyqrq7u0U9EdlE54weo0V2b6eKbhpQWl3v4zZ2boyF6vgota4/VLvUu36J6oouVIdHzgBdl3STxaDqRzYNxWZyaHs7taTgeM8994jrhpwLqlmj+iRyzOnaofrC86l90g0dSvu7UH0SnX9yrHvf9BhqPd5QjpVuAPS+KUSOK93AoVpP+ixQ7Rxtzz33HB555BFxLuiYGYZhTBV2qhjGRKA7/xR9oLqJgaDFZ2+MWUDSmAQtxkjOeyCoZ44c0HvRYojqhEiEoT/9F2gD7UOcL5piOB6SE+8fPTFAdSjEYIX1vReO54McDIoMGANFaIYDiW3cfffdotaEHBeDEzeQbDU9Rg7GQJEAw3H96le/EnVm5FQ+9dRTQl7d4ETR+5CwyWBO1Uie6/7QAp8cQqqrIgeCehWR2AQ5VoZoBTlVl19+ec9rpMzN+SDn1hANM7By5UohCU5O71A+b7SPh4eHiKj2tpsid3Rd974mDcdBNZiD8emnn4obLSTqQeeXxDjIaab5I7GZN998U9Ql9be/N+QMU+3ihYQmqM6p980fqqUbahNxOtbBzs+FjpWcUarHokgpnXt6DTm8dJ2Q00vH8M4775xTr8UwDGMqsFPFMDJAd7EJig5QZMoApXZR0TkplBkYbHFDSmtUqE/CBcYobRkDRb0o1YYWZL1tGAnIflo4UgSNFsgjgWFuKRJyoeMxqItRpI6EEQwYEzU0LGiNdUDO5wieD0M6lMF5I2eIzhk17e0PCYVQetz5GrRSSiQ5nAQ1ju29iKV/ny81kt6XnIKBeiDRdS3nuTaketLimZwqcqYI+kkOFTl/JLBiEKmQOjcXuqZ6f2YNUBRlqJ8ZQ0pq72gz2UW9rMg56h2Zoeik4fnB0hLJsSPnmK5fmg8SvDGcUzpXdI2f75zStU9iHyRQcyFoznunIg40JxfCkL5JTndv54eOlRQ+B7tW6HuPIlSkAmm4dunYDGmDdMz0XUrRtJEW22AYhhkufMuHYWSAFl+0UHz55Zf7LLDfeustsWDuXc9ASmADRUCoNoMWSHT3uT+02DHUnwwFiiJQfQ3VVVFtRX9okSKXpDrJKNP70V3l/k4G/U51T1KhiAbVklBK20B3xHsfDy38id4qczSHxqYQyVlTNVCKJS2QqVaGFse9F9t0vrZt29ZHmpxU9SiatXnz5gHHp8gIRRYoVcqwEKXFJ503A7SoP19Ejc4dHfPXX38tanB6v653A1q5zjU5ULTYpiiOwakiVUyq4aJms4Z9ejOcuRkJKJ2NHKj+kANEx09RFQOXXXaZuAlAETgDtM9rr70mHEVDs+b+0ByQY0F1mQRFwCjNz3BO6XNJ1/v5zilFtYjeEbfBWLhwofgeM2zDcaoo8krOH9XcGSA7qV6UUhUHiyRShPWOO+4QypCGa5eOzRDxo2uQjp2uD4ZhGJNlVGUxGGacMJCCnEFtjhQASfXvwQcfFGpms2fP1nd1dfXs949//EPs9/DDD+u3bNmi//bbb8XjpNx2ySWXiIafpMz3yiuv6F988UX9PffcI5TAejfCpNf3biZ6PvW/iooKoTZob2+v/9WvfiWapD7zzDP6zZs3693c3C54rMaq/xE0Lu1LSnx0nNTQ9LHHHhOqfM8991wf9T9S/OoPqYr1VkYcSP2PFA/Jbg8PD6Gc9sYbb+ifeuopMXcxMTE9+9Gck+qZp6en/tlnn9U///zzQlksLi5u2I2bhwup6i1btkz/5JNP6t98801h79SpU4Ud/Zu5FhUViWObPHmy/uWXX9Y//fTT4nj7Kx725r777hNz2htSB6Rria4fOi+k6vff//73vHaePn1a7EfzRgpsf/3rX0WTYZrX/n8ujD3Xg0FKcAb1t/j4+HMUEoOCgs55zVDmhq6j4TbZvpD6H1071NCWmhG/9NJLYqPrj15HKn29FUB7qxPedddd4vyTIiD9/tFHHw04PqkvkoKjQf3PACk8BgcHi+8Gup78/f2FauZg3HTTTfqLLrpILxX6jqJrljZSOY2Nje35na4ZA9TImJr4Ojo66v/85z/r//Of/4jPuZOTkz4jI2PAsbdu3SrOYW91UjqXfn5+4hjpu5SuhauuukrycTAMw4wk7FQxzDAYTJabFgC0WLayshKLUVp01dfX99mnpaVFf91114lFGY3Re+FHjgA5ALQQsbGxEYsNcgJogdLY2Dgsp4qorKwU+9MijGwj6XKSJieHRE6nivjiiy+EXDLJK9NG80HvnZmZKYtTReTm5ooFIx0HHQ8twNatW6f//PPP++xHi/W5c+eKhSA5Ci+88ILRkupyQpLbK1asENcESY7TeaXfDXLh/UlNTRXOOTnCdJ1cf/31wjkeCHKe6PgSExPPee7dd98VC1JyRB555BGx6L0QP/30k7jmaEySAidJ/8Hk6Y0514NBstp004EW3L3t+vDDD8V73XjjjZLmhpxpWuCPhFNFn+kbbrhBHxoaKuygzypdz+Tk9b6BYoCcLHqOrm2aV9qXjnMw6IYHScz3hz7H69evF3M2c+ZM/alTpwYdg9oMeHl5CYdXKga5+IG2/vNELQKojQNdczQ39FnvfUOoN9TOgeaEHOT+0GvoGOlY6ZipbQXDMIwpo6L/KR0tYxiGGQhqkkvCE9Qkubf8OsOcD5LjJiEHShUcDSlxU4TqzObOnSsUFS/UeoFhGIaRDtdUMQxjshjqpriWghkKVKc1f/58s3WoDDz99NPsUDEMw4wSHKliGMYkITUw2hITE4WAR28FP4ZhGIZhGFOCI1UMw5gkd911l1D/IuUwdqgYhmEYhjFlOFLFMAzDMAzDMAwjAY5UMQzDMAzDMAzDSICdKoZhGIZhGIZhGAlYYgyj0+lQVlYGJycnqFQqpc1hGIZhGIZhxgnUdai5uRm+vr5Qq003DtHR0YGurq4RG9/a2hq2trYjNv54YUw7VeRQ+fv7K20GwzAMwzAMM04pLi7GpEmTYKoOVXCgIyqqtCP2Ht7e3sjPz2fHajw7VRShIpY6XgVLldWwx1HZ2UkzxNYakrGxkTyETqIdehsLyTZo5RjDVtoYOmvpd5O0coxhIy16qpXhstJZS7Rh+B8rmY9D4uutlLfh7BjSeq3rrKT3atdLtEFgrZP0cpWV9D/+ltbSxrCUwQZb627pY1hqJL3e0bpTsg0OVhrpY1hIs8PFql2yDc6WHTKMIc0ON4tWyTa4qNukvd5C2usJd7UM50Mt7fPhopa+RHVWS4uuNLXoEDizoGe9aYpQhIocqsL4IDg7yR9Na2rWITCuQLwPR6tM2KnSarV48skn8eGHH6KiokKEV2+55Rb84Q9/MCqdz7APOVSWquGveFRqiasltXSHCBYyOFUWEp0qS+mXg8rSQvExdFbSv1RUMowBiQ4NZFjEq0zABnmOQ9nXC2QZQ6JDI4NDNF6cKrWNtDEsrKQ7RBbW0r/vLCV+11jKcF1aWUlPn7e2lHZd2chwPmwstYo7uXYW0v+O2ltIu64cJL6ecJQh1c1J4hjOMtjgrJY+F8RYKDFxdFKJTW50MP1jNxUUdaqeffZZvPrqq3jvvfcQFRWFU6dO4dZbb4WLiwseeughJU1jGIZhGIZhGIYxfafqyJEjuOyyy3DppZeK34OCgvDxxx/jxIkTSprFMAzDMAzDMGMGrV4HrX5kxmWMQ1EpkwULFmDv3r3IysoSv58+fRqHDh3C2rVrB9y/s7MTTU1NfTaGYRjGNLAYAyky4xFLlTwpTozxqGEBFXelGX1UrEDHmC6KOlW///3vcc0112Dq1KmwsrJCbGwsfv3rX+P6668fcP9nnnlGpAYaNlb+M57AkAlYe3mcbOeOMY5504KwKDaEp2uUuWH+DIR7e/K8jyJ2llZ4dOZieNja87yPIgH2E3FtwErYSK0NZoZEqNN8THe7VDhXzOhh43APrGzXkHfF094PHfQjtjFjwKnaunUrPvroI2zZsgUJCQmitur5558XPwfi8ccfR2NjY89GEpeMcXS0a+AfwovM0aa2sQXRk31G/X3NnayKGiyPDFXaDLOivVuDtLoqbA6L5uXOKFLcVoV6TTPW+y6EmiMno0Zey0lYq+0Q674BFhLUh5mh0dX2ISysomFtfyO5WDx9jEmhqFP129/+tidaNW3aNNx44414+OGHRURqIGxsbODs7NxnY4yjrqYZtrZWsHfkL6HRJK+kFrY2lvCd4DKq72vuxBeWwsbSAtMmTVTaFLNiZ2EW7CytsdQvWGlTzAY99NhZfgwWKgus9J6ttDlmQ7e+E/F1X4mIyUy3jZIUiBnj0etq0NHyH6hU1rBxvAcqlStP38/oRvA/Zgw4VW1tbed0qLawsIBOxydQbjQaLRrr2+DpxY7oaKLV6ZFZUIXIEF7cj/a8/5iRh4unToaa63xGDY1Oh61ZybjYfzL8HPi7ZtTmXa/Fd2UH4Wvnifke0aP2vuaOVq9BYt03wsGKc78CVlzvMzro29HZ+jZ02gLYOD0ItQXfxGFMA0WdqvXr1+Nvf/sbvv/+exQUFOCrr77CCy+8gMsvv1xJs8YttdXN8Jhgug3sxitpeRWICPYGr+1Hl9PF5dDp9YgN8B3ldzZvSlub8GNJHq4KmwYrGfrMMMbRpu3EN6UHEeMaikhnXmSOFjpokVS/De3aJszyuBJWaq4pHK2Z17R/A03HTtg43ApL63kwd7R6/YhtQ+XAgQNijU/9Z6nH19dffz3ovvfcQxFHFV588cU+j9fV1QmNBcpKc3V1xe23346WlpY++yQnJ2Px4sWiKTHpLPzjH/+Akij6F++VV17Bpk2bcN999yEiIgK/+c1vcPfdd+Opp55S0qxxS01VEzy82KkabYoq6sXPQB/3UX9vc4b+DuxLz8XSqcGw5MX9qPJTSR7aujVYGxg+um9s5tR1NeH7siO4yCsW/vYcHR8tqJQ/uWE7mjXVmOZ2HazV/Hd2tNB2nRBRK0vbFbCyoxvy5iscYkpCFa2trZg+fTr+85//nHc/CqYcO3ZMOF/9IYfqzJkz2L17N7Zt2yYctbvuuqvneVIAX7VqFQIDAxEfH4/nnnsOTz75JN544w2YZZ8qJycn4Zn2905HnWF44aaI6gLHUVfVhKDJXoPup5dhHlQyTKVKavanHKdTjrnodRzpueWIDJqIwpLaIbxeBnUjncLnQuEx0kuqsCQsCHMCJuFIXpE0G7SSXv7zGCrFbdDL0MhEf4HjoHf4NCMVD8XOR3ptDbLqa/ruYCH9fp62W9pxqNTSF18aiTYQlmppH5DO7r5/xnOb67CzLAlrvBfhk8IfUdN54dYjljJ8SKWO0aqWXu9rJXEuxRja4X/ITtT9hDnu8xDudhMS675Au7ZhWONYSJxLCxn+EFvI8IdUrWqTZoO+27gdu3OgbnoRDg43Aw63oaX1A+j1ZyMaal2HJBtauBxlWKxdu3bQ9kgGSktL8eCDD2Lnzp09/WoNpKenY8eOHTh58iRmzZrVE4i55JJLhKAdOWEkdNfV1YW3334b1tbWiIqKQlJSksh46+18jSacm2FG1FKkaoKTCLMyo58CGB7kBQs1z/1oszctVzhW1pbmewdTCeo727EtLwObwqJgb8nqaKNJWlMR4muzcMWkRXC05L4+o0lm0z5UdWRjpvtm2FtwdsJoodM3oLnlv9DpGuHs9BAsLPxgblBESTsCmyFS1b9PLPWOHbatOp0QpyPBOnKG+nP06FGR8mdwqIgVK1YIHYbjx4/37LNkyRLhUBlYvXo1MjMzUV9/NkNotGGnyoyor20VdT3OrpzzPdqUVzeho1ODEH+WtR9tciprUdXSigUhAaP+3uZOfFUZCpsacEXYuX80mZHlaG06ClurcPmkhbBWK5qUYnbkNB9AWXsK4jw2w9FygtLmmBEatLZtQWfnUTg53gNrq+lKGzSuoJql3r1iB1PqNoZnn30WlpaWeOihhwZ8vqKiAl5eXn0eo/3d3d3Fc4Z9Jk7sm+Zs+N2wz2jDTpUZQel99TUt8OS6KkVIy6tEZIi3Mm9u5uxNz8WCyYGwt+aIyWjzVU4aApxcMGui+d05Vpo9lQlo13Zhne88qLl72KiS33IMha3xmOm+Cc5W3KtwNOno/BGtrR/B3v5KWNquNptGwSNdU0W9YXv3iqXescMhPj4eL730Et59991xlznFTpVZilWw1LESpOWWIzRgAqytOA1ttCmsa0BxXQMWTQ4c9fc2d0iw4rOsVFwaHA53WzulzTErtHodvi09CgdLW6z0jlPaHLOjqPUUcluOYIbb5XC14psKo4mmOwNNza/AwioKVvY3caNgGejfJ5Z6xw6HgwcPoqqqCgEBASL6RFthYSEeffRRBAUFiX28vb3FPr3p7u4WioD0nGGfysrKPvsYfjfsM9qwU2Vm1FY1c68qhahpaEV9UxvCAjgdRAn2ZuRibrA/nGy5AfZok91Qi4SqMlw1ZZqZ3DM2Hbp03fiq5BACHCZgoSenYY42pW2nkd28H9PdNsLD+uyCkRkddLpqdLb8FyqVGjZO90OlHt/p96YkqX4+qJaKpNBJVMKwkfAE1VeRaAUxf/58NDQ0iKiWgX379olarLlz5/bsQ4qAGo2mZx9SCgwPD4ebmxuUgJ0qM4MjVcqSlluBqFBOBVGCssZmZFbW4OIpIYq8v7mzPT8LtpaWWB4wWWlTzI6W7g58UXwIM9wmY4Yrz/9oU96ehvSm3Yh2Wwcv2ymj/v5mjb4DXa3vQqtJh7Xj/VBbRihtkVnQ0tLS4zAR+fn54t9FRUXw8PBAdHR0n83KykpEl8ghIqjN0po1a3DnnXfixIkTOHz4MB544AFcc801PfLr1113nRCpoP5VJL3+6aefirTCRx55RLHjZqfKDJ0qV3cHWHEKmmJOFfWrsrf7Ra2GGT32ZORg+iRveDk58LSPMt16HT7OSMZivyCEOLMq2mhT19WML4sPYbFXNMKd/Ef9/c2dqo4spNR/hwjnlZhkzwIKo4se3R3boWn/Clb2V8PSduW4rLPSjeA2VE6dOoXY2FixEeTo0L//9Kc/GT0GSaZPnToVy5cvF1LqixYt6tODisQydu3aJRy2uLg4kT5I4yslp06wJJCZ0drcgY72LrhPcEJl2fB6aDDDp6m1AyWVDYgK8cbJM9L6JjFDp661HacKS7EqMgwfHj97B40ZPSrbWvB9fiauCo3BK8lH0NrdxdM/ipR31OG70mPY4DcfnbouFLT2rUdgRpa6rkIk1n8hUgGt1Q7IaznCUz6K6DTJ6NJWwtrheqgtJqGr7RNA387nYAS46KKLhtT7tKCg4JzHSOlvy5Yt531dTEyMqNEyFThSZabRKs+JLkqbYbak5pQjOoxTAJXip+x8+Lu5INhTmZxrc+dERQkKm+uxOXSa0qaYJeRI7SyPx3q/efC181DaHLOjSVOB+NpP4G07VUStxmPExJTR6yrR2fwf6PXdsHF8ACr1+PlbPBI9qgwbYxzsVJkhNZVNmDCRFQCVIrOgEu4uDvB05RQ0JWjr0uBgdgFWR4Yp8v4M8FXeGUywc8BiHy7cV4LM5mIcqEoRPaw8bfhvwWjTpm3AqbpP4WQ1ETGuG6DmpKFRphOatg+g7ToJlYoVSRn5YKfKDKmuaISnN0eqlKJLo0V2YTWmhZ0ttmRGn2P5xbC3thb1Vczo06HtxsdZSVjuH4pJjvxdpASnG/IQX5eNK/0Xw9mSb/CMNl26ViTUfQZLtTVi3a+Epcp21G0wd7o790OnzcN4QasfuY0xDq6pkgM55CZ1+lGzo6aiEROoAXD//YdTjThMG86HSuIYKhm+AVQ66SkZqvPMZ2pWGS5ZEoWfTmQPOmXne70cNozG62UbQyvt9ep+r9dpddh3JgcrIkORXlyFbt2FjdRbjpPzoZUh3Uji+YBWhZKmZuwtzMW1k6fjldNHhaM1FPRqacehk2EeutXS70t2aaX1rbNQD//C/KkqG5YqO1zquwyfFu1Dm7Zz2GNZqqVdnJZq6Y25LaV+UYg7zdKOw2KIH9JD1T9ghtsqxLhdhxN136JD2wILiTZIPQbTGaNDsg1Q/yK3PRya9XIsjBhzgSNVZkhdbQvUFmq4uNkrbYrZUlBaK4o4g/y4pkEpkksq0NbZhbkhrISmFAfLClDV3oorQrl/klLsrUxGeXstrpi0BDYyODbM0NBBi4T6HajtKsV8z01wsuS/CczYV/8zV9ipMkPoLn19TQuLVSgIRafOCMEKTgFUkl1nsrFkSjDsrXkxqRSfZ6ciwMkVcyZOUswGc2dXxUk0d7djg99CWKh4WTD66HGm8ScUt6ZiruflcLHyU8AGhmGkwt+eZkp1ZSM8WaxCUVKzyzElcAJsrDkLVynya+pRVNeApeHBitlg7pCs+tasFFwSFA5ve0elzTFLdNDj+7KjUKtUWOc7H2pWpFOEnJZTyGw6ihi3y+FpE6qMEcyYRQcVtCOw0biMcbBTZaaIuiqWVVeU2oZWVNe3YGrwRGUNMXMoWjUz0A/uDqwCpRR5TXUiFfDaKdNhrZZWY8QMj269Fl+XHIKzlQNWes/iaVSI4rYzSGv8AREua+BrF8PngRlSaf5IbYxxsFNlplRXUq8qltJVmpSsMkRP4RRAJalubkVycTlWRrHEupLsK85FS3cX1odMVdQOc6ZTp8GXxQfgZ+eJpROmK22O2VLbmYfk+i8R4rQIQY7zlTaHYRgjYafKjNP/nF3tYWPLtSRKkp5XAR9PZ7i5sGiIkuxNz0WIpzs3BFYQuhn6aVYyIty8EDth/DTkHGu0ajvwRckBhDsHYJ5HpNLmmC2NmjIk1n0KH7tohDuvhIqXa8wFGInUP8PGGAc7VWZKZ7sGzY3tnAKoMB2d3cgqrEIMR6sUbwi8PzMPa6eFQ8V/PxSjqasTn2YnY0NIJCZyfZViNGpa8UXxT4h1C0Wc2xTlDDFzWrtrEV+75WyTYLfLYaGyVtokhmHOAztVZkxVeQMm+HDjTaU5nVGKmCl+okicUY4T+cVQq1WYHcQqdEqS3VCLQ2UFuD58BmwtWMRFKWq7mvBF8QHM9YjEdNfJitlh7lCTYIpY6aHDTPerYaNmMRdmYDhSpTzsVJkx1RWN8GKnSnEKy+qg6dYiNHCC0qaYNVqdHjtSsnDx1Mkssa4we4tzUdvRhs1h05Q2xayp6mzAVyUHsMhzGqJcgpQ2x2zR6jVIrv8ajZpyxHlcB0dL/lvBMKYIO1VmTFU5KwCaCslZpYgJ594kSpNTVSsk1pdF8J15pdmanSJSAC/yY7l7JSnvqMPXpYdwkVcsIp0DFbXFvNEjq2kPStoSEOt+FTxsQpQ2iDExdHrViG2McbBTZcZUVTTAzdMRVlYsYWwKKoBBfu5wcrBR2hSzZ2dqFqb7+8DbhdNslKS9W4OPMpOwdFIIQl08zP66VJLS9hp8W3oYF0+ciXCnAD4XClLUegoZjbsQ6XIJJtnP5HPBMCYEJ6ybCnr9qI/R1tyB9tZOeHo5o7ykDioZbFDpZOlgJw0ZplIlxxhDOI6W5k4UltRh2mRfHE3Kl9EGaYOodCqTuCYkjzGE19c1t+NYThEuiQ7H2wfjf7FBK9EGGkPibSxZbLCQfk713RIHUBtnQ3ljC77LzsA1YdPx78SjaOjs+MUGtbTJ1HVL/4Bp1dLH0HRLu6lloZb+AbNQX3gpkNNchy+KjmPjpHno1KqR2VzS53lLiXaoZfjCU8vw5S/VDlmO4wJfeM3txajt/hYz3dZBrfZCWtMBUXMlpw0Wsowh7Zqw0MmxoOiS9OoWGf4GjhYjpdTH6n/Gw5EqM0ekAHJdlUmQTIIVUzkF0BQ4kFkAV3s7RPtxY2alSagqQ0p1Ba6LmA5LqV4pI4nCtip8W3oca33jEObE/fWUpFFThaM1W+Fq7YNZ7uthqeIsB4ZRGv4LZeaQAqCXj6vSZjB0J7iwGlaWFgj0c+f5UBiNVos9Z3KwKjoMVhacHqs02/IyRAR63WRuDKw0+a2V+K70OC71nY1QR+4npiQduhYcq/0cOr0W8zw3wc7CWVF7GGXRQj1iG2McPFNmjlAA9GZZdVNAp9cjJasU01mwwiRILqlAQ1sHFk/h4nyl0er1+DA9CZEeXoibyNFcpcltqcD3ZSexzm8Ogh04mqu0MmB8/feo6SzCfM+r4Grlrag9DGPOsFNl5lCkyt3LCRaWfCmYAsmZZQgL8oKdjZXSpjAAdqRkYn5oINwc7Hg+TKExcEYy1oWEw8+R78grTXZzGbaXncIGv7kIcvBS2hwzR4+MpoPIaT6O2R4b4WUbobRBjALoR0j5j8ZljINX0mZOc2M7ujq74TGBFymmQH1jG8qqGhEZxmk1pkBZQzOSi8uxOjpMaVMYipA01uHH4jxcN3U67Cz5xoPSZDaXYmdFAi7zmwd/O3aslKaoLQWJ9T9givNyBDrMV9ochjE72KliUF3eCC9frqsyFZIzSzGDBStMhr1puQj0cEOYF8t6mwIHSgpQ1tqE66ZMHwGdK2aoZDSVYE9FEtb5LoK/PacCKg2lASbUfoyJdhEXbBKsBteLjicM6n8jsTHGwU4VI1IAJ7JYhcmQkVcJBztr+Huzo2sKtHVpsCctB5dGh8PKgr8yTYHPs1LhaGWDS4NYuMIUONNUhH1V8VjnsxCB9lzTozRt2lqcrHkXLd3Vg+5jobJGuMtq+HGvK4aRDV4hMKgsq8dEjlSZDFqtTtRWzZzqr7QpzM/EF5SitUuDJWHBPCcmQKdWi/czEjDD0xezvFi4whTIbC7E3qqTuNR3AYIdOH1ZaXr3rRoItcoSxa3xCHVaigCHuaNmFzNyaPXqEdsY4+CZYlBRelaswpLFKkyG0xklmBIwAQ621kqbwvzMt8npWBASAC8nB54TE6C+sx0fZSViXVAEAp04qmsKZDUXY1fFCaz1mY8QB3Z2TRmNrg02Fg5o665DfWeB0uYwMqCDCjqoR2Dj9D9jYaeKQUtTOzraNZgwkaXVTYX6pnYUltdj+hRemJgKlU0tOFFQgnXTOOXMVMhvqscPhRm4PjwWrja2SpvDUL+9lhLsKD+GNT5zEeo4iefERLFWO2Cy00UobotHc3eleMzWwhm+dtOVNo1hxizsVDGCylJOATQ1EjOKhWCFim8SmQz7MvPgam+HWH9ObzIVTlSWILW2AjeGz4S1mgvvTYG81jL8UH4Uq7znYIoTpzGbIuHOq9DQVYyq9vSex+wt3OFuE4wZblfB1oKFecYaLFShPJZKG2AS6PXSXq+T+HoTEasQTYClzoXU1wNQSRxDJcPpUMlwTlU6ad5QblENVs0DQv08kVNUM0wbJOcTSEayDTLYodJKN4HG6NZqsf10Ji6bEYGsshohYjGkMSSu+VVa6R62qluGa1vi7Ti9DMfRe4zvcjNxe9QsXBkyDVsyTxv1ep3Ug6BFjAy3JVVqaedD0y3dkVRD+jWh7vfFm95Yg/buE9jgNw8arTXSmoqG9PrhYCnDl41UOyxkmEsLiV94g9ngYjURjZpKBNhPh17ljLSmQ+jQUmuCs+0JWtorUNS+A352kQhx3Ii0hu/QqWuBOdOqk+MPGGMucKSKEVSWNcCbFQBNCvItEzNKMTOC7/SaEhkV1Siqa8DKSO5dZSro9Hp8lJEkmgIv85+stDnMzxS0VuLrkiNY4R2LaS5BPC8KooYlQhxnY67HZgQ5zkRa44/o0Db32Uf185KwrD0DHdpGWKo5pXYswUIVysNOFdOT/ufq4QAbG26oaUqczipFgLcb3JztlDaF6cX2lCxE+Xoh0J0FEkyFtm4N3ktLxGLfQER7cL8kU6GorRpfFh/GxRNjMNONHV6l0KEbifXb0NBVDkuVNewsnAZUDLRRO8LbLgyu1v7Q98oaMThcDMMMDn9KGEF7WxeaG9vPpgAyJkNbexeyC6sxI5wLvk2JhvYO7M/Mw7rpU2Gh5qI3U6GqvQVbs1OwKTQaPg7nLhoZZShpr8HWooNY4BmJuR7hfBoUJLP5EFIb94iolaXKBi5W3phoG4owpwWY5roKce4bMMEmGAUtR0S/Kxu1E/zsYxHuvBrBjgv53Jm8+t/IbIxxsFPF9FBJdVU+7FSZGgnpxYiZ4gsLbjxrUhzLKxZpZwsmByptCtOL9Lpq7C/Nw00RsXC04pYEpkJFRz0+LTqAOLcwLPKMUtocs6aqIxdHaz6Fm7Uv5npswmTHOWjW1Ii0P3K4kht2oLw9Rewb47YJjpZeqOnMga2FK6a5Xs5RK4YZBHaqmD51VdwE2PQormxAS1snIkM4pcmUIIfqu9MZWDIlCK72XHtgSuwvyUdeY51wrCxlEKRg5KG6sxGfFP2EaJdALPNi6W5l0aO6Mx+pjXuho+RAfRdqO4vQpKnq2SPC5RLRzyqzaSdqOrOR3vg99NCLCBdjelBPKe0IbDQuYxw8U0wPVeWN8PZ14xkxQRIzSliwwgQpqW/E6eIKrI+JUNoUph9f5pyBVq/H5inTeG5MiLquZnxctB8hjj5Y4x0HFacWKUpZezpSGnYi0GGGSP8z1E552EwWW2rD1z37etiEwNHSExp9u4IWM4zpwk4V00NFeQMcnWzh4Mh33U2N1JxyuLvYw8+L0zNNjT3pOZjo4ojpk7yVNoXpBTlUH6QnwtfBCWsDp/DcmBCNmjZ8UrQf3nbuuMxvHiw4mqgord31iK/7GuXtWUKsgmQpfOymIb/lMLr1nWIfik552U5F2c9pgS5Wk+BjF4MIl0vhZs3KjqYAq/8pDztVTA+arm7UVjfD248VzUyNLo0WpzNLMSsqQGlTmH50aLrxfXIG1kRPgYMN1/CYmiLgu2kJiJvoh/ne/NkxJVq6O/Bx4X7YWdhgs/9iWKtZeVZpajoLfv6XHm3ddUJW3cAkh1nQ6bWo6ciGnYUrolzXwdbCCY1dpQhzuhi+dpzOyTDsVDF9KC+t5xRAEyU+rRhhARPg7MCRRFMjvbwaeTX1uHQaK5uZGrUdbXgvPQGrA8MQ4T5BaXOYXnTqNPis+CC6dBpcOeli2FtwrY6pQBErf/s42Ft4IMRxCVyt/FDVkYkObROiXDegov2MiGSVtSchs2kX7C3dlTbZ7KHap5HaGOPgmWL6UFFWDx8/rqsyRRpbOpBbXIOZESyvbopQtCrI0w2Rvl5Km8L0o7i5UUitXx0WA39HTqE1Jbr1WnxdchQ1nY3Y7L8CLlYOSpvEAMhvOYSazlxMdloKGwtHZDXtRX1XAUKcFouIVV7LwZ558rQNg42FM88bY/awU8X0oaKkXigAqlTcl8AUOZVWhOnhfrCytFDaFKYfbV0a/JCSKaJV9tacymRqpNVVYWdhtlAEdLflZtqmhA567K48jtyWUmyatByeNpyCbgqUtMXjTMM3SG/8QfSsorQ/d+sg8bsBJ8uJsLdwQ1nbaUVtZaimSjViG2Mc7FQxfairbYFWq4OnFzfONEWKKxrQ1NKBqMksimCKpJZWCkXASzgN0CQ5WlGExOpy3BoZB3tLdnxNjUM1SUhqyMKVfhfD15ZTNU0BHbQ9/9boOtDcXQmN7qz6n1plBV/7GWjprhY1WAxj7lhiPKDXiwzgsX8MCo/x8+srRV2VK6orGocxhjQT5BhDpZNjLqXfmZFqh4pEmAYgPrUIc2ICcTq95MJjSDyOwWwY7THUEsfQj+JxbEvMwP3L52OqlycyK2r6jqGVaIMMt8FUahmubYnHoZfjOLqHdxzbc7LgFmGHG6fMxFtnTqFbwsWhG6YNvdGqpU2GRiU9aq1SSf/OtOiWNob65y/+Q1W5aOzU4hKfpfih7ARyW8qHPIYkOyTOhVqGLzw5xhgJrFQ2UKnc4Gk3H4UtCYh2XYlOXQeK20rQqOkC0Lfe10IoCY5t2nQSv+xGEUNfKfnHHePra3OJVAUFBYk0s/7b/fffr6RZZg+JVXBdlemSllcBextrBPlxYbAp0tLZhe0pmVg/IwJ2VuPjvtV4Y2vGWVnoq8K4h5UpktJYgO1lJ3GJ7xxEuQQqbQ7zMxp9JxLqtsHZcgIiXZaJ2qqMpgNo1FTwHJkAOr16xDbGOBSdqZMnT6K8vLxn2717t3h88+bNSppl9ggFQBarMFkoPTMxoxizonixYaokF1egvKEZa6ZxfyRThKJTH2QkwtvBGWsDWbHRFMlpKcNXxYdx8cQZmOXOnyNTgfpWJdR/i5SGXTjdsB3deopQMQyjuFM1YcIEeHt792zbtm3D5MmTsXTpUj47ClJRWg9Xd0fY2HLNgamSkF6CIF930RCYMU2+S0rHVB8vhHp5KG0KM2gPq1OIneDLPaxMlJL2Gmwt/Amz3adgyQSOKppqrRVjWul/I7ExxmEyM9XV1YUPP/wQt912GyvPKUxnhwYN9a0crTJh2tq7kJZbjtnRHK0yVZo6OrEzNQsbYiNgw2qNJkldZzvez0jAqoAwRLqzFL4pUtXZIJoET3GehDU+s6EGK5GZMjZqBzhZeiptBsOYt1P19ddfo6GhAbfccsug+3R2dqKpqanPxowMFSV1XFdl4pxMLUJ0mA/sOaJosiQUlqG6uRVrWA3QZClpacRnOSnYHDoNAU4s5W2KNGhasKVgHybYOOMK/0WwVnOtoqnibjMJczw3w9+eI4ujDcmCjISc+tiXGzFDp+qtt97C2rVr4evrO+g+zzzzDFxcXHo2f3//UbXRnCgrqYfPJBZCMGWq61tQVF6PuKgApU1hzsM3CWmI8JmAqT4sEW3KPay+yUtDc1en0qYwg9Cm7cSnRT9Bq9fh2sCL4WzJqc+mSHl7JhLqvkWI42xEum6EpaqvIiDDjGdMwqkqLCzEnj17cMcdd5x3v8cffxyNjY09W3Fx8ajZaG6U/xypUssgv8yMHMdOF2BmhD+srbgZsCmnAX6fnIENMyLgYGOttDnMICTVlKO+82z/HcY06dJ14+uSIyhuq8Z1QcvgbeumtEnMANR3leJI9UeiP0qcx81wsZrE8zQK6KAesY0xDpOYqXfeeQdeXl649NJLz7ufjY0NnJ2d+2zMyFBb3QydjpoA8xybMsUV9ahvasP0cD+lTWHOQ0pJJXKr67BxegTP0xjGwdKamwYrjB567KtMwsnaTGwOWIJQx8GzWxhl5dfTGr5BUesxRLtdiUDHhVCZxpKTYUYMxa9wWriTU3XzzTfD0pLzpE0tBdDXn1MAx0K0igQrLDiqaNJ8fzoD3s5OmBXIDvBY5CK/ENwaGYfrwmdg5gReyCtNfH226GW11nc24tzClDaHGYTy9tNIrP0QnjahiHG/GjZqvlE7Umj16hHbGONQfKYo7a+oqEio/jGmRVlxLXz9WQ7a1MkuqoKmW4vIyT5Km8Kchw5NN75KSsPqyDC4O9jxXI0hbCwsEO0xEdsLs/Bdfjrm+wRizkROaTKFXlZbiw5gtkc4lk2cARUrA5okbdpa4Vi1aqoR53ETPG24NxwzPlHcqVq1ahX0ej2mTOHmfqZGWXEdR6rGAHo9cDylEHNiWF7d1MmrqUN8URmujI2GissVTR61SoVpHt5Y7BsMPWVW6HWobGvBN3ln4O/oCkuV4n9CzZ7KjnqhDOhvPwHrfBfDSsUZL6ba1yqneQ8ym3YgzHkFwpxXQ63iXpjyzrFqxDbGOPjbR65VrSmMoZP39ZWlDbC1tYKzsz2aGtqMGkIlw3GodBLHkGEqVVoZBrGU9kWkGkJvxbSMMiyOnYywSROQU1j9yxg6hc+FOA4ZvpAl6nAMZS5HdAw1sDc1B3cvnYOLQoKxPyt/aK+XQY/EFOZCLYMvopOY7qrvvrARs338Md8nADsKstDWqcXmydOxqyAbiycFoaqtBZpu2kvawei6pX3GumX4eKlUMnzOVcrZUK3twnt5B7EpYBY2+K3EVyWH0dI9PNERtQxzIRULE7BhpGhsK0Npx2eIcVuNKLfbkNywE02aqgH3NYWms21abnLMGI/yVyxjsmi7dagqb+Ro1RhAq9MjPrUQc6cHKW0KcwG6dTp8EZ+KRWFB8HXl+gJTxUKlQoT7BOwrzkV6XTUOlxXiaFkRfB2dcby8GJ9lpWLuRH8smzQZS3yDlTbX7OnUdeOrkkOo6KjHdYHLMMGGe46ZKp26Fpys/RKl7emY43GlkF8HR0MkwzVVysNOFXNeyko4BXCskJhWiglujvCbyIsJU6eiqQX7M/OwKS4KVhYsh2+K6PR60bfK1eaXPjs+Dk5o79YgpaYS90+fh3C3CeL3MFcPXB4Spai9DCVb6LG7Ih6J9Tm4OmApQhy4ztR00SO/5RRO1H4BX7upmONxBWwtnJQ2imEkwU4Vc17KitipGit0abqRmF7M0aoxwuHcQrR0dGFVVKjSpjADQAlYuwpzhOO0OjAMV4ZFwc7SEqm1lbgxMhZV7a14PyMBRyuK8FbaKThYWcPGgjPqTYGTdZnYVRGPS33nYobrZKXNYc4Dpf4drfkELZo6LPC8Dj52LGIxXChdcqQ2xjh4ppgLNgF293SEjS0XlI4FTqUUIcjPHZ5uDkqbwlwAKj/8MvEMYib5IMyLVTZNkaauTryflohuvQ5tGg1+yM/CZZMj0KntxieZyT37hbp4wM/BmYUrTIis5hJ8XnwA8zwjcZHXdFYGNGG0eg3Smn5ESsNOhDsvRozraliqbJQ2i5HAgQMHsH79evj6+kKlUuHrr7/ueU6j0eB3v/sdpk2bBgcHB7HPTTfdhLKysj5j1NXV4frrrxc9aV1dXXH77bejpaWlzz7JyclYvHgxbG1t4e/vj3/84x+Knjd2qpjz0t7WhYa6Vq6rGiO0tnfhTHY5R6vGCA1tHdiekonLYiNhb803LkyRDm039hblYntBlkj102i1+CIrtef5CbYOWOATKCJWrd1dQjGQMQ3KO+qwpXAfghy8cZnfAlipOZJoylR3FuBI9RbhUC2YcB1crf2VNmlModOrRmwbKq2trZg+fTr+85//nPNcW1sbEhIS8Mc//lH8/PLLL5GZmYkNGzb02Y8cqjNnzmD37t3Ytm2bcNTuuuuunuebmpqEgnhgYCDi4+Px3HPP4cknn8Qbb7wBpeBvGMYoaXW/AHfkZ1fybI0Bjp8uwO2bF+BIQh5qOjuUNoe5AEnF5Zgy0ROXx0bho+NJPF8mjJ2llaiBa+8Wsn9ws7HDUr9g1La34WRVCRwsrbHCPxR66GFrYYXPc1NEbRajHE2aVnxcuA/rfOfh2oBl+Kb0MBo1rXxKTJQuXRsS6r/FJPtoRLtuREV7KvKaD0KHs585ZnB0I5SqR+MOlbVr14ptIFxcXISj1Jt///vfmDNnjuhbGxAQgPT0dOzYsQMnT57ErFmzxD6vvPIKLrnkEjz//PMiuvXRRx+hq6sLb7/9NqytrREVFYWkpCS88MILfZyv0YQjVcwFKSmshV+gJ8/UGKGhuR3puRWYN4MVycYK355Oh5ezA+aF8J1ZU4bqqJq7unB1+DRM85yIm6bOFJGs45VFsLOwxIPTF4hIVVpdFVo1Xbg7ao5QEWSUpVOnwZclh1DUVonrA5fD1+786baWcvQuYCRR0paKU7Xvw9FqImZ53AhnKxYdGc80NjaKNEFK8yOOHj0q/m1wqIgVK1ZArVbj+PHjPfssWbJEOFQGVq9eLaJe9fX1ChwFO1WMEZQW1sLL2wVWVvyHZqxwNDEPkaE+cHH8RbmMMV06NN34/FQqlkdMZpl1E4dqqeo62oUS4InKYmwryBAqgbdFzkJqbQW+yjuDnMZafF+YgcauDhHdYpSHoof7q05jb2XieSNVNmprLJ84F9NdWTBBaTq0jUiq+xTl7SmIcduEYMeFUHEsYFB0evWIbYZ0u95bZ2enPOe5o0PUWF177bWifoqoqKiAl5dXn/0sLS3h7u4unjPsM3HixD77GH437DPacKSKuSDNTe1oaWqHj787z9YYob6pHRl5lVgQw9GqsUJxfSP2Z+Zj86xo2FpxZrYpQ/VVpAxIdVTE9eGxKGpuFA6WgSh3LwQ6uUHL6X8mRWZzMVq7B0+LpkhjQn06FnrOQKzr1FG1jRkIPYrbTiGhdgvcrYMx0+N6OFhy5owSkBAEpe4ZtmeeeUbymBqNBldddRX0ej1effVVjHXYqWKMorSoFn4BrFA2ljiSmIfoUB84c7RqzHA4pxA1zW3YMD1CaVMYI6E6KhKw2FWc1fMYKQHOnOCHfSW54jlm7NCu7YSzlSPquhpR1KbM3W7mXNq0tUio24LajlzMdL8OAQ5zuGFwP7RQjdhGFBcXizQ9w/b444/L4lAVFhaKGitDlIrw9vZGVVVVn/27u7uFIiA9Z9insrJvrb/hd8M+ow07VYzxdVXsVI0p6hvb8PX+FHR08qJuLPFV4hn4u7tgdtAkpU1hjMDawkIIVqh+XniQQ7XENxiVbS0iDZAZWzhZ2mOBx3QRrSLHiqBzy3VWyqOHDgWtR0RK4ETbSMS6XwM7CzelzTIbyOnpvdnY2Eh2qLKzs7Fnzx54ePS9aT9//nw0NDQIVT8D+/btg06nw9y5c3v2IUVAGssAOWfh4eFwc1PmuuAcE0InUZ3JRNI7VFLtOM/rywprsWztNFhaqKDt1p1nCBnmQuIYKq0MNlhKLy5XSbyuVDrpNuQUVJ8da9g2SDZBljHUWmmv18tQDqjSyjCGEbex2ts1+OJEKm5YMAMlNQ2oaGyR1wYZdBNU3dIG+TlFX9njkGEe9GoV6to6kFpThZvD43C6uhxzvP1xsrIEKTWVqGlvv+Ab6Yy5KM6HHOdTbaH4+VCrTOPv6ELPuchpqUZyQwV0ekuoVWqsnBgnfrpYOeDHqkRUdihTBM+cpUXbiMqqzxDmNB8x7rcgt/k4CloTf27ZLS/turGjOti7/knucYdKS0sLcnJyen7Pz88XynxUE+Xj44NNmzYJOXWSStdqtT01UPQ8CU9ERERgzZo1uPPOO/Haa68Jx+mBBx7ANddcI5T/iOuuuw5//vOfRf8qqslKTU3FSy+9hH/9619QCo5UMUbRWN8qelb5TOK6KoYZaQprG3AwswCbZ0+DtSULxJg6P5XmY09RLuo72/FFTir2Fueiqr1vk0rGdPG1O/t3bbZ7KKzVVjhemw6dXgcbtRXW+y6AnYUNDlenILE+B2u85wjnilEWHbTIbD6E+NqvMck+CnM8NsHBkqNWpsKpU6cQGxsrNuKRRx4R//7Tn/6E0tJSfPvttygpKcGMGTOEk2XYjhw50jMGSaZPnToVy5cvF1LqixYt6tODiuq6du3aJRy2uLg4PProo2J8peTUCY5UMUZTUlCDSYEe4ifDMCPLwewCBHq6Yf2MCHxx6pdms4xpklLL9TdjESuVBeZ5ToGTpS3sLW3xQ/kBtHRThBGY7hoq+o19WvSj+L2puQjBDt6wt7DlXlcmQoOmXDQMDnWaj3me14xo1MrUoUQGQ/2T3OMOlYsuuui8mUvGZDVR1GrLli3n3ScmJgYHDx6EqcCRKmZI0urcr4phRgf6m/Nl/BkEe7ohLsiPp51hRgCNXosvi4+hsLUG1mpLuFufLZZ3s3LEDLdQHKhK7tnX2coBQQ7e6NR19TxG0SxG+ahVVvMhnKr9SkSt5nps5qgVowjsVDFDEqvw9nOFJacjMcyo0NrZhS/iU7E6OgwTnR151scgHrb2CHHmtGlTZ39VKraVnkKc+xRRPzXdLRSFrRUo7/hFbGSR5zRkNBehrqsZXjZuWDlxFi71nYdV3rOgHoEIATM0GjUVImpV31WK+Z7XINghzqwUAke6TxVzYXimmCHVVbW1dsF7Euctj0UsLNSImuyNhTOCMTsqAPNighAyyQP+3q5wd7ZX2jxmEPKr63Ekpwib53B91VjE18EZN0XEIsyVW1KYOrktFfi4cK+opyLHiTYDc9wjYKW2xJnGAhHFWuc7D23aDuyrTIROr8d6vwXsWJlM1OowTtZ+BV/7CCG/zn2tmNGCnSpmSJQU1sA/mBvvjUW0Wh3Cg7ww2d8TpVWNQprU1toK65dG444r58OF+1mZLD9l5qGxrQOXz4hS2hRmGLVWX+aewQ1TZyDaYyLPn4mj/7kWp7GrBVEuQZjvESkcKkoFjK/LRLOmDXM8IlDaXoPDNalo0LTgUHUKunVaWMigosjIF7U6Wv0x6rsKhGMV5LgQaozv86PVq0dsY4yDZ4oZEsV51QgInsCzNsYwyB3HpxVDrVKhrLoRqTnl8JvoIhys4ymFZljWO7bqqz4/mQJfFycsmhyotDnMEEmuqcAnWcnYHBaN2Ak+PH9jgMK2SnxZclDUUXXpNPi+7ChK2qsR6uQHb1t37KtM6Nl3spMvPG1coOklv22pYh0wU4ha5bccRmLdx/CwDkKcx01wseL6VGbk4E89MySKC2qwckMsbGyt0NnBTWXHCgahncLyetQ3teP6S2ehu1uLxpYOJKQVo7iyQWkTmQvQrunGJ6eScduCOJQ1NiOvpo7nbAyRXleND9ITccPUWFhbWOJ4RbHSJjEXoEnTip0VJ3t+pybAMa6Tcaw2XQhcEI6WdohxmYwTdRni93CnIEywcYO3rSfSmvKQ1pTL86wwLd3ViK/bAn/7OExzuwKV7WnIazkArX58rWH0UEE3AjVkNC5jHBypYoZEa3MH6uta4BfI9QFjEUr/s7O1gp+XC3JLarDjcLpwqGaE+2FmhD9C/Tm105Qpb2zG9ymZuCouGq52tkqbwwyRnMY6vJ0Wj9WBYVjsG8TzNwZTAys76tCo+aUH2dIJ01HRUYfitioEO/hg8YSZYp/DNUmIdpmM6a7hitrMGNCjuO0UTtW+DztLN8z2uBUeNiE8PYyssFPFDJmS/BpOARyj+Hu7IbOgCvtPZqO5tRORId544NolwqlysLPC3JggzI/hxZ4pk1RSjpTSSlwzOwaWav4KH2sUNTfgf6knsXRSMFYGhCptDjNEOrRdWDYxFuFOAVjtPRsu1g6i1ork2Ge7T8Wx2mRktxSivKMaJ+vOiMbBjOnQoW1Ecv3nKGg9gqnOazDRNhLjBa6pUh5O/2OGTFF+NRYsi+CZG4MciM+BTqeHWq3CdWvj4Ohgiz3HMpGRXymet7crwc3r5yAxswQdnb/UBzCmxY60LNwyPw4bYqbiy6Q0pc1hhkhZazPeSDmB26NmwcZKje8Lz6aOMaYPiVPUdDaJJsC1XU1CpKJV24E13nPQ2t2O1Macnn3DnAKh0Y2vFLPxQkV7Kuo689Gt/6Xn2FhHp1eJbSTGZYyDnSpTQSeDTIARHarleH1pQQ3c3B3g4Ggj0gH7oINkVBLHUEmdB2GDHGOoTMCGvr9rfnaUJgd5ob6xDR98c0LIARsstdADFVWNQLdevL/UYzCZuRxOS/j+Y8jwd0UlUXzKcBw6rR6fnUjB3UvnYI7/JJwsKDF+DBmCW2qp8ymDv66TekLkWCeohz9IdXMbXk88iTtmxMFGZYWvcs8MSyxGho8otONkzaRSSf+uUasu3Mz3dH252AxMsPGEj6033svfC93Pr6dUQAcLF/xQdRxt3WOvQbB2nCyktef7oGt1Py+DB18Kd2jZKWaMh3NHmCFDAhVVZY3wD+L6m7EIrUWptqqovE44VAaoZ9WVK6ejo0uDTg1HqUyd5o5ObD2ZjFVRofB3c1HaHGYY1He24/XUEwh0dsNVYTFCmZMZe7RrO1HSXoM27dmoh43aCnM8piKtqVCIXTDMaKCFesQ2xjh4pphhpwD6h7C0+liE/KiKmiaETDrrFHt7OmHZ3CmImeKHzPwq7DiUrrSJjJEU1TVid1oOrp4TA0cba563MUhTV6dIBfSyd8D14TNgKUcokRlVNDotHCxtcYlPHALtJ+KKSUtQ39WM9KZCaPUypG8wDDMm4G9vZlgUk1PF/arGLCdTi8TPq9fMxOUrZkClUiEluwzHUwrg7GiLBTOCReTKy91RaVOZC3AivwS5VbW4enYMLCSkozHK0drdhTdTT8LBygo3R8yENTeRHVN06jT4pPCg+Bni6IvcljLsqjglRC0YZrRrqkZiY4yDa6qYYVFeUgdbOyu4eTiivvYXeVlm7PDNvmQ4OdiiubUDWp0e1lYWWLUgAtOm+CIzvxKODjbw8XbF+9+fRLfIPWdMlW3JGbh90SysjgrDDylZSpvDDIMObTfePhOPGyNicVtUHN5NSxCPMWOHvZXJsLXU9OlrRTLsDMOYBxypYoaFtluHsqI6TgEcw5Aj1dDcLn5O9vfEvVcvhouTLV779BC+25+KXYczUFrdiIviWPbZ1NFodfjkZDKm+Xljhr+P0uYww6RLp8V7aQlo69bgjujZcLTilM6xDDtUzGiig3rENsY4eKYYSSmAgVxXNeah2vipIROF3PrWHYloaevsea6xuR21jW2K2scYR0NbB7aeSsGlMeEIdHflaRujdOt1+CgjCdVtrbgreg7cbOyUNomRCRKwYBhm/MJOFTNsCnOqMCl4AtQWfBmNZbw9neHiaIeUrLKexygVkOqqZkUGoLKuWVH7GOPJr6nH9pQsXDMnBu4OvBgfq2j1enyanYyshhrcM20ufB2clDaJkUiQgzduDl4Nf3svnktmxGTwR2pjjINXw8ywqalqEvLqvv7uPItjmPLqJthaW8LL4+zCbWrwRKxcMBVuLvb47mAqyqoblTaRGQIJRWVILC7H9XNnwNaKy2bHMtvyM3CorAB3Rs9GmKuH0uYwEihorcCRmjPY4LcQiyeQfD4vvxhmvMGfakZytCpwMt95G+scTykUkal7r1mM6eF+qK5rQVJ6CYorGpQ2jRkGu9OyUdvShqtnTePeR2Ocg2UF+Do3Tcitz/TyVdocRgKpjfnYUrhHRKuuDVgGd2uOQDLywep/ysNOFSOJwtwqBIVO5Fkc45zJKcd3P6bi812J2LozAYnpJSitauzTHJgZO9Bp+yw+FfY21qLGihnbnK6pwPvpiVgXNBUXTwpR2hxGAtS/6pOifShorcS1gSsww5WFgBhmvMBOFSNZrMLN0xGOTrY8k2OcTk23iFDRglzTrVXaHEYiGq0WHx1LQrj3BMwL8ef5HOPkNdXh9dQTmOvtj40hkeAqh7GLTq/D4ZoUfFNyCLPcw7HRbxHsLWyUNosZ4+j1auhGYKNxGeMYFwn3ep0OepWEPjoSO56r5LibL0fXdZ1EO4ZxHJ3tXagorUNAyASkJRVBpZN+HHqdWtl5oHMqw+lQaSXaYSl92aSS6BupLGAScwmdCZxPGT7mks/HED8aza2d+PjIadyyaCbqm9uRVVEz5DEGNkTiy2VoUqxSSzwhMsyDvlsG12YIQ1Q2teK/Ccdxa3QcbpwyE59kJKNL+0tfpOGiIwlQqUi8sFQyfMC6NGNrSZPT3IA3W3/EKp8ZuC5wLbaXxSO3pUJps0wGWtBLRSvxg97ZLf3zxZgP7H4ykinK4RRAhjFVyhqa8E1iOq6cFY2Jzo5Km8NIpKmrE6+fPgFrCwvcETMLDpbcy2os06nT4LvSk9hXkYx1vrOxynsGrOS4m8WYHVqoRmxjjIOdKkaWuir/kAlQyXG3k2EY2TlTWonDWQW4bt50ONjwInys06Htxjup8ahtb8O90+bCw9ZeaZMYiaQ1FeOd/L3wsHHG9UEr4WXjxnPKMGMMdqoYyVSWNUCn1cHbj/8IjCdC/D0xOypAaTMYmTiQVYDC2gZcN3s6LNX81T8uelllpiC1rhL3RM/FJEcXpU1iJNKkacMnhQeR1liAqwMuxhz3qVBxlIAZQuXDyCgA8ikwFv7LyshCUV41AkNZWn080d7RhSUzJ8PJnguoxwvfJqYLRcfLYyOVNoWRiR2FWdhXkovbI2chwm0Cz+sYRw89TtRl4NOiHxHpEoRN/kvhbMmRSObCjIRIhWFjjINnipGFwtxKBLK0+rhrCpxVVI2LZrHk73ihW6fDJydPY5KrCy4OZ2nu8cLRiiJ8npOKq8JiMHciKz2OB6o66/FRwW7UdTXhhqBViHAOVNokhmEuADtVjGxNgCd4O8PegaMa44n9J7MRFuiFSV6uSpvCyERrlwYfnUjC3GB/zAzgZrLjhTN1lXgnPR4r/ENxaRCljTFjHY1ei72VCdhRfgJLJsRgne982LH0OjMIOqhGbGOMg50qRhba27pQWdqAIE4BHFc0t3XiSFI+Vs0PB+uQjB+qmltFxOqS6CmYMtFTaXMYmShqbsCrKccwxdUTN0yNhY0Fq8iNB/Jay/B+wS7x75uCViHU0U9pkxiGGQB2qhjZyM+uQEiYN8/oOOPkmUJYWlhgZgSnFY0nCmob8HVSOjbPjIafq7PS5jAyUdfZLhwra7UF7oqaC2drzh4YD7RrO7Gt7Cj2V53GSu9ZuMRnHketmD5o9aoR2xjjYKeKkY28zAoEBHvCwoIvq/GEVqfHrmMZWDpzMhxsWY57PJFaVom9Gbm4Ye4MuDvYKW0OI6fkeno8ilsacH/MfExyZKd5vJDZXIT38nfAQqUWUaswx0lKm8QwzM/w6peRjbrqZrS3dmFSEKcTjTcKyuqQV1qLi2eHKW0KIzPH8ouRWFSGm+bFcg+rcQSpPH6dl4YDpfm4PXI2Znj6KG0SIxNt2k58V3YE+6uSsMJ7pqi1sudaK7OH1f+Uh50qRlbycioREjaRZ3Ucsvd4FqYEecF/IotWjDd2peegpL4JN8yZDiuuwxlXHC4vxJas01gfHIHVAVO45HwckdlcjHfzd0Kv1+Pm4NUId+IUbYZREktF350xLfTSO7zlZZZj5foZ+FHCWCqJdqhkaFQn1QaBxDxklQwd91Raaa9X93p9a3MHjibkYvW8qXj3q2PiTrgx6NXS87HVaolzIYMNcrTqkCr2oZLBhsGm4ptTZ3D9vBm4duY0fHz8tEj7HAyd1OOQIUVfJXky5bBB+hjSyxUufFFkV9fh1ZYTuDEyFl42TtiamYxO7S8fbjl6e+okvr5bBhvGC9Rw1VjaNHp8VpSAKU6+WO0Th2CHYPxUdRKt2o5Rs2GkxpCjP5JW4ge9q3vsiL0Ipb4RqH9i9T/j4UgVIyulxXWwtrHChImcwz8eOZVaBLVKhZmRfEd0vEFO1CcnkkUK4MaZUUqbw8hMTXsbXk06DkuVCvdOnwt3W66hG09kNZfhf7l7oNFpcXMw9bUKUNokhjE7FHeqSktLccMNN8DDwwN2dnaYNm0aTp06pbRZzDDRaXUoyqtGyBRWARyvC+/dRzOwKG4yHOxYtGK80dWtxYdHk+Dr6oS106YobQ4zAgIW755JQFZ9De6bMQ+TXdx5jscR7doufFd6EjsrTom+Vhv9FsLB0lZps5hRQj9CPapoXGYMOFX19fVYuHAhrKyssH37dqSlpeGf//wn3NzclDSLkUheVgWCQ7muarxSSKIVxTW4eA4vuscjrZ1d+OBIIiJ9J2JJeLDS5jAyQ6l+P+RnYXt+Fm6MisU8H446jzdyW8rwXv4udOi6cEvwakQ5ByltEsOYBYrWVD377LPw9/fHO++80/NYcDD/ER/rFORWiboqB0dbtLZIy+tmTJN9x7Nw56YF8Pd2Q3FFvdLmMDLT0NaB948k4LbFs9DW2YVTBaU8x+OM+MpSVLe14obIGZjo7IDv8tONrpNkTB9yqHaUn0SIg49QCAx3noTdFfFo7m5X2jRmhKB6qhGpqeI+VWMjUvXtt99i1qxZ2Lx5M7y8vBAbG4s333xz0P07OzvR1NTUZ2NMj472LlSU1iM41EtpU5gRoqWtE4cT87Bq4VRRY8WMP6qbW7HlWBJWRYUhyo8jz+ORouYG/CfpGPwdXXBb5Cw4WHJK73gjr7VcRK1auztErVWMa4jSJjHMuEVRpyovLw+vvvoqwsLCsHPnTtx777146KGH8N577w24/zPPPAMXF5eejaJcjGmSm1WBkHDuizLeRSvoxvacmEClTWFGiOK6Rmw9mYKNsREI9+b+c+ORxs4OvJF6Ai1dXXhgOjcKHo906jSizmpb2THMcZ+Kq/wvgpuVo9JmMTLDfarGYPpffn4+Dh48iMLCQrS1tWHChAkiwjR//nzY2g6tIFKn04lI1dNPPy1+p3FSU1Px2muv4eabbz5n/8cffxyPPPJIz+8UqWLHyjTJzSjHgoumwtrGEl2dLJY7HqFUoR2H0nDN2jhk5lehvqlNaZOYESCnqhZfxp/BplnR+PREividGV906bT4JPs0FvsG4Y6oOSIVML6KUz7HGwWtlXgvfycWTojGjcErcaouC8dr06HVSxXEZxhmSE7VRx99hJdeekko802cOBG+vr5Cra+urg65ubnCobr++uvxu9/9DoGBxt259vHxQWRkZJ/HIiIi8MUXXwy4v42NjdgY06exoQ11NS0IDpuIzFT+4zxeKatqxOmMEqxdHIkt37Nq53glvbwa3ySm46rZ07Dl+GnkNXId3XjkYFkBylqbcE3YdJESSM6VluusxhUavRb7q04jrbEQK73jRMPgvZUJKGqrUto0RiJcUzVG0v8ogvTyyy/jlltuERGq8vJyxMfH49ChQ0KxjyJG33zzTU/k6bPPPjPqzUn5LzMzs89jWVlZRjtljGmTm1mOUE4BHPcciM+Fs6MtZkz1U9oUZgRJLa3E98mZuG7udAS4u/Bcj1NyG+vw7+Sj8HVwxt3Rc+FszTcyxyNVnQ3YUrgPCfXZ2OA3H5f4zIW9BZ/rscxIyKkbNkZGp+rvf/87jh8/jvvuu2/AdDuKHl100UUibS8jIwMhIcYVQj788MM4duyYSP/LycnBli1b8MYbb+D+++830nzGlMlOL0fQZC9YWY2djuTM0NF0a0Ua4EVzpsDJgf8oj2dOF5djZ2o2bpgTCz9XbvA9XmnsOltnVdHWjAdiFiDYmducjEf00ON0Qy7eyd8J0hu6NWQNprOQBcOMrFO1evVqowajVEBq4hsXF2fU/rNnz8ZXX32Fjz/+GNHR0Xjqqafw4osvijRCZuxTV9OM5qZ2BE5mFcDxTkFpHbIKqrBqQYTSpjAjTHxhKfZm5uLGubHwduZi9/FKt16HL3PPYE9xNm6OiMMSX253Ml4hZcDvy47j+7JjmOUejmsDl8HTxlVps5hhpv+NxMaMYp+qXbt24X//+x++++47tLcPrQfCunXrxDam0clQ5ClH3rrUMeSoVe03RnZaOSZP8UFOWvnoHYcMc6nSyjCGhbQxVDrpX2QqiedUpTV+3x+PZOKOzQsRGTQR6bmVv4whQ6ByNI9jMNRyaKVKHUMGzRcZLiucyCmGFdS4ee5MvHM4XsivDwWVDHOpljgXOhlaAZhCNwE5Okvpz3NCjpeWoaSxBddNnY5AB3dszUpBh3aAyVcp/+fHFCSR5FiA6q2UubAyGuuQ3bQPCzynYqPvaiQ15OJI9RlRhzUcpKaNyZF2JvV8dHUrKpLNjDGGfbVQbdUTTzyBoKAg0WdKrVbj/fffl9c6ZlzUVZFYhdqCv5jGOx2d3dh9OB0rFkyFnY2V0uYwI8zhnEKcyCvGzQtmwsPBnud7HFPa0oR/Jx0T/34wdj78HDn1c7xCSoAHq9PwQcEeeNu64daQ1Qh19FXaLMYIOFKlPENa6XZ1deGTTz7BihUrMHXqVCQkJKCkpEQIVtDj5FwxTG+qyhvR2d4F/yDucWMOkLR6aWUDls0PV9oUZhTYn5WPxKIy3LJwJlzth9ZSgxlbtHdr8H56Ik5UFOOuabMxx3uS0iYxI0hdVzM+LfoJh2vOYJVPHC7zWwBnS755wjCyOFUPPvigkFEnWfXLL79cOFOU7qdSqWBhwUIEzODkZJQjLIIbAZsLuw5lIDTQEyH+HkqbwowCe9NzhTLgLQvi4GLHQiXjnZ9KCvDumQSsCJiMq6ZEw1rNf//HM2caC/FO3k50aLtwc8hKzHKfAjWrwZkkHKkaQ07Vq6++irvvvlvUT5E6HwlSMIwx5GZWICTcWzjgzPinpa0T+49nY/WiSFiz8qNZsPNMNrKraoRj5WTLjtV4J7+pHq8kHoWLjS3umzEXXnYOSpvEjCDt2i7srDiFL4sPI9olCNcHLYePrTvPOcMM16n64IMPcOLECdGw9+qrr8a2bdug1cpQ/c2Me8qK66DT6jEpkB1xc+F0RikamtuwdHaY0qYwowT1sCqobRA1Vg421jzv45xmTRf+l3IK6bXVwrGK8fBW2iRmhCltrxG1VpnNJdgcsAQrvWfCjntbmQwcqRpDTtW1116L3bt3IyUlRdRTUbTK29tbNPylBsAMcz5yM8oRyimAZsWOA2mInuKDQB/ucWMufHs6DWUNTbh1IUeszAFSHtxZmI1PMlOwITgSV4REcTqgGQhZnKjNwHv5u2BvYYvbQlZjplsopwQyzHDU/4KDg/HnP/8ZBQUF+PDDD3HllVfihhtuwKRJk/DQQw/xpDIDkpVWhtCpPpwCaEbUN7Xjx+PZuHRxFGysZenewJg41M3gq8QzKK5rwG0L4+Bqx+IV5kBGXTVeTj4MTzsH3DdtHibac/+y8U6jpg3flB4R/a1iXENwU/BKBNhzT0qlb3KQDL3cmxxtG8yFYetcU30MNQXeunUrysrK8Jvf/AYHDhyQ1zpmfKUA6vSYFMQpgOZEUnoJahpasWoeqwGak2P1TVI6sqtqcduiWXB3sFPaJGYUaOrqxJtnTiCltgL3Rs/DnImsDmgOFLRW4v383UhpyMcGv3lCJdDFilUCGfNEluZB7u7uWLx4sYhWMcxA6PV65KSXYUok97swN74/eAYhkzwxNYjvYpoTP6RkIqW0ArctnIUJjixkYA7QHe29Jbl4PyMByyaF4rop02FrwVHq8Y4OesTXZ+OtvJ1o03bgluDVWOQZBSs5Or8zxp8HvWrENmYEnKqdO3eKiNT//d//IS8vTzyWkZGBjRs3Ys6cOaK+imHOnwLoy42AzYzW9i7sPJKO1Qsi4GDHAgbmxO60HJwqLMWti+Lg7cwpYeZCXlMdXjl9BFZqCzwYswD+ji5Km8SMAu3aTuyuSMAnRfsxyX4Cbgy6BOFOgTz3jNlgtFP11ltvYe3atXj33Xfx7LPPYt68eaKmav78+UKwIjU1FT/88MPIWsuMacpL6tHVqUFgyASlTWFGmYyCKuSV1OCSRZE892bG/sw8HMkpxC0L4+Dr6qy0Ocwo0drdhfcyEnCkohB3RM3GRX4h3N3ITKjsqBeO1aGa01joGYNNk5bBy4YFi8wpUnXgwAGsX79e9LelcqGvv/76nOylP/3pT0JR3M7ODitWrEB2dnafferq6nD99dfD2dkZrq6uuP3229HS0tJnn+TkZJEpZ2trC39/f/zjH/+Akhgdl6emv+RM/fa3v8UXX3yBzZs347///a9QAxzzaX86/fiwgYoZJKDSj7wNWamlmBrli4KsisGHkBjwVGmlH4dehqwFlQkch0pigq9KJz3sr/75OPYczsBtV8zHzDBfJGWUDmkMvVqaHSq1DHOpVSl/PmTIwlDJ0AljqKfjSEYhtF063DJvJrYcTURBU6NkG6TmRUi8pM4iwxhUCD4e0A9yj/ZQUTHy6xpxTfg0hDlNwKdZKWjs7BhoAMnIkSvTLfH1ehNIlZIjXUuO40isq0BqfTXmekzFZb4rkd5UjAPVqSKiNVrH0a2T9qWr0chSJWN2tLa2Yvr06bjttttwxRVXnPM8OT8vv/wy3nvvPSGA98c//lHoNJCaODlIBDlU5eXlQnlco9Hg1ltvxV133YUtW7aI55uamrBq1SrhkL322mvCH6H3IweM9lMCo6+W3Nxc4UgRNEGWlpZ47rnnxr5DxYwqWWdKETzFG1bcFNbs6Ozqxg8HzuDiOVPg5sziBebG8bxi7ErNxvULYhHsyXetzYnSlia8kngM1e2teGjGfEzznKi0ScwoodFrcajmDN7J3wUbCyvcOXk14tzCYCH1DhNj0pGqtWvX4q9//Ssuv/zyc56jKNWLL76IP/zhD7jssssQExOD999/X4jeGSJa6enp2LFjB/73v/9h7ty5WLRoEV555RV88sknYj/io48+QldXF95++21ERUXhmmuuESrkL7zwgmJXh9FXdXt7O+ztzyq6UCjPxsZGhO0YZijUVDWhqaENwVP4j6o5UlhWh+TMUqxbOk2WqAsztkgoKMX3SRm4ds50hHmxEqg50aXT4qucNHyZcwYbJ0dic1g0bCxYyMCcJNi/LT2Gr0uOYpprEG4OXoFgB14HjFen6nzk5+ejoqJCRJgMuLi4COfp6NGj4nf6SRGnWbNm9exD+6vVahw/frxnnyVLlsDa+pdabYp2ZWZmor6+HkowJFke8hgdHc8WG3d3d4v6Kk9Pzz77cK8qxphoVXj0JGSdOXu3gTEv9p/KwS0b52Le9GAcTcpX2hxmlEkurkCXSoerZk3DV4lpSCuv4nNgRpyprUJxcyM2hUXjodj5onEw/c6YB0Vt1Xgvfw9muIXgUt85KG+vw/6qFNR2NSltGnMBKN2uNxRcoW2oVFScLf+YOLGvU02/G56jn15efRWDKUOO1MZ770Opg/3HMDzn5uZmuk5VQEAA3nzzzZ7fSZzigw8+6LMPRbDYqWIuRGZqKeYsCYeNrRU6OzQ8YWaGVqvDtv2puGH9bOSX1KCipllpk5hRhhypbp0Om+KiYWmhRnLJ4DWWzPjsafX2mXgs9A3EHdGz8FNJPvaX53CTUTNBDz0S63OR3liEeZ4RuDFoGc40FuJQTZrR9VbMAPOqV41ITZ9hTBKC6M0TTzyBJ598kk/FcJyqgoICY3dlmPNC6X9VZQ0Ii/RFakIhz5YZUlnbjCNJ+SIN8J2vjwlHizEvsipr8MmJZFwzJwaWajUSijhybW4cLitEXmMdrg6fhike7tianYL6znalzWJGiQ6dBvurkpFUn4ulXjGi3upoTQYS6nOglapYxchOcXGxUOIzMJwolSEoQ1RWVvYpI6LfZ8yY0bNPVVXfLAbKkCNFQMPr6Se9pjeG3w37jDayVgqWlg5N0Ysx72jV1Ji+dz0Y8+LY6Xx0dGmwbM4UpU1hFCKvpg4fHUvC6qgpWDA5gM+DGVLe2oz/JB0TPx+avgCzvVj8ytxo0LTim9Kj+LL4CCKc/XFHyGpEOgdANU6UMUcLUhIdqY0gh6r3NlynKjg4WDg9e/fu7ZNaSLVS1KaJoJ8NDQ2Ij4/v2Wffvn2iHy7VXhn2Iel2UgY0QEqB4eHhiqT+yeZUUe7igw8+iLCwMDmGY8ykrmqirytc3ByUNoVRCFLf/25/KqJCvTElqG/uNGM+FNY14J3Dp7AwNBArI0OVNodRAI1Oh2/z0/FRZhKW+0/GzVNnwtl6eAs2ZuxS0l6D9wv2Ctn1hRMicW3ASgTaKxNxYKTR0tKCpKQksRnEKejfRUVFolTo17/+tVAH/Pbbb4UU+k033SR6Wm3cuFHsHxERgTVr1uDOO+/EiRMncPjwYTzwwANC4Y/2I6677johUkH9q86cOYNPP/1UtH965JFHFDt9RjtVpKRx7bXXCmEKOiDSlyePkZp3hYSE4OTJk3jnnXdG1lpm3NDR3oX8rApExPBdSXOmsbkdPxxIwyWLI+HixDLr5kpFUwveOnQKkT5e2DgjkpUhzZScxlq8mHQYbd0a/Gr6QsR48ILaHKF+Vm/n7UJ6UwHW+MzD5X5LMcHGVWmzTB5TUv87deoUYmNjxUaQo0P/Jp+BeOyxx0QwhvpJzZ49WzhhJKFu6FFlkEyfOnUqli9fjksuuUTIqr/xxht9FAN37dolHLa4uDg8+uijYnylelQRKj0JxhvB3XffLQ6YelXt3LlTNOgi6UKSNySt+Xnz5mG0oXAhTeoy+2tgqfpFUnGoqHrJMQ7r9TbSXi+wspI+hlQ7rIYkBjkgemvjxyBZ9YtWT8M7r+zp87huCGMMaIOV9ACszlq61K9Ooh06K+mpD1LHkHoMZ8e48D4r5ofDz8sFH353EtoBGmFrJR+HpJefHcNSjvMh1QbJJsgyht5yZObB0cYaN86LRWN7Bz6LT4HmPLV2Uo9D6jEIG6ykd6yVfhwyNDuXYwyJc6Gy7Huuo9y9sDEkCrmNdfg2P004WkMdYzioraSNYSGDDVaWWkVfT9haSm2DDFhLHMPOUgMbtRVmuUdghmsYsltKcLQmBc3dbUaPYWshzQZNaxe2r3kTjY2NfeqJTAnDWnju1w/B0kH+CG93ayeOb3zZpOfAVDB6xbR9+3YRiXr++efx3XffieZdVFC2bds2RRwqZuxTmFMFC0sLTArkfjXmzo/Hs8TPi7i+yqxp6ezCO0fiYWNliZsXxMHeWgZvmBmTnKmrwkunDwsRk1/NWIipbhOUNolRgE6dBodrkvF+wXax7rwpaC0We06HjVqGm9njVP1vJDZGZqeKOhhTjiMRFBQkQnQ33HCDsS9nmHPQ6fTIPFOCiOksWGHuUHTqm30pmBbmgymBXF9lznRouvHB0UQ0trXjjkWz4GbPaaHmSoumCx9mJmJHYRauCovB5tBpsLWQIcTIjDkoOrW78gQ+LdoDdxsX3BJ8CeLcpsJCJaveGsNIwuhvJ7pDQI23DFhYWMDOzkT+2IkMRr3C728CSLVDjuMY4hjpSUXYfMsi7P8hGRrN2ZQFlU5a+oReL/1LVjVACtqQx9BKTIexkH53SKUzhXkw7jgaG9qx/ac0rF0ciarqZlFvZUAt8ZTKcEnIUucj9e+/LDbIcdNRNbI2aKHD58dTsTo6DHcunIWPjp5GWUOTvMchy1xKH0Qt8W+XQZlrrKM/zz3ehPIK5NTW44rQSDw8fTG+yklDel31iNihlXpXXo67+mPvT/mAaHUS07YHmMtWTTsKW48h0N4LF02MRpRzOA7XpCO1oRC6ASauWyftS7dbYyLrOyMYbv2TMeMyI+BUUbGYwbFqb2/H+vXrhfJGbxISEowdkmFQU9mExvo2hEb4Ij25mGfEzMnKr0Kgjzs2LJ+GLd8OXF/FmA87U7NFfdUti2bi81OpyKqoUdokRsGGwe+mJSJ2gg82hUUjq74G3+ZloN2IWitm/FHYVoX38vch3GkSFk2IxBz3KaJ5cEZTidKmMWaM0U4VdU7uzWWXXTYS9jBmSPrpIkTM8GenihHsO56FGy+bjaVzwrDv2NlaK8Z8OZZbjMb2TmyaFS2crPgC7odoziRWlyOnoRYbQyPxyMyF+CY3Dam1fZuEMuZDZnMJsppLEe0SgIu8pmGuxxQcqDqD/Na+TWHNgZGqf+KaqlFwqhhGzkbAC5ZHwsnFDs2Nv6R8MeaJVqvDN3uScfPl81BUXo+cwpFJ82HGDullVWjr7MI1c6fDxc4G+9LzlDaJUZBmTRc+SE/C9AneuDw0CtM8vfFtXjra9J18XswQPfRIaSxEWlMxYt1CcKnvbNR2NeNAVSpquszPuWKUw+hk046ODtGkq7m5eUA5R3qus5O/0Jih09baiaLcKhasYHqob2rHjoNpuGRpFJwdf+lbwZgvhbUNeOvgKcT4+2DjzEioZSkOY8Yyp6sr8K+Ew6K27eGZ3NfK3NHqdThVl4M3cnegsLUKm/wXYqPfIrPpcaUfoR5VHKkaAafq9ddfF52KnZycznmOdOupGfCbb745hLdmmF9IP12MiJgAnhKmh4y8SqTnVuCy5TGwUPMCmgFqmlvxv59OYqKLI26YOwPWltL7yTFjXyFwS8ZpfJ2ThnXBEbghfAYcrVhu25zp0nXjSE26cK7quppxTcAyXOIzF65WjkqbxoxzjHaqqLPxr3/960Gfp+fef/99uexizIy87ErY2FrCj3tWMb2gmioLCxWWzZ3C88L80svqYLwQT7pj4Sy42nEkk4Goq3ox6RA0Oh0enrEIs7z8eFrMnHZtFw5Un8Y7+duFo3VT0Cqs8p4FZysHjEeEDrZ+BDalD2w8OlXZ2dmYPn36oM/HxMSIfRhmOOi0OhGtmjYziCeQ6VNf9dXuZESGeIseVgxDdHVr8eGJJBTVNeCuxbMxyc2FJ4ZBW7cGn2YnY2t2Mpb7h+KOqNnwtLXnmTFzWrrbsacyHu8X7IIKKtwStBorJsbB0dJE2gLJBLVXGKmNkdmp6u7uRnX14AXj9BztwzDDJSW+AJOn+sDOnlM3mF+gflVf70vGqvlT4ePpzFPDCOgO6raUTPyUlY9b5sci2ncizwwjyGyoEVGritZmPDh9AS7yC4EF1+CZPQ2aFuysOIkPCnfDWm2FW4PXYrKjr9nPC6OAUxUVFYU9e/YM+vyuXbvEPgwzXBrqWlFeUoeIaf48iUwfCsvrcSA+F1csnw57O3a6mV84XlCCT0+lYMP0CFw8JYSnhhF0arXYVpCBN8+cQIynNx6IWQB/R45oMkB9VzN+KD+Gjwv3orS9ZtxJqo/ExsjsVN1222146qmnsG3btnOe++677/C3v/1N7MMwUqNV0bEsWMGcy8kzRSgsr8Ply1i4gulLdlUt/nfoJGb4+2BzXDQs1Ub/aWPGOSUtTfh38lGcrinH7VGzsTEkEnaWVkqbxZgANV2N6NB2KW0GoyBFRUU4ePAgdu7ciYSEBMkq5kb/5bnrrruwceNGbNiwAZGRkbj88svFFhERIR5fv3692IdhpJCbWQEbGyv4B3nyRDLnsONwulB8Wz43nGeH6UNVcyveOHgCzra2uG1hHBxsOKLJnEWn12N/aR5eSjoMF2tbPDJjEWZO4LQvZnwxEnLqhm08UVBQgN/97ncIDAxEcHAwli5dirVr12LWrFlwcXHBypUr8dlnn0Gn0w15bJWeJJSGwNatW7FlyxYhSkEvnTJlCq677jpcddVVGG2oPxZNwDK7q2GpGv4fUJW1tD++Kjn+eFtZKT+GldG9oAdFbyN9jAWrouHi5oAfvjw1PBuspMss62WQatZZS7tbrrOSfrddZynty1BnJf3LVJbj6HVpU9+qWzbOxf4T2UjOKhuVeTg7huQhoJU4n3oZbJDjOHQW8p1PueeColQbYiMQ6OGGT0+cRllD84jNgymcD72ldG0ueeZCr/hxwMgxojy8sC5kKuo62vFNbhqq2lqHPMagWAx9IdYftZW0MSwspdtgIcNxWFlqJb3e2kp6nb61hTQbuls7ceqKF9HY2CjaB5kihrVw9NbfwsLeRvbxtW2dSL3qOZOeA2N56KGH8N5772H16tUiGDRnzhz4+vrCzs4OdXV1SE1NFZGrTz75BBYWFnjnnXcwe/Zso8cf8lcpOU9KOFCM+ZCaVIQb7roI9g42ojEww/SmqaUD3+xLwZUrZ6CmoRVlVY08QUwP3Todvow/g4WhgbhlYRy2nc5AckkFzxDTw5naKuQ01GJ5wGTcP2MejpQV4ceiPHTppC3AGUZJDBLoIzHueMHBwQF5eXnw8PA45zkvLy8sW7ZMbE888QR27NiB4uLiITlVRt1Cbm3tdRdnBPZnmN401reirKgWkdNZsIIZmMKyOhyMz8HGZTEsXMEMyOGcQmw9mYJLYsKxMioULP7G9Bey+CE/C6+ePo5gFzf8auYCRLhP4ElimHHMM888M6BDNRBr1qzBFVdcMaTxjXKqQkND8fe//x3l5eWD7kOpgLt37xZ5iS+//PKQjGCY/qQkFmJabCBPDDMoJ1OLUFRej8uXT4eFenzlfDPykFNVizd/Oolw7wm4ft4M2MqQ4syMLypaW/Da6RP4sTgPV06Jxg1TZ8DVhhtKM2MPVv+Th46ODjz//PPDeq1RTtX+/ftx8uRJUdA1d+5c3H///ULt75///Cf+8Ic/CE+OchJJ/Y9yFB977LFhGcMwBvKyKmBhaYHAEL5zyAzOjkNpsLJUY8X8qTxNzIDUtrbhzZ9OiBSWO5fOhqcjN4NlzuVUZSn+FX8I7d0a/GrGQizxDYKaw5sMMy6prq4WaubUDkqrPZv2q9Fo8NJLLyEoKEgEkoaDUbftwsPD8cUXXwjpQVLEoCKuI0eOoL29HZ6enoiNjcWbb74polRU2MUwUtHp9DhzugjTZgahMG/wptOMedOt1eHL3adx02VzUF3fgoS0YqVNYkyQzm4tthxPwrKpk3Hn0jn44lQqMmrHT38aRh5aNRp8kXNGOFgbJ0dippcfvs5LQ0FTPU8xY/KMVE+p8dan6tChQ1i3bp0Q+FCpVEL1jwQpSMnc0tISTz75JG6++eZhjT2kXIiAgAA8+uijYmOYkSY1sRA33bMMjk62aGnu4AlnBqSptQNf7jmNq9fMRENTG/JKanmmmHOgSNXe9FxUNrVg06xoHMovxP6sfJ4p5hwKmxvwyumjWOgTiJsjZiKtrgo7CjLRrOGeRgwz1vnDH/6ASy65BP/3f/8nlAAp645aRD399NPYtGmTpLG5QyJjsjQ3tqMwrwoxs4KUNoUxcUgB8IeDZ7BhWQwmejgpbQ5jwqSWVuKtg6cQM8kbN8ydATuus2IG6W11sKwA/0o8BAuVCo/MXITFvkHi3wxjinCfKuNISUkRjlV0dDT+8pe/iGjVP/7xD8kOFcFOFWPSJJ3IQ/SMQFjK0DeKGd9k5lfhSGIeNq+OFb2sGGYwKFr1xsGT0Op0uGfJXPi6sCPODExTVyc+yUrGB+lJmOnlK+qtprpxrS/DjFXq6+tF6RJB/ans7e2FgyUHLIXEmDQlhbUi9W9qtJ/oX8Uw5+NESiFcneyEY/XhdyfR2SW9eSQzPunQdOPjk8lYNDkQty2Mww+pWUgoMq6ZNGN+5DXV4eWkI5gz0R+bQqNR1tqEbfmZqGpvUdo0hhFwnyrjSUtLQ0VFRY96eWZm5jntoGJiYjBU2KliTJ6kk3mInTOZnSrGKHYfzRCNgS9fMR2f7UiAVjeOOhcysnMotxCljU3YPDMa/m4u+D4lUzQQZpj+0DfJ8cpinK4pxzL/ybh/+jzEV5ViT1EO2ro1PGEMM0ZYvny5cKYMkHAFQamA9Dj9NKgCDgVO/2NMnswzpXBwtIF/0NlwLcOcD/qe/GZfCmysLLBmcSRPFnNB8mvq8eqBE5jg5IA7Fs2Cqz2njzKD06Htxg8FmXgl6QhcrG3xm5mLhagF11sxykeqVCOwja/zmp+fj7y8PPGz/2Z4nH4Oh2FFqhoaGvDWW28hPT1d/B4VFSV6VLm4uMAskeOKk2UMnfI2aGUYo1/5lLZLh5T4QsyYFYLiPCNkkOW4ySzHXEiMkKhkiLCodNKKqlUyzKVKhmuC7hoNhe5uLT7/IQk3bpyDxdMn40ByrnQbZGgwrJY4FzoZiuTlqLOXPBUyZGVKvTT731FsbenEewfisSoqDPcumouv4s8gq7JmxL9q1CYhdyz9M6qD8gIOsiz+hjBGjaYdH6QkYbKrO9aFTMVcL398X5iJjPpqRedSL/F7X9hgKcMYEq9Nqa8ntJbSPmHa7rETtWZJdeMIDAzESDFkp+rUqVNYvXq1KO6aM2eOeOyFF14QzYCpidbMmTNHwk7GzEk+VYBbHlgOFzd7NNa3KW0OMwZoa+/C59sTcf1ls9HQ0Y7kLK6XYc4PpYpuT8lCcV2jkF0/nleMfRm54+5OLSMvuQ11eDnhCGZ7T8KmsGiUtTTh+4JMVLZxvRXDmBrffvvtgI9TYGjKlCnw8fEZPafq4YcfxoYNG0SzX2qSRXR3d+OOO+7Ar3/9axw4cMDosajB1p///OdzGg1nZGQM1SxmnNPa0oHczHJMnxWMA7vPKG0OM0aobWjF17tO48pLYkU/q4LSOqVNYsaI7HpFUwuumj0NgR6u+PxUKpo6OpU2izFhyO8+UVGC0/U/11vFGOqtctHazf2tmNG5Bkfi/s94u6e0cePG82bFXHPNNcLHIVXAoaIeTqTqd7/7XY9DRdC/H3vsMfHcUKHUwfLy8p6NOh0zzEAknchH5IwAWFmzvgpjPEXl9dhxOA2XL5uOCe6OPHWMUdQ0t+LNn06gpqUN91w8F6FeHjxzjNH1VqQU6Gxtg0fjFmGhL9dbMYypoNPpBtxIan337t1ISEjAX//612GNPWSnytnZGUVF50pbFxcXw8lp6L0+yCHz9vbu2Qza8QzTn4rSetTXtiByuj9PDjMkzuRW4FhyAa5aFQsnexuePcYoNFodvk1Kx47ULBG1WhEZCjU3f2WMoKajDR9kJGFLRhJmefnh17ELEeHO/a2YkWNkRCrObuaAi4sLli1bhn/961/48ssvR8epuvrqq3H77bfj008/FY4UbZ988olI/7v22muHbEB2djZ8fX0REhKC66+/fkCHjWEMJB7LReyckCELFzDM0dP5yC2pwaZVsbC24mbSjPEkF1fgjQMnMcXbE7csioOzLTvmjHHkNJ7tb3WwtABXhkbj9qhZ8LbniDnDmCpTp05FSUnJ6DhVzz//PK644grcdNNNCAoKEtstt9yCTZs24dlnnx3SWHPnzsW7776LHTt24NVXXxUyhosXL0Zzc/OA+3d2dqKpqanPxpgX2enlQr0sNGL4hYSM+bLrcAZa2ztxxfLpsJBBzY8xw3TA5laRDhjhw1EHZgj1VpUleD7+oBCxuC9mHjaHRcPVhqX7mREoqhqJzYzIy8sTwZ5Rcaqsra3x0ksvidzDpKQksdXV1YlwmY3N0O7erV27Fps3bxZdi0lR8IcffhBy7Vu3bh1w/2eeeUaE5wybvz+ngZkb1JQt4VguZi0IVdoUZgyi0+vx9b5kWFtbYv1F02SRF2fMLx3w++RMXBYbifUxU2FlwVFPxvh6q+2FWXgh8Wzt+COxi3BpcDgcLK15ChnGBCCf5je/+Q0uvfTSYb1+2AL+pIoxbdo0sQ1HIWMgXF1dhZxhTk7OgM8//vjjaGxs7Nko9ZAxP84kFcPRyRaBIXynmBk6XRottu5MgKerA9Ys5ObAzDC+g0or8eqPx0Wz4HuWzIGPy9DriRnzpaGzA59lp+I/ycfgYWuP38QtEoqBNuygM1IYqXqqcVZT5ebmBnd393M2CgzFxcXBy8vrHGVyYxmyjFprayv+/ve/Y+/evaiqqhKKGb0ZbhdioqWlBbm5ubjxxhsHfJ4OeKjRMGb8QY1dE0/kYfbCMBTmSWuyyJgnHZ3d+HRHAm5YPxsXzQrF/lMD38hhmMFobO/AO0fisTg0CHcsnIV9mbk4nMs1wYzxUB+r99MTEejkijVBUzDf2x/7ivNwsrYIWm6OxjAjAmXWDVSXT0J81NYpMnL4N1uH7FSRIMVPP/0kHB9qkCVFMIBCbOvXrxfdjcvKyvDEE0/AwsJiWIIXjHmREl+IWQvC4DPJDeUl9Uqbw4xBmts68en2BFy/bjbaOzU4nlKotEnMGIPWvQeyC5BXU49NM6OE7PqXiWlo5p5WzBAobG7A6yknhDrgqoAwLJoUgD0lOUiqKed5ZIb0fTQSvvh48+9vueWWERt7yE7V9u3b8f3332PhwoWS35zUNciBqq2txYQJE7Bo0SIcO3ZM/JthzkdnhwYp8QXCsfpu6wmeLGZY1DW1iYjVdZfEoVPTjaSMUp5JZsiU1Dfivz8dx7rocNy/dC6+SkpDZmUNzyQzJNLrqpFRV42ZPr5YHTAFi32CsbM4C1kNfC0xjFyQbgM1ACaNCIMvQsIUavXZiqi2tjb8+9//Fv13R7ymypCLKAckxU4RKlL1o4Oi3ydPnizL2Mz4J/F4HgKCPeHp5ay0KcwYpqquGZ/tSsSyOVMQFcqqkszw6OrW4sukNGxLycQVsVFYN41ELIZdtsyYKRQUSKguxT8TDyKhphRXhcbgzsg58Hd0Udo0xsThPlXGQcEcEsUzQOl+BQUFPb+TAjlpOIxKpOqpp57Cn/70J7z33nuyCVQwMsVXpY4hgw0qOY6jX53eYLQ3tyMtqQiz50/Gjq/ie71ehqJKGcZQ6STOhVaG86GWNoZKK9kEqGRYV6p0Ul9//vNZVtGIL3edxhUrp0PXrUNGXuXIzIXEy0oti7at9Gtb4ukYvkKSjEg9hsGOI62oEqXVjbhyVjTuXTQXX8anoqyheUTtkIpahmtC6qVpCn8CCZ3Eonw5/gbq9TpooMehoiKcLC3DEr8g3BY+GzkNtdhVmI2q9tYLDCD9E6aV4W+gXuIYUl9PaLXS5kLbKcMXP2NyKtLn+10KRjlVsbGxfWqnSJ1v4sSJokeVlZVVn30TEhJkM45hLkTC0RzceO8yuLjZo7G+jSeMGTaFZXX4Zm8yNq6Yju5uHXKKWASFkSBicegUFocF4dbFs3AoqwAHswqEpD/DDIVObTd2F+XgaHmRUAh8YMZ8nK4ux97iXKEiyDA9jJRS3zhT/xtJjHKqKPeQYUyRpoY2ZKeXYeb8UPz4Q7LS5jBjnLySWmzbn4oNy6bhqz2nkV9Sq7RJzBhFiFhkFSCrsgZXxEUj3NsTX8afQU0L3/xhhk6Lpgvf5qXjUFkBlvtPxiMzFyG+shQ/luShqauTp5RhxopTRap8RHd3N55++mncdtttmDRp0kjbxjBGcepwNq65YwmOH8hEWwv/cWGkkVVQhe0HzmDj8hh8vjMJxRWsLskMn4rGFryx/wQujgjB3RfNwd60XBzL4x6LzPCo62gXPa5+KsnH8oBQ/CZuMY5XFIvfyfFizBdW/zOenTt3wsXlbJ0itYaiNlGpqani9971ViNaU2VpaYnnnnsON91007DfkGHkpq66GUW51YidOxmH96bxBDOSSc+rhKWFBa5cNQNbdySgrKqRZ5UZNt06HXafyUFWRQ0unxmFKd6e+CYxDY3tfBOIGR5UV/Vx5mn4ODhhRcBk4VwdKy/CT6UF6AA7V2YJZRePRIbxOMxavvnmm/v8fvfdd/f5fbjtooZcwbds2TLRp4phTC1aFTMrCLZ2ZyUyGUYqKdll+OlkNq5aEwufCawwyUinsLYB//3xGOrbOnDfsvmYGejL08pIory1GR+kJ+F/qSfh7eCEx2Ytxkr/UNhZ9q13ZxgGPZGpC21arXZ01P/Wrl2L3//+90hJSUFcXBwcHBz6PL9hw4ZhGcIwUqgorUdZcR3iFoTi0IFMnkxGFhLTS8Qdq6vXxuHTPYko5YgVI4P0+ndJ6Ugvq8KG2AhE+k/Et6fT0dDOogPM8ClpacK7aQkIcHLFyqDJeGxmoBC3OFRegLZuDU+tGUmqj8S4zAg5Vffdd5/4+cILL5zzHC0+huvdMYxUjv6YjitvXoSE+AK0tXJaDSMPCWnF4s7V1ati8dkeqrEafr41wxjIqarFf/YexcqYKbjvonnYnZaNk4XcfJqRRlFzA95OPyWcq+WTJuO3M5fgWEURDpaxc8Uwx44dw7x584yaCGoCnJ+fj6ioqJFL/xuJcBnDyEFVeSOKcqswe0EoTygjK0kZpdhzPAubV8Yi0MeNZ5eRhc5uLb5NTscnJ5OxKDQIty6YCVd7W55dRhbn6p30eLyddgo+9s7CuVodMAUOlpwibxZ1VXJu44gbb7wRq1evxmeffYbW1oH7vaWlpeH//u//MHnyZMTH9+qBOkZ6MDKMbBz7KQPRsYFwdOKFCSMvydll2HkkHVeumIFgPw+eXkY28mrq8J+fjqGqqRX3L52HucH+PLuMLBS3NOLdjHi8lXYK3vaO+M3MxVgTMAWOVuxcMeZHWloaLr30UvzhD3+Aq6uriEKtXLkS69evx6JFi+Dp6YmZM2eKCNWuXbuGLMyn0svZSniUaWpqEpKIy+yuhqVq+F8QKmtpXy4qaxkKQi2HnIl5LlYSx+jXyFkRG+jGiJWFpNev3jQbXV3d2Lc9WTEbCJ2VtHsWeku14jboLKXnUuusZBhDoh1y2hARPBFrF0Xi2/0pyCmuGeIY0mzQS78s5TmnUo9Dhq87nYWyxyDbcfQbI8jDFRtnRKK5owtfJ6WhtrVtxG2Q57qSaIOl9KWIHGNIva4gy3HoJL1edR4bJjk4Y7l/KEJc3HGqshQHy/MHbiKsln4caonHYSHx9WIMC2ljaNs6kHPjM2hsbISzs7NJr4X9X38Cajv5byjr2jtQfPefTXoOhsOpU6dw6NAhFBYWor29XThUsbGxuPjii+Hu7j6sMWX4OmYY0+LYwUxcf8dSxB/NQWMDN9pk5CU9vxI6nR6XXTQN3/6Uiuyiap5iRjYKahvwn/3HsXzqZNy7dA72Z+bjcF6h6EHDMFIpaW3CexkJ8LF3wlK/EDwyYzFO15Tjp9I81HTw30vGfJg1a5bY5GR8OFU6PcXcJLxeJ/39xwNy/NU2gTEaaluQeaYEcxeFYdd3ScMbRCv9OFQS7/TpZbhTqJJ4bap00qMaajlKLaWaIYd4Ua/vmOy8SnzXrcNlF0/D9wdSkZlfNSqGSL9vS4JC0sdQSxxDhsvKJHLX5TgfAx2HtluLXaezkF5ciQ0zIjDNZyK+S8pAWUPTiNggR92E1K8rnRwKY3Ich8QJ1ctxQnQSr24jvvfLu1rxSUMKPO3ssWRSMB6KXoT0uirsL84XMu1yRNyknlO9zgSyHDQyhHFHC+5TpTim8HeJYWTnxKFshEX6wd3TkWeXGRFyiqrx9d7TuGRxFCIne/MsM7JTXNeI1/YfR0Z5NW5dHIc10VNgZTGGFnmMyVPT3oYvs8/gn/GH0NLVhXumz8HNUbEIdHJV2jSGGXMMK1JFSn85OTmoqqoS/+7NkiVL5LKNYYZNU0Mb0pKLMHdxOLZ/NTT1FoYxlrySWny19zQuXz4darUKqdnlPHmMrGh1evyUmY8zpZVYPyMCDyyfh22nM5BdWcszzchGY2cHvsvLwL7iXCz0DcQtkTNR1tqM/SV5yG7ga21sQFG5kegpxX2qRsypIo336667ThR29de44D5VjClx8lA2br53GTy9nFFTdW7aDMPIQUFpHb7ccxqXr5gOK0sL0TCYYeSmpqUN7xyKx8xAX1wRF43cqlpsT8lCs7aLJ5uRjVaNBrsKc3CgIh/zvP1xVVgMGjrbsb80H2dqK3mmGUbO9L977rlHFHalpqairq4O9fX1PRv9zjCmQktzB1ISCzFvabjSpjDjnMKyOmzdkYAlcaGYNz1IaXOYcUxCYRn+vfeo+PcDy+cjLsBPaZOYcUiHtls4Us/FH0BidRnWB0/FwzMWInaCD9RyFGYyY6NH1TjsVTUQHR0DKGCOhlOVnZ2Np59+GhEREULjnWQce28MY0qcOpID/yBPePtxw1ZmZCmrasSWH05hVlQAls2dwtPNjBitnV34/FQqvoxPxdIpQbhtYRy8nBx4xhnZ6dJpcaS8SDhXB8oKcPGkyXg0dhHm+wTAWs31fcy5aLVa/PGPf0RwcDDs7OxEE92nnnqqT3Yb/ftPf/oTfHx8xD4rVqwQ/kVvKFBz/fXXCxl38jduv/12tLS0yDblVL5Edvn5+cHR0RF5eXnicbL9rbfeGh2nau7cuaKeimHGAm2tnUg8nofFyyOVNoUxA6rrWvDRtpMIDZiA9RdNg4VUmTyGOQ9UV/XKj8dQUteIuxfPwerIMFhb8kKXkR+tXo/4qlL8K/EQdhRmI3aCL343aylWB4TB2dqGp9wUMJFI1bPPPotXX30V//73v5Geni5+/8c//oFXXnmlZx/6/eWXX8Zrr72G48ePw8HBAatXr+4TMSKH6syZM9i9eze2bduGAwcO4K677pJtuv7617/i3XffFbZY9+pXGx0djf/973/DGnPIzX+/+uor0Yn4t7/9LaZNmwarfg1jY2JiMOrNf22uktj8V1rTW6nNgwXWJtB41xQaEMvQeLf/662sLUVt1Y87kpGbWWHcGDIobOmlNt6V+HpZbJChAbHe0gRkcWVpYmz8vva2Vti0Khaabq2ot+rs6j47hoXU45D0ctnmQmrDWVka70pt/msCDW/lnEuKVK2bNhVuDnbYeSYbqWWVo9r8V/L5kGUu9Yofh97CBJoYyzAPxowR7OyGRb5BCHP1QEpNBQ6WFaCirVckQeJcqCQ27pWjAbGurQMFt/11bDT//e+TI9f8974njZ6DdevWYeLEiX2iPVdeeaWISH344YciSuXr64tHH30Uv/nNb8TzNDa9hpyca665RjhjkZGROHnyZE8vqR07duCSSy5BSUmJeL1UQkND8frrr2P58uVwcnLC6dOnERISgoyMDMyfP1+UNQ2VIa+YaGLoYG+77TbMnj0bM2bMEB2IDT8ZxtTQdHXj2E8ZWLgsEmoL7iLAjDxtHRp8/EM8ujRaXL9uNpwc+E4uM7JUNbfi7SPx2J2Wg7XRU3DTvFh4ONjztDMjRn5TPT7ISMTLSUfQpdPh3ph5uC0yTjhZjAJQX7CR2obAggULsHfvXmRlZYnfyVk5dOgQ1q5dK37Pz89HRUWFSPkzQE4hZcIdPXq2XpR+Uspf7+a8tL9arRaRLTkoLS0VjtVAaYEajWZYYw753hBNBsOMNc6cLsaMOSGYFhuA06cKlDaHMQPORqmSsGpBBG5cPwef7UxEZVOr0mYx45zk0gpkVdVgWXgI7ls6F4dzC3EwpwAarSxtghnmHGo62vBNXhr2FOVgrrc/NodNQ6umC4cqCpBUUyZSB5mRh6Z5JKbaMCZFxHpjY2Mjtv78/ve/F/tOnToVFhYWosbqb3/7m0jnI8ihIigy1Rv63fAc/fTy8urzvKWlJdzd3Xv2kQpFwg4ePIjAwMA+j3/++efDDhIN2anq/+YMMxagcPOhfWlYtT4WGaml6OwY3l0IhhnadQfsPJyOBTOCcf26Wfh8XzKKKoaeUsAwQ6FD040fUrOQWFwuUgJn+PtiV9rQUgIZZqi0dndhX0kuDpTmI9bLF0v8grEqIAxHK4pwvLIY7d38d3cs4+/v3+f3J554Ak8++eQ5+23duhUfffQRtmzZgqioKCQlJeHXv/61SNm7+eabYSqQUAbZQxErik59+eWXyMzMxPvvvy9quIbDsLKYc3Nz8eKLL4o0QIO396tf/UoofDCMqVKQU4XqyibMmh+Kwz+evXYZZjQ4kpSP5tZObF45Az8cSkN6Pi9umZGnvLEZbx46iemTvEVK4JygSfjmdDpqW9t4+pkRo1uvw8nKEpysKUa4qycW+QTjYr8QxFeX4nB5IWo7+PobEUZK/vznMYuLi/vUVA0UpSJIc4GiVVQbRZD+AvW2feaZZ4QT4+3tLR6vrKwU6n8G6HcqJSJon6qqKvSmu7tbKAIaXi+Vyy67DN999x3+8pe/CKEMcrJmzpwpHlu5cuXoOFU7d+7Ehg0bxIEvXLhQPHb48GHhjUoxZCyj10tPq1DpZEjN0OmVfb1cY2glFreqB3/94d1nsPmWRUg5mY/mxvbBBznPGKM1FypTmEuVDEXXMgjgSW2LIkdbFWpuLoXU9DK0tHXisuUxcLGzwYmUwuEYIcmGs2NIP6c6SLNDjspGqR8PU6mulJyuY8TrU/IrkFlcjcVTgqDv0kGtGdiGCU4O8HFxQpCHGzIrqpFZWWNSx3HBIXRyiLBIM0Qnwxee1I+oToZ5kONvOYl2ZFTVic3XwQmL/ALxq+hFyKyvwcHSAhQ2NZx/ABnES7RaieJAXaymaYAcKmOEKtra2kTtU28oDZCiQQRJrZNjRHVXBieK0gWpVuree+8Vv5NQRENDA+Lj4xEXFyce27dvnxiDaq/kYvHixUJdUC6GfMmS9/nwww/j73//+zmP/+53vzNLp4oZO1RXNCLrTCkWrYjE9i/ilTaHMTPyS2vxyQ+nhDKgk4Mt9h3PHJEceIbpT1e3FnvTcgedGHKorp4Vg8zKapQ2NGFhaCCm+/vgh5RMtHR28YQykihrbcbWrFTsKMjGQt9A3BI5E9XtrThSViSUA7nuSgaGISph9LhDYP369aKGKiAgQARcEhMT8cILLwiBO8MNSkoHJEnzsLAw4WRRbyhKD9y4caPYh3rhrlmzBnfeeaeQXSfhiAceeEBEv+RQ/hsphuxUUcof5Uv2hyaLUgIZxtQ5si8dN92/DH4BHigtqlXaHMbMqKhpxgffncRVq2PhZB+D735KhZZFBBgFod5WF00JRllDk1APJOILSxE+0bPHoZrg6IDqFhZaYaTR1NWJ7QVZ2Feci5levlgeEPL/27sPsCiv9G3g99CbgHRRiohiwV5RY+wmmmJ6j6mbZE3fzaZsstnNt6lbkux/U3Y3m96T1RRTjYm9YAUE6b333pn5rucgBGwB3hdmBu7fdR0HZobX8xaGeeac8zxYPXoc9hbkILowF7UtDOCt3f/93/+pIOnXv/61msInQdBtt92mptd1+N3vfoe6ujpVd0pGpBYuXKhSpjs5/ZwSXtZlSSAlKc9l5Euyj0ttK73INs80A0USbPR7nSpZqCYR52WXXdbtfgm0JN98dnY2hlqdKj1qMxlOqPfVt37YD446VVqLV/agztXMqHBERI7EB69t71blW69aWWobdhZQp8rO/HWq9KmLZAF1qnSu7+TsaI9LVk5TI1X/23wYjU2tA9IHXWpdaay3ZdKlD7D6PlhKfaexI31w+azJOJSdj+Euzsgsq8Cu1PbpqRNH+GGcvw8CPYehrrkFPx5LQ05FlUXWDdOl3pbW6X86nA+t9Z30OJZ61Lrqac2uccN9MD8wGGM8vBBbUojdBdnIq62GQWONKT2m8qsaTbf/yTrqVL34RP/VqbrnDxZ9DPri888/7/a9jIbJqNpbb72FP/3pT7j55pt7vc1e//rLUJxElunp6SoXfceaKqmYfP/99/e6A0TmcDg6HZEzQjBxWjDiD/dhbQuRRg1NLfjw64M4f8lkXHveHHz83SFU1/5cTZ5ooMwLC0JCfjG+j0+Bp4sTlkSMUSNTTa2tWD05ApsTUvDZkQT1vGlBI04ZVBH1VXJFqWq+zq6IGhGEWyfPQmFdLXYXZSK+vAhGzpGmfiCJKk506aWXqimLH3300cAEVTKkJ5WH//a3v+Hhhx9W98nQnqRVvPvuu3vdASJzMLYZsX3zUSw/bxpSj+UzxTqZRWubEZ9ticHyeeNx/QVz8On3h9X0QKKBYm9rgzajCT8mpqHVaERpbT1cHO0x1t8b9ra2yK2oQkxue12Y2NxC3DB/JoY5OaKmsUnd5+Jgj/pmpsom7WSN1Rfpifg+KxUz/UdiVfBYrAmNwN7CHBwo5tRAc2f/GyrmzZunBo/6otdBlcw/lEQV0mpq2v/4S5BFZG0ykotQlF+JBUsn4MevY83dHRqi5EPYzXsSUVXbgKtWz1J1rRLS9CluSPRLpChwVlkF5oUF49v4ZPi4ucDB1hYVdQ1YOmEMNh5O6HzuhBF+aG5rUwGVBFNzRwch2NtTfTiwLS2DI1iki8a2VuzKz8Ke4gyMH+6LeQHBWDpqjBq1kppX2TW/kDWQqI8aGhrUuq2RI0f26ec1zf5lMEXWbuu3cbjmtsU4FpuDglwWZSXzkRTrJeW1uGDJZAT4uOOn6GRmBqQBISNQS8aPwZ1LolDV0IhjBcXwcnNRI1CSvKKDrK86kp2vvj5vyngYYMCXMccQ5uOFZRFj8N7+GLT0YXE30ekGSI5VlKjm4+SCuQHBuGHCTFQ0NmBvYTZiSgvQbOT1ZmnZ/6zF8OHDuyWqkPX1Mljk4uKCd999t/+CKimGJfnkpQPTp08/Y7aMQ4cO9akjROZQXVmP/TtTsGT1VHz42jYY9agNRaQh5frbX+zDxSumwXf4DHz+U2yPElgQaVHd2ITPjyTA09lJrV+R72cEByKn/OcRgdmhI1WZtKyySoz180aAuxte3R6tUrWX1+Vh/Eg/BA33QHppOU8G6a60sR5fZSZic3YKpvqMUKNX54ZG4FBxHvYV5aipg0S98fzzz3eLZyQboK+vr6qDJfFOvwVVspiro3JyRw55osHi0N40jJ88CtPmhuHQntPXcSEaCBXVDXjni2isOTsS6y6ciw2bY1BSUcuDT/2usuHnRCkyQjV/TIgaraqsb8TZ48LwVWyiSqu+ZHwY4vKKVEAlZCqgBFmlTLlO/UxGpvYX56oWPMwTc/2DcOeUKJUtMLooB0fLitBq0iFroDXimqpeueGGG6C3HgVVjz/++Cm/JhosSSt+/DoGF145DykJ+aipajB3l2iIa25pw8YfYrBgehiuPX82vtoej+TMYnN3i4aQwupafHwgFosjwuDh7IRvjybjWGGJSrk+xter21orWVuVVlLOhBU0oGRtlbRNmYmY7huIJaPG4LzRE9TolQRYMrpFdDqxsT1fSz9lypT+WVOVk5OjhstGjRqlvo+Ojsb777+PiRMn9jlbBpG55WeXI+VYPs5eFYlNH+83d3eIlF2H01FUVoPzFkfC33sYtsWk88jQgCmuqcPHB+K63efl6oyM0orOtVOujg6qjtVPqekqeyDRQGtobcHugizVRrsPxxz/INw9dQGyaioRXZKNhPIitA2FtOwcqeqVadOmnXE5U8c6K3lOTwsB9zqouvrqq1XwdN1116GwsBDLly9HZGSkqnws33etmGw1LOGXTY8+aN2GHkPmOuyHQeM2elnPutPOzfG4fv1ShI3zR1pasdkXdxradLgmDNq2YdD488JGhzWuRoP5+wA99qMPG0lLL8G75dG4eNVU+HoPw6atR9HU0vd1VjZ67IjGHLt9OQ4n0lqWWo+3/xrrirb3w2T+PvTmJTOvuAqLx4xGVFAQkgpLsGbKeBRX1CI9vww2Wg6qBfwJbN+GxmtTjz+jGgsI2+jRBz1+QbQWITb2/rc8o7RKNVf7JMzwG4kVgeNwfvBEHCyS0atclDf2biaKqUXrKw1Zqg0bNuC3v/0tHnjgAURFRan79uzZo0pGPffccyqHRG/1+lf36NGjmDNnjvr6448/xuTJk1Xx3++//x633367dQZVRJLGtaEZOzbH4+xzJiP731vR0sKsQmQZyirr8PbGaJy/crKqZ/W/zUdQXs2pLTTwZB3Vt3HJWDIhDBEjfJBbUY3tiRlo0+EDGCK91LW0YEdeJrYXZiDcwwtzAoJw3/QFyKiuwL7CHBwrLxl8RYU5UtUrTz31lEqfvnr16m7T/IKCglRN3oMHD/Z/UNXS0tKZtOKHH37ABRdcoL4eP348CgoKet0BIktyLCYHE6cGY+6iCOzc8vOaASJza2puxSffH8bZM8NVAosvt8YhNafU3N2iIaigsgbv74mBk70dGjtGTU8YlZBpglI8uKiaSVbIvFKrylVzs3fALP+RWB0agQvDJmJ/Ua4KsKqb2wtZWz2mVO+VuLg4jB49+qT75b6EhL69/+v1uOakSZPw6quvYseOHdi8eTPOOeccdX9+fj68vb371AkiS/LT1zGYOjMUPn7u5u4KUTfywerWA6n4ZmeCqmcVNfXkPwhEA6UzoDqFYC9P3LJoNi6eMQmeLk48KWR2tS3N2Jqbgb8c3IFPUuLg7+IGP2dXc3eLzGTChAl4+umn0dzc3HmffC33yWN90euRqmeffRYXXXQR/vKXv2DdunWYOnWquv+LL77onBZIZM3KS2txKDodS1dPwcdv7jR3d4hOkphRhPKqely8fKpKYCHZAVuOp7cmsgRHcgpUQoulE8KwfmkUDmXlYXtyJuqafn4DQ2QuKZVlqg0mMgO3P2bhDtaZvTJAdP7556vEex3Z/SQjoCSm+PLLL/s/qJIEAGFhYcjOzkZra2u34liSvEKqEBMNBlIQOGLiSEyeEYK4Q1nm7g7RSYrLa/DW5/uwdukUXHf+bGzcEqNqXBFZiqqGRmw8lIBdKVlYMmEM7l0+H9EZudiVmsX060RkVjIQlJ6erhLtJSYmqvuuuOIKlZDP1dV1YIKq8PBwxMfHY+zYsd0eCw0N7VMHiCxRa2sbtnwdg/Mum42s9BJUVzIpAFmehqYWfPTtISyePRY3XDgPX++IRxLrWZEFpmb/KDoWgZ7uWBwxGveuWID9DK6I9MVEFb0mwZOe5aB6tabKxsZGBVNlZYNryJToVHIyS5F4NBcrzpvGA0QWSzJY/RidrKYAnrtwIlZEjYetLdMAk+XJr6zG+/ti8OauQ/Ad5or7VizAionhcHGwN3fXiGiIeeutt/DVV191fv+73/0Onp6emD9/PrKy+jZDqdd/eZ955hmV011SqxMNdju3HIO7hzOmzuJILFm25KxivPHZPgT4uGPdBXPg7ckF2GTZwdUbuw7C53hwtWriWFVImIhooFKqOzs7d9an+uc//6nqU/n4+OC+++4bmEQV119/Perr61WCCgcHh84OdSgvL+9TR4gsUUtzK77/8gguuGIOMtNKUFVRZ+4uEZ1WVW0D3tu0H2fNHKMCqy37khGTlMcjRhYpv7IGH+yLQaDnMCyaEIb7ls7H/qw87EzLYkILIupXOTk5akmT+Oyzz3DppZeqqYALFizA4sWLByaoeuGFF/r0HxFZq7zsMiTE5GDl+dPw6Tu71dpCIkueDrjtQCqy8stx3tmRCA30wre7jqk6V0SWGly9vz8GgR7DcPa40bh/2QJEZ+YyuCLqBUM/ZeqT7Q5Gbm5uajlTcHAwvv/+e9x///3qficnJzQ0NAxMUCVp1ImGmt0/HcNVt5yNabNH43B0urm7Q/SLMvPL8frGPVizKBI3rp2nigXnFVfxyJHFyq+qwQf7YzHCYxgWHw+u1MhVaiZqmYqdiHS0YsUK3HLLLZg+fTqSk5OxevVqdb8k4+tr8r1eB1UiLS0Nb7zxhrp98cUX4efnh2+++UZFe1IceMgxWsjIhdYRFD1GYIxG7dsw2Zi9D4a27p/NtLa14ofPDmHtNVHISi5CRVntL2/ERuPx1OMjpzZt2zBo3QehwyVhsIASTAYdPq7Tnj6id51obGnB/746jFmTg3HlypnYeyQDu+MzNP+q22j97FKH1xqjxj7ocWlbwqC1Hl2whJf+ruejqLQGH5XGIsDDDWdHhOG+JQtwMCNPpWKvaWw67TZMevz50boNXfqg7do22erQBzsL2A+Nf78UO41/A5utKOmPydDe+mO7g9BLL72ERx99VE0D/N///gdvb291/8GDB3HVVVf1aZu9vlq2bduGyZMnY9++fdiwYQNqa9vfXMbExODxxx9HX0kCDCm4de+99/Z5G0T9qSC3AnEHM7HigunqWiWyFgfisvHBl/sROW4ErjxnJtxcHM3dJaJfVFhVq1Kx/3f7fni4OOGeFfNx/rQJ8HLtvpabiKi3JNOfJKf4/PPPcc4553Te/6c//Qm///3vMSBB1UMPPYQ///nP2Lx5s0pU0WHp0qXYu3dvnzqxf/9+/Otf/+qsaExkqfZsTYSDkx1mRI0xd1eIeqWwtAZvbdiH6rpG3HzRPIQH+fAIklUFV69ujYatwYBfL52HS2ZFwt/dzdxdI7K8OlX90QaJ2NhYGI8Pq8vXZ2p90esB3ri4OLz//vsn3S9TAEtLS3vdARnpuuaaa/Cf//xHBWtElqyt1YjNnx/GxdfNR1ZaMUqLqs3dJaIea25pU/WsJo0JwPmLJyMuJR8/RSejzVKmMBOdQWlNHT47nICfEtOxYGwIbjl7NjJKyrEjORM55VwvSERnNm3aNBQWFqqYRb6WWUddk491fC+3bW1t/T9SJcNlBQUFJ91/+PBhjBw5stcdWL9+PdasWYPly5f3+meJzKEovxIHd6finItnws5Oh8nrRAMsPq0Qb36+FyP9PHD9BXPg5e7Cc0BWo6qhEV/HJuGF73ehqLoW10ZNx40LZyLct31NBNGQxJGqX5SRkQFfX9/Or9PT09VtR+v4Xm77otdB1ZVXXokHH3xQRXoSyckw2q5du/Db3/5W1bDqjQ8//BCHDh3C008/3aPnNzU1obq6ulsjMof9O1PQ2NCChSsm8gSQVaqobsC7m/YjM68cN6ydiynjAs3dJaJeqWtqxpaENDz//U6kFZfh4hmTcNuiOZgU6K9LYhkiGlxCQkJU7NLS0qLWTkkMI/edqg1IUCUViMePH4+goCA1dW/ixIlYtGgR5s+fr7Jo9JRk27jnnnvw3nvvqZzwPSHBl4eHR2eTPhCZgwwPf//ZIYybNBLhE0bwJJBVkml/P+1PwcYtsVg0MxyXLJ8KFyd7c3eLqFcaW1qxPTkTz/+wE0dyCrBiYjjuXjofs0NHwd7WirK3EWlMGNxfbbCxt7dXGf/0ZjD1sZJpdnY2jh49qgIryfE+duzYXv28VC++6KKLYGv78/Qpmb8oEaSNjY0aler6mJD7pHWQkSoJrJY6Xg47w89JM3rLYK8xd6id9tyjBgcd3sho7YceU9l0OBbQeD5Mdjr8ET3h2judMREBWHHhdHzwn+2oqqjr3g97W7Pvh0njGwqjvQ59sNP+kbHRVmuKYR36YK99G1r7ofU4qG2c5qXGydEOq+ZPQEigFzbvScSx9KJ+3A9NP96+DTsLSDuty36Yvw9aq1jocU51SeF9vA8ySjVphD8Wjg2Bh7MT9mXkIjojB/XNLT3ehjmvba190Celusn8+6FD3QOt+2FsaETObx5DVVUV3N3dYYnkvbAMNIT++UnY9HCQojeMjY3IfPT3Fn0M+kLq7sq6qvvuuw966fXL2M6dO7Fw4UJVk0paXy1btkwlvejqxhtvVKNgMr3wxIBKODo6qkZkKdKSChF4JBurL5mFj9/coRJZEFmjxqZWfP5THCJC/bBy/gRMGB2A73YfQ11Ds7m7RtQr8lHx0fwi1cJ8vLAgPAQLw0PUKNaetGyU1dXziBINcWPHjsUTTzyhljDNnDkTrq6u3R6/++67+z+oktTpkpBCCmNde+21avpfXwwbNgyRkZHd7pMdkuJbJ95PZMl2bTmGS69fgEUrI/HT131Lw0lkKZIyi5FTWIHl88bjlkvm44e9SYhPPTk5EZE1SC8tVy3A3Q1RY4Lx68VzkV5aoYIruZ9o0Oiv9OeDcPqf+O9//6uS70mxX2ldyay5AQmq8vPzVYKJDz74QBXsldpSkhJdgqxRo0b1ugNE1s7YZsQ3Gw7gqlvPRl52GZKP5pm7S0Sa1De24IutcQgP9sU5CyZgYlgAvt2ZgJr6n6dfE1mTwupabDycgM0JqZgzehQunRmJ2qZm7E3PRmxuIVqP164hoqEhIyND9232eia1j48P7rzzTjVclpaWhssuuwxvvfUWQkND1SiWFlu3bsULL7ygaRtE5lBT1aDqVy1bPRXDvVmQkgaH1OwS/Od/u1Hf2KxGraZG9L5sBpElkUDqx8R0/H3zThVQzQsLxv0rFmLp+DC4OfZ9bTaRuTFRhflpWho6evRoPPTQQ5g6dSoee+wxbNu2DWahcm30/VMmk8ZPqHTJ3Nq3fCH6bkOPAqB6bKNN4/nQIZduXxbIZiQXIvZAhlpf9dF/t6NF6yefbTpcWRrT9hg0not22lfBaz6nOhxKm97XATyJUeM8Cn3ymPXuYLS0tOKbLfFICirEqrMmYmKIP77elYDq2sYB68Opmcz+kms0ad8PrWvxTTr8iuqR2EDrFCFd/gT24lgYYcSRtHzVwny9MC88GPcvXYCjBUVqamBhVW3fOqHH+dC4DZMOr1Umox6JeTT+juqQmEfzfrQweyT1XJ+vFhmp+vWvf40RI0bg6quvVuugvvrqq75ujmhQ2PPTMTQ1tWDxuZPN3RUiXaXnlOG/n+xBZXUDbr44CtMncLo3DQ7pJeV4f88RvPrjPjS3tuHmhbNww4IZGB/gy3pXZD3kQ57+atQ/QdXDDz+sRqhkqp+kVX/xxRdVIeB33nkH55xzTm83RzSoGI0mfPu/Axg9LgATp7COGg0uzS2t+G7HMWz4IQZzp4Ti6jWzMNzd2dzdItJFaW09vopNwt+/34mUojKsnhKBu5bNx9ywIDjoUXKEiAa1Xk//2759Ox544AFcfvnlan0VEXVXW9OoCgOfe/lsFOZXory0hoeIBpWs/HL89397cPbscNywdh52HkrDgfhsXaZwEZlbQ0srdqVmqWmAEwP9VNbApePH4FBWHvZl5KCyXsvUV6J+wux/1jdS1THtjwEV0ellpRXjSHQ61lwyC/YaiwATWaKW1jb8sCcJn3x/WE0FvOa82fD27F7ng8iaGU0mHM0rwn+278c7ew7D3dkJdy6NwlVzp2KMr5e5u0dEGu3YsUOVh4qKikJeXnvmZpl5JzV5BzRRRUJCgpr+19zcvTDkBRdc0NdNEg0qe7cnIzDIG0tXT8V3nx8yd3eI+kVuYSVe37AXZ80cgxvWzsWuw+mIjs1Sb0iJBovciip8ciAO7k6OmBU6EhfPnKRGtPZn5CImpwCNLa3m7iINcR3Z//pju4PR//73P1x33XWqLNThw4fR1NReMqSqqgpPPfUUvv766/4PqtLT03HRRRchLi5OZeQyHf/D2ZGdq61Nh7QzRIOA/G5889lBXHXTIkyfE4bD0enm7hJRv2htM+Kn6BRVOPichRMxKXwENu9ORHZBBY84DSrVjU0qJfu25AxMCvTH7NGjsHzCGMTlFeFAZi5yazjdm8ga/PnPf8arr76K66+/XtXf7bBgwQL12IBM/7vnnntUoori4mK4uLggPj5erbOaNWuWqjNFRD+rr23Cpk/2I+rs8QgJ8+WhoUEtv7gKb27ci9ikPFy8YhrOXzwZbi6O5u4Wke7ajCZVNPi/Ow7gtR0H1MjsDQtm4razZmN6UCDsbZmKm8y0pqo/2iCUlJSERYsWnXS/h4cHKisr+7TNXv/W79mzB0888YRaU2VjY6PawoUL8fTTT+Puu+/uUyeIBrOigkps+SYG5140E55eXHNCg5u8udx/NBv/+WSXGq299dL5mDM5BLY2TMtLg1NRdS02xSTir9/twKHsfESFBeG3K87CuZPGwdeNr/lEliggIACpqakn3S/rqcLCwgYmqJLpfcOGDVNfS2CVn5+vvg4JCVFRHxGdLOloHuIOZeGCy+fA0cmeh4gGvbqGZmzadhSffn8EkWMDceNFUQgJ5OJ+GrykxtX+rDy8vG0f3t13BM4O9rj97Dm4cf4MRAb684MF6l/H11Tp3QbrSNWtt96qZt/t27dPLWGSeOa9997Db3/7W9xxxx192mav11RJkd+YmBg1BXDu3Ll47rnn4ODggH//+999juyIhoLdWxPh7eeOc9bOwBcfRXeuRyQazHIKK9SUwBkTg3DR8qlIzynFloMpqKlvXxRMNBjlVFSp9m18MqYHjcCy8WNwbuQ4NZJ1MDuPadmJzOyhhx6C0WjEsmXLUF9fr6YCOjo6qqDqrrvu6tM2DaZevrP77rvvUFdXh4svvlgNm5133nlITk6Gt7c3PvroI1UUeKBUV1eruY9LHS6DnUHDp/92fU6CqBgcHDT9vNqGvbY+6LEfsLU1fx/UNjT2Q4cijSYd0qCb7E4eCHZwtMPl6xYiM60YO7cknPnnbfunD737ee1Ttkw6rC0w2mvcD1sd9kOHY2HUeEr12A+jLseibz/n4uyAJXPGYuxof+yKSVe1rWRtinmOpbafb++DHr8f5v15vbZhCefDErZxpuMgadhnhYzCOH9vZJdX4mBWPhILS9BqNOraB5MOy7n6+jvebRu2Jus/n42NyHro9yojnLu7OyxRx3vhsEefgq2Tk+7bb2tsRPqfH7HoY6CFZDGXeKa2thYTJ06Em5tbn7fV61+bVatWdX4dHh6OxMRElJeXY/jw4Z0ZAIccPUYcjHpso/sLc6/Z6PFKbNRhGzYWcD6074eh7eTfh5b6Fmz6MBpX3HwWyouqcSwm5wwb0OFYat1Em41F5GO1adW2I8bez3TuFzbQ9hpp1GEehh5HwtjH/WioacbXW+IxclQeVkaNx7Qxgfh+d6IqJtxrJm3HUpeBYh02YrKA/dDjz4+Nxm3osR96/PnR/Gf0DD+fkV+umqujA6YGBWDp2DCcP2k8YnMLcCgzX63N0mM/dAlGdPlTbrD6oApNVvS+lsV/+0Rm20kwpQcdPosAvLw4T56op6oq6vD1pwdw/hVzUFPVgNzMUh48GnK1rd74bC9mTAjCRcumIDOvHFv2JaGmjlMCafCra2rG7tRs1YK9PDA9ZCRuOXsWSqrr1OhVXEEhmlpZnoZIbzLLrqc2bNjQf0HVTTfd1O37119/vdf/GRG1k0Bq6zdxWHPZbHzy5k6Ul7C2CQ0tMjJxMCEHxzKKsHj2WNxyyXzsicnA/risPk8JJLI22eVVqn0Tl4TJowIwIyQQ50wZh6P5RTiclY+s8r6ldqahh8V/f5lMk+wgq582btyo7pOyUOLgwYMqnXpvgq8+BVWS3Y+I9HMsNgfuni648Mq5+Oj1Hajnp/Q0BNU3NOPr7fGISczFygUTMHlsIH7Yk4SMvDJzd41oQDMHHszMU81vuBtmBAfiqrlT1ajWwaw8xOQWqq+JqO/eeOONzq8ffPBBXH755aoAsO3xNeyS4fzXv/51n9eO9TpRhSWxmEQV9tpTZBssIsGDBfRBj37YmT/Bg9LDRBMrLpwOL59h2PD2LrS0tOnaB82JKnRIMqHLfmhMCGC0gD7okexCazIAS0l2cbpF8LIsd/qEICyaOQY5hZX4cV8yKqrr+6cPFpCcob0fg2U/zPvzahs2gyvhhp2NDcaP8MXM4ECEeA9HUlEpDmXnIbW47Ixr0CzlWGpeHm0hiSoyHrfsJA0d74XHPNJ/iSrSnrLsY9AXvr6+qiZVREREt/ulPNT8+fNRVtb7D/YsY/U20RC2ZVMMWppbseqiGUM32QvR8SmBhxJy8K+Pd6G6thE3XTwPy+aOg5OjLst/iayKZAU8mleEt/Ycxj9+3I2SmlpcMHUC7l+xEMsnjIGPm4u5u0hktVpbW1WyvRPJfZJqvS969Jdq+vTpPX6zd+jQoT51hGioMrYZ8dUn+3HZDQux7Lyp+OHLI+buEpFZNTS1YPOeRBw+loMlc8fhtssWYm9sBg7E56CtTYe0ZERWprK+ET8mpuOnpHSE+3pjWtAI3LF4LgqraxGTU6CCr/rmFnN3k8yJ2f965cYbb8TNN9+MtLQ0zJkzR90nhYCfeeYZ9Vi/BVVr167t/LqxsREvv/yySj8YFRWl7tu7dy/i4+PVPEQi6r2mxhZsfG8PLl23AGetnIQd38fzMNKQV1pZh0++O4yQQC8snh2OGRODsfNgGo6m5g/5Y0NDdzQ3pbhMNSd7O0wK9MeUUQE4Z9I4NS3wSE4BkkpLT6p9RUTd/fWvf0VAQAD+9re/oaCgQN03YsQIPPDAA/jNb36DAVlTdcstt6j/9P/9v//X7f7HH38cOTk5A5oVkGuqTsA1VVa5pqorSVwhgVX84Wzs3Z2iuQtcU9WOa6qsY03VL5kQ5o9Fs8LR0mrEjwdTkJ5bNgjWInFNlV7nY7CtqeoNTxcnTB01QtW/cnZ0QHxBEWJyC1RmwT71gWuqrG5NVfhD/bemKvUZyz4GehxDoXX/ev2n7ZNPPsGBAwdOuv/aa69VKQmZap2o76or6/GZGrFaqOqUHI5O5+EkOu5YehGSM4tVMovzF0WipKIWP+1PQUFp+x9EoqE8PXBbcoZqI308MG1UAK6ePQ2NLS0qc2BMXgHK6xrM3U0ii6RXsNjroMrZ2Rm7du3C2LFju90v9zn1Q4RMNNSUl9bis/f34KLrF6C5qRXxMdnm7hKRxZAaVgfisxGTVoC5U0Jw9bkzkZpTiu2HUlFRzTeNRLkVVap9E5+McX4+mDJqBNaHz0NBVQ2O5BYgPr8IDS2tPFCDkdXm8x4ceh1U3XvvvbjjjjtUQoquC7tkhOqxxx7rjz4SDTnFBVX44uNoXHjFXDQ3tyLlGNeQEHXV1NKK7QfTcOhYLs6aHoab10YhJjkPu46ko76RC/aJ5AOIY4Ulqjnb2yEy0B/TRo3AubL+qqQMcXlFSCoqQQuTvxCZJ6h66KGHEBYWhhdffBHvvvuuum/ChAmqoJYU0RqSdFgQajJp34ZBc1EIHT7isIRt6PAHQo/U5iaDtn7kZ5bh608PYM2ls9DS2ILM1OJeb8MgJdY1sZTFztqubRsd9sNoARUobHQ4HbpUJtS4DZPJoNuO1Fc34rttCTgQk4WzZ4fj9osXIDouE/vjstHS2tavfdD4K64YjdoOpg5/OgCjDq93GvthOv2pGtD1TAYL2I/+WNfV1NyKgyl5qnm5OmPyqAAsHROGtZETkFRYirjcQqQVl6lATLGE9Wl6vN5pPB8ma6q3bEHZ//Ly8lRx3W+++Qb19fUIDw9XcYIsE1KbNJlULob//Oc/qKysxIIFC/DKK690mwVXXl6Ou+66C19++SVsbGxwySWXqNjDzc0NlqpPy4UleBqyARTRAMpKK8b3XxzGuRfPxBcfRiMvu+8L84kGs7LKOmzYHINR/p5YPGcsZkwIwt6YTBxOzGUadqIuZG3VtqQM1fzd3TA5KACrp0TA0c4OCfnFOJpXiMzyCn0+gKEhp6KiQgVJS5YsUUGVFNlNSUnB8OHDO5/z3HPP4R//+AfeeustjB49Ws10W7VqFRISEjqXEl1zzTUqK9/mzZvR0tKi0pz/6le/wvvvv697nyWzuR5LmHqd/c+SWEz2vz5keTuJvfbilgaN+6H1OLRvQ4djobUfNjp8xGYBGQRNXa6riVODsGhlJDa+uwdFBZU934jmPujwCbatjQUcSx0y3umQEVJzpjc9MnLZWUD2P13Ox5kfHxPsg0Uzw+HsZI/dh9MRl5z/86fwel3blvBpvi5ZDPX4PYf5r20zZd4bLNfEqOEemBzkr9K0wwBV+0qarM+y1mtb6/mQzHfpT1p25ruO98Jjf/cUbB37IftfUyNSnuv5MXjooYdUnoUdO3ac8nEJOwIDA1Xa8t/+9rfqPtm2v78/3nzzTVx55ZU4duyYKt20f//+ztGtb7/9FqtXr0Zubq76ea2kwO+TTz6JV199FUVFRUhOTlYz8STACw0NVTWsesv881mI6BclxORg77ZEXHj1XHj5DuMRI/oFadmleGPjXvywJwkzJwXj1ssWYPLYQOgws5doUFLJLWKT8bfvdmDDoXg42NnimnnTcO+KBVg2YYwa1SL6JV988YUKhC677DL4+flh+vTpappfh4yMDBQWFmL58uWd90lQOHfuXOzZs0d9L7eenp6dAZWQ58s0QMnjoIc///nPKoiTUTMHB4fO+yMjI/Haa6/1aZs6DE0Q0UA4Ep0BR0d7XHT1PHzy1i6Vfp2IzkxSsKdkFWNCWAAWzghD1LRQ7DyUjoSsIk5vIjoFmb+UXlKu2lexiQj380bkyADcctYsVDY0Ii5XRrAKmaJ9iK2p6qjl1MHR0VG1E6Wnp6v1Uffffz8eeeQRNdp09913q8Bl3bp1KqASMjLVlXzf8ZjcSkDWlZ2dHby8vDqfo9Xbb7+Nf//731i2bBluv/32zvunTp2KxMTEPm2TQRWRFdm3IxkOjna45NooFVjV1jSau0tEVvEmMSGtEMfSC9VolRQQjpoRhh2H0pCU2fsEMERDhUyZlUQW0uxtbRER4IPIkf5YNC4UJTV1Kj17fF4xKupZzsDcJC+V5txUp9muCAoK6na/JJr44x//eMppdbNmzcJTTz2lvpeRqqNHj6ppdhJUWQpJpiEJNE7Vf1nD1Re9nv73xBNPqEweJ2poaFCPEVH/2vFDArIzSnDxdfPhNoy14Yh6E1zFJufjP5/swsGEHCyfG4GbL5qH8aP9OS2Q6Be0tLWpNVYfRsfir9/twN70HIR4D8edy6Jw2+I5KtDycXPhcRykcnJy1Nqnjvbwww+f8nkjRoxQ66G6kizh2dntNTcDAgLUraxj6kq+73hMbouLu3/g1draqjICdjxHK+njqdZ9ffrppyoQHJCRqj/96U9qmMzFpfsvjgRa8tgf/vCHPnWEiHpuy1exWHLuZFx2w0JseHcPqirqePiIevHpu2QFjE3OUyNXS2aPxcLpYdgTk4GE9EJOCyT6BY0trYjJKVDNyd4O4/x9MDHQD4vGjVajVjJ6FV9cjKLqWh7LQTL9T5JU9CRRxYIFC5CUlNTtPkkCERISor6WbH8SGG3ZsgXTpk3rnFooa6WkDq6IiopSqdYPHjyImTNnqvt+/PFHNYoka6/0IPGKjJzJiJVsd8OGDarfMi1w06ZNAxNUSdaOU9XwiYmJUXMdiWhg/PRNHBYsbcVl6xbgs/f3orS4+3xnIvrl4OpIUh7iUvIRGT4CZ80YgwXTw7D7SAbi0woYXBH1MMCKzS1UTZJbjPVrD7BuHTcL1Y1NKk17QkEx8qtqeDyHgPvuuw/z589X0/+k/FJ0dLRauyRNSAxx7733qkQRUpeqI6W6ZPRbu3Zt58jWOeecg1tvvVVNG5TpeHfeeafKDKhH5j9x4YUXqhpYMsvO1dVVBVkzZsxQ961YsaJ/gyrJLy8HQtq4ceO6BVZtbW2ora3tttCLiPrfrh+PoampBZdcNx+ff7gPhXkVPOxEfQiuYpLzEZdSgEnhAZg/bbQaudobm4m41ALWuSLqoebWtvZ1VvlFsHWwQbivtwqwbpg/Ew3NLSq4ii8o7nOadrL84r+zZ8/Gxo0b1fRACVgkaHrhhRdU3akOv/vd71BXV6fqTsmI1MKFC1XK9K61ot577z0VSEkiiY7iv1LbSk9nnXWWqoOllx7XqZICXfLUm266SR0cSX/YQTJ6SE53Ga4bSKxT1R3rVA3eOlW/ZMrMUMxfOgFffbIfOZmlPz9gAfWdWKdKv+PJOlU9r1Ol5VzIZ4YTwwIwd3IoXJwdcDA+G4cSc9HU3Kr7+bCEWj6sU6Xf8Rws1wR03g9bGwPGSIAV4IfxI3zV+qxjBcVILCxFZlkFjKd4K8o6Vb17Lzzu/v6rU5X8d8uu1aWVDAzJFMCu+rKvPf6z1JGxQyJOGdazt9dQbJeIdBV7MBPNza047/LZ+O6zQ0hP7r4AlIh6Tt7fxacVqhY2yhvzpoRi3tRQHEnMw/74bNTWN/FwEvVyNDi5qFQ1m1gDRvsMx4QAP1w8fRLsbG3U/UmFJUgpKVOjXWR52f8Gm4yMDDUStnXrVjQ2Np60zElm4fVWrz/rO/vss1U0J4vOJDPHiZHdokWLYHV6Nlg3+PdDj+Ng1GEbfbiQu9Gjumdb9+vaHP0wGHrXh6SYbLQ0NuOctTPw49exSIrLhan7B+u974MeH1fq8YrcqvV8aN8PG2i/Jkwmg9lHFPRgYwEvNVqnuZh6+DKTmV6qWqCfB+ZODcUdlyxAfEoBomMyUVanQ604jdeESY+XKh1et41GCxiFNZp/G3rsh0FrH3SISXTZj9OOmJmQmVeu2jdIRKCnO8YH+mJpeBgunToJ6SUVSCwoQWJxCeqams27H33LrE1W4Nprr1UB1Ouvv65qZJ0qX0S/B1V79+7F1VdfjaysLNWZrvoa2RGRPtKTCrHp4/1qxMrR0Q4xh9pTmBKRNvnFVdi4OQbenq6YPSUEN14ahbS8UuyLzVSPEVEff7cqq1X7MSEN3m4uiBjhg2nBI7BmWgTyKqvbA6yCEn0+xBjMLGRNlbWQBHuSXTAiIkK3bfY6qJJkFFLU66uvvlK56PWI7IhIPzkZJdj47h5ccNU82Ds74MCuVB5eIp2UVdbh2+0J2HkgDbOmBeOKc2agqKwGe2MykJ5bxuNMpOX3q7Yeu1OyVXNxcVDFhiMCfLFkfBgqGxo7AywmuiCtJKGG1N4ya1CVkpKiCmOdqgoxEVkGyQK44e1dWHvdfDg62qssgUSkH1lX9VN0ikq/Pn3CKKxZFIm6hiaVMTAxveiUC++JqOdk6t+hrHzV7G1tEe7npZJcXDNvGtqMRrUGK6mwFOkl5Wg9YSnKkMSRql557bXX1ECR1KmKjIw8KVfElClT+j+okqJbqampDKqILJzUrfrkrV24+NooODjaqbpWRKQvyQi4NyYT+49mY/LYEVg4YwwWzQrH/rgsxCbno4WL7ok0a88WWKKajcGAYG9PjA/wxbmTx8HNyVEFVsmF7YkwahqZSIZ+WUlJCdLS0nDjjTd23iez7wY0UcVdd92F3/zmNygsLMTkyZN1ieyIqH9Ultfhkzd34aJro7Bq7Qxs/uIwjHokEyGibtrajCo7YExSHiJC/TF3SigWzAjD4WO5OJSQg7oGbQvuiaidjAJnllao9u3RZPi4uappglODRmDNlAgUVdeqEazkohLkVQ+dgsPM/tc7UiJq+vTp+OCDD3RLVNHjOlUdpADXSRvRGNmZvU5VL+oB9Ut9KGGvfRsGjfsBPfZDax/UNmzMvx861Loyaa11ZadDH47vh4urIy68ai4a65ux6dMDaDmh3k6/9kGX/TCYvw+61Owyf/Y/S9gPPfqguZaPxmtKbeMXXmpCAr0wOzIYoYHeSMoswoH4bBSUVOt6TnXJmmcBta4sZT8soU6VRfTBEvajDz/v4mCPcD9vtQ5LbpuNbUgpLkNKUSnSSsrQ1MuRY6nRlPKcZddo6ngvPP7u/qtTlfgPyz4GfeHq6qqSVei5nMmuL3ndici61Nc14dO3d2P1JTNx+Q0L8PkH+1Bb83NdBiLSX1Z+uWrD3Z0xY0IQrjh3Jsor61RwlZRRpGr3EJF+6ptbEJtbqJpMEwzy8cBYfx+V6OKymZHIKq9UUwRTispQUls3uA4911T1ytKlS80fVIWEhOj2nxPRwJHRqS8/isbicybjihvPwhcf7UNJUfdPzYlIfxXVDdiyLxk7DqUhcmwgFkwPw7K5ETicmINDKfksJkzUX9MEyypV25yQCk8XJ4z188E4fx8sHT8GtU3N+PxIAjJKK3j8h6Dzzz8f9913H+Li4k65nOmCCy7o9Tb7NE/qnXfewauvvqpGrfbs2aMCrRdeeAGjR4/GhRde2JdNEtEAkPVUUhh4ZtQYXHL9Anyz4SCy0op57IkGQHNLm1pfJW30SG/MnBSEO6aNRlJmMQ4k5CC/hPWuiPpLZX0j9mfmqmZnY4PRPsNRWjt4al9xTVXvSOY/8cQTT5z0WF+XM/V61uwrr7yC+++/H6tXr0ZlZWXnf+rp6akCKyKyfAf3pGHLVzFqOuCMeWPM3R2iIScjrwyffn8Er23co5JYXLlqOtadPweRY0bAVof1XkR0epKCXdZaDapMgaZ+bIOQ0Wg8betrfoheB1X/93//h//85z/4/e9/D9suSQmkILAMoRGRdUhJyMf/3tmN6XPCsPLC6bDVIZkDEfVhamB0Mv750Q7EpeQjamoo1l9xFhbNGAM3F0ceTiIiK9GnRBWSgvBEjo6OqKszz6I/k9EEk4x79pFBa8YgPYo86rFgWcMxaO+DDsXzdEhJCa2f0rZZxn4YNB5Pkx678QuPl+RV4MP/bMXqy2bjsuvm46uPo7slsNClDz1MNHhGWgO+Vj0KQ+qRDsvsPbCIlyutL1WKyQKym5l0eJ1oa9+RtuZWxMTmqBYy0gszJwXj1xcvQGpWMY4cy1MJL07FqEOyU5NRj9c7k9nPh1GH/TC1WUAGQkvog40F7IclZCC0pkoITFTxi/7xj3/gV7/6FZycnNTXZ3L33Xejt3r9cizrpo4cOXJSwopvv/0WEyZM6HUHiMj8mQE3vLMbS86dgitvORtffRKNglwu3CUyl6y8ctU8hzlj2oRRuGDZZDQ2tSAmMQ9Hk/NR39jCk0NE1EvPP/88rrnmGhVUydenI2uqBiSokvVU69evR2Njo6pNFR0drQpnPf3003jttdd6vT5LWmZmpvp+0qRJ+MMf/oBzzz23t90iIg2MbUZs2XQEU2aPxtpr52Pbt3FIOJLNY0pkRpU1DdganYIdB1IxbrQfpo4fhbNmhSM5U0avcpFTwA8/iKidjNP2x2rMwbTCM6NLWaj+KBHV66DqlltugbOzMx599FHU19fj6quvRmBgIF588UVceeWVvdrWqFGj8Mwzz2Ds2LEqQHvrrbdU9sDDhw+rAIuIBlbs/gyUl9Rg9aWz4Bvgge0/JqiMgURkPlLP6lhakWrDPVwwbfxIXLR8ihqxOpyci7jUfDQ26THPloho8GtpacH48eOxadMmXWfZGUwSzfSRBFW1tbXw8/PTrUNeXl74y1/+gptvvrnHVaSX2F0KO0P3/PK9YbDXNind0CVhR5/ZaZ8Yr7kfdjrshy7HQuM2bCygD8JW24Rwkx6JI2z6tg13Txecf8VclZXs6w0H0KRlulEf+6DnsTDpkE1Nj/OhtR8mOx32Q4djYbTVuA1bPfoA818TOuxHX9eN2NraYFyoH6ZOGoVAPw8kZhQhJjEXOUWVZjoWMP+aKjOeD0taz2QJfdBjG5awpqqtqRFJLzyCqqoquLu7wxJ1vBeeeMdTsHV00n37cgwSXrHsY9AXI0eOxA8//KBrUKXpknVxcdEtoJL0hR9++KFKdhEVFXXK5zQ1NamLp2sjIv1VV9bj49e3o7mpBVfdtAjevsN4mIksSFubEcfSCvH+1wfwxmd70dDYjItXTMMtF0dh1qRgODnqkMGCiGiQWr9+PZ599lm0tuo3yt+jV90ZM2Zgy5YtGD58uMr8Jwu4TufQoUO96oCkYZcgStZoubm5YePGjZg4ceIpnyvrtv70pz/1avtE1DctLW346n8HMPescbj8hoX48ZtYJB3N4+EksjBllXXYsi8ZWw+kYnyoH6aNH4XFs8eqtVexyXnIPE3mQCIaPFj8t3f279+vYpvvv/8ekydPhqura7fHN2zY0D9BlaxzkpTpYu3atdBTRESEyiYow4qffvop1q1bh23btp0ysHr44YdVoowOMlIVFBSka3+IqLt9O5JRmF+JVRdMx6hgb2z9/ijadElRTkR6j17FpxWq5u3piiljA3H+4snqfll3FZ9SgPLqeh50IhryPD09cckll+h6HDStqeoPy5cvx5gxY/Cvf/3rF5/LNVXdcU3VcVxTpdt6pq7riNyGOWH1xbNgZ2+r1llVlvewLh3XVP18PLmmqh3XVHW5JjT9iv5inSobgwFho7wROTYQ4cG+KCqtVgHWsfQiNDW3T3vhmqrBtZ7JEvqgxza4pqpnOt4LT7qt/9ZUxf9r8K2p6g92fRkuMxqNmDt3brf79+3bB1tbW8yaNUtTh2TbsnaKiCyLFAX+9J1dmL9kAq68aRG2fBWDlGP55u4WEZ2B0WRCak6parLOamJYAKaMG4nl88YjJasYcSn5SC8o16UoNBGRpZM4QxLiffHFF2hubsayZcvw+OOPq8zmWtn0ZWFXTk7OSffn5eWpx3pDpvNt375d1amStVXy/datW1VhLiKyPJJefeeWBHz/+SEsPXcKFq+KhI3GLIdENDAk7fqhY7l4+4toldxC6mCdu3Ai7rxiEZbOHgvf4W48FUTWzNQPbZB58skn8cgjj6g8DpIBUEpC9TZ+0W2kKiEhQSWuOJEksJDHeqO4uBjXX389CgoK1NDllClT8N1332HFihW97RYRDaD0lCJ88Pp2rL5oJq688Sx8+9khlJfW8BwQWVFyi20HUrH9YCqCR3pjcvgIrDt/Dsqq6tToVUJ6oaqDRUQ0mLz99tt4+eWXcdttt6nvJa36mjVr8Nprr8FG43KFXgdVkrCiqKgIYWFh3e6XwMiul7WW/vvf/8IiaC1uqsP8ZT3mXphM2pIHGHSZwKzDxxptGpMgnCE7ZY8ZzV9D/ExZNnvKBI3XxBkyjdaU1uKT13dg7qIIXHnDQuz58RiORKef3AcdMjufqR8DtYZHF1r7YdJhP3QYWbTR+Gtu0qGgtI3G31Fd1p3osB9aa10ZdHitysksU+0H+2OICPNX66+WzhiLjNxSHE0uQFp2iSpArGVt1y/RY12XoU2P86Hx59tg/rWXg2VNlR77ofV8NMNqMPtfz2RnZ2P16tXdcjnI+638/HyMGjUKWvT6ZXDlypVqmt7nn3+uRpdEZWWlGkrjCBPR0GJsM2LPT8eQlVaElRfOQEi4HzZ/cRj1tVwXSWRtmlvaEJeUr5rHMGdMGjsCS+aOxTlnTUBSRjES0gqRU1Bh7m4SEfWZ1KVycuqe0MPe3h4tLdpH5nsdVP31r3/FokWLEBISoqb8CUmJ7u/vj3feeUdzh4jI+uRnl+P9f2/F4nOn4Nrbl+CHL48gPanQ3N0ioj6qqmnA7kPpqo3098DEMSNw4bIpapG3ZA48llqAQk75JbIc/bUGapCtqzKZTLjhhhs6S0UJqZV7++23d6tV1W91qrqSRV2xsbF47733EBMTo7Jl3HjjjbjqqqtUpEdEQ1NzUyu+/+wQxk0aiRUXTEfqsXxs/+4omplWjMiq5RVVqfbDnkSEjvTGhDEBuHLNLNQ1NCEhtRDH0gpRWsf6V0TmxOl/PSP1cE907bXXQg99mgUtkdyvfvUrXTpARINLcnwe8nPKsXLtdFz1q8X49ovDKCqoNHe3iEgj+XwkI7dMte92HsOYYB8VYN04LQql1bVqeqCMYlXXNfJYE5FFeuONN/pt2z0KqiSX+7nnnqtGouTrM7ngggv06hsRWana6gZsfGcPZkSNwaXXzcf+3SnYvytVDbsTkfVrazMiOaNYNQd7O4SP8cXEMQE4e1Y48oqrcCy9EIkZRcwgSDRQOP3P7HoUVK1duxaFhYXw8/NTX5+OZM9oa9Mh9Q0RWT0JoA7uTkVWdhnOuXAGQsP98cOmIygvrTV314hIR80trTiaWqCai5M9xo/2V2uwls+LQFZBBRLTi5CUVaTqZBERDemgShamnuprIqJfUlJYhff/uw1RiyJw1U2LsG9nMg7uSeOoFdEgJLWtpMCwNHdXJ0SE+mHq+JFYtWA8sgsqkJRZjKSsYtQ3WFGuaiIrwDVVVhJUeXl5ITk5GT4+PrjppptU9eFhw4b1f++IaFBoazVi54/HkJJYgBXnTcPY8YHYvOkISourzd01IuonsrZqf3y2ahJgjQv1U1MEV0RFqCmCEmAlZxZzDRYRDQo9Ks3W3NyM6ur2Nz9vvfWWSj1IRNRbRfmVeP+/25GZXowrbliIuWeNg40OxWiJyPIDrAPx2XjvqwP454c7VFKL8CAf3H75Aqy7YA7mTQ7FcHdnc3eTyPrXVPVHI/1GqqKiotRaqpkzZ6opO3fffbdKpX4qr7/+es/+ZyIaugWDtyYiLbEAy8+bhjERI/DjN7EozGNRUaKhQKb+HU7MVc3J0Q7jQvwwNtQfZ80IQ3lVPRIzi9QoVmllnbm7SkSkb1D17rvv4vnnn0daWpr6vqqqiqNVRKRJcWEVPnxjB2bMDcPFV0chKT5XTRFsatRe1ZyIrIMkr4hNzkdMagEc7e0wJshHrcOKmjIa1bWNSMwqUlMEC8tqzN1VIsvG7H/WEVT5+/vjmWeeUV+PHj0a77zzDry9vfu7b0Q0BEatDuxORXJCPhavjMS6O5Zi55YEJMTmmLtrRDTAmlpakZBeqJq9nS3CRnqrAOvqc2eioakFKdklquUUVsLI8gxEZO2JKpYsWQIHB4f+75kVMemQEVHS0euwEW0/r8cfKT2yQ2rdj7ZBkqGyTfs1YejZssnTMkGHa7sHWZRrSmvx5ft7MWb8CCxaFYlJk0fhx69jUV7S/um0SeOyK4NJh98vPWjcEYMOy89MJu3n1GTUdjxNNtrPh9aXKx0Og+brUo9+mGy0v27rcT4Mmq+J7vthbG5FakqRara2NggJ9MLYEF9csDAS9nY2SM8pQ2pWsbptam5/kTHZaupC+zY0vu7qck1oPKdGPY6DHr+jWo+FLsdS4wasKEkls/9ZSVDVkahCgipJVPHss88y+x8R6U7WWWWnFWPOoghcecsixERnIHp7EprbuFKWaCgXGk7PKVUNO48hwNddBVhzp47GmsWRyCmoQGp2KVJyS1BV02Du7hLREMVEFURkUVpa2rBrSwKOxeZg6eopuPbXS7Ht+3ikJRWau2tEZAEKS6pV23EgDe5uTggP8VVt8byxKtFFanaJavnFVebuKtHA4Zoq60tUIdPUmKiCiPqbTP379K1dmDA1CMvOm4pJ04Kx9bujqK6s58EnIkWSWRyKz1HNwckOo0d5IzzYF5etnI42oxFpOaVIySpBZl4ZWgfL1HAiskhMVEFEFu1YTA7SUoqxYOkEXHvbYuzflYKDe9JUkgsioq6JLhIzilSzMRgw0t9TTRNcOncchrk6IjOvHGk5JSrQqqlr4oGjQcVgMqnWH9slHYOqrjIyMjq/liLATk5Ovd0EEVGvSJp1SVyRENM+JXDC5FHYvjkemanFPJJEdBLJDphTWKHaj/uS4e3pivBgH0wcMwIr5o9HWWV9+zqt3FLkFVWizcg3jkQ0wEGV0WjEk08+iVdffRVFRUUqK2BYWBgee+wxhIaG4uabb9bYJSKiU5MCwR+8th2TZ4Rg5YXTUZRfiR2b41FeWstDRkSnVVZZp9q+2Cw4OtghdKQXxozywfmLJ8PB3hZZ+eUqwErLL1dTComsDtdUWV9Q9ec//1llAHzuuedw6623dt4fGRmJF154gUEVEfUrk8mE2IOZSIrPw7xF43DVzYsQH5ON6B0pqOeUHiL6BZKCPSmjWDXh6+WmAqz2UawJKK+uVwFWem6ZGuniKBZZA6ZUt8Kg6u2338a///1vLFu2DLfffnvn/VOnTkViYqLe/SMiOu2UQMkKGHcoC/OXTMC69UtxeF+6Wm/VcrxuDRHRLykpr1Vtb2wmHBztERI4HGGjfLD6rIlwdrRHZn45MvLK1FqsKo5iEZFeQVVeXh7Cw8NPOS2wpaWlt5sjItJEpv5t+mQ/AkYOx8KlEzBlVij270xBzIFMJrMgol4nu0jOKlFN+Hi6qgBrXIgfls0dp4KqrONBVlZBRWfhYSKz4/Q/6wuqJk6ciB07diAkJKTb/Z9++immT5+uZ9+IiHq13urTd3YjZIyfyhQ4bU4Y9m5LRGJcnvpbQ0TUW6WVdapFH81Sa6+C/Ier9ViLZobDy90FBWXVKqtgZn6ZqovVylcboiGr10HVH/7wB6xbt06NWMno1IYNG5CUlKSmBW7atKl/eklE1ENZacWqRUSORNTZ4zFjXjj2bE9EekoRjyER9VlzSxvSJJlFbqn63s3FEaGBXqpduGQKHOxskV1coUaxZMqgBGNEA4VrqqwwqLrwwgvx5Zdf4oknnoCrq6sKsmbMmKHuW7FiBczCJPVqNNSsMRk0/v8af15tw2T2bZja2jR3QYcjMXgYbDT+vPnrMBlgo8OMBKNZrqvk2BykxuchckYIlp07BTPn1mHXT8eQn13exz7ocD60Hk5bPV5rdNiG1n7o0AeDxm2YdDiWJhsdtqHxsjJp/xWFyVaHbWhMSa7LsdT+J6xXx7O+uREJlflISMhX3/sMd0NosBfGjPTGkunhaGxuVUWH1UhWXhnqGpp178OpGNr0uLa1vyfRuh+6XNsarytTz04ZUd+CKnHWWWdh8+bNfflRIqIBIwWCY/dnICEuDzPmhuGCK+YiP7sMu39KRGlxNc8EEemmtKIWJdW12H80G7Y2BgT6eWL0KG/MnBSENWdPUiNXWcdHsXILKtX6LSLdcE2VdQZV4uDBgzh27Jj6etKkSVxPRUQWS7IB7tuRrFKxz14wFlfcuBApiQXYuy0J1ZX15u4eEQ0ykoa9o/jw9gOAk6Mdgkd4qfVYS+eMw3APFxSVVqtkF5L4IrewEi2tOgy1EZH1BFXFxcW48sorsXXrVnh6eqr7KisrsWTJEnz44Yfw9fXtj34SEWnWUN+M7ZvjcTg6HVFnR+C62xbj6OEsRO9MUY8REfWHxqZWJGcWq9axHit4xHCEBHph5fzxcHdzQkFJNbILKpBZUI7c4kq0tZl/CjhZD66pssKg6q677kJNTQ3i4+MxYcIEdV9CQoJKXnH33Xfjgw8+6I9+EhHppqaqAd9/cUTVtJIaVzfcuQxHojNwaG+aqn9FRNSfauubkJBWqJqQoCpkhBeCA4djzaJJcHF2UNkEswvK1WhWvgRZGtetEZGFBVXffvstfvjhh86AqiPN+ksvvYSVK1fq3T8ion5TVlKDLz+OxohRwzFvUQRuuns54g5m4tC+dNTXNvHIE9GAqK5tRFxKvmqSoGG4u7OaLiiB1rTxo+DoYIe8okrkFFWq0az8kiqOZFF3XFNlfUGVpFG3t7c/6X65Tx4jIrI2BbkV2Pj+XlVAWNZc3bh+GRJic9RIFtdcEdFAq6huQEV1HmKS8tT33p6uCA4YrqYMTh8/Ck6O9igsre5ct5VXVMXEF0Rm1uuElUuXLsU999yD/Pz2FKJCalbdd999WLZsmd79IyIa0ALCMnL14es7YO9gh+tuX4JzLpoBHz93ngUiMpuyyjocTszF5z/F4Z8fbMdr/9utAi5XZwcsnxeBe65bjBvXzlNfjw/1g6uTA8/WEF5XpWfT6plnnoHBYMC9997beV9jYyPWr18Pb29vuLm54ZJLLkFRUfdaktnZ2VizZg1cXFzg5+eHBx54AK2trYNrpOqf//wnLrjgAoSGhiIoKEjdl5OTg8jISLz77rv90UciogGfFvj954dVdsCZ88aobIE52WXYvysFBXkVPBtEZFaVNQ2qyXRBIcHVKH9PBAUMx/ypo+G72E09LtMFc4pkNKtSfU80kPbv349//etfmDJlSrf7ZSDmq6++wieffAIPDw/ceeeduPjii7Fr1y71eFtbmwqoAgICsHv3bhQUFOD6669Xs+Keeuopiz2JBpOp9xVj5UdkXVViYqL6XtZXLV++HAOturpanYwlthfDznDylMSeMthqrHyo9ef16IMe/bC1sYz9sNHYD0vog7Drc8UC3c6H9mOpQ/FfPQrWatwPk8afd3F1xPSoMZg8IwSlRdXYvycVWWnFA94PPYr/6lJkVWM/9OgDtBb1tJRjqXU/dCn+q8d+aP158/dBj37oUkhZh2Mpa7BG+nmoKYMSbI3wcUdDU4sKrnKPB1olFbU43TtAfY6leX9ej/PZ1tyImLcfQVVVFdzdLXPGQsd74ZmX/Rl29k66b7+1pREHP3m018egtrYWM2bMwMsvv4w///nPmDZtGl544QW1HckU/v777+PSSy9Vz5V4QmKJPXv2YN68efjmm29w3nnnqVlx/v7+6jmvvvoqHnzwQZSUlMDBwTJHYvv0rk+G8VasWKEaEdFgV1/XhF0/HcOB3amYPDMEK8+bhrraRhzYk4qUYwXqgyYiIkvR1NyK9Nwy1YStrQ0Cfd0R5D8cY4N9cPbMMfJmTiW8kAQYucVV6mv5OaLTBW9dOTo6qnY669evV6NNMugiQVXXOrctLS3dBmPGjx+P4ODgzqBKbidPntwZUIlVq1bhjjvuUNnHp0+fbt1B1Y8//qiG5/bu3XtSpCpR5/z581UUedZZZ/VHP4mIzK6pqUUFVof3pWPStGAsWDwBUWePx8E9qUiIy4WRdWWIyAJJzSsZpZK2O0bFU/D1dEOgnwdG+Xli4pgAeLo5o7SqTiW9yC2tRF5xFcqrWRzdWvR3naqOJT8dHn/8cfzxj3885c98+OGHOHTokJr+d6LCwkI10tRR67aDBFDyWMdzugZUHY93PGapehxUyZDdrbfeesqhPxl2vO222/D3v/+dQZU106MGhsECtqHHqIEe2zC2aeyDDtk0tU6F1OE4GHSYw6F1EwZbPc7nz9NIjC1tiNubhvjodIybNBKzFoxF1MJxiD2YgaMHs9TI1inZmHTrgzmnthqMFjD9z6CxD4Nl+p8e+9Gmx+u21mtCex/0Oacm65/G2MMulDfUoLygBkeRq753cbJHoL8nRvp7YProQKyeMwEtLa3ILWofzZJWWFKN1h5+eKR1KqQ+x1Lb+TQ0W9EshH5OqS75E7rGAKcbpcrJyVEJ7TZv3gwnJ/2nI1qyHgdVMTExePbZZ0/7uNSo+utf/6pXv4iILJ7RaEJiXK5qIeF+mDYnDLMXjENyfB4O70tT66+IiKxBfWMLUrNKVJPAztbGAD/vYRgZIIGWJ2ZGBqvAq7isRo1mSXHiguIqJsAYIiSg6smaqoMHD6K4uFitp+ogiSe2b9+ukt199913aG5uRmVlZbfRKsn+J4kphNxGR0d3225HdsCO51h1UCU7c6r6VJ0bsrNTi8eIiIairNRi1bx83DBldhguu/EslBRU4si+dKQlFXLdFRFZlTajCQUl1aodiMtW97m7OamRLAmyZk0Ohr/3MLUOS57TEWTJLddmDTyDsb31x3Z7Y9myZYiLi+t234033qjWTUmiCZlGKPHEli1bVCp1kZSUpFKoR0VFqe/l9sknn1TBmaRTFzLyJUHdxIkTYfVB1ciRI3H06FGEh4ef8vHY2FiMGDFCz74REVmd8tJabP0mFnt+OoZJ04OxcMUknLUyErEHMhB3JAdNjS3m7iIRUZ9U1zaqdiytqDMBhgRWI/w81PqsyWNHwMPdGeWV9cgvOz6aVVKFkvJaFaTR4Dds2DBVZqkrV1dXVZOq4/6bb74Z999/P7y8vFSgdNddd6lASpJUdMx+k+Dpuuuuw3PPPafWUT366KMq+cWZkmNYTVC1evVqPPbYYzjnnHNOmiPZ0NCgFqxJ+kMiIoIKng7tScPhvekIiwhQUwPnnD0ex2JzELM/QwVfRETWngBDAidpB4/f5+xojxF+7hgR4IHwYF8smhkOeztbFJZVt49klUirRhXrZlnVmio9Pf/887CxsVEjVU1NTSqzn6Re72Bra4tNmzapbH8SbElQtm7dOjzxxBOwZD2uUyXT/2R+pOyoZAGMiIjozC3/0ksvqfmSkunjxGwd/Yl1qnROSqBxobF+9bYGSZ0qrfuhw/nQfCws4ThYSH0nPc6HzwhPTJ0zGhETRyI/pxyxBzORnlzU86mBuizE1+OcMlHFoEpUocMloT1RhfYuWMKxsIxEFRbQhxMSVQx3d1EjWYG+MqLlDl+vn6cNFpb+3GrrmyzqWEqdqoMf/d4q6lTNXtt/dar2f9b7OlVDUY9HqiRYkqrGEjU+/PDDnW8CpGaVRJgSWA1kQEVEZG1Kiqrxw5cx2LWlfWrgohWTsHjVZBw9koWjh7JV7SsiosGmorpetfjUgm7TBgN83FUbF+oHH09X1DU0dwZY+WXtt5JAg8yfUp10Lv4bEhKCr7/+GhUVFUhNTVWB1dixYzF8+PDebIaIaEhrqG/GgV2pOLg7DSFjfDFlZihm3TkWWWnFSIjJRkZKMRNbENGQmDbYQaYIdg20JoSPgJeHC2rqGjtHtAok4CqrRmMTixSTlQdVHSSImj17tv69ISIaQuSDqczUYtWGeThj4tQgLD5nMpautlFrr+KPZKOyvM7c3SQi6nctrW3ILapUrWP6n6O9Hfy83TDCxwMjfNwxZVwgPN1d1HosCbCKymqON45oqbqSetTYPFF/bHOQ6lNQRURE+qqpasC+7cmI3pGCoNE+mDQ1GNf8ajGKCypVcJWSkI8WYz/kyyUislBNLa3IKaxUrYOTox0CvN1VkCUjW1OPB1q1dU1qFEuCLHVbWoPqxtMUYifqBwyqiIgsbPQqO71ENUcne4yPHKkyB569KhIpiQUqwCrIqzB3N4mIzEKm/mXml6vWoWNES4Isf293RIT6wdvTFY0trWoUq1AFWjWqcHF5df2gPHNcU2V+DKqIiCw4LXvMgUzVfAM8MGlGMC64Yg4a6poRH5ONY3G5qK/jJ7FENLSdakRLkmH4Hg+0ZGRrbmQI/Ia7qXpZxeXto1mHE/NQVsUp1qQPBlV60KGgnUmHMtiSiVETHVItm0w67IdJ4360tWFQ0COluiXQYT62wcZk9vzAJl1KDvR9P0rzyrGtoBI7vzuKMREBmDQ9BFGLIpCVWqRGr7JSi2HsyWuRHqmcjOZ/rYHWTRi198FgASmfTW06vE7osR9aU6rrkQ69zWQBqeF1eD+g9Vjo8DtuCenMTZr3w4jihioU51Yh7vg9NgYDvIe7to9o+bjDodUA28bT/z+mFitaT2RFdaoGK7MGVU8//TQ2bNigal05Oztj/vz5ePbZZztrYBERUXdtrUYkx+er1p7cIlilZbddI8ktcpEYl4Oy4hoeNiKiExhNJpSU16p2NKU9vTvRoAiqtm3bhvXr16tMgq2trXjkkUewcuVKJCQkqOrJRET0S8ktkhC9IxmjQr0xaVowrrhpkcoYmBSXi6T4PNRWN/AQEhENclxTNcSDqm+//bbb92+++Sb8/Pxw8OBBLFq0yGz9IiKytuQWORmlqtk72KnpgRGRIxG1ZDwKciuQdDRXZQ+UNVpEREQ0yNdUVVW1F4Hz8vIyd1eIiKxSS3MrEuNkGmAuXFwdET4hUE0RlOyBUlw4MT4fGclFaG0dJGsPiYiIdaosgMUEVUajEffeey8WLFiAyMjIUz6nqalJtQ7V1dUD2EMiIusimQFjD2So5jHctX306uwILD9vKtISC5AUn4+czFIY21j/iojImnH6n/lZTFAla6uOHj2KnTt3njGxxZ/+9KcB7RcR0WBQVVGn1l7t25kCvxEeGDdpJJatmQJ7ezukJRUgOSEfuRJg6ZDNlIiIaKixiKDqzjvvxKZNm7B9+3aMGjXqtM97+OGHcf/993cbqQoKChqgXhIRDQ7FBVWq7fwhAQEjh2PcxECsOG8abO1t1AhWamIhR7CIiKwJU6oP7aBKFlffdddd2LhxI7Zu3YrRo0ef8fmOjo6qERGRPgrzKlTbvjkegUFeGDthhBrBcnC0R2ZqEVITC1QNrJYWrsEiIiKyyKBKpvy9//77+PzzzzFs2DAUFhaq+z08PFTdKiIiGjj5OeWqbfs+Xk0RlCyC8xZFYNWFM5CdXqKmCaYnF6GxmVkEiYgsCddUDfGg6pVXXlG3ixcv7nb/G2+8gRtuuMFMvSIioo4pgnu2JsHTyxXh40dg8sxQLFszFfm55WoEKy25ELU1jTxYREQ05Jl9+h8REVk2KSZ8YHeqam7DnDBmwgiERQRg0YpJKCmqRqqMYCUVorys1txdJSIamiTJUH8kGmLyIutKVGFuJo0XjMFWj06YzL8Now5plQ0GzZswQdvaDYOtDiekzQLWj+hwLC3iurSxNX8/dNgPgx7nw2Sj7cdlfodGBltt+1FXWYfYvWmqOTrbI2xcAMZEjMDc+eGormxQiS4ykgtRlF95+g/ObPS4rrT9uEGHPph0uCa0ng89+gAbHV63NZ4PU5vBMv7+aD0WGo+DHn0w6fJSpcf50NgHWz36oPH3vIXlJqjnGFQREVGfNDW04FhMjmr29rYIGeOnRrEuuGqeCqik2HBmShGy0ovVc4mIqJ8w+5/ZMagiIiLNJDugrLOSJqN6ASM9ETo2ALMWjMXKtTNUhkEJsKSVlHKaIBERDS4MqoiISFcySlWQW6Hanp+OwXWYE0LD/REa7ofZC8eiqakNGalFyEwtVvWwWppbeQaIiDSQyZI6zBA/5XapZxhUERFRv6qraUT84SzVbGxtEBjqg9Axfli4bALcPV2Ql1WGzLRiZKQUqaQYRERE1oZBFRERDRhjmxE5GaWq7fghAR7DXVSAFTrWH/OXTEBtdYMKsKQuVm5WGUexiIh6QhID9UdWbWbq7jEGVUREZDZVFfWIOZCpmiS7GHV8FOusFZPg4emi1mJlZ5SoIEy+NjK9LxERWSAGVUREZDHJLmQKoDQxzMMZQaE+CA7zxZSZobCzt1VTBSXIys4sRXlpjbm7TERkEWQ9Vb+sqWJJ2R5jUEVERBappqoBCTE5qgkfP3cEj/ZRqdsXLJ2ApqbW46NYJcjOKEVdbaO5u0xEREMUgyoiIrIKpcXVqh3alw4bexuMGDlcBVmTZ4ZixXnTUFFe1xlk5WaXobmJWQWJaIhgnSqzY1BFRERWmfAiL7tMtT3bkuDoZI+Rwd4qyFq4bCI8h7uipKgaudmlaspgXk45mhpZgJiIBieDyaRaf2yXeoZBFRERWT0JmNKTC1UTrm5OGBnshZEh3liwdCKGe7mitKSmMxDLy61AQ31zn/8/dw9nVdxY1nUVFVZxVIyIaIgbFEGVyWiCScNKOoOt5g7o8LGrjeZNmAza+mGw0d4HtLVp3wa0nRATtPfBYNDhWGjvhPZtaP2EyaTDcdAjW5uNxmNhY2v+PgijBfyOGg3mvzZtjf3eh/qKOqRIO74ey8XVEYHB3iq74LwFY+Hl646Kstr2ACurVKVvr69t6vF/7znMCQH+7ggO8lK1to7F5uDwvnT1mGQxlP71qKixxpcrPa4Jkw6vNVpfMk16XNt6VCnVeCxMtto7YdK6CR3Op0mP1zut14Qu+6Ht521adXitGijS1f7orhUdAnMbFEEVERHRmdTXNSH1WL5qwsm1fSQrMMQbM6PGYtXamaiqqFNTBSXAkkCrtub0iS8K8yqRnVnWmUBj/tIJyEovQWN9M6bNGY0xESNgY2PA/l0pnYk2iIho8GJQRUREQ05jQzPSkgpVE7ImKzDIS41mSVC04oJpSE0swLcbDp7y52UUysbOVq3tkmmEXt5uKqBSWQkbW/DxmzvV6NjiVZGqvlZ5aa36ucgZIRgV4o3K8jocPZSF2jpmLCQi7bimyvwYVBER0ZAngVDXGln2DnZwdnE443GRgEqCsQXLJqAwvwJNTS0YNzEQb7y0RW1Pmpu7M5xdHAHUYuHyiXB2dkB2eglGjBqugrc9O5LQZk1TjIiI6JQsYOEIERGRZZGRqOrK+jM+JyTMFyvOnwZbWxt8u/EQ/AM9Ve2sjrVZsrZKphTaO9jC1s4Gk2eEIHpn+3TALV/FYuLUYDg48LNNItIxpXp/NOoRvpoTERH1goxOTZwaBP+RXirbYMeaKf8RnmpaXweP4a5oaWlTI1aS7r2xoUUFWcLJ2QFlJTUY5u6sKQshERFZBo5UERER9cK5l8zCwuWTUFpSjZRjBZ33Oznbo7Kife2U8BvhoT7llfVUUqi4pLCq8zFPL1c1oiUjWEREumT77a9GPcJXcyIiol7YvyMZ2747iuHeblh71Vxcf8cSuA1zQlJ8Puzt7RAwcrh63uSZoSgqqFQjVV4+w1BaXN25DR+/YWhpaUV9HUepiIgGA07/IyIi6oWOAsKmg5mdSS1UTaqaRpQVV2Pp6imws7dVtavijj+nKL8CwzxdOrcRETkKaUkFqKlu6LZt2daoYG8VjEkaeCKinpByrRpKtp5xu9QzDKqIiIg06FrkVxJRSOsMtI6LO5yN8y6bjYuuiUJdbaPKHBh/JEfddiVrrBYum6hGwWqq6lFUUIXiwko1dbC4sIrrr4iILBSDKiIiIp11Dag6vt/0cTQCRg2Hu4cLUo7ltz/nhEn45aU1eOdfP8HB0U4lvpB1WX4BnipToOdwV9TWNKjgSgVZEnAVV6PueLZBIhrC+mv9E9dU9RiDKiIiogEgmQBzMkp79NzmplbkZJaq1kECLV9/CbI84BvggbETAtVarYaGZhVoFXcEWkVVqKnqPq2QiIj6F4MqYdJWeNFk1J7vw2Br/k8TTEbtBSgNNjrkPmlr0/bzJu19MOlwPgwadwM2BvN/wqTDNQFbHQ6mSeOxMOrw6Z0e58OgcRsGHX6/bG3Mvh+GNoP5z4fBaP7zKWwNvQrK8muLkZ9W3HmfTDP09nNXI1q+AZ6YGzVGfS9BWUlhpQqyJEGGjGxVltXCeIrfBYMO+2HSek3YtFnE+TBp/Bumx6+o1v3Qei7a+2AB+9GL343TbkPjJkytOlyXA0Re0vR4WTvVdqlnGFQRERFZKQm0CvMqVOtgY2ujsgtKkCXB1pRZo9X3NjY2anphaVE1SouqUKJuq9HY2GLWfSAiGgwYVBEREQ0ikvxCTQMsqEL84Z/v9/Byha+fO3z8PTAyxAdT54TB3dMFtTWNKriSzIUlRVXq64qyOpi4loLIenBNldkxqCIiIhoCqsrrVEtNLOi2TssnwAM+Emz5uWP63PbpgzJzq6ykY1SrWk0hLC+pYZp3IkslM3v7I/05U6r3GIMqIiKiIUrWXuVnl6vWdY2Vx3AX+Pi3j2oFjZZRrdHw8HRRKd0l2JJRrY7b8tJaNDZ1z3ZIRDTUMKgiIiKiTjLtr7K8TrXUYz+Patnb28LLd5gayfL2HYbwCYGYuygCrm6OqJHCx12CrfKSWrV+S9Z8EVH/M5hMqvXHdqlnGFQRERHRL5IAqSi/UrWuHJ3s4SWjWr7u8PYbhknTQuDl6wYnJwdVwFgFWaXSJNCqRUVZLZqYHIOIBhkGVURERNRnEiCdOIVQuLg6qhEtLx83VU9rwpQgDPd2U/fX1zWp4Kq8I+Aqbw+46mobeSaI+oKJKsyOQRURERHpTgInaV0LGHeObPm4qQBLphOGjPHD9Hlj4O7hjOaWNhVsVXSObNWgvKwWVRX1zEZIRBaNQRUREREN6MhWQW6Fap1sAFs7Gwz3cusMuHwDPBARORKeXm4qG6EEVhXltaqIsQRaHeu+JHAjGvJk6VN/FOrlkqoeY1BFREREZtfWalSp26V1JdkIpZ6Wp5crvLzd4OntiohJo9TXrsOc0NzUgoryOtUk4FK3EnyV1zFRBhENGAZVREREZNHZCKsq6lTLSivu9phkJJRgS0azZHTL09sNo8f6q6+lBlddTWN7wNVlZEttq7IebW398bE+kXkw+5/5MaiyFCYdXtyNNtp+XuOPC5NR+34YbDR2RIc+6MFk0DhmbjJo7oPBoPWaMOizeFYrmfujhdZrShgN5t8Pg3GQ7IcO50Prtal1H46PoGjWqvXatoDzqcc2+nhJtDa3orSuCaU55Sf1wdnFAcN9hqmgS4KskYGemBQ5Eh7DXWFra4Pa6obOIKvjVgKw6op6tLa2me1YmjRuQyBsde4AAB/7SURBVI9fL0u4JrQeB0XjsTC1sv4a9RyDKiIiIhp0pFBxQ3YZ8rPLTnpMpg1KsCUBltwGjByOiMhRamqhvYMdamsa1RTCqvL647d1qFSjZfVoaeYbbbJA8vllf9SU4pqqHmNQRUREREOKTAuUlpd1QsBlMKiU7x7DZQ2XGzy8XOHr76EKHUvwJZkLJViT0ayOaYRyq76vrENtTROzFNKQ9vTTT2PDhg1ITEyEs7Mz5s+fj2effRYRERGdz2lsbMRvfvMbfPjhh2hqasKqVavw8ssvw9/fv/M52dnZuOOOO/DTTz/Bzc0N69atU9u2s7Pc0MVye0ZERERkplTw3bITHufobA8PTxc1wuV+/DZgpCfcPV0xzMNZPadaAq3K+vbb4wGXjHLVVDWw6DEN+jpV27Ztw/r16zF79my0trbikUcewcqVK5GQkABXV1f1nPvuuw9fffUVPvnkE3h4eODOO+/ExRdfjF27dqnH29rasGbNGgQEBGD37t0oKCjA9ddfD3t7ezz11FOwVAaTrAC1UtXV1epkLDZcBDuDfZ+3Y9A8N1/7BGbNfdCjHxYyN1/zmipd5mHbWMAag0GypsoC5uZbxPnUYxu6XNuWsB+DY02VRWzDEs6nHutfBsE6IBsbA9w8JNByUUGWp9we/1ruc3KyR2Njiwq2pEmQJdMJa6rag7CaynqVrZDH0nLWVLW2NuKng0+jqqoK7u7usOT3wkunPgg7W0fdt9/a1oQfY57t8zEoKSmBn5+fCrYWLVqktuPr64v3338fl156qXqOjGpNmDABe/bswbx58/DNN9/gvPPOQ35+fufo1auvvooHH3xQbc/BwQGWiCNVRERERBoZjabOgAnoXvBYyNRBFXB5uGCYp9w6I2SMrxrxkvvsHWzbpxZWNbS3yjpUVza0B1zVDZ1BF9GpL0D5UKAfjo3x5+Ct2/Xs6KjaL6mqqlK3Xl5e6vbgwYNoaWnB8uXLO58zfvx4BAcHdwZVcjt58uRu0wFliqBMB4yPj8f06dNhiRhUEREREQ1A0ePigirVTsXJ2UEFXW7Hgyx3T2eEjvVXwZcEXnZ2tmhsbEZNpQRd7SNdKtiS2+NfsxAy9ZegoKBu3z/++OP44x//eMafMRqNuPfee7FgwQJERkaq+woLC9VIk6enZ7fnSgAlj3U8p2tA1fF4x2OWikEVERERkZk1NjSrVniGoEsCLQm43Nyd1G1gkBeGTXJW67mcXRxV7a2amo5A6/gI1/GAS0a/amsaVJFlGnz6u05VTk5Ot+l/PRmlWr9+PY4ePYqdO3diKGBQRURERGQlQdfpRrps7WwwzN0Zwzzbgyz1tYczAoO81WiXm7uzqs8lo1lSo0sCLXVb09jl+0bU1TbCaLWr7Yewfk5UIQFVb9ZU3Xnnndi0aRO2b9+OUaNGdd4vySeam5tRWVnZbbSqqKhIPdbxnOjo6G7bk8c7HrNUDKqIiIiIrJyMQEkR48rKutM+R9LFdwZc7hJoOcF/hCfCI0ao713d2kcf6uqaUFPdqEa2JNBSAVfN8dvqBtTVMnU8nZrJZMJdd92FjRs3YuvWrRg9enS3x2fOnKmy+G3ZsgWXXHKJui8pKUmlUI+KilLfy+2TTz6J4uJileRCbN68WQV1EydOtNhDz6CKiIiIaAiliy/Krzzl4waDQQVWw9QUQwm8nOA2TEa7vOA2zEnd5+p6PPCqlaDr51bX5VamIErgxcQaQy+l+vr161Vmv88//xzDhg3rXAMlGQqlbpXc3nzzzbj//vtV8goJlCQIk0BKklQIScEuwdN1112H5557Tm3j0UcfVdvuybRDc2FQRURERERqlEEFSbVNQN7JdbqEja2NCrzc3NqDLAm2XIc5wcfPHaFj/NTol6ubE2ztbNHc1NIeaNXKKFeXgKsjAKttVBkPrbe4D53olVdeUbeLFy/udv8bb7yBG264QX39/PPPw8bGRo1UdS3+28HW1lZNHZRsfxJsSX0rKf77xBNPWPQBZ1AlQbjGycMGG+2LPk1GPWpdaeyHDn3Qo9aIqa3N/LWy9HiF19oPk/aDaTJo3A89svdaRL0t4+CoSaQHS6jZZQnH0kLqO2nvgwXU/Do+wqFxA4PjfFjAsezv+k7yV6W2vgm1xd1TbJ/IycWxPcA6PsLVMdLl7+sL12Ht30vyDaPJiPraJjWyVacCrvbbjqCr43sJvnpN47GwaWuF1bCQkSpTD57v5OSEl156SbXTCQkJwddffw1rwqCKiIiIiPolsUZp0emDL0muIeu8ZIqh6zBHuMjo1zAneHi5ITDEW93v4uYIJ6f24Ks9wGpf66UCseOBl0xp7Pi6oU5Gvjj0RUMsqJKMIH/5y19UIbCCggK1qG3t2rXm7BIRERERDVByjY46W2ciwZdMKVSjXsenG0rz9HbDyFDv9sfc2ke+JKBqqG9qD7o6gy0ZCWs8PiLWHoTV1zQOrjVf/Vz8lyw8qKqrq8PUqVNx00034eKLLzZnV4iIiIjIQoOv6sp61c5E1nu5uDiogEtGvTqCLxkN8/YdpgIvFxkRc3VU6eU3fRyN9CTLLSZL1sWsQdW5556rGhERERGRFsY2Y2c2wl9aU+XobI+2lsEzDNPfxX9pkK2pkgwh0jpUV595kSQRERER0UnvKRtaeFBIVzqkDRo4Tz/9tMpv39GCgoLM3SUiIiIiIsvI/tcfjQZfUPXwww+jqqqqs+Xk5Ji7S0RERERENMRZ1fQ/qaJsyZWUiYiIiIgGnNRc1Vqb8nTbpcE3UkVERERERGRpzDpSVVtbi9TU1M7vMzIycOTIEXh5eSE4ONicXSMiIiIisg79tf6Ja6qsI6g6cOAAlixZ0vn9/fffr27XrVuHN99804w9IyIiIiIisoKgavHixarytWYmqTOgodaAwQJmQap90LoJbfthsNGhXoMexcm1ng8dTqepTYcdOUN9jB79uCV8OqRxHxST9hNi0lrSXY/9sOmPUvW9Y9DjtUqP33Ot9DgfemxDKxubwbEfg+Z8DJL90Ph7brCA1ypdjqUFnAtDWzOsR39l6rOA9yJWwqoSVRARERER0Qk4/c/sLGCIhoiIiIiIyHpxpIqIiIiIyJqp1OdMqW5OHKkiIiIiIiLSgCNVRERERETWTBKe6ZD07JTbpR7hSBUREREREZEGHKkiIiIiIrJmzP5ndhypIiIiIiIi0oAjVURERERE1ozZ/8yOI1VEREREREQacKSKiIiIiMiacU2V2TGo0oFJDblqY7Ax6NERjT9uGQOXBhuN6TvbdOmEDhvRdl2Y5AXS3Aw6XJdt2k+IwcZmcBwLjUyWcBws5FhAj9dMjQy6vE5Y/3GwmGvCEvpgCb+jlnAcLKUfWvtgbNKrJzQEMKgiIiIiIrJm8jlsf3wYawGf71oLC/hIhYiIiIiIyHpxpIqIiIiIyJpxTZXZcaSKiIiIiIhIA45UERERERFZM6Mk+TL203apJxhUERERERFZM07/MztO/yMiIiIiItKAI1VERERERNaMI1Vmx5EqIiIiIiIiDThSRURERERkzYyq+m8/bZd6giNVREREREREGnCkioiIiIjIiplMRtX6Y7vUMwyqhAVcMCajJQwatmnegsHGoHkbJu3d0M5gAcPdOhwHPc6HJTAZLOH3QweD5HzAYP37YbDRfk1ZwKvEoDgXig7nwyIMmvMxOPbDoPVvh7FZr67QEMCgioiIiIjI2rP/9cf6J9ku9cgg+WiIiIiIiIjIPDhSRURERERkzdSIEkeqzIkjVURERERERBpwpIqIiIiIyJoZjYDBOCiTuVkLjlQRERERERFpwJEqIiIiIiJrxjVVZseRKiIiIiIiIg04UkVEREREZMVMRiNM/bCmysQ1VT3GoIqIiIiIyJpx+p/ZcfofERERERGRBhypshSDZHjVZBwscXobBgWTAYPDIDkfhsHy+zEI2AyW341Bgr8blmWQ/H5oLYVrNDXDahhNgIHFf82Jf+GJiIiIiIg04EgVEREREZHVr6nqj+K//TD6NUhxpIqIiIiIiEgDjlQREREREVkxk9EEUz+sqTJxpKrHOFJFRERERESkAUeqiIiIiIisPot0f6ypGhzZqQcCR6qIiIiIiIg04EgVEREREZEV45oq8+NIFRERERERkQYcqSIiIiIismZcU2V2Vh1UdaR5bEULwNpkFoKDn5bEYDKYuwvUDX8/LAV/NywNX6ssCv92KK2mFqtJK95f74XVdmnwB1U1NTXqdie+NndXqIPlv+4MLW3m7gAREZF1k/ebHh4esEQODg4ICAjAzsL+ey8s25f/h87MYLKG8Ps0jEYj8vPzMWzYMBgM/JRrMKiurkZQUBBycnLg7u5u7u6QBeG1Qbw2iK8bNJB/U+QtsgRUgYGBsLGx3JkGjY2NaG5u7rftS0Dl5OTUb9sfLKx6pEou8FGjRpm7G9QP5AWOQRXx2iC+bhD/ppA5329Y6ghVVxLwMOgxP8sNu4mIiIiIiKwAgyoiIiIiIiINGFSRRXF0dMTjjz+ubol4bRBfN4h/U4jvN8gaWHWiCiIiIiIiInPjSBUREREREZEGDKqIiIiIiIg0YFBFRERERESkAYMq0mT79u04//zzVWE8KcD82WefdXtcluz94Q9/wIgRI+Ds7Izly5cjJSWl23PKy8txzTXXqDoRnp6euPnmm1FbW9vtObGxsTjrrLNUHQYp1vfcc8+d1JdPPvkE48ePV8+ZPHkyvv66/6qL0y97+umnMXv2bFWc28/PD2vXrkVSUtJJBQvXr18Pb29vuLm54ZJLLkFRUVG352RnZ2PNmjVwcXFR23nggQfQ2tra7Tlbt27FjBkzVIKT8PBwvPnmmyf156WXXkJoaKi6PubOnYvo6GieRjN55ZVXMGXKlM76MFFRUfjmm286H+d1QR2eeeYZ9bfl3nvv5fUxxP3xj39U10LXJn/zO/B1g8xOElUQ9dXXX39t+v3vf2/asGGDJDwxbdy4sdvjzzzzjMnDw8P02WefmWJiYkwXXHCBafTo0aaGhobO55xzzjmmqVOnmvbu3WvasWOHKTw83HTVVVd1Pl5VVWXy9/c3XXPNNaajR4+aPvjgA5Ozs7PpX//6V+dzdu3aZbK1tTU999xzpoSEBNOjjz5qsre3N8XFxfHkmsmqVatMb7zxhjpnR44cMa1evdoUHBxsqq2t7XzO7bffbgoKCjJt2bLFdODAAdO8efNM8+fP73y8tbXVFBkZaVq+fLnp8OHD6nrz8fExPfzww53PSU9PN7m4uJjuv/9+de7/7//+T10L3377bedzPvzwQ5ODg4Pp9ddfN8XHx5tuvfVWk6enp6moqGgAjwh1+OKLL0xfffWVKTk52ZSUlGR65JFH1O+rXCuC1wWJ6OhoU2hoqGnKlCmme+65p/Og8PoYmh5//HHTpEmTTAUFBZ2tpKSk83FeF2RuDKpIv4vphKDKaDSaAgICTH/5y18676usrDQ5OjqqwEjIm2D5uf3793c+55tvvjEZDAZTXl6e+v7ll182DR8+3NTU1NT5nAcffNAUERHR+f3ll19uWrNmTbf+zJ0713TbbbfxDFuI4uJida63bdvWeS3IG+lPPvmk8znHjh1Tz9mzZ4/6XoIoGxsbU2FhYedzXnnlFZO7u3vn9fC73/1O/aHt6oorrlBBXYc5c+aY1q9f3/l9W1ubKTAw0PT000/34x5Tb8jv+GuvvcbrgpSamhrT2LFjTZs3bzadffbZnUEVXzeGdlAlH8CeCq8LsgSc/kf9JiMjA4WFhWrKXwcPDw819WrPnj3qe7mVKX+zZs3qfI4838bGBvv27et8zqJFi+Dg4ND5nFWrVqmpZBUVFZ3P6fr/dDyn4/8h86uqqlK3Xl5e6vbgwYNoaWnpdt5kKkdwcHC360Omcvr7+3c7r9XV1YiPj+/RuW9ublb/V9fnyPUl3/P6ML+2tjZ8+OGHqKurU9MAeV2QkGnBMu33xN9tXh9DmywfkOUGYWFhatmATA8XvC7IEjCoon4jAZXo+oa44/uOx+RW1sl0ZWdnp954d33OqbbR9f843XM6HifzMhqNak3EggULEBkZqe6TcyOBsgTVZ7o++nruJfBqaGhAaWmpeuPO68OyxMXFqXV0sg7u9ttvx8aNGzFx4kReF6SC7EOHDql1mSfi68bQJR/IynrZb7/9Vq3LlA9uZa11TU0NrwuyCHbm7gARDY1PnY8ePYqdO3eauytkISIiInDkyBE1gvnpp59i3bp12LZtm7m7RWaWk5ODe+65B5s3b1ZJZYg6nHvuuZ1fS6IbCbJCQkLw8ccfq0RYRObGkSrqNwEBAer2xGxu8n3HY3JbXFzc7XHJ7CYZAbs+51Tb6Pp/nO45HY+T+dx5553YtGkTfvrpJ4waNarzfjk3MjWvsrLyjNdHX8+9ZJWTP7Q+Pj6wtbXl9WFhZJRSMjXOnDlTjUhMnToVL774Iq+LIU6mccnfBMnmKbMWpEmw/Y9//EN9LSPOfN0gIbMcxo0bh9TUVL5ukEVgUEX9ZvTo0eqFbsuWLZ33yZQsWSslayeE3MqbavlD2uHHH39U08XkU6iO50jqdll/00E+xZRPuocPH975nK7/T8dzOv4fGniSu0QCKpnWJedUroeu5M20vb19t/Mm6+RkjnzX60OmiXUNvOW8SsAkU8V6cu7lzbv8X12fI9eXfM/rw3LIOWlqauJ1McQtW7ZM/c7LKGZHkzW3sn6m42u+bpCQ0itpaWmqZAv/npBFMHemDLL+DE2S6lqaXE5///vf1ddZWVmdKdUldfXnn39uio2NNV144YWnTKk+ffp00759+0w7d+5UGZ+6plSXrD6SUv26665TKZclPbak0D4xpbqdnZ3pr3/9q8ogJ1mCmFLdvO644w6VTn/r1q3dUuDW19d3S4EradZ//PFHlVI9KipKtRNTqq9cuVKlZZc06b6+vqdMqf7AAw+oc//SSy+dMqW6ZJ188803VcbJX/3qV+q67JpVkAbOQw89pLJAZmRkqNcF+V4yfn7//ffqcV4X1FXX7H+8Poau3/zmN+rvibxuyN98KbUhJTYks6zg6waZG4Mq0uSnn35SwdSJbd26dZ1p1R977DEVFMmb2mXLlqm6NF2VlZWpIMrNzU2lyr7xxhtVsNaV1LhauHCh2sbIkSNVsHaijz/+2DRu3DhVj0hSbEsdHDKfU10X0qR2VQcJrn/961+rdNoSGF100UUq8OoqMzPTdO6556raZPIHVP6wtrS0nHQdTps2TZ37sLCwbv9HB6lfJQGcPEdSrEtdNDKPm266yRQSEqLOhQTJ8rrQEVAJXhd0pqCK18fQJKUyRowYoV435H2AfJ+amtr5OK8LMjeD/GPu0TIiIiIiIiJrxTVVREREREREGjCoIiIiIiIi0oBBFRERERERkQYMqoiIiIiIiDRgUEVERERERKQBgyoiIiIiIiINGFQRERERERFpwKCKiIiIiIhIAwZVRGRVMjMzYTAYcOTIkR49/4YbbsDatWv7vV962bp1q9q/ysrKHv9MT/axL9tdvHgx7r33XliDRYsW4f333zfb///qq6/i/PPPN9v/T0RE5sWgiogshgQH8sZfmr29PUaPHo3f/e53aGxs7HxOUFAQCgoKEBkZicFo/vz5av88PDx6/DMvvvgi3nzzzTMGQ33Zrjl88sknGD9+PJycnDB58mR8/fXXv/gzX3zxBYqKinDllVd23hcaGtp5LXVtzzzzzC8GmfKzL7zwQuf3XX/e3d0ds2fPxueff97tZ2666SYcOnQIO3bs0HgEiIjIGjGoIiKLcs4556g3/+np6Xj++efxr3/9C48//njn47a2tggICICdnR0GIwcHB7V/8ga+pyRQ8vT01H27A2337t246qqrcPPNN+Pw4cNq9E3a0aNHz/hz//jHP3DjjTfCxqb7n7QnnnhCXUtd21133dWnvr3xxhvq5w8cOIAFCxbg0ksvRVxcXLfje/XVV6u+EBHR0MOgiogsiqOjo3rzLyNS8oZ6+fLl2Lx58xmn/8XHx+O8885TowjDhg3DWWedhbS0tG7b/etf/4oRI0bA29sb69evR0tLS+djTU1N+O1vf4uRI0fC1dUVc+fOVSMZHbKystTUruHDh6vHJ02a1DmCUlFRgWuuuQa+vr5wdnbG2LFj1RvwDjk5Obj88stV0OPl5YULL7xQ7cPpnDiCIiNQ8rPfffcdJkyYADc3t87A81TT/+Trbdu2qdGrjtEV+f9O3G5ZWZkKYGSfXVxc1KjQBx98cMZz80vH6UTyXDkvHWT0R/rw7bffdt4XHh6O1157TX0tfZZ9e+CBB9S+/r//9/8wY8YM/POf/zzt/1FSUoIff/zxlFPv5FqQa6lrk373hZwD+flx48apfrW2tuKnn37q9hzpg4yaNTQ09On/ICIi68WgiogsloxQyOiFjAKcTl5enlpPI8GYvLk+ePCgmoolb3o7yJtfCbLk9q233lKBStfpcnfeeSf27NmDDz/8ELGxsbjsssvUm/uUlBT1uARhElBs375djU48++yzKrgRjz32GBISEvDNN9/g2LFjeOWVV+Dj46Mek8Bt1apV6s29TAvbtWtXZ1DU3Nzc4+NQX1+vgsJ33nlH9SE7O1sFLKcigUlUVBRuvfXWztEZCVBPJFMqZ86cia+++kod51/96le47rrrEB0dfdp+/NJxOtHZZ5+NnTt3oq2tTX0vwZ4cm45ATM6dnBeZrihk2xJEdyXHT+4/Hdm+BIUShA0Eua7++9//qq9PvC5nzZqlHt+3b9+A9IWIiCzH4Jw/Q0RWa9OmTSrwkDenEsjIlK4zjVS89NJLavqbvNGXdVhCRhO6khEm2YZMHZT1OmvWrMGWLVtU4CEBiowsyW1gYKB6vgQsMpoi9z/11FPqsUsuuUSN5oiwsLDObctj06dPV2+oO9bjdPjoo49gNBrVSEzHtDvZpox6SGCxcuXKHh0TCc4kEcKYMWM6gxuZ2nYqcizkzb4EGjKycjoy2tQ1MJNpcTIa9vHHH2POnDknPb8nx+lEMmJYU1OjpvJJACcBoYxCffbZZ+pxOQbSDxmtEoWFhfD39++2Dfle7j8dGUWU55w49U88+OCDePTRR7vdJ8Gv9Ku3ZFRPrh8ZhZJzKudZRiC7kmMux1/6REREQwuDKiKyKEuWLFGjPXV1dWpNlaydkoDmdGQaoLxJ7gioTkWm68kb4g4yDbBjPYzcykjKiYGYBHQyVVDcfffduOOOO/D999+rkRTpz5QpU9Rjcr98L0kKJEiSaXiSFELExMQgNTVVjVSdOEp04vTEM5E36x0BVUf/i4uLoYXsswRCEkTJiJGMnMk+y/91Kj05TieS4HHq1KkqeJJAT5qMiMkaudraWjVyJaNZWkiQI0ktTkUCOJkO2ZUEcX0h16Kce1nrd99996m1UzKd80QyBVRGFomIaGhhUEVEFkXWvHSMXLz++uvqTblMt5LkBacib2J/yYkBl4wayWiDkDf3EnDJtMGugZfomOJ3yy23qGloMlVOAqunn34af/vb39TozrnnnqtGJmSNlaz9WrZsmZouKNP1ZNsyQvPee++d1CdZg9VTp+q/yWSCFn/5y1/UVEFZ5yQjcHLcJWPg6aYl9uQ4nYpM7ZOgSqZnSgAlgYhM1ZNpexJU/eY3v+l8roysSRa/ruT7M424yXRCWdd2usc6rqUTyfo7UVVVdVKSD1l3dmKWROmDbEuajMytXr1aTfv08/Pr9rzy8vJenVsiIhocuKaKiCyWTOl65JFH1BSu0y3+lxEjWa/UNfFEb8jUPRmBkZGfjjfNHa3rm3lZl3T77bdjw4YNKhD4z3/+0/mYvIlet24d3n33XRWk/Pvf/1b3S5IFWW8kb7xP3HZ/pjaXEaGOdUynI+u7JGnGtddeqwJXmdKYnJys+Tidbl2VTLfsWDslt5IUQ/6/jvuErAWT53Ulgarcf6Z+yfTA0wVWpyMJReT6kiCxKxmJkkDrxBG5rmR6pATLTz75ZLf7ZfRRRiGlT0RENLQwqCIiiybJEGRkRNZOnYqsL6qurlY1iiTdtQQxktAhKSmpR9uXN8+Sve/6669XAVNGRoZK1iCjUTIyJWQER9YbyWMyzU8SXnQkRvjDH/6gahbJND/JQihrwjoek+3KaIkELxL4yc/LqI1MJ8zNzUV/kfU+kixBsv6VlpZ2jsqdGFRIwCKJQCTBxm233XbSKFFvj9OpSBIRWVclx6VrUCWjdzKNsWvwcs8996g1WjIKmJiYiD/+8Y/qnMo5Ph0JYOQYS5B4Ivl/JeDq2uRaETIlU0YgJUCWjH2yP7LmS/Zx3rx5nVM4T0euCUn3L1MnO8g5luC061RNIiIaGhhUEZFFkzVV8qb6ueeeU+usTiTreSTrn0xPk1ERGUGQUaQzrbE6kUznkmBB3mBHRESodVH79+9HcHCwelxGaGRKnwRLku1OAoGXX365c1To4YcfViNmEkBIAChJM4SsT5I36rKdiy++WP28TGOU0YyO6Wf9QRJISD8mTpyoRtEkucSJZPRPRtJkWqMEOTLa1JGWva/H6VQkSYhML5R+SJIQIcdJAr0T11NJIPP++++rkT4ZPfv0009VUoszFXqW/ZQaVaeaYikBrwRuXZsUk+4g0x9lhFESWsi6O1l/Jefxyy+//MV6XnIdSHHqrqNVMvomyU+IiGjoMZi0TswnIiIyIxmBkqBIRhFDQkLM0gcZpVy6dKma0tifUzuJiMgycaSKiIismoyySTKTU43IDRSpB/b2228zoCIiGqI4UkVERERERKQBR6qIiIiIiIg0YFBFRERERESkAYMqIiIiIiIiDRhUERERERERacCgioiIiIiISAMGVURERERERBowqCIiIiIiItKAQRUREREREZEGDKqIiIiIiIg0YFBFRERERESEvvv/XREF4OnegBgAAAAASUVORK5CYII=",
@@ -2262,10 +2266,10 @@
    "id": "p15b-md-02",
    "metadata": {
     "papermill": {
-     "duration": 0.140378,
-     "end_time": "2026-06-06T14:32:06.059839",
+     "duration": 0.016625,
+     "end_time": "2026-06-15T04:29:17.523150+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:05.919461",
+     "start_time": "2026-06-15T04:29:17.506525+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2280,16 +2284,16 @@
    "id": "p15b-code-02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:32:06.302997Z",
-     "iopub.status.busy": "2026-06-06T14:32:06.301997Z",
-     "iopub.status.idle": "2026-06-06T14:32:08.771405Z",
-     "shell.execute_reply": "2026-06-06T14:32:08.761610Z"
+     "iopub.execute_input": "2026-06-15T04:29:17.556163Z",
+     "iopub.status.busy": "2026-06-15T04:29:17.556163Z",
+     "iopub.status.idle": "2026-06-15T04:29:17.833370Z",
+     "shell.execute_reply": "2026-06-15T04:29:17.833370Z"
     },
     "papermill": {
-     "duration": 2.505857,
-     "end_time": "2026-06-06T14:32:08.775518",
+     "duration": 0.292998,
+     "end_time": "2026-06-15T04:29:17.833370+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:06.269661",
+     "start_time": "2026-06-15T04:29:17.540372+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2339,16 +2343,16 @@
    "id": "p15b-code-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:32:08.949729Z",
-     "iopub.status.busy": "2026-06-06T14:32:08.947680Z",
-     "iopub.status.idle": "2026-06-06T14:32:10.026581Z",
-     "shell.execute_reply": "2026-06-06T14:32:10.025284Z"
+     "iopub.execute_input": "2026-06-15T04:29:17.876239Z",
+     "iopub.status.busy": "2026-06-15T04:29:17.876239Z",
+     "iopub.status.idle": "2026-06-15T04:29:17.994050Z",
+     "shell.execute_reply": "2026-06-15T04:29:17.994050Z"
     },
     "papermill": {
-     "duration": 1.198943,
-     "end_time": "2026-06-06T14:32:10.028192",
+     "duration": 0.143715,
+     "end_time": "2026-06-15T04:29:17.994050+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:08.829249",
+     "start_time": "2026-06-15T04:29:17.850335+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2429,10 +2433,10 @@
    "id": "p15b-md-03",
    "metadata": {
     "papermill": {
-     "duration": 0.054105,
-     "end_time": "2026-06-06T14:32:10.101754",
+     "duration": 0.021031,
+     "end_time": "2026-06-15T04:29:18.037372+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:10.047649",
+     "start_time": "2026-06-15T04:29:18.016341+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2447,16 +2451,16 @@
    "id": "p15b-code-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:32:10.349829Z",
-     "iopub.status.busy": "2026-06-06T14:32:10.339851Z",
-     "iopub.status.idle": "2026-06-06T14:32:10.816172Z",
-     "shell.execute_reply": "2026-06-06T14:32:10.812370Z"
+     "iopub.execute_input": "2026-06-15T04:29:18.080533Z",
+     "iopub.status.busy": "2026-06-15T04:29:18.080533Z",
+     "iopub.status.idle": "2026-06-15T04:29:18.201787Z",
+     "shell.execute_reply": "2026-06-15T04:29:18.201787Z"
     },
     "papermill": {
-     "duration": 0.626957,
-     "end_time": "2026-06-06T14:32:10.825405",
+     "duration": 0.143258,
+     "end_time": "2026-06-15T04:29:18.201787+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:10.198448",
+     "start_time": "2026-06-15T04:29:18.058529+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2524,10 +2528,10 @@
    "id": "p15b-md-04",
    "metadata": {
     "papermill": {
-     "duration": 0.230486,
-     "end_time": "2026-06-06T14:32:11.146141",
+     "duration": 0.020951,
+     "end_time": "2026-06-15T04:29:18.243552+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:10.915655",
+     "start_time": "2026-06-15T04:29:18.222601+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2549,16 +2553,16 @@
    "id": "p15b-code-05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:32:11.504793Z",
-     "iopub.status.busy": "2026-06-06T14:32:11.504793Z",
-     "iopub.status.idle": "2026-06-06T14:32:12.819899Z",
-     "shell.execute_reply": "2026-06-06T14:32:12.814065Z"
+     "iopub.execute_input": "2026-06-15T04:29:18.291375Z",
+     "iopub.status.busy": "2026-06-15T04:29:18.290374Z",
+     "iopub.status.idle": "2026-06-15T04:29:18.433136Z",
+     "shell.execute_reply": "2026-06-15T04:29:18.433136Z"
     },
     "papermill": {
-     "duration": 1.44002,
-     "end_time": "2026-06-06T14:32:12.829800",
+     "duration": 0.165269,
+     "end_time": "2026-06-15T04:29:18.434352+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:11.389780",
+     "start_time": "2026-06-15T04:29:18.269083+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2630,16 +2634,16 @@
    "id": "p15b-code-06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:32:13.078374Z",
-     "iopub.status.busy": "2026-06-06T14:32:13.078374Z",
-     "iopub.status.idle": "2026-06-06T14:33:22.462416Z",
-     "shell.execute_reply": "2026-06-06T14:33:22.455328Z"
+     "iopub.execute_input": "2026-06-15T04:29:18.480852Z",
+     "iopub.status.busy": "2026-06-15T04:29:18.480852Z",
+     "iopub.status.idle": "2026-06-15T04:29:53.636725Z",
+     "shell.execute_reply": "2026-06-15T04:29:53.635993Z"
     },
     "papermill": {
-     "duration": 69.438527,
-     "end_time": "2026-06-06T14:33:22.462416",
+     "duration": 35.181107,
+     "end_time": "2026-06-15T04:29:53.638291+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:32:13.023889",
+     "start_time": "2026-06-15T04:29:18.457184+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2670,7 +2674,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 2_000 tune and 2_000 draw iterations (8_000 + 8_000 draws total) took 28 seconds.\n"
+      "Sampling 4 chains for 2_000 tune and 2_000 draw iterations (8_000 + 8_000 draws total) took 23 seconds.\n"
      ]
     },
     {
@@ -2748,10 +2752,10 @@
    "id": "p15b-md-05",
    "metadata": {
     "papermill": {
-     "duration": 0.035612,
-     "end_time": "2026-06-06T14:33:22.540573",
+     "duration": 0.013001,
+     "end_time": "2026-06-15T04:29:53.670556+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:22.504961",
+     "start_time": "2026-06-15T04:29:53.657555+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2766,16 +2770,16 @@
    "id": "p15b-code-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:33:22.852597Z",
-     "iopub.status.busy": "2026-06-06T14:33:22.851800Z",
-     "iopub.status.idle": "2026-06-06T14:33:25.376141Z",
-     "shell.execute_reply": "2026-06-06T14:33:25.373798Z"
+     "iopub.execute_input": "2026-06-15T04:29:53.723926Z",
+     "iopub.status.busy": "2026-06-15T04:29:53.723417Z",
+     "iopub.status.idle": "2026-06-15T04:29:54.933899Z",
+     "shell.execute_reply": "2026-06-15T04:29:54.933899Z"
     },
     "papermill": {
-     "duration": 2.625555,
-     "end_time": "2026-06-06T14:33:25.378843",
+     "duration": 1.247112,
+     "end_time": "2026-06-15T04:29:54.933899+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:22.753288",
+     "start_time": "2026-06-15T04:29:53.686787+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2817,7 +2821,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAHqCAYAAADyPMGQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAgXVJREFUeJzt3QeYXGeVJ/z/rVzVOUndrVbO2ZYsZ8sZmyGZAYMXMCaMCcMsYZkhLHwDmGW9MwPsLIOxjU1wwMY4AE4EY1lZtuSgnEOrc46V0/2e896u7pbUkkruVt1bVf/f89ynWt0t6/pWd91T5z3vOZqu6zqIiIiI6KxsZ/8WIiIiImLgRERERHQOmHEiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0OdL9xnySTCbR0tKCoqIiaJpm9ukQERHReSS9wAcHB1FbWwub7cw5JQZOY5CgaerUqefr+SEiIiILamxsRF1d3Rm/h4HTGCTTlLqAxcXF5+fZISIiIksYGBhQCZPU/f9MGDiNIbU8J0ETAyciIqL8oKVRnsPicCIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiyvbA6dFHH8VnPvMZrFy5Em63W7VBf+qpp075vkAgoL73Qx/6EObNmwev14vS0lJcffXVePzxx005dyIiIspNlp1V9+1vfxvHjx9HVVUVJk+erAbujmXDhg24/fbbUVFRgeuvvx4f+MAH0NHRgWeeeQYf+chHsGnTJvz0pz/N+PkTERFR7rFsxunBBx9UgZMEQZ/61KdO+33V1dV45JFH0NLSgieeeAJ33303fvGLX2D//v2YPn067rnnHmzdujWj505ERES5ybKB0w033IBp06ad9fsuuOACfOxjH4PL5Trh85Kl+uxnP6s+Xr9+/Xk7TyIiIsoflg2cJoLT6VSPDodlVySJiIgoi+Rs4JRIJPDwww+ronLJXhERERGNV86mYv6//+//w65du1R91JIlS874vZFIRB0pAwMDGThDIiIiyjY5mXG67777VJH4ihUr8P/+3/876/fL95aUlAwfU6dOzch5EhERUXbJucBJduP94z/+I5YvX46XXnoJhYWFZ/073/zmN9Hf3z98nK71AREREeW3nFqqe+CBB9ROOlma+9vf/oby8vK0/p402JSDiIiIKC8yTqmgadGiRXj55ZdRWVlp9ikRERFRjrHlyvKcBE0LFixQQZN0GyciIiLKm6U6CYY2btyoPt6+fbt6lC7gzz//vPr4lltuUceaNWvUTDtd17F69Wrce++9p/y3rrnmGnUQERER5WTgJEHTQw89dMLn1q5dO/zxjBkzVODU0NCggiZx//33n/a/x8CJiIiIxkvTU1EHndDHSdoSyA674uJiXhkiIqIcNnAO9/2cqHEiIiIiygQGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERERpYuBERERElCYGTkRERETZHjg9+uij+MxnPoOVK1fC7XZD0zQ89dRTp/3+trY2/MM//ANqamrg8Xgwb9483HXXXYhGoxk9byIiIspdDljUt7/9bRw/fhxVVVWYPHkyGhsbzxg0XXLJJep7brnlFhU0bdy4Ed/5znewefNmvPjii7DZLBsjEhERUZawbDTx4IMPqsCpo6MDn/rUp874vV//+tfR0NCAe+65B8888wz+z//5P9iwYQPuuOMO/OUvf8FDDz2UsfMmIiKi3GXZwOmGG27AtGnTzvp9g4ODeOKJJzBr1ix87nOfG/68LO3dfffdsNvteOCBB87z2RIREVE+sGzglK4tW7YgEongxhtvVMHSaFLvtHz5cmzduhXhcNi0cyQiIqLckPWB06FDh9Tj3Llzx/y6fD6RSODo0aMZPjMiIiLKNZYtDk9Xf3+/eiwpKRnz66nPp75vLJKxkiNlYGBgws+TiIiIsl/WZ5wmgtRCSYCVOqZOnWr2KREREZEFZX3gdLaM0tkyUuKb3/ym+r7UcabWB0RERJS/sn6pLlXblKp1Opl8Xno4ya6705EGm3IQERER5XTG6dJLL4XL5cJLL70EXddP+Fprayt27NihmmNKN3EiIiKivA6ciouLcdttt6ldc/fdd98pS3Cyo+7OO+807fyIiIgod2j6yWkaC3UOl7EpYvv27SpzdM0112D69OnqczJaRY5UZkmySk1NTXj/+9+vRq5I5/BNmzbhpptuOueRK7KrTmqipN5JAjMiIiLKXedy37dsjZMETSePSlm7du3wxzNmzBgOnKTR5Wuvvabm273wwgt4/vnnVdfx733ve2ocC+fUERERUU5nnMzEjBMREVH+GDiHjFPW1zgRERERZQoDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIiIGTkREREQTixknIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKkyPdbyTKB5FIBF1dXejp6cHAwIA6BgcH4ff7EY1Gh49EIgGn0wmXywW32w2Px4Py8nJUVVWhsrJSPRYVFZn9v0NERBOMgRPlpXg8js7OTrS1talDPpaASYKkdIXD4RP+fPTo0RP+LAHUnDlzMHfuXEybNg0OB3/diIiyHV/JKecFg0G0t7cPB0mpQEnX9TG/PxrWEfIDkRAQVYeOaARIxIBkAkjEAT0J2OyA3WEcDjfgLdTgLQJ8hYCnUFOBmByvvvqqykwtWbIEq1atQnV1dcavARERTQwGTpRTAVJ3d7c6JDDq6OhQAdPpskixqI5gPxDoB4IDOoKDUAGTBEhvz0ggZnfqKK0CSidrKJskn4nizTffVMfUqVOxcuVKFUjZ7fa3+48REZEJNP10b7vzmNS1lJSUoL+/H8XFxWafDp20xCZZHAmMpA4pdUiwFAqFTnutwgFdBUiBvqHHfsksZe7SFlcA1TM1lNdqsA1tySgtLcXq1auxbNkyBlBERFly32fgNM4LSOePxPSSNaqvr0dzc7PKHknQlEwmT/t3IkFjmU0OlUUaAAIDQDJujWfK6QYmTQdqZmlweTT1ubKyMlx99dVYunQpbKmoioiIMoaBUwYvIE0s2bG2d+9eHDx4EMePH1fLbyeLx4yASIIjySSFJVAKQD1KDVI2kPqo6pnAlLkanG4jgKqpqcHNN9+sCsmJiChzGDhl8ALSxGSWGhoasH37dhU0SfCUkojrGOgGBruHltgGjILtXCEBVM0sYMo8DQ6nEUAtXrwYN9xwg1rKIyIia933WRxOpmptbcXzzz+PlpaW4c+F/Do6G3X0dwL+XgmskLMkQ9Z8COg4rmPqImDydA179uzBgQMHcNVVV+GKK65g/RMRkYWwxmkMzDidf5JVeuWVV/Daa6+pjJNklrqagY4GHYPdyFu+EmDmEg0lVUb2SRppvvvd7+byHRHRecSlugxeQDp30kfpqaeeUjvhRFeTjmO7dMQivJoplVOAGUtHCsgvuOAC3HjjjfD5fLxIREQTjEt1ZFlNTU145JFHVMYpEtJxZLuOvnazz8p6JPvW16Fj+mJg8gxN1X9JwfxNN92kdt9pmhFQERFRZnHvM2WM1DE9+uijKmjq79KxYw2DpjOJx6ACy13rkwj062qH4e9//3t1DXt7ezP2vBER0QgGTpQR0n9JMk0yRHegS8e+LboKDOjsBnuAnWt1HN+TVMXkMhPvZz/7GTZs2KCGDRMRUeYwcKLzTjp6P/7442oo7mCPjr2v6lnTb8kqZGeh7L7bviaplvCkg/qaNWtw3333qX5XRESUGQyc6LySHXNPP/20GosSDurYL0GTRbp4Z6NwANi7WcfB15NqGLFk8n7961/jj3/8IwKBgNmnR0SU89jHic4raTdw5MgRJOJQQVNspLcljUNXE9DbrmP6opHi8X379uHaa6/FqlWrOLqFiOg8yZmMkyxdPPDAA7jkkktQWVmp2gjI7qPvfe976OvrM/v08pJkQ15++WX1cf3upBqTQhMnEQOO7jCKx/19uqof+/Of/4yf//znXL4jIjpPcqYB5vvf/3784Q9/wPz589WWbbvdjrVr1+Ktt97CwoULsW3bNhQUFKT132Ifp/GTQby/+tWvVPsBqcmR5SU6vybPAKYt0uB0Ga0K5I3D9ddfr3qSERHR6eVdH6etW7eqoOmyyy7D+vXr4XCM/G998IMfVDU20nDxjjvuMPU888mrr76qgiYZyHv4LQZNmdBeD3S36Jg2NLpl165davlOxrbI4XQ6M3IeRES5LCeW6mR7tpDOyqODJvGud71LPXZ2dppybvlIOoLLOBVRv1vPqaG8VhePAke369i5NqnaPsgS9rp163DPPfeoAco5kmAmIjJNTgROixYtUo8vvfSSulGM9sILL6guy9dcc41JZ5df5Mb83HPPqedBlug6uFPeFIF+YPdGHQe2JhEJ6ir9/OSTT6odeKMHKhMR0bnJiaW6ZcuW4Qtf+IJ6V71kyRLcfPPNqsZJsh6HDh1Sn7/ooovMPs28IMum0ldIdtFJ12syV3eLsftuylygdq6GhoYGtYli+fLluO666ziLkYgoX4vDxQ9/+EN885vfPCHr9JGPfAQ/+MEPMGPGjNP+PdmNJMfoIrGpU6dyyO/b2EV3//33q+t/ZHtS1dyQdbi8RvH4pKlG8bgsa1988cW48sor4fV6zT49IqKsKA635coOrjvvvBN33XWX6qTc3t6uZnlJQbh0V5abQ3396e/id999t7pgqUOCJjo3EixJEX5qiY5Bk/VIrdnhN4z6J5kVKM/V5s2b8ZOf/ASbNm06ZZmbiIhyNOP04IMPqsBJbgD//b//9xO+JvU2733ve/HZz35WBVVjYcZp/KR/kDS7jEV0bF+jIzaSwCOLKptsZKAKSowMlLxpkPYFstwtdYFERPliIN/aEfzpT39Sj2MVgKc+J52VT8ftdquD3p4DBw6ooEkcfpNBU7bobTfqn6qm6pi2UEM/+vHMM8+oVhJS/zRr1iwGUEREuRg4peqTpMbmZKk2BAyMzo+DBw+qJVHRckRXN2PKLp2NRv+nmtk66uZpatfdo48+imnTpqkRLmeqDyQiyjc5UeN0+eWXD9cqRaPRE2qfvvvd76qP2Y5g4kmDxSeeeELVxvS06ji+O+tXffNWMgE0HwTe/KuOlsO6+rPswHvooYfw8MMPo7Gx0exTJCKyhJyocZI1SSkAl+zH7Nmz1cgV6ZIsheFyc587d65aSiorK0vrv8eRK2cmPzLSdkDqmkRHo44jb+rI/p8kSnF5gCnzNDVA2Db09kp+t6666iqViWINFBHlknO57+dE4CRkF51knJ599tnhHXTTp0/He97zHnzrW99KO2gSDJxOT36o/vKXv6hRHqL1qI5jO3PiR4jG4PYCU+ZrmDRtJICqq6tTWd4FCxYwgCKinJCXgdNEYuB0KlkC3bhxI7Zs2aKW5vQkcHxvEi2HTXiCKOPcPmDK3KEAym58btKkSaoGSgZrMwNFRNmMgVMGL2A+BEyy3Ll27Vr4/X71uf5OHcd26wj2m312lGlON1AzS0P1LMDhNFoW1NbWqhrCOXPmMIAioqzEwCmDFzAXSRJSdla9+eab2L1793DBfciv4/geHT2tZp8hmc3uBKbM0VAzG7A7tOEM1GWXXab6QJ08bJuIyMoYOGXwAuYSaesg2aXXX39ddV9PkYCp7ZgcUEt0RClOV6qIfCSAKiwsxCWXXKLmQ3o8Hl4sIrI8Bk4ZvIC5QHpdbdu2DTt27BjOLiUTOrpagI7jOgZObY9FdEoGavJ0oGa2BrfXCKBcLhdWrVqlslAFBQW8YkRkWQycMngBs5k0DF23bp1ajksJDepoq9fR0QAkYqaeHmUhmdRSWQfUzhkZ5SLLdrJ8J1mo6upqs0+RiOgUDJzGKdcDp56eHhUwybJcalNld6uOtiM6+pldoglSVg3VibyofGTunYxxufTSS1lITkSWknez6ig90kld2gm88sorSCQSwwFT437ukKOJ19smh47CMh21szVU1Go4evSoOiorK9US3rJly1hITkRZhX2c8iTjJA1CZYBrU1OT+nNfh7FDLsCWApTBZppSAzVp+kgrg6KiIlUHtXLlSvh8Pj4XRGQKLtVl8AJmg/379+OPf/wjwuEw4jEd9buMGiYiM9gdULvwRheSSx3U8uXLVUfy8vJyPjFElFEMnDJ4Aa1OZvSlZsoN9ug4uE1HJGT2WREBmg2onGIEUIWlRgAlHcgXLVqEK664AjU1NbxMRJQRDJwyeAGtSoq+pZZpw4YNwzPlJNOU7wN2ZNeXpwBwFwB2u5H9sMlhkxowo0+VHPJxIj50xE78WL5GE6uoAqibq6GseqSQXIZzX3311ZgyZQovNxGdVywOJzUiJRU0yUy55oP5eVEkKKqsBUqqNPiKAW8hYLOP3JzfjmRSRzIuwemoYEs/MThLSX1efe9Q8BUfCsDCAR3hgDwCYT8Qz+P2D4PdwL5uHb5iXc3Eq6zTcOjQIXXIKBcJoGS4MBGR2VgcnoMZp02bNuFvf/ub+vjoziTajiLvlFQCVdM1VNSMdLROielAIGFDTNeQgIa4BDW6Bk3TYZMaHA2wQYdDkwNwqkddbUEdHRRNNOmhNdAN9HcZj9E8XlKVrGDdfA1VdZpa0ktloG644QY12oWIaCJxqS6DF9Bq3nrrLTz77LPq4+N7kmg+hLxSWAbMWj5SMyMGEzY0Rp3oi9swkLQjmJSvvZ0IyAiejIDKCLJsmvyX9FP+a5JoGv05+T6HCsaMv++y6SiwJVFoS6LAnoTPduoaqr9XR1ezju5m5G1dmttn9IKqmqap5VSpgVqxYoUaKiyjXYiIJgIDpwxeQCtpaGjAr3/9a1Xf1HRQR8Pe/Cpoqp0DTF9sU1khySpJsHQ84kRvwv42A6XMkaxWhSOOSkcClY44yuzJE7Jb/j7ZCamjUzq6x5GXGajpi41eUKlxLqtXr1a9oGwSURERjQMDpzwMnAKBAO6//34MDg6is0nHodf1vKpjmnOhhsopxk21IeLEzpAbUT17b6guLYkpzjjqXDEVTKWCqERcR1cT1NDlfOzBVVQOzFiqoajMuCAywuW9730vd+AR0bgwcMqzwEkyTL/5zW9w5MgRBAd17FyrI2k0Bs95situ8RUaCss0JHVgR9CDY1Gn5TNM5xpE1bnimOWOotg+sqWvv1NH04H8HJMzaRowfYkGp0tq0zTV/0kKyJ1Oee6JiM4Nd9Xlmc2bN6ugSaaoHNyaP0GTZGEWXGoETZGkhi1+L3oSuTdFSDJnRyMuHI04UeFIqABKslGyU1AO6c/VclhHdwvyhjRw7W3XMXOZ0QtKNkQcPHgQH/7wh1FRUWH26RFRDpuwXXWyRCQ3b3k83X9SahKyQTZlnLq6unDfffep2XOH30qi4zjyxsxlGmpmaaqeaf1gAfpVLVN+8GpJzPVEMdMdVbsAU7vypLZNlvLyqV9XeY2xIcDl0eB2u3HLLbdgwYIFZp8WEWWRjC7V7dy5E1/5ylewbt260wZMKanBslaXLYGTXG8pBpeicHn3vW9L/twtq6YCc1caNUyb/V60xfJzicatJVUGarY7CtdQSZf0h2o+ZIzVkR5T+cDpBuat0lBSaUSRV155Ja699loWjhORtZbqZAaavED5/X41IqG1tRXHjh3Dbbfdpiagy9b4WCymijdLS0vH80/RGLZt26aCJtlldXR7/gRNBSXA7AuMKGFvyJ23QZOI6DbsC3twKOxW2SfJQskOtNkXaKibZwRQ7cdzP4CKRYC9m3RMXyy7KzVs3LgRbW1tuPXWW9UOPCKiiTKubUff//731W6uhx9+WHWpvuqqq9TnpVB5y5Yt2Lt3ryrY3LNnD370ox9N1DmT1L1EoyrLl+rXlC99fmx2YN5FmnpsjTqwP8yboohDw6GIG3/pL8SOoBuhpAa3T8Os5TasvFFDzWzj2uUySXjX79ZxYFtSvZk4fPgwHnroIfUaRURkicBJxnosXrwYH/vYx8b8+qxZs/CHP/wBPT09+Pa3vz2ef4rGyDYFg0GE/Dra6vPn8sxcqsFbpKnA4PWgN6d2z00E6YR+ZCiA2h70qGafLq+GmUttWPkOyUIB9hxP0EnD0D2bkohFdLS0tOBXv/oV+vr6zD4tIsoRtvEWJi9cuHD4z6mtwHJDT5G1Quny+/zzz4/nn6JRZPlTdtKJ5oO60aY6D5TXApNnaCqzsC3gVSNTaGxJaGonngRQbwY88Cc0ON0api0yAqhpizQ4Pbl79fy9wO4NOiJBHd3d3fjlL3+Jjo4Os0+LiPI9cKqsrDwhSEptA5b6ppNv9BJk0cTYtWuXuu5SBNzZmB9XVep2pMmlOBh2oSuee20HzgcZBlMfdeGlgUJs9XvRn7DB4ZTMk4aV77Bh7kpp54CcFPIDu9brCA7oarevbKSQOkwiItMCJ5laLsXgKatWrVI7vR544IHhz0kQ9fLLL2PmzJnjOlE6MXAS7fV6Xmw7l87gCy7R1A2/K27H3rDb7FPKygCqKebEywMFahdiV8yuZr9VTdWw7Goblq7W1E7FXJteEg0bmSfpdRUKhVQ9ZnNzs9mnRURZbFwvk+985zuxb98+tbtOvOtd78LUqVPx05/+FJdeeik++MEP4qKLLlIvWJ/85Ccn6pzzmrxzrq83ipq68uH1X5O2Axp8xUZd02t+7xgjdelcLqjsQlzvL1BBlMzyS+gyykRT7R0uullTI028RblzTeMxYO9mHQPdOsLhMB555BE0NuZJqpaIrBU43XHHHfjZz3423J9Jms89++yzmDt3LrZu3YpnnnlG9USQoOl//I//MVHnnNdkp6KQm0BkZJU0J2k2YwddRY2mbu6v+r1q+z1NDGkY+kbQiz/3F2JPyI1AQoPDpaF2toYLr7dhyVWaGm2SC7vxZJedBE/9XToikQgeffRRHD+eR91iich6ncNPJlmo3t5etZxXVVWFbGLlBphPPvmkCp6kBUHzIeQsh9NYniuuNGbQbQ140ZLH/ZoyQ8ckR0L1g6pxxmFLDRaO6ehsBjrqdfizfHOaBIHyc1U6SVObWT760Y9i+vTpZp8WEZnMErPqOPLg/EjVZwz2Ime5vcDCy4zlORmnssXvYzF4RmjoiDvUIR3Jp7timOGOodCZRPUMoHqGBn+fjvZjRiCVjCPryBzH/a/qmH8JUDY5hscee0y1U5ESAyKidExY4CR1TG+++abqmyJqa2uxYsUKeL3Sa4cmgnRol2hYkoSBLH/nfzqTpgPTFxtT76UH0eZBHwaSObBWlGVkSfRgxI2DERcqHQnMcMUwxRVDYamGwgs1zFiio6MRaD2iI5xl/SWTSeDAazoWXAaUVkXVst3HP/5xTJkyxexTI6J8CJzkRv6tb31Ldegd3ZpASNAkdVA/+MEPOHJlAkgjUSG1TVKzkUtkS/ysZbI13lgf6o3b8KrfhxBrmkwmOxkd6tgZcmOaK4aZ7hiKnEnUzAKqZ2roadXRckTHYDeyKniSzNPCy4CSyqgqGL/99tsZPBHR+a1xkhu5jFmReia73Y7LL78c06ZNU1+TGWrSpFEKx+fPn69GsqT6PFmdVWucDhw4gN/+9rdqa7X0p8kFbh8wdaGGSVONgEmW5mT+nDRv5O45q9JR5UiouXjVzpEIXgqvG/bK1n9kVc2TLAvLcGCPx6MyTzU1NWafFhHlao2TZJqkHcH73vc+/OQnPzmlTqCpqQlf/OIX1dgVGbly7733juefy3uyHJraXp0L0+ynzNNUxiLVO6g+4lS7u7hzzuo0dMYd6PQ7UGRLYI4nqjJREnxIPyjJQDXsk8aTyIqap31bdCy6XDr4Gq0KPvGJT2DSpElmnxoR5WLGSd6ZSQuCQ4cODY9bOZl0DZf2BLIFOFu69lo14/Taa6/hz3/+M7qadRzclp0ZJ3mHXzff2PKe2ubeHrNjT8iDvgRrmbKVV0tigTeiaqE0zRi423Fcx/E9elYE+nYHsOgKDUVlmioxkMxTdXW12adFRBa879vG+w/J8tzpgiYhX5Pvke+l8Uld52ztq1NRC1x4vTHuQ/4fuuN2bBj0YZO/gEFTlpNatLeCXrw0UICmqEMFTzJX8MIbjI7k2dLnabDX6DAuNZupjS5ERBMWOEntUltb21m/T75n3rx54/mnaKjBaOrdcbbNmZM6kvkX2+D2aarR4ha/F+sGfWrJh3KHP2nH1oAP6wZ8ai6eDBaWjuSLr9DgKYSlJaTD+KaRDuMcz0JEEx44ffnLX8a6devw17/+9bTf89JLL2H9+vX40pe+NJ5/igC4XK7h5pDZoqgcWHa1hrLJRvfvfSFj4GyrambJ0Sm5qjvhwJqBAuwOuhHXgZIqDcuvtWHyDFg/87RFx8BQh3GpeZKNLkREKeN6u3/NNdfg85//PN7znvfgwx/+sDpSXXhlnMHvfvc7PPHEE+p7rrvuulNegFI78Cg9qXVXV5a0xiqdBJVlkgyZLMu9HvAikOTIlHwhuyKlF5QMF77QF8JkZwKzL7ChvFrH4bd0xCKwpORQ8GS0KjDGs9x2222YNWuW2adGRNleHG6z2aBpmmrIKI9jOd3X5HPxuDWbEVm1ODwajeLuu+9WH7/2QlItLVi5nmnuRTa1Y64tZsdrfh8SzDDlMR2z3VEs8UZg14BYxAiees++0m8aqcObf7GRLZV2Kx/60IdYckCUozLWjmD16tWnDZjo/CzVFRQUIBAIqLohq3YPL6sG5q2SoBqqUHhbwMueTHlPw5GIG50xBy4qCKHUncTCSzW0HDZ23p2fiZkTMJ7lNR3zLpI3AgmVPX//+9+PJUuWmH1qRGSicQVOa9eunbgzobRUVlaqwMlXZM3ASeqv5qzQVNAkfZneDHpYy0TDZHzO2sECLPZGVAPN2jnSLR6qvUY0bL0LpSeNc5uzAqiamsTTTz+tMr8yToqI8hMLTrLM5MmT1WNBiTUzfdMWGXPm+uOyPZ1BE50qCQ27Qh686veqTvHFFVI4rqGkyppXS7Jhh97Q0XbMSIs999xz2LJli9mnRUQmmdC94M3NzScM+eXQzImXaspXUALLkXOS3j1ie8jD5Tk6o5aYE/0DdlxSEFRLd4su19C4L4mmg9a8cEd36KquUDrey05i6fd07bXXslyBKM+MO+Mks+h++MMfqh0nskvu0ksvVYd8PGPGDPzHf/yHZYvAs1FqjlZBKSxHll1kia4x6kA3+zNRGmSXpSzdHYs41c/OtEU2zL9Es2yvsuN7pSYrqT6W+ZsvvPACkjIxmIjyxrhenuQd1zvf+U71AiK75yRYGj3kV45vfOMbKrX9l7/8RY0yoPGpqqpSO3yABNw+HZGgNa6o0wVUTDGyTYfCRqNOonSX7qTreE/cjgt8YVTUaPBdDezfqiM0aL1r2HxI5kUmMWu5DW+88YZ6HZSicYfDotEeEVkn43TXXXep5pYXX3wxNm3ahPr6evVnOeTjzZs345JLLlFfk++l8ZOgKVXnVGihrNOk6dKeAuiJ2zg+hd6W41EX1g8WIJjU4C3SsOxqGyrrrHkx2+ulaDwJSTbt3bsXjz32mGqYSUS5b1x9nKTZpYwmOHz4MIqKisb8nsHBQcyZMwcej0c1xcwGVu3jlPL888+rd7pNB3U07LXGPu4LrtPgK9bwRsCjboBEb5dbS2JVQQiTnAn159ajOup362qHm9WUVAILLjWavEpd50c+8hHVMoSIskvGhvx2dHSo4sjTBU1CviYdxuV7aYJ31lkkpnN5oIImCcFbY1yuoPGJ6DZs9PvUeB5RM0vDkis1S3bM7+8Cdm9IqoaesjHmV7/6lXrhJaLcNa7ASYq/JUo7G8k6yffSxO6s81lkZ11qG3lfwoaozg4XNBE07At7sGnQi2hSZh4aLQukuarVBPoleJJ6Qx3d3d34xS9+gc7OTrNPi4jOk3Hd5T7zmc9gzZo12LFjx2m/R74m3/MP//AP4/mnaIyMk9urwWGBVTEZ4Co6mG2iCdYed2LNYKGqnZP+YAsvtWHGEmP3ppWE/MCu9TqCA7p6oyiZp9bWVrNPi4isFjh95StfUQGRLMX967/+K/bs2QO/368O+fg73/mOWsq788478dWvfnXizjrPyeiV1Bqsx2f22Ug2wHjsYgsCOg+CSRvWDRbgUNg13PZisSzdSX9VC5HO55J5GuzR1U67hx56CI2NjWafFhFZqTjc2BZ/+kG+Z/oah/yOj7yjlXYPB7Yl0d0MU0esXPwuI/5+rq8IMd1iqQDKKTXOmJp155RBwVEdR97S0WOxxI4UisscvuJKDU6nE7fddpvqc0dE1pWxIb9Tp061XNfc3/72t7j//vuxfft2tT24rq4Ol19+Of7rv/7rjEXs2aa0tFQFTmZnnFKNOP0JjUETnXetMSfWDNhxcUEQZa4kFlyiqVEosutOhvJaQSIO7N2iY/7FQNnkmGpV8KEPfQjz5s0z+9SIaAKMK3CSXk1WId17P/nJT+Lhhx9WL1Af+9jH4PP5VKr8T3/6k4oicylwSm15drgkcDWvJUFq9Etfwsg+5jsHdHhtSXhsOuyaDrkq8mgbepZkR72ua+oxrmuI60Ac8mgEnjK7TQqj6ezdxhd5I5jnjqJ6pobiCuDg61JjZI0rJ0Hc/td0zLsIqKhN4IknnlDB0/z5880+NSIap5zZO/6jH/1IBU1f+tKX8OMf/xg26cY4JBdHIkidkxhaLTWNtCEQA3kWOGnQUWxPotyeQLkjgVJ7QgVMrnFuKkzqUAFURNcQSsphUzU+0hRSrvFAwqY6bec7HRr2hDxqQ4L0fPIVA8uu1nB8bxKtR2AJ0nfq4DYdcy8CKqck8bvf/Q633norFixYYPapEVG+B07BYBD/+3//b9VoUwKo0UGTOPnPuUBqJ4TN5GfQN5TEkxt6PmSTqp1x1LlimOSMw3Ga+CXhSCDhSUC368ZhMw5JOWlSA5Y0Hm1xG7TE0GNcgy1pg02TBpA63CowU/+1UwKrwYTRnb07bkd73KGCq3zVGXfg5YECrPCFUeOKY+ZSG8om6zj8pq6Ktc0mFaSSCZPnvrIuiSeffBIf+MAHsGjRIrNPjYjepgm77e7evVt1EJetuKerN//4xz+O80Emlff19eHTn/40YrEYnnnmGXUulZWVuOmmm4bn5+WSVDBodomZt9B4lJt5rmaWapxxTHPFMNkZh33U9U46koiURoaPuC+OuCcO3fH2lk5VEBWzqcMescMetsMRdsARcsARdMA14II9ZkeJI6mO6e7Y8LXvjNnRHHOiMy7RlpZ3DTO3BLyYGYthqS+M0kkall8H6xSOS/D0hq6CqKqpSTz99NOqNnThwoVmnxkRmRE4yfDef/qnf8LRo0dP+z2pnXXnK3CS8SOpYGLZsmU4dOjQCZmZH/zgB/iXf/mX0/59KSIfPWcqnaaeZkudb8K4d5rC6QbsTqNjuD/Hsh4y9mOGO4aZ7ih8ki0aEiuIIVAdQLA6iGhxdEJjFMlOJexGtipWNMYTq0MFUxJAufvd8HR74O5zo8ieVMcsT0wt6TVGnWiMODGQzKflUw3Hoi4VOMrSXapwvP24jmO7dCTjJp+eDhyS4EnmOk5N4qmnnuKyHVGWGtfd7rXXXsN73/teVYAtM5qWLl2qPv+Nb3xDFUKWl5eroOkTn/iE6vN0vqS69EptU0VFBd58800V/Pz5z39WzSK/9rWvqflup3P33XerbYipQ3YLWp3MCBTxmPnZpkBS8jK5keUotCWwwhfCzSV+LPZGVNCUcCXQP6sfzVc2o3l1M/rm9yFaMrFBU1o0IOFNIDQ5hL55fWi7rA0NNzSgfWU7BqcOqiVCOd/5nihuKAngqsIAqp3yA2KNeYaZ4E/aVeH4gbBLBfSTp2u44FptuNeY2Q6/oaOzUVd1l7JsJwOCiSiP+jjdcssteO655/DSSy/huuuuG97VlkgYdRkSvHz+859XX9+2bZsaCnw+SAfzBx54QO2iO3LkyPBIklRG7Oabb1bn9/LLL6edcZLgyapDfoWk+2V5tH53Ei2HzTmHSdOBORfa0B6zY5M/uwebltnjmOeJotYZH17+jJREMDB9AMGaoMoGWZ0s9Xk7vChoKYCvw2fUUw21ijgacaE+4lI7+PJFhSOOVb4QfFJnpgPNh3Q07jM+NpUGzF2hoWqqdEDX8MEPfpA1T0T5MuR3y5YtuOiii1RQMhb5x6VRo+wA+/a3v43zRf5nhZzL6KBJ3HjjjXC73cPLeWORr8u5jj6srq2tTT0GB807B2+hcRMezOIddRIwXVEYwLXFQUxxGUFTcHIQrZe1ovWKVgTqAlkRNAk5TwnyOld2ounaJpUlSzgTKLTrWOaL4KaSQcz3RFSRez7ojjvwt4FCHI841fNaN0/D0tUaPAXWWLbraJAgTlfLdsw8EWWPcQVOEpmN7oib2iIvI1dGf+7KK6/E3/72N5wvqcZyqQBqNKl7kv5NMgIhV0h2rKurS30c6DN/qS4b65tK7AlcVhBUAdNkZwK6pmOwblAtxXWs7ECkbCQDmY2kTqp3QS+armtC15IuVZvltkEtP0oANc8TgT0PAijJsL0R9OJVvzEsuLBMhgXbMMkC+0Vk5x+DJ6LsM6473qRJk9RutpOHz44uzk4FWLLb7nyReXhi3759p3xNAgw5ztcyoRmam40ZKzKNPWbi/T0bd9Q5NR0X+kK4vjigtq8PB0xXN6N7WTdihSYWjZ2nLJR/ml8FhJ3LO4cDqCUqgPJjljsKWx4EUC0xJ14eKFS7D2UkypwVNsxbpcFudPWwTPAkEw+IyNrGdceTRm6y7T9FRpvIC8C///u/D7ckkAJyqS2aO3cuzhfp33T99derc/n1r389/Hk5h9QSodQR5IqdO3eqxz6jJt4UsvThHlry8GdJ4CSF0jcU+zFzaBu/v9YIKCRgklYCOU0DAlMCIwGUL6a6m1/gC+PGYj+muaI5X0Qe0m3Y4Pdhd9Ct+mFVTtGw/BoNhWUWCJ6OG8HTH//4R2zatMncEyKi81cc/pOf/ARf/vKXVXC0atUqVRR+4YUXYs+eParWqKamBrt27UI8HscvfvELtbvufJEs12WXXYaenh6100+Cqc2bN6s6LNntJy9G6Y5cOZcisUyTJUfZPSjXdOe6JPy95pyH1ImsuNGmRoY82yfX1bpFxy4tiWXeCKYNBUwSNHQt60KkPLuX48ZFlq2aClF6qBSOiNGVpD9hU0GFNNW08vM5EcrsCawqCKr6Lxks0LDXvE0WKdMXa5gyVxt+E3rDDTdYbhYoUa7KWHH4HXfcoebAyZKdsNvtePHFF9UvfHt7u2oLIDvdvve9753XoElIRuv1119XbREkWJKgTgqo//mf/xkbN27MmTl1sjtRgqZAv25a0HRCfZPKNln3xd1nS+K6ooAKmqSLjhRMt1zVkt9Bk7DBWMK7phk9C3pUEXmJPYkrikK4sjCoRsjkst6EHWsGCtEYdUB6yc5YYsPCyzTVm8wsx/fIsGJjPJS86ZPsU2qHMhHlSMZpx44dWL58+WnHoEjkJkGVBFTSLuDOO+9ENrBqxkmK7v/rv/4L0WgUB19PoqvJvHOpmQ013qI56sBrAR+s2sTy6iLJKiRVlqnzgk5ES2VJik4m3cpLDpeg+HgxtKQRCDdFHdgbcqveSLlLxwxXDMt9YdUVPhrW1Y63fhOXwaVwffYFNmg2qM030hNPdv4SUQ5knGScyegap9Ek0yRLdRI0/fSnP8XnPve58fxTBGDNmjUqaPL36qYGTcJToFm6vkm23F9eOBQ0eWNou7SNQdMZJJ1J9C7sVTVQ/il+lZ2rc8VxQ3FAFdN7tNwblG3QUB91Yc1AgVqqdHk0LLrchmmLpMeSOWfU0QDsfy2JRBxqIoO0dMmGaQZE+WJcdz35ZZZluaam09/FZejuF7/4xZycF5dJLS0teOutt9THR3eaX8Sb6oVjxVYE0sf80sIgyhxJ1fW7/eJ2tT2fzk6K5LuWd6HlyhYEJwXV0GEppn+H6qQeVvViuWgwaccrAwU4Oqrn05KrNLi95pxPbzuwe2NSZcCk7EFqROWRiMw3rruebJ9tbW1VwVNHR8eYo0xkRtzMmTOxdu3a8fxTeU1qmqTeQci4BjNrm04dt2K9wEm22E9yJpC0J9G+qh3xghzfMXcexIpj6LioA62XtiJcFoZDgxrlIi0MFnnCqq1DrklCw/ZRPZ+KymVYsIaKWnPOR3q07VqvIzioqzepv/zlL7F//35zToaIho3rrvd3f/d3eOihh9RynSzbydpgyne/+11861vfwuzZs7Fu3bqc6qNkxhKdBKaxiBSPmn/DktoL91BZk9WW6qSp4wKPUcfUs7DHmClHb5sU0csyp8zDixRH4NSABd4obioexIIc7UIuPZ/WDBaiJ26Hw6lh/sU2zL5Qg82EUq9IENi9XmqudLVM/8QTT6jX03GUphLROI37rnfbbbfhnnvuUYXi73rXu1RRuAz5veuuu1RH7/Xr16Ourm68/0zekqBUdgmqj98yt+FliscnfZw0xHQgPDQPzSpmuqNw23RVDO6vG+lgT+OgQQ0WlhE0HSs6EC2MwmUDFg010ZzjjuRcE81g0oZ1gz7sD40MC5aeTz4T9orIIO+9m3W0HjWusWTvJdsvgRQRZZ7RwGWcPvvZz6oO4t/85jdVU0ypeVq4cKHKlKS6idO5k/T873//e/Vx21EdvcZ4OtN5i6zaikDHnKFsU//s/gl4W0AnkDl+1UE1y8/X6kPZoTK4A041B08GJO8Pu1Efcaolr1ygQ8PesAcdcQdWFYTUz/2yqzUc25VEe32Gz0UHju3UVRuSWcttaradTES49dZbUVlZmdmTIcpzE3Zr+frXv64yTRI0LVu2TKWTGTS9fdK/5cknn1QZPH+fjmMWWKI7ddSKtbapF9uT8Nl0JG1JBGoDZp9ObgdQtUE0X9WMrqVdiHvjw13IpYh8hiuqCvRzRVfcgZcHCtAWc6jlOmkVMN+kcS0dx4E9Q0XjsnwvbV52796d+RMhymPnlHG67rrrzvo9TqfsStFU75HR5HMyeoXSI0ORJQiNx3Qc2KpDt9BmJm+RkVEYtFhheLXDKAIPV4TVjDbKQBPNqX7VvqCosQglR0rgCzuwoiCM+Z4I9obdaIxKdJH9GaiobsNmvxdz3FE1569iioaCMqjfzUwP2h7sAXa8omPeRUBJVRRPP/006uvrcfPNN8PhmJBFBCKaqAaYNmmx+zZJ4JQtXXDNboB54MAB/Pa3v1UfSz+XnlZYiixXyJR52X0khbRWcWVhQO2m617UjcEZ52+oNI1NS2gobChE6ZFS2KNGNnIgYVNNNFtiuTPGRbqqXzxqXEv9riTajplwIhowdYGmWidICwXJ8MtMTi7dEZ3f+/45vT05dsyMV4f8Iktzzz33nPq45bBuuaBpdI2T3BStQx8eExIuD5t9MnlJsnyDMwdVFqrouJGBkpefSwtD6InbsCfkQaeag5fd+hJ2vDJYiJW+EGpdcVVzVFKlq80bCWMcYmboQOM+HQNdkn3SVJ+nn//853jnO9+JCy64gHPuiM6Tc3oVY0uB809m/wUCAQQHdBzfa73lJqlvsjs0NdzXSs0vXZqudnpJx2v2bTKX7tAxMHtAzcIrPlqM4vpilAO4qiiIlqgDu3NgjEtM1/BqwIvZ8SiWytJdrYaCkqGlu5GuLBkh42G2r9ExdyVQOimGZ599VnUcl13OHo8nsydDlAesc+cjtUQnhZ6yeHr4TWvVNaXIzUH0q8Jw6yy9FNmMi5XwJljfZKExLn3z+9B0TRMGpg9A13SVoZExLstyogu5hiMRN9YOFsCf0NQYoqWrbZhkQss6aVMiLQuO70mq1w15Hbn//vvPONWBiN4eBk4WkUwmVUF4aonOn+GC03RJbZPoi1vrR8drM7JzMpeOrCXpTqJncQ9arhoZ4yJtI24s9mOmS9pHWC+z+naW7lqjxq67ORfaMGeFOQ0zmw8BuzYkEQ7oqkWMdBuXXnry+kJEE8Nad788Ju8QpS9LLKqj6YB1bySFZcZjj8VaEaRGgOhO6167fBcrNMa4tF3chmiRNCoFLiwI47qiAMrt8axfutsS8GJ30K0yxpOmaWoTRWqmYybJSCbZdSfjmWTvzyuvvIKHH374hMkORPT2MXCyAHk3KH2vRMshXU1FtyIZtVJYanzcY7EiX/tQ4CTz6cjawpVhtFzRonY/JhwJlDqSuKY4qIqt3Vm9fKfhYMSNDX4fwknpMq5h2TUaykzoASyvIYfe0HHojaT6+Pjx47jvvvtUOQARjQ8DJws4ePAgenp61Cy61qOwLKlvstk1RJIaAknr1DcJGUIr2L8pS9igWkY0X92MwamDqqh/ujuGG0uyf/lOGmauGShA99Csu4WX2VTbADN0Nkr2KQl/r45wOKzanPz5z39Wg8OJ6O1h4GQBu3btUo8dDUDSwq2uiiuMR7khWKkwHKNvs9l7v83b+qfupd1ovbxVDRF2acby3TVFgeH2EtkorNuwftCHI2Gjz5kETgsvNafbeDgA7Fqvq9pJ8dprr6nap+7u7syfDFEOYOBkskgkojJOoqvJ2nf94kojWOpSgZO1JIcunWaxocOUnmhpVA0RluW7pCOJclm+KwpgsTectQOEZdbdjpAXrwc8SOhAWbWGZau14ZFFGT0XHajfrWPflqSR2W5tVT2f9u/fn/mTIcpyDJxMdujQIZU2Dw1mvv/LOdFGMk6yFGE1w5Ux2Vwik++0keW7QE1A7b6b74mq9gVVQ+N0slFD1IV1gwUIJjU1rmjp1TZT6p5Eb7tRON7fpSMajeKJJ55Qw9i5644ofQycTNbc3Kwe+zphaUVlUPUaUt/UZ6mO4YbEUKbJZsFzo3OTcCfQeWEn2le2I+6Oo9CeVM0zV/hCw7sns7JlwUABumJS9wQsuNSGunnmnEs0DOzdpKPliHEtN2zYgMcee0xNLSCis+NdxmSSMhf+PmvfEGSZQbTHrFffJKKpwCnGH+lcEZocQvPqZgxMG1B/niHF48V+THFKry5r/76MJaLb1I47qXuS2XLTFtkw9yIN4xgBOr6lu106Dr5u7Lo7cuSIWrqTsS1EdGa8y5hIeqy0tbWpjzM9Yf1cpZYW2iw01PfkPjqCgVNukb5cPUt60HppK6KFUXhsOi4pDOGyghC8Q93is7Hu6c2AR9XlVdVpWHyVBqdJk1G6mqRwPImQX1d9nqRoPFVzSURjY+BkolAopIrD1cd+WJbbJ60INPVC32HBwvDRGSd71JrnR+MTKY+o3k99c/rU6JYaV1xln+a6I9CyMPtUH3Vho9+nlr6LyoxmmakeaZkWHAB2rdPR32nUPT3++OPYtGmTemNHRKdi4GSiVE1BPGbNuXQp5TUY3k0X1a35IyMNB4UtamOBeK6yA33z+tTolnBZWPXuWuqL4NqiAMqysPO4bLJ4ZbAAAwkb3F4NS66yoaLWnHOJx4xZd23HjGBJxj/94Q9/YL8nojFY8y6YJwKBwPCATiuTye+ixaLLdCKiGxkxDRqzTnkwuqXt0jZ0Le1CwjnUebwoiAt8oawbHBxM2rB2oABtMWPO3fyLbaibb865SILp6A4dR3cYg4J37typsk+prDgRGRg4mSj1gpSw8Fxaqb0oKjcCJxlial0awqnlujCX63KeBvin+lXxuH+KXxVbzxoqHs+2zuNxaNjs9+JQ2KX+PG2hDfNWmTMkWLQdA/a9ahSNHz16FL/4xS/UwGAiMjBwsgArlxLI0oHclKRbeMiiy3QpoaRxfo6QlQM8mujO413Lu9B6Sespg4Mrsmr5TsOukAdvDBWNV06RpTsNLq85Z9PXAezekEQ0pKOzsxMPPvggmpqazDkZIoux9p2QTFc5tEzXZOlsk0EaDApH2PrnShMrUhE5ZXDw1cVBXOQLwZNFy3fHoy5sGDSGBBeWDhWNl5lzLtKQd+c6XbVKkbKChx56iJ3GiRg4WYNkdKzI6QaKKobqm6LWrW9KYcYpz40xOHiaO4Z3lPgx3xPJmtEt3QmjaLwvboPLYxSNT5pmXrPM3Rt09LTpqlD8d7/7nZp1R5TPmHEykdNpBCNm1TKcTekkI6jrjdssv0wnAkNdwx0BZpzy2ejBwandd4u9Ebwji5pnypsAGdPSEnWoBplzVtgwc5lmypssGTy+/zUdbfW6alHw5z//WR0c00L5yvp3wxzmchnFoHaL3udLJ6W6hVv0BE/iH6pxcgasnx2jzAwOlt13HRd0IO6Jw2c3mmeuLgyixJ6w/FOQgIZXA17sDbnVn2tmaVh0haYywRknO+626zi+x1j2lKyTZJ9iMQvvbCE6Txg4WSBwsjmsm3ES7RYc6jsWf2JUcXj2lLXQ+aQBwdqgWr7rnduLpC2JSmdCFY/L7Du35eufNOwPu9Wuu5gOlFRqWHaNeXVPzYeAA1uTKgt14MABPPzww8NtVYjyBQMnE7ndbstmnFweqXEyeiP1WrRb+MlCuoaE9HLSNe6soxPodh39c/tVAOWvMdoXzBiqf8qG7uMy6kiGBI9ullk905xz6W4B9mxKIh7V1U472XHX1dVlzskQmYCBk4k8HmNAlc1mXs+W0/EWGY+BpA1JCw71HZs2slwX5HIdnSrhTaDrwi60XtaKSEkEzqHu4zcUBzDZYe1lJ3/SrpplNg3VPc1absPclea8dgz2ADvX6wgHdNXjSXo91dfXZ/5EiEzAwMnk4nDb0Gh0h9OagdPg0PJXthhermOBOJ1BpCyiise7lnUh4UqgyJ7EFUUhXFoQhM/Cw4OlWebWgBc7g25jSPBUDUtXa/AUZP5cwn5jxt1gj45wOIxHHnkEu3btyvyJEGVYdt0Vc4ymacNZJ7vFAie3RxvOOGUTFojTOXUfr/Oj6eom9M/sV8ODa4eGBy/yhGG37PKdhsMRNzb4jX5PMoBb6p7KqjN/JrEosGejju5mXe2ye+aZZ7B+/XoOCKacll13xRyuc7JaxilVsB636r3jNFIZMqffYheULEt36uhd2IuWK1sQqgjBrgELvFHcWOJHjWpfYE3dcQfWDBSorv4Op4aFl9owbZGmAsJMSiaBA9t0NB8yXixeeeUVPPvss0gkrL9zkejtYOBkMqtmnOxDdROJoflv2YKBE71dsaIY2i9uR8eKDsS8MfhsOi4rNJbvvBbdfRfWbVg/6MPhoTl3dfM0LL7cnJYFx/cMDQjWge3bt+M3v/mNWsIjyjUMnKyScbLYzjpt6CfDmreL0xtMGBGfI+KAFsuuoI8s0r6gOoiW1S3om9U3snxn4d13OjTsDHnwmt+rMsQlVRqWX6uhuNKcAcH7hwYEHzt2TBWN9/b2Zv5EiM4jBk4ms2pLgvjQCoVTs96N4mzFs1L3IdgIk8bTvqBvQZ9avkt1H5fdd9cWBVBq0eaZzTGnWrrrTxijWhZfYUPdvMyfR287sGtDEpGQrtoUSLuCxsbGzJ8I0XnCwMkq3cMttlQXjxqPriwLnE5YrmMHcZqA5TvpPt61tAsJpzE8+JqiAJZ4rVk8nmpZcDziVL2qpi2yYZEJS3fBfmPHnQwIDgaDakDw7t27M3sSROcJAyfLjF2x1rKSNLcTbpv1bg5nk9oJyMCJJmz33VQ/mlc3I1ATgE0D5nmiuL7YjwpH3JKjWt4IevF6wKOW7mR0klq6qzBpQHCrrgrFn376aVU4LvPuiLIZAyeTWXWpLjw0RaHIwj1tztrLKWixi0pZPzy488JOtK9sV7PvCu26mnu31BuGzYLZp4aoa7jbuFq6uzLzS3epAcGpHXfSquDJJ59ENDqU0ibKQgycLBI4WW1eXXDAeJTGgFYsiD0T9nKi8yk0OYTmq5oxWDeolsPmquxTAGV262WfBpN2FTydsHRnwqBg2XF3+M2kal2wb98+/OpXv0J/f39mT4JogjBwsshSndV21UVCQCKmq2WJbMs6ndA9PLtiPsqi3k/dy7rRflE74u64eoNxTVEQCz1hy73ROGXpzqRddx0N0iwziVhER1tbGx544AE0NDRk9iSIJgADJ5NZtY+T8A+9IaxwWHMX0dkyTva4HbYYf8Tp/AlNCqnWBf5aY3DwQm8Uq4usObZFlu5k111ffGTX3ZR5Jsy4W6sj0K8jEAioovFt27ax7omyCu8qFgmcrNY5XPR3Gu+cK53WW4I4E1lcDA21JGCdE533nzdnEl0XdKHzgk4kHUn1RkMKx+ss2HVc7bobLED90NLd9EU2LLxUy+jrj2Szd63X0dVkjGl58cUXVafxeDy7XmcofzFwMpnX67Vs4DTQZTxWqYyTtZYf0l2u4846ypRAbWC475NTAy4uDOFCX8hyhePyxuLNoBdvBDxI6EBZtYZl12ooLM3gOSSAg6/rqN890mlc6p76+voydxJEbxMDJ5MVFBhjzV1G4slSBnuBRFyHx6aj1G69pYczYYE4mSHui6Ptkjb0zemDDh0z3TFcXRSw5NLd8ahLZZ/kTYbHp2HJVTZMmpbZc2g5DOzdnEQsqqOlpQU///nPcejQocyeBNE5YuBksrKyMthsNtidGlxG8sky9CTQ12F8bOVhp2NhxolMYwP65vWpuXfSNLPMkcR1RX5MsmDPp/6EXdU9tUQdsNmBOStsmLVcGx65lJFz6DTqnvy9OkKhEB577DG8/PLLahmPyIoYOJnMbrejvLxcfewthOVI8zoh87qyyWCqCabfgmuglBfClWG1dBcpicBlA64oDGKeJ2K5ZW8ZU/RqwIs9IbdaNqueqWHJlVpGs+CRoIxp0dF61Lg2GzduxCOPPILBwcHMnQRRmhg4WUBVVZV6zGSNQbp62qB6r5TYkyi0JbJv2K+0JOAbVzJJwptQI1sGpxo9n5Z4I1jps17LAmmPfiDsxma/D9EkUFSuYdk1GgrLMpvhPrZTx4FtxpDg+vp63HfffTh8+HDmToIo3wOnL3zhC9A0TR0ybNKqpk0zCgtkqrnVJGJAf4fxIj/VlT3LdYGkpnrW2JI2FoiT6QODu5d2o3txN3RNx3R3DFcWBi05QLs97sCawcLhlgVLrrShojaz59DdDOxYm1QtC2TO3W9+8xu89NJLamwLkRXkbOAkM5Huvffe4eJrK5s1a5Z6LKpARmsL0tXZODpwst6L/dg0Vb8hXANGk1EiMw1OH1QNM6VlQZUzoYYFF1iwaDyYtGH9YAFah+qe5l9sQ938zJ5D2A/sXDeydLd582a1666npyezJ0I0BgvepsdPGqt9+tOfxi233IKLLroI2bBUV1RUBLtdQ0mGu/mmu1wnu+tkNle5PXve9cm7ZuHqZ+BE1hCuCqP10lY16066jcuOu2ILLoFL3dOWgBeHwsbvzrSFNsxZIdn7zC/d7X8tqYaONzc34/7778eePXsydxJE+RI4ff3rX0dvby/uueceZANZSpw7d676uKLWest10nOlu8X4WJYZskXPUMbJ3ZfhwVxEZxArjqH18lZEiiOq1cdVRUGUWPINiYZdIQ/eDHiQ1IFJ0zTMv0RTWahM6mkFdryiY6BLV8OBn3rqKfzpT3/i0h2ZJucCp3Xr1uFnP/sZfvSjH6GmpgbZYsmSJeqxvFYCKVhOx3EjZV7nisGeJct13XFjAKC73w0tYcGLSnkr4Umg/ZJ2tePOrYInGRJsxeAJqI+61K47aZZZXq1h0eVaxkdESbfx3Zt0NB00Xnu2bt2KX/7yl+oNMlGm5VTgJIWEskR3/fXX41Of+lTafy8SiWBgYOCEI9OmT5+u6rGcLg0lxiY7SxnoBkJ+XXVEnpIlReLBpDF6RdM1Zp3IkqNa2i5uU53GXRpwpYWDp7aYExsHjR13xRVGuwJnphO5OtCwV8e+LcbSnTTMlKW7gwcPZvhEKN/lVOD0jW98Q03dlu6z5+Luu+9GSUnJ8DF16lRkmjTBXLx4sfpYUuJW1NFgvNuTbsjZQUNX3FhX8HRbsDU75T3dqaN9VTvC5caYlssLg5Zt+9GdcKiicXkzUlCiYbEETyb8WvW2A9tl6a5bV296H3/8cWzYsIGDgiljciZwkl+cn/70p/hf/+t/YebMmef0d7/5zW+iv79/+GhsbIQZLrzwQvVYXqvBYcF65o7jRk8nGWJqxYLWsbTHjOU6b6fF2rITDdEdutptl1q2u7IoCK9mvd12YiBpV8GTZHN9RZlvlJkSDQF7NupoG9p1t2bNGjz99NOqBorofMuJwEmmasvS3CWXXIIvfvGL5/z33W43iouLTzjMUF1djdraWthsQFXmk15nFYsAvUOdxGe6s+MFqmMocJKddbZITvy4U64GT6vaESuIwWfTcUWRNfs8icBQu4JAQoO30Mg8mRE8SZfzozt1HNmeVDvwZLedtCxgt3E633LiTuL3+1V32VdffVWNMEk1vZRDisVTW/7lz9KN1spSWafqGdZcrmurN17Mp7mzo0g8rNtUWwINGnydPrNPh+i0ki6j5klaFRTbk7jIF7Js3zTp9bTBPxI8LbpCg9OkLHl7vRSOJxGL6KpUg0XjdL4Zb8eznGSMpCh8LC+88IL6ZfrYxz6mvk/6JVnZsmXLVJdcFEVRUqWrAZhWIucTDujwFGhqh51MWLe6lpgTpY4IfG0++Ov8Zp8O0RlHtHSs7EDNlhrUuOJYmIhgX9hj6eBpdVEAviJg0RXA7o26mjaQaYPdRsPMRZfLn/pU8HT77bdj0qRJmT8ZynmarkvCM3ddc801KuvU2dmJysr0ukvKrjopEpd6JzOW7V588UVs27YN3S06Dmy13tNTOweYscSGnrgNawctOJn4JEW2BG4sCUC36Wi4vkEV5BJZWUFTAap2GttrX/V7VfBvVVLMvrooqHpSDfbo2LNJV73fzCA7/aRdghSve71efPSjH8WUKVPMORnKKudy38+Jpbpcs2rVKvVYXqPBZcGa5o4GoylmuSOJUotunx5tMGnDQMIGTQpa27lcR9YXqAugf0a/+nhlQciyxeLCn7QPtyqQ4cDzL85sh/GT6zClaFwCuFAohEcffVStOBBNJAZOFiT1WDNmzFAvPpMtWOsUj0on8WwqEtfQGDXesRc1Wnupliild0EvwqVGm4ILfGHL1juldttt8vvUYO2yyRpmX2je61Y8BpX1knYF4XBYBU/d3d2mnQ/lnpwPnNauXav6e6S7TGe1rFP1DGsO/k0VicvgX4eFX9BTjkecamyEp9cD56B1lz2IhtmA7qXd0DVd1TtNccYtfXF6Ew5s9XuHx7NMXWhe8CQZ8X2v6vD36Wp26cMPP6yWYIgmggVvySQWLFig1lmdbg0Vtda7JlKMGRzQ4dCMHXbZsLuudag1QVEDs06UHWJFMfTPNm74y31hy79JaYs78VbQKGafOl/D5BnmnYsUqe/brCM4qKv6Fck8ScNMovFi4GRR0kl8xYoV6mMrLteNzjoZy3XWfkEXRyPGDsDCpkLYovzRp+zQN7sPMV9MFV/P81j/xi87bfeGjHkss5bbUGrixrZYFNi7WUckpKOrqwvPPPMMO4zTuPHuYfGeTtJ7qqRSeqXAcjobgERcR4k9qbqJW11n3I7euA22hA3F9eY0OSU6Z3aj3knM9UQtXSiesj/sUsvjUqc5/2IbfCb+ukmX8QOvGTv9ZK6dlG8QjQcDJwuTpbp58+ZZNuuUiAOdQ9NpZmdJkfjBsPFOuOh4EbS49a4p0ViCk4NqGLBdAxZ5I1nxu/Zm0IOOmB12B7DwMnPm2qX4+6A6jIv169dj//795p0MZT0GThaXWq6rrIOll+tqnXG4s+CdcHPMgcGEDfaYHSVHS8w+HaL0aEDPwp7hDRnZ8LumQ8NrAZ9qBeL2alggbQpMvOPIm7yWw8br1XPPPaeKxoneDgZOFjd79mx4PB64PBqKLbgxMNgP1TPFpgEzsqBIXO5Ae4bqL4qPFcMetpt9QkRpiZZGVXsC+V2bnhW/a0BM17DFP9Ljycw2BeL4Xh2Bfh3BYFA1GiZ6Oxg4WZzM3pMddqKi1ppLS23HRorEtSwoEm+JOdAVt6tap9IDpWafDlHaBqcNqseZruzYkJEaCiyZJ9WmYKqGKUb1gSlkGPDhN3X1uHfvXuzevdu8k6GsxcApCyxatEg9ltfAkrqapWOvrqa611i814xBw67gUK1TcxE83dacBUZ0smBNEAlnAgV2PSs2ZKR0xh3YMdSmYNpCc3faBfqBpoNG0PmnP/1JZZ+IzgUDpywwc+ZMOJ1OVSfgs2BZjrx7a6vH8K6fbCDN+o5FjEaYFTsrWChOWUG36whVhdTH1Y5seJMy4ljUhaNDO+3mXqTBbeL0o6YDI0t2aqg60Tlg4JQFHA6HCp5E2WRYUttRY7uvvAsus2fHC/quoAeBhAZnyImy/WVmnw5RWlKB0+SsyO6eaGfQo4aDO10a5q8yr1hcRtsf2a6rx+3bt+Po0aPmnAhlJQZOWWLu3LnqsWySNeucZLhmV5OR/p6fJVmnuNoybUxRLm4ohq+VA4DJ+kKVIejQUepIZsXuutGSstPO70MkqaGwTMPMJea9nvl7R+ozX3jhBSQS2bP0SeZi4JQlZs2apR4Ly6WrOCyp+bDxDq7WFUeJPZE1tReHwkZH8aodVXD3GrVPRFaVdCfVKBaRTXVOKSHdhm0B4w1L9SxzR0o17NURDevo6enB1q1bzTsRyioWvQXTycrKylBYWAibTd6pWfP6hAalUNx4B7cwC0ZDpOwKudEadUBLapj0+iQ4AsZMOyKrkmaY2Ro4iY64AwdCxhsWaVFgVr2TNPFt2Ge8Zq1bt469nSgtDJyyhIxemT59uvrYiv2cUpr2j2SdSrMk6yS77LYGvGocizTGnLx1MhxBBk9kXZFy441JZZYViI+2N+xGd9wOh1PDvIvMW7LrOC6dxXU1AJiF4pQOBk5ZpK7OaB8utQFWFfJLh17jHdxSbzhres0koGGz3wf/ULF49avVcA4Yu+6IrCZSYgROxXapGsqO37GxOotv9XsR1Y3mmLVzzDuXozuMN3w7duzAsWPHzDsRygoMnLJIba1RDFBowZYEo0nqW3bYVTkTWdLXyRDRbVg/WKBGRDjCDtRsqYGvjQXjZD1xXxxJe1LNriuwZVeB+Mn1TrtH9XfyFJhfKP78888jHs+e1y3KPAZOWaS6ulo9urwanBauYZZp5FIoLpZ4I7Bl0TvisG7DusECNZxUOotPenOS0V08e+9NlIs0IFYYG846ZbP6qNP4fbMDc0wcyaIKxUNGobgMAiY6HQZOWcTlcqGiokJ9XGDxrFPzIWO3SpE9mVWF4qn5Wpv8Phwe2m1XeqQUNZtr4Oo3/kxkBdFCo+2H/I5lN6MtSFyX+k0NVVPNKxQ/utN4k7dp0ya0t7ebcyJkeQycskxVVZV69BbC0pLyIrTDeBGa54lmTVPM0fUXO0MevCY1GEnAPeBGzaYalO8uhy3KXxuyxnKdyOalupRg0oZ9Q8O3py/SYDNpb0ZPK9DdoiOZTOLZZ59Vj0Qn4x0gy1RWGlvqvEXWLRAf/SLU0airEQsXFYRhz6Ilu5TmmBN/GyhEQ8QBDZpqlDll3RQU1RdJRTmR6YGTLwcCJ3Ek4lKbM6QUoW6uea9vknWKx3S0tLSozBPRyRg4ZWvgZPGMU8qxnToiIWPJbpnP6D2TbaTu6fWgD+sHfegfallQsbcCdevqUHSsCFrC+kEs5Z64N3cyTkL2B+4KGYXitXPMq+OMhYH6XcabvFdeeQUNDQ3mnAhZFgOnLGyEKcwckHkuEjHg8BvGVt+Z7himurJjHMtYuuIOrBkswPagB6GkpnbeVeyrQN0rdSg5XAItxgCKMifhNlKebpvc5LMvmzuW1phD9XaSQvGa2Sb2dmow2qrouo6nnnqKjTHpBAycskxJiVEV7jImFmSF/i6gcb/xrvhCXxhFtuxd45Lap6MRF/7SX4g3A8aQYHvUjrKDZZj6ylQ1LNgetpt9mpRHgZNDA3KnXauGA0ObMqpnAnYTW6nJEODgoI7BwUE888wzrHeiYQycskxRURFsNpsavZJNwVPTAaCvQ1cv8pcWhuDKsuGkYy0r1Edd+OtAIbYFPKr3ky1uQ8nREpWBqnqzCu4ed64kAsiCdIeuejmNZJ1yQ1vMgb64TXUUr55h3nlIL7oDW3XI7N+jR49i7dq15p0MWQoDpywjQVNxcbH62J1FgZM49IaOcNCod7qsMJSVxeJjZaAaoy78baAAm/1edMXs0HQNBW0FqHm1RrUxKGgpYB8oOi+SDiNwcmjZ/7s0QsPhiJF1mjRNM33+5pG3jGu8YcMG7Nq1y9TzIWtg4JTFy3XZFjjFIsC+zTpiUV0NJ11VEMqZ2gx5sW+LObHeX4CXBwpQH3EioQPufjeqtlehbm0dio8WQ4uzDoomjm43fn9y4U3IaC1Rp+rrJLuHzR5q3tUEtAw19P3973+PvXv3mntCZDoGTtkcOGVJgfjJs+z2vyp9UoxBwBeonXa59aLfn7Crhn5/7i/E3pAb4aFC8vL95WoZr/RgKWwR/urR+OlDS3QyeiWXxKGp4ElUTTX/f65+t46O40ax+NNPP419+/aZfUpkIr56Z3XgZP4Lytsx2CPLdkm1026WO5aTwVNq9t3+sFsFUG8EPPAnjFYGpYdLVQBVvqecheREp9EUNUreyyZb4xIdfktXfemkKeaTTz7JzFMeY+CUhUpLS7M245TS3QwcfnMkeLowR4OnVCH5cVVIXoBX/V70xG2wJW0oPl6slvBUABXiTjw6d7IhQciyVq6R9h9JHfAUaJZ5rZPWKh0NI20K3nrrLbNPiUzAwCkLZVsvp9PpbBzJPEmPpxW+MLQcDZ4MGlpiTqwdLMCGQZ9RSJ7UjABqnRFAcQmPzuknaqj5alzPzuzz2ZbrehPGG4oSo++vJRx+c2TZTsay/OUvf2GrgjzDwCmLM06eLA+cUoWXh143gqcZ7hguLciN3XZnpqEz7sB6v9GNvHN0ALW2DqUHSmGL8VeTzvJTFNeGf06iORg4CXlzIQrLrPX/J8t2jfuN16lXX30Vjz/+OMLh7JyMQOeOr85ZWuPkcDhgs2vwFCDrdTVLv5Sk6ptS44pjdVEA7izv85QeTS1HbPAbGSi1hJewofRIKaasnWLswuM4FzoNV79LzU+ULvZST5eLBpM2y46YksBJXrekz9Phw4fxi1/8At3d3WafFmVAbv625UEvp5Fhv8gJMhB498YkYhEdZY4krikKZHWH8XMlGShZwpMaqIGhInLZhScDhQsbC3O1/IvGwd1nDHPriedufZxsqBBWfYPY3QLsXp9U8zi7urpw//33Y9u2bWoZj3IXA6csVVVVpR59Ri/MnODvBXat1xHy6yiw67i2OIA6Zwz5w6iBkmaarwc8CA61MajcVYnajbXwdHoYQNEwb6c39wOnoYyT7CDWLHq3CvQDO9fpajJCLBbDiy++iN/97ncIhaRPHeUii/4o0tlMmTJFPRZXWGvtf7zCASN46us0xrNcXBjCBd4QbHmVctHQILvw+guxM+hGNAm4Bl2o3laNyVsnqyUaym+uPhe8PV6166wpZuJAt/MsNqp2y27h+DAWBvZu1nFsZ1L1qNu/fz/uu+8+1NfXm31qdB4wcMpS06dPV49F5eo+m1PiUWDvJh2NB4xgaZYnhquLAiiw5UPd04ltDA5H3PjLQBEOhV2qE7m324vaTbWo3F4JRzB3RrvSuZFeYKIx6kRoKCuTi2SkkfzcC1sW/Li3HgV2rUuqrPnAwAAeeughtetOMlGUO3L3Ny7HTZo0CW63Ww3CLDReQ3NO4z4dezeP1D1dX+zHLHc0Z/s9neld966QBy8NFKIhYmQXClsKVf1T+e5y2CMWfitOE05q3nwdPrUT9UA497OPqcDJyhmnk5fudqzV0V4/sutOCsd7enrMPjWaIAycsrhAfM6cOZYZSXC+9HUYL0L9XcbSnXQZv6owmHfZJxFM2vB60Is1AwVoHxomXNxQrHbgqRYGUf4657qi40Wq5k0cjLjgT2ZJNDEOqXEysgSWLZJx4Mh2Hfu2JBEN62hvb8cDDzyAQ4cOmX1qNAH4SpvFVqxYoR6rpgK2HH79jIaAPRt1HN2RRCIOVDkTKvs03xPJs9onQ1/Cjk3+AtUDqjtuH25hIGNcyvaWsQt5jio+VoyKPRXq48NhF/aEjF11uUx+v1OBkyzhZ5vedmDnWh2DPbrq8/TYY49h3bp13HWX5Rg4ZbGZM2eqZpiyXFdh1IrntLZjwPY1SbV7RbJPi70RXF8cQLXaeZd/AZT0gFo36MMWvxd9Qz2gSupLVBPNih0VcA7kbtFwvjW6LNtXhvJ9UtBoLM/tVEFT7maaU9ya8XudTOrqTVM2ioal1YqOtmPG/8vatWvVrLuENICirMTAKYtpmoaVK1eqj6fO13I665QSCRq7Vw6+bqTAi+xJXF4YUst3FfYsfWUdFw2tMSfWDBZg46APHUNLeEXNRZiycQqqN1ejoKmAjTSzkQ742nyYsn4KSo4Zg733hVKZptwPmoR3aEledq1lMz0JHN2hq/mcsuS4b98+1bKAwVN2YuCU5S6++GIUFxerQZh18/PjxTQ1quWtv+loOqirjuOyfHd1cRBXFAZQnqcBVEfcgY3+ArwyUKAmy6sBqX0eVO2sQt2aOlTsqoCnyyPb9cjiHAEHJr0+CZPenKR6eQUTmsos7gt78iZoEvLGSIT8yAkdDVB1T/KadfDgQWaespSms8XpKWQbqYw16e/vV0GJ1R04cAC//e1v1buaneuSaldHPnF5oYLGSdM02IbeCkjx9MGwG52qOWD+3GhGk7E1Mv9vhiuqGoqmJFwJBKoDCE0KIVwehu7Iv2VOq5IC/5KjJSiuL1bzCyX4PRh24UDYjUQe/hwv8YYxzxNF6xEdx3blzs9pSRWw8FKbWiVYtGgRPvCBD6gNP5Qd930GTuO8gFYhaV9J/0aCumogKevq+cbtA6bMOzGA6o3bcCjsRnPMoXrC5CcdkxwJTHHFUOuMwT3q9Vm36QiXhRGqMoKoaHGUeWgTaDFNBUuyJGeL24aD/x1BT17snDsdySBPdiZwZHsS7TnWS7J0ErBAgicbcM011+Dqq682+5Ty2sA53PezoKUYpePd7343Ojo60I1uLLzMKEZM5FnPNal/OrpdR/NBHbVzJICC6v8k3cdlfEl9xIXjESdCOToQ9WzLeHJsh0cFUbWuGCY74vBJHUm3Vx0iaUsiWhJFpCyCSElEBVJxXzxfk3bnnQxxlhYDJUdK1HxC0R+3YW/YjdaYvDzn74XXoKPcYRRQD/bkZquVI28lMXelTe20mzZtmtrwQ9bHjFOOZJxEX1+farTm9/sx0KVj7xaj/idfOZxA9UygepYGl8e4AUnTwLaYA/VRp3rM3yyU0FFoS2KyM66CKblJuW2nLock7UkVQMUKY+qIFhofJzyJfL6vj08SKGgpQNnBMlXDJGS4876QkR3lhQVK7NJ2JIB4TMfWF3Jnme5ksy/UMHm6hoKCAnzuc59DYWGh2aeUlwa4VJe5C2g10mjtV7/6FSKRCAL9Og5s1dX8t3wmw0EraoHJMzSUVI7c6SNJTRVRy1y4XjWFPd+jACOQkgCqwpFQN64Se3K4j84p323TEffEVUYq5jMCKamfSriNI+lIQnfqxqMEZPl+eYVuBEwyMsUZMNpFhJIa9obcaIg68zyQP9FsdwTLfRH0tksjydwNnKTOaelqDQUlGhYvXowPfvCDZp9SXhpg4JS5C2hFTU1Nqlg8EDDerR16Q0dvm9lnZQ2eAiOAkqahqSyUGEzY0BJ1oCXmZBB10nKJBFOljiSKbAm1y0kO+ZztHO7xuqZDt+sqgBp+POljyWxJobp6tOtIOpMqEEu6jMe4N64CsqzcCzzUWqD0UClcfmNMSiQphd9uHIm41FxCOtFVhQG1W/bYriRaj+T21fGVABdca/xgf/7zn1cjtSizGDhl8AJa+f/hqaeeQmNjo/qzbNtv2KfnY5/IsWlAaZUxrqa8BrBLR80hkgGQIEqW8qTJZD7uZkonoPLYdDX6JnXIn6VhoVs+1nQ4bboqotQm8PJJAJbKcskRLRpaQiyKqeDKck/V0JKc7JRLBUzRJHAo4saRsAtxy52wNbi0JN5V4lc/O2/8NanqF3Pd/FXSyJhZJ7MwcMrgBbQyaa720ksv4bXXXlN/9vfK2BId/j6zz8xaZOp6+WSgvFZD2STA7tROGDDaGTeCKDlkXhydCyN4cmo6bJoxPkNKoO3y55Me5fOOoe+RR5eWCsTk4yS8tpHxG2OJu+OIlkZVUXuk1Chul6VCs9oKFDUUqSNVwxTToXZ4yrgUBkxnNt0VxcqCsCo32PFKfrzb8xUDF1xnvL584QtfQGWlMZOQMoO76kix2+24+eabMXXqVDz33HNAWQRLr9bU1O6GvTriebbr7kwDObua5dBVPVRplY6yag2lkwGPT0O1M66OVAFve8yhjq64nUssZ6VBrlxc1yYg26mrTJZkt3z2JIptxrJhsd3IeDkiDjjaHfC1+4a+W1fZKBVEDR3y5/O11CejUeTfLmgtgLfTqzq4i3BSU8HSsagLsaHP0ZlJ/zEhv5P5Ijggs+10lE3WVG8+Bk7WxXYEeUAKDqdPn66yTzt37kT1TE0VS8vSXa71RhkvaSIqgznlBUx4i3SUVwOlkzUUl2vqJl1sj2KuJ6oyCJ0xh9o2LoFUOO/aHGSahrCuIZywofuk3aJ26KqYXQrby2SHoD2BAjvU8pgcRU1FJ7ZbGGq1IEt8EkxJTdU5SwKuARc8vR64e9zwdnnVvMAU6SF2OOJCE4u+z0mZPa42J8iO4I7jyCupwOnIkSO44oorzD4dyuXAqbm5WbWuf/HFF7F//360tbWhvLxc/eB97WtfwyWXXIJ8J1tc3//+92PFihXqOknPp9kXaKieaWSfJFigU4UGgWY5DumwO3VVFyVBVNlko7i81hVXh5AMVGPEqbaTRxlEZZTUofUkHOpAZKRzeiqISgVUzqRNBTpypEhmSgrPpWZKdgbKkp88qmBKJcqMoEr6LNnDdrX0Zg/Z4Rp0nRAoCX/ChsaoQwVLg3ncuHI85E2J6GzSERt6LvNF39Dr8PHjxxGNRuFyGXVxZC050cfpG9/4Bv7t3/4Ns2fPVh1Yq6qqcOjQIfzhD3+A/O899thj+PCHP5x3NU6nk0wm8frrr+OVV15BOGy0GB/s1dG4Xx/+xaWzKygByqqh3iEWlY8swciYDMlAsVeUddstlNkTQ9nD5Ji9q9Ilhd7dcQe643ZVC8e2FuNT6YhjdZFRCb59TVItX+WblTdpcHs1fPrTn0ZdXZ3Zp5M3BvKtHcEzzzyDioqKU1rWb9iwAddff73KtrS2tsLtlqniZ5frgVNKMBjE5s2bsXXrVsRiRk3BYM9QANVh9tllF5cHqJhi7NIrLD1xh159xKm6ludfx/LsIIXnEkB5bUl4NWO3oEdqpoafRqO7ktQnhZI21YVeHqWFxaDaLMC6pYlgg64aXkrdWtsxYyNLPlpylYbiCg233nqrmmNHmZF3gdOZ3HTTTfjrX/+Kbdu24aKLLkrr7+RL4JQi/Z4kgJJrxABq/LyFwKTpxsgXp3ukY3lTzIEDITcGuIRDdIoFnggWeSOIhnW89XL+jYxKmbdKQ+UUTW3sYZlJ5nBX3ShOp9Gd1+HIiXKu80Ja/d944424/PLLhwOoovIYFl2uqe3AMvutq8Vo4kdnF/IDx/dI3yygvEZHtXQsr9Iw1RVXh3Qr388AimhYtTOmAidxbFf+Bk0iVdclo7PImnI6mmhoaMDf/vY31NTUYOnSpaf9PhlPIsfoyDOfA6jLLrtMBVBvvPEGUBJV74CmBXS0HtHR3mBs36f0duh1N8uhw1eio26e8U6yzhVXhxQRy2wyPzNQlMemumJY6QupTvQdDbr6nSHAZuPSvlXl7DMjS0633367CoikcFx6Gp3O3XffrZbmUof0PcpnUhP2jne8A1/+8pdx7bXXwufzwVOgYeYyGy66ScP0RTI01+yzzC7BfuDgNl0VvKZ600j26YbiAFb4QvBqSbNPkSjDdMxxR7CqwAiaOht1HHmLae1UvMRVEuvKyRon2TUmQZPspvvMZz6D+++//4zfP1bGSYKnfKlxSicI3bFjB7Zs2YKenh71uaRkU1qMLJS/1+wzzM7ZVNMWaiiv1oY7lMvMsgNhN5skUs6TNwrLfeHhVh4th3XU7865W9HbMnelzNLUhssnKDPyusZJgqZPfepTKmi64447cO+9957178huu3R33OUjqROTwvqVK1fi4MGDKoCSPiNVdZo6pJWBBFDdLcbyFKWXgdr/qo6ich3TFmkoqdQwzxPFDFdUDX6Vxokc/Eq5GDDN80RUZ3AZnyNvwI7vyf0hvufCMdS6STL9ZE2OXAuaPvnJT+Lhhx/GRz/6Ufzyl7/kOvEE0jQN8+fPV4e0d5A2Brt27UJRWQJFF2mIRXS0H4ca6ZIPQzknwmAPsGejjtJJOqYv1lBQomGJL4LZnqgqID8edTKAoqwnrR7muUcCJtHfpePYTj0vezWdSaoMoqjI6HZP1uPIxaDptttuw0MPPcSg6TySgvv3ve99uOGGG1QRuRyS6qybB0yZq6nRAe3H2JE8XdI3q69DR2WdkYHy+oALC8KY742oFgbSTNPoJkSUPX2ZZMbjdFcMk51xVceUCpikV9xAl9lnaE0ur/HIwMm6HLm0PCdBkzQNe/TRR89YDE4TuxNv9erVuPLKK9UynrQyOHr0qKrdkSMclHl4upo5lW/jE96OriajdmzydB1T5mnweY0ASpY3DkXcOB5xqvEiRNako8yexDRXVO2Wc43afiRvDJoOMmA62zKd02X8fpeWlp7vJ4vyOXC66667VIZJdoPNmzcP3//+90/5nk984hOYMWOGKeeXL1tnFyxYoI6uri6Vgdq+fbvMhle78KYtAHo7dLVzprfVqG2gsUmdWNsxoP24jskzdNTN1VDgBS7whbHIE8bRiEsdHCpMVuHRJFiKYZo7prqwp0RCOjobjB1z0t+Mzsw3VJNcVlbGOXUWlhOBU319/XDDsB/84Adjfo/MsGPglBmVlZWqY/t1112HvXv3qrl4TU1Nw1moeMzo1SJDPJmuP0sAdRToqNcxabqOmtkavIUaFnijahBqc9SBY1GXmpPGsR9k1lKcBEzVo5biEnEdPa1GT6b+Tj4v5zr/UkyePJkXzsJysh3BeOXbyJVMkCzUzp071SHXdfQ7Ulmekt5GgT5TTzErlNcAtXOMWVYpAwkbjkWcaIo6EeE8PDqvdFQ6EmoZborzxKW4gS4dHY3Gm6IEm+S+LfMv1lBRq6k3+ifPXqXzi7PqMngB6dxInC6tDCSA2rdvH8Lh8AlBVG8b0NtmvFPlct6Z35lOnintIAD70DRaeQvUEbejOepES8yBKIMomrC6pcRQx/sYvLaR99qRoI7OpqGluEFe7vE2vlz1d5r6fZb+g7IBhzKHgVMGLyC9ffF4HIcPH1YtDQ4dOjQ8YFgkEzoGe+VdLNDfqatt+8yNnsruAKqmApOmaSgsG8lCJXWgK25HW8yB1pgDAY51oXNchpPMUo0zpppUjg6W4lFjdmUXl9onVFk1sPBSm7r3fOlLX1LtXyhz8roBJmUPGSmQKiiXIOrYsWNqZ54c6oe4EuqYukBTdRMSPMkx0G10K+dygHENpJC87ZgOt09H5RSgYoqGwlINk5wJdSxDRC3ndcQcKiPVFXMgzp15dAIdpfYkqhxxTHLGUeFIYCiRqSRiRmsRqUuU1hlsdDvxJk83Lrj0yWPQZG2scRoDM07mL+fJaBdZ0pPC/yNHjiAYPLGjpmSfQn6jLsrfp8PfBwT6OYA4xe0z3sFKMX5xpTY8/yqVjepN2FVReW/cjp64HSFdXrT5DjdfOGT5zZFQAVKFI45yRwLOk57+qCydtwM9rTr6OhksnU/FlcCSK20qYPrHf/xHtcGGMosZJ8pq8uJRUVGhjhUrVqhAqqOjA42NjepoaGhAX18ffEUafEWyVDXyiq+CqX4g0DeUoerNzxd86dwuO/LajuqwO6QzOVBSpaGkCmpnnnHDTAx/fzipqazUYMIGf1Ie7QglNdXyIKZWad5OUKWrlLZD01W3aG1UC095lH89oWuqL5XM6uOImfO37FZiT6pASWqV5LHIlsTJK0Gy2zW1NC6BEmuWMkOzAbOWG0+GjLZi0GR9zDiNgRkn65PWEzL2paWlRT3KIc/byRJSK9VtNN/raweCLGCF22u8wy0q01BYbvSOsaX2ko9BghoJrGKnBDk6JJElH8lft0OHcyhISj2eCwnQwkmb+rckaAtKAJe0wa+COTuHH6fJpSVVfZIExpJJKrUnxnwupDmt/G4M9hhvMgLy68M91hklwevsCzVVoyjNhP/pn/4JHs/QzBXKKBaHZ/ACknUEAgG0tbWpo7m5WWWm5HOjyS4gWX6QnXtcfjDIMp6vBPAWGdkob6E8Ak7PSBfj8ZCMYTJuLBEanxh5p22znzloG02Cqb64HX0JG/oSxjIjm4Aay25VzjiqHAlUOuIodZyaYpU5krKcLbWB/l6jRjAWHfdTS+Pc2CHtB0onaSrL/qEPfUjVe5I5GDhl8AKSdckNW/pHyQgY2b0n9VJShJ4iBecSRMmIE8lGsdj8VBLcyNBROVSQYwfsQ48S/8gyqDp04/rJIUFSIjHy8dnaSsi7bptDgrSRf0vmdXkKjCDOUyhZsrGDq0BCQ3fcgZ6EXe0ilOXG3K/V0lFsS6r5b3JIdunk2DM4oGNgVDYpfOL7B7JADeKCS4yh3k6nU40Kmzt3rtmnldcGzuG+z6W6cV5Ayh7S7kCCp9E790a3P5BuxzLmhN2OrUcCq4JioKAUKCzR1KOvWN6pn/h90aS0YXCoIEoe+xNS4ZMLgZSOcntCtQaodcZQaD9xTS0cMHa7SX2SBEycC2lNngKgeqamerDJGxBZnvvIRz6C2tpas08t7w0wcBofBk75kY2SuihpwilHd3f3Cct5HUPztfhO3dpLHYVlUF3Ui8qhjlQz0JS4DrVrUHYQSmZKdhNKrVY2kJBP2gNIsCQjTUb3UpJAXwJ8mf8o2VL+nFqX3QmUTQaq6jSUVY/87MkIsPe9730c5msRDJwyeAEpN4IoqYt66623VDPO0d3MZalDGv11NfNdvOVpko0yCt9LKjUUVQCOk/fYy3OasKlgSoIoyUj1x+2W6Wvl1UaW4KSf0ujTl11v0lm/W9oDtEvwZOaZ0plIfWD5ZKC8VnayntgORJbkVq1ahTlz5rBfk4UwcMrgBaTcIjVQkoHasWOHqo1KjXKUh752XS3lyc2LXcyzg+wYlExUKisldVOnq5UaSNjVLj4JrAaGd/LJV89XUKWrtgCpNgFVzgSK7ScWhKXGEEkvpf6u/GytkQ1kyVgCdQmSJLskDWhHq6qqUoXfF1xwAcrLy007Tzo9Bk7jxMCJUi0P9uzZo7JQsksvJRo2lvJk+nvYz2uVTRwuY3lPWjHIvD853L7TB0YSOAUTNtUaIdXXKpLUENE1RHUNcV3aNMiSoHZKH6pUe4bUIUttBbYkfPakepQg6aSVRRWQS5Yz1T5DdsKRNckGCQmSymtkCe7U7OaUKVNUF/CFCxeyN1MWYOCUwQtI+UFqoGQpb/v27Se0OJCbnARQMhE+PjJqj7KIw2m0Y/Cl2jHIY9Hpd/JNJNnZqbre9w0FTJ0y3uS8/7M0DsUVwOQZGipqJXga+RmRQu/Zs2dj5syZahmusLCQ1zmLMHDK4AWk/JJIJNSOPAmipMVBailP6k16240gSjIFXMrLfpJRkGahsnVcDpdHg9Nt1K+43EbRrxSop46T54vpSV0F09KWQR5jYWk6aWw+kGLukJ/dubMpUzlpmjFPzls08jyXlZUNz9usq6uDbXQxE2UVBk4ZvICU30t5sown9VDt7e0nNBvsbDSW8oKnNjOnXHVygopduLOe1C1Vq+ySpgJp4XK5sGTJEjUOStoIcCBvbmDglMELSCQkcJIAaufOnScs5QX6jSxUVxN35RFlA2m+WjlFMkya6hWWUlNTo2bJLV68GG6329RzpInHwCmDF5BotGQyqZbwpBZKlvRkaW94V16HZKKMRpvcSk5kHbIEW14NVE7VVCuL4c87nSq7JAETm1TmtoFzuO/L8HIimiBS4zBv3jx1hEIhtStPMlFNTU0omyxblTVVENzdYizlyTR6IsosqU+T9hSlVdJnSXZXnrjOOn36dBUwycGhu3QyjlwZAzNOdD525Uk9lCzl9fb2ntilvBHolNYGnCdGNOGkmF9mHkpPr8IyDUWlsmvy1B2TshS3aNEiLF26VGUeKL8McORK5i4g0bmQXXiSfZKlPMlGRSKR4a/J1PquZiMbFQnyuhKdS12S7HyUWXDS5FQevfJx4djd41M74mTsyaxZs1QLAWknQPlrgIFT5i4g0XiGDh84cEAt5R05cmS4tcHwqJdmFpUTjQ6OJHMkPbZ8hRo8RYBH2kR4ZYn89D23ZNebBEmVlZUqqySNKeXw+Xy8uDSMgdM4MXCiTJOdeDLqRbJQ9fX1w5+XWGqgS0dnk1FUHo/yuaHcJ9mjojKgoHSow3sp4HRpZ6wtlDe5Ms5EgqTUowRL8uhwsJyXzoyB0zgxcCIrjHrZvXu3WtY7eRyHzC3raQPHvVDOkKU1KdKWmYLSmXusMTgSHElAJMGQHBUVFSooKi0tRVFREZtP0rgwcBonBk5kFX19fSqAkkCqra3thK+Fgzr6O4C+TuORI18omxRXAhU1GkonG6NuTg6SqqurVQsAWV6TY9KkSbDbh7pQEk0wBk4ZvIBEmSI/j9IbSuqijh07pnpGjc5GBQd0DHYDAz06BntYYE7WU1hq9EqSBpMywmZ0oDR16lRVrD1t2jQ1vkQ6dBNlCgOnDF5AIjNEo1E0NDTg6NGjqrC8o6PjlO+JRY2RL4F+I6gKDUK1PIiNbOTLGi6PMYxXxl7IodmMJqJS8xWLsvbLyqSgu7LOCJZGtwHwer2YP3++6nkmO9vYjZvMxAaYRDlO3o3LBHY5xODgIBobG1UwJY+yrOd0JVFSCXWMHqQWjxk9oyKBE4fOqs8FzR1Q7BhqTCj9dmT3lNx0pf7F7jh9YbCQHYnR0NDgXDU8V0dwEPD3Acl4xk6fhsjzVl4ro0ukuHvkuZMibQmWpFeS/Oxy6Y2yERtgjoEZJ8p28XgcnZ2daoaeHJKRkiackkU9WwAiwVMqkAoHdBVcpQKtRHzimxMWl0uwpKmaF7nJamPESLKUIx2c5cYrYzDkUbJuwWDwhF5YY/3/SKZtsBfwyxJmr2TfJvb/gQCbw3gey6qlO77RS2n0czd79mw1423BggXMLJElMeNElOcksEgV1Z4cUEnn8p6eHvUoxedyyMdySG8po4lg6m9opyz/SWAlQVQkBETDOqJheTSWyySwSh0SAMmSmk0O+6gGhT5NNSaU7eZj7Z6S3VJS4zJ58mT1cWr3lNyAxyLzACWAkvPv6upSAaI8SsAogaJ0jJZj8nTj30rEdJWJkiAq0Gd8zIajZybPpWQDJdCVuW6ydCrPpwS60i5gdKAkJJMk9UqpYEmW5YhyBTNOY2DGifKRZGekn5QEVanAanSQJcHJRJPmhBIgSaAk88HkkK3lE9naobm5WR3S2kEeJVN1Mlm+NGrBjHowWeaTTFUu9c2S4FWaRUrQ4xoKgKSrtgREdpcE2yM1ZHbHyKPMdbPbz7xUKqQuVJbf5s6dqzpxs7ibsgmLwzN4AYnyhSyJjc5QSV3V6CMcDqugRLJWJwdHkgGTgEgyR6lDsmGy3TyTRcGyE1GyURJEtbS0oLW1VWWmJGs1FgmoJIAyAimjFkxqqORRH9nUaBmS4VPdtaU2TD1qwx+fqYFkuqTbdmFhoTrktVFaBEjbAAl+2YmbshkDpwxeQCI6NTiRAEqW1iRgOt0Sm1VI0CT1YFIHNvo4Uz1YqhhdlivV0uXQsmVsaNly9NLlRAdGqWyR22ssfcpypyybSYAkjxKono5kgeQ1TYJYmc0mdWNyyFKaBLBSPyaHfJ88yufkkD/LI4u5KVexxomITJMq5M4WEgxI1kSO0SRzJsuUkqGSQEo+lvopeZTsmwQpcqAi9TdODViSSR2JmNEyQYIo2eEnyS15lDZckrWSXYypnYwS80icqWrDZKnMaSyhqUdXelkjCXBS3bWl0/boOjFu+ScaPw7wISIag2RcZAlKDilyPrkWTJYsJSsl71TlY6mnkiXL1KMU4svwWZvbyBBNZKCXWiqTcSOpsSOpIEkySWfKOhHR+DBwIiI6BxKUpOp8pKh9LBJcSeAUCoWGD1m+HH3IEqEsa6YO+TuppU0JjkYvlckhy2myxCbZPAZGROZh4ERENMEksEnVC7FOkii3WLtqk4iIiMhCGDgRERERpYmBExEREVGaGDgRERERpYmBExEREVGaGDgRERERpYmBExEREVGaGDgRERERpYmBExEREVGaGDgRERERpYmBExEREVGaGDgRERERpYmBExEREVGaGDgRERERpcmR7jfmE13X1ePAwIDZp0JERETnWep+n7r/nwkDpzEMDg6qx6lTp070c0NEREQWvv+XlJSc8Xs0PZ3wKs8kk0m0tLSgqKgImqaZfTp5EelLkNrY2Iji4mKzT4fOgM9VduHzlV34fJlHQiEJmmpra2GznbmKiRmnMchFq6urO1/PD52GBE0MnLIDn6vswucru/D5MsfZMk0pLA4nIiIiShMDJyIiIqI0MXAi07ndbnznO99Rj2RtfK6yC5+v7MLnKzuwOJyIiIgoTcw4EREREaWJgRMRERFRmhg4EREREaWJgRNlXHNzM/7zP/8T73jHOzBt2jS4XC5UV1fjAx/4AF577TU+IxYTDofxla98BVdeeSVqampUAas0ibvuuuvw9NNPpzWigMz1hS98QTXzlaOrq4tPh4Wknpexjh/+8Idmnx6NgcXhlHHf+MY38G//9m+YPXs2rrnmGlRVVeHQoUP4wx/+oG7Cjz32GD784Q/zmbEIudFKgHvJJZdg7ty5qKysRGdnJ5577jm0t7fjzjvvxM9//nOzT5NO45VXXsH1118Pn8+HQCCgnjt5DskaJECaPn06PvGJT5zyNXlzefnll5tyXnR6DJwo45555hlUVFTg6quvPuHzGzZsUC/whYWFaG1tZXsCC40gisfjKjM4mt/vV8HU3r17sW/fPixYsMC0c6SxSaC0dOlSXHDBBejp6cG6desYOFkwcJLXwrVr15p9KpQmLtVRxv393//9KUGTuOqqq3Dttdeit7cXu3bt4jNjoRFEJwdNQgLcm266SX185MgRE86MzubrX/+6+n265557eLGIJghn1ZGlOJ1O9ehw8EczG2qf1qxZowKrRYsWmX06dBLJLv3sZz/Dgw8+qGrTyLokuL3//vvR3d2tShekhEGWxcmauFRHltHQ0IB58+ahvLwcjY2NsNvtZp8SjRIMBvHv//7vqg6to6MDL774onrOvv/97+Pb3/42r5XFnqtly5Zh5syZeOmll9Tn5GbMpTprLtWN9bmPfvSjKpiS2jSyFr6tJ0uIxWK4/fbbEYlEVOE4gyZr3oy/973vnZAd/I//+A989atfNfW8aOwNGG1tbcNBE1nXP//zP+PWW29VGSYJmN566y38z//5P/Hoo48ikUiozTJkLcw4kSWKjyVokheIz3zmM+pdFlmXvJg3NTXhiSeewL/+67/i3e9+t/qYwa41yCYLqSH88Y9/jC9/+cvDn2fGKbvepCxfvhyHDx/mxgsLYnE4mR40fepTn1JB0x133IF7772Xz4jFSYAk26e/9rWv4Qc/+IHq5fTLX/7S7NMiQO1+lN8n2e34xS9+kdckS8ny3H/7b/9Nfbx582azT4dOwsCJTA2aPvnJT+Khhx5S6/ly85VCY8oeN954o3rkVmprkBYRkqV49dVXVYA7upmi1DcJKT6WP9fX15t9unQGqV5bkn0ia2GNE5kaND388MO47bbbVPDEoCn7tLS0qEfugrQG6er+6U9/esyvvfDCC6ru6WMf+5j6vqKiooyfH6Vv69at6nHGjBm8bBbDGicybXlOgiUpinz88cdZH2Nh0txSluZO3t0jW6hvuOEGvPnmm2qpNbW0QNbEGifr2bNnjyoKP7lPmjQJ/uAHP6iyg0ePHkVBQYFp50inYsaJMu6uu+5SQZM0UJT2A7Kd/WQyfoDvtKxBCr//7//9v2pWnTwn8rxJGwLJYAwODqoZg5I1JKJz88ADD+CRRx7B6tWr1VgjybrLrjpZVvV4PPj1r3/NoMmCGDhRxqVqK6QeQ4qLT/fumIGTNciuORnMLEWqmzZtUmM8ysrK1Aytj3/84yrTNFYvGiI6s5tvvln1rJNgSVpHSFsWGaAtZQz/8i//goULF/ISWhCX6oiIiIjSxC1MRERERGli4ERERESUJgZORERERGli4ERERESUJgZORERERGli4ERERESUJgZORERERAyciIiIiCYWM05EREREaWLgRER5R8b5cEwMEb0dDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYhyTn19vaphuuaaazAwMIAvf/nLqq7J6XTiu9/97gnf++CDD2LZsmXwer2orq7GZz/7WfT19Y353+3s7MRXvvIVzJ49G263G1VVVbjllluwdevWDP2fEZHZGDgRUc4KhUJYvXo1HnnkEaxYsQLvete7UFRUNPz1r33ta/jCF76AmpoavPOd74Su6/j5z3+O9773verj0RobG7Fq1Sr853/+p/rz3//932PBggX44x//iCuuuAJPPvlkxv//iCjzNP3kVwciohzIOM2cOVN9fNlll+FPf/oTSkpKhr8u2afjx4+rDNPatWsxf/589fmuri71/YcPH8bLL7+M6667bvjv/N3f/Z3679x555249957Ybfb1eefeeYZ3HrrrSgoKMChQ4cwefLkjP//ElHmMONERDntJz/5yQlB02jf//73h4MmUVlZic997nPq4/Xr1w9//siRIypoKisrw49//OPhoCmVeZLlusHBQTz00EPn9f+FiMzHwImIcpYswV100UWn/fo73vGOUz43b9489dja2jr8uU2bNqnHd7/73SgsLDzl79x+++3qcePGjRNy3kRkXQyciChnTZs27Yxfr6urO+VzqRqoSCQy/LmWlhb1OH369DH/O7L0d3KwRUS5iYETEeUsj8dzxq/bbBPzEsgu5ET5g4ETEdFZ1NbWqkcpKD9dMXpqaZCIchsDJyKis5B2A+L555+H3+8/5euPPvqoerzyyit5LYlyHAMnIqKzkIaX0uept7cXX/3qV5FIJIa/Jn2cpCWB1EbdcccdvJZEOc5h9gkQEWWD+++/H1dddZVqkCk9nqQZZnNzs9pJJ+0JpAM5ezgR5T5mnIiI0jB16lRs27YNX/rSl1TG6emnn8bevXvxnve8Bxs2bMCHPvQhXkeiPMDO4URERERpYsaJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiICOn5/wE86RXDnB85vwAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAHqCAYAAADyPMGQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAgZNJREFUeJzt3QeYXGeVJ/z/rVzVOamDWjlnWbKcLWdshmSCwQsYE4Y0zBKWGcIO3wBmWe/MADvLYGxjY3DAxjgATgRjWcGSbMlBOYdW5xwrp/s9571drZbUkkruVt1bVf/f89ynWt0t6/pWd91T5z3vOZqu6zqIiIiI6KxsZ/8WIiIiImLgRERERHQOmHEiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0OdL9xnySTCbR2tqKoqIiaJpm9ukQERHReSS9wIeGhlBXVweb7cw5JQZOY5CgacqUKefr+SEiIiILampqQn19/Rm/h4HTGCTTlLqAxcXF5+fZISIiIksYHBxUCZPU/f9MGDiNIbU8J0ETAyciIqL8oKVRnsPicCIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiyvbA6ZFHHsHnPvc5rFy5Em63W7VBf/LJJ0/5vkAgoL73wx/+MObOnQuv14vS0lJcddVVeOyxx0w5dyIiIspNlp1V953vfAfHjh1DVVUVqqur1cDdsWzYsAG33XYbKioqcN111+GDH/wgOjs78fTTT+OjH/0oNm7ciJ/97GcZP38iIiLKPZbNON1///0qcJIg6NOf/vRpv6+mpgYPP/wwWltb8fjjj+POO+/EL3/5S+zbtw/Tpk3DXXfdhS1btmT03ImIiCg3WTZwuv766zF16tSzft/y5cvx8Y9/HC6X64TPS5bq85//vPp4/fr15+08iYiIKH9YNnCaCE6nUz06HJZdkSQiIqIskrOBUyKRwEMPPaSKyiV7RURERDReOZuK+f/+v/8PO3fuVPVRixcvPuP3RiIRdaQMDg5m4AyJiIgo2+Rkxumee+5RReIrVqzA//t//++s3y/fW1JSMnJMmTIlI+dJRERE2SXnAifZjfcP//APWLZsGV588UUUFhae9e98+9vfxsDAwMhxutYHRERElN9yaqnuvvvuUzvpZGnub3/7G8rLy9P6e9JgUw4iIiKivMg4pYKmhQsX4qWXXkJlZaXZp0REREQ5xpYry3MSNM2fP18FTdJtnIiIiChvluokGHrllVfUx9u2bVOP0gX8ueeeUx/ffPPN6lizZo2aaafrOlavXo277777lP/W1VdfrQ4iIiKinAycJGh68MEHT/jc2rVrRz6ePn26CpwaGxtV0CTuvffe0/73GDgRERHReGl6KuqgE/o4SVsC2WFXXFzMK0NERJTDBs/hvp8TNU5EREREmcDAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYiIiCjbA6dHHnkEn/vc57By5Uq43W5omoYnn3zytN/f3t6Ov//7v0dtbS08Hg/mzp2LO+64A9FoNKPnTURERLnLAYv6zne+g2PHjqGqqgrV1dVoamo6Y9B08cUXq++5+eabVdD0yiuv4Lvf/S42bdqEF154ATabZWNEIiIiyhKWjSbuv/9+FTh1dnbi05/+9Bm/95vf/CYaGxtx11134emnn8b/+T//Bxs2bMDtt9+Ov/zlL3jwwQczdt5ERESUuywbOF1//fWYOnXqWb9vaGgIjz/+OGbOnIkvfOELI5+Xpb0777wTdrsd991333k+WyIiIsoHlg2c0rV582ZEIhHccMMNKlgaTeqdli1bhi1btiAcDpt2jkRERJQbsj5wOnjwoHqcM2fOmF+XzycSCRw5ciTDZ0ZERES5xrLF4ekaGBhQjyUlJWN+PfX51PeNRTJWcqQMDg5O+HkSERFR9sv6jNNEkFooCbBSx5QpU8w+JSIiIrKgrA+czpZROltGSnz7299W35c6ztT6gIiIiPJX1i/VpWqbUrVOJ5PPSw8n2XV3OtJgUw4iIiKinM44XXLJJXC5XHjxxReh6/oJX2tra8P27dtVc0zpJk5ERESU14FTcXExbr31VrVr7p577jllCU521H32s5817fyIiIgod2j6yWkaC3UOl7EpYtu2bSpzdPXVV2PatGnqczJaRY5UZkmySs3NzXj/+9+vRq5I5/CNGzfixhtvPOeRK7KrTmqipN5JAjMiIiLKXedy37dsjZMETSePSlm7du3Ix9OnTx8JnKTR5Wuvvabm2z3//PN47rnnVNfx73//+2ocC+fUERERUU5nnMzEjBMREVH+GDyHjFPW1zgRERERZQoDJyIiIqI0MXAiIiIiShMDJyIiIqI0MXAiIiIiShMDJyIiIiIGTkREREQTixknIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKEwMnIiIiojQxcCIiIiJKkyPdbyTKB5FIBN3d3ejt7cXg4KA6hoaG4Pf7EY1GR45EIgGn0wmXywW32w2Px4Py8nJUVVWhsrJSPRYVFZn9v0NERBOMgRPlpXg8jq6uLrS3t6tDPpaASYKkdIXD4RP+fOTIkRP+LAHU7NmzMWfOHEydOhUOB3/diIiyHV/JKecFg0F0dHSMBEmpQEnX9TG/PxrWEfIDkRAQVYeOaARIxIBkAkjEAT0J2OyA3WEcDjfgLdTgLQJ8hYCnUFOBmByvvvqqykwtXrwYq1atQk1NTcavARERTQwGTpRTAVJPT486JDDq7OxUAdPpskixqI7gABAYAIKDOoJDUAGTBEhvz/FAzO7UUVoFlFZrKJskn4nizTffVMeUKVOwcuVKFUjZ7fa3+48REZEJNP10b7vzmNS1lJSUYGBgAMXFxWafDp20xCZZHAmMpA4pdUiwFAqFTnutwgFdBUiB/uHHAcksZe7SFlcANTM0lNdpsA1vySgtLcXq1auxdOlSBlBERFly32fgNM4LSOePxPSSNWpoaEBLS4vKHknQlEwmT/t3IkFjmU0OlUUaBAKDQDJujWfK6QYmTQNqZ2pweTT1ubKyMlx11VVYsmQJbKmoioiIMoaBUwYvIE0s2bG2Z88eHDhwAMeOHVPLbyeLx4yASIIjySSFJVAKQD1KDVI2kPqomhnA5DkanG4jgKqtrcVNN92kCsmJiChzGDhl8ALSxGSWGhsbsW3bNhU0SfCUkojrGOwBhnqGl9gGjYLtXCEBVO1MYPJcDQ6nEUAtWrQI119/vVrKIyIia933WRxOpmpra8Nzzz2H1tbWkc+F/Dq6mnQMdAH+PgmskLMkQ9ZyEOg8pmPKQqB6mobdu3dj//79uPLKK3H55Zez/omIyEJY4zQGZpzOP8kqvfzyy3jttddUxkkyS90tQGejjqEe5C1fCTBjsYaSKiP7JI003/3ud3P5jojoPOJSXQYvIJ076aP05JNPqp1wortZx9GdOmIRXs2UysnA9CXHC8iXL1+OG264AT6fjxeJiGiCcamOLKu5uRkPP/ywyjhFQjoOb9PR32H2WVmPZN/6O3VMWwRUT9dU/ZcUzN94441q952mGQEVERFlFvc+U8ZIHdMjjzyigqaBbh3b1zBoOpN4DCqw3Lk+icCArnYY/v73v1fXUHpXERFR5jFwooyQ/kuSaZIhuoPdOvZu1lVgQGc31AvsWKvj2O6kKiaXmXh33303NmzYoIYNExFR5jBwovNOOno/9thjaijuUK+OPa/qWdNvySpkZ6Hsvtu2JqmW8KSD+po1a3DPPfeoBqFERJQZDJzovJIdc0899ZRaWgoHdeyToMkiXbyzUTgA7Nmk48DrSTWMWDJ5Dz74IP7whz8gEAiYfXpERDmPfZzovJJ2A4cPH0YiDhU0xY73tqRx6G4G+jp0TJPeT9M1bN++Hfv27cM111yDVatWcXQLEdF5kjMZJ1m6uO+++3DxxRejsrJStRGQ3Uff//730d/fb/bp5SXJhrz00kvq44ZdSTUmhSZOIgYc2W4Uj/v7dVU/9uc//xm/+MUv1LgaIiKaeDnTAPP973+/Wq6YN2+e2rJtt9uxdu1avPXWW1iwYAG2bt2KgoKCtP5b7OM0fjKI91e/+pVqPyA1ObK8ROdX9XRg6kINTpfRqkDeOFx33XWqJxkREZ1e3vVx2rJliwqaLr30Uqxfvx4Ox/H/rQ996EOqxkYaLt5+++2mnmc+efXVV1XQJAN5D73FoCkTOhqAnlYdU4dHt+zcuRN79+5VY1vkcDqdGTkPIqJclhNLdbI9W0hn5dFBk3jXu96lHru6ukw5t3wkHcFlnIpo2KXn1FBeq4tHgSPbdOxYm1RtH2QJe926dbjrrrvUAOUcSTATEZkmJwKnhQsXqscXX3xR3ShGe/7551WX5auvvtqks8svcmN+5pln1PMgS3SdLLUxRWAA2PWKjv1bkogEdZV+fuKJJ/DrX//6hIHKRER0bnJiqW7p0qX40pe+pN5VL168GDfddJOqcZKsx8GDB9XnL7zwQrNPMy/IsmljY6PaRSddr8lcPa3G7rvJc4C6OZp6bmQTxbJly3DttddyFiMRUb4Wh4sf/ehH+Pa3v31C1umjH/0ofvjDH2L69Omn/XuyG0mO0UViU6ZM4ZDft7GL7t5771XX//C2pKq5IetweY3i8UlTjOJxWda+6KKLcMUVV8Dr9Zp9ekREWVEcbsuVHVyf/exncccdd6hOyh0dHejr61MF4dJdWW4OZ+qufOedd6oLljokaKJzI8GSFOGnlugYNFmP1JodesOof5JZgfJcbdq0CT/96U+xceNGxGKcgUNElBcZp/vvv18FTnID+O///b+f8LVnn30W733ve/H5z39eBVVjYcZp/KR/kDS7jEV0bFujI3Y8gUcWVVZtZKAKSowMlLxpkPYFstwtdYFERPliMN/aEfzpT39Sj2MVgKc+t23bttP+fbfbrQ56e/bv36+CJnHoTQZN2aKvw6h/qpqiY+oCDQMYwNNPP61aSUj908yZMxlAERHlYuCUqk+SGpuTpdoQMDA6Pw4cOKCWREXrYV3djCm7dDUZ/Z9qZ+mon6upXXePPPIIpk6dqka4nKk+kIgo3+REjdNll102UqsUjUZPqH363ve+pz5mO4KJJw0WH3/8cVUr09um49iurF/1zVvJBNByAHjzrzpaD+nqz7IDTwYIP/TQQ2hqajL7FImILCEnapxkTVIKwCX7MWvWLDVyRbokS2G43NznzJmjlpLKysrS+u9x5MqZyY+MtB2QuibR2aTj8Js6sv8niVJcHmDyXE0NELYNv72S360rr7xSZaJYA0VEueRc7vs5ETgJ2UUnGSdpvpjaQTdt2jS85z3vwb/8y7+kHTQJBk6nJwOT//rXv6pRHqLtiI6jO3LiR4jG4PYCk+dpmDT1eABVX1+vsrzz589nAEVEOSEvA6eJxMDpVLIE+sorr2Dz5s1qaU5PAsf2JNF6yIQniDLO7QMmzxkOoOzG5yZNmqRqoGSwNjNQRJTNGDhl8ALmQ8Aky51r166F3+9Xnxvo0nF0l47ggNlnR5nmdAO1MzXUzAQcTqNlQV1dnaohnD17NgMoIspKDJwyeAFzkSQhZWfVm2++iV27do0U3If8Oo7t1tHbZvYZktnsTmDybA21swC7QxvJQF166aWqD9TJw7aJiKyMgVMGL2AukbYOkl16/fXXVff1FAmY2o/KAbVER5TidKWKyI8HUIWFhbj44ovVfEiPx8OLRUSWx8ApgxcwF0ivq61bt2L79u0j2aVkQkd3K9B5TMfgqe2xiE7JQFVPA2pnaXB7jQDK5XJh1apVKgtVUFDAK0ZElsXAKYMXMJtJw9B169ap5biU0JCO9gYdnY1AgqPL6BzJpJbKeqBu9vFRLrJsJ8t3koWqqanhNSUiy2HglMELmI16e3tVwCTLcqlNlT1tOtoP6xhgdokmSFkNVCfyovLjc+9kjMsll1zCQnIispS8m1VH6ZFO6tJO4OWXX0YikRgJmJr2cYccTby+djl0FJbpqJuloaJOw5EjR9RRWVmplvCWLl3KQnIiyirs45QnGSdpECoDXJubm9Wf+zuNHXIBthSgDDbTlBqoSdOOtzIoKipSdVArV66Ez+fjc0FEpuBSXQYvYDbYt28f/vjHPyIcDiMe09Gw06hhIjKD3QG1C290IbnUQS1btkx1JC8vL+cTQ0QZxcApgxfQ6mRGX2qm3FCvjgNbdURCZp8VEaDZgMrJRgBVWGoEUNKBfOHChbj88stRW1vLy0REGcHAKYMX0Kqk6FtqmTZs2DAyU04yTfk+YEd2fXkKAHcBYLcb2Q+bHDapATP6VMkhHyfiw0fsxI/lazSxiiqA+jkaymqOF5LLcO6rrroKkydP5uUmovOKxeGkRqSkgiaZKddyID8vigRFlXVASZUGXzHgLQRs9uM357cjmdSRjEtwOirY0k8MzlJSn1ffOxx8xYcDsHBARzggj0DYD8TzuP3DUA+wt0eHr1hXM/Eq6zUcPHhQHTLKRQIoGS5MRGQ2FofnYMZJhvG+9NJL6uMjO5JoP4K8U1IJVE3TUFF7vKN1SkwHAgkbYrqGBDTEJajRNWiaDpvU4GiADTocmhyAUz3qagvq6KBookkPrcEeYKDbeIzm8ZKqZAXr52moqtfUkl4qA3X99der0S5ERBOJS3UZvIBW89Zbb+GZZ55RHx/bnUTLQeSVwjJg5rLjNTNiKGFDU9SJ/rgNg0k7gkn52tuJgIzgyQiojCDLpsl/ST/lvyaJptGfk+9zqGDM+Psum44CWxKFtiQK7En4bKeuofr7dHS36OhpQd7Wpbl9Ri+oqqmaWk6VGqgVK1aoocIy2oWIaCIwcMrgBbSSxsZG/PrXv1b1Tc0HdDTuya+CprrZwLRFNpUVkqySBEvHIk70JexvM1DKHMlqVTjiqHQkUOmIo8yePCG75e+XnZA6uqSjexx5mYGatsjoBZUa57J69WrVC8omERUR0TgwcMrDwCkQCODee+/F0NAQupp0HHxDz6s6ptkXaKicbNxUGyMO7Ax5ENGz94bq0pKY7Iyj3hVTwVQqiErEdXQ3Qw1dzsceXEXlwPQlGorKjAsiI1ze+973cgceEY0LA6c8C5wkw/Sb3/wGhw8fRnBIx461OpJGY/CcJ7viFl2uobBMQ1IHtgc9OBp1Wj7DdK5BVL0rjpnuKIrtx7f0DXTpaN6fn2NyJk0Fpi3W4HRJbZqm+j9JAbnTKc89EdG54a66PLNx40YVNMkUlQNb8idokizM/EuMoCmS1LDZ70VvIvemCEV1G45EXDgScaLCkVABlGSjZKegHNKfq/WQjp5W5A1p4NrXoWPGUqMXlPwOHDhwAB/5yEdQUVFh9ukRUQ6bsF11skQkN295PN1/UmoSskE2ZZy6u7txzz33qNlzh95KovMY8saMpRpqZ2qqnmn9UAEGVC1TfvBqSczxRDHDHVW7AFO78qS2TZby8qlfV3mtsSHA5dHgdrtx8803Y/78+WafFhFlkYwu1e3YsQNf+9rXsG7dutMGTCmpwbJWly2Bk1zvX/3qV2hqalLvvvduzp+7ZdUUYM5Ko4Zpk9+L9lh+LtG4taTKQM1yR+EaLumS/lAtB42xOtJjKh843cDcVRpKKo0o8oorrsA111zDwnEistZSncxAkxcov9+vRiS0tbXh6NGjuPXWW9UEdNkaH4vFVPFmaWnpeP4pGsPWrVtV0CS7rI5sy5+gqaAEmLXciBL2hNx5GzQJKYDfG/bgYNitsk+ShZIdaLOWa6ifawRQHcdyP4CKRYA9G3VMWyS7KzXVy6y9vR233HKL2oFHRDRRxrXt6Ac/+IHazfXQQw+pLtVXXnml+rwUKm/evBl79uxRBZu7d+/Gj3/844k6Z5K6l2hUZflS/Zrypc+PzQ7MvVBTj21RB/aFeVMUcWg4GHHjLwOF2B50I5TU4PZpmLnMhpU3aKidZVy7XCYJ74ZdOvZvTao3E4cOHcKDDz6oXqOIiCwROMlYj0WLFuHjH//4mF+fOXMm/vCHP6C3txff+c53xvNP0RjZpmAwiJBfR3tD/lyeGUs0eIs0FRi8HvTm1O65iSCd0A8PB1Dbgh7V7NPl1TBjiQ0r3yFZKMCe4wk6aRi6+5UkYhEdra2tajm7v7/f7NMiohxhG29h8oIFC0b+nNoKLDf0FFkrlC6/zz333Hj+KRpFlj83bdqkPm45oBttqvNAeR1QPV1TmYWtAa8amUJjS0JTO/EkgHoz4IE/ocHp1jB1oRFATV2owenJ3avn7wd2bdARCero6enBAw88gM7OTrNPi4jyPXCqrKw8IUhKbQOW+qaTb/QSZNHE2Llzp7ruUgTc1ZQfV1XqdqTJpTgQdqE7nnttB84HGQbTEHXhxcFCbPF7MZCwweGUzJOGle+wYc5KaeeAnBTyAzvX6wgO6mq3r3TVlzpMIiLTAieZWi7F4CmrVq1SO73uu+++kc9JECUDZ2fMmDGuE6UTAyfR0aDnxbZz6Qw+/2JN3fC743bsCbvNPqWsDKCaY068NFigdiF2x+xq9lvVFA1Lr7JhyWpN7VTMtekl0bCReZJeV6FQSNVjtrS0mH1aRJTFxvUy+c53vhN79+5Vu+vEu971LkyZMgU/+9nPcMkll+BDH/oQLrzwQvWC9alPfWqizjmvyTvnhgajqKk7H17/NWk7oMFXbNQ1veb3jjFSl87lgsouxPX+AhVEySy/hC6jTDTV3uHCmzQ10sRblDvXNB4D9mzSMdijIxwO4+GHH1a7UYmIMh443X777fj5z38+0p9Jms8988wzmDNnDrZs2YKnn35a9USQoOl//I//MZ5/iobJTkUhN4HI8VXSnKTZjB10FbWaurm/6vdm9fw5q5GGoW8EvfjzQCF2h9wIJDQ4XBrqZmm44DobFl+pqdEmubAbT3bZSfA00K0jEongkUcewbFjedQtlois1zn8ZJKF6uvrU8t5VVVVyCZWboD5xBNPqOBJWhC0HETOcjiN5bniSmMG3ZaAF6153K8pM3RMciRUP6haZxy21GDhmI6uFqCzQVdF19lMgkD5uSqdpKnNLB/72Mcwbdo0s0+LiExmiVl1HHlwfqTqM4b6kLPcXmDBpcbynIxT2ez3sRg8IzR0xh3qkI7k01wxTHfHUOhMomY6UDNdg79fR8dRI5BKxpF1ZI7jvld1zLsYKKuO4dFHH1XtVKTEgIgoHRMWOEkd05tvvqn6poi6ujqsWLECXq/02qGJIB3aJRqWJGEgy9/5n86kacC0RcbUe+lBtGnIh8FkDqwVZRlZEj0QceNAxIVKRwLTXTFMdsVQWKqh8AIN0xfr6GwC2g7rCGdZf8lkEtj/mo75lwKlVVG1bPeJT3wCkydPNvvUiCgfAie5kf/Lv/yL6tA7ujWBkKBJ6qB++MMfcuTKBJBGokJqm6RmI5fIlviZS2VrvLE+1Be34VW/DyHWNJlMdjI61LEj5MZUVwwz3DEUOZOonQnUzNDQ26aj9bCOoR5kVfAkmacFlwIllVFVMH7bbbcxeCKi81vjJDdyGbMi9Ux2ux2XXXYZpk6dqr7W2NiomjRK4fi8efPUSJZUnyers2qN0/79+/Hb3/5Wba2W/jS5wO0DpizQMGmKETDJ0pzMn5Pmjdw9Z1U6qhwJNRevxnk8gpfC68Y9svUfWVXzJMvCMhzY4/GozFNtba3Zp0VEuVrjJJkmaUfwvve9Dz/96U9PqRNobm7Gl7/8ZTV2RUau3H333eP55/KeLIemtlfnwjT7yXM1lbFI9Q5qiDjV7i7unLM6DV1xB7r8DhTZEpjtiapMlAQf0g9KMlCNe6XxJLKi5mnvZh0LL5MOvkargk9+8pOYNGmS2adGRLmYcZJ3ZtKC4ODBgyPjVk4mXcOlPYFsAc6Wrr1WzTi99tpr+POf/4zuFh0HtmZnxkne4dfPM7a8p7a5d8Ts2B3yoD/BWqZs5dWSmO+NqFooTTMG7nYe03Fst54Vgb7dASy8XENRmaZKDCTzVFNTY/ZpEZEF7/u28f5Dsjx3uqBJyNfke+R7aXxS1zlb++pU1AEXXGeM+5D/h564HRuGfNjoL2DQlOWkFu2toBcvDhagOepQwZPMFbzgeqMjebb0eRrqMzqMS81maqMLEdGEBU5Su9Te3n7W75PvmTt37nj+KRpuMJp6d5xtc+akjmTeRTa4fZpqtLjZ78W6IZ9a8qHc4U/asSXgw7pBn5qLJ4OFpSP5oss1eAphaQnpML7xeIdxjmchogkPnL761a9i3bp1+Otf/3ra73nxxRexfv16fOUrXxnPP0UAXC7XSHPIbFFUDiy9SkNZtdH9e2/IGDjbpppZcnRKrupJOLBmsAC7gm7EdaCkSsOya2yong7rZ5426xgc7jAuNU+y0YWIKGVcb/evvvpqfPGLX8R73vMefOQjH1FHqguvjDP43e9+h8cff1x9z7XXXnvKC1BqBx6lJ7Xu6sqS1lilk6CyTJIhk2W51wNeBJIcmZIvZFek9IKS4cIX+EKodiYwa7kN5TU6Dr2lIxaBJSWHgyejVYExnuXWW2/FzJkzzT41Isr24nCbzQZN01RDRnkcy+m+Jp+Lx63ZjMiqxeHRaBR33nmn+vi155NqacHK9UxzLrSpHXPtMTte8/uQYIYpj+mY5Y5isTcCuwbEIkbw1Hf2lX7TSB3evIuMbKm0W/nwhz/MkgOiHJWxdgSrV68+bcBE52eprqCgAIFAQNUNWbV7eFkNMHeVBNVQhcJbA172ZMp7Gg5H3OiKOXBhQQil7iQWXKKh9ZCx8+78TMycgPEsr+mYe6G8EUio7Pn73/9+LF682OxTIyITjStwWrt27cSdCaWlsrJSBU6+ImsGTlJ/NXuFpoIm6cv0ZtDDWiYaIeNz1g4VYJE3ohpo1s2WbvFQ7TWiYetdKD1pnNvsFUDVlCSeeuoplfmVcVJElJ9YcJJlqqur1WNBiTUzfVMXGnPmBuKyPZ1BE50qCQ07Qx686veqTvHFFVI4rqGkyppXS7JhB9/Q0X7USIs9++yz2Lx5s9mnRUQmmdC94C0tLScM+eXQzImXaspXUALLkXOS3j1iW8jD5Tk6o9aYEwODdlxcEFRLdwsv09C0N4nmA9a8cEe266quUDrey05i6fd0zTXXsFyBKM+MO+Mks+h+9KMfqR0nskvukksuUYd8PH36dPzHf/yHZYvAs1FqjlZBKSxHll1kia4p6kAP+zNRGmSXpSzdHY041c/O1IU2zLtYs2yvsmN7pCYrqT6W+ZvPP/88kjIxmIjyxrhenuQd1zvf+U71AiK75yRYGj3kV45vfetbKrX9l7/8RY0yoPGpqqpSO3yABNw+HZGgNa6o0wVUTDayTQfDRqNOonSX7qTreG/cjuW+MCpqNfiuAvZt0REast41bDko8yKTmLnMhjfeeAPBYBAf+MAH4HBYNNojIutknO644w7V3PKiiy7Cxo0b0dDQoP4sh3y8adMmXHzxxepr8r00fhI0peqcCi2UdZo0TdpTAL1xG8en0NtyLOrC+qECBJMavEUall5lQ2W9NS9mR4MUjSchySYZdP6b3/xGNcwkotw3rj5O0uxSRhMcOnQIRUVFY37P0NAQZs+eDY/Ho5piZgOr9nFKee6559Q73eYDOhr3WGMf9/JrNfiKNbwR8KgbINHb5daSWFUQwiRnQv25/YiOo7t0tcPNakoqgfmXGE1epa7zox/9qGoZQkTZJWNDfjs7O1Vx5OmCJiFfkw7j8r00wTvrLBLTuTxQQZOE4G0xLlfQ+ER0G17x+9R4HlEzU8PiKzVLdswf6AZ2bUiqhp6yMeZXv/qVeuElotw1rsBJir8lSjsbyTrJ99LE7qzzWWRnXWobeX/ChqjODhc0ETTsDXuwcciLaBIoKjNaFkhzVasJDEjwJPWGOnp6evDLX/4SXV1dZp8WEZ0n47rLfe5zn8OaNWuwffv2036PfE2+5+///u/H80/RKJMmTVKPbq8GhwVWxWSAq+hktokmWEfciTVDhap2TvqDLbjEhumLjd2bVhLyAzvX6wgO6uqNomSe2trazD4tIrJa4PS1r31NBUSyFPev//qv2L17N/x+vzrk4+9+97tqKe+zn/0svv71r0/cWec5t9s9sjzq8Zl9NkBRufHYzRYEdB4EkzasGyrAgbBrpO3Fois0tURsJdL5XDJPQ7262nH84IMPoqmpyezTIiIrFYcb2+JPP8j3TF/jkN/xeeCBB9SL8v6tSfS0wNQRKxe9y4i/n+0vQky3WCqAckqtM6Zm3TllUHBUx+G3dPRaLLEjheIyh6+4UoPT6cStt96q+twRkXVlbMjvlClTLNc197e//S3uvfdebNu2TW0Prq+vx2WXXYb/+q//OmMRe7YpKytTgZPZGadUI05/QmPQROddW8yJNYN2XFQQRJkrifkXa2hv0NGwU1dDea0gEQf2bNYx7yKgrDqGRx99FB/+8Icxd+5cs0+NiCbAuAIn6dVkFdK991Of+hQeeugh9QL18Y9/HD6fTwUXf/rTn1QUmUuBU2rLs8Mlgat5LQlSo1/6E0b2Md85oMNrS8Jj02HXdMhVkUfb8LMkO+p1XVOPcV1DXAfikEcj8JTZbVIYTWfvNr7QG8FcdxQ10zUUlwMHXpcaI2tcOQni9r2mY+6FQEVdAo8//rgKnubNm2f2qRHROOXM3vEf//jHKmj6yle+gp/85CewSTfGYbk4EsHlMuo9hldLTSNtCMRgngVOGnQU25MotydQ7kig1J5QAZNrnJsKkzpUABXRNYSScthUjY80hZRrPJiwqU7b+U6Hht0hj9qQID2ffMXA0qs0HNuTRNthWIL0nTqwVcecC4HKyUn87ne/wy233IL58+ebfWpElO+Bk4w8+N//+3+rRpsSQI0OmsTJf84FUjshbCY/g77hJJ7c0PMhm1TjjKPeFcMkZxyO08QvCUcCCU8Cul03DptxSMpJkxoweUxq0BIabHGbOrS4BlvSBpsmDSB1uFVgpv5rpwRWQwmjO3tP3I6OuEMFV/mqK+7A3wYLsNIXRq0rjhlLbCir1nHoTV0Va5tNKkglEybPeWV9Ek888QQ++MEPYuHChWafGhG9TRN22921a5fqIC5bcU9Xb/6JT3wC54NMKu/v78dnPvMZxGIxPP300+pcKisrceONN47Mz8slqWDQ7BIzb6HxKDfzXM0s1TrjmOqKodoZh33U9U46koiURkaOuC+OuCcO3fH2lk5VIBWzqcMescMetsMRdsARcsARdMA16II9ZkeJI6mOae7YyLXvitnREnOiKy7RVn5lpKR32OaAFzNiMSzxhVE6ScOya2GdwnEJnt7QVRBVNSWJp556StWGLliwwOwzIyIzAicZ3vuP//iPOHLkyGm/J7Wz7nwFTjJ+JBVMLF26FAcPHjwhM/PDH/4Q//zP/3zavy9F5KPnTKXT1NNsqfNNGPdOUzjdgN1pdAz351jWQ8Z+THfHMMMdhU+yRcNiBTEEagII1gQRLY5OaIwi2amE3chWxYrGeGJ1qGBKAij3gBueHg/c/W4U2ZPqmOmJqSW9pqgTTREnBpP5tHyq4WjUpQJHWbpLFY53HNNxVArH4yafng4clOBJ+rBNSeLJJ5/ksh1RlhrX3e61117De9/7XlWALTOalixZoj7/rW99SxVClpeXq6Dpk5/8pOrzdL6kuvRKbVNFRQXefPNNFfz8+c9/VuNJvvGNb6j5bqdz5513qm2IqUN2C1qdzAgU8Zj52aZAUvIyuZHlKLQlsMIXwk0lfizyRlTQlHAlMDBzAC1XtKBldQv65/UjWjKxQVNaNCDhTSBUHUL/3H60X9qOxusb0bGyA0NThtQSoZzvPE8U15cEcGVhADVO+QGxxjzDTPAn7apwfH/YpQL66mkall+jjfQaM9uhN3R0Nemq7lKW7fbs2WP2KRFRJvs43XzzzXj22Wfx4osv4tprrx3Z1ZZIGHUZErx88YtfVF/funWrGgp8PkgH8/vuu0/tojt8+PDISJJURuymm25S5/fSSy+lnXGS4MmqQ36FpPtlebRhVxKth8w5h0nTgNkX2NARs2OjP7sHm5bZ4yrgkGW51PJnpCSCwWmDCNYGVTbI6mSpz9vpRUFrAXydPqOearhVxJGICw0Rl9rBly8qHHGs8oXgkzozHWg5qKNpr/GxqTRgzgoNVVOkA7qGD33oQ6x5IsqXIb+bN2/GhRdeqIKSscg/LqMHZAfYd77zHZwv8j8r5FxGB03ihhtuUJ22U8t5Y5Gvy7mOPqyuvb1dPQaHzDsHb6FxEx7K4h11EjBdXhjANcVB1LmMoClYHUTbpW1ou7wNgfpAVgRNQs5TgryulV1ovqZZZckSzgQK7TqW+iK4sWQI8zwRVeSeD3pU4XghjkWc6nmtn6thyWoNngJrLNt1NkoQp6tlO2aeiLLHuAInicxGd8RNbZGXkSujP3fFFVfgb3/7G86XVGO5VAA1mtQ9Sf8mGYGQKyQ71t3drT4O9Ju/VJeN9U0l9gQuLQiqgKnamYCu6RiqH1JLcZ0rOxEpO56BzEZSJ9U3vw/N1zaje3G3qs1y26CWHyWAmuuJwJ4HAZRk2N4IevGq3xgWXKiGBdswyQL7RWTnH4MnouxjG++wWdnNliL1RGJ0cXYqwJLddueLzMMTe/fuPeVrEmDIcb6WCc3Q0mLMWJFp7DET7+/ZuKPOqem4wBfCdcUBtX19JGC6qgU9S3sQKzSxaOw8ZaH8U/0qIOxa1jUSQC1WAZQfM91R2PIggGqNOfHSYKHafSgjUWavsGHuKg12o6uHZYInmXhARNY2rjueNHKTbf8pMtpEXgD+/d//faQlgRSQS23RnDlzcL5I/6brrrtOncuvf/3rkc/LOaSWCKWOIFfs2LFDPfYbNfGmkKUP9/CShz9LAicplL6+2I8Zw9v4/XVGQCEBk7QSyGkaEJgcOB5A+WKqu/lyXxg3FPsx1RXN+SLykG7DBr8Pu4Ju1Q+rcrKGZVdrKCwzP3iS3X/yevXHP/4RGzduNPeEiOj8FYf/9Kc/xVe/+lUVHK1atUoVhV9wwQXYvXu3qjWqra3Fzp07EY/H8ctf/lLtrjtfJMt16aWXore3V+30k2Bq06ZNqg5LdvvJi1G6I1fOpUgs02TJUXYPyjXdsS4Jf5855yF1IitusKmRIc/0y3W1btGxS0tiqTeCqcMBkwQN3Uu7ESnP7uW4cZFlq+ZClB4shSNidCUZSNhUUCFNNa38fE6EMntCzbsrsMsON6Bxj3mbLFKmLdIweY428ib0+uuvt9wsUKJclbHi8Ntvv13NgZMlO2G32/HCCy+oX/iOjg7VFkB2un3/+98/r0GTkIzW66+/rtoiSLAkQZ0UUP/TP/0TXnnllZyZUye7EyVoCgzopgVNJ9Q3qWyTdV/cfbYkri0KqKBJuuhIwXTrla35HTQJG4wlvKtb0Du/VxWRl9iTuLwohCsKg2qETC7rS9jV0l1z1AHpJTt9sQ0LLtVUbzKzHNutq12yQt70SfYptUOZiHIk47R9+3YsW7bstGNQJHKToEoCKmkX8NnPfhbZwKoZJym6/6//+i9Eo1EceD2J7mbzzqV2FtR4C7nxbAn4YNUmllcVBVFoT6osU9fyLkRLZUmKTibdyksOlaD4WLEaByPkud0TcqveSLlLx3RXDMt8YdUVPhrW1Y63AROXwaumArOX26DZoDbfSE882flLRDmQcZJxJqNrnEaTTJMs1UnQ9LOf/Qxf+MIXxvNPEYA1a9aooMnfp5saNAlPgXFzDVi0vkm23F9WOBw0eWNov6SdQdMZJJ1J9C3oUzVQ/sl+lZ2rd8VxfXFAFdN7tNwblG3Q0BB1Yc1ggVqqdHk0LLzMhqkLpceSOWfU1Qjsey2JRBxqIoO0dMmGaQZE+WJcdz35ZZZluebm09/FZejul7/85ZycF5dJra2teOutt9THR3aYX8Sb6oVjxVYE0sf8ksIgyhxJ1fW746IOtT2fzk6K5LuXdaP1ilYEJwXV0GEppn+H6qQeVvViuWgoacfLgwU4Mqrn0+IrNbi95pxPXwew65WkyoBJ2YPUiMojEZlvXHc92T7b1tamgqfOzs4xR5nIjLgZM2Zg7dq14/mn8prUNEm9g5BxDWbWNp06bsV6gZNssZ/kTCBpT6JjVQfiBTm+Y+48iBXH0HlhJ9ouaUO4LAyHBtVZXVoYLPSEVVuHXJOEhm2jej4VlcuwYA0Vdeacj/Ro27leR3BIV29SH3jgAezbt8+ckyGiEeO66/3d3/0dHnzwQbVcJ8t2sjaY8r3vfQ//8i//glmzZmHdunU51UfJjCU6CUxjESkeNf+GJbUXbp81WxFIU8f5HqOOqXdBrzFTjt42KaKXZU6ZhxcpjsCpAfO9UdxYPIT5OdqFXHo+rRkqRG/cDodTw7yLbJh1gQabCaVekSCwa73UXOlqmf7xxx9Xr6fjKE0lonEa913v1ltvxV133aUKxd/1rneponAZ8nvHHXeojt7r169HfX39eP+ZvCVBqewSVB+/ZW7DyxSPT/o4aYjpQHh4HppVzHBH4bbpqhjcX3+8gz2NgwY1WFhG0HSu6ES0MAqXDVg43ERztjuSc000g0kb1g35sC90fFiw9HzymbBXRAZ579mko+2IcY0ley/ZfgmkiCjzjAYu4/T5z39edRD/9re/rZpiSs3TggULVKYk1U2czp2k53//+9+rj9uP6OgzxtOZzltk1VYEOmYPZ5sGZg1MwNsCOoHM8asJqll+vjYfyg6WwR1wqjl4cz1R7Au70RBxqiWvXKBDw56wB51xB1YVhNTP/dKrNBzdmURHQ4bPRQeO7tBVG5KZy2xqtp1MRLjllltQWVmZ2ZMhynMTdmv55je/qTJNEjQtXbpUpZMZNL190r/liSeeUBk8f7+OoxZYojt11Iq1tqkX25Pw2XQkbUkE6gJmn05uB1B1QbRc2YLuJd2Ie+MjXciliHy6K6oK9HNFd9yBlwYL0B5zqOW6WcttmGfSuJbOY8Du4aJxWb6XNi+7du3K/IkQ5bFzyjhde+21Z/0ep1N2pWiq98ho8jkZvULpkaHIEoTGYzr2b9GhW2gzk7fYyCgMWawwvMZhFIGHK8JqRhtloInmFL9qX1DUVISSwyXwhR1YURDGPE8Ee8JuNEUlusj+DFRUt2GT34vZ7qia81cxWUNBGdTvZqYHbQ/1Attf1jH3QqCkKoqnnnoKDQ0NuOmmm+BwTMgiAhFNVANMm7TYfZskcMqWLrhmN8Dcv38/fvvb36qPpZ9LbxssRZYrZMq87D6SQlqruKIwoHbT9SzswdD08zdUmsamJTQUNhai9HAp7FEjGzmYsKkmmq2x3BnjUjo8rqVweFxLw84k2o+acCIaMGW+plonSAsFyfDLTE4u3RGd3/v+Ob09OXrUjFeH/CJLc88++6z6uPWQbrmgaXSNk9wUrUMfGRMSLg+bfTJ5SbJ8QzOGVBaq6JiRgZKXn0sKQ+iN27A75EGXmoOX3foTdrw8VIiVvhDqXHFVc1RSpavNGwljHGJm6EDTXh2D3ZJ90lSfp1/84hd45zvfieXLl3POHdF5ck6vYmwpcP7J7L9AIIDgoI5je6y33CT1TXaHpob7Wqn5pUvT1U4v6XjNvk3m0h06BmcNqll4xUeKUdxQjHIAVxYF0Rp1YFcOjHGJ6RpeDXgxKx7FElm6q9NQUDK8dHe8K0tGyHiYbWt0zFkJlE6K4ZlnnlEdx2WXs8fjyezJEOUB69z5SC3RSaGnLJ4eetNadU0pcnMQA6ow3DpLL0U242IlvAnWN1lojEv/vH40X92MwWmD0DVdZWhkjMvSnOhCruFwxI21QwXwJzQ1hmjJahsmmdCyTtqUSMuCY7uT6nVDXkfuvffeM051IKK3h4GTRSSTSVUQLloP6vBnuOA0XVLbJPrj1vrR8dqM7JzMpSNrSbqT6F3Ui9Yrj49xkbYRNxT7McMl7SOsl1l9O0t3bVFj193sC2yYvcKchpktB4GdG5IIB3TVIka6jUsvPXl9IaKJYa27Xx6Td4jSlyUW1dF8wLo3ksIy47HXYq0IUiNAdKd1r12+ixUaY1zaL2pHtEgalQIXFIRxbVEA5fZ41i/dbQ54sSvoVhnjSVM1tYkiNdMxk2Qkk+y6k/FMsvfn5ZdfxkMPPXTCZAcievsYOFmAvBuUvlepbJNMRbciGbVSWGp83GuxIl/7cOAk8+nI2sKVYbRe3qp2PyYcCZQ6kri6OKiKrd1ZvXyn4UDEjQ1+H8JJ6TKuYenVGspM6AEsryEH39Bx8I2k+vjYsWO45557VDkAEY0PAycLOHDgAHp7e9UsurYjsCypb7LZNUSSGgJJ69Q3CRlCK9i/KUvYoFpGtFzVgqEpQ6qof5o7hhtKsn/5ThpmrhksQM/wrLsFl9pU2wAzdDVJ9imJoT4d4XBYtTn585//rAaHE9Hbw8DJAnbu3KkeOxuBpIVbXRVXGI9yQ7BSYThG32az936bt/VPPUt60HZZmxoi7NKM5buriwIj7SWyUVi3Yf2QD4fDRp8zCZwWXGJOt/FwwBgULO1NxGuvvaZqn3p6ejJ/MkQ5gIGTySKRiMo4ie5ma9/1iyuNYKlbBU7Wkhy+dJrFhg5TeqKlUTVEWJbvko4kymX5riiARd5w1g4Qlll320NevB7wIKEDZTUalq7WRkYWZfRcdKBhl469m5NGZrutTfV82rdvX+ZPhijLMXAy2cGDB1XaPDSU+f4v50Q7nnGSpQirGamMyeYSmXynHV++C9QG1O67eZ6oal9QNTxOJxs1Rl1YN1SAYFKDt0jDkqtsptQ9ib4Oo3B8oFtHNBrF448/roaxc9cdUfoYOJmspaVFPfZ3wdKKyqDqNaS+qd9SHcMNieFMk82C50bnJuFOoOuCLnSs7EDcE0ehPamaZ67whUZ2T2Zly4LBAnTHpO4JmH+JDfVzzTmXaBjYs1FH62HjWm7YsAGPPvqomlpARGfHu4zJJGUu/P3WviHIMoPoiFmvvklEU4FTjD/SuSJUHULLlS0YnDqoisenS/F4sR+TndKry9q/L2OJ6Da1407qnmS23NSFNsy5UMM4RoCOb+lup44Drxu77g4fPqyW7mRsCxGdGe8yJpIeK+3t7erjTE9YP1eppYV2Cw31PbmPjmDglFukL1fv4l60X9qOaGEUHpuOiwtDuLQgBO9wt/hsrHt6M+BRdXlV9RoWXanBadJklO5mYOf6JEJ+XfV5kqLxVM0lEY2NgZOJQqGQKg5XH/thWW6ftCLQ1At9pwULwwUzTrktUhZRvZ/6Z/er0S21rrjKPs1xR6BlYfapIerCK36fWvouKjOaZaZ6pGVacBDYuU7HQJdR9/TYY49h48aN6o0dEZ2KgZOJUjUF8Zg159KllNdiZDddVLfmj4w0HBT2iJ0F4rnKDvTP7VejW8JlYdW7a4kvgmuKAijLws7jssni5aECDCZscHs1LL7Shoo6c84lHjNm3bUfNYIlGf/0hz/8gf2eiMZgzbtgnggEAiMDOq1MJr+LVosu04mIbmTENGiwR62ZFaOJG93Sfkk7upd0I+Ec7jxeFMRyXyjrBgcHkzasHSxAe8yYczfvIhvq55lzLpJgOrJdx5HtxqDgHTt2qOxTKitORAYGTiZKvSAlLDyXVmovisqNwEmGmFqXhvBwnZM9zMAp52mAf4ofLatb4J/sV8XWM4eLx7Ot83gcGjb5vTgYdqk/T11gw9xV5gwJFu1Hgb2vGkXjR44cwS9/+Us1MJiIDAycLMDKpQSydCA3JekWHrLoMl1KKGmcnyNk5QCPJrrzePeybrRd3HbK4OCKrFq+07Az5MEbw0XjlZNl6U6Dy2vO2fR3Ars2JBEN6ejq6sL999+P5uZmc06GyGKsfSck01UOL9M1WzrbZJAGg8IRtv650sSKVEROGRx8VXEQF/pC8GTR8t2xqAsbhowhwYWlw0XjZeacizTk3bFOV61SpKzgwQcfZKdxIgZO1iAZHStyuoGiiuH6pqh165tSmHHKc2MMDp7qjuEdJX7M80SyZnRLT8IoGu+P2+DyGEXjk6aa1yxz1wYdve26KhT/3e9+p2bdEeUzZpxM5HQawYhZtQxnUzrJCOr64jbLL9OJwHDXcEeAGad8NnpwcGr33SJvBO/IouaZ8iZAxrS0Rh2qQebsFTbMWKqZ8iZLBo/ve01He4OuWhT8+c9/VgfHtFC+sv7dMIe5XEYxqN2i9/nSSalu4RY9wZP4h2ucnAHrZ8coM4ODZfdd5/JONbrFZzeaZ64uDKLEnrD8U5CAhlcDXuwJudWfa2dqWHi5pjLBGSc77rbpOLbbWPaUrJNkn2IxC+9sITpPGDhZIHCyOaybcRIdFhzqOxZ/YlRxePaUtdD5pAHBuqBavuub04ekLYlKZ0IVj8vsO7fl65807Au71a67mA6UVGpYerV5dU8tB4H9W5IqC7V//3489NBDI21ViPIFAycTud1uy2acXB6pcTJ6I/VZtFv4yUK6hoT0ctI17qyjE+h2HQNzBlQA5a812hdMH65/yobu4zLqSIYEj26WWTPDnHPpaQV2b0wiHtXVTjvZcdfd3W3OyRCZgIGTiTweY0CVzWZez5bT8RYZj4GkDUkLDvUdm3Z8uS7I5To6VcKbQPcF3Wi7tA2Rkgicw93Hry8OoNph7WUnf9KummU2D9c9zVxmw5yV5rx2DPUCO9brCAd01eNJej01NDRk/kSITMDAyeTicNvwaHSH05qB09Dw8le2GFmuY4E4nWX2nRSPdy/tRsKVQJE9icuLQrikIAifhYcHS7PMLQEvdgTdxpDgKRqWrNbgKcj8uYT9xoy7oV4d4XAYDz/8MHbu3Jn5EyHKsOy6K+YYTdNGsk52iwVObo82knHKJiwQp3PqPl7vR/NVzRiYMaCGB9cNDw9e6AnDbtnlOw2HIm5s8Bv9nmQAt9Q9ldVk/kxiUWD3Kzp6WnS1y+7pp5/G+vXrOSCYclp23RVzuM7JahmnVMF63Kr3jtNIZcicfotdULIs3amjb0EfWq9oRagiBLsGzPdGcUOJH7WqfYE19cQdWDNYoLr6O5waFlxiw9SFmgoIMymZBPZv1dFy0HixePnll/HMM88gkbD+zkWit4OBk8msmnGyD9dNJIbnv2ULBk70dsWKYui4qAOdKzoR88bgs+m4tNBYvvNadPddWLdh/ZAPh4bn3NXP1bDoMnNaFhzbPTwgWAe2bduG3/zmN2oJjyjXMHCySsbJYjvrtOGfDGveLk5vKGFEfI6IA1osu4I+skj7gpogWle3on9m//HlOwvvvtOhYUfIg9f8XpUhLqnSsOwaDcWV5gwI3jc8IPjo0aOqaLyvry/zJ0J0HjFwMplVWxLEh1conJr1bhRnK56Vug/BRpg0nvYF/fP71fJdqvu47L67piiAUos2z2yJOdXS3UDCGNWy6HIb6udm/jz6OoCdG5KIhHTVpkDaFTQ1NWX+RIjOEwZOVukebrGlunjUeHRlWeB0wnIdO4jTBCzfSffx7iXdSDiN4cFXFwWw2GvN4vFUy4JjEafqVTV1oQ0LTVi6Cw4YO+5kQHAwGFQDgnft2pXZkyA6Txg4WWbsirWWlaS5nXDbrHdzOJvUTkAGTjRhu++m+NGyugWB2gBsGjDXE8V1xX5UOOKWHNXyRtCL1wMetXQno5PU0l2FSQOC23RVKP7UU0+pwnGZd0eUzRg4mcyqS3Xh4SkKRRbuaXPWXk5Bi11UyvrhwV0XdKFjZYeafVdo19XcuyXeMGwWzD41Rl0j3cbV0t0VmV+6Sw0ITu24k1YFTzzxBKLR4ZQ2URZi4GSRwMlq8+qCg8ajNAa0YkHsmbCXE51PoeoQWq5swVD9kFoOm6OyTwGU2a2XfRpK2lXwdMLSnQmDgmXH3aE3k6p1wd69e/GrX/0KAwMDmT0JognCwMkiS3VW21UXCQGJmK6WJbIt63RC9/Dsivkoi3o/9SztQceFHYi74+oNxtVFQSzwhC33RuOUpTuTdt11NkqzzCRiER3t7e2477770NjYmNmTIJoADJxMZtU+TsI//IawwmHNXURnyzjZ43bYYvwRp/MnNCmkWhf464zBwQu8UawusubYFlm6k113/fHju+4mzzVhxt1aHYEBHYFAQBWNb926lXVPlFV4V7FI4GS1zuFioMt451zptN4SxJnI4mJouCUB65zovP+8OZPoXt6NruVdSDqS6o2GFI7XW7DruNp1N1SAhuGlu2kLbVhwiZbR1x/JZu9cr6O72RjT8sILL6hO4/F4dr3OUP5i4GQyr9dr2cBpsNt4rFIZJ2stP6S7XMeddZQpgbrASN8npwZcVBjCBb6Q5QrH5Y3Fm0Ev3gh4kNCBshoNS6/RUFiawXNIAAde19Gw63incal76u/vz9xJEL1NDJxMVlBgjDV3GYknSxnqAxJxHR6bjlK79ZYezoQF4mSGuC+O9ovb0T+7Hzp0zHDHcFVRwJJLd8eiLpV9kjcZHp+GxVfaMGlqZs+h9RCwZ1MSsaiO1tZW/OIXv8DBgwczexJE54iBk8nKyspgs9lgd2pwGckny9CTQH+n8bGVh52OhRknMo0N6J/br+beSdPMMkcS1xb5McmCPZ8GEnZV99QadcBmB2avsGHmMm1k5FJGzqHLqHvy9+kIhUJ49NFH8dJLL6llPCIrYuBkMrvdjvLycvWxtxCWI83rhMzryiZDqSaYfguugVJeCFeG1dJdpCQClw24vDCIuZ6I5Za9ZUzRqwEvdofcatmsZoaGxVdoGc2CR4IypkVH2xHj2rzyyit4+OGHMTQ0lLmTIEoTAycLqKqqUo+ZrDFIV287VO+VEnsShbZE9g37lZYEfONKJkl4E2pky9AUo+fTYm8EK33Wa1kg7dH3h93Y5PchmgSKyjUsvVpDYVlmM9xHd+jYv9UYEtzQ0IB77rkHhw4dytxJEOV74PSlL30JmqapQ4ZNWtXUqUZhgUw1t5pEDBjoNF7kp7iyZ7kukNRUzxpb0sYCcTJ9YHDPkh70LOqBrumY5o7hisKgJQdod8QdWDNUONKyYPEVNlTUZfYcelqA7WuTqmWBzLn7zW9+gxdffFGNbSGygpwNnGQm0t133z1SfG1lM2fOVI9FFchobUG6uppGB07We7Efm6bqN4Rr0GgySmSmoWlDqmGmtCyocibUsOACCxaNB5M2rB8qQNtw3dO8i2yon5fZcwj7gR3rji/dbdq0Se266+3tzeyJEI3Bgrfp8ZPGap/5zGdw880348ILL0Q2LNUVFRXBbtdQkuFuvuku18nuOpnNVW7Pnnd98q5ZuAYYOJE1hKvCaLukTc26k27jsuOu2IJL4FL3tDngxcGw8bszdYENs1dI9j7zS3f7XkuqoeMtLS249957sXv37sydBFG+BE7f/OY30dfXh7vuugvZQJYS58yZoz6uqLPecp30XOlpNT6WZYZs0TuccXL3Z3gwF9EZxIpjaLusDZHiiGr1cWVRECWWfEOiYWfIgzcDHiR1YNJUDfMu1lQWKpN624DtL+sY7NbVcOAnn3wSf/rTn7h0R6bJucBp3bp1+PnPf44f//jHqK2tRbZYvHixeiyvk0AKltN5zEiZ17tisGfJcl1P3BgA6B5wQ0tY8KJS3kp4Eui4uEPtuHOr4EmGBFsxeAIaoi61606aZZbXaFh4mZbxEVHSbXzXRh3NB4zXni1btuCBBx5Qb5CJMi2nAicpJJQluuuuuw6f/vSn0/57kUgEg4ODJxyZNm3aNFWP5XRpKDE22VnKYA8Q8uuqI/LkLCkSDyaN0SuarsHVz+U6st6olvaL2lWncZcGXGHh4Kk95sQrQ8aOu+IKo12BM9OJXB1o3KNj72Zj6U4aZsrS3YEDBzJ8IpTvcipw+ta3vqWmbkv32XNx5513oqSkZOSYMmUKMk2aYC5atEh9LClxK+psNN7tSTfk7KChO26sK3h7LNZdlEhiAaeOjlUdCJcbY1ouKwxatu1HT8KhisblzUhBiYZFEjyZMPGgrwPYJkt3Pbp60/vYY49hw4YNHBRMGZMzgZP84vzsZz/D//pf/wszZsw4p7/77W9/GwMDAyNHU1MTzHDBBReox/I6DQ4LJkg6jxk9nWSIqRULWsfSETOW67xdDJzImnSHrnbbpZbtrigKwqtZb7edGEzaVfAk2VxfUeYbZaZEQ8DuV3S0D++6W7NmDZ566ilVA0V0vuVE4CRTtWVp7uKLL8aXv/zlc/77brcbxcXFJxxmqKmpQV1dHWw2oCrzSa+zikWAvuFO4jPc2fEC1TkcOMnOOlskJ37cKVeDp1UdiBXE4LPpuLzImn2eRGC4XUEgocFbaGSezAiepMv5kR06Dm9Lqh14sttOWhaw2zidbzlxJ/H7/aq77KuvvqpGmKSaXsohxeKpLf/yZ+lGa2WprFPNdGsu17U3GC/mU93ZUSQe1m2qLYEGDb4un9mnQ3RaSZdR8yStCortSVzoC1m2b5r0etrgPx48Lbxcg9OkLHlHgxSOJxGL6KpUg0XjdL4Zb8eznGSMpCh8LM8//7z6Zfr4xz+uvk/6JVnZ0qVLVZdcFEVRUqWrAZhWIucTDujwFGhqh51MWLe61pgTpY4IfO0++Ov9Zp8O0RlHtHSu7ETt5lrUuuJYkIhgb9iEdM45BE+riwLwFQELLwd2vaKraQOZNtRjNMxceJn8qV8FT7fddhsmTZqU+ZOhnKfpuiQ8c9fVV1+tsk5dXV2orEyvu6TsqpMical3MmPZ7oUXXsDWrVvR06pj/xbrPT11s4Hpi23ojduwdsiCk4lPUmRL4IaSAHSbjsbrGlVBLpGVFTQXoGqHsb32Vb9XBf9WJcXsq4uCqifVUK+O3Rt11fvNDLLTT9olSPG61+vFxz72MUyePNmck6Gsci73/ZxYqss1q1atUo/ltRpcFqxp7mw0mmKWO5Iotej26dGGkjYMJmzQpKC1g8t1ZH2B+gAGpg+oj1cWhCxbLC78SftIqwIZDjzvosx2GD+5DlOKxiWAC4VCeOSRR9SKA9FEYuBkQVKPNX36dPXiU23BWqd4VDqJZ1ORuIamqPGOvajJ2ku1RCl98/sQLjXaFCz3hS1b75TabbfR71ODtcuqNcy6wLzXrXgMKusl7QrC4bAKnnp6ekw7H8o9OR84rV27VvX3SHeZzmpZp5rp1hz8myoSl8G/Dgu/oKccizjV2AhPnwfOIesuexCNsAE9S3qga7qqd5rsjFv64vQlHNji946MZ5mywLzgSTLie1/V4e/X1ezShx56SC3BEE0EC96SScyfP18VsjvdGirqrHdNpBgzOKjDoRk77LJhd13bcGuCokZmnSg7xIpiGJhl3PCX+cKWf5PSHnfiraBRzD5lnobq6eadixSp792kIzikq/oVyTxJw0yi8WLgZFHSSXzlypXqYysu143OOhnLddZ+QRdHIsYOwMLmQtii/NGn7NA/qx8xX0wVX8/1WP/GLztt94SMeSwzl9lQauLGtlgU2LNJRySko7u7G08//TQ7jNO48e5h8Z5O0nuqpFJ6pcByuhqBRFxHiT2puolbXVfcjr64DbaEDcUN5jQ5JTpndqPeSczxRC1dKJ6yL+xSy+NSpznvIht8Jv66SZfx/a8ZO/1krp2UbxCNBwMnC5MtkXPnzrVs1ikRB7qGp9PMypIi8QNh451w0bEiaHHrXVOisQSrg2oYsF0DFnojWfG79mbQg86YHXYHsOBSc+bapfj7oTqMi/Xr12Pfvn3mnQxlPQZOFrdixQr1WFkPSy/X1TnjcGfBO+GWmANDCRvsMTtKjpSYfTpE6dGA3gW9IxsysuF3TYeG1wI+1QrE7dUwX9oUmHjHkTd5rYeM16tnn31WFY0TvR0MnCxu1qxZ8Hg8cHk0FFfAcoIDUD1TbBowPQuKxOUOtHu4/qL4aDHsYbvZJ0SUlmhpVLUnyJ7fNSCma9jsP97jycw2BeLYHh2BAR3BYFA1GiZ6Oxg4WZzM3pMddqJisjWXltqPHi8S17KgSLw15kB33K5qnUr3l5p9OkRpG5o6pB6nu7JjQ0ZqKLBknlSbgikaJhvVB6aQYcCH3tTV4549e7Br1y7zToayFgOnLLBw4UL1WF4LS+pukY69uprqXmvxXjMGDTuDw7VOLUXw9FhzFhjRyYK1QSScCRTY9azYkJHSFXdg+3CbgqkLzN1pFxgAmg8YQeef/vQnlX0iOhcMnLLAjBkz4HQ6VZ2Az4JlOfLurb0BI7t+soE06zsaMRphVuyoYKE4ZQXdriNUFVIf1ziy4U3KcUejLhwZ3mk350INbhOnHzXvP75kp4aqE50DBk5ZwOFwqOBJlFXDktqPGNt95V1wmT07XtB3Bj0IJDQ4Q06U7Ssz+3SI0pIKnKqzIrt7oh1BjxoO7nRpmLfKvGJxGW1/eJuuHrdt24YjR46YcyKUlRg4ZYk5c+aox7JJ1qxzkuGa3c1G+ntelmSd4mrLtDFFubixGL42DgAm6wtVhqBDR6kjmRW760ZLyk47vw+RpIbCMg0zFpv3eubvO16f+fzzzyORyJ6lTzIXA6csMXPmTPVYWCZdxWFJLYeMd3B1rjhK7Imsqb04GDY6ildtr4K7z6h9IrKqpDupRrGIbKpzSgnpNmwNGG9YamaaO1KqcY+OaFhHb28vtmzZYt6JUFax6C2YTlZWVobCwkLY7PJOzZrXJzQkheLGO7gFWTAaImVnyI22qANaUsOk1yfBETBm2hFZlTTDzNbASXTGHdgfMt6wSIsCs+qdpIlv417jNWvdunXs7URpYeCUJWT0yrRp09THVuznlNK873jWqTRLsk6yy25LwKvGsUhjzOot1XAEGTyRdUXKjTcmlVlWID7anrAbPXE7HE4Ncy80b8mu85h0FtfVAGAWilM6GDhlkfp6o3241AZYVcgvHXqNd3BLvOGs6TWTgIZNfh/8w8XiNa/WwDlo7LojsppIiRE4Fdulaig7fsfG6iy+xe9FVDeaY9bNNu9cjmw33vBt374dR48eNe9EKCswcMoidXVGMUCBxXs2SupbdthVORNZ0tfJENFtWD9UoEZEOMIO1G6uha+dBeNkPXFfHEl7Us2uK7BlV4H4yfVOu0b1d/IUmF8o/txzzyEez57XLco8Bk5ZpKamRj1KPyenhWuYZRq5FIqLxd4IbFn0jjis27BuqEANJ5XO4pPenGR0F8/eexPlIg2IFRoF4iX27P7hbIg6jd83OzDbxJEsqlA8ZBSKyyBgotNh4JRFXC4XKiqMAqcCCzbCHK3loLFbpciezKpC8dR8rY1+Hw4N77YrPVyK2k21cA0Yfyaygmih0fZDfseym9EWJK4DxZUaqqaYVyh+ZIfxJm/jxo3o6Ogw50TI8hg4ZZmqqir16C2EpSXlRWi78SI01xPNmqaYo+svdoQ8eE1qMJKAe9CN2o21KN9VDluUvzZkjeU64cvipbqUYNKGvcPDt6ct1GAzaW9GbxvQ06ojmUzimWeeUY9EJ+MdIMtUVlaqR2+RdQvER78IdTbpasTChQVh2LNoyS6lJebE3wYL0RhxQIOmGmVOXjcZRQ1FUlFOZJpcCpzE4YhLbc5weTXUzzHv9U2yTvGYjtbWVpV5IjoZA6dsDZwsnnFKObpDRyRkLNkt9Rm9Z7KN1D29HvRh/ZAPA8MtCyr2VKB+XT2KjhZBS1g/iKXcE/cagVM2F4ePJvsDd4aMQvG62ebVccbCQMNO403eyy+/jMbGRnNOhCyLgVMWNsIUZg7IPBeJGHDoDWOr7wx3DFNc2TGOZSzdcQfWDBVgW9CDUFJTO+8q9lag/uV6lBwqgRZjAEWZk/AYKU+3TW7y2ZfNHUtbzKF6O0mheO0sE3s7NRptVXRdx5NPPsnGmHQCBk5ZpqTEqAp3GRMLssJAN9C0z3hXfIEvjCJb9q5xSe3TkYgLfxkoxFsBY0iwPWpH2YEyTHl5ihoWbA/bzT5NygMJl/F75NCA3GnXqmH/8KaMmhmA3cRWajIEODioY2hoCE8//TTrnWgEA6csU1RUBJvNBptNagGQNZr3A/2dunqRv6QwBFeWDScda1nhaNSFvw4WYmvAo3o/2eI2lBwpURmoqjer4O5150oigCxId+iql9PxrFNuaI850B+3qY7iNdPNOw/pRbd/q27stjtyBGvXrjXvZMhSGDhlGQmaiouL1cfuLAqcxME3dISDRr3TpYWhrCwWHysD1RR14W+DBdjk96I7ZoemayhoL0Dtq7WqjUFBawH7QNF5kXQYgZNDy/7fpeM0HIoYWadJUzXT528e3mZc4w0bNmDnzp2mng9ZAwOnLF6uy7bAKRYB9m7SEYvqajjpqoJQztRmyIt9e8yJ9f4CvDRYgIaIEwkdcA+4UbWtCvVr61F8pBhanHVQNHF0u/H7kwtvQkZrjTpVXyfZPWz2UPPuZqB1uKHv73//e+zZs8fcEyLTMXDK5sApSwrET55lt+9V6ZNiDAJernba5daL/kDCrhr6/XmgEHtCboSHC8nL95WrZbzSA6WwRfirRxMYOOVYPB6HpoInUTXF/P+5hl06Oo8ZxeJPPfUU9u7da/YpkYn46p3VgZP5Lyhvx1CvLNsl1U67me5YTgZPqdl3+8JuFUC9EfDAnzBaGZQeKlUBVPnuchaS0/jk3q/NiOaoUfJeVg1LOPSWrvrSSVPMJ554gpmnPMbAKQuVlpZmbcYppacFOPTm8eBJdtvl6l1ACsmPqULyArzq96I3boMtaUPxsWK1hKcCqBB34tG5k3mKQpa1co20/0jqgKdAs8xrnbRW6Ww83qbgrbfeMvuUyAQMnLJQtvVyOp2upuOZJ+nxtMIXhpajwZNBQ2vMibVDBdgw5DMKyZOaEUCtMwIoLuHROf1EDdfMxfXszD6fbbmuL2G8oSgx+v5awqE3jy/byViWv/zlL2xVkGcYOGVxxsmT5YFTqvDy4OtG8DTdHcMlBbmx2+7MNHTFHVjvN7qRd40OoNbWo3R/KWwx/mrSWX6K4trIz0k0BwMnIW8uRGGZtf7/ZNmuaZ/xOvXqq6/iscceQzicnZMR6Nzx1TlLa5wcDgdsdg2eAmS97hZg/5ak6ptS64pjdVEA7izv85QeTS1HbPAbGSi1hJewofRwKSavnWzswuM4FzoN14BLzU+ULvZST5eLhpI2y46YksBJXrcSCeDQoUP45S9/iZ6eHrNPizIgN3/b8qCXU0VFhfrYW4ScIAOBd72SRCyio8yRxNVFgazuMH6uJAMlS3hSAzU4XEQuu/BkoHBhU2Guln/ROLj7jWFuvfHcrY+TDRXCqm8Qe1qBXeuTah5nd3c37rnnHmzdulUt41HuYuCUpaqqqtSjz+iFmRP8fcDO9TpCfh0Fdh3XFAdQ74whfxg1UNJM8/WAB8HhNgaVOytR90odPF0eBlA0wtvlzf3AaTjjJDuINYverQIDwI51upqMEI/H8cILL+Dxxx9HKCR96igXWfRHkc5m8uTJ6rG4wlpr/+MVDhjBU3+XMZ7losIQlntDsOVVykVDo+zCGyjEjqAb0STgGnKhZmsNqrdUqyUaym+ufhe8vV6166w5ZuJAt/MsNqp2y27h+DAWBvZs0nF0R1L1qNu/f7/KPjU0NJh9anQeMHDKUtOmTVOPReXqPptT4lFgz0YdTfuNYGmmJ4arigIosOVD3dOJbQwORdz4y2ARDoZdqhO5t8eLuo11qNxWCUcwd0a70rmRXmCiKepEaDgrk4tkpJH83AtbFvy4tx0Bdq5Lqqz54OAgHnzwQbXrLhbLp8x57svd37gcV11dDbfbrQZhFhqvoTmnaa+OPZuO1z1dV+zHTHc0Z/s9neld986QBy8OFqIxYmQXClsLVf1T+a5y2CMWfitOE05q3nydPrUTdX8497OPqcDJyhmnk5futq/V0dFwfNedFI739vaafWo0QRg4ZXGB+OzZsy0zkuB86e80XoQGuo2lO+kyfmVhMO+yTyKYtOH1oBdrBgvQMTxMuLixWO3AUy0Movx1znVFx4pUzZs4EHHBn8ySaGIcUuNkZAksWyTjMhxYx97NSUTDOjo6OnDffffh4MGDZp8aTQC+0maxFStWqMeqKYAth18/oyFg9ys6jmxPIhEHqpwJlX2a54nkWe2ToT9hx0Z/geoB1RO3j7QwkDEuZXvK2IU8RxUfLUbFbmM37aGwC7tDxq66XCa/36nASZbws01fB7BjrY6hXl31eXr00Uexbt067rrLcgycstiMGTNUM0xZrqswasVzWvtRYNuapNq9ItmnRd4IrisOoEbtvMu/AEp6QK0b8mGz34v+4R5QJQ0lqolmxfYKOAdzt2g43xpdlu0tQ/leKWg0lud2qKApdzPNKW7N+L1OJnX1pikbRcPSakVH+1Hj/2Xt2rVq1l1CGkBRVmLglMU0TcPKlSvVx1PmaTmddUqJBI3dKwdeN1LgRfYkLisMqeW7CnuWvrKOi4a2mBNrhgrwypAPncNLeEUtRZj8ymTUbKpBQXMBG2lmIx3wtfswef1klBw1BnvvDaUyTbkfNAnv8JK87FrLZnoSOLJdV/M5Zclx7969+N3vfsfgKUsxcMpyF110EYqLi9UgzPp5+fFimhrV8tbfdDQf0FXHcVm+u6o4iMsLAyjP0wCqM+7AK/4CvDxYoCbLqwGp/R5U7ahC/Zp6VOysgKfbI9v1yOIcAQcmvT4Jk96cpHp5BROayizuDXvyJmgS8sZIhPzICZ2NUHVP8pp14MABZp6ylKazxekpZBupjDUZGBhQQYnVSc+Q3/72t+pdzY51SbWrI5+4vFBB46SpGmzDbwWkePpA2I0u1Rwwf240o8nYGpn/N90VVQ1FUxKuBAI1AYQmhRAuD0N35N8yp1VJgX/JkRIUNxSr+YUS/B4Iu7A/7EYiD3+OF3vDmOuJou2wjqM7c+fntKQKWHCJTa0SLFy4EB/84AfVhh/Kjvs+A6dxXkCrkLSvpH8jQV01kJR19Xzj9gGT554YQPXFbTgYdqMl5lA9YfKTjkmOBCa7YqhzxuAe9fqs23SEy8IIVRlBVLQ4yjy0CbSYpoIlWZKzxW0jwf/2oCcvds6djmSQq50JHN6WREeO9ZIsnQTMl+DJBlx99dW46qqrzD6lvDZ4Dvf9LGgpRul497vfjc7OTvSgBwsuNYoRE3nWc03qn45s09FyQEfdbAmgoPo/SfdxGV/SEHHhWMSJUI4ORD3bMp4c2+BRQVSdK4ZqRxw+qSPp8apDJG1JREuiiJRFECmJqEAq7ovna9LuvJMhztJioORwiZpPKAbiNuwJu9EWk5fn/L3wGnSUO4wC6qHe3Gy1cvitJOastKmddlOnTlUbfsj6mHHKkYyT6O/vV43W/H4/Brt17Nls1P/kK4cTqJkB1MzU4PIYNyBpGtgec6Ah6lSP+ZuFEjoKbUlUO+MqmJKblNt26nJI0p5UAVSsMKaOaKHxccKTyOf7+vgkgYLWApQdKFM1TEKGO+8NGdlRXligxC5tRwKIx3RseT53lulONusCDdXTNBQUFOALX/gCCgsLzT6lvDTIpbrMXUCrkUZrv/rVrxCJRBAY0LF/i67mv+UzGQ5aUQdUT9dQUnn8Th9JaqqIWubC9akp7PkeBRiBlARQFY6EunGV2JMjfXRO+W6bjrgnrjJSMZ8RSEn9VMJtHElHErpTNx4lIMv3yyt0I2CSkSnOgNEuIpTUsCfkRmPUmeeB/IlmuSNY5ougr0MaSeZu4CR1TktWaygo0bBo0SJ86EMfMvuU8tIgA6fMXUAram5uVsXigYDxbu3gGzr62s0+K2vwFBgBlDQNTWWhxFDChtaoA60xJ4Ook5ZLJJgqdSRRZEuoXU5yyOds53CP1zUdul1XAdTIo01X2awTPucY/pxdR9KZVIFY0mU8xr1xFZBl5V7g4dYCpQdL4fIbY1IiSSn8duNwxKXmEtKJriwMqN2yR3cm0XY4t6+OrwRYfo3xg/3FL34RkyZNMvuU8s4gA6fMXUAr/z88+eSTaGpqUn+WbfuNe/V87BM5Ng0orTLG1ZTXAnbpqDlMMgASRMlSnjSZzMfdTOkEVB6brkbfpA75szQsdMvHmg6nTVdFlNoEXj4JwFJZLjmiRcayoTxKgGW5p2p4SU52yqUCpmgSOBhx43DYhbjlTtgaXFoS7yrxq5+dN/6aVPWLuW7eKmlkzKyTWRg4ZfACWpl0pn3xxRfx2muvqT/7+2RsiQ5/v9lnZi0ydb28Giiv01A2CbA7tRMGjHbFjSBKDpkXR+fCCJ6cmg6bZozPkBJou/z5pEf5vGP4e+TRpaUCMXlMwmuT/8bp/6W4O45oaVQVtUdKjeJ2WSo0q61AUWOROlI1TDEdaoenjEthwHRm01xRrCwIq3KD7S/nx7s9XzGw/Frj9eVLX/oSKiuNmYSUGdxVR4rdbsdNN92EKVOm4NlnnwXKIlhylaamdjfu0RHPs113ZxrI2d0ih67qoUqrdJTVaCitBjw+DTXOuDpSBbwdMYc6uuN2LrGclQa5cnFdm4Bspw6vpsNnS8JnT6LYZiwbFtuNjJcj4oCjwwFfh2/4u3WVjVJB1PAhfz5fS30yGkX+7YK2Ani7vKqDuwgnNRUsHY26EBv+HJ2Z9B8T8juZL4KDMttOR1m1hn379uGKK64w+5ToNNiOIA9IweG0adNU9mnHjh2omaGpYmlZusu13ijjJU1EZTCnvIAJb5GO8hqgtFpDcbmmbtLF9ijmeKIqg9AVc6ht4xJIhfOuzUGmaQjpGkIJG3pO2i1qh66K2aWwvUx2CNoTKLBDLY/JUdRcdGK7heFWC7EiY6eg1FSdsyTgGnTB0+eBu9cNb7dXzQtMkR5ihyIutESdDLDPQZk9rjYnyI7gzmPIK6nA6fDhwwycLCwnAqeWlhbVuv6FF15QkXp7ezvKy8tx+eWX4xvf+AYuvvhi5DvZ4vr+978fK1asUNdJej7NWq6hZoaRfZJggU4VGgJa5Diow+7UVV2UBFFl1UZxeZ0rrg4hGaimiFNtJ48yiMooqUPrTTjUgYjxOVneSwVRqYDKmbSpQEeOFMlMSeG51EzJzkBZ8pNHFUypRJkRVEmfJXvYrpbe7CE7XEOuEwIl4U/ITk0nmqJODOVx48rxkDcloqtZR2z4ucwX/cOvw42NjYhGo3C5jLo4spac6OP0rW99C//2b/+GWbNmqQ6sVVVVOHjwIP7whz9A/vceffRRfOQjH8m7GqfTSSaTeP311/Hyyy8jHDZajA/16Wjap4/84tLZFZQAZTVQ7xCLyo8vwciYDMlAsVeUddstlNkTw9nD5Ji9q9Ilhd49cQd64nZVC8e2FuNT6YhjdZFRCb5tTVItX+WblTdqcHs1fOYzn0F9fb3Zp5M3BvNtV93TTz+NioqKU1rWb9iwAdddd53KtrS1tcHtlqniZ5frgVNKMBjEpk2bsGXLFsRiRk3BUO9wANVp9tllF5cHqJhs7NIrLD1xh15DxKm6ludfx/Ls2cElAZTXllQ1VLI70CM1UyNPo9FdSeqTQkmb6kIvj9LCYkhtFmDd0kSwQVcNL6Vurf2osZElHy2+UkNxhYZbbrlFzbGjzMi7wOlMbrzxRvz1r3/F1q1bceGFF6b1d/IlcEqRfk8SQMk1YgA1ft5CYNI0Y+SL0328Y3lzzIH9ITcGuYRDdIr5nggWeiOIhnW89VL+jYxKmbtKQ+VkTW3sYZlJ5nBX3ShOp9Gd1+HIiXKu80Ja/d9www247LLLRgKoovIYFl6mqe3AMvutu9Vo4kdnF/IDx3ZL3yygvFZHjXQsr9IwxRVXh3Qr38cAimhEjTOmAidxdGf+Bk0iVdclo7PImnI6mpACu7/97W+ora3FkiVLTvt9Mp5EjtGRZz4HUJdeeqkKoN544w2gJKreAU0N6Gg7rKOj0di+T+nt0OtpkUOHr0RH/VzjnWS9K66OpqhDzSbzMwNFeWyKK4aVvpDq0dXZqKvfGQJsNi7tW1XOPjOy5HTbbbepgEgKx6Wn0enceeedamkudUjfo3wmNWHveMc78NWvfhXXXHMNfD4fPAUaZiy14cIbNUxbKENzzT7L7BIcAA5s1VXBa6o3jWSfri8OYIUvBK+WNPsUiTJMx2x3BKsKjKCpq0nH4beY1k7FS1wlsa6crHGSXWMSNMluus997nO49957z/j9Y2WcJHjKlxqndILQ7du3Y/Pmzejt7VWfS0o2pdXIQvn7zD7D7JxNNXWBhvIabaRDucws2x92s0ki5Tx5o7DMFx5p5dF6SEfDrpy7Fb0tc1bKLE1tpHyCMiOva5wkaPr0pz+tgqbbb78dd99991n/juy2S3fHXT6SOjEprF+5ciUOHDigAqhjx46hql5Th7QykACqp9VYnqL0MlD7XtVRVK5j6kINJZUa5nqimO6KqsGv0jiRg18pFwOmuZ6I6gwuo3XkDdix3bk/xPdcOIZbN0mmn6zJkWtB06c+9Sk89NBD+NjHPoYHHniA68QTSNM0zJs3Tx3S3kHaGOzcuRNFZQkUXaghFtHRcQxqpEs+DOWcCEO9wO5XdJRO0jFtkYaCEg2LfRHM8kRVAfkxdp2mHCCtHua6jwdMYqBbx9Edel72ajqTVBlEUZHR7Z6sx5GLQdOtt96KBx98kEHTeSQF9+973/tw/fXXqyJyOSTVWT8XmDxHU6MDpBcLG2qmR/pm9XfqqKw3MlBeH3BBQRjzvBHVwkCaaRrdhIiypy+TzHic5oqh2hkfGdAsAZP0ihvsNvsMrcnlNR4ZOFmXI5eW5yRokqZhjzzyyBmLwWlid+KtXr1azVWSZTxpZXDkyBFVuyNHOCjz8HQ1cyrfxie8Hd3NRu1Y9TQdk+dq8HmNAEqWNw5G3DgWcarxIkTWpKPMnsRUV1TtlnON2n4kbwyaDzBgOtsyndNl/H6Xlpae7yeL8jlwuuOOO1SGSXaDzZ07Fz/4wQ9O+Z5PfvKTmD59uinnly9bZ+fPn6+O7u5ulYHatm2bzIZXu/Cmzgf6OnW1c6avzahtoLFJnVj7UaDjmI7q6Trq52go8ALLfWEs9IRxJOJSB4cKk1V4NAmWYpjqjqku7CmRkI6uRmPHnPQ3ozPzDdckl5WVcU6dheVE4NTQ0DDSMOyHP/zhmN8jM+wYOGVGZWWl6th+7bXXYs+ePWouXnNz80gWKh4zerXIEE+m688SQB0BOht0TJqmo3aWBm+hhvneqBqE2hJ14GjUpeakcewHmbUUJwFTzailuERcR2+b0ZNpoIvPy7nOvxTV1dW8cBaWk+0IxivfRq5kgmShduzYoQ65rqPfkcrylPQ2CvSbeopZobwWqJttzLJKGUzYcDTiRHPUiQjn4dF5paPSkVDLcJOdJy7FDXbr6Gwy3hQl2CT3bZl3kYaKOk290T959iqdX5xVl8ELSOdG4nRpZSAB1N69exEOh08Iovragb52450ql/PO/M60eoa0gwDsw9No5S1QV9yuAqjWmANRBlE0YXVLieGO9zF4bcffa0eCOrqah5fihni5x9v4ctXfaer3WfoPygYcyhwGThm8gPT2xeNxHDp0SLU0OHjw4MiAYZFM6Bjqk3exwECXrrbtMzd6KrsDqJoCTJqqobDseBYqqUMt4bXFHOoIcKwLneMynGSWap0x1aRydLAUjxqzK7u51D6hymqABZfY1L3nK1/5imr/QpmT1w0wKXvISIFUQbkEUUePHlU78+RQP8SVUMeU+Zqqm5DgSY7BHqNbOZcDjGsgheTS+sHt01E5GaiYrKGwVEOVM6GOpYio5bzOmAOdcTu6Yw7EuTOPTqCj1J5ElSOOSc44KhwJDCcylURMR1+HUZcorTPY6HbiVU8zLrj0yWPQZG2scRoDM07mL+fJaBdZ0pPC/8OHDyMYPLGjpmSfQn6jLsrfr8PfDwQGOIA4xe0z3sFKMX5xpTYy/yqVjepL2FVGqi9uR2/cjpAuL9p8h5svHLL85kioAKnCEUe5IwHnSU9/VJbOO4DeNh39XQyWzqfiSmDxFTYVMP3DP/yD2mBDmcWME2U1efGoqKhQx4oVK1Qg1dnZiaamJnU0Njaiv78fviINviJZqjr+iq+CqQEg0D+coerLzxd86dwuO/Laj+iwO6QzOVBSpaGkCmpnnnHDTIx8fzipqazUUMIGf1Ie7QglNdXyIKZWad5OUKWrlLZD01W3aG1UC095lH89oWuqL5XM6uOImfO37FZiT6pASWqV5LHIlsTJK0Gy2zW1NC6BEmuWMkOzATOXGU+GjLZi0GR9zDiNgRkn65PWEzL2pbW1VT3KIc/byRJSK9VjNN+TLuZBFrDC7TXe4RaVaSgsN3rH2FJ7yccgQY0EVrFTghwdksiSj+Sv26HDORwkpR7PhQRo4aRN/VsStAUlgEva4FfBnJ3Dj9Pk0pKqPkkCY8kkldoTYz4X0pxWfjeGeo03GQH59eEe64yS4HXWBZqqUZRmwv/4j/8Ij2d45gplFIvDM3gByToCgQDa29vV0dLSojJT8rnRZBeQLD/Izj0uPxhkGc9XAniLjGyUt1AeAafneBfj8ZCMYTJuLBEanzj+TttmP3PQNpoEU/1xO/oTNvQnjGVGNgE1lt2qnHFUORKodMRR6jg1xSpzJGU5W2oD/X1GjWAsOu6nlsa5sUPaD5RO0lSW/cMf/rCq9yRzMHDK4AUk65IbtvSPkhEwsntP6qWkCD1FCs4liJIRJ5KNYrH5qSS4kaGjTrfxQq8CHTsgE40k/pFlUHXoxvWTQ4KkROL4x2drKyHvum0OCdKMf0sdXsBTYARxnkLJko0dXAUSGnriDvQm7OiO29VyY+7XaukotiXV/Dc5JLt0cuwZHNQxOCqbFD7x/QNZoAZx/sXGUG+n06lGhc2ZM8fs08prg+dw3+dS3TgvIGUPaXcgwdPonXuj2x9It2MZc8Jux9YjgVVBMVBQChSWaOrRVyzv1E/8vmgS6I47VBAljwMJqfDJhUBKR7k9oVoD1DljKLSfuKYWDhi73aQ+SQImzoW0Jk8BUDNDUz3Y5M2HLM999KMfRV1dndmnlvcGGTiNDwOn/MhGSV2UNOGUo6en54TlvM7h+Vp8p25dkgErLIPqol5UDnWkmoGmxHWoXYOyg1AyU7KbUGq1soGEfNIeQIIlGWkyupeSBPoS4Mv8R8mW8ufUuuxOoKwaqKrXUFZz/GdPRoC9733v4zBfi2DglMELSLkRREld1FtvvaWacY7uZi5LHdLor7uF7+ItT5NslFH4XlKpoagCcJy8x16e04RNBVMSRElGaiBut0xfK692fAlO+imNPn3Z9Sad9XukPUCHBE9mnimdidQHllcD5XWyk/XEdiCyJLdq1SrMnj2b/ZoshIFTBi8g5RapgZIM1Pbt21VtVGqUozz0d+hqKU9uXuxinh1kx6BkolJZKambOl2t1GDCrnbxSWA1OLKTT756voIqXbUFSLUJkGalxfYTC8JSY4ikl9JAd3621sgGsmQsgboESZJdkga0o1VVVanC7+XLl6O8vNy086TTY+A0TgycKNXyYPfu3SoLJbv0UqJhYylPpr+H/bxW2cThMpb3pBWDzPuTw+07fWAkgVMwYVOtEVJ9rSJJDRFdQ1TXENelTYMsCWqn9KFKtWdIHbLUVmBLwmdPqkcJkk5aWVQBuWQ5U+0zZCccWZNskpAgqbxWluBOzW5OnjxZdQFfsGABezNlAQZOGbyAlB+kBkqW8rZt23ZCiwO5yUkAJRPh48dH7VEWcTiNdgy+VDsGeSw6/U6+iSQ7O1XX+/7hgKlLxpuc93+WxqG4AqierqGiToKn4z8jUug9a9YszJgxQy3DFRYW8jpnEQZOGbyAlF8SiYTakSdBlLQ4SC3lSb1JX4cRREmmgEt52U8yCtIsVLaOy+HyaKotg9SvuKQ9g9MoUE8dJ88X05O6CqalLYM8xsLSdNLYfCDF3CE/u3NnU6Zy0lRjnpy36PjzXFZWNjJvs76+HrbRxUyUVRg4ZfACUn4v5ckyntRDdXR0nNBssKvJWMoLntrMnHLVyQkqduHOelK3VKOyS5oKpIXL5cLixYvVOChpI8CBvLmBgVMGLyCRkMBJAqgdO3acsJQXGDCyUN3N3JVHlA2k+WrlZMkwaapXWEptba2aJbdo0SK43W5Tz5EmHgOnDF5AotGSyaRawpNaKFnSk6W9kV15nZKJMhptcis5kXXIEmx5DVA5RVOtLEY+73Sq7JIETGxSmdsGz+G+L8PLiWiCSI3D3Llz1REKhdSuPMlENTc3o6xatiprqiC4p9VYypNp9ESUWVKfVlRmtA8onSS7K09cZ502bZoKmOTg0F06GUeujIEZJzofu/KkHkqW8vr6+k7sUt4EdElrA84TI5pwUswvMw+lp1dhmYZCGdczqsB79FLcwoULsWTJEpV5oPwyyJErmbuAROdCduFJ9kmW8iQbFYlERr4mU+u7W4xsVCTI60p0LnVJsvNRZsFJk1N59MrHhWN3j0/tiJOxJzNnzlQtBKSdAOWvQQZOmbuAROMZOrx//361lHf48OGR1gYjo15aWFRONDo4ksyR9NjyFWrwFAEeaRPhlSXy0/fckl1vEiRVVlaqrJI0ppTD5/Px4tIIBk7jxMCJMk124smoF8lCNTQ0jHxeYqnBbh1dzUZReTzK54Zyn2SPpAapoHS4w3sp4HRpZ6wtlDe5Ms5EgqTUowRL8uhwsJyXzoyB0zgxcCIrjHrZtWuXWtY7eRyHzC3rbQfHvVDOkKW1kipjpqB05h5rDI4ERxIQSTAkR0VFhQqKSktLUVRUxOaTNC4MnMaJgRNZRX9/vwqgJJBqb28/4WvhoI6BTqC/y3jkyBfKJsWVQEWthtJqY9TNyUFSTU2NagEgy2tyTJo0CXb7cBdKognGwCmDF5AoU+TnUXpDSV3U0aNHVc+o0dmo4KCOoR5gsFfHUC8LzMl6ZEeb9EqSBpMywmZ0oDRlyhRVrD116lQ1vkQ6dBNlCgOnDF5AIjNEo1E0NjbiyJEjqrC8s7PzlO+JRY2RL4EBI6gKDUG1PIgd38iXNVweo/eOjL1Qh81oIio1X7Eoa7+sTAq6K+uNYGn0nDev14t58+apnmeys43duMlMbIBJlOPk3bhMYJdDDA0NoampSQVT8ijLek5XEiWVUMfoQWrxmNEzKhI4ceis+lzQ3AHFEhwVlxv9dmT3lNx0pf7F7jh9YbCQHYnR0PDgXDU8V0dwCPD3A8l4xk6fhsnzVl4no0ukuPv4cydF2hIsSa8k+dnl0htlIzbAHAMzTpTt4vE4urq61Aw9OSQjJU04JYt6tgBEgqdUIBUO6Cq4SgVaifjENyeUQKmoXFM1L3KT1caIkWQpRzo4y41XxmDIo2TdgsHgCb2wxvr/kUzbUB/glyXMPsm+Tez/AwE2h/E8ltVId3yjl9Lo527WrFlqxtv8+fOZWSJLYsaJKM9JYJEqqj05oJLO5b29vepRis/lkI/lkN5SRhPB1N/QTln+k8BKgqhICIiGdUTD8mgsl0lglTokANJsxrKaLK+NNCj0aaoxoWw3H2v3lOyWkhqX6upq9XFq95TcgMci8wAlgJLz7+7uVgGiPErAKIGidIyWo3qa8W8lYrrKREkQFeg3PmbD0TOT59LhNAJdmesmS6fyfEqgK+0CRgdKQjJJUq+UCpZkWY4oVzDjNAZmnCgfSXZG+klJUJUKrEYHWRKcTDRpTigBkgRKMh9MDtlaPpGtHVpaWtQhrR3kUTJVJ5PlS6MWzKgHk2U+yVTlUt8sCV6lWaQEPa7hAEi6aktAZHdJsH28hszuOP4oy6d2+5mXSoXUhcry25w5c1QnbhZ3UzZhcXgGLyBRvpAlsdEZKqmrGn2Ew2EVlEjW6uTgSDJgEhBJ5ih1SDZMtptnsihYdiJKNkqCqNbWVrS1tanMlGStxiIBlQRQRiBl1IJJDZU86sc3NVqGZPhUd22pDVOP2sjHZ2ogmS7ptl1YWKgOeW2UFgHSNkCCX3bipmzGwCmDF5CITg1OJICSpTUJmE63xGYVEjRJPZjUgY0+zlQPlipGl+VKtXQ5vGwZG162HL10OdGBUSpb5PYaS5+y3CnLZhIgyaMEqqcjWSB5TZMgVmazSd2YHLKUJgGs1I/JId8nj/I5OeTP8shibspVrHEiItOkCrmzhQQDkjWRYzTJnMkypWSoJJCSj6V+Sh4l+yZBihyoSP2NUwOWZFJHIma0TJAgSnb4SXJLHqUNl2StZBdjaiejxDwSZ6raMFkqcxpLaOrRlV7WSAKcVHdt6bQ9uk6MW/6Jxo8DfIiIxiAZF1mCkkOKnE+uBZMlS8lKyTtV+VjqqWTJMvUohfgyfNbmNjJEExnopZbKZNxIauxIKkiSTNKZsk5END4MnIiIzoEEJak6HylqH4sEVxI4hUKhkUOWL0cfskQoy5qpQ/5OamlTgqPRS2VyyHKaLLFJNo+BEZF5GDgREU0wCWxS9UKskyTKLdau2iQiIiKyEAZORERERGli4ERERESUJgZORERERGli4ERERESUJgZORERERGli4ERERESUJgZORERERGli4ERERESUJgZORERERGli4ERERESUJgZORERERGli4ERERESUJgZORERERGlypPuN+UTXdfU4ODho9qkQERHReZa636fu/2fCwGkMQ0ND6nHKlCkT/dwQERGRhe//JSUlZ/weTU8nvMozyWQSra2tKCoqgqZpZp9OXkT6EqQ2NTWhuLjY7NOhM+BzlV34fGUXPl/mkVBIgqa6ujrYbGeuYmLGaQxy0err68/X80OnIUETA6fswOcqu/D5yi58vsxxtkxTCovDiYiIiNLEwImIiIgoTQycyHRutxvf/e531SNZG5+r7MLnK7vw+coOLA4nIiIiShMzTkRERERpYuBERERElCYGTkRERERpYuBEGdfS0oL//M//xDve8Q5MnToVLpcLNTU1+OAHP4jXXnuNz4jFhMNhfO1rX8MVV1yB2tpaVcAqTeKuvfZaPPXUU2mNKCBzfelLX1LNfOXo7u7m02EhqedlrONHP/qR2adHY2BxOGXct771Lfzbv/0bZs2ahauvvhpVVVU4ePAg/vCHP6ib8KOPPoqPfOQjfGYsQm60EuBefPHFmDNnDiorK9HV1YVnn30WHR0d+OxnP4tf/OIXZp8mncbLL7+M6667Dj6fD4FAQD138hySNUiANG3aNHzyk5885Wvy5vKyyy4z5bzo9Bg4UcY9/fTTqKiowFVXXXXC5zds2KBe4AsLC9HW1sb2BBYaQRSPx1VmcDS/36+CqT179mDv3r2YP3++aedIY5NAacmSJVi+fDl6e3uxbt06Bk4WDJzktXDt2rVmnwqliUt1lHEf+MAHTgmaxJVXXolrrrkGfX192LlzJ58ZC40gOjloEhLg3njjjerjw4cPm3BmdDbf/OY31e/TXXfdxYtFNEE4q44sxel0qkeHgz+a2VD7tGbNGhVYLVy40OzToZNIdunnP/857r//flWbRtYlwe29996Lnp4eVbogJQyyLE7WxKU6sozGxkbMnTsX5eXlaGpqgt1uN/uUaJRgMIh///d/V3VonZ2deOGFF9Rz9oMf/ADf+c53eK0s9lwtXboUM2bMwIsvvqg+JzdjLtVZc6lurM997GMfU8GU1KaRtfBtPVlCLBbDbbfdhkgkogrHGTRZ82b8/e9//4Ts4H/8x3/g61//uqnnRWNvwGhvbx8Jmsi6/umf/gm33HKLyjBJwPTWW2/hf/7P/4lHHnkEiURCbZYha2HGiSxRfCxBk7xAfO5zn1Pvssi65MW8ubkZjz/+OP71X/8V7373u9XHDHatQTZZSA3hT37yE3z1q18d+TwzTtn1JmXZsmU4dOgQN15YEIvDyfSg6dOf/rQKmm6//XbcfffdfEYsTgIk2T79jW98Az/84Q9VL6cHHnjA7NMiQO1+lN8n2e345S9/mdckS8ny3H/7b/9Nfbxp0yazT4dOwsCJTA2aPvWpT+HBBx9U6/ly85VCY8oeN9xwg3rkVmprkBYRkqV49dVXVYA7upmi1DcJKT6WPzc0NJh9unQGqV5bkn0ia2GNE5kaND300EO49dZbVfDEoCn7tLa2qkfugrQG6er+mc98ZsyvPf/886ru6eMf/7j6vqKiooyfH6Vvy5Yt6nH69Om8bBbDGicybXlOgiUpinzsscdYH2Nh0txSluZO3t0jW6ivv/56vPnmm2qpNbW0QNbEGifr2b17tyoKP7lPmjQJ/tCHPqSyg0eOHEFBQYFp50inYsaJMu6OO+5QQZM0UJT2A7Kd/WQyfoDvtKxBCr//7//9v2pWnTwn8rxJGwLJYAwNDakZg5I1JKJzc9999+Hhhx/G6tWr1VgjybrLrjpZVvV4PPj1r3/NoMmCGDhRxqVqK6QeQ4qLT/fumIGTNciuORnMLEWqGzduVGM8ysrK1AytT3ziEyrTNFYvGiI6s5tuukn1rJNgSVpHSFsWGaAtZQz//M//jAULFvASWhCX6oiIiIjSxC1MRERERGli4ERERESUJgZORERERGli4ERERESUJgZORERERGli4ERERESUJgZORERERAyciIiIiCYWM05EREREaWLgRER5R8b5cEwMEb0dDJyIiIiI0sTAiYiIiChNDJyIiIiI0sTAiYhyTkNDg6phuvrqqzE4OIivfvWrqq7J6XTie9/73gnfe//992Pp0qXwer2oqanB5z//efT394/53+3q6sLXvvY1zJo1C263G1VVVbj55puxZcuWDP2fEZHZGDgRUc4KhUJYvXo1Hn74YaxYsQLvete7UFRUNPL1b3zjG/jSl76E2tpavPOd74Su6/jFL36B9773verj0ZqamrBq1Sr853/+p/rzBz7wAcyfPx9//OMfcfnll+OJJ57I+P8fEWWepp/86kBElAMZpxkzZqiPL730UvzpT39CSUnJyNcl+3Ts2DGVYVq7di3mzZunPt/d3a2+/9ChQ3jppZdw7bXXjvydv/u7v1P/nc9+9rO4++67Ybfb1eeffvpp3HLLLSgoKMDBgwdRXV2d8f9fIsocZpyIKKf99Kc/PSFoGu0HP/jBSNAkKisr8YUvfEF9vH79+pHPHz58WAVNZWVl+MlPfjISNKUyT7JcNzQ0hAcffPC8/r8QkfkYOBFRzpIluAsvvPC0X3/HO95xyufmzp2rHtva2kY+t3HjRvX47ne/G4WFhaf8ndtuu009vvLKKxNy3kRkXQyciChnTZ069Yxfr6+vP+VzqRqoSCQy8rnW1lb1OG3atDH/O7L0d3KwRUS5iYETEeUsj8dzxq/bbBPzEsgu5ET5g4ETEdFZ1NXVqUcpKD9dMXpqaZCIchsDJyKis5B2A+K5556D3+8/5euPPPKIerziiit4LYlyHAMnIqKzkIaX0uepr68PX//615FIJEa+Jn2cpCWB1EbdfvvtvJZEOc5h9gkQEWWDe++9F1deeaVqkCk9nqQZZktLi9pJJ+0JpAM5ezgR5T5mnIiI0jBlyhRs3boVX/nKV1TG6amnnsKePXvwnve8Bxs2bMCHP/xhXkeiPMDO4URERERpYsaJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiIKE0MnIiIiIjSxMCJiIiICOn5/wFbGxk7PMHx2gAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 600x500 with 1 Axes>"
       ]
@@ -2857,16 +2861,16 @@
    "id": "p15b-code-08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:33:25.492312Z",
-     "iopub.status.busy": "2026-06-06T14:33:25.490339Z",
-     "iopub.status.idle": "2026-06-06T14:33:28.762240Z",
-     "shell.execute_reply": "2026-06-06T14:33:28.760861Z"
+     "iopub.execute_input": "2026-06-15T04:29:54.986146Z",
+     "iopub.status.busy": "2026-06-15T04:29:54.986146Z",
+     "iopub.status.idle": "2026-06-15T04:29:55.632946Z",
+     "shell.execute_reply": "2026-06-15T04:29:55.632946Z"
     },
     "papermill": {
-     "duration": 3.332675,
-     "end_time": "2026-06-06T14:33:28.762725",
+     "duration": 0.672214,
+     "end_time": "2026-06-15T04:29:55.632946+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:25.430050",
+     "start_time": "2026-06-15T04:29:54.960732+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2931,10 +2935,10 @@
    "id": "p15b-md-06",
    "metadata": {
     "papermill": {
-     "duration": 0.055655,
-     "end_time": "2026-06-06T14:33:28.868406",
+     "duration": 0.025444,
+     "end_time": "2026-06-15T04:29:55.684536+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:28.812751",
+     "start_time": "2026-06-15T04:29:55.659092+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2951,16 +2955,16 @@
    "id": "p15b-code-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:33:28.975093Z",
-     "iopub.status.busy": "2026-06-06T14:33:28.974081Z",
-     "iopub.status.idle": "2026-06-06T14:33:29.514402Z",
-     "shell.execute_reply": "2026-06-06T14:33:29.513317Z"
+     "iopub.execute_input": "2026-06-15T04:29:55.733231Z",
+     "iopub.status.busy": "2026-06-15T04:29:55.733231Z",
+     "iopub.status.idle": "2026-06-15T04:29:55.916380Z",
+     "shell.execute_reply": "2026-06-15T04:29:55.916380Z"
     },
     "papermill": {
-     "duration": 0.601591,
-     "end_time": "2026-06-06T14:33:29.516415",
+     "duration": 0.211331,
+     "end_time": "2026-06-15T04:29:55.916380+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:28.914824",
+     "start_time": "2026-06-15T04:29:55.705049+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3039,16 +3043,16 @@
    "id": "p15b-code-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:33:29.668870Z",
-     "iopub.status.busy": "2026-06-06T14:33:29.668303Z",
-     "iopub.status.idle": "2026-06-06T14:33:30.461518Z",
-     "shell.execute_reply": "2026-06-06T14:33:30.461030Z"
+     "iopub.execute_input": "2026-06-15T04:29:55.959268Z",
+     "iopub.status.busy": "2026-06-15T04:29:55.959268Z",
+     "iopub.status.idle": "2026-06-15T04:29:56.214426Z",
+     "shell.execute_reply": "2026-06-15T04:29:56.214426Z"
     },
     "papermill": {
-     "duration": 0.891362,
-     "end_time": "2026-06-06T14:33:30.463525",
+     "duration": 0.271495,
+     "end_time": "2026-06-15T04:29:56.214426+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:29.572163",
+     "start_time": "2026-06-15T04:29:55.942931+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3120,10 +3124,10 @@
    "id": "p15b-md-07",
    "metadata": {
     "papermill": {
-     "duration": 0.053124,
-     "end_time": "2026-06-06T14:33:30.571226",
+     "duration": 0.026844,
+     "end_time": "2026-06-15T04:29:56.265637+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:30.518102",
+     "start_time": "2026-06-15T04:29:56.238793+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3138,16 +3142,16 @@
    "id": "p15b-code-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:33:30.680296Z",
-     "iopub.status.busy": "2026-06-06T14:33:30.680296Z",
-     "iopub.status.idle": "2026-06-06T14:33:30.730139Z",
-     "shell.execute_reply": "2026-06-06T14:33:30.729491Z"
+     "iopub.execute_input": "2026-06-15T04:29:56.322563Z",
+     "iopub.status.busy": "2026-06-15T04:29:56.322563Z",
+     "iopub.status.idle": "2026-06-15T04:29:56.334011Z",
+     "shell.execute_reply": "2026-06-15T04:29:56.334011Z"
     },
     "papermill": {
-     "duration": 0.103329,
-     "end_time": "2026-06-06T14:33:30.730139",
+     "duration": 0.040764,
+     "end_time": "2026-06-15T04:29:56.334011+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:30.626810",
+     "start_time": "2026-06-15T04:29:56.293247+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3282,10 +3286,10 @@
    "id": "p15b-md-08",
    "metadata": {
     "papermill": {
-     "duration": 0.050831,
-     "end_time": "2026-06-06T14:33:30.831602",
+     "duration": 0.024459,
+     "end_time": "2026-06-15T04:29:56.384993+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:30.780771",
+     "start_time": "2026-06-15T04:29:56.360534+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3299,10 +3303,10 @@
    "id": "cell-29",
    "metadata": {
     "papermill": {
-     "duration": 0.052786,
-     "end_time": "2026-06-06T14:33:30.947885",
+     "duration": 0.021216,
+     "end_time": "2026-06-15T04:29:56.427209+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:30.895099",
+     "start_time": "2026-06-15T04:29:56.405993+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3334,16 +3338,16 @@
    "id": "cell-30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T14:33:31.047621Z",
-     "iopub.status.busy": "2026-06-06T14:33:31.047621Z",
-     "iopub.status.idle": "2026-06-06T14:33:31.063944Z",
-     "shell.execute_reply": "2026-06-06T14:33:31.062966Z"
+     "iopub.execute_input": "2026-06-15T04:29:56.489995Z",
+     "iopub.status.busy": "2026-06-15T04:29:56.489995Z",
+     "iopub.status.idle": "2026-06-15T04:29:56.492984Z",
+     "shell.execute_reply": "2026-06-15T04:29:56.492984Z"
     },
     "papermill": {
-     "duration": 0.062196,
-     "end_time": "2026-06-06T14:33:31.063944",
+     "duration": 0.030685,
+     "end_time": "2026-06-15T04:29:56.494000+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:31.001748",
+     "start_time": "2026-06-15T04:29:56.463315+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3388,10 +3392,10 @@
    "id": "cell-31",
    "metadata": {
     "papermill": {
-     "duration": 0.054251,
-     "end_time": "2026-06-06T14:33:31.175913",
+     "duration": 0.028749,
+     "end_time": "2026-06-15T04:29:56.548969+00:00",
      "exception": false,
-     "start_time": "2026-06-06T14:33:31.121662",
+     "start_time": "2026-06-15T04:29:56.520220+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3452,18 +3456,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 161.566512,
-   "end_time": "2026-06-06T14:33:33.641828",
+   "duration": 74.364324,
+   "end_time": "2026-06-15T04:29:57.624530+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/PyMC-15_executed_final.ipynb",
+   "input_path": "d:/dev/CoursIA/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice2a/PyMC-15-Decision-Utility-Money.out.ipynb",
    "parameters": {},
-   "start_time": "2026-06-06T14:30:52.075316",
+   "start_time": "2026-06-15T04:28:43.260206+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Constat (rappel)

Le drift de provenance PyMC se mesure sur `metadata.language_info.version` (interpreteur enregistre a l'execution = signal reellement committe). 9 notebooks off-env sur 3 versions Python. Cible = `coursia-ml-training` (py3.12.13 / pymc 5.28.5 / pytensor 2.38.3 / numpy 2.4.4).

| Version | Notebooks |
|---------|-----------|
| py3.12.13 (cible) | PyMC-1,2,3,4,5,8,9,10,11,14,17 (11, non touches) |
| py3.13.12 (off) | PyMC-6,7,12,16,18,20 |
| py3.10.18 (off) | PyMC-13,15,19 |

Slice 1 (#3027, merge) a unifie PyMC-6,7,12,19,20. Reste 4 off-env : PyMC-13,15 (py3.10.18) + PyMC-16,18 (py3.13.12).

## Slice 2a (cette PR) -- les 2 py3.10.18

| Notebook | Avant | Apres | Code cells | Erreurs |
|----------|-------|-------|-----------|---------|
| PyMC-13-Debugging | py3.10.18 | **py3.12.13** | 13/13 exec | 0 |
| PyMC-15-Decision-Utility-Money | py3.10.18 | **py3.12.13** | 28/28 exec | 0 |

### Preuve Papermill (coursia-ml-training)
```
EXEC PyMC-13-Debugging rc=0 -- VERIFY py=3.12.13 code=13 exec=13 err=0 -- OK_COPIED
EXEC PyMC-15-Decision-Utility-Money rc=0 -- VERIFY py=3.12.13 code=28 exec=28 err=0 -- OK_COPIED
```

### Conformite
- **Pure re-exec** : `src_invariant=True` (sources cellules byte-identiques a HEAD), `added_source_lines=0`. Seuls outputs/execution_count/language_info changent.
- **C.3** : staging = 2 notebooks uniquement. Les 9 PNG savefig de PyMC-15 sont des side-artifacts **non-trackes** sur main (figures inline base64 dans le notebook) -> non stagees.
- **H.3** : 0 cellule code null-exec. **C.1** : 0 NotImplementedError/assert False/1/0 (notebooks seedes, exec end-to-end).
- **Catalogue** : byte-identique a main (aucune regen branche). **0 collision** (famille PyMC, po-2023=GenAI).

### Autorisation
Pas d'issue dediee -- fix de provenance C.2 autorise par greenlight ai-01 dashboard (option b, 03:03Z ; continue 03:58Z).

**Slice 2b** (PyMC-16, PyMC-18, py3.13.12) prochain cycle -> complete 9/9 off-env.