### PR TITLE
fix(ci): re-enable genai + wsl suites in scripts-tests (#2871 part 2)

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -94,17 +94,6 @@ jobs:
         # is empty under POSIX. Both are fixed; papermill/nbformat are now
         # installed above. The 7 suites run here green (354 tests, validated
         # under WSL ubuntu + CI deps). genai -> po-2023, wsl -> po-2025.
-        #
-        # One residual polluter remains under the full ubuntu collection order:
-        # test_genai_comfyui_client::TestComfyUIClientInit sees client.session as a
-        # MagicMock ('mock.Session()') instead of a real requests.Session. The
-        # three concrete pollution sources found and fixed are above (config
-        # sys.modules, Path.drive, requests sys.modules mutation); this fourth
-        # one is order-dependent and does not reproduce on Windows (3170 pass),
-        # only under the POSIX collection order on ubuntu. It is ignored here
-        # with a tracking note rather than blocking the 6 re-enabled suites;
-        # the comfyui client tests still run green in isolation (77/77) and in
-        # every partial collection tried. Root-causing it is tracked in #2871.
         run: |
           pytest \
             scripts/tests \
@@ -112,5 +101,4 @@ jobs:
             scripts/lean/tests \
             MyIA.AI.Notebooks/GameTheory/tests \
             MyIA.AI.Notebooks/QuantConnect/scripts/tests \
-            --ignore=scripts/tests/test_genai_comfyui_client.py \
             --tb=short -q

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -94,6 +94,17 @@ jobs:
         # is empty under POSIX. Both are fixed; papermill/nbformat are now
         # installed above. The 7 suites run here green (354 tests, validated
         # under WSL ubuntu + CI deps). genai -> po-2023, wsl -> po-2025.
+        #
+        # One residual polluter remains under the full ubuntu collection order:
+        # test_genai_comfyui_client::TestComfyUIClientInit sees client.session as a
+        # MagicMock ('mock.Session()') instead of a real requests.Session. The
+        # three concrete pollution sources found and fixed are above (config
+        # sys.modules, Path.drive, requests sys.modules mutation); this fourth
+        # one is order-dependent and does not reproduce on Windows (3170 pass),
+        # only under the POSIX collection order on ubuntu. It is ignored here
+        # with a tracking note rather than blocking the 6 re-enabled suites;
+        # the comfyui client tests still run green in isolation (77/77) and in
+        # every partial collection tried. Root-causing it is tracked in #2871.
         run: |
           pytest \
             scripts/tests \
@@ -101,4 +112,5 @@ jobs:
             scripts/lean/tests \
             MyIA.AI.Notebooks/GameTheory/tests \
             MyIA.AI.Notebooks/QuantConnect/scripts/tests \
+            --ignore=scripts/tests/test_genai_comfyui_client.py \
             --tb=short -q

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -58,6 +58,15 @@ jobs:
           pip install numpy pandas scipy pyarrow pytest
           pip install requests bcrypt jupyter_client
           pip install pyyaml tomli
+          # python-dotenv: scripts/whisper_int8_comparison.py (and several
+          # genai-stack modules) import `dotenv` at top level.
+          pip install python-dotenv
+          # papermill + nbformat: genai-stack/commands/notebooks.py imports
+          # papermill at top level, so test_genai_notebooks.py needs it at
+          # collection time. Both are declared deps of genai-stack
+          # (scripts/genai-stack/requirements.txt). Lets us re-include the
+          # genai test suites that were excluded as missing-dep (#2871 part 2).
+          pip install papermill nbformat
           # torch (CPU) is needed at collection time by the Sudoku/RRN test
           # modules under scripts/tests/ (they `import torch` at top level and
           # skip themselves at runtime when CUDA is absent). Without it those
@@ -77,23 +86,18 @@ jobs:
         # owned by ml-tests.yml and intentionally excluded here (it duplicates
         # torch on its own job).
         #
-        # The genai + wsl suites below need lane-specific environment that a
-        # generic CPU runner does not have — live ComfyUI/genai services and
-        # module setup (genai), and a Windows-Subsystem-for-Linux host (wsl).
-        # They are excluded here and owned by their lanes (genai -> po-2023,
-        # wsl -> po-2025) as part 2 of #2871; this job stays green so a red here
-        # is a real scripts/ regression, not a missing-env collection/mock error.
+        # The genai + wsl suites were previously excluded as missing-env
+        # (#2871 part 2): they failed on ubuntu due to (a) missing papermill
+        # dep at collection time and (b) two genuine test bugs now fixed —
+        # test_genai_docker.py polluted sys.modules['config'] for sibling
+        # tests, and wsl_papermill.win_to_wsl_path relied on Path.drive which
+        # is empty under POSIX. Both are fixed; papermill/nbformat are now
+        # installed above. The 7 suites run here green (354 tests, validated
+        # under WSL ubuntu + CI deps). genai -> po-2023, wsl -> po-2025.
         run: |
           pytest \
             scripts/tests \
-            --ignore=scripts/tests/test_genai_notebooks.py \
-            --ignore=scripts/tests/test_genai_comfyui_client.py \
-            --ignore=scripts/tests/test_genai_commands_models.py \
-            --ignore=scripts/tests/test_genai_commands_gpu.py \
             scripts/notebook_tools/tests \
-            --ignore=scripts/notebook_tools/tests/test_genai_config.py \
-            --ignore=scripts/notebook_tools/tests/test_genai_docker.py \
-            --ignore=scripts/notebook_tools/tests/test_wsl_papermill.py \
             scripts/lean/tests \
             MyIA.AI.Notebooks/GameTheory/tests \
             MyIA.AI.Notebooks/QuantConnect/scripts/tests \

--- a/scripts/notebook_tools/tests/test_genai_audio_models.py
+++ b/scripts/notebook_tools/tests/test_genai_audio_models.py
@@ -333,15 +333,23 @@ class TestE2eTestResult:
             text = '{"text": "test"}'
             headers = {"Content-Type": "application/json"}
 
-        import types
-        import sys
+        # Patch the REAL requests module's attributes (get/post/exceptions.Timeout)
+        # rather than replacing sys.modules["requests"]. audio_apis.py does
+        # `import requests` *inside* its functions, so it resolves to the real
+        # module object — patching its attributes is intercepted correctly, AND
+        # monkeypatch restores them cleanly. Replacing sys.modules["requests"]
+        # globally contaminates any module imported afterwards that captured
+        # `requests` at its own top level (e.g. comfyui_client.py:20
+        # `import requests` then `self.session = requests.Session()`), because
+        # the binding obtained during that import window stays the mock even
+        # after monkeypatch restores sys.modules. That cross-test pollution
+        # made test_genai_comfyui_client.py::TestComfyUIClientInit fail under
+        # the full-collection order on ubuntu CI (#2871).
+        import requests as _real_requests
 
-        mock_requests = types.SimpleNamespace()
-        mock_requests.post = lambda *a, **kw: MockResp()
-        mock_requests.get = lambda *a, **kw: MockResp()
-        mock_requests.exceptions = types.SimpleNamespace(Timeout=Exception)
-        # Patch sys.modules so `import requests` inside the function picks up mock
-        monkeypatch.setitem(sys.modules, "requests", mock_requests)
+        monkeypatch.setattr(_real_requests, "get", lambda *a, **kw: MockResp())
+        monkeypatch.setattr(_real_requests, "post", lambda *a, **kw: MockResp())
+        monkeypatch.setattr(_real_requests.exceptions, "Timeout", Exception)
 
         result = _aa_mod.e2e_test_service("whisper-api")
         required_keys = {"service", "status", "time_s", "size_bytes", "detail"}

--- a/scripts/notebook_tools/tests/test_genai_docker.py
+++ b/scripts/notebook_tools/tests/test_genai_docker.py
@@ -62,17 +62,20 @@ _mock_config = types.SimpleNamespace(
 )
 
 # Inject mock config into sys.modules so docker.py `from config import ...` resolves.
-# Track which keys we inject so we can cleanly remove them afterwards (targeted
-# deletion is safer than sys.modules.clear() which nukes builtins).
-_injected_keys: list[str] = []
-if "config" not in sys.modules:
-    _injected_keys.append("config")
+# Save the previous binding so we can RESTORE it afterwards (not just delete).
+# Blindly popping the key nukes a real `config` module that a sibling test
+# already imported (e.g. test_genai_config.py when both run together), leaving
+# `from config import ...` broken for the rest of the session — collection-order
+# flakiness observed under Ubuntu CI (#2871 part 2).
+_prev_config = sys.modules.get("config")
 sys.modules["config"] = _mock_config
 _dk_spec.loader.exec_module(_dk_mod)
 
-# Remove only the keys we injected — leaves all other cached modules intact.
-for _key in _injected_keys:
-    sys.modules.pop(_key, None)
+# Restore the prior binding (or remove the key if there was none).
+if _prev_config is not None:
+    sys.modules["config"] = _prev_config
+else:
+    sys.modules.pop("config", None)
 
 DockerManager = _dk_mod.DockerManager
 _run_cmd = _dk_mod._run_cmd

--- a/scripts/notebook_tools/wsl_papermill.py
+++ b/scripts/notebook_tools/wsl_papermill.py
@@ -52,11 +52,27 @@ def _default_mode() -> str:
 # WSL mode (Windows only)
 # =============================================================================
 
+_WIN_DRIVE_RE = __import__("re").compile(r"^([A-Za-z]:)[\\/](.*)$")
+
+
 def win_to_wsl_path(win_path: str) -> str:
-    """Convert Windows path to WSL path."""
-    p = Path(win_path).resolve()
-    drive = p.drive[0].lower()
-    return f"/mnt/{drive}{p.as_posix()[2:]}"
+    """Convert a Windows path (e.g. ``D:\\projects\\repo``) to its WSL mount
+    form (``/mnt/d/projects/repo``).
+
+    Works cross-platform: do NOT rely on ``pathlib.Path.drive`` — under
+    WSL/POSIX the path parser is ``PurePosixPath`` which does not recognise a
+    ``X:`` drive prefix (``p.drive == ""``), and ``Path.resolve()`` rewrites
+    the path to ``/mnt/d/...`` which strips the drive letter entirely. Detect
+    the Windows drive prefix with a regex so the conversion is identical on
+    Windows, WSL, and Linux CI (#2871 part 2). A path without a drive prefix
+    is returned unchanged.
+    """
+    m = _WIN_DRIVE_RE.match(win_path)
+    if not m:
+        return win_path  # no Windows drive prefix — already POSIX, leave as-is
+    drive = m.group(1)[0].lower()
+    rest = m.group(2).replace("\\", "/")
+    return f"/mnt/{drive}/{rest}"
 
 
 def run_wsl(cmd: str, timeout: int = 300) -> tuple[int, str, str]:

--- a/scripts/tests/test_execute_qcpy_docker.py
+++ b/scripts/tests/test_execute_qcpy_docker.py
@@ -10,9 +10,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
-# Mock optional dependencies before importing the module
+# Mock optional dependencies before importing the module.
+# Save the prior binding and restore it after the import. Without save/restore,
+# the MagicMock stays in sys.modules["requests"] for the rest of the session and
+# contaminates any later module that does `import requests` at its top level
+# (e.g. docker.py -> _dk_mod.requests becomes a MagicMock, breaking
+# test_genai_docker::TestCheckServiceHealth under the full ubuntu collection
+# order). See #2871.
+_mocked_optional_deps = {}
 for mod_name in ("websocket", "requests"):
     if mod_name not in sys.modules:
+        _mocked_optional_deps[mod_name] = None  # sentinel: was absent
         sys.modules[mod_name] = MagicMock()
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "notebook_tools"))
@@ -22,6 +30,10 @@ from execute_qcpy_docker import (
     REPO_ROOT,
     cell_needs_execution,
 )
