### PR TITLE
fix(genai-video): comfyui-video GPU targeting + gemma tokenizer deps for LTX-2 GGUF (See #2891)

### DIFF
--- a/docker-configurations/services/comfyui-video/.env.example
+++ b/docker-configurations/services/comfyui-video/.env.example
@@ -2,11 +2,13 @@
 # Copiez ce fichier vers .env et adaptez les valeurs
 
 # GPU Configuration
-# CRITICAL: Use GPU_DEVICE_ID=0 pour RTX 3090 (PyTorch GPU 0 = nvidia-smi GPU 1)
-# EXCLUSIF avec comfyui-qwen (meme GPU, ne pas lancer les deux)
-GPU_DEVICE_ID=0
-CUDA_VISIBLE_DEVICES=0
-NVIDIA_VISIBLE_DEVICES=0
+# Avec CUDA_DEVICE_ORDER=PCI_BUS_ID (fixe dans docker-compose.yml), l'index GPU
+# correspond a l'ordre nvidia-smi : GPU 0 = 3080Ti (16GB), GPU 1 = 3090 (24GB).
+# Le 3090 est cible via GPU_DEVICE_ID=1 (deterministe, pas de remapped index).
+# EXCLUSIF avec comfyui-qwen (meme GPU 1, ne pas lancer les deux simultanement).
+GPU_DEVICE_ID=1
+CUDA_VISIBLE_DEVICES=0,1
+NVIDIA_VISIBLE_DEVICES=0,1
 
 # Port externe (8189 pour ne pas confliter avec comfyui-qwen:8188)
 COMFYUI_VIDEO_PORT=8189

--- a/docker-configurations/services/comfyui-video/docker-compose.yml
+++ b/docker-configurations/services/comfyui-video/docker-compose.yml
@@ -48,7 +48,14 @@ services:
         target: /install_video_nodes.sh
 
     environment:
-      - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+      # Expose both GPUs to CUDA; selection is done by the entrypoint's
+      # --cuda-device flag (GPU_DEVICE_ID). Avoids pre-filtering with
+      # CUDA_VISIBLE_DEVICES, which (without PCI_BUS_ID order) remaps indices
+      # unpredictably and previously landed the server on the 16GB GPU0.
+      - CUDA_VISIBLE_DEVICES=0,1
+      # Deterministic enumeration = nvidia-smi order, so device index N inside
+      # matches nvidia-smi GPU N (0=3080Ti 16GB, 1=3090 24GB).
+      - CUDA_DEVICE_ORDER=PCI_BUS_ID
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-0}
       - GPU_DEVICE_ID=${GPU_DEVICE_ID:-0}
       - PYTHONUNBUFFERED=1

--- a/docker-configurations/services/comfyui-video/entrypoint.sh
+++ b/docker-configurations/services/comfyui-video/entrypoint.sh
@@ -33,6 +33,11 @@ echo "Verification des dependances..."
 venv/bin/pip install -r requirements.txt
 venv/bin/pip install einops
 
+# Gemma-3 tokenizer deps (LTX-2 GGUF text encoder: gemma-3-12b-it-qat GGUF).
+# Without these, loading the gemma tokenizer fails at CLIPLoaderGGUF /
+# DualCLIPLoaderGGUF time with "Please install sentencepiece and protobuf".
+venv/bin/pip install sentencepiece protobuf
+
 # =============================================================================
 # CUSTOM NODES - VIDEO
 # =============================================================================


### PR DESCRIPTION
## What

Three `comfyui-video` infra changes required to run **LTX-2 GGUF (Q4) audio-video on the RTX 3090** (Epic #2891). All verified empirically this session.

## Changes

1. **`docker-compose.yml`** — GPU targeting fix. Expose both GPUs (`CUDA_VISIBLE_DEVICES=0,1`) + set `CUDA_DEVICE_ORDER=PCI_BUS_ID`. Without PCI_BUS_ID, torch enumerates `FASTEST_FIRST`, so the device index targeted by `GPU_DEVICE_ID` remaps unpredictably and previously landed the server on the **16GB GPU0** instead of the **24GB 3090**. PCI_BUS_ID -> device index N == nvidia-smi GPU N.

2. **`entrypoint.sh`** — install `sentencepiece` + `protobuf` for the **gemma-3 tokenizer**. The LTX-2 GGUF text encoder (gemma-3-12b-it-qat GGUF, loaded via `CLIPLoaderGGUF`/`DualCLIPLoaderGGUF`) needs them; without, it fails with `"Please install sentencepiece and protobuf"`. Previously had to be installed manually via `docker exec` (lost on container recreate).

3. **`.env.example`** — corrected GPU guidance. The old comment claimed `GPU_DEVICE_ID=0` targets the 3090 (`"PyTorch GPU 0 = nvidia-smi GPU 1"`), relying on FASTEST_FIRST ordering. With PCI_BUS_ID the 3090 is deterministically GPU 1, so `GPU_DEVICE_ID=1`.

## Verified

- Container log: `Device: cuda:0 NVIDIA GeForce RTX 3090 : cudaMallocAsync` (24GB, not the 16GB GPU0).
- gemma tokenizer loads (sentencepiece/protobuf installed in entrypoint).

See #2891 — partial (infra for the LTX-2 GGUF notebook; the notebook cell update + real A/V output land in a separate follow-up PR).