### PR TITLE
feat(lean): Knots Phase 5 PR3 -- backward tricolorability transfer (partial, colour-preservation proven)

### DIFF
--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -12,7 +12,7 @@ name: Lean Knot CI
 #
 # Uses the shared lean-build.yml reusable workflow.
 #
-# Sorry profile (verified 2026-06-14, prose-header mode, baseline=25):
+# Sorry profile (verified 2026-06-15, prose-header mode, baseline=28):
 # knot_lean's real sorries are INLINE (`exact sorry`, `:= sorry`,
 # `sorry -- comment`), never bare `sorry` on its own line. The standalone-tactic
 # filter (`^\s*sorry\s*$`) counts 0 here and would catch no regression, so we
@@ -20,8 +20,12 @@ name: Lean Knot CI
 # real sorry and fails on any addition. Breakdown of the 25:
 #   - Basic.lean:                1 (prose: TODO comment on well-formedness)
 #   - Reidemeister.lean:         2 (reidemeister_theorem ×2 — PL topology, OOS)
-#   - Invariant.lean:            4 (tricolorable_invariant, trefoil_not_unknot,
-#                                  unknottingNumber + prose)
+#   - Invariant.lean:            7 (tricolorable_invariant, trefoil_not_unknot,
+#                                  unknottingNumber + prose; +3 from the PARTIAL
+#                                  `tricolorable_backward` transfer — Epic #2874
+#                                  PR3: colour-preservation proven, 3 residual
+#                                  tactic sorries on the Fox-transfer assembly,
+#                                  user-authorised, ai-01 to advise)
 #   - Conway.lean:              11 (Conway knot 11n34, Kinoshita-Terasaka,
 #                                  mutation — scaffolding)
 #   - Lidman.lean:               5 (11n102 unknotting number = 2 — Heegaard-Floer)
@@ -51,5 +55,5 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean
       display-name: knot_lean
-      sorry-baseline: "25"
+      sorry-baseline: "28"
       sorry-filter-mode: prose-header

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -1081,4 +1081,96 @@ quantifies *why* the two-slot bucket cannot be reduced to the single-slot
 construction. CI baseline remains unchanged.
 -/
 
