### PR TITLE
chore(iit): unify IIT exec provenance onto pyphi env (py3.9.25) -- Intro_to_PyPhi

### DIFF
--- a/MyIA.AI.Notebooks/IIT/Intro_to_PyPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/Intro_to_PyPhi.ipynb
@@ -5,10 +5,10 @@
    "id": "3653fac8",
    "metadata": {
     "papermill": {
-     "duration": 0.00734,
-     "end_time": "2026-06-06T07:35:04.370466",
+     "duration": 0.006803,
+     "end_time": "2026-06-15T05:29:42.004754",
      "exception": false,
-     "start_time": "2026-06-06T07:35:04.363126",
+     "start_time": "2026-06-15T05:29:41.997951",
      "status": "completed"
     },
     "tags": []
@@ -98,16 +98,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:35:04.388168Z",
-     "iopub.status.busy": "2026-06-06T07:35:04.387829Z",
-     "iopub.status.idle": "2026-06-06T07:35:08.670509Z",
-     "shell.execute_reply": "2026-06-06T07:35:08.669249Z"
+     "iopub.execute_input": "2026-06-15T05:29:42.013067Z",
+     "iopub.status.busy": "2026-06-15T05:29:42.013067Z",
+     "iopub.status.idle": "2026-06-15T05:29:49.937768Z",
+     "shell.execute_reply": "2026-06-15T05:29:49.937768Z"
     },
     "papermill": {
-     "duration": 4.292862,
-     "end_time": "2026-06-06T07:35:08.672363",
+     "duration": 7.929489,
+     "end_time": "2026-06-15T05:29:49.940994",
      "exception": false,
-     "start_time": "2026-06-06T07:35:04.379501",
+     "start_time": "2026-06-15T05:29:42.011505",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -120,33 +120,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Defaulting to user installation because normal site-packages is not writeable\n",
-      "Requirement already satisfied: pyphi in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (1.2.0)\n",
-      "Requirement already satisfied: decorator>=4.0.0 in c:\\python313\\lib\\site-packages (from pyphi) (5.2.1)\n",
-      "Requirement already satisfied: joblib>=0.8.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyphi) (1.5.0)\n",
-      "Requirement already satisfied: numpy>=1.11.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyphi) (2.4.3)\n",
-      "Requirement already satisfied: psutil>=2.1.1 in c:\\python313\\lib\\site-packages (from pyphi) (7.0.0)\n",
-      "Requirement already satisfied: pyemd>=0.3.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyphi) (2.0.0)\n",
-      "Requirement already satisfied: pymongo>=2.7.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyphi) (4.17.0)\n",
-      "Requirement already satisfied: pyyaml>=3.13 in c:\\python313\\lib\\site-packages (from pyphi) (6.0.2)\n",
-      "Requirement already satisfied: redis>=2.10.5 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyphi) (7.4.0)\n",
-      "Requirement already satisfied: scipy>=0.13.3 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyphi) (1.15.3)\n",
-      "Requirement already satisfied: tblib>=1.3.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyphi) (3.2.2)\n",
-      "Requirement already satisfied: tqdm>=4.20.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyphi) (4.67.3)\n",
-      "Requirement already satisfied: pot>=0.9.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyemd>=0.3.0->pyphi) (0.9.6.post1)\n",
-      "Requirement already satisfied: dnspython<3.0.0,>=2.6.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pymongo>=2.7.1->pyphi) (2.7.0)\n",
-      "Requirement already satisfied: colorama in c:\\python313\\lib\\site-packages (from tqdm>=4.20.0->pyphi) (0.4.6)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+      "Requirement already satisfied: pyphi in C:\\ProgramData\\miniconda3\\Lib\\site-packages (1.2.0)\n",
+      "Requirement already satisfied: decorator>=4.0.0 in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (5.2.1)\n",
+      "Requirement already satisfied: joblib>=0.8.0 in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (1.5.2)\n",
+      "Requirement already satisfied: numpy>=1.11.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (2.2.6)\n",
+      "Requirement already satisfied: psutil>=2.1.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (7.2.2)\n",
+      "Requirement already satisfied: pyemd>=0.3.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (2.0.0)\n",
+      "Requirement already satisfied: pymongo>=2.7.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (4.17.0)\n",
+      "Requirement already satisfied: pyyaml>=3.13 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (6.0.3)\n",
+      "Requirement already satisfied: redis>=2.10.5 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (7.1.1)\n",
+      "Requirement already satisfied: scipy>=0.13.3 in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (1.17.0)\n",
+      "Requirement already satisfied: tblib>=1.3.2 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (3.2.2)\n",
+      "Requirement already satisfied: tqdm>=4.20.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (4.67.3)\n",
+      "Requirement already satisfied: pot>=0.9.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyemd>=0.3.0->pyphi) (0.9.6.post1)\n",
+      "Requirement already satisfied: dnspython<3.0.0,>=2.6.1 in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from pymongo>=2.7.1->pyphi) (2.7.0)\n",
+      "Requirement already satisfied: colorama in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from tqdm>=4.20.0->pyphi) (0.4.6)\n"
      ]
     }
    ],
