### PR TITLE
test(prover): characterize P2 probe-goal cache window (#1460)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -992,8 +992,15 @@ def test_probe_goal_caches_unchanged_file(tactic_tools, monkeypatch):
     assert json.loads(first)["goal"] == f"goal at {line}"
 
 
-def test_probe_goal_cache_invalidates_on_file_change(tactic_tools, monkeypatch):
-    """Editing the file changes its content hash, so the next probe recomputes."""
+def test_probe_goal_cache_invalidates_on_context_change(tactic_tools, monkeypatch):
+    """An edit INSIDE the [sorry-11, sorry+10] context window busts the cache.
+
+    P2 fix (#1460): the probe cache keys on the surrounding context hash
+    (±probe_ctx_lines around sorry), not the whole file. A context-window edit
+    changes that hash -> cache miss -> recompute. (The old whole-file-hash
+    test assumed ANY edit invalidated; the P2 narrowing makes that false -- see
+    the companion test_probe_goal_cache_survives_out_of_window_edit below.)
+    """
     import prover.lean_utils as lean_utils
 
     calls = {"n": 0}
@@ -1006,12 +1013,48 @@ def test_probe_goal_cache_invalidates_on_file_change(tactic_tools, monkeypatch):
     line = tactic_tools._test_sorry_line
 
     tactic_tools.compile_probe_goal(line)
-    # Mutate the underlying file: the content hash changes -> cache miss.
+    # Mutate a line INSIDE the context window (the line right after sorry is
+    # within [sorry-11, sorry+10] -> changes the context hash -> cache miss).
+    path = Path(tactic_tools._filepath)
+    lines = path.read_text(encoding="utf-8").split("\n")
+    lines[line] = lines[line] + "  -- in-window context edit"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    tactic_tools.compile_probe_goal(line)
+
+    assert calls["n"] == 2, "an in-window context edit must invalidate the probe cache"
+
+
+def test_probe_goal_cache_survives_out_of_window_edit(tactic_tools, monkeypatch):
+    """An edit OUTSIDE the context window does NOT bust the cache (P2 #1460).
+
+    The padded fixture places the sorry near the middle with ~50 trailing
+    padding lines, so an EOF append lands far outside [sorry-11, sorry+10].
+    The context hash is unchanged -> cache hit -> no recompute. This is the
+    P2 optimization (edits far from the sorry no longer invalidate the cache)
+    and the exact case the old whole-file-hash assertion wrongly expected to
+    recompute (it failed with `assert 1 == 2` on a clean main).
+    """
+    import prover.lean_utils as lean_utils
+
+    calls = {"n": 0}
+
+    def fake_get_goal_state(filepath, line):
+        calls["n"] += 1
+        return f"goal v{calls['n']}"
+
+    monkeypatch.setattr(lean_utils, "get_goal_state", fake_get_goal_state)
+    line = tactic_tools._test_sorry_line
+
+    tactic_tools.compile_probe_goal(line)
+    # Append at EOF -- outside the context window, so the hash is unchanged.
     path = Path(tactic_tools._filepath)
     path.write_text(path.read_text(encoding="utf-8") + "\n-- edit\n", encoding="utf-8")
     tactic_tools.compile_probe_goal(line)
 
-    assert calls["n"] == 2, "a content change must invalidate the probe cache"
+    assert calls["n"] == 1, (
+        "an out-of-window (EOF) edit must NOT invalidate the probe cache "
+        "(P2 #1460: hash surrounding context only)"
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Context

Follow-up to #3087, where I flagged a pre-existing failing test: `test_probe_goal_cache_invalidates_on_file_change`. This PR fixes it.

## Root cause

The probe-goal cache (`compile_probe_goal`, `tools.py:1711`) was narrowed in the **P2 fix (#1460)** to key on the surrounding-context hash (`lines[sorry-11 : sorry+10]`) instead of the whole file -- so edits far from the sorry no longer invalidate the cache (deliberate optimization, documented in the method docstring at `tools.py:1714-1718`).

The old test still asserted the **pre-P2 whole-file-hash behavior**: it appended `\n-- edit\n` at EOF and expected a recompute (`calls["n"] == 2`). But the padded fixture puts the sorry near the middle (`sorry_line = 54`) with ~50 trailing lines, so EOF (~line 106) is far outside the `[44, 64]` context window -> the cache correctly hit -> `calls["n"] == 1` -> `assert 1 == 2` failed.

## Fix

Replaced the stale test with two **characterization** tests of the P2 behavior:
- `test_probe_goal_cache_invalidates_on_context_change` -- an **in-window** edit (the line right after sorry, index within `[sorry-11, sorry+10]`) changes the context hash -> cache miss -> recompute (`calls == 2`).
- `test_probe_goal_cache_survives_out_of_window_edit` -- an **EOF append** stays outside the window -> cache hit -> no recompute (`calls == 1`). This is the exact case the old assertion wrongly expected to recompute.

## Validation (G.1)

- **Reproduced** the failure on clean `origin/main` first: `assert 1 == 2`.
- Suite: clean main = 71 passed / 1 failed; this branch = **73 passed / 0 failed**.
- `test_prover_guards.py` is **not exercised by CI** (no workflow references it), so this is local test-suite hygiene, not a CI red -- but a locally-failing test is a real defect (confusing red bar for anyone running `pytest`).

## Scope

- 1 file, +47/-4, test-only. No production code touched (the cache logic is unchanged and correct).
- Unrelated working-tree drift (`Reidemeister.lean`, submodule pointer, scratch `tmp_*.py`) is NOT staged.

See #1460
