### PR TITLE
fix(search): reconcile MGS-1..4 #r to net8.0 (pinned dotnet-interactive kernel)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-1-Introduction.ipynb
@@ -85,7 +85,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-10528.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -130,12 +130,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '358064.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '10528.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -235,10 +235,10 @@
     "// Wiring: load MetaGeneticSharp + GeneticSharp DLLs from submodule build\n",
     "// Build prerequisite: dotnet build from c:/dev/MetaGeneticSharp\n",
     "// Requires: git submodule update --init GeneticSharp (nested submodule)\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Domain.dll\"\n",
     "\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
@@ -382,21 +382,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Meilleur chromosome : [0,0000, -4,0000, 3,0000, 1,0000]\r\n"
+      "  Meilleur chromosome : [-1,0000, -4,0000, 1,0000, 5,0000]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Fitness (inverted)  : 0,037037\r\n"
+      "  Fitness (inverted)  : 0,022727\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Objectif f(x)=sum(x^2) : 26,000000\r\n"
+      "  Objectif f(x)=sum(x^2) : 43,000000\r\n"
      ]
     },
     {
@@ -410,7 +410,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps total          : 153 ms\r\n"
+      "  Temps total          : 342 ms\r\n"
      ]
     }
    ],
@@ -547,21 +547,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0,3      20,400000    9,000000     34,000000    7,964923    \r\n"
+      "0,3      19,000000    2,000000     31,000000    10,770330   \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0,75     15,800000    6,000000     26,000000    6,462198    \r\n"
+      "0,75     18,200000    4,000000     35,000000    11,889491   \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0,95     19,200000    2,000000     47,000000    15,315352   \r\n"
+      "0,95     25,200000    10,000000    53,000000    16,630093   \r\n"
      ]
     },
     {
@@ -716,56 +716,56 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1        21,000000           \r\n"
+      "1        10,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5        21,000000           \r\n"
+      "5        10,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10       21,000000           \r\n"
+      "10       10,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "15       21,000000           \r\n"
+      "15       10,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "20       21,000000           \r\n"
+      "20       10,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "25       21,000000           \r\n"
+      "25       10,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "30       21,000000           \r\n"
+      "30       10,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "30       21,000000           \r\n"
+      "30       10,000000           \r\n"
      ]
     },
     {
@@ -779,7 +779,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Convergence finale : f(x) = 21,000000\r\n"
+      "Convergence finale : f(x) = 10,000000\r\n"
      ]
     },
     {
@@ -917,14 +917,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DefaultMetaHeuristic      42,000000       0,023256        [1,0000, -2,0000, ...]\r\n"
+      "DefaultMetaHeuristic      28,000000       0,034483        [1,0000, 1,0000, ...]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "NoOpMetaHeuristic         17,000000       0,055556        [2,0000, 2,0000, ...]\r\n"
+      "NoOpMetaHeuristic         21,000000       0,045455        [0,0000, -1,0000, ...]\r\n"
      ]
     },
     {

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-2-Composition.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-2-Composition.ipynb
@@ -76,7 +76,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-28796.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -121,12 +121,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '389868.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '28796.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -240,10 +240,10 @@
     "// Wiring: load MetaGeneticSharp + GeneticSharp DLLs from submodule build\n",
     "// Build prerequisite: dotnet build c:/dev/MetaGeneticSharp/MetaGeneticSharp.sln\n",
     "// Requires: git -C c:/dev/MetaGeneticSharp submodule update --init GeneticSharp\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Domain.dll\"\n",
     "\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
@@ -443,21 +443,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current + Neighbor (adjacent)  14,0000         Neighbor (adjacent)\r\n"
+      "Current + Neighbor (adjacent)  9,0000          Neighbor (adjacent)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current + Random (diversifie)  11,0000         Random (diversifie)\r\n"
+      "Current + Random (diversifie)  5,0000          Random (diversifie)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current + Best (elitiste)      19,0000         Best (elitiste)\r\n"
+      "Current + Best (elitiste)      11,0000         Best (elitiste)\r\n"
      ]
     },
     {
@@ -612,14 +612,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Default (baseline)   10,0000      36,0000      27,0000     \r\n"
+      "Default (baseline)   6,0000       2,0000       49,0000     \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SizeBased(25/25)     18,0000      38,0000      27,0000     \r\n"
+      "SizeBased(25/25)     42,0000      30,0000      25,0000     \r\n"
      ]
     },
     {
@@ -633,14 +633,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Default moyenne : 24,3333\r\n"
+      "  Default moyenne : 19,0000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SizeBased moyenne: 27,6667\r\n"
+      "  SizeBased moyenne: 32,3333\r\n"
      ]
     },
     {
@@ -798,21 +798,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 20,0000   "
+      " 8,0000    "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 17,0000   "
+      " 18,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 2,0000    "
+      " 21,0000   "
      ]
     },
     {
@@ -826,7 +826,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 27,0000   "
+      " 9,0000    "
      ]
     },
     {
@@ -847,14 +847,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 28,0000   "
+      " 12,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 22,0000   "
+      " 7,0000    "
      ]
     },
     {
@@ -868,14 +868,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 23,0000   "
+      " 18,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 18,0000   "
+      " 37,0000   "
      ]
     },
     {
@@ -896,14 +896,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Default moyenne  : 15,4000\r\n"
+      "  Default moyenne  : 13,4000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  GenPhased moyenne: 23,4000\r\n"
+      "  GenPhased moyenne: 20,0000\r\n"
      ]
     },
     {
@@ -1054,35 +1054,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 15,0000   "
+      " 30,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 55,0000   "
+      " 21,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 13,0000   "
+      " 10,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 18,0000   "
+      " 5,0000    "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 15,0000   "
+      " 22,0000   "
      ]
     },
     {
@@ -1103,7 +1103,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 15,0000   "
+      " 53,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 36,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 36,0000   "
      ]
     },
     {
@@ -1117,21 +1131,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 15,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 13,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 21,0000   "
+      " 22,0000   "
      ]
     },
     {
@@ -1152,14 +1152,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Default moyenne     : 23,2000\r\n"
+      "  Default moyenne     : 17,6000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  StageSwitch moyenne : 16,4000\r\n"
+      "  StageSwitch moyenne : 33,0000\r\n"
      ]
     },
     {
@@ -1367,35 +1367,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 8,0000    "
+      " 39,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 23,0000   "
+      " 27,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 41,0000   "
+      " 14,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 22,0000   "
+      " 45,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 4,0000    "
+      " 15,0000   "
      ]
     },
     {
@@ -1416,14 +1416,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 23,0000   "
+      " 22,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 22,0000   "
+      " 21,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 17,0000   "
      ]
     },
     {
@@ -1437,14 +1444,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 6,0000    "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 25,0000   "
+      " 24,0000   "
      ]
     },
     {
@@ -1465,21 +1465,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Default moyenne   : 19,6000\r\n"
+      "  Default moyenne   : 28,0000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Composed moyenne  : 19,2000\r\n"
+      "  Composed moyenne  : 20,8000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Amelioration      : 2,0%\r\n"
+      "  Amelioration      : 25,7%\r\n"
      ]
     },
     {

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
@@ -94,7 +94,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-86032.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -139,12 +139,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '416684.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '86032.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -258,10 +258,10 @@
     "// Wiring: load MetaGeneticSharp + GeneticSharp DLLs from submodule build\n",
     "// Build prerequisite: dotnet build c:/dev/MetaGeneticSharp/MetaGeneticSharp.sln\n",
     "// Requires: git -C c:/dev/MetaGeneticSharp submodule update --init GeneticSharp\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Domain.dll\"\n",
     "\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
@@ -508,14 +508,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Valeurs       : [57,30, 55,96]\r\n"
+      "  Valeurs       : [40,11, 48,14]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Fitness       : -38,2600\r\n"
+      "  Fitness       : -33,0300\r\n"
      ]
     },
     {
@@ -571,7 +571,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fitness herite  : -38,2600\r\n"
+      "    Fitness herite  : -33,0300\r\n"
      ]
     },
     {
@@ -613,7 +613,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fitness herite  : -38,2600\r\n"
+      "    Fitness herite  : -33,0300\r\n"
      ]
     },
     {
@@ -641,7 +641,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Valeurs : [57,30, 55,96]\r\n"
+      "  Valeurs : [40,11, 48,14]\r\n"
      ]
     },
     {
@@ -935,7 +935,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Genes : [80,92, 59,24]\r\n"
+      "  Genes : [76,47, 38,92]\r\n"
      ]
     },
     {
@@ -1112,7 +1112,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Meilleur chromosome : position=50,00, vitesse=24,91\r\n"
+      "  Meilleur chromosome : position=50,00, vitesse=25,01\r\n"
      ]
     },
     {
@@ -1126,7 +1126,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Distance totale     : 0,0900\r\n"
+      "  Distance totale     : 0,0100\r\n"
      ]
     },
     {
@@ -1283,21 +1283,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1,2500     "
+      " 0,0000     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1,2000     "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 0,6900     "
+      " 0,0100     "
      ]
     },
     {
@@ -1311,7 +1304,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,0900     "
+      " 0,0500     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,1400     "
      ]
     },
     {
@@ -1332,35 +1332,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 3,5700     "
+      " 2,4000     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 8,0000     "
+      " 1,5500     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1,4500     "
+      " 0,6500     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1,4600     "
+      " 2,9200     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1,2500     "
+      " 1,2400     "
      ]
     },
     {
@@ -1381,21 +1381,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Uniforme moyenne  : 0,6460\r\n"
+      "  Uniforme moyenne  : 0,0400\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Heterogene moyenne: 3,1460\r\n"
+      "  Heterogene moyenne: 1,7520\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Amelioration      : -387,0%\r\n"
+      "  Amelioration      : -4280,0%\r\n"
      ]
     },
     {

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb
@@ -79,7 +79,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-26356.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -124,12 +124,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '444112.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '26356.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -236,10 +236,10 @@
     "// Wiring: load MetaGeneticSharp + GeneticSharp DLLs from submodule build\n",
     "// Build prerequisite: dotnet build c:/dev/MetaGeneticSharp/MetaGeneticSharp.sln\n",
     "// Requires: git -C c:/dev/MetaGeneticSharp submodule update --init GeneticSharp\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Domain.dll\"\n",
     "\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
@@ -478,14 +478,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Best fitness    : -14,5300\r\n"
+      "  Best fitness    : -7,2700\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Worst fitness   : -119,0700\r\n"
+      "  Worst fitness   : -116,8000\r\n"
      ]
     },
     {
@@ -506,7 +506,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Ile 0 : 10 individus, fitness [-103,8200 .. -23,3500], premier = (54,94, 2,59)\r\n"
+      "  Ile 0 : 10 individus, fitness [-116,8000 .. -24,0200], premier = (63,34, 15,68)\r\n"
      ]
     },
     {
@@ -527,7 +527,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Ile 1 : 10 individus, fitness [-116,1400 .. -35,3600], premier = (9,74, 1,64)\r\n"
+      "  Ile 1 : 10 individus, fitness [-86,3500 .. -15,1900], premier = (83,84, 12,57)\r\n"
      ]
     },
     {
@@ -548,7 +548,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Ile 2 : 10 individus, fitness [-113,9700 .. -19,5900], premier = (29,35, 94,00)\r\n"
+      "  Ile 2 : 10 individus, fitness [-108,2300 .. -7,2700], premier = (82,66, 80,57)\r\n"
      ]
     },
     {
@@ -569,7 +569,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Ile 3 : 10 individus, fitness [-119,0700 .. -14,5300], premier = (81,97, 92,10)\r\n"
+      "  Ile 3 : 10 individus, fitness [-105,7400 .. -33,4100], premier = (10,23, 50,78)\r\n"
      ]
     },
     {
@@ -784,7 +784,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Meilleur chromosome : (41,90, 12,94)\r\n"
+      "  Meilleur chromosome : (42,00, 13,00)\r\n"
      ]
     },
     {
@@ -798,14 +798,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Distance totale     : 0,1600\r\n"
+      "  Distance totale     : 0,0000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Fitness             : -0,1600\r\n"
+      "  Fitness             : -0,0000\r\n"
      ]
     },
     {
@@ -978,7 +978,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Meilleur chromosome : (40,95, 12,99)\r\n"
+      "  Meilleur chromosome : (42,00, 12,79)\r\n"
      ]
     },
     {
@@ -992,14 +992,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Distance totale     : 1,0600\r\n"
+      "  Distance totale     : 0,2100\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Fitness             : -1,0600\r\n"
+      "  Fitness             : -0,2100\r\n"
      ]
     },
     {
@@ -1027,7 +1027,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Comparaison avec None (distance 0,1600) : None est meilleur (hasard)\r\n"
+      "Comparaison avec None (distance 0,0000) : None est meilleur (hasard)\r\n"
      ]
     }
    ],
