### PR TITLE
fix(symbolic-learning): guided-example framing/intros from EPITA class feedback (SL-1, SL-2, SL-4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -2007,9 +2007,9 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide : CBH avec un ordre different\n",
+    "### Exemple guidé : CBH conjonctif et l'ordre des exemples\n",
     "\n",
-    "L'ordre des exemples influence le resultat de CBH. Voici ce qui se passe quand on place les negatifs en premier."
+    "CBH (section 4) construit son hypothèse exemple par exemple : l'ordre de présentation peut donc l'amener à explorer des chemins différents. On teste ici une question précise : **le faux positif résiduel de la version conjonctive est-il un accident d'ordre, ou une limite structurelle ?** On rejoue donc CBH en plaçant les exemples négatifs en premier, puis on compare au résultat de la section 4."
    ]
   },
   {
@@ -2072,17 +2072,19 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : CBH avec un ordre different\n",
+    "### Interprétation : l'ordre ne sauve pas la représentation conjonctive\n",
     "\n",
-    "Le resultat obtenu avec les negatifs en premier est **identique** a celui obtenu avec l'ordre original : l'hypothese `Hungry=Yes` avec 1 faux positif.\n",
+    "Avec les négatifs en premier, CBH retombe sur **exactement le même résultat** qu'avec l'ordre original (section 4) : l'hypothèse `Hungry=Yes` (tous les autres attributs en `?`), avec **1 faux positif** résiduel.\n",
     "\n",
     "| Aspect | Observation |\n",
     "|--------|-------------|\n",
-    "| Hypothese finale | `('?', '?', '?', 'Yes', '?', ...)` (Hungry=Yes) |\n",
-    "| Consistance | Non (1 faux positif) |\n",
-    "| Convergence | Le backtracking a l'exemple 9 n'a pas pu etre resolu |\n",
+    "| Hypothèse finale | `('?', '?', '?', 'Yes', '?', ...)` — Hungry=Yes |\n",
+    "| Consistance | Non — 1 faux positif, irréductible |\n",
+    "| Effet de l'ordre | Aucun ici : le mur est atteint quel que soit l'ordre |\n",
     "\n",
-    "> **Note** : Dans ce cas precis, l'ordre n'a pas change le resultat final. Cependant, pour d'autres jeux de donnees ou d'autres ordres, CBH peut produire des hypotheses differentes. C'est cette instabilite qui motive l'utilisation du Version Space."
+    "Le point pédagogique n'est donc **pas** l'instabilité de CBH selon l'ordre, mais ce que cette *stabilité-dans-l'échec* révèle : le faux positif n'est pas un accident d'ordre, c'est la **signature du biais de représentation conjonctif**. Aucune conjonction unique ne sépare les 12 exemples — précisément l'effondrement diagnostiqué à la section 5 (Version Space vide) et formalisé au tableau de la section 8.\n",
+    "\n",
+    "Et ce mur n'est pas une fatalité de l'algorithme : c'est une limite de **l'espace d'hypothèses**. La **section 9** le franchit *sans changer de stratégie de recherche* — `current_best_learning` (Figure 19.2 d'AIMA) autorise les **disjonctions** (`add_or`) et atteint **100 % de consistance (12/12)** sur ces mêmes 12 exemples. C'est le passage conjonctif → disjonctif, et non un réglage d'ordre ou un autre algorithme conjonctif comme le Version Space, qui résout réellement le problème."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -777,7 +777,7 @@
     "2. **Ordre-dependance** : Le resultat depend de l'ordre des exemples\n",
     "3. **Hypothese unique** : On ne garde qu'une seule hypothese, pas l'espace complet\n",
     "\n",
-    "> **Note** : CBH est un algorithme glouton qui peut echouer ou trouver un resultat sous-optimal selon l'ordre d'arrivee des exemples. Le Version Space resout ce probleme en gardant **toutes** les hypotheses consistantes."
+    "> **Note** : CBH est un algorithme glouton qui ne retient qu'une seule hypothèse. Le **Version Space** (section 5) lève cette limite *algorithmique* en gardant **toutes** les hypothèses consistantes à la fois — mais il partage le même **espace d'hypothèses conjonctif** : sur les 12 exemples du restaurant, il s'effondre lui aussi (G et S deviennent vides). La limite de fond n'est donc pas l'algorithme mais la **représentation** ; c'est la **section 9** (hypothèses disjonctives) qui la résout vraiment."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
@@ -1632,6 +1632,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "sl2-guided1-intro",
+   "metadata": {},
+   "source": [
+    "### Exemple guidé 1 : l'EBL appliqué à la différentiation symbolique\n",
+    "\n",
+    "Les sections 4 à 6 ont illustré l'EBL sur la *simplification arithmétique* : à partir d'un seul exemple résolu, on extrait par variabilisation une règle macro réutilisable. Avant de passer aux exercices, voici un **exemple entièrement résolu** qui rejoue exactement le même mécanisme sur un autre domaine, la **différentiation symbolique**.\n",
+    "\n",
+    "La théorie de domaine est ici l'ensemble des règles de dérivation ($d/dx(u+v)=du+dv$, $d/dx(u\\cdot v)=du\\cdot v + u\\cdot dv$, ...). La cellule construit d'abord un dérivateur symbolique, puis montre comment l'EBL en généralise la *règle de la chaîne* à partir d'une seule trace de preuve — la démarche des sections 4-6, transposée. Étudiez-le : les trois exercices qui suivent vous demanderont de l'étendre."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "d8492780",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
@@ -1880,6 +1880,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "sl4-guided-sibling-intro",
+   "metadata": {},
+   "source": [
+    "### Exemple guidé : apprendre `sibling` avec FOIL\n",
+    "\n",
+    "Avant de passer aux exercices, voici un **exemple entièrement résolu** qui réutilise l'implémentation de FOIL de la section 3 sur un nouveau concept : la relation frère/sœur `sibling(x, y) :- parent(z, x), parent(z, y), neq(x, y)`.\n",
+    "\n",
+    "L'exemple déroule les trois étapes attendues d'un problème ILP : (1) constituer le *background* — ici l'inégalité `neq/2`, FOIL n'ayant pas de `\\=` natif ; (2) fournir les exemples positifs et négatifs ; (3) laisser FOIL sélectionner les littéraux du corps par gain d'information. La trace pas-à-pas montre notamment pourquoi le littéral `neq(x, y)` est indispensable pour exclure les paires `(p, p)`. Chaque exercice « À votre tour » qui suit reprend ce schéma sur un autre concept."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "4e6e75a6",


### PR DESCRIPTION
## Contexte

Retours user pendant le cours EPITA Symbolic Learning (17/06) sur le cadrage et le placement des exemples guidés. Fixes markdown-only, atomiques, même domaine.

## Changements

- **SL-1** — l'exemple guidé « CBH avec un ordre différent » rejoue le CBH *conjonctif* (négatifs d'abord) et obtient le même résultat qu'à la section 4 (`Hungry=Yes`, 1 faux positif, inconsistant). L'ancienne interprétation s'arrêtait là et concluait « cette instabilité motive le Version Space » — trompeur, car le Version Space est lui aussi conjonctif et s'effondre sur les mêmes 12 exemples. **Reframe** : le résultat identique quel que soit l'ordre montre que le faux positif est la *signature du biais conjonctif*, pas un artefact d'ordre ; la conclusion pointe désormais vers la section 9 où `current_best_learning` (Figure 19.2 AIMA) lève le biais par disjonctions (`add_or`) et atteint **100 % (12/12)**. Chiffres ancrés sur les sorties committées (cellules 12/35/29).
- **SL-2** — ajout d'une cellule d'intro avant le premier `# Exemple guide 1 : EBL differentiation symbolique` (apparaissait directement après un `---`).
- **SL-4** — ajout d'une cellule d'intro avant le premier `# Exemple guide : sibling avec FOIL` (suivait le header `## 7. Exercices` sans markdown explicatif, contrairement aux exemples guidés suivants).

## Vérifications

- **Markdown uniquement** (exception C.2) : aucune cellule de code ni sortie touchée, aucune ré-exécution requise. Diff vérifié : zéro `execution_count`/`outputs`/code modifié.
- Forensic SL-1 : 18 cellules code, 0 null exec_count, 0 erreur, 0 pattern interdit.
- **SL-6 : aucun changement** — la section Clingo « la vraie librairie » précède déjà le bloc exemples-guidés/exercices depuis #3214.
- Scope atomique : 3 notebooks, pas de catalogue ni submodule.

Remplace #3218 (base obsolète après les merges nocturnes #3197/#3203/#3205/#3208/#3214).