### PR TITLE
docs(qc): verify SectorMomentum post-#2801 (0.62 -> 0.56, mild -9%)

### DIFF
--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -53,7 +53,7 @@ Strategies with solid risk-adjusted returns. These are the primary candidates fo
 | 19 | AllWeather | RISK | Multi-asset | ~~0.67~~ → **0.47** ✓post-#2801 | 7.5 | 16.4 | 0.46 | **historique** (downgraded -30%, low-turnover multi-asset NOT near-immune, PSR 19.6%) |
 | 20 | ML-Trend-Scanning | ML | Multi-window | ~~0.66~~ → **0.33** ✓post-#2801 | 7.1 | 29.4 | 0.24 | **historique** (downgraded -50%, daily rebalance on SPY/TLT/GLD multi-asset = very high turnover crushed by real IBKR fees, PSR 7.8%) |
 | 21 | VolTarget-Momentum | COMP | Multi-asset | ~~0.65~~ → **0.50** ✓post-#2801 | 11.1 | 21.2 | 0.53 | robuste borderline (revised -23%, PSR 9.4%) |
-| 22 | SectorMomentum | IND | Equities+Bonds+Gold | 0.62 | 13.2 | — | — | robuste |
+| 22 | SectorMomentum | IND | Equities+Bonds+Gold | ~~0.62~~ → **0.56** ✓post-#2801 | 13.1 | 22.8 | 0.58 | robuste (mild -9%, monthly rebalance winner-takes-all on 3 ETFs = low rotation near-immune, contrasts heavier multi-sleeve baskets; PSR 13.8% low, not a true leader) |
 | 23 | BlackLitterman-Momentum | COMP | Equities/ETF | 0.60 | 13.7 | — | — | robuste |
 | 24 | Crypto-MultiCanal | IND | Crypto (BTC) | ~~0.58~~ → **0.33** ✓post-#2801 | 4.6 | 14.1 | 0.33 | **historique** (downgraded -43%, crypto indicator NOT robust post-fees, PSR 13.0%) |
 | 25 | ML-FeatureEngineering | ML | Multi-asset | 0.57 | 10.5 | — | — | robuste |
@@ -99,6 +99,7 @@ brokerage = the #2801 Lot 1 remediation). Results vs the pre-remediation catalog
 | HAR-RV-Kelly | 31650567 | — | **0.75** | (gap-fill) | robuste borderline (first real data, PSR 24.0%, MaxDD -48% crypto) |
 | RL-DQN-Trading | 32057969 | 0.53 | **0.58 (2020-21)** | n/a | **non re-verifiable** (~1yr window, runtime error on extension) |
 | MeanReversion | 30776121 | 0.81 | **0.81** | 0% | robuste (confirmed, PSR 46.8%, low-turnover sector rotation holds) |
+| SectorMomentum | 29686886 | 0.62 | **0.56** | -9% | robuste (mild — monthly rebalance winner-takes-all on 3 ETFs = low rotation near-immune; PSR 13.8% low, not a true leader) |
 | LongShortHarvest | 32921183 | 3.39 | **1.64** | -52% | robuste (confirmed, **PSR 98.7%** top — catalog was 1Y-OOS, baseline-clone) |
 | DynamicVIXSpyRegime | 32921262 | 1.72 | **1.00** | -42% | robuste (confirmed, **PSR 69.4%** — catalog was 1Y-OOS, baseline-clone) |
 | Portfolio-Optimization-ML | 29318874 | 0.90 | **0.88** | -2% | robuste (confirmed, monthly-rebalance fee-homogeneous equity basket near-immune, PSR 37.2%) |
@@ -108,7 +109,7 @@ brokerage = the #2801 Lot 1 remediation). Results vs the pre-remediation catalog
 | TrendStocksLite | 28817425 | 0.72 | **0.71** | -2% | robuste (confirmed — weekly trend on 15 liquid large-caps, low realized turnover, near-immune, PSR 25.0%) |
 | ML-RandomForest | 29434751 | 0.68 | **0.70** | +3% | robuste (confirmed — bi-weekly RF on 10 mega-caps, moderate turnover near-immune on fee-homogeneous US equity, PSR 18.4%, baseline-clone 32940005) |
 
-**Finding (methodological, now 24-strategy sample)** : the remediation impact is **not
+**Finding (methodological, now 25-strategy sample)** : the remediation impact is **not
 uniform**, and the batch-4 results *refine and partly correct* the earlier 10-strategy pattern.
 The distinguishing axis is **not** asset class, nor ML-vs-indicator alone — it is the
 combination of (a) the fee-per-trade the asset class carries and (b) how the strategy turns


### PR DESCRIPTION
## Summary

Re-backtested **ESGF-SectorMomentum** (project `29686886`) under its existing IBKR margin brokerage as part of the #1630 post-#2801 verification campaign. The strategy was already remediated (IBKR brokerage present in `main.py`), so it was backtested directly — no baseline-clone needed.

**Strategy**: monthly-rebalance dual momentum on SPY/TLT/GLD (3 ETFs, winner-takes-all multi-lookback composite 21/63/126/252d, daily SMA200 intra-month exit).

## Result (full period, 2015-present, 2817 tradeable dates)

| Metric | Value |
|--------|-------|
| Sharpe | **0.562** (catalog 0.62 → **0.56**, mild -9%) |
| CAGR | 13.1% |
| MaxDD | -22.8% |
| Calmar | 0.58 |
| PSR | **13.8%** (low) |

Backtest: `1630-SectorMomentum-post2801` (`c7de8070`) on project `29686886`.

## Classification: robuste (mild), not a true leader

- Sharpe 0.562 > 0.5 → **robuste** by the campaign threshold.
- PSR 13.8% < 50% → not statistically significant. The "true leaders" (PSR > 50%) remain PNS, LeveragedETFMomentum, TrendWeather, EMA-CS.
- Confirms the docstring "Sharpe ceiling ~0.555 for dual momentum on 3-5 assets" (v3.2) — the catalog 0.62 was stale/optimistic.

## Finding refinement (regime discriminator)

SectorMomentum is a **low-turnover multi-asset** strategy (monthly, winner-takes-all among 3 ETFs = minimal rotation) and shows only **mild -9%** fee impact. This contrasts the heavier collapses observed for:
- **AllWeather** (-30%) — low-turnover but **multi-sleeve** (holds many assets simultaneously → more rebalancing friction),
- **ML-Trend-Scanning** (-50%) — **daily** rebalance on the same SPY/TLT/GLD basket.

Within the "low-turnover multi-asset" zone, **rebalance frequency + concentration structure** modulate fee friction: winner-takes-all among few ETFs is near-immune, while simultaneous multi-sleeve baskets are more exposed. SectorMomentum is robuste-by-Sharpe but its low PSR means it is not a genuine alpha leader.

## Changes

`docs/qc/qc-comparative-backtests.md` only (3 edits):
- Tier-1 row #22 SectorMomentum: `0.62` → `~~0.62~~ → 0.56 ✓post-#2801` + metrics.
- Secondary project-id table: added SectorMomentum row (`29686886`).
- Finding count: 24 → 25-strategy sample.

## Notes

- `totalOrders=0` returned by the MCP is the known phantom parse bug — CAGR 13% is impossible with zero trades.
- No `COURSE_CATALOG.generated.*` touched (automation-owned). `openzeppelin` submodule not staged (SymbolicAI lane, pre-existing).

See #1630