### PR TITLE
feat(sl-5): resolve Exercice 3 (ancestor DeepProbLog) into guided example + variation

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-NeuroSymbolic.ipynb
@@ -1459,9 +1459,11 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Regle transitive ancestor\n",
+    "### Exemple guide 3 : Regle transitive ancestor dans DeepProbLog\n",
     "\n",
-    "Ajoutez une regle transitive `ancestor(X,Z) :- parent(X,Y), ancestor(Y,Z)` au systeme DeepProbLog, avec le fait de base `ancestor(X,Y) :- parent(X,Y)`."
+    "> **Bascule TP -> Exemple guide** (See #2161). Solution demontree ci-dessous.\n",
+    "\n",
+    "On etend le systeme `dpl` (cellule `SimpleDeepProbLog`) avec la **fermeture transitive** de `parent` : le predicat `ancestor`. Deux regles suffisent -- un cas de base et une regle recursive -- et c'est le chainage arriere du moteur (avec sa limite `max_depth`) qui resout la recursion."
    ]
   },
   {
@@ -1489,20 +1491,125 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : ajoutez la regle ancestor transitive\n"
+      "=== Regle transitive ancestor (fermeture de parent) ===\n",
+      "  ancestor('Marie', 'Paul') = 0.8242\n",
+      "  ancestor('Pierre', 'Paul') = 0.9193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ancestor('Marie', 'Pierre') = 0.8966\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ancestor('Marie', 'Sophie') = 0.0316\n",
+      "  ancestor('Sophie', 'Paul') = 0.0739\n",
+      "\n",
+      "Lecture : ancestor est la FERMETURE TRANSITIVE de parent.\n",
+      "ancestor(Marie, Paul) = parent(Marie, Pierre) AND parent(Pierre, Paul)\n",
+      "                     = 0.8966 * 0.9193 = 0.8242  (chemin Marie -> Pierre -> Paul).\n",
+      "Les ancetres directs (Pierre->Paul, Marie->Pierre) valent ~0.9 (un seul saut).\n",
+      "Les paires sans chemin restent faibles (< 0.1) : Marie->Sophie = 0.03,\n",
+      "Sophie->Paul = 0.07. La fermeture ne cree rien, elle propage parent.\n",
+      "Le chainage arriere plonge jusqu a max_depth (anti-boucle sur la recursion).\n",
+      "\n",
+      "Exemple guide 3 OK : regle ancestor transitive ajoutee, fermeture verifiee.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 3 : Regle transitive ancestor\n",
-    "# TODO etudiant : ajoutez les regles ancestor au systeme dpl\n",
+    "# Exemple guide 3 : Regle transitive ancestor dans DeepProbLog\n",
+    "# Resolution de l'Exercice 3 (See #2161) : solution demontree ci-dessous.\n",
+    "#\n",
+    "# On etend le systeme dpl avec la fermeture transitive de parent : ancestor.\n",
+    "# Deux regles suffisent :\n",
+    "#   (base)       ancestor(X,Y) :- parent(X,Y)            # un parent est un ancetre\n",
+    "#   (transitive) ancestor(X,Z) :- parent(X,Y), ancestor(Y,Z)   # on remonte d'un cran\n",
+    "# La limite max_depth du chainage arriere evite les boucles infinies sur la recursion.\n",
     "\n",
-    "# Indice : ajoutez 2 regles :\n",
-    "#   1. parent(X,Y) => ancestor(X,Y)\n",
-    "#   2. parent(X,Y) AND ancestor(Y,Z) => ancestor(X,Z)\n",
-    "# Attention a la limite de profondeur pour eviter les boucles infinies\n",
+    "# Etape 1 : regle de base -- un parent est un ancetre (cas d'arret).\n",
+    "dpl.add_rule([('parent', ('X', 'Y'))], ('ancestor', ('X', 'Y')))\n",
     "\n",
-    "print('Exercice a completer : ajoutez la regle ancestor transitive')"
+    "# Etape 2 : regle transitive -- on remonte d'un niveau, puis on continue.\n",
+    "dpl.add_rule([('parent', ('X', 'Y')), ('ancestor', ('Y', 'Z'))],\n",
+    "             ('ancestor', ('X', 'Z')))\n",
+    "\n",
+    "# Etape 3 : on interroge la fermeture transitive.\n",
+    "print('=== Regle transitive ancestor (fermeture de parent) ===')\n",
+    "requetes = [\n",
+    "    ('ancestor', ('Marie', 'Paul')),    # Marie -> Pierre -> Paul : VRAI ancetre (2 sauts)\n",
+    "    ('ancestor', ('Pierre', 'Paul')),   # Pierre -> Paul : VRAI (direct)\n",
+    "    ('ancestor', ('Marie', 'Pierre')),  # Marie -> Pierre : VRAI (direct)\n",
+    "    ('ancestor', ('Marie', 'Sophie')),  # aucun chemin Marie ..-> Sophie\n",
+    "    ('ancestor', ('Sophie', 'Paul')),   # Sophie -> Luc : pas de lien vers Paul\n",
+    "]\n",
+    "for pred, args in requetes:\n",
+    "    prob = dpl.query(pred, args)\n",
+    "    print(f'  {pred}{args} = {prob:.4f}')\n",
+    "\n",
+    "print()\n",
+    "print('Lecture : ancestor est la FERMETURE TRANSITIVE de parent.')\n",
+    "print('ancestor(Marie, Paul) = parent(Marie, Pierre) AND parent(Pierre, Paul)')\n",
+    "print('                     = 0.8966 * 0.9193 = 0.8242  (chemin Marie -> Pierre -> Paul).')\n",
+    "print('Les ancetres directs (Pierre->Paul, Marie->Pierre) valent ~0.9 (un seul saut).')\n",
+    "print('Les paires sans chemin restent faibles (< 0.1) : Marie->Sophie = 0.03,')\n",
+    "print('Sophie->Paul = 0.07. La fermeture ne cree rien, elle propage parent.')\n",
+    "print('Le chainage arriere plonge jusqu a max_depth (anti-boucle sur la recursion).')\n",
+    "print()\n",
+    "print('Exemple guide 3 OK : regle ancestor transitive ajoutee, fermeture verifiee.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl5-ex3-var-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 (variation) : La limite de profondeur compte\n",
+    "\n",
+    "La regle `ancestor` est **recursive** : `ancestor(X,Z) :- parent(X,Y), ancestor(Y,Z)`. Le chainage arriere du moteur s'arrete a `max_depth`.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Pour `depth` dans `[0, 1, 2, 3, 5]`, calculez `dpl.query('ancestor', ('Marie', 'Paul'), max_depth=depth)`.\n",
+    "2. A partir de quelle profondeur la **fermeture transitive** (valeur ~0.82) apparait-elle ?\n",
+    "3. Que donne `max_depth=0` ? Que donne `max_depth=1` (pourquoi seulement ~0.07, c'est-a-dire le fait direct `parent(Marie, Paul)`, sans la transitivite) ?\n",
+    "\n",
+    "**Indice** : la requete est emise a `depth=0` et plonge d'un niveau a chaque litteral du corps (`depth+1`). Le chemin `Marie -> Pierre -> Paul` demande 2 plongees ; en dessous de `max_depth=2`, la recursion est coupee avant d'atteindre le fait neural. C'est le compromis expressivite vs terminaison du chainage arriere."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "sl5-ex3-var-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : impact de max_depth sur ancestor\n",
+      "Question : a partir de quelle profondeur la transitivite (Marie -> Paul) se revele ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (variation) : La limite de profondeur compte\n",
+    "# TODO etudiant : mesurez ancestor(Marie, Paul) selon max_depth.\n",
+    "\n",
+    "# Etape 1 : pour depth in [0, 1, 2, 3, 5], interroger :\n",
+    "#   prob = dpl.query('ancestor', ('Marie', 'Paul'), max_depth=depth)\n",
+    "\n",
+    "# Etape 2 : a partir de quelle depth la fermeture transitive (~0.82) apparait-elle ?\n",
+    "# Etape 3 : que donne max_depth=0 ? max_depth=1 (pourquoi seulement le fait direct) ?\n",
+    "print('Exercice a completer : impact de max_depth sur ancestor')\n",
+    "print('Question : a partir de quelle profondeur la transitivite (Marie -> Paul) se revele ?')\n",
+    "\n",
+    "# Indice : le chemin Marie->Paul = 2 plongees ; max_depth < 2 coupe avant le fait neural.\n",
+    "# result = None  # TODO etudiant : tableau depth -> prob"
    ]
   },
   {
@@ -1549,7 +1656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "e2b9c7aa",
    "metadata": {
     "execution": {
@@ -1636,7 +1743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "dee9a21b",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

See #2161 (SymbolicLearning exercises → Exemples guidés). Resolves **SL-5 Exercice 3** into a worked example following the proven SL-7/8/10 + Ex2 recipe (solve stub → "Exemple guide", keep `# Indice`/`# Etape`, add a C.1-clean variation exercise).

## Changes (1 file, +119/-12)

- **Ex3** (cell `b2483326`): stub → **Exemple guide 3**. Extends the `SimpleDeepProbLog` system (`dpl`) with the **transitive closure** of `parent` — the `ancestor` predicate — via two rules:
  - `(base) ancestor(X,Y) :- parent(X,Y)`
  - `(transitive) ancestor(X,Z) :- parent(X,Y), ancestor(Y,Z)`
  - The backward-chaining engine (max_depth gate) resolves the recursion and prevents infinite loops.
- **Variation** (new, after Ex3): "La limite de profondeur compte" — sweep `dpl.query('ancestor', ('Marie','Paul'), max_depth=depth)` to show that the transitive value appears only at `max_depth ≥ 2`. C.1-clean stub.
- **Ex4/Ex5**: `execution_count` bumped +1 (insertion hygiene; source + outputs unchanged).

## Proof of execution (kernel python3)

```
ancestor(Marie, Paul)   = 0.8242   [Marie -> Pierre -> Paul : fermeture a 2 sauts]
ancestor(Pierre, Paul)  = 0.9193   [direct : base rule = parent(Pierre, Paul)]
ancestor(Marie, Pierre) = 0.8966   [direct : base rule = parent(Marie, Pierre)]
ancestor(Marie, Sophie) = 0.0316   [aucun chemin : faible]
ancestor(Sophie, Paul)  = 0.0739   [aucun chemin : faible]
= parent(Marie, Pierre) * parent(Pierre, Paul) = 0.8966 * 0.9193
```

## Validation

- `nbformat.validate` OK. **C.1 = 0** (no `raise NotImplementedError`/`assert False`/`1/0`). **H.3 = 0** (no code cell with `execution_count=None` + no outputs).
- `execution_count` monotonic [1..14].
- **Scope**: only Ex3 (source+outputs), Ex3 markdown relabel, the 2 new variation cells, and Ex4/Ex5 exec_count bumps. Section-7 LTNtorch cell (`4b4e4ecb`) and **all** infra cells (numpy, fuzzy, `NeuralPredicate`, `parent_pred`, grandparent rule, `dpl` instance, Ex1, Ex2) are **byte-identical to origin/main** (source + outputs + execution_count verified).

## Env note (rule F)

SL-5 section 7 uses **LTNtorch** (torch-based `ltn`). Section 7 hits a CUDA device-mismatch on this box (`cuda.is_available()=True` but mixed device tensors; `CUDA_VISIBLE_DEVICES=''` does not disable CUDA here) — a **pre-existing GPU/device cell unrelated to Ex3** (pure-numpy). Per the rule-F GPU exception, Ex3 was re-executed via its pure-numpy dependency chain (cells 2,5,8,11,14,17) and section 7 left with its valid origin/main outputs. Flagged to ai-01 (same class as the swi-prolog gap on SL-4/SL-9).

Co-Authored-By: Claude <noreply@anthropic.com>
