### PR TITLE
feat(lean15): add 3 executable Brzozowski exercises (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Finiteness-Derivatives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Finiteness-Derivatives.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "abb4bf69",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002226,
+     "end_time": "2026-06-17T03:48:58.897086",
+     "exception": false,
+     "start_time": "2026-06-17T03:48:58.894860",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Lean-15 — Dérivées symboliques de Brzozowski : la finitude qui garantit le *matching* linéaire\n",
     "\n",
@@ -15,7 +24,16 @@
   {
    "cell_type": "markdown",
    "id": "2c3d28bf",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002532,
+     "end_time": "2026-06-17T03:48:58.901618",
+     "exception": false,
+     "start_time": "2026-06-17T03:48:58.899086",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Le problème : pourquoi un reconnaisseur regex *devrait* être linéaire\n",
     "\n",
@@ -30,7 +48,16 @@
   {
    "cell_type": "markdown",
    "id": "b6eb658f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002,
+     "end_time": "2026-06-17T03:48:58.905618",
+     "exception": false,
+     "start_time": "2026-06-17T03:48:58.903618",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. La dérivée de Brzozowski (1964)\n",
     "\n",
@@ -55,7 +82,16 @@
   {
    "cell_type": "markdown",
    "id": "99edfb4f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002,
+     "end_time": "2026-06-17T03:48:58.909618",
+     "exception": false,
+     "start_time": "2026-06-17T03:48:58.907618",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Le théorème de finitude — *le* résultat qui garantit la terminaison\n",
     "\n",
@@ -72,11 +108,19 @@
    "id": "115a3011",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T01:18:32.003299Z",
-     "iopub.status.busy": "2026-06-15T01:18:32.003299Z",
-     "iopub.status.idle": "2026-06-15T01:18:32.106638Z",
-     "shell.execute_reply": "2026-06-15T01:18:32.106638Z"
-    }
+     "iopub.execute_input": "2026-06-17T03:48:58.914617Z",
+     "iopub.status.busy": "2026-06-17T03:48:58.914617Z",
+     "iopub.status.idle": "2026-06-17T03:49:00.552091Z",
+     "shell.execute_reply": "2026-06-17T03:49:00.552091Z"
+    },
+    "papermill": {
+     "duration": 1.642479,
+     "end_time": "2026-06-17T03:49:00.554097",
+     "exception": false,
+     "start_time": "2026-06-17T03:48:58.911618",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -115,11 +159,19 @@
    "id": "e91d349e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T01:18:32.109248Z",
-     "iopub.status.busy": "2026-06-15T01:18:32.109248Z",
-     "iopub.status.idle": "2026-06-15T01:18:32.677871Z",
-     "shell.execute_reply": "2026-06-15T01:18:32.677344Z"
-    }
+     "iopub.execute_input": "2026-06-17T03:49:00.564608Z",
+     "iopub.status.busy": "2026-06-17T03:49:00.563619Z",
+     "iopub.status.idle": "2026-06-17T03:49:04.519763Z",
+     "shell.execute_reply": "2026-06-17T03:49:04.519763Z"
+    },
+    "papermill": {
+     "duration": 3.962453,
+     "end_time": "2026-06-17T03:49:04.521061",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:00.558608",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -154,11 +206,19 @@
    "id": "ead1b606",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T01:18:32.679996Z",
-     "iopub.status.busy": "2026-06-15T01:18:32.679480Z",
-     "iopub.status.idle": "2026-06-15T01:18:32.762936Z",
-     "shell.execute_reply": "2026-06-15T01:18:32.761927Z"
-    }
+     "iopub.execute_input": "2026-06-17T03:49:04.527127Z",
+     "iopub.status.busy": "2026-06-17T03:49:04.527127Z",
+     "iopub.status.idle": "2026-06-17T03:49:04.622204Z",
+     "shell.execute_reply": "2026-06-17T03:49:04.621143Z"
+    },
+    "papermill": {
+     "duration": 0.0997,
+     "end_time": "2026-06-17T03:49:04.623270",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.523570",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -303,7 +363,16 @@
   {
    "cell_type": "markdown",
    "id": "a9fbf7ee",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00372,
+     "end_time": "2026-06-17T03:49:04.631423",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.627703",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture des sorties\n",
     "\n",
@@ -319,7 +388,16 @@
   {
    "cell_type": "markdown",
    "id": "67b8fb95",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004049,
+     "end_time": "2026-06-17T03:49:04.638468",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.634419",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Le point fixe — pourquoi l'espace des dérivées est minuscule\n",
     "\n",
@@ -335,7 +413,16 @@
   {
    "cell_type": "markdown",
    "id": "6c03c0a7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00351,
+     "end_time": "2026-06-17T03:49:04.645974",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.642464",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. La formalisation Lean constructive — Zhuchko, Maarand, Veanes, Ebner (ITP 2025)\n",
     "\n",
@@ -353,7 +440,16 @@
   {
    "cell_type": "markdown",
    "id": "a1fe6bb8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002999,
+     "end_time": "2026-06-17T03:49:04.653218",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.650219",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Le pont vers l'Epic Conway #2162\n",
     "\n",
@@ -375,7 +471,16 @@
   {
    "cell_type": "markdown",
    "id": "f0ac26b6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003997,
+     "end_time": "2026-06-17T03:49:04.662319",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.658322",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercices\n",
     "\n",
@@ -400,6 +505,230 @@
     "\n",
     "**Exercice 3 (finitude explicite).** Montrez par le calcul (une série de `#eval` de `deriv` itérés) que l'espace des dérivées de `concat (char 'a') (char 'b')` est bien fini : partez de `abWord`, dérivez par 'a', puis par 'b', et observez que la dérivée finale est nullable (`eps`) puis devient `empty` si on dérive encore. *Indice : `#eval deriv 'a' abWord`, `#eval deriv 'b' (deriv 'a' abWord)`.*"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "brz-ex01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002938,
+     "end_time": "2026-06-17T03:49:04.669256",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.666318",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — `nullable` : une regex reconnaît-elle le mot vide ?\n",
+    "\n",
+    "Une regex est représentée par un *tuple* imbriqué (convention partagée par les\n",
+    "3 exercices ci-dessous) :\n",
+    "\n",
+    "```python\n",
+    "('#empty',)              # ∅  : langage vide\n",
+    "('#eps',)                # ε  : le mot vide seulement\n",
+    "('#char', c)             # un seul caractere c\n",
+    "('#concat', r1, r2)      # r1 · r2\n",
+    "('#union', r1, r2)       # r1 + r2\n",
+    "('#star', r)             # r* (zero, une ou plusieurs occurrences)\n",
+    "('#plus', r)             # r+ = r · r*  (une ou plusieurs ; miroir de l'Ex.1 Lean)\n",
+    "```\n",
+    "\n",
+    "Une regex $r$ est **nullable** si $\\varepsilon \\in L(r)$ (elle accepte le mot\n",
+    "vide). C'est la brique de base dont la dérivée (Ex. 2) et la reconnaissance\n",
+    "(Ex. 3) ont besoin.\n",
+    "\n",
+    "**Objectif.** Écrire `nullable(r)` retournant `True` ssi $\\varepsilon \\in L(r)$.\n",
+    "\n",
+    "**Indice.** `eps` → `True` ; `empty` / `char` → `False` ; `concat` → ET des deux ;\n",
+    "`union` → OU des deux ; `star` → toujours `True` ; `plus` → comme son sous-terme.\n",
+    "\n",
+    "**Étapes.** (1) Filtrer (`match`) sur la tête du tuple pour distinguer les 7 cas ;\n",
+    "(2) pour `concat`/`union`/`plus`, récursion sur le(s) sous-terme(s).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "brz-ex02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T03:49:04.679763Z",
+     "iopub.status.busy": "2026-06-17T03:49:04.678763Z",
+     "iopub.status.idle": "2026-06-17T03:49:04.683933Z",
+     "shell.execute_reply": "2026-06-17T03:49:04.682928Z"
+    },
+    "papermill": {
+     "duration": 0.010678,
+     "end_time": "2026-06-17T03:49:04.683933",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.673255",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def nullable(r):\n",
+    "    # TODO etudiant : True ssi la regex r accepte le mot vide.\n",
+    "    # Indice : 'eps'->True ; 'empty'/'char'->False ; 'star'->True ;\n",
+    "    #          'concat'->nullable(r1) and nullable(r2) ;\n",
+    "    #          'union' ->nullable(r1) or  nullable(r2) ; 'plus'->nullable(r1).\n",
+    "    # Etape 1 : match sur r[0] pour distinguer les 7 cas.\n",
+    "    # Etape 2 : recursion sur les sous-termes pour concat/union/plus.\n",
+    "    return None\n",
+    "\n",
+    "# Tests (a decommenter) :\n",
+    "# assert nullable(('#eps',)) is True\n",
+    "# assert nullable(('#empty',)) is False\n",
+    "# assert nullable(('#char', 'a')) is False\n",
+    "# assert nullable(('#concat', ('#char', 'a'), ('#eps',))) is False\n",
+    "# assert nullable(('#union', ('#char', 'a'), ('#eps',))) is True\n",
+    "# assert nullable(('#star', ('#char', 'a'))) is True\n",
+    "# assert nullable(('#plus', ('#char', 'a'))) is False\n",
+    "# print('Exercice 1 : OK')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "brz-ex03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005,
+     "end_time": "2026-06-17T03:49:04.693634",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.688634",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — `derivative` : la dérivée de Brzozowski\n",
+    "\n",
+    "La **dérivée** $D_a(r)$ est le langage des suffixes : $w \\in D_a(r) \\iff aw \\in L(r)$.\n",
+    "C'est l'opération dont la **finitude** (théorème central de ce notebook) garantit\n",
+    "la terminaison de la reconnaissance.\n",
+    "\n",
+    "**Objectif.** Écrire `derivative(r, a)` retournant la dérivée de `r` par le\n",
+    "caractère `a` (convention AST de l'Exercice 1). On renvoie la forme\n",
+    "**non simplifiée** (la simplification est un autre sujet).\n",
+    "\n",
+    "**Indice.** `char c` → `#eps` si `c == a` sinon `#empty` ; `union` → dérivée des\n",
+    "deux branches ; `star r` → `#concat(derivative(r, a), #star r)` ;\n",
+    "`concat r1 r2` → si `nullable(r1)` : `#union(#concat(D(r1), r2), D(r2))`,\n",
+    "sinon `#concat(D(r1), r2)`.\n",
+    "\n",
+    "**Étapes.** (1) `empty`/`eps`/`char` (cas de base) ; (2) `union`/`star`/`plus`\n",
+    "(une récursion directe) ; (3) `concat` (test `nullable` + double branche).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "brz-ex04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T03:49:04.703327Z",
+     "iopub.status.busy": "2026-06-17T03:49:04.703327Z",
+     "iopub.status.idle": "2026-06-17T03:49:04.707852Z",
+     "shell.execute_reply": "2026-06-17T03:49:04.707343Z"
+    },
+    "papermill": {
+     "duration": 0.011185,
+     "end_time": "2026-06-17T03:49:04.708853",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.697668",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def derivative(r, a):\n",
+    "    # TODO etudiant : derivée de Brzozowski de r par le caractere a (forme non simplifiee).\n",
+    "    # Indice : 'char c' -> '#eps' si c==a sinon '#empty' ; 'eps'/'empty' -> '#empty' ;\n",
+    "                        # Etape 1 : empty/eps/char. Etape 2 : union/star/plus. Etape 3 : concat.\n",
+    "    return None\n",
+    "\n",
+    "# Tests (a decommenter) :\n",
+    "# assert derivative(('#char', 'a'), 'a') == ('#eps',)\n",
+    "# assert derivative(('#char', 'a'), 'b') == ('#empty',)\n",
+    "# assert derivative(('#eps',), 'a') == ('#empty',)\n",
+    "# assert derivative(('#union', ('#char', 'a'), ('#char', 'b')), 'a') == ('#union', ('#eps',), ('#empty',))\n",
+    "# assert derivative(('#star', ('#char', 'a')), 'a') == ('#concat', ('#eps',), ('#star', ('#char', 'a')))\n",
+    "# print('Exercice 2 : OK')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "brz-ex05",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003,
+     "end_time": "2026-06-17T03:49:04.713853",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.710853",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — `matches` : reconnaître un mot par dérivées itérées\n",
+    "\n",
+    "On reconnaît un mot $s$ en **dérivant successivement** par chaque caractère puis\n",
+    "en testant la nullabilité du résultat : $s \\in L(r) \\iff \\mathrm{nullable}(D_{s}(r))$.\n",
+    "C'est exactement le mécanisme linéaire défendu en §1 (et l'analogue exécutable de\n",
+    "l'Exercice Lean « construire la regex de “contient au moins un a” puis vérifier\n",
+    "`accepts` »).\n",
+    "\n",
+    "**Objectif.** Écrire `matches(r, s)` réutilisant `derivative` (Ex. 2) et\n",
+    "`nullable` (Ex. 1).\n",
+    "\n",
+    "**Indice.** Parcourir les caractères de `s` en remplaçant `r` par\n",
+    "`derivative(r, c)` à chaque pas, puis retourner `nullable(r)`.\n",
+    "\n",
+    "**Étapes.** (1) Boucle `for c in s: r = derivative(r, c)` ; (2) retourner\n",
+    "`nullable(r)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "brz-ex06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T03:49:04.720251Z",
+     "iopub.status.busy": "2026-06-17T03:49:04.720251Z",
+     "iopub.status.idle": "2026-06-17T03:49:04.723294Z",
+     "shell.execute_reply": "2026-06-17T03:49:04.723294Z"
+    },
+    "papermill": {
+     "duration": 0.008203,
+     "end_time": "2026-06-17T03:49:04.724299",
+     "exception": false,
+     "start_time": "2026-06-17T03:49:04.716096",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def matches(r, s):\n",
+    "    # TODO etudiant : True ssi le mot s (iterable de caracteres) appartient a L(r).\n",
+    "    # Reutilise derivative (Exercice 2) et nullable (Exercice 1).\n",
+    "    # Indice : for c in s: r = derivative(r, c) ; puis return nullable(r).\n",
+    "    # Etape 1 : boucle de derivation. Etape 2 : return nullable(r).\n",
+    "    return None\n",
+    "\n",
+    "# Tests (a decommenter) — le meme langage que l'Exercice Lean 'contient au moins un a' :\n",
+    "# assert matches(('#star', ('#char', 'a')), '') is True\n",
+    "# assert matches(('#star', ('#char', 'a')), 'aaa') is True\n",
+    "# assert matches(('#star', ('#char', 'a')), 'aab') is False\n",
+    "# assert matches(('#char', 'a'), 'a') is True\n",
+    "# assert matches(('#char', 'a'), 'b') is False\n",
+    "# print('Exercice 3 : OK')\n"
+   ]
   }
  ],
  "metadata": {
@@ -418,6 +747,18 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 10.440812,
+   "end_time": "2026-06-17T03:49:08.191911",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\Lean-15-Finiteness-Derivatives.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\Lean-15-Finiteness-Derivatives_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-17T03:48:57.751099",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Adds **3 progressive executable Python exercises** to `MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Finiteness-Derivatives.ipynb` (python3 kernel, **1 exercise previously**) per the **≥3-exercises-per-notebook** convention (Epic #2161). Same lane/grain as the merged #3198 (Lean-17 Knots).

### Context — why these exercises

The notebook's existing `## Exercices` markdown section (cell [11], **kept intact — anti-regression**) describes 3 Lean-flavored exercises to complete in `Finiteness/Basic.lean` and validate via `lake build Finiteness` (run as a subprocess). **But those are not executable as notebook cells** (kernel is `python3`; Lean runs via WSL subprocess for display). The 3 new Python code cells **operationalize the same Brzozowski concepts** as runnable stubs, so the exercises are actually doable inline.

### The 3 exercises (progressive, AST defined once in Ex1 markdown)

| # | Function | Concept | Lean-prose counterpart |
|---|----------|---------|------------------------|
| Ex1 | `nullable(r)` | does regex accept the empty string? (foundation) | assumed by Lean exercises |
| Ex2 | `derivative(r, a)` | the Brzozowski derivative (incl. `plus` case = mirror of Lean Ex1 `r⁺ = r·r*`) | Lean Ex1 (derive) |
| Ex3 | `matches(r, s)` | derivative-based word matching (linear recognizer of §1) | Lean Ex2 (`accepts`) |

Shared AST: `('#empty',)`, `('#eps',)`, `('#char', c)`, `('#concat', r1, r2)`, `('#union', r1, r2)`, `('#star', r)`, `('#plus', r)`. Each stub = `return None` + commented asserts, preceded by a markdown cell (objective + **Indice** + **Étapes**).

## Validation (C.1 + C.2)

- **C.1** (no voluntary error): stubs use `return None` + commented asserts — **no `raise NotImplementedError` / `assert False` / `1/0`** (grep-verified). The Lean prose exercises (cell [11]) preserved unchanged.
- **Correctness verified**: a reference implementation passes **ALL 17 commented asserts** (exercises are solvable; hints/tests are correct — verified before shipping).
- **C.2** (committed WITH outputs): re-executed `notebook_tools.py execute --kernel python3` → **SUCCESS (12.5s, 0 errors)**. 6 code cells, all `execution_count` 1-6, 3 Lean-build outputs (`lake build Finiteness` SUCCESS via WSL) + 3 def-only stubs (empty outputs). `count_exercises` = **4** (was 1; meets ≥3 threshold). `validate`: **0 errors** (warning = pre-existing LaTeX-`$`-balance false-positive).

## Scope

Single notebook, single subject (3 Brzozowski exercises), additive (+366/-25, the −25 is JSON re-indentation churn from cell insertion, no content loss — Lean prose cell [11] retained). Partial contribution to #2161 rollout → `See #2161`. No catalog touched. Base 4 commits behind origin/main but **no conflict** (none of the 4 touched Lean-15) — force-push to rebase is forbidden per git-workflow rule; merges cleanly.