### PR TITLE
docs(qc): verify ML-FeatureEngineering post-#2801 (0.57 -> 0.65, +15% UPWARD)

### DIFF
--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -56,7 +56,7 @@ Strategies with solid risk-adjusted returns. These are the primary candidates fo
 | 22 | SectorMomentum | IND | Equities+Bonds+Gold | ~~0.62~~ → **0.56** ✓post-#2801 | 13.1 | 22.8 | 0.58 | robuste (mild -9%, monthly rebalance winner-takes-all on 3 ETFs = low rotation near-immune, contrasts heavier multi-sleeve baskets; PSR 13.8% low, not a true leader) |
 | 23 | BlackLitterman-Momentum | COMP | Equities/ETF | ~~0.60~~ → **0.83** ✓post-#2801 | 15.8 | 16.9 | 0.94 | **robuste (catalog CORRECTED UPWARD +38%)** — catalog 0.60 was stale; code already had IBKR so the docstring v2 BEST (0.823, CAGR 15.7%, MaxDD -16.9%) was the WITH-fees value; monthly rebalance + fee-homogeneous 15-stock US equity basket = near-immune to fees; **PSR 51.4% = true leader (borderline significant)** |
 | 24 | Crypto-MultiCanal | IND | Crypto (BTC) | ~~0.58~~ → **0.33** ✓post-#2801 | 4.6 | 14.1 | 0.33 | **historique** (downgraded -43%, crypto indicator NOT robust post-fees, PSR 13.0%) |
-| 25 | ML-FeatureEngineering | ML | Multi-asset | 0.57 | 10.5 | — | — | robuste |
+| 25 | ML-FeatureEngineering | ML | Equities (10 mega-caps) | ~~0.57~~ → **0.65** ✓post-#2801 | 18.7 | 28.1 | 0.67 | robuste (catalog CORRECTED UPWARD +15% — was stale; real Sharpe of current RF+GB 18-feature ensemble near-immune on fee-homogeneous US equity; PSR 15.1% low, not a true leader; universe corrected Multi-asset→Equities; baseline-clone 32952140) |
 | 26 | Markov-Regime-Detection | ML | Equities | 0.57 | — | — | — | robuste |
 | 27 | ML-XGBoost | ML | Multi-asset | 0.57 | 14.8 | — | — | robuste |
 | 28 | MomentumStrategy | IND | Equities | ~~0.57~~ → **0.50** ✓post-#2801 | 11.2 | 25.8 | 0.43 | robuste borderline (at threshold -12%, PSR 9.3% non-significant) |
@@ -101,6 +101,7 @@ brokerage = the #2801 Lot 1 remediation). Results vs the pre-remediation catalog
 | MeanReversion | 30776121 | 0.81 | **0.81** | 0% | robuste (confirmed, PSR 46.8%, low-turnover sector rotation holds) |
 | SectorMomentum | 29686886 | 0.62 | **0.56** | -9% | robuste (mild — monthly rebalance winner-takes-all on 3 ETFs = low rotation near-immune; PSR 13.8% low, not a true leader) |
 | BlackLitterman-Momentum | 29816300 | 0.60 | **0.83** | +38% | **robuste (catalog CORRECTED UPWARD — was stale, not a fee effect; code already remediated, real Sharpe matches docstring v2 BEST 0.823; monthly fee-homogeneous 15-stock US equity = near-immune; PSR 51.4% true leader borderline)** |
+| ML-FeatureEngineering | 29808616 | 0.57 | **0.65** | +15% | robuste (catalog CORRECTED UPWARD — was stale; current RF+GB 18-feature ensemble better than the run that produced 0.57; bi-weekly fee-homogeneous US equity = near-immune; PSR 15.1% low, not a true leader; universe corrected Multi-asset→Equities; baseline-clone 32952140) |
 | LongShortHarvest | 32921183 | 3.39 | **1.64** | -52% | robuste (confirmed, **PSR 98.7%** top — catalog was 1Y-OOS, baseline-clone) |
 | DynamicVIXSpyRegime | 32921262 | 1.72 | **1.00** | -42% | robuste (confirmed, **PSR 69.4%** — catalog was 1Y-OOS, baseline-clone) |
 | Portfolio-Optimization-ML | 29318874 | 0.90 | **0.88** | -2% | robuste (confirmed, monthly-rebalance fee-homogeneous equity basket near-immune, PSR 37.2%) |