+/-! ## 10. Backward transfer — formal declaration (partial, Epic #2874 PR3)
+
+The mate of `Reidemeister1Connected.tricolorable_forward` (PR #3000): a
+tricoloring of `d₂` restricts to one of `d₁` under the strengthened connected-R1
+model. The §9 decomposition analysis splits the proof by the Fox mode at the
+appended kink `C = ⟨a, b, c, c⟩` (with `b = d₁.numEdges + 1`, `c = d₁.numEdges + 2`):
+
+* **all-equal mode** (`col₂(a-1) = col₂(b-1) = col₂(c-1)`): the naïve
+  restriction `col₁ := col₂|_{Fin d₁.numEdges}` is Fox-preserving — the
+  `a → b` rename at the modified endpoint crossing is colour-invisible. The
+  sub-lemma `tricolorable_backward` below proves the **colour-preservation**
+  half constructively (a preserved label reads the same colour under `col₁` in
+  `d₁` as under `col₂` in `d₂`; mirrors `tricolorable_forward`'s `hcolF1`).
+* **all-distinct mode** (`col₂(a-1) ≠ col₂(b-1)`): needs the colour-symmetry /
+  multi-position rebalancing characterised empirically in §9.4–§9.6 (the 47.9%
+  naïve-fail regime). Research-level.
+
+The remaining assembly — Fox-transfer at every `d₁` crossing (the unchanged
+ones inherit via the colour-preservation fact, mirroring `h_inherit`; the
+modified crossing `Y` and the all-distinct kink mode need the §9.1
+construction), the `d₁.numEdges ≥ 2` lift (derivable from `d₁.wf` + the
+proper-arc hypothesis, but a separate wf-parity argument), and the `≥ 2`-colour
+lift — is left as three residual tactic `sorries` for ai-01 to advise on. This
+raises the Knots-CI prose-header baseline from 25 to 28 (three residual tactic
+`sorries`, one per sub-goal). User-authorised partial delivery (2026-06-15):
+ship with residual sub-proof obligations that ai-01 will advise on. Together
+with `tricolorable_forward` (#3000) this yields the R1 bi-implication needed
+to unblock the §2 placeholder `tricolorable_invariant`. See #2874.
+-/
+
+/-- BACKWARD tricolorability transfer (PARTIAL): under the strengthened
+    connected-R1 model `Reidemeister1Connected d₁ d₂`, a tricoloring of `d₂`
+    restricts to a tricoloring of `d₁`. The colour-preservation sub-lemma is
+    discharged constructively (mirrors `tricolorable_forward`'s `hcolF1`); the
+    Fox-transfer assembly and the all-distinct kink mode remain as residual
+    tactic `sorries` (see §9.1, §9.4–§9.6). -/
+theorem Reidemeister1Connected.tricolorable_backward {d₁ d₂ : KnotDiagram}
+    (h : Reidemeister1Connected d₁ d₂) (htri₂ : IsTricolorable d₂) :
+    IsTricolorable d₁ := by
+  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, ha1, ha2, _hamem, _hproper, hrename, hsurg⟩ := h
+  -- Surgery shape (mirrors `tricolorable_forward`).
+  have hd₂num : d₂.numEdges = d₁.numEdges + 2 := by
+    simpa using congrArg (·.numEdges) hsurg
+  have hd₂cross : d₂.crossings =
+      d₁.crossings.set i.val Y' ++
+        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := by
+    simpa using congrArg (·.crossings) hsurg
+  obtain ⟨col₂, hfox₂, hge2₂, h2col₂⟩ := htri₂
+  -- Naïve restriction: `col₁` embeds `d₁`'s edge indices into `d₂` (the +2
+  -- fresh edges sit above `Fin d₁.numEdges`). Mirrors `tricolorable_forward`'s
+  -- `emb`/`col₂` (PR #3000), reversed.
+  have hd₂ge₁ : d₁.numEdges ≤ d₂.numEdges := by omega
+  let col₁ : Fin d₁.numEdges → TriColor :=
+    fun k => col₂ ⟨k.val, Nat.lt_of_lt_of_le k.isLt hd₂ge₁⟩
+  -- (F1) Colour preservation: a preserved label `l ∈ [1, d₁.numEdges]` reads
+  -- the SAME colour under `col₁` (in `d₁`) as under `col₂` (in `d₂`). Pure
+  -- arithmetic on the `(l-1) % numEdges` index; the reverse of forward `hcolF1`.
+  -- This is the constructive core that the unchanged-crossing Fox-inheritance
+  -- (`h_inherit` in the forward proof) rides on.
+  have hcolPres : ∀ l, 1 ≤ l → l ≤ d₁.numEdges →
+      d₁.colorAtNat col₁ l = d₂.colorAtNat col₂ l := by
+    intro l hl1 hln
+    have hn0d₁ : d₁.numEdges ≠ 0 := by omega
+    have hn0d₂ : d₂.numEdges ≠ 0 := by omega
+    simp only [KnotDiagram.colorAtNat, dif_neg hn0d₁, dif_neg hn0d₂]
+    have h1 : (l - 1) % d₁.numEdges = l - 1 := Nat.mod_eq_of_lt (by omega)
+    have h2 : (l - 1) % d₂.numEdges = l - 1 := Nat.mod_eq_of_lt (by omega)
+    simp only [h1, h2]
+    rfl
+  -- Residual assembly (§9): Fox-transfer at every `d₁` crossing under `col₁`
+  -- (unchanged crossings inherit via `hcolPres` — mirrors forward `h_inherit`;
+  -- the modified crossing `Y` and the all-distinct kink mode need the §9.1
+  -- colour-symmetry construction), the `d₁.numEdges ≥ 2` lift (wf + proper-arc),
+  -- and the `≥ 2`-colour lift. Left for ai-01 to advise on.
+  refine' ⟨col₁, ?fox, ?num, ?col⟩
+  case fox =>
+    -- ∀ c ∈ d₁.crossings, triColorConditionAt d₁ col₁ c.
+    -- Unchanged crossings: c ∈ d₂.crossings (survives `set i Y'`), Fox at c
+    -- under col₂ holds (hfox₂), transferred via hcolPres.
+    -- Modified crossing Y = d₁.crossings.get i: Fox under col₁; all-equal kink
+    -- mode colour-invisible, all-distinct mode research-level (§9.1, §9.6).
+    sorry
+  case num =>
+    -- d₁.numEdges ≥ 2: derivable from d₁.wf + proper-arc (j ≠ i ⟹ length ≥ 2
+    -- ⟹ non-degenerate ⟹ wf parity forces numEdges ≥ 2). Separate wf argument.
+    sorry
+  case col =>
+    -- ≥ 2 colours under col₁: under the all-equal kink mode the two distinct
+    -- colours of col₂ embed into Fin d₁.numEdges (the fresh edges duplicate
+    -- col₂(a-1)). Follows from the Fox-mode case split.
+    sorry
+
 end Knots

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -1164,8 +1164,21 @@ theorem Reidemeister1Connected.tricolorable_backward {d₁ d₂ : KnotDiagram}
     -- mode colour-invisible, all-distinct mode research-level (§9.1, §9.6).
     sorry
   case num =>
-    -- d₁.numEdges ≥ 2: derivable from d₁.wf + proper-arc (j ≠ i ⟹ length ≥ 2
-    -- ⟹ non-degenerate ⟹ wf parity forces numEdges ≥ 2). Separate wf argument.
+    -- d₁.numEdges ≥ 2. Diagnostic for the BG-prover (ai-01): d₁ is forced
+    -- NON-DEGENERATE (`crossings ≠ []`) because `_hproper` supplies a distinct
+    -- crossing index `j ≠ i`, both inhabiting `Fin d₁.crossings.length`. Hence
+    -- `d₁.wf` (Basic.lean:261) takes its ELSE branch — the parity condition:
+    -- every label in `[1, numEdges]` appears exactly twice
+    -- (`(List.range numEdges).all (fun i => edges.count (i+1) = 2)`), and every
+    -- occurring label lies in `[1, numEdges]` (clause (a)).
+    --   * numEdges = 0: `edges ≠ []` (crossings ≠ []), so (a) demands labels in
+    --     [1, 0] = ∅ — impossible.
+    --   * numEdges = 1: a single crossing contributes 4 slots, each forced to
+    --     label 1, so `edges.count 1 = 4 ≠ 2` — parity (b) fails.
+    -- Therefore numEdges ∉ {0, 1}, i.e. ≥ 2. Mechanical, BUT requires unfolding
+    -- the Bool-valued `wf` (`decide` / `List.range.all` / `edges.count` /
+    -- `List.flatMap`) over an ABSTRACT `d₁`, so `decide` cannot close it — it
+    -- is the natural mate of the Fox-transfer assembly and is left for ai-01.
     sorry
   case col =>
     -- ≥ 2 colours under col₁: under the all-equal kink mode the two distinct


### PR DESCRIPTION
## Summary

Declares `Reidemeister1Connected.tricolorable_backward` (Epic #2874 PR3), the mate of `tricolorable_forward` (#3000, merged): under the strengthened connected-R1 model, a tricoloring of `d₂` restricts to a tricoloring of `d₁`. This is the backward half of the R1 bi-implication needed to unblock the §2 placeholder `tricolorable_invariant`.

**Prior session context was stale**: a note said the forward lemma was "NEXT to prove", but #3000 already merged it. G.1 verification (`git log Invariant.lean` → `dc14fda5d feat(lean): Knots Phase 5 PR2 -- forward tricolorability transfer`) confirmed `tricolorable_forward` is complete (lines 478–660, no sorry). The real target is the **backward** direction, which existed only as a documented statement (§9.3 code-block) — never declared, to keep the baseline honest at 25.

This PR declares it (partial), per the user's instruction (2026-06-15): *"Essaie de décomposer et de faire ce que tu peux et puis tu peux livrer avec des sous-sorry résiduels sur lesquels ai-01 avisera"* — decompose, prove the tractable parts, ship with residual sorries ai-01 will advise on.

## Decomposition (per §9.1 Fox mode at the appended kink `C = ⟨a, b, c, c⟩`)

| Sub-goal | Status | Note |
|----------|--------|------|
| **Colour preservation** `hcolPres` (a preserved label `l ∈ [1, n]` reads the same colour under `col₁` in `d₁` as under `col₂` in `d₂`) | ✅ **PROVEN** | Pure arithmetic on `(l-1) % numEdges`; mirrors forward `hcolF1`. Compiled first-try. This is the constructive core the unchanged-crossing Fox-inheritance rides on. |
| `fox` — Fox-transfer at every `d₁` crossing | ⚠️ sorry | Unchanged crossings inherit via `hcolPres` (mirrors forward `h_inherit`); the **modified crossing `Y`** and the **all-distinct kink mode** need the §9.1 colour-symmetry construction (research-level, §9.4–§9.6). |
| `num` — `d₁.numEdges ≥ 2` | ⚠️ sorry | Derivable from `d₁.wf` + proper-arc (`j ≠ i ⟹ length ≥ 2 ⟹ non-degenerate ⟹ wf parity forces numEdges ≥ 2`). Separate wf-parity argument; tractable but fiddly. Forward got this free from `htri₁`; backward must derive it. |
| `col` — `≥ 2` colours under `col₁` | ⚠️ sorry | Under the all-equal kink mode the two distinct colours of `col₂` embed into `Fin d₁.numEdges` (the fresh edges duplicate `col₂(a-1)`). Follows from the Fox-mode case split. |

The naïve restriction is `col₁ k := col₂ ⟨k.val, …⟩` (the +2 fresh edges sit above `Fin d₁.numEdges`), the reverse of forward's `emb`/`col₂`.

## Validation (lean-merge-discipline §B)

**`grep -c` sorry (CI-exact prose-header, the filter `lean-knot.yml` uses):**
```
                        before    after
Invariant.lean             4        7    (+3: the three tactic sorries above)
knot_lean TOTAL           25       28
```
The +3 are tactic `sorry`s, one per residual sub-goal (fox/num/col). All prose mentions use "sorries"/"sorry's" (CI-excluded). Baseline raised 25 → 28 in `lean-knot.yml` with justification.

**Lake build: SUCCESS — 321 jobs** (exit 0, verified twice, no pipe masking):
```
KNOT_BUILD_EXIT=0
Build completed successfully (321 jobs).
```
- **Toolchain**: v4.31.0-rc1 (`knot_lean/lean-toolchain`).
- **Env note**: built via **WSL** Lean (`~/.elan/bin/lake build`). The native Windows `lake.exe` is blocked by an application-control policy (**os error 4551**, "une stratégie de contrôle d'application a bloqué ce fichier") on the freshly-downloaded v4.31.0-rc1 `lean.exe` — no MOTW stream, so `Unblock-File` doesn't apply; WSL Lean is the rule-F-compliant local toolchain (closer to CI's ubuntu-latest anyway). Baseline (old Invariant.lean) builds clean in WSL too (`BASELINE_EXIT=0`).

**Axiom check**: no new axioms — the only new tactic `sorry`s are local proofs, not `axiom` declarations. Existing sorry-bearing declarations unchanged.

## Scope

- `MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean` (+92): §10 comment block + the `tricolorable_backward` theorem with proven `hcolPres` + 3 residual sorries.
- `.github/workflows/lean-knot.yml` (+12/-4): baseline 25→28, header breakdown (Invariant 4→7), date refresh.

Single subject (backward transfer partial). Catalog untouched. No production code replaced by sorry — this is an **additive** declaration of a theorem that previously existed only as a documented statement.

See #2874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
