### PR TITLE
feat(sl10): resolve Ex3 (no separating threshold exists) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
@@ -5,10 +5,10 @@
    "id": "sl10-01",
    "metadata": {
     "papermill": {
-     "duration": 0.004344,
-     "end_time": "2026-06-17T02:08:44.656424+00:00",
+     "duration": 0.004235,
+     "end_time": "2026-06-17T02:11:26.711654+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.652080+00:00",
+     "start_time": "2026-06-17T02:11:26.707419+00:00",
      "status": "completed"
     },
     "tags": []
@@ -43,10 +43,10 @@
    "id": "sl10-02",
    "metadata": {
     "papermill": {
-     "duration": 0.003477,
-     "end_time": "2026-06-17T02:08:44.666400+00:00",
+     "duration": 0.003478,
+     "end_time": "2026-06-17T02:11:26.719030+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.662923+00:00",
+     "start_time": "2026-06-17T02:11:26.715552+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "sl10-03",
    "metadata": {
     "papermill": {
-     "duration": 0.003515,
-     "end_time": "2026-06-17T02:08:44.673494+00:00",
+     "duration": 0.003949,
+     "end_time": "2026-06-17T02:11:26.726553+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.669979+00:00",
+     "start_time": "2026-06-17T02:11:26.722604+00:00",
      "status": "completed"
     },
     "tags": []
@@ -113,16 +113,16 @@
    "id": "sl10-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.681868Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.681587Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.690038Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.689267Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.735016Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.734781Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.742365Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.741728Z"
     },
     "papermill": {
-     "duration": 0.013892,
-     "end_time": "2026-06-17T02:08:44.690891+00:00",
+     "duration": 0.012773,
+     "end_time": "2026-06-17T02:11:26.742971+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.676999+00:00",
+     "start_time": "2026-06-17T02:11:26.730198+00:00",
      "status": "completed"
     },
     "tags": []
@@ -186,10 +186,10 @@
    "id": "sl10-05",
    "metadata": {
     "papermill": {
-     "duration": 0.003624,
-     "end_time": "2026-06-17T02:08:44.698354+00:00",
+     "duration": 0.003626,
+     "end_time": "2026-06-17T02:11:26.750383+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.694730+00:00",
+     "start_time": "2026-06-17T02:11:26.746757+00:00",
      "status": "completed"
     },
     "tags": []
@@ -205,10 +205,10 @@
    "id": "sl10-06",
    "metadata": {
     "papermill": {
-     "duration": 0.003499,
-     "end_time": "2026-06-17T02:08:44.705386+00:00",
+     "duration": 0.004059,
+     "end_time": "2026-06-17T02:11:26.758131+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.701887+00:00",
+     "start_time": "2026-06-17T02:11:26.754072+00:00",
      "status": "completed"
     },
     "tags": []
@@ -230,16 +230,16 @@
    "id": "sl10-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.713946Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.713729Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.724406Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.723682Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.766605Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.766415Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.775406Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.774784Z"
     },
     "papermill": {
-     "duration": 0.016212,
-     "end_time": "2026-06-17T02:08:44.725109+00:00",
+     "duration": 0.014169,
+     "end_time": "2026-06-17T02:11:26.775917+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.708897+00:00",
+     "start_time": "2026-06-17T02:11:26.761748+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,16 +287,16 @@
    "id": "sl10-08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.734131Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.733864Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.742116Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.741450Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.786929Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.786713Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.793969Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.793347Z"
     },
     "papermill": {
-     "duration": 0.014189,
-     "end_time": "2026-06-17T02:08:44.743063+00:00",
+     "duration": 0.014706,
+     "end_time": "2026-06-17T02:11:26.794757+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.728874+00:00",
+     "start_time": "2026-06-17T02:11:26.780051+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,10 +398,10 @@
    "id": "sl10-09",
    "metadata": {
     "papermill": {
-     "duration": 0.004058,
-     "end_time": "2026-06-17T02:08:44.751534+00:00",
+     "duration": 0.00483,
+     "end_time": "2026-06-17T02:11:26.803634+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.747476+00:00",
+     "start_time": "2026-06-17T02:11:26.798804+00:00",
      "status": "completed"
     },
     "tags": []
@@ -426,10 +426,10 @@
    "id": "sl10-10",
    "metadata": {
     "papermill": {
-     "duration": 0.003506,
-     "end_time": "2026-06-17T02:08:44.758912+00:00",
+     "duration": 0.003411,
+     "end_time": "2026-06-17T02:11:26.811031+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.755406+00:00",
+     "start_time": "2026-06-17T02:11:26.807620+00:00",
      "status": "completed"
     },
     "tags": []
@@ -452,16 +452,16 @@
    "id": "sl10-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.767502Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.767316Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.772450Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.771893Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.819240Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.818887Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.824324Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.823833Z"
     },
     "papermill": {
-     "duration": 0.010713,
-     "end_time": "2026-06-17T02:08:44.772984+00:00",
+     "duration": 0.010927,
+     "end_time": "2026-06-17T02:11:26.825246+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.762271+00:00",
+     "start_time": "2026-06-17T02:11:26.814319+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,10 +519,10 @@
    "id": "sl10-12",
    "metadata": {
     "papermill": {
-     "duration": 0.003555,
-     "end_time": "2026-06-17T02:08:44.780343+00:00",
+     "duration": 0.003528,
+     "end_time": "2026-06-17T02:11:26.832393+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.776788+00:00",
+     "start_time": "2026-06-17T02:11:26.828865+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,10 +550,10 @@
    "id": "sl10-13",
    "metadata": {
     "papermill": {
-     "duration": 0.003597,
-     "end_time": "2026-06-17T02:08:44.787533+00:00",
+     "duration": 0.003423,
+     "end_time": "2026-06-17T02:11:26.839231+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.783936+00:00",
+     "start_time": "2026-06-17T02:11:26.835808+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "sl10-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.796317Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.796118Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.800552Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.799934Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.847413Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.847193Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.851353Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.850812Z"
     },
     "papermill": {
-     "duration": 0.009947,
-     "end_time": "2026-06-17T02:08:44.801238+00:00",
+     "duration": 0.009188,
+     "end_time": "2026-06-17T02:11:26.851980+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.791291+00:00",
+     "start_time": "2026-06-17T02:11:26.842792+00:00",
      "status": "completed"
     },
     "tags": []
@@ -622,10 +622,10 @@
    "id": "sl10-15",
    "metadata": {
     "papermill": {
-     "duration": 0.003943,
-     "end_time": "2026-06-17T02:08:44.809141+00:00",
+     "duration": 0.003488,
+     "end_time": "2026-06-17T02:11:26.859264+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.805198+00:00",
+     "start_time": "2026-06-17T02:11:26.855776+00:00",
      "status": "completed"
     },
     "tags": []
@@ -653,16 +653,16 @@
    "id": "sl10-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.817751Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.817561Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.823554Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.823000Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.867419Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.867227Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.873094Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.872441Z"
     },
     "papermill": {
-     "duration": 0.011408,
-     "end_time": "2026-06-17T02:08:44.824259+00:00",
+     "duration": 0.010826,
+     "end_time": "2026-06-17T02:11:26.873562+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.812851+00:00",
+     "start_time": "2026-06-17T02:11:26.862736+00:00",
      "status": "completed"
     },
     "tags": []
@@ -728,10 +728,10 @@
    "id": "sl10-17",
    "metadata": {
     "papermill": {
-     "duration": 0.003717,
-     "end_time": "2026-06-17T02:08:44.832089+00:00",
+     "duration": 0.003779,
+     "end_time": "2026-06-17T02:11:26.881137+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.828372+00:00",
+     "start_time": "2026-06-17T02:11:26.877358+00:00",
      "status": "completed"
     },
     "tags": []
@@ -766,10 +766,10 @@
    "id": "sl10-18",
    "metadata": {
     "papermill": {
-     "duration": 0.003895,
-     "end_time": "2026-06-17T02:08:44.839706+00:00",
+     "duration": 0.003681,
+     "end_time": "2026-06-17T02:11:26.888524+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.835811+00:00",
+     "start_time": "2026-06-17T02:11:26.884843+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,16 +790,16 @@
    "id": "sl10-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.849733Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.849392Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.855848Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.855100Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.897923Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.897732Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.903182Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.902639Z"
     },
     "papermill": {
-     "duration": 0.012867,
-     "end_time": "2026-06-17T02:08:44.856670+00:00",
+     "duration": 0.01141,
+     "end_time": "2026-06-17T02:11:26.903690+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.843803+00:00",
+     "start_time": "2026-06-17T02:11:26.892280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -864,10 +864,10 @@
    "id": "sl10-20",
    "metadata": {
     "papermill": {
-     "duration": 0.004407,
-     "end_time": "2026-06-17T02:08:44.865809+00:00",
+     "duration": 0.00416,
+     "end_time": "2026-06-17T02:11:26.911751+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.861402+00:00",
+     "start_time": "2026-06-17T02:11:26.907591+00:00",
      "status": "completed"
     },
     "tags": []
@@ -905,10 +905,10 @@
    "id": "sl10-21",
    "metadata": {
     "papermill": {
-     "duration": 0.004122,
-     "end_time": "2026-06-17T02:08:44.874183+00:00",
+     "duration": 0.003549,
+     "end_time": "2026-06-17T02:11:26.919256+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.870061+00:00",
+     "start_time": "2026-06-17T02:11:26.915707+00:00",
      "status": "completed"
     },
     "tags": []
@@ -930,16 +930,16 @@
    "id": "sl10-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.883084Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.882864Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.887836Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.887100Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.928123Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.927799Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.932730Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.931985Z"
     },
     "papermill": {
-     "duration": 0.010385,
-     "end_time": "2026-06-17T02:08:44.888383+00:00",
+     "duration": 0.010505,
+     "end_time": "2026-06-17T02:11:26.933339+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.877998+00:00",
+     "start_time": "2026-06-17T02:11:26.922834+00:00",
      "status": "completed"
     },
     "tags": []
@@ -995,10 +995,10 @@
    "id": "sl10-23",
    "metadata": {
     "papermill": {
-     "duration": 0.003792,
-     "end_time": "2026-06-17T02:08:44.896052+00:00",
+     "duration": 0.003859,
+     "end_time": "2026-06-17T02:11:26.941337+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.892260+00:00",
+     "start_time": "2026-06-17T02:11:26.937478+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1028,10 +1028,10 @@
    "id": "sl10-24",
    "metadata": {
     "papermill": {
-     "duration": 0.004153,
-     "end_time": "2026-06-17T02:08:44.904297+00:00",
+     "duration": 0.003665,
+     "end_time": "2026-06-17T02:11:26.948779+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.900144+00:00",
+     "start_time": "2026-06-17T02:11:26.945114+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1059,16 +1059,16 @@
    "id": "sl10-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.914068Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.913837Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.920762Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.920055Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.957961Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.957670Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.963379Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.962772Z"
     },
     "papermill": {
-     "duration": 0.013047,
-     "end_time": "2026-06-17T02:08:44.921506+00:00",
+     "duration": 0.011162,
+     "end_time": "2026-06-17T02:11:26.963919+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.908459+00:00",
+     "start_time": "2026-06-17T02:11:26.952757+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1146,10 +1146,10 @@
    "id": "sl10ex1var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.004422,
-     "end_time": "2026-06-17T02:08:44.930750+00:00",
+     "duration": 0.004175,
+     "end_time": "2026-06-17T02:11:26.972354+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.926328+00:00",
+     "start_time": "2026-06-17T02:11:26.968179+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1173,16 +1173,16 @@
    "id": "sl10ex1var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.940896Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.940673Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.944463Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.943861Z"
+     "iopub.execute_input": "2026-06-17T02:11:26.981783Z",
+     "iopub.status.busy": "2026-06-17T02:11:26.981578Z",
+     "iopub.status.idle": "2026-06-17T02:11:26.984751Z",
+     "shell.execute_reply": "2026-06-17T02:11:26.984263Z"
     },
     "papermill": {
-     "duration": 0.009879,
-     "end_time": "2026-06-17T02:08:44.945030+00:00",
+     "duration": 0.009079,
+     "end_time": "2026-06-17T02:11:26.985397+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.935151+00:00",
+     "start_time": "2026-06-17T02:11:26.976318+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1223,10 +1223,10 @@
    "id": "sl10-26",
    "metadata": {
     "papermill": {
-     "duration": 0.005993,
-     "end_time": "2026-06-17T02:08:44.955569+00:00",
+     "duration": 0.004223,
+     "end_time": "2026-06-17T02:11:26.995752+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.949576+00:00",
+     "start_time": "2026-06-17T02:11:26.991529+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1242,16 +1242,16 @@
    "id": "sl10-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.964796Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.964590Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.973075Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.972329Z"
+     "iopub.execute_input": "2026-06-17T02:11:27.005152Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.004967Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.013060Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.012526Z"
     },
     "papermill": {
-     "duration": 0.01395,
-     "end_time": "2026-06-17T02:08:44.973639+00:00",
+     "duration": 0.013599,
+     "end_time": "2026-06-17T02:11:27.013567+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.959689+00:00",
+     "start_time": "2026-06-17T02:11:26.999968+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1367,10 +1367,10 @@
    "id": "sl10ex2var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003953,
-     "end_time": "2026-06-17T02:08:44.981683+00:00",
+     "duration": 0.003781,
+     "end_time": "2026-06-17T02:11:27.021227+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.977730+00:00",
+     "start_time": "2026-06-17T02:11:27.017446+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1394,16 +1394,16 @@
    "id": "sl10ex2var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:44.991450Z",
-     "iopub.status.busy": "2026-06-17T02:08:44.991221Z",
-     "iopub.status.idle": "2026-06-17T02:08:44.995603Z",
-     "shell.execute_reply": "2026-06-17T02:08:44.994966Z"
+     "iopub.execute_input": "2026-06-17T02:11:27.029355Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.029207Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.032089Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.031666Z"
     },
     "papermill": {
-     "duration": 0.010253,
-     "end_time": "2026-06-17T02:08:44.996183+00:00",
+     "duration": 0.007826,
+     "end_time": "2026-06-17T02:11:27.032633+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:44.985930+00:00",
+     "start_time": "2026-06-17T02:11:27.024807+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1454,10 +1454,10 @@
    "id": "sl10-28",
    "metadata": {
     "papermill": {
-     "duration": 0.003804,
-     "end_time": "2026-06-17T02:08:45.004170+00:00",
+     "duration": 0.003614,
+     "end_time": "2026-06-17T02:11:27.040229+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.000366+00:00",
+     "start_time": "2026-06-17T02:11:27.036615+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1473,16 +1473,16 @@
    "id": "sl10-29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:45.012959Z",
-     "iopub.status.busy": "2026-06-17T02:08:45.012754Z",
-     "iopub.status.idle": "2026-06-17T02:08:45.016183Z",
-     "shell.execute_reply": "2026-06-17T02:08:45.015471Z"
+     "iopub.execute_input": "2026-06-17T02:11:27.048557Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.048407Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.053829Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.053356Z"
     },
     "papermill": {
-     "duration": 0.008722,
-     "end_time": "2026-06-17T02:08:45.016716+00:00",
+     "duration": 0.010271,
+     "end_time": "2026-06-17T02:11:27.054282+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.007994+00:00",
+     "start_time": "2026-06-17T02:11:27.044011+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1492,24 +1492,165 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "seuil | vraies | fausses | separable ?\n",
+      "---------------------------------------------\n",
+      "  0.0 |      2 |       3 | non\n",
+      "  0.1 |      2 |       3 | non\n",
+      "  0.2 |      2 |       3 | non\n",
+      "  0.3 |      2 |       3 | non\n",
+      "  0.4 |      2 |       3 | non\n",
+      "  0.5 |      2 |       2 | non\n",
+      "  0.6 |      2 |       2 | non\n",
+      "  0.7 |      1 |       0 | non\n",
+      "  0.8 |      1 |       0 | non\n",
+      "  0.9 |      1 |       0 | non\n",
+      "  1.0 |      1 |       0 | non\n",
+      "\n",
+      "Un seuil separant toutes les VRAIES de toutes les FAUSSES existe-t-il ? NON.\n",
+      "\n",
+      "Lecture : grandparent (VRAIE) et travaille_pour :- parent o travaille_pour\n",
+      "(FAUSSE) ont la MEME confiance 0.67. Tout seuil <= 0.67 les garde toutes\n",
+      "les deux (fausses qui leurent) ; tout seuil > 0.67 les jette toutes les\n",
+      "deux (vraie perdue). Le seuil ne peut pas couper ENTRE deux regles de meme\n",
+      "confiance : le bon seuil n'existe pas. Pour separer ces deux regles il\n",
+      "faudrait un SCORE DIFFERENT de la confiance -- un score qui recompense le\n",
+      "fait que grandparent est causalement amont, ou penalise l'effet 'conjoint'\n",
+      "(travail des enfants => travail des parents). Les donnees seules (comptage)\n",
+      "ne suffisent pas : il faut soit un biais de gabarit (refuser une tete\n",
+      "'travaille_pour' derivee d'une chaine par 'parent'), soit des contre-exemples\n",
+      "(un parent dont l'enfant travaille ailleurs sans y travailler lui-meme).\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 3 : Le bon seuil n'existe pas\n",
-    "# TODO etudiant : faites varier min_conf de 0.0 a 1.0 (pas de 0.1) et classez a\n",
-    "# la main chaque regle candidate comme VRAIE (loi du domaine) ou FAUSSE\n",
-    "# (correlation du micro-monde). Tracez (ou tabulez) le nombre de vraies regles\n",
-    "# retenues et de fausses regles retenues a chaque seuil.\n",
-    "# Indice : grandparent :- parent o parent est VRAIE ; travaille_pour :- parent o\n",
-    "# travaille_pour est FAUSSE ; les deux ont la MEME confiance 0.67...\n",
-    "# Etape 1 : tableau seuil -> (vraies retenues, fausses retenues)\n",
-    "# Etape 2 : existe-t-il un seuil qui garde toutes les vraies et aucune fausse ?\n",
-    "# Etape 3 : que faudrait-il changer (donnees ? gabarits ? score ?) pour separer\n",
-    "#           ces deux regles ?\n",
+    "# Exemple guide 3 : Le bon seuil n'existe pas\n",
+    "#\n",
+    "# La confiance filtre les regles minees par FREQUENCE, pas par SENS. On quantifie\n",
+    "# cette impuissance : on fait varier min_conf de 0.0 a 1.0, on classe CHAQUE\n",
+    "# candidate a la main (loi du domaine VRAIE vs coincidence du micro-monde\n",
+    "# FAUSSE), et on cherche s'il existe un seuil qui garde toutes les vraies sans\n",
+    "# aucune fausse.\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : verdict manuel de chaque candidate (cf l'interpretation de mine_rules)\n",
+    "VERDICT = {\n",
+    "    \"travaille_pour(X,Y) :- dirige(X,Y)\":                      \"VRAIE\",   # 1.00 quasi-schema\n",
+    "    \"grandparent(X,Y) :- parent(X,Z), parent(Z,Y)\":            \"VRAIE\",   # 0.67 la definition\n",
+    "    \"dirige(X,Y) :- parent(X,Z), travaille_pour(Z,Y)\":         \"FAUSSE\",  # 0.67 franchement fausse\n",
+    "    \"travaille_pour(X,Y) :- parent(X,Z), travaille_pour(Z,Y)\": \"FAUSSE\",  # 0.67 suspecte\n",
+    "    \"dirige(X,Y) :- travaille_pour(X,Y)\":                      \"FAUSSE\",  # 0.40 sur-generalisation\n",
+    "}\n",
+    "\n",
+    "# Etape 2 : balayage des seuils -- on recombine les memes candidates, sans\n",
+    "# re-miner, en changeant seulement le seuil de retention.\n",
+    "print(f\"{'seuil':>5} | {'vraies':>6} | {'fausses':>7} | separable ?\")\n",
+    "print(\"-\" * 45)\n",
+    "separable_trouve = False\n",
+    "for seuil_10 in range(0, 11):\n",
+    "    seuil = seuil_10 / 10\n",
+    "    retenues = [c for c in candidates if c[\"conf\"] >= seuil]\n",
+    "    v = sum(1 for c in retenues if VERDICT[c[\"text\"]] == \"VRAIE\")\n",
+    "    f = sum(1 for c in retenues if VERDICT[c[\"text\"]] == \"FAUSSE\")\n",
+    "    sep = (v == 2 and f == 0)   # garde toutes les vraies, aucune fausse\n",
+    "    separable_trouve = separable_trouve or sep\n",
+    "    print(f\"{seuil:>5.1f} | {v:>6} | {f:>7} | {'OUI' if sep else 'non'}\")\n",
+    "\n",
+    "print()\n",
+    "print(f\"Un seuil separant toutes les VRAIES de toutes les FAUSSES existe-t-il ? \"\n",
+    "      f\"{'OUI' if separable_trouve else 'NON.'}\")\n",
+    "print()\n",
+    "print(\"Lecture : grandparent (VRAIE) et travaille_pour :- parent o travaille_pour\")\n",
+    "print(\"(FAUSSE) ont la MEME confiance 0.67. Tout seuil <= 0.67 les garde toutes\")\n",
+    "print(\"les deux (fausses qui leurent) ; tout seuil > 0.67 les jette toutes les\")\n",
+    "print(\"deux (vraie perdue). Le seuil ne peut pas couper ENTRE deux regles de meme\")\n",
+    "print(\"confiance : le bon seuil n'existe pas. Pour separer ces deux regles il\")\n",
+    "print(\"faudrait un SCORE DIFFERENT de la confiance -- un score qui recompense le\")\n",
+    "print(\"fait que grandparent est causalement amont, ou penalise l'effet 'conjoint'\")\n",
+    "print(\"(travail des enfants => travail des parents). Les donnees seules (comptage)\")\n",
+    "print(\"ne suffisent pas : il faut soit un biais de gabarit (refuser une tete\")\n",
+    "print(\"'travaille_pour' derivee d'une chaine par 'parent'), soit des contre-exemples\")\n",
+    "print(\"(un parent dont l'enfant travaille ailleurs sans y travailler lui-meme).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl10ex3var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003548,
+     "end_time": "2026-06-17T02:11:27.061419+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:11:27.057871+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (variation) : Un score qui separe\n",
+    "\n",
+    "La confiance echoue a separer `grandparent` (VRAIE) de `travaille_pour :- parent o travaille_pour` (FAUSSE), toutes deux a 0.67. Inventez un score **complementaire** qui les separe.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Pour chaque candidate, calculer un score de **diversite du support** : nombre de SUJETS distincts dans ses instances de support (un vrai `grandparent` vient de plusieurs familles ; une coincidence de micro-monde tient souvent a une seule).\n",
+    "2. Re-classer les candidates par ce score et verifier que `grandparent` > `travaille_pour :- parent`.\n",
+    "3. Quelle paire de regles ce score echoue-t-il a separer a son tour ?\n",
+    "\n",
+    "**Indice** : aucun score unique ne separe tout -- c'est le moteur des approches multi-criteres (confidence + support + diversite + leverage) en association rule mining.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "sl10ex3var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T02:11:27.069902Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.069749Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.073068Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.072597Z"
+    },
+    "papermill": {
+     "duration": 0.008386,
+     "end_time": "2026-06-17T02:11:27.073583+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:11:27.065197+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : un score complementaire separateur\n",
+      "Etape 1 : diversite du support = nombre de sujets distincts\n",
+      "Etape 2 : grandparent doit battre travaille_pour:-parent\n",
+      "Etape 3 : quelle paire reste inseparable ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (variation) : Un score qui separe\n",
+    "# TODO etudiant : la confiance ne separe pas grandparent (VRAIE) de\n",
+    "# travaille_pour:-parent (FAUSSE), toutes deux a 0.67. Inventez un score de\n",
+    "# DIVERSITE du support.\n",
+    "\n",
+    "# Etape 1 : pour chaque candidate, compter les SUJETS distincts dans ses\n",
+    "# instances de support (support = inst & rels[head]).\n",
+    "# def diversite_support(candidate, kg_facts):\n",
+    "#     ...\n",
+    "\n",
+    "# Etape 2 : re-classer par diversite et verifier grandparent > travaille_pour:-parent\n",
+    "# Etape 3 : quelle paire ce score echoue-t-il a separer a son tour ?\n",
+    "\n",
+    "print(\"Exercice a completer : un score complementaire separateur\")\n",
+    "print(\"Etape 1 : diversite du support = nombre de sujets distincts\")\n",
+    "print(\"Etape 2 : grandparent doit battre travaille_pour:-parent\")\n",
+    "print(\"Etape 3 : quelle paire reste inseparable ?\")\n",
+    "\n",
+    "# Indice : aucun score unique ne separe tout -> multi-criteres (conf + support +\n",
+    "# diversite + leverage). C'est le coeur de l'association rule mining.\n",
+    "# result = None  # TODO etudiant : classement par diversite\n"
    ]
   },
   {
@@ -1517,10 +1658,10 @@
    "id": "sl10-30",
    "metadata": {
     "papermill": {
-     "duration": 0.00383,
-     "end_time": "2026-06-17T02:08:45.024607+00:00",
+     "duration": 0.003962,
+     "end_time": "2026-06-17T02:11:27.081378+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.020777+00:00",
+     "start_time": "2026-06-17T02:11:27.077416+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1532,20 +1673,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "sl10-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:08:45.033688Z",
-     "iopub.status.busy": "2026-06-17T02:08:45.033442Z",
-     "iopub.status.idle": "2026-06-17T02:08:45.036543Z",
-     "shell.execute_reply": "2026-06-17T02:08:45.035935Z"
+     "iopub.execute_input": "2026-06-17T02:11:27.090048Z",
+     "iopub.status.busy": "2026-06-17T02:11:27.089898Z",
+     "iopub.status.idle": "2026-06-17T02:11:27.093161Z",
+     "shell.execute_reply": "2026-06-17T02:11:27.092665Z"
     },
     "papermill": {
-     "duration": 0.00859,
-     "end_time": "2026-06-17T02:08:45.037134+00:00",
+     "duration": 0.008477,
+     "end_time": "2026-06-17T02:11:27.093837+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.028544+00:00",
+     "start_time": "2026-06-17T02:11:27.085360+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1580,10 +1721,10 @@
    "id": "sl10-33",
    "metadata": {
     "papermill": {
-     "duration": 0.004398,
-     "end_time": "2026-06-17T02:08:45.045925+00:00",
+     "duration": 0.004073,
+     "end_time": "2026-06-17T02:11:27.102369+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.041527+00:00",
+     "start_time": "2026-06-17T02:11:27.098296+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1634,10 +1775,10 @@
    "id": "sl10-32",
    "metadata": {
     "papermill": {
-     "duration": 0.004274,
-     "end_time": "2026-06-17T02:08:45.054380+00:00",
+     "duration": 0.004077,
+     "end_time": "2026-06-17T02:11:27.110471+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.050106+00:00",
+     "start_time": "2026-06-17T02:11:27.106394+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1665,10 +1806,10 @@
    "id": "sl10-34",
    "metadata": {
     "papermill": {
-     "duration": 0.004433,
-     "end_time": "2026-06-17T02:08:45.063404+00:00",
+     "duration": 0.004461,
+     "end_time": "2026-06-17T02:11:27.119330+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:08:45.058971+00:00",
+     "start_time": "2026-06-17T02:11:27.114869+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1711,14 +1852,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.465146,
-   "end_time": "2026-06-17T02:08:45.309877+00:00",
+   "duration": 2.27951,
+   "end_time": "2026-06-17T02:11:27.255539+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T02:08:42.844731+00:00",
+   "start_time": "2026-06-17T02:11:24.976029+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Reconciliation of SL-10 capstone **Ex3** onto fresh `main`. The worker's stacked branch `feat/sl10-ex3-guided` (#3190) conflicted (DIRTY) after the Ex1+Ex2 tip #3189 was squash-merged — standard stacked-PR squash artifact. This branch carries the **same notebook content** rebuilt on fresh main, so the diff is exactly Ex3.

## Livrable
- `Exercice 3` stub -> **`Exemple guide 3 : le bon seuil n'existe pas`** : balayage de seuils prouvant que deux regles de meme confiance (0.67) ne peuvent etre separees par aucun seuil.
- Nouvel **`Exercice 3 (variation)`** : markdown + stub code C.1-clean (TODO/pass).

## Preuves
- **Papermill** kernel `python3` : **EXIT 0**, 40/40 cellules, **0 erreur** (validation locale ai-01).
- **C.1** : `grep -cE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : outputs + execution_count presents.
- **Anti-regression** (cell-level diff vs main) : prefixe 0..31 identique ; cellule 32 stub->guide ; +2 cellules inserees (33-34) ; **queue Ex4+conclusion byte-identique** (decalage pur, 0 edit parasite). LLM cells inchangees vs main.
- Catalogue + submodules byte-identiques a main. Credit po-2024.

Supersedes #3190 (closed as conflicted-after-squash). See #2161