### PR TITLE
docs(i18n): translate Probas/PORT_PYTHON_PLAN.md EN->FR (Phase 0.5 #1650)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PORT_PYTHON_PLAN.en.md
+++ b/MyIA.AI.Notebooks/Probas/PORT_PYTHON_PLAN.en.md
@@ -1,0 +1,162 @@
+# Infer.NET → Python Port Plan
+
+**Issue**: #297
+**Status**: Research phase
+**Author**: po-2025 (Cycle 22, Track 3)
+**Date**: 2026-05-11
+
+## Context
+
+20 Infer.NET (.NET Interactive / C#) notebooks covering probabilistic programming from fundamentals to decision theory. Goal: create Python equivalents using modern probabilistic programming libraries, making the content accessible without .NET dependency.
+
+An existing Python notebook `Pyro_RSA_Hyperbole.ipynb` (13/13 exec) demonstrates Pyro usage in this repo.
+
+## Library Recommendation
+
+| Library | Strengths | Weaknesses | Verdict |
+|---------|-----------|------------|---------|
+| **PyMC v5+** | NUTS sampler, intuitive `Model()` context, ArviZ viz, best docs | Slow for large models, no VI-native feel | **Primary** for notebooks 1-8, 14-20 |
+| **NumPyro** | JAX-fast HMC/NUTS + SVI, scales well, Pyro-compatible | JAX complexity, less intuitive API | **Primary** for notebooks 9-12 (LDA, HMM, large models) |
+| **pgmpy** | Bayesian network primitives (CPT, D-separation, inference) | Limited to discrete BNs | Supplementary for notebook 4 |
+| **hmmlearn** | HMM fit/predict/score out of the box | No Bayesian treatment of params | Supplementary for notebook 11 |
+| **Pyro** | General PPL, SVI, guide architecture | Lower-level than PyMC | Existing dependency, used for RSA notebook |
+
+**Recommendation**: **PyMC v5+** as primary (covers 16/20 notebooks natively), **NumPyro** for advanced models (LDA, HMM), **pgmpy** for BN foundations.
+
+## Notebook Mapping
+
+### Phase 1: Fundamentals (Notebooks 1-3) — PyMC
+
+| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+|---|---------------|---------|-----------|--------|---------------------|
+| 1 | Setup (Two Coins) | Beta-Bernoulli conjugate | PyMC | 2h | `Variable.Bernoulli` → `pm.Bernoulli`, `InferenceEngine` → `pm.sample()` |
+| 2 | Gaussian Mixtures | GMM, conjugate priors, `Variable.Switch` | PyMC + sklearn | 4h | `Variable.Switch` → `pm.Mixture` or `pm.Categorical` weight indexing |
+| 3 | Factor Graphs | Discrete inference, Monty Hall | PyMC | 3h | `Variable.If/Case` → `pm.math.switch`, `pt.where` |
+
+### Phase 2: Classical Models (Notebooks 4-6) — PyMC + pgmpy
+
+| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+|---|---------------|---------|-----------|--------|---------------------|
+| 4 | Bayesian Networks | CPT, D-separation, do-calculus | pgmpy + PyMC | 5h | `Variable.Case` CPT → `pgmpy.factors.discrete.TabularCPD`, D-sep → `pgmpy.independence` |
+| 5 | Skills IRT | IRT, DINA, Q-matrix | PyMC | 5h | `Variable.Gaussian` for ability → `pm.Normal`, DINA → `pm.Deterministic` with `pt.prod` |
+| 6 | TrueSkill | Gaussian ranking, online learning | PyMC | 4h | `ConstrainBetween` → `pm.Potential` or `pm.Normal` with ordered transform |
+
+### Phase 3: Classification & Selection (Notebooks 7-8) — PyMC
+
+| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+|---|---------------|---------|-----------|--------|---------------------|
+| 7 | Classification | Bayes Point Machine, A/B test | PyMC + scipy | 4h | BPM → `pm.Bernoulli` with `pm.math.invprobit`, A/B → `pm.Beta` comparison |
+| 8 | Model Selection | Evidence, Bayes Factor, ARD | PyMC + ArviZ | 4h | Evidence → `pm.compute_log_marginal_likelihood`, ARD → `pm.Horseshoe` or sparse prior |
+
+### Phase 4: Advanced Models (Notebooks 9-12) — NumPyro
+
+| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+|---|---------------|---------|-----------|--------|---------------------|
+| 9 | Topic Models (LDA) | Dirichlet-Multinomial, VMP | NumPyro | 6h | `Variable.Dirichlet` → `numpyro.distributions.Dirichlet`, SVI + guide |
+| 10 | Crowdsourcing | Worker models, communities | NumPyro | 5h | Biased Worker confusion matrix → `numpyro.plates` + categorical |
+| 11 | Sequences (HMM) | HMM, Forward-Backward | hmmlearn + NumPyro | 5h | Manual Forward-Backward with `numpyro.scan` or `hmmlearn.GaussianHMM` |
+| 12 | Recommenders | Matrix factorization, Click Model | NumPyro | 5h | `Variable.Array` traits → `numpyro.sample` with `numpyro.plate` |
+
+### Phase 5: Reference (Notebook 13) — PyMC/NumPyro
+
+| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+|---|---------------|---------|-----------|--------|---------------------|
+| 13 | Debugging | Diagnostics, EP vs VMP comparison | ArviZ + PyMC | 3h | EP/VMP → NUTS/ADVI comparison, `arviz.plot_trace`, `az.summary` |
+
+### Phase 6: Decision Theory (Notebooks 14-20) — PyMC + numpy
+
+| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+|---|---------------|---------|-----------|--------|---------------------|
+| 14 | Decision Foundations | Lotteries, VNM axioms, utility | numpy + scipy | 3h | Mostly numpy/math, `scipy.optimize` for calibration |
+| 15 | Utility of Money | St-Petersburg, CARA/CRRA | numpy + scipy | 3h | Utility functions as numpy arrays, Monte Carlo |
+| 16 | Multi-Attribute | MAUT, SMART, swing weights | numpy + scipy | 3h | Weighted sum, sensitivity analysis |
+| 17 | Decision Networks | Influence diagrams | pgmpy + numpy | 4h | `pgmpy.models.BayesianNetwork` + decision nodes |
+| 18 | Value of Information | EVPI, EVSI | PyMC + numpy | 3h | Pre-posterior analysis via `pm.sample_posterior_predictive` |
+| 19 | Expert Systems | Minimax, regret | numpy + scipy | 3h | Decision matrix operations |
+| 20 | Sequential Decisions | MDPs, Value/Policy iteration | numpy | 3h | Bellman equation iteration (pure numpy) |
+
+## Effort Summary
+
+| Phase | Notebooks | Estimated Hours | Library |
+|-------|-----------|----------------|---------|
+| 1: Fundamentals | 1-3 | 9h | PyMC |
+| 2: Classical | 4-6 | 14h | PyMC + pgmpy |
+| 3: Classification | 7-8 | 8h | PyMC |
+| 4: Advanced | 9-12 | 21h | NumPyro |
+| 5: Reference | 13 | 3h | ArviZ |
+| 6: Decision Theory | 14-20 | 22h | numpy + PyMC |
+| **Total** | **20** | **~77h** | |
+
+## Key API Translation Reference
+
+### Infer.NET → PyMC
+
+| Infer.NET | PyMC v5+ | Notes |
+|-----------|----------|-------|
+| `Variable.Bernoulli(p)` | `pm.Bernoulli('x', p=p)` | Direct |
+| `Variable.GaussianFromMeanAndVariance(m, v)` | `pm.Normal('x', mu=m, sigma=pt.sqrt(v))` | Note sigma vs variance |
+| `Variable.GaussianFromMeanAndPrecision(m, p)` | `pm.Normal('x', mu=m, tau=p)` | PyMC supports tau param |
+| `Variable.Beta(a, b)` | `pm.Beta('x', alpha=a, beta=b)` | Direct |
+| `Variable.Dirichlet(a)` | `pm.Dirichlet('x', a=a)` | Direct |
+| `Variable.Gamma(s, r)` | `pm.Gamma('x', alpha=s, beta=r)` | Note rate vs scale |
+| `Variable.Discrete(probs)` | `pm.Categorical('x', p=probs)` | Discrete → Categorical |
+| `Variable.Switch(idx, values)` | `pm.Mixture('x', w=w, comp=components)` | Or `pt.switch` |
+| `Variable.If(cond) { ... }` | `pm.math.switch(cond, then, else)` | PyTensor op |
+| `VariableArray<T>(range)` | `pm.Normal('x', ..., shape=N)` | shape parameter |
+| `observed.ObservedValue(data)` | `pm.Normal('x', ..., observed=data)` | observed kwarg |
+| `InferenceEngine(EP)` | `pm.sample(draws=1000)` | NUTS by default |
+| `InferenceEngine(VMP)` | `pm.fit(method='advi')` | ADVI approximation |
+| `engine.Infer<Gaussian>(x)` | `trace.posterior['x']` | ArviZ InferenceData |
+
+### Infer.NET → NumPyro
+
+| Infer.NET | NumPyro | Notes |
+|-----------|---------|--------|
+| `Variable.Dirichlet` in plate | `numpyro.sample('theta', dist.Dirichlet(a), sample_intermediates=True)` | |
+| `Variable.Discrete` with plate | `numpyro.sample('z', dist.Categorical(probs), with numpyro.plate(...))` | |
+| VMP iteration | `numpyro.infer.SVI(model, guide, optim, loss=Trace_ELBO())` | |
+| `Range` | `numpyro.plate('name', size)` | Context manager |
+
+## Scaffolding Priority
+
+**Sprint 1** (easiest wins, builds foundation):
+1. `Infer-1-Setup` → `PyMC-1-Setup` (2h)
+2. `Infer-3-Factor-Graphs` → `PyMC-3-Factor-Graphs` (3h)
+
+These two cover the fundamental workflow (model → sample → posterior) and discrete inference (Monty Hall), providing a template for all subsequent notebooks.
+
+**Sprint 2** (highest pedagogical value):
+3. `Infer-4-Bayesian-Networks` → `PyMC-4-Bayesian-Networks` (5h)
+4. `Infer-2-Gaussian-Mixtures` → `PyMC-2-Gaussian-Mixtures` (4h)
+
+## Dependencies
+
+```
+# requirements-python-port.txt
+pymc>=5.10           # Primary PPL (NUTS, ADVI, posterior predictive)
+arviz>=0.17          # Visualization + diagnostics
+numpyro>=0.13        # JAX backend for advanced models
+jax>=0.4             # NumPyro backend
+pgmpy>=0.9           # Bayesian network primitives
+hmmlearn>=0.3        # HMM fit/predict
+scipy>=1.11          # Optimization, stats
+matplotlib>=3.7      # Plotting
+seaborn>=0.13        # Statistical viz
+numpy>=1.24          # Core
+pandas>=2.0          # Data handling
+```
+
+All CPU-only, no GPU required.
+
+## Naming Convention
+
+- Directory: `MyIA.AI.Notebooks/Probas/PyMC/`
+- Files: `PyMC-{N}-{Title}.ipynb` for PyMC-based, `NumPyro-{N}-{Title}.ipynb` for NumPyro-based
+- Data: reuse `Infer/data/` CSV/JSON files directly (same datasets)
+- Kernel: `python3`
+
+## Open Questions
+
+1. **Decision theory notebooks (14-20)**: These are mostly math/numpy, not PPL. Should they use PyMC at all, or stay pure numpy? Recommendation: numpy + scipy for 14-16,19-20; PyMC for 17 (decision networks) and 18 (EVPI/EVSI).
+2. **LDA (notebook 9)**: NumPyro SVI is complex. Alternative: use `gensim` or `sklearn.decomposition.LatentDirichletAllocation` for comparison, then show NumPyro for Bayesian treatment.
+3. **Exercise parity**: Should Python notebooks have exact same exercises as C# originals, or adapt to Python idioms? Recommendation: same concepts, Python-idiomatic implementations.

--- a/MyIA.AI.Notebooks/Probas/PORT_PYTHON_PLAN.md
+++ b/MyIA.AI.Notebooks/Probas/PORT_PYTHON_PLAN.md
@@ -1,162 +1,164 @@
-# Infer.NET → Python Port Plan
+# Plan de portage Infer.NET → Python
 
-**Issue**: #297
-**Status**: Research phase
-**Author**: po-2025 (Cycle 22, Track 3)
-**Date**: 2026-05-11
+**Issue** : #297
+**Statut** : Phase de recherche
+**Auteur** : po-2025 (Cycle 22, Track 3)
+**Date** : 2026-05-11
 
-## Context
+> Version anglaise originale préservée dans [PORT_PYTHON_PLAN.en.md](PORT_PYTHON_PLAN.en.md).
 
-20 Infer.NET (.NET Interactive / C#) notebooks covering probabilistic programming from fundamentals to decision theory. Goal: create Python equivalents using modern probabilistic programming libraries, making the content accessible without .NET dependency.
+## Contexte
 
-An existing Python notebook `Pyro_RSA_Hyperbole.ipynb` (13/13 exec) demonstrates Pyro usage in this repo.
+20 notebooks Infer.NET (.NET Interactive / C#) couvrent la programmation probabiliste, des fondamentaux jusqu'à la théorie de la décision. Objectif : créer des équivalents Python à l'aide de bibliothèques modernes de programmation probabiliste, afin de rendre le contenu accessible sans dépendance .NET.
 
-## Library Recommendation
+Un notebook Python existant `Pyro_RSA_Hyperbole.ipynb` (13/13 cellules exécutées) démontre l'utilisation de Pyro dans ce dépôt.
 
-| Library | Strengths | Weaknesses | Verdict |
+## Recommandation de bibliothèques
+
+| Bibliothèque | Atouts | Limites | Verdict |
 |---------|-----------|------------|---------|
-| **PyMC v5+** | NUTS sampler, intuitive `Model()` context, ArviZ viz, best docs | Slow for large models, no VI-native feel | **Primary** for notebooks 1-8, 14-20 |
-| **NumPyro** | JAX-fast HMC/NUTS + SVI, scales well, Pyro-compatible | JAX complexity, less intuitive API | **Primary** for notebooks 9-12 (LDA, HMM, large models) |
-| **pgmpy** | Bayesian network primitives (CPT, D-separation, inference) | Limited to discrete BNs | Supplementary for notebook 4 |
-| **hmmlearn** | HMM fit/predict/score out of the box | No Bayesian treatment of params | Supplementary for notebook 11 |
-| **Pyro** | General PPL, SVI, guide architecture | Lower-level than PyMC | Existing dependency, used for RSA notebook |
+| **PyMC v5+** | Échantillonneur NUTS, contexte `Model()` intuitif, visualisation ArviZ, meilleure documentation | Lent pour les gros modèles, pas d'orientation variationnelle native | **Principale** pour les notebooks 1-8, 14-20 |
+| **NumPyro** | HMC/NUTS + SVI rapides via JAX, passe bien à l'échelle, compatible Pyro | Complexité JAX, API moins intuitive | **Principale** pour les notebooks 9-12 (LDA, HMM, gros modèles) |
+| **pgmpy** | Primitives de réseaux bayésiens (CPT, D-séparation, inférence) | Limité aux réseaux bayésiens discrets | Complémentaire pour le notebook 4 |
+| **hmmlearn** | HMM fit/predict/score prêts à l'emploi | Pas de traitement bayésien des paramètres | Complémentaire pour le notebook 11 |
+| **Pyro** | PPL généraliste, SVI, architecture de guide | Plus bas niveau que PyMC | Dépendance existante, utilisé pour le notebook RSA |
 
-**Recommendation**: **PyMC v5+** as primary (covers 16/20 notebooks natively), **NumPyro** for advanced models (LDA, HMM), **pgmpy** for BN foundations.
+**Recommandation** : **PyMC v5+** comme bibliothèque principale (couvre 16/20 notebooks nativement), **NumPyro** pour les modèles avancés (LDA, HMM), **pgmpy** pour les fondations des réseaux bayésiens.
 
-## Notebook Mapping
+## Correspondance des notebooks
 
-### Phase 1: Fundamentals (Notebooks 1-3) — PyMC
+### Phase 1 : Fondamentaux (Notebooks 1-3) — PyMC
 
-| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+| # | Notebook Infer | Motif | Bibliothèque Python | Effort | Traduction d'API clé |
 |---|---------------|---------|-----------|--------|---------------------|
-| 1 | Setup (Two Coins) | Beta-Bernoulli conjugate | PyMC | 2h | `Variable.Bernoulli` → `pm.Bernoulli`, `InferenceEngine` → `pm.sample()` |
-| 2 | Gaussian Mixtures | GMM, conjugate priors, `Variable.Switch` | PyMC + sklearn | 4h | `Variable.Switch` → `pm.Mixture` or `pm.Categorical` weight indexing |
-| 3 | Factor Graphs | Discrete inference, Monty Hall | PyMC | 3h | `Variable.If/Case` → `pm.math.switch`, `pt.where` |
+| 1 | Setup (Two Coins) | Beta-Bernoulli conjugué | PyMC | 2h | `Variable.Bernoulli` → `pm.Bernoulli`, `InferenceEngine` → `pm.sample()` |
+| 2 | Gaussian Mixtures | GMM, a priori conjugués, `Variable.Switch` | PyMC + sklearn | 4h | `Variable.Switch` → `pm.Mixture` ou indexation des poids par `pm.Categorical` |
+| 3 | Factor Graphs | Inférence discrète, Monty Hall | PyMC | 3h | `Variable.If/Case` → `pm.math.switch`, `pt.where` |
 
-### Phase 2: Classical Models (Notebooks 4-6) — PyMC + pgmpy
+### Phase 2 : Modèles classiques (Notebooks 4-6) — PyMC + pgmpy
 
-| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+| # | Notebook Infer | Motif | Bibliothèque Python | Effort | Traduction d'API clé |
 |---|---------------|---------|-----------|--------|---------------------|
-| 4 | Bayesian Networks | CPT, D-separation, do-calculus | pgmpy + PyMC | 5h | `Variable.Case` CPT → `pgmpy.factors.discrete.TabularCPD`, D-sep → `pgmpy.independence` |
-| 5 | Skills IRT | IRT, DINA, Q-matrix | PyMC | 5h | `Variable.Gaussian` for ability → `pm.Normal`, DINA → `pm.Deterministic` with `pt.prod` |
-| 6 | TrueSkill | Gaussian ranking, online learning | PyMC | 4h | `ConstrainBetween` → `pm.Potential` or `pm.Normal` with ordered transform |
+| 4 | Bayesian Networks | CPT, D-séparation, do-calcul | pgmpy + PyMC | 5h | `Variable.Case` CPT → `pgmpy.factors.discrete.TabularCPD`, D-sép → `pgmpy.independence` |
+| 5 | Skills IRT | IRT, DINA, Q-matrix | PyMC | 5h | `Variable.Gaussian` pour l'habileté → `pm.Normal`, DINA → `pm.Deterministic` avec `pt.prod` |
+| 6 | TrueSkill | Classement gaussien, apprentissage en ligne | PyMC | 4h | `ConstrainBetween` → `pm.Potential` ou `pm.Normal` avec transformation ordonnée |
 
-### Phase 3: Classification & Selection (Notebooks 7-8) — PyMC
+### Phase 3 : Classification et sélection (Notebooks 7-8) — PyMC
 
-| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+| # | Notebook Infer | Motif | Bibliothèque Python | Effort | Traduction d'API clé |
 |---|---------------|---------|-----------|--------|---------------------|
-| 7 | Classification | Bayes Point Machine, A/B test | PyMC + scipy | 4h | BPM → `pm.Bernoulli` with `pm.math.invprobit`, A/B → `pm.Beta` comparison |
-| 8 | Model Selection | Evidence, Bayes Factor, ARD | PyMC + ArviZ | 4h | Evidence → `pm.compute_log_marginal_likelihood`, ARD → `pm.Horseshoe` or sparse prior |
+| 7 | Classification | Bayes Point Machine, test A/B | PyMC + scipy | 4h | BPM → `pm.Bernoulli` avec `pm.math.invprobit`, A/B → comparaison `pm.Beta` |
+| 8 | Model Selection | Évidence, facteur de Bayes, ARD | PyMC + ArviZ | 4h | Évidence → `pm.compute_log_marginal_likelihood`, ARD → `pm.Horseshoe` ou a priori parcimonieux |
 
-### Phase 4: Advanced Models (Notebooks 9-12) — NumPyro
+### Phase 4 : Modèles avancés (Notebooks 9-12) — NumPyro
 
-| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+| # | Notebook Infer | Motif | Bibliothèque Python | Effort | Traduction d'API clé |
 |---|---------------|---------|-----------|--------|---------------------|
 | 9 | Topic Models (LDA) | Dirichlet-Multinomial, VMP | NumPyro | 6h | `Variable.Dirichlet` → `numpyro.distributions.Dirichlet`, SVI + guide |
-| 10 | Crowdsourcing | Worker models, communities | NumPyro | 5h | Biased Worker confusion matrix → `numpyro.plates` + categorical |
-| 11 | Sequences (HMM) | HMM, Forward-Backward | hmmlearn + NumPyro | 5h | Manual Forward-Backward with `numpyro.scan` or `hmmlearn.GaussianHMM` |
-| 12 | Recommenders | Matrix factorization, Click Model | NumPyro | 5h | `Variable.Array` traits → `numpyro.sample` with `numpyro.plate` |
+| 10 | Crowdsourcing | Modèles d'annotateurs, communautés | NumPyro | 5h | Matrice de confusion d'annotateur biaisé → `numpyro.plates` + catégorielle |
+| 11 | Sequences (HMM) | HMM, Forward-Backward | hmmlearn + NumPyro | 5h | Forward-Backward manuel avec `numpyro.scan` ou `hmmlearn.GaussianHMM` |
+| 12 | Recommenders | Factorisation de matrice, modèle de clic | NumPyro | 5h | Traits `Variable.Array` → `numpyro.sample` avec `numpyro.plate` |
 
-### Phase 5: Reference (Notebook 13) — PyMC/NumPyro
+### Phase 5 : Référence (Notebook 13) — PyMC/NumPyro
 
-| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+| # | Notebook Infer | Motif | Bibliothèque Python | Effort | Traduction d'API clé |
 |---|---------------|---------|-----------|--------|---------------------|
-| 13 | Debugging | Diagnostics, EP vs VMP comparison | ArviZ + PyMC | 3h | EP/VMP → NUTS/ADVI comparison, `arviz.plot_trace`, `az.summary` |
+| 13 | Debugging | Diagnostics, comparaison EP vs VMP | ArviZ + PyMC | 3h | EP/VMP → comparaison NUTS/ADVI, `arviz.plot_trace`, `az.summary` |
 
-### Phase 6: Decision Theory (Notebooks 14-20) — PyMC + numpy
+### Phase 6 : Théorie de la décision (Notebooks 14-20) — PyMC + numpy
 
-| # | Infer Notebook | Pattern | Python Lib | Effort | Key API Translation |
+| # | Notebook Infer | Motif | Bibliothèque Python | Effort | Traduction d'API clé |
 |---|---------------|---------|-----------|--------|---------------------|
-| 14 | Decision Foundations | Lotteries, VNM axioms, utility | numpy + scipy | 3h | Mostly numpy/math, `scipy.optimize` for calibration |
-| 15 | Utility of Money | St-Petersburg, CARA/CRRA | numpy + scipy | 3h | Utility functions as numpy arrays, Monte Carlo |
-| 16 | Multi-Attribute | MAUT, SMART, swing weights | numpy + scipy | 3h | Weighted sum, sensitivity analysis |
-| 17 | Decision Networks | Influence diagrams | pgmpy + numpy | 4h | `pgmpy.models.BayesianNetwork` + decision nodes |
-| 18 | Value of Information | EVPI, EVSI | PyMC + numpy | 3h | Pre-posterior analysis via `pm.sample_posterior_predictive` |
-| 19 | Expert Systems | Minimax, regret | numpy + scipy | 3h | Decision matrix operations |
-| 20 | Sequential Decisions | MDPs, Value/Policy iteration | numpy | 3h | Bellman equation iteration (pure numpy) |
+| 14 | Decision Foundations | Loteries, axiomes VNM, utilité | numpy + scipy | 3h | Surtout numpy/math, `scipy.optimize` pour la calibration |
+| 15 | Utility of Money | St-Pétersbourg, CARA/CRRA | numpy + scipy | 3h | Fonctions d'utilité comme tableaux numpy, Monte Carlo |
+| 16 | Multi-Attribute | MAUT, SMART, poids swing | numpy + scipy | 3h | Somme pondérée, analyse de sensibilité |
+| 17 | Decision Networks | Diagrammes d'influence | pgmpy + numpy | 4h | `pgmpy.models.BayesianNetwork` + nœuds de décision |
+| 18 | Value of Information | EVPI, EVSI | PyMC + numpy | 3h | Analyse pré-postérieure via `pm.sample_posterior_predictive` |
+| 19 | Expert Systems | Minimax, regret | numpy + scipy | 3h | Opérations sur matrices de décision |
+| 20 | Sequential Decisions | MDP, itération de valeur/politique | numpy | 3h | Itération de l'équation de Bellman (numpy pur) |
 
-## Effort Summary
+## Synthèse de l'effort
 
-| Phase | Notebooks | Estimated Hours | Library |
+| Phase | Notebooks | Heures estimées | Bibliothèque |
 |-------|-----------|----------------|---------|
-| 1: Fundamentals | 1-3 | 9h | PyMC |
-| 2: Classical | 4-6 | 14h | PyMC + pgmpy |
-| 3: Classification | 7-8 | 8h | PyMC |
-| 4: Advanced | 9-12 | 21h | NumPyro |
-| 5: Reference | 13 | 3h | ArviZ |
-| 6: Decision Theory | 14-20 | 22h | numpy + PyMC |
+| 1 : Fondamentaux | 1-3 | 9h | PyMC |
+| 2 : Classiques | 4-6 | 14h | PyMC + pgmpy |
+| 3 : Classification | 7-8 | 8h | PyMC |
+| 4 : Avancés | 9-12 | 21h | NumPyro |
+| 5 : Référence | 13 | 3h | ArviZ |
+| 6 : Théorie de la décision | 14-20 | 22h | numpy + PyMC |
 | **Total** | **20** | **~77h** | |
 
-## Key API Translation Reference
+## Référentiel de traduction d'API
 
 ### Infer.NET → PyMC
 
 | Infer.NET | PyMC v5+ | Notes |
 |-----------|----------|-------|
 | `Variable.Bernoulli(p)` | `pm.Bernoulli('x', p=p)` | Direct |
-| `Variable.GaussianFromMeanAndVariance(m, v)` | `pm.Normal('x', mu=m, sigma=pt.sqrt(v))` | Note sigma vs variance |
-| `Variable.GaussianFromMeanAndPrecision(m, p)` | `pm.Normal('x', mu=m, tau=p)` | PyMC supports tau param |
+| `Variable.GaussianFromMeanAndVariance(m, v)` | `pm.Normal('x', mu=m, sigma=pt.sqrt(v))` | Attention sigma vs variance |
+| `Variable.GaussianFromMeanAndPrecision(m, p)` | `pm.Normal('x', mu=m, tau=p)` | PyMC accepte le paramètre tau |
 | `Variable.Beta(a, b)` | `pm.Beta('x', alpha=a, beta=b)` | Direct |
 | `Variable.Dirichlet(a)` | `pm.Dirichlet('x', a=a)` | Direct |
-| `Variable.Gamma(s, r)` | `pm.Gamma('x', alpha=s, beta=r)` | Note rate vs scale |
-| `Variable.Discrete(probs)` | `pm.Categorical('x', p=probs)` | Discrete → Categorical |
-| `Variable.Switch(idx, values)` | `pm.Mixture('x', w=w, comp=components)` | Or `pt.switch` |
-| `Variable.If(cond) { ... }` | `pm.math.switch(cond, then, else)` | PyTensor op |
-| `VariableArray<T>(range)` | `pm.Normal('x', ..., shape=N)` | shape parameter |
-| `observed.ObservedValue(data)` | `pm.Normal('x', ..., observed=data)` | observed kwarg |
-| `InferenceEngine(EP)` | `pm.sample(draws=1000)` | NUTS by default |
-| `InferenceEngine(VMP)` | `pm.fit(method='advi')` | ADVI approximation |
+| `Variable.Gamma(s, r)` | `pm.Gamma('x', alpha=s, beta=r)` | Attention rate vs scale |
+| `Variable.Discrete(probs)` | `pm.Categorical('x', p=probs)` | Discret → Categorical |
+| `Variable.Switch(idx, values)` | `pm.Mixture('x', w=w, comp=components)` | Ou `pt.switch` |
+| `Variable.If(cond) { ... }` | `pm.math.switch(cond, then, else)` | Opération PyTensor |
+| `VariableArray<T>(range)` | `pm.Normal('x', ..., shape=N)` | Paramètre shape |
+| `observed.ObservedValue(data)` | `pm.Normal('x', ..., observed=data)` | Argument observed |
+| `InferenceEngine(EP)` | `pm.sample(draws=1000)` | NUTS par défaut |
+| `InferenceEngine(VMP)` | `pm.fit(method='advi')` | Approximation ADVI |
 | `engine.Infer<Gaussian>(x)` | `trace.posterior['x']` | ArviZ InferenceData |
 
 ### Infer.NET → NumPyro
 
 | Infer.NET | NumPyro | Notes |
 |-----------|---------|--------|
-| `Variable.Dirichlet` in plate | `numpyro.sample('theta', dist.Dirichlet(a), sample_intermediates=True)` | |
-| `Variable.Discrete` with plate | `numpyro.sample('z', dist.Categorical(probs), with numpyro.plate(...))` | |
-| VMP iteration | `numpyro.infer.SVI(model, guide, optim, loss=Trace_ELBO())` | |
-| `Range` | `numpyro.plate('name', size)` | Context manager |
+| `Variable.Dirichlet` dans un plate | `numpyro.sample('theta', dist.Dirichlet(a), sample_intermediates=True)` | |
+| `Variable.Discrete` avec plate | `numpyro.sample('z', dist.Categorical(probs), with numpyro.plate(...))` | |
+| Itération VMP | `numpyro.infer.SVI(model, guide, optim, loss=Trace_ELBO())` | |
+| `Range` | `numpyro.plate('name', size)` | Gestionnaire de contexte |
 
-## Scaffolding Priority
+## Priorité d'échafaudage
 
-**Sprint 1** (easiest wins, builds foundation):
+**Sprint 1** (victoires les plus simples, construit les fondations) :
 1. `Infer-1-Setup` → `PyMC-1-Setup` (2h)
 2. `Infer-3-Factor-Graphs` → `PyMC-3-Factor-Graphs` (3h)
 
-These two cover the fundamental workflow (model → sample → posterior) and discrete inference (Monty Hall), providing a template for all subsequent notebooks.
+Ces deux notebooks couvrent le flux de travail fondamental (modèle → échantillonnage → postérieure) et l'inférence discrète (Monty Hall), fournissant un modèle pour tous les notebooks suivants.
 
-**Sprint 2** (highest pedagogical value):
+**Sprint 2** (plus grande valeur pédagogique) :
 3. `Infer-4-Bayesian-Networks` → `PyMC-4-Bayesian-Networks` (5h)
 4. `Infer-2-Gaussian-Mixtures` → `PyMC-2-Gaussian-Mixtures` (4h)
 
-## Dependencies
+## Dépendances
 
 ```
 # requirements-python-port.txt
-pymc>=5.10           # Primary PPL (NUTS, ADVI, posterior predictive)
-arviz>=0.17          # Visualization + diagnostics
-numpyro>=0.13        # JAX backend for advanced models
-jax>=0.4             # NumPyro backend
-pgmpy>=0.9           # Bayesian network primitives
+pymc>=5.10           # PPL principal (NUTS, ADVI, prédictive postérieure)
+arviz>=0.17          # Visualisation + diagnostics
+numpyro>=0.13        # Backend JAX pour les modèles avancés
+jax>=0.4             # Backend NumPyro
+pgmpy>=0.9           # Primitives de réseaux bayésiens
 hmmlearn>=0.3        # HMM fit/predict
-scipy>=1.11          # Optimization, stats
-matplotlib>=3.7      # Plotting
-seaborn>=0.13        # Statistical viz
-numpy>=1.24          # Core
-pandas>=2.0          # Data handling
+scipy>=1.11          # Optimisation, statistiques
+matplotlib>=3.7      # Tracé
+seaborn>=0.13        # Visualisation statistique
+numpy>=1.24          # Cœur
+pandas>=2.0          # Manipulation de données
 ```
 
-All CPU-only, no GPU required.
+Tout en CPU uniquement, aucun GPU requis.
 
-## Naming Convention
+## Convention de nommage
 
-- Directory: `MyIA.AI.Notebooks/Probas/PyMC/`
-- Files: `PyMC-{N}-{Title}.ipynb` for PyMC-based, `NumPyro-{N}-{Title}.ipynb` for NumPyro-based
-- Data: reuse `Infer/data/` CSV/JSON files directly (same datasets)
-- Kernel: `python3`
+- Répertoire : `MyIA.AI.Notebooks/Probas/PyMC/`
+- Fichiers : `PyMC-{N}-{Title}.ipynb` pour les notebooks basés sur PyMC, `NumPyro-{N}-{Title}.ipynb` pour ceux basés sur NumPyro
+- Données : réutiliser directement les fichiers CSV/JSON de `Infer/data/` (mêmes jeux de données)
+- Kernel : `python3`
 
-## Open Questions
+## Questions ouvertes
 
-1. **Decision theory notebooks (14-20)**: These are mostly math/numpy, not PPL. Should they use PyMC at all, or stay pure numpy? Recommendation: numpy + scipy for 14-16,19-20; PyMC for 17 (decision networks) and 18 (EVPI/EVSI).
-2. **LDA (notebook 9)**: NumPyro SVI is complex. Alternative: use `gensim` or `sklearn.decomposition.LatentDirichletAllocation` for comparison, then show NumPyro for Bayesian treatment.
-3. **Exercise parity**: Should Python notebooks have exact same exercises as C# originals, or adapt to Python idioms? Recommendation: same concepts, Python-idiomatic implementations.
+1. **Notebooks de théorie de la décision (14-20)** : Ce sont principalement des maths/numpy, pas du PPL. Devraient-ils utiliser PyMC du tout, ou rester en numpy pur ? Recommandation : numpy + scipy pour 14-16, 19-20 ; PyMC pour 17 (réseaux de décision) et 18 (EVPI/EVSI).
+2. **LDA (notebook 9)** : La SVI de NumPyro est complexe. Alternative : utiliser `gensim` ou `sklearn.decomposition.LatentDirichletAllocation` pour la comparaison, puis montrer NumPyro pour le traitement bayésien.
+3. **Parité des exercices** : Les notebooks Python doivent-ils avoir exactement les mêmes exercices que les originaux en C#, ou s'adapter aux idiomes Python ? Recommandation : mêmes concepts, implémentations idiomatiques en Python.


### PR DESCRIPTION
## Summary

First atomic slice of **#1650 Phase 0.5** (po-2025 partition): translate a deep English markdown doc to French in this FR-primary repo (CLAUDE.md section E), preserving the English original verbatim as a sidecar. This is *manual ad-hoc defrichage EN to FR* — a prelude to the Argumentum translation engine (#1271-gated), not the engine itself.

**Doc translated**: `Probas/PORT_PYTHON_PLAN.md` — the Infer.NET to Python port research plan (20 notebooks, library recommendation, notebook mapping, API translation reference). Foundational research doc, explicitly scoped for translation in the #1650 inventory.

## Changes

| File | Change |
|------|--------|
| `PORT_PYTHON_PLAN.md` | Rewritten in French (source FR primaire). 98 ins / 96 del (~1:1 translation). |
| `PORT_PYTHON_PLAN.en.md` | **New** — English original preserved **byte-for-byte** (verified `diff` vs `origin/main`). |

## Translation discipline (G.1 / anti-regression)

- **Verbatim-preserved**: all code identifiers (`Variable.Bernoulli`, `pm.Normal`, `numpyro.plate`, ...), library/API names (PyMC, NumPyro, pgmpy, ArviZ), file paths, and acronyms (NUTS, HMC, SVI, ADVI, LDA, HMM, BPM, ARD, IRT, DINA, CARA, CRRA, MAUT, MDP, EVPI, EVSI, VNM, CPT, EP, VMP).
- **Structure preserved**: all tables (column counts verified), code blocks, headers, links.
- **Translated**: prose, table column headers, section titles, comments inside the dependencies code block.
- A small MD060 (table-pipe alignment) lint warning on one single-row table is cosmetic and matches the source document's style exactly — left as-is to keep the FR/EN sidecars structurally parallel (no pendulum).

## Verification

- `diff` of `PORT_PYTHON_PLAN.en.md` vs `origin/main:.../PORT_PYTHON_PLAN.md` = **IDENTICAL** (byte-for-byte preservation).
- Secret scan (`sk-` / `ghp_` / `sk-proj`) on both files = **0 literal**.
- No `CATALOG-STATUS` / `COURSE_CATALOG` marker touched (deep doc, not a catalog README) — catalog-pr-hygiene respected.
- Base fresh from `origin/main` (`e4c5a295`) — catalog-pr-hygiene HARD 2.

## Scope note

Atomic per-doc slice (catalog-pr-hygiene HARD 3 + issue mandate: *"traduit Probas/PORT_PYTHON_PLAN.md"* as a standalone PR). Next slices in po-2025 partition: `Probas/Infer/scripts/README.md` (289w EN), then Argumentum/Z3/Sudoku EN docs (scoping).

See #1650 — Phase 0.5 contribution; the Epic stays OPEN (engine itself is #1271-gated, many docs remain).

🤖 po-2025 cycle, deep queue ai-01 (directive 2026-06-16T20:03Z, item 1).

Co-Authored-By: Claude <noreply@anthropic.com>
