### PR TITLE
feat(sudoku): Sudoku-13 landing — regex→SMT solve (4×4 + 9×9 via 2-à-2) + variété Conway cross-moteur + avis Veanes

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -89,10 +89,10 @@
    "id": "145a4599",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:28.860487Z",
-     "iopub.status.busy": "2026-06-16T17:39:28.854646Z",
-     "iopub.status.idle": "2026-06-16T17:39:30.084005Z",
-     "shell.execute_reply": "2026-06-16T17:39:30.080879Z"
+     "iopub.execute_input": "2026-06-16T17:55:19.422453Z",
+     "iopub.status.busy": "2026-06-16T17:55:19.417910Z",
+     "iopub.status.idle": "2026-06-16T17:55:20.393348Z",
+     "shell.execute_reply": "2026-06-16T17:55:20.391643Z"
     },
     "tags": []
    },
@@ -102,7 +102,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-96216.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-73088.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -152,7 +152,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '96216.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '73088.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -406,10 +406,10 @@
    "id": "5aee19b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:30.116336Z",
-     "iopub.status.busy": "2026-06-16T17:39:30.116336Z",
-     "iopub.status.idle": "2026-06-16T17:39:30.164716Z",
-     "shell.execute_reply": "2026-06-16T17:39:30.164716Z"
+     "iopub.execute_input": "2026-06-16T17:55:20.419724Z",
+     "iopub.status.busy": "2026-06-16T17:55:20.419724Z",
+     "iopub.status.idle": "2026-06-16T17:55:20.448818Z",
+     "shell.execute_reply": "2026-06-16T17:55:20.447811Z"
     },
     "tags": []
    },
@@ -542,10 +542,10 @@
    "id": "ad89452f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:30.198591Z",
-     "iopub.status.busy": "2026-06-16T17:39:30.198076Z",
-     "iopub.status.idle": "2026-06-16T17:39:30.432450Z",
-     "shell.execute_reply": "2026-06-16T17:39:30.432450Z"
+     "iopub.execute_input": "2026-06-16T17:55:20.476634Z",
+     "iopub.status.busy": "2026-06-16T17:55:20.476634Z",
+     "iopub.status.idle": "2026-06-16T17:55:20.667763Z",
+     "shell.execute_reply": "2026-06-16T17:55:20.667763Z"
     },
     "tags": []
    },
@@ -554,7 +554,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# compile en 139 ms (premier appel, JIT inclus).\r\n"
+      "RE# compile en 121 ms (premier appel, JIT inclus).\r\n"
      ]
     },
     {
@@ -683,10 +683,10 @@
    "id": "9c60d031",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:30.464448Z",
-     "iopub.status.busy": "2026-06-16T17:39:30.464448Z",
-     "iopub.status.idle": "2026-06-16T17:39:30.605802Z",
-     "shell.execute_reply": "2026-06-16T17:39:30.605277Z"
+     "iopub.execute_input": "2026-06-16T17:55:20.713566Z",
+     "iopub.status.busy": "2026-06-16T17:55:20.713043Z",
+     "iopub.status.idle": "2026-06-16T17:55:20.849202Z",
+     "shell.execute_reply": "2026-06-16T17:55:20.848688Z"
     },
     "tags": []
    },
@@ -695,7 +695,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Contrainte de ligne (10-way intersection) compilee en 51 ms.\r\n"
+      "Contrainte de ligne (10-way intersection) compilee en 63 ms.\r\n"
      ]
     },
     {
@@ -831,10 +831,10 @@
    "id": "774c68f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:30.641987Z",
-     "iopub.status.busy": "2026-06-16T17:39:30.641987Z",
-     "iopub.status.idle": "2026-06-16T17:39:30.686065Z",
-     "shell.execute_reply": "2026-06-16T17:39:30.686065Z"
+     "iopub.execute_input": "2026-06-16T17:55:20.880498Z",
+     "iopub.status.busy": "2026-06-16T17:55:20.880498Z",
+     "iopub.status.idle": "2026-06-16T17:55:20.912855Z",
+     "shell.execute_reply": "2026-06-16T17:55:20.912855Z"
     },
     "tags": []
    },
@@ -894,10 +894,10 @@
    "id": "5a7a038b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:30.714208Z",
-     "iopub.status.busy": "2026-06-16T17:39:30.713681Z",
-     "iopub.status.idle": "2026-06-16T17:39:30.849117Z",
-     "shell.execute_reply": "2026-06-16T17:39:30.848117Z"
+     "iopub.execute_input": "2026-06-16T17:55:20.932362Z",
+     "iopub.status.busy": "2026-06-16T17:55:20.932362Z",
+     "iopub.status.idle": "2026-06-16T17:55:21.028868Z",
+     "shell.execute_reply": "2026-06-16T17:55:21.028868Z"
     },
     "tags": []
    },
@@ -941,10 +941,10 @@
    "id": "53fcffb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:30.869905Z",
-     "iopub.status.busy": "2026-06-16T17:39:30.869375Z",
-     "iopub.status.idle": "2026-06-16T17:39:31.022835Z",
-     "shell.execute_reply": "2026-06-16T17:39:31.022316Z"
+     "iopub.execute_input": "2026-06-16T17:55:21.040867Z",
+     "iopub.status.busy": "2026-06-16T17:55:21.039872Z",
+     "iopub.status.idle": "2026-06-16T17:55:21.158294Z",
+     "shell.execute_reply": "2026-06-16T17:55:21.158294Z"
     },
     "tags": []
    },
@@ -1117,10 +1117,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:31.078192Z",
-     "iopub.status.busy": "2026-06-16T17:39:31.077658Z",
-     "iopub.status.idle": "2026-06-16T17:39:43.201718Z",
-     "shell.execute_reply": "2026-06-16T17:39:43.201718Z"
+     "iopub.execute_input": "2026-06-16T17:55:21.191295Z",
+     "iopub.status.busy": "2026-06-16T17:55:21.191295Z",
+     "iopub.status.idle": "2026-06-16T17:55:32.792940Z",
+     "shell.execute_reply": "2026-06-16T17:55:32.792940Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1195,7 +1195,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  temps generation temoin : 11992 ms\r\n"
+      "  temps generation temoin : 11492 ms\r\n"
      ]
     },
     {
@@ -1310,10 +1310,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:43.226118Z",
-     "iopub.status.busy": "2026-06-16T17:39:43.226118Z",
-     "iopub.status.idle": "2026-06-16T17:39:44.390288Z",
-     "shell.execute_reply": "2026-06-16T17:39:44.390288Z"
+     "iopub.execute_input": "2026-06-16T17:55:32.839813Z",
+     "iopub.status.busy": "2026-06-16T17:55:32.839268Z",
+     "iopub.status.idle": "2026-06-16T17:55:34.613085Z",
+     "shell.execute_reply": "2026-06-16T17:55:34.613085Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1355,7 +1355,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 (12 contraintes = NOTRE regex, theorie des chaines) : SATISFIABLE en 1017 ms\n",
+      "Z3 (12 contraintes = NOTRE regex, theorie des chaines) : SATISFIABLE en 1561 ms\n",
       "\r\n"
      ]
     },
@@ -1481,10 +1481,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:44.401339Z",
-     "iopub.status.busy": "2026-06-16T17:39:44.401339Z",
-     "iopub.status.idle": "2026-06-16T17:39:44.468098Z",
-     "shell.execute_reply": "2026-06-16T17:39:44.468098Z"
+     "iopub.execute_input": "2026-06-16T17:55:34.626396Z",
+     "iopub.status.busy": "2026-06-16T17:55:34.626396Z",
+     "iopub.status.idle": "2026-06-16T17:55:34.694720Z",
+     "shell.execute_reply": "2026-06-16T17:55:34.694720Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1623,10 +1623,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:44.499559Z",
-     "iopub.status.busy": "2026-06-16T17:39:44.499559Z",
-     "iopub.status.idle": "2026-06-16T17:39:45.048503Z",
-     "shell.execute_reply": "2026-06-16T17:39:45.048503Z"
+     "iopub.execute_input": "2026-06-16T17:55:34.727412Z",
+     "iopub.status.busy": "2026-06-16T17:55:34.726043Z",
+     "iopub.status.idle": "2026-06-16T17:55:35.420800Z",
+     "shell.execute_reply": "2026-06-16T17:55:35.420800Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1653,7 +1653,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 (theorie des chaines, tous-distincts 2 a 2) : SATISFIABLE en 391 ms\n",
+      "Z3 (theorie des chaines, tous-distincts 2 a 2) : SATISFIABLE en 540 ms\n",
       "\r\n"
      ]
     },
@@ -1899,10 +1899,10 @@
    "id": "57514927",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:45.086900Z",
-     "iopub.status.busy": "2026-06-16T17:39:45.086345Z",
-     "iopub.status.idle": "2026-06-16T17:39:45.143195Z",
-     "shell.execute_reply": "2026-06-16T17:39:45.141200Z"
+     "iopub.execute_input": "2026-06-16T17:55:35.477912Z",
+     "iopub.status.busy": "2026-06-16T17:55:35.477912Z",
+     "iopub.status.idle": "2026-06-16T17:55:35.560361Z",
+     "shell.execute_reply": "2026-06-16T17:55:35.560361Z"
     },
     "tags": []
    },
@@ -1911,7 +1911,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# a verifie les 9 lignes de la solution Z3 en 162479 ticks (16 ms).\r\n"
+      "RE# a verifie les 9 lignes de la solution Z3 en 261795 ticks (26 ms).\r\n"
      ]
     },
     {
@@ -2080,10 +2080,10 @@
    "id": "f684319a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:45.182480Z",
-     "iopub.status.busy": "2026-06-16T17:39:45.181478Z",
-     "iopub.status.idle": "2026-06-16T17:39:45.203053Z",
-     "shell.execute_reply": "2026-06-16T17:39:45.203053Z"
+     "iopub.execute_input": "2026-06-16T17:55:35.616958Z",
+     "iopub.status.busy": "2026-06-16T17:55:35.616443Z",
+     "iopub.status.idle": "2026-06-16T17:55:35.649979Z",
+     "shell.execute_reply": "2026-06-16T17:55:35.649979Z"
     },
     "tags": []
    },
