### PR TITLE
feat(sl): SL-1 Ex2 -> Exemple guide 2 (Version Space: convergence + collapse)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -2256,9 +2256,9 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Version Space sur un sous-ensemble\n",
+    "### Exemple guide 2 : Version Space sur un sous-ensemble\n",
     "\n",
-    "Executez le Candidate Elimination sur les 6 premiers exemples seulement et observez la taille du Version Space."
+    "L'intuition naive dit qu'avec **moins d'exemples**, le Version Space est plus grand (moins contraint). Verifions-le : lancons Candidate Elimination sur les 6 premiers exemples seulement, puis comparons au resultat sur les 12. La surprise -- que nous allons interpreter -- est que le Version Space ne fait pas que retroceder : il peut **converger** (G == S) puis s'**effondrer** (G et S vides)."
    ]
   },
   {
@@ -2286,30 +2286,125 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : appelez candidate_elimination(EXAMPLES[:6])\n"
+      "Candidate Elimination sur EXAMPLES[:6] (6 exemples) :\n",
+      "  |G-set| = 1    |S-set| = 1\n",
+      "  G : ('?', '?', '?', 'Yes', '?', '?', '?', '?', '?', '?')\n",
+      "  S : ('?', '?', '?', 'Yes', '?', '?', '?', '?', '?', '?')\n",
+      "\n",
+      "G == S ? True\n",
+      "=> Le Version Space s'est reduit a une hypothese unique : Alt = Yes.\n",
+      "\n",
+      "Sur les 12 exemples : |G| = 0, |S| = 0\n",
+      "=> Le Version Space est VIDE : aucune conjonction n'est coherente avec les 12 exemples.\n",
+      "\n",
+      "Convergence du Version Space selon le nombre d'exemples k :\n",
+      "  k  | |G| | |S| | etat\n",
+      " ------------------------------------------\n",
+      "  1 |   1 |   1 | borne G=1, S=1\n",
+      "  2 |   1 |   1 | borne G=1, S=1\n",
+      "  3 |   3 |   1 | borne G=3, S=1\n",
+      "  4 |   3 |   1 | borne G=3, S=1\n",
+      "  5 |   1 |   1 | borne G=1, S=1\n",
+      "  6 |   1 |   1 | converge (G == S)\n",
+      "  7 |   1 |   1 | converge (G == S)\n",
+      "  8 |   1 |   1 | converge (G == S)\n",
+      "  9 |   1 |   1 | converge (G == S)\n",
+      " 10 |   0 |   0 | VIDE (effondrement)\n",
+      " 11 |   0 |   0 | VIDE (effondrement)\n",
+      " 12 |   0 |   0 | VIDE (effondrement)\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : Version Space sur un sous-ensemble\n",
-    "# TODO etudiant : Executez candidate_elimination sur EXAMPLES[:6]\n",
-    "# Etape 1 : Executer sur les 6 premiers exemples\n",
-    "result = None  # TODO etudiant : remplacer par l'appel a candidate_elimination(EXAMPLES[:6])\n",
+    "# Exemple guide 2 : Version Space sur un sous-ensemble\n",
+    "# On lance Candidate Elimination sur les 6 premiers exemples, puis on compare\n",
+    "# au resultat sur les 12 exemples (section precedente).\n",
+    "G_sub, S_sub, trace_sub = candidate_elimination(EXAMPLES[:6])\n",
     "\n",
-    "# Etape 2 : Afficher les resultats\n",
-    "if result is not None:\n",
-    "    G_sub, S_sub, trace_sub = result\n",
-    "    print(f\"G-set ({len(G_sub)} hypotheses) :\")\n",
-    "    for g in sorted(G_sub):\n",
-    "        print(f\"  {g}\")\n",
-    "    print(f\"\\nS-set ({len(S_sub)} hypotheses) :\")\n",
-    "    for s in sorted(S_sub):\n",
-    "        print(f\"  {s}\")\n",
+    "print(\"Candidate Elimination sur EXAMPLES[:6] (6 exemples) :\")\n",
+    "print(f\"  |G-set| = {len(G_sub)}    |S-set| = {len(S_sub)}\")\n",
+    "for g in sorted(G_sub):\n",
+    "    print(f\"  G : {g}\")\n",
+    "for s in sorted(S_sub):\n",
+    "    print(f\"  S : {s}\")\n",
+    "\n",
+    "# Les deux bornes ont converge vers la MEME hypothese.\n",
+    "print(f\"\\nG == S ? {sorted(G_sub) == sorted(S_sub)}\")\n",
+    "print(\"=> Le Version Space s'est reduit a une hypothese unique : Alt = Yes.\")\n",
+    "\n",
+    "# Comparaison avec les 12 exemples (section 5).\n",
+    "G_full, S_full, _ = candidate_elimination(EXAMPLES)\n",
+    "print(f\"\\nSur les 12 exemples : |G| = {len(G_full)}, |S| = {len(S_full)}\")\n",
+    "if len(G_full) == 0:\n",
+    "    print(\"=> Le Version Space est VIDE : aucune conjonction n'est coherente avec les 12 exemples.\")\n",
+    "\n",
+    "# Tableau de convergence : |G| et |S| selon le nombre d'exemples k.\n",
+    "print(\"\\nConvergence du Version Space selon le nombre d'exemples k :\")\n",
+    "print(\"  k  | |G| | |S| | etat\")\n",
+    "print(\" \" + \"-\" * 42)\n",
+    "for k in range(1, len(EXAMPLES) + 1):\n",
+    "    Gk, Sk, _ = candidate_elimination(EXAMPLES[:k])\n",
+    "    if len(Gk) == 0:\n",
+    "        etat = \"VIDE (effondrement)\"\n",
+    "    elif sorted(Gk) == sorted(Sk):\n",
+    "        etat = \"converge (G == S)\"\n",
+    "    else:\n",
+    "        etat = f\"borne G={len(Gk)}, S={len(Sk)}\"\n",
+    "    print(f\" {k:2d} |   {len(Gk)} |   {len(Sk)} | {etat}\")\n",
+    "# Indice : le Version Space converge DES k=6 (G == S = Alt=Yes), puis\n",
+    "# s'effondre au 10e exemple (k=10). Le concept WillWait n'est PAS\n",
+    "# representable par une seule conjonction : meme limite d'expression que\n",
+    "# CBH (Ex1), mais Version Space la revele comme |G| = |S| = 0 (VS vide)."
+   ]
+  },
+  {
+   "id": "sl1-ex2-variation-md",
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 (variation) : Le Version Space depend-il de l'ordre des exemples ?\n",
+    "\n",
+    "Current-Best-Hypothesis (Exercice 1) produit une hypothese unique qui peut **dependre de l'ordre** des exemples. Le Version Space, lui, conserve **toutes** les hypotheses coherentes. L'ensemble final est-il invariant quand on reordonnance les exemples ? Fixez une graine, melangez une **copie** de `EXAMPLES`, relancez `candidate_elimination` sur les 12 exemples melanges, et comparez la taille finale du Version Space au resultat en ordre original.\n",
+    "\n",
+    "**Indices** :\n",
+    "1. `random.seed(42)` puis copiez `EXAMPLES` et `random.shuffle` la copie (ne mutez pas l'original).\n",
+    "2. Appelez `candidate_elimination(shuffled)` et lisez `|G|` final.\n",
+    "3. Refaites avec 2 autres graines. Que constatez-vous sur `|G|` final ?\n",
+    "4. Conclusion : l'ensemble des hypotheses coherentes est une propriete du **jeu de donnees** (intersection d'ensembles), pas de l'ordre de parcours -- contrairement a CBH."
+   ]
+  },
+  {
+   "id": "sl1-ex2-variation-stub",
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 16,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : melangez EXAMPLES puis appelez candidate_elimination\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (variation) : Le Version Space depend-il de l'ordre des exemples ?\n",
+    "# TODO etudiant : melanger EXAMPLES (sur une COPIE), relancer candidate_elimination, comparer |G| final\n",
+    "import random\n",
+    "# Etape 1 : fixer une graine et melanger UNE COPIE de EXAMPLES\n",
+    "random.seed(42)\n",
+    "shuffled = None  # TODO etudiant : copier EXAMPLES puis random.shuffle la copie\n",
+    "# Etape 2 : executer Candidate Elimination sur la liste melangee\n",
+    "result_shuffled = None  # TODO etudiant : remplacer par candidate_elimination(shuffled)\n",
+    "# Etape 3 : afficher |G| final et conclure sur l'invariance par ordre\n",
+    "if result_shuffled is not None:\n",
+    "    G_sh, S_sh, _ = result_shuffled\n",
+    "    print(f\"Version Space sur exemples melanges : |G| = {len(G_sh)}, |S| = {len(S_sh)}\")\n",
     "else:\n",
-    "    print(\"Exercice a completer : appelez candidate_elimination(EXAMPLES[:6])\")\n",
-    "\n",
-    "# Indice : Comparez |G| et |S| avec le resultat sur les 12 exemples.\n",
-    "# Le Version Space est-il plus grand ou plus petit avec moins d'exemples ?"
+    "    print(\"Exercice a completer : melangez EXAMPLES puis appelez candidate_elimination\")\n",
+    "# Indice : l'ensemble des hypotheses coherentes avec un jeu de donnees est une\n",
+    "# propriete du JEU de donnees (intersection d'ensembles), pas de l'ordre.\n",
+    "# Comparez au comportement order-dependant de CBH (Ex1)."
    ]
   },
   {
@@ -2335,7 +2430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "a66db8dd23f7",
    "metadata": {
     "execution": {
@@ -2443,7 +2538,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "ef84c058",
    "metadata": {
     "execution": {


### PR DESCRIPTION
Resolve **SL-1 Exercice 2** (Version Space sur un sous-ensemble) into a worked **Exemple guide 2** and add a variation exercise. See #2161 (SymbolicLearning exercise resolution, partition po-2025).

## What changed

- **Cell 41 (md)**: relabel `Exercice 2` -> `Exemple guide 2` + prose reframed around the *executed* finding.
- **Cell 42 (code)**: stub -> worked solution. Runs `candidate_elimination(EXAMPLES[:6])`, compares to the full 12-example result, and prints a convergence table (`|G|`,`|S|` for k=1..12).
- **New cells (md + stub)**: variation exercise "Le Version Space depend-il de l'ordre des exemples ?" (order-invariance vs CBH order-dependence).

## Honest finding (executed, not assumed)

The exercise enonce invited the naive answer "fewer examples -> larger version space". The **real execution** is richer:

| Subset | |G| | |S| | State |
|--------|-----|-----|-------|
| `EXAMPLES[:6]` | 1 | 1 | **converged** (G == S = `('?','?','?','Yes',...)`) |
| `EXAMPLES` (12) | 0 | 0 | **empty** (collapse at k=10) |

The version space converges to a single hypothesis (Alt=Yes) by k=6, then **collapses to empty** at the 10th example. Conclusion: the WillWait concept is **not representable as a single conjunction** -- the same expressiveness limit CBH hit in Ex1 (PR #3201), now revealed by Candidate Elimination as `|G| = |S| = 0` (empty VS) rather than as a backtrack. Per `feedback-guided-example-narrative-after-exec`: narrative written on the real result, not the enonce's intuition.

The variation contrasts VS **order-invariance** (3 shuffles all collapse to `|G|=0`, verified) with CBH **order-dependence** -- foreshadowed by cell 45's synthesis table.

## Validation (regle H)

- Papermill end-to-end (kernel `python3`): **18 code cells, 0 errors**.
- C.1: 0 `raise NotImplementedError` / `assert False` / `1/0`.
- C.2: outputs committed (worked cell `ec=15`, variation stub `ec=16`).
- Surgical inject: only changed cells got fresh outputs; unchanged cells byte-identical (verified `covers` cell unchanged, 0 timestamp churn).
- Diff: `+118 / -23` on a single notebook (no catalog, no collateral).
- Scope C.3: only the notebook I modified is staged.

Atomic, single-subject. SL-1 Ex3 / Ex5 follow as separate serialized PRs (same .ipynb -> serialize per ai-01 dispatch).