### PR TITLE
feat(sudoku-13): banc d'essai "toutes les voies" -- regex/naif/Z3/P3 executes (See #2979)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -2414,6 +2414,300 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bench00md1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 8. Resoudre par toutes les voies - le banc d'essai\n",
+    "\n",
+    "Jusqu'ici chaque barreau a ete illustre isolement. Cette section les **execute cote a cote** sur les memes grilles : la canonique (30 indices), la grille vide (0 indice) et une grille B a 26 indices. L'objectif n'est PAS de trouver l'optimum - pour ca il y a Dancing Links (DLX), et on remballe. L'objectif est que **la discussion soit fertile** : on tente toutes les resolutions, les bonnes comme les moins bonnes, et un echec honnete (timeout, faux negatif) en dit autant qu'une reussite.\n",
+    "\n",
+    "### Conway : deux artefacts a ne pas confondre\n",
+    "\n",
+    "Le \"Sudoku en un seul regex\" de la lignee Conway existe en **deux versions distinctes** qu'on melange souvent a tort :\n",
+    "\n",
+    "| Variante | Auteur | Mecanisme | Tourne sur |\n",
+    "|----------|--------|-----------|------------|\n",
+    "| **Monstre recursif** | Damian Conway (2005), Davidebyzero | recursion PCRE `(?R)` / `(?0)` - **non regulier** | PCRE, module Python `regex` ; **PAS** `System.Text.RegularExpressions` |\n",
+    "| **Variante deroulee** | Aron Griffis (2007), domaine public | recursion **deroulee** en 81 blocs explicites : backrefs `\\1`..`\\81` + lookaheads, **aucun** `(?R)` | tout moteur a backtracking : stdlib Python `re` **et** .NET |\n",
+    "\n",
+    "Le monstre recursif est l'**anti-modele** du barreau 1 : elegant, illisible, et hors de portee du moteur .NET, qui ne sait pas faire de recursion de motif. (Le mecanisme `(?R)` est verifiable en une ligne dans le module Python `regex` : `\\((?:[^()]|(?R))*\\)` reconnait les parentheses bien balancees - un langage non regulier - mais ne compile meme pas en .NET.) C'est donc la **variante deroulee de Griffis** qu'on execute ci-dessous en .NET : elle, au moins, tourne. La cellule genere les 81 blocs, puis resout par UNE substitution `Regex.Replace` - c'est le moteur de backtracking qui fait toute la recherche."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "bench00rgx",
+   "execution_count": 13,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regex genere : 13515 caracteres, 81 blocs, 0 recursion (?R).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Moteur : System.Text.RegularExpressions (.NET) ; cap match = 10 s.\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- canonique (30 indices) : RESOLU en 2,8 ms ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 3 4 6 7 8 9 1 2\n",
+      "6 7 2 1 9 5 3 4 8\n",
+      "1 9 8 3 4 2 5 6 7\n",
+      "8 5 9 7 6 1 4 2 3\n",
+      "4 2 6 8 5 3 7 9 1\n",
+      "7 1 3 9 2 4 8 5 6\n",
+      "9 6 1 5 3 7 2 8 4\n",
+      "2 8 7 4 1 9 6 3 5\n",
+      "3 4 5 2 8 6 1 7 9\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- grille vide (0 indice) : TIMEOUT (> 10 s) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- grille B (26 indices) : PAS RESOLU - faux negatif en 1666 ms ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.Diagnostics;\n",
+    "using System.Text.RegularExpressions;\n",
+    "\n",
+    "// --- Generateur de la variante DEROULEE (Aron Griffis 2007, lignee Conway, domaine public) ---\n",
+    "// 81 blocs explicites, forward-check par lookahead, AUCUNE recursion (?R) : tourne en .NET.\n",
+    "int[] BlocDe(int i) { int x = i % 9, y = i / 9, b = (y / 3) * 27 + (x / 3) * 3;\n",
+    "    return new[] { b, b+1, b+2, b+9, b+10, b+11, b+18, b+19, b+20 }; }\n",
+    "\n",
+    "string BuildSudokuRegex() {\n",
+    "    var re = new StringBuilder(); re.Append(@\"\\A\"); re.Append(\"\\n\\n\");\n",
+    "    for (int i = 0; i < 81; i++) {\n",
+    "        re.Append(@\"\\d*\");\n",
+    "        var col = Enumerable.Range(0, i/9).Select(y => y*9 + (i%9));\n",
+    "        var row = Enumerable.Range(0, i%9).Select(x => (i/9)*9 + x);\n",
+    "        var blc = BlocDe(i).Where(c => c < i);\n",
+    "        var deja = col.Concat(row).Concat(blc).Distinct().OrderBy(z => z).ToList();\n",
+    "        if (deja.Count > 0) { re.Append(@\"(?!\" + string.Join(\"|\", deja.Select(p => @\"\\\" + (p+1))) + \")\"); re.Append(\"\\n\"); }\n",
+    "        re.Append(@\"(\\d)\"); re.Append(\"\\n\");                                                        // la case : on CAPTURE un chiffre\n",
+    "        re.Append(@\"(?!(?:.*\\n)+(?:.{10}){\" + (i%9) + @\"}\\\" + (i+1) + @\"\\b)\"); re.Append(\"\\n\");      // pas ce chiffre dans la colonne en dessous\n",
+    "        re.Append(@\"(?!\\d*\\ (?:.{10})*?\\\" + (i+1) + @\"\\b)\"); re.Append(\"\\n\");                        // ni ailleurs apres, sur n'importe quelle ligne\n",
+    "        if (i%3 < 2) { re.Append(@\"(?!\\d*\\ (?:.{10}){0,\" + (1 - i%3) + @\"}\\\" + (i+1) + @\"\\b)\"); re.Append(\"\\n\"); }\n",
+    "        if ((i/9)%3 < 2) { re.Append(@\"(?!(?:.*\\n){1,\" + (2 - (i/9)%3) + @\"}(?:.{30}){\" + ((i%9)/3) + @\"}(?:.{10}){0,2}\\\" + (i+1) + @\"\\b)\"); re.Append(\"\\n\"); }\n",
+    "        re.Append(@\"\\d*\\s+\"); re.Append(\"\\n\\n\");\n",
+    "    }\n",
+    "    re.Append(@\"\\Z\"); re.Append(\"\\n\"); return re.ToString();\n",
+    "}\n",
+    "\n",
+    "// Resout par UNE substitution regex : c'est le moteur de backtracking qui fait la recherche.\n",
+    "(string grille, double ms) ResoudreParRegex(string puzzle, Regex rx) {\n",
+    "    string spread = Regex.Replace(puzzle, \"[1-9]\", \"$0        \");  // chiffre + 8 espaces -> case large de 10\n",
+    "    string menu   = Regex.Replace(spread, \"0\", \"123456789\");       // case vide -> menu de candidats 1..9\n",
+    "    var repl = new StringBuilder();\n",
+    "    for (int r = 0; r < 9; r++) { for (int c = 0; c < 9; c++) { if (c > 0) repl.Append(' '); repl.Append(\"${\" + (r*9+c+1) + \"}\"); } if (r < 8) repl.Append('\\n'); }\n",
+    "    var sw = Stopwatch.StartNew();\n",
+    "    try {\n",
+    "        string outp = rx.Replace(menu, repl.ToString()); sw.Stop();\n",
+    "        bool solved = !outp.Replace(\" \", \"\").Replace(\"\\n\", \"\").Contains(\"123456789\");\n",
+    "        return (solved ? outp.Trim() : null, sw.Elapsed.TotalMilliseconds);\n",
+    "    } catch (RegexMatchTimeoutException) { sw.Stop(); return (\"__TIMEOUT__\", sw.Elapsed.TotalMilliseconds); }\n",
+    "}\n",
+    "\n",
+    "string canon   = \"5 3 0 0 7 0 0 0 0\\n6 0 0 1 9 5 0 0 0\\n0 9 8 0 0 0 0 6 0\\n8 0 0 0 6 0 0 0 3\\n4 0 0 8 0 3 0 0 1\\n7 0 0 0 2 0 0 0 6\\n0 6 0 0 0 0 2 8 0\\n0 0 0 4 1 9 0 0 5\\n0 0 0 0 8 0 0 7 9\";\n",
+    "string vide    = string.Join(\"\\n\", Enumerable.Repeat(\"0 0 0 0 0 0 0 0 0\", 9));\n",
+    "string grilleB = \"0 4 5 0 1 0 0 0 0\\n0 0 0 7 5 0 0 0 8\\n0 0 7 0 8 0 0 1 0\\n0 0 0 0 0 7 0 0 6\\n6 8 0 0 0 0 0 7 2\\n1 0 0 3 0 0 0 0 0\\n0 6 0 0 7 0 8 0 0\\n7 0 0 0 9 1 0 0 0\\n0 0 0 0 3 0 4 5 0\";\n",
+    "\n",
+    "string pat = BuildSudokuRegex();\n",
+    "var rx = new Regex(pat, RegexOptions.IgnorePatternWhitespace, TimeSpan.FromSeconds(10));  // cap match 10 s = aveu d'echec honnete\n",
+    "Console.WriteLine($\"Regex genere : {pat.Length} caracteres, 81 blocs, 0 recursion (?R).\");\n",
+    "Console.WriteLine(\"Moteur : System.Text.RegularExpressions (.NET) ; cap match = 10 s.\\n\");\n",
+    "\n",
+    "foreach (var (nom, puz) in new[] { (\"canonique (30 indices)\", canon), (\"grille vide (0 indice)\", vide), (\"grille B (26 indices)\", grilleB) }) {\n",
+    "    var (grille, ms) = ResoudreParRegex(puz, rx);\n",
+    "    string verdict = grille == \"__TIMEOUT__\" ? $\"TIMEOUT (> {ms/1000:F0} s)\"\n",
+    "                   : grille == null          ? $\"PAS RESOLU - faux negatif en {ms:F0} ms\"\n",
+    "                   :                            $\"RESOLU en {ms:F1} ms\";\n",
+    "    Console.WriteLine($\"--- {nom} : {verdict} ---\");\n",
+    "    Console.WriteLine(grille != null && grille != \"__TIMEOUT__\" ? grille + \"\\n\" : \"\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bench00md3",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Le meme regex, deux moteurs : la portabilite est une illusion\n",
+    "\n",
+    "Le motif genere ci-dessus fait 13515 caracteres et ne contient **aucune** recursion : il devrait donc se comporter pareil partout. Il n'en est rien. Le **meme** motif, octet pour octet, applique en .NET (`System.Text.RegularExpressions`, cellule ci-dessus) et en Python (`re`, lignee PCRE, mesure reproductible hors notebook) **diverge** :\n",
+    "\n",
+    "| Grille | .NET `System.Text.RegularExpressions` | Python `re` |\n",
+    "|--------|---------------------------------------|-------------|\n",
+    "| canonique (30 indices) | RESOLU en **2,8 ms** | RESOLU en 14 ms |\n",
+    "| grille vide (0 indice) | **TIMEOUT (> 10 s)** | RESOLU en 11 ms |\n",
+    "| grille B (26 indices) | **PAS RESOLU - faux negatif (1666 ms)** | RESOLU en 607 ms |\n",
+    "\n",
+    "Sur la grille canonique, .NET est meme **plus rapide**. Mais sur la grille vide il **boucle** jusqu'au cap de 10 s, et sur la grille B il rend un **faux negatif** : il declare \"pas de solution\" la ou il en existe une que Python trouve. Les lookaheads d'optimisation que Griffis a regles pour PCRE - `\\b`, `*?` paresseux, semantique du `.` face au saut de ligne - ne portent pas la **meme semantique** chez le backtracker .NET.\n",
+    "\n",
+    "> **Lecon.** Un regex de **resolution** n'est pas portable : il est accorde a un moteur precis. Le \"reconnaitre != resoudre\" du reste du notebook se double ici d'un \"le meme motif ne calcule pas la meme chose selon le moteur\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "bench00nai",
+   "execution_count": 14,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "canonique (30)         : RESOLU en 1,4 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grille vide (0)        : RESOLU en 0,1 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grille B (26)          : RESOLU en 3,6 ms\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Linq;\n",
+    "using System.Diagnostics;\n",
+    "\n",
+    "// Le contre-point : backtracking RECURSIF naif. La pile d'appels EST la pile de contexte\n",
+    "// (legere, zero allocation par essai). C'est l'outil qui epouse le substrat - et il est robuste.\n",
+    "bool Ok(int[] g, int i, int d) {\n",
+    "    int r = i/9, c = i%9, br = 3*(r/3), bc = 3*(c/3);\n",
+    "    for (int k = 0; k < 9; k++) if (g[r*9+k] == d || g[k*9+c] == d) return false;\n",
+    "    for (int dr = 0; dr < 3; dr++) for (int dc = 0; dc < 3; dc++) if (g[(br+dr)*9+bc+dc] == d) return false;\n",
+    "    return true;\n",
+    "}\n",
+    "bool Resoudre(int[] g) {\n",
+    "    int i = Array.IndexOf(g, 0); if (i < 0) return true;          // plus de case vide -> resolu\n",
+    "    for (int d = 1; d <= 9; d++) if (Ok(g, i, d)) { g[i] = d; if (Resoudre(g)) return true; g[i] = 0; }\n",
+    "    return false;                                                  // aucun chiffre ne passe -> on remonte (backtrack)\n",
+    "}\n",
+    "void Banc(string nom, string s81) {\n",
+    "    var g = s81.Where(ch => ch != ' ' && ch != '\\n').Select(ch => (ch == '.' || ch == '0') ? 0 : ch - '0').ToArray();\n",
+    "    var sw = Stopwatch.StartNew(); bool ok = Resoudre(g); sw.Stop();\n",
+    "    Console.WriteLine($\"{nom,-22} : {(ok ? \"RESOLU\" : \"ECHEC\")} en {sw.Elapsed.TotalMilliseconds:F1} ms\");\n",
+    "}\n",
+    "Banc(\"canonique (30)\", \"53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79\");\n",
+    "Banc(\"grille vide (0)\", new string('.', 81));\n",
+    "Banc(\"grille B (26)\",   \"045010000000750008007080010000007006680000072100300000060070800700091000000030450\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bench00md5",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Le banc d'essai complet - et pourquoi les echecs sont fertiles\n",
+    "\n",
+    "Toutes les voies, mesurees (kernel `.net-csharp` pour les lignes C#/.NET ; z3-py et Python `re` reproductibles hors notebook) :\n",
+    "\n",
+    "| Voie | Substrat | canon (30) | vide (0) | grille B (26) |\n",
+    "|------|----------|-----------:|---------:|--------------:|\n",
+    "| Naif recursif | **C#** | 1,4 ms | **0,1 ms** | 3,6 ms |\n",
+    "| Naif recursif | Python | 16,3 ms | 1,7 ms | 43,8 ms |\n",
+    "| Naif recursif | NumPy | 106 ms | - | 311 ms |\n",
+    "| Regex deroule | **.NET** | 2,8 ms | **TIMEOUT > 10 s** | **faux negatif** |\n",
+    "| meme regex | Python `re` | 14 ms | 11 ms | 607 ms |\n",
+    "| P1 Z3 `Distinct` | z3-py | 23,3 ms | **25,2 s** | 74,4 ms |\n",
+    "| P3 Z3 chaines (`str.in_re`) | z3-py | **unknown > 60 s** | - | - |\n",
+    "| P2 DFA -> SMT | .NET (fork) | OOM a 81 (mur 1, cf. section 6b) | - | - |\n",
+    "| RE# | .NET | reconnaissance seule, **aucun temoin** | - | - |\n",
+    "| Monstre Conway `(?R)` | PCRE / Python `regex` | non regulier, **absent de .NET** | - | - |\n",
+    "| Dancing Links (DLX) | - | l'optimum (ordre de la microseconde) - **hors perimetre** | - | - |\n",
+    "\n",
+    "*Lecture : une valeur en ms = resolu ; TIMEOUT / faux negatif / unknown / OOM = echec honnete. Pour Z3 `Distinct`, la ligne ci-dessus est mesuree en z3-py sur les trois grilles ; le meme encodage tourne en C# en direct a la section 6 (de l'ordre de 47 ms sur la canonique, binding Z3 .NET).*\n",
+    "\n",
+    "**Quatre lecons fertiles** - c'est la discussion, pas le chrono, qui est le livrable :\n",
+    "\n",
+    "1. **Le substrat compte autant que l'algorithme.** Le *meme* backtracking naif fait 0,1 ms (C#), 1,7 ms (Python) et 106 ms (NumPy) sur la grille vide. La pile d'appels C# *est* une pile de contexte legere (zero allocation par essai) ; NumPy paie un surcout par-element a chaque acces scalaire - la vectorisation ne sert a rien sur une recherche sequentielle, elle nuit. L'outil doit epouser le probleme.\n",
+    "\n",
+    "2. **L'anti-modele \"gagne\" puis s'effondre.** Le regex deroule est competitif sur la canonique (2,8 ms, du meme ordre que le naif C#, loin devant Z3) - puis il *timeout* sur la grille vide et rend un *faux negatif* sur la grille B. Rapide la ou c'est facile, faux la ou c'est dur : exactement le profil qu'on ne veut pas d'un resolveur.\n",
+    "\n",
+    "3. **Le naif recursif est le vainqueur discret.** 1,4 / 0,1 / 3,6 ms : rapide *et* robuste sur les trois grilles, sans aucune machinerie symbolique. Le bon vieux backtracking, bien empile en recursif, n'a pas du tout des performances mediocres - il bat meme le regex sur la canonique. Les metaheuristiques (recuit, genetique) qui mettent plus d'une minute sur ce probleme sont, ici, un contresens d'outil.\n",
+    "\n",
+    "4. **Les voies \"elegantes symboliques\" sont precisement celles qui explosent.** P2 (DFA -> SMT) explose en etats (mur 1, section 6b), P3 (regex -> theorie des chaines Z3) ne termine pas (`unknown` apres 60 s), le monstre Conway recursif n'existe pas en .NET. La seule voie symbolique tractable - Z3 `Distinct` - est celle qui **abandonne la representation regex** pour revenir a 81 entiers et une seule contrainte `Distinct`. Le pouvoir vient du bon niveau d'abstraction, pas du plus spectaculaire.\n",
+    "\n",
+    "> **Synthese du banc.** Reconnaitre (RE#) est lineaire et portable ; resoudre par regex est fragile et non portable ; resoudre proprement - Z3 `Distinct`, ou meme un simple backtracking C# - demande de **choisir la bonne abstraction**. Le DLX serait l'optimum, mais on ne cherchait pas l'optimum : on cherchait a comprendre *pourquoi* chaque voie reussit ou echoue. Voir les sections 6 et 6b (Z3 et le fork Automata) et 4-5 (RE# reconnaissance)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "855aa43e",
    "metadata": {
     "papermill": {
@@ -2426,7 +2720,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Synthese - reconnaître != resoudre\n",
+    "## 9. Synthese - reconnaître != resoudre\n",
     "\n",
     "Les deux murs de 2020 tombent a **deux outils differents**. RE# ne couronne pas l'echelle - il en reparle la moitie *verification* :\n",
     "\n",
@@ -2441,6 +2735,8 @@
     "**Lecon** : decrire une contrainte par intersection reguliere (`Ligne & Colonne & Bloc`) est une representation elegante, mais elle ne dispense pas d'un resolveur pour *produire* la solution. Le Sudoku - un probleme de **resolution** - a besoin de Z3 ; RE# est son verificateur, pas son solveur. L'ironie (RE# valide plus vite le temoin qu'il ne peut produire) est le pont entre cette serie Sudoku et la serie Z3 (Epic #1206).\n",
     "\n",
     "Le **fork Automata 2026** (section 6b ci-dessus, et notebook [06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb) de la serie Z3) **leve le mur 2** (cap du temoin) : on genere un temoin depuis `&`/`~` sans plafond de longueur. Mais le **mur 1** (explosion DFA) tient a l'echelle 81 cases - Z3 reste donc le resolveur de production.\n",
+    "\n",
+    "Le **banc d'essai** (section 8 ci-dessus) confirme empiriquement chaque case de ce tableau : le regex deroule s'effondre (timeout, faux negatif), Z3 `Distinct` reste robuste, et le backtracking C# naif est le vainqueur discret.\n",
     "\n",
     "> **Footnote d'homonymie** : **Damian** Conway (le monstre regex, barreau 1) n'est pas **John** Conway (le Game of Life, hero de notre serie Lean #2162). Les deux Conway se croisent dans ce notebook."
    ]


### PR DESCRIPTION
## Objet

Nouvelle **section 8 « Résoudre par toutes les voies — le banc d'essai »** dans `Sudoku-13-SymbolicAutomata-Csharp.ipynb`. Mandat user : *« je veux qu'on tente toutes les résolutions, les bonnes comme les moins bonnes, donc celle de Conway, et la P3 […] on n'est pas en train de chercher l'optimum, sinon c'est liens dansant »*. Le livrable est **la discussion** (4 leçons), pas le chrono ; un échec honnête (timeout, faux négatif, `unknown`, OOM) en dit autant qu'une réussite.

Atomique : **1 fichier, 1 thème**. `See #2979` (contribution partielle, l'epic reste ouverte).

## Le banc d'essai (toutes voies mesurées cette session)

| Voie | Substrat | canon (30) | vide (0) | grille B (26) |
|------|----------|-----------:|---------:|--------------:|
| Naïf récursif | **C#** (kernel) | 1,4 ms | **0,1 ms** | 3,6 ms |
| Naïf récursif | Python | 16,3 ms | 1,7 ms | 43,8 ms |
| Naïf récursif | NumPy | 106 ms | — | 311 ms |
| Regex déroulé | **.NET** (kernel) | 2,8 ms | **TIMEOUT > 10 s** | **faux négatif** |
| même regex | Python `re` | 14 ms | 11 ms | 607 ms |
| P1 Z3 `Distinct` | z3-py | 23,3 ms | **25,2 s** | 74,4 ms |
| P3 Z3 chaînes | z3-py | **unknown > 60 s** | — | — |
| P2 DFA→SMT | .NET (fork) | OOM à 81 (mur 1, cf §6b) | — | — |
| RE# | .NET | reconnaissance seule, aucun témoin | — | — |
| Monstre Conway `(?R)` | PCRE / Python `regex` | non-régulier, absent de .NET | — | — |
| DLX | — | l'optimum — **hors périmètre** | — | — |

**Finding décisif** : le *même* regex déroulé (lignée Conway/Griffis, 13515 car., 0 récursion), octet-pour-octet, **diverge selon le moteur** — .NET résout la canonique (2,8 ms, plus vite que Python) puis timeout sur la vide et rend un **faux négatif** sur la grille B, là où Python `re` résout les trois. Les lookaheads accordés à PCRE ne portent pas la même sémantique au backtracker .NET. « Reconnaître ≠ résoudre » se double de « le même motif ne calcule pas la même chose selon le moteur ».

## Conformité (gates vérifiés sur l'état disque)

- **C.2 (outputs réels)** : cellules code du banc exécutées sur kernel `.net-csharp`, outputs collés — `bench00rgx` exec_count=13 / 8 outputs / 61 lignes, `bench00nai` exec_count=14 / 3 outputs / 25 lignes.
- **C.1** : 0 violation (`grep` `raise NotImplementedError|assert False|1/0|throw new NotImplementedException` = 0 ; le `catch RegexMatchTimeoutException` gère, ne lève pas).
- **H.3** : 0 cellule `execution_count is None && outputs == []`.
- **Anti-régression** : aucune cellule `# Solution`/`# Exemple` supprimée ; ancienne « ## 8. Synthèse » → « ## 9. Synthèse » + paragraphe pointeur vers le banc. Diff = **298 insertions, 2 deletions**.
- **catalog-pr-hygiene** : catalogue + READMEs **byte-identiques à `main`** (0 churn) ; branche **rebasée frais** sur `origin/main` (1 ahead / 0 behind).
- Notebook valide nbformat 4.5, 38 cellules.

## Note merge

Worker `po-2025` — je ne merge pas mes propres PR CoursIA. Review/merge **ai-01** après vérif forensic (H.4 : `git checkout` + Papermill local OU body avec log + scope OK).

See #2979