### PR TITLE
docs(genai): restore French diacritics in SemanticKernel README (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
@@ -9,17 +9,17 @@ maturity: PRODUCTION=12, BETA=3, TEMPLATE=3, ALPHA=2
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Text Generation](../Texte/README.md)
 
-Microsoft Semantic Kernel represente un tournant dans la maniere de construire des applications intelligentes. Ce SDK d'orchestration agentique connecte les LLMs aux outils, donnees et workflows de votre systeme. La reponse de Microsoft a l'ecosysteme LangChain, Semantic Kernel transforme des applications statiques en systemes autonomes capables de raisonnement, d'apprentissage et d'action.
+Microsoft Semantic Kernel représente un tournant dans la manière de construire des applications intelligentes. Ce SDK d'orchestration agentique connecte les LLMs aux outils, données et workflows de votre système. La réponse de Microsoft à l'écosystème LangChain, Semantic Kernel transforme des applications statiques en systèmes autonomes capables de raisonnement, d'apprentissage et d'action.
 
-Cette serie pedagogique vous guidera a travers la transition entre le prompt engineering simple et la construction de systemes multi-agents sophistiques, ou chaque composant travaille de concert pour resoudre des problemes d'une complexite croissante.
+Cette série pédagogique vous guidera à travers la transition entre le prompt engineering simple et la construction de systèmes multi-agents sophistiqués, où chaque composant travaille de concert pour résoudre des problèmes d'une complexité croissante.
 
-**Fil rouge** : le NotebookMaker, un systeme a 3 agents (Admin, Coder, Reviewer) qui genere automatiquement des notebooks pedagogiques. Ce demonstrateur incarne l'essence meme de Semantic Kernel : orchestrer des agents specialises pour resoudre des problemes complexes.
+**Fil rouge** : le NotebookMaker, un système à 3 agents (Admin, Coder, Reviewer) qui génère automatiquement des notebooks pédagogiques. Ce démonstrateur incarne l'essence même de Semantic Kernel : orchestrer des agents spécialisés pour résoudre des problèmes complexes.
 
-## Serie principale (Python)
+## Série principale (Python)
 
-Parcours pedagogique complet sur Semantic Kernel en Python :
+Parcours pédagogique complet sur Semantic Kernel en Python :
 
-| # | Notebook | Contenu | Duree |
+| # | Notebook | Contenu | Durée |
 |---|----------|---------|-------|
 | 01 | [SK-1-Fundamentals](01-SemanticKernel-Intro.ipynb) | Kernel, Services, Plugins, Chat | 45 min |
 | 02 | [SK-2-Functions](02-SemanticKernel-Advanced.ipynb) | Function Calling moderne, Memory, Groundedness | 50 min |
@@ -28,16 +28,16 @@ Parcours pedagogique complet sur Semantic Kernel en Python :
 | 05 | [SK-5-VectorStores](05-SemanticKernel-VectorStores.ipynb) | RAG, Embeddings, Qdrant | 50 min |
 | 06 | [SK-6-ProcessFramework](06-SemanticKernel-ProcessFramework.ipynb) | Workflows, Orchestration, State | 40 min |
 | 07 | [SK-7-MultiModal](07-SemanticKernel-MultiModal.ipynb) | DALL-E, Whisper, GPT-4 Vision | 45 min |
-| 08 | [SK-8-MCP](08-SemanticKernel-MCP.ipynb) | Model Context Protocol, Interoperabilite | 45 min |
+| 08 | [SK-8-MCP](08-SemanticKernel-MCP.ipynb) | Model Context Protocol, Interopérabilité | 45 min |
 
-## Notebooks avances (Python/C# Interop)
+## Notebooks avancés (Python/C# Interop)
 
-| # | Notebook | Description | Duree |
+| # | Notebook | Description | Durée |
 |---|----------|-------------|-------|
 | 09 | [SK-9-Building-CLR](09-SemanticKernel-Building-CLR.ipynb) | Interop Python/C# via pythonnet, chargement DLL .NET | 40 min |
-| 10 | [SK-10-NotebookMaker](10-SemanticKernel-NotebookMaker.ipynb) | **Systeme 3-agents** (Admin, Coder, Reviewer) pour generation de notebooks | 60 min |
+| 10 | [SK-10-NotebookMaker](10-SemanticKernel-NotebookMaker.ipynb) | **Système 3-agents** (Admin, Coder, Reviewer) pour génération de notebooks | 60 min |
 | 10a | [SK-10a-NotebookMaker-batch](10a-SemanticKernel-NotebookMaker-batch.ipynb) | Version batch sans UI interactive | 30 min |
