### PR TITLE
docs(conway): sync README sorry count (2->7) + P4/P5 status to #2975 scaffolding (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -5,7 +5,7 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 ## Status
 
 - **Toolchain**: v4.30.0-rc2
-- **Sorry count**: 2 (HashlifeCorrectness P4/P5 — prover targets, Epic #2162)
+- **Sorry count**: 7 (all in `HashlifeCorrectness.lean` — P4 double-nine inductive step [5] + P5 large-n jump [2], Epic #2162)
 - **Build**: `lake build Conway` -- SUCCESS (3352 jobs)
 - **Dependencies**: Mathlib4
 
@@ -38,7 +38,7 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 | `Conway/Life/Computation.lean` | 0 | Hashlife cross-validation (6 + 6 fast), eater1 still-life (1), glider composition (5) |
 | `Conway/Life/HashlifeMemo.lean` | 0 | Memoized Hashlife for community pillar witnesses (OTCA 35K, UnitCell 4096, Gemini 33M) |
 | `Conway/Life/Pillars.lean` | 0 | Community-witness theorem scaffolding (4 pillars) |
-| `Conway/Life/HashlifeCorrectness.lean` | 2 | Bounded correctness theorem, prover targets P4/P5 (Epic #1453, #2162) |
+| `Conway/Life/HashlifeCorrectness.lean` | 7 | Bounded correctness `hashlife_correct`; P4/P5 prover targets (Epic #1453, #2162) |
 
 ### Phase 3 — Free Will Theorem (Epic #1651, COMPLETE)
 
@@ -77,10 +77,16 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
   - Eater 1 (fishhook) still-life proved by `native_decide`
   - Multi-period glider composition theorems
 - **Memoized Hashlife**: Community pillar witnesses (OTCA 35K gen, UnitCell 4096 gen, Gemini 33M gen)
-- **HashlifeCorrectness**: Central theorem `hashlifeResult_central_correct` with 5 sub-goals
-  - P1-P3 proven (base case k=0 in full generality via `2^16 native_decide`, PR #2810)
-  - P4: well-formedness membership (sorry kept, now provable after wf-fix PR #2795)
-  - P5: highest-level inductive step (sorry, plausibly true)
+- **HashlifeCorrectness**: bounded correctness `hashlife_correct`, decomposed P1-P5
+  - **P1-P3 proven** (base case `k=0` via `2^16 native_decide`, PR #2810)
+  - **P4 inductive step** (5 sorry): decomposed by #2975 scaffolding into four `: True`
+    sub-lemmas (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`,
+    `p4_half_steps_compose`) + glue `p4_succ_membership` (the real pointwise
+    biconditional). Research-level double-nine light-cone composition. The scaffolds'
+    real statements live in their docstrings — restate + prove, do not eliminate as `True`.
+  - **P5 large-n** (2 sorry): `p5_small_n_fallback` **PROVEN** (PR #2984); `p5_large_n_jump`
+    (P5.2, blocked on P4) + `p5_inductive_step` large-n branch (P5.3 glue) remain. Base
+    `n=0` proven (`hashlife_correct_base_zero` #2898, `evolveHashlifeFastAux_zero_n` #2901).
 
 ### Kochen-Specker + Free Will Theorem (Phase 3, PROVED)
 


### PR DESCRIPTION
## What

The `conway_lean` README claimed **"Sorry count: 2"** and described P4/P5 as opaque sorries ("P5: highest-level inductive step (sorry, plausibly true)"). The actual state (verified against `HashlifeCorrectness.lean`) is **7 sorries**, and the #2975 scaffolding decomposed P4 into named sub-lemmas while parts of P5 are now **proven**.

Real defect fixed: undercount (2 vs 7) + stale P4/P5 status that hides both the scaffolding structure and the proven sub-parts (P5.1, base `n=0`).

## Changes (docs-only — `README.md`, 1 file, +12/-6)

- **Status** `Sorry count: 2` -> `7` (5 P4 double-nine inductive step + 2 P5 large-n jump), with the breakdown.
- **HashlifeCorrectness table row** sorry `2` -> `7`.
- **P4/P5 Key Results** rewritten:
  - **P1-P3 proven** (`k=0` base via `2^16 native_decide`, PR #2810).
  - **P4 (5 sorry)**: #2975 scaffolding into four `: True` sub-lemmas (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_half_steps_compose`) + glue `p4_succ_membership` (the real pointwise biconditional). Notes that the scaffolds real statements live in docstrings (restate + prove, do **not** eliminate as `True`).
  - **P5 (2 sorry)**: `p5_small_n_fallback` **PROVEN** (PR #2984); `p5_large_n_jump` (P5.2, blocked on P4) + `p5_inductive_step` large-n branch (P5.3 glue) remain. Base `n=0` proven (`hashlife_correct_base_zero` #2898, `evolveHashlifeFastAux_zero_n` #2901).

## Verification (G.1, against real file)

| Claim | Check |
|-------|-------|
| 7 sorries | tactic-sorry grep in `HashlifeCorrectness.lean` = **7**: L1448/1458/1468/1479 (P4 scaffolds), L1495 (`p4_succ_membership`), L1800 (`p5_large_n_jump`), L1809 (`· sorry`, large-n branch of `p5_inductive_step`) |
| Grep caveat | `· sorry` (L1809) is **missed** by the naive `^\s*sorry\b` pattern — a broad pattern is required or the count reads 6, not 7 |
| All other Conway files | 0 sorry (only `HashlifeCorrectness.lean` carries sorries) |
| Toolchain | `leanprover/lean4:v4.30.0-rc2` (README was already correct, unchanged) |

## Scope

- **Docs-only** (`README.md`). No `.lean` change -> **no `lake build` required** (lean-merge-discipline §1 applies to `*.lean` PRs only).
- No catalogue touched.
- Base branched off fresh `origin/main`.

Contributes to #2651 Partie 2 (sous-READMEs des séries au plus près du contenu réel). Conway depth context: #2162.

`See #2651`, `See #2162` (partial — neither is closed by this single README).