### PR TITLE
docs(sl6): add 3 ASP prose bridges to restore interleaved pedagogy

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
@@ -1751,6 +1751,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "sl6-asp-translation-bridge",
+   "metadata": {},
+   "source": [
+    "### Traduire le Knowledge Graph en programme ASP\n",
+    "\n",
+    "La cellule suivante effectue la traduction en trois temps : (1) chaque paire\n",
+    "`(s, o)` du KG devient un fait `predicat(\"s\",\"o\").`, (2) chaque regle minee dont la\n",
+    "*PCA confidence* depasse 0.5 devient une clause de Horn `tete(X,Y) :- corps(X,Z,Y).`,\n",
+    "puis (3) clingo *grounde* (instancie les variables) et calcule le **modele stable** --\n",
+    "l'ensemble des atomes vrais au point fixe. On recupere ce modele pour le comparer a\n",
+    "notre `apply_rules` Python et valider que les deux moteurs derivent la meme chose."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "8b0a3dcf",
@@ -1834,6 +1849,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "sl6-asp-verification-bridge",
+   "metadata": {},
+   "source": [
+    "### Verification : clingo retrouve-t-il notre completion ?\n",
+    "\n",
+    "Sur les *memes* faits et les *memes* regles qualifiees (les cinq regles dont la PCA\n",
+    ">= 0.5, pas seulement la regle cible), clingo et notre `apply_rules` doivent deriver\n",
+    "exactement les memes triplets. Le tableau ci-dessous compare predicat par predicat le\n",
+    "KG initial, la completion Python et la saturation clingo : un verdict `IDENTIQUE`\n",
+    "confirme que notre chainage avant artisanal etait bien un Datalog correct."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "id": "871be88a",
@@ -1900,6 +1929,27 @@
     "else:\n",
     "    print(\"\\nDivergence : clingo sature au point fixe (les regles se nourrissent\")\n",
     "    print(\"entre elles), la ou apply_rules ne fait qu'une seule passe.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl6-asp-beyond-datalog-bridge",
+   "metadata": {},
+   "source": [
+    "### Au-dela de Datalog : recursion et contraintes d'integrite\n",
+    "\n",
+    "L'equivalence ci-dessus est rassurante mais trompeuse : elle ne tient que parce que\n",
+    "nos regles minees ne s'alimentent pas entre elles. Deux capacites de l'ASP restent\n",
+    "inaccessibles a notre mineur de regles fermees a taille fixe :\n",
+    "\n",
+    "- la **recursion** -- `ancestorOf` se definit par rapport a lui-meme, un *point fixe*\n",
+    "  qu'aucune enumeration de corps de taille fixe ne peut exprimer ;\n",
+    "- les **contraintes d'integrite** -- une regle sans tete `:- corps.` *interdit* un\n",
+    "  motif, et le solveur repond `UNSAT` s'il ne peut le satisfaire, transformant la\n",
+    "  derivation en *verification*.\n",
+    "\n",
+    "La cellule suivante active ces deux leviers sur notre KG, puis injecte un cycle\n",
+    "comme contre-experience pour montrer la contrainte d'integrite en action."
    ]
   },
   {


### PR DESCRIPTION
## What

Fixes a genuine #2651 prose-depth gap in `SL-6-KnowledgeGraphs-ILP.ipynb` (SymbolicAI/SymbolicLearning, Python lane). **Pure additive markdown** — no code touched.

See #2651 (partial — prose depth along the visitor descent path).

## The gap (measured, not vibes)

The first half of the notebook (cells 4-30) follows a clean interleaved pattern: **markdown -> code -> `### Interpretation` -> `---`**, giving a `maxRun` (longest run of consecutive code cells without markdown between) of **1** throughout.

But the ASP/clingo section broke that pattern: **cells 33-36 were a run of 4 consecutive code cells** (clingo install + KG→ASP translation + clingo-vs-`apply_rules` comparison + recursion/integrity-constraint demo) with **no pedagogical markdown between them**, and only a single interpretation cell at the end (37) covering all four. A student going through the section saw 4 dense ASP programs back-to-back with no conceptual anchor.

`maxRun = 4` here was the **only** `>=4` run in the entire SymbolicAI Python family (86 notebooks scanned); everything else is `<=3`. So this is a real, isolated outlier — not a systemic gap.

## The fix (3 markdown bridges)

Inserted 3 brief framing markdown cells, each referencing the actual concepts in the following code cell (PCA confidence, grounding, *modèle stable*, `UNSAT`, `ancestorOf` recursion) and mirroring the established `### Interpretation` style:

| Bridge | Placed before | Frames |
|--------|---------------|--------|
| `### Traduire le Knowledge Graph en programme ASP` | the translation cell | the 3-step translation (facts / Horn clauses / grounding + modèle stable) |
| `### Vérification : clingo retrouve-t-il notre complétion ?` | the comparison cell | why the per-predicate `IDENTIQUE` verdict validates our Datalog |
| `### Au-delà de Datalog : récursion et contraintes d'intégrité` | the recursion/constraint cell | why recursion + integrity constraints are beyond fixed-size rule mining |

`maxRun 4 -> 1` — the ASP section now matches the structural standard of the ILP section.

## Hygiene

- **Pure additive**: 50 insertions, 0 deletions. No code cell `source`/`execution_count`/`outputs` changed (C.2 markdown-only exception — existing outputs remain valid, no re-execution needed).
- **Atomic**: single notebook, single concern (C.3 scope respected).
- **Branch cut fresh from `origin/main`** (`4840f506`) — I detected and dropped a local `f0c47d6d` commit belonging to the parallel po-2025 session's Pyro_RSA branch (collision avoidance, lesson from #3049/#3051).
- **Validation**: `validate_pr_notebooks.py` 1/1 PASS (18 code cells), `notebook_lint.py` 1/1 pass.

## Audit context (anti-churn, G.5)

This was found via a structural pedagogy audit (maxRun + interpretation coverage) across all 86 SymbolicAI Python notebooks. The audit is otherwise conclusive: **the SymbolicAI Python family is conformant** — all other notebooks are `maxRun <= 3` with coverage `>= 0.88`. SL-6 was the single genuine outlier. Combined with the prior GameTheory audit (conformant), the Python-lane #2161/#2651 queue is genuinely drained; this PR is the last real gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)