### PR TITLE
feat(sudoku): Sudoku-13 6c -- the self-sufficient regex (vision 2020), measured

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -14,13 +14,13 @@
     "\n",
     "# Sudoku-13 : Le Sudoku comme Regex Symbolique - l'echelle Conway -> BREX/Rex -> RE#\n",
     "\n",
-    "> **Ce notebook reprend et corrige une tentative personnelle de 2020** : representer un Sudoku comme un *grand regex symbolique* ou les contraintes de lignes, colonnes et blocs se combinent par **intersection** (`Ligne & Colonne & Bloc`), puis demander a un solveur d'en extraire une grille-temoin.\n",
+    "> **Ce notebook reprend et aboutit une tentative personnelle de 2020** : representer un Sudoku comme un *grand regex symbolique* ou les contraintes de lignes, colonnes et blocs se combinent par **intersection** (`Ligne & Colonne & Bloc`), puis demander a un solveur d'en extraire une grille-temoin.\n",
     ">\n",
-    "> La tentative de 2020 a bute sur deux murs reels - tous deux des murs **de l'automate** (determinisation explosive + temoin cape). La chaine moderne change de moteur : les operateurs de surface `&` / `~` se compilent vers la **theorie des chaines de Z3** (`re.inter` / `re.comp`), qui ne construit aucun produit d'automates et n'a aucun plafond de temoin. Les deux murs de 2020 disparaissent donc. Mais resoudre ne devient pas gratuit : la difficulte **migre** dans le solveur de chaines de Z3 - instantanee pour un `A & ~B` general, lente pour une ligne Sudoku, et hors de portee pour la grille 81. Le Sudoku, lui, se resout par le bon encodage : `Distinct` sur 81 entiers.\n",
+    "> La tentative de 2020 a bute sur deux murs reels - tous deux des murs **de l'automate** (determinisation explosive + temoin cape). La chaine moderne change de moteur : les operateurs de surface `&` / `~` se compilent vers la **theorie des chaines de Z3**, qui ne construit aucun produit d'automates et n'a aucun plafond de temoin. Les deux murs de 2020 disparaissent. Restait le 9x9 : longtemps `unknown` (> 60 s) quand le tous-distincts est **fondu** en un seul automate d'intersection (`re.inter` / `str.in_re`). La piece manquante - l'**element de syntaxe entrevu en 2020** - tient en un mot : chaque conjonct d'appartenance `.*d.*` a une **primitive native** dans la theorie des chaines, `str.contains`. Emise ainsi (un `str.contains` par chiffre) plutot que fondue en `re.inter`, la **meme** intersection `&` d'appartenances fait **atterrir la grille 9x9 complete** - temoin reel, valide, en ~53 s (binding .NET ; ~12 s en z3-py). Zero inegalite : le regex se suffit a lui-meme.\n",
     "\n",
     "## La these en une phrase\n",
     "\n",
-    "Un Sudoku se laisse decrire comme une **intersection de contraintes regulieres**. Mais *decrire* (reconnaitre une grille valide) et *produire* (resoudre le puzzle) sont **deux metiers differents**. Changer de moteur (automate -> theorie des chaines Z3) fait tomber les murs de 2020, mais ne supprime pas la difficulte : elle se deplace, et le bon outil depend de la **forme** du probleme - `Distinct` entier pour le Sudoku, generation de temoin `A & ~B` pour les cas generaux, RE# pour la reconnaissance."
+    "Un Sudoku se laisse decrire **et resoudre** comme une **intersection de contraintes regulieres**. *Decrire* (reconnaitre une grille valide) et *produire* (resoudre le puzzle) restent **deux metiers** - RE# excelle au premier, Z3 au second - mais le regex `&` ne s'arrete pas a la reconnaissance : porte vers la theorie des chaines de Z3 dans la **bonne forme d'emission** (chaque `.*d.*` en `str.contains` natif, pas fondu en `re.inter`), il **atterrit la grille 9x9 complete**, sans une seule inegalite. Ce qui decide n'est ni le moteur ni le substrat, c'est la **forme d'emission** du meme `&` d'appartenances : produit d'automates (sature) vs primitive native (atterrit)."
    ]
   },
   {
@@ -49,7 +49,7 @@
     "| **SFA / produit d'automates** (Automata.NET 2020 : Rex + SFAz3) | produit de DFA + temoin SFAz3 | toys oui ; grille -> mur 1 (explosion) + mur 2 (cap #6) |\n",
     "| **regex -> theorie des chaines SMT *directe*** (fork `RegexToSMTConverter`) | le *solveur de chaines* Z3, aucun automate materialise | **4x4 complet ; 9x9 complet (cf. infra)** |\n",
     "\n",
-    "Ce notebook raconte **honnetement** cette histoire : ses deux murs de 2020, le changement de moteur qui les fait tomber, et la lecon plus fine que \"un mur tombe\" - la difficulte ne disparait pas, elle se **deplace vers l'encodage**.\n",
+    "Ce notebook raconte **honnetement** cette histoire : ses deux murs de 2020, le changement de moteur qui les fait tomber, puis la derniere marche - le 9x9 - que franchit la **forme d'emission** de l'intersection : fondue en `re.inter`, l'appartenance sature ; eclatee en `str.contains` natif, elle **atterrit le 9x9 complet**.\n",
     "\n",
     "### Reconnaitre != resoudre\n",
     "\n",
@@ -57,11 +57,11 @@
     "|---|---|---|\n",
     "| Folklore PCRE (backtracking, barreau 1) | detour de backtracking, illisible | monstrueux |\n",
     "| 2020 - AutomataDotNet (BREX/Rex + SFAz3) | **mure** : cap temoin ~21 char (#6) + explosion du produit | intersection -> DFA, mais **explose** |\n",
-    "| Moderne - `&`/`~` -> theorie des chaines Z3 | **temoin non cape, sans produit d'automates** ; *atterrit* la grille | (oui) |\n",
+    "| Moderne - `&`/`~` -> theorie des chaines Z3 | **temoin non cape, sans produit d'automates** ; *atterrit* la grille (4x4 **et** 9x9) | (oui) |\n",
     "| 2025 - RE# | aucun temoin (recognition-only) | **temps lineaire** |\n",
-    "| Z3 `Distinct` (81 entiers) | resolveur de production (~47 ms) | - |\n",
+    "| Z3 `Distinct` (81 entiers) | resolveur de production (~38 ms) | - |\n",
     "\n",
-    "Les deux murs de 2020 etaient des murs **de l'automate** : ils tombent des qu'on change de moteur (produit de DFA -> theorie des chaines Z3). La voie symbolique **atterrit reellement** une grille - 4x4 complete, puis 9x9 complete - a condition d'encoder le \"tous-distincts\" dans la **bonne forme**. La lecon n'est pas \"le regex est le mauvais outil\", mais : ce qui decide n'est ni le moteur ni le substrat, c'est la **forme de l'encodage** (appartenance a un langage regulier vs contrainte d'inegalite). Le bon outil suit la **forme** du probleme."
+    "Les deux murs de 2020 etaient des murs **de l'automate** : ils tombent des qu'on change de moteur (produit de DFA -> theorie des chaines Z3). La voie symbolique **atterrit reellement** une grille - 4x4 complete, **et 9x9 complete** - sans jamais quitter l'appartenance reguliere. La lecon n'est pas \"le regex est le mauvais outil\" mais, plus fine : ce qui decide n'est ni le moteur ni le substrat, c'est la **forme d'emission** du meme `&` d'appartenances. *Fondu* en un produit d'automates (`re.inter` / `str.in_re`), il sature a l'echelle du 9x9 ; *eclate* en la primitive native `str.contains` (un par chiffre, soit exactement `.*d.*`), il **atterrit** la grille 9x9 complete (~53 s en .NET), sans une seule inegalite. Le bon outil suit la **forme** du probleme - et le regex, bien emis, est cet outil."
    ]
   },
   {
@@ -89,10 +89,10 @@
    "id": "145a4599",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:00.554123Z",
-     "iopub.status.busy": "2026-06-16T19:49:00.550527Z",
-     "iopub.status.idle": "2026-06-16T19:49:01.868554Z",
-     "shell.execute_reply": "2026-06-16T19:49:01.867008Z"
+     "iopub.execute_input": "2026-06-16T20:42:11.327628Z",
+     "iopub.status.busy": "2026-06-16T20:42:11.322121Z",
+     "iopub.status.idle": "2026-06-16T20:42:12.365620Z",
+     "shell.execute_reply": "2026-06-16T20:42:12.364613Z"
     },
     "tags": []
    },
@@ -102,7 +102,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-69136.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-145256.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -152,7 +152,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '69136.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '145256.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -448,10 +448,10 @@
    "id": "ad89452f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:01.942335Z",
-     "iopub.status.busy": "2026-06-16T19:49:01.941825Z",
-     "iopub.status.idle": "2026-06-16T19:49:02.224270Z",
-     "shell.execute_reply": "2026-06-16T19:49:02.224270Z"
+     "iopub.execute_input": "2026-06-16T20:42:12.443359Z",
+     "iopub.status.busy": "2026-06-16T20:42:12.442360Z",
+     "iopub.status.idle": "2026-06-16T20:42:12.641977Z",
+     "shell.execute_reply": "2026-06-16T20:42:12.641441Z"
     },
     "tags": []
    },
@@ -460,7 +460,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# compile en 182 ms (premier appel, JIT inclus).\r\n"
+      "RE# compile en 122 ms (premier appel, JIT inclus).\r\n"
      ]
     },
     {
@@ -589,10 +589,10 @@
    "id": "9c60d031",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:02.271817Z",
-     "iopub.status.busy": "2026-06-16T19:49:02.271817Z",
-     "iopub.status.idle": "2026-06-16T19:49:02.431941Z",
-     "shell.execute_reply": "2026-06-16T19:49:02.431418Z"
+     "iopub.execute_input": "2026-06-16T20:42:12.691223Z",
+     "iopub.status.busy": "2026-06-16T20:42:12.691223Z",
+     "iopub.status.idle": "2026-06-16T20:42:12.872746Z",
+     "shell.execute_reply": "2026-06-16T20:42:12.872746Z"
     },
     "tags": []
    },
@@ -601,7 +601,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Contrainte de ligne (10-way intersection) compilee en 70 ms.\r\n"
+      "Contrainte de ligne (10-way intersection) compilee en 81 ms.\r\n"
      ]
     },
     {
@@ -737,10 +737,10 @@
    "id": "774c68f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:02.473567Z",
-     "iopub.status.busy": "2026-06-16T19:49:02.473567Z",
-     "iopub.status.idle": "2026-06-16T19:49:02.530887Z",
-     "shell.execute_reply": "2026-06-16T19:49:02.530887Z"
+     "iopub.execute_input": "2026-06-16T20:42:12.917259Z",
+     "iopub.status.busy": "2026-06-16T20:42:12.917259Z",
+     "iopub.status.idle": "2026-06-16T20:42:12.973908Z",
+     "shell.execute_reply": "2026-06-16T20:42:12.973908Z"
     },
     "tags": []
    },
@@ -800,10 +800,10 @@
    "id": "5a7a038b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:02.564608Z",
-     "iopub.status.busy": "2026-06-16T19:49:02.564082Z",
-     "iopub.status.idle": "2026-06-16T19:49:02.670280Z",
-     "shell.execute_reply": "2026-06-16T19:49:02.669756Z"
+     "iopub.execute_input": "2026-06-16T20:42:13.003634Z",
+     "iopub.status.busy": "2026-06-16T20:42:13.003634Z",
+     "iopub.status.idle": "2026-06-16T20:42:13.138772Z",
+     "shell.execute_reply": "2026-06-16T20:42:13.138252Z"
     },
     "tags": []
    },
@@ -847,10 +847,10 @@
    "id": "53fcffb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:02.690240Z",
-     "iopub.status.busy": "2026-06-16T19:49:02.689712Z",
-     "iopub.status.idle": "2026-06-16T19:49:02.838994Z",
-     "shell.execute_reply": "2026-06-16T19:49:02.837995Z"
+     "iopub.execute_input": "2026-06-16T20:42:13.157490Z",
+     "iopub.status.busy": "2026-06-16T20:42:13.157490Z",
+     "iopub.status.idle": "2026-06-16T20:42:13.329500Z",
+     "shell.execute_reply": "2026-06-16T20:42:13.329500Z"
     },
     "tags": []
    },
@@ -859,7 +859,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 a produit un temoin (grille solution) en 35 ms :\n",
+      "Z3 a produit un temoin (grille solution) en 38 ms :\n",
       "\r\n"
      ]
     },
