### PR TITLE
docs(probas): add Prérequis + Durée header to Pyro_RSA_Hyperbole (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb
@@ -36,6 +36,7 @@
     "- Les **imprécisions** numérales (ou *pragmatic halo*), ex. \"Il a coûté 50 dollars\" signifiant en réalité ~50.\n",
     "- L'**ironie**, en ajoutant des dimensions affectives (valence + arousal).\n",
     "\n",
+    "### Prérequis\n- Notions de programmation probabiliste et d'inférence bayésienne\n- Python : PyTorch et Pyro (`pyro-ppl`)\n\n### Durée estimée : 45 minutes\n\n",
     "*(Remarque : ce notebook suppose une version de Pyro postérieure à [4392d54], mais la plupart des fonctionnalités devraient marcher sur des versions récentes.)*"
    ]
   },


### PR DESCRIPTION
## Résumé

`Probas/Pyro_RSA_Hyperbole.ipynb` avait **Navigation + Objectifs** mais manquait deux éléments du gabarit en-tête (`notebook-conventions`) : **Prérequis** et **Durée estimée**. Dernier vrai manque en-tête identifié dans Probas côté Python (Infer = conforme ; PyMC série = gap distinct déféré à ai-01, cf dashboard).

## Changement (markdown-only, 1 fichier)

Ajout en cell-0, contenu fidèle dérivé du contenu réel du notebook :
- **Prérequis** : notions de programmation probabiliste/bayésienne + Python (PyTorch, Pyro `pyro-ppl`)
- **Durée estimée** : 45 minutes (2 modèles RSA — simple + hyperbole — plus extensions imprécision/ironie, infra inférence par recherche exhaustive)

Placé avant la remarque de version pour une lecture cohérente du bandeau.

## Conformité

- **C.2** : modification **markdown-only** → exception (aucune re-exécution requise, outputs précédents valides).
- **Byte-stable** : `+1` ligne en cell-0, **0** `execution_count` / `outputs` / catalogue touché (`git diff --stat` = 1 insertion).
- **Catalog hygiene** : aucun fichier `COURSE_CATALOG.*` ni marqueur `CATALOG-STATUS` modifié (régénération = cron sur main).
- **Anti-régression** : additif pur, aucune cellule supprimée.
- Branche fraîche sur `origin/main` (4840f506), aucune collision PR ouverte (Probas/Pyro).

See #2651