-| 10b | [SK-10b-NotebookMaker-batch-param](10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb) | Version parametrisee pour Papermill | 30 min |
+| 10b | [SK-10b-NotebookMaker-batch-param](10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb) | Version paramétrisée pour Papermill | 30 min |
 
 ## Templates
 
@@ -47,7 +47,7 @@ Parcours pedagogique complet sur Semantic Kernel en Python :
 | [Workbook-Template](Workbook-Template.ipynb) | Template workbook C# |
 | [Workbook-Template-Python](Workbook-Template-Python.ipynb) | Template Python |
 
-## Concepts cles
+## Concepts clés
 
 | Concept | Description | Notebook |
 |---------|-------------|----------|
@@ -55,22 +55,22 @@ Parcours pedagogique complet sur Semantic Kernel en Python :
 | **Services** | Connexions LLM (OpenAI, Azure) | 01 |
 | **Plugins** | Collections de fonctions | 01, 02 |
 | **Function Calling** | `FunctionChoiceBehavior.Auto()` | 02 |
-| **Agents** | Entites autonomes | 03 |
+| **Agents** | Entités autonomes | 03 |
 | **AgentGroupChat** | Collaboration multi-agents | 03, 10 |
-| **Filters** | Interception avant/apres | 04 |
+| **Filters** | Interception avant/après | 04 |
 | **Vector Stores** | RAG, embeddings | 05 |
-| **Process Framework** | Workflows orchestres | 06 |
+| **Process Framework** | Workflows orchestrés | 06 |
 | **Multi-Modal** | Images, audio, vision | 07 |
-| **MCP** | Interoperabilite des outils | 08 |
+| **MCP** | Interopérabilité des outils | 08 |
 | **pythonnet/CLR** | Interop Python/.NET | 09 |
-| **NotebookState** | Gestion etat notebook | 10 |
+| **NotebookState** | Gestion état notebook | 10 |
 | **SelectionStrategy** | Choix agent dynamique | 10 |
 
-## Parcours recommande
+## Parcours recommandé
 
 ```text
 ┌─────────────────────────────────────────────────────────────────────┐
-│                     SERIE PRINCIPALE (Python)                       │
+│                     SÉRIE PRINCIPALE (Python)                       │
 ├─────────────────────────────────────────────────────────────────────┤
 │                                                                     │
 │  01-Fundamentals ───> 02-Functions ───> 03-Agents                   │
@@ -84,33 +84,33 @@ Parcours pedagogique complet sur Semantic Kernel en Python :
 │        └──────────> 08-MCP <─┘               │                      │
 │                                              │                      │
 ├─────────────────────────────────────────────────────────────────────┤
-│                     SERIE AVANCEE (Interop)                         │
+│                     SÉRIE AVANCÉE (Interop)                         │
 ├─────────────────────────────────────────────────────────────────────┤
 │                                              │                      │
 │                                              v                      │
 │  09-Building-CLR ─────────────────> 10-NotebookMaker                │
-│  (Python/C# Interop)                (Agents generateurs)            │
+│  (Python/C# Interop)                (Agents générateurs)            │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-## Prerequisites
+## Prérequis
 
 ### Python
 
 ```bash
-# Environnement recommande
+# Environnement recommandé
 python -m venv venv
 source venv/bin/activate  # Linux/macOS
 venv\Scripts\activate     # Windows
 
-# Dependances
+# Dépendances
 pip install semantic-kernel python-dotenv openai qdrant-client
 ```
 
 ### Configuration
 
-Creer un fichier `.env` dans le repertoire :
+Créer un fichier `.env` dans le répertoire :
 
 ```bash
 OPENAI_API_KEY=sk-...
@@ -131,7 +131,7 @@ AZURE_OPENAI_API_KEY=...
 # .NET SDK 9.0+ requis
 dotnet --version
 