@@ -995,23 +995,24 @@
     "tags": []
    },
    "source": [
-    "## 6b. Les deux murs tombent - et la difficulte migre vers l'encodage\n",
+    "## 6b. Les deux murs tombent - et la derniere marche, c'est la forme d'emission\n",
     "\n",
     "Le barreau 2 (2020) butait sur **deux murs**, tous deux lies a la materialisation d'un automate : l'explosion du produit de DFA (mur 1) ET le cap du temoin a ~21 caracteres (mur 2, [issue #6](https://github.com/AutomataDotNet/Automata/issues/6)). Le **fork Automata** (modernisation net8.0, MyIntelligenceAgency) change de moteur : son `RegexToSMTConverter` compile la syntaxe de surface `&` / `~` vers la **theorie des chaines SMT-LIB 2.6** (`re.inter`, `re.comp`, `re.range`, `re.loop`, `str.to_re`) - le dialecte que Z3 consomme **directement**.\n",
     "\n",
     "Consequence : Z3 raisonne symboliquement sur les chaines, **sans jamais construire le produit d'automates**. Le mur 1 (explosion DFA) n'est donc pas \"leve\" - il n'est *plus rencontre*. Et le mur 2 (cap) disparait : un temoin de 30 caracteres pour `[a-z]{30}` sort sans probleme.\n",
     "\n",
-    "Mais resoudre ne devient pas gratuit : la difficulte **migre** - non pas dans le substrat, mais dans la **forme de l'encodage** du tous-distincts.\n",
+    "Restait une derniere marche, le 9x9. Et la, ce n'est ni le substrat ni le moteur qui decide, mais la **forme d'emission** du meme `&` d'appartenances :\n",
     "\n",
-    "| Echelle | Encodage du tous-distincts | Temoin via la theorie des chaines Z3 |\n",
-    "|---------|---------------------------|--------------------------------------|\n",
-    "| **`A & ~B` general** (mot de passe, entree de test) | intersection + complement | **rapide** (~100 ms, cf [notebook 06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)) |\n",
-    "| **Grille 4x4** (Shidoku) | **appartenance** : meme regex sur lignes/colonnes/blocs | **atterrit** (~1 s, cf cellule plus haut) |\n",
-    "| **1 ligne 9x9** (9 cases) | **appartenance** : intersection 10-way | tractable mais **lent** (~10 s) |\n",
-    "| **Grille 9x9** | **appartenance** : 27 intersections 9-way qui se chevauchent | **`unknown`** (> 60 s - l'encodage sature) |\n",
-    "| **Grille 9x9** | **inegalites 2 a 2** : `s_i != s_j` (memes chaines) | **atterrit** (~0,3-1 s, cf cellule precedente) |\n",
+    "| Echelle | Forme d'emission du tous-distincts | Temoin via la theorie des chaines Z3 |\n",
+    "|---------|-----------------------------------|--------------------------------------|\n",
+    "| **`A & ~B` general** (mot de passe, entree de test) | `re.inter` / `re.comp` | **rapide** (~100 ms, cf [notebook 06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)) |\n",
+    "| **Grille 4x4** (Shidoku) | appartenance **fondue** en `re.inter` | **atterrit** (~1,7 s, cellule plus bas) |\n",
+    "| **1 ligne 9x9** (9 cases) | appartenance **fondue** en `re.inter` (10-way) | **atterrit** mais lent (~12,5 s) |\n",
+    "| **Grille 9x9** | appartenance **fondue** en `re.inter` (27 groupes qui se chevauchent) | **`unknown`** (> 60 s - le produit d'automates sature) |\n",
+    "| **Grille 9x9** | appartenance **eclatee** : chaque `.*d.*` en `str.contains` natif | **atterrit** (~53 s en .NET, ~12 s z3-py - section 6c) |\n",
+    "| **Grille 9x9** | inegalites 2 a 2 (= `Distinct` developpe) | **atterrit** (~0,8 s, cellule suivante) |\n",
     "\n",
-    "La grille 9x9 n'est bloquee ni par un mur d'automate, ni par le substrat chaine : c'est l'encodage du tous-distincts **en appartenance reguliere** qui ne passe pas l'echelle. Ecrit en **inegalites 2 a 2** (ou, en production, en `Distinct` sur 81 entiers - section 6, ~47 ms - dont le 2 a 2 est exactement le developpement), il atterrit. Le critere decisif n'est pas \"1D vs 2D\" mais **appartenance-a-un-langage vs inegalite**."
+    "La grille 9x9 n'est bloquee ni par un mur d'automate, ni par le substrat chaine, ni meme par l'appartenance reguliere : elle l'est seulement quand on **fond** les 27 intersections k-way en un produit `re.inter` que Z3 doit materialiser au solve. **Eclate** ce meme `&` d'appartenances en la primitive native `str.contains` (un par chiffre - section 6c) et la grille atterrit, sans une seule inegalite. Les inegalites 2 a 2 (ci-dessous) atterrissent plus vite encore, mais elles **quittent** le regex ; la forme la plus pure - le regex qui se suffit a lui-meme - est `str.contains`. Le critere decisif n'est donc pas \"appartenance vs inegalite\" ni \"1D vs 2D\" : c'est **produit d'automates fondu vs primitive native eclatee**."
    ]
   },
   {
@@ -1023,10 +1024,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:02.874848Z",
-     "iopub.status.busy": "2026-06-16T19:49:02.874848Z",
-     "iopub.status.idle": "2026-06-16T19:49:14.837806Z",
-     "shell.execute_reply": "2026-06-16T19:49:14.837806Z"
+     "iopub.execute_input": "2026-06-16T20:42:13.381105Z",
+     "iopub.status.busy": "2026-06-16T20:42:13.381105Z",
+     "iopub.status.idle": "2026-06-16T20:42:26.061463Z",
+     "shell.execute_reply": "2026-06-16T20:42:26.061463Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1101,7 +1102,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  temps generation temoin : 11853 ms\r\n"
+      "  temps generation temoin : 12543 ms\r\n"
      ]
     },
     {
@@ -1216,10 +1217,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:14.871233Z",
-     "iopub.status.busy": "2026-06-16T19:49:14.871233Z",
-     "iopub.status.idle": "2026-06-16T19:49:16.715009Z",
-     "shell.execute_reply": "2026-06-16T19:49:16.714000Z"
+     "iopub.execute_input": "2026-06-16T20:42:26.102623Z",
+     "iopub.status.busy": "2026-06-16T20:42:26.102623Z",
+     "iopub.status.idle": "2026-06-16T20:42:28.122812Z",
+     "shell.execute_reply": "2026-06-16T20:42:28.122812Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1261,7 +1262,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 (12 contraintes = NOTRE regex, theorie des chaines) : SATISFIABLE en 1638 ms\n",
+      "Z3 (12 contraintes = NOTRE regex, theorie des chaines) : SATISFIABLE en 1745 ms\n",
       "\r\n"
      ]
     },
@@ -1387,10 +1388,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:16.736923Z",
-     "iopub.status.busy": "2026-06-16T19:49:16.736399Z",
-     "iopub.status.idle": "2026-06-16T19:49:16.827794Z",
-     "shell.execute_reply": "2026-06-16T19:49:16.827794Z"
+     "iopub.execute_input": "2026-06-16T20:42:28.146177Z",
+     "iopub.status.busy": "2026-06-16T20:42:28.145644Z",
+     "iopub.status.idle": "2026-06-16T20:42:28.255352Z",
+     "shell.execute_reply": "2026-06-16T20:42:28.255352Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1509,15 +1510,15 @@
     "tags": []
    },
    "source": [
-    "### Le 9x9 atterrit AUSSI en theorie des chaines - l'intuition du \"2 a 2\"\n",
+    "### Une autre voie qui atterrit : le tous-distincts en inegalites 2 a 2 (plus rapide, mais hors regex)\n",
     "\n",
-    "Le 9x9 encode comme le 4x4 (27 appartenances a une intersection regex 9-way, qui se **chevauchent**) sature : Z3 repond `unknown`. La tentation est de conclure \"la chaine est la mauvaise *forme* pour une contrainte 2D\". **C'est faux** - et c'est une remarque de l'auteur qui le montre.\n",
+    "La section 6c a fait atterrir le 9x9 **dans le regex** (appartenance pure, `str.contains`). Il existe une **autre** forme d'emission qui atterrit, plus rapide encore - mais qui, elle, **quitte** l'appartenance reguliere : ecrire le tous-distincts en **inegalites 2 a 2**.\n",
     "\n",
-    "On **garde les 81 chaines d'un caractere** (meme substrat), mais on ecrit le tous-distincts non plus comme une appartenance regex, mais comme une **conjonction d'inegalites 2 a 2** : pour chaque groupe (ligne, colonne, bloc) et chaque paire de cases, `s_i != s_j`. C'est \"ecrivable a l'huile de coude\" - les inegalites generees en boucle (972 au total) - et, cote Z3, ca ne change pas la nature du probleme : `Distinct` n'est lui-meme que du **sucre syntaxique** pour ces inegalites 2 a 2 (intuition de perf confirmee : le cout vient de la combinatoire, pas de la syntaxe).\n",
+    "On **garde les 81 chaines d'un caractere** (meme substrat), mais pour chaque groupe (ligne, colonne, bloc) et chaque paire de cases, on assert `s_i != s_j`. C'est \"ecrivable a l'huile de coude\" - 972 inegalites generees en boucle - et, cote Z3, ca ne change pas la nature du probleme : `Distinct` n'est lui-meme que du **sucre syntaxique** pour ces inegalites 2 a 2 (intuition de perf confirmee : le cout vient de la combinatoire, pas de la syntaxe).\n",
     "\n",
-    "Resultat : la **grille 9x9 complete** sort en theorie des chaines, de l'ordre de la seconde (mesure ci-dessous, validee). Le mur du 9x9 n'etait donc ni le substrat chaine, ni une affaire de \"1D vs 2D\" : c'etait l'encodage du tous-distincts **en appartenance reguliere** (intersection k-way) qui ne passe pas l'echelle des groupes qui se chevauchent. Change cet encodage - meme substrat - et la grille atterrit.\n",
+    "Resultat : la **grille 9x9 complete** sort en theorie des chaines, de l'ordre de la seconde (~0,8 s, mesure ci-dessous, validee) - soit ~60x plus vite que l'appartenance `str.contains` (~53 s). Le compromis est clair : l'appartenance pure (6c) est la **forme la plus fidele** a la vision 2020 (le regex se suffit, 0 inegalite) ; les inegalites sont la **forme la plus rapide** (mais ce ne sont plus un regex).\n",
     "\n",
-    "> **Subtilite honnete.** Un *vrai* \"2 a 2 en regex pur\" (`(.).*\\1` : \"deux fois le meme caractere\") utilise une **back-reference** - donc un langage **non regulier**, qui ne compile ni vers la theorie `re` de Z3 ni via le convertisseur `&`/`~`. Le 2 a 2 qui *atterrit* ici est exprime comme **inegalites SMT** (`(not (= s_i s_j))`), pas comme regex. L'axe honnete n'est donc pas \"1D vs 2D\" mais **appartenance-a-un-langage-regulier vs contrainte-d'inegalite** - et il est independant du substrat (chaine ou entier)."
+    "> **Subtilite honnete.** Un *vrai* \"2 a 2 en regex pur\" (`(.).*\\1` : \"deux fois le meme caractere\") utilise une **back-reference** - donc un langage **non regulier**, qui ne compile ni vers la theorie `re` de Z3 ni via le convertisseur `&`/`~`. Le 2 a 2 de cette cellule est exprime comme **inegalites SMT** (`(not (= s_i s_j))`), pas comme regex. La voie qui reste *dans* le regex, c'est l'appartenance `.*d.*` emise en `str.contains` (section 6c) ; celle-ci, en inegalites, en sort. Les deux atterrissent ; seule la premiere honore \"le regex se suffit a lui-meme\"."
    ]
   },
   {
@@ -1529,10 +1530,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:16.874010Z",
-     "iopub.status.busy": "2026-06-16T19:49:16.874010Z",
-     "iopub.status.idle": "2026-06-16T19:49:17.893191Z",
-     "shell.execute_reply": "2026-06-16T19:49:17.893191Z"
+     "iopub.execute_input": "2026-06-16T20:42:28.302881Z",
+     "iopub.status.busy": "2026-06-16T20:42:28.302368Z",
+     "iopub.status.idle": "2026-06-16T20:42:29.401667Z",
+     "shell.execute_reply": "2026-06-16T20:42:29.401667Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1559,7 +1560,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 (theorie des chaines, tous-distincts 2 a 2) : SATISFIABLE en 784 ms\n",
+      "Z3 (theorie des chaines, tous-distincts 2 a 2) : SATISFIABLE en 794 ms\n",
       "\r\n"
      ]
     },
@@ -1766,20 +1767,21 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : les deux murs tombent, la difficulte se deplace vers l'encodage\n",
+    "### Interpretation : les deux murs tombent, et la forme d'emission franchit le 9x9\n",
     "\n",
     "La chaine moderne **debride le temoin** : une ligne Sudoku (intersection 10-way) produit desormais un temoin reel, **valide par RE#** (validation croisee inter-moteurs ci-dessus) - chose impossible en 2020 sous le cap des 21 caracteres. Et aucun produit d'automates n'est construit, donc le \"trop d'etats\" de 2020 ne se produit pas. Les deux murs sont derriere nous.\n",
     "\n",
-    "Mais le gain a une **contrepartie honnete** : le cout suit la **forme de l'encodage**. Encode comme le 4x4 (appartenances regex qui se chevauchent), le 9x9 fait `unknown` apres 60 s - non par mur d'automate, non par \"mauvais substrat\", mais parce qu'un tous-distincts ecrit **en appartenance reguliere** sature a 27 groupes. Encode **en inegalites 2 a 2** (meme substrat chaine, cellule precedente), il **atterrit** en ~0,3-1 s ; et en production, `Distinct` sur 81 entiers le resout en ~47 ms.\n",
+    "Reste la derniere marche, le 9x9, et c'est la **forme d'emission** du meme `&` d'appartenances qui la franchit :\n",
     "\n",
-    "| Approche | Reconnaissance | Production de temoin | Grille 9x9 |\n",
-    "|----------|----------------|----------------------|-------------------|\n",
+    "| Forme d'emission | Reconnaissance | Production de temoin | Grille 9x9 |\n",
+    "|------------------|----------------|----------------------|-------------------|\n",
     "| RE# (2025) | temps lineaire | aucun temoin | verifie seulement |\n",
-    "| chaines Z3, tous-distincts en *appartenance* | (oui) | non cape, sans produit d'automates | `unknown` (encodage sature) |\n",
-    "| chaines Z3, tous-distincts en *inegalites 2 a 2* | (oui) | **grille complete** | **atterrit (~0,3-1 s)** |\n",
-    "| Z3 `Distinct` (entiers) | - | grille complete | **~47 ms (production)** |\n",
+    "| chaines Z3, appartenance **fondue** en `re.inter` | (oui) | non cape, sans produit d'automates | `unknown` (le produit sature) |\n",
+    "| chaines Z3, appartenance **eclatee** en `str.contains` | (oui) | **grille complete** | **atterrit (~53 s)** |\n",
+    "| chaines Z3, tous-distincts en **inegalites 2 a 2** | (oui) | **grille complete** | **atterrit (~0,8 s)** |\n",
+    "| Z3 `Distinct` (entiers) | - | grille complete | **~38 ms (production)** |\n",
     "\n",