@@ -160,10 +148,10 @@
    "id": "75ba5ca1",
    "metadata": {
     "papermill": {
-     "duration": 0.006823,
-     "end_time": "2026-06-06T07:35:08.686070",
+     "duration": 0.005542,
+     "end_time": "2026-06-15T05:29:49.952326",
      "exception": false,
-     "start_time": "2026-06-06T07:35:08.679247",
+     "start_time": "2026-06-15T05:29:49.946784",
      "status": "completed"
     },
     "tags": []
@@ -181,16 +169,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:35:08.701059Z",
-     "iopub.status.busy": "2026-06-06T07:35:08.700695Z",
-     "iopub.status.idle": "2026-06-06T07:35:16.504777Z",
-     "shell.execute_reply": "2026-06-06T07:35:16.503342Z"
+     "iopub.execute_input": "2026-06-15T05:29:49.965037Z",
+     "iopub.status.busy": "2026-06-15T05:29:49.964035Z",
+     "iopub.status.idle": "2026-06-15T05:29:52.137522Z",
+     "shell.execute_reply": "2026-06-15T05:29:52.137522Z"
     },
     "papermill": {
-     "duration": 7.814357,
-     "end_time": "2026-06-06T07:35:16.507154",
+     "duration": 2.181866,
+     "end_time": "2026-06-15T05:29:52.140519",
      "exception": false,
-     "start_time": "2026-06-06T07:35:08.692797",
+     "start_time": "2026-06-15T05:29:49.958653",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -203,46 +191,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "DEBUG:2026-06-06 09:35:13,680:jax._src.path:37: etils.epath was not found. Using pathlib for file I/O.\n"
+      "C:\\ProgramData\\miniconda3\\envs\\pyphi\\lib\\site-packages\\pyemd\\__init__.py:74: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n",
+      "  from .emd import emd, emd_with_flow, emd_samples\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Welcome to PyPhi!\n",
-      "\n",
-      "If you use PyPhi in your research, please cite the paper:\n",
-      "\n",
-      "  Mayner WGP, Marshall W, Albantakis L, Findlay G, Marchman R, Tononi G.\n",
-      "  (2018). PyPhi: A toolbox for integrated information theory.\n",
-      "  PLOS Computational Biology 14(7): e1006343.\n",
-      "  https://doi.org/10.1371/journal.pcbi.1006343\n",
-      "\n",
-      "Documentation is available online (or with the built-in `help()` function):\n",
-      "  https://pyphi.readthedocs.io\n",
-      "\n",
-      "To report issues, please use the issue tracker on the GitHub repository:\n",
-      "  https://github.com/wmayner/pyphi\n",
-      "\n",
-      "For general discussion, you are welcome to join the pyphi-users group:\n",
-      "  https://groups.google.com/forum/#!forum/pyphi-users\n",
-      "\n",
-      "To suppress this message, either:\n",
-      "  - Set `WELCOME_OFF: true` in your `pyphi_config.yml` file, or\n",
-      "  - Set the environment variable PYPHI_WELCOME_OFF to any value in your shell:\n",
-      "        export PYPHI_WELCOME_OFF='yes'\n",
-      "\n",
       "PyPhi version: 1.2.0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\numpy\\lib\\_format_impl.py:838: VisibleDeprecationWarning: dtype(): align should be passed as Python or NumPy boolean but got `align=0`. Did you mean to pass a tuple to create a subarray type? (Deprecated NumPy 2.4)\n",
-      "  array = pickle.load(fp, **pickle_kwargs)\n"
      ]
     }
    ],
