### PR TITLE
fix(z3): evaluate symbolic-array outputs in NB-03 (readable numbers, honest MC)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
@@ -5,10 +5,10 @@
    "id": "a1b2c3d0",
    "metadata": {
     "papermill": {
-     "duration": 0.003288,
-     "end_time": "2026-06-12T00:19:22.442214+00:00",
+     "duration": 0.005971,
+     "end_time": "2026-06-15T17:18:28.847230+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:22.438926+00:00",
+     "start_time": "2026-06-15T17:18:28.841259+00:00",
      "status": "completed"
     },
     "tags": []
@@ -50,16 +50,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:15.062829Z",
-     "iopub.status.busy": "2026-06-14T14:51:15.055894Z",
-     "iopub.status.idle": "2026-06-14T14:51:16.326480Z",
-     "shell.execute_reply": "2026-06-14T14:51:16.323039Z"
+     "iopub.execute_input": "2026-06-15T17:18:28.877626Z",
+     "iopub.status.busy": "2026-06-15T17:18:28.867938Z",
+     "iopub.status.idle": "2026-06-15T17:18:30.743579Z",
+     "shell.execute_reply": "2026-06-15T17:18:30.736749Z"
     },
     "papermill": {
-     "duration": 2.349404,
-     "end_time": "2026-06-12T00:19:24.794287+00:00",
+     "duration": 1.889662,
+     "end_time": "2026-06-15T17:18:30.743788+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:22.444883+00:00",
+     "start_time": "2026-06-15T17:18:28.854126+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -73,7 +73,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-2908.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-46580.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -118,12 +118,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.14:2050/\", \"http://172.19.64.1:2050/\", \"http://172.28.176.1:2050/\", \"http://127.0.0.1:2050/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '2908.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '46580.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -211,10 +211,10 @@
    "id": "d4e5f6a3",
    "metadata": {
     "papermill": {
-     "duration": 0.00407,
-     "end_time": "2026-06-12T00:19:25.536684+00:00",
+     "duration": 0.007258,
+     "end_time": "2026-06-15T17:18:30.757667+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:25.532614+00:00",
+     "start_time": "2026-06-15T17:18:30.750409+00:00",
      "status": "completed"
     },
     "tags": []
@@ -263,10 +263,10 @@
    "id": "e5f6a7b4",
    "metadata": {
     "papermill": {
-     "duration": 0.004764,
-     "end_time": "2026-06-12T00:19:25.545649+00:00",
+     "duration": 0.004923,
+     "end_time": "2026-06-15T17:18:30.768634+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:25.540885+00:00",
+     "start_time": "2026-06-15T17:18:30.763711+00:00",
      "status": "completed"
     },
     "tags": []
@@ -288,16 +288,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:16.332170Z",
-     "iopub.status.busy": "2026-06-14T14:51:16.331045Z",
-     "iopub.status.idle": "2026-06-14T14:51:17.101957Z",
-     "shell.execute_reply": "2026-06-14T14:51:17.101679Z"
+     "iopub.execute_input": "2026-06-15T17:18:30.784072Z",
+     "iopub.status.busy": "2026-06-15T17:18:30.783742Z",
+     "iopub.status.idle": "2026-06-15T17:18:31.413443Z",
+     "shell.execute_reply": "2026-06-15T17:18:31.413141Z"
     },
     "papermill": {
-     "duration": 0.571302,
-     "end_time": "2026-06-12T00:19:26.121583+00:00",
+     "duration": 0.638816,
+     "end_time": "2026-06-15T17:18:31.413538+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:25.550281+00:00",
+     "start_time": "2026-06-15T17:18:30.774722+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -375,10 +375,10 @@
    "id": "a7b8c9d6",
    "metadata": {
     "papermill": {
-     "duration": 0.004759,
-     "end_time": "2026-06-12T00:19:26.131019+00:00",
+     "duration": 0.005954,
+     "end_time": "2026-06-15T17:18:31.425231+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:26.126260+00:00",
+     "start_time": "2026-06-15T17:18:31.419277+00:00",
      "status": "completed"
     },
     "tags": []
@@ -386,7 +386,7 @@
    "source": [
     "### Interprétation 1 — Le pattern closure pour Select\n",
     "\n",
-    "**Sortie obtenue** : Un tableau de 5 entiers distincts entre 1 et 5 dont la somme vaut 14.\n",
+    "**Sortie obtenue** : Un tableau de 5 entiers distincts entre 1 et 5 dont la somme vaut 15 (par exemple `[1, 3, 2, 4, 5]`).\n",
     "\n",
     "| Aspect | Détail |\n",
     "|--------|---------|\n",
@@ -399,7 +399,7 @@
     "2. Z3.Linq traduit chaque `t.Values[idx]` en un appel `MkSelect` sur le tableau symbolique\n",
     "3. La contrainte de distinctness nécessite O(n²) clauses (ici 10 paires pour 5 éléments)\n",
     "\n",
-    "> **Note technique** : La somme 1+2+3+4+5 = 15, donc pour obtenir 14 il faut remplacer un élément par un doublon d'un autre, mais la contrainte de distinctness force exactement la permutation qui somme à 14. Z3 explore cet espace automatiquement.\n",
+    "> **Note technique** : La somme 1+2+3+4+5 = 15, et les 5 valeurs sont distinctes et bornées dans [1, 5]. Le seul ensemble de 5 entiers distincts de [1, 5] est précisément {1, 2, 3, 4, 5} — la contrainte de somme force donc une **permutation** de ces valeurs. Z3 explore l'espace des 5! = 120 permutations et en retourne une, ici `[1, 3, 2, 4, 5]`.\n",
     "\n",
     "> **Modes d'encodage des collections** : `int[] Values` est ici représenté via la **théorie des tableaux** Z3 — un seul `ArrayExpr` symbolique, et chaque `Values[i]` se traduit en `Select`. Z3.Linq offre une alternative, le mode **Constants** (`ctx.DefaultCollectionHandling = CollectionHandling.Constants`), qui crée un constant Z3 indépendant par élément au lieu d'un tableau symbolique. Les deux modes aboutissent à la même solution mais diffèrent dans la structure des formules SMT produites. Le notebook [02b — Sudoku Modes Comparison](02b_Sudoku_Modes_Comparison.ipynb) compare les deux modes côte à côte sur un Sudoku 4x4."
    ]
@@ -409,10 +409,10 @@
    "id": "b8c9d0e7",
    "metadata": {
     "papermill": {
-     "duration": 0.004921,
-     "end_time": "2026-06-12T00:19:26.140690+00:00",
+     "duration": 0.005258,
+     "end_time": "2026-06-15T17:18:31.435436+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:26.135769+00:00",
+     "start_time": "2026-06-15T17:18:31.430178+00:00",
      "status": "completed"
     },
     "tags": []
@@ -438,16 +438,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:17.104274Z",
-     "iopub.status.busy": "2026-06-14T14:51:17.103815Z",
-     "iopub.status.idle": "2026-06-14T14:51:17.366349Z",
-     "shell.execute_reply": "2026-06-14T14:51:17.365925Z"
+     "iopub.execute_input": "2026-06-15T17:18:31.447282Z",
+     "iopub.status.busy": "2026-06-15T17:18:31.446995Z",
+     "iopub.status.idle": "2026-06-15T17:18:31.632641Z",
+     "shell.execute_reply": "2026-06-15T17:18:31.632446Z"
     },
     "papermill": {
-     "duration": 0.211546,
-     "end_time": "2026-06-12T00:19:26.357469+00:00",
+     "duration": 0.191905,
+     "end_time": "2026-06-15T17:18:31.632740+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:26.145923+00:00",
+     "start_time": "2026-06-15T17:18:31.440835+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -550,10 +550,10 @@
    "id": "d0e1f2a9",
    "metadata": {
     "papermill": {
-     "duration": 0.004704,
-     "end_time": "2026-06-12T00:19:26.366814+00:00",
+     "duration": 0.005231,
+     "end_time": "2026-06-15T17:18:31.643499+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:26.362110+00:00",
+     "start_time": "2026-06-15T17:18:31.638268+00:00",
      "status": "completed"
     },
     "tags": []
@@ -580,10 +580,10 @@
    "id": "e1f2a3ba",
    "metadata": {
     "papermill": {
-     "duration": 0.005077,
-     "end_time": "2026-06-12T00:19:26.376439+00:00",
+     "duration": 0.005499,
+     "end_time": "2026-06-15T17:18:31.653990+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:26.371362+00:00",
+     "start_time": "2026-06-15T17:18:31.648491+00:00",
      "status": "completed"
     },
     "tags": []
@@ -609,16 +609,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:17.369345Z",
-     "iopub.status.busy": "2026-06-14T14:51:17.368877Z",
-     "iopub.status.idle": "2026-06-14T14:51:17.749312Z",
-     "shell.execute_reply": "2026-06-14T14:51:17.748958Z"
+     "iopub.execute_input": "2026-06-15T17:18:31.667481Z",
+     "iopub.status.busy": "2026-06-15T17:18:31.667210Z",
+     "iopub.status.idle": "2026-06-15T17:18:31.929378Z",
+     "shell.execute_reply": "2026-06-15T17:18:31.929148Z"
     },
     "papermill": {
-     "duration": 0.263981,
-     "end_time": "2026-06-12T00:19:26.644936+00:00",
+     "duration": 0.269486,
+     "end_time": "2026-06-15T17:18:31.929478+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:26.380955+00:00",
+     "start_time": "2026-06-15T17:18:31.659992+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -638,40 +638,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "  (select (store a!1 4 50) 0)), "
+      "10, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "  (select (store a!1 4 50) 1)), "
+      "20, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "  (select (store a!1 4 50) 2)), "
+      "30, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "  (select (store a!1 4 50) 3)), "
+      "40, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "  (select (store a!1 4 50) 4))"
+      "50"
      ]
     },
     {
@@ -692,55 +687,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
-      "                  3\n",
-      "                  (select (store a!1 4 50) 1))))\n",
-      "  (select a!2 0))), "
+      "10, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
-      "                  3\n",
-      "                  (select (store a!1 4 50) 1))))\n",
-      "  (select a!2 1))), "
+      "40, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
-      "                  3\n",
-      "                  (select (store a!1 4 50) 1))))\n",
-      "  (select a!2 2))), "
+      "30, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
-      "                  3\n",
-      "                  (select (store a!1 4 50) 1))))\n",
-      "  (select a!2 3))), "
+      "20, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
-      "                  3\n",
-      "                  (select (store a!1 4 50) 1))))\n",
-      "  (select a!2 4)))"
+      "50"
      ]
     },
     {
@@ -755,15 +730,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Vérification : arr[1] = (let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
-      "                  3\n",
-      "                  (select (store a!1 4 50) 1))))\n",
-      "  (select a!2 1))) (attendu 40), arr[3] = (let ((a!1 (store (store (store (store a 0 10) 1 20) 2 30) 3 40)))\n",
-      "(let ((a!2 (store (store (store a!1 4 50) 1 (select (store a!1 4 50) 3))\n",
-      "                  3\n",
-      "                  (select (store a!1 4 50) 1))))\n",
-      "  (select a!2 3))) (attendu 20)\r\n"
+      "Vérification : arr[1] = 40 (attendu 40), arr[3] = 20 (attendu 20)\r\n"
      ]
     },
     {
@@ -797,11 +764,13 @@
     "        ctx.MkInt(3), ctx.MkInt(40)),\n",
     "        ctx.MkInt(4), ctx.MkInt(50));\n",
     "\n",
-    "    // Afficher le tableau avant le swap\n",
+    "    // Afficher le tableau avant le swap.\n",
+    "    // MkSelect renvoie une Expr symbolique : on l'évalue avec Simplify() pour\n",
+    "    // réduire select(store(...), i) en la valeur concrète (axiome de McCarthy).\n",
     "    Console.Write(\"Tableau avant swap  : [\");\n",
     "    for (int k = 0; k < 5; k++)\n",
     "    {\n",
-    "        var val = ctx.MkSelect(concrete, ctx.MkInt(k));\n",
+    "        var val = ctx.MkSelect(concrete, ctx.MkInt(k)).Simplify();\n",
     "        Console.Write(k < 4 ? $\"{val}, \" : $\"{val}\");\n",
     "    }\n",
     "    Console.WriteLine(\"]\");\n",
@@ -814,26 +783,26 @@
     "    var after_first_store = ctx.MkStore(concrete, ctx.MkInt(1), sel_a_3);\n",
     "    var after_swap = ctx.MkStore(after_first_store, ctx.MkInt(3), sel_a_1);\n",
     "\n",
-    "    // Afficher le tableau après le swap\n",
+    "    // Afficher le tableau après le swap (évaluation des selects)\n",
     "    Console.Write(\"Tableau après swap  : [\");\n",
     "    for (int k = 0; k < 5; k++)\n",
     "    {\n",
-    "        var val = ctx.MkSelect(after_swap, ctx.MkInt(k));\n",
+    "        var val = ctx.MkSelect(after_swap, ctx.MkInt(k)).Simplify();\n",
     "        Console.Write(k < 4 ? $\"{val}, \" : $\"{val}\");\n",
     "    }\n",
     "    Console.WriteLine(\"]\");\n",
     "\n",
     "    // Vérifier que le swap est correct\n",
-    "    var val_at_1 = ctx.MkSelect(after_swap, ctx.MkInt(1));\n",
-    "    var val_at_3 = ctx.MkSelect(after_swap, ctx.MkInt(3));\n",
+    "    var val_at_1 = ctx.MkSelect(after_swap, ctx.MkInt(1)).Simplify();\n",
+    "    var val_at_3 = ctx.MkSelect(after_swap, ctx.MkInt(3)).Simplify();\n",
     "    Console.WriteLine($\"\\nVérification : arr[1] = {val_at_1} (attendu 40), arr[3] = {val_at_3} (attendu 20)\");\n",
     "\n",
     "    // Vérifier que les autres éléments sont inchangés\n",
     "    var others_unchanged = true;\n",
     "    foreach (var k in new[] { 0, 2, 4 })\n",
     "    {\n",
-    "        var before = ctx.MkSelect(concrete, ctx.MkInt(k));\n",
-    "        var after = ctx.MkSelect(after_swap, ctx.MkInt(k));\n",
+    "        var before = ctx.MkSelect(concrete, ctx.MkInt(k)).Simplify();\n",
+    "        var after = ctx.MkSelect(after_swap, ctx.MkInt(k)).Simplify();\n",
     "        var eq = ctx.MkEq(before, after);\n",
     "        var s = ctx.MkSolver();\n",
     "        s.Assert(ctx.MkNot(eq));\n",
@@ -850,10 +819,10 @@
    "id": "a3b4c5dc",
    "metadata": {
     "papermill": {
-     "duration": 0.005355,
-     "end_time": "2026-06-12T00:19:26.656127+00:00",
+     "duration": 0.006424,
+     "end_time": "2026-06-15T17:18:31.942936+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:26.650772+00:00",
+     "start_time": "2026-06-15T17:18:31.936512+00:00",
      "status": "completed"
     },
     "tags": []
@@ -881,10 +850,10 @@
    "id": "b4c5d6ed",
    "metadata": {
     "papermill": {
-     "duration": 0.005196,
-     "end_time": "2026-06-12T00:19:26.666724+00:00",
+     "duration": 0.005655,
+     "end_time": "2026-06-15T17:18:31.954661+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:26.661528+00:00",
+     "start_time": "2026-06-15T17:18:31.949006+00:00",
      "status": "completed"
     },
     "tags": []
@@ -913,16 +882,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:17.751560Z",
-     "iopub.status.busy": "2026-06-14T14:51:17.751173Z",
-     "iopub.status.idle": "2026-06-14T14:51:18.107170Z",
-     "shell.execute_reply": "2026-06-14T14:51:18.106804Z"
+     "iopub.execute_input": "2026-06-15T17:18:31.967984Z",
+     "iopub.status.busy": "2026-06-15T17:18:31.967652Z",
+     "iopub.status.idle": "2026-06-15T17:18:32.239918Z",
+     "shell.execute_reply": "2026-06-15T17:18:32.239683Z"
     },
     "papermill": {
-     "duration": 0.334958,
-     "end_time": "2026-06-12T00:19:27.007521+00:00",
+     "duration": 0.27958,
+     "end_time": "2026-06-15T17:18:32.240036+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:26.672563+00:00",
+     "start_time": "2026-06-15T17:18:31.960456+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -942,35 +911,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "État initial    : [2M, 2C] sur la rive gauche\r\n"
+      "État initial      : [2M, 2C] sur la rive gauche\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Aller   (delta)  : -0M, -1C\r\n"
+      "Aller   (delta)   : -0M, -2C\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "État après aller : [(select (store (store init 0 2) 1 2) 0)-0, (select (store (store init 0 2) 1 2) 1)-1]\r\n"
+      "État après aller  : [2M, 0C] sur la rive gauche\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Retour (delta)   : +0M, +1C\r\n"
+      "Retour (delta)    : +0M, +1C\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "État après retour: [2M, 2C] sur la rive gauche\r\n"
+      "État après retour : [2M, 1C] sur la rive gauche\r\n"
      ]
     },
     {
@@ -978,14 +947,23 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solution store-based trouvée pour 2 étapes (aller+retour).\r\n"
+      "Transition store-based valide : [2,2] -> [2,0] -> [2,1].\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "La résolution complète [2,2] -> [0,0] nécessite davantage d'étapes.\r\n"
      ]
     }
    ],
    "source": [
     "// Exemple 4 : Missionnaires-Cannibales simplifié avec Store (2M/2C, 2 étapes)\n",
     "// État = tableau [M_left, C_left] (missionnaires et cannibales sur la rive gauche)\n",
-    "// But : passer de [2, 2] à [0, 0] en 2 étapes\n",
+    "// On modélise une transition élémentaire (un aller + un retour) qui FAIT PROGRESSER\n",
+    "// l'état. La résolution complète [2,2] -> [0,0] est impossible en 2 étapes ; on cherche\n",
+    "// donc simplement une transition valide (aller+retour) aboutissant à un état != [2,2].\n",
     "using (var ctx = new Microsoft.Z3.Context())\n",
     "{\n",
     "    var solver = ctx.MkSolver();\n",
@@ -1028,7 +1006,7 @@
     "    var c1r = ctx.MkSub(ctx.MkInt(N), c1);\n",
     "    solver.Assert(ctx.MkImplies(ctx.MkGt(m1r, ctx.MkInt(0)), ctx.MkGe(m1r, c1r)));\n",
     "\n",
-    "    // Variables pour le retour\n",
+    "    // Variables pour le retour (delta2 = personnes qui reviennent droite -> gauche)\n",
     "    var deltaM2 = ctx.MkIntConst(\"deltaM2\");\n",
     "    var deltaC2 = ctx.MkIntConst(\"deltaC2\");\n",
     "\n",
@@ -1036,6 +1014,10 @@
     "    solver.Assert(ctx.MkGe(deltaC2, ctx.MkInt(0)));\n",
     "    solver.Assert(ctx.MkGt(ctx.MkAdd(deltaM2, deltaC2), ctx.MkInt(0)));\n",
     "    solver.Assert(ctx.MkLe(ctx.MkAdd(deltaM2, deltaC2), ctx.MkInt(BOAT)));\n",
+    "    // Validité du retour : on ne peut ramener que des personnes réellement présentes\n",
+    "    // sur la rive droite après l'aller (soit delta1 au plus).\n",
+    "    solver.Assert(ctx.MkLe(deltaM2, deltaM1));\n",
+    "    solver.Assert(ctx.MkLe(deltaC2, deltaC1));\n",
     "\n",
     "    // État après retour\n",
     "    var state2 = ctx.MkStore(ctx.MkStore(state1, ctx.MkInt(0),\n",
@@ -1047,29 +1029,39 @@
     "    solver.Assert(ctx.MkGe(c2, ctx.MkInt(0)));\n",
     "    solver.Assert(ctx.MkLe(m2, ctx.MkInt(N)));\n",
     "    solver.Assert(ctx.MkLe(c2, ctx.MkInt(N)));\n",
+    "    // Contrainte de progression : l'état final doit différer de l'état initial [N, N].\n",
+    "    // Sans elle, le solveur trouve un aller-retour « sur place » (delta1 == delta2).\n",
+    "    solver.Assert(ctx.MkOr(ctx.MkNot(ctx.MkEq(m2, ctx.MkInt(N))),\n",
+    "                           ctx.MkNot(ctx.MkEq(c2, ctx.MkInt(N)))));\n",
     "\n",
     "    if (solver.Check() == Status.SATISFIABLE)\n",
     "    {\n",
     "        var model = solver.Model;\n",
+    "        // Toutes les valeurs affichées sont évaluées contre le modèle pour obtenir\n",
+    "        // des entiers concrets (les Expr symboliques non évaluées imprimeraient du SMT-LIB).\n",
     "        var dm1 = model.Eval(deltaM1);\n",
     "        var dc1 = model.Eval(deltaC1);\n",
     "        var dm2 = model.Eval(deltaM2);\n",
     "        var dc2 = model.Eval(deltaC2);\n",
+    "        var m0v = model.Eval(m0);\n",
+    "        var c0v = model.Eval(c0);\n",
+    "        var m1v = model.Eval(m1);\n",
+    "        var c1v = model.Eval(c1);\n",
     "        var m2v = model.Eval(m2);\n",
     "        var c2v = model.Eval(c2);\n",
     "\n",
     "        Console.WriteLine(\"=== Missionnaires-Cannibales (2M/2C, Store-based) ===\");\n",
-    "        Console.WriteLine($\"État initial    : [{N}M, {N}C] sur la rive gauche\");\n",
-    "        Console.WriteLine($\"Aller   (delta)  : -{dm1}M, -{dc1}C\");\n",
-    "        Console.WriteLine($\"État après aller : [{m0}-{dm1}, {c0}-{dc1}]\");\n",
-    "        Console.WriteLine($\"Retour (delta)   : +{dm2}M, +{dc2}C\");\n",
-    "        Console.WriteLine($\"État après retour: [{m2v}M, {c2v}C] sur la rive gauche\");\n",
-    "        Console.WriteLine($\"\\nSolution store-based trouvée pour 2 étapes (aller+retour).\");\n",
+    "        Console.WriteLine($\"État initial      : [{m0v}M, {c0v}C] sur la rive gauche\");\n",
+    "        Console.WriteLine($\"Aller   (delta)   : -{dm1}M, -{dc1}C\");\n",
+    "        Console.WriteLine($\"État après aller  : [{m1v}M, {c1v}C] sur la rive gauche\");\n",
+    "        Console.WriteLine($\"Retour (delta)    : +{dm2}M, +{dc2}C\");\n",
+    "        Console.WriteLine($\"État après retour : [{m2v}M, {c2v}C] sur la rive gauche\");\n",
+    "        Console.WriteLine($\"\\nTransition store-based valide : [{m0v},{c0v}] -> [{m1v},{c1v}] -> [{m2v},{c2v}].\");\n",
+    "        Console.WriteLine(\"La résolution complète [2,2] -> [0,0] nécessite davantage d'étapes.\");\n",
     "    }\n",
     "    else\n",
     "    {\n",
-    "        Console.WriteLine(\"UNSAT : aucune solution en 2 étapes.\");\n",
-    "        Console.WriteLine(\"Le problème complet (passer de [2,2] à [0,0]) nécessite plus d'étapes.\");\n",
+    "        Console.WriteLine(\"UNSAT : aucune transition aller+retour ne fait progresser l'état [2,2].\");\n",
     "    }\n",
     "}"
    ]