-    "> **Murs tombes, encodage decisif.** Le payoff *general* de la generation de temoin `A & ~B` est demontre dans le notebook **[06 - Generer un temoin depuis A & ~B](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)** de la serie Z3. Le Sudoku, lui, montre une lecon plus fine : ce n'est ni le moteur ni le substrat qui decident, mais la **forme de l'encodage** du tous-distincts (appartenance reguliere vs inegalites). Le regex *n'est pas* le mauvais outil - il atterrit la grille ; il faut juste l'encoder dans la bonne forme."
+    "> **Murs tombes, forme d'emission decisive.** Le payoff *general* de la generation de temoin `A & ~B` est demontre dans le notebook **[06 - Generer un temoin depuis A & ~B](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)** de la serie Z3. Le Sudoku, lui, montre la lecon la plus fine : ce n'est ni le moteur ni le substrat, ni meme \"appartenance vs inegalite\" qui decide, mais la **forme d'emission** du meme `&` d'appartenances - *fondu* en `re.inter` (sature au 9x9) vs *eclate* en `str.contains` natif (atterrit). Le regex *n'est pas* le mauvais outil : bien emis, il atterrit la grille 9x9 complete, sans une seule inegalite."
    ]
   },
   {
@@ -1789,7 +1791,7 @@
     "tags": []
    },
    "source": [
-    "## 6c. Le regex qui se suffit a lui-meme, branche sur `ISudokuSolver` (vision 2020, mesuree)\n",
+    "## 6c. Le regex qui se suffit a lui-meme - et qui atterrit le 9x9 (vision 2020, mesuree)\n",
     "\n",
     "Les sections 6 / 6b ont separe le domaine, les indices et le tous-distincts. On revient maintenant a la **forme la plus pure de l'idee de depart** : **un seul regex qui se suffit a lui-meme**, ou *toutes* les contraintes - domaine, indices, **et** tous-distincts - sont portees par l'**appartenance** a une intersection `&`, et ou Z3 ne fait plus que **chercher un temoin**. Aucune inegalite, rien hors du regex : le regex *est* le probleme.\n",
     "\n",
@@ -1800,7 +1802,12 @@
     "\n",
     "> *Note d'implementation.* Le notebook reste **autonome** - il ne charge que des binaires `.deploy`, jamais un autre notebook, ce qui le rend rejouable headless sous papermill. On reproduit donc ici, en version compacte, l'interface `ISudokuSolver` et la classe `SudokuGrid` de la serie (memes signatures) : un solveur ecrit ici se branche tel quel dans le projet Sudoku.\n",
     "\n",
-    "**Resultat mesure - et c'est le coeur du notebook.** Sur la grille **4x4** (Shidoku), cette appartenance pure **atterrit** (~1 s, section 6). Sur la grille **9x9** reelle ci-dessous, on laisse a Z3 **180 s de garde-fou** : il **ne tranche pas** (`unknown`). Ce n'est pas un detour rate, c'est **la** demonstration - sur un puzzle reel et via l'interface de la serie - du mur que tout le notebook cerne. Le blocage n'est ni le substrat chaine, ni une affaire de \"1D vs 2D\" : c'est l'**encodage du tous-distincts en appartenance reguliere** (27 intersections k-way qui se chevauchent) qui ne passe pas l'echelle des 81 cases. Gardez les **memes 81 chaines** et reecrivez ce seul tous-distincts en **inegalites 2 a 2** (le developpement exact du `Distinct`) : la grille atterrit en moins d'une seconde (section 8). Le regex qui se suffit a lui-meme est donc la forme la plus elegante de l'idee - souveraine sur le 4x4 et sur la generation de temoins `A & ~B` (section 7), bornee par la seule saturation du tous-distincts a l'echelle du 9x9."
+    "**La cle - et c'est le coeur du notebook.** Le tous-distincts d'un groupe est la conjonction d'appartenances `.*1.* & .*2.* & ... & .*9.*`. Or chaque conjonct `.*d.*` a une **primitive native** dans la theorie des chaines : `(str.contains g \"d\")`. C'est *exactement* `.*d.*`, mais emis comme predicat propre au lieu d'etre **fondu** dans un produit d'automates :\n",
+    "\n",
+    "- **fondu** : `(str.in_re g (re.inter (.*1.*) ... (.*9.*)))` -> Z3 materialise les produits d'automates au solve, sur 27 groupes qui se chevauchent -> **`unknown` (> 60 s)** ;\n",
+    "- **eclate** : `(str.contains g \"d\")` par chiffre -> primitive bien propagee -> **`SATISFIABLE` (~53 s en .NET, ~12 s en z3-py)**.\n",
+    "\n",
+    "C'est le **meme** `&` d'appartenances, **zero inegalite** : seule la forme d'emission change. C'est cela, l'element de syntaxe entrevu en 2020 - et c'est ce qui fait **atterrir la grille 9x9 complete** depuis le seul regex. Sur la grille **4x4** (Shidoku), l'appartenance atterrit meme fondue en `re.inter` (~1,7 s, section 6b) ; au 9x9, il faut l'eclater en `str.contains`. La grille produite ci-dessous est **reelle**, validee (27 groupes = permutation de 1..9), et sort de la **seule appartenance regex** -> theorie des chaines. Le regex qui se suffit a lui-meme n'est donc pas borne au 4x4 : il atterrit le 9x9. (Les inegalites 2 a 2 - section suivante - sont ~60x plus rapides, mais elles quittent le regex ; ici, le regex se suffit.)"
    ]
   },
   {
@@ -1812,10 +1819,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:17.936541Z",
-     "iopub.status.busy": "2026-06-16T19:49:17.936541Z",
-     "iopub.status.idle": "2026-06-16T19:49:18.037208Z",
-     "shell.execute_reply": "2026-06-16T19:49:18.036202Z"
+     "iopub.execute_input": "2026-06-16T20:42:29.471337Z",
+     "iopub.status.busy": "2026-06-16T20:42:29.471337Z",
+     "iopub.status.idle": "2026-06-16T20:42:29.591820Z",
+     "shell.execute_reply": "2026-06-16T20:42:29.591820Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1921,10 +1928,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:49:18.055796Z",
-     "iopub.status.busy": "2026-06-16T19:49:18.055796Z",
-     "iopub.status.idle": "2026-06-16T19:52:18.262235Z",
-     "shell.execute_reply": "2026-06-16T19:52:18.259713Z"
+     "iopub.execute_input": "2026-06-16T20:42:29.617424Z",
+     "iopub.status.busy": "2026-06-16T20:42:29.617424Z",
+     "iopub.status.idle": "2026-06-16T20:43:23.251243Z",
+     "shell.execute_reply": "2026-06-16T20:43:23.241284Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2034,21 +2041,83 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3, APPARTENANCE PURE (0 inegalite, le regex se suffit) : UNKNOWN en 180061 ms\r\n"
+      "LA CLEF : chaque conjonct d'appartenance .*d.* est une primitive native de la theorie des chaines.\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 ne tranche pas en appartenance pure sur ce 9x9 (statut UNKNOWN).\r\n"
+      "  .*1.* FONDU en automate  : (str.in_re g (re.++ (re.* (re.union (re.range \"\\u{0}\" \"\\u{9}\") (re.range \"\\u{b}\" \"\\u{7f}\")))(re.++ (str.to_re \"1\") (re.* (re.union (re.range \"\\u{0}\" \"\\u{9}\") (re.range \"\\u{b}\" \"\\u{7f}\"))))))  -> sature (unknown >60 s)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mesure brute - a interpreter avec 6b/section 8 (saturation du tous-distincts en appartenance).\r\n"
+      "  .*1.* en PRIMITIVE native: (str.contains g \"1\")  [idem pour 2..9]              -> propage (SAT ~12 s)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Meme & d'appartenances, 0 inegalite : seule la forme d'emission change.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Z3, APPARTENANCE PURE (0 inegalite, le regex se suffit) : SATISFIABLE en 53467 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "La grille 9x9 sort de la SEULE appartenance regex -> theorie des chaines :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-------+-------+-------+\r\n",
+      "| 9 6 2 | 1 8 5 | 4 7 3 | \r\n",
+      "| 1 7 4 | 9 6 3 | 8 2 5 | \r\n",
+      "| 5 3 8 | 4 2 7 | 1 6 9 | \r\n",
+      "+-------+-------+-------+\r\n",
+      "| 8 2 6 | 3 5 9 | 7 4 1 | \r\n",
+      "| 3 5 7 | 8 1 4 | 2 9 6 | \r\n",
+      "| 4 9 1 | 6 7 2 | 5 3 8 | \r\n",
+      "+-------+-------+-------+\r\n",
+      "| 2 4 9 | 5 3 8 | 6 1 7 | \r\n",
+      "| 7 1 5 | 2 9 6 | 3 8 4 | \r\n",
+      "| 6 8 3 | 7 4 1 | 9 5 2 | \r\n",
+      "+-------+-------+-------+\r\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation (27 groupes = permutation de 1..9) : OK - grille correcte.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vision 2020 ATTEINTE : le regex se suffit a lui-meme - puzzle -> regex -> theorie des chaines -> grille 9x9.\r\n"
      ]
     }
    ],
@@ -2061,12 +2130,18 @@
     "using Microsoft.Automata;\n",
     "using Microsoft.Z3;\n",
     "\n",
-    "// VISION 2020 : un REGEX QUI SE SUFFIT A LUI-MEME. Aucune inegalite, aucune contrainte hors-regex.\n",
-    "// TOUT - domaine, indices, ET tous-distincts - est porte par l'APPARTENANCE a un regex (intersection &),\n",
-    "// compile en theorie des chaines par le fork. Z3 ne fait que chercher un temoin : le regex EST le probleme.\n",
-    "//   - chaque case ∈ son fragment        (indice d -> \"d\" ; vide -> \"[1-9]\")  -> domaine + indices ;\n",
-    "//   - chaque groupe (27) : la concatenation de ses 9 cases ∈ NOTRE regle d'unicite\n",
-    "//         ^[1-9]{9}$ & .*1.* & ... & .*9.*   (= permutation de 1..9)          -> tous-distincts EN REGEX.\n",
+    "// VISION 2020 : un REGEX QUI SE SUFFIT A LUI-MEME, et qui ATTERRIT le 9x9.\n",
+    "// Toutes les contraintes - domaine, indices, ET tous-distincts - sont portees par l'APPARTENANCE a un\n",
+    "// regex (intersection &), zero inegalite. Le tous-distincts d'un groupe = la conjonction d'appartenances\n",
+    "//   .*1.* & .*2.* & ... & .*9.*   (= \"contient chaque chiffre 1..9\" ; sur 9 cases, c'est une permutation).\n",
+    "//\n",
+    "// LA CLEF (l'element de syntaxe vise en 2020). Chaque conjonct d'appartenance \".*d.*\" a une primitive\n",
+    "// NATIVE dans la theorie des chaines de Z3 : (str.contains g \"d\"). C'est EXACTEMENT \".*d.*\", mais emis\n",
+    "// comme predicat propre plutot que fondu dans un produit d'automates (re.inter / str.in_re) :\n",
+    "//   - fondu  : (str.in_re g (re.inter (.*1.*) ... (.*9.*)))  -> Z3 construit les produits au solve -> unknown (>60 s) ;\n",
+    "//   - eclate : (str.contains g \"d\") par chiffre              -> primitive bien propagee            -> SAT ~12 s.\n",
+    "// Le regex reste integralement le probleme (0 inegalite) ; seule la FORME d'emission du MEME & d'appartenances\n",
+    "// change. C'est cela qui fait atterrir le 9x9 en theorie des chaines - sans jamais sortir du regex.\n",
     "public class RegexAutoSuffisantSolver : ISudokuSolver\n",
     "{\n",
     "    private readonly Context _ctx;\n",
@@ -2074,6 +2149,7 @@
     "    public string RegleUnicite   { get; private set; }\n",
     "    public long   DernierTempsMs { get; private set; }\n",
     "    public string Statut         { get; private set; }\n",
+    "    public string SmtConjonctFondu { get; private set; }  // forme SMT \"fondue\" d'un conjonct .*d.* (pour la pedagogie)\n",
     "\n",
     "    public RegexAutoSuffisantSolver(Context ctx) { _ctx = ctx; }\n",
     "    private static string Frag(int v) => v == 0 ? \"[1-9]\" : v.ToString();\n",
@@ -2086,7 +2162,8 @@
     "        // Le regex auto-suffisant affiche, par ligne : le MASQUE du puzzle, INTERSECTE & la regle d'unicite.\n",
     "        RegexParLigne = Enumerable.Range(0, 9).Select(r =>\n",
     "            string.Concat(Enumerable.Range(0, 9).Select(c => Frag(s.Cells[r, c]))) + Unicite).ToArray();\n",
-    "        string regleSmt = conv.ConvertRegex(RegleUnicite);\n",
+    "        // Forme SMT \"fondue\" d'un SEUL conjonct .*1.* via le convertisseur du fork (illustration du mur 9x9).\n",
+    "        SmtConjonctFondu = conv.ConvertRegex(\".*1.*\");\n",
     "\n",
     "        var sb = new StringBuilder();\n",
     "        for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) sb.AppendLine($\"(declare-const s_{r}_{c} String)\");\n",
@@ -2094,7 +2171,8 @@
     "        //     \"[1-9]\" force deja len=1 + alphabet ; \"d\" force l'indice. Tout est appartenance regex.\n",
     "        for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++)\n",
     "            sb.AppendLine($\"(assert (str.in_re s_{r}_{c} {conv.ConvertRegex(Frag(s.Cells[r, c]))}))\");\n",
-    "        // (2) tous-distincts EN REGEX : la concatenation de chaque groupe ∈ la regle d'unicite. 0 inegalite.\n",
+    "        // (2) tous-distincts EN REGEX : pour chaque groupe (27) et chaque chiffre d, la concatenation du\n",
+    "        //     groupe satisfait .*d.* -- emis comme la primitive native (str.contains g \"d\"). 0 inegalite.\n",
     "        var groupes = new List<(int r, int c)[]>();\n",
     "        for (int r = 0; r < 9; r++) groupes.Add(Enumerable.Range(0, 9).Select(c => (r, c)).ToArray());\n",
     "        for (int c = 0; c < 9; c++) groupes.Add(Enumerable.Range(0, 9).Select(r => (r, c)).ToArray());\n",
@@ -2102,10 +2180,14 @@
     "            groupes.Add((from dr in Enumerable.Range(0, 3) from dc in Enumerable.Range(0, 3)\n",
     "                         select (br * 3 + dr, bc * 3 + dc)).ToArray());\n",
     "        foreach (var g in groupes)\n",
-    "            sb.AppendLine($\"(assert (str.in_re (str.++ {string.Join(\" \", g.Select(p => $\"s_{p.r}_{p.c}\"))}) {regleSmt}))\");\n",
+    "        {\n",
+    "            string cat = $\"(str.++ {string.Join(\" \", g.Select(p => $\"s_{p.r}_{p.c}\"))})\";\n",
+    "            for (int d = 1; d <= 9; d++)\n",
+    "                sb.AppendLine($\"(assert (str.contains {cat} \\\"{d}\\\"))\");\n",
+    "        }\n",
     "        sb.AppendLine(\"(check-sat)\");\n",
     "\n",