@@ -257,10 +214,10 @@
    "id": "91886d72",
    "metadata": {
     "papermill": {
-     "duration": 0.007261,
-     "end_time": "2026-06-06T07:35:16.521860",
+     "duration": 0.005092,
+     "end_time": "2026-06-15T05:29:52.151123",
      "exception": false,
-     "start_time": "2026-06-06T07:35:16.514599",
+     "start_time": "2026-06-15T05:29:52.146031",
      "status": "completed"
     },
     "tags": []
@@ -290,16 +247,16 @@
    "id": "5e296ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:35:16.538368Z",
-     "iopub.status.busy": "2026-06-06T07:35:16.537351Z",
-     "iopub.status.idle": "2026-06-06T07:35:16.547169Z",
-     "shell.execute_reply": "2026-06-06T07:35:16.545880Z"
+     "iopub.execute_input": "2026-06-15T05:29:52.156406Z",
+     "iopub.status.busy": "2026-06-15T05:29:52.156406Z",
+     "iopub.status.idle": "2026-06-15T05:29:52.169523Z",
+     "shell.execute_reply": "2026-06-15T05:29:52.169128Z"
     },
     "papermill": {
-     "duration": 0.020026,
-     "end_time": "2026-06-06T07:35:16.549469",
+     "duration": 0.015421,
+     "end_time": "2026-06-15T05:29:52.171910",
      "exception": false,
-     "start_time": "2026-06-06T07:35:16.529443",
+     "start_time": "2026-06-15T05:29:52.156489",
      "status": "completed"
     },
     "tags": []
@@ -338,10 +295,10 @@
    "id": "eb86b36c",
    "metadata": {
     "papermill": {
-     "duration": 0.007046,
-     "end_time": "2026-06-06T07:35:16.564400",
+     "duration": 0.005183,
+     "end_time": "2026-06-15T05:29:52.183398",
      "exception": false,
-     "start_time": "2026-06-06T07:35:16.557354",
+     "start_time": "2026-06-15T05:29:52.178215",
      "status": "completed"
     },
     "tags": []
@@ -366,16 +323,16 @@
    "id": "62301b90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:35:16.581131Z",
-     "iopub.status.busy": "2026-06-06T07:35:16.580412Z",
-     "iopub.status.idle": "2026-06-06T07:35:16.590101Z",
-     "shell.execute_reply": "2026-06-06T07:35:16.588790Z"
+     "iopub.execute_input": "2026-06-15T05:29:52.184788Z",
+     "iopub.status.busy": "2026-06-15T05:29:52.184788Z",
+     "iopub.status.idle": "2026-06-15T05:29:52.217297Z",
+     "shell.execute_reply": "2026-06-15T05:29:52.216110Z"
     },
     "papermill": {
-     "duration": 0.020024,
-     "end_time": "2026-06-06T07:35:16.591988",
+     "duration": 0.03056,
+     "end_time": "2026-06-15T05:29:52.219097",
      "exception": false,
-     "start_time": "2026-06-06T07:35:16.571964",
+     "start_time": "2026-06-15T05:29:52.188537",
      "status": "completed"
     },
     "tags": []
@@ -422,10 +379,10 @@
    "id": "7a35fb70",
    "metadata": {
     "papermill": {
-     "duration": 0.006256,
-     "end_time": "2026-06-06T07:35:16.605467",
+     "duration": 0.004994,
+     "end_time": "2026-06-15T05:29:52.230771",
      "exception": false,
-     "start_time": "2026-06-06T07:35:16.599211",
+     "start_time": "2026-06-15T05:29:52.225777",
      "status": "completed"
     },
     "tags": []
@@ -450,16 +407,16 @@
    "id": "cfb3a7f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:35:16.622266Z",
-     "iopub.status.busy": "2026-06-06T07:35:16.621868Z",
-     "iopub.status.idle": "2026-06-06T07:35:57.946432Z",
-     "shell.execute_reply": "2026-06-06T07:35:57.945586Z"
+     "iopub.execute_input": "2026-06-15T05:29:52.232642Z",
+     "iopub.status.busy": "2026-06-15T05:29:52.232642Z",
+     "iopub.status.idle": "2026-06-15T05:30:00.730293Z",
+     "shell.execute_reply": "2026-06-15T05:30:00.730293Z"
     },
     "papermill": {
-     "duration": 41.335026,
-     "end_time": "2026-06-06T07:35:57.948032",
+     "duration": 8.497272,
+     "end_time": "2026-06-15T05:30:00.733028",
      "exception": false,
-     "start_time": "2026-06-06T07:35:16.613006",
+     "start_time": "2026-06-15T05:29:52.235756",
      "status": "completed"
     },
     "tags": []
