### PR TITLE
fix(notebook-tools): exclude .QuantConnect/TrashBin from count_exercises scan (#2161)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -38,7 +38,9 @@ Exit codes:
     1 -- one or more pedagogical notebooks below threshold (--check only)
 
 Excludes (same convention as count_notebooks_by_series.py): .ipynb_checkpoints,
-research, archive, _output, partner-course, examples, obj, bin, .git.
+research, archive, _output, partner-course, examples, obj, bin, .git, plus
+`.QuantConnect`/`TrashBin` (QuantConnect CLI app-data + recycle bin of deleted
+project notebooks -- not pedagogical content).
 """
 
 from __future__ import annotations
@@ -57,6 +59,11 @@ EXCLUDE_DIRS = {
     ".ipynb_checkpoints", ".git", "__pycache__", "obj", "bin",
     "_output", "research", "archive", "partner-course", "examples",
     ".venv", "node_modules",
+    # QuantConnect CLI app-data: the hidden `.QuantConnect/` directory holds the
+    # CLI's metadata + `TrashBin/` (a recycle bin of deleted project research.ipynb).
+    # Counting 450+ trashed notebooks as "pedagogical" inflated the sub-threshold
+    # tally (false sub-3) -- same class of artifact gap as `_output.ipynb`.
+    ".QuantConnect", "TrashBin",
 }
 
 # \bexercice\b anywhere in the line, case-insensitive, French or English form.

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -325,6 +325,27 @@ class TestExclusions:
         result = iter_pedagogical_notebooks(tmp_path)
         assert [p.name for p in result] == ["keep.ipynb"]
 
+    def test_excludes_quantconnect_trashbin(self, tmp_path):
+        """`.QuantConnect/` is the QuantConnect CLI app-data dir; its `TrashBin/`
+        holds recycled (deleted) project research.ipynb. Counting these 450+
+        trashed notebooks as pedagogical inflated the sub-threshold tally --
+        they must be excluded (same artifact-gap class as `_output.ipynb`).
+        """
+        qc = tmp_path / "ESGF-Workspace" / ".QuantConnect" / "TrashBin"
+        qc.mkdir(parents=True)
+        # A trashed project's research notebook (the real-world shape).
+        (qc / "1777304234858_ESGF-Deleted").mkdir()
+        (qc / "1777304234858_ESGF-Deleted" / "research.ipynb").write_text(
+            "{}", encoding="utf-8"
+        )
+        # Sibling: the hidden `.QuantConnect` root itself (config etc.) -- also out.
+        (tmp_path / "ESGF-Workspace" / ".QuantConnect" / "config.json").write_text(
+            "{}", encoding="utf-8"
+        )
+        (tmp_path / "ESGF-Workspace" / "ESGF-Real.ipynb").write_text("{}", encoding="utf-8")
+        result = iter_pedagogical_notebooks(tmp_path)
+        assert [p.name for p in result] == ["ESGF-Real.ipynb"]
+
 
 # ---------------------------------------------------------------------------
 # Threshold / verdict integration


### PR DESCRIPTION
## Summary

`count_exercises.py` (shipped in #3036, propagating cluster-wide for the **#2161** `>=3 exercises/notebook` convention) was scanning the QuantConnect CLI app-data directory `.QuantConnect/TrashBin/` as if it held pedagogical notebooks. It contains **452 recycled (deleted) project `research.ipynb` files** — each counted as a sub-threshold notebook, inflating the repo-wide sub-3 tally.

| | Scanned | Sub-threshold | Total exercises |
|---|---|---|---|
| Before | 1091 | **627** (misleading) | 1769 |
| After  | 639  | **175** (accurate)  | 1769 |

Total exercises unchanged (1769) — the trashed notebooks held 0 exercises, confirming they were genuine trash, not mislabeled content.

## Why

`.QuantConnect` is a hidden application-data directory (QuantConnect CLI metadata + recycle bin) — the same artifact class as `.git` / `.ipynb_checkpoints`. Excluding it is unambiguous. This is the same class of exclusion gap the original `_output.ipynb` fix addressed: a non-pedagogical artifact directory being swept into the count.

A CI gate using `count_exercises.py --check` (exit 1 on sub-threshold) would have been permanently red on this repo because of the trash. After this fix, `--check` reflects real pedagogical content only.

## Changes
- `EXCLUDE_DIRS`: add `.QuantConnect` and `TrashBin` (redundant for intent clarity).
- `test_excludes_quantconnect_trashbin`: new test covering the real shape (`ESGF-Workspace/.QuantConnect/TrashBin/<timestamp>_Deleted/research.ipynb` + sibling `config.json`).

## Validation
- `pytest scripts/notebook_tools/tests/test_count_exercises.py` -> **23/23 pass** (22 original + 1 new).
- Repo-wide scan: TrashBin fully excluded (`grep TrashBin` -> 0 hits), sub-3 drops 627->175.
- Diff: 2 files, +29/-1, **0 catalog churn** (cf catalog-pr-hygiene).

## Scope note
Also investigated this cycle: the count_exercises Defi/Challenge blindspot (the other G.1 angle mort flagged in dashboard memory). Analysis: **theoretical only** -- no real pedagogical notebook has a false sub-3 from it (the GenAI `CHALLENGE BONUS` notebooks are already 3+ via `Exercice`), and a naive fix would be net-harmful (DeFi = "Decentralized Finance" homograph collision; prose "le defi de l'explosion combinatoire"). Left unfixed pending disambiguation design (require following code-stub for ambiguous words). Reported to coordinator.

See #2161 (no `Closes` -- partial tooling improvement, convention rollout ongoing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)