### PR TITLE
feat(sl-4): resolve Exercice 1 (sibling) into guided example + add offspring exercise

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
@@ -1887,33 +1887,138 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Exercice a completer : regle sibling\n",
-      "Etape 1 : identifiez les freres/soeurs dans la famille\n",
-      "Etape 2 : definissez les positifs (siblings) et negatifs (non-siblings)\n",
-      "Etape 3 : quels litteraux candidats sont necessaires ?\n",
-      "Indice : la regle attendue est sibling(X,Y) :- parent(Z,X), parent(Z,Y), X\\=Y\n"
+      "Apprentissage de sibling(x, y) -- trace pas-a-pas FOIL\n",
+      "==========================================================\n",
+      "\n",
+      "Body : parent(z, x)\n",
+      "  couvre 2 positif(s) : [('Bob', 'Catherine'), ('Catherine', 'Bob')]\n",
+      "  couvre 10 negatif(s) : [('Bob', 'Arthur'), ('Bob', 'Bob'), ('Bob', 'Diana'), ('Catherine', 'Eve'), ('Diana', 'Bob'), ('Diana', 'Eve'), ('Diana', 'Frank'), ('Eve', 'Catherine'), ('Eve', 'Diana'), ('Frank', 'Diana')]\n",
+      "\n",
+      "Body : parent(z, x), parent(z, y)\n",
+      "  couvre 2 positif(s) : [('Bob', 'Catherine'), ('Catherine', 'Bob')]\n",
+      "  couvre 1 negatif(s) : [('Bob', 'Bob')]\n",
+      "  gain FOIL vs body precedent : 2.971\n",
+      "\n",
+      "Body : parent(z, x), parent(z, y), neq(x, y)\n",
+      "  couvre 2 positif(s) : [('Bob', 'Catherine'), ('Catherine', 'Bob')]\n",
+      "  couvre 0 negatif(s) : []\n",
+      "  gain FOIL vs body precedent : 0.644\n",
+      "\n",
+      "==========================================================\n",
+      "Regle apprise : sibling(x, y) :- parent(z, x), parent(z, y), neq(x, y).\n",
+      "\n",
+      "Verification : 2 positif(s) couvert(s), 0 negatif(s) couvert(s)\n",
+      "OK : la regle couvre exactement les siblings, sans faux positif.\n",
+      "\n",
+      "Lecture : deux personnes sont siblings ssi elles partagent un parent\n",
+      "ET sont distinctes -- neq(x, y) est indispensable pour exclure (Bob, Bob).\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 : Apprendre la regle \"sibling\" avec FOIL\n",
-    "# TODO etudiant : Definissez le background, les positifs et les negatifs\n",
-    "# pour apprendre la regle sibling(X, Y) :- parent(Z, X), parent(Z, Y), X != Y.\n",
-    "# Indice : utilisez la meme famille que ci-dessus\n",
-    "# Etape 1 : definissez les faits sibling positifs et negatifs\n",
-    "# Etape 2 : proposez des litteraux candidats\n",
-    "# Etape 3 : executez FOIL pas-a-pas\n",
-    "\n",
-    "# Background supplementaire pour l'inegalite\n",
-    "print(\"Exercice a completer : regle sibling\")\n",
-    "print(\"Etape 1 : identifiez les freres/soeurs dans la famille\")\n",
-    "print(\"Etape 2 : definissez les positifs (siblings) et negatifs (non-siblings)\")\n",
-    "print(\"Etape 3 : quels litteraux candidats sont necessaires ?\")\n",
-    "print(\"Indice : la regle attendue est sibling(X,Y) :- parent(Z,X), parent(Z,Y), X\\\\=Y\")"
+    "# Exemple guide : Apprendre la regle \"sibling\" avec FOIL\n",
+    "# Objectif : retrouver sibling(x, y) :- parent(z, x), parent(z, y), neq(x, y).\n",
+    "# Etape 1 : background + inegalite. FOIL n'a pas de predicat builtin \"\\=\" :\n",
+    "# on l'encode comme fait neq/2 dans le background.\n",
+    "SIB_BG = set(BACKGROUND)\n",
+    "for a in CONSTANTS:\n",
+    "    for b in CONSTANTS:\n",
+    "        if a != b:\n",
+    "            SIB_BG.add((\"neq\", (a, b)))\n",
+    "# Etape 2 : exemples. Deux personnes sont siblings ssi elles partagent un\n",
+    "# parent direct et sont distinctes. Dans la famille ci-dessus, seuls Bob et\n",
+    "# Catherine ont un parent commun (Arthur).\n",
+    "SIB_POS = {(\"Bob\", \"Catherine\"), (\"Catherine\", \"Bob\")}\n",
+    "SIB_NEG = {\n",
+    "    (\"Bob\", \"Diana\"), (\"Diana\", \"Bob\"),\n",
+    "    (\"Catherine\", \"Eve\"), (\"Eve\", \"Catherine\"),\n",
+    "    (\"Diana\", \"Frank\"), (\"Frank\", \"Diana\"),\n",
+    "    (\"Arthur\", \"Bob\"), (\"Bob\", \"Arthur\"),\n",
+    "    (\"Bob\", \"Bob\"),\n",
+    "    (\"Diana\", \"Eve\"), (\"Eve\", \"Diana\"),\n",
+    "}\n",
+    "# Etape 3 : litteraux candidats et selection par gain FOIL.\n",
+    "target_args = (\"x\", \"y\")\n",
+    "candidats = [\n",
+    "    [Literal(\"parent\", (\"z\", \"x\"))],\n",
+    "    [Literal(\"parent\", (\"z\", \"x\")), Literal(\"parent\", (\"z\", \"y\"))],\n",
+    "    [Literal(\"parent\", (\"z\", \"x\")), Literal(\"parent\", (\"z\", \"y\")), Literal(\"neq\", (\"x\", \"y\"))],\n",
+    "]\n",
+    "print(\"Apprentissage de sibling(x, y) -- trace pas-a-pas FOIL\")\n",
+    "print(\"=\" * 58)\n",
+    "prev_pos, prev_neg = None, None\n",
+    "for body in candidats:\n",
+    "    cp, cn = check_clause_covers(body, \"sibling\", target_args, CONSTANTS, SIB_BG, SIB_POS, SIB_NEG)\n",
+    "    cp_set, cn_set = set(cp), set(cn)\n",
+    "    print(f\"\\nBody : {', '.join(str(l) for l in body)}\")\n",
+    "    print(f\"  couvre {len(cp_set)} positif(s) : {sorted(cp_set)}\")\n",
+    "    print(f\"  couvre {len(cn_set)} negatif(s) : {sorted(cn_set)}\")\n",
+    "    if prev_pos is not None:\n",
+    "        g = foil_gain(prev_pos, prev_neg, len(cp_set), len(cp_set) + len(cn_set))\n",
+    "        print(f\"  gain FOIL vs body precedent : {g:.3f}\")\n",
+    "    prev_pos, prev_neg = len(cp_set), len(cp_set) + len(cn_set)\n",
+    "regle_sibling = HornClause(\n",
+    "    Literal(\"sibling\", (\"x\", \"y\")),\n",
+    "    [Literal(\"parent\", (\"z\", \"x\")), Literal(\"parent\", (\"z\", \"y\")), Literal(\"neq\", (\"x\", \"y\"))],\n",
+    ")\n",
+    "print(\"\\n\" + \"=\" * 58)\n",
+    "print(f\"Regle apprise : {regle_sibling}\")\n",
+    "final_pos, final_neg = check_clause_covers(\n",
+    "    regle_sibling.body, \"sibling\", target_args, CONSTANTS, SIB_BG, SIB_POS, SIB_NEG)\n",
+    "final_pos_set, final_neg_set = set(final_pos), set(final_neg)\n",
+    "print(f\"\\nVerification : {len(final_pos_set)} positif(s) couvert(s), \"\n",
+    "      f\"{len(final_neg_set)} negatif(s) couvert(s)\")\n",
+    "assert final_pos_set == SIB_POS, f\"Couverture positive incorrecte : {final_pos_set}\"\n",
+    "assert final_neg_set == set(), f\"La regle couvre un negatif : {final_neg_set}\"\n",
+    "print(\"OK : la regle couvre exactement les siblings, sans faux positif.\")\n",
+    "print(\"\\nLecture : deux personnes sont siblings ssi elles partagent un parent\")\n",
+    "print(\"ET sont distinctes -- neq(x, y) est indispensable pour exclure (Bob, Bob).\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f46235a0",
+   "metadata": {},
+   "source": [
+    "### A votre tour : la regle \"offspring\" (inverse de parent) avec FOIL\n",
+    "\n",
+    "Appliquez FOIL a la relation **offspring** (x est l'enfant de y) : c'est\n",
+    "l'inverse exact de `parent`. Cet exercice consolide le fonctionnement de FOIL\n",
+    "avant le passage aux operateurs bottom-up (W) dans la section suivante."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c5ead040",
+   "metadata": {},
+   "source": [
+    "# Exercice : Apprendre la regle \"offspring\" (x enfant de y) avec FOIL\n",
+    "# TODO etudiant : apprenez offspring(x, y) :- parent(y, x).\n",
+    "# Indice : un seul litteral suffit dans le body (l'inverse de parent).\n",
+    "# Etape 1 : definissez les positifs (couples (enfant, parent)) et negatifs\n",
+    "# Etape 2 : quel litteral candidat couvre exactement les positifs sans negatif ?\n",
+    "# Etape 3 : executez FOIL avec check_clause_covers et verifiez la couverture\n",
+    "print(\"Exercice a completer : regle offspring (inverse de parent)\")\n",
+    "print(\"Etape 1 : listez les couples (enfant, parent) de la famille\")\n",
+    "print(\"Etape 2 : proposez le body a un seul litteral\")\n",
+    "print(\"Etape 3 : verifiez que la couverture est exacte (0 negatif)\")"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : regle offspring (inverse de parent)\n",
+      "Etape 1 : listez les couples (enfant, parent) de la famille\n",
+      "Etape 2 : proposez le body a un seul litteral\n",
+      "Etape 3 : verifiez que la couverture est exacte (0 negatif)\n"
+     ]
+    }
+   ],
+   "execution_count": 13
   },
   {
    "cell_type": "markdown",
@@ -1934,7 +2039,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "498d3825",
    "metadata": {
     "execution": {
@@ -1998,7 +2103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "fa814830",
    "metadata": {
     "execution": {
@@ -2085,7 +2190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "972eb4bf",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

Part of the SymbolicLearning exercise-resolution pass (SL-1..SL-10 -> Exemples guidés, 1 PR/exercise). This PR resolves **SL-4 Exercice 1 (sibling / FOIL)** and adds a fresh exercise to keep the exercise count.

### Changes
- **Cell `4e6e75a6` (Exercice 1 -> Exemple guide):** the sibling FOIL stub is replaced by a worked example. It runs FOIL step-by-step on the Arthur family, building the clause body `parent(z,x)` -> `parent(z,x), parent(z,y)` -> `parent(z,x), parent(z,y), neq(x,y)`. The trace makes the **language-bias** point explicit: without `neq(x,y)` the clause admits the `(Bob,Bob)` self-pair; with it, coverage is exactly `{(Bob,Catherine),(Catherine,Bob)}`, 0 negatives. This directly demonstrates the defi-presentation question-twist for Ex.1 ("FOIL trouve-t-il `X != Y` tout seul ?").
- **New markdown + code cells (`offspring`):** a fresh FOIL exercise (`offspring(x,y) :- parent(y,x)`, single-literal body) inserted right after the example, before the W-operator transition, so the notebook keeps its exercise count and the narrative ("au lieu d'utiliser FOIL... operateur W") still flows.

## Proof of execution (rule C.2 / D)

The changed cells are **pure-Python FOIL** (no Popper dependency). They were re-executed via a real `python3` kernel (`jupyter_client`), capturing genuine stream outputs:

```
Body : parent(z, x)                                  -> 2 pos, 10 neg
Body : parent(z, x), parent(z, y)                    -> 2 pos,  1 neg [(Bob,Bob)]   gain 2.971
Body : parent(z, x), parent(z, y), neq(x, y)         -> 2 pos,  0 neg               gain 0.644
OK : la regle couvre exactement les siblings, sans faux positif.
```

- `grep -nE "raise NotImplementedError|assert False|1/0"` on the notebook: the only `assert` is inside the worked example (`assert final_pos_set == SIB_POS` / `assert final_neg_set == set()`) — both pass at runtime, no voluntary failure.
- `execution_count`: flows 1..16 sequentially, no gaps/duplicates (the offspring insertion shifts Ex.2/3/4 from 13/14/15 to 14/15/16).
- `nbformat.validate`: PASS.
- No `# Solution` / `# Exemple résolu` cell was deleted (anti-regression). The previous sibling stub was an exercise stub, now upgraded to a worked example; a new stub was added.

### Why targeted re-execution instead of full Papermill
The notebook's Popper section requires `swi-prolog` in the WSL `python3-wsl` env. **swipl is currently missing** in WSL (`dpkg -l | grep swi-prolog` -> 0 packages; `which swipl` -> nothing) and `janus_swi` cannot build without it; installing needs `sudo` (user action, rule F). The committed Popper outputs are still valid (produced in a prior run when swipl was installed) and are **left untouched** — only the changed cells were re-executed. This is C.2/C.3-compliant: changed code cells get fresh real outputs; unchanged cells keep valid outputs; only changed cells' outputs were touched.

## Env blocker (for ai-01 / user)
- **`swi-prolog` missing in WSL** — needed to faithfully full-papermill SL-4 (and any SL notebook using Popper). Repair: `sudo add-apt-repository ppa:swi-prolog/stable && sudo apt update && sudo apt install -y swi-prolog`, then the notebook's self-install cell rebuilds `janus_swi` + `popper`. Needs sudo password.

## Catalogue
Byte-identical to `main` (no regeneration on this branch).

Co-Authored-By: Claude <noreply@anthropic.com>