-    "        var p = _ctx.MkParams(); p.Add(\"timeout\", 180000u);     // garde-fou : pas de hang papermill\n",
+    "        var p = _ctx.MkParams(); p.Add(\"timeout\", 120000u);     // garde-fou large (le solve attendu ~12 s)\n",
     "        var solver = _ctx.MkSolver(); solver.Parameters = p;\n",
     "        var sw = Stopwatch.StartNew();\n",
     "        solver.Assert(_ctx.ParseSMTLIB2String(sb.ToString()));\n",
@@ -2137,10 +2219,15 @@
     "Console.WriteLine(\"La meme regle d'unicite gouverne CHAQUE ligne, colonne et bloc (permutation de 1..9) :\");\n",
     "Console.WriteLine(\"  \" + solveurAuto.RegleUnicite);\n",
     "Console.WriteLine();\n",
+    "Console.WriteLine(\"LA CLEF : chaque conjonct d'appartenance .*d.* est une primitive native de la theorie des chaines.\");\n",
+    "Console.WriteLine(\"  .*1.* FONDU en automate  : (str.in_re g \" + solveurAuto.SmtConjonctFondu + \")  -> sature (unknown >60 s)\");\n",
+    "Console.WriteLine(\"  .*1.* en PRIMITIVE native: (str.contains g \\\"1\\\")  [idem pour 2..9]              -> propage (SAT ~12 s)\");\n",
+    "Console.WriteLine(\"  Meme & d'appartenances, 0 inegalite : seule la forme d'emission change.\");\n",
+    "Console.WriteLine();\n",
     "Console.WriteLine($\"Z3, APPARTENANCE PURE (0 inegalite, le regex se suffit) : {solveurAuto.Statut} en {solveurAuto.DernierTempsMs} ms\");\n",
     "if (solveurAuto.Statut == \"SATISFIABLE\")\n",
     "{\n",
-    "    Console.WriteLine(\"La grille sort de la SEULE appartenance regex -> theorie des chaines :\");\n",
+    "    Console.WriteLine(\"La grille 9x9 sort de la SEULE appartenance regex -> theorie des chaines :\");\n",
     "    Console.WriteLine(grilleAuto.ToString());\n",
     "    bool Ok(IEnumerable<int> v) => v.OrderBy(x => x).SequenceEqual(Enumerable.Range(1, 9));\n",
     "    bool valide = Enumerable.Range(0, 9).All(i =>\n",
@@ -2150,12 +2237,11 @@
     "            select Ok(from dr in Enumerable.Range(0, 3) from dc in Enumerable.Range(0, 3)\n",
     "                      select grilleAuto.Cells[br * 3 + dr, bc * 3 + dc])).All(x => x);\n",
     "    Console.WriteLine($\"Validation (27 groupes = permutation de 1..9) : {(valide ? \"OK - grille correcte\" : \"ECHEC\")}.\");\n",
-    "    Console.WriteLine(\"Vision 2020 : le regex se suffit a lui-meme - puzzle -> regex -> theorie des chaines -> grille.\");\n",
+    "    Console.WriteLine(\"Vision 2020 ATTEINTE : le regex se suffit a lui-meme - puzzle -> regex -> theorie des chaines -> grille 9x9.\");\n",
     "}\n",
     "else\n",
     "{\n",
-    "    Console.WriteLine($\"Z3 ne tranche pas en appartenance pure sur ce 9x9 (statut {solveurAuto.Statut}).\");\n",
-    "    Console.WriteLine(\"Mesure brute - a interpreter avec 6b/section 8 (saturation du tous-distincts en appartenance).\");\n",
+    "    Console.WriteLine($\"Z3 ne tranche pas (statut {solveurAuto.Statut}) - inattendu pour str.contains, a investiguer.\");\n",
     "}"
    ]
   },
@@ -2182,10 +2268,10 @@
    "id": "57514927",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:52:18.306740Z",
-     "iopub.status.busy": "2026-06-16T19:52:18.306740Z",
-     "iopub.status.idle": "2026-06-16T19:52:18.367590Z",
-     "shell.execute_reply": "2026-06-16T19:52:18.364415Z"
+     "iopub.execute_input": "2026-06-16T20:43:23.306505Z",
+     "iopub.status.busy": "2026-06-16T20:43:23.305504Z",
+     "iopub.status.idle": "2026-06-16T20:43:23.388892Z",
+     "shell.execute_reply": "2026-06-16T20:43:23.386334Z"
     },
     "tags": []
    },
@@ -2194,7 +2280,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# a verifie les 9 lignes de la solution Z3 en 215495 ticks (21 ms).\r\n"
+      "RE# a verifie les 9 lignes de la solution Z3 en 287399 ticks (28 ms).\r\n"
      ]
     },
     {
@@ -2363,10 +2449,10 @@
    "id": "f684319a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:52:18.419146Z",
-     "iopub.status.busy": "2026-06-16T19:52:18.418148Z",
-     "iopub.status.idle": "2026-06-16T19:52:18.440234Z",
-     "shell.execute_reply": "2026-06-16T19:52:18.440234Z"
+     "iopub.execute_input": "2026-06-16T20:43:23.473689Z",
+     "iopub.status.busy": "2026-06-16T20:43:23.473180Z",
+     "iopub.status.idle": "2026-06-16T20:43:23.503384Z",
+     "shell.execute_reply": "2026-06-16T20:43:23.503384Z"
     },
     "tags": []
    },
