### PR TITLE
feat(sl7): resolve Ex1 as guided example + add variation exercise (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "097196f2",
    "metadata": {
     "papermill": {
-     "duration": 0.008533,
-     "end_time": "2026-06-10T14:02:44.514829",
+     "duration": 0.005783,
+     "end_time": "2026-06-17T00:53:18.762419+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.506296",
+     "start_time": "2026-06-17T00:53:18.756636+00:00",
      "status": "completed"
     },
     "tags": []
@@ -48,16 +48,16 @@
    "id": "3dc32d19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.528886Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.527887Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.538998Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.538215Z"
+     "iopub.execute_input": "2026-06-17T00:53:18.776435Z",
+     "iopub.status.busy": "2026-06-17T00:53:18.776137Z",
+     "iopub.status.idle": "2026-06-17T00:53:18.783150Z",
+     "shell.execute_reply": "2026-06-17T00:53:18.782630Z"
     },
     "papermill": {
-     "duration": 0.018683,
-     "end_time": "2026-06-10T14:02:44.540045",
+     "duration": 0.015144,
+     "end_time": "2026-06-17T00:53:18.783975+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.521362",
+     "start_time": "2026-06-17T00:53:18.768831+00:00",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "23731406",
    "metadata": {
     "papermill": {
-     "duration": 0.006871,
-     "end_time": "2026-06-10T14:02:44.553665",
+     "duration": 0.004744,
+     "end_time": "2026-06-17T00:53:18.793688+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.546794",
+     "start_time": "2026-06-17T00:53:18.788944+00:00",
      "status": "completed"
     },
     "tags": []
@@ -144,16 +144,16 @@
    "id": "f1d96718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.568602Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.568602Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.585167Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.584168Z"
+     "iopub.execute_input": "2026-06-17T00:53:18.804329Z",
+     "iopub.status.busy": "2026-06-17T00:53:18.804015Z",
+     "iopub.status.idle": "2026-06-17T00:53:18.809538Z",
+     "shell.execute_reply": "2026-06-17T00:53:18.808963Z"
     },
     "papermill": {
-     "duration": 0.025677,
-     "end_time": "2026-06-10T14:02:44.585672",
+     "duration": 0.012152,
+     "end_time": "2026-06-17T00:53:18.810263+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.559995",
+     "start_time": "2026-06-17T00:53:18.798111+00:00",
      "status": "completed"
     },
     "tags": []
@@ -236,10 +236,10 @@
    "id": "3827f67e",
    "metadata": {
     "papermill": {
-     "duration": 0.008528,
-     "end_time": "2026-06-10T14:02:44.601709",
+     "duration": 0.00466,
+     "end_time": "2026-06-17T00:53:18.819715+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.593181",
+     "start_time": "2026-06-17T00:53:18.815055+00:00",
      "status": "completed"
     },
     "tags": []
@@ -261,10 +261,10 @@
    "id": "59e172f2",
    "metadata": {
     "papermill": {
-     "duration": 0.006782,
-     "end_time": "2026-06-10T14:02:44.615574",
+     "duration": 0.004318,
+     "end_time": "2026-06-17T00:53:18.828751+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.608792",
+     "start_time": "2026-06-17T00:53:18.824433+00:00",
      "status": "completed"
     },
     "tags": []
@@ -299,16 +299,16 @@
    "id": "581df035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.632904Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.632379Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.646433Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.645928Z"
+     "iopub.execute_input": "2026-06-17T00:53:18.839298Z",
+     "iopub.status.busy": "2026-06-17T00:53:18.839089Z",
+     "iopub.status.idle": "2026-06-17T00:53:18.846099Z",
+     "shell.execute_reply": "2026-06-17T00:53:18.845326Z"
     },
     "papermill": {
-     "duration": 0.023443,
-     "end_time": "2026-06-10T14:02:44.647437",
+     "duration": 0.013336,
+     "end_time": "2026-06-17T00:53:18.846773+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.623994",
+     "start_time": "2026-06-17T00:53:18.833437+00:00",
      "status": "completed"
     },
     "tags": []
@@ -381,10 +381,10 @@
    "id": "72e21fc7",
    "metadata": {
     "papermill": {
-     "duration": 0.007052,
-     "end_time": "2026-06-10T14:02:44.658511",
+     "duration": 0.005301,
+     "end_time": "2026-06-17T00:53:18.858792+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.651459",
+     "start_time": "2026-06-17T00:53:18.853491+00:00",
      "status": "completed"
     },
     "tags": []
@@ -408,16 +408,16 @@
    "id": "eed948cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.670034Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.670034Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.678653Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.678046Z"
+     "iopub.execute_input": "2026-06-17T00:53:18.871126Z",
+     "iopub.status.busy": "2026-06-17T00:53:18.870844Z",
+     "iopub.status.idle": "2026-06-17T00:53:18.876600Z",
+     "shell.execute_reply": "2026-06-17T00:53:18.875887Z"
     },
     "papermill": {
-     "duration": 0.014638,
-     "end_time": "2026-06-10T14:02:44.679162",
+     "duration": 0.013194,
+     "end_time": "2026-06-17T00:53:18.877221+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.664524",
+     "start_time": "2026-06-17T00:53:18.864027+00:00",
      "status": "completed"
     },
     "tags": []
@@ -507,10 +507,10 @@
    "id": "85c22afd",
    "metadata": {
     "papermill": {
-     "duration": 0.004706,
-     "end_time": "2026-06-10T14:02:44.688493",
+     "duration": 0.005375,
+     "end_time": "2026-06-17T00:53:18.888264+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.683787",
+     "start_time": "2026-06-17T00:53:18.882889+00:00",
      "status": "completed"
     },
     "tags": []
@@ -529,16 +529,16 @@
    "id": "1c109513",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.704333Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.703813Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.724701Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.724196Z"
+     "iopub.execute_input": "2026-06-17T00:53:18.900624Z",
+     "iopub.status.busy": "2026-06-17T00:53:18.900396Z",
+     "iopub.status.idle": "2026-06-17T00:53:18.907957Z",
+     "shell.execute_reply": "2026-06-17T00:53:18.907236Z"
     },
     "papermill": {
-     "duration": 0.030748,
-     "end_time": "2026-06-10T14:02:44.725704",
+     "duration": 0.015276,
+     "end_time": "2026-06-17T00:53:18.908920+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.694956",
+     "start_time": "2026-06-17T00:53:18.893644+00:00",
      "status": "completed"
     },
     "tags": []
@@ -651,10 +651,10 @@
    "id": "bf930a24",
    "metadata": {
     "papermill": {
-     "duration": 0.006524,
-     "end_time": "2026-06-10T14:02:44.736226",
+     "duration": 0.005894,
+     "end_time": "2026-06-17T00:53:18.920905+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.729702",
+     "start_time": "2026-06-17T00:53:18.915011+00:00",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +685,10 @@
    "id": "d6bb9fe1",
    "metadata": {
     "papermill": {
-     "duration": 0.00575,
-     "end_time": "2026-06-10T14:02:44.747747",
+     "duration": 0.005468,
+     "end_time": "2026-06-17T00:53:18.935137+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.741997",
+     "start_time": "2026-06-17T00:53:18.929669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -715,16 +715,16 @@
    "id": "2c0873ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.762473Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.761948Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.771502Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.771502Z"
+     "iopub.execute_input": "2026-06-17T00:53:18.947197Z",
+     "iopub.status.busy": "2026-06-17T00:53:18.946970Z",
+     "iopub.status.idle": "2026-06-17T00:53:18.955623Z",
+     "shell.execute_reply": "2026-06-17T00:53:18.954914Z"
     },
     "papermill": {
-     "duration": 0.018971,
-     "end_time": "2026-06-10T14:02:44.773507",
+     "duration": 0.016025,
+     "end_time": "2026-06-17T00:53:18.956241+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.754536",
+     "start_time": "2026-06-17T00:53:18.940216+00:00",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +846,10 @@
    "id": "0f9984a1",
    "metadata": {
     "papermill": {
-     "duration": 0.007934,
-     "end_time": "2026-06-10T14:02:44.788959",
+     "duration": 0.005135,
+     "end_time": "2026-06-17T00:53:18.966658+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.781025",
+     "start_time": "2026-06-17T00:53:18.961523+00:00",
      "status": "completed"
     },
     "tags": []
@@ -882,16 +882,16 @@
    "id": "9a30e01b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.800471Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.799947Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.818511Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.817921Z"
+     "iopub.execute_input": "2026-06-17T00:53:18.978831Z",
+     "iopub.status.busy": "2026-06-17T00:53:18.978502Z",
+     "iopub.status.idle": "2026-06-17T00:53:18.984388Z",
+     "shell.execute_reply": "2026-06-17T00:53:18.983711Z"
     },
     "papermill": {
-     "duration": 0.025403,
-     "end_time": "2026-06-10T14:02:44.819570",
+     "duration": 0.013056,
+     "end_time": "2026-06-17T00:53:18.985036+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.794167",
+     "start_time": "2026-06-17T00:53:18.971980+00:00",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +974,10 @@
    "id": "74c02d03",
    "metadata": {
     "papermill": {
-     "duration": 0.004521,
-     "end_time": "2026-06-10T14:02:44.828145",
+     "duration": 0.005622,
+     "end_time": "2026-06-17T00:53:18.996533+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.823624",
+     "start_time": "2026-06-17T00:53:18.990911+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1013,16 +1013,16 @@
    "id": "83e5f5eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.838161Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.838161Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.848559Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.847962Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.008836Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.008517Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.021150Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.020204Z"
     },
     "papermill": {
-     "duration": 0.016962,
-     "end_time": "2026-06-10T14:02:44.849617",
+     "duration": 0.020049,
+     "end_time": "2026-06-17T00:53:19.021973+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.832655",
+     "start_time": "2026-06-17T00:53:19.001924+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1187,10 +1187,10 @@
    "id": "3653b321",
    "metadata": {
     "papermill": {
-     "duration": 0.005244,
-     "end_time": "2026-06-10T14:02:44.859070",
+     "duration": 0.008242,
+     "end_time": "2026-06-17T00:53:19.036031+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.853826",
+     "start_time": "2026-06-17T00:53:19.027789+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1223,16 +1223,16 @@
    "id": "dc08268f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.870098Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.869571Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.878712Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.878712Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.049750Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.049383Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.056425Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.055525Z"
     },
     "papermill": {
-     "duration": 0.016466,
-     "end_time": "2026-06-10T14:02:44.879712",
+     "duration": 0.015038,
+     "end_time": "2026-06-17T00:53:19.057140+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.863246",
+     "start_time": "2026-06-17T00:53:19.042102+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1308,10 +1308,10 @@
    "id": "a575226a",
    "metadata": {
     "papermill": {
-     "duration": 0.004843,
-     "end_time": "2026-06-10T14:02:44.889062",
+     "duration": 0.006505,
+     "end_time": "2026-06-17T00:53:19.070442+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.884219",
+     "start_time": "2026-06-17T00:53:19.063937+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1342,10 +1342,10 @@
    "id": "1bd557a0",
    "metadata": {
     "papermill": {
-     "duration": 0.005641,
-     "end_time": "2026-06-10T14:02:44.899517",
+     "duration": 0.006348,
+     "end_time": "2026-06-17T00:53:19.082984+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.893876",
+     "start_time": "2026-06-17T00:53:19.076636+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1385,16 +1385,16 @@
    "id": "f9d67f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.914944Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.914421Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.924861Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.924861Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.095410Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.095196Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.106203Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.105169Z"
     },
     "papermill": {
-     "duration": 0.020095,
-     "end_time": "2026-06-10T14:02:44.926422",
+     "duration": 0.018628,
+     "end_time": "2026-06-17T00:53:19.107100+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.906327",
+     "start_time": "2026-06-17T00:53:19.088472+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1537,10 +1537,10 @@
    "id": "2f9d2c01",
    "metadata": {
     "papermill": {
-     "duration": 0.004048,
-     "end_time": "2026-06-10T14:02:44.935780",
+     "duration": 0.008674,
+     "end_time": "2026-06-17T00:53:19.121717+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.931732",
+     "start_time": "2026-06-17T00:53:19.113043+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1569,16 +1569,16 @@
    "id": "8917b738",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.945902Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.944917Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.956904Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.955903Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.135260Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.134998Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.139143Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.138461Z"
     },
     "papermill": {
-     "duration": 0.016617,
-     "end_time": "2026-06-10T14:02:44.956904",
+     "duration": 0.012246,
+     "end_time": "2026-06-17T00:53:19.139789+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.940287",
+     "start_time": "2026-06-17T00:53:19.127543+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1626,10 +1626,10 @@
    "id": "a2edb6e2",
    "metadata": {
     "papermill": {
-     "duration": 0.005516,
-     "end_time": "2026-06-10T14:02:44.967438",
+     "duration": 0.006181,
+     "end_time": "2026-06-17T00:53:19.151902+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.961922",
+     "start_time": "2026-06-17T00:53:19.145721+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1662,16 +1662,16 @@
    "id": "54a6b7c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:44.978493Z",
-     "iopub.status.busy": "2026-06-10T14:02:44.978493Z",
-     "iopub.status.idle": "2026-06-10T14:02:44.987488Z",
-     "shell.execute_reply": "2026-06-10T14:02:44.986629Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.167672Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.167270Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.174197Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.173454Z"
     },
     "papermill": {
-     "duration": 0.01459,
-     "end_time": "2026-06-10T14:02:44.988028",
+     "duration": 0.016929,
+     "end_time": "2026-06-17T00:53:19.174905+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.973438",
+     "start_time": "2026-06-17T00:53:19.157976+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1732,10 +1732,10 @@
    "id": "d74db354",
    "metadata": {
     "papermill": {
-     "duration": 0.004185,
-     "end_time": "2026-06-10T14:02:44.996962",
+     "duration": 0.005813,
+     "end_time": "2026-06-17T00:53:19.186823+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:44.992777",
+     "start_time": "2026-06-17T00:53:19.181010+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1759,10 +1759,10 @@
    "id": "3c2e7728",
    "metadata": {
     "papermill": {
-     "duration": 0.004745,
-     "end_time": "2026-06-10T14:02:45.005867",
+     "duration": 0.006488,
+     "end_time": "2026-06-17T00:53:19.199010+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:45.001122",
+     "start_time": "2026-06-17T00:53:19.192522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1787,16 +1787,16 @@
    "id": "dada4cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:45.017515Z",
-     "iopub.status.busy": "2026-06-10T14:02:45.016812Z",
-     "iopub.status.idle": "2026-06-10T14:02:45.034099Z",
-     "shell.execute_reply": "2026-06-10T14:02:45.033589Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.214719Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.214413Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.223343Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.222316Z"
     },
     "papermill": {
-     "duration": 0.025025,
-     "end_time": "2026-06-10T14:02:45.035100",
+     "duration": 0.016983,
+     "end_time": "2026-06-17T00:53:19.224143+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:45.010075",
+     "start_time": "2026-06-17T00:53:19.207160+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1922,10 +1922,10 @@
    "id": "3cc1a67b",
    "metadata": {
     "papermill": {
-     "duration": 0.004515,
-     "end_time": "2026-06-10T14:02:45.044804",
+     "duration": 0.006079,
+     "end_time": "2026-06-17T00:53:19.236636+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:45.040289",
+     "start_time": "2026-06-17T00:53:19.230557+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1953,10 +1953,10 @@
    "id": "74eec2fe",
    "metadata": {
     "papermill": {
-     "duration": 0.004505,
-     "end_time": "2026-06-10T14:02:45.052825",
+     "duration": 0.006339,
+     "end_time": "2026-06-17T00:53:19.249646+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:45.048320",
+     "start_time": "2026-06-17T00:53:19.243307+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1994,16 +1994,16 @@
    "id": "a916457d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:45.063086Z",
-     "iopub.status.busy": "2026-06-10T14:02:45.062565Z",
-     "iopub.status.idle": "2026-06-10T14:02:45.962658Z",
-     "shell.execute_reply": "2026-06-10T14:02:45.961515Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.265539Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.265242Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.278811Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.277978Z"
     },
     "papermill": {
-     "duration": 0.90633,
-     "end_time": "2026-06-10T14:02:45.963664",
+     "duration": 0.023386,
+     "end_time": "2026-06-17T00:53:19.279403+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:45.057334",
+     "start_time": "2026-06-17T00:53:19.256017+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2051,16 +2051,16 @@
    "id": "426133ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:02:45.976698Z",
-     "iopub.status.busy": "2026-06-10T14:02:45.976194Z",
-     "iopub.status.idle": "2026-06-10T14:03:15.036048Z",
-     "shell.execute_reply": "2026-06-10T14:03:15.034940Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.291340Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.291028Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.297692Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.297085Z"
     },
     "papermill": {
-     "duration": 29.067373,
-     "end_time": "2026-06-10T14:03:15.036558",
+     "duration": 0.013408,
+     "end_time": "2026-06-17T00:53:19.298243+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:02:45.969185",
+     "start_time": "2026-06-17T00:53:19.284835+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2178,16 +2178,16 @@
    "id": "6e670307",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:03:15.048260Z",
-     "iopub.status.busy": "2026-06-10T14:03:15.048260Z",
-     "iopub.status.idle": "2026-06-10T14:03:15.066795Z",
-     "shell.execute_reply": "2026-06-10T14:03:15.065793Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.309056Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.308873Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.313656Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.313110Z"
     },
     "papermill": {
-     "duration": 0.025534,
-     "end_time": "2026-06-10T14:03:15.067793",
+     "duration": 0.010922,
+     "end_time": "2026-06-17T00:53:19.314181+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.042259",
+     "start_time": "2026-06-17T00:53:19.303259+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2244,10 +2244,10 @@
    "id": "d4216022",
    "metadata": {
     "papermill": {
-     "duration": 0.005508,
-     "end_time": "2026-06-10T14:03:15.080812",
+     "duration": 0.005125,
+     "end_time": "2026-06-17T00:53:19.324685+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.075304",
+     "start_time": "2026-06-17T00:53:19.319560+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2285,10 +2285,10 @@
    "id": "ba9beb92",
    "metadata": {
     "papermill": {
-     "duration": 0.004913,
-     "end_time": "2026-06-10T14:03:15.091726",
+     "duration": 0.005375,
+     "end_time": "2026-06-17T00:53:19.335256+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.086813",
+     "start_time": "2026-06-17T00:53:19.329881+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2304,24 +2304,24 @@
    "id": "3c800f32",
    "metadata": {
     "papermill": {
-     "duration": 0.007508,
-     "end_time": "2026-06-10T14:03:15.107099",
+     "duration": 0.005176,
+     "end_time": "2026-06-17T00:53:19.345752+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.099591",
+     "start_time": "2026-06-17T00:53:19.340576+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Ajouter une regle via prompt personnalise\n",
+    "### Exemple guide 1 : Ajouter une regle via prompt personnalise (domaine film)\n",
     "\n",
-    "Simulez un LLM qui genere des regles pour un nouveau domaine : la prediction de la qualite d'un film.\n",
+    "Nous appliquons le pipeline des sections 2-3 a un **nouveau domaine** : la prediction de la qualite d'un film. La cible n'est plus `WillWait` mais `bon_film` -- il faut donc adapter la verification (qui utilisait `ex[\"WillWait\"]` en dur).\n",
     "\n",
     "**Etapes** :\n",
     "1. Definir les attributs du domaine (genre, duree, budget, critique)\n",
     "2. Creer 6 exemples (3 positifs, 3 negatifs)\n",
-    "3. Generer 3 regles candidates (simulatees)\n",
-    "4. Verifier chaque regle avec l'oracle symbolique"
+    "3. Generer 3 regles candidates (simulees)\n",
+    "4. Verifier chaque regle avec l'oracle symbolique (cible `bon_film`)"
    ]
   },
   {
@@ -2330,16 +2330,16 @@
    "id": "5101d0d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:03:15.117671Z",
-     "iopub.status.busy": "2026-06-10T14:03:15.117671Z",
-     "iopub.status.idle": "2026-06-10T14:03:15.130302Z",
-     "shell.execute_reply": "2026-06-10T14:03:15.129680Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.363475Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.363242Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.371771Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.370829Z"
     },
     "papermill": {
-     "duration": 0.020162,
-     "end_time": "2026-06-10T14:03:15.131309",
+     "duration": 0.020977,
+     "end_time": "2026-06-17T00:53:19.372484+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.111147",
+     "start_time": "2026-06-17T00:53:19.351507+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2349,36 +2349,176 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : definissez les exemples et regles du domaine film\n"
+      "Verification des regles candidates du domaine film\n",
+      "================================================================\n",
+      "Regle                            | TP | FP | FN |  OK | Couv.\n",
+      "----------------------------------------------------------------\n",
+      "R1: critique=good => bon_film    |  3 |  0 |  0 | OUI |   oui\n",
+      "R2: genre=drama => bon_film      |  2 |  0 |  1 | OUI |   non\n",
+      "R3: budget=high => bon_film      |  1 |  2 |  2 | NON |   non\n",
+      "\n",
+      "Lecture : R1 (critique=good) est a la fois consistante (FP=0) ET complete\n",
+      "(FN=0) : c'est la regle cherchee. R2 est consistante mais incomplete\n",
+      "(elle oublie la comedie positive) ; R3 est incoherente (budget=high couvre\n",
+      "aussi des exemples negatifs). L'oracle isole donc R1, exactement comme en\n",
+      "section 3 sur le domaine du restaurant.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 : Prediction de la qualite d'un film\n",
-    "# TODO etudiant : Definissez le domaine, les exemples, et les regles candidates\n",
+    "# Exemple guide 1 : domaine film -- generation + verification symbolique\n",
+    "#\n",
+    "# On reprend l'architecture des sections 2-3 sur un nouveau domaine.\n",
+    "# Concept sous-jacent (que l'oracle doit isoler) : un bon film est simplement\n",
+    "# bien critique, independamment du genre, de la duree ou du budget.\n",
     "\n",
-    "# Etape 1 : Definir les attributs\n",
+    "# Etape 1 : les 4 attributs du domaine film\n",
     "FILM_ATTRIBUTES = [\"genre\", \"duree\", \"budget\", \"critique\"]\n",
     "\n",
-    "# Etape 2 : Creer des exemples\n",
+    "# Etape 2 : 6 exemples (3 positifs, 3 negatifs)\n",
     "film_examples = [\n",
-    "    # TODO etudiant : ajoutez 3 positifs et 3 negatifs\n",
-    "    # Exemple : {\"genre\": \"drama\", \"duree\": \"long\", \"budget\": \"high\", \"critique\": \"good\", \"bon_film\": True}\n",
+    "    {\"genre\": \"drama\",  \"duree\": \"long\",  \"budget\": \"high\", \"critique\": \"good\", \"bon_film\": True},\n",
+    "    {\"genre\": \"drama\",  \"duree\": \"court\", \"budget\": \"low\",  \"critique\": \"good\", \"bon_film\": True},\n",
+    "    {\"genre\": \"comedy\", \"duree\": \"court\", \"budget\": \"low\",  \"critique\": \"good\", \"bon_film\": True},\n",
+    "    {\"genre\": \"action\", \"duree\": \"long\",  \"budget\": \"high\", \"critique\": \"bad\",  \"bon_film\": False},\n",
+    "    {\"genre\": \"comedy\", \"duree\": \"court\", \"budget\": \"low\",  \"critique\": \"bad\",  \"bon_film\": False},\n",
+    "    {\"genre\": \"action\", \"duree\": \"court\", \"budget\": \"high\", \"critique\": \"bad\",  \"bon_film\": False},\n",
     "]\n",
     "\n",
-    "# Etape 3 : Generer des regles candidates\n",
-    "# TODO etudiant : creez 3 HornClause candidates\n",
-    "film_rules = []  # TODO etudiant : ajoutez vos regles\n",
+    "# Etape 3 : 3 regles candidates (comme ce que produirait un LLM) :\n",
+    "# une correcte (R1), une consistante mais incomplete (R2), une erronee (R3).\n",
+    "film_rules = [\n",
+    "    HornClause([\"critique=good\"], \"bon_film\"),   # R1\n",
+    "    HornClause([\"genre=drama\"], \"bon_film\"),     # R2\n",
+    "    HornClause([\"budget=high\"], \"bon_film\"),     # R3\n",
+    "]\n",
     "\n",
-    "# Etape 4 : Verifier\n",
-    "if film_examples and film_rules:\n",
-    "    for i, rule in enumerate(film_rules):\n",
-    "        # Note : adapt verify_rule si le target est \"bon_film\" au lieu de \"WillWait\"\n",
-    "        print(f\"Regle {i+1}: {rule}\")\n",
-    "else:\n",
-    "    print(\"Exercice a completer : definissez les exemples et regles du domaine film\")\n",
+    "# Etape 4 : verification. La cible change (\"bon_film\"), on generalise donc\n",
+    "# verify_rule en parametrant la cle cible -- meme logique TP/FP/FN/TN qu'en\n",
+    "# section 3, appliquee a un domaine quelconque.\n",
+    "def verify_film_rule(rule, examples, target=\"bon_film\"):\n",
+    "    \"\"\"verify_rule generalisee : la cle cible devient un parametre.\"\"\"\n",
+    "    tp = fp = fn = tn = 0\n",
+    "    for ex in examples:\n",
+    "        applies = rule.evaluate(ex)\n",
+    "        is_pos = ex[target]\n",
+    "        if rule.negated:\n",
+    "            if applies and not is_pos:\n",
+    "                tp += 1\n",
+    "            elif applies and is_pos:\n",
+    "                fp += 1\n",
+    "            elif (not applies) and (not is_pos):\n",
+    "                fn += 1\n",
+    "            else:\n",
+    "                tn += 1\n",
+    "        else:\n",
+    "            if applies and is_pos:\n",
+    "                tp += 1\n",
+    "            elif applies and (not is_pos):\n",
+    "                fp += 1\n",
+    "            elif (not applies) and is_pos:\n",
+    "                fn += 1\n",
+    "            else:\n",
+    "                tn += 1\n",
+    "    consistent = (fp == 0)\n",
+    "    covers_all = (fn == 0) if not rule.negated else True\n",
+    "    return tp, fp, fn, tn, consistent, covers_all\n",
     "\n",
-    "# Indice : une bonne regle pourrait etre \"critique=good AND genre=drama => bon_film\""
+    "\n",
+    "print(\"Verification des regles candidates du domaine film\")\n",
+    "print(\"=\" * 64)\n",
+    "print(f\"{'Regle':32s} | {'TP':>2} | {'FP':>2} | {'FN':>2} | {'OK':>3} | {'Couv.':>5}\")\n",
+    "print(\"-\" * 64)\n",
+    "for i, rule in enumerate(film_rules):\n",
+    "    tp, fp, fn, tn, ok, cov = verify_film_rule(rule, film_examples)\n",
+    "    print(f\"R{i+1}: {str(rule)[:28]:28s} | {tp:>2} | {fp:>2} | {fn:>2} | \"\n",
+    "          f\"{'OUI' if ok else 'NON':>3} | {'oui' if cov else 'non':>5}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Lecture : R1 (critique=good) est a la fois consistante (FP=0) ET complete\")\n",
+    "print(\"(FN=0) : c'est la regle cherchee. R2 est consistante mais incomplete\")\n",
+    "print(\"(elle oublie la comedie positive) ; R3 est incoherente (budget=high couvre\")\n",
+    "print(\"aussi des exemples negatifs). L'oracle isole donc R1, exactement comme en\")\n",
+    "print(\"section 3 sur le domaine du restaurant.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5281a2e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006033,
+     "end_time": "2026-06-17T00:53:19.384529+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T00:53:19.378496+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 (variation) : Domaine \"activite en plein air\"\n",
+    "\n",
+    "Reproduisez l'exemple guide ci-dessus sur un **domaine different** : decider si l'on fait une activite en plein air (`dehors`). Vous choisissez les attributs, vous construisez 6 exemples equilibres (3 ou l'on sort, 3 ou l'on reste) caches derriere un concept simple, puis vous proposez 3 regles candidates dont une seule est parfaite. Adaptez la verification a la cible `dehors`.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Choisir 3 ou 4 attributs et leurs valeurs (ex : `meteo`, `vent`, `temperature`, `weekend`)\n",
+    "2. Construire 6 exemples (3 `dehors=True`, 3 `dehors=False`) caches derriere un concept mono-attribut\n",
+    "3. Proposer 3 `HornClause` : 1 parfaite, 1 consistante mais incomplete, 1 incoherente\n",
+    "4. Verifier avec une cible parametree (`dehors`) et afficher le tableau TP/FP/FN/OK/Couverture\n",
+    "\n",
+    "# Indice : un concept mono-attribut (un seul predicat decisif, ex `meteo=soleil`)\n",
+    "#           est le plus simple a isoler -- comme `critique=good` dans l'exemple."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "0abbe4b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T00:53:19.398036Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.397639Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.401223Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.400554Z"
+    },
+    "papermill": {
+     "duration": 0.01125,
+     "end_time": "2026-06-17T00:53:19.401775+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T00:53:19.390525+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : domaine activite en plein air\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (variation) : domaine \"activite en plein air\"\n",
+    "# TODO etudiant : definissez le domaine, 6 exemples, 3 candidats, puis verifiez.\n",
+    "\n",
+    "# Etape 1 : attributs\n",
+    "OUTDOOR_ATTRIBUTES = []  # TODO etudiant : ex [\"meteo\", \"vent\", \"temperature\", \"weekend\"]\n",
+    "\n",
+    "# Etape 2 : 6 exemples (3 dehors=True, 3 dehors=False)\n",
+    "outdoor_examples = [\n",
+    "    # TODO etudiant : ex {\"meteo\": \"soleil\", \"vent\": \"non\", \"temperature\": \"douce\",\n",
+    "    #                      \"weekend\": \"oui\", \"dehors\": True}\n",
+    "]\n",
+    "\n",
+    "# Etape 3 : 3 regles candidates (1 parfaite, 1 incomplete, 1 incoherente)\n",
+    "outdoor_rules = []  # TODO etudiant : ajoutez vos HornClause\n",
+    "\n",
+    "# Etape 4 : verification (adaptez verify_film_rule avec target=\"dehors\")\n",
+    "# TODO etudiant : affichez le tableau TP/FP/FN/OK/Couverture comme ci-dessus.\n",
+    "\n",
+    "print(\"Exercice a completer : domaine activite en plein air\")"
    ]
   },
   {
@@ -2386,10 +2526,10 @@
    "id": "2936e442",
    "metadata": {
     "papermill": {
-     "duration": 0.009001,
-     "end_time": "2026-06-10T14:03:15.145307",
+     "duration": 0.006385,
+     "end_time": "2026-06-17T00:53:19.414021+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.136306",
+     "start_time": "2026-06-17T00:53:19.407636+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2407,20 +2547,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "174aa8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:03:15.162675Z",
-     "iopub.status.busy": "2026-06-10T14:03:15.161677Z",
-     "iopub.status.idle": "2026-06-10T14:03:15.177054Z",
-     "shell.execute_reply": "2026-06-10T14:03:15.175938Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.427323Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.427096Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.431221Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.430617Z"
     },
     "papermill": {
-     "duration": 0.02496,
-     "end_time": "2026-06-10T14:03:15.177611",
+     "duration": 0.012087,
+     "end_time": "2026-06-17T00:53:19.431939+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.152651",
+     "start_time": "2026-06-17T00:53:19.419852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2464,10 +2604,10 @@
    "id": "0962260b",
    "metadata": {
     "papermill": {
-     "duration": 0.010711,
-     "end_time": "2026-06-10T14:03:15.191853",
+     "duration": 0.006729,
+     "end_time": "2026-06-17T00:53:19.444785+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.181142",
+     "start_time": "2026-06-17T00:53:19.438056+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2485,20 +2625,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "3548d43c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:03:15.208380Z",
-     "iopub.status.busy": "2026-06-10T14:03:15.208380Z",
-     "iopub.status.idle": "2026-06-10T14:03:15.224405Z",
-     "shell.execute_reply": "2026-06-10T14:03:15.223403Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.459713Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.459397Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.464541Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.463938Z"
     },
     "papermill": {
-     "duration": 0.026052,
-     "end_time": "2026-06-10T14:03:15.224909",
+     "duration": 0.013576,
+     "end_time": "2026-06-17T00:53:19.465333+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.198857",
+     "start_time": "2026-06-17T00:53:19.451757+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2563,10 +2703,10 @@
    "id": "3818d99f",
    "metadata": {
     "papermill": {
-     "duration": 0.007509,
-     "end_time": "2026-06-10T14:03:15.240422",
+     "duration": 0.007026,
+     "end_time": "2026-06-17T00:53:19.478992+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.232913",
+     "start_time": "2026-06-17T00:53:19.471966+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2581,20 +2721,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "b1ef475c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T14:03:15.252635Z",
-     "iopub.status.busy": "2026-06-10T14:03:15.252635Z",
-     "iopub.status.idle": "2026-06-10T14:03:15.271579Z",
-     "shell.execute_reply": "2026-06-10T14:03:15.270586Z"
+     "iopub.execute_input": "2026-06-17T00:53:19.492582Z",
+     "iopub.status.busy": "2026-06-17T00:53:19.492345Z",
+     "iopub.status.idle": "2026-06-17T00:53:19.496147Z",
+     "shell.execute_reply": "2026-06-17T00:53:19.495369Z"
     },
     "papermill": {
-     "duration": 0.026172,
-     "end_time": "2026-06-10T14:03:15.272579",
+     "duration": 0.011687,
+     "end_time": "2026-06-17T00:53:19.496784+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.246407",
+     "start_time": "2026-06-17T00:53:19.485097+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2604,7 +2744,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer (LLM reel configure)\n"
+      "Exercice a completer (pas de .env : variante simulateur, cf. indice)\n"
      ]
     }
    ],
@@ -2636,10 +2776,10 @@
    "id": "7cb00ad4",
    "metadata": {
     "papermill": {
-     "duration": 0.004639,
-     "end_time": "2026-06-10T14:03:15.284257",
+     "duration": 0.00574,
+     "end_time": "2026-06-17T00:53:19.508603+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.279618",
+     "start_time": "2026-06-17T00:53:19.502863+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2691,10 +2831,10 @@
    "id": "227e37ae",
    "metadata": {
     "papermill": {
-     "duration": 0.005703,
-     "end_time": "2026-06-10T14:03:15.295641",
+     "duration": 0.00603,
+     "end_time": "2026-06-17T00:53:19.520720+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.289938",
+     "start_time": "2026-06-17T00:53:19.514690+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2722,10 +2862,10 @@
    "id": "b2e6b9c6",
    "metadata": {
     "papermill": {
-     "duration": 0.008826,
-     "end_time": "2026-06-10T14:03:15.312834",
+     "duration": 0.005653,
+     "end_time": "2026-06-17T00:53:19.535312+00:00",
      "exception": false,
-     "start_time": "2026-06-10T14:03:15.304008",
+     "start_time": "2026-06-17T00:53:19.529659+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2763,18 +2903,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 33.081054,
-   "end_time": "2026-06-10T14:03:15.766444",
+   "duration": 3.082327,
+   "end_time": "2026-06-17T00:53:19.773654+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SL-7-LLM-SymbolicLearning.ipynb",
-   "output_path": "SL-7-LLM-SymbolicLearning.ipynb",
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T14:02:42.685390",
+   "start_time": "2026-06-17T00:53:16.691327+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Contexte

Suite du rollout de la convention **3 exercices/notebook** (#2161) sur la serie SymbolicLearning, partitionnee entre workers. Cette PR traite **SL-7 Exercice 1** (po-2024 partition : SL-7 Ex1 a Ex4, dans l'ordre du notebook). Les exercices **cohabitent** avec les exemples guides : un exercice resolu devient un exemple guide, et un nouvel exercice (variation du meme concept) est ajoute a la suite.

Voir [exercise-example-labeling.md](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/exercise-example-labeling.md) et [three-exercises-per-notebook.md](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/three-exercises-per-notebook.md).

## Livrable

**Ex1 resolu en exemple guide** (domaine film) :
- Solution complete fonctionnelle : `film_examples` (6 exemples etiquetes), 3 regles Horn candidates (R1 `critique=good`, R2 `genre=drama`, R3 `budget=high`), `verify_film_rule()` generalisee (TP/FP/FN/TN + consistante=`FP==0` + couverture=`FN==0`), affiche un tableau de verification.
- Markdown relicole « Exercice 1 » -> « **Exemple guide 1** », Etapes 1-4 conservees comme narration guidee.

**Nouvel exercice en variation** apres l'exemple resolu :
- Domaine « activite en plein air » (cible `dehors`, concept mono-attribut), markdown (contexte + objectif + 4 Etapes + Indice) + stub C.1-clean (`pass`/`print`, PAS de `raise NotImplementedError`).

## Preuves (validation reelle)

- **Papermill** : `notebook_tools.py execute ... --kernel python3` -> **SUCCESS** 5.3s, 1/1 notebooks, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` sur le notebook = **0**.
- **C.2** : 21 cellules code, toutes avec `execution_count` set + outputs presents + 0 output d'erreur.
  - Exemple guide Ex1 : R1 parfaite (TP=3/FP=0/FN=0, consistante ET complete = regle cherchee) ; R2 consistante mais incomplete ; R3 incoherente. Reflete la logique oracle de la section 3.
  - Stub de variation : s'execute proprement (`print("Exercice a completer ...")`).
- **Section 7 (demo Gemini 3.5 flash reelle) preservere** : pas de `.env`/cle en local -> papermill la faisait retomber sur le simulateur. Les 3 cellules section-7 (`a916457d`/`426133ee`/`6e670307`) source+outputs+execution_count sont restaurees depuis `origin/main` pour garder la demo reelle + son markdown d'interpretation coherents (exception documentee : cellule LLM/API non reproductible localement sans cle).

## Anti-regression (verifie)

- Cellules markdown : 28 -> 29 (+1 ajoutee, **0 supprimee, 0 reduite**).
- Lignes source code : 912 -> 980 (+68) : stub remplace par solution + variation. Aucun contenu pedagogique supprime.
- Les ~256 « deletions » du diff brut = re-serialisation des outputs (refresh C.2) + l'ancien stub Ex1, PAS de suppression de contenu.

## Scope

- 1 fichier `.ipynb`. Pas de churn catalogue (`COURSE_CATALOG.generated.*` non touche). Submodule openzeppelin non stage.
- Partial : Ex1/4 de SL-7. Ex2, Ex3, Ex4 suivent dans des PR separees (1 PR/exercice, serialisees).

See #2161
