### PR TITLE
docs(genai): restore French diacritics in Texte README (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -21,51 +21,51 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 - **Production enterprise** : gestion de sessions, retry, batch processing
 - **Déploiement local** : vLLM, quantification, optimisation des coûts
 
-## Contenu detaille
+## Contenu détaillé
 
-### Tier 1 : Fondations (Debutant)
+### Tier 1 : Fondations (Débutant)
 
-| # | Notebook | Description | Duree |
+| # | Notebook | Description | Durée |
 |---|----------|-------------|-------|
-| 1 | `1_OpenAI_Intro.ipynb` | Introduction a l'API OpenAI, tokens, Chat Completions, Responses API | 45 min |
-| 2 | `2_PromptEngineering.ipynb` | Zero-shot, few-shot, Chain-of-Thought, modeles raisonnants | 50 min |
+| 1 | `1_OpenAI_Intro.ipynb` | Introduction à l'API OpenAI, tokens, Chat Completions, Responses API | 45 min |
+| 2 | `2_PromptEngineering.ipynb` | Zero-shot, few-shot, Chain-of-Thought, modèles raisonnants | 50 min |
 
-### Tier 2 : Sorties Structurees (Intermediaire)
+### Tier 2 : Sorties Structurées (Intermédiaire)
 
-| # | Notebook | Description | Duree |
+| # | Notebook | Description | Durée |
 |---|----------|-------------|-------|
-| 3 | `3_Structured_Outputs.ipynb` | JSON Schema, Pydantic, mode strict, extraction de donnees | 55 min |
-| 4 | `4_Function_Calling.ipynb` | Tools API, appels paralleles, boucle agentique | 60 min |
+| 3 | `3_Structured_Outputs.ipynb` | JSON Schema, Pydantic, mode strict, extraction de données | 55 min |
+| 4 | `4_Function_Calling.ipynb` | Tools API, appels parallèles, boucle agentique | 60 min |
 
-### Tier 3 : Augmentation (Intermediaire)
+### Tier 3 : Augmentation (Intermédiaire)
 
-| # | Notebook | Description | Duree |
+| # | Notebook | Description | Durée |
 |---|----------|-------------|-------|
 | 5 | `5_RAG_Modern.ipynb` | RAG, embeddings, chunking, Responses API multi-turn, citations | 65 min |
-| 6 | `6_PDF_Web_Search.ipynb` | Support PDF (base64/file_id), web_search integre | 50 min |
-| 7 | `7_Code_Interpreter.ipynb` | Code interpreter, analyse de donnees, generation de graphiques | 55 min |
+| 6 | `6_PDF_Web_Search.ipynb` | Support PDF (base64/file_id), web_search intégré | 50 min |
+| 7 | `7_Code_Interpreter.ipynb` | Code interpreter, analyse de données, génération de graphiques | 55 min |
 
-### Tier 4 : Fonctionnalites Avancees
+### Tier 4 : Fonctionnalités Avancées
 
-| # | Notebook | Description | Duree |
+| # | Notebook | Description | Durée |
 |---|----------|-------------|-------|
 | 8 | `8_Reasoning_Models.ipynb` | o4-mini, gpt-5-thinking, reasoning_effort, comparaisons | 60 min |
 | 9 | `9_Production_Patterns.ipynb` | Conversations API, background mode, retry, batch processing | 70 min |
 | 10 | `10_LocalLlama.ipynb` | vLLM, Qwen3.5-35B-A3B, ZwZ-8B, multi-endpoints, benchmarking | 60 min |
-| 11 | `11_Quantization.ipynb` | AWQ, GPTQ, llmcompressor, modeles vision, deploiement vLLM | 60 min |
+| 11 | `11_Quantization.ipynb` | AWQ, GPTQ, llmcompressor, modèles vision, déploiement vLLM | 60 min |
 | 12 | `12_Test_Time_Scaling.ipynb` | Best-of-N, Tree-of-Thoughts (BFS/DFS), Reflexion, routeur adaptatif (cf ICR) | 60 min |
 
-## Prerequis
+## Prérequis
 
 ### Configuration API
 1. Copier `.env.example` vers `.env`
-2. Ajouter votre cle API OpenAI : `OPENAI_API_KEY=sk-...`
+2. Ajouter votre clé API OpenAI : `OPENAI_API_KEY=sk-...`
 
 ### Pour les notebooks locaux (10)
 - Docker avec support GPU
-- Ollama ou vLLM installe
+- Ollama ou vLLM installé
 
-## Parcours suggere
+## Parcours suggéré
 
 ```text
 ┌─────────────────────────────────────────────────────────────────┐
@@ -85,8 +85,8 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 │                 │                                              │
 │                 └──────► 6_PDF_Web_Search                      │
 │                                                                 │
-│  10_LocalLlama (independant, prerequis: 1)                     │
-│        └──────► 11_Quantization (prerequis: 10)                │
+│  10_LocalLlama (indépendant, prérequis: 1)                     │
+│        └──────► 11_Quantization (prérequis: 10)                │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -95,14 +95,14 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 
 | API | Notebooks | Description |
 |-----|-----------|-------------|
-| **Chat Completions** | 1-4, 8 | API classique, toujours supportee |
-| **Responses API** | 1, 5, 9 | Nouvelle API avec persistence |
+| **Chat Completions** | 1-4, 8 | API classique, toujours supportée |
+| **Responses API** | 1, 5, 9 | Nouvelle API avec persistance |
 | **Embeddings** | 5 | text-embedding-3-large |
 | **Tools/Functions** | 4, 6, 7 | Function calling moderne |
 | **File Upload** | 6, 7 | Support PDF et fichiers |
-| **Reasoning** | 2, 8 | Modeles o4-mini, gpt-5-thinking |
+| **Reasoning** | 2, 8 | Modèles o4-mini, gpt-5-thinking |
 
-## Technologies et ecosysteme
+## Technologies et écosystème
 
 - **OpenAI API** : GPT-4o, GPT-4o-mini, o4-mini, gpt-5-thinking
 - **Python** : openai, pydantic, tiktoken, semantic-kernel
@@ -111,14 +111,14 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 
 ## Mode batch
 
-Tous les notebooks supportent un mode batch pour les tests automatises :
+Tous les notebooks supportent un mode batch pour les tests automatisés :
 
 ```bash
 # Dans .env
 BATCH_MODE=true
 ```
 
-Ce mode desactive les interactions utilisateur et utilise des exemples predefinis.
+Ce mode désactive les interactions utilisateur et utilise des exemples prédéfinis.
 
 ## Validation
 
@@ -126,31 +126,31 @@ Ce mode desactive les interactions utilisateur et utilise des exemples predefini
 # Valider la structure
 python scripts/notebook_tools/notebook_tools.py validate GenAI/Texte --quick
 
-# Executer tous les notebooks
+# Exécuter tous les notebooks
 python scripts/notebook_tools/notebook_tools.py execute GenAI/Texte --timeout 300
 ```
 
-## Recette : maitriser les LLMs pour piloter tout le generatif
+## Recette : maîtriser les LLMs pour piloter tout le génératif
 
-Le fil rouge de cette serie est la progression de l'interaction basique avec un LLM vers la maitrise complete en production. Voici comment les tiers s'articulent :
+Le fil rouge de cette série est la progression de l'interaction basique avec un LLM vers la maîtrise complète en production. Voici comment les tiers s'articulent :
 
-1. **Tier 1** (fondations) : [1_OpenAI_Intro](1_OpenAI_Intro.ipynb) couvre l'API OpenAI et les tokens. [2_PromptEngineering](2_PromptEngineering.ipynb) explore les techniques de prompting (zero-shot, few-shot, chain-of-thought). A la fin, vous savez interagir efficacement avec un LLM.
+1. **Tier 1** (fondations) : [1_OpenAI_Intro](1_OpenAI_Intro.ipynb) couvre l'API OpenAI et les tokens. [2_PromptEngineering](2_PromptEngineering.ipynb) explore les techniques de prompting (zero-shot, few-shot, chain-of-thought). À la fin, vous savez interagir efficacement avec un LLM.
 
-2. **Tier 2** (sorties structurees) : [3_Structured_Outputs](3_Structured_Outputs.ipynb) maitrise les formats JSON et Pydantic. [4_Function_Calling](4_Function_Calling.ipynb) connecte le LLM a des outils externes. Ces deux notebooks sont essentiels pour tout systeme qui pilote d'autres modeles generatifs (image, audio, video).
+2. **Tier 2** (sorties structurées) : [3_Structured_Outputs](3_Structured_Outputs.ipynb) maîtrise les formats JSON et Pydantic. [4_Function_Calling](4_Function_Calling.ipynb) connecte le LLM à des outils externes. Ces deux notebooks sont essentiels pour tout système qui pilote d'autres modèles génératifs (image, audio, video).
 
-3. **Tier 3** (augmentation) : [5_RAG_Modern](5_RAG_Modern.ipynb) et [6_PDF_Web_Search](6_PDF_Web_Search.ipynb) enrichissent le LLM avec des sources externes. [7_Code_Interpreter](7_Code_Interpreter.ipynb) lui donne la capacite d'executer du code.
+3. **Tier 3** (augmentation) : [5_RAG_Modern](5_RAG_Modern.ipynb) et [6_PDF_Web_Search](6_PDF_Web_Search.ipynb) enrichissent le LLM avec des sources externes. [7_Code_Interpreter](7_Code_Interpreter.ipynb) lui donne la capacité d'exécuter du code.
 
-4. **Tier 4** (production et local) : [8_Reasoning_Models](8_Reasoning_Models.ipynb) exploite les modeles raisonnants. [9_Production_Patterns](9_Production_Patterns.ipynb) couvre les patterns enterprise. [10_LocalLlama](10_LocalLlama.ipynb) et [11_Quantization](11_Quantization.ipynb) deployent en local avec vLLM.
+4. **Tier 4** (production et local) : [8_Reasoning_Models](8_Reasoning_Models.ipynb) exploite les modèles raisonnants. [9_Production_Patterns](9_Production_Patterns.ipynb) couvre les patterns enterprise. [10_LocalLlama](10_LocalLlama.ipynb) et [11_Quantization](11_Quantization.ipynb) déploient en local avec vLLM.
 
 ## Cross-series Bridges
 
-| Serie | Lien | Connection |
+| Série | Lien | Connection |
 |-------|------|------------|
-| [Image](../Image/README.md) | Prompts structurés | Les textes prompts guident la generation d'images (DALL-E, GPT-5 Image) — notebooks [1](1_OpenAI_Intro.ipynb) et [4](4_Function_Calling.ipynb) |
+| [Image](../Image/README.md) | Prompts structurés | Les textes prompts guident la génération d'images (DALL-E, GPT-5 Image) — notebooks [1](1_OpenAI_Intro.ipynb) et [4](4_Function_Calling.ipynb) |
 | [Audio](../Audio/README.md) | STT/TTS + RAG podcast | Whisper STT et TTS APIs sont les bases du pipeline podcast (Audio/03-2) ; le RAG (notebook [5](5_RAG_Modern.ipynb)) alimente le contenu |
-| [Video](../Video/README.md) | GPT-5 Video + Sora prompts | La comprehension video (Video/01-2) utilise les memes APIs texte ; Sora (Video/04-3) depend de prompts structures |
+| [Video](../Video/README.md) | GPT-5 Video + Sora prompts | La compréhension vidéo (Video/01-2) utilise les mêmes APIs texte ; Sora (Video/04-3) dépend de prompts structurés |
 | [SemanticKernel](../SemanticKernel/README.md) | Orchestration agentique | Semantic Kernel orchestre les LLMs via plugins et agents — prolonge les patterns de function calling (notebook [4](4_Function_Calling.ipynb)) |
-| [SymbolicAI](../../SymbolicAI/README.md) | Reasoning formel | Les modeles raisonnants (notebook [8](8_Reasoning_Models.ipynb)) complementent le reasoning formel (Z3, Tweety, Lean) |
+| [SymbolicAI](../../SymbolicAI/README.md) | Reasoning formel | Les modèles raisonnants (notebook [8](8_Reasoning_Models.ipynb)) complètent le reasoning formel (Z3, Tweety, Lean) |
 
 ## FAQ
 
@@ -158,59 +158,59 @@ Le fil rouge de cette serie est la progression de l'interaction basique avec un 
 
 Les notebooks couvrent les deux APIs OpenAI :
 
-- **Chat Completions** (notebooks 1-4, 8) : l'API classique `client.chat.completions.create()`. Toujours supportee, simple d'usage, stateless. Ideale pour les requetes unitaires et les prototypes.
-- **Responses API** (notebooks 1, 5, 9) : la nouvelle API `client.responses.create()`. Ajoute la persistence automatique des conversations, le support natif du RAG multi-turn, et les citations. Recommandee pour les workflows multi-etapes.
+- **Chat Completions** (notebooks 1-4, 8) : l'API classique `client.chat.completions.create()`. Toujours supportée, simple d'usage, stateless. Idéale pour les requêtes unitaires et les prototypes.
+- **Responses API** (notebooks 1, 5, 9) : la nouvelle API `client.responses.create()`. Ajoute la persistance automatique des conversations, le support natif du RAG multi-turn, et les citations. Recommandée pour les workflows multi-étapes.
 
-En pratique, commencez avec Chat Completions (notebook 1), puis migrez vers Responses API quand vous avez besoin de persistence ou de RAG (notebook 5).
+En pratique, commencez avec Chat Completions (notebook 1), puis migrez vers Responses API quand vous avez besoin de persistance ou de RAG (notebook 5).
 
-### Structured Outputs echoue en mode strict
+### Structured Outputs échoue en mode strict
 
-Le mode strict (`strict=True`) impose des contraintes sur les schemas JSON :
+Le mode strict (`strict=True`) impose des contraintes sur les schémas JSON :
 
-- **Tous les champs** doivent etre `required` (pas de champ optionnel `Optional`).
+- **Tous les champs** doivent être `required` (pas de champ optionnel `Optional`).
 - **Pas de types union** complexes (`str | int | None`).
 - **Pas de profondeur excessive** (> 5 niveaux d'imbrication).
-- Le schema doit etre **deterministe** : chaque champ a exactement un type possible.
+- Le schéma doit être **déterministe** : chaque champ a exactement un type possible.
 
-Si le mode strict echoue, retirer `strict=True` et utiliser le mode par defaut (moins strict, mais le schema est quand meme respecte dans ~95% des cas). Le notebook [3_Structured_Outputs](3_Structured_Outputs.ipynb) montre les deux approches.
+Si le mode strict échoue, retirer `strict=True` et utiliser le mode par défaut (moins strict, mais le schéma est quand même respecté dans ~95% des cas). Le notebook [3_Structured_Outputs](3_Structured_Outputs.ipynb) montre les deux approches.
 
-### Function calling : le modele appelle un outil inexistant
+### Function calling : le modèle appelle un outil inexistant
 
-Ce phenomene (hallucination d'outils) arrive quand :
+Ce phénomène (hallucination d'outils) arrive quand :
 
-- La description de l'outil est ambigue ou incomplete.
-- Le prompt utilisateur est vague et le modele "invente" un outil pour repondre.
-- Trop d'outils sont declares simultanement (> 10).
+- La description de l'outil est ambiguë ou incomplète.
+- Le prompt utilisateur est vague et le modèle "invente" un outil pour répondre.
+- Trop d'outils sont déclarés simultanément (> 10).
 
-Mitigation : fournir des descriptions precises pour chaque outil, valider les arguments cote client avant execution, et limiter le nombre d'outils actifs. Le notebook [4_Function_Calling](4_Function_Calling.ipynb) montre le pattern de validation.
+Mitigation : fournir des descriptions précises pour chaque outil, valider les arguments côté client avant exécution, et limiter le nombre d'outils actifs. Le notebook [4_Function_Calling](4_Function_Calling.ipynb) montre le pattern de validation.
 
-### RAG : les reponses sont hors-sujet ou inventees
+### RAG : les réponses sont hors-sujet ou inventées
 
-Les causes les plus frequentes :
+Les causes les plus fréquentes :
 
-- **Chunking trop grand** : les segments depassent 512 tokens, diluant le contenu pertinent. Utiliser des chunks de 200-400 tokens avec chevauchement de 50 tokens.
-- **Embedding inadapte** : `text-embedding-3-small` est plus rapide mais moins precis que `text-embedding-3-large` pour le RAG technique.
-- **Pas de citation** : sans verification, le modele peut halluciner des sources. La Responses API (notebook 5) genere automatiquement des citations.
-- **Top-k trop eleve** : injecter trop de context noie le signal. Commencer avec `top_k=3` et ajuster.
+- **Chunking trop grand** : les segments dépassent 512 tokens, diluant le contenu pertinent. Utiliser des chunks de 200-400 tokens avec chevauchement de 50 tokens.
+- **Embedding inadapté** : `text-embedding-3-small` est plus rapide mais moins précis que `text-embedding-3-large` pour le RAG technique.
+- **Pas de citation** : sans vérification, le modèle peut halluciner des sources. La Responses API (notebook 5) génère automatiquement des citations.
+- **Top-k trop élevé** : injecter trop de contexte noie le signal. Commencer avec `top_k=3` et ajuster.
 
-### Modeles raisonnants (o4-mini, gpt-5-thinking) : tokens et cout
+### Modèles raisonnants (o4-mini, gpt-5-thinking) : tokens et coût
 
-Les modeles raisonnants consomment des **reasoning tokens** (non visibles) en plus des tokens d'entree/sortie. Implications :
+Les modèles raisonnants consomment des **reasoning tokens** (non visibles) en plus des tokens d'entrée/sortie. Implications :
 
-- **Cout** : le cout reel peut etre 3-10x superieur a un modele non-raisonnant pour le meme prompt. Utiliser `reasoning_effort="low"` pour les taches simples.
-- **Latence** : les modeles raisonnants prennent plus de temps (10-60s vs 2-5s). Pas adaptes au temps reel.
-- **Usage** : excellents pour les taches de planification, l'analyse multi-etapes, et la decomposition de problemes complexes. Inutiles pour le simple formatage ou l'extraction.
+- **Coût** : le coût réel peut être 3-10x supérieur à un modèle non-raisonnant pour le même prompt. Utiliser `reasoning_effort="low"` pour les tâches simples.
+- **Latence** : les modèles raisonnants prennent plus de temps (10-60s vs 2-5s). Pas adaptés au temps réel.
+- **Usage** : excellents pour les tâches de planification, l'analyse multi-étapes, et la décomposition de problèmes complexes. Inutiles pour le simple formatage ou l'extraction.
 
-Le notebook [8_Reasoning_Models](8_Reasoning_Models.ipynb) compare les couts et la qualite entre modeles raisonnants et classiques.
+Le notebook [8_Reasoning_Models](8_Reasoning_Models.ipynb) compare les coûts et la qualité entre modèles raisonnants et classiques.
 
 ### LLM local (vLLM) : erreur CUDA ou OOM
 
-Les notebooks 10-11 utilisent vLLM pour servir des modeles locaux. Problemes courants :
+Les notebooks 10-11 utilisent vLLM pour servir des modèles locaux. Problèmes courants :
 
-- **VRAM insuffisante** : Qwen3.5-35B-A3B en FP16 necessite ~70 GB. Utiliser la quantification AWQ (notebook 11) pour reduire a ~12 GB.
-- **Version CUDA** : vLLM requiert CUDA 12.1+. Verifier avec `nvidia-smi` et `nvcc --version`.
-- **Port deja occupe** : vLLM utilise le port 8000 par defaut. Utiliser `--port 8001` si besoin.
-- **Timeout au premier appel** : le chargement du modele prend 30-120s au demarrage. Les appels suivants sont instantanes.
+- **VRAM insuffisante** : Qwen3.5-35B-A3B en FP16 nécessite ~70 GB. Utiliser la quantification AWQ (notebook 11) pour réduire à ~12 GB.
+- **Version CUDA** : vLLM requiert CUDA 12.1+. Vérifier avec `nvidia-smi` et `nvcc --version`.
+- **Port déjà occupé** : vLLM utilise le port 8000 par défaut. Utiliser `--port 8001` si besoin.
+- **Timeout au premier appel** : le chargement du modèle prend 30-120s au démarrage. Les appels suivants sont instantanés.
 
 ## Ressources
 


### PR DESCRIPTION
## Summary

Content-based restoration of French diacritics across the **Texte series README**, systematically unaccented — same genuine gap as root/Video/Audio/Image (#3082 / #3086 / #3093). Markdown-only.

Follow-up to ai-01 dispatch (passe 2, cycle :23): *« Trickle restant = Texte / FineTuning / SemanticKernel (même méthode content-based + review mot-à-mot) »*. Confirmed genuine gap (GenAI family), not a false positive (~96% FP warning = Python family).

## Method — word-by-word, NOT blind find-replace

Accents restored on French prose only. Preserved byte-identical:
- **CATALOG-STATUS marker** (lines 3-8) — verified unchanged
- All **19 `.ipynb` link paths** (identical before/after)
- Bash/text code blocks
- ASCII parcours diagram — visual width of accented words (`indépendant`, `prérequis`) unchanged → box alignment intact (19 right-borders preserved)
- Every English/technical term: LLM, RAG, JSON, Pydantic, vLLM, OpenAI, GPT-4o, o4-mini, gpt-5-thinking, Chat Completions, Responses API, Embeddings, function calling, code interpreter, AWQ, GPTQ, llmcompressor, Qwen, ZwZ, Pinecone, Qdrant, Chroma, tiktoken, semantic-kernel, zero-shot, few-shot, chain-of-thought, Best-of-N, Tree-of-Thoughts, BFS/DFS, Reflexion, reasoning tokens, batch, ICR
- Anglicism fix: `persistence` → French `persistance`

## Verification (G.1)

- `git diff --stat`: 1 file, **70 ins / 70 del** (line-for-line, net 0 lines)
- Line count unchanged: 220 == 220
- `grep .ipynb` count: **19 == 19** (no link touched)
- CATALOG-STATUS marker: **byte-identical** (diff confirmed)
- ASCII box: 19 right-borders intact (no alignment breakage)
- Spot-check: **0** English terms accidentally accented; remaining matches in unaccented-word grep are correct French (`persistance`, `courants` — false positives of an over-broad regex)

See #2876 (partial — FineTuning / SemanticKernel remain).

