### PR TITLE
docs(gittins): add missing README for Gittins index / bandit series (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/gittins_lean/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/gittins_lean/README.md
@@ -1,0 +1,83 @@
+# gittins_lean — Multi-Armed Bandits & the Gittins Index
+
+Lean 4 formalization of the **multi-armed bandit** problem and the **Gittins
+index** (Gittins 1979, Weber 1992) — the optimal policy for the discounted
+infinite-horizon bandit. The **geometric-discount building blocks are fully
+proven** (PR #2911); the **marquee optimality theorem is stated but intractable**
+in the current Mathlib (no MDP/Bellman formalization), held as `sorry`.
+
+Part of the `Probas/Infer` (Infer.NET probabilistic) series. Companion notebook:
+[`Infer-20b-Lean-Gittins.ipynb`](../Infer-20b-Lean-Gittins.ipynb).
+
+## Status
+
+- **Toolchain**: `leanprover/lean4:v4.30.0-rc2`
+- **Sorry**: **5** — all in `GittinsTheorem.lean` (the optimality theorem + index
+  properties). `Discount.lean` = **0 sorry** (fully proven), `Basic.lean` = 0.
+- **Build**: `lake build Gittins` (depends on Mathlib4)
+- **Dependencies**: Mathlib4 (`v4.30.0-rc2`) — real analysis for the discount lemmas
+
+## What it formalizes
+
+A **multi-armed bandit**: at each step a policy chooses one of several arms
+(`BanditArm`) and observes a reward; the goal is to maximize total expected
+discounted reward (discount `γ ∈ (0,1)`). The **Gittins index** of an arm is the
+fixed point of an optimal-stopping problem; the **Gittins index policy** (play
+the arm with the highest index) is optimal for the discounted bandit.
+
+The formalization is split into a **proven** layer and a **stated** layer:
+
+- **Proven** (`Discount.lean`): the geometric-series identities underpinning
+  discounted value — `∑' γ^n = 1/(1-γ)`, `∑' γ^n·r = r/(1-γ)`, and
+  `discount_monotone` (γ₁ ≤ γ₂ ⇒ ∑' γ₁^n ≤ ∑' γ₂^n). `discount_monotone` is
+  proven **closed-form** via `geometric_series_converges` +
+  `one_div_le_one_div_of_le`, sidestepping the missing `tsum_le_tsum` on bare `ℝ`
+  in Mathlib v4.30.0-rc2.
+- **Stated, intractable** (`GittinsTheorem.lean`): `gittinsIndex` (optimal
+  stopping), `gittins_optimality` (the central theorem — the index policy
+  maximizes expected discounted reward), `gittins_index_known_arm`,
+  `gittins_index_monotone_discount`. All `sorry`.
+
+## Modules
+
+| File | Lines | sorry | Content |
+|------|-------|-------|---------|
+| `Gittins/Basic.lean` | 37 | 0 | Core types — `BanditArm`, `BanditInstance` (arms + discount γ), `Policy := Nat → Nat`, `RewardHistory`, `pullCount`, `empiricalMean`. Pure Lean 4, no Mathlib. |
+| `Gittins/Discount.lean` | 68 | 0 | Geometric discounting **proven** via Mathlib real analysis: `geometric_series_converges`, `one_minus_gamma_pos`, `present_value_constant`, `discount_monotone`. |
+| `Gittins/GittinsTheorem.lean` | 96 | 5 | The marquee theorem **stated with sorry**: `gittinsIndex`, `gittinsPolicy` (argmax), `gittins_optimality`, `gittins_index_known_arm`, `gittins_index_monotone_discount`. (`gittins_beats_greedy` is a `: True := trivial` placeholder, not a sorry.) |
+| `Gittins.lean` | 19 | 0 | Umbrella imports |
+
+## Why the optimality theorem is intractable
+
+A complete proof of `gittins_optimality` requires:
+
+1. **Optimal-stopping characterization** of the Gittins index (retirement value / fixed point),
+2. **Index decomposability** across independent arms,
+3. **Induction on the planning horizon**, and
+4. A **formal expected value** over the reward distribution.
+
+Mathlib (v4.30.0-rc2) has **no MDP, bandit, or Bellman-equation** formalization,
+nor a measure-theoretic expected-value API suitable here. A full proof is
+estimated at ~2000–5000 lines of supporting definitions — research-level, beyond
+a single PR. The theorem is therefore **stated** (with the precise statement
+preserved in its docstring) rather than silently weakened.
+
+## Build
+
+```bash
+# From this directory (WSL required)
+lake build Gittins
+# Depends on Mathlib4 — first build is heavy, subsequent builds use the cache
+```
+
+## Notebook companion
+
+[`Infer-20b-Lean-Gittins.ipynb`](../Infer-20b-Lean-Gittins.ipynb) — pedagogical
+presentation of the bandit problem and the Gittins index, bridging the Infer.NET
+probabilistic-programming material to the Lean formalization.
+
+## See also
+
+- **PR #2911** — `discount_monotone` proven closed-form (sorry 1→0)
+- **`Probas/Infer/`** — Infer.NET probabilistic series (Bayesian inference, conjugate priors)
+- **Epic #2651** — README/structure audit (Lean-series)


### PR DESCRIPTION
## What

`gittins_lean` had **no README** — a creation gap flagged by ai-01 in the Lean-series README staleness audit (02:00Z feed: "gaps creation gittins/conway_cgt/finiteness, defaut reel"). Second of the 3 gap-creation items (finiteness #3111 done cycle N-1; conway_cgt queued next).

## Change (docs-only — new `README.md`, English to match the code's English docstrings)

83-line README grounded in the real code:
- **Status**: toolchain v4.30.0-rc2, sorry **5** (all `GittinsTheorem.lean`), depends on **Mathlib4** (unlike the autonomous `finiteness_lean`).
- **Proven/stated split**: `Discount.lean` **fully proven** (`geometric_series_converges`, `present_value_constant`, `discount_monotone` closed-form via `one_div_le_one_div_of_le` — sidesteps missing `tsum_le_tsum` on bare ℝ, PR #2911 MERGED 2026-06-13). `GittinsTheorem.lean` **stated with sorry** (the marquee optimality theorem).
- **Modules table**: Basic (37, 0 sorry, pure types), Discount (68, 0, proven), GittinsTheorem (96, 5, stated), umbrella.
- **Why intractable**: Mathlib v4.30.0-rc2 has no MDP/bandit/Bellman formalization + no suitable expected-value API; full proof ~2000-5000 lines of supporting defs. Theorem stated (docstring preserves precise statement) rather than silently weakened.
- **Companion notebook** `Infer-20b-Lean-Gittins.ipynb` confirmed present.

## Verification (G.1, before writing — manual sorry count authoritative)

| Claim | Check |
|-------|-------|
| Discount.lean = 0 sorry | Read full file (68 lines) — 4 theorems, all proven (`tsum_geometric_of_lt_one`, `tsum_mul_right`, `one_div_le_one_div_of_le`, `linarith`). No `sorry`. |
| GittinsTheorem.lean = **5** real sorry | Manual classification of every `sorry` line: **real tactic** = L27 (`gittinsIndex` body), L65 (value-fn `V` let), L69 (`gittins_optimality` proof), L81 (`gittins_index_known_arm`), L88 (`gittins_index_monotone_discount`). The other 4 occurrences (L5/L11/L38/L72) are **prose/comments** ("Statement with sorry", "sorry placeholders", "`sorry`-stubbed", "also sorry"). `gittins_beats_greedy` (L94) = `: True := trivial` placeholder, **not** a sorry. |
| Basic.lean = 0 sorry | Read full file — pure structure/def declarations, no proofs. |
| #2911 status | `gh pr view 2911` = MERGED 2026-06-13T14:01Z. |
| Notebook exists | `Infer-20b-Lean-Gittins.ipynb` confirmed. |

## Scope

- **Docs-only** (new README.md). No `.lean` change → no `lake build` required (lean-merge-discipline §1 exempts docs-only).
- No catalogue touched. Base off fresh `origin/main` (`fa4a84b18`).
- Single domain (Probas/Infer Lean), single deliverable — atomic.

Contributes to ai-01's Lean-series README audit (#2651). `conway_cgt_lean` (3rd gap-creation item) queued for next cycle.

`See #2651` (Lean-series README audit — partial).