### PR TITLE
feat(sl7): resolve Ex2 (direct vs CoT) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "097196f2",
    "metadata": {
     "papermill": {
-     "duration": 0.005783,
-     "end_time": "2026-06-17T00:53:18.762419+00:00",
+     "duration": 0.005672,
+     "end_time": "2026-06-17T01:07:53.686439+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.756636+00:00",
+     "start_time": "2026-06-17T01:07:53.680767+00:00",
      "status": "completed"
     },
     "tags": []
@@ -48,16 +48,16 @@
    "id": "3dc32d19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:18.776435Z",
-     "iopub.status.busy": "2026-06-17T00:53:18.776137Z",
-     "iopub.status.idle": "2026-06-17T00:53:18.783150Z",
-     "shell.execute_reply": "2026-06-17T00:53:18.782630Z"
+     "iopub.execute_input": "2026-06-17T01:07:53.700704Z",
+     "iopub.status.busy": "2026-06-17T01:07:53.700302Z",
+     "iopub.status.idle": "2026-06-17T01:07:53.709191Z",
+     "shell.execute_reply": "2026-06-17T01:07:53.708264Z"
     },
     "papermill": {
-     "duration": 0.015144,
-     "end_time": "2026-06-17T00:53:18.783975+00:00",
+     "duration": 0.017289,
+     "end_time": "2026-06-17T01:07:53.710126+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.768831+00:00",
+     "start_time": "2026-06-17T01:07:53.692837+00:00",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "23731406",
    "metadata": {
     "papermill": {
-     "duration": 0.004744,
-     "end_time": "2026-06-17T00:53:18.793688+00:00",
+     "duration": 0.005029,
+     "end_time": "2026-06-17T01:07:53.720801+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.788944+00:00",
+     "start_time": "2026-06-17T01:07:53.715772+00:00",
      "status": "completed"
     },
     "tags": []
@@ -144,16 +144,16 @@
    "id": "f1d96718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:18.804329Z",
-     "iopub.status.busy": "2026-06-17T00:53:18.804015Z",
-     "iopub.status.idle": "2026-06-17T00:53:18.809538Z",
-     "shell.execute_reply": "2026-06-17T00:53:18.808963Z"
+     "iopub.execute_input": "2026-06-17T01:07:53.732963Z",
+     "iopub.status.busy": "2026-06-17T01:07:53.732663Z",
+     "iopub.status.idle": "2026-06-17T01:07:53.739019Z",
+     "shell.execute_reply": "2026-06-17T01:07:53.738342Z"
     },
     "papermill": {
-     "duration": 0.012152,
-     "end_time": "2026-06-17T00:53:18.810263+00:00",
+     "duration": 0.013917,
+     "end_time": "2026-06-17T01:07:53.739626+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.798111+00:00",
+     "start_time": "2026-06-17T01:07:53.725709+00:00",
      "status": "completed"
     },
     "tags": []
@@ -236,10 +236,10 @@
    "id": "3827f67e",
    "metadata": {
     "papermill": {
-     "duration": 0.00466,
-     "end_time": "2026-06-17T00:53:18.819715+00:00",
+     "duration": 0.005186,
+     "end_time": "2026-06-17T01:07:53.750038+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.815055+00:00",
+     "start_time": "2026-06-17T01:07:53.744852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -261,10 +261,10 @@
    "id": "59e172f2",
    "metadata": {
     "papermill": {
-     "duration": 0.004318,
-     "end_time": "2026-06-17T00:53:18.828751+00:00",
+     "duration": 0.005447,
+     "end_time": "2026-06-17T01:07:53.760707+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.824433+00:00",
+     "start_time": "2026-06-17T01:07:53.755260+00:00",
      "status": "completed"
     },
     "tags": []
@@ -299,16 +299,16 @@
    "id": "581df035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:18.839298Z",
-     "iopub.status.busy": "2026-06-17T00:53:18.839089Z",
-     "iopub.status.idle": "2026-06-17T00:53:18.846099Z",
-     "shell.execute_reply": "2026-06-17T00:53:18.845326Z"
+     "iopub.execute_input": "2026-06-17T01:07:53.775676Z",
+     "iopub.status.busy": "2026-06-17T01:07:53.775179Z",
+     "iopub.status.idle": "2026-06-17T01:07:53.783764Z",
+     "shell.execute_reply": "2026-06-17T01:07:53.782843Z"
     },
     "papermill": {
-     "duration": 0.013336,
-     "end_time": "2026-06-17T00:53:18.846773+00:00",
+     "duration": 0.01849,
+     "end_time": "2026-06-17T01:07:53.784649+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.833437+00:00",
+     "start_time": "2026-06-17T01:07:53.766159+00:00",
      "status": "completed"
     },
     "tags": []
@@ -381,10 +381,10 @@
    "id": "72e21fc7",
    "metadata": {
     "papermill": {
-     "duration": 0.005301,
-     "end_time": "2026-06-17T00:53:18.858792+00:00",
+     "duration": 0.005686,
+     "end_time": "2026-06-17T01:07:53.796685+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.853491+00:00",
+     "start_time": "2026-06-17T01:07:53.790999+00:00",
      "status": "completed"
     },
     "tags": []
@@ -408,16 +408,16 @@
    "id": "eed948cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:18.871126Z",
-     "iopub.status.busy": "2026-06-17T00:53:18.870844Z",
-     "iopub.status.idle": "2026-06-17T00:53:18.876600Z",
-     "shell.execute_reply": "2026-06-17T00:53:18.875887Z"
+     "iopub.execute_input": "2026-06-17T01:07:53.809340Z",
+     "iopub.status.busy": "2026-06-17T01:07:53.809115Z",
+     "iopub.status.idle": "2026-06-17T01:07:53.814986Z",
+     "shell.execute_reply": "2026-06-17T01:07:53.814313Z"
     },
     "papermill": {
-     "duration": 0.013194,
-     "end_time": "2026-06-17T00:53:18.877221+00:00",
+     "duration": 0.013507,
+     "end_time": "2026-06-17T01:07:53.815843+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.864027+00:00",
+     "start_time": "2026-06-17T01:07:53.802336+00:00",
      "status": "completed"
     },
     "tags": []
@@ -507,10 +507,10 @@
    "id": "85c22afd",
    "metadata": {
     "papermill": {
-     "duration": 0.005375,
-     "end_time": "2026-06-17T00:53:18.888264+00:00",
+     "duration": 0.005499,
+     "end_time": "2026-06-17T01:07:53.827090+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.882889+00:00",
+     "start_time": "2026-06-17T01:07:53.821591+00:00",
      "status": "completed"
     },
     "tags": []
@@ -529,16 +529,16 @@
    "id": "1c109513",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:18.900624Z",
-     "iopub.status.busy": "2026-06-17T00:53:18.900396Z",
-     "iopub.status.idle": "2026-06-17T00:53:18.907957Z",
-     "shell.execute_reply": "2026-06-17T00:53:18.907236Z"
+     "iopub.execute_input": "2026-06-17T01:07:53.838963Z",
+     "iopub.status.busy": "2026-06-17T01:07:53.838753Z",
+     "iopub.status.idle": "2026-06-17T01:07:53.845473Z",
+     "shell.execute_reply": "2026-06-17T01:07:53.844854Z"
     },
     "papermill": {
-     "duration": 0.015276,
-     "end_time": "2026-06-17T00:53:18.908920+00:00",
+     "duration": 0.013682,
+     "end_time": "2026-06-17T01:07:53.845985+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.893644+00:00",
+     "start_time": "2026-06-17T01:07:53.832303+00:00",
      "status": "completed"
     },
     "tags": []
@@ -651,10 +651,10 @@
    "id": "bf930a24",
    "metadata": {
     "papermill": {
-     "duration": 0.005894,
-     "end_time": "2026-06-17T00:53:18.920905+00:00",
+     "duration": 0.005054,
+     "end_time": "2026-06-17T01:07:53.856779+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.915011+00:00",
+     "start_time": "2026-06-17T01:07:53.851725+00:00",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +685,10 @@
    "id": "d6bb9fe1",
    "metadata": {
     "papermill": {
-     "duration": 0.005468,
-     "end_time": "2026-06-17T00:53:18.935137+00:00",
+     "duration": 0.005566,
+     "end_time": "2026-06-17T01:07:53.867527+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.929669+00:00",
+     "start_time": "2026-06-17T01:07:53.861961+00:00",
      "status": "completed"
     },
     "tags": []
@@ -715,16 +715,16 @@
    "id": "2c0873ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:18.947197Z",
-     "iopub.status.busy": "2026-06-17T00:53:18.946970Z",
-     "iopub.status.idle": "2026-06-17T00:53:18.955623Z",
-     "shell.execute_reply": "2026-06-17T00:53:18.954914Z"
+     "iopub.execute_input": "2026-06-17T01:07:53.879549Z",
+     "iopub.status.busy": "2026-06-17T01:07:53.879325Z",
+     "iopub.status.idle": "2026-06-17T01:07:53.887713Z",
+     "shell.execute_reply": "2026-06-17T01:07:53.887172Z"
     },
     "papermill": {
-     "duration": 0.016025,
-     "end_time": "2026-06-17T00:53:18.956241+00:00",
+     "duration": 0.015631,
+     "end_time": "2026-06-17T01:07:53.888678+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.940216+00:00",
+     "start_time": "2026-06-17T01:07:53.873047+00:00",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +846,10 @@
    "id": "0f9984a1",
    "metadata": {
     "papermill": {
-     "duration": 0.005135,
-     "end_time": "2026-06-17T00:53:18.966658+00:00",
+     "duration": 0.006171,
+     "end_time": "2026-06-17T01:07:53.900337+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.961523+00:00",
+     "start_time": "2026-06-17T01:07:53.894166+00:00",
      "status": "completed"
     },
     "tags": []
@@ -882,16 +882,16 @@
    "id": "9a30e01b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:18.978831Z",
-     "iopub.status.busy": "2026-06-17T00:53:18.978502Z",
-     "iopub.status.idle": "2026-06-17T00:53:18.984388Z",
-     "shell.execute_reply": "2026-06-17T00:53:18.983711Z"
+     "iopub.execute_input": "2026-06-17T01:07:53.911974Z",
+     "iopub.status.busy": "2026-06-17T01:07:53.911761Z",
+     "iopub.status.idle": "2026-06-17T01:07:53.917593Z",
+     "shell.execute_reply": "2026-06-17T01:07:53.916733Z"
     },
     "papermill": {
-     "duration": 0.013056,
-     "end_time": "2026-06-17T00:53:18.985036+00:00",
+     "duration": 0.012788,
+     "end_time": "2026-06-17T01:07:53.918382+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.971980+00:00",
+     "start_time": "2026-06-17T01:07:53.905594+00:00",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +974,10 @@
    "id": "74c02d03",
    "metadata": {
     "papermill": {
-     "duration": 0.005622,
-     "end_time": "2026-06-17T00:53:18.996533+00:00",
+     "duration": 0.005383,
+     "end_time": "2026-06-17T01:07:53.929425+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:18.990911+00:00",
+     "start_time": "2026-06-17T01:07:53.924042+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1013,16 +1013,16 @@
    "id": "83e5f5eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.008836Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.008517Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.021150Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.020204Z"
+     "iopub.execute_input": "2026-06-17T01:07:53.942914Z",
+     "iopub.status.busy": "2026-06-17T01:07:53.942707Z",
+     "iopub.status.idle": "2026-06-17T01:07:53.951228Z",
+     "shell.execute_reply": "2026-06-17T01:07:53.950487Z"
     },
     "papermill": {
-     "duration": 0.020049,
-     "end_time": "2026-06-17T00:53:19.021973+00:00",
+     "duration": 0.017156,
+     "end_time": "2026-06-17T01:07:53.951858+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.001924+00:00",
+     "start_time": "2026-06-17T01:07:53.934702+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1187,10 +1187,10 @@
    "id": "3653b321",
    "metadata": {
     "papermill": {
-     "duration": 0.008242,
-     "end_time": "2026-06-17T00:53:19.036031+00:00",
+     "duration": 0.005406,
+     "end_time": "2026-06-17T01:07:53.962634+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.027789+00:00",
+     "start_time": "2026-06-17T01:07:53.957228+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1223,16 +1223,16 @@
    "id": "dc08268f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.049750Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.049383Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.056425Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.055525Z"
+     "iopub.execute_input": "2026-06-17T01:07:53.974160Z",
+     "iopub.status.busy": "2026-06-17T01:07:53.973938Z",
+     "iopub.status.idle": "2026-06-17T01:07:53.979903Z",
+     "shell.execute_reply": "2026-06-17T01:07:53.979154Z"
     },
     "papermill": {
-     "duration": 0.015038,
-     "end_time": "2026-06-17T00:53:19.057140+00:00",
+     "duration": 0.012863,
+     "end_time": "2026-06-17T01:07:53.980706+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.042102+00:00",
+     "start_time": "2026-06-17T01:07:53.967843+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1308,10 +1308,10 @@
    "id": "a575226a",
    "metadata": {
     "papermill": {
-     "duration": 0.006505,
-     "end_time": "2026-06-17T00:53:19.070442+00:00",
+     "duration": 0.005635,
+     "end_time": "2026-06-17T01:07:53.991766+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.063937+00:00",
+     "start_time": "2026-06-17T01:07:53.986131+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1342,10 +1342,10 @@
    "id": "1bd557a0",
    "metadata": {
     "papermill": {
-     "duration": 0.006348,
-     "end_time": "2026-06-17T00:53:19.082984+00:00",
+     "duration": 0.005525,
+     "end_time": "2026-06-17T01:07:54.002719+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.076636+00:00",
+     "start_time": "2026-06-17T01:07:53.997194+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1385,16 +1385,16 @@
    "id": "f9d67f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.095410Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.095196Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.106203Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.105169Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.015790Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.015529Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.025618Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.024767Z"
     },
     "papermill": {
-     "duration": 0.018628,
-     "end_time": "2026-06-17T00:53:19.107100+00:00",
+     "duration": 0.018041,
+     "end_time": "2026-06-17T01:07:54.026432+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.088472+00:00",
+     "start_time": "2026-06-17T01:07:54.008391+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1537,10 +1537,10 @@
    "id": "2f9d2c01",
    "metadata": {
     "papermill": {
-     "duration": 0.008674,
-     "end_time": "2026-06-17T00:53:19.121717+00:00",
+     "duration": 0.005391,
+     "end_time": "2026-06-17T01:07:54.037409+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.113043+00:00",
+     "start_time": "2026-06-17T01:07:54.032018+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1569,16 +1569,16 @@
    "id": "8917b738",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.135260Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.134998Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.139143Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.138461Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.049901Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.049407Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.053359Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.052759Z"
     },
     "papermill": {
-     "duration": 0.012246,
-     "end_time": "2026-06-17T00:53:19.139789+00:00",
+     "duration": 0.011085,
+     "end_time": "2026-06-17T01:07:54.053919+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.127543+00:00",
+     "start_time": "2026-06-17T01:07:54.042834+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1626,10 +1626,10 @@
    "id": "a2edb6e2",
    "metadata": {
     "papermill": {
-     "duration": 0.006181,
-     "end_time": "2026-06-17T00:53:19.151902+00:00",
+     "duration": 0.005372,
+     "end_time": "2026-06-17T01:07:54.064638+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.145721+00:00",
+     "start_time": "2026-06-17T01:07:54.059266+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1662,16 +1662,16 @@
    "id": "54a6b7c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.167672Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.167270Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.174197Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.173454Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.078014Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.077788Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.083085Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.082392Z"
     },
     "papermill": {
-     "duration": 0.016929,
-     "end_time": "2026-06-17T00:53:19.174905+00:00",
+     "duration": 0.012386,
+     "end_time": "2026-06-17T01:07:54.083824+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.157976+00:00",
+     "start_time": "2026-06-17T01:07:54.071438+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1732,10 +1732,10 @@
    "id": "d74db354",
    "metadata": {
     "papermill": {
-     "duration": 0.005813,
-     "end_time": "2026-06-17T00:53:19.186823+00:00",
+     "duration": 0.005735,
+     "end_time": "2026-06-17T01:07:54.095407+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.181010+00:00",
+     "start_time": "2026-06-17T01:07:54.089672+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1759,10 +1759,10 @@
    "id": "3c2e7728",
    "metadata": {
     "papermill": {
-     "duration": 0.006488,
-     "end_time": "2026-06-17T00:53:19.199010+00:00",
+     "duration": 0.005614,
+     "end_time": "2026-06-17T01:07:54.106946+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.192522+00:00",
+     "start_time": "2026-06-17T01:07:54.101332+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1787,16 +1787,16 @@
    "id": "dada4cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.214719Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.214413Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.223343Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.222316Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.120051Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.119852Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.128149Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.127295Z"
     },
     "papermill": {
-     "duration": 0.016983,
-     "end_time": "2026-06-17T00:53:19.224143+00:00",
+     "duration": 0.015892,
+     "end_time": "2026-06-17T01:07:54.128710+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.207160+00:00",
+     "start_time": "2026-06-17T01:07:54.112818+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1922,10 +1922,10 @@
    "id": "3cc1a67b",
    "metadata": {
     "papermill": {
-     "duration": 0.006079,
-     "end_time": "2026-06-17T00:53:19.236636+00:00",
+     "duration": 0.00582,
+     "end_time": "2026-06-17T01:07:54.140782+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.230557+00:00",
+     "start_time": "2026-06-17T01:07:54.134962+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1953,10 +1953,10 @@
    "id": "74eec2fe",
    "metadata": {
     "papermill": {
-     "duration": 0.006339,
-     "end_time": "2026-06-17T00:53:19.249646+00:00",
+     "duration": 0.005407,
+     "end_time": "2026-06-17T01:07:54.151891+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.243307+00:00",
+     "start_time": "2026-06-17T01:07:54.146484+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1994,16 +1994,16 @@
    "id": "a916457d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.265539Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.265242Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.278811Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.277978Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.164431Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.164229Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.175640Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.174818Z"
     },
     "papermill": {
-     "duration": 0.023386,
-     "end_time": "2026-06-17T00:53:19.279403+00:00",
+     "duration": 0.018883,
+     "end_time": "2026-06-17T01:07:54.176288+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.256017+00:00",
+     "start_time": "2026-06-17T01:07:54.157405+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2051,16 +2051,16 @@
    "id": "426133ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.291340Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.291028Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.297692Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.297085Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.188715Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.188525Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.195461Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.194565Z"
     },
     "papermill": {
-     "duration": 0.013408,
-     "end_time": "2026-06-17T00:53:19.298243+00:00",
+     "duration": 0.013834,
+     "end_time": "2026-06-17T01:07:54.196149+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.284835+00:00",
+     "start_time": "2026-06-17T01:07:54.182315+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2178,16 +2178,16 @@
    "id": "6e670307",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.309056Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.308873Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.313656Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.313110Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.211501Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.211179Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.217657Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.216562Z"
     },
     "papermill": {
-     "duration": 0.010922,
-     "end_time": "2026-06-17T00:53:19.314181+00:00",
+     "duration": 0.016318,
+     "end_time": "2026-06-17T01:07:54.218659+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.303259+00:00",
+     "start_time": "2026-06-17T01:07:54.202341+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2244,10 +2244,10 @@
    "id": "d4216022",
    "metadata": {
     "papermill": {
-     "duration": 0.005125,
-     "end_time": "2026-06-17T00:53:19.324685+00:00",
+     "duration": 0.008579,
+     "end_time": "2026-06-17T01:07:54.236544+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.319560+00:00",
+     "start_time": "2026-06-17T01:07:54.227965+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2285,10 +2285,10 @@
    "id": "ba9beb92",
    "metadata": {
     "papermill": {
-     "duration": 0.005375,
-     "end_time": "2026-06-17T00:53:19.335256+00:00",
+     "duration": 0.008827,
+     "end_time": "2026-06-17T01:07:54.253269+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.329881+00:00",
+     "start_time": "2026-06-17T01:07:54.244442+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2304,10 +2304,10 @@
    "id": "3c800f32",
    "metadata": {
     "papermill": {
-     "duration": 0.005176,
-     "end_time": "2026-06-17T00:53:19.345752+00:00",
+     "duration": 0.009883,
+     "end_time": "2026-06-17T01:07:54.270902+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.340576+00:00",
+     "start_time": "2026-06-17T01:07:54.261019+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2330,16 +2330,16 @@
    "id": "5101d0d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.363475Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.363242Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.371771Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.370829Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.288048Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.287818Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.295704Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.294921Z"
     },
     "papermill": {
-     "duration": 0.020977,
-     "end_time": "2026-06-17T00:53:19.372484+00:00",
+     "duration": 0.015985,
+     "end_time": "2026-06-17T01:07:54.296382+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.351507+00:00",
+     "start_time": "2026-06-17T01:07:54.280397+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2447,10 +2447,10 @@
    "id": "a5281a2e",
    "metadata": {
     "papermill": {
-     "duration": 0.006033,
-     "end_time": "2026-06-17T00:53:19.384529+00:00",
+     "duration": 0.005695,
+     "end_time": "2026-06-17T01:07:54.308292+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.378496+00:00",
+     "start_time": "2026-06-17T01:07:54.302597+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2476,16 +2476,16 @@
    "id": "0abbe4b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.398036Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.397639Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.401223Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.400554Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.321144Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.320939Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.324367Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.323773Z"
     },
     "papermill": {
-     "duration": 0.01125,
-     "end_time": "2026-06-17T00:53:19.401775+00:00",
+     "duration": 0.011177,
+     "end_time": "2026-06-17T01:07:54.325167+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.390525+00:00",
+     "start_time": "2026-06-17T01:07:54.313990+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2526,23 +2526,23 @@
    "id": "2936e442",
    "metadata": {
     "papermill": {
-     "duration": 0.006385,
-     "end_time": "2026-06-17T00:53:19.414021+00:00",
+     "duration": 0.005794,
+     "end_time": "2026-06-17T01:07:54.336708+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.407636+00:00",
+     "start_time": "2026-06-17T01:07:54.330914+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Comparer prompt direct vs CoT\n",
+    "### Exemple guide 2 : Comparer prompt direct vs Chain-of-Thought (CoT)\n",
     "\n",
-    "Comparez les regles generees par un prompt direct avec celles extraites d'un raisonnement CoT.\n",
+    "Cet exemple guide compare les regles produites par une **generation directe** (`use_cot=False`) a celles enrichies par des **traces Chain-of-Thought** (`use_cot=True`). Les deux lots sont verifies par le meme oracle symbolique ; on compare ensuite le nombre de regles validees, le taux d'acceptation et la couverture des exemples positifs.\n",
     "\n",
     "**Etapes** :\n",
-    "1. Executez le pipeline sans CoT\n",
-    "2. Executez le pipeline avec CoT\n",
-    "3. Comparez la couverture et la precision"
+    "1. Executer le pipeline sans CoT (`verbose=False`)\n",
+    "2. Executer le pipeline avec CoT (`verbose=False`)\n",
+    "3. Comparer le nombre de regles validees, le taux d'acceptation et la couverture\n"
    ]
   },
   {
@@ -2551,16 +2551,16 @@
    "id": "174aa8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.427323Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.427096Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.431221Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.430617Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.347679Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.347499Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.353413Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.352834Z"
     },
     "papermill": {
-     "duration": 0.012087,
-     "end_time": "2026-06-17T00:53:19.431939+00:00",
+     "duration": 0.012196,
+     "end_time": "2026-06-17T01:07:54.353921+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.419852+00:00",
+     "start_time": "2026-06-17T01:07:54.341725+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2570,33 +2570,153 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : comparez direct vs CoT\n",
-      "Etape 1 : executez le pipeline sans CoT\n",
-      "Etape 2 : executez le pipeline avec CoT\n",
-      "Etape 3 : comparez n_validated, coverage, et precision moyenne\n"
+      "Comparaison generation directe vs CoT\n",
+      "================================================================\n",
+      "Metrique                           |       Direct |          CoT\n",
+      "----------------------------------------------------------------\n",
+      "Candidates generees                |            5 |            6\n",
+      "Regles validees (consistantes)     |            2 |            3\n",
+      "Regles rejetees (inconsistantes)   |            3 |            3\n",
+      "Taux d'acceptation                 |          40% |          50%\n",
+      "Couverture positifs                |           0% |           0%\n",
+      "\n",
+      "Lecture : sur CE jeu d'exemples, aucune regle POSITIVE consistante\n",
+      "n'existe (toutes ont FP>=1) : le concept positif est disjonctif. Les\n",
+      "regles validees sont donc toutes NEGATIVES (NOT WillWait). Le CoT, en\n",
+      "generant a partir des traces sur positifs ET negatifs, decouvre une\n",
+      "regle negative supplementaire (3 validees vs 2 en direct), d'ou un\n",
+      "taux d'acceptation plus eleve (50% vs 40%). La couverture des positifs\n",
+      "reste 0% dans les deux cas : c'est une limite du formalisme Horn sur un\n",
+      "concept disjonctif, pas une defaillance du CoT.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : Comparaison direct vs CoT\n",
-    "# TODO etudiant : Comparez les deux approches\n",
+    "# Exemple guide 2 : Comparaison generation directe vs Chain-of-Thought (CoT)\n",
+    "#\n",
+    "# On execute deux fois le pipeline Neuro-Symbolique sur le meme jeu\n",
+    "# d'exemples (EXAMPLES) : en generation directe, puis en ajoutant les\n",
+    "# regles issues des traces CoT. Le meme oracle verifie les deux lots.\n",
+    "# On compare alors n_validated, le taux d'acceptation et la couverture.\n",
     "\n",
-    "# Etape 1 : Pipeline sans CoT\n",
-    "# p_direct = NeuroSymbolicPipeline(use_cot=False)\n",
-    "# r_direct = p_direct.run(EXAMPLES, verbose=False)\n",
+    "# Etape 1 : Pipeline sans CoT (generation directe)\n",
+    "p_direct = NeuroSymbolicPipeline(use_cot=False)\n",
+    "r_direct = p_direct.run(EXAMPLES, verbose=False)\n",
     "\n",
-    "# Etape 2 : Pipeline avec CoT\n",
-    "# p_cot = NeuroSymbolicPipeline(use_cot=True)\n",
-    "# r_cot = p_cot.run(EXAMPLES, verbose=False)\n",
+    "# Etape 2 : Pipeline avec CoT (traces sur positifs ET negatifs)\n",
+    "p_cot = NeuroSymbolicPipeline(use_cot=True)\n",
+    "r_cot = p_cot.run(EXAMPLES, verbose=False)\n",
     "\n",
-    "# Etape 3 : Comparaison\n",
-    "print(\"Exercice a completer : comparez direct vs CoT\")\n",
-    "print(\"Etape 1 : executez le pipeline sans CoT\")\n",
-    "print(\"Etape 2 : executez le pipeline avec CoT\")\n",
-    "print(\"Etape 3 : comparez n_validated, coverage, et precision moyenne\")\n",
+    "# Etape 3 : Taux d'acceptation = regles valides / candidates generees\n",
+    "def taux_acceptation(result):\n",
+    "    return result.n_validated / result.n_candidates if result.n_candidates else 0.0\n",
     "\n",
-    "# Indice : le CoT genere souvent des regles plus precises mais moins nombreuses\n",
-    "# result = None  # TODO etudiant : stockez les resultats de comparaison"
+    "rows = [\n",
+    "    (\"Candidates generees\", r_direct.n_candidates, r_cot.n_candidates, \"d\"),\n",
+    "    (\"Regles validees (consistantes)\", r_direct.n_validated, r_cot.n_validated, \"d\"),\n",
+    "    (\"Regles rejetees (inconsistantes)\", r_direct.n_rejected, r_cot.n_rejected, \"d\"),\n",
+    "    (\"Taux d'acceptation\", taux_acceptation(r_direct), taux_acceptation(r_cot), \".0%\"),\n",
+    "    (\"Couverture positifs\", r_direct.coverage, r_cot.coverage, \".0%\"),\n",
+    "]\n",
+    "\n",
+    "print(\"Comparaison generation directe vs CoT\")\n",
+    "print(\"=\" * 64)\n",
+    "print(f\"{'Metrique':34s} | {'Direct':>12s} | {'CoT':>12s}\")\n",
+    "print(\"-\" * 64)\n",
+    "for label, vd, vc, fmt in rows:\n",
+    "    print(f\"{label:34s} | {format(vd, fmt):>12s} | {format(vc, fmt):>12s}\")\n",
+    "print()\n",
+    "print(\"Lecture : sur CE jeu d'exemples, aucune regle POSITIVE consistante\")\n",
+    "print(\"n'existe (toutes ont FP>=1) : le concept positif est disjonctif. Les\")\n",
+    "print(\"regles validees sont donc toutes NEGATIVES (NOT WillWait). Le CoT, en\")\n",
+    "print(\"generant a partir des traces sur positifs ET negatifs, decouvre une\")\n",
+    "print(\"regle negative supplementaire (3 validees vs 2 en direct), d'ou un\")\n",
+    "print(\"taux d'acceptation plus eleve (50% vs 40%). La couverture des positifs\")\n",
+    "print(\"reste 0% dans les deux cas : c'est une limite du formalisme Horn sur un\")\n",
+    "print(\"concept disjonctif, pas une defaillance du CoT.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl7ex2var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005376,
+     "end_time": "2026-06-17T01:07:54.364761+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:07:54.359385+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 (variation) : Effet du nombre d'exemples sur la couverture\n",
+    "\n",
+    "Au lieu de comparer deux modes de generation (direct vs CoT), comparez le comportement du pipeline quand on lui donne **un nombre croissant d'exemples**. On s'attend a ce que la couverture des positifs augmente avec le nombre d'exemples, jusqu'a un plateau une fois toutes les sous-classes couvertes.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Construire des sous-ensembles d'EXAMPLES de tailles 3, 5, puis la taille complete\n",
+    "2. Executer le pipeline (generation directe) sur chaque sous-ensemble\n",
+    "3. Afficher l'evolution de `n_validated` et de `coverage` selon la taille\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "sl7ex2var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:07:54.376859Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.376675Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.380459Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.379566Z"
+    },
+    "papermill": {
+     "duration": 0.011139,
+     "end_time": "2026-06-17T01:07:54.381197+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:07:54.370058+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : effet du nombre d'exemples sur la couverture\n",
+      "Etape 1 : construisez des sous-ensembles de tailles 3, 5, len(EXAMPLES)\n",
+      "Etape 2 : executez le pipeline (direct) sur chaque sous-ensemble\n",
+      "Etape 3 : affichez l'evolution de n_validated et coverage\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (variation) : effet du nombre d'exemples sur la couverture\n",
+    "# TODO etudiant : comparez le pipeline sur des sous-ensembles croissants\n",
+    "\n",
+    "# Etape 1 : sous-ensembles de tailles 3, 5, puis len(EXAMPLES)\n",
+    "# tailles = [3, 5, len(EXAMPLES)]\n",
+    "# sous_ensembles = {k: EXAMPLES[:k] for k in tailles}\n",
+    "\n",
+    "# Etape 2 : pipeline en generation directe sur chaque sous-ensemble\n",
+    "# resultats = []\n",
+    "# for k, exs in sous_ensembles.items():\n",
+    "#     p = NeuroSymbolicPipeline(use_cot=False)\n",
+    "#     r = p.run(exs, verbose=False)\n",
+    "#     resultats.append((k, r.n_validated, r.coverage))\n",
+    "\n",
+    "# Etape 3 : afficher l'evolution de n_validated et coverage selon la taille\n",
+    "print(\"Exercice a completer : effet du nombre d'exemples sur la couverture\")\n",
+    "print(\"Etape 1 : construisez des sous-ensembles de tailles 3, 5, len(EXAMPLES)\")\n",
+    "print(\"Etape 2 : executez le pipeline (direct) sur chaque sous-ensemble\")\n",
+    "print(\"Etape 3 : affichez l'evolution de n_validated et coverage\")\n",
+    "\n",
+    "# Indice : la couverture des positifs augmente avec le nombre d'exemples,\n",
+    "# puis se stabilise (plateau) une fois toutes les sous-classes couvertes.\n",
+    "# result = None  # TODO etudiant : liste de tuples (taille, n_validated, coverage)\n"
    ]
   },
   {
@@ -2604,10 +2724,10 @@
    "id": "0962260b",
    "metadata": {
     "papermill": {
-     "duration": 0.006729,
-     "end_time": "2026-06-17T00:53:19.444785+00:00",
+     "duration": 0.005064,
+     "end_time": "2026-06-17T01:07:54.391632+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.438056+00:00",
+     "start_time": "2026-06-17T01:07:54.386568+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2625,20 +2745,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "3548d43c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.459713Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.459397Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.464541Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.463938Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.403424Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.403241Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.407244Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.406744Z"
     },
     "papermill": {
-     "duration": 0.013576,
-     "end_time": "2026-06-17T00:53:19.465333+00:00",
+     "duration": 0.010771,
+     "end_time": "2026-06-17T01:07:54.407907+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.451757+00:00",
+     "start_time": "2026-06-17T01:07:54.397136+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2703,10 +2823,10 @@
    "id": "3818d99f",
    "metadata": {
     "papermill": {
-     "duration": 0.007026,
-     "end_time": "2026-06-17T00:53:19.478992+00:00",
+     "duration": 0.00543,
+     "end_time": "2026-06-17T01:07:54.418870+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.471966+00:00",
+     "start_time": "2026-06-17T01:07:54.413440+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2721,20 +2841,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "b1ef475c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T00:53:19.492582Z",
-     "iopub.status.busy": "2026-06-17T00:53:19.492345Z",
-     "iopub.status.idle": "2026-06-17T00:53:19.496147Z",
-     "shell.execute_reply": "2026-06-17T00:53:19.495369Z"
+     "iopub.execute_input": "2026-06-17T01:07:54.430603Z",
+     "iopub.status.busy": "2026-06-17T01:07:54.430415Z",
+     "iopub.status.idle": "2026-06-17T01:07:54.433790Z",
+     "shell.execute_reply": "2026-06-17T01:07:54.433132Z"
     },
     "papermill": {
-     "duration": 0.011687,
-     "end_time": "2026-06-17T00:53:19.496784+00:00",
+     "duration": 0.010562,
+     "end_time": "2026-06-17T01:07:54.434385+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.485097+00:00",
+     "start_time": "2026-06-17T01:07:54.423823+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2776,10 +2896,10 @@
    "id": "7cb00ad4",
    "metadata": {
     "papermill": {
-     "duration": 0.00574,
-     "end_time": "2026-06-17T00:53:19.508603+00:00",
+     "duration": 0.00573,
+     "end_time": "2026-06-17T01:07:54.445769+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.502863+00:00",
+     "start_time": "2026-06-17T01:07:54.440039+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2831,10 +2951,10 @@
    "id": "227e37ae",
    "metadata": {
     "papermill": {
-     "duration": 0.00603,
-     "end_time": "2026-06-17T00:53:19.520720+00:00",
+     "duration": 0.005149,
+     "end_time": "2026-06-17T01:07:54.456320+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.514690+00:00",
+     "start_time": "2026-06-17T01:07:54.451171+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2862,10 +2982,10 @@
    "id": "b2e6b9c6",
    "metadata": {
     "papermill": {
-     "duration": 0.005653,
-     "end_time": "2026-06-17T00:53:19.535312+00:00",
+     "duration": 0.005304,
+     "end_time": "2026-06-17T01:07:54.467384+00:00",
      "exception": false,
-     "start_time": "2026-06-17T00:53:19.529659+00:00",
+     "start_time": "2026-06-17T01:07:54.462080+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2907,14 +3027,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.082327,
-   "end_time": "2026-06-17T00:53:19.773654+00:00",
+   "duration": 3.003232,
+   "end_time": "2026-06-17T01:07:54.710252+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T00:53:16.691327+00:00",
+   "start_time": "2026-06-17T01:07:51.707020+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
> **PR empilée (stacked)** : base = `feat/sl7-ex1-guided` (#3172). Merger **#3172 d'abord** ; cette PR se re-cible automatiquement vers `main`. Le diff ci-dessous ne montre que la contribution Ex2.

## Contexte

Rollout convention **3 exercices/notebook** (#2161), serie SymbolicLearning, partition po-2024. **SL-7 Exercice 2** (Comparer prompt direct vs CoT). Les exercices cohabitent avec les exemples guides : un exercice resolu devient un exemple guide, un nouvel exercice (variation du meme concept) est ajoute.

## Livrable

**Ex2 resolu en exemple guide** (direct vs Chain-of-Thought) :
- Solution complete : `NeuroSymbolicPipeline` execute deux fois sur `EXAMPLES` (`use_cot=False` puis `use_cot=True`, `verbose=False`), calcul du **taux d'acceptation** (`n_validated/n_candidates`) et de la couverture, tableau comparatif Direct vs CoT.
- Markdown relicole « Exercice 2 » -> « **Exemple guide 2** », Etapes conservees.

**Nouvel exercice en variation** : « Effet du nombre d'exemples sur la couverture » (pipeline direct sur sous-ensembles croissants 3/5/`len(EXAMPLES)`, observer `n_validated` et `coverage`). Meme pipeline, concept voisin (comparer deux configurations), axe neuf (taille d'echantillon). Stub C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`notebook_tools.py execute --kernel python3`) : **SUCCESS** 5.3s, 1/1 notebooks, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 22 cellules code, toutes `execution_count` set + outputs presents + 0 output d'erreur. Section 7 (demo Gemini 3.5 flash reelle) restauree depuis `origin/main` apres papermill (pas de `.env`/cle en local -> regression simulateur evitee).
- **Sortie Ex2** : Direct 5 candidates / 2 validees / 40% acceptation / 0% couv ; CoT 6 candidates / 3 validees / 50% acceptation / 0% couv.

## Lecture honnete du resultat (ancree dans la sortie reelle)

Sur ce jeu d'exemples, **aucune regle POSITIVE consistante** n'existe (toutes ont FP>=1) : le concept positif est **disjonctif**, donc toutes les regles validees sont NEGATIVES (`NOT WillWait`). Le CoT decouvre une contrainte negative supplementaire (3 vs 2), d'ou un taux d'acceptation plus eleve. La couverture des positifs reste **0%** dans les deux cas — limite du formalisme Horn sur un concept disjonctif, pas une defaillance du CoT.

Ces nombres correspondent **exactement** aux cellules demo de reference du notebook (`f9d67f71` / `8917b738` sur `origin/main`) : **pas une regression**.

**Choix de metrique** : les regles validees ayant toutes FP=0, leur precision est trivialement 1.0 — la metrique informative est le **taux d'acceptation** (cf metrique existante cellule `54a6b7c4`), pas une precision moyenne.

## Anti-regression (verifie vs base `feat/sl7-ex1-guided`)

- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- Source code +46 lignes (stub Ex2 19L -> solution 42L + stub variation). Markdown Ex2 relicole (compte de lignes preserve).
- 1 fichier `.ipynb`. Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
