### PR TITLE
fix(qc-mcp-lite): add create_project tool to unblock baseline-clone deployment

### DIFF
--- a/scripts/qc-mcp-lite/server.py
+++ b/scripts/qc-mcp-lite/server.py
@@ -216,6 +216,29 @@ def list_backtests(project_id: int) -> dict:
 
 
 @mcp.tool()
+def create_project(name: str, language: str = "Py") -> dict:
+    """Create a new QC project. Returns projectId.
+
+    ``language`` is "Py" (default) or "C#". The project is created in the
+    account's default organization unless the account has a single org. Used
+    to deploy local-only baseline-clone strategies (e.g. QC Strategy Library
+    references like LongShortHarvest) to QC Cloud so they can be compiled and
+    backtested — ``create_file`` requires an existing project.
+    """
+    data = _api_post("/projects/create", {"name": name, "language": language})
+    # QC returns {"projects": [{projectId, name, organizationId}], ...} — mirror
+    # the read_project shape so callers get a consistent projectId field.
+    projects = data.get("projects", [])
+    proj = projects[0] if projects else {}
+    return {
+        "projectId": proj.get("projectId", 0),
+        "name": proj.get("name", name),
+        "language": language,
+        "organizationId": proj.get("organizationId", ""),
+    }
+
+
+@mcp.tool()
 def list_projects(name_contains: str = "") -> dict:
     """List all QC projects.
 

--- a/scripts/qc-mcp-lite/tests/test_server.py
+++ b/scripts/qc-mcp-lite/tests/test_server.py
@@ -27,6 +27,7 @@ from server import (
     create_backtest,
     create_compile,
     create_file,
+    create_project,
     list_backtests,
     list_projects,
     read_backtest,
@@ -476,6 +477,42 @@ class TestListBacktests:
             result = list_backtests(1)
             assert result["count"] == 30  # Total count
             assert len(result["backtests"]) == 20  # Capped at 20
+
+
+@patch.dict("os.environ", _DUMMY_ENV)
+class TestCreateProject:
+    def test_returns_project_id(self):
+        mock_resp = _mock_api_response({
+            "projects": [{"projectId": 23456789, "name": "MyClone", "organizationId": "org1"}]
+        })
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            result = create_project("MyClone", "Py")
+            assert result["projectId"] == 23456789
+            assert result["name"] == "MyClone"
+            body = mock_post.call_args.kwargs["json"]
+            assert body["name"] == "MyClone"
+            assert body["language"] == "Py"
+
+    def test_defaults_language_python(self):
+        mock_resp = _mock_api_response({
+            "projects": [{"projectId": 1, "name": "X", "organizationId": "o"}]
+        })
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            create_project("X")
+            body = mock_post.call_args.kwargs["json"]
+            assert body["language"] == "Py"
+
+    def test_surfaces_qc_rejection_not_empty_id(self):
+        """Regression (cf create_backtest success:false guard): a rejected
+        create must raise the QC error, NOT return projectId=0 silently — a
+        zero id would block every subsequent create_file/backtest on a
+        non-existent project and force blind retries."""
+        mock_resp = _mock_api_response(
+            {"success": False, "errors": ["Project name already exists"]}
+        )
+        with patch("requests.post", return_value=mock_resp):
+            with pytest.raises(RuntimeError, match="Project name already exists"):
+                create_project("dup")
 
 
 @patch.dict("os.environ", _DUMMY_ENV)


### PR DESCRIPTION
## What

Adds a `create_project(name, language="Py")` tool to qc-mcp-lite (`POST /projects/create`), so local-only baseline-clone strategies can be deployed to QC Cloud for backtesting.

## Why

qc-mcp-lite could create files (`create_file`/`update_file_contents`) but **not the project itself** — both require an existing `projectId`. This blocked the **#1630 baseline-clone** track: local-only strategies like `LongShortHarvest-QC` (catalog Sharpe **3.39** — highest entry — but `README` says *"metrics from original library, not locally reproduced"*, Cloud project ID `None`) cannot reach QC Cloud for a post-#2801 re-backtest under real IBKR fees.

This is the same "qc-mcp-lite lacks the needed capability" class the user flagged for #3023 — and the same fix: give the sanctioned wrapper the missing endpoint rather than writing ad-hoc REST.

## How

- `create_project` → `_api_post("/projects/create", {"name", "language"})`, returns `projectId` from QC's response shape `{"projects": [{projectId, name, organizationId}], ...}` (mirrors the existing `read_project` extraction).
- Reuses the shared `_api_post`, so the **#3023 `success:false` guard applies**: a rejected create (e.g. duplicate project name) raises `RuntimeError` instead of returning `projectId=0` silently — which would otherwise block every subsequent `create_file`/`create_backtest` on a non-existent project and force blind retries.

## Validation

- **50/50 tests pass** (47 prior + 3 new): returns `projectId`, defaults `language="Py"`, surfaces rejection (`success:false` → `RuntimeError`, not empty id).
- Endpoint/response shape verified against [QC API v2 create-project docs](https://www.quantconnect.com/docs/v2/cloud-platform/api-reference/project-management/create-project) before implementing (not guessed).
- Fresh base `origin/main` `97789f89`; diff is `+60/-0` across 2 files (no catalog, no submodule).

## Scope

Tooling-only (qc-mcp-lite wrapper). Does **not** deploy or backtest anything — that's the follow-up baseline-clone PR once this is merged + the MCP server restarted (alongside #3023's `name_contains`, both land on next MCP restart).

See #1630

🤖 Generated with [Claude Code](https://claude.com/claude-code)