### PR TITLE
feat(sl-9): resolve Exercice 1 (grandmother) into guided example + add mother exercise

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-9-InverseResolution.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-9-InverseResolution.ipynb
@@ -1224,25 +1224,102 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Apprentissage de grandmother/2 :\n  bottom = 8 litteraux, 45 candidats connectes -> grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).  (p=1, score=-2)\n\nTheorie finale :\n  grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).\n\nVerification : 1/1 positif(s) couvert(s), 0/10 negatif(s) couvert(s)\nEquivalente a grandmother(X,Y) :- female(X), parent(X,Z), parent(Z,Y) ? True\n\nLecture : grandmother(tom, ann) -- un grand-pere -- joue le role symetrique\nde grandfather(liz, eve) : il force le litteral female(X), comme la grand-mere\nforcait male(X) pour grandfather. Avec un seul positif, ce sont les negatifs\n(notamment les autres (liz, female)) qui eliminent les clauses spurious.\n"
     }
    ],
    "source": [
-    "# Exercice 1 : Apprendre grandmother/2\n",
-    "# TODO etudiant : definissez les exemples positifs et negatifs de grandmother\n",
-    "# (la grand-mere) sur le MEME arbre genealogique, et faites-la apprendre par\n",
-    "# progol_learn. Quel negatif joue le role symetrique de grandfather(liz, eve) ?\n",
-    "# Indice : les grands-parents de l'arbre sont tom (x3), bob (jim) et liz (eve).\n",
-    "# Etape 1 : POS_GM (qui est grand-mere de qui ?) et NEG_GM (>= 5 exemples varies)\n",
-    "# Etape 2 : progol_learn(POS_GM, NEG_GM, FACTS, {\"parent\", \"male\", \"female\"})\n",
-    "# Etape 3 : verifiez la theorie apprise (female au lieu de male ?)\n",
-    "\n",
-    "print(\"Exercice a completer\")"
+    "# Exemple guide : Apprendre grandmother/2\n",
+    "# Objectif : retrouver grandmother(X, Y) :- female(X), parent(X, Z), parent(Z, Y).\n",
+    "# Etape 1 : positifs et negatifs. Sur l'arbre, la seule grand-mere est liz (de eve) :\n",
+    "# liz est parent de sue, sue parent de eve, et liz est female. Les autres\n",
+    "# grands-parents (tom x3, bob) sont des grand-peres (male) -> un seul positif.\n",
+    "POS_GM = [(\"grandmother\", \"liz\", \"eve\")]\n",
+    "NEG_GM = [\n",
+    "    (\"grandmother\", \"tom\", \"ann\"),   # grand-pere : force le litteral female(X)\n",
+    "    (\"grandmother\", \"tom\", \"pat\"),\n",
+    "    (\"grandmother\", \"tom\", \"sue\"),\n",
+    "    (\"grandmother\", \"bob\", \"jim\"),   # grand-pere\n",
+    "    # liz est grand-mere UNIQUEMENT de eve. Sans ces 3 negatifs, une clause\n",
+    "    # \"spurious\" (parent(Z, X), female(Y), male(Z)) couvrirait (liz, eve) par\n",
+    "    # hasard : avec un seul positif, ce sont les negatifs qui portent le signal.\n",
+    "    (\"grandmother\", \"liz\", \"ann\"),\n",
+    "    (\"grandmother\", \"liz\", \"pat\"),\n",
+    "    (\"grandmother\", \"liz\", \"sue\"),\n",
+    "    (\"grandmother\", \"pat\", \"jim\"),   # mere, parent direct (pas grand-mere)\n",
+    "    (\"grandmother\", \"sue\", \"eve\"),   # parent direct\n",
+    "    (\"grandmother\", \"ann\", \"jim\"),   # aucun lien de parente\n",
+    "]\n",
+    "# Etape 2 : apprentissage (memes faits et meme biais de body_preds que grandfather).\n",
+    "print(\"Apprentissage de grandmother/2 :\")\n",
+    "theory_gm = progol_learn(POS_GM, NEG_GM, FACTS, {\"parent\", \"male\", \"female\"})\n",
+    "# Etape 3 : verification -- la clause cible est-elle apprise, et le litteral sexe\n",
+    "# est-il bien female (et non male, comme pour grandfather) ?\n",
+    "print(\"\\nTheorie finale :\")\n",
+    "for c in theory_gm:\n",
+    "    print(f\"  {show_clause(c)}\")\n",
+    "ok_pos = sum(covers(c, e, FACTS) for c in theory_gm for e in POS_GM)\n",
+    "ok_neg = sum(covers(c, e, FACTS) for c in theory_gm for e in NEG_GM)\n",
+    "print(f\"\\nVerification : {ok_pos}/{len(POS_GM)} positif(s) couvert(s), \"\n",
+    "      f\"{ok_neg}/{len(NEG_GM)} negatif(s) couvert(s)\")\n",
+    "target_gm = ((\"grandmother\", \"X\", \"Y\"),\n",
+    "             [(\"female\", \"X\"), (\"parent\", \"X\", \"Z\"), (\"parent\", \"Z\", \"Y\")])\n",
+    "equiv = any(subsumes(c, target_gm) and subsumes(target_gm, c) for c in theory_gm)\n",
+    "print(f\"Equivalente a grandmother(X,Y) :- female(X), parent(X,Z), parent(Z,Y) ? {equiv}\")\n",
+    "assert ok_pos == len(POS_GM), f\"positifs manques: {ok_pos}/{len(POS_GM)}\"\n",
+    "assert ok_neg == 0, f\"fuite negative: {ok_neg}/{len(NEG_GM)}\"\n",
+    "assert equiv, \"la clause apprise n'est pas equivalente a la cible\"\n",
+    "print(\"\\nLecture : grandmother(tom, ann) -- un grand-pere -- joue le role symetrique\")\n",
+    "print(\"de grandfather(liz, eve) : il force le litteral female(X), comme la grand-mere\")\n",
+    "print(\"forcait male(X) pour grandfather. Avec un seul positif, ce sont les negatifs\")\n",
+    "print(\"(notamment les autres (liz, female)) qui eliminent les clauses spurious.\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "757bedb4",
+   "metadata": {},
+   "source": [
+    "### A votre tour : Apprendre mother/2 (la mere)\n",
+    "\n",
+    "Changeons de generation : apprenez la relation **mother** (X est la mere de Y) avec\n",
+    "le meme moteur `progol_learn`. C'est l'homologue direct de grandmother, une\n",
+    "generation plus bas : la clause cible est `mother(X, Y) :- female(X), parent(X, Y)`.\n",
+    "\n",
+    "Ici vous disposez de **plusieurs positifs** (liz, pat et sue sont toutes meres) :\n",
+    "un cas plus favorable que grandmother, qui ne disposait que d'un seul positif.\n",
+    "Quelle clause le moteur apprend-il, et quel negatif suffit a forcer le litteral\n",
+    "`female(X)` ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "38bcac50",
+   "metadata": {},
+   "source": [
+    "# Exercice : Apprendre mother/2 (la mere)\n",
+    "# TODO etudiant : definissez POS_MOTHER et NEG_MOTHER, puis appelez progol_learn.\n",
+    "# Indice : la cible est mother(X, Y) :- female(X), parent(X, Y)  (2 litteraux).\n",
+    "#          Les meres de l'arbre : liz (de sue), pat (de jim), sue (de eve).\n",
+    "#          Quel negatif (un pere) force le litteral female(X) ?\n",
+    "# Etape 1 : POS_MOTHER (les couples (mere, enfant)) et NEG_MOTHER (peres + non-parents).\n",
+    "# Etape 2 : theory_mother = progol_learn(POS_MOTHER, NEG_MOTHER, FACTS, {\"parent\", \"male\", \"female\"})\n",
+    "# Etape 3 : la theorie apprise est-elle equivalente a la cible (subsumes dans les 2 sens) ?\n",
+    "print(\"Exercice a completer : regle mother/2\")\n",
+    "print(\"Etape 1 : listez les couples (mere, enfant) -- liz/sue, pat/jim, sue/eve\")\n",
+    "print(\"Etape 2 : quel negatif force female(X) ? (un pere, symetrique de grandmother(tom, ann))\")\n",
+    "print(\"Etape 3 : verifiez l'equivalence avec mother(X,Y) :- female(X), parent(X,Y)\")\n",
+    "result = None  # TODO etudiant : votre theory_mother ici\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer : regle mother/2\nEtape 1 : listez les couples (mere, enfant) -- liz/sue, pat/jim, sue/eve\nEtape 2 : quel negatif force female(X) ? (un pere, symetrique de grandmother(tom, ann))\nEtape 3 : verifiez l'equivalence avec mother(X,Y) :- female(X), parent(X,Y)\n"
+    }
+   ],
+   "execution_count": 10
   },
   {
    "cell_type": "markdown",
@@ -1265,7 +1342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "sl9-22",
    "metadata": {
     "execution": {
@@ -1327,7 +1404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "sl9-24",
    "metadata": {
     "execution": {
@@ -1391,7 +1468,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "sl9-26",
    "metadata": {
     "execution": {
@@ -1456,7 +1533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "fe495e59",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

Epic: SymbolicLearning exercise-resolution lane (#2161). Part of ai-01 dispatch (2026-06-17): resolve SL-1..SL-10 exercises into **Exemples guidés**. This PR = **SL-9 Ex.1 (grandmother/2)**.

`Exercice 1 : Apprendre grandmother/2` was a `# TODO etudiant` stub. It is resolved into a worked **Exemple guide** that reuses the notebook's own pure-Python `progol_learn` API and recovers the target clause.

## What changed

- **Cell `sl9-20`** (Ex.1 stub -> worked example): defines `POS_GM`/`NEG_GM` and calls `progol_learn(POS_GM, NEG_GM, FACTS, {"parent","male","female"})`. The clause is verified equivalent to `grandmother(X,Y) :- female(X), parent(X,Z), parent(Z,Y)` via bidirectional `subsumes`.
- **New markdown + code stub** (`mother/2`, cible `mother(X,Y):-female(X),parent(X,Y)`) inserted after the example, to keep >=3 exercises in the notebook. Stub is C.1-clean (`print` + `# TODO etudiant`, no `raise NotImplementedError`).
- Tail Ex.2-5 `execution_count` bumped +1 (one new code cell inserted before them).
- Defi table untouched: `Ex.1 (grandmother)` question-twist (extend to `grandparent/2`) is now answerable *because* the grandmother machinery is demonstrated.

## Teaching point (stronger than grandfather)

With a **single** positive (liz -> eve, the only grandmother), the **negatives carry the signal**. Adding `grandmother(liz, ann|pat|sue)` (liz is grandmother ONLY of eve) kills the spurious clause `parent(Z,X), female(Y), male(Z)` that would otherwise win on a score tie. This is symmetric to `grandfather(liz,eve)` forcing `male(X)`.

## Validation (real kernel, python3 via `jupyter_client`)

Re-executed the changed cells only (preamble API cells + worked example + mother stub). Unchanged cells (incl. the Aleph / SWI-Prolog section) keep their committed outputs (C.2/C.3). Worked-example output:

```
Apprentissage de grandmother/2 :
  bottom = 8 litteraux, 45 candidats connectes -> grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).  (p=1, score=-2)

Theorie finale :
  grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).

Verification : 1/1 positif(s) couvert(s), 0/10 negatif(s) couvert(s)
Equivalente a grandmother(X,Y):-female(X),parent(X,Z),parent(Z,Y) ? True
```

- `nbformat` VALID
- `0` occurrence of `raise NotImplementedError` / `assert False` / `1/0` (C.1 clean)
- diff: 1 file, +94 / -17 (the -17 = the old `# TODO` stub source lines, not a working solution)

## Env note (transparency)

The notebook's Aleph/Popper section needs `swi-prolog` in the WSL env, which is currently **missing** (env drift, needs `sudo apt install swi-prolog` -- user action, rule F). That section was NOT re-executed here (it keeps its valid committed outputs); only the pure-Python changed cells were re-executed. The Aleph env repair is tracked separately and is orthogonal to this exercise resolution.

See #2161