### PR TITLE
docs(lean): #2651 Partie 2 — cooperative_games drift fix + sensitivity_lean gabarit

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
@@ -5,7 +5,7 @@ Lean 4 formalization of cooperative game theory (Shapley value, core).
 ## Status
 
 - **Toolchain**: v4.30.0-rc2
-- **Sorry count**: 1 production (`Basic.lean` L309, `bondareva_shapley_forward.hCore`, tagged `INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION`)
+- **Sorry count**: 1 production (`Basic.lean` L312, `bondareva_shapley_forward.hCore`, tagged `INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION`)
 - **Build**: `lake build CooperativeGames` -- SUCCESS
 - **Dependencies**: Mathlib4
 
@@ -20,10 +20,10 @@ Lean 4 formalization of cooperative game theory (Shapley value, core).
 
 - **Shapley value uniqueness**: Proved that the Shapley value is the unique value satisfying efficiency, symmetry, null player, and additivity axioms (Shapley.lean, 0 sorry)
 - **Core definitions**: Cooperative game, characteristic function, player set, Core (Basic.lean)
-- **Bondareva-Shapley `←` direction** (balanced ⇒ Core nonempty): all scaffolding closed except the final extraction step at L309
+- **Bondareva-Shapley `←` direction** (balanced ⇒ Core nonempty): all scaffolding closed except the final extraction step at L312
 
 ## Notes
 
-- The lone `sorry` lives in `bondareva_shapley_forward.hCore` (Basic.lean L309). The proof reduces "P ⊆ {x : ∑ xᵢ ≥ v(N)}" to extracting an allocation with equality, which requires either Farkas-style hyperplane separation or a constructive minimum-existence argument over a compact convex set
+- The lone `sorry` lives in `bondareva_shapley_forward.hCore` (Basic.lean L312). The proof reduces "P ⊆ {x : ∑ xᵢ ≥ v(N)}" to extracting an allocation with equality, which requires either Farkas-style hyperplane separation or a constructive minimum-existence argument over a compact convex set
 - Mathlib4 currently lacks the hyperplane-separation lemma needed; tagged **INTRACTABLE** by the multi-agent prover until that infrastructure lands (cf [LEAN_INVENTORY.md](../LEAN_INVENTORY.md) GO/NO-GO table)
 - Related to `stable_marriage_lean/` (matching theory as cooperative game)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
@@ -1,32 +1,80 @@
-# Sensitivity Lean
+# sensitivity_lean — Sensitivity Conjecture (Huang 2019)
 
-Lean 4 formalization of the Sensitivity Theorem from Boolean function analysis.
+> Series: [`SymbolicAI/Lean`](../README.md) · [`sensitivity_lean`](./)
+
+Lean 4 formalization of the **Sensitivity Theorem** from Boolean function
+analysis — the degree bound that **resolves the Sensitivity Conjecture** (open
+since 1989/1992, settled by Hao Huang in 2019 via a four-page combinatorial
+argument).
+
+Complete mini-project: **0 sorry, 0 axiom** beyond Lean core axioms.
 
 ## Status
 
-- **Toolchain**: v4.30.0-rc2
-- **Sorry count**: 0
-- **Build**: `lake build Sensitivity` -- SUCCESS
+- **Toolchain**: `v4.30.0-rc2`
+- **Sorry**: **0** — every proof is closed
+- **Build**: `lake build Sensitivity` — SUCCESS
 - **Dependencies**: Mathlib4
+
+## What it formalizes
+
+For a Boolean function `f : {0,1}^n → {0,1}`, three complexity measures are
+linked by the chain `s(f) ≤ bs(f) ≤ deg(f)`:
+
+- **Sensitivity** `s(f)`: the maximum, over inputs `x`, of the number of
+  coordinates `i` whose flip `x ⊕ eᵢ` changes `f(x)`.
+- **Block sensitivity** `bs(f)`: the maximum number of *disjoint* blocks of
+  coordinates that can each individually flip `f`.
+- **Degree** `deg(f)`: the degree of `f` as a real multilinear polynomial.
+
+The **Sensitivity Conjecture** (Nisan–Szegedy 1992, refining Wegener 1989 and
+Cook et al. 1986) asked whether `bs(f)` is polynomially bounded in `s(f)`. Huang
+(2019) settled it positively by proving the degree theorem: **every induced
+subgraph of the `n`-cube on more than half its vertices has a vertex of degree
+`≥ √n`** (`huang_degree_theorem`, `MainTheorem.lean` L84). The corollary is the
+quadratic bound `deg(f) ≤ s(f)²`, i.e. `bs(f) ≤ s(f)²`.
+
+The proof hinges on a spectral argument (`exists_eigenvalue`, L51): a signed
+adjacency matrix `Aₙ` of the hypercube has eigenvalue `√n`, and Cauchy's
+interlacing theorem forces a high-degree vertex in any large induced subgraph.
 
 ## Modules
 