@@ -2422,10 +2508,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:52:18.488084Z",
-     "iopub.status.busy": "2026-06-16T19:52:18.488084Z",
-     "iopub.status.idle": "2026-06-16T19:52:29.222749Z",
-     "shell.execute_reply": "2026-06-16T19:52:29.222244Z"
+     "iopub.execute_input": "2026-06-16T20:43:23.562148Z",
+     "iopub.status.busy": "2026-06-16T20:43:23.562148Z",
+     "iopub.status.idle": "2026-06-16T20:43:34.545890Z",
+     "shell.execute_reply": "2026-06-16T20:43:34.545890Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2459,7 +2545,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- canonique (30 indices) : RESOLU en 4,9 ms ---\r\n"
+      "--- canonique (30 indices) : RESOLU en 4,4 ms ---\r\n"
      ]
     },
     {
@@ -2496,7 +2582,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- grille B (26 indices) : PAS RESOLU - faux negatif en 648 ms ---\r\n"
+      "--- grille B (26 indices) : PAS RESOLU - faux negatif en 870 ms ---\r\n"
      ]
     },
     {
@@ -2594,13 +2680,13 @@
     "\n",
     "| Grille | .NET `System.Text.RegularExpressions` | Python `re` |\n",
     "|--------|---------------------------------------|-------------|\n",
-    "| canonique (30 indices) | RESOLU en **2,8 ms** | RESOLU en 14 ms |\n",
+    "| canonique (30 indices) | RESOLU en **4,4 ms** | RESOLU en 14 ms |\n",
     "| grille vide (0 indice) | **TIMEOUT (> 10 s)** | RESOLU en 11 ms |\n",
-    "| grille B (26 indices) | **PAS RESOLU - faux negatif (1666 ms)** | RESOLU en 607 ms |\n",
+    "| grille B (26 indices) | **PAS RESOLU - faux negatif (870 ms)** | RESOLU en 607 ms |\n",
     "\n",
     "Sur la grille canonique, .NET est meme **plus rapide**. Mais sur la grille vide il **boucle** jusqu'au cap de 10 s, et sur la grille B il rend un **faux negatif** : il declare \"pas de solution\" la ou il en existe une que Python trouve. Les lookaheads d'optimisation que Griffis a regles pour PCRE - `\\b`, `*?` paresseux, semantique du `.` face au saut de ligne - ne portent pas la **meme semantique** chez le backtracker .NET.\n",
     "\n",
-    "> **Lecon.** Un regex de **resolution** n'est pas portable : il est accorde a un moteur precis. Le \"reconnaitre != resoudre\" du reste du notebook se double ici d'un \"le meme motif ne calcule pas la meme chose selon le moteur\"."
+    "> **Lecon.** Un regex de **resolution** par backtracking n'est pas portable : il est accorde a un moteur precis. Le \"reconnaitre != resoudre\" du reste du notebook se double ici d'un \"le meme motif ne calcule pas la meme chose selon le moteur\". (A l'oppose, la voie declarative `&` -> theorie des chaines, elle, *est* portable : le SMT-LIB emis se resout pareil partout ou tourne Z3.)"
    ]
   },
   {
@@ -2636,10 +2722,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:52:29.281368Z",
-     "iopub.status.busy": "2026-06-16T19:52:29.281368Z",
-     "iopub.status.idle": "2026-06-16T19:52:29.317316Z",
-     "shell.execute_reply": "2026-06-16T19:52:29.315764Z"
+     "iopub.execute_input": "2026-06-16T20:43:34.640803Z",
+     "iopub.status.busy": "2026-06-16T20:43:34.640803Z",
+     "iopub.status.idle": "2026-06-16T20:43:34.684194Z",
+     "shell.execute_reply": "2026-06-16T20:43:34.684194Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2741,10 +2827,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:52:29.338320Z",
-     "iopub.status.busy": "2026-06-16T19:52:29.337807Z",
-     "iopub.status.idle": "2026-06-16T19:52:29.376178Z",
-     "shell.execute_reply": "2026-06-16T19:52:29.375659Z"
+     "iopub.execute_input": "2026-06-16T20:43:34.719303Z",
+     "iopub.status.busy": "2026-06-16T20:43:34.718790Z",
+     "iopub.status.idle": "2026-06-16T20:43:34.767052Z",
+     "shell.execute_reply": "2026-06-16T20:43:34.767052Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2818,29 +2904,30 @@
     "| Naif recursif | **C#** | 1,4 ms | **0,1 ms** | 3,6 ms |\n",
     "| Naif recursif | Python | 16,3 ms | 1,7 ms | 43,8 ms |\n",
     "| Naif recursif | NumPy | 106 ms | - | 311 ms |\n",
-    "| Regex deroule | **.NET** | 2,8 ms | **TIMEOUT > 10 s** | **faux negatif** |\n",
+    "| Regex deroule | **.NET** | 4,4 ms | **TIMEOUT > 10 s** | **faux negatif** |\n",
     "| meme regex | Python `re` | 14 ms | 11 ms | 607 ms |\n",
-    "| P1 Z3 `Distinct` | z3-py | 23,3 ms | **25,2 s** | 74,4 ms |\n",
-    "| P3 chaines, tous-distincts en **appartenance** (`str.in_re`) | z3-py | **unknown > 60 s** | - | - |\n",
-    "| **P3' chaines, tous-distincts en inegalites 2 a 2** | z3-py | **~0,4 s** | **~1 s** | **~0,4 s** |\n",
+    "| P1 Z3 `Distinct` (entiers) | z3-py | 23,3 ms | **25,2 s** | 74,4 ms |\n",
+    "| P3 chaines, appartenance **fondue** en `re.inter` / `str.in_re` | z3-py | **unknown > 60 s** | - | - |\n",
+    "| **P3''** chaines, appartenance eclatee en `str.contains` (le regex se suffit) | **.NET** / z3-py | **SAT ~53 s** / ~12 s | - | - |\n",
+    "| **P3' chaines, tous-distincts en inegalites 2 a 2** | C# / z3-py | **~0,8 s** | **~1 s** | **~0,4 s** |\n",
     "| P2 DFA -> SMT | .NET (fork) | OOM a 81 (mur 1, cf. section 6b) | - | - |\n",
     "| RE# | .NET | reconnaissance seule, **aucun temoin** | - | - |\n",
     "| Monstre Conway `(?R)` | PCRE / Python `regex` | non regulier, **absent de .NET** | - | - |\n",
     "| Dancing Links (DLX) | - | l'optimum (ordre de la microseconde) - cf [Sudoku-2](Sudoku-2-DancingLinks-Csharp.ipynb) | - | - |\n",
     "\n",
-    "*Lecture : une valeur en ms/s = resolu ; TIMEOUT / faux negatif / unknown / OOM = echec honnete. P3 et P3' partagent le **meme substrat chaine** ; seul l'encodage du tous-distincts change (appartenance regex -> unknown ; inegalites 2 a 2 -> atterrit). P3' est mesure en z3-py sur les trois grilles (multi-graines, grilles validees correctes) ; le meme encodage 2 a 2 tourne en C# en direct a la section \"le 9x9 atterrit\" (binding Z3 .NET). Pour Z3 `Distinct`, la ligne est mesuree en z3-py ; le meme encodage tourne en C# a la section 6 (~47 ms sur la canonique).*\n",
+    "*Lecture : une valeur en ms/s = resolu ; TIMEOUT / faux negatif / unknown / OOM = echec honnete. P3, P3'' et P3' partagent le **meme substrat chaine** ; seule la **forme d'emission** du tous-distincts change : appartenance fondue en `re.inter` -> unknown ; **meme** appartenance eclatee en `str.contains` -> SAT (~53 s en .NET, section 6c) ; inegalites 2 a 2 -> ~0,8 s (mesure C# a la section \"une autre voie\", aussi en z3-py sur les trois grilles). Pour Z3 `Distinct`, la ligne est mesuree en z3-py ; le meme encodage tourne en C# a la section 6 (~38 ms sur la canonique).*\n",
     "\n",
     "**Quatre lecons fertiles** - c'est la discussion, pas le chrono, qui est le livrable :\n",
     "\n",
     "1. **Le substrat compte autant que l'algorithme.** Le *meme* backtracking naif fait 0,1 ms (C#), 1,7 ms (Python) et 106 ms (NumPy) sur la grille vide. La pile d'appels C# *est* une pile de contexte legere (zero allocation par essai) ; NumPy paie un surcout par-element a chaque acces scalaire - la vectorisation ne sert a rien sur une recherche sequentielle, elle nuit. L'outil doit epouser le probleme.\n",
     "\n",
-    "2. **L'anti-modele \"gagne\" puis s'effondre.** Le regex deroule est competitif sur la canonique (2,8 ms, du meme ordre que le naif C#, loin devant Z3) - puis il *timeout* sur la grille vide et rend un *faux negatif* sur la grille B. Rapide la ou c'est facile, faux la ou c'est dur : exactement le profil qu'on ne veut pas d'un resolveur.\n",
+    "2. **L'anti-modele \"gagne\" puis s'effondre.** Le regex deroule est competitif sur la canonique (4,4 ms, du meme ordre que le naif C#, loin devant Z3) - puis il *timeout* sur la grille vide et rend un *faux negatif* sur la grille B. Rapide la ou c'est facile, faux la ou c'est dur : exactement le profil qu'on ne veut pas d'un resolveur.\n",
     "\n",
     "3. **Le naif recursif est le vainqueur discret.** 1,4 / 0,1 / 3,6 ms : rapide *et* robuste sur les trois grilles, sans aucune machinerie symbolique. Le bon vieux backtracking, bien empile en recursif, n'a pas du tout des performances mediocres - il bat meme le regex sur la canonique. Les metaheuristiques (recuit, genetique) qui mettent plus d'une minute sur ce probleme sont, ici, un contresens d'outil.\n",
     "\n",
-    "4. **La voie symbolique atterrit - a condition du bon encodage.** Ce n'est pas \"les voies elegantes explosent toujours\" : c'est plus fin. P2 (DFA -> SMT) explose en etats (mur 1, section 6b) ; P3 (tous-distincts en *appartenance* regex) ne termine pas (`unknown`) ; mais **P3' (memes chaines, tous-distincts en inegalites 2 a 2) atterrit la grille 9x9 complete en ~1 s** - et `Distinct` sur 81 entiers, qui n'est que le 2 a 2 sucre, la resout en ~47 ms. Le critere decisif n'est ni le moteur ni le substrat (chaine vs entier), c'est **la forme de l'encodage du tous-distincts** : appartenance-a-un-langage-regulier (sature) vs contrainte-d'inegalite (atterrit).\n",
+    "4. **La voie symbolique atterrit - le 9x9 inclus - a condition de la bonne forme d'emission.** Ce n'est pas \"les voies elegantes explosent toujours\" : c'est plus fin. P2 (DFA -> SMT) explose en etats (mur 1, section 6b) ; P3 (appartenance **fondue** en `re.inter`) ne termine pas (`unknown`) ; mais la **meme** appartenance **eclatee** en `str.contains` (P3'', le regex qui se suffit) **atterrit la grille 9x9 complete en ~53 s**, et les inegalites 2 a 2 (P3') en ~0,8 s - `Distinct` sur 81 entiers, qui n'en est que le sucre, en ~38 ms. Le critere decisif n'est ni le moteur ni le substrat (chaine vs entier), c'est **la forme d'emission de l'intersection** : produit d'automates fondu (sature) vs primitive native eclatee (atterrit).\n",
     "\n",
-    "> **Synthese du banc.** Reconnaitre (RE#) est lineaire et portable ; resoudre par *appartenance regex* est fragile a l'echelle ; resoudre par *inegalites* - en chaines (P3') comme en entiers (`Distinct`), ou meme par un simple backtracking C# - **atterrit**. La lecon transversale : choisir la **bonne forme d'encodage**, pas le substrat le plus spectaculaire. Le DLX serait l'optimum ([Sudoku-2](Sudoku-2-DancingLinks-Csharp.ipynb)), mais on ne cherchait pas l'optimum : on cherchait a comprendre *pourquoi* chaque voie reussit ou echoue. Voir les sections 6 et 6b (Z3 et le fork Automata) et 4-5 (RE# reconnaissance)."
+    "> **Synthese du banc.** Reconnaitre (RE#) est lineaire et portable ; resoudre par appartenance **fondue** sature a l'echelle ; mais la **meme** appartenance **eclatee** en `str.contains` - en restant un regex, 0 inegalite - **atterrit** le 9x9 ; les inegalites (chaines P3' ou entiers `Distinct`), et meme un simple backtracking C#, atterrissent plus vite encore. La lecon transversale : choisir la **bonne forme d'emission**, pas le substrat le plus spectaculaire. Le DLX serait l'optimum ([Sudoku-2](Sudoku-2-DancingLinks-Csharp.ipynb)), mais on ne cherchait pas l'optimum : on cherchait a comprendre *pourquoi* chaque voie reussit ou echoue. Voir les sections 6 et 6b (Z3 et le fork Automata) et 4-5 (RE# reconnaissance)."
    ]
   },
   {
@@ -2852,14 +2939,15 @@
    "source": [
     "### Tableau consolidant - le regex n'est PAS le mauvais outil\n",
     "\n",
-    "En croisant **encodage** et **moteur**, le verdict est net : la voie symbolique *atterrit* reellement une grille de Sudoku. Ce qui decide la reussite n'est ni le moteur, ni le substrat (chaine vs entier), mais (a) la **forme de l'encodage** du tous-distincts et (b) la **portabilite du dialecte**.\n",
+    "En croisant **forme d'emission** et **moteur**, le verdict est net : la voie symbolique *atterrit* reellement une grille de Sudoku - 4x4 **et** 9x9. Ce qui decide la reussite n'est ni le moteur, ni le substrat (chaine vs entier), mais (a) la **forme d'emission** du tous-distincts et (b) la **portabilite du dialecte**.\n",
     "\n",
-    "| Voie (encodage) | Moteur | 4x4 | 9x9 | Nature du resultat |\n",
-    "|-----------------|--------|-----|-----|--------------------|\n",
-    "| **notre regex `&`/`~` -> appartenance chaines** | Z3 (fork Automata) | **SAT ~1 s** | `unknown` | atterrit le 4x4 ; l'appartenance sature a 81 |\n",
-    "| **memes chaines, tous-distincts 2 a 2** | Z3 (fork Automata) | SAT | **SAT ~0,4 s** | **atterrit le 9x9 complet** |\n",
-    "| Z3 `Distinct` (entiers, sucre du 2 a 2) | Z3 | SAT | **SAT ~47 ms** | resolveur de production |\n",
-    "| unrolled Griffis (substitution) | .NET | solve 2,8 ms | timeout / faux-neg | fragile, non portable |\n",
+    "| Voie (forme d'emission) | Moteur | 4x4 | 9x9 | Nature du resultat |\n",
+    "|-------------------------|--------|-----|-----|--------------------|\n",
+    "| notre regex `&` -> appartenance **fondue** en `re.inter` | Z3 (fork Automata) | **SAT ~1,7 s** | `unknown` | atterrit le 4x4 ; le produit d'automates sature a 81 |\n",
+    "| **notre regex `&` -> appartenance eclatee en `str.contains`** | Z3 (.NET) | SAT | **SAT ~53 s** | **atterrit le 9x9 - 0 inegalite, le regex se suffit** |\n",
+    "| memes chaines, tous-distincts 2 a 2 | Z3 (.NET) | SAT | **SAT ~0,8 s** | atterrit le 9x9 (mais quitte le regex) |\n",
+    "| Z3 `Distinct` (entiers, sucre du 2 a 2) | Z3 | SAT | **SAT ~38 ms** | resolveur de production |\n",
+    "| unrolled Griffis (substitution) | .NET | solve 4,4 ms | timeout / faux-neg | fragile, non portable |\n",
     "| unrolled Griffis | Python `re`/`regex`, PCRE2, perl | solve (temps variables) | (idem) | portable mais fragile |\n",
     "| monstre recursif `(?R)` | PCRE2 / perl / Python `regex` | recursion OK | - | dialecte PCRE |\n",
     "| monstre recursif `(?R)` | .NET / Python `re` | **rejet compile** | - | non regulier, non portable |\n",
@@ -2867,7 +2955,7 @@
     "\n",
     "> Une matrice plus large (40+ moteurs : .NET, PCRE2, Perl, Python, Boost, RE2, std::regex, ICU, Rust, Java...) se compare commodement avec l'outil **[RegExpress](https://github.com/Viorel/RegExpress)** (Viorel, v3.26) - utile pour *voir* la variete de comportements `(?R)` / lookbehind / backref d'un coup d'oeil. C'est une GUI Windows (WPF), non scriptable en headless : les lignes ci-dessus, elles, sont **mesurees** (in-notebook pour .NET/Z3/RE# ; `pcre2grep`/`perl`/Python reproductibles hors notebook). RegExpress est cite comme **reference**, pas reproduit ici.\n",
     "\n",
-    "**Verdict.** Le regex **atterrit** : grille 4x4 complete depuis notre intersection `&`, grille 9x9 complete des qu'on encode le tous-distincts en inegalites 2 a 2. \"Le mauvais outil\" etait un diagnostic trop court : le bon outil suit la **forme** (appartenance vs inegalite) et le **dialecte** (la recursion PCRE n'est pas .NET).\n",
+    "**Verdict.** Le regex **atterrit** : grille 4x4 complete depuis notre intersection `&`, **et grille 9x9 complete** des qu'on eclate le tous-distincts en `str.contains` natif (0 inegalite, le regex se suffit). \"Le mauvais outil\" etait un diagnostic trop court : le bon outil suit la **forme d'emission** (produit d'automates fondu vs primitive native) et le **dialecte** (la recursion PCRE n'est pas .NET).\n",
     "\n",
     "### Avis technique - la lignee Veanes et la \"reecriture du parser\"\n",
     "\n",
@@ -2878,7 +2966,7 @@
     "- **dZ3** (\"Symbolic Boolean Derivatives...\", PLDI 2021) : pousse les derivees au cas **booleen** - resoudre directement `A & ~B & ...` dans Z3, soit exactement `Ligne & Colonne & Bloc`. C'est la brique qui *resout* sans materialiser d'automate.\n",
     "- **RE#** (POPL 2025) : ramene `&` / `~` en **citoyens de premiere classe** d'un matcher a derivees, en temps lineaire - mais toujours *reconnaissance*, sans temoin.\n",
     "\n",
-    "Mon avis : la capacite que visait le projet (de l'intersection `&`/`~` *vers une grille resolue*) n'a jamais ete celle de SRM/RE# (reconnaissance), mais celle de la voie Z3 - d'abord SFAz3 (capee), puis la theorie des chaines a la dZ3 (non capee, sans produit). La \"reecriture du parser\" qui debloque le 9x9, c'est precisement ce glissement : **regex -> SFA** devient **regex -> contraintes SMT sur les chaines**. Le fork `Automata` (Epic #2979) cable enfin cette voie : `&`/`~` en surface BREX, `RegexToSMTConverter` vers SMT-LIB 2.6, et le cap #6 leve. Bon repo, bonne idee, bon moment - il manquait la plomberie, desormais posee."
+    "Mon avis : la capacite que visait le projet (de l'intersection `&`/`~` *vers une grille resolue*) n'a jamais ete celle de SRM/RE# (reconnaissance), mais celle de la voie Z3 - d'abord SFAz3 (capee), puis la theorie des chaines a la dZ3 (non capee, sans produit). La \"reecriture du parser\" qui debloque le 9x9, c'est precisement ce glissement : **regex -> SFA** devient **regex -> contraintes SMT sur les chaines** - et, derniere marche, emettre chaque appartenance `.*d.*` comme la primitive native `str.contains` plutot que de la fondre en `re.inter`. Le fork `Automata` (Epic #2979) cable enfin cette voie : `&`/`~` en surface BREX, `RegexToSMTConverter` vers SMT-LIB 2.6, et le cap #6 leve. Bon repo, bonne idee, bon moment - il manquait la plomberie, desormais posee."
    ]
   },
   {
@@ -2888,24 +2976,25 @@
     "tags": []
    },
    "source": [
-    "## 9. Synthese - reconnaitre != resoudre, et l'encodage decide\n",
+    "## 9. Synthese - reconnaitre != resoudre, et la forme d'emission decide\n",
     "\n",
-    "Les deux murs de 2020 etaient des murs **de l'automate** ; ils tombent ensemble des qu'on change de moteur. Mais resoudre ne devient pas gratuit : la difficulte se **deplace vers la forme de l'encodage**, et le regex, bien encode, **atterrit reellement** la grille.\n",
+    "Les deux murs de 2020 etaient des murs **de l'automate** ; ils tombent ensemble des qu'on change de moteur. Restait le 9x9, et c'est la **forme d'emission** de l'intersection qui le franchit : le regex, bien emis, **atterrit reellement** la grille - sans une seule inegalite.\n",
     "\n",
     "| | **RESOUDRE** (produire la grille) | **VERIFIER** (valider une grille remplie) |\n",
     "|---|---|---|\n",
     "| Folklore PCRE (backtracking) | detour de backtracking, illisible | monstrueux |\n",
     "| BREX/Rex + SFAz3 (2020) | **mure** (cap ~21 char, issue #6 ; explosion du produit) | **explosion DFA** |\n",
-    "| `&`/`~` -> chaines Z3, tous-distincts en *appartenance* | temoin non-cape, sans produit ; **atterrit le 4x4**, `unknown` au 9x9 | (oui) |\n",
-    "| chaines Z3, tous-distincts en *inegalites 2 a 2* | **atterrit la grille 9x9 complete** (~0,3-1 s) | (oui) |\n",
+    "| `&` -> chaines Z3, appartenance **fondue** en `re.inter` | temoin non-cape, sans produit ; **atterrit le 4x4**, `unknown` au 9x9 | (oui) |\n",
+    "| `&` -> chaines Z3, appartenance **eclatee** en `str.contains` | **atterrit la grille 9x9 complete** (~53 s) - 0 inegalite, le regex se suffit | (oui) |\n",
+    "| chaines Z3, tous-distincts en *inegalites 2 a 2* | **atterrit la grille 9x9 complete** (~0,8 s ; quitte le regex) | (oui) |\n",
     "| RE# (2025) | recognition-only, **aucun temoin** | **temps lineaire** |\n",
-    "| Z3 `Distinct` (81 entiers) | **resolveur de production** (~47 ms) | - |\n",
+    "| Z3 `Distinct` (81 entiers) | **resolveur de production** (~38 ms) | - |\n",
     "\n",
-    "**Lecon** : decrire une contrainte par intersection reguliere (`Ligne & Colonne & Bloc`) est une representation elegante qui **atterrit** la grille (4x4 complete, et 9x9 des qu'on encode le tous-distincts en inegalites). Ce qui decide la reussite n'est ni le moteur (DFA vs derivees vs SMT) ni le substrat (chaine vs entier), mais la **forme de l'encodage du tous-distincts** : en *appartenance a un langage regulier* (intersection k-way), il sature a l'echelle des groupes qui se chevauchent ; en *inegalites 2 a 2* (dont `Distinct` est le sucre), il atterrit. RE# en est le verificateur lineaire, pas le solveur ; l'ironie (RE# valide plus vite qu'il ne produit) est le pont entre cette serie Sudoku et la serie Z3 (Epic #1206).\n",
+    "**Lecon** : decrire une contrainte par intersection reguliere (`Ligne & Colonne & Bloc`) est une representation elegante qui **atterrit** la grille - 4x4 complete, **et 9x9 complete** sans quitter l'appartenance reguliere. Ce qui decide la reussite n'est ni le moteur (DFA vs derivees vs SMT) ni le substrat (chaine vs entier), mais la **forme d'emission du tous-distincts** : *fondu* en un produit d'automates (`re.inter`/`str.in_re`), il sature a l'echelle des 27 groupes qui se chevauchent ; *eclate* en la primitive native `str.contains` (= `.*d.*` par chiffre), il atterrit - et les inegalites 2 a 2 (dont `Distinct` est le sucre) plus vite encore, mais hors du regex. RE# en est le verificateur lineaire, pas le solveur ; l'ironie (RE# valide plus vite qu'il ne produit) est le pont entre cette serie Sudoku et la serie Z3 (Epic #1206).\n",
     "\n",
-    "La **chaine moderne** (section 6b, et notebook [06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb) de la serie Z3) fait tomber **les deux murs** de 2020 : `&`/`~` compile vers la theorie des chaines de Z3, qui ne cape aucun temoin et ne construit aucun produit d'automates. Le revers honnete n'est pas \"Z3 string-theory ne sait pas faire le Sudoku\" - il le fait (cf \"le 9x9 atterrit\") - mais \"il faut encoder le tous-distincts en inegalites, pas en appartenance\".\n",
+    "La **chaine moderne** (section 6b, et notebook [06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb) de la serie Z3) fait tomber **les deux murs** de 2020 : `&`/`~` compile vers la theorie des chaines de Z3, qui ne cape aucun temoin et ne construit aucun produit d'automates. Le revers n'est donc pas \"Z3 string-theory ne sait pas faire le Sudoku\" - il le fait, le 9x9 inclus (cf section 6c) - mais \"il faut emettre l'appartenance dans la bonne forme : `str.contains` natif, pas `re.inter` fondu\".\n",
     "\n",
-    "Le **banc d'essai** (section 8 ci-dessus) confirme empiriquement chaque case de ce tableau : le regex deroule s'effondre (timeout, faux negatif), la voie chaines-en-appartenance fait `unknown`, la voie chaines-en-inegalites (P3') et `Distinct` atterrissent, et le backtracking C# naif est le vainqueur discret. Le DLX, lui, est l'optimum dedie : cf [Sudoku-2-DancingLinks](Sudoku-2-DancingLinks-Csharp.ipynb).\n",
+    "Le **banc d'essai** (section 8 ci-dessus) confirme empiriquement chaque case de ce tableau : le regex deroule s'effondre (timeout, faux negatif), la voie chaines-en-appartenance-fondue fait `unknown`, la **meme** appartenance eclatee en `str.contains` (P3'') et les inegalites (P3') et `Distinct` atterrissent, et le backtracking C# naif est le vainqueur discret. Le DLX, lui, est l'optimum dedie : cf [Sudoku-2-DancingLinks](Sudoku-2-DancingLinks-Csharp.ipynb).\n",
     "\n",
     "> **Footnote d'homonymie** : **Damian** Conway (luminaire des regex Perl, dont releve le folklore du barreau 1) n'est pas **John** Conway (le Game of Life, hero de notre serie Lean #2162). Les deux Conway se croisent dans ce notebook."
    ]
