### PR TITLE
docs(symbolicai): #2651 Partie 2 — top-nav harmonization (AP5) on SymbolicAI family

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -1,5 +1,7 @@
 # Planification Automatique - Automated Planning
 
+[← Lean](../Lean/README.md) | [↑ SymbolicAI](../README.md) | [SmartContracts →](../SmartContracts/README.md)
+
 <!-- CATALOG-STATUS
 series: SymbolicAI-Planners
 pedagogical_count: 13

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -1,6 +1,6 @@
 # SymbolicAI - Intelligence Artificielle Symbolique
 
-[← Notebooks](../README.md) | [↑ ..](../README.md) | [→ Sudoku](../Sudoku/README.md)
+[← Notebooks](../README.md) | [→ Sudoku](../Sudoku/README.md)
 
 <!-- CATALOG-STATUS
 series: SymbolicAI

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -1,5 +1,7 @@
 # Web Sémantique - Semantic Web
 
+[← Tweety](../Tweety/README.md) | [↑ SymbolicAI](../README.md) | [Lean →](../Lean/README.md)
+
 <!-- CATALOG-STATUS
 series: SymbolicAI-SemanticWeb
 pedagogical_count: 18

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -1,5 +1,7 @@
 # Smart Contracts - Des Cypherpunks aux Blockchains Modernes
 
+[← Planners](../Planners/README.md) | [↑ SymbolicAI](../README.md)
+
 <!-- CATALOG-STATUS
 series: SymbolicAI-SmartContracts
 pedagogical_count: 27

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -1,5 +1,7 @@
 # SymbolicLearning - Apprentissage Symbolique
 
+[↑ SymbolicAI](../README.md)
+
 <!-- CATALOG-STATUS
 series: SymbolicAI-SymbolicLearning
 pedagogical_count: 10

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -1,5 +1,7 @@
 # TweetyProject - Série de Notebooks Jupyter
 
+[↑ SymbolicAI](../README.md) | [SemanticWeb →](../SemanticWeb/README.md)
+
 <!-- CATALOG-STATUS
 series: SymbolicAI-Tweety
 pedagogical_count: 10


### PR DESCRIPTION
## Summary

Partie 2 du gabarit README ([#2651](#2651), gabarit [`docs/reference/readme-series-gabarit.md`](docs/reference/readme-series-gabarit.md) #2800) — harmonisation de la navigation de la famille **SymbolicAI** (anti-pattern 5 du gabarit : « l'élément le plus absent »).

5 enfants SymbolicAI ouvraient directement sur le marqueur CATALOG-STATUS sans barre de navigation top (**Tweety, SemanticWeb, Planners, SmartContracts, SymbolicLearning**). Ajout d'une nav parcours-based suivant la convention de la famille Search (`<- prev | ^ SymbolicAI | next ->`), + dé-duplication de la nav double-parent du README SymbolicAI (`<- Notebooks` et `^ ..` pointaient tous deux vers `../README.md`).

Parcours fidèle aux phases déclarées dans le README parent :

- Phase 1 Tweety -> Phase 2 SemanticWeb -> Phase 3 Lean -> Phase 4 Planners -> SmartContracts
- SymbolicLearning standalone (parcours alternatif, nav parent-only)

**SMT** et **Argument_Analysis** avaient déjà une nav — laissés intacts.

## Scope

Docs-only : 11 insertions / 1 deletion, 6 fichiers. Conforme ai-01 deep-queue po-2024 item (1) « #2651 prose READMEs Search/.NET-non-Lean restants ». Lot cohérent 6-fichiers / famille unique (AP5 nav) — même pattern que po-2025 #3170 (ML/Sudoku) et po-2026 #3151 (Lean-series).

## Verifications

- `git diff origin/main --stat` : 6 fichiers, 11 insertions / 1 deletion
- Catalogue (`COURSE_CATALOG.generated.json/.md`) **byte-identique** main (0 churn)
- Submodule MGS `4d1318d` inchangé (= main)
- Liens nav résolvent vers des READMEs siblings existants (Tweety / SemanticWeb / Lean / Planners / SmartContracts / SymbolicAI / Sudoku)
- Base fraîche origin/main `117c96cc` (0 behind)
- Markdown-only (C.2 exception, pas de re-exec notebook)
- Partition po-2024 (SymbolicAI non-Lean) — pas de collision (po-2025 #3170 = ML/Sudoku, po-2026 = Lean)

See #2651 (Partie 2 — Epic stays OPEN, contribution au sweep gabarit multi-familles).