@@ -1175,49 +1175,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,2100 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 0,2100 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 1,0600 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 0,0000 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 0,2100 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 0,3380 \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Insulaire (4 iles)"
+      " 0,0100 "
      ]
     },
     {
@@ -1231,13 +1189,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,0000 "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       " 0,0200 "
      ]
     },
@@ -1245,21 +1196,70 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,2100 "
+      " 1,2600 "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,2200 "
+      " 0,0100 "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,0920 \r\n"
+      " 0,2620 \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Insulaire (4 iles)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0000 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0400 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0000 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0000 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0700 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0220 \r\n"
      ]
     },
     {
@@ -1273,21 +1273,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Panmictique moyenne  : 0,3380\r\n"
+      "  Panmictique moyenne  : 0,2620\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Insulaire moyenne    : 0,0920\r\n"
+      "  Insulaire moyenne    : 0,0220\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Difference           : 72,8% (insulaire meilleur)\r\n"
+      "  Difference           : 91,6% (insulaire meilleur)\r\n"
      ]
     },
     {

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
@@ -93,23 +93,30 @@ L'aboutissement : le paysage n'est plus synthétique mais un **relief terrestre 
 
 ## Configuration requise
 
-Ces notebooks requièrent **.NET 9.0** et le kernel `dotnet-interactive` (règle : pas de contournement, installer l'environnement complet) :
+Le kernel `dotnet-interactive` (version pinnée **1.0.552801**) est un **hôte .NET 8.0** : il ne peut pas charger d'assemblies compilées en `net9.0` (`System.Runtime 9.0.0.0` introuvable à l'exécution). Les notebooks MGS se répartissent donc sur deux TFM :
+
+- **MGS-1 à MGS-5** (Introduction, Composition, Eukaryote, Islands, Compound) ne consomment que `MetaGeneticSharp.Domain` + `Infrastructure` + `GeneticSharp`. Ils référencent les **DLL `net8.0`** et s'exécutent sur le kernel pinné.
+- **MGS-6 à MGS-9** (Benchmarks, TSP, Landscape, Everest) dépendent en plus de `MetaGeneticSharp.Extensions` (SkiaSharp / `System.Drawing.Common`), non encore buildé pour `net8.0`. Ils référencent les DLL `net9.0` et restent **bloqués sur le kernel pinné** (follow-up : builder `Extensions` pour `net8.0`, ou multi-targeter le fork).
+
+Règle : pas de contournement, installer l'environnement complet :
 
 ```powershell
-# 1. .NET 9 SDK (si manquant)
-dotnet --version  # doit afficher 9.x
+# 1. .NET SDK (8.0 pour le kernel pinné ; 9.0 pour le fork source)
+dotnet --version
 
-# 2. dotnet-interactive (kernel Jupyter pour C#)
+# 2. dotnet-interactive (kernel Jupyter pour C#, hôte net8.0)
 dotnet tool install --global Microsoft.dotnet-interactive
 dotnet interactive jupyter install
 
 # 3. Sous-modules + build du fork (les notebooks chargent les DLL par #r absolu)
 cd MyIA.AI.Notebooks/Search/MetaGeneticSharp
 git submodule update --init --recursive
-dotnet build
+dotnet build                      # build net9.0 (fork source ; DLLs pour MGS-6..9)
 ```
 
-Les notebooks chargent les DLL via `#r "c:/dev/MetaGeneticSharp/..."` (chemin du checkout de travail du fork). Vérifiez que `dotnet build` a produit les binaires sous `src/MetaGeneticSharp.Domain/bin/Debug/net9.0/` et `src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/`.
+> **Bins `net8.0` pour MGS-1..5.** Le fork est actuellement single-TFM `net9.0`, donc `-p:TargetFramework=net8.0` échoue (le `project.assets.json` restauré ne contient que la cible net9.0). Pour produire `Domain` + `Infrastructure` en `net8.0` (requis par le kernel pinné), il faut soit retargeter temporairement le `.csproj` en `net8.0` puis `dotnet build`, soit — solution propre — multi-targeter le fork en `<TargetFrameworks>net8.0;net9.0</TargetFrameworks>` (follow-up sur le fork, `Extensions`/SkiaSharp restant net9.0-only). Les bins référencés par MGS-1..5 doivent exister sous `src/MetaGeneticSharp.Domain/bin/Debug/net8.0/`.
+
+Les notebooks chargent les DLL via `#r "c:/dev/MetaGeneticSharp/..."` (chemin du checkout de travail du fork). **MGS-1..5** pointent sur `src/MetaGeneticSharp.Domain/bin/Debug/net8.0/` (4 DLL : GeneticSharp.Domain, GeneticSharp.Infrastructure.Framework, MetaGeneticSharp.Domain, MetaGeneticSharp.Infrastructure) ; **MGS-6..9** pointent sur `src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/` (Extensions + SkiaSharp + System.Drawing.Common). Les résultats numériques des notebooks sont **stochastiques** (GA non seedé) : les outputs committés sont une exécution valide, les valeurs varient d'une exécution à l'autre.
 
 Règle C.2 : les notebooks sont committés **avec leurs outputs** (exécution réelle, kernel .NET).
 


### PR DESCRIPTION
## Contexte

Le kernel `dotnet-interactive` pinné (**1.0.552801**) est un **hôte .NET 8.0** : il ne peut pas charger d'assemblies compilées en `net9.0` (`System.Runtime 9.0.0.0` introuvable à l'exécution). Après la consolidation #3169, **MGS-5 seul** s'exécutait (déjà `net8.0`) ; **MGS-1..4** référençaient les mêmes 4 DLLs mais depuis le bin `net9.0` → elles ne chargeaient pas sur le kernel pinné (outputs gelés/inexécutables).

