### PR TITLE
fix(arg-analysis): 4-capstone stub-cell outputs (C.2, See #2137)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-4-capstone.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-4-capstone.ipynb
@@ -970,14 +970,21 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "Exercice 1 a completer : definir vg5_convergence_floor et evaluer sur baseline + pipeline\n"
+    }
+   ],
    "source": [
     "# Exercice 1 -- a completer\n",
     "# TODO etudiant : definir vg5_convergence_floor et l'evaluer sur baseline + pipeline.\n",
     "# Indice : la baseline n'a pas de verdicts ; le pipeline a `convergent_verdicts`.\n",
     "# Etape 1 : ecrire la fonction prenant (synthesis_md, populated_fields, verdicts).\n",
     "# Etape 2 : l'appliquer aux deux syntheses.\n",
-    "pass\n"
+    "pass\n",
+    "print(\"Exercice 1 a completer : definir vg5_convergence_floor et evaluer sur baseline + pipeline\")"
    ]
   },
   {
@@ -1019,14 +1026,21 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "Exercice 2 a completer : ecrire diagnose_failures(vg_result) -> List[str]\n"
+    }
+   ],
    "source": [
     "# Exercice 2 -- a completer\n",
     "# TODO etudiant : ecrire diagnose_failures(vg_result) -> List[str].\n",
     "# Indice : chaque gate porte dans vg_result les compteurs (citations, words, required_citations, fields...).\n",
     "# Etape 1 : iterer sur vg1..vg4.\n",
     "# Etape 2 : pour chaque gate not pass, formater un message utilisant ses compteurs.\n",
-    "result = None  # TODO etudiant\n"
+    "result = None  # TODO etudiant\n",
+    "print(\"Exercice 2 a completer : ecrire diagnose_failures(vg_result) -> List[str]\")"
    ]
   },
   {
@@ -1068,14 +1082,21 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "Exercice 3 a completer : construire adversarial_synth (citations d'un seul champ)\n"
+    }
+   ],
    "source": [
     "# Exercice 3 -- a completer\n",
     "# TODO etudiant : construire adversarial_synth qui bourre des citations d'UN seul champ.\n",
     "# Indice : VG-1 compte les citations brutes, VG-4 exige >= 2 champs DISTINCTS par paragraphe.\n",
     "# Etape 1 : ecrire la synthese avec beaucoup de [artifact:arguments:N] mais jamais 2 champs differents.\n",
     "# Etape 2 : la soumettre a validate_value_gates et observer.\n",
-    "pass\n"
+    "pass\n",
+    "print(\"Exercice 3 a completer : construire adversarial_synth (citations d'un seul champ)\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Zero-cost **C.2 fix** for `Argument_Analysis_Agentic-4-capstone.ipynb` (#2137 Argument analysis series, capstone integration notebook).

The capstone notebook (baseline 0-shot vs pipeline comparison, value-gates **VG-1..VG-4**) had **3 exercise stub cells** (array indices 21, 23, 25) with **empty outputs** (`"outputs": []`). This fails the C.2 *"output systematique"* convention: every code cell — including stubs — must produce output so the catalogue `all_have_outputs` gate stays a true signal.

Each stub keeps its C.1-compliant body (`pass` / `result = None  # TODO etudiant` / `pass` — no `raise NotImplementedError`) and gains an **additive** `print("Exercice N a completer ...")` line whose output is the exercise prompt. All `# Exercice` / `# TODO` / `# Indice` / `# Etape N` comments preserved.

## Preuves (G.1)

- **C.2 state (after)**: 13/13 code cells have `outputs` + `execution_count`, **0 error outputs**, no `NotImplementedError`/`1/0`.
- **Outputs verified by execution**: re-executed the notebook end-to-end via papermill (exit 0, 13/13 cells green), then **applied the verified outputs surgically** (`json.dump indent=1`) to keep the diff minimal — avoids papermill's per-cell metadata timestamp churn (300 noise lines → 27 ins / 6 del).
- **No metadata churn**: `git diff | grep -E 'duration|end_time|start_time|iopub'` = empty.
- **Catalogue untouched** (catalog-pr-hygiene HARD 1): `git diff` on `*CATALOG*` / `*generated*` = empty; `CATALOG-STATUS` marker left to the catalog-drift bot.
- **nbformat VALID** (`nbformat.validate` passes).
- **`exec_count` preserved** (11 / 12 / 13).

## Conformite

- **C.1** (no voluntary error): stubs use `pass` / `return None` / `result = None` — no `raise NotImplementedError`. Additive print only.
- **C.2** (commit with outputs): stub cells now produce output.
- **Anti-regression**: additive, no existing content stripped.
- **Atomic** (catalog-pr-hygiene HARD 3): 1 file, 1 subject.
- **Fresh rebase**: HEAD = `origin/main` = `fa4a84b1`.
- **Secrets**: none.

## Scope note (honest)

This is the **capstone grain** of the C.2 audit I proposed on the CoursIA-2 dashboard. The sibling `Argument_Analysis_Agentic-0-init.ipynb` also has a C.2 gap (cell#12 FOL smoke-test stub, no output), but that notebook requires the **Tweety `libs/` infra** (76 JARs + `jdk-17-portable`) which is **not installed in this tree** — re-execution would `RuntimeError` on the JVM-init cells. Parked until the Tweety infra is provisioned here or the main CoursIA tree is free of the parallel PyMC session. Reported separately.

See #2137 (partial contribution to the Argument analysis epic).