### PR TITLE
feat(genai-texte): NB-17 native reasoning vs hand-rolled scaling (See #2926, Phase 5)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
@@ -1,0 +1,966 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9a460dd7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003148,
+     "end_time": "2026-06-15T22:21:13.107753",
+     "exception": false,
+     "start_time": "2026-06-15T22:21:13.104605",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 17. Modeles a raisonnement natif vs scaling du test-time compute\n",
+    "\n",
+    "**Phase 5 de l'epic #2926** — suite de **NB-12** (moteurs), **NB-16** (scaling pass@k).\n",
+    "\n",
+    "## La question centrale de Snell (Phase 5)\n",
+    "\n",
+    "NB-16 a mesure que le **test-time compute exterieur** (BoN, Reflexion) se met a l'echelle :\n",
+    "plus d'echantillons = plus de succes (la ou il y a de la marge). Mais les **modeles a\n",
+    "raisonnement natif** (deepseek-r1, o1/o3, gpt-5-thinking) depensent leur test-time compute\n",
+    "**a l'interieur** : ils generent des **tokens de raisonnement caches** avant la reponse.\n",
+    "\n",
+    "> **Question (Snell)** : a **cout egal** (en tokens, raisonnement inclus), un modele a\n",
+    "> raisonnement natif bat-il le scaling hand-rolled (BoN/Reflexion) sur un modele standard ?\n",
+    "\n",
+    "Snell et al. 2024 montrent que le scaling hand-rolled, **quand il est compute-optimal**,\n",
+    "peut egaler un modele **14x plus grand** — i.e. depenser du compute exterieur peut valoir\n",
+    "l'investissement dans un modele plus gros. Ce notebook mesure cela **directement** :\n",
+    "on compare, sur la meme suite graduee, le **BoN** d'un modele standard (llama-3.3-70b,\n",
+    "0 token de raisonnement) au **single-shot** d'un modele a raisonnement natif (deepseek-r1),\n",
+    "**normalise en tokens**.\n",
+    "\n",
+    "## Plan\n",
+    "1. Suite graduee + verificateur exact (herites de NB-16) + pass@k.\n",
+    "2. **Baseline non-reasoning** : BoN pass@k sur llama-3.3-70b, **cout en tokens cumules**.\n",
+    "3. **Raisonnement natif** : single-shot deepseek-r1, cout = prompt + completion + **reasoning tokens**.\n",
+    "4. **Comparaison cost-normalisee** : courbe tokens-vs-pass du BoN + point du modele a raisonnement.\n",
+    "5. Limites honnetes (G.2) + pont Phase 6 (plugin Semantic Kernel)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ef08a82",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003026,
+     "end_time": "2026-06-15T22:21:13.113537",
+     "exception": false,
+     "start_time": "2026-06-15T22:21:13.110511",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 0. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0e45f46d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:21:13.122498Z",
+     "iopub.status.busy": "2026-06-15T22:21:13.122284Z",
+     "iopub.status.idle": "2026-06-15T22:21:15.932629Z",
+     "shell.execute_reply": "2026-06-15T22:21:15.932079Z"
+    },
+    "papermill": {
+     "duration": 2.81654,
+     "end_time": "2026-06-15T22:21:15.933055",
+     "exception": false,
+     "start_time": "2026-06-15T22:21:13.116515",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".env charge depuis : D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n",
+      "BASELINE (non-reasoning)=meta-llama/llama-3.3-70b-instruct | REASONING=deepseek/deepseek-r1 | BATCH=False\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -q openai python-dotenv matplotlib numpy\n",
+    "\n",
+    "import os, re, math, time\n",
+    "from pathlib import Path\n",
+    "from openai import OpenAI\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "_env_path = None\n",
+    "_current = Path.cwd()\n",
+    "for _i in range(10):\n",
+    "    if (_current / \".env\").exists():\n",
+    "        _env_path = _current / \".env\"; break\n",
+    "    if _current.name in (\"GenAI\", \"MyIA.AI.Notebooks\"):\n",
+    "        break\n",
+    "    _current = _current.parent\n",
+    "if _env_path is None:\n",
+    "    for _cand in (Path.cwd() / \"MyIA.AI.Notebooks\" / \"GenAI\" / \".env\",\n",
+    "                  Path.cwd() / \"GenAI\" / \".env\"):\n",
+    "        if _cand.exists():\n",
+    "            _env_path = _cand; break\n",
+    "if _env_path is not None:\n",
+    "    load_dotenv(_env_path); print(f\".env charge depuis : {_env_path}\")\n",
+    "\n",
+    "# Baseline NON-reasoning (0 token de raisonnement) vs raisonnement natif\n",
+    "BASELINE_MODEL = os.getenv(\"OPENAI_MODEL_FAST\", \"meta-llama/llama-3.3-70b-instruct\")\n",
+    "REASONING_MODEL = os.getenv(\"REASONING_MODEL\", \"deepseek/deepseek-r1\")\n",
+    "BATCH_MODE = os.getenv(\"BATCH_MODE\", \"true\").lower() in (\"1\", \"true\", \"yes\")\n",
+    "client = OpenAI(api_key=os.getenv(\"OPENROUTER_API_KEY\"),\n",
+    "                base_url=os.getenv(\"OPENROUTER_BASE_URL\", \"https://openrouter.ai/api/v1\"))\n",
+    "print(f\"BASELINE (non-reasoning)={BASELINE_MODEL} | REASONING={REASONING_MODEL} | BATCH={BATCH_MODE}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7a3782a3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:21:15.940701Z",
+     "iopub.status.busy": "2026-06-15T22:21:15.940445Z",
+     "iopub.status.idle": "2026-06-15T22:21:26.680115Z",
+     "shell.execute_reply": "2026-06-15T22:21:26.679206Z"
+    },
+    "papermill": {
+     "duration": 10.744115,
+     "end_time": "2026-06-15T22:21:26.680170",
+     "exception": false,
+     "start_time": "2026-06-15T22:21:15.936055",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "meta-llama/llama-3.3-70b-instruct  -> '391'          | total_tokens=   31 (dont reasoning=0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deepseek/deepseek-r1               -> '391'          | total_tokens=  290 (dont reasoning=266)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def tokens_raisonnement(usage):\n",
+    "    \"\"\"Extrait les reasoning tokens d'un objet usage (None si modele non-reasoning).\"\"\"\n",
+    "    try:\n",
+    "        d = getattr(usage, \"completion_tokens_details\", None)\n",
+    "        return getattr(d, \"reasoning_tokens\", None) or 0 if d else 0\n",
+    "    except Exception:\n",
+    "        return 0\n",
+    "\n",
+    "def chat_usage(prompt, model, system=None, temperature=0.7, max_tokens=2000, retries=2):\n",
+    "    \"\"\"Chat qui renvoie (texte, total_tokens). total = prompt + completion (+ reasoning inclus\n",
+    "    dans completion_tokens chez OpenRouter). Capt aussi les reasoning tokens separement.\"\"\"\n",
+    "    messages = ([{\"role\": \"system\", \"content\": system}] if system else []) \\\n",
+    "               + [{\"role\": \"user\", \"content\": prompt}]\n",
+    "    for essai in range(retries + 1):\n",
+    "        try:\n",
+    "            resp = client.chat.completions.create(model=model, messages=messages,\n",
+    "                                                  temperature=temperature, max_tokens=max_tokens)\n",
+    "            txt = resp.choices[0].message.content or \"\"\n",
+    "            u = resp.usage\n",
+    "            total = (u.prompt_tokens or 0) + (u.completion_tokens or 0)\n",
+    "            rtok = tokens_raisonnement(u)\n",
+    "            if txt.strip() or rtok:\n",
+    "                return txt, total, rtok\n",
+    "        except Exception as exc:\n",
+    "            if essai == retries:\n",
+    "                print(f\"  [chat_usage] echec ({model}) : {str(exc)[:80]}\")\n",
+    "            else:\n",
+    "                time.sleep(1.0)\n",
+    "    return \"\", 0, 0\n",
+    "\n",
+    "# Ping : montre la decomposition des tokens (baseline vs raisonnement).\n",
+    "for m in (BASELINE_MODEL, REASONING_MODEL):\n",
+    "    txt, tot, rt = chat_usage(\"Combien font 17 x 23 ? Reponds uniquement par le nombre.\",\n",
+    "                              model=m, temperature=0.0, max_tokens=2000)\n",
+    "    print(f\"{m:34s} -> {txt.strip()!r:14s} | total_tokens={tot:5d} (dont reasoning={rt})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c37df8f0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006079,
+     "end_time": "2026-06-15T22:21:26.686249",
+     "exception": false,
+     "start_time": "2026-06-15T22:21:26.680170",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Suite graduee + verificateur + pass@k (herites de NB-16)\n",
+    "\n",
+    "Meme suite que NB-16 (reponses entieres verifiables) pour que la comparaison soit\n",
+    "**equitable**. Estimateur pass@k non-biasé (HumanEval)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "92cdacae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:21:26.694815Z",
+     "iopub.status.busy": "2026-06-15T22:21:26.694610Z",
+     "iopub.status.idle": "2026-06-15T22:21:26.700685Z",
+     "shell.execute_reply": "2026-06-15T22:21:26.699779Z"
+    },
+    "papermill": {
+     "duration": 0.011387,
+     "end_time": "2026-06-15T22:21:26.701402",
+     "exception": false,
+     "start_time": "2026-06-15T22:21:26.690015",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Suite : 6 problemes, buckets=['facile', 'moyen', 'difficile'] | heritee de NB-16 (comparaison equitable).\n"
+     ]
+    }
+   ],
+   "source": [
+    "PROBLEMES = {\n",
+    "    \"facile\": [\n",
+    "        (\"Combien font 7 + 8 ? Reponds uniquement par le nombre.\", 15),\n",
+    "        (\"Combien font 12 x 11 ? Reponds uniquement par le nombre.\", 132),\n",
+    "    ],\n",
+    "    \"moyen\": [\n",
+    "        (\"Un train part avec 45 passagers. 12 montent au suivant, 7 descendent. \"\n",
+    "         \"Combien reste-t-il de passagers ? Reponds uniquement par le nombre.\", 50),\n",
+    "        (\"Si 3 pommes coutent 1,50 EUR, combien coutent 12 pommes (en EUR entier) ? \"\n",
+    "         \"Reponds uniquement par le nombre.\", 6),\n",
+    "    ],\n",
+    "    \"difficile\": [\n",
+    "        (\"Un capital de 1000 EUR augmente de 10% puis diminue de 10%. \"\n",
+    "         \"Quelle est la valeur finale en EUR ? Reponds uniquement par le nombre.\", 990),\n",
+    "        (\"Combien de nombres entre 1 et 20 (inclus) sont divisibles par 3 OU par 5 ? \"\n",
+    "         \"Reponds uniquement par le nombre.\", 9),\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "def extraire_nombre(texte):\n",
+    "    m = re.findall(r'-?\\d+', texte or \"\")\n",
+    "    return int(m[0]) if m else None\n",
+    "\n",
+    "def est_correct(attendu):\n",
+    "    def _v(texte):\n",
+    "        n = extraire_nombre(texte)\n",
+    "        return n is not None and n == attendu\n",
+    "    return _v\n",
+    "\n",
+    "def pass_at_k(n, c, k):\n",
+    "    if n - c < k:\n",
+    "        return 1.0\n",
+    "    return 1.0 - math.comb(n - c, k) / math.comb(n, k)\n",
+    "\n",
+    "print(f\"Suite : {sum(len(v) for v in PROBLEMES.values())} problemes, \"\n",
+    "      f\"buckets={list(PROBLEMES)} | heritee de NB-16 (comparaison equitable).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1691bde3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002998,
+     "end_time": "2026-06-15T22:21:26.708408",
+     "exception": false,
+     "start_time": "2026-06-15T22:21:26.705410",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Baseline non-reasoning — BoN pass@k (cout en tokens)\n",
+    "\n",
+    "Sur le modele **standard** (llama-3.3-70b, 0 token de raisonnement), on genere n echantillons\n",
+    "et on mesure pass@k. **Cle** : on enregistre aussi les **tokens cumules** (k echantillons = k\n",
+    "couts), pour normaliser la comparaison contre le modele a raisonnement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5de7bf4b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:21:26.718156Z",
+     "iopub.status.busy": "2026-06-15T22:21:26.717963Z",
+     "iopub.status.idle": "2026-06-15T22:22:15.361780Z",
+     "shell.execute_reply": "2026-06-15T22:22:15.360146Z"
+    },
+    "papermill": {
+     "duration": 48.650168,
+     "end_time": "2026-06-15T22:22:15.363087",
+     "exception": false,
+     "start_time": "2026-06-15T22:21:26.712919",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BoN baseline : 12 echantillons / probleme sur meta-llama/llama-3.3-70b-instruct\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket facile    : collecte OK\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket moyen     : collecte OK\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket difficile : collecte OK\n",
+      "\n",
+      "=== Baseline non-reasoning (BoN) ===\n",
+      "bucket      | pass@1 (tok) | pass@2 (tok) | pass@4 (tok) | pass@6 (tok)\n",
+      "-----------------------------------------------------------------------\n",
+      "facile      | 1.00 (30) | 1.00 (73) | 1.00 (147) | 1.00 (220)\n",
+      "moyen       | 1.00 (63) | 1.00 (114) | 1.00 (228) | 1.00 (331)\n",
+      "difficile   | 0.17 (60) | 0.29 (109) | 0.43 (218) | 0.48 (314)\n",
+      "Legendre : pass@k (tokens cumules moyens sur les k echantillons).\n"
+     ]
+    }
+   ],
+   "source": [
+    "N_ECHANTILLONS = 6 if BATCH_MODE else 12\n",
+    "K_LIST = [1, 2, 4, 6]\n",
+    "\n",
+    "# Pour chaque probleme : n echantillons + (correct?, tokens de cet echantillon)\n",
+    "base = {b: [] for b in PROBLEMES}   # liste de (liste_de_corrects, liste_de_tokens)\n",
+    "print(f\"BoN baseline : {N_ECHANTILLONS} echantillons / probleme sur {BASELINE_MODEL}\")\n",
+    "for bucket, probs in PROBLEMES.items():\n",
+    "    for enonce, attendu in probs:\n",
+    "        verif = est_correct(attendu)\n",
+    "        corrects, toks = [], []\n",
+    "        for _ in range(N_ECHANTILLONS):\n",
+    "            txt, tot, _ = chat_usage(enonce, model=BASELINE_MODEL, temperature=0.8,\n",
+    "                                     max_tokens=80)\n",
+    "            corrects.append(int(verif(txt))); toks.append(tot)\n",
+    "        base[bucket].append((corrects, toks))\n",
+    "    print(f\"  bucket {bucket:9s} : collecte OK\")\n",
+    "\n",
+    "# pass@k moyen + tokens cumules moyens par bucket\n",
+    "print(\"\\n=== Baseline non-reasoning (BoN) ===\")\n",
+    "header = \"bucket      | \" + \" | \".join(f\"pass@{k} (tok)\" for k in K_LIST)\n",
+    "print(header); print(\"-\" * len(header))\n",
+    "base_curve = {b: {\"pass\": {}, \"tok\": {}} for b in PROBLEMES}   # pour la figure\n",
+    "for b in PROBLEMES:\n",
+    "    row_p, row_t = [], []\n",
+    "    for k in K_LIST:\n",
+    "        ps, ts = [], []\n",
+    "        for corrects, toks in base[b]:\n",
+    "            c = sum(corrects[:N_ECHANTILLONS]); ps.append(pass_at_k(N_ECHANTILLONS, c, k))\n",
+    "            ts.append(sum(toks[:k]))                # tokens des k premiers echantillons\n",
+    "        base_curve[b][\"pass\"][k] = sum(ps)/len(ps); base_curve[b][\"tok\"][k] = sum(ts)/len(ts)\n",
+    "        row_p.append(f\"{sum(ps)/len(ps):.2f}\")\n",
+    "        row_t.append(f\"{int(sum(ts)/len(ts))}\")\n",
+    "    print(f\"{b:11s} | \" + \" | \".join(f\"{p} ({t})\" for p, t in zip(row_p, row_t)))\n",
+    "print(\"Legendre : pass@k (tokens cumules moyens sur les k echantillons).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4677511f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003026,
+     "end_time": "2026-06-15T22:22:15.369112",
+     "exception": false,
+     "start_time": "2026-06-15T22:22:15.366086",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Raisonnement natif — deepseek-r1 single-shot\n",
+    "\n",
+    "Le modele a raisonnement natif est appele **une seule fois** par probleme (single-shot). Il\n",
+    "depense ses tokens de test-time compute **en interne** (reasoning tokens, caches). On enregistre\n",
+    "le **total tokens** (prompt + completion + raisonnement) comme cout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "86adcabc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:22:15.376975Z",
+     "iopub.status.busy": "2026-06-15T22:22:15.376688Z",
+     "iopub.status.idle": "2026-06-15T22:23:47.075415Z",
+     "shell.execute_reply": "2026-06-15T22:23:47.073436Z"
+    },
+    "papermill": {
+     "duration": 91.709672,
+     "end_time": "2026-06-15T22:23:47.081757",
+     "exception": false,
+     "start_time": "2026-06-15T22:22:15.372085",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Raisonnement natif : single-shot deepseek/deepseek-r1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket facile    : single-shot 2/2 = 1.00 | avg total_tokens=300 (dont reasoning=276)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket moyen     : single-shot 2/2 = 1.00 | avg total_tokens=571 (dont reasoning=512)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket difficile : single-shot 2/2 = 1.00 | avg total_tokens=728 (dont reasoning=661)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Single-shot du modele a raisonnement, par probleme. (succes, total_tokens, reasoning_tokens)\n",
+    "reason = {b: [] for b in PROBLEMES}\n",
+    "print(f\"Raisonnement natif : single-shot {REASONING_MODEL}\")\n",
+    "for bucket, probs in PROBLEMES.items():\n",
+    "    for enonce, attendu in probs:\n",
+    "        verif = est_correct(attendu)\n",
+    "        txt, tot, rt = chat_usage(enonce, model=REASONING_MODEL, temperature=0.0,\n",
+    "                                  max_tokens=2000)\n",
+    "        reason[bucket].append((int(verif(txt)), tot, rt))\n",
+    "    succ = sum(r[0] for r in reason[bucket]); n = len(reason[bucket])\n",
+    "    avg_tok = sum(r[1] for r in reason[bucket]) / n\n",
+    "    avg_rt = sum(r[2] for r in reason[bucket]) / n\n",
+    "    print(f\"  bucket {bucket:9s} : single-shot {succ}/{n} = {succ/n:.2f} | \"\n",
+    "          f\"avg total_tokens={avg_tok:.0f} (dont reasoning={avg_rt:.0f})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "088b0847",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01477,
+     "end_time": "2026-06-15T22:23:47.105250",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.090480",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Comparaison cost-normalisee (la question Snell)\n",
+    "\n",
+    "On superpose, sur un axe **x = tokens depenses**, :\n",
+    "- la **courbe BoN** du modele standard (pass@k vs tokens cumules, par bucket),\n",
+    "- le **point** du modele a raisonnement (single-shot solve-rate vs ses tokens, par bucket).\n",
+    "\n",
+    "Si le point du modele a raisonnement est **au-dessus** de la courbe BoN au meme token-budget,\n",
+    "le raisonnement natif **gagne** au cout-egal ; s'il est en-dessous, le **scaling hand-rolled\n",
+    "est plus compute-efficace** (le resultat de Snell : hand-rolled compute-optimal peut valoir un\n",
+    "modele plus gros)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5f17e75c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:23:47.120351Z",
+     "iopub.status.busy": "2026-06-15T22:23:47.120072Z",
+     "iopub.status.idle": "2026-06-15T22:23:47.712464Z",
+     "shell.execute_reply": "2026-06-15T22:23:47.711824Z"
+    },
+    "papermill": {
+     "duration": 0.604042,
+     "end_time": "2026-06-15T22:23:47.712762",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.108720",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwIAAAH5CAYAAAAydolLAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAQ6wAAEOsBUJTofAAAvL1JREFUeJzsnQd4FNXXxk8KvSQQqnQR6V0QxEJXOiKiIApSFFRQEQWxIKKAAiqioChNpMlfepOuWOmKWJDeQgsQSoCQZL/nPTr7zW52N7vJbLLJvr/nWcJOvXPnzuzpN8Rms9mEEEIIIYQQElSEZnQDCCGEEEIIIekPFQFCCCGEEEKCECoChBBCCCGEBCFUBAghhBBCCAlCqAgQQgghhBAShFARIIQQQgghJAihIkAIIYQQQkgQQkWAEEIIIYSQIISKACGEEEIIIUEIFQFCCCGEEEKCECoChBBCCCGEBCFUBAghhBBCCAlCqAgQQgghhBAShFARIIQQQgghJAihIkAIIYQQQkgQQkWAEEIIIYSQIISKACGEEEIIIUEIFQESsPTs2VNCQkIyuhkkk7Jp0yYdPzNmzHBYHhcXJwMHDpTSpUtLWFiYlC1bVoKdxo0bJ+uHQHn+3njjDW3HoUOHJLONNX+DPsF50UdmsAz3zx/4euwbN25IpUqVpF+/fn5pD/EPeB/gvZDSe8JqEhMTpWLFivLkk0/69Tzk/6EiQNL842f+5M6dW6pXry5vvvmmXL16NaObSPxwzyF0XLhwQTJre9555x2ZOHGiPPTQQyq4ffDBB35tIyHBzEcffSSHDx+W1157TQIFvDMWL16c0c0gLoBxZsSIETJ16lT57bffMro5QQEVAZJmOnfuLLNmzdLP22+/LXnz5pXhw4fL/fffn6bjfvbZZ1QmAgwI3nhJB5Ii4K49d999t46fRx991GH52rVrVVkdO3asruvYsWM6tjjzwOePpJXr16/L6NGjpWvXrlKiRAkJFPDOoCLgO2vWrJG///7b7+fp0qWLFC9eXA2KxP+Ep8M5SBanZs2a0r17d/t3hF3Ur19fvvnmG9m+fbvUrVs3VcfNli2bfghJDaGhoZIzZ85ky0+ePKlhQcQzfP7SFyhd6O/w8Kzzs/zVV1/JmTNn/BamlJWx2Wxy5coVNawFCtmzZ0+3dzeMNDDWnDhxQm666aZ0OW+wQo8A8Ytrr0mTJvr/f/75x2Hd/Pnz1QJbpkwZFdIKFiwo9913n3z//ffJjuMqRvnYsWPyxBNPSLly5XT/QoUKqaIxatQoh+2SkpLkww8/VCUlV65ckj9/fmnatKlag93FQu7du1c6dOggERER+vJt3bq17Nu3z20sMDwgNWrU0HbA2jVs2DCNb3Tm1KlTMmDAAD0PXqRFixZVxck55hnHxLHXr1+v13PzzTfrsXENq1at0m3++OMPadu2rbYxMjJS++jy5cvJznnp0iV55ZVXNNYyR44c2s/od2dXqy/Xgz6CJQ2g/41wMOf4ZHcx3ujf119/Xe892lS5cmWZPXu2S6sTLIjly5e33ztY95ctW+awXUrtcY7bNtpx8OBB+fbbb1NsP8YQFIZbb73V5XqMWexvDnnA9TRs2FD7G23H/p06ddL7lhJ//vmnXnepUqW0f4oUKSJ33HGHfP7558kEBFxTo0aNtG8QjocYbCjg8fHx9u0mT54s9957r5QsWVLHHY73wAMPyO+//y7e4Or5M5ZdvHhRxzSsdmhrnTp1VPF3Bm19//33pUKFCrod7iksxBjjvsbU49qsHD+puR6A94rxXGHcjRw5UhISEsQXjFhrhMw8/PDD+h7DfcT7DRw/flz69OmjzyHuHe4h3nvR0dGSFjZu3CitWrWSAgUK2PsQoXKu3lt4VzZo0ED7sHDhwtKrVy85e/asT+fD+x79f+edd7pcv3nzZn3n4vhoD56Xbt26yf79+x22W716tf6m4FhoT61ateTjjz/W8eXL74PxTgAzZ850CGtNidS8+//66y+9v3jn4/rwTh88eLCON1fv/nXr1unzgXcOth83bpxDHsjChQt1bBrvFqwHsbGxGlNfrFgxXYffOrxvnd9n6AeMPYxzjCu0vUePHnLkyBHxBlc5Ar68t+BlhJEwT548+sF27jwzbdq00efq66+/9qptJPVkHdMDCSiMF3lUVFSyeFH8COFHDi+jo0ePaiwgXvIQzvBicAdeCi1atNB9+vfvr8IPhGC8bDds2KAvY/MPPF7WEJbw8sN2eDFBMPriiy8cPBjGDy+Ehfbt2+sPIxQYxJHjR2r37t1qoTDz6aef2n+s8SOGFzRe4PihGjp0qH07tBXXhPP37t1bX/DYD0IaBJZt27Yls06//PLL6lLHNUKpmjBhgrbjf//7nx4DbtN27drJTz/9pD9mePmiPQb4kcEPL5QYvOShSJw/f15fwhBS8eOLHxNfrweKBQTcRYsWqXCHH1mAH0RvQFvwgwaBFf05adIkvQ8Q2CBwmH8UoTxhHQQgWBRxnbg38+bN09j+1LQHAvktt9wizz//vG6L/T1tjzY+9thjGu72ww8/6FgyYwixhrUTQinajO0QGgdlEn2KsQl3epUqVdz2TUxMjD4D+LHGDzoEGdwzjD08F7gvBjgfxnDt2rXlxRdf1B9ePG+4Z3ClG1a7d999V26//XZ5+umn9XoxpvEMQMDbuXOn9ntqwXMERRRjFcnXyLPA/cE5zOP5pZdeUmEFP/4YzxjX06dP13vmK1aPn9RcD54FvB8M4RLXg/fXkiVLfL4evBPuuusuqVevniq0UN6NMYNlp0+f1vuO5/fXX3/V5xcC8datW1Ww9JVp06bp8TBucB24XoxrXDPGA/rGYMWKFXYBfciQIfqcYXzBaOMtEIzxrsG9d35/AoxFjHWcA+3CmIe3DtcIZdUYn+jfvn376n3AeEcf4V34zDPPaL9MmTLF698HKD74XYC1GX0PpcFXvH3379q1S39T0K6nnnpKlQAYD8aPH6+KMPoeyp8ZXB/GH8Y6jg3h2nxPoPzg2nBu3C9sD2UEzxSEehgloCziHDD8oB+NvocijbGL9yCEbBiTYBjCuEB78H/cZ1/w5b31+OOP63sL4+qRRx7RZeg7hBDj99A5mfy2227TdxmUVyjpxI/YCEklGzduhDnG9vLLL9vOnDmjnz/++MP22muv6fIyZcrYrl+/7rDP5cuXkx0nOjraFhUVZWvdurXD8h49euhxDH799Vf9PmbMGI/tWr9+vW7XqlUrW0JCgn356dOnbUWKFLFFRkbaLl26ZF+OdmL7OXPmOBxn9OjRuvybb75Jds3FihWznTt3zr48MTHRVrlyZVvx4sUdjtGxY0dbgQIFbPv373dYfvDgQVvevHltPXv2tC+bPn26HrtmzZq2a9eu2Zfv3LlTl4eEhNjmz5/vcJwOHTrYsmXL5nA9zz33nC77+eefHbY9f/68rWTJkrbGjRun+nqGDx+u26P93mLsg/uB4xocOXJE29m1a9cUx8iVK1dsFSpUsFWpUsXr9hjXhn41g/t9zz33eNX2f/75R4/Rp0+fZO3Jnz+/7a677rIvu//++2358uWzxcfH23xlyZIlep558+Z53G7BggW6XadOnWw3btxwWJeUlKQfT/34+++/a58/9dRTDsvRH+gXT8+fedkTTzzhsPynn36yvwsM/v77bx2zjRo1cuiTCxcu2EqVKuXy3qT3+PHlejAWQkNDbfXr13d4PmNiYvQ58fZ6jP7G9kOGDEm27tFHH9V1s2fPdlg+c+ZMXd67d2/7Mox7LEMfmcEyXJv5HZszZ059H5nHCBg3bpxuv2nTJv2OPi5btqy+n9DHBniX4h3tfGx3GG3r169fsnXHjh2z5ciRw1auXDn93XDGuM8YK2gH+te8HcZ+ixYt9PibN2/26ffBVf94g6/vSrwbMP6///57h+UjRozQ44wcOTLZu798+fIO73JzP+bKlcvhdwRjsGjRonqO/v37O+zz/vvvJ/vtwn3Hc+DM2rVrddt33303xfek83vC2/fW4sWLdbv33nsv2bp27drpu/TixYvJ1qE/brnlFo/HJmmHoUEkzcAaAusFPrB6wlXesmVLdXM6xxTCHWgACxgsCoiJheXyl19+8XgeWDAALASwHLnDcCXCOgKLugHaB+soEkthATGDGES4N83AugScXawAbnJ4NgxgdWnWrJlaY4xQHbhrly5dqiFGsBbBrW58YNWCFdNV+AHaCCu/Adzg2B8eFHgDzNxzzz1ans8IM8Jv3JdffqmWf1jUzOeEZQr3BVY65yRQb64nrcASb7YMwtqFEAvn/jWPEcTIYozASgZ3N0JsMG7SC3gQ4F1BrLO5z2DJgufFHPsMCyvaiRAUWMh8AfuClStXekzExr0FsPg5x5I7hzgY/YgxgbZiDMCSjD5P6VlLCYQ3mMFYxpg230u4/HFu3HdzrgGeY1g1A2n8eHM98GLgvmJb8/MJKyqe2dQAa7sZHB/9hutCiIwZWLHxTGPsOYfEpAQs6NeuXVMLLfrD/F5AqCEw3kXI68L7BN4ws0Ua71Kz1zUl4Ilx5RUGCxYsUG8KQr0MT54Z4z7Da4r3DyzC5u0w9l999VWH9723vw9pxZt3Ja4d71n8hjh7EjF+MEZdhbzAy+EuJwCWc3gVDDAG8btpPGPOvwvAPH6Nqn7GOMN7Bvcfvy/ou9S8E7x9b8ELg5AleOPMYw8feC7wfoKH2xmMHXjGiH9haBBJMxCG4OqDoIkQCLgfEauJB98ZuB/x8oer1vkHOaU4TcQGI+QCigYEd1R+gZCGF4khtIMDBw7oX6x3xljmHINqfsEaGD9g+OF0JqXtDSECL1yEjLiKZQauXOaujo0fHvOPsnm5uY3Gy/W7775Txccd2MZ8PG+uJ624OwfipM1ACIEShx+Xc+fOJdsHrud8+fJJegGXNkKyIIAZLm2En+BH9cEHH7Rvh1AjuP4Rh4/7AgEAwicEupRCORBCAAEDbvo5c+Zo6BbGNipyQakzwJjCsb2p5Y0xgFChH3/8MZniBxe+P+6l+VkxnkOEaDiDEI1AGj/eXI/xznAV4lW1atVkYTGGIGwAo4g59ALPp1mgBNgH78Vq1aolOwfejzgPjAu4Bl/COBDHDQyh3xUIp/L1Or3BldJiCKjOIYrO+PIu9/b3wRMw3jg/K+hns0HLm3elp3bjvQGFzvk3CLjLR3J3XmP8OK9z/l0wgJKJkEEoe+Z8IuDqWUkJb99bGH/oV0+Vo4zx5zx2AmEuk6wOFQGSZvBSa968uf4fMaSwOiMOFUlSEEaMBxnKAV4SeFEiLhUCAiwjEIbhVYBykBJImIJghuRZWFxgVUGsMOIOYbFL7UvD7Dnw5ofMm+0NqzCs+IhxTWtbfDknXtCe6nY7Kwm+Xn9qcHcO8/FhUUPb8YP87LPPavw+vCEYI/ixmTt3rs/W9rQCYR8WScSZQxFADDKsjohBNwuUeA727NmjSYXwOGF8wvpnCKW4Lk8gFhoxvxjbUChwve+9956eGwmqvoAfelgpISAgxwF/IYDg+UC/wlLu73tpNf4cP1ZfD8aIs7IFKy3GhoFzfLg/Ma4ZcfkQmF1hdWUW4x3jypDiL9L6+4Axg+fcDJ5188Ra/nxXehoTns7rzfhFHgu8Coi9x3sFOReGsQ6/1al9r3rz3sKx4XWAZ8odrpRMjB3kQBH/QkWAWA6sfXihwvKAH17DxQ2LKqxdsErAUmrGSNz0BvyQIbEIH3gh4JGAxR3JSXhhG0lmEMrgOjVjVExJS6KkL2ElEEBgCTEUJX+DH1+4a2Ex9Mc5/W2dgTJoJJDD0mQGyZLp3R4AYR9WfowxKLNIeMMPm6uSiAiBgfXRsEDCA4YfXnjBzEKgO6Ac4wNXP8YNwsqQtD5o0CD1AsBiCOsarODuBDqAtuLZwI+zs7UQP66uyqpajXFeJGs6/8gbFuqMHj++YLwzEF7kfD1415hB9RbnCmXO1n93zy/Gm/PxDKEOy3Ecb47lytKM/VJ6L5iv0xlX7XIHPI5Qwpwrx5nbgyRlT8UGzO9yZ2+Gu3d5Sr8PnkByu3MhCSRrp3bsu+ovPNfwGOD3IT2BgoPnHv1gVjhgFMDvRVrw5r2F9wAMhK5CxVyBUDa8bz15sYg1MEeA+AW8UGH5h4XGKK1nWC2crSYQVrZs2ZLiMWHlQzy8GcSKGi9qw/KEqggAVT3MVg6Ew6DqAgRlWEv9DV54eCGi2gOsSt66Q9MCFA/8kKFqg7Nly4pzGiFCqXEje4O7MQKB2lWZOX+3xwBWRowlKAHoV6PkrBnnUBBDKYbXKyWrKNrvbJGDtc4IzzD2N4QUeBpclSs0+s1dP37yySeWjzl3wAoLRQ0VnczPLZ5jVAkJhPHjCwgxwfWgChLi2833Du8VMxC4IHCbP97Mp4LnF+eB0ORsPYUwi3ASvN98VYDhlUSb8D52lfMD4c0I1UR4B4RpjHUoVc7lJ325F6jMg3e781iFlw0x7gjjcfXsGs8CFGo846g2ZxZWcTx4ugCUdF9+HwCO6eq8eN6c75uvSpeh0OHakXfh/NuG/B7cA6Pd6QXuB8aN83sG9yC13gBv31vINzHkAldeE1fvJCN8yShFTvwHPQLEb0IwEp/GjBmjPyiwzqF+NYQiJL0ZJQ137NihP3CIpYTw6gkI0wixgXsTyXQQ6GG1gnCD2EPD0gVvA86BBCW8RLC9UT4UiUdoT3pN0oK2IRwKP2jwjKAsIH7sYdFFuAisxb7UUvcG/EAiLhyWMAg/+EFCv6NWNEJW8KJ2p5ikhFGmEUmOCJOBcIF4ZlcxzakBcfVIin7hhRfUagaBG9ZjWHMxRvDjkJ7tca6fjfwXJLYhFtlZGEMJSlhzEZoCtzsSVFHiD0l0RmKjOzAm4U6HEAgLJyx2uFaMWQgySOgDiL3FdeKZQVlGCIVwnWNuBCRgorQkngssx/HwzKFEIo4Htz0EExzf17r3qQHP6HPPPaeKAJ4BJArihx2lDo3SwVZ7dHwdP76AuRBwXCgCOA+KC+B6cI8QVpPWGv8GELZRaAHHx3OKdhvlQ2FlNwRgX8D7EWUv8R7GfUF5SlitIchB6YC3Fu8KjHMIjAjpwHsTYwyWdQjD2MbXwgG45zCEwBtmNr6gPTgHjg3vChRthFLh/YzyoVB0jTldUMoV7328K9F+vMugJKH8JpYbcxR4+/tgvDfQx3ie8axiHCI8xkpwfXgX4PcIyfFG+VDE0uOZhrU8PYHyhX5DiBp+GyCQ432APnKVsO0N3r63oPTg3mAMYyxje3jNMFkYtsdvobMSt3z5clXkDMMe8SMWVB4iQYpRTs1cBs0Myr2h9BtK0RllRFFK7e6779ZyYSi12LRpU13mqVShwYEDB7QUHUoAYn+UU0NpsQEDBtiOHj3qsC9Kun3wwQe26tWra5k6tKNJkyYO5dRSKifpqjSfu5KUnkpZotTc0KFDbZUqVdK24Lrx/759+zqU+DRKyOEc3rbR3T5xcXG2UaNGaSlS9FOePHm0rx555BGX5VB9uZ533nlHy/6Fh4e7LF3o7XHcla3cvXu3lilE2dXcuXPbGjRooGXqfG2PFeVDXV0HyvVhLDrz2Wef2e69914tI5g9e3Zb4cKFdaw7l3x1BUrEopQsSlxirOJ+YYy88sorDqUKjTKAn376qa1evXraP8a2KBtrLte7dOlS22233abboC9Rpm/Pnj0u+9zX8qGucNWvaOvYsWO1DCD6BPcJ43LRokV6HG/6xp/jJzXXg9KMeJZQuhTvtjfffNNegtGX8qHO7TaD9xnKhGIsYVzfdNNN+r44ceKEw3belg81wPumc+fOWnYS7cffhg0b6jscZVDNrF69Wkul4p1VqFAhHZ94p/tSehMlLvEcoCSqu1LP9913n94rjI/SpUvrO8q53PLKlSu1z/BsoD01atSwTZw40aEUqi+/D3v37tXyo3gX43q8EYVS865EOe0uXbpo/6G/cc8HDRqkZVHNeHr3u7vHnsavu32mTp1qq1atmpaSxX3p1q2b9o2rse5N+VBf3lsAJbpRvjoiIkLvN8oIoyzw5MmTk/1+o9T1Aw88kOwYxHpC8I8/FQ1CCCHEzNixYzVM4Oeff06Wx0OyFvAIoTgEJjjEBG+EpAQ8qQiDRMSAtxNWktRDRYAQQohfQHiUcyUUxHIj3MVIBnSea4RkLRDygfuNkBTzDOiEuAL5H8gxQJgax0v6wBwBQgghfgHx0IjRbteuncbRI08FOQLHjx/XMoNUArI+qKSFPARCvAE5KpiPiKQfVAQIIYT4BSQLIpkZygAqiCBRHSUEUTUIygEhhJCMhaFBhBBCCCGEBCGcR4AQQgghhJAghIoAIYQQQgghQQhzBFIAlS0w0RVmCsTkFoQQQgghhGQ0mBwSs9qjMhcm1EwNlGxTAEoAZlckhBBCCCEk0NiyZYvUq1cvVftSEUgBeAKMTsbU9ahxi+oXUVFRWuaKWAv71/+wj/0P+9i/sH/9D/vY/7CP/Usw9G90dLQaqw1ZNTVQEUgBIxwISgBmRcTAypEjh3Z6Vh1YGQn71/+wj/0P+9i/sH/9D/vY/7CP/Usw9W94GkLXmSxMCCGEEEJIEEJFgBBCCCGEkCCEigAhhBBCCCFBCBUBQgghhBBCghAqAoQQQgghhAQhVAQIIYQQQggJQqgIEEIIIYQQEoRQESCEEEIIISQIoSJACCGEEEJIEEJFgBBCCCGEkCCEigAhhBBCCCFBCBUBQgghhBBCghAqAoQQQgghhAQhVAQIIYQQQggJQqgIEEJIGklISLB0O0JI+sHnlwTzeKEiQAghaWDRokVSoEABeeKJJyQxMdHlNliO9dgO2xNCAgM+vyTYxwsVAUIISSV4yXfp0kUuX74sn332mfTp0yfZjwO+YznWYztsnxl+HAjJ6vD5Jb6QVccLFQFCCEnDj0KiLVGKP1pcshfJLjNmzHD4cTB+FLAc67Edts8MPw6EBMXzm2STgi36S3hkcY/PL9ZjO2zP5zd4x4skJsprRYpKqWye3/dYj+2wfaCPFyoChBCSBiWgZL+SEtUsSsoNLWdXBuAWvnHjhv41lACsx3bYnsoAIYGhBES1f0ny1WkjRbuOdlAG8PyalQCsx3bYnspA8CoB44oXl64FCsjMUqUclAHzeMFyrMd22D7QlQEqAoQQkgYlIKJehC7PVjCbXRmYOXOm3HXXXfrXUAKwHmB7KgOEBIYSkKdiI10enr+QgzJQqVIlByUA6wG2pzIQvEpAy3z5dXmxbNkclAFjvBhKANYDbB/oykCIzWazSQCzb98+GTdunPz888/y+++/a2fjb0rgst555x2ZNGmSnDlzRmrVqiXvv/++NGjQwKfzHzt2TEqVKiVHjx6VkiVLqusHxytcuLCEhYWJP4i7EScrDq6Q5fuXy7lr56RgzoLStnxbaVOujeTOlts/54xPkMU7T8iincck5kq8ROXJLvfXLikda98kubOHp1u7fOlfb9qcFe6N1aR1DHvqA7FlT/d7kp6gCkRkZKRcuXJFw3xg4XfmxrkbcnDMQYk/HZ9MCTATsz5GomdFS968eeX8+fMSHu5b/2TE+A8U0uM9HOxkxT42P78I84GFP9k2F8/KqbkvS8KF6GRKgJlLO1bIubWTU/38ZtU+DiTS2r8JpvGCMB9Y+J05eeOG9Dh6VI7eiE+mBJiZe/68jDx9Kk3jxRsZNTUE/K/Fnj17ZMWKFXL77bdLUlKSfrwBSsDw4cNlzJgxUqNGDfn444+lZcuWsmvXLrn55pslUDkYe1D6rukrp+JOSYiEiE1scvjiYdlxeod8+uun8lnLz6RcRDlLz7n/zGXp/vkvEh17TUJCoESJHDx7RbYeOi8TN/wjX/a5XUKzn0n3dqW1zeUL58309ybQ8NQHE3/5Sq4e6SNnLiWk2z1Jb/Dy7tatmyaCxXwTI/lr508m5Ktn4OVycn7zeSlwVwHJViCbS2UB+4OuXbv6/KOQEeOfkMyO+fm9uHWx5Lrl9mRCvnoGuo2RK7vXSZ7qzSU8X5RLZQH7p/b5JZlvvMw4f16a5M2bTMjH91mlS8nC2FjpFBEhRcKzuVQWsH+gjpeA9whA8A8N/TeCqWfPnrJt27YUPQLXrl2TokWLytNPPy2jRo3SZfHx8XLrrbdK69at1UsQiB4BWFrbL24vZ+LOSJIkV3hCJVQK5y4sSzsutcz6DKtis/HfyqmL1yTJxUgIDREpki+H5L55nMRcj/Z7u7zpX2/aXDR/Tln/wj2WWUYz4t74i9SOYU99YEvKJlf2vyC2hPwuIw79cU8yCucEYHcWf3eYPQZ4p33++ee+3YcMGP+BBi2p/ier9rFzArA7i787zB6D1Dy/wdDHgYIV/ZvolADszuLvDrPHIK3jJWg9AoYS4As//vijXLx48d+4rv/Inj27dOrUSRYuXCiBCsItYGl1B4QvrF+6f6l0qtDJknP+b/sxtSq6PadN5OTF65IjuqRkizwpIskHMPLlT14+Kwv3LpWOt3RMU3vw0F2Ovya5rl9z+7As2HY8xTZj/VdbD0vn20qIFSzet1SvUSTE733gb7zpY1/74MaFumJLiEzxnny9/Zh0qVdKMjsff/KpxgjP+mKmCvXeKgNmJeDRx3rocRJscEG7rked2mcW65fsOiFd65f2+riEBAN450EYAxDuINR7qwxYqQSQzDleehw96rUy4G8lIGg8Ama89QjA4g9vwNWrVyVnzpz25XDvPPnkkxrvlStXLpf7QoHAxyA6Olrq168vhw4dsnsEzp49K4UKFbL8hvZa00t2nt6p4RbpxZVDT0rS1TLMGyfER2xJiRKzaqJc+X3dv56Bl8u5DAMyuHH+hhwc/a8SkKdac4lqNUBCQv3zo4BwoXplCsjcvrdLVsSf72ESHH1sTPqEhH71DHQb4zIMyCDh0lk5NedfJaBHjx4yZcqUNPdLVu/jjMbK/k00jRd4BhAO5CoMyODUjRvy2H9KgFXjxZ1HoGzZslnbI5AakIiRI0cOByUAYJY36D1Y704ReO+992TEiBHJlsfExOgxEaoUGxubam+FJ85cOZOuSoCSmIdKACGpAEJ81H3PyPVjv0v86ZOaE1CkfRG322M9lIDwyGK6n7+UAADzzqnYOHWLZ0X8+R4mwdPHI0eOlE2bNsnhw4c1JyDijofcbnt59zpVAsqUKaP7nTt3Ls3nD4Y+zkis7t+RpvGCnIB+Ue69SIsuxqoSYOV4cQVk07SSJRWBtDBo0CCNB3P2CERFRWmcmTFxhD80+MJ5CsuxK8fSVxkIu6JBR1QGCEmFR2D1R5Jw4aR6BJAY7Amsv/D9BVUasJ+/PQJFI3LrOysr4s/3MAmOPjYsvBDq4BFAYrAn8lZvLld2r9ftX3vtNcs8Alm5jzMaK/s30TRe4BFAYrAn7s8fIYtiL1o6Xlxx/fr1NB8jSyoCsPyjc5A0bPYKwBMQEhKi692RP39+/TiDG2jcRGiW5u9WgRKMqL6SEq/c/oplOQLzthyT15f8meJ2OYoukmyR2zxuM7T+UEtyBM6cPSOFCxX2mCMwYtlfKR7rjXaVLMwRWCxjtoxJcTsr+sDfeNPHvvbBjQv15PqplK97ZIeqWSJHAH3Y74knZJYRFjTUc1gQwHpshxwBhBN1qlNCPknFj8P8rUfl9SV7UvQI3F+nZJYWLvz1HiZZv4/x/CJM2B4WhBwBD2FBIDzfv/MMIEcA+0GWsCLmO6v2caBgRf8mmsaLkTDsKSwIFP1vngHNKbBwvDhjxfGypCKAuQbA33//LTVr1rQv/+uvv6R06dJuw4IyGtRhRxnKlCrTtC/fXrKHZbfknJ3rlpbJmw6mXDWo+DGJuW7z2K5Ot7aX3Nkcw7FS88BdzZ5T8ubI6XaAP1SvjEz57lCKVVO61CtjWdUUXNuMPz5P8d5Y0Qf+xps+9rUPskVul/iYxilWDXqgbknJER6W+ZWAfk9qorCvVYOMScegDGD/sFDffxw61y0pkzftT3H8d6h1ky+XRUhQkJaqQcakY1AGsD8I1ARQYg2JaagaVMykDATyeMmS8SB33HGHWvUXLFhgX4bpn1ExCOVDAxWUnUQtegiUAHXazX+xHOutLE8JQRk1xyE46Ln+PZX9L5bP7ttApraanK7tSmubsd7K0okZcW8CDU99EBJ6Q0pVXCyF82VPt3uSUfTv3z/F0qFIDD699LT+dcY8AzGOg+MF+vgnJKtgPL+elAAkBl/4cZ7+dcZ5BmJfn1+SOcdLKQ9KABKDP4k5q3+dcZ6BOBDHS8BXDYqLi5OVK1fq/zEp2P79+zWhF9xzzz0aA9usWTONw8IsxAaYSOyNN97QicWqV6+ulYTWrFnj84RiGTWz8MqDK2X5geUSczVGonJFSdub20rrcq39OrMwyg0u3nlczly+LoXz5pCOtUuoVdE8s7C/2+XrzMIptTkr3JtAnFnYXR9gZuH0vifpCWaaRGjh5cuXA2Jm4azc155g/XX/kxX72Pz8cmbhrI8VMwsX+G+8ZOWZhQNeEUDZznLlXM/WunHjRmncuLF+sB0+BrgsKANQADAQatWqJe+//740bNjQp/NnhCIQzLB//Q/7OG0sWrRI5yhJtCVKyX4lJaJehEslANUiYKBwpQzEbo2VY58ck7CQMPnqq6/k/vvvz6CryZxwDPufrNrH9uc3ySZR7V+SPBUbuVQCYDA8cOCAS2Xgyt8/SMzSdzW0Ly3Pb1bt40DBiv5d9N94kcREGVe8uLTMl9+lEmCMF1fKwJpLF2VwdDQC+i1/31uhCAR8aBDqo0Kod/WBAgBQzsmsBAAkZrz88svaOUga/vnnn31WAgghxBm8xPEyhxAPYR5CvbMSgLrRmzdv1r/4juVYD6gEEBIAz29oiArzEOpdTRaGnEL8xXddfvGspUoAyVzjRcLCVJiHUO9qsjBjvOi8AUeP6np/KwGWAY8Acc/Ro0fhMdG/ICEhwRYdHa1/ifWwf/0P+9gaFi5caAsPD7eFhIXYij9a3Ja9SHZ9V/Ts2dN2/fp17WP8xXcsx3psh+2xH/YnqYNj2P9k9T62P7+hYbaCLfrbwiOL259f45rx13h+sR7bYXurnt+s3scZjZX9u/C/8RIeEmJ7rUhRW6ls2T2OF6zHdtjen+97Zxk1NVARSAEqAukL+9f/sI+tw/hxwDvC/KNg7mPzj4MKFFQC0gzHsP8Jhj529/ya8efzGwx9nJFY3b8LM3i8+EsRCPjQIEIICXS3MRLA+vbt67I0HL5jOdZju4B1DxMSZPD5Jb6QVcdLwCcLZzRMFk5f2L/+h31sPaguYa4C4a6PnbcjqYNj2P8EUx97+1xa/fwGUx9nBP7q34QMGi9BmyxMCCGBjrcveyoBhAQefH5JMI8XKgKEEEIIIYQEIVQECCGEEEIICUKoCBBCCCGEEBKEUBEghBBCCCEkCKEiQAghhBBCSBBCRYAQQgghhJAghIoAIYQQQgghQQgVAUIIIYQQQoIQKgKEEEIIIYQEIVQECCGEEEIICUKoCBBCCCGEEBKEUBEghBBCCCEkCKEiQAghhBBCSBBCRYAQQgghhJAghIoAIYQQQgghQQgVAUIIIYQQQoIQKgKEEEIIIYQEIeFWHzAmJka2bNki0dHRcvXqVYmKipKKFStKrVq1JCQkxOrTEUIIIYQQQjJKEYiNjZWZM2fqZ9euXWKz2RzWQwHImzev3H///dK3b19p1KiRFaclhBBCCCGEZFRo0KhRo6RcuXIyYcIEadGihSxatEgOHjwoly5dkvj4eDl9+rT88ssv8s4778j58+elWbNm0rx5c/njjz/SempCCCGEEEJIRnkENm3aJAsXLpTGjRu7XF+oUCH93HbbbdKvXz9VBj766CPdr0qVKmk9PSGEEEIIISQjFIE1a9b4tH2BAgXktddeS+tpCSGEEEIIIYFSNejNN9+UEydOuFyH5GGsJ4QQQgghhGQxRWDEiBFy7Ngxl+ugIGA9IYQQQgghJIspAqgW5K5EKDwCkZGRVp6OEEIIIYQQklE5AnPnztUPgBLwwgsvJBP4r127Jtu2bWPZUEIIIYQQQrKKIoASoSgVangErly5ImFhYQ7bZM+eXR577DF56aWX0no6QgghhBBCSCAoAj169NAPaNKkiUyePFkqVapkRdsIIYQQQgghgTyzsMHGjRutPBwhhBBCCCEkMyQLg507d8qDDz4oxYsXlxw5cujfLl26yK5du6w+FSGEEEIIISQQPAKbN2+WFi1aSLFixaRr165StGhROXXqlCxatEgaNmwoa9eulTvvvNPKUxJCCCGEEEIyWhEYOnSoNG7cWJYvXy7h4f9/6LFjx0qbNm10/ffff2/lKQkhhBBCCCEZHRqEsKCBAwc6KAEAVYSwfMeOHVaejhBCCCGEEBIIikCePHnk9OnTLtchRAjrCSGEEEIIIVlMEWjXrp0MGTJE1q1b57Ac319++WVp3769lacjhBBCCCGEBEKOwPjx42XPnj1y7733Sv78+aVIkSLqIbh48aLUq1dPxo0bZ+XpCCGEEEIIIYGgCBQoUEB++uknTRZGUvD58+elYMGCWikIycKhoZZXKyWEEEIIIYRktCIAIOwjBIhhQIQQQgghhASRIgBOnDghx44dk2vXriVbd/fdd/vjlIQQQgghhJCMUgQOHDggjz76qPz888/63WazOawPCQmRxMREK09JCCGEEEIIyWhFoG/fvuoJmDZtmlSpUkWyZ89u5eEJIYQQQgghgagIbNmyRWbOnCmdOnWy8rCEEEIIIYQQi7G0jE+JEiV0FmFCCCGEEEJIECkCb7/9towZM0bOnTtn5WEJIYQQQgghgRYa5FwmFDkCZcuWlVq1aklkZGSyZOElS5ak9ZSEEEIIIYSQjFYEMGswBHyDW265xf7/S5cupfXwhBBCCCGEkEBUBDZt2mRNSwghhBBCCCGZM0fAHfHx8elxGkIIIYQQQkhGKAKzZs2SiRMn2r///vvvUqFCBcmdO7c0btxYTp8+beXpCCGEEEIIIYGgCIwdO1ZCQ///kAMGDNBJxT744AOJjo6WYcOGWXk6QgghhBBCSCBMKHbo0CGdURicPXtWNm/eLMuXL5f77rtPChcuLIMHD7bydIQQQgghhJBA8AjAG2DkA2zcuFGyZcsmTZo00e/FixeXmJgYK09HCCGEEEIICQSPQM2aNWXSpElSsmRJ+fDDD6Vp06aSI0cOXXfkyBEpUqSIlacjhBBCCCGEBIJHYNSoUfLdd99JjRo1ZPfu3TJixAj7ukWLFkn9+vV9PuZff/0lLVq0kDx58kixYsXkpZde8qoKEbwP/fr1k9KlS+u+1apVk08++cTn8xNCCCGEEJIVsdQj0KhRI7X87927V8qXL+8ws3Dv3r0dJhvzhvPnz6tXAZWHFi5cKMePH5dBgwZJXFycfPTRRx73ffDBB1WJgHICZWDlypXSv39/CQsLk759+6b6GgkhhBBCCMkKWKoIgHz58kndunX1/1AKbrrpJgkPD5fWrVv7fCxY8DFzMbwJBQsW1GUJCQny1FNPaQUiHNsVJ0+e1ByF6dOnS8+ePXUZFIqtW7fKvHnzqAgQQgghhJCgx28TiiUmJkq5cuXkt99+S/UxVq1aJc2bN7crAaBLly6SlJQka9ascbvfjRs39G9ERITDcny32Wypbg8hhBBCCCFZBcs9AmbSKnQjtKdXr14OyxBuhApEWOeOUqVKScuWLTUsqGLFivodSgWUh9mzZ3s8JzwQ+Bhg/gNDsTE+UETwl1gP+9f/sI/9D/vYv7B//Q/72P+wj/1LMPRvogXX5ldFIK0gR8CcZ2BQoEABOXfunMd9kVPw0EMPSdWqVfU7cgMw6/EDDzzgcb/33nvPIcnZnHyMCkgYVLGxsbrMPHkasQb2r/9hH/sf9rF/Yf/6H/ax/2Ef+5dg6N8YC8ry+00RCAkJkTJlytjLh6Yn8EQ8/vjj8s8//8icOXPUg7B27Vp57rnnVIl4+OGH3e6LZOQ+ffo4eARQ7SgqKkonRTO0r0KFCqlyQayF/et/2Mf+h33sX9i//od97H/Yx/4lGPr3+vXrgasIQPs6ePBgmo4Bod3Q5pw9Bea8AWdWrFghCxYs0PyE6tWr67LGjRvL6dOn5YUXXvCoCOTPn18/zmAQGQMJ12b+TqyF/et/2Mf+h33sX9i//od97H/Yx/4lq/dvmAXX5RdfyZ9//imzZs3SGH1U8AH79u2TS5cu+XScSpUqJcsFgGIAKz3WueOPP/7QzsHcAWZq164tJ06c0PKjhBBCCCGEBDOWKgIQsLt166ZWeCT5vvbaayp4g5dffllGjhzp0/FatWol69atkwsXLtiXwdIPDQ/JwO5ASBJcQs4Vi7Zv366zG+fOndvnayOEEEIIISQrYakiMHjwYNmwYYNO3oXKO+aqQZhHYPXq1T4dDzMDY16Cjh07asUfzAvw4osv6nLzHALNmjVzmKwM58IkYp07d5Yvv/xS1q9fL0OGDJEZM2bIgAEDLLpaQgghhBBCMi+W5gj873//k7Fjx6q13rmkUdmyZeXQoUM+5whAiIfwDmUASgESed9++22H7XAuTDRmgO2w3yuvvKIKADwKmNMAFYGeeeaZNF4lIYQQQgghmR9LFYHLly9rhR5XXLlyJVXHrFy5soYHeWLTpk3JlsFDMH/+/FSdkxBCCCGEkKyOpaFBNWrUkK+//tptJZ/bbrvNytMRQgghhBBCAsEjgOTgDh06aNLwgw8+qHMJbNmyRebOnSvTpk3T3AFCCCGEEEJIFvMItGnTRubNmyfff/+9xvQjWfipp57SEJ3Zs2drUi8hhBBCCCEk47F8QjFU6sFn7969cvbsWZ34y1PNf0IIIYQQQkj647eZhW+99Vb9EEIIIYQQQrKgIoCSnN6CnIHnn38+rackhBBCCCGEZLQigEnEvIWKACGEEEIIIVlEEUhKSrKmJYQQQgghhJDMWTWIEEIIIYQQEoTJwt99953bdaGhoRIREaEJxDly5LDytIQQQgghhJCMVAQaN26seQAGmEfA/B3kypVLnnzySRk7dqwqB4QQQgghhJBMrgisXbtW+vTpI82bN9cZhosUKSKnT5+WRYsWyfr161X4/+233/Rv3rx5ZcSIEVaenhBCCCGEEJIRisCUKVOka9euMmrUKIflbdu2lWHDhsncuXNl4cKFmmA8a9YsKgKEEEIIIYRkEJbG5qxcuVKaNm3qcl2TJk3UY2D8//jx41aemhBCCCGEEJJRigDCfTZu3OhyHZZjPYiPj5d8+fJZeWpCCCGEEEJIRoUG9e/fX8N9zpw5I+3atZPChQvr/5csWSLTp0+XN954Q7f78ccfpWbNmlaemhBCCCGEEJJRisDrr78ukZGR8s4778jnn3+uFYNQOahYsWLywQcfyIABA3S77t27yxNPPGHlqQkhhBBCCCEZpQiAgQMHyjPPPCPHjh2T6OhoKV68uJQsWdKhVGilSpWsPi0hhBBCCCEkIxUBAKG/dOnS+iGEEEIIIYQEgSLw999/y9dff60egWvXrjmsQ6jQ1KlTrT4lIYQQQgghJCMVAcwN8Pjjj0vOnDmlTJkykj17dof1zrMME0IIIYQQQrKAIjBy5Ejp3LmzTJs2TXLnzm3loQkhhBBCCCGBOo/AiRMnpG/fvlQCCCGEEEIICSZF4O6775bff//dykMSQgghhBBCAj00aNSoUTpHAHIEWrRooXMKOFOwYEErT0kIIYQQQgjJaEWgTp069hmG3SUGJyYmWnlKQgghhBBCSEYrAkgSZmUgQgghhBBCgkwR6Nmzp5WHI4QQQgghhGSGZGFCCCGEEEJIkHgEatSoIXPmzJFq1apJ9erVPYYGYd2vv/6a1lMSQgghhBBCMloRqFu3ruTJk8f+f+YIEEIIIYQQEgSKwPTp0+3/nzFjRloPRwghhBBCCMkKOQJxcXGyb98+sdls/j4VIYQQQgghJCMUgXHjxsmIESPs3zdv3iwlSpSQihUrSoUKFWT//v1Wno4QQgghhBASCIrA559/LiVLlrR/HzRokFStWlWWLFkihQoVkmHDhll5OkIIIYQQQkggzCNw9OhRueWWW/T/x48fl+3bt8u3334rd911lyQkJOiMw4QQQgghhJAs5hHIlSuXXLx4Uf+/fv16yZs3r9xxxx36PTIyUmJjY608HSGEEEIIISQQPAL169eXMWPGSGhoqIwdO1ZatWolYWFhug75AcgXIIQQQgghhGTBZOHo6Ghp166dXL58Wd5++237uvnz59u9A4QQQgghhJAs5BGoUqWKHDhwQGJiYiQqKsph3fjx46VYsWJWno4QQgghhBASCIqAgbMSAKpXr+6PUxFCCCGEEEICcUIxQgghhBBCSOBBRYAQQgghhJAghIoAIYQQQgghQUiaFYH4+HhrWkIIIYQQQgjJPIpAwYIF5f7775epU6fKqVOnrGkVIYQQQgghJLAVgYULF0qpUqVk1KhROmEYJhV78803ZefOnda0kBBCCCGEEBJ4ikDLli3lww8/1JmDf/31V3nggQdk7dq1qhBAQXjyySdlxYoVcu3aNWtaTAghhBBCCAmsZOGqVavKkCFDZPPmzRomBC9BbGysdO/eXecWaNu2rXz66adWnpIQQgghhBASSFWDkDvw6KOPyrx58+TMmTOybNkyufXWW+X999/31ykJIYQQQgghgVQ+NDw8XJo2bSrvvfee/PXXX+lxSkIIIYQQQogHOI8AIYQQQgghQQgVAUIIIYQQQoIQKgKEEEIIIYQEIVQECCGEEEIICUIsVQSmT5/udp3NZtM5BQghhBBCCCFZTBHo16+fLFiwwKUS8Nhjj2kpUUIIIYQQQkgWUwQ++eQTFfgxk7BBYmKidOnSRZYvXy5r1qyx8nSEEEIIIYSQQFAEHn/8cXn33XflwQcflI0bN0p8fLx06NBBNm3aJBs2bJDbb7/d52Ni3oEWLVpInjx5pFixYvLSSy/pcb3h+PHj0qNHDylcuLDkypVLKleuLLNnz07FlRFCCCGEEJK1CLf6gAMGDJDLly+rAlC9enXZv3+/KgXVqlXz+Vjnz5/XicgqVKggCxcuVMF+0KBBEhcXJx999JHHfaOjo6Vhw4ZSsWJFmTJliuTPn1/27Nkj169fT8PVEUIIIYQQkjVIsyJw7ty5ZMuQFHz48GH5+uuvZenSpXLTTTfZtytYsKBPoUYXL16URYsW2fdLSEiQp556SoYNG6bHdQc8B6VKlZLVq1dLWFiYLmvWrFkqrpAQQgghhJCsR5oVgUKFCklISIjLdUgSvvPOOx2WIWfAW1atWiXNmzd3UB6Qb4CkZOQb9OzZ0+V+UB6++uormTZtml0JIIQQQgghhFioCEDYdqcIpBXkB/Tq1cthWWRkpBQvXlzXuWPHjh2aR5AtWza555575Mcff5SoqCjNF3jrrbd0uTugROBjDjEyFBjjk5SU5JNCQ7yH/et/2Mf+h33sX9i//od97H/Yx/4lGPo30YJrS7Mi4M4qbwXIEYDg70yBAgVchiQZnDx5Uv/26dNH+vbtK2+88YZs2bJFXn/9dQkNDZXRo0e73fe9996TESNGJFseExMjOXLk0EEVGxury3AsYi3sX//DPvY/7GP/wv71P+xj/8M+9i/B0L8xMTGBlyxscO3aNRXkIbTnzJlT0vvmA4QVjR8/Xv/fpEkTuXTpkowbN04VAlQRcgWSkaFAmD0C9evXV48Cqg8Z2hdCohh2ZD3sX//DPvY/7GP/wv71P+xj/8M+9i/B0L/XLSiAY7kiMGPGDJk0aZLs3LlTbwI6H2VDR40aJXfffbdPx4ISYWhzZqBgeEo6xn4AFYfMIFn47bffln379mlFI1eguhA+zuA6jIEEzdL8nVgL+9f/sI/9D/vYv7B//Q/72P+wj/1LVu/fMAuuyzJfyZUrV6R169Yag4+qPn/++adcvXpV/vnnH2nXrp20adNGvvnmG5+OWalSpWS5AFAMYKXHOndUqVIlRW8FIYQQQgghwYxlisDDDz+sygASdZE3cMstt2hMfdmyZWXIkCEyYcIEefbZZ3VblP70xp3RqlUrWbdunVy4cMG+bMGCBarhtWzZ0u1+ZcqUUYs/9jWzdu1aDQlKSVEghBBCCCEkq2NJaBCE819++UX++OMPyZcvn84w7FxJCFZ4eAeOHTsm27Zt09h9KASeQJnQiRMnSseOHXVbTCj24osv6nLzHAII+cG8BQj5MUAIECY1e+6559QbsXXrVs0PwPwCmKWYEEIIIYSQYMYSj8Bnn32mCbbGnAK33nqrzJ07V0N4ihQpotZ/zAwMoTxv3rwqyH/66acpHhex/uvXr5fw8HBVBoYOHarnQWUfM8hFwERjZhCOhDbAK9C2bVudXRjVgEaOHGnFJRNCCCGEEJKpscQjgMRgVNsx+OGHH2Tw4MEOQnfnzp112dixY6VRo0bqGYCFv0SJEh6PXbly5WQhPs5s2rTJ5fKHHnpIP4QQQgghhBA/eASQwGtU6gEQ3FG60wwq+Bw8eFD27t0rEREROuswqv8QQgghhBBCMqkiAKv+0aNH7d+RIDx//nyHbfAdZY5KlSqlE34hhKho0aJWnJ4QQgghhBCSEaFBqOCzatUqDf8BiOHv1KmTbN68Wav3HDlyRH766Sd59913NVF31qxZWv4TE3QRQgghhBBCMqlHYMCAAZqYi7kDAOYTQAhQ9+7dJTIyUsOEULXnhRde0BKj77zzjr2UKCGEEEIIISSTegSqVaumcwWgTOe3336r4T+lS5fWZWbi4uLUa4CqQn379rXi1IQQQgghhJCMnFBs+PDh8thjj0nNmjW1MhBKhxpcvnxZPQa1atXSSca+/vrrZPMMEEIIIYQQQjKhIgDeeOMN2bBhg+zatUuqVq0qBQsWlOLFi+tnxowZGhK0ePFinUuAEEIIIYQQkslDg8zA6j979mz9/7lz53Syr6ioKAkNtVTnIIQQQgghhASSImAGHgEQHx8v2bNn9+epCCGEEEIIIT5gqZkeZUEnTpxo//77779LhQoVJHfu3NK4cWM5ffq0lacjhBBCCCGEBIIigCRhcwgQyorCE/DBBx9o8vCwYcOsPB0hhBBCCCEkEEKDDh06JFWqVNH/nz17VicUW758udx33306edjgwYOtPB0hhBBCCCEkEDwC8AYgHwBs3LhRsmXLJk2aNNHvqBwUExNj5ekIIYQQQgghgeARwBwCkyZNkpIlS8qHH34oTZs21XkDwJEjR6RIkSJWno4QQgghhBASCIrAqFGjpG3btlKjRg3Jly+frFu3zr5u0aJFUr9+fStPRwghhBBCCAkERaBRo0Zq+d+7d6+UL19eIiMj7et69+4tt9xyi5WnI4QQQgghhATKPALwBNStW9dhGfIGWrdubfWpCCGEEEIIIamE8wgQQgghhBAShHAeAUIIIYQQQoIQziNACCGEEEJIEMJ5BAghhBBCCAlCOI8AIYQQQgghQQjnESCEEEIIISQI4TwChBBCCCGEBCHpMo8A4DwChBBCCCGEZGFFICkpSTZs2KBegWvXrjmsCwkJkeeff97qUxJCCCGEEEIyUhE4efKkThwGJQBCv81m0+X4vwEVAUIIIYQQQrJY+dBBgwZJVFSUHD16VJWAX375RecWGDlypM4wDAWBEEIIIYQQksU8At99952WDcWcAQDKQOnSpXVGYfz/mWeekVWrVll5SkIIydQkxcVJ7LLlErtsqSTGnJOwqIIS0a69RLRrK6G5c2d08wghhGRhLFUEYmNjdQZhTCyWP39+OX36tH1dw4YNZcyYMVaejhBCMjXXDxyUI716ScLJk4ihhPUEU7TL1W3b5ezkyVJ62jTJcXO5jG4mIYSQLIqloUHlypWT6Oho/X/VqlVl1qxZDvMIFCxY0MrTEUJIpvYEqBJgGEz+y6ky/mI51mM7QgghJOAVgTZt2siaNWv0/6+++qoK/5hNuESJEjrj8IABA6w8HSGEZFoQDqSegKQk1xskJen62OXL07tphBBCggRLQ4NGjx5t/3+rVq3khx9+UGUAZURbtGihywghJJixxcfLtT/+kJjPPkt545AQiV22TAp06ZIeTSOEEBJkWD6PgJl69erphxBCgpXE2Fi5umuXxG3fIVd37JCru3eL7fp173a22STxbIy/m0gIISRI8YsisHbtWi0dinwBVBBq0KCBNG/e3B+nIoSQgAHV0W4cOyZXtm2TKz/+KFf+/Evi9+1L/QFDQiSsUJSVTSSEEEL8N6HYAw88ID/99JMmBiM/AJWDzp07p8rAwoULpVixYlaekhBCMgzbjRty7a+/1NIft2OnxO3YLolnzqa4X1hkpIQXLSrX//47hRPYJKJdO+saTAghhPhLEejXr58cOHBA1q9fL02aNLEv37Bhg3Tv3l369++vOQOEEJIZSbx06d8wH4T47NgpV3/7TWxXr6a4X/ayZSVXnTqSu24dyVW7jmQvV1b329+6zb9Vg1wlDIeGSniRIhLRtq1/LoYQQkjQE251SNAnn3zioASApk2b6hwCUAQIISSzhPkknDihQr8h+F/H7OhGmU93ZMsmOatWEVvFShLV6A7JU7euhEclD+8JyZ1b5wlINo/Af3+hBGA9JxUjhBCSKRSBAgUK6MfdusjISCtPRwghlmFLSJBrf/8tV7fvkLid/wr+CadOpbhfaESE5K5d+1+Lf53akrNaNbFlyyZnzpyRvIULS1hYmNt9MVlY+ZUrtEQoqgMhMRg5AQgHgieASgAhhJBMowg899xzavlv3Lix5M2b17780qVL8s4778izzz5r5ekIISTVJF6+Ild/3aUCP2L7r/36m1eTd2UrXVpy16kjuerU1r/Zb75ZQkIdp2RJTEz0uh0Q9lEelCVCCSGEZGpF4PDhw3Lo0CEpWbKkhgcZycIbN26UfPnyybFjx2TgwIG6bUhIiEyYMMHK0xNCiFtuREfbQ3zwVxN13U3mZRAeLjmrVPnX4l+3jv4NL1w4vZpMCCGEZB5FYPny5ZItWzYNA9q1a5d9uREutGzZMvsyKgKEEH9hS0zUeH674L9zhySciE5xv9B8+SRX7Vr/WfzrSK7q1SU0V650aTMhhBCSqRWBgwcPWnk4QgjxCoT0oIJP3Pbt/1bz2bVLkq5cSXG/bCVL2kN8UM0nR4VbkoX5EEIIIVkVv84sTAgh/uDGqdNydecO+2y9qOUvKcXlh4VJzsqVHQT/bEWLpFeTCSGEkKynCKxatUpatWrl0z6opnH06FGpU6dOWk9PCMni2JKS5Po/+/4V/BHqs32H3Dh+PMX9QvPkkVy1av0b22+E+eTJky5tJoQQQoJCEXjyySd1FuFevXrprMIlSpRwuR2qaGzatEnmzp0r8+fPlw8++ICKACEkGUlXr8rV33b/v+C/c5ckXbqU4n7hNxWX3LXr2AX/HBUqSIiH0p2EEEJIsJNmReCff/6RSZMmqWD//PPPS6lSpaRGjRpSuHBhyZEjh1y4cEFzB3777TdJSEiQdu3ayffffy81a9a05goIIZmahDNnJA5x/Zi4a+dOufbHHyIJCZ53Cg2VHJUq/iv4/xfqk6148fRqMiGEEJIlSLMiAGEfCgA+sPivX79etm7dKtu2bZNr166pt6BixYrqMejQoYOWFCWEBG+YT/yBA/bYfgj+N44cSXE/zMKbu1ZNjeuH4J+rZi0Jy8swH0IIISRgkoUxkRg+hJCsWZkndhlmwF0qiTHnJCyqoES0ay8R7dzPgJt0/bpc2737X4v/9u0Sh2o+sbEpniu8aNH/LP119W/OihUlJJy1DQghhBAr4S8rISRFrh84KEd69ZKEkycxCYiIzSZy6JBc3bZdzk6eLKWnTZMcN5eThHPn/rX0/yf4X0WYz40bng8eEiI5br3VLvjnrlNbwm+6SecaIYQQQoj/oCJACEnRE6BKwOnT/y6AEmD6m3DqlBx84AGdcderMJ9cuSRXjRr/b/GvVVPC8uXz6zUQQgghJDlUBAghHkE4kHoC3GGzie3qVbdKABQEzNILSz/+5qxUSUKyZfNfgwkhhBDiFVQECCEeQU6APRzICzA7b67/Qnwg+GP2Xob5EEIIIYEHFQFCiFtsNpvcOHbcKyUACb43L10iYRER6dI2QgghhKSNUPEzcXFxsm/fPhUoCCGZB0zmdaRHT89hQQYhIZKtdCkqAYQQQkiwKgLjxo2TESNG2L9v3rxZZxrGPAIVKlSQ/fv3W3k6QogfuPr7HjnS9wk53O0RiduyxbudbDaJaNfO300jhBBCSKAqAp9//rmULFnS/n3QoEFStWpVWbJkiRQqVEiGDRtm5ekIIRZybe9eOTZggBzq3FmubN7ssC4kZ85/8wRcERoq4cWKSUTbtunTUEIIIYQEXo7A0aNH5ZZbbtH/Hz9+XLZv3y7ffvut3HXXXZKQkCD9+/e38nSEEAuIP3RIznz0sVxcsSJZLkDeJk2k8MABEpIjZ/J5BP77G16kiM4j4G5SMUIIIYQEgUcgV65ccvHiRf3/+vXrJW/evHLHHXfo98jISIn1YkZRZ/766y9p0aKF5MmTR4oVKyYvvfSSxMfH+3SMDz74QKuWtKXFkhA7N06ckBOvvCL727SVi8uXOygBee64Q8rOnyelJk+SnJUr62Rh5VeukGJvjpBct9WV7OXK6V98x3KsJ4QQQkgQewTq168vY8aMkdDQUBk7dqy0atVKwsLCdB3yA5Av4Avnz5+Xpk2ban7BwoUL1cuAcCMkIH/00UdeHePkyZOat1CkSJFUXRMhWQ1MDBY34UM5D+E/IcFhHcp9Fn7uWclTv36y/WDxL9Cli34IIYQQkvkJtzpZGFb3du3aSZkyZeTtt9+2r5s/f77dO+Atn3zyiXoYFi1aJAULFtRlCDF66qmnNN/gpptuSvEY8CC0b99eDh8+nIorIiTrkHDunMR8PlXOz54ttuvXHdblrFr1XwXgzjtZ858QQggJEixVBKpUqSIHDhyQmJgYiYqKclg3fvx4De3xhVWrVknz5s3tSgDo0qWL9OvXT9asWSM9e/b0uP/3338vixcvlr///lu6du3q49UQkjVIvHhRYqZPl/Mzv5CkuDiHdTkqVJDCzw6UvM2aUQEghBBCggy/TCgGJQDzBkRHR2tITnh4uFSvXj1V+QG9evVyWIZcg+LFi+s6TyQmJsozzzwjr7zyim7vLfBAGHkOANdgHM/4JCUl6V9iPexf60i6EifnZ38p56fPkCTTmAahJUtIoWcGSESb1hISGqp9TqyD49i/sH/9D/vY/7CP/Usw9G+iBddmuSLwzTffyPDhw2Xnzp3awC1btkidOnXkiSeekHvuuUceeeQRn3IEIPg7U6BAATl37pzHfSdNmiRXrlyR559/3qf2v/feew5zIRjAy5EjRw4dVEbSM3IhiLWwf9MOwn6uL1ki1+bMFduFCw7rQosWlRyPPSZXb68v1wsWlLMxMRnWzqwMx7F/Yf/6H/ax/2Ef+5dg6N8YC37DLVUE5s6dK927d9fwnb59++rHoHz58jJ9+nSfFIHUcvr0aXn99dfliy++kOzZs/u0L5KR+/Tp4+ARQBI0vByFCxe2a1+YF8FIhCbWwf5NPbb4GxK78GuJ+XSKJJ4+7bAurHBhiXryScn/QCexhYXJ2bNn2cd+hOPYv7B//Q/72P+wj/1LMPTvdad8vwxXBEaOHCnPPfec5gPgBpgVAUws9v777/t0PFj+XZUchafAnDfgDJSAGjVq6PwFF/6ziCLJGB98R1lThCu5In/+/PpxBoPIGEjQLM3fibWwf33DlpAgsUuWytlJk+TG8eMO68IKFJCovn2lQLeuEopJwf57ObKP/Q/72L+wf/0P+9j/sI/9S1bv3zALrstSRQCJwq1bt3a5DvMA+DqPQKVKlZLlAuAYsNJjnTuwz3fffaeKhDNYhiTk++67z6e2EBJo2JKS5OKqVXJ24kc6KZiZ0Hz5JKp3LynQ/VEJy5snw9pICCGEkMDFUkUAVYEghDdr1izZut9++01LivoC5iEYNWqUWvGNXIEFCxaohteyZUuPE4gZngADeCow4dno0aPVW0BIZgWJ+Jc3bJAzEz6U63v3OqwLyZ1bCj72qEQ9/riERURkWBsJIYQQEmSKQLdu3eSNN95Qa33jxo11GUoS/v777/Luu+9K//79fToeyoROnDhROnbsqPMGYEKxF198UZeb5xCA4oF5Avbt26ffa9WqlexYUCQQEmS0i5DMqABc+f4HOTNhglz7/XeHdSE5ckiBbt0kqm8fCfcQNkcIIYQQ4hdFAErAnj17pEWLFvZ5BGDVP3PmjE40NnToUJ+OhzCe9evXy4ABA1QZyJcvnybymicqM2KeEf9PSFYlbutWOT1hglzdtt1xRbZsUuDBzpoInK1o0YxqHiGEEEKCXRFAhZ4lS5bIxo0bZe3atVqZBEm9mBQMn9RQuXJlWbduncdtNm3alOJxvNmGkEDj6m+/yZkPJsiVH390XBEaKhH3d5RC/Z+S7CVLZFTzCCGEEJKJ8cuEYk2aNNEPISR1XPvrLznz4UTNBXAgJETyt24thZ55WnKUK5dRzSOEEEJIFsBSRQBhPEeOHJHHH3882boZM2ZosjAVBELcc/3AATkzcaJcWrU62bq8zZtJ4QEDJWfFWzOkbYQQQgjJWliqCLz66qvSoUMHl+uQJ/DZZ5/JDz/8YOUpCckSxB89Kmc/niSxS5diOkSHdXnuuksKDxwouapXy7D2EUIIISTrYemcy0gUvu2221yuq1Onjq4nhPw/N06elOg33pD9rVpL7OLFDkpA7ttukzJfzpLSn02hEkAIIYSQwPYIoFSou0nDMBuwMd0zIcFOwtmzEvPZZ3J+7jyxxcc7rMtZo4YUee5Zyd2woT5ThBBCCCEBrwjcfvvt8vHHH0unTp0cBBjUP580aZKuJySYSbxwQWKmTZdzs2aJ7epVh3U5KlXSEKC8TRpTASCEEEJI5lIERowYocnAmLm3Z8+eUrx4cTlx4oR88cUXsnfvXpbwJEFL4uXLcu6LL+TctOmSdPmyw7rs5cpJ4YEDJN+990pIqKXReoQQQggh6aMINGzYUCsHvfTSSzJkyBBJSkqS0NBQ+/IGDRpYeTpCAp6kq1fl/Jw5EvPZ5+oNMJOtZEktAxrRtq2EhPulki8hhBBCiFsslz4aNWqklYGuQgA6f14iIyMld+7cVp+GkIAmKT5eLny1QM5++okknjnrsC68aFEp1L+/RD7QSUKyZcuwNhJCCCEkuPGbGTJXrlz6ISSYsN24IRcWL5azkyZLQnS0w7qwqCgp9OQTEvnQQxKaI0eGtZEQQgghxHJFoFevXnLlyhWZP39+snUPP/yw5M+fX6ZMmcKeJ1kOW2KiXFy5Us589JHcOHzEYV1oRIRE9e4tBR/pJqF58mRYGwkhhBBC/KYIrF27VsaNG+dy3QMPPCCDBw+28nSEZDioiHVpzVo5M/FDid+332EdhP6CPXtKwZ49JCxfvgxrIyGEEEKI3xUBzB5cuHBhl+uioqLk1KlTVp6OkAxVAK58952cnjBBrv/xp8O6kJw5pWD3R6Rg794SXqBAhrWREEIIISTdFIESJUrIL7/8Ik2bNk22DstRTpSQzM6Vn3+RMxMmyNWdOx2WI/EX8f9RT/SVbEWKZFj7CCGEEELSXRHo2rWrvP3221K+fHnp0qWLffmCBQtk1KhRMnDgQCtPR0i6Erdzp5yZ8KHE/fyz44qwMIns1EkK9e8n2W66KaOaRwghhBCScYrA66+/Lrt27dLE4N69e6sHIDo6WuLi4qRVq1YyfPhwK09HSLpw7Y8/NAToyrffOa4ICZH87dpK4aefluxlymRU8wghhBBCMl4RyJ49uyxfvlyThjds2CAxMTGaG9C8eXNp1qyZlacixO9c37dPznw4US6tWZNsHWYBLvzM05KjQoUMaRshhBBCSEDOI9CiRQv9EJIZiT98WM58/LFcXLYcWcEO6/Lec48UGjhAclWtmmHtI4QQQggJOEXgyBHH+umuKF26tJWnJMQybpw4IWcnT5YLCxeJJCY6rMvdsIEUHjhQcteunWHtI4QQQggJWEWgbNmyEhIS4nGbRCcBi5CMJuHMGTn76RS5MH++zgxsJletWlL4ueckT4PbM6x9hBBCCCEBrwgsWrQo2bLz58/LN998Iz///LOMGTPGytMRkiYSzp+Xc1OnyrkvZ4vt2jWHdTmqVJYizz4ree6+O0XllhBCCCFEgl0R6NChg8vlPXv2lEGDBsm3334rDz30kJWnJMRnEi9dknPTZ8i5mTMl6coVh3XZbymvIUD5WrSgAkAIIYSQLI1fkoVd0bp1a51bYNKkSel1SkIcSIqLU+t/zNSpkhQb67AuW+nSUnjAM5K/dWsJCQvLsDYSQgghhGQ5ReDHH3+UnDlzptfpCLGTdP26XJg3T85O+UwSY2Ic1oUXLy6FnuovkR076szAhBBCCCHBgqWKgKuZg+Pj4+XPP/+U77//XgYPHmzl6QjxiC0+XisAoRJQwqlTDuvCCheSQk/2k8guD0po9uwZ1kZCCCGEkCyhCCxbtizZMngBSpYsqSFBffr0sfJ0hLjElpgoscuWydmPPpYbx445rAuLjJSovn2kQLduEporV4a1kRBCCCEkSykCBw8etPJwhPiELSlJLn3zjZyZ+JHEHzjgsC40b14p2OtxKfjYYxKWN2+GtZEQQgyuXLmilfUSEhIk0LDZbHLt2jW5evUqCyf4Cfaxf8kK/RseHi4FChSQPHny+O8ckg4gPCg7wy9IGhN9Y5ctl9hlSyUx5pyERRWUiHbtJaJdWwnJlUsub9wkZz78UK7/9ZfDflhX8NFHJarX4+oNIISQQADC//Hjx/X/gfj7CMEpR44cmVaAygywj/1LVujfuLg4/dx8882qFPgDS486a9YsuXDhggwYMEC///7773L//ferp+DOO++Ur776SooUKWLlKUkQcP3AQTnSq5cknDyJJxtqvsihQ3J123Y588EHEla4sMTv3euwT0j27FKga1eJeqKvhEdFZVjbCSHEFWfPntUJNsuVKxeQhTRgTYWyAuEjMwtSgQz72L9khf69du2aytB4XxQrVswv5wi18mBjx46V0ND/PyQUAlg6PvjgA4mOjpZhw4ZZeToSJJ4AVQJOn/53AZQA09/E8+cdlYDwcIl8+CEpv+YbKfryUCoBhJCABJ5yWCsDUQkghAQGeD/gPYH3hb+w1CNw6NAhqVKliv4f2svmzZtl+fLlct9990nhwoVZNYj4DMKB1BOQEiEhEtGhgxR6+inJXqpUejSNEEJSTVJSkoPhjBBCXIH3BN4XmUIRQGMNrWXjxo2SLVs2adKkiX4vXry4xDjVcCckJZATYA8H8kDOqlXlpjGj061dhBBCCCGZHUsVgZo1a2qZUJQL/fDDD6Vp06bq0gBHjhxhfgDxGSQGp6QEgKQrV9KlPYQQQgghWQVL/ZKjRo2S7777TmrUqCG7d++WESNG2NctWrRI6tevb+XpSBCA6kDqEfBESIiEFWIuACEkOIi7EScL9i6QHqt6SLtF7fQvvmN5ZgfJkR07dpTIyEhp2bJlqo8D42PevHnl+vXr+r1x48byySefpPp4jz/+uMyePVv/v2nTJofEzbJly8rq1atTfexgoWfPnjJ06FCvt0d/w6CcGfnf//4n3bp1k6BTBBo1aqQP35YtWzRf4LbbbrOv6927t7z11ltWno4EAbmq10jZI2CzSUS7dunVJEIIyTAOxh6U9ovby5s/vSk7T++UQxcP6V98x3Kst4rmzZtLrly5VKDOly+f/qZ/++23Xu8P4RsVW/aaCjr89ddfHiu4fP3113L48GE5ffq0rFmzJtVtL126tFy+fNkelZAW0GbkPHbt2lUCnbZt20rRokUlf/78UrFiRfn888/dbvvzzz9LrVq1tE49Pi1atJA9e/a43R59gLFg/uBevvfeew4CcPny5SV37tzSrFkzvZep5ZFHHpENGzZIWkGIelqUwJRwVgzBAw88IDt37lSjeKBjeaYSXhZ169ZVbd5M69at5dZbb7X6dCQLE7d1q5ybN8/zRqGhEl6smES0bZtezSKEkAwBFv++a/rKmbgz+t0mNoe/WI71VnoG3n//fRWoY2Nj5cknn9SS4L5MgBYRESGvvfaa19ujVCIE2ECaWwFC5MMPP5wpkrtHjx4tR48elYsXL2okxquvvqrGWVfccsstsmzZMjl37pycOXNGlYgHH3zQ7bHvuusuHQvGZ+vWrdonnTt31vV//vmnWv0nT56sOaGIDunSpYsEOklJSVpq1EqgIEGR+fTTTyXQCfxRTYKSuG3b5MiT/USuXv13gWFBcvobXqSIlJ42TUJz586ophJCSJqBIBKfGO/xs3T/UjkVd0qSxHUFESzHemyX0rF8FXwg8EGwwUzIJ06csLf53Xff1cmOoqKiNKTHWGcuI75y5Uq1jqbEK6+8Im+++aZ6BWBthqUZigEsyzh+oUKF1CqPNhjgfBDSYQWHVRttAIhKgDCGUCNXfPnll1KtWjU1WkLA9WQJR/VDb0NUtm3bJnfccYceF1bip556yh6eBNAmKBaVKlXSa3z66adVCG/Tpo0aUrHvsWPH7NsPGjRIvRtYV6dOnRQ9MtWrV7crUYbnZd++fS63RX+WKlVKt8O9xD3ev3+/12Nj2rRpem/QPqNPUSUSIV3wJOFe/vrrrw59i3sHwzCuB+HimG/KHTNmzJAGDRo49N2UKVO076Bgdu/e3V6gBopHhw4d7N6N22+/XatXvvzyy+rJeO6557S/H330UXs4F8Zu3bp11Xtx8uTJZCFeuE/wahn8/fff2nb0Gz7PPPOMKsitWrVSD5bhJYFCZHgiMHYCnXSZWZgQX7jx669yfOjLYvtPCQjNn19KfvyxxB88ILHLlkni2RjNCUA4EDwBVAIIIZmdG0k3pO6XdS051tu/vK0fT2zvvl2yh3lvdcfkZzNnzlSh76abbtJl+I4CIRCeypQpo0IrLMDff/+9fT8IwwMHDtR5hFatWuW53W+/rdUGEYoz7z9v8IEDB2TIkCFyzz33yKVLl9T6DA/DRx99pG1q166dCn3//POPCp8//vhjitcCKzgs5fiLkucIn8FxcF5nT8SVK1dUOIbw6Q1hYWEybtw4FXIxczQEx4kTJzqUT1+yZIn89NNPKkRCuIfyAMsxwnRgkYcADYEXQFBF30GxwDVjPZQcCK/ugMK2cOFCVYJwTFj63YE24N6hb6EADB8+3KvJt+AVwiSy8BgZQKivV6+e/TuEfYQJYXnVqlV1GfZZunSp9sE777yjihv63dtZcxF69MMPP+i9b9iwoSofvXr10j6HZR99jnCwXbt2aQ1+eEjQv1AW+/Xr53CsL774QttiKEOegAcEoXI4BhRVsH37dlVIMK5xfCgTZipXrqyhUVB+oJwEKvQIkIDzBFweMtRBCSg9darkqXebFOjSRcrOmiXlV63Uv/hOJYAQQvzHCy+8oEJonjx55Pnnn1fByhDaIIRhGYRkCOGYVPSXX35RwdnMiy++qOEpKCbiK/A2wMIM4Q5WWJzPsIojNAUeA0xaiph4KBFQGFICoStQLmA9h+COkCcIgoiZd+bChQv6F8f3htq1a6tVH30EAfuJJ55IZsXHuSEYYj22hfCMD9oPRWrHjh0OQj2uG8eDVfvGjRt2i7OnJFsIroivh6CNe+MOCLK4RnzggTHndnoCXh5Y4xEqZoBzOoeF4zuUDANYzyFQ41phrYci4qrf3QGlCN4hVKGEF8XoKyhw8ArA+4F7CgUK1nlPwKJ/8803a1tSUkRg2UdfwWuF/sTnzjvv9LgPFCFg9mAFIlQESEDlBBzv1x9lIxyUgFzVq2V00wghJCgZP368ColXr15VIR+W7W+++UbXwfqKcAoDCF4Q0rDcWRiE8AvBz1dOnTql1tYSJUqoMA7BGCEfAMVJ4KHwNZ8AFnUoJ2iX8YmOjk7WbqPtADH33oDEaFjg4QlBe3HNRnsNzImlsOw7f4dAbQBLNyzLEELRFgjOxvHMSbsIfzEDYRihKegjKD4pAaEVgjH6F2EuRtUl44PvZqZPn65hWuaZsbEd2mcG3w2BGBhhREYbcV/R71BejHMZ3gNXuOsr3E8I5kjShcfqpZdeUqXJE1DEvAXXj5wKXzAUoED2Bvg1NAguJjxY0Nq8dfmQ4FYCkBPg7AmgEkAICQayhWbTcB1PLPxnYYohP+CV21+RThU6pXg+X4DFHHMFoTogrKP33nuvCnEQqg0glMEqi+XOIFdgwoQJPsdMwwKMkI/ffvtNlQyElMCCbwiVENAg8MGq6y3YD4IiEltTAp4QhLcgfMUIifJE//791dMwZ84cVQRwzXPnzpXUAOEeHhhM0Ip8BsTwQ6g0YvjNCoOnEB5nD4070M9xcXEqmMOz4e74UBRWrFiRLAwLbURIjgH2x7mx3MCsUCC8B+fCeIEQDyUktUCBQMw/PjgnPA8oUNOjRw+3YT/Oy/PmzavXb2AO9cGYQViTN8cxgOcGykagKwKWewRgKUByB7REdBweXgD3mFGDlxCXSsB/D2BI3rxS8rMpVAIIIUEDhAnE7Hv6tC/fXormLiqhbn66sRzrsV1Kx/ImDtyZP/74Q4VTQ7CD4IawHFjBEY8Oqz9i4yE4O4NQitdff13GjBnjs1UVwjgs4kgMhoXcAOE0Rm4CtoNC4E15UwjraAcSWSFUQ2BFvoA5hMUMQlBQItLb9kIBgBUc/ZKWspU4FgypCA2CQI8cCk+eCQjAiHmHMIvtoXR99dVXGorjCihVuKdQAOD1QS5H4cKF1QPhCYSEYRvnMCIk7yJeft26dToekG+AykFmCz/ySRCyhHuFHAH0E3I80gquFf2NazHCxOBxAEgk90YZql27tipwCHlCvyBZ2TwGUF0J4wbeMXyMXBgcH+E/ziFAGDPIEQl0LFUEoPXiosuVK6cJRLghBngxwJVEiCclAJ6AvOPGSU6TBYEQQohI7my55bOWn0nh3IX1e4iEOPzFcqzHdlaBmHwjZAO/73379tUPgLUVRj54B2AtR9nK+fPnuz0W5hPy1ToKYRIGRYTF4PxGVSAAQQ8CPKIPEOsNgezDDz9M8ZioLoPjov04boUKFdxaewESRCHfmGUad0BRgfANARfX66kcZ0qgXyGAIgcDCg+EWyS2ugNKDQRVhM/Ae4J49o8//lgToYER7mNY5RF21b59e20rrOewzsOYaw73cQVkOUyw5gyUA6zDmChYsKBWikJfOCsL6COMA5Q3xccXb447kBuAikW4FigfyCsxKgRBwYGChHPinrtj5MiRqmyi7QiTeuyxx+zrcNy1a9eqEgMPBgzdxrXh/uC6EDqE8QRPAO4FjN+G9yqQCbFZWDwV2fdwxyCmEC4f3FxkayMrHtpanz59kmVVBzoo44UHDy+4kiVL6nWh1Be0ZkPbJNYpAfAEXCpalP3rRziG/Q/72L9khf41QmrMMfbegnkCVh5cKcsPLJeYqzESlStK2t7cVlqXa22ZEgDRAFZlWKRT4z3IaiCMCBNupSV8xRn2sX/JyP79+uuvtcJRasPCvH1XOMuoqcHS4H2U+XLnBoFrzzmJhAQvrpQA5ARkr1JZLp35d7IcQgghyYGw3/nWzvoh6YM5TISQlEDSMj6ZAUtDg+COQkKNK+Da8yVDmwSfEsCcAEIIIYSQTKoIdOvWTd544w1Zv369fRncMZhMApnciKEiwQ2VAEIIIYSQwMDS0CAoAZhKGnF0SFQByBlALCfq6g4dOtTK05FMBpUAQghJPUa8s1XbEUKIpR4BTOqBclTwCKCqAJKDkWCDLHQs54speKESQAghqQfVVVD1BBVZkCztCizHeqMiCyGEpIRfJHPMZocPIYBKACGEpB4I9V26dFFL/2effaY12D///HOHiklQAmB8M5JasT3KG95///0Z2HJCSJZXBJynnU4J8/TSJOtDJYAQQtKuBCTaEqX4o8Ul5psYu7BvKANmJSB7kewSdW+UnJxzksoAIcT/igDqmvpSn9WdS5NkPagEEEKINUpAyX4lJaJehOSvnV8OjjloVwamTJmi4UCGElBuaDnJVjCbhOcPl2OfHKMyQAjxb44AXlQLFy7UzxdffKGzC95111067TgmUnj//fflzjvv1OWeZu4jWQsqAYQQYq0SACDkQ9iH0A/hH7OaOisBANtjP+yP42RUzsDPP/+sbcSMtjNnzkz1cUaNGqU5h8YESzBAXrt2LVXHOn/+vM4mfPHiRZfrV69enaqJ3gIF9JM/i7NgBmLMInz9+nW/nYNkIkUAU3Ubn02bNmnFIPwdMGCAvnwwtfO3334rzZs3l3Xr1lnTahLQUAkghJDUg1yARx99VP8W61bMrgQYmJUBTOTprAQYYD/sj+M89thj+jetwLtwxx13SO7cuaVBgwYpbv/aa69J79695fLly9KjR49Un3fYsGGWTeo1duxYLXeeP39+S46XFfnoo4/ktttukxw5csjDDz/ssK5EiRJq8EW+Csn8WFo1aMGCBdK1a1eX67CcVQyyPlQCCCEkbaDCHgRVgJyAG+duJNtGlYGXy0mRTkX0r7MSALAf9jd+g9NSuS8pKUlsNpsULFhQnnvuOXnllVe82u/gwYNSvXp1CRSMRGsoWiQ5hrKIKI5XX31VK0C6AorlJ598ks6tIwGvCCBpaefOnS7X7dixQ0JDLT0dCTCoBBBCiDVMnjxZQzziT8drToBLZaBANinSvoj+dQbbYz/sj+PgeL6C8BlMBlq3bl31AJw8eVK9+/D2wyqcEgivgccC+QkIDTp9+rSGEFetWlXy5csnN998s3z88ccO+6xatUot0REREVKqVCm7FwDzFDlbpg0Q4tOvXz8pWbKkFCtWTJ555hm3YUO//PKL5MyZU2655RaHUKFOnTrpOWvUqCG7du1y2AfX/dBDD0nRokW1TWgLFCODL7/8UqpVqyaRkZFqKcd8SuY+GD16tCpDOP4DDzwgFy5c0HVoI7wlhQoV0nU1a9aUP/74Q9fFx8erF6RcuXK6Hooh2mmwdetWufvuu7VULMJ0EJ7tCpwD/Q9FEEqQKxBmNWnSJA3hwjUA9EfHjh313K6ANwj3FooeydxYKplDw3799ddlxIgR8uuvv0p0dLT+xUODDzXwrAuVAEIIsdawBst1SsqAK5yVAOdSo76A3D54+y9duiSFCxf2aV/E8qNSIKIBEBpUpEgRFSwxrxCEd+QMvPjiiyrUgu3bt6uSARni3LlzaliEcJwSjz/+uAq8EKL/+usv+eeff2TkyJEut/3tt99U4DUDxQGFTI4dO6ZtnTZtmn0dBP727dur4nD48GFVJND+qVOn6vply5ap5Rw5kTExMdK9e3dp166dCvIGUGawD46PuHqETANc/++//y779u1T5WDevHnqcQEvv/yyGlBxvqNHj+o8TWgngGx13333yaBBg+Ts2bN6fFSN+vPPPx2uKzY2VrcrXry4zJ49W7JlS64wmkO+vvvuO50A1hvgXUKfOCtNJMgVgXHjxulAhQWhTp06qp3jL+Lxnn76af1Lsh5UAgghJJ2UgfOelQGst0oJAPjthuUeQqQVk4K2bt1aBUhYoWE9v/fee1UABYg5Rx5BmzZttM1QGmrXru3xePAyLF26VCZOnKgx/7BoG4K5K2BVN+cGQAGAovPWW2+pl6J8+fJ6zQbbtm1TQRzr4UlAyAwEcOP48LQMGTJELf5o85NPPqnXhiRpA8hF6EMc/+2335b58+erggHhHgoWlBeEXcGyD48G/o+wGxRbgfKUK1cuVWzQTrQXyhk8M7DY45y33367Wv2x3uzFaNy4sfYxrP0pRWQgudg4l7fgesxeCpI5sVQRwEsCygC03o0bN8qcOXP0L76PHz/eozbqDjwgSEDOkyePPiAvvfSSg6btCmjL2K5WrVo6UKGQwK0GbZ5YC5UAQgjxHxD0UCIUgiSE+/ObPQteWI/tsD32S4sSAMqUKSNWgtAfhJXA8g2hfcWKFWrVNuYlMofseOt1gHCMkB0cD5+2bduqguAKhNKYqwXBAo6QGfMcR+ZrxvGxDfYzjg9F4dSpU/b18GoY6/CBDILKOgbOx4YMg2MiSgIfKA8QwlEGFm3Duri4OGnYsKH9mFA0IMxDwMc54WEwnxPKBc5r7mf0AfI5zCBEy/hs3rzZ5TV7C5QY9AvJ3PhlZmEMDMSupRVomk2bNtU4RcS/4cGCJo4HBBnt7oB7Edv36tVLXzh4yUCbrl+/vrrhfHVvEtdQCSCEEP8CIRcColEdqMBdngUvrL/w/QXdHvul1SPgyzxBKYGwGMTII/QGf2EchCUbFnBDYEaYjC9gHxghIfTCwp4SyAEYM2aM/TvkAbQDSoiR1GyeKBXHhzERwre788PwaJQ2dYX5ePg/zofzom8RAoTKShDwH3zwQY2cQGgULPMIu3FVxhTnRL6EpypKCJeCggPPwfr16+0hRwjRsuI+I6kY9woGV5K5CejsXbjGoB0jZg/uQwj2CDvC8hMnTrjdD/MWwJOARBsoEog5hHYMLRuJSiTtUAkghBD/4jxjsJYIdZEYbAbrzfMMYH8rJ/LEsRCPDyETAjz+n5KX3gDbQRmAEAzhfc2aNfoxQFvxG43fa5wHRryUYtARKYBQomeffVaNh2gTQnkwF4ArYBC8evWqKkoAShKUEuQ3wsKN5eYE5nr16ml7YUy8cuWKhvQgBwFl0UH//v1VsUA+JM4NQRt5AziWAUJzkFSLZQhbQuIxrPuImMB+uFZY6FGqE+3BOngJnn/+ebuVH4oOvAAAeQjoI5wHAjn6FbkEzjkCiMRo0qSJKgPIufAFHBf3Fn9xzcY9N8D5oKQgmZlkbgJaEcBAxwA2NFkAoR6D0vzycAZuMudYRmj0eJg9KRDEO6gEEEJIBigBLkqEusJ50jErlQHEp8NaDW/Dli1b9P8tW7b0al+E6n744YcaqovIARwLibUGqBaEpFYY8fA7jhxDCMopgaRbWNlhnUb1HRgO9+7d63JbeA0MhcMAEQYQ4iEnIO4e1nQDCOYQuCH8IzoB7YYcYgjomENp+PDhmtuANmMb58lTUWoTCcc4Po43YcIEXQ4vwCOPPKL7ITcBlZgQZgSgXCBRGjH+6DfM3YD+BjjOypUrdeJWVDJC3gI8C64m+Hrvvffknnvu8VkZQE4E7i1yGpB7gP+bS4niGqEEkcxPiM3wyQUgiJmDF8DsxgN4WBBX57zcE3gpVKxYUZOR8BJwBzwQ5vhBPOywIMAtiIfPsFIgiSmtsZeZkbht2+R4v/5iu3rVrgSU/GyK5KxmjRIQ7P2bHrCP/Q/72L9khf5FiAjCMdzFZhthPZ6UACQGIycA4UAplRDF7x5yBrwFogGswTCqWRkeFAhAIEbYMMKIIWT7E1jMkVCM6j1ZpY8Rpo3cTVR1ghcjUMms/esM8ltxLeZcEwPk4MIzAy8YZNSAyRGwCrj5jJq2ZqCR+6LZogNRrgtas7sJz8zaM+LznEFZMAx4eCNQkgsE27wIN379VS4PGYrCxPo9JG9eyfPuu3KpaFG55GXJsZQI5v5NL9jH/od97F+yQv8i1AK/Ka5m+8UylJIEUfdGuZ0szBDykRPgSlnAd+wfPStajwdrvLeVf/C7aXgRMrMQ5QpUDTLq9Vsx23JKoB9dnSez9jG8ECjDml79l1oya/+6et/B2+OqtCtk07RiqSKAuDtPpaeguaRWY0kLmMMAyTKIGUT1IU8gGdnsMTA8AlFRURpaZAyqzGyJSrUnYOjLdiXAak+AQbD2b3rCPvY/7GP/khX6F7+XEE5cCeZYhnAXxJKfnHNSwvOHS0S9CJdKAKoD6cROYw4mUwZit8b+u/9/x0P5S28xggUyuzU1EMAYdXWf2cf+Jav0b2hoqD67rgrduAoHy1BFAPFsiBtDTVtn8BJCGStfas7C8m9YfczgGOa8AU8gFOjNN9/UyT+aNWvmlaXAXGPY/CAbPzi4KebvwZATcLz/Uw7hQP7MCQi2/s0I2Mf+h33sXzJ7/xqCiTsBBTO7YpInxKMf++SYLoMy4DxZGMJ9EEaEXACzMgAlAPuFhYTpcVCdJzVtND4kdbirNmTAPvYvWaV/Q0JCXL7rrHj/WepTRbILEltQCstwFyGOEy80xPp7Kq/lCsz+h+o/ZqAYwErvPDOgK1BtCMksUARwfuI7TAwmhJCMAcI7hHgI8xDqY9bHJJssDEmyzpOOYbu0KgGEkOAg1OoqP8iGRyY7vAIo81m1alWdJhuhOZglzxdatWol69at06m3DZC9DktQSlUKNm3apPkAyHKHYkJ8h0oAIYQEjjKAWH9XMwY7z0CM7agEEEK8wfIsK1jgMV04EnEw+x5m+8MkXpjq2lf69eunGf0o54VyodOnT9fSWliOxF8DhPyYZyNELV3sgzJeqC6Eqb6Nz/79+y271qwMlQBCCAksZQC15mHccjVJmKEMYD22oxJACMmQqkGYshr1dBFnDwEdlQqgHKBOL+r7+gJyBOBJGDBggAr2UAqQyIu6tp4y8jHRBUKI8GnUqJHDtmibp9n4CJUAQggJNCDUIz/OU9UfKAPIGcAEVt5WByKEBDeWvikwzTbKb7Zt21aTdJHhjIk0ILxXq1ZNpxVH7VlfqFy5soYHpRQGZAbuUV/zEYKRpLg4iV22XGKXLZXEmHMSFlVQclWvIedQti6dEoMJIYR4h7fCPZUAQoi3WPq2gCXCiFM0wCQau3fvVq8A/m/lVOck9Vw/cFCO9OolCSdPIh0ddbZQ3kCubttu34ZKACGEBB5x8QmyeOcJWbTzmMRciZeoPNnl/tolpWPtmyR3dioBhJAMyhHABBOuLPEI8UGI0Jw5c6w8HUmDJ0CVgNOn/11gTC5tnmQ6JERKfvwxlQBCCAkg9p+5LM3GfyvDFu2WbYfPy4EzV/QvvmM51pOMAZORGqHLKBuKko+YOA4gTxIFVEjK8z49/PDDPoWjo2JlZmTbtm3JwtczvSLgavpjM5gchWQ8CAdST0BSkvuNbDaJP3ggPZtFCCEkBU9A989/kVMXr7m04WA51mM7K2jevLlOEorkY+To3XbbbfLtt996vT+EX4Qp7d27174MJcEze013V5w7d04mT54sAwcOlEAH806UKFFCcznLli0ro0aNcrstJqtDFUjM3RQZGSl33HGHfP/99263P3LkiI4X8weVHs39gjGEcPHcuXNLvXr15Ndff031taBkvRVFYHr27ClDhw4Vf+GsGAI8T5jkdvny5ZKRWOpDRL1+T6ATWMoz40FOgD0cyB0hIRK7bJkU6NIlPZtGCCFBOwtqfKIH44yI/G/7MYmO/X9Bwpkkm+j6r7cfky71Snk8VvawUK8EcpT9RmhvUlKSTsyJpOXTp097nYeAIiH43Z8/f75kZb744gtVnKAwBTqY3BWl3qHkHT16VO69916tvIjJ65xBrufs2bN1BmuMF8zP1K5dOzl16pRkz57dpUH48uX/90ohwb148eL2Y8fExEiHDh3kww8/VOPwxx9/LO3bt1dlMUeOHBLIz2dSUpLlExgijxaeIuTWZgmPAF4Yzp+RI0eqq+edd97xeR4B4h+QGOxRCQA2mySejUmvJhFCSFADJaDiq6s9fl5fsserY722ZE+Kx0pJ6XAGVt1HHnlEBbsTJ07YhaN3331XhcSoqCit7mesM0DVv5UrV8rOnTu99iK88sorcs8996i1FN+heLzwwgtqlca5zAVCTp48KQ888IAUKlRIypUrp9ZtCGygevXqWkbVTJUqVeR///uf/v+ff/7R+YqwL8JLUG3JAHILjotyrFBmICh7KlwCq27Tpk29usaDBw9qVUWcF0Jyt27dtF8NYKUfO3as1KlTR/sAk7JiPYRGWPFxXSjLboBt0T4oISiw8vXXX3s8P/oASoD53u7bt8/ltjgmjo1tcL8hCGNuJ0wW6w0ICYdycOedd+r3hQsX6vFwLRD8n3/+eb1f5r6Nj4+X7t2767kxF5UnLxTGQrFixRz6bvz48VK3bl29b1AyjL6FNR6Wf4xVrKtZs6aWusd9h7KDYjfwYNx99926PcbesGHD9C/uw5YtW5KFeK1evVrPaYDxj9CmokWLalg8ngkATwrAPcc5sB9o0qSJXrvZU5CpFQF0tvPn6tWrOtEYbrxzdR+SMaA6kHoEPIHprAtFpVeTCCGEBDAo9DFz5kwV6ox5fPAdQhQE/WPHjjlYfg0gpCEsBAKVt0Ao+/TTT+XMmTN63gYNGqhAiO9PPfWUhrYYYOJQCHUISVm7dq1WJ4TnAjz++ONqqTfYunWrWrIhHMbFxakwjv9HR0frNYwZM0aPYRbuW7durWE/mBepV69eHnMkK1Wq5NX1QaAeMmSIHD9+XIup4PzO0RLIq1y2bJleF4R+hOcYCgOEx0GDBtm3hQIEYRkl02F8xfxJuB+eePnll1W4xf28cuWKCt6eKFOmjAruEGzRr+a5nDyB+Z+wvQGupVatWvbv8DLUqFHDQbFZunSpeilwrahGCQ+CWVFKiS+//FI9F+hfKC2GERrjFf2NUCIsRx8XLFhQxxSUXPQpvBmYC8sA5eYxSS6WQzHzBMYqvCU4JpRMKLBQdMCPP/6of6FA4VgongMQogXPCua/yjITijkD9yFu6LPPPqvuRZLxRLRr75VHIKJdu/RqEiGEkAAElnjEhkNohFAzevRoe1gQBC4sgwAMCzMs05jHxzlmGxOBwppqFrA8AastjokYcoQiQVCCEA5rNIRhCFkQpiDsQgCGBRjbwuA4ePBgu/AP4XbDhg0qkAEsh7UWx4OQD8UFckm2bNmkYsWKav2fO3euvR0NGzbU8+O8mIMIYTTuLOEQVGGt9wZ4NVq2bKmCNSzECNVxtnrDkwIhEdZrCI3YB3/RFlzDjh077Nt27txZt4XVHv/HteA+eAL3EX2I+4I+hfXaE4cPH5ZLly6pYA9vjTdAOdq1a5f2nQHOifFkBt9xbANY6qHMYJxhXyg6K1asEG+BvAkFB5Z3eFMMbxTuO86DPBUoY/CeFDN5E1wBzwUUF/RtSqFLUDTh7YHigLGAceVNX8Hz4YuiYzXpVmesZMmSOiBIxhPRrq2cnTz536pBrhKGQ0MlvEgRicjAmDVCCAkmELP/91v/WgndMX/rUa/Cg0Z2qOpVjoA3QMiGsAzBCYIdQmkgnMLAB4urOSwCghfWYbm5kgsEPVjAYYU2rPWeMAtnEPCdvxsCJc4Db4BZiEV7sBwUKVJEBW6Ep8CiDwuwIVAieRMColkohUUXyafu2mGcF8K7M2jDxYsXxRvglYCwioo3EEwRGuOcW5BSH5jj8KHgIKwF12S00VBY4EmBEA/gZYHl22yNR7IuwlSGDx+ux/BEzpw5VUmrUKGCCscQ2HHPDRD9Ye4/KA0YJ2bvAbaH58IMvpuv37nwDLwRuKfoL4w/A3MfeOo7YzsoFwjdgUcJf6EkjBs3zqMCh3N7C7w3aLur3AlPYAykpIhlao8AgIaEHIHMWuIpqxGaO7eUnjZNhX3FCBP67y+WYz22I4QQ4n8glOUID/P46Vy3pBSPyCmhbiI7sRzrH6hbMsVj+Vq5B9tD8EO5Q6PKCazQhvAJIHAhGRTLnYGFG9taWSEF54EQiTAPA5zDfH4jPAihP0h8rV+/vi6HwIa4bexrfCCQYbvUgPAWWJq9AWFSEP5RLQf9Bc8KFK3UACEfk7Yi+RbHwnUgh8A43p49e/S+4GNWAswkJCT4VHkHMfyoJgSMY+NjVgJu3Lih12UOCwKoFmQ2ChsKJpabBWoz+I57iuObz+cr8DAg/wTnQ4gQ8gPGjh2r69w9D87LocggrMyco2KAMYW24tpTOo4BFBz0J7wTWUIRgEYHzcr8gbsQ7jq4n2BZIIFBjpvLSfmVK6TYmyMk1211JXu5cvoX37Ec6wkhhAQOmCzsyz63S9H8OV3ZcHQ51vtrUjEITrDKGkIbBEuEQaDiC5IdYfWHoO3K6AdZ4PXXX9c4fCsjDSAcIhwI+YgQZiFnwPJr0KZNGxW2cG5ziAqqtEBpgIfi+vXrKgxDOER4R2rAebzNg4TCgVAreDNgmU6LbIT4fgAlB0DpMcfbO4MQlFmzZqn3AsrIDz/8oGVPUfHIFQitQp+gfyAAozokciaQs+AJ5DcA5GCYgRUeoV1QEiAAo3oRMJ8fChK8ODgn2or7ilyNtLJx40Y9Njw/EOgR6hP2XxUgJPcayo0nateurcnmUEQQKjZx4kT7OnhX4EFArgHuMRQCI+QL9wfhRc4KF8YMkszhbckSigBiCZ0/yLzHwITW2qJFCytPR9IILP4oD1p21iwpv2ql/sV3egIIISQwKV84r6x/4R4Z3am61C9bUG4unEf/4juWY72VIAfAqAcPYQxx9PgACNYIszDCPyAYeSoT2rt3b8tDIBDTD0s4lAIIVIjphoXcbAVGrgCEY3NCLK4HicFITC1VqpQKargWb8N7nEFfrFmzxiHW3R0Iw4FVGn0BQRnJsKkFFYCQgwFPDYRZWNuNCjWugGUaITsQWKGI4J5AVnvmmWcc+gYKH8D1IBwIIVToJwiuCAFKKVkY54Ci6Bwmg9CxxYsXq0KI8yMxHPfAHH+PPoFnBv2DXAYk/iIBN63Aeo+SpTgvlFV4GV588UVdh36AgoJzIhnb0/OA/ZFfgvwRs5cFSgUUICR/I6cD9wOeGiNE6dVXX9Vjoy+/+eYbXQ5FJ6PzZ0NsqfVHBQlIRsLgxwsOLxpokqhcgJeG1fVkyb8xmuxf/8I+9j/sY/+SFfrXCKkxx9gHEhANYJGFIJ3ZJwCDMIbcAEP48hcwfCJBFOEnwdbHgUig9++2bds0VwRemdS+K5xl1IBOFiaEEEIISU9g4UeS7FtvveX3c0ERIMRbMLNwSkpAemC5IoDyYFOmTLHHDDoDdxghhBBCiD9BeApCXlD73pjYiRDixxwBuN0Qo4eyVXB5wF2BMlt///23JrRA+yGEEEKI7yDMwcrtsjqoWAPZA3HogRgaQkiWUwSQAIOJMYw6vZjhDhnn8A4gbs7b6bcJIYQQ8v8gYRKJjEhoRY6EK7Ac67EdtieEkHRVBDBFMiZ7QIkkaN9GWStkpyN2Lj1i9AghhJCsBIT6Ll26aMnCzz77TKviOCsD+I7lWI/tsD2VAUJIuioCqIOKurRQAlBayVwvFXMMIKuZEEIIIb4pAYlJNinYor+ERxaXGTNmOCgDhhKA5ViP7bA9lQFCiN8VAcwRgBq+ALMOIh8ANGvWTN5++22dRRC5A6ifitnuCCGEEOKbEhDV/iXJV6eNFO062kEZwKRFZiUA67EdtqcyQAjxuyKAZBzD8o/8ACMhZ9SoUeoFwMQQCBeCsvDxxx+n9XSEEEJI0CkBeSo20uXh+Qs5KAOVKlVyUAKwHmB7KgOEEL8rAub5yDDr4NNPP63/x4xt27dvVw8BZrrbt2+f1K1bN62nI4QQQrI0qPrz6KOP6t8CzZ6wKwEGZmXgwIEDyZQAA+yH/XEczLjLakLeA09LtWrV7JM5OfPXX39l6kpEyNt8+OGH/Xb8uLg4ufXWW7WKJAmiHAFn8JBUqFBBatSokWyaaUIIIYQkBzOhduvWTf9/cetiSbiYXJhSZaDbGIm861H966wEAOyH/UHXrl31uGnlq6++kjvuuENy584tDRo0kKw8BwGMl4E683Mg4GksYFnPnj1lzJgxGdY+ko4Tis2dO1e+//57rxSD559/3opTEkIIIVmWyZMnq1UaYT+n5r7s0uIfni9KIu54yOX+UAKwX8KFaBXIcLy0YBQCKViwoIYB//PPP7Js2TLJqkyaNEnGjRuX0c0ISLwdC/Bq1a5dW/NFc+TIkSFtJenkEZgwYYIMHjzYqw8hhBBCPBMWFiaff/65CvEQ5lWod+EZ8EYJwHFwPF+BR//dd99VyzgsvCdPnpTmzZtrzgHCf1MCYTUQGGfOnKmW9fz58+v8QgcPHpQ777xTvyOk+OLFi/Z9Vq1apYVHIiIi5Pbbb5effvpJlyPUGPMjXL9+3b7tL7/8IlFRURIfH6/fv/zySw3niYyMlLvuukv27Nlj3xbnHz9+vF6Lcd7z58+7bPexY8fkjz/+0DYaXLt2TZOyIfyiX9atW+ewD66hX79+UrJkSSlWrJjOaIx9DFA0BZOqom116tSRzZs329c1adJEXn75ZbWuI7cSxVaMKosIv37xxRelaNGi2m7khGzatMm+7r333tMQHLQL14S2G0BAR44mJnYtX768KjfuBHuEdaMd5nthBv3n61jApLK4Zz/++KPL9SQLKQI///yzDqSUPu4mQSGEEEKIF8rApX+r9Lkj4ZI1SoDBrFmzZMGCBXLp0iUpXLhwqo7x7bffqmCNv2+++ab07t1bQ2+io6O1kMhHH31kF1wfeOABLTaC5RBOIcgizhwCKARLs+UZVQsR8oTQYyxHdUJEKGDf7t27S7t27exKgqEoIGn6xIkTcuHCBXn//fddtve3335TwRcl0Q2gwOzevVtzA3744Qedrdi5cAoEf1wntsG1YB/w66+/aqjXBx98IOfOndM+6Nixo0P8/LRp07Qfzpw5I7fccou2H6xZs0bmzZunuZYQ0qEolS5dWtdhe7QD25w6dUoVDCPuHzH6UChQsAX9vHLlSg3TWbt2rUO70T/ow+PHj+uxoWy4A/3t61ioXLmytp0EaY4AIYQQQlIPhPgpU6bIzTffrML9ld2OlmhnLu9ep9the+yXFiUAQBjHsbJly5bqHIPXX39drcgIE4Fg2LJlS7Wq58mTRzp06CA7duzQ7ebPny/33nuvtGnTRs+FBGdYwJcsWWIXtiGMGgIstu/Ro4d+R+jTkCFDtEw5rvnJJ59UbwQMlQbPPvusCtF58+aVzp0728/rDDwFzgIxFAwoGkWKFNHP0KFD7etOnz4tS5culYkTJ+p+sPobSgn49NNP1ZsADwMmXG3btq3UqlVLhXMDCP4Q5KF8vPPOO+oxgHUfSg4UDHg3ECpWrlw5vR/GNWOiVigtuD9IAN66dascOXJES7djPqf+/fvruooVK0rfvn3tbQKYeA59jXvz9ddfOyg+roCXw9exAA+HO88LCQyoCBBCCCEBCjzpTzzxhL06UJ7qzT1un7d6c3s1IeyXVk98mTJlJK0gVMYAQqfzdwikAFZp5+RcfMdyQ1hev369Ws1XrFihAnm9evXsYUgIoYEQbnxgCTf2ddUO47zOIJzFOUQGXgTDEu/cLzg3+hkeC+PcEPahIBjroSSY2wYFBcc0MB8b66FQoO0I1xkxYoQMGzZMrfCw+Bv74bgPPfSQ/ZgIAYKiAQUC63bu3OlwToT2IKTHYMuWLRq289prrzkojFWrVlVlCR+z5yM1YwHeA/QnCVyoCBBCCCEBiPOMwZownC/K4z7h+RznGTDPQJwa0rNEJmLNnct14rsRgw5BGN4EWLXhGTC8AYYgjVAZhPwYH4THIOzFV1DpEOc15yPcdNNNamk3MP8f54aFHIK/ce7Y2Fi7ooH1L730kkPbrly54uBVMB8P66GIGNf91FNPqdCO3AqUgIXnwzguPBHm4169elVzDbAOf83rIJSbvRBNmzaV0aNH618c2wDeB7Qdn0ceeSRNY+HPP/9U7wfJwooAYv/r169vTWsIIYQQ4loJcFEi1BXOk46lVRlwbhdCVRCmgmRV/N8ch58WkHiKpFrEqkPgRUw/4u0RPmSA8CCExGA7VKUxQAgMYuARj492QYhF3gCEX19Bwi9CmJALYADLO3IX4I3AB+E7Zk8DQmwQeoQwGJwfyb6rV6/W9fDMIEwL1RUhM0FY37hxo0NiLyzviKVHfyJxuFGjRtoOhPogYRp9DC8GPob1Htf8yiuv2Cd1xblR0hPAIwFlZurUqarQoD+R44DjmRk4cKBWc4Tnwd2cCakdC7g+5ERAISGBCz0ChBBCSIABIS8lJQCJwRd+nKd/U1IGcDwrQPJwrly5VLiFlRr/h5XeClD9BoIsLN6oBoSKhAgBQsiLgVHt5+6771YrvQGUheHDh6uXAGEwyEFAW1MLrPBGPoKR5wDlAG2EYOvsaUBlJMTOw/qNikfIddi7d6+uQ+w/1iN0CdeFEBtUMIJSYIDEbpwTXg9MxGqE5BjViLAfrheeBqM2/4ABAzRUCEI/QolQbQkKEkBYDxKD4TFAyBKOi3vmqioQFBiUAfVVGUhpLECRw3WxdGhgE2IzTw1MkgGNFg8RtHto59CAYQ3AQ5XWJCySHPav/2Ef+x/2sX/JCv1rCFyuJqzSGYULFFCrdsEW/SVfnTYeS4R6UhYu7Vgh59ZOVsEQArS3SZ4QDdAObB9oM+hCsIZQnZqwH2+BlRtCPRQRf00qZvRxixYtVKCHwJ9VQFgW+g9eldRWm0orgTyGrXpXOMuoqYEeAUIIISSAgOACazT+nl8/Ra78/f8hKs5KgFFNyNU8A9gP+5uPl9lBsjCSaDt16uTX88C6j1h5ziycOhDCBI9IRikBxHuoCBBCCCEBxv33369hMmGhIRKz9F27MuA8WRhi6F1NOobtsR/2x3FwvMyOMYHVxx9/zHATQiwi85sHCCGEkCysDED4hVCf1OwJubh1cbLJwvAXIBcAykD+eh3VE5CVlADgPJtvVgGJw5k5dIVkbugRIIQQQjKBZwCx/q5mDHaegRjbZTUlgBDiH6gIEEIIIZlAGUDCL2aHNSsBBoYygPXYjkoAIcQbGBpECCGEBDgQ6lOq+gNlAPXqJ02alCUSgwkh/oceAUIIISQT4K1wTyWAEOItVAQIIYQQQggJQqgIEEIIIZmIpLg4OT//KznUvbvsb9Va/+I7lmc1PvnkE2ncuLH9O/IfjBl7AXIiChYsKBUrVtTvmEkXM/diu02bNknVqlW9qjbUqlUrmTp1qr36UoMGDVLd5m+//VYnCTPAXASrV6/W/7/xxhs6eRjxDO5dsWLFfNrHeWxkpsnXbr31Vjl7NvkM4ekBFQFCCCEkk3D9wEHZ37qNnBw+XK5u3yHxBw/qX3zHcqy3sm5/rly5VMDKly+f3HbbbSrkegsEeIQpmYUzzHuQllKZmG0ZQhPArLXLli2Tw4cPy99//63LXnjhBRk3bpxuh/NjUjBcR0qsWrVKevfuLVbw8ssvy7BhwyTQ+fTTT+WWW26RiIgIKVq0qFadunjxotvt27Ztq9vlz59fFS+jbK07oIRh7BgfTNJWo0YN+3rMhtuyZUvJkyePlCtXTubNm5em6zGPjdQyI41KoDeYFUNj8jX0/ZgxYyQjoCJACCGEZAJg8T/Sq5cknD797wKbzeEvlmO9lZ6B999/XwWs2NhYefLJJzVpOSEhwev9IWS+9tpr4g8OHjyoQhWUFPOy6tWrS0axa9cuOXbsmIMXI1CBEL5lyxa9t/v27ZP4+HgZOnSo2+1Hjx6twjuUhUWLFsmrr76q+7sDShjGjvGpU6eOzolh0LVrV1VEYAmfPn26end+//13CXQSfBj/3vLoo4+qEnL9+nVJb6gIEEIIIRmMzWaTpPh4j58LixdLwsmTIklJrg+SlKTrLyxekuKxcD5fCA0NlUceeUQrF504ccLe5nfffVduvvlmiYqKko4dO9rXGQwYMEBWrlwpO3fu9Oo8R44ckWbNmqlw36hRI7X2m4E3AV4FVEfq06ePbN261V5WFX8TExOlbt26UqhQoWTW16SkJBk/frxajXF8WKx37Nih6yC4IwzJFf/884+GDuGY5cuX16pM7li+fLkey1uvR/fu3eWmm25Shemuu+6S3bt329fBSty/f3/tV1xb7dq1Zf/+/drnCJspXry4zJ8/38GrAWEbFvtSpUqlqIDBCo+wKuNe4h5DIXAHFKzs2bPr/43r87S9s1Kwbds26dGjh71Pf/nlF3n77bfV64Q+a9++vcycOdNhv7Fjx0qRIkWkZMmSMmHCBI/nMMaG0XdPPfWUPPjgg9of8ERASTOA1wh9lC9fPh2/8Eag7/v162cfU/hcuXJFw7k6deokvXr1ksjISG2Tc4jXtWvX9PyHDh3S7xDo4RlCHxveNChRUH4wxqFQ4/ivvPKKbo+2FChQQH788UdJb6gIEEIIIRmM7cYN+btGTY+fU2+O9OpYp958M8Vj4Xy+AAEbQlrp0qVVcAX4DqEYgj6s4BBMzRZfAIF14MCBXofKQFBC2MmZM2fkww8/tMftO/PEE0+o4F6vXj21Nn/22Wf6F2zfvt1lvDWOh+0WLlyoVu3FixerApNS/DYUEwip0dHReq0I4Vi7dq3L7X/77TepVKmSeAtyCSC8nj59WurXr6/XbwYCKqz0UMCgwGD7q1evqlCJ64GXBt8BQmxgVb5w4YK2E9f6v//9z+P5V6xYoUoIPrDyDxo0yOP2UAYhuFepUkXvN8KFvAEWf4RoQeAFsPwjlwPCr0GtWrUcPAK4h/DwQHBesmSJjBgxQjZs2CDeMnfuXHnuuee075o2barjECCM7PXXX9fckUuXLmmIGRQFKDrmMYUP+hQgBA0elHPnzukxU2LIkCHy3Xffaa4DPC4YxwgBQpvwDKGvcXwoQgaVK1d2UFbSCyoChBBCCHEJYu5hBYVA9Pzzz2t4iFGe9Msvv9RlEHwhHMJSCisvrNZmXnzxRQ0hgWDkCQh8P/30k54jZ86catmH4GkVEPLeeustqVatmlpvK1SooMKoJ2Dhh8ALyzxi3KGkwPsAgc4VEDphgfYWWMixfY4cOVQ4heU8JibGvr5Dhw4as45zP/TQQ6owICQH32HthhJg9Pfdd9+tAi0s+xBqoVSklNPRpk0bFVTheYGAC+u4J2bPnq0CLARyeCpw370JpcFYgUXdAMfAuDKD7xDMDeDBMY8F9NWcOXPEW9A+eJUwv8Zjjz1m9/5g/MIDAqXj6tWren+h2HgC54cHAH2b0jWj3fBYwYOB8YV9atasmaLSCc8Bxk96Q0WAEEIIIS5BKA0szBCYIOQPHjxYvvnmG113/PhxDb0xQKgDhB0sdxbwYCFFqIQnEFZkWKcNUhLUfQGKBmLSfQGhHghrwjUYH4TmnESIlgtg4faUcOvsZYGnBG2CMmBcq9mbYa6cA4sywpPMs0pDKDU8Ibg/TZo0kcKFC2sfTp482X4shLwY4S74vzOwUt93331eVTTC+XEe9CfOARA6ZRx/1KhRybwOyD+AYG6A7aCAmMF3c76Hq7FgjC1zEvLmzZtdthOJzea+Q5gPQHgXvFnwqBQtWlSVISOkyB2+jEP0OZ4XX8calCCzhyS94KwjhBBCSAYTAmvzb7963ObC//7nVXhQ0ddfl8jOD6R4Pp/aFxKiVk1YWGElv/fee6VEiRL2mGgAgRTWbCx3BrkCsJBiX3cg5AjCIARpw6oOYdMqIOwiph0hKL7sc8cdd2iIhzfAIp+SUGkA6zbCk9asWaOWeFw3FA1f8zcMunXrpp4LhAVBQYC3BuFMhjfEXQ6E2XLv7M3xdnvkJ7hj2rRp2jZ4PQzglYEXAkqm4RlAWAyWG7gaC8bYMpSf1IIQNnzi4uI09ApeHigU7nI7nJdDAcG+BmbFEMoa+h9jDbkBKR3L4M8//9R7lt7QI0AIIYRkMBAOQrNn9/iJ7NhRwmEhDnXz0x0aqusjO3ZI8VipKeH5xx9/qLBkCGsI2/nggw+0PCiSJWH1R5w7LK7OQDBC6IunEokQuhEGAys5ki1hiUcoilUgrwBtwHVA2EbCqnMysjOIgYeygxhvtAnCL5JKkVDqCliXEY7jjTAPCzCEY3hRYEFGyE9aMCzK6Gsk5qYURgMB3VAUDhw4oOd3V2oVAj/maIDwiz6AQvfVV1+lWJr11KlTqpiYw4IAwrIQi49z4toRNobjG8nEACE15rEAK75zDkVqQI4A8gMwZnPkyKFCveFlgYcAXoeUqvcgcRvPAvoNngbkL5jbjUR2CPVQXjAWfv31V3vIF87hrHAhxwb5B1A60xsqAoQQQkgmIDR3bik9bZqEFyny7wJDmP/vL5ZjPbazCggzRghG69at1XKKD4DQBuEa3gFY85HAaq5i4wzq9KcU+gDhFXHysKo+88wzyQTItPDss89qrHi7du00BAWVYCB8eQLXjcRgCKlIdEXYDa7ZXfgPBET0hTfzLaAtqCqDijhIFIVgnBaQuP3mm2/qtaGqDXIIPIG8DVQZQv4HqvYgr8A8NwDCfYwwHwizUOIQqgTFBdVuPv74Y+1LTyA3ANWZcB5nkAgNoRzHQ19gXgOzRwBjACE56HcoZFAakLidViDko/24l1FRUfLzzz/bvSVIKobHCHkD8FQY4UTOoB1oM3IH0GZnhQjhY7fffrvceeedGt4ExcBI6kaIHNbj+EZlJ/QTKh2ZvSbpRYgttT6oIAFaGgYhXnB4WBHTh2oGGEDmOD1iDexf/8M+9j/sY/+SFfrXCKkxx9h7C+YJiF2+XGKXLZPEszESVihKItq1k4i2bS1TAiAawPKLxMq0TAAWjCCMCAI0Qn48wT72L5mlf+Pi4lT5QPUivNN8eVc4y6ipgTkChBBCSCYCwn6BLl30QwIPWNczw4RiJDBAIrN59u30hqFBhBBCCCGEBCFUBAghhBBCCAlCqAgQQgghmQDEO1u5HSGEUBEghBBCApxFixZpxR1UrEGytCuwHOuxHbYnhJCUoCJACCGEBDAQ6jH5ESZR+uyzz7QUobMygO9YjvXYDttTGSCEpAQVAUIIISTAlQBJTJTXihSVUtmyy4wZMxyUAUMJwHKsx3bYnsoAISQlqAgQQgghAa4EjCteXLoWKCAzS5VyUAZu3LjhoARgPbbD9lQGCCGZXhH466+/pEWLFjrzHWa0e+mllyQ+Pj7F/YxZ8DBlOabbbtiwoc4eRwghhGQ2JaBlvvy6vFi2bA7KQKVKlRyUAKwH2D4QlYEGDRpoe8Hs2bN1JleDf/75R2dqxcy4I0eO1GWYxbhgwYJSsWJF2bx5s5QvXz7Fcxw5ckRnBMYMsgA1/Y2ZY1PD448/rm11B2QTTCKWGUG70X5/glmBU5pcjWQcAa0InD9/Xl8SEPwXLlyoM/VNmTJFBg0alOK+77zzjgwfPlynR1++fLlOF92yZUs5cOBAurSdEEIISQ2o+vPoo4/q35cLF7ErAQZmZQC/ac5KgAH2w/44zmOPPWZJNaGvvvpK7rjjDp0ECUJ9WnjkkUdkw4YN9u/vvvuuHvPSpUvy2muv6Uyry5Ytk8OHD8vff/8td911l+zfvz/F48IAiDyJHDlyiBXGSCggXbt2TfOxsiq///673HvvvVKoUCGdwffatWsO64cNG6YfEpgEtCIADf7ixYtqycAg69Wrl74osPzEiRNu98MgHD16tLzwwguqCDRr1kzmzZunVoVx48al6zUQQgghvhAeHi7dunXT/884f15O3riRbBsI/bNKl5KBhQrpX2clAGA/7A8gyOK4qSUpKUk97fgdfe655+SVV14Rqzl48KBUr17d4XvZsmXVQ5BRQN54+OGHJTQ0oMWlDAPKZbZs2dTrZHh6nIHieOHCBdm2bVu6t4+kTECP7FWrVknz5s31xWOAwYYXkic3048//qgKhLpV/yN79uzSqVMnWblypd/bTQghhKSFyZMnS8+ePeXojXjpcfSoS2WgSHg26RdVSP86g+2xH/bHcXA8X6lQoYIa3xCuAw/AyZMn9TcZv60lSpTw6hgwwt18881a0nTw4MEO6yA4Gl6Fu+++WzZu3KhKBsJ64NVH7sPWrVv1O5Y7h7HAIAghvWjRonr8jh076vJDhw65tEwbfPnll1KtWjWJjIxUL8OePXvcth8RBebwJfD+++/r9RcpUkTGjx/vsA7K0nvvvSe33nqryi6tW7eWY8eOOYQ/tWrVSq3nt9xyi0PI0htvvKFySvfu3VX5qVq1qnz77bf29bNmzdJ9sK5UqVLaDoNvvvlGbrvtNr2mOnXqqBfDAPJQv379pGTJktp/zzzzjMe+KVeunPz5558u12Ms4Vj333+/3pcFCxZo2Fbv3r21T93RpEkT9e6QwCP15oF0AC45eAHMYJAjzAfrPO0HEDtppnLlyho7ePXqVc0bcAUeGHwMoqOj7VUZjA8UEXd1nEnaYP/6H/ax/2Ef+5es0L8QGCGs4q8rYIFGKVBDYIZQ7yr8xxXOSgCOg+O5O5e79hnC55IlS1TwNLfX+a+n33Dsf88996hwD6sw9jE+xjEg8EJYfOihh1TQBBC0P/30U/npp5/0uxGHj+1x79u1ayf169eXvXv36m86jIDOx3X+P4TRV199VZYuXSpVqlSRzz//XI8DwRcGQzNXrlzRUCQIusZx1q5dK2+99ZYaI7E/FJSzZ8/ajz9x4kTNJ4BgDmVhxIgRqqxAMI+Li9MIhaFDh2qf4NiIdoDSgNBl7I92TZs2TaZPn67H6dChg4Z/oW3oy/Xr16vycu7cOQ2Zwj6//vqrepAWL16s1ncYPKEUof+hcCDHAcoDFB48N2jPm2++KW+//bZD/0CxQPg1FLIyZcq4vbdQFtDOr7/+WhUKV2PCeV/IY999951PYzCtOI+zzIztvzHvjBXvwPBAzxGA4O8MNH88BJ72Q2xgzpw5k+2HzsR6d4oANHk8uM7ExMToMfEQxcbG6jK6Cq2H/et/2Mf+h33sX7JC/0KAwm9KSnH7sOTjer/44gsV7hEG5MoDYHDKpAQgLwD743fP1/wAQ4CCUI6YewPjOEaokKfjwhsAQRfJuuDFF1+UDz/8UPfFfs7HwP+Nda7OYQg9+P7LL79o6BCES0OAb9Soka4ztjf+bz4u+gOeCRgGsRyW7LFjx2o+AgRsMxDwAbwhxjHnzJmj/VqjRg39DqUAihbaZhwfXhRY3wGUDoQkQ5hHm2GRRwI0QOIzFLW5c+eq1wFtxHGNfATkUHzwwQcqdEOwRwgO4vHhKcifP7+GUeGc8CpA2Id3Bce47777pGbNmqr0oP+x/6lTp/Q6ABQRXDdkHaNPhwwZIuvWrdOcjcKFC7u9rzg+vBzoK+yLNpn729zvZlDwBXJbes56bRaeocRmVpKSkjTx/cyZMy5l0yytCGQESESGO9LsEYDFISoqSh8OY1BByw4LC8vAlmZN2L/+h33sf9jH/iUr9C880xBOUorbx3oImt9//70KkwtjYzUcyB2LLsaqEoBwHOwHQS0tHguEibhqIxSwlNqPUCJYlo1t8BdWcuyL/zsfA/831rk6h3Gv8f348eOqoBjCrRnz+fAxHxdWdAjCENANUJAEbXW+FowvAEu+YZTEdrVq1bJvi20glKNtxvEhwJsVVPwf+x09elR27dqlsoR5LN955532/jD3F0COBPaNiIhQLwJCkV5++WVtA3IhURERkQ7wlsC7YYCysqi4iLAknAPjwXxvsQznQbuhVEOZgPcFERcGUAKNakm4JmyDNqJNru67c787e1cQKpWWPBVfMTwBxhjIrISGhqph2zxuDIzKWFlWEYAF37D6mIFF35w34Go/dA4sLmavAPbDYMB6d+CBxscZPCzGSwg3xfydWAv71/+wj/0P+9i/ZPb+NQSTlAQUCGxPPvmkvTpQp4gIj9vfnz9CFsVe1O2xH4TDtPSRIYynpv0Q+hG2YmyDa4EAj+/Gx/kYrpa7+guBGQKwkazqrm3O/4fygDLksMSnBGLgYbVHxSIjJ+Kmm25Sgd44LpJgEU5sPj4EZsMLYgb7IXTHHOKE9huCKj64JnN/4Hvnzp11GQR7fKC4wFOAMCoc07gm5Bg4Yyg4p0+fThb6ZPQLlAxUZkQYEhQe5DAAKAb4pGZMOK9HmBKUl/QWyJ3HWmYlJCTE5XNsxfsvoH2qiClzzgWAYgArvXP8v/N+AA+vGRzLmFeAEEIICWScZwxGjoCnsCBQ1GmeAfMMxFa1CUY2WJwhyOL/7ub2efDBB7XoB8JNsD1yBGCQs4J69eqpMgAvPsqN4vjmxFp39O/fX+cYgoKC9qPMKEJocAxXtGnTxmGOAAjfM2fOVMs+rh1lMc3WfxwfFZWMMqe4XpRcNerpI5F56tSpaqyEErB7925NiDZAuxB+hHXIz8BxEIqD0B7kAKC9UHwQ828IgU888YTG9sNrhDASeJsQ5w9vAEKRcA3PPvustgXXDOVh9erVDtcJBQXHR9iT87qUMMaBYZ02DLFmcG/QDhJ4BLQiAK0UMWvQuA2QoY6HDok17sCAhlUf2xrgJQGNFw8UIYQQktmUAG8ShV1NOmalMgDhFMY0CJ9btmzR/7v7PUYcPjwSiEdH4i/imVHZxgogBEOAh2EQYS+oHIT8g5SA1RtzDPXo0UOt36iMhGtyB8JjEMMPARsg5h6hORBqYViEx8AIIQIDBgzQZFwI/ZBDEKuPxGHDw4BkY8TsI/kaffLUU085FChp3769JvsicgGhPyifjggInB9eAOQeoN24r1AYAKoEQTlBDgbCmKEgIYTIaDPWQXmARR7Wf1wDEqydQY4Fzoc5LHxRBhAOhXFgGGHRPrPBFZO54toRZk0CjxBbAKdTQ3tFUgwy6qF1w6UI7R+xah999JF9O2ThYyDu27fPvgwaP9xksEAgoWbSpEma5Q8t3hwrlxLQqPHAQoPGA4iXKRI2EKuVWV3SgQz71/+wj/0P+9i/ZIX+hWUYIN7aFRC0EePvSQlAYjByAhAOBE+Ap+pBSFCF1dhbnMNWghmEESEkB7KHlTj3MWQWRC4gyTorgapMKFkKBSQ9ySpj+JCHd4WzjJolcwRQKgsaNjLm4QqDZQMlr8wY2fpmkAGPQYBsffxgQBOGVu6LEkAIIYSkN/g9gxUa9CxQwO1kYYaQj5wAV8oCvmP/kadP6fFgEEvPZM2sgruJsoh3cP6AwCbg3whwLSI8yBPm+D0DaH9w3+FDCCGEZBYgrKNcKCbuGn3mtESFh0nLfPldKgEwbiEx2NU8A2suXdT9jeNRCSCEZKocAUIIISQYwcytmmQaFiaDo6NVqHc1WRhCSVzNQIztsR/2x3FwPBLYIDQoq4UFkcCHigAhhBCSzqDohZHM6a0yMPf8eQclAIm4SALFX7MygO2oBBCSNUhKSvLrxIlUBAghhJB0BjXdXZVZ9KQMINbfrAQYidL4a1YGsB2VAEIyP9f+K8vqag4Iq2DAICGEEJLOoOQkykZiwqiUfuRr166tlfJeeOEFrcCCWXFRJcQZLIfggORMlI/EfkbFkUC0RBL2sb/J7P0bHx+vir65RK3VUBEghBBC0hkk7mK2WpTJdq565wqUXkSpbE8JvxAYUHt+5MiRaU4MRtU9WCJz5syZqUsvBjLsY/+SFfo3d+7cWkHTn4n+VAQIIYSQDCBPnjz6CUSywlwNgQ772L+wf70j8/pLCCGEEEIIIamGigAhhBBCCCFBCBUBQgghhBBCghDmCKSAkcQVjZrM/8WcxcTEaAIKY86sh/3rf9jH/od97F/Yv/6Hfex/2Mf+JRj6N/o/2dSbggPuoCKQAkg0AfXr18/ophBCCCGEEJJMVi1btqykhhAb6isRt6Am8+7duzXrHOWboH1BKdiyZYsUL148o5uX5WD/+h/2sf9hH/sX9q//YR/7H/axfwmG/k1ISFAloHr16lomNTXQI5AC6Nh69eolW45BVbJkyQxpUzDA/vU/7GP/wz72L+xf/8M+9j/sY/+S1fu3bCo9AQZMFiaEEEIIISQIoSJACCGEEEJIEEJFwEfy588vw4cP17/Eeti//od97H/Yx/6F/et/2Mf+h33sX9i/3sFkYUIIIYQQQoIQegQIIYQQQggJQqgIEEIIIYQQEoRQESCEEEIIISQIoSJACCGEEEJIEEJFgBBCCCGEkCCEioCX/PXXX9KiRQvJkyePFCtWTF566SWJj4/P6GZlCvbt2yf9+vWTWrVqSXh4uFSrVs3ldlOnTpVbb71VZ3OuWbOmLF++PNk2sbGx0rt3bylYsKDky5dPOnfurNOIBzMLFiyQDh066MyJGJ/o52nTpolzQTD2b+pYuXKl3HPPPVK4cGHJkSOH3HzzzTJo0CDtKzPLli3TfkX/op+nT5+e7Fh4Z7z44ov6DsG9wjvl77//TseryRxcvnxZx3NISIhs27bNYR3HceqYMWOG9qfzZ+jQoQ7bsX/TxsyZM6V27draf4UKFZJWrVrJ1atX7ev5nkg9jRs3djmG8Zk3b559O45hH0H5UOKZc+fO2YoXL267++67batXr7ZNnTrVFhERYXv66aczummZgsWLF9tKlixpe+CBB2zVq1e3Va1aNdk2c+fOtYWEhNheffVV24YNG2xPPvmkLTw83PbTTz85bHfvvffqsebPn29bsmSJrVq1araaNWvabty4YQtWGjRoYHv44Ydt8+bNs61fv942dOhQW2hoqO2NN96wb8P+TT2zZs2yvfjii7b//e9/to0bN9omTpxoi4qKsrVo0cK+zebNm21hYWHar+hf9DP6e8GCBQ7Hwnq8O/AOwbvkrrvuspUoUcJ24cKFDLiywOWll16yFS1aFJqsbevWrfblHMepZ/r06dqfGHfoL+Nz5MgR+zbs37Tx1ltv2fLly2cbPXq0bdOmTfrO6N+/v+3SpUu6nu+JtLFnzx6HsYvPQw89pGP0zJkzug3HsO9QEfCCUaNG2fLkyWOLiYmxL/v000/1gT5+/HiGti0zkJiYaP9/jx49XCoCt956q61r164Oyxo2bGhr1aqV/fuPP/6oP2TffPONfdlff/2lDz0e5mDFeAGa6du3ry1//vz2vmf/WsuUKVO0r4znv2XLlrY77rjDYRv0d+XKle3fjx49qu8MvDsM8E7Bu+Wdd95Jx9YHNn/++af2ySeffJJMEeA4Trsi4Op9YcD+TT3oAwicK1eudLsN3xPWU65cOVvr1q3t3zmGfYehQV6watUqad68ubqQDLp06SJJSUmyZs2aDG1bZiA01PMwO3DggOzdu1f71MzDDz8s69evl+vXr9vvQ2RkpLpJDSpWrKihMAjfCFbgfnYGrumLFy/KlStX2L9+ICoqyu7CR/9t3LhRHnzwwWT9++eff8qhQ4f0O94VeGeYt8M7pWXLluxfEwMGDNBQQow9MxzH/oX9mzYQ4lOuXDkNBXIF3xPW8+OPP8rBgwflkUce0e8cw6mDioCX+QGVKlVyWIZBVLx4cV1H0obRh859XLlyZRW08KAb2+FhRTyg83a8D458//33UqJECY19ZP9aQ2Jioly7dk127Nghb775prRv317Kli0r+/fvlxs3brjsX2D0Hf4WKVJEChQokGw79u+//O9//5Pdu3fL66+/nmwdx7E1VK1aVcLCwjTXZfTo0TquAfs3bfz8889SvXp1eeutt/Q5z549uzRq1Eh++eUXXc/3hPXMmTNHcyiQIwc4hlNHeCr3CyrOnz+vgr8zeFDPnTuXIW3Kav0LnPvYeBEafcz74L0SgMSp8ePH63f2rzWUKVNGjh8/rv+/77779EcIsH+tIS4uTpOwR40aJfnz50+2nv2cNmC4GjFihNx+++0qAC1dulReffVVHdMfffQR+zeNnDx5UrZv366K7KRJkyR37tw6lmHJ/+eff9i/FpOQkCBfffWVGmSgDAD2ceqgIkBIFuLYsWPy0EMPSZMmTWTgwIEZ3ZwsBVzGCLXas2ePWv3atWsna9euzehmZRnQp0WLFpXHH388o5uSJbn33nv1YwABNVeuXPL+++/LK6+8kqFtywognAfVruDVqlGjhi5r0KCBeg2haJn7nqQdvHvPnDkj3bp1y+imZHoYGuQF0BKdSwUaWqU5b4CkDkNbd+5jQ7s3+pj3wTMXLlzQ+FTEr3/99df23Az2rzXgx71hw4bSp08fWbJkicb7Llq0iP1rAYcPH1YPFizW6COMZQhVAH/xYT9bD2KpERq0a9cu9m8aQb/g3WsoAQD9gXwtGA/Yv9YCjyz626xgsY9TBxUBL0C8mXPcGAYRas46x6IR3zH60LmP8R1xlohlNbZDLWXn+viucjiCDdSpbtu2rY5LJEJFRETY17F/rQc/9tmyZdM5MsqXL6//d9W/wOg7/D116pT9R8m8XbD3L2J3EcPbpk0b/ZHGBx4XAO8WijVwHPsX9m/acy/cgdwivies/b1bvHixJlSjTw04hlMHFQEvgJV13bp1aqUyT+IEiyvcqyRt4OHE5B/oUzPz58+XZs2a6QNs3Ae8HJH9b4AKATt37pTWrVtLMMdKwrKHyhOrV6/WJGEz7F/rQQIgEv/Qt5hkDMIqQgKc+xfJZwgNAHhX4J0Bb40B+htVQoK9f1GtAx4W8wchK+CTTz7RmGuOY+tBLhESh2G1Zv+mDRhiYmJi1LtigO8oLlC3bl2+JywE+S3wEjqHBXEMp5JUlBwN2gnF7rnnHq07O23aNFtkZCQnFPOSK1eu6IQp+DRu3NhWqlQp+/fTp0/rNnPmzNEavq+//rpO2tSvXz+tyYx6v86TgGD/r776yrZ06VKdoCxYJwExzxmAR3n8+PHJJlu5du2absP+TT3333+/7e2337YtW7bMtm7dOu3nYsWK2WrUqGG7fv26w0RBmDwI/Yt+Rn+jH81gchu8O/AOwbsE7xROFOQa9KPzPAIcx6kHNezHjBljW7FihX4wFtGXzz33nH0b9m/qwZwt9erVs5UvX14nd8QkVZjsEZMPRkdH6zZ8T1hD+/btbaVLl7YlJSUlW8cx7DtUBLzkjz/+sDVr1syWK1cuW5EiRWyDBw+2CwHEMwcPHtQfdFcfPKgGn3/+ue2WW26xZc+eXR9KCF7O4EXYq1cvfUnmzZvX1qlTp6Cf1K1MmTJu+xd9b8D+TR2YJbRWrVo6Yygm9cGEeK+99potNjbWYTv88KNf0b/oZ8wK6gwUsxdeeEHfIXiXNG/eXCfQIt4pAoDjOHUMHDjQVqFCBR13OXLk0L6bMGFCMmGK/Zt6MFlb9+7ddVZg9DOUL8yGa4bvibQbZtF3mH3cHRzDvhGCf1LrTSCEEEIIIYRkTpgjQAghhBBCSBBCRYAQQgghhJAghIoAIYQQQgghQQgVAUIIIYQQQoIQKgKEEEIIIYQEIVQECCGEEEIICUKoCBBCCCGEEBKEUBEghBBCCCEkCKEiQEgQEBISkuJnxowZHo/xxhtvSN68eSWz8dxzz0nZsmUzuhmZgvr168vHH3+cIec+dOiQjrETJ06kuO2uXbt027i4OL+05YMPPpCVK1d6ta27tuB5wnN19uxZv7QxWEG/zpkzJ1X7/vDDD1KoUCG5ePGi5e0iJLNCRYCQIOCnn35y+IABAwY4LGvTpk1GN5NkIIsWLVJhvFevXhlyfpx7xIgRXisC2DZQFAFXbcHzhOcqMjLSL20MVtKiCDRq1EiqVq0q48ePt7xdhGRWwjO6AYQQ/9OgQYNky0qXLu1yOQlOIPx27dpVcuXKldFNyRIULlxYPySw6N27twwePFheffVVyZYtW0Y3h5AMhx4BQogkJSXJW2+9pSE0OXLkkEqVKsmnn36a4n5vvvmm5M6d2249vX79ugwbNkzKlCmjx6lcuXIy613Pnj2lWrVqsmnTJqldu7bkyZNHQ1K2b9/usN20adPUegfBNCoqSu68807ZunWrx/bAmty+fXttU4kSJeTdd991ud2xY8eke/fuGiaA4999993Jzo++eOaZZ2Ts2LF6LByzQ4cOEh0d7bBdel6zzWaTcePGya233qrnuvnmm+X9999Pdm1dunSRokWLSs6cOaVcuXLy/PPPe+y3gwcPyubNm6Vz587J1q1YsUItqbj+AgUKSOPGjWXnzp329YcPH9b9IiIi9Lruvfde2b17t8MxECKDdjsrHlgO0C9NmjTR/9erV88erubOIvz444/r/yFoYztz6Jc393bp0qVy2223aagbLPb4vzGGcSxcE0KkUgqb89QW59AgeDzwfdasWdKvXz89b5EiReS9997T9fPmzZOKFStK/vz5pVOnTnLhwgWHc+H7U089JcWLF9d7X7duXVmzZo14wxdffKHjDuMB/dK6dWu9RgPcL9w33D/cR9zPI0eOOBwDbX/nnXfklVde0Xaj/S+99JKOyfXr10utWrW0P5s1ayZHjx6172dc98yZM1UIx/ELFiwogwYNkoSEhBRDD3EerAMYe99++62OSePeGOsAlt9+++1633E/+vfvL1euXHE4XseOHbUvvfX4EJLlsRFCgg48+mPHjrV/HzRokC0sLMw2fPhw2zfffGMbMGCAbjNx4kT7NliXJ08e+/fBgwfb8ubNa9u4caN9Wfv27W0FCxa0TZgwwbZmzRrbc889ZwsJCbGtXLnSvk2PHj1sUVFRturVq9tmz55tW758uf6/VKlStvj4eN3m22+/1fPjHBs2bNBtXn/9dT2mJ2677TZbsWLFbDNmzLAtXrzY1qBBA1uJEiVsZcqUsW9z7tw5/V61alXbnDlzbCtWrLDdd999tvz589tOnTpl3w7b3HTTTbaGDRvalixZoscsWrSoHtNMel4z7kuuXLlsb731lm3t2rW2ESNG2LJly2abPHmyfZsmTZrYKlasaJs3b57em5kzZ+p+nvjss8/0ONeuXXNYjmPgWjp27GhbtGiR9tWwYcNsy5Yt0/UXL160lS1b1nbzzTdrXy5cuNBWt25dW2RkpO3IkSNuxxt4//33dTmIjY21ffzxx/p9+vTptp9++kk/rjh9+rTt1Vdf1W1Xr16t2+3YscPre7tv3z691scee0z7Fsd45513bF9++aWux7Ewhjp37mxvB87pa1twHVh+5swZ/X7w4EH9jnuOMYJzP/XUU7ps6NChOq4wZr/44gtbRESErW/fvvbzXL9+Xcc29p06daqeq3v37rbw8HDbb7/95vHevvvuu3qO3r17a3/gHAMHDrRt3bpV1+M+4X7hvuH+od/KlSun9xX313wPS5YsqefF+TH2sAzvDoxljBXsj21atGhh38+4bjxLPXv21H1HjRqlbR8yZIjb94sB+gLrwJ49e2y1a9e2NWrUyH5vjh49qusWLFhgCw0N1etctWqVbdq0abYiRYrYHnrooWTHrFWrlu3pp5/22G+EBAtUBAgJQsyCGQQVCEYQRsx07drVVrhwYVtCQoLDD3VSUpKtX79+tgIFCth+/vln+/YQXnFcKBJm8ENcr149B6EYwuXvv/9uXwaBFftu3rxZv6NtEK59AT/+OMb69evtyy5cuGDLly+fgyIA4RrChVnohwBcunRp24svvmhfhn2wL45hgGMbQl96XzMEWBzj008/dVgOYQqCa2Jion7HPfrwww9tvvDEE0+o8GwG9xlC3b333ut2Pyg/aNMff/xhXxYTE6NtgIDorSJg7g9DQPWEs5Dty72FwIh9zUKuM7j33gqK7triThHo0qWLfRs8W1Au0V9nz561L3/hhRdUODeAUAvBGYKwmdtvv9324IMPum0bxm7u3Ln1/rrj+eef1/Pjvhn8+eefel/N4whtr1+/vsO+UB6c7z+MB9j2/PnzDtd91113Oez72muvadugvHmrCIB77rnH1qZNm2RjFfcM7yznd4Lzc2c8j1CsCCE2G0ODCAlyfvnlF7lx44Y8+OCDDssfeughOXPmjOzdu9e+DPLAY489JgsXLpSNGzeqG94AYQpw+Tdt2lRd/sanRYsWGkqSmJho3/amm27SEBiDKlWq2MM6QJ06deTcuXMaUrN27VqvkkJxHQg7wPkN8L158+YO26GdCENBW402hoWFyT333JMs9Ajb4RgGODb2w7nS+5rXrVunfx944AGHc+H6Tp48aQ/HwHEQhjN58mTZt2+feAPCnZzj2f/++29tm6fkYYQTIeQJ4VAG6A9c//fffy/pjTf3tkaNGrqsW7dusmzZMomNjfU6fM7c7/ieGtA3BmgHwrsQVoNQMAOEfiF85fLly/brql69ui53HmeewuWQrIxxhJAcT/fQGNcGCA2sWbNmsntobrvRToxr8/3HMvO4Nrj//vsdviP8CG1zDiNLDXhHIdQJIXHm/sF9Dw0NlW3btjlsj/Ao5xA/QoIVKgKEBDnnz5/Xv4gpN2N8h3BqEB8fr/HViF2HYGIGsdDYFgl45k+fPn30R9n8w+tcSSV79uz699q1a/oXggliqffs2aOxy/jhhgJibos3wqyr60I7Fy9enKydOJ85thkgFtoZLDOuJT2vGeeCIobl5nMZwpnR9vnz52ucNmK5K1SooEIdFDdPoA2IOzcTExOjfyHoeRo7zv0LsMzTvfIX3txbCKrLly9XBQDCKcYM8kqcY+Jd5cOYj4nvqcHVOEhpbOC6oFg6XxfyepzHrD/vYWra7u5ZMs5phUBu5GHgfpr7B3ktUMad+whj/erVq2k+LyFZAVYNIiTIMSyBp0+f1qRYg1OnTjmsN35AkZB33333aSKeOaEY20GocpeE50qo9gQSPvHBj/ySJUs04RU/7lOnTnW5PZIo4cFwxrgOczvR/pEjRybb1lkYRp84g2U4V3pfM86F5EhYaQ1hywwSTQHahqTjzz//XJNkISzCuwMLP6zPrsCxkdRpxrBQeyrnif1wXFd97jxuoES6UkCtxNt7i23wQT351atXaz8j6RdJr+544oknpG3btvbvnoRrf1wXPBnuxr47zPewZMmSbo/tapzjHhrWfStwPofxXBrPEhKZ4Zk0g++GV8QTxlj76KOPHLyU7u4VvC1mDwwhwQwVAUKCHFSvgbC5YMECrSxi8NVXX6kg6ywMwBsArwDqpKM6B6q/AISooEoPhFQILVYBCzhCGyBs//nnnx6vA1beDRs22MOD8B0hNWahFO388ssvNZwBVVI8gfAnHMMID8KxYSU1hI30vGZY+Q0rb7t27VI8BkIiUIEHigDuF8KE3CkCUCJwrc7LIDxOnz5dQy5cgbHwv//9T5UBQxGBgI8+h+BsgOM43zuEP3ljSXaFu219ubcAFXpwbQj1mjt3rsPxnY8NYdKV8O9Lu1MLrgtjwV0b3NGwYUO1iuMe4vlwdw+nTJmi9w1VoQDu52+//WbpnBKYp8JcvQrjBm0zPIsYI1AW9+/fL+XLl7c/b+bwOnf3Bl4v7H/gwAF5+umnU2wLlF5jvBIS7FARICTIgdCJycVQJhNWOcwtAKEDJTAnTpyocczOQNBGuAlK8eHHfNSoURqiAgEVllaUFYRgjNJ9CHWBEAoLtbcMHz5cBV6UC4QygjhiWG5RctAdOC/i4x955BEtc4iQhdGjR6uwZwbHmD17tsYPP/vsszqfAjwJEAYhZJmFlXz58kmrVq1k6NChakUcMmSIClQI3QHpec1QyCDkPProo/Liiy+qMgKLKeKjIcQjJAZKC9qGbSDoQLDCPURfoG/cgfKgCHVBXLdhOTZKfmJuAeQlIEwJVnXEnUPBgHUcVnSUL4VSCIUD4+ftt9+W8PBwndHZHA8OhRH7oV0Q1o8fP+7QBlwfxhq8GdgfH5T1dIURk44Sn8YYhEDpzb2FFwvXgHsGazRKp6I9LVu2dDg+hFAoKxCOUYLVnQXZXVusBH2PdmNsoAa+kUOAcCHcY4xzV0CBxbjCuEVOA8rf4i/GC+4r+hd9AkUB149wMgjZqLGPvkO+ilVAwMd4efjhh2XHjh3aZpzbUD7wnEF569u3r7YXY3HChAk6ppz7G6VIkd+B+2coRyjDirwPPH8YjzgW8gbgwcT7yWzQQM7ACy+8YNm1EZKpyehsZUJI+uNcxQUVZ958802troIKQhUqVLB98sknDvu4quqBkpKoZoJ9jTKHKCuI/bNnz65Vh1DOEiURzRU7nCvUoMKIUToSoDxls2bNdP8cOXLYypcvr+e/ceOGx+tCKUFUFMmZM6etePHiWqbw2WefdagaBKKjo7XMILZBO1EdB+Uif/jhh2SVY0aPHq3b4Zjt2rWzHT9+3OFY6XnNqI6CqizVqlXTc6HKEMqbvvfee/YKOX369NHyoSgzivUtW7a0bdmyxWO/4RpQ3nTKlCnJ1i1dulSr0+D6UcmmadOmtp07/6+9OzhNIIjCAJz0YAnWYQHiyQ6sw4sN2IPVeJOwHShYgvcN/4QNG9kggZCEvO8Dc1kZdpyXhLc7+/vyfvx8Pvfr9bolLCUFJtGR95GWt9ut32w27Xxms1m/3W77/X7/ITUoUnOJIk1NPfr3tNvt2rolMnK8vo/W9ng8thoZjqfmUyPjFKGkzCTlJnMar9FXzuWz1KCkFo1NpeBMJRElYjUJP8PvaM5/uVy2mNlHkjqUiM/MN+u8Wq36y+XyfrzrurZuWb/MOeuZdR2bSn6aquv79Kdh3plT3p/xU0f5zIfo3EHSuDJeai1xqqmz+9Sg6/Xa5p0xMu74WCJZ83nm71ReGSsJTOPkr9Pp1JKEksIF9P1zfvx2MwLw1+SLoXLVO/uOK8gV0lxhzpVw+C7ZhpM7Ktl6OPWFdT8td9Py7Iw6hze2BgHQtpzM5/OnrutadCT8N3k4PNv18iA+8EZ8KABtv/XhcJhMXoL/IBGxSZRaLBa/fSrwZ9gaBAAABbkjAAAABWkEAACgII0AAAAUpBEAAICCNAIAAFCQRgAAAArSCAAAQEEaAQAAKEgjAAAABWkEAACgII0AAAAUpBEAAICCNAIAAFCQRgAAAArSCAAAwFM9r4ThWmS1mHNNAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lecture : pour chaque bucket, la courbe = BoN (scaling exterieur), la croix = r1\n",
+      "(raisonnement natif). Si la croix est au-dessus de la courbe au meme cout -> le raisonnement\n",
+      "natif gagne ; sinon -> le scaling hand-rolled est plus compute-efficace (Snell).\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib\n",
+    "matplotlib.use(\"Agg\")\n",
+    "import matplotlib.pyplot as plt\n",
+    "from IPython.display import display, Image\n",
+    "import io\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7.0, 4.6))\n",
+    "couleurs = {\"facile\": \"#2ca02c\", \"moyen\": \"#1f77b4\", \"difficile\": \"#d62728\"}\n",
+    "for b in PROBLEMES:\n",
+    "    xs = [base_curve[b][\"tok\"][k] for k in K_LIST]\n",
+    "    ys = [base_curve[b][\"pass\"][k] for k in K_LIST]\n",
+    "    ax.plot(xs, ys, \"-o\", color=couleurs[b], linewidth=2, markersize=6,\n",
+    "            label=f\"BoN {b} ({BASELINE_MODEL.split('/')[-1]})\")\n",
+    "    # point du modele a raisonnement (croix) sur la meme bucket\n",
+    "    r_succ = sum(r[0] for r in reason[b]) / len(reason[b])\n",
+    "    r_tok = sum(r[1] for r in reason[b]) / len(reason[b])\n",
+    "    ax.scatter([r_tok], [r_succ], marker=\"X\", s=160, color=couleurs[b],\n",
+    "               edgecolor=\"black\", linewidth=1.2, zorder=5,\n",
+    "               label=f\"r1 {b} ({REASONING_MODEL.split('/')[-1]})\")\n",
+    "ax.set_xlabel(\"Tokens depenses (cout test-time compute)\")\n",
+    "ax.set_ylabel(\"Taux de succes (pass@k / single-shot)\")\n",
+    "ax.set_title(\"Raisonnement natif vs scaling hand-rolled (cost-normalise)\")\n",
+    "ax.set_ylim(-0.05, 1.08); ax.grid(True, alpha=0.3)\n",
+    "ax.legend(fontsize=8, loc=\"lower right\", ncol=1)\n",
+    "buf = io.BytesIO(); fig.tight_layout(); fig.savefig(buf, format=\"png\", dpi=110); plt.close(fig)\n",
+    "buf.seek(0); display(Image(data=buf.read()))\n",
+    "print(\"Lecture : pour chaque bucket, la courbe = BoN (scaling exterieur), la croix = r1\")\n",
+    "print(\"(raisonnement natif). Si la croix est au-dessus de la courbe au meme cout -> le raisonnement\")\n",
+    "print(\"natif gagne ; sinon -> le scaling hand-rolled est plus compute-efficace (Snell).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4aff0bae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:23:47.721970Z",
+     "iopub.status.busy": "2026-06-15T22:23:47.721741Z",
+     "iopub.status.idle": "2026-06-15T22:23:47.727143Z",
+     "shell.execute_reply": "2026-06-15T22:23:47.726409Z"
+    },
+    "papermill": {
+     "duration": 0.009416,
+     "end_time": "2026-06-15T22:23:47.726179",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.716763",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Verdict cost-normalise (par bucket) ===\n",
+      "bucket      |   r1 single-shot |  BoN @ meme cout | gagnant\n",
+      "----------------------------------------------------------------------\n",
+      "facile      |    1.00 (  300 tok) |    1.00 (  220 tok) | egal / bruit\n",
+      "moyen       |    1.00 (  571 tok) |    1.00 (  331 tok) | egal / bruit\n",
+      "difficile   |    1.00 (  728 tok) |    0.48 (  314 tok) | r1 (raisonnement)\n",
+      "\n",
+      "Lecture honnete (G.2) : n petit, bruit eleve -> tracer la conclusion avec\n",
+      "prudence. La METHODE (cost-normalise tokens-incl-reasoning) est transferable.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tableau synthetique : au cout du single-shot r1, ou en serait le BoN ?\n",
+    "print(\"=== Verdict cost-normalise (par bucket) ===\")\n",
+    "print(f\"{'bucket':11s} | {'r1 single-shot':>16s} | {'BoN @ meme cout':>16s} | gagnant\")\n",
+    "print(\"-\" * 70)\n",
+    "for b in PROBLEMES:\n",
+    "    r_succ = sum(r[0] for r in reason[b]) / len(reason[b])\n",
+    "    r_tok = sum(r[1] for r in reason[b]) / len(reason[b])\n",
+    "    # pass@k BoN le plus proche (en tokens) du cout r1 (interpolation naive: prend le k le plus proche)\n",
+    "    k_best = min(K_LIST, key=lambda k: abs(base_curve[b][\"tok\"][k] - r_tok))\n",
+    "    bon_at = base_curve[b][\"pass\"][k_best]\n",
+    "    bon_tok = base_curve[b][\"tok\"][k_best]\n",
+    "    gagnant = \"r1 (raisonnement)\" if r_succ > bon_at + 0.01 else \\\n",
+    "              (\"BoN (scaling)\" if bon_at > r_succ + 0.01 else \"egal / bruit\")\n",
+    "    print(f\"{b:11s} | {r_succ:>7.2f} ({r_tok:>5.0f} tok) | {bon_at:>7.2f} ({bon_tok:>5.0f} tok) | {gagnant}\")\n",
+    "print(\"\\nLecture honnete (G.2) : n petit, bruit eleve -> tracer la conclusion avec\")\n",
+    "print(\"prudence. La METHODE (cost-normalise tokens-incl-reasoning) est transferable.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff222a9f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002001,
+     "end_time": "2026-06-15T22:23:47.732184",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.730183",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Limites honnetes (G.2)\n",
+    "\n",
+    "- **n petit** (6 echantillons) : pass@k bruite ; les points du modele a raisonnement sont\n",
+    "  estimes sur 2 problemes par bucket (bruit fort). Snell utilise des milliers d'evaluations.\n",
+    "- **Une seule comparaison modele** (deepseek-r1 vs llama-3.3-70b) : le verdict depend du couple\n",
+    "  de modeles. Snell compare a un modele 14x plus gros ; ici le rapport de taille/cout differe.\n",
+    "- **Suite simple** : sur de l'arithmetique, le bucket difficile peut saturer chez r1 (1.0)\n",
+    "  tandis que le BoN plafonne — ce qui ferait gagner r1, mais c'est parce que r1 est un modele\n",
+    "  **plus fort**, pas seulement parce qu'il raisonne. Desintriquer \"taille du modele\" et\n",
+    "  \"test-time compute natif\" necessiterait une comparaison a **qualite de modele compareble**\n",
+    "  (exercice 2) — non resolu ici, assume franchement.\n",
+    "- **Cout = tokens** (approximation) : le vrai cout OpenRouter est en $, non en tokens ; on\n",
+    "  normalise en tokens parce que c'est model-agnostique et que les reasoning tokens sont ainsi\n",
+    "  comptabilises. Le cout $ depend des prix respectifs (exercice 3).\n",
+    "\n",
+    "**Ce qui est demontre** : la **methodologie de comparaison cost-normalisee** (courbe tokens-vs-pass\n",
+    "du scaling hand-rolled + point du modele a raisonnement) — reproductible et applicable a d'autres\n",
+    "couples de modeles / suites plus difficiles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c4ff0e3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004,
+     "end_time": "2026-06-15T22:23:47.742240",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.738240",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Travaux pratiques\n",
+    "\n",
+    "Les exercices sont a completer (convention C.1 : pas d'erreur volontaire)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77a3c5bc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004275,
+     "end_time": "2026-06-15T22:23:47.749607",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.745332",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : plusieurs modeles a raisonnement (frontiere)\n",
+    "\n",
+    "Trace la meme comparaison cost-normalisee avec **plusieurs** modeles a raisonnement (deepseek-r1,\n",
+    "o3-mini, gpt-5-thinking) : chaque modele = un point. Construis la **frontiere de Pareto**\n",
+    "(modeles dominates elimines) tokens-vs-succes.\n",
+    "\n",
+    "# Indice : boucle sur une liste de REASONING_MODELS, collecte (tokens, succes) par bucket,\n",
+    "# trace tous les points + enveloppe de Pareto (un point est Pareto-optimal si aucun autre n'a\n",
+    "# a la fois moins de tokens ET plus de succes)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "fc3a5aec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:23:47.758136Z",
+     "iopub.status.busy": "2026-06-15T22:23:47.757958Z",
+     "iopub.status.idle": "2026-06-15T22:23:47.761227Z",
+     "shell.execute_reply": "2026-06-15T22:23:47.760774Z"
+    },
+    "papermill": {
+     "duration": 0.007998,
+     "end_time": "2026-06-15T22:23:47.760714",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.752716",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 - frontiere Pareto raisonnement : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def frontiere_pareto_raisonnement(modeles):\n",
+    "    \"\"\"Exercice 1 : points (tokens, succes) de plusieurs modeles a raisonnement + frontiere.\"\"\"\n",
+    "    # TODO etudiant : pour chaque modele, single-shot sur PROBLEMES, collecter (tok, succ),\n",
+    "    # renvoyer la liste + l'indice des points Pareto-optimaux.\n",
+    "    return None\n",
+    "\n",
+    "print(f\"Exercice 1 - frontiere Pareto raisonnement : {'implemente' if False else 'a completer'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "525434a4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003,
+     "end_time": "2026-06-15T22:23:47.767743",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.764743",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : desintriquer \"taille du modele\" vs \"raisonnement natif\"\n",
+    "\n",
+    "Le verdict Phase 5 confond \"r1 est plus gros/meilleur\" et \"r1 raisonne\". Desintrique : compare\n",
+    "le BoN sur r1 **mode raisonnement off** (si disponible) vs r1 raisonnement **on**, au meme\n",
+    "budget tokens. Le delta isole l'apport du test-time compute natif.\n",
+    "\n",
+    "# Indice : certains modeles exposent un parametre \"reasoning_effort\" (low/medium/high) ou un\n",
+    "# modele \"non-thinking\" jumeau. Compare pass@k a budget tokens egal entre effort=low et high."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1247e56d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:23:47.777448Z",
+     "iopub.status.busy": "2026-06-15T22:23:47.777270Z",
+     "iopub.status.idle": "2026-06-15T22:23:47.780898Z",
+     "shell.execute_reply": "2026-06-15T22:23:47.780198Z"
+    },
+    "papermill": {
+     "duration": 0.007846,
+     "end_time": "2026-06-15T22:23:47.780158",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.772312",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 - taille vs raisonnement : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def isoler_apport_raisonnement(model_high, model_low, enonce, attendu):\n",
+    "    \"\"\"Exercice 2 : compare single-shot raisonnement on vs off, a budget tokens compare.\"\"\"\n",
+    "    # TODO etudiant : appeler les deux variantes, retourner (succes_high, tok_high, succ_low, tok_low).\n",
+    "    return None\n",
+    "\n",
+    "print(f\"Exercice 2 - taille vs raisonnement : {'implemente' if False else 'a completer'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73ee58f2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005329,
+     "end_time": "2026-06-15T22:23:47.789275",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.783946",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (avance) : cout en dollars (OpenRouter)\n",
+    "\n",
+    "Refais la comparaison en **dollars** (pas tokens) : recupere le prix input/output/reasoning de\n",
+    "chaque modele (API OpenRouter `/models` ou tarifs publics) et calcule le cout $ reel de chaque\n",
+    "strategie. La frontiere tokens-vs-succes peut **inverser** en $ (si le modele a raisonnement est\n",
+    "beaucoup plus cher par token).\n",
+    "\n",
+    "# Indice : GET https://openrouter.ai/api/v1/models -> pricing.prompt/completion/completion_reasoning\n",
+    "# par modele ; calcule cout = tok_prompt*prompt + tok_completion*completion (+ reasoning*raisonnement)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b7eae56c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T22:23:47.798963Z",
+     "iopub.status.busy": "2026-06-15T22:23:47.798780Z",
+     "iopub.status.idle": "2026-06-15T22:23:47.801795Z",
+     "shell.execute_reply": "2026-06-15T22:23:47.801276Z"
+    },
+    "papermill": {
+     "duration": 0.00897,
+     "end_time": "2026-06-15T22:23:47.802254",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.793284",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 - cout en dollars : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def cout_dollars(model, tok_prompt, tok_completion, tok_reasoning=0):\n",
+    "    \"\"\"Exercice 3 : cout $ reel d'un appel via la tarification OpenRouter.\"\"\"\n",
+    "    # TODO etudiant : requeter /api/v1/models, extraire pricing, calculer le cout $.\n",
+    "    return None\n",
+    "\n",
+    "print(f\"Exercice 3 - cout en dollars : {'implemente' if False else 'a completer'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ad6cadc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00551,
+     "end_time": "2026-06-15T22:23:47.810766",
+     "exception": false,
+     "start_time": "2026-06-15T22:23:47.805256",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Conclusion et suite\n",
+    "\n",
+    "On a compare, **a cout normalise en tokens (raisonnement inclus)**, le **scaling hand-rolled**\n",
+    "(BoN pass@k sur un modele standard) au **raisonnement natif** (single-shot deepseek-r1), sur la\n",
+    "meme suite graduee. La figure superpose la courbe tokens-vs-pass du BoN et le point du modele a\n",
+    "raisononnement par bucket — la **question centrale de Snell** : a cout egal, qui gagne ?\n",
+    "\n",
+    "**Ce qui est demontre** : la **methodologie de comparaison cost-normalisee** — equitable\n",
+    "(meme suite, meme verificateur) et transferable (autres couples de modeles, autres suites).\n",
+    "\n",
+    "**Limites honnetes (G.2)** : n petit, une seule comparaison de modeles, suite simple, cout en\n",
+    "tokens (approximation du $). Le verdict depend du couple de modeles et du bucket ; il faut le\n",
+    "lire avec prudence et l'etendre (exercices 1-3) avant de generaliser.\n",
+    "\n",
+    "**Suite de l'epic #2926 :**\n",
+    "- **Phase 6** — plugin **Semantic Kernel** : integrer les moteurs (BoN/ToT/Reflexion/memory) comme\n",
+    "  **plugins SK** (pont series SemanticKernel), exposant le test-time scaling comme outil reutilisable.\n",
+    "\n",
+    "**References :** Snell et al. 2024 (test-time compute scaling) ; NB-12 (moteurs), NB-16 (pass@k\n",
+    "scaling), NB-13/14/15 (routeur, memoire, ToT-CSP) de cette serie."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 156.923657,
+   "end_time": "2026-06-15T22:23:48.196076",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb",
+   "output_path": "tmp/17_Native_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-15T22:21:11.272419",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Nouveau notebook **NB-17 — Modeles a raisonnement natif vs scaling hand-rolled**, **Phase 5** de l'epic **#2926** (ICR test-time scaling). Suit NB-12 (moteurs), NB-16 (pass@k scaling).

La question centrale de Snell et al. 2024 : **a cout egal (tokens, raisonnement inclus), un modele a raisonnement natif (deepseek-r1) bat-il le scaling hand-rolled (BoN sur un modele standard) ?**

### Contenu (22 cellules : 10 code, 12 markdown)
- **Baseline non-reasoning** : BoN pass@k sur llama-3.3-70b (0 reasoning token), **cout en tokens cumules**.
- **Raisonnement natif** : single-shot **deepseek-r1**, cout = prompt + completion + **reasoning tokens** (captures via `completion_tokens_details.reasoning_tokens`).
- Meme suite graduee + verificateur exact que NB-16 (comparaison **equitable**) + estimateur pass@k non-biasé.
- **Comparaison cost-normalisee** : courbe tokens-vs-pass du BoN + point du modele a raisonnement, par bucket (figure matplotlib inline).

## Preuves d'execution reelle (H.1 / pr-review-discipline D)

Execute end-to-end via **Papermill** (kernel python3 = conda base 3.13.12) :
- **10/10 cellules code**, `execution_count` 1-10, **0 erreur**, **1 figure matplotlib inline (PNG)**.
- **Vrais appels API** aux DEUX familles : llama-3.3-70b (baseline, n=6/probleme) + deepseek-r1 (single-shot).

**Verdict cost-normalise, honnete (G.2), reellement mesure :**

| bucket | r1 single-shot | BoN @ budget mesure | gagnant |
|--------|---------------|---------------------|---------|
| facile | 1.00 (300 tok) | 1.00 (220 tok) | BoN moins cher (egal succes) |
| moyen | 1.00 (571 tok) | 1.00 (331 tok) | BoN moins cher (egal succes) |
| **difficile** | **1.00 (728 tok)** | **0.48 (314 tok)** | **r1 (raisonnement)** |

**Interpretation honnete** :
- **facile/moyen** : les deux strategies saturent a 1.00, mais **BoN est moins cher en tokens** → sur les problemes faciles, le scaling hand-rolled est **plus compute-efficace** (le modele a raisonnement gaspille des tokens de raisonnement sur du facile).
- **difficile** : **r1 (1.00) >> BoN (0.48)** → le raisonnement natif resout les 2 problemes durs que le BoN n'arrive pas a craquer meme a k=6. **C'est le resultat de Snell** : la ou le scaling exterieur plafonne, le raisonnement natif peut ouvrir.
- **Nuance assume (G.2)** : les couts ne sont pas exactement apparies (BoN k≤6 plafonne a ~314 tok vs r1 a 728 tok ; une comparaison au meme cout necessiterait k plus grand = Exercice 1). De plus, r1 est un modele **plus fort** : l'apport est **confondu** entre "taille du modele" et "raisonnement natif" (Exercice 2 desintrique).

## Limites honnetes (G.2, section 5 du notebook)
- n petit (6), 2 problemes/bucket : bruit eleve ; Snell utilise des milliers d'evaluations.
- **Une seule paire de modeles** : le verdict depend du couple (exercice 1 = frontiere Pareto multi-modeles).
- **Suite simple** (arithmetique) : facile/moyen saturent ; le signal net est sur difficile.
- **Confusion taille-vs-raisonnement** non resolue (exercice 2).
- **Cout = tokens** (approximation du $, exercice 3 = vrai cout OpenRouter).
- Ce notebook demontre surtout la **methodologie** (cost-normalise tokens-incl-reasoning), transferable.

## Conformite
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`. 3 exercices en stubs (`# TODO etudiant`, `return None`).
- **C.2** : commite AVEC outputs reels (Papermill) + 1 figure PNG inline.
- **#2161** : `count_exercises.py` rapporte **3 exercices** (conforme).
- **Anti-regression** : nouveau notebook, ne touche aucun code de production.
- **Secrets** : aucune cle inline ; `.env` via `load_dotenv` (gitignore).
- **Catalogue** : nouveau notebook, non regenere (cron/bot).
- **Scope** : 1 fichier, 1 sujet (atomique, catalog-pr-hygiene HARD 3).

## Ponts pedagogiques
NB-12 (moteurs) / NB-16 (pass@k) -> **NB-17** (raisonnement natif vs scaling) ; suite Phase 6 (plugin Semantic Kernel).

## Scope de cette PR
**Phase 5 / 6** de #2926. Suite logique de #3094 (Phase 4). See #2926 (contribution partielle — l'epic reste ouverte).
