### PR TITLE
docs(genai): restore French diacritics in Image README (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -2,24 +2,24 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Docker Management](../00-GenAI-Environment/00-2-Docker-Services-Management.ipynb)
 
-La generation d'images par IA est la deuxieme modalite generative la plus accessible apres le texte. Elle couvre un spectre large : generation from scratch (DALL-E, FLUX), edition d'images existantes (Qwen Image Edit), upscaling (Real-ESRGAN), et orchestration de workflows multi-modeles via ComfyUI. La progression va du prompt cloud one-shot au workflow ComfyUI multi-modeles oriente production.
+La génération d'images par IA est la deuxième modalité générative la plus accessible après le texte. Elle couvre un spectre large : génération from scratch (DALL-E, FLUX), édition d'images existantes (Qwen Image Edit), upscaling (Real-ESRGAN), et orchestration de workflows multi-modèles via ComfyUI. La progression va du prompt cloud one-shot au workflow ComfyUI multi-modèles orienté production.
 
-## Fil rouge : construire un generateur de contenu visuel educatif
+## Fil rouge : construire un générateur de contenu visuel éducatif
 
-L'objectif fil rouge de cette serie est de construire un systeme capable de produire des visuels pedagogiques de qualite : diagrammes, illustrations conceptuelles, et images d'identite pour des supports de cours. Chaque niveau apporte une brique supplementaire : generation simple via API cloud (niveau 1), modeles avances et edition fine (niveau 2), comparaison et orchestration multi-modeles (niveau 3), workflows de production (niveau 4), et cas d'usage concrets par domaine (examples).
+L'objectif fil rouge de cette série est de construire un système capable de produire des visuels pédagogiques de qualité : diagrammes, illustrations conceptuelles, et images d'identité pour des supports de cours. Chaque niveau apporte une brique supplémentaire : génération simple via API cloud (niveau 1), modèles avancés et édition fine (niveau 2), comparaison et orchestration multi-modèles (niveau 3), workflows de production (niveau 4), et cas d'usage concrets par domaine (examples).
 
 ## Acquis d'apprentissage
 
-A l'issue de la serie, l'apprenant sait :
+À l'issue de la série, l'apprenant sait :
 
-- **Choisir la bonne modalite** : API cloud (DALL-E 3, GPT-5 Image) vs ComfyUI auto-heberge (SD XL, FLUX, Qwen) selon le besoin (controle, cout, debit, donnees sensibles).
+- **Choisir la bonne modalité** : API cloud (DALL-E 3, GPT-5 Image) vs ComfyUI auto-hébergé (SD XL, FLUX, Qwen) selon le besoin (contrôle, coût, débit, données sensibles).
 - **Manipuler une image en code** : PIL/OpenCV pour redimensionnement, masques, compositing, conversion VAE latents <-> pixels.
-- **Concevoir un workflow ComfyUI** : graphe de noeuds (Sampler, VAE, ConditioningCombine, ModelSampling), import/export JSON, batching et seeds reproductibles.
-- **Editer plutot que regenerer** : Qwen Image Edit, ControlNet, inpainting (zones a regenerer dans un visuel existant) — moins couteux et plus controlable que repartir de zero.
-- **Composer plusieurs modeles** : pipeline base + LoRA style + upscaler + post-processing pour atteindre une qualite "supports de cours".
-- **Operationnaliser** : gestion VRAM (quantizations Nunchaku INT4 / FP8), file d'attente ComfyUI, monitoring GPU, deploiement derriere une API.
+- **Concevoir un workflow ComfyUI** : graphe de nœuds (Sampler, VAE, ConditioningCombine, ModelSampling), import/export JSON, batching et seeds reproductibles.
+- **Éditer plutôt que régénérer** : Qwen Image Edit, ControlNet, inpainting (zones à régénérer dans un visuel existant) — moins coûteux et plus contrôlable que repartir de zéro.
+- **Composer plusieurs modèles** : pipeline base + LoRA style + upscaler + post-processing pour atteindre une qualité "supports de cours".
+- **Opérationnaliser** : gestion VRAM (quantizations Nunchaku INT4 / FP8), file d'attente ComfyUI, monitoring GPU, déploiement derrière une API.
 
