### PR TITLE
feat(tools): count_exercises.py -- per-notebook exercise counter (#2161)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Count exercises per pedagogical notebook (issue #2161 tooling).
+
+Counts exercise cells -- the convention is >= 3 exercises per notebook. This
+tool exists because the historical scan used a strict `^#+\\s*Exercice` regex
+that UNDERCOUNTED two real cases (the G.1 finding from the #2161 audit cycle):
+
+  1. Exercise headers in forms the strict regex misses, e.g.
+        `## 8. Exercice : ...`   (numbered section header)
+        `### Exercice - Exploration`  (dash separator, no number)
+     The strict `^#+\\s*Exercice` requires the word right after the hashes with
+     no intervening number/dash, so `## 8. Exercice` was missed.
+  2. Exercise CODE cells with NO markdown header at all -- a stub code cell
+     whose first comment is `# Exercice ...` but is not preceded by any markdown
+     "Exercice" header. A header-only counter never sees these.
+
+This tool counts `\bexercice\b` ANYWHERE in a markdown header (numbered or not)
+PLUS stub code cells whose source comments reference an exercise, then
+de-duplicates so an exercise that is both a markdown header AND the following
+code cell counts once.
+
+An exercise is defined here as a STUB (work for the student), per the
+exercise/example labeling convention:
+  - markdown "Exercice" header whose following code cell is a stub, OR
+  - a stub code cell whose own source comments contain "Exercice".
+A markdown "Exemple" header + working code is an EXAMPLE, not counted.
+
+Usage:
+    python count_exercises.py                                  # all pedagogical notebooks
+    python count_exercises.py --family IIT                     # single family
+    python count_exercises.py MyIA.AI.Notebooks/IIT/Intro_to_PyPhi.ipynb   # single notebook
+    python count_exercises.py --threshold 3                    # default: flag < 3
+    python count_exercises.py --json                           # machine-readable
+    python count_exercises.py --check                          # exit 1 if any sub-threshold
+
+Exit codes:
+    0 -- no sub-threshold notebooks (or non-check mode)
+    1 -- one or more pedagogical notebooks below threshold (--check only)
+
+Excludes (same convention as count_notebooks_by_series.py): .ipynb_checkpoints,
+research, archive, _output, partner-course, examples, obj, bin, .git.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+NOTEBOOKS_DIR = REPO_ROOT / "MyIA.AI.Notebooks"
+
+EXCLUDE_DIRS = {
+    ".ipynb_checkpoints", ".git", "__pycache__", "obj", "bin",
+    "_output", "research", "archive", "partner-course", "examples",
+    ".venv", "node_modules",
+}
+
+# \bexercice\b anywhere in the line, case-insensitive, French or English form.
+# Matches `### Exercice 1`, `## 8. Exercice`, `### Exercice - ...`, `### Exercise`.
+EXERCISE_WORD_RE = re.compile(r"\bexercic(?:e|es)\b", re.IGNORECASE)
+EXERCISE_WORD_EN_RE = re.compile(r"\bexercises?\b", re.IGNORECASE)
+
+# An ATX markdown header line starts with `#` (1-6 hashes) followed by a space
+# and the header text. We deliberately do NOT match Setext headers (underlines
+# of `---`/`===`) because a horizontal rule `---` on its own line would be a
+# false positive (a `---` separator is a `<hr>`, not a header) -- this is what
+# initially mis-paired a `---` cell with the exercise code cell below it.
+MARKDOWN_HEADER_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.*)", re.MULTILINE)
+
+# Stub indicators inside a code cell source (mirrors detect_solution_leaks.py +
+# the notebook-conventions C.1 patterns). An exercise cell is a STUB; a complete
+# solution is an EXAMPLE and is not counted as an exercise.
+#
+# NOTE: `# Exercice` is intentionally NOT a stub pattern here. A bare
+# `# Exercice ...` comment with no code is a stub (caught by the <=1 effective
+# code-line rule below), but a `# Exercice ...` comment ABOVE real working code
+# is a solution/example and must NOT be classified as a stub. Detecting that a
+# code cell *mentions* an exercise is a separate concern (_code_cell_mentions_
+# exercise); whether it is a *stub* is answered only by these patterns + the
+# code-line count.
+STUB_PATTERNS = [
+    re.compile(r'print\(["\']Exercice[s]? a completer', re.IGNORECASE),
+    re.compile(r"^\s*pass\s*$", re.MULTILINE),
+    re.compile(r"\breturn\s+None\b"),
+    re.compile(r"#\s*TODO", re.IGNORECASE),
+    re.compile(r"#\s*Indice", re.IGNORECASE),
+    re.compile(r'Console\.WriteLine\(["\']Exercice', re.IGNORECASE),
+    re.compile(r"^\s*result\s*=\s*None\b", re.MULTILINE | re.IGNORECASE),
+    re.compile(r"^\s*raise\s+NotImplementedError", re.MULTILINE),
+    re.compile(r"^\s*assert\s+False\b", re.MULTILINE),
+]
+
+
+@dataclass
+class ExerciseHit:
+    """A single detected exercise occurrence with evidence."""
+
+    cell_index: int
+    cell_type: str  # 'markdown' or 'code'
+    source: str  # full cell source (joined)
+    detected_by: str  # 'markdown_header' | 'code_cell_comment'
+
+    @property
+    def preview(self) -> str:
+        # For a markdown header, show the actual header line (the one carrying
+        # the exercise word), not necessarily the first line of the cell (which
+        # may be a `---` separator or an anchor that obscures the evidence).
+        if self.cell_type == "markdown":
+            for line in self.source.split("\n"):
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    m = MARKDOWN_HEADER_RE.match(line)
+                    if m and (
+                        EXERCISE_WORD_RE.search(m.group(1))
+                        or EXERCISE_WORD_EN_RE.search(m.group(1))
+                    ):
+                        return stripped[:90]
+            # Fallback: first non-empty line.
+            for line in self.source.split("\n"):
+                if line.strip():
+                    return line.strip()[:90]
+        first_line = (self.source.split("\n") or [""])[0].strip()
+        return first_line[:90]
+
+
+@dataclass
+class NotebookCount:
+    """Exercise count for one notebook with per-hit evidence."""
+
+    path: Path
+    exercises: list[ExerciseHit] = field(default_factory=list)
+    parse_error: str | None = None
+
+    @property
+    def count(self) -> int:
+        return len(self.exercises)
+
+    @property
+    def conforming(self) -> bool:
+        # parse errors are reported separately, never a silent conform
+        return self.parse_error is None
+
+
+def _is_stub_code(source: str) -> bool:
+    """True if the code cell source looks like a student stub, not a solution.
+
+    Mirrors detect_solution_leaks.is_stub_code but broadened to the C.1
+    convention: a cell with <= 1 effective code line, or any stub marker.
+    """
+    if not source.strip():
+        return True
+    for pat in STUB_PATTERNS:
+        if pat.search(source):
+            return True
+    lines = [
+        ln.strip()
+        for ln in source.strip().split("\n")
+        if ln.strip()
+        and not ln.strip().startswith("#")
+        and not ln.strip().startswith("//")
+    ]
+    code_lines = [
+        ln for ln in lines
+        if not ln.startswith("import ") and not ln.startswith("from ")
+        and not ln.startswith("using ")
+    ]
+    return len(code_lines) <= 1
+
+
+def _code_cell_mentions_exercise(source: str) -> bool:
+    """A code cell whose comments name an exercise (`# Exercice ...`)."""
+    comments = [ln for ln in source.split("\n") if ln.strip().startswith("#")]
+    blob = "\n".join(comments)
+    return bool(EXERCISE_WORD_RE.search(blob) or EXERCISE_WORD_EN_RE.search(blob))
+
+
+def _markdown_mentions_exercise(source: str) -> bool:
+    """True if any markdown header line contains the exercise word."""
+    for m in MARKDOWN_HEADER_RE.finditer(source):
+        header_text = m.group(1)
+        if EXERCISE_WORD_RE.search(header_text) or EXERCISE_WORD_EN_RE.search(header_text):
+            return True
+    return False
+
+
+def count_exercises_in_notebook(path: Path) -> NotebookCount:
+    """Count exercises in one notebook, with per-cell evidence.
+
+    Deduplication: a markdown header at cell i followed by the matching code
+    stub at cell i+1 is ONE exercise. We pair them. A code-cell exercise with
+    no preceding markdown header is its own exercise.
+    """
+    result = NotebookCount(path=path)
+    try:
+        with open(path, "r", encoding="utf-8-sig") as f:
+            nb = json.load(f)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        result.parse_error = f"Failed to parse notebook: {exc}"
+        return result
+
+    cells = nb.get("cells", [])
+
+    # First pass: detect markdown-header exercises and their paired code stub.
+    header_cell_indices: set[int] = set()
+    for i, cell in enumerate(cells):
+        if cell.get("cell_type") != "markdown":
+            continue
+        source = "".join(cell.get("source", []))
+        if _markdown_mentions_exercise(source):
+            result.exercises.append(
+                ExerciseHit(
+                    cell_index=i,
+                    cell_type="markdown",
+                    source=source,
+                    detected_by="markdown_header",
+                )
+            )
+            header_cell_indices.add(i)
+
+    # Track which code cells are the paired stub of a header just above them
+    # so we do not double-count them in the second pass.
+    paired_code_indices: set[int] = set()
+    for idx in sorted(header_cell_indices):
+        for j in range(idx + 1, min(idx + 4, len(cells))):
+            cell = cells[j]
+            if cell.get("cell_type") == "code":
+                paired_code_indices.add(j)
+                break
+
+    # Second pass: code-cell exercises with NO preceding markdown header.
+    for i, cell in enumerate(cells):
+        if cell.get("cell_type") != "code":
+            continue
+        if i in paired_code_indices:
+            continue
+        source = "".join(cell.get("source", []))
+        if _code_cell_mentions_exercise(source) and _is_stub_code(source):
+            result.exercises.append(
+                ExerciseHit(
+                    cell_index=i,
+                    cell_type="code",
+                    source=source,
+                    detected_by="code_cell_comment",
+                )
+            )
+
+    return result
+
+
+def iter_pedagogical_notebooks(root: Path) -> list[Path]:
+    """Yield pedagogical .ipynb paths, applying the standard exclusions.
+
+    Excludes execution-artifact notebooks whose filename ends in `_output.ipynb`
+    (the papermill convention used in this repo: each lab has both
+    `LabN-Name.ipynb` and `LabN-Name_output.ipynb`; counting both double-counts).
+    """
+    out: list[Path] = []
+    if not root.exists():
+        return out
+    for nb_path in sorted(root.rglob("*.ipynb")):
+        parts = nb_path.parts
+        if any(exc in parts for exc in EXCLUDE_DIRS):
+            continue
+        if nb_path.stem.endswith("_output"):
+            continue
+        out.append(nb_path)
+    return out
+
+
+def _family_of(path: Path, notebooks_dir: Path) -> str:
+    try:
+        rel = path.relative_to(notebooks_dir)
+        return rel.parts[0] if rel.parts else "_root"
+    except ValueError:
+        return "_root"
+
+
+def run(
+    targets: list[Path],
+    threshold: int,
+    json_out: bool,
+    check: bool,
+) -> int:
+    """Execute the count over the given targets. Returns exit code for --check."""
+    if json_out:
+        return _run_json(targets, threshold)
+    return _run_text(targets, threshold, check)
+
+
+def _run_text(targets: list[Path], threshold: int, check: bool) -> int:
+    sub_threshold: list[tuple[Path, NotebookCount]] = []
+    parse_errors: list[tuple[Path, str]] = []
+    total_notebooks = 0
+    total_exercises = 0
+
+    for nb_path in targets:
+        total_notebooks += 1
+        cnt = count_exercises_in_notebook(nb_path)
+        if cnt.parse_error:
+            parse_errors.append((nb_path, cnt.parse_error))
+            continue
+        total_exercises += cnt.count
+        if cnt.count < threshold:
+            sub_threshold.append((nb_path, cnt))
+
+    print(f"Notebooks scanned : {total_notebooks}")
+    print(f"Total exercises   : {total_exercises}")
+    print(f"Threshold         : >= {threshold} per notebook")
+    print(f"Conforming        : {total_notebooks - len(sub_threshold) - len(parse_errors)}")
+    print(f"Sub-threshold     : {len(sub_threshold)}")
+    if parse_errors:
+        print(f"Parse errors      : {len(parse_errors)}")
+
+    if sub_threshold:
+        print("\n--- Sub-threshold notebooks (with evidence) ---")
+        for nb_path, cnt in sub_threshold:
+            rel = nb_path.relative_to(REPO_ROOT) if nb_path.is_absolute() else nb_path
+            print(f"\n[{cnt.count}/{threshold}] {rel}")
+            for hit in cnt.exercises:
+                print(f"    cell {hit.cell_index:>3} ({hit.cell_type:<8} {hit.detected_by}): {hit.preview}")
+    else:
+        print("\nAll scanned notebooks meet the threshold.")
+
+    if parse_errors:
+        print("\n--- Parse errors (investigate manually) ---")
+        for nb_path, err in parse_errors:
+            print(f"  {nb_path}: {err[:120]}")
+
+    if check and sub_threshold:
+        return 1
+    return 0
+
+
+def _run_json(targets: list[Path], threshold: int) -> int:
+    payload = {"threshold": threshold, "notebooks": []}
+    for nb_path in targets:
+        cnt = count_exercises_in_notebook(nb_path)
+        entry = {
+            "path": str(nb_path.relative_to(REPO_ROOT))
+            if nb_path.is_absolute()
+            else str(nb_path),
+            "count": cnt.count,
+            "conforming": cnt.count >= threshold and cnt.parse_error is None,
+            "parse_error": cnt.parse_error,
+            "evidence": [
+                {
+                    "cell_index": h.cell_index,
+                    "cell_type": h.cell_type,
+                    "detected_by": h.detected_by,
+                    "preview": h.preview,
+                }
+                for h in cnt.exercises
+            ],
+        }
+        payload["notebooks"].append(entry)
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Count exercises per pedagogical notebook (#2161).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Notebook paths or directories. Defaults to all pedagogical notebooks.",
+    )
+    parser.add_argument(
+        "--family",
+        help="Restrict to a top-level family under MyIA.AI.Notebooks/ (e.g. IIT, ML).",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=3,
+        help="Minimum exercises per notebook (default: 3, per #2161).",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_out",
+        action="store_true",
+        help="Emit machine-readable JSON.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if any notebook is below threshold (for CI / gates).",
+    )
+    args = parser.parse_args(argv)
+
+    # Resolve targets.
+    targets: list[Path] = []
+    if args.paths:
+        for raw in args.paths:
+            p = Path(raw)
+            if not p.exists():
+                print(f"warning: {raw} does not exist, skipping", file=sys.stderr)
+                continue
+            if p.is_dir():
+                targets.extend(iter_pedagogical_notebooks(p))
+            elif p.suffix == ".ipynb":
+                targets.append(p)
+    elif args.family:
+        targets = iter_pedagogical_notebooks(NOTEBOOKS_DIR / args.family)
+    else:
+        targets = iter_pedagogical_notebooks(NOTEBOOKS_DIR)
+
+    if not targets:
+        print("No notebooks matched the given targets.", file=sys.stderr)
+        return 0
+
+    return run(
+        targets,
+        threshold=args.threshold,
+        json_out=args.json_out,
+        check=args.check,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -1,0 +1,340 @@
+"""Tests for scripts/notebook_tools/count_exercises.py
+
+Covers the two #2161 G.1 trap cases that the historical strict
+`^#+\\s*Exercice` scan undercounted, plus baseline stub/header detection
+and the `_output.ipynb` execution-artifact exclusion.
+
+Pure functions, no I/O on the real repo (uses tmp_path fixtures).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_tools_dir = str(Path(__file__).resolve().parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from count_exercises import (
+    _is_stub_code,
+    count_exercises_in_notebook,
+    iter_pedagogical_notebooks,
+)
+
+
+def _write_nb(path: Path, cells: list[dict]) -> Path:
+    """Write a minimal notebook with the given cells to path."""
+    nb = {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb), encoding="utf-8")
+    return path
+
+
+def _split_source(source: str) -> list[str]:
+    """Split a source string into nbformat's list-of-lines form.
+
+    nbformat stores `source` as a list where every element EXCEPT possibly the
+    last includes its trailing newline. Splitting on '\\n' and dropping the
+    separator breaks multi-line stub detection (`_is_stub_code` joins the list
+    and then sees a single mangled line). We preserve the newlines.
+    """
+    if not source:
+        return []
+    lines = source.splitlines(keepends=True)
+    return lines
+
+
+def _md(source: str) -> dict:
+    return {"cell_type": "markdown", "source": _split_source(source), "metadata": {}}
+
+
+def _code(source: str) -> dict:
+    return {
+        "cell_type": "code",
+        "source": _split_source(source),
+        "metadata": {},
+        "execution_count": None,
+        "outputs": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Header detection
+# ---------------------------------------------------------------------------
+
+class TestHeaderDetection:
+    def test_plain_exercice_header_counts(self, tmp_path):
+        nb = _write_nb(
+            tmp_path / "a.ipynb",
+            [
+                _md("# Titre"),
+                _md("### Exercice 1 : un"),
+                _code("# TODO\npass"),
+                _md("### Exercice 2 : deux"),
+                _code("return None"),
+                _md("### Exercice 3 : trois"),
+                _code("# Indice\nx = None"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3
+        assert result.parse_error is None
+
+    def test_numbered_section_header_is_counted(self, tmp_path):
+        """Trap case: `## 8. Exercice` (numbered section header).
+
+        The strict `^#+\\s*Exercice` regex requires the word right after the
+        hashes with no intervening number/dot/space, so it missed this form.
+        Our \\bexercice\\b-anywhere header match must catch it.
+        """
+        nb = _write_nb(
+            tmp_path / "b.ipynb",
+            [
+                _md("## 8. Exercice : le piege numerote"),
+                _code("# TODO etudiant\npass"),
+                _md("## 9. Exercice"),
+                _code("return None"),
+                _md("## 10. Exercice"),
+                _code("# TODO\nx = None"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, "Numbered headers (## 8. Exercice) must count"
+
+    def test_dash_separator_header_is_counted(self, tmp_path):
+        """Trap case: `### Exercice - Exploration` (dash separator, no number)."""
+        nb = _write_nb(
+            tmp_path / "c.ipynb",
+            [
+                _md("### Exercice - Exploration"),
+                _code("# TODO\npass"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1
+
+    def test_english_exercise_header_counts(self, tmp_path):
+        nb = _write_nb(
+            tmp_path / "d.ipynb",
+            [_md("### Exercise 1"), _code("pass"), _md("### Exercise 2"), _code("pass")],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 2
+
+    def test_setext_separator_is_not_a_header(self, tmp_path):
+        """A `---` horizontal rule must NOT pair as a header over a code cell.
+
+        Regression for the mis-pairing that initially counted a `---` separator
+        as a Setext H2 and consumed the exercise code cell below it as its
+        paired stub (so the code cell was missed).
+        """
+        nb = _write_nb(
+            tmp_path / "e.ipynb",
+            [
+                _md("---\n\n## Exercice : apres separateur"),
+                _code("# TODO\npass"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        # The `---` is NOT a header; the real header `## Exercice` is cell 0.
+        assert result.count == 1
+        assert result.exercises[0].cell_index == 0
+
+
+# ---------------------------------------------------------------------------
+# Code-cell-only exercises (the second G.1 trap case)
+# ---------------------------------------------------------------------------
+
+class TestCodeCellOnlyExercise:
+    def test_code_cell_exercice_without_header_is_counted(self, tmp_path):
+        """Trap case: a stub code cell whose comments name an exercise but with
+        NO preceding markdown Exercice header. A header-only counter misses it.
+        """
+        nb = _write_nb(
+            tmp_path / "f.ipynb",
+            [
+                _md("# Titre"),
+                _md("### Exercice 1"),
+                _code("# Exercice 1 : a faire\n# TODO etudiant\npass"),
+                # NO markdown header here -- code-cell-only exercise:
+                _code("# Exercice 2 : bonus sans header\n# TODO\nreturn None"),
+                _md("### Exercice 3"),
+                _code("# Indice\npass"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            "Code-cell-only exercise (no markdown header) must count"
+        )
+        detected_as = {h.detected_by for h in result.exercises}
+        assert "markdown_header" in detected_as
+        assert "code_cell_comment" in detected_as
+
+    def test_code_cell_exercice_paired_with_header_not_double_counted(
+        self, tmp_path
+    ):
+        """A markdown header immediately followed by its stub code cell is ONE
+        exercise, not two.
+        """
+        nb = _write_nb(
+            tmp_path / "g.ipynb",
+            [
+                _md("### Exercice 1"),
+                _code("# Exercice 1 : implementation\n# TODO\npass"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1
+
+    def test_solution_code_cell_is_not_an_exercise(self, tmp_path):
+        """A code cell whose comments mention 'Exercice' but holds a COMPLETE
+        solution (not a stub) is an example, not an exercise -- not counted.
+        """
+        solution = (
+            "# Exercice 1 : solution complete\n"
+            "def solve(x):\n"
+            "    return x * 2\n"
+            "print(solve(21))\n"
+        )
+        nb = _write_nb(
+            tmp_path / "h.ipynb",
+            [
+                _md("# Titre"),
+                _code(solution),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 0
+
+
+# ---------------------------------------------------------------------------
+# Stub classification
+# ---------------------------------------------------------------------------
+
+class TestStubClassification:
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "# TODO etudiant\npass\n",
+            "# Indice\nreturn None\n",
+            'print("Exercice a completer")\n',
+            "result = None  # TODO etudiant\n",
+            "# Exercice 1 : a faire\n",
+        ],
+    )
+    def test_recognized_stubs(self, source):
+        """These patterns must classify as stubs (work for the student)."""
+        assert _is_stub_code(source) is True
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "# Exercice 1 : solution complete\n"
+            "def solve(x):\n"
+            "    return x * 2\n"
+            "print(solve(21))\n",
+            "import numpy as np\n"
+            "x = np.array([1, 2, 3])\n"
+            "print(x.mean())\n",
+        ],
+    )
+    def test_solutions_are_not_stubs(self, source):
+        """Complete working code is not a stub."""
+        assert _is_stub_code(source) is False
+
+    def test_banned_patterns_still_count_as_exercise_cell(self, tmp_path):
+        """C.1 says raise NotImplementedError / assert False / 1/0 are banned,
+        but if present they are still stubs (work for the student). The tool
+        counts the exercise; the lint pass (audit_c1_c3) flags the banned form.
+        They are orthogonal concerns.
+        """
+        nb = _write_nb(
+            tmp_path / "ban.ipynb",
+            [_md("### Exercice 1"), _code("raise NotImplementedError\n")],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1
+
+
+# ---------------------------------------------------------------------------
+# Evidence fields
+# ---------------------------------------------------------------------------
+
+class TestEvidence:
+    def test_each_hit_has_cell_index_and_preview(self, tmp_path):
+        nb = _write_nb(
+            tmp_path / "ev.ipynb",
+            [
+                _md("### Exercice 1 : premier"),
+                _code("pass"),
+                _md("### Exercice 2 : second"),
+                _code("pass"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 2
+        for hit in result.exercises:
+            assert hit.cell_index >= 0
+            assert hit.cell_type in {"markdown", "code"}
+            assert isinstance(hit.preview, str)
+            assert hit.preview  # non-empty
+
+    def test_malformed_notebook_records_parse_error(self, tmp_path):
+        bad = tmp_path / "bad.ipynb"
+        bad.write_text("{not valid json", encoding="utf-8")
+        result = count_exercises_in_notebook(bad)
+        assert result.parse_error is not None
+        assert result.count == 0
+
+
+# ---------------------------------------------------------------------------
+# iter_pedagogical_notebooks exclusions
+# ---------------------------------------------------------------------------
+
+class TestExclusions:
+    def test_excludes_output_artifacts(self, tmp_path):
+        """`Name_output.ipynb` execution artifacts are excluded to avoid
+        double-counting the lab + its papermill output.
+        """
+        (tmp_path / "Lab1-Real.ipynb").write_text("{}", encoding="utf-8")
+        (tmp_path / "Lab1-Real_output.ipynb").write_text("{}", encoding="utf-8")
+        result = iter_pedagogical_notebooks(tmp_path)
+        names = sorted(p.name for p in result)
+        assert names == ["Lab1-Real.ipynb"]
+
+    def test_excludes_checkpoint_dir(self, tmp_path):
+        cp = tmp_path / ".ipynb_checkpoints"
+        cp.mkdir()
+        (cp / "x-checkpoint.ipynb").write_text("{}", encoding="utf-8")
+        (tmp_path / "y.ipynb").write_text("{}", encoding="utf-8")
+        result = iter_pedagogical_notebooks(tmp_path)
+        assert [p.name for p in result] == ["y.ipynb"]
+
+    def test_excludes_research_archive(self, tmp_path):
+        for d in ("research", "archive", "_output"):
+            sub = tmp_path / d
+            sub.mkdir()
+            (sub / "skip.ipynb").write_text("{}", encoding="utf-8")
+        (tmp_path / "keep.ipynb").write_text("{}", encoding="utf-8")
+        result = iter_pedagogical_notebooks(tmp_path)
+        assert [p.name for p in result] == ["keep.ipynb"]
+
+
+# ---------------------------------------------------------------------------
+# Threshold / verdict integration
+# ---------------------------------------------------------------------------
+
+class TestThresholdIntegration:
+    def test_sub_threshold_notebook_flagged(self, tmp_path):
+        nb = _write_nb(
+            tmp_path / "low.ipynb",
+            [_md("### Exercice 1"), _code("pass")],  # only 1
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count < 3


### PR DESCRIPTION
## Summary

Codifies the **G.1 finding from the #2161 audit cycle**: the historical strict `^#+\s*Exercice` scan **UNDERCOUNTED** exercises in two real cases, producing false sub-3 verdicts that triggered busywork fabrication across the cluster. This was the root cause of the discrepancy po-2025 surfaced (scan said sub-3, Read-verif said already-conforming) — the scan was wrong, not the notebooks.

Deliverable from ai-01's REALLOC deep-queue (05:18Z): *"Ton finding scan-undercount est durable -> code = verite. Cree `scripts/notebook_tools/count_exercises.py` (il n'existe PAS)."*

## The two trap cases this fixes

1. **Exercise headers the strict regex misses**: `## 8. Exercice` (numbered section header) and `### Exercice - Exploration` (dash separator). Strict `^#+\s*Exercice` requires the word right after the hashes with no intervening number/dash, so it skipped these. Verified in the wild: `ML/.../Lab9-First-ADK-Agent.ipynb` has `## 8. Exercice`.

2. **Exercise CODE cells with NO markdown header**: a stub code cell whose first comment is `# Exercice ...` but is not preceded by any markdown "Exercice" header. A header-only counter never sees these. Verified in the wild: `IIT/Intro_to_PyPhi.ipynb` cell 28 (`# Exercice - Exploration` with no header above).

## How it works

`count_exercises.py` counts `\bexercice\b` ANYWHERE in an **ATX** markdown header (numbered or not — NOT Setext, so a `---` separator is not a false header) PLUS stub code cells whose comments reference an exercise, then **de-duplicates** so an exercise that is both a markdown header AND the following code cell counts once.

Also excludes `_output.ipynb` papermill artifacts (a real double-count source: each lab ships `LabN.ipynb` AND `LabN_output.ipynb` — the strict scan counted both, inflating totals and creating false sub-threshold flags).

## Evidence table (run on scope families)

| Family | Notebooks | Total exos | Conforming (>=3) | Sub-threshold |
|--------|-----------|-----------|-------------------|---------------|
| IIT    | 2         | 6         | 2                 | 0             |
| ML     | 27        | 99        | 27                | 0             |
| Search | 54        | 217       | 53                | 1 (MGS-8-EverestRelief, .NET, out of Python scope) |

ML family: 8 notebooks initially flagged sub-threshold were all `_output.ipynb` duplicates — **all 27 real notebooks conform** after the artifact exclusion. This is exactly the false-positive class the tool was built to eliminate.

## Usage

```
python scripts/notebook_tools/count_exercises.py                          # all pedagogical
python scripts/notebook_tools/count_exercises.py --family IIT             # single family
python scripts/notebook_tools/count_exercises.py path/to/nb.ipynb         # single notebook
python scripts/notebook_tools/count_exercises.py --json                   # machine-readable
python scripts/notebook_tools/count_exercises.py --check                  # CI gate (exit 1)
```

Per-hit evidence: cell index + cell type + detection method (`markdown_header` / `code_cell_comment`) + first-line preview (markdown hits show the real header line, not a `---` separator).

## Tests

22 cases in `tests/test_count_exercises.py`, pure functions on `tmp_path` (no real-repo I/O):
- The two **mandated trap cases**: numbered header `## 8. Exercice` + code-cell-only exercise with no header.
- Stub-vs-solution classification (complete code is an example, not an exercise).
- Setext-separator-is-not-a-header regression (the `---` mis-pairing bug found during dev).
- `_output.ipynb` artifact exclusion.
- No-regression: the 74 existing `count_notebooks_by_series` + `detect_solution_leaks` tests still pass.

```
22 passed in 0.13s
```

## Anti-regression check

New file only — no modification to existing tooling. `grep -r "count_exercises" scripts/` confirms no prior tool of this name existed (`count_notebooks_by_series.py` counts notebooks, not exercises).

See #2161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)