### PR TITLE
docs(grothendieck): sync README structure table to 23-module complete state (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -18,57 +18,50 @@ The goal is to give learners a curated entry point into:
 
 ## Structure
 
-### Phase 1 (Tour) — `0 sorry`
+The formalization spans **23 modules (Parts 1-23, 3182 lines, 0 sorry)**, imported
+in order by the umbrella `Grothendieck.lean`. Each module self-numbers via its header
+(`Grothendieck tribute — Part N`).
 
-| File | Content | Lines |
-|------|---------|-------|
-| `Grothendieck/CategoryAndSites.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | ~110 |
-| `Grothendieck/SchemesTour.lean` | Scheme type, Spec functor, Γ, homeoOfIso, fully-faithful | ~70 |
-| `Grothendieck/ZariskiSite.lean` | Zariski pretopology, zariskiTopology_eq bridge theorem, subcanonical | ~60 |
-| `Grothendieck/MathlibMap.lean` | `#check` index of all Grothendieck-related Mathlib definitions | ~70 |
-| `Grothendieck/Calibration.lean` | 4 micro-proof targets for prover harness (Epic #1453) | ~60 |
+| Part | File | Content | Lines |
+|------|------|---------|-------|
+| 1 | `Grothendieck/CategoryAndSites.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 106 |
+| 2 | `Grothendieck/SchemesTour.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 79 |
+| 3 | `Grothendieck/ZariskiSite.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 84 |
+| 4 | `Grothendieck/MathlibMap.lean` | `#check` index of Grothendieck-related Mathlib definitions | 90 |
+| 5 | `Grothendieck/Calibration.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 80 |
+| 6 | `Grothendieck/SieveLattice.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
+| 7 | `Grothendieck/SheafBasics.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 128 |
+| 8 | `Grothendieck/SieveOps.lean` | Topology ordering, covering closure, sieve composition | 124 |
+| 9 | `Grothendieck/CoverageGen.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 148 |
+| 10 | `Grothendieck/CanonicalProps.lean` | Canonical topology, subcanonicity, representable sheaves | 133 |
+| 11 | `Grothendieck/SieveGenerate.lean` | Sieve generation identities | 128 |
+| 12 | `Grothendieck/DenseTopology.lean` | The dense topology | 131 |
+| 13 | `Grothendieck/Sheafification.lean` | Sheafification (the associated sheaf functor) | 175 |
+| 14 | `Grothendieck/LeftExact.lean` | Left exactness of sheafification | 133 |
+| 15 | `Grothendieck/SitePoints.lean` | Points of a site (fiber functors) | 220 |
+| 16 | `Grothendieck/Subcanonical.lean` | Subcanonical Grothendieck topologies | 88 |
+| 17 | `Grothendieck/SheafHom.lean` | Internal hom of sheaves | 140 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
+| 19 | `Grothendieck/Conservative.lean` | Conservative families of points | 226 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | Sheaf cohomology (Ext-based) | 214 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | Mayer-Vietoris squares | 195 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | Mayer-Vietoris long exact sequence | 164 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | Čech cohomology | 123 |
 
-### Phase 2 (Extension) — `0 sorry` (Issue #2159, Epic #2162)
-
-| File | Content | Lines |
-|------|---------|-------|
-| `Grothendieck/SieveLattice.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback` (contravariant composition), `pullback_bot`, `pullback_monotone` | ~90 |
-
-### Phase 3 (Sheaf Basics) — `0 sorry` (Issue #2159, Epic #2162)
-
-| File | Content | Lines |
-|------|---------|-------|
-| `Grothendieck/SheafBasics.lean` | Sheaf/separated basics, subcanonical topologies, sheaf transfer along J₁ ≤ J₂ | ~128 |
-
-### Phase 4 (Topology Ordering) — `0 sorry` (Issue #2159, PR #2675)
-
-| File | Content | Lines |
-|------|---------|-------|
-| `Grothendieck/SieveOps.lean` | Topology ordering, covering closure, sieve composition properties | ~124 |
-
-### Phase 5 (Coverage Generation) — `0 sorry` (Issue #2159, PR #2675)
-
-| File | Content | Lines |
-|------|---------|-------|
-| `Grothendieck/CoverageGen.lean` | Coverage-to-topology, sheaf characterization for generated topology, sup of coverages | ~148 |
-
-### Phase 6 (Canonical Topology) — `0 sorry` (Issue #2159, PR #2675)
-
-| File | Content | Lines |
-|------|---------|-------|
-| `Grothendieck/CanonicalProps.lean` | Canonical topology, subcanonicity, representable sheaves, finest topology | ~134 |
+The extension (Parts 6-23) was developed under Issue #2159 / Epic #1646 and is
+**complete**: all 23 modules merged, 0 `sorry`, 0 axiom added.
 
 ## Build
 
 ```bash
 # From this directory (WSL required)
 lake build Grothendieck
-# Builds all 10 modules (~912 jobs, ~2 min cached)
+# Builds all 23 modules (3182 lines)
 ```
 
 ## Sorry count
 
-**0 production sorry** — all proofs are complete at creation.
+**0 sorry, 0 axiom** — all 23 modules are complete at creation (Parts 1-23 merged).
 
 ## Toolchain
 


### PR DESCRIPTION
## What

The `grothendieck_lean` README documented only **Phases 1-6 ("10 modules")**, but the formalization is **complete at 23 modules** (Parts 1-23, 3182 lines, 0 sorry). This syncs the structure table to the real state.

Real defect fixed by this PR: the README **undercounted (10 vs 23)**, **omitted Parts 11-23 entirely** (13 modules), carried an **unverifiable `~912 jobs` build claim**, and grouped modules into stale "Phase" batches that did not match the modules own `Part N` header self-numbering.

## Changes (docs-only — `README.md`, 1 file)

- Restructure 6 stale "Phase" sub-tables into **one Part 1-23 table**, ordered to match the umbrella `Grothendieck.lean` import order + each module header `Grothendieck tribute — Part N`.
- Add the **13 missing modules** (Parts 11-23): SieveGenerate, DenseTopology, Sheafification, LeftExact, SitePoints, Subcanonical, SheafHom, ConstantSheaf, Conservative, SheafCohomology/Basic, MayerVietorisSquare, SheafCohomology/MayerVietoris, SheafCohomology/Cech.
- Replace approximate line counts (`~110`, `~70`...) with **exact** ones.
- Build block: `Builds all 10 modules (~912 jobs, ~2 min cached)` → `Builds all 23 modules (3182 lines)` (the 912-job figure was unverifiable without a build; replaced with a `wc -l`-measured line count).
- Sorry count: `0 sorry, 0 axiom — Parts 1-23 merged`.

## Verification (G.1, against real files)

| Claim | Check |
|-------|-------|
| 23 modules | `ls Grothendieck/*.lean` (20) + `Grothendieck/SheafCohomology/*.lean` (3) = 23 |
| 3182 lines | `sum(wc -l)` over all 23 module files = **3182** |
| 0 sorry | `grep -rcE "^\s*sorry\b"` over all `.lean` = **0** (clean) |
| Toolchain | `cat lean-toolchain` = `leanprover/lean4:v4.30.0-rc2` (README was already correct, unchanged) |
| Part ordering | umbrella `Grothendieck.lean` imports all 23 in Part 1-23 order |

## Scope

- **Docs-only** (`README.md`). No `.lean` change → **no `lake build` required** for this PR (lean-merge-discipline §1 applies to `*.lean` PRs only).
- No catalogue touched (`catalog-guard.yml` not triggered).
- Base rebased onto fresh `origin/main` (20bbede72) before push.

Contributes to #2651 Partie 2 (sous-READMEs des séries au plus près du contenu réel). Grothendieck epic context: #2159 (Parts 1-23 complete).

`See #2651`, `See #2159` (partial — neither epic is closed by this single README).