### PR TITLE
docs(pymc): fix PyMC-12 broken header table + add PyMC-1-Setup headers (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
@@ -20,12 +20,16 @@
     "\n",
     "**Equivalent Infer.NET** : [Infer-1-Setup](../Infer/Infer-1-Setup.ipynb)\n",
     "\n",
+    "**Duree estimee** : 40 minutes\n",
+    "\n",
     "**Objectifs** :\n",
     "- Installer et configurer PyMC dans un notebook Jupyter\n",
     "- Comprendre le workflow : Modele → Echantillonnage → Posterior\n",
     "- Implementer le probleme des deux pieces (Two Coins)\n",
     "- Maitriser les priors conjugues Beta-Bernoulli\n",
-    "- Comparer avec l'approche Infer.NET"
+    "- Comparer avec l'approche Infer.NET\n",
+    "\n",
+    "**Prerequis** : Aucun (premier notebook de la serie)\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Recommenders.ipynb
@@ -20,12 +20,10 @@
     "\n",
     "**Adapte de** : Infer-12-Recommenders (Infer.NET / C#)\n",
     "\n",
-    "| Aspect | Detail |\n",
-    "|--------|--------|\n",
-    "**Objectif** | Implementer des systemes de recommandation bayesiens avec PyMC |\n",
-    "**Prerequis** | PyMC-01 a PyMC-11, bases d'algebre lineaire |\n",
-    "**Durree** | ~45 minutes |\n",
-    "**Outils** | PyMC, ArviZ, NumPy, SciPy, Matplotlib |"
+    "**Objectifs** : Implementer des systemes de recommandation bayesiens avec PyMC\n",
+    "**Prerequis** : PyMC-01 a PyMC-11, bases d'algebre lineaire\n",
+    "**Duree estimee** : 45 minutes\n",
+    "**Outils** : PyMC, ArviZ, NumPy, SciPy, Matplotlib"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Residual PyMC header gap — handoff G.1 from the parallel po-2025 session (10:31Z) + confirmed by ai-01 (10:59Z): « Residual PyMC handoff: PyMC-12 (table cassée + typo Durree) + PyMC-1-Setup (manque header) = vraies défauts → PR séparée si repris ».

Two real defects in the PyMC series, both fixed in markdown-only cell-0 edits:

### PyMC-12-Recommenders — broken header table (rendering bug)
The cell-0 metadata table was BROKEN: the data rows lacked the leading `|` delimiter, so the table did **not render** on GitHub/Jupyter (the metadata appeared as plain text instead of a table):

**Before (broken — no leading `|`, no rendering):**
```
| Aspect | Detail |
|--------|--------|
**Objectif** | Implementer des systemes de recommandation bayesiens avec PyMC |
**Prerequis** | PyMC-01 a PyMC-11, bases d'algebre lineaire |
**Durree** | ~45 minutes |
**Outils** | PyMC, ArviZ, NumPy, SciPy, Matplotlib |
```

**After (canonical standalone format — matches all PyMC siblings):**
```
**Objectifs** : Implementer des systemes de recommandation bayesiens avec PyMC
**Prerequis** : PyMC-01 a PyMC-11, bases d'algebre lineaire
**Duree estimee** : 45 minutes
**Outils** : PyMC, ArviZ, NumPy, SciPy, Matplotlib
```

Converted to the standalone `**key** : value` line format that ALL sibling notebooks already use (PyMC-10/11/13 + the 2-9 batch from #3060). Also fixes the `Durree` typo → `Duree estimee` (series convention).

### PyMC-1-Setup — missing series-entry headers
The series entry (1/20) had Navigation + Objectifs but lacked the standardized `Duree estimee` + `Prerequis` en-tete. Added `**Duree estimee** : 40 minutes` and `**Prerequis** : Aucun (premier notebook de la serie)` in the standalone format matching its existing `**Objectifs**` block.

## Validation

- **Markdown-only**: zero code-cell changes -> 0 re-execution required (C.2 markdown-only exception, C.3 scope). Diff isolated to cell 0.
- `validate_pr_notebooks.py` 2/2 PASS.
- `git diff --stat`: 2 files changed, 10 insertions(+), 8 deletions(-).
- Confirmed 0 `execution_count`/`outputs` churn (grep verified).
- ASCII style matches local PyMC convention (no accents: Duree estimee, Prerequis) per CLAUDE.md.
- Base fresh vs `origin/main` (0 behind).

## Scope

One subject (PyMC residual header fixes), 2 notebooks, single domain (Probas/PyMC). See #2651 (completes the PyMC family header parity after #3060).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
