### PR TITLE
docs(kernels): triton-windows + bitsandbytes CUDA env fix (#2891)

### DIFF
--- a/docs/reference/kernels-runtime.md
+++ b/docs/reference/kernels-runtime.md
@@ -149,6 +149,31 @@ Installation : `python SymbolicAI/SmartContracts/setup_env.py`.
 
 Verifier qu'elles ont aussi un env Conda dedie ou un venv local equivalent. La memoire est specifique ai-01 mais le pattern (env dedie ML) est cluster-wide. Inventorier via `conda env list` sur chaque machine.
 
+### GenAI GPU stack : triton-windows + bitsandbytes
+
+Les notebooks GenAI GPU (ex. [Video/02-5-LTX2-Audiovisual](../../MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb), #2891) utilisent `triton` (JIT de kernels) et `bitsandbytes` (quantization INT4/NF4). `torch` embarque son runtime CUDA (`torch.cuda.is_available()=True` marche SANS le Toolkit), mais triton/bnb ont besoin de plus :
+
+| Besoin | Fourni par |
+|--------|-----------|
+| Detection CUDA par triton (`ptxas` + `cuda.h` + `cuda.lib`) | pip wheels `nvidia-cuda-nvcc-cu12` + `nvidia-cuda-runtime-cu12` |
+| Compilateur C hote pour le JIT triton (`driver.c`) + bnb | `CC` env ; triton-windows embarque un TinyCC (`triton/runtime/tcc/tcc.exe`) |
+
+**Piege Windows** : si Python et ses paquets sont en **user site-packages** (`%APPDATA%\Python\PythonXX\site-packages` — cas quand `C:\PythonXX\Lib\site-packages` exige admin), `sysconfig['platlib']` pointe sur la base. L'auto-detection de triton (`find_cuda_pip`) et de son TinyCC (`get_cc`) ratent alors. Symptomes : `RuntimeError: Failed to find CUDA` (triton) et `Failed to find C compiler. Please specify via CC` (triton + bnb).
+
+**Fix sans UAC** (canonical triton-windows, prefere a un system Toolkit install) : un `usercustomize.py` en user site-packages injecte `CUDA_HOME` + `CC` au demarrage de chaque interpreteur Python. Exemple (po-2023, 2026-06-16, pour #2891) :
+
+```python
+# %APPDATA%\Python\Python313\site-packages\usercustomize.py
+import os, site
+base = site.getusersitepackages()
+if os.path.isdir(os.path.join(base, "nvidia")):
+    os.environ.setdefault("CUDA_HOME", os.path.join(base, "nvidia"))
+if os.path.isfile(os.path.join(base, "triton", "runtime", "tcc", "tcc.exe")):
+    os.environ.setdefault("CC", os.path.join(base, "triton", "runtime", "tcc", "tcc.exe"))
+```
+
+`setdefault` => n'ecrase jamais une valeur explicite ; n'affecte que les processus Python (pas de risque global `CC` pour les builds non-Python) ; no-op sur les machines sans les wheels. Test froid (G.2) : vider `~/.triton/cache` puis executer un kernel triton -> `max err = 0` vs torch sur le GPU.
+
 ## WSL kernels (Lean / GameTheory / OpenSpiel)
 
 Notebooks dans `GameTheory/` et `SymbolicAI/Lean/` requierent un kernel WSL specifique :


### PR DESCRIPTION
## What

Documents the runtime fix that unblocks the GenAI GPU stack (`triton` JIT + `bitsandbytes`) on Windows, added to `docs/reference/kernels-runtime.md` under the Python section.

## Context (#2891 LTX-2)

`02-5-LTX2-Audiovisual.ipynb` needs `triton` (kernel JIT) and `bitsandbytes` (INT4/NF4 quantization). `torch` ships its own CUDA runtime (`cuda.is_available()=True` without any Toolkit), but triton/bnb need more:

| Need | Provided by |
|------|-------------|
| triton CUDA detection (`ptxas` + `cuda.h` + `cuda.lib`) | pip wheels `nvidia-cuda-nvcc-cu12` + `nvidia-cuda-runtime-cu12` |
| Host C compiler for triton `driver.c` JIT + bnb | `CC` env → triton-windows bundled TinyCC (`triton/runtime/tcc/tcc.exe`) |

**Windows pitfall**: when Python + packages are in **user site-packages** (`%APPDATA%\Python\PythonXX\`, the case when `C:\PythonXX\Lib\site-packages` needs admin), `sysconfig['platlib']` points at the base. triton's `find_cuda_pip` and `get_cc` (bundled TinyCC discovery) both look under platlib → miss. Symptoms: `Failed to find CUDA` (triton) and `Failed to find C compiler. Please specify via CC` (triton + bnb).

**Fix (no UAC)**: a `usercustomize.py` in user site-packages injects `CUDA_HOME` + `CC` at every Python interpreter startup (`setdefault`, no-op where the wheels are absent, no global-CC risk). Verified cold-cache on po-2023 (2026-06-16): cleared `~/.triton/cache` → triton GPU kernel exact-match vs torch (max err 0.0) on RTX 3090, bitsandbytes 0.49.2 import OK.

## Scope / review

- Docs-only, single file, +25 lines. No catalog/generated files touched (byte-identical to origin/main).
- This is **not** a system CUDA Toolkit install (no UAC, no system install, no CDN-URL hunt) — the pip-wheels + `usercustomize.py` is the canonical triton-windows pattern and strictly smaller.
- Remaining #2891 blocker (not addressed here, user's job per ai-01 dispatch): the gated Gemma-3 HF token. The notebook's c6 cells are built to *detect* the exact C-compiler failure this fix resolves.

## Validation

- [x] Content sourced from triton source (`windows_utils.py find_cuda`, `runtime/build.py get_cc`) — read, not guessed (G.1)
- [x] Cold-cache + fresh-process proof on po-2023 (triton JIT max err 0.0, bnb import OK)
- [x] Fresh rebase on `origin/main`, atomic (one subject), no catalog churn

See #2891

🤖 Generated with [Claude Code](https://claude.com/claude-code)