### PR TITLE
docs(genai): restore French diacritics in FineTuning README (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/README.md
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/README.md
@@ -1,4 +1,4 @@
-# FineTuning - Adapter les LLMs a vos taches
+# FineTuning - Adapter les LLMs à vos tâches
 
 <!-- CATALOG-STATUS
 series: GenAI-FineTuning
@@ -9,16 +9,16 @@ maturity: PRODUCTION=4, BETA=1
 
 [← GenAI](../README.md) | [↑ ..](../README.md) | [→ PostTraining](../PostTraining/README.md)
 
-Serie progressive sur le fine-tuning des modeles de langue : des bases LoRA a la fusion de modeles, en passant par la quantization, l'instruction-following et l'alignement par preferences humaines. GPU recommande (T4/V100 suffisent pour la plupart des exercices).
+Série progressive sur le fine-tuning des modèles de langue : des bases LoRA à la fusion de modèles, en passant par la quantization, l'instruction-following et l'alignement par préférences humaines. GPU recommandé (T4/V100 suffisent pour la plupart des exercices).
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, vous serez capable de :
+À l'issue de cette série, vous serez capable de :
 
-1. **Appliquer** LoRA et QLoRA pour fine-tuner des modeles 7B sur un GPU consumer
+1. **Appliquer** LoRA et QLoRA pour fine-tuner des modèles 7B sur un GPU consumer
 2. **Transformer** un base model en instruct model via SFT (format ChatML)
-3. **Aligner** les modeles sur les preferences humaines avec DPO
-4. **Fusionner** plusieurs adaptateurs fine-tunes en un seul modele unifie (TIES, DARE, MoE)
+3. **Aligner** les modèles sur les préférences humaines avec DPO
+4. **Fusionner** plusieurs adaptateurs fine-tunés en un seul modèle unifié (TIES, DARE, MoE)
 
 ## Structure
 
@@ -27,35 +27,35 @@ FineTuning/
 ├── FT-01-Introduction-FineTuning.ipynb   # LoRA, full vs partial vs PEFT
 ├── FT-02-QLoRA-Quantization.ipynb        # Quantization 4-bit (NF4) + LoRA
 ├── FT-03-Supervised-FineTuning-SFT.ipynb # Instruction-following, format chat
-├── FT-04-RLHF-DPO.ipynb                  # Alignement preferences, DPO
+├── FT-04-RLHF-DPO.ipynb                  # Alignement préférences, DPO
 └── FT-05-ModelMerging-Routing.ipynb      # Fusion d'adaptateurs, routage MoE
 ```
 
-## Progression pedagogique
+## Progression pédagogique
 
-| Notebook | Sujet | Prerequis | Duree | Niveau |
+| Notebook | Sujet | Prérequis | Durée | Niveau |
 |----------|-------|-----------|-------|--------|
-| [FT-01](FT-01-Introduction-FineTuning.ipynb) | Fine-tuning complet, partiel, LoRA | Bases LLMs | ~30 min | Debutant |
-| [FT-02](FT-02-QLoRA-Quantization.ipynb) | Quantization NF4, QLoRA, bitsandbytes | FT-01 | ~30 min | Intermediaire |
-| [FT-03](FT-03-Supervised-FineTuning-SFT.ipynb) | Base model vs Instruct model, format ChatML | FT-01 | ~45 min | Intermediaire |
-| [FT-04](FT-04-RLHF-DPO.ipynb) | Reward Model, RLHF, DPO | FT-01, FT-02, FT-03 | ~30 min | Avance |
-| [FT-05](FT-05-ModelMerging-Routing.ipynb) | TIES, DARE, MergeKit, routage MoE | FT-01 a FT-04 | ~45 min | Avance |
+| [FT-01](FT-01-Introduction-FineTuning.ipynb) | Fine-tuning complet, partiel, LoRA | Bases LLMs | ~30 min | Débutant |
+| [FT-02](FT-02-QLoRA-Quantization.ipynb) | Quantization NF4, QLoRA, bitsandbytes | FT-01 | ~30 min | Intermédiaire |
+| [FT-03](FT-03-Supervised-FineTuning-SFT.ipynb) | Base model vs Instruct model, format ChatML | FT-01 | ~45 min | Intermédiaire |
+| [FT-04](FT-04-RLHF-DPO.ipynb) | Reward Model, RLHF, DPO | FT-01, FT-02, FT-03 | ~30 min | Avancé |
+| [FT-05](FT-05-ModelMerging-Routing.ipynb) | TIES, DARE, MergeKit, routage MoE | FT-01 à FT-04 | ~45 min | Avancé |
 
 ## Technologies couvertes
 
 ### Frameworks
-- **transformers** (Hugging Face) - Modeles de base
+- **transformers** (Hugging Face) - Modèles de base
 - **peft** (Hugging Face) - LoRA, adaptateurs
 - **bitsandbytes** - Quantization 4-bit / 8-bit
 - **trl** (Hugging Face) - SFTTrainer, DPOTrainer
-- **mergekit** - Fusion de modeles (TIES, DARE, SLERP)
+- **mergekit** - Fusion de modèles (TIES, DARE, SLERP)
 
-### Modeles utilises
-- **Petits modeles** (FT-01) : DistilBERT, TinyLlama
-- **Modeles 1-3B** (FT-02, FT-03) : Phi-3, Llama-3.2
-- **Modeles 7B+** (FT-04, FT-05) : Mistral-7B, Llama-2-7B (avec QLoRA)
+### Modèles utilisés
+- **Petits modèles** (FT-01) : DistilBERT, TinyLlama
+- **Modèles 1-3B** (FT-02, FT-03) : Phi-3, Llama-3.2
+- **Modèles 7B+** (FT-04, FT-05) : Mistral-7B, Llama-2-7B (avec QLoRA)
 
-## Prerequis
+## Prérequis
 
 ```bash
 pip install transformers peft accelerate bitsandbytes trl datasets
@@ -64,117 +64,117 @@ pip install mergekit  # Pour FT-05 uniquement
 
 ### Configuration GPU
 
-| Notebook | VRAM minimale | VRAM recommandee |
+| Notebook | VRAM minimale | VRAM recommandée |
 |----------|---------------|------------------|
 | FT-01 | 4 GB (CPU possible) | 8 GB |
 | FT-02 | 6 GB (QLoRA) | 12 GB |
 | FT-03 | 8 GB | 16 GB |
-| FT-04 | 12 GB (DPO 2 modeles en memoire) | 24 GB |
+| FT-04 | 12 GB (DPO 2 modèles en mémoire) | 24 GB |
 | FT-05 | 16 GB (merge) | 24 GB |
 
-## Concepts cles
+## Concepts clés
 
 ### LoRA (Low-Rank Adaptation)
-Decompose les mises a jour de poids en matrices de bas rang (A, B avec rang r << dim). Reduit les parametres entrainables de ~99%.
+Décompose les mises à jour de poids en matrices de bas rang (A, B avec rang r << dim). Réduit les paramètres entraînables de ~99%.
 
 ### QLoRA
-Combine quantization 4-bit (NF4 + double quantization) avec LoRA. Permet de fine-tuner des modeles 7B sur un GPU consumer (RTX 3090/4090).
+Combine quantization 4-bit (NF4 + double quantization) avec LoRA. Permet de fine-tuner des modèles 7B sur un GPU consumer (RTX 3090/4090).
 
 ### SFT (Supervised Fine-Tuning)
-Transforme un base model en instruct model via supervision sur des paires (instruction, reponse). Format ChatML recommande.
+Transforme un base model en instruct model via supervision sur des paires (instruction, réponse). Format ChatML recommandé.
 
 ### DPO (Direct Preference Optimization)
-Alternative simplifiee a RLHF : optimise directement sur les paires (preferred, rejected) sans Reward Model explicite.
+Alternative simplifiée à RLHF : optimise directement sur les paires (preferred, rejected) sans Reward Model explicite.
 
 ### Model Merging
-Combine plusieurs adaptateurs LoRA fine-tunes sur des taches differentes en un seul modele unifie. Algorithmes : TIES, DARE, SLERP, weighted average.
+Combine plusieurs adaptateurs LoRA fine-tunés sur des tâches différentes en un seul modèle unifié. Algorithmes : TIES, DARE, SLERP, weighted average.
 
-## Parcours recommande
+## Parcours recommandé
 
-### Decouverte (1h)
-1. **FT-01** - Comprendre LoRA et le compromis parametres/qualite
+### Découverte (1h)
+1. **FT-01** - Comprendre LoRA et le compromis paramètres/qualité
 2. **FT-03** - SFT pour instruction-following (sans QLoRA)
 
 ### Standard (2-3h)
-1. FT-01 a FT-04 dans l'ordre
+1. FT-01 à FT-04 dans l'ordre
 
-### Avance (3-4h)
-1. FT-01 a FT-05 dans l'ordre + experimenter mergekit recipes
+### Avancé (3-4h)
+1. FT-01 à FT-05 dans l'ordre + expérimenter mergekit recipes
 
 ## FAQ
 
 ### OOM pendant FT-04 (DPO) ou FT-05 (Model Merging)
 
-DPO (FT-04) charge **deux modeles** en memoire (policy + reference), ce qui double la consommation VRAM. Strategies :
+DPO (FT-04) charge **deux modèles** en mémoire (policy + reference), ce qui double la consommation VRAM. Stratégies :
 
-- Utiliser QLoRA 4-bit (`load_in_4bit=True`) pour reduire chaque modele a ~25% de sa taille FP16.
-- Reduire `per_device_train_batch_size` a 1 et compenser avec `gradient_accumulation_steps`.
-- Pour FT-05 (merge), les modeles sont charges sequentiellement, pas en parallele — 16 GB suffisent si vous mergez un modele a la fois.
+- Utiliser QLoRA 4-bit (`load_in_4bit=True`) pour réduire chaque modèle à ~25% de sa taille FP16.
+- Réduire `per_device_train_batch_size` à 1 et compenser avec `gradient_accumulation_steps`.
+- Pour FT-05 (merge), les modèles sont chargés séquentiellement, pas en parallèle — 16 GB suffisent si vous mergez un modèle à la fois.
 
-FT-01 a FT-03 sont accessibles sur GPU 8-12 GB (T4, RTX 3060). FT-04 et FT-05 preferent 24 GB (RTX 3090/4090).
+FT-01 à FT-03 sont accessibles sur GPU 8-12 GB (T4, RTX 3060). FT-04 et FT-05 préfèrent 24 GB (RTX 3090/4090).
 
-### Quelle difference entre cette serie et PostTraining ?
+### Quelle différence entre cette série et PostTraining ?
 
-| Aspect | FineTuning (cette serie) | PostTraining |
+| Aspect | FineTuning (cette série) | PostTraining |
 |--------|-------------------------|--------------|
-| **Focus** | Boite a outils pratique | Profondeur methodologique |
-| **Approche** | "Comment faire" | "Pourquoi ca marche" |
-| **Modeles** | 0.5B a 7B, variés | Qwen2.5-0.5B/1.5B uniquement |
+| **Focus** | Boîte à outils pratique | Profondeur méthodologique |
+| **Approche** | "Comment faire" | "Pourquoi ça marche" |
+| **Modèles** | 0.5B à 7B, variés | Qwen2.5-0.5B/1.5B uniquement |
 | **Techniques** | LoRA, QLoRA, SFT, DPO, merging | SFT, DPO, GRPO, RLVR |
 | **GPU cible** | T4/V100 (4-8 GB min) | RTX 3070 (8 GB) |
-| **Math du loss** | Non detaillee | Expliquee avant le code |
+| **Math du loss** | Non détaillée | Expliquée avant le code |
 
 Recommandation : faire FineTuning d'abord pour la pratique, puis PostTraining pour comprendre les fondamentaux.
 
 ### LoRA rank : comment choisir r ?
 
-Le rang `r` de LoRA controle le compromis parametres/qualite :
+Le rang `r` de LoRA contrôle le compromis paramètres/qualité :
 
-- **r=4-8** : bon pour des taches simples (classification, formatage). ~0.1% parametres entrainables.
-- **r=16** (defaut) : bon compromis pour instruction-following et DPO. ~0.5% parametres.
-- **r=32-64** : taches complexes (raisonnement, code). Plus de parametres mais plus de VRAM.
-- **r=128+** : rarement necessaire — a ce stade, un full fine-tuning partiel est souvent plus efficace.
+- **r=4-8** : bon pour des tâches simples (classification, formatage). ~0.1% paramètres entraînables.
+- **r=16** (défaut) : bon compromis pour instruction-following et DPO. ~0.5% paramètres.
+- **r=32-64** : tâches complexes (raisonnement, code). Plus de paramètres mais plus de VRAM.
+- **r=128+** : rarement nécessaire — à ce stade, un full fine-tuning partiel est souvent plus efficace.
 
 Le notebook [FT-01](FT-01-Introduction-FineTuning.ipynb) compare r=4 vs r=16 vs r=64 sur DistilBERT pour rendre ce compromis visible.
 
 ### bitsandbytes ne s'installe pas sur Windows
 
-`bitsandbytes` (requis pour QLoRA, FT-02 a FT-04) depend de CUDA. Sur Windows :
+`bitsandbytes` (requis pour QLoRA, FT-02 à FT-04) dépend de CUDA. Sur Windows :
 
 ```bash
-# Verifier CUDA
+# Vérifier CUDA
 python -c "import torch; print(torch.version.cuda)"
 
 # Installer bitsandbytes compatible Windows
 pip install bitsandbytes>=0.45
 
-# Si erreur DLL non trouvee
-# Verifier que CUDA_HOME est configure
+# Si erreur DLL non trouvée
+# Vérifier que CUDA_HOME est configuré
 set CUDA_HOME=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4
 ```
 
-Alternative : utiliser Google Colab (GPU T4 gratuit) pour les notebooks FT-02 a FT-04 si votre machine n'a pas de GPU.
+Alternative : utiliser Google Colab (GPU T4 gratuit) pour les notebooks FT-02 à FT-04 si votre machine n'a pas de GPU.
 
 ### Peut-on fine-tuner sans GPU ?
 
-Partiellement. FT-01 fonctionne en mode CPU (DistilBERT, petit modele). Pour les notebooks FT-02 a FT-05 :
+Partiellement. FT-01 fonctionne en mode CPU (DistilBERT, petit modèle). Pour les notebooks FT-02 à FT-05 :
 
-- **Google Colab** (GPU T4 gratuit) : FT-01 a FT-03 executables.
-- **Kaggle Kernels** (GPU P100 gratuit, 30h/semaine) : FT-01 a FT-04.
-- **Unsloth** (optimisation memoire) : reduit la VRAM requise de ~40%, permet QLoRA 7B sur T4.
+- **Google Colab** (GPU T4 gratuit) : FT-01 à FT-03 exécutables.
+- **Kaggle Kernels** (GPU P100 gratuit, 30h/semaine) : FT-01 à FT-04.
+- **Unsloth** (optimisation mémoire) : réduit la VRAM requise de ~40%, permet QLoRA 7B sur T4.
 
-Les notebooks sont concus pour tourner avec `LOAD_MODEL_AND_TRAIN=False` en mode demo (outputs pre-calcules visibles sans GPU).
+Les notebooks sont conçus pour tourner avec `LOAD_MODEL_AND_TRAIN=False` en mode démo (outputs pré-calculés visibles sans GPU).
 
-### MergeKit produit un modele degradé
+### MergeKit produit un modèle dégradé
 
-Si le modele merge (FT-05) perd en qualite par rapport aux adaptateurs individuels :
+Si le modèle merge (FT-05) perd en qualité par rapport aux adaptateurs individuels :
 
-- Verifier que les adaptateurs ont ete fine-tunes sur des taches **suffisamment differentes** (merger des adaptateurs trop similaires ne produit pas de gain).
-- L'algorithme TIES est plus robuste que SLERP pour les merges multi-taches.
-- DARE (Drop And Rescale) elimine les poids redondants — essayer si TIES ne converge pas.
-- Le routage MoE (Mixture of Experts) est une alternative au merge statique : chaque token est route vers l'adaptateur le plus competent. FT-05 couvre cette approche.
+- Vérifier que les adaptateurs ont été fine-tunés sur des tâches **suffisamment différentes** (merger des adaptateurs trop similaires ne produit pas de gain).
+- L'algorithme TIES est plus robuste que SLERP pour les merges multi-tâches.
+- DARE (Drop And Rescale) élimine les poids redondants — essayer si TIES ne converge pas.
+- Le routage MoE (Mixture of Experts) est une alternative au merge statique : chaque token est routé vers l'adaptateur le plus compétent. FT-05 couvre cette approche.
 
-## References
+## Références
 
 - **Hugging Face PEFT** : https://huggingface.co/docs/peft
 - **QLoRA paper** : https://arxiv.org/abs/2305.14314


### PR DESCRIPTION
## Summary

Content-based restoration of French diacritics across the **FineTuning series README**, systematically unaccented — same genuine gap as root/Video/Audio/Image/Texte (#3082 / #3086 / #3093 / #3097). Markdown-only.

Follow-up to ai-01 dispatch (passe 2, cycle :23): *« Trickle restant = Texte / FineTuning / SemanticKernel »*. Confirmed genuine gap (GenAI family), not a false positive (~96% FP warning = Python family).

## Method — word-by-word, NOT blind find-replace

Accents restored on French prose only (incl. bash code-block comments). Preserved byte-identical:
- **CATALOG-STATUS marker** (lines 3-8) — verified unchanged
- All **6 `.ipynb` link paths** (identical before/after)
- Bash/text code blocks + structure tree diagram
- All **4 reference URLs** (huggingface, 2× arxiv, github)
- Every English/technical term: LoRA, QLoRA, DPO, SFT, RLHF, TIES, DARE, SLERP, MoE, NF4, bitsandbytes, transformers, peft, trl, mergekit, DistilBERT, TinyLlama, Phi-3, Llama-3.2, Mistral-7B, Llama-2-7B, ChatML, Reward Model, GRPO, RLVR, Unsloth, Qwen2.5, GPU/VRAM, RTX/T4/V100, FP16, CUDA, Colab, Kaggle, weighted average, base/instruct model, `LOAD_MODEL_AND_TRAIN`

## Verification (G.1)

- `git diff --stat`: 1 file, **68 ins / 68 del** (line-for-line, net 0 lines)
- Line count unchanged: 182 == 182
- `grep .ipynb` count: **6 == 6** (no link touched)
- CATALOG-STATUS marker: **byte-identical**
- Reference URLs: **4/4 intact**
- Spot-check: **0** English terms accidentally accented; **0** remaining unaccented FR prose words

See #2876 (partial — **SemanticKernel remains**, last of the trickle).