-# Packages (references dans notebooks)
+# Packages (références dans notebooks)
 # - Microsoft.SemanticKernel
 # - Microsoft.SemanticKernel.Agents.Core
 ```
@@ -143,98 +143,98 @@ dotnet --version
 - [SK Blog](https://devblogs.microsoft.com/semantic-kernel/)
 - [MCP Specification](https://modelcontextprotocol.io/)
 
-## Recette : construire le NotebookMaker (systeme 3 agents)
+## Recette : construire le NotebookMaker (système 3 agents)
 
-Le fil rouge de cette serie est le NotebookMaker, un systeme multi-agents qui genere automatiquement des notebooks pedagogiques. Voici comment les notebooks s'articulent :
+Le fil rouge de cette série est le NotebookMaker, un système multi-agents qui génère automatiquement des notebooks pédagogiques. Voici comment les notebooks s'articulent :
 
-1. **Fondations (01-03)** : [01](01-SemanticKernel-Intro.ipynb) cree un Kernel et connecte un LLM. [02](02-SemanticKernel-Advanced.ipynb) ajoute le function calling et la memoire. [03](03-SemanticKernel-Agents.ipynb) introduit les agents autonomes et la collaboration via AgentGroupChat.
+1. **Fondations (01-03)** : [01](01-SemanticKernel-Intro.ipynb) crée un Kernel et connecte un LLM. [02](02-SemanticKernel-Advanced.ipynb) ajoute le function calling et la mémoire. [03](03-SemanticKernel-Agents.ipynb) introduit les agents autonomes et la collaboration via AgentGroupChat.
 
-2. **Observabilite et donnees (04-06)** : [04](04-SemanticKernel-Filters-Observability.ipynb) intercepte et log les appels. [05](05-SemanticKernel-VectorStores.ipynb) connecte une base vectorielle (RAG). [06](06-SemanticKernel-ProcessFramework.ipynb) orchestre des workflows avec etat.
+2. **Observabilité et données (04-06)** : [04](04-SemanticKernel-Filters-Observability.ipynb) intercepte et log les appels. [05](05-SemanticKernel-VectorStores.ipynb) connecte une base vectorielle (RAG). [06](06-SemanticKernel-ProcessFramework.ipynb) orchestre des workflows avec état.
 
-3. **Extensions (07-08)** : [07](07-SemanticKernel-MultiModal.ipynb) ajoute les capacites multimodales (images, audio). [08](08-SemanticKernel-MCP.ipynb) connecte le Kernel au protocole MCP pour l'interopabilite.
+3. **Extensions (07-08)** : [07](07-SemanticKernel-MultiModal.ipynb) ajoute les capacités multimodales (images, audio). [08](08-SemanticKernel-MCP.ipynb) connecte le Kernel au protocole MCP pour l'interopérabilité.
 
-4. **NotebookMaker (09-10)** : [09](09-SemanticKernel-Building-CLR.ipynb) prepare l'interop Python/C#. [10](10-SemanticKernel-NotebookMaker.ipynb) assemble le systeme 3 agents (Admin, Coder, Reviewer). Les versions [10a](10a-SemanticKernel-NotebookMaker-batch.ipynb) et [10b](10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb) ajoutent le mode batch et la parametrisation Papermill.
+4. **NotebookMaker (09-10)** : [09](09-SemanticKernel-Building-CLR.ipynb) prépare l'interop Python/C#. [10](10-SemanticKernel-NotebookMaker.ipynb) assemble le système 3 agents (Admin, Coder, Reviewer). Les versions [10a](10a-SemanticKernel-NotebookMaker-batch.ipynb) et [10b](10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb) ajoutent le mode batch et la paramétrisation Papermill.
 
 ## Cross-series Bridges
 
-| Serie | Lien | Connection |
-|-------|------|-------------|
-| [GenAI/Texte](../Texte/README.md) | LLMs et APIs | Les notebooks Texte couvrent les memes modeles (OpenAI, Anthropic) que SemanticKernel les orchestre en agents |
-| [GenAI/Image](../Image/README.md) | Generation d'images | Le notebook 07-MultiModal utilise la generation d'images DALL-E via le Kernel SK |
-| [GenAI/Audio](../Audio/README.md) | Speech et TTS | Le notebook 07-MultiModal integre aussi le TTS (text-to-speech) via le Kernel |
-| [ML](../../ML/README.md) | Pipelines ML | Le NotebookMaker (10) genere des notebooks ML automatiquement, la validation croisee ML-4 evalue les modeles produits |
-| [QuantConnect](../../QuantConnect/README.md) | Trading algorithmique | Les agents SK peuvent etre connectes a des sources de donnees financieres via MCP (08) pour des signaux de trading LLM-augmentes |
-| [Vibe-Coding](../Vibe-Coding/README.md) | Developpement avec agents | Les patterns d'orchestration multi-agents du NotebookMaker (10) s'appliquent aux workflows Vibe-Coding |
+| Série | Lien | Connection |
+|-------|------|------------|
+| [GenAI/Texte](../Texte/README.md) | LLMs et APIs | Les notebooks Texte couvrent les mêmes modèles (OpenAI, Anthropic) que SemanticKernel les orchestre en agents |
+| [GenAI/Image](../Image/README.md) | Génération d'images | Le notebook 07-MultiModal utilise la génération d'images DALL-E via le Kernel SK |
+| [GenAI/Audio](../Audio/README.md) | Speech et TTS | Le notebook 07-MultiModal intègre aussi le TTS (text-to-speech) via le Kernel |
+| [ML](../../ML/README.md) | Pipelines ML | Le NotebookMaker (10) génère des notebooks ML automatiquement, la validation croisée ML-4 évalue les modèles produits |
+| [QuantConnect](../../QuantConnect/README.md) | Trading algorithmique | Les agents SK peuvent être connectés à des sources de données financières via MCP (08) pour des signaux de trading LLM-augmentés |
+| [Vibe-Coding](../Vibe-Coding/README.md) | Développement avec agents | Les patterns d'orchestration multi-agents du NotebookMaker (10) s'appliquent aux workflows Vibe-Coding |
 
 ## Changelog
 
-### Fevrier 2026
+### Février 2026
 
-- Reorganisation de la serie complete (01-10)
-- Renumerotation notebooks avances : 09-Building-CLR, 10-NotebookMaker
-- Verification et validation de tous les notebooks (100% execution)
-- Mise a jour README avec parcours recommande ameliore
+- Réorganisation de la série complète (01-10)
+- Renumérotation notebooks avancés : 09-Building-CLR, 10-NotebookMaker
+- Vérification et validation de tous les notebooks (100% exécution)
+- Mise à jour README avec parcours recommandé amélioré
 
 ### Janvier 2026
 
-- Modernisation complete de la serie Python (8 notebooks)
+- Modernisation complète de la série Python (8 notebooks)
 - Ajout notebooks 04-08 (Filters, VectorStores, Process, MultiModal, MCP)
-- Remplacement des Planners deprecies par `FunctionChoiceBehavior.Auto()`
-- Ajout interpretations pedagogiques style GameTheory
-- Integration Qdrant pour Vector Stores
+- Remplacement des Planners dépréciés par `FunctionChoiceBehavior.Auto()`
+- Ajout interprétations pédagogiques style GameTheory
+- Intégration Qdrant pour Vector Stores
 
 ## FAQ
 
-### `semantic-kernel` installe mais `ImportError` au premier notebook
+### `semantic-kernel` installé mais `ImportError` au premier notebook
 
-Semantic Kernel evolue rapidement et les versions sont parfois incompatibles entre elles. Si `ImportError: cannot import name 'Kernel'` ou similaire :
+Semantic Kernel évolue rapidement et les versions sont parfois incompatibles entre elles. Si `ImportError: cannot import name 'Kernel'` ou similaire :
 
 ```bash
