### PR TITLE
docs(search): sync README structure tree to filesystem (Part4 + MGS-Notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -389,12 +389,10 @@ Search/
 │       └── App-18-HyperparameterTuning.ipynb
 │
 ├── MetaGeneticSharp/                      # Sous-module : metaheuristiques composables sur GeneticSharp (jsboige/MetaGeneticSharp)
-│
-├── Foundations/                           # (deprecated) Ancien repertoire
-│   └── README.md
+├── MetaGeneticSharp-Notebooks/            # Notebooks pedagogiques MGS-1..8 (.NET Interactive, consomment le sous-module)
+├── Part4-Metaheuristics/                  # Entree Partie 4 (side track C# .NET 9 ; README d'orientation vers les notebooks MGS)
 │
 ├── CSPs_Intro.ipynb                       # Ancien notebook (conserve)
-├── Exploration_non_informee_*.ipynb       # Anciens notebooks (conerves)
 ├── GeneticSharp-EdgeDetection.ipynb       # Ancien notebook (conserve)
 ├── Portfolio_Optimization_GeneticSharp.ipynb # Ancien notebook (conserve)
 └── PyGad-EdgeDetection.ipynb              # Ancien notebook (conserve)


### PR DESCRIPTION
## What

The Search parent README's **"Structure des fichiers"** tree lagged behind the repo. It listed only the `MetaGeneticSharp/` submodule but omitted the two sibling directories added by epic #1203, and still referenced a removed directory + a glob matching nothing.

Same **"epic complete → README stale"** pattern already applied this cycle to MGS (#3103), GameTheory (#3109), and the Lean series (Grothendieck #3098, Conway #3102, Knot #3107, finiteness #3111).

## Changes (grounded against `git`, origin/main @ `e87f6a9b`)

| Action | Entry | Evidence |
|--------|-------|----------|
| **ADD** | `MetaGeneticSharp-Notebooks/` | `git ls-tree -d` confirms real, tracked; holds MGS-1..8 notebooks |
| **ADD** | `Part4-Metaheuristics/` | `git ls-tree -d` confirms real; Part 4 entry README (85 lines) |
| **DROP** | `Foundations/` block (deprecated) | `git ls-tree -d` shows **no** such dir (only `Part1-Foundations/` exists) |
| **DROP** | `Exploration_non_informee_*.ipynb` | `git ls-files` glob matches **0** files |

Kept verbatim: the `MetaGeneticSharp/` submodule line + the 4 legacy root notebooks that **do** exist (`CSPs_Intro`, `GeneticSharp-EdgeDetection`, `Portfolio_Optimization_GeneticSharp`, `PyGad-EdgeDetection` — all tracked).

## Verification

- Docs-only, 1 file, `+2/-4` (inside one code-fence block).
- **Catalogue byte-identical** (not in diff); **submodule byte-identical** (gitlink untouched).
- Tree connectors well-formed after edit (one separator between the MGS cluster and the legacy notebooks; last entry `└──`).
- No `.ipynb` touched → no Papermill/re-exec needed.

## Scope

Single section ("Structure des fichiers"), single defect type (tree out of sync with filesystem), atomic. The sibling Sudoku README was audited in the same pass and is **clean** (32 tracked notebooks == 32 in README tree == catalogue 32), so no PR there.

See #2651

cc @jsboige (ai-01 merge — worker does not self-merge CoursIA PRs)