-La structure detaillee (notebooks par niveau, contenu, services utilises) est listee plus bas. Le decompte canonique reside dans `CATALOG-STATUS.json` du depot.
+La structure détaillée (notebooks par niveau, contenu, services utilisés) est listée plus bas. Le décompte canonique réside dans `CATALOG-STATUS.json` du dépôt.
 
 ## Structure
 
@@ -34,40 +34,40 @@ Image/
 
 ## Progression par niveau
 
-### 01-Foundation - Modeles de base
+### 01-Foundation - Modèles de base
 
-Avant de produire des visuels pedagogiques, il faut maitriser les outils de generation. Ce niveau couvre les deux approches : API cloud (DALL-E 3, GPT-5) pour la simplicite, et modeles locaux via ComfyUI (SD XL Turbo, Qwen) pour le controle fin. [01-3](01-Foundation/01-3-Basic-Image-Operations.ipynb) donne les bases de manipulation d'image (PIL, OpenCV) necessaires pour comprendre ce que font les modeles.
+Avant de produire des visuels pédagogiques, il faut maîtriser les outils de génération. Ce niveau couvre les deux approches : API cloud (DALL-E 3, GPT-5) pour la simplicité, et modèles locaux via ComfyUI (SD XL Turbo, Qwen) pour le contrôle fin. [01-3](01-Foundation/01-3-Basic-Image-Operations.ipynb) donne les bases de manipulation d'image (PIL, OpenCV) nécessaires pour comprendre ce que font les modèles.
 
 | Notebook | Contenu | Service |
 |----------|---------|---------|
-| [01-1-OpenAI-DALL-E-3](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) | Generation avec DALL-E 3 | OpenAI API |
-| [01-2-GPT-5-Image-Generation](01-Foundation/01-2-GPT-5-Image-Generation.ipynb) | Generation avec GPT-5 | OpenAI API |
-| [01-3-Basic-Image-Operations](01-Foundation/01-3-Basic-Image-Operations.ipynb) | Operations de base | PIL/OpenCV |
+| [01-1-OpenAI-DALL-E-3](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) | Génération avec DALL-E 3 | OpenAI API |
+| [01-2-GPT-5-Image-Generation](01-Foundation/01-2-GPT-5-Image-Generation.ipynb) | Génération avec GPT-5 | OpenAI API |
+| [01-3-Basic-Image-Operations](01-Foundation/01-3-Basic-Image-Operations.ipynb) | Opérations de base | PIL/OpenCV |
 | [01-4-Forge-SD-XL-Turbo](01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb) | Stable Diffusion XL Turbo | ComfyUI |
 | [01-5-Qwen-Image-Edit](01-Foundation/01-5-Qwen-Image-Edit.ipynb) | Introduction Qwen | ComfyUI |
 
 [README 01-Foundation](01-Foundation/README.md)
 
-### 02-Advanced - Modeles avances
+### 02-Advanced - Modèles avancés
 
-Un visuel educatif de qualite demande des outils plus precis : edition d'images existantes (Qwen), generation haute qualite (FLUX), ou modeles legers et rapides (Z-Image/Lumina). Ce niveau explore les modeles de pointe et leurs compromis entre qualite, vitesse et ressources GPU.
+Un visuel éducatif de qualité demande des outils plus précis : édition d'images existantes (Qwen), génération haute qualité (FLUX), ou modèles légers et rapides (Z-Image/Lumina). Ce niveau explore les modèles de pointe et leurs compromis entre qualité, vitesse et ressources GPU.
 
 | Notebook | Contenu | Service |
 |----------|---------|---------|
