### PR TITLE
fix(ci): count Lean case-bullet · sorry in standalone-tactic gate + refresh Conway baseline (See #2747)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -18,7 +18,9 @@ name: Lean Build (reusable)
 # Sorry-filter modes (chosen per project's sorry "profile"):
 #   raw               : grep -c "sorry"                          (every mention)
 #   prose-header      : grep "sorry" | grep -viE "sorries|sorry.s"   (excludes prose plural/possessive)
-#   standalone-tactic : grep -cE "^\s*sorry\s*$"                  (only sorry as sole token on a line)
+#   standalone-tactic : sorry as the sole tactic token on a line, INCLUDING the
+#                       Lean case-bullet form `· sorry` (U+00B7), which a bare
+#                       `^\s*sorry\s*$` silently dropped (blind spot, See #2747)
 # Use raw only when sorry ALWAYS means tactic (no prose mentions). Use prose-header
 # when the only non-tactic mentions are "sorries"/"sorry's" in header comments.
 # Use standalone-tactic when there are MANY prose mentions of "sorry" mixed with
@@ -72,7 +74,13 @@ jobs:
               prose-header)
                 COUNT=$(grep "sorry" "$f" | grep -viE "sorries|sorry.s" | wc -l || true) ;;
               standalone-tactic)
-                COUNT=$(grep -cE "^\s*sorry\s*$" "$f" || true) ;;
+                # Count `sorry` as the sole tactic on a line, INCLUDING the
+                # Lean case-bullet form `· sorry` (U+00B7). The bare
+                # `^\s*sorry\s*$` regex MISSED it, so a bullet-sorry reported
+                # delta 0 and silently passed the anti-regression gate (blind
+                # spot, See #2747). Strip bullet bytes (c2 b7) first so BOTH
+                # forms match in any locale (byte-exact, not UTF-8 dependent).
+                COUNT=$(tr -d '\302\267' < "$f" | grep -cE "^\s*sorry\s*$" || true) ;;
               *)
                 echo "ERROR: unknown sorry-filter-mode '$MODE'"; exit 2 ;;
             esac

--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -8,15 +8,16 @@ name: Lean Conway CI
 # version in PR #2747 (same standalone-tactic mode, same baseline 8, now via the
 # shared lean-build.yml reusable workflow).
 #
-# Sorry profile (verified 2026-06-10, standalone-tactic mode, baseline=8):
-# conway has 8 real tactic sorries + many PROSE mentions in block comments
-# ("Each sorry is a target", "Left as sorry", "remain sorry-gated"). The
-# grothendieck prose-header filter OVERCOUNTS here (reads the prose), so we use
-# standalone-tactic (sorry as sole token on its line) to distinguish tactic vs
-# prose. Breakdown of the 8:
-#   - HashlifeCorrectness.lean: 2 (intractable P4/P5 — central correctness + main theorem)
-#   - HashlifeMemo.lean:        2 (scaffolding, Phase 3c)
-#   - Pillars.lean:             4 (scaffolding witnesses, Phase 3c)
+# Sorry profile (re-verified 2026-06-16, standalone-tactic mode, baseline=7):
+# conway has 7 real tactic sorries, ALL in HashlifeCorrectness.lean. The
+# standalone-tactic filter now also counts the Lean case-bullet form `· sorry`
+# (fixed in lean-build.yml, See #2747); the prior regex silently dropped it, so
+# CI reported 6 while the real count was 7 (1 unit of hidden slack). Prose
+# mentions ("Each sorry is a target", "Left as sorry", "remain sorry-gated")
+# are excluded by the sole-token check. Breakdown of the 7:
+#   - HashlifeCorrectness.lean: 7 (6 standalone P4/P5 + 1 case-bullet P5)
+#   - HashlifeMemo.lean:        0 (discharged since #2794, Phase 3c)
+#   - Pillars.lean:             0 (discharged since #2790, scaffolding witnesses)
 # Raising this baseline requires a documented justification in the PR body.
 
 on:
@@ -42,5 +43,5 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
       display-name: conway_lean
-      sorry-baseline: "8"
+      sorry-baseline: "7"
       sorry-filter-mode: standalone-tactic


### PR DESCRIPTION
## What

The shared `lean-build.yml` **standalone-tactic** sorry filter used `grep -cE "^\s*sorry\s*$"`, which matches only a line that is **solely** `sorry`. The Lean case-bullet form `· sorry` (U+00B7 bullet + sorry) does **not** match — so a PR adding a `· sorry` reported delta 0 and **silently passed** the anti-regression sorry-baseline gate.

Real example: `conway_lean/Conway/Life/HashlifeCorrectness.lean:1809` is `  · sorry` (a P5 case-bullet). CI counted it as 0.

## Fix

`lean-build.yml` — strip the bullet bytes (`c2 b7` = U+00B7) before the sole-token check, so **both** `sorry` and `· sorry` match, in any locale (byte-exact, not UTF-8 dependent):
```bash
COUNT=$(tr -d '\302\267' < "$f" | grep -cE "^\s*sorry\s*$" || true)
```
Stripping is safe for counting: only lines that reduce to exactly `sorry` (after whitespace) match, so a `·` appearing elsewhere cannot create a false sole-token line.

## Conway baseline re-verification (G.1 — the dispatch's "baseline=8 sous-évalué ?")

Answer: **no, baseline 8 was not under-counting — it had 1 unit of hidden slack.** Real sole-token count is **7**, not 8:

| file | old CI (missed bullet) | new CI | notes |
|------|---|---|---|
| HashlifeCorrectness.lean | 6 | **7** | 6 standalone P4/P5 + 1 case-bullet P5 |
| HashlifeMemo.lean | 0 | 0 | discharged #2794 |
| Pillars.lean | 0 | 0 | discharged #2790 |
| **total** | **6** | **7** | baseline was **8** → 1–2 slack |

The "8" was stale — set 2026-06-10 when HashlifeMemo (2) + Pillars (4) still carried sorries; both discharged while HashlifeCorrectness grew to 7. CI counted 6 (missed the bullet), so the gate had hidden slack. **Lowered baseline 8→7 (0 slack)** + refreshed the breakdown header. New count 7 ≤ 7 → PASS; any new sole-token sorry (standalone OR bullet) → FAIL, forcing a justified baseline bump (the intended anti-regression flow).

## Evidence — repo-wide audit (fix must not break other callers)

Only `HashlifeCorrectness.lean` carries a `· sorry`. Per standalone-tactic-mode project, old vs new count vs baseline:

| project | baseline | old | new | Δ | result |
|---------|---|---|---|---|---|
| conway | 7 | 6 | 7 | +1 | OK (catches bullet) |
| gittins | 3 | 3 | 3 | 0 | OK (no bullet) |
| conway-cgt, game-defs, game-defs-ext, mathlib-examples, sensitivity, social-choice-peters | 0 | 0 | 0 | 0 | OK |

Only conway's CI count changes (6→7). No other caller affected.

## Validation

- Reproduced CI semantics locally (`tr` byte-strip + `grep -cE`) on the exact `find` glob each workflow uses: conway 6→7, all others unchanged.
- Scope: 2 files (`lean-build.yml`, `lean-conway.yml`), no catalog/README/`.lean` churn.
- 0 proof attempts, 0 `.lean` change — pure CI anti-regression fix.

Dispatched by ai-01 (workspace-CoursIA 02:00Z): *"auditer les workflows lean-*.yml check-sorry pour l'angle mort `· sorry` ... re-verifier Conway #2747 baseline=8 (sous-evalue ?)"*.

See #2747