### PR TITLE
feat(genai-texte): NB-18 Semantic Kernel plugins for test-time scaling (See #2926, Phase 6 / final)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
@@ -1,0 +1,908 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f1fed449",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003661,
+     "end_time": "2026-06-15T23:25:21.689880",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:21.686219",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 18. Plugins Semantic Kernel pour le test-time scaling\n",
+    "\n",
+    "**Phase 6 (finale) de l'epic #2926** — suite de **NB-12** (moteurs) a **NB-17** (raisonnement natif).\n",
+    "Ce notebook **clot #2926** en exposant les moteurs de test-time scaling (BoN, Reflexion, routeur)\n",
+    "comme des **plugins [Semantic Kernel](https://github.com/microsoft/semantic-kernel)** (SK), faisant\n",
+    "le **pont avec la serie SemanticKernel** du depot.\n",
+    "\n",
+    "## Pourquoi des plugins ?\n",
+    "\n",
+    "Jusqu'ici (NB-12 a NB-17), les moteurs etaient des **fonctions Python** appelees a la main. Les\n",
+    "exposer en **plugins SK** les rend :\n",
+    "- **decouvrables** (le kernel connait leur schema : nom, description, parametres types),\n",
+    "- **composables** (un plugin peut en invoquer un autre via le kernel),\n",
+    "- **invocables par le LLM** (auto-function-calling : le modele choisit l'outil),\n",
+    "- **interoperables** avec le reste de l'ecosysteme SK (agents, process framework, MCP — serie\n",
+    "  SemanticKernel NB-03/06/08).\n",
+    "\n",
+    "> Ide centrale : le **Kernel** est un **hub de composition**. Les moteurs de test-time scaling\n",
+    "> deviennent des **outils** que le kernel peut orchestrer — exactement la couche d'integration\n",
+    "> que SK apporte au-dessus des appels API bruts.\n",
+    "\n",
+    "## Plan\n",
+    "1. Setup : Kernel + service SK (OpenAI/OpenRouter).\n",
+    "2. Plugin **BoN** (`best_of_n`).\n",
+    "3. Plugin **Reflexion** (`reflexion` avec verificateur).\n",
+    "4. Plugin **Routeur** (compose : invoque BoN ou Reflexion selon la strategie).\n",
+    "5. Composition via le kernel + pont auto-function-calling (exercice) vers la serie SemanticKernel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b94a092",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002,
+     "end_time": "2026-06-15T23:25:21.694885",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:21.692885",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 0. Setup — Kernel Semantic Kernel + service OpenRouter\n",
+    "\n",
+    "Semantic Kernel (Python, v1.x) se connecte a OpenAI. On le branche sur **OpenRouter** (comme\n",
+    "NB-12 a NB-17) via un client `AsyncOpenAI` passe au connecteur `OpenAIChatCompletion`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "187fa0df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:21.703282Z",
+     "iopub.status.busy": "2026-06-15T23:25:21.702986Z",
+     "iopub.status.idle": "2026-06-15T23:25:26.212482Z",
+     "shell.execute_reply": "2026-06-15T23:25:26.211664Z"
+    },
+    "papermill": {
+     "duration": 4.514673,
+     "end_time": "2026-06-15T23:25:26.213133",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:21.698460",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".env charge depuis : D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n",
+      "semantic-kernel 1.43.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -q semantic-kernel python-dotenv\n",
+    "\n",
+    "import os, re, asyncio\n",
+    "from pathlib import Path\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import AsyncOpenAI\n",
+    "import semantic_kernel as sk\n",
+    "from semantic_kernel import Kernel\n",
+    "from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion, OpenAIPromptExecutionSettings\n",
+    "from semantic_kernel.contents import ChatHistory\n",
+    "from semantic_kernel.functions import kernel_function, KernelArguments\n",
+    "\n",
+    "_env_path = None\n",
+    "_current = Path.cwd()\n",
+    "for _i in range(10):\n",
+    "    if (_current / \".env\").exists():\n",
+    "        _env_path = _current / \".env\"; break\n",
+    "    if _current.name in (\"GenAI\", \"MyIA.AI.Notebooks\"):\n",
+    "        break\n",
+    "    _current = _current.parent\n",
+    "if _env_path is None:\n",
+    "    for _cand in (Path.cwd() / \"MyIA.AI.Notebooks\" / \"GenAI\" / \".env\",\n",
+    "                  Path.cwd() / \"GenAI\" / \".env\"):\n",
+    "        if _cand.exists():\n",
+    "            _env_path = _cand; break\n",
+    "if _env_path is not None:\n",
+    "    load_dotenv(_env_path); print(f\".env charge depuis : {_env_path}\")\n",
+    "\n",
+    "print(f\"semantic-kernel {sk.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "af4c5201",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:26.221357Z",
+     "iopub.status.busy": "2026-06-15T23:25:26.221061Z",
+     "iopub.status.idle": "2026-06-15T23:25:29.519933Z",
+     "shell.execute_reply": "2026-06-15T23:25:29.519294Z"
+    },
+    "papermill": {
+     "duration": 3.304092,
+     "end_time": "2026-06-15T23:25:29.520228",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:26.216136",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ping SK->OpenRouter : 'OK'\n"
+     ]
+    }
+   ],
+   "source": [
+    "FAST_MODEL = os.getenv(\"OPENAI_MODEL_FAST\", \"meta-llama/llama-3.3-70b-instruct\")\n",
+    "\n",
+    "def make_kernel():\n",
+    "    \"\"\"Construit un Kernel SK branche sur OpenRouter (AsyncOpenAI custom).\"\"\"\n",
+    "    aoai = AsyncOpenAI(api_key=os.getenv(\"OPENROUTER_API_KEY\"),\n",
+    "                       base_url=os.getenv(\"OPENROUTER_BASE_URL\", \"https://openrouter.ai/api/v1\"))\n",
+    "    kernel = Kernel()\n",
+    "    kernel.add_service(OpenAIChatCompletion(ai_model_id=FAST_MODEL, async_client=aoai,\n",
+    "                                            service_id=\"or\"))\n",
+    "    return kernel\n",
+    "\n",
+    "async def llm(kernel, prompt, temperature=0.7, max_tokens=80):\n",
+    "    \"\"\"Helper : un appel au service SK (cache la ceremony ChatHistory).\"\"\"\n",
+    "    svc = kernel.get_service(\"or\")\n",
+    "    ch = ChatHistory(); ch.add_user_message(prompt)\n",
+    "    settings = OpenAIPromptExecutionSettings(max_tokens=max_tokens, temperature=temperature)\n",
+    "    r = await svc.get_chat_message_contents(chat_history=ch, settings=settings)\n",
+    "    return str(r[0])\n",
+    "\n",
+    "kernel = make_kernel()\n",
+    "_ping = await llm(kernel, \"Reponds uniquement par : OK\", temperature=0.0, max_tokens=10)\n",
+    "print(\"Ping SK->OpenRouter :\", repr(_ping[:30]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04578c91",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003795,
+     "end_time": "2026-06-15T23:25:29.528025",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:29.524230",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le modele plugin de Semantic Kernel\n",
+    "\n",
+    "Un **plugin** SK = une classe Python dont les methodes sont decorees par `@kernel_function`.\n",
+    "SK extrait le **schema** (nom, description, parametres + types) depuis la signature et la\n",
+    "docstring → le kernel sait les **decouvrir** et les **invoquer**. Les arguments passent par\n",
+    "`KernelArguments(**params)`.\n",
+    "\n",
+    "> Pont vers la serie SemanticKernel : voir `MyIA.AI.Notebooks/GenAI/SemanticKernel/01-SemanticKernel-Intro.ipynb`\n",
+    "> (plugins de base) et `03-SemanticKernel-Agents.ipynb` (agents qui orchestrent des plugins).\n",
+    "\n",
+    "On definit maintenant un **verificateur** reutilisable (extraction d'entier, herite de NB-16/17),\n",
+    "puis nos trois plugins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6dd61be5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:29.536627Z",
+     "iopub.status.busy": "2026-06-15T23:25:29.536402Z",
+     "iopub.status.idle": "2026-06-15T23:25:29.540969Z",
+     "shell.execute_reply": "2026-06-15T23:25:29.539901Z"
+    },
+    "papermill": {
+     "duration": 0.009752,
+     "end_time": "2026-06-15T23:25:29.541777",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:29.532025",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Demo : Un train part avec 45 passagers. 12 montent au suivant, 7 descendent. Combien reste-t-il de passagers ? Reponds uniquement par le nombre. | attendu : 50\n"
+     ]
+    }
+   ],
+   "source": [
+    "def extraire_nombre(texte):\n",
+    "    m = re.findall(r'-?\\d+', texte or \"\")\n",
+    "    return int(m[0]) if m else None\n",
+    "\n",
+    "# Probleme de demo (reponse entiere verifiable) : sert aux demos BoN + Reflexion + routeur.\n",
+    "# On choisit un probleme \"moyen\" que le modele resout fiablement, pour demontrer le MECANISME\n",
+    "# plugin/composition SK (le but de ce notebook) — pas la robustesse du modele (cf NB-16/17).\n",
+    "DEMO = (\"Un train part avec 45 passagers. 12 montent au suivant, 7 descendent. \"\n",
+    "        \"Combien reste-t-il de passagers ? Reponds uniquement par le nombre.\")\n",
+    "DEMO_REPONSE = 50\n",
+    "print(\"Demo :\", DEMO, \"| attendu :\", DEMO_REPONSE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3ed4a20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002999,
+     "end_time": "2026-06-15T23:25:29.550762",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:29.547763",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Plugin BoN — `best_of_n`\n",
+    "\n",
+    "Le moteur **Best-of-N** (NB-12/NB-16) en plugin : genere `n` echantillons, renvoie la liste des\n",
+    "reponses (l'appeleur peut ensuite les verifier / voter). Le plugin **depend du kernel** (pour le\n",
+    "service) — passe au constructeur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e5c46664",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:29.559055Z",
+     "iopub.status.busy": "2026-06-15T23:25:29.558736Z",
+     "iopub.status.idle": "2026-06-15T23:25:29.564574Z",
+     "shell.execute_reply": "2026-06-15T23:25:29.563502Z"
+    },
+    "papermill": {
+     "duration": 0.010699,
+     "end_time": "2026-06-15T23:25:29.564463",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:29.553764",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plugin 'bon' enregistre : fonction best_of_n(prompt: str, n: int = 3).\n"
+     ]
+    }
+   ],
+   "source": [
+    "class BoNPlugin:\n",
+    "    \"\"\"Plugin SK : Best-of-N sampling (test-time scaling parallel).\"\"\"\n",
+    "    def __init__(self, kernel): self._k = kernel\n",
+    "\n",
+    "    @kernel_function(name=\"best_of_n\", description=\"Genere n reponses independantes a un prompt.\")\n",
+    "    async def best_of_n(self, prompt: str, n: int = 3) -> str:\n",
+    "        reps = []\n",
+    "        for _ in range(n):\n",
+    "            reps.append((await llm(self._k, prompt, temperature=0.8)).strip())\n",
+    "        return \" || \".join(reps)\n",
+    "\n",
+    "kernel.add_plugin(BoNPlugin(kernel), plugin_name=\"bon\")\n",
+    "print(\"Plugin 'bon' enregistre : fonction best_of_n(prompt: str, n: int = 3).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fb2b0918",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:29.573539Z",
+     "iopub.status.busy": "2026-06-15T23:25:29.573271Z",
+     "iopub.status.idle": "2026-06-15T23:25:31.015138Z",
+     "shell.execute_reply": "2026-06-15T23:25:31.014514Z"
+    },
+    "papermill": {
+     "duration": 1.447016,
+     "end_time": "2026-06-15T23:25:31.015481",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:29.568465",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BoN (n=4) reponses : 50 || 50 || 50 || 50\n",
+      "Correctes (== 50) : ['50', '50', '50', '50']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Demo : invoque best_of_n via le kernel (pattern plug['fn'].invoke(kernel, args)).\n",
+    "_plug_bon = kernel.plugins[\"bon\"]\n",
+    "_res_bon = await _plug_bon[\"best_of_n\"].invoke(kernel, KernelArguments(prompt=DEMO, n=4))\n",
+    "print(\"BoN (n=4) reponses :\", _res_bon)\n",
+    "print(f\"Correctes (== {DEMO_REPONSE}) :\", [r for r in str(_res_bon).split(' || ') if extraire_nombre(r) == DEMO_REPONSE])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4345ed55",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003006,
+     "end_time": "2026-06-15T23:25:31.022488",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:31.019482",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Plugin Reflexion — `reflexion` (avec verificateur)\n",
+    "\n",
+    "Le moteur **Reflexion** (NB-12/NB-14) en plugin : K tours, verifie la reponse, renvoie le\n",
+    "diagnostic a l'LLM si rate. On injecte un **verificateur** (fonction `reponse -> bool`) au\n",
+    "constructeur — c'est le **pattern d'injection de dependance** de SK (le plugin ne sait pas\n",
+    "verifier, on lui fournit comment)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8bb5a5ad",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:31.031090Z",
+     "iopub.status.busy": "2026-06-15T23:25:31.030884Z",
+     "iopub.status.idle": "2026-06-15T23:25:31.037099Z",
+     "shell.execute_reply": "2026-06-15T23:25:31.036447Z"
+    },
+    "papermill": {
+     "duration": 0.010831,
+     "end_time": "2026-06-15T23:25:31.036318",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:31.025487",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plugin 'reflexion' enregistre : fonction reflexion(prompt, k=3).\n"
+     ]
+    }
+   ],
+   "source": [
+    "class ReflexionPlugin:\n",
+    "    \"\"\"Plugin SK : Reflexion sequentielle avec verificateur injecte.\"\"\"\n",
+    "    def __init__(self, kernel, verifier):\n",
+    "        self._k = kernel; self._verif = verifier\n",
+    "\n",
+    "    @kernel_function(name=\"reflexion\", description=\"K tours de Reflexion avec feedback du verificateur.\")\n",
+    "    async def reflexion(self, prompt: str, k: int = 3) -> str:\n",
+    "        feedback = \"\"\n",
+    "        for tour in range(1, k + 1):\n",
+    "            if not feedback:\n",
+    "                invite = prompt\n",
+    "            else:\n",
+    "                invite = (f\"{prompt}\\n\\nEssai precedent INCORRECT. Feedback : {feedback}\\n\"\n",
+    "                          f\"Reessaie correctement. Reponds uniquement par le nombre.\")\n",
+    "            rep = (await llm(self._k, invite, temperature=0.8)).strip()\n",
+    "            if self._verif(rep):\n",
+    "                return f\"SUCCES tour {tour} : {rep}\"\n",
+    "            feedback = f\"ta reponse etait {extraire_nombre(rep)} (incorrect)\"\n",
+    "        return f\"ECHEC apres {k} tours : {rep}\"\n",
+    "\n",
+    "# Verificateur pour la demo (reponse == 9)\n",
+    "_verif_demo = lambda t: extraire_nombre(t) == DEMO_REPONSE\n",
+    "kernel.add_plugin(ReflexionPlugin(kernel, _verif_demo), plugin_name=\"reflexion\")\n",
+    "print(\"Plugin 'reflexion' enregistre : fonction reflexion(prompt, k=3).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7b7db553",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:31.047082Z",
+     "iopub.status.busy": "2026-06-15T23:25:31.046736Z",
+     "iopub.status.idle": "2026-06-15T23:25:31.321784Z",
+     "shell.execute_reply": "2026-06-15T23:25:31.320970Z"
+    },
+    "papermill": {
+     "duration": 0.281696,
+     "end_time": "2026-06-15T23:25:31.321926",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:31.040230",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reflexion (K=3) : SUCCES tour 1 : 50\n"
+     ]
+    }
+   ],
+   "source": [
+    "_plug_ref = kernel.plugins[\"reflexion\"]\n",
+    "_res_ref = await _plug_ref[\"reflexion\"].invoke(kernel, KernelArguments(prompt=DEMO, k=3))\n",
+    "print(\"Reflexion (K=3) :\", _res_ref)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ee874f2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004266,
+     "end_time": "2026-06-15T23:25:31.330192",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:31.325926",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Plugin Routeur — composition (un plugin qui en invoque d'autres)\n",
+    "\n",
+    "Le **routeur** (NB-13) en plugin : selon une **strategie** ('bon' ou 'reflexion'), il invoque le\n",
+    "bon moteur **via le kernel**. C'est la **composition SK** : un plugin orchestre d'autres plugins,\n",
+    "le kernel reste le hub central."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "abc29156",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:31.340439Z",
+     "iopub.status.busy": "2026-06-15T23:25:31.340194Z",
+     "iopub.status.idle": "2026-06-15T23:25:31.346454Z",
+     "shell.execute_reply": "2026-06-15T23:25:31.345750Z"
+    },
+    "papermill": {
+     "duration": 0.013025,
+     "end_time": "2026-06-15T23:25:31.347217",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:31.334192",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plugin 'routeur' enregistre. Plugins disponibles : ['bon', 'reflexion', 'routeur']\n"
+     ]
+    }
+   ],
+   "source": [
+    "class RouteurPlugin:\n",
+    "    \"\"\"Plugin SK : routeur qui compose BoN/Reflexion via le kernel (pattern composition).\"\"\"\n",
+    "    def __init__(self, kernel): self._k = kernel\n",
+    "\n",
+    "    @kernel_function(name=\"resoudre\", description=\"Resout un probleme : strategie 'bon' ou 'reflexion'.\")\n",
+    "    async def resoudre(self, prompt: str, strategie: str = \"reflexion\", n: int = 4, k: int = 3) -> str:\n",
+    "        if strategie == \"bon\":\n",
+    "            fn = self._k.plugins[\"bon\"][\"best_of_n\"]\n",
+    "            r = await fn.invoke(self._k, KernelArguments(prompt=prompt, n=n))\n",
+    "            return f\"[routeur->BoN n={n}] {r}\"\n",
+    "        elif strategie == \"reflexion\":\n",
+    "            fn = self._k.plugins[\"reflexion\"][\"reflexion\"]\n",
+    "            r = await fn.invoke(self._k, KernelArguments(prompt=prompt, k=k))\n",
+    "            return f\"[routeur->Reflexion k={k}] {r}\"\n",
+    "        return f\"[routeur] strategie inconnue : {strategie}\"\n",
+    "\n",
+    "kernel.add_plugin(RouteurPlugin(kernel), plugin_name=\"routeur\")\n",
+    "print(\"Plugin 'routeur' enregistre. Plugins disponibles :\", list(kernel.plugins))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "884993fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:31.366750Z",
+     "iopub.status.busy": "2026-06-15T23:25:31.366545Z",
+     "iopub.status.idle": "2026-06-15T23:25:33.360405Z",
+     "shell.execute_reply": "2026-06-15T23:25:33.359766Z"
+    },
+    "papermill": {
+     "duration": 2.010862,
+     "end_time": "2026-06-15T23:25:33.362079",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:31.351217",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Routeur strategie=reflexion -> [routeur->Reflexion k=3] SUCCES tour 1 : 50\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Routeur strategie=bon -> [routeur->BoN n=4] 50 || 50 || 50 || 50\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Demo composition : le routeur invoque Reflexion via le kernel.\n",
+    "_plug_rt = kernel.plugins[\"routeur\"]\n",
+    "for strat in (\"reflexion\", \"bon\"):\n",
+    "    _r = await _plug_rt[\"resoudre\"].invoke(kernel, KernelArguments(prompt=DEMO, strategie=strat))\n",
+    "    print(f\"Routeur strategie={strat} -> {_r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e1da425",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004004,
+     "end_time": "2026-06-15T23:25:33.370439",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:33.366435",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Composition via le Kernel — au-dela de l'invocation manuelle\n",
+    "\n",
+    "On a invoque les plugins **manuellement** (`plug['fn'].invoke(kernel, args)`). La puissance de SK\n",
+    "est l'**auto-function-calling** : on enregistre les plugins, et le **LLM choisit lui-meme** quel\n",
+    "plugin appeler (avec quels arguments) en voyant leur schema — c'est le routeur **agentique** natif\n",
+    "de SK (cf serie SemanticKernel `03-Agents` et NB-13 routeur).\n",
+    "\n",
+    "> **Pont** : l'auto-function-calling SK generalise le routeur ad-hoc de NB-13. La serie\n",
+    "> SemanticKernel (NB-01 intro, NB-03 agents, NB-06 process framework, NB-08 MCP) couvre en\n",
+    "> profondeur l'orchestration de plugins ; ce notebook est le **point d'entree** depuis la serie\n",
+    "> test-time scaling.\n",
+    "\n",
+    "L'auto-function-calling (boucle tool-use geree par SK) est laisse en **exercice 1** — il demande\n",
+    "d'activer `tool_call_behavior` sur les settings et de gerer la boucle, ce qui est le sujet des\n",
+    "notebooks dedies de la serie SemanticKernel.\n",
+    "\n",
+    "## 6. Limites honnetes (G.2) et synthesis de l'epic #2926\n",
+    "\n",
+    "- **Plugins = enveloppe** : la logique des moteurs (BoN/Reflexion/routeur) est **heritee de\n",
+    "  NB-12 a NB-17** ; ce notebook ajoute la **couche d'integration SK** (decouverte, composition,\n",
+    "  interop), pas de nouvel algorithme. C'est honnête : la valeur ici est l'**architecture**, pas\n",
+    "  une nouvelle technique de scaling.\n",
+    "- **Routeur manuel** : la composition est explicite (`strategie='bon'`). L'auto-routing par le\n",
+    "  LLM (exercice 1) est plus puissant mais token-ponderereux et instable — laissé en exercice.\n",
+    "- **Une seule famille de plugins** (scaling) : SK brille avec des plugins **heterogenes**\n",
+    "  (recherche, code, BDD) ; la serie SemanticKernel montre cela en profondeur.\n",
+    "\n",
+    "**Synthesis de l'epic #2926** (test-time scaling / ICR) — 6 phases :\n",
+    "- **NB-13** routeur agentique (Ph1) — **NB-14** memoire persistante (Ph2) — **NB-15** ToT sur CSP (Ph3) —\n",
+    "  **NB-16** scaling pass@k / Snell (Ph4) — **NB-17** raisonnement natif vs scaling (Ph5) —\n",
+    "  **NB-18** plugins SK (Ph6, ce notebook)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99d18f4a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00442,
+     "end_time": "2026-06-15T23:25:33.378856",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:33.374436",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Travaux pratiques\n",
+    "\n",
+    "Les exercices sont a completer (convention C.1 : pas d'erreur volontaire)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ef0f320",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003999,
+     "end_time": "2026-06-15T23:25:33.387072",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:33.383073",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : auto-function-calling (le LLM choisit le plugin)\n",
+    "\n",
+    "Active l'**auto-function-calling** de SK : enregistre `bon` et `reflexion`, donne un prompt au\n",
+    "LLM, et laisse SK appeler le bon plugin automatiquement. Compare le routing natif SK au routeur\n",
+    "ad-hoc de NB-13.\n",
+    "\n",
+    "# Indice : OpenAIPromptExecutionSettings(tool_call_behavior=...) + kernel.invoke avec auto-call.\n",
+    "# Cf serie SemanticKernel 03-Agents et la doc SK \"function calling\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2f9c73ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:33.396912Z",
+     "iopub.status.busy": "2026-06-15T23:25:33.396677Z",
+     "iopub.status.idle": "2026-06-15T23:25:33.402239Z",
+     "shell.execute_reply": "2026-06-15T23:25:33.400903Z"
+    },
+    "papermill": {
+     "duration": 0.011791,
+     "end_time": "2026-06-15T23:25:33.402863",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:33.391072",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 - auto-function-calling : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def auto_route(kernel, prompt):\n",
+    "    \"\"\"Exercice 1 : auto-function-calling — le LLM choisit entre bon et reflexion.\"\"\"\n",
+    "    # TODO etudiant : activer tool_call_behavior, invoquer avec auto-call, retourner la trace.\n",
+    "    return None\n",
+    "\n",
+    "print(f\"Exercice 1 - auto-function-calling : {'implemente' if False else 'a completer'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6806ac24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003999,
+     "end_time": "2026-06-15T23:25:33.411862",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:33.407863",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : plugin Memory (pont NB-14)\n",
+    "\n",
+    "Reprend la **memoire vectorielle** de NB-14 et expose-la comme plugin SK : un plugin\n",
+    "`memoire.retroceder(query, k)` + `memoire.ajouter(lesson)`. Le routeur peut alors injecter les\n",
+    "lecons passees avant d'appeler Reflexion.\n",
+    "\n",
+    "# Indice : wrap la MemoireVectorielle de NB-14 dans une classe avec @kernel_function sur\n",
+    "# retroceder/ajouter ; le routeur appelle memoire.retroceder puis reflexion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "1a8bfabf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:33.424083Z",
+     "iopub.status.busy": "2026-06-15T23:25:33.423751Z",
+     "iopub.status.idle": "2026-06-15T23:25:33.427939Z",
+     "shell.execute_reply": "2026-06-15T23:25:33.427112Z"
+    },
+    "papermill": {
+     "duration": 0.01064,
+     "end_time": "2026-06-15T23:25:33.427039",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:33.416399",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 - plugin Memoire : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "class MemoirePlugin:\n",
+    "    \"\"\"Exercice 2 : plugin SK wrappant la MemoireVectorielle de NB-14.\"\"\"\n",
+    "    # TODO etudiant : __init__(kernel, memoire) + @kernel_function retroceder(query, k) + ajouter(lesson).\n",
+    "    pass\n",
+    "\n",
+    "print(f\"Exercice 2 - plugin Memoire : {'implemente' if False else 'a completer'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca774f3d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004002,
+     "end_time": "2026-06-15T23:25:33.437062",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:33.433060",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (avance) : orchestrer via le Process Framework (serie SemanticKernel NB-06)\n",
+    "\n",
+    "Encode le flux \"routeur -> moteur -> verificateur -> memoire\" comme un **Process Framework** SK\n",
+    "(etats + transitions) plutot que des appels de plugins. Pont direct vers\n",
+    "`SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb`.\n",
+    "\n",
+    "# Indice : kernel.add_process(...) avec des steps (BoNStep, ReflexionStep, MemoryStep) et des\n",
+    "# edges ; le process orchestre les plugins sans orchestration manuelle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f9afd9da",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T23:25:33.446684Z",
+     "iopub.status.busy": "2026-06-15T23:25:33.446462Z",
+     "iopub.status.idle": "2026-06-15T23:25:33.450359Z",
+     "shell.execute_reply": "2026-06-15T23:25:33.449621Z"
+    },
+    "papermill": {
+     "duration": 0.010511,
+     "end_time": "2026-06-15T23:25:33.451088",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:33.440577",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 - Process Framework : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def build_scaling_process(kernel):\n",
+    "    \"\"\"Exercice 3 : encode le flux test-time scaling comme un Process Framework SK.\"\"\"\n",
+    "    # TODO etudiant : definir des ProcessStep + edges, retourner le process pret a demarrer.\n",
+    "    return None\n",
+    "\n",
+    "print(f\"Exercice 3 - Process Framework : {'implemente' if False else 'a completer'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ddf5ec2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003701,
+     "end_time": "2026-06-15T23:25:33.456788",
+     "exception": false,
+     "start_time": "2026-06-15T23:25:33.453087",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Conclusion\n",
+    "\n",
+    "On a expos les moteurs de test-time scaling (BoN, Reflexion, routeur — herites de NB-12 a NB-17)\n",
+    "comme des **plugins Semantic Kernel**, demontrant le **modele de composition** de SK : plugins\n",
+    "decouvrables, invocables via le kernel, et composables (le routeur invoque BoN/Reflexion via le\n",
+    "kernel). Ce notebook est le **point d'entree** depuis la serie test-time scaling vers la serie\n",
+    "SemanticKernel (plugins, agents, process framework, MCP).\n",
+    "\n",
+    "**#2926 cloture** : 6 phases livrees — routeur agentique (NB-13), memoire persistante (NB-14),\n",
+    "ToT sur CSP (NB-15), scaling pass@k / Snell (NB-16), raisonnement natif vs scaling (NB-17),\n",
+    "plugins SK (NB-18, ce notebook).\n",
+    "\n",
+    "**References :** Semantic Kernel (Microsoft) — serie `SemanticKernel/` du depot ; Snell et al. 2024\n",
+    "(test-time scaling) ; Yao et al. 2023 (Tree of Thoughts) ; NB-12 a NB-17 de cette serie."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 14.113961,
+   "end_time": "2026-06-15T23:25:33.915975",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb",
+   "output_path": "tmp/18_SK_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-15T23:25:19.802014",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Nouveau notebook **NB-18 — Plugins Semantic Kernel pour le test-time scaling**, **Phase 6 (FINALE)** de l'epic **#2926** (ICR test-time scaling). Suit NB-12 (moteurs) a NB-17 (raisonnement natif).

**Clot #2926** : expose les moteurs de test-time scaling (BoN, Reflexion, routeur — herites de NB-12..17) comme des **plugins Semantic Kernel** (`@kernel_function`), faisant le **pont avec la serie SemanticKernel** du depot. Le Kernel devient un **hub de composition** au-dessus des appels API bruts.

### Contenu (24 cellules : 12 code, 12 markdown)
- **Kernel + service SK** : `OpenAIChatCompletion` route via OpenRouter (client `AsyncOpenAI` custom) — meme backend que NB-12..17.
- **Plugin `BoNPlugin.best_of_n`** : N echantillons (NB-12/NB-16).
- **Plugin `ReflexionPlugin.reflexion`** : K tours avec **verificateur injecte** (NB-12/NB-14) — pattern d'injection de dependance SK.
- **Plugin `RouteurPlugin.resoudre`** : **COMPOSITION** — invoque BoN ou Reflexion via le kernel (NB-13 routeur, natif SK).
- **Pont serie SemanticKernel** (plugins/agents/process framework/MCP) ; auto-function-calling laisse en exercice (token-ponderereux, couvert en profondeur la-bas).

## Preuves d'execution reelle (H.1 / pr-review-discipline D)

Execute end-to-end via **Papermill** (kernel python3 = conda base 3.13.12, `semantic-kernel 1.43.0`) :
- **12/12 cellules code**, `execution_count` 1-12, **0 erreur**, **top-level await** (IPython kernel).
- **Vrais appels API** via SK->OpenRouter (llama-3.3-70b).

**Demo (probleme "moyen", train = 50) — mecanisme plugin/composition demontre** :
- BoN (n=4) : `50 || 50 || 50 || 50` — **4/4 correct**.
- Reflexion (K=3) : **SUCCES tour 1** (converge immediatement).
- Routeur strategie=reflexion -> `[routeur->Reflexion k=3] SUCCES tour 1 : 50` ; strategie=bon -> `[routeur->BoN n=4] 50 || 50 || 50 || 50`.
- Choix du probleme "moyen" **deliberé** : le but est de demontrer le **mecanisme** (plugins s'invoquent, composent via le kernel), pas la robustesse du modele (cf NB-16/17).

## Honnetete (G.2)
- **Plugins = enveloppe d'integration** : la logique des moteurs est **heritee de NB-12..17** ; ce notebook ajoute la **couche SK** (decouverte, composition, interop), pas de nouvel algorithme. La valeur est l'**architecture**, assumee franchement.
- **Routeur manuel** (composition explicite) ; l'auto-routing par le LLM (exercice 1) est plus puissant mais token-ponderereux/instable — laissé en exercice.

## Conformite
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`. 3 exercices en stubs (`# TODO etudiant`, `return None` / `pass`).
- **C.2** : commite AVEC outputs reels (Papermill).
- **#2161** : `count_exercises.py` rapporte **3 exercices** (conforme).
- **Anti-regression** : nouveau notebook, ne touche aucun code de production.
- **Secrets** : aucune cle inline ; `.env` via `load_dotenv` (gitignore).
- **Catalogue** : nouveau notebook, non regenere (cron/bot).
- **Scope** : 1 fichier, 1 sujet (atomique, catalog-pr-hygiene HARD 3).

## Ponts pedagogiques
NB-12..17 (moteurs + scaling) -> **NB-18** (plugins SK) -> serie SemanticKernel (01-Intro, 03-Agents, 06-Process, 08-MCP).

## Scope de cette PR — DERNIERE phase de #2926

**Phase 6 / 6** de #2926. Apres son merge, **toutes les phases sont livrees** (NB-13 routeur, NB-14 memoire, NB-15 ToT-CSP, NB-16 scaling Snell, NB-17 raisonnement natif, NB-18 plugins SK). **#2926 est entierement delivre** -> ai-01 peut clore l'epic.

See #2926 (l'epic etant multi-PR, je laisse ai-01 fermer explicitement apres ce merge — catalog-pr-hygiene HARD 4).
