### PR TITLE
docs(qc): PSR + inverse-vol vs ERC pedagogical section (Closes #1405)

### DIFF
--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -368,6 +368,73 @@ Standardized backtest results from QC Cloud via MCP qc-mcp-lite. Period: 2018-01
 
 **Note**: AdaptiveAssetAllocation (31781187) et MarkovRegime (31871247) n'ont produit aucune métrique (0 trades ou erreur d'exécution).
 
+### Risk Parity pedagogique : inverse-vol vs ERC, et lecture critique du PSR (See #1405)
+
+Les 4 strategies etudiantes ci-dessus sont aussi un support de cours. Cette section formalise les 3 points d'enseignement demandes par #1405 : (1) pourquoi le Sharpe seul ne suffit pas et ce que mesure le **PSR**, (2) la difference entre **inverse-volatilite naive** et **Equal Risk Contribution (ERC)**, (3) la lecture critique d'un backtest (dates hardcoded, MaxDD > 100%, fenetres non comparables).
+
+#### 1. Le PSR (Probabilistic Sharpe Ratio) — Bailey & Lopez de Prado (2012)
+
+Le ratio de Sharpe observe suppose des rendements **IID et gaussiens**. Les rendements reels violent ces deux hypotheses : ils ont en general une **asymetrie (skew) negative** (les krachs sont plus profonds que les booms ne sont hauts) et des **queues epaisses (kurtosis > 3)**. Sous ces conditions, le Sharpe empirique est **systematiquement surestime**, surtout sur de courtes fenetres.
+
+Le PSR corrige en estimant la probabilite que le vrai Sharpe depasse un seuil de reference `SR0` (souvent 0, le hasard) :
+
+```text
+                     (SR_hat - SR0) * sqrt(T - 1)
+   PSR(SR0) = Phi( ------------------------------------ )
+                  sqrt( 1 - skew*SR_hat + (kurt-1)/4 * SR_hat^2 )
+```
+
+ou `T` = nombre d'annees d'observation (quand `SR_hat` est annualise), `skew` et `kurt` sont les moments empiriques des rendements, et `Phi` = fonction de repartition de la loi normale centree.
+
+**Lecture** : asymetrie negative et exces de kurtosis (kurt > 3) **gonflent le denominateur**, donc abaissent le PSR. Un meme Sharpe nominal peut donner un PSR tres different selon la distribution des rendements. Regle pratique : **PSR > 50%** = l'edge observe a plus de chances d'etre reel que d'etre du bruit ; **PSR < 50%** = on ne peut pas ecarter le bruit.
+
+**Applique aux 4 strategies etudiantes** :
+
+| Strategie | Sharpe | PSR% | Lecture |
+|-----------|--------|------|---------|
+| DualMomentum | 0.493 | **54.9** | Edge a la limite de la significativite (juste au-dessus de 50%). Fenetre courte (2 ans) => estimation des moments bruitee, a confirmer sur une periode plus longue. |
+| RiskParity inverse-vol | 0.514 | 16.3 | Sharpe plus haut mais PSR faible : sur 10 ans, l'edge moyen est reel mais **statistiquement peu concluant** (estimation robuste d'un edge faible). |
+| ValueFactor | 0.227 | 0.8 | Quasi-zero : l'alpha observe est indistinguable du bruit. Confirme l'effondrement du facteur value sur une decennie dominee par la growth. |
+| OptionWheel | -0.51 | 0.0 | Aucun edge. La probabilite d'un vrai Sharpe positif est nulle. |
+
+**Contraste cle** : Sharpe et PSR ne classent pas pareil. RiskParity bat DualMomentum en Sharpe (0.514 > 0.493) mais DualMomentum le bat largement en PSR (54.9 > 16.3). Le PSR est la statistique a citer, pas le Sharpe brut — premiere lecon de lecture critique.
+
+#### 2. inverse-volatilite naive vs Equal Risk Contribution (ERC)
+
+Le `RiskParity inverse-vol` etudiant n'implemente pas du "vrai" risk parity. Deux familles distinctes :
+
+**inverse-volatilite (naive)** — ce que fait l'etudiant :
+
+```text
+   poids_i  proportionnel a  1 / sigma_i
+```
+Chaque actif recoit un poids inverse a sa volatilite **individuelle**. Methode simple, une seule donnee par actif, mais elle **ignore les correlations**.
+
+**Equal Risk Contribution (ERC)** — Maillard, Roncalli & Teiletche (2010), le "vrai" risk parity :
+
+```text
+   chaque actif i contribue EGALEMENT au risque total :
+   (Sigma * w)_i / (w' * Sigma * w)  =  constant   pour tout i
+```
+ou `Sigma` est la **matrice de covariance** complete (correlations incluses). Resolution par programmation convexe (QP / Newton-Lagrange), sans solution analytique en general.
+
+**Pourquoi la difference compte** : avec l'inverse-vol naive, deux actifs **fortement correles** (ex. deux ETF actions US) reçoivent chacun un budget de risque eleve, donc le portefeuille reste **concentre sur un meme facteur** — faussement "diversifie". L'ERC, en integrant la covariance, **force une vraie diversification** : deux actifs correles se partagent un meme budget de risque cumule, pas deux budgets independants.
+
+**Pedagogique** : le `RiskParity inverse-vol` (Sharpe 0.514, PSR 16.3%) est un **bon point d'entree** — simple, robuste, peu de parametres. L'upgrade naturel est l'**ERC** (gestion des correlations via la matrice de covariance). Le saut conceptuel : passer de "donner moins de poids au plus volatile" (1D) a "egaliser la contribution marginale au risque" (matricielle, multidimensionnelle).
+
+#### 3. Lecture critique d'un backtest — les pieges visibles dans la table ci-dessus
+
+- **Dates de debut hardcoded** (`*` sur les 4) : les fenetres ne sont **pas aligned** avec le reste du catalogue (2018-2025). Les metriques ne sont pas directement comparables — comparer le Sharpe d'un DualMomentum 2023-2025 a un TrendFollowing 2018-2025 est abusif.
+- **MaxDD > 100% (OptionWheel, 103.5%)** : un drawdown superieur a 100% signale une vente d'options **naked non couverte** integrale — le simulateur ne capture pas parfaitement l'assignation / liquidation forcee. Le backtest est probablement **optimiste** sur la perte reelle.
+- **Croiser PSR et duree** : un PSR de 54.9% sur 2 ans (DualMomentum) n'a pas le meme poids qu'un PSR de 81.8% sur 8 ans (TrendFollowing, ligne 381). La signification statistique croit avec `sqrt(T)` ; une courte fenetre a besoin d'un edge plus fort pour convaincre.
+
+#### References
+
+- Bailey, D. & Lopez de Prado, M. (2012), *"The Sharpe Ratio Efficient Frontier"*, Journal of Risk.
+- Lopez de Prado, M. (2014), *"The Deflated Sharpe Ratio"*, SSRN (extension corrigeant le biais de selection multiple).
+- Maillard, S., Roncalli, T. & Teiletche, J. (2010), *"The Properties of Equally Weighted Risk Contribution Portfolios"*, Journal of Portfolio Management.
+- Broad, J., *Hands-On AI Trading* (chap. performance / risk-adjusted metrics).
+
 ### Not alignable (hardcoded ML train/test split)
 
 | Project | QC ID | Reason | Current Period |


