### PR TITLE
feat(lean): Conway P5.2 wf input -- wf_padCenter2 (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1006,6 +1006,30 @@ private theorem wf_padToLevelPlus1 {nw ne sw se : MacroCell}
              MacroCell.level, he_lvl, hla, hlb, hld]
   decide
 
+/-- `padToLevelPlus1` preserves well-formedness in either arm: a leaf passes
+    through unchanged (`MacroCell.wf (.leaf _) = true`), and a node is padded
+    into a wf node by `wf_padToLevelPlus1`. General (non-destructured) form so
+    it composes, closing the gap that the destructured `{nw ne sw se}` form
+    leaves for the leaf case. -/
+private theorem wf_padToLevelPlus1_gen (c : MacroCell) (h : c.wf = true) :
+    (padToLevelPlus1 c).wf = true := by
+  cases c with
+  | leaf _ => simp only [padToLevelPlus1, MacroCell.wf]
+  | node nw ne sw se => exact wf_padToLevelPlus1 h
+
+/-- **`padCenter2` preserves well-formedness** — the composition of the two
+    `padToLevelPlus1` steps. `padCenter2` is definitionally
+    `padToLevelPlus1 (padToLevelPlus1 c)` (Hashlife.lean); this lemma delivers
+    the wf lift-by-composition advertised alongside `padToLevelPlus1` /
+    `centerInLevelPlus2`. P5.2 structural input: `hashlifeJump c =
+    hashlifeResult (padCenter2 c)` feeds `hashlifeResult_central_correct`,
+    whose hypothesis `c.wf = true` requires `(padCenter2 c).wf = true` on the
+    padded input. -/
+theorem wf_padCenter2 (c : MacroCell) (h : c.wf = true) :
+    (padCenter2 c).wf = true := by
+  show (padToLevelPlus1 (padToLevelPlus1 c)).wf = true
+  exact wf_padToLevelPlus1_gen _ (wf_padToLevelPlus1_gen c h)
+
 /-! ## P4 structural input: centerInLevelPlus2 level + wf
 
 `centerInLevelPlus2 c` embeds `c` (any level `n`) in a level-`(n+2)` cell,


### PR DESCRIPTION
## Summary

Adds `wf_padCenter2`, the **well-formedness lift-by-composition** of the two `padToLevelPlus1` steps that `padCenter2` is defined as (`padCenter2 c = padToLevelPlus1 (padToLevelPlus1 c)`, Hashlife.lean). The `padCenter2` docstring advertises this composition; this lemma delivers the wf half that was missing.

**Why:** P5.2 structural input. `hashlifeJump c = hashlifeResult (padCenter2 c)` feeds `hashlifeResult_central_correct`, whose hypothesis `c.wf = true` requires `(padCenter2 c).wf = true` on the padded input. Same structural-input tier as `wf_centerInLevelPlus2` (the P4 analog) and the `emptyOfLevel` / `padToLevelPlus1` level+wf lemmas — additive ingredients farmed to workers while ai-01 owns the core P4 verrou + P5 composition.

This is the **P5.2 counterpart** of the P4 wf input shipped in #3050 (`wf_hashlifeResult_of_level_two`). Together they provide the wf halves of both the P4 (hashlifeResult) and P5 (hashlifeJump→padCenter2) padded-input paths.

**Proof:**
1. A `private` general helper `wf_padToLevelPlus1_gen (c : MacroCell) (h : c.wf = true) : (padToLevelPlus1 c).wf = true` handles both arms: leaf passes through unchanged (`MacroCell.wf (.leaf _) = true`), node is padded by the existing destructured `wf_padToLevelPlus1`. Closes the leaf-case gap that the destructured `{nw ne sw se}` form leaves.
2. `wf_padCenter2` composes it twice: `wf_padToLevelPlus1_gen _ (wf_padToLevelPlus1_gen c h)`. Mirrors the docstring's "lift by composition" intent.

Non-research additive ingredient. No BG-prover collision: the 5 P4-verrou sorries + 2 P5 sorries are untouched (ai-01 territory).

## Lean PR discipline (rule B)

### Sorry delta (anti-regression, rule D)
| File | Before | After | Δ |
|------|--------|-------|---|
| `Conway/Life/HashlifeCorrectness.lean` | 7 | 7 | **0** |

The 7 are: 5× P4 verrou (L1270-1310) + 2× P5 (`p5_large_n_jump`, `p5_inductive_step` 2nd branch, L1572/1578) — all ai-01 BG-prover territory. The new theorems (`wf_padToLevelPlus1_gen` + `wf_padCenter2`) are **sorry-free**.

### Lake build SUCCESS (local, mandatory per lean-merge-discipline)
```
$ lake build Conway.Life.HashlifeCorrectness
Build completed successfully (3320 jobs)
```
(`set -o pipefail` on the piped invocation; exit 0.) Only warnings are pre-existing `unused simp arg` linter notes + the 7 existing `declaration uses sorry` warnings (all on unchanged sorries).

### Proof integrity / axiom check
No new axioms. Pure composition of existing proven lemmas (`wf_padToLevelPlus1`, `emptyOfLevel_wf`). 

### Scope diff
- 1 file: `Conway/Life/HashlifeCorrectness.lean`
- `+24 / -0` (additive: 1 private helper + 1 new theorem + 2 docstrings)
- Region: immediately after `wf_padToLevelPlus1` (L1007), in the padding-wf group, far from both the P4 sorry block (L1270-1310) and the P5 sorry block (L1572-1578).

## Collision check (intra-lane collision lesson, post-#3043)
- `git show origin/main:...HashlifeCorrectness.lean | grep wf_padCenter2` → only docstring references to `padCenter2`, no `wf_padCenter2` theorem. Absent from main.
- `gh pr list --state open --search padCenter2` → 0 open PRs.
- Grain is **novel**: the deep-queue directive was "scan umbrella Conway #2162 grain non-research (P4/P5 = ai-01 BG-prover, 0 collision)". This theorem is a P5.2 structural input, not core P5.

## Deferred (not this PR)
- P4 verrou membership biconditional (the 5 P4 sorries) — ai-01 BG-prover.
- P5 `p5_large_n_jump` / `p5_inductive_step` (the 2 P5 sorries) — ai-01 BG-prover.
- P4.1 tiling-union (geometric `toGrid` offsets) — research-level, separate cycle.

See #2162 (epic stays open — additive ingredient, not a full close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)