@@ -1079,10 +1071,10 @@
    "id": "d6e7f8af",
    "metadata": {
     "papermill": {
-     "duration": 0.005342,
-     "end_time": "2026-06-12T00:19:27.018417+00:00",
+     "duration": 0.005899,
+     "end_time": "2026-06-15T17:18:32.252297+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.013075+00:00",
+     "start_time": "2026-06-15T17:18:32.246398+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1090,7 +1082,7 @@
    "source": [
     "### Interprétation 4 — Store-based vs tableaux séparés\n",
     "\n",
-    "**Sortie obtenue** : Soit une solution 2-étapes valide, soit UNSAT (le problème complet nécessite plus d'étapes).\n",
+    "**Sortie obtenue** : Une transition valide `[2,2] -> [2,0] -> [2,1]` (aller de 2 cannibales, retour d'1 cannibal). L'état final `[2,1]` diffère bien de l'état initial `[2,2]` : la transition fait progresser le problème sans violer l'invariant de sécurité sur aucune des deux rives.\n",
     "\n",
     "| Aspect | Notebook 01 (tableaux séparés) | Store-based |\n",
     "|--------|----------------------------------|-------------|\n",
@@ -1102,7 +1094,8 @@
     "**Points clés** :\n",
     "1. L'approche Store est plus **proche de la sémantique fonctionnelle** : chaque étape est une transformation de la précédente\n",
     "2. Les invariants de sécurité sont les mêmes, mais exprimés via `MkImplies` au lieu de `Where`\n",
-    "3. Pour des problèmes à nombreuses étapes, les chaînes de Store deviennent longues mais restent correctes"
+    "3. **Deux contraintes de correction du modèle** : (a) le retour ne peut ramener que des personnes réellement présentes sur la rive droite (`delta2 ≤ delta1`) ; (b) une contrainte de **progression** force l'état final à différer de l'état initial — sans elle, le solveur renvoie un aller-retour « sur place » (`delta1 == delta2`) techniquement SAT mais sans intérêt pédagogique\n",
+    "4. Pour des problèmes à nombreuses étapes, les chaînes de Store deviennent longues mais restent correctes"
    ]
   },
   {
@@ -1110,10 +1103,10 @@
    "id": "e7f8a9b0",
    "metadata": {
     "papermill": {
-     "duration": 0.005242,
-     "end_time": "2026-06-12T00:19:27.030229+00:00",
+     "duration": 0.005808,
+     "end_time": "2026-06-15T17:18:32.266764+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.024987+00:00",
+     "start_time": "2026-06-15T17:18:32.260956+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1148,16 +1141,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:18.109785Z",
-     "iopub.status.busy": "2026-06-14T14:51:18.109352Z",
-     "iopub.status.idle": "2026-06-14T14:51:18.563277Z",
-     "shell.execute_reply": "2026-06-14T14:51:18.562379Z"
+     "iopub.execute_input": "2026-06-15T17:18:32.280220Z",
+     "iopub.status.busy": "2026-06-15T17:18:32.279879Z",
+     "iopub.status.idle": "2026-06-15T17:18:32.548111Z",
+     "shell.execute_reply": "2026-06-15T17:18:32.547899Z"
     },
     "papermill": {
-     "duration": 0.288554,
-     "end_time": "2026-06-12T00:19:27.323954+00:00",
+     "duration": 0.275564,
+     "end_time": "2026-06-15T17:18:32.548202+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.035400+00:00",
+     "start_time": "2026-06-15T17:18:32.272638+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1177,32 +1170,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "  (select a!1 0)), "
+      "30, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "  (select a!1 1)), "
+      "10, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "  (select a!1 2)), "
+      "40, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "  (select a!1 3))"
+      "20"
      ]
     },
     {
@@ -1223,32 +1212,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "  (select (store (store a!1 0 (select a!1 1)) 1 (select a!1 0)) 0)), "
+      "10, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "  (select (store (store a!1 0 (select a!1 1)) 1 (select a!1 0)) 1)), "
+      "30, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "  (select (store (store a!1 0 (select a!1 1)) 1 (select a!1 0)) 2)), "
+      "40, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "  (select (store (store a!1 0 (select a!1 1)) 1 (select a!1 0)) 3))"
+      "20"
      ]
     },
     {
@@ -1269,36 +1254,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
-      "  (select (store (store a!2 2 (select a!2 3)) 3 (select a!2 2)) 0))), "
+      "10, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
-      "  (select (store (store a!2 2 (select a!2 3)) 3 (select a!2 2)) 1))), "
+      "30, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
-      "  (select (store (store a!2 2 (select a!2 3)) 3 (select a!2 2)) 2))), "
+      "20, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
-      "  (select (store (store a!2 2 (select a!2 3)) 3 (select a!2 2)) 3)))"
+      "40"
      ]
     },
     {
@@ -1319,40 +1296,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
-      "(let ((a!3 (store (store a!2 2 (select a!2 3)) 3 (select a!2 2))))\n",
-      "  (select (store (store a!3 1 (select a!3 2)) 2 (select a!3 1)) 0)))), "
+      "10, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
-      "(let ((a!3 (store (store a!2 2 (select a!2 3)) 3 (select a!2 2))))\n",
-      "  (select (store (store a!3 1 (select a!3 2)) 2 (select a!3 1)) 1)))), "
+      "20, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
-      "(let ((a!3 (store (store a!2 2 (select a!2 3)) 3 (select a!2 2))))\n",
-      "  (select (store (store a!3 1 (select a!3 2)) 2 (select a!3 1)) 2)))), "
+      "30, "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(let ((a!1 (store (store (store (store a 0 30) 1 10) 2 40) 3 20)))\n",
-      "(let ((a!2 (store (store a!1 0 (select a!1 1)) 1 (select a!1 0))))\n",
-      "(let ((a!3 (store (store a!2 2 (select a!2 3)) 3 (select a!2 2))))\n",
-      "  (select (store (store a!3 1 (select a!3 2)) 2 (select a!3 1)) 3))))"
+      "40"
      ]
     },
     {
@@ -1391,13 +1356,14 @@
     "        ctx.MkInt(2), ctx.MkInt(40)),\n",
     "        ctx.MkInt(3), ctx.MkInt(20));\n",
     "\n",
-    "    // Affichage d'un tableau symbolique\n",
+    "    // Affichage d'un tableau symbolique. Chaque select est réduite par Simplify()\n",
+    "    // en l'entier concret correspondant (réécriture select(store(...), i) -> valeur).\n",
     "    void PrintArray(string label, ArrayExpr arr)\n",
     "    {\n",
     "        Console.Write($\"{label} [\");\n",
     "        for (int k = 0; k < 4; k++)\n",
     "        {\n",
-    "            var val = ctx.MkSelect(arr, ctx.MkInt(k));\n",
+    "            var val = ctx.MkSelect(arr, ctx.MkInt(k)).Simplify();\n",
     "            Console.Write(k < 3 ? $\"{val}, \" : $\"{val}\");\n",
     "        }\n",
     "        Console.WriteLine(\"]\");\n",
@@ -1447,10 +1413,10 @@
    "id": "a9b0c1d2",
    "metadata": {
     "papermill": {
-     "duration": 0.006301,
-     "end_time": "2026-06-12T00:19:27.337358+00:00",
+     "duration": 0.006643,
+     "end_time": "2026-06-15T17:18:32.563865+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.331057+00:00",
+     "start_time": "2026-06-15T17:18:32.557222+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1478,10 +1444,10 @@
    "id": "b0c1d2e3",
    "metadata": {
     "papermill": {
-     "duration": 0.0063,
-     "end_time": "2026-06-12T00:19:27.350639+00:00",
+     "duration": 0.007416,
+     "end_time": "2026-06-15T17:18:32.578622+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.344339+00:00",
+     "start_time": "2026-06-15T17:18:32.571206+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1510,16 +1476,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:18.566589Z",
-     "iopub.status.busy": "2026-06-14T14:51:18.566035Z",
-     "iopub.status.idle": "2026-06-14T14:51:18.914159Z",
-     "shell.execute_reply": "2026-06-14T14:51:18.913146Z"
+     "iopub.execute_input": "2026-06-15T17:18:32.597492Z",
+     "iopub.status.busy": "2026-06-15T17:18:32.597217Z",
+     "iopub.status.idle": "2026-06-15T17:18:32.811866Z",
+     "shell.execute_reply": "2026-06-15T17:18:32.811652Z"
     },
     "papermill": {
-     "duration": 0.226311,
-     "end_time": "2026-06-12T00:19:27.583091+00:00",
+     "duration": 0.226504,
+     "end_time": "2026-06-15T17:18:32.811952+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.356780+00:00",
+     "start_time": "2026-06-15T17:18:32.585448+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1622,10 +1588,10 @@
    "id": "d2e3f4a5",
    "metadata": {
     "papermill": {
-     "duration": 0.006242,
-     "end_time": "2026-06-12T00:19:27.596435+00:00",
+     "duration": 0.008301,
+     "end_time": "2026-06-15T17:18:32.827406+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.590193+00:00",
+     "start_time": "2026-06-15T17:18:32.819105+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1653,10 +1619,10 @@
    "id": "e3f4a5b6",
    "metadata": {
     "papermill": {
-     "duration": 0.006253,
-     "end_time": "2026-06-12T00:19:27.609487+00:00",
+     "duration": 0.008549,
+     "end_time": "2026-06-15T17:18:32.843375+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.603234+00:00",
+     "start_time": "2026-06-15T17:18:32.834826+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1682,16 +1648,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:18.917269Z",
-     "iopub.status.busy": "2026-06-14T14:51:18.916705Z",
-     "iopub.status.idle": "2026-06-14T14:51:19.017124Z",
-     "shell.execute_reply": "2026-06-14T14:51:19.016716Z"
+     "iopub.execute_input": "2026-06-15T17:18:32.861689Z",
+     "iopub.status.busy": "2026-06-15T17:18:32.861335Z",
+     "iopub.status.idle": "2026-06-15T17:18:32.942585Z",
+     "shell.execute_reply": "2026-06-15T17:18:32.942347Z"
     },
     "papermill": {
-     "duration": 0.068916,
-     "end_time": "2026-06-12T00:19:27.687382+00:00",
+     "duration": 0.091128,
+     "end_time": "2026-06-15T17:18:32.942697+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.618466+00:00",
+     "start_time": "2026-06-15T17:18:32.851569+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1731,10 +1697,10 @@
    "id": "a5b6c7d8",
    "metadata": {
     "papermill": {
-     "duration": 0.007171,
-     "end_time": "2026-06-12T00:19:27.701210+00:00",
+     "duration": 0.007449,
+     "end_time": "2026-06-15T17:18:32.957620+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.694039+00:00",
+     "start_time": "2026-06-15T17:18:32.950171+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1760,16 +1726,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:19.019827Z",
-     "iopub.status.busy": "2026-06-14T14:51:19.019361Z",
-     "iopub.status.idle": "2026-06-14T14:51:19.081523Z",
-     "shell.execute_reply": "2026-06-14T14:51:19.080625Z"
+     "iopub.execute_input": "2026-06-15T17:18:32.984155Z",
+     "iopub.status.busy": "2026-06-15T17:18:32.983592Z",
+     "iopub.status.idle": "2026-06-15T17:18:33.059834Z",
+     "shell.execute_reply": "2026-06-15T17:18:33.059143Z"
     },
     "papermill": {
-     "duration": 0.049856,
-     "end_time": "2026-06-12T00:19:27.757608+00:00",
+     "duration": 0.093481,
+     "end_time": "2026-06-15T17:18:33.059973+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.707752+00:00",
+     "start_time": "2026-06-15T17:18:32.966492+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1810,10 +1776,10 @@
    "id": "c7d8e9fa",
    "metadata": {
     "papermill": {
-     "duration": 0.009808,
-     "end_time": "2026-06-12T00:19:27.774935+00:00",
+     "duration": 0.008172,
+     "end_time": "2026-06-15T17:18:33.076022+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.765127+00:00",
+     "start_time": "2026-06-15T17:18:33.067850+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1840,16 +1806,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T14:51:19.084205Z",
-     "iopub.status.busy": "2026-06-14T14:51:19.083724Z",
-     "iopub.status.idle": "2026-06-14T14:51:19.134142Z",
-     "shell.execute_reply": "2026-06-14T14:51:19.133417Z"
+     "iopub.execute_input": "2026-06-15T17:18:33.093239Z",
+     "iopub.status.busy": "2026-06-15T17:18:33.092931Z",
+     "iopub.status.idle": "2026-06-15T17:18:33.137778Z",
+     "shell.execute_reply": "2026-06-15T17:18:33.137374Z"
     },
     "papermill": {
-     "duration": 0.046696,
-     "end_time": "2026-06-12T00:19:27.834141+00:00",
+     "duration": 0.054047,
+     "end_time": "2026-06-15T17:18:33.137970+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.787445+00:00",
+     "start_time": "2026-06-15T17:18:33.083923+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1890,10 +1856,10 @@
    "id": "e9fa0b1c",
    "metadata": {
     "papermill": {
-     "duration": 0.006696,
-     "end_time": "2026-06-12T00:19:27.848853+00:00",
+     "duration": 0.00929,
+     "end_time": "2026-06-15T17:18:33.154634+00:00",
      "exception": false,
-     "start_time": "2026-06-12T00:19:27.842157+00:00",
+     "start_time": "2026-06-15T17:18:33.145344+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1946,14 +1912,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 7.877116,
-   "end_time": "2026-06-12T00:19:28.083368+00:00",
+   "duration": 9.746128,
+   "end_time": "2026-06-15T17:18:33.397211+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Z3\\03_Array_Theory.ipynb",
-   "output_path": "d:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Z3\\03_Array_Theory.ipynb",
+   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\03_Array_Theory.ipynb",
+   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\03_Array_Theory_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-12T00:19:20.206252+00:00",
+   "start_time": "2026-06-15T17:18:23.651083+00:00",
    "version": "2.7.0"
   },
   "polyglot_notebook": {


### PR DESCRIPTION
## Contexte

Finalisation qualité du notebook `03_Array_Theory.ipynb` (deep-queue po-2025, `See #2979`). Le notebook s'exécutait sans erreur mais **4 défauts de cohérence output/interprétation** le rendaient pédagogiquement trompeur.

## Défauts corrigés (1 thème : cohérence des sorties)

| # | Défaut | Avant | Après |
|---|--------|-------|-------|
| Ex1 | Interprétation markdown contradictoire | « somme vaut 14 » | `== 15` (contrainte + output) |
| Ex3 | Output SMT-LIB brut illisible | `(let ((a!1 (store ...))) (select ... 0))` | `[10, 20, 30, 40, 50]` |
| Ex4 | Transition no-op + valeurs non évaluées | `[2,2] -> [2,2]` (aller-retour sur place) | `[2,2] -> [2,0] -> [2,1]` (progression réelle) |
| Ex5 | Output SMT-LIB brut via `PrintArray` | `(let ((a!1 ...)))` | `[30, 10, 40, 20] -> [10, 20, 30, 40]` |

## Cause racine

`ctx.MkSelect(arr, idx)` retourne une `Expr` dont `.ToString()` produit la **syntaxe SMT-LIB**, pas une valeur. Deux remèdes selon le contexte :
- **Chaînes `select(store(...))` concrètes** → `.Simplify()` (l'axiome de McCarthy `select(store(a,i,v),i)=v` réduit en numérique) — Ex3, Ex5.
- **Valeurs symboliques** (dépendent d'un modèle) → `model.Eval(...)` — Ex4.

## Détail Ex4 (Missionnaires-Cannibales)

Le no-op `[2,2]→[2,2]` venait de l'absence de contrainte de **progression** : le solveur renvoyait un aller-retour « sur place » (`delta1 == delta2`), techniquement SAT mais sans valeur pédagogique. Ajout de deux contraintes de correction du modèle :
1. **Validité du retour** : `delta2 ≤ delta1` (on ne ramène que des personnes réellement sur la rive droite).
2. **Progression** : état final ≠ état initial → transition valide `[2,2] -> [2,0] -> [2,1]`.

## Preuves de validation

- `papermill` kernel `.net-csharp` : **exit 0**, 11 s, 0 erreur.
- **10 cellules code**, 0 `execution_count` null, 0 output manquant (H.3 ✓).
- 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1 ✓).
- **0 expression SMT-LIB brute** résiduelle dans les outputs (`(let`/`(select`/`(store` : 0).
- Sorties vérifiées : Ex3 `[10,20,30,40,50]→[10,40,30,20,50]`, Ex4 `[2,2]→[2,0]→[2,1]`, Ex5 trié `True`.
- Catalogue `COURSE_CATALOG.generated.{json,md}` **byte-identique** à `main`.
- Branche fraîche depuis `origin/main` (1 ahead / 0 behind).

## Note anti-régression

Diff `+217 / −251` (deletions > insertions). Les suppressions sont : (a) les **anciens outputs SMT-LIB bruts** (très longs) remplacés par des nombres courts, (b) la restructuration du bloc d'affichage Ex4. **Aucune cellule `# Solution` / `# Exemple`, aucun code fonctionnel, aucune contrainte Z3 utile supprimés** — toutes les modifications de code sont additives (`.Simplify()`, `model.Eval`, 2 contraintes de correction).

See #2979 (epic reste ouverte — livrable partiel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)