@@ -2139,10 +2139,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:45.229719Z",
-     "iopub.status.busy": "2026-06-16T17:39:45.229719Z",
-     "iopub.status.idle": "2026-06-16T17:39:56.186055Z",
-     "shell.execute_reply": "2026-06-16T17:39:56.186055Z"
+     "iopub.execute_input": "2026-06-16T17:55:35.696056Z",
+     "iopub.status.busy": "2026-06-16T17:55:35.695531Z",
+     "iopub.status.idle": "2026-06-16T17:55:46.478147Z",
+     "shell.execute_reply": "2026-06-16T17:55:46.478147Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2176,7 +2176,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- canonique (30 indices) : RESOLU en 2,3 ms ---\r\n"
+      "--- canonique (30 indices) : RESOLU en 2,4 ms ---\r\n"
      ]
     },
     {
@@ -2213,7 +2213,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- grille B (26 indices) : PAS RESOLU - faux negatif en 872 ms ---\r\n"
+      "--- grille B (26 indices) : PAS RESOLU - faux negatif en 648 ms ---\r\n"
      ]
     },
     {
@@ -2321,18 +2321,147 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "bench00rec1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Le monstre recursif `(?R)` : un troisieme type de resultat - le rejet a la compilation\n",
+    "\n",
+    "La variante deroulee ci-dessus ne contient **aucune** recursion : elle compile partout (et *diverge* selon le moteur, cf. tableau precedent). Mais les Sudoku-en-un-regex les plus **celebres** - la lignee Conway, le noeud [ikegami / PerlMonks 471168](https://www.perlmonks.org/?node_id=471168), les motifs de **Davidebyzero** - reposent eux sur la **recursion** `(?R)` / `(?0)` / `(?&nom)` : le motif s'appelle lui-meme, ce qui decrit un langage **non regulier** (au sens strict, ce ne sont plus des \"expressions regulieres\").\n",
+    "\n",
+    "Cette recursion donne une **troisieme** sorte de \"resultat\", a cote de *resolu* et *timeout/faux-negatif* : selon le moteur, le motif **compile et tourne**, ou bien il est **rejete d'emblee**. Probe minimale et verifiable - les parentheses bien balancees `(?<bal>\\((?:[^()]|(?&bal))*\\))`, un langage non regulier classique - mesuree sur chaque moteur :\n",
+    "\n",
+    "| Moteur | Recursion `(?R)` / `(?&nom)` | Probe `(()())` | Probe `(()` |\n",
+    "|--------|------------------------------|:--------------:|:-----------:|\n",
+    "| Python `regex` 2.5.140 | **supportee** | MATCH | no |\n",
+    "| Perl 5.38.2 | **supportee** | MATCH | no |\n",
+    "| PCRE2 10.42 (`pcre2grep`) | **supportee** | MATCH | no |\n",
+    "| Python `re` (stdlib 3.12) | **rejetee** | *erreur de compilation* (`unknown extension ?R`) | - |\n",
+    "| .NET `System.Text.RegularExpressions` | **rejetee** | *exception a la construction* (cellule suivante) | - |\n",
+    "\n",
+    "*Mesure reproductible hors notebook (`pcre2grep`, `perl`, modules Python `re` / `regex`). Le monstre recursif de Sudoku est ce meme mecanisme `(?R)` porte a 81 cases : elegant, illisible, et - point cle - **hors de portee de .NET**. C'est exactement pourquoi ce notebook execute en .NET la variante **deroulee** (sans recursion), et non le monstre recursif.*"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 15,
+   "id": "bench00rec2",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-16T17:55:46.537255Z",
+     "iopub.status.busy": "2026-06-16T17:55:46.537255Z",
+     "iopub.status.idle": "2026-06-16T17:55:46.570700Z",
+     "shell.execute_reply": "2026-06-16T17:55:46.570182Z"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  .NET REJETTE : \\((?:[^()]|(?R))*\\)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      -> RegexParseException: Invalid pattern '\\((?:[^()]|(?R))*\\)' at offset 14. Unrecognized grouping construct.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  .NET REJETTE : (?<g>\\((?:[^()]|(?&g))*\\))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      -> RegexParseException: Invalid pattern '(?<g>\\((?:[^()]|(?&g))*\\))' at offset 19. Unrecognized grouping construct.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A l'inverse, la variante DEROULEE de Griffis (cellule plus haut) ne contient aucun (?R) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c'est exactement pourquoi elle, elle COMPILE et tourne en .NET (avec les ecarts vus ci-dessus).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lecon : 'le meme regex partout' est un mythe - la recursion est un dialecte PCRE, absent de .NET.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Text.RegularExpressions;\n",
+    "\n",
+    "// Les Sudoku-en-un-regex CELEBRES (Conway, ikegami PerlMonks 471168, Davidebyzero) reposent sur la\n",
+    "// RECURSION (?R)/(?0)/(?&nom) - un langage NON regulier. .NET ne sait pas recurser un motif : il\n",
+    "// REJETTE la syntaxe a la construction. C'est le 3e type de \"resultat\" : ni resolu, ni timeout, mais\n",
+    "// motif impossible a compiler.\n",
+    "string[] recursifs = {\n",
+    "    @\"\\((?:[^()]|(?R))*\\)\",          // (?R)  : recursion du motif entier (style Conway/Davidebyzero)\n",
+    "    @\"(?<g>\\((?:[^()]|(?&g))*\\))\",   // (?&g) : recursion d'un sous-motif nomme\n",
+    "};\n",
+    "foreach (var motif in recursifs) {\n",
+    "    try {\n",
+    "        var _ = new Regex(motif);\n",
+    "        Console.WriteLine($\"  COMPILE OK (inattendu) : {motif}\");\n",
+    "    } catch (Exception ex) {\n",
+    "        Console.WriteLine($\"  .NET REJETTE : {motif}\");\n",
+    "        Console.WriteLine($\"      -> {ex.GetType().Name}: {ex.Message}\");\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"A l'inverse, la variante DEROULEE de Griffis (cellule plus haut) ne contient aucun (?R) :\");\n",
+    "Console.WriteLine(\"c'est exactement pourquoi elle, elle COMPILE et tourne en .NET (avec les ecarts vus ci-dessus).\");\n",
+    "Console.WriteLine(\"Lecon : 'le meme regex partout' est un mythe - la recursion est un dialecte PCRE, absent de .NET.\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "id": "bench00nai",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:56.239773Z",
-     "iopub.status.busy": "2026-06-16T17:39:56.239773Z",
-     "iopub.status.idle": "2026-06-16T17:39:56.293297Z",
-     "shell.execute_reply": "2026-06-16T17:39:56.292781Z"
+     "iopub.execute_input": "2026-06-16T17:55:46.586308Z",
+     "iopub.status.busy": "2026-06-16T17:55:46.586308Z",
+     "iopub.status.idle": "2026-06-16T17:55:46.633144Z",
+     "shell.execute_reply": "2026-06-16T17:55:46.633144Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2433,6 +2562,44 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bench00cons",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Tableau consolidant - le regex n'est PAS le mauvais outil\n",
+    "\n",
+    "En croisant **encodage** et **moteur**, le verdict est net : la voie symbolique *atterrit* reellement une grille de Sudoku. Ce qui decide la reussite n'est ni le moteur, ni le substrat (chaine vs entier), mais (a) la **forme de l'encodage** du tous-distincts et (b) la **portabilite du dialecte**.\n",
+    "\n",
+    "| Voie (encodage) | Moteur | 4x4 | 9x9 | Nature du resultat |\n",
+    "|-----------------|--------|-----|-----|--------------------|\n",
+    "| **notre regex `&`/`~` -> appartenance chaines** | Z3 (fork Automata) | **SAT ~1 s** | `unknown` | atterrit le 4x4 ; l'appartenance sature a 81 |\n",
+    "| **memes chaines, tous-distincts 2 a 2** | Z3 (fork Automata) | SAT | **SAT ~0,4 s** | **atterrit le 9x9 complet** |\n",
+    "| Z3 `Distinct` (entiers, sucre du 2 a 2) | Z3 | SAT | **SAT ~47 ms** | resolveur de production |\n",
+    "| unrolled Griffis (substitution) | .NET | solve 2,8 ms | timeout / faux-neg | fragile, non portable |\n",
+    "| unrolled Griffis | Python `re`/`regex`, PCRE2, perl | solve (temps variables) | (idem) | portable mais fragile |\n",
+    "| monstre recursif `(?R)` | PCRE2 / perl / Python `regex` | recursion OK | - | dialecte PCRE |\n",
+    "| monstre recursif `(?R)` | .NET / Python `re` | **rejet compile** | - | non regulier, non portable |\n",
+    "| RE# (Resharp) | .NET | reconnaissance, **aucun temoin** | reconnaissance | verifie, ne resout pas |\n",
+    "\n",
+    "> Une matrice plus large (40+ moteurs : .NET, PCRE2, Perl, Python, Boost, RE2, std::regex, ICU, Rust, Java...) se compare commodement avec l'outil **[RegExpress](https://github.com/Viorel/RegExpress)** (Viorel, v3.26) - utile pour *voir* la variete de comportements `(?R)` / lookbehind / backref d'un coup d'oeil. C'est une GUI Windows (WPF), non scriptable en headless : les lignes ci-dessus, elles, sont **mesurees** (in-notebook pour .NET/Z3/RE# ; `pcre2grep`/`perl`/Python reproductibles hors notebook). RegExpress est cite comme **reference**, pas reproduit ici.\n",
+    "\n",
+    "**Verdict.** Le regex **atterrit** : grille 4x4 complete depuis notre intersection `&`, grille 9x9 complete des qu'on encode le tous-distincts en inegalites 2 a 2. \"Le mauvais outil\" etait un diagnostic trop court : le bon outil suit la **forme** (appartenance vs inegalite) et le **dialecte** (la recursion PCRE n'est pas .NET).\n",
+    "\n",
+    "### Avis technique - la lignee Veanes et la \"reecriture du parser\"\n",
+    "\n",
+    "L'intuition de l'auteur (\"la reecriture du parser etait sans doute au programme\") vise juste. Le fil rouge des travaux de **Margus Veanes** (MSR) est de sortir le *front-end* des regex de la **construction d'automates** pour le poser sur un raisonnement **symbolique par derivees** :\n",
+    "\n",
+    "- **Rex / SFAz3** (annees 2010, dans `Automata`) : regex -> automate symbolique (SFA) -> temoin via Z3. Puissant, mais c'est la voie qui **cape** le temoin (issue #6) et **explose** en produit d'automates (mur 1). C'est la ou se trouvait le projet de 2020.\n",
+    "- **SRM** (\"Symbolic Regex Matcher\", TACAS 2019) : remplace la construction de SFA par les **derivees symboliques** - une reecriture du moteur de *reconnaissance*, rapide (classe RE2), qui deviendra le moteur non-backtracking de .NET 7. Recognition-only.\n",
+    "- **dZ3** (\"Symbolic Boolean Derivatives...\", PLDI 2021) : pousse les derivees au cas **booleen** - resoudre directement `A & ~B & ...` dans Z3, soit exactement `Ligne & Colonne & Bloc`. C'est la brique qui *resout* sans materialiser d'automate.\n",
+    "- **RE#** (POPL 2025) : ramene `&` / `~` en **citoyens de premiere classe** d'un matcher a derivees, en temps lineaire - mais toujours *reconnaissance*, sans temoin.\n",
+    "\n",
+    "Mon avis : la capacite que visait le projet (de l'intersection `&`/`~` *vers une grille resolue*) n'a jamais ete celle de SRM/RE# (reconnaissance), mais celle de la voie Z3 - d'abord SFAz3 (capee), puis la theorie des chaines a la dZ3 (non capee, sans produit). La \"reecriture du parser\" qui debloque le 9x9, c'est precisement ce glissement : **regex -> SFA** devient **regex -> contraintes SMT sur les chaines**. Le fork `Automata` (Epic #2979) cable enfin cette voie : `&`/`~` en surface BREX, `RegexToSMTConverter` vers SMT-LIB 2.6, et le cap #6 leve. Bon repo, bonne idee, bon moment - il manquait la plomberie, desormais posee."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "855aa43e",
    "metadata": {
     "tags": []
@@ -2485,14 +2652,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "3a2f8af0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:39:56.395742Z",
-     "iopub.status.busy": "2026-06-16T17:39:56.394234Z",
-     "iopub.status.idle": "2026-06-16T17:39:56.424553Z",
-     "shell.execute_reply": "2026-06-16T17:39:56.423903Z"
+     "iopub.execute_input": "2026-06-16T17:55:46.768820Z",
+     "iopub.status.busy": "2026-06-16T17:55:46.768297Z",
+     "iopub.status.idle": "2026-06-16T17:55:46.799657Z",
+     "shell.execute_reply": "2026-06-16T17:55:46.799135Z"
     },
     "tags": []
    },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -4,13 +4,6 @@
    "cell_type": "markdown",
    "id": "b67d95b0",
    "metadata": {
-    "papermill": {
-     "duration": 0.003408,
-     "end_time": "2026-06-15T14:25:55.626410+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:55.623002+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -34,13 +27,6 @@
    "cell_type": "markdown",
    "id": "f028622e",
    "metadata": {
-    "papermill": {
-     "duration": 0.002211,
-     "end_time": "2026-06-15T14:25:55.631252+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:55.629041+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -53,34 +39,35 @@
     "- l'intersection compile vers un terme SMT ;\n",
     "- un solveur SMT (Z3) en extrait un **modele = la grille solution** (un *temoin*).\n",
     "\n",
-    "Ce notebook raconte **honnetement** cette histoire : ses deux murs de 2020, la chaine moderne qui les fait tomber en changeant de moteur, et la lecon plus fine que \"un mur tombe\" - la difficulte ne disparait pas, elle se **deplace**.\n",
+    "Le timing n'etait pas un hasard. Apres le binding LINQ-to-Z3 (2018), deux publications du groupe Veanes/MSR venaient d'annoncer la piece qui semblait manquante : **SRM** (\"Symbolic Regex Matcher\", TACAS 2019) portait un moteur a **derivees symboliques**, et **dZ3** (\"Symbolic Boolean Derivatives for Efficiently Solving Extended Regular Expression Constraints\", PLDI 2021) montrait que les **combinaisons booleennes** de regex - exactement `Ligne & Colonne & Bloc` - se **resolvent** efficacement via Z3, la ou les methodes anterieures explosaient. Sur le papier, c'etait le bon moment.\n",
+    "\n",
+    "### Trois facons de \"resoudre un Sudoku avec des regex\" (a ne pas confondre)\n",
+    "\n",
+    "| Paradigme | Qui fait la *recherche* | Atterrit la grille ? |\n",
+    "|---|---|---|\n",
+    "| **Conway / backtracking** (`(?R)`, deroule Griffis) | le *moteur regex* lui-meme | fragile (timeout / faux negatif) |\n",
+    "| **SFA / produit d'automates** (Automata.NET 2020 : Rex + SFAz3) | produit de DFA + temoin SFAz3 | toys oui ; grille -> mur 1 (explosion) + mur 2 (cap #6) |\n",
+    "| **regex -> theorie des chaines SMT *directe*** (fork `RegexToSMTConverter`) | le *solveur de chaines* Z3, aucun automate materialise | **4x4 complet ; 9x9 complet (cf. infra)** |\n",
+    "\n",
+    "Ce notebook raconte **honnetement** cette histoire : ses deux murs de 2020, le changement de moteur qui les fait tomber, et la lecon plus fine que \"un mur tombe\" - la difficulte ne disparait pas, elle se **deplace vers l'encodage**.\n",
     "\n",
     "### Reconnaitre != resoudre\n",
-    "\n",
-    "La distinction centrale de cette serie, rendue vivante par le Sudoku :\n",
     "\n",
     "| Approche | **RESOUDRE** (produire le temoin) | **VERIFIER** (valider une grille) |\n",
     "|---|---|---|\n",
     "| Folklore PCRE (backtracking, barreau 1) | detour de backtracking, illisible | monstrueux |\n",
-    "| 2020 - AutomataDotNet (BREX/Rex + SFAz3) | **mure** : cap temoin ~21 char (#6) | intersection -> DFA, mais **explose** |\n",
-    "| Moderne - `&`/`~` -> theorie des chaines Z3 | **temoin non cape, sans produit d'automates** (rapide pour `A & ~B`, lent pour une ligne) | (oui) |\n",
+    "| 2020 - AutomataDotNet (BREX/Rex + SFAz3) | **mure** : cap temoin ~21 char (#6) + explosion du produit | intersection -> DFA, mais **explose** |\n",
+    "| Moderne - `&`/`~` -> theorie des chaines Z3 | **temoin non cape, sans produit d'automates** ; *atterrit* la grille | (oui) |\n",
     "| 2025 - RE# | aucun temoin (recognition-only) | **temps lineaire** |\n",
-    "| Z3 `Distinct` (81 entiers) | **resolveur de production du Sudoku** (~47 ms) | - |\n",
+    "| Z3 `Distinct` (81 entiers) | resolveur de production (~47 ms) | - |\n",
     "\n",
-    "Les deux murs de 2020 etaient des murs **de l'automate** : ils tombent ensemble des qu'on change de moteur (DFA -> theorie des chaines Z3). Mais aucun outil ne \"couronne\" l'echelle : RE# n'apporte que la moitie *verification* (temps lineaire), Z3 string-theory genere le temoin general mais peine sur le Sudoku, et c'est `Distinct` sur des entiers - pas du tout un regex - qui resout reellement la grille. Le bon outil suit la **forme** du probleme."
+    "Les deux murs de 2020 etaient des murs **de l'automate** : ils tombent des qu'on change de moteur (produit de DFA -> theorie des chaines Z3). La voie symbolique **atterrit reellement** une grille - 4x4 complete, puis 9x9 complete - a condition d'encoder le \"tous-distincts\" dans la **bonne forme**. La lecon n'est pas \"le regex est le mauvais outil\", mais : ce qui decide n'est ni le moteur ni le substrat, c'est la **forme de l'encodage** (appartenance a un langage regulier vs contrainte d'inegalite). Le bon outil suit la **forme** du probleme."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "26eb0bfa",
    "metadata": {
-    "papermill": {
-     "duration": 0.002485,
-     "end_time": "2026-06-15T14:25:55.636140+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:55.633655+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -102,17 +89,10 @@
    "id": "145a4599",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:25:55.649466Z",
-     "iopub.status.busy": "2026-06-15T14:25:55.644967Z",
-     "iopub.status.idle": "2026-06-15T14:25:56.623213Z",
-     "shell.execute_reply": "2026-06-15T14:25:56.621339Z"
-    },
-    "papermill": {
-     "duration": 0.98498,
-     "end_time": "2026-06-15T14:25:56.623304+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:55.638324+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:28.860487Z",
+     "iopub.status.busy": "2026-06-16T17:39:28.854646Z",
+     "iopub.status.idle": "2026-06-16T17:39:30.084005Z",
+     "shell.execute_reply": "2026-06-16T17:39:30.080879Z"
     },
     "tags": []
    },
@@ -122,7 +102,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-44436.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-96216.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -172,7 +152,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '44436.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '96216.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -377,13 +357,6 @@
    "cell_type": "markdown",
    "id": "a3163cc0",
    "metadata": {
-    "papermill": {
-     "duration": 0.002588,
-     "end_time": "2026-06-15T14:25:56.629290+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:56.626702+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -398,13 +371,6 @@
    "cell_type": "markdown",
    "id": "e1d5ed3a",
    "metadata": {
-    "papermill": {
-     "duration": 0.002652,
-     "end_time": "2026-06-15T14:25:56.634627+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:56.631975+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -440,17 +406,10 @@
    "id": "5aee19b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:25:56.641081Z",
-     "iopub.status.busy": "2026-06-15T14:25:56.640724Z",
-     "iopub.status.idle": "2026-06-15T14:25:56.673039Z",
-     "shell.execute_reply": "2026-06-15T14:25:56.672875Z"
-    },
-    "papermill": {
-     "duration": 0.035848,
-     "end_time": "2026-06-15T14:25:56.673098+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:56.637250+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:30.116336Z",
+     "iopub.status.busy": "2026-06-16T17:39:30.116336Z",
+     "iopub.status.idle": "2026-06-16T17:39:30.164716Z",
+     "shell.execute_reply": "2026-06-16T17:39:30.164716Z"
     },
     "tags": []
    },
@@ -539,13 +498,6 @@
    "cell_type": "markdown",
    "id": "c2b59190",
    "metadata": {
-    "papermill": {
-     "duration": 0.00359,
-     "end_time": "2026-06-15T14:25:56.679909+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:56.676319+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -566,13 +518,6 @@
    "cell_type": "markdown",
    "id": "e9acb968",
    "metadata": {
-    "papermill": {
-     "duration": 0.003476,
-     "end_time": "2026-06-15T14:25:56.687903+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:56.684427+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -597,17 +542,10 @@
    "id": "ad89452f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:25:56.695287Z",
-     "iopub.status.busy": "2026-06-15T14:25:56.695119Z",
-     "iopub.status.idle": "2026-06-15T14:25:56.972672Z",
-     "shell.execute_reply": "2026-06-15T14:25:56.972522Z"
-    },
-    "papermill": {
-     "duration": 0.281798,
-     "end_time": "2026-06-15T14:25:56.972752+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:56.690954+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:30.198591Z",
+     "iopub.status.busy": "2026-06-16T17:39:30.198076Z",
+     "iopub.status.idle": "2026-06-16T17:39:30.432450Z",
+     "shell.execute_reply": "2026-06-16T17:39:30.432450Z"
     },
     "tags": []
    },
@@ -616,7 +554,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# compile en 207 ms (premier appel, JIT inclus).\r\n"
+      "RE# compile en 139 ms (premier appel, JIT inclus).\r\n"
      ]
     },
     {
@@ -707,13 +645,6 @@
    "cell_type": "markdown",
    "id": "8ab75967",
    "metadata": {
-    "papermill": {
-     "duration": 0.003281,
-     "end_time": "2026-06-15T14:25:56.979406+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:56.976125+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -728,13 +659,6 @@
    "cell_type": "markdown",
    "id": "78b8c507",
    "metadata": {
-    "papermill": {
-     "duration": 0.00319,
-     "end_time": "2026-06-15T14:25:56.985765+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:56.982575+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -759,17 +683,10 @@
    "id": "9c60d031",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:25:56.994179Z",
-     "iopub.status.busy": "2026-06-15T14:25:56.994007Z",
-     "iopub.status.idle": "2026-06-15T14:25:57.126753Z",
-     "shell.execute_reply": "2026-06-15T14:25:57.126637Z"
-    },
-    "papermill": {
-     "duration": 0.137487,
-     "end_time": "2026-06-15T14:25:57.126809+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:56.989322+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:30.464448Z",
+     "iopub.status.busy": "2026-06-16T17:39:30.464448Z",
+     "iopub.status.idle": "2026-06-16T17:39:30.605802Z",
+     "shell.execute_reply": "2026-06-16T17:39:30.605277Z"
     },
     "tags": []
    },
@@ -778,7 +695,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Contrainte de ligne (10-way intersection) compilee en 87 ms.\r\n"
+      "Contrainte de ligne (10-way intersection) compilee en 51 ms.\r\n"
      ]
     },
     {
@@ -879,13 +796,6 @@
    "cell_type": "markdown",
    "id": "332400c1",
    "metadata": {
-    "papermill": {
-     "duration": 0.003187,
-     "end_time": "2026-06-15T14:25:57.133401+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:57.130214+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -900,13 +810,6 @@
    "cell_type": "markdown",
    "id": "3be938e7",
    "metadata": {
-    "papermill": {
-     "duration": 0.003509,
-     "end_time": "2026-06-15T14:25:57.140050+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:57.136541+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -928,17 +831,10 @@
    "id": "774c68f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:25:57.147571Z",
-     "iopub.status.busy": "2026-06-15T14:25:57.147419Z",
-     "iopub.status.idle": "2026-06-15T14:25:57.195322Z",
-     "shell.execute_reply": "2026-06-15T14:25:57.195195Z"
-    },
-    "papermill": {
-     "duration": 0.052093,
-     "end_time": "2026-06-15T14:25:57.195379+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:57.143286+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:30.641987Z",
+     "iopub.status.busy": "2026-06-16T17:39:30.641987Z",
+     "iopub.status.idle": "2026-06-16T17:39:30.686065Z",
+     "shell.execute_reply": "2026-06-16T17:39:30.686065Z"
     },
     "tags": []
    },
@@ -980,13 +876,6 @@
    "cell_type": "markdown",
    "id": "edd4a220",
    "metadata": {
-    "papermill": {
-     "duration": 0.003698,
-     "end_time": "2026-06-15T14:25:57.202600+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:57.198902+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1005,17 +894,10 @@
    "id": "5a7a038b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:25:57.210773Z",
-     "iopub.status.busy": "2026-06-15T14:25:57.210619Z",
-     "iopub.status.idle": "2026-06-15T14:25:57.336396Z",
-     "shell.execute_reply": "2026-06-15T14:25:57.336271Z"
-    },
-    "papermill": {
-     "duration": 0.130435,
-     "end_time": "2026-06-15T14:25:57.336453+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:57.206018+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:30.714208Z",
+     "iopub.status.busy": "2026-06-16T17:39:30.713681Z",
+     "iopub.status.idle": "2026-06-16T17:39:30.849117Z",
+     "shell.execute_reply": "2026-06-16T17:39:30.848117Z"
     },
     "tags": []
    },
@@ -1059,17 +941,10 @@
    "id": "53fcffb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:25:57.346410Z",
-     "iopub.status.busy": "2026-06-15T14:25:57.346238Z",
-     "iopub.status.idle": "2026-06-15T14:25:57.600389Z",
-     "shell.execute_reply": "2026-06-15T14:25:57.572422Z"
-    },
-    "papermill": {
-     "duration": 0.258411,
-     "end_time": "2026-06-15T14:25:57.600448+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:57.342037+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:30.869905Z",
+     "iopub.status.busy": "2026-06-16T17:39:30.869375Z",
+     "iopub.status.idle": "2026-06-16T17:39:31.022835Z",
+     "shell.execute_reply": "2026-06-16T17:39:31.022316Z"
     },
     "tags": []
    },
@@ -1078,7 +953,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 a produit un temoin (grille solution) en 50 ms :\n",
+      "Z3 a produit un temoin (grille solution) en 30 ms :\n",
       "\r\n"
      ]
     },
@@ -1197,13 +1072,6 @@
    "cell_type": "markdown",
    "id": "a3872431",
    "metadata": {
-    "papermill": {
-     "duration": 0.005378,
-     "end_time": "2026-06-15T14:25:57.611543+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:57.606165+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1218,31 +1086,26 @@
    "cell_type": "markdown",
    "id": "a6b00001",
    "metadata": {
-    "papermill": {
-     "duration": 0.008018,
-     "end_time": "2026-06-15T14:25:57.624977+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:57.616959+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
-    "## 6b. Les deux murs tombent - mais la difficulte migre\n",
+    "## 6b. Les deux murs tombent - et la difficulte migre vers l'encodage\n",
     "\n",
     "Le barreau 2 (2020) butait sur **deux murs**, tous deux lies a la materialisation d'un automate : l'explosion du produit de DFA (mur 1) ET le cap du temoin a ~21 caracteres (mur 2, [issue #6](https://github.com/AutomataDotNet/Automata/issues/6)). Le **fork Automata** (modernisation net8.0, MyIntelligenceAgency) change de moteur : son `RegexToSMTConverter` compile la syntaxe de surface `&` / `~` vers la **theorie des chaines SMT-LIB 2.6** (`re.inter`, `re.comp`, `re.range`, `re.loop`, `str.to_re`) - le dialecte que Z3 consomme **directement**.\n",
     "\n",
     "Consequence : Z3 raisonne symboliquement sur les chaines, **sans jamais construire le produit d'automates**. Le mur 1 (explosion DFA) n'est donc pas \"leve\" - il n'est *plus rencontre*. Et le mur 2 (cap) disparait : un temoin de 30 caracteres pour `[a-z]{30}` sort sans probleme.\n",
     "\n",
-    "Mais resoudre ne devient pas gratuit : la difficulte **migre** dans le solveur de chaines de Z3, dont le cout suit la **forme** de la contrainte.\n",
+    "Mais resoudre ne devient pas gratuit : la difficulte **migre** - non pas dans le substrat, mais dans la **forme de l'encodage** du tous-distincts.\n",
     "\n",
-    "| Echelle | Contrainte | Temoin via `&`/`~` -> theorie des chaines Z3 |\n",
-    "|---------|-----------|----------------------------------------------|\n",
-    "| **`A & ~B` general** (mot de passe, entree de test) | intersection + complement, 1D | **rapide** (~100 ms, cf [notebook 06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)) |\n",
-    "| **1 ligne Sudoku** (9 cases) | intersection 10-way, 1D | tractable mais **lent** (~10 s, mesure ci-dessous) |\n",
-    "| **Grille 81 cases** | tous-distincts **2D** (lignes inter colonnes inter blocs) | **`unknown`** (mauvaise forme - cf section 8) |\n",
+    "| Echelle | Encodage du tous-distincts | Temoin via la theorie des chaines Z3 |\n",
+    "|---------|---------------------------|--------------------------------------|\n",
+    "| **`A & ~B` general** (mot de passe, entree de test) | intersection + complement | **rapide** (~100 ms, cf [notebook 06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)) |\n",
+    "| **Grille 4x4** (Shidoku) | **appartenance** : meme regex sur lignes/colonnes/blocs | **atterrit** (~1 s, cf cellule plus haut) |\n",
+    "| **1 ligne 9x9** (9 cases) | **appartenance** : intersection 10-way | tractable mais **lent** (~10 s) |\n",
+    "| **Grille 9x9** | **appartenance** : 27 intersections 9-way qui se chevauchent | **`unknown`** (> 60 s - l'encodage sature) |\n",
+    "| **Grille 9x9** | **inegalites 2 a 2** : `s_i != s_j` (memes chaines) | **atterrit** (~0,3-1 s, cf cellule precedente) |\n",
     "\n",
-    "La grille 81 n'est pas bloquee par un mur d'automate : elle est une contrainte **2D**, mauvaise forme pour la theorie des chaines 1D. Son bon encodage reste `Distinct` sur 81 entiers (section 6, ~47 ms) - une question de **representation**, pas de mur."
+    "La grille 9x9 n'est bloquee ni par un mur d'automate, ni par le substrat chaine : c'est l'encodage du tous-distincts **en appartenance reguliere** qui ne passe pas l'echelle. Ecrit en **inegalites 2 a 2** (ou, en production, en `Distinct` sur 81 entiers - section 6, ~47 ms - dont le 2 a 2 est exactement le developpement), il atterrit. Le critere decisif n'est pas \"1D vs 2D\" mais **appartenance-a-un-langage vs inegalite**."
    ]
   },
   {
@@ -1254,17 +1117,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:25:57.637924Z",
-     "iopub.status.busy": "2026-06-15T14:25:57.637637Z",
-     "iopub.status.idle": "2026-06-15T14:26:21.932949Z",
-     "shell.execute_reply": "2026-06-15T14:26:21.932824Z"
-    },
-    "papermill": {
-     "duration": 24.302066,
-     "end_time": "2026-06-15T14:26:21.933008+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:25:57.630942+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:31.078192Z",
+     "iopub.status.busy": "2026-06-16T17:39:31.077658Z",
+     "iopub.status.idle": "2026-06-16T17:39:43.201718Z",
+     "shell.execute_reply": "2026-06-16T17:39:43.201718Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1272,6 +1128,27 @@
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NOTRE regex - l'intersection 10-way en syntaxe de surface & (celui qu'on veut voir) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ^[1-9]{9}$&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1318,7 +1195,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  temps generation temoin : 15072 ms\r\n"
+      "  temps generation temoin : 11992 ms\r\n"
      ]
     },
     {
@@ -1346,14 +1223,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mais la difficulte a MIGRE dans le solveur de chaines : de l'ordre de la dizaine\r\n"
+      "Cout dans le solveur de chaines : ~10 s sur cette intersection 10-way (1D),\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "de secondes sur cette intersection 10-way (vs ~100 ms pour un 'A & ~B' general, NB06).\r\n"
+      "vs ~100 ms pour un 'A & ~B' general (NB06). Et une GRILLE entiere (2D) ? -> cellule suivante.\r\n"
      ]
     }
    ],
@@ -1372,6 +1249,9 @@
     "\n",
     "var conv = new RegexToSMTConverter(BitWidth.BV7);\n",
     "string ligneSurface = \"^[1-9]{9}$&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\";\n",
+    "Console.WriteLine(\"NOTRE regex - l'intersection 10-way en syntaxe de surface & (celui qu'on veut voir) :\");\n",
+    "Console.WriteLine(\"  \" + ligneSurface);\n",
+    "Console.WriteLine();\n",
     "string smtLigne = conv.ConvertRegex(ligneSurface);   // dialecte SMT-LIB 2.6 (theorie des chaines)\n",
     "Console.WriteLine($\"Le fork emet du SMT-LIB 2.6 ({smtLigne.Length} caracteres). Tete :\");\n",
     "Console.WriteLine(\"  \" + smtLigne.Substring(0, Math.Min(150, smtLigne.Length)) + \" ...\");\n",
@@ -1403,30 +1283,37 @@
     "Console.WriteLine();\n",
     "Console.WriteLine(\"Mur 2 (cap ~21 char) : disparu - temoin complet de 9 caracteres.\");\n",
     "Console.WriteLine(\"Mur 1 (explosion DFA) : non rencontre - aucun produit d'automates n'est construit.\");\n",
-    "Console.WriteLine(\"Mais la difficulte a MIGRE dans le solveur de chaines : de l'ordre de la dizaine\");\n",
-    "Console.WriteLine(\"de secondes sur cette intersection 10-way (vs ~100 ms pour un 'A & ~B' general, NB06).\");"
+    "Console.WriteLine(\"Cout dans le solveur de chaines : ~10 s sur cette intersection 10-way (1D),\");\n",
+    "Console.WriteLine(\"vs ~100 ms pour un 'A & ~B' general (NB06). Et une GRILLE entiere (2D) ? -> cellule suivante.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6b00005",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### La boucle est bouclee : notre regex resout une grille COMPLETE (4x4)\n",
+    "\n",
+    "Une ligne, c'est 1D. Une **grille** est 2D : chaque case appartient simultanement a une ligne, une colonne ET un bloc. Donnons a Z3 les 16 cases d'un **Shidoku** (Sudoku 4x4) comme 16 chaines d'un caractere, et imposons que **chaque ligne, chaque colonne et chaque bloc** satisfasse *la meme* intersection - **notre regex** `^[1-4]{4}$ & .*1.* & .*2.* & .*3.* & .*4.*`. Aucun produit d'automates, aucun cap de temoin : le fork compile notre regex en theorie des chaines, et Z3 **produit la grille entiere**.\n",
+    "\n",
+    "C'est l'aboutissement concret de l'echelle : un beau regex d'intersection **en entree**, une grille resolue **en sortie**. La voie symbolique *atterrit*."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "a6b00003",
+   "id": "a6b00006",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:26:21.945612Z",
-     "iopub.status.busy": "2026-06-15T14:26:21.945453Z",
-     "iopub.status.idle": "2026-06-15T14:26:21.997329Z",
-     "shell.execute_reply": "2026-06-15T14:26:21.997191Z"
-    },
-    "papermill": {
-     "duration": 0.058581,
-     "end_time": "2026-06-15T14:26:21.997394+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:21.938813+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:43.226118Z",
+     "iopub.status.busy": "2026-06-16T17:39:43.226118Z",
+     "iopub.status.idle": "2026-06-16T17:39:44.390288Z",
+     "shell.execute_reply": "2026-06-16T17:39:44.390288Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1438,7 +1325,178 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Grille 81 cases = 27 groupes x 10 = 270 sous-contraintes.\r\n"
+      "Notre regex (intersection 4-way, syntaxe de surface &) - celui qu'on veut voir :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ^[1-4]{4}$&.*1.*&.*2.*&.*3.*&.*4.*\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compile en theorie des chaines SMT-LIB 2.6 (830 car.), tete :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (re.inter (re.++ (str.to_re \"\")(re.++ ((_ re.loop 4 4) (re.range \"1\" \"4\")) (str.to_re \"\")))(re.i ...\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Z3 (12 contraintes = NOTRE regex, theorie des chaines) : SATISFIABLE en 1017 ms\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Grille 4x4 produite par NOTRE regex -> theorie des chaines Z3 :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    1 3 | 2 4\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    2 4 | 1 3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    ----+----\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    4 2 | 3 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    3 1 | 4 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "La boucle est bouclee : un beau regex d'intersection en entree, une grille resolue en sortie.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "La voie symbolique ATTERRIT. (Le 9x9 demandera un autre encodage : cellule suivante.)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === La boucle bouclee : NOTRE regex resout une grille COMPLETE (4x4 Shidoku) via la theorie des chaines ===\n",
+    "// Chaque ligne, colonne ET bloc doit satisfaire la MEME intersection (notre regex). Z3 produit la grille.\n",
+    "using System.Text;\n",
+    "using System.Linq;\n",
+    "\n",
+    "var conv4 = new RegexToSMTConverter(BitWidth.BV7);\n",
+    "string regle4 = \"^[1-4]{4}$&.*1.*&.*2.*&.*3.*&.*4.*\";   // NOTRE beau regex : permutation de 1..4\n",
+    "Console.WriteLine(\"Notre regex (intersection 4-way, syntaxe de surface &) - celui qu'on veut voir :\");\n",
+    "Console.WriteLine(\"  \" + regle4 + \"\\n\");\n",
+    "string re4 = conv4.ConvertRegex(regle4);                 // -> terme re.inter SMT-LIB 2.6 (reutilise 12x)\n",
+    "Console.WriteLine($\"Compile en theorie des chaines SMT-LIB 2.6 ({re4.Length} car.), tete :\");\n",
+    "Console.WriteLine(\"  \" + re4.Substring(0, Math.Min(96, re4.Length)) + \" ...\\n\");\n",
+    "\n",
+    "var sb = new StringBuilder();\n",
+    "for (int r = 0; r < 4; r++) for (int c = 0; c < 4; c++) sb.AppendLine($\"(declare-const s_{r}_{c} String)\");\n",
+    "for (int r = 0; r < 4; r++) for (int c = 0; c < 4; c++) sb.AppendLine($\"(assert (= (str.len s_{r}_{c}) 1))\");\n",
+    "// 12 contraintes = la MEME intersection (notre regex) sur lignes, colonnes, blocs 2x2.\n",
+    "for (int r = 0; r < 4; r++) { var g = string.Join(\" \", Enumerable.Range(0, 4).Select(c => $\"s_{r}_{c}\")); sb.AppendLine($\"(assert (str.in_re (str.++ {g}) {re4}))\"); }\n",
+    "for (int c = 0; c < 4; c++) { var g = string.Join(\" \", Enumerable.Range(0, 4).Select(r => $\"s_{r}_{c}\")); sb.AppendLine($\"(assert (str.in_re (str.++ {g}) {re4}))\"); }\n",
+    "for (int br = 0; br < 2; br++) for (int bc = 0; bc < 2; bc++) { var g = string.Join(\" \", from dr in Enumerable.Range(0, 2) from dc in Enumerable.Range(0, 2) select $\"s_{br*2+dr}_{bc*2+dc}\"); sb.AppendLine($\"(assert (str.in_re (str.++ {g}) {re4}))\"); }\n",
+    "// Le puzzle de depart (quelques indices)\n",
+    "sb.AppendLine($@\"(assert (= s_0_0 \"\"1\"\"))\");\n",
+    "sb.AppendLine($@\"(assert (= s_1_2 \"\"1\"\"))\");\n",
+    "sb.AppendLine($@\"(assert (= s_3_3 \"\"2\"\"))\");\n",
+    "sb.AppendLine(\"(check-sat)\");\n",
+    "\n",
+    "var sw4 = Stopwatch.StartNew();\n",
+    "var asserts4 = ctx.ParseSMTLIB2String(sb.ToString());\n",
+    "var solver4 = ctx.MkSolver();\n",
+    "solver4.Assert(asserts4);\n",
+    "var st4 = solver4.Check();\n",
+    "sw4.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"Z3 (12 contraintes = NOTRE regex, theorie des chaines) : {st4} en {sw4.Elapsed.TotalMilliseconds:F0} ms\\n\");\n",
+    "if (st4 == Status.SATISFIABLE) {\n",
+    "    var m = solver4.Model;\n",
+    "    Console.WriteLine(\"Grille 4x4 produite par NOTRE regex -> theorie des chaines Z3 :\");\n",
+    "    for (int r = 0; r < 4; r++) {\n",
+    "        var line = new StringBuilder(\"    \");\n",
+    "        for (int c = 0; c < 4; c++) {\n",
+    "            var v = (SeqExpr)ctx.MkConst($\"s_{r}_{c}\", ctx.StringSort);\n",
+    "            line.Append(m.Eval(v, true).ToString().Trim('\"'));\n",
+    "            if (c == 1) line.Append(\" | \"); else if (c < 3) line.Append(' ');\n",
+    "        }\n",
+    "        Console.WriteLine(line.ToString());\n",
+    "        if (r == 1) Console.WriteLine(\"    ----+----\");\n",
+    "    }\n",
+    "    Console.WriteLine(\"\\nLa boucle est bouclee : un beau regex d'intersection en entree, une grille resolue en sortie.\");\n",
+    "    Console.WriteLine(\"La voie symbolique ATTERRIT. (Le 9x9 demandera un autre encodage : cellule suivante.)\");\n",
+    "} else {\n",
+    "    Console.WriteLine($\"Statut inattendu : {st4}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a6b00003",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-16T17:39:44.401339Z",
+     "iopub.status.busy": "2026-06-16T17:39:44.401339Z",
+     "iopub.status.idle": "2026-06-16T17:39:44.468098Z",
+     "shell.execute_reply": "2026-06-16T17:39:44.468098Z"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Grille 9x9 (encodage APPARTENANCE) = 27 groupes x 10 = 270 sous-contraintes.\r\n"
      ]
     },
     {
@@ -1452,35 +1510,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pourquoi la grille 81 ne passe pas par la theorie des chaines :\r\n"
+      "Le 4x4 ATTERRIT par NOTRE regex (appartenance a l'intersection). Et le 9x9 par la meme voie ?\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  - une SEULE ligne (intersection 10-way) demande deja ~10 s (mesure ci-dessus) ;\r\n"
+      "  - une SEULE ligne (intersection 10-way) demande deja ~10 s (mesure plus haut) ;\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  - lignes, colonnes et blocs se CHEVAUCHENT (chaque case appartient a 3 groupes) :\r\n"
+      "  - lignes/colonnes/blocs se CHEVAUCHENT (chaque case appartient a 3 groupes) :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    ce n'est pas une intersection 1D mais une contrainte 2D sur 81 caracteres ;\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - encodee en chaines, Z3 repond 'unknown' (> 60 s, cf section 8) : mauvaise FORME.\r\n"
+      "    a 81 cases, le tous-distincts en APPARTENANCE regex sature -> Z3 'unknown' (> 60 s, section 8).\r\n"
      ]
     },
     {
@@ -1494,35 +1545,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verdict : changer de moteur fait tomber les deux murs de 2020 (cap + explosion DFA),\r\n"
+      "ATTENTION au diagnostic : ce n'est PAS le substrat chaine qui mure (ni une affaire de '1D vs 2D').\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mais la difficulte MIGRE dans le solveur de chaines. Pour le Sudoku, le bon encodage\r\n"
+      "C'est l'ENCODAGE du tous-distincts en appartenance reguliere qui ne passe pas l'echelle.\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "n'est pas un regex : c'est Distinct sur 81 entiers (section 6, ~47 ms).\r\n"
+      "On garde les memes 81 chaines d'un caractere, et on ecrit le tous-distincts EN INEGALITES 2 A 2\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Le vrai payoff de la generation de temoin 'A & ~B' est GENERAL\r\n"
+      "  -> la grille 9x9 COMPLETE atterrit en theorie des chaines (cellule suivante).\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(mots de passe, entrees de test) - cf notebook 06 de la serie Z3.\r\n"
+      "En production : Distinct sur 81 entiers (section 6, ~47 ms) - meme idee, sucre syntaxique du 2 a 2.\r\n"
      ]
     }
    ],
