### PR TITLE
feat(sl8): resolve Ex2 (sampling-EQ reliability) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "sl8-01",
    "metadata": {
     "papermill": {
-     "duration": 0.003968,
-     "end_time": "2026-06-17T01:25:17.063673+00:00",
+     "duration": 0.003984,
+     "end_time": "2026-06-17T01:28:32.733757+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.059705+00:00",
+     "start_time": "2026-06-17T01:28:32.729773+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "sl8-02",
    "metadata": {
     "papermill": {
-     "duration": 0.003041,
-     "end_time": "2026-06-17T01:25:17.071273+00:00",
+     "duration": 0.0032,
+     "end_time": "2026-06-17T01:28:32.740610+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.068232+00:00",
+     "start_time": "2026-06-17T01:28:32.737410+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,16 +89,16 @@
    "id": "sl8-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.078780Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.078567Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.088527Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.087872Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.748415Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.748216Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.756972Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.756363Z"
     },
     "papermill": {
-     "duration": 0.015159,
-     "end_time": "2026-06-17T01:25:17.089417+00:00",
+     "duration": 0.013798,
+     "end_time": "2026-06-17T01:28:32.757576+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.074258+00:00",
+     "start_time": "2026-06-17T01:28:32.743778+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,10 +178,10 @@
    "id": "sl8-04",
    "metadata": {
     "papermill": {
-     "duration": 0.003094,
-     "end_time": "2026-06-17T01:25:17.096428+00:00",
+     "duration": 0.004591,
+     "end_time": "2026-06-17T01:28:32.765921+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.093334+00:00",
+     "start_time": "2026-06-17T01:28:32.761330+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,10 +206,10 @@
    "id": "sl8-05",
    "metadata": {
     "papermill": {
-     "duration": 0.00305,
-     "end_time": "2026-06-17T01:25:17.102604+00:00",
+     "duration": 0.003201,
+     "end_time": "2026-06-17T01:28:32.772419+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.099554+00:00",
+     "start_time": "2026-06-17T01:28:32.769218+00:00",
      "status": "completed"
     },
     "tags": []
@@ -247,16 +247,16 @@
    "id": "sl8-06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.109889Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.109668Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.118412Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.117641Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.780190Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.779893Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.787819Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.787343Z"
     },
     "papermill": {
-     "duration": 0.013673,
-     "end_time": "2026-06-17T01:25:17.119187+00:00",
+     "duration": 0.012735,
+     "end_time": "2026-06-17T01:28:32.788474+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.105514+00:00",
+     "start_time": "2026-06-17T01:28:32.775739+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "sl8-07",
    "metadata": {
     "papermill": {
-     "duration": 0.003674,
-     "end_time": "2026-06-17T01:25:17.126673+00:00",
+     "duration": 0.00337,
+     "end_time": "2026-06-17T01:28:32.795281+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.122999+00:00",
+     "start_time": "2026-06-17T01:28:32.791911+00:00",
      "status": "completed"
     },
     "tags": []
@@ -385,10 +385,10 @@
    "id": "sl8-08",
    "metadata": {
     "papermill": {
-     "duration": 0.003022,
-     "end_time": "2026-06-17T01:25:17.132927+00:00",
+     "duration": 0.003317,
+     "end_time": "2026-06-17T01:28:32.801862+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.129905+00:00",
+     "start_time": "2026-06-17T01:28:32.798545+00:00",
      "status": "completed"
     },
     "tags": []
@@ -423,16 +423,16 @@
    "id": "sl8-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.140574Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.140398Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.146866Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.146037Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.810081Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.809885Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.817260Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.816622Z"
     },
     "papermill": {
-     "duration": 0.011378,
-     "end_time": "2026-06-17T01:25:17.147600+00:00",
+     "duration": 0.012592,
+     "end_time": "2026-06-17T01:28:32.817895+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.136222+00:00",
+     "start_time": "2026-06-17T01:28:32.805303+00:00",
      "status": "completed"
     },
     "tags": []
@@ -526,10 +526,10 @@
    "id": "sl8-10",
    "metadata": {
     "papermill": {
-     "duration": 0.003337,
-     "end_time": "2026-06-17T01:25:17.154425+00:00",
+     "duration": 0.003795,
+     "end_time": "2026-06-17T01:28:32.825536+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.151088+00:00",
+     "start_time": "2026-06-17T01:28:32.821741+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,16 +550,16 @@
    "id": "sl8-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.162322Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.162041Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.170807Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.170038Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.834457Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.834233Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.844032Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.843273Z"
     },
     "papermill": {
-     "duration": 0.01361,
-     "end_time": "2026-06-17T01:25:17.171450+00:00",
+     "duration": 0.015458,
+     "end_time": "2026-06-17T01:28:32.844703+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.157840+00:00",
+     "start_time": "2026-06-17T01:28:32.829245+00:00",
      "status": "completed"
     },
     "tags": []
@@ -626,10 +626,10 @@
    "id": "sl8-12",
    "metadata": {
     "papermill": {
-     "duration": 0.003627,
-     "end_time": "2026-06-17T01:25:17.178854+00:00",
+     "duration": 0.00344,
+     "end_time": "2026-06-17T01:28:32.851814+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.175227+00:00",
+     "start_time": "2026-06-17T01:28:32.848374+00:00",
      "status": "completed"
     },
     "tags": []
@@ -659,10 +659,10 @@
    "id": "sl8-13",
    "metadata": {
     "papermill": {
-     "duration": 0.004161,
-     "end_time": "2026-06-17T01:25:17.186630+00:00",
+     "duration": 0.003536,
+     "end_time": "2026-06-17T01:28:32.859027+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.182469+00:00",
+     "start_time": "2026-06-17T01:28:32.855491+00:00",
      "status": "completed"
     },
     "tags": []
@@ -697,16 +697,16 @@
    "id": "sl8-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.195620Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.195146Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.203905Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.203111Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.868277Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.868045Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.876337Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.875613Z"
     },
     "papermill": {
-     "duration": 0.014241,
-     "end_time": "2026-06-17T01:25:17.204523+00:00",
+     "duration": 0.014235,
+     "end_time": "2026-06-17T01:28:32.876980+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.190282+00:00",
+     "start_time": "2026-06-17T01:28:32.862745+00:00",
      "status": "completed"
     },
     "tags": []
@@ -770,10 +770,10 @@
    "id": "sl8-15",
    "metadata": {
     "papermill": {
-     "duration": 0.00376,
-     "end_time": "2026-06-17T01:25:17.212515+00:00",
+     "duration": 0.003938,
+     "end_time": "2026-06-17T01:28:32.884993+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.208755+00:00",
+     "start_time": "2026-06-17T01:28:32.881055+00:00",
      "status": "completed"
     },
     "tags": []
@@ -798,10 +798,10 @@
    "id": "sl8-16",
    "metadata": {
     "papermill": {
-     "duration": 0.003816,
-     "end_time": "2026-06-17T01:25:17.220167+00:00",
+     "duration": 0.004017,
+     "end_time": "2026-06-17T01:28:32.893342+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.216351+00:00",
+     "start_time": "2026-06-17T01:28:32.889325+00:00",
      "status": "completed"
     },
     "tags": []
@@ -832,16 +832,16 @@
    "id": "sl8-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.229220Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.228852Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.262527Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.261624Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.902427Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.902041Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.929207Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.928388Z"
     },
     "papermill": {
-     "duration": 0.039337,
-     "end_time": "2026-06-17T01:25:17.263189+00:00",
+     "duration": 0.032745,
+     "end_time": "2026-06-17T01:28:32.929857+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.223852+00:00",
+     "start_time": "2026-06-17T01:28:32.897112+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,10 +922,10 @@
    "id": "sl8-18",
    "metadata": {
     "papermill": {
-     "duration": 0.003781,
-     "end_time": "2026-06-17T01:25:17.270885+00:00",
+     "duration": 0.00396,
+     "end_time": "2026-06-17T01:28:32.937666+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.267104+00:00",
+     "start_time": "2026-06-17T01:28:32.933706+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,10 +960,10 @@
    "id": "sl8-19",
    "metadata": {
     "papermill": {
-     "duration": 0.004058,
-     "end_time": "2026-06-17T01:25:17.278768+00:00",
+     "duration": 0.003555,
+     "end_time": "2026-06-17T01:28:32.944835+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.274710+00:00",
+     "start_time": "2026-06-17T01:28:32.941280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1000,10 +1000,10 @@
    "id": "sl8-20",
    "metadata": {
     "papermill": {
-     "duration": 0.003799,
-     "end_time": "2026-06-17T01:25:17.286427+00:00",
+     "duration": 0.003795,
+     "end_time": "2026-06-17T01:28:32.952635+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.282628+00:00",
+     "start_time": "2026-06-17T01:28:32.948840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,16 +1031,16 @@
    "id": "sl8-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.295336Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.294954Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.311398Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.310648Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.961454Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.961227Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.977712Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.976858Z"
     },
     "papermill": {
-     "duration": 0.021866,
-     "end_time": "2026-06-17T01:25:17.312027+00:00",
+     "duration": 0.021848,
+     "end_time": "2026-06-17T01:28:32.978320+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.290161+00:00",
+     "start_time": "2026-06-17T01:28:32.956472+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1122,10 +1122,10 @@
    "id": "sl8ex1var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003742,
-     "end_time": "2026-06-17T01:25:17.319519+00:00",
+     "duration": 0.003816,
+     "end_time": "2026-06-17T01:28:32.986231+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.315777+00:00",
+     "start_time": "2026-06-17T01:28:32.982415+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1149,16 +1149,16 @@
    "id": "sl8ex1var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.328036Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.327714Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.331799Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.331084Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.995101Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.994905Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.998626Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.998006Z"
     },
     "papermill": {
-     "duration": 0.00934,
-     "end_time": "2026-06-17T01:25:17.332460+00:00",
+     "duration": 0.009194,
+     "end_time": "2026-06-17T01:28:32.999198+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.323120+00:00",
+     "start_time": "2026-06-17T01:28:32.990004+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1208,10 +1208,10 @@
    "id": "sl8-22",
    "metadata": {
     "papermill": {
-     "duration": 0.003419,
-     "end_time": "2026-06-17T01:25:17.339680+00:00",
+     "duration": 0.003922,
+     "end_time": "2026-06-17T01:28:33.007056+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.336261+00:00",
+     "start_time": "2026-06-17T01:28:33.003134+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1228,16 +1228,16 @@
    "id": "sl8-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.347704Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.347512Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.350979Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.350293Z"
+     "iopub.execute_input": "2026-06-17T01:28:33.016886Z",
+     "iopub.status.busy": "2026-06-17T01:28:33.016575Z",
+     "iopub.status.idle": "2026-06-17T01:28:33.362596Z",
+     "shell.execute_reply": "2026-06-17T01:28:33.361887Z"
     },
     "papermill": {
-     "duration": 0.008528,
-     "end_time": "2026-06-17T01:25:17.351556+00:00",
+     "duration": 0.352192,
+     "end_time": "2026-06-17T01:28:33.363175+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.343028+00:00",
+     "start_time": "2026-06-17T01:28:33.010983+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1247,22 +1247,173 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Fiabilite de l'oracle d'equivalence par echantillonnage (20 graines)\n",
+      "================================================================\n",
+      " n_samples |  NEEDLE (desaccords rares) |  TARGET parites (denses)\n",
+      "----------------------------------------------------------------\n",
+      "         1 |                        0% |                     50%\n",
+      "        10 |                       10% |                    100%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        50 |                       60% |                    100%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       100 |                      100% |                    100%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       500 |                      100% |                    100%\n",
+      "\n",
+      "Lecture : le seuil de fiabilite (n_samples au-dela duquel le taux tend\n",
+      "vers 100%) depend fortement du langage. NEEDLE (contient 'aabbaabb') a\n",
+      "des desaccords RARES -- peu de mots distinguent une hypothese fausse de\n",
+      "la cible, il faut donc beaucoup d'echantillons pour tomber sur un mot\n",
+      "revelateur. TARGET (parite des 'a' et 'b') a des desaccords DENSES --\n",
+      "pres de la moitie des mots distinguent deux DFAs differents -- donc peu\n",
+      "d'echantillons suffisent. La fiabilite d'un oracle PAC est plafonnee par\n",
+      "la DENSITE des contre-exemples dans le langage cible.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : Fiabilite de l'oracle d'equivalence approximatif\n",
-    "# TODO etudiant : pour n_samples dans [1, 10, 50, 100, 500], lancez L* sur le\n",
-    "# langage-aiguille NEEDLE (section 6) avec 20 graines differentes (seed=0..19)\n",
-    "# et mesurez le TAUX de runs qui retournent un DFA exactement correct.\n",
-    "# Indice : la correction se verifie avec find_counterexample(hyp, NEEDLE, ALPHABET)\n",
-    "# Etape 1 : double boucle n_samples x seed, verbose=False\n",
-    "# Etape 2 : tableau n_samples -> taux de reussite (sur 20 runs)\n",
-    "# Etape 3 : ou situez-vous le seuil de fiabilite ? Refaites la mesure sur TARGET\n",
-    "#           (parites) : pourquoi le seuil depend-il du langage ?\n",
+    "# Exemple guide 2 : Fiabilite de l'oracle d'equivalence approximatif\n",
+    "#\n",
+    "# L'oracle d'equivalence par echantillonnage est une variable aleatoire :\n",
+    "# sa fiabilite se mesure en repetant l'experience. Pour plusieurs tailles\n",
+    "# d'echantillon et 20 graines, on mesure le TAUX de runs qui produisent\n",
+    "# un DFA exactement correct (verifie par l'oracle EXACT find_counterexample).\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : taux de reussite sur n_seeds graines\n",
+    "def taux_fiabilite(mq, target, n_samples, n_seeds=20):\n",
+    "    \"\"\"Lance L* n_seeds fois ; retourne la fraction de runs exactement corrects.\"\"\"\n",
+    "    corrects = 0\n",
+    "    for seed in range(n_seeds):\n",
+    "        eq = make_sampling_eq(mq, ALPHABET, n_samples, seed=seed)\n",
+    "        hyp, _, _ = lstar(ALPHABET, mq, eq, verbose=False)\n",
+    "        if find_counterexample(hyp, target, ALPHABET) is None:\n",
+    "            corrects += 1\n",
+    "    return corrects / n_seeds\n",
+    "\n",
+    "# Etape 2 : tableau n_samples -> taux de reussite (sur 20 runs), NEEDLE vs TARGET\n",
+    "print(\"Fiabilite de l'oracle d'equivalence par echantillonnage (20 graines)\")\n",
+    "print(\"=\" * 64)\n",
+    "print(f\"{'n_samples':>10} | {'NEEDLE (desaccords rares)':>26} | \"\n",
+    "      f\"{'TARGET parites (denses)':>24}\")\n",
+    "print(\"-\" * 64)\n",
+    "for n_samples in [1, 10, 50, 100, 500]:\n",
+    "    t_needle = taux_fiabilite(NEEDLE.accepts, NEEDLE, n_samples)\n",
+    "    t_target = taux_fiabilite(membership_query, TARGET, n_samples)\n",
+    "    print(f\"{n_samples:>10} | {t_needle:>25.0%} | {t_target:>23.0%}\")\n",
+    "\n",
+    "# Etape 3 : seuil de fiabilite + pourquoi il depend du langage\n",
+    "print()\n",
+    "print(\"Lecture : le seuil de fiabilite (n_samples au-dela duquel le taux tend\")\n",
+    "print(\"vers 100%) depend fortement du langage. NEEDLE (contient 'aabbaabb') a\")\n",
+    "print(\"des desaccords RARES -- peu de mots distinguent une hypothese fausse de\")\n",
+    "print(\"la cible, il faut donc beaucoup d'echantillons pour tomber sur un mot\")\n",
+    "print(\"revelateur. TARGET (parite des 'a' et 'b') a des desaccords DENSES --\")\n",
+    "print(\"pres de la moitie des mots distinguent deux DFAs differents -- donc peu\")\n",
+    "print(\"d'echantillons suffisent. La fiabilite d'un oracle PAC est plafonnee par\")\n",
+    "print(\"la DENSITE des contre-exemples dans le langage cible.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8ex2var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004043,
+     "end_time": "2026-06-17T01:28:33.371209+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:28:33.367166+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 (variation) : Fiabilite vs longueur des mots echantillonnes\n",
+    "\n",
+    "Pour NEEDLE, le contre-exemple revelateur est un mot LONG (il faut un mot contenant \"aabbaabb\"). L'oracle echantillonne des mots de longueur `<= max_len` : que se passe-t-il si `max_len < 8` (aucun mot genere ne peut contenir le motif) ? Mesurez le taux de fiabilite pour `max_len` dans `[5, 8, 12, 20]`, a `n_samples` fixe.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Reutiliser `taux_fiabilite` en variant `max_len` (parametre de `make_sampling_eq`) avec `n_samples=200` fixe, sur NEEDLE\n",
+    "2. Tableau `max_len` -> taux de reussite (20 graines)\n",
+    "3. Pourquoi `max_len < len(motif)` annule-t-il la fiabilite meme avec beaucoup d'echantillons ?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "sl8ex2var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:28:33.379662Z",
+     "iopub.status.busy": "2026-06-17T01:28:33.379489Z",
+     "iopub.status.idle": "2026-06-17T01:28:33.382946Z",
+     "shell.execute_reply": "2026-06-17T01:28:33.382406Z"
+    },
+    "papermill": {
+     "duration": 0.008539,
+     "end_time": "2026-06-17T01:28:33.383505+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:28:33.374966+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : fiabilite vs longueur des mots echantillonnes\n",
+      "Etape 1 : reutilisez taux_fiabilite en variant max_len (n_samples=200 fixe)\n",
+      "Etape 2 : affichez le tableau max_len -> taux sur NEEDLE\n",
+      "Etape 3 : expliquez pourquoi max_len < 8 annule la fiabilite\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (variation) : fiabilite vs longueur des mots echantillonnes\n",
+    "# TODO etudiant : pour NEEDLE, la fiabilite depend de max_len (longueur max\n",
+    "# des mots tires par l'oracle d'equivalence).\n",
+    "\n",
+    "# Etape 1 : taux_fiabilite en variant max_len, n_samples=200 fixe, sur NEEDLE\n",
+    "# def taux_fiabilite_maxlen(max_len, n_samples=200, n_seeds=20):\n",
+    "#     corrects = 0\n",
+    "#     for seed in range(n_seeds):\n",
+    "#         eq = make_sampling_eq(NEEDLE.accepts, ALPHABET, n_samples,\n",
+    "#                               max_len=max_len, seed=seed)\n",
+    "#         hyp, _, _ = lstar(ALPHABET, NEEDLE.accepts, eq, verbose=False)\n",
+    "#         if find_counterexample(hyp, NEEDLE, ALPHABET) is None:\n",
+    "#             corrects += 1\n",
+    "#     return corrects / n_seeds\n",
+    "\n",
+    "# Etape 2 : tableau max_len -> taux (20 graines)\n",
+    "# for max_len in [5, 8, 12, 20]:\n",
+    "#     print(f\"  max_len={max_len:>2} : {taux_fiabilite_maxlen(max_len):.0%}\")\n",
+    "\n",
+    "# Etape 3 : pourquoi max_len < len(motif) annule-t-il la fiabilite ?\n",
+    "print(\"Exercice a completer : fiabilite vs longueur des mots echantillonnes\")\n",
+    "print(\"Etape 1 : reutilisez taux_fiabilite en variant max_len (n_samples=200 fixe)\")\n",
+    "print(\"Etape 2 : affichez le tableau max_len -> taux sur NEEDLE\")\n",
+    "print(\"Etape 3 : expliquez pourquoi max_len < 8 annule la fiabilite\")\n",
+    "\n",
+    "# Indice : si aucun mot genere ne peut contenir le motif 'aabbaabb',\n",
+    "# l'oracle ne trouvera JAMAIS de contre-exemple, meme avec n_samples infini.\n",
+    "# result = None  # TODO etudiant : dict {max_len: taux}\n"
    ]
   },
   {
@@ -1270,10 +1421,10 @@
    "id": "sl8-24",
    "metadata": {
     "papermill": {
-     "duration": 0.003947,
-     "end_time": "2026-06-17T01:25:17.359237+00:00",
+     "duration": 0.003863,
+     "end_time": "2026-06-17T01:28:33.391306+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.355290+00:00",
+     "start_time": "2026-06-17T01:28:33.387443+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1286,20 +1437,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "sl8-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.367760Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.367511Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.370929Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.370314Z"
+     "iopub.execute_input": "2026-06-17T01:28:33.400794Z",
+     "iopub.status.busy": "2026-06-17T01:28:33.400568Z",
+     "iopub.status.idle": "2026-06-17T01:28:33.404248Z",
+     "shell.execute_reply": "2026-06-17T01:28:33.403645Z"
     },
     "papermill": {
-     "duration": 0.008533,
-     "end_time": "2026-06-17T01:25:17.371439+00:00",
+     "duration": 0.0096,
+     "end_time": "2026-06-17T01:28:33.404859+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.362906+00:00",
+     "start_time": "2026-06-17T01:28:33.395259+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1333,10 +1484,10 @@
    "id": "sl8-26",
    "metadata": {
     "papermill": {
-     "duration": 0.003353,
-     "end_time": "2026-06-17T01:25:17.378456+00:00",
+     "duration": 0.00411,
+     "end_time": "2026-06-17T01:28:33.412862+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.375103+00:00",
+     "start_time": "2026-06-17T01:28:33.408752+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1348,20 +1499,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "sl8-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.386622Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.386432Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.389664Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.389009Z"
+     "iopub.execute_input": "2026-06-17T01:28:33.421925Z",
+     "iopub.status.busy": "2026-06-17T01:28:33.421736Z",
+     "iopub.status.idle": "2026-06-17T01:28:33.425319Z",
+     "shell.execute_reply": "2026-06-17T01:28:33.424511Z"
     },
     "papermill": {
-     "duration": 0.008106,
-     "end_time": "2026-06-17T01:25:17.390176+00:00",
+     "duration": 0.009001,
+     "end_time": "2026-06-17T01:28:33.425997+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.382070+00:00",
+     "start_time": "2026-06-17T01:28:33.416996+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1396,10 +1547,10 @@
    "id": "sl8-29",
    "metadata": {
     "papermill": {
-     "duration": 0.00338,
-     "end_time": "2026-06-17T01:25:17.397067+00:00",
+     "duration": 0.004082,
+     "end_time": "2026-06-17T01:28:33.434075+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.393687+00:00",
+     "start_time": "2026-06-17T01:28:33.429993+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1456,10 +1607,10 @@
    "id": "sl8-28",
    "metadata": {
     "papermill": {
-     "duration": 0.00329,
-     "end_time": "2026-06-17T01:25:17.403630+00:00",
+     "duration": 0.003957,
+     "end_time": "2026-06-17T01:28:33.443729+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.400340+00:00",
+     "start_time": "2026-06-17T01:28:33.439772+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1487,10 +1638,10 @@
    "id": "sl8-30",
    "metadata": {
     "papermill": {
-     "duration": 0.003471,
-     "end_time": "2026-06-17T01:25:17.411045+00:00",
+     "duration": 0.00415,
+     "end_time": "2026-06-17T01:28:33.452082+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.407574+00:00",
+     "start_time": "2026-06-17T01:28:33.447932+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1533,14 +1684,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.428777,
-   "end_time": "2026-06-17T01:25:17.545944+00:00",
+   "duration": 2.768843,
+   "end_time": "2026-06-17T01:28:33.699342+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T01:25:15.117167+00:00",
+   "start_time": "2026-06-17T01:28:30.930499+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
> **PR empilee (stacked)** : base = `feat/sl8-ex1-guided` (#3179). Merger #3179 d'abord ; cette PR se re-cible vers main. Le diff ne montre que la contribution Ex2.

## Livrable

**Ex2 resolu en exemple guide** (fiabilite de l'oracle d'equivalence par echantillonnage) :
- `taux_fiabilite(mq, target, n_samples, n_seeds=20)` : lance L* `n_seeds` fois (graine fraiche a chaque run), verifie l'exactitude via `find_counterexample`, retourne la fraction de runs corrects. Tableau sur `n_samples in [1,10,50,100,500]` pour NEEDLE (desaccords rares) vs TARGET (desaccords denses).

**Nouvel exercice en variation** : fiabilite vs longueur des mots echantillonnes (`max_len`), a `n_samples=200` fixe sur NEEDLE — pourquoi `max_len < len(motif)` annule la fiabilite. Reutilise `taux_fiabilite`. C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`--kernel python3`) : **SUCCESS** 4.9s, 1/1 notebooks, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 12 cellules code, `execution_count` set + outputs + 0 erreur. (SL-8 = notebook algorithmique pur, sans cellule LLM/API.)
- **Sortie Ex2** : NEEDLE `0%->10%->60%->100%->100%` (seuil ~100) ; TARGET `50%->100%->100%->100%->100%` (seuil ~10).

## Lecture pedagogique

Le seuil de fiabilite depend de la **densite des desaccords** dans le langage cible. NEEDLE (desaccords rares : peu de mots revelent une hypothese fausse) exige beaucoup d'echantillons ; TARGET (desaccords denses : ~la moitie des mots distinguent deux DFAs) converge vite. La fiabilite PAC est plafonnee par cette densite.

## Anti-regression (verifie vs `feat/sl8-ex1-guided`)

- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- Source code +56 lignes (stub Ex2 -> solution + stub variation). Commentaire Ex2 relicole.
- 1 fichier `.ipynb` (SL-8). Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