-| [02-1-Qwen-Image-Edit-2509](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb) | Edition avancee Qwen | ComfyUI |
-| [02-2-FLUX-1-Advanced-Generation](02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb) | Generation FLUX | ComfyUI |
+| [02-1-Qwen-Image-Edit-2509](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb) | Édition avancée Qwen | ComfyUI |
+| [02-2-FLUX-1-Advanced-Generation](02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb) | Génération FLUX | ComfyUI |
 | [02-3-Stable-Diffusion-3-5](02-Advanced/02-3-Stable-Diffusion-3-5.ipynb) | SD 3.5 | ComfyUI |
 | [02-4-Z-Image-Lumina2](02-Advanced/02-4-Z-Image-Lumina2.ipynb) | Z-Image/Lumina | ComfyUI |
 
 [README 02-Advanced](02-Advanced/README.md)
 
-### 03-Orchestration - Multi-modeles
+### 03-Orchestration - Multi-modèles
 
-En production, un seul modele ne suffit pas toujours. Ce niveau compare les modeaux entre eux pour choisir le bon selon le contexte, orchestre des pipelines de traitement (generation puis edition puis upscaling), et optimise les performances pour le deploiement.
+En production, un seul modèle ne suffit pas toujours. Ce niveau compare les modèles entre eux pour choisir le bon selon le contexte, orchestre des pipelines de traitement (génération puis édition puis upscaling), et optimise les performances pour le déploiement.
 
 | Notebook | Contenu |
 |----------|---------|
-| [03-1-Multi-Model-Comparison](03-Orchestration/03-1-Multi-Model-Comparison.ipynb) | Comparaison multi-modeles |
+| [03-1-Multi-Model-Comparison](03-Orchestration/03-1-Multi-Model-Comparison.ipynb) | Comparaison multi-modèles |
 | [03-2-Workflow-Orchestration](03-Orchestration/03-2-Workflow-Orchestration.ipynb) | Orchestration de workflows |
 | [03-3-Performance-Optimization](03-Orchestration/03-3-Performance-Optimization.ipynb) | Optimisation performance |
 
@@ -75,30 +75,30 @@ En production, un seul modele ne suffit pas toujours. Ce niveau compare les mode
 
 ### 04-Applications - Production
 
-Ce niveau met en oeuvre les workflows complets : generation automatisee de contenu educatif, pipelines creatifs, integration en production, et un exemple concret de conversion d'images en patrons de point de croix.
+Ce niveau met en œuvre les workflows complets : génération automatisée de contenu éducatif, pipelines créatifs, intégration en production, et un exemple concret de conversion d'images en patrons de point de croix.
 
 | Notebook | Contenu |
 |----------|---------|
-| [04-1-Educational-Content-Generation](04-Applications/04-1-Educational-Content-Generation.ipynb) | Contenu educatif |
-| [04-2-Creative-Workflows](04-Applications/04-2-Creative-Workflows.ipynb) | Workflows creatifs |
-| [04-3-Production-Integration](04-Applications/04-3-Production-Integration.ipynb) | Integration production |
+| [04-1-Educational-Content-Generation](04-Applications/04-1-Educational-Content-Generation.ipynb) | Contenu éducatif |
+| [04-2-Creative-Workflows](04-Applications/04-2-Creative-Workflows.ipynb) | Workflows créatifs |
+| [04-3-Production-Integration](04-Applications/04-3-Production-Integration.ipynb) | Intégration production |
 | [04-4-Cross-Stitch-Pattern-Maker-Legacy](04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb) | Point de croix (legacy) |
 
 [README 04-Applications](04-Applications/README.md)
 
 ### examples/ - Cas d'usage
 
-Applications directes par domaine : histoire-geographie (cartes, reconstitutions), litterature (illustrations de textes), et sciences (diagrammes, schemas techniques). Ces notebooks montrent comment adapter les techniques des niveaux precedents a des besoins concrets.
+Applications directes par domaine : histoire-géographie (cartes, reconstitutions), littérature (illustrations de textes), et sciences (diagrammes, schémas techniques). Ces notebooks montrent comment adapter les techniques des niveaux précédents à des besoins concrets.
 
 | Notebook | Domaine |
 |----------|---------|