## Changement

Flip des 4 chemins `#r` `net9.0` → `net8.0` dans MGS-1..4 (mêmes 4 DLLs : `GeneticSharp.Domain`, `GeneticSharp.Infrastructure.Framework`, `MetaGeneticSharp.Domain`, `MetaGeneticSharp.Infrastructure`). Le fork MGS est single-TFM `net9.0`, mais le bin `net8.0` de `Domain` est un build `net8.0` authentique (`deps.json` → `.NETCoreApp,Version=v8.0`), source-équivalent (DLLs de taille identique au build `net9.0`).

## Preuve d'exécution (critère D — notebooks)

Re-exécuté via **papermill 2.7.0** sur le kernel `.net-csharp` (hôte net8.0) :

| Notebook | cells code | exécutées | erreurs | net9.0 résiduel |
|----------|-----------|-----------|---------|-----------------|
| MGS-1 Introduction | 9 | 9 | 0 | 0 |
| MGS-2 Composition | 10 | 10 | 0 | 0 |
| MGS-3 Eukaryote | 9 | 9 | 0 | 0 |
| MGS-4 Islands | 9 | 9 | 0 | 0 |

Output réel confirmé (MGS-1) : `MetaGeneticSharp + GeneticSharp charges avec succes` + exécution GA. Sorties injectées chirurgicalement (outputs/execution_count depuis l'exécution, métadonnées de cellule originales préservées, `indent=1`) — pas de churn timestamp papermill. Diff total : 153+/146− sur 5 fichiers.

## Scope

- **MGS-1..4** : flip + re-exécution (ce PR).
- **MGS-5** : intact (déjà `net8.0`, référence).
- **MGS-6..9** : laissés à `net9.0` — dépendent de `MetaGeneticSharp.Extensions` (SkiaSharp / `System.Drawing.Common`), non buildé pour `net8.0`. Documentés comme bloqués sur le kernel pinné + follow-up (multi-targeter le fork `net8.0;net9.0`).

## README

Section « Configuration requise » réécrite pour documenter honnêtement le split TFM + la caveat de reproductibilité des bins `net8.0` (fork single-TFM `net9.0` → `-p:TargetFramework=net8.0` échoue ; il faut retargeter le `.csproj` ou multi-targeter). Vérifié par build (la commande `-p:TargetFramework=net8.0` a bien échoué avec `NETSDK1005` — corrigé dans le README avant commit).

## Notes review

- Outputs **stochastiques** (GA non seedé) : les valeurs numériques varient d'une exécution à l'autre — les outputs committés sont une exécution valide, pas une régression.
- Aucune suppression de cellule `# Solution`/`# Exemple` (anti-régression). 0 `raise NotImplementedError`/`assert False`/`1/0` (D.2).
- Catalogue non touché (catalog-pr-hygiene HARD 1).

See #1203