### PR TITLE
fix(lean13): robust WSL subprocess capture for run_lean + Yoneda exercise (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13-Grothendieck-Tribute.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13-Grothendieck-Tribute.ipynb
@@ -5,10 +5,10 @@
    "id": "lean13-title",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-12T09:27:59.085893",
+     "duration": 0.005984,
+     "end_time": "2026-06-17T06:06:32.388874",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.085893",
+     "start_time": "2026-06-17T06:06:32.382890",
      "status": "completed"
     },
     "tags": []
@@ -30,10 +30,10 @@
    "id": "lean13-intro-bio",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-12T09:27:59.085893",
+     "duration": 0.003103,
+     "end_time": "2026-06-17T06:06:32.394977",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.085893",
+     "start_time": "2026-06-17T06:06:32.391874",
      "status": "completed"
     },
     "tags": []
@@ -72,10 +72,10 @@
    "id": "d9fcc71c",
    "metadata": {
     "papermill": {
-     "duration": 0.000694,
-     "end_time": "2026-06-12T09:27:59.103375",
+     "duration": 0.002897,
+     "end_time": "2026-06-17T06:06:32.400874",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.102681",
+     "start_time": "2026-06-17T06:06:32.397977",
      "status": "completed"
     },
     "tags": []
@@ -127,16 +127,16 @@
    "id": "lean13-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:27:59.109814Z",
-     "iopub.status.busy": "2026-06-12T09:27:59.109814Z",
-     "iopub.status.idle": "2026-06-12T09:27:59.129984Z",
-     "shell.execute_reply": "2026-06-12T09:27:59.129984Z"
+     "iopub.execute_input": "2026-06-17T06:06:32.407120Z",
+     "iopub.status.busy": "2026-06-17T06:06:32.407120Z",
+     "iopub.status.idle": "2026-06-17T06:06:32.426661Z",
+     "shell.execute_reply": "2026-06-17T06:06:32.426661Z"
     },
     "papermill": {
-     "duration": 0.023302,
-     "end_time": "2026-06-12T09:27:59.131109",
+     "duration": 0.024693,
+     "end_time": "2026-06-17T06:06:32.427667",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.107807",
+     "start_time": "2026-06-17T06:06:32.402974",
      "status": "completed"
     },
     "tags": []
@@ -146,7 +146,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Setup OK : grothendieck_lean project trouve a C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\grothendieck_lean\n",
+      "Setup OK : grothendieck_lean project trouve a C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\grothendieck_lean\n",
       "  Execution Lean : WSL lake env lean\n",
       "  23 modules Grothendieck detectes\n"
      ]
@@ -205,15 +205,35 @@
     "USE_NATIVE_LEAN = shutil.which('lake') is not None and os.name != 'nt'\n",
     "\n",
     "def wsl(cmd, timeout=60):\n",
-    "    \"\"\"Run a bash command inside WSL Ubuntu when available.\"\"\"\n",
+    "    \"\"\"Run a bash command inside WSL Ubuntu when available.\n",
+    "\n",
+    "    Captures stdout/stderr via temp files rather than capture_output=True, to\n",
+    "    avoid the CPython ``_readerthread`` race on Windows that silently dropped\n",
+    "    subprocess output (the committed cells 25-27 previously showed only an\n",
+    "    ``Exception in thread (_readerthread)`` trace instead of Lean output).\n",
+    "    \"\"\"\n",
     "    full = ['wsl', '-d', 'Ubuntu', '--', 'bash', '-lc', cmd]\n",
+    "    out_f = tempfile.NamedTemporaryFile('wb', delete=False, suffix='.out')\n",
+    "    err_f = tempfile.NamedTemporaryFile('wb', delete=False, suffix='.err')\n",
+    "    out_path, err_path = out_f.name, err_f.name\n",
+    "    out_f.close()\n",
+    "    err_f.close()\n",
     "    try:\n",