-# Verifier la version installee
+# Vérifier la version installée
 pip show semantic-kernel
 
-# Installer la version testee avec les notebooks
+# Installer la version testée avec les notebooks
 pip install semantic-kernel>=1.30.0 python-dotenv openai
 ```
 
-Les notebooks 01-03 utilisent les APIs stables (`Kernel`, `ChatCompletionAgent`, `AgentGroupChat`). Les APIs depreciees (`Planner`, `SKContext`) ont ete remplacees par `FunctionChoiceBehavior.Auto()` depuis janvier 2026. Si votre code utilise encore `Planner`, consulter le notebook [02](02-SemanticKernel-Advanced.ipynb) pour la migration.
+Les notebooks 01-03 utilisent les APIs stables (`Kernel`, `ChatCompletionAgent`, `AgentGroupChat`). Les APIs dépréciées (`Planner`, `SKContext`) ont été remplacées par `FunctionChoiceBehavior.Auto()` depuis janvier 2026. Si votre code utilise encore `Planner`, consulter le notebook [02](02-SemanticKernel-Advanced.ipynb) pour la migration.
 
-### Le NotebookMaker genere des notebooks vides ou incomplets
+### Le NotebookMaker génère des notebooks vides ou incomplets
 
-Le NotebookMaker (notebook [10](10-SemanticKernel-NotebookMaker.ipynb)) orchestre 3 agents (Admin, Coder, Reviewer) pour generer un notebook. Si le resultat est vide ou incomplet :
+Le NotebookMaker (notebook [10](10-SemanticKernel-NotebookMaker.ipynb)) orchestre 3 agents (Admin, Coder, Reviewer) pour générer un notebook. Si le résultat est vide ou incomplet :
 
-- Verifier que le model LLM configure supporte le function calling (`gpt-4o-mini` minimum, `gpt-4o` recommande).
-- Le systeme necessite 3 a 5 iterations agentiques pour converger. Les versions batch ([10a](10a-SemanticKernel-NotebookMaker-batch.ipynb)) et parametrisee ([10b](10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb)) offrent plus de controle sur le nombre de tours.
-- Les filtres d'observabilite (notebook [04](04-SemanticKernel-Filters-Observability.ipynb)) permettent de tracer chaque echange agentique et diagnostiquer les blocages.
+- Vérifier que le modèle LLM configuré supporte le function calling (`gpt-4o-mini` minimum, `gpt-4o` recommandé).
+- Le système nécessite 3 à 5 itérations agentiques pour converger. Les versions batch ([10a](10a-SemanticKernel-NotebookMaker-batch.ipynb)) et paramétrisée ([10b](10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb)) offrent plus de contrôle sur le nombre de tours.
+- Les filtres d'observabilité (notebook [04](04-SemanticKernel-Filters-Observability.ipynb)) permettent de tracer chaque échange agentique et diagnostiquer les blocages.
 
-### Quelle difference entre Semantic Kernel et LangChain ?
+### Quelle différence entre Semantic Kernel et LangChain ?
 
-| Critere | Semantic Kernel | LangChain |
+| Critère | Semantic Kernel | LangChain |
 |---------|----------------|-----------|
-| **Editeur** | Microsoft | Communautaire |
+| **Éditeur** | Microsoft | Communautaire |
 | **Langues** | Python + C# | Python + JS/TS |
 | **Approche** | Plugins et Kernel central | Chains et LCEL |
 | **Agents** | `ChatCompletionAgent` + `AgentGroupChat` | `AgentExecutor` |
 | **RAG** | VectorStores natifs | Retrievers + VectorStores |
 | **Interop .NET** | Natif (pythonnet/CLR) | Non |
-| **Maturite entreprise** | Integre Azure | Ecosysteme large |
+| **Maturité entreprise** | Intègre Azure | Écosystème large |
 
-Si vous travaillez dans l'ecosysteme Microsoft (Azure, .NET, Teams), Semantic Kernel est le choix naturel. Pour un ecosysteme Python pur ou du prototypage rapide, LangChain offre plus de flexibilite.
+Si vous travaillez dans l'écosystème Microsoft (Azure, .NET, Teams), Semantic Kernel est le choix naturel. Pour un écosystème Python pur ou du prototypage rapide, LangChain offre plus de flexibilité.
 
 ### Les agents SK bouclent sans converger
 
-L'`AgentGroupChat` (notebook [03](03-SemanticKernel-Agents.ipynb)) peut entrer en boucle infinie si la `SelectionStrategy` ne definit pas de condition de terminaison claire. Mitigation :
+L'`AgentGroupChat` (notebook [03](03-SemanticKernel-Agents.ipynb)) peut entrer en boucle infinie si la `SelectionStrategy` ne définit pas de condition de terminaison claire. Mitigation :
 
-- Utiliser une `TerminationStrategy` explicite (nombre max de tours, mot-cle de fin).
+- Utiliser une `TerminationStrategy` explicite (nombre max de tours, mot-clé de fin).
 - Limiter `maximum_iterations` dans la configuration du chat.
-- La `SelectionStrategy` par defaut est round-robin — pour des agents specialises, implementer une strategie basee sur le contexte (voir NotebookMaker notebook [10](10-SemanticKernel-NotebookMaker.ipynb)).
+- La `SelectionStrategy` par défaut est round-robin — pour des agents spécialisés, implémenter une stratégie basée sur le contexte (voir NotebookMaker notebook [10](10-SemanticKernel-NotebookMaker.ipynb)).
 
 ### VectorStores / RAG : Qdrant injoignable
 
 Le notebook [05](05-SemanticKernel-VectorStores.ipynb) utilise Qdrant pour le RAG. Si erreur de connexion :
 
 ```bash