-| [history-geography](examples/history-geography.ipynb) | Histoire-Geographie |
-| [literature-visual](examples/literature-visual.ipynb) | Litterature |
+| [history-geography](examples/history-geography.ipynb) | Histoire-Géographie |
+| [literature-visual](examples/literature-visual.ipynb) | Littérature |
 | [science-diagrams](examples/science-diagrams.ipynb) | Diagrammes scientifiques |
 
 ## Technologies
 
-| Technologie | Notebooks | Prerequis |
+| Technologie | Notebooks | Prérequis |
 |-------------|-----------|-----------|
 | **OpenAI DALL-E 3** | 01-1, 01-2 | `OPENAI_API_KEY` |
 | **ComfyUI + Qwen** | 01-4, 01-5, 02-1 | Docker, ~29GB VRAM |
@@ -106,7 +106,7 @@ Applications directes par domaine : histoire-geographie (cartes, reconstitutions
 | **ComfyUI + SD 3.5** | 02-3 | Docker GPU |
 | **Z-Image/Lumina** | 02-4 | Docker, ~10GB VRAM |
 
-## Prerequisites
+## Prérequis
 
 ### API Keys
 
@@ -123,14 +123,14 @@ cd docker-configurations/services/comfyui-qwen
 docker-compose up -d
 ```
 
-Acces : http://localhost:8188
+Accès : http://localhost:8188
 
-## Parcours recommande
+## Parcours recommandé
 
 ```
 01-Foundation (bases)
     |
-02-Advanced (modeles specifiques)
+02-Advanced (modèles spécifiques)
     |
 03-Orchestration (comparaison, workflows)
     |
@@ -139,54 +139,54 @@ Acces : http://localhost:8188
 
 | Objectif | Notebooks |
 |----------|-----------|
-| Decouverte rapide | 01-1, 01-3 |
-| Generation avancee | 01-1 a 02-4 |
+| Découverte rapide | 01-1, 01-3 |
+| Génération avancée | 01-1 à 02-4 |
 | Production | Tous + 03 + 04 |
 
-## Recette : construire un generateur de contenu visuel educatif
+## Recette : construire un générateur de contenu visuel éducatif
 
-Le fil rouge de cette serie est la creation d'un systeme de visuels pedagogiques. Voici comment les niveaux s'articulent :
+Le fil rouge de cette série est la création d'un système de visuels pédagogiques. Voici comment les niveaux s'articulent :
 
-1. **01-Foundation** (generation de base) : [01-1](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) et [01-2](01-Foundation/01-2-GPT-5-Image-Generation.ipynb) couvrent la generation via API cloud. [01-4](01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb) et [01-5](01-Foundation/01-5-Qwen-Image-Edit.ipynb) introduisent les modeles locaux. A la fin, vous savez generer une image a partir d'un texte.
+1. **01-Foundation** (génération de base) : [01-1](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) et [01-2](01-Foundation/01-2-GPT-5-Image-Generation.ipynb) couvrent la génération via API cloud. [01-4](01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb) et [01-5](01-Foundation/01-5-Qwen-Image-Edit.ipynb) introduisent les modèles locaux. À la fin, vous savez générer une image à partir d'un texte.
 
-2. **02-Advanced** (edition et qualite) : [02-1](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb) permet d'editer une image existante pour corriger ou enrichir un visuel. [02-4](02-Advanced/02-4-Z-Image-Lumina2.ipynb) offre une generation rapide pour le prototypage. [02-2](02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb) pousse la qualite plus loin.
+2. **02-Advanced** (édition et qualité) : [02-1](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb) permet d'éditer une image existante pour corriger ou enrichir un visuel. [02-4](02-Advanced/02-4-Z-Image-Lumina2.ipynb) offre une génération rapide pour le prototypage. [02-2](02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb) pousse la qualité plus loin.
 
-3. **03-Orchestration** (comparaison et pipelines) : [03-1](03-Orchestration/03-1-Multi-Model-Comparison.ipynb) compare les modeles pour choisir le meilleur rapport qualite/cout. [03-2](03-Orchestration/03-2-Workflow-Orchestration.ipynb) assemble un pipeline de generation complet.
+3. **03-Orchestration** (comparaison et pipelines) : [03-1](03-Orchestration/03-1-Multi-Model-Comparison.ipynb) compare les modèles pour choisir le meilleur rapport qualité/coût. [03-2](03-Orchestration/03-2-Workflow-Orchestration.ipynb) assemble un pipeline de génération complet.
 
-4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Content-Generation.ipynb) applique le pipeline au contenu educatif. Les notebooks [examples/](examples/) montrent des cas d'usage par domaine (histoire, sciences, litterature).
+4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Content-Generation.ipynb) applique le pipeline au contenu éducatif. Les notebooks [examples/](examples/) montrent des cas d'usage par domaine (histoire, sciences, littérature).
 
 ## Cross-series Bridges
 
