### PR TITLE
docs(qc): verify CausalEventAlpha post-#2801 (0.78 -> 0.45, downgraded historique)

### DIFF
--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -44,7 +44,7 @@ Strategies with solid risk-adjusted returns. These are the primary candidates fo
 | 10 | Multi-Layer-EMA | IND | Crypto (BTC) | ~~0.93~~ → **0.80** ✓post-#2801 | 25.0 | 57.1 | 0.44 | robuste (confirmed -14%, ML crypto holds, PSR 23.9%, MaxDD -57% BTC) |
 | 11 | Portfolio-Optimization-ML | ML | Multi-asset | ~~0.90~~ → **0.88** ✓post-#2801 | 27.2 | 41.6 | 0.65 | robuste (confirmed -2%, monthly rebalance + fee-homogeneous US equity basket = near-immune, PSR 37.2%) |
 | 12 | EMA-Cross-Stocks | IND | Equities | ~~0.87~~ → **0.99** ✓post-#2801 | 29.2 | 35.7 | 0.82 | robuste (PSR 49.7%, borderline significant) |
-| 13 | CausalEventAlpha | ML | Equities | 0.78 | 16.8 | — | — | robuste |
+| 13 | CausalEventAlpha | ML | Equities | ~~0.78~~ → **0.45** ✓post-#2801 | 11.7 | 38.8 | 0.30 | **historique** (downgraded -43%, monthly cadence but full-basket rotation = high turnover, PSR 5.5%) |
 | 14 | Gaussian-Direction-Classifier | ML | Equities | 0.76 | — | — | — | robuste |
 | 15 | ML-Temporal-CNN | DL | Equities (QQQ) | ~~0.73~~ → **0.46** ✓post-#2801 | 12.5 | 30.8 | 0.41 | **historique** (downgraded -37%, DL/CNN overfits real fees, PSR 5.2%) |
 | 16 | TrendStocksLite | IND | Equities | 0.72 | 18.2 | — | — | robuste |
@@ -102,8 +102,9 @@ brokerage = the #2801 Lot 1 remediation). Results vs the pre-remediation catalog
 | LongShortHarvest | 32921183 | 3.39 | **1.64** | -52% | robuste (confirmed, **PSR 98.7%** top — catalog was 1Y-OOS, baseline-clone) |
 | DynamicVIXSpyRegime | 32921262 | 1.72 | **1.00** | -42% | robuste (confirmed, **PSR 69.4%** — catalog was 1Y-OOS, baseline-clone) |
 | Portfolio-Optimization-ML | 29318874 | 0.90 | **0.88** | -2% | robuste (confirmed, monthly-rebalance fee-homogeneous equity basket near-immune, PSR 37.2%) |
+| CausalEventAlpha | 29809163 | 0.78 | **0.45** | -43% | **historique** (was robuste — monthly cadence but full-basket sector rotation = high turnover, PSR 5.5%) |
 
-**Finding (methodological, now 21-strategy sample)** : the remediation impact is **not
+**Finding (methodological, now 22-strategy sample)** : the remediation impact is **not
 uniform**, and the batch-4 results *refine and partly correct* the earlier 10-strategy pattern.
 The distinguishing axis is **not** asset class, nor ML-vs-indicator alone — it is the
 combination of (a) the fee-per-trade the asset class carries and (b) how the strategy turns
@@ -127,7 +128,13 @@ over against that fee. Four regimes now observed:
   AllWeather, rotates *within a single fee-homogeneous equity class* (<0.25 bps/trade), so its slow
   signals incur negligible cost. AllWeather's -30% drop came from its bonds/gold sleeve crossing
   higher per-trade friction. The discriminator is thus **signal-frequency × fee-homogeneity of the
-  traded basket**, not asset-class alone.**
+  traded basket**, not asset-class alone.** Batch 7 sharpens this further: cadence is not turnover.
+  Portfolio-Optimization-ML (monthly, fee-homogeneous 15-stock basket, **low** turnover — covariance
+  weights nudge rather than rotate) is near-immune (0.90→0.88, -2%), whereas CausalEventAlpha (also
+  monthly, also a fee-homogeneous 8-sector-ETF basket) **collapses** (0.78→0.45, -43%, PSR 5.5%) because
+  it liquidates and re-ranks the entire basket each month and concentrates to 4 sectors in bear regimes
+  — high per-period turnover. A monthly schedule over a homogeneous basket is therefore *not* sufficient
+  for immunity; the driver is realized turnover per rebalance.
 - **Low-turnover multi-asset & crypto indicators are NOT immune** (-30% to -43%): batch 4
   *invalidates* the earlier broad "ML/crypto holds" generalization. AllWeather (low-turnover
   multi-asset, -30% → 0.47) and Crypto-MultiCanal (crypto indicator, -43% → 0.33) both drop
@@ -158,11 +165,11 @@ of 41 catalog entries shrinks to roughly **a dozen genuinely-holding strategies*
 the rest are overstated to varying degrees.
 
 **Implication for the réunion Nicolas 15/06** : the catalog is not uniformly stale, but the
-overstatement is widespread — **only 6 of 21 verified strategies hold robuste with significant PSR**.
+overstatement is widespread — **only 6 of 22 verified strategies hold robuste with significant PSR**.
 The overstatement is structural in two families (value/factor/trend, and crypto indicators), while
 structured ML and regime-aware composites are validated. The comparative table MUST be cited by
 significance (PSR) not raw Sharpe; collapsed entries need a caveat before any pedagogical use. The
-remaining Tier-1 list (22 strategies) needs systematic re-backtest before the table is trusted
+remaining Tier-1 list (21 strategies) needs systematic re-backtest before the table is trusted
 end-to-end. LongShortHarvest-QC (catalog 3.39, the single highest entry) and DynamicVIXSpyRegime-QC
 (1.72) — previously QC Community Library references without an owned project — were deployed as owned
 baseline-clones (project IDs 32921183 / 32921262) and re-run over 2015-2024: both keep robuste status
@@ -185,7 +192,8 @@ Backtests: `1630-baseline-HighBookToMarketFScore-post2801` (0.411, 14.5%, -60.4%
 `1630-baseline-MomentumStrategy-post2801` (0.499, 11.2%, -25.8%, PSR 9.3%),
 `1630-baseline-LongShortHarvest-post2801` (1.635, 45.6%, -17.0%, PSR 98.7%),
 `1630-baseline-DynamicVIXSpyRegime-post2801` (0.997, 17.9%, -16.5%, PSR 69.4%),
-`1630-PortfolioOptimizationML-post2801` (0.884, 27.2%, -41.6%, PSR 37.2%).
+`1630-PortfolioOptimizationML-post2801` (0.884, 27.2%, -41.6%, PSR 37.2%),
+`1630-CausalEventAlpha-post2801` (0.447, 11.7%, -38.8%, PSR 5.5%).
 
 ---
 


### PR DESCRIPTION
## Summary

Batch-7 of the **#1630** post-#2801 verification campaign. Re-backtests Tier-1 catalog entry **#13 CausalEventAlpha** (QC project `29809163`) under the **#2801 IBKR-margin brokerage remediation** (`BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN`) — real fees exposed, **strategy logic unchanged** (only the brokerage line added in `initialize`). Native period 2015-present, 2878 tradeable dates, backtest `bd4cd898ad83d5093480a35ec630714a`.

## Result

| | Catalog | Verified (IBKR margin) | Delta |
|---|---|---|---|
| Sharpe | 0.78 | **0.447** | **-43%** |
| CAGR | 16.8% | 11.7% | |
| MaxDD | — | -38.8% | |
| Calmar | — | 0.30 | |
| PSR | — | **5.5%** | |

**Verdict: downgraded `robuste` → `historique`.** PSR ≈ 5% is statistically indistinguishable from zero skill; the catalog 0.78 was an artifact of the negligible default fee model.

## Methodological refinement — cadence is not turnover

CausalEventAlpha is **monthly** over a **fee-homogeneous 8-sector-ETF basket** — exactly the profile that made Portfolio-Optimization-ML (Batch-7 prior entry) near-immune (-2%). Yet it **collapses -43%**, because each monthly rebalance **liquidates and re-ranks the entire basket** (and concentrates to 4 sectors in bear regimes) = high per-period turnover. This sharpens the established discriminator: a monthly schedule over a homogeneous basket is **not** sufficient for fee immunity — the driver is **realized turnover per rebalance**, not rebalance cadence. The pair (Portfolio-Optimization-ML low-turnover vs CausalEventAlpha full-rotation) cleanly isolates cadence from turnover.

## Changes (atomic, catalog-only)

- Tier-1 row #13: verified Sharpe + `✓post-#2801` marker + `historique` status
- Detail-findings table: CausalEventAlpha row
- Near-immune bullet: Batch-7 cadence-vs-turnover refinement
- Backtest-list entry + sample counts (21→22 verified / 22→21 remaining)
- **No** `*.generated.*` / CATALOG-STATUS churn; submodules untouched

## Verification
- Backtest run via MCP qc-mcp-lite: compile `BuildSuccess`, backtest `Completed`, 2878 dates.
- `totalOrders` from the MCP read is the known phantom (CAGR 11.7% over 2878 dates = clearly traded).

See #1630 (partial epic — 22/41 Tier-1 verified, 21 remain; serialized on the org's single backtest node).