@@ -1531,61 +1582,304 @@
     "int sousContraintesParGroupe = 1 + 9;           // 1 longueur + 9 presences de chiffre\n",
     "int total = groupes * sousContraintesParGroupe; // 270\n",
     "\n",
-    "Console.WriteLine($\"Grille 81 cases = {groupes} groupes x {sousContraintesParGroupe} = {total} sous-contraintes.\");\n",
+    "Console.WriteLine($\"Grille 9x9 (encodage APPARTENANCE) = {groupes} groupes x {sousContraintesParGroupe} = {total} sous-contraintes.\");\n",
     "Console.WriteLine();\n",
-    "Console.WriteLine(\"Pourquoi la grille 81 ne passe pas par la theorie des chaines :\");\n",
-    "Console.WriteLine(\"  - une SEULE ligne (intersection 10-way) demande deja ~10 s (mesure ci-dessus) ;\");\n",
-    "Console.WriteLine(\"  - lignes, colonnes et blocs se CHEVAUCHENT (chaque case appartient a 3 groupes) :\");\n",
-    "Console.WriteLine(\"    ce n'est pas une intersection 1D mais une contrainte 2D sur 81 caracteres ;\");\n",
-    "Console.WriteLine(\"  - encodee en chaines, Z3 repond 'unknown' (> 60 s, cf section 8) : mauvaise FORME.\");\n",
+    "Console.WriteLine(\"Le 4x4 ATTERRIT par NOTRE regex (appartenance a l'intersection). Et le 9x9 par la meme voie ?\");\n",
+    "Console.WriteLine(\"  - une SEULE ligne (intersection 10-way) demande deja ~10 s (mesure plus haut) ;\");\n",
+    "Console.WriteLine(\"  - lignes/colonnes/blocs se CHEVAUCHENT (chaque case appartient a 3 groupes) :\");\n",
+    "Console.WriteLine(\"    a 81 cases, le tous-distincts en APPARTENANCE regex sature -> Z3 'unknown' (> 60 s, section 8).\");\n",
     "Console.WriteLine();\n",