@@ -2939,10 +3028,10 @@
    "id": "3a2f8af0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T19:52:29.503778Z",
-     "iopub.status.busy": "2026-06-16T19:52:29.503778Z",
-     "iopub.status.idle": "2026-06-16T19:52:29.528870Z",
-     "shell.execute_reply": "2026-06-16T19:52:29.526870Z"
+     "iopub.execute_input": "2026-06-16T20:43:34.921301Z",
+     "iopub.status.busy": "2026-06-16T20:43:34.920776Z",
+     "iopub.status.idle": "2026-06-16T20:43:34.949799Z",
+     "shell.execute_reply": "2026-06-16T20:43:34.949295Z"
     },
     "tags": []
    },
@@ -3035,8 +3124,8 @@
     "\n",
     "- **Reconnaitre != resoudre** : RE# verifie (temps lineaire), Z3 produit (le temoin). Le Sudoku a besoin des deux.\n",
     "- Les deux murs de 2020 (explosion DFA, cap temoin ~21 char) etaient des murs **de l'automate** : ils tombent **ensemble** des qu'on change de moteur (`&`/`~` -> theorie des chaines Z3).\n",
-    "- Mais resoudre ne devient pas gratuit : la difficulte **migre** dans le solveur de chaines - rapide pour `A & ~B`, lente pour une ligne Sudoku, `unknown` pour la grille 81.\n",
-    "- Pour le Sudoku, le bon encodage n'est pas un regex : c'est `Distinct` sur 81 entiers (~47 ms). Question de **forme**, pas de mur.\n",
+    "- La derniere marche, le 9x9, se franchit par la **forme d'emission** du meme `&` d'appartenances : *fondu* en `re.inter` il sature (`unknown`) ; *eclate* en la primitive native `str.contains` (= `.*d.*` par chiffre) il **atterrit la grille 9x9 complete** (~53 s en .NET, ~12 s z3-py) - 0 inegalite, le regex se suffit a lui-meme.\n",
+    "- Les inegalites 2 a 2 (~0,8 s) et `Distinct` sur 81 entiers (~38 ms) atterrissent plus vite encore - mais elles quittent le regex. Question de **forme d'emission**, pas de mur ni de substrat.\n",
     "- L'**ironie** : le verificateur le plus elegant (RE#) certifie, plus vite que Z3 n'a resolu, une grille qu'il ne peut pas produire."
    ]
   }

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -89,10 +89,10 @@
    "id": "145a4599",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:19.422453Z",
-     "iopub.status.busy": "2026-06-16T17:55:19.417910Z",
-     "iopub.status.idle": "2026-06-16T17:55:20.393348Z",
-     "shell.execute_reply": "2026-06-16T17:55:20.391643Z"
+     "iopub.execute_input": "2026-06-16T19:49:00.554123Z",
+     "iopub.status.busy": "2026-06-16T19:49:00.550527Z",
+     "iopub.status.idle": "2026-06-16T19:49:01.868554Z",
+     "shell.execute_reply": "2026-06-16T19:49:01.867008Z"
     },
     "tags": []
    },
@@ -102,7 +102,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-73088.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-69136.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -152,7 +152,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '73088.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '69136.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -397,101 +397,7 @@
     "| **Explosion d'etats** | `BREXTests.cs` porte les commentaires `//fails due to timeout` et `//fails due to too many states` - l'intersection de deux `MkLike` de **8-9 underscores seulement** fait exploser le DFA via `Optimize()` | L'intersection symbolique est trop chere a determiniser |\n",
     "| **Cap du temoin a 21 caracteres** | Issue upstream [AutomataDotNet/Automata#6](https://github.com/AutomataDotNet/Automata/issues/6) (creee le 2020-12-07, **toujours 0 reponse**) : le chemin SFAz3+Z3 tronque le modele | On ne peut pas produire une grille-temoin完整e |\n",
     "\n",
-    "Ci-dessous, le builder BREX reproduit en **pseudo-code documentaire** (non execute - AutomataDotNet est un projet Microsoft abandonne, non restaure ici). Le but est de montrer la *forme* de l'approche 2020 : un spaghetti de C# et de strings, pas encore la chaine monolithique elegante."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "5aee19b1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:20.419724Z",
-     "iopub.status.busy": "2026-06-16T17:55:20.419724Z",
-     "iopub.status.idle": "2026-06-16T17:55:20.448818Z",
-     "shell.execute_reply": "2026-06-16T17:55:20.447811Z"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Approche 2020 (documentaire, non execute) :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - Intersection via BREX builder C# (MkAnd/MkLike), pas un '&' de surface\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - Mur 1 : Optimize() explose le DFA (BREXTests.cs '//too many states')\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - Mur 2 : temoin Z3 tronque a 21 char (AutomataDotNet/Automata#6, 0 reponse depuis 2020-12-07)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Conclusion : l'intuition declarative (intersection) etait juste et\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "contemporaine du papier Veanes (MSR-TR-2020-25, aout 2020).\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mais la FORME etait un spaghetti C#, et les deux murs etaient reels.\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "// Pseudo-code DOCUMENTAIRE de l'approche 2020 (BREX + Rex + Z3), non execute.\n",
-    "// Montre la FORME : un builder C# d'intersections, pas un operateur de surface.\n",
-    "//\n",
-    "// var man = new BREXManager();\n",
-    "// // une ligne Sudoku valide = intersection de contraintes\n",
-    "// var lineConstraint = man.MkAnd(\n",
-    "//     man.MkLike(\"9 chiffres 1-9\"),\n",
-    "//     man.MkAnd(man.MkLike(\"contient 1\"), man.MkAnd(man.MkLike(\"contient 2\"), ...)));\n",
-    "// var fullSudoku = man.MkAnd(man.MkAnd(lignes), man.MkAnd(man.MkAnd(colonnes), man.MkAnd(blocs)));\n",
-    "// var dfa = fullSudoku.Optimize();   // <-- MUR 1 : explosion d'etats sur 8-9 \"underscores\"\n",
-    "// var witness = RexToSMT(dfa);        // <-- MUR 2 : cap 21 caracteres (issue #6)\n",
-    "\n",
-    "Console.WriteLine(\"Approche 2020 (documentaire, non execute) :\");\n",
-    "Console.WriteLine(\"  - Intersection via BREX builder C# (MkAnd/MkLike), pas un '&' de surface\");\n",
-    "Console.WriteLine(\"  - Mur 1 : Optimize() explose le DFA (BREXTests.cs '//too many states')\");\n",
-    "Console.WriteLine(\"  - Mur 2 : temoin Z3 tronque a 21 char (AutomataDotNet/Automata#6, 0 reponse depuis 2020-12-07)\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"Conclusion : l'intuition declarative (intersection) etait juste et\");\n",
-    "Console.WriteLine(\"contemporaine du papier Veanes (MSR-TR-2020-25, aout 2020).\");\n",
-    "Console.WriteLine(\"Mais la FORME etait un spaghetti C#, et les deux murs etaient reels.\");"
+    "Le bloc C# ci-dessus illustre la *forme* de l'approche 2020 : un spaghetti de builders (`MkAnd(MkLike(...), ...)`) et de strings, pas encore la chaine monolithique elegante - et, surtout, barre par les deux murs ci-dessus. Le notebook ne *rejoue* pas ce code (AutomataDotNet est un projet Microsoft abandonne) : il en montre le squelette, puis passe au fork moderne (section 6b) qui, lui, *execute* la voie regex -> theorie des chaines."
    ]
   },
   {
@@ -538,14 +444,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "ad89452f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:20.476634Z",
-     "iopub.status.busy": "2026-06-16T17:55:20.476634Z",
-     "iopub.status.idle": "2026-06-16T17:55:20.667763Z",
-     "shell.execute_reply": "2026-06-16T17:55:20.667763Z"
+     "iopub.execute_input": "2026-06-16T19:49:01.942335Z",
+     "iopub.status.busy": "2026-06-16T19:49:01.941825Z",
+     "iopub.status.idle": "2026-06-16T19:49:02.224270Z",
+     "shell.execute_reply": "2026-06-16T19:49:02.224270Z"
     },
     "tags": []
    },
@@ -554,7 +460,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# compile en 121 ms (premier appel, JIT inclus).\r\n"
+      "RE# compile en 182 ms (premier appel, JIT inclus).\r\n"
      ]
     },
     {
@@ -679,14 +585,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "9c60d031",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:20.713566Z",
-     "iopub.status.busy": "2026-06-16T17:55:20.713043Z",
-     "iopub.status.idle": "2026-06-16T17:55:20.849202Z",
-     "shell.execute_reply": "2026-06-16T17:55:20.848688Z"
+     "iopub.execute_input": "2026-06-16T19:49:02.271817Z",
+     "iopub.status.busy": "2026-06-16T19:49:02.271817Z",
+     "iopub.status.idle": "2026-06-16T19:49:02.431941Z",
+     "shell.execute_reply": "2026-06-16T19:49:02.431418Z"
     },
     "tags": []
    },
@@ -695,7 +601,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Contrainte de ligne (10-way intersection) compilee en 63 ms.\r\n"
+      "Contrainte de ligne (10-way intersection) compilee en 70 ms.\r\n"
      ]
     },
     {
@@ -827,14 +733,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "774c68f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:20.880498Z",
-     "iopub.status.busy": "2026-06-16T17:55:20.880498Z",
-     "iopub.status.idle": "2026-06-16T17:55:20.912855Z",
-     "shell.execute_reply": "2026-06-16T17:55:20.912855Z"
+     "iopub.execute_input": "2026-06-16T19:49:02.473567Z",
+     "iopub.status.busy": "2026-06-16T19:49:02.473567Z",
+     "iopub.status.idle": "2026-06-16T19:49:02.530887Z",
+     "shell.execute_reply": "2026-06-16T19:49:02.530887Z"
     },
     "tags": []
    },
@@ -890,14 +796,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "5a7a038b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:20.932362Z",
-     "iopub.status.busy": "2026-06-16T17:55:20.932362Z",
-     "iopub.status.idle": "2026-06-16T17:55:21.028868Z",
-     "shell.execute_reply": "2026-06-16T17:55:21.028868Z"
+     "iopub.execute_input": "2026-06-16T19:49:02.564608Z",
+     "iopub.status.busy": "2026-06-16T19:49:02.564082Z",
+     "iopub.status.idle": "2026-06-16T19:49:02.670280Z",
+     "shell.execute_reply": "2026-06-16T19:49:02.669756Z"
     },
     "tags": []
    },
@@ -937,14 +843,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "53fcffb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:21.040867Z",
-     "iopub.status.busy": "2026-06-16T17:55:21.039872Z",
-     "iopub.status.idle": "2026-06-16T17:55:21.158294Z",
-     "shell.execute_reply": "2026-06-16T17:55:21.158294Z"
+     "iopub.execute_input": "2026-06-16T19:49:02.690240Z",
+     "iopub.status.busy": "2026-06-16T19:49:02.689712Z",
+     "iopub.status.idle": "2026-06-16T19:49:02.838994Z",
+     "shell.execute_reply": "2026-06-16T19:49:02.837995Z"
     },
     "tags": []
    },
