### PR TITLE
feat(arganalysis): 1-informal rung -- taxonomy + deterministic fallacy detector (See #2137)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal.ipynb
@@ -1,0 +1,753 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-header",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002246,
+     "end_time": "2026-06-15T06:20:11.054405",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.052159",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Argument_Analysis_Agentic-1-informal : Detection de sophismes par taxonomie\n",
+    "\n",
+    "**Navigation** : [README](./README.md) | [2-formal >>](./Argument_Analysis_Agentic-2-formal.ipynb)\n",
+    "\n",
+    "| Champ | Valeur |\n",
+    "|-------|--------|\n",
+    "| **Module** | SymbolicAI / Argument_Analysis |\n",
+    "| **Rung** | 1-informal (Epic #2137 Phase 1) |\n",
+    "| **Niveau** | Introduction |\n",
+    "| **Duree estimee** | 30 minutes |\n",
+    "| **Kernel** | Python 3 (pandas) |\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "\n",
+    "- [ ] Charger la **taxonomie des sophismes** (CSV `argumentum_fallacies_taxonomy.csv`, 1406 lignes) et identifier les 7 familles de premier niveau\n",
+    "- [ ] Descendre d'un niveau dans l'arbre taxonomique (depth=2) pour une famille donnee, via un filtre pandas\n",
+    "- [ ] Construire un **detecteur deterministe** (sans LLM) base sur des mots-cles, et l'appliquer sur un texte synthetique neutre\n",
+    "- [ ] Distinguer le role du detecteur par mots-cles (ce rung) du role du LLM (rungs ulterieurs) pour l'extraction semantique\n",
+    "\n",
+    "### Prerequis\n",
+    "\n",
+    "- Python 3.10+ ; le package `pandas` installe\n",
+    "- Bases de lecture d'un CSV avec pandas (`read_csv`, filtrage boolean)\n",
+    "- Aucune cle API requise (ce rung est 100% deterministe, zero appel LLM)\n",
+    "\n",
+    "> **Note anti-theatre** : ce rung charge **reellement** le CSV et execute un **vrai** filtrage pandas. Aucune sortie n'est simulee. Le detecteur par mots-cles est volontairement simpliste : son but est pedagogique (montrer la couche de matching), pas d'atteindre une haute precision. L'extraction semantique robuste est l'objet des rungs suivants (LLM + logique formelle).\n",
+    "\n",
+    "> **Confidentialite** : tous les exemples sont **synthetiques et neutres** (meteorologie, oiseaux, Socrate, phrases abstraites). Aucun corpus EPITA, aucun nom d'etudiant, aucun texte sensible. Le depot est public sur GitHub."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00157,
+     "end_time": "2026-06-15T06:20:11.057889",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.056319",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Introduction : la taxonomie des sophismes\n",
+    "\n",
+    "Un **sophisme** (fallacy) est un argument qui semble valide mais qui ne l'est pas, soit parce que les premisses ne soutiennent pas la conclusion, soit parce qu'il manipule l'auditoire. Pour detecter automatiquement un sophisme, il faut d'abord une **taxonomie** : un arbre hierarchise qui classe les sophismes par familles, sous-familles, etc.\n",
+    "\n",
+    "Ce notebook utilise la taxonomie du projet *Argumentum* (1406 entrees), organisee comme un arbre de profondeur variable :\n",
+    "\n",
+    "| `depth` | Role | Exemple |\n",
+    "|---------|------|--------|\n",
+    "| `0` | Meta-noeud racine | \"Argument fallacieux\" (1 seule ligne, a exclure) |\n",
+    "| `1` | **7 familles de premier niveau** | Insuffisance, Influence, Obstruction, ... |\n",
+    "| `2` | Sous-familles | Obstruction -> {Refus du debat, Sabotage, Ad hominem} |\n",
+    "| `3`+ | Sophismes specifiques | Ad hominem -> circonstanciel, abusif, ... |\n",
+    "\n",
+    "**Stance anti-theatre** : on charge le CSV avec `pandas.read_csv` et on filtre **reellement** les lignes. Le detecteur de la section 3 tourne sur de vraies listes de mots-cles appliquees a un texte synthetique — jamais de resultat en dur.\n",
+    "\n",
+    "| Etape | Outil | Ce qu'il fait |\n",
+    "|-------|-------|---------------|\n",
+    "| Texte naturel -> sophisme identifie | Detecteur mots-cles (ce rung) | Matching chaine, deterministe, peu precis |\n",
+    "| Texte naturel -> structure informelle | LLM (rung 3) | Extraction semantique probabiliste |\n",
+    "| Structure -> verification logique | Tweety (rung 2) | Preuve sound & complete |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-load-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001904,
+     "end_time": "2026-06-15T06:20:11.064493",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.062589",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Charger la taxonomie et identifier les 7 familles\n",
+    "\n",
+    "La cellule ci-dessous charge le CSV avec `pandas.read_csv(..., dtype=str)` — tout est traite comme chaine pour eviter les coercitions numeriques sur les colonnes `depth`, `path`, etc. On filtre ensuite `depth == '1'` pour obtenir les familles de premier niveau.\n",
+    "\n",
+    "> **Pourquoi exclure `depth == '0'` ?** Il existe un meta-noeud racine \"Argument fallacieux\" (1 ligne) qui represente le concept general de sophisme. Ce n'est pas une famille operationnelle : on l'evicte pour ne garder que les 7 vraies familles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "aa1i-load-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T06:20:11.069769Z",
+     "iopub.status.busy": "2026-06-15T06:20:11.069439Z",
+     "iopub.status.idle": "2026-06-15T06:20:11.491251Z",
+     "shell.execute_reply": "2026-06-15T06:20:11.490757Z"
+    },
+    "papermill": {
+     "duration": 0.425708,
+     "end_time": "2026-06-15T06:20:11.492117",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.066409",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total lignes CSV      : 1406\n",
+      "Meta-noeud depth=0    : 1 ligne(s) -> exclue(s) de la liste des familles\n",
+      "Familles depth=1      : 7\n",
+      "\n",
+      "=== Les 7 familles de sophismes (depth=1) ===\n",
+      "  1. Insuffisance              -- Les arguments que vous utilisez ne suffisent pas à démontrer votre propos.\n",
+      "  2. Influence                 -- Vous manipulez votre auditoire pour le persuader au lieu de le convaincre.\n",
+      "  3. Erreur mathématique       -- Votre raisonnement comporte des inexactitudes quantitatives.\n",
+      "  4. Erreur de raisonnement    -- Votre thèse repose sur un raisonnement incohérent.\n",
+      "  5. Abus de langage           -- Vous usez de subtilités linguistiques pour convaincre.\n",
+      "  6. Tricherie                 -- Vous vous affranchissez des règles tacites qui régissent un débat rationnel.\n",
+      "  7. Obstruction               -- Par un artifice, oratoire ou autre, vous faites en sorte que la discussion ne se déroule pas comme prévu.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [2] - Charger la taxonomie et afficher les 7 familles de depth=1\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Chemin relatif depuis le dossier du notebook (resolu via --cwd de Papermill)\n",
+    "CSV_PATH = 'data/argumentum_fallacies_taxonomy.csv'\n",
+    "df = pd.read_csv(CSV_PATH, dtype=str)\n",
+    "\n",
+    "# La racine depth=0 est un meta-noeud (1 ligne) : on l'exclut.\n",
+    "meta_root = df[df['depth'] == '0']\n",
+    "print(f\"Total lignes CSV      : {len(df)}\")\n",
+    "print(f\"Meta-noeud depth=0    : {len(meta_root)} ligne(s) -> exclue(s) de la liste des familles\")\n",
+    "\n",
+    "# Les 7 familles de premier niveau\n",
+    "familles = df[df['depth'] == '1'][['Famille', 'desc_fr']].reset_index(drop=True)\n",
+    "print(f\"Familles depth=1      : {len(familles)}\")\n",
+    "print()\n",
+    "print('=== Les 7 familles de sophismes (depth=1) ===')\n",
+    "for i, row in familles.iterrows():\n",
+    "    num = i + 1\n",
+    "    desc = row['desc_fr'] if pd.notna(row['desc_fr']) else '(pas de description)'\n",
+    "    print(f\"  {num}. {row['Famille']:<25} -- {desc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-load-interpret",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001936,
+     "end_time": "2026-06-15T06:20:11.496357",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.494421",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : les 7 familles de la taxonomie\n",
+    "\n",
+    "**Sortie obtenue** : 7 familles de depth=1, chacune avec une description courte.\n",
+    "\n",
+    "| Famille | Idee generale |\n",
+    "|---------|---------------|\n",
+    "| **Insuffisance** | Les premisses ne suffisent pas a prouver la conclusion |\n",
+    "| **Influence** | Manipulation emotionnelle de l'auditoire au lieu d'argumenter |\n",
+    "| **Erreur mathematique** | Inexactitude quantitative (statistiques, proportions) |\n",
+    "| **Erreur de raisonnement** | Raisonnement incoherent logiquement |\n",
+    "| **Abus de langage** | Jeu sur les mots, ambiguite linguistique |\n",
+    "| **Tricherie** | Contournement des regles tacites du debat rationnel |\n",
+    "| **Obstruction** | La discussion est empechee de se derouler normalement |\n",
+    "\n",
+    "> **Point cle** : le meta-noeud `depth=0` (\"Argument fallacieux\", 1 ligne) n'est PAS une famille. C'est la racine conceptuelle de tout l'arbre. Les 7 familles operationnelles commencent a `depth=1`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-beam-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002121,
+     "end_time": "2026-06-15T06:20:11.500186",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.498065",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Descente d'un niveau (depth=2) : la famille Obstruction\n",
+    "\n",
+    "Pour comprendre comment l'arbre se ramifie, on choisit une famille et on regarde ses **sous-familles directes** (depth=2). Prenons **Obstruction** : la famille qui regroupe les sophismes ou l'on empeche le debat d'avoir lieu normalement.\n",
+    "\n",
+    "On filtre avec deux conditions combinees par `&` : `Famille == 'Obstruction'` ET `depth == '2'`. Le resultat est un sous-DataFrame qu'on affiche avec ses colonnes utiles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "aa1i-beam-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T06:20:11.505016Z",
+     "iopub.status.busy": "2026-06-15T06:20:11.504618Z",
+     "iopub.status.idle": "2026-06-15T06:20:11.513174Z",
+     "shell.execute_reply": "2026-06-15T06:20:11.512790Z"
+    },
+    "papermill": {
+     "duration": 0.011838,
+     "end_time": "2026-06-15T06:20:11.513932",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.502094",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Sous-familles depth=2 de 'Obstruction' (3 trouvees) ===\n",
+      "\n",
+      "  [7.1] Refus du débat\n",
+      "      Exemple : Mes positions sont claires, connues de tous, et elles ne changeront pas.\n",
+      "\n",
+      "  [7.2] Saboter le débat\n",
+      "      Exemple : Allons donc dans mon bureau pour discuter de la stupidité de votre demande d'augmentation....\n",
+      "\n",
+      "  [7.3] Ad hominem\n",
+      "      Exemple : Comment pouvez-vous prétendre que votre politique de santé fonctionnera quand vous n'avez ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [4] - Descente d'un niveau : sous-familles depth=2 de la famille Obstruction\n",
+    "# On filtre le DataFrame principal : famille choisie ET depth=2.\n",
+    "FAMILLE_DEMO = 'Obstruction'\n",
+    "sous_familles = df[(df['Famille'] == FAMILLE_DEMO) & (df['depth'] == '2')][\n",
+    "    ['path', 'Famille', 'Sous-Famille', 'text_fr', 'example_fr']\n",
+    "].reset_index(drop=True)\n",
+    "\n",
+    "print(f\"=== Sous-familles depth=2 de '{FAMILLE_DEMO}' ({len(sous_familles)} trouvees) ===\")\n",
+    "for i, row in sous_familles.iterrows():\n",
+    "    text_fr = row['text_fr'] if pd.notna(row['text_fr']) else '(sans nom)'\n",
+    "    example = row['example_fr'] if pd.notna(row['example_fr']) else '(pas d exemple)'\n",
+    "    ex_str = str(example)\n",
+    "    print(f\"\\n  [{row['path']}] {text_fr}\")\n",
+    "    print(f\"      Exemple : {ex_str[:90]}{'...' if len(ex_str) > 90 else ''}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-beam-interpret",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001919,
+     "end_time": "2026-06-15T06:20:11.517740",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.515821",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : la ramification depth=2\n",
+    "\n",
+    "**Sortie obtenue** : 3 sous-familles pour Obstruction, identifiees par leur `path` hierarchique.\n",
+    "\n",
+    "| path | Sous-famille | Idee |\n",
+    "|------|--------------|------|\n",
+    "| `7.1` | Refus du debat | Refuser d'argumenter (positions non negociables) |\n",
+    "| `7.2` | Saboter le debat (Sabotage) | Detourner la discussion, la rendre impossible |\n",
+    "| `7.3` | Ad hominem | Attaquer la personne plutot que l'argument |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Le `path` (ex `7.1`, `7.2`) encode la position hierarchique : le `7` correspond a la 7e famille de depth=1 (Obstruction), le suffixe `.N` a la Neme sous-famille.\n",
+    "2. Chaque sous-famille peut elle-meme se ramifier en depth=3 (ex : Ad hominem -> circonstanciel, abusif, preemptif). L'arbre a jusqu'a 10 niveaux pour certains sophismes tres specifiques.\n",
+    "3. La colonne `example_fr` donne un exemple d'usage — utile pour calibrer un detecteur ou entrainer un classifieur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-ex1-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002391,
+     "end_time": "2026-06-15T06:20:11.521995",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.519604",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : descendre d'un niveau pour une AUTRE famille\n",
+    "\n",
+    "**Contexte** : on vient de descendre Obstruction. Le meme filtre pandas fonctionne pour n'importe quelle famille.\n",
+    "\n",
+    "**Objectif** : choisissez une famille parmi {Insuffisance, Influence, Erreur mathematique, Erreur de raisonnement, Abus de langage, Tricherie} et affichez ses sous-familles depth=2 (nom + exemple). Retournez le nombre de sous-familles trouvees.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Etape 1 : fixer `FAMILLE_EX1` a un nom parmi les 6 autres familles\n",
+    "- # Etape 2 : reutiliser le filtre `df[(df['Famille'] == FAMILLE_EX1) & (df['depth'] == '2')]`\n",
+    "- # Etape 3 : iterer et afficher chaque sous-famille avec son `text_fr`\n",
+    "- # Etape 4 : retourner/compter le nombre de sous-familles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "aa1i-ex1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T06:20:11.528200Z",
+     "iopub.status.busy": "2026-06-15T06:20:11.527955Z",
+     "iopub.status.idle": "2026-06-15T06:20:11.531316Z",
+     "shell.execute_reply": "2026-06-15T06:20:11.530925Z"
+    },
+    "papermill": {
+     "duration": 0.007907,
+     "end_time": "2026-06-15T06:20:11.532024",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.524117",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 : None a None sous-famille(s) depth=2\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : descendre d'un niveau pour une autre famille que Obstruction.\n",
+    "# Etape 1 : choisir une famille (parmi Insuffisance, Influence, Erreur mathematique,\n",
+    "#            Erreur de raisonnement, Abus de langage, Tricherie).\n",
+    "FAMILLE_EX1 = None  # TODO etudiant : remplacer par le nom d'une famille\n",
+    "\n",
+    "# Etape 2-3 : filtrer et afficher les sous-familles depth=2 de cette famille.\n",
+    "# TODO etudiant : reprendre le filtre de la cellule demo avec FAMILLE_EX1.\n",
+    "\n",
+    "# Etape 4 : nombre de sous-familles trouvees\n",
+    "nb_sous_familles_ex1 = None  # TODO etudiant : len(...) du DataFrame filtre\n",
+    "\n",
+    "print(f\"Exercice 1 : {FAMILLE_EX1} a {nb_sous_familles_ex1} sous-famille(s) depth=2\")\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-detector-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001878,
+     "end_time": "2026-06-15T06:20:11.535745",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.533867",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Detection deterministe par mots-cles sur un texte synthetique\n",
+    "\n",
+    "La descente taxonomique nous donne un **referentiel** de noms de sophismes. On construit maintenant un **detecteur** : etant donne un texte, quel sophisme de la taxonomie est probablement present ?\n",
+    "\n",
+    "Ce detecteur est **deterministe et zero-LLM** : il s'agit d'un simple dictionnaire `{nom_sophisme: [mots_cles]}`. Si un mot-cle apparait (insensible a la casse) dans le texte, le sophisme correspondant est signale. Ce couche est volontairement simpliste — sa limite (faible precision, aucun sens contextuel) est exactement ce qui motivera l'introduction du LLM dans les rungs suivants.\n",
+    "\n",
+    "> **Important** : on travaille sur des **exemples synthetiques** (phrases abstraites construites pour la demonstration). Aucun texte reel, aucune donnee sensible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "aa1i-detector-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T06:20:11.541507Z",
+     "iopub.status.busy": "2026-06-15T06:20:11.541297Z",
+     "iopub.status.idle": "2026-06-15T06:20:11.545699Z",
+     "shell.execute_reply": "2026-06-15T06:20:11.545248Z"
+    },
+    "papermill": {
+     "duration": 0.007785,
+     "end_time": "2026-06-15T06:20:11.546359",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.538574",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Texte synthetique analyse ---\n",
+      "Tous les politiciens mentent, donc celui-ci ment aussi. D apres le professeur X, c est evident. Vous etes incompetent pour dire le contraire.\n",
+      "\n",
+      "--- Sophismes detectes (3) ---\n",
+      "  - Generalisation abusive    (famille=Insuffisance, sous_famille=Generalisation abusive) trigger='tous les'\n",
+      "  - Ad hominem                (famille=Obstruction, sous_famille=Ad hominem) trigger='vous etes'\n",
+      "  - Appel a l autorite        (famille=Influence, sous_famille=Appel a l autorite) trigger='professeur'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [6] - Detecteur deterministe par mots-cles + test sur un texte synthetique\n",
+    "\n",
+    "# Dictionnaire {nom_du_sophisme: (famille, sous_famille, [mots_cles])}\n",
+    "# Les mots-cles sont choisis pour etre discriminants sur des exemples pedagogiques.\n",
+    "# Cette table est VOLONTAIREMENT courte : son but est pedagogique, pas exhaustif.\n",
+    "DETECTEUR_SOPHISMES = {\n",
+    "    \"Generalisation abusive\": (\"Insuffisance\", \"Generalisation abusive\",\n",
+    "                               [\"tous les\", \"toujours\", \"jamais\", \"chaque\", \"aucun\"]),\n",
+    "    \"Ad hominem\": (\"Obstruction\", \"Ad hominem\",\n",
+    "                   [\"vous etes\", \"incompetent\", \"malhonnete\", \"qui etes-vous\"]),\n",
+    "    \"Appel a l autorite\": (\"Influence\", \"Appel a l autorite\",\n",
+    "                           [\"expert\", \"professeur\", \"autorite\", \"selon lui\", \"comme dit\"]),\n",
+    "    \"Faux dilemme\": (\"Erreur de raisonnement\", \"Faux dilemme\",\n",
+    "                     [\"soit ... soit\", \"ou bien\", \"seules options\", \"le seul choix\"]),\n",
+    "}\n",
+    "\n",
+    "def detecter_sophismes(texte, table=DETECTEUR_SOPHISMES):\n",
+    "    \"\"\"Retourne la liste des sophismes detectes dans `texte` (matching insensible a la casse).\n",
+    "\n",
+    "    Chaque element est un dict {sophisme, famille, sous_famille, mot_cle_trigger}.\n",
+    "    Aucun appel LLM : c'est du filtrage de chaine pur.\n",
+    "    \"\"\"\n",
+    "    texte_lower = texte.lower()\n",
+    "    matches = []\n",
+    "    for nom_sophisme, (famille, sous_famille, mots_cles) in table.items():\n",
+    "        for mot in mots_cles:\n",
+    "            if mot.lower() in texte_lower:\n",
+    "                matches.append({\n",
+    "                    \"sophisme\": nom_sophisme,\n",
+    "                    \"famille\": famille,\n",
+    "                    \"sous_famille\": sous_famille,\n",
+    "                    \"mot_cle_trigger\": mot,\n",
+    "                })\n",
+    "                break  # un seul trigger par sophisme suffit\n",
+    "    return matches\n",
+    "\n",
+    "\n",
+    "# Texte synthetique neutre : pas de personne reelle, pas d opinion politique.\n",
+    "TEXTE_SYNTHETIQUE = (\n",
+    "    \"Tous les politiciens mentent, donc celui-ci ment aussi. \"\n",
+    "    \"D apres le professeur X, c est evident. \"\n",
+    "    \"Vous etes incompetent pour dire le contraire.\"\n",
+    ")\n",
+    "\n",
+    "detections = detecter_sophismes(TEXTE_SYNTHETIQUE)\n",
+    "print(\"--- Texte synthetique analyse ---\")\n",
+    "print(TEXTE_SYNTHETIQUE)\n",
+    "print()\n",
+    "print(f\"--- Sophismes detectes ({len(detections)}) ---\")\n",
+    "for d in detections:\n",
+    "    print(f\"  - {d['sophisme']:<25} (famille={d['famille']}, sous_famille={d['sous_famille']}) \"\n",
+    "          f\"trigger='{d['mot_cle_trigger']}'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-detector-interpret",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001693,
+     "end_time": "2026-06-15T06:20:11.549805",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.548112",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : sortie du detecteur\n",
+    "\n",
+    "**Sortie obtenue** : 3 sophismes signales sur le texte synthetique, chacun avec son trigger.\n",
+    "\n",
+    "| Sophisme | Famille | Trigger | Lecture |\n",
+    "|----------|---------|---------|--------|\n",
+    "| Generalisation abusive | Insuffisance | `tous les` | Le `tous les` indique une generalisation sans nuance |\n",
+    "| Appel a l'autorite | Influence | `professeur` | Invoquer une autorite (\"professeur X\") sans preuve |\n",
+    "| Ad hominem | Obstruction | `incompetent` | Attaque la personne, pas l'argument |\n",
+    "\n",
+    "**Limites volontaires de ce detecteur** :\n",
+    "1. **Pas de contexte** : `tous les oiseaux ont des plumes` declencherait aussi \"Generalisation abusive\", alors que c'est un fait. Le matching mots-cles ignore la sémantique.\n",
+    "2. **Couverture limitee** : la table contient 4 sophismes ; la taxonomie en compte des centaines. Etendre la table a la main est fastidieux — c'est la qu'un LLM devient utile.\n",
+    "3. **Aucun score de confiance** : un match est binaire (present / absent). Pas de probabilite ni de ranking.\n",
+    "\n",
+    "> **Lien avec les rungs suivants** : le rung 2 (logique formelle) verifie si un argument est valide ; le rung 3 (orchestration LLM) remplace la table mots-cles par une extraction semantique robuste. Ce rung montre la **ligne de base** (baseline) que ces techniques cherchent a ameliorer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-ex2-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002434,
+     "end_time": "2026-06-15T06:20:11.553978",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.551544",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : ajouter une regle de detection pour un sophisme au choix\n",
+    "\n",
+    "**Contexte** : la table `DETECTEUR_SOPHISMES` contient 4 entrees. Vous allez l'etendre.\n",
+    "\n",
+    "**Objectif** : ajoutez une nouvelle entree dans le dictionnaire (un sophisme de votre choix parmi ceux de la taxonomie), definissez 2-3 mots-cles pertinents, puis testez votre detecteur etendu sur une phrase synthetique que vous ecrivez.\n",
+    "\n",
+    "**Exemples de sophismes candidats** (a chercher dans le CSV filtre par `nom_vulgarisé`) : Pente glissante, Homme de paille, Appel a l'emotion, Argument circulaire.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Etape 1 : copier `DETECTEUR_SOPHISMES` dans une nouvelle variable `table_etendue`\n",
+    "- # Etape 2 : ajouter une cle avec un tuple `(famille, sous_famille, [mots_cles])`\n",
+    "- # Etape 3 : ecrire une `PHRASE_TEST` synthetique contenant un des mots-cles\n",
+    "- # Etape 4 : appeler `detecter_sophismes(PHRASE_TEST, table_etendue)` et afficher"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "aa1i-ex2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T06:20:11.560428Z",
+     "iopub.status.busy": "2026-06-15T06:20:11.560223Z",
+     "iopub.status.idle": "2026-06-15T06:20:11.564071Z",
+     "shell.execute_reply": "2026-06-15T06:20:11.563672Z"
+    },
+    "papermill": {
+     "duration": 0.007442,
+     "end_time": "2026-06-15T06:20:11.564727",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.557285",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 : 0 sophisme(s) detecte(s)\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : etendre le detecteur et tester sur une phrase synthetique.\n",
+    "# Etape 1 : copier la table existante\n",
+    "table_etendue = dict(DETECTEUR_SOPHISMES)  # TODO etudiant : point de depart\n",
+    "\n",
+    "# Etape 2 : ajouter un nouveau sophisme\n",
+    "# TODO etudiant : table_etendue['Mon sophisme'] = ('Famille', 'Sous-famille', ['mot1', 'mot2'])\n",
+    "\n",
+    "# Etape 3 : phrase synthetique de test\n",
+    "PHRASE_TEST = None  # TODO etudiant : une phrase contenant un des nouveaux mots-cles\n",
+    "\n",
+    "# Etape 4 : detection et affichage\n",
+    "detections_ex2 = []  # TODO etudiant : detecter_sophismes(PHRASE_TEST, table_etendue)\n",
+    "print(f\"Exercice 2 : {len(detections_ex2)} sophisme(s) detecte(s)\")\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-ex3-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001759,
+     "end_time": "2026-06-15T06:20:11.568184",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.566425",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : fonction qui retourne la famille du premier sophisme detecte\n",
+    "\n",
+    "**Contexte** : on veut parfois une reponse simple — \"quelle est la famille dominante de ce texte ?\" — plutot qu'une liste de tous les matches.\n",
+    "\n",
+    "**Objectif** : ecrivez une fonction `famille_premier_sophisme(texte)` qui retourne le nom de la **famille** du premier sophisme detecte dans `texte`, ou `None` si aucun match. Utilisez `detecter_sophismes` definie plus haut.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Etape 1 : appeler `detecter_sophismes(texte)` pour obtenir la liste des matches\n",
+    "- # Etape 2 : si la liste est vide, retourner `None`\n",
+    "- # Etape 3 : sinon, retourner `matches[0]['famille']`\n",
+    "- # Etape 4 : tester sur deux phrases (une qui match, une qui ne match pas)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "aa1i-ex3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T06:20:11.574305Z",
+     "iopub.status.busy": "2026-06-15T06:20:11.573992Z",
+     "iopub.status.idle": "2026-06-15T06:20:11.578197Z",
+     "shell.execute_reply": "2026-06-15T06:20:11.577164Z"
+    },
+    "papermill": {
+     "duration": 0.00768,
+     "end_time": "2026-06-15T06:20:11.578851",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.571171",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Phrase avec sophisme -> famille : None\n",
+      "Phrase sans sophisme  -> famille : None\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : famille du premier sophisme detecte.\n",
+    "def famille_premier_sophisme(texte):\n",
+    "    # TODO etudiant : utiliser detecter_sophismes(texte) et retourner\n",
+    "    # la famille du premier element, ou None si la liste est vide.\n",
+    "    # Etape 1 :\n",
+    "    matches = []  # TODO etudiant : detecter_sophismes(texte)\n",
+    "    # Etape 2-3 :\n",
+    "    return None  # TODO etudiant : remplacer par la logique\n",
+    "\n",
+    "# Etape 4 : tests\n",
+    "phrase_avec = \"Tous les chats sont noirs, c'est bien connu.\"\n",
+    "phrase_sans = \"Le ciel est bleu aujourd'hui.\"\n",
+    "famille_avec = famille_premier_sophisme(phrase_avec)\n",
+    "famille_sans = famille_premier_sophisme(phrase_sans)\n",
+    "print(f\"Phrase avec sophisme -> famille : {famille_avec}\")\n",
+    "print(f\"Phrase sans sophisme  -> famille : {famille_sans}\")\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1i-conclusion",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001872,
+     "end_time": "2026-06-15T06:20:11.582556",
+     "exception": false,
+     "start_time": "2026-06-15T06:20:11.580684",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Conclusion et recapitulatif\n",
+    "\n",
+    "Ce rung a pose les **fondations taxonomiques** de la detection de sophismes : on charge un referentiel structure (le CSV), on descend dans l'arbre par filtre pandas, puis on construit une couche de matching mots-cles. Aucune LLM, aucune simulation : tout est deterministe et reproductible.\n",
+    "\n",
+    "### Tableau recapitulatif\n",
+    "\n",
+    "| Etape | Outil | Force | Limite |\n",
+    "|-------|-------|-------|-------|\n",
+    "| **Charger la taxonomie** | `pandas.read_csv` + filtre `depth=='1'` | Referentiel de 7 familles verifiees | Le CSV est vaste (1406 lignes), il faut filtrer |\n",
+    "| **Descendre d'un niveau** | Filtre booleen `(Famille == X) & (depth == '2')` | Identification des sous-familles directes | Manuelle, famille par famille |\n",
+    "| **Detection mots-cles** | Dictionnaire `{sophisme: [mots]}` + `in` | Deterministe, zero API, transparent | Pas de contexte, faible precision |\n",
+    "\n",
+    "### Points a retenir\n",
+    "\n",
+    "1. **La taxonomie est un arbre** : `depth` encode le niveau (0=racine meta, 1=familles, 2=sous-familles, 3+=instances specifiques). Le `path` (ex `7.3`) encode la position hierarchique.\n",
+    "\n",
+    "2. **Le detecteur mots-cles est une baseline** : il montre ce qu'on peut faire sans LLM, et donc ce que le LLM devra ameliorer. Une limite importante est l'absence de contexte (`tous les oiseaux` declencherait une fausse \"Generalisation abusive\").\n",
+    "\n",
+    "3. **Confidentialite par design** : tous les exemples sont synthetiques. Pour un usage reel, le pipeline complet (rung 3) orchestre l'extraction LLM puis la verification formelle (rung 2) — jamais de stockage de texte sensible dans le depot public.\n",
+    "\n",
+    "### Prochaines etapes\n",
+    "\n",
+    "- [2-formal](./Argument_Analysis_Agentic-2-formal.ipynb) : une fois un argument identifie, verifier sa **validite logique** avec le raisonneur Tweety (PL, FOL, modal, argumentation de Dung).\n",
+    "- [3-orchestration](./Argument_Analysis_Agentic-3-orchestration.ipynb) : remplacer la table mots-cles par un LLM qui extrait la structure informative, puis deleguer la verification a Tweety."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2.496196,
+   "end_time": "2026-06-15T06:20:11.813429",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/r1_out.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-15T06:20:09.317233",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -33,7 +33,8 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 | # | Notebook | Contenu | Rôle |
 |---|----------|---------|------|
 | 0 | [Agentic-0-init](Argument_Analysis_Agentic-0-init.ipynb) | Configuration, chargement API | Setup |
-| 1 | [Agentic-1-informal_agent](Argument_Analysis_Agentic-1-informal_agent.ipynb) | Agent analyse informelle | Détection d'arguments |
+| 1 | [Agentic-1-informal](Argument_Analysis_Agentic-1-informal.ipynb) | Détection de sophismes par taxonomie (CSV 1406 nœuds) | Détection d'arguments |
+| 1* | [Agentic-1-informal_agent](Argument_Analysis_Agentic-1-informal_agent.ipynb) | *(legacy)* Agent analyse informelle | Détection d'arguments |
 | 2 | [Agentic-2-formal](Argument_Analysis_Agentic-2-formal.ipynb) | Logique formelle réelle (PL + FOL + Modal + Dung via Tweety) | Formalisation |
 | 2* | [Agentic-2-pl_agent](Argument_Analysis_Agentic-2-pl_agent.ipynb) | *(legacy)* Agent logique propositionnelle | Formalisation |
 | 3 | [Agentic-3-orchestration](Argument_Analysis_Agentic-3-orchestration.ipynb) | Orchestration multi-agents | Coordination |
@@ -55,7 +56,8 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 | Notebook | Compétence clé | Temps |
 |----------|----------------|-------|
 | **0-init** | Configurer l'environnement Python + Java, charger les clés API, vérifier la connexion Tweety/JVM | 30 min |
-| **1-informal_agent** | Construire un agent LLM qui identifie et annote les arguments dans un texte naturel | 60 min |
+| **1-informal** | Charger la taxonomie des sophismes (CSV 1406 nœuds, 7 familles), descendre d'un niveau (depth=2) et construire un détecteur déterministe par mots-clés sur un texte synthétique | 30 min |
+| **1-informal_agent** *(legacy)* | Construire un agent LLM qui identifie et annote les arguments dans un texte naturel | 60 min |
 | **2-formal** | Vérifier des arguments en logique propositionnelle, du premier ordre et modale avec le solveur réel Tweety (JVM/JPype), apéru Dung — mode fail-loud, jamais simulé | 45 min |
 | **2-pl_agent** *(legacy)* | Convertir les arguments informels en formules propositionnelles et les vérifier via SAT | 60 min |
 | **3-orchestration** | Composer les agents précédents en pipeline coordonné avec rapport de sortie structuré | 50 min |


### PR DESCRIPTION
## Summary

Rung **1-informal** of the #2137 rung-by-rung refonte of the Argument_Analysis series. A compact, self-contained notebook that loads the real fallacy taxonomy CSV and runs a deterministic keyword detector on synthetic text — **no LLM, no EPITA submodule dependency**.

This is the second rung delivered (after #3028 / 2-formal, merged). Per the #2137 plan: 1 rung = 1 PR. Lead: po-2023.

## Bricks (each: intro-md → executed-code → interpretation-md)

1. **Load the taxonomy** (`data/argumentum_fallacies_taxonomy.csv`, 1406 rows) with `pandas.read_csv(..., dtype=str)`, enumerate the **7 top-level families** (depth=1): Insuffisance, Influence, Erreur mathématique, Erreur de raisonnement, Abus de langage, Tricherie, Obstruction. The depth=0 meta-node "Argument fallacieux" is excluded as the conceptual root.
2. **Beam descent one level** (depth=2): enumerate the subfamilies of Obstruction (Refus du débat, Sabotage, Ad hominem) via a pandas boolean filter on the `path` column (`7.1`, `7.2`, `7.3`).
3. **Deterministic keyword detector** (dict mapping fallacy → keyword list) applied to a synthetic neutral text; prints family/subfamily/trigger for each match. The demo text yields 3 detections (Généralisation abusive, Ad hominem, Appel à l'autorité).

## Exercises (≥3, #2161), all stubbed per C.1

- **Exercice 1**: descend one level for a DIFFERENT family than the demo (return its subfamilies).
- **Exercice 2**: add a new keyword rule to the detector and test on a synthetic sentence.
- **Exercice 3**: write a function returning the family of the first detected fallacy (or None).

Stubs use `pass` / `print("Exercice a completer")` / `return None` — no `raise NotImplementedError` (rule C.1, verified by grep: 0 violations).

## Execution (rule C.2)

Executed via `papermill` (kernel `python3`, `--cwd` at notebook dir so the relative CSV path resolves). **6/6 code cells executed, exec_counts 1-6 contiguous, 0 errors.** Real `pandas.read_csv`, real boolean filtering, real string matching — anti-théâtre: no simulated outputs.

## Privacy (#2137 HARD)

Synthetic/neutral examples ONLY (abstract "politiciens" sentence, neutral phrases). No EPITA corpus, no real names, no sensitive text. The repo is public on GitHub.

## README

New canonical `1-informal` row; legacy `1-informal_agent` demoted to `1*` (mirrors how `2-formal` / `2-pl_agent` coexist). **CATALOG-STATUS block untouched** — the catalog regen is left to automation (cron + per-PR CI), per catalog-pr-hygiene HARD 1.

## Checklist

- [x] Scope: one subject (one rung notebook + its README row)
- [x] Catalog byte-identical to main (verified)
- [x] ≥3 exercises stubbed per C.1
- [x] Papermill execution, real outputs
- [x] Privacy: synthetic-only examples
- [x] No secrets, no emojis
- [x] See #2137 (partial — 1 of 4 remaining rungs; next: 3-orchestration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)