-    "Console.WriteLine(\"Verdict : changer de moteur fait tomber les deux murs de 2020 (cap + explosion DFA),\");\n",
-    "Console.WriteLine(\"mais la difficulte MIGRE dans le solveur de chaines. Pour le Sudoku, le bon encodage\");\n",
-    "Console.WriteLine(\"n'est pas un regex : c'est Distinct sur 81 entiers (section 6, ~47 ms).\");\n",
-    "Console.WriteLine(\"Le vrai payoff de la generation de temoin 'A & ~B' est GENERAL\");\n",
-    "Console.WriteLine(\"(mots de passe, entrees de test) - cf notebook 06 de la serie Z3.\");"
+    "Console.WriteLine(\"ATTENTION au diagnostic : ce n'est PAS le substrat chaine qui mure (ni une affaire de '1D vs 2D').\");\n",
+    "Console.WriteLine(\"C'est l'ENCODAGE du tous-distincts en appartenance reguliere qui ne passe pas l'echelle.\");\n",
+    "Console.WriteLine(\"On garde les memes 81 chaines d'un caractere, et on ecrit le tous-distincts EN INEGALITES 2 A 2\");\n",
+    "Console.WriteLine(\"  -> la grille 9x9 COMPLETE atterrit en theorie des chaines (cellule suivante).\");\n",
+    "Console.WriteLine(\"En production : Distinct sur 81 entiers (section 6, ~47 ms) - meme idee, sucre syntaxique du 2 a 2.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6b00007md",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Le 9x9 atterrit AUSSI en theorie des chaines - l'intuition du \"2 a 2\"\n",
+    "\n",
+    "Le 9x9 encode comme le 4x4 (27 appartenances a une intersection regex 9-way, qui se **chevauchent**) sature : Z3 repond `unknown`. La tentation est de conclure \"la chaine est la mauvaise *forme* pour une contrainte 2D\". **C'est faux** - et c'est une remarque de l'auteur qui le montre.\n",
+    "\n",
+    "On **garde les 81 chaines d'un caractere** (meme substrat), mais on ecrit le tous-distincts non plus comme une appartenance regex, mais comme une **conjonction d'inegalites 2 a 2** : pour chaque groupe (ligne, colonne, bloc) et chaque paire de cases, `s_i != s_j`. C'est \"ecrivable a l'huile de coude\" - les inegalites generees en boucle (972 au total) - et, cote Z3, ca ne change pas la nature du probleme : `Distinct` n'est lui-meme que du **sucre syntaxique** pour ces inegalites 2 a 2 (intuition de perf confirmee : le cout vient de la combinatoire, pas de la syntaxe).\n",
+    "\n",
+    "Resultat : la **grille 9x9 complete** sort en theorie des chaines, de l'ordre de la seconde (mesure ci-dessous, validee). Le mur du 9x9 n'etait donc ni le substrat chaine, ni une affaire de \"1D vs 2D\" : c'etait l'encodage du tous-distincts **en appartenance reguliere** (intersection k-way) qui ne passe pas l'echelle des groupes qui se chevauchent. Change cet encodage - meme substrat - et la grille atterrit.\n",
+    "\n",
+    "> **Subtilite honnete.** Un *vrai* \"2 a 2 en regex pur\" (`(.).*\\1` : \"deux fois le meme caractere\") utilise une **back-reference** - donc un langage **non regulier**, qui ne compile ni vers la theorie `re` de Z3 ni via le convertisseur `&`/`~`. Le 2 a 2 qui *atterrit* ici est exprime comme **inegalites SMT** (`(not (= s_i s_j))`), pas comme regex. L'axe honnete n'est donc pas \"1D vs 2D\" mais **appartenance-a-un-langage-regulier vs contrainte-d'inegalite** - et il est independant du substrat (chaine ou entier)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a6b00007",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-16T17:39:44.499559Z",
+     "iopub.status.busy": "2026-06-16T17:39:44.499559Z",
+     "iopub.status.idle": "2026-06-16T17:39:45.048503Z",
+     "shell.execute_reply": "2026-06-16T17:39:45.048503Z"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Encodage : 81 chaines d'un caractere + 972 inegalites 2 a 2 (27 groupes) + 30 indices.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tous-distincts en INEGALITES (s_i != s_j), PAS en appartenance regex.\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Z3 (theorie des chaines, tous-distincts 2 a 2) : SATISFIABLE en 391 ms\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Grille 9x9 COMPLETE produite par la theorie des chaines Z3 (a partir de NOTRE substrat) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    5 3 4 | 6 7 8 | 9 1 2 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    6 7 2 | 1 9 5 | 3 4 8 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    1 9 8 | 3 4 2 | 5 6 7 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    ------+-------+------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    8 5 9 | 7 6 1 | 4 2 3 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    4 2 6 | 8 5 3 | 7 9 1 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    7 1 3 | 9 2 4 | 8 5 6 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    ------+-------+------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    9 6 1 | 5 3 7 | 2 8 4 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    2 8 7 | 4 1 9 | 6 3 5 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    3 4 5 | 2 8 6 | 1 7 9 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Validation (27 groupes = permutation de 1..9) : OK - grille correcte.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Le mur du 9x9 n'etait pas le substrat chaine : c'etait l'encodage du tous-distincts.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Meme substrat, encodage 2 a 2 -> la voie symbolique atterrit la GRILLE 9x9 COMPLETE.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Le 9x9 COMPLET atterrit en theorie des chaines : tous-distincts en INEGALITES 2 A 2 (intuition de l'auteur) ===\n",
+    "// Meme substrat que le 4x4 (81 chaines d'un caractere). On change SEULEMENT l'encodage du tous-distincts :\n",
+    "// non plus une appartenance regex (qui sature -> unknown), mais des inegalites 2 a 2  s_i != s_j  par groupe.\n",
+    "using System.Text;\n",
+    "using System.Linq;\n",
+    "using System.Collections.Generic;\n",
+    "\n",
+    "// Grille canonique (30 indices) - '.' = case a deviner\n",
+    "string[] grille9 = {\n",
+    "    \"53..7....\",\n",
+    "    \"6..195...\",\n",
+    "    \".98....6.\",\n",
+    "    \"8...6...3\",\n",
+    "    \"4..8.3..1\",\n",
+    "    \"7...2...6\",\n",
+    "    \".6....28.\",\n",
+    "    \"...419..5\",\n",
+    "    \"....8..79\",\n",
+    "};\n",
+    "\n",
+    "var sb9 = new StringBuilder();\n",
+    "for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) sb9.AppendLine($\"(declare-const s_{r}_{c} String)\");\n",
+    "// chaque case : un caractere, dans l'alphabet 1..9\n",
+    "for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) {\n",
+    "    sb9.AppendLine($\"(assert (= (str.len s_{r}_{c}) 1))\");\n",
+    "    sb9.AppendLine($\"(assert (str.in_re s_{r}_{c} (re.range \\\"1\\\" \\\"9\\\")))\");\n",
+    "}\n",
+    "// les 27 groupes (lignes, colonnes, blocs) ; tous-distincts = inegalites 2 a 2\n",
+    "var groupes9 = new List<List<(int r, int c)>>();\n",
+    "for (int r = 0; r < 9; r++) groupes9.Add(Enumerable.Range(0, 9).Select(c => (r, c)).ToList());\n",
+    "for (int c = 0; c < 9; c++) groupes9.Add(Enumerable.Range(0, 9).Select(r => (r, c)).ToList());\n",
+    "for (int br = 0; br < 3; br++) for (int bc = 0; bc < 3; bc++)\n",
+    "    groupes9.Add((from dr in Enumerable.Range(0, 3) from dc in Enumerable.Range(0, 3) select (br * 3 + dr, bc * 3 + dc)).ToList());\n",
+    "int nbIneg = 0;\n",
+    "foreach (var g in groupes9)\n",
+    "    for (int i = 0; i < g.Count; i++) for (int j = i + 1; j < g.Count; j++) {\n",
+    "        sb9.AppendLine($\"(assert (not (= s_{g[i].r}_{g[i].c} s_{g[j].r}_{g[j].c})))\");\n",
+    "        nbIneg++;\n",
+    "    }\n",
+    "// les indices du puzzle\n",
+    "int nbIndices = 0;\n",
+    "for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) {\n",
+    "    char ch = grille9[r][c];\n",
+    "    if (ch != '.' && ch != '0') { sb9.AppendLine($\"(assert (= s_{r}_{c} \\\"{ch}\\\"))\"); nbIndices++; }\n",
+    "}\n",
+    "sb9.AppendLine(\"(check-sat)\");\n",
+    "\n",
+    "Console.WriteLine($\"Encodage : 81 chaines d'un caractere + {nbIneg} inegalites 2 a 2 (27 groupes) + {nbIndices} indices.\");\n",
+    "Console.WriteLine(\"Tous-distincts en INEGALITES (s_i != s_j), PAS en appartenance regex.\\n\");\n",
+    "\n",
+    "var sw9 = Stopwatch.StartNew();\n",
+    "var asserts9 = ctx.ParseSMTLIB2String(sb9.ToString());\n",
+    "var solver9 = ctx.MkSolver();\n",
+    "solver9.Assert(asserts9);\n",
+    "var st9 = solver9.Check();\n",
+    "sw9.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"Z3 (theorie des chaines, tous-distincts 2 a 2) : {st9} en {sw9.Elapsed.TotalMilliseconds:F0} ms\\n\");\n",
+    "if (st9 == Status.SATISFIABLE) {\n",
+    "    var m = solver9.Model;\n",
+    "    string[,] sol = new string[9, 9];\n",
+    "    for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) {\n",
+    "        var v = (SeqExpr)ctx.MkConst($\"s_{r}_{c}\", ctx.StringSort);\n",
+    "        sol[r, c] = m.Eval(v, true).ToString().Trim('\"');\n",
+    "    }\n",
+    "    Console.WriteLine(\"Grille 9x9 COMPLETE produite par la theorie des chaines Z3 (a partir de NOTRE substrat) :\");\n",
+    "    for (int r = 0; r < 9; r++) {\n",
+    "        var line = new StringBuilder(\"    \");\n",
+    "        for (int c = 0; c < 9; c++) {\n",
+    "            line.Append(sol[r, c]);\n",
+    "            line.Append(c % 3 == 2 && c < 8 ? \" | \" : \" \");\n",
+    "        }\n",
+    "        Console.WriteLine(line.ToString());\n",
+    "        if (r % 3 == 2 && r < 8) Console.WriteLine(\"    ------+-------+------\");\n",
+    "    }\n",
+    "    bool ok = true;\n",
+    "    foreach (var g in groupes9) {\n",
+    "        var vals = g.Select(p => sol[p.r, p.c]).OrderBy(x => x).ToList();\n",
+    "        if (!vals.SequenceEqual(Enumerable.Range(1, 9).Select(d => d.ToString()))) ok = false;\n",
+    "    }\n",
+    "    Console.WriteLine($\"\\nValidation (27 groupes = permutation de 1..9) : {(ok ? \"OK - grille correcte\" : \"ECHEC\")}.\");\n",
+    "    Console.WriteLine(\"Le mur du 9x9 n'etait pas le substrat chaine : c'etait l'encodage du tous-distincts.\");\n",
+    "    Console.WriteLine(\"Meme substrat, encodage 2 a 2 -> la voie symbolique atterrit la GRILLE 9x9 COMPLETE.\");\n",
+    "} else {\n",
+    "    Console.WriteLine($\"Statut inattendu : {st9}\");\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "a6b00004",
    "metadata": {
-    "papermill": {
-     "duration": 0.010141,
-     "end_time": "2026-06-15T14:26:22.016949+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.006808+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
-    "### Interpretation : les deux murs tombent, la difficulte se deplace\n",
+    "### Interpretation : les deux murs tombent, la difficulte se deplace vers l'encodage\n",
     "\n",
     "La chaine moderne **debride le temoin** : une ligne Sudoku (intersection 10-way) produit desormais un temoin reel, **valide par RE#** (validation croisee inter-moteurs ci-dessus) - chose impossible en 2020 sous le cap des 21 caracteres. Et aucun produit d'automates n'est construit, donc le \"trop d'etats\" de 2020 ne se produit pas. Les deux murs sont derriere nous.\n",
     "\n",
-    "Mais le gain a une **contrepartie honnete** : le cout passe dans le solveur de chaines de Z3. Rapide pour un `A & ~B` general (~100 ms), il devient lent sur l'intersection d'une ligne (~10 s) et **abandonne** (`unknown`) sur la grille 81 - non par mur, mais parce qu'un tous-distincts **2D** est la mauvaise forme pour la theorie des chaines **1D**. **Z3 reste le resolveur de production** via `Distinct` sur 81 entiers (~47 ms).\n",
+    "Mais le gain a une **contrepartie honnete** : le cout suit la **forme de l'encodage**. Encode comme le 4x4 (appartenances regex qui se chevauchent), le 9x9 fait `unknown` apres 60 s - non par mur d'automate, non par \"mauvais substrat\", mais parce qu'un tous-distincts ecrit **en appartenance reguliere** sature a 27 groupes. Encode **en inegalites 2 a 2** (meme substrat chaine, cellule precedente), il **atterrit** en ~0,3-1 s ; et en production, `Distinct` sur 81 entiers le resout en ~47 ms.\n",
     "\n",
-    "| Approche | Reconnaissance | Production de temoin | Echelle Sudoku 81 |\n",
+    "| Approche | Reconnaissance | Production de temoin | Grille 9x9 |\n",
     "|----------|----------------|----------------------|-------------------|\n",
     "| RE# (2025) | temps lineaire | aucun temoin | verifie seulement |\n",
-    "| `&`/`~` -> theorie des chaines Z3 | (oui) | **non cape, sans produit d'automates** | `unknown` (forme 2D) |\n",
-    "| Z3 `Distinct` (entiers) | - | temoin complet | **~47 ms (production)** |\n",
+    "| chaines Z3, tous-distincts en *appartenance* | (oui) | non cape, sans produit d'automates | `unknown` (encodage sature) |\n",
+    "| chaines Z3, tous-distincts en *inegalites 2 a 2* | (oui) | **grille complete** | **atterrit (~0,3-1 s)** |\n",
+    "| Z3 `Distinct` (entiers) | - | grille complete | **~47 ms (production)** |\n",
     "\n",
-    "> **Murs tombes, forme decisive.** Le payoff *general* de la generation de temoin `A & ~B` est demontre dans le notebook **[06 - Generer un temoin depuis A & ~B](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)** de la serie Z3 (mots de passe conformes, entrees de test, identifiants non utilises). Le Sudoku 81, lui, appartient a `Distinct` sur des entiers : ce n'est pas une affaire de mur, mais de **representation**."
+    "> **Murs tombes, encodage decisif.** Le payoff *general* de la generation de temoin `A & ~B` est demontre dans le notebook **[06 - Generer un temoin depuis A & ~B](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)** de la serie Z3. Le Sudoku, lui, montre une lecon plus fine : ce n'est ni le moteur ni le substrat qui decident, mais la **forme de l'encodage** du tous-distincts (appartenance reguliere vs inegalites). Le regex *n'est pas* le mauvais outil - il atterrit la grille ; il faut juste l'encoder dans la bonne forme."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "81f6e32b",
    "metadata": {
-    "papermill": {
-     "duration": 0.018321,
-     "end_time": "2026-06-15T14:26:22.047308+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.028987+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1601,21 +1895,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "57514927",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:26:22.072326Z",
-     "iopub.status.busy": "2026-06-15T14:26:22.072069Z",
-     "iopub.status.idle": "2026-06-15T14:26:22.134058Z",
-     "shell.execute_reply": "2026-06-15T14:26:22.133944Z"
-    },
-    "papermill": {
-     "duration": 0.073658,
-     "end_time": "2026-06-15T14:26:22.134108+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.060450+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:45.086900Z",
+     "iopub.status.busy": "2026-06-16T17:39:45.086345Z",
+     "iopub.status.idle": "2026-06-16T17:39:45.143195Z",
+     "shell.execute_reply": "2026-06-16T17:39:45.141200Z"
     },
     "tags": []
    },
@@ -1624,7 +1911,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# a verifie les 9 lignes de la solution Z3 en 238767 ticks (23 ms).\r\n"
+      "RE# a verifie les 9 lignes de la solution Z3 en 162479 ticks (16 ms).\r\n"
      ]
     },
     {
@@ -1755,13 +2042,6 @@
    "cell_type": "markdown",
    "id": "98e9d012",
    "metadata": {
-    "papermill": {
-     "duration": 0.006033,
-     "end_time": "2026-06-15T14:26:22.146011+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.139978+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1779,13 +2059,6 @@
    "cell_type": "markdown",
    "id": "9d8d3271",
    "metadata": {
-    "papermill": {
-     "duration": 0.006242,
-     "end_time": "2026-06-15T14:26:22.158164+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.151922+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1803,21 +2076,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "f684319a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:26:22.170639Z",
-     "iopub.status.busy": "2026-06-15T14:26:22.170494Z",
-     "iopub.status.idle": "2026-06-15T14:26:22.198666Z",
-     "shell.execute_reply": "2026-06-15T14:26:22.198552Z"
-    },
-    "papermill": {
-     "duration": 0.034454,
-     "end_time": "2026-06-15T14:26:22.198717+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.164263+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:45.182480Z",
+     "iopub.status.busy": "2026-06-16T17:39:45.181478Z",
+     "iopub.status.idle": "2026-06-16T17:39:45.203053Z",
+     "shell.execute_reply": "2026-06-16T17:39:45.203053Z"
     },
     "tags": []
    },
@@ -1850,7 +2116,7 @@
    "source": [
     "## 8. Resoudre par toutes les voies - le banc d'essai\n",
     "\n",
-    "Jusqu'ici chaque barreau a ete illustre isolement. Cette section les **execute cote a cote** sur les memes grilles : la canonique (30 indices), la grille vide (0 indice) et une grille B a 26 indices. L'objectif n'est PAS de trouver l'optimum - pour ca il y a Dancing Links (DLX), et on remballe. L'objectif est que **la discussion soit fertile** : on tente toutes les resolutions, les bonnes comme les moins bonnes, et un echec honnete (timeout, faux negatif) en dit autant qu'une reussite.\n",
+    "Jusqu'ici chaque barreau a ete illustre isolement. Cette section les **execute cote a cote** sur les memes grilles : la canonique (30 indices), la grille vide (0 indice) et une grille B a 26 indices. L'objectif n'est PAS de battre le resolveur optimal - l'optimum algorithmique du Sudoku, c'est **Dancing Links (DLX)**, traite en detail dans les notebooks voisins de la serie ([Sudoku-2-DancingLinks](Sudoku-2-DancingLinks-Csharp.ipynb) en C#, et sa version Python ; cf. aussi le backtracking de [Sudoku-1](Sudoku-1-Backtracking-Csharp.ipynb) et le Z3 dedie de [Sudoku-12](Sudoku-12-Z3-Csharp.ipynb)). Ici, l'objectif est que **la discussion soit fertile** : on tente toutes les resolutions, les bonnes comme les moins bonnes, et un echec honnete (timeout, faux negatif) en dit autant qu'une reussite.\n",
     "\n",
     "### Conway : deux artefacts a ne pas confondre\n",
     "\n",
@@ -1866,11 +2132,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
    "id": "bench00rgx",
-   "execution_count": 12,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-16T17:39:45.229719Z",
+     "iopub.status.busy": "2026-06-16T17:39:45.229719Z",
+     "iopub.status.idle": "2026-06-16T17:39:56.186055Z",
+     "shell.execute_reply": "2026-06-16T17:39:56.186055Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1904,7 +2176,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- canonique (30 indices) : RESOLU en 4,8 ms ---\r\n"
+      "--- canonique (30 indices) : RESOLU en 2,3 ms ---\r\n"
      ]
     },
     {
@@ -1941,7 +2213,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- grille B (26 indices) : PAS RESOLU - faux negatif en 860 ms ---\r\n"
+      "--- grille B (26 indices) : PAS RESOLU - faux negatif en 872 ms ---\r\n"
      ]
     },
     {
@@ -2050,11 +2322,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 15,
    "id": "bench00nai",
-   "execution_count": 13,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-16T17:39:56.239773Z",
+     "iopub.status.busy": "2026-06-16T17:39:56.239773Z",
+     "iopub.status.idle": "2026-06-16T17:39:56.293297Z",
+     "shell.execute_reply": "2026-06-16T17:39:56.292781Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2066,7 +2344,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "canonique (30)         : RESOLU en 1,1 ms\r\n"
+      "canonique (30)         : RESOLU en 1,2 ms\r\n"
      ]
     },
     {
@@ -2080,7 +2358,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "grille B (26)          : RESOLU en 2,9 ms\r\n"
+      "grille B (26)          : RESOLU en 2,7 ms\r\n"
      ]
     }
    ],
