### PR TITLE
feat(sl-6): resolve Exercice 1 (uncleOf relation) into guided example + variation

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
@@ -2110,15 +2110,11 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Ajouter une nouvelle relation au KG\n",
+    "### Exemple guide 1 : Ajouter une nouvelle relation au KG\n",
     "\n",
-    "Ajoutez une relation `uncleOf` (oncle) au Knowledge Graph familial. Un oncle de X est le frere du parent de X. Definissez quelques triples `uncleOf` manuellement, puis executez le rule mining pour voir si l'algorithme decouvre la regle `siblingOf(A,B) ^ parentOf(B,C) => uncleOf(A,C)`.\n",
+    "> **Bascule TP -> Exemple guide** (See #2161). Solution demontree ci-dessous.\n",
     "\n",
-    "**Etapes** :\n",
-    "1. Ajouter 3-4 triples `uncleOf` manuellement dans le graphe `g`\n",
-    "2. Re-extraire les relations\n",
-    "3. Relancer le rule mining\n",
-    "4. Verifier si la regle `siblingOf ^ parentOf => uncleOf` est decouverte"
+    "On ajoute la relation `uncleOf` (oncle/tante) au Knowledge Graph, puis on relance le rule mining pour voir si l'algorithme **rediscover** la regle definissante `siblingOf(A,B) ^ parentOf(B,C) => uncleOf(A,C)` (A est frere/soeur de B, B est parent de C, donc A est oncle/tante de C)."
    ]
   },
   {
@@ -2146,34 +2142,135 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : ajoutez des triples uncleOf et testez le rule mining\n"
+      "Etape 1 : 10 triples uncleOf ajoutes au graphe.\n",
+      "Etape 2 : 5 relations dont uncleOf (10 paires).\n",
+      "\n",
+      "Etape 3-4 : 2 regle(s) uncleOf decouverte(s) :\n",
+      "  siblingOf ^ parentOf => uncleOf   [supp=10, body=10, conf=1.00, pca=1.00]\n",
+      "  uncleOf ^ siblingOf => uncleOf   [supp=10, body=10, conf=1.00, pca=1.00]\n",
+      "\n",
+      "Extension siblingOf(A,B) ^ parentOf(B,C) : 10 paires.\n",
+      "uncleOf couvre 10/10 de ces paires -> la regle definissante remonte a conf=1.00 (un axiome).\n",
+      "\n",
+      "Lecture : le mineur rediscover BIEN la regle definissante siblingOf ^ parentOf => uncleOf\n",
+      "avec confidence 1.00 (relation completee exhaustivement -> axiome). Il\n",
+      "remonte aussi une regle REDONDANTE uncleOf ^ siblingOf => uncleOf (le\n",
+      "sibling dun oncle est aussi oncle) : meme extension, syntaxe differente.\n",
+      "AMIE evite ce doublon en n enumerant que des regles FERMEES (closed rules).\n",
+      "\n",
+      "Exemple guide 1 OK : uncleOf ajoute, regle definissante rediscover a conf 1.00.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 : Ajouter uncleOf et tester le rule mining\n",
-    "# TODO etudiant : ajouter quelques triples uncleOf au graphe\n",
-    "# Indice : un oncle est le frere d'un parent\n",
-    "# Exemple : Jean a pour frere Claire (siblingOf), Claire est parent de Paul\n",
-    "#           donc Jean est oncle de Marc, Lea, Hugo, Julie\n",
+    "# Exemple guide 1 : Ajouter uncleOf et rediscover sa regle par le rule mining\n",
+    "# Resolution de l'Exercice 1 (See #2161) : solution demontree ci-dessous.\n",
+    "#\n",
+    "# uncleOf(A, C) :- siblingOf(A, B), parentOf(B, C).\n",
+    "# A est oncle/tante de C si A est frere/soeur d'un parent B de C.\n",
+    "# On enrichit le graphe `g` (deja complete par apply_rules en section 7) avec\n",
+    "# les triples uncleOf pour les paires bien definies, puis on relance le minage.\n",
     "\n",
-    "# Etape 1 : ajouter 3-4 triples uncleOf\n",
-    "# g.add((person(\"Jean\"), FAM.uncleOf, person(\"Marc\")))\n",
-    "# g.add((person(\"Jean\"), FAM.uncleOf, person(\"Lea\")))\n",
-    "# ...\n",
+    "# Etape 1 : ajout des triples uncleOf. On couvre les paires (A,C) telles que\n",
+    "# A est sibling d'un parent de C -- c'est l'extension exacte de la regle.\n",
+    "uncle_triples = [\n",
+    "    (\"Jean\", \"Paul\"), (\"Jean\", \"Anne\"),        # Jean sib Claire, Claire parent Paul/Anne\n",
+    "    (\"Claire\", \"Luc\"), (\"Claire\", \"Sophie\"),   # Claire sib Jean, Jean parent Luc/Sophie\n",
+    "    (\"Luc\", \"Hugo\"), (\"Luc\", \"Julie\"),         # Luc sib Sophie, Sophie parent Hugo/Julie\n",
+    "    (\"Sophie\", \"Marc\"), (\"Sophie\", \"Lea\"),     # Sophie sib Luc, Luc parent Marc/Lea\n",
+    "    (\"Anne\", \"Thomas\"), (\"Anne\", \"Emma\"),      # Anne sib Paul, Paul parent Thomas/Emma\n",
+    "]\n",
+    "for uncle, nephew in uncle_triples:\n",
+    "    g.add((person(uncle), FAM.uncleOf, person(nephew)))\n",
+    "print(f\"Etape 1 : {len(uncle_triples)} triples uncleOf ajoutes au graphe.\")\n",
     "\n",
-    "# Etape 2 : re-extraire les relations\n",
-    "# relations_ex1 = extract_relations(g)\n",
+    "# Etape 2 : re-extraction des relations (inclut maintenant uncleOf).\n",
+    "relations_ex1 = extract_relations(g)\n",
+    "print(f\"Etape 2 : {len(relations_ex1)} relations dont \"\n",
+    "      f\"uncleOf ({len(relations_ex1['uncleOf'])} paires).\")\n",
     "\n",
-    "# Etape 3 : relancer le rule mining\n",
-    "# rules_ex1 = mine_rules(relations_ex1, all_entities, min_support=1, min_confidence=0.3)\n",
+    "# Etape 3 : relance du rule mining sur le graphe enrichi.\n",
+    "rules_ex1 = mine_rules(relations_ex1, all_entities, min_support=1, min_confidence=0.3)\n",
+    "uncle_rules = [r for r in rules_ex1 if r[\"head\"] == \"uncleOf\"]\n",
     "\n",
-    "# Etape 4 : chercher la regle uncleOf\n",
-    "# uncle_rules = [r for r in rules_ex1 if r[\"head\"] == \"uncleOf\"]\n",
-    "# for r in uncle_rules:\n",
-    "#     print(r)\n",
+    "# Etape 4 : verdict -- la regle definissante est-elle decouverte ?\n",
+    "print(f\"\\nEtape 3-4 : {len(uncle_rules)} regle(s) uncleOf decouverte(s) :\")\n",
+    "for r in uncle_rules:\n",
+    "    body = \" ^ \".join(r[\"body\"])\n",
+    "    print(f\"  {body} => uncleOf   \"\n",
+    "          f\"[supp={r['support']}, body={r['body_size']}, \"\n",
+    "          f\"conf={r['confidence']:.2f}, pca={r['pca_confidence']:.2f}]\")\n",
     "\n",
-    "print(\"Exercice a completer : ajoutez des triples uncleOf et testez le rule mining\")"
+    "# Comparaison avec l'extension reelle de la regle.\n",
+    "body_pairs = compute_body_pairs(relations_ex1[\"siblingOf\"], relations_ex1[\"parentOf\"])\n",
+    "print(f\"\\nExtension siblingOf(A,B) ^ parentOf(B,C) : {len(body_pairs)} paires.\")\n",
+    "print(f\"uncleOf couvre {len(relations_ex1['uncleOf'] & body_pairs)}/{len(body_pairs)} \"\n",
+    "      f\"de ces paires -> la regle definissante remonte a conf=1.00 (un axiome).\")\n",
+    "\n",
+    "print()\n",
+    "print('Lecture : le mineur rediscover BIEN la regle definissante '\n",
+    "      'siblingOf ^ parentOf => uncleOf')\n",
+    "print('avec confidence 1.00 (relation completee exhaustivement -> axiome). Il')\n",
+    "print('remonte aussi une regle REDONDANTE uncleOf ^ siblingOf => uncleOf (le')\n",
+    "print('sibling dun oncle est aussi oncle) : meme extension, syntaxe differente.')\n",
+    "print('AMIE evite ce doublon en n enumerant que des regles FERMEES (closed rules).')\n",
+    "print()\n",
+    "print('Exemple guide 1 OK : uncleOf ajoute, regle definissante rediscover a conf 1.00.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl6-ex1-var-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 (variation) : Cousinage et la limite du mineur a 2 atomes\n",
+    "\n",
+    "Ajoutez maintenant quelques triples `cousinOf` (cousins : enfants de freres/soeurs). La regle definissante est `parentOf(A,B) ^ siblingOf(B,D) ^ parentOf(D,C) => cousinOf(A,C)` -- un **corps a 3 atomes**.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Ajouter 2-3 triples `cousinOf` (ex. Luc et Paul sont cousins : enfants de Jean et Claire qui sont siblings).\n",
+    "2. Re-extraire et relancer le rule mining.\n",
+    "3. La regle `cousinOf` est-elle decouverte ? Pourquoi le mineur a 2 atomes ne peut-il PAS l'exprimer ?\n",
+    "\n",
+    "**Indice** : notre `mine_rules` n'enumere que des corps de 1 ou 2 atomes. Le cousinage demande d'enchainer 3 relations (parent, sibling, parent) -- inaccessible a ce mineur. C'est precisement ce que l'Exercice 3 (regles a 3 atomes) viendra lever, et ce qu'AMIE controle par son parametre de longueur maximale de corps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "sl6-ex1-var-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : ajoutez cousinOf et constatez labsence de regle decouverte\n",
+      "Question : pourquoi le mineur a 2 atomes ne peut-il pas exprimer le cousinage ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (variation) : Cousinage et la limite du mineur a 2 atomes\n",
+    "# TODO etudiant : ajoutez cousinOf et constatez que le mineur a 2 atomes\n",
+    "# ne PEUT PAS rediscover sa regle (corps a 3 atomes).\n",
+    "\n",
+    "# Etape 1 : ajouter 2-3 triples cousinOf\n",
+    "# g.add((person('Luc'), FAM.cousinOf, person('Paul')))   # Luc enfant de Jean,\n",
+    "#                                                          Paul enfant de Claire,\n",
+    "#                                                          Jean sib Claire\n",
+    "\n",
+    "# Etape 2 : re-extraire et relancer mine_rules\n",
+    "# relations_c = extract_relations(g)\n",
+    "# rules_c = mine_rules(relations_c, all_entities, min_support=1, min_confidence=0.3)\n",
+    "# cousin_rules = [r for r in rules_c if r['head'] == 'cousinOf']\n",
+    "\n",
+    "# Etape 3 : cousin_rules est vide -- pourquoi ? (corps a 3 atomes non enumerate)\n",
+    "print('Exercice a completer : ajoutez cousinOf et constatez labsence de regle decouverte')\n",
+    "print('Question : pourquoi le mineur a 2 atomes ne peut-il pas exprimer le cousinage ?')\n",
+    "\n",
+    "# Indice : cousinOf demande parent ^ sibling ^ parent (3 atomes). Voir Exercice 3.\n",
+    "# result = None  # TODO etudiant : nombre de regles cousinOf decouvertes (attendu : 0)"
    ]
   },
   {
@@ -2206,7 +2303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "89b763a7",
    "metadata": {
     "execution": {
@@ -2308,7 +2405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "d20502d5",
    "metadata": {
     "execution": {
@@ -2391,7 +2488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "e85c35a4",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

See #2161 (SymbolicLearning exercises → Exemples guidés). Resolves **SL-6 Exercice 1** into a worked example following the proven SL-7/8/10 + SL-5 recipe (solve stub → "Exemple guide", keep `# Indice`/`# Etape`, add a C.1-clean variation exercise).

> **Branch is off `main`** (different notebook from the SL-5 PRs #3206/#3207 — no collision). SL-6 is fully re-executable on this box (rdflib + clingo both present, no SL-5-style §7 GPU gap).

## Changes (1 file, +127/-30)

- **Ex1** (cell `409ababa`): stub → **Exemple guide 1**. Adds the `uncleOf` relation to the family KG (10 triples covering `uncleOf(A,C) :- siblingOf(A,B), parentOf(B,C)`), re-extracts, re-runs `mine_rules`. The miner **rediscovers** the defining rule with confidence 1.00.
- **Variation** (new, after Ex1): "Cousinage et la limite du mineur à 2 atomes" — add `cousinOf`; its defining rule has a **3-atom body** (`parent ^ sibling ^ parent`) the 2-atom miner cannot express → 0 rules discovered; previews Ex3. C.1-clean stub.
- **Ex2/Ex3/Ex4**: `execution_count` bumped +1 (insertion hygiene; source + outputs unchanged).

## Proof of execution (kernel python3)

```
10 triples uncleOf ajoutés.
2 règles uncleOf découvertes :
  siblingOf ^ parentOf => uncleOf   [supp=10, body=10, conf=1.00, pca=1.00]
  uncleOf ^ siblingOf => uncleOf    [supp=10, body=10, conf=1.00, pca=1.00]
```

The second rule is **redundant** (sibling of an uncle is also an uncle: same extension, different syntax) — exactly the Ex1 presentation-twist topic (how AMIE avoids enumerating duplicates via closed rules).

## Validation

- `nbformat.validate` OK. **C.1 = 0** (no `raise NotImplementedError`/`assert False`/`1/0`). **H.3 = 0** (no code cell with `execution_count=None` + no outputs).
- `execution_count` monotonic [1..19].
- **Scope**: only Ex1 (source+outputs), Ex1 markdown relabel, the 2 new variation cells, and Ex2/Ex3/Ex4 exec_count bumps. **All infra cells** (KG build, `extract_relations`, `compute_body_pairs`, `evaluate_rule`, `mine_rules`, `apply_rules`, the clingo ASP cells) are **byte-identical to origin/main** (source + outputs + execution_count).

Co-Authored-By: Claude <noreply@anthropic.com>
