### PR TITLE
feat(lean): Conway P4 wf input -- wf_hashlifeResult_of_level_two (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1136,6 +1136,57 @@ theorem level_hashlifeResult_of_level_two (c : MacroCell)
   -- `node (leaf _) (leaf _) (leaf _) (leaf _)` of level 1, by computation.
   rfl
 
+/-- **Level-2 base of well-formedness preservation**: a well-formed level-2
+    `MacroCell` maps under `hashlifeResult` to a well-formed cell. This is the
+    wf sibling of `level_hashlifeResult_of_level_two`: the same 16-leaf shape
+    reduction lands on `step4x4 c` (a `node` of four level-0 leaves), whose
+    `.wf = true` is unconditional (`wf_step4x4`). P4 structural input: the
+    wave-1 results `r_i` of the double-nine recursion must be wf so that the
+    wave-2 `hashlifeResultAux` recursion does not hit its defensive
+    `deadLeaf` arm (Hashlife.lean fuel-exhausted fallback). -/
+theorem wf_hashlifeResult_of_level_two (c : MacroCell)
+    (hwf : c.wf = true) (hk : c.level = 2) :
+    (hashlifeResult c).wf = true := by
+  obtain ⟨a, b, d, e, rfl, ha⟩ := shape_of_level_succ c 1 hk
+  obtain ⟨hwa, hwb, hwd, hwe, hlb, hld, hle⟩ := wf_node_elim hwf
+  rw [ha] at hlb hld hle
+  obtain ⟨a1, a2, a3, a4, rfl, ha1⟩ := shape_of_level_succ a 0 ha
+  obtain ⟨b1, b2, b3, b4, rfl, hb1⟩ := shape_of_level_succ b 0 hlb
+  obtain ⟨d1, d2, d3, d4, rfl, hd1⟩ := shape_of_level_succ d 0 hld
+  obtain ⟨e1, e2, e3, e4, rfl, he1⟩ := shape_of_level_succ e 0 hle
+  obtain ⟨_, _, _, _, hla2, hla3, hla4⟩ := wf_node_elim hwa
+  obtain ⟨_, _, _, _, hlb2, hlb3, hlb4⟩ := wf_node_elim hwb
+  obtain ⟨_, _, _, _, hld2, hld3, hld4⟩ := wf_node_elim hwd
+  obtain ⟨_, _, _, _, hle2, hle3, hle4⟩ := wf_node_elim hwe
+  rw [ha1] at hla2 hla3 hla4
+  rw [hb1] at hlb2 hlb3 hlb4
+  rw [hd1] at hld2 hld3 hld4
+  rw [he1] at hle2 hle3 hle4
+  obtain ⟨v1, rfl⟩ := shape_of_level_zero a1 ha1
+  obtain ⟨v2, rfl⟩ := shape_of_level_zero a2 hla2
+  obtain ⟨v3, rfl⟩ := shape_of_level_zero a3 hla3
+  obtain ⟨v4, rfl⟩ := shape_of_level_zero a4 hla4
+  obtain ⟨v5, rfl⟩ := shape_of_level_zero b1 hb1
+  obtain ⟨v6, rfl⟩ := shape_of_level_zero b2 hlb2
+  obtain ⟨v7, rfl⟩ := shape_of_level_zero b3 hlb3
+  obtain ⟨v8, rfl⟩ := shape_of_level_zero b4 hlb4
+  obtain ⟨v9, rfl⟩ := shape_of_level_zero d1 hd1
+  obtain ⟨v10, rfl⟩ := shape_of_level_zero d2 hld2
+  obtain ⟨v11, rfl⟩ := shape_of_level_zero d3 hld3
+  obtain ⟨v12, rfl⟩ := shape_of_level_zero d4 hld4
+  obtain ⟨v13, rfl⟩ := shape_of_level_zero e1 he1
+  obtain ⟨v14, rfl⟩ := shape_of_level_zero e2 hle2
+  obtain ⟨v15, rfl⟩ := shape_of_level_zero e3 hle3
+  obtain ⟨v16, rfl⟩ := shape_of_level_zero e4 hle4
+  -- c is now a concrete level-2 node of 16 leaves; `hashlifeResult` =
+  -- `hashlifeResultAux 2 c`, the `level == 2` arm yields `step4x4 c` =
+  -- `node (leaf _) (leaf _) (leaf _) (leaf _)` of four wf level-0 leaves,
+  -- whose `.wf` is `true` by reduction: wf inspects only levels (each leaf
+  -- is level 0) and leaf-wf (each `true`), value-independent like the level
+  -- sibling above (no GoL evaluation needed). Closes by `rfl`, mirroring
+  -- `level_hashlifeResult_of_level_two`.
+  rfl
+
 /-- Exhaustive check of the P4 base case over the 16 leaf booleans of a
     (fully explicit) level-2 cell: `2^16` instances by `native_decide`. -/
 private theorem p4_base_exhaustive :


### PR DESCRIPTION
## Summary

Adds the **well-formedness sibling** of `level_hashlifeResult_of_level_two` (#2949): a well-formed level-2 `MacroCell` maps under `hashlifeResult` to a well-formed cell.

**Why:** P4 structural input. The double-nine recursion's wave-1 results `r_i` must be well-formed so that the wave-2 `hashlifeResultAux` recursion does not hit its defensive `deadLeaf` fuel-exhausted fallback (`Conway/Life/Hashlife.lean:202-205`). Same dependency tier as the proven `level_hashlifeResult_of_level_two` (#2949), `wf_step4x4`, `wf_node_quad_level` (#3012) — all structural inputs farmed to workers while ai-01 owns the core P4 verrou + P5 composition.

**Proof** mirrors the proven level sibling exactly:
1. `shape_of_level_succ` / `shape_of_level_zero` obtain chain reduces `c` to a concrete level-2 node of 16 leaves (identical skeleton to the sibling).
2. `hashlifeResult c = hashlifeResultAux 2 c`, the `level == 2` arm yields `step4x4 c`.
3. `(step4x4 c).wf` is `true` by **structural reduction**: `wf` inspects only levels (each leaf is level 0) and leaf-wf (each `true`), **value-independent** — no Game-of-Life evaluation is needed, exactly like the level sibling (whose `.level` also ignores leaf contents).
4. Closes by `rfl` (mirrors `level_hashlifeResult_of_level_two`'s closing `rfl`).

Non-research additive ingredient. No BG-prover collision: the 5 P4-verrou sorries + 2 P5 sorries are untouched (ai-01 territory).

## Lean PR discipline (rule B)

### Sorry delta (anti-regression, rule D)
| File | Before | After | Δ |
|------|--------|-------|---|
| `Conway/Life/HashlifeCorrectness.lean` | 7 | 7 | **0** |

The 7 are: 5× P4 verrou stubs/membership + 2× P5 (`p5_large_n_jump`, `p5_inductive_step` 2nd branch) — all ai-01 BG-prover territory. The new theorem `wf_hashlifeResult_of_level_two` is **sorry-free** (closes by `rfl`).

> Note: the real baseline is **7** proof-sorries (not 6). My earlier `grep` regex undercounted by missing an inline `· sorry` P5 branch. The lake build's sorry-warning list is authoritative. No regression either way (0 delta).

### Lake build SUCCESS (local, mandatory per lean-merge-discipline)
```
$ lake build Conway.Life.HashlifeCorrectness
Build completed successfully (3320 jobs)
```
(set -o pipefail on the piped invocation; exit 0.) The only warnings are: 3 pre-existing `unused simp arg` linter notes on `wf_centerInLevelPlus2` (L1056, not this PR's code) + the 7 existing `declaration uses sorry` warnings.

### Proof integrity / axiom check
No new axioms. Pure structural reduction (`rfl`); `hashlifeResult`/`step4x4`/`MacroCell.wf` are standard `def`s. Existing proven theorems (`trefoil_tricolorable` etc. are in a different module; conway_lean proofs unaffected) recompile green.

### Scope diff
- 1 file: `Conway/Life/HashlifeCorrectness.lean`
- `+51 / -0` (additive: 1 new theorem + docstring + inline comment block)
- Region: immediately after `level_hashlifeResult_of_level_two` (L1139), far from both the P4 sorry block (L1297-1346) and the P5 sorry block (L1599-1609).

## Collision check (intra-lane collision lesson, post-#3043)
- `git fetch origin && git log origin/main --grep wf_hashlifeResult` → absent.
- `gh pr list --state open --search Conway` → 0 open Conway PRs.
- Grain is **novel**: no memory pointer or prior dispatch named it; the deep-queue directive was "scan umbrella Conway #2162 grain non-research (P4/P5 = ai-01 BG-prover, 0 collision)". This theorem is a structural input, not core P4/P5.

## Deferred (not this PR)
- P4 verrou membership biconditional (the 5 P4 sorries) — ai-01 BG-prover.
- P5 `p5_large_n_jump` / `p5_inductive_step` (the 2 P5 sorries) — ai-01 BG-prover.
- P4.1 tiling-union (geometric `toGrid` offsets) — research-level, separate cycle.

See #2162 (epic stays open — additive ingredient, not a full close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)