-| Serie | Lien | Connection |
+| Série | Lien | Connection |
 |-------|------|------------|
-| [Video](../Video/README.md) | Image-to-video | SVD (Video/02-4) anime une image existante ; le pipeline Video/03-2 enchaine generation d'images puis animation |
-| [Audio](../Audio/README.md) | Sync audio-video | Audio/04-4 synchronise la piste audio avec les visuels generes |
-| [Texte](../Texte/README.md) | Prompts structures | Les prompts DALL-E et GPT-5 Image beneficient des techniques de prompt engineering (Texte/2) et function calling (Texte/4) |
-| [SemanticKernel](../SemanticKernel/README.md) | Orchestration | Les pipelines d'orchestration (03-2) partagent les memes patterns que les agents Semantic Kernel |
+| [Video](../Video/README.md) | Image-to-video | SVD (Video/02-4) anime une image existante ; le pipeline Video/03-2 enchaîne génération d'images puis animation |
+| [Audio](../Audio/README.md) | Sync audio-video | Audio/04-4 synchronise la piste audio avec les visuels générés |
+| [Texte](../Texte/README.md) | Prompts structurés | Les prompts DALL-E et GPT-5 Image bénéficient des techniques de prompt engineering (Texte/2) et function calling (Texte/4) |
+| [SemanticKernel](../SemanticKernel/README.md) | Orchestration | Les pipelines d'orchestration (03-2) partagent les mêmes patterns que les agents Semantic Kernel |
 
 ## FAQ
 
 ### DALL-E 3 retourne des images floues ou hors-sujet
 
-DALL-E 3 (notebook [01-1](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb)) interprete les prompts librement et peut simplifier les details complexes. Mitigation :
+DALL-E 3 (notebook [01-1](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb)) interprète les prompts librement et peut simplifier les détails complexes. Mitigation :
 
-- Structurer le prompt : `style [photographiste/illustration/3D render], sujet [precis], contexte [arriere-plan], eclairage [type]`.
+- Structurer le prompt : `style [photographiste/illustration/3D render], sujet [précis], contexte [arrière-plan], éclairage [type]`.
 - Utiliser `size="1792x1024"` pour les compositions larges, `1024x1024` pour les portraits.
-- GPT-5 Image (notebook [01-2](01-Foundation/01-2-GPT-5-Image-Generation.ipynb)) offre un meilleur suivi des instructions detaillees que DALL-E 3.
-- Pour un controle total, passer en ComfyUI local (niveau 02+).
+- GPT-5 Image (notebook [01-2](01-Foundation/01-2-GPT-5-Image-Generation.ipynb)) offre un meilleur suivi des instructions détaillées que DALL-E 3.
+- Pour un contrôle total, passer en ComfyUI local (niveau 02+).
 
 ### ComfyUI retourne une erreur 401 ou 502
 
 Les services ComfyUI (ports 8188, 8001, 1111, 17861) tournent dans des conteneurs Docker avec authentification bearer token. Si erreur 401 ou 502 :
 
 ```bash
-# Verifier les conteneurs actifs
+# Vérifier les conteneurs actifs
 docker ps | grep comfyui
 
-# Redemarrer le service
+# Redémarrer le service
 cd docker-configurations/services/comfyui-qwen && docker-compose restart
 
-# Verifier le bearer token (drift bcrypt entre container et .env)
+# Vérifier le bearer token (drift bcrypt entre container et .env)
 cat MyIA.AI.Notebooks/GenAI/.env | grep COMFYUI_BEARER_TOKEN
 ```
 
