### PR TITLE
docs(smt,z3): harmonize SMT/Z3 sub-series READMEs to series gabarit (#2651 Partie 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
@@ -1,6 +1,6 @@
 # SMT - Satisfiability Modulo Theories
 
-**Navigation** : [Index SymbolicAI](../README.md) | [Index général](../../README.md)
+[← Intelligence Symbolique](../README.md) | [Z3 (C# .NET) →](Z3/README.md) | [Z3-Python →](Z3-Python/README.md)
 
 ## En quelques mots
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -1,10 +1,10 @@
 # Série Z3-Python - Résolution de contraintes SMT en Python
 
-**Navigation** : [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Série Z3 C# (Z3.Linq)](../Z3/README.md) | [Index général](../../../README.md)
+[← SMT](../README.md) | [Z3 C# (Z3.Linq) →](../Z3/README.md)
 
 ## Série en quelques mots
 
-**6 notebooks (série complète) | 1 kernel | z3-solver (Python) | matplotlib**
+L'API z3-py expose l'intégralité du solveur Z3 en Python — `Solver`, `Optimize`, tactiques, théories `BitVec`/`Array`/`String`. Série complète de **6 notebooks** (z3-solver + matplotlib), de la satisfaction de contraintes à l'optimisation avancée.
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs Python souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de la syntaxe de base de z3-py pour monter progressivement vers l'optimisation et la modélisation de problèmes combinatoires.
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -1,10 +1,10 @@
 # Série Z3 - Programmation Déclarative avec Z3.Linq
 
-**Navigation** : [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md)
+[← SMT](../README.md) | [Z3-Python (série sœur) →](../Z3-Python/README.md)
 
 ## Série en quelques mots
 
-**7 notebooks** | **1 kernel** | **~5h10 de travail** | **Z3.Linq + fork Automata (.NET 9)**
+Le binding Z3.Linq traduit des requêtes LINQ C# en formules SMT — on décrit les contraintes, le solveur produit la solution. Série .NET 9 de **7 notebooks** (~5h10), du théorème linéaire à la génération de témoins (fork Automata).
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs C# souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de théorèmes linéaires simples pour monter progressivement vers les théories de tableaux et l'optimisation hiérarchique.
 


### PR DESCRIPTION
## Contexte

#2651 Partie 2 — harmonisation des READMEs sous-séries au gabarit (`docs/reference/readme-series-gabarit.md`). Cette PR traite la **sous-série SMT/Z3** (ma partition po-2025 : Z3 = .NET + j'ai livré toutes les PR notebooks Z3 #2970/#3005/#3072/#3080/#3085). C'est le dernier grain résiduel #2651 dans cette partition — Infer/PyMC/Probas (#3162 merged), ML family/Sudoku (#3170 in flight), Argumentum (audité CLEAN contre les 5 anti-patterns nommés), Z3 notebooks (audit complet) étant tous faits.

## Changements (3 fichiers, +5/-5)

**Anti-pattern 3 (ponts copiés-collés)** — breadcrumbs multi-parents redondants :
- `Z3/README.md` : `Index SMT | Index SymbolicAI | Index général` (3 niveaux vers le haut) → `[← SMT] | [Z3-Python (sœur) →]` (1 parent + 1 sibling). Ajoute le lien sibling manquant (Z3-Python pointait vers Z3 mais pas l'inverse — asymétrie corrigée).
- `Z3-Python/README.md` : même collapse `Index SMT | Index SymbolicAI | … | Index général` → `[← SMT] | [Z3 C# →]`.
- `SMT/README.md` (parent) : `Index SymbolicAI | Index général` → `[← Intelligence Symbolique] | [Z3 →] | [Z3-Python →]`. Le parent gagne des down-links vers ses enfants (le pattern ML/README harmonisé), au lieu d'être up-only.

**Anti-pattern 1 (décompte avant le pourquoi)** — ouvertures count-led :
- `Z3/README.md` + `Z3-Python/README.md` : la section « Série en quelques mots » ouvrait sur un strip de métadonnées (`**7 notebooks** | **1 kernel** | ~5h10 | …`). Remplacé par une phrase-concept qui mène avec le paradigme (LINQ→SMT / API z3-py complète), le décompte étant replié dans la prose. Cohérent avec le fix Infer/README (#3162).

## Note §E (honnête)

5 insertions / 5 deletions = **sous le plancher §E <20 lignes** pour une PR docs standalone. Plaidéie : bundle **cohérent d'une seule sous-série** (SMT/Z3, 3 fichiers) corrigeant **2 anti-patterns nommés** du gabarit — précédent #3151 (bundle sous-série Lean de 23 lignes mergé). Si ai-01 juge le §E bloquant, je peux (a) fusionner avec d'autre dette nav résiduelle, ou (b) laisser po-2024 l'absorber si sa passe SymbolicAI descend dans SMT/. Décision laissée au reviewer — les workers ne mergent pas eux-mêmes.

Markdownlint MD060/MD036 warnings : pré-existants (tables compactes du repo), non causés par ces edits (seules lignes nav + prose touchées).

See #2651
