### PR TITLE
docs(qc): verify ML-XGBoost post-#2801 (catalog 0.57 -> 0.555, robuste near-immune -3%) (See #1630)

### DIFF
--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -58,7 +58,7 @@ Strategies with solid risk-adjusted returns. These are the primary candidates fo
 | 24 | Crypto-MultiCanal | IND | Crypto (BTC) | ~~0.58~~ → **0.33** ✓post-#2801 | 4.6 | 14.1 | 0.33 | **historique** (downgraded -43%, crypto indicator NOT robust post-fees, PSR 13.0%) |
 | 25 | ML-FeatureEngineering | ML | Equities (10 mega-caps) | ~~0.57~~ → **0.65** ✓post-#2801 | 18.7 | 28.1 | 0.67 | robuste (catalog CORRECTED UPWARD +15% — was stale; real Sharpe of current RF+GB 18-feature ensemble near-immune on fee-homogeneous US equity; PSR 15.1% low, not a true leader; universe corrected Multi-asset→Equities; baseline-clone 32952140) |
 | 26 | Markov-Regime-Detection | ML | Equities | 0.57 | — | — | — | robuste |
-| 27 | ML-XGBoost | ML | Multi-asset | 0.57 | 14.8 | — | — | robuste |
+| 27 | ML-XGBoost | ML | Equities (15 mega-caps) | ~~0.57~~ → **0.555** ✓post-#2801 | 14.5 | 40.4 | 0.36 | robuste (confirmed mild -3%, bi-weekly GradientBoostingRegressor on fee-homogeneous 15 mega-caps = near-immune; PSR 10.6% low, not a true leader; universe corrected Multi-asset→Equities) |
 | 28 | MomentumStrategy | IND | Equities | ~~0.57~~ → **0.50** ✓post-#2801 | 11.2 | 25.8 | 0.43 | robuste borderline (at threshold -12%, PSR 9.3% non-significant) |
 | 28b | MeanReversion | IND | Equities (sectors) | ~~0.81~~ → **0.81** ✓post-#2801 | 10.0 | 7.5 | 1.34 | robuste (confirmed, PSR 46.8% near-significant, low-turnover multi-asset holds = signal-frequency immunity) |
 | 29 | RegimeSwitching | ML | Equities/ETF | 0.55 | 11.7 | — | — | robuste |
@@ -110,8 +110,9 @@ brokerage = the #2801 Lot 1 remediation). Results vs the pre-remediation catalog
 | ML-Trend-Scanning | 29808859 | 0.66 | **0.33** | -50% | **historique** (was robuste — daily-rebalance SPY/TLT/GLD multi-asset crushed by real fees, PSR 7.8%) |
 | TrendStocksLite | 28817425 | 0.72 | **0.71** | -2% | robuste (confirmed — weekly trend on 15 liquid large-caps, low realized turnover, near-immune, PSR 25.0%) |
 | ML-RandomForest | 29434751 | 0.68 | **0.70** | +3% | robuste (confirmed — bi-weekly RF on 10 mega-caps, moderate turnover near-immune on fee-homogeneous US equity, PSR 18.4%, baseline-clone 32940005) |
+| ML-XGBoost | 29434753 | 0.57 | **0.555** | -3% | robuste (confirmed flat-to-mildly-down, NOT an upward correction — bi-weekly GradientBoostingRegressor on fee-homogeneous 15 mega-caps = near-immune; PSR 10.6% low, not a true leader; universe corrected Multi-asset→Equities; baseline-clone 32958201) |
 
-**Finding (methodological, now 27-strategy sample)** : the remediation impact is **not
+**Finding (methodological, now 28-strategy sample)** : the remediation impact is **not
 uniform**, and the batch-4 results *refine and partly correct* the earlier 10-strategy pattern.
 The distinguishing axis is **not** asset class, nor ML-vs-indicator alone — it is the
 combination of (a) the fee-per-trade the asset class carries and (b) how the strategy turns


### PR DESCRIPTION
## Summary

Post-#2801 verification of **ML-XGBoost** (project `29434753`) — catalog-only atomic PR for the #1630 campaign.

The original `main.py` carried **no brokerage model**, so this was verified via a **baseline-clone** (`32958201`) with `set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)` injected after `set_cash`.

## Backtest evidence

- Project: `32958201` (clone of `29434753`) · Compile `7b868194...` **BuildSuccess** (0 err)
- Backtest `6179c32186373fc5ef9df30876e51244` · 2015-2026, 2879 tradeable dates, **Completed**
- **Sharpe 0.555** · CAGR 14.511% · MaxDD 40.4% · **PSR 10.655%**
- (`totalOrders=0` from the MCP wrapper is a known phantom parse bug — CAGR 14.5% is impossible without trades; source of truth = QC Cloud UI.)

## Classification

- Catalog `0.57` → real **0.555** = **-3% delta** (near-immune robuste, as predicted for a bi-weekly fee-homogeneous 15-mega-cap US equity basket).
- **NOT an upward correction** (unlike BlackLitterman +38%, ML-FeatureEngineering +15%) — this one is flat-to-mildly-down; the catalog 0.57 was essentially correct.
- PSR 10.6% low → **robuste but not a true leader**.
- **Universe correction**: catalog "Multi-asset" → **Equities (15 mega-caps)** — same mislabel found previously on ML-FeatureEngineering.

## Pattern

Bi-weekly/monthly fee-homogeneous US-equity ML basket = near-immune robuste regardless of ML complexity (RF +3%, GradientBoosting -3%, BL optimizer +38% stale-corrected). ML-Trend-Scanning (daily multi-asset) remains the only ML that collapses under real fees.

## Catalog edits

- Tier-1 row 27 (Sharpe + universe correction + MaxDD/Calmar filled)
- Secondary table row (ML-XGBoost, project 29434753, baseline-clone 32958201)
- Finding count 27 → 28

Partial delivery to the #1630 epic — `See #1630` (not `Closes`).

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