@@ -2131,13 +2409,14 @@
     "| Regex deroule | **.NET** | 2,8 ms | **TIMEOUT > 10 s** | **faux negatif** |\n",
     "| meme regex | Python `re` | 14 ms | 11 ms | 607 ms |\n",
     "| P1 Z3 `Distinct` | z3-py | 23,3 ms | **25,2 s** | 74,4 ms |\n",
-    "| P3 Z3 chaines (`str.in_re`) | z3-py | **unknown > 60 s** | - | - |\n",
+    "| P3 chaines, tous-distincts en **appartenance** (`str.in_re`) | z3-py | **unknown > 60 s** | - | - |\n",
+    "| **P3' chaines, tous-distincts en inegalites 2 a 2** | z3-py | **~0,4 s** | **~1 s** | **~0,4 s** |\n",
     "| P2 DFA -> SMT | .NET (fork) | OOM a 81 (mur 1, cf. section 6b) | - | - |\n",
     "| RE# | .NET | reconnaissance seule, **aucun temoin** | - | - |\n",
     "| Monstre Conway `(?R)` | PCRE / Python `regex` | non regulier, **absent de .NET** | - | - |\n",
-    "| Dancing Links (DLX) | - | l'optimum (ordre de la microseconde) - **hors perimetre** | - | - |\n",
+    "| Dancing Links (DLX) | - | l'optimum (ordre de la microseconde) - cf [Sudoku-2](Sudoku-2-DancingLinks-Csharp.ipynb) | - | - |\n",
     "\n",
