### PR TITLE
feat(knot): prove tricolorable_backward num case via wf parity

### DIFF
--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -12,7 +12,7 @@ name: Lean Knot CI
 #
 # Uses the shared lean-build.yml reusable workflow.
 #
-# Sorry profile (verified 2026-06-15, prose-header mode, baseline=28):
+# Sorry profile (verified 2026-06-17, prose-header mode, baseline=27):
 # knot_lean's real sorries are INLINE (`exact sorry`, `:= sorry`,
 # `sorry -- comment`), never bare `sorry` on its own line. The standalone-tactic
 # filter (`^\s*sorry\s*$`) counts 0 here and would catch no regression, so we
@@ -20,12 +20,12 @@ name: Lean Knot CI
 # real sorry and fails on any addition. Breakdown of the 25:
 #   - Basic.lean:                1 (prose: TODO comment on well-formedness)
 #   - Reidemeister.lean:         2 (reidemeister_theorem ×2 — PL topology, OOS)
-#   - Invariant.lean:            7 (tricolorable_invariant, trefoil_not_unknot,
-#                                  unknottingNumber + prose; +3 from the PARTIAL
+#   - Invariant.lean:            6 (tricolorable_invariant, trefoil_not_unknot,
+#                                  unknottingNumber + prose; +2 from the PARTIAL
 #                                  `tricolorable_backward` transfer — Epic #2874
-#                                  PR3: colour-preservation proven, 3 residual
-#                                  tactic sorries on the Fox-transfer assembly,
-#                                  user-authorised, ai-01 to advise)
+#                                  PR3: colour-preservation proven, `num` PROVEN
+#                                  by wf parity (numEdges ≥ 2 from length ≥ 2);
+#                                  2 residual tactic sorries fox/col, user-authorised)
 #   - Conway.lean:              11 (Conway knot 11n34, Kinoshita-Terasaka,
 #                                  mutation — scaffolding)
 #   - Lidman.lean:               5 (11n102 unknotting number = 2 — Heegaard-Floer)
@@ -55,5 +55,5 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean
       display-name: knot_lean
-      sorry-baseline: "28"
+      sorry-baseline: "27"
       sorry-filter-mode: prose-header

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -1175,11 +1175,65 @@ theorem Reidemeister1Connected.tricolorable_backward {d₁ d₂ : KnotDiagram}
     --     [1, 0] = ∅ — impossible.
     --   * numEdges = 1: a single crossing contributes 4 slots, each forced to
     --     label 1, so `edges.count 1 = 4 ≠ 2` — parity (b) fails.
