### PR TITLE
feat(lean): Conway P5 level lift — level_padCenter2 (See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1030,6 +1030,29 @@ theorem wf_padCenter2 (c : MacroCell) (h : c.wf = true) :
   show (padToLevelPlus1 (padToLevelPlus1 c)).wf = true
   exact wf_padToLevelPlus1_gen _ (wf_padToLevelPlus1_gen c h)
 
+/-- **`padCenter2` lifts the level by 2** (level companion of
+    `wf_padCenter2`). On a node `c` (hence `1 ≤ c.level`), composing
+    `padToLevelPlus1` twice raises the level by exactly 2: inner pad
+    yields `c.level + 1`, outer pad of the resulting node yields
+    `c.level + 2`. Mirrors the destructured `level_padToLevelPlus1`
+    (L974) but in the consumer-friendly form `(hk : 1 ≤ c.level)`, same
+    shape as `padCenter2_correct` (L636) so they chain. Closes the
+    level-side of the `padCenter2` lift advertised alongside
+    `wf_padCenter2`. -/
+theorem level_padCenter2 (c : MacroCell) (hk : 1 ≤ c.level) :
+    (padCenter2 c).level = c.level + 2 := by
+  cases c with
+  | leaf b =>
+    -- leaves have level 0, contradicting 1 ≤ c.level
+    simp only [MacroCell.level] at hk
+    omega
+  | node nw ne sw se =>
+    show (padToLevelPlus1 (padToLevelPlus1
+            (MacroCell.node nw ne sw se))).level
+          = (MacroCell.node nw ne sw se).level + 2
+    simp only [padToLevelPlus1, MacroCell.level, emptyOfLevel_level]
+    omega
+
 /-! ## P4 structural input: centerInLevelPlus2 level + wf
 
 `centerInLevelPlus2 c` embeds `c` (any level `n`) in a level-`(n+2)` cell,


### PR DESCRIPTION
## Summary

Level companion of `wf_padCenter2` (PR #3053, mergé): on a node `c` (équivalent `1 ≤ c.level`), composer `padToLevelPlus1` deux fois élève le niveau de exactement 2.

```lean
level_padCenter2 (c : MacroCell) (hk : 1 ≤ c.level) :
    (padCenter2 c).level = c.level + 2
```

## Pourquoi maintenant

Mirror la forme destructurée privée `level_padToLevelPlus1` (L974) — mais en **forme consumer-friendly** `(hk : 1 ≤ c.level)`, **même shape** que `padCenter2_correct` (L636) → ils chainent directement. Ferme le côté *level* du lift `padCenter2` annoncé à côté de `wf_padCenter2`.

Ensemble (`level_padCenter2` + `wf_padCenter2`), ils fournissent l'**entrée structurelle complète** (level + wf) pour l'étape `hashlifeJump c = hashlifeResult (padCenter2 c)` dans **P5.2** : la post-condition `hashlifeResult_central_correct` (L1380) requiert à la fois la *well-formedness* de la cellule paddée **et** son niveau (`= k + 2`).

## Scope

- **Touche** : `MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean`, **+23 lignes / −0 / 1 fichier** (insertion juste après `wf_padCenter2` L1031).
- **Ne touche pas** : aucune des sorries P4/P5 verrou (L1321-1361 = 5x P4 + L1623/1629 = 2x P5 = **ai-01 BG-prover territory**). Strict additif sorry-free.

## Preuve (7 lignes)

- Arm `leaf b` : `simp only [MacroCell.level] at hk; omega` discharge `1 ≤ 0`.
- Arm `node nw ne sw se` : `simp only [padToLevelPlus1, MacroCell.level, emptyOfLevel_level]; omega` — **même machinerie** que `level_padToLevelPlus1` (L974). `padCenter2` est définitionnellement `padToLevelPlus1 ∘ padToLevelPlus1`, donc le show ramène à la composition mécanique.

## Build / sorry baseline

- `lake build` Windows native (toolchain v4.30.0-rc2) : **3352 jobs SUCCESS**.
- Sorry baseline préservée : **7 = 7** (5x P4 verrou L1344, 1354, 1364, 1375, 1384 + 2x P5 L1646, 1652 ; les lignes ont shifté +23 cause des insertions, comptage identique).

## Position dans la deep-queue Conway non-research

Per dispatch ai-01 09:59Z (workspace-CoursIA dashboard, post-merges #3050+#3053+#3058) :
> Deep-queue résiduel : wf composition lift residual + P5.2 obstacle scan. P4/P5 verrous = ai-01 BG-prover (0 collision).

Cette PR = **`wf composition lift residual`** explicit dispatch (côté level — `wf_padCenter2` déjà fait côté wf via #3053). Le scan P5.2 obstacle reste à effectuer (cycle suivant) ; il identifiera vraisemblablement la dépendance directe sur `hashlifeResult_central_correct` (= P4 verrou ai-01 BG-prover).

## Test plan

- [x] Lake build SUCCESS local (3352 jobs, sorry list intacte)
- [x] Sorry delta 7=7 vérifié (additif sorry-free)
- [x] `git diff --stat` cohérent (+23/-0 1 fichier)
- [x] Insertion-point clean : juste après `wf_padCenter2` L1031, avant section `## P4 structural input: centerInLevelPlus2`
- [ ] CI `Lean Conway CI` SUCCESS (en attente)
- [ ] CI `Catalog Guard` PASS (PR ne touche pas le catalogue)

See #2162

🤖 Generated with [Claude Code](https://claude.com/claude-code)