-# Verifier que Qdrant est actif
+# Vérifier que Qdrant est actif
 curl http://localhost:6333/collections
 
 # Ou utiliser l'instance cloud
@@ -242,11 +242,11 @@ QDRANT_URL=https://qdrant.myia.io
 QDRANT_API_KEY=votre-cle
 ```
 
-Le notebook fonctionne en mode demo avec un magasin en memoire si Qdrant n'est pas disponible. Pour la production, Qdrant (ou un autre store persistant) est recommande.
+Le notebook fonctionne en mode démo avec un magasin en mémoire si Qdrant n'est pas disponible. Pour la production, Qdrant (ou un autre store persistant) est recommandé.
 
-### Comment utiliser les filtres pour deboguer les appels LLM ?
+### Comment utiliser les filtres pour déboguer les appels LLM ?
 
-Les filtres SK (notebook [04](04-SemanticKernel-Filters-Observability.ipynb)) interceptent chaque appel LLM avant et apres execution. Pour le debug :
+Les filtres SK (notebook [04](04-SemanticKernel-Filters-Observability.ipynb)) interceptent chaque appel LLM avant et après exécution. Pour le debug :
 
 ```python
 from semantic_kernel.filters import FilterTypes
@@ -259,7 +259,7 @@ async def log_filter(context, next):
     print(f"Resultat: {context.result}")
 ```
 
-Ce pattern est essentielle pour comprendre ce que font les agents dans un systeme multi-agents comme le NotebookMaker.
+Ce pattern est essentiel pour comprendre ce que font les agents dans un système multi-agents comme le NotebookMaker.
 
 ## Licence
 


### PR DESCRIPTION
## Contexte

Dernier README series-level GenAI du trickle #2876 (accents README rolling epic). Methode content-based + review mot-a-mot, meme protocole que Image (#3093), Texte (#3097) et FineTuning (#3101) deja merged.

## Changements

Restauration des diacritiques francais sur toute la prose : introductions, objectifs, tables de concepts, recette, changelog (Fevrier/Janvier 2026), FAQ. Aussi les commentaires francais dans les blocs de code bash/python.

### Preuves de preservation (G.1, verifie contre origin/main)

| Element | origin/main | working |
|---------|-------------|---------|
| Liens `.ipynb` | 36 | **36** (identique) |
| CATALOG-STATUS marker | — | **byte-identical** |
| URLs de reference | 4 | **4 intactes** |
| Lignes totales | 266 | **266** |
| Structure diagramme ASCII | — | **byte-identique** (3 mots FR accentues, char-count preserve) |

### Diff du diagramme (les SEULES 3 lignes changees dans le bloc ASCII)
```
< │   SERIE PRINCIPALE (Python)   │      ->  SERIE PRINCIPALE
< │   SERIE AVANCEE (Interop)     │      ->  SERIE AVANCEE
< │   (Agents generateurs)        │      ->  (Agents generateurs)
```
L'asymetrie originale (section PRINCIPALE a une ligne box-vide, AVANCEE non) est preservee.

### Termes techniques NON touche (0 anglicisme/presque sur-accentue)
Semantic Kernel, Papermill, pythonnet, MCP, DALL-E, Whisper, Kernel/Plugins/Agents/Services (vocabulaire SK), gpt-4o-mini, gpt-4o, Qdrant, AgentGroupChat, FunctionChoiceBehavior, TerminationStrategy, SelectionStrategy, FilterTypes, Microsoft.SemanticKernel.*

### 2 corrections non-diacritiques spottees en review mot-a-mot
1. **Anglicisme** : heading `## Prerequisites` -> `## Prerequis` (convention sibling Image README, aucun lien interne ne pointait sur l'ancre).
2. **Accord grammatical** : `Ce pattern est essentielle` -> `essentiel` (pattern = masculin).

## Conformite

- **Markdown-only** : C.1/C.2/H.3 n/a (pas de notebook).
- **Catalogue NON touche** : CATALOG-STATUS laisse au bot catalog-drift (HARD 1).
- **Atomique** : 1 fichier, 1 sujet (See #2876 contribution partielle a l'epic).
- **Fresh base** : rebase sur origin/main `597ef084`.
- **Diff balance** : 72 ins / 72 del (prose-only, pas de churn structurel).

See #2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)