-    -- Therefore numEdges ∉ {0, 1}, i.e. ≥ 2. Mechanical, BUT requires unfolding
-    -- the Bool-valued `wf` (`decide` / `List.range.all` / `edges.count` /
-    -- `List.flatMap`) over an ABSTRACT `d₁`, so `decide` cannot close it — it
-    -- is the natural mate of the Fox-transfer assembly and is left for ai-01.
-    sorry
+    -- PROVEN: `_hproper` ⟹ two distinct `Fin crossings.length` indices `i ≠ j`
+    -- ⟹ `crossings.length ≥ 2`, so `d₁` is non-degenerate and `wf` takes its
+    -- parity branch. `edges.length = 4·crossings.length` (4 slots/crossing);
+    -- parity (a)+(b) force `2·numEdges = edges.length`, hence `numEdges ≥ 4`.
+    obtain ⟨j, hjne, _⟩ := _hproper
+    have hlen2 : 2 ≤ d₁.crossings.length := by
+      by_contra h
+      have hi : i.val = 0 := by omega
+      have hj : j.val = 0 := by omega
+      exact hjne (Fin.ext (hj.trans hi.symm))
+    have hne : d₁.crossings ≠ [] := by
+      intro he; rw [he] at hlen2; simp at hlen2
+    have hwf := _hwf₁
+    simp only [KnotDiagram.wf, if_neg hne, Bool.and_eq_true] at hwf
+    obtain ⟨ha_all, hb_all⟩ := hwf
+    have hedges_len : d₁.edges.length = 4 * d₁.crossings.length := by
+      have H : ∀ (cs : List PDCrossing),
+          (cs.flatMap fun c => [c.e1, c.e2, c.e3, c.e4] : List Nat).length =
+            4 * cs.length := by
+        intro cs; induction cs with
+        | nil => rfl
+        | cons c cs' ih =>
+          simp only [List.flatMap_cons, List.length_append, List.length_cons,
+            List.length_nil, ih]; omega
+      simp only [KnotDiagram.edges]; exact H d₁.crossings
+    by_contra hne2
+    -- `d₁.edges ≠ []`: length = 4·crossings.length ≥ 8 > 0.
+    have hedges_ne : d₁.edges ≠ [] := by
+      intro h0; rw [h0, List.length_nil] at hedges_len; omega
+    obtain ⟨l0, hl0⟩ := List.exists_mem_of_ne_nil d₁.edges hedges_ne
+    rw [List.all_eq_true] at ha_all hb_all
+    -- Clause (a) at `l0 ∈ edges` forces `1 ≤ l0 ≤ numEdges`, so `numEdges ≥ 1`;
+    -- with `hne2` (`numEdges ≤ 1`), `numEdges = 1`.
+    have ha_l0 : 1 ≤ l0 ∧ l0 ≤ d₁.numEdges := by
+      simpa using ha_all l0 hl0
+    have hne1 : d₁.numEdges = 1 := by omega
+    -- Clause (b) at `i = 0`: `edges.count 1 = 2`.
+    have hb1 : d₁.edges.count 1 = 2 := by
+      have h0mem : (0 : ℕ) ∈ List.range d₁.numEdges := by
+        rw [List.mem_range]; omega
+      have h := hb_all 0 h0mem; simpa using h
+    -- Clause (a) (numEdges = 1) forces every edge = 1, so `count 1 = length`.
+    have hall1 : ∀ e ∈ d₁.edges, e = 1 := by
+      intro e he
+      have h : 1 ≤ e ∧ e ≤ d₁.numEdges := by simpa using ha_all e he
+      omega
+    have hcount1 : d₁.edges.count 1 = d₁.edges.length := by
+      have H : ∀ (l : List Nat), (∀ e ∈ l, e = 1) → l.count 1 = l.length := by
+        intro l hl
+        induction l with
+        | nil => rfl
+        | cons hd tl ih =>
+          obtain rfl : hd = 1 := hl hd List.mem_cons_self
+          rw [List.count_cons, List.length_cons, if_pos (by decide)]
+          have := ih (fun e he => hl e (List.mem_cons_of_mem _ he))
+          omega
+      exact H d₁.edges hall1
+    -- `4·crossings.length = count 1 = 2` contradicts `crossings.length ≥ 2`.
+    rw [hcount1, hedges_len] at hb1; omega
   case col =>
     -- ≥ 2 colours under col₁: under the all-equal kink mode the two distinct
     -- colours of col₂ embed into Fin d₁.numEdges (the fresh edges duplicate

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
@@ -5,7 +5,7 @@ avec sorry stratégiques commentés (références papier + prérequis Mathlib).
 
 Epic #2874 (Phase 5 en cours). Toolchain `v4.31.0-rc1`.
 
-## État des sorries (vérifié 2026-06-16, 19 réels — 16 + 3 du transfer backward PARTIEL #3124)
+## État des sorries (vérifié 2026-06-17, 18 réels — 16 + 2 du transfer backward PARTIEL #3124, `num` prouvé)
 
 Deux comptes, selon le filtre :
 
@@ -13,18 +13,19 @@ Deux comptes, selon le filtre :
 |---------|------------|-------------------|
 | `Knots/Basic.lean` | 0 | 1 |
 | `Knots/Reidemeister.lean` | 2 | 2 |
-| `Knots/Invariant.lean` | 6 | 7 |
+| `Knots/Invariant.lean` | 5 | 6 |
 | `Knots/Conway.lean` | 8 | 11 |
 | `Knots/Lidman.lean` | 3 | 5 |
 | `Knots/MathlibPrerequisites.lean` | 0 | 2 |
-| **Total** | **19** | **28** |
+| **Total** | **18** | **27** |
 
 - **sorry réels** (`exact sorry`, `:= sorry`, `:= by sorry`) = ce qui manque
-  vraiment comme preuve. **19** au total — 16 stables + **3 du transfer backward
-  PARTIEL `tricolorable_backward` (#3124)** : sous-buts `fox`/`num`/`col`
-  laissés en sorry après décomposition (cœur `hcolPres` prouvé, cf. § Phase 5).
+  vraiment comme preuve. **18** au total — 16 stables + **2 du transfer backward
+  PARTIEL `tricolorable_backward` (#3124)** : sous-buts `fox`/`col` laissés en
+  sorry après décomposition (`num` PROUVÉ par parité `wf`, cf. § Phase 5 ;
+  cœur `hcolPres` prouvé).
 - **sorry prose** (toute ligne contenant `sorry`, filtre CI `prose-header`) =
-  **baseline CI 28** (workflow `lean-knot.yml`). Ce compte inclut les
+  **baseline CI 27** (workflow `lean-knot.yml`, baissé de 28 après preuve `num`). Ce compte inclut les
   occurrences dans les commentaires de diagnostic (ex. le commentaire sur
   `KnotDiagram.wf` dans `Basic.lean`).
 
@@ -48,7 +49,7 @@ sauf justification documentée dans le body PR.
   réfutant `tricolorable_invariant` sous le modèle PR1 (diagnostic, cf. § Phase 5)
 - [x] `trefoil_wf`, `unknot_wf`, `figureEight_wf` — les 3 diagrammes nommés satisfont la parité PD de `KnotDiagram.wf`
 - [x] `Reidemeister1Connected.tricolorable_forward` (#3000, MERGED) — transfer **forward** de la 3-colorabilité d₁→d₂ sous le modèle R1 connecté (`Invariant.lean` L478, preuve complète sans sorry via `hcolF1`/`hcolF2b`/`hcolF2c`)
-- [~] `Reidemeister1Connected.tricolorable_backward` (#3124, MERGED, **PARTIEL**) — transfer **backward** d₂→d₁ : `hcolPres` (préservation des couleurs sur les labels préservés, cœur constructif) **PROUVÉ** ; 3 sous-buts résiduels `fox`/`num`/`col` laissés en sorry (recherche §9.1, décomposition instruite user)
+- [~] `Reidemeister1Connected.tricolorable_backward` (#3124, MERGED, **PARTIEL**) — transfer **backward** d₂→d₁ : `hcolPres` (préservation des couleurs sur les labels préservés, cœur constructif) **PROUVÉ** ; `num` PROUVÉ (parité `wf` : `crossings.length ≥ 2 ⟹ numEdges ≥ 2`) ; 2 sous-buts résiduels `fox`/`col` restent en sorry (recherche §9.1, décomposition instruite user)
 
 ### Scaffolding (sorry, cible formelle)
 


### PR DESCRIPTION
## Summary

Proves the `num` residual sub-goal of `Reidemeister1Connected.tricolorable_backward` (#3124 PARTIAL, Epic #2874), eliminating one sorry via the `KnotDiagram.wf` parity argument.

### The proof (case `num`, `Invariant.lean` L1200–1235)

Goal: `d₁.numEdges ≥ 2`. The hypothesis `_hproper : ∃ j ≠ i, (d₁.crossings.get j).hasEdge a` gives a crossing `j ≠ i` carrying edge `a`.

1. `j ≠ i` with both `∈ Fin crossings.length` ⟹ `crossings.length ≥ 2`.
2. `crossings ≠ []` ⟹ `d₁.wf` unfolds to the parity predicate: every edge label `l` satisfies `1 ≤ l ≤ numEdges`, and each `k+1` (`k < numEdges`) appears exactly twice in `edges`.
3. `edges.length = 4 * crossings.length ≥ 8`.
4. `by_contra`: assume `numEdges < 2`. Any edge `l0 ∈ edges` has `1 ≤ l0 ≤ numEdges` ⟹ `numEdges ≥ 1` ⟹ `numEdges = 1`.
5. With `numEdges = 1`, clause (a) forces every edge `= 1`, so `count 1 = length ≥ 8`; clause (b) at `k = 0` gives `count 1 = 2`. Contradiction (`8 ≤ 2`).

## Lean PR evidence (§B pr-review-discipline)

1. **`grep` sorry** — `Knots/Invariant.lean`: **6 → 5 real** sorries (`exact sorry` / bare `sorry`; `num` eliminated). knot_lean repo real sorries: **19 → 18**.
2. **Lake build SUCCESS** — `lake build Knots.Invariant`, 317 jobs, EXIT 0 (Mathlib cache, ~13s): `Build completed successfully (317 jobs)`. Residual sorry-warnings: L112/L691/L753 (unrelated theorems), L1120 (`tricolorable_backward` decl — `fox`/`col` remain).
3. **Proof integrity** — `num` uses standard tactics only (`omega`, `simp only`, `rw`, `induction`, `decide`); no `sorryAx`, no new axioms beyond `[propext, Quot.sound]`. Does not depend on the eliminated sorry.
4. **No prover refactor** — pure proof addition; no `agent_tests/prover/` changes.

## CI baseline

`lean-knot.yml` `sorry-baseline` **28 → 27** (prose-header count drops by 1; regression floor tightened, not relaxed). Verified locally: `grep "sorry" | grep -viE "sorries|sorry.s"` across knot_lean `.lean` = 27.

## Scope

PARTIAL — eliminates `num` only. `fox` and `col` residual sub-goals of `tricolorable_backward` remain sorry (research §9.1, decomposition instructed by user). **1 of 3** backward-transfer sub-goals resolved.

See #2874