+
+# Restore sys.modules so the optional-dep mocks don't leak to sibling suites.
+for mod_name in list(_mocked_optional_deps):
+    sys.modules.pop(mod_name, None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four genuine test bugs + missing deps were masking 7 suites as missing-env failures on ubuntu. Fix all four, add the deps, drop the excludes. All 7 suites now run green under the full ubuntu collection order.

This is **#2871 part 2 (genai lane → po-2023)**. See #2871.

## Bugs fixed (4)

**Bug 1 — `test_genai_docker.py` config pollution.** `sys.modules.pop("config")` after loading docker_manager nuked the real `config` module for sibling tests that import it later. Fix: save/restore the previous binding.

**Bug 2 — `wsl_papermill.win_to_wsl_path` cross-platform.** Relied on `Path(win_path).drive`. Under WSL/POSIX `p.drive == ""` and `Path.resolve()` strips the drive letter. Fix: regex detection of the Windows drive prefix.

**Bug 3 — `test_genai_audio_models` requests pollution.** Replaced `sys.modules["requests"]` wholesale with a SimpleNamespace mock. That contaminates modules imported afterwards that captured `requests` at top level. Fix: patch `requests.get/.post/.exceptions.Timeout` on the **real** module via `monkeypatch.setattr`.

**Bug 4 — `test_execute_qcpy_docker` requests pollution (root cause of the residual ubuntu failure).** Mocked optional deps (`websocket`, `requests`) at **module import time** without teardown — the MagicMock stayed in `sys.modules["requests"]` for the rest of the session. Under the POSIX collection order on ubuntu this module is imported before `test_genai_docker`, so `docker.py`'s top-level `import requests` bound the MagicMock into `docker.requests`, breaking `test_connection_refused` (and contaminating `comfyui_client`). On Windows the order differs and `requests` was already in `sys.modules`, so the `if not in` guard skipped — which is why it passed locally. Fix: save which deps were absent and restore `sys.modules` (pop them) right after the import.

## Deps added

- `papermill` + `nbformat` — `genai-stack/commands/notebooks.py` imports papermill at top level.
- `python-dotenv` — `whisper_int8_comparison.py` (and several genai-stack modules) import `dotenv` at top level.

## Validation

- Full combined scope (`scripts/tests` + `notebook_tools/tests`) = **3174 passed, 0 failed** after all 4 fixes.
- The 7 previously-excluded suites run green under WSL ubuntu + CI deps.
- Forced ubuntu collection order (`test_execute_qcpy_docker` before `test_genai_docker` before `test_genai_comfyui_client`) = 141 passed.
- No `--ignore` needed anymore — `test_genai_comfyui_client` is re-included.
- Catalog byte-identical to `origin/main`.

## Checklist

- [x] Scope: one subject (re-enable the excluded suites via 4 bug fixes)
- [x] Catalog byte-identical to main
- [x] No secrets, no emojis
- [x] See #2871 (partial — genai lane contribution to the part-2 triage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)