### PR TITLE
docs(ml,sudoku): harmonize ML family + Sudoku READMEs to series gabarit (#2651 Partie 2)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/README.md
@@ -1,5 +1,7 @@
 # AgenticDataScience - Agents IA pour Data Science avec Google ADK
 
+[← DataScienceWithAgents (parent)](../README.md) | [ML.NET (C#) →](../../ML.Net/README.md)
+
 Formation avancée sur les agents IA pour la Data Science, intégrant les frameworks Google ADK (DS-STAR, MLE-STAR) avec support multi-provider.
 
 ## Pourquoi cette série

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -1,5 +1,7 @@
 # DataScienceWithAgents - Data Science Python avec Agents IA
 
+[← ML (série parente)](../README.md) | [ML.NET (C#) →](../ML.Net/README.md) | [AgenticDataScience (Google ADK) →](AgenticDataScience/README.md)
+
 Formation complète en Data Science Python avec intégration d'agents IA. Combine les fondamentaux NumPy/Pandas avec deux tracks complémentaires : LangChain (3 jours) et Google ADK (4 jours).
 
 Au-delà des bibliothèques classiques, cette formation explore un changement de paradigme : passer de *l'écriture* de code data science à *l'orchestration* d'**agents LLM** qui le produisent et l'exécutent. Après les fondations NumPy/Pandas, le track **LangChain** apprend à construire des agents capables d'interroger un DataFrame, de nettoyer un jeu de données ou de scorer des candidatures ; le track **Google ADK** monte en puissance avec des systèmes multi-agents (boucles planner-coder, frameworks DS-STAR / MLE-STAR) jusqu'à concourir sur des compétitions Kaggle. L'enjeu pédagogique n'est pas seulement technique : il s'agit de comprendre *quand* un agent autonome accélère réellement le travail d'analyse, et *comment* l'encadrer (outils, validation, garde-fous).

--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -7,6 +7,8 @@ breakdown: ML.Net=8
 maturity: PRODUCTION=7, ALPHA=1
 -->
 
+[← ML (série parente)](../README.md) | [DataScienceWithAgents (Python) →](../DataScienceWithAgents/README.md) | [Probas/Infer.NET →](../../Probas/Infer/README.md)
+
 Série de notebooks couvrant ML.NET, la bibliothèque open-source de Microsoft pour le Machine Learning dans l'écosystème .NET.
 
 ML.NET apporte le machine learning **nativement dans l'écosystème .NET** : on entraîne et on consomme des modèles directement en C#, sans quitter sa stack applicative ni dépendre d'un runtime Python. C'est un choix pensé pour les développeurs autant que pour les data scientists — l'AutoML abaisse la barrière d'entrée, et les modèles s'exécutent *in-process* dans des applications existantes (API web, services, desktop). L'interopérabilité **ONNX** permet d'importer des modèles entraînés ailleurs (scikit-learn, PyTorch, Hugging Face) et de les servir côté .NET : ML.NET devient ainsi un pont concret entre la recherche en Python et la production en entreprise.
@@ -370,7 +372,3 @@ Voir la licence du repository principal.
 | [QuantConnect](../../QuantConnect/README.md) | Trading algorithmique | Les modèles de prévision de séries temporelles (ML-5) s'appliquent directement aux stratégies de trading |
 | [GenAI](../../GenAI/README.md) | IA générative | Les modèles ONNX (ML-6) servent à déployer des LLMs et modèles NLP (BERT, Whisper) via ONNX Runtime dans .NET |
 | [DataScienceWithAgents](../DataScienceWithAgents/README.md) | Python ML | Les mêmes concepts ML.NET existent en Python via scikit-learn dans le track DataScienceWithAgents |
-
-## Navigation
-
-- [<- Retour à la série ML](../README.md) | [Probas/Infer.NET ->](../../Probas/Infer/README.md) | [DataScienceWithAgents ->](../DataScienceWithAgents/README.md)

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -7,7 +7,7 @@ breakdown: DataScienceWithAgents=19, ML.Net=8
 maturity: PRODUCTION=23, BETA=3, ALPHA=1
 -->
 
-[← Notebooks](../README.md) | [↑ ..](../README.md) | [→ GenAI](../GenAI/README.md)
+[← Notebooks](../README.md) | [ML.NET (C#) →](ML.Net/README.md) | [Data Science with Agents (Python) →](DataScienceWithAgents/README.md) | [RL →](../RL/)
 
 Le monde regorge de données, mais les transformer en décisions éclairées demande plus qu'un tableur. Le Machine Learning offre un cadre systématique pour construire des modèles prédictifs à partir de données, en allant de la régression linéaire aux réseaux de neurones en passant par les systèmes de recommandation. Cette série vous forme au ML pratique avec deux stack complémentaires : **ML.NET** pour l'écosystème .NET/C# et **Python Data Science with Agents** pour les pipelines modernes enrichis de LLMs.
 
@@ -71,7 +71,7 @@ ML/
 
 ## ML.NET (C# / .NET Interactive)
 
-Série de 8 notebooks couvrant ML.NET de l'introduction à l'évaluation avancée. Vous apprendrez à construire un pipeline ML complet en C#, du chargement de données au déploiement ONNX, en passant par l'entraînement, l'AutoML, et l'évaluation rigoureuse.
+Pipeline ML.NET complet en C#, de l'introduction à l'évaluation avancée : du chargement de données au déploiement ONNX, en passant par l'entraînement, l'AutoML et l'évaluation rigoureuse.
 
 | # | Notebook | Contenu | Focus |
 |---|----------|---------|-------|
@@ -255,8 +255,3 @@ Les deux sous-séries sont indépendantes et peuvent être suivies dans n'import
 ## Licence
 
 Voir la licence du repository principal.
-
----
-
-- [← Notebooks](../README.md) | [↑ ..](../README.md) | [→ GenAI](../GenAI/README.md)
-- [ML.NET →](ML.Net/README.md) | [DataScienceWithAgents →](DataScienceWithAgents/README.md) | [RL →](../RL/)

--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -7,9 +7,9 @@ breakdown: root=32
 maturity: PRODUCTION=32
 -->
 
-Cette série de **32 notebooks** (16 C#, 16 Python) explore différentes techniques de résolution de Sudoku, des algorithmes classiques aux approches symboliques, probabilistes et neuronales. Les notebooks sont disponibles en **approche miroir C#/Python** pour permettre aux étudiants de choisir leur langage.
+[← Notebooks](../README.md) | [→ Search](../Search/README.md)
 
-[← Notebooks](../README.md) | [↑ ..](../README.md) | [→ Search](../Search/README.md)
+Comment résoudre un Sudoku ? Cette série explore les techniques de résolution, des algorithmes classiques (backtracking, contraintes) aux approches symboliques, probabilistes et neuronales. Les 32 notebooks (16 C#, 16 Python) sont proposés en **approche miroir C#/Python** pour permettre à chaque étudiant de choisir son langage.
 
 **A qui s'adresse cette série** : étudiants en informatique (L2-M2) découvrant les paradigmes algorithmiques, candidats a des entretiens techniques, et enseignants cherchant un fil rouge pédagogique. Les notebooks Python ne nécessitent que Python 3.10+. Les notebooks C# requierent .NET 9.0 + dotnet-interactive. Aucun prérequis en IA : les concepts sont introduits depuis le backtracking.
 


### PR DESCRIPTION
## Summary

#2651 **Partie 2** — README harmonization for the **.NET-CPU series** in the po-2025 partition (`ML` family + `Sudoku`), against [`docs/reference/readme-series-gabarit.md`](docs/reference/readme-series-gabarit.md). A coherent 5-file family bundle: the ML parent + its 3 children + Sudoku, all of which had real **anti-pattern 5 (navigation)** debt, plus two **anti-pattern 1 (count-led pitch)** fixes.

`See #2651` — Partie 2 (Epic OPEN). Distinct from the MGS consolidation (#3157, on HOLD per ai-01 pending user arbitration) — this PR touches only `ML/` and `Sudoku/`, no overlap with `Search/`.

## What changed

### ML family — anti-pattern 5 (navigation)
| File | Before | After |
|---|---|---|
| `ML/README` (parent) | redundant double-parent top nav (`[← Notebooks]`+`[↑ ..]` both → `../README.md`, pointed at GenAI sibling) + a duplicate bottom `Navigation` block | top nav → parent + 2 children + RL; bottom block removed (consolidated at top) |
| `ML/ML.Net/README` | legacy bottom `## Navigation` (old `<-` / `->` arrows) | moved to a top nav bar (parent + DataScienceWithAgents + Probas/Infer cross-link) |
| `ML/DataScienceWithAgents/README` | **no nav bar at all** (299-line README) | top nav bar added |
| `ML/DataScienceWithAgents/AgenticDataScience/README` | **no nav bar at all** (313-line README) | top nav bar added |

### Anti-pattern 1 (count-led pitch)
- `ML/README`: de-counted the ML.NET sub-section pitch ("Série de 8 notebooks couvrant ML.NET…" → concept-led; the count was redundant with the notebook table right below).
- `Sudoku/README`: de-counted the lead pitch ("Cette série de **32 notebooks**…" → "Comment résoudre un Sudoku ? Cette série explore…" — count demoted to a secondary clause, all content preserved).

### Sudoku/README — anti-pattern 5 (navigation)
- nav bar was sitting **after** the pitch (gabarit: nav belongs at top) → moved to top; removed the redundant `[↑ ..]` double-parent link.

## No content loss

Every deleted line is either (a) a redundant/duplicate nav bar consolidated to the top, or (b) a count-led pitch whose replacement preserves all content. The deletion audit (in the commit) confirms this. Bot-owned `CATALOG-STATUS` / `breakdown:` / `maturity:` fields **not touched**.

## Validation
- **Markdown-only** (5 `README.md` files, no `.ipynb`) → C.2 not applicable; outputs unchanged.
- 0 `raise NotImplementedError` / `assert False` introduced (C.1 respected — no code touched).
- Base fresh from `origin/main` (0 behind); atomic single-subject bundle (.NET-CPU family gabarit).

## §E note for review
23 lines across 5 files (10 ins / 13 del). Above §E's hard <20 floor; a coherent cross-series-family bundle (not "multiple READMEs sans cohérence"). Same line count as the single-file #3151 (merged) but broader family scope — addresses real navigation-absence debt on 4 READMEs that had no/minimal nav.

Co-Authored-By: Claude <noreply@anthropic.com>
