### PR TITLE
feat(secrets): centralize shared secrets in .secrets/master.env + render/sync tool

### DIFF
--- a/.claude/rules/secrets-hygiene.md
+++ b/.claude/rules/secrets-hygiene.md
@@ -22,7 +22,18 @@ S'applique a **tous les agents** ecrivant du code dans le repo.
 
 Detail (incident, fix structurel, regex de detection, postmortem template) : [docs/secrets-and-coord-detail.md](../../docs/reference/secrets-and-coord-detail.md#1-secrets-hygiene--content-based-pas-path-based).
 
+## Centralisation — `.secrets/master.env` (source unique)
+
+Les secrets **partages** (HF, OpenAI, Anthropic, Civitai, API keys par service, tokens ComfyUI) vivent dans **`.secrets/master.env`** (gitignored). Le script [`scripts/secrets/render_envs.py`](../../scripts/secrets/render_envs.py) propage ces valeurs vers chaque `.env` consommateur ; la CONFIG service-spécifique (ports, paths, GPU) reste dans chaque `.env`.
+
+- **Rotater un secret** = éditer `master.env` + `python scripts/secrets/render_envs.py` + `docker compose restart` (OBLIGATOIRE pour ComfyUI-Login : le hash bcrypt n'est régénéré depuis l'env qu'au restart, pas à chaud — source du "drift" qui a fait croire à tort à une clé perdue en juin 2026).
+- **Audit drift** = `python scripts/secrets/render_envs.py --check` (exit 1 si un `.env` diffère de master).
+- Les mots de passe **par instance** (un par ComfyUI/Forge/Whisper) ne sont PAS centralisés — ils restent dans leur `.env` service.
+
+Detail complet (inventaire, rotation, règle restart, incident fondateur) : [docs/genai/secrets-management.md](../../docs/genai/secrets-management.md).
+
 ## Voir aussi
 
 - [.claude/rules/git-workflow.md](git-workflow.md) — no direct main push
 - [docs/env-python-reparation.md](../../docs/reference/env-python-reparation.md) — env discipline (regle F)
+- [docs/genai/secrets-management.md](../../docs/genai/secrets-management.md) — centralisation master.env + render

--- a/docker-configurations/services/comfyui-video/entrypoint.sh
+++ b/docker-configurations/services/comfyui-video/entrypoint.sh
@@ -67,7 +67,14 @@ if password:
     hashed = bcrypt.hashpw(password, salt)
     with open(password_path, 'wb') as f:
         f.write(hashed + b'\n' + username.encode('utf-8'))
-    print(f'Utilisateur {username} configure')
+    # Self-check : confirme que le .env (env au startup) verifie le hash ecrit.
+    # Previent le 'drift' (container au hash perime si .env change sans restart).
+    with open(password_path, 'rb') as f:
+        stored = f.read().split(b'\n')[0]
+    if bcrypt.checkpw(password, stored):
+        print(f'AUTH OK: utilisateur {username} configure, hash verifie contre COMFYUI_PASSWORD')
+    else:
+        print('AUTH WARNING: le hash ecrit ne verifie pas COMFYUI_PASSWORD (propagation env defectueuse ?)')
 else:
     print('Aucun mot de passe configure, authentification desactivee')
 "

--- a/docs/genai/secrets-management.md
+++ b/docs/genai/secrets-management.md
@@ -1,0 +1,97 @@
+# Secrets management — central source of truth
+
+**Objectif :** une gestion propre et durable de TOUS les secrets de l'infrastructure GenAI / CoursIA, pour que le drift (un secret édité à un endroit mais pas ailleurs) soit mécaniquement impossible.
+
+## Architecture — `.secrets/master.env` + render
+
+```
+.secrets/master.env                    <- SOURCE UNIQUE (éditer ici)
+   HF_TOKEN, OPENAI_API_KEY, COMFYUI_VIDEO_TOKEN, ... (18 clés partagées)
+
+scripts/secrets/render_envs.py
+   --bootstrap   one-shot : lit les .env éparpillés, écrit master.env
+   (défaut)      sync     : propage master.env -> chaque .env (15 cibles)
+   --check       gate     : exit 1 si un .env drift de master (audit local)
+
+docker-configurations/services/*/.env  <- CONFIG service (ports, paths, GPU)
+MyIA.AI.Notebooks/GenAI/.env           <- CONFIG notebooks + secrets synchronisés
+```
+
+**Principe :** `master.env` ne contient que les secrets **partagés** (un consommateur ≠, une valeur commune). La CONFIG service-spécifique (ports, chemins, GPU ids, noms de modèles, `TZ`) reste dans chaque `.env` et n'est **jamais** touchée par le render. Les mots de passe **par instance** (chaque ComfyUI / Forge a le sien) ne sont PAS centralisés — voir §"Secrets par instance".
+
+## Rotation d'un secret (procédure canonique)
+
+```bash
+# 1. Éditer la source unique
+$EDITOR .secrets/master.env          # ex: changer HF_TOKEN
+
+# 2. Propager vers tous les .env consommateurs
+python scripts/secrets/render_envs.py
+
+# 3. Redémarrer les containers impactés (OBLIGATOIRE pour ComfyUI-Login,
+#    voir §"Règle du restart ComfyUI" ci-dessous)
+docker compose -f docker-configurations/services/<svc>/docker-compose.yml restart
+```
+
+Le render est **idempotent** : re-lancer ne change rien si déjà synchronisé.
+
+## Audit / détection de drift
+
+```bash
+python scripts/secrets/render_envs.py --check
+# exit 0 = tous les .env synchronisés avec master
+# exit 1 = drift détéré (un .env a été édité à la main), affiche chaque écart
+```
+
+`--check` compare chaque clé secrète de chaque `.env` à `master.env`. À lancer après toute édition manuelle d'un `.env`, ou périodiquement. **Note :** c'est un outil **local** (les `.env` sont gitignored, donc absents d'un checkout CI frais) — le scanner d'inline-literals côté code committé reste gitleaks CI (cf [secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md)).
+
+## Inventaire des secrets centralisés (master.env)
+
+| Catégorie | Clés | Consommateurs | Sensible rotation |
+|-----------|------|---------------|-------------------|
+| Hugging Face (aliasé) | `HF_TOKEN` = `HUGGINGFACE_TOKEN` | 5 services + notebooks | Oui (gated/quotas) |
+| LLM APIs payantes | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY` | notebooks | Oui (facturation) |
+| Hubs / git | `CIVITAI_TOKEN`, `GITHUB_TOKEN` = `GITHUB_ACCESS_TOKEN` | services + notebooks | Oui |
+| Client API keys (server↔client) | `WHISPER_API_KEY`, `VLLM_API_KEY`, `TTS_API_KEY`, `QWEN_ASR_API_KEY`, `MUSICGEN_API_KEY`, `DEMUCS_API_KEY`, `FUNASR_API_KEY` | 1 service + notebooks | Moyen |
+| Tokens client ComfyUI | `COMFYUI_VIDEO_TOKEN`, `COMFYUI_API_TOKEN` | notebooks → services ComfyUI | Moyen |
+| Session | `SECRET_KEY` | 1 service | Oui |
+
+**Alias :** `HF_TOKEN`/`HUGGINGFACE_TOKEN` et `GITHUB_TOKEN`/`GITHUB_ACCESS_TOKEN` désignent le MÊME secret sous deux noms (services vs notebooks). Le render écrit la même valeur des deux côtés ; le bootstrap vérifie leur cohérence (abort si divergence).
+
+## Secrets par instance (NON centralisés — config service)
+
+Ces secrets sont légitimement **différents par instance** (un mot de passe par container). Ils restent dans le `.env` de leur service et ne sont jamais collapsés :
+
+| Secret | Instances | Pourquoi par-instance |
+|--------|-----------|----------------------|
+| `COMFYUI_PASSWORD`, `COMFYUI_USERNAME` | comfyui-qwen, comfyui-video | Chaque ComfyUI a son propre login |
+| `FORGE_PASSWORD`, `FORGE_USER` | forge-turbo, sd-forge-main | Chaque Forge a son propre login |
+| `WHISPER_PASSWORD`/`WHISPER_USER`, `WHISPER_WEBUI_PASSWORD`/`WHISPER_WEBUI_USER` | whisper-api, whisper-webui | Logins par instance |
+
+Leur **prévention du drift** = la règle du restart (ci-dessous) + le self-check entrypoint, PAS la centralisation.
+
+## Règle du restart ComfyUI-Login (le piège du drift)
+
+`ComfyUI-Login` stocke un **hash bcrypt** dans `workspace/login/PASSWORD` (bind-mount persistant). L'`entrypoint.sh` **régénère ce hash depuis `COMFYUI_PASSWORD` (env) à chaque démarrage du container** — mais **pas pendant qu'il tourne**.
+
+Conséquence : si tu changes `COMFYUI_PASSWORD` dans le `.env` **sans restart**, le container garde un hash **périmé** jusqu'au prochain restart. Un client qui s'authentifie avec le nouveau mot de passe obtient un 401 — exactement le symptôme qui a fait croire (à tort) à une "clé perdue".
+
+**Règle :** après tout changement de `COMFYUI_PASSWORD` (ou `COMFYUI_*_TOKEN`), `docker compose restart` le container concerné. Le render affiche un rappel.
+
+**Self-check entrypoint :** après écriture du hash, l'entrypoint vérifie `bcrypt.checkpw(COMFYUI_PASSWORD, hash)` et logge la confirmation — donc les logs de démarrage prouvent que le hash du container courant matche le `.env` au startup.
+
+## Incident fondateur (juin 2026)
+
+Diagnostic erroné "drift bcrypt / plaintext perdu" sur `comfyui-video` → demande user de reset. **Vérification re-faite :** `bcrypt.checkpw(.env_password, hash) == True` — la clé n'était JAMAIS perdue. Le container avait simplement été vérifié avant son restart (hash périmé en RAM), puis restarté (hash régénéré depuis le `.env` courant). Leçon G.1/G.9 : un verdict "clé perdue" doit être vérifié **après restart**, pas sur un container au hash potentiellement périmé. Cet épisode a motivé la centralisation ci-dessus.
+
+## À faire (phase 2, optionnel)
+
+- Brancher `render_envs.py --check` en pre-commit local (hook `pre-commit`, pas CI — `.env` absents du checkout CI).
+- Documenter la rotation `WHISPER_API_KEY` (le token du reverse-proxy IIS `whisper-api.myia.io`) dans la procédure — actuellement dans `docker-configurations/services/whisper-api/.env` + propagation cross-repos (cf mémoire `whisper-token-rotation.md`).
+- Étendre `master.env` aux tokens cross-repos (roo-extensions, hermes-agent) via un master partagé si besoin.
+
+## Voir aussi
+
+- [.claude/rules/secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md) — anti-patterns inline-literals, règle HARD content-based.
+- [docs/reference/secrets-and-coord-detail.md](../reference/secrets-and-coord-detail.md) — incidents + postmortem responsable.
+- [scripts/secrets/render_envs.py](../../scripts/secrets/render_envs.py) — l'outil (`--bootstrap` / sync / `--check`).

--- a/scripts/secrets/render_envs.py
+++ b/scripts/secrets/render_envs.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""
+Centralized secrets management for the GenAI / CoursIA infrastructure.
+
+MODEL
+-----
+``.secrets/master.env`` is the SINGLE canonical source for every shared
+secret (API tokens, service passwords, session keys). Each service
+``.env`` (and the GenAI notebooks ``.env``) is a mix of:
+
+  * service-specific CONFIG (ports, paths, GPU ids, model names) -> stays
+    in the service ``.env``, never touched here;
+  * shared SECRETS (the keys listed in ``SECRET_KEYS`` below) -> their
+    VALUE is propagated from ``master.env`` by this script.
+
+Rotate a shared secret:
+  1. Edit ``.secrets/master.env``.
+  2. ``python scripts/secrets/render_envs.py``          (propagate)
+  3. ``docker compose restart <impacted-services>``     (ComfyUI-Login
+     regenerates its bcrypt hash from the env at restart; a running
+     container keeps a STALE hash until restarted -- the original cause
+     of the "drift" incident).
+
+MODES
+-----
+  (default)   sync: propagate master.env values into every .env that
+              references a SECRET key. Idempotent (re-running is a no-op
+              when already in sync).
+  --check     report drift only (any service .env whose value for a
+              SECRET key differs from master), exit 1 on drift. Use as a
+              CI / pre-commit gate.
+  --bootstrap ONE-SHOT: scan existing .env files, extract SECRET values,
+              write master.env (first-seen value per key; conflicts
+              reported). Use only to initialize master.env from a legacy
+              scattered layout.
+
+All printed output masks secret values (only the last 4 chars shown).
+Neither master.env nor any .env is committed (all gitignored).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MASTER_ENV = REPO_ROOT / ".secrets" / "master.env"
+
+# Service + notebooks .env files managed by this script.
+TARGET_ENVS = [
+    *sorted((REPO_ROOT / "docker-configurations" / "services").glob("*/.env")),
+    REPO_ROOT / "MyIA.AI.Notebooks" / "GenAI" / ".env",
+]
+
+# Keys whose VALUE is a shared secret and must be synced from master.env.
+# Everything else (ports, paths, GPU ids, model names, TZ, ...) is
+# service-specific CONFIG and is left untouched in each .env.
+#
+# Per-instance passwords (each ComfyUI / Forge instance has its OWN
+# password) are INTENTIONALLY excluded -- they are not shared and must
+# not be collapsed to one value. Their drift prevention is the
+# restart-after-.env-change rule (+ entrypoint self-check), not
+# centralization.
+SECRET_KEYS: frozenset[str] = frozenset({
+    # Hugging Face (aliased -- same logical token, two names)
+    "HF_TOKEN", "HUGGINGFACE_TOKEN",
+    # Paid LLM APIs (centrally managed, rotation-sensitive)
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+    # Model hubs / git
+    "CIVITAI_TOKEN", "GITHUB_TOKEN", "GITHUB_ACCESS_TOKEN",
+    # Per-service client API keys (server defines the value; clients must match)
+    "WHISPER_API_KEY", "VLLM_API_KEY", "TTS_API_KEY",
+    "QWEN_ASR_API_KEY", "MUSICGEN_API_KEY", "DEMUCS_API_KEY",
+    "FUNASR_API_KEY",
+    # ComfyUI client tokens (notebook client <-> service must agree)
+    "COMFYUI_VIDEO_TOKEN", "COMFYUI_API_TOKEN",
+    # Session
+    "SECRET_KEY",
+})
+
+# Explicit value aliases: these key pairs must always carry the SAME
+# value (one logical secret under two names). On sync, both are written
+# from master; on bootstrap, a conflict between an aliased pair is a
+# hard error (the two names must agree).
+ALIASES: dict[str, str] = {
+    "HUGGINGFACE_TOKEN": "HF_TOKEN",
+    "GITHUB_ACCESS_TOKEN": "GITHUB_TOKEN",
+}
+
+
+# --------------------------------------------------------------------------- #
+# dotenv parse / serialize (minimal, dependency-free)
+# --------------------------------------------------------------------------- #
+import re
+
+_LINE_RE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+
+
+def parse_kv(value: str) -> str:
+    """Strip surrounding quotes / inline comment from a dotenv value."""
+    v = value.strip()
+    if len(v) >= 2 and v[0] in "\"'" and v[-1] == v[0]:
+        v = v[1:-1]
+    return v.strip()
+
+
+def read_env(path: Path) -> dict[str, str]:
+    """Return {KEY: raw_value} for every assignment line in path."""
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = _LINE_RE.match(line)
+        if m:
+            out[m.group(1)] = parse_kv(m.group(2))
+    return out
+
+
+def mask(value: str) -> str:
+    """Mask a secret for display: show only the last 4 chars."""
+    if not value:
+        return "<empty>"
+    if len(value) <= 4:
+        return "*" * len(value)
+    return f"***{value[-4:]}"
+
+
+# --------------------------------------------------------------------------- #
+# bootstrap: build master.env from the scattered legacy .env values
+# --------------------------------------------------------------------------- #
+def _source_priority(env: Path) -> int:
+    """Canonical-source priority: a service .env (the server that DEFINES a
+    key) outranks the GenAI notebooks .env (a client that CONSUMES it).
+    Lower number = higher priority."""
+    if "docker-configurations" in env.parts and "services" in env.parts:
+        return 0  # service = canonical
+    return 1      # GenAI notebooks = client
+
+
+def bootstrap() -> int:
+    if MASTER_ENV.exists():
+        print(f"[!] {MASTER_ENV} already exists -- bootstrap is one-shot.")
+        print("    Delete it first if you really want to re-bootstrap.")
+        return 1
+
+    # value + the (priority, source) that supplied it.
+    gathered: dict[str, str] = {}
+    src: dict[str, tuple[int, str]] = {}
+    client_drift: list[str] = []   # service-vs-client: resolvable (service wins)
+    hard_conflicts: list[str] = []  # same-priority: genuinely per-instance / misclassified
+
+    for env in TARGET_ENVS:
+        if not env.exists():
+            continue
+        prio = _source_priority(env)
+        for key, val in read_env(env).items():
+            if key not in SECRET_KEYS or not val:
+                continue
+            if key not in gathered:
+                gathered[key] = val
+                src[key] = (prio, env.parent.name)
+            elif gathered[key] == val:
+                continue
+            else:
+                prev_prio, prev_src = src[key]
+                if prio < prev_prio:
+                    # current (service) outranks stored (client): record drift, swap.
+                    client_drift.append(f"  {key}: {env.parent.name}({mask(val)}) "
+                                        f"overrides stale {prev_src}({mask(gathered[key])})")
+                    gathered[key] = val
+                    src[key] = (prio, env.parent.name)
+                elif prio > prev_prio:
+                    # stored (service) outranks current (client): record drift, keep.
+                    client_drift.append(f"  {key}: {prev_src}({mask(gathered[key])}) "
+                                        f"overrides stale {env.parent.name}({mask(val)})")
+                else:
+                    # same priority, different values -> genuinely per-instance
+                    hard_conflicts.append(f"  {key}: {env.parent.name}={mask(val)} "
+                                          f"vs {prev_src}={mask(gathered[key])}")
+
+    # Enforce alias agreement on the gathered values.
+    for alias, canonical in ALIASES.items():
+        if alias in gathered and canonical in gathered and gathered[alias] != gathered[canonical]:
+            hard_conflicts.append(f"  ALIAS MISMATCH: {alias}={mask(gathered[alias])} "
+                                  f"!= {canonical}={mask(gathered[canonical])}")
+
+    if hard_conflicts:
+        print("[X] Bootstrap aborted -- same-priority conflicts (per-instance or "
+              "misclassified key):")
+        for c in hard_conflicts:
+            print(c)
+        print("\n    These keys have legitimately different values across peers")
+        print("    (e.g. one password per instance). Remove them from SECRET_KEYS")
+        print("    in render_envs.py -- they are config, not shared secrets.")
+        return 2
+
+    MASTER_ENV.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Centralized secrets -- SINGLE source of truth.",
+        "# Edit a value HERE, then run: python scripts/secrets/render_envs.py",
+        "# Never commit (gitignored). Service-specific config (incl. per-instance",
+        "# passwords) stays in each service .env; only shared SECRET values are",
+        "# synced from this file.",
+        "",
+    ]
+    for key in sorted(gathered):
+        lines.append(f"{key}={gathered[key]}")
+    MASTER_ENV.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"[+] Wrote {MASTER_ENV} with {len(gathered)} secret keys:")
+    for key in sorted(gathered):
+        print(f"      {key} = {mask(gathered[key])}")
+    if client_drift:
+        print(f"\n[i] {len(client_drift)} client/notebook drift(s) resolved "
+              f"(service value taken as canonical):")
+        for d in client_drift:
+            print(d)
+        print("    Run `python scripts/secrets/render_envs.py` to propagate the "
+              "canonical values into the drifted notebooks .env.")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# sync: propagate master.env -> every .env
+# --------------------------------------------------------------------------- #
+def sync(check_only: bool) -> int:
+    if not MASTER_ENV.exists():
+        print(f"[X] {MASTER_ENV} not found. Run with --bootstrap first.")
+        return 1
+    master = read_env(MASTER_ENV)
+    missing_in_master = SECRET_KEYS - master.keys()
+    if missing_in_master:
+        print(f"[!] {len(missing_in_master)} declared SECRET keys are absent from "
+              f"master.env (left untouched in services): {sorted(missing_in_master)}")
+
+    drift: list[str] = []
+    written: list[str] = []
+    for env in TARGET_ENVS:
+        if not env.exists():
+            continue
+        original = env.read_text(encoding="utf-8").splitlines()
+        changed = False
+        out_lines: list[str] = []
+        for line in original:
+            m = _LINE_RE.match(line)
+            if m and m.group(1) in master:
+                key, new_val = m.group(1), master[m.group(1)]
+                cur = parse_kv(m.group(2))
+                if cur != new_val:
+                    drift.append(f"  {env.parent.name}: {key} "
+                                 f"{mask(cur)} -> {mask(new_val)}")
+                    out_lines.append(f"{key}={new_val}")
+                    changed = True
+                else:
+                    out_lines.append(line)
+            else:
+                out_lines.append(line)
+        if changed and not check_only:
+            env.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
+            written.append(env.parent.name)
+
+    if drift:
+        if check_only:
+            print(f"[X] DRIFT detected ({len(drift)} key(s) differ from master):")
+            for d in drift:
+                print(d)
+            print("\n    Run `python scripts/secrets/render_envs.py` to resync.")
+            return 1
+        print(f"[+] Resynced {len(drift)} value(s) across: {', '.join(written)}")
+        for d in drift:
+            print(d)
+        print("\n[i] Restart impacted containers (ComfyUI-Login hashes regen at restart).")
+        return 0
+
+    print(f"[OK] All {len(TARGET_ENVS)} target .env in sync with master.env "
+          f"({len(master)} secret keys). No drift.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--bootstrap", action="store_true",
+                      help="one-shot: build master.env from existing .env values")
+    mode.add_argument("--check", action="store_true",
+                      help="report drift only, exit 1 on drift (CI / pre-commit)")
+    args = p.parse_args()
+    if args.bootstrap:
+        return bootstrap()
+    return sync(check_only=args.check)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Centralized secrets management for the GenAI / CoursIA infrastructure, so the **drift** that mimicked a "lost key" (juin 2026) is mechanically impossible going forward.

**Root cause of the scare:** ComfyUI-Login regenerates its bcrypt hash from `COMFYUI_PASSWORD` (env) only at container **restart**, not hot. A running container whose `.env` had been changed kept a stale hash → read as "drift / plaintext lost". **Verified: the key was never lost** (`bcrypt.checkpw(.env_password, hash) == True` after restart). The real problem was **duplication without a source of truth** (`HF_TOKEN` copied in 5 service `.env`, inconsistent `HF_TOKEN`/`HUGGINGFACE_TOKEN` naming, `.secrets/` under-used).

## What's in this PR (tooling + doc + rules — NO secrets)

| File | Role |
|------|------|
| `scripts/secrets/render_envs.py` | `--bootstrap` (one-shot extract from legacy `.env`), sync (propagate `master.env` → 15 `.env` targets, idempotent), `--check` (drift gate, exit 1). Service sources canonical over GenAI notebooks; same-priority conflicts abort. |
| `docs/genai/secrets-management.md` | Inventory, rotation procedure, ComfyUI restart rule, per-instance password policy, incident writeup. |
| `docker-configurations/services/comfyui-video/entrypoint.sh` | Self-check: the written bcrypt hash must verify against `COMFYUI_PASSWORD` at startup (drift visible in logs). |
| `.claude/rules/secrets-hygiene.md` | Pointer to the centralized system. |

**The actual secrets stay gitignored** (`.secrets/master.env` + all `.env`) — confirmed `git check-ignore`. Only the tooling/doc/rules are committed.

## Outcomes (verified locally)

- `HF_TOKEN` deduplicated: **5 sources → 1** (`master.env`).
- Aliases resolved: `HF_TOKEN`=`HUGGINGFACE_TOKEN`, `GITHUB_TOKEN`=`GITHUB_ACCESS_TOKEN`.
- **4 client/notebook drifts fixed**: `COMFYUI_VIDEO_TOKEN`, `COMFYUI_API_TOKEN`, `QWEN_ASR_API_KEY`, `FUNASR_API_KEY` (swapped in the GenAI `.env`) → synced to the service canonical values.
- `python scripts/secrets/render_envs.py --check` → exit 0 (all 15 `.env` in sync, no drift).

## Rotation procedure (now canonical)

```
1. edit  .secrets/master.env
2. run   python scripts/secrets/render_envs.py
3. run   docker compose restart <impacted-services>   # ComfyUI hash regens at restart
```

Per-instance passwords (one per ComfyUI/Forge/Whisper instance) are intentionally NOT centralized — they're config, prevented from drifting via the restart rule + entrypoint self-check.

## Validation
- `ast.parse` OK; bootstrap → sync → `--check` exit 0 end-to-end.
- Self-leak grep on the 4 committed files: no real secret literals (only masked examples + key NAMES).
- `.secrets/master.env` + all `.env` confirmed gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
