### PR TITLE
docs(genai-image): document 02-5 Bonsai-Image-Ternary in series README

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -26,7 +26,7 @@ La structure détaillée (notebooks par niveau, contenu, services utilisés) est
 ```
 Image/
 ├── 01-Foundation/     # Modèles de base (5 notebooks)
-├── 02-Advanced/       # Modèles avancés (4 notebooks)
+├── 02-Advanced/       # Modèles avancés (5 notebooks)
 ├── 03-Orchestration/  # Multi-modèles (3 notebooks)
 ├── 04-Applications/   # Production (4 notebooks)
 └── examples/          # Cas d'usage (3 notebooks)
@@ -50,7 +50,7 @@ Avant de produire des visuels pédagogiques, il faut maîtriser les outils de g�
 
 ### 02-Advanced - Modèles avancés
 
-Un visuel éducatif de qualité demande des outils plus précis : édition d'images existantes (Qwen), génération haute qualité (FLUX), ou modèles légers et rapides (Z-Image/Lumina). Ce niveau explore les modèles de pointe et leurs compromis entre qualité, vitesse et ressources GPU.
+Un visuel éducatif de qualité demande des outils plus précis : édition d'images existantes (Qwen), génération haute qualité (FLUX), ou modèles légers et rapides (Z-Image/Lumina). Ce niveau explore les modèles de pointe et leurs compromis entre qualité, vitesse et ressources GPU. Le notebook [02-5](02-Advanced/02-5-Bonsai-Image-Ternary.ipynb) pousse l'optimisation à l'extrême avec Bonsai-Image (FLUX.2 Klein 4B en quantization ternaire 1.58-bit), qui ne consomme que ~6.8 GiB de VRAM à 1024x1024.
 
 | Notebook | Contenu | Service |
 |----------|---------|---------|
@@ -58,6 +58,7 @@ Un visuel éducatif de qualité demande des outils plus précis : édition d'ima
 | [02-2-FLUX-1-Advanced-Generation](02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb) | Génération FLUX | ComfyUI |
 | [02-3-Stable-Diffusion-3-5](02-Advanced/02-3-Stable-Diffusion-3-5.ipynb) | SD 3.5 | ComfyUI |
 | [02-4-Z-Image-Lumina2](02-Advanced/02-4-Z-Image-Lumina2.ipynb) | Z-Image/Lumina | ComfyUI |
+| [02-5-Bonsai-Image-Ternary](02-Advanced/02-5-Bonsai-Image-Ternary.ipynb) | Bonsai-Image 4B, quantization ternaire 1.58-bit | ComfyUI |
 
 [README 02-Advanced](02-Advanced/README.md)
 
@@ -105,6 +106,7 @@ Applications directes par domaine : histoire-géographie (cartes, reconstitution
 | **ComfyUI + FLUX** | 02-2 | Docker GPU |
 | **ComfyUI + SD 3.5** | 02-3 | Docker GPU |
 | **Z-Image/Lumina** | 02-4 | Docker, ~10GB VRAM |
+| **Bonsai-Image (ternaire)** | 02-5 | ComfyUI, ~7 GB VRAM |
 
 ## Prérequis
 
@@ -140,7 +142,7 @@ Accès : http://localhost:8188
 | Objectif | Notebooks |
 |----------|-----------|
 | Découverte rapide | 01-1, 01-3 |
-| Génération avancée | 01-1 à 02-4 |
+| Génération avancée | 01-1 à 02-5 |
 | Production | Tous + 03 + 04 |
 
 ## Recette : construire un générateur de contenu visuel éducatif
@@ -149,7 +151,7 @@ Le fil rouge de cette série est la création d'un système de visuels pédagogi
 
 1. **01-Foundation** (génération de base) : [01-1](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) et [01-2](01-Foundation/01-2-GPT-5-Image-Generation.ipynb) couvrent la génération via API cloud. [01-4](01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb) et [01-5](01-Foundation/01-5-Qwen-Image-Edit.ipynb) introduisent les modèles locaux. À la fin, vous savez générer une image à partir d'un texte.
 
-2. **02-Advanced** (édition et qualité) : [02-1](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb) permet d'éditer une image existante pour corriger ou enrichir un visuel. [02-4](02-Advanced/02-4-Z-Image-Lumina2.ipynb) offre une génération rapide pour le prototypage. [02-2](02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb) pousse la qualité plus loin.
+2. **02-Advanced** (édition et qualité) : [02-1](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb) permet d'éditer une image existante pour corriger ou enrichir un visuel. [02-4](02-Advanced/02-4-Z-Image-Lumina2.ipynb) offre une génération rapide pour le prototypage. [02-2](02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb) pousse la qualité plus loin. [02-5](02-Advanced/02-5-Bonsai-Image-Ternary.ipynb) montre la quantization extrême (ternaire 1.58-bit) pour faire tenir un modèle 4B dans ~7 GB de VRAM.
 
 3. **03-Orchestration** (comparaison et pipelines) : [03-1](03-Orchestration/03-1-Multi-Model-Comparison.ipynb) compare les modèles pour choisir le meilleur rapport qualité/coût. [03-2](03-Orchestration/03-2-Workflow-Orchestration.ipynb) assemble un pipeline de génération complet.
 


### PR DESCRIPTION
## Summary

The notebook `02-5-Bonsai-Image-Ternary.ipynb` (merged in #1746, statut BETA, tracks #1613) was referenced **nowhere** in the Image series README — the 02-Advanced table stopped at 02-4. This is an additive documentation sync (same pattern as #3110 for Video 02-5-LTX2).

## Changes (additive, 6 ins / 4 del)

- Structure tree: `02-Advanced (4 notebooks)` -> `(5 notebooks)`
- 02-Advanced prose: Bonsai sentence (FLUX.2 Klein 4B ternary 1.58-bit, ~6.8 GiB VRAM @ 1024x1024)
- 02-Advanced table: new row `02-5-Bonsai-Image-Ternary` (3-col Notebook|Contenu|Service, matching siblings)
- Technologies table: new row `Bonsai-Image (ternaire)` -> 02-5, ComfyUI, ~7 GB VRAM
- Parcours: `Génération avancée | 01-1 à 02-4` -> `01-1 à 02-5`
- Recette 02-Advanced: 02-5 mention (extreme quantization, 4B model in ~7 GB)

## Verification (G.1)

All values sourced from the notebook header cells (re-verified via grep this cycle):
- Model: Bonsai-Image = FLUX.2 Klein 4B base, Bonsai-4B-2Bit variant, ternary 1.58-bit, Gemlite INT2 packing
- VRAM: ~6.8 GiB peak @ 1024x1024 (on-disk ~1.21 GB)
- Service: ComfyUI API via custom node `BonsaiTernaryNode`
- Statut: BETA, Issue: #1613

## Notes

- Markdown-only (no re-exec required, exception C.2).
- No inline CATALOG-STATUS marker in Image README (references external `CATALOG-STATUS.json`) -> HARD 1 catalog byte-identical trivially satisfied.
- One subject (atomic, G.4); `See #1613` (the notebook's feature issue — partial doc sync, does not close #1613).

See #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)