@@ -194,17 +194,17 @@ Les notebooks ont une graceful degradation : sans token, ils basculent vers les 
 
 ### Qwen Image Edit ne modifie pas l'image correctement
 
-Le modele Qwen Image Edit (notebooks [01-5](01-Foundation/01-5-Qwen-Image-Edit.ipynb) et [02-1](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb)) est sensible au format du prompt d'edition. Points critiques :
+Le modèle Qwen Image Edit (notebooks [01-5](01-Foundation/01-5-Qwen-Image-Edit.ipynb) et [02-1](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb)) est sensible au format du prompt d'édition. Points critiques :
 
-- L'image source doit etre en PNG ou JPEG, resolution <= 1024x1024 pour des resultats optimaux.
-- Le prompt d'edition doit etre specifique : "remplacer le texte 'X' par 'Y'" plutot que "changer le texte".
-- L'architecture Qwen utilise un VAE 16 canaux (non standard SDXL), un scheduler `beta`, et CFG 1.0 — ces parametres sont pre-configures dans les notebooks, ne pas les modifier sans test.
+- L'image source doit être en PNG ou JPEG, résolution <= 1024x1024 pour des résultats optimaux.
+- Le prompt d'édition doit être spécifique : "remplacer le texte 'X' par 'Y'" plutôt que "changer le texte".
+- L'architecture Qwen utilise un VAE 16 canaux (non standard SDXL), un scheduler `beta`, et CFG 1.0 — ces paramètres sont pré-configurés dans les notebooks, ne pas les modifier sans test.
 
 ### GPU Out of Memory pendant un notebook ComfyUI
 
-Les modeles image sont gourmands en VRAM. Allocation typique :
+Les modèles image sont gourmands en VRAM. Allocation typique :
 
-| Modele | VRAM requise | Notebooks |
+| Modèle | VRAM requise | Notebooks |
 |--------|-------------|-----------|
 | Qwen Image Edit | ~29 GB | 01-5, 02-1 |
 | FLUX.1 | ~24 GB | 02-2 |
@@ -212,32 +212,32 @@ Les modeles image sont gourmands en VRAM. Allocation typique :
 | SD 3.5 | ~12 GB | 02-3 |
 | Z-Image/Lumina | ~10 GB | 02-4 |
 
-Strategies si OOM :
+Stratégies si OOM :
 
-- Utiliser les quantizations Nunchaku INT4 ou FP8 pour reduire la VRAM (notebook [03-3](03-Orchestration/03-3-Performance-Optimization.ipynb)).
-- Fermer les autres notebooks GPU avant une generation lourde.
-- Verifier avec `nvidia-smi` et liberer avec `torch.cuda.empty_cache()`.
+- Utiliser les quantizations Nunchaku INT4 ou FP8 pour réduire la VRAM (notebook [03-3](03-Orchestration/03-3-Performance-Optimization.ipynb)).
+- Fermer les autres notebooks GPU avant une génération lourde.
+- Vérifier avec `nvidia-smi` et libérer avec `torch.cuda.empty_cache()`.
 
-### Quelle difference entre DALL-E 3, GPT-5 Image et ComfyUI ?
+### Quelle différence entre DALL-E 3, GPT-5 Image et ComfyUI ?
 
-| Critere | DALL-E 3 | GPT-5 Image | ComfyUI (SD/FLUX/Qwen) |
+| Critère | DALL-E 3 | GPT-5 Image | ComfyUI (SD/FLUX/Qwen) |
 |---------|----------|-------------|------------------------|
