### PR TITLE
feat(sl8): resolve Ex3 (Maler-Pnueli suffix variant) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "sl8-01",
    "metadata": {
     "papermill": {
-     "duration": 0.003984,
-     "end_time": "2026-06-17T01:28:32.733757+00:00",
+     "duration": 0.003727,
+     "end_time": "2026-06-17T01:33:26.170226+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.729773+00:00",
+     "start_time": "2026-06-17T01:33:26.166499+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "sl8-02",
    "metadata": {
     "papermill": {
-     "duration": 0.0032,
-     "end_time": "2026-06-17T01:28:32.740610+00:00",
+     "duration": 0.002869,
+     "end_time": "2026-06-17T01:33:26.176260+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.737410+00:00",
+     "start_time": "2026-06-17T01:33:26.173391+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,16 +89,16 @@
    "id": "sl8-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.748415Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.748216Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.756972Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.756363Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.183506Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.183315Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.191775Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.191184Z"
     },
     "papermill": {
-     "duration": 0.013798,
-     "end_time": "2026-06-17T01:28:32.757576+00:00",
+     "duration": 0.013478,
+     "end_time": "2026-06-17T01:33:26.192620+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.743778+00:00",
+     "start_time": "2026-06-17T01:33:26.179142+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,10 +178,10 @@
    "id": "sl8-04",
    "metadata": {
     "papermill": {
-     "duration": 0.004591,
-     "end_time": "2026-06-17T01:28:32.765921+00:00",
+     "duration": 0.003217,
+     "end_time": "2026-06-17T01:33:26.199383+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.761330+00:00",
+     "start_time": "2026-06-17T01:33:26.196166+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,10 +206,10 @@
    "id": "sl8-05",
    "metadata": {
     "papermill": {
-     "duration": 0.003201,
-     "end_time": "2026-06-17T01:28:32.772419+00:00",
+     "duration": 0.002951,
+     "end_time": "2026-06-17T01:33:26.205371+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.769218+00:00",
+     "start_time": "2026-06-17T01:33:26.202420+00:00",
      "status": "completed"
     },
     "tags": []
@@ -247,16 +247,16 @@
    "id": "sl8-06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.780190Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.779893Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.787819Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.787343Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.212392Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.212222Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.219669Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.219061Z"
     },
     "papermill": {
-     "duration": 0.012735,
-     "end_time": "2026-06-17T01:28:32.788474+00:00",
+     "duration": 0.011782,
+     "end_time": "2026-06-17T01:33:26.220130+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.775739+00:00",
+     "start_time": "2026-06-17T01:33:26.208348+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "sl8-07",
    "metadata": {
     "papermill": {
-     "duration": 0.00337,
-     "end_time": "2026-06-17T01:28:32.795281+00:00",
+     "duration": 0.003119,
+     "end_time": "2026-06-17T01:33:26.226336+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.791911+00:00",
+     "start_time": "2026-06-17T01:33:26.223217+00:00",
      "status": "completed"
     },
     "tags": []
@@ -385,10 +385,10 @@
    "id": "sl8-08",
    "metadata": {
     "papermill": {
-     "duration": 0.003317,
-     "end_time": "2026-06-17T01:28:32.801862+00:00",
+     "duration": 0.003994,
+     "end_time": "2026-06-17T01:33:26.233434+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.798545+00:00",
+     "start_time": "2026-06-17T01:33:26.229440+00:00",
      "status": "completed"
     },
     "tags": []
@@ -423,16 +423,16 @@
    "id": "sl8-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.810081Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.809885Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.817260Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.816622Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.241564Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.241229Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.247609Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.247134Z"
     },
     "papermill": {
-     "duration": 0.012592,
-     "end_time": "2026-06-17T01:28:32.817895+00:00",
+     "duration": 0.011232,
+     "end_time": "2026-06-17T01:33:26.248223+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.805303+00:00",
+     "start_time": "2026-06-17T01:33:26.236991+00:00",
      "status": "completed"
     },
     "tags": []
@@ -526,10 +526,10 @@
    "id": "sl8-10",
    "metadata": {
     "papermill": {
-     "duration": 0.003795,
-     "end_time": "2026-06-17T01:28:32.825536+00:00",
+     "duration": 0.003422,
+     "end_time": "2026-06-17T01:33:26.254983+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.821741+00:00",
+     "start_time": "2026-06-17T01:33:26.251561+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,16 +550,16 @@
    "id": "sl8-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.834457Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.834233Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.844032Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.843273Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.263104Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.262887Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.271721Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.270998Z"
     },
     "papermill": {
-     "duration": 0.015458,
-     "end_time": "2026-06-17T01:28:32.844703+00:00",
+     "duration": 0.013883,
+     "end_time": "2026-06-17T01:33:26.272246+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.829245+00:00",
+     "start_time": "2026-06-17T01:33:26.258363+00:00",
      "status": "completed"
     },
     "tags": []
@@ -626,10 +626,10 @@
    "id": "sl8-12",
    "metadata": {
     "papermill": {
-     "duration": 0.00344,
-     "end_time": "2026-06-17T01:28:32.851814+00:00",
+     "duration": 0.003569,
+     "end_time": "2026-06-17T01:33:26.279591+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.848374+00:00",
+     "start_time": "2026-06-17T01:33:26.276022+00:00",
      "status": "completed"
     },
     "tags": []
@@ -659,10 +659,10 @@
    "id": "sl8-13",
    "metadata": {
     "papermill": {
-     "duration": 0.003536,
-     "end_time": "2026-06-17T01:28:32.859027+00:00",
+     "duration": 0.004285,
+     "end_time": "2026-06-17T01:33:26.287428+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.855491+00:00",
+     "start_time": "2026-06-17T01:33:26.283143+00:00",
      "status": "completed"
     },
     "tags": []
@@ -697,16 +697,16 @@
    "id": "sl8-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.868277Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.868045Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.876337Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.875613Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.295819Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.295477Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.302811Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.302226Z"
     },
     "papermill": {
-     "duration": 0.014235,
-     "end_time": "2026-06-17T01:28:32.876980+00:00",
+     "duration": 0.012824,
+     "end_time": "2026-06-17T01:33:26.303549+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.862745+00:00",
+     "start_time": "2026-06-17T01:33:26.290725+00:00",
      "status": "completed"
     },
     "tags": []
@@ -770,10 +770,10 @@
    "id": "sl8-15",
    "metadata": {
     "papermill": {
-     "duration": 0.003938,
-     "end_time": "2026-06-17T01:28:32.884993+00:00",
+     "duration": 0.003595,
+     "end_time": "2026-06-17T01:33:26.311078+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.881055+00:00",
+     "start_time": "2026-06-17T01:33:26.307483+00:00",
      "status": "completed"
     },
     "tags": []
@@ -798,10 +798,10 @@
    "id": "sl8-16",
    "metadata": {
     "papermill": {
-     "duration": 0.004017,
-     "end_time": "2026-06-17T01:28:32.893342+00:00",
+     "duration": 0.003365,
+     "end_time": "2026-06-17T01:33:26.317880+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.889325+00:00",
+     "start_time": "2026-06-17T01:33:26.314515+00:00",
      "status": "completed"
     },
     "tags": []
@@ -832,16 +832,16 @@
    "id": "sl8-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.902427Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.902041Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.929207Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.928388Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.325453Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.325274Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.350453Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.349814Z"
     },
     "papermill": {
-     "duration": 0.032745,
-     "end_time": "2026-06-17T01:28:32.929857+00:00",
+     "duration": 0.029804,
+     "end_time": "2026-06-17T01:33:26.350953+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.897112+00:00",
+     "start_time": "2026-06-17T01:33:26.321149+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,10 +922,10 @@
    "id": "sl8-18",
    "metadata": {
     "papermill": {
-     "duration": 0.00396,
-     "end_time": "2026-06-17T01:28:32.937666+00:00",
+     "duration": 0.003912,
+     "end_time": "2026-06-17T01:33:26.358798+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.933706+00:00",
+     "start_time": "2026-06-17T01:33:26.354886+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,10 +960,10 @@
    "id": "sl8-19",
    "metadata": {
     "papermill": {
-     "duration": 0.003555,
-     "end_time": "2026-06-17T01:28:32.944835+00:00",
+     "duration": 0.003438,
+     "end_time": "2026-06-17T01:33:26.365748+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.941280+00:00",
+     "start_time": "2026-06-17T01:33:26.362310+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1000,10 +1000,10 @@
    "id": "sl8-20",
    "metadata": {
     "papermill": {
-     "duration": 0.003795,
-     "end_time": "2026-06-17T01:28:32.952635+00:00",
+     "duration": 0.003911,
+     "end_time": "2026-06-17T01:33:26.372927+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.948840+00:00",
+     "start_time": "2026-06-17T01:33:26.369016+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,16 +1031,16 @@
    "id": "sl8-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.961454Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.961227Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.977712Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.976858Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.381438Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.381260Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.395839Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.395151Z"
     },
     "papermill": {
-     "duration": 0.021848,
-     "end_time": "2026-06-17T01:28:32.978320+00:00",
+     "duration": 0.020021,
+     "end_time": "2026-06-17T01:33:26.396492+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.956472+00:00",
+     "start_time": "2026-06-17T01:33:26.376471+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1122,10 +1122,10 @@
    "id": "sl8ex1var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003816,
-     "end_time": "2026-06-17T01:28:32.986231+00:00",
+     "duration": 0.003874,
+     "end_time": "2026-06-17T01:33:26.404574+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.982415+00:00",
+     "start_time": "2026-06-17T01:33:26.400700+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1149,16 +1149,16 @@
    "id": "sl8ex1var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.995101Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.994905Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.998626Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.998006Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.412422Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.412231Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.415848Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.415287Z"
     },
     "papermill": {
-     "duration": 0.009194,
-     "end_time": "2026-06-17T01:28:32.999198+00:00",
+     "duration": 0.008467,
+     "end_time": "2026-06-17T01:33:26.416310+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.990004+00:00",
+     "start_time": "2026-06-17T01:33:26.407843+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1208,10 +1208,10 @@
    "id": "sl8-22",
    "metadata": {
     "papermill": {
-     "duration": 0.003922,
-     "end_time": "2026-06-17T01:28:33.007056+00:00",
+     "duration": 0.003708,
+     "end_time": "2026-06-17T01:33:26.423588+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.003134+00:00",
+     "start_time": "2026-06-17T01:33:26.419880+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1228,16 +1228,16 @@
    "id": "sl8-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:33.016886Z",
-     "iopub.status.busy": "2026-06-17T01:28:33.016575Z",
-     "iopub.status.idle": "2026-06-17T01:28:33.362596Z",
-     "shell.execute_reply": "2026-06-17T01:28:33.361887Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.432078Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.431826Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.754850Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.754189Z"
     },
     "papermill": {
-     "duration": 0.352192,
-     "end_time": "2026-06-17T01:28:33.363175+00:00",
+     "duration": 0.328166,
+     "end_time": "2026-06-17T01:33:26.755401+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.010983+00:00",
+     "start_time": "2026-06-17T01:33:26.427235+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1251,14 +1251,14 @@
       "================================================================\n",
       " n_samples |  NEEDLE (desaccords rares) |  TARGET parites (denses)\n",
       "----------------------------------------------------------------\n",
-      "         1 |                        0% |                     50%\n",
-      "        10 |                       10% |                    100%\n"
+      "         1 |                        0% |                     50%\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "        10 |                       10% |                    100%\n",
       "        50 |                       60% |                    100%\n"
      ]
     },
@@ -1333,10 +1333,10 @@
    "id": "sl8ex2var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.004043,
-     "end_time": "2026-06-17T01:28:33.371209+00:00",
+     "duration": 0.003645,
+     "end_time": "2026-06-17T01:33:26.762998+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.367166+00:00",
+     "start_time": "2026-06-17T01:33:26.759353+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1359,16 +1359,16 @@
    "id": "sl8ex2var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:33.379662Z",
-     "iopub.status.busy": "2026-06-17T01:28:33.379489Z",
-     "iopub.status.idle": "2026-06-17T01:28:33.382946Z",
-     "shell.execute_reply": "2026-06-17T01:28:33.382406Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.770843Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.770681Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.773797Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.773252Z"
     },
     "papermill": {
-     "duration": 0.008539,
-     "end_time": "2026-06-17T01:28:33.383505+00:00",
+     "duration": 0.008013,
+     "end_time": "2026-06-17T01:33:26.774444+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.374966+00:00",
+     "start_time": "2026-06-17T01:33:26.766431+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1421,10 +1421,10 @@
    "id": "sl8-24",
    "metadata": {
     "papermill": {
-     "duration": 0.003863,
-     "end_time": "2026-06-17T01:28:33.391306+00:00",
+     "duration": 0.003489,
+     "end_time": "2026-06-17T01:33:26.781521+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.387443+00:00",
+     "start_time": "2026-06-17T01:33:26.778032+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1441,16 +1441,16 @@
    "id": "sl8-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:33.400794Z",
-     "iopub.status.busy": "2026-06-17T01:28:33.400568Z",
-     "iopub.status.idle": "2026-06-17T01:28:33.404248Z",
-     "shell.execute_reply": "2026-06-17T01:28:33.403645Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.792072Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.791873Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.799689Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.799140Z"
     },
     "papermill": {
-     "duration": 0.0096,
-     "end_time": "2026-06-17T01:28:33.404859+00:00",
+     "duration": 0.014723,
+     "end_time": "2026-06-17T01:33:26.800122+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.395259+00:00",
+     "start_time": "2026-06-17T01:33:26.785399+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1460,23 +1460,203 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Comparaison Angluin (prefixes -> S) vs Maler-Pnueli (suffixes -> E)\n",
+      "======================================================================\n",
+      "Langage                | Variante      |  |S| |  |E| | |S|x|E| |    MQ |  EQ\n",
+      "----------------------------------------------------------------------\n",
+      "TARGET (parites)       | Angluin       |    4 |    3 |      12 |    19 |   2\n",
+      "TARGET (parites)       | Maler-Pnueli  |    4 |    3 |      12 |    19 |   2\n",
+      "L_5 (longueur % 5)     | Angluin       |    6 |    4 |      24 |    34 |   2\n",
+      "L_5 (longueur % 5)     | Maler-Pnueli  |    5 |    6 |      30 |    41 |   2\n",
+      "\n",
+      "Lecture : les deux variantes echangent |S| contre |E|. Angluin ajoute\n",
+      "des PREFIXES a S (un acces par etat revele par le contre-exemple) ;\n",
+      "Maler-Pnueli ajoute des SUFFIXES a E (un distinguant par contre-exemple).\n",
+      "Sur TARGET (4 etats) les deux coincident. Sur L_5, Maler-Pnueli garde |S|\n",
+      "plus petit (5 vs 6) mais grossit |E| (6 vs 4) : le total |S|x|E| et le\n",
+      "nombre de MQ sont alors legerement PLUS eleves (41 vs 34). La compacite\n",
+      "globale n'avantage donc AUCUNE des deux variantes en general. L'interet\n",
+      "reel de la variante suffixes est structurel : ajouter des suffixes a E ne\n",
+      "fait que raffiner le partitionnement des lignes (chaque colonne ne peut\n",
+      "que distinguer davantage de lignes egales), donc elle ne peut PAS\n",
+      "introduire d'inconsistance -- elle la resout, d'ou moins de passes de\n",
+      "re-stabilisation de la table.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 3 : Variante de traitement du contre-exemple (suffixes vs prefixes)\n",
-    "# TODO etudiant : implementez la variante qui, au lieu d'ajouter les prefixes du\n",
-    "# contre-exemple a S, ajoute tous ses SUFFIXES a E (variante Maler-Pnueli).\n",
-    "# Indice : copiez lstar() et modifiez uniquement le traitement du contre-exemple ;\n",
-    "#          les suffixes de c sont c[i:] pour i in range(len(c))\n",
-    "# Etape 1 : ecrivez lstar_suffixes(alphabet, mq, eq)\n",
-    "# Etape 2 : comparez sur le langage cible ET sur L_5 (divisibilite par 5) :\n",
-    "#           |S|, |E|, nombre de MQ, nombre d'EQ pour les deux variantes\n",
-    "# Etape 3 : laquelle maintient la table la plus compacte ? Pourquoi la variante\n",
-    "#           suffixes ne peut-elle jamais rendre la table inconsistante ?\n",
+    "# Exemple guide 3 : Variante de traitement du contre-exemple (suffixes vs prefixes)\n",
+    "#\n",
+    "# Angluin (1987) ajoute tous les PREFIXES du contre-exemple a S. La variante\n",
+    "# de Maler-Pnueli ajoute tous ses SUFFIXES a E : meme garantie de terminaison,\n",
+    "# mais un profil de cout different (|E| croit, |S| reste compact).\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "def lstar_suffixes(alphabet, mq, eq, verbose=False):\n",
+    "    \"\"\"L* variante Maler-Pnueli : integre le contre-exemple par ses SUFFIXES\n",
+    "    (ajoutes a E) plutot que par ses prefixes (ajoutes a S).\"\"\"\n",
+    "    table = ObservationTable(alphabet, mq)\n",
+    "    n_eq = 0\n",
+    "    round_ = 0\n",
+    "    while True:\n",
+    "        # 1. Stabiliser la table (fermeture + consistance)\n",
+    "        while True:\n",
+    "            sa = table.find_unclosed()\n",
+    "            if sa is not None:\n",
+    "                table.S.append(sa)\n",
+    "                table.fill()\n",
+    "                continue\n",
+    "            ae = table.find_inconsistency()\n",
+    "            if ae is not None:\n",
+    "                table.E.append(ae)\n",
+    "                table.fill()\n",
+    "                continue\n",
+    "            break\n",
+    "        # 2. Conjecturer et interroger le professeur\n",
+    "        hyp = conjecture(table)\n",
+    "        n_eq += 1\n",
+    "        round_ += 1\n",
+    "        cex = eq(hyp)\n",
+    "        if cex is None:\n",
+    "            return hyp, table, n_eq\n",
+    "        # 3. Maler-Pnueli : ajouter les SUFFIXES cex[i:] du contre-exemple a E\n",
+    "        for i in range(len(cex)):\n",
+    "            suf = cex[i:]\n",
+    "            if suf not in table.E:\n",
+    "                table.E.append(suf)\n",
+    "        table.fill()\n",
+    "\n",
+    "\n",
+    "# Deuxieme langage de comparaison : L_5 = mots de longueur divisible par 5.\n",
+    "def l5_dfa():\n",
+    "    delta = {(q, a): (q + 1) % 5 for q in range(5) for a in ALPHABET}\n",
+    "    return DFA(range(5), ALPHABET, delta, 0, {0})\n",
+    "\n",
+    "\n",
+    "L5 = l5_dfa()\n",
+    "\n",
+    "\n",
+    "def eq_exact_pour(target):\n",
+    "    \"\"\"Oracle d'equivalence EXACT pour une cible donnee (DFA).\"\"\"\n",
+    "    return lambda h: find_counterexample(h, target, ALPHABET)\n",
+    "\n",
+    "\n",
+    "# Etape 2 : comparaison prefixes (Angluin) vs suffixes (Maler-Pnueli)\n",
+    "print(\"Comparaison Angluin (prefixes -> S) vs Maler-Pnueli (suffixes -> E)\")\n",
+    "print(\"=\" * 70)\n",
+    "print(f\"{'Langage':22s} | {'Variante':13s} | {'|S|':>4} | {'|E|':>4} | \"\n",
+    "      f\"{'|S|x|E|':>7} | {'MQ':>5} | {'EQ':>3}\")\n",
+    "print(\"-\" * 70)\n",
+    "langages = [(\"TARGET (parites)\", membership_query, TARGET),\n",
+    "            (\"L_5 (longueur % 5)\", L5.accepts, L5)]\n",
+    "for nom, mq, tgt in langages:\n",
+    "    eq = eq_exact_pour(tgt)\n",
+    "    for variante, runner in [(\"Angluin\", lstar), (\"Maler-Pnueli\", lstar_suffixes)]:\n",
+    "        hyp, tbl, n_eq = runner(ALPHABET, mq, eq, verbose=False)\n",
+    "        taille = len(tbl.S) * len(tbl.E)\n",
+    "        print(f\"{nom:22s} | {variante:13s} | {len(tbl.S):>4} | {len(tbl.E):>4} | \"\n",
+    "              f\"{taille:>7} | {tbl.n_mq:>5} | {n_eq:>3}\")\n",
+    "\n",
+    "# Etape 3 : lecture\n",
+    "print()\n",
+    "print(\"Lecture : les deux variantes echangent |S| contre |E|. Angluin ajoute\")\n",
+    "print(\"des PREFIXES a S (un acces par etat revele par le contre-exemple) ;\")\n",
+    "print(\"Maler-Pnueli ajoute des SUFFIXES a E (un distinguant par contre-exemple).\")\n",
+    "print(\"Sur TARGET (4 etats) les deux coincident. Sur L_5, Maler-Pnueli garde |S|\")\n",
+    "print(\"plus petit (5 vs 6) mais grossit |E| (6 vs 4) : le total |S|x|E| et le\")\n",
+    "print(\"nombre de MQ sont alors legerement PLUS eleves (41 vs 34). La compacite\")\n",
+    "print(\"globale n'avantage donc AUCUNE des deux variantes en general. L'interet\")\n",
+    "print(\"reel de la variante suffixes est structurel : ajouter des suffixes a E ne\")\n",
+    "print(\"fait que raffiner le partitionnement des lignes (chaque colonne ne peut\")\n",
+    "print(\"que distinguer davantage de lignes egales), donc elle ne peut PAS\")\n",
+    "print(\"introduire d'inconsistance -- elle la resout, d'ou moins de passes de\")\n",
+    "print(\"re-stabilisation de la table.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8ex3var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003651,
+     "end_time": "2026-06-17T01:33:26.807425+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:33:26.803774+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (variation) : Variante Rivest-Schapire (un seul suffixe, par dichotomie)\n",
+    "\n",
+    "Angluin ajoute **tous** les prefixes, Maler-Pnueli **tous** les suffixes. La variante de Rivest-Schapire (1993) est plus parcimonieuse : par **recherche dichotomique** sur le contre-exemple, elle identifie **un seul** suffixe distinguant et l'ajoute a `E`. Implementez cette recherche.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Soit un contre-exemple `c` ou l'hypothese et la cible differentent : trouvez par dichotomie un indice `i` tel que le suffixe `c[i:]` separe la ligne d'acces correspondante de celle de la cible\n",
+    "2. Ajoutez ce **seul** suffixe `c[i:]` a `E` (pas tous les suffixes)\n",
+    "3. Comparez le nombre total de MQ avec la variante Maler-Pnueli (tous les suffixes) sur `TARGET` : Rivest ajoute-t-il moins de colonnes ?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "sl8ex3var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:33:26.815227Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.815021Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.818298Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.817732Z"
+    },
+    "papermill": {
+     "duration": 0.007996,
+     "end_time": "2026-06-17T01:33:26.818834+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:33:26.810838+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : variante Rivest-Schapire (un seul suffixe par dichotomie)\n",
+      "Etape 1 : ecrivez suffixe_distinguant_rivest(table, cex) (recherche dichotomique)\n",
+      "Etape 2 : ecrivez lstar_rivest (copie de lstar_suffixes, ajout d'un seul suffixe)\n",
+      "Etape 3 : comparez n_mq et |E| avec Maler-Pnueli sur TARGET\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (variation) : variante Rivest-Schapire (un seul suffixe par dichotomie)\n",
+    "# TODO etudiant : au lieu d'ajouter TOUS les suffixes du contre-exemple a E,\n",
+    "# n'en ajouter qu'UN, trouve par recherche dichotomique.\n",
+    "\n",
+    "# Etape 1 : recherche dichotomique d'un suffixe distinguant dans le contre-exemple\n",
+    "# def suffixe_distinguant_rivest(table, cex):\n",
+    "#     # cex = contre-exemple ou hyp et target differentent\n",
+    "#     # renvoyer un seul suffixe cex[i:] a ajouter a E\n",
+    "#     ...\n",
+    "#     return None  # TODO etudiant\n",
+    "\n",
+    "# Etape 2 : lstar_rivest : copiez lstar_suffixes, remplacez l'ajout de tous les\n",
+    "# suffixes par l'ajout du SEUL suffixe renvoye par suffixe_distinguant_rivest\n",
+    "# def lstar_rivest(alphabet, mq, eq, verbose=False):\n",
+    "#     ...\n",
+    "#     return None  # TODO etudiant\n",
+    "\n",
+    "# Etape 3 : comparer n_mq et |E| avec Maler-Pnueli sur TARGET\n",
+    "print(\"Exercice a completer : variante Rivest-Schapire (un seul suffixe par dichotomie)\")\n",
+    "print(\"Etape 1 : ecrivez suffixe_distinguant_rivest(table, cex) (recherche dichotomique)\")\n",
+    "print(\"Etape 2 : ecrivez lstar_rivest (copie de lstar_suffixes, ajout d'un seul suffixe)\")\n",
+    "print(\"Etape 3 : comparez n_mq et |E| avec Maler-Pnueli sur TARGET\")\n",
+    "\n",
+    "# Indice : la dichotomie exploite le fait que si row(cex[0:]) (hyp) != row(cex[0:])\n",
+    "# (target) mais row(cex[k:]) (hyp) == row(cex[k:]) (target), alors il existe un\n",
+    "# point de bascule i ; cex[i:] est le suffixe cherche. O(log|cex|) ajout au lieu de |cex|.\n",
+    "# result = None  # TODO etudiant : le DFA appris par lstar_rivest\n"
    ]
   },
   {
@@ -1484,10 +1664,10 @@
    "id": "sl8-26",
    "metadata": {
     "papermill": {
-     "duration": 0.00411,
-     "end_time": "2026-06-17T01:28:33.412862+00:00",
+     "duration": 0.003443,
+     "end_time": "2026-06-17T01:33:26.825860+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.408752+00:00",
+     "start_time": "2026-06-17T01:33:26.822417+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1499,20 +1679,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "sl8-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:33.421925Z",
-     "iopub.status.busy": "2026-06-17T01:28:33.421736Z",
-     "iopub.status.idle": "2026-06-17T01:28:33.425319Z",
-     "shell.execute_reply": "2026-06-17T01:28:33.424511Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.833709Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.833574Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.837093Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.836126Z"
     },
     "papermill": {
-     "duration": 0.009001,
-     "end_time": "2026-06-17T01:28:33.425997+00:00",
+     "duration": 0.008195,
+     "end_time": "2026-06-17T01:33:26.837579+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.416996+00:00",
+     "start_time": "2026-06-17T01:33:26.829384+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1547,10 +1727,10 @@
    "id": "sl8-29",
    "metadata": {
     "papermill": {
-     "duration": 0.004082,
-     "end_time": "2026-06-17T01:28:33.434075+00:00",
+     "duration": 0.003808,
+     "end_time": "2026-06-17T01:33:26.845385+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.429993+00:00",
+     "start_time": "2026-06-17T01:33:26.841577+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1607,10 +1787,10 @@
    "id": "sl8-28",
    "metadata": {
     "papermill": {
-     "duration": 0.003957,
-     "end_time": "2026-06-17T01:28:33.443729+00:00",
+     "duration": 0.003715,
+     "end_time": "2026-06-17T01:33:26.852889+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.439772+00:00",
+     "start_time": "2026-06-17T01:33:26.849174+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1638,10 +1818,10 @@
    "id": "sl8-30",
    "metadata": {
     "papermill": {
-     "duration": 0.00415,
-     "end_time": "2026-06-17T01:28:33.452082+00:00",
+     "duration": 0.003476,
+     "end_time": "2026-06-17T01:33:26.859820+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.447932+00:00",
+     "start_time": "2026-06-17T01:33:26.856344+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1684,14 +1864,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.768843,
-   "end_time": "2026-06-17T01:28:33.699342+00:00",
+   "duration": 2.529194,
+   "end_time": "2026-06-17T01:33:26.996136+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T01:28:30.930499+00:00",
+   "start_time": "2026-06-17T01:33:24.466942+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
> **PR empilee (stacked)** : base = `feat/sl8-ex2-guided` (#3180). Ordre de merge : #3179 -> #3180 -> celle-ci. Le diff ne montre que la contribution Ex3.

## Livrable

**Ex3 resolu en exemple guide** (variante Maler-Pnueli : suffixes vs prefixes) :
- `lstar_suffixes(alphabet, mq, eq)` : copie de `lstar` integrant le contre-exemple par ses **suffixes** (ajoutes a `E`) au lieu de ses prefixes (a `S`). Oracle d'equivalence exact via `eq_exact_pour(target)`. Comparaison sur TARGET (parites) et L_5 (longueur % 5) : |S|, |E|, |S|x|E|, MQ, EQ.

**Nouvel exercice en variation** : variante Rivest-Schapire (un seul suffixe trouv par dichotomie). L'etudiant implemente `suffixe_distinguant_rivest` + `lstar_rivest`, compare MQ/|E| avec Maler-Pnueli. C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`--kernel python3`) : **SUCCESS** 4.5s, 1/1 notebooks, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 13 cellules code, `execution_count` set + outputs + 0 erreur.
- **Sortie Ex3** : TARGET les deux variantes coincident (|S|=4,|E|=3,MQ=19) ; L_5 Angluin |S|=6,|E|=4,MQ=34 vs Maler-Pnueli |S|=5,|E|=6,MQ=41.

## Lecture honnete (ancree dans la sortie reelle)

Les deux variantes **echangent |S| contre |E|**. Sur TARGET elles coincident ; sur L_5, Maler-Pnueli garde |S| plus petit (5 vs 6) mais grossit |E| (6 vs 4), d'ou un total de MQ legerement PLUS eleve (41 vs 34). **La compacite globale n'avantage aucune des deux** (correction : la premiere version sur-estimait l'avantage de Maler-Pnueli). Son interet reel est **structurel** : ajouter des suffixes ne fait que raffiner le partitionnement des lignes, donc ne peut PAS introduire d'inconsistance -- elle la resout.

## Anti-regression (verifie vs `feat/sl8-ex2-guided`)

- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- Source code +100 lignes (stub Ex3 -> `lstar_suffixes` + DFA L_5 + comparaison + stub variation). Commentaire Ex3 relicole.
- 1 fichier `.ipynb` (SL-8). Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
