### PR TITLE
fix(genai-video): correct LTX-2 Section 2b unverified claims (auth works, real GGUF repos, verified nodes) (See #2891)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb
@@ -74,30 +74,12 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "ltx2-01",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-16T21:04:44.308822Z",
-     "iopub.status.busy": "2026-06-16T21:04:44.308562Z",
-     "iopub.status.idle": "2026-06-16T21:04:44.316822Z",
-     "shell.execute_reply": "2026-06-16T21:04:44.316232Z"
-    },
-    "papermill": {
-     "duration": 0.012879,
-     "end_time": "2026-06-16T21:04:44.317845",
-     "exception": false,
-     "start_time": "2026-06-16T21:04:44.304966",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "LTX-2 Audiovisual | runtime=comfyui_gguf | quant=fp8-cast\n",
-      "  97f @ 768x512 | audio=True | run_generation=False\n"
-     ]
+     "name": "stdout",
+     "text": "LTX-2 Audiovisual | runtime=comfyui_gguf | quant=fp8-cast\n  97f @ 768x512 | audio=True | run_generation=False\n"
     }
    ],
    "source": [
@@ -146,8 +128,10 @@
     "comfyui_host = \"http://127.0.0.1:8189\"   # comfyui-video (GPU 3090), derriere ComfyUI-Login\n",
     "\n",
     "# Configuration\n",
-    "run_generation = False             # Safety : la generation GPU requiert Gemma (gated) pour ltx_pipelines,\n",
-    "                                   # ou l'auth ComfyUI (bcrypt) pour comfyui_gguf. Cf Section dediee.\n",
+    "run_generation = False             # Safety : passer a True apres avoir (a) telecharge les modeles GGUF\n",
+    "                                   # (cf tableau Section 2b) et (b) valide le wiring du workflow contre\n",
+    "                                   # /object_info. L'auth ComfyUI-Login FONCTIONNE (COMFYUI_PASSWORD +\n",
+    "                                   # restart) ; le verrou est la presence des modeles, PAS l'auth.\n",
     "save_as_mp4 = True\n",
     "save_results = True\n",
     "\n",
@@ -772,17 +756,25 @@
     "\n",
     "Le format GGUF (GPT-Generated Unified Format) packe les poids en 4-bit avec une table de descente (de-quantization a la volee). Le node `UnetLoaderGGUF` (custom node `ComfyUI-GGUF` de city96) charge ce format directement dans ComfyUI. Combine au text encoder Gemma lui-meme en GGUF (`unsloth/gemma-3-12b-it-qat-GGUF`, NON gated), l'ensemble tient largement sur une RTX 3090 — c'est la configuration standard des amateurs.\n",
     "\n",
-    "### Set de modeles (deja telecharge dans le bind-mount comfyui-video)\n",
+    "### Set de modeles (a telecharger dans le bind-mount shared/models)\n",
     "\n",
-    "| Role | Fichier | Repertoire ComfyUI |\n",
-    "|------|---------|--------------------|\n",
-    "| Transformer 22B (Q4) | `ltx-2.3-22b-dev-Q4_K_M.gguf` | `models/unet/` |\n",
-    "| VAE video | `ltx-2.3-22b-dev_video_vae.safetensors` | `models/vae/` |\n",
-    "| VAE audio | `ltx-2.3-22b-dev_audio_vae.safetensors` | `models/vae/` |\n",
-    "| Text encoder Gemma (Q4) | `gemma-3-12b-it-qat-UD-Q4_K_XL.gguf` | `models/text_encoders/` |\n",
-    "| Projection Gemma | `mmproj-BF16.gguf` | `models/text_encoders/` |\n",
-    "| LoRA distillee | `ltx-2.3-22b-distilled-lora-384.safetensors` | `models/loras/` |\n",
-    "| Upsampler spatial x2 | `ltx-2.3-spatial-upscaler-x2-1.0.safetensors` | `models/latent_upscale_models/` |\n",
+    "Sources verifiees contre l'API HuggingFace (17/06). Les VAE et connecteurs sont dans\n",
+    "`unsloth/LTX-2.3-GGUF` (sous-repertoires `vae/` et `text_encoders/`), PAS dans\n",
+    "`Lightricks/LTX-2.3` (qui ne contient que checkpoints + LoRA + upscalers).\n",
+    "\n",
+    "| Role | Fichier | Repo HF | Repertoire ComfyUI |\n",
+    "|------|---------|---------|--------------------|\n",
+    "| Transformer 22B (Q4) | `ltx-2.3-22b-dev-Q4_K_M.gguf` | `unsloth/LTX-2.3-GGUF` | `models/unet/` |\n",
+    "| VAE video | `ltx-2.3-22b-dev_video_vae.safetensors` | `unsloth/LTX-2.3-GGUF` (`vae/`) | `models/vae/` |\n",
+    "| VAE audio | `ltx-2.3-22b-dev_audio_vae.safetensors` | `unsloth/LTX-2.3-GGUF` (`vae/`) | `models/vae/` |\n",
+    "| Connecteurs embeddings | `ltx-2.3-22b-dev_embeddings_connectors.safetensors` | `unsloth/LTX-2.3-GGUF` (`text_encoders/`) | `models/text_encoders/` |\n",
+    "| Text encoder Gemma (Q4, NON gated) | `gemma-3-12b-it-qat-UD-Q4_K_XL.gguf` | `unsloth/gemma-3-12b-it-qat-GGUF` | `models/text_encoders/` |\n",
+    "| LoRA distillee | `ltx-2.3-22b-distilled-lora-384.safetensors` | `Lightricks/LTX-2.3` | `models/loras/` |\n",
+    "| Upsampler spatial x2 (optionnel) | `ltx-2.3-spatial-upscaler-x2-1.0.safetensors` | `Lightricks/LTX-2.3` | `models/latent_upscale_models/` |\n",
+    "\n",
+    "NB : `mmproj-BF16.gguf` (present dans `models/clip/`) sert aux modeles de vision (Gemma-VL/Qwen-VL),\n",
+    "il n'est PAS utilise par LTX-2 : le chargeur natif `LTXAVTextEncoderLoader` prend directement le\n",
+    "Gemma GGUF + les connecteurs d'embeddings.\n",
     "\n",
     "### Graphe de nodes ComfyUI (audio+video conjoint)\n",
     "\n",
@@ -790,7 +782,7 @@
     "\n",
     "```\n",
     "UnetLoaderGGUF ──MODEL──┐\n",
-    "DualCLIPLoaderGGUF ─CLIP─► CLIPTextEncode(+) ──COND+──┐\n",
+    "LTXAVTextEncoderLoader ─CLIP─► CLIPTextEncode(+) ──COND+──┐\n",
     "                        └─CLIPTextEncode(-) ──COND-──┤\n",
     "EmptyLTXVLatentVideo(704x512x121) ──LATENT_V──┐       │\n",
     "LTXVEmptyLatentAudio ───────────── LATENT_A──┤       │\n",
@@ -801,42 +793,21 @@
     "\n",
     "Parametres validates (workflow RuneXX T2V_Basic, communautaire) : 704x512, 121 frames (~5s a 24fps), LoRA distillee a 0.6, CFG ~1 (path distille), scheduler LTXV 8 steps, euler_ancestral_cfg_pp.\n",
     "\n",
-    "### Bloqueur d'execution actuel (auth ComfyUI-Login)\n",
+    "### Authentification ComfyUI-Login (VERIFIEE fonctionnelle)\n",
     "\n",
-    "L'endpoint `comfyui-video` (port 8189, GPU 3090) est protege par **ComfyUI-Login** (bcrypt + session cookie chiffre). Un incident de **drift bcrypt** (le hash stocke ne matche ni `COMFYUI_PASSWORD` ni le token .env — cf memoire `genai_services_reminder`) bloque actuellement l'appel API programmatique. Debloquer requiert soit le mot de passe originel, soit un reset temporaire du hash (reversible). La cellule ci-dessous implemente l'appel API complet (workflow + polling + recuperation MP4) ; il s'executera des que l'auth sera levee.\n"
+    "L'endpoint `comfyui-video` (port 8189, GPU 3090) est protege par **ComfyUI-Login** (bcrypt + session cookie chiffre). L'auth **FONCTIONNE** : `POST /login` (form `password` = `COMFYUI_PASSWORD`) renvoie un cookie de session, verifie `bcrypt.checkpw(.env_password, hash) == True` + HTTP 302. Le piege (qui avait fait croire a tort a un \"drift / cle perdue\") : ComfyUI-Login regenere le hash bcrypt depuis `COMFYUI_PASSWORD` (env) **uniquement au restart du container**, pas a chaud — un `.env` modifie sans `docker compose restart` laisse un hash stale en RAM. Regle : apres tout changement de `COMFYUI_PASSWORD`, restart le container. La centralisation des secrets (`.secrets/master.env` + `render_envs.py` + le self-check entrypoint, PR #3160) rend ce drift desormais visible dans les logs. **Le verrou restant pour la generation n'est PAS l'auth : c'est la presence des modeles GGUF** (cf tableau ci-dessus, download requis).\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
    "id": "f16f29a5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-16T21:06:03.783371Z",
-     "iopub.status.busy": "2026-06-16T21:06:03.782863Z",
-     "iopub.status.idle": "2026-06-16T21:06:03.793851Z",
-     "shell.execute_reply": "2026-06-16T21:06:03.793039Z"
-    },
-    "papermill": {
-     "duration": 0.016268,
-     "end_time": "2026-06-16T21:06:03.794831",
-     "exception": false,
-     "start_time": "2026-06-16T21:06:03.778563",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Generation ComfyUI+GGUF : graphe pret, execution bloquee par l'auth ComfyUI-Login.\n",
-      "  - Workflow : 19 nodes (GGUF loaders + LTXV A/V concat/sep + VHS_VideoCombine)\n",
-      "  - Params : 704x512x121, distilled LoRA 0.6, CFG 1.0, 8 steps euler_ancestral_cfg_pp\n",
-      "  - Bloqueur : drift bcrypt ComfyUI-Login (hash != .env) => reset temporaire requis.\n",
-      "  Debloquer COMFYUI_PASSWORD (ou reset hash) puis runtime_path='comfyui_gguf' + run_generation=True.\n"
-     ]
+     "name": "stdout",
+     "text": "Generation ComfyUI+GGUF : graphe pret, execution desactivee (run_generation=False).\n  - Workflow : nodes verifies presents via /object_info (LTXAVTextEncoderLoader,\n    LTXVAudioVAELoader, LTXVConcat/SeparateAVLatent, VHS_VideoCombine).\n  - Params : 704x512x121, distilled LoRA 0.6, CFG 1.0, 8 steps euler_ancestral_cfg_pp.\n  - Auth : FONCTIONNE. Le verrou = presence des modeles GGUF (tableau Section 2b).\n  Activer : telecharger les modeles + valider le wiring empiriquement + run_generation=True.\n"
     }
    ],
    "source": [
@@ -851,7 +822,8 @@
     "# Noms de fichiers GGUF dans le bind-mount comfyui-video (cf tableau section precedente).\n",
     "GGUF_MODEL = \"ltx-2.3-22b-dev-Q4_K_M.gguf\"\n",
     "GGUF_GEMMA = \"gemma-3-12b-it-qat-UD-Q4_K_XL.gguf\"\n",
-    "GGUF_MMPROJ = \"mmproj-BF16.gguf\"\n",
+    "GEMMA = \"gemma-3-12b-it-qat-UD-Q4_K_XL.gguf\"\n",
+    "CONNECTORS = \"ltx-2.3-22b-dev_embeddings_connectors.safetensors\"\n",
     "VAE_VIDEO = \"ltx-2.3-22b-dev_video_vae.safetensors\"\n",
     "VAE_AUDIO = \"ltx-2.3-22b-dev_audio_vae.safetensors\"\n",
     "DISTILLED_LORA = \"ltx-2.3-22b-distilled-lora-384.safetensors\"\n",
@@ -868,12 +840,13 @@
     "    Structure : GGUF loaders -> encode -> latent A/V concat -> sample -> separate -> decode A/V.\n",
     "    Les cles \"inputs\"/\"class_type\" suivent la convention API ComfyUI.\n",
     "    '''\n",
-    "    # TODO (post-auth) : valider chaque socket contre GET /object_info/<node>.\n",
+    "    # TODO (post-download) : valider chaque socket + les valeurs COMBO (text_encoder/device)\n",
+    "    # contre GET /object_info/LTXAVTextEncoderLoader une fois les modeles GGUF presents.\n",
     "    # Structure de reference (workflow minimal, params RuneXX T2V_Basic).\n",
     "    return {\n",
     "        \"10\": {\"class_type\": \"UnetLoaderGGUF\", \"inputs\": {\"unet_name\": GGUF_MODEL}},\n",
-    "        \"11\": {\"class_type\": \"DualCLIPLoaderGGUF\",\n",
-    "               \"inputs\": {\"clip_name1\": GGUF_GEMMA, \"clip_name2\": GGUF_MMPROJ, \"type\": \"sdxl\"}},\n",
+    "        \"11\": {\"class_type\": \"LTXAVTextEncoderLoader\",\n",
+    "               \"inputs\": {\"text_encoder\": GEMMA, \"ckpt_name\": CONNECTORS, \"device\": \"default\"}},\n",
     "        \"12\": {\"class_type\": \"LoraLoaderModelOnly\",\n",
     "               \"inputs\": {\"model\": [\"10\", 0], \"lora_name\": DISTILLED_LORA, \"strength_model\": 0.6}},\n",
     "        \"20\": {\"class_type\": \"CLIPTextEncode\", \"inputs\": {\"clip\": [\"11\", 0], \"text\": prompt}},\n",
@@ -894,7 +867,7 @@
     "        \"50\": {\"class_type\": \"LTXVSeparateAVLatent\", \"inputs\": {\"av_latent\": [\"43\", 0]}},\n",
     "        \"60\": {\"class_type\": \"VAELoader\", \"inputs\": {\"vae_name\": VAE_VIDEO}},\n",
     "        \"61\": {\"class_type\": \"VAEDecodeTiled\", \"inputs\": {\"samples\": [\"50\", 0], \"vae\": [\"60\", 0]}},\n",
-    "        \"70\": {\"class_type\": \"VAELoader\", \"inputs\": {\"vae_name\": VAE_AUDIO}},\n",
+    "        \"70\": {\"class_type\": \"LTXVAudioVAELoader\", \"inputs\": {\"ckpt_name\": VAE_AUDIO}},\n",
     "        \"71\": {\"class_type\": \"LTXVAudioVAEDecode\", \"inputs\": {\"audio_latent\": [\"50\", 1], \"vae\": [\"70\", 0]}},\n",
     "        \"90\": {\"class_type\": \"VHS_VideoCombine\",\n",
     "               \"inputs\": {\"images\": [\"61\", 0], \"audio\": [\"71\", 0], \"frame_rate\": 24,\n",
@@ -925,16 +898,19 @@
     "        print(\"(polling /history puis recuperation MP4 via /view ...)\")\n",
     "        # TODO (post-auth) : poll /history/{prompt_id} jusqu'a completion, GET /view du MP4.\n",
     "    except urllib.error.HTTPError as e:\n",
-    "        print(f\"ECHEC auth ComfyUI (HTTP {e.code}) : drift bcrypt — le mot de passe .env ne\")\n",
-    "        print(\"matche pas le hash stocke. Deblocage = reset temporaire du hash (reversible).\")\n",
+    "        print(f\"ECHEC ComfyUI (HTTP {e.code}). L'auth est normalement fonctionnelle ; si 401,\")\n",
+    "        print(\"verifier que le container a ete restart APRES tout changement de COMFYUI_PASSWORD\")\n",
+    "        print(\"(le hash bcrypt est regenere au restart seulement, cf Section 2b ci-dessus).\")\n",
     "    except Exception as e:\n",
     "        print(f\"ECHEC : {type(e).__name__}: {str(e)[:200]}\")\n",
     "else:\n",
-    "    print(\"Generation ComfyUI+GGUF : graphe pret, execution bloquee par l'auth ComfyUI-Login.\")\n",
-    "    print(\"  - Workflow : 19 nodes (GGUF loaders + LTXV A/V concat/sep + VHS_VideoCombine)\")\n",
-    "    print(\"  - Params : 704x512x121, distilled LoRA 0.6, CFG 1.0, 8 steps euler_ancestral_cfg_pp\")\n",
-    "    print(\"  - Bloqueur : drift bcrypt ComfyUI-Login (hash != .env) => reset temporaire requis.\")\n",
-    "    print(\"  Debloquer COMFYUI_PASSWORD (ou reset hash) puis runtime_path='comfyui_gguf' + run_generation=True.\")\n"
+    "    print(\"Generation ComfyUI+GGUF : graphe pret, execution desactivee (run_generation=False).\")\n",
+    "    print(\"  - Workflow : nodes verifies presents via /object_info (LTXAVTextEncoderLoader,\")\n",
+    "    print(\"    LTXVAudioVAELoader, LTXVConcat/SeparateAVLatent, VHS_VideoCombine).\")\n",
+    "    print(\"  - Params : 704x512x121, distilled LoRA 0.6, CFG 1.0, 8 steps euler_ancestral_cfg_pp.\")\n",
+    "    print(\"  - Auth : FONCTIONNE. Le verrou = presence des modeles GGUF (tableau Section 2b).\")\n",
+    "    print(\"  Activer : telecharger les modeles + valider le wiring empiriquement + run_generation=True.\")\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Summary

Corrects **unverified / false claims** in the LTX-2 ComfyUI+GGUF Section 2b that shipped (merged) in #3150. All corrections verified against ground truth on 17/06: HuggingFace API + ComfyUI `GET /object_info` on the live `comfyui-video` container.

This is the G.1 follow-up: #3150 documented a workflow + model set + blocker without fully verifying them. This PR fixes the verified-wrong parts and reframes the honest state.

## Corrections (all verified)

### 1. Auth was never broken ("drift bcrypt / cle perdue" was a false diagnostic)
- **Claim in #3150**: ComfyUI-Login drift bcrypt blocks programmatic API access; needs password or hash reset.
- **Ground truth**: `POST /login` with `COMFYUI_PASSWORD` -> `bcrypt.checkpw(.env_password, hash) == True` + HTTP 302. **Auth works.** ComfyUI-Login regenerates the bcrypt hash from the env only at container **restart** (not hot) -- a `.env` changed without `docker compose restart` reads as stale. The key was never lost (root-caused + structurally fixed in #3160). Markdown + code error messages updated.

### 2. "Modeles deja telecharges" was false
- **Claim**: GGUF set already in the bind-mount.
- **Ground truth**: `models/unet|vae|clip` empty -- nothing downloaded. Table reframed to "a telecharger" with exact HF repo + path. Verified VAEs + connectors live in **`unsloth/LTX-2.3-GGUF`** (`vae/`, `text_encoders/`), **not** `Lightricks/LTX-2.3` (checkpoints + LoRA + upscalers only). Added the missing `embeddings_connectors`. Flagged `mmproj-BF16.gguf` (in `clip/`) as vision-only, not LTX-2.

### 3. Workflow nodes corrected (verified via `/object_info`)
- `DualCLIPLoaderGGUF` + `mmproj` (SDXL/VLM pattern) -> **`LTXAVTextEncoderLoader`** (native LTX-2, verified `outputs: CLIP` -> `CLIPTextEncode.clip`).
- `VAELoader` -> **`LTXVAudioVAELoader`** (verified `outputs: VAE` -> `LTXVAudioVAEDecode.audio_vae`).
- All A/V nodes (`LTXVConcatAVLatent`, `LTXVSeparateAVLatent`, `LTXVEmptyLatentAudio`, `LTXVAudioVAEDecode`, `EmptyLTXVLatentVideo`, `LTXVScheduler`, `UnetLoaderGGUF`) confirmed present (1097 node classes, 23 LTX* nodes).

## Validation
- `nbformat.validate` OK (v4, 23 cells).
- Cells 2 + 12 **re-executed** (run_generation=False safe path), outputs refreshed, 0 error. Per-cell output comparison vs `origin/main`: only cell 12's output changed (intended); all other cells' outputs preserved (C.2 respected).
- The actual generation (run_generation=True) remains gated -- it requires the GGUF models, which are **downloading now** (~24GB, the verified set). TODO flag in code marks the empirical COMBO-value validation + real MP4 as the next step.

## Honest state (G.3)
This PR is **not** "LTX-2 generation works". It is: "the ComfyUI+GGUF audio-video path is **verified real** (files exist on HF, nodes exist in the container, auth works), the notebook now documents it accurately, and the model download is in flight." Real MP4 = next.

See #2891 (partial).

Generated with [Claude Code](https://claude.com/claude-code)