### PR DESCRIPTION
## Contexte

#1405 demande d'enrichir le catalogue QC depuis les projets etudiants ESGF 2026, avec deux criteres d'acceptation :
1. **Backtest reporte** (Sharpe / CAGR / MaxDD / PSR, periode) — **deja fait** : les 4 strategies (DualMomentum, RiskParity, ValueFactor, OptionWheel) sont documentees avec backtest IDs reels (`88d36544`, `d6a7bc52`, `da42c569`, `b9eca3c8`) + key findings 11-14 dans ce meme doc. Les 2 autres (AdaptiveAssetAllocation, MarkovRegime) ont produit 0 trade / erreur, documentees en note.
2. **Points d'enseignement explicites** ("pour Risk Parity : section dediee inverse-vol vs ERC + PSR") — **manquait**. Verifie G.1 : le PSR etait utilise 50+ fois comme valeur de colonne mais **jamais defini** (ni formule, ni interpretation) ; la distinction inverse-vol vs ERC etait **absente** de tout le depot (le README n'avait qu'une heuristique "PSR > 50% = significatif").

Cette PR livre le **seul critere d'acceptation restant** -> `Closes #1405`.

## Livrable (enrichissement docs-only d'un seul fichier, pas de nouveau fichier)

Nouvelle section `### Risk Parity pedagogique : inverse-vol vs ERC, et lecture critique du PSR` (apres la table des strategies etudiantes ESGF), en 3 parties :