-| File | sorry | Description |
-|------|-------|-------------|
-| `Sensitivity.lean` | 0 | Root import file |
-| `Sensitivity/Hypercube.lean` | 0 | Boolean hypercube definitions |
-| `Sensitivity/MainTheorem.lean` | 0 | Sensitivity theorem statement and proof |
-| `Sensitivity/Operator.lean` | 0 | Sensitivity operator definitions |
-| `Sensitivity/VectorSpace.lean` | 0 | Vector space structure for Boolean functions |
+| File | Lines | sorry | Content |
+|------|------:|------:|---------|
+| `Sensitivity.lean` | 1 | 0 | Root import umbrella |
+| `Sensitivity/Hypercube.lean` | 124 | 0 | Boolean hypercube `Q n`, vertices, adjacency |
+| `Sensitivity/VectorSpace.lean` | 132 | 0 | Real vector space of Boolean functions, `ℝ^{2^n}` basis |
+| `Sensitivity/Operator.lean` | 100 | 0 | Sensitivity and block-sensitivity operators |
+| `Sensitivity/MainTheorem.lean` | 131 | 0 | `exists_eigenvalue` (L51), `huang_degree_theorem` (L84) |
 
-## Key Results
+## Key results
 
-- **COMPLETE**: All proofs done, 0 sorry
-- Formalization of the **Huang degree theorem** (Huang 2019, `huang_degree_theorem` in `MainTheorem.lean`): an induced subgraph of the hypercube on more than half its vertices has a vertex of degree `>= sqrt(n)` -- the combinatorial result that resolves the Sensitivity Conjecture (`deg(f) <= s(f)^2`)
-- Boolean hypercube structure
-- Sensitivity and block sensitivity operators
+- **`huang_degree_theorem`** (`MainTheorem.lean` L84) — the main result: for
+  `H : Set (Q m.succ)` with `Card H ≥ 2^m + 1` (more than half the `2^{m+1}`
+  vertices of `Q_{m+1}`), `H` contains a vertex of degree `≥ √(m+1)`.
+- **`exists_eigenvalue`** (`MainTheorem.lean` L51) — the spectral lemma feeding
+  the degree theorem.
+- Complete hypercube + vector-space + operator infrastructure (0 sorry).
 
 ## Notes
 
-- The Sensitivity Theorem was conjectured by Nisan and Szegedy (1992) and proved by Huang (2019)
-- Part of the SymbolicAI/Lean formalization series
+- The Sensitivity Conjecture was posed by Nisan and Szegedy (1992) and resolved
+  by Hao Huang (*Induced subgraphs of hypercubes and a proof of the Sensitivity
+  Conjecture*, Annals of Mathematics 190(3), 2019).
+- Part of the [`SymbolicAI/Lean`](../README.md) formalization series.
+
+## Build
+
+```bash
+# From this directory (WSL recommended for lake on Windows)
+lake build Sensitivity
+```
+
+## See also
+
+- **[`SymbolicAI/Lean`](../README.md)** — parent series index
+- Huang (2019), *Induced subgraphs of hypercubes and a proof of the Sensitivity
+  Conjecture*, Ann. Math. 190(3).
+- Nisan & Szegedy (1992), *On the degree of Boolean functions as real
+  polynomials*, DIMACS.


### PR DESCRIPTION
## Summary

Two Lean-series README hygiene fixes bundled (clears §E by grouping — a solo <50-line docs PR would be refused; together they form one coherent Lean-series README-accuracy/gabarit unit).

### 1. `cooperative_games_lean/README.md` — sorry line-drift fix (accuracy bug)

The README cited the lone `sorry` at `Basic.lean` **L309** in three places (Status, Key Results, Notes). **Verified against source (G.1)**: the `sorry` is actually at **L312** (`hCore` block starts L300, `sorry` at L312). Fixed L309 → L312 (×3). Pure accuracy fix, no content change.

```
$ grep -n '\bsorry\b' CooperativeGames/Basic.lean
312:      sorry
```

### 2. `sensitivity_lean/README.md` — gabarit enrichment (stub → sibling parity)

The README was a 32-line stub — less than half the size of its sibling COMPLETE-formalization READMEs (`finiteness` 82l, `gittins` 83l, `conway_cgt` 91l). Enriched to 80 lines against `docs/reference/readme-series-gabarit.md`:

- **Nav parent bar** (anti-pattern 5) — `SymbolicAI/Lean` series pointer.
- **"What it formalizes"** — substantive math context (not padding): the `s(f) ≤ bs(f) ≤ deg(f)` chain, what sensitivity/block-sensitivity/degree mean, the Nisan–Szegedy (1992) Sensitivity Conjecture, and Huang's (2019) resolution via the degree theorem + spectral argument.
- **Modules table** — accurate per-file line counts (Hypercube 124 / VectorSpace 132 / Operator 100 / MainTheorem 131) + real theorem names (`huang_degree_theorem` L84, `exists_eigenvalue` L51), **verified against source**:
  ```
  $ grep -nE 'theorem ' Sensitivity/MainTheorem.lean
  51:theorem exists_eigenvalue ...
  84:theorem huang_degree_theorem ...
  ```
- **Build + cross-ref sections** — parity with `finiteness_lean/README.md`.

**0 sorry, 0 axiom unchanged** — no `.lean` touched.

## Verification

- **Docs-only**: no `.lean` changed → no `lake build` needed (§B Lean rule exempt; this is §E docs territory).
- **G.1 source-verified**: cooperative sorry line (L312), sensitivity theorem names + line counts (MainTheorem.lean L51/L84, module wc -l). No hallucinated references.
- **No catalogue touched** (bot-owned).

## Scope

Part of the **#2651 Partie 2** Lean-series README harmonization (po-2026 partition; po-2025 did Probas #3162, po-2024 did Search #3148). `See #2651` (Epic OPEN).

See #2651
