### PR TITLE
docs(qc): verify ML-Trend-Scanning post-#2801 (catalog 0.66 -> 0.33, downgraded historique) (See #1630)

### DIFF
--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -51,7 +51,7 @@ Strategies with solid risk-adjusted returns. These are the primary candidates fo
 | 17 | ML-LLM-Summarization | ML/NLP | Equities | 0.69 | 15.5 | — | — | robuste |
 | 18 | ML-RandomForest | ML | Multi-asset | 0.68 | 20.1 | — | — | robuste |
 | 19 | AllWeather | RISK | Multi-asset | ~~0.67~~ → **0.47** ✓post-#2801 | 7.5 | 16.4 | 0.46 | **historique** (downgraded -30%, low-turnover multi-asset NOT near-immune, PSR 19.6%) |
-| 20 | ML-Trend-Scanning | ML | Multi-window | 0.66 | 19.1 | — | — | robuste |
+| 20 | ML-Trend-Scanning | ML | Multi-window | ~~0.66~~ → **0.33** ✓post-#2801 | 7.1 | 29.4 | 0.24 | **historique** (downgraded -50%, daily rebalance on SPY/TLT/GLD multi-asset = very high turnover crushed by real IBKR fees, PSR 7.8%) |
 | 21 | VolTarget-Momentum | COMP | Multi-asset | ~~0.65~~ → **0.50** ✓post-#2801 | 11.1 | 21.2 | 0.53 | robuste borderline (revised -23%, PSR 9.4%) |
 | 22 | SectorMomentum | IND | Equities+Bonds+Gold | 0.62 | 13.2 | — | — | robuste |
 | 23 | BlackLitterman-Momentum | COMP | Equities/ETF | 0.60 | 13.7 | — | — | robuste |
@@ -104,6 +104,7 @@ brokerage = the #2801 Lot 1 remediation). Results vs the pre-remediation catalog
 | Portfolio-Optimization-ML | 29318874 | 0.90 | **0.88** | -2% | robuste (confirmed, monthly-rebalance fee-homogeneous equity basket near-immune, PSR 37.2%) |
 | CausalEventAlpha | 29809163 | 0.78 | **0.45** | -43% | **historique** (was robuste — monthly cadence but full-basket sector rotation = high turnover, PSR 5.5%) |
 | Gaussian-Direction-Classifier | 29398513 | 0.76 | **0.76** | 0% | robuste (confirmed — daily schedule but low realized turnover on liquid mega-cap = near-immune, PSR 22.7%) |
+| ML-Trend-Scanning | 29808859 | 0.66 | **0.33** | -50% | **historique** (was robuste — daily-rebalance SPY/TLT/GLD multi-asset crushed by real fees, PSR 7.8%) |
 | TrendStocksLite | 28817425 | 0.72 | **0.71** | -2% | robuste (confirmed — weekly trend on 15 liquid large-caps, low realized turnover, near-immune, PSR 25.0%) |
 
 **Finding (methodological, now 24-strategy sample)** : the remediation impact is **not


### PR DESCRIPTION
## Summary
Verify ML-Trend-Scanning post-#2801 for catalog #1630 (Tier-1 #20).

The original project (29808859) **already carried** `set_brokerage_model(IBKR, Margin)` — so it was backtested directly (no baseline-clone needed), full native period 2015→present (2878 dates).

## Result
- **Sharpe 0.66 → 0.328 (-50%, COLLAPSE)**
- CAGR 7.1%, MaxDD -29.4%, Calmar 0.24
- **PSR 7.8%** (non-significant)

**Verdict: DOWNGRADED to historique.** The catalog 0.66 was pre-remediation (optimistic). DAILY rebalance on a SPY/TLT/GLD multi-asset portfolio = very high turnover, and real IBKR fees compound heavily on every daily rebalance. Reinforces the regime finding: **daily-rebalance multi-asset is NOT robust post-fees** (worse than AllWeather -30%, which is *low*-turnover multi-asset). The discriminator holds — realized turnover × fee-per-trade, not asset class alone.

## Catalog edits (atomic, docs-only, 2 ins / 1 del)
1. Tier-1 row: add `✓post-#2801` + real Sharpe; status `robuste → historique`.
2. Secondary table: project-id row (29808859), inserted after Gaussian-Direction to avoid any conflict with the open #3081 (ML-RandomForest) insertion after TrendStocksLite.
3. No baseline-clone entry (original backtested, already remediated — like TrendStocksLite).

## Notes
- `totalOrders=0` from the MCP is the known phantom-parse bug (CAGR 7.1% requires trades).
- No `COURSE_CATALOG.generated` churn; submodule untouched.

See #1630 (partial — one more Tier-1 verified, ~15 remain serialized on the single backtest node).
