### PR TITLE
docs(qc): verify Temporal-CNN-Prediction post-#2801 (catalog 0.54 -> 0.161, DOWNGRADE historique) (See #1630)

### DIFF
--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -62,7 +62,7 @@ Strategies with solid risk-adjusted returns. These are the primary candidates fo
 | 28 | MomentumStrategy | IND | Equities | ~~0.57~~ → **0.50** ✓post-#2801 | 11.2 | 25.8 | 0.43 | robuste borderline (at threshold -12%, PSR 9.3% non-significant) |
 | 28b | MeanReversion | IND | Equities (sectors) | ~~0.81~~ → **0.81** ✓post-#2801 | 10.0 | 7.5 | 1.34 | robuste (confirmed, PSR 46.8% near-significant, low-turnover multi-asset holds = signal-frequency immunity) |
 | 29 | RegimeSwitching | ML | Equities/ETF | 0.55 | 11.7 | — | — | robuste |
-| 30 | Temporal-CNN-Prediction | DL | Multi-asset | 0.54 | — | — | — | robuste |
+| 30 | Temporal-CNN-Prediction | DL | Equities (QQQ top-3) | ~~0.54~~ → **0.161** ✓post-#2801 | 4.8 | 31.7 | 0.15 | **historique** (downgraded -70%, DL/CNN weekly-retraining overfits real fees severely — confirms ML-Temporal-CNN 0.73→0.46 pattern but worse; PSR 2.7%) |
 | 31 | RL-DQN-Trading | RL | Portfolio | ~~0.53~~ → **0.58 (2020-21 only)** ✓post-#2801 | 18.2 | 33.2 | 0.55 | **non re-verifiable** (locked to ~1yr window, runtime error on extension, PSR 30.2%) |
 | 31b | RL-Portfolio-Q-Learning | RL | Equities | 0.58 | 18.2 | 33.2 | — | historique (2020-2021) |
 | 32 | LSTM-Forecasting | DL | Multi-asset | 0.53 | — | — | — | robuste |
@@ -111,8 +111,9 @@ brokerage = the #2801 Lot 1 remediation). Results vs the pre-remediation catalog
 | TrendStocksLite | 28817425 | 0.72 | **0.71** | -2% | robuste (confirmed — weekly trend on 15 liquid large-caps, low realized turnover, near-immune, PSR 25.0%) |
 | ML-RandomForest | 29434751 | 0.68 | **0.70** | +3% | robuste (confirmed — bi-weekly RF on 10 mega-caps, moderate turnover near-immune on fee-homogeneous US equity, PSR 18.4%, baseline-clone 32940005) |
 | ML-XGBoost | 29434753 | 0.57 | **0.555** | -3% | robuste (confirmed flat-to-mildly-down, NOT an upward correction — bi-weekly GradientBoostingRegressor on fee-homogeneous 15 mega-caps = near-immune; PSR 10.6% low, not a true leader; universe corrected Multi-asset→Equities; baseline-clone 32958201) |
+| Temporal-CNN-Prediction | 29816576 | 0.54 | **0.161** | -70% | **historique** (downgraded — DL/CNN weekly retraining overfits real fees severely; confirms ML-Temporal-CNN 0.73→0.46 pattern but MORE severe (0.54→0.161 barely above zero); QQQ top-3 universe + fee drag + overfit; PSR 2.7%; universe Multi-asset→Equities; baseline-clone 32967763 + temporalcnn.py lib copy) |
 
-**Finding (methodological, now 28-strategy sample)** : the remediation impact is **not
+**Finding (methodological, now 29-strategy sample)** : the remediation impact is **not
 uniform**, and the batch-4 results *refine and partly correct* the earlier 10-strategy pattern.
 The distinguishing axis is **not** asset class, nor ML-vs-indicator alone — it is the
 combination of (a) the fee-per-trade the asset class carries and (b) how the strategy turns


### PR DESCRIPTION
## Summary

Post-#2801 verification of **Temporal-CNN-Prediction** (project `29816576`) — catalog-only atomic PR for the #1630 campaign.

The original `main.py` carried **no brokerage model** AND imports a custom `temporalcnn` library (TensorFlow/Keras Conv1D). Verified via a **baseline-clone** (`32967763`) with both `main.py` (+`set_brokerage_model(IBKR, MARGIN)`) and `temporalcnn.py` (copied verbatim).

## Backtest evidence

- Project: `32967763` (clone of `29816576`) · Compile `7cc5a379...` **BuildSuccess** (0 err)
- Backtest `4e6ec942b7a827a89c4a626ed27d97a0` · 2018-2024 (~5yrs), **Completed**
- **Sharpe 0.161** · CAGR 4.8% · MaxDD 31.7% · **PSR 2.675%**
- (`tradeableDates=0` / `totalOrders=0` are known phantom parse bugs for dynamic-universe strategies; the metrics are real — source of truth = QC Cloud UI.)

## Classification

- Catalog `0.54` → real **0.161** = **-70% → DOWNGRADE robuste → historique** (Sharpe well below 0.5).
- **Universe correction**: catalog "Multi-asset" → **Equities (QQQ top-3 by weight)** — the strategy trades QQQ ETF constituents, not multi-asset (4th catalog mislabel found in the ML/DL family).

## Finding — confirms DL overfits real fees, more severely than ML-Temporal-CNN

This **confirms** the DL-overfits-real-fees finding (ML-Temporal-CNN `0.73 → 0.46`), but **MORE severe**: `0.54 → 0.161` is barely above zero. The weekly CNN retraining (Conv1D on QQQ top-3 OHLCV, 20 epochs, ~780 model fits over the period) overfits; combined with fee drag on the QQQ equity universe, the strategy is essentially non-viable net of costs. PSR 2.7% very low. This is now two CNN strategies collapsing under real fees — the DL regime is consistently fragile.

## Catalog edits

- Tier-1 row 30 (downgrade to historique + universe correction + MaxDD/Calmar filled)
- Secondary table row (Temporal-CNN-Prediction, project 29816576, baseline-clone 32967763 + temporalcnn.py lib copy)
- Finding count 28 → 29

Partial delivery to the #1630 epic — `See #1630` (not `Closes`).

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
