### PR TITLE
feat(sl-1): resolve Exercice 1 (CBH ordre aleatoire) into guided example + variation

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -2099,11 +2099,11 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : CBH avec ordre personnalise\n",
+    "### Exemple guide 1 : CBH avec ordre aleatoire\n",
     "\n",
-    "Testez CBH avec un ordre **aleatoire** des exemples. Executez plusieurs fois et comparez les hypotheses obtenues. Que constatez-vous sur la stabilite de CBH ?\n",
+    "Une intuition courante : comme CBH ne garde qu'**une seule** hypothese et l'ajuste au gre des exemples, son resultat pourrait dependre fortement de l'ordre d'arrivee. Verifions-le en relancant CBH sur **trois ordres aleatoires** (seeds distinctes) et en comparant les hypotheses finales. Le resultat est surprenant et revele la vraie limite de CBH sur ces donnees.\n",
     "\n",
-    "**Etapes** :\n",
+    "**Etapes (resolues ci-dessous)** :\n",
     "1. Melangez les exemples avec `import random; random.shuffle(shuffled)`\n",
     "2. Executez CBH sur les exemples melanges\n",
     "3. Repetez 3 fois et comparez les resultats"
@@ -2134,21 +2134,112 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : testez CBH avec un ordre aleatoire\n",
-      "Comparez les hypotheses finales sur 3 executions avec des seeds differents\n"
+      "CBH sur 3 ordres aleatoires (seeds 0, 7, 42) :\n",
+      "================================================================\n",
+      "seed= 0 | hypothese finale : ('?', '?', '?', 'Yes', '?', '?', '?', '?', '?', '?')\n",
+      "       | faux positifs=1, faux negatifs=0, consistante=False\n",
+      "\n",
+      "seed= 7 | hypothese finale : ('?', '?', '?', 'Yes', '?', '?', '?', '?', '?', '?')\n",
+      "       | faux positifs=1, faux negatifs=0, consistante=False\n",
+      "\n",
+      "seed=42 | hypothese finale : ('?', '?', '?', 'Yes', '?', '?', '?', '?', '?', '?')\n",
+      "       | faux positifs=1, faux negatifs=0, consistante=False\n",
+      "\n",
+      "Hypotheses distinctes sur 3 seeds : 1/3\n",
+      "\n",
+      "Constat :\n",
+      "- CBH converge vers la MEME hypothese sur 3 ordres differents : elle est STABLE\n",
+      "  ici, contrairement a l'intuition d'instabilite.\n",
+      "- MAIS cette hypothese n'est PAS consistante (1 faux positif).\n",
+      "- Interpretation : le concept 'WillWait' n'est PAS representable par une seule\n",
+      "  conjonction d'attributs. CBH (une seule conjonction) ne peut donc PAS\n",
+      "  l'apprendre parfaitement, quel que soit l'ordre. C'est une limite de PUISSANCE\n",
+      "  D'EXPRESSION de l'espace d'hypotheses, pas d'instabilite d'ordre.\n",
+      "\n",
+      "Le Version Space (section 5) garde TOUTES les hypotheses consistantes : il\n",
+      "caracterise exactement ce qu'une conjonction peut representer, et permet de\n",
+      "mesurer si une seule conjonction suffit pour ce concept.\n"
      ]
     }
    ],
    "source": [
     "import random\n",
     "\n",
-    "# TODO etudiant : testez CBH avec un ordre aleatoire (3 executions)\n",
-    "# Indice : copiez EXAMPLES, melangez avec random.shuffle, executez current_best_hypothesis\n",
-    "random.seed(42)\n",
-    "shuffled = EXAMPLES.copy()\n",
-    "random.shuffle(shuffled)\n",
-    "print(\"Exercice a completer : testez CBH avec un ordre aleatoire\")\n",
-    "print(\"Comparez les hypotheses finales sur 3 executions avec des seeds differents\")"
+    "# Exemple guide : CBH avec ordre aleatoire -- intuition d'instabilite a l'epreuve\n",
+    "# Intuition : CBH ne gardant qu'UNE hypothese ajustee exemple par exemple,\n",
+    "# l'ordre d'arrivee devrait fortement changer le resultat. Verifions sur 3 ordres\n",
+    "# aleatoires (seeds distinctes) et confrontons a l'intuition.\n",
+    "\n",
+    "print(\"CBH sur 3 ordres aleatoires (seeds 0, 7, 42) :\")\n",
+    "print(\"=\" * 64)\n",
+    "\n",
+    "results = {}\n",
+    "for seed in (0, 7, 42):\n",
+    "    random.seed(seed)\n",
+    "    shuffled = EXAMPLES.copy()\n",
+    "    random.shuffle(shuffled)\n",
+    "    h, _trace = current_best_hypothesis(shuffled)\n",
+    "    fp, fn = count_errors(h, EXAMPLES)\n",
+    "    results[seed] = h\n",
+    "    print(f\"seed={seed:>2} | hypothese finale : {h}\")\n",
+    "    print(f\"       | faux positifs={fp}, faux negatifs={fn}, consistante={is_consistent(h, EXAMPLES)}\")\n",
+    "    print()\n",
+    "\n",
+    "distinct = len(set(results.values()))\n",
+    "print(f\"Hypotheses distinctes sur 3 seeds : {distinct}/3\")\n",
+    "print()\n",
+    "print(\"Constat :\")\n",
+    "print(\"- CBH converge vers la MEME hypothese sur 3 ordres differents : elle est STABLE\")\n",
+    "print(\"  ici, contrairement a l'intuition d'instabilite.\")\n",
+    "print(\"- MAIS cette hypothese n'est PAS consistante (1 faux positif).\")\n",
+    "print(\"- Interpretation : le concept 'WillWait' n'est PAS representable par une seule\")\n",
+    "print(\"  conjonction d'attributs. CBH (une seule conjonction) ne peut donc PAS\")\n",
+    "print(\"  l'apprendre parfaitement, quel que soit l'ordre. C'est une limite de PUISSANCE\")\n",
+    "print(\"  D'EXPRESSION de l'espace d'hypotheses, pas d'instabilite d'ordre.\")\n",
+    "print()\n",
+    "print(\"Le Version Space (section 5) garde TOUTES les hypotheses consistantes : il\")\n",
+    "print(\"caracterise exactement ce qu'une conjonction peut representer, et permet de\")\n",
+    "print(\"mesurer si une seule conjonction suffit pour ce concept.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl1-ex1-variation-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 (variation) : Taux de consistance de CBH\n",
+    "\n",
+    "L'exemple guide compare 3 ordres et trouve une hypothese stable mais NON consistante. Generalisez la mesure : executez CBH sur **20 graines** differentes et calculez le **taux de consistance** -- la proportion de graines pour lesquelles CBH aboutit a une hypothese **consistante** (`is_consistent` vrai). Affichez aussi le nombre d'hypotheses distinctes produites.\n",
+    "\n",
+    "**Indices** :\n",
+    "1. Boucle `for seed in range(20)` : `random.seed(seed)`, copiez + melangez `EXAMPLES`, lancez `current_best_hypothesis`.\n",
+    "2. Comptez les `is_consistent(h, EXAMPLES)` vrais -> taux = `nb_consistantes / 20`.\n",
+    "3. Comptez les hypotheses distinctes avec un `set`.\n",
+    "4. Conclusion : un taux faible confirme que le concept depasse l'espace d'une seule conjonction -- c'est alors le Version Space (section 5) qui le met en evidence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "sl1-ex1-variation-stub",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : mesurez le taux de consistance de CBH sur 20 graines\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (variation) : Taux de consistance de CBH\n",
+    "# TODO etudiant : executez CBH sur 20 graines, mesurez le taux de consistance\n",
+    "# Etape 1 : for seed in range(20): random.seed(seed); melangez EXAMPLES; current_best_hypothesis\n",
+    "# Etape 2 : comptez les hypotheses consistantes (is_consistent) -> taux = nb_consistantes / 20\n",
+    "# Etape 3 : comptez les hypotheses distinctes (len(set(...)))\n",
+    "# Indice : un taux faible confirme que le concept depasse l'espace d'une seule conjonction.\n",
+    "print(\"Exercice a completer : mesurez le taux de consistance de CBH sur 20 graines\")"
    ]
   },
   {
@@ -2172,7 +2263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "883aa023",
    "metadata": {
     "execution": {
@@ -2244,7 +2335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "a66db8dd23f7",
    "metadata": {
     "execution": {
@@ -2352,7 +2443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "ef84c058",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

Resout **Exercice 1** du notebook `SL-1-LogicalLearning.ipynb` (SymbolicLearning, partition po-2025) selon la recette SymbolicLearning : stub -> exemple guide + nouvelle variation.

**Exercice 1** (CBH avec ordre personnalise) devient **Exemple guide 1 : CBH avec ordre aleatoire**. La cellule stub est remplacee par une solution complete qui relance CBH sur 3 ordres aleatoires (seeds 0/7/42) et confronte le resultat a l'intuition d'instabilite.

### Resultat honnete (ce que demontre reellement l'execution)
Les 3 ordres convergent vers la **meme hypothese** `('?','?','?','Yes',...)` (1 faux positif, non consistante). CBH est donc **stable** ici, contrairement a l'intuition -- mais l'hypothese est **fausse**. La vraie limite revelee est la **puissance d'expression** : le concept `WillWait` n'est pas representable par une seule conjonction d'attributs, quel que soit l'ordre. Ce constat prepare la section Version Space (section 5), qui caracterise rigoureusement ce qu'une conjonction peut representer.

> Note pedagogique : la narration a ete reformulee apres execution, parce que la 1re version claimait une "instabilite" que les donnees ne demontrent pas (les 3 seeds convergent). Le resultat reel (stable-mais-inconsistant) est une lecon plus riche et plus honnete.

### Nouvelle variation
**Exercice 1 (variation) : Taux de consistance de CBH** -- execute CBH sur 20 graines, mesure le % d'hypotheses consistantes. Stub C.1-clean (`print` + `# TODO etudiant` + `# Etape N` / `# Indice`), aucun `raise NotImplementedError`.

## Proof of execution (regle D)

- Papermill end-to-end, kernel `python3`, **0 erreur**.
- 17 cellules code, `execution_count` sequence **1-17** (sequentiel, aucun null).
- 0 cellule sans output.
- Scan C.1 : **0** `raise NotImplementedError | assert False | 1/0`.
- Outputs injectes chirurgicalement (pattern surgical-inject) : **0 ligne de churn metadata papermill**. Le diff est de **106 insertions / 15 deletions** sur 5 hunks seulement.
  - Cellule 37 (markdown) : titre `### Exercice 1` -> `### Exemple guide 1`.
  - Cellule 38 : stub -> solution guidee (+ outputs reels).
  - +2 cellules (variation markdown + variation stub).
  - `execution_count` +1 sur Ex2/Ex3/Ex5 (14->15, 15->16, 16->17) -- seul le nouveau CODE cell decale le compteur.
  - Toutes les autres cellules : outputs + metadata **byte-identiques** a main.

## Scope

1 sujet atomique (SL-1 Ex1). Base fraiche (rebase sur `origin/main` a6342251, 0 commit en retard). SL-1 Ex2/Ex3/Ex5 feront l'objet de PR separees (serialisees, meme notebook).

See #2161