@@ -110,7 +111,7 @@ brokerage = the #2801 Lot 1 remediation). Results vs the pre-remediation catalog
 | TrendStocksLite | 28817425 | 0.72 | **0.71** | -2% | robuste (confirmed — weekly trend on 15 liquid large-caps, low realized turnover, near-immune, PSR 25.0%) |
 | ML-RandomForest | 29434751 | 0.68 | **0.70** | +3% | robuste (confirmed — bi-weekly RF on 10 mega-caps, moderate turnover near-immune on fee-homogeneous US equity, PSR 18.4%, baseline-clone 32940005) |
 
-**Finding (methodological, now 26-strategy sample)** : the remediation impact is **not
+**Finding (methodological, now 27-strategy sample)** : the remediation impact is **not
 uniform**, and the batch-4 results *refine and partly correct* the earlier 10-strategy pattern.
 The distinguishing axis is **not** asset class, nor ML-vs-indicator alone — it is the
 combination of (a) the fee-per-trade the asset class carries and (b) how the strategy turns


### PR DESCRIPTION
## Summary

Re-backtested **ML-FeatureEngineering** (project `29808616`) as part of the #1630 post-#2801 verification campaign. The original had **no brokerage model** (default fee-negligible), so a **baseline-clone** was created (project `32952140`, `1630-ML-FeatureEngineering-post2801`) with IBKR margin brokerage added; all other code identical.

**Strategy**: RF + GB ensemble (200/150 trees) on an 18-feature set (12 baseline + 6 novel student-project features). Bi-weekly rebalance, monthly retraining, max 5 positions, confidence-weighted sizing. Universe: 10 US mega-caps.

## Result (2015-01-01 → present, 2878 tradeable dates)

| Metric | Value |
|--------|-------|
| Sharpe | **0.654** (catalog 0.57 → **0.65**, **CORRECTED UPWARD +15%**) |
| CAGR | 18.7% |
| MaxDD | -28.1% |
| Calmar | 0.67 |
| PSR | 15.1% (low) |

Backtest: `1630-ML-FeatureEngineering-post2801` (`7ec01008`) on clone project `32952140` (original `29808616`).

## Classification: robuste (not a true leader, PSR < 50%)

## Key finding — second consecutive upward correction

Like BlackLitterman (#3095), the catalog `0.57` was **stale** — the current RF+GB 18-feature ensemble performs better than whatever run produced 0.57. Fee impact is ~0: bi-weekly rebalance on a fee-homogeneous 10-stock US equity basket = **near-immune** (same regime as ML-RandomForest +3%, Gaussian-Direction 0%, BlackLitterman near-immune). The +15% is a catalog-accuracy correction, not a remediation effect.

This reinforces the methodological note: **some catalog entries were simply stale**, and the bi-weekly/monthly fee-homogeneous US-equity ML basket is a robust near-immune regime regardless of ML complexity (RF, GB, or BL optimizer).

## Universe correction

The catalog mislabeled this strategy "Multi-asset" — the actual universe is **10 US mega-cap equities** (single asset class). Corrected to "Equities (10 mega-caps)" so the near-immune regime classification is consistent with the fee-homogeneous US-equity basket.

## Changes

`docs/qc/qc-comparative-backtests.md` only (3 edits):
- Tier-1 row #25 ML-FeatureEngineering: `0.57` → `~~0.57~~ → 0.65 ✓post-#2801` + metrics + universe correction.
- Secondary project-id table: added ML-FeatureEngineering row (`29808616`, clone `32952140`).
- Finding count: 26 → 27-strategy sample.

## Notes

- `totalOrders=0` returned by the MCP is the known phantom parse bug — CAGR 18.7% is impossible with zero trades.
- No `COURSE_CATALOG.generated.*` touched (automation-owned). `openzeppelin` submodule not staged (SymbolicAI lane, pre-existing).

See #1630