### PR TITLE
docs(ml): enrich 3 stub Lab READMEs (Python Agents Day1-3) onto gabarit (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/README.md
@@ -1,10 +1,37 @@
 # Lab 1 : Les Bases de la Data Science en Python
 
-Ce laboratoire est une introduction pratique aux outils fondamentaux de la data science en Python. 
+**Objectif :** Prendre en main les outils fondamentaux de la data science en Python — Pandas, Matplotlib et Scikit-Learn — sur un jeu de ventes synthétique.
 
-L'objectif est de se familiariser avec :
-- La manipulation de données via les DataFrames **Pandas**.
-- L'exploration et la visualisation de données simples.
-- Le concept de **modèle/prédiction** avec Scikit-Learn.
+Ce laboratoire ouvre la **Journée 1** du workshop. Il pose les fondations techniques manipulées dans tous les labs suivants : avant d'orchestrer des agents d'IA capables d'interroger des données (Labs 2-7), il faut savoir charger, explorer et modéliser ces données soi-même. Le fil conducteur va de la lecture d'un DataFrame jusqu'à une première prédiction par régression linéaire, puis ouvre explicitement sur l'enjeu du workshop : passer « de la data aux agents IA ».
 
-Ce lab pose les fondations techniques nécessaires pour aborder la construction d'agents d'IA capables d'interagir avec des données.
+## Objectifs d'apprentissage
+
+À la fin de ce lab, vous saurez :
+
+1. Charger et manipuler un jeu de données avec **Pandas** (lecture CSV, `info`, `describe`, `head`)
+2. Explorer, sélectionner et filtrer des données selon des conditions
+3. Visualiser des tendances avec **Matplotlib**
+4. Entraîner un modèle de **régression linéaire** simple avec Scikit-Learn (`train_test_split`, `r2_score`)
+5. Relier ces briques à la suite agentique du workshop
+
+## Données fournies
+
+- `sales_data.csv` : jeu de ventes synthétique (ventes journalières par produit), support des exemples et des exercices.
+
+## Prérequis
+
+- Python 3.10+
+- Bibliothèques : `pandas`, `matplotlib`, `scikit-learn`
+- Aucune expérience préalable en data science requise
+
+## Notebook
+
+- [Lab1-PythonForDataScience.ipynb](Lab1-PythonForDataScience.ipynb) — notebook étudiant (3 exercices : statistiques par produit, filtrage conditionnel, prédictions par produit)
+
+## Suite
+
+[Lab 2 (RFP Analysis)](../../Day2/Labs/Lab2-RFP-Analysis/README.md) entre dans l'**IA agentique** : un premier agent LangChain analyse un appel d'offre. Les Labs 4 et 5 (Journée 3) reprennent et approfondissent le socle Pandas / ML posé ici.
+
+## Navigation
+
+[<- Index Python Agents](../../../README.md) | [>> Lab 2](../../Day2/Labs/Lab2-RFP-Analysis/README.md)

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/README.md
@@ -1,5 +1,36 @@
 # Lab 4 : Data Wrangling avec Pandas
 
-**Objectif :** Apprendre à nettoyer, transformer et agréger un jeu de données réaliste avec Pandas.
+**Objectif :** Nettoyer, corriger et transformer un jeu de données « sale » réaliste avec Pandas, jusqu'à le rendre exploitable pour l'analyse.
 
-Ce laboratoire vous confrontera à un jeu de données "sale" typique de ce que l'on rencontre en Data Science. Vous apprendrez les techniques fondamentales pour préparer les données avant l'analyse et la modélisation.
+Ce laboratoire ouvre la **Journée 3** côté data. Il part du constat classique — la préparation des données occupe l'essentiel du temps d'un projet de data science (la « règle des 80/20 ») — et déroule un pipeline de nettoyage complet sur un jeu de transactions commerciales. C'est le socle de données réutilisé directement par le [Lab 5](../Lab5-Viz-ML/README.md) pour la visualisation et la modélisation.
+
+## Objectifs d'apprentissage
+
+À la fin de ce lab, vous saurez :
+
+1. Inspecter un jeu de données et diagnostiquer les valeurs manquantes
+2. Imputer intelligemment les valeurs manquantes (au-delà du simple remplissage par zéro)
+3. Corriger les types de colonnes (dates, numériques) pour fiabiliser les calculs
+4. Créer des colonnes dérivées et agréger les données pour l'analyse
+5. Détecter les anomalies (méthode IQR) et les doublons
+
+## Données fournies
+
+- `transactions.csv` : transactions commerciales brutes (colonnes `date`, `id_produit`, `categorie`, `quantite`, `prix_unitaire`), volontairement bruitées (valeurs manquantes, types incohérents, doublons).
+
+## Prérequis
+
+- [Lab 1 (Day 1)](../../../Day1/Labs/README.md) : bases Pandas (chargement, filtrage)
+- Python 3.10+ avec `pandas`
+
+## Notebook
+
+- [Lab4-DataWrangling.ipynb](Lab4-DataWrangling.ipynb) — notebook étudiant (5 étapes guidées + 3 exercices : analyse temporelle, détection d'anomalies par méthode IQR, correction de doublons)
+
+## Suite
+
+[Lab 5 (Visualisation & ML)](../Lab5-Viz-ML/README.md) repart du jeu nettoyé ici pour l'exploration visuelle (Matplotlib / Seaborn) et une première classification.
+
+## Navigation
+
+[<- Index Python Agents](../../../../README.md) | [Lab 3 <<](../../../Day2/Labs/Lab3-CV-Screening/README.md) | [>> Lab 5](../Lab5-Viz-ML/README.md)

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/README.md
@@ -1,7 +1,35 @@
 # Lab 5 : Visualisation & Machine Learning
 
-**Objectif :** Apprendre à explorer des données visuellement avec Matplotlib/Seaborn et à construire un premier modèle de Machine Learning avec Scikit-Learn.
+**Objectif :** Explorer un jeu de données par la visualisation (Matplotlib / Seaborn), puis construire et évaluer un premier modèle de classification avec Scikit-Learn.
 
-Ce laboratoire fait suite au Lab 4. Nous utiliserons le jeu de données nettoyé pour :
-1.  **Visualiser** les tendances et les insights cachés dans les données.
-2.  **Entraîner** un modèle de classification simple pour faire des prédictions.
+Ce laboratoire fait suite au [Lab 4](../Lab4-DataWrangling/README.md) : il repart du jeu de transactions nettoyé pour passer à l'**analyse exploratoire visuelle (EDA)** puis à la **modélisation**. Le fil va de quelques graphiques diagnostiques (chiffre d'affaires par catégorie, évolution journalière) jusqu'à une régression logistique évaluée — un enchaînement représentatif du début d'un projet de ML supervisé.
+
+## Objectifs d'apprentissage
+
+À la fin de ce lab, vous saurez :
+
+1. Mener une analyse exploratoire visuelle (EDA) avec **Matplotlib** et **Seaborn**
+2. Lire un graphique pour en extraire des insights métier (catégories, tendances temporelles)
+3. Préparer features et cible, puis séparer entraînement / test (`train_test_split`)
+4. Entraîner une **régression logistique** et évaluer sa performance (accuracy, matrice de confusion, courbe ROC / AUC)
+
+## Données fournies
+
+- Aucune donnée propre : ce lab réutilise `transactions.csv` du [Lab 4](../Lab4-DataWrangling/) (chemin relatif `../Lab4-DataWrangling/transactions.csv`), illustrant la continuité préparation → analyse.
+
+## Prérequis
+
+- [Lab 4 (Data Wrangling)](../Lab4-DataWrangling/README.md) : jeu de données nettoyé réutilisé ici
+- Python 3.10+ avec `pandas`, `matplotlib`, `seaborn`, `scikit-learn`
+
+## Notebook
+
+- [Lab5-Viz-ML.ipynb](Lab5-Viz-ML.ipynb) — notebook étudiant (exemple guidé + exercices : prix moyen par catégorie, distribution des prix, matrice de confusion, courbe ROC / AUC)
+
+## Suite
+
+[Lab 6 (First Agent)](../Lab6-First-Agent/README.md) bascule vers l'**IA agentique** : le modèle Scikit-Learn devient un outil qu'un agent LangChain peut appeler pour raisonner.
+
+## Navigation
+
+[<- Index Python Agents](../../../../README.md) | [Lab 4 <<](../Lab4-DataWrangling/README.md) | [>> Lab 6](../Lab6-First-Agent/README.md)


### PR DESCRIPTION
## Contexte — #2651 Partie 2 (sous-READMEs), lane po-2025:CoursIA-Python

Dispatch ai-01 (dashboard 05:57Z) : *Step 2 — prose pedagogique READMEs ML + IIT (#2651)*.

**Constat (grounding).** Les READMEs **racine** ML et IIT ont deja ete harmonises sur le gabarit #2651 (PR #2829), puis affines (diacritiques #2894/#2904/#2944/#3021) — refaire de la prose dessus = churn cosmetique (G.3). De meme, les sous-READMEs de **serie** ML.Net (376 L), DataScienceWithAgents (299 L), AgenticDataScience (313 L) sont deja enrichis (#2432/#2437/#1728). La famille IIT n'a pas de sous-README.

**Grain reel restant** = les READMEs au niveau **Lab** de `PythonAgentsForDataScience` (workshop Day1-3), heterogenes, dont **3 quasi-stubs** :

| README | Avant | Apres | Notebook source |
|--------|-------|-------|-----------------|
| `Day1/Labs/` (Lab 1) | 9 lignes | gabarit complet | `Lab1-PythonForDataScience.ipynb` (18 cells) |
| `Lab4-DataWrangling/` | 4 lignes | gabarit complet | `Lab4-DataWrangling.ipynb` (28 cells) |
| `Lab5-Viz-ML/` | 6 lignes | gabarit complet | `Lab5-Viz-ML.ipynb` (29 cells) |

## Demarche (#2651 Partie 2)

1. **Gabarit issu de l'existant, pas invente** : derive des Lab2/3/6/7 deja conformes — `**Objectif :**` / intro de positionnement / `## Objectifs d'apprentissage` / `## Donnees fournies` / `## Prerequis` / `## Notebook` / `## Suite` / `## Navigation`.
2. **Harmoniser** : les 3 stubs alignes sur ce gabarit. **Lab2/3/6/7 deja conformes = non touches** (anti-churn G.3, "ne retirer que le bruit").
3. **Enrichir fidelement** : contenu verifie par lecture des notebooks reels :
   - **Lab 1** : Pandas (lecture CSV, info/describe), exploration/filtrage, Matplotlib, sklearn `LinearRegression` + `train_test_split`/`r2_score` ; donnees `sales_data.csv` ; 3 exercices (stats par produit, filtrage conditionnel, predictions) ; conclusion "De la Data aux Agents IA".
   - **Lab 4** : pipeline nettoyage 5 etapes (inspection / valeurs manquantes / types / transformation / agregation) ; donnees `transactions.csv` (colonnes `date,id_produit,categorie,quantite,prix_unitaire`) ; 3 exercices (analyse temporelle, anomalies IQR, doublons) ; intro "regle 80/20".
   - **Lab 5** : **reutilise `transactions.csv` du Lab 4** (continuite preparation -> analyse) ; EDA Matplotlib/Seaborn + `LogisticRegression` (accuracy, matrice de confusion, ROC/AUC) ; exemple guide + exercices.

## Conformite

- **Fidelite** : chaque section adossee au contenu reel (headers, imports, fichiers data, exercices) lus dans les `.ipynb`.
- **Ton sobre**, pas de jugement de valeur (coherent Partie 1).
- **Pas de `_output.ipynb` reference** : absents de ces 3 dossiers (lien casse evite).
- **Prerequis fideles** : Lab1/4/5 = pure data-science -> PAS de cle API LLM (≠ labs agentiques 2/3/6/7).
- **0 churn catalogue** : aucun fichier `*.generated.*` ni marqueur `CATALOG-STATUS` dans le diff (ces READMEs Lab ne sont pas catalog-tracked). Branche fraiche `origin/main`.
- **Liens de navigation verifies** : toutes les cibles relatives resolvent vers des fichiers existants.
- **Atomique** : 3 fichiers, +98/-12, 1 sous-serie. 0 collision (lane ML = po-2025).

`See #2651` (contribution partielle Partie 2 — l'epic reste ouverte pour les autres sous-series).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>