### PR TITLE
feat(sl-1): enrich CBH narrative -- 2 senses per operation + Occam/MDL metric + exception caveat

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -1469,9 +1469,16 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Limites du Version Space\n",
+    "## 8. Limites du Version Space conjonctif\n",
     "\n",
-    "Le Version Space a des limites fondamentales qui expliquent pourquoi il n'est pas utilise en pratique aujourd'hui.\n",
+    "Les sections 4 et 5 ont travaille sur une representation **conjonctive** des hypotheses.\n",
+    "Cette section recense ses limites en distinguant deux natures :\n",
+    "\n",
+    "- des limites **fondamentales**, partagees par CBH et le Version Space, qui ont reellement\n",
+    "  motive le passage a d'autres familles de modeles (8.1, 8.3, 8.4 ci-dessous) ;\n",
+    "- une limite de **representation** --- l'impossibilite des disjonctions (8.2) --- qui n'est\n",
+    "  *pas* une impasse : elle se leve en enrichissant le langage d'hypotheses, ce que fait deja\n",
+    "  l'operation `add_or` introduite en section 3 et exercee en section 9.\n",
     "\n",
     "### 8.1 Sensibilite au bruit\n",
     "\n",
@@ -1548,9 +1555,20 @@
     "tags": []
    },
    "source": [
-    "### 8.2 Incapacite a representer les disjonctions\n",
+    "### 8.2 Incapacite de la representation conjonctive a exprimer les disjonctions\n",
     "\n",
-    "Le Version Space ne represente que des **conjonctions**. Si le concept cible est une disjonction (ex: \"Patrons=Some OU (Patrons=Full ET Fri/Sat=Yes)\"), le VS ne peut pas le representer."
+    "Une hypothese **conjonctive** unique (sections 4-5) ne peut pas exprimer un concept\n",
+    "disjonctif comme \"Patrons=Some OU (Patrons=Full ET Fri/Sat=Yes)\". C'est exactement ce qui\n",
+    "**effondre** notre Version Space sur les 12 exemples du restaurant (section 5 : `|G| = |S| = 0`).\n",
+    "\n",
+    "Mais c'est une limite du **langage d'hypotheses**, pas une impasse de l'apprentissage par\n",
+    "generalisation/specialisation. Il suffit d'**enrichir la representation** : autoriser une\n",
+    "hypothese a etre une *liste* de conjonctions reliees par OU, et ajouter l'operation **`add_or`**\n",
+    "(le sens « augmenter l'enonce » de la generalisation, tableau de la section 3). La section 9 le\n",
+    "verifie : avec cette seule extension, `current_best_learning` trouve une hypothese **100%\n",
+    "consistante** la ou le VS conjonctif s'effondrait. Le prix n'est donc pas l'impossibilite, mais\n",
+    "le **controle de la complexite** --- une representation disjonctive peut toujours memoriser les\n",
+    "exemples au lieu de generaliser, d'ou la necessite du rasoir d'Occam / MDL (section 9)."
    ]
   },
   {
@@ -1642,14 +1660,19 @@
    "source": [
     "### Interpretation : Limites du Version Space\n",
     "\n",
-    "| Limite | Cause | Consequence | Solution alternative |\n",
-    "|--------|-------|-------------|---------------------|\n",
-    "| **Bruit** | Un seul exemple erronee | VS vide | Modeles probabilistes (tolerance aux erreurs) |\n",
-    "| **Disjonctions** | Reprsentation conjonctive seule | Approximation sous-optimale | Arbres de decision, ensembles de regles |\n",
-    "| **Explosion combinatoire** | Nombre de specialisations | G-set tres grand | Heuristiques, attribution de probabilites |\n",
-    "| **Attributs continus** | Besoin de seuils discrets | Non applicable directement | Arbres de decision avec seuils |\n",
+    "| Limite | Nature | Cause | Consequence | Reponse |\n",
+    "|--------|--------|-------|-------------|---------|\n",
+    "| **Bruit** | Fondamentale | Un seul exemple errone | VS vide | Modeles probabilistes (tolerance aux erreurs) |\n",
+    "| **Disjonctions** | Representation | Langage **conjonctif** (pas l'algorithme) | Effondrement du VS conjonctif (section 5) | Enrichir le langage : disjonctions + `add_or` (sections 3 et 9, **resolu dans ce notebook**), puis arbres de decision / regles pour la compacite |\n",
+    "| **Explosion combinatoire** | Fondamentale | Nombre de specialisations | G-set tres grand | Heuristiques, attribution de probabilites |\n",
+    "| **Attributs continus** | Fondamentale | Besoin de seuils discrets | Non applicable directement | Arbres de decision avec seuils |\n",
     "\n",
-    "> **Note historique** : Malgre ses limites, le Version Space est fondamental en apprentissage symbolique. Il a inspire des methodes plus robustes comme les arbres de decision (ID3/C4.5) et les modeles de theorie des versions probabilistes."
+    "> **Note historique** : le Version Space reste un pilier conceptuel de l'apprentissage\n",
+    "> symbolique --- frontieres G/S, ordre de generalite, convergence. Ses limites fondamentales\n",
+    "> (bruit, explosion, attributs continus) ont motive des familles plus robustes (arbres de\n",
+    "> decision ID3/C4.5, modeles probabilistes), tandis que sa limite de representation --- les\n",
+    "> disjonctions --- se leve directement en enrichissant le langage d'hypotheses, comme le\n",
+    "> montre la section 9."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "6b0e8fee",
    "metadata": {
     "papermill": {
-     "duration": 0.00445,
-     "end_time": "2026-06-10T14:02:23.861956",
+     "duration": 0.00644,
+     "end_time": "2026-06-16T22:36:03.278870+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:23.857506",
+     "start_time": "2026-06-16T22:36:03.272430+00:00",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "2b4d29e4",
    "metadata": {
     "papermill": {
-     "duration": 0.004515,
-     "end_time": "2026-06-10T14:02:23.870984",
+     "duration": 0.005218,
+     "end_time": "2026-06-16T22:36:03.291353+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:23.866469",
+     "start_time": "2026-06-16T22:36:03.286135+00:00",
      "status": "completed"
     },
     "tags": []
@@ -92,16 +92,16 @@
    "id": "dc85e1f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:23.879552Z",
-     "iopub.status.busy": "2026-06-10T14:02:23.879552Z",
-     "iopub.status.idle": "2026-06-10T14:02:23.905132Z",
-     "shell.execute_reply": "2026-06-10T14:02:23.904010Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.303128Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.302765Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.314229Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.313495Z"
     },
     "papermill": {
-     "duration": 0.031551,
-     "end_time": "2026-06-10T14:02:23.905650",
+     "duration": 0.01846,
+     "end_time": "2026-06-16T22:36:03.315049+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:23.874099",
+     "start_time": "2026-06-16T22:36:03.296589+00:00",
      "status": "completed"
     },
     "tags": []
@@ -183,10 +183,10 @@
    "id": "62d393f1",
    "metadata": {
     "papermill": {
-     "duration": 0.003146,
-     "end_time": "2026-06-10T14:02:23.913299",
+     "duration": 0.004489,
+     "end_time": "2026-06-16T22:36:03.324470+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:23.910153",
+     "start_time": "2026-06-16T22:36:03.319981+00:00",
      "status": "completed"
     },
     "tags": []
@@ -210,10 +210,10 @@
    "id": "ee8b228d",
    "metadata": {
     "papermill": {
-     "duration": 0.004625,
-     "end_time": "2026-06-10T14:02:23.921995",
+     "duration": 0.004699,
+     "end_time": "2026-06-16T22:36:03.333681+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:23.917370",
+     "start_time": "2026-06-16T22:36:03.328982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -241,16 +241,16 @@
    "id": "4b2b04b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:23.930885Z",
-     "iopub.status.busy": "2026-06-10T14:02:23.930885Z",
-     "iopub.status.idle": "2026-06-10T14:02:23.950870Z",
-     "shell.execute_reply": "2026-06-10T14:02:23.949706Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.344474Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.344250Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.350826Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.350173Z"
     },
     "papermill": {
-     "duration": 0.025727,
-     "end_time": "2026-06-10T14:02:23.951391",
+     "duration": 0.012929,
+     "end_time": "2026-06-16T22:36:03.351443+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:23.925664",
+     "start_time": "2026-06-16T22:36:03.338514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -334,10 +334,10 @@
    "id": "3fcf13d2",
    "metadata": {
     "papermill": {
-     "duration": 0.003645,
-     "end_time": "2026-06-10T14:02:23.959204",
+     "duration": 0.004338,
+     "end_time": "2026-06-16T22:36:03.360391+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:23.955559",
+     "start_time": "2026-06-16T22:36:03.356053+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "3fb92770",
    "metadata": {
     "papermill": {
-     "duration": 0.003742,
-     "end_time": "2026-06-10T14:02:23.967137",
+     "duration": 0.005525,
+     "end_time": "2026-06-16T22:36:03.370443+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:23.963395",
+     "start_time": "2026-06-16T22:36:03.364918+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,16 +398,16 @@
    "id": "e4d6947a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:23.977894Z",
-     "iopub.status.busy": "2026-06-10T14:02:23.977894Z",
-     "iopub.status.idle": "2026-06-10T14:02:23.997424Z",
-     "shell.execute_reply": "2026-06-10T14:02:23.995908Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.381234Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.381027Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.388011Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.387290Z"
     },
     "papermill": {
-     "duration": 0.025686,
-     "end_time": "2026-06-10T14:02:23.997943",
+     "duration": 0.013239,
+     "end_time": "2026-06-16T22:36:03.388519+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:23.972257",
+     "start_time": "2026-06-16T22:36:03.375280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -508,10 +508,10 @@
    "id": "b1a2400b",
    "metadata": {
     "papermill": {
-     "duration": 0.006916,
-     "end_time": "2026-06-10T14:02:24.012216",
+     "duration": 0.00437,
+     "end_time": "2026-06-16T22:36:03.397388+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.005300",
+     "start_time": "2026-06-16T22:36:03.393018+00:00",
      "status": "completed"
     },
     "tags": []
@@ -534,13 +534,56 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2381abd1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004783,
+     "end_time": "2026-06-16T22:36:03.408830+00:00",
+     "exception": false,
+     "start_time": "2026-06-16T22:36:03.404047+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Les deux sens de chaque operation : croissance vs reduction de l'enonce\n",
+    "\n",
+    "La section ci-dessus a presente generaliser et specialiser chacune comme **une seule**\n",
+    "operation. C'est suffisant pour faire tourner CBH (section 4) et le Version Space (section 5)\n",
+    "sur une representation **conjonctive**. Mais le cours IAMA souligne une structure plus riche :\n",
+    "**chaque direction admet deux sens**, selon qu'elle **augmente** ou **reduit** la taille de\n",
+    "l'enonce logique.\n",
+    "\n",
+    "| Direction (declenchee par) | Sens « reduit l'enonce » | Sens « augmente l'enonce » |\n",
+    "|---|---|---|\n",
+    "| **Generaliser** (faux negatif : un positif n'est pas couvert) | enlever un conjoint : relacher une contrainte vers `?`. L'enonce raccourcit. | ajouter une **exception positive** par **disjonction** (`h OU nouveau_cas`). L'enonce grandit d'un disjonct. |\n",
+    "| **Specialiser** (faux positif : un negatif est couvert) | supprimer un disjonct, ou reduire l'espace couvert. L'enonce raccourcit. | ajouter une **exception negative** par **conjonction** (`h ET condition`). L'enonce grandit d'un conjoint. |\n",
+    "\n",
+    "- Les sections 3 a 5 n'exercent que les deux cases « faciles » de la representation conjonctive :\n",
+    "  **generaliser-reduire** (relacher `?`) et **specialiser-augmenter** (epingler `?` vers une valeur).\n",
+    "- Les deux autres cases exigent une representation **disjonctive** (une hypothese = une liste de\n",
+    "  conjonctions reliees par OU). Elles apparaissent en section 9, via l'algorithme de reference\n",
+    "  aima-python et son operation `add_or`.\n",
+    "\n",
+    "> **Point cle pour la suite.** Toute croissance de l'enonce (ajout d'une exception, positive ou\n",
+    "> negative) a un **cout** : un modele plus long est plus fragile, il memorise au lieu de\n",
+    "> generaliser. Un algorithme prudent pese donc ce cout au moyen d'une **metrique de complexite**\n",
+    "> (la taille de l'enonce) et **recommence les reductions** chaque fois qu'elles restent possibles\n",
+    "> sans casser la consistance, car un **modele simple consistant generalise mieux** (rasoir\n",
+    "> d'Occam / MDL). Ce principe est rendu operationnel en section 9, une fois la representation\n",
+    "> disjonctive disponible. Et il faut le souligner d'emblee : **parfois l'exception est la seule\n",
+    "> facon de gagner la consistance** ; dans ce cas la metrique ne l'interdit pas, elle la minimise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "77fbb6ab",
    "metadata": {
     "papermill": {
-     "duration": 0.006793,
-     "end_time": "2026-06-10T14:02:24.026349",
+     "duration": 0.005122,
+     "end_time": "2026-06-16T22:36:03.418516+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.019556",
+     "start_time": "2026-06-16T22:36:03.413394+00:00",
      "status": "completed"
     },
     "tags": []
@@ -584,16 +627,16 @@
    "id": "ebd916fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.043799Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.043270Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.058208Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.057190Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.430179Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.429943Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.437996Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.437231Z"
     },
     "papermill": {
-     "duration": 0.025496,
-     "end_time": "2026-06-10T14:02:24.059266",
+     "duration": 0.015359,
+     "end_time": "2026-06-16T22:36:03.438667+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.033770",
+     "start_time": "2026-06-16T22:36:03.423308+00:00",
      "status": "completed"
     },
     "tags": []
@@ -710,10 +753,10 @@
    "id": "462c713b",
    "metadata": {
     "papermill": {
-     "duration": 0.007768,
-     "end_time": "2026-06-10T14:02:24.074412",
+     "duration": 0.005858,
+     "end_time": "2026-06-16T22:36:03.450333+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.066644",
+     "start_time": "2026-06-16T22:36:03.444475+00:00",
      "status": "completed"
     },
     "tags": []
@@ -742,10 +785,10 @@
    "id": "22c65a7f",
    "metadata": {
     "papermill": {
-     "duration": 0.007935,
-     "end_time": "2026-06-10T14:02:24.089818",
+     "duration": 0.005433,
+     "end_time": "2026-06-16T22:36:03.461138+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.081883",
+     "start_time": "2026-06-16T22:36:03.455705+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,16 +833,16 @@
    "id": "cf277e5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.107210Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.106202Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.118888Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.118301Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.473037Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.472827Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.484584Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.483854Z"
     },
     "papermill": {
-     "duration": 0.022231,
-     "end_time": "2026-06-10T14:02:24.119897",
+     "duration": 0.018852,
+     "end_time": "2026-06-16T22:36:03.485223+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.097666",
+     "start_time": "2026-06-16T22:36:03.466371+00:00",
      "status": "completed"
     },
     "tags": []
@@ -809,14 +852,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trace Version Space :"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "Trace Version Space :\n",
       " Ex | Label | |G| | |S|\n",
       "-------------------------\n",
       "  0 |     + |   1 |   1\n",
@@ -963,10 +999,10 @@
    "id": "98b8d953",
    "metadata": {
     "papermill": {
-     "duration": 0.007505,
-     "end_time": "2026-06-10T14:02:24.135501",
+     "duration": 0.005015,
+     "end_time": "2026-06-16T22:36:03.495265+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.127996",
+     "start_time": "2026-06-16T22:36:03.490250+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1003,10 +1039,10 @@
    "id": "e4ab2892",
    "metadata": {
     "papermill": {
-     "duration": 0.006993,
-     "end_time": "2026-06-10T14:02:24.149419",
+     "duration": 0.004611,
+     "end_time": "2026-06-16T22:36:03.504580+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.142426",
+     "start_time": "2026-06-16T22:36:03.499969+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1035,16 +1071,16 @@
    "id": "e5d20a7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.165789Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.165789Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.181543Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.180457Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.517027Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.516832Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.527935Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.527339Z"
     },
     "papermill": {
-     "duration": 0.027248,
-     "end_time": "2026-06-10T14:02:24.182541",
+     "duration": 0.019608,
+     "end_time": "2026-06-16T22:36:03.529009+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.155293",
+     "start_time": "2026-06-16T22:36:03.509401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1193,10 +1229,10 @@
    "id": "15fc8c86",
    "metadata": {
     "papermill": {
-     "duration": 0.007071,
-     "end_time": "2026-06-10T14:02:24.197368",
+     "duration": 0.005352,
+     "end_time": "2026-06-16T22:36:03.539779+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.190297",
+     "start_time": "2026-06-16T22:36:03.534427+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1223,10 +1259,10 @@
    "id": "ccca7f32",
    "metadata": {
     "papermill": {
-     "duration": 0.007329,
-     "end_time": "2026-06-10T14:02:24.212501",
+     "duration": 0.004926,
+     "end_time": "2026-06-16T22:36:03.550229+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.205172",
+     "start_time": "2026-06-16T22:36:03.545303+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1245,16 +1281,16 @@
    "id": "c68c743e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.228341Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.228341Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.243359Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.242268Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.561011Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.560771Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.568194Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.567465Z"
     },
     "papermill": {
-     "duration": 0.024922,
-     "end_time": "2026-06-10T14:02:24.243877",
+     "duration": 0.013694,
+     "end_time": "2026-06-16T22:36:03.568780+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.218955",
+     "start_time": "2026-06-16T22:36:03.555086+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1392,10 +1428,10 @@
    "id": "de22cbc0",
    "metadata": {
     "papermill": {
-     "duration": 0.008962,
-     "end_time": "2026-06-10T14:02:24.260131",
+     "duration": 0.005417,
+     "end_time": "2026-06-16T22:36:03.579241+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.251169",
+     "start_time": "2026-06-16T22:36:03.573824+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1422,10 +1458,10 @@
    "id": "f98934d2",
    "metadata": {
     "papermill": {
-     "duration": 0.007151,
-     "end_time": "2026-06-10T14:02:24.274883",
+     "duration": 0.006316,
+     "end_time": "2026-06-16T22:36:03.590975+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.267732",
+     "start_time": "2026-06-16T22:36:03.584659+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1448,16 +1484,16 @@
    "id": "0ff352e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.291423Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.291423Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.305296Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.304715Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.603477Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.603216Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.608030Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.607343Z"
     },
     "papermill": {
-     "duration": 0.023915,
-     "end_time": "2026-06-10T14:02:24.306445",
+     "duration": 0.011834,
+     "end_time": "2026-06-16T22:36:03.608564+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.282530",
+     "start_time": "2026-06-16T22:36:03.596730+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1503,10 +1539,10 @@
    "id": "ce6eb73f",
    "metadata": {
     "papermill": {
-     "duration": 0.007721,
-     "end_time": "2026-06-10T14:02:24.321719",
+     "duration": 0.004993,
+     "end_time": "2026-06-16T22:36:03.618909+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.313998",
+     "start_time": "2026-06-16T22:36:03.613916+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1523,16 +1559,16 @@
    "id": "ad095fa3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.338287Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.338287Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.353871Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.352347Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.629866Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.629627Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.635149Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.634175Z"
     },
     "papermill": {
-     "duration": 0.024739,
-     "end_time": "2026-06-10T14:02:24.353871",
+     "duration": 0.012007,
+     "end_time": "2026-06-16T22:36:03.635789+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.329132",
+     "start_time": "2026-06-16T22:36:03.623782+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1595,10 +1631,10 @@
    "id": "0ec254c5",
    "metadata": {
     "papermill": {
-     "duration": 0.0083,
-     "end_time": "2026-06-10T14:02:24.370659",
+     "duration": 0.004732,
+     "end_time": "2026-06-16T22:36:03.647014+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.362359",
+     "start_time": "2026-06-16T22:36:03.642282+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1621,10 +1657,10 @@
    "id": "92096025",
    "metadata": {
     "papermill": {
-     "duration": 0.007167,
-     "end_time": "2026-06-10T14:02:24.384950",
+     "duration": 0.00549,
+     "end_time": "2026-06-16T22:36:03.657542+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.377783",
+     "start_time": "2026-06-16T22:36:03.652052+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1666,16 +1702,16 @@
    "id": "927a1be6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.402425Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.402425Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.433781Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.432166Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.670443Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.670155Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.700377Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.699343Z"
     },
     "papermill": {
-     "duration": 0.041257,
-     "end_time": "2026-06-10T14:02:24.434779",
+     "duration": 0.038287,
+     "end_time": "2026-06-16T22:36:03.701141+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.393522",
+     "start_time": "2026-06-16T22:36:03.662854+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1685,7 +1721,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hypothese trouvee : 5 disjonction(s) en 0.01s"
+      "Hypothese trouvee : 5 disjonction(s) en 0.02s"
      ]
     },
     {
@@ -1741,10 +1777,10 @@
    "id": "2c82c885",
    "metadata": {
     "papermill": {
-     "duration": 0.005312,
-     "end_time": "2026-06-10T14:02:24.447629",
+     "duration": 0.006991,
+     "end_time": "2026-06-16T22:36:03.715369+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.442317",
+     "start_time": "2026-06-16T22:36:03.708378+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1781,13 +1817,147 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b74b7ea1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007652,
+     "end_time": "2026-06-16T22:36:03.730506+00:00",
+     "exception": false,
+     "start_time": "2026-06-16T22:36:03.722854+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Complexite de l'enonce, rasoir d'Occam et MDL\n",
+    "\n",
+    "La section 9 a montre que `current_best_learning` **reussit** la ou notre Version Space\n",
+    "conjonctif s'effondrait. Mais relisez l'observation n. 2 ci-dessus : l'algorithme retourne la\n",
+    "**premiere** hypothese consistante trouvee, **sans biais de simplicite**. C'est precisement le\n",
+    "fil conducteur annonce en section 3 qu'il faut maintenant rendre operationnel.\n",
+    "\n",
+    "**Le cout d'une exception.** Ajouter un conjoint (specialiser) ou un disjonct (generaliser par\n",
+    "`add_or`) fait **grandir l'enonce**. Un enonce plus long couvre ses exemples d'entrainement en\n",
+    "les **memorisant** plutot qu'en capturant la regle sous-jacente : il generalise mal. D'ou le\n",
+    "principe du **rasoir d'Occam** (ou, plus formellement, de la **longueur de description\n",
+    "minimale**, MDL) : parmi les hypotheses consistantes, preferer la plus simple.\n",
+    "\n",
+    "**Recommencer les reductions.** Un algorithme qui tient ce biais ne se contente pas d'ajouter\n",
+    "des exceptions : apres chaque croissance, il **recommence les reductions** (enlever un conjoint,\n",
+    "supprimer un disjonct) tant que la consistance est preservee. C'est ce que fait **FOIL**\n",
+    "(AIMA 19.5, induction logique inductive top-down), dont l'heuristique de gain d'information\n",
+    "penalise les clauses longues ; FOIL est traite en SL-4. La metrique `statement_size` ci-dessous\n",
+    "en donne un echo minimal.\n",
+    "\n",
+    "**L'exception parfois inevitable.** Et c'est ici que la nuance compte : la consistance **peut\n",
+    "forcer** une exception. Le domaine du restaurant le demontre. La section 5 a montre qu'**aucune\n",
+    "conjonction unique** n'est consistante avec les 12 exemples (le Version Space s'effondre) ;\n",
+    "la section 9 vient de montrer que la **seule** voie vers une hypothese 12/12 consistante est\n",
+    "d'ajouter des disjonctions. La metrique d'Occam n'**interdit** donc pas les exceptions, elle\n",
+    "les **minimise** sous contrainte de consistance. En cas de conflit, **la consistance l'emporte\n",
+    "sur la simplicite** (un modele complexe mais juste bat un modele simple mais faux) ; Occam sert\n",
+    "alors a departager les hypotheses consistantes entre elles, en privilegiant celle qui emploie\n",
+    "le moins d'exceptions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "2ba3456c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-16T22:36:03.745941Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.745668Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.752731Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.751823Z"
+    },
+    "papermill": {
+     "duration": 0.016273,
+     "end_time": "2026-06-16T22:36:03.753677+00:00",
+     "exception": false,
+     "start_time": "2026-06-16T22:36:03.737404+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CBH (section 4, representation conjonctive) :\n",
+      "  Hypothese finale : ('?', '?', '?', 'Yes', '?', '?', '?', '?', '?', '?')\n",
+      "  statement_size   : 1 condition(s)\n",
+      "  -> CBH a garde la PREMIERE hypothese consistante (ici 1 condition,\n",
+      "     Hungry=Yes) ; il n'a pas cherche la plus simple parmi les consistantes,\n",
+      "     il n'a simplement pas de rasoir.\n",
+      "\n",
+      "AIMA current_best_learning (section 9, representation disjonctive) :\n",
+      "  Hypothese : 5 disjonction(s)\n",
+      "  statement_size : 28 conditions au total\n",
+      "  -> 5 disjonctions tres specifiques : croissance abusive. Le rasoir\n",
+      "     d'Occam (MDL) chercherait l'hypothese consistante la plus compacte\n",
+      "     (cf. exercice 5) : minimiser le nombre d'exceptions, pas les eliminer.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Complexite de l'enonce : un rasoir d'Occam operationnel (Minimum Description Length)\n",
+    "#\n",
+    "# Toute croissance de l'hypothese (ajout d'un conjoint ou d'un disjonct) a un cout :\n",
+    "# un modele plus long memorise plutot qu'il ne generalise. La metrique ci-dessous\n",
+    "# mesure la taille de l'enonce. CBH (section 4) et le Version Space (section 5)\n",
+    "# ne l'utilisent PAS : ils gardent la PREMIERE hypothese consistante, pas la plus\n",
+    "# simple. FOIL (AIMA 19.5, induction logique inductive top-down) l'integre au\n",
+    "# contraire pour penaliser les clauses longues.\n",
+    "\n",
+    "\n",
+    "def statement_size_conjunctive(h: Hypothesis) -> int:\n",
+    "    \"\"\"Taille d'une hypothese conjonctive = nombre de conditions explicites.\n",
+    "\n",
+    "    Chaque contrainte non-joker (ni '?', ni None) est une condition de l'enonce.\n",
+    "    Plus ce nombre est grand, plus l'enonce est long (plus d'exceptions negatives).\n",
+    "    \"\"\"\n",
+    "    return sum(1 for v in h if v is not None and v != \"?\")\n",
+    "\n",
+    "\n",
+    "def statement_size_disjunctive(h: list) -> int:\n",
+    "    \"\"\"Taille d'une hypothese disjonctive (format aima-python) = somme des\n",
+    "    conditions de chaque disjonction (branche).\n",
+    "\n",
+    "    Le nombre de branches est aussi un cout : chaque disjonction est une\n",
+    "    exception positive ajoutee pour couvrir un exemple rebelle.\n",
+    "    \"\"\"\n",
+    "    return sum(len(branch) for branch in h)\n",
+    "\n",
+    "\n",
+    "# (1) Sur le resultat CBH conjonctif de la section 4\n",
+    "print(\"CBH (section 4, representation conjonctive) :\")\n",
+    "print(f\"  Hypothese finale : {cbh_result}\")\n",
+    "print(f\"  statement_size   : {statement_size_conjunctive(cbh_result)} condition(s)\")\n",
+    "print(f\"  -> CBH a garde la PREMIERE hypothese consistante (ici 1 condition,\")\n",
+    "print(f\"     Hungry=Yes) ; il n'a pas cherche la plus simple parmi les consistantes,\")\n",
+    "print(f\"     il n'a simplement pas de rasoir.\")\n",
+    "print()\n",
+    "\n",
+    "# (2) Sur l'hypothese disjonctive AIMA de la section 9\n",
+    "print(\"AIMA current_best_learning (section 9, representation disjonctive) :\")\n",
+    "print(f\"  Hypothese : {len(h)} disjonction(s)\")\n",
+    "print(f\"  statement_size : {statement_size_disjunctive(h)} conditions au total\")\n",
+    "print(f\"  -> 5 disjonctions tres specifiques : croissance abusive. Le rasoir\")\n",
+    "print(f\"     d'Occam (MDL) chercherait l'hypothese consistante la plus compacte\")\n",
+    "print(f\"     (cf. exercice 5) : minimiser le nombre d'exceptions, pas les eliminer.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "affee29e",
    "metadata": {
     "papermill": {
-     "duration": 0.008584,
-     "end_time": "2026-06-10T14:02:24.463844",
+     "duration": 0.006818,
+     "end_time": "2026-06-16T22:36:03.767722+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.455260",
+     "start_time": "2026-06-16T22:36:03.760904+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1805,10 +1975,10 @@
    "id": "23cff9a5",
    "metadata": {
     "papermill": {
-     "duration": 0.007285,
-     "end_time": "2026-06-10T14:02:24.478927",
+     "duration": 0.007582,
+     "end_time": "2026-06-16T22:36:03.782585+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.471642",
+     "start_time": "2026-06-16T22:36:03.775003+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1821,20 +1991,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "d1ecd1cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.495788Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.495788Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.510968Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.510461Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.796264Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.795963Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.800620Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.799890Z"
     },
     "papermill": {
-     "duration": 0.025838,
-     "end_time": "2026-06-10T14:02:24.512487",
+     "duration": 0.012152,
+     "end_time": "2026-06-16T22:36:03.801199+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.486649",
+     "start_time": "2026-06-16T22:36:03.789047+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1870,10 +2040,10 @@
    "id": "1266c022",
    "metadata": {
     "papermill": {
-     "duration": 0.006513,
-     "end_time": "2026-06-10T14:02:24.527262",
+     "duration": 0.005405,
+     "end_time": "2026-06-16T22:36:03.812329+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.520749",
+     "start_time": "2026-06-16T22:36:03.806924+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1897,10 +2067,10 @@
    "id": "e767a280",
    "metadata": {
     "papermill": {
-     "duration": 0.008152,
-     "end_time": "2026-06-10T14:02:24.544255",
+     "duration": 0.005875,
+     "end_time": "2026-06-16T22:36:03.823452+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.536103",
+     "start_time": "2026-06-16T22:36:03.817577+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1918,20 +2088,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "f2c3a922",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.562753Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.561746Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.573420Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.572791Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.836472Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.836144Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.840536Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.839874Z"
     },
     "papermill": {
-     "duration": 0.022648,
-     "end_time": "2026-06-10T14:02:24.574424",
+     "duration": 0.012142,
+     "end_time": "2026-06-16T22:36:03.841232+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.551776",
+     "start_time": "2026-06-16T22:36:03.829090+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1963,10 +2133,10 @@
    "id": "4bfff412",
    "metadata": {
     "papermill": {
-     "duration": 0.007822,
-     "end_time": "2026-06-10T14:02:24.588614",
+     "duration": 0.005688,
+     "end_time": "2026-06-16T22:36:03.852501+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.580792",
+     "start_time": "2026-06-16T22:36:03.846813+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1979,20 +2149,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "883aa023",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.606118Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.606118Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.621230Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.619660Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.864335Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.863988Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.868683Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.868049Z"
     },
     "papermill": {
-     "duration": 0.025547,
-     "end_time": "2026-06-10T14:02:24.621748",
+     "duration": 0.011648,
+     "end_time": "2026-06-16T22:36:03.869442+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.596201",
+     "start_time": "2026-06-16T22:36:03.857794+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2033,10 +2203,10 @@
    "id": "a483cb1cf590",
    "metadata": {
     "papermill": {
-     "duration": 0.008883,
-     "end_time": "2026-06-10T14:02:24.638696",
+     "duration": 0.005796,
+     "end_time": "2026-06-16T22:36:03.881063+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.629813",
+     "start_time": "2026-06-16T22:36:03.875267+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2051,20 +2221,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "a66db8dd23f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.656496Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.656496Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.667813Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.666780Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.894785Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.894431Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.898468Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.897647Z"
     },
     "papermill": {
-     "duration": 0.022875,
-     "end_time": "2026-06-10T14:02:24.668819",
+     "duration": 0.012083,
+     "end_time": "2026-06-16T22:36:03.899151+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.645944",
+     "start_time": "2026-06-16T22:36:03.887068+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2091,10 +2261,10 @@
    "id": "ec85b3dd",
    "metadata": {
     "papermill": {
-     "duration": 0.008292,
-     "end_time": "2026-06-10T14:02:24.685289",
+     "duration": 0.005587,
+     "end_time": "2026-06-16T22:36:03.910675+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.676997",
+     "start_time": "2026-06-16T22:36:03.905088+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2116,10 +2286,10 @@
    "id": "b7e4d1a9",
    "metadata": {
     "papermill": {
-     "duration": 0.007526,
-     "end_time": "2026-06-10T14:02:24.700320",
+     "duration": 0.005443,
+     "end_time": "2026-06-16T22:36:03.921796+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.692794",
+     "start_time": "2026-06-16T22:36:03.916353+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2141,10 +2311,10 @@
    "id": "8c843445",
    "metadata": {
     "papermill": {
-     "duration": 0.008911,
-     "end_time": "2026-06-10T14:02:24.717517",
+     "duration": 0.005,
+     "end_time": "2026-06-16T22:36:03.931929+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.708606",
+     "start_time": "2026-06-16T22:36:03.926929+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2159,20 +2329,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "ef84c058",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:24.734456Z",
-     "iopub.status.busy": "2026-06-10T14:02:24.734456Z",
-     "iopub.status.idle": "2026-06-10T14:02:24.747474Z",
-     "shell.execute_reply": "2026-06-10T14:02:24.746471Z"
+     "iopub.execute_input": "2026-06-16T22:36:03.943864Z",
+     "iopub.status.busy": "2026-06-16T22:36:03.943637Z",
+     "iopub.status.idle": "2026-06-16T22:36:03.947185Z",
+     "shell.execute_reply": "2026-06-16T22:36:03.946539Z"
     },
     "papermill": {
-     "duration": 0.023945,
-     "end_time": "2026-06-10T14:02:24.748476",
+     "duration": 0.010746,
+     "end_time": "2026-06-16T22:36:03.947959+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.724531",
+     "start_time": "2026-06-16T22:36:03.937213+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2182,14 +2352,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "Exercice a completer\n"
      ]
     }
    ],
@@ -2214,13 +2377,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e6380160",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005294,
+     "end_time": "2026-06-16T22:36:03.959006+00:00",
+     "exception": false,
+     "start_time": "2026-06-16T22:36:03.953712+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 6 : Les quatre operations et la tension Occam vs consistance\n",
+    "\n",
+    "Repondez aux questions suivantes en vous appuyant sur le tableau des 4 operations (section 3)\n",
+    "et la discussion rasoir d'Occam / MDL (section 9). Pour chaque reponse, identifiez le mecanisme\n",
+    "en jeu, puis sa consequence pratique --- comme dans l'exemple guide de reflexion ci-dessus.\n",
+    "\n",
+    "| Question | Reponse |\n",
+    "|----------|--------|\n",
+    "| La section 5 montre qu'ajouter la condition `Hungry=Yes` (specialiser par conjonction) ne suffit pas a rendre une conjonction consistante. Selon le tableau des 4 operations (section 3), a quel sens de la specialisation correspond cet ajout, et pourquoi cet echec pousse-t-il a recourir a l'autre sens (generaliser par disjonction, `add_or`) ? | _(a completer)_ |\n",
+    "| Un etudiant propose d'eliminer toute erreur en ajoutant une exception (une disjonction) pour CHAQUE exemple positif mal classe. Quel est le cout de cette strategie au sens du rasoir d'Occam (MDL) ? A partir de quand devient-elle neanmoins la seule option acceptable ? | _(a completer)_ |\n",
+    "| CBH (section 4) et le Version Space (section 5) n'implantent aucun biais de simplicite. Donnez une situation concrete (sur le domaine du restaurant ou un autre) ou cela conduit a retenir une hypothese manifestement trop longue, et expliquez pourquoi FOIL (AIMA 19.5) l'eviterait. | _(a completer)_ |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a464171c",
    "metadata": {
     "papermill": {
-     "duration": 0.008523,
-     "end_time": "2026-06-10T14:02:24.766014",
+     "duration": 0.005499,
+     "end_time": "2026-06-16T22:36:03.970155+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.757491",
+     "start_time": "2026-06-16T22:36:03.964656+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2238,6 +2428,8 @@
     "| **Consistance** | Pas de faux positifs ni de faux negatifs |\n",
     "| **Generalisation** | Remplacer une contrainte par `?` (couvrir plus) |\n",
     "| **Specialisation** | Remplacer `?` par une valeur (couvrir moins) |\n",
+    "| **Generalisation/Specialisation : 2 sens** | Chaque direction admet une operation qui **reduit** l'enonce et une qui l'**augmente** (exception positive par disjonction, negative par conjonction) |\n",
+    "| **Rasoir d'Occam (MDL)** | Parmi les hypotheses consistantes, preferer la plus simple ; **minimiser** les exceptions (cf. FOIL, AIMA 19.5), non les interdire |\n",
     "| **CBH** | Maintient une seule hypothese, ajustee incrementalement |\n",
     "| **Version Space** | Maintient G-set et S-set, represente toutes les hypotheses consistantes |\n",
     "| **Candidate Elimination** | Algorithme pour mettre a jour G et S efficacement |\n",
@@ -2250,7 +2442,7 @@
     "| Ordre-dependance | Oui | Non |\n",
     "| Backtracking | Possible | Jamais |\n",
     "| Bruit | Robuste (peut revenir) | Fragile (VS vide) |\n",
-    "| Complexite memoire | O(1) | O(|G| + |S|) |\n"
+    "| Complexite memoire | O(1) | O(|G| + |S|) |"
    ]
   },
   {
@@ -2258,10 +2450,10 @@
    "id": "410e5149",
    "metadata": {
     "papermill": {
-     "duration": 0.007513,
-     "end_time": "2026-06-10T14:02:24.782546",
+     "duration": 0.007305,
+     "end_time": "2026-06-16T22:36:03.983170+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.775033",
+     "start_time": "2026-06-16T22:36:03.975865+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2281,10 +2473,10 @@
    "id": "315ebc46",
    "metadata": {
     "papermill": {
-     "duration": 0.00952,
-     "end_time": "2026-06-10T14:02:24.799099",
+     "duration": 0.006004,
+     "end_time": "2026-06-16T22:36:03.995192+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.789579",
+     "start_time": "2026-06-16T22:36:03.989188+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2305,7 +2497,8 @@
     "| **Ex. 2 (Version Space, sous-ensemble)** | Sur votre sous-ensemble, identifiez l'exemple dont l'ajout reduit le plus le Version Space. Qu'est-ce qui rend un exemple *informatif* (raisonnez avec les frontieres S et G) ? |\n",
     "| **Ex. 3 (regles avec couverture)** | Comparez vos regles a l'hypothese disjonctive AIMA de la section 9 : laquelle est la plus compacte ? Quel biais (rasoir d'Occam) ferait preferer l'une a l'autre, et lequel des deux algorithmes l'implemente ? |\n",
     "| **Ex. 4 (reflexion)** | Donnez un domaine concret ou le biais conjonctif de ce notebook est le bon choix, et un ou il est catastrophique. Reliez votre reponse au theoreme *no free lunch*. |\n",
-    "| **Ex. 5 (consistance sans Occam)** | La section 8 prouve qu'aucune conjonction unique n'est consistante : la borne inferieure est donc 2 disjonctions. Votre echantillonnage de graines l'atteint-il ? Pourquoi un echantillonnage ne prouve jamais la minimalite, et quel type d'algorithme (exact, a la Popper de SL-4) fournirait ce certificat ? |\n"
+    "| **Ex. 5 (consistance sans Occam)** | La section 8 prouve qu'aucune conjonction unique n'est consistante : la borne inferieure est donc 2 disjonctions. Votre echantillonnage de graines l'atteint-il ? Pourquoi un echantillonnage ne prouve jamais la minimalite, et quel type d'algorithme (exact, a la Popper de SL-4) fournirait ce certificat ? |\n",
+    "| **Ex. 6 (4 operations et tension Occam)** | Parmi les 4 operations du tableau de la section 3, lesquelles CBH (section 4) sait-il effectivement realiser avec sa representation conjonctive, et lesquelles lui sont interdites (d'ou son effondrement en section 5) ? Illustrez avec un exemple du restaurant ou la seule operation capable de restaurer la consistance est une croissance de l'enonce (une exception), et justifiez pourquoi le rasoir d'Occam l'accepte tout de meme. |"
    ]
   },
   {
@@ -2313,10 +2506,10 @@
    "id": "902a1f86",
    "metadata": {
     "papermill": {
-     "duration": 0.008518,
-     "end_time": "2026-06-10T14:02:24.815631",
+     "duration": 0.005959,
+     "end_time": "2026-06-16T22:36:04.007228+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:24.807113",
+     "start_time": "2026-06-16T22:36:04.001269+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2357,18 +2550,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.824695,
-   "end_time": "2026-06-10T14:02:25.046923",
+   "duration": 2.764406,
+   "end_time": "2026-06-16T22:36:04.243201+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SL-1-LogicalLearning.ipynb",
-   "output_path": "SL-1-LogicalLearning.ipynb",
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-1-LogicalLearning.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-1-LogicalLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T14:02:22.222228",
+   "start_time": "2026-06-16T22:36:01.478795+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Contexte

Sur signalement user (issue #3159) : `SL-1-LogicalLearning.ipynb` presentait generaliser et specialiser chacune comme **une seule operation**, alors que le cours IAMA souligne que **chaque direction a deux sens** (l'un augmente la taille de l'enonce, l'autre la reduit), qu'une **metrique penalise la croissance abusive** (rasoir d'Occam / MDL) et recommande de **recommencer les reductions**, et que **parfois l'exception est la seule voie vers la consistance**. Ce narratif etait absent. Le present PR le tisse a travers les sections 3, 5 et 9.

## Livrable (enrichissement atomique d'un seul notebook, pas de nouveau fichier)

| Emplacement | Ajout |
|-------------|-------|
| **Section 3** (apres interpretation generaliser/specialiser) | Cellule conceptuelle : les **4 operations** (reduit/augmente x generaliser/specialiser), exception positive par disjonction / negative par conjonction ; anticipation que les operations disjonctives apparaissent en section 9. |
| **Section 9** (apres interpretation `add_or`) | Markdown « Complexite de l'enonce, rasoir d'Occam et MDL » (cout d'une exception, recommencer les reductions via FOIL 19.5/SL-4, caveat exception parfois inevitable appuye sur section 5 + section 9) + cellule code `statement_size` (metrique conjonctive + disjonctive). |
| **Exercice 6** (apres Ex5) | Reflexion sur les 4 operations et la tension Occam vs consistance (distinct de Ex5 = echantillonnage metrique). |
| **Section 11 resume** | 2 lignes : « Generalisation/Specialisation : 2 sens » + « Rasoir d'Occam (MDL) ». |
| **Defi presentation** | Twist Ex.6 (quelles operations CBH sait-il faire, lesquelles lui sont interdites, exemple ou la croissance est la seule voie). |

## Preuves de validation (regle H / pr-review-discipline D)

- **Papermill SUCCESS** (`notebook_tools.py execute`, kernel `python3`, 4.7s, 0 erreur).
- **C.2** : 16/16 cellules code avec `execution_count` non-null et outputs coherents.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **Output de la nouvelle cellule metrique** (deterministe, graine 42) :
  - CBH (section 4) : `statement_size = 1 condition` (Hungry=Yes) — CBH garde la 1re consistante, aucun rasoir.
  - AIMA (section 9) : `5 disjonctions / 28 conditions` — croissance abusive ; Occam chercherait la plus compacte.
- **C.3** : seul `SL-1-LogicalLearning.ipynb` est committe (source modifiee -> re-exec requise). Aucun autre notebook, aucun catalogue, submodule openzeppelin non-stage.
- **Anti-regression** : aucun contenu existant supprime ; 11 sections intactes, 6 exercices (5 -> 6), 52 cellules. Insertions > deletions (le diff apparent eleve = re-serialization Papermill de tout le notebook, exigee par C.2).

## Style

Le notebook existant est uniformement sans accents francais (convention ancienne). Les nouvelles cellules **matchent ce style** pour la coherence intra-fichier (pas de mix accentue/non-accentue dans le meme notebook).

Closes #3159
