### PR TITLE
docs(conway-cgt): add missing README for vihdzp/combinatorial-games tour (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/README.md
@@ -1,0 +1,91 @@
+# conway_cgt_lean — Tour of vihdzp/combinatorial-games
+
+A **curated tour** (`#check`-based) of the combinatorial game theory formalized in
+[`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games),
+imported as a Lake dependency — surreal numbers, nimbers, and general
+combinatorial games. This is **not** an original formalization: it presents and
+exhibits the upstream results, which are the current home of CGT in the Lean
+ecosystem after Mathlib's CGT modules were removed.
+
+Reference: Conway, J.H. — *On Numbers and Games* (2001).
+
+## Status
+
+- **Toolchain**: `leanprover/lean4:v4.31.0-rc1` (tracks the upstream repo — newer than the other Lean series on v4.30.0-rc2)
+- **Sorry**: **0** — the file is a tour of `#check`s and docstrings, no proofs
+- **Build**: `lake build CGTTour` (depends on Mathlib4 + CombinatorialGames)
+- **Dependencies**:
+  - **Mathlib4** (latest)
+  - **[CombinatorialGames](https://github.com/vihdzp/combinatorial-games)** (Apache-2.0) — Violeta Hernandez Palacios
+
+## Why this exists — Mathlib CGT removal
+
+The upstream repository **superseded Mathlib's CGT modules**
+(`SetTheory.Surreal`, `SetTheory.PGame`, `SetTheory.Game`, `SetTheory.Nimber`),
+which were deprecated in Mathlib PR [#28063](https://github.com/leanprover-community/mathlib4/pull/28063)
+(Aug 2025) and **removed in PR [#35550](https://github.com/leanprover-community/mathlib4/pull/35550)**
+(Feb 2026). The upstream author (vihdzp) is the same person who maintained the
+Mathlib CGT code. This tour points learners to where CGT now lives.
+
+## What the tour covers
+
+The file imports the upstream modules and exhibits their key results:
+
+### 1. Combinatorial games
+- **`IGame`** (pre-games): concrete representation by left/right option sets
+  (`left`/`right : Set IGame`) — you can inspect individual moves.
+- **`Game`** (games up to equivalence `≈`): the quotient
+  `Antisymmetrization IGame (· ≤ ·)`, an `OrderedAddCommGroup`.
+- Birthday, canonical form, player.
+
+### 2. Surreal numbers
+- **`Surreal`**: numeric games quotiented by equivalence — a **`LinearOrder`**,
+  a complete ordered field containing every ordered field as a subfield.
+- **Simplicity theorem** (`IGame.Fits.equiv_of_forall_not_fits`): the key tool
+  for computing surreal values.
+- Full field arithmetic: addition (from `Game`), multiplication, division.
+- **Dyadic** embedding (`Dyadic.toIGame`) — dyadic surreals = finite birthday.
+- **Ordinal** embedding (`NatOrdinal.toSurreal`).
+
+### 3. Nimbers
+- **`Nimber`**: ordinals with nim arithmetic; arise from impartial games via the
+  **Sprague-Grundy theorem** (every impartial game ≈ a game of nim).
+- **Nim addition** via minimum-excluded (`Nimber.add_def`).
+- **Field of characteristic 2** (`Field Nimber`) — every element is its own
+  additive inverse. Long-term project goal: prove nimbers algebraically closed.
+
+### Mathlib vs upstream (comparison table in the file)
+
+| Aspect | Mathlib (removed) | combinatorial-games (current) |
+|--------|-------------------|-------------------------------|
+| Games | `PGame` (basic) | `IGame` (concrete) + `Game` (quotient) |
+| Surreals | Basic/Dyadic/Mul | + Division, Hahn series, Birthday, Pow |
+| Nimbers | Basic/Field | + Nat, SimplestExtension |
+| Games lib | 8 modules | 15+ modules (Impartial, Loopy, Specific…) |
+
+## Modules
+
+| File | Lines | Content |
+|------|-------|---------|
+| `CGTTour.lean` | 169 | Imports the upstream `CombinatorialGames.*` modules and tours their key types/instances/theorems via `#check` + docstrings (`IGame`/`Game`, `Surreal` + simplicity theorem, `Nimber` + Sprague-Grundy), with a Mathlib-vs-upstream comparison table. |
+
+## Build
+
+```bash
+# From this directory (WSL required)
+lake build CGTTour
+# Depends on Mathlib4 + CombinatorialGames (two git deps) — first build is heavy
+```
+
+## Cite, not vendor
+
+The upstream repo is a **Lake dependency** (`require CombinatorialGames from git`),
+not vendored. License: **Apache-2.0**. The tour file is original exposition built
+on top of the imported results.
+
+## See also
+
+- **Upstream**: [`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games) (Apache-2.0, Violeta Hernandez Palacios)
+- **`knot_lean/`** — references this tour in its dependencies table (Conway game-theory foundation)
+- **`conway_lean/`** — Conway's Game of Life / Free Will Theorem (the *other* Conway series)
+- **Epic #2651** — README/structure audit (Lean-series)


### PR DESCRIPTION
## What

`conway_cgt_lean` had **no README** — a creation gap flagged by ai-01 in the Lean-series README staleness audit (02:00Z feed). **This is the LAST of the 3 gap-creation items** (finiteness #3111 HELD, gittins #3116 MERGED, this closes the audit).

## Important — safe to merge independent of #3111 / Epic #2978 reprise

ai-01 HELD #3111 (finiteness README) because its Brzozowski→RE# narrative is part of the regex Epic #2978 reprise the user flagged. **conway_cgt is unrelated to regex** — it is combinatorial game theory (surreal numbers, nimbers). This PR touches no #2978/#2979 narrative and can merge on its own merits.

## Change (docs-only — new `README.md`, English to match the code's English docstrings)

91-line README grounded in the real code:
- **Status**: toolchain v4.31.0-rc1 (tracks upstream, newer than the v4.30.0-rc2 of the other Lean series), sorry **0**, deps Mathlib4 + CombinatorialGames.
- **What it is**: a **tour** (`#check`-based, no proofs) of the CGT formalized in `vihdzp/combinatorial-games` — **not** original formalization. Exhibits upstream results.
- **Historical context**: the upstream repo **superseded Mathlib's CGT modules** (`SetTheory.Surreal`/`PGame`/`Game`/`Nimber`), deprecated Mathlib PR #28063 (Aug 2025), **removed PR #35550 (Feb 2026)** — same author (vihdzp = Violeta Hernandez Palacios). This tour points to where CGT now lives.
- **3 toured layers**: combinatorial games (`IGame`/`Game` quotient), surreal numbers (LinearOrder + simplicity theorem + field ops + dyadic/ordinal embeddings), nimbers (Sprague-Grundy + char-2 field, algebraically-closed conjecture).
- **Mathlib-vs-upstream comparison table** (from the file).
- **Cite-not-vendor**: upstream is a Lake `require from git` dependency (Apache-2.0), NOT vendored — clean.

## Verification (G.1, before writing)

| Claim | Check |
|-------|-------|
| 0 sorry | Read full `CGTTour.lean` (169 lines) — only `#check`, docstrings, `namespace`/`open`. `grep -rn sorry` = 0. |
| Not original formalization | File header L1-23 + lakefile L1-19 both state "tour of vihdzp/combinatorial-games results, imported as Lake dependency". `require CombinatorialGames from git` confirmed in lakefile. |
| Toolchain v4.31.0-rc1 | `lean-toolchain` confirmed; tracks upstream (Mathlib CGT removal forced the bump). |
| Mathlib PR refs | #28063 / #35550 cited as **full URLs** (`mathlib4/pull/N`) in the README, not bare `#N` — prevents GitHub auto-linking to CoursIA issues. |
| Referenced from knot_lean | knot_lean README deps table lists `vihdzp/combinatorial-games` = "Déjà dans conway_cgt_lean/". |

## Scope

- **Docs-only** (new README.md). No `.lean` change → no `lake build` required (lean-merge-discipline §1 exempts docs-only).
- No catalogue touched. Base off fresh `origin/main` (`7379f690c`).
- Single domain (GameTheory Lean), single deliverable — atomic.

Closes the 3-item Lean-series README gap-creation audit (finiteness #3111 + gittins #3116 + this).

`See #2651` (Lean-series README audit — partial; contributes, does not close the audit epic).