@@ -478,15 +435,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:17<01:42, 17.01s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Computing concepts:  86%|████████▌ | 6/7 [00:17<00:02,  2.11s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:15,  2.55s/it]"
      ]
     },
     {
@@ -517,15 +466,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:15<01:15, 15.05s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Evaluating Φ cuts:  67%|██████▋   | 4/6 [00:15<00:05,  2.89s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:12,  2.41s/it]"
      ]
     },
     {
@@ -540,7 +481,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Φ pour le sous-système (0,1,2) à l’état (0,0,0) : 1.875\n"
+      "Φ pour le sous-système (0,1,2) à l’état (0,0,0) : 1.874999\n"
      ]
     },
     {
@@ -569,10 +510,10 @@
    "id": "388d4d94",
    "metadata": {
     "papermill": {
-     "duration": 0.008876,
-     "end_time": "2026-06-06T07:35:57.963130",
+     "duration": 0.006241,
+     "end_time": "2026-06-15T05:30:00.745887",
      "exception": false,
-     "start_time": "2026-06-06T07:35:57.954254",
+     "start_time": "2026-06-15T05:30:00.739646",
      "status": "completed"
     },
     "tags": []
@@ -597,16 +538,16 @@
    "id": "1748a54f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:35:57.978932Z",
-     "iopub.status.busy": "2026-06-06T07:35:57.977791Z",
-     "iopub.status.idle": "2026-06-06T07:36:34.945994Z",
-     "shell.execute_reply": "2026-06-06T07:36:34.943809Z"
+     "iopub.execute_input": "2026-06-15T05:30:00.745945Z",
+     "iopub.status.busy": "2026-06-15T05:30:00.745945Z",
+     "iopub.status.idle": "2026-06-15T05:30:07.954042Z",
+     "shell.execute_reply": "2026-06-15T05:30:07.952030Z"
     },
     "papermill": {
-     "duration": 36.983177,
-     "end_time": "2026-06-06T07:36:34.953015",
+     "duration": 7.203649,
+     "end_time": "2026-06-15T05:30:07.956486",
      "exception": false,
-     "start_time": "2026-06-06T07:35:57.969838",
+     "start_time": "2026-06-15T05:30:00.752837",
      "status": "completed"
     },
     "tags": []
@@ -625,15 +566,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:18<01:51, 18.61s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Computing concepts:  86%|████████▌ | 6/7 [00:18<00:02,  2.31s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:15,  2.60s/it]"
      ]
     },
     {
@@ -701,10 +634,10 @@
    "id": "d1e8755b",
    "metadata": {
     "papermill": {
-     "duration": 0.011337,
-     "end_time": "2026-06-06T07:36:34.975565",
+     "duration": 0.011789,
+     "end_time": "2026-06-15T05:30:07.979110",
      "exception": false,
-     "start_time": "2026-06-06T07:36:34.964228",
+     "start_time": "2026-06-15T05:30:07.967321",
      "status": "completed"
     },
     "tags": []
@@ -719,16 +652,16 @@
    "id": "8be318a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:36:35.010261Z",
-     "iopub.status.busy": "2026-06-06T07:36:35.009509Z",
-     "iopub.status.idle": "2026-06-06T07:38:55.479930Z",
-     "shell.execute_reply": "2026-06-06T07:38:55.478000Z"
+     "iopub.execute_input": "2026-06-15T05:30:08.002101Z",
+     "iopub.status.busy": "2026-06-15T05:30:08.002101Z",
+     "iopub.status.idle": "2026-06-15T05:30:34.950704Z",
+     "shell.execute_reply": "2026-06-15T05:30:34.949298Z"
     },
     "papermill": {
-     "duration": 140.488522,
-     "end_time": "2026-06-06T07:38:55.482869",
+     "duration": 26.963492,
+     "end_time": "2026-06-15T05:30:34.952999",
      "exception": false,
-     "start_time": "2026-06-06T07:36:34.994347",
+     "start_time": "2026-06-15T05:30:07.989507",
      "status": "completed"
     },
     "tags": []
@@ -747,15 +680,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:22<02:12, 22.14s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Computing concepts:  86%|████████▌ | 6/7 [00:22<00:02,  2.74s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:03<00:21,  3.53s/it]"
      ]
     },
     {
@@ -786,15 +711,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:15<01:19, 15.86s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Evaluating Φ cuts:  67%|██████▋   | 4/6 [00:16<00:06,  3.04s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:13,  2.67s/it]"
      ]
     },
     {
@@ -832,15 +749,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:18<01:53, 18.89s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Computing concepts: 100%|██████████| 7/7 [00:19<00:00,  1.99s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:15,  2.58s/it]"
      ]
     },
     {
@@ -871,15 +780,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:15<01:19, 15.84s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Evaluating Φ cuts:  67%|██████▋   | 4/6 [00:15<00:06,  3.03s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:12,  2.44s/it]"
      ]
     },
     {
@@ -917,15 +818,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:19<01:58, 19.76s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Computing concepts:  86%|████████▌ | 6/7 [00:19<00:02,  2.45s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:14,  2.47s/it]"
      ]
     },
     {
@@ -956,15 +849,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:16<01:24, 16.81s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Evaluating Φ cuts: 100%|██████████| 6/6 [00:16<00:00,  2.09s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:12,  2.52s/it]"
      ]
     },
     {
@@ -1003,10 +888,10 @@
    "id": "c91e98c8",
    "metadata": {
     "papermill": {
-     "duration": 0.013684,
-     "end_time": "2026-06-06T07:38:55.509613",
+     "duration": 0.009261,
+     "end_time": "2026-06-15T05:30:34.976168",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.495929",
+     "start_time": "2026-06-15T05:30:34.966907",
      "status": "completed"
     },
     "tags": []
@@ -1034,16 +919,16 @@
    "id": "42dafeb5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:38:55.538375Z",
-     "iopub.status.busy": "2026-06-06T07:38:55.537607Z",
-     "iopub.status.idle": "2026-06-06T07:38:55.545402Z",
-     "shell.execute_reply": "2026-06-06T07:38:55.543889Z"
+     "iopub.execute_input": "2026-06-15T05:30:35.004413Z",
+     "iopub.status.busy": "2026-06-15T05:30:35.003414Z",
+     "iopub.status.idle": "2026-06-15T05:30:35.011764Z",
+     "shell.execute_reply": "2026-06-15T05:30:35.010415Z"
     },
     "papermill": {
-     "duration": 0.024935,
-     "end_time": "2026-06-06T07:38:55.547824",
+     "duration": 0.026024,
+     "end_time": "2026-06-15T05:30:35.015203",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.522889",
+     "start_time": "2026-06-15T05:30:34.989179",
      "status": "completed"
     },
     "tags": []
@@ -1077,10 +962,10 @@
    "id": "63af95b4",
    "metadata": {
     "papermill": {
-     "duration": 0.012476,
-     "end_time": "2026-06-06T07:38:55.572441",
+     "duration": 0.010517,
+     "end_time": "2026-06-15T05:30:35.035429",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.559965",
+     "start_time": "2026-06-15T05:30:35.024912",
      "status": "completed"
     },
     "tags": []
@@ -1100,16 +985,16 @@
    "id": "57501e53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:38:55.599997Z",
-     "iopub.status.busy": "2026-06-06T07:38:55.599149Z",
-     "iopub.status.idle": "2026-06-06T07:38:55.720339Z",
-     "shell.execute_reply": "2026-06-06T07:38:55.718667Z"
+     "iopub.execute_input": "2026-06-15T05:30:35.050814Z",
+     "iopub.status.busy": "2026-06-15T05:30:35.049802Z",
+     "iopub.status.idle": "2026-06-15T05:30:35.095103Z",
+     "shell.execute_reply": "2026-06-15T05:30:35.093744Z"
     },
     "papermill": {
-     "duration": 0.138251,
-     "end_time": "2026-06-06T07:38:55.722674",
+     "duration": 0.055629,
+     "end_time": "2026-06-15T05:30:35.098091",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.584423",
+     "start_time": "2026-06-15T05:30:35.042462",
      "status": "completed"
     },
     "tags": []
@@ -1128,15 +1013,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts: 100%|██████████| 7/7 [00:00<00:00, 65.20it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "                                                                 "
+      "                                                         "
      ]
     },
     {
@@ -1166,10 +1043,10 @@
    "id": "560d96b0",
    "metadata": {
     "papermill": {
-     "duration": 0.018868,
-     "end_time": "2026-06-06T07:38:55.754622",
+     "duration": 0.014337,
+     "end_time": "2026-06-15T05:30:35.122516",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.735754",
+     "start_time": "2026-06-15T05:30:35.108179",
      "status": "completed"
     },
     "tags": []
@@ -1186,16 +1063,16 @@
    "id": "1083ab9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:38:55.781726Z",
-     "iopub.status.busy": "2026-06-06T07:38:55.780883Z",
-     "iopub.status.idle": "2026-06-06T07:38:55.791658Z",
-     "shell.execute_reply": "2026-06-06T07:38:55.790113Z"
+     "iopub.execute_input": "2026-06-15T05:30:35.145527Z",
+     "iopub.status.busy": "2026-06-15T05:30:35.145527Z",
+     "iopub.status.idle": "2026-06-15T05:30:35.161493Z",
+     "shell.execute_reply": "2026-06-15T05:30:35.159958Z"
     },
     "papermill": {
-     "duration": 0.027454,
-     "end_time": "2026-06-06T07:38:55.793578",
+     "duration": 0.03173,
+     "end_time": "2026-06-15T05:30:35.163552",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.766124",
+     "start_time": "2026-06-15T05:30:35.131822",
      "status": "completed"
     },
     "tags": []
@@ -1236,10 +1113,10 @@
    "id": "a9a149d4",
    "metadata": {
     "papermill": {
-     "duration": 0.013785,
-     "end_time": "2026-06-06T07:38:55.819537",
+     "duration": 0.009625,
+     "end_time": "2026-06-15T05:30:35.184241",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.805752",
+     "start_time": "2026-06-15T05:30:35.174616",
      "status": "completed"
     },
     "tags": []
@@ -1263,16 +1140,16 @@
    "id": "5658a6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:38:55.848637Z",
-     "iopub.status.busy": "2026-06-06T07:38:55.847949Z",
-     "iopub.status.idle": "2026-06-06T07:38:55.856114Z",
-     "shell.execute_reply": "2026-06-06T07:38:55.854670Z"
+     "iopub.execute_input": "2026-06-15T05:30:35.201771Z",
+     "iopub.status.busy": "2026-06-15T05:30:35.200772Z",
+     "iopub.status.idle": "2026-06-15T05:30:35.210764Z",
+     "shell.execute_reply": "2026-06-15T05:30:35.209786Z"
     },
     "papermill": {
-     "duration": 0.024897,
-     "end_time": "2026-06-06T07:38:55.858332",
+     "duration": 0.022976,
+     "end_time": "2026-06-15T05:30:35.215270",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.833435",
+     "start_time": "2026-06-15T05:30:35.192294",
      "status": "completed"
     },
     "tags": []
@@ -1307,10 +1184,10 @@
    "id": "50f14939",
    "metadata": {
     "papermill": {
-     "duration": 0.011983,
-     "end_time": "2026-06-06T07:38:55.883927",
+     "duration": 0.010777,
+     "end_time": "2026-06-15T05:30:35.234305",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.871944",
+     "start_time": "2026-06-15T05:30:35.223528",
      "status": "completed"
     },
     "tags": []
@@ -1334,10 +1211,10 @@
    "id": "5d067a10",
    "metadata": {
     "papermill": {
-     "duration": 0.012429,
-     "end_time": "2026-06-06T07:38:55.908332",
+     "duration": 0.009497,
+     "end_time": "2026-06-15T05:30:35.252110",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.895903",
+     "start_time": "2026-06-15T05:30:35.242613",
      "status": "completed"
     },
     "tags": []
@@ -1369,10 +1246,10 @@
    "id": "0f04c796",
    "metadata": {
     "papermill": {
-     "duration": 0.012895,
-     "end_time": "2026-06-06T07:38:55.934371",
+     "duration": 0.009175,
+     "end_time": "2026-06-15T05:30:35.271108",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.921476",
+     "start_time": "2026-06-15T05:30:35.261933",
      "status": "completed"
     },
     "tags": []
@@ -1395,16 +1272,16 @@
    "id": "e55f113d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:38:55.963733Z",
-     "iopub.status.busy": "2026-06-06T07:38:55.963217Z",
-     "iopub.status.idle": "2026-06-06T07:38:56.028190Z",
-     "shell.execute_reply": "2026-06-06T07:38:56.026668Z"
+     "iopub.execute_input": "2026-06-15T05:30:35.279271Z",
+     "iopub.status.busy": "2026-06-15T05:30:35.279271Z",
+     "iopub.status.idle": "2026-06-15T05:30:35.324556Z",
+     "shell.execute_reply": "2026-06-15T05:30:35.324556Z"
     },
     "papermill": {
-     "duration": 0.082243,
-     "end_time": "2026-06-06T07:38:56.030325",
+     "duration": 0.046093,
+     "end_time": "2026-06-15T05:30:35.326938",
      "exception": false,
-     "start_time": "2026-06-06T07:38:55.948082",
+     "start_time": "2026-06-15T05:30:35.280845",
      "status": "completed"
     },
     "tags": []
@@ -1466,10 +1343,10 @@
    "id": "ad58565a",
    "metadata": {
     "papermill": {
-     "duration": 0.013861,
-     "end_time": "2026-06-06T07:38:56.059512",
+     "duration": 0.010491,
+     "end_time": "2026-06-15T05:30:35.345547",
      "exception": false,
-     "start_time": "2026-06-06T07:38:56.045651",
+     "start_time": "2026-06-15T05:30:35.335056",
      "status": "completed"
     },
     "tags": []
@@ -1487,10 +1364,10 @@
    "id": "0b0d592b",
    "metadata": {
     "papermill": {
-     "duration": 0.015429,
-     "end_time": "2026-06-06T07:38:56.088759",
+     "duration": 0.008584,
+     "end_time": "2026-06-15T05:30:35.364646",
      "exception": false,
-     "start_time": "2026-06-06T07:38:56.073330",
+     "start_time": "2026-06-15T05:30:35.356062",
      "status": "completed"
     },
     "tags": []
@@ -1522,16 +1399,16 @@
    "id": "53ad8dc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:38:56.121761Z",
-     "iopub.status.busy": "2026-06-06T07:38:56.120745Z",
-     "iopub.status.idle": "2026-06-06T07:38:56.128903Z",
-     "shell.execute_reply": "2026-06-06T07:38:56.127477Z"
+     "iopub.execute_input": "2026-06-15T05:30:35.388216Z",
+     "iopub.status.busy": "2026-06-15T05:30:35.388216Z",
+     "iopub.status.idle": "2026-06-15T05:30:35.404058Z",
+     "shell.execute_reply": "2026-06-15T05:30:35.404058Z"
     },
     "papermill": {
-     "duration": 0.026587,
-     "end_time": "2026-06-06T07:38:56.131026",
+     "duration": 0.03672,
+     "end_time": "2026-06-15T05:30:35.410514",
      "exception": false,
-     "start_time": "2026-06-06T07:38:56.104439",
+     "start_time": "2026-06-15T05:30:35.373794",
      "status": "completed"
     },
     "tags": []
@@ -1565,10 +1442,10 @@
    "id": "d0948bcb",
    "metadata": {
     "papermill": {
-     "duration": 0.014136,
-     "end_time": "2026-06-06T07:38:56.158094",
+     "duration": 0.044366,
+     "end_time": "2026-06-15T05:30:35.479105",
      "exception": false,
-     "start_time": "2026-06-06T07:38:56.143958",
+     "start_time": "2026-06-15T05:30:35.434739",
      "status": "completed"
     },
     "tags": []
@@ -1589,9 +1466,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pyphi",
+   "display_name": "Python 3 (PyPhi/IIT)",
    "language": "python",
-   "name": "python3"
+   "name": "pyphi"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1603,18 +1480,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.9.25"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 235.834827,
-   "end_time": "2026-06-06T07:38:57.571942",
+   "duration": 56.017619,
+   "end_time": "2026-06-15T05:30:36.038340",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\IIT\\Intro_to_PyPhi.ipynb",
-   "output_path": "d:\\tmp\\h3_iit2.ipynb",
+   "input_path": "d:/dev/CoursIA/MyIA.AI.Notebooks/IIT/Intro_to_PyPhi.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/iit_unify2_1781501376/Intro_to_PyPhi.smoke.ipynb",
    "parameters": {},
-   "start_time": "2026-06-06T07:35:01.737115",
+   "start_time": "2026-06-15T05:29:40.020721",
    "version": "2.6.0"
   },
   "polyglot_notebook": {


### PR DESCRIPTION
## Constat — drift de provenance intra-famille IIT

La famille IIT (2 notebooks Python-pur) avait une provenance d'exécution **incohérente** :

| Notebook | kernelspec | `language_info.version` | État |
|----------|-----------|-------------------------|------|
| `IIT-2-AdvancedTopics` | `pyphi` ("Python 3 (PyPhi/IIT)") | **3.9.25** | canonique (env dédié #1943) |
| `Intro_to_PyPhi` | `python3` | **3.13.3** | **off-env (drift)** |

L'env canonique = conda env dédié **`pyphi`** (py3.9.25 / pyphi 1.2.0 / numpy 1.26.4), requis par #1943 — PyPhi 1.2.0 importe `from collections import Iterable`, cassé en Python ≥3.10. `Intro_to_PyPhi`, exécuté en dernier sur py3.13.3, était le notebook dérivé.

## Action — slice atomique (1 notebook)

Ré-exécution de `Intro_to_PyPhi` sur l'env `pyphi` via `papermill -k pyphi` :
- **py=3.9.25** (= sibling, = #1943) ✓
- **13/13 code cells**, **0 erreur** ✓
- **Pure re-exec** : source byte-identique à HEAD (`diff_cells=[]`)
- **Normalisation kernelspec** = sibling exact : `name: python3→pyphi`, `display_name: pyphi→"Python 3 (PyPhi/IIT)"`

### Diff de provenance (seules métadonnées hors outputs)
```
-   "display_name": "pyphi",
+   "display_name": "Python 3 (PyPhi/IIT)",
-   "name": "python3"
+   "name": "pyphi"
-   "version": "3.13.3"
+   "version": "3.9.25"
```

### Preuve papermill
```
Executing: 100%|██████████| 30/30 [00:56<00:00,  1.87s/cell]
RC=0 ; SMOKE: py=3.9.25 kernel=pyphi code=13 exec=13 err=0 → VERDICT OK
```

## Méthodologie
Signal de drift = `metadata.language_info.version` (interpréteur committé), **pas** une lib applicative — même méthodo que l'unification PyMC mergée ce cycle (#3027 / #3030 / #3033). Règle F (réparer, pas contourner) : smoke initial échoué car env `pyphi` sans `papermill` (fallback silencieux base 3.13.12) ; corrigé via `papermill` base + kernelspec `pyphi` existant (py3.9.25).

## Conformité
- **C.2** : committé AVEC outputs réels. **C.3** : staging = 1 notebook ; aucun PNG tracké dans `IIT/` ; catalogue/Z3.Linq/README non touchés.
- **H.3** : 0 exec_count None+vide. **C.1** : 0 pattern interdit.
- **Catalogue** byte-identique à `main`. **0 collision** (IIT = lane po-2025 exclusive).
- **#2161** : les 2 notebooks IIT ont déjà ≥3 exercices stubés (pas de gap).

## Autorisation
Dispatch ai-01 dashboard 2026-06-15T05:04Z : *"Next deep-queue sur ta famille Python/ML : ... OU IIT/PyPhi enrich. PAS GenAI."* Réalise l'option IIT/PyPhi (unification provenance, classe identique PyMC), non-cosmétique. Réf env : #1943. Workers ne mergent pas → attente merge ai-01.