### PR TITLE
feat(sl-5): resolve Exercice 2 (frere/oncle LTN) into guided example + variation

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
@@ -1244,9 +1244,11 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Entrainement LTN sur un nouveau domaine\n",
+    "### Exemple guide 2 : Entrainement LTN pour frere et oncle\n",
     "\n",
-    "Entrainez un predicat neuronal `frere(X,Y)` sur des faits positifs et negatifs, puis utilisez la regle `frere(X,Y) AND parent(Y,Z) => oncle(X,Z)` pour apprendre `oncle`."
+    "> **Bascule TP -> Exemple guide** (See #2161). Solution demontree ci-dessous.\n",
+    "\n",
+    "On entraine un predicat neuronal `frere(X,Y)` sur des faits positifs et negatifs, puis on utilise la regle `frere(X,Y) AND parent(Y,Z) => oncle(X,Z)` pour apprendre `oncle`. Cela illustre le deuxieme pilier des LTN : l'apprentissage **guide par regle**, ou un predicat est contraint non seulement par des faits mais aussi par la semantique logique d'une regle."
    ]
   },
   {
@@ -1274,17 +1276,173 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : entrainez frere et oncle\n"
+      "=== Entrainement du predicat neuronal \"frere\" ===\n",
+      "  Epoch 30 : perte = 0.5833\n",
+      "  Epoch 60 : perte = 0.2891\n",
+      "  Epoch 90 : perte = 0.1923\n",
+      "  Epoch 120 : perte = 0.1441\n",
+      "  Epoch 150 : perte = 0.1152\n",
+      "\n",
+      "=== Resultats frere (cible : positifs ~1, negatifs ~0) ===\n",
+      "  frere(Marie, Sophie) = 0.9677   [positif]\n",
+      "  frere(Sophie, Marie) = 0.9795   [positif]\n",
+      "  frere(Marie, Pierre) = 0.0137   [negatif]\n",
+      "  frere(Pierre, Paul) = 0.0002   [negatif]\n",
+      "  frere(Sophie, Luc) = 0.0087   [negatif]\n",
+      "  frere(Pierre, Sophie) = 0.0140   [negatif]\n",
+      "  frere(Paul, Marie) = 0.0088   [negatif]\n",
+      "  frere(Luc, Pierre) = 0.0003   [negatif]\n",
+      "  frere(Marie, Luc) = 0.0069   [negatif]\n",
+      "  frere(Paul, Sophie) = 0.0070   [negatif]\n",
+      "\n",
+      "=== Entrainement guide par regle : frere(X,Y) AND parent(Y,Z) => oncle(X,Z) ===\n",
+      "  Epoch 10 : perte = 0.3700\n",
+      "  Epoch 20 : perte = 0.1880\n",
+      "  Epoch 30 : perte = 0.1177\n",
+      "\n",
+      "=== Verifications oncle (le corps de la regle tire la verite vers le haut) ===\n",
+      "oncle(Marie, Luc) = 0.8340   [corps = frere(Marie,Sophie)=0.968 AND parent(Sophie,Luc)=0.914]\n",
+      "oncle(Sophie, Pierre) = 0.8317   [corps = frere(Sophie,Marie)=0.980 AND parent(Marie,Pierre)=0.897]\n",
+      "\n",
+      "Exemple guide 2 OK : frere appris par faits, oncle derive par regle.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : Entrainement LTN pour frere et oncle\n",
-    "# TODO etudiant : creez et entrainez les predicats frere et oncle\n",
+    "# Exemple guide 2 : Entrainement LTN pour frere et oncle\n",
+    "# Resolution de l'Exercice 2 (See #2161) : solution demontree ci-dessous.\n",
+    "#\n",
+    "# On reproduit le pattern de l'entrainement de parent (par faits) puis de\n",
+    "# grandparent (par regle) : (1) on entraine frere(X,Y) sur des faits positifs\n",
+    "# et negatifs, puis (2) on derive oncle(X,Z) via la regle\n",
+    "#   frere(X,Y) AND parent(Y,Z) => oncle(X,Z)\n",
+    "# en reutilisant le parent_pred deja entraine plus haut.\n",
     "\n",
-    "# Indice : suivez le meme pattern que l'entrainement parent/grandparent\n",
+    "# Etape 1 : faits du predicat frere. On introduit une fratrie : Marie et Sophie\n",
+    "# sont soeurs. Les negatifs sont echantillonnes en monde clos (toute paire non\n",
+    "# listee comme positive est supposee fausse), comme pour parent precedemment.\n",
+    "frere_positive = [('Marie', 'Sophie'), ('Sophie', 'Marie')]\n",
+    "frere_negative = [('Marie', 'Pierre'), ('Pierre', 'Paul'), ('Sophie', 'Luc'),\n",
+    "                  ('Pierre', 'Sophie'), ('Paul', 'Marie'), ('Luc', 'Pierre'),\n",
+    "                  ('Marie', 'Luc'), ('Paul', 'Sophie')]\n",
     "\n",
-    "print('Exercice a completer : entrainez frere et oncle')"
+    "# Etape 2 : entrainement du predicat neuronal frere (meme idiom que parent :\n",
+    "# entropie croisee, la derivee de la sigmoide se compense dans le gradient).\n",
+    "frere_pred = NeuralPredicate(n_inputs=2 * len(entities), name='frere')\n",
+    "\n",
+    "print('=== Entrainement du predicat neuronal \"frere\" ===')\n",
+    "lr = 0.5\n",
+    "for epoch in range(150):\n",
+    "    total_loss = 0.0\n",
+    "    for s, o in frere_positive:\n",
+    "        x = pair_embedding(s, o)\n",
+    "        val = frere_pred(x)\n",
+    "        total_loss += -np.log(max(val, 1e-10))\n",
+    "        frere_pred.update(x * (1 - val), (1 - val), lr)\n",
+    "    for s, o in frere_negative:\n",
+    "        x = pair_embedding(s, o)\n",
+    "        val = frere_pred(x)\n",
+    "        total_loss += -np.log(max(1 - val, 1e-10))\n",
+    "        frere_pred.update(-x * val, -val, lr)\n",
+    "    if (epoch + 1) % 30 == 0:\n",
+    "        print(f'  Epoch {epoch+1:2d} : perte = {total_loss:.4f}')\n",
+    "\n",
+    "print('\\n=== Resultats frere (cible : positifs ~1, negatifs ~0) ===')\n",
+    "for s, o in frere_positive:\n",
+    "    print(f'  frere({s}, {o}) = {frere_pred(pair_embedding(s, o)):.4f}   [positif]')\n",
+    "for s, o in frere_negative:\n",
+    "    print(f'  frere({s}, {o}) = {frere_pred(pair_embedding(s, o)):.4f}   [negatif]')\n",
+    "\n",
+    "# Etape 3 : derivation de oncle par la regle frere(X,Y) AND parent(Y,Z) => oncle(X,Z).\n",
+    "# Les chaines (X frere/soeur de Y, Y parent de Z) :\n",
+    "#   - Marie est soeur de Sophie, qui est parent de Luc  -> oncle(Marie, Luc)\n",
+    "#   - Sophie est soeur de Marie, qui est parent de Pierre -> oncle(Sophie, Pierre)\n",
+    "# On reutilise le parent_pred deja entraine (cellule parent).\n",
+    "chains_oncle = [('Marie', 'Sophie', 'Luc'), ('Sophie', 'Marie', 'Pierre')]\n",
+    "\n",
+    "oncle_pred = NeuralPredicate(n_inputs=2 * len(entities), name='oncle')\n",
+    "\n",
+    "print('\\n=== Entrainement guide par regle : frere(X,Y) AND parent(Y,Z) => oncle(X,Z) ===')\n",
+    "lr = 0.5\n",
+    "for epoch in range(30):\n",
+    "    total_loss = 0.0\n",
+    "    for x_bro, y_par, z_child in chains_oncle:\n",
+    "        x_xz = pair_embedding(x_bro, z_child)\n",
+    "        fr_val = frere_pred(pair_embedding(x_bro, y_par))\n",
+    "        par_val = parent_pred(pair_embedding(y_par, z_child))\n",
+    "        onc_val = oncle_pred(x_xz)\n",
+    "        body = fuzzy_and(fr_val, par_val)\n",
+    "        rule_truth = fuzzy_implies(body, onc_val)\n",
+    "        total_loss += -np.log(max(rule_truth, 1e-10))\n",
+    "        gw, gb = oncle_pred.gradient(x_xz)\n",
+    "        error = body - onc_val\n",
+    "        oncle_pred.update(gw * error, gb * error, lr)\n",
+    "    if (epoch + 1) % 10 == 0:\n",
+    "        print(f'  Epoch {epoch+1:2d} : perte = {total_loss:.4f}')\n",
+    "\n",
+    "print('\\n=== Verifications oncle (le corps de la regle tire la verite vers le haut) ===')\n",
+    "for x_bro, y_par, z_child in chains_oncle:\n",
+    "    val = oncle_pred(pair_embedding(x_bro, z_child))\n",
+    "    fr_val = frere_pred(pair_embedding(x_bro, y_par))\n",
+    "    par_val = parent_pred(pair_embedding(y_par, z_child))\n",
+    "    print(f'oncle({x_bro}, {z_child}) = {val:.4f}   '\n",
+    "          f'[corps = frere({x_bro},{y_par})={fr_val:.3f} AND parent({y_par},{z_child})={par_val:.3f}]')\n",
+    "\n",
+    "print('\\nExemple guide 2 OK : frere appris par faits, oncle derive par regle.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl5-ex2-var-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 (variation) : Amitie et transitivite discutable\n",
+    "\n",
+    "Reproduisez le schema (predicat appris par faits, puis derive par regle) avec un nouveau domaine : entrainez `ami(X,Y)` sur des faits, puis derivez `ami_ami(X,Z)` par la regle `ami(X,Y) AND ami(Y,Z) => ami_ami(X,Z)`.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Definir 2-3 faits positifs `ami` (ex. Pierre ami de Paul, Paul ami de Luc) et un echantillon de negatifs en monde clos, puis entrainer `ami_pred` (meme idiom que `frere`).\n",
+    "2. Construire les chaines de transitivite et entrainer `ami_ami_pred` par la regle (meme idiom que `oncle`).\n",
+    "3. **Question** : la regle force l'agent a *croire* que l'ami d'un ami est un ami. Pourquoi est-ce semantiquement discutable ? Que se passe-t-il si la regle est fausse mais qu'on l'entraine quand meme ?\n",
+    "\n",
+    "**Indice** : un reseau neuro-symbolique apprend exactement ce que les regles et les faits lui disent d'apprendre -- ni plus, ni moins. Une regle fausse produit un predicat coherent avec la regle, pas avec le monde. C'est le coeur du debat sur la *soundness* vs l'*expressivite* des LTN."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "sl5-ex2-var-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : ami par faits, ami_ami par regle\n",
+      "Question : la regle force ami_ami meme si semantiquement faux.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (variation) : Amitie et transitivite discutable\n",
+    "# TODO etudiant : entrainez ami_pred par faits, puis ami_ami_pred par regle.\n",
+    "\n",
+    "# Etape 1 : faits ami (positifs + negatifs en monde clos) puis entrainement\n",
+    "# ami_pred = NeuralPredicate(n_inputs=2 * len(entities), name='ami')\n",
+    "# ami_positive = [...]\n",
+    "# ami_negative = [...]\n",
+    "# (meme boucle d'entrainement que frere)\n",
+    "\n",
+    "# Etape 2 : chaines de transitivite puis entrainement de ami_ami_pred\n",
+    "# chains_ami_ami = [('Pierre', 'Paul', 'Luc'), ...]   # ami(X,Y) AND ami(Y,Z)\n",
+    "# (meme boucle guidee par regle que oncle)\n",
+    "\n",
+    "# Etape 3 : pourquoi la transitivite de l'amitie est-elle discutable ?\n",
+    "print('Exercice a completer : ami par faits, ami_ami par regle')\n",
+    "print('Question : la regle force ami_ami meme si semantiquement faux.')\n",
+    "\n",
+    "# Indice : un LTN apprend ce que les regles disent, pas ce qui est vrai.\n",
+    "# result = None  # TODO etudiant : ami_ami(Pierre, Luc) = ?"
    ]
   },
   {
@@ -1308,7 +1466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "b2483326",
    "metadata": {
     "execution": {
@@ -1391,7 +1549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "e2b9c7aa",
    "metadata": {
     "execution": {
@@ -1478,7 +1636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "dee9a21b",
    "metadata": {
     "execution": {
@@ -1616,6 +1774,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "782353e4",
    "metadata": {},
    "source": [
     "## Ressources\n",
@@ -1626,8 +1785,7 @@
     "- Russell & Norvig, *AIMA*, 4e ed., Chapitre 19\n",
     "\n",
     "**Navigation** : [Index](./README.md) | [<< SL-4 ILP](SL-4-InductiveLogicProgramming.ipynb) | [Suivant >> SL-6 KG-ILP](SL-6-KnowledgeGraphs-ILP.ipynb)"
-   ],
-   "id": "782353e4"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

See #2161 (SymbolicLearning exercises → Exemples guidés). Resolves **SL-5 Exercice 2** into a worked example following the proven SL-7/8/10 recipe (solve stub → "Exemple guide", keep `# Indice`/`# Etape`, add a C.1-clean variation exercise).

## Changes (1 file, +170/-12)

- **Ex2** (cell `b7c8387b`): stub → **Exemple guide 2**.
  - Trains `frere(X,Y)` on facts (Marie/Sophie sisters) — reuses the `NeuralPredicate` + cross-entropy idiom of the `parent` cell.
  - Derives `oncle(X,Z)` via `frere(X,Y) AND parent(Y,Z) => oncle(X,Z)` — reuses the rule-guided idiom of the `grandparent` cell + the already-trained `parent_pred`.
- **Variation** (new, after Ex2): "Amitié et transitivité discutable" — train `ami`, derive `ami_ami` by `ami(X,Y) AND ami(Y,Z) => ami_ami(X,Z)`; discusses why rule-learning is soundness-blind. C.1-clean stub.
- **Ex3/Ex4/Ex5**: `execution_count` bumped +1 (insertion hygiene; source + outputs unchanged).

## Proof of execution (kernel python3)

```
frere(Marie, Sophie) = 0.9677   [positif ~1]
frere(Sophie, Marie) = 0.9795   [positif ~1]
frere(*) negatives   = 0.0002..0.0140   [negatifs ~0]
oncle(Marie, Luc)    = 0.8340   [body: frere 0.968 AND parent 0.914]
oncle(Sophie, Pierre)= 0.8317   [body: frere 0.980 AND parent 0.897]
```

## Validation

- `nbformat.validate` OK. **C.1 = 0** (no `raise NotImplementedError`/`assert False`/`1/0`). **H.3 = 0** (no code cell with `execution_count=None` + no outputs).
- `execution_count` monotonic [1..13].
- **Scope**: only Ex2 (source+outputs), the 2 new variation cells, and Ex3/4/5 exec_count bumps. Section-7 LTNtorch cell (`4b4e4ecb`) and all infra cells are **byte-identical to origin/main**.

## Env note (rule F)

SL-5 section 7 uses **LTNtorch** (torch-based `ltn`, has `ltn.Connective`; the PyPI `ltn` is the wrong TF-based package). Installed LTNtorch from `github.com/logictensornetworks/LTNtorch`. Section 7 then hits a CUDA device-mismatch on this box (`cuda.is_available()=True` but mixed device tensors; `CUDA_VISIBLE_DEVICES=''` does not disable CUDA here) — a **pre-existing GPU/device cell unrelated to Ex2** (pure-numpy). Per the rule-F GPU exception, Ex2 was re-executed via its pure-numpy dependency chain (cells 2,5,8,11,14) and section 7 left with its valid origin/main outputs. Flagged to ai-01 for a GPU-machine full-papermill pass (cf. the swi-prolog gap on SL-4/SL-9).

Co-Authored-By: Claude <noreply@anthropic.com>