-| **Cout** | $0.04-0.12/image | Variable (API) | Gratuit (local) |
-| **Controle** | Prompt seul | Prompt + instructions | Noeuds, masques, seeds |
-| **Edition** | Non | Oui (native) | Oui (inpainting, ControlNet) |
-| **Qualite** | Bonne | Excellente | Excellente (avec reglages) |
+| **Coût** | $0.04-0.12/image | Variable (API) | Gratuit (local) |
+| **Contrôle** | Prompt seul | Prompt + instructions | Nœuds, masques, seeds |
+| **Édition** | Non | Oui (native) | Oui (inpainting, ControlNet) |
+| **Qualité** | Bonne | Excellente | Excellente (avec réglages) |
 | **VRAM** | 0 (API) | 0 (API) | 10-29 GB |
 
-Pour du prototypage rapide, DALL-E 3 ou GPT-5 Image suffisent. Pour un controle fin, une production repetitive, ou des donnees sensibles, ComfyUI est indispensable.
+Pour du prototypage rapide, DALL-E 3 ou GPT-5 Image suffisent. Pour un contrôle fin, une production répétitive, ou des données sensibles, ComfyUI est indispensable.
 
-### Comment creer un workflow ComfyUI reproductible ?
+### Comment créer un workflow ComfyUI reproductible ?
 
-Un workflow ComfyUI est un graphe JSON de noeuds connectes. Pour le rendre reproductible :
+Un workflow ComfyUI est un graphe JSON de nœuds connectés. Pour le rendre reproductible :
 
 1. Exporter le workflow depuis l'interface ComfyUI (bouton "Save").
-2. Utiliser la meme seed (`noise_seed` dans le noeud KSampler) pour reproduire exactement la meme image.
-3. Verrouiller les versions de modeles (checkpoint, VAE, CLIP) — un modele mis a jour peut changer les resultats.
-4. Le notebook [03-2](03-Orchestration/03-2-Workflow-Orchestration.ipynb) montre comment charger un workflow JSON et l'executer programmatiquement via l'API ComfyUI.
+2. Utiliser la même seed (`noise_seed` dans le nœud KSampler) pour reproduire exactement la même image.
+3. Verrouiller les versions de modèles (checkpoint, VAE, CLIP) — un modèle mis à jour peut changer les résultats.
+4. Le notebook [03-2](03-Orchestration/03-2-Workflow-Orchestration.ipynb) montre comment charger un workflow JSON et l'exécuter programmatiquement via l'API ComfyUI.
 
 ## Licence
 


### PR DESCRIPTION
## Summary

Content-based restoration of French diacritics across the **Image series README** prose body, which was systematically unaccented — same genuine gap pattern as root/Video/Audio (fixed in #3082 / #3086). Markdown-only.

Follow-up to ai-01 dispatch (cycle :23): *"restant Image/Texte/FineTuning/SemanticKernel = content-based + review mot-à-mot (~96% FP sur certaines familles)"*. This README was confirmed a **genuine gap** (prose like « La generation dimages par IA est la deuxieme modalite generative »), not a false positive — the ~96% FP warning concerns the Python-family, not GenAI.

## Method — word-by-word, NOT blind find-replace

Accents restored on French prose only. Preserved byte-identical:
- All **37 `.ipynb` link paths** (verified identical before/after)
- Code/bash blocks, tree-structure diagram, `CATALOG-STATUS.json` reference
- Every English/technical term: DALL-E, FLUX, GPT-5, Qwen Image Edit, Real-ESRGAN, ComfyUI, SD XL, Z-Image/Lumina, Nunchaku INT4, FP8, LoRA, ControlNet, VAE, PIL/OpenCV, upscaler, post-processing, seeds, pipeline, from scratch, one-shot, etc.

## Verification (G.1)

- `git diff --stat`: 1 file, **76 ins / 76 del** (line-for-line, net 0 lines)
- Line count unchanged: 244 == 244
- `grep -oE "].*\.ipynb\)"` count: **37 == 37** (no link touched)
- Typo `modeaux` → `modèles` fixed (line 66, same as Video/Audio)
- Spot-check: **0** remaining unaccented common FR words; **0** English terms accidentally accented

No CATALOG-STATUS marker block in this file (unlike Video), so nothing to preserve beyond links/code.

See #2876 (partial — Texte/FineTuning/SemanticKernel remain).