1. **PSR (Bailey & Lopez de Prado 2012)** — pourquoi le Sharpe seul trompe (rendements non-gaussiens : skew negatif + fat tails), formule de correction (denominateur penalise par skew/kurtosis), regle pratique >50%, et **lecture appliquee aux 4 strategies** :
   - DualMomentum : PSR **54.9%** (edge a la limite de la significativite, fenetre courte 2 ans -> a confirmer)
   - RiskParity : PSR 16.3% (Sharpe plus haut 0.514 mais edge faible sur 10 ans)
   - ValueFactor : PSR 0.8% (bruit)
   - OptionWheel : PSR 0.0% (aucun edge)
   - **Contraste cle** : Sharpe et PSR ne classent pas pareil (RiskParity gagne en Sharpe, DualMomentum en PSR).
2. **inverse-vol vs ERC** — naive `1/sigma_i` (ignore les correlations) vs Equal Risk Contribution de Maillard/Roncalli/Teiletche 2010 (matrice de covariance, QP convexe). Pourquoi l'inverse-vol laisse des actifs correles sur-budgetes sur un seul facteur. Le RiskParity etudiant comme point d'entree inverse-vol, l'ERC comme upgrade.
3. **Lecture critique d'un backtest** — dates hardcoded (fenetres non-aligned), MaxDD > 100% (vente naked optimiste), croisement PSR x duree.

## Preuves

- **Anti-duplication (G.1)** : `grep -rliE "Probabilistic Sharpe Ratio|Equal Risk Contribution|Bailey.*Lopez"` -> seul le BOOK_MAPPING cite Lopez de Prado pour FracDiff (pas PSR), et le README a une heuristique d'1 ligne. Aucune section pedagogique pre-existante.
- **Diff** : 67 insertions, **0 deletions** (addition pure, anti-regression safe). 1 fichier.
- **Scope strict** : seul `docs/qc/qc-comparative-backtests.md` modifie. Pas de catalogue regenere, submodule openzeppelin non-stage.
- **Style** : matche la convention no-accents francais du doc existant ("periode", "strategie", "decennie").
- **Markdown hygiene** : fences avec language hint `text` (matche les 2 fences `python` existants), blank lines autour des fences.

## Note pour le reviewer

- `docs/qc/qc-comparative-backtests.md` est **edite a la main** (catalogue QC de reference), pas un artefact genere -> edition directe OK (cf .claude/rules/catalog-pr-hygiene : la regle "ne jamais regen" vise `COURSE_CATALOG.generated.*`, pas ce doc).
- La formule PSR est celle canonique de Bailey & Lopez de Prado (2012), *The Sharpe Ratio Efficient Frontier*. Les metriques citees proviennent de la table de-ligne 364-367 (deja validee en cycles precedents).

Closes #1405