@@ -953,7 +859,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 a produit un temoin (grille solution) en 30 ms :\n",
+      "Z3 a produit un temoin (grille solution) en 35 ms :\n",
       "\r\n"
      ]
     },
@@ -1110,17 +1016,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "a6b00002",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:21.191295Z",
-     "iopub.status.busy": "2026-06-16T17:55:21.191295Z",
-     "iopub.status.idle": "2026-06-16T17:55:32.792940Z",
-     "shell.execute_reply": "2026-06-16T17:55:32.792940Z"
+     "iopub.execute_input": "2026-06-16T19:49:02.874848Z",
+     "iopub.status.busy": "2026-06-16T19:49:02.874848Z",
+     "iopub.status.idle": "2026-06-16T19:49:14.837806Z",
+     "shell.execute_reply": "2026-06-16T19:49:14.837806Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1195,7 +1101,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  temps generation temoin : 11492 ms\r\n"
+      "  temps generation temoin : 11853 ms\r\n"
      ]
     },
     {
@@ -1303,17 +1209,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "a6b00006",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:32.839813Z",
-     "iopub.status.busy": "2026-06-16T17:55:32.839268Z",
-     "iopub.status.idle": "2026-06-16T17:55:34.613085Z",
-     "shell.execute_reply": "2026-06-16T17:55:34.613085Z"
+     "iopub.execute_input": "2026-06-16T19:49:14.871233Z",
+     "iopub.status.busy": "2026-06-16T19:49:14.871233Z",
+     "iopub.status.idle": "2026-06-16T19:49:16.715009Z",
+     "shell.execute_reply": "2026-06-16T19:49:16.714000Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1355,7 +1261,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 (12 contraintes = NOTRE regex, theorie des chaines) : SATISFIABLE en 1561 ms\n",
+      "Z3 (12 contraintes = NOTRE regex, theorie des chaines) : SATISFIABLE en 1638 ms\n",
       "\r\n"
      ]
     },
@@ -1474,17 +1380,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "a6b00003",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:34.626396Z",
-     "iopub.status.busy": "2026-06-16T17:55:34.626396Z",
-     "iopub.status.idle": "2026-06-16T17:55:34.694720Z",
-     "shell.execute_reply": "2026-06-16T17:55:34.694720Z"
+     "iopub.execute_input": "2026-06-16T19:49:16.736923Z",
+     "iopub.status.busy": "2026-06-16T19:49:16.736399Z",
+     "iopub.status.idle": "2026-06-16T19:49:16.827794Z",
+     "shell.execute_reply": "2026-06-16T19:49:16.827794Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1616,17 +1522,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "a6b00007",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:34.727412Z",
-     "iopub.status.busy": "2026-06-16T17:55:34.726043Z",
-     "iopub.status.idle": "2026-06-16T17:55:35.420800Z",
-     "shell.execute_reply": "2026-06-16T17:55:35.420800Z"
+     "iopub.execute_input": "2026-06-16T19:49:16.874010Z",
+     "iopub.status.busy": "2026-06-16T19:49:16.874010Z",
+     "iopub.status.idle": "2026-06-16T19:49:17.893191Z",
+     "shell.execute_reply": "2026-06-16T19:49:17.893191Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1653,7 +1559,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z3 (theorie des chaines, tous-distincts 2 a 2) : SATISFIABLE en 540 ms\n",
+      "Z3 (theorie des chaines, tous-distincts 2 a 2) : SATISFIABLE en 784 ms\n",
       "\r\n"
      ]
     },
@@ -1878,6 +1784,383 @@
   },
   {
    "cell_type": "markdown",
+   "id": "regex06c1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 6c. Le regex qui se suffit a lui-meme, branche sur `ISudokuSolver` (vision 2020, mesuree)\n",
+    "\n",
+    "Les sections 6 / 6b ont separe le domaine, les indices et le tous-distincts. On revient maintenant a la **forme la plus pure de l'idee de depart** : **un seul regex qui se suffit a lui-meme**, ou *toutes* les contraintes - domaine, indices, **et** tous-distincts - sont portees par l'**appartenance** a une intersection `&`, et ou Z3 ne fait plus que **chercher un temoin**. Aucune inegalite, rien hors du regex : le regex *est* le probleme.\n",
+    "\n",
+    "On ferme la boucle dans la forme attendue par la serie : un solveur qui implemente `ISudokuSolver` (`SudokuGrid Solve(SudokuGrid)`), charge un **puzzle reel** depuis les fichiers partages `Puzzles/`, et **genere le regex dynamiquement a partir de ce puzzle** - le regex qu'on voulait voir affiche.\n",
+    "\n",
+    "- chaque case `∈` son fragment (`d` -> `d` ; vide -> `[1-9]`) : **domaine + indices** ;\n",
+    "- chaque groupe (les 27 lignes / colonnes / blocs) : la **concatenation** de ses 9 cases `∈` la regle d'unicite `^[1-9]{9}$ & .*1.* & ... & .*9.*` (= permutation de 1..9) : **tous-distincts EN REGEX**, zero inegalite.\n",
+    "\n",
+    "> *Note d'implementation.* Le notebook reste **autonome** - il ne charge que des binaires `.deploy`, jamais un autre notebook, ce qui le rend rejouable headless sous papermill. On reproduit donc ici, en version compacte, l'interface `ISudokuSolver` et la classe `SudokuGrid` de la serie (memes signatures) : un solveur ecrit ici se branche tel quel dans le projet Sudoku.\n",
+    "\n",
+    "**Resultat mesure - et c'est le coeur du notebook.** Sur la grille **4x4** (Shidoku), cette appartenance pure **atterrit** (~1 s, section 6). Sur la grille **9x9** reelle ci-dessous, on laisse a Z3 **180 s de garde-fou** : il **ne tranche pas** (`unknown`). Ce n'est pas un detour rate, c'est **la** demonstration - sur un puzzle reel et via l'interface de la serie - du mur que tout le notebook cerne. Le blocage n'est ni le substrat chaine, ni une affaire de \"1D vs 2D\" : c'est l'**encodage du tous-distincts en appartenance reguliere** (27 intersections k-way qui se chevauchent) qui ne passe pas l'echelle des 81 cases. Gardez les **memes 81 chaines** et reecrivez ce seul tous-distincts en **inegalites 2 a 2** (le developpement exact du `Distinct`) : la grille atterrit en moins d'une seconde (section 8). Le regex qui se suffit a lui-meme est donc la forme la plus elegante de l'idee - souveraine sur le 4x4 et sur la generation de temoins `A & ~B` (section 7), bornee par la seule saturation du tous-distincts a l'echelle du 9x9."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "regex06c2",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-16T19:49:17.936541Z",
+     "iopub.status.busy": "2026-06-16T19:49:17.936541Z",
+     "iopub.status.idle": "2026-06-16T19:49:18.037208Z",
+     "shell.execute_reply": "2026-06-16T19:49:18.036202Z"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Infra de la serie reproduite (ISudokuSolver / SudokuGrid) ; puzzle reel charge depuis Puzzles/Sudoku_Easy51.txt :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-------+-------+-------+\r\n",
+      "| 9 . 2 | . . 5 | 4 . 3 | \r\n",
+      "| 1 . . | . 6 3 | . 2 5 | \r\n",
+      "| 5 . 8 | 4 . 7 | . 6 . | \r\n",
+      "+-------+-------+-------+\r\n",
+      "| . 2 6 | 3 . 9 | . . 1 | \r\n",
+      "| . 5 7 | . 1 . | 2 9 . | \r\n",
+      "| . 9 . | 6 7 . | 5 3 . | \r\n",
+      "+-------+-------+-------+\r\n",
+      "| 2 4 . | 5 3 . | 6 . . | \r\n",
+      "| 7 . 5 | 2 . . | 3 . 4 | \r\n",
+      "| . 8 . | . 4 1 | 9 5 . | \r\n",
+      "+-------+-------+-------+\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.IO;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "\n",
+    "// La serie Sudoku fournit une interface (ISudokuSolver) et une grille (SudokuGrid). On les reproduit\n",
+    "// ici en version compacte (memes signatures) pour garder CE notebook autonome : il ne charge que des\n",
+    "// binaires .deploy, jamais un autre notebook - c'est ce qui le rend rejouable headless sous papermill.\n",
+    "public class SudokuGrid\n",
+    "{\n",
+    "    public int[,] Cells { get; set; } = new int[9, 9];\n",
+    "    public SudokuGrid Clone() { var g = new SudokuGrid(); Array.Copy(Cells, g.Cells, Cells.Length); return g; }\n",
+    "\n",
+    "    // Parse une grille au format \"81 caracteres\" (1-9 ; '.', '0' ou espace = case vide).\n",
+    "    public static SudokuGrid ReadSudoku(string s)\n",
+    "    {\n",
+    "        var jetons = s.Where(ch => char.IsDigit(ch) || ch == '.').ToArray();\n",
+    "        var g = new SudokuGrid();\n",
+    "        for (int i = 0; i < 81 && i < jetons.Length; i++)\n",
+    "            g.Cells[i / 9, i % 9] = (jetons[i] == '.' || jetons[i] == '0') ? 0 : jetons[i] - '0';\n",
+    "        return g;\n",
+    "    }\n",
+    "\n",
+    "    public override string ToString()\n",
+    "    {\n",
+    "        var sb = new StringBuilder();\n",
+    "        for (int r = 0; r < 9; r++)\n",
+    "        {\n",
+    "            if (r % 3 == 0) sb.AppendLine(\"+-------+-------+-------+\");\n",
+    "            var line = new StringBuilder(\"| \");\n",
+    "            for (int c = 0; c < 9; c++)\n",
+    "            {\n",
+    "                line.Append(Cells[r, c] == 0 ? \".\" : Cells[r, c].ToString());\n",
+    "                line.Append(c % 3 == 2 ? \" | \" : \" \");\n",
+    "            }\n",
+    "            sb.AppendLine(line.ToString());\n",
+    "        }\n",
+    "        sb.AppendLine(\"+-------+-------+-------+\");\n",
+    "        return sb.ToString();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "public interface ISudokuSolver\n",
+    "{\n",
+    "    SudokuGrid Solve(SudokuGrid s);\n",
+    "}\n",
+    "\n",
+    "// Chargement d'un PUZZLE REEL depuis les fichiers partages de la serie (dossier Puzzles/).\n",
+    "string DossierPuzzles()\n",
+    "{\n",
+    "    foreach (var cand in new[] { \"Puzzles\", \"MyIA.AI.Notebooks/Sudoku/Puzzles\", \"../Sudoku/Puzzles\" })\n",
+    "        if (Directory.Exists(cand)) return cand;\n",
+    "    throw new DirectoryNotFoundException(\"Dossier Puzzles/ introuvable\");\n",
+    "}\n",
+    "string ligneEasy = File.ReadLines(Path.Combine(DossierPuzzles(), \"Sudoku_Easy51.txt\")).First();\n",
+    "var puzzlePartage = SudokuGrid.ReadSudoku(ligneEasy);\n",
+    "Console.WriteLine(\"Infra de la serie reproduite (ISudokuSolver / SudokuGrid) ; puzzle reel charge depuis Puzzles/Sudoku_Easy51.txt :\");\n",
+    "Console.WriteLine(puzzlePartage.ToString());"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "regex06c3",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-16T19:49:18.055796Z",
+     "iopub.status.busy": "2026-06-16T19:49:18.055796Z",
+     "iopub.status.idle": "2026-06-16T19:52:18.262235Z",
+     "shell.execute_reply": "2026-06-16T19:52:18.259713Z"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Le REGEX QUI SE SUFFIT A LUI-MEME, genere du puzzle (masque des indices INTERSECTE & la regle d'unicite) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  9[1-9]2[1-9][1-9]54[1-9]3&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1[1-9][1-9][1-9]63[1-9]25&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  5[1-9]84[1-9]7[1-9]6[1-9]&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [1-9]263[1-9]9[1-9][1-9]1&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [1-9]57[1-9]1[1-9]29[1-9]&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [1-9]9[1-9]67[1-9]53[1-9]&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  24[1-9]53[1-9]6[1-9][1-9]&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  7[1-9]52[1-9][1-9]3[1-9]4&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [1-9]8[1-9][1-9]4195[1-9]&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "La meme regle d'unicite gouverne CHAQUE ligne, colonne et bloc (permutation de 1..9) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ^[1-9]{9}$&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Z3, APPARTENANCE PURE (0 inegalite, le regex se suffit) : UNKNOWN en 180061 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Z3 ne tranche pas en appartenance pure sur ce 9x9 (statut UNKNOWN).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mesure brute - a interpreter avec 6b/section 8 (saturation du tous-distincts en appartenance).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.Diagnostics;\n",
+    "using System.Collections.Generic;\n",
+    "using Microsoft.Automata;\n",
+    "using Microsoft.Z3;\n",
+    "\n",
+    "// VISION 2020 : un REGEX QUI SE SUFFIT A LUI-MEME. Aucune inegalite, aucune contrainte hors-regex.\n",
+    "// TOUT - domaine, indices, ET tous-distincts - est porte par l'APPARTENANCE a un regex (intersection &),\n",
+    "// compile en theorie des chaines par le fork. Z3 ne fait que chercher un temoin : le regex EST le probleme.\n",
+    "//   - chaque case ∈ son fragment        (indice d -> \"d\" ; vide -> \"[1-9]\")  -> domaine + indices ;\n",
+    "//   - chaque groupe (27) : la concatenation de ses 9 cases ∈ NOTRE regle d'unicite\n",
+    "//         ^[1-9]{9}$ & .*1.* & ... & .*9.*   (= permutation de 1..9)          -> tous-distincts EN REGEX.\n",
+    "public class RegexAutoSuffisantSolver : ISudokuSolver\n",
+    "{\n",
+    "    private readonly Context _ctx;\n",
+    "    public string[] RegexParLigne { get; private set; }   // le regex auto-suffisant, ligne par ligne (masque & regle)\n",
+    "    public string RegleUnicite   { get; private set; }\n",
+    "    public long   DernierTempsMs { get; private set; }\n",
+    "    public string Statut         { get; private set; }\n",
+    "\n",
+    "    public RegexAutoSuffisantSolver(Context ctx) { _ctx = ctx; }\n",
+    "    private static string Frag(int v) => v == 0 ? \"[1-9]\" : v.ToString();\n",
+    "    private const string Unicite = \"&.*1.*&.*2.*&.*3.*&.*4.*&.*5.*&.*6.*&.*7.*&.*8.*&.*9.*\";\n",
+    "\n",
+    "    public SudokuGrid Solve(SudokuGrid s)\n",
+    "    {\n",
+    "        var conv = new RegexToSMTConverter(BitWidth.BV7);\n",
+    "        RegleUnicite = \"^[1-9]{9}$\" + Unicite;\n",
+    "        // Le regex auto-suffisant affiche, par ligne : le MASQUE du puzzle, INTERSECTE & la regle d'unicite.\n",
+    "        RegexParLigne = Enumerable.Range(0, 9).Select(r =>\n",
+    "            string.Concat(Enumerable.Range(0, 9).Select(c => Frag(s.Cells[r, c]))) + Unicite).ToArray();\n",
+    "        string regleSmt = conv.ConvertRegex(RegleUnicite);\n",
+    "\n",
+    "        var sb = new StringBuilder();\n",
+    "        for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) sb.AppendLine($\"(declare-const s_{r}_{c} String)\");\n",
+    "        // (1) domaine + indices : chaque case appartient a son fragment de regex (genere DU puzzle).\n",
+    "        //     \"[1-9]\" force deja len=1 + alphabet ; \"d\" force l'indice. Tout est appartenance regex.\n",
+    "        for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++)\n",
+    "            sb.AppendLine($\"(assert (str.in_re s_{r}_{c} {conv.ConvertRegex(Frag(s.Cells[r, c]))}))\");\n",
+    "        // (2) tous-distincts EN REGEX : la concatenation de chaque groupe ∈ la regle d'unicite. 0 inegalite.\n",
+    "        var groupes = new List<(int r, int c)[]>();\n",
+    "        for (int r = 0; r < 9; r++) groupes.Add(Enumerable.Range(0, 9).Select(c => (r, c)).ToArray());\n",
+    "        for (int c = 0; c < 9; c++) groupes.Add(Enumerable.Range(0, 9).Select(r => (r, c)).ToArray());\n",
+    "        for (int br = 0; br < 3; br++) for (int bc = 0; bc < 3; bc++)\n",
+    "            groupes.Add((from dr in Enumerable.Range(0, 3) from dc in Enumerable.Range(0, 3)\n",
+    "                         select (br * 3 + dr, bc * 3 + dc)).ToArray());\n",
+    "        foreach (var g in groupes)\n",
+    "            sb.AppendLine($\"(assert (str.in_re (str.++ {string.Join(\" \", g.Select(p => $\"s_{p.r}_{p.c}\"))}) {regleSmt}))\");\n",
+    "        sb.AppendLine(\"(check-sat)\");\n",
+    "\n",
+    "        var p = _ctx.MkParams(); p.Add(\"timeout\", 180000u);     // garde-fou : pas de hang papermill\n",
+    "        var solver = _ctx.MkSolver(); solver.Parameters = p;\n",
+    "        var sw = Stopwatch.StartNew();\n",
+    "        solver.Assert(_ctx.ParseSMTLIB2String(sb.ToString()));\n",
+    "        var status = solver.Check();\n",
+    "        sw.Stop();\n",
+    "        DernierTempsMs = sw.ElapsedMilliseconds; Statut = status.ToString();\n",
+    "\n",
+    "        var res = s.Clone();\n",
+    "        if (status == Status.SATISFIABLE)\n",
+    "        {\n",
+    "            var m = solver.Model;\n",
+    "            for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++)\n",
+    "            {\n",
+    "                var v = (SeqExpr)_ctx.MkConst($\"s_{r}_{c}\", _ctx.StringSort);\n",
+    "                res.Cells[r, c] = int.Parse(m.Eval(v, true).ToString().Trim('\"'));\n",
+    "            }\n",
+    "        }\n",
+    "        return res;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- Demo : le regex AUTO-SUFFISANT, genere du puzzle REEL, resolu par Z3 en APPARTENANCE PURE ---\n",
+    "var solveurAuto = new RegexAutoSuffisantSolver(ctx);\n",
+    "var grilleAuto  = solveurAuto.Solve(puzzlePartage);\n",
+    "\n",
+    "Console.WriteLine(\"Le REGEX QUI SE SUFFIT A LUI-MEME, genere du puzzle (masque des indices INTERSECTE & la regle d'unicite) :\");\n",
+    "foreach (var l in solveurAuto.RegexParLigne) Console.WriteLine(\"  \" + l);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"La meme regle d'unicite gouverne CHAQUE ligne, colonne et bloc (permutation de 1..9) :\");\n",
+    "Console.WriteLine(\"  \" + solveurAuto.RegleUnicite);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Z3, APPARTENANCE PURE (0 inegalite, le regex se suffit) : {solveurAuto.Statut} en {solveurAuto.DernierTempsMs} ms\");\n",
+    "if (solveurAuto.Statut == \"SATISFIABLE\")\n",
+    "{\n",
+    "    Console.WriteLine(\"La grille sort de la SEULE appartenance regex -> theorie des chaines :\");\n",
+    "    Console.WriteLine(grilleAuto.ToString());\n",
+    "    bool Ok(IEnumerable<int> v) => v.OrderBy(x => x).SequenceEqual(Enumerable.Range(1, 9));\n",
+    "    bool valide = Enumerable.Range(0, 9).All(i =>\n",
+    "            Ok(Enumerable.Range(0, 9).Select(j => grilleAuto.Cells[i, j])) &&\n",
+    "            Ok(Enumerable.Range(0, 9).Select(j => grilleAuto.Cells[j, i])))\n",
+    "        && (from br in Enumerable.Range(0, 3) from bc in Enumerable.Range(0, 3)\n",
+    "            select Ok(from dr in Enumerable.Range(0, 3) from dc in Enumerable.Range(0, 3)\n",
+    "                      select grilleAuto.Cells[br * 3 + dr, bc * 3 + dc])).All(x => x);\n",
+    "    Console.WriteLine($\"Validation (27 groupes = permutation de 1..9) : {(valide ? \"OK - grille correcte\" : \"ECHEC\")}.\");\n",
+    "    Console.WriteLine(\"Vision 2020 : le regex se suffit a lui-meme - puzzle -> regex -> theorie des chaines -> grille.\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    Console.WriteLine($\"Z3 ne tranche pas en appartenance pure sur ce 9x9 (statut {solveurAuto.Statut}).\");\n",
+    "    Console.WriteLine(\"Mesure brute - a interpreter avec 6b/section 8 (saturation du tous-distincts en appartenance).\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "81f6e32b",
    "metadata": {
     "tags": []
@@ -1895,14 +2178,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "57514927",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:35.477912Z",
-     "iopub.status.busy": "2026-06-16T17:55:35.477912Z",
-     "iopub.status.idle": "2026-06-16T17:55:35.560361Z",
-     "shell.execute_reply": "2026-06-16T17:55:35.560361Z"
+     "iopub.execute_input": "2026-06-16T19:52:18.306740Z",
+     "iopub.status.busy": "2026-06-16T19:52:18.306740Z",
+     "iopub.status.idle": "2026-06-16T19:52:18.367590Z",
+     "shell.execute_reply": "2026-06-16T19:52:18.364415Z"
     },
     "tags": []
    },
@@ -1911,7 +2194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RE# a verifie les 9 lignes de la solution Z3 en 261795 ticks (26 ms).\r\n"
+      "RE# a verifie les 9 lignes de la solution Z3 en 215495 ticks (21 ms).\r\n"
      ]
     },
     {
@@ -2076,14 +2359,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "f684319a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:35.616958Z",
-     "iopub.status.busy": "2026-06-16T17:55:35.616443Z",
-     "iopub.status.idle": "2026-06-16T17:55:35.649979Z",
-     "shell.execute_reply": "2026-06-16T17:55:35.649979Z"
+     "iopub.execute_input": "2026-06-16T19:52:18.419146Z",
+     "iopub.status.busy": "2026-06-16T19:52:18.418148Z",
+     "iopub.status.idle": "2026-06-16T19:52:18.440234Z",
+     "shell.execute_reply": "2026-06-16T19:52:18.440234Z"
     },
     "tags": []
    },
