### PR TITLE
feat(sl7): resolve Ex3 (hallucination detector) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "097196f2",
    "metadata": {
     "papermill": {
-     "duration": 0.005672,
-     "end_time": "2026-06-17T01:07:53.686439+00:00",
+     "duration": 0.006312,
+     "end_time": "2026-06-17T01:12:21.347449+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.680767+00:00",
+     "start_time": "2026-06-17T01:12:21.341137+00:00",
      "status": "completed"
     },
     "tags": []
@@ -48,16 +48,16 @@
    "id": "3dc32d19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:53.700704Z",
-     "iopub.status.busy": "2026-06-17T01:07:53.700302Z",
-     "iopub.status.idle": "2026-06-17T01:07:53.709191Z",
-     "shell.execute_reply": "2026-06-17T01:07:53.708264Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.360877Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.360598Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.368396Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.367745Z"
     },
     "papermill": {
-     "duration": 0.017289,
-     "end_time": "2026-06-17T01:07:53.710126+00:00",
+     "duration": 0.014831,
+     "end_time": "2026-06-17T01:12:21.369331+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.692837+00:00",
+     "start_time": "2026-06-17T01:12:21.354500+00:00",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "23731406",
    "metadata": {
     "papermill": {
-     "duration": 0.005029,
-     "end_time": "2026-06-17T01:07:53.720801+00:00",
+     "duration": 0.005545,
+     "end_time": "2026-06-17T01:12:21.380612+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.715772+00:00",
+     "start_time": "2026-06-17T01:12:21.375067+00:00",
      "status": "completed"
     },
     "tags": []
@@ -144,16 +144,16 @@
    "id": "f1d96718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:53.732963Z",
-     "iopub.status.busy": "2026-06-17T01:07:53.732663Z",
-     "iopub.status.idle": "2026-06-17T01:07:53.739019Z",
-     "shell.execute_reply": "2026-06-17T01:07:53.738342Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.394070Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.393836Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.400972Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.400267Z"
     },
     "papermill": {
-     "duration": 0.013917,
-     "end_time": "2026-06-17T01:07:53.739626+00:00",
+     "duration": 0.015274,
+     "end_time": "2026-06-17T01:12:21.401588+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.725709+00:00",
+     "start_time": "2026-06-17T01:12:21.386314+00:00",
      "status": "completed"
     },
     "tags": []
@@ -236,10 +236,10 @@
    "id": "3827f67e",
    "metadata": {
     "papermill": {
-     "duration": 0.005186,
-     "end_time": "2026-06-17T01:07:53.750038+00:00",
+     "duration": 0.005616,
+     "end_time": "2026-06-17T01:12:21.413037+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.744852+00:00",
+     "start_time": "2026-06-17T01:12:21.407421+00:00",
      "status": "completed"
     },
     "tags": []
@@ -261,10 +261,10 @@
    "id": "59e172f2",
    "metadata": {
     "papermill": {
-     "duration": 0.005447,
-     "end_time": "2026-06-17T01:07:53.760707+00:00",
+     "duration": 0.005148,
+     "end_time": "2026-06-17T01:12:21.423603+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.755260+00:00",
+     "start_time": "2026-06-17T01:12:21.418455+00:00",
      "status": "completed"
     },
     "tags": []
@@ -299,16 +299,16 @@
    "id": "581df035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:53.775676Z",
-     "iopub.status.busy": "2026-06-17T01:07:53.775179Z",
-     "iopub.status.idle": "2026-06-17T01:07:53.783764Z",
-     "shell.execute_reply": "2026-06-17T01:07:53.782843Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.435145Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.434908Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.442189Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.441401Z"
     },
     "papermill": {
-     "duration": 0.01849,
-     "end_time": "2026-06-17T01:07:53.784649+00:00",
+     "duration": 0.014192,
+     "end_time": "2026-06-17T01:12:21.442887+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.766159+00:00",
+     "start_time": "2026-06-17T01:12:21.428695+00:00",
      "status": "completed"
     },
     "tags": []
@@ -381,10 +381,10 @@
    "id": "72e21fc7",
    "metadata": {
     "papermill": {
-     "duration": 0.005686,
-     "end_time": "2026-06-17T01:07:53.796685+00:00",
+     "duration": 0.005412,
+     "end_time": "2026-06-17T01:12:21.453591+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.790999+00:00",
+     "start_time": "2026-06-17T01:12:21.448179+00:00",
      "status": "completed"
     },
     "tags": []
@@ -408,16 +408,16 @@
    "id": "eed948cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:53.809340Z",
-     "iopub.status.busy": "2026-06-17T01:07:53.809115Z",
-     "iopub.status.idle": "2026-06-17T01:07:53.814986Z",
-     "shell.execute_reply": "2026-06-17T01:07:53.814313Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.466143Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.465930Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.471650Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.470924Z"
     },
     "papermill": {
-     "duration": 0.013507,
-     "end_time": "2026-06-17T01:07:53.815843+00:00",
+     "duration": 0.012824,
+     "end_time": "2026-06-17T01:12:21.472256+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.802336+00:00",
+     "start_time": "2026-06-17T01:12:21.459432+00:00",
      "status": "completed"
     },
     "tags": []
@@ -507,10 +507,10 @@
    "id": "85c22afd",
    "metadata": {
     "papermill": {
-     "duration": 0.005499,
-     "end_time": "2026-06-17T01:07:53.827090+00:00",
+     "duration": 0.005623,
+     "end_time": "2026-06-17T01:12:21.483336+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.821591+00:00",
+     "start_time": "2026-06-17T01:12:21.477713+00:00",
      "status": "completed"
     },
     "tags": []
@@ -529,16 +529,16 @@
    "id": "1c109513",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:53.838963Z",
-     "iopub.status.busy": "2026-06-17T01:07:53.838753Z",
-     "iopub.status.idle": "2026-06-17T01:07:53.845473Z",
-     "shell.execute_reply": "2026-06-17T01:07:53.844854Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.494614Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.494367Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.501243Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.500341Z"
     },
     "papermill": {
-     "duration": 0.013682,
-     "end_time": "2026-06-17T01:07:53.845985+00:00",
+     "duration": 0.013517,
+     "end_time": "2026-06-17T01:12:21.501865+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.832303+00:00",
+     "start_time": "2026-06-17T01:12:21.488348+00:00",
      "status": "completed"
     },
     "tags": []
@@ -651,10 +651,10 @@
    "id": "bf930a24",
    "metadata": {
     "papermill": {
-     "duration": 0.005054,
-     "end_time": "2026-06-17T01:07:53.856779+00:00",
+     "duration": 0.005149,
+     "end_time": "2026-06-17T01:12:21.512266+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.851725+00:00",
+     "start_time": "2026-06-17T01:12:21.507117+00:00",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +685,10 @@
    "id": "d6bb9fe1",
    "metadata": {
     "papermill": {
-     "duration": 0.005566,
-     "end_time": "2026-06-17T01:07:53.867527+00:00",
+     "duration": 0.004686,
+     "end_time": "2026-06-17T01:12:21.522275+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.861961+00:00",
+     "start_time": "2026-06-17T01:12:21.517589+00:00",
      "status": "completed"
     },
     "tags": []
@@ -715,16 +715,16 @@
    "id": "2c0873ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:53.879549Z",
-     "iopub.status.busy": "2026-06-17T01:07:53.879325Z",
-     "iopub.status.idle": "2026-06-17T01:07:53.887713Z",
-     "shell.execute_reply": "2026-06-17T01:07:53.887172Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.532817Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.532606Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.540048Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.539442Z"
     },
     "papermill": {
-     "duration": 0.015631,
-     "end_time": "2026-06-17T01:07:53.888678+00:00",
+     "duration": 0.013722,
+     "end_time": "2026-06-17T01:12:21.540567+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.873047+00:00",
+     "start_time": "2026-06-17T01:12:21.526845+00:00",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +846,10 @@
    "id": "0f9984a1",
    "metadata": {
     "papermill": {
-     "duration": 0.006171,
-     "end_time": "2026-06-17T01:07:53.900337+00:00",
+     "duration": 0.004809,
+     "end_time": "2026-06-17T01:12:21.550463+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.894166+00:00",
+     "start_time": "2026-06-17T01:12:21.545654+00:00",
      "status": "completed"
     },
     "tags": []
@@ -882,16 +882,16 @@
    "id": "9a30e01b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:53.911974Z",
-     "iopub.status.busy": "2026-06-17T01:07:53.911761Z",
-     "iopub.status.idle": "2026-06-17T01:07:53.917593Z",
-     "shell.execute_reply": "2026-06-17T01:07:53.916733Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.561806Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.561471Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.569241Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.568346Z"
     },
     "papermill": {
-     "duration": 0.012788,
-     "end_time": "2026-06-17T01:07:53.918382+00:00",
+     "duration": 0.01472,
+     "end_time": "2026-06-17T01:12:21.569881+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.905594+00:00",
+     "start_time": "2026-06-17T01:12:21.555161+00:00",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +974,10 @@
    "id": "74c02d03",
    "metadata": {
     "papermill": {
-     "duration": 0.005383,
-     "end_time": "2026-06-17T01:07:53.929425+00:00",
+     "duration": 0.006785,
+     "end_time": "2026-06-17T01:12:21.582386+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.924042+00:00",
+     "start_time": "2026-06-17T01:12:21.575601+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1013,16 +1013,16 @@
    "id": "83e5f5eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:53.942914Z",
-     "iopub.status.busy": "2026-06-17T01:07:53.942707Z",
-     "iopub.status.idle": "2026-06-17T01:07:53.951228Z",
-     "shell.execute_reply": "2026-06-17T01:07:53.950487Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.593320Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.593123Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.601777Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.601065Z"
     },
     "papermill": {
-     "duration": 0.017156,
-     "end_time": "2026-06-17T01:07:53.951858+00:00",
+     "duration": 0.015064,
+     "end_time": "2026-06-17T01:12:21.602275+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.934702+00:00",
+     "start_time": "2026-06-17T01:12:21.587211+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1187,10 +1187,10 @@
    "id": "3653b321",
    "metadata": {
     "papermill": {
-     "duration": 0.005406,
-     "end_time": "2026-06-17T01:07:53.962634+00:00",
+     "duration": 0.005023,
+     "end_time": "2026-06-17T01:12:21.612599+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.957228+00:00",
+     "start_time": "2026-06-17T01:12:21.607576+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1223,16 +1223,16 @@
    "id": "dc08268f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:53.974160Z",
-     "iopub.status.busy": "2026-06-17T01:07:53.973938Z",
-     "iopub.status.idle": "2026-06-17T01:07:53.979903Z",
-     "shell.execute_reply": "2026-06-17T01:07:53.979154Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.624375Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.624151Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.629333Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.628584Z"
     },
     "papermill": {
-     "duration": 0.012863,
-     "end_time": "2026-06-17T01:07:53.980706+00:00",
+     "duration": 0.012352,
+     "end_time": "2026-06-17T01:12:21.629897+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.967843+00:00",
+     "start_time": "2026-06-17T01:12:21.617545+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1308,10 +1308,10 @@
    "id": "a575226a",
    "metadata": {
     "papermill": {
-     "duration": 0.005635,
-     "end_time": "2026-06-17T01:07:53.991766+00:00",
+     "duration": 0.005327,
+     "end_time": "2026-06-17T01:12:21.640585+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.986131+00:00",
+     "start_time": "2026-06-17T01:12:21.635258+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1342,10 +1342,10 @@
    "id": "1bd557a0",
    "metadata": {
     "papermill": {
-     "duration": 0.005525,
-     "end_time": "2026-06-17T01:07:54.002719+00:00",
+     "duration": 0.005116,
+     "end_time": "2026-06-17T01:12:21.650890+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:53.997194+00:00",
+     "start_time": "2026-06-17T01:12:21.645774+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1385,16 +1385,16 @@
    "id": "f9d67f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.015790Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.015529Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.025618Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.024767Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.662565Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.662359Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.671536Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.670892Z"
     },
     "papermill": {
-     "duration": 0.018041,
-     "end_time": "2026-06-17T01:07:54.026432+00:00",
+     "duration": 0.016106,
+     "end_time": "2026-06-17T01:12:21.672230+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.008391+00:00",
+     "start_time": "2026-06-17T01:12:21.656124+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1537,10 +1537,10 @@
    "id": "2f9d2c01",
    "metadata": {
     "papermill": {
-     "duration": 0.005391,
-     "end_time": "2026-06-17T01:07:54.037409+00:00",
+     "duration": 0.005247,
+     "end_time": "2026-06-17T01:12:21.682914+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.032018+00:00",
+     "start_time": "2026-06-17T01:12:21.677667+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1569,16 +1569,16 @@
    "id": "8917b738",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.049901Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.049407Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.053359Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.052759Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.695871Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.695649Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.699129Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.698507Z"
     },
     "papermill": {
-     "duration": 0.011085,
-     "end_time": "2026-06-17T01:07:54.053919+00:00",
+     "duration": 0.010503,
+     "end_time": "2026-06-17T01:12:21.699795+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.042834+00:00",
+     "start_time": "2026-06-17T01:12:21.689292+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1626,10 +1626,10 @@
    "id": "a2edb6e2",
    "metadata": {
     "papermill": {
-     "duration": 0.005372,
-     "end_time": "2026-06-17T01:07:54.064638+00:00",
+     "duration": 0.005413,
+     "end_time": "2026-06-17T01:12:21.710321+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.059266+00:00",
+     "start_time": "2026-06-17T01:12:21.704908+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1662,16 +1662,16 @@
    "id": "54a6b7c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.078014Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.077788Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.083085Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.082392Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.722528Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.722307Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.727524Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.726614Z"
     },
     "papermill": {
-     "duration": 0.012386,
-     "end_time": "2026-06-17T01:07:54.083824+00:00",
+     "duration": 0.012672,
+     "end_time": "2026-06-17T01:12:21.728071+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.071438+00:00",
+     "start_time": "2026-06-17T01:12:21.715399+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1732,10 +1732,10 @@
    "id": "d74db354",
    "metadata": {
     "papermill": {
-     "duration": 0.005735,
-     "end_time": "2026-06-17T01:07:54.095407+00:00",
+     "duration": 0.005883,
+     "end_time": "2026-06-17T01:12:21.740178+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.089672+00:00",
+     "start_time": "2026-06-17T01:12:21.734295+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1759,10 +1759,10 @@
    "id": "3c2e7728",
    "metadata": {
     "papermill": {
-     "duration": 0.005614,
-     "end_time": "2026-06-17T01:07:54.106946+00:00",
+     "duration": 0.005851,
+     "end_time": "2026-06-17T01:12:21.752087+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.101332+00:00",
+     "start_time": "2026-06-17T01:12:21.746236+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1787,16 +1787,16 @@
    "id": "dada4cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.120051Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.119852Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.128149Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.127295Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.765281Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.765082Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.773782Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.773021Z"
     },
     "papermill": {
-     "duration": 0.015892,
-     "end_time": "2026-06-17T01:07:54.128710+00:00",
+     "duration": 0.016436,
+     "end_time": "2026-06-17T01:12:21.774469+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.112818+00:00",
+     "start_time": "2026-06-17T01:12:21.758033+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1922,10 +1922,10 @@
    "id": "3cc1a67b",
    "metadata": {
     "papermill": {
-     "duration": 0.00582,
-     "end_time": "2026-06-17T01:07:54.140782+00:00",
+     "duration": 0.005826,
+     "end_time": "2026-06-17T01:12:21.786637+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.134962+00:00",
+     "start_time": "2026-06-17T01:12:21.780811+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1953,10 +1953,10 @@
    "id": "74eec2fe",
    "metadata": {
     "papermill": {
-     "duration": 0.005407,
-     "end_time": "2026-06-17T01:07:54.151891+00:00",
+     "duration": 0.006278,
+     "end_time": "2026-06-17T01:12:21.798861+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.146484+00:00",
+     "start_time": "2026-06-17T01:12:21.792583+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1994,16 +1994,16 @@
    "id": "a916457d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.164431Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.164229Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.175640Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.174818Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.812346Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.811946Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.823305Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.822584Z"
     },
     "papermill": {
-     "duration": 0.018883,
-     "end_time": "2026-06-17T01:07:54.176288+00:00",
+     "duration": 0.019033,
+     "end_time": "2026-06-17T01:12:21.823845+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.157405+00:00",
+     "start_time": "2026-06-17T01:12:21.804812+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2051,16 +2051,16 @@
    "id": "426133ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.188715Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.188525Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.195461Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.194565Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.836961Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.836535Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.845605Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.844683Z"
     },
     "papermill": {
-     "duration": 0.013834,
-     "end_time": "2026-06-17T01:07:54.196149+00:00",
+     "duration": 0.016463,
+     "end_time": "2026-06-17T01:12:21.846204+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.182315+00:00",
+     "start_time": "2026-06-17T01:12:21.829741+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2178,16 +2178,16 @@
    "id": "6e670307",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.211501Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.211179Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.217657Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.216562Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.860319Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.860119Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.865005Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.864332Z"
     },
     "papermill": {
-     "duration": 0.016318,
-     "end_time": "2026-06-17T01:07:54.218659+00:00",
+     "duration": 0.013033,
+     "end_time": "2026-06-17T01:12:21.865560+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.202341+00:00",
+     "start_time": "2026-06-17T01:12:21.852527+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2244,10 +2244,10 @@
    "id": "d4216022",
    "metadata": {
     "papermill": {
-     "duration": 0.008579,
-     "end_time": "2026-06-17T01:07:54.236544+00:00",
+     "duration": 0.006013,
+     "end_time": "2026-06-17T01:12:21.877564+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.227965+00:00",
+     "start_time": "2026-06-17T01:12:21.871551+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2285,10 +2285,10 @@
    "id": "ba9beb92",
    "metadata": {
     "papermill": {
-     "duration": 0.008827,
-     "end_time": "2026-06-17T01:07:54.253269+00:00",
+     "duration": 0.005838,
+     "end_time": "2026-06-17T01:12:21.889334+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.244442+00:00",
+     "start_time": "2026-06-17T01:12:21.883496+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2304,10 +2304,10 @@
    "id": "3c800f32",
    "metadata": {
     "papermill": {
-     "duration": 0.009883,
-     "end_time": "2026-06-17T01:07:54.270902+00:00",
+     "duration": 0.0062,
+     "end_time": "2026-06-17T01:12:21.901815+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.261019+00:00",
+     "start_time": "2026-06-17T01:12:21.895615+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2330,16 +2330,16 @@
    "id": "5101d0d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.288048Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.287818Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.295704Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.294921Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.915941Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.915673Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.924268Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.923428Z"
     },
     "papermill": {
-     "duration": 0.015985,
-     "end_time": "2026-06-17T01:07:54.296382+00:00",
+     "duration": 0.016369,
+     "end_time": "2026-06-17T01:12:21.924832+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.280397+00:00",
+     "start_time": "2026-06-17T01:12:21.908463+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2447,10 +2447,10 @@
    "id": "a5281a2e",
    "metadata": {
     "papermill": {
-     "duration": 0.005695,
-     "end_time": "2026-06-17T01:07:54.308292+00:00",
+     "duration": 0.005995,
+     "end_time": "2026-06-17T01:12:21.937003+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.302597+00:00",
+     "start_time": "2026-06-17T01:12:21.931008+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2476,16 +2476,16 @@
    "id": "0abbe4b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.321144Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.320939Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.324367Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.323773Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.950356Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.950115Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.954099Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.953478Z"
     },
     "papermill": {
-     "duration": 0.011177,
-     "end_time": "2026-06-17T01:07:54.325167+00:00",
+     "duration": 0.01178,
+     "end_time": "2026-06-17T01:12:21.954865+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.313990+00:00",
+     "start_time": "2026-06-17T01:12:21.943085+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2526,10 +2526,10 @@
    "id": "2936e442",
    "metadata": {
     "papermill": {
-     "duration": 0.005794,
-     "end_time": "2026-06-17T01:07:54.336708+00:00",
+     "duration": 0.005823,
+     "end_time": "2026-06-17T01:12:21.966951+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.330914+00:00",
+     "start_time": "2026-06-17T01:12:21.961128+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2551,16 +2551,16 @@
    "id": "174aa8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.347679Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.347499Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.353413Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.352834Z"
+     "iopub.execute_input": "2026-06-17T01:12:21.980259Z",
+     "iopub.status.busy": "2026-06-17T01:12:21.980035Z",
+     "iopub.status.idle": "2026-06-17T01:12:21.985994Z",
+     "shell.execute_reply": "2026-06-17T01:12:21.985411Z"
     },
     "papermill": {
-     "duration": 0.012196,
-     "end_time": "2026-06-17T01:07:54.353921+00:00",
+     "duration": 0.01407,
+     "end_time": "2026-06-17T01:12:21.986863+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.341725+00:00",
+     "start_time": "2026-06-17T01:12:21.972793+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2641,10 +2641,10 @@
    "id": "sl7ex2var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.005376,
-     "end_time": "2026-06-17T01:07:54.364761+00:00",
+     "duration": 0.006636,
+     "end_time": "2026-06-17T01:12:21.999548+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.359385+00:00",
+     "start_time": "2026-06-17T01:12:21.992912+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2667,16 +2667,16 @@
    "id": "sl7ex2var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.376859Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.376675Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.380459Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.379566Z"
+     "iopub.execute_input": "2026-06-17T01:12:22.013236Z",
+     "iopub.status.busy": "2026-06-17T01:12:22.013008Z",
+     "iopub.status.idle": "2026-06-17T01:12:22.017668Z",
+     "shell.execute_reply": "2026-06-17T01:12:22.016895Z"
     },
     "papermill": {
-     "duration": 0.011139,
-     "end_time": "2026-06-17T01:07:54.381197+00:00",
+     "duration": 0.012335,
+     "end_time": "2026-06-17T01:12:22.018321+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.370058+00:00",
+     "start_time": "2026-06-17T01:12:22.005986+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2724,23 +2724,23 @@
    "id": "0962260b",
    "metadata": {
     "papermill": {
-     "duration": 0.005064,
-     "end_time": "2026-06-17T01:07:54.391632+00:00",
+     "duration": 0.006514,
+     "end_time": "2026-06-17T01:12:22.031548+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.386568+00:00",
+     "start_time": "2026-06-17T01:12:22.025034+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Detecter les hallucinations du LLM\n",
+    "### Exemple guide 3 : Detecter les hallucinations du LLM\n",
     "\n",
-    "Un LLM peut generer des regles qui semblent correctes mais qui sont en fait des **hallucinations** (conditions impossibles ou triviales). Implementez un detecteur d'hallucinations.\n",
+    "Un LLM peut generer des regles qui semblent correctes mais qui sont en fait des **hallucinations** : conditions impossibles (contradiction sur un meme attribut), attributs hors domaine, ou tautologie (regle sans condition, qui conclut toujours). Cet exemple guide implemente un detecteur qui parcourt les conditions d'une regle et signale ces trois familles de problemes.\n",
     "\n",
     "**Etapes** :\n",
-    "1. Definir ce qu'est une regle \"hallucinee\" (condition impossible, tautologie, contradiction)\n",
+    "1. Definir ce qu'est une regle \"hallucinee\" (contradiction, attribut invalide, tautologie)\n",
     "2. Implementer `detect_hallucination()`\n",
-    "3. Tester sur des regles problematiques"
+    "3. Tester sur des regles problematiques (contradiction, attribut inexistant, tautologie)\n"
    ]
   },
   {
@@ -2749,16 +2749,16 @@
    "id": "3548d43c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.403424Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.403241Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.407244Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.406744Z"
+     "iopub.execute_input": "2026-06-17T01:12:22.045627Z",
+     "iopub.status.busy": "2026-06-17T01:12:22.045097Z",
+     "iopub.status.idle": "2026-06-17T01:12:22.054382Z",
+     "shell.execute_reply": "2026-06-17T01:12:22.053657Z"
     },
     "papermill": {
-     "duration": 0.010771,
-     "end_time": "2026-06-17T01:07:54.407907+00:00",
+     "duration": 0.017328,
+     "end_time": "2026-06-17T01:12:22.055106+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.397136+00:00",
+     "start_time": "2026-06-17T01:12:22.037778+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2768,29 +2768,80 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : implementez detect_hallucination\n",
-      "Etape 1 : detectez les contradictions (meme attribut, valeurs differentes)\n",
-      "Etape 2 : detectez les attributs invalides\n",
-      "Etape 3 : detectez les tautologies (pas de conditions)\n",
+      "Detection d'hallucinations sur les regles problematiques\n",
+      "==============================================================\n",
+      "H1: Patrons=Full AND Patrons=Some => WillWait\n",
+      "    -> HALLUCINATION\n",
+      "       - Contradiction : 'Patrons=Full' et 'Patrons=Some' sont incompatibles\n",
       "\n",
-      "Regles a tester :\n",
-      "  H1: Patrons=Full AND Patrons=Some => WillWait\n",
-      "  H2: AttributInexistant=v => WillWait\n",
-      "  H3:  => WillWait\n"
+      "H2: AttributInexistant=v => WillWait\n",
+      "    -> HALLUCINATION\n",
+      "       - Attribut invalide : 'AttributInexistant' (hors du domaine connu)\n",
+      "\n",
+      "H3:  => WillWait\n",
+      "    -> HALLUCINATION\n",
+      "       - Tautologie : la regle n'a aucune condition (elle conclut toujours, sans specialisation)\n",
+      "\n",
+      "Lecture : les trois regles declenchent chacune une famille distincte\n",
+      "d'hallucination. H1 est une contradiction (Patrons ne peut valoir Full\n",
+      "ET Some a la fois) ; H2 cite un attribut inconnu du domaine ; H3 est une\n",
+      "tautologie (sans condition, la regle conclut pour TOUT exemple, donc ne\n",
+      "specialise rien). Un oracle symbolique seul ne detecte pas ces defauts\n",
+      "(il mesure TP/FP/FN) : ce detecteur complementaire filtre les candidats\n",
+      "du LLM AVANT la verification, pour eviter de valider des regles vides\n",
+      "de sens.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 3 : Detection d'hallucinations\n",
+    "# Exemple guide 3 : Detection d'hallucinations\n",
+    "\n",
     "\n",
     "def detect_hallucination(rule: HornClause, valid_attrs: list[str], valid_values: dict) -> list[str]:\n",
     "    \"\"\"Detecte les problemes potentiels dans une regle.\n",
-    "    \n",
+    "\n",
     "    Retourne une liste de problemes detectes (vide = OK).\n",
+    "    Trois familles d'hallucinations :\n",
+    "      - Tautologie : aucune condition (la regle conclut toujours, sans specialisation).\n",
+    "      - Attribut invalide : une condition porte sur un attribut inconnu,\n",
+    "        ou une valeur hors du domaine autorise.\n",
+    "      - Contradiction : deux conditions sur le MEME attribut avec des\n",
+    "        valeurs differentes (la regle n'est jamais satisfaite).\n",
     "    \"\"\"\n",
     "    problems = []\n",
-    "    pass  # TODO etudiant : implementez la detection\n",
-    "    return problems  # Retourne une liste vide par defaut\n",
+    "\n",
+    "    # Tautologie : aucune condition -> la regle conclut dans tous les cas\n",
+    "    if not rule.conditions:\n",
+    "        problems.append(\"Tautologie : la regle n'a aucune condition \"\n",
+    "                        \"(elle conclut toujours, sans specialisation)\")\n",
+    "        return problems  # rien d'autre a verifier\n",
+    "\n",
+    "    seen: dict[str, str] = {}  # attribut -> premiere valeur vue\n",
+    "    for cond in rule.conditions:\n",
+    "        if \"=\" not in cond:\n",
+    "            problems.append(f\"Condition mal formee (sans '=') : '{cond}'\")\n",
+    "            continue\n",
+    "        attr, _, value = cond.partition(\"=\")\n",
+    "        attr, value = attr.strip(), value.strip()\n",
+    "\n",
+    "        # Attribut invalide : hors du domaine d'attributs connus\n",
+    "        if attr not in valid_attrs:\n",
+    "            problems.append(f\"Attribut invalide : '{attr}' (hors du domaine connu)\")\n",
+    "            continue  # inutile de verifier la valeur d'un attribut inconnu\n",
+    "\n",
+    "        # Valeur hors domaine\n",
+    "        if attr in valid_values and value not in valid_values[attr]:\n",
+    "            problems.append(f\"Valeur hors domaine : '{attr}={value}' \"\n",
+    "                            f\"(valeurs valides : {valid_values[attr]})\")\n",
+    "\n",
+    "        # Contradiction : meme attribut deja vu avec une valeur differente\n",
+    "        if attr in seen and seen[attr] != value:\n",
+    "            problems.append(f\"Contradiction : '{attr}={seen[attr]}' et \"\n",
+    "                            f\"'{attr}={value}' sont incompatibles\")\n",
+    "        else:\n",
+    "            seen[attr] = value\n",
+    "\n",
+    "    return problems\n",
     "\n",
     "\n",
     "# Tests : regles problematiques a detecter\n",
@@ -2805,17 +2856,112 @@
     "    \"Hungry\": [\"Yes\", \"No\"],\n",
     "    \"Type\": [\"French\", \"Thai\", \"Burger\", \"Italian\"],\n",
     "}\n",
+    "valid_attrs = list(valid_values.keys())\n",
     "\n",
-    "print(\"Exercice a completer : implementez detect_hallucination\")\n",
-    "print(\"Etape 1 : detectez les contradictions (meme attribut, valeurs differentes)\")\n",
-    "print(\"Etape 2 : detectez les attributs invalides\")\n",
-    "print(\"Etape 3 : detectez les tautologies (pas de conditions)\")\n",
-    "print()\n",
-    "print(\"Regles a tester :\")\n",
+    "print(\"Detection d'hallucinations sur les regles problematiques\")\n",
+    "print(\"=\" * 62)\n",
     "for i, rule in enumerate(test_rules):\n",
-    "    print(f\"  H{i+1}: {rule}\")\n",
+    "    problems = detect_hallucination(rule, valid_attrs, valid_values)\n",
+    "    statut = \"OK (pas d'hallucination)\" if not problems else \"HALLUCINATION\"\n",
+    "    print(f\"H{i+1}: {rule}\")\n",
+    "    print(f\"    -> {statut}\")\n",
+    "    for p in problems:\n",
+    "        print(f\"       - {p}\")\n",
+    "    print()\n",
     "\n",
-    "# Indice : parcourez les conditions et verifiez coherence et validite"
+    "print(\"Lecture : les trois regles declenchent chacune une famille distincte\")\n",
+    "print(\"d'hallucination. H1 est une contradiction (Patrons ne peut valoir Full\")\n",
+    "print(\"ET Some a la fois) ; H2 cite un attribut inconnu du domaine ; H3 est une\")\n",
+    "print(\"tautologie (sans condition, la regle conclut pour TOUT exemple, donc ne\")\n",
+    "print(\"specialise rien). Un oracle symbolique seul ne detecte pas ces defauts\")\n",
+    "print(\"(il mesure TP/FP/FN) : ce detecteur complementaire filtre les candidats\")\n",
+    "print(\"du LLM AVANT la verification, pour eviter de valider des regles vides\")\n",
+    "print(\"de sens.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl7ex3var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0066,
+     "end_time": "2026-06-17T01:12:22.068748+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:12:22.062148+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (variation) : Detecter une regle non confirmee par les donnees\n",
+    "\n",
+    "Une regle peut etre **formellement valide** (pas de contradiction, attributs corrects, conditions presentes) et pourtant constituer une **hallucination vis-a-vis des donnees** : si AUCUN exemple d'entrainement ne satisfait toutes ses conditions, la regle n'est jamais declenchee et n'est pas confirmee par l'experience. Etendez le detecteur pour signaler ces regles \"mortes\".\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Ecrire `regle_non_confirmee(rule, examples)` : retourne `True` si aucun exemple ne satisfait toutes les conditions de la regle\n",
+    "2. Appliquer `detect_hallucination` (formel) PUIS `regle_non_confirmee` (donnees) sur un jeu de regles\n",
+    "3. Distinguer les deux types de problemes dans l'affichage\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "sl7ex3var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:12:22.083538Z",
+     "iopub.status.busy": "2026-06-17T01:12:22.083311Z",
+     "iopub.status.idle": "2026-06-17T01:12:22.087364Z",
+     "shell.execute_reply": "2026-06-17T01:12:22.086654Z"
+    },
+    "papermill": {
+     "duration": 0.01235,
+     "end_time": "2026-06-17T01:12:22.088010+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:12:22.075660+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : detecter les regles non confirmees par les donnees\n",
+      "Etape 1 : ecrivez regle_non_confirmee(rule, examples)\n",
+      "Etape 2 : combinez detect_hallucination (formel) et regle_non_confirmee (donnees)\n",
+      "Etape 3 : affichez les deux types de problemes distinctement\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (variation) : regle non confirmee par les donnees\n",
+    "# TODO etudiant : une regle formellement valide peut etre \"morte\" si\n",
+    "# aucun exemple d'entrainement ne satisfait toutes ses conditions.\n",
+    "\n",
+    "# Etape 1 : fonction de couverture par les donnees\n",
+    "def regle_non_confirmee(rule, examples):\n",
+    "    \"\"\"Retourne True si AUCUN exemple ne satisfait toutes les conditions.\"\"\"\n",
+    "    # TODO etudiant : parcourez examples, testez rule.evaluate(ex)\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "# Etape 2 : combiner detection formelle + couverture donnees\n",
+    "# for rule in regles_test:\n",
+    "#     formel = detect_hallucination(rule, valid_attrs, valid_values)\n",
+    "#     morte = regle_non_confirmee(rule, EXAMPLES)\n",
+    "#     ...\n",
+    "\n",
+    "# Etape 3 : afficher les deux types de problemes distinctement\n",
+    "print(\"Exercice a completer : detecter les regles non confirmees par les donnees\")\n",
+    "print(\"Etape 1 : ecrivez regle_non_confirmee(rule, examples)\")\n",
+    "print(\"Etape 2 : combinez detect_hallucination (formel) et regle_non_confirmee (donnees)\")\n",
+    "print(\"Etape 3 : affichez les deux types de problemes distinctement\")\n",
+    "\n",
+    "# Indice : HornClause.evaluate(ex) retourne True si toutes les conditions\n",
+    "# sont satisfaites ; une regle \"morte\" n'a aucun exemple qui l'active.\n",
+    "# result = None  # TODO etudiant\n"
    ]
   },
   {
@@ -2823,10 +2969,10 @@
    "id": "3818d99f",
    "metadata": {
     "papermill": {
-     "duration": 0.00543,
-     "end_time": "2026-06-17T01:07:54.418870+00:00",
+     "duration": 0.0068,
+     "end_time": "2026-06-17T01:12:22.101503+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.413440+00:00",
+     "start_time": "2026-06-17T01:12:22.094703+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2841,20 +2987,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "b1ef475c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:07:54.430603Z",
-     "iopub.status.busy": "2026-06-17T01:07:54.430415Z",
-     "iopub.status.idle": "2026-06-17T01:07:54.433790Z",
-     "shell.execute_reply": "2026-06-17T01:07:54.433132Z"
+     "iopub.execute_input": "2026-06-17T01:12:22.118315Z",
+     "iopub.status.busy": "2026-06-17T01:12:22.118086Z",
+     "iopub.status.idle": "2026-06-17T01:12:22.122406Z",
+     "shell.execute_reply": "2026-06-17T01:12:22.121561Z"
     },
     "papermill": {
-     "duration": 0.010562,
-     "end_time": "2026-06-17T01:07:54.434385+00:00",
+     "duration": 0.013088,
+     "end_time": "2026-06-17T01:12:22.123034+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.423823+00:00",
+     "start_time": "2026-06-17T01:12:22.109946+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2896,10 +3042,10 @@
    "id": "7cb00ad4",
    "metadata": {
     "papermill": {
-     "duration": 0.00573,
-     "end_time": "2026-06-17T01:07:54.445769+00:00",
+     "duration": 0.006262,
+     "end_time": "2026-06-17T01:12:22.137350+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.440039+00:00",
+     "start_time": "2026-06-17T01:12:22.131088+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2951,10 +3097,10 @@
    "id": "227e37ae",
    "metadata": {
     "papermill": {
-     "duration": 0.005149,
-     "end_time": "2026-06-17T01:07:54.456320+00:00",
+     "duration": 0.006271,
+     "end_time": "2026-06-17T01:12:22.149817+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.451171+00:00",
+     "start_time": "2026-06-17T01:12:22.143546+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2982,10 +3128,10 @@
    "id": "b2e6b9c6",
    "metadata": {
     "papermill": {
-     "duration": 0.005304,
-     "end_time": "2026-06-17T01:07:54.467384+00:00",
+     "duration": 0.006315,
+     "end_time": "2026-06-17T01:12:22.162720+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:07:54.462080+00:00",
+     "start_time": "2026-06-17T01:12:22.156405+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3027,14 +3173,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.003232,
-   "end_time": "2026-06-17T01:07:54.710252+00:00",
+   "duration": 2.998269,
+   "end_time": "2026-06-17T01:12:22.405305+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T01:07:51.707020+00:00",
+   "start_time": "2026-06-17T01:12:19.407036+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
> **PR empilée (stacked)** : base = `feat/sl7-ex2-guided` (#3173). Merger dans l'ordre #3172 -> #3173 -> celle-ci. Le diff ne montre que la contribution Ex3.

## Contexte

Rollout convention **3 exercices/notebook** (#2161), serie SymbolicLearning, partition po-2024. **SL-7 Exercice 3** (Detecter les hallucinations du LLM) — le stub avait `detect_hallucination()` en `pass`. Resolu en exemple guide + variation.

## Livrable

**Ex3 resolu en exemple guide** (detecteur d'hallucinations) :
- `detect_hallucination(rule, valid_attrs, valid_values) -> list[str]` implementee : parse chaque condition `attr=value`, detecte 3 familles :
  - **Tautologie** : aucune condition (conclut toujours, ne specialise rien).
  - **Attribut invalide** : attribut hors `valid_attrs`, ou valeur hors domaine.
  - **Contradiction** : deux conditions sur le MEME attribut avec valeurs differentes.
- Markdown relicole « Exercice 3 » -> « **Exemple guide 3** ».

**Nouvel exercice en variation** : « Detecter une regle non confirmee par les donnees » — une regle formellement valide peut etre "morte" si aucun exemple ne satisfait ses conditions (hallucination vis-a-vis des donnees). Stub `regle_non_confirmee(rule, examples)` a combiner avec `detect_hallucination`. C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`notebook_tools.py execute --kernel python3`) : **SUCCESS** 5.4s, 1/1 notebooks, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 23 cellules code, toutes `execution_count` set + outputs presents + 0 output d'erreur. Section 7 (demo Gemini 3.5 flash reelle) restauree depuis `origin/main`.
- **Sortie Ex3** : les 3 regles de test sont toutes flaggues HALLUCINATION, une famille chacune :
  - H1 `Patrons=Full AND Patrons=Some` -> **Contradiction**
  - H2 `AttributInexistant=v` -> **Attribut invalide**
  - H3 `[]` (sans condition) -> **Tautologie**

## Lecture pedagogique

Un oracle symbolique seul (TP/FP/FN) ne detecte pas ces defauts : une tautologie a TP eleves mais ne specialise rien, une contradiction n'est jamais satisfaite. Ce detecteur filtre les candidats du LLM **avant** la verification, pour ne pas valider des regles vides de sens.

## Anti-regression (verifie vs base `feat/sl7-ex2-guided`)

- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- Source code +73 lignes (stub Ex3 -> solution + stub variation). Markdown Ex3 relicole.
- 1 fichier `.ipynb`. Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
