### PR TITLE
feat(sl8): resolve Ex4 (noisy membership oracle) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "sl8-01",
    "metadata": {
     "papermill": {
-     "duration": 0.003727,
-     "end_time": "2026-06-17T01:33:26.170226+00:00",
+     "duration": 0.004381,
+     "end_time": "2026-06-17T01:49:29.525969+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.166499+00:00",
+     "start_time": "2026-06-17T01:49:29.521588+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "sl8-02",
    "metadata": {
     "papermill": {
-     "duration": 0.002869,
-     "end_time": "2026-06-17T01:33:26.176260+00:00",
+     "duration": 0.003306,
+     "end_time": "2026-06-17T01:49:29.533129+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.173391+00:00",
+     "start_time": "2026-06-17T01:49:29.529823+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,16 +89,16 @@
    "id": "sl8-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.183506Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.183315Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.191775Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.191184Z"
+     "iopub.execute_input": "2026-06-17T01:49:29.541768Z",
+     "iopub.status.busy": "2026-06-17T01:49:29.541544Z",
+     "iopub.status.idle": "2026-06-17T01:49:29.551198Z",
+     "shell.execute_reply": "2026-06-17T01:49:29.550452Z"
     },
     "papermill": {
-     "duration": 0.013478,
-     "end_time": "2026-06-17T01:33:26.192620+00:00",
+     "duration": 0.015322,
+     "end_time": "2026-06-17T01:49:29.551865+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.179142+00:00",
+     "start_time": "2026-06-17T01:49:29.536543+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,10 +178,10 @@
    "id": "sl8-04",
    "metadata": {
     "papermill": {
-     "duration": 0.003217,
-     "end_time": "2026-06-17T01:33:26.199383+00:00",
+     "duration": 0.003715,
+     "end_time": "2026-06-17T01:49:29.561762+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.196166+00:00",
+     "start_time": "2026-06-17T01:49:29.558047+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,10 +206,10 @@
    "id": "sl8-05",
    "metadata": {
     "papermill": {
-     "duration": 0.002951,
-     "end_time": "2026-06-17T01:33:26.205371+00:00",
+     "duration": 0.00363,
+     "end_time": "2026-06-17T01:49:29.568919+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.202420+00:00",
+     "start_time": "2026-06-17T01:49:29.565289+00:00",
      "status": "completed"
     },
     "tags": []
@@ -247,16 +247,16 @@
    "id": "sl8-06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.212392Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.212222Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.219669Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.219061Z"
+     "iopub.execute_input": "2026-06-17T01:49:29.577536Z",
+     "iopub.status.busy": "2026-06-17T01:49:29.577321Z",
+     "iopub.status.idle": "2026-06-17T01:49:29.585506Z",
+     "shell.execute_reply": "2026-06-17T01:49:29.584967Z"
     },
     "papermill": {
-     "duration": 0.011782,
-     "end_time": "2026-06-17T01:33:26.220130+00:00",
+     "duration": 0.01344,
+     "end_time": "2026-06-17T01:49:29.586043+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.208348+00:00",
+     "start_time": "2026-06-17T01:49:29.572603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "sl8-07",
    "metadata": {
     "papermill": {
-     "duration": 0.003119,
-     "end_time": "2026-06-17T01:33:26.226336+00:00",
+     "duration": 0.003609,
+     "end_time": "2026-06-17T01:49:29.593281+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.223217+00:00",
+     "start_time": "2026-06-17T01:49:29.589672+00:00",
      "status": "completed"
     },
     "tags": []
@@ -385,10 +385,10 @@
    "id": "sl8-08",
    "metadata": {
     "papermill": {
-     "duration": 0.003994,
-     "end_time": "2026-06-17T01:33:26.233434+00:00",
+     "duration": 0.003532,
+     "end_time": "2026-06-17T01:49:29.600286+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.229440+00:00",
+     "start_time": "2026-06-17T01:49:29.596754+00:00",
      "status": "completed"
     },
     "tags": []
@@ -423,16 +423,16 @@
    "id": "sl8-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.241564Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.241229Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.247609Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.247134Z"
+     "iopub.execute_input": "2026-06-17T01:49:29.608599Z",
+     "iopub.status.busy": "2026-06-17T01:49:29.608396Z",
+     "iopub.status.idle": "2026-06-17T01:49:29.614814Z",
+     "shell.execute_reply": "2026-06-17T01:49:29.614121Z"
     },
     "papermill": {
-     "duration": 0.011232,
-     "end_time": "2026-06-17T01:33:26.248223+00:00",
+     "duration": 0.01131,
+     "end_time": "2026-06-17T01:49:29.615319+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.236991+00:00",
+     "start_time": "2026-06-17T01:49:29.604009+00:00",
      "status": "completed"
     },
     "tags": []
@@ -526,10 +526,10 @@
    "id": "sl8-10",
    "metadata": {
     "papermill": {
-     "duration": 0.003422,
-     "end_time": "2026-06-17T01:33:26.254983+00:00",
+     "duration": 0.003699,
+     "end_time": "2026-06-17T01:49:29.622752+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.251561+00:00",
+     "start_time": "2026-06-17T01:49:29.619053+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,16 +550,16 @@
    "id": "sl8-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.263104Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.262887Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.271721Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.270998Z"
+     "iopub.execute_input": "2026-06-17T01:49:29.631848Z",
+     "iopub.status.busy": "2026-06-17T01:49:29.631644Z",
+     "iopub.status.idle": "2026-06-17T01:49:29.641105Z",
+     "shell.execute_reply": "2026-06-17T01:49:29.640225Z"
     },
     "papermill": {
-     "duration": 0.013883,
-     "end_time": "2026-06-17T01:33:26.272246+00:00",
+     "duration": 0.015358,
+     "end_time": "2026-06-17T01:49:29.641975+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.258363+00:00",
+     "start_time": "2026-06-17T01:49:29.626617+00:00",
      "status": "completed"
     },
     "tags": []
@@ -626,10 +626,10 @@
    "id": "sl8-12",
    "metadata": {
     "papermill": {
-     "duration": 0.003569,
-     "end_time": "2026-06-17T01:33:26.279591+00:00",
+     "duration": 0.004117,
+     "end_time": "2026-06-17T01:49:29.650761+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.276022+00:00",
+     "start_time": "2026-06-17T01:49:29.646644+00:00",
      "status": "completed"
     },
     "tags": []
@@ -659,10 +659,10 @@
    "id": "sl8-13",
    "metadata": {
     "papermill": {
-     "duration": 0.004285,
-     "end_time": "2026-06-17T01:33:26.287428+00:00",
+     "duration": 0.003794,
+     "end_time": "2026-06-17T01:49:29.658487+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.283143+00:00",
+     "start_time": "2026-06-17T01:49:29.654693+00:00",
      "status": "completed"
     },
     "tags": []
@@ -697,16 +697,16 @@
    "id": "sl8-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.295819Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.295477Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.302811Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.302226Z"
+     "iopub.execute_input": "2026-06-17T01:49:29.667886Z",
+     "iopub.status.busy": "2026-06-17T01:49:29.667674Z",
+     "iopub.status.idle": "2026-06-17T01:49:29.674692Z",
+     "shell.execute_reply": "2026-06-17T01:49:29.674123Z"
     },
     "papermill": {
-     "duration": 0.012824,
-     "end_time": "2026-06-17T01:33:26.303549+00:00",
+     "duration": 0.012334,
+     "end_time": "2026-06-17T01:49:29.675309+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.290725+00:00",
+     "start_time": "2026-06-17T01:49:29.662975+00:00",
      "status": "completed"
     },
     "tags": []
@@ -770,10 +770,10 @@
    "id": "sl8-15",
    "metadata": {
     "papermill": {
-     "duration": 0.003595,
-     "end_time": "2026-06-17T01:33:26.311078+00:00",
+     "duration": 0.003837,
+     "end_time": "2026-06-17T01:49:29.683235+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.307483+00:00",
+     "start_time": "2026-06-17T01:49:29.679398+00:00",
      "status": "completed"
     },
     "tags": []
@@ -798,10 +798,10 @@
    "id": "sl8-16",
    "metadata": {
     "papermill": {
-     "duration": 0.003365,
-     "end_time": "2026-06-17T01:33:26.317880+00:00",
+     "duration": 0.003694,
+     "end_time": "2026-06-17T01:49:29.690743+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.314515+00:00",
+     "start_time": "2026-06-17T01:49:29.687049+00:00",
      "status": "completed"
     },
     "tags": []
@@ -832,16 +832,16 @@
    "id": "sl8-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.325453Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.325274Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.350453Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.349814Z"
+     "iopub.execute_input": "2026-06-17T01:49:29.699931Z",
+     "iopub.status.busy": "2026-06-17T01:49:29.699728Z",
+     "iopub.status.idle": "2026-06-17T01:49:29.724733Z",
+     "shell.execute_reply": "2026-06-17T01:49:29.723810Z"
     },
     "papermill": {
-     "duration": 0.029804,
-     "end_time": "2026-06-17T01:33:26.350953+00:00",
+     "duration": 0.03054,
+     "end_time": "2026-06-17T01:49:29.725366+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.321149+00:00",
+     "start_time": "2026-06-17T01:49:29.694826+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,10 +922,10 @@
    "id": "sl8-18",
    "metadata": {
     "papermill": {
-     "duration": 0.003912,
-     "end_time": "2026-06-17T01:33:26.358798+00:00",
+     "duration": 0.004828,
+     "end_time": "2026-06-17T01:49:29.734230+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.354886+00:00",
+     "start_time": "2026-06-17T01:49:29.729402+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,10 +960,10 @@
    "id": "sl8-19",
    "metadata": {
     "papermill": {
-     "duration": 0.003438,
-     "end_time": "2026-06-17T01:33:26.365748+00:00",
+     "duration": 0.004209,
+     "end_time": "2026-06-17T01:49:29.742556+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.362310+00:00",
+     "start_time": "2026-06-17T01:49:29.738347+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1000,10 +1000,10 @@
    "id": "sl8-20",
    "metadata": {
     "papermill": {
-     "duration": 0.003911,
-     "end_time": "2026-06-17T01:33:26.372927+00:00",
+     "duration": 0.003882,
+     "end_time": "2026-06-17T01:49:29.750162+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.369016+00:00",
+     "start_time": "2026-06-17T01:49:29.746280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,16 +1031,16 @@
    "id": "sl8-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.381438Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.381260Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.395839Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.395151Z"
+     "iopub.execute_input": "2026-06-17T01:49:29.759641Z",
+     "iopub.status.busy": "2026-06-17T01:49:29.759426Z",
+     "iopub.status.idle": "2026-06-17T01:49:29.776515Z",
+     "shell.execute_reply": "2026-06-17T01:49:29.775701Z"
     },
     "papermill": {
-     "duration": 0.020021,
-     "end_time": "2026-06-17T01:33:26.396492+00:00",
+     "duration": 0.023093,
+     "end_time": "2026-06-17T01:49:29.777252+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.376471+00:00",
+     "start_time": "2026-06-17T01:49:29.754159+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1122,10 +1122,10 @@
    "id": "sl8ex1var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003874,
-     "end_time": "2026-06-17T01:33:26.404574+00:00",
+     "duration": 0.006037,
+     "end_time": "2026-06-17T01:49:29.787756+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.400700+00:00",
+     "start_time": "2026-06-17T01:49:29.781719+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1149,16 +1149,16 @@
    "id": "sl8ex1var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.412422Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.412231Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.415848Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.415287Z"
+     "iopub.execute_input": "2026-06-17T01:49:29.798597Z",
+     "iopub.status.busy": "2026-06-17T01:49:29.798386Z",
+     "iopub.status.idle": "2026-06-17T01:49:29.802515Z",
+     "shell.execute_reply": "2026-06-17T01:49:29.801837Z"
     },
     "papermill": {
-     "duration": 0.008467,
-     "end_time": "2026-06-17T01:33:26.416310+00:00",
+     "duration": 0.01012,
+     "end_time": "2026-06-17T01:49:29.803135+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.407843+00:00",
+     "start_time": "2026-06-17T01:49:29.793015+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1208,10 +1208,10 @@
    "id": "sl8-22",
    "metadata": {
     "papermill": {
-     "duration": 0.003708,
-     "end_time": "2026-06-17T01:33:26.423588+00:00",
+     "duration": 0.003985,
+     "end_time": "2026-06-17T01:49:29.811508+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.419880+00:00",
+     "start_time": "2026-06-17T01:49:29.807523+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1228,16 +1228,16 @@
    "id": "sl8-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.432078Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.431826Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.754850Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.754189Z"
+     "iopub.execute_input": "2026-06-17T01:49:29.821112Z",
+     "iopub.status.busy": "2026-06-17T01:49:29.820898Z",
+     "iopub.status.idle": "2026-06-17T01:49:30.178754Z",
+     "shell.execute_reply": "2026-06-17T01:49:30.177910Z"
     },
     "papermill": {
-     "duration": 0.328166,
-     "end_time": "2026-06-17T01:33:26.755401+00:00",
+     "duration": 0.363927,
+     "end_time": "2026-06-17T01:49:30.179502+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.427235+00:00",
+     "start_time": "2026-06-17T01:49:29.815575+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1251,14 +1251,14 @@
       "================================================================\n",
       " n_samples |  NEEDLE (desaccords rares) |  TARGET parites (denses)\n",
       "----------------------------------------------------------------\n",
-      "         1 |                        0% |                     50%\n"
+      "         1 |                        0% |                     50%\n",
+      "        10 |                       10% |                    100%\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "        10 |                       10% |                    100%\n",
       "        50 |                       60% |                    100%\n"
      ]
     },
@@ -1266,7 +1266,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "       100 |                      100% |                    100%\n"
+      "       100 |                      100% |                    100%"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
@@ -1333,10 +1340,10 @@
    "id": "sl8ex2var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003645,
-     "end_time": "2026-06-17T01:33:26.762998+00:00",
+     "duration": 0.004154,
+     "end_time": "2026-06-17T01:49:30.188108+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.759353+00:00",
+     "start_time": "2026-06-17T01:49:30.183954+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1359,16 +1366,16 @@
    "id": "sl8ex2var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.770843Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.770681Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.773797Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.773252Z"
+     "iopub.execute_input": "2026-06-17T01:49:30.197688Z",
+     "iopub.status.busy": "2026-06-17T01:49:30.197478Z",
+     "iopub.status.idle": "2026-06-17T01:49:30.201350Z",
+     "shell.execute_reply": "2026-06-17T01:49:30.200772Z"
     },
     "papermill": {
-     "duration": 0.008013,
-     "end_time": "2026-06-17T01:33:26.774444+00:00",
+     "duration": 0.009376,
+     "end_time": "2026-06-17T01:49:30.201896+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.766431+00:00",
+     "start_time": "2026-06-17T01:49:30.192520+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1421,10 +1428,10 @@
    "id": "sl8-24",
    "metadata": {
     "papermill": {
-     "duration": 0.003489,
-     "end_time": "2026-06-17T01:33:26.781521+00:00",
+     "duration": 0.005647,
+     "end_time": "2026-06-17T01:49:30.211645+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.778032+00:00",
+     "start_time": "2026-06-17T01:49:30.205998+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1441,16 +1448,16 @@
    "id": "sl8-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.792072Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.791873Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.799689Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.799140Z"
+     "iopub.execute_input": "2026-06-17T01:49:30.220743Z",
+     "iopub.status.busy": "2026-06-17T01:49:30.220551Z",
+     "iopub.status.idle": "2026-06-17T01:49:30.229584Z",
+     "shell.execute_reply": "2026-06-17T01:49:30.228881Z"
     },
     "papermill": {
-     "duration": 0.014723,
-     "end_time": "2026-06-17T01:33:26.800122+00:00",
+     "duration": 0.014729,
+     "end_time": "2026-06-17T01:49:30.230221+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.785399+00:00",
+     "start_time": "2026-06-17T01:49:30.215492+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1577,10 +1584,10 @@
    "id": "sl8ex3var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003651,
-     "end_time": "2026-06-17T01:33:26.807425+00:00",
+     "duration": 0.004909,
+     "end_time": "2026-06-17T01:49:30.239683+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.803774+00:00",
+     "start_time": "2026-06-17T01:49:30.234774+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1603,16 +1610,16 @@
    "id": "sl8ex3var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.815227Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.815021Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.818298Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.817732Z"
+     "iopub.execute_input": "2026-06-17T01:49:30.250225Z",
+     "iopub.status.busy": "2026-06-17T01:49:30.250007Z",
+     "iopub.status.idle": "2026-06-17T01:49:30.253555Z",
+     "shell.execute_reply": "2026-06-17T01:49:30.252954Z"
     },
     "papermill": {
-     "duration": 0.007996,
-     "end_time": "2026-06-17T01:33:26.818834+00:00",
+     "duration": 0.009633,
+     "end_time": "2026-06-17T01:49:30.254175+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.810838+00:00",
+     "start_time": "2026-06-17T01:49:30.244542+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1664,10 +1671,10 @@
    "id": "sl8-26",
    "metadata": {
     "papermill": {
-     "duration": 0.003443,
-     "end_time": "2026-06-17T01:33:26.825860+00:00",
+     "duration": 0.004806,
+     "end_time": "2026-06-17T01:49:30.263805+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.822417+00:00",
+     "start_time": "2026-06-17T01:49:30.258999+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1683,16 +1690,16 @@
    "id": "sl8-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:33:26.833709Z",
-     "iopub.status.busy": "2026-06-17T01:33:26.833574Z",
-     "iopub.status.idle": "2026-06-17T01:33:26.837093Z",
-     "shell.execute_reply": "2026-06-17T01:33:26.836126Z"
+     "iopub.execute_input": "2026-06-17T01:49:30.274432Z",
+     "iopub.status.busy": "2026-06-17T01:49:30.274232Z",
+     "iopub.status.idle": "2026-06-17T01:49:30.832773Z",
+     "shell.execute_reply": "2026-06-17T01:49:30.832064Z"
     },
     "papermill": {
-     "duration": 0.008195,
-     "end_time": "2026-06-17T01:33:26.837579+00:00",
+     "duration": 0.564829,
+     "end_time": "2026-06-17T01:49:30.833319+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.829384+00:00",
+     "start_time": "2026-06-17T01:49:30.268490+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1702,24 +1709,233 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Oracle d'appartenance bruite : comportement de L* (cible TARGET = 4 etats)\n",
+      "==================================================================\n",
+      "p=0.05 :  4 etats | max_rounds |  2 EQ | EXACT vs TARGET\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "p=0.01 : 50 etats | max_rounds |  3 EQ | ecart (contre-ex 'bbbabbbab')\n",
+      "p=0.20 :  4 etats | max_rounds |  2 EQ | EXACT vs TARGET\n",
+      "\n",
+      "Lecture : le resultat n'est PAS monotone en p -- il depend de QUELS mots\n",
+      "l'oracle ment, pas seulement de combien. Ici le cas le moins bruite\n",
+      "(p=0.01) a ete le plus catastrophique : quelques mensonges mal places\n",
+      "creent une explosion d'etats (autant de distinctions de Myhill-Nerode\n",
+      "FANTOMES, memorisees dans T), alors que p=0.05 et p=0.20 retombent par\n",
+      "chance sur la cible de 4 etats. Avec une autre graine, l'issue serait\n",
+      "differente. Lecon centrale : un apprenant EXACT comme L* n'a AUCUNE\n",
+      "degradation gracieuse face au bruit -- son comportement est path-dependent\n",
+      "(un seul mensonge peut tout casser), la ou un classifieur statistique se\n",
+      "degrade SMOOTHMENT avec p (loi des grands nombres).\n",
+      "\n",
+      "Reponse a la question : pourquoi UNE seule reponse fausse cree-t-elle un\n",
+      "etat fantome permanent ? L* memorise dans T la (fausse) valeur du mot et\n",
+      "la traite comme une VERITE de Myhill-Nerode. Cette distinction persiste\n",
+      "dans toutes les conjectures suivantes -- le filet statistique (moyenner\n",
+      "plusieurs tirages) n'existe pas. Un mensonge est pour L* une constante,\n",
+      "pas un bruit : c'est le prix de sa garantie d'exactitude.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 4 : Oracle d'appartenance bruite\n",
-    "# TODO etudiant : enveloppez membership_query dans un oracle qui MENT avec\n",
-    "# probabilite p = 0.05 (graine fixee), et observez le comportement de L*.\n",
-    "# Indice : copiez lstar() en ajoutant un parametre max_rounds (ex. 15) pour\n",
-    "#          eviter une boucle infinie ; le mensonge doit etre DETERMINISTE par mot\n",
-    "#          (memoisez la premiere reponse, sinon la table T cache deja pour vous).\n",
-    "# Etape 1 : noisy_mq avec random.Random(0), p=0.05\n",
-    "# Etape 2 : lancez L* (borne) : la table se stabilise-t-elle ? combien d'etats ?\n",
-    "# Etape 3 : relancez avec p=0.01 et p=0.20 : que devient le DFA appris ?\n",
-    "# Question : pourquoi UNE seule reponse fausse peut-elle creer un etat fantome\n",
-    "# permanent, alors qu'un bruit de 5% est anodin pour un classifieur statistique ?\n",
+    "# Exemple guide 4 : Oracle d'appartenance bruite\n",
+    "#\n",
+    "# On enveloppe membership_query dans un oracle qui MENT avec probabilite p,\n",
+    "# de facon DETERMINISTE par mot (la premiere reponse est memoisee -- sinon la\n",
+    "# table T cacherait deja les mensonges pour nous). On borne L* (max_rounds)\n",
+    "# car un oracle bruite peut rendre la fonction d'appartenance non reguliere\n",
+    "# (donc la stabilisation de la table peut ne jamais converger).\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "\n",
+    "def make_noisy_mq(true_mq, p=0.05, seed=0):\n",
+    "    \"\"\"Oracle d'appartenance qui ment avec probabilite p, deterministe par mot.\"\"\"\n",
+    "    rng = random.Random(seed)\n",
+    "    cache = {}\n",
+    "\n",
+    "    def noisy_mq(word):\n",
+    "        if word not in cache:\n",
+    "            truth = true_mq(word)\n",
+    "            lie = rng.random() < p\n",
+    "            cache[word] = (not truth) if lie else truth\n",
+    "        return cache[word]\n",
+    "\n",
+    "    return noisy_mq\n",
+    "\n",
+    "\n",
+    "def lstar_bounded(alphabet, mq, eq, max_rounds=8, max_steps=60):\n",
+    "    \"\"\"L* borne. Evite la boucle infinie si mq est inconsistant (oracle bruite).\n",
+    "\n",
+    "    On ne conjecture QUE sur une table fermee ET consistante : un oracle bruite\n",
+    "    peut rendre la fonction non reguliere, auquel cas la stabilisation echoue\n",
+    "    (max_steps) et l'on retourne (None, table, n_eq, False) = non-stabilise.\n",
+    "    \"\"\"\n",
+    "    table = ObservationTable(alphabet, mq)\n",
+    "    n_eq = 0\n",
+    "    hyp = None\n",
+    "    for _round in range(1, max_rounds + 1):\n",
+    "        # Stabiliser la table ; max_steps contre la non-regularite du bruit.\n",
+    "        steps = 0\n",
+    "        while True:\n",
+    "            sa = table.find_unclosed()\n",
+    "            if sa is not None:\n",
+    "                table.S.append(sa)\n",
+    "                table.fill()\n",
+    "            else:\n",
+    "                ae = table.find_inconsistency()\n",
+    "                if ae is not None:\n",
+    "                    table.E.append(ae)\n",
+    "                    table.fill()\n",
+    "                else:\n",
+    "                    break\n",
+    "            steps += 1\n",
+    "            if steps > max_steps:\n",
+    "                break\n",
+    "        # Table non stabilisee -> impossible de conjecturer proprement.\n",
+    "        if table.find_unclosed() is not None or table.find_inconsistency() is not None:\n",
+    "            return hyp, table, n_eq, False   # non-stabilise\n",
+    "        hyp = conjecture(table)\n",
+    "        n_eq += 1\n",
+    "        cex = eq(hyp)\n",
+    "        if cex is None:\n",
+    "            return hyp, table, n_eq, True    # stabilise\n",
+    "        for i in range(1, len(cex) + 1):\n",
+    "            if cex[:i] not in table.S:\n",
+    "                table.S.append(cex[:i])\n",
+    "        table.fill()\n",
+    "    return hyp, table, n_eq, False           # max_rounds atteint\n",
+    "\n",
+    "\n",
+    "# Etape 2 et 3 : L* borne sous oracle bruite, pour p = 0.05 puis 0.01 et 0.20\n",
+    "print(\"Oracle d'appartenance bruite : comportement de L* (cible TARGET = 4 etats)\")\n",
+    "print(\"=\" * 66)\n",
+    "for p in [0.05, 0.01, 0.20]:\n",
+    "    noisy = make_noisy_mq(membership_query, p=p, seed=0)\n",
+    "    eq_noisy = make_sampling_eq(noisy, ALPHABET, 300, seed=1)\n",
+    "    hyp, _tbl, n_eq, stable = lstar_bounded(\n",
+    "        ALPHABET, noisy, eq_noisy, max_rounds=8)\n",
+    "    if hyp is None:\n",
+    "        print(f\"p={p:>4.2f} : NON-STABILISE (aucun DFA coherrent) \"\n",
+    "              f\"apres {n_eq} conjectures\")\n",
+    "        continue\n",
+    "    cex_real = find_counterexample(hyp, TARGET, ALPHABET)\n",
+    "    exact = cex_real is None\n",
+    "    statut = \"stable\" if stable else \"max_rounds\"\n",
+    "    verdict = \"EXACT vs TARGET\" if exact else f\"ecart (contre-ex {cex_real!r})\"\n",
+    "    print(f\"p={p:>4.2f} : {len(hyp.states):>2} etats | {statut:>10s} | \"\n",
+    "          f\"{n_eq:>2} EQ | {verdict}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Lecture : le resultat n'est PAS monotone en p -- il depend de QUELS mots\")\n",
+    "print(\"l'oracle ment, pas seulement de combien. Ici le cas le moins bruite\")\n",
+    "print(\"(p=0.01) a ete le plus catastrophique : quelques mensonges mal places\")\n",
+    "print(\"creent une explosion d'etats (autant de distinctions de Myhill-Nerode\")\n",
+    "print(\"FANTOMES, memorisees dans T), alors que p=0.05 et p=0.20 retombent par\")\n",
+    "print(\"chance sur la cible de 4 etats. Avec une autre graine, l'issue serait\")\n",
+    "print(\"differente. Lecon centrale : un apprenant EXACT comme L* n'a AUCUNE\")\n",
+    "print(\"degradation gracieuse face au bruit -- son comportement est path-dependent\")\n",
+    "print(\"(un seul mensonge peut tout casser), la ou un classifieur statistique se\")\n",
+    "print(\"degrade SMOOTHMENT avec p (loi des grands nombres).\")\n",
+    "print()\n",
+    "print(\"Reponse a la question : pourquoi UNE seule reponse fausse cree-t-elle un\")\n",
+    "print(\"etat fantome permanent ? L* memorise dans T la (fausse) valeur du mot et\")\n",
+    "print(\"la traite comme une VERITE de Myhill-Nerode. Cette distinction persiste\")\n",
+    "print(\"dans toutes les conjectures suivantes -- le filet statistique (moyenner\")\n",
+    "print(\"plusieurs tirages) n'existe pas. Un mensonge est pour L* une constante,\")\n",
+    "print(\"pas un bruit : c'est le prix de sa garantie d'exactitude.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8ex4var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004201,
+     "end_time": "2026-06-17T01:49:30.842453+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:49:30.838252+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 (variation) : Robustesse par vote majoritaire\n",
+    "\n",
+    "Le bruit de l'oracle d'appartenance casse l'hypothese d'exactitude de L*. La parade classique : pour chaque mot, poser la requete `K` fois a l'oracle bruite et garder la **reponse majoritaire** (le vrai verdict ressort des que `K` est grand devant le taux de mensonges). Implementez ce `robust_mq` et montrez qu'il permet a L* de retrouver le DFA exact.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Ecrire `make_robust_mq(noisy_mq, K)` : pour chaque mot, echantillonne `K` reponses bruitees et renvoie la majorite (memoire par mot, comme le bruite)\n",
+    "2. Lancer `lstar_bounded` avec `robust_mq` (K=21) sur un oracle bruite a p=0.05\n",
+    "3. Le DFA appris est-il exact vs `TARGET` ? Quel `K` minimal suffit pour p=0.05 ? pour p=0.20 ?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "sl8ex4var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:49:30.852644Z",
+     "iopub.status.busy": "2026-06-17T01:49:30.852447Z",
+     "iopub.status.idle": "2026-06-17T01:49:30.856903Z",
+     "shell.execute_reply": "2026-06-17T01:49:30.856142Z"
+    },
+    "papermill": {
+     "duration": 0.010783,
+     "end_time": "2026-06-17T01:49:30.857431+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:49:30.846648+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : robustesse par vote majoritaire\n",
+      "Etape 1 : ecrivez make_robust_mq(noisy_mq, K) (vote majoritaire par mot)\n",
+      "Etape 2 : lancez lstar_bounded avec robust_mq (K=21) sur un bruite p=0.05\n",
+      "Etape 3 : le DFA est-il exact vs TARGET ? K minimal pour p=0.05 ? p=0.20 ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 (variation) : robustesse par vote majoritaire\n",
+    "# TODO etudiant : diluez le bruit en posant K fois chaque requete et en\n",
+    "# gardant la reponse majoritaire.\n",
+    "\n",
+    "# Etape 1 : oracle robuste par vote majoritaire\n",
+    "# def make_robust_mq(noisy_mq, K=21):\n",
+    "#     \"\"\"Pour chaque mot, pose K fois la requete bruitee et renvoie la majorite.\"\"\"\n",
+    "#     cache = {}\n",
+    "#     def robust_mq(word):\n",
+    "#         if word not in cache:\n",
+    "#             ...  # TODO etudiant : K appels, majorite (sum(reponses) > K/2)\n",
+    "#         return cache[word]\n",
+    "#     return robust_mq\n",
+    "\n",
+    "# Etape 2 : lancer lstar_bounded avec robust_mq (K=21) sur un bruite p=0.05\n",
+    "# noisy = make_noisy_mq(membership_query, p=0.05, seed=0)\n",
+    "# robust = make_robust_mq(noisy, K=21)\n",
+    "# eq_r = make_sampling_eq(robust, ALPHABET, 1000, seed=1)\n",
+    "# hyp, _, _, _ = lstar_bounded(ALPHABET, robust, eq_r, max_rounds=15)\n",
+    "\n",
+    "# Etape 3 : exactitude vs TARGET + K minimal pour p=0.05 et p=0.20\n",
+    "print(\"Exercice a completer : robustesse par vote majoritaire\")\n",
+    "print(\"Etape 1 : ecrivez make_robust_mq(noisy_mq, K) (vote majoritaire par mot)\")\n",
+    "print(\"Etape 2 : lancez lstar_bounded avec robust_mq (K=21) sur un bruite p=0.05\")\n",
+    "print(\"Etape 3 : le DFA est-il exact vs TARGET ? K minimal pour p=0.05 ? p=0.20 ?\")\n",
+    "\n",
+    "# Indice : le vote majoritaire marche seulement si chaque appel bruite est\n",
+    "# INDEPENDANT. Ici make_noisy_mq memoise par mot -> il faut lever la memoire\n",
+    "# (un oracle bruite NON memoise) pour que K tirages soient independants.\n",
+    "# result = None  # TODO etudiant : le DFA robuste appris\n"
    ]
   },
   {
@@ -1727,10 +1943,10 @@
    "id": "sl8-29",
    "metadata": {
     "papermill": {
-     "duration": 0.003808,
-     "end_time": "2026-06-17T01:33:26.845385+00:00",
+     "duration": 0.004333,
+     "end_time": "2026-06-17T01:49:30.866315+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.841577+00:00",
+     "start_time": "2026-06-17T01:49:30.861982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1787,10 +2003,10 @@
    "id": "sl8-28",
    "metadata": {
     "papermill": {
-     "duration": 0.003715,
-     "end_time": "2026-06-17T01:33:26.852889+00:00",
+     "duration": 0.003871,
+     "end_time": "2026-06-17T01:49:30.874192+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.849174+00:00",
+     "start_time": "2026-06-17T01:49:30.870321+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1818,10 +2034,10 @@
    "id": "sl8-30",
    "metadata": {
     "papermill": {
-     "duration": 0.003476,
-     "end_time": "2026-06-17T01:33:26.859820+00:00",
+     "duration": 0.004038,
+     "end_time": "2026-06-17T01:49:30.882325+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:33:26.856344+00:00",
+     "start_time": "2026-06-17T01:49:30.878287+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1864,14 +2080,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.529194,
-   "end_time": "2026-06-17T01:33:26.996136+00:00",
+   "duration": 3.224076,
+   "end_time": "2026-06-17T01:49:31.011895+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T01:33:24.466942+00:00",
+   "start_time": "2026-06-17T01:49:27.787819+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "sl8-01",
    "metadata": {
     "papermill": {
-     "duration": 0.003984,
-     "end_time": "2026-06-17T01:28:32.733757+00:00",
+     "duration": 0.003727,
+     "end_time": "2026-06-17T01:33:26.170226+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.729773+00:00",
+     "start_time": "2026-06-17T01:33:26.166499+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "sl8-02",
    "metadata": {
     "papermill": {
-     "duration": 0.0032,
-     "end_time": "2026-06-17T01:28:32.740610+00:00",
+     "duration": 0.002869,
+     "end_time": "2026-06-17T01:33:26.176260+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.737410+00:00",
+     "start_time": "2026-06-17T01:33:26.173391+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,16 +89,16 @@
    "id": "sl8-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.748415Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.748216Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.756972Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.756363Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.183506Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.183315Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.191775Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.191184Z"
     },
     "papermill": {
-     "duration": 0.013798,
-     "end_time": "2026-06-17T01:28:32.757576+00:00",
+     "duration": 0.013478,
+     "end_time": "2026-06-17T01:33:26.192620+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.743778+00:00",
+     "start_time": "2026-06-17T01:33:26.179142+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,10 +178,10 @@
    "id": "sl8-04",
    "metadata": {
     "papermill": {
-     "duration": 0.004591,
-     "end_time": "2026-06-17T01:28:32.765921+00:00",
+     "duration": 0.003217,
+     "end_time": "2026-06-17T01:33:26.199383+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.761330+00:00",
+     "start_time": "2026-06-17T01:33:26.196166+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,10 +206,10 @@
    "id": "sl8-05",
    "metadata": {
     "papermill": {
-     "duration": 0.003201,
-     "end_time": "2026-06-17T01:28:32.772419+00:00",
+     "duration": 0.002951,
+     "end_time": "2026-06-17T01:33:26.205371+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.769218+00:00",
+     "start_time": "2026-06-17T01:33:26.202420+00:00",
      "status": "completed"
     },
     "tags": []
@@ -247,16 +247,16 @@
    "id": "sl8-06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.780190Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.779893Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.787819Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.787343Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.212392Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.212222Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.219669Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.219061Z"
     },
     "papermill": {
-     "duration": 0.012735,
-     "end_time": "2026-06-17T01:28:32.788474+00:00",
+     "duration": 0.011782,
+     "end_time": "2026-06-17T01:33:26.220130+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.775739+00:00",
+     "start_time": "2026-06-17T01:33:26.208348+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "sl8-07",
    "metadata": {
     "papermill": {
-     "duration": 0.00337,
-     "end_time": "2026-06-17T01:28:32.795281+00:00",
+     "duration": 0.003119,
+     "end_time": "2026-06-17T01:33:26.226336+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.791911+00:00",
+     "start_time": "2026-06-17T01:33:26.223217+00:00",
      "status": "completed"
     },
     "tags": []
@@ -385,10 +385,10 @@
    "id": "sl8-08",
    "metadata": {
     "papermill": {
-     "duration": 0.003317,
-     "end_time": "2026-06-17T01:28:32.801862+00:00",
+     "duration": 0.003994,
+     "end_time": "2026-06-17T01:33:26.233434+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.798545+00:00",
+     "start_time": "2026-06-17T01:33:26.229440+00:00",
      "status": "completed"
     },
     "tags": []
@@ -423,16 +423,16 @@
    "id": "sl8-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.810081Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.809885Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.817260Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.816622Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.241564Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.241229Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.247609Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.247134Z"
     },
     "papermill": {
-     "duration": 0.012592,
-     "end_time": "2026-06-17T01:28:32.817895+00:00",
+     "duration": 0.011232,
+     "end_time": "2026-06-17T01:33:26.248223+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.805303+00:00",
+     "start_time": "2026-06-17T01:33:26.236991+00:00",
      "status": "completed"
     },
     "tags": []
@@ -526,10 +526,10 @@
    "id": "sl8-10",
    "metadata": {
     "papermill": {
-     "duration": 0.003795,
-     "end_time": "2026-06-17T01:28:32.825536+00:00",
+     "duration": 0.003422,
+     "end_time": "2026-06-17T01:33:26.254983+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.821741+00:00",
+     "start_time": "2026-06-17T01:33:26.251561+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,16 +550,16 @@
    "id": "sl8-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.834457Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.834233Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.844032Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.843273Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.263104Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.262887Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.271721Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.270998Z"
     },
     "papermill": {
-     "duration": 0.015458,
-     "end_time": "2026-06-17T01:28:32.844703+00:00",
+     "duration": 0.013883,
+     "end_time": "2026-06-17T01:33:26.272246+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.829245+00:00",
+     "start_time": "2026-06-17T01:33:26.258363+00:00",
      "status": "completed"
     },
     "tags": []
@@ -626,10 +626,10 @@
    "id": "sl8-12",
    "metadata": {
     "papermill": {
-     "duration": 0.00344,
-     "end_time": "2026-06-17T01:28:32.851814+00:00",
+     "duration": 0.003569,
+     "end_time": "2026-06-17T01:33:26.279591+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.848374+00:00",
+     "start_time": "2026-06-17T01:33:26.276022+00:00",
      "status": "completed"
     },
     "tags": []
@@ -659,10 +659,10 @@
    "id": "sl8-13",
    "metadata": {
     "papermill": {
-     "duration": 0.003536,
-     "end_time": "2026-06-17T01:28:32.859027+00:00",
+     "duration": 0.004285,
+     "end_time": "2026-06-17T01:33:26.287428+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.855491+00:00",
+     "start_time": "2026-06-17T01:33:26.283143+00:00",
      "status": "completed"
     },
     "tags": []
@@ -697,16 +697,16 @@
    "id": "sl8-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.868277Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.868045Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.876337Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.875613Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.295819Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.295477Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.302811Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.302226Z"
     },
     "papermill": {
-     "duration": 0.014235,
-     "end_time": "2026-06-17T01:28:32.876980+00:00",
+     "duration": 0.012824,
+     "end_time": "2026-06-17T01:33:26.303549+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.862745+00:00",
+     "start_time": "2026-06-17T01:33:26.290725+00:00",
      "status": "completed"
     },
     "tags": []
@@ -770,10 +770,10 @@
    "id": "sl8-15",
    "metadata": {
     "papermill": {
-     "duration": 0.003938,
-     "end_time": "2026-06-17T01:28:32.884993+00:00",
+     "duration": 0.003595,
+     "end_time": "2026-06-17T01:33:26.311078+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.881055+00:00",
+     "start_time": "2026-06-17T01:33:26.307483+00:00",
      "status": "completed"
     },
     "tags": []
@@ -798,10 +798,10 @@
    "id": "sl8-16",
    "metadata": {
     "papermill": {
-     "duration": 0.004017,
-     "end_time": "2026-06-17T01:28:32.893342+00:00",
+     "duration": 0.003365,
+     "end_time": "2026-06-17T01:33:26.317880+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.889325+00:00",
+     "start_time": "2026-06-17T01:33:26.314515+00:00",
      "status": "completed"
     },
     "tags": []
@@ -832,16 +832,16 @@
    "id": "sl8-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.902427Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.902041Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.929207Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.928388Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.325453Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.325274Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.350453Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.349814Z"
     },
     "papermill": {
-     "duration": 0.032745,
-     "end_time": "2026-06-17T01:28:32.929857+00:00",
+     "duration": 0.029804,
+     "end_time": "2026-06-17T01:33:26.350953+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.897112+00:00",
+     "start_time": "2026-06-17T01:33:26.321149+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,10 +922,10 @@
    "id": "sl8-18",
    "metadata": {
     "papermill": {
-     "duration": 0.00396,
-     "end_time": "2026-06-17T01:28:32.937666+00:00",
+     "duration": 0.003912,
+     "end_time": "2026-06-17T01:33:26.358798+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.933706+00:00",
+     "start_time": "2026-06-17T01:33:26.354886+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,10 +960,10 @@
    "id": "sl8-19",
    "metadata": {
     "papermill": {
-     "duration": 0.003555,
-     "end_time": "2026-06-17T01:28:32.944835+00:00",
+     "duration": 0.003438,
+     "end_time": "2026-06-17T01:33:26.365748+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.941280+00:00",
+     "start_time": "2026-06-17T01:33:26.362310+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1000,10 +1000,10 @@
    "id": "sl8-20",
    "metadata": {
     "papermill": {
-     "duration": 0.003795,
-     "end_time": "2026-06-17T01:28:32.952635+00:00",
+     "duration": 0.003911,
+     "end_time": "2026-06-17T01:33:26.372927+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.948840+00:00",
+     "start_time": "2026-06-17T01:33:26.369016+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,16 +1031,16 @@
    "id": "sl8-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.961454Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.961227Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.977712Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.976858Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.381438Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.381260Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.395839Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.395151Z"
     },
     "papermill": {
-     "duration": 0.021848,
-     "end_time": "2026-06-17T01:28:32.978320+00:00",
+     "duration": 0.020021,
+     "end_time": "2026-06-17T01:33:26.396492+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.956472+00:00",
+     "start_time": "2026-06-17T01:33:26.376471+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1122,10 +1122,10 @@
    "id": "sl8ex1var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003816,
-     "end_time": "2026-06-17T01:28:32.986231+00:00",
+     "duration": 0.003874,
+     "end_time": "2026-06-17T01:33:26.404574+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.982415+00:00",
+     "start_time": "2026-06-17T01:33:26.400700+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1149,16 +1149,16 @@
    "id": "sl8ex1var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:32.995101Z",
-     "iopub.status.busy": "2026-06-17T01:28:32.994905Z",
-     "iopub.status.idle": "2026-06-17T01:28:32.998626Z",
-     "shell.execute_reply": "2026-06-17T01:28:32.998006Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.412422Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.412231Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.415848Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.415287Z"
     },
     "papermill": {
-     "duration": 0.009194,
-     "end_time": "2026-06-17T01:28:32.999198+00:00",
+     "duration": 0.008467,
+     "end_time": "2026-06-17T01:33:26.416310+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:32.990004+00:00",
+     "start_time": "2026-06-17T01:33:26.407843+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1208,10 +1208,10 @@
    "id": "sl8-22",
    "metadata": {
     "papermill": {
-     "duration": 0.003922,
-     "end_time": "2026-06-17T01:28:33.007056+00:00",
+     "duration": 0.003708,
+     "end_time": "2026-06-17T01:33:26.423588+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.003134+00:00",
+     "start_time": "2026-06-17T01:33:26.419880+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1228,16 +1228,16 @@
    "id": "sl8-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:33.016886Z",
-     "iopub.status.busy": "2026-06-17T01:28:33.016575Z",
-     "iopub.status.idle": "2026-06-17T01:28:33.362596Z",
-     "shell.execute_reply": "2026-06-17T01:28:33.361887Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.432078Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.431826Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.754850Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.754189Z"
     },
     "papermill": {
-     "duration": 0.352192,
-     "end_time": "2026-06-17T01:28:33.363175+00:00",
+     "duration": 0.328166,
+     "end_time": "2026-06-17T01:33:26.755401+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.010983+00:00",
+     "start_time": "2026-06-17T01:33:26.427235+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1251,14 +1251,14 @@
       "================================================================\n",
       " n_samples |  NEEDLE (desaccords rares) |  TARGET parites (denses)\n",
       "----------------------------------------------------------------\n",
-      "         1 |                        0% |                     50%\n",
-      "        10 |                       10% |                    100%\n"
+      "         1 |                        0% |                     50%\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "        10 |                       10% |                    100%\n",
       "        50 |                       60% |                    100%\n"
      ]
     },
@@ -1333,10 +1333,10 @@
    "id": "sl8ex2var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.004043,
-     "end_time": "2026-06-17T01:28:33.371209+00:00",
+     "duration": 0.003645,
+     "end_time": "2026-06-17T01:33:26.762998+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.367166+00:00",
+     "start_time": "2026-06-17T01:33:26.759353+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1359,16 +1359,16 @@
    "id": "sl8ex2var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:33.379662Z",
-     "iopub.status.busy": "2026-06-17T01:28:33.379489Z",
-     "iopub.status.idle": "2026-06-17T01:28:33.382946Z",
-     "shell.execute_reply": "2026-06-17T01:28:33.382406Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.770843Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.770681Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.773797Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.773252Z"
     },
     "papermill": {
-     "duration": 0.008539,
-     "end_time": "2026-06-17T01:28:33.383505+00:00",
+     "duration": 0.008013,
+     "end_time": "2026-06-17T01:33:26.774444+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.374966+00:00",
+     "start_time": "2026-06-17T01:33:26.766431+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1421,10 +1421,10 @@
    "id": "sl8-24",
    "metadata": {
     "papermill": {
-     "duration": 0.003863,
-     "end_time": "2026-06-17T01:28:33.391306+00:00",
+     "duration": 0.003489,
+     "end_time": "2026-06-17T01:33:26.781521+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.387443+00:00",
+     "start_time": "2026-06-17T01:33:26.778032+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1441,16 +1441,16 @@
    "id": "sl8-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:33.400794Z",
-     "iopub.status.busy": "2026-06-17T01:28:33.400568Z",
-     "iopub.status.idle": "2026-06-17T01:28:33.404248Z",
-     "shell.execute_reply": "2026-06-17T01:28:33.403645Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.792072Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.791873Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.799689Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.799140Z"
     },
     "papermill": {
-     "duration": 0.0096,
-     "end_time": "2026-06-17T01:28:33.404859+00:00",
+     "duration": 0.014723,
+     "end_time": "2026-06-17T01:33:26.800122+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.395259+00:00",
+     "start_time": "2026-06-17T01:33:26.785399+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1460,23 +1460,203 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Comparaison Angluin (prefixes -> S) vs Maler-Pnueli (suffixes -> E)\n",
+      "======================================================================\n",
+      "Langage                | Variante      |  |S| |  |E| | |S|x|E| |    MQ |  EQ\n",
+      "----------------------------------------------------------------------\n",
+      "TARGET (parites)       | Angluin       |    4 |    3 |      12 |    19 |   2\n",
+      "TARGET (parites)       | Maler-Pnueli  |    4 |    3 |      12 |    19 |   2\n",
+      "L_5 (longueur % 5)     | Angluin       |    6 |    4 |      24 |    34 |   2\n",
+      "L_5 (longueur % 5)     | Maler-Pnueli  |    5 |    6 |      30 |    41 |   2\n",
+      "\n",
+      "Lecture : les deux variantes echangent |S| contre |E|. Angluin ajoute\n",
+      "des PREFIXES a S (un acces par etat revele par le contre-exemple) ;\n",
+      "Maler-Pnueli ajoute des SUFFIXES a E (un distinguant par contre-exemple).\n",
+      "Sur TARGET (4 etats) les deux coincident. Sur L_5, Maler-Pnueli garde |S|\n",
+      "plus petit (5 vs 6) mais grossit |E| (6 vs 4) : le total |S|x|E| et le\n",
+      "nombre de MQ sont alors legerement PLUS eleves (41 vs 34). La compacite\n",
+      "globale n'avantage donc AUCUNE des deux variantes en general. L'interet\n",
+      "reel de la variante suffixes est structurel : ajouter des suffixes a E ne\n",
+      "fait que raffiner le partitionnement des lignes (chaque colonne ne peut\n",
+      "que distinguer davantage de lignes egales), donc elle ne peut PAS\n",
+      "introduire d'inconsistance -- elle la resout, d'ou moins de passes de\n",
+      "re-stabilisation de la table.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 3 : Variante de traitement du contre-exemple (suffixes vs prefixes)\n",
-    "# TODO etudiant : implementez la variante qui, au lieu d'ajouter les prefixes du\n",
-    "# contre-exemple a S, ajoute tous ses SUFFIXES a E (variante Maler-Pnueli).\n",
-    "# Indice : copiez lstar() et modifiez uniquement le traitement du contre-exemple ;\n",
-    "#          les suffixes de c sont c[i:] pour i in range(len(c))\n",
-    "# Etape 1 : ecrivez lstar_suffixes(alphabet, mq, eq)\n",
-    "# Etape 2 : comparez sur le langage cible ET sur L_5 (divisibilite par 5) :\n",
-    "#           |S|, |E|, nombre de MQ, nombre d'EQ pour les deux variantes\n",
-    "# Etape 3 : laquelle maintient la table la plus compacte ? Pourquoi la variante\n",
-    "#           suffixes ne peut-elle jamais rendre la table inconsistante ?\n",
+    "# Exemple guide 3 : Variante de traitement du contre-exemple (suffixes vs prefixes)\n",
+    "#\n",
+    "# Angluin (1987) ajoute tous les PREFIXES du contre-exemple a S. La variante\n",
+    "# de Maler-Pnueli ajoute tous ses SUFFIXES a E : meme garantie de terminaison,\n",
+    "# mais un profil de cout different (|E| croit, |S| reste compact).\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "def lstar_suffixes(alphabet, mq, eq, verbose=False):\n",
+    "    \"\"\"L* variante Maler-Pnueli : integre le contre-exemple par ses SUFFIXES\n",
+    "    (ajoutes a E) plutot que par ses prefixes (ajoutes a S).\"\"\"\n",
+    "    table = ObservationTable(alphabet, mq)\n",
+    "    n_eq = 0\n",
+    "    round_ = 0\n",
+    "    while True:\n",
+    "        # 1. Stabiliser la table (fermeture + consistance)\n",
+    "        while True:\n",
+    "            sa = table.find_unclosed()\n",
+    "            if sa is not None:\n",
+    "                table.S.append(sa)\n",
+    "                table.fill()\n",
+    "                continue\n",
+    "            ae = table.find_inconsistency()\n",
+    "            if ae is not None:\n",
+    "                table.E.append(ae)\n",
+    "                table.fill()\n",
+    "                continue\n",
+    "            break\n",
+    "        # 2. Conjecturer et interroger le professeur\n",
+    "        hyp = conjecture(table)\n",
+    "        n_eq += 1\n",
+    "        round_ += 1\n",
+    "        cex = eq(hyp)\n",
+    "        if cex is None:\n",
+    "            return hyp, table, n_eq\n",
+    "        # 3. Maler-Pnueli : ajouter les SUFFIXES cex[i:] du contre-exemple a E\n",
+    "        for i in range(len(cex)):\n",
+    "            suf = cex[i:]\n",
+    "            if suf not in table.E:\n",
+    "                table.E.append(suf)\n",
+    "        table.fill()\n",
+    "\n",
+    "\n",
+    "# Deuxieme langage de comparaison : L_5 = mots de longueur divisible par 5.\n",
+    "def l5_dfa():\n",
+    "    delta = {(q, a): (q + 1) % 5 for q in range(5) for a in ALPHABET}\n",
+    "    return DFA(range(5), ALPHABET, delta, 0, {0})\n",
+    "\n",
+    "\n",
+    "L5 = l5_dfa()\n",
+    "\n",
+    "\n",
+    "def eq_exact_pour(target):\n",
+    "    \"\"\"Oracle d'equivalence EXACT pour une cible donnee (DFA).\"\"\"\n",
+    "    return lambda h: find_counterexample(h, target, ALPHABET)\n",
+    "\n",
+    "\n",
+    "# Etape 2 : comparaison prefixes (Angluin) vs suffixes (Maler-Pnueli)\n",
+    "print(\"Comparaison Angluin (prefixes -> S) vs Maler-Pnueli (suffixes -> E)\")\n",
+    "print(\"=\" * 70)\n",
+    "print(f\"{'Langage':22s} | {'Variante':13s} | {'|S|':>4} | {'|E|':>4} | \"\n",
+    "      f\"{'|S|x|E|':>7} | {'MQ':>5} | {'EQ':>3}\")\n",
+    "print(\"-\" * 70)\n",
+    "langages = [(\"TARGET (parites)\", membership_query, TARGET),\n",
+    "            (\"L_5 (longueur % 5)\", L5.accepts, L5)]\n",
+    "for nom, mq, tgt in langages:\n",
+    "    eq = eq_exact_pour(tgt)\n",
+    "    for variante, runner in [(\"Angluin\", lstar), (\"Maler-Pnueli\", lstar_suffixes)]:\n",
+    "        hyp, tbl, n_eq = runner(ALPHABET, mq, eq, verbose=False)\n",
+    "        taille = len(tbl.S) * len(tbl.E)\n",
+    "        print(f\"{nom:22s} | {variante:13s} | {len(tbl.S):>4} | {len(tbl.E):>4} | \"\n",
+    "              f\"{taille:>7} | {tbl.n_mq:>5} | {n_eq:>3}\")\n",
+    "\n",
+    "# Etape 3 : lecture\n",
+    "print()\n",
+    "print(\"Lecture : les deux variantes echangent |S| contre |E|. Angluin ajoute\")\n",
+    "print(\"des PREFIXES a S (un acces par etat revele par le contre-exemple) ;\")\n",
+    "print(\"Maler-Pnueli ajoute des SUFFIXES a E (un distinguant par contre-exemple).\")\n",
+    "print(\"Sur TARGET (4 etats) les deux coincident. Sur L_5, Maler-Pnueli garde |S|\")\n",
+    "print(\"plus petit (5 vs 6) mais grossit |E| (6 vs 4) : le total |S|x|E| et le\")\n",
+    "print(\"nombre de MQ sont alors legerement PLUS eleves (41 vs 34). La compacite\")\n",
+    "print(\"globale n'avantage donc AUCUNE des deux variantes en general. L'interet\")\n",
+    "print(\"reel de la variante suffixes est structurel : ajouter des suffixes a E ne\")\n",
+    "print(\"fait que raffiner le partitionnement des lignes (chaque colonne ne peut\")\n",
+    "print(\"que distinguer davantage de lignes egales), donc elle ne peut PAS\")\n",
+    "print(\"introduire d'inconsistance -- elle la resout, d'ou moins de passes de\")\n",
+    "print(\"re-stabilisation de la table.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8ex3var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003651,
+     "end_time": "2026-06-17T01:33:26.807425+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:33:26.803774+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (variation) : Variante Rivest-Schapire (un seul suffixe, par dichotomie)\n",
+    "\n",
+    "Angluin ajoute **tous** les prefixes, Maler-Pnueli **tous** les suffixes. La variante de Rivest-Schapire (1993) est plus parcimonieuse : par **recherche dichotomique** sur le contre-exemple, elle identifie **un seul** suffixe distinguant et l'ajoute a `E`. Implementez cette recherche.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Soit un contre-exemple `c` ou l'hypothese et la cible differentent : trouvez par dichotomie un indice `i` tel que le suffixe `c[i:]` separe la ligne d'acces correspondante de celle de la cible\n",
+    "2. Ajoutez ce **seul** suffixe `c[i:]` a `E` (pas tous les suffixes)\n",
+    "3. Comparez le nombre total de MQ avec la variante Maler-Pnueli (tous les suffixes) sur `TARGET` : Rivest ajoute-t-il moins de colonnes ?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "sl8ex3var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:33:26.815227Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.815021Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.818298Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.817732Z"
+    },
+    "papermill": {
+     "duration": 0.007996,
+     "end_time": "2026-06-17T01:33:26.818834+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:33:26.810838+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : variante Rivest-Schapire (un seul suffixe par dichotomie)\n",
+      "Etape 1 : ecrivez suffixe_distinguant_rivest(table, cex) (recherche dichotomique)\n",
+      "Etape 2 : ecrivez lstar_rivest (copie de lstar_suffixes, ajout d'un seul suffixe)\n",
+      "Etape 3 : comparez n_mq et |E| avec Maler-Pnueli sur TARGET\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (variation) : variante Rivest-Schapire (un seul suffixe par dichotomie)\n",
+    "# TODO etudiant : au lieu d'ajouter TOUS les suffixes du contre-exemple a E,\n",
+    "# n'en ajouter qu'UN, trouve par recherche dichotomique.\n",
+    "\n",
+    "# Etape 1 : recherche dichotomique d'un suffixe distinguant dans le contre-exemple\n",
+    "# def suffixe_distinguant_rivest(table, cex):\n",
+    "#     # cex = contre-exemple ou hyp et target differentent\n",
+    "#     # renvoyer un seul suffixe cex[i:] a ajouter a E\n",
+    "#     ...\n",
+    "#     return None  # TODO etudiant\n",
+    "\n",
+    "# Etape 2 : lstar_rivest : copiez lstar_suffixes, remplacez l'ajout de tous les\n",
+    "# suffixes par l'ajout du SEUL suffixe renvoye par suffixe_distinguant_rivest\n",
+    "# def lstar_rivest(alphabet, mq, eq, verbose=False):\n",
+    "#     ...\n",
+    "#     return None  # TODO etudiant\n",
+    "\n",
+    "# Etape 3 : comparer n_mq et |E| avec Maler-Pnueli sur TARGET\n",
+    "print(\"Exercice a completer : variante Rivest-Schapire (un seul suffixe par dichotomie)\")\n",
+    "print(\"Etape 1 : ecrivez suffixe_distinguant_rivest(table, cex) (recherche dichotomique)\")\n",
+    "print(\"Etape 2 : ecrivez lstar_rivest (copie de lstar_suffixes, ajout d'un seul suffixe)\")\n",
+    "print(\"Etape 3 : comparez n_mq et |E| avec Maler-Pnueli sur TARGET\")\n",
+    "\n",
+    "# Indice : la dichotomie exploite le fait que si row(cex[0:]) (hyp) != row(cex[0:])\n",
+    "# (target) mais row(cex[k:]) (hyp) == row(cex[k:]) (target), alors il existe un\n",
+    "# point de bascule i ; cex[i:] est le suffixe cherche. O(log|cex|) ajout au lieu de |cex|.\n",
+    "# result = None  # TODO etudiant : le DFA appris par lstar_rivest\n"
    ]
   },
   {
@@ -1484,10 +1664,10 @@
    "id": "sl8-26",
    "metadata": {
     "papermill": {
-     "duration": 0.00411,
-     "end_time": "2026-06-17T01:28:33.412862+00:00",
+     "duration": 0.003443,
+     "end_time": "2026-06-17T01:33:26.825860+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.408752+00:00",
+     "start_time": "2026-06-17T01:33:26.822417+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1499,20 +1679,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "sl8-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:28:33.421925Z",
-     "iopub.status.busy": "2026-06-17T01:28:33.421736Z",
-     "iopub.status.idle": "2026-06-17T01:28:33.425319Z",
-     "shell.execute_reply": "2026-06-17T01:28:33.424511Z"
+     "iopub.execute_input": "2026-06-17T01:33:26.833709Z",
+     "iopub.status.busy": "2026-06-17T01:33:26.833574Z",
+     "iopub.status.idle": "2026-06-17T01:33:26.837093Z",
+     "shell.execute_reply": "2026-06-17T01:33:26.836126Z"
     },
     "papermill": {
-     "duration": 0.009001,
-     "end_time": "2026-06-17T01:28:33.425997+00:00",
+     "duration": 0.008195,
+     "end_time": "2026-06-17T01:33:26.837579+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.416996+00:00",
+     "start_time": "2026-06-17T01:33:26.829384+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1547,10 +1727,10 @@
    "id": "sl8-29",
    "metadata": {
     "papermill": {
-     "duration": 0.004082,
-     "end_time": "2026-06-17T01:28:33.434075+00:00",
+     "duration": 0.003808,
+     "end_time": "2026-06-17T01:33:26.845385+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.429993+00:00",
+     "start_time": "2026-06-17T01:33:26.841577+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1607,10 +1787,10 @@
    "id": "sl8-28",
    "metadata": {
     "papermill": {
-     "duration": 0.003957,
-     "end_time": "2026-06-17T01:28:33.443729+00:00",
+     "duration": 0.003715,
+     "end_time": "2026-06-17T01:33:26.852889+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.439772+00:00",
+     "start_time": "2026-06-17T01:33:26.849174+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1638,10 +1818,10 @@
    "id": "sl8-30",
    "metadata": {
     "papermill": {
-     "duration": 0.00415,
-     "end_time": "2026-06-17T01:28:33.452082+00:00",
+     "duration": 0.003476,
+     "end_time": "2026-06-17T01:33:26.859820+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:28:33.447932+00:00",
+     "start_time": "2026-06-17T01:33:26.856344+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1684,14 +1864,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.768843,
-   "end_time": "2026-06-17T01:28:33.699342+00:00",
+   "duration": 2.529194,
+   "end_time": "2026-06-17T01:33:26.996136+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T01:28:30.930499+00:00",
+   "start_time": "2026-06-17T01:33:24.466942+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "sl8-01",
    "metadata": {
     "papermill": {
-     "duration": 0.003968,
-     "end_time": "2026-06-17T01:25:17.063673+00:00",
+     "duration": 0.003984,
+     "end_time": "2026-06-17T01:28:32.733757+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.059705+00:00",
+     "start_time": "2026-06-17T01:28:32.729773+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "sl8-02",
    "metadata": {
     "papermill": {
-     "duration": 0.003041,
-     "end_time": "2026-06-17T01:25:17.071273+00:00",
+     "duration": 0.0032,
+     "end_time": "2026-06-17T01:28:32.740610+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.068232+00:00",
+     "start_time": "2026-06-17T01:28:32.737410+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,16 +89,16 @@
    "id": "sl8-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.078780Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.078567Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.088527Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.087872Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.748415Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.748216Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.756972Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.756363Z"
     },
     "papermill": {
-     "duration": 0.015159,
-     "end_time": "2026-06-17T01:25:17.089417+00:00",
+     "duration": 0.013798,
+     "end_time": "2026-06-17T01:28:32.757576+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.074258+00:00",
+     "start_time": "2026-06-17T01:28:32.743778+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,10 +178,10 @@
    "id": "sl8-04",
    "metadata": {
     "papermill": {
-     "duration": 0.003094,
-     "end_time": "2026-06-17T01:25:17.096428+00:00",
+     "duration": 0.004591,
+     "end_time": "2026-06-17T01:28:32.765921+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.093334+00:00",
+     "start_time": "2026-06-17T01:28:32.761330+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,10 +206,10 @@
    "id": "sl8-05",
    "metadata": {
     "papermill": {
-     "duration": 0.00305,
-     "end_time": "2026-06-17T01:25:17.102604+00:00",
+     "duration": 0.003201,
+     "end_time": "2026-06-17T01:28:32.772419+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.099554+00:00",
+     "start_time": "2026-06-17T01:28:32.769218+00:00",
      "status": "completed"
     },
     "tags": []
@@ -247,16 +247,16 @@
    "id": "sl8-06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.109889Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.109668Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.118412Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.117641Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.780190Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.779893Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.787819Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.787343Z"
     },
     "papermill": {
-     "duration": 0.013673,
-     "end_time": "2026-06-17T01:25:17.119187+00:00",
+     "duration": 0.012735,
+     "end_time": "2026-06-17T01:28:32.788474+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.105514+00:00",
+     "start_time": "2026-06-17T01:28:32.775739+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "sl8-07",
    "metadata": {
     "papermill": {
-     "duration": 0.003674,
-     "end_time": "2026-06-17T01:25:17.126673+00:00",
+     "duration": 0.00337,
+     "end_time": "2026-06-17T01:28:32.795281+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.122999+00:00",
+     "start_time": "2026-06-17T01:28:32.791911+00:00",
      "status": "completed"
     },
     "tags": []
@@ -385,10 +385,10 @@
    "id": "sl8-08",
    "metadata": {
     "papermill": {
-     "duration": 0.003022,
-     "end_time": "2026-06-17T01:25:17.132927+00:00",
+     "duration": 0.003317,
+     "end_time": "2026-06-17T01:28:32.801862+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.129905+00:00",
+     "start_time": "2026-06-17T01:28:32.798545+00:00",
      "status": "completed"
     },
     "tags": []
@@ -423,16 +423,16 @@
    "id": "sl8-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.140574Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.140398Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.146866Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.146037Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.810081Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.809885Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.817260Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.816622Z"
     },
     "papermill": {
-     "duration": 0.011378,
-     "end_time": "2026-06-17T01:25:17.147600+00:00",
+     "duration": 0.012592,
+     "end_time": "2026-06-17T01:28:32.817895+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.136222+00:00",
+     "start_time": "2026-06-17T01:28:32.805303+00:00",
      "status": "completed"
     },
     "tags": []
@@ -526,10 +526,10 @@
    "id": "sl8-10",
    "metadata": {
     "papermill": {
-     "duration": 0.003337,
-     "end_time": "2026-06-17T01:25:17.154425+00:00",
+     "duration": 0.003795,
+     "end_time": "2026-06-17T01:28:32.825536+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.151088+00:00",
+     "start_time": "2026-06-17T01:28:32.821741+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,16 +550,16 @@
    "id": "sl8-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.162322Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.162041Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.170807Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.170038Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.834457Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.834233Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.844032Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.843273Z"
     },
     "papermill": {
-     "duration": 0.01361,
-     "end_time": "2026-06-17T01:25:17.171450+00:00",
+     "duration": 0.015458,
+     "end_time": "2026-06-17T01:28:32.844703+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.157840+00:00",
+     "start_time": "2026-06-17T01:28:32.829245+00:00",
      "status": "completed"
     },
     "tags": []
@@ -626,10 +626,10 @@
    "id": "sl8-12",
    "metadata": {
     "papermill": {
-     "duration": 0.003627,
-     "end_time": "2026-06-17T01:25:17.178854+00:00",
+     "duration": 0.00344,
+     "end_time": "2026-06-17T01:28:32.851814+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.175227+00:00",
+     "start_time": "2026-06-17T01:28:32.848374+00:00",
      "status": "completed"
     },
     "tags": []
@@ -659,10 +659,10 @@
    "id": "sl8-13",
    "metadata": {
     "papermill": {
-     "duration": 0.004161,
-     "end_time": "2026-06-17T01:25:17.186630+00:00",
+     "duration": 0.003536,
+     "end_time": "2026-06-17T01:28:32.859027+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.182469+00:00",
+     "start_time": "2026-06-17T01:28:32.855491+00:00",
      "status": "completed"
     },
     "tags": []
@@ -697,16 +697,16 @@
    "id": "sl8-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.195620Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.195146Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.203905Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.203111Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.868277Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.868045Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.876337Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.875613Z"
     },
     "papermill": {
-     "duration": 0.014241,
-     "end_time": "2026-06-17T01:25:17.204523+00:00",
+     "duration": 0.014235,
+     "end_time": "2026-06-17T01:28:32.876980+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.190282+00:00",
+     "start_time": "2026-06-17T01:28:32.862745+00:00",
      "status": "completed"
     },
     "tags": []
@@ -770,10 +770,10 @@
    "id": "sl8-15",
    "metadata": {
     "papermill": {
-     "duration": 0.00376,
-     "end_time": "2026-06-17T01:25:17.212515+00:00",
+     "duration": 0.003938,
+     "end_time": "2026-06-17T01:28:32.884993+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.208755+00:00",
+     "start_time": "2026-06-17T01:28:32.881055+00:00",
      "status": "completed"
     },
     "tags": []
@@ -798,10 +798,10 @@
    "id": "sl8-16",
    "metadata": {
     "papermill": {
-     "duration": 0.003816,
-     "end_time": "2026-06-17T01:25:17.220167+00:00",
+     "duration": 0.004017,
+     "end_time": "2026-06-17T01:28:32.893342+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.216351+00:00",
+     "start_time": "2026-06-17T01:28:32.889325+00:00",
      "status": "completed"
     },
     "tags": []
@@ -832,16 +832,16 @@
    "id": "sl8-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.229220Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.228852Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.262527Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.261624Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.902427Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.902041Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.929207Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.928388Z"
     },
     "papermill": {
-     "duration": 0.039337,
-     "end_time": "2026-06-17T01:25:17.263189+00:00",
+     "duration": 0.032745,
+     "end_time": "2026-06-17T01:28:32.929857+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.223852+00:00",
+     "start_time": "2026-06-17T01:28:32.897112+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,10 +922,10 @@
    "id": "sl8-18",
    "metadata": {
     "papermill": {
-     "duration": 0.003781,
-     "end_time": "2026-06-17T01:25:17.270885+00:00",
+     "duration": 0.00396,
+     "end_time": "2026-06-17T01:28:32.937666+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.267104+00:00",
+     "start_time": "2026-06-17T01:28:32.933706+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,10 +960,10 @@
    "id": "sl8-19",
    "metadata": {
     "papermill": {
-     "duration": 0.004058,
-     "end_time": "2026-06-17T01:25:17.278768+00:00",
+     "duration": 0.003555,
+     "end_time": "2026-06-17T01:28:32.944835+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.274710+00:00",
+     "start_time": "2026-06-17T01:28:32.941280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1000,10 +1000,10 @@
    "id": "sl8-20",
    "metadata": {
     "papermill": {
-     "duration": 0.003799,
-     "end_time": "2026-06-17T01:25:17.286427+00:00",
+     "duration": 0.003795,
+     "end_time": "2026-06-17T01:28:32.952635+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.282628+00:00",
+     "start_time": "2026-06-17T01:28:32.948840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,16 +1031,16 @@
    "id": "sl8-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.295336Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.294954Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.311398Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.310648Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.961454Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.961227Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.977712Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.976858Z"
     },
     "papermill": {
-     "duration": 0.021866,
-     "end_time": "2026-06-17T01:25:17.312027+00:00",
+     "duration": 0.021848,
+     "end_time": "2026-06-17T01:28:32.978320+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.290161+00:00",
+     "start_time": "2026-06-17T01:28:32.956472+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1122,10 +1122,10 @@
    "id": "sl8ex1var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003742,
-     "end_time": "2026-06-17T01:25:17.319519+00:00",
+     "duration": 0.003816,
+     "end_time": "2026-06-17T01:28:32.986231+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.315777+00:00",
+     "start_time": "2026-06-17T01:28:32.982415+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1149,16 +1149,16 @@
    "id": "sl8ex1var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.328036Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.327714Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.331799Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.331084Z"
+     "iopub.execute_input": "2026-06-17T01:28:32.995101Z",
+     "iopub.status.busy": "2026-06-17T01:28:32.994905Z",
+     "iopub.status.idle": "2026-06-17T01:28:32.998626Z",
+     "shell.execute_reply": "2026-06-17T01:28:32.998006Z"
     },
     "papermill": {
-     "duration": 0.00934,
-     "end_time": "2026-06-17T01:25:17.332460+00:00",
+     "duration": 0.009194,
+     "end_time": "2026-06-17T01:28:32.999198+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.323120+00:00",
+     "start_time": "2026-06-17T01:28:32.990004+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1208,10 +1208,10 @@
    "id": "sl8-22",
    "metadata": {
     "papermill": {
-     "duration": 0.003419,
-     "end_time": "2026-06-17T01:25:17.339680+00:00",
+     "duration": 0.003922,
+     "end_time": "2026-06-17T01:28:33.007056+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.336261+00:00",
+     "start_time": "2026-06-17T01:28:33.003134+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1228,16 +1228,16 @@
    "id": "sl8-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.347704Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.347512Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.350979Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.350293Z"
+     "iopub.execute_input": "2026-06-17T01:28:33.016886Z",
+     "iopub.status.busy": "2026-06-17T01:28:33.016575Z",
+     "iopub.status.idle": "2026-06-17T01:28:33.362596Z",
+     "shell.execute_reply": "2026-06-17T01:28:33.361887Z"
     },
     "papermill": {
-     "duration": 0.008528,
-     "end_time": "2026-06-17T01:25:17.351556+00:00",
+     "duration": 0.352192,
+     "end_time": "2026-06-17T01:28:33.363175+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.343028+00:00",
+     "start_time": "2026-06-17T01:28:33.010983+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1247,22 +1247,173 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Fiabilite de l'oracle d'equivalence par echantillonnage (20 graines)\n",
+      "================================================================\n",
+      " n_samples |  NEEDLE (desaccords rares) |  TARGET parites (denses)\n",
+      "----------------------------------------------------------------\n",
+      "         1 |                        0% |                     50%\n",
+      "        10 |                       10% |                    100%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        50 |                       60% |                    100%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       100 |                      100% |                    100%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       500 |                      100% |                    100%\n",
+      "\n",
+      "Lecture : le seuil de fiabilite (n_samples au-dela duquel le taux tend\n",
+      "vers 100%) depend fortement du langage. NEEDLE (contient 'aabbaabb') a\n",
+      "des desaccords RARES -- peu de mots distinguent une hypothese fausse de\n",
+      "la cible, il faut donc beaucoup d'echantillons pour tomber sur un mot\n",
+      "revelateur. TARGET (parite des 'a' et 'b') a des desaccords DENSES --\n",
+      "pres de la moitie des mots distinguent deux DFAs differents -- donc peu\n",
+      "d'echantillons suffisent. La fiabilite d'un oracle PAC est plafonnee par\n",
+      "la DENSITE des contre-exemples dans le langage cible.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : Fiabilite de l'oracle d'equivalence approximatif\n",
-    "# TODO etudiant : pour n_samples dans [1, 10, 50, 100, 500], lancez L* sur le\n",
-    "# langage-aiguille NEEDLE (section 6) avec 20 graines differentes (seed=0..19)\n",
-    "# et mesurez le TAUX de runs qui retournent un DFA exactement correct.\n",
-    "# Indice : la correction se verifie avec find_counterexample(hyp, NEEDLE, ALPHABET)\n",
-    "# Etape 1 : double boucle n_samples x seed, verbose=False\n",
-    "# Etape 2 : tableau n_samples -> taux de reussite (sur 20 runs)\n",
-    "# Etape 3 : ou situez-vous le seuil de fiabilite ? Refaites la mesure sur TARGET\n",
-    "#           (parites) : pourquoi le seuil depend-il du langage ?\n",
+    "# Exemple guide 2 : Fiabilite de l'oracle d'equivalence approximatif\n",
+    "#\n",
+    "# L'oracle d'equivalence par echantillonnage est une variable aleatoire :\n",
+    "# sa fiabilite se mesure en repetant l'experience. Pour plusieurs tailles\n",
+    "# d'echantillon et 20 graines, on mesure le TAUX de runs qui produisent\n",
+    "# un DFA exactement correct (verifie par l'oracle EXACT find_counterexample).\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : taux de reussite sur n_seeds graines\n",
+    "def taux_fiabilite(mq, target, n_samples, n_seeds=20):\n",
+    "    \"\"\"Lance L* n_seeds fois ; retourne la fraction de runs exactement corrects.\"\"\"\n",
+    "    corrects = 0\n",
+    "    for seed in range(n_seeds):\n",
+    "        eq = make_sampling_eq(mq, ALPHABET, n_samples, seed=seed)\n",
+    "        hyp, _, _ = lstar(ALPHABET, mq, eq, verbose=False)\n",
+    "        if find_counterexample(hyp, target, ALPHABET) is None:\n",
+    "            corrects += 1\n",
+    "    return corrects / n_seeds\n",
+    "\n",
+    "# Etape 2 : tableau n_samples -> taux de reussite (sur 20 runs), NEEDLE vs TARGET\n",
+    "print(\"Fiabilite de l'oracle d'equivalence par echantillonnage (20 graines)\")\n",
+    "print(\"=\" * 64)\n",
+    "print(f\"{'n_samples':>10} | {'NEEDLE (desaccords rares)':>26} | \"\n",
+    "      f\"{'TARGET parites (denses)':>24}\")\n",
+    "print(\"-\" * 64)\n",
+    "for n_samples in [1, 10, 50, 100, 500]:\n",
+    "    t_needle = taux_fiabilite(NEEDLE.accepts, NEEDLE, n_samples)\n",
+    "    t_target = taux_fiabilite(membership_query, TARGET, n_samples)\n",
+    "    print(f\"{n_samples:>10} | {t_needle:>25.0%} | {t_target:>23.0%}\")\n",
+    "\n",
+    "# Etape 3 : seuil de fiabilite + pourquoi il depend du langage\n",
+    "print()\n",
+    "print(\"Lecture : le seuil de fiabilite (n_samples au-dela duquel le taux tend\")\n",
+    "print(\"vers 100%) depend fortement du langage. NEEDLE (contient 'aabbaabb') a\")\n",
+    "print(\"des desaccords RARES -- peu de mots distinguent une hypothese fausse de\")\n",
+    "print(\"la cible, il faut donc beaucoup d'echantillons pour tomber sur un mot\")\n",
+    "print(\"revelateur. TARGET (parite des 'a' et 'b') a des desaccords DENSES --\")\n",
+    "print(\"pres de la moitie des mots distinguent deux DFAs differents -- donc peu\")\n",
+    "print(\"d'echantillons suffisent. La fiabilite d'un oracle PAC est plafonnee par\")\n",
+    "print(\"la DENSITE des contre-exemples dans le langage cible.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8ex2var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004043,
+     "end_time": "2026-06-17T01:28:33.371209+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:28:33.367166+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 (variation) : Fiabilite vs longueur des mots echantillonnes\n",
+    "\n",
+    "Pour NEEDLE, le contre-exemple revelateur est un mot LONG (il faut un mot contenant \"aabbaabb\"). L'oracle echantillonne des mots de longueur `<= max_len` : que se passe-t-il si `max_len < 8` (aucun mot genere ne peut contenir le motif) ? Mesurez le taux de fiabilite pour `max_len` dans `[5, 8, 12, 20]`, a `n_samples` fixe.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Reutiliser `taux_fiabilite` en variant `max_len` (parametre de `make_sampling_eq`) avec `n_samples=200` fixe, sur NEEDLE\n",
+    "2. Tableau `max_len` -> taux de reussite (20 graines)\n",
+    "3. Pourquoi `max_len < len(motif)` annule-t-il la fiabilite meme avec beaucoup d'echantillons ?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "sl8ex2var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:28:33.379662Z",
+     "iopub.status.busy": "2026-06-17T01:28:33.379489Z",
+     "iopub.status.idle": "2026-06-17T01:28:33.382946Z",
+     "shell.execute_reply": "2026-06-17T01:28:33.382406Z"
+    },
+    "papermill": {
+     "duration": 0.008539,
+     "end_time": "2026-06-17T01:28:33.383505+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:28:33.374966+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : fiabilite vs longueur des mots echantillonnes\n",
+      "Etape 1 : reutilisez taux_fiabilite en variant max_len (n_samples=200 fixe)\n",
+      "Etape 2 : affichez le tableau max_len -> taux sur NEEDLE\n",
+      "Etape 3 : expliquez pourquoi max_len < 8 annule la fiabilite\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (variation) : fiabilite vs longueur des mots echantillonnes\n",
+    "# TODO etudiant : pour NEEDLE, la fiabilite depend de max_len (longueur max\n",
+    "# des mots tires par l'oracle d'equivalence).\n",
+    "\n",
+    "# Etape 1 : taux_fiabilite en variant max_len, n_samples=200 fixe, sur NEEDLE\n",
+    "# def taux_fiabilite_maxlen(max_len, n_samples=200, n_seeds=20):\n",
+    "#     corrects = 0\n",
+    "#     for seed in range(n_seeds):\n",
+    "#         eq = make_sampling_eq(NEEDLE.accepts, ALPHABET, n_samples,\n",
+    "#                               max_len=max_len, seed=seed)\n",
+    "#         hyp, _, _ = lstar(ALPHABET, NEEDLE.accepts, eq, verbose=False)\n",
+    "#         if find_counterexample(hyp, NEEDLE, ALPHABET) is None:\n",
+    "#             corrects += 1\n",
+    "#     return corrects / n_seeds\n",
+    "\n",
+    "# Etape 2 : tableau max_len -> taux (20 graines)\n",
+    "# for max_len in [5, 8, 12, 20]:\n",
+    "#     print(f\"  max_len={max_len:>2} : {taux_fiabilite_maxlen(max_len):.0%}\")\n",
+    "\n",
+    "# Etape 3 : pourquoi max_len < len(motif) annule-t-il la fiabilite ?\n",
+    "print(\"Exercice a completer : fiabilite vs longueur des mots echantillonnes\")\n",
+    "print(\"Etape 1 : reutilisez taux_fiabilite en variant max_len (n_samples=200 fixe)\")\n",
+    "print(\"Etape 2 : affichez le tableau max_len -> taux sur NEEDLE\")\n",
+    "print(\"Etape 3 : expliquez pourquoi max_len < 8 annule la fiabilite\")\n",
+    "\n",
+    "# Indice : si aucun mot genere ne peut contenir le motif 'aabbaabb',\n",
+    "# l'oracle ne trouvera JAMAIS de contre-exemple, meme avec n_samples infini.\n",
+    "# result = None  # TODO etudiant : dict {max_len: taux}\n"
    ]
   },
   {
@@ -1270,10 +1421,10 @@
    "id": "sl8-24",
    "metadata": {
     "papermill": {
-     "duration": 0.003947,
-     "end_time": "2026-06-17T01:25:17.359237+00:00",
+     "duration": 0.003863,
+     "end_time": "2026-06-17T01:28:33.391306+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.355290+00:00",
+     "start_time": "2026-06-17T01:28:33.387443+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1286,20 +1437,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "sl8-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.367760Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.367511Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.370929Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.370314Z"
+     "iopub.execute_input": "2026-06-17T01:28:33.400794Z",
+     "iopub.status.busy": "2026-06-17T01:28:33.400568Z",
+     "iopub.status.idle": "2026-06-17T01:28:33.404248Z",
+     "shell.execute_reply": "2026-06-17T01:28:33.403645Z"
     },
     "papermill": {
-     "duration": 0.008533,
-     "end_time": "2026-06-17T01:25:17.371439+00:00",
+     "duration": 0.0096,
+     "end_time": "2026-06-17T01:28:33.404859+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.362906+00:00",
+     "start_time": "2026-06-17T01:28:33.395259+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1333,10 +1484,10 @@
    "id": "sl8-26",
    "metadata": {
     "papermill": {
-     "duration": 0.003353,
-     "end_time": "2026-06-17T01:25:17.378456+00:00",
+     "duration": 0.00411,
+     "end_time": "2026-06-17T01:28:33.412862+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.375103+00:00",
+     "start_time": "2026-06-17T01:28:33.408752+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1348,20 +1499,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "sl8-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T01:25:17.386622Z",
-     "iopub.status.busy": "2026-06-17T01:25:17.386432Z",
-     "iopub.status.idle": "2026-06-17T01:25:17.389664Z",
-     "shell.execute_reply": "2026-06-17T01:25:17.389009Z"
+     "iopub.execute_input": "2026-06-17T01:28:33.421925Z",
+     "iopub.status.busy": "2026-06-17T01:28:33.421736Z",
+     "iopub.status.idle": "2026-06-17T01:28:33.425319Z",
+     "shell.execute_reply": "2026-06-17T01:28:33.424511Z"
     },
     "papermill": {
-     "duration": 0.008106,
-     "end_time": "2026-06-17T01:25:17.390176+00:00",
+     "duration": 0.009001,
+     "end_time": "2026-06-17T01:28:33.425997+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.382070+00:00",
+     "start_time": "2026-06-17T01:28:33.416996+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1396,10 +1547,10 @@
    "id": "sl8-29",
    "metadata": {
     "papermill": {
-     "duration": 0.00338,
-     "end_time": "2026-06-17T01:25:17.397067+00:00",
+     "duration": 0.004082,
+     "end_time": "2026-06-17T01:28:33.434075+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.393687+00:00",
+     "start_time": "2026-06-17T01:28:33.429993+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1456,10 +1607,10 @@
    "id": "sl8-28",
    "metadata": {
     "papermill": {
-     "duration": 0.00329,
-     "end_time": "2026-06-17T01:25:17.403630+00:00",
+     "duration": 0.003957,
+     "end_time": "2026-06-17T01:28:33.443729+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.400340+00:00",
+     "start_time": "2026-06-17T01:28:33.439772+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1487,10 +1638,10 @@
    "id": "sl8-30",
    "metadata": {
     "papermill": {
-     "duration": 0.003471,
-     "end_time": "2026-06-17T01:25:17.411045+00:00",
+     "duration": 0.00415,
+     "end_time": "2026-06-17T01:28:33.452082+00:00",
      "exception": false,
-     "start_time": "2026-06-17T01:25:17.407574+00:00",
+     "start_time": "2026-06-17T01:28:33.447932+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1533,14 +1684,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.428777,
-   "end_time": "2026-06-17T01:25:17.545944+00:00",
+   "duration": 2.768843,
+   "end_time": "2026-06-17T01:28:33.699342+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T01:25:15.117167+00:00",
+   "start_time": "2026-06-17T01:28:30.930499+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-ActiveAutomataLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "sl8-01",
    "metadata": {
     "papermill": {
-     "duration": 0.005216,
-     "end_time": "2026-06-10T11:53:41.348666",
+     "duration": 0.003968,
+     "end_time": "2026-06-17T01:25:17.063673+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.343450",
+     "start_time": "2026-06-17T01:25:17.059705+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "sl8-02",
    "metadata": {
     "papermill": {
-     "duration": 0.004149,
-     "end_time": "2026-06-10T11:53:41.357502",
+     "duration": 0.003041,
+     "end_time": "2026-06-17T01:25:17.071273+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.353353",
+     "start_time": "2026-06-17T01:25:17.068232+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,16 +89,16 @@
    "id": "sl8-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.365310Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.364782Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.390956Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.389835Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.078780Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.078567Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.088527Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.087872Z"
     },
     "papermill": {
-     "duration": 0.030299,
-     "end_time": "2026-06-10T11:53:41.391486",
+     "duration": 0.015159,
+     "end_time": "2026-06-17T01:25:17.089417+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.361187",
+     "start_time": "2026-06-17T01:25:17.074258+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,10 +178,10 @@
    "id": "sl8-04",
    "metadata": {
     "papermill": {
-     "duration": 0.004022,
-     "end_time": "2026-06-10T11:53:41.400206",
+     "duration": 0.003094,
+     "end_time": "2026-06-17T01:25:17.096428+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.396184",
+     "start_time": "2026-06-17T01:25:17.093334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,10 +206,10 @@
    "id": "sl8-05",
    "metadata": {
     "papermill": {
-     "duration": 0.004002,
-     "end_time": "2026-06-10T11:53:41.408729",
+     "duration": 0.00305,
+     "end_time": "2026-06-17T01:25:17.102604+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.404727",
+     "start_time": "2026-06-17T01:25:17.099554+00:00",
      "status": "completed"
     },
     "tags": []
@@ -247,16 +247,16 @@
    "id": "sl8-06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.418789Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.417272Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.437988Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.436907Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.109889Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.109668Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.118412Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.117641Z"
     },
     "papermill": {
-     "duration": 0.025744,
-     "end_time": "2026-06-10T11:53:41.438497",
+     "duration": 0.013673,
+     "end_time": "2026-06-17T01:25:17.119187+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.412753",
+     "start_time": "2026-06-17T01:25:17.105514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "sl8-07",
    "metadata": {
     "papermill": {
-     "duration": 0.002504,
-     "end_time": "2026-06-10T11:53:41.444513",
+     "duration": 0.003674,
+     "end_time": "2026-06-17T01:25:17.126673+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.442009",
+     "start_time": "2026-06-17T01:25:17.122999+00:00",
      "status": "completed"
     },
     "tags": []
@@ -385,10 +385,10 @@
    "id": "sl8-08",
    "metadata": {
     "papermill": {
-     "duration": 0.002661,
-     "end_time": "2026-06-10T11:53:41.449705",
+     "duration": 0.003022,
+     "end_time": "2026-06-17T01:25:17.132927+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.447044",
+     "start_time": "2026-06-17T01:25:17.129905+00:00",
      "status": "completed"
     },
     "tags": []
@@ -423,16 +423,16 @@
    "id": "sl8-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.458835Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.458835Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.468503Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.467911Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.140574Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.140398Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.146866Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.146037Z"
     },
     "papermill": {
-     "duration": 0.01686,
-     "end_time": "2026-06-10T11:53:41.469026",
+     "duration": 0.011378,
+     "end_time": "2026-06-17T01:25:17.147600+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.452166",
+     "start_time": "2026-06-17T01:25:17.136222+00:00",
      "status": "completed"
     },
     "tags": []
@@ -526,10 +526,10 @@
    "id": "sl8-10",
    "metadata": {
     "papermill": {
-     "duration": 0.002575,
-     "end_time": "2026-06-10T11:53:41.474033",
+     "duration": 0.003337,
+     "end_time": "2026-06-17T01:25:17.154425+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.471458",
+     "start_time": "2026-06-17T01:25:17.151088+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,16 +550,16 @@
    "id": "sl8-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.481402Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.481402Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.500329Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.499220Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.162322Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.162041Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.170807Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.170038Z"
     },
     "papermill": {
-     "duration": 0.024439,
-     "end_time": "2026-06-10T11:53:41.501363",
+     "duration": 0.01361,
+     "end_time": "2026-06-17T01:25:17.171450+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.476924",
+     "start_time": "2026-06-17T01:25:17.157840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -626,10 +626,10 @@
    "id": "sl8-12",
    "metadata": {
     "papermill": {
-     "duration": 0.003665,
-     "end_time": "2026-06-10T11:53:41.510252",
+     "duration": 0.003627,
+     "end_time": "2026-06-17T01:25:17.178854+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.506587",
+     "start_time": "2026-06-17T01:25:17.175227+00:00",
      "status": "completed"
     },
     "tags": []
@@ -659,10 +659,10 @@
    "id": "sl8-13",
    "metadata": {
     "papermill": {
-     "duration": 0.003214,
-     "end_time": "2026-06-10T11:53:41.516079",
+     "duration": 0.004161,
+     "end_time": "2026-06-17T01:25:17.186630+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.512865",
+     "start_time": "2026-06-17T01:25:17.182469+00:00",
      "status": "completed"
     },
     "tags": []
@@ -697,16 +697,16 @@
    "id": "sl8-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.526540Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.526014Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.546077Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.544931Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.195620Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.195146Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.203905Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.203111Z"
     },
     "papermill": {
-     "duration": 0.025824,
-     "end_time": "2026-06-10T11:53:41.546589",
+     "duration": 0.014241,
+     "end_time": "2026-06-17T01:25:17.204523+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.520765",
+     "start_time": "2026-06-17T01:25:17.190282+00:00",
      "status": "completed"
     },
     "tags": []
@@ -770,10 +770,10 @@
    "id": "sl8-15",
    "metadata": {
     "papermill": {
-     "duration": 0.004784,
-     "end_time": "2026-06-10T11:53:41.556597",
+     "duration": 0.00376,
+     "end_time": "2026-06-17T01:25:17.212515+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.551813",
+     "start_time": "2026-06-17T01:25:17.208755+00:00",
      "status": "completed"
     },
     "tags": []
@@ -798,10 +798,10 @@
    "id": "sl8-16",
    "metadata": {
     "papermill": {
-     "duration": 0.004695,
-     "end_time": "2026-06-10T11:53:41.566067",
+     "duration": 0.003816,
+     "end_time": "2026-06-17T01:25:17.220167+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.561372",
+     "start_time": "2026-06-17T01:25:17.216351+00:00",
      "status": "completed"
     },
     "tags": []
@@ -832,16 +832,16 @@
    "id": "sl8-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.576609Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.576609Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.622118Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.620993Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.229220Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.228852Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.262527Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.261624Z"
     },
     "papermill": {
-     "duration": 0.051855,
-     "end_time": "2026-06-10T11:53:41.622642",
+     "duration": 0.039337,
+     "end_time": "2026-06-17T01:25:17.263189+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.570787",
+     "start_time": "2026-06-17T01:25:17.223852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,10 +922,10 @@
    "id": "sl8-18",
    "metadata": {
     "papermill": {
-     "duration": 0.003139,
-     "end_time": "2026-06-10T11:53:41.628942",
+     "duration": 0.003781,
+     "end_time": "2026-06-17T01:25:17.270885+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.625803",
+     "start_time": "2026-06-17T01:25:17.267104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,10 +960,10 @@
    "id": "sl8-19",
    "metadata": {
     "papermill": {
-     "duration": 0.002614,
-     "end_time": "2026-06-10T11:53:41.634720",
+     "duration": 0.004058,
+     "end_time": "2026-06-17T01:25:17.278768+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.632106",
+     "start_time": "2026-06-17T01:25:17.274710+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1000,10 +1000,10 @@
    "id": "sl8-20",
    "metadata": {
     "papermill": {
-     "duration": 0.002646,
-     "end_time": "2026-06-10T11:53:41.640017",
+     "duration": 0.003799,
+     "end_time": "2026-06-17T01:25:17.286427+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.637371",
+     "start_time": "2026-06-17T01:25:17.282628+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,16 +1031,16 @@
    "id": "sl8-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.647830Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.647306Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.652053Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.651468Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.295336Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.294954Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.311398Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.310648Z"
     },
     "papermill": {
-     "duration": 0.009991,
-     "end_time": "2026-06-10T11:53:41.652582",
+     "duration": 0.021866,
+     "end_time": "2026-06-17T01:25:17.312027+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.642591",
+     "start_time": "2026-06-17T01:25:17.290161+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1050,23 +1050,157 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "DFA appris : DFA(4 etats, 1 acceptants)\n",
+      "  Conjectures (equivalences) : 2\n",
+      "  |S| = 13, |E| = 3, MQ posees = 55\n",
+      "\n",
+      "Prediction theorique : 4 etats (rien vu / 'a' vu / 'ab' vu / 'abb' vu).\n",
+      "-> observe : 4 etats (confirme).\n",
+      "\n",
+      "       mot | DFA | vrai | OK ?\n",
+      "----------------------------------\n",
+      "     (eps) |   0 |    0 | OK\n",
+      "         a |   0 |    0 | OK\n",
+      "        ab |   0 |    0 | OK\n",
+      "       abb |   1 |    1 | OK\n",
+      "      abbb |   1 |    1 | OK\n",
+      "      babb |   1 |    1 | OK\n",
+      "     aaabb |   1 |    1 | OK\n",
+      "      abab |   0 |    0 | OK\n",
+      "    abbabb |   1 |    1 | OK\n",
+      "     bbabb |   1 |    1 | OK\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 : Apprendre le langage \"contient 'abb' comme facteur\"\n",
-    "# TODO etudiant : faites apprendre par L* le langage des mots qui contiennent\n",
-    "# la sous-chaine \"abb\", SANS construire le DFA cible vous-meme.\n",
-    "# Indice : la requete d'appartenance peut etre une simple fonction Python ;\n",
-    "#          pour l'equivalence, utilisez make_sampling_eq avec n_samples=2000.\n",
-    "# Etape 1 : ecrivez mq_abb(word) (une ligne : l'operateur 'in' suffit)\n",
-    "# Etape 2 : lancez lstar(ALPHABET, mq_abb, make_sampling_eq(mq_abb, ALPHABET, 2000))\n",
-    "# Etape 3 : combien d'etats a le DFA appris ? Expliquez chacun d'eux\n",
-    "#           (prediction theorique : 4 -- rien vu, 'a' vu, 'ab' vu, 'abb' vu)\n",
-    "# Etape 4 : verifiez le DFA sur 10 mots de votre choix\n",
+    "# Exemple guide 1 : Apprendre le langage \"contient 'abb' comme facteur\"\n",
+    "#\n",
+    "# On apprend par L* le langage des mots (sur {a, b}) qui contiennent la\n",
+    "# sous-chaine \"abb\", SANS construire le DFA cible : l'apprenant n'a acces\n",
+    "# qu'a la requete d'appartenance (l'operateur 'in') et a un oracle\n",
+    "# d'equivalence par echantillonnage.\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : requete d'appartenance -- une ligne suffit ('abb' in word)\n",
+    "def mq_abb(word: str) -> bool:\n",
+    "    return \"abb\" in word\n",
+    "\n",
+    "# Etape 2 : lancer L* avec un oracle d'equivalence par echantillonnage\n",
+    "learned, final_table, n_eq = lstar(\n",
+    "    ALPHABET, mq_abb, make_sampling_eq(mq_abb, ALPHABET, 2000), verbose=False\n",
+    ")\n",
+    "\n",
+    "print(f\"DFA appris : {learned}\")\n",
+    "print(f\"  Conjectures (equivalences) : {n_eq}\")\n",
+    "print(f\"  |S| = {len(final_table.S)}, |E| = {len(final_table.E)}, \"\n",
+    "      f\"MQ posees = {final_table.n_mq}\")\n",
+    "\n",
+    "# Etape 3 : interpretation des etats (prediction theorique : 4 etats)\n",
+    "#   - \"rien vu\"  : aucune amorce du motif\n",
+    "#   - \"'a' vu\"   : un 'a' isole, pas encore suivi de 'bb'\n",
+    "#   - \"'ab' vu\"  : debut du motif, il manque encore un 'b'\n",
+    "#   - \"'abb' vu\" : motif trouve, etat absorbant acceptant\n",
+    "print()\n",
+    "print(\"Prediction theorique : 4 etats (rien vu / 'a' vu / 'ab' vu / 'abb' vu).\")\n",
+    "print(f\"-> observe : {len(learned.states)} etats \"\n",
+    "      f\"({'confirme' if len(learned.states) == 4 else 'a commenter'}).\")\n",
+    "\n",
+    "# Etape 4 : verification sur 10 mots\n",
+    "test_words = [\"\", \"a\", \"ab\", \"abb\", \"abbb\", \"babb\", \"aaabb\",\n",
+    "              \"abab\", \"abbabb\", \"bbabb\"]\n",
+    "print()\n",
+    "print(f\"{'mot':>10} | DFA | vrai | OK ?\")\n",
+    "print(\"-\" * 34)\n",
+    "for w in test_words:\n",
+    "    pred = learned.accepts(w)\n",
+    "    vrai = \"abb\" in w\n",
+    "    print(f\"{w or '(eps)':>10} | {int(pred):>3} | {int(vrai):>4} | \"\n",
+    "          f\"{'OK' if pred == vrai else 'ECHEC'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl8ex1var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003742,
+     "end_time": "2026-06-17T01:25:17.319519+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:25:17.315777+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 (variation) : Apprendre un autre langage-facteur\n",
+    "\n",
+    "Reprenez la methode de l'exemple guide pour apprendre par L* le langage des mots (sur {a, b}) qui contiennent la sous-chaine **\"ba\"** (au lieu de \"abb\"). Combien d'etats le DFA minimal comporte-t-il, et pourquoi ?\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Ecrire `mq_ba(word)` : appartenance au langage \"contient 'ba' comme facteur\"\n",
+    "2. Lancer L* avec `make_sampling_eq(mq_ba, ALPHABET, 2000)`\n",
+    "3. Donner le nombre d'etats du DFA appris et expliquer chacun (prediction theorique : 3 etats)\n",
+    "4. Verifier sur 8 mots de votre choix\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "sl8ex1var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T01:25:17.328036Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.327714Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.331799Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.331084Z"
+    },
+    "papermill": {
+     "duration": 0.00934,
+     "end_time": "2026-06-17T01:25:17.332460+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T01:25:17.323120+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : apprenez le langage 'contient ba' par L*\n",
+      "Etape 1 : ecrivez mq_ba(word) avec l'operateur 'in'\n",
+      "Etape 2 : lancez lstar(ALPHABET, mq_ba, make_sampling_eq(..., 2000))\n",
+      "Etape 3 : donnez le nombre d'etats et expliquez chacun\n",
+      "Etape 4 : verifiez sur 8 mots\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (variation) : apprendre le langage \"contient 'ba' comme facteur\"\n",
+    "# TODO etudiant : reprenez l'exemple guide ci-dessus avec le motif \"ba\".\n",
+    "\n",
+    "# Etape 1 : requete d'appartenance au langage \"contient 'ba'\"\n",
+    "# def mq_ba(word: str) -> bool:\n",
+    "#     return ...  # TODO etudiant : une ligne avec l'operateur 'in'\n",
+    "\n",
+    "# Etape 2 : lancer L* avec un oracle d'equivalence par echantillonnage\n",
+    "# learned_ba, table_ba, n_eq_ba = lstar(ALPHABET, mq_ba,\n",
+    "#                                        make_sampling_eq(mq_ba, ALPHABET, 2000),\n",
+    "#                                        verbose=False)\n",
+    "\n",
+    "# Etape 3 : nombre d'etats et interpretation (prediction : 3 etats)\n",
+    "# print(f\"DFA appris : {learned_ba} ({n_eq_ba} equivalences)\")\n",
+    "\n",
+    "# Etape 4 : verification sur 8 mots\n",
+    "print(\"Exercice a completer : apprenez le langage 'contient ba' par L*\")\n",
+    "print(\"Etape 1 : ecrivez mq_ba(word) avec l'operateur 'in'\")\n",
+    "print(\"Etape 2 : lancez lstar(ALPHABET, mq_ba, make_sampling_eq(..., 2000))\")\n",
+    "print(\"Etape 3 : donnez le nombre d'etats et expliquez chacun\")\n",
+    "print(\"Etape 4 : verifiez sur 8 mots\")\n",
+    "\n",
+    "# Indice : le motif \"ba\" est plus court que \"abb\" -> moins d'etats \"amorce\".\n",
+    "# result = None  # TODO etudiant : le DFA appris (learned_ba)\n"
    ]
   },
   {
@@ -1074,10 +1208,10 @@
    "id": "sl8-22",
    "metadata": {
     "papermill": {
-     "duration": 0.004676,
-     "end_time": "2026-06-10T11:53:41.662437",
+     "duration": 0.003419,
+     "end_time": "2026-06-17T01:25:17.339680+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.657761",
+     "start_time": "2026-06-17T01:25:17.336261+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1090,20 +1224,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "sl8-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.670811Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.670301Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.684028Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.682949Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.347704Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.347512Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.350979Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.350293Z"
     },
     "papermill": {
-     "duration": 0.017447,
-     "end_time": "2026-06-10T11:53:41.684028",
+     "duration": 0.008528,
+     "end_time": "2026-06-17T01:25:17.351556+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.666581",
+     "start_time": "2026-06-17T01:25:17.343028+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1136,10 +1270,10 @@
    "id": "sl8-24",
    "metadata": {
     "papermill": {
-     "duration": 0.00453,
-     "end_time": "2026-06-10T11:53:41.695102",
+     "duration": 0.003947,
+     "end_time": "2026-06-17T01:25:17.359237+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.690572",
+     "start_time": "2026-06-17T01:25:17.355290+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1152,20 +1286,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "sl8-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.703377Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.702372Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.713792Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.713228Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.367760Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.367511Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.370929Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.370314Z"
     },
     "papermill": {
-     "duration": 0.016676,
-     "end_time": "2026-06-10T11:53:41.714796",
+     "duration": 0.008533,
+     "end_time": "2026-06-17T01:25:17.371439+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.698120",
+     "start_time": "2026-06-17T01:25:17.362906+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1199,10 +1333,10 @@
    "id": "sl8-26",
    "metadata": {
     "papermill": {
-     "duration": 0.003012,
-     "end_time": "2026-06-10T11:53:41.721808",
+     "duration": 0.003353,
+     "end_time": "2026-06-17T01:25:17.378456+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.718796",
+     "start_time": "2026-06-17T01:25:17.375103+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1214,20 +1348,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "sl8-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T11:53:41.728334Z",
-     "iopub.status.busy": "2026-06-10T11:53:41.728334Z",
-     "iopub.status.idle": "2026-06-10T11:53:41.744900Z",
-     "shell.execute_reply": "2026-06-10T11:53:41.744900Z"
+     "iopub.execute_input": "2026-06-17T01:25:17.386622Z",
+     "iopub.status.busy": "2026-06-17T01:25:17.386432Z",
+     "iopub.status.idle": "2026-06-17T01:25:17.389664Z",
+     "shell.execute_reply": "2026-06-17T01:25:17.389009Z"
     },
     "papermill": {
-     "duration": 0.02309,
-     "end_time": "2026-06-10T11:53:41.746406",
+     "duration": 0.008106,
+     "end_time": "2026-06-17T01:25:17.390176+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.723316",
+     "start_time": "2026-06-17T01:25:17.382070+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1262,10 +1396,10 @@
    "id": "sl8-29",
    "metadata": {
     "papermill": {
-     "duration": 0.002592,
-     "end_time": "2026-06-10T11:53:41.759382",
+     "duration": 0.00338,
+     "end_time": "2026-06-17T01:25:17.397067+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.756790",
+     "start_time": "2026-06-17T01:25:17.393687+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1322,10 +1456,10 @@
    "id": "sl8-28",
    "metadata": {
     "papermill": {
-     "duration": 0.00262,
-     "end_time": "2026-06-10T11:53:41.753654",
+     "duration": 0.00329,
+     "end_time": "2026-06-17T01:25:17.403630+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.751034",
+     "start_time": "2026-06-17T01:25:17.400340+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1353,10 +1487,10 @@
    "id": "sl8-30",
    "metadata": {
     "papermill": {
-     "duration": 0.003016,
-     "end_time": "2026-06-10T11:53:41.764954",
+     "duration": 0.003471,
+     "end_time": "2026-06-17T01:25:17.411045+00:00",
      "exception": false,
-     "start_time": "2026-06-10T11:53:41.761938",
+     "start_time": "2026-06-17T01:25:17.407574+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1395,18 +1529,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.436989,
-   "end_time": "2026-06-10T11:53:45.159511",
+   "duration": 2.428777,
+   "end_time": "2026-06-17T01:25:17.545944+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SL-8-ActiveAutomataLearning.ipynb",
-   "output_path": "SL-8-ActiveAutomataLearning.ipynb",
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-8-ActiveAutomataLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T11:53:39.722522",
+   "start_time": "2026-06-17T01:25:15.117167+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
> **PR empilee (stacked)** : base = `feat/sl8-ex3-guided` (#3181). Ordre de merge : #3179 -> #3180 -> #3181 -> celle-ci. **Complete SL-8** (les 4 exercices resolus en exemples guides + variations).

## Livrable

**Ex4 resolu en exemple guide** (oracle d'appartenance bruite) :
- `make_noisy_mq(true_mq, p, seed)` : ment avec probabilite p, **deterministe par mot** (memoisation de la premiere reponse).
- `lstar_bounded(..., max_rounds=8, max_steps=60)` : L* borne. **Ne conjecture que sur une table fermee ET consistante** (sinon retourne non-stabilise) -- evite le crash ou `conjecture` tournait sur une table non-fermee et produisait un DFA a transitions manquantes.

**Nouvel exercice en variation** : robustesse par **vote majoritaire** (K requetes par mot, on garde la majorite). L'etudiant implemente `make_robust_mq` et montre que L* retrouve le DFA exact. C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`--kernel python3`) : **SUCCESS** 5.1s, 1/1 notebooks, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 14 cellules code, `execution_count` set + outputs + 0 erreur.
- **Sortie Ex4** : p=0.05 -> 4 etats EXACT ; **p=0.01 -> 50 etats, ecart** ; p=0.20 -> 4 etats EXACT.

## Lecture honnete (NON monotone en p -- corrige apres la premiere version)

Le resultat **depend de quels mots sont mentis**, pas seulement de `p`. Ici le cas le moins bruite (p=0.01) a ete le **plus catastrophique** (explosion a 50 etats), alors que p=0.05 et p=0.20 retombent par chance sur la cible. Avec une autre graine, l'issue serait differente.

**Lecon centrale** : un apprenant **EXACT** comme L* n'a **aucune degradation gracieuse** face au bruit -- son comportement est **path-dependent** (un seul mensonge memorise cree un etat-fantome de Myhill-Nerode permanent), la ou un classifieur statistique se degrade **smoothment** avec `p`. C'est le prix de la garantie d'exactitude.

> Note reviewer : la non-monotonicite p=0.01 > p=0.20 est **intentionnelle et documentee** (path-dependence = la lecon). Ne PAS interpreter comme un bug.

## Anti-regression (verifie vs `feat/sl8-ex3-guided`)

- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- Source code +121 lignes (stub Ex4 -> `make_noisy_mq` + `lstar_bounded` + runs + stub variation). Commentaire Ex4 relicole.
- 1 fichier `.ipynb` (SL-8). Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
