### PR TITLE
feat(sl7): resolve Ex4 (generator validation rate) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "097196f2",
    "metadata": {
     "papermill": {
-     "duration": 0.006312,
-     "end_time": "2026-06-17T01:12:21.347449+00:00",
+     "duration": 0.005442,
+     "end_time": "2026-06-17T01:18:15.924348+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.341137+00:00",
+     "start_time": "2026-06-17T01:18:15.918906+00:00",
      "status": "completed"
     },
     "tags": []
@@ -48,16 +48,16 @@
    "id": "3dc32d19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.360877Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.360598Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.368396Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.367745Z"
+     "iopub.execute_input": "2026-06-17T01:18:15.936942Z",
+     "iopub.status.busy": "2026-06-17T01:18:15.936716Z",
+     "iopub.status.idle": "2026-06-17T01:18:15.944336Z",
+     "shell.execute_reply": "2026-06-17T01:18:15.943685Z"
     },
     "papermill": {
-     "duration": 0.014831,
-     "end_time": "2026-06-17T01:12:21.369331+00:00",
+     "duration": 0.015308,
+     "end_time": "2026-06-17T01:18:15.945781+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.354500+00:00",
+     "start_time": "2026-06-17T01:18:15.930473+00:00",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "23731406",
    "metadata": {
     "papermill": {
-     "duration": 0.005545,
-     "end_time": "2026-06-17T01:12:21.380612+00:00",
+     "duration": 0.004722,
+     "end_time": "2026-06-17T01:18:15.955780+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.375067+00:00",
+     "start_time": "2026-06-17T01:18:15.951058+00:00",
      "status": "completed"
     },
     "tags": []
@@ -144,16 +144,16 @@
    "id": "f1d96718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.394070Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.393836Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.400972Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.400267Z"
+     "iopub.execute_input": "2026-06-17T01:18:15.966101Z",
+     "iopub.status.busy": "2026-06-17T01:18:15.965888Z",
+     "iopub.status.idle": "2026-06-17T01:18:15.971344Z",
+     "shell.execute_reply": "2026-06-17T01:18:15.970842Z"
     },
     "papermill": {
-     "duration": 0.015274,
-     "end_time": "2026-06-17T01:12:21.401588+00:00",
+     "duration": 0.011867,
+     "end_time": "2026-06-17T01:18:15.972093+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.386314+00:00",
+     "start_time": "2026-06-17T01:18:15.960226+00:00",
      "status": "completed"
     },
     "tags": []
@@ -236,10 +236,10 @@
    "id": "3827f67e",
    "metadata": {
     "papermill": {
-     "duration": 0.005616,
-     "end_time": "2026-06-17T01:12:21.413037+00:00",
+     "duration": 0.005156,
+     "end_time": "2026-06-17T01:18:15.982020+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.407421+00:00",
+     "start_time": "2026-06-17T01:18:15.976864+00:00",
      "status": "completed"
     },
     "tags": []
@@ -261,10 +261,10 @@
    "id": "59e172f2",
    "metadata": {
     "papermill": {
-     "duration": 0.005148,
-     "end_time": "2026-06-17T01:12:21.423603+00:00",
+     "duration": 0.004965,
+     "end_time": "2026-06-17T01:18:15.992699+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.418455+00:00",
+     "start_time": "2026-06-17T01:18:15.987734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -299,16 +299,16 @@
    "id": "581df035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.435145Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.434908Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.442189Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.441401Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.003682Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.003493Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.009850Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.009413Z"
     },
     "papermill": {
-     "duration": 0.014192,
-     "end_time": "2026-06-17T01:12:21.442887+00:00",
+     "duration": 0.012773,
+     "end_time": "2026-06-17T01:18:16.010583+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.428695+00:00",
+     "start_time": "2026-06-17T01:18:15.997810+00:00",
      "status": "completed"
     },
     "tags": []
@@ -381,10 +381,10 @@
    "id": "72e21fc7",
    "metadata": {
     "papermill": {
-     "duration": 0.005412,
-     "end_time": "2026-06-17T01:12:21.453591+00:00",
+     "duration": 0.005254,
+     "end_time": "2026-06-17T01:18:16.021623+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.448179+00:00",
+     "start_time": "2026-06-17T01:18:16.016369+00:00",
      "status": "completed"
     },
     "tags": []
@@ -408,16 +408,16 @@
    "id": "eed948cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.466143Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.465930Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.471650Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.470924Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.033336Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.033123Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.038866Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.037871Z"
     },
     "papermill": {
-     "duration": 0.012824,
-     "end_time": "2026-06-17T01:12:21.472256+00:00",
+     "duration": 0.012831,
+     "end_time": "2026-06-17T01:18:16.039537+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.459432+00:00",
+     "start_time": "2026-06-17T01:18:16.026706+00:00",
      "status": "completed"
     },
     "tags": []
@@ -507,10 +507,10 @@
    "id": "85c22afd",
    "metadata": {
     "papermill": {
-     "duration": 0.005623,
-     "end_time": "2026-06-17T01:12:21.483336+00:00",
+     "duration": 0.005447,
+     "end_time": "2026-06-17T01:18:16.050565+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.477713+00:00",
+     "start_time": "2026-06-17T01:18:16.045118+00:00",
      "status": "completed"
     },
     "tags": []
@@ -529,16 +529,16 @@
    "id": "1c109513",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.494614Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.494367Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.501243Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.500341Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.062776Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.062569Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.069751Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.069044Z"
     },
     "papermill": {
-     "duration": 0.013517,
-     "end_time": "2026-06-17T01:12:21.501865+00:00",
+     "duration": 0.014533,
+     "end_time": "2026-06-17T01:18:16.070618+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.488348+00:00",
+     "start_time": "2026-06-17T01:18:16.056085+00:00",
      "status": "completed"
     },
     "tags": []
@@ -651,10 +651,10 @@
    "id": "bf930a24",
    "metadata": {
     "papermill": {
-     "duration": 0.005149,
-     "end_time": "2026-06-17T01:12:21.512266+00:00",
+     "duration": 0.005366,
+     "end_time": "2026-06-17T01:18:16.081559+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.507117+00:00",
+     "start_time": "2026-06-17T01:18:16.076193+00:00",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +685,10 @@
    "id": "d6bb9fe1",
    "metadata": {
     "papermill": {
-     "duration": 0.004686,
-     "end_time": "2026-06-17T01:12:21.522275+00:00",
+     "duration": 0.005843,
+     "end_time": "2026-06-17T01:18:16.092852+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.517589+00:00",
+     "start_time": "2026-06-17T01:18:16.087009+00:00",
      "status": "completed"
     },
     "tags": []
@@ -715,16 +715,16 @@
    "id": "2c0873ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.532817Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.532606Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.540048Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.539442Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.105080Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.104874Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.113569Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.112988Z"
     },
     "papermill": {
-     "duration": 0.013722,
-     "end_time": "2026-06-17T01:12:21.540567+00:00",
+     "duration": 0.015877,
+     "end_time": "2026-06-17T01:18:16.114343+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.526845+00:00",
+     "start_time": "2026-06-17T01:18:16.098466+00:00",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +846,10 @@
    "id": "0f9984a1",
    "metadata": {
     "papermill": {
-     "duration": 0.004809,
-     "end_time": "2026-06-17T01:12:21.550463+00:00",
+     "duration": 0.005469,
+     "end_time": "2026-06-17T01:18:16.125328+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.545654+00:00",
+     "start_time": "2026-06-17T01:18:16.119859+00:00",
      "status": "completed"
     },
     "tags": []
@@ -882,16 +882,16 @@
    "id": "9a30e01b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.561806Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.561471Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.569241Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.568346Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.137584Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.137356Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.144100Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.143034Z"
     },
     "papermill": {
-     "duration": 0.01472,
-     "end_time": "2026-06-17T01:12:21.569881+00:00",
+     "duration": 0.014263,
+     "end_time": "2026-06-17T01:18:16.144922+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.555161+00:00",
+     "start_time": "2026-06-17T01:18:16.130659+00:00",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +974,10 @@
    "id": "74c02d03",
    "metadata": {
     "papermill": {
-     "duration": 0.006785,
-     "end_time": "2026-06-17T01:12:21.582386+00:00",
+     "duration": 0.007865,
+     "end_time": "2026-06-17T01:18:16.158947+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.575601+00:00",
+     "start_time": "2026-06-17T01:18:16.151082+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1013,16 +1013,16 @@
    "id": "83e5f5eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.593320Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.593123Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.601777Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.601065Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.172165Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.171828Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.180644Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.180064Z"
     },
     "papermill": {
-     "duration": 0.015064,
-     "end_time": "2026-06-17T01:12:21.602275+00:00",
+     "duration": 0.016837,
+     "end_time": "2026-06-17T01:18:16.181639+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.587211+00:00",
+     "start_time": "2026-06-17T01:18:16.164802+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1187,10 +1187,10 @@
    "id": "3653b321",
    "metadata": {
     "papermill": {
-     "duration": 0.005023,
-     "end_time": "2026-06-17T01:12:21.612599+00:00",
+     "duration": 0.005457,
+     "end_time": "2026-06-17T01:18:16.192867+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.607576+00:00",
+     "start_time": "2026-06-17T01:18:16.187410+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1223,16 +1223,16 @@
    "id": "dc08268f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.624375Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.624151Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.629333Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.628584Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.205548Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.205213Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.210960Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.210222Z"
     },
     "papermill": {
-     "duration": 0.012352,
-     "end_time": "2026-06-17T01:12:21.629897+00:00",
+     "duration": 0.013384,
+     "end_time": "2026-06-17T01:18:16.211872+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.617545+00:00",
+     "start_time": "2026-06-17T01:18:16.198488+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1308,10 +1308,10 @@
    "id": "a575226a",
    "metadata": {
     "papermill": {
-     "duration": 0.005327,
-     "end_time": "2026-06-17T01:12:21.640585+00:00",
+     "duration": 0.005921,
+     "end_time": "2026-06-17T01:18:16.223829+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.635258+00:00",
+     "start_time": "2026-06-17T01:18:16.217908+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1342,10 +1342,10 @@
    "id": "1bd557a0",
    "metadata": {
     "papermill": {
-     "duration": 0.005116,
-     "end_time": "2026-06-17T01:12:21.650890+00:00",
+     "duration": 0.005892,
+     "end_time": "2026-06-17T01:18:16.235706+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.645774+00:00",
+     "start_time": "2026-06-17T01:18:16.229814+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1385,16 +1385,16 @@
    "id": "f9d67f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.662565Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.662359Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.671536Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.670892Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.248958Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.248726Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.259222Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.258464Z"
     },
     "papermill": {
-     "duration": 0.016106,
-     "end_time": "2026-06-17T01:12:21.672230+00:00",
+     "duration": 0.018573,
+     "end_time": "2026-06-17T01:18:16.260089+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.656124+00:00",
+     "start_time": "2026-06-17T01:18:16.241516+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1537,10 +1537,10 @@
    "id": "2f9d2c01",
    "metadata": {
     "papermill": {
-     "duration": 0.005247,
-     "end_time": "2026-06-17T01:12:21.682914+00:00",
+     "duration": 0.005758,
+     "end_time": "2026-06-17T01:18:16.272593+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.677667+00:00",
+     "start_time": "2026-06-17T01:18:16.266835+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1569,16 +1569,16 @@
    "id": "8917b738",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.695871Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.695649Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.699129Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.698507Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.285671Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.285450Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.289960Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.289267Z"
     },
     "papermill": {
-     "duration": 0.010503,
-     "end_time": "2026-06-17T01:12:21.699795+00:00",
+     "duration": 0.012351,
+     "end_time": "2026-06-17T01:18:16.290618+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.689292+00:00",
+     "start_time": "2026-06-17T01:18:16.278267+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1626,10 +1626,10 @@
    "id": "a2edb6e2",
    "metadata": {
     "papermill": {
-     "duration": 0.005413,
-     "end_time": "2026-06-17T01:12:21.710321+00:00",
+     "duration": 0.005904,
+     "end_time": "2026-06-17T01:18:16.302509+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.704908+00:00",
+     "start_time": "2026-06-17T01:18:16.296605+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1662,16 +1662,16 @@
    "id": "54a6b7c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.722528Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.722307Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.727524Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.726614Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.315394Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.315156Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.320993Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.320168Z"
     },
     "papermill": {
-     "duration": 0.012672,
-     "end_time": "2026-06-17T01:12:21.728071+00:00",
+     "duration": 0.013433,
+     "end_time": "2026-06-17T01:18:16.321672+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.715399+00:00",
+     "start_time": "2026-06-17T01:18:16.308239+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1732,10 +1732,10 @@
    "id": "d74db354",
    "metadata": {
     "papermill": {
-     "duration": 0.005883,
-     "end_time": "2026-06-17T01:12:21.740178+00:00",
+     "duration": 0.006006,
+     "end_time": "2026-06-17T01:18:16.333940+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.734295+00:00",
+     "start_time": "2026-06-17T01:18:16.327934+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1759,10 +1759,10 @@
    "id": "3c2e7728",
    "metadata": {
     "papermill": {
-     "duration": 0.005851,
-     "end_time": "2026-06-17T01:12:21.752087+00:00",
+     "duration": 0.005998,
+     "end_time": "2026-06-17T01:18:16.345626+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.746236+00:00",
+     "start_time": "2026-06-17T01:18:16.339628+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1787,16 +1787,16 @@
    "id": "dada4cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.765281Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.765082Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.773782Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.773021Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.358946Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.358730Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.367567Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.366466Z"
     },
     "papermill": {
-     "duration": 0.016436,
-     "end_time": "2026-06-17T01:12:21.774469+00:00",
+     "duration": 0.016647,
+     "end_time": "2026-06-17T01:18:16.368480+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.758033+00:00",
+     "start_time": "2026-06-17T01:18:16.351833+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1922,10 +1922,10 @@
    "id": "3cc1a67b",
    "metadata": {
     "papermill": {
-     "duration": 0.005826,
-     "end_time": "2026-06-17T01:12:21.786637+00:00",
+     "duration": 0.006224,
+     "end_time": "2026-06-17T01:18:16.381258+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.780811+00:00",
+     "start_time": "2026-06-17T01:18:16.375034+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1953,10 +1953,10 @@
    "id": "74eec2fe",
    "metadata": {
     "papermill": {
-     "duration": 0.006278,
-     "end_time": "2026-06-17T01:12:21.798861+00:00",
+     "duration": 0.006348,
+     "end_time": "2026-06-17T01:18:16.393342+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.792583+00:00",
+     "start_time": "2026-06-17T01:18:16.386994+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1994,16 +1994,16 @@
    "id": "a916457d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.812346Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.811946Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.823305Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.822584Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.407501Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.407275Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.419176Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.418414Z"
     },
     "papermill": {
-     "duration": 0.019033,
-     "end_time": "2026-06-17T01:12:21.823845+00:00",
+     "duration": 0.020661,
+     "end_time": "2026-06-17T01:18:16.420008+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.804812+00:00",
+     "start_time": "2026-06-17T01:18:16.399347+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2051,16 +2051,16 @@
    "id": "426133ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.836961Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.836535Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.845605Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.844683Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.433644Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.433437Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.440821Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.440156Z"
     },
     "papermill": {
-     "duration": 0.016463,
-     "end_time": "2026-06-17T01:12:21.846204+00:00",
+     "duration": 0.015167,
+     "end_time": "2026-06-17T01:18:16.441480+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.829741+00:00",
+     "start_time": "2026-06-17T01:18:16.426313+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2178,16 +2178,16 @@
    "id": "6e670307",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.860319Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.860119Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.865005Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.864332Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.455382Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.455065Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.460038Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.459398Z"
     },
     "papermill": {
-     "duration": 0.013033,
-     "end_time": "2026-06-17T01:12:21.865560+00:00",
+     "duration": 0.013088,
+     "end_time": "2026-06-17T01:18:16.460653+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.852527+00:00",
+     "start_time": "2026-06-17T01:18:16.447565+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2244,10 +2244,10 @@
    "id": "d4216022",
    "metadata": {
     "papermill": {
-     "duration": 0.006013,
-     "end_time": "2026-06-17T01:12:21.877564+00:00",
+     "duration": 0.008551,
+     "end_time": "2026-06-17T01:18:16.476222+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.871551+00:00",
+     "start_time": "2026-06-17T01:18:16.467671+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2285,10 +2285,10 @@
    "id": "ba9beb92",
    "metadata": {
     "papermill": {
-     "duration": 0.005838,
-     "end_time": "2026-06-17T01:12:21.889334+00:00",
+     "duration": 0.006316,
+     "end_time": "2026-06-17T01:18:16.488813+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.883496+00:00",
+     "start_time": "2026-06-17T01:18:16.482497+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2304,10 +2304,10 @@
    "id": "3c800f32",
    "metadata": {
     "papermill": {
-     "duration": 0.0062,
-     "end_time": "2026-06-17T01:12:21.901815+00:00",
+     "duration": 0.006774,
+     "end_time": "2026-06-17T01:18:16.502139+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.895615+00:00",
+     "start_time": "2026-06-17T01:18:16.495365+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2330,16 +2330,16 @@
    "id": "5101d0d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.915941Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.915673Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.924268Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.923428Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.516404Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.516184Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.523706Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.523014Z"
     },
     "papermill": {
-     "duration": 0.016369,
-     "end_time": "2026-06-17T01:12:21.924832+00:00",
+     "duration": 0.01553,
+     "end_time": "2026-06-17T01:18:16.524288+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.908463+00:00",
+     "start_time": "2026-06-17T01:18:16.508758+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2447,10 +2447,10 @@
    "id": "a5281a2e",
    "metadata": {
     "papermill": {
-     "duration": 0.005995,
-     "end_time": "2026-06-17T01:12:21.937003+00:00",
+     "duration": 0.006336,
+     "end_time": "2026-06-17T01:18:16.537637+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.931008+00:00",
+     "start_time": "2026-06-17T01:18:16.531301+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2476,16 +2476,16 @@
    "id": "0abbe4b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.950356Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.950115Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.954099Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.953478Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.551392Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.551183Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.555426Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.554654Z"
     },
     "papermill": {
-     "duration": 0.01178,
-     "end_time": "2026-06-17T01:12:21.954865+00:00",
+     "duration": 0.012383,
+     "end_time": "2026-06-17T01:18:16.556029+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.943085+00:00",
+     "start_time": "2026-06-17T01:18:16.543646+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2526,10 +2526,10 @@
    "id": "2936e442",
    "metadata": {
     "papermill": {
-     "duration": 0.005823,
-     "end_time": "2026-06-17T01:12:21.966951+00:00",
+     "duration": 0.006162,
+     "end_time": "2026-06-17T01:18:16.568900+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.961128+00:00",
+     "start_time": "2026-06-17T01:18:16.562738+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2551,16 +2551,16 @@
    "id": "174aa8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:21.980259Z",
-     "iopub.status.busy": "2026-06-17T01:12:21.980035Z",
-     "iopub.status.idle": "2026-06-17T01:12:21.985994Z",
-     "shell.execute_reply": "2026-06-17T01:12:21.985411Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.582696Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.582446Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.588855Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.587926Z"
     },
     "papermill": {
-     "duration": 0.01407,
-     "end_time": "2026-06-17T01:12:21.986863+00:00",
+     "duration": 0.014334,
+     "end_time": "2026-06-17T01:18:16.589750+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.972793+00:00",
+     "start_time": "2026-06-17T01:18:16.575416+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2641,10 +2641,10 @@
    "id": "sl7ex2var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.006636,
-     "end_time": "2026-06-17T01:12:21.999548+00:00",
+     "duration": 0.006504,
+     "end_time": "2026-06-17T01:18:16.602939+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:21.992912+00:00",
+     "start_time": "2026-06-17T01:18:16.596435+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2667,16 +2667,16 @@
    "id": "sl7ex2var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:22.013236Z",
-     "iopub.status.busy": "2026-06-17T01:12:22.013008Z",
-     "iopub.status.idle": "2026-06-17T01:12:22.017668Z",
-     "shell.execute_reply": "2026-06-17T01:12:22.016895Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.616599Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.616397Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.620048Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.619397Z"
     },
     "papermill": {
-     "duration": 0.012335,
-     "end_time": "2026-06-17T01:12:22.018321+00:00",
+     "duration": 0.011448,
+     "end_time": "2026-06-17T01:18:16.620838+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.005986+00:00",
+     "start_time": "2026-06-17T01:18:16.609390+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2724,10 +2724,10 @@
    "id": "0962260b",
    "metadata": {
     "papermill": {
-     "duration": 0.006514,
-     "end_time": "2026-06-17T01:12:22.031548+00:00",
+     "duration": 0.006312,
+     "end_time": "2026-06-17T01:18:16.633646+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.025034+00:00",
+     "start_time": "2026-06-17T01:18:16.627334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2749,16 +2749,16 @@
    "id": "3548d43c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:22.045627Z",
-     "iopub.status.busy": "2026-06-17T01:12:22.045097Z",
-     "iopub.status.idle": "2026-06-17T01:12:22.054382Z",
-     "shell.execute_reply": "2026-06-17T01:12:22.053657Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.649436Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.649231Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.656633Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.655881Z"
     },
     "papermill": {
-     "duration": 0.017328,
-     "end_time": "2026-06-17T01:12:22.055106+00:00",
+     "duration": 0.01581,
+     "end_time": "2026-06-17T01:18:16.657519+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.037778+00:00",
+     "start_time": "2026-06-17T01:18:16.641709+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2884,10 +2884,10 @@
    "id": "sl7ex3var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.0066,
-     "end_time": "2026-06-17T01:12:22.068748+00:00",
+     "duration": 0.006394,
+     "end_time": "2026-06-17T01:18:16.670537+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.062148+00:00",
+     "start_time": "2026-06-17T01:18:16.664143+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2910,16 +2910,16 @@
    "id": "sl7ex3var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:22.083538Z",
-     "iopub.status.busy": "2026-06-17T01:12:22.083311Z",
-     "iopub.status.idle": "2026-06-17T01:12:22.087364Z",
-     "shell.execute_reply": "2026-06-17T01:12:22.086654Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.684717Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.684504Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.688777Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.687952Z"
     },
     "papermill": {
-     "duration": 0.01235,
-     "end_time": "2026-06-17T01:12:22.088010+00:00",
+     "duration": 0.012659,
+     "end_time": "2026-06-17T01:18:16.689464+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.075660+00:00",
+     "start_time": "2026-06-17T01:18:16.676805+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2969,20 +2969,26 @@
    "id": "3818d99f",
    "metadata": {
     "papermill": {
-     "duration": 0.0068,
-     "end_time": "2026-06-17T01:12:22.101503+00:00",
+     "duration": 0.006596,
+     "end_time": "2026-06-17T01:18:16.702537+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.094703+00:00",
+     "start_time": "2026-06-17T01:18:16.695941+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 4 : Mesurer le taux d'hallucination du vrai LLM\n",
+    "### Exemple guide 4 : Mesurer le taux d'hallucination du generateur\n",
     "\n",
-    "La section 7 a valide UN lot de regles du vrai LLM. Un seul tirage ne mesure\n",
-    "rien : la generation est stochastique. Estimez le **taux de validation oracle**\n",
-    "du generateur, et son evolution avec la temperature."
+    "La section 7 a valide **UN** lot de regles du vrai LLM. Un seul tirage ne mesure rien : la generation est stochastique. Cet exemple guide rejoue plusieurs tirages et mesure quelle fraction des regles produites survit a l'oracle symbolique, puis comment ce taux evolve avec le \"bruit\" de la generation.\n",
+    "\n",
+    "Sans `.env`, on substitue la stochasticite de la **graine** a celle de la temperature (cf. indice) : la question posee -- *l'oracle stabilise-t-il le pipeline face a la stochasticite de la generation ?* -- est identique.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Ecrire `generate_rules(seed, bruit)` qui echantillonne un bassin de candidats selon la graine (generation \"focalisee\" vs \"bruitee\")\n",
+    "2. Pour chaque regime, faire 5 tirages ; pour chaque tirage, compter `n_generees` et `n_validees` (`verify_rule` sur `EXAMPLES`, garder `is_consistent`)\n",
+    "3. Afficher par regime : total genere, total valide, taux de validation\n",
+    "4. L'oracle rend-il le pipeline insensible au bruit de generation ? Qu'est-ce qui change vraiment (cout, diversite) ?\n"
    ]
   },
   {
@@ -2991,16 +2997,16 @@
    "id": "b1ef475c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:12:22.118315Z",
-     "iopub.status.busy": "2026-06-17T01:12:22.118086Z",
-     "iopub.status.idle": "2026-06-17T01:12:22.122406Z",
-     "shell.execute_reply": "2026-06-17T01:12:22.121561Z"
+     "iopub.execute_input": "2026-06-17T01:18:16.716565Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.716308Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.723725Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.723128Z"
     },
     "papermill": {
-     "duration": 0.013088,
-     "end_time": "2026-06-17T01:12:22.123034+00:00",
+     "duration": 0.015782,
+     "end_time": "2026-06-17T01:18:16.724594+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.109946+00:00",
+     "start_time": "2026-06-17T01:18:16.708812+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3010,31 +3016,190 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer (pas de .env : variante simulateur, cf. indice)\n"
+      "Taux de validation oracle par regime de generation (simulateur, 5 tirages)\n",
+      "======================================================================\n",
+      "Regime                           |  Generees |  Validees |   Taux\n",
+      "----------------------------------------------------------------------\n",
+      "temperature ~0.2 (focalise)      |        20 |        15 |   75%\n",
+      "temperature ~0.9 (bruite)        |        30 |        13 |   43%\n",
+      "\n",
+      "Lecture : le regime bruite genere PLUS de regles au total (bassin plus\n",
+      "large, k plus eleve) mais son taux de validation est plus bas (bassin\n",
+      "dilue d'inconsistantes). L'oracle symbolique filtre les deux regimes de\n",
+      "la meme facon : ne survivent que les regles consistantes (FP=0). La\n",
+      "QUALITE du resultat final est donc stable ; ce qui change vraiment,\n",
+      "c'est le COUT (plus d'appels LLM et de verification) et la DIVERSITE\n",
+      "exploree (plus de candidats, donc plus de chances de decouvrir une\n",
+      "regle utile, au prix de plus de bruit).\n",
+      "\n",
+      "Conclusion : un seul tirage (section 7) n'est PAS representatif. Seul\n",
+      "l'oracle rend le pipeline robuste a la stochasticite de la generation.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 4 : Taux d'hallucination du vrai LLM\n",
-    "# TODO etudiant : repetez la generation de la section 7 et mesurez quelle fraction\n",
-    "# des regles produites survit a l'oracle symbolique.\n",
-    "# Etape 1 : ecrivez generate_rules(temperature) qui rejoue l'appel LLM de la\n",
-    "#           section 7 (meme prompt, parse_llm_rules) avec ce parametre.\n",
-    "# Etape 2 : pour temperature dans (0.2, 0.9), faites 5 tirages chacun ;\n",
-    "#           pour chaque tirage, comptez n_generees et n_validees (verify_rule\n",
-    "#           sur EXAMPLES, garder is_consistent).\n",
-    "# Etape 3 : affichez par temperature : total genere, total valide, taux de\n",
-    "#           validation. La temperature elevee produit-elle plus de regles\n",
-    "#           valides au total, ou seulement plus de bruit ?\n",
-    "# Etape 4 : l'oracle rend-il le pipeline insensible a la temperature ? Qu'est-ce\n",
-    "#           qui change vraiment entre les deux reglages (cout, diversite) ?\n",
-    "# Indice : sans .env, utilisez le simulateur en faisant varier la graine plutot\n",
-    "#          que la temperature -- la question (stochasticite vs oracle) est la meme.\n",
+    "# Exemple guide 4 : Taux d'hallucination du generateur (l'oracle comme filtre)\n",
+    "#\n",
+    "# La section 7 a valide UN seul tirage du LLM. Un seul tirage ne mesure\n",
+    "# rien : la generation est stochastique. Ici on rejoue plusieurs tirages\n",
+    "# et on mesure quelle fraction des regles produites survit a l'oracle\n",
+    "# symbolique, et comment ce taux evolve avec le \"bruit\" de generation.\n",
+    "#\n",
+    "# Sans .env (pas de vrai LLM), on substitue la stochasticite de la GRAINE\n",
+    "# a celle de la temperature (cf. indice) : la question posee est identique.\n",
     "\n",
-    "if LLM_AVAILABLE:\n",
-    "    print(\"Exercice a completer (LLM reel configure)\")\n",
-    "else:\n",
-    "    print(\"Exercice a completer (pas de .env : variante simulateur, cf. indice)\")"
+    "import random\n",
+    "\n",
+    "# Bassin de candidats : melange de regles CONSISTANTES (validables par\n",
+    "# l'oracle) et INCONSISTANTES (rejetees). Leur statut est connu grace a\n",
+    "# la section 3 (cf. cellule 8917b738 sur origin/main).\n",
+    "CONSISTANTES = [\n",
+    "    HornClause([\"Patrons=None\"], \"WillWait\", negated=True),\n",
+    "    HornClause([\"Patrons=Full\", \"Price=$$$\"], \"WillWait\", negated=True),\n",
+    "    HornClause([\"Patrons=Full\", \"Hungry=No\"], \"WillWait\", negated=True),\n",
+    "]\n",
+    "INCONSISTANTES = [\n",
+    "    HornClause([\"Patrons=Some\"], \"WillWait\"),\n",
+    "    HornClause([\"Patrons=Full\", \"Hungry=Yes\"], \"WillWait\"),\n",
+    "    HornClause([\"Hungry=Yes\"], \"WillWait\"),\n",
+    "    HornClause([\"Type=French\"], \"WillWait\"),\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def generate_rules(seed: int, bruit: bool):\n",
+    "    \"\"\"Simule un tirage LLM stochastique.\n",
+    "\n",
+    "    bruit=False -> generation 'focalisee' (temperature basse) : pioche\n",
+    "                   dans un bassin a dominante consistante.\n",
+    "    bruit=True  -> generation 'bruitee' (temperature elevee) : pioche\n",
+    "                   dans le bassin complet, donc plus d'hallucinations.\n",
+    "    \"\"\"\n",
+    "    pool = CONSISTANTES + (INCONSISTANTES if bruit else INCONSISTANTES[:1])\n",
+    "    k = 6 if bruit else 4\n",
+    "    return random.Random(seed).sample(pool, k)\n",
+    "\n",
+    "\n",
+    "def stats_tirage(rules):\n",
+    "    \"\"\"Retourne (n_generees, n_validees) selon l'oracle sur EXAMPLES.\"\"\"\n",
+    "    n_val = sum(\n",
+    "        1 for i, r in enumerate(rules)\n",
+    "        if verify_rule(r, EXAMPLES, i).is_consistent\n",
+    "    )\n",
+    "    return len(rules), n_val\n",
+    "\n",
+    "\n",
+    "regimes = [(\"temperature ~0.2 (focalise)\", False, 20),\n",
+    "           (\"temperature ~0.9 (bruite)\", True, 90)]\n",
+    "\n",
+    "print(\"Taux de validation oracle par regime de generation (simulateur, 5 tirages)\")\n",
+    "print(\"=\" * 70)\n",
+    "print(f\"{'Regime':32s} | {'Generees':>9s} | {'Validees':>9s} | {'Taux':>6s}\")\n",
+    "print(\"-\" * 70)\n",
+    "for label, bruit, base_seed in regimes:\n",
+    "    tot_gen = tot_val = 0\n",
+    "    for draw in range(5):\n",
+    "        rules = generate_rules(base_seed + draw, bruit)\n",
+    "        g, v = stats_tirage(rules)\n",
+    "        tot_gen += g\n",
+    "        tot_val += v\n",
+    "    taux = tot_val / tot_gen if tot_gen else 0.0\n",
+    "    print(f\"{label:32s} | {tot_gen:>9d} | {tot_val:>9d} | {taux:>5.0%}\")\n",
+    "print()\n",
+    "print(\"Lecture : le regime bruite genere PLUS de regles au total (bassin plus\")\n",
+    "print(\"large, k plus eleve) mais son taux de validation est plus bas (bassin\")\n",
+    "print(\"dilue d'inconsistantes). L'oracle symbolique filtre les deux regimes de\")\n",
+    "print(\"la meme facon : ne survivent que les regles consistantes (FP=0). La\")\n",
+    "print(\"QUALITE du resultat final est donc stable ; ce qui change vraiment,\")\n",
+    "print(\"c'est le COUT (plus d'appels LLM et de verification) et la DIVERSITE\")\n",
+    "print(\"exploree (plus de candidats, donc plus de chances de decouvrir une\")\n",
+    "print(\"regle utile, au prix de plus de bruit).\")\n",
+    "print()\n",
+    "print(\"Conclusion : un seul tirage (section 7) n'est PAS representatif. Seul\")\n",
+    "print(\"l'oracle rend le pipeline robuste a la stochasticite de la generation.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl7ex4var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006191,
+     "end_time": "2026-06-17T01:18:16.737224+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:18:16.731033+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 (variation) : Stabilite du taux de validation (intervalle de confiance)\n",
+    "\n",
+    "Le taux de validation mesure sur 5 tirages reste une estimation bruitee. Combien de tirages faut-il pour l'estimer fiablement ? Etendez l'etude : tirez `N=20` fois a un regime fixe, calculez la **moyenne** et l'**ecart-type** du taux de validation par tirage, et donnez un intervalle de confiance approximatif (moyenne +/- ecart-type).\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Reutiliser `generate_rules` + `stats_tirage` pour `N=20` tirages a un regime fixe\n",
+    "2. Calculer le taux de validation de chaque tirage, puis leur moyenne et ecart-type\n",
+    "3. Afficher l'intervalle moyenne +/- ecart-type et commenter la stabilite de l'estimation\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "sl7ex4var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:18:16.750846Z",
+     "iopub.status.busy": "2026-06-17T01:18:16.750636Z",
+     "iopub.status.idle": "2026-06-17T01:18:16.754307Z",
+     "shell.execute_reply": "2026-06-17T01:18:16.753605Z"
+    },
+    "papermill": {
+     "duration": 0.011234,
+     "end_time": "2026-06-17T01:18:16.754862+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:18:16.743628+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : stabilite du taux de validation sur N=20 tirages\n",
+      "Etape 1 : calculez le taux de validation de chacun des 20 tirages\n",
+      "Etape 2 : derivez moyenne et ecart-type\n",
+      "Etape 3 : affichez l'intervalle moyenne +/- ecart-type\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 (variation) : stabilite du taux de validation\n",
+    "# TODO etudiant : estimez le taux de validation avec un intervalle de confiance.\n",
+    "\n",
+    "# Etape 1 : N=20 tirages a un regime fixe (reutilisez generate_rules + stats_tirage)\n",
+    "# taux_par_tirage = []\n",
+    "# for draw in range(20):\n",
+    "#     rules = generate_rules(1000 + draw, bruit=True)\n",
+    "#     g, v = stats_tirage(rules)\n",
+    "#     taux_par_tirage.append(v / g)\n",
+    "\n",
+    "# Etape 2 : moyenne et ecart-type du taux de validation\n",
+    "# moyenne = sum(taux_par_tirage) / len(taux_par_tirage)\n",
+    "# variance = sum((t - moyenne) ** 2 for t in taux_par_tirage) / len(taux_par_tirage)\n",
+    "# ecart_type = variance ** 0.5\n",
+    "\n",
+    "# Etape 3 : intervalle moyenne +/- ecart-type\n",
+    "print(\"Exercice a completer : stabilite du taux de validation sur N=20 tirages\")\n",
+    "print(\"Etape 1 : calculez le taux de validation de chacun des 20 tirages\")\n",
+    "print(\"Etape 2 : derivez moyenne et ecart-type\")\n",
+    "print(\"Etape 3 : affichez l'intervalle moyenne +/- ecart-type\")\n",
+    "\n",
+    "# Indice : plus l'ecart-type est petit devant la moyenne, plus l'estimation\n",
+    "# est stable -- et moins il faut de tirages pour conclure.\n",
+    "# result = None  # TODO etudiant : (moyenne, ecart_type)\n"
    ]
   },
   {
@@ -3042,10 +3207,10 @@
    "id": "7cb00ad4",
    "metadata": {
     "papermill": {
-     "duration": 0.006262,
-     "end_time": "2026-06-17T01:12:22.137350+00:00",
+     "duration": 0.005655,
+     "end_time": "2026-06-17T01:18:16.766292+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.131088+00:00",
+     "start_time": "2026-06-17T01:18:16.760637+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3097,10 +3262,10 @@
    "id": "227e37ae",
    "metadata": {
     "papermill": {
-     "duration": 0.006271,
-     "end_time": "2026-06-17T01:12:22.149817+00:00",
+     "duration": 0.006115,
+     "end_time": "2026-06-17T01:18:16.778156+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.143546+00:00",
+     "start_time": "2026-06-17T01:18:16.772041+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3128,10 +3293,10 @@
    "id": "b2e6b9c6",
    "metadata": {
     "papermill": {
-     "duration": 0.006315,
-     "end_time": "2026-06-17T01:12:22.162720+00:00",
+     "duration": 0.006146,
+     "end_time": "2026-06-17T01:18:16.790325+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:12:22.156405+00:00",
+     "start_time": "2026-06-17T01:18:16.784179+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3173,14 +3338,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.998269,
-   "end_time": "2026-06-17T01:12:22.405305+00:00",
+   "duration": 3.12239,
+   "end_time": "2026-06-17T01:18:17.029442+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T01:12:19.407036+00:00",
+   "start_time": "2026-06-17T01:18:13.907052+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
> **PR empilée (stacked)** : base = `feat/sl7-ex3-guided` (#3175). Merger dans l'ordre #3172 -> #3173 -> #3175 -> celle-ci. Le diff ne montre que la contribution Ex4. **Complete SL-7** (les 4 exercices sont resolus en exemples guides + variations).

## Contexte

Rollout convention **3 exercices/notebook** (#2161), serie SymbolicLearning, partition po-2024. **SL-7 Exercice 4** (Mesurer le taux d'hallucination du vrai LLM) — la section 7 a valide UN seul tirage ; un seul tirage ne mesure rien. Resolu en exemple guide + variation.

## Livrable

**Ex4 resolu en exemple guide** (taux de validation oracle vs bruit de generation) :
- Sans vrai LLM (pas de `.env`), la stochasticite de la **temperature** est substituee par un **echantillonnage par graine** d'un bassin cure de regles (cf. indice du stub : la question "l'oracle stabilise-t-il le pipeline face a la stochasticite ?" est identique).
  - `generate_rules(seed, bruit)` : `bruit=False` (focalise / low-temp) pioche k=4 dans un bassin a dominante consistante ; `bruit=True` (bruite / high-temp) pioche k=6 dans le bassin complet.
  - `stats_tirage` via `verify_rule(...).is_consistent` sur `EXAMPLES`.
- Markdown relicole « Exercice 4 » -> « **Exemple guide 4** ».

**Nouvel exercice en variation** : « Stabilite du taux de validation (intervalle de confiance) » — N=20 tirages a regime fixe, moyenne + ecart-type du taux, intervalle moyenne +/- ecart-type. Reutilise `generate_rules` + `stats_tirage`. C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`notebook_tools.py execute --kernel python3`) : **SUCCESS** 5.4s, 1/1 notebooks, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 24 cellules code, toutes `execution_count` set + outputs presents + 0 output d'erreur. Section 7 (demo Gemini 3.5 flash reelle) restauree depuis `origin/main`.
- **Sortie Ex4** : `focalise` 20 generees / 15 validees / **75%** ; `bruite` 30 generees / 13 validees / **43%**.

## Lecture pedagogique (ancree dans la sortie reelle)

Le regime bruite genere **plus** de regles au total mais a un taux de validation **plus bas** (plus d'hallucinations). L'oracle filtre les deux regimes de la meme facon (seules les regles consistantes survivent) : la **qualite** du resultat final est stable. Ce qui change vraiment, c'est le **cout** (plus d'appels LLM + verification) et la **diversite** exploree. Un seul tirage (section 7) n'est **pas** representatif.

## Anti-regression (verifie vs base `feat/sl7-ex3-guided`)

- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- Source code +82 lignes (stub Ex4 -> solution + stub variation). Markdown Ex4 relicole.
- 1 fichier `.ipynb`. Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
