### PR TITLE
feat(sl-4): resolve Exercice 2 (W operator) into guided example + add sport exercise

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
@@ -2073,30 +2073,110 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : operateur W\n",
-      "Etape 1 : choisissez un domaine et definissez 2-3 faits\n",
-      "Etape 2 : creez deux clauses specifiques\n",
-      "Etape 3 : appliquez apply_w_operator et verifiez le resultat\n"
-     ]
+     "name": "stdout",
+     "text": "Liaisons directes (background) :\n  direct(Berlin, Warsaw)\n  direct(Brussels, Berlin)\n  direct(Lyon, Paris)\n  direct(Paris, Brussels)\n\nClause 1 (recursive) : connected(Paris, Berlin) :- direct(Paris, Brussels), connected(Brussels, Berlin).\nClause 2 (base)      : connected(Brussels, Berlin) :- direct(Brussels, Berlin).\n\nOperateur W : 1 clause(s) resultante(s)\n  -> connected(Paris, Berlin).\n\nOK : connected(Paris, Berlin) reconstruit par identification (operateur W).\n"
     }
    ],
    "source": [
-    "# Exercice 2 : Operateur W sur un nouveau domaine\n",
-    "# TODO etudiant : Appliquez l'operateur W pour decouvrir une regle\n",
-    "# sur un domaine de votre choix (par exemple : transport, cuisine, sport)\n",
-    "# Indice : definissez 2-3 clauses specifiques et combinez-les\n",
-    "# Etape 1 : definissez le background et les clauses initiales\n",
-    "# Etape 2 : appliquez apply_w_operator\n",
-    "# Etape 3 : verifiez que la clause resultante est correcte\n",
+    "# Exemple guide : Operateur W (identification) sur un domaine de transport\n",
+    "# Objectif : combiner deux clauses via l'operateur W pour generaliser, comme la\n",
+    "# demo ancestor de la section precedente, mais sur un NOUVEAU domaine (un reseau\n",
+    "# de transports). On montre que l'identification est domain-agnostique.\n",
+    "# Domaine : direct(X, Y) = liaison directe ; connected(X, Y) = joignable (transitif).\n",
     "\n",
-    "print(\"Exercice a completer : operateur W\")\n",
-    "print(\"Etape 1 : choisissez un domaine et definissez 2-3 faits\")\n",
-    "print(\"Etape 2 : creez deux clauses specifiques\")\n",
-    "print(\"Etape 3 : appliquez apply_w_operator et verifiez le resultat\")"
+    "# Etape 1 : le reseau de liaisons directes (background du domaine).\n",
+    "DIRECT = {\n",
+    "    (\"direct\", \"Paris\", \"Brussels\"),\n",
+    "    (\"direct\", \"Brussels\", \"Berlin\"),\n",
+    "    (\"direct\", \"Berlin\", \"Warsaw\"),\n",
+    "    (\"direct\", \"Lyon\", \"Paris\"),\n",
+    "}\n",
+    "print(\"Liaisons directes (background) :\")\n",
+    "for (pred, a, b) in sorted(DIRECT):\n",
+    "    print(f\"  {pred}({a}, {b})\")\n",
+    "print()\n",
+    "\n",
+    "# Etape 2 : deux clauses specifiques a combiner.\n",
+    "#   c1 (recursive) : connected(Paris, Berlin) :- direct(Paris, Brussels), connected(Brussels, Berlin)\n",
+    "#   c2 (cas de base) : connected(Brussels, Berlin) :- direct(Brussels, Berlin)\n",
+    "# L'operateur W resout le litteral commun connected(Brussels, Berlin) -- present\n",
+    "# dans le body de c1 ET en tete de c2 -- pour fusionner les deux clauses.\n",
+    "c1 = HornClause(\n",
+    "    head=Literal(\"connected\", (\"Paris\", \"Berlin\")),\n",
+    "    body=[Literal(\"direct\", (\"Paris\", \"Brussels\")),\n",
+    "          Literal(\"connected\", (\"Brussels\", \"Berlin\"))],\n",
+    ")\n",
+    "c2 = HornClause(\n",
+    "    head=Literal(\"connected\", (\"Brussels\", \"Berlin\")),\n",
+    "    body=[Literal(\"direct\", (\"Brussels\", \"Berlin\"))],\n",
+    ")\n",
+    "print(f\"Clause 1 (recursive) : {c1}\")\n",
+    "print(f\"Clause 2 (base)      : {c2}\")\n",
+    "print()\n",
+    "\n",
+    "# Etape 3 : application de l'operateur W (identification).\n",
+    "w_results = apply_w_operator(c1, c2)\n",
+    "print(f\"Operateur W : {len(w_results)} clause(s) resultante(s)\")\n",
+    "for r in w_results:\n",
+    "    print(f\"  -> {r}\")\n",
+    "print()\n",
+    "\n",
+    "# Lecture : W a resolu connected(Brussels, Berlin) et renvoye la tete generalisee\n",
+    "# connected(Paris, Berlin). C'est l'etape d'identification de la resolution\n",
+    "# inverse : a partir de la regle recursive + le cas de base, on reconstruit le\n",
+    "# fait compose \"Paris est connecte a Berlin\". La version simplifiee du notebook\n",
+    "# retourne la tete seule ; un systeme complet (Progol) preserverait en plus le\n",
+    "# body non-resolu (direct(Paris, Brussels), direct(Brussels, Berlin)).\n",
+    "assert any(r.head.predicate == \"connected\"\n",
+    "           and tuple(r.head.args) == (\"Paris\", \"Berlin\") for r in w_results), \\\n",
+    "    \"le W-operator doit produire connected(Paris, Berlin)\"\n",
+    "print(\"OK : connected(Paris, Berlin) reconstruit par identification (operateur W).\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7771c793",
+   "metadata": {},
+   "source": [
+    "### A votre tour : operateur W sur un tournoi (sport)\n",
+    "\n",
+    "Changez de domaine pour verifier que l'identification est bien un mecanisme\n",
+    "generique : appliquez l'operateur W a un tournoi ou `defeated(X, Y)` note \"X a\n",
+    "battu Y directement\" et `stronger(X, Z)` la relation transitive qui en decoule.\n",
+    "Vous retrouvez le meme schema recursive + cas de base que `connected`/`direct`, et\n",
+    "le W doit renvoyer la tete generalisee `stronger(premier, dernier)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "1eb25f7e",
+   "metadata": {},
+   "source": [
+    "# Exercice : Operateur W sur un tournoi (domaine sport)\n",
+    "# TODO etudiant : transposez l'exemple guide sur un tournoi ou defeated(X, Y)\n",
+    "# signifie \"X a battu Y\" et stronger(X, Z) la relation transitive associee.\n",
+    "# Indice : meme schema que connected/direct --\n",
+    "#            stronger(A, C) :- defeated(A, B), stronger(B, C)   (recursive)\n",
+    "#            stronger(B, C) :- defeated(B, C)                   (base)\n",
+    "#          et apply_w_operator doit renvoyer la tete stronger(A, C).\n",
+    "# Etape 1 : definissez DEFEATED (4-5 resultats de matchs) puis les deux clauses.\n",
+    "# Etape 2 : w = apply_w_operator(clause_recursive, clause_base).\n",
+    "# Etape 3 : verifiez que la tete du resultat est stronger(premier vainqueur, dernier battu).\n",
+    "print(\"Exercice a completer : operateur W sur un tournoi (defeated/stronger)\")\n",
+    "print(\"Etape 1 : DEFEATED = { (defeated, Luna, Rex), (defeated, Rex, Tao), ... }\")\n",
+    "print(\"Etape 2 : clause recursive stronger(A,C):-defeated(A,B),stronger(B,C) + base\")\n",
+    "print(\"Etape 3 : apply_w_operator -> la tete stronger(Luna, Tao)\")\n",
+    "result = None  # TODO etudiant : votre resultat apply_w_operator ici\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer : operateur W sur un tournoi (defeated/stronger)\nEtape 1 : DEFEATED = { (defeated, Luna, Rex), (defeated, Rex, Tao), ... }\nEtape 2 : clause recursive stronger(A,C):-defeated(A,B),stronger(B,C) + base\nEtape 3 : apply_w_operator -> la tete stronger(Luna, Tao)\n"
+    }
+   ],
+   "execution_count": 15
   },
   {
    "cell_type": "markdown",
@@ -2117,7 +2197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "fa814830",
    "metadata": {
     "execution": {
@@ -2204,7 +2284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "972eb4bf",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

Epic: SymbolicLearning exercise-resolution lane (#2161), ai-01 dispatch 2026-06-17. po-2026 lane = SL-4 Ex.2/3/4 (now that #3183 Ex.1 is merged). This PR = **SL-4 Ex.2 (operateur W / identification)**.

`Exercice 2 : Operateur W sur un nouveau domaine` was a `# TODO etudiant` stub. It is resolved into a worked **Exemple guide** applying the notebook's own `apply_w_operator` on a fresh domain.

## What changed

- **Cell `498d3825`** (Ex.2 stub -> worked example): defines a transport network `DIRECT` (direct/2) and combines a recursive clause `connected(Paris, Berlin) :- direct(Paris, Brussels), connected(Brussels, Berlin)` with the base case `connected(Brussels, Berlin) :- direct(Brussels, Berlin)` via `apply_w_operator`. The operator resolves the shared literal `connected(Brussels, Berlin)` and returns the generalized head `connected(Paris, Berlin)` — the same identification pattern as the ancestor demo, re-skinned to show the operator is domain-agnostic.
- **New markdown + code stub** (sport tournament: `defeated/2` + `stronger/2`, same recursive+base schema) inserted after, to keep >=3 exercises. Stub is C.1-clean (`print` + `# TODO etudiant`, no `raise NotImplementedError`).
- Ex.3/Ex.4 `execution_count` bumped +1 (one new code cell inserted before them).

## Teaching point

The W operator (identification) is domain-agnostic: given a recursive clause + base case sharing a literal, it composes them into the generalized head. Demonstrated on transport (`connected`/`direct`) to contrast with the family domain (`ancestor`/`parent`) of the preamble demo. The simplified operator's empty-body behavior is documented honestly (a complete inverse-resolution system like Progol would preserve the unresolved body literals).

## Validation (real kernel, python3 via `jupyter_client`)

Re-executed changed cells only (preamble API cells + worked example + sport stub). Unchanged cells keep committed outputs (C.2/C.3). Worked-example output:

```
Liaisons directes (background) :
  direct(Berlin, Warsaw)
  direct(Brussels, Berlin)
  direct(Lyon, Paris)
  direct(Paris, Brussels)

Clause 1 (recursive) : connected(Paris, Berlin) :- direct(Paris, Brussels), connected(Brussels, Berlin).
Clause 2 (base)      : connected(Brussels, Berlin) :- direct(Brussels, Berlin).

Operateur W : 1 clause(s) resultante(s)
  -> connected(Paris, Berlin).

OK : connected(Paris, Berlin) reconstruit par identification (operateur W).
```

- `nbformat` VALID
- `0` occurrence of `raise NotImplementedError` / `assert False` / `1/0` (C.1 clean)
- diff: 1 file, +101 / -21 (the -21 = the old `# TODO` stub, not a working solution — anti-regression rule D excludes exercise cells)

## Notes

- Base off `origin/main` (post-#3183 merge) — no collision; fresh 0/0.
- SL-9 is **HOLD USER** per ai-01 (rework series position #5 AIMA); po-2026 does not touch SL-9 beyond the already-posted #3191.

See #2161