### PR TITLE
feat(genai-texte): NB-16 scaling test-time compute / Snell 2024 (See #2926, Phase 4)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
@@ -1,0 +1,959 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "eee91f89",
+   "metadata": {
+    "papermill": {
+     "duration": 0.036608,
+     "end_time": "2026-06-15T21:24:50.447382",
+     "exception": false,
+     "start_time": "2026-06-15T21:24:50.410774",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 16. Scaling du test-time compute (Snell 2024)\n",
+    "\n",
+    "**Phase 4 de l'epic #2926** — suite de **NB-12** (moteurs), **NB-13** (routeur), **NB-14**\n",
+    "(memoire), **NB-15** (ToT sur CSP).\n",
+    "\n",
+    "## L'idee de Snell et al. 2024\n",
+    "\n",
+    "> *\"Scaling LLM Test-Time Compute Optimally can be more effective than scaling model\n",
+    "> parameters.\"* — Snell, Lee, Xu, Kumar (DeepMind, 2024).\n",
+    "\n",
+    "Le **test-time compute** (combien de calcul on depense a l'inference : plus d'echantillons,\n",
+    "plus de recherche, plus de tours de Reflexion) se met a l'echelle **comme le compute\n",
+    "d'entrainement**. Mais la strategie **optimale** depend du **regime** :\n",
+    "\n",
+    "- Sur des problemes **faciles (pour le modele)** : **echantillonner large en parallele**\n",
+    "  (Best-of-N) est le plus efficace — un seul essai rate rarement.\n",
+    "- Sur des problemes **difficiles** : la **recherche sequentielle** (affiner via le retour\n",
+    "  d'un verificateur, facon Reflexion) est plus compute-efficace qu'echantillonner a l'aveugle.\n",
+    "\n",
+    "Il existe donc une **frontiere compute-optimale** : pour un budget donne, quelle strategie\n",
+    "maximise le taux de succes depend de la difficulte.\n",
+    "\n",
+    "## Plan (ce notebook mesure tout sur de vraies donnees)\n",
+    "1. **Suite graduee** de problemes a **reponse entiere verifiable** (facile / moyen / difficile).\n",
+    "2. **Scaling BoN** : pass@k (estimateur non-biasé HumanEval) pour k = 1, 2, 4, 6, par bucket.\n",
+    "3. **Compute-optimal** : a budget egal, **BoN (parallele)** vs **Reflexion (sequentiel)**.\n",
+    "4. **Limites honnetes** (G.2) : petit N, petit modele, bruit — les lois de Snell sont\n",
+    "   asymptotiques ; ce notebook est **illustratif**, pas une replication a l'echelle.\n",
+    "\n",
+    "> Pont Phase 5 : comparer a un **modele a raisonnement natif** (le raisonnement est alors\n",
+    "> \"interne\" au modele, compute decale dans les tokens de pensée)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60591a16",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013008,
+     "end_time": "2026-06-15T21:24:50.477951",
+     "exception": false,
+     "start_time": "2026-06-15T21:24:50.464943",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 0. Setup — meme infrastructure que NB-12 a NB-15"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "556b8f60",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:24:50.500623Z",
+     "iopub.status.busy": "2026-06-15T21:24:50.500294Z",
+     "iopub.status.idle": "2026-06-15T21:24:55.475558Z",
+     "shell.execute_reply": "2026-06-15T21:24:55.469575Z"
+    },
+    "papermill": {
+     "duration": 4.986923,
+     "end_time": "2026-06-15T21:24:55.477440",
+     "exception": false,
+     "start_time": "2026-06-15T21:24:50.490517",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".env charge depuis : D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FAST_MODEL=meta-llama/llama-3.3-70b-instruct | BATCH_MODE=False\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -q openai python-dotenv matplotlib numpy\n",
+    "\n",
+    "import os, re, math, time\n",
+    "from pathlib import Path\n",
+    "from functools import lru_cache\n",
+    "from openai import OpenAI\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "_env_path = None\n",
+    "_current = Path.cwd()\n",
+    "for _i in range(10):\n",
+    "    if (_current / \".env\").exists():\n",
+    "        _env_path = _current / \".env\"; break\n",
+    "    if _current.name in (\"GenAI\", \"MyIA.AI.Notebooks\"):\n",
+    "        break\n",
+    "    _current = _current.parent\n",
+    "if _env_path is None:\n",
+    "    for _cand in (Path.cwd() / \"MyIA.AI.Notebooks\" / \"GenAI\" / \".env\",\n",
+    "                  Path.cwd() / \"GenAI\" / \".env\"):\n",
+    "        if _cand.exists():\n",
+    "            _env_path = _cand; break\n",
+    "if _env_path is not None:\n",
+    "    load_dotenv(_env_path); print(f\".env charge depuis : {_env_path}\")\n",
+    "\n",
+    "FAST_MODEL = os.getenv(\"OPENAI_MODEL_FAST\", \"meta-llama/llama-3.3-70b-instruct\")\n",
+    "BIG_MODEL = os.getenv(\"OPENAI_MODEL_BIG\", \"openai/gpt-5-nano\")\n",
+    "BATCH_MODE = os.getenv(\"BATCH_MODE\", \"true\").lower() in (\"1\", \"true\", \"yes\")\n",
+    "client = OpenAI(api_key=os.getenv(\"OPENROUTER_API_KEY\"),\n",
+    "                base_url=os.getenv(\"OPENROUTER_BASE_URL\", \"https://openrouter.ai/api/v1\"))\n",
+    "print(f\"FAST_MODEL={FAST_MODEL} | BATCH_MODE={BATCH_MODE}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "97bcb2cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:24:55.490960Z",
+     "iopub.status.busy": "2026-06-15T21:24:55.490705Z",
+     "iopub.status.idle": "2026-06-15T21:24:57.776981Z",
+     "shell.execute_reply": "2026-06-15T21:24:57.771930Z"
+    },
+    "papermill": {
+     "duration": 2.295377,
+     "end_time": "2026-06-15T21:24:57.777940",
+     "exception": false,
+     "start_time": "2026-06-15T21:24:55.482563",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ping : 'OK'\n"
+     ]
+    }
+   ],
+   "source": [
+    "def chat(prompt, system=None, model=FAST_MODEL, temperature=0.7, max_tokens=400, retries=2):\n",
+    "    \"\"\"Chat avec retry leger (OpenRouter peut etre transient). Renvoie '' si echec total.\"\"\"\n",
+    "    messages = ([{\"role\": \"system\", \"content\": system}] if system else []) \\\n",
+    "               + [{\"role\": \"user\", \"content\": prompt}]\n",
+    "    for essai in range(retries + 1):\n",
+    "        try:\n",
+    "            resp = client.chat.completions.create(model=model, messages=messages,\n",
+    "                                                  temperature=temperature, max_tokens=max_tokens)\n",
+    "            txt = resp.choices[0].message.content or \"\"\n",
+    "            if txt.strip():\n",
+    "                return txt\n",
+    "        except Exception as exc:\n",
+    "            if essai == retries:\n",
+    "                print(f\"  [chat] echec apres {retries+1} essais : {exc}\")\n",
+    "            else:\n",
+    "                time.sleep(1.0)\n",
+    "    return \"\"\n",
+    "\n",
+    "_ping = chat(\"Reponds uniquement par : OK\", max_tokens=10, temperature=0.0)\n",
+    "print(\"Ping :\", repr(_ping[:40]) if _ping else \"ECHEC\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e71d685",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006012,
+     "end_time": "2026-06-15T21:24:57.789933",
+     "exception": false,
+     "start_time": "2026-06-15T21:24:57.783921",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Suite graduee + verificateur + estimateur pass@k\n",
+    "\n",
+    "On travaille sur des problemes a **reponse entiere verifiable** (pas de juge LLM : le\n",
+    "verificateur est exact, ce qui rend pass@k objectif). Trois buckets de difficulte.\n",
+    "\n",
+    "**Estimateur pass@k non-biasé (HumanEval / Snell)** : a partir de n echantillons dont c sont\n",
+    "corrects, `pass@k = 1 - C(n-c, k) / C(n, k)`. C'est l'estimateur standard (Chen et al. 2021)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d402fcb1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:24:57.804563Z",
+     "iopub.status.busy": "2026-06-15T21:24:57.804230Z",
+     "iopub.status.idle": "2026-06-15T21:24:57.814332Z",
+     "shell.execute_reply": "2026-06-15T21:24:57.812826Z"
+    },
+    "papermill": {
+     "duration": 0.019739,
+     "end_time": "2026-06-15T21:24:57.815672",
+     "exception": false,
+     "start_time": "2026-06-15T21:24:57.795933",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pass@k (n=6, c=4): {1: 0.667, 2: 0.933, 4: 1.0, 6: 1.0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Suite graduee : (enonce, reponse_entiere_attendue). Reponses verifiees a la main.\n",
+    "PROBLEMES = {\n",
+    "    \"facile\": [\n",
+    "        (\"Combien font 7 + 8 ? Reponds uniquement par le nombre.\", 15),\n",
+    "        (\"Combien font 12 x 11 ? Reponds uniquement par le nombre.\", 132),\n",
+    "    ],\n",
+    "    \"moyen\": [\n",
+    "        (\"Un train part avec 45 passagers. 12 montent au suivant, 7 descendent. \"\n",
+    "         \"Combien reste-t-il de passagers ? Reponds uniquement par le nombre.\", 50),\n",
+    "        (\"Si 3 pommes coutent 1,50 EUR, combien coutent 12 pommes (en EUR entier) ? \"\n",
+    "         \"Reponds uniquement par le nombre.\", 6),\n",
+    "    ],\n",
+    "    \"difficile\": [\n",
+    "        (\"Un capital de 1000 EUR augmente de 10% puis diminue de 10%. \"\n",
+    "         \"Quelle est la valeur finale en EUR ? Reponds uniquement par le nombre.\", 990),\n",
+    "        (\"Combien de nombres entre 1 et 20 (inclus) sont divisibles par 3 OU par 5 ? \"\n",
+    "         \"Reponds uniquement par le nombre.\", 9),\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "def extraire_nombre(texte):\n",
+    "    \"\"\"Extrait le 1er nombre entier (gere '990', '990 EUR', '= 990', '-50').\"\"\"\n",
+    "    m = re.findall(r'-?\\d+', texte or \"\")\n",
+    "    return int(m[0]) if m else None\n",
+    "\n",
+    "def est_correct(reponse_attendue):\n",
+    "    \"\"\"Renvoie un verificateur (texte -> bool) pour une reponse entiere attendue.\"\"\"\n",
+    "    def _verif(texte):\n",
+    "        n = extraire_nombre(texte)\n",
+    "        return n is not None and n == reponse_attendue\n",
+    "    return _verif\n",
+    "\n",
+    "def pass_at_k(n, c, k):\n",
+    "    \"\"\"Estimateur non-biasé pass@k (HumanEval). n=total, c=corrects, k budget.\"\"\"\n",
+    "    if n - c < k:\n",
+    "        return 1.0\n",
+    "    return 1.0 - math.comb(n - c, k) / math.comb(n, k)\n",
+    "\n",
+    "# Auto-verif rapide de l'estimateur : 4 corrects sur 6 echantillons.\n",
+    "print(\"pass@k (n=6, c=4):\", {k: round(pass_at_k(6, 4, k), 3) for k in (1, 2, 4, 6)})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ef441ab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005998,
+     "end_time": "2026-06-15T21:24:57.828679",
+     "exception": false,
+     "start_time": "2026-06-15T21:24:57.822681",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Scaling BoN — pass@k par bucket\n",
+    "\n",
+    "Pour chaque probleme, on genere **n** echantillons independants (temperature > 0), on compte\n",
+    "les corrects, puis on estime pass@k. On agregre par bucket (taux moyen). Petit n (BATCH_MODE)\n",
+    "pour garder l'execution rapide et dans le budget API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "81c9ccc3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:24:57.842985Z",
+     "iopub.status.busy": "2026-06-15T21:24:57.842433Z",
+     "iopub.status.idle": "2026-06-15T21:25:34.430285Z",
+     "shell.execute_reply": "2026-06-15T21:25:34.429326Z"
+    },
+    "papermill": {
+     "duration": 36.600451,
+     "end_time": "2026-06-15T21:25:34.435136",
+     "exception": false,
+     "start_time": "2026-06-15T21:24:57.834685",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BoN : 12 echantillons / probleme, K=[1, 2, 4, 6] (FAST_MODEL=meta-llama/llama-3.3-70b-instruct)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket facile    : collecte OK\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket moyen     : collecte OK\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket difficile : collecte OK\n",
+      "\n",
+      "=== pass@k moyen par bucket (estimateur non-biasé) ===\n",
+      "bucket      | pass@1 | pass@2 | pass@4 | pass@6\n",
+      "-----------------------------------------------\n",
+      "facile      |   1.00  |   1.00  |   1.00  |   1.00 \n",
+      "moyen       |   1.00  |   1.00  |   1.00  |   1.00 \n",
+      "difficile   |   0.38  |   0.54  |   0.67  |   0.75 \n"
+     ]
+    }
+   ],
+   "source": [
+    "N_ECHANTILLONS = 6 if BATCH_MODE else 12      # echantillons par probleme\n",
+    "K_LIST = [1, 2, 4, 6]\n",
+    "\n",
+    "def echantillonner_bon(enonce, n, model=FAST_MODEL):\n",
+    "    \"\"\"Genere n echantillons independants pour un enonce. Renvoie la liste des reponses.\"\"\"\n",
+    "    return [chat(enonce, model=model, temperature=0.8, max_tokens=80) for _ in range(n)]\n",
+    "\n",
+    "# Collecte par bucket : {bucket: {k: [pass@k par probleme]}}\n",
+    "resultats = {b: {k: [] for k in K_LIST} for b in PROBLEMES}\n",
+    "print(f\"BoN : {N_ECHANTILLONS} echantillons / probleme, K={K_LIST} (FAST_MODEL={FAST_MODEL})\")\n",
+    "for bucket, probs in PROBLEMES.items():\n",
+    "    for enonce, attendu in probs:\n",
+    "        reps = echantillonner_bon(enonce, N_ECHANTILLONS)\n",
+    "        verif = est_correct(attendu)\n",
+    "        corrects = sum(1 for r in reps if verif(r))\n",
+    "        for k in K_LIST:\n",
+    "            resultats[bucket][k].append(pass_at_k(N_ECHANTILLONS, corrects, k))\n",
+    "    print(f\"  bucket {bucket:9s} : collecte OK\")\n",
+    "\n",
+    "# Tableau : pass@k moyen par bucket\n",
+    "print(\"\\n=== pass@k moyen par bucket (estimateur non-biasé) ===\")\n",
+    "header = \"bucket      | \" + \" | \".join(f\"pass@{k}\" for k in K_LIST)\n",
+    "print(header); print(\"-\" * len(header))\n",
+    "agg = {b: {k: (sum(v)/len(v) if v else 0.0) for k, v in d.items()} for b, d in resultats.items()}\n",
+    "for b in PROBLEMES:\n",
+    "    print(f\"{b:11s} | \" + \" | \".join(f\"  {agg[b][k]:.2f} \" for k in K_LIST))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "58d9200a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:25:34.449358Z",
+     "iopub.status.busy": "2026-06-15T21:25:34.448939Z",
+     "iopub.status.idle": "2026-06-15T21:25:35.738389Z",
+     "shell.execute_reply": "2026-06-15T21:25:35.737127Z"
+    },
+    "papermill": {
+     "duration": 1.299134,
+     "end_time": "2026-06-15T21:25:35.739874",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:34.440740",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAssAAAHOCAYAAABuLUT1AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAQ6wAAEOsBUJTofAAAgE9JREFUeJzt3Qd4U2UXB/DT3dJCacsqe5aNAgqCA5CNCIhsRUBBEEEFRRBE9voUXIjgAERAAQUHgkxxMUQQBWTLplBoyyzd+Z7/CzckadIm7U2TNv/f80Tpvcm9N3ckJ+8973m9DAaDQYiIiIiIKAPvjJOIiIiIiAgYLBMRERER2cBgmYiIiIjIBgbLREREREQ2MFgmIiIiIrKBwTIRERERkQ0MlomIiIiIbGCwTERERERkA4NlIiIiIiIbGCwTEREREdnAYJmIiIiIyAYGy0RERERENjBYJiIiIiKygcEyEREREZENDJaJiIiIiGxgsExEREREZAODZSIiIiIiGxgsE4nIli1bxMvLSxYuXGicduLECTVt/Pjxkpe2m+5o2rSplC9f3tWbQS709NNPS82aNSU9PV3c2a+//qqu5W3btkl+ZO3z1NZnLI4VplWsWFF8fX3VczQ//fST3HfffVKwYEHjZ19ufg5iu7AubDt5DgbL5BZiYmJk1KhRUrt2bSlUqJD6IMQH5WOPPSaffvqpqzfPI73zzju5GoRnd3348vrmm2+csk3kHAg0cNz27Nnj1PXs2rVLnVOTJk0Sb+87X3d9+/ZVAY/pA5851apVk1deeUXOnTuXo/XiBxqWWbduXatB+uTJk9V8BHmaBx98UFq3bi0vvfSSGAwG8WSfffaZTJgwQZo1a6Y+/z///HM1PT4+Xjp37iw3btyQmTNnqukPPfSQqzdXncc4nxlA51++rt4AolOnTkmDBg3k0qVL0qVLFxkwYID4+/vLf//9J7/99psKop555plc365y5crJzZs3VcuGJ8J+x5c+Agt3Xh++VPv06SOdOnXKMG/9+vUeH3i4IwQVOG443nfffbfT1oN1VKhQQf3otua9996TsLAw9e/Lly/L5s2bVRC2YsUK2bdvnwqgcxpELV68WJ566im7nv/yyy9Lq1at5IcffpD27dtLfmfrM3bDhg0SGhoqn3zyiVmr8s6dO9VxQgCNoFmD8wjL8fPzE1fAcca5xjtZ+ZdnRgHkVt588025cOGCCpZefPHFDPPPnz/vku3Ch3RgYKBL1k36wI8u8tyAHEHnuHHjzAIuUwiiS5cubfx7yJAhKghbtWqVbNq0yeoPMHuVLFlS/f/111+Xbt262fVZ0rx5c7U9c+bMcctgGT880aobEhLi1M9YfOYXLlw4w3HTvgvCw8PNpuOuAT+ryZmYhkEud+TIEeMXhTUlSpTIMO348eOqBRotEwEBAVK8eHHVIoMWCc3Bgwfl+eefl1q1aqlWiqCgIJXm8dZbb0laWlqOc+zWrl2rcuew3KJFi8rAgQPVF4mlw4cPS8eOHVV6CR5t2rRRrVaOtkKgFaxq1arq/aK1DLeWU1NTHcqps2ed2ns8efKk/Pzzz2a3qk2XeezYMdUKjKAAQSm+5AcPHqzuEJjCrdMRI0ZIlSpV1L5CSx6OA243O7I+S1qeonbb1vR1mb1fbdrp06ela9euantwXB5//HGVDgTz589X5w2+gJEOtGDBAqvb8Ndff6m7IcWKFVP7AM9FOlFCQoLYy55zWTufe/TooebjeVgXUgauXr1q9jykHWAfINibOnWqeh7ex1133aXOWfj3339VMIbrAkEJjuP169etnkd47vDhw6VUqVLG5Xz55ZcZ3geea+2ugGU+KZaL2+vQr18/4zHDcTH19ddfS5MmTdSxwXmDlAa0NNrrq6++UikQjzzyiGQnyLX8oZWYmKhaD5Gqgf2AgO3RRx+VP//80+pysM0TJ05U59m7775r17oR9OHzYd26daoFNSum+/bDDz+U6tWrq23D+Y39bPn54MhnonYebdy4UaZNmyZRUVHqvMNzs/LFF1+o8wTbgvMG54+1a8LyM1ZbJ/KS8XmgnRta2gzuIAHOH9Nr3VbOMoJ7TLv//vvVeVSgQAF1/F544QVJTk7O9LX25idj23AeW26X6bWA7fj444/VHdTg4GD1aNy4MdPH8hC2LJPLVapUSf0fAcmMGTOyTHvYvXu3Cqzx4YsPJNzGvXbtmmzfvl19sLds2dL4IYgPXQQFCC7xZbdmzRoVuCHFA6032YWgY/bs2SpAxjYgMPnoo4/Uh+TcuXONz8MHPj4UEYgMGjRIBbu4lYggwLJ1JDMIwLBv6tevrwKgpKQkdSvy22+/Fb0h8Ecu4LBhw6RIkSIyZswYs3nabUcEN/jyQQcqBHr40YMvbOyLP/74Q30ZA1rVcByeffZZdazwJYVAG8fK3vVZg8AAr+vdu7fK98Ty7YUfNTgG+BLF/jxw4IB88MEHquUKrY34NwJY3IbHlxzeI44djqXmxx9/VC2PZcqUkaFDh6og9u+//5ZZs2bJ77//rt6zXucy9jdyMxH84AcJAmCkKCFlAPsb68OxMPXaa6+p8+S5554THx8fFbDhRxuCSKQ14bgg2EOHMvzYQCA0b968DNuIFAJ82SPgwfIQVPTs2VOd0/379xdHoeU2JSVF7XccMxw7wP7ToDUYgSaCD/wbQR0CSByTo0ePyvTp07NcD/Y/XoegzRb8kNNaJK9cuaI+M/A5VKNGDbMf7wgk27Vrp5aJ/6MFGucKzvcHHnhAfR5oPwBM4Zi+/fbbKtjEvoqIiMhyu3GO4UfBL7/8Ih06dBB74LPozJkz6jMGnyv4XEBgj+tMy/fN7mci5uH8RKCK6xHne2bw+YdzDj+O33jjDfWjY8mSJer9ZAXnOLZ3ypQp6kc39p32HdGiRQvVCRKfs6NHj1bXf1aw/xctWqR+aOF94Ect9snKlSvV+aXHnSd8B+Dasdwu7XsNEExjO3D9PfHEE2oatgGfNTiHcNzIzRmIXOzYsWOG0NBQJJYaihUrZnj88ccNM2bMMPz222+GtLQ0s+emp6cbatWqZfD19TXs2LEjw7JMn3/9+nWr6+vVq5fBx8fHEB0dbZz2008/qfUvWLDAOO348eNq2rhx4zJMCwoKUtttqnXr1gY/Pz+z9WJdeP4PP/xg9txZs2ap6eXKlcty/xw5csTg7e1taNCggSExMdE4PTY21hAZGZlhu7G9mIZttdSkSRO71gl4Hp5vzd13322oUKGC2gZTOCbYt+PHj1d/X758WW3LoEGDcrS+zGD5ffr0sTrP2vvFNLxm2rRpZtNffPFFNb1UqVJquzXnz583BAQEGHr27GmcdvPmTUOJEiUyHBP46quv1HIWLlyY6XY7ci4/+OCDBi8vL3VNmJowYYJa16RJk4zTcC5g2l133WW2bX/99ZeajuUsW7bMbDkdO3ZU5+61a9cynEf169c3Ww72TdmyZQ0FCxY0XLlyJcvjYO3asjZNs3v3brWNL7zwQoZ5Q4YMUdeC5bVnDY57tWrVrM7DdmL91h6PPPKIIS4uzuz5n376qZo3YMAAs+mHDh1S50aVKlXMjhfWXalSJfVvXPt4Lc4vDY4XpmE/WPr111/VvMmTJ2f5HrX9WKBAAcOJEyeM07EtnTp1yrAORz4TtfMI78P0vMgMzo2QkBB1fpheQwkJCeozw9bnqem0zD6ntG2y3G/WzqcVK1aoaZ07dzakpKRkuPbwsPXazD5LrU2ztV3wzTffqHn4zLf06KOPGgoVKmS4evVqhnnkXpiGQS6HVjK0yOHWGG5P4fbryJEjVYtN5cqVVSctDZ6HFAb8OsctLUumPd6xLA1axOLi4lRrBW5zoqXI1u1Te6BFANttCq2AaDHDbXXALeDvvvtO3fJEa5QptA7a23kI+ZNYFm65owVDgxYk3FLNbdj/aOlESgC2C/tUe2Cf4JihFRDQsoeWux07dqiWK3eB80RLA9GgpRnQgqa1imstnmhVRjqNBq2+aFlEyxVagk33AVrH0Mqr7QNb7D2XL168qFrUcH6hJdwUzgntmrGEc8P0fEGrNW5FR0ZGqlZly/eOc9fa7WZ0OjNdDvYNlo33bZkqoge0QiL2Ruu36X7FAy2tOOe0uxKZwX7LqiUX6QJ4D3igpQ93cND6ihZAvD+Ntn/RWmsKqQm9evVSd1X27t1rdR249tHqjBZEe64BbZu1lCB7PPnkk+rujum5gzsLptue3c9EtKLbm6OMz2rcccBrTK8hfA7gXM1N6FgJuPtieYfHMl3LmdBSjvffvXv3DOcz7kwhjSq/lgvMT5iGQW4BH/S4TYwHviTw4bF8+XL1ZYbAFIEFgjAtYKlXr16Wy8StQ+T1Ir/SWhCAL4rssgyUTb/kYmNj1f/xPvDFgRw5S1rOqT15ibhtCLg1bAn1Y3MbUhYAt5bxyGz/4DYncq2RpoDbkggucNsdAQQCEqQHZAX70DKfVsu3zC7kpVp2CNKqIlg7tpiHlBrLfYAfPXhYg06rmbH3XNYCLOSWWkJQjv2qnSOmbL0Pa7fRtfeunbumrJ132jSkROhN27eZpU9ktW81WVVCwQ9y0w5++KzBj1sEn+h4jFv12jHA9Y0fGpa044JjYGubsax7771XBbDLli2za5sdCebsPUbZ+UzENWsvd/qswvWF89rV1SlwPqNSB3K3c3o+k+swWCa3g7wyBFJ4lC1bVuUn4sMdvcodgRY75O4hVxCtfciHRQsDaq+iBSkngxRkFuS5ulRZZl+y1joEOkrbbwiAbeVUmgayyDPF85DXibxFtAoi3xqtqejQl1UvdnQosmzRQ15pTkraZXb8bM0zPa7aPkBupbVWYdMA1FVsvY/cPncdPee0fbt69WqzFu2sfghYQn6tteA/K9pdILSSasFyTqGvAfK8ly5dqlrqM6NtMz4H9Zadz0TLXPj8Jjc+L/HjHn0FbHFFowc5hsEyuTWtQ9XZs2fNWjlQhSAz6KyDLwW0EKHjhbXqG86GLzvcvkQPdEvo5IbWKns6+WkdRVCVwPJDdf/+/Rmery0TrUSWrSpYp72dWmx9iZi2NKHTjT2QyoDgFg8EZOgIo/0I0oJeW+tDBzO0ALrTl4u2DxDo27sPbC0jq3NZCwytHWu0WOGY4q6Ls+C8s2wxxTQwXS/OO2stk9ZSDzILULBf0HkSrbj23EGyBS3E6PyI9BJH6u/i+WBaZQTXIK5jtACadkQEpNJoz8kMflghJQLpCKh2Yov2+WTtToIt2vHI7Bjlxmei6WeVZRUSa+evM+E8Qqsu7giZpqhk9nlpyd7UsazOZ5w76GRoTwdPck/MWSaXQ46grVJbyNc1va2HL218CSIfzVp+ndYyouV7WraUIQ8R1QpyA7YB1QbwZYoe56ZQbcE0JzIzyGvDhzFaWJFnqMGHO5ZjCfm1YJnXiX0WHR1t9/Yj0Lf2BYLcV3yRo3VYu2VuCvsc+aKA42p5bPFetCDItOXP1voQLCIgNX2Y3g639TpnwkhrCJpwe91aHXC0SGW1Tfaey2ghReoKcqBRZcQU8jGRooKyd86CdZiedwi6cN5hv2vVOrTzDulTpscb1Rbef//9DMvUcmCt7SNUNwGkLGiBqyms33R7bEG1FqwfFUccobUAojVYow2AgRQGU0hxQGsxKj/UqVMn0+XihytyeZF/jr4MtmAf4rPDkZHpcA6Zpgnh3NFSpLRtz43PRPwIQF40qnPgOGlwHOwpOacn/CgA/DixVipU2w+oCoIfU5afl/gBoX3/ZCWz81kbkObVV1+1eueGKRh5A1uWyeUwGIlWzghfULh9jc4PGFAAt+kRUKB0F2j1MB9++GHV2QnTEXSgFBjKbSGwQok1dJ5DpxV0FsKt3IYNG6pAEQGeZcuQM6E1CUEOvrBQHgj5ywh40MKDFh97bvPhixi3bvFlg/eM27lomUZ5KeTeWgbACCbx42Ls2LEqbxqvRzCGL2is01oAYg1qSGN/YTkoh6QF//gyxJczjgGCXrQMI3jWOoihdig6yaFGKfIG8aWPgB+twQj80FqD8lI4RqajcGW2vqy2E190OO5I28E5gs6HzoRb0+i4g1QhbCtKQ+HYIvDQSlOh5TyzVBF7z2VA3jf2I56Lslxa6TgEangNyro5+w4POrLhvEMKDEbdxDFEh0ENOuji3ESQigABQTzKZZl29NLg/MTxR6ky7EvUesadGLy/e+65Rw0HjbQrXPtYJvKKcS6jEx2uHbRcZpWLivrX6CiMdA5c/9YgGNLSZXDsUNYRxxXTcB5q8H5wzuNHAt47fixppeMQAKHknj05xiiLiBreWI81CHKRroTlW9tvtuAcxHvEuYGWUlyDGI0Q14FW0i43PhOxzThn8aMAOdq4LnAnC/vOnv4JesLxR9oJ3i9SpfBZg3MMHbAxQiOOAc47BLq49nAM0QkP56B2fuMHkOUPVGvwXvF5hc97lCPEZxaCcOxj/JBFKhpKUKLvDT4LMXYAhlRH+gsaUuz9TCYXcnU5DqLt27cbRowYocpwFS9eXJXSQlkqlKyaOHGi1bI6KKeG8k8onYaSV3gdSrdt3LjR+ByUNRs4cKAqBYbyTlWrVjX873//U8+xp5RVZqXjLEsdZVY+6MCBA4b27durkkp4YDv37t1rqFevnqF69ep27SOUOXr77bcNlStXVu+3fPnyat9s2LDBatmjo0ePGtq1a2cIDg5W+xL/xnY4UjruwoULquxSWFiYKuVlWS7p9OnThueff95QsWJFg7+/v6Fw4cKG2rVrqxJZ+/fvV8+5dOmSYdiwYYa6deuq5eA4YP19+/ZV2+PI+mw5fPiwoWXLlup9auW/siodZ20fZFZCytZr8B5wHpYuXVodlyJFiqjz9rXXXjOcOnXKYA97zmX4999/Dd26dVPrwPOwPcOHDzcr0ZVVGStb5fmsvUYrkYVjiWOI7cNxxjFesmSJ1feCcxQlBbF9KDn25ptvGjZt2mR1v6KkGs4LnBOYb7ldP/74ozpvIyIi1PJKlixpaNasmWHmzJmqdJ89UJoLZcy0MmGZlY7D5w6e+/TTTxv++++/DMvCOrFPoqKijOc7rus//vgjw3NNS8dZwvZr67Q8RuvXr1fTv//+e7ven+k5+8EHH6jPOGxbmTJlDGPHjjUkJyebPd+Rz8TMzqOsLF68WJ0n2BacNzh/cB7lZuk4wHGfN2+e4d5771Xl9fB5iHKCL730kiEpKcmspB7KW+LaCgwMNNxzzz3qGNhbOg5QKhKf5zhXrZVRXLp0qaFp06aqTKp2jNq2bWv48MMPHd6/lPu88B9XButEnggtyuhc06hRI+OoakTuBHcG0LESLXGuriiQXWi5Q6sfKlBgtEZ3h5Zf3MpHqUV7WqqRwoaW45x2eCWizDFnmcjJrOVjI48TOX243UpEzoG0LgSRGAUwJ9VvcgNymZGyhfKZuVUDmIjsw5xlIidDXi+qOSC3FF/YyDVFJyLkGSKXjYicBznCeQE6cfJGL5F7YrBM5GToWILOdRhkBb3CUZwenaHeeOONLDuvERERkWsxZ5mIiIiIyAbmLBMRERER2cBgmYiIiIjIBgbLREREREQ2sINfFtAhC6NGYeQxX1/uLiIiIqK8NK7BxYsX1UizgYGB2VoGo78sIFDGUJlERERElDdh6HIMUpQdDJazgBZlbSdHRkY6fX1paWkSGxsrERER4uPj4/T1kXPwOBK5D16PRJ57LUZHR6tGTy2eyw4Gy1nQUi8QKJcuXTpXTqSAgAB1UPmhnnfxOBK5D16PRO4hzYXXYk5SadnBj4iIiIjIBgbLREREREQ2MFgmIiIiIrKBwTIRERERkQ0MlomIiIiIbGCwTERERERkA4NlIiIiIiIbGCwTEREREdnAYJmIiIiIyAYGy0RERERENjBYJiIiIiKygcEyEREREZENDJaJiIiIiGxgsExEREREZAODZSIiIiIiGxgsExERERHZ4Ctu7ujRo/LWW2/J9u3bZd++fVKtWjX1/6wYDAaZMWOGzJkzRy5evCh33323vP3223LfffeJO0pPT5ev9+2SL/48IFduJEtosL/0vKe6PF6rvnh78zdNXsHjSOQ+eD0SuYf0PH4tehkQVbqxb7/9VoYMGSINGzaUw4cPqx1uT7A8ffp0GTdunPp/nTp15IMPPpCNGzfKnj17pGLFinav/8yZM1KmTBk5ffq0lC5dWpxh/eF98tKy3ZJwIwJh/u2Hl3oUCI6Vd7rXk1ZRtZyybtIPjyOR++D1SOQe1rv4WtQjjnP7YBnBsfaro2/fvvLnn39mGSwnJiZK8eLF5fnnn5epU6eqacnJyRIVFSXt2rVTrc3uEizjJBq48JAY0v1tZMWki5d3sszrW5Uf7G6Mx5HIffB6JHIP693gWtQjjnP7tu/sNM9v3bpVrl69Kt26dTNO8/f3l86dO8uaNWvEnX4I4NeW7ZMIvNV8PA/PJ/fD40jkPng9ErmH9Hx0Lbp9znJ2HDx4UP0f+c2mqlevLqdOnZKbN29KUFCQuBryd27dlsiKt3reF3/tkI616ubClpEjVu37i8eRyE3weiTKm9fiqn275fE694g7ypfBcnx8vAQEBEhgYKDZ9LCwMNXxD/NtBctokcZDEx0drf6flpamHnpCortI+O3cnayNWREnY1Zs0nUbKPfxOBK5D16PRO7AIEt3/Sudaur/w1WP2C1fBss5MWvWLJkwYUKG6bGxsSoA1xN6hN5JdCciIiLyRAa5fD1ZVS/TG+K3nMqXwTJakJOSklRHP9PWZbQoe3l5qfm2DB8+XPr372/WstygQQOJiIiQokWL6rqdKJ3CQJmIiIg8m5cUDvHXPc4CxIM5lS+DZS1X+dChQ3LXXXeZ5TKXLVs203zlQoUKqYclHx8f9dATagzuPhxj9/OndA1nbp2b5mWNXRFn9/N5HImch9cjUV68Fr2kV/0ausdZoMcy82Ww3LhxYxXwrlixwhgsp6SkyMqVK1XpOHeBYtzjghdLwg20dGdW9SNdCgTHS8+6bfNE8W5P80TdhjJtDY8jkTvg9UiUN6/Fx2q1FXfl9p8QCQkJ8tVXX6nHyZMnVec77W8tt6V58+ZSuXJl42uQevHaa6+pkf/effdd2bx5s/Ts2VPlrbzyyiviLvABjWLcqDGIk8W6WzUI3+ueN0a58UQ8jkTug9cjkXvwzkfXotu3LMfExEjXrl3Npml///TTT9K0aVPV0zE1NdXsOSNHjlSVLxAwa8Ndr1u3zqHR+3IDinDP6yuZjG4Tr06iFlE1Xb2plAkeRyL3weuRyD20yifXotuP4OdquTHcNaAYN2oMonQKeoQi0R35O4/VqufWv7bIHI8jkfvg9UjkHtJdeC16xHDXnhIsa9BKjpZw9Ah1RqI75Q4eRyL3weuRyHOvxTOeMNw1EREREZGrMFgmIiIiIrKBwTIRERERkQ0MlomIiIiIbGCwTERERERkA4NlIiIiIiIbGCwTEREREdnAYJmIiIiIyAYGy0RERERENjBYJiIiIiKygcEyEREREZENDJaJiIiIiGxgsExEREREZAODZSIiIiIiGxgsExERERHZwGCZiIiIiMgGBstERERERDYwWCYiIiIisoHBMhERERGRDQyWiYiIiIhsYLBMRERERGQDg2UiIiIiIhsYLBMRERER2cBgmYiIiIjIBl/R0d69e2XDhg2yY8cOiY6Olps3b0pERIRUrVpVHnroIWnTpo0EBwfruUoiIiIiIvdtWTYYDPLZZ59J/fr15a677pIpU6ZITEyMFC9eXAXJvr6+smnTJunevbtERkZK//795cSJE/psPRERERGRO7cs16xZU5KTk6VPnz6yZMkSqVatmtXnJSQkyI8//ihffvml1KpVSz766CPp1atXTldPREREROS+wfLrr78uPXr0EG/vzBupCxQoIJ07d1YPtCyfPXs2p6smIiIiInLvYDk7rcPly5dXDyIiIiIid+aUahjx8fHy66+/ytKlS9W/ITExUdLT052xOiIiIiIi9w+W0dlv9OjRUqZMGWnSpIn07t1bjh8/ruYh/WLSpEl6ro6IiIiIKO8Ey2PHjpXZs2fLzJkz5fDhwyp41nTo0EG+//57PVdHRERERJR36iwvXLhQpk6dKgMHDpS0tDSzeZUqVZJjx47puToiIiIiorzTshwbGyvVq1e3Og/Bc0pKip6rIyIiIiLKO8FyVFSUGsHPmi1btqj6ykREREREHpmGMWzYMBkwYID4+flJly5d1LQzZ87Itm3b5L333lNpGkREREREHhks9+3bV+Li4mT8+PEqdxk6deokwcHBMnnyZOnWrZueqyMiIiIiyjvBMgwfPlyeffZZ+f3331UOc3h4uDRq1EhCQ0P1XhURERERUd4KliEkJERat27tjEUTEREREeXdYDkhIUE2bdokp0+fVqP2mfLy8lJ5zUREREREHhcs//zzz/L444+rvGVrGCwTERERkceWjnv++eelTp06snfvXklKSpL09HSzh+VAJUREREREHtOyfPLkSXnnnXekZs2aei6WiIiIiCjvtyzff//9cujQIT0XSURERESUP1qW582bJ127dhV/f39p3ry5FC5cOMNzUEqOiIiIiMjjgmUEx+XKlZOBAweqznzWMG+ZiIiIiDwyWO7du7f89ttv8vLLL0tUVJRqYSYiIiIiyqt0DZZRXxmpGE8++aSeiyUiIiIiyvsd/EqVKsVhrYmIiIgo39A1WJ44caJMmzZN4uPjdVvmwYMHpWXLlhIcHCwlSpSQV199VZKTk7N8XWxsrAwaNEjKli2rXlurVi2ZO3eubttFRERERPmfrmkYS5YskVOnTqlOfnfffXeGahjo9Pftt9/avTwE3Q8//LBUqVJFVq5cKWfPnpXhw4erIbVnz56d6WtRlQOB9tSpU1XAvGbNGnnuuefEx8dHBgwYkO33SERERESeQ9dg+fr16yqw1Vy7di1Hy0NL8NWrV2XVqlXGknOpqakyePBgGT16tJQsWdLq686fPy8//fSTLFiwQPr27aumIejeuXOnfPnllwyWiYiIiCj3g2UEqHpau3attGjRwqw2c7du3VR6xfr1642BsKWUlBT1f8v8afyNgJ6IiIiIKNdzlvWGNIpq1aqZTUNqR2RkpJpnS5kyZaRVq1YqBePff/9VLdzLly9XAfbzzz+fC1tORERERPlBjluWZ82aJU888YQUL15c/TszyFkeNmyYQznL1kYBDAsLk7i4uExfixzn7t27S82aNdXfyFV+//335fHHH8/0dUj7wEMTHR1tHEwlNwZUwTrS09M5eEsex+NI5D54PRJ57rWYpsO6chwsv/LKK/LAAw+oYBn/1jNYzi6DwSD9+vWTI0eOyNKlS1VL9IYNG+Sll15SgXaPHj1svhYB/4QJE6xW1wgICHDylos6ia5cuaL+7e3t1g3/lAkeRyL3weuRyHOvxdjYWNcHy3jj1v6tBwS22k61bHE2zWO29MMPP8iKFSvkn3/+kdq1a6tpTZs2lZiYGDW6YGbBMqpt9O/f36xluUGDBhIRESFFixaV3PoFVKRIEdUaTnkTjyOR++D1SOS512JSUpJ7dfD75ZdfpF69ehISEpJh3o0bN2TXrl3y0EMP2b085Ctb5iYjeEYAa5nLbAp5yjgIqK1sqm7duvLJJ5+o0nMFChSw+tpChQqphyUsL7cOLH5t5eb6yDl4HIncB69HIs+8Fn10WI+ubeDNmjVTgao1CHox3xFt27aVjRs3yuXLl43T0GKMHY0OfLagzjN+vaBl2RSC9WLFitkMlImIiIiInBYsI1fYFrQsBwUFObQ8lIgrWLCgdOrUSVWyQN3kESNGqOmmNZabN28ulStXNv7drl07NRBJly5dZPHixbJp0yYZOXKkLFy4UIYOHZrNd0dEREREnibHaRjbt2+XrVu3Gv9Gh7rffvvN7DmJiYlq5L7q1as7nLOMQBcBLgJmBM7IJ54yZYrZ89CKjMFKNHgeXjdmzBgVJKNlukKFCqrz3pAhQ7L9XomIiIjIs+Q4WF63bp2xegSqXbz33nsZnuPn56cC5Tlz5ji8fLwOqRiZ2bJlS4ZpaGletmyZw+sjIiIiItItDWPcuHGqCgYeSMNAS7P2t/ZAT8Q9e/ZI48aNc7o6IiIiIqJco2s1DL1LxxERERER5ZsOfqg2gVxh03rIAwYMUIOWjB8/nsE0EREREXlusIwR8kw79+Hv5cuXS4kSJeStt97K0DGPiIiIiPI3g8EgN//+Wy7OnCU3Zs5U/8ffmVVRy7fB8oEDB9Rod3Dz5k356quv5J133lH/nzFjhnz++ed6ro6IiIiI3Fji4cNy/PHH5UT3HhI/f74k/7BG/R9/Yzrme1SwbDoy3u+//6469nXs2FH9XadOHTlz5oyeqyMiIiIiN5V4+LCc7PWEJB08dGeiSUoupmO+uwfMugbLFStWlLVr16p/L1myROrXry/h4eHq75iYGKvDSBMRERFR/mIwGOTcqFGSnpBgFiCbQdW0hAT1PHdOydC1Gsbw4cPVoCGffvqpxMXFmaVdoBYyWpeJiIiIKH9L/OcfSfr3QNZPRInhfw9I4t69EuSmcaKuwfLTTz+tBgPZuXOn1KtXT5o1a2acFxERIS+++KKeqyMiIiIiF0tPTJSU6GhJjY5W/085Fy1XN2xwaBnXNmzwjGAZHnroIfWwhNJxRERERJR3GNLTJS021hgEq/9Hn7sVGN/+Oy0uLmcr8faWtCtXxV3pHiynpKSoNAy0Lp8+fVo++OADqVKlihp6GmkYGL6aiIiIiFwPOcMp58/fDnzNg2CttdiQkuLkjUgXn9BCnhEs//fff9KiRQu5dOmS1K1bV9Vcvnbtmpr3yy+/yI8//igLFizQc5VEREREZIUhLU1SL10yS4/QgmAVGJ+LlrTLl3VZl3doqPhFRhof4iUSv2Sp3a8v2LKleESw/MILL0jRokXljz/+kMKFC4u/v79xXpMmTeS1117Tc3VEREREHivt+g1JjT6XMUVC+/eFCyKpqTlfkZ+f+BUvfisQLhkpviogLqn+jWm+JSLFJyTY7CWobpHw11+3ysZlNoKzt7cEVqsmgbVri0cEy6h48cUXX0iRIkUkLS3NbB5G8YuOjtZzdURERET5kiE1VVIvXjQJhDOmSKRf1SfP1ycs7FbQq4LfksagWAuEfYtEiJePj0PL9PLykpLTp6s6yjbLx3l7i3eBAlJyxnT1fI8Iln19fW3Wybtw4YKEhITouToiIiKiPCnt2jWbQbCadiFGxKLhMTu8/PzMg2DL1uHIEuIdFCTOEBgVJeWWLlF1lI1l5BAU344VA6pVlVIzZkhAlSriznQNlpFqMXPmTGnbtq14e98a7wS/FBBAf/TRR9K8eXM9V0dERETkdtAhLuVCzK0UCZPOc6rD3O2gOP36dV3W5RMRYT0Ivt0y7BMeLl63YzJXCIyKkgpff63qKF9Zt15uxFyQ4GLFJbR1K5V64c4tyk4JlmfMmCGNGzeWGjVqSIcOHdQOQDWMffv2yZEjR1QuMxEREVFehQbA9CtX7rQCW2kdRvpEpnm6dvIKCLDSEmyaIlFCvAMDxd15eXmpGsr+NWuKXLyo+rf5OJjWkW+C5WrVqsmuXbtUTWXkLmNHrF69WlXIwPDXlSpV0nN1RERERLoyJCerjnG2UySixYAcXB34Fi2aIUXCN7KEsWUYucR5oeU1v9O9znKFChXks88+03uxRERERDluFUaptJRzNvKEz0WrUmtaTm1OeAUFiV9JG3nC+Hfx4uJtUjWMPChYJiIiInKF9KQkSUWOsEl6hGmesGoVTkzM+Yq8vMS3WDGbecJ4oO4wW4XzBwbLRERElDdahc2GXc7YOoz5ekA5M79SJa3nCePv4sVUlQnyDAyWiYiIyOXSb96UlGi0CttIkYg+r/KJc8zHR3yLo1XYWorE7VbhggXZKkxGDJaJiIjIqQzp6TaGXb4z2lxafLwu6/IuVCjTUmroVOfly/CH7MezhYiIiHIk/cYNm/WE1eP8eZGUlJyvyNfXOOyy1dHmUFeYA6BRXguWf//9dzlw4IA8+OCDUrVqVWevjoiIiHRkSEu7NexyJqXUUHdYDz6hoeJrUUFCC4JRWcK3SBGHh10mcqtguVevXhIQECALFixQf8+dO1cGDx6s/o3pqLnMUfyIiIjcR9r163dKqVlLkYiJEUlN1WfYZZO84AwpEhhgo0ABXd4TkdsGy7/99pu89dZbxr+nTZsm/fv3l1mzZslzzz0nEyZMYLBMRESUSwypqZIaE2MzT1i1Cl+7psu6MKxyZqPNYVhmVw67TOQWwfLFixclMjJS/Xv//v1y+vRpefHFFyUkJET69OkjXbt21XN1REREnj3s8rVrtwPh23nCFikSqRcu6DPssr9/pnnCqlU4KEiX90WUr4PliIgIOXnypMpP/vHHH1XgXBPjgOM2T1qapOtwwRIREXnMsMtoFbaVIhF9XnWs04NPkSJ30iOspEig1Zil1MhT6Rost23bVkaOHCl///23LFy4UHr37m2ct2/fPjUUNhERkafThl3OrJQaOtXpMuxyYOCdYZetpEj4olWYwy4T5U6wjHxltCCjVbldu3Yyfvx447xVq1ZJmzZt9FwdERFRpgFp4j//yJV16+XGxRiRosUktHUrCaxTx+mtpOnJybeGXTZrCTZPkTDcvKnPsMtFi2ZeSq1wYbYKE7lLsBwaGirz58+32fmPiIgoNyQePiznRo2SpH8P3Jrg7S3J6ekSP3++BNSoLiWnT5fAqKjstwrHx2dSSu2cpF28pMv78MKwy7byhNFaXKyYyicmojxWZzk+Pl6lXaCDH1IzwsLCJDExUfz9/cWbPWGJiMjJgfLJXk9IekLCnYkmfWaSDh5S88stXWI1YE5PTLzTWc5aisT582JISsr5hnp7iy8G2ChRwuZocxiNjq3CRPkoWMav7TFjxsh7770nCQkJ6gLfuXOnCpY7d+4sDRs2lHHjxum5SiIiIrPvIbQoq0DZVqfy9HTVMe7Mc4Ol8BNPSOp58yoSaXFxumyLd8GCxg5zVlMk0CrMYZeJ3J6uV+nYsWNl9uzZMnPmTFVPOcrkF3uHDh3kk08+YbBMREROgxxlY+pFZgwGSTl7Vi7+73/ZW5GPjxp22WYpNeQKFyyYvWUTUf4NllEBY+rUqTJw4EDV0c9UpUqV5NixY3qujoiIPBxaiJOOHpXEQ4ck6fARubZxoy7L9Q4NzbSUGjrVcdhlIs+ga7AcGxsr1atXtzoPwXNKSoqeqyMiIg9hSEuT5JOnJOnwYUk6fEjlJScdOiwpp0/naLn+5cpJwbZtzPKEfUtEik9IsG7bTkR5m67BMtIuNmzYYHVI6y1btkitWrX0XB0REeVDqZcuqaBYC4hVgHz0qD6d6iwUbNVSir30ku7LJaL8Q9dgediwYTJgwADx8/OTLl26qGlnzpyRbdu2qU5/SNMgIiLSqk4kHTl6u7UYwfGtVIq02FiHloNBNQKiqqjKFl5BQXLp/dl2v7Zgy5bZ2HIi8iS6Bst9+/aVuLg4NRgJcpehU6dOEhwcLJMnT5Zu3brpuToiIsoDDOnpknLmzK2A+HZucdKhQ5J86pTtihVWeBcoIAFRUcZHYNUoCahSRQ26YVyXwSDXNm1S5eEyXba3twRWqyaBtWvn9O0RUT6ne82a4cOHy7PPPitbt26VS5cuSXh4uDRq1EgNWEJERPlbanz8rWDYNLf4yFExmNY8zoq3t/iXL38nIEZwXLWqGoTDK4ta/ShZigFHjHWWrQXM3t4q8C45YzprGBNRlpxS4DEkJERatWrljEUTEZEbwHDOyceOZcgtTo2JcWg5PkWLSGCVOwEx0ikCKlUS78DAbG8b0jEw4IjZCH4Iig0G9c+AalWl1IwZqlWaiChXg+X3339fzp49K9OnT88wb9SoUVKmTBl5/vnn9VwlERE5EdIaUs+dk0Sto93t3OLk4ydQ5sju5XgFBqrgVMstvhUYR4lveLhTthvrqPD115K4d69cWbdebsRckOBixSW0dSuVesEWZSJySbA8Z84clYZhq1IGBithsExE5J7Srl0zySs+bEynSL9+3f6FeHmJX9kyEhh1KxjWUin8ypTJ9brECIiD6tQR/5o1RS5elKJFi4oPayMTkSuD5ZMnT0oVG7e1KlasKCdOnNBzdURElA2GlBRJOn7c2NFOBchHDkvquWiHloOOdaqFuGrUrdZiPCpXVvnARET5ha7BcqFCheT48ePStGnTDPP+++8/KcAPUCKi3E2hiIm5ExBrqRT//SfiwCBRXn5+4l+l8q3c4tvpE0inUKPYMZ2BiPI5XYNldOqbMGGCtGjRQuUna1BredKkSdK2bVs9V0dERKbDPh85cicgPnRIEo8ckfQrVxxajl+pUsaOdlpuMUa58/J1Sn9wIiK3p+unHzr23XfffVK1alV5+OGHpWTJknLu3DnZvHmzyhWbNm2anqsjIvI4htRUVZ/YrGbxYceHffYuVOh2QHwntxh/+4SEOG3biYjE04NlBMd79uxRHfkQIB8+fFgiIiLk5ZdfVqP7oeYyERHZP+yz6SAeqsX42DHHhn329ZWAihVvl2a7k1uMUe+YQkFElDXd76shIJ4yZYreiyUiyrfSb96UpKOoWWyeW5wWF+f4sM/GgPh2i3GF8uLl7++0bSciyu90DZZPnz4tFy9elHr16mWYt3v3bilWrJiULl1az1USEeWtYZ9PnzYbxMM47PPtATMcGvbZNLc4Kkp8OFIqEZF7B8vPPfecKh1nLVheunSpHDlyRL799luHlnnw4EEZOnSoGj67YMGC8tRTT8nkyZPF346WEgyQMnr0aFmzZo1cv35dypcvL6+//ro88cQTDm0DEVG2hn0+dGcQD5VKceSIGG7edGzY5woVbgXExioUUXYN+0xERG4YLO/YsUMGDhxodV6zZs1k0aJFDi0vPj5edRREAL5y5UoV/GLQk4SEBJk9e3amr42OjpZGjRqpzoYfffSRKmu3f/9+SXIk14+IKAvpSUlq2GfVWmySW5x68aLjwz5rqRO3Uyn8MexzQIDTtp2IiHI5WEbrrZ+fn9V53t7ecu3aNYeWN3fuXLl69aqsWrXK2DkwNTVVBg8erFqM0aHQlldffVWVr/vxxx+NIzY1b97cofUTEZnWLE45e86YV6zlFiefcHDY56AgNXCHWW5x1SjxDQtz6vYTEZEbBMvVq1dXgW2bNm0yzEP6BVp5HbF27VpVs9m0ika3bt1k0KBBsn79eunbt6/V1yHAXr58ucyfP59DmxKRw9KuXs1Qmk0N+3zjhv0L8fIS/7JlM+QWu2LYZyIicpNg+aWXXlIBLALUp59+2lhnecGCBfLxxx+r4NXRfGUsx1ThwoUlMjJSzbMFnQmTk5NVK3eTJk1UvjNK2PXp00flO9tq/SYiz2JITpak4yfutBTfzi1OjXZw2OewsDsBsZZbjBQKjlpKRJTn6Roso/PdhQsX1Ch+8+bNM04PCgpSA5YgWHU0ZxnBsaWwsDCJy6Sk0vnz59X/+/fvLwMGDJDx48fLH3/8IW+88YZKB8lscBS0SuNhmvsMaWlp6uFsWEd6enqurIuch8fRDYd9vnBBBcTJqqPdreA4+b/jyO2yezkowYY8YgTD/lFVbgXFVaLEp0hEhprFqG3B4+8eeD0See61mKbDunSvszxixAjVyW/btm0SGxurWnTR0Q4d7HILDgQghQMDpGgdDJEz/dZbb6mgGQG8NbNmzVLBviW8l4Bc6GiDbb9ye3haBPaUN/E4uo4hIUHSjh+XtGPHJO2/45J2/D9JO/afGK5fd2g53pGR4lOxgvhUrGT8v3epUuLleyuFAh+/CephELl0yUnvhvTA65HIc6/F2NhY9wuWAYFx69atc7wctCBrO9WyxTmz0QDxOkAlDVPo4IcBU44ePSq1a9e2+lpU20CLtGnLcoMGDVTQjyG7c+sXUJEiRZhvnYfxOObSsM8nT0ryEVSgOKzKsuHfKWfOZGPY5yjxr3K7pRgtxlWqiHdwsNO2nXIXr0ciz70Wk3SogqZrsGxPaTikatirWrVqGXKTETwjgMU8W2rUqJHpchMTEzMN9K21guOg5taBxa+t3FwfOQePo34pFGlq2Oc7g3gkHjksyUePqZxju/n53Rn22SS32Ld4cQ777AF4PRJ55rXoo8N6dA2WbVWnMP0iciRYbtu2rUydOlUuX75szF1esWKF2tGtWrWy+bpy5cqpluONGzfKkCFDjNM3bNig0i+yCqaJyJXDPh+9FRCbjHKXFh/v0HJ8IyNvV5+4U7c4oDyHfSYiIhcHy0iPsDZt3bp1ahARjOLnCJSIe//996VTp06qrjIGJUFONKab1lhGesXJkydVeoUG6RYdO3ZUFToeeeQR2blzp8pXRv3lYN5eJXIpQ1paxmGf0eHO0WGfg4ONo9oZ6xZXqcJhn4mIyD2D5VArX1CYhg5/SH1AoIrayfZC7vGmTZvUcNcImDHcNfKJEQhb5sBgsBJTjz76qHzxxRcyadIk+fDDD1W5OXTcGzVqVA7eIRE5KjUuzmQQj9t1i48edWzYZx8f8a9Q/vYgHrcH8kDN4lIlmUJBRERO5ZQOftbUrFlTxowZk62BTpBOkZktW7ZYnd69e3f1IKJcHPbZIrc47aJjlSJ8ixa9XbP4Tm6xf8WKHPaZiIjyb7CckJCgBiUpVapUbqyOiJzIkJ4uKefO3QmIb6dSoDKFw8M+qwoU5rnFHPaZiIjybbCMTnWWt0Qxkt6ZM2fk5s2bdlXLICL3kXblyu2R7cxzi9MTUGHYgWGfy5XLkFushn1mzVsiIvKkYLl+/foZguXAwEApXbq0dO7cWaVUEJE7D/t8yCy3OPX2aJj28gkPv9PRTsstrlxJvG0MAkRERORRwfLChQv1XBwROWPY5/Pn73S0u51KkXTcwWGfAwIkAMM+W+QW+xYp4tTtJyIiync5yydOnFAl3erVq5fpqHtEpK+069dvB8S3W4tVCsURSb961aHlIF0CAXEgahXfbjH2L1tWvHxzrX8wERGRy+j6bffyyy+rMm7vvPOO+nvVqlXSo0cPSUlJUWXg1q9fr1I1iEjnYZ9PnMiQW5xy9qxDy/EODb2TPnE7lcK/chXxCWFdciIi8ly6BssIjidOnGj8GwOJtGvXTtU6xmAir7/+ukN1lonyYppD4j//yJV16+XGxRiRosUktHUrCaxTJ8f1gFUKxcWLZh3tEByjXFu2hn02zS1GCkWxYqxZTERE5MxgOTo6WsqWLav+fezYMTl06JAsXrxYatWqpQYW6dOnj56rI3IrCFzPjRolSf8euDXB21uS09Mlfv58CahRXUpOn66CU3ug2gQG7rDMLU67fNmhbfItGSmBVaLMcosDKlQQLz+/7LxFIiIij6P7CH4xMTHq3xs2bFA5ylraRUBAgCofR5RfA+WTvZ4wL6mWnm78Z9LBQ2p+uaVLzAJmDPuMIZ5VQIzA+Mit1uKUU6cdG/Y5JMSso12ANuxzoUL6vUkiIiIPpGuw/NBDD8kbb7whFy5ckLfeeksNUa1BK7PW6kyUnyA9Ai3KKlA2CZDNpKer+WeGDJWwXj3vtBZj2OfExGwM+3xnEA8E374lOewzERGR2wfLb7/9tvTu3VtGjRqlql9MmTLFOO/zzz+XBx98UM/VEbkF5CgbUy8yg5HvTp2SmOkz7FoucohNA2JVhaJSJfH298/5RhMREVHuB8sYznrz5s1W561bt04NUEKU31zbsCFHr1fDPqshn28P4nE7nYLDPhMREblerhVKLcTcScqn0i5fUUM625tj7Fe6tIQ+1smYW4y/OewzERGRe+KoAkQ5GPTj8oqv5ArKITrQGa9Q2zZS9PnnnbptREREpA8Gy0QOSomOlrjPF8vl5csl/fp1h19fsGVLp2wXERER6Y/BMpGdEg8ckNgFC+TqmrUiqanmM+1Jw/D2lsBq1SSwdm2nbicRERHph8EyURZl4W789pvEzp8vCdu2Z5jvW7y4hD/VW4Lq1ZPTA561XT7O21u8CxSQkjOms8QbERGRpwfL8fHxsm/fPjl9+rS0bdtWwsLCJDExUfz9/cWbHZkoD0hPTparq3+QuAULJOnIkQzzA6pVk4in+0mhNm3E63YpNww4YjaCn0lrc0C1qlJqxgw1UAgRERF5aLCMVrgxY8bIe++9JwkJCaoFbefOnSpY7ty5szRs2FDGjRun5yqJdJV25YrEf7lM4hZ/LmkXL2WYH/zAAypILtCoUYYWYpR+q/D115K4d69cWbdebsRckOBixSW0dSuVesEWZSIiIg8PlseOHSuzZ8+WmTNnSvPmzSXKZFjfDh06yCeffMJgmdxS8pkzEvfZIrn89ddiMB2yGvz8JLR9ewnv21cCq945p61BQBxUp47416wpcvGiFC1aVHx8fJy78URERJQ3guWFCxfK1KlTZeDAgZKWlmY2r1KlSnLs2DE9V0eUYzf/+Udi5y+Qa+vXZ8g19i5USMK6d5ewJ58Uv+LFXLaNRERElE+C5djYWKlevbrVeQieU1JS9FwdUbYY0tPl+k8/qcoWN//clWG+X6lSEt6njxR+vLN4Bwe7ZBuJiIgoHwbLSLvYsGGDSsGwtGXLFqlVq5aeqyNySHpiolz55luJW7hQkk+cyDAfecXIR0YdZC9fFoohIiIinYPlYcOGyYABA8TPz0+6dOmipp05c0a2bdumOv0hTYMot6XGxUn8kqUSv3SppMXHZ5gf8vDDKkgOql+fnfCIiIjIecFy3759JS4uTsaPH69yl6FTp04SHBwskydPlm7duum5OqJMJf13XOI++0yufPONGJKSzOah3FvoY4+pdIuAihVcto1ERETk3nS/1zx8+HB59tlnZevWrXLp0iUJDw+XRo0aSWhoqN6rIrJavvDmrl2q0x7yki1H1fMJC5OwXr0krFdP8Y2IcNl2EhERUd7glMTMkJAQadWqlTMWTWSVITVVrm3cqILkxH/+yTDfv1w5Ce/XV0I7dhTvoCCXbCMRERF5YLC8aNEih57/1FNP5XSVREbpN27I5a9XStyiRZJy5kyG+chDRj5ySLNm4sXRI4mIiCi3g2XkKZvSOkjhdrjlNGCwTHpIiYmR+MVLJP7LLyX96lXzmd7eUrBVK4no11eC7rrLVZtIRERE+UCOg+V4k+oCR48ela5du0rv3r1VNYzixYvLhQsXZMWKFbJ48WJZvnx5TldHHi7x8GGJW7BQrqxeLWJRt9srKEgKP/64hPd5SvzLlHHZNhIREVH+keNg2bTj3qhRo1TnPvxfU6xYMaldu7YEBQXJyJEjZdOmTTldJXkY3KVI2LZNYhcslBu//pphvk/RIhL+ZG8J695NfAoXdsk2EhERUf6kawc/VMB49dVXrc6rX7++Kh9HZC9DSopcXbtWddpLOngww3z/ypUkot/TUujR9uLt7++SbSQiIqL8TddgGa3Iy5Ytk5YtW2aY9+WXX0rRokX1XB3lU2nXrsnl5Ssk7vPPJfX8+QzzCzS6TyKeflqCH3iAg4gQERFR3gmWR48eLQMHDpRjx46pwUgQPMfExMiqVavkl19+kXnz5um5OspnUs6dk7hFn8vlFStUlQszPj5SqF071WkvsEYNV20iEREReRhdg2UMdR0ZGSlTpkyRESNGSGpqqvj6+kq9evXk22+/lUcffVTP1VE+cXP/ftVpDykXkpZmNs87OFgKd+8u4b2fFL/ISJdtIxEREXkm3Qclad++vXqkp6fLxYsXVeqFN+vbkgVDerrqrId85IQdOzLM942MlPDevaVw1y7iU7CgS7aRiIiIyCkj+AECZJSOIzKVnpQkV7//XlW2SD52LMP8gBrVb3Xaa9NavPz8XLKNRERERE4PlolMpcbHy+VlyyRu8RJJu3Qpw/zgJg9JRL9+UqBhQ3baIyIiIrfBYJmcKvnUKYlb+JlcXrVKDDdvms1Dy3GhDo9KRN++ElClisu2kYiIiMgWBsvkFDf37FH5yNc2bMCoImbzvENDJaxHDwl7opf4FSvmsm0kIiIiygqDZdKNIS1Nrm3erCpb3Ny9O8N8v9KlJbxvXync+THxLlDAJdtIRERE5LJged++fVKrVi2b87/77jvp0KGDnqskN5B+86Zc+eYbiV24UFJOnsowP/CuOqrTXsGWLcTLx8cl20hERETk8mD5nnvuUUNav/LKK2bTr1+/LkOHDpVFixZJmkUdXcq7Ui9dkvilSyV+6ReSdvmy+UwvLwlp/rAaaS+obl122iMiIqI8Sddgefz48fL666/L6tWr5bPPPpNy5crJli1bpF+/fpKQkCArV67Uc3XkIkn//adSLa58+60YkpPN5nkFBEho58ckok8f8S9f3mXbSEREROR2wfKoUaOkbdu20rt3b6lTp47691dffaVSLzDUNQYoobzJYDBIws6dEjd/gVzfsiXDfJ/wcNVhL6xnT/END3fJNhIRERG5fQe/u+66SwXGDz/8sCxfvlwNdb1kyRIJCgrSe1WUCwypqXJt/XpV2SJx374M8/0rVJDwfn0ltEMH8Q4MdMk2EhERETmLt96tj1OmTJFmzZpJo0aNZO7cuXLixAmpW7eu7LAypDG5r7TrNyTus8/kWKvWcnb4yxkC5QL33COl58yRij+slrBu3RgoExERUb6ka8ty48aN5e+//5bp06fLSy+9pKa1b99ennnmGXnwwQfl1VdfVR0AyX2lXLgg8YsXS/yXyyT92jXzmd7eahjq8H79JKh2bVdtIhEREVHeDJZTU1Nl9+7dUq1aNeO0kiVLytq1a1UrM4Nl95V46JDKR76yZo1ISorZPK8CBaRwl8cl/KmnxL90aZdtIxEREVGeDpa3b98uPjbq6A4aNEhatWql5+pIh7SZG79vlbgFC+TG779nmO9btKiEPdVbpVn4hIa6ZBuJiIiI8k3Osq1AWVOxYkWHl3nw4EFp2bKlBAcHS4kSJVTrdLJFubKsvPPOO6rOL1JCSFS5t8vffCPHO3aS0/37ZwiUA6KiJHLaNKm8aaMUGTCAgTIRERF5LF1bllEBIyubN2+2e3nx8fFqmVWqVFE1ms+ePSvDhw9XNZtnz55t1zLOnz8vEyZMkGLFiomnS7t6VeKXLZP4zxdLakxMhvnBjRtL+NNPS/D9jTmICBEREZHewXKhQoUyBFkIeJHHXLhwYTXCnyOQ53z16lVZtWqVhN+u3Yu86MGDB8vo0aNVPnRW0BKNOs8nT54UT5V85qzEf75ILq/4StITEsxn+vpK6CPtVKe9QJNccyIiIiLSOVj+5ptvrE6/dOmSClh79Ojh0PLQMbBFixbGQBm6deum8p/Xr18vffv2zfT1v/32m9qmQ4cOSc+ePcXT3Ny7T+IWzJer69aLWAwz7h0SImE9ukvYk0+KX4kSLttGIiIiIo8alMSaIkWKqBZePBDsOpKv/PTTT5tNQwt1ZGSkmpeZtLQ0GTJkiIwZM0Y931MY0tPl+s8/q8oWGHHPkm/JSFXVonCXLuITEuKSbSQiIiLKK3IlWNaCV+QPOwIpHAiOLYWFhUlcXFymr50zZ47cuHFDhg0b5tA6kfaBhyY6Otq4/Xg4G9aRnp7u8LrSk5Lk6nffy+VFn0nyf8czzA+oWUPC+vaVgq1aiZfvrcOeG+/HU2X3OBKR/ng9EnnutZimw7p0DZaRm2wJlSsOHDigOtk1aNBAckNMTIy88cYbsmjRIvH393fotbNmzVLbaik2NlYCAgLE2XASXblyRf3b2zvrYiXpl69I0nffStKqb8QQH59hvl+jRhLQvZv43nWXJHl5SZKV55DrjyMROQ+vRyLPvRZjY2PdK1hGBz7LDn6o5QsNGzaUjz/+2KHloQVZ26mWLc6mecyWECjXqVNHjRp4+fJlY8dAPPB3SEiI+N5uXbWEahv9+/c3a1lGkB8RESFFixaV3PoFhNSVzErxJZ88KfGfLZKr334rhsREs3lefn5SsEMHCevzlARUquT0babsH0cicj5ej0Seey0mJSW5V7D8008/ZZgWGBgopUuXllKlSjm8PIwEaJmbjOAZAazpKIGW8JpffvlFBduWMA0dB9u0aWOzogcelnBQnXlg8aMi8Z9/5Mq69XLzYozEFS0moa1bSWCdOmY/QBJ2/6U67V3buAkvMt/G0FAJe6KXhPXqJb5FijhtW8k++NXs7POGiOzD65HIM69FHx3Wo2uw3KRJEz0XJ23btpWpU6eq1mAtd3nFihVqR2c2GiAGIdFalDUvvfSSBAUFybRp01SrsztJPHxYzo0aJUn/Hrg1wdtbktPTJX7+fAmoUV1KTp0qySdPSdz8+XLz778zvN6vbFkJ79tHCnfqJN4FCuT+GyAiIiLKp5zWwQ8DhyRapAdAZukTllAi7v3335dOnTqpusoYlGTEiBFqummN5ebNm6s6ykePHlV/33333RmWhWAb6RdNmzYVdwuUT/Z6wrz+cXq68Z9JBw7K8cc6Z2hFhqC6dSX86X5S8OGHxYutJURERETuHSwjlWDy5Mkyb948YxWJnPRKRMrEpk2bZOjQoSpgLliwoMonnjJlSoZlIh85r8H+QouyCpRNAmSLJ5n/7eUlBVF7ul8/KVCvbq5sJxEREZGn0jVYfvvtt1U1CdRTRn3j119/XeWKfPnll6oqBqY5qnr16rJx48ZMn7Nly5Ysl2PPc3IbcpSNqRd2QNm3Yi8PF/9y5Zy6XURERER0i651Oz799FNVdg3BMqA1eNy4cbJ//34V9GppEnTLtQ0bHHq+f7myDJSJiIiI8mqwfOLECZUvjNZkPz8/Yyc7dMgbPHiwLFy4UM/V5XlpV6+pznx28faWtCt3BkshIiIiojwWLKMW8fXr19W/y5YtazZIyaVLl1SnP7rDp1BB27nKltLTxSc0Y0k7IiIiIsojOcv333+/7Ny5U9q1aye9evWS8ePHqyGu0cqMAUlQtYLuKNiypcR+8qlDzyciIiKiPBosIzhGeTdAqTekYXzxxRdy8+ZNadmypSoDR3dgwBHUUU46eCjzFmZvbwmsVk0Ca9fOzc0jIiIi8ni6pmFUrVpVHn74YfXvgIAAeffdd1XwHBcXJ8uWLZNixYrpubo8DyPzlZw+/dZAIrZyl7291fySM6ZnGEqciIiIiPJQsIxA2XJ4as3hw4eNgTTdERgVJeWWLpGAalXvTDQJijG9/BdLJaBKFddsIBEREZEH0zUNA7WMr161XrEB03/55Rc9V5evAuYKX38tiXv3ypV16+VGzAUJLlZcQlu3UqkXbFEmIiIiyifDXdsK7LZu3co0jCz2W1CdOuJfs6bIxYtStGhRVYKPiIiIiPJwsDxt2jT10AK+Zs2aqbrKppKSktRw1Ki1TERERETkMcFy48aN5eWXXxaDwSATJ06Unj17SunSpc2e4+/vr0bwe/TRR3O6OiIiIiKivBMsN2nSRD20luUBAwZIyZIl9dg2IiIiIqL8k7M8btw4PRdHRERERJS3S8d1795d9uzZY/fzExMTZfbs2TJ//vycrpqIiIiIyL1blsuWLauGuY6KipIuXbqof9epU0fCw8PV/OTkZDl+/Ljs2rVL1q5dK99995167ty5c/XYfiIiIiIi921ZfvPNN+Xo0aPSoUMH+fTTT9XAIyh75ufnJwUKFJCgoCCpUaOG9O3bV9VaXrJkiezcuVPq16+vzzsgIiIiInLnnOXIyEiZMGGCehw7dkwFw9HR0SrlAi3MGAa7QYMGKngmIiIiIvLYQUkqVaqkHkRERERE4ulpGERERERE+RWDZSIiIiIiGxgsExERERHZwGCZiIiIiMgdguVr167l5uqIiIiIiNwnWO7fv7/NeXFxcaoGMxERERGRRwbLGJ1v2LBhGaZfvHhRmjZtKjdv3tRzdUREREREeafO8o8//ijNmzeXkJAQmTRpkpp27tw51aKMkfw2b96s5+qIiIiIiPJOsFyvXj1ZvXq1tGnTRgoWLCjdu3dXgXJERISsX79eChcurOfqiIiIiIjyVge/+++/X1atWiXjxo2T+vXrS6lSpVSLMgNlIiIiIvK4luWVK1dand6jRw/VyjxgwADVqqzp3LlzTldJRERERJQ3guUuXbpkOr9Pnz7Gf3t5eUlaWlpOV0lERERElDeC5ePHj+uzJURERERE+S1YLleunHg6g8Egly5dksTExBy3nGNZWA7K7KElnvTl4+MjgYGBUqRIEe5fIiIiyt1qGJorV67IH3/8oQJIBCX33Xefqo6RHyG4PXv2rBqd0N/fXwVjOYEALiAggIGckyQnJ8v169clKSlJdT7lfiYiIqJcC5ZjYmJkxIgRsmzZMhUklylTRs6fP68GJXnttddkzJgxkt/gBwEC5WLFiqkSeXoE36mpqeLr68tAzkliY2PVuYpjV7RoUVdvDhEREXlCsHzw4EFVX/nee++VAwcOSIUKFYzzduzYoWouY2CS4cOHS36ClAm0KOsRKFPuwLG6fPmyOnZERERETq+zjPzaxx57TDp06CArVqwwC5ShYcOG8tlnn8nUqVNVyylG+UPqQn6AHOWcpl5Q7sMxY2UWIiIiypWW5Q8//FClDLz99tuSnp4ulSpVypBCgCA5Pj5ejh49qjoFTpw4UebNm6fH6omIiIiI3LdleenSpWrwEbTWeXt7qxbkGzduyMCBA2XOnDkyatQoNW/KlClSvnx5VXsZec0IrImIiIiI8nWwfOjQIbn77ruNf8+YMUOmTZsmI0eOVHnMzz77rErPQBCdkpKinnv16lXWaM4m5Nui5X7hwoXqb/wAGTJkiNlz0MpftmxZ9SOlU6dOatru3btVZZICBQqo12M51l6rh/Hjx0tISIjx7xMnTqhp586d031dRERERG6dhoEWYpQ7M+3sZ1l/GZUxULLr1KlT6t9aGS/KuVWrVklYWJjx7yNHjsjLL7+sfqw8+uijqjIJvPDCCypP94cfflCdLVHOz/K1zoJgecKECdK+fXspWbKk09dHRERE5DbBMnKU0brcuHFj9TcqYiAnuXbt2qqkGjoAIhUjPDxcqlSpIv/++69q8dSCZsqZunXrmv2NY4EccaTGVKxY0exHzODBg6VZs2Y2X0tEREREOqdhoArGl19+afwb6QGorYxBH9CKiJbLNWvWqFQMBMn4PwJr09v0ZNvHH3+s0iWQPoFKIugkaco0laJv376qNRm0jpY4Hvg/6gtPmjRJ/btp06YZXqvZtm2btGrVSgoVKqRan1HNZMOGDWreli1b1Ov//PNPs9cg1UNbpiW8RgvQ8UMKrzftAIp0EATxkZGR6g5F/fr1Zf369TrsOSIiIiI3aFkeNmyYVK5cWVauXCmdO3dWQdr+/ftVfWWkXaB1GQEXbv0jReCdd96Rb775Ro9V53urV69WOd8Ignv06CG7du2Srl272nz+2LFjpUaNGioFA8cDASgeCIBbtmyp6l33799fBcLW/P777/Lwww+r3OZPPvlEChcurAJjHMfsqlevnnzwwQfy/PPPy4IFC6RatWrGeUjFwXZduHBBdQDFD6zFixfLI488onKscXeCiIiIKE8Hyxjk4fPPP5devXqpahhoZUTLIQIuPDQIoNHqiaAJARllbfLkyfLggw+qIBNat26tBtNAC7E1+KESFRVlTLFAyzEghxyt+qVLlzY7JpZeffVV9cNn8+bNxvrRaGXOCQTmCOChVq1acs899xjnLVmyRPbs2SN///238Tl4j/hRhfe4fPnyHK2biIiIyOVpGICOW+gshlv67dq1ky+++EL++ecflT+7du1a1Tp6//33q/molEFZQ2c8tCRjwBdTXbp0ccr6EhISZPv27aq0X24NtIJ0C7QeI8DHMN/aA63NO3fuzJVtICIiInL6cNeg5dOilRktgseOHVMBH26tI58Vw2AjJYDsg7xvBI5IYzFVvHhxp6wPg8agskluVqu4dOmS/PXXX+Ln55dhHkdGJCIionwVLENgYKCqwoAH5UzRokXF19dXYmJizKYjv9cZkJ+MNJrMaiHj+For+4dA23LURnugQkqdOnXk008/zcYWExEREeWRNIzM6utu3LhR4uLinL2qfActq+gch/QWU1999ZVT1hccHCyNGjWSRYsWqTsC1iDnGXCXwLR1GJ3xMuPv76/+j3xrUy1atJD//vtPtWYjl9nyQURERJRvWpYxEAaCLFS7AAR5qOCAUftQPg75qSgLRvYbM2aMdOzYUfr162eshoE0F2eZPn266nyJIBbl3HDcEAhjYJOnn35aBcuobIIBRkJDQ1XLN0ZsxL8zg5xkBP/z589Xr8EDwfBTTz0l8+bNU2k6r7zyinoeSskhNQOt18xvJyIionzTsozg2LQ1cPTo0aqzHzr6NWjQQF5//XU9V+cRUMN67ty5smnTJlVlBD84li1b5rT1PfDAA8ZayihXh1KAOK6mIzKiggUqZmA+AtwXX3wxy1ZgBNsoH/fzzz+r6h6otwyoq4zKG+ggitJxqLyBIB3l6rAtRERERK7kZcBQbzpBHeV169bJQw89pDr3YbQ+VDRAazIGJUGVBXRacwRGnRs6dKhs3bpVDZCBlkiUU9Nu61sTHR0tb7/9tgossR1o9cQ2oZXSchjurJw5c0aNNHj69GljCoJlmgloJdpyCocDnfrQ8pqdHGCyj97HzRLusOBcR945OyoSuRavRyLPvRbPZBHH5XoaBoJSrTMaRnxD5y0t7QItiBj22hHoNIaUAATdGGDj7NmzMnz4cFXibPbs2TZfh1QFPB9pA6gpjJxa1OxF6/a+ffvUQSIiIiIiytVgGa23b7zxhqrW8NZbb6m0AQ3qLZctW9ah5SH94OrVqyoNAIE3oNUVt+mR4mGrxBlu36NFGq2zGgyvjfWj8xpyq4mIiIiIcjVnGakPJUqUkFGjRqnAFDmoGnRKQ66qIzCYCTqaaYEydOvWTdUCRopFZiXQTANlQNM7WpQzK4tGREREROS0lmUMPoLOWtYgl1mr0WsvtA4jlcIyEMbAJpjniMOHD6sUkerVqzv0OiIiIiLyXLoPSmKtIxVG9UO94Mw65dnKWUZwbAnlzByp24xOcy+88IJK2+jZs2emz0XaBx6mnQW1pHRrtYexbHTE06ufJJajPci5sI9t1ZPOKSwXd0CctXwish+vRyLPvRbTdFiXR9RZHj9+vCq99uOPP6qBNzIza9YsVUPYUmxsrOqkaAmDbGA6cqn1DuBYDcN5cLEmJSU5XJ3FkeVfuXJF/RujIhKR6/B6JPLcazE2Nta9gmUExxMnTsxQZxmVKEaMGKHqLCMP2V4IsLWdatnibJrHnJmPP/5YbROGU27evHmWz0e1jf79+5u1LKOKRkREhNUqGqjwgaDWMkc6u7QWZZaOcy5cpEgLclZlFO0HD+pLs1QVkWvxeiTy3GsxKSnJvYJlBJZaxQvUN0YFjMWLF0utWrVUrWTUWXZEtWrVMuQmI3jGejDPnuD9ueeeU8GyZe6zLYUKFVIPSzio1g6sFtDqGdhiWdqDnAf715kXKwJyW+cNEeUuXo9Ennkt+uiwHm93rrPctm1b2bhxoxr+WLNixQq1ozHSW2YwCh3ykwcMGCBjx47N1vshIiIiIs/m1nWWBw0aJO+//75aDlI6MCgJ0jkw3bTGMtIrTp48qToSwoEDB9RrMJhJ7969Zfv27cbn4rZ7pUqVdHm/RERERJS/uXWdZeQso2Me8ncR/GK5yCdGJzzLHBjTDnY7duxQ6RoYre/++++XRo0aGR/In6bMjyGOHW5bmP7YyYmFCxeqlAeMpKhVSMHfX331lS7LJyIiIvLIOsuAushIxcgq5cJU37591SOvQee+fy7+IxtObJAbqTekYEBBaVG2hdQuUjtX8pePHDmiKpqMHDlSHn30UZWAr4dHHnlEtm3bZrUMIBEREZFH11nWWOs0R3cciT8iY34bIwfiDqi/vcVb0iVdFuxbINXDq8uUB6ZIlbAqTt0GpMogYEeed8WKFXVbLlJfnFV1goiIiMiZdC9yh7xhlIjDsNQdOnTI8CDrgXLvtb3lUNwh4zQEyhpMx3w8z1nQEo/WZEBON1qyP/jgAxkyZIhUrVpVChQoIOXLl1f54tbK+S1atEjq1q2r7h6gRRolA5FHbi0NwxY8r06dOmoZuEsxZswYDiJARERE+SdY3rlzpwp2vv76a/U4ffq0yhtevXq17NmzR65fv67n6vIFtOSiRflmyk2zANkUpmM+nueskf1QMWTGjBnq3ytXrlRpE/jBg2AVueeojz158mT5+eefM+Qyv/nmm6osICqf4LWoaY3OlY4M+IE8dOSjt27dWr7//nuVCvLee++pgJmIiIgoX6RhvPrqqyrAQrDk5+en/o9hrrdu3arKuCEA8gQIaFPSU+x67t5Le42pF5lBwIzn/RXzl9QqUsuuZft5+9md64zW5KioKPVvtBCjFRk+/PBD43PQibJChQrywAMPyOHDh9Xz0cqMERKfffZZmTdvnvG5HTt2FHtdu3ZNxo0bp86fqVOnqmktW7ZUw6NjkBhUQMGgMERERER5Olj++++/VcUKbQhDDAUNjRs3VgEV5qHlML9DoFx/sXOG9e7zo/0Du+x6cpf4+/jnaH2oYoJWX3T+u3HjhnG6FiyjBTohIUGeeeaZbK8DP6Zw16Fr165mVU1atGihanPj7kSTJk1y9D6IiIiIXJ6GgVZMtAbi/8WKFTPmrELp0qVVgEV5B0ZAfOqpp9Rw38uXL1f1qjHN9IeQNua6ad1rR2m5zLgLgTsS2gOpHIB0HiIiIqI837Jco0YNNcx1s2bNVE3jmTNnSu3atVXgM336dA4GksdgtMS7777bLL0COcumtPSIc+fOqR9E2YGRHgH5zmXKlMkwH6kfRERERHk+WEbeqtaajNxTDEl91113qb+Dg4M9ZhAK5AojBcLenOW+P9pfE/qzNp85lLOcE0iBwJ0CU0uWLDH7Gz+KUCljwYIFqgU6O7RlnDlzRh577LEcbTMRERGR2wbLGFradDARDDuNfFTcsr/vvvtUaoYnUOkoduYK1ytWT9VRRnk4W9UwtLrLVcOrSt1idXNlgBKtk93zzz+vRj1EQLtmzRo1oqKp0NBQ1TkPnTfT09NVxz78/6efflKdOu+5554s14PBSiZOnKg6+CFgbtq0qRpB8L///pNvv/1WVVZBME1ERESUrwYlCQkJUa3LZBsCXww4gjrKtsrHIVAO8guSqQ9MzbVAGQYOHKgC1vfff1+Vh0PnzKVLl6ofPqYQ5GLQEQyVjVrJBQsWVMG1Iz+OMHIgaiujMyHWh9QdpO20b98+Q+s2ERERUW7xMuhcuBedtRA07dixQ6KjoyUyMlIFVy+++GKeHMUNLZ3Io0UnM2s5uSdOnFD/10qt6T2CH6DlGYFy5bDKOVoH6X/cbEF9atSZxjmPVnIich1ej0Seey2eySKOy/WWZQTIbdq0UbfhUfYLpcUuXLigWgrxWL9+vTRs2FDPVeYbGMp6WftlKod5w4kNcj3luhQKKCQtyrZQOcq52aJMRERERE4IlpHfWrNmTZXbWqhQIeN0DFzRtm1bNXQyRvkj6xAQ1y5SW6oXri6+vr4MkImIiIjyU53l/fv3q4FHTANlrRMYpmNwCSIiIiIijwyWK1euLJcvX7Y6D63LFStW1HN1RERERER5J1hGxQSUEbMcuGLLli1quOu33npLz9UREREREeWdnOURI0aoFuSHH35YpV6gtyN6PWJaWFiYqsWLByAf9++//9Zz9URERERE7hss169fn53SiIiIiCjf0DVYxoAURERERET5ha45y0RERERE+QmDZSIiIiKi3EjDoJzByON/nbosa/eek+vJaVIoyE/a1Cwhd5cpzFxwIiIiIhdgsOwmDp2/JsOX75H9566qv729RNINIvN+/k9qliwks7rdLVVLFHT1ZhIRERF5FKZhuEmg/PiHW+VA9K1AGRAoazAd8/E8IiIiIso9DJbdIPUCLcoJyalmAbIpTMd8PA/Pd5a+fftKrVq1ZOPGjVKnTh0JCgqSJk2ayIkTJyQuLk66deumhjKvVKmSLFu2zOy18+bNk6pVq0pAQICUL19eJk+eLOnp6WrepUuX1PSPP/44wzobNmyolqs5c+aMPPnkk1KkSBG1/oceekh27dpl9hosf8iQIfLBBx9IuXLlVE3vTp06qZreRERERHpisOwECGiTUtPseuw8EadSL2wFyhrMx/P+PBln97KzE1ifP39eXn75ZRkzZowsWbJEjh07Jk888YR0795dateuLV9//bWqp42A9uTJk+o177//vgwaNEhat24t33//vQq6MWLjq6++quYj8H3sscdk/vz5Zuvav3+//PHHH/LMM8+ov+Pj4+WBBx6QPXv2qGViXcHBwWqQm5iYGLPXfvfdd+qBgPndd99Vo0YOHTrU4fdLRERElBnmLDtBclq6VH39R6csu+vc7XY/99DkNhLg6+PQ8tGCjMCzZs2a6u9z586pIBQjL44dO1ZNu/fee2XlypXyzTffqBbeiRMnSo8ePeS9995T81u1aiXJyckyc+ZMee211yQiIkIGDBggLVq0kAMHDkj16tXV8xA8lylTRlq2bKn+fuedd+Ty5csqgC5WrJia1rx5c4mKilJDpf/vf/8zbid+CCBYRos1oPV76tSpqjXb25u/AYmIiEgfjCrITMmSJY2BMiBQBQS6msKFC6tg9vTp03Lw4EGVZtG1a1ez5aAlGgEzAl9A63DFihWNrcupqamyePFi1QqtBbfr16+XZs2aSXh4uJqPh4+Pj0oF2blzp9nyMU0LlKFGjRqSkpKSoQWaiIiIKCcYLJMZBMKm/P39bU5PTExUqRNQvHhxs/na32ipBpS+69+/v3z++ecqCF69erXKMe7Xr5/xNQi60Vrt5+dn9sBrEJjbs53YJiIiIiK9MA3DCfx9vFUKhD3+Pn1Zus2zP7VixaD7pE7pwnZvh7OhFRgsW3QvXLhgNh8QGL/xxhsqUEYLM1qRK1SoYLasNm3ayKRJkzKsx7QVmYiIiCi3MFh2ArSi2psrfG/5cFVHGeXhMuvkh7rLNUoWknvKhbvVACWogFG0aFFZsWKF6sSnWb58uWrtbdCggXFaiRIlpH379ir3GGkVCxcuNFsWUj2QmoGcZnTsIyIiInI1BssuhsAXA46gjrKt8nEIlAv4+6rnuVOgDMgpRse/F154QeUxt2vXTrZv3y4zZsyQl156SXXuM4WOfo888ohKo3j88cfN5g0fPlxV4EA+8osvvihly5ZVqRo7duxQudTDhg3L5XdHREREno7BshvAyHxfP9fY6gh+UD2ykLzd/W6JKu6eI/ihWgZyi2fNmiVz5syRyMhIVTpu9OjRGZ6L8nIFChSQnj17SmBgoNk8BNYItF9//XVVfSM2NlYF4Pfdd59ZqzURERFRbvEyOHOUi3wAg2SgvBk6mJUuXTrDfJQs0wbKyCkcij2nL8vavefkWlKahAb5S5taJeSu0qFu16KcXZs3b1bl4P78809Vr9lV9Dxu1qSlpalWcaSooPWdiFyH1yOR516LZ7KI4+zBlmU3goD47jKFpVZkiPj6+uabAFmr13z06FEZMWKE3H///S4NlImIiIjsxdJxlCs++ugjVf0CPvnkE1dvDhEREZFdGCxTrkAOM26/7Nq1S6pVq+bqzSEiIiKyC4NlIiIiIiIbGCwTEREREdnAYJmIiIiIyAYGy0RERERENjBYJiIiIiKygcEyEREREZENDJYpU5cvX1aDoyxcuNA44t2QIUPMnvP2229L2bJl1Wg8nTp1UtN2796thqnG0NZ4PZZj7bVZjbKH13711VfGaY4ug4iIiCgnOIKfG8Fw1zf//luurFsvcuO6+BQqJAVbtpTAOnXcZjS/VatWSVhYmPHvI0eOyMsvvywjR46URx99VIoUKaKmv/DCC6qu8g8//CBBQUFSsGDBDK/NSmRkpGzbtk2ioqKc8l6IiIiIssJg2U0kHj4s50aNkqR/D9ya4O0tkp4usZ98KgE1qkvJ6dMl0A2Cxrp165r9fejQIRXkDxgwQCpWrGicfvDgQRk8eLBx1D5rr81KQECAap0mIiIichWmYbhJoHyy1xOSdPDQnYnp6cZ/Yjrm43nO9vHHH6tUB6RPNG/eXI4ePWo23zQNom/fvqo1GSpVqmRM18D/Y2NjZdKkSerfTZs2zfBaDVqOW7VqJYXQil6woDRs2FA2bNhgMw3DGizj4YcfluDgYAkNDZVevXpJTEyMrvuFiIiIPBODZRdDqyxalNMTEswCZDPp6Wo+nofnO8vq1avl2WefVa3BSJlAsNy1a1ebzx87dqzMmDFD/XvlypUqaMVr8f+QkBB55pln1L/nzJlj9fW///67CqSTkpLkk08+ka+//lo6duwop06dsnubsXwsA0HysmXL5KOPPpKdO3eq5RARERHlFNMwnAABrSElxa7n3vznnzupF5lJT1fPS9i9W4Jq17Zr2V5+fg7lOk+ePFkefPBBWbBggfq7devWkpiYqFqIrUFrspZPjBQLtBxDuXLlVGe/0qVLZ5pG8eqrr0rlypVl8+bN6vmAVmZHjBo1Su655x4VrGvvtXbt2lKrVi1Zs2aNtGvXzqHlEREREZlisOwECJQP1bnLKcs+9cSTdj+36j9/i5e/v13PRWe8Xbt2yf/+9z+z6V26dLEZLOdEQkKCbN++XaZNm2YMlLOzDLROv/XWW2r7NQjgy5Qpo1qYGSwTERFRvk7DQEexli1bqnzUEiVKqNbI5ORku1p3p0+frkqaoRpDo0aNVHBG1l28eFFSU1OlWLFiZtOLFy/ulPXFx8dLenq6lCxZMkfLQJA8bNgw8fPzM3sgleP06dO6bjMRERF5HrduWUYwhI5bVapUUbfZz549K8OHD1ctirNnz870tcilHTdunAqY69SpIx988IG6xb9nzx6zqg10S9GiRcXX1zdDx7gLFy44ZX2FCxcWb29vOXfuXI6WgdSL0aNHG+s7m9LK2BERERHly2B57ty5cvXqVdXZLDw8XE1D6ydKkiFAstUqiTxb3N5H/V+0OgJycXF7HrfsbXU40wtyhZECYW/O8qkne9u97LJLFjuUs2wvpELUq1dP7Wttn0FWlSiyC3cK0Nq/aNEidZyyk4qhLePAgQMq35qIiIjIo9Iw1q5dKy1atDAGytCtWzd1+379+vU2X7d161YVZOO5Gn9/f+ncubPq9OVsaO309ve361Ggfn1VR1nVVc6Mt7cE1qghBerVs3vZjg5kMmbMGPn111+lX79+sm7dOpk6dap8/vnn4ixo9T98+LA6xitWrJCNGzeqnOn58+fbvYw333xTDXzSvXt3Fehv2bJFFi9eLH369FH/JiIiIsq3wTLylatVq5bh1jtGdsO8zF4Hlq+tXr26ymW9efOmuAsEtBhwxLtAAdsBs7e3ml9yxnSnjuTXoUMH1Zq/adMmldaAHyQox+YsDzzwgApo8Z5Qsxk/ZhDwopqGvRo3biy//fabXL9+XQX56NA3ceJEVScalTaIiIiI8nXOMoJjSxgyOS4uLtPXYfS3wMDADK9Dxz/MR6c/a9AijYcmOjpa/R8dyUwrLmiwPAR7Oal/HFClipRbsuTWCH4HzEfwU/OrVlWBsn/lyk6tswyos4yHKbTkA9Z9/Phx478B9YxN52uwjy2nWb4WkEaB4NwSnoOg2XLZ1pZRv359VSPamsz2F+ZZO6Z6wHKx7c5aPhHZj9cjkedei2k6rMutg2VXmDVrlkyYMCHDdIxIhwDcWn40piOXOid8KlaQ0su+lMS9e+Xaho0i16+Jd6FQCWnRXAJq1VIBeU7XQXfgYsVgKKgC4qzlX7lyRf0bHRmJyHV4PRJ57rUYGxubv4NltARrO9UUWi1N85itvQ6BEAJZ09ZlvA5BJ+bbgmob/fv3N2tZbtCggURERKiKEZaQ0oFlopKEHnzr1pXA2rXV8pyZcuHpcJHi3LB2TPX8JYuKHNmtI01E+uD1SOS512JSUlL+DpaRc2yZm4zgGQGsZT6y5evg0KFDctdddwYHwbK0usu2FCpUSD0s4aBaO7BaQKtnYItlaQ9yHuxfZ16sCMhtnTdElLt4PRJ55rXoo8N63Pp+VNu2bVWFhMuXLxunoWoCdnRmwyKj0xcCXjxXk5KSomo1c0Q3IiIiIsoXwfKgQYOkYMGCxsoMCxYskBEjRqjppjWWmzdvblb5ALfXX3vtNVVT+d1335XNmzdLz549Vd7KK6+84qJ3Q0RERER5jVunYSC3GJUShg4dqgJmBM7IJ54yZUqGHBjLzm8jR45U1Q4QMKMT1913361qB+s9eh+a9+0ZfpvcC84Z1N4mIiIiyrPBslYbGakYmbE2+ATyUdG6jIczoRUbNX7Rao1OgOT+cKzwA8dabjoRERFRngqW3R16dKKnZUxMjMqt1iORHKVVWN7IeS3KCJRxlwLHjoiIiCgzjMhyCC3YpUqVUoGXHrf1kTqC4NvZg494KhwjHCscM1YbISIioqywZVkHCLr0qteLlk/kWGN5LHFERERE5FpsWSYiIiIisoHBMhERERGRDQyWiYiIiIhsYLBMRERERGQDg2UiIiIiIhtYDSML2siA0dHRubI+VMPAoBkoH8dqGHkXjyOR++D1SOS512L07fjNcqRnRzBYzgLKuEGDBg1cvSlERERElM14rnz58tl5qXgZOPpFphITE2Xv3r2q7rGvr2+u/AJCYP7HH39IZGSk09dHzsHjSOQ+eD0See61mJqaqgLl2rVrS2BgYLaWwZblLGDH3nvvvbm+XpxEpUuXzvX1kr54HIncB69HIs+8Fstns0VZww5+REREREQ2MFgmIiIiIrKBwbKbKVSokIwbN079n/IuHkci98Hrkcg9FMqj1yI7+BERERER2cCWZSIiIiIiGxgsExERERHZwGCZiIiIiMgGBstERERERDYwWHYTR48elUGDBsndd9+tRgqsVauWqzeJHLRixQrp2LGjKrQeHBysjuX8+fOFfWiJXO/69evq2vTy8pI///zT1ZtD5HE+++wzqVu3rhrsrUiRItK2bVu5efOm5AUcwc9N7N+/X3744Qdp2LChpKenqwflLbNmzVKjBM2cOVMNj75hwwYZMGCAnD59WpXKISLXmTRpkhr2lohy35QpU2TGjBkyevRoadSokVy6dEk2bdokaWlpkhewdJybQHDs7X2rob9v376q5WPfvn2u3ixyAC5+/Fo29eyzz8qyZcskPj7eeHyJKHcdPHhQ7rnnHvVDFnfwdu7cqf4mIuc7dOiQulv+3XffqdbkvIjf3m6CgVTeZxkoA245Xb16VW7cuOGSbSIikaFDh6oguWrVqq7eFCKPs2DBAqlQoUKeDZSBERqRE/32229SqlQpKViwoKs3hcgjffXVV7J371554403XL0pRB5p+/btUrt2bZk8ebIUK1ZM/P395f7775cdO3ZIXsFgmciJgfKXX34pr7zyiqs3hcgjJSQkyPDhw2Xq1Kl5bnhdovzi/Pnzsn79elm0aJHMmTNHvvnmG9XRtlWrVhITEyN5AYNlIic4c+aMdO/eXZo1ayYvvPCCqzeHyCOhJat48eLSr18/V28KkUf3ybp+/bq6y9OlSxdp166dyl9Gl7nZs2dLXsBqGEQ6u3z5ssrNioiIkK+//pr56EQucPLkSdWhb9WqVXLlyhU1DV/Y2v/xCAkJcfFWEuV/YWFh6vuwTp06xmnh4eGqTw8qgeUFDJaJdISake3bt1dfztu2bZPQ0FBXbxKRRzp+/LgkJyfLI488kmEe7vigTCdyKYnIuWrWrCnHjh2zOi8xMVHyAgbLRDpBDddu3brJgQMH5Ndff1Ud+4jINTAo0E8//WQ2bc+ePTJs2DCZO3eu3HvvvS7bNiJP0r59e1URA9cfrkuIjY2V3bt3q+sxL2Cw7EYdUdasWWO8fYhyY8jvgSZNmqhBLsi9DR48WFavXq1u/eL4mbZa4XZTQECAS7ePyJMULlxYmjZtanVe/fr1pV69erm+TUSeqFOnTurHKfKVMThJUFCQTJs2TX0n4nszL+CgJG7ixIkTqg6hNWgdsfWhT+4Do/fhh46tW8KYT0Sus2XLFpWCwUFJiHJ/0K5hw4bJ999/r9KjHnzwQXn77belRo0akhcwWCYiIiIisoHd9ImIiIiIbGCwTERERERkA4NlIiIiIiIbGCwTEREREdnAYJmIiIiIyAYGy0RERERENjBYJiIiIiKygcEyEREREZENDJaJnGz8+PHi5eVlfAQGBkr16tXlf//7n6Snp+s6vC/W5ayRz6ZOnZrt11++fFm994ULFxqnYVRKZ2xv3759pVatWpKb8D62bt2aYTre81tvvWX2ntu3b2/2upCQEHEXOD7YZoy2lR0NGjSQDz74wGx5S5cuFWeNeor9d+7cObueb2tbLI8J5Ryudxybf//9N1uvHzBggHoQuQsGy0S5ICgoSLZt26Yea9eula5du8qoUaNUwJwX5DRYzu8mTJhgNVjG8X7iiSfEE6xatUoFsE8//XSuBcvY7zkNlufMmSMzZ850whZ6drCMY5PdYHnkyJGyaNEiOXLkiO7bRpQdvtl6FRE5xNvbW+677z7j382aNZO9e/fKypUrVdBM+ZPpMc/v3nnnHenZs6f6YZiX1KhRw9WbQBYqV64s999/v7pLgfOKyNXYskzkIgULFpSUlBSz1lvcAv/zzz/NntepUyd1q9jUt99+K9WqVVMpHbj1vXPnzgzLNxgMMnHiRClRooS61Y/W7I0bN6p1YF2mz0OqQFRUlAQEBEjFihXl7bffNs7H7VS0Et24ccOYSmK5PZY+/vhjKV++vBQoUECaN28uR48etWufoCX24YcfluDgYAkNDZVevXpJTEyM2XOSkpLk9ddfV9uJ7S1durRKvbCE91i3bl21LOyjXbt2mc1Ha+K9996r1lOsWDF1K/7w4cNWUzoyWxb2B4wYMcK4f7T9a5mGYY+TJ09Kly5d1HZhfa1bt1Y/rExh3w4ZMkQFE+XKlVPPxXly8eJF43NwbmGbypYtq/ZTZGSkPProo3LlyhWHtmfBggXi7+8vn376qc3nHD9+XH799Ve13RqcIz///LP88MMPxv1imnaD6Q0bNlTBddGiReW5555T55g924/9ix+cgGOoLd+WzLbFVmrMX3/9JY0aNVLbV69ePfV3YmKi2s6wsDB13lkL5Ow5h221xg4dOlQtF++3QoUK8tprr5k9Z968eVK1alU1H+fA5MmTzVK5tDQafIa0atVKXX94Pq57PA/XTfHixdUDyzZ9rfa+8VmCc1xLF1u9erXVc8/UN998o9aL1n48sO2Azxxtf2O6dv2OHj1anbd4H1iHtRZ/vHbJkiWSmpqa5b4jcjYGy0S5BB/6eFy7dk2+++47+frrr82CC3vt2bNHHn/8calSpYpqme7Tp49069ZNfQmZev/999UXIAI+PK9SpUrSv3//DMt78cUX5Y033lDLQTCB5+M26Ny5c9V8vOaZZ54xSyXBrWtb8OX67LPPqmAGt+YRLOOLzxICHtPgCctF4IIAY9myZfLRRx+pL+6OHTuavQ7vfdasWep2P7b3zTffNAuy4Pz58/LCCy+oYGv58uUqyHnsscfMfpycOXNGfenjh8cnn3yiAofGjRtLXFycQ8vCdgMCHW3/ILjKDpwb2AcIzLD/Fy9eLLGxsfLQQw/J6dOnzZ6LcwgPBMzvvvuuCgaxDZpp06apZeDOxfr162X27NlSsmTJDOdJZnAODRo0SN0Sxzlgy6ZNm8TX11cFWRqcI/iBgRZCbb9o599XX30lHTp0kNq1a6tzBOlIOEdN15HZ9mP/arnRCOa15duS2bZYg2OL6wHnMa5T/N25c2f1GlwHOA/w42TYsGFm6Tf2nsOW8J4QYCM4xHmGVC1cG6a549qxwI+n77//Xl2neM6rr76aYXlPPfWU+gGAfYt9hm3HdY5zCMfy+eefl+nTp8uXX36Z4X13795dvXccD7Tw4ly3/LGWGfyowWsBqVva/sZ0wGcVgv6XX35ZfVa0adNGnnzySfWeTeFaxPvH5x2RyxmIyKnGjRtnwKVm+ejevbshNTXV+LyffvpJTd+5c6fZ6zt27Gho0qSJ8W+8rkKFCmav/fTTT9VrsS7AvMjISMPTTz9ttqxnnnlGPQ/rgqNHjxq8vLwM8+bNM3veyJEjDSVKlDCkpaUZ30NwcLBd77dhw4aGBx980Gza2LFj1XoXLFhg83UPPfSQoXHjxob09HTjtP3796vt++GHH9Tf69evV8tZunSpzeX06dNHvWbfvn0Z9u2vv/5q9TXYXwkJCYaQkBCzfWHvsvD3m2++mWG5ltNxHB955BHj35b79d1331Xr+/fff43TYmNj1XOGDx9unFauXDlD6dKlDYmJiWbL8vPzMx4zrKdz584GR+D4YJsvXrxomDp1qiEgIMDw7bffZvm6Z5991lCzZs0M0y3fL+D4Yvt79uxpNn3t2rVm+zqr7bd1vdhibVusTdeu1zVr1hinff/998Zr1vScKVasmOGll15y6By25qOPPlLL37p1q9X5WFeRIkUMPXr0MJv+2muvGfz9/Q2XLl0yO35z5swxPmfv3r1q2n333Wf22vr16xs6deqU4X3js8R0vfisMV0vjt3zzz9vtqxVq1ap1x4/flz9jf/j7xUrVpg9b/PmzWr6unXrzKZjv957771m01JSUgw+Pj6G2bNn29xvRLmFLctEuQCtUWhhwuO3335TLYE//vhjtnp879ixQ92O9vHxMU6zbKFGq2l0dLRqvTNl2cKF27Naa63W8o1HixYtVIuqZWtmVtLS0lSKAlqjTGXVgp6QkCC///67aoHGMrTtQGpImTJljGkmaMHEreUePXpkujy0ptWsWTNDXir2i2b79u3SsmVLiYiIUK2iWO7169czpGLYsyy9IJUBaR+4Na0JDw9X24nzxlSTJk3UbWzT7ULLoHbLH62va9asUa2P2H+OVF4ZM2aMTJkyRbX8WZ5D1uBcQyqFPbB/kWqCFkbTcw7vB7n9WhpSdrff9PzJ7i18bAfuiGhwHgKuCw2uP9yt0a4Re89ha3Be45gj7cOagwcPqlZWyzs0aAVOTk6WP/74w2w6zhfLbTd9P9p0a9e36bWL94gWdHzm6AF3CHA+oxXd9Bhhe3E3BftNg2sSFX5wbhG5GoNlolyAL9977rlHPXArGLf1kfqAW8j79u1zaFn48kCOralChQqpHEPT54BlAGP5OnwBowG0SJEi4ufnZ3xoX7aOBsvImcWXn+V6kCOZmfj4ePVFidvaptuBx6lTp4zbgZQE3M7NLD8V8CVrCjm3gBQKwDKR04l14pYwghwEM9hu7Tn2LktP2A/W9hWmWaaHZLVdCHiRTvPZZ5+p9AjkriP3/FaDd+aQJoEUiQceeMCu7cY6TQP3zGipBQjKTI8zfqzgeGjHOrvbjwDWdLlarqyjP261/Qnav63tc21/23sOW4PzGj/KbMGywfLc0P7O7NywZ9s12FbkY1uuQ6+AFcce22q5f5Degs8Ny/XgnLp586Yu6ybKCVbDIHIRrfVw//79qjVRC3bRUmT5RWkaHCJYtOwwdPXqVbMvPi0/0LTDF1i+Dq08WDZaLU2DAw06BzkCwTlahCzXc+HChUxfhy9ybAc6/qAlyxKCeUArML5QETBlFTBnBq36aEVGbqUWRODL2jLoyG04HocOHcowHfsP8xyBQAOtsnigg+X8+fPVv9Exsnfv3pm+FrnQyHPFHQd03kJAk9V22xuUau8DOcjo4GdJCxqzu/3I5zXNy84sCNWTveewNTiv//nnnyz3ma3rytFzwxbcmcDnjWnAjHVonyeAzylrn1H2wHbiMwJ3DKyx/JGNTo/YN0SuxpZlIhfRWpS1L1H0gocDBw6YtcTs3r3b7HVoZUNAYHrLEi2BprAstMSh85opBD6mtFuzaNnSWr5NH6jYAQik7ekYhtu2uH2OjkWmLLfPEioH4BY03ru17UAPfO02OG53o4NVTqC1CoGNaRCIZWb3tj2Wo0dLM1py0ZnKNGBGIIJ0GXtbea1BRy10tkKwYnp+2aJVUMDtd5SDMz3XbD0fFTEsWWu9RBUXnJ///fef1WNtLbi1tv22WvjRIm66PO151rZFT/aew9bgvMbrbKU7YP8iyFyxYoXZdJyzeF+mHStzyvTaxXHHZ4bpjxocO8tzCOkVpmwdG7xP/IDHfGv7yPQHO56Ha93RH+xEzsCWZaJcgHxL5MgCWmWQ14uyT8gzRaUD7UsIX0q41Yze9GihnTFjhvq3KVQHQLkstF4NHjxYBR0oT2aahoGgFaWhXnrpJXUbFZUpfvrpJ2OOMtJCtLxF9IxHSx164WP9aF1CXimerwXXaAVHIIlca/RSR9qHrS8x3D5HbnS/fv1UbjHe6+eff57lPkJVC+QyIg8Tr0PrFvKCN2zYoJaFKgP4sm3Xrp2qhHHs2DG1vWgNRjCO6gP2wnoAyx04cKBq3UcpOctb1fbC/sEPkwcffFAFTdg32g8NR2B7ULbvkUceUecHjilyh3Eu4Fg6AudH/fr1jSXv8AMLgbf23rOCoBNBEJ6P6giooqCdN5aQWoQyhThe2o8+bb8gjQLrRuskAmE8UM0EJdVQxQTvFduHPGZUN0FQjPMyq+3Hc3Ceo8UZ+wcPBFy22NoWPdlzDluD6w8VO7Avxo0bp+40nT17Vn755RdVUQPvc+zYsSp9C62vuAbweYLPB5wXerW+IljFeYcgF+XfsE1IHzH9kY3+Byifh88pfBagldiyEgl+qONa+uKLL9RycJegTp06Kr0L/S1QAQNVPDAN5wCuP9w9QFUajZa7npMfiUS6ybWuhEQeyrIahq+vr+phPnjwYMOFCxfMnovqFM2aNVPVDypVqmT44osvMlTDgJUrVxqioqJUtQL0at++fbshNDTUWA0D0CN//Pjxqsd+gQIFDB06dDAsW7ZMbcOePXvMnvf+++8batWqpXrWh4eHGxo1amSYNWuWWc90bG/x4sVVz37L7bE0d+5cQ5kyZQyBgYHquTt27MiyGgagskG7du3UewkKCjJUqVLFMGjQIMPp06eNz7l586Zh1KhRhrJly6rqD6gKYVr1AxUsLCszxMfHZ1j/okWLDBUrVlTbiEoBf/zxR4ae/vYuC5Ux6tWrp7bZtNqIo9Uw4MSJE6oKRMGCBdVxa9mypeGff/4xe449FQn+97//Ge655x61L7EObF9mVUQsq2Fotm3bpqqE9O/f36zKg6mkpCRDRESEqupg6syZM+p4Fi5c2Kxai1bZBPsD24YH9vPLL79suHz5st3bj/MMxxDXVFZfZ7a2xZ5jYqu6g7UKG/acw9bExcUZnnvuOVWFBtch3teYMWPMnvPhhx+q5eG8x/k/adIkY/UTW8fPVrUWy3Nbe9/4LMFnCrahatWqGaqh4LPglVdeUZ8FeI8DBw5Ux8X03NPOx+rVq6vPKNN5OFcmTJig3gfWUbRoUfWZh+vR1NChQzNU1SFyFS/8R7/Qm4jcGVqn0IKKtIu8NtIauTfUzUVFg82bN7t6UygbkA+OO1TI5Xc13MXCYDSoBY2a0USuxjQMonwKeYUY1AK3SnF7FYOA4MsQt1AZKJPeXnnlFZVb/Pfff8tdd93l6s2hPAwj+mE0QaTqELkDBstE+RRKcSGX8MMPP1Qjw5UqVUrlJZuOmkekF+QBY7hlywosRI5CbryWi07kDpiGQURERERkA0vHERERERHZwGCZiIiIiMgGBstERERERDYwWCYiIiIisoHBMhERERGRDQyWiYiIiIhsYLBMRERERGQDg2UiIiIiIhsYLBMRERER2cBgmYiIiIjIBgbLREREREQ2MFgmIiIiIrKBwTIRERERkQ0MlomIiIiIbGCwTERERERkA4NlIiIiIiKx7v9/pYzNsmDVwgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Figure 1 : pass@k vs k. Si facile sature vite et difficile monte avec k,\n",
+      "c'est le resultat central de Snell : le gain du scaling depend du regime.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Figure 1 : courbes de scaling pass@k par bucket (le coeur de Snell 2024).\n",
+    "import matplotlib\n",
+    "matplotlib.use(\"Agg\")           # PDF-safe ; on affiche via display ci-dessous\n",
+    "import matplotlib.pyplot as plt\n",
+    "from IPython.display import display, Image\n",
+    "import io\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6.5, 4.2))\n",
+    "couleurs = {\"facile\": \"#2ca02c\", \"moyen\": \"#1f77b4\", \"difficile\": \"#d62728\"}\n",
+    "for b in PROBLEMES:\n",
+    "    ys = [agg[b][k] for k in K_LIST]\n",
+    "    ax.plot(K_LIST, ys, \"-o\", label=b, color=couleurs[b], linewidth=2, markersize=7)\n",
+    "ax.set_xlabel(\"Budget d'echantillons k (test-time compute)\")\n",
+    "ax.set_ylabel(\"pass@k (taux de succes estime)\")\n",
+    "ax.set_title(\"Scaling du test-time compute (BoN) par difficulte\")\n",
+    "ax.set_ylim(-0.05, 1.08); ax.set_xticks(K_LIST)\n",
+    "ax.grid(True, alpha=0.3); ax.legend(title=\"difficulte\")\n",
+    "buf = io.BytesIO(); fig.tight_layout(); fig.savefig(buf, format=\"png\", dpi=110); plt.close(fig)\n",
+    "buf.seek(0)\n",
+    "display(Image(data=buf.read()))\n",
+    "print(\"Figure 1 : pass@k vs k. Si facile sature vite et difficile monte avec k,\")\n",
+    "print(\"c'est le resultat central de Snell : le gain du scaling depend du regime.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4baf4295",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005881,
+     "end_time": "2026-06-15T21:25:35.753826",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:35.747945",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Compute-optimal — parallele (BoN) vs sequentiel (Reflexion)\n",
+    "\n",
+    "A **budget de calcul egal** (meme nombre d'appels), on compare deux strategies :\n",
+    "- **BoN (parallele)** : K echantillons independants, succes si l'un passe (pass@K).\n",
+    "- **Reflexion (sequentiel)** : on genere, on verifie, on renvoie le diagnostic a l'LLM qui\n",
+    "  reessaie, jusqu'a K tours. Succes si un tour passe.\n",
+    "\n",
+    "Snell : le sequentiel est compute-optimal sur les problemes **difficiles** (chaque essai\n",
+    "profite du feedback), le parallele sur les **faciles** (pas besoin de feedback, juste retry)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "00d9c1d1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:25:35.770379Z",
+     "iopub.status.busy": "2026-06-15T21:25:35.769797Z",
+     "iopub.status.idle": "2026-06-15T21:25:41.411679Z",
+     "shell.execute_reply": "2026-06-15T21:25:41.404623Z"
+    },
+    "papermill": {
+     "duration": 5.645035,
+     "end_time": "2026-06-15T21:25:41.405435",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:35.760400",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reflexion sequentielle : K=4 tours max (FAST_MODEL=meta-llama/llama-3.3-70b-instruct)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket facile    : taux Reflexion(K=4) = 1.00\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket moyen     : taux Reflexion(K=4) = 1.00\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket difficile : taux Reflexion(K=4) = 0.50\n",
+      "\n",
+      "=== Compute-optimal : BoN parallele vs Reflexion sequentielle (budget egal) ===\n",
+      "bucket      | BoN pass@4 | Reflexion K=4\n",
+      "----------------------------------------\n",
+      "facile      |     1.00      |     1.00      <- egal\n",
+      "moyen       |     1.00      |     1.00      <- egal\n",
+      "difficile   |     0.67      |     0.50      <- BoN\n"
+     ]
+    }
+   ],
+   "source": [
+    "def reflexion_sequentielle(enonce, attendu, K=4, model=FAST_MODEL):\n",
+    "    \"\"\"K tours : genere, verifie, renvoie le feedback si rate. Renvoie (succes, tours_utilises).\"\"\"\n",
+    "    verif = est_correct(attendu)\n",
+    "    feedback = \"\"\n",
+    "    for tour in range(1, K + 1):\n",
+    "        if not feedback:\n",
+    "            invite = enonce\n",
+    "        else:\n",
+    "            invite = (f\"{enonce}\\n\\nEssai precedent INCORRECT. Feedback : {feedback}\\n\"\n",
+    "                      f\"Reessaie correctement cette fois. Reponds uniquement par le nombre.\")\n",
+    "        rep = chat(invite, model=model, temperature=0.8, max_tokens=80)\n",
+    "        if verif(rep):\n",
+    "            return True, tour\n",
+    "        feedback = f\"ta reponse etait {extraire_nombre(rep)} (incorrect)\"\n",
+    "    return False, K\n",
+    "\n",
+    "K_SEQ = 4\n",
+    "# Reflexion sur tous les problemes, K_SEQ tours max\n",
+    "reflex = {b: [] for b in PROBLEMES}     # succes (0/1) par probleme\n",
+    "print(f\"Reflexion sequentielle : K={K_SEQ} tours max (FAST_MODEL={FAST_MODEL})\")\n",
+    "for bucket, probs in PROBLEMES.items():\n",
+    "    for enonce, attendu in probs:\n",
+    "        ok, tours = reflexion_sequentielle(enonce, attendu, K=K_SEQ)\n",
+    "        reflex[bucket].append(int(ok))\n",
+    "    taux = sum(reflex[bucket]) / len(reflex[bucket])\n",
+    "    print(f\"  bucket {bucket:9s} : taux Reflexion(K={K_SEQ}) = {taux:.2f}\")\n",
+    "\n",
+    "# BoN au MEME budget compute = K_SEQ echantillons -> pass@K_SEQ (deja calcule)\n",
+    "print(\"\\n=== Compute-optimal : BoN parallele vs Reflexion sequentielle (budget egal) ===\")\n",
+    "header = f\"bucket      | BoN pass@{K_SEQ} | Reflexion K={K_SEQ}\"\n",
+    "print(header); print(\"-\" * len(header))\n",
+    "compare = {}\n",
+    "for b in PROBLEMES:\n",
+    "    bon = agg[b][K_SEQ]\n",
+    "    ref = sum(reflex[b]) / len(reflex[b])\n",
+    "    compare[b] = (bon, ref)\n",
+    "    gagnant = \"BoN\" if bon > ref else (\"Reflexion\" if ref > bon else \"egal\")\n",
+    "    print(f\"{b:11s} |     {bon:.2f}      |     {ref:.2f}      <- {gagnant}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9ee963ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:25:41.448565Z",
+     "iopub.status.busy": "2026-06-15T21:25:41.448012Z",
+     "iopub.status.idle": "2026-06-15T21:25:41.634327Z",
+     "shell.execute_reply": "2026-06-15T21:25:41.633047Z"
+    },
+    "papermill": {
+     "duration": 0.195588,
+     "end_time": "2026-06-15T21:25:41.632431",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.436843",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAssAAAHOCAYAAABuLUT1AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAQ6wAAEOsBUJTofAAAW/FJREFUeJzt3QncTPX7//HLvmVfsktRlmiXtCEUqZSitFAhqSSiokIibVqUpIUWqRQpki3a9+VbRL6pKEt2Kjvzf7w/3/+Z39xzz7ln7vuee+6Z+349H49J95mZc86cOefMda5zfT6fAoFAIGAAAAAA0imYfhIAAAAAIVgGAAAAfBAsAwAAAD4IlgEAAAAfBMsAAACAD4JlAAAAwAfBMgAAAOCDYBkAAADwQbAMAAAA+CBYBgAAAHwQLAMAAAA+CJYBAAAAHwTLAAAAgA+CZQAAAMAHwTIAAADgg2AZAAAA8EGwDAAAAPggWAbysR49eliBAgVyezVs8uTJbj0WL16c26uSZyXLd43EOeyww6xly5a5vRpuv9P+lyi///67W+bw4cMznCYHDx500w4//HArXLhwmmNk0aJF1rx5cytdurSbrvOUzlHe/+c0rZeWpXVH7iJYRlR79uyxp59+2tq0aWOVK1e2IkWKWIUKFez000+3Bx54wLZu3Wp5lU5SOmF9//33lqoeffTRhJzYU12itpOWoWUhteg88NZbb+X2aiDOXnjhBRsxYoS1atXKnnvuOXvppZfcdP2uXXTRRfbvv//aww8/7KafccYZub267rdI+yIBdGIVTvDykGJWr15t5513nv3www922mmn2S233GLVqlWzbdu22aeffmp33XWXvfnmm/bFF19YXqQTkk6kytAce+yxlooUmGn9I2V2nnnmGZswYUKurFcqbad4B8var/r372+JxHedPToPdO/e3Tp16pTbq4IsqFOnju3atctlj0PNnz/fypYta88++2yarPJXX33lfucUQCto9ugcofkoaZRbwbL2Rd0x0LogMQiWkWFGuWPHjvbTTz/ZlClTrFu3bmmeV+D8559/2hNPPJFr64js0Qk/t076qc77wQz/8U1WfNfIzxQIFy9ePN309evXW7ly5dKVKGm66C5qqIIFC0acD/K4AOBj/PjxAe0iAwcOzNT7li1bFujatWugSpUqgaJFiwbq1q3r5rF9+/Y0r5s0aZKb/4IFCwKjRo1yrytWrFigadOmgXfffde9ZunSpYFzzz03UKZMmUDZsmUD3bt3D/z9999p5jNs2DA3H732lltuCVSvXj04n6lTp6ZbP71W8wm3aNEi95zWK3S+4Y8zzzwzzfveeOONwBlnnBEoXbp0oHjx4oFjjz028MwzzwQya86cOYGWLVsG53PMMccEnnjiicDBgwfTvE7rrvXYtGlT4Oqrrw5UqlTJvb558+ZuW3p+++23iOuvh54LnVek+W/evDlw7bXXBipXrhwoVapUoG3btoEVK1a418ycOTNw4oknBkqUKOG29+jRo9N9ni+++MKt35FHHhkoWbKke+g9zz//fLrXevuCvoNY97Fffvklptdu2bIlcOuttwbq1avntlO5cuUCRx99dODmm2+OeTvpO69Tp07g999/d/t2xYoV0zyvY6Vdu3aBGjVqBIoUKeK22UUXXRT48ccf06yL33JCP/f69esDN954o1ue5qXj6PLLLw8uK9TatWsDV1xxRaBChQpu+5522mmBDz74IMPvNVxmlufn559/Dpx//vlu39Xj7LPPdp/d226h5s6dG7j00ksDhx9+uPs+9PrTTz898Pbbb0ect/ajVq1auc+n7+6SSy4JrFq1ys03/Fh89dVXAxdccEGgdu3a7hxQvnx5ty4fffRRuvl667Zu3brgNtT6aF2++uqrdOeFSI9Q3377baBz587uu9d21PnstttuC/z7778xbcOffvrJbZeaNWu686bmc8opp6Q7l+h8MHHixMBJJ50UPK70uhkzZqSbZ6RtlJVzjc7d2keqVq3q1u24444LvPfee4FYRTrnZua7ysgrr7zizvWah85F+g3Qb4GWqXO4xzvOvWneOSf84X1mv+87/HfCo22naS1atHDbVefGo446KnDTTTcF9uzZk+F7Q39vQo+78Gl+6xa6bTOzfyB2qZESQa54/fXX3b99+vTJ1C0i1XXt37/f+vbt6xpNfPzxx67ma+HChfbJJ59YyZIl07znjjvucFns66+/3goVKmSPPfaYXXDBBfbGG2/Ytddea126dHGlIJ999pmrLytWrJiroQ531VVX6WxmAwYMcPPT7e7LLrvM/vnnH+vZs2emP79uve3bt89Gjx5tvXv3djXacuihhwZfM2zYMLvnnntcvZv+v0SJEjZ37lzr1auX/fLLLzZmzJiYlqVbfXpP7dq1bdCgQXbIIYe4z3/jjTfaf/7zH5s4cWK695x99tlWpkwZVwqzZcsWt03OOecce+edd9y/qi9XnZ3uAFSqVMmGDh0afK+ei0bz0GfV51q7dq2NHTvW2rVrZyNHjrSBAwe6/eLqq6+2V1991YYMGeJuCWp7e2bMmGFLliyxiy++2N0C3b59u9unrrnmGtu4caMNHjzYsqphw4ZunrHU7Wn/UUMdfYcqpdm7d6+tXLnSFixYENwWsWwn7UfaB0466SR3G/Tvv/9235Oodv/kk0+2G264wc3jv//9r7utq1u83333nR1xxBHudVrOqFGjbNOmTfbII4+k+Tzyxx9/WIsWLdyytO8feeSRtmbNGnvqqads3rx59vXXX7t9RLQ9tT6//vqr26YnnHCCLV++3M4999zg8qLJzPL8rFq1KjgP7RNHHXWUu4V95plnpsvKiY7Lv/76y6644gqrWbOm2xd0XJ9//vluX+ratWvwtZqPbjcXLVrUbr75Zvd6nUc0b9WShtNdrvLly7vjXeVi+nw6tnR8fvDBB249Q2ke2obadtqvtV76Xtq3b++2qxp26bvR93bllVe612o/Cvfee++58oxatWrZTTfd5I4bHbc6ZnTO0/6X0R2IzZs3u3VUY7PrrrvO6tat62pmf/zxR7feoecvHXMvvviiO0defvnlbtr06dPtwgsvdN9btPN1Vs81yr7qXL1z505XsqTvS/t5tP3DT2a/q0hUVqTfjfr169vdd9/t9hPdBf3www+jvle/U5GORx07ap/z0UcfuW2hc5t3fGZE5Vv6Xo477ji3XatUqeLOM/pu9Buhdcsu7Rv6/Qtfr9DjPbv7B3xkIrBGPqPsma6QM0NZmQIFCgQ+/vjjNNNHjBjhroBHjhwZnOZd2SursXv37uD07777zk3XfF577bU081EmQlmb0Oyyd/V9wgknpJnPtm3bXNZCnyE0qx1rZtlvWmgmSevYr1+/dM8pC1OwYMHAypUro24zrechhxwSqFatWmDjxo3B6fv27XPZXC0/NNviZRfOO++8wIEDB4LTV69e7eajjF3odL/sUui8Ik277rrr0kx/5JFH3HQtIzT7oW1+6KGHuuxFqH/++Sfd8rRe2kd0l2Dv3r1ZzizrteEZS79tq9f26dMn6msz2k6arvkoUxhJpM+6ZMkSt6/27ds33bz81r1Tp04uwxa+32h7a7v36NEjOG3IkCFunZ588sk0r50+fXrEzGek7zozy/PTrVs3N9/Zs2enmT527NiI31OkbaXsa/369QONGjVKM11ZukKFCgV++OGHNNOVrYt0lyfSvJU51rmsQ4cOEb/T8Lsiuhul6U8//XSa6X7njV27drmMa7NmzdKcf7y7Tnrf5MmTAxnRnRq9TtnWjLz11lvuddq24XQ+0B24HTt2+O7TWT3X9O7dO82yPvvsMzf9jjvuCMQi0rbLzHcVifdZdI7X/3t27tzp7u5FyyxHOx79zkmRfhOmTZvmpulukrZlKGV6vYx9djPLGa1XVvYPxI7eMOBLmStlLmOlDJGuxtu2bWunnnpqmuduvfVWK1WqlGsMGE7ZOF0te5T903KVbVBWMJQySsr2RsooKtsZOh812tC8lQFUhi/elMHQ74AycspMhD6UdVGWyMteZkQZPGXllJFSVtKjTNSdd97p/j/SdlOWR/VzHmW1lP1SRkzZzOzS9gzf9qLPFtqwRNtcWdUVK1akeb2+79D6XmXPlAFXxlr71s8//5zlddN2jyWrrEy/6gvVAFXbJbtuu+22iNO9z6r12rFjh9sHlF1UljXWxq/aJm+//bZ16NDB7f+h+5Oyf+rCSnctQjP3yswpSxhKGSQtN97Li0T7uOZx9NFHu/mE0p0lZWbDhe4Xyuxqv1C2snXr1q59hI5X2bBhg2tErCxvkyZN0u37kYTOW/PRvHUcaf+M9D3o+NEdhVA6f0n4/uxHx7jqW5VZ1DJDt6Oyl7qTFm07Kmsr7777rmtU5keZUO3Tyr6Hn3OU2da+pztw8T7X6PwdSvuG9pFYt1E8viu/z6KMuM71Hm2f8PXNaS+//LL7V3dQw+8gqBY6UV02Znf/gD/KMOBLJyDvhysWXjAS/sMm+sHQrSLdlgqnUo1wCgIU/EWaLjqxhmvUqJHvNJVExNuyZcvcv8ccc4zva3Rb1wtMFDCG0i1q3ZrLaLt50yJtt2ifV7eWsyP8e/G2vd/3Ff6d6AStW6PqbmvdunXp3qPAOadp+z7++OMuOND+pzID3UpXYKfblCr7iZVKMrxtEE63fXWrVcFd+PesW+qxUOCh4FMXYXpEEnpxpP1G+0ekRnsNGjSIejGS2eVFooBWAYuWF04XUdpXwoM/XeSodEiBYaR9QOUHCrK94yLSvHUhHRogedRrj/a5999/P925K1LAUr169XSNtSpWrOh7jsnoPKCLAz0yOg/4UVCtUprnn3/eXnnlFTv++ONd70MqYTrllFPSLEv7V40aNXznldGysnquiXTMazvFuo0iyex3Fc5bz0jnwcaNG1si6VjSuSG3e6fI7v4BfwTL8KWTpzpgV+BVr169HFuOX8CSUSDzvzt78aU668xQoCGzZs1Kk9GO9COjekvVZYZSHWMyDBgQz+8l9PtRnaNqLhWoqs5XPyZ6r4Ik1Qd62y+nKfOqbPicOXNcUKtMoGojmzVr5mojY23ZHl5r7/nmm2/srLPOct+16h/1r16rH3x975FqayPxtofupoRni3NCopcnCqwVGOriUdumadOmLqutoFyB4tSpU7O8X6hnHgWYyngq86wgW9lLzfu+++5zQVlOnGO89dV3r30qEr+LrFDaJ1Xrqv1U7Ty0PVTzrONHF3zesnSRoBpjPzkRKPptp6yeh7PyXeUFGV0EZPb3J5Lc2j/yA4Jl+LrkkktcsKzGBGrAFI0XGC5dujTdc7raVVYjJ4Nu3cINz/JqmoQuVxndSBmtSLfpMzq5KUuphj3KcikTlBE1ZlODplDeunqNM7Td1FVfKDWQC31N+GcLzTp508I/b26M2qYg+dtvv3UZRGVcQ+VESUw0KonQbXI99AOvxjFqfKkGZV6/ylndTsrK6odOQU54Bk6Zt/Bg3G85+s4ULOhYUQOjaLQsZde07PBbv2roF01mlxeJGjEp4Im0PDWk1DEV2shPQZDXkEuZ1PB+oEN52zLSvHWnQgF3KDViUoZSdzJU0hEqtNFmvOk8IPqes7odPQoa9VBpiL4X3QEZN26ca7SsrKWWpe2hRmReBjwzsnquibd4fFfeeuqcp0atoSL9BuUkfS/K6qqxqxoe+/GOhVh/fyKJ9puUnf0D/qhZhi/V4qoWUdmN1157LeJr1HL+9ttvD96m1i1u1ed9+eWXaV6nWi5llTp37pxj66tlqBcMj35Mn3zySfdj7tUhiuo5VbelOknP7t273Y9SOK+3g0gnN9UHizIjqqMOp+V766NbhfohDX142Satm5aj1uGhoyEeOHDAZask0nZTBiY0C6cgRDVruu2vk2XoZ0hEyUOkTFR45km9aqiXiOzSD0Kk28Xh9B2Hfs/ej413cRN6Gzmr28nvs6qlfqRbnlqOvufw1+vHTcHR7Nmz3V2HSELnpxpEzSe89wLVMsdSD57Z5UWiYFs91SjQ0h2DUDr2wm+v+20r3ZIPHx1PgbguBnURoouvUJF6mfGbt94ffj7KCr/9Q3dQdDH24IMPBvvmDaWLmWj7lZ4Pz6ir9tQrMfD2U/X44118R8rqRvu+snquibd4fFfqmUfZaH2W0AsnncsfeughSyQvEaJaaW3LcN7n1LlZZVPhbVnUq4iO21hk9JuU3f0D/sgsw5dKC/RDqgzEpZdeauPHj3eNbfTD4DUU0A9c6Mh2ul2o26zKFqhLH6/rONXhKZOqDElOUndDGjxFWa1Jkya5EQgVtIQ2VOzXr5/r4kwlEDq5KIhXVzuRaiD1Y6X6SX123VpXQxz9iOvznXjiiXbvvfe6hjG6qNA81bWV6jj14z5z5kyX9YhWx6blqism3QrXPJVx04+AbqWp2ylN1y3LcAo8FXSrQZdOnPqcykbpxyO01lSNcZTJU5ZXXQ15AU5oA5t4U3ZM20R3JLR9devvt99+c93bKSOU3eA91q7jVEuo/VGBpdZBF3TK4Ghb6XsNHZkrq9tJ89AFpY4NdSum/UT7vC4a9VnDb69qOSrdUcMk7a8KHLQ/ab/Seum7VlCj/VjlK1oPZawUjGr/8Ibk1g+iMuO6Ta8svp5Tdku373WsqRuwaDKzPD8KsvRZtR3ULZW+ewU82v+VvQ79/Gr4qzsxajyq70HHhtZZWWWVfamkJZTKdXSc6iJc9cBe13FqwKoGaqFZNm1/fVe6iPW68NN2UeZf8w4PuDNL35uCnPvvv991l6Zl67yo71sXqaqB136jrru0DXSh4HUdpuA+o5Ehdf7RPqT9VPuM5qltoQtLfZfeOVaBrM4H2l76fvX6qlWrunOBXq/vLNKFe3bPNfEWj+9Kn0XfhY4j7bfa7mqjoMZ2mWmLEA+qLVc3bVp/leLoWNDxrHPetGnTXBeI+u1QoKttrvOgGuHpuPd+o1SSFMuFgneM6rjTBY+2o4JwNYzM7v6BDGSi5wzkU+oO6amnnnIDA6hbn8KFC7vuptQF2EMPPZSm2x6vc/0uXbq4wTLUdZa65RkwYEC612XUBY5fN16R3hM+KIm6RVLH+U2aNAlMmTIl4mdSN2gaNEDrd8QRRwQefPDBwMKFCyN266MusdQJvzq9j9RdlTrnV1dH2jaanzrG17Z6+OGHXbdSsdJALJq3ukPyBlUZN25choOSqGsvbWe9/uSTT3YDPoT766+/XJdG+s7U1V2sg5KE8+t6ye89GjhCgyxokAtv4IPnnnsu4neYU13HaRtpn9D3p8+v7aT3abtpYJNYt1NG3b2JBtTQgCsaAEDvVzdN2h8jvU/dpF1zzTVuu6h7wfDPrUFUbr/99kCDBg3c+qrrQ/1/r169Ap9//nmaef35559uABEN1uENSvLhhx+6z6FBEWL5XjOzPD/alh07dnT7rh7eoCTHH398oGHDhmleq+k6XrSdtM4aTEddp0XqJsvrpkwDaOjzeIOSqJtEDSLSvn37NK9Vl5UaIEhdZOlztG7d2k2L9Nkz+k4jdXWmAXnUvZrmG6lrPm0DvUeDiug8oONS3VmqezWtb0bUXab2SXWfp+2nQYD0HQwdOtR9P5EG4tA2UReMOtfVqlXLbQudp2M5j2b2XJPZrhZj2Z6Z+a4y8vLLL7tzvbaDzv2xDkoSz67jRNtO3Q16g4F432H//v2Dg5J4XeapK0tvMCmdN955552Yu44TdUWo40r7WaRtG+v+gdgV0H8yCqaBZDd8+HA3SISu4nO7NXIiKEOlxoIcuvCjLLpu63s9NeQGZZSVMfRKKeJJ3VQqc6dMtgZaAICcRM0yAKSo8HpsUe2jyn9US5ub66E2AKolze56hHfFJyp/kkR+RgD5FzXLAJCiVFOtNgSqP1UbA9Ulqv5V0/wGUMkJXr/Aqq9VRls126qDVQ1vdrqlU3Za/a2rPYDaD6gbPg1GoR5VNCyyugQEgJxGsAwAKRwsKzhWmYMaUqo0QY2mVJakhnSJogZNGsnv9ddfd70RaFAENaTVoBPZaUiqhlpqpKQGhGqwq+BZpVZqVKvu/6INmgIA8UDNMgAAAOCDy3IAAADAB8EyAAAA4INgGQAAAPBBA78o1FhFowlp5K/ChdlcAAAAqUINg9U3u0aHLF68eJbmQfQXhQJlDV8JAACA1KThxDVceFYQLEehjLK3kRPZFRMAAACyZ926dS7p6cVzWUGwHIVXeqFAuWbNmrm9OgAAAMik7JTS0sAPAAAA8EGwDAAAAPggWAYAAAB8ECwDAAAAPmjgBwDIVYFAwDZt2uT6tT9w4EBurw6AFFCoUCHXb3KlSpWsQIECObosgmUAQK4GymvWrLG///7bihYt6n4AASCavXv32j///GN79uyxGjVq5GjATLAMAMg1yigrUK5SpYpVrFgxt1cHQArZvHmzbdiwwZ1HstOPcjTULAMAco1KL5RRJlAGkFk6b+j8ofNITiJYBgDkGtUoU3oBIKt0/sjptg4EywAAAIAPgmUAAADAB8EyAADZNHz4cNca33uoS6uGDRvaAw88YAcPHsz0/Hr06OHmc9VVV6V7rlOnTtayZUtLFfosRx99dPDvyZMnu8+mRlnZmU92/fjjj1a6dGnbuHGj5WXqMaJmzZpum3/99dfB6WpYW6FCBfvkk09ydf1SAb1hAACS0/CyubTc7Vl6W4kSJez99993/79r1y5btGiR3X777S5Y1r9Z8corr9iwYcPsiCOOyNL74e/OO+90AXhO9qIQL7Nnz7Znn33WBbZbtmyxqlWr2plnnmn9+vWzk08+OcP3jhw50vbv359uui4UbrrpJhsyZIh98MEHObj2qY/MMgAAcVCwYEFr3ry5e7Rq1cruueceu+CCC2z69OlZml/9+vWtWrVqNnr0aEs2uhhIZb/++qu98847ds0111iyZ4V1J0FB/VFHHWWTJk2yDz/80B599FErUqSIC5gV9PtZvny5PfnkkzZixIiIz+vza37/+c9/cvBTpD6CZQAAcoiyd/v27UszTZlBBSkaeUzZ6BYtWriAJZy6xLrtttvspZdeslWrVmW6LOSQQw6xr776ypo1axYsC5k1a1a6jGXbtm1dP9dlypRxWcr33nsvzWu8sonPPvvMvbZUqVI2aNAg99zDDz9sJ510kpUtW9bNo2PHjrZixQrLLA0soQxnnTp1rFixYm5dlVWP5s8//7QrrrgiuC3POOMM++abb6K+78UXX7TDDz/cjjvuuOC033//3X3OF154wa699lr3mVSmMGDAgDSZ2XXr1rnvT+/XMnVRo3XXZwj1/PPPW+PGjd1r1MXZaaed5r6PWJ9XDw8KlP/991+3TceMGWPnnnuu218uvvhi973oO3nuued8L6iUOe7Tp48LtCPR9tb+oXnBH8EyAABxoqBKD9WDvv322/bmm2+6wCY0AGrfvr3Lat5///02bdo0F9QqCI0U5PXs2dMFUlnJLitI79q1q3Xv3t1lt+vVq2cXXnihq9X1/Pbbb3beeee5gFzreuqpp1qHDh1s8eLF6ebXrVs3a926tQu4r7zyymCweuONN9rMmTNdmYBKThTM6YIgM7p06WJPP/20DRw40M3/nHPOcUHwnDlzfN+zdetWF2B+//33Nm7cOLf+CuS1jhqoIiMLFixw6xmJAl99jtdff91dFGjeodlb1VoriB47dqy7sBg8eLALsBWUenTxo4Bb2/Ldd991wflZZ51l27Zti+l5UUZYn1HPly9fPt16ah2PPfZYt73uvfde+/nnn9M8/8Ybb7jv+u67785wW2g7zJ8/P8PX5HfULAMAEAfKAOrWeCgFq6H1ysrkfvnlly7IOvvss900/atAVgGxAr5QyggrYLvjjjvsrrvucg21MjMcsII8r9RAy1EWVMuZOnWqm6ZANzT4UvnI0qVLbeLEiekaESoYVKY71COPPJLmQsDLUitQ6927d0zrqdpuXVjMnTvX2rVr56ZpPsrgql5bFxeRqBRBwaW2p5YpCjiPPPJIe+ihh1zjSr8h1tXQTVnbSFQfrnIHb5up5EQZdH12Ba1NmjRx8/foAkNBui5KFOCWLFnSrZMC6gcffDD4OmWFPdGe1zrqYkr7g7dP6XtT4K7SDAXaf/31l1s/lWhccskl7mLFm9/OnTtdRlzv0R2DjBxzzDH22GOPuQs83QlBemSWAQCIA91O1210PT7++GMXgCgo7tWrV/A1H330kQtevEBZFAxddNFF7j2RKEhVSYBuw2eWMsmhgzcoQPziiy+C05QZVpBXo0YNK1y4sFuXefPmRSylCA3mPJ9//rkLbJX91vsVKCqYy0wphpanwFEZYS8zr4fm+9133/kOOKH3KbjXe7336DOqjje0nCGcsrUqmfBr2Be6zUR3BhR8ehl5BbIK1Bs1auS+c22zyy+/3C1ftdBy/PHHu+y6AlllbfX+UNGeVw2xtqXq30UXN6o71oXTW2+95UpGQmvhlWEP3X+UaT700EPt6quvtmhUwqLPpOAbkZFZBgAgTg38TjzxxDQZRwVQKi1Qlk/dnilQ87KgoRTY+JUuKGjS+xUsDR06NOb1URAXfvtey1HG1sskn3/++bZ9+3bXGFHZbWVIddt+9erVEdcxlF6jTLA+s0ooqlev7uqsFVRnZvhhlTXos4dn5T1a30gZdb1PwXqk92XUe4i3bqqNjiT8+/E+t7fdFCjfeuutrvxCwbq2sYLzG264IThvBf4qbdEFky6MdIdAQbfe610YZPT8ypUrXT2zx6uj1n4gp5xySpptUqtWrWBXfKpvVyZ8xowZ7rsVXcB4/+qh0h+Ptx1SvdFmTiJYBgAgh6ihmqi0QcGyAqFI9bTK6uk5PwrEdIvdr7TAr2ZZwXlowKzlqIcN+eWXX1zmVplK9drh8Qua1PgtlLLmCryU4SxXrpybpouDzNYr63Mry6va3EgiXVx471Nts7pGC+cXCHvvk9D64FDh34+XcfW2m+rMdZFx3333BV/z008/pZuPaq71UBCrmu5bbrnFBfZqkBfteWXTQz+DAuDQshFdQKmkxrN+/XqXIfbq0FWCE+lOgIJ7NeLURYbH2w66O4DICJYBAMghS5Yscf96gYxulyvoVQmBV5+rAFNZQD3nR7Wk/fv3dwGaGnUpgxsLzderWVYApsDY65fXC4pD56WgTH35qu43Gr1fAXRoZleN4iL16ZuRNm3auIsArUfTpk0z9b6XX37ZXZAoIx4rZXFr167tgkq/babA1aP6awWnqlX2Pnf49p8yZYrv8vTdKyusi4Fly5bF9LzKYrySDu+CITTbr7sCa9asCf792muvuUBYtH+oDjyUGkHqM02YMMH1XhJKJR0q81HfzYiMYBkAgDhQAONl7JTZU+8Wqh1Vbau6NBNl+9RVlzKKqkHWLX412tItfvXCkBENQKHb6+ouTHW50Sig0/JVGlC3bl0bP368/fHHHy5glgYNGrhb+WqAqEBaWWI1qFOgFguVEojqYq+77jqXPdf6eVnmWKk2WT1yKEus0gYFzGosqfkp+62Ga5GoJEFBqrbFzTff7AJgjcanmmyVhIQGvOFUIuPXxZxKIPSZLr30Uvv222/dBYrm5WXotb4qn3jiiSfcRYUCdq1nKG3HzZs3u0aSCnRV76xMvFdGEe15BbTq3UIBsj6Xssr6LnWBpe2jcg0Fy8pK6z26Q6BSDdH29xvh8YQTTnD10qHU2FE9YqiMCJERLAMAEAfKOKqWVNTYTXWkCooVGHnZVzVAUwZRNa9qrKWgUMGLMs0KZDKi7J/6zVXQFAstUw3DVMKhYEwBs3pX8LK3us2vEgo9r94UtL7qPUOjEIYOi+xHmVb1z6s+ndW/sjKaysJqXpml9+niQQG9stv6rCpbyaiBmsoGdHGidVZPFQo+FXiqUVx4I71wqg9Wo7xIPUCMGjXKdZ2nz6HvS9tH0zyq6VZQ7nXJpnk9/vjjLuD3KNhVQKtM+44dO9xFib5vrwu6aM/rQkeN//S59B327dvXPv3002D2WP+qFEQXF7pYUFd0fuUq0Up11I1eaK8cSK9AQE0g4UsthXUC0dV4ZrrsAQBEp1vActhhh+X2quQpCmDVvZnXsAvpg0RlbNU921VXXRXcF3VBoZrk0L6xc4uCf11A6YLLu0BSbbIusNSAUXGJeuPwSnyyQl0Zqv9sZalDG/3lpXPIn3GI48i5AwCAfEVZd5WfqJwiWSlzrkFZVGqienbdBVCNuEpMVM+swUiUVc5o4JZoVDaj3lpSNVBOlKQPllUHpD4mdXtHt7V0WyYWSpjrlo6uHHXlpVtjoa0/AQBA/qXYQrXAXpdryUiNF1WPrJri66+/3jXCU2NDZZY1cIzq3P0GbYlGdx0UbGdU240UKcNQdyoaYUitd9XJuRpQeK2LM6JAWXVi+lf1WRpVR3U5ahGq8dxjRRkGAOQcyjCA2Cj+USyivpOVXc5O+UVe8jtlGOYK5vUBVfwf3oLTj1r+qvWqbi3oiknDX7766quub8XQISoBAABSgXqrqFOnjksAEignVtIHy1npykQtRtW6tEuXLsFpalmq4UT9Oj0HAAAAUi5Yzorly5cH+5AMr/1Rn4UM6QgAAIB828+yhvdU/5EapSeUOhRXibaeV6O/SJSR1sPjjQWvDtv1AADEj87JauGf5M1nACQxnT/8YrR4xG55MljOjrFjx9qIESMi9neY0VjzcfVK18QsJ8XN3jY0t1chJZzbN/bhY/McjqWkP5ZqHVvKajeobJvW/l+SIhmVq1Iyt1cBgE/Dxz179riBYiJR/JZdeTJYVgZZG04N/UKzy8ooK4PhDVkZiYaN7NmzZ5rMsoYmVX+HlStXtoT4e2lilpPidm8qlNurkBIStt8mI46lpD+WDuwuYHawgAX2F7Bkpq5LASRn2zbFen6/dYoHsytPHv1erbLGVT/mmGPS1DJ7/S77KVOmjHuE05CXeiREYF9ilpPqDib3j2uySNh+m4w4llLgWEqN41iJFgDJe3z6/dbF4zcwTzbwU+fdCng1ZGXo0JYa/aZDhw65um4AgLw5vLR+sL2H7kZq1LWs9sD022+/uW5PS5cu7eanMQJatmxpHTt2jPu6L1682C3j66+/jvu886Nt27a5/eGnn35K1x+wtrO6ws2MyZMnu/d5g6dkdT4ZueSSS2zQoEHBv7X+kUb1GzhwoMvkPvfcc3FZ7jfffOOC2fBlffLJJ657vNA2ZLkp6TPLO3fuDJ5sVq1a5Tact4No5Bml3XVC0XMa7U+Ujr/jjjvcl63nmzRpYuPHj3d1K7feemuufh4AQGym3Zc7wdsld5yYpffpruX777/v/n/t2rU2evRoN1bARx995JI4mXHXXXe5IY31e1e2bFk78sgjLadoDIPPPvvM9RiF+ATLavukEYcbNWoUnF6tWjW3nXPyu8yKb7/91t555x23v2Xktttus0ceecQmTJhg1157bVwa5WnQOcVpGk0w1KmnnmqNGzd2w3FHakeWaEkfLG/YsMFd8YTy/l60aJG70lZLx/3796f7UvVFaBASFX1ruOy5c+dmavQ+AABipYxb8+bNg39r5FmNHPbCCy9kOlhW2eDpp59uZ599tuU03YkNXW/kDHUSkIzb+bHHHnP7mUYF9HPnnXfaAw884BKPvXv3jstyJ02a5LLl11xzjT3++OPpnldArgSnll2kSBHLTUlfhqHhCxX0RnooUPZuIXnDHXp0i0LZZY3+p4Z+n3/+uZ1yyim59CkAAPlNjRo1XNZM/fuHUnaxdevWVqpUKZc17tatm0sMhd5i1+3pl156yf1/RkOBL1u2zC644AI3H83v3HPPtZUrVwaf79+/v2vUriF/Q29x69b3008/7VuGod9NNXhXAKW7tUo4zZgxI82ye/To4bKnev9xxx3nlq8G8Vr3aMaMGWP16tULNsxq06aNKz0JbZQ1ZMgQN2KdgkxlvV955ZV083nmmWfc9ilZsqS7y6zPoM+i0gWP/g4fvffRRx9NV4eujHDfvn1dBljLPOGEE2zevHlpXuOVwijjf9RRR7nyAX2X3jbX91e3bt1gYs8ry9F0v/IJratG5dO20D4zdOjQLHV3lpX5/Pvvv/bmm2/axRdf7Pua4cOH26hRo2zcuHF2/fXXWzxoW99+++0uU61B4yLp1KmTe10yDCaX9MEyAACpSLeWt2zZEgyevEBZAZeC29dee80mTpxoX331lQt4Q2/V169f37Wx0f+HB6ke3TZXxlrLUKCkYFJ3UhU0ej0A3HfffVa1alW7+uqrXZJJwVH37t1dJvG6667zXffLL7/cBdODBw+2t956y5UTdO7c2d5+++00r1u/fr3169fP1bu+/vrrLsi+8MILXTshPy+++KIrM1Hm8L333rNnn33WBeOh9akagVfLV43srFmz7JxzzrErrrjC5syZE3yNpivL2apVK7eN9LnD70THau/evda2bVs3TwWG+pz6zLr4+PHHH9O8VvXjDz74oAv4td1VAqp1874/tY8SleHo+9ND0/26q1UPXPo+VAqhu+LKsirQzYyszkfrpn1CZQ+RaFuMGDHCBbUqmQinfUp39qM9wilbrIuRjGrwdcdDpRjz58+33Jb0ZRgAAKQKLzBQzbICTTXQu/nmm4PPK5t24oknuoDKy2yqXY0ytMqgKUDWrXplSpVxzei2vYKYChUquGDC6yZVwbPKDdUAS1lS1VErONV0ZQaXLl3qulHNqIHWDz/84NZPtaleQK1gVZlRLfP8888PvlaB+gcffOCCGlF2WcHrF1984Ro4RvLll1+6DKju/nq8iwWvxFLBqkon27Vr56YpkFVXrsOGDbP27du7affee68rVdHtfFGgqGB95MiRlllTpkxxQfB//vOfYJ2x5vff//7XzU8XAh5lO7/77rtgV2W6KNLFiLL3NWvWdFl20QVPRt/f33//7T6P9hMF1t7nVKZVWX1dgKihaDTZmY8u1JQdj1SiqiBaQW3Pnj3dHYpIVGKkzx6N7hp4d0i0nbX/aRtGox7NtC/lNjLLAADEgYIL1VbqofIB3W5XKYVu13sN1lUCoeyn19ZGDzX4Um2zApfMUImAAlf1Ae3NSyUXCtZC53XSSSe5kgYFTcpkP/XUU76ZTlGDRAnP0nbt2tUFOPqcHpVpeIGyeIFmaNlHpAaFmo8CuY8//jhdFlqfSxcBKm8IzU4qANT7vBF1Ve6hLHaojMoJMqJl6qJF30X4MsO/F2XBQ/v0jeUzR/Lpp5+6QFvbOXSZKknZtWuXLVmyJMfnowsQ9ToRiS60zjjjDHfHQvttJGrAqu0T7eHVQysTfcMNN7gLOa+b34xo3byRlHMTmWUAAOJAwcWHH37oRhRTRlJZ5KuuusoFKwpOldFVkHfLLbe4Rzi1sckMNY5S7a0e4cLrQC+77DK75557XNBy0UUXZThfracCfgWsoQ499FAX7CizqgyylCtXLuJyleH1o1pnZUMVuOv2vkpSVBqisgZtQ30uZaz9GnUpePIuEKpUqZJuHbNCy1QgHmmZ4f30ZuUz+y3Tu3iIJNb9ITvz0Tr7jU6sBqvK8Lf8/3Xa2rd1QRFK+4i+v1gH9VHpkersFYBrP/LWQfS37pCEDiandVPAn9sIlgEAiAMFFyqxEDV0U0ZZPWIoSFU2V0GWSi+U5VXjpXB+GT4/ClRUU6ssXTiVf3gUvOtWujJ56mZVZQUZdcel+Srbq6A5dMTbv/76y61/eLCYle2k0hQ91qxZY6+++qq7sNDnVy2zlq/MrV/DLgXICmAVgHkNI0PXMZwCLtUkh9JnC//MKg2JV//BsfAuRlTyojsL4UJr3XNqPnqvF7RGokB47ty5rqZZZSnKMIfOL7NlGOrlRds+UqNV7WuqtdZFk0frFkspSk4jWAYAIAcocFZGVzW1qilVQzv1yqTMmupts0u32ZW1VtlFRqOUqcsv3QpXTxHqB1rdcen2uRfYh/NqjTWwV2g3Yfrb6/UiXtRrgxrxKdOo7eJ9Lq2zMrYKYP0ok6qGfaFZ+kgDdaiO2Ju3J7zRmJap4FyZ94y6UItFrJlm7QuqTVf5Rng5SWZkZz66oFOjUJXW+H2vVapUcdtLAbPKUlQ6o305tAwjGm+b6q6C15OZR40klXFW402NshxKdfJeGVNuIlgGACCHKFOqzKlKJZQxUy8KqsVV/e+ll14a7NZNwYgydOGBREaUHVY9sjJ+CmpVgqDeKdTgTg3fFKirsZ4CdWW3vYaEM2fOdOUhGowi9Ja3RwGqSjVUU6xb4ApWXn75ZVcbq/dmlxoN6nOr8Zv+VbZSDeu8DLkCMgVhalSoRmtaHwVzapyonifUe4aopwc1DNR207b0utsLpzpmbX9tK++zKKMdSttDvW9o++tiQrXLXkM+ZaXVq0isFEgq+z516lSXhVVmO1LQr9foe9Fn1D6gZeuiR72caDurSzcFwdFkZz4KgHXnQZ/Tr0GmKBOsDLNqmPW9aB9T1llZ38xkfjWf8Kyyuh7U+kba93WBp4up3EYDPwAAcoiCMwVyKsPYvn2765VCmTmvBwX1fqFAR8GM+h3ODL1ePUsoWFGgqaBZ5QwKLBWcKci78sorXZDoDWXs9UGsYFGv9aOAslevXi7AV0Cq7tOUtVUQm13eNlDXcQq81BOFapdDR4XTsvr06eMGwVDvF3pOjfA0cq9HjRvVY8fChQtdWYueV4Yy0gWL+rLWxYW6eFPjy9AeSkQBrbLuqs1Vd2nqhUPbVMFaRkGkX5mJ7iZ4Q5Zr+6t3lEgUCOq16gFEXfOpkZ5qufUev/6H4zkfXRToIiq0Sz4/Rx99tM2ePdvV42s75XQtsS7mlPXW58ltBQKq1ocvXaWpBkgF8rqVkxDDoxfLw+zJ9ZH7HkVaN0xobfkWx1LSH0uHn1HC6jatZBVKZ61hVqJUqVMmt1cBMVA2WNlqBY665Y/o1KWgRvFTEBw+UEtuGjRokLtb4A0h78cblM5v8J54xHFklgEAAPIpNf5UlliDmSSLHTt2uHIbjR6YDAiWAQAA8il116fSnPAeQ3LT6tWrXa8tqpFOBjTwAwAAeYIau1FdmnlqVJlMjj76aPdIFmSWAQAAAB8EywAAAIAPgmUAQK45sDfghi0GgKzQEPIZDcoTDwTLAIBcs3v7Qdu1c4/9u3tHbq8KgBSzefNm1zAx0uA68UQDPwBArtmwfK8VK7PT7KhN9m/Jv61w4eT8Wdr5+5bcXgUAYRllBcqlS5e2SpUqWU5KzrMSACBfUMcFf3y52/bsOGjFy+60QkWTZ1CEUA1bVMvtVQAQQiMTlilTxgXKOT2YCsEyACDXA+a/liVPH6+RtO8WeXQwAHkfNcsAAACAD4JlAAAAwAfBMgAAAOCDYBkAAADwQbAMAAAA+CBYBgAAAHwQLAMAAAA+CJYBAAAAHwTLAAAAgA+CZQAAAMAHwTIAAADgg2AZAAAA8EGwDAAAAPggWAYAAAB8ECwDAAAAPgiWAQAAAB8EywAAAIAPgmUAAADAB8EyAAAA4INgGQAAAPBBsAwAAAD4IFgGAAAAfBAsAwAAAD4IlgEAAAAfBMsAAACAD4JlAAAAwAfBMgAAAOCDYBkAAADwQbAMAAAA+CBYBgAAAHwQLAMAAAA+CJYBAAAAHwTLAAAAgA+CZQAAAMAHwTIAAADgg2AZAAAA8EGwDAAAAKRqsLx8+XJr27atlSpVyqpWrWqDBw+2vXv3Rn3f5s2brU+fPla7dm333qOPPtomTJiQkHUGAABA3lDYktjWrVutdevWVr9+fZs+fbqtWbPGBgwYYDt37rQnnngiw/decsklLtAePXq0C5jfffddu/76661QoULWq1evhH0GAAAApK6kDpaVCd6xY4fNmDHDKlSo4Kbt37/f+vbta0OGDLHq1atHfN/69ett0aJFNmnSJOvRo4ebpqD7q6++sldffZVgGQAAAKlfhjFnzhxr06ZNMFCWLl262MGDB23evHm+79u3b5/7t2zZsmmm6+9AIJCDawwAAIC8JKmDZZVRNGjQIM20cuXKWbVq1dxzfmrVqmXt2rVzJRg//fST/f333/b666+7APuGG25IwJoDAAAgL0j6mmUFx+HKly9vW7ZsyfC9qnHu2rWrNW7c2P2tWuVx48ZZ586dM3yfyj708Kxbt879e+DAAfdIiAJFErOcVFeQuwSxSNh+m4w4lmLDsRRVvj6OgHx+7CZ1sJxVKrW4+uqr7b///a+98sorLhM9f/5869+/vwu0L730Ut/3jh071kaMGBGxd41ixYpZQpT+X4CPjBXnxysmGzdutHyLYykmHEvR5evjCEhhit/ydLCswHb79u0RM86hdczhZs+ebdOmTbMffvjBmjRp4qa1bNnSNmzYYAMHDswwWFZvGz179kyTWW7WrJlVrFjRKleubAnx99LELCfF7d5UKLdXISUkbL9NRhxLMeFYii5fH0dACtuzZ0/eDpZVrxxem6zgWQFseC1zKNUpq+xCfSuHOu644+zZZ591Xc+VLFky4nvLlCnjHuE0Pz0SIvC/BoqI4mCB3F6DlJCw/TYZcSzFhmMpqnx9HAH5/NhN6gZ+7du3twULFti2bduC05QxLliwoGvA56dOnTquRkWZ5VDffPONValSxTdQBgAAAFImWNYIfKVLl7ZOnTq5nizUb/KgQYPc9NA+ls866yyrV69e8O8OHTq4gUguvvhie/nll23hwoV222232eTJk+2mm27KpU8DAACAVJP0NcsKdBXgKmBW4Kx64lGjRqV5nbLIGqzEo9fpfUOHDnVBsjLTdevWdY33brzxxlz4JAAAAEhFSR0sS8OGDV0pRkYWL16cbpoyza+99loOrhkAAADyuqQuwwAAAAByE8EyAAAA4INgGQAAAPBBsAwAAAD4IFgGAAAAfBAsAwAAAD4IlgEAAAAfBMsAAACAD4JlAAAAwAfBMgAAAOCDYBkAAADwQbAMAAAA+CBYBgAAAHwQLAMAAAA+CJYBAAAAHwTLAAAAgA+CZQAAAMAHwTIAAADgg2AZAAAA8EGwDAAAAPggWAYAAAB8ECwDAAAAuRUs79y503755RcLBAI5vSgAAAAgeYPlhx56yEaMGBH8+6OPPrIaNWrYUUcdZfXr17eVK1fGc3EAAABA6gTLzz77rNWsWTP494ABA6xx48Y2c+ZMq1Spkg0ZMiSeiwMAAAByVOF4zuyPP/6wevXquf9fs2aNffPNN/bBBx/Y6aefbvv377frr78+nosDAAAAUiezXKJECduxY4f7/4ULF9ohhxxiLVq0cH+XK1fOtm/fHs/FAQAAAKmTWW7WrJmNGTPGChYsaA8++KC1b9/eChUq5J5TvbLqlwEAAIB828Bv3bp1dt5559k///xjo0aNCj732muvBbPMAAAAQL7LLDdq1Mh+/fVX27x5s1WsWDHNcw8//LBVrVo1nosDAAAAUq+fZQXK6ld57dq1rmGfNGnSxCpXrpwTiwMAAABSI1ieO3euNW/e3IoXL261a9e2H374wU3v3bu3TZkyJd6LAwAAAFIjWJ46dap16NDB6tata+PHj7eDBw8GnzviiCNs0qRJ8VwcAAAAkDrB8siRI61///4uaO7Ro0ea5zQ4yZIlS+K5OAAAACB1gmU17lNmOZJSpUrRzzIAAADyb7Cs3i6WL18e8TnVLtepUyeeiwMAAABSJ1ju1q2bDR8+3I3e5ylQoIArv3jggQfsiiuuiOfiAAAAgNTpZ1mB8tKlS61t27bBfpY1it/GjRutY8eOdvvtt8dzcQAAAEDqBMtFixa1mTNn2qJFi2z+/Pm2adMmq1ChgrVp08Y9AAAAgHwbLHtatWrlHgAAIA8YXja31yD5DacTg7wqrjXLqlX260t58uTJLuMMAAAA5Mtg+c4777S//vor4nOqW9bzAAAAQL4MltW478QTT4z43PHHH++eBwAAAPJlsKxu4vwGHtm6dasdOHAgnosDAAAAUidYPvnkk+3JJ5+0QCCQZrr+Hj9+vHseAAAAyJe9YYwYMcL1gtG0aVPr0aOHVatWzdauXWsvvviirVixwhYvXhzPxQEAAACpEyyfcsoprkeMwYMH22233WYHDx60ggULBqc3b948nosDAAAAUquf5VNPPdU++eQT27Vrl6tTLleunJUsWTLeiwEAAABSc1ASKVGihHsAAAAAqSquDfyuueYa69q1a8TnLr30Uuvdu3c8FwcAAACkTrA8f/58u+iiiyI+17lzZ5s7d248FwcAAACkTrCsUfoqV64c8bmKFSv6ju4HAAAA5PlguUaNGvbFF19EfE7T1ZUcAAAAkC+D5csuu8xGjRplr7/+eprp06ZNs9GjR1u3bt3iuTgAAAAgdYLlu+++21q2bOka85UuXdqOPPJI96/+PvPMM23YsGHxXBwAAACQOl3HFS1a1GbNmuUa+r3//vu2efNmV6vcpk0bO+uss+K5KAAAACC1Msuetm3b2n333WcTJ050/2YnUF6+fLmbX6lSpaxq1apudMC9e/fG9N41a9ZY9+7dXaND9fncsGFDmzJlSpbXBQAAAPlLXDPLq1evjvqa2rVrxzw/jQDYunVrq1+/vk2fPt0FvwMGDLCdO3faE088keF7161b54bZPuqoo1zQXqZMGVu6dKnt2bMn5uUDAAAgf4trsHzYYYdZgQIFMnzNgQMHYp7fhAkTbMeOHTZjxgyrUKGCm7Z//37r27evDRkyxKpXr+77XmWga9WqZe+9954VKlTITaMUBAAAALkWLCuojZQd1mAkn3/+uY0ZMyZT85szZ46rd/YCZenSpYv16dPH5s2bZz169Ij4PgXY6pHj+eefDwbKAAAAQK4GyxdccEHE6QpqVT7xwQcf+A6H7VevrCG0Q5UrV87116zn/Hz77beurrlIkSKuF45PP/3UNTRU/fK9997rpgMAAAAJDZYz0qFDB5cVHj9+fMzvUVZawXG48uXL25YtW3zft379evdvz549rVevXjZ8+HD78ssvXdd2BQsWdI0O/SgrrUdo7bNXPpKZEpJsKUAwH5OCgdxeg5SQsP02GXEsxYZjKap8fRwJx1J0+X0fycPHbsKCZWV3ixcvnpBlHTx40P2rEo6HH37Y/X+rVq3s77//toceesgFzeodI5KxY8faiBEj0k1XN3jFihWzhCjdODHLSXHFOTHFPAx9vsWxFBOOpejy9XEkHEvR5fd9JEkpfkuqYLlfv37ppqkcYtmyZfbxxx/brbfemqn5KYO8ffv2iBnn0DrmSO8T9aQRSg38NMLgL7/8Yk2aNIn4XpWLKCMdmllu1qyZK+NQF3QJ8ffSxCwnxe3eRD16LBK23yYjjqWYcCxFl6+PI+FYii6/7yNJKh69oMU1WH7nnXfSTVM2uWbNmq78IjQIjUWDBg3S1SYreFYAq+f8NGrUKMP57t692/c5dTGnRzg1FExYY8HAvsQsJ9UdzLjnFfxPvm7kyrEUG46lqPL1cSQcS9Hl930kDx+7cQ2Wf/vtt3jOztq3b2+jR4+2bdu2BWuXp02b5uqO27Vr5/u+OnXquMzxggUL7MYbbwxO18iCKr+IFkwDAAAAOTaCX7hYR9wLpy7iSpcubZ06dXJdxU2aNMkGDRrkpof2sazyinr16qV5r8ot3n77bevfv78LkhV0q15ZZRYaDRAAAABIaLD80ksv2bhx44J/L1myxI2+V7JkSWvZsqVt2LAhU/NT7fHChQutcOHCLmC+/fbbXSmHGuGFt3TUYCWhzjvvPJs6darLLnfs2NGN4qeGeyNHjszmpwQAAEB+EdcyjAcffNCuu+664N833XSTFS1a1B599FEXRGvUvWeffTZT82zYsKELeDOyePHiiNPVp3Nm+nUGAAAAcixY/v3334P1wJs2bbKPPvrIZs2aZeecc45rSZzZ3jAAAACAPFOGoYZ3Xn3yokWL3Eh56t9YNOpePPq6AwAAAFIys3zMMce4LuLUVdzjjz/u+jn2BvJYvXq1ValSJZ6LAwAAAFInWFaPE2pM17RpU9eLRWit8YwZM9zgHgAAAEC+DJZPPfVUl0FesWKFHXHEEcG+keXaa69N170bAAAAkG+CZVFG+YQTTkg3vUOHDvFeFAAAAJD6g5IAAAAAqYhgGQAAAPBBsAwAAAD4IFgGAAAAEh0sBwIBW7t2re3fvz+nFgEAAACkVrA8d+5ca968uRUvXtxq165tP/zwg5veu3dvmzJlSrwXBwAAAKRGsDx16lTXRVzdunXdSH4HDx4MPqd+lydNmhTPxQEAAACpEyyPHDnS+vfv74LmHj16pHmucePGtmTJknguDgAAAEidYPnXX3/1HXykVKlStn379nguDgAAAEidYLlq1aq2fPnyiM+pdrlOnTrxXBwAAACQOsFyt27dbPjw4bZw4cLgtAIFCrjyiwceeMCuuOKKeC4OAAAAyFGF4zkzBcpLly61tm3bWsWKFd209u3b28aNG61jx452++23x3NxAAAAQOoEy0WLFrWZM2faokWLbP78+bZp0yarUKGCtWnTxj0AAACAfBsse1q1auUeAAAAQL4OllevXp2p12ugEgAAACBfBMuHHXaYa8QXqwMHDmR3kQAAAEBqBMszZswI/v8///zjGvFptL7OnTvboYceauvXr7c333zT9cF8//33Z3dxAAAAQOoEyxdccEHw/3v16uV6wnj++efTvKZfv3529dVX24IFC1z3cgAAAEC+62d52rRpdtlll0V8TtNDs9AAAABAvgqWCxUqZN99913E57799lsrWDCuiwMAAABSp+u4K6+80u6++27btWuXderUyapUqWIbNmxwGeUxY8ZYnz594rk4AAAAIHWC5YceesgKFy7shra+5557gtOLFy9uN9xwgwuYAQAA8pon+7yf26uQEm6Y0NrydbCsQFkB89ChQ+3HH3+0devWWbVq1axJkyZWvnz5eC4KAAAASM0R/BQYn3HGGTkxawAAACBhaHEHAAAA+CBYBgAAAHwQLAMAAAA+CJYBAACARATL6l85I3/++Wc8FwcAAACkTrB8zDHH2BdffBHxuRdeeMF1IQcAAADky2D5iCOOsNNPP93uuusu279/v5u2adMmu+iii+yaa66xHj16xHNxAAAAQOoEy3PmzLHHHnvMHn30UTv55JNtwoQJ1rhxY/v2229t4cKF9sgjj8RzcQAAAEBqDUpy/fXXW/Pmza1FixZuiOvjjjvOFi9ebIcccki8FwUAAACkVm8YH330kXXu3NnKlCljXbt2dVllBdDbt2+P96IAAACA1AmWBw8ebK1atbKmTZvakiVL7JVXXrF3333XFi1aZEcffbTNnz8/nosDAAAAUidYnjhxoj377LP21ltvWeXKld20c845x3788Uc79dRT3f8DAAAA+bJm+YcffrDatWunm16+fHl79dVX7cILL4zn4gAAAIDUySxHCpRDqYYZAAAAyJeZ5XvuuSfD5wsUKOD6YAYAAADyXbAcqR/lf/75xw4cOGAlSpSwYsWKESwDAAAgf5ZhbN26Nd1j165dbrCSevXquf6WAQAAgHw7KEm6BRQubGeffbatWbPG9bf8ySef5PQiAQAAgOQclMRPzZo17fvvv0/U4gAAAIDUCJZ/++03u//+++2II45IxOIAAACA5CvDKF26tOvxItS+ffts7969VrJkSZs+fXo8FwcAAACkTrA8cODAdMFy8eLFXQlG+/btrUKFCvFcHAAAAJA6wfLw4cPjOTsAAAAgfzTwAwAAACy/dx334Ycf2sSJE23FihW2e/fudM//8MMP8V4kAAAAkPyZ5blz51rr1q1t06ZN9vXXX1utWrWsUqVK9vPPP9u///5rJ554YjwXBwAAAKROsDxs2DDr37+/zZ492/09cuRIe//9912WuUiRIi6Qzqzly5db27ZtrVSpUla1alUbPHiw610jMx599FHX8LBjx46ZXj4AAADyr7gGy8uWLXO9XhQsWNAFp8omS506dVzjv3vvvTdT89Nw2QqwFRyr27nRo0e7Eo8BAwbEPI/169fbiBEjrEqVKpn+PAAAAMjf4lqzrG7iDh486ALlatWq2cqVK+30008P9sH8xx9/ZGp+EyZMsB07dtiMGTOC3c7t37/f+vbta0OGDLHq1atHnYcy0eeff76tWrUqi58KAAAA+VW2M8svvviibd682f3/Mccc4+qT5ayzzrJRo0bZrFmzXC3znXfeaU2aNMnUvOfMmWNt2rRJ0z9zly5dXEA+b968qO//+OOP7a233rIxY8Zk+nMBAAAA2Q6Wr776apdBFtUre4OSqGRC2WRldVWaoYD6ySefzHS9coMGDdJMK1eunMta67mMHDhwwG688UYbOnSoez0AAACQ8DKMQCAQ/P8OHToE/79GjRr2zTff2C+//GK7du1yQW/RokUzXbOs4Dhc+fLlbcuWLRm+d/z48a5m+pZbbsnUMlX2oYdn3bp1weBbj4QoUCQxy0l1Bf9v34O/hO23yYhjKTYcS1Hl6+NIOJai4zhKymMpHsuLez/LoZRlrl+/viXahg0b7O6773YlIpkN0MeOHesaBIZTZrxYsWKWEKUbJ2Y5Ka54fv/xitHGjRst3+JYignHUnT5+jgSjqWoOI6S81jySoVzPVieOnWqqw+OJXjOTKZXGeTt27dHzDiH1jGHU6DctGlT17hw27ZtwYaBeujvQw45xAoXjvzR1dNGz54902SWmzVrZhUrVrTKlStbQvy9NDHLSXG7NxXK7VVICQnbb5MRx1JMOJaiy9fHkXAsRcVxlJzH0p49e5IjWH7sscdiel1mg2WVboTXJit4VgAbXsscSu/RSIIKtsNpmhoOnnPOORHfW6ZMGfcIV6hQIfdIiMC+xCwn1R38X308Mpaw/TYZcSzFhmMpqnx9HAnHUnQcR0l5LMVjeXEJlj///HOXfY03NQxUQ0Flg73a5WnTprl+nNu1a5fhICReRtmjxoclSpSw++67z2WdAQAAgFytWc6uPn362Lhx46xTp06uX+U1a9bYoEGD3PTQPpbVTZ36UVZjQjn22GPTzUvBtsovWrZsmdDPAAAAgNQV1xH84k0lEwsXLnT1xQqYb7/9dldPrEZ44S0dVY8MAAAA5JvMsjRs2NAWLFiQ4WsWL14cdT6xvAYAAACIa7Cs0fQAAACAvCipyzAAAACA3ESwDAAAAPggWAYAAAB8ECwDAAAAPgiWAQAAAB8EywAAAIAPgmUAAADAB8EyAAAA4INgGQAAAPBBsAwAAAD4IFgGAAAAfBAsAwAAAD4IlgEAAAAfBMsAAACAD4JlAAAAwAfBMgAAAOCDYBkAAADwQbAMAAAA+CBYBgAAAHwQLAMAAAA+CJYBAAAAHwTLAAAAgA+CZQAAAMAHwTIAAADgg2AZAAAA8EGwDAAAAPggWAYAAAB8ECwDAAAAPgiWAQAAAB8EywAAAIAPgmUAAADAB8EyAAAA4INgGQAAAPBBsAwAAAD4IFgGAAAAfBAsAwAAAD4IlgEAAAAfBMsAAACAD4JlAAAAwAfBMgAAAOCDYBkAAADwQbAMAAAA+CBYBgAAAHwQLAMAAAA+CJYBAAAAHwTLAAAAgA+CZQAAAMAHwTIAAADgg2AZAAAA8EGwDAAAAPggWAYAAAB8ECwDAAAAPgiWAQAAAB8EywAAAIAPgmUAAAAgVYPl5cuXW9u2ba1UqVJWtWpVGzx4sO3duzfD96xbt8697thjj7XSpUtbzZo1rVu3brZq1aqErTcAAABSX2FLYlu3brXWrVtb/fr1bfr06bZmzRobMGCA7dy505544gnf933zzTfu9ddcc401b97cNm3aZCNHjrRmzZrZkiVLrHLlygn9HAAAAEhNSR0sT5gwwXbs2GEzZsywChUquGn79++3vn372pAhQ6x69eoR33faaae5jHThwv/38Vq0aGG1a9e2F1980QYOHJiwzwAAAIDUldRlGHPmzLE2bdoEA2Xp0qWLHTx40ObNm+f7vnLlyqUJlEWlGMoor127NkfXGQAAAHlHUgfLyg43aNAgXSBcrVo191xmrFixwjZs2GANGzaM81oCAAAgr0r6mmUFx+HKly9vW7ZsiXk+gUDA+vXr58o2Lrvssgxfq7IPPUIbC8qBAwfcIyEKFEnMclJdwUBur0FKSNh+m4w4lmLDsRRVvj6OhGMpOo6jpDyW4rG8pA6W42X48OG2cOFCe++991yvGhkZO3asjRgxIt30zZs3W7FixSwhSjdOzHJSXPH8/uMVo40bN1q+xbEUE46l6PL1cSQcS1FxHCXnsaT4LU8Hy8ogb9++PWLGObSOOSPPPPOM3XPPPfbcc8/ZWWedFfX16m2jZ8+eaTLL6kWjYsWKietF4++liVlOitu9qVBur0JKyNe9v3AsxYRjKbp8fRwJx1JUHEfJeSzt2bMnbwfLqlcOr01W8KwANryWORL1onH99de7YFndyMWiTJky7hGuUKFC7pEQgX2JWU6qO1ggt9cgJSRsv01GHEux4ViKKl8fR8KxFB3HUVIeS/FYXlI38Gvfvr0tWLDAtm3bFpw2bdo0K1iwoLVr1y7D9y5evNjVJ/fq1cvuuuuuBKwtAAAA8pqkDpb79OnjRuDr1KmT6ypu0qRJNmjQIDc9tI9llVfUq1cv+PeyZcvcezSYyZVXXmmff/558LFy5cpc+jQAAABINUlfs6yGeTfddJMLfhU4q5541KhR6Vo6arASzxdffOHKNfQ49dRT07y2e/fuNnny5IR9BgAAAKSupA6WRf0iqxQjWslFqB49ergHAAAAkGfLMAAAAIDcRLAMAAAA+CBYBgAAAHwQLAMAAAA+CJYBAAAAHwTLAAAAgA+CZQAAAMAHwTIAAADgg2AZAAAA8EGwDAAAAPggWAYAAAB8ECwDAAAAPgiWAQAAAB8EywAAAIAPgmUAAADAB8EyAAAA4INgGQAAAPBBsAwAAAD4IFgGAAAAfBAsAwAAAD4IlgEAAAAfBMsAAACAD4JlAAAAwAfBMgAAAOCDYBkAAADwQbAMAAAA+CBYBgAAAHwQLAMAAAA+CJYBAAAAHwTLAAAAgA+CZQAAAMAHwTIAAADgg2AZAAAA8EGwDAAAAPggWAYAAAB8ECwDAAAAPgiWAQAAAB8EywAAAIAPgmUAAADAB8EyAAAA4INgGQAAAPBBsAwAAAD4IFgGAAAAfBAsAwAAAD4IlgEAAAAfBMsAAACAD4JlAAAAwAfBMgAAAOCDYBkAAADwQbAMAAAA+CBYBgAAAHwQLAMAAAA+CJYBAAAAHwTLAAAAgA+CZQAAACBVg+Xly5db27ZtrVSpUla1alUbPHiw7d27N+r7AoGAjRkzxmrXrm0lSpSwU045xT7//POErDMAAADyhqQOlrdu3WqtW7d2wfH06dNt9OjRNnHiRBswYEDU995///02bNgwu+WWW2zWrFlWrVo1a9eunf36668JWXcAAACkvsKWxCZMmGA7duywGTNmWIUKFdy0/fv3W9++fW3IkCFWvXr1iO/bvXu33XfffTZw4EAXLMvpp59uRx55pD300EM2fvz4hH4OAAAApKakzizPmTPH2rRpEwyUpUuXLnbw4EGbN2+e7/s+/fRTF2TrtZ6iRYvaRRddZO+++26OrzcAAADyhoLJXq/coEGDNNPKlSvnSir0XEbvk/D3NmzY0FavXm27du3KoTUGAABAXlI42WuWFRyHK1++vG3ZsiXD9xUrVsyKFy+e7n1q+Kfn1egvEmWk9fD88ccf7t8///zTDhw4YAmxI6mvYZLG1p0bcnsVUsKqVass3+JYignHUnT5+jgSjqWoOI6S81hat25dsIw3TwbLuWHs2LE2YsSIdNPVmwaSzWW5vQIp4a6XcnsNkPw4lqLhOEJ0HEfJfCxt3LjRDjvssLwXLCsTvH379nTTlRkOrWOO9L49e/a4hn6h2WW9r0CBAu55P+ppo2fPnsG/NQ9ll+vWrWuFCyf15spXdKXYrFkz+/LLL11ZDoCs4VgCso/jKHkpo6xAuUmTJlmeR1JHf6o5Dq9NVvCsnTK8Hjn8ffLzzz/bMcccE5yueXn9LvspU6aMe4SqV69eNj4FcpJOSjVr1szt1QBSHscSkH0cR8kpqxllT1IXIbVv394WLFhg27ZtC06bNm2aFSxY0PWZ7KdFixYu4NVrPfv27XN9NXfo0CHH1xsAAAB5Q1IHy3369LHSpUtbp06dXFdxkyZNskGDBrnpoX0sn3XWWWmyvyq9uOOOO1yfyo899pi9//77dtlll9nmzZvt1ltvzaVPAwAAgFST1GUYqi1euHCh3XTTTS5gVuCseuJRo0aleZ16qQhv5Xjbbbe5ni8UMKtW5dhjj7W5c+fa4YcfnuBPgZygOwcaoTG8ZAZA5nAsAdnHcZS3FQgoogQAAACQWmUYAAAAQG4iWAYAAAB8ECwDAAAAPgiWAQAAAB8Ey0i4Rx55xA0OU6hQIdfLSTxMnjzZjc64adMm9/fvv//u/n7jjTfiMn8AQN6h8Rv0G6HfDm/QihtvvDHqb9W3335rzZs3t5IlS7r3az6R3puRSL9PmZ0HEiupu45D3vPf//7XBg4c6Lr2O++886xSpUpxme+5555rn332mZUrVy4u8wMA5B8zZsxw3dVG+63q16+f66529uzZbjRgdWkb/t5YRvnT79WRRx6ZI58F8UewjITSEOTqrbBXr15x7fO6cuXK7gEAQGYdd9xxMf1WLV++3Pr27WutWrXyfW80xYoVc9lppA7KMJAwPXr0cFfocsQRR7jbUE8++aS79XTUUUe521q6FaURGrdv357u/S+++KI7KWmERl3la+jyVatWRSzD8KPXNW3a1M2jRo0aNnToUJclAJL5uDn66KNtwYIFbt9VNuvMM890t3K3bNliXbp0cQMh6Jh67bXX0rz36aefdseWfpx1bN1777128OBB95yOFU1/5pln0i3z5JNPdvP1/Pnnn3bFFVe4407LP+OMM+ybb75J8x7vNrKO6Tp16ljZsmXdrWsNCgXkNu3n2kf1O6NRf3/55Zc0z4eWQUT6rfJ+YzQS8MiRI93/t2zZMt17Pcoct2vXzh2byj7rmJo/f36mygQ1j9atW1upUqXc8dStWzfbsGFDXLcLYkOwjIS566677P7773f/P336dHci0A+yglWNyjhnzhz3Y/7BBx+kq2V+8MEHrXv37nbCCSe49z733HNWv379TP0Qjx071o0AefbZZ9s777zjbq89/vjjLmAGktn69evdLWHtq1OmTLGVK1fa5Zdfbl27drUmTZrYm2++6Y4NBbTeBeS4cePchae3vysAGD58uA0ePNg9r8D3wgsvtOeffz7NspYuXWpffvmlXXvtte7vrVu32mmnnWbff/+9m6eWpR9v/YiH/3C//fbb7qGA+bHHHnPHskZgBXLTrFmzrHfv3i4brJIJBcuXXHJJpn6r9F79e8ghh7hjQ/8/fvz4iO//5JNPXCC9Z88ee/bZZ90xc8EFF9jq1atjXmfNX/NQkKyL4IkTJ9pXX33l5oNcoBH8gESZMWOGRowM/PbbbxGf37dvX+Djjz92r/n555/dtG3btgVKliwZ6N27t+98J02a5N6zceNG97fmr7+nTZvm/t6xY0fgkEMOCdxxxx1p3vfUU08FSpQoEdi0aVMcPyUQP927dw8UKFAgsGTJkuC0cePGuf37tttuC07bunVroFChQoFHH300sH///kClSpUCl156aZp5af8vWrRocH9fsGCBm89PP/0UfM2AAQMCtWrVChw4cMD9fffddwfKli0b+Ouvv4Kv2b17d6B27dqBQYMGBafVqVMnULNmTfecZ9iwYYEiRYoE5wXkhpNPPjlw+umnp5l21113uX1fvx3e/nvDDTdE/a3SsaD9OlT4e1u0aBFo1KiROw4jCf99ijSPM844w83n4MGDwWlLly5154LZs2dnYSsgO8gsI9e99NJLrrxCV+xFihRxWSxZsWJF8Ap7586dwUxXVnz66af2zz//uGzC/v37g482bdrYrl27bMmSJXH7PEC8Va9e3Ro3bhz822sYpP3Xo8atVapUsT/++MPVVarMIjx7pkz03r17XeZYlB1WPaaXXdYx8fLLL7ssdMGC//t5mDdvnsuqVahQIXjcqHcAlYIo0xVK01Ta4WnUqJHt27ePW8fINbpzqZIh3UUJdfHFF+fI8vRb9fnnn7s7oTpOsjoPZad1/Gr9veNOx32tWrXSHXfIeQTLyFW6JXbVVVdZs2bN7PXXX3cnGU2T3bt3u39VI+YFDFnl1TIff/zxLiD3HirlEAUYQLIK7+WlaNGivtN13Kh0Qg499NA0z3t/q9ZZVDep0iRdsOrHWLerVdp09dVXpzl23nrrrTTHjR56T/hx47ee3rEMJJr2Z+3bupAMFX5sxIuOPbULyM7vleahIPmWW25Jd9yplIPfq8SjNwzkqmnTptmxxx7rGiJ5VOcYqmLFiu7ftWvXWs2aNbO0HGXFvPozXZmHq1u3bpbmCyQjb38Pz+j+9ddfaZ4XBcZ33323C5SVYVYWOfR40GvPOecc16gpXGgWGUhG6iWpcOHCvsdCvOmCUXdl9HuVnXnoQnbIkCERxyKIV5eriB3BMnKVSiC87JNHDZhCnXLKKa4F86RJk1wGOiu8eahVf/jtOCCvUQ8YChJ0MRq6v+vujY630OOoatWq1rFjR3vggQfc7V1vkAaPSj1UmtGwYUPXsA9IJSqF0B1F3bFUptaTUwNW6RjR7416b1Kj3KyUYnjzWLZsmWv0jtxHsIxc1bZtW7vhhhtc1konh3fffdcWLlyY5jVqDTxs2DDXe4Vub6k1sP5dtGiRXXbZZXbiiSfGdKV+zz33uJ4AFDCrlbFOYr/++qvNnDnTtVZWMA3kBdq31aJfAyjo9rO6WVSJk1r49+/fP3i3xqO+ZDWwj46Tzp07p3luwIAB7gJW9cg333yzG9FMt7a/+OILd6s5NAABkpF6kdHvhu6iXHrppa6GWWVEOWXMmDGuPYAuNNUnswYs0ch/yghfc801Mc1DPUBpHmpnoHXWPPTbpe7n9Dm8buuQGATLyFXXXXedC1jVJZVODurm6pVXXknXYbuCXGXKNPyoMl/qt1LBdXgdWkZ0la++ldWFnJan+i/1oamsWnh2G0h16rJN+7j2d3VxpVHD1HWcbu2G03Gni0VdfKoP8lAKrBVo33nnne6CVW0IdNzpGOUuDVLB+eefbxMmTHBdlL766quuz2N1x6Z/c4IaqS9evNgdM2osq4tXNdDNTJa4RYsW9vHHH7tEkYJjNcxVGaK6vatXr16OrDf8FVCXGBk8DwDI495//333I/z111+7/poBAP+HYBkA8ik1QtJIZiql0Mh8ymQBANKi6zgAyKc0Kph6vxCNNAYASI/MMgAAAOCDzDIAAADgg2AZAAAA8EGwDAAAAPggWAYAAAB8ECwDAAAAPgiWAQAAAB8EywAAAIAPgmUAAADAB8EyAAAA4INgGQAAAPBBsAwAAAD4IFgGAAAAfBAsAwAAAD4IlgEAAAAfBMsAAACAD4JlAAAAwCL7fwfK3sN6AhhDAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Figure 2 : si Reflexion gagne sur 'difficile' et BoN sur 'facile', c'est la\n",
+      "frontiere compute-optimale de Snell (chaque regime a sa strategie).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Figure 2 : BoN parallele vs Reflexion sequentielle par bucket (frontiere compute-optimale).\n",
+    "fig, ax = plt.subplots(figsize=(6.5, 4.2))\n",
+    "buckets = list(PROBLEMES.keys())\n",
+    "x = range(len(buckets))\n",
+    "bon_vals = [compare[b][0] for b in buckets]\n",
+    "ref_vals = [compare[b][1] for b in buckets]\n",
+    "w = 0.35\n",
+    "ax.bar([i - w/2 for i in x], bon_vals, w, label=f\"BoN parallele (pass@{K_SEQ})\", color=\"#ff7f0e\")\n",
+    "ax.bar([i + w/2 for i in x], ref_vals, w, label=f\"Reflexion sequentielle (K={K_SEQ})\", color=\"#9467bd\")\n",
+    "ax.set_ylabel(\"Taux de succes\"); ax.set_ylim(0, 1.1)\n",
+    "ax.set_title(\"Compute-optimal : strategie gagante selon la difficulte\")\n",
+    "ax.set_xticks(list(x)); ax.set_xticklabels(buckets)\n",
+    "ax.legend(); ax.grid(True, alpha=0.3, axis=\"y\")\n",
+    "buf = io.BytesIO(); fig.tight_layout(); fig.savefig(buf, format=\"png\", dpi=110); plt.close(fig)\n",
+    "buf.seek(0); display(Image(data=buf.read()))\n",
+    "print(\"Figure 2 : si Reflexion gagne sur 'difficile' et BoN sur 'facile', c'est la\")\n",
+    "print(\"frontiere compute-optimale de Snell (chaque regime a sa strategie).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9bbf934",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001304,
+     "end_time": "2026-06-15T21:25:41.643993",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.642689",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Limites honnetes (G.2) et lecture des resultats\n",
+    "\n",
+    "Ce notebook est **illustratif**, pas une replication a l'echelle de Snell et al. 2024 :\n",
+    "\n",
+    "- **Petit n / petit K** (6 echantillons, K <= 6) : l'estimateur pass@k a une variance elevee ;\n",
+    "  les courbes sont bruitees. Snell utilise des milliers d'echantillons sur des centaines de\n",
+    "  problemes de competition (MATH).\n",
+    "- **Petit modele** (llama-3.3-70b via OpenRouter) : sur de l'arithmetique simple, pass@1 peut\n",
+    "  deja etre eleve -> le scaling apporte peu (les buckets \"facile/moyen\" saturent). C'est\n",
+    "  **attendu** et **honnete** : le scaling du test-time compute apporte le plus sur des\n",
+    "  problemes **genuinement difficiles et verifiables** (maths de competition, code). Si nos\n",
+    "  buckets saturent, la conclusion honnete est *\"sur ce modele et ces problemes, BoN ajoute peu\n",
+    "  car pass@1 est deja haut\"* — pas d'inflation (G.2).\n",
+    "- **Verificateur exact** (entier) : pas de juge LLM, donc pass@k est objectif, mais cela limite\n",
+    "  le notebook a des problemes a reponse entiere.\n",
+    "- **Cout** : le test-time compute a un cout API reel (k echantillons = k appels) — c'est le\n",
+    "  compromis que Snell met en balance contre le cout d'entrainement.\n",
+    "\n",
+    "**Ce qui est demontre ici** : la **methodologie** (suite graduee + verificateur exact +\n",
+    "estimateur pass@k non-biasé + comparaison parallele/sequentiel a budget egal) — reproductible\n",
+    "et applicable a un plus grand modele / une suite plus difficile (Phase 5)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64b35628",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005744,
+     "end_time": "2026-06-15T21:25:41.663152",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.657408",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Travaux pratiques\n",
+    "\n",
+    "Les exercices sont a completer (convention C.1 : pas d'erreur volontaire)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14cee7a2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00725,
+     "end_time": "2026-06-15T21:25:41.678568",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.671318",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : suite plus difficile (maths de competition) + n plus grand\n",
+    "\n",
+    "La suite actuelle sature peut-etre (pass@1 deja haut). Etends avec 3 problemes **genuinement\n",
+    "difficiles** (ex : MATH/AMC) a reponse entiere verifiable, et monte n a 20+ echantillons.\n",
+    "Re-affiche la courbe de scaling : les buckets difficiles devraient monter avec k.\n",
+    "\n",
+    "# Indice : garde le meme format (enonce, attendu) dans PROBLEMES[\"competition\"] ; verifie\n",
+    "# la reponse attendue a la main ; relance la cellule de collecte avec N_ECHANTILLONS=20."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "39893c17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:25:41.704149Z",
+     "iopub.status.busy": "2026-06-15T21:25:41.703731Z",
+     "iopub.status.idle": "2026-06-15T21:25:41.709646Z",
+     "shell.execute_reply": "2026-06-15T21:25:41.708668Z"
+    },
+    "papermill": {
+     "duration": 0.013232,
+     "end_time": "2026-06-15T21:25:41.708629",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.695397",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 - bucket competition : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def ajouter_bucket_competition():\n",
+    "    \"\"\"Exercice 1 : ajoute 3 problemes de competition a reponse entiere verifiable, n>=20.\"\"\"\n",
+    "    # TODO etudiant : retourner une liste [(enonce, attendu), ...] verifiee a la main.\n",
+    "    return None\n",
+    "\n",
+    "_r = ajouter_bucket_competition()\n",
+    "print(f\"Exercice 1 - bucket competition : {'defini' if _r is not None else 'a completer'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f8fe1ec",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014613,
+     "end_time": "2026-06-15T21:25:41.723242",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.708629",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : meilleur estimateur de pass@k (multi-trials)\n",
+    "\n",
+    "L'estimateur actuel calcule pass@k depuis une seule serie de n echantillons. Implemente\n",
+    "l'estimation sur **plusieurs trials independants** (m echantillons relances t fois) avec\n",
+    "intervalle de confiance (bootstrap), pour quantifier le bruit souligne en section 4.\n",
+    "\n",
+    "# Indice : pour chaque probleme, tires t jeux de n echantillons, calcule pass@k sur chaque\n",
+    "# jeu, puis moyenne + ecart-type (ou percentile bootstrap a 95%)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a237b6ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:25:41.749641Z",
+     "iopub.status.busy": "2026-06-15T21:25:41.749395Z",
+     "iopub.status.idle": "2026-06-15T21:25:41.756477Z",
+     "shell.execute_reply": "2026-06-15T21:25:41.754792Z"
+    },
+    "papermill": {
+     "duration": 0.017448,
+     "end_time": "2026-06-15T21:25:41.757710",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.740262",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 - pass@k + IC : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def pass_at_k_avec_ic(enonce, attendu, k, n=6, trials=3):\n",
+    "    \"\"\"Exercice 2 : pass@k moyen + intervalle de confiance bootstrap sur `trials` essais.\"\"\"\n",
+    "    # TODO etudiant : t trials de n echantillons chacun -> pass@k par trial -> IC.\n",
+    "    return None\n",
+    "\n",
+    "print(f\"Exercice 2 - pass@k + IC : {'implemente' if False else 'a completer'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90d6bc22",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006999,
+     "end_time": "2026-06-15T21:25:41.771967",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.764968",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (avance) : frontiere compute-optimale reelle (budget variable)\n",
+    "\n",
+    "Trace la **frontiere compute-optimale** : pour chaque budget total B (appels) de 1 a 16,\n",
+    "calcule le taux de succes max entre BoN(B) et Reflexion(B), par bucket. Affiche la strategie\n",
+    "gagante en fonction de B et de la difficulte (une heatmap bucket x B).\n",
+    "\n",
+    "# Indice : boucle sur B, evalue BoN pass@B et Reflexion K=B, garde le max ; heatmap\n",
+    "# matplotlib (imshow) bucket (lignes) x B (colonnes) coloree par la strategie gagante."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "fca0165a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T21:25:41.789726Z",
+     "iopub.status.busy": "2026-06-15T21:25:41.789454Z",
+     "iopub.status.idle": "2026-06-15T21:25:41.796043Z",
+     "shell.execute_reply": "2026-06-15T21:25:41.794538Z"
+    },
+    "papermill": {
+     "duration": 0.013566,
+     "end_time": "2026-06-15T21:25:41.794363",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.780797",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 - frontiere compute-optimale : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def frontiere_compute_optimale(budgets=range(1, 9)):\n",
+    "    \"\"\"Exercice 3 : pour chaque budget, strategie gagante (BoN vs Reflexion) par bucket.\"\"\"\n",
+    "    # TODO etudiant : boucler sur budgets, evaluer les deux strategies, renvoyer la matrice.\n",
+    "    return None\n",
+    "\n",
+    "print(f\"Exercice 3 - frontiere compute-optimale : {'implemente' if False else 'a completer'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "683d2ad6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013782,
+     "end_time": "2026-06-15T21:25:41.811727",
+     "exception": false,
+     "start_time": "2026-06-15T21:25:41.797945",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Conclusion et suite\n",
+    "\n",
+    "On a mesure, sur de vraies donnees, le **scaling du test-time compute** (Snell et al. 2024) :\n",
+    "pass@k par bucket de difficulte (estimateur non-biasé HumanEval) et comparaison\n",
+    "**parallele (BoN) vs sequentiel (Reflexion)** a budget egal — la frontiere compute-optimale.\n",
+    "\n",
+    "**Resultats honnetes (G.2)** : sur un petit modele et une suite arithmetique simple, pass@1\n",
+    "est deja eleve -> le scaling BoN apporte peu sur les buckets faciles/moyens ; le signal le plus\n",
+    "net (quand il apparaît) est sur le bucket difficile. Ce notebook demontre surtout la\n",
+    "**methodologie** (verificateur exact + estimateur pass@k + comparaison a budget egal),\n",
+    "transferable a un plus grand modele et une suite plus difficile.\n",
+    "\n",
+    "**Suite de l'epic #2926 :**\n",
+    "- **Phase 5** — vs **modeles a raisonnement natif** (gpt-5-thinking, o1-like) : le\n",
+    "  test-time compute est alors \"interne\" ; compare cout-normalise hand-rolled (BoN/ToT/Reflexion)\n",
+    "  vs natif.\n",
+    "- **Phase 6** — plugin **Semantic Kernel** (pont series SemanticKernel, integration Python).\n",
+    "\n",
+    "**References :** Snell, Lee, Xu, Kumar, *\"Scaling LLM Test-Time Compute Optimally\"* (2024) ;\n",
+    "Chen et al., *\"Evaluating Large Language Models Trained on Code\"* (HumanEval, pass@k, 2021) ;\n",
+    "Yao et al., *\"Tree of Thoughts\"* (2023) ; NB-12/13/14/15 de cette serie."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 53.991295,
+   "end_time": "2026-06-15T21:25:42.466454",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb",
+   "output_path": "tmp/16_Scaling_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-15T21:24:48.475159",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Nouveau notebook **NB-16 — Scaling du test-time compute (Snell 2024)**, **Phase 4** de l'epic **#2926** (ICR test-time scaling). Suit NB-13 (Phase 1, routeur), NB-14 (Phase 2, memoire), NB-15 (Phase 3, ToT CSP).

Implemente le livrable Phase 4 : **mesurer comment le test-time compute se met a l'echelle**, apres Snell, Lee, Xu, Kumar (DeepMind 2024), *"Scaling LLM Test-Time Compute Optimally"*. S'appuie sur les moteurs de NB-12.

### Contenu (21 cellules : 10 code, 11 markdown)
- **Suite graduee** a **reponse entiere verifiable** (facile/moyen/difficile) — pas de juge LLM, pass@k est objectif.
- **Estimateur pass@k non-biasé (HumanEval / Chen et al. 2021)** : `pass@k = 1 - C(n-c,k)/C(n,k)`.
- **Scaling BoN** : pass@k pour k=1,2,4,6 par bucket. **Courbe matplotlib inline** (pass@k vs k par bucket).
- **Compute-optimal** : a budget egal, **BoN (parallele)** vs **Reflexion (sequentiel)**. Snell : sequentiel gagne sur difficile, parallele sur facile.
- **3 exercices** C.1 (#2161).

## Preuves d'execution reelle (H.1 / pr-review-discipline D)

Execute end-to-end via **Papermill** (kernel python3 = conda base 3.13.12) :

- **10/10 cellules code** avec `execution_count` (1-10), **0 erreur**, **2 figures matplotlib inline** (PNG).
- Vrais appels API (llama-3.3-70b via OpenRouter), n=6 echantillons / probleme, K=4 Reflexion.

**Resultats — honnetes (G.2), reelement mesurees :**

| bucket | pass@1 | pass@2 | pass@4 | pass@6 |
|--------|--------|--------|--------|--------|
| facile | 1.00 | 1.00 | 1.00 | 1.00 |
| moyen | 1.00 | 1.00 | 1.00 | 1.00 |
| **difficile** | **0.38** | **0.54** | **0.67** | **0.75** |

**Interpretation honnete** :
- **facile/moyen saturent a 1.00** (pass@1 deja max) — c'est le point de regime de Snell : **la ou il n'y a pas de marge (headroom), le scaling n'apporte rien**. Attendu et assume (section 4).
- **difficile monte de maniere monotone 0.38 → 0.75** — **la ou il y a de la marge, plus d'echantillons aident**. C'est la courbe de scaling, mesuree.
- **Compute-optimal** (budget 4) : facile/moyen = egal (1.00/1.00) ; difficile **BoN 0.67 > Reflexion 0.50**. Sur ce modele/suite, le parallele reste compute-optimal meme sur difficile (le feedback Reflexion crude aide moins que des retry independants) — resultat non-trivial, assume franchement (ne force pas "sequentiel gagne sur dur").

## Limites honnetes (G.2, section 4 du notebook)
- Petit n (6), petit K (<=6) : estimateur bruite ; Snell utilise des milliers d'echantillons sur MATH.
- Petit modele : sur de l'arithmetique simple, pass@1 est deja eleve -> scaling faible sur facile/moyen. **Attendu**.
- Le notebook demontre surtout la **methodologie** (verificateur exact + estimateur non-biasé + comparaison a budget egal), transferable a un plus grand modele / suite plus difficile (**Phase 5**).

## Conformite
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`. 3 exercices en stubs (`# TODO etudiant`, `return None`).
- **C.2** : commite AVEC outputs reels (Papermill) + 2 figures PNG inline.
- **#2161** : `count_exercises.py` rapporte **3 exercices** (conforme).
- **Anti-regression** : nouveau notebook, ne touche aucun code de production.
- **Secrets** : aucune cle inline ; `.env` via `load_dotenv` (gitignore).
- **Catalogue** : nouveau notebook, catalogue non regenere (cron/bot).
- **Scope** : 1 fichier, 1 sujet (atomique, catalog-pr-hygiene HARD 3).

## Ponts pedagogiques
NB-12 (moteurs BoN/Reflexion) -> **NB-16** (scaling du test-time compute) ; suite Phase 5 (modeles a raisonnement natif), Phase 6 (plugin Semantic Kernel).

## Scope de cette PR
**Phase 4 / 6** de #2926. **Independante de #3092 (Phase 3)** : NB-16 reutilise NB-12 (BoN), pas Phase 3 (ToT-CSP).

See #2926 (contribution partielle — l'epic reste ouverte).
