### PR TITLE
feat(sl10): resolve Ex1 (extend schema, symmetric spouse relation) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
@@ -5,10 +5,10 @@
    "id": "sl10-01",
    "metadata": {
     "papermill": {
-     "duration": 0.004761,
-     "end_time": "2026-06-10T12:10:50.961396",
+     "duration": 0.005134,
+     "end_time": "2026-06-17T02:02:00.485249+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:50.956635",
+     "start_time": "2026-06-17T02:02:00.480115+00:00",
      "status": "completed"
     },
     "tags": []
@@ -43,10 +43,10 @@
    "id": "sl10-02",
    "metadata": {
     "papermill": {
-     "duration": 0.003661,
-     "end_time": "2026-06-10T12:10:50.967749",
+     "duration": 0.004247,
+     "end_time": "2026-06-17T02:02:00.495353+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:50.964088",
+     "start_time": "2026-06-17T02:02:00.491106+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "sl10-03",
    "metadata": {
     "papermill": {
-     "duration": 0.004786,
-     "end_time": "2026-06-10T12:10:50.975700",
+     "duration": 0.006056,
+     "end_time": "2026-06-17T02:02:00.507020+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:50.970914",
+     "start_time": "2026-06-17T02:02:00.500964+00:00",
      "status": "completed"
     },
     "tags": []
@@ -113,16 +113,16 @@
    "id": "sl10-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:10:50.985171Z",
-     "iopub.status.busy": "2026-06-10T12:10:50.985171Z",
-     "iopub.status.idle": "2026-06-10T12:10:51.004150Z",
-     "shell.execute_reply": "2026-06-10T12:10:51.002516Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.522004Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.521659Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.533453Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.532195Z"
     },
     "papermill": {
-     "duration": 0.024767,
-     "end_time": "2026-06-10T12:10:51.005204",
+     "duration": 0.020963,
+     "end_time": "2026-06-17T02:02:00.534529+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:50.980437",
+     "start_time": "2026-06-17T02:02:00.513566+00:00",
      "status": "completed"
     },
     "tags": []
@@ -186,10 +186,10 @@
    "id": "sl10-05",
    "metadata": {
     "papermill": {
-     "duration": 0.004762,
-     "end_time": "2026-06-10T12:10:51.015236",
+     "duration": 0.004987,
+     "end_time": "2026-06-17T02:02:00.544398+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:51.010474",
+     "start_time": "2026-06-17T02:02:00.539411+00:00",
      "status": "completed"
     },
     "tags": []
@@ -205,10 +205,10 @@
    "id": "sl10-06",
    "metadata": {
     "papermill": {
-     "duration": 0.004807,
-     "end_time": "2026-06-10T12:10:51.024446",
+     "duration": 0.007925,
+     "end_time": "2026-06-17T02:02:00.558387+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:51.019639",
+     "start_time": "2026-06-17T02:02:00.550462+00:00",
      "status": "completed"
     },
     "tags": []
@@ -230,16 +230,16 @@
    "id": "sl10-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:10:51.035120Z",
-     "iopub.status.busy": "2026-06-10T12:10:51.035120Z",
-     "iopub.status.idle": "2026-06-10T12:10:51.716651Z",
-     "shell.execute_reply": "2026-06-10T12:10:51.716651Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.575416Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.574978Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.591211Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.590040Z"
     },
     "papermill": {
-     "duration": 0.688503,
-     "end_time": "2026-06-10T12:10:51.717656",
+     "duration": 0.025771,
+     "end_time": "2026-06-17T02:02:00.592285+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:51.029153",
+     "start_time": "2026-06-17T02:02:00.566514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,16 +287,16 @@
    "id": "sl10-08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:10:51.724655Z",
-     "iopub.status.busy": "2026-06-10T12:10:51.723655Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.640202Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.639198Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.603594Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.603354Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.614020Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.612922Z"
     },
     "papermill": {
-     "duration": 10.92005,
-     "end_time": "2026-06-10T12:11:02.640705",
+     "duration": 0.017553,
+     "end_time": "2026-06-17T02:02:00.614851+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:51.720655",
+     "start_time": "2026-06-17T02:02:00.597298+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,10 +398,10 @@
    "id": "sl10-09",
    "metadata": {
     "papermill": {
-     "duration": 0.004068,
-     "end_time": "2026-06-10T12:11:02.649904",
+     "duration": 0.005012,
+     "end_time": "2026-06-17T02:02:00.625095+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.645836",
+     "start_time": "2026-06-17T02:02:00.620083+00:00",
      "status": "completed"
     },
     "tags": []
@@ -426,10 +426,10 @@
    "id": "sl10-10",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T12:11:02.657923",
+     "duration": 0.004026,
+     "end_time": "2026-06-17T02:02:00.633345+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.653923",
+     "start_time": "2026-06-17T02:02:00.629319+00:00",
      "status": "completed"
     },
     "tags": []
@@ -452,16 +452,16 @@
    "id": "sl10-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.670149Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.668641Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.686314Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.685209Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.642971Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.642620Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.649214Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.648383Z"
     },
     "papermill": {
-     "duration": 0.023765,
-     "end_time": "2026-06-10T12:11:02.687358",
+     "duration": 0.012458,
+     "end_time": "2026-06-17T02:02:00.649883+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.663593",
+     "start_time": "2026-06-17T02:02:00.637425+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,10 +519,10 @@
    "id": "sl10-12",
    "metadata": {
     "papermill": {
-     "duration": 0.005222,
-     "end_time": "2026-06-10T12:11:02.697307",
+     "duration": 0.004125,
+     "end_time": "2026-06-17T02:02:00.658016+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.692085",
+     "start_time": "2026-06-17T02:02:00.653891+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,10 +550,10 @@
    "id": "sl10-13",
    "metadata": {
     "papermill": {
-     "duration": 0.004702,
-     "end_time": "2026-06-10T12:11:02.706309",
+     "duration": 0.003871,
+     "end_time": "2026-06-17T02:02:00.665660+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.701607",
+     "start_time": "2026-06-17T02:02:00.661789+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "sl10-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.717459Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.716935Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.732298Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.731177Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.674827Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.674518Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.679303Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.678413Z"
     },
     "papermill": {
-     "duration": 0.022238,
-     "end_time": "2026-06-10T12:11:02.733335",
+     "duration": 0.010559,
+     "end_time": "2026-06-17T02:02:00.680028+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.711097",
+     "start_time": "2026-06-17T02:02:00.669469+00:00",
      "status": "completed"
     },
     "tags": []
@@ -622,10 +622,10 @@
    "id": "sl10-15",
    "metadata": {
     "papermill": {
-     "duration": 0.005483,
-     "end_time": "2026-06-10T12:11:02.743437",
+     "duration": 0.004601,
+     "end_time": "2026-06-17T02:02:00.688960+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.737954",
+     "start_time": "2026-06-17T02:02:00.684359+00:00",
      "status": "completed"
     },
     "tags": []
@@ -653,16 +653,16 @@
    "id": "sl10-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.755115Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.755115Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.763956Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.762950Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.699972Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.699604Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.708125Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.707140Z"
     },
     "papermill": {
-     "duration": 0.017316,
-     "end_time": "2026-06-10T12:11:02.764956",
+     "duration": 0.015142,
+     "end_time": "2026-06-17T02:02:00.708906+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.747640",
+     "start_time": "2026-06-17T02:02:00.693764+00:00",
      "status": "completed"
     },
     "tags": []
@@ -728,10 +728,10 @@
    "id": "sl10-17",
    "metadata": {
     "papermill": {
-     "duration": 0.004109,
-     "end_time": "2026-06-10T12:11:02.774607",
+     "duration": 0.004411,
+     "end_time": "2026-06-17T02:02:00.718014+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.770498",
+     "start_time": "2026-06-17T02:02:00.713603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -766,10 +766,10 @@
    "id": "sl10-18",
    "metadata": {
     "papermill": {
-     "duration": 0.004795,
-     "end_time": "2026-06-10T12:11:02.784541",
+     "duration": 0.004254,
+     "end_time": "2026-06-17T02:02:00.726691+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.779746",
+     "start_time": "2026-06-17T02:02:00.722437+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,16 +790,16 @@
    "id": "sl10-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.796704Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.796704Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.811213Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.809603Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.737031Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.736632Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.744700Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.743653Z"
     },
     "papermill": {
-     "duration": 0.021077,
-     "end_time": "2026-06-10T12:11:02.811213",
+     "duration": 0.014516,
+     "end_time": "2026-06-17T02:02:00.745475+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.790136",
+     "start_time": "2026-06-17T02:02:00.730959+00:00",
      "status": "completed"
     },
     "tags": []
@@ -864,10 +864,10 @@
    "id": "sl10-20",
    "metadata": {
     "papermill": {
-     "duration": 0.004696,
-     "end_time": "2026-06-10T12:11:02.822387",
+     "duration": 0.004463,
+     "end_time": "2026-06-17T02:02:00.754454+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.817691",
+     "start_time": "2026-06-17T02:02:00.749991+00:00",
      "status": "completed"
     },
     "tags": []
@@ -905,10 +905,10 @@
    "id": "sl10-21",
    "metadata": {
     "papermill": {
-     "duration": 0.004645,
-     "end_time": "2026-06-10T12:11:02.832348",
+     "duration": 0.005027,
+     "end_time": "2026-06-17T02:02:00.764320+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.827703",
+     "start_time": "2026-06-17T02:02:00.759293+00:00",
      "status": "completed"
     },
     "tags": []
@@ -930,16 +930,16 @@
    "id": "sl10-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.844420Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.843914Z",
-     "iopub.status.idle": "2026-06-10T12:11:05.893815Z",
-     "shell.execute_reply": "2026-06-10T12:11:05.893205Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.775869Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.775446Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.782920Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.781838Z"
     },
     "papermill": {
-     "duration": 3.056947,
-     "end_time": "2026-06-10T12:11:05.893815",
+     "duration": 0.014467,
+     "end_time": "2026-06-17T02:02:00.783782+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.836868",
+     "start_time": "2026-06-17T02:02:00.769315+00:00",
      "status": "completed"
     },
     "tags": []
@@ -995,10 +995,10 @@
    "id": "sl10-23",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T12:11:05.903331",
+     "duration": 0.006799,
+     "end_time": "2026-06-17T02:02:00.795815+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.898331",
+     "start_time": "2026-06-17T02:02:00.789016+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1028,10 +1028,10 @@
    "id": "sl10-24",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T12:11:05.913331",
+     "duration": 0.004833,
+     "end_time": "2026-06-17T02:02:00.805183+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.908331",
+     "start_time": "2026-06-17T02:02:00.800350+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1059,16 +1059,16 @@
    "id": "sl10-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:05.923842Z",
-     "iopub.status.busy": "2026-06-10T12:11:05.923842Z",
-     "iopub.status.idle": "2026-06-10T12:11:05.939349Z",
-     "shell.execute_reply": "2026-06-10T12:11:05.939349Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.818424Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.818037Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.825737Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.824650Z"
     },
     "papermill": {
-     "duration": 0.022515,
-     "end_time": "2026-06-10T12:11:05.940352",
+     "duration": 0.016214,
+     "end_time": "2026-06-17T02:02:00.826662+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.917837",
+     "start_time": "2026-06-17T02:02:00.810448+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1078,23 +1078,144 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Schema etendu : marie_avec ajoutee, jeanne declaree personne.\n",
+      "\n",
+      "Faits marie_avec apres completion symetrique : 2\n",
+      "  marie_avec(henri, jeanne)\n",
+      "  marie_avec(jeanne, henri)\n",
+      "\n",
+      "KG : 17 -> 19 faits (17 admis + 1 mariage + 1 completion).\n",
+      "\n",
+      "Lecture : un seul triplet en entree, DEUX en sortie. La completion\n",
+      "symetrique est une regle du SCHEMA (au meme titre qu'une contrainte\n",
+      "fonctionnelle), pas une regle MINEE : elle est vraie par definition, on\n",
+      "n'a pas besoin de donnees pour la confirmer -- contrairement aux regles\n",
+      "de la cellule mine_rules dont la confiance se mesure par comptage.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 : Etendre le schema\n",
-    "# TODO etudiant : ajoutez la relation marie_avec (personne, personne) au schema,\n",
-    "# deux phrases au corpus (ex : \"Henri est marie a Jeanne.\"), l'entite jeanne,\n",
-    "# puis re-executez extraction + oracle. La relation est SYMETRIQUE : ajoutez a\n",
-    "# l'oracle la completion automatique marie_avec(Y,X) des que marie_avec(X,Y)\n",
-    "# est admis.\n",
-    "# Indice : SIGNATURES, PERSONS, CORPUS, et la boucle de oracle() sont a etendre.\n",
-    "# Etape 1 : schema + corpus etendus\n",
-    "# Etape 2 : re-extraction (LLM ou simulateur) et oracle\n",
-    "# Etape 3 : verifiez que les deux sens du mariage sont dans le KG\n",
+    "# Exemple guide 1 : Etendre le schema (relation symetrique marie_avec)\n",
+    "#\n",
+    "# On ajoute la relation marie_avec(personne, personne) au schema, l'entite\n",
+    "# jeanne, et le fait marie_avec(henri, jeanne). La nouveaute : cette relation\n",
+    "# est SYMETRIQUE. L'oracle doit completer automatiquement marie_avec(Y,X) des\n",
+    "# que marie_avec(X,Y) est admis -- sinon on perd la moitie du mariage.\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : on etend le vocabulaire ferme (le biais de langage, cf SL-4/SL-9).\n",
+    "SIGNATURES[\"marie_avec\"] = (\"personne\", \"personne\")\n",
+    "PERSONS.add(\"jeanne\")\n",
+    "TYPE_OF[\"jeanne\"] = \"personne\"\n",
+    "print(\"Schema etendu : marie_avec ajoutee, jeanne declaree personne.\")\n",
+    "\n",
+    "# Etape 2 : le nouveau fait. Hors-ligne (pas de .env) l'extraction LLM n'est pas\n",
+    "# disponible : on injecte le triplet \"or\" exactement comme le ferait une\n",
+    "# extraction LLM multi-passes + vote (cf le filet de securite de la cellule\n",
+    "# d'extraction). En ligne, EXTRACTION_PROMPT extrairait marie_avec(henri, jeanne).\n",
+    "marie_triples = [(\"marie_avec\", \"henri\", \"jeanne\")]\n",
+    "\n",
+    "# Etape 3 : oracle ETENDU. On reutilise oracle() pour les verifications de type\n",
+    "# et de contrainte fonctionnelle, puis on ajoute la completion symetrique POUR\n",
+    "# LES RELATIONS DECLAREES SYMETRIQUES (et elles seules).\n",
+    "def oracle_symmetric(triples, symmetric_rels):\n",
+    "    accepted, rejected = oracle(triples)          # types + contraintes fonctionnelles\n",
+    "    complets = []\n",
+    "    for (r, s, o) in accepted:\n",
+    "        if r in symmetric_rels and (r, o, s) not in accepted and (r, o, s) not in complets:\n",
+    "            complets.append((r, o, s))           # marie_avec(henri,jeanne) -> (jeanne,henri)\n",
+    "    return accepted + complets, rejected\n",
+    "\n",
+    "# Etape 4 : re-execution de l'oracle sur le KG + le nouveau fait.\n",
+    "kg2, rej2 = oracle_symmetric(kg_facts + marie_triples, symmetric_rels={\"marie_avec\"})\n",
+    "mariages = sorted((s, o) for (r, s, o) in kg2 if r == \"marie_avec\")\n",
+    "print(f\"\\nFaits marie_avec apres completion symetrique : {len(mariages)}\")\n",
+    "for s, o in mariages:\n",
+    "    print(f\"  marie_avec({s}, {o})\")\n",
+    "print(f\"\\nKG : {len(kg_facts)} -> {len(kg2)} faits \"\n",
+    "      f\"(17 admis + 1 mariage + 1 completion).\")\n",
+    "print()\n",
+    "print(\"Lecture : un seul triplet en entree, DEUX en sortie. La completion\")\n",
+    "print(\"symetrique est une regle du SCHEMA (au meme titre qu'une contrainte\")\n",
+    "print(\"fonctionnelle), pas une regle MINEE : elle est vraie par definition, on\")\n",
+    "print(\"n'a pas besoin de donnees pour la confirmer -- contrairement aux regles\")\n",
+    "print(\"de la cellule mine_rules dont la confiance se mesure par comptage.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl10ex1var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004717,
+     "end_time": "2026-06-17T02:02:00.836278+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:02:00.831561+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 (variation) : Symetrie vs anti-symetrie\n",
+    "\n",
+    "La completion symetrique ne doit s'appliquer **qu'aux relations declarees symetriques**. Verifiez qu'une relation **anti-symetrique** comme `parent` n'est **jamais** completee en `parent(Y, X)`, meme si on la passe a `oracle_symmetric`.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Appeler `oracle_symmetric(kg_facts, symmetric_rels={\"marie_avec\"})` et recuperer les faits `parent`.\n",
+    "2. Verifier qu'aucun `parent(Y, X)` n'a ete ajoute par completion (la liste des faits `parent` avant/apres est identique).\n",
+    "3. Que faudrait-il faire pour qu'une **nouvelle** relation symetrique beneficie automatiquement de la completion, sans modifier le code de `oracle_symmetric` ?\n",
+    "\n",
+    "**Indice** : c'est l'appartenance a `symmetric_rels` qui ouvre ou ferme la porte. Une relation symetrique oubliee dans cet ensemble = un demi-mariage silencieux (un seul sens persiste, l'autre n'est jamais derive).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "sl10ex1var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T02:02:00.848599Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.848238Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.852936Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.852044Z"
+    },
+    "papermill": {
+     "duration": 0.01209,
+     "end_time": "2026-06-17T02:02:00.853655+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:02:00.841565+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : symetrie vs anti-symetrie\n",
+      "Montrez qu'aucun parent(Y, X) n'est ajoute : la porte symmetric_rels reste fermee.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (variation) : Symetrie vs anti-symetrie\n",
+    "# TODO etudiant : montrez que la completion symetrique respecte la porte\n",
+    "# symmetric_rels et n'ajoute JAMAIS parent(Y, X) pour un parent(X, Y) admis.\n",
+    "\n",
+    "# Etape 1 : oracle_symmetric avec SEULEMENT marie_avec comme symetrique\n",
+    "# kg3, _ = oracle_symmetric(kg_facts, symmetric_rels={\"marie_avec\"})\n",
+    "\n",
+    "# Etape 2 : faits parent avant / apres -> doivent etre EGAUX (rien complete)\n",
+    "# parents_avant = {(s, o) for (r, s, o) in kg_facts if r == \"parent\"}\n",
+    "# parents_apres = {(s, o) for (r, s, o) in kg3 if r == \"parent\"}\n",
+    "\n",
+    "# Etape 3 : conclure sur le role de la porte symmetric_rels\n",
+    "print(\"Exercice a completer : symetrie vs anti-symetrie\")\n",
+    "print(\"Montrez qu'aucun parent(Y, X) n'est ajoute : la porte symmetric_rels reste fermee.\")\n",
+    "\n",
+    "# Indice : la completion ne s'applique qu'aux relations de symmetric_rels.\n",
+    "# Ajouter une relation symetrique = l'inscrire dans l'ensemble, pas coder.\n",
+    "# result = None  # TODO etudiant : parents_avant == parents_apres ?\n"
    ]
   },
   {
@@ -1102,10 +1223,10 @@
    "id": "sl10-26",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-06-10T12:11:05.946349",
+     "duration": 0.004363,
+     "end_time": "2026-06-17T02:02:00.862742+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.943349",
+     "start_time": "2026-06-17T02:02:00.858379+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1117,20 +1238,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "sl10-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:05.953334Z",
-     "iopub.status.busy": "2026-06-10T12:11:05.953334Z",
-     "iopub.status.idle": "2026-06-10T12:11:05.969511Z",
-     "shell.execute_reply": "2026-06-10T12:11:05.969511Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.873171Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.872811Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.876926Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.876013Z"
     },
     "papermill": {
-     "duration": 0.021155,
-     "end_time": "2026-06-10T12:11:05.970504",
+     "duration": 0.010448,
+     "end_time": "2026-06-17T02:02:00.877592+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.949349",
+     "start_time": "2026-06-17T02:02:00.867144+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1165,10 +1286,10 @@
    "id": "sl10-28",
    "metadata": {
     "papermill": {
-     "duration": 0.002539,
-     "end_time": "2026-06-10T12:11:05.976050",
+     "duration": 0.006394,
+     "end_time": "2026-06-17T02:02:00.888549+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.973511",
+     "start_time": "2026-06-17T02:02:00.882155+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1180,20 +1301,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "sl10-29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:05.983616Z",
-     "iopub.status.busy": "2026-06-10T12:11:05.983092Z",
-     "iopub.status.idle": "2026-06-10T12:11:06.001398Z",
-     "shell.execute_reply": "2026-06-10T12:11:06.000378Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.898691Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.898300Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.902512Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.901535Z"
     },
     "papermill": {
-     "duration": 0.022966,
-     "end_time": "2026-06-10T12:11:06.002423",
+     "duration": 0.010463,
+     "end_time": "2026-06-17T02:02:00.903303+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.979457",
+     "start_time": "2026-06-17T02:02:00.892840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1228,10 +1349,10 @@
    "id": "sl10-30",
    "metadata": {
     "papermill": {
-     "duration": 0.005773,
-     "end_time": "2026-06-10T12:11:06.013226",
+     "duration": 0.004662,
+     "end_time": "2026-06-17T02:02:00.912587+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.007453",
+     "start_time": "2026-06-17T02:02:00.907925+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1243,20 +1364,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "sl10-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:06.024781Z",
-     "iopub.status.busy": "2026-06-10T12:11:06.024781Z",
-     "iopub.status.idle": "2026-06-10T12:11:06.032861Z",
-     "shell.execute_reply": "2026-06-10T12:11:06.031860Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.923147Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.922770Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.926797Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.925886Z"
     },
     "papermill": {
-     "duration": 0.014641,
-     "end_time": "2026-06-10T12:11:06.032861",
+     "duration": 0.010129,
+     "end_time": "2026-06-17T02:02:00.927478+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.018220",
+     "start_time": "2026-06-17T02:02:00.917349+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1291,10 +1412,10 @@
    "id": "sl10-33",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T12:11:06.054631",
+     "duration": 0.004645,
+     "end_time": "2026-06-17T02:02:00.937352+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.049631",
+     "start_time": "2026-06-17T02:02:00.932707+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1345,10 +1466,10 @@
    "id": "sl10-32",
    "metadata": {
     "papermill": {
-     "duration": 0.006593,
-     "end_time": "2026-06-10T12:11:06.044589",
+     "duration": 0.003883,
+     "end_time": "2026-06-17T02:02:00.945222+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.037996",
+     "start_time": "2026-06-17T02:02:00.941339+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1376,10 +1497,10 @@
    "id": "sl10-34",
    "metadata": {
     "papermill": {
-     "duration": 0.005048,
-     "end_time": "2026-06-10T12:11:06.065730",
+     "duration": 0.003801,
+     "end_time": "2026-06-17T02:02:00.953057+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.060682",
+     "start_time": "2026-06-17T02:02:00.949256+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1418,18 +1539,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 17.414731,
-   "end_time": "2026-06-10T12:11:06.633869",
+   "duration": 2.854294,
+   "end_time": "2026-06-17T02:02:01.198065+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SL-10-Capstone-NeuroSymbolic.ipynb",
-   "output_path": "SL-10-Capstone-NeuroSymbolic.ipynb",
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T12:10:49.219138",
+   "start_time": "2026-06-17T02:01:58.343771+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
> Premiere PR du stack SL-10 (Ex1-4). Base = `origin/main` (frais). Ordre de merge : celle-ci -> Ex2 -> Ex3 -> Ex4. Complete progressivement le Capstone neuro-symbolique.

## Livrable

**Ex1 resolu en exemple guide** (etendre le schema, relation symetrique `marie_avec`) :
- `oracle_symmetric(triples, symmetric_rels)` : reutilise `oracle()` (types + contraintes fonctionnelles) puis ajoute la **completion symetrique** `marie_avec(Y,X)` pour chaque `marie_avec(X,Y)` admis — **uniquement** pour les relations declarees dans `symmetric_rels`.
- 1 triplet en entree -> **2 faits** en sortie (`henri <-> jeanne`), KG 17 -> 19.

**Nouvel exercice en variation** : "Symetrie vs anti-symetrie" — verifier qu'une relation ANTI-symetrique (`parent`) n'est **jamais** completee. C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`notebook_tools.py execute --kernel python3 --scrub-keys`, deterministe) : **SUCCESS** 5.1s, 1/1, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 13 cellules code, `execution_count` set + outputs + 0 erreur.

## Cellules LLM preservees

Pas de `.env` en local -> les cellules extraction/QA regressent au simulateur sous papermill. **Restore** depuis `origin/main` (sorties reelles `gemini-3.5-flash`) : `sl10-07` (config), `sl10-08` (extraction), `sl10-22` (QA).

**Note reviewer** : `sl10-19` (forward_chain) est aussi restoree a cause d'une **non-determinisme PRE-EXISTANTE** — les temoins sont choisis par ordre d'iteration d'un `set` (hash seed Python), donc le chemin `marc` vs `claire` varie. Les DEUX sont valides (Henri a 2 enfants qui travaillent tous les deux a l'atelier_verne) et les faits derives sont **identiques**. Restaure pour matcher le temoin canonique d'origin/main. **Finding pour ai-01** : ce non-determinisme meritait un `sorted()` dans `forward_chain` pour la reproductibilite — follow-up possible, hors-scope de cette PR.

## Anti-regression (verifie vs `origin/main`)

- CHANGED SOURCE : **uniquement** `sl10-25` (stub -> exemple resolu).
- CHANGED OUTPUT : **uniquement** `sl10-25`.
- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- 1 fichier `.ipynb` (SL-10), base fraiche `origin/main`. Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
