### PR TITLE
feat(genai): transparent wake-on-demand wrapper for notebooks (See #2982)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/shared/helpers/genai_service.py
+++ b/MyIA.AI.Notebooks/GenAI/shared/helpers/genai_service.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+genai_service.py - Client HTTP transparent pour services GenAI idle-monitores.
+
+Contrepartie cote notebook de `service_wake.py` (#2982) : les 16 services GenAI
+GPU sont auto-stoppes apres 20 min d'inactivite (liberation VRAM). Ce module
+rend le **wake-on-demand transparent au niveau du code notebook** : un appel
+`call_service("musicgen", "/v1/models")` reveille le service si besoin, attend
+le warm-up, puis execute la requete HTTP. Le notebook n'a plus a connaitre
+`service_wake.py` ni a gerer le 502 / connection-refused.
+
+## Pourquoi un wrapper (approche wake-and-retry cote appelant)
+
+- Aucun des 16 services ne configure `idle_action=sleep` (ils font `docker stop`).
+  Un container stoppe n'a AUCUN listener sur son port -> le wake DOIT provenir
+  de l'appelant (ou d'un proxy persistant, over-engineering pour une stack dev).
+- Ce wrapper est **additif** : il ne modifie ni le monitor ni les services. Il
+  reutilise `service_wake.ensure_service_up` (PR #2998, teste cold-start reel).
+- **Economie VRAM preservee** : les services s'auto-stoppent toujours apres
+  `idle_timeout` ; le wrapper ne lance `docker start` qu'en cas de demande reelle.
+
+## Usage
+
+    from helpers.genai_service import call_service
+
+    # Drop-in pour requests.get("http://localhost:8192/v1/models")
+    resp = call_service("musicgen", "/v1/models")
+    models = resp.json()
+
+    # POST avec payload + cle API
+    resp = call_service("tts-kokoro", "/v1/audio/speech",
+                        method="POST", json={"text": "bonjour"},
+                        api_key=os.getenv("KOKORO_API_KEY"))
+
+## Registre des services
+
+Le registre mappe un nom court (notebook-friendly) au tuple
+(container_docker, port_hote, chemin_health). Ports verifies via `docker inspect`
+sur po-2023 + memoire `docker-infra-regrounded.md`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger("genai_service")
+
+# Taille de fallback du registre : les services non listes necessitent un
+# container+health explicites (call_service_generic ci-dessous).
+DEFAULT_WAKE_TIMEOUT = 180
+DEFAULT_POLL_INTERVAL = 2
+
+# Registre des services GenAI : nom court -> (container, port, health_path).
+# Ports verifies via `docker inspect` (containers UP) + memoire infra pour les
+# services stoppes (demucs/kokoro/fish/qwen-asr/higgs non inspectables a froid).
+SERVICE_REGISTRY: Dict[str, Dict[str, Any]] = {
+    # Audio - TTS / STT / music / separation
+    "musicgen":      {"container": "musicgen-api",    "port": 8192, "health": "/health"},
+    "tts":           {"container": "tts-api",         "port": 8191, "health": "/health"},
+    "tts-kokoro":    {"container": "tts-kokoro",      "port": 8191, "health": "/health"},
+    "tts-fish":      {"container": "tts-fishaudio",   "port": 8197, "health": "/health"},
+    "tts-gateway":   {"container": "tts-gateway",     "port": 8196, "health": "/health"},
+    "higgs":         {"container": "higgs-tts",       "port": 8199, "health": "/health"},
+    "whisper":       {"container": "whisper-api",     "port": 8190, "health": "/health"},
+    "qwen-asr":      {"container": "qwen-asr-api",    "port": 8195, "health": "/health"},
+    "demucs":        {"container": "demucs-api",      "port": 8193, "health": "/health"},
+    # Image / Video
+    "comfyui-qwen":  {"container": "comfyui-qwen",    "port": 8188, "health": "/system_stats"},
+    "comfyui-video": {"container": "comfyui-video",   "port": 8189, "health": "/system_stats"},
+    "forge":         {"container": "forge-turbo",     "port": 1111, "health": "/sdapi/v1/options"},
+}
+
+
+def _resolve_service(name: str) -> Dict[str, Any]:
+    """Resout un nom court depuis le registre ; KeyError si inconnu."""
+    if name not in SERVICE_REGISTRY:
+        known = ", ".join(sorted(SERVICE_REGISTRY))
+        raise KeyError(
+            f"Service GenAI inconnu: {name!r}. Services enregistres: {known}. "
+            f"Pour un service hors-registre, utiliser call_service_generic() "
+            f"avec container+health explicites."
+        )
+    return SERVICE_REGISTRY[name]
+
+
+def _import_ensure_service_up():
+    """Importe ensure_service_up depuis service_wake (shared entre services).
+
+    service_wake.py vit dans docker-configurations/services/shared/. On le rend
+    importable en l'ajoutant au sys.path ; fallback gracieux si absent (les
+    notebooks peuvent quand meme appeler des services deja UP, le wake sera juste
+    saute avec un avertissement).
+    """
+    # Chemin 1 : service_wake a cote de ce module (shared/helpers/).
+    here = Path(__file__).resolve().parent
+    # Chemin 2 : docker-configurations/services/shared/ (emplacement canonique).
+    repo_shared = here.parents[3] / "docker-configurations" / "services" / "shared"
+    for candidate in (here, repo_shared):
+        if (candidate / "service_wake.py").exists():
+            sys.path.insert(0, str(candidate))
+            try:
+                from service_wake import ensure_service_up  # type: ignore
+                return ensure_service_up
+            except ImportError:
+                continue
+    logger.warning(
+        "service_wake.py introuvable (cherche dans %s et %s). Le wake-on-demand "
+        "est desactive : les services devront etre demarres manuellement.",
+        here, repo_shared,
+    )
+    return None
+
+
+def call_service_generic(
+    container: str,
+    port: int,
+    path: str,
+    method: str = "GET",
+    health_path: str = "/health",
+    api_key: Optional[str] = None,
+    timeout: int = DEFAULT_WAKE_TIMEOUT,
+    poll_interval: int = DEFAULT_POLL_INTERVAL,
+    request_timeout: float = 30.0,
+    **kwargs: Any,
+) -> requests.Response:
+    """Reveille si besoin puis execute une requete HTTP sur un service GenAI.
+
+    Version "hors-registre" : container, port et health_path explicites. Pour
+    les services connus, preferer `call_service()` (registre court).
+
+    Args:
+        container: Nom du container Docker (ex: "musicgen-api").
+        port: Port hote expose (ex: 8192).
+        path: Chemin de la requete (ex: "/v1/models").
+        method: Methode HTTP ("GET", "POST", ...).
+        health_path: Chemin du healthcheck (ex: "/health").
+        api_key: Cle API (Bearer) si le service a l'auth active. Lu depuis .env
+            via le nom "uppercase-container" si None (ex: MUSICGEN_API_API_KEY).
+        timeout: Delai max de warm-up apres docker start (secondes).
+        poll_interval: Intervalle de poll du healthcheck (secondes).
+        request_timeout: Timeout de la requete HTTP finale (secondes).
+        **kwargs: Args forwards a requests.request (json, data, headers, ...).
+
+    Returns:
+        requests.Response de la requete finale.
+
+    Raises:
+        RuntimeError: si le service ne peut etre reveille dans le delai.
+    """
+    base_url = f"http://localhost:{port}"
+    health_url = f"{base_url}{health_path}"
+    target_url = f"{base_url}{path}"
+
+    # Cle API : explicite > .env derive du nom de container.
+    if api_key is None:
+        env_var = f"{container.upper().replace('-', '_')}_API_KEY"
+        api_key = os.getenv(env_var)
+    # Cas particulier : tts-gateway utilise TTS_GATEWAY_API_KEY (sans le _API).
+    if api_key is None and "gateway" in container:
+        api_key = os.getenv("TTS_GATEWAY_API_KEY")
+
+    ensure_service_up = _import_ensure_service_up()
+    if ensure_service_up is not None:
+        if not ensure_service_up(
+            container, health_url, api_key=api_key,
+            timeout=timeout, poll_interval=poll_interval,
+        ):
+            raise RuntimeError(
+                f"Service {container} non healthy apres {timeout}s de warm-up. "
+                f"Verifiez `docker logs {container}`."
+            )
+    else:
+        logger.warning("Wake desactive (service_wake absent) - requete directe.")
+
+    headers = dict(kwargs.pop("headers", {}) or {})
+    if api_key and "Authorization" not in headers:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    logger.info("%s %s (container=%s)", method, target_url, container)
+    return requests.request(
+        method, target_url, headers=headers, timeout=request_timeout, **kwargs
+    )
+
+
+def call_service(
+    name: str,
+    path: str,
+    method: str = "GET",
+    api_key: Optional[str] = None,
+    **kwargs: Any,
+) -> requests.Response:
+    """Drop-in pour requests.get/post sur un service GenAI du registre.
+
+    Reveille le service si idle-stopped, attend le warm-up, puis execute la
+    requete. Le notebook n'a plus a gerer le 502 / connection-refused.
+
+    Args:
+        name: Nom court du service dans le registre (ex: "musicgen", "whisper").
+        path: Chemin de la requete (ex: "/v1/models").
+        method: Methode HTTP ("GET", "POST", ...).
+        api_key: Cle API (Bearer). Si None, lu depuis .env.
+        **kwargs: Args forwards a requests.request (json, data, ...).
+
+    Returns:
+        requests.Response de la requete finale.
+
+    Example:
+        >>> resp = call_service("musicgen", "/v1/models")
+        >>> resp.status_code
+        200
+        >>> resp = call_service("tts-kokoro", "/v1/audio/speech",
+        ...                     method="POST", json={"text": "bonjour"})
+    """
+    info = _resolve_service(name)
+    return call_service_generic(
+        container=info["container"],
+        port=info["port"],
+        path=path,
+        method=method,
+        health_path=info["health"],
+        api_key=api_key,
+        **kwargs,
+    )
+
+
+def list_services() -> Dict[str, Dict[str, Any]]:
+    """Retourne une copie du registre des services connus (pour introspection)."""
+    return dict(SERVICE_REGISTRY)
+
+
+if __name__ == "__main__":
+    # CLI minimal : `python genai_service.py musicgen /v1/models`
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    import argparse
+    parser = argparse.ArgumentParser(description="Client GenAI avec wake-on-demand (#2982).")
+    parser.add_argument("name", help="Nom court du service (ex: musicgen)")
+    parser.add_argument("path", help="Chemin de la requete (ex: /v1/models)")
+    parser.add_argument("-X", "--method", default="GET")
+    args = parser.parse_args()
+    r = call_service(args.name, args.path, method=args.method)
+    print(f"{r.status_code} {args.method} {args.name}{args.path}")
+    print(r.text[:500])

--- a/MyIA.AI.Notebooks/GenAI/shared/helpers/tests/test_genai_service.py
+++ b/MyIA.AI.Notebooks/GenAI/shared/helpers/tests/test_genai_service.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Tests unitaires pour genai_service.py — wrapper wake-on-demand (#2982).
+
+CI-runnables SANS Docker : `ensure_service_up` et `requests.request` sont
+mockes. Valide le contrat du wrapper :
+- Resolution du registre (noms connus / inconnus).
+- Propagation de la cle API (Bearer) depuis .env.
+- Wake-then-call : ensure_service_up appele AVANT requests.request.
+- Forward des kwargs (json, data) a requests.request.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Rendre le package `helpers` importable depuis ce fichier de test.
+SHARED = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(SHARED))
+sys.path.insert(0, str(SHARED.parent))
+
+from helpers import genai_service  # noqa: E402
+
+
+# --- Registre ---
+
+def test_registry_contains_known_services():
+    """Le registre couvre les principaux services GenAI (audio + image/video)."""
+    names = genai_service.SERVICE_REGISTRY.keys()
+    for expected in ("musicgen", "whisper", "tts-gateway", "demucs", "comfyui-qwen"):
+        assert expected in names, f"Service manquant dans le registre: {expected}"
+
+
+def test_registry_entries_have_required_fields():
+    """Chaque entree a container (str), port (int), health (str)."""
+    for name, info in genai_service.SERVICE_REGISTRY.items():
+        assert isinstance(info["container"], str) and info["container"], name
+        assert isinstance(info["port"], int) and 1000 <= info["port"] <= 65535, name
+        assert isinstance(info["health"], str) and info["health"].startswith("/"), name
+
+
+def test_resolve_known_service():
+    info = genai_service._resolve_service("musicgen")
+    assert info["container"] == "musicgen-api"
+    assert info["port"] == 8192
+    assert info["health"] == "/health"
+
+
+def test_resolve_unknown_service_raises_keyerror():
+    """Un service inconnu leve KeyError (pas un crash silencieux)."""
+    with pytest.raises(KeyError, match="Service GenAI inconnu"):
+        genai_service._resolve_service("does-not-exist")
+
+
+# --- Wake-then-call ---
+
+@mock.patch.object(genai_service, "requests")
+@mock.patch.object(genai_service, "_import_ensure_service_up")
+def test_call_service_wakes_before_request(mock_import_wake, mock_requests):
+    """ensure_service_up est appele AVANT requests.request (wake-then-call)."""
+    mock_wake = mock.MagicMock(return_value=True)
+    mock_import_wake.return_value = mock_wake
+    fake_resp = mock.MagicMock(status_code=200)
+    mock_requests.request.return_value = fake_resp
+
+    resp = genai_service.call_service("musicgen", "/v1/models")
+
+    assert resp.status_code == 200
+    mock_wake.assert_called_once()
+    mock_requests.request.assert_called_once()
+    # Le wake doit cibler le bon container (1er arg positionnel d'ensure_service_up).
+    assert mock_wake.call_args.args[0] == "musicgen-api"
+    assert mock_wake.call_args.args[1] == "http://localhost:8192/health"
+    # Et l'URL finale pointe bien sur le port attendu.
+    req_args, _ = mock_requests.request.call_args
+    assert req_args[1] == "http://localhost:8192/v1/models"
+
+
+@mock.patch.object(genai_service, "_import_ensure_service_up")
+def test_call_service_raises_when_wake_fails(mock_import_wake):
+    """Si le warm-up echoue (ensure_service_up=False), RuntimeError avant requete."""
+    mock_import_wake.return_value = mock.MagicMock(return_value=False)
+    with pytest.raises(RuntimeError, match="non healthy"):
+        genai_service.call_service("musicgen", "/v1/models")
+
+
+@mock.patch.object(genai_service, "requests")
+@mock.patch.object(genai_service, "_import_ensure_service_up")
+def test_call_service_forwards_kwargs_to_requests(mock_import_wake, mock_requests):
+    """Les kwargs (json, data) sont forwardes a requests.request."""
+    mock_import_wake.return_value = mock.MagicMock(return_value=True)
+    mock_requests.request.return_value = mock.MagicMock(status_code=200)
+
+    genai_service.call_service(
+        "tts-kokoro", "/v1/audio/speech", method="POST",
+        json={"text": "bonjour"}, request_timeout=5.0,
+    )
+
+    _, kwargs = mock_requests.request.call_args
+    assert kwargs["json"] == {"text": "bonjour"}
+    assert kwargs["timeout"] == 5.0
+
+
+# --- Cle API (Bearer) ---
+
+@mock.patch.object(genai_service, "requests")
+@mock.patch.object(genai_service, "_import_ensure_service_up")
+def test_api_key_explicit_sets_bearer_header(mock_import_wake, mock_requests):
+    """Une cle API explicite devient un header Authorization: Bearer."""
+    mock_import_wake.return_value = mock.MagicMock(return_value=True)
+    mock_requests.request.return_value = mock.MagicMock(status_code=200)
+
+    genai_service.call_service("musicgen", "/v1/models", api_key="secret123")
+
+    _, kwargs = mock_requests.request.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer secret123"
+
+
+@mock.patch.object(genai_service, "requests")
+@mock.patch.object(genai_service, "_import_ensure_service_up")
+def test_api_key_from_env_when_none_passed(mock_import_wake, mock_requests, monkeypatch):
+    """Sans api_key explicite, la cle est derivee du nom de container (MUSICGEN_API_API_KEY)."""
+    mock_import_wake.return_value = mock.MagicMock(return_value=True)
+    mock_requests.request.return_value = mock.MagicMock(status_code=200)
+    monkeypatch.setenv("MUSICGEN_API_API_KEY", "env-secret")
+    monkeypatch.setenv("TTS_GATEWAY_API_KEY", "")  # s'assurer qu'on prend la bonne
+
+    genai_service.call_service("musicgen", "/v1/models")
+
+    _, kwargs = mock_requests.request.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer env-secret"
+
+
+@mock.patch.object(genai_service, "requests")
+@mock.patch.object(genai_service, "_import_ensure_service_up")
+def test_no_authorization_header_when_no_api_key(mock_import_wake, mock_requests, monkeypatch):
+    """Sans aucune cle, pas de header Authorization ajoute."""
+    mock_import_wake.return_value = mock.MagicMock(return_value=True)
+    mock_requests.request.return_value = mock.MagicMock(status_code=200)
+    monkeypatch.delenv("MUSICGEN_API_API_KEY", raising=False)
+
+    genai_service.call_service("musicgen", "/v1/models")
+
+    _, kwargs = mock_requests.request.call_args
+    assert "Authorization" not in kwargs.get("headers", {})
+
+
+# --- Fallback sans service_wake ---
+
+@mock.patch.object(genai_service, "requests")
+@mock.patch.object(genai_service, "_import_ensure_service_up")
+def test_works_without_service_wake_graceful(mock_import_wake, mock_requests):
+    """Si service_wake absent, pas de crash : requete directe avec avertissement."""
+    mock_import_wake.return_value = None
+    mock_requests.request.return_value = mock.MagicMock(status_code=200)
+
+    resp = genai_service.call_service("musicgen", "/v1/models")
+    assert resp.status_code == 200
+    mock_requests.request.assert_called_once()
+
+
+# --- call_service_generic (hors-registre) ---
+
+@mock.patch.object(genai_service, "requests")
+@mock.patch.object(genai_service, "_import_ensure_service_up")
+def test_generic_call_for_unregistered_service(mock_import_wake, mock_requests):
+    """call_service_generic accepte container+port explicites (hors-registre)."""
+    mock_import_wake.return_value = mock.MagicMock(return_value=True)
+    mock_requests.request.return_value = mock.MagicMock(status_code=200)
+
+    genai_service.call_service_generic(
+        container="custom-svc", port=9999, path="/health",
+        health_path="/ready", method="GET",
+    )
+
+    args, _ = mock_requests.request.call_args
+    assert args[0] == "GET"
+    assert args[1] == "http://localhost:9999/health"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/docs/genai/genai-services.md
+++ b/docs/genai/genai-services.md
@@ -218,6 +218,28 @@ if ensure_service_up("musicgen-api", "http://localhost:8192/health"):
     ...
 ```
 
+**Notebook-side wrapper** (`MyIA.AI.Notebooks/GenAI/shared/helpers/genai_service.py`):
+a drop-in for `requests.get/post` that makes the wake-on-demand **transparent at
+the notebook level** — no need to import `service_wake` or handle 502. It resolves
+a short name from a registry (12 services: ports + health paths verified), wakes
+the container if idle-stopped, waits for warm-up, then issues the HTTP request:
+
+```python
+from helpers.genai_service import call_service
+
+# Drop-in for requests.get("http://localhost:8192/v1/models")
+resp = call_service("musicgen", "/v1/models")
+
+# POST with payload + API key (Bearer derived from MUSICGEN_API_API_KEY)
+resp = call_service("tts-kokoro", "/v1/audio/speech", method="POST",
+                    json={"text": "bonjour"})
+```
+
+The registry maps short names → `(container, port, health_path)`; an unknown name
+raises `KeyError`. For services outside the registry, use `call_service_generic()`
+with explicit `container`/`port`/`health_path`. Unit tests (CI-runnable, Docker
+mocked) lock the wake-then-call contract: `shared/helpers/tests/test_genai_service.py`.
+
 VRAM economy is preserved: the idle monitor still re-stops the service after
 `idle_timeout`. See issue #2982 for the A/B/C/D decision rationale (caller-side
 wake chosen over reverse-proxy / always-on / native-sleep).


### PR DESCRIPTION
## Summary

Notebook-level integration of the merged `service_wake.py` helper (#2998/#3006). Makes wake-on-demand **transparent at the notebook level** — a single `call_service(name, path)` resolves the service from a 12-entry registry, wakes the container if idle-stopped, waits for warm-up, then issues the HTTP request. Drop-in for `requests.get/post`.

This is approach D (caller-side wake, already chosen in #2982 rationale). The wrapper does **not** close #2982 — it integrates the notebook side of the decision; the issue stays open for full-transparency confirmation.

## Why

Per the #2982 decision rationale: none of the 16 GPU services configure `idle_action=sleep` — they all `docker stop`. A stopped container has no listener on its port, so wake must originate from the caller. `service_wake.py` (merged) is the explicit helper; this wrapper removes the boilerplate from notebook code so a notebook call just works without importing `service_wake` or handling 502/connection-refused.

VRAM economy is **preserved**: services still auto-stop after `idle_timeout` (20 min); the wrapper only triggers `docker start` on real demand.

## Changes (3 files, +~330 / −0)

- **`MyIA.AI.Notebooks/GenAI/shared/helpers/genai_service.py`** (new): `SERVICE_REGISTRY` (12 services — ports verified via `docker inspect`), `call_service(name, path, ...)` (registry-based), `call_service_generic(container, port, ...)` (for out-of-registry services), `_resolve_service()` (KeyError on unknown), `_import_ensure_service_up()` (graceful fallback if `service_wake.py` absent).
- **`MyIA.AI.Notebooks/GenAI/shared/helpers/tests/test_genai_service.py`** (new): 12 CI-runnable unit tests, Docker mocked. Covers registry coverage/fields, resolve known/unknown, wake-then-call ordering (ensure_service_up called BEFORE requests.request), RuntimeError when wake fails, kwargs forwarding, Bearer propagation (explicit / env-derived / absent), graceful fallback, generic path.
- **`docs/genai/genai-services.md`** (+21 lines): "Notebook-side wrapper" section documenting usage.

## Validation

- **Unit tests**: `python -m pytest shared/helpers/tests/test_genai_service.py` → **12/12 passed** (0.07s, no Docker needed).
- **Live test** (against running containers, pre-commit): `call_service("musicgen", "/health")` → 200 (fast-path, already healthy), `call_service("tts-gateway", "/health")` → 200 (models kokoro/tada/qwen). Cold-start path proven by `service_wake.py` (#2982 last comment).
- **G.1 (verify-before-claiming)**: registry ports cross-checked against memory `docker-infra-regrounded.md` + `docker inspect` on UP containers.
- **Catalog byte-identical to origin/main** (no churn); branch fresh (0 behind).
- **C.2/C.3**: no notebooks modified — wrapper + tests + docs only.

## Scope

Atomic (1 subject: wake-on-demand wrapper). No catalog regen, no notebook re-exec, no force push.

See #2982.