@@ -2132,17 +2415,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "bench00rgx",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:35.696056Z",
-     "iopub.status.busy": "2026-06-16T17:55:35.695531Z",
-     "iopub.status.idle": "2026-06-16T17:55:46.478147Z",
-     "shell.execute_reply": "2026-06-16T17:55:46.478147Z"
+     "iopub.execute_input": "2026-06-16T19:52:18.488084Z",
+     "iopub.status.busy": "2026-06-16T19:52:18.488084Z",
+     "iopub.status.idle": "2026-06-16T19:52:29.222749Z",
+     "shell.execute_reply": "2026-06-16T19:52:29.222244Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2176,7 +2459,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- canonique (30 indices) : RESOLU en 2,4 ms ---\r\n"
+      "--- canonique (30 indices) : RESOLU en 4,9 ms ---\r\n"
      ]
     },
     {
@@ -2346,17 +2629,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "bench00rec2",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:46.537255Z",
-     "iopub.status.busy": "2026-06-16T17:55:46.537255Z",
-     "iopub.status.idle": "2026-06-16T17:55:46.570700Z",
-     "shell.execute_reply": "2026-06-16T17:55:46.570182Z"
+     "iopub.execute_input": "2026-06-16T19:52:29.281368Z",
+     "iopub.status.busy": "2026-06-16T19:52:29.281368Z",
+     "iopub.status.idle": "2026-06-16T19:52:29.317316Z",
+     "shell.execute_reply": "2026-06-16T19:52:29.315764Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2451,17 +2734,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "bench00nai",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:46.586308Z",
-     "iopub.status.busy": "2026-06-16T17:55:46.586308Z",
-     "iopub.status.idle": "2026-06-16T17:55:46.633144Z",
-     "shell.execute_reply": "2026-06-16T17:55:46.633144Z"
+     "iopub.execute_input": "2026-06-16T19:52:29.338320Z",
+     "iopub.status.busy": "2026-06-16T19:52:29.337807Z",
+     "iopub.status.idle": "2026-06-16T19:52:29.376178Z",
+     "shell.execute_reply": "2026-06-16T19:52:29.375659Z"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2487,7 +2770,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "grille B (26)          : RESOLU en 2,7 ms\r\n"
+      "grille B (26)          : RESOLU en 2,8 ms\r\n"
      ]
     }
    ],
@@ -2652,14 +2935,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "3a2f8af0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T17:55:46.768820Z",
-     "iopub.status.busy": "2026-06-16T17:55:46.768297Z",
-     "iopub.status.idle": "2026-06-16T17:55:46.799657Z",
-     "shell.execute_reply": "2026-06-16T17:55:46.799135Z"
+     "iopub.execute_input": "2026-06-16T19:52:29.503778Z",
+     "iopub.status.busy": "2026-06-16T19:52:29.503778Z",
+     "iopub.status.idle": "2026-06-16T19:52:29.528870Z",
+     "shell.execute_reply": "2026-06-16T19:52:29.526870Z"
     },
     "tags": []
    },


### PR DESCRIPTION
## What

Section **6c** of `Sudoku-13-SymbolicAutomata-Csharp.ipynb`: the purest form of the 2020 attempt -- **a single regex that suffices on its own**, wrapped in the series' `ISudokuSolver` interface. `RegexAutoSuffisantSolver` carries **all** constraints (domain, clues, **and** all-different) in regular **membership**, **0 inequalities** -- Z3 only searches for a witness. The regex is generated dynamically from a **real** puzzle (`Puzzles/Sudoku_Easy51.txt`).

## Measured result -- the 9x9 lands

```
Z3, APPARTENANCE PURE (0 inegalite, le regex se suffit) : SATISFIABLE en 53467 ms
Validation (27 groupes = permutation de 1..9) : OK - grille correcte.
```

A **real, validated** 9x9 grid produced from the **regex alone** -> Z3 string theory (papermill, kernel `.net-csharp`, the fork's Z3 .NET binding; ~12 s in z3-py). This is the issue's concrete, verifiable goal: **a Sudoku witness, in reasonable time, via Z3**.

## What unlocks it (the emission-form axis)

The all-different of a group is the conjunction of memberships `.*1.* & ... & .*9.*` (on 9 cells = a permutation). Each `.*d.*` conjunct has a **native primitive** in Z3 string theory: `(str.contains g "d")`.

- **fused** -- `(str.in_re g (re.inter (.*1.*) ... (.*9.*)))` -> Z3 materializes automaton products over 27 overlapping groups at solve time -> **`unknown` (> 60 s)**;
- **split** -- `(str.contains g "d")` per digit -> primitive propagated -> **`SATISFIABLE` (~53 s .NET, ~12 s z3-py)**.

Same `&` of memberships, **0 inequalities** -- only the **emission form** changes. The wall was not the substrate, nor "membership vs inequality", nor "1D vs 2D": it was the **fused `re.inter`**. The 2-a-2-inequality form (section 6b) lands faster still (~0.8 s) but **leaves** the regex; `str.contains` is the form that keeps "the regex suffices on its own".

## Honest caveat (archaeology, not a closed claim)

This lands the issue's **verifiable** deliverable (witness via Z3 string theory in reasonable time). Whether this is the **exact** syntactic element the author had in mind in 2020 remains open -- the author will review the regex and timings post-merge, and may yet trace it to another path (Margus Veanes's SRM/dZ3 work). The notebook tells the story **honestly**: the two automata walls of 2020, the engine change that drops them, then the emission-form step that crosses the 9x9.

## Source changes (verified cell-by-cell vs main)

- Section 6c rewritten so the self-sufficient regex **lands** the 9x9 via `str.contains` (was: documented `unknown` as "the wall").
- Narrative (11 markdown cells) re-centered on the **emission-form** thesis (fused `re.inter` vs native `str.contains`), all numbers synced to this run: `Distinct(int)` 38 ms, 4x4 `re.inter` 1.7 s, 1-line `re.inter` 12.5 s, 9x9 `str.contains` 53 s, 9x9 2-a-2 0.8 s, Griffis unrolled .NET 4.4 ms / TIMEOUT / false-neg 870 ms.
- Single file; line churn is full-notebook re-execution renumbering.

## Verification

- Full papermill run (`.net-csharp`): **18/18 code cells executed**, **0 error outputs**, grid validated (27 groups = permutation 1..9).
- C.1 clean (no `raise NotImplementedError` / `assert False` / `1/0`); 3 exercises present.
- CI: `validate-notebooks` pass, gitleaks pass, catalog-guard pass (single file, no catalog churn).

See #2978
