### PR TITLE
docs(readme): harmonize PyMC + Argumentum to #2651 gabarit (Partie 2)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -1,8 +1,8 @@
 # Programmation Probabiliste avec PyMC
 
-Port Python de la série Infer.NET — **20 notebooks** couvrant l'inference bayesienne avec PyMC (NUTS, echantillonnage MCMC), des fondamentaux aux modèles relationnels avances, incluant une section complète sur la théorie de la décision.
+[← Série Probas](../README.md) | [Infer.NET (C#) →](../Infer/README.md)
 
-**20 notebooks** | Python 3.10+ | PyMC 5.x | ~19h
+Port Python de la série Infer.NET couvrant l'inference bayesienne avec PyMC (NUTS, echantillonnage MCMC), des fondamentaux aux modèles relationnels avances, incluant une section complète sur la théorie de la décision.
 
 **A qui s'adresse cette série** : praticiens Python, data scientists et étudiants souhaitant maitriser l'inference bayesienne moderne avec l'ecosysteme PyMC/ArviZ. Aucun prérequis en C# ou Infer.NET : chaque notebook est autonome.
 
@@ -56,8 +56,6 @@ A l'issue de cette série, vous serez capable de :
 | 18 | [PyMC-18-Decision-Value-Information](PyMC-18-Decision-Value-Information.ipynb) | 45 min | EVPI, EVSI, valeur de l'information |
 | 19 | [PyMC-19-Decision-Expert-Systems](PyMC-19-Decision-Expert-Systems.ipynb) | 50 min | Systèmes experts, Minimax, regret |
 | 20 | [PyMC-20-Decision-Sequential](PyMC-20-Decision-Sequential.ipynb) | 60 min | MDPs, bandits, POMDPs |
-
-**Duree totale** : ~19h
 
 ## Progression Pédagogique
 
@@ -153,6 +151,15 @@ Alterner chaque notebook PyMC avec son équivalent [Infer.NET](../Infer/).Compar
 
 ## FAQ / Troubleshooting
 
+### `ModuleNotFoundError: pymc`
+
+PyMC n'est pas present dans le kernel Jupyter actif. Installer les dependances puis verifier le kernel :
+
+```bash
+pip install pymc arviz
+jupyter kernelspec list  # doit afficher pymc-env
+```
+
 ### PyMC ne s'installe pas sur Windows (compilateur C manquant)
 
 PyMC 5.x requiert un compilateur C pour les extensions natives. Solution :
@@ -171,6 +178,7 @@ conda install -c conda-forge pymc
 - Verifier les priors : des priors trop larges causent des explorations inutiles
 - Augmenter `target_accept` : `pm.sample(target_accept=0.95)` (defaut 0.8)
 - Utiliser `init="advi"` pour une initialisation plus robuste
+- Reduire `draws` et `tune` (ex. 500/500 au lieu de 1000/1000) si la compilation C (PyTensor) est disponible mais le temps de calcul reste prohibitif
 - Consulter [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) pour les diagnostics complets
 
 ### ArviZ affiche des divergences
@@ -179,7 +187,7 @@ Les divergences indiquent que l'echantillonneur n'a pas explore correctement cer
 
 1. `az.plot_trace(trace)` -> verifier le melange des chaînes
 2. `az.summary(trace)` -> verifier que `r_hat < 1.05` et `ess_bulk > 400`
-3. Reparametriser le modèle (centrage, log-transform)
+3. Reparametriser le modèle (centrage, log-transform ; parametrisation centered vs non-centered — voir [PyMC-2-Gaussian-Mixtures](PyMC-2-Gaussian-Mixtures.ipynb) et [PyMC-13-Debugging](PyMC-13-Debugging.ipynb))
 4. Augmenter le nombre de tirages : `pm.sample(draws=4000, tune=2000)`
 
 ### Erreur "SamplingError: Initial evaluation of model failed"
@@ -219,20 +227,6 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 - [Bayesian Methods for Hackers](https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers)
 - [Statistical Rethinking (McElreath)](https://xcelab.net/rm/statistical-rethinking/) — livre de référence pour l'inference bayesienne appliquee
 
----
-
-[Retour au README Probas](../README.md)
-
-## FAQ rapide
-
-| Problème | Solution |
-|----------|----------|
-| `ModuleNotFoundError: pymc` | `pip install pymc arviz` -- PyMC 5.x et ArviZ pour les diagnostics |
-| Echantillonnage très lent (>5 min par modèle) | Verifier qu'un compilateur C est disponible (PyMC utilise PyTensor avec compilation C). Sinon, reduire `draws` et `tune` (ex: 500/500 au lieu de 1000/1000) |
-| Convergence non atteinte (R-hat > 1.05) | Augmenter le nombre de `tune` steps. Le notebook 13 (Debugging) detaille les strategies de diagnostic |
-| Divergences dans l'echantillonnage | Re-parametrer le modèle (centered vs non-centered). Voir notebook 2 (Gaussian Mixtures) et 13 (Debugging) |
-| `SamplingError: Initial evaluation failed` | Les priors sont incompatibles avec les observations. Verifier les distributions a priori et les valeurs initiales |
-
 ## Ponts inter-séries
 
 | Série | Lien | Relation |
@@ -241,7 +235,3 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML](../../ML/) | Pipeline ML classique | PyMC comme alternative bayesienne |
 | [QuantConnect](../../QuantConnect/) | Strategies de trading | Modèles bayesiens appliques au trading |
-
-## Navigation
-
-[<- Retour a la série Probas](../README.md) \| [Infer.NET (C#) ->](../Infer/README.md)

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -7,6 +7,8 @@ breakdown: Argument_Analysis=11
 maturity: PRODUCTION=10, ALPHA=1
 -->
 
+[← Intelligence Symbolique](../README.md)
+
 Pipeline complet d'analyse argumentative combinant Semantic Kernel, TweetyProject et programmation logique pour l'identification et l'évaluation d'arguments dans des textes.
 
 ## Pourquoi cette série
@@ -19,11 +21,20 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 
 **À qui s'adresse cette série** : enseignants en pensée critique, équipes éditoriales construisant des outils de fact-checking, étudiants en philosophie computationnelle ou en linguistique formelle, et ingénieurs explorant les architectures hybrides LLM + solveur. La maîtrise préalable supposée est modérée : Python intermediate, intuition logique propositionnelle, familiarité minimale avec les LLMs et l'OpenAI API. Les notebooks (~4-5h total) s'enchaînent dans l'ordre 0 → 1 → 2 → 3, avec l'`Executor` comme point d'entrée pour une exécution batch reproductible (Papermill / MCP).
 
+## Objectifs d'apprentissage
+
+À l'issue de cette série, vous serez capable de :
+
+1. **Extraire le tissu argumentatif** d'un texte en identifiant prémisses, conclusions et transitions à l'aide d'un agent LLM (Semantic Kernel)
+2. **Formaliser des arguments** en logique propositionnelle et vérifier leur cohérence avec un solveur SAT (TweetyProject)
+3. **Détecter les sophismes** courants (homme de paille, faux dilemme, ad hominem, appel à l'autorité) de manière systématique
+4. **Orchestrer un pipeline multi-agents** combinant extraction informelle, formalisation logique et validation formelle
+5. **Comparer les approches** LLM-only vs hybride (LLM + solveur formel) et comprendre les limites de chaque couche
+
 ## Vue d'ensemble
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 6 |
 | Kernel | Python 3 |
 | Durée estimée | ~4-5h |
 | API requise | OpenAI |
@@ -43,16 +54,6 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 | 4 | [Agentic-4-capstone](Argument_Analysis_Agentic-4-capstone.ipynb) | Capstone : baseline 0-shot vs pipeline intégral, verdicts convergents + value-gates VG-1..VG-4 | Intégration |
 | UI | [UI_configuration](Argument_Analysis_UI_configuration.ipynb) | Interface utilisateur widgets | Interaction |
 | Exec | [Executor](Argument_Analysis_Executor.ipynb) | Orchestrateur principal | Exécution |
-
-## Objectifs d'apprentissage
-
-À l'issue de cette série, vous serez capable de :
-
-1. **Extraire le tissu argumentatif** d'un texte en identifiant prémisses, conclusions et transitions à l'aide d'un agent LLM (Semantic Kernel)
-2. **Formaliser des arguments** en logique propositionnelle et vérifier leur cohérence avec un solveur SAT (TweetyProject)
-3. **Détecter les sophismes** courants (homme de paille, faux dilemme, ad hominem, appel à l'autorité) de manière systématique
-4. **Orchestrer un pipeline multi-agents** combinant extraction informelle, formalisation logique et validation formelle
-5. **Comparer les approches** LLM-only vs hybride (LLM + solveur formel) et comprendre les limites de chaque couche
 
 ## Ce que chaque notebook apporte
 
@@ -243,7 +244,7 @@ Le pipeline génère un rapport JSON dans `output/analysis_report.json` :
 
 [La mer qui monte](../../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du dépôt — l'analyse d'argumentation comme changement de représentation vers le vérifiable : du langage naturel aux sémantiques formelles qu'on peut interroger.
 
-> **Note** : Le pipeline est exécutable de bout en bout. L'`Executor` (point d'entrée Papermill/MCP) a été re-exécuté avec succès le 2026-06-16 : validation `COMPLETE_VALIDATED` à 100 % (1 argument identifié, 4 sophismes, 1 belief set formel, 10 requêtes au solveur). Voir [RECONSTRUCTION_PLAN.md](RECONSTRUCTION_PLAN.md) pour le diagnostic des bugs structurels résolus (résolution de chemin robuste, fuite de `os.chdir` hors du `%run`, chaîne `%run` cohérente).
+> **Note** : Le pipeline s'exécute de bout en bout. L'`Executor` (point d'entrée Papermill/MCP) produit une validation `COMPLETE_VALIDATED` à 100 % (1 argument identifié, 4 sophismes, 1 belief set formel, 10 requêtes au solveur).
 
 ## Ressources
 


### PR DESCRIPTION
Harmonize 2 sub-series READMEs onto `docs/reference/readme-series-gabarit.md` (Partie 2 of #2651, gabarit stabilized by merged #2800). One coherent subject: gabarit alignment of 2 niveau-2 sous-series in the po-2025 partition (Argumentum/Probas).

## PyMC/README.md
- **Nav to top** (anti-pattern 5): barre `[← Série Probas] | [Infer.NET (C#) →]` déplacée sous le titre (était en pied uniquement). Pied et back-link mid-file redondants supprimés.
- **No opening count banner** (anti-pattern 1): bandeau `**20 notebooks** | Python 3.10+ | PyMC 5.x | ~19h` et `**Duree totale** : ~19h` retirés (les décomptes vivent dans le catalogue généré).
- **FAQ dédupliquée** (anti-pattern 4): la table `## FAQ rapide` doublonnait la `## FAQ / Troubleshooting` détaillée. Les 2 astuces uniques (réduire `draws`/`tune` 500/500 ; re-paramétrisation centered/non-centered → notebooks 2 et 13) et le cas `ModuleNotFoundError: pymc` sont **fusionnés** dans la FAQ détaillée avant suppression de la table. Aucune perte d information.

## Argumentum/README.md
- **Nav ajoutée** (anti-pattern 5): `[← Intelligence Symbolique](../README.md)` sous le titre (était absente).
- **Objectifs avant la table** (ordre gabarit §4 → §5): le bloc `## Objectifs d apprentissage` déplacé avant `## Vue d ensemble` / table des notebooks.
- **Compte corrigé**: `| Notebooks | 6 |` retiré (la table liste 11 entrées, `CATALOG-STATUS` compte `pedagogical_count: 11` — la valeur 6 était stale ; le compte appartient au marqueur bot-owned).
- **De-leak** (règle de rédaction gabarit, pas de vocabulaire de conventions internes): la `> **Note**` d exécution ne fuite plus le détail dev interne (`RECONSTRUCTION_PLAN.md`, bugs structurels résolus) ni la date. Conservé: le fait utile pour le lecteur (pipeline exécutable end-to-end, validation `COMPLETE_VALIDATED` 100 %).

## Vérifications
- Diff: 2 fichiers, +26/-35 (61 lignes de churn — > seuil §E 50).
- **Aucune régénération du catalogue** sur la branche (règle catalog-hygiène HARD).
- Aucun secret, aucun `.en.md` touché.
- Aucune perte de contenu pédagogique (la déduplication fusionne l information avant de supprimer).

## À signaler (règle dure CATALOG-STATUS)
`Probas/PyMC/README.md` n a pas de marqueur `CATALOG-STATUS` (cas listé par le gabarit ligne 80). Ce marqueur est **bot-owned** : son ajout passe par le cycle cron catalog-drift, pas par cette PR.

See #2651 (Partie 2 — l Epic reste OUVERT : reste Infer/README 1069L rééquilibration + Probas/README parent + autres familles workers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)