### PR TITLE
docs(arg-analysis): reflect Executor re-exec success (COMPLETE_VALIDATED 100%)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -243,7 +243,7 @@ Le pipeline génère un rapport JSON dans `output/analysis_report.json` :
 
 [La mer qui monte](../../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du dépôt — l'analyse d'argumentation comme changement de représentation vers le vérifiable : du langage naturel aux sémantiques formelles qu'on peut interroger.
 
-> **Note** : Cette série est en statut DRAFT — les notebooks définissent l'architecture mais n'ont pas encore d'exécution complète. Voir [RECONSTRUCTION_PLAN.md](RECONSTRUCTION_PLAN.md) pour le statut.
+> **Note** : Le pipeline est exécutable de bout en bout. L'`Executor` (point d'entrée Papermill/MCP) a été re-exécuté avec succès le 2026-06-16 : validation `COMPLETE_VALIDATED` à 100 % (1 argument identifié, 4 sophismes, 1 belief set formel, 10 requêtes au solveur). Voir [RECONSTRUCTION_PLAN.md](RECONSTRUCTION_PLAN.md) pour le diagnostic des bugs structurels résolus (résolution de chemin robuste, fuite de `os.chdir` hors du `%run`, chaîne `%run` cohérente).
 
 ## Ressources
 


### PR DESCRIPTION
## Summary

La note README (ligne 246) affirmait la série en statut **DRAFT** « les notebooks définissent l'architecture mais n'ont pas encore d'exécution complète ».

Cette affirmation est **stale** après #3132 : l'`Executor` a été re-exécuté avec succès le 2026-06-16 (Papermill SUCCESS 481s, validation `COMPLETE_VALIDATED` 100 % — 1 argument, 4 sophismes, 1 belief set formel, 10 requêtes au solveur, 0 fuite `sk-` dans les outputs).

## Change

Mise à jour honnête de la note :
- Avant : « série en statut DRAFT … pas encore d'exécution complète »
- Après : « Le pipeline est exécutable de bout en bout … COMPLETE_VALIDATED 100 % … » + lien vers `RECONSTRUCTION_PLAN.md` (bugs structurels résolus : résolution de chemin robuste, fuite `os.chdir` hors du `%run`, chaîne `%run` cohérente).

## Verification

- `git diff --stat` : 1 fichier, 1 insertion / 1 deletion — prose-only.
- CATALOG-STATUS marker (README lignes 3-8) **byte-identical** (catalog-pr-hygiene respecté : le catalogue appartient à l'automatisation, jamais régénéré sur une branche feature).
- Aucun code, aucun notebook, aucun output touché.

## Why

Règle G.1 / G.9 + honnêteté des rapports : le dépôt ne doit pas affirmer un statut DRAFT contredit par une re-exec réussie documentée. Correction docs atomique, un seul sujet.

See #2137 (contribution à l'Epic Argumentum — cette PR ne ferme pas l'epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)