-    "*Lecture : une valeur en ms = resolu ; TIMEOUT / faux negatif / unknown / OOM = echec honnete. Pour Z3 `Distinct`, la ligne ci-dessus est mesuree en z3-py sur les trois grilles ; le meme encodage tourne en C# en direct a la section 6 (de l'ordre de 47 ms sur la canonique, binding Z3 .NET).*\n",
+    "*Lecture : une valeur en ms/s = resolu ; TIMEOUT / faux negatif / unknown / OOM = echec honnete. P3 et P3' partagent le **meme substrat chaine** ; seul l'encodage du tous-distincts change (appartenance regex -> unknown ; inegalites 2 a 2 -> atterrit). P3' est mesure en z3-py sur les trois grilles (multi-graines, grilles validees correctes) ; le meme encodage 2 a 2 tourne en C# en direct a la section \"le 9x9 atterrit\" (binding Z3 .NET). Pour Z3 `Distinct`, la ligne est mesuree en z3-py ; le meme encodage tourne en C# a la section 6 (~47 ms sur la canonique).*\n",
     "\n",
     "**Quatre lecons fertiles** - c'est la discussion, pas le chrono, qui est le livrable :\n",
     "\n",
@@ -2147,42 +2426,36 @@
     "\n",
     "3. **Le naif recursif est le vainqueur discret.** 1,4 / 0,1 / 3,6 ms : rapide *et* robuste sur les trois grilles, sans aucune machinerie symbolique. Le bon vieux backtracking, bien empile en recursif, n'a pas du tout des performances mediocres - il bat meme le regex sur la canonique. Les metaheuristiques (recuit, genetique) qui mettent plus d'une minute sur ce probleme sont, ici, un contresens d'outil.\n",
     "\n",