-    "        r = subprocess.run(full, capture_output=True, text=True, timeout=timeout)\n",
-    "        return r.returncode, r.stdout, r.stderr\n",
+    "        with open(out_path, 'wb') as o, open(err_path, 'wb') as e:\n",
+    "            r = subprocess.run(full, stdout=o, stderr=e, timeout=timeout)\n",
+    "        out = Path(out_path).read_text(encoding='utf-8', errors='replace')\n",
+    "        err = Path(err_path).read_text(encoding='utf-8', errors='replace')\n",
+    "        return r.returncode, out, err\n",
     "    except FileNotFoundError:\n",
     "        return 127, '', 'WSL executable not found'\n",
     "    except subprocess.TimeoutExpired:\n",
     "        return -1, '', f'TIMEOUT after {timeout}s'\n",
+    "    finally:\n",
+    "        for p in (out_path, err_path):\n",
+    "            try:\n",
+    "                Path(p).unlink()\n",
+    "            except OSError:\n",
+    "                pass\n",
     "\n",
     "# --- Lean file reading ---\n",
     "\n",
@@ -352,16 +372,16 @@
    "id": "087578d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:27:59.137048Z",
-     "iopub.status.busy": "2026-06-12T09:27:59.137048Z",
-     "iopub.status.idle": "2026-06-12T09:27:59.146468Z",
-     "shell.execute_reply": "2026-06-12T09:27:59.146468Z"
+     "iopub.execute_input": "2026-06-17T06:06:32.433673Z",
+     "iopub.status.busy": "2026-06-17T06:06:32.433673Z",
+     "iopub.status.idle": "2026-06-17T06:06:32.449332Z",
+     "shell.execute_reply": "2026-06-17T06:06:32.449332Z"
     },
     "papermill": {
-     "duration": 0.01349,
-     "end_time": "2026-06-12T09:27:59.147498",
+     "duration": 0.019665,
+     "end_time": "2026-06-17T06:06:32.450337",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.134008",
+     "start_time": "2026-06-17T06:06:32.430672",
      "status": "completed"
     },
     "tags": []
@@ -376,7 +396,7 @@
       "Total : 3182 lignes Lean\n",
       "\n",
       "Pour lancer le build complet (validation formelle) :\n",
-      "  wsl -d Ubuntu -- bash -lc \"cd /mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean && lake build Grothendieck\"\n",
+      "  wsl -d Ubuntu -- bash -lc \"cd /mnt/c/dev/CoursIA-2/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean && lake build Grothendieck\"\n",
       "\n",
       "Note : le contenu pedagogique du notebook (display_lean_module) fonctionne sans build.\n"
      ]
@@ -420,10 +440,10 @@
    "id": "lean13-section1",
    "metadata": {
     "papermill": {
-     "duration": 0.002099,
-     "end_time": "2026-06-12T09:27:59.152597",
+     "duration": 0.003001,
+     "end_time": "2026-06-17T06:06:32.455337",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.150498",
+     "start_time": "2026-06-17T06:06:32.452336",
      "status": "completed"
     },
     "tags": []
@@ -442,16 +462,16 @@
    "id": "lean13-check-functor-yoneda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:27:59.158604Z",
-     "iopub.status.busy": "2026-06-12T09:27:59.158604Z",
-     "iopub.status.idle": "2026-06-12T09:27:59.162311Z",
-     "shell.execute_reply": "2026-06-12T09:27:59.162311Z"
+     "iopub.execute_input": "2026-06-17T06:06:32.462337Z",
+     "iopub.status.busy": "2026-06-17T06:06:32.462337Z",
+     "iopub.status.idle": "2026-06-17T06:06:32.465152Z",
+     "shell.execute_reply": "2026-06-17T06:06:32.465152Z"
     },
     "papermill": {
-     "duration": 0.007689,
-     "end_time": "2026-06-12T09:27:59.163323",
+     "duration": 0.007805,
+     "end_time": "2026-06-17T06:06:32.466157",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.155634",
+     "start_time": "2026-06-17T06:06:32.458352",
      "status": "completed"
     },
     "tags": []
@@ -566,10 +586,10 @@
    "id": "lean13-interp-functor",
    "metadata": {
     "papermill": {
-     "duration": 0.001988,
-     "end_time": "2026-06-12T09:27:59.168322",
+     "duration": 0.002636,
+     "end_time": "2026-06-17T06:06:32.470793",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.166334",
+     "start_time": "2026-06-17T06:06:32.468157",
      "status": "completed"
     },
     "tags": []
@@ -590,10 +610,10 @@
    "id": "lean13-section2",
    "metadata": {
     "papermill": {
-     "duration": 0.003002,
-     "end_time": "2026-06-12T09:27:59.174611",
+     "duration": 0.0,
+     "end_time": "2026-06-17T06:06:32.472799",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.171609",
+     "start_time": "2026-06-17T06:06:32.472799",
      "status": "completed"
     },
     "tags": []
@@ -616,16 +636,16 @@
    "id": "lean13-check-sieves",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:27:59.178132Z",
-     "iopub.status.busy": "2026-06-12T09:27:59.178132Z",
-     "iopub.status.idle": "2026-06-12T09:27:59.184939Z",
-     "shell.execute_reply": "2026-06-12T09:27:59.184939Z"
+     "iopub.execute_input": "2026-06-17T06:06:32.472799Z",
+     "iopub.status.busy": "2026-06-17T06:06:32.472799Z",
+     "iopub.status.idle": "2026-06-17T06:06:32.486367Z",
+     "shell.execute_reply": "2026-06-17T06:06:32.486367Z"
     },
     "papermill": {
-     "duration": 0.006807,
-     "end_time": "2026-06-12T09:27:59.184939",
+     "duration": 0.013568,
+     "end_time": "2026-06-17T06:06:32.486367",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.178132",
+     "start_time": "2026-06-17T06:06:32.472799",
      "status": "completed"
     },
     "tags": []
@@ -691,10 +711,10 @@
    "id": "lean13-interp-sieves",
    "metadata": {
     "papermill": {
-     "duration": 0.005899,
-     "end_time": "2026-06-12T09:27:59.190838",
+     "duration": 0.00401,
+     "end_time": "2026-06-17T06:06:32.493090",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.184939",
+     "start_time": "2026-06-17T06:06:32.489080",
      "status": "completed"
     },
     "tags": []
@@ -718,10 +738,10 @@
    "id": "lean13-section3",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-12T09:27:59.193804",
+     "duration": 0.002005,
+     "end_time": "2026-06-17T06:06:32.497100",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.193804",
+     "start_time": "2026-06-17T06:06:32.495095",
      "status": "completed"
     },
     "tags": []
@@ -740,16 +760,16 @@
    "id": "lean13-check-sheaves",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:27:59.199663Z",
-     "iopub.status.busy": "2026-06-12T09:27:59.199663Z",
-     "iopub.status.idle": "2026-06-12T09:27:59.208251Z",
-     "shell.execute_reply": "2026-06-12T09:27:59.208251Z"
+     "iopub.execute_input": "2026-06-17T06:06:32.504120Z",
+     "iopub.status.busy": "2026-06-17T06:06:32.504120Z",
+     "iopub.status.idle": "2026-06-17T06:06:32.507866Z",
+     "shell.execute_reply": "2026-06-17T06:06:32.507866Z"
     },
     "papermill": {
-     "duration": 0.008588,
-     "end_time": "2026-06-12T09:27:59.208251",
+     "duration": 0.007757,
+     "end_time": "2026-06-17T06:06:32.507866",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.199663",
+     "start_time": "2026-06-17T06:06:32.500109",
      "status": "completed"
     },
     "tags": []
@@ -864,10 +884,10 @@
    "id": "lean13-interp-sheaves",
    "metadata": {
     "papermill": {
-     "duration": 0.002679,
-     "end_time": "2026-06-12T09:27:59.214441",
+     "duration": 0.004009,
+     "end_time": "2026-06-17T06:06:32.514327",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.211762",
+     "start_time": "2026-06-17T06:06:32.510318",
      "status": "completed"
     },
     "tags": []
@@ -887,10 +907,10 @@
    "id": "lean13-section4",
    "metadata": {
     "papermill": {
-     "duration": 0.003489,
-     "end_time": "2026-06-12T09:27:59.222152",
+     "duration": 0.0,
+     "end_time": "2026-06-17T06:06:32.516798",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.218663",
+     "start_time": "2026-06-17T06:06:32.516798",
      "status": "completed"
     },
     "tags": []
@@ -914,16 +934,16 @@
    "id": "lean13-check-scheme",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:27:59.230883Z",
-     "iopub.status.busy": "2026-06-12T09:27:59.230325Z",
-     "iopub.status.idle": "2026-06-12T09:27:59.234254Z",
-     "shell.execute_reply": "2026-06-12T09:27:59.233733Z"
+     "iopub.execute_input": "2026-06-17T06:06:32.525827Z",
+     "iopub.status.busy": "2026-06-17T06:06:32.525827Z",
+     "iopub.status.idle": "2026-06-17T06:06:32.529714Z",
+     "shell.execute_reply": "2026-06-17T06:06:32.529714Z"
     },
     "papermill": {
-     "duration": 0.009367,
-     "end_time": "2026-06-12T09:27:59.234782",
+     "duration": 0.006493,
+     "end_time": "2026-06-17T06:06:32.529714",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.225415",
+     "start_time": "2026-06-17T06:06:32.523221",
      "status": "completed"
     },
     "tags": []
@@ -1027,10 +1047,10 @@
    "id": "lean13-interp-scheme",
    "metadata": {
     "papermill": {
-     "duration": 0.003461,
-     "end_time": "2026-06-12T09:27:59.241479",
+     "duration": 0.002006,
+     "end_time": "2026-06-17T06:06:32.535730",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.238018",
+     "start_time": "2026-06-17T06:06:32.533724",
      "status": "completed"
     },
     "tags": []
@@ -1053,10 +1073,10 @@
    "id": "lean13-section5",
    "metadata": {
     "papermill": {
-     "duration": 0.003282,
-     "end_time": "2026-06-12T09:27:59.248535",
+     "duration": 0.006456,
+     "end_time": "2026-06-17T06:06:32.542186",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.245253",
+     "start_time": "2026-06-17T06:06:32.535730",
      "status": "completed"
     },
     "tags": []
@@ -1075,16 +1095,16 @@
    "id": "lean13-check-bigzariski",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:27:59.255953Z",
-     "iopub.status.busy": "2026-06-12T09:27:59.255953Z",
-     "iopub.status.idle": "2026-06-12T09:27:59.259511Z",
-     "shell.execute_reply": "2026-06-12T09:27:59.259511Z"
+     "iopub.execute_input": "2026-06-17T06:06:32.548346Z",
+     "iopub.status.busy": "2026-06-17T06:06:32.548346Z",
+     "iopub.status.idle": "2026-06-17T06:06:32.551613Z",
+     "shell.execute_reply": "2026-06-17T06:06:32.551613Z"
     },
     "papermill": {
-     "duration": 0.008168,
-     "end_time": "2026-06-12T09:27:59.259511",
+     "duration": 0.007422,
+     "end_time": "2026-06-17T06:06:32.551613",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.251343",
+     "start_time": "2026-06-17T06:06:32.544191",
      "status": "completed"
     },
     "tags": []
@@ -1193,10 +1213,10 @@
    "id": "lean13-interp-bigzariski",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-06-12T09:27:59.266916",
+     "duration": 0.0,
+     "end_time": "2026-06-17T06:06:32.551613",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.263915",
+     "start_time": "2026-06-17T06:06:32.551613",
      "status": "completed"
     },
     "tags": []
@@ -1222,10 +1242,10 @@
    "id": "lean13-section6",
    "metadata": {
     "papermill": {
-     "duration": 0.003186,
-     "end_time": "2026-06-12T09:27:59.273107",
+     "duration": 0.011882,
+     "end_time": "2026-06-17T06:06:32.563495",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.269921",
+     "start_time": "2026-06-17T06:06:32.551613",
      "status": "completed"
     },
     "tags": []
@@ -1244,16 +1264,16 @@
    "id": "lean13-check-morphisms",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:27:59.279898Z",
-     "iopub.status.busy": "2026-06-12T09:27:59.279898Z",
-     "iopub.status.idle": "2026-06-12T09:27:59.283217Z",
-     "shell.execute_reply": "2026-06-12T09:27:59.283217Z"
+     "iopub.execute_input": "2026-06-17T06:06:32.563495Z",
+     "iopub.status.busy": "2026-06-17T06:06:32.563495Z",
+     "iopub.status.idle": "2026-06-17T06:06:32.573595Z",
+     "shell.execute_reply": "2026-06-17T06:06:32.573595Z"
     },
     "papermill": {
-     "duration": 0.007985,
-     "end_time": "2026-06-12T09:27:59.284223",
+     "duration": 0.0101,
+     "end_time": "2026-06-17T06:06:32.573595",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.276238",
+     "start_time": "2026-06-17T06:06:32.563495",
      "status": "completed"
     },
     "tags": []
@@ -1368,10 +1388,10 @@
    "id": "lean13-interp-morphisms",
    "metadata": {
     "papermill": {
-     "duration": 0.003006,
-     "end_time": "2026-06-12T09:27:59.290156",
+     "duration": 0.003509,
+     "end_time": "2026-06-17T06:06:32.579539",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.287150",
+     "start_time": "2026-06-17T06:06:32.576030",
      "status": "completed"
     },
     "tags": []
@@ -1397,10 +1417,10 @@
    "id": "lean13-section7",
    "metadata": {
     "papermill": {
-     "duration": 0.001999,
-     "end_time": "2026-06-12T09:27:59.295154",
+     "duration": 0.002006,
+     "end_time": "2026-06-17T06:06:32.585554",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.293155",
+     "start_time": "2026-06-17T06:06:32.583548",
      "status": "completed"
     },
     "tags": []
@@ -1444,10 +1464,10 @@
    "id": "4c39dc61",
    "metadata": {
     "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-06-12T09:27:59.301153",
+     "duration": 0.0,
+     "end_time": "2026-06-17T06:06:32.585554",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.298154",
+     "start_time": "2026-06-17T06:06:32.585554",
      "status": "completed"
     },
     "tags": []
@@ -1482,42 +1502,43 @@
    "id": "6e9d167b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:27:59.307855Z",
-     "iopub.status.busy": "2026-06-12T09:27:59.307855Z",
-     "iopub.status.idle": "2026-06-12T09:28:29.369763Z",
-     "shell.execute_reply": "2026-06-12T09:28:29.369763Z"
+     "iopub.execute_input": "2026-06-17T06:06:32.595552Z",
+     "iopub.status.busy": "2026-06-17T06:06:32.595552Z",
+     "iopub.status.idle": "2026-06-17T06:08:26.679284Z",
+     "shell.execute_reply": "2026-06-17T06:08:26.678739Z"
     },
     "papermill": {
-     "duration": 30.070614,
-     "end_time": "2026-06-12T09:28:29.372770",
+     "duration": 114.087992,
+     "end_time": "2026-06-17T06:08:26.683544",
      "exception": false,
-     "start_time": "2026-06-12T09:27:59.302156",
+     "start_time": "2026-06-17T06:06:32.595552",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Exception in thread Thread-3 (_readerthread):\n",
-      "Traceback (most recent call last):\n",
-      "  File \"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\threading.py\", line 1045, in _bootstrap_inner\n",
-      "    self.run()\n",
-      "  File \"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\threading.py\", line 982, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\subprocess.py\", line 1599, in _readerthread\n",
-      "    buffer.append(fh.read())\n",
-      "                  ^^^^^^^^^\n",
-      "  File \"<frozen codecs>\", line 322, in decode\n",
-      "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 8: invalid continuation byte\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "CategoryTheory.Limits.HasLimits : (C : Type u_2) → [CategoryTheory.Category.{u_1, u_2} C] → Prop\n",
+      "@CategoryTheory.Adjunction : {C : Type u_3} →\n",
+      "  [inst : CategoryTheory.Category.{u_1, u_3} C] →\n",
+      "    {D : Type u_4} →\n",
+      "      [inst_1 : CategoryTheory.Category.{u_2, u_4} D] →\n",
+      "        CategoryTheory.Functor C D → CategoryTheory.Functor D C → Type (max (max (max u_3 u_4) u_1) u_2)\n",
+      "@CategoryTheory.Adjunction.adjunctionOfEquivLeft : {C : Type u_3} →\n",
+      "  [inst : CategoryTheory.Category.{u_1, u_3} C] →\n",
+      "    {D : Type u_4} →\n",
+      "      [inst_1 : CategoryTheory.Category.{u_2, u_4} D] →\n",
+      "        {G : CategoryTheory.Functor D C} →\n",
+      "          {F_obj : C → D} →\n",
+      "            (e : (X : C) → (Y : D) → (F_obj X ⟶ Y) ≃ (X ⟶ G.obj Y)) →\n",
+      "              (he :\n",
+      "                  ∀ (X : C) (Y Y' : D) (g : Y ⟶ Y') (h : F_obj X ⟶ Y),\n",
+      "                    (e X Y') (CategoryTheory.CategoryStruct.comp h g) =\n",
+      "                      CategoryTheory.CategoryStruct.comp ((e X Y) h) (G.map g)) →\n",
+      "                CategoryTheory.Adjunction.leftAdjointOfEquiv e he ⊣ G\n",
       "\n",
       "Lecture : HasLimits exprime l'existence de toutes les limites dans une categorie, tandis qu'Adjunction formalise une adjonction F ⊣ G entre deux foncteurs.\n"
      ]
@@ -1547,42 +1568,30 @@
    "id": "3091aa4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:28:29.379769Z",
-     "iopub.status.busy": "2026-06-12T09:28:29.379769Z",
-     "iopub.status.idle": "2026-06-12T09:28:59.427598Z",
-     "shell.execute_reply": "2026-06-12T09:28:59.427598Z"
+     "iopub.execute_input": "2026-06-17T06:08:26.693022Z",
+     "iopub.status.busy": "2026-06-17T06:08:26.692464Z",
+     "iopub.status.idle": "2026-06-17T06:10:13.846121Z",
+     "shell.execute_reply": "2026-06-17T06:10:13.846121Z"
     },
     "papermill": {
-     "duration": 30.051829,
-     "end_time": "2026-06-12T09:28:59.427598",
+     "duration": 107.162345,
+     "end_time": "2026-06-17T06:10:13.849778",
      "exception": false,
-     "start_time": "2026-06-12T09:28:29.375769",
+     "start_time": "2026-06-17T06:08:26.687433",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Exception in thread Thread-5 (_readerthread):\n",
-      "Traceback (most recent call last):\n",
-      "  File \"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\threading.py\", line 1045, in _bootstrap_inner\n",
-      "    self.run()\n",
-      "  File \"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\threading.py\", line 982, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\subprocess.py\", line 1599, in _readerthread\n",
-      "    buffer.append(fh.read())\n",
-      "                  ^^^^^^^^^\n",
-      "  File \"<frozen codecs>\", line 322, in decode\n",
-      "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 8: invalid continuation byte\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "@CategoryTheory.Sieve.pullback : {C : Type u_2} →\n",
+      "  [inst : CategoryTheory.Category.{u_1, u_2} C] → {X Y : C} → (Y ⟶ X) → CategoryTheory.Sieve X → CategoryTheory.Sieve Y\n",
+      "@CategoryTheory.GrothendieckTopology.pullback_stable : ∀ {C : Type u_2} [inst : CategoryTheory.Category.{u_1, u_2} C]\n",
+      "  {X Y : C} {S : CategoryTheory.Sieve X} (J : CategoryTheory.GrothendieckTopology C) (f : Y ⟶ X),\n",
+      "  S ∈ J X → CategoryTheory.Sieve.pullback f S ∈ J Y\n",
       "\n",
       "Lecture : pullback_stable est exactement l'axiome SGA de stabilite des cribles couvrants par image inverse.\n"
      ]
@@ -1611,44 +1620,30 @@
    "id": "550858c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-12T09:28:59.427598Z",
-     "iopub.status.busy": "2026-06-12T09:28:59.427598Z",
-     "iopub.status.idle": "2026-06-12T09:29:29.494525Z",
-     "shell.execute_reply": "2026-06-12T09:29:29.494525Z"
+     "iopub.execute_input": "2026-06-17T06:10:13.858787Z",
+     "iopub.status.busy": "2026-06-17T06:10:13.857785Z",
+     "iopub.status.idle": "2026-06-17T06:12:34.333948Z",
+     "shell.execute_reply": "2026-06-17T06:12:34.332943Z"
     },
     "papermill": {
-     "duration": 30.066927,
-     "end_time": "2026-06-12T09:29:29.494525",
+     "duration": 140.483015,
+     "end_time": "2026-06-17T06:12:34.336813",
      "exception": false,
-     "start_time": "2026-06-12T09:28:59.427598",
+     "start_time": "2026-06-17T06:10:13.853798",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Exception in thread Thread-7 (_readerthread):\n",
-      "Traceback (most recent call last):\n",
-      "  File \"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\threading.py\", line 1045, in _bootstrap_inner\n",
-      "    self.run()\n",
-      "  File \"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\threading.py\", line 982, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\subprocess.py\", line 1599, in _readerthread\n",
-      "    buffer.append(fh.read())\n",
-      "                  ^^^^^^^^^\n",
-      "  File \"<frozen codecs>\", line 322, in decode\n",
-      "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 8: invalid continuation byte\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "theorem AlgebraicGeometry.Scheme.zariskiTopology_eq.{u} : AlgebraicGeometry.Scheme.zariskiTopology =\n",
+      "  AlgebraicGeometry.Scheme.zariskiPretopology.toGrothendieck :=\n",
+      "Eq.symm CategoryTheory.Precoverage.toGrothendieck_toPretopology_eq_toGrothendieck\n",
       "\n",
-      "Lignes non vides affichees : 0\n",
+      "Lignes non vides affichees : 3\n",
       "Lecture : la preuve est un renversement d'egalite (`Eq.symm`) applique au pont general `Precoverage.toGrothendieck_toPretopology_eq_toGrothendieck`.\n"
      ]
     }
@@ -1672,13 +1667,86 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e2d7f8a6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004001,
+     "end_time": "2026-06-17T06:12:34.346595",
+     "exception": false,
+     "start_time": "2026-06-17T06:12:34.342594",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : le lemme de Yoneda\n",
+    "\n",
+    "**Objectif** : explorer la formalisation Mathlib du **lemme de Yoneda**, pilier de la theorie des categories et de l'approche grothendieckienne des foncteurs representables (cf section 1 sur les foncteurs et Yoneda).\n",
+    "\n",
+    "Le lemme de Yoneda dit que pour tout foncteur `F : C^op -> Type*` et tout objet `X : C`, l'application qui evalue une transformation naturelle `yoneda X -> F` en `id X` est une bijection vers `F.obj X`. En particulier, un objet est entirement determine par les morphismes qui l'atteignent : c'est le slogan des foncteurs representables au coeur de la geometrie algebrique grothendieckienne.\n",
+    "\n",
+    "**Indice** : un `#check CategoryTheory.yoneda` revele le plongement de Yoneda `C -> (C^op -> Type*)` qui envoie un objet `X` sur le foncteur representable `Hom(-, X)`. `CategoryTheory.Yoneda` est la variante duale. Le lemme lui-meme vit dans `CategoryTheory.Yoneda.yonedaLemma`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8aac9b8d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T06:12:34.356389Z",
+     "iopub.status.busy": "2026-06-17T06:12:34.356389Z",
+     "iopub.status.idle": "2026-06-17T06:14:20.014743Z",
+     "shell.execute_reply": "2026-06-17T06:14:20.013738Z"
+    },
+    "papermill": {
+     "duration": 105.667147,
+     "end_time": "2026-06-17T06:14:20.017742",
+     "exception": false,
+     "start_time": "2026-06-17T06:12:34.350595",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CategoryTheory.yoneda.{v₁, u₁} {C : Type u₁} [CategoryTheory.Category.{v₁, u₁} C] :\n",
+      "  CategoryTheory.Functor C (CategoryTheory.Functor Cᵒᵖ (Type v₁))\n",
+      "\n",
+      "Lecture : CategoryTheory.yoneda est le plongement de Yoneda C -> presheaf C (X |-> Hom(-, X)). Le lemme de Yoneda identifie les transformations naturelles depuis un foncteur representable aux elements du foncteur cible ; c'est l'outil fondateur des foncteurs representables en geometrie algebrique.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : le lemme de Yoneda\n",
+    "# On inspecte le plongement de Yoneda formalise dans Mathlib.\n",
+    "\n",
+    "snippet_ex4 = \"\"\"\n",
+    "import Mathlib.CategoryTheory.Yoneda\n",
+    "\n",
+    "#check CategoryTheory.yoneda\n",
+    "\"\"\"\n",
+    "\n",
+    "resultat_ex4 = run_lean(snippet_ex4, timeout_s=900)\n",
+    "print(resultat_ex4)\n",
+    "print(\"Lecture : CategoryTheory.yoneda est le plongement de Yoneda C -> presheaf C \"\n",
+    "      \"(X |-> Hom(-, X)). Le lemme de Yoneda identifie les transformations naturelles \"\n",
+    "      \"depuis un foncteur representable aux elements du foncteur cible ; c'est l'outil \"\n",
+    "      \"fondateur des foncteurs representables en geometrie algebrique.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "lean13-section8",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-12T09:29:29.494525",
+     "duration": 0.003999,
+     "end_time": "2026-06-17T06:14:20.024741",
      "exception": false,
-     "start_time": "2026-06-12T09:29:29.494525",
+     "start_time": "2026-06-17T06:14:20.020742",
      "status": "completed"
     },
     "tags": []
@@ -1768,14 +1836,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 95.072951,
-   "end_time": "2026-06-12T09:29:33.056322",
+   "duration": 468.859824,
+   "end_time": "2026-06-17T06:14:20.153221",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\Lean-13-Grothendieck-Tribute.ipynb",
    "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\Lean-13-Grothendieck-Tribute_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-12T09:27:57.983371",
+   "start_time": "2026-06-17T06:06:31.293397",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Two coupled improvements to `Lean-13-Grothendieck-Tribute.ipynb` (python3 kernel):

1. **Fixed a pre-existing C.2 defect**: the 3 committed exercise cells (Ex1 limites/adjonction, Ex2 cribles/pullback, Ex3 Zariski) displayed **only a CPython `_readerthread` exception trace with NO Lean output**. Root cause: `wsl()` used `subprocess.run(capture_output=True)`, whose Windows reader-thread race silently dropped the captured stdout/stderr. Replaced with **temp-file redirection** — the real Mathlib signatures (`CategoryTheory.Limits.HasLimits`, `@CategoryTheory.Adjunction`, `CategoryTheory.Sieve.pullback`, `AlgebraicGeometry.Scheme.zariskiTopology_eq`) are now captured and displayed.

2. **Added Exercice 4 (lemme de Yoneda)** — exploration of `CategoryTheory.yoneda` via `run_lean`, fitting the tribute (Yoneda is foundational, already referenced in section 1). Brings `count_exercises` **2 → 3** (meets convention #2161 threshold).

## Validation (C.1 + C.2 + H.1)

- `notebook_tools.py execute --kernel python3` → **SUCCESS (470.7s, 0 failures)**.
- All **12 code cells executed** (`execution_count` 1-12, 0 null).
- **0 errors** across the notebook.
- **0 `_readerthread` / `Exception in thread` traces in outputs** (the only matches are in the new `wsl()` docstring that documents the fix, and cell 24 markdown prose — both confirmed source/comment, not output).
- Cell [29] Yoneda output: `CategoryTheory.yoneda.{v₁, u₁} ... : CategoryTheory.Functor C (CategoryTheory.Functor Cᵒᵖ (Type v₁))` ✓
- C.1 sweep: 0 real `raise NotImplementedError` / `assert False` / `1/0` (1 false-positive match = markdown prose naming the convention).
- `count_exercises.py` = **3** (was 2, conforming now).
- Anti-regression: cells [25/26/27] source unchanged; their outputs went from broken (exception-only) to real Lean output. Cell [11] Lean prose intact.

## Environment note (rule F)

The grothendieck_lean Mathlib cache was cold (0 `.olean`); warmed via `lake exe cache get` (8062 `.olean` fetched). `lake env lean` now resolves `import Mathlib.CategoryTheory.*` in <1s. No env bypass.

## Scope

1 file (`Lean-13-Grothendieck-Tribute.ipynb`), +259/-191. fox/col §9.1 + Conway P4 remain BG-prover ai-01 (not touched).

See #2161 (partial — one notebook). Not `Closes` (repo-wide convention epic).