### PR TITLE
docs(genai-texte): document NB-13..18 (test-time scaling arc) in Texte README (See #2926)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -13,13 +13,14 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 
 ## Ce que vous apprendrez
 
-À travers ces 12 notebooks pratiques, vous acquerrez une expertise complète :
+À travers ces 18 notebooks pratiques, vous acquerrez une expertise complète :
 - **Art du prompt engineering** : du zéro-shot au chain-of-thought
 - **Structuration des réponses** : JSON Schema, Pydantic, extraction de données
 - **Intelligence augmentée** : function calling, RAG moderne, code interpreter
 - **Raisonnement avancé** : modèles o4-mini, gpt-5-thinking
 - **Production enterprise** : gestion de sessions, retry, batch processing
 - **Déploiement local** : vLLM, quantification, optimisation des coûts
+- **Test-time scaling (ICR)** : routeur agentique, mémoire persistante, Tree-of-Thoughts sur CSP, courbes de scaling, raisonnement natif, plugins Semantic Kernel (notebooks 13 à 18, arc approfondi au-delà de NB-12)
 
 ## Contenu détaillé
 
@@ -54,6 +55,19 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 | 10 | `10_LocalLlama.ipynb` | vLLM, Qwen3.5-35B-A3B, ZwZ-8B, multi-endpoints, benchmarking | 60 min |
 | 11 | `11_Quantization.ipynb` | AWQ, GPTQ, llmcompressor, modèles vision, déploiement vLLM | 60 min |
 | 12 | `12_Test_Time_Scaling.ipynb` | Best-of-N, Tree-of-Thoughts (BFS/DFS), Reflexion, routeur adaptatif (cf ICR) | 60 min |
+
+### Tier 5 : Test-Time Scaling approfondi (ICR)
+
+Le notebook 12 introduit en Python pur les quatre moteurs d'inférence au moment du test (Best-of-N, Tree-of-Thoughts, Reflexion, routeur adaptatif). Les notebooks 13 à 18 approfondissent cet arc en s'inspirant du projet de référence [Iterative-Contextual-Refinements (ICR)](https://github.com/ryoiki-tokuien/Iterative-Contextual-Refinements) : on passe d'un routeur codé en dur à une orchestration agentique, on rend la mémoire persistante, on attaque des problèmes de recherche où le single-shot échoue, on quantifie les compromis de scaling, on compare au raisonnement natif, puis on expose le tout comme plugins réutilisables.
+
+| # | Notebook | Description | Durée |
+|---|----------|-------------|-------|
+| 13 | `13_Agentic_Orchestration.ipynb` | Routeur agentique : function calling (pont NB-04) pour laisser un LLM choisir le moteur par sous-tâche (mode "Agentic" d'ICR) | 60 min |
+| 14 | `14_Persistent_Memory.ipynb` | Mémoire vectorielle persistante (baseline BoW + cosine, pont NB-05 RAG) qui rétrocède les leçons aux runs suivants (agent "Memory" d'ICR) | 55 min |
+| 15 | `15_Tree_of_Thoughts_Search.ipynb` | Tree-of-Thoughts sur cryptarithmes (SEND+MORE=MONEY) : recherche DFS colonne par colonne avec propagation de retenue (pont séries Search/Sudoku) | 60 min |
+| 16 | `16_Scaling_Test_Time_Compute.ipynb` | Courbes de scaling Snell 2024 : estimateur pass@k, BoN vs Reflexion, frontière compute-optimale selon la difficulté | 65 min |
+| 17 | `17_Native_Reasoning_vs_Scaling.ipynb` | Raisonnement natif (deepseek-r1, reasoning tokens) vs scaling hand-rolled (BoN), comparaison cost-normalisée en tokens | 60 min |
+| 18 | `18_Semantic_Kernel_Plugins.ipynb` | Moteurs exposés en plugins Semantic Kernel (`@kernel_function`) composables via le kernel (pont série SemanticKernel) | 60 min |
 
 ## Prérequis
 
@@ -141,6 +155,8 @@ Le fil rouge de cette série est la progression de l'interaction basique avec un
 3. **Tier 3** (augmentation) : [5_RAG_Modern](5_RAG_Modern.ipynb) et [6_PDF_Web_Search](6_PDF_Web_Search.ipynb) enrichissent le LLM avec des sources externes. [7_Code_Interpreter](7_Code_Interpreter.ipynb) lui donne la capacité d'exécuter du code.
 
 4. **Tier 4** (production et local) : [8_Reasoning_Models](8_Reasoning_Models.ipynb) exploite les modèles raisonnants. [9_Production_Patterns](9_Production_Patterns.ipynb) couvre les patterns enterprise. [10_LocalLlama](10_LocalLlama.ipynb) et [11_Quantization](11_Quantization.ipynb) déploient en local avec vLLM.
+
+5. **Tier 5** (test-time scaling approfondi) : partant de [12_Test_Time_Scaling](12_Test_Time_Scaling.ipynb) (les quatre moteurs en Python pur), l'arc NB-13..18 décompose chaque facette de l'inférence au moment du test — orchestration agentique via function calling ([13](13_Agentic_Orchestration.ipynb)), mémoire persistante par similarité ([14](14_Persistent_Memory.ipynb)), Tree-of-Thoughts sur des problèmes de recherche ([15](15_Tree_of_Thoughts_Search.ipynb)), courbes de scaling de Snell ([16](16_Scaling_Test_Time_Compute.ipynb)), raisonnement natif vs scaling hand-rolled ([17](17_Native_Reasoning_vs_Scaling.ipynb)), puis intégration Semantic Kernel ([18](18_Semantic_Kernel_Plugins.ipynb)).
 
 ## Cross-series Bridges
 


### PR DESCRIPTION
## Summary

Sync du README Texte après la fermeture de l'epic **#2926** (test-time scaling). Le README etait stale : la prose disait **« 12 notebooks »** et la table de structure s'arretait a NB-12, alors que **NB-13..18 sont tous merged** sur `main` (#3084 NB-13, #3089 NB-14, #3092 NB-15, #3094 NB-16, #3096 NB-17, #3099 NB-18).

**Dispatch ai-01** (cycle coord 02:00Z) : « MAIN = ajouter les lignes NB-13..18 a la table de structure README Texte (**additif**, ne re-touche pas les diacritics fraichement posees) » — debloquee par le merge de #3097 (Texte README diacritics, po-2023).

### Changements (additifs, 17 insertions / 1 deletion)
1. **Compte** : « 12 notebooks » -> « 18 notebooks » (prose, ligne 16).
2. **« Ce que vous apprendrez »** : nouveau bullet sur l'arc test-time scaling (ICR).
3. **Nouvelle section « Tier 5 : Test-Time Scaling approfondi (ICR) »** : paragraphe d'intro + table 6 lignes (NB-13..18, descriptions informatives par concept, durations, ponts vers NB-04/05 et series Search/Sudoku/SemanticKernel).
4. **Recette** : point 5 qui parcourt l'arc Tier 5.

## Preuves (G.1)

```
MyIA.AI.Notebooks/GenAI/Texte/README.md | 18 +++++++++++++++++-
1 file changed, 17 insertions(+), 1 deletion(-)
```

- **L'unique deletion** = le compte « 12 » -> « 18 ». **Aucune prose accentuee existante n'est modifiee** (diacritics #3097 intacts — verifie via `git diff | grep '^- '`).
- **Catalogue NON touche** : `git diff` sur `*CATALOG*` / `*generated*` = vide. Le marqueur `CATALOG-STATUS` (`pedagogical_count`) est laisse au bot catalog-drift (regle catalog-pr-hygiene HARD 1) — il se regenerera a 18 sur `main`.
- **Parcours diagramme + table APIs laisses intacts** : le diagramme omettait deja NB-12 (pre-existing gap hors-scope) ; ne pas risquer de casser l'ASCII art ni empieter sur les diacritics adjacentes.
- **Markdownlint** : warnings MD032/MD060 pre-existing (les tables Tier 1-4 ont les memes MD060 ; la liste « Ce que vous apprendrez » suivait deja le `:` sans ligne vide). La table Tier 5 **reproduit le style existant** (tables single-line non-alignees) — pas de regression, pas de churn.

## Conformite
- **Markdown-only** (pas un notebook) : C.1/C.2/H.3 ne s'appliquent pas.
- **Anti-regression** : additif, ne supprime aucun contenu (seule la stale-count 12->18).
- **Secrets** : aucun.
- **Scope** : 1 fichier, 1 sujet (atomique, catalog-pr-hygiene HARD 3).
- **Fresh rebase** depuis `origin/main` (`597ef084`, inclut #3097 diacritics).

## Ponts pedagogiques documentes
NB-12 (moteurs) -> **NB-13..18** (arc ICR) -> series SemanticKernel / Search / Sudoku.

See #2926 (epic closed ; README sync post-merge).
