### PR TITLE
fix(prover): build-aware sorry count in _build_check_or_revert (#1500 class)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -1024,8 +1024,21 @@ class TacticTools:
             }
 
         if result.get("success"):
-            # P1 fix: track delta0 even on clean build success from file_replace
-            sorry_count = Path(self._filepath).read_text(encoding="utf-8").count("sorry")
+            # P1 fix + #1500: track delta0 even on clean build success from
+            # file_replace. Use the build-aware count (max of the text token
+            # and the 'uses sorry' build warnings): a build can SUCCEED while
+            # still warning 'declaration uses sorry' (an implicit sorry from an
+            # unresolved apply?/exact?/solve_by_elim), and the file text then
+            # no longer contains the token 'sorry' -- a text-only count would
+            # record 0, i.e. a false 'solved / new low' on the dominant
+            # file_replace path (~75 vs ~5 compile() calls in the cycle-97 L308
+            # trace). Mirrors compile() (tools.py:1769) and the #1500 gates in
+            # provers.run_session / workflow P1 latch.
+            _content = Path(self._filepath).read_text(encoding="utf-8")
+            sorry_count = max(
+                _content.count("sorry"),
+                _count_sorries_from_build_output(result.get("raw_output", "")),
+            )
             self._record_sorry_count(sorry_count)
             return None
 
@@ -1058,8 +1071,13 @@ class TacticTools:
 
         # If only sorry-related errors, accept the replacement (don't revert)
         if not non_sorry_errors:
-            # P1 fix: track delta0 on sorry-only build success from file_replace
-            current_sorry = Path(self._filepath).read_text(encoding="utf-8").count("sorry")
+            # P1 fix + #1500: track delta0 on sorry-only build success from
+            # file_replace, build-aware (see the success-path note above).
+            _content = Path(self._filepath).read_text(encoding="utf-8")
+            current_sorry = max(
+                _content.count("sorry"),
+                _count_sorries_from_build_output(raw_output),
+            )
             self._record_sorry_count(current_sorry)
             return None
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1317,3 +1317,94 @@ def test_autonomous_gate_structural_flag_feeds_result():
         final_sorry=4, original_sorry_count=4, final_build_ok=True,
     )
     assert structural is True  # build-OK, sorry_delta==0 -> "proof restructured"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #1500 (tools.py) — _build_check_or_revert success path must count the
+# build-aware sorry, not the text token.
+#
+# The build-count fix (#1500) was applied to compile() (tools.py:1769) and to
+# the provers.run_session / workflow P1-latch gates, but _build_check_or_revert
+# -- the build-check run after every file_replace_* edit (the dominant
+# autonomous path: ~75 replace vs ~5 compile() calls in the cycle-97 L308
+# trace) -- still used text.count('sorry'). A build that SUCCEEDS while warning
+# 'declaration uses sorry' (implicit sorry from an unresolved apply?/exact?),
+# with the explicit 'sorry' token removed, reports text=0, which
+# _record_sorry_count(0) reads as a fresh 'solved / new low' -> false progress
+# signal on the path that matters most.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _patch_verifier_success(monkeypatch, raw_output):
+    """Mock verify_project_file to return a successful build with given log."""
+    import prover.verifier as vmod
+
+    class _FakeVerifier:
+        def verify_project_file(self, rel, force=False):
+            return {"success": True, "errors": "", "raw_output": raw_output}
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _FakeVerifier())
+
+
+def test_build_check_or_revert_counts_implicit_sorry(tmp_path, monkeypatch):
+    """A success-path build that warns 'uses sorry' must record count 1, not 0.
+
+    The agent swapped the explicit sorry for apply? (found nothing): the file
+    text no longer contains the token 'sorry', but the build still warns of an
+    implicit sorry. The build-aware count must see it so _record_sorry_count
+    does not register a false 'solved / new low'.
+    """
+    swapped = (
+        "import Mathlib.Tactic\n"
+        "theorem t : True := by\n"
+        "  apply?\n"
+    )
+    fake = tmp_path / "Implicit.lean"
+    fake.write_text(swapped, encoding="utf-8")
+
+    _patch_verifier_success(
+        monkeypatch,
+        "warning: ./Implicit.lean:3:0: declaration uses 'sorry'\n",
+    )
+
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(
+        filepath=str(fake), sorry_line=3, indentation=2,
+        indent_str="  ", full_file=swapped,
+    )
+    tt = TacticTools(state, str(fake), sctx)
+
+    # pre-edit content carried 1 explicit sorry
+    original = swapped.replace("  apply?\n", "  sorry\n")
+    result = tt._build_check_or_revert(original, "test")
+
+    assert result is None, "a successful build must not revert"
+    assert tt._min_compile_sorry_count == 1, (
+        f"implicit sorry must be counted via build output (got "
+        f"{tt._min_compile_sorry_count}); a text-only count would record 0 "
+        f"and falsely signal solved"
+    )
+
+
+def test_build_check_or_revert_real_solve_records_zero(tmp_path, monkeypatch):
+    """A genuine solve (build success, no sorry warning) records 0."""
+    proved = (
+        "import Mathlib.Tactic\n"
+        "theorem t : True := by\n"
+        "  trivial\n"
+    )
+    fake = tmp_path / "Proved.lean"
+    fake.write_text(proved, encoding="utf-8")
+
+    _patch_verifier_success(monkeypatch, "Build completed successfully.\n")
+
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(
+        filepath=str(fake), sorry_line=3, indentation=2,
+        indent_str="  ", full_file=proved,
+    )
+    tt = TacticTools(state, str(fake), sctx)
+
+    original = proved.replace("  trivial\n", "  sorry\n")
+    assert tt._build_check_or_revert(original, "test") is None
+    assert tt._min_compile_sorry_count == 0


### PR DESCRIPTION
## Context

Dispatch from ai-01 (Epic #1453, prover harness, po-2026 lane): 2 S-size forensic-grounded fixes in `agent_tests/prover/`:
- **(a)** D1 compile-stagnation guard in `compile()`
- **(b)** text-count -> build-count: count sorries from the `lake build` warnings, not `text.count('sorry')`

## G.1 finding: both fixes were already ~90% done in a prior #1453 cycle

Before implementing, I grounded against the code (SDDD + rule G.1: verify before claiming). Findings:

**(b) build-count** -- already applied to:
- `compile()` at `tools.py:1769` (`sorry_count = max(text_sorry_count, build_sorry_count)`)
- the P1-latch gates in `provers.run_session` and `workflow.py`

**BUT one genuine gap remained**: `_build_check_or_revert` (the build-check run after every `file_replace_*` edit -- the **dominant autonomous path**: ~75 replace vs ~5 `compile()` calls in the cycle-97 L308 trace) still used `text.count('sorry')`. A build that SUCCEEDS while warning `declaration uses sorry` (an implicit sorry from an unresolved `apply?`/`exact?`/`solve_by_elim`), with the explicit `sorry` token removed, then reports text=0 -> `_record_sorry_count(0)` reads a false "solved / new low" on the path that matters most. **This PR closes that gap** (`tools.py:1028` success path + `tools.py:1071` sorry-only path).

**(a) stagnation guard** -- already fully implemented in the prior cycle:
- `compile()` at `tools.py:1792` (`_consecutive_delta0 >= _stagnation_threshold`)
- `_build_check_or_revert` via `_record_sorry_count` (`tools.py:1037`, P1 delta0 tracking)
- `_record_sorry_count` (`tools.py:978`), `reset_stagnation` (`tools.py:965`)

So **(a) literal re-implementation (progress-hash + `raise StagnationDetected`)** was NOT added -- it would (1) duplicate the existing `_consecutive_delta0` guard, and (2) raising from inside `compile()` would break its `-> str` JSON contract (every caller expects a JSON result string, not an exception). **Flagging this deviation for ai-01's review.**

## Changes

- `prover/tools.py`: `_build_check_or_revert` success path (`:1028`) + sorry-only path (`:1071`) now use `max(text.count('sorry'), _count_sorries_from_build_output(raw))`, mirroring `compile():1769` and the P1-latch gates. The `LOST_PROGRESS` path (`:1071`) is left text-count on purpose (self-consistent comparison: `original_content` has no build output to count from).
- `tests/test_prover_guards.py`: +2 tests (`test_build_check_or_revert_counts_implicit_sorry` -- a success-path build that warns `uses sorry` must record count 1, not 0; `test_build_check_or_revert_real_solve_records_zero` -- a genuine solve records 0).

## Validation

- `python -m pytest tests/test_prover_guards.py -q` -> **73 passed, 1 pre-existing failure**.
  - The failure (`test_probe_goal_cache_invalidates_on_file_change`) is **unrelated to this PR**: my diff is isolated to `_build_check_or_revert` (2 hunks `@1024` + `@1058`) and a pure test-file append (`@1317`); the failing test lives at line ~995, untouched. It is a stale test vs the P2 surrounding-context cache fix -- it appends at end-of-file, outside the `[sorry_line-10, +10]` window the cache now keys on, so the cache correctly does not invalidate. Flagging for ai-01.
- The 2 new tests pass explicitly: `pytest -k build_check_or_revert` -> **2 passed**.
- Per the dispatch, ai-01 does the prod validation (multi-agent run).

See #1453