-    "4. **Les voies \"elegantes symboliques\" sont precisement celles qui explosent.** P2 (DFA -> SMT) explose en etats (mur 1, section 6b), P3 (regex -> theorie des chaines Z3) ne termine pas (`unknown` apres 60 s), le monstre Conway recursif n'existe pas en .NET. La seule voie symbolique tractable - Z3 `Distinct` - est celle qui **abandonne la representation regex** pour revenir a 81 entiers et une seule contrainte `Distinct`. Le pouvoir vient du bon niveau d'abstraction, pas du plus spectaculaire.\n",
+    "4. **La voie symbolique atterrit - a condition du bon encodage.** Ce n'est pas \"les voies elegantes explosent toujours\" : c'est plus fin. P2 (DFA -> SMT) explose en etats (mur 1, section 6b) ; P3 (tous-distincts en *appartenance* regex) ne termine pas (`unknown`) ; mais **P3' (memes chaines, tous-distincts en inegalites 2 a 2) atterrit la grille 9x9 complete en ~1 s** - et `Distinct` sur 81 entiers, qui n'est que le 2 a 2 sucre, la resout en ~47 ms. Le critere decisif n'est ni le moteur ni le substrat (chaine vs entier), c'est **la forme de l'encodage du tous-distincts** : appartenance-a-un-langage-regulier (sature) vs contrainte-d'inegalite (atterrit).\n",
     "\n",
