### PR TITLE
feat(sl10): resolve Ex3 (no good threshold exists) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
@@ -5,10 +5,10 @@
    "id": "sl10-01",
    "metadata": {
     "papermill": {
-     "duration": 0.005134,
-     "end_time": "2026-06-17T02:02:00.485249+00:00",
+     "duration": 0.004344,
+     "end_time": "2026-06-17T02:08:44.656424+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.480115+00:00",
+     "start_time": "2026-06-17T02:08:44.652080+00:00",
      "status": "completed"
     },
     "tags": []
@@ -43,10 +43,10 @@
    "id": "sl10-02",
    "metadata": {
     "papermill": {
-     "duration": 0.004247,
-     "end_time": "2026-06-17T02:02:00.495353+00:00",
+     "duration": 0.003477,
+     "end_time": "2026-06-17T02:08:44.666400+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.491106+00:00",
+     "start_time": "2026-06-17T02:08:44.662923+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "sl10-03",
    "metadata": {
     "papermill": {
-     "duration": 0.006056,
-     "end_time": "2026-06-17T02:02:00.507020+00:00",
+     "duration": 0.003515,
+     "end_time": "2026-06-17T02:08:44.673494+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.500964+00:00",
+     "start_time": "2026-06-17T02:08:44.669979+00:00",
      "status": "completed"
     },
     "tags": []
@@ -113,16 +113,16 @@
    "id": "sl10-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.522004Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.521659Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.533453Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.532195Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.681868Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.681587Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.690038Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.689267Z"
     },
     "papermill": {
-     "duration": 0.020963,
-     "end_time": "2026-06-17T02:02:00.534529+00:00",
+     "duration": 0.013892,
+     "end_time": "2026-06-17T02:08:44.690891+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.513566+00:00",
+     "start_time": "2026-06-17T02:08:44.676999+00:00",
      "status": "completed"
     },
     "tags": []
@@ -186,10 +186,10 @@
    "id": "sl10-05",
    "metadata": {
     "papermill": {
-     "duration": 0.004987,
-     "end_time": "2026-06-17T02:02:00.544398+00:00",
+     "duration": 0.003624,
+     "end_time": "2026-06-17T02:08:44.698354+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.539411+00:00",
+     "start_time": "2026-06-17T02:08:44.694730+00:00",
      "status": "completed"
     },
     "tags": []
@@ -205,10 +205,10 @@
    "id": "sl10-06",
    "metadata": {
     "papermill": {
-     "duration": 0.007925,
-     "end_time": "2026-06-17T02:02:00.558387+00:00",
+     "duration": 0.003499,
+     "end_time": "2026-06-17T02:08:44.705386+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.550462+00:00",
+     "start_time": "2026-06-17T02:08:44.701887+00:00",
      "status": "completed"
     },
     "tags": []
@@ -230,16 +230,16 @@
    "id": "sl10-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.575416Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.574978Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.591211Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.590040Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.713946Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.713729Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.724406Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.723682Z"
     },
     "papermill": {
-     "duration": 0.025771,
-     "end_time": "2026-06-17T02:02:00.592285+00:00",
+     "duration": 0.016212,
+     "end_time": "2026-06-17T02:08:44.725109+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.566514+00:00",
+     "start_time": "2026-06-17T02:08:44.708897+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,16 +287,16 @@
    "id": "sl10-08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.603594Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.603354Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.614020Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.612922Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.734131Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.733864Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.742116Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.741450Z"
     },
     "papermill": {
-     "duration": 0.017553,
-     "end_time": "2026-06-17T02:02:00.614851+00:00",
+     "duration": 0.014189,
+     "end_time": "2026-06-17T02:08:44.743063+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.597298+00:00",
+     "start_time": "2026-06-17T02:08:44.728874+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,10 +398,10 @@
    "id": "sl10-09",
    "metadata": {
     "papermill": {
-     "duration": 0.005012,
-     "end_time": "2026-06-17T02:02:00.625095+00:00",
+     "duration": 0.004058,
+     "end_time": "2026-06-17T02:08:44.751534+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.620083+00:00",
+     "start_time": "2026-06-17T02:08:44.747476+00:00",
      "status": "completed"
     },
     "tags": []
@@ -426,10 +426,10 @@
    "id": "sl10-10",
    "metadata": {
     "papermill": {
-     "duration": 0.004026,
-     "end_time": "2026-06-17T02:02:00.633345+00:00",
+     "duration": 0.003506,
+     "end_time": "2026-06-17T02:08:44.758912+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.629319+00:00",
+     "start_time": "2026-06-17T02:08:44.755406+00:00",
      "status": "completed"
     },
     "tags": []
@@ -452,16 +452,16 @@
    "id": "sl10-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.642971Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.642620Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.649214Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.648383Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.767502Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.767316Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.772450Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.771893Z"
     },
     "papermill": {
-     "duration": 0.012458,
-     "end_time": "2026-06-17T02:02:00.649883+00:00",
+     "duration": 0.010713,
+     "end_time": "2026-06-17T02:08:44.772984+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.637425+00:00",
+     "start_time": "2026-06-17T02:08:44.762271+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,10 +519,10 @@
    "id": "sl10-12",
    "metadata": {
     "papermill": {
-     "duration": 0.004125,
-     "end_time": "2026-06-17T02:02:00.658016+00:00",
+     "duration": 0.003555,
+     "end_time": "2026-06-17T02:08:44.780343+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.653891+00:00",
+     "start_time": "2026-06-17T02:08:44.776788+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,10 +550,10 @@
    "id": "sl10-13",
    "metadata": {
     "papermill": {
-     "duration": 0.003871,
-     "end_time": "2026-06-17T02:02:00.665660+00:00",
+     "duration": 0.003597,
+     "end_time": "2026-06-17T02:08:44.787533+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.661789+00:00",
+     "start_time": "2026-06-17T02:08:44.783936+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "sl10-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.674827Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.674518Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.679303Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.678413Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.796317Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.796118Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.800552Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.799934Z"
     },
     "papermill": {
-     "duration": 0.010559,
-     "end_time": "2026-06-17T02:02:00.680028+00:00",
+     "duration": 0.009947,
+     "end_time": "2026-06-17T02:08:44.801238+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.669469+00:00",
+     "start_time": "2026-06-17T02:08:44.791291+00:00",
      "status": "completed"
     },
     "tags": []
@@ -622,10 +622,10 @@
    "id": "sl10-15",
    "metadata": {
     "papermill": {
-     "duration": 0.004601,
-     "end_time": "2026-06-17T02:02:00.688960+00:00",
+     "duration": 0.003943,
+     "end_time": "2026-06-17T02:08:44.809141+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.684359+00:00",
+     "start_time": "2026-06-17T02:08:44.805198+00:00",
      "status": "completed"
     },
     "tags": []
@@ -653,16 +653,16 @@
    "id": "sl10-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.699972Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.699604Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.708125Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.707140Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.817751Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.817561Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.823554Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.823000Z"
     },
     "papermill": {
-     "duration": 0.015142,
-     "end_time": "2026-06-17T02:02:00.708906+00:00",
+     "duration": 0.011408,
+     "end_time": "2026-06-17T02:08:44.824259+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.693764+00:00",
+     "start_time": "2026-06-17T02:08:44.812851+00:00",
      "status": "completed"
     },
     "tags": []
@@ -728,10 +728,10 @@
    "id": "sl10-17",
    "metadata": {
     "papermill": {
-     "duration": 0.004411,
-     "end_time": "2026-06-17T02:02:00.718014+00:00",
+     "duration": 0.003717,
+     "end_time": "2026-06-17T02:08:44.832089+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.713603+00:00",
+     "start_time": "2026-06-17T02:08:44.828372+00:00",
      "status": "completed"
     },
     "tags": []
@@ -766,10 +766,10 @@
    "id": "sl10-18",
    "metadata": {
     "papermill": {
-     "duration": 0.004254,
-     "end_time": "2026-06-17T02:02:00.726691+00:00",
+     "duration": 0.003895,
+     "end_time": "2026-06-17T02:08:44.839706+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.722437+00:00",
+     "start_time": "2026-06-17T02:08:44.835811+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,16 +790,16 @@
    "id": "sl10-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.737031Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.736632Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.744700Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.743653Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.849733Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.849392Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.855848Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.855100Z"
     },
     "papermill": {
-     "duration": 0.014516,
-     "end_time": "2026-06-17T02:02:00.745475+00:00",
+     "duration": 0.012867,
+     "end_time": "2026-06-17T02:08:44.856670+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.730959+00:00",
+     "start_time": "2026-06-17T02:08:44.843803+00:00",
      "status": "completed"
     },
     "tags": []
@@ -864,10 +864,10 @@
    "id": "sl10-20",
    "metadata": {
     "papermill": {
-     "duration": 0.004463,
-     "end_time": "2026-06-17T02:02:00.754454+00:00",
+     "duration": 0.004407,
+     "end_time": "2026-06-17T02:08:44.865809+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.749991+00:00",
+     "start_time": "2026-06-17T02:08:44.861402+00:00",
      "status": "completed"
     },
     "tags": []
@@ -905,10 +905,10 @@
    "id": "sl10-21",
    "metadata": {
     "papermill": {
-     "duration": 0.005027,
-     "end_time": "2026-06-17T02:02:00.764320+00:00",
+     "duration": 0.004122,
+     "end_time": "2026-06-17T02:08:44.874183+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.759293+00:00",
+     "start_time": "2026-06-17T02:08:44.870061+00:00",
      "status": "completed"
     },
     "tags": []
@@ -930,16 +930,16 @@
    "id": "sl10-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.775869Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.775446Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.782920Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.781838Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.883084Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.882864Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.887836Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.887100Z"
     },
     "papermill": {
-     "duration": 0.014467,
-     "end_time": "2026-06-17T02:02:00.783782+00:00",
+     "duration": 0.010385,
+     "end_time": "2026-06-17T02:08:44.888383+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.769315+00:00",
+     "start_time": "2026-06-17T02:08:44.877998+00:00",
      "status": "completed"
     },
     "tags": []
@@ -995,10 +995,10 @@
    "id": "sl10-23",
    "metadata": {
     "papermill": {
-     "duration": 0.006799,
-     "end_time": "2026-06-17T02:02:00.795815+00:00",
+     "duration": 0.003792,
+     "end_time": "2026-06-17T02:08:44.896052+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.789016+00:00",
+     "start_time": "2026-06-17T02:08:44.892260+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1028,10 +1028,10 @@
    "id": "sl10-24",
    "metadata": {
     "papermill": {
-     "duration": 0.004833,
-     "end_time": "2026-06-17T02:02:00.805183+00:00",
+     "duration": 0.004153,
+     "end_time": "2026-06-17T02:08:44.904297+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.800350+00:00",
+     "start_time": "2026-06-17T02:08:44.900144+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1059,16 +1059,16 @@
    "id": "sl10-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.818424Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.818037Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.825737Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.824650Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.914068Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.913837Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.920762Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.920055Z"
     },
     "papermill": {
-     "duration": 0.016214,
-     "end_time": "2026-06-17T02:02:00.826662+00:00",
+     "duration": 0.013047,
+     "end_time": "2026-06-17T02:08:44.921506+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.810448+00:00",
+     "start_time": "2026-06-17T02:08:44.908459+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1146,10 +1146,10 @@
    "id": "sl10ex1var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.004717,
-     "end_time": "2026-06-17T02:02:00.836278+00:00",
+     "duration": 0.004422,
+     "end_time": "2026-06-17T02:08:44.930750+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.831561+00:00",
+     "start_time": "2026-06-17T02:08:44.926328+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1173,16 +1173,16 @@
    "id": "sl10ex1var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.848599Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.848238Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.852936Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.852044Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.940896Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.940673Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.944463Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.943861Z"
     },
     "papermill": {
-     "duration": 0.01209,
-     "end_time": "2026-06-17T02:02:00.853655+00:00",
+     "duration": 0.009879,
+     "end_time": "2026-06-17T02:08:44.945030+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.841565+00:00",
+     "start_time": "2026-06-17T02:08:44.935151+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1223,10 +1223,10 @@
    "id": "sl10-26",
    "metadata": {
     "papermill": {
-     "duration": 0.004363,
-     "end_time": "2026-06-17T02:02:00.862742+00:00",
+     "duration": 0.005993,
+     "end_time": "2026-06-17T02:08:44.955569+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.858379+00:00",
+     "start_time": "2026-06-17T02:08:44.949576+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1242,16 +1242,16 @@
    "id": "sl10-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.873171Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.872811Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.876926Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.876013Z"
+     "iopub.execute_input": "2026-06-17T02:08:44.964796Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.964590Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.973075Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.972329Z"
     },
     "papermill": {
-     "duration": 0.010448,
-     "end_time": "2026-06-17T02:02:00.877592+00:00",
+     "duration": 0.01395,
+     "end_time": "2026-06-17T02:08:44.973639+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.867144+00:00",
+     "start_time": "2026-06-17T02:08:44.959689+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1261,24 +1261,192 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Ordre [texte d'abord] : ne_a(sophie, ?) admis = ['lyon']\n",
+      "Ordre [registre d'abord] : ne_a(sophie, ?) admis = ['lyon']\n",
+      "\n",
+      "Oracle a sources (flux complet) : 17 acceptes, 2 rejetes\n",
+      "  REJETE ne_a(sophie, bordeaux) [vieux_registre] -> rejete : source vieux_registre (0.4) <= admise texte_principal (0.9)\n",
+      "  REJETE fondateur_de(atelier_verne, fonderie_brun) [texte_principal] -> types (organisation, organisation) != signature ('personne', 'organisation')\n",
+      "\n",
+      "Lecture : dans les DEUX ordres, lyon (texte_principal, 0.9) l'emporte sur\n",
+      "bordeaux (vieux_registre, 0.4). La decision ne depend plus de la chance de\n",
+      "l'enonce : elle est encodee dans la fiabilite des sources. Attention au cas\n",
+      "d'egalite (deux sources de meme fiabilite) : le tie-break retombe sur\n",
+      "premier-arrive (f_new > f_old est strict) -- l'exercice variation l'attaque.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : Une meilleure politique de conflit\n",
-    "# TODO etudiant : remplacez le premier-arrive-premier-cru par une politique a\n",
-    "# sources : chaque triplet arrive maintenant avec une etiquette de source\n",
-    "# (\"texte_principal\" ou \"vieux_registre\") et un score de fiabilite. En cas de\n",
-    "# conflit fonctionnel, gardez le triplet de la source la plus fiable, QUEL QUE\n",
-    "# SOIT l'ordre d'arrivee.\n",
-    "# Indice : transformez les triplets en (relation, sujet, objet, source) et\n",
-    "# donnez fiabilite 0.9 au texte, 0.4 au registre. Testez les DEUX ordres.\n",
-    "# Etape 1 : oracle_avec_sources(triples_etiquetes, fiabilite)\n",
-    "# Etape 2 : verifiez que lyon gagne meme si bordeaux arrive en premier\n",
-    "# Etape 3 : que se passe-t-il si deux sources ont la meme fiabilite ?\n",
+    "# Exemple guide 2 : Une meilleure politique de conflit (oracle a sources)\n",
+    "#\n",
+    "# L'oracle actuel resout les conflits fonctionnels par \"premier arrive, premier\n",
+    "# cru\" : comme ne_a(sophie, lyon) arrive avant ne_a(sophie, bordeaux), lyon gagne\n",
+    "# -- par chance, car le texte principal est enonce avant le vieux registre. On\n",
+    "# rend cette decision EXPLICITE et robuste a l'ordre : chaque triplet porte une\n",
+    "# etiquette de source et un score de fiabilite ; en cas de conflit fonctionnel,\n",
+    "# on garde le PLUS FIABLE, quel que soit l'ordre d'arrivee.\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : fiabilite par source\n",
+    "FIABILITE = {\"texte_principal\": 0.9, \"vieux_registre\": 0.4}\n",
+    "\n",
+    "\n",
+    "def oracle_avec_sources(triples_etiquetes):\n",
+    "    \"\"\"triples_etiquetes : liste de (relation, sujet, objet, source).\n",
+    "\n",
+    "    Sur un conflit fonctionnel, garde le triplet de la source la plus fiable,\n",
+    "    QUEL QUE SOIT l'ordre d'arrivee. Renvoie (acceptes, rejetes) ou chaque\n",
+    "    element porte sa source.\n",
+    "    \"\"\"\n",
+    "    accepts, rejects = [], []\n",
+    "    for (r, s, o, source) in triples_etiquetes:\n",
+    "        # --- verifications de type (reutilisees de oracle) ---\n",
+    "        sig = SIGNATURES.get(r)\n",
+    "        if sig is None:\n",
+    "            rejects.append(((r, s, o, source), \"relation inconnue\")); continue\n",
+    "        if s not in TYPE_OF or o not in TYPE_OF:\n",
+    "            rejects.append(((r, s, o, source), \"entite inconnue\")); continue\n",
+    "        if (TYPE_OF[s], TYPE_OF[o]) != sig:\n",
+    "            rejects.append(((r, s, o, source),\n",
+    "                f\"types ({TYPE_OF[s]}, {TYPE_OF[o]}) != signature {sig}\")); continue\n",
+    "        # --- conflit fonctionnel parmi les deja admis ---\n",
+    "        conflit = None\n",
+    "        for (rr, ss, oo, src) in accepts:\n",
+    "            if rr != r:\n",
+    "                continue\n",
+    "            if (r, \"sujet\") in FUNCTIONAL and ss == s and oo != o:\n",
+    "                conflit = (rr, ss, oo, src); break        # ne_a(sophie, *)\n",
+    "            if (r, \"objet\") in FUNCTIONAL and oo == o and ss != s:\n",
+    "                conflit = (rr, ss, oo, src); break        # dirige(*, org)\n",
+    "        if conflit is not None:\n",
+    "            f_new, f_old = FIABILITE[source], FIABILITE[conflit[3]]\n",
+    "            if f_new > f_old:\n",
+    "                # le nouveau est PLUS fiable : il ejecte l'ancien, meme arrive apres\n",
+    "                accepts = [t for t in accepts if t != conflit]\n",
+    "                rejects.append(((conflit[0], conflit[1], conflit[2], conflit[3]),\n",
+    "                    f\"ejecte : source {conflit[3]} ({f_old}) < nouvelle {source} ({f_new})\"))\n",
+    "                accepts.append((r, s, o, source))\n",
+    "            else:\n",
+    "                rejects.append(((r, s, o, source),\n",
+    "                    f\"rejete : source {source} ({f_new}) <= admise {conflit[3]} ({f_old})\"))\n",
+    "            continue\n",
+    "        accepts.append((r, s, o, source))\n",
+    "    return accepts, rejects\n",
+    "\n",
+    "\n",
+    "# Etape 2 : on etiquette le flux d'extraction. Le piege bordeaux vient du\n",
+    "# vieux_registre ; tout le reste, du texte_principal.\n",
+    "VIEUX_REGISTRE = {(\"ne_a\", \"sophie\", \"bordeaux\")}\n",
+    "flux = [(r, s, o, \"vieux_registre\" if (r, s, o) in VIEUX_REGISTRE else \"texte_principal\")\n",
+    "        for (r, s, o) in triples]\n",
+    "\n",
+    "# Etape 3 : on isole le conflit ne_a(sophie, *) et on teste les DEUX ordres.\n",
+    "ne_lyon = (\"ne_a\", \"sophie\", \"lyon\", \"texte_principal\")\n",
+    "ne_bord = (\"ne_a\", \"sophie\", \"bordeaux\", \"vieux_registre\")\n",
+    "for nom, ordre in [(\"texte d'abord\", [ne_lyon, ne_bord]),\n",
+    "                   (\"registre d'abord\", [ne_bord, ne_lyon])]:\n",
+    "    acc, rej = oracle_avec_sources(ordre)\n",
+    "    gagnant = [o for (r, s, o, _src) in acc if r == \"ne_a\" and s == \"sophie\"]\n",
+    "    print(f\"Ordre [{nom}] : ne_a(sophie, ?) admis = {gagnant}\")\n",
+    "\n",
+    "print()\n",
+    "acc, rej = oracle_avec_sources(flux)\n",
+    "print(f\"Oracle a sources (flux complet) : {len(acc)} acceptes, {len(rej)} rejetes\")\n",
+    "for (r, s, o, source), raison in rej:\n",
+    "    print(f\"  REJETE {r}({s}, {o}) [{source}] -> {raison}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Lecture : dans les DEUX ordres, lyon (texte_principal, 0.9) l'emporte sur\")\n",
+    "print(\"bordeaux (vieux_registre, 0.4). La decision ne depend plus de la chance de\")\n",
+    "print(\"l'enonce : elle est encodee dans la fiabilite des sources. Attention au cas\")\n",
+    "print(\"d'egalite (deux sources de meme fiabilite) : le tie-break retombe sur\")\n",
+    "print(\"premier-arrive (f_new > f_old est strict) -- l'exercice variation l'attaque.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl10ex2var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003953,
+     "end_time": "2026-06-17T02:08:44.981683+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:08:44.977730+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 (variation) : Vote sur egalite de fiabilite\n",
+    "\n",
+    "Quand deux sources ont la **meme fiabilite** et se contredisent, le tie-break actuel retombe sur \"premier arrive\". Remplacez-le par un **vote** : comptez les soutiens de chaque triplet avant de trancher — celui qui recueille le cumul de fiabilite (ou le nombre de soutiens) le plus eleve gagne.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Etiqueter 3 sources : `texte_principal` (0.9), `acte_officiel` (0.9), `vieux_registre` (0.4). Deux sources a 0.9 soutiennent `ne_a(sophie, lyon)` ; une a 0.4 soutient `ne_a(sophie, bordeaux)`.\n",
+    "2. Implementer `oracle_vote(triples_etiquetes, fiabilite)` : grouper par triplet, puis au conflit garder le triplet au cumul de fiabilite le plus eleve.\n",
+    "3. Verifier que `lyon` l'emporte meme si `bordeaux` arrive en premier, ET qu'aucune source individuelle ne domine seule.\n",
+    "\n",
+    "**Indice** : le vote transforme une decision binaire source-contre-source en une agregation ponderee — c'est l'idee du filet de securite multi-passes + vote mentionne dans la cellule d'extraction.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "sl10ex2var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T02:08:44.991450Z",
+     "iopub.status.busy": "2026-06-17T02:08:44.991221Z",
+     "iopub.status.idle": "2026-06-17T02:08:44.995603Z",
+     "shell.execute_reply": "2026-06-17T02:08:44.994966Z"
+    },
+    "papermill": {
+     "duration": 0.010253,
+     "end_time": "2026-06-17T02:08:44.996183+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:08:44.985930+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : vote sur egalite de fiabilite\n",
+      "Etape 1 : 3 sources (deux a 0.9 pour lyon, une a 0.4 pour bordeaux)\n",
+      "Etape 2 : oracle_vote tranche par cumul de fiabilite / nombre de soutiens\n",
+      "Etape 3 : lyon gagne quel que soit l'ordre d'arrivee\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (variation) : Vote sur egalite de fiabilite\n",
+    "# TODO etudiant : quand deux sources de MEME fiabilite se contredisent, le\n",
+    "# tie-break actuel retombe sur premier-arrive. Remplacez-le par un VOTE.\n",
+    "\n",
+    "# Etape 1 : 3 sources -- deux a 0.9 pour lyon, une a 0.4 pour bordeaux\n",
+    "# sources = {\"texte_principal\": 0.9, \"acte_officiel\": 0.9, \"vieux_registre\": 0.4}\n",
+    "# flux_vote = [\n",
+    "#     (\"ne_a\", \"sophie\", \"lyon\", \"texte_principal\"),\n",
+    "#     (\"ne_a\", \"sophie\", \"lyon\", \"acte_officiel\"),\n",
+    "#     (\"ne_a\", \"sophie\", \"bordeaux\", \"vieux_registre\"),\n",
+    "# ]\n",
+    "\n",
+    "# Etape 2 : oracle_vote : au conflit, garder le triplet au cumul de fiabilite\n",
+    "# (ou nombre de soutiens) le plus eleve -- independant de l'ordre d'arrivee.\n",
+    "# def oracle_vote(triples_etiquetes, fiabilite):\n",
+    "#     ...\n",
+    "\n",
+    "# Etape 3 : lyon doit gagner MEME si bordeaux arrive en premier\n",
+    "print(\"Exercice a completer : vote sur egalite de fiabilite\")\n",
+    "print(\"Etape 1 : 3 sources (deux a 0.9 pour lyon, une a 0.4 pour bordeaux)\")\n",
+    "print(\"Etape 2 : oracle_vote tranche par cumul de fiabilite / nombre de soutiens\")\n",
+    "print(\"Etape 3 : lyon gagne quel que soit l'ordre d'arrivee\")\n",
+    "\n",
+    "# Indice : grouper par (r, s, o), sommer les fiabilites, garder le max.\n",
+    "# C'est l'agregation ponderee derriere le \"multi-passes + vote\" de l'extraction.\n",
+    "# result = None  # TODO etudiant : gagnant du vote\n"
    ]
   },
   {
@@ -1286,10 +1454,10 @@
    "id": "sl10-28",
    "metadata": {
     "papermill": {
-     "duration": 0.006394,
-     "end_time": "2026-06-17T02:02:00.888549+00:00",
+     "duration": 0.003804,
+     "end_time": "2026-06-17T02:08:45.004170+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.882155+00:00",
+     "start_time": "2026-06-17T02:08:45.000366+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1301,20 +1469,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "sl10-29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.898691Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.898300Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.902512Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.901535Z"
+     "iopub.execute_input": "2026-06-17T02:08:45.012959Z",
+     "iopub.status.busy": "2026-06-17T02:08:45.012754Z",
+     "iopub.status.idle": "2026-06-17T02:08:45.016183Z",
+     "shell.execute_reply": "2026-06-17T02:08:45.015471Z"
     },
     "papermill": {
-     "duration": 0.010463,
-     "end_time": "2026-06-17T02:02:00.903303+00:00",
+     "duration": 0.008722,
+     "end_time": "2026-06-17T02:08:45.016716+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.892840+00:00",
+     "start_time": "2026-06-17T02:08:45.007994+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1349,10 +1517,10 @@
    "id": "sl10-30",
    "metadata": {
     "papermill": {
-     "duration": 0.004662,
-     "end_time": "2026-06-17T02:02:00.912587+00:00",
+     "duration": 0.00383,
+     "end_time": "2026-06-17T02:08:45.024607+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.907925+00:00",
+     "start_time": "2026-06-17T02:08:45.020777+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1364,20 +1532,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "sl10-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:02:00.923147Z",
-     "iopub.status.busy": "2026-06-17T02:02:00.922770Z",
-     "iopub.status.idle": "2026-06-17T02:02:00.926797Z",
-     "shell.execute_reply": "2026-06-17T02:02:00.925886Z"
+     "iopub.execute_input": "2026-06-17T02:08:45.033688Z",
+     "iopub.status.busy": "2026-06-17T02:08:45.033442Z",
+     "iopub.status.idle": "2026-06-17T02:08:45.036543Z",
+     "shell.execute_reply": "2026-06-17T02:08:45.035935Z"
     },
     "papermill": {
-     "duration": 0.010129,
-     "end_time": "2026-06-17T02:02:00.927478+00:00",
+     "duration": 0.00859,
+     "end_time": "2026-06-17T02:08:45.037134+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.917349+00:00",
+     "start_time": "2026-06-17T02:08:45.028544+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1412,10 +1580,10 @@
    "id": "sl10-33",
    "metadata": {
     "papermill": {
-     "duration": 0.004645,
-     "end_time": "2026-06-17T02:02:00.937352+00:00",
+     "duration": 0.004398,
+     "end_time": "2026-06-17T02:08:45.045925+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.932707+00:00",
+     "start_time": "2026-06-17T02:08:45.041527+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1466,10 +1634,10 @@
    "id": "sl10-32",
    "metadata": {
     "papermill": {
-     "duration": 0.003883,
-     "end_time": "2026-06-17T02:02:00.945222+00:00",
+     "duration": 0.004274,
+     "end_time": "2026-06-17T02:08:45.054380+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.941339+00:00",
+     "start_time": "2026-06-17T02:08:45.050106+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1497,10 +1665,10 @@
    "id": "sl10-34",
    "metadata": {
     "papermill": {
-     "duration": 0.003801,
-     "end_time": "2026-06-17T02:02:00.953057+00:00",
+     "duration": 0.004433,
+     "end_time": "2026-06-17T02:08:45.063404+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:02:00.949256+00:00",
+     "start_time": "2026-06-17T02:08:45.058971+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1543,14 +1711,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.854294,
-   "end_time": "2026-06-17T02:02:01.198065+00:00",
+   "duration": 2.465146,
+   "end_time": "2026-06-17T02:08:45.309877+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T02:01:58.343771+00:00",
+   "start_time": "2026-06-17T02:08:42.844731+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
@@ -5,10 +5,10 @@
    "id": "sl10-01",
    "metadata": {
     "papermill": {
-     "duration": 0.004344,
-     "end_time": "2026-06-17T02:08:44.656424+00:00",
+     "duration": 0.004235,
+     "end_time": "2026-06-17T02:11:26.711654+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.652080+00:00",
+     "start_time": "2026-06-17T02:11:26.707419+00:00",
      "status": "completed"
     },
     "tags": []
@@ -43,10 +43,10 @@
    "id": "sl10-02",
    "metadata": {
     "papermill": {
-     "duration": 0.003477,
-     "end_time": "2026-06-17T02:08:44.666400+00:00",
+     "duration": 0.003478,
+     "end_time": "2026-06-17T02:11:26.719030+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.662923+00:00",
+     "start_time": "2026-06-17T02:11:26.715552+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "sl10-03",
    "metadata": {
     "papermill": {
-     "duration": 0.003515,
-     "end_time": "2026-06-17T02:08:44.673494+00:00",
+     "duration": 0.003949,
+     "end_time": "2026-06-17T02:11:26.726553+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.669979+00:00",
+     "start_time": "2026-06-17T02:11:26.722604+00:00",
      "status": "completed"
     },
     "tags": []
@@ -113,16 +113,16 @@
    "id": "sl10-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.681868Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.681587Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.690038Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.689267Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.735016Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.734781Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.742365Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.741728Z"
     },
     "papermill": {
-     "duration": 0.013892,
-     "end_time": "2026-06-17T02:08:44.690891+00:00",
+     "duration": 0.012773,
+     "end_time": "2026-06-17T02:11:26.742971+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.676999+00:00",
+     "start_time": "2026-06-17T02:11:26.730198+00:00",
      "status": "completed"
     },
     "tags": []
@@ -186,10 +186,10 @@
    "id": "sl10-05",
    "metadata": {
     "papermill": {
-     "duration": 0.003624,
-     "end_time": "2026-06-17T02:08:44.698354+00:00",
+     "duration": 0.003626,
+     "end_time": "2026-06-17T02:11:26.750383+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.694730+00:00",
+     "start_time": "2026-06-17T02:11:26.746757+00:00",
      "status": "completed"
     },
     "tags": []
@@ -205,10 +205,10 @@
    "id": "sl10-06",
    "metadata": {
     "papermill": {
-     "duration": 0.003499,
-     "end_time": "2026-06-17T02:08:44.705386+00:00",
+     "duration": 0.004059,
+     "end_time": "2026-06-17T02:11:26.758131+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.701887+00:00",
+     "start_time": "2026-06-17T02:11:26.754072+00:00",
      "status": "completed"
     },
     "tags": []
@@ -230,16 +230,16 @@
    "id": "sl10-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.713946Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.713729Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.724406Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.723682Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.766605Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.766415Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.775406Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.774784Z"
     },
     "papermill": {
-     "duration": 0.016212,
-     "end_time": "2026-06-17T02:08:44.725109+00:00",
+     "duration": 0.014169,
+     "end_time": "2026-06-17T02:11:26.775917+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.708897+00:00",
+     "start_time": "2026-06-17T02:11:26.761748+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,16 +287,16 @@
    "id": "sl10-08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.734131Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.733864Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.742116Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.741450Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.786929Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.786713Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.793969Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.793347Z"
     },
     "papermill": {
-     "duration": 0.014189,
-     "end_time": "2026-06-17T02:08:44.743063+00:00",
+     "duration": 0.014706,
+     "end_time": "2026-06-17T02:11:26.794757+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.728874+00:00",
+     "start_time": "2026-06-17T02:11:26.780051+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,10 +398,10 @@
    "id": "sl10-09",
    "metadata": {
     "papermill": {
-     "duration": 0.004058,
-     "end_time": "2026-06-17T02:08:44.751534+00:00",
+     "duration": 0.00483,
+     "end_time": "2026-06-17T02:11:26.803634+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.747476+00:00",
+     "start_time": "2026-06-17T02:11:26.798804+00:00",
      "status": "completed"
     },
     "tags": []
@@ -426,10 +426,10 @@
    "id": "sl10-10",
    "metadata": {
     "papermill": {
-     "duration": 0.003506,
-     "end_time": "2026-06-17T02:08:44.758912+00:00",
+     "duration": 0.003411,
+     "end_time": "2026-06-17T02:11:26.811031+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.755406+00:00",
+     "start_time": "2026-06-17T02:11:26.807620+00:00",
      "status": "completed"
     },
     "tags": []
@@ -452,16 +452,16 @@
    "id": "sl10-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.767502Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.767316Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.772450Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.771893Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.819240Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.818887Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.824324Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.823833Z"
     },
     "papermill": {
-     "duration": 0.010713,
-     "end_time": "2026-06-17T02:08:44.772984+00:00",
+     "duration": 0.010927,
+     "end_time": "2026-06-17T02:11:26.825246+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.762271+00:00",
+     "start_time": "2026-06-17T02:11:26.814319+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,10 +519,10 @@
    "id": "sl10-12",
    "metadata": {
     "papermill": {
-     "duration": 0.003555,
-     "end_time": "2026-06-17T02:08:44.780343+00:00",
+     "duration": 0.003528,
+     "end_time": "2026-06-17T02:11:26.832393+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.776788+00:00",
+     "start_time": "2026-06-17T02:11:26.828865+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,10 +550,10 @@
    "id": "sl10-13",
    "metadata": {
     "papermill": {
-     "duration": 0.003597,
-     "end_time": "2026-06-17T02:08:44.787533+00:00",
+     "duration": 0.003423,
+     "end_time": "2026-06-17T02:11:26.839231+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.783936+00:00",
+     "start_time": "2026-06-17T02:11:26.835808+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "sl10-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.796317Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.796118Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.800552Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.799934Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.847413Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.847193Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.851353Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.850812Z"
     },
     "papermill": {
-     "duration": 0.009947,
-     "end_time": "2026-06-17T02:08:44.801238+00:00",
+     "duration": 0.009188,
+     "end_time": "2026-06-17T02:11:26.851980+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.791291+00:00",
+     "start_time": "2026-06-17T02:11:26.842792+00:00",
      "status": "completed"
     },
     "tags": []
@@ -622,10 +622,10 @@
    "id": "sl10-15",
    "metadata": {
     "papermill": {
-     "duration": 0.003943,
-     "end_time": "2026-06-17T02:08:44.809141+00:00",
+     "duration": 0.003488,
+     "end_time": "2026-06-17T02:11:26.859264+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.805198+00:00",
+     "start_time": "2026-06-17T02:11:26.855776+00:00",
      "status": "completed"
     },
     "tags": []
@@ -653,16 +653,16 @@
    "id": "sl10-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.817751Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.817561Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.823554Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.823000Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.867419Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.867227Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.873094Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.872441Z"
     },
     "papermill": {
-     "duration": 0.011408,
-     "end_time": "2026-06-17T02:08:44.824259+00:00",
+     "duration": 0.010826,
+     "end_time": "2026-06-17T02:11:26.873562+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.812851+00:00",
+     "start_time": "2026-06-17T02:11:26.862736+00:00",
      "status": "completed"
     },
     "tags": []
@@ -728,10 +728,10 @@
    "id": "sl10-17",
    "metadata": {
     "papermill": {
-     "duration": 0.003717,
-     "end_time": "2026-06-17T02:08:44.832089+00:00",
+     "duration": 0.003779,
+     "end_time": "2026-06-17T02:11:26.881137+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.828372+00:00",
+     "start_time": "2026-06-17T02:11:26.877358+00:00",
      "status": "completed"
     },
     "tags": []
@@ -766,10 +766,10 @@
    "id": "sl10-18",
    "metadata": {
     "papermill": {
-     "duration": 0.003895,
-     "end_time": "2026-06-17T02:08:44.839706+00:00",
+     "duration": 0.003681,
+     "end_time": "2026-06-17T02:11:26.888524+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.835811+00:00",
+     "start_time": "2026-06-17T02:11:26.884843+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,16 +790,16 @@
    "id": "sl10-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.849733Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.849392Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.855848Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.855100Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.897923Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.897732Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.903182Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.902639Z"
     },
     "papermill": {
-     "duration": 0.012867,
-     "end_time": "2026-06-17T02:08:44.856670+00:00",
+     "duration": 0.01141,
+     "end_time": "2026-06-17T02:11:26.903690+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.843803+00:00",
+     "start_time": "2026-06-17T02:11:26.892280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -864,10 +864,10 @@
    "id": "sl10-20",
    "metadata": {
     "papermill": {
-     "duration": 0.004407,
-     "end_time": "2026-06-17T02:08:44.865809+00:00",
+     "duration": 0.00416,
+     "end_time": "2026-06-17T02:11:26.911751+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.861402+00:00",
+     "start_time": "2026-06-17T02:11:26.907591+00:00",
      "status": "completed"
     },
     "tags": []
@@ -905,10 +905,10 @@
    "id": "sl10-21",
    "metadata": {
     "papermill": {
-     "duration": 0.004122,
-     "end_time": "2026-06-17T02:08:44.874183+00:00",
+     "duration": 0.003549,
+     "end_time": "2026-06-17T02:11:26.919256+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.870061+00:00",
+     "start_time": "2026-06-17T02:11:26.915707+00:00",
      "status": "completed"
     },
     "tags": []
@@ -930,16 +930,16 @@
    "id": "sl10-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.883084Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.882864Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.887836Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.887100Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.928123Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.927799Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.932730Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.931985Z"
     },
     "papermill": {
-     "duration": 0.010385,
-     "end_time": "2026-06-17T02:08:44.888383+00:00",
+     "duration": 0.010505,
+     "end_time": "2026-06-17T02:11:26.933339+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.877998+00:00",
+     "start_time": "2026-06-17T02:11:26.922834+00:00",
      "status": "completed"
     },
     "tags": []
@@ -995,10 +995,10 @@
    "id": "sl10-23",
    "metadata": {
     "papermill": {
-     "duration": 0.003792,
-     "end_time": "2026-06-17T02:08:44.896052+00:00",
+     "duration": 0.003859,
+     "end_time": "2026-06-17T02:11:26.941337+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.892260+00:00",
+     "start_time": "2026-06-17T02:11:26.937478+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1028,10 +1028,10 @@
    "id": "sl10-24",
    "metadata": {
     "papermill": {
-     "duration": 0.004153,
-     "end_time": "2026-06-17T02:08:44.904297+00:00",
+     "duration": 0.003665,
+     "end_time": "2026-06-17T02:11:26.948779+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.900144+00:00",
+     "start_time": "2026-06-17T02:11:26.945114+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1059,16 +1059,16 @@
    "id": "sl10-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.914068Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.913837Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.920762Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.920055Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.957961Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.957670Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.963379Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.962772Z"
     },
     "papermill": {
-     "duration": 0.013047,
-     "end_time": "2026-06-17T02:08:44.921506+00:00",
+     "duration": 0.011162,
+     "end_time": "2026-06-17T02:11:26.963919+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.908459+00:00",
+     "start_time": "2026-06-17T02:11:26.952757+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1146,10 +1146,10 @@
    "id": "sl10ex1var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.004422,
-     "end_time": "2026-06-17T02:08:44.930750+00:00",
+     "duration": 0.004175,
+     "end_time": "2026-06-17T02:11:26.972354+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.926328+00:00",
+     "start_time": "2026-06-17T02:11:26.968179+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1173,16 +1173,16 @@
    "id": "sl10ex1var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.940896Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.940673Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.944463Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.943861Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.981783Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.981578Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.984751Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.984263Z"
     },
     "papermill": {
-     "duration": 0.009879,
-     "end_time": "2026-06-17T02:08:44.945030+00:00",
+     "duration": 0.009079,
+     "end_time": "2026-06-17T02:11:26.985397+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.935151+00:00",
+     "start_time": "2026-06-17T02:11:26.976318+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1223,10 +1223,10 @@
    "id": "sl10-26",
    "metadata": {
     "papermill": {
-     "duration": 0.005993,
-     "end_time": "2026-06-17T02:08:44.955569+00:00",
+     "duration": 0.004223,
+     "end_time": "2026-06-17T02:11:26.995752+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.949576+00:00",
+     "start_time": "2026-06-17T02:11:26.991529+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1242,16 +1242,16 @@
    "id": "sl10-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.964796Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.964590Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.973075Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.972329Z"
+     "iopub.execute_input": "2026-06-17T02:11:27.005152Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.004967Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.013060Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.012526Z"
     },
     "papermill": {
-     "duration": 0.01395,
-     "end_time": "2026-06-17T02:08:44.973639+00:00",
+     "duration": 0.013599,
+     "end_time": "2026-06-17T02:11:27.013567+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.959689+00:00",
+     "start_time": "2026-06-17T02:11:26.999968+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1367,10 +1367,10 @@
    "id": "sl10ex2var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003953,
-     "end_time": "2026-06-17T02:08:44.981683+00:00",
+     "duration": 0.003781,
+     "end_time": "2026-06-17T02:11:27.021227+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.977730+00:00",
+     "start_time": "2026-06-17T02:11:27.017446+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1394,16 +1394,16 @@
    "id": "sl10ex2var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.991450Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.991221Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.995603Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.994966Z"
+     "iopub.execute_input": "2026-06-17T02:11:27.029355Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.029207Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.032089Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.031666Z"
     },
     "papermill": {
-     "duration": 0.010253,
-     "end_time": "2026-06-17T02:08:44.996183+00:00",
+     "duration": 0.007826,
+     "end_time": "2026-06-17T02:11:27.032633+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.985930+00:00",
+     "start_time": "2026-06-17T02:11:27.024807+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1454,10 +1454,10 @@
    "id": "sl10-28",
    "metadata": {
     "papermill": {
-     "duration": 0.003804,
-     "end_time": "2026-06-17T02:08:45.004170+00:00",
+     "duration": 0.003614,
+     "end_time": "2026-06-17T02:11:27.040229+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.000366+00:00",
+     "start_time": "2026-06-17T02:11:27.036615+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1473,16 +1473,16 @@
    "id": "sl10-29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:45.012959Z",
-     "iopub.status.busy": "2026-06-17T02:08:45.012754Z",
-     "iopub.status.idle": "2026-06-17T02:08:45.016183Z",
-     "shell.execute_reply": "2026-06-17T02:08:45.015471Z"
+     "iopub.execute_input": "2026-06-17T02:11:27.048557Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.048407Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.053829Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.053356Z"
     },
     "papermill": {
-     "duration": 0.008722,
-     "end_time": "2026-06-17T02:08:45.016716+00:00",
+     "duration": 0.010271,
+     "end_time": "2026-06-17T02:11:27.054282+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.007994+00:00",
+     "start_time": "2026-06-17T02:11:27.044011+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1492,24 +1492,165 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "seuil | vraies | fausses | separable ?\n",
+      "---------------------------------------------\n",
+      "  0.0 |      2 |       3 | non\n",
+      "  0.1 |      2 |       3 | non\n",
+      "  0.2 |      2 |       3 | non\n",
+      "  0.3 |      2 |       3 | non\n",
+      "  0.4 |      2 |       3 | non\n",
+      "  0.5 |      2 |       2 | non\n",
+      "  0.6 |      2 |       2 | non\n",
+      "  0.7 |      1 |       0 | non\n",
+      "  0.8 |      1 |       0 | non\n",
+      "  0.9 |      1 |       0 | non\n",
+      "  1.0 |      1 |       0 | non\n",
+      "\n",
+      "Un seuil separant toutes les VRAIES de toutes les FAUSSES existe-t-il ? NON.\n",
+      "\n",
+      "Lecture : grandparent (VRAIE) et travaille_pour :- parent o travaille_pour\n",
+      "(FAUSSE) ont la MEME confiance 0.67. Tout seuil <= 0.67 les garde toutes\n",
+      "les deux (fausses qui leurent) ; tout seuil > 0.67 les jette toutes les\n",
+      "deux (vraie perdue). Le seuil ne peut pas couper ENTRE deux regles de meme\n",
+      "confiance : le bon seuil n'existe pas. Pour separer ces deux regles il\n",
+      "faudrait un SCORE DIFFERENT de la confiance -- un score qui recompense le\n",
+      "fait que grandparent est causalement amont, ou penalise l'effet 'conjoint'\n",
+      "(travail des enfants => travail des parents). Les donnees seules (comptage)\n",
+      "ne suffisent pas : il faut soit un biais de gabarit (refuser une tete\n",
+      "'travaille_pour' derivee d'une chaine par 'parent'), soit des contre-exemples\n",
+      "(un parent dont l'enfant travaille ailleurs sans y travailler lui-meme).\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 3 : Le bon seuil n'existe pas\n",
-    "# TODO etudiant : faites varier min_conf de 0.0 a 1.0 (pas de 0.1) et classez a\n",
-    "# la main chaque regle candidate comme VRAIE (loi du domaine) ou FAUSSE\n",
-    "# (correlation du micro-monde). Tracez (ou tabulez) le nombre de vraies regles\n",
-    "# retenues et de fausses regles retenues a chaque seuil.\n",
-    "# Indice : grandparent :- parent o parent est VRAIE ; travaille_pour :- parent o\n",
-    "# travaille_pour est FAUSSE ; les deux ont la MEME confiance 0.67...\n",
-    "# Etape 1 : tableau seuil -> (vraies retenues, fausses retenues)\n",
-    "# Etape 2 : existe-t-il un seuil qui garde toutes les vraies et aucune fausse ?\n",
-    "# Etape 3 : que faudrait-il changer (donnees ? gabarits ? score ?) pour separer\n",
-    "#           ces deux regles ?\n",
+    "# Exemple guide 3 : Le bon seuil n'existe pas\n",
+    "#\n",
+    "# La confiance filtre les regles minees par FREQUENCE, pas par SENS. On quantifie\n",
+    "# cette impuissance : on fait varier min_conf de 0.0 a 1.0, on classe CHAQUE\n",
+    "# candidate a la main (loi du domaine VRAIE vs coincidence du micro-monde\n",
+    "# FAUSSE), et on cherche s'il existe un seuil qui garde toutes les vraies sans\n",
+    "# aucune fausse.\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : verdict manuel de chaque candidate (cf l'interpretation de mine_rules)\n",
+    "VERDICT = {\n",
+    "    \"travaille_pour(X,Y) :- dirige(X,Y)\":                      \"VRAIE\",   # 1.00 quasi-schema\n",
+    "    \"grandparent(X,Y) :- parent(X,Z), parent(Z,Y)\":            \"VRAIE\",   # 0.67 la definition\n",
+    "    \"dirige(X,Y) :- parent(X,Z), travaille_pour(Z,Y)\":         \"FAUSSE\",  # 0.67 franchement fausse\n",
+    "    \"travaille_pour(X,Y) :- parent(X,Z), travaille_pour(Z,Y)\": \"FAUSSE\",  # 0.67 suspecte\n",
+    "    \"dirige(X,Y) :- travaille_pour(X,Y)\":                      \"FAUSSE\",  # 0.40 sur-generalisation\n",
+    "}\n",
+    "\n",
+    "# Etape 2 : balayage des seuils -- on recombine les memes candidates, sans\n",
+    "# re-miner, en changeant seulement le seuil de retention.\n",
+    "print(f\"{'seuil':>5} | {'vraies':>6} | {'fausses':>7} | separable ?\")\n",
+    "print(\"-\" * 45)\n",
+    "separable_trouve = False\n",
+    "for seuil_10 in range(0, 11):\n",
+    "    seuil = seuil_10 / 10\n",
+    "    retenues = [c for c in candidates if c[\"conf\"] >= seuil]\n",
+    "    v = sum(1 for c in retenues if VERDICT[c[\"text\"]] == \"VRAIE\")\n",
+    "    f = sum(1 for c in retenues if VERDICT[c[\"text\"]] == \"FAUSSE\")\n",
+    "    sep = (v == 2 and f == 0)   # garde toutes les vraies, aucune fausse\n",
+    "    separable_trouve = separable_trouve or sep\n",
+    "    print(f\"{seuil:>5.1f} | {v:>6} | {f:>7} | {'OUI' if sep else 'non'}\")\n",
+    "\n",
+    "print()\n",
+    "print(f\"Un seuil separant toutes les VRAIES de toutes les FAUSSES existe-t-il ? \"\n",
+    "      f\"{'OUI' if separable_trouve else 'NON.'}\")\n",
+    "print()\n",
+    "print(\"Lecture : grandparent (VRAIE) et travaille_pour :- parent o travaille_pour\")\n",
+    "print(\"(FAUSSE) ont la MEME confiance 0.67. Tout seuil <= 0.67 les garde toutes\")\n",
+    "print(\"les deux (fausses qui leurent) ; tout seuil > 0.67 les jette toutes les\")\n",
+    "print(\"deux (vraie perdue). Le seuil ne peut pas couper ENTRE deux regles de meme\")\n",
+    "print(\"confiance : le bon seuil n'existe pas. Pour separer ces deux regles il\")\n",
+    "print(\"faudrait un SCORE DIFFERENT de la confiance -- un score qui recompense le\")\n",
+    "print(\"fait que grandparent est causalement amont, ou penalise l'effet 'conjoint'\")\n",
+    "print(\"(travail des enfants => travail des parents). Les donnees seules (comptage)\")\n",
+    "print(\"ne suffisent pas : il faut soit un biais de gabarit (refuser une tete\")\n",
+    "print(\"'travaille_pour' derivee d'une chaine par 'parent'), soit des contre-exemples\")\n",
+    "print(\"(un parent dont l'enfant travaille ailleurs sans y travailler lui-meme).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl10ex3var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003548,
+     "end_time": "2026-06-17T02:11:27.061419+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:11:27.057871+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (variation) : Un score qui separe\n",
+    "\n",
+    "La confiance echoue a separer `grandparent` (VRAIE) de `travaille_pour :- parent o travaille_pour` (FAUSSE), toutes deux a 0.67. Inventez un score **complementaire** qui les separe.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Pour chaque candidate, calculer un score de **diversite du support** : nombre de SUJETS distincts dans ses instances de support (un vrai `grandparent` vient de plusieurs familles ; une coincidence de micro-monde tient souvent a une seule).\n",
+    "2. Re-classer les candidates par ce score et verifier que `grandparent` > `travaille_pour :- parent`.\n",
+    "3. Quelle paire de regles ce score echoue-t-il a separer a son tour ?\n",
+    "\n",
+    "**Indice** : aucun score unique ne separe tout -- c'est le moteur des approches multi-criteres (confidence + support + diversite + leverage) en association rule mining.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "sl10ex3var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T02:11:27.069902Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.069749Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.073068Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.072597Z"
+    },
+    "papermill": {
+     "duration": 0.008386,
+     "end_time": "2026-06-17T02:11:27.073583+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:11:27.065197+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : un score complementaire separateur\n",
+      "Etape 1 : diversite du support = nombre de sujets distincts\n",
+      "Etape 2 : grandparent doit battre travaille_pour:-parent\n",
+      "Etape 3 : quelle paire reste inseparable ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (variation) : Un score qui separe\n",
+    "# TODO etudiant : la confiance ne separe pas grandparent (VRAIE) de\n",
+    "# travaille_pour:-parent (FAUSSE), toutes deux a 0.67. Inventez un score de\n",
+    "# DIVERSITE du support.\n",
+    "\n",
+    "# Etape 1 : pour chaque candidate, compter les SUJETS distincts dans ses\n",
+    "# instances de support (support = inst & rels[head]).\n",
+    "# def diversite_support(candidate, kg_facts):\n",
+    "#     ...\n",
+    "\n",
+    "# Etape 2 : re-classer par diversite et verifier grandparent > travaille_pour:-parent\n",
+    "# Etape 3 : quelle paire ce score echoue-t-il a separer a son tour ?\n",
+    "\n",
+    "print(\"Exercice a completer : un score complementaire separateur\")\n",
+    "print(\"Etape 1 : diversite du support = nombre de sujets distincts\")\n",
+    "print(\"Etape 2 : grandparent doit battre travaille_pour:-parent\")\n",
+    "print(\"Etape 3 : quelle paire reste inseparable ?\")\n",
+    "\n",
+    "# Indice : aucun score unique ne separe tout -> multi-criteres (conf + support +\n",
+    "# diversite + leverage). C'est le coeur de l'association rule mining.\n",
+    "# result = None  # TODO etudiant : classement par diversite\n"
    ]
   },
   {
@@ -1517,10 +1658,10 @@
    "id": "sl10-30",
    "metadata": {
     "papermill": {
-     "duration": 0.00383,
-     "end_time": "2026-06-17T02:08:45.024607+00:00",
+     "duration": 0.003962,
+     "end_time": "2026-06-17T02:11:27.081378+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.020777+00:00",
+     "start_time": "2026-06-17T02:11:27.077416+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1532,20 +1673,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "sl10-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:45.033688Z",
-     "iopub.status.busy": "2026-06-17T02:08:45.033442Z",
-     "iopub.status.idle": "2026-06-17T02:08:45.036543Z",
-     "shell.execute_reply": "2026-06-17T02:08:45.035935Z"
+     "iopub.execute_input": "2026-06-17T02:11:27.090048Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.089898Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.093161Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.092665Z"
     },
     "papermill": {
-     "duration": 0.00859,
-     "end_time": "2026-06-17T02:08:45.037134+00:00",
+     "duration": 0.008477,
+     "end_time": "2026-06-17T02:11:27.093837+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.028544+00:00",
+     "start_time": "2026-06-17T02:11:27.085360+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1580,10 +1721,10 @@
    "id": "sl10-33",
    "metadata": {
     "papermill": {
-     "duration": 0.004398,
-     "end_time": "2026-06-17T02:08:45.045925+00:00",
+     "duration": 0.004073,
+     "end_time": "2026-06-17T02:11:27.102369+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.041527+00:00",
+     "start_time": "2026-06-17T02:11:27.098296+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1634,10 +1775,10 @@
    "id": "sl10-32",
    "metadata": {
     "papermill": {
-     "duration": 0.004274,
-     "end_time": "2026-06-17T02:08:45.054380+00:00",
+     "duration": 0.004077,
+     "end_time": "2026-06-17T02:11:27.110471+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.050106+00:00",
+     "start_time": "2026-06-17T02:11:27.106394+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1665,10 +1806,10 @@
    "id": "sl10-34",
    "metadata": {
     "papermill": {
-     "duration": 0.004433,
-     "end_time": "2026-06-17T02:08:45.063404+00:00",
+     "duration": 0.004461,
+     "end_time": "2026-06-17T02:11:27.119330+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.058971+00:00",
+     "start_time": "2026-06-17T02:11:27.114869+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1711,14 +1852,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.465146,
-   "end_time": "2026-06-17T02:08:45.309877+00:00",
+   "duration": 2.27951,
+   "end_time": "2026-06-17T02:11:27.255539+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T02:08:42.844731+00:00",
+   "start_time": "2026-06-17T02:11:24.976029+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
@@ -5,10 +5,10 @@
    "id": "sl10-01",
    "metadata": {
     "papermill": {
-     "duration": 0.004761,
-     "end_time": "2026-06-10T12:10:50.961396",
+     "duration": 0.005134,
+     "end_time": "2026-06-17T02:02:00.485249+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:50.956635",
+     "start_time": "2026-06-17T02:02:00.480115+00:00",
      "status": "completed"
     },
     "tags": []
@@ -43,10 +43,10 @@
    "id": "sl10-02",
    "metadata": {
     "papermill": {
-     "duration": 0.003661,
-     "end_time": "2026-06-10T12:10:50.967749",
+     "duration": 0.004247,
+     "end_time": "2026-06-17T02:02:00.495353+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:50.964088",
+     "start_time": "2026-06-17T02:02:00.491106+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "sl10-03",
    "metadata": {
     "papermill": {
-     "duration": 0.004786,
-     "end_time": "2026-06-10T12:10:50.975700",
+     "duration": 0.006056,
+     "end_time": "2026-06-17T02:02:00.507020+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:50.970914",
+     "start_time": "2026-06-17T02:02:00.500964+00:00",
      "status": "completed"
     },
     "tags": []
@@ -113,16 +113,16 @@
    "id": "sl10-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:10:50.985171Z",
-     "iopub.status.busy": "2026-06-10T12:10:50.985171Z",
-     "iopub.status.idle": "2026-06-10T12:10:51.004150Z",
-     "shell.execute_reply": "2026-06-10T12:10:51.002516Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.522004Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.521659Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.533453Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.532195Z"
     },
     "papermill": {
-     "duration": 0.024767,
-     "end_time": "2026-06-10T12:10:51.005204",
+     "duration": 0.020963,
+     "end_time": "2026-06-17T02:02:00.534529+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:50.980437",
+     "start_time": "2026-06-17T02:02:00.513566+00:00",
      "status": "completed"
     },
     "tags": []
@@ -186,10 +186,10 @@
    "id": "sl10-05",
    "metadata": {
     "papermill": {
-     "duration": 0.004762,
-     "end_time": "2026-06-10T12:10:51.015236",
+     "duration": 0.004987,
+     "end_time": "2026-06-17T02:02:00.544398+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:51.010474",
+     "start_time": "2026-06-17T02:02:00.539411+00:00",
      "status": "completed"
     },
     "tags": []
@@ -205,10 +205,10 @@
    "id": "sl10-06",
    "metadata": {
     "papermill": {
-     "duration": 0.004807,
-     "end_time": "2026-06-10T12:10:51.024446",
+     "duration": 0.007925,
+     "end_time": "2026-06-17T02:02:00.558387+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:51.019639",
+     "start_time": "2026-06-17T02:02:00.550462+00:00",
      "status": "completed"
     },
     "tags": []
@@ -230,16 +230,16 @@
    "id": "sl10-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:10:51.035120Z",
-     "iopub.status.busy": "2026-06-10T12:10:51.035120Z",
-     "iopub.status.idle": "2026-06-10T12:10:51.716651Z",
-     "shell.execute_reply": "2026-06-10T12:10:51.716651Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.575416Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.574978Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.591211Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.590040Z"
     },
     "papermill": {
-     "duration": 0.688503,
-     "end_time": "2026-06-10T12:10:51.717656",
+     "duration": 0.025771,
+     "end_time": "2026-06-17T02:02:00.592285+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:51.029153",
+     "start_time": "2026-06-17T02:02:00.566514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,16 +287,16 @@
    "id": "sl10-08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:10:51.724655Z",
-     "iopub.status.busy": "2026-06-10T12:10:51.723655Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.640202Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.639198Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.603594Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.603354Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.614020Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.612922Z"
     },
     "papermill": {
-     "duration": 10.92005,
-     "end_time": "2026-06-10T12:11:02.640705",
+     "duration": 0.017553,
+     "end_time": "2026-06-17T02:02:00.614851+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:10:51.720655",
+     "start_time": "2026-06-17T02:02:00.597298+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,10 +398,10 @@
    "id": "sl10-09",
    "metadata": {
     "papermill": {
-     "duration": 0.004068,
-     "end_time": "2026-06-10T12:11:02.649904",
+     "duration": 0.005012,
+     "end_time": "2026-06-17T02:02:00.625095+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.645836",
+     "start_time": "2026-06-17T02:02:00.620083+00:00",
      "status": "completed"
     },
     "tags": []
@@ -426,10 +426,10 @@
    "id": "sl10-10",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-10T12:11:02.657923",
+     "duration": 0.004026,
+     "end_time": "2026-06-17T02:02:00.633345+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.653923",
+     "start_time": "2026-06-17T02:02:00.629319+00:00",
      "status": "completed"
     },
     "tags": []
@@ -452,16 +452,16 @@
    "id": "sl10-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.670149Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.668641Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.686314Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.685209Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.642971Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.642620Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.649214Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.648383Z"
     },
     "papermill": {
-     "duration": 0.023765,
-     "end_time": "2026-06-10T12:11:02.687358",
+     "duration": 0.012458,
+     "end_time": "2026-06-17T02:02:00.649883+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.663593",
+     "start_time": "2026-06-17T02:02:00.637425+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,10 +519,10 @@
    "id": "sl10-12",
    "metadata": {
     "papermill": {
-     "duration": 0.005222,
-     "end_time": "2026-06-10T12:11:02.697307",
+     "duration": 0.004125,
+     "end_time": "2026-06-17T02:02:00.658016+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.692085",
+     "start_time": "2026-06-17T02:02:00.653891+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,10 +550,10 @@
    "id": "sl10-13",
    "metadata": {
     "papermill": {
-     "duration": 0.004702,
-     "end_time": "2026-06-10T12:11:02.706309",
+     "duration": 0.003871,
+     "end_time": "2026-06-17T02:02:00.665660+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.701607",
+     "start_time": "2026-06-17T02:02:00.661789+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "sl10-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.717459Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.716935Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.732298Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.731177Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.674827Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.674518Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.679303Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.678413Z"
     },
     "papermill": {
-     "duration": 0.022238,
-     "end_time": "2026-06-10T12:11:02.733335",
+     "duration": 0.010559,
+     "end_time": "2026-06-17T02:02:00.680028+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.711097",
+     "start_time": "2026-06-17T02:02:00.669469+00:00",
      "status": "completed"
     },
     "tags": []
@@ -622,10 +622,10 @@
    "id": "sl10-15",
    "metadata": {
     "papermill": {
-     "duration": 0.005483,
-     "end_time": "2026-06-10T12:11:02.743437",
+     "duration": 0.004601,
+     "end_time": "2026-06-17T02:02:00.688960+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.737954",
+     "start_time": "2026-06-17T02:02:00.684359+00:00",
      "status": "completed"
     },
     "tags": []
@@ -653,16 +653,16 @@
    "id": "sl10-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.755115Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.755115Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.763956Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.762950Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.699972Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.699604Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.708125Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.707140Z"
     },
     "papermill": {
-     "duration": 0.017316,
-     "end_time": "2026-06-10T12:11:02.764956",
+     "duration": 0.015142,
+     "end_time": "2026-06-17T02:02:00.708906+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.747640",
+     "start_time": "2026-06-17T02:02:00.693764+00:00",
      "status": "completed"
     },
     "tags": []
@@ -728,10 +728,10 @@
    "id": "sl10-17",
    "metadata": {
     "papermill": {
-     "duration": 0.004109,
-     "end_time": "2026-06-10T12:11:02.774607",
+     "duration": 0.004411,
+     "end_time": "2026-06-17T02:02:00.718014+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.770498",
+     "start_time": "2026-06-17T02:02:00.713603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -766,10 +766,10 @@
    "id": "sl10-18",
    "metadata": {
     "papermill": {
-     "duration": 0.004795,
-     "end_time": "2026-06-10T12:11:02.784541",
+     "duration": 0.004254,
+     "end_time": "2026-06-17T02:02:00.726691+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.779746",
+     "start_time": "2026-06-17T02:02:00.722437+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,16 +790,16 @@
    "id": "sl10-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.796704Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.796704Z",
-     "iopub.status.idle": "2026-06-10T12:11:02.811213Z",
-     "shell.execute_reply": "2026-06-10T12:11:02.809603Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.737031Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.736632Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.744700Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.743653Z"
     },
     "papermill": {
-     "duration": 0.021077,
-     "end_time": "2026-06-10T12:11:02.811213",
+     "duration": 0.014516,
+     "end_time": "2026-06-17T02:02:00.745475+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.790136",
+     "start_time": "2026-06-17T02:02:00.730959+00:00",
      "status": "completed"
     },
     "tags": []
@@ -864,10 +864,10 @@
    "id": "sl10-20",
    "metadata": {
     "papermill": {
-     "duration": 0.004696,
-     "end_time": "2026-06-10T12:11:02.822387",
+     "duration": 0.004463,
+     "end_time": "2026-06-17T02:02:00.754454+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.817691",
+     "start_time": "2026-06-17T02:02:00.749991+00:00",
      "status": "completed"
     },
     "tags": []
@@ -905,10 +905,10 @@
    "id": "sl10-21",
    "metadata": {
     "papermill": {
-     "duration": 0.004645,
-     "end_time": "2026-06-10T12:11:02.832348",
+     "duration": 0.005027,
+     "end_time": "2026-06-17T02:02:00.764320+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.827703",
+     "start_time": "2026-06-17T02:02:00.759293+00:00",
      "status": "completed"
     },
     "tags": []
@@ -930,16 +930,16 @@
    "id": "sl10-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:02.844420Z",
-     "iopub.status.busy": "2026-06-10T12:11:02.843914Z",
-     "iopub.status.idle": "2026-06-10T12:11:05.893815Z",
-     "shell.execute_reply": "2026-06-10T12:11:05.893205Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.775869Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.775446Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.782920Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.781838Z"
     },
     "papermill": {
-     "duration": 3.056947,
-     "end_time": "2026-06-10T12:11:05.893815",
+     "duration": 0.014467,
+     "end_time": "2026-06-17T02:02:00.783782+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:02.836868",
+     "start_time": "2026-06-17T02:02:00.769315+00:00",
      "status": "completed"
     },
     "tags": []
@@ -995,10 +995,10 @@
    "id": "sl10-23",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T12:11:05.903331",
+     "duration": 0.006799,
+     "end_time": "2026-06-17T02:02:00.795815+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.898331",
+     "start_time": "2026-06-17T02:02:00.789016+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1028,10 +1028,10 @@
    "id": "sl10-24",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T12:11:05.913331",
+     "duration": 0.004833,
+     "end_time": "2026-06-17T02:02:00.805183+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.908331",
+     "start_time": "2026-06-17T02:02:00.800350+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1059,16 +1059,16 @@
    "id": "sl10-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:05.923842Z",
-     "iopub.status.busy": "2026-06-10T12:11:05.923842Z",
-     "iopub.status.idle": "2026-06-10T12:11:05.939349Z",
-     "shell.execute_reply": "2026-06-10T12:11:05.939349Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.818424Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.818037Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.825737Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.824650Z"
     },
     "papermill": {
-     "duration": 0.022515,
-     "end_time": "2026-06-10T12:11:05.940352",
+     "duration": 0.016214,
+     "end_time": "2026-06-17T02:02:00.826662+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.917837",
+     "start_time": "2026-06-17T02:02:00.810448+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1078,23 +1078,144 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Schema etendu : marie_avec ajoutee, jeanne declaree personne.\n",
+      "\n",
+      "Faits marie_avec apres completion symetrique : 2\n",
+      "  marie_avec(henri, jeanne)\n",
+      "  marie_avec(jeanne, henri)\n",
+      "\n",
+      "KG : 17 -> 19 faits (17 admis + 1 mariage + 1 completion).\n",
+      "\n",
+      "Lecture : un seul triplet en entree, DEUX en sortie. La completion\n",
+      "symetrique est une regle du SCHEMA (au meme titre qu'une contrainte\n",
+      "fonctionnelle), pas une regle MINEE : elle est vraie par definition, on\n",
+      "n'a pas besoin de donnees pour la confirmer -- contrairement aux regles\n",
+      "de la cellule mine_rules dont la confiance se mesure par comptage.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 : Etendre le schema\n",
-    "# TODO etudiant : ajoutez la relation marie_avec (personne, personne) au schema,\n",
-    "# deux phrases au corpus (ex : \"Henri est marie a Jeanne.\"), l'entite jeanne,\n",
-    "# puis re-executez extraction + oracle. La relation est SYMETRIQUE : ajoutez a\n",
-    "# l'oracle la completion automatique marie_avec(Y,X) des que marie_avec(X,Y)\n",
-    "# est admis.\n",
-    "# Indice : SIGNATURES, PERSONS, CORPUS, et la boucle de oracle() sont a etendre.\n",
-    "# Etape 1 : schema + corpus etendus\n",
-    "# Etape 2 : re-extraction (LLM ou simulateur) et oracle\n",
-    "# Etape 3 : verifiez que les deux sens du mariage sont dans le KG\n",
+    "# Exemple guide 1 : Etendre le schema (relation symetrique marie_avec)\n",
+    "#\n",
+    "# On ajoute la relation marie_avec(personne, personne) au schema, l'entite\n",
+    "# jeanne, et le fait marie_avec(henri, jeanne). La nouveaute : cette relation\n",
+    "# est SYMETRIQUE. L'oracle doit completer automatiquement marie_avec(Y,X) des\n",
+    "# que marie_avec(X,Y) est admis -- sinon on perd la moitie du mariage.\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : on etend le vocabulaire ferme (le biais de langage, cf SL-4/SL-9).\n",
+    "SIGNATURES[\"marie_avec\"] = (\"personne\", \"personne\")\n",
+    "PERSONS.add(\"jeanne\")\n",
+    "TYPE_OF[\"jeanne\"] = \"personne\"\n",
+    "print(\"Schema etendu : marie_avec ajoutee, jeanne declaree personne.\")\n",
+    "\n",
+    "# Etape 2 : le nouveau fait. Hors-ligne (pas de .env) l'extraction LLM n'est pas\n",
+    "# disponible : on injecte le triplet \"or\" exactement comme le ferait une\n",
+    "# extraction LLM multi-passes + vote (cf le filet de securite de la cellule\n",
+    "# d'extraction). En ligne, EXTRACTION_PROMPT extrairait marie_avec(henri, jeanne).\n",
+    "marie_triples = [(\"marie_avec\", \"henri\", \"jeanne\")]\n",
+    "\n",
+    "# Etape 3 : oracle ETENDU. On reutilise oracle() pour les verifications de type\n",
+    "# et de contrainte fonctionnelle, puis on ajoute la completion symetrique POUR\n",
+    "# LES RELATIONS DECLAREES SYMETRIQUES (et elles seules).\n",
+    "def oracle_symmetric(triples, symmetric_rels):\n",
+    "    accepted, rejected = oracle(triples)          # types + contraintes fonctionnelles\n",
+    "    complets = []\n",
+    "    for (r, s, o) in accepted:\n",
+    "        if r in symmetric_rels and (r, o, s) not in accepted and (r, o, s) not in complets:\n",
+    "            complets.append((r, o, s))           # marie_avec(henri,jeanne) -> (jeanne,henri)\n",
+    "    return accepted + complets, rejected\n",
+    "\n",
+    "# Etape 4 : re-execution de l'oracle sur le KG + le nouveau fait.\n",
+    "kg2, rej2 = oracle_symmetric(kg_facts + marie_triples, symmetric_rels={\"marie_avec\"})\n",
+    "mariages = sorted((s, o) for (r, s, o) in kg2 if r == \"marie_avec\")\n",
+    "print(f\"\\nFaits marie_avec apres completion symetrique : {len(mariages)}\")\n",
+    "for s, o in mariages:\n",
+    "    print(f\"  marie_avec({s}, {o})\")\n",
+    "print(f\"\\nKG : {len(kg_facts)} -> {len(kg2)} faits \"\n",
+    "      f\"(17 admis + 1 mariage + 1 completion).\")\n",
+    "print()\n",
+    "print(\"Lecture : un seul triplet en entree, DEUX en sortie. La completion\")\n",
+    "print(\"symetrique est une regle du SCHEMA (au meme titre qu'une contrainte\")\n",
+    "print(\"fonctionnelle), pas une regle MINEE : elle est vraie par definition, on\")\n",
+    "print(\"n'a pas besoin de donnees pour la confirmer -- contrairement aux regles\")\n",
+    "print(\"de la cellule mine_rules dont la confiance se mesure par comptage.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl10ex1var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004717,
+     "end_time": "2026-06-17T02:02:00.836278+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:02:00.831561+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 (variation) : Symetrie vs anti-symetrie\n",
+    "\n",
+    "La completion symetrique ne doit s'appliquer **qu'aux relations declarees symetriques**. Verifiez qu'une relation **anti-symetrique** comme `parent` n'est **jamais** completee en `parent(Y, X)`, meme si on la passe a `oracle_symmetric`.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Appeler `oracle_symmetric(kg_facts, symmetric_rels={\"marie_avec\"})` et recuperer les faits `parent`.\n",
+    "2. Verifier qu'aucun `parent(Y, X)` n'a ete ajoute par completion (la liste des faits `parent` avant/apres est identique).\n",
+    "3. Que faudrait-il faire pour qu'une **nouvelle** relation symetrique beneficie automatiquement de la completion, sans modifier le code de `oracle_symmetric` ?\n",
+    "\n",
+    "**Indice** : c'est l'appartenance a `symmetric_rels` qui ouvre ou ferme la porte. Une relation symetrique oubliee dans cet ensemble = un demi-mariage silencieux (un seul sens persiste, l'autre n'est jamais derive).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "sl10ex1var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T02:02:00.848599Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.848238Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.852936Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.852044Z"
+    },
+    "papermill": {
+     "duration": 0.01209,
+     "end_time": "2026-06-17T02:02:00.853655+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:02:00.841565+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : symetrie vs anti-symetrie\n",
+      "Montrez qu'aucun parent(Y, X) n'est ajoute : la porte symmetric_rels reste fermee.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (variation) : Symetrie vs anti-symetrie\n",
+    "# TODO etudiant : montrez que la completion symetrique respecte la porte\n",
+    "# symmetric_rels et n'ajoute JAMAIS parent(Y, X) pour un parent(X, Y) admis.\n",
+    "\n",
+    "# Etape 1 : oracle_symmetric avec SEULEMENT marie_avec comme symetrique\n",
+    "# kg3, _ = oracle_symmetric(kg_facts, symmetric_rels={\"marie_avec\"})\n",
+    "\n",
+    "# Etape 2 : faits parent avant / apres -> doivent etre EGAUX (rien complete)\n",
+    "# parents_avant = {(s, o) for (r, s, o) in kg_facts if r == \"parent\"}\n",
+    "# parents_apres = {(s, o) for (r, s, o) in kg3 if r == \"parent\"}\n",
+    "\n",
+    "# Etape 3 : conclure sur le role de la porte symmetric_rels\n",
+    "print(\"Exercice a completer : symetrie vs anti-symetrie\")\n",
+    "print(\"Montrez qu'aucun parent(Y, X) n'est ajoute : la porte symmetric_rels reste fermee.\")\n",
+    "\n",
+    "# Indice : la completion ne s'applique qu'aux relations de symmetric_rels.\n",
+    "# Ajouter une relation symetrique = l'inscrire dans l'ensemble, pas coder.\n",
+    "# result = None  # TODO etudiant : parents_avant == parents_apres ?\n"
    ]
   },
   {
@@ -1102,10 +1223,10 @@
    "id": "sl10-26",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-06-10T12:11:05.946349",
+     "duration": 0.004363,
+     "end_time": "2026-06-17T02:02:00.862742+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.943349",
+     "start_time": "2026-06-17T02:02:00.858379+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1117,20 +1238,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "sl10-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:05.953334Z",
-     "iopub.status.busy": "2026-06-10T12:11:05.953334Z",
-     "iopub.status.idle": "2026-06-10T12:11:05.969511Z",
-     "shell.execute_reply": "2026-06-10T12:11:05.969511Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.873171Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.872811Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.876926Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.876013Z"
     },
     "papermill": {
-     "duration": 0.021155,
-     "end_time": "2026-06-10T12:11:05.970504",
+     "duration": 0.010448,
+     "end_time": "2026-06-17T02:02:00.877592+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.949349",
+     "start_time": "2026-06-17T02:02:00.867144+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1165,10 +1286,10 @@
    "id": "sl10-28",
    "metadata": {
     "papermill": {
-     "duration": 0.002539,
-     "end_time": "2026-06-10T12:11:05.976050",
+     "duration": 0.006394,
+     "end_time": "2026-06-17T02:02:00.888549+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.973511",
+     "start_time": "2026-06-17T02:02:00.882155+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1180,20 +1301,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "sl10-29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:05.983616Z",
-     "iopub.status.busy": "2026-06-10T12:11:05.983092Z",
-     "iopub.status.idle": "2026-06-10T12:11:06.001398Z",
-     "shell.execute_reply": "2026-06-10T12:11:06.000378Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.898691Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.898300Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.902512Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.901535Z"
     },
     "papermill": {
-     "duration": 0.022966,
-     "end_time": "2026-06-10T12:11:06.002423",
+     "duration": 0.010463,
+     "end_time": "2026-06-17T02:02:00.903303+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:05.979457",
+     "start_time": "2026-06-17T02:02:00.892840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1228,10 +1349,10 @@
    "id": "sl10-30",
    "metadata": {
     "papermill": {
-     "duration": 0.005773,
-     "end_time": "2026-06-10T12:11:06.013226",
+     "duration": 0.004662,
+     "end_time": "2026-06-17T02:02:00.912587+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.007453",
+     "start_time": "2026-06-17T02:02:00.907925+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1243,20 +1364,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "sl10-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T12:11:06.024781Z",
-     "iopub.status.busy": "2026-06-10T12:11:06.024781Z",
-     "iopub.status.idle": "2026-06-10T12:11:06.032861Z",
-     "shell.execute_reply": "2026-06-10T12:11:06.031860Z"
+     "iopub.execute_input": "2026-06-17T02:02:00.923147Z",
+     "iopub.status.busy": "2026-06-17T02:02:00.922770Z",
+     "iopub.status.idle": "2026-06-17T02:02:00.926797Z",
+     "shell.execute_reply": "2026-06-17T02:02:00.925886Z"
     },
     "papermill": {
-     "duration": 0.014641,
-     "end_time": "2026-06-10T12:11:06.032861",
+     "duration": 0.010129,
+     "end_time": "2026-06-17T02:02:00.927478+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.018220",
+     "start_time": "2026-06-17T02:02:00.917349+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1291,10 +1412,10 @@
    "id": "sl10-33",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-10T12:11:06.054631",
+     "duration": 0.004645,
+     "end_time": "2026-06-17T02:02:00.937352+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.049631",
+     "start_time": "2026-06-17T02:02:00.932707+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1345,10 +1466,10 @@
    "id": "sl10-32",
    "metadata": {
     "papermill": {
-     "duration": 0.006593,
-     "end_time": "2026-06-10T12:11:06.044589",
+     "duration": 0.003883,
+     "end_time": "2026-06-17T02:02:00.945222+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.037996",
+     "start_time": "2026-06-17T02:02:00.941339+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1376,10 +1497,10 @@
    "id": "sl10-34",
    "metadata": {
     "papermill": {
-     "duration": 0.005048,
-     "end_time": "2026-06-10T12:11:06.065730",
+     "duration": 0.003801,
+     "end_time": "2026-06-17T02:02:00.953057+00:00",
      "exception": false,
-     "start_time": "2026-06-10T12:11:06.060682",
+     "start_time": "2026-06-17T02:02:00.949256+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1418,18 +1539,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 17.414731,
-   "end_time": "2026-06-10T12:11:06.633869",
+   "duration": 2.854294,
+   "end_time": "2026-06-17T02:02:01.198065+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SL-10-Capstone-NeuroSymbolic.ipynb",
-   "output_path": "SL-10-Capstone-NeuroSymbolic.ipynb",
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T12:10:49.219138",
+   "start_time": "2026-06-17T02:01:58.343771+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
> **PR empilee (stacked)** : base = `feat/sl10-ex2-guided` (#3189). Ordre de merge SL-10 : #3188 (Ex1) -> #3189 (Ex2) -> celle-ci (Ex3) -> Ex4.

## Livrable

**Ex3 resolu en exemple guide** (le bon seuil n'existe pas) :
- `VERDICT` : classement manuel de chaque candidate (VRAIE = loi du domaine / FAUSSE = coincidence du micro-monde), **aligne avec l'interpretation `mine_rules`** du notebook.
- Balayage `min_conf` 0.0→1.0 (pas 0.1), tableau seuil → (vraies retenues, fausses retenues).

**Resultat** : `separable = NON` a **TOUS** les seuils :
- seuil ≤ 0.4 → V=2, F=3 ; 0.5-0.6 → V=2, F=2 ; ≥ 0.7 → V=1, F=0 (vraie perdue).
- `grandparent` (VRAIE, 0.67) et `travaille_pour:-parent` (FAUSSE, 0.67) sont **a egalite de confiance** → le seuil ne peut pas couper entre elles. **Le bon seuil n'existe pas.**

**Nouvel exercice en variation** : "Un score qui separe" — inventer un score complementaire (diversite du support) qui separe les deux regles a 0.67. C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`--kernel python3 --scrub-keys`, deterministe) : **SUCCESS** 4.2s, 1/1, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 15 cellules code, `execution_count` set + outputs + 0 erreur.
- Cellules LLM restorees depuis `origin/main` (`sl10-07/08/19/22`) — pas de `.env` local.

## Anti-regression (verifie vs `feat/sl10-ex2-guided`)

- CHANGED SOURCE : **uniquement** `sl10-29`. CHANGED OUTPUT : **uniquement** `sl10-29`.
- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- 1 fichier `.ipynb` (SL-10). Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
