### PR TITLE
feat(z3): notebook 06 temoin A & ~B via fork Automata + Sudoku-13 section 6b (See #2979)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3.Linq"]
 	path = MyIA.AI.Notebooks/SymbolicAI/SMT/Z3.Linq
 	url = https://github.com/MyIntelligenceAgency/Z3.Linq.git
+[submodule "MyIA.AI.Notebooks/SymbolicAI/SMT/Automata"]
+	path = MyIA.AI.Notebooks/SymbolicAI/SMT/Automata
+	url = https://github.com/MyIntelligenceAgency/Automata.git

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -5,10 +5,10 @@
    "id": "b67d95b0",
    "metadata": {
     "papermill": {
-     "duration": 0.003448,
-     "end_time": "2026-06-14T21:32:48.310478+00:00",
+     "duration": 0.003408,
+     "end_time": "2026-06-15T14:25:55.626410+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:48.307030+00:00",
+     "start_time": "2026-06-15T14:25:55.623002+00:00",
      "status": "completed"
     },
     "tags": []
@@ -35,10 +35,10 @@
    "id": "f028622e",
    "metadata": {
     "papermill": {
-     "duration": 0.002455,
-     "end_time": "2026-06-14T21:32:48.316046+00:00",
+     "duration": 0.002211,
+     "end_time": "2026-06-15T14:25:55.631252+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:48.313591+00:00",
+     "start_time": "2026-06-15T14:25:55.629041+00:00",
      "status": "completed"
     },
     "tags": []
@@ -73,10 +73,10 @@
    "id": "26eb0bfa",
    "metadata": {
     "papermill": {
-     "duration": 0.002357,
-     "end_time": "2026-06-14T21:32:48.320800+00:00",
+     "duration": 0.002485,
+     "end_time": "2026-06-15T14:25:55.636140+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:48.318443+00:00",
+     "start_time": "2026-06-15T14:25:55.633655+00:00",
      "status": "completed"
     },
     "tags": []
@@ -97,16 +97,16 @@
    "id": "145a4599",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:48.334349Z",
-     "iopub.status.busy": "2026-06-14T21:32:48.329234Z",
-     "iopub.status.idle": "2026-06-14T21:32:49.685452Z",
-     "shell.execute_reply": "2026-06-14T21:32:49.681309Z"
+     "iopub.execute_input": "2026-06-15T14:25:55.649466Z",
+     "iopub.status.busy": "2026-06-15T14:25:55.644967Z",
+     "iopub.status.idle": "2026-06-15T14:25:56.623213Z",
+     "shell.execute_reply": "2026-06-15T14:25:56.621339Z"
     },
     "papermill": {
-     "duration": 1.36207,
-     "end_time": "2026-06-14T21:32:49.685557+00:00",
+     "duration": 0.98498,
+     "end_time": "2026-06-15T14:25:56.623304+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:48.323487+00:00",
+     "start_time": "2026-06-15T14:25:55.638324+00:00",
      "status": "completed"
     },
     "tags": []
@@ -117,7 +117,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-13784.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -162,12 +162,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:2545:5f43:5adb:da74:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '1065220.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '13784.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -298,10 +298,10 @@
    "id": "a3163cc0",
    "metadata": {
     "papermill": {
-     "duration": 0.003223,
-     "end_time": "2026-06-14T21:32:49.692531+00:00",
+     "duration": 0.002588,
+     "end_time": "2026-06-15T14:25:56.629290+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:49.689308+00:00",
+     "start_time": "2026-06-15T14:25:56.626702+00:00",
      "status": "completed"
     },
     "tags": []
@@ -319,10 +319,10 @@
    "id": "e1d5ed3a",
    "metadata": {
     "papermill": {
-     "duration": 0.003116,
-     "end_time": "2026-06-14T21:32:49.698795+00:00",
+     "duration": 0.002652,
+     "end_time": "2026-06-15T14:25:56.634627+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:49.695679+00:00",
+     "start_time": "2026-06-15T14:25:56.631975+00:00",
      "status": "completed"
     },
     "tags": []
@@ -360,16 +360,16 @@
    "id": "5aee19b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:49.706325Z",
-     "iopub.status.busy": "2026-06-14T21:32:49.706075Z",
-     "iopub.status.idle": "2026-06-14T21:32:49.745362Z",
-     "shell.execute_reply": "2026-06-14T21:32:49.745201Z"
+     "iopub.execute_input": "2026-06-15T14:25:56.641081Z",
+     "iopub.status.busy": "2026-06-15T14:25:56.640724Z",
+     "iopub.status.idle": "2026-06-15T14:25:56.673039Z",
+     "shell.execute_reply": "2026-06-15T14:25:56.672875Z"
     },
     "papermill": {
-     "duration": 0.043626,
-     "end_time": "2026-06-14T21:32:49.745433+00:00",
+     "duration": 0.035848,
+     "end_time": "2026-06-15T14:25:56.673098+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:49.701807+00:00",
+     "start_time": "2026-06-15T14:25:56.637250+00:00",
      "status": "completed"
     },
     "tags": []
@@ -460,10 +460,10 @@
    "id": "c2b59190",
    "metadata": {
     "papermill": {
-     "duration": 0.00336,
-     "end_time": "2026-06-14T21:32:49.752351+00:00",
+     "duration": 0.00359,
+     "end_time": "2026-06-15T14:25:56.679909+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:49.748991+00:00",
+     "start_time": "2026-06-15T14:25:56.676319+00:00",
      "status": "completed"
     },
     "tags": []
@@ -484,10 +484,10 @@
    "id": "e9acb968",
    "metadata": {
     "papermill": {
-     "duration": 0.003269,
-     "end_time": "2026-06-14T21:32:49.759108+00:00",
+     "duration": 0.003476,
+     "end_time": "2026-06-15T14:25:56.687903+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:49.755839+00:00",
+     "start_time": "2026-06-15T14:25:56.684427+00:00",
      "status": "completed"
     },
     "tags": []
@@ -514,16 +514,16 @@
    "id": "ad89452f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:49.770325Z",
-     "iopub.status.busy": "2026-06-14T21:32:49.770025Z",
-     "iopub.status.idle": "2026-06-14T21:32:50.154672Z",
-     "shell.execute_reply": "2026-06-14T21:32:50.154543Z"
+     "iopub.execute_input": "2026-06-15T14:25:56.695287Z",
+     "iopub.status.busy": "2026-06-15T14:25:56.695119Z",
+     "iopub.status.idle": "2026-06-15T14:25:56.972672Z",
+     "shell.execute_reply": "2026-06-15T14:25:56.972522Z"
     },
     "papermill": {
-     "duration": 0.3911,
-     "end_time": "2026-06-14T21:32:50.154735+00:00",
+     "duration": 0.281798,
+     "end_time": "2026-06-15T14:25:56.972752+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:49.763635+00:00",
+     "start_time": "2026-06-15T14:25:56.690954+00:00",
      "status": "completed"
     },
     "tags": []
@@ -533,7 +533,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# compile en 201 ms (premier appel, JIT inclus).\r\n"
+      "RE# compile en 148 ms (premier appel, JIT inclus).\r\n"
      ]
     },
     {
@@ -595,10 +595,10 @@
    ],
    "source": [
     "// RE# via references DLL directes (cf note technique ci-dessus : pas de #r \"nuget:\" sous papermill).\n",
-    "// Resharp (engine F#) + Resharp.Runtime + FSharp.Core 10.1.300 (assembly 10.0.0.0 requise).\n",
-    "#r \"C:/Users/jsboi/.nuget/packages/resharp/1.0.3/lib/net9.0/Resharp.dll\"\n",
-    "#r \"C:/Users/jsboi/.nuget/packages/resharp/1.0.3/lib/net9.0/Resharp.Runtime.dll\"\n",
-    "#r \"C:/Users/jsboi/.nuget/packages/fsharp.core/10.1.300/lib/netstandard2.1/FSharp.Core.dll\"\n",
+    "// Resharp + Resharp.Runtime build net8.0 + FSharp.Core 10.0.100 (assembly 10.0.0.0) : le kernel .net-csharp tourne sous net8.0.\n",
+    "#r \"C:/Users/jsboi/.nuget/packages/resharp/1.0.3/lib/net8.0/Resharp.dll\"\n",
+    "#r \"C:/Users/jsboi/.nuget/packages/resharp/1.0.3/lib/net8.0/Resharp.Runtime.dll\"\n",
+    "#r \"C:/Users/jsboi/.nuget/packages/fsharp.core/10.0.100/lib/netstandard2.1/FSharp.Core.dll\"\n",
     "using System.Diagnostics;\n",
     "\n",
     "// Smoke test : l'INTERSECTION & est first-class dans UNE chaine. C'est l'operateur\n",
@@ -624,10 +624,10 @@
    "id": "8ab75967",
    "metadata": {
     "papermill": {
-     "duration": 0.003859,
-     "end_time": "2026-06-14T21:32:50.162156+00:00",
+     "duration": 0.003281,
+     "end_time": "2026-06-15T14:25:56.979406+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.158297+00:00",
+     "start_time": "2026-06-15T14:25:56.976125+00:00",
      "status": "completed"
     },
     "tags": []
@@ -645,10 +645,10 @@
    "id": "78b8c507",
    "metadata": {
     "papermill": {
-     "duration": 0.004357,
-     "end_time": "2026-06-14T21:32:50.169978+00:00",
+     "duration": 0.00319,
+     "end_time": "2026-06-15T14:25:56.985765+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.165621+00:00",
+     "start_time": "2026-06-15T14:25:56.982575+00:00",
      "status": "completed"
     },
     "tags": []
@@ -675,16 +675,16 @@
    "id": "9c60d031",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:50.178071Z",
-     "iopub.status.busy": "2026-06-14T21:32:50.177895Z",
-     "iopub.status.idle": "2026-06-14T21:32:50.348573Z",
-     "shell.execute_reply": "2026-06-14T21:32:50.348419Z"
+     "iopub.execute_input": "2026-06-15T14:25:56.994179Z",
+     "iopub.status.busy": "2026-06-15T14:25:56.994007Z",
+     "iopub.status.idle": "2026-06-15T14:25:57.126753Z",
+     "shell.execute_reply": "2026-06-15T14:25:57.126637Z"
     },
     "papermill": {
-     "duration": 0.175282,
-     "end_time": "2026-06-14T21:32:50.348683+00:00",
+     "duration": 0.137487,
+     "end_time": "2026-06-15T14:25:57.126809+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.173401+00:00",
+     "start_time": "2026-06-15T14:25:56.989322+00:00",
      "status": "completed"
     },
     "tags": []
@@ -694,7 +694,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Contrainte de ligne (10-way intersection) compilee en 45 ms.\r\n"
+      "Contrainte de ligne (10-way intersection) compilee en 38 ms.\r\n"
      ]
     },
     {
@@ -796,10 +796,10 @@
    "id": "332400c1",
    "metadata": {
     "papermill": {
-     "duration": 0.003795,
-     "end_time": "2026-06-14T21:32:50.356738+00:00",
+     "duration": 0.003187,
+     "end_time": "2026-06-15T14:25:57.133401+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.352943+00:00",
+     "start_time": "2026-06-15T14:25:57.130214+00:00",
      "status": "completed"
     },
     "tags": []
@@ -817,10 +817,10 @@
    "id": "3be938e7",
    "metadata": {
     "papermill": {
-     "duration": 0.003382,
-     "end_time": "2026-06-14T21:32:50.363547+00:00",
+     "duration": 0.003509,
+     "end_time": "2026-06-15T14:25:57.140050+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.360165+00:00",
+     "start_time": "2026-06-15T14:25:57.136541+00:00",
      "status": "completed"
     },
     "tags": []
@@ -844,16 +844,16 @@
    "id": "774c68f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:50.371754Z",
-     "iopub.status.busy": "2026-06-14T21:32:50.371581Z",
-     "iopub.status.idle": "2026-06-14T21:32:50.420218Z",
-     "shell.execute_reply": "2026-06-14T21:32:50.420085Z"
+     "iopub.execute_input": "2026-06-15T14:25:57.147571Z",
+     "iopub.status.busy": "2026-06-15T14:25:57.147419Z",
+     "iopub.status.idle": "2026-06-15T14:25:57.195322Z",
+     "shell.execute_reply": "2026-06-15T14:25:57.195195Z"
     },
     "papermill": {
-     "duration": 0.053217,
-     "end_time": "2026-06-14T21:32:50.420283+00:00",
+     "duration": 0.052093,
+     "end_time": "2026-06-15T14:25:57.195379+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.367066+00:00",
+     "start_time": "2026-06-15T14:25:57.143286+00:00",
      "status": "completed"
     },
     "tags": []
@@ -897,10 +897,10 @@
    "id": "edd4a220",
    "metadata": {
     "papermill": {
-     "duration": 0.003924,
-     "end_time": "2026-06-14T21:32:50.428247+00:00",
+     "duration": 0.003698,
+     "end_time": "2026-06-15T14:25:57.202600+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.424323+00:00",
+     "start_time": "2026-06-15T14:25:57.198902+00:00",
      "status": "completed"
     },
     "tags": []
@@ -921,16 +921,16 @@
    "id": "5a7a038b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:50.436424Z",
-     "iopub.status.busy": "2026-06-14T21:32:50.436241Z",
-     "iopub.status.idle": "2026-06-14T21:32:50.590939Z",
-     "shell.execute_reply": "2026-06-14T21:32:50.590814Z"
+     "iopub.execute_input": "2026-06-15T14:25:57.210773Z",
+     "iopub.status.busy": "2026-06-15T14:25:57.210619Z",
+     "iopub.status.idle": "2026-06-15T14:25:57.336396Z",
+     "shell.execute_reply": "2026-06-15T14:25:57.336271Z"
     },
     "papermill": {
-     "duration": 0.159248,
-     "end_time": "2026-06-14T21:32:50.591001+00:00",
+     "duration": 0.130435,
+     "end_time": "2026-06-15T14:25:57.336453+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.431753+00:00",
+     "start_time": "2026-06-15T14:25:57.206018+00:00",
      "status": "completed"
     },
     "tags": []
@@ -971,16 +971,16 @@
    "id": "53fcffb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:50.599585Z",
-     "iopub.status.busy": "2026-06-14T21:32:50.599419Z",
-     "iopub.status.idle": "2026-06-14T21:32:50.823388Z",
-     "shell.execute_reply": "2026-06-14T21:32:50.807467Z"
+     "iopub.execute_input": "2026-06-15T14:25:57.346410Z",
+     "iopub.status.busy": "2026-06-15T14:25:57.346238Z",
+     "iopub.status.idle": "2026-06-15T14:25:57.600389Z",
+     "shell.execute_reply": "2026-06-15T14:25:57.572422Z"
     },
     "papermill": {
-     "duration": 0.228742,
-     "end_time": "2026-06-14T21:32:50.823454+00:00",
+     "duration": 0.258411,
+     "end_time": "2026-06-15T14:25:57.600448+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.594712+00:00",
+     "start_time": "2026-06-15T14:25:57.342037+00:00",
      "status": "completed"
     },
     "tags": []
@@ -990,7 +990,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 a produit un temoin (grille solution) en 27 ms.\n",
+      "Z3 a produit un temoin (grille solution) en 47 ms.\n",
       "\r\n"
      ]
     },
@@ -1839,10 +1839,10 @@
    "id": "a3872431",
    "metadata": {
     "papermill": {
-     "duration": 0.00633,
-     "end_time": "2026-06-14T21:32:50.836206+00:00",
+     "duration": 0.005378,
+     "end_time": "2026-06-15T14:25:57.611543+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.829876+00:00",
+     "start_time": "2026-06-15T14:25:57.606165+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1857,13 +1857,304 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a6b00001",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008018,
+     "end_time": "2026-06-15T14:25:57.624977+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:25:57.616959+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6b. Le mur 2 est leve - mais a quelle echelle ?\n",
+    "\n",
+    "Le barreau 2 (2020) butait sur **deux murs** : l'explosion du DFA (mur 1) ET le cap du temoin a ~21 caracteres (mur 2, [issue #6](https://github.com/AutomataDotNet/Automata/issues/6)). Le **fork Automata** (modernisation net8.0, MyIntelligenceAgency) **leve le mur 2** : on genere desormais un temoin depuis la syntaxe de surface `&` / `~`, sans plafond de longueur.\n",
+    "\n",
+    "Mais **le mur 1 reste**. Question de recherche : *une fois le temoin debride, la generation depuis l'intersection est-elle tractable a l'echelle d'un Sudoku, et differe-t-elle du `Distinct` de Z3 (~27 ms) ?* Mesurons.\n",
+    "\n",
+    "| Echelle | Contraintes | Generation de temoin |\n",
+    "|---------|-------------|----------------------|\n",
+    "| **1 ligne** (9 cases) | intersection 10-way | fork Automata : tractable (mesure ci-dessous) |\n",
+    "| **Grille 81 cases** | 270 sous-contraintes (27 groupes x 10) | explosion combinatoire (voir plus bas) |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a6b00002",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:25:57.637924Z",
+     "iopub.status.busy": "2026-06-15T14:25:57.637637Z",
+     "iopub.status.idle": "2026-06-15T14:26:21.932949Z",
+     "shell.execute_reply": "2026-06-15T14:26:21.932824Z"
+    },
+    "papermill": {
+     "duration": 24.302066,
+     "end_time": "2026-06-15T14:26:21.933008+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:25:57.630942+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Temoin Automata (1 ligne) : 273918456\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  permutation de 1..9     : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  valide selon RE#        : True  (validation croisee inter-moteurs)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  temps build + temoin    : 24196 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rappel : Z3 resout la grille ENTIERE (81 cases) en ~27 ms (cf section 6).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Le fork Automata (submodule sibling de la serie Z3) genere un temoin depuis la MEME\n",
+    "// intersection 10-way que RE# verifie ci-dessus. On CROISE les deux moteurs : le temoin\n",
+    "// produit par Automata doit etre VALIDE selon le verificateur RE# `ligneValide` (cf section 5).\n",
+    "#r \"../SymbolicAI/SMT/Automata/.deploy/System.CodeDom.dll\"\n",
+    "#r \"../SymbolicAI/SMT/Automata/.deploy/Microsoft.Automata.dll\"\n",
+    "using System.Linq;\n",
+    "using System.Diagnostics;\n",
+    "using Microsoft.Automata;\n",
+    "using Microsoft.Automata.Rex;\n",
+    "\n",
+    "var engineLigne = new RexEngine(BitWidth.BV7);\n",
+    "// Ligne Sudoku ancree : 9 chiffres 1-9 contenant chacun de 1..9 = une permutation.\n",
+    "string ligneSurface = \"^[1-9]{9}$&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\";\n",
+    "\n",
+    "var swAuto = Stopwatch.StartNew();\n",
+    "var autLigne = engineLigne.CreateFromRegexes(ligneSurface);  // construit le DFA de l'intersection\n",
+    "string temoinLigne = engineLigne.GenerateMember(autLigne);   // genere le temoin (marche aleatoire)\n",
+    "swAuto.Stop();\n",
+    "\n",
+    "// Validation croisee inter-moteurs : RE# (ligneValide, defini section 5) accepte-t-il le temoin Automata ?\n",
+    "bool valideParREsharp = ligneValide.Matches(temoinLigne).Length > 0;\n",
+    "bool permutation = temoinLigne.Length == 9 &&\n",
+    "                   Enumerable.Range(1, 9).All(d => temoinLigne.Contains((char)('0' + d)));\n",
+    "\n",
+    "Console.WriteLine($\"Temoin Automata (1 ligne) : {temoinLigne}\");\n",
+    "Console.WriteLine($\"  permutation de 1..9     : {permutation}\");\n",
+    "Console.WriteLine($\"  valide selon RE#        : {valideParREsharp}  (validation croisee inter-moteurs)\");\n",
+    "Console.WriteLine($\"  temps build + temoin    : {swAuto.Elapsed.TotalMilliseconds:F0} ms\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Rappel : Z3 resout la grille ENTIERE (81 cases) en ~27 ms (cf section 6).\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a6b00003",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:26:21.945612Z",
+     "iopub.status.busy": "2026-06-15T14:26:21.945453Z",
+     "iopub.status.idle": "2026-06-15T14:26:21.997329Z",
+     "shell.execute_reply": "2026-06-15T14:26:21.997191Z"
+    },
+    "papermill": {
+     "duration": 0.058581,
+     "end_time": "2026-06-15T14:26:21.997394+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:26:21.938813+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Grille 81 cases = 27 groupes x 10 = 270 sous-contraintes.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pourquoi on ne lance pas l'intersection 270-way :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - le DFA d'UNE ligne (10-way) demande deja des secondes (mesure ci-dessus) ;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - lignes, colonnes et blocs se CHEVAUCHENT (chaque case appartient a 3 groupes) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    ce n'est pas une intersection 1D mais une contrainte 2D sur 81 caracteres ;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - le produit cartesien des automates explose (mur 1, jamais leve par le fork).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verdict : le fork leve le mur 2 (cap temoin), PAS le mur 1 (explosion DFA).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A l'echelle Sudoku, Z3 Distinct reste le resolveur de production (~27 ms).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Le vrai payoff du fork = generation de temoin GENERALE 'A & ~B'\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(cf notebook 06 de la serie Z3 : 06_Witness_Generation_Automata).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// 81 cases : on NE LANCE PAS l'intersection complete. On compte et on explique (pas de faux timing).\n",
+    "// Un Sudoku = 27 groupes (9 lignes + 9 colonnes + 9 blocs), chacun = permutation de 1..9.\n",
+    "int groupes = 9 + 9 + 9;                        // 27\n",
+    "int sousContraintesParGroupe = 1 + 9;           // 1 longueur + 9 presences de chiffre\n",
+    "int total = groupes * sousContraintesParGroupe; // 270\n",
+    "\n",
+    "Console.WriteLine($\"Grille 81 cases = {groupes} groupes x {sousContraintesParGroupe} = {total} sous-contraintes.\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Pourquoi on ne lance pas l'intersection 270-way :\");\n",
+    "Console.WriteLine(\"  - le DFA d'UNE ligne (10-way) demande deja des secondes (mesure ci-dessus) ;\");\n",
+    "Console.WriteLine(\"  - lignes, colonnes et blocs se CHEVAUCHENT (chaque case appartient a 3 groupes) :\");\n",
+    "Console.WriteLine(\"    ce n'est pas une intersection 1D mais une contrainte 2D sur 81 caracteres ;\");\n",
+    "Console.WriteLine(\"  - le produit cartesien des automates explose (mur 1, jamais leve par le fork).\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Verdict : le fork leve le mur 2 (cap temoin), PAS le mur 1 (explosion DFA).\");\n",
+    "Console.WriteLine(\"A l'echelle Sudoku, Z3 Distinct reste le resolveur de production (~27 ms).\");\n",
+    "Console.WriteLine(\"Le vrai payoff du fork = generation de temoin GENERALE 'A & ~B'\");\n",
+    "Console.WriteLine(\"(cf notebook 06 de la serie Z3 : 06_Witness_Generation_Automata).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6b00004",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010141,
+     "end_time": "2026-06-15T14:26:22.016949+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:26:22.006808+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : un mur tombe, l'autre tient\n",
+    "\n",
+    "Le fork **debride le temoin** : une ligne Sudoku (intersection 10-way) produit desormais un temoin reel, **valide par RE#** (validation croisee inter-moteurs ci-dessus) - chose impossible en 2020 sous le cap des 21 caracteres. C'est un gain authentique.\n",
+    "\n",
+    "Mais le **mur 1 (explosion du DFA)** tient : la grille 81 cases n'est pas une intersection 1D, c'est une contrainte 2D dont le produit d'automates explose. **Z3 reste le resolveur de production** (~27 ms pour les 81 cases) la ou l'intersection reguliere ne passe pas a l'echelle.\n",
+    "\n",
+    "| Approche | Reconnaissance | Production de temoin | Echelle Sudoku 81 |\n",
+    "|----------|----------------|----------------------|-------------------|\n",
+    "| RE# (2025) | temps lineaire | aucun temoin | verifie seulement |\n",
+    "| Fork Automata (2026) | (oui) | **temoin non-cape, `&`/`~` surface** | explose (mur 1) |\n",
+    "| Z3 direct | - | temoin complet | **~27 ms (production)** |\n",
+    "\n",
+    "> **Cap leve, pas l'echelle.** Le payoff *general* de la generation de temoin `A & ~B` est demontre dans le notebook **[06 - Generer un temoin depuis A & ~B](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)** de la serie Z3 (mots de passe conformes, entrees de test, identifiants non utilises). Le Sudoku 81 reste le domaine de Z3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "81f6e32b",
    "metadata": {
     "papermill": {
-     "duration": 0.006537,
-     "end_time": "2026-06-14T21:32:50.849350+00:00",
+     "duration": 0.018321,
+     "end_time": "2026-06-15T14:26:22.047308+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.842813+00:00",
+     "start_time": "2026-06-15T14:26:22.028987+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1881,20 +2172,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "57514927",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:50.863241Z",
-     "iopub.status.busy": "2026-06-14T21:32:50.863070Z",
-     "iopub.status.idle": "2026-06-14T21:32:50.966708Z",
-     "shell.execute_reply": "2026-06-14T21:32:50.966537Z"
+     "iopub.execute_input": "2026-06-15T14:26:22.072326Z",
+     "iopub.status.busy": "2026-06-15T14:26:22.072069Z",
+     "iopub.status.idle": "2026-06-15T14:26:22.134058Z",
+     "shell.execute_reply": "2026-06-15T14:26:22.133944Z"
     },
     "papermill": {
-     "duration": 0.110735,
-     "end_time": "2026-06-14T21:32:50.966790+00:00",
+     "duration": 0.073658,
+     "end_time": "2026-06-15T14:26:22.134108+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.856055+00:00",
+     "start_time": "2026-06-15T14:26:22.060450+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1904,7 +2195,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# a verifie les 9 lignes de la solution Z3 en 186531 ticks (18 ms).\r\n"
+      "RE# a verifie les 9 lignes de la solution Z3 en 125167 ticks (12 ms).\r\n"
      ]
     },
     {
@@ -2036,10 +2327,10 @@
    "id": "98e9d012",
    "metadata": {
     "papermill": {
-     "duration": 0.008247,
-     "end_time": "2026-06-14T21:32:50.983244+00:00",
+     "duration": 0.006033,
+     "end_time": "2026-06-15T14:26:22.146011+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.974997+00:00",
+     "start_time": "2026-06-15T14:26:22.139978+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2060,10 +2351,10 @@
    "id": "9d8d3271",
    "metadata": {
     "papermill": {
-     "duration": 0.007949,
-     "end_time": "2026-06-14T21:32:50.998329+00:00",
+     "duration": 0.006242,
+     "end_time": "2026-06-15T14:26:22.158164+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:50.990380+00:00",
+     "start_time": "2026-06-15T14:26:22.151922+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2083,20 +2374,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "f684319a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:51.015512Z",
-     "iopub.status.busy": "2026-06-14T21:32:51.015317Z",
-     "iopub.status.idle": "2026-06-14T21:32:51.050516Z",
-     "shell.execute_reply": "2026-06-14T21:32:51.050381Z"
+     "iopub.execute_input": "2026-06-15T14:26:22.170639Z",
+     "iopub.status.busy": "2026-06-15T14:26:22.170494Z",
+     "iopub.status.idle": "2026-06-15T14:26:22.198666Z",
+     "shell.execute_reply": "2026-06-15T14:26:22.198552Z"
     },
     "papermill": {
-     "duration": 0.043984,
-     "end_time": "2026-06-14T21:32:51.050584+00:00",
+     "duration": 0.034454,
+     "end_time": "2026-06-15T14:26:22.198717+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:51.006600+00:00",
+     "start_time": "2026-06-15T14:26:22.164263+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2126,10 +2417,10 @@
    "id": "855aa43e",
    "metadata": {
     "papermill": {
-     "duration": 0.007642,
-     "end_time": "2026-06-14T21:32:51.066001+00:00",
+     "duration": 0.006178,
+     "end_time": "2026-06-15T14:26:22.211111+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:51.058359+00:00",
+     "start_time": "2026-06-15T14:26:22.204933+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2145,8 +2436,11 @@
     "| BREX/Rex+Z3 (2020) | **mure** (cap 21 char, issue #6) | **explosion DFA** |\n",
     "| Z3 direct (moderne) | **resolveur reel du benchmark** | - |\n",
     "| RE# (2025) | recognition-only, **aucun temoin** | **temps lineaire** - mur DFA tombe |\n",
+    "| Fork Automata (2026) | temoin non-cape (`&`/`~` surface), mais explose a l'echelle | (oui, petits fragments) |\n",
     "\n",
     "**Lecon** : decrire une contrainte par intersection reguliere (`Ligne & Colonne & Bloc`) est une representation elegante, mais elle ne dispense pas d'un resolveur pour *produire* la solution. Le Sudoku - un probleme de **resolution** - a besoin de Z3 ; RE# est son verificateur, pas son solveur. L'ironie (RE# valide plus vite le temoin qu'il ne peut produire) est le pont entre cette serie Sudoku et la serie Z3 (Epic #1206).\n",
+    "\n",
+    "Le **fork Automata 2026** (section 6b ci-dessus, et notebook [06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb) de la serie Z3) **leve le mur 2** (cap du temoin) : on genere un temoin depuis `&`/`~` sans plafond de longueur. Mais le **mur 1** (explosion DFA) tient a l'echelle 81 cases - Z3 reste donc le resolveur de production.\n",
     "\n",
     "> **Footnote d'homonymie** : **Damian** Conway (le monstre regex, barreau 1) n'est pas **John** Conway (le Game of Life, hero de notre serie Lean #2162). Les deux Conway se croisent dans ce notebook."
    ]
@@ -2156,10 +2450,10 @@
    "id": "b71a1c63",
    "metadata": {
     "papermill": {
-     "duration": 0.007588,
-     "end_time": "2026-06-14T21:32:51.081816+00:00",
+     "duration": 0.005852,
+     "end_time": "2026-06-15T14:26:22.223032+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:51.074228+00:00",
+     "start_time": "2026-06-15T14:26:22.217180+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2183,20 +2477,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "3a2f8af0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T21:32:51.099085Z",
-     "iopub.status.busy": "2026-06-14T21:32:51.098883Z",
-     "iopub.status.idle": "2026-06-14T21:32:51.135264Z",
-     "shell.execute_reply": "2026-06-14T21:32:51.135131Z"
+     "iopub.execute_input": "2026-06-15T14:26:22.235597Z",
+     "iopub.status.busy": "2026-06-15T14:26:22.235443Z",
+     "iopub.status.idle": "2026-06-15T14:26:22.261292Z",
+     "shell.execute_reply": "2026-06-15T14:26:22.261194Z"
     },
     "papermill": {
-     "duration": 0.045368,
-     "end_time": "2026-06-14T21:32:51.135332+00:00",
+     "duration": 0.032285,
+     "end_time": "2026-06-15T14:26:22.261342+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:51.089964+00:00",
+     "start_time": "2026-06-15T14:26:22.229057+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2261,10 +2555,10 @@
    "id": "03783737",
    "metadata": {
     "papermill": {
-     "duration": 0.007768,
-     "end_time": "2026-06-14T21:32:51.150435+00:00",
+     "duration": 0.006116,
+     "end_time": "2026-06-15T14:26:22.273680+00:00",
      "exception": false,
-     "start_time": "2026-06-14T21:32:51.142667+00:00",
+     "start_time": "2026-06-15T14:26:22.267564+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2279,10 +2573,12 @@
     "- **Issue upstream** [AutomataDotNet/Automata#6](https://github.com/AutomataDotNet/Automata/issues/6) (creee 2020-12-07, toujours sans reponse) : cap du temoin a 21 caracteres (barreau 2, mur 2).\n",
     "- **Margus Veanes et al.**, *Derivative-based nonbacktracking real-world regex matching* - [MSR-TR-2020-25](https://www.microsoft.com/en-us/research/publication/derivative-based-nonbacktracking-real-world-regex-matching-with-backtracking-semantics/) (aout 2020). Le papier contemporain de la tentative 2020.\n",
     "- **RE#** (engine F#/.NET, MIT) - [github.com/ieviev/resharp-dotnet](https://github.com/ieviev/resharp-dotnet), NuGet `Resharp`. `&`/`~` first-class, non-backtracking, temps lineaire (barreau 3).\n",
+    "- **Fork Automata** (net8.0, MyIntelligenceAgency) - [github.com/MyIntelligenceAgency/Automata](https://github.com/MyIntelligenceAgency/Automata). Modernise AutomataDotNet (gele ~2020) : operateurs de surface `&`/`~` + temoin non-cape (mur 2 / issue #6 leve). Consomme par le notebook 06 de la serie Z3.\n",
     "\n",
     "### Connexions dans cette serie\n",
     "- **[Sudoku-12 Z3 C#](Sudoku-12-Z3-Csharp.ipynb)** : le resolveur Z3 explore en profondeur (bit-vectors, optimisations). Ce notebook (13) presente le meme Z3 sous l'angle narratif \"regex symbolique -> SMT -> temoin\".\n",
     "- **Epic #1206 (Z3.Linq DSL)** : un autre \"geste\" de l'auteur (2018), etendre un front-end declaratif pour laisser Z3 temoigner. La compilation regex -> SMT et le DSL Z3.Linq sont **le meme geste dans deux librairies**.\n",
+    "- **[Notebook 06 - Generer un temoin depuis A & ~B](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)** : le fork Automata leve le cap du temoin (#6) et generalise `A & ~B` (mots de passe, entrees de test). La section 6b ci-dessus mesure sa portee (1 ligne tractable, 81 cases en explosion).\n",
     "- **Epic #2162 (Game of Life, Lean)** : **John** Conway, a ne pas confondre avec **Damian** (regex).\n",
     "\n",
     "### La preuve Lean derriere RE#\n",
@@ -2295,7 +2591,8 @@
     "- **Reconnaitre != resoudre** : RE# verifie (temps lineaire), Z3 produit (le temoin). Le Sudoku a besoin des deux.\n",
     "- Les deux murs de 2020 (explosion DFA, cap temoin 21 char) tombent a **deux outils differents** : RE# et Z3.\n",
     "- L'**ironie** : le verificateur le plus elegant (RE#) certifie, plus vite que Z3 n'a resolu, une grille qu'il ne peut pas produire.\n",
-    "- Z3, appele directement (sans le chemin SFAz3 cape), **n'a pas** le mur des 21 caracteres : c'est le resolveur reel du benchmark Sudoku multi-paradigmes."
+    "- Z3, appele directement (sans le chemin SFAz3 cape), **n'a pas** le mur des 21 caracteres : c'est le resolveur reel du benchmark Sudoku multi-paradigmes.\n",
+    "- Le **fork Automata 2026** leve le **mur 2** (cap du temoin) - temoin `A & ~B` non-cape depuis `&`/`~` - mais **pas le mur 1** (explosion DFA a l'echelle). Voir section 6b et notebook 06."
    ]
   }
  ],
@@ -2310,18 +2607,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "13.0"
+   "version": "12.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.936137,
-   "end_time": "2026-06-14T21:32:51.397922+00:00",
+   "duration": 29.384899,
+   "end_time": "2026-06-15T14:26:22.832029+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "_sudoku13_rewrite.ipynb",
-   "output_path": "_sudoku13_rewrite_out.ipynb",
+   "input_path": "Sudoku-13-SymbolicAutomata-Csharp.ipynb",
+   "output_path": "_s13_out.ipynb",
    "parameters": {},
-   "start_time": "2026-06-14T21:32:45.461785+00:00",
+   "start_time": "2026-06-15T14:25:53.447130+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb
@@ -1,0 +1,1347 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "13e003ad",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003123,
+     "end_time": "2026-06-15T14:02:51.664285+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:51.661162+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 06 — Générer un témoin depuis `A & ~B` (fork Automata vivant)\n",
+    "\n",
+    "`<<` [05 — Meal Planner hiérarchique](05_Meal_Planner_Hierarchical.ipynb) | [Sudoku-13 — Automates symboliques `>>`](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Le problème : reconnaître ne suffit pas, il faut **produire**\n",
+    "\n",
+    "Un moteur comme **RE#** (`System.Text.RegularExpressions`) répond à **« cette chaîne appartient-elle au langage ? »** — c'est de la *reconnaissance*. Mais beaucoup de tâches réelles demandent l'inverse : **« donne-moi une chaîne qui appartient au langage »** — c'est la *génération de témoin* (witness generation). Exemples :\n",
+    "\n",
+    "- générer un mot de passe **conforme à une politique** mais **évitant** les motifs faibles connus ;\n",
+    "- fabriquer une entrée de **test** qui satisfait une contrainte **et** en viole une autre ;\n",
+    "- produire un identifiant **valide** mais **pas encore utilisé**.\n",
+    "\n",
+    "Toutes ces tâches s'écrivent `A & ~B` : *« dans le langage A, mais pas dans le langage B »*.\n",
+    "\n",
+    "## Ce notebook\n",
+    "\n",
+    "On consomme le **fork `MyIntelligenceAgency/Automata`** (modernisation net8.0 de `Microsoft.Automata`, dit *AutomataDotNet*, gelé vers 2020). Le fork ajoute deux choses que ni RE# ni le paquet public ne savent faire :\n",
+    "\n",
+    "1. les opérateurs de **surface** `&` (intersection) et `~` (complément) **directement dans la syntaxe regex** ;\n",
+    "2. la **génération de témoin sans le plafond historique de ~21 caractères** (issue #6).\n",
+    "\n",
+    "### Objectifs\n",
+    "\n",
+    "1. Manipuler l'algèbre `CharSetSolver` (BDD sur 128 caractères ASCII).\n",
+    "2. Écrire `A & ~B` en surface et **générer un témoin** via `RexEngine`.\n",
+    "3. Émettre la formule **SMT-LIB** correspondante (`re.inter` / `re.comp`).\n",
+    "4. Comprendre **honnêtement** la portée : le fork lève le mur du témoin, **pas** l'explosion d'automate à grande échelle — voir le Sudoku-13 pour le verdict mesuré.\n",
+    "\n",
+    "> **Non-but** (issue #2979) : ce patch **ne remplace pas RE#** pour la reconnaissance et **ne réveille pas** `Z3.LinqBinding`. Il ajoute ce que RE# ne fait pas : *un témoin depuis la syntaxe `&`/`~`*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "76086898",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:51.680768Z",
+     "iopub.status.busy": "2026-06-15T14:02:51.675815Z",
+     "iopub.status.idle": "2026-06-15T14:02:52.557951Z",
+     "shell.execute_reply": "2026-06-15T14:02:52.556460Z"
+    },
+    "papermill": {
+     "duration": 0.887505,
+     "end_time": "2026-06-15T14:02:52.558030+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:51.670525+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-58096.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '58096.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK — fork Automata (surface &/~ + témoin non-capé) chargé.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Le fork est déployé en submodule sibling (cf scripts/environment/automata-build-deploy.ps1).\n",
+    "// .deploy/ contient Microsoft.Automata.dll (pure-managed, fork net8.0) + sa dépendance System.CodeDom.\n",
+    "#r \"../Automata/.deploy/System.CodeDom.dll\"\n",
+    "#r \"../Automata/.deploy/Microsoft.Automata.dll\"\n",
+    "\n",
+    "using System;\n",
+    "using System.Linq;\n",
+    "using System.Diagnostics;\n",
+    "using System.Text.RegularExpressions;\n",
+    "using Microsoft.Automata;\n",
+    "using Microsoft.Automata.Rex;\n",
+    "\n",
+    "Console.WriteLine(\"Imports OK — fork Automata (surface &/~ + témoin non-capé) chargé.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbc5abdb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002179,
+     "end_time": "2026-06-15T14:02:52.562661+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.560482+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Reconnaître vs produire — trois outils, trois rôles\n",
+    "\n",
+    "| Outil | Question répondue | Direction |\n",
+    "|-------|-------------------|-----------|\n",
+    "| **RE#** (`Regex.IsMatch`) | « *s* appartient-il à *L* ? » | reconnaissance |\n",
+    "| **RexEngine** (ce notebook) | « donne-moi un *s* de *L* » | **génération de témoin** |\n",
+    "| **Z3** (notebooks 01–05) | « existe-t-il un *s* satisfaisant ces contraintes ? » | résolution SMT générale |\n",
+    "\n",
+    "Les trois sont complémentaires. RexEngine occupe la case que RE# laisse vide : il **fabrique** un mot du langage, et — grâce au fork — depuis un langage décrit avec `&` et `~`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0839c0fe",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002422,
+     "end_time": "2026-06-15T14:02:52.567542+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.565120+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. L'algèbre `CharSetSolver` — des BDD sur l'alphabet\n",
+    "\n",
+    "Sous le capot, un langage régulier est un **automate dont les transitions sont étiquetées par des ensembles de caractères**. Ces ensembles ne sont pas stockés en clair mais comme **BDD** (*Binary Decision Diagrams*) — une représentation compacte et canonique des prédicats booléens sur les bits d'un caractère.\n",
+    "\n",
+    "`CharSetSolver(BitWidth.BV7)` travaille sur **7 bits = 128 caractères ASCII**. C'est l'*algèbre* partagée par tout le pipeline : convertir une regex en automate, intersecter, complémenter, tester l'appartenance. **Retenez ce mot — « algèbre partagée » — il reviendra au §6.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e45df611",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:52.572974Z",
+     "iopub.status.busy": "2026-06-15T14:02:52.572826Z",
+     "iopub.status.idle": "2026-06-15T14:02:52.735140Z",
+     "shell.execute_reply": "2026-06-15T14:02:52.735028Z"
+    },
+    "papermill": {
+     "duration": 0.165396,
+     "end_time": "2026-06-15T14:02:52.735195+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.569799+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"a\") = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"Z\") = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"5\") = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"ab\") = False\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Construire un automate depuis une regex, puis tester l'appartenance.\n",
+    "// API correcte : solver.Accepts(automate, chaine)  (et NON automate.Accepts).\n",
+    "var solver = new CharSetSolver(BitWidth.BV7);\n",
+    "\n",
+    "// \"^[a-z]$\" = exactement une lettre minuscule.\n",
+    "var uneMinuscule = solver.Convert(\"^[a-z]$\", RegexOptions.None)\n",
+    "                         .RemoveEpsilons().Determinize().Minimize();\n",
+    "\n",
+    "foreach (var s in new[] { \"a\", \"Z\", \"5\", \"ab\" })\n",
+    "    Console.WriteLine($\"  Accepts(\\\"{s}\\\") = {solver.Accepts(uneMinuscule, s)}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d989aa5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001983,
+     "end_time": "2026-06-15T14:02:52.739850+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.737867+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. L'opérateur de surface `&` — intersection dans la syntaxe\n",
+    "\n",
+    "Le fork branche `&` **en tête du parser regex** : `A&B` est analysé comme l'**intersection** des deux langages, et câblé sur `Automaton.Intersect`. Pas de manipulation manuelle d'automates : on l'écrit, c'est tout.\n",
+    "\n",
+    "Exemple canonique : `^[ab]$ & ^[bc]$`. Un caractère unique qui est *(a ou b)* **et** *(b ou c)* ne peut être que **`b`** — l'intersection est le singleton `{b}`.\n",
+    "\n",
+    "> **Pourquoi les ancres `^…$` ?** Une regex .NET non ancrée signifie *« la chaîne **contient** un tel caractère »* : `[ab]` ≡ `.*[ab].*`. Sans ancres, `[ab]&[bc]` accepterait `\"ac\"` (contient `a` *et* `c`). Les ancres bornent la longueur et donnent un témoin propre et lisible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "82374f96",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:52.744741Z",
+     "iopub.status.busy": "2026-06-15T14:02:52.744607Z",
+     "iopub.status.idle": "2026-06-15T14:02:52.789332Z",
+     "shell.execute_reply": "2026-06-15T14:02:52.789235Z"
+    },
+    "papermill": {
+     "duration": 0.04757,
+     "end_time": "2026-06-15T14:02:52.789379+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.741809+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"a\") = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"b\") = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"c\") = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Témoin de (^[ab]$ & ^[bc]$) = \"b\"\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// \"[ab] & [bc]\" ancré = le singleton {b}. On construit via le solveur et on vérifie.\n",
+    "var inter = solver.Convert(\"^[ab]$&^[bc]$\", RegexOptions.None)\n",
+    "                  .RemoveEpsilons().Determinize().Minimize();\n",
+    "\n",
+    "foreach (var s in new[] { \"a\", \"b\", \"c\" })\n",
+    "    Console.WriteLine($\"  Accepts(\\\"{s}\\\") = {solver.Accepts(inter, s)}\");\n",
+    "\n",
+    "// Génération du témoin : engine.CreateFromRegexes partage l'algèbre interne du moteur.\n",
+    "var engine = new RexEngine(BitWidth.BV7);\n",
+    "var interAut = engine.CreateFromRegexes(\"^[ab]$&^[bc]$\");\n",
+    "string temoinInter = engine.GenerateMember(interAut);\n",
+    "Console.WriteLine($\"  Témoin de (^[ab]$ & ^[bc]$) = \\\"{temoinInter}\\\"\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dabb355",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00237,
+     "end_time": "2026-06-15T14:02:52.793999+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.791629+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. L'opérateur de surface `~` — complément, et le motif `A & ~B`\n",
+    "\n",
+    "`~A` est le **complément** de *A* : tout ce qui n'est **pas** dans *A*. Combiné à `&`, on obtient le motif vedette **`A & ~B`** : *« dans A, mais pas dans B »*.\n",
+    "\n",
+    "Exemple : `^[a-z]$ & ~[aeiou]` = une lettre minuscule **qui n'est pas une voyelle** = une **consonne**.\n",
+    "\n",
+    "> **Précédence de `~` — un piège à connaître.** `~` se lie à l'**atome qui suit immédiatement** (une classe `[…]`, une ancre, ou un groupe `(…)`). Pour complémenter une **séquence**, il faut **parenthéser** : `~(.*motif.*)` et non `~.*motif.*` (ce dernier ne complémente que le `.` et laisse passer le motif). On exploitera cette règle au §8."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a541f2e0",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:52.799227Z",
+     "iopub.status.busy": "2026-06-15T14:02:52.799095Z",
+     "iopub.status.idle": "2026-06-15T14:02:52.844405Z",
+     "shell.execute_reply": "2026-06-15T14:02:52.844486Z"
+    },
+    "papermill": {
+     "duration": 0.048221,
+     "end_time": "2026-06-15T14:02:52.844543+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.796322+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"a\") = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"e\") = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"t\") = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Accepts(\"z\") = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Témoin de (^[a-z]$ & ~[aeiou]) = \"x\" (une consonne)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// A & ~B : une minuscule (A) qui n'est pas une voyelle (~B) = une consonne.\n",
+    "var consonne = engine.CreateFromRegexes(\"^[a-z]$&~[aeiou]\");\n",
+    "\n",
+    "foreach (var s in new[] { \"a\", \"e\", \"t\", \"z\" })\n",
+    "    Console.WriteLine($\"  Accepts(\\\"{s}\\\") = {engine.Solver.Accepts(consonne, s)}\");\n",
+    "\n",
+    "string temoinConsonne = engine.GenerateMember(consonne);\n",
+    "Console.WriteLine($\"  Témoin de (^[a-z]$ & ~[aeiou]) = \\\"{temoinConsonne}\\\" (une consonne)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4128fa0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002524,
+     "end_time": "2026-06-15T14:02:52.849741+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.847217+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Le moteur de témoin — le chemin sûr\n",
+    "\n",
+    "`RexEngine.GenerateMember(automate)` effectue une **marche aléatoire** sur l'automate déterministe et renvoie un mot accepté. Deux règles d'usage :\n",
+    "\n",
+    "- **Construire l'automate via `engine.CreateFromRegexes(...)`** (ou `engine.Solver`), pour qu'il partage l'**algèbre** du moteur (cf §2). Le §6 montre ce qui se passe sinon.\n",
+    "- Utiliser **`GenerateMember`** (marche aléatoire) et non `GenerateMemberUniformly` : ce dernier exige un automate fini et **lève une exception** sur un langage infini/bouclant.\n",
+    "\n",
+    "Le chemin est toujours le même :\n",
+    "```csharp\n",
+    "var engine = new RexEngine(BitWidth.BV7);\n",
+    "var aut    = engine.CreateFromRegexes(\"...&~...\");  // surface &/~\n",
+    "string w   = engine.GenerateMember(aut);            // témoin\n",
+    "bool ok    = engine.Solver.Accepts(aut, w);         // vérification\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "11e49691",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:52.855702Z",
+     "iopub.status.busy": "2026-06-15T14:02:52.855556Z",
+     "iopub.status.idle": "2026-06-15T14:02:52.929851Z",
+     "shell.execute_reply": "2026-06-15T14:02:52.929704Z"
+    },
+    "papermill": {
+     "duration": 0.077687,
+     "end_time": "2026-06-15T14:02:52.929904+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.852217+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  regex=^[ab]$&^[bc]$          témoin=\"b\" accepté=True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  regex=^[a-z]$&~[aeiou]       témoin=\"n\" accepté=True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  regex=^[0-9]{4}$&~(.*0.*)    témoin=\"5364\" accepté=True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Vérification systématique : tout témoin généré doit être accepté par son propre automate.\n",
+    "string CheckTemoin(RexEngine eng, string regex)\n",
+    "{\n",
+    "    var aut = eng.CreateFromRegexes(regex);\n",
+    "    string w = eng.GenerateMember(aut);\n",
+    "    bool ok = eng.Solver.Accepts(aut, w);\n",
+    "    return $\"  regex={regex,-22} témoin=\\\"{w}\\\" accepté={ok}\";\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(CheckTemoin(engine, \"^[ab]$&^[bc]$\"));\n",
+    "Console.WriteLine(CheckTemoin(engine, \"^[a-z]$&~[aeiou]\"));\n",
+    "Console.WriteLine(CheckTemoin(engine, \"^[0-9]{4}$&~(.*0.*)\"));  // 4 chiffres sans aucun zéro"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4ed7a37",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002291,
+     "end_time": "2026-06-15T14:02:52.934814+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.932523+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Le piège du solveur croisé — une leçon sur l'identité d'algèbre\n",
+    "\n",
+    "Que se passe-t-il si on construit l'automate avec **un** `CharSetSolver` puis qu'on demande le témoin à un `RexEngine` qui en possède **un autre** ? Les BDD des deux solveurs ne partagent **aucune identité de terminal** : la descente dans l'algèbre échouerait.\n",
+    "\n",
+    "Le fork (#2979, étape 4) transforme cette situation en **`ArgumentException` claire et actionnable** — au lieu de l'historique `NullReferenceException` cryptique au fond de `BDDAlgebra.Choose`. **Ce n'est pas un bug, c'est une garde** : le message vous dit exactement quoi faire.\n",
+    "\n",
+    "> On enveloppe la démonstration dans un `try/catch` : le notebook s'exécute de bout en bout (la garde est *attendue*, pas une panne)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4590ac3f",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:52.940371Z",
+     "iopub.status.busy": "2026-06-15T14:02:52.940223Z",
+     "iopub.status.idle": "2026-06-15T14:02:52.990519Z",
+     "shell.execute_reply": "2026-06-15T14:02:52.990421Z"
+    },
+    "papermill": {
+     "duration": 0.053382,
+     "end_time": "2026-06-15T14:02:52.990570+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.937188+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ArgumentException attendue (garde du fork) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  RexEngine.GenerateMember: the automaton was built with a different CharSetSolver than this engine. BDD descent requires a shared algebra. Build the automaton via engine.CreateFromRegexes(...) or engine.Solver, or construct the engine via the RexEngine(CharSetSolver) ctor. (Parameter 'fa')\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Correction → CreateFromRegexes : témoin = \"[vabF\"\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// MAUVAIS chemin : automate bâti avec un solveur externe, témoin demandé à un autre moteur.\n",
+    "var solveurExterne = new CharSetSolver(BitWidth.BV7);\n",
+    "var moteur = new RexEngine(BitWidth.BV7);   // possède un solveur DIFFÉRENT\n",
+    "var autExterne = solveurExterne.Convert(\"[ab]+\", RegexOptions.None)\n",
+    "                               .RemoveEpsilons().Determinize().Minimize();\n",
+    "\n",
+    "try\n",
+    "{\n",
+    "    string w = moteur.GenerateMember(autExterne);   // déclenche la garde\n",
+    "    Console.WriteLine($\"(inattendu) témoin = {w}\");\n",
+    "}\n",
+    "catch (ArgumentException ex)\n",
+    "{\n",
+    "    Console.WriteLine(\"ArgumentException attendue (garde du fork) :\");\n",
+    "    Console.WriteLine(\"  \" + ex.Message.Split('\\n')[0]);\n",
+    "}\n",
+    "\n",
+    "// BON chemin : construire via le moteur lui-même.\n",
+    "var autSafe = moteur.CreateFromRegexes(\"[ab]+\");\n",
+    "Console.WriteLine($\"  Correction → CreateFromRegexes : témoin = \\\"{moteur.GenerateMember(autSafe)}\\\"\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35c6807d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002706,
+     "end_time": "2026-06-15T14:02:52.995936+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.993230+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Émettre la formule SMT-LIB — `re.inter` / `re.comp`\n",
+    "\n",
+    "Le même motif `A & ~B` se **traduit en théorie des chaînes SMT-LIB**, le langage des solveurs comme Z3. Le fork expose `RegexToSMTConverter` (rendu **public** pour ce notebook, #2979 étape 6) : il convertit une regex de surface en expression SMT, où `&` devient `re.inter` et `~` devient `re.comp`.\n",
+    "\n",
+    "C'est le pont entre les deux mondes du cours : la **syntaxe regex** d'ici et la **contrainte SMT** des notebooks Z3 01–05."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "527386f5",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:53.002659Z",
+     "iopub.status.busy": "2026-06-15T14:02:53.002508Z",
+     "iopub.status.idle": "2026-06-15T14:02:53.038576Z",
+     "shell.execute_reply": "2026-06-15T14:02:53.038481Z"
+    },
+    "papermill": {
+     "duration": 0.040141,
+     "end_time": "2026-06-15T14:02:53.038626+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:52.998485+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "regex   : [ab]&~[bc]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SMT-LIB : (re.inter (re-range #b1100001 #b1100010) (re.comp (re-range #b1100010 #b1100011)))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "regex   : [a-z]&~[aeiou]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SMT-LIB : (re.inter (re-range #b1100001 #b1111010) (re.comp (re-union (re-range #b1100001 #b1100001)(re-union (re-range #b1100101 #b1100101)(re-union (re-range #b1101001 #b1101001)(re-union (re-range #b1101111 #b1101111) (re-range #b1110101 #b1110101)))))))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var conv = new RegexToSMTConverter(BitWidth.BV7);\n",
+    "\n",
+    "foreach (var regex in new[] { \"[ab]&~[bc]\", \"[a-z]&~[aeiou]\" })\n",
+    "{\n",
+    "    Console.WriteLine($\"regex   : {regex}\");\n",
+    "    Console.WriteLine($\"SMT-LIB : {conv.ConvertRegex(regex)}\");\n",
+    "    Console.WriteLine();\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba38e2c5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00253,
+     "end_time": "2026-06-15T14:02:53.043827+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.041297+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Le payoff — générer un mot de passe `politique & ~faibles`\n",
+    "\n",
+    "Voici le motif `A & ~B` à pleine puissance, sur un cas réel : **fabriquer un mot de passe conforme à une politique tout en évitant les motifs faibles connus**.\n",
+    "\n",
+    "- **A** = `^[A-Za-z0-9]{8}$` — exactement 8 caractères alphanumériques ;\n",
+    "- **~B₁** = `~(.*password.*)` — ne **contient pas** la sous-chaîne `password` ;\n",
+    "- **~B₂** = `~(^[0-9].*$)` — ne **commence pas** par un chiffre.\n",
+    "\n",
+    "On note l'usage des **parenthèses** sur `~(…)` (cf §4) : on complémente bien des *séquences*, pas un seul atome. Le moteur produit des témoins variés (marche aléatoire) — chacun est un mot de passe valide selon la politique, vérifié contre les trois conditions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "70e34ed8",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:53.049764Z",
+     "iopub.status.busy": "2026-06-15T14:02:53.049594Z",
+     "iopub.status.idle": "2026-06-15T14:02:53.101380Z",
+     "shell.execute_reply": "2026-06-15T14:02:53.101270Z"
+    },
+    "papermill": {
+     "duration": 0.055156,
+     "end_time": "2026-06-15T14:02:53.101444+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.046288+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Témoins générés (chacun re-vérifié indépendamment) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  \"Jp8papa9\"  len8=True  sansPassword=True  sansChiffreInitial=True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  \"W9ppaapa\"  len8=True  sansPassword=True  sansChiffreInitial=True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  \"tppa5p08\"  len8=True  sansPassword=True  sansChiffreInitial=True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  \"p9Tppap8\"  len8=True  sansPassword=True  sansChiffreInitial=True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  \"Opass79p\"  len8=True  sansPassword=True  sansChiffreInitial=True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// A & ~B1 & ~B2 : 8 alphanumériques, sans \"password\", ne commençant pas par un chiffre.\n",
+    "string politique = \"^[A-Za-z0-9]{8}$&~(.*password.*)&~(^[0-9].*$)\";\n",
+    "var motDePasse = engine.CreateFromRegexes(politique);\n",
+    "\n",
+    "// Vérificateurs indépendants (RE#) pour prouver l'honnêteté de chaque témoin.\n",
+    "bool SansPassword(string s) => !s.Contains(\"password\");\n",
+    "bool SansChiffreInitial(string s) => s.Length > 0 && !char.IsDigit(s[0]);\n",
+    "\n",
+    "Console.WriteLine(\"Témoins générés (chacun re-vérifié indépendamment) :\");\n",
+    "for (int i = 0; i < 5; i++)\n",
+    "{\n",
+    "    string w = engine.GenerateMember(motDePasse);\n",
+    "    bool len8 = w.Length == 8;\n",
+    "    Console.WriteLine($\"  \\\"{w}\\\"  len8={len8}  sansPassword={SansPassword(w)}  sansChiffreInitial={SansChiffreInitial(w)}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7e76feb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002696,
+     "end_time": "2026-06-15T14:02:53.107318+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.104622+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Le plafond de 21 caractères est levé (issue #6)\n",
+    "\n",
+    "La machinerie de témoin historique d'AutomataDotNet plafonnait en pratique vers **~21 caractères** pour les automates non triviaux (au-delà, elle explosait ou bouclait). Le fork sous net8.0 lève ce plafond : on génère ici un témoin de **30 caractères** sans difficulté.\n",
+    "\n",
+    "> **Honnêteté — la portée exacte.** Le fork lève le **mur du témoin** (longueur). Il ne lève **pas** le **mur de l'explosion d'automate** : intersecter des dizaines de contraintes (p. ex. les 81 cases d'un Sudoku) fait exploser le produit cartésien des états. Pour le Sudoku à l'échelle, **Z3 `Distinct` reste le résolveur de production** (~27 ms). Le verdict mesuré est au §6b du [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb). Le vrai payoff de ce notebook est la **génération de témoin générale** `A & ~B`, pas le Sudoku."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "2a81aba6",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:53.113631Z",
+     "iopub.status.busy": "2026-06-15T14:02:53.113496Z",
+     "iopub.status.idle": "2026-06-15T14:02:53.149123Z",
+     "shell.execute_reply": "2026-06-15T14:02:53.149031Z"
+    },
+    "papermill": {
+     "duration": 0.039052,
+     "end_time": "2026-06-15T14:02:53.149173+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.110121+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  témoin     = \"xoflbuoqbwsunesjylabcznvcgoamx\"\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  longueur   = 30  (ancien plafond ~21)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  accepté    = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  temps      = 0,0 ms\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// [a-z]{30} : plus long que l'ancien plafond ~21. Mesure du temps.\n",
+    "var long30 = engine.CreateFromRegexes(\"^[a-z]{30}$\");\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "string temoinLong = engine.GenerateMember(long30);\n",
+    "sw.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"  témoin     = \\\"{temoinLong}\\\"\");\n",
+    "Console.WriteLine($\"  longueur   = {temoinLong.Length}  (ancien plafond ~21)\");\n",
+    "Console.WriteLine($\"  accepté    = {engine.Solver.Accepts(long30, temoinLong)}\");\n",
+    "Console.WriteLine($\"  temps      = {sw.Elapsed.TotalMilliseconds:F1} ms\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbad4641",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002768,
+     "end_time": "2026-06-15T14:02:53.154819+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.152051+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices pour pratiquer le motif `A & ~B` et la génération de témoin. Les cellules sont des **squelettes à compléter** : remplacez les `// TODO etudiant` puis exécutez. Un vérificateur indépendant est fourni à chaque fois."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "078db832",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002589,
+     "end_time": "2026-06-15T14:02:53.161578+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.158989+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Une adresse e-mail valide mais pas `@spam.com`\n",
+    "\n",
+    "Générez un témoin pour le motif `A & ~B` où :\n",
+    "- **A** = une adresse e-mail simple, p. ex. `^[a-z]+@[a-z]+\\.[a-z]+$` ;\n",
+    "- **~B** = qui **ne se termine pas** par `@spam.com` → `~(.*@spam\\.com$)`.\n",
+    "\n",
+    "`# Indice` : pensez à **parenthéser** le `~(…)` (cf §4). `# Etape 1` : construisez l'automate via `engine.CreateFromRegexes`. `# Etape 2` : générez et vérifiez le témoin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8d8ed423",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:53.167942Z",
+     "iopub.status.busy": "2026-06-15T14:02:53.167809Z",
+     "iopub.status.idle": "2026-06-15T14:02:53.203957Z",
+     "shell.execute_reply": "2026-06-15T14:02:53.203859Z"
+    },
+    "papermill": {
+     "duration": 0.03974,
+     "end_time": "2026-06-15T14:02:53.204008+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.164268+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : definir motifEmail (A & ~B).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : e-mail valide, mais pas @spam.com.\n",
+    "// Etape 1 : composez le motif A & ~B (A = email simple, ~B = pas @spam.com).\n",
+    "string motifEmail = null;  // TODO etudiant : \"^[a-z]+@[a-z]+\\\\.[a-z]+$&~(.*@spam\\\\.com$)\"\n",
+    "\n",
+    "if (motifEmail == null)\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice a completer : definir motifEmail (A & ~B).\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    // Etape 2 : construire, generer, verifier.\n",
+    "    var autEmail = engine.CreateFromRegexes(motifEmail);\n",
+    "    string temoin = engine.GenerateMember(autEmail);\n",
+    "    bool pasSpam = !temoin.EndsWith(\"@spam.com\");\n",
+    "    Console.WriteLine($\"temoin=\\\"{temoin}\\\"  pasSpam={pasSpam}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90f7ee76",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002627,
+     "end_time": "2026-06-15T14:02:53.209747+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.207120+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Diagnostiquer et corriger le piège du solveur croisé\n",
+    "\n",
+    "Le code ci-dessous **échoue** : il construit l'automate avec un `CharSetSolver` local puis demande le témoin à un `RexEngine` distinct (le piège du §6). **Diagnostiquez** l'exception attendue, puis **corrigez** en utilisant le chemin sûr.\n",
+    "\n",
+    "`# Indice` : relisez le §6 — l'automate doit partager l'**algèbre** du moteur. `# Etape 1` : remplacez la construction par `engine.CreateFromRegexes(...)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9b80eed1",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:53.216188Z",
+     "iopub.status.busy": "2026-06-15T14:02:53.216052Z",
+     "iopub.status.idle": "2026-06-15T14:02:53.246049Z",
+     "shell.execute_reply": "2026-06-15T14:02:53.245955Z"
+    },
+    "papermill": {
+     "duration": 0.033726,
+     "end_time": "2026-06-15T14:02:53.246098+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.212372+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : construire autEx2 via le chemin sur (cf section 6).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : corriger le piège du solveur croisé.\n",
+    "var solveurLocal = new CharSetSolver(BitWidth.BV7);\n",
+    "var moteurEx2 = new RexEngine(BitWidth.BV7);\n",
+    "\n",
+    "// TODO etudiant : cette construction utilise le MAUVAIS solveur. Corrigez-la.\n",
+    "// Indice : Automaton<BDD> autEx2 = moteurEx2.CreateFromRegexes(\"^[a-z]{5}$\");\n",
+    "Automaton<BDD> autEx2 = null;  // Etape 1 : construire via moteurEx2.CreateFromRegexes(...)\n",
+    "\n",
+    "if (autEx2 == null)\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice a completer : construire autEx2 via le chemin sur (cf section 6).\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    string temoin = moteurEx2.GenerateMember(autEx2);\n",
+    "    Console.WriteLine($\"temoin=\\\"{temoin}\\\"  accepte={moteurEx2.Solver.Accepts(autEx2, temoin)}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0feeceac",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002639,
+     "end_time": "2026-06-15T14:02:53.251695+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.249056+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Un numéro de test à 10 chiffres, non déjà utilisé\n",
+    "\n",
+    "Classique de la génération de test : produire un identifiant **valide** mais **pas dans une liste déjà utilisée**. Motif `A & ~B` :\n",
+    "- **A** = `^[0-9]{10}$` — dix chiffres ;\n",
+    "- **~B** = ne commence pas par un préfixe réservé connu, p. ex. `~(^0000.*$)`.\n",
+    "\n",
+    "`# Indice` : même schéma qu'au §8. `# Etape 1` : composez le motif. `# Etape 2` : générez plusieurs témoins et vérifiez qu'aucun ne commence par `0000`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e0fc9b03",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-15T14:02:53.257963Z",
+     "iopub.status.busy": "2026-06-15T14:02:53.257833Z",
+     "iopub.status.idle": "2026-06-15T14:02:53.285778Z",
+     "shell.execute_reply": "2026-06-15T14:02:53.285682Z"
+    },
+    "papermill": {
+     "duration": 0.031401,
+     "end_time": "2026-06-15T14:02:53.285825+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.254424+00:00",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : definir motifNumero (A & ~B).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : numero de test a 10 chiffres, ne commencant pas par 0000.\n",
+    "string motifNumero = null;  // TODO etudiant : \"^[0-9]{10}$&~(^0000.*$)\"\n",
+    "\n",
+    "if (motifNumero == null)\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice a completer : definir motifNumero (A & ~B).\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    var autNum = engine.CreateFromRegexes(motifNumero);\n",
+    "    for (int i = 0; i < 3; i++)\n",
+    "    {\n",
+    "        string w = engine.GenerateMember(autNum);\n",
+    "        Console.WriteLine($\"numero=\\\"{w}\\\"  len10={w.Length == 10}  pasPrefixe0000={!w.StartsWith(\"0000\")}\");\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccaf4bc8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002894,
+     "end_time": "2026-06-15T14:02:53.291595+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T14:02:53.288701+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "| Ce qu'on a vu | Outil du fork |\n",
+    "|---------------|---------------|\n",
+    "| Intersection `&` en surface | parser → `Automaton.Intersect` |\n",
+    "| Complément `~` en surface (avec parenthésage) | parser → `Automaton.Complement` |\n",
+    "| Témoin de `A & ~B` | `RexEngine.GenerateMember` (chemin partagé) |\n",
+    "| Garde solveur croisé | `ArgumentException` claire (#2979 étape 4) |\n",
+    "| Formule SMT-LIB | `RegexToSMTConverter` → `re.inter` / `re.comp` |\n",
+    "| Témoin > 21 caractères | plafond #6 levé sous net8.0 |\n",
+    "\n",
+    "### À retenir\n",
+    "\n",
+    "- **Reconnaître ≠ produire.** RexEngine fabrique un témoin là où RE# ne fait que tester.\n",
+    "- **`A & ~B`** est le motif universel de génération sous contrainte positive/négative.\n",
+    "- **`~` se lie à l'atome suivant** : parenthésez `~(…)` pour complémenter une séquence.\n",
+    "- **Algèbre partagée** : construisez l'automate via le moteur (`CreateFromRegexes`).\n",
+    "- **Portée honnête** : le fork lève le mur du témoin, pas l'explosion d'automate. À l'échelle (Sudoku 81), **Z3 reste le résolveur de production**.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "`<<` [05 — Meal Planner hiérarchique](05_Meal_Planner_Hierarchical.ipynb) | [Sudoku-13 — Automates symboliques `>>`](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.977705,
+   "end_time": "2026-06-15T14:02:53.418639+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "06_Witness_Generation_Automata.ipynb",
+   "output_path": "06_Witness_Generation_Automata.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-15T14:02:49.440934+00:00",
+   "version": "2.7.0"
+  },
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "csharp",
+    "items": [
+     {
+      "aliases": [
+       "c#",
+       "cs"
+      ],
+      "languageName": "C#",
+      "name": "csharp"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -4,7 +4,7 @@
 
 ## Série en quelques mots
 
-**6 notebooks** | **1 kernel** | **~4h30 de travail** | **Z3.Linq (.NET 9)**
+**7 notebooks** | **1 kernel** | **~5h10 de travail** | **Z3.Linq + fork Automata (.NET 9)**
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs C# souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de théorèmes linéaires simples pour monter progressivement vers les théories de tableaux et l'optimisation hiérarchique.
 
@@ -34,6 +34,7 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 | 03 | [Array Theory](03_Array_Theory.ipynb) | Z3 array theory : Select/Store, switching dynamique | ~45 min | BETA |
 | 04 | [Nested Arrays 2D](04_Nested_Arrays_2D.ipynb) | Tableaux imbriqués, grilles 2D, Sudoku 4x4, carré magique | ~40 min | BETA |
 | 05 | [Meal Planner Hierarchical](05_Meal_Planner_Hierarchical.ipynb) | Planificateur de repas : data fusion LINQ + théorème hiérarchique | ~50 min | BETA |
+| 06 | [Witness Generation Automata](06_Witness_Generation_Automata.ipynb) | **Fork Automata** : générer un *témoin* depuis `A & ~B` (intersection/complément de surface), cap des 21 caractères levé (#6), émission SMT-LIB `re.inter`/`re.comp` | ~40 min | BETA |
 
 ### Fil pédagogique
 
@@ -43,6 +44,7 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 4. **Notebook 03** plonge dans la théorie des tableaux Z3 (Select/Store), avec switching dynamique entre représentations
 5. **Notebook 04** généralise aux tableaux imbriqués (2D) : grilles, carrés magiques, Sudoku 4x4
 6. **Notebook 05** intègre tout : data fusion LINQ + théorème hiérarchique multi-niveaux pour un planificateur de repas réaliste, et démontre le mode `CollectionHandling.Constants` (feature ressuscitée du fork)
+7. **Notebook 06** ferme la boucle *reconnaissance vs production* : le fork [Automata](https://github.com/MyIntelligenceAgency/Automata) (modernisation net8.0 de AutomataDotNet, gelé ~2020) génère un **témoin** depuis la syntaxe de surface `&`/`~` (intersection/complément), démontre que le cap des 21 caractères (#6) est levé, et émet du SMT-LIB (`re.inter`/`re.comp`). C'est le payoff général de la génération de témoin `A & ~B` que [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) mesure ensuite à l'échelle (§6b)
 
 ## Prérequis
 
@@ -52,7 +54,8 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 | **.NET Interactive** | `dotnet tool install --global Microsoft.dotnet-interactive` |
 | **Kernel Jupyter** | `.net-csharp` (installe automatiquement par .NET Interactive) |
 | **Package NuGet** | `Z3.Linq` (NB-01, 02 : charge automatiquement via `#r nuget:...`) |
-| **Tous les notebooks — fork** | La série entière utilise le fork [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) : NB-04 pour le support `int[][]` (absent du NuGet public endjin), NB-02b, NB-03 et NB-05 pour la feature `CollectionHandling` (mode `Constants` ressuscité, câblée le 14/06/2026), NB-01 et NB-02 pour l'homogénéité de la série (toute la série sur la même build fork, cohérence pédagogique). Exécuter **une fois** : [`scripts/environment/z3-build-deploy.ps1`](../../../../scripts/environment/z3-build-deploy.ps1) (Windows) ou [`.sh`](../../../../scripts/environment/z3-build-deploy.sh) (Linux/macOS) — compile uniquement le wrapper (~1,5 s) et rassemble les 4 DLL dans `.deploy/`. |
+| **NB-01 à 05 — fork Z3.Linq** | Ces notebooks utilisent le fork [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) : NB-04 pour le support `int[][]` (absent du NuGet public endjin), NB-02b, NB-03 et NB-05 pour la feature `CollectionHandling` (mode `Constants` ressuscité, câblée le 14/06/2026), NB-01 et NB-02 pour l'homogénéité de la série (toute la série sur la même build fork, cohérence pédagogique). Exécuter **une fois** : [`scripts/environment/z3-build-deploy.ps1`](../../../../scripts/environment/z3-build-deploy.ps1) (Windows) ou [`.sh`](../../../../scripts/environment/z3-build-deploy.sh) (Linux/macOS) — compile uniquement le wrapper (~1,5 s) et rassemble les 4 DLL dans `.deploy/`. |
+| **NB-06 — fork Automata** | Le notebook 06 consomme un fork **distinct**, [MyIntelligenceAgency/Automata](https://github.com/MyIntelligenceAgency/Automata) (modernisation net8.0 de AutomataDotNet, gelé ~2020 ; ajoute les opérateurs de surface `&`/`~` et lève le cap du témoin #6), monté en sous-module sibling de `Z3.Linq/`. Exécuter **une fois** : [`scripts/environment/automata-build-deploy.ps1`](../../../../scripts/environment/automata-build-deploy.ps1) — compile le wrapper (~6 s) et rassemble `Microsoft.Automata.dll` + `System.CodeDom.dll` dans `.deploy/`. |
 
 > Les notebooks sont autonomes : le chargement du fork Z3.Linq et l'initialisation du contexte sont inclus dans les cellules de setup de chaque notebook via `#r "../Z3.Linq/.deploy/..."`, d'où le pré-requis du script de build ci-dessus (décision ai-01 [DECISION COORD] 2026-06-13, option (b), étendue à 02b/03/05 le 14/06/2026 pour `CollectionHandling`, puis à 01/02 le 15/06/2026 pour l'homogénéité de la série).
 
@@ -62,7 +65,10 @@ Toute la série Z3 charge le **même fork** [MyIntelligenceAgency/Z3.Linq](https
 
 | Notebooks                   | Source                | Chargement                    | Pré-requis      |
 |-----------------------------|-----------------------|-------------------------------|-----------------|
-| 01, 02, 02b, 03, 04, 05     | Fork (voir ci-dessus) | `#r "../Z3.Linq/.deploy/..."` | Script de build |
+| 01, 02, 02b, 03, 04, 05     | Fork [Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) | `#r "../Z3.Linq/.deploy/..."` | [`z3-build-deploy.ps1`](../../../../scripts/environment/z3-build-deploy.ps1) |
+| 06                          | Fork [Automata](https://github.com/MyIntelligenceAgency/Automata) | `#r "../Automata/.deploy/..."` | [`automata-build-deploy.ps1`](../../../../scripts/environment/automata-build-deploy.ps1) |
+
+> **Notebook 06 fait exception au « fork unique »** : il consomme le fork *Automata* (regex symbolique → génération de témoin, opérateurs de surface `&`/`~`, cap #6 levé), monté en sous-module sibling de `Z3.Linq/`, via son propre script de build. Les notebooks 01-05 (résolution LINQ → SMT) partagent la build Z3.Linq ; le 06 (reconnaissance/production de témoin) est le compagnon « regex symbolique » de la série, relié à l'Epic #2978/#2979.
 
 **Pourquoi un fork ?** Trois raisons : (1) le support des tableaux imbriqués `int[][]` (construction de sort Z3 `Array Int (Array Int Int)`, extraction récursive `ExtractCollection`) provient de [Z3.LinqBinding@EPFdevelopment](https://github.com/MyIntelligenceAgency/Z3.LinqBinding/tree/EPFdevelopment) et n'existe pas dans le NuGet public endjin (`Z3.Linq` 2.0.1, qui ne gère qu'un seul niveau de collection) ; (2) la feature `CollectionHandling` (mode `Constants`, un constant Z3 par élément) a été ressuscitée et câblée le 14/06/2026 ; (3) l'homogénéité de la série (NB-01 et NB-02 basculés sur le fork le 15/06/2026). Publier un NuGet forké n'est pas possible (nous ne sommes pas propriétaires du *package-id*), d'où le script qui compile **uniquement** le wrapper fin et rassemble le solveur natif + les dépendances managées depuis le cache NuGet.
 

--- a/scripts/environment/automata-build-deploy.ps1
+++ b/scripts/environment/automata-build-deploy.ps1
@@ -1,0 +1,152 @@
+# Automata Fork Build Script for CoursIA SymbolicAI Notebooks
+#
+# Builds the AutomataDotNet fork (which adds surface '&' / '~' regex operators and
+# lifts the 21-char witness cap, #2979) and gathers the DLLs the SMT/Z3 notebook 06
+# needs into the submodule's .deploy/ directory.
+#
+# Why this script exists:
+#   The fork (github.com/MyIntelligenceAgency/Automata, branch
+#   feature/net8-modernization-core) carries surface intersection/complement regex
+#   syntax + uncapped witness generation that are NOT on any public AutomataDotNet
+#   package (the upstream Microsoft.Automata is frozen ~2020 and was never net8.0).
+#   Microsoft.Automata is pure-managed (no native libz3-style payload), so building
+#   the single Automata.csproj (~6s) plus copying its one external managed dependency
+#   (System.CodeDom) from the NuGet cache is all that the notebook #r path-loads need.
+#
+# Result: a fresh checkout with --recurse-submodules + .NET SDK can run notebook
+#   06_Witness_Generation_Automata self-contained (no publish account, offline-friendly).
+#
+# Mirrors scripts/environment/z3-build-deploy.ps1 (Z3.Linq fork). See #2979 step 6.
+# See: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb (cell 1)
+
+param(
+    # Path to the Automata submodule (auto-detected relative to this script).
+    [string]$SubmoduleDir = (Resolve-Path (Join-Path $PSScriptRoot "..\..\MyIA.AI.Notebooks\SymbolicAI\SMT\Automata")),
+
+    # Build configuration.
+    [string]$Configuration = "Release",
+
+    # Force rebuild even if .deploy/ already looks complete.
+    [switch]$Force = $false
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Automata Fork Build for CoursIA SymbolicAI ===" -ForegroundColor Cyan
+Write-Host ""
+
+# --- locate submodule + csproj ---------------------------------------------------------
+$submodule = (Resolve-Path $SubmoduleDir).Path
+$csproj = Join-Path $submodule "src\Automata\Automata.csproj"
+$deployDir = Join-Path $submodule ".deploy"
+
+if (-not (Test-Path $csproj)) {
+    Write-Host "ERROR: Automata.csproj not found at: $csproj" -ForegroundColor Red
+    Write-Host "Did you clone with --recurse-submodules? Run:" -ForegroundColor Yellow
+    Write-Host "  git submodule update --init --recursive" -ForegroundColor Gray
+    exit 1
+}
+
+Write-Host "Submodule : $submodule" -ForegroundColor Gray
+Write-Host "Project   : $csproj" -ForegroundColor Gray
+Write-Host "Output    : $deployDir" -ForegroundColor Gray
+Write-Host ""
+
+# --- dotnet SDK precondition (installable everywhere, rule F) -------------------------
+$dotnet = Get-Command dotnet -ErrorAction SilentlyContinue
+if (-not $dotnet) {
+    Write-Host "ERROR: dotnet SDK not found on PATH." -ForegroundColor Red
+    Write-Host "Install .NET 8.0+ SDK from https://dotnet.microsoft.com/download" -ForegroundColor Yellow
+    exit 1
+}
+
+# --- idempotency check -----------------------------------------------------------------
+# .deploy/ is complete when both required DLLs are present.
+$requiredDlls = @("Microsoft.Automata.dll", "System.CodeDom.dll")
+$complete = $false
+if ((Test-Path $deployDir) -and -not $Force) {
+    $missing = $requiredDlls | Where-Object { -not (Test-Path (Join-Path $deployDir $_)) }
+    if (-not $missing) {
+        $complete = $true
+    }
+}
+if ($complete) {
+    Write-Host ".deploy/ already complete (2 DLLs present). Use -Force to rebuild." -ForegroundColor Green
+    exit 0
+}
+
+# --- build the csproj ------------------------------------------------------------------
+Write-Host "Building Automata fork ($Configuration)..." -ForegroundColor Cyan
+& dotnet build $csproj -c $Configuration --nologo 2>&1 | ForEach-Object {
+    if ($_ -match "error|Erreur") { Write-Host $_ -ForegroundColor Red }
+    elseif ($_ -match "succeeded|réussi|->") { Write-Host $_ -ForegroundColor Gray }
+}
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "ERROR: dotnet build failed (exit $LASTEXITCODE)." -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+
+$buildOut = Join-Path $submodule "src\Automata\bin\$Configuration\net8.0"
+$builtDll = Join-Path $buildOut "Microsoft.Automata.dll"
+if (-not (Test-Path $builtDll)) {
+    Write-Host "ERROR: build succeeded but Microsoft.Automata.dll not found at $buildOut" -ForegroundColor Red
+    exit 1
+}
+
+# Sanity: confirm the fork core (CharSetSolver) is in the built DLL.
+$bytes = [System.IO.File]::ReadAllText($builtDll, [System.Text.Encoding]::Latin1)
+if ($bytes -notmatch "CharSetSolver") {
+    Write-Host "WARNING: built Microsoft.Automata.dll lacks CharSetSolver — is the submodule at the fork commit?" -ForegroundColor Yellow
+    Write-Host "  Expected commit 4a7b7f0 (MyIntelligenceAgency/Automata, surface &/~ + uncapped witness)." -ForegroundColor Gray
+} else {
+    Write-Host "  CharSetSolver present (fork core OK)." -ForegroundColor Green
+}
+
+# --- prepare .deploy/ ------------------------------------------------------------------
+if (Test-Path $deployDir) { Remove-Item -Recurse -Force $deployDir }
+New-Item -ItemType Directory -Path $deployDir -Force | Out-Null
+
+# 1. the fork assembly from the local build output
+Copy-Item $builtDll $deployDir -Force
+
+# 2. managed dependency from the NuGet package cache.
+#    System.CodeDom is the single external managed dependency (see deps.json). A
+#    dotnet build of a library does not copy managed deps into bin/ (resolved at
+#    runtime via deps.json), but #r path-loads in a notebook need it on disk.
+$nugetRoot = Join-Path $env:USERPROFILE ".nuget\packages"
+if (-not (Test-Path $nugetRoot)) {
+    Write-Host "ERROR: NuGet package cache not found at $nugetRoot" -ForegroundColor Red
+    Write-Host "  (run the build once to restore packages, or set NUGET_PACKAGES)" -ForegroundColor Yellow
+    exit 1
+}
+
+$codeDom = Join-Path $nugetRoot "system.codedom\8.0.0\lib\net8.0\System.CodeDom.dll"
+if (Test-Path $codeDom) {
+    Copy-Item $codeDom (Join-Path $deployDir "System.CodeDom.dll") -Force
+} else {
+    Write-Host "ERROR: dependency not found in NuGet cache: $codeDom" -ForegroundColor Red
+    Write-Host "  Run: dotnet restore $csproj  (then re-run this script)" -ForegroundColor Yellow
+    exit 1
+}
+
+# --- verify ----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== .deploy/ contents ===" -ForegroundColor Cyan
+Get-ChildItem $deployDir -Filter "*.dll" | ForEach-Object {
+    Write-Host ("  {0,-24} {1,8} KB" -f $_.Name, [int]($_.Length/1KB)) -ForegroundColor Gray
+}
+
+$missing = $requiredDlls | Where-Object { -not (Test-Path (Join-Path $deployDir $_)) }
+if ($missing) {
+    Write-Host ""
+    Write-Host "FAILED: missing DLLs: $($missing -join ', ')" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "=== Automata fork build complete ===" -ForegroundColor Green
+Write-Host ".deploy/ ready at: $deployDir" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Notebook 06 cell 1 should now resolve:" -ForegroundColor White
+Write-Host '  #r "../Automata/.deploy/Microsoft.Automata.dll"' -ForegroundColor Gray
+exit 0


### PR DESCRIPTION
## Resume

Step 6 de l'epic **#2978 / #2979** : demontrer le payoff *general* de la generation de temoin `A & ~B` (intersection / complement de surface) via le fork **[MyIntelligenceAgency/Automata](https://github.com/MyIntelligenceAgency/Automata)** (modernisation net8.0 de AutomataDotNet, gele ~2020). Repond a la question de recherche de #2979 : *une fois #6 debride, le chemin witness-SMT-depuis-intersection est-il tractable pour un Sudoku 81 cases ?*

**Reponse mesuree (honnete) :** le fork leve le **mur 2** (cap du temoin a ~21 chars, [issue #6](https://github.com/AutomataDotNet/Automata/issues/6)) mais PAS le **mur 1** (explosion du DFA a l'echelle). Z3 `Distinct` reste le resolveur de production (~27 ms pour 81 cases). Le payoff reel = generation de temoin **generale** (`A & ~B` = test input / password generation), pas le Sudoku a l'echelle.

## Livrables (un theme, atomique)

| Fichier | Nature |
|---------|--------|
| `.gitmodules` + sous-module `SMT/Automata` | Sous-module sibling de `Z3.Linq/`, pinne au fork commit `4a7b7f0` (RegexToSMTConverter rendu public pour consommation notebook) |
| `scripts/environment/automata-build-deploy.ps1` | Build du wrapper + `.deploy/` (Microsoft.Automata.dll + System.CodeDom.dll), miroir de `z3-build-deploy.ps1` |
| `SMT/Z3/06_Witness_Generation_Automata.ipynb` | **NOUVEAU** (27 cellules, kernel `.net-csharp`, outputs colles) |
| `Sudoku/Sudoku-13-...ipynb` | Insertion section 6b (4 cellules) + refs fork sections 8/9 + fix portabilite RE# |
| `SMT/Z3/README.md` | Ligne notebook 06 + fil pedagogique + config fork Automata |

## Preuves d'execution (regle D / C.2)

**Notebook 06** (papermill `.net-csharp`, 0 erreur) -- emission SMT-LIB depuis la syntaxe de surface (prouve `RegexToSMTConverter` public + fonctionnel) :
\`\`\`
regex   : [ab]&~[bc]
SMT-LIB : (re.inter (re-range #b1100001 #b1100010) (re.comp (re-range #b1100010 #b1100011)))
\`\`\`

**Sudoku-13 section 6b** (papermill complet, 33 cellules, 0 erreur) -- temoin pour UNE ligne (intersection 10-way) genere par Automata et **VALIDE par RE#** (validation croisee inter-moteurs) :
\`\`\`
Temoin Automata (1 ligne) : 273918456
  permutation de 1..9     : True
  valide selon RE#        : True  (validation croisee inter-moteurs)
  temps build + temoin    : 24196 ms
Rappel : Z3 resout la grille ENTIERE (81 cases) en ~27 ms (cf section 6).
\`\`\`
Grille 81 cases = **honnete** : ne lance PAS l'intersection 270-way, compte les contraintes (270 = 27 groupes x 10) et explique l'explosion DFA. Pas de faux timing.

## Verifications

- **H.3 / C.2** : 0 cellule code avec `execution_count: null` + outputs vides (06 : 12 code cells ; Sudoku-13 : 12). Outputs colles, 0 erreur sur les deux.
- **C.1** : 0 `throw`/`NotImplementedException`/`assert false`. 3 exercices stubbes (`Console.WriteLine(\"Exercice a completer\")` + `// TODO etudiant`) -- #2161 satisfait pour le 06.
- **Anti-regression** : Sudoku-13 -- 4 cellules ajoutees (6b) + 3 sources editees (cellule RE# `#r`, sections 8/9). Z3 + RE# existants byte-identical hors ces 3. Aucune cellule supprimee.
- **Catalogue** : byte-identical a `main` (branche rebasee sur `origin/main` frais).

## Fix de portabilite RE# (regle F -- env reparation, PAS contournement)

La cellule RE# pre-existante de Sudoku-13 referencait les builds **net9.0** de Resharp + FSharp.Core **10.1.300** (assembly 10.1.0.0), incompatibles avec le kernel `.net-csharp` canonique qui tourne sous **net8.0** (`dotnet-interactive 1.0.552801`, `tfm: net8.0`). Diagnostic via PEReader : Resharp 1.0.3 (build net8.0) lie `System.Runtime 8.0.0.0` + `FSharp.Core 10.0.0.0`. Fix : bascule vers les builds **net8.0** de Resharp + **FSharp.Core 10.0.100** (assembly 10.0.0.0). Environnement repare localement (restore cache NuGet), commentaire de cellule corrige (il affirmait a tort que 10.1.300 = assembly 10.0.0.0). Smoke-test + papermill complet valides.

See #2979 (contribution partielle a l'epic #2978 ; l'epic reste ouverte).

Generated with [Claude Code](https://claude.com/claude-code)