### PR TITLE
docs(search): academic References sections — Part1/Part2/Part4 sub-series (#2651 Partie 2)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -68,6 +68,19 @@ Pour le setup complet, voir le [README de la série Search](../README.md).
 
 Cette partie irrigue le reste du dépôt : les Dancing Links de Search-8 sont à l'œuvre dans la série [Sudoku](../../Sudoku/README.md), Minimax et MCTS (Search-6/7) se prolongent dans [GameTheory](../../GameTheory/README.md) avec OpenSpiel puis dans [RL](../../RL/README.md) côté politiques apprises, et les prédicats Z3 de Search-10 ouvrent sur [SymbolicAI](../../SymbolicAI/README.md).
 
+## Références
+
+Couverture par notebook des sources fondatrices mobilisées dans cette partie :
+
+| Notebook(s) | Référence |
+|-------------|-----------|
+| Search-1 à 7, 9 | Russell, S., & Norvig, P. — *Artificial Intelligence: A Modern Approach* (4e éd., 2021). La référence pour la formalisation en espace d'états, les algorithmes informés/non informés et la recherche dans les jeux. |
+| Search-3 (Informed) | Hart, P. E., Nilsson, N. J., & Raphael, B. (1968) — « A Formal Basis for the Heuristic Determination of Minimum Cost Paths », *IEEE Trans. on Systems Science and Cybernetics* 4(2). L'article fondateur d'A*. |
+| Search-5 (GeneticAlgorithms) | Holland, J. H. (1975) — *Adaptation in Natural and Artificial Systems*. University of Michigan Press. Origine des algorithmes génétiques. |
+| Search-7 (MCTS) | Browne, C. B., Powley, E., et al. (2012) — « A Survey of Monte Carlo Tree Search Methods », *IEEE Trans. on Computational Intelligence and AI in Games* 4(1). |
+| Search-8 (DancingLinks) | Knuth, D. E. (2000) — « Dancing Links », dans *Millennial Perspectives in Computer Science* (Springer). |
+| Search-11 (Metaheuristics) | Kennedy, J., & Eberhart, R. (1995) — « Particle Swarm Optimization », *Proc. IEEE Int. Conf. on Neural Networks*. Origine du PSO. |
+
 ## FAQ
 
 | Problème | Solution |

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
@@ -111,6 +111,18 @@ CSP-1 (Fundamentals) ──> CSP-2 (Consistency) ──> CSP-3 (Advanced)
 | [SymbolicAI/SMT/Z3](../../SymbolicAI/SMT/Z3/README.md) | Solveur SMT | CSP-6 (LCG) et automates symboliques |
 | [Probas/Infer](../../Probas/Infer/) | Infer.NET | Modèles graphiques et contraintes |
 
+## Références
+
+Couverture par notebook des sources fondatrices de la programmation par contraintes :
+
+| Notebook(s) | Référence |
+|-------------|-----------|
+| CSP-1 à 6 | Tsang, E. (1993) — *Foundations of Constraint Satisfaction*. Academic Press. La référence classique sur le modèle CSP et les algorithmes de résolution. |
+| CSP-1, CSP-2 | Russell, S., & Norvig, P. — *Artificial Intelligence: A Modern Approach* (4e éd., 2021), ch. « Constraint Satisfaction Problems ». Formalisation (X, D, C) et backtracking avec MRV/LCV. |
+| CSP-2 (Consistency) | Mackworth, A. K. (1977) — « Consistency in Networks of Relations », *Artificial Intelligence* 8(1). Origine de l'arc-consistency (AC-3). |
+| CSP-3 (Advanced) | Régin, J.-C. (1994) — « A filtering algorithm for constraints of difference in CSPs », *AAAI-94*. Le propagateur global AllDifferent. |
+| CSP-6 (Hybridization) | Ohrimenko, I., Stuckey, P. J., & Codish, M. (2009) — « Propagation via Lazy Clause Generation », *Constraints* 14(3). Origine de la Lazy Clause Generation. |
+
 ## Navigation
 
 [<- Partie 1 : Search Fondamental](../Part1-Foundations/README.md) | [Retour à la série Search](../README.md) | [Applications ->](../Applications/README.md)

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
@@ -76,6 +76,18 @@ Les notebooks chargent les DLL via `#r "c:/dev/MetaGeneticSharp/..."` (chemin du
 
 Le code de la bibliothèque vit dans le **fork** [jsboige/MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp), monté ici comme sous-module (`MyIA.AI.Notebooks/Search/MetaGeneticSharp/`). Les notebooks pédagogiques (`MetaGeneticSharp-Notebooks/`) sont propriété du dépôt CoursIA et consomment la bibliothèque via ses DLLs buildées. Ce point d'entrée ferme la boucle : depuis la série Search Python (Parties 1-2), on bascule vers le side track C#, qui redirige à son tour vers le fork pour le code source complet, les tests et la feuille de route.
 
+## Références
+
+Les métaheuristiques reconstruites dans cette partie suivent les articles fondateurs. Les liens bibliothèque (GeneticSharp, fork MGS) sont regroupés dans la section « Liens » ci-dessous.
+
+| Notebook(s) | Métaheuristique | Référence |
+|-------------|-----------------|-----------|
+| MGS-1 (Introduction) | Algorithme génétique | Holland, J. H. (1975) — *Adaptation in Natural and Artificial Systems*. University of Michigan Press. |
+| MGS-5 (Benchmarks) | Whale Optimization Algorithm | Mirjalili, S., & Lewis, A. (2016) — « The Whale Optimization Algorithm », *Advances in Engineering Software* 95. |
+| MGS-8 (EverestRelief) | Equilibrium Optimizer | Faramarzi, A., Heidarinejad, M., Stephens, B., & Mirjalili, S. (2020) — « Equilibrium optimizer: A novel optimization algorithm », *Knowledge-Based Systems* 197. |
+| MGS-8 (EverestRelief) | Particle Swarm Optimization (baseline) | Kennedy, J., & Eberhart, R. (1995) — « Particle Swarm Optimization », *Proc. IEEE Int. Conf. on Neural Networks*. |
+| MGS-5, MGS-6 | No-Free-Lunch | Wolpert, D. H., & Macready, W. G. (1997) — « No free lunch theorems for optimization », *IEEE Trans. on Evolutionary Computation* 1(1). |
+
 ## Liens
 
 - [Fork jsboige/MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) — code source, tests, ROADMAP


### PR DESCRIPTION
## Summary

Per the [README series gabarit](../blob/main/docs/reference/readme-series-gabarit.md) (#2651 Partie 2, section 10 « References »), the three foundational **Search** sub-series lacked a `## Références` section. This PR adds one to each, following the gabarit's "coverage per notebook" format: each seminal academic source is mapped to the actual notebook(s) it underpins.

## Changes (3 files, docs-only, pure additive)

**`Search/Part1-Foundations/README.md`** — 6 references:
- AIMA (Russell & Norvig) → Search-1..7,9
- A\* (Hart, Nilsson & Raphael, 1968) → Search-3
- Genetic Algorithms (Holland, 1975) → Search-5
- MCTS survey (Browne et al., 2012) → Search-7
- Dancing Links (Knuth, 2000) → Search-8
- PSO (Kennedy & Eberhart, 1995) → Search-11

**`Search/Part2-CSP/README.md`** — 5 references:
- CSP foundations (Tsang, 1993) → CSP-1..6
- AIMA, CSP chapter → CSP-1/2
- Arc-consistency / AC-3 (Mackworth, 1977) → CSP-2
- AllDifferent filtering (Régin, 1994) → CSP-3
- Lazy Clause Generation (Ohrimenko, Stuckey & Codish, 2009) → CSP-6

**`Search/Part4-Metaheuristics/README.md`** — 5 references:
- GA (Holland, 1975) → MGS-1
- Whale Optimization (Mirjalili & Lewis, 2016) → MGS-5
- Equilibrium Optimizer (Faramarzi et al., 2020) → MGS-8
- PSO baseline (Kennedy & Eberhart, 1995) → MGS-8
- No-Free-Lunch (Wolpert & Macready, 1997) → MGS-5, MGS-6

## Guardrails

- **Conservative citations only.** Every reference is a seminal, widely-attested source (textbook or foundational paper). No speculative citations.
- **Anti-regression:** 37 insertions, 0 deletions — pure additive, no existing content altered.
- **Catalogue + submodule byte-identical to `main`** (verified pre-commit) — no `COURSE_CATALOG.generated.*` churn, MGS submodule unchanged at `4d1318d`.
- **Gabarit compliance:** References section follows the canonical placement (before FAQ / closing Navigation) and the "coverage per notebook" table format.

## Partition note

Search series = po-2024 (.NET / non-Lean) partition. No overlap with Lean (po-2026), GenAI (po-2023), Probas/Argumentum (po-2025).

See #2651