### PR TITLE
feat(sl10): resolve Ex4 (end-to-end poisoning) as guided example + variation (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-Capstone-NeuroSymbolic.ipynb
@@ -5,10 +5,10 @@
    "id": "sl10-01",
    "metadata": {
     "papermill": {
-     "duration": 0.004235,
-     "end_time": "2026-06-17T02:11:26.711654+00:00",
+     "duration": 0.004409,
+     "end_time": "2026-06-17T02:29:15.989122+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.707419+00:00",
+     "start_time": "2026-06-17T02:29:15.984713+00:00",
      "status": "completed"
     },
     "tags": []
@@ -43,10 +43,10 @@
    "id": "sl10-02",
    "metadata": {
     "papermill": {
-     "duration": 0.003478,
-     "end_time": "2026-06-17T02:11:26.719030+00:00",
+     "duration": 0.003445,
+     "end_time": "2026-06-17T02:29:15.998038+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.715552+00:00",
+     "start_time": "2026-06-17T02:29:15.994593+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "sl10-03",
    "metadata": {
     "papermill": {
-     "duration": 0.003949,
-     "end_time": "2026-06-17T02:11:26.726553+00:00",
+     "duration": 0.00328,
+     "end_time": "2026-06-17T02:29:16.005143+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.722604+00:00",
+     "start_time": "2026-06-17T02:29:16.001863+00:00",
      "status": "completed"
     },
     "tags": []
@@ -113,16 +113,16 @@
    "id": "sl10-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.735016Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.734781Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.742365Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.741728Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.013311Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.013112Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.020804Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.020100Z"
     },
     "papermill": {
-     "duration": 0.012773,
-     "end_time": "2026-06-17T02:11:26.742971+00:00",
+     "duration": 0.013005,
+     "end_time": "2026-06-17T02:29:16.021612+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.730198+00:00",
+     "start_time": "2026-06-17T02:29:16.008607+00:00",
      "status": "completed"
     },
     "tags": []
@@ -186,10 +186,10 @@
    "id": "sl10-05",
    "metadata": {
     "papermill": {
-     "duration": 0.003626,
-     "end_time": "2026-06-17T02:11:26.750383+00:00",
+     "duration": 0.003575,
+     "end_time": "2026-06-17T02:29:16.028924+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.746757+00:00",
+     "start_time": "2026-06-17T02:29:16.025349+00:00",
      "status": "completed"
     },
     "tags": []
@@ -205,10 +205,10 @@
    "id": "sl10-06",
    "metadata": {
     "papermill": {
-     "duration": 0.004059,
-     "end_time": "2026-06-17T02:11:26.758131+00:00",
+     "duration": 0.004036,
+     "end_time": "2026-06-17T02:29:16.036962+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.754072+00:00",
+     "start_time": "2026-06-17T02:29:16.032926+00:00",
      "status": "completed"
     },
     "tags": []
@@ -230,16 +230,16 @@
    "id": "sl10-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.766605Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.766415Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.775406Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.774784Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.045395Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.045216Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.054931Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.054385Z"
     },
     "papermill": {
-     "duration": 0.014169,
-     "end_time": "2026-06-17T02:11:26.775917+00:00",
+     "duration": 0.015061,
+     "end_time": "2026-06-17T02:29:16.055714+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.761748+00:00",
+     "start_time": "2026-06-17T02:29:16.040653+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,16 +287,16 @@
    "id": "sl10-08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.786929Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.786713Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.793969Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.793347Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.065425Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.065231Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.072954Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.072296Z"
     },
     "papermill": {
-     "duration": 0.014706,
-     "end_time": "2026-06-17T02:11:26.794757+00:00",
+     "duration": 0.013353,
+     "end_time": "2026-06-17T02:29:16.073507+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.780051+00:00",
+     "start_time": "2026-06-17T02:29:16.060154+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,10 +398,10 @@
    "id": "sl10-09",
    "metadata": {
     "papermill": {
-     "duration": 0.00483,
-     "end_time": "2026-06-17T02:11:26.803634+00:00",
+     "duration": 0.003868,
+     "end_time": "2026-06-17T02:29:16.081152+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.798804+00:00",
+     "start_time": "2026-06-17T02:29:16.077284+00:00",
      "status": "completed"
     },
     "tags": []
@@ -426,10 +426,10 @@
    "id": "sl10-10",
    "metadata": {
     "papermill": {
-     "duration": 0.003411,
-     "end_time": "2026-06-17T02:11:26.811031+00:00",
+     "duration": 0.003513,
+     "end_time": "2026-06-17T02:29:16.088354+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.807620+00:00",
+     "start_time": "2026-06-17T02:29:16.084841+00:00",
      "status": "completed"
     },
     "tags": []
@@ -452,16 +452,16 @@
    "id": "sl10-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.819240Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.818887Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.824324Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.823833Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.096774Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.096595Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.101813Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.101192Z"
     },
     "papermill": {
-     "duration": 0.010927,
-     "end_time": "2026-06-17T02:11:26.825246+00:00",
+     "duration": 0.010547,
+     "end_time": "2026-06-17T02:29:16.102307+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.814319+00:00",
+     "start_time": "2026-06-17T02:29:16.091760+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,10 +519,10 @@
    "id": "sl10-12",
    "metadata": {
     "papermill": {
-     "duration": 0.003528,
-     "end_time": "2026-06-17T02:11:26.832393+00:00",
+     "duration": 0.003333,
+     "end_time": "2026-06-17T02:29:16.109370+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.828865+00:00",
+     "start_time": "2026-06-17T02:29:16.106037+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,10 +550,10 @@
    "id": "sl10-13",
    "metadata": {
     "papermill": {
-     "duration": 0.003423,
-     "end_time": "2026-06-17T02:11:26.839231+00:00",
+     "duration": 0.003643,
+     "end_time": "2026-06-17T02:29:16.116608+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.835808+00:00",
+     "start_time": "2026-06-17T02:29:16.112965+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "sl10-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.847413Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.847193Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.851353Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.850812Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.125156Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.124992Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.128967Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.128340Z"
     },
     "papermill": {
-     "duration": 0.009188,
-     "end_time": "2026-06-17T02:11:26.851980+00:00",
+     "duration": 0.009165,
+     "end_time": "2026-06-17T02:29:16.129499+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.842792+00:00",
+     "start_time": "2026-06-17T02:29:16.120334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -622,10 +622,10 @@
    "id": "sl10-15",
    "metadata": {
     "papermill": {
-     "duration": 0.003488,
-     "end_time": "2026-06-17T02:11:26.859264+00:00",
+     "duration": 0.003821,
+     "end_time": "2026-06-17T02:29:16.137042+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.855776+00:00",
+     "start_time": "2026-06-17T02:29:16.133221+00:00",
      "status": "completed"
     },
     "tags": []
@@ -653,16 +653,16 @@
    "id": "sl10-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.867419Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.867227Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.873094Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.872441Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.145290Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.145155Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.150359Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.149828Z"
     },
     "papermill": {
-     "duration": 0.010826,
-     "end_time": "2026-06-17T02:11:26.873562+00:00",
+     "duration": 0.010265,
+     "end_time": "2026-06-17T02:29:16.150985+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.862736+00:00",
+     "start_time": "2026-06-17T02:29:16.140720+00:00",
      "status": "completed"
     },
     "tags": []
@@ -728,10 +728,10 @@
    "id": "sl10-17",
    "metadata": {
     "papermill": {
-     "duration": 0.003779,
-     "end_time": "2026-06-17T02:11:26.881137+00:00",
+     "duration": 0.003552,
+     "end_time": "2026-06-17T02:29:16.158109+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.877358+00:00",
+     "start_time": "2026-06-17T02:29:16.154557+00:00",
      "status": "completed"
     },
     "tags": []
@@ -766,10 +766,10 @@
    "id": "sl10-18",
    "metadata": {
     "papermill": {
-     "duration": 0.003681,
-     "end_time": "2026-06-17T02:11:26.888524+00:00",
+     "duration": 0.003818,
+     "end_time": "2026-06-17T02:29:16.165636+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.884843+00:00",
+     "start_time": "2026-06-17T02:29:16.161818+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,16 +790,16 @@
    "id": "sl10-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.897923Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.897732Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.903182Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.902639Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.174470Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.174301Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.180302Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.179710Z"
     },
     "papermill": {
-     "duration": 0.01141,
-     "end_time": "2026-06-17T02:11:26.903690+00:00",
+     "duration": 0.011662,
+     "end_time": "2026-06-17T02:29:16.181107+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.892280+00:00",
+     "start_time": "2026-06-17T02:29:16.169445+00:00",
      "status": "completed"
     },
     "tags": []
@@ -864,10 +864,10 @@
    "id": "sl10-20",
    "metadata": {
     "papermill": {
-     "duration": 0.00416,
-     "end_time": "2026-06-17T02:11:26.911751+00:00",
+     "duration": 0.003825,
+     "end_time": "2026-06-17T02:29:16.189193+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.907591+00:00",
+     "start_time": "2026-06-17T02:29:16.185368+00:00",
      "status": "completed"
     },
     "tags": []
@@ -905,10 +905,10 @@
    "id": "sl10-21",
    "metadata": {
     "papermill": {
-     "duration": 0.003549,
-     "end_time": "2026-06-17T02:11:26.919256+00:00",
+     "duration": 0.003748,
+     "end_time": "2026-06-17T02:29:16.196707+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.915707+00:00",
+     "start_time": "2026-06-17T02:29:16.192959+00:00",
      "status": "completed"
     },
     "tags": []
@@ -930,16 +930,16 @@
    "id": "sl10-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.928123Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.927799Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.932730Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.931985Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.205805Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.205600Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.210703Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.210169Z"
     },
     "papermill": {
-     "duration": 0.010505,
-     "end_time": "2026-06-17T02:11:26.933339+00:00",
+     "duration": 0.010611,
+     "end_time": "2026-06-17T02:29:16.211225+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.922834+00:00",
+     "start_time": "2026-06-17T02:29:16.200614+00:00",
      "status": "completed"
     },
     "tags": []
@@ -995,10 +995,10 @@
    "id": "sl10-23",
    "metadata": {
     "papermill": {
-     "duration": 0.003859,
-     "end_time": "2026-06-17T02:11:26.941337+00:00",
+     "duration": 0.004051,
+     "end_time": "2026-06-17T02:29:16.219442+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.937478+00:00",
+     "start_time": "2026-06-17T02:29:16.215391+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1028,10 +1028,10 @@
    "id": "sl10-24",
    "metadata": {
     "papermill": {
-     "duration": 0.003665,
-     "end_time": "2026-06-17T02:11:26.948779+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-06-17T02:29:16.227686+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.945114+00:00",
+     "start_time": "2026-06-17T02:29:16.223685+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1059,16 +1059,16 @@
    "id": "sl10-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.957961Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.957670Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.963379Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.962772Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.238580Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.238270Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.243838Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.243278Z"
     },
     "papermill": {
-     "duration": 0.011162,
-     "end_time": "2026-06-17T02:11:26.963919+00:00",
+     "duration": 0.011084,
+     "end_time": "2026-06-17T02:29:16.244359+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.952757+00:00",
+     "start_time": "2026-06-17T02:29:16.233275+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1146,10 +1146,10 @@
    "id": "sl10ex1var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.004175,
-     "end_time": "2026-06-17T02:11:26.972354+00:00",
+     "duration": 0.003751,
+     "end_time": "2026-06-17T02:29:16.252367+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.968179+00:00",
+     "start_time": "2026-06-17T02:29:16.248616+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1173,16 +1173,16 @@
    "id": "sl10ex1var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:26.981783Z",
-     "iopub.status.busy": "2026-06-17T02:11:26.981578Z",
-     "iopub.status.idle": "2026-06-17T02:11:26.984751Z",
-     "shell.execute_reply": "2026-06-17T02:11:26.984263Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.260462Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.260316Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.263187Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.262749Z"
     },
     "papermill": {
-     "duration": 0.009079,
-     "end_time": "2026-06-17T02:11:26.985397+00:00",
+     "duration": 0.007692,
+     "end_time": "2026-06-17T02:29:16.263800+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.976318+00:00",
+     "start_time": "2026-06-17T02:29:16.256108+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1223,10 +1223,10 @@
    "id": "sl10-26",
    "metadata": {
     "papermill": {
-     "duration": 0.004223,
-     "end_time": "2026-06-17T02:11:26.995752+00:00",
+     "duration": 0.003674,
+     "end_time": "2026-06-17T02:29:16.271137+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.991529+00:00",
+     "start_time": "2026-06-17T02:29:16.267463+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1242,16 +1242,16 @@
    "id": "sl10-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:27.005152Z",
-     "iopub.status.busy": "2026-06-17T02:11:27.004967Z",
-     "iopub.status.idle": "2026-06-17T02:11:27.013060Z",
-     "shell.execute_reply": "2026-06-17T02:11:27.012526Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.279261Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.279121Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.286338Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.285873Z"
     },
     "papermill": {
-     "duration": 0.013599,
-     "end_time": "2026-06-17T02:11:27.013567+00:00",
+     "duration": 0.012209,
+     "end_time": "2026-06-17T02:29:16.286978+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:26.999968+00:00",
+     "start_time": "2026-06-17T02:29:16.274769+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1367,10 +1367,10 @@
    "id": "sl10ex2var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003781,
-     "end_time": "2026-06-17T02:11:27.021227+00:00",
+     "duration": 0.003834,
+     "end_time": "2026-06-17T02:29:16.294613+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.017446+00:00",
+     "start_time": "2026-06-17T02:29:16.290779+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1394,16 +1394,16 @@
    "id": "sl10ex2var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:27.029355Z",
-     "iopub.status.busy": "2026-06-17T02:11:27.029207Z",
-     "iopub.status.idle": "2026-06-17T02:11:27.032089Z",
-     "shell.execute_reply": "2026-06-17T02:11:27.031666Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.303897Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.303721Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.306937Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.306385Z"
     },
     "papermill": {
-     "duration": 0.007826,
-     "end_time": "2026-06-17T02:11:27.032633+00:00",
+     "duration": 0.008886,
+     "end_time": "2026-06-17T02:29:16.307508+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.024807+00:00",
+     "start_time": "2026-06-17T02:29:16.298622+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1454,10 +1454,10 @@
    "id": "sl10-28",
    "metadata": {
     "papermill": {
-     "duration": 0.003614,
-     "end_time": "2026-06-17T02:11:27.040229+00:00",
+     "duration": 0.003738,
+     "end_time": "2026-06-17T02:29:16.315047+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.036615+00:00",
+     "start_time": "2026-06-17T02:29:16.311309+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1473,16 +1473,16 @@
    "id": "sl10-29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:27.048557Z",
-     "iopub.status.busy": "2026-06-17T02:11:27.048407Z",
-     "iopub.status.idle": "2026-06-17T02:11:27.053829Z",
-     "shell.execute_reply": "2026-06-17T02:11:27.053356Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.325097Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.324935Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.330234Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.329665Z"
     },
     "papermill": {
-     "duration": 0.010271,
-     "end_time": "2026-06-17T02:11:27.054282+00:00",
+     "duration": 0.011744,
+     "end_time": "2026-06-17T02:29:16.330790+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.044011+00:00",
+     "start_time": "2026-06-17T02:29:16.319046+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1576,10 +1576,10 @@
    "id": "sl10ex3var-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003548,
-     "end_time": "2026-06-17T02:11:27.061419+00:00",
+     "duration": 0.00386,
+     "end_time": "2026-06-17T02:29:16.339124+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.057871+00:00",
+     "start_time": "2026-06-17T02:29:16.335264+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1603,16 +1603,16 @@
    "id": "sl10ex3var-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:27.069902Z",
-     "iopub.status.busy": "2026-06-17T02:11:27.069749Z",
-     "iopub.status.idle": "2026-06-17T02:11:27.073068Z",
-     "shell.execute_reply": "2026-06-17T02:11:27.072597Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.348169Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.347815Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.352307Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.351817Z"
     },
     "papermill": {
-     "duration": 0.008386,
-     "end_time": "2026-06-17T02:11:27.073583+00:00",
+     "duration": 0.009977,
+     "end_time": "2026-06-17T02:29:16.352888+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.065197+00:00",
+     "start_time": "2026-06-17T02:29:16.342911+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1658,10 +1658,10 @@
    "id": "sl10-30",
    "metadata": {
     "papermill": {
-     "duration": 0.003962,
-     "end_time": "2026-06-17T02:11:27.081378+00:00",
+     "duration": 0.003849,
+     "end_time": "2026-06-17T02:29:16.360640+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.077416+00:00",
+     "start_time": "2026-06-17T02:29:16.356791+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1677,16 +1677,16 @@
    "id": "sl10-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-17T02:11:27.090048Z",
-     "iopub.status.busy": "2026-06-17T02:11:27.089898Z",
-     "iopub.status.idle": "2026-06-17T02:11:27.093161Z",
-     "shell.execute_reply": "2026-06-17T02:11:27.092665Z"
+     "iopub.execute_input": "2026-06-17T02:29:16.370167Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.369988Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.377510Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.376986Z"
     },
     "papermill": {
-     "duration": 0.008477,
-     "end_time": "2026-06-17T02:11:27.093837+00:00",
+     "duration": 0.013187,
+     "end_time": "2026-06-17T02:29:16.378065+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.085360+00:00",
+     "start_time": "2026-06-17T02:29:16.364878+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1696,24 +1696,215 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Le poison parent(lucas, sophie) passe l'oracle : ADMISSIBLE\n",
+      "  (types OK, parent hors FUNCTIONAL -> aucune contrainte ne s'y oppose)\n",
+      "\n",
+      "Sans poison : 3 fait(s) nouveau(x).\n",
+      "Avec poison : 12 fait(s) nouveau(x).\n",
+      "DOMMAGE attribuable au poison : 9 fait(s) contamines, dont\n",
+      "4 ont le poison comme TEMOIN DIRECT ; les 5 autres\n",
+      "sont des effets de CASCADE (un fait contamine nourrit une autre regle).\n",
+      "\n",
+      "Entrees directes du poison et leur provenance :\n",
+      "  dirige(lucas, atelier_verne)\n",
+      "    regle   : dirige(X,Y) :- parent(X,Z), travaille_pour(Z,Y)  (conf 0.67)\n",
+      "    temoins : parent(lucas, sophie), travaille_pour(sophie, atelier_verne)\n",
+      "  grandparent(nadia, sophie)\n",
+      "    regle   : grandparent(X,Y) :- parent(X,Z), parent(Z,Y)  (conf 0.67)\n",
+      "    temoins : parent(nadia, lucas), parent(lucas, sophie)\n",
+      "  grandparent(marc, sophie)\n",
+      "    regle   : grandparent(X,Y) :- parent(X,Z), parent(Z,Y)  (conf 0.67)\n",
+      "    temoins : parent(marc, lucas), parent(lucas, sophie)\n",
+      "  travaille_pour(lucas, atelier_verne)\n",
+      "    regle   : travaille_pour(X,Y) :- parent(X,Z), travaille_pour(Z,Y)  (conf 0.67)\n",
+      "    temoins : parent(lucas, sophie), travaille_pour(sophie, atelier_verne)\n",
+      "\n",
+      "Total des 9 faits contamines (directs + cascade) :\n",
+      "  dirige(lucas, atelier_verne)\n",
+      "  dirige(marc, atelier_verne)\n",
+      "  dirige(nadia, atelier_verne)\n",
+      "  dirige(paul, atelier_verne)\n",
+      "  grandparent(marc, sophie)\n",
+      "  grandparent(nadia, sophie)\n",
+      "  travaille_pour(lucas, atelier_verne)\n",
+      "  travaille_pour(nadia, atelier_verne)\n",
+      "  travaille_pour(paul, atelier_verne)\n",
+      "\n",
+      "Lecture : UNE seule phrase fausse mais bien typee provoque une CASCADE de\n",
+      "faits faux par chainage avant -- via des regles ELLES-MEMES VRAIES (la\n",
+      "regle grandparent :- parent o parent est correcte). Le poison traverse car\n",
+      "parent n'est pas fonctionnel et lucas/sophie ont les bons types ; pire, les\n",
+      "faits contamines alimentent d'autres regles (dirige, travaille_pour) et\n",
+      "l'effet s'amplifie. Le dommage reel (9 faits) depasse\n",
+      "les entrees directes (4) : c'est le cout d'un chainage\n",
+      "avant sans re-validation.\n",
+      "\n",
+      "Quelle etape aurait PU l'arreter ?\n",
+      "  - L'oracle NON : parent(lucas, sophie) est bien type et non-fonctionnel.\n",
+      "  - Le mineur NON : la regle grandparent est genuinement vraie.\n",
+      "  - Le chainage avant NON : il est sound, il applique des regles vraies.\n",
+      "  => Le seul verrou possible est SCHEMA : une contrainte de CARDINALITE\n",
+      "     (un enfant a au plus 2 parents : sophie a deja claire, il faudrait\n",
+      "     connaitre un 2e parent legitime pour bloquer lucas), ou d'ACYCLICITE\n",
+      "     / generation (lucas est lui-meme petit-enfant d'henri : il ne peut pas\n",
+      "     etre ancetre de sophie, aussi descendante d'henri). Sans ces\n",
+      "     contraintes le pipeline est aveugle au sens. La variation implemente la\n",
+      "     defense par cardinalite.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 4 : Empoisonnement de bout en bout\n",
-    "# TODO etudiant : ajoutez au corpus la phrase fausse mais bien typee\n",
-    "# \"Lucas est le pere de Sophie.\" et re-executez TOUT le pipeline (extraction,\n",
-    "# oracle, mining, inference). Tracez la propagation : quels faits nouveaux\n",
-    "# (faux) apparaissent par chainage avant ? Quelle etape aurait PU l'arreter ?\n",
-    "# Indice : parent(lucas, sophie) passe l'oracle (types corrects, pas de\n",
-    "# contrainte fonctionnelle sur parent) puis nourrit la regle grandparent...\n",
-    "# Etape 1 : pipeline complet avec la phrase empoisonnee\n",
-    "# Etape 2 : listez les faits derives contamines et leur provenance\n",
-    "# Etape 3 : proposez (en commentaire) la contrainte qui l'aurait bloquee,\n",
-    "#           et ce qu'elle exigerait du schema (ages ? generations ? cycles ?)\n",
+    "# Exemple guide 4 : Empoisonnement de bout en bout\n",
+    "#\n",
+    "# On injecte une phrase fausse mais parfaitement typee : \"Lucas est le pere de\n",
+    "# Sophie.\" -> parent(lucas, sophie). Elle passe l'oracle (types personne/personne,\n",
+    "# parent n'est pas fonctionnel -> pas de conflit), puis l'etape d'INFERENCE\n",
+    "# applique les regles DEJA APPRISES au KG etendu. On trace la propagation et on\n",
+    "# demande quelle etape aurait PU l'arreter.\n",
     "\n",
-    "print(\"Exercice a completer\")"
+    "# Etape 1 : le poison. On le fait passer l'oracle pour montrer qu'il est admis.\n",
+    "POISON = (\"parent\", \"lucas\", \"sophie\")\n",
+    "acc_p, rej_p = oracle([POISON])\n",
+    "print(f\"Le poison {POISON[0]}({POISON[1]}, {POISON[2]}) passe l'oracle : \"\n",
+    "      f\"{'ADMISSIBLE' if POISON in acc_p else 'REJETE'}\")\n",
+    "print(\"  (types OK, parent hors FUNCTIONAL -> aucune contrainte ne s'y oppose)\")\n",
+    "\n",
+    "# Etape 2 : inference sur le KG empoisonne. On applique les regles DEJA APPRISES\n",
+    "# (le `rules` de la cellule mine_rules) -- c'est l'etape d'inference d'un pipeline\n",
+    "# reel : on apprend les regles une fois, puis on les applique aux nouveaux faits.\n",
+    "# (NB : re-miner sur le seul fait empoisonne diluerait la confiance -- le poison\n",
+    "# ajoute des chaines parent o parent sans fait grandparent correspondant -- et\n",
+    "# ferait tomber la regle sous le seuil. Ce serait une autre lecon, pas celle-ci.)\n",
+    "poison_facts = kg_facts + [POISON]\n",
+    "kg_p, derived_p = forward_chain(poison_facts, rules)\n",
+    "\n",
+    "# Etape 3 : on mesure le DOMMAGE reel. On compare a la derivation SANS poison\n",
+    "# (le `derived` de la cellule forward_chain). Tout fait derive avec le poison\n",
+    "# mais absent sans poison est ATTRIBUABLE au poison (cascade comprise : un fait\n",
+    "# contamine nourrit a son tour d'autres regles). Les DIRECTS sont ceux dont le\n",
+    "# poison est un temoin immediat.\n",
+    "clean_set = {f for (f, _rule, _wit) in derived}\n",
+    "tainted = [(f, rule, wit) for (f, rule, wit) in derived_p if f not in clean_set]\n",
+    "directs = [(f, rule, wit) for (f, rule, wit) in tainted\n",
+    "           if any(tuple(w) == POISON for w in wit)]\n",
+    "\n",
+    "print(f\"\\nSans poison : {len(derived)} fait(s) nouveau(x).\")\n",
+    "print(f\"Avec poison : {len(derived_p)} fait(s) nouveau(x).\")\n",
+    "print(f\"DOMMAGE attribuable au poison : {len(tainted)} fait(s) contamines, dont\")\n",
+    "print(f\"{len(directs)} ont le poison comme TEMOIN DIRECT ; les {len(tainted) - len(directs)} autres\")\n",
+    "print(\"sont des effets de CASCADE (un fait contamine nourrit une autre regle).\")\n",
+    "\n",
+    "print(\"\\nEntrees directes du poison et leur provenance :\")\n",
+    "for (r, s, o), rule, wit in directs:\n",
+    "    print(f\"  {r}({s}, {o})\")\n",
+    "    print(f\"    regle   : {rule['text']}  (conf {rule['conf']:.2f})\")\n",
+    "    print(f\"    temoins : \" + \", \".join(f\"{w[0]}({w[1]}, {w[2]})\" for w in wit))\n",
+    "\n",
+    "print(f\"\\nTotal des {len(tainted)} faits contamines (directs + cascade) :\")\n",
+    "for (r, s, o), _rule, _wit in sorted(tainted):\n",
+    "    print(f\"  {r}({s}, {o})\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Lecture : UNE seule phrase fausse mais bien typee provoque une CASCADE de\")\n",
+    "print(\"faits faux par chainage avant -- via des regles ELLES-MEMES VRAIES (la\")\n",
+    "print(\"regle grandparent :- parent o parent est correcte). Le poison traverse car\")\n",
+    "print(\"parent n'est pas fonctionnel et lucas/sophie ont les bons types ; pire, les\")\n",
+    "print(\"faits contamines alimentent d'autres regles (dirige, travaille_pour) et\")\n",
+    "print(\"l'effet s'amplifie. Le dommage reel (\" + str(len(tainted)) + \" faits) depasse\")\n",
+    "print(\"les entrees directes (\" + str(len(directs)) + \") : c'est le cout d'un chainage\")\n",
+    "print(\"avant sans re-validation.\")\n",
+    "print()\n",
+    "print(\"Quelle etape aurait PU l'arreter ?\")\n",
+    "print(\"  - L'oracle NON : parent(lucas, sophie) est bien type et non-fonctionnel.\")\n",
+    "print(\"  - Le mineur NON : la regle grandparent est genuinement vraie.\")\n",
+    "print(\"  - Le chainage avant NON : il est sound, il applique des regles vraies.\")\n",
+    "print(\"  => Le seul verrou possible est SCHEMA : une contrainte de CARDINALITE\")\n",
+    "print(\"     (un enfant a au plus 2 parents : sophie a deja claire, il faudrait\")\n",
+    "print(\"     connaitre un 2e parent legitime pour bloquer lucas), ou d'ACYCLICITE\")\n",
+    "print(\"     / generation (lucas est lui-meme petit-enfant d'henri : il ne peut pas\")\n",
+    "print(\"     etre ancetre de sophie, aussi descendante d'henri). Sans ces\")\n",
+    "print(\"     contraintes le pipeline est aveugle au sens. La variation implemente la\")\n",
+    "print(\"     defense par cardinalite.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl10ex4var-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004289,
+     "end_time": "2026-06-17T02:29:16.386860+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:29:16.382571+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 (variation) : Bloquer le poison (cardinalite des parents)\n",
+    "\n",
+    "Implémentez la contrainte de CARDINALITÉ qui aurait bloqué le poison : un enfant a **au plus 2 parents**. Re-injectez le poison après les 2 parents légitimes de Sophie et montrez qu'il est rejeté.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Étendre l'oracle : compter les parents déjà admis pour chaque enfant ; rejeter le 3e.\n",
+    "2. Ajouter un 2e parent légitime à Sophie (ex. le père `thomas`), puis injecter `parent(lucas, sophie)` — lucas est le 3e parent → rejeté.\n",
+    "3. Que reste-t-il non couvert par cette contrainte ? (Indice : un empoisonnement par une seule affirmation sur un enfant *sans* parent connu.)\n",
+    "\n",
+    "**Indice** : la cardinalité borne le nombre d'attaques simultanées, mais ne prouve pas la véracité. C'est une défense en profondeur, pas une preuve.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "sl10ex4var-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T02:29:16.395991Z",
+     "iopub.status.busy": "2026-06-17T02:29:16.395803Z",
+     "iopub.status.idle": "2026-06-17T02:29:16.398682Z",
+     "shell.execute_reply": "2026-06-17T02:29:16.398163Z"
+    },
+    "papermill": {
+     "duration": 0.008304,
+     "end_time": "2026-06-17T02:29:16.399385+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T02:29:16.391081+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : bloquer le poison par cardinalite\n",
+      "Etape 1 : oracle_cardinalite (au plus 2 parents par enfant)\n",
+      "Etape 2 : lucas = 3e parent de sophie -> rejet\n",
+      "Etape 3 : quel poison passe encore malgre la cardinalite ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 (variation) : Bloquer le poison (cardinalite des parents)\n",
+    "# TODO etudiant : implémentez la contrainte \"un enfant a au plus 2 parents\".\n",
+    "\n",
+    "# Etape 1 : oracle_cardinalite(triples, max_parents=2) : rejeter le (max+1)e parent\n",
+    "# def oracle_cardinalite(triples, max_parents=2):\n",
+    "#     ...\n",
+    "\n",
+    "# Etape 2 : sophie a deja claire + thomas (2e parent legitime), puis lucas -> 3e\n",
+    "# flux = kg_facts + [(\"parent\", \"thomas\", \"sophie\"), (\"parent\", \"lucas\", \"sophie\")]\n",
+    "\n",
+    "# Etape 3 : que reste-t-il non couvert ? (poison sur enfant SANS parent connu)\n",
+    "print(\"Exercice a completer : bloquer le poison par cardinalite\")\n",
+    "print(\"Etape 1 : oracle_cardinalite (au plus 2 parents par enfant)\")\n",
+    "print(\"Etape 2 : lucas = 3e parent de sophie -> rejet\")\n",
+    "print(\"Etape 3 : quel poison passe encore malgre la cardinalite ?\")\n",
+    "\n",
+    "# Indice : la cardinalite borne le nombre d'attaques simultanees, mais ne prouve\n",
+    "# pas la veracite. Defense en profondeur, pas preuve.\n",
+    "# result = None  # TODO etudiant : lucas rejete ?\n"
    ]
   },
   {
@@ -1721,10 +1912,10 @@
    "id": "sl10-33",
    "metadata": {
     "papermill": {
-     "duration": 0.004073,
-     "end_time": "2026-06-17T02:11:27.102369+00:00",
+     "duration": 0.004036,
+     "end_time": "2026-06-17T02:29:16.407341+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.098296+00:00",
+     "start_time": "2026-06-17T02:29:16.403305+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1775,10 +1966,10 @@
    "id": "sl10-32",
    "metadata": {
     "papermill": {
-     "duration": 0.004077,
-     "end_time": "2026-06-17T02:11:27.110471+00:00",
+     "duration": 0.005076,
+     "end_time": "2026-06-17T02:29:16.416990+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.106394+00:00",
+     "start_time": "2026-06-17T02:29:16.411914+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1806,10 +1997,10 @@
    "id": "sl10-34",
    "metadata": {
     "papermill": {
-     "duration": 0.004461,
-     "end_time": "2026-06-17T02:11:27.119330+00:00",
+     "duration": 0.004377,
+     "end_time": "2026-06-17T02:29:16.426411+00:00",
      "exception": false,
-     "start_time": "2026-06-17T02:11:27.114869+00:00",
+     "start_time": "2026-06-17T02:29:16.422034+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1852,14 +2043,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.27951,
-   "end_time": "2026-06-17T02:11:27.255539+00:00",
+   "duration": 2.49368,
+   "end_time": "2026-06-17T02:29:16.661004+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-17T02:11:24.976029+00:00",
+   "start_time": "2026-06-17T02:29:14.167324+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
> **PR empilee (stacked)** : base = `feat/sl10-ex3-guided` (#3190). Ordre de merge SL-10 : #3188 (Ex1) -> #3189 (Ex2) -> #3190 (Ex3) -> celle-ci (Ex4). **COMPLETE SL-10** (les 4 exercices du Capstone resolus en exemples guides + variations).

## Livrable

**Ex4 resolu en exemple guide** (empoisonnement de bout en bout) :
- Poison `parent(lucas, sophie)` : passe l'oracle (bien type, parent non-fonctionnel).
- Inference sur le KG etendu avec les **regles deja apprises** (etape d'inference d'un pipeline reel — pas de re-mining, qui diluerait la confiance).
- **DOMMAGE mesure honnetement** : 3 faits (clean) -> 12 (empoisonne) = **9 contamines**.
  - **4 DIRECTS** (poison = temoin) : `grandparent(marc, sophie)`, `grandparent(nadia, sophie)`, `dirige(lucas, atelier_verne)`, `travaille_pour(lucas, atelier_verne)`.
  - **5 CASCADE** : le poison remonte l'arbre lucas -> nadia -> paul (`dirige`/`travaille_pour` faux pour nadia et paul sur atelier_verne).
- **Lecon** : aucun verrou existant (oracle/mineur/chainage) ne l'arrete — seul un **schema** (cardinalite <=2 parents, ou acyclicite/generation) le bloquerait.

**Nouvel exercice en variation** : "Bloquer le poison (cardinalite des parents)" — implementer `oracle_cardinalite`, montrer lucas rejete comme 3e parent. C.1-clean.

## Preuves (validation reelle)

- **Papermill** (`--kernel python3 --scrub-keys`, deterministe) : **SUCCESS** 4.4s, 1/1, 0 erreur.
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = **0**.
- **C.2** : 16 cellules code, `execution_count` set + outputs + 0 erreur.
- **Determinisme** : sortie Ex4 verifiee **identique sur 2 runs** (le filtre de contamination exclut l'ambiguite de temoin set-iteration).
- Cellules LLM restorees depuis `origin/main` (`sl10-07/08/19/22`) — pas de `.env` local.

## Anti-regression (verifie vs `feat/sl10-ex3-guided`)

- CHANGED SOURCE : **uniquement** `sl10-31`. CHANGED OUTPUT : **uniquement** `sl10-31`.
- +1 markdown (variation), **0 supprimee** ; +1 code (stub variation), **0 supprime**.
- 1 fichier `.ipynb` (SL-10). Pas de churn catalogue. Submodule openzeppelin non stage.

See #2161
