### PR TITLE
feat(sl8): resolve Ex1 (learn 'contains abb' via L*) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "sl8-01",
    "metadata": {
     "papermill": {
-     "duration": 0.005216,
-     "end_time": "2026-06-10T11:53:41.348666",
+     "duration": 0.003968,
+     "end_time": "2026-06-17T01:25:17.063673+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.343450",
+     "start_time": "2026-06-17T01:25:17.059705+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "sl8-02",
    "metadata": {
     "papermill": {
-     "duration": 0.004149,
-     "end_time": "2026-06-10T11:53:41.357502",
+     "duration": 0.003041,
+     "end_time": "2026-06-17T01:25:17.071273+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.353353",
+     "start_time": "2026-06-17T01:25:17.068232+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,16 +89,16 @@
    "id": "sl8-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.365310Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.364782Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.390956Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.389835Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.078780Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.078567Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.088527Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.087872Z"
     },
     "papermill": {
-     "duration": 0.030299,
-     "end_time": "2026-06-10T11:53:41.391486",
+     "duration": 0.015159,
+     "end_time": "2026-06-17T01:25:17.089417+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.361187",
+     "start_time": "2026-06-17T01:25:17.074258+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,10 +178,10 @@
    "id": "sl8-04",
    "metadata": {
     "papermill": {
-     "duration": 0.004022,
-     "end_time": "2026-06-10T11:53:41.400206",
+     "duration": 0.003094,
+     "end_time": "2026-06-17T01:25:17.096428+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.396184",
+     "start_time": "2026-06-17T01:25:17.093334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,10 +206,10 @@
    "id": "sl8-05",
    "metadata": {
     "papermill": {
-     "duration": 0.004002,
-     "end_time": "2026-06-10T11:53:41.408729",
+     "duration": 0.00305,
+     "end_time": "2026-06-17T01:25:17.102604+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.404727",
+     "start_time": "2026-06-17T01:25:17.099554+00:00",
      "status": "completed"
     },
     "tags": []
@@ -247,16 +247,16 @@
    "id": "sl8-06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.418789Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.417272Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.437988Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.436907Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.109889Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.109668Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.118412Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.117641Z"
     },
     "papermill": {
-     "duration": 0.025744,
-     "end_time": "2026-06-10T11:53:41.438497",
+     "duration": 0.013673,
+     "end_time": "2026-06-17T01:25:17.119187+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.412753",
+     "start_time": "2026-06-17T01:25:17.105514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "sl8-07",
    "metadata": {
     "papermill": {
-     "duration": 0.002504,
-     "end_time": "2026-06-10T11:53:41.444513",
+     "duration": 0.003674,
+     "end_time": "2026-06-17T01:25:17.126673+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.442009",
+     "start_time": "2026-06-17T01:25:17.122999+00:00",
      "status": "completed"
     },
     "tags": []
@@ -385,10 +385,10 @@
    "id": "sl8-08",
    "metadata": {
     "papermill": {
-     "duration": 0.002661,
-     "end_time": "2026-06-10T11:53:41.449705",
+     "duration": 0.003022,
+     "end_time": "2026-06-17T01:25:17.132927+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.447044",
+     "start_time": "2026-06-17T01:25:17.129905+00:00",
      "status": "completed"
     },
     "tags": []
@@ -423,16 +423,16 @@
    "id": "sl8-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.458835Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.458835Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.468503Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.467911Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.140574Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.140398Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.146866Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.146037Z"
     },
     "papermill": {
-     "duration": 0.01686,
-     "end_time": "2026-06-10T11:53:41.469026",
+     "duration": 0.011378,
+     "end_time": "2026-06-17T01:25:17.147600+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.452166",
+     "start_time": "2026-06-17T01:25:17.136222+00:00",
      "status": "completed"
     },
     "tags": []
@@ -526,10 +526,10 @@
    "id": "sl8-10",
    "metadata": {
     "papermill": {
-     "duration": 0.002575,
-     "end_time": "2026-06-10T11:53:41.474033",
+     "duration": 0.003337,
+     "end_time": "2026-06-17T01:25:17.154425+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.471458",
+     "start_time": "2026-06-17T01:25:17.151088+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,16 +550,16 @@
    "id": "sl8-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.481402Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.481402Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.500329Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.499220Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.162322Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.162041Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.170807Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.170038Z"
     },
     "papermill": {
-     "duration": 0.024439,
-     "end_time": "2026-06-10T11:53:41.501363",
+     "duration": 0.01361,
+     "end_time": "2026-06-17T01:25:17.171450+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.476924",
+     "start_time": "2026-06-17T01:25:17.157840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -626,10 +626,10 @@
    "id": "sl8-12",
    "metadata": {
     "papermill": {
-     "duration": 0.003665,
-     "end_time": "2026-06-10T11:53:41.510252",
+     "duration": 0.003627,
+     "end_time": "2026-06-17T01:25:17.178854+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.506587",
+     "start_time": "2026-06-17T01:25:17.175227+00:00",
      "status": "completed"
     },
     "tags": []
@@ -659,10 +659,10 @@
    "id": "sl8-13",
    "metadata": {
     "papermill": {
-     "duration": 0.003214,
-     "end_time": "2026-06-10T11:53:41.516079",
+     "duration": 0.004161,
+     "end_time": "2026-06-17T01:25:17.186630+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.512865",
+     "start_time": "2026-06-17T01:25:17.182469+00:00",
      "status": "completed"
     },
     "tags": []
@@ -697,16 +697,16 @@
    "id": "sl8-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.526540Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.526014Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.546077Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.544931Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.195620Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.195146Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.203905Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.203111Z"
     },
     "papermill": {
-     "duration": 0.025824,
-     "end_time": "2026-06-10T11:53:41.546589",
+     "duration": 0.014241,
+     "end_time": "2026-06-17T01:25:17.204523+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.520765",
+     "start_time": "2026-06-17T01:25:17.190282+00:00",
      "status": "completed"
     },
     "tags": []
@@ -770,10 +770,10 @@
    "id": "sl8-15",
    "metadata": {
     "papermill": {
-     "duration": 0.004784,
-     "end_time": "2026-06-10T11:53:41.556597",
+     "duration": 0.00376,
+     "end_time": "2026-06-17T01:25:17.212515+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.551813",
+     "start_time": "2026-06-17T01:25:17.208755+00:00",
      "status": "completed"
     },
     "tags": []
@@ -798,10 +798,10 @@
    "id": "sl8-16",
    "metadata": {
     "papermill": {
-     "duration": 0.004695,
-     "end_time": "2026-06-10T11:53:41.566067",
+     "duration": 0.003816,
+     "end_time": "2026-06-17T01:25:17.220167+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.561372",
+     "start_time": "2026-06-17T01:25:17.216351+00:00",
      "status": "completed"
     },
     "tags": []
@@ -832,16 +832,16 @@
    "id": "sl8-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.576609Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.576609Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.622118Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.620993Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.229220Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.228852Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.262527Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.261624Z"
     },
     "papermill": {
-     "duration": 0.051855,
-     "end_time": "2026-06-10T11:53:41.622642",
+     "duration": 0.039337,
+     "end_time": "2026-06-17T01:25:17.263189+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.570787",
+     "start_time": "2026-06-17T01:25:17.223852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,10 +922,10 @@
    "id": "sl8-18",
    "metadata": {
     "papermill": {
-     "duration": 0.003139,
-     "end_time": "2026-06-10T11:53:41.628942",
+     "duration": 0.003781,
+     "end_time": "2026-06-17T01:25:17.270885+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.625803",
+     "start_time": "2026-06-17T01:25:17.267104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,10 +960,10 @@
    "id": "sl8-19",
    "metadata": {
     "papermill": {
-     "duration": 0.002614,
-     "end_time": "2026-06-10T11:53:41.634720",
+     "duration": 0.004058,
+     "end_time": "2026-06-17T01:25:17.278768+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.632106",
+     "start_time": "2026-06-17T01:25:17.274710+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1000,10 +1000,10 @@
    "id": "sl8-20",
    "metadata": {
     "papermill": {
-     "duration": 0.002646,
-     "end_time": "2026-06-10T11:53:41.640017",
+     "duration": 0.003799,
+     "end_time": "2026-06-17T01:25:17.286427+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.637371",
+     "start_time": "2026-06-17T01:25:17.282628+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,16 +1031,16 @@
    "id": "sl8-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.647830Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.647306Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.652053Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.651468Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.295336Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.294954Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.311398Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.310648Z"
     },
     "papermill": {
-     "duration": 0.009991,
-     "end_time": "2026-06-10T11:53:41.652582",
+     "duration": 0.021866,
+     "end_time": "2026-06-17T01:25:17.312027+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.642591",
+     "start_time": "2026-06-17T01:25:17.290161+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1050,23 +1050,157 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "DFA appris : DFA(4 etats, 1 acceptants)\n",
+      "  Conjectures (equivalences) : 2\n",
+      "  |S| = 13, |E| = 3, MQ posees = 55\n",
+      "\n",
+      "Prediction theorique : 4 etats (rien vu / 'a' vu / 'ab' vu / 'abb' vu).\n",
+      "-> observe : 4 etats (confirme).\n",
+      "\n",
+      "       mot | DFA | vrai | OK ?\n",
+      "----------------------------------\n",
+      "     (eps) |   0 |    0 | OK\n",
+      "         a |   0 |    0 | OK\n",
+      "        ab |   0 |    0 | OK\n",
+      "       abb |   1 |    1 | OK\n",
+      "      abbb |   1 |    1 | OK\n",
+      "      babb |   1 |    1 | OK\n",
+      "     aaabb |   1 |    1 | OK\n",
+      "      abab |   0 |    0 | OK\n",
+      "    abbabb |   1 |    1 | OK\n",
+      "     bbabb |   1 |    1 | OK\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 : Apprendre le langage \"contient 'abb' comme facteur\"\n",
-    "# TODO etudiant : faites apprendre par L* le langage des mots qui contiennent\n",
-    "# la sous-chaine \"abb\", SANS construire le DFA cible vous-meme.\n",
-    "# Indice : la requete d'appartenance peut etre une simple fonction Python ;\n",
-    "#          pour l'equivalence, utilisez make_sampling_eq avec n_samples=2000.\n",
-    "# Etape 1 : ecrivez mq_abb(word) (une ligne : l'operateur 'in' suffit)\n",
-    "# Etape 2 : lancez lstar(ALPHABET, mq_abb, make_sampling_eq(mq_abb, ALPHABET, 2000))\n",
-    "# Etape 3 : combien d'etats a le DFA appris ? Expliquez chacun d'eux\n",
-    "#           (prediction theorique : 4 -- rien vu, 'a' vu, 'ab' vu, 'abb' vu)\n",
-    "# Etape 4 : verifiez le DFA sur 10 mots de votre choix\n",
+    "# Exemple guide 1 : Apprendre le langage \"contient 'abb' comme facteur\"\n",
+    "#\n",
+    "# On apprend par L* le langage des mots (sur {a, b}) qui contiennent la\n",
+    "# sous-chaine \"abb\", SANS construire le DFA cible : l'apprenant n'a acces\n",
+    "# qu'a la requete d'appartenance (l'operateur 'in') et a un oracle\n",
+    "# d'equivalence par echantillonnage.\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : requete d'appartenance -- une ligne suffit ('abb' in word)\n",
+    "def mq_abb(word: str) -> bool:\n",
+    "    return \"abb\" in word\n",
+    "\n",
+    "# Etape 2 : lancer L* avec un oracle d'equivalence par echantillonnage\n",
+    "learned, final_table, n_eq = lstar(\n",
+    "    ALPHABET, mq_abb, make_sampling_eq(mq_abb, ALPHABET, 2000), verbose=False\n",
+    ")\n",
+    "\n",
+    "print(f\"DFA appris : {learned}\")\n",
+    "print(f\"  Conjectures (equivalences) : {n_eq}\")\n",
+    "print(f\"  |S| = {len(final_table.S)}, |E| = {len(final_table.E)}, \"\n",
+    "      f\"MQ posees = {final_table.n_mq}\")\n",
+    "\n",
+    "# Etape 3 : interpretation des etats (prediction theorique : 4 etats)\n",
+    "#   - \"rien vu\"  : aucune amorce du motif\n",
+    "#   - \"'a' vu\"   : un 'a' isole, pas encore suivi de 'bb'\n",
+    "#   - \"'ab' vu\"  : debut du motif, il manque encore un 'b'\n",
+    "#   - \"'abb' vu\" : motif trouve, etat absorbant acceptant\n",
+    "print()\n",
+    "print(\"Prediction theorique : 4 etats (rien vu / 'a' vu / 'ab' vu / 'abb' vu).\")\n",
+    "print(f\"-> observe : {len(learned.states)} etats \"\n",
+    "      f\"({'confirme' if len(learned.states) == 4 else 'a commenter'}).\")\n",
+    "\n",
+    "# Etape 4 : verification sur 10 mots\n",
+    "test_words = [\"\", \"a\", \"ab\", \"abb\", \"abbb\", \"babb\", \"aaabb\",\n",
+    "              \"abab\", \"abbabb\", \"bbabb\"]\n",
+    "print()\n",
+    "print(f\"{'mot':>10} | DFA | vrai | OK ?\")\n",
+    "print(\"-\" * 34)\n",
+    "for w in test_words:\n",
+    "    pred = learned.accepts(w)\n",
+    "    vrai = \"abb\" in w\n",
+    "    print(f\"{w or '(eps)':>10} | {int(pred):>3} | {int(vrai):>4} | \"\n",
+    "          f\"{'OK' if pred == vrai else 'ECHEC'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8ex1var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003742,
+     "end_time": "2026-06-17T01:25:17.319519+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:25:17.315777+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 (variation) : Apprendre un autre langage-facteur\n",
+    "\n",
+    "Reprenez la methode de l'exemple guide pour apprendre par L* le langage des mots (sur {a, b}) qui contiennent la sous-chaine **\"ba\"** (au lieu de \"abb\"). Combien d'etats le DFA minimal comporte-t-il, et pourquoi ?\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Ecrire `mq_ba(word)` : appartenance au langage \"contient 'ba' comme facteur\"\n",
+    "2. Lancer L* avec `make_sampling_eq(mq_ba, ALPHABET, 2000)`\n",
+    "3. Donner le nombre d'etats du DFA appris et expliquer chacun (prediction theorique : 3 etats)\n",
+    "4. Verifier sur 8 mots de votre choix\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "sl8ex1var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:25:17.328036Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.327714Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.331799Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.331084Z"
+    },
+    "papermill": {
+     "duration": 0.00934,
+     "end_time": "2026-06-17T01:25:17.332460+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:25:17.323120+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : apprenez le langage 'contient ba' par L*\n",
+      "Etape 1 : ecrivez mq_ba(word) avec l'operateur 'in'\n",
+      "Etape 2 : lancez lstar(ALPHABET, mq_ba, make_sampling_eq(..., 2000))\n",
+      "Etape 3 : donnez le nombre d'etats et expliquez chacun\n",
+      "Etape 4 : verifiez sur 8 mots\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (variation) : apprendre le langage \"contient 'ba' comme facteur\"\n",
+    "# TODO etudiant : reprenez l'exemple guide ci-dessus avec le motif \"ba\".\n",
+    "\n",
+    "# Etape 1 : requete d'appartenance au langage \"contient 'ba'\"\n",
+    "# def mq_ba(word: str) -> bool:\n",
+    "#     return ...  # TODO etudiant : une ligne avec l'operateur 'in'\n",
+    "\n",
+    "# Etape 2 : lancer L* avec un oracle d'equivalence par echantillonnage\n",
+    "# learned_ba, table_ba, n_eq_ba = lstar(ALPHABET, mq_ba,\n",
+    "#                                        make_sampling_eq(mq_ba, ALPHABET, 2000),\n",
+    "#                                        verbose=False)\n",
+    "\n",
+    "# Etape 3 : nombre d'etats et interpretation (prediction : 3 etats)\n",
+    "# print(f\"DFA appris : {learned_ba} ({n_eq_ba} equivalences)\")\n",
+    "\n",
+    "# Etape 4 : verification sur 8 mots\n",
+    "print(\"Exercice a completer : apprenez le langage 'contient ba' par L*\")\n",
+    "print(\"Etape 1 : ecrivez mq_ba(word) avec l'operateur 'in'\")\n",
+    "print(\"Etape 2 : lancez lstar(ALPHABET, mq_ba, make_sampling_eq(..., 2000))\")\n",
+    "print(\"Etape 3 : donnez le nombre d'etats et expliquez chacun\")\n",
+    "print(\"Etape 4 : verifiez sur 8 mots\")\n",
+    "\n",
+    "# Indice : le motif \"ba\" est plus court que \"abb\" -> moins d'etats \"amorce\".\n",
+    "# result = None  # TODO etudiant : le DFA appris (learned_ba)\n"
    ]
   },
   {
@@ -1074,10 +1208,10 @@
    "id": "sl8-22",
    "metadata": {
     "papermill": {
-     "duration": 0.004676,
-     "end_time": "2026-06-10T11:53:41.662437",
+     "duration": 0.003419,
+     "end_time": "2026-06-17T01:25:17.339680+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.657761",
+     "start_time": "2026-06-17T01:25:17.336261+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1090,20 +1224,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "sl8-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.670811Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.670301Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.684028Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.682949Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.347704Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.347512Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.350979Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.350293Z"
     },
     "papermill": {
-     "duration": 0.017447,
-     "end_time": "2026-06-10T11:53:41.684028",
+     "duration": 0.008528,
+     "end_time": "2026-06-17T01:25:17.351556+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.666581",
+     "start_time": "2026-06-17T01:25:17.343028+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1136,10 +1270,10 @@
    "id": "sl8-24",
    "metadata": {
     "papermill": {
-     "duration": 0.00453,
-     "end_time": "2026-06-10T11:53:41.695102",
+     "duration": 0.003947,
+     "end_time": "2026-06-17T01:25:17.359237+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.690572",
+     "start_time": "2026-06-17T01:25:17.355290+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1152,20 +1286,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "sl8-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.703377Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.702372Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.713792Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.713228Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.367760Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.367511Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.370929Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.370314Z"
     },
     "papermill": {
-     "duration": 0.016676,
-     "end_time": "2026-06-10T11:53:41.714796",
+     "duration": 0.008533,
+     "end_time": "2026-06-17T01:25:17.371439+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.698120",
+     "start_time": "2026-06-17T01:25:17.362906+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1199,10 +1333,10 @@
    "id": "sl8-26",
    "metadata": {
     "papermill": {
-     "duration": 0.003012,
-     "end_time": "2026-06-10T11:53:41.721808",
+     "duration": 0.003353,
+     "end_time": "2026-06-17T01:25:17.378456+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.718796",
+     "start_time": "2026-06-17T01:25:17.375103+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1214,20 +1348,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "sl8-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.728334Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.728334Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.744900Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.744900Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.386622Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.386432Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.389664Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.389009Z"
     },
     "papermill": {
-     "duration": 0.02309,
-     "end_time": "2026-06-10T11:53:41.746406",
+     "duration": 0.008106,
+     "end_time": "2026-06-17T01:25:17.390176+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.723316",
+     "start_time": "2026-06-17T01:25:17.382070+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1262,10 +1396,10 @@
    "id": "sl8-29",
    "metadata": {
     "papermill": {
-     "duration": 0.002592,
-     "end_time": "2026-06-10T11:53:41.759382",
+     "duration": 0.00338,
+     "end_time": "2026-06-17T01:25:17.397067+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.756790",
+     "start_time": "2026-06-17T01:25:17.393687+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1322,10 +1456,10 @@
    "id": "sl8-28",
    "metadata": {
     "papermill": {
-     "duration": 0.00262,
-     "end_time": "2026-06-10T11:53:41.753654",
+     "duration": 0.00329,
+     "end_time": "2026-06-17T01:25:17.403630+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.751034",
+     "start_time": "2026-06-17T01:25:17.400340+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1353,10 +1487,10 @@
    "id": "sl8-30",
    "metadata": {
     "papermill": {
-     "duration": 0.003016,
-     "end_time": "2026-06-10T11:53:41.764954",
+     "duration": 0.003471,
+     "end_time": "2026-06-17T01:25:17.411045+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.761938",
+     "start_time": "2026-06-17T01:25:17.407574+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1395,18 +1529,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.436989,
-   "end_time": "2026-06-10T11:53:45.159511",
+   "duration": 2.428777,
+   "end_time": "2026-06-17T01:25:17.545944+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SL-8-ActiveAutomataLearning.ipynb",
-   "output_path": "SL-8-ActiveAutomataLearning.ipynb",
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T11:53:39.722522",
+   "start_time": "2026-06-17T01:25:15.117167+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Contexte

Rollout convention **3 exercices/notebook** (#2161), serie SymbolicLearning. **SL-8 Exercice 1** (Apprendre le langage "contient 'abb' comme facteur" par L*). Resolu en exemple guide + variation. (SL-8 : la description de chaque exercice vit en commentaire de la cellule code -> le relicolage « Exercice -> Exemple guide » se fait la.)

## Livrable

**Ex1 resolu en exemple guide** (apprendre "contient 'abb'" via L*) :
- `mq_abb(word) = "abb" in word` puis `lstar(ALPHABET, mq_abb, make_sampling_eq(mq_abb, ALPHABET, 2000))`. Affiche le DFA appris, les comptes |S|/|E|/MQ, la prediction theorique de 4 etats (rien vu / 'a' vu / 'ab' vu / 'abb' vu), et verifie sur 10 mots.

**Nouvel exercice en variation** : apprendre le langage-facteur "contient 'ba'" (motif plus court -> moins d'etats d'amorce). L'etudiant ecrit `mq_ba`, lance L*, predit 3 etats, verifie. C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`notebook_tools.py execute --kernel python3`) : **SUCCESS** 4.3s, 1/1 notebooks, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 11 cellules code, toutes `execution_count` set + outputs presents + 0 output d'erreur. (SL-8 = notebook algorithmique pur, sans cellule LLM/API : pas de restore de section.)
- **Sortie Ex1** : `DFA(4 etats, 1 acceptant)`, 2 conjectures, |S|=13, |E|=3, MQ=55, **les 10 mots de test sont OK**. La prediction de 4 etats est **confirmee**.

## Anti-regression (verifie vs `origin/main`)

- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- Source code +54 lignes (stub Ex1 -> solution + stub variation). Commentaire Ex1 relicole.
- 1 fichier `.ipynb` (SL-8). Branche fraiche depuis `origin/main`. Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