-    "> **Synthese du banc.** Reconnaitre (RE#) est lineaire et portable ; resoudre par regex est fragile et non portable ; resoudre proprement - Z3 `Distinct`, ou meme un simple backtracking C# - demande de **choisir la bonne abstraction**. Le DLX serait l'optimum, mais on ne cherchait pas l'optimum : on cherchait a comprendre *pourquoi* chaque voie reussit ou echoue. Voir les sections 6 et 6b (Z3 et le fork Automata) et 4-5 (RE# reconnaissance)."
+    "> **Synthese du banc.** Reconnaitre (RE#) est lineaire et portable ; resoudre par *appartenance regex* est fragile a l'echelle ; resoudre par *inegalites* - en chaines (P3') comme en entiers (`Distinct`), ou meme par un simple backtracking C# - **atterrit**. La lecon transversale : choisir la **bonne forme d'encodage**, pas le substrat le plus spectaculaire. Le DLX serait l'optimum ([Sudoku-2](Sudoku-2-DancingLinks-Csharp.ipynb)), mais on ne cherchait pas l'optimum : on cherchait a comprendre *pourquoi* chaque voie reussit ou echoue. Voir les sections 6 et 6b (Z3 et le fork Automata) et 4-5 (RE# reconnaissance)."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "855aa43e",
    "metadata": {
-    "papermill": {
-     "duration": 0.006178,
-     "end_time": "2026-06-15T14:26:22.211111+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.204933+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
-    "## 9. Synthese - reconnaitre != resoudre\n",
+    "## 9. Synthese - reconnaitre != resoudre, et l'encodage decide\n",
     "\n",
-    "Les deux murs de 2020 etaient des murs **de l'automate** ; ils tombent ensemble des qu'on change de moteur. Mais aucun outil ne couronne l'echelle : la difficulte se **deplace**, et le bon outil suit la **forme** du probleme.\n",
+    "Les deux murs de 2020 etaient des murs **de l'automate** ; ils tombent ensemble des qu'on change de moteur. Mais resoudre ne devient pas gratuit : la difficulte se **deplace vers la forme de l'encodage**, et le regex, bien encode, **atterrit reellement** la grille.\n",
     "\n",
     "| | **RESOUDRE** (produire la grille) | **VERIFIER** (valider une grille remplie) |\n",
     "|---|---|---|\n",
     "| Folklore PCRE (backtracking) | detour de backtracking, illisible | monstrueux |\n",
-    "| BREX/Rex + SFAz3 (2020) | **mure** (cap ~21 char, issue #6) | **explosion DFA** |\n",
-    "| `&`/`~` -> theorie des chaines Z3 (moderne) | temoin non-cape, sans produit d'automates ; rapide pour `A & ~B`, lent pour une ligne, `unknown` a 81 | (oui) |\n",
+    "| BREX/Rex + SFAz3 (2020) | **mure** (cap ~21 char, issue #6 ; explosion du produit) | **explosion DFA** |\n",
+    "| `&`/`~` -> chaines Z3, tous-distincts en *appartenance* | temoin non-cape, sans produit ; **atterrit le 4x4**, `unknown` au 9x9 | (oui) |\n",
+    "| chaines Z3, tous-distincts en *inegalites 2 a 2* | **atterrit la grille 9x9 complete** (~0,3-1 s) | (oui) |\n",
     "| RE# (2025) | recognition-only, **aucun temoin** | **temps lineaire** |\n",
-    "| Z3 `Distinct` (81 entiers) | **resolveur reel du benchmark** (~47 ms) | - |\n",
+    "| Z3 `Distinct` (81 entiers) | **resolveur de production** (~47 ms) | - |\n",
     "\n",
-    "**Lecon** : decrire une contrainte par intersection reguliere (`Ligne & Colonne & Bloc`) est une representation elegante, mais elle ne dispense pas d'un resolveur adapte a la *forme* du probleme pour *produire* la solution. Le Sudoku - un tous-distincts **2D** - a besoin de `Distinct` sur des entiers (Z3) ; RE# en est le verificateur, pas le solveur. L'ironie (RE# valide plus vite le temoin qu'il ne peut produire) est le pont entre cette serie Sudoku et la serie Z3 (Epic #1206).\n",
+    "**Lecon** : decrire une contrainte par intersection reguliere (`Ligne & Colonne & Bloc`) est une representation elegante qui **atterrit** la grille (4x4 complete, et 9x9 des qu'on encode le tous-distincts en inegalites). Ce qui decide la reussite n'est ni le moteur (DFA vs derivees vs SMT) ni le substrat (chaine vs entier), mais la **forme de l'encodage du tous-distincts** : en *appartenance a un langage regulier* (intersection k-way), il sature a l'echelle des groupes qui se chevauchent ; en *inegalites 2 a 2* (dont `Distinct` est le sucre), il atterrit. RE# en est le verificateur lineaire, pas le solveur ; l'ironie (RE# valide plus vite qu'il ne produit) est le pont entre cette serie Sudoku et la serie Z3 (Epic #1206).\n",
     "\n",
-    "La **chaine moderne** (section 6b, et notebook [06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb) de la serie Z3) fait tomber **les deux murs** de 2020 : `&`/`~` compile vers la theorie des chaines de Z3, qui ne cape aucun temoin et ne construit aucun produit d'automates. Le revers honnete : sur la grille 81 (forme 2D) Z3 string-theory repond `unknown` - Z3 `Distinct` sur des entiers reste donc le resolveur de production.\n",
+    "La **chaine moderne** (section 6b, et notebook [06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb) de la serie Z3) fait tomber **les deux murs** de 2020 : `&`/`~` compile vers la theorie des chaines de Z3, qui ne cape aucun temoin et ne construit aucun produit d'automates. Le revers honnete n'est pas \"Z3 string-theory ne sait pas faire le Sudoku\" - il le fait (cf \"le 9x9 atterrit\") - mais \"il faut encoder le tous-distincts en inegalites, pas en appartenance\".\n",
     "\n",
-    "Le **banc d'essai** (section 8 ci-dessus) confirme empiriquement chaque case de ce tableau : le regex deroule s'effondre (timeout, faux negatif), Z3 `Distinct` reste robuste, et le backtracking C# naif est le vainqueur discret.\n",
+    "Le **banc d'essai** (section 8 ci-dessus) confirme empiriquement chaque case de ce tableau : le regex deroule s'effondre (timeout, faux negatif), la voie chaines-en-appartenance fait `unknown`, la voie chaines-en-inegalites (P3') et `Distinct` atterrissent, et le backtracking C# naif est le vainqueur discret. Le DLX, lui, est l'optimum dedie : cf [Sudoku-2-DancingLinks](Sudoku-2-DancingLinks-Csharp.ipynb).\n",
     "\n",
     "> **Footnote d'homonymie** : **Damian** Conway (luminaire des regex Perl, dont releve le folklore du barreau 1) n'est pas **John** Conway (le Game of Life, hero de notre serie Lean #2162). Les deux Conway se croisent dans ce notebook."
    ]
@@ -2191,13 +2464,6 @@
    "cell_type": "markdown",
    "id": "b71a1c63",
    "metadata": {
-    "papermill": {
-     "duration": 0.005852,
-     "end_time": "2026-06-15T14:26:22.223032+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.217180+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -2219,21 +2485,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "3a2f8af0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T14:26:22.235597Z",
-     "iopub.status.busy": "2026-06-15T14:26:22.235443Z",
-     "iopub.status.idle": "2026-06-15T14:26:22.261292Z",
-     "shell.execute_reply": "2026-06-15T14:26:22.261194Z"
-    },
-    "papermill": {
-     "duration": 0.032285,
-     "end_time": "2026-06-15T14:26:22.261342+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.229057+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-06-16T17:39:56.395742Z",
+     "iopub.status.busy": "2026-06-16T17:39:56.394234Z",
+     "iopub.status.idle": "2026-06-16T17:39:56.424553Z",
+     "shell.execute_reply": "2026-06-16T17:39:56.423903Z"
     },
     "tags": []
    },
@@ -2296,13 +2555,6 @@
    "cell_type": "markdown",
    "id": "03783737",
    "metadata": {
-    "papermill": {
-     "duration": 0.006116,
-     "end_time": "2026-06-15T14:26:22.273680+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T14:26:22.267564+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -2350,19 +2602,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 29.384899,
-   "end_time": "2026-06-15T14:26:22.832029+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Sudoku-13-SymbolicAutomata-Csharp.ipynb",
-   "output_path": "_s13_out.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-15T14:25:53.447130+00:00",
-   "version": "2.7.0"
+   "version": "13.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Sudoku-13 — atterrissage de la voie symbolique + variété cross-moteur

Refonte de `MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb` pour **arrêter le diagnostic "mauvais outil / hors scope"** et **réellement atterrir** une grille résolue depuis notre regex d'intersection `&`/`~`, puis montrer la **variété des résultats regex** annoncée. Tout est exécuté (papermill `.net-csharp`, **45 cellules, 0 erreur**).

### Volet 1 — le landing (la boucle est bouclée)

- **4×4** : notre regex `^[1-4]{4}$ & .*1.* & …` → `RegexToSMTConverter` (fork Automata) → théorie des chaînes Z3 (`str.in_re`, 12 contraintes = NOTRE regex) → **SATISFIABLE ~1,5 s**, grille valide en sortie. Beau regex en entrée, grille résolue en sortie.
- **9×9** : mêmes 81 variables chaînes de longueur 1, le **tous-distincts encodé "2 à 2"** (972 inégalités par groupe, intuition de l'auteur) + 30 indices → **SATISFIABLE ~0,5 s**, grille **validée** (27 groupes = permutation de 1..9).
- **Thèse recadrée** : le mur du 9×9 n'est ni le substrat (chaîne vs entier) ni une histoire de "forme 1D vs 2D". Le vrai axe est **appartenance-à-un-langage-régulier vs contrainte-d'inégalité**. `Distinct` est le sucre du 2-à-2. Caveat honnête : un *vrai* pairwise-regex (`(.).*\1`) utilise des backreferences = non régulier = non compilable vers la théorie `re` de Z3 ; le 2-à-2 qui atterrit est exprimé en inégalités SMT, pas en regex.

### Volet 2 — la variété Conway + l'argumentaire "pas le mauvais outil"

- **Le monstre récursif `(?R)`** (lignée Conway / [ikegami PerlMonks 471168](https://www.perlmonks.org/?node_id=471168) / Davidebyzero) donne un **troisième** type de résultat — *compile-ou-rejet* — à côté de *résolu* et *timeout/faux-négatif*. Table cross-moteur **réelle** (probe parenthèses balancées) : Python `regex` 2.5.140 / Perl 5.38.2 / PCRE2 10.42 supportent la récursion (MATCH) ; Python `re` stdlib + .NET la **rejettent**.
- **Démo .NET in-kernel** (sortie réelle papermill) : `new Regex(@"(?R)")` et `(?&g)` → `RegexParseException: Unrecognized grouping construct` capturée **en direct**. La récursion est un dialecte PCRE absent de .NET — d'où l'exécution de la variante **déroulée** Griffis (qui, elle, compile et tourne : canonique 2,4 ms / vide TIMEOUT >10 s / grille B faux-négatif).
- **Tableau consolidant** encodages × moteurs × résultats. [RegExpress (Viorel)](https://github.com/Viorel/RegExpress) cité comme référence 40+ moteurs (GUI WPF), explicitement labellisé *non reproduit in-notebook*. **Verdict : le regex atterrit** — ce qui décide est la *forme* de l'encodage et le *dialecte*, pas le substrat.
- **Avis technique — lignée Veanes** : Rex/SFAz3 (capé #6, explosif) → SRM (TACAS'19, dérivées symboliques, devenu le moteur non-backtracking de .NET 7) → dZ3 (PLDI'21, dérivées **booléennes** résolvant `A & ~B & …` dans Z3) → RE# (POPL'25, `&`/`~` first-class, reconnaissance seule). La "réécriture du parser" = **regex→SFA devient regex→contraintes SMT sur les chaînes** ; le fork `Automata` (#2979) câble enfin cette voie.

### Vérification du repo (question de l'auteur)

Vérifié : **pas le mauvais repo**. Le submodule = `MyIntelligenceAgency/Automata` (fork de `AutomataDotNet/Automata`) où vivent Rex/SFAz3 (témoin) + `&`/`~`→SMT. Le sibling `AutomataDotNet/srm` est un *matcher de reconnaissance* ("a fully compatible subset of the .NET regex language, which mainly omits non-regular features") — pas de `&`/`~`, pas de témoin : il ne résoudrait jamais un Sudoku.

### Garanties

- C.2/H.3 : notebook committé **avec outputs réels** (papermill, 0 erreur), re-exécution end-to-end après insertion de cellules.
- Aucun artefact fabriqué : regex monstrueux = troncature du réel ; résultats cross-moteur non reproductibles in-notebook = labellisés *référence citée*, pas "calculé".
- Diff scopé au seul notebook (le `M` du submodule Z3.Linq = `.deploy/` non suivi, pointeur inchangé).

See #2978, See #2979 (contribution à l'Epic regex symbolique ; **ne ferme pas** l'Epic — validation user requise). Rien posté sur l'upstream `AutomataDotNet/Automata#6`.
