### PR TITLE
feat(sl-3): resolve Exercice 1 (weather determinations) into guided example + variation

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
@@ -1559,21 +1559,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : determinations meteorologiques\n",
-      "Etape 1 : testez chaque attribut individuellement avec check_determination\n",
-      "Etape 2 : si aucun attribut seul ne suffit, testez les paires\n",
-      "Etape 3 : utilisez minimal_consistent_det pour la determination minimale\n"
+      "Etape 1 : test de chaque attribut individuellement\n",
+      "------------------------------------------------------------\n",
+      "  season     -> weather : NON  (3 groupes, 3 violations)\n",
+      "  humidity   -> weather : NON  (2 groupes, 2 violations)\n",
+      "  wind       -> weather : NON  (2 groupes, 2 violations)\n",
+      "  pressure   -> weather : NON  (2 groupes, 2 violations)\n",
+      "\n",
+      "Etape 2 : recherche de la determination minimale\n",
+      "------------------------------------------------------------\n",
+      "  Niveau 1 : test de 4 combinaisons...\n",
+      "  Niveau 2 : test de 6 combinaisons...\n",
+      "  Niveau 3 : test de 4 combinaisons...\n",
+      "    TROUVE : {season, humidity, wind} apres 11 tests\n",
+      "\n",
+      "Etape 3 : interpretation\n",
+      "------------------------------------------------------------\n",
+      "  Determination minimale : {season, humidity, wind}\n",
+      "  Trouvee au niveau 3 (11 sous-ensembles testes).\n",
+      "  Attribut(s) EXCLU(S) par RBL : {pressure} -- juge(s) non pertinent(s).\n",
+      "\n",
+      "Lecture : aucun attribut seul ne determine le temps (par ex. season melange\n",
+      "sunny et storm en ete). Il faut COMBINER season + humidity + wind (niveau 3).\n",
+      "La PRESSION est REJETEE par la recherche minimale : deux jours de meme\n",
+      "(season, humidity, wind) ont le meme temps quelle que soit la pression.\n",
+      "C'est l'apport de RBL : identifier les variables pertinentes et eliminer\n",
+      "le bruit, SANS ajuster de modele statistique -- la structure logique suffit.\n",
+      "\n",
+      "Exemple guide 1 OK : determination meteo = {season, humidity, wind}, pression excluse.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 : Determinations dans un jeu de donnees meteorologiques\n",
-    "# TODO etudiant : Identifiez quelles proprietes determinent le type de temps\n",
-    "# Indice : Utilisez check_determination et minimal_consistent_det\n",
-    "# Etape 1 : examinez les donnees ci-dessous\n",
-    "# Etape 2 : testez chaque attribut individuellement\n",
-    "# Etape 3 : trouvez la determination minimale\n",
+    "# Exemple guide 1 : Determinations dans un jeu de donnees meteorologiques\n",
+    "# Resolution de l'Exercice 1 (See #2161) : solution demontree ci-dessous.\n",
+    "#\n",
+    "# Objectif : quelles proprietes (season, humidity, wind, pressure) determinent\n",
+    "# le type de temps ? On reutilise check_determination (groupage + test de\n",
+    "# consistence) et minimal_consistent_det (recherche du plus petit sous-ensemble\n",
+    "# d'attributs qui determine la cible).\n",
     "\n",
+    "# Les donnees meteorologiques (10 observations synthetiques).\n",
     "weather_data = [\n",
     "    {\"season\": \"summer\", \"humidity\": \"low\",  \"wind\": \"low\",    \"pressure\": \"high\", \"weather\": \"sunny\"},\n",
     "    {\"season\": \"summer\", \"humidity\": \"low\",  \"wind\": \"high\",   \"pressure\": \"high\", \"weather\": \"sunny\"},\n",
@@ -1589,10 +1615,94 @@
     "\n",
     "WEATHER_ATTRS = [\"season\", \"humidity\", \"wind\", \"pressure\"]\n",
     "\n",
-    "print(\"Exercice a completer : determinations meteorologiques\")\n",
-    "print(\"Etape 1 : testez chaque attribut individuellement avec check_determination\")\n",
-    "print(\"Etape 2 : si aucun attribut seul ne suffit, testez les paires\")\n",
-    "print(\"Etape 3 : utilisez minimal_consistent_det pour la determination minimale\")"
+    "# Etape 1 : aucun attribut pris isolement ne determine le temps.\n",
+    "print(\"Etape 1 : test de chaque attribut individuellement\")\n",
+    "print(\"-\" * 60)\n",
+    "for attr in WEATHER_ATTRS:\n",
+    "    res = check_determination(weather_data, [attr], \"weather\")\n",
+    "    status = \"OUI\" if res.holds else \"NON\"\n",
+    "    print(f\"  {attr:10s} -> weather : {status}  ({res.coverage} groupes, {len(res.violations)} violations)\")\n",
+    "\n",
+    "# Etape 2 : recherche de la determination minimale (sous-ensembles par taille croissante).\n",
+    "print()\n",
+    "print(\"Etape 2 : recherche de la determination minimale\")\n",
+    "print(\"-\" * 60)\n",
+    "weather_det = minimal_consistent_det(weather_data, WEATHER_ATTRS, \"weather\", verbose=True)\n",
+    "\n",
+    "# Etape 3 : interpretation du resultat.\n",
+    "print()\n",
+    "print(\"Etape 3 : interpretation\")\n",
+    "print(\"-\" * 60)\n",
+    "if weather_det.determination:\n",
+    "    found = set(weather_det.determination)\n",
+    "    excluded = set(WEATHER_ATTRS) - found\n",
+    "    print(f\"  Determination minimale : {{{', '.join(weather_det.determination)}}}\")\n",
+    "    print(f\"  Trouvee au niveau {weather_det.found_at_level} ({weather_det.subsets_tested} sous-ensembles testes).\")\n",
+    "    print(f\"  Attribut(s) EXCLU(S) par RBL : {{{', '.join(sorted(excluded))}}} -- juge(s) non pertinent(s).\")\n",
+    "    print()\n",
+    "    print(\"Lecture : aucun attribut seul ne determine le temps (par ex. season melange\")\n",
+    "    print(\"sunny et storm en ete). Il faut COMBINER season + humidity + wind (niveau 3).\")\n",
+    "    print(\"La PRESSION est REJETEE par la recherche minimale : deux jours de meme\")\n",
+    "    print(\"(season, humidity, wind) ont le meme temps quelle que soit la pression.\")\n",
+    "    print(\"C'est l'apport de RBL : identifier les variables pertinentes et eliminer\")\n",
+    "    print(\"le bruit, SANS ajuster de modele statistique -- la structure logique suffit.\")\n",
+    "else:\n",
+    "    print(\"  Aucune determination : le concept est disjonctif (cf. cas restaurant).\")\n",
+    "print()\n",
+    "print(\"Exemple guide 1 OK : determination meteo = {season, humidity, wind}, pression excluse.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl3-ex1-var-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 (variation) : Un attribut trompeur\n",
+    "\n",
+    "RBL est censé écarter les attributs non-pertinents. Ajoutez un 5ᵉ attribut **bruité** (par ex. `forecaster` = le nom du météorologue, sans lien avec le temps) aux données et vérifiez que la détermination minimale l'exclut toujours.\n",
+    "\n",
+    "**Étapes** :\n",
+    "1. Ajoutez `forecaster` (valeurs arbitraires) à chaque ligne de `weather_data`.\n",
+    "2. Relancez `minimal_consistent_det` sur les 5 attributs.\n",
+    "3. La détermination minimale change-t-elle ? Pourquoi RBL est-il robuste au bruit ?\n",
+    "\n",
+    "**Indice** : un attribut non pertinent augmente le nombre de groupes sans réduire les violations — la recherche par taille croissante le saute naturellement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "sl3-ex1-var-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : attribut bruite et robustesse de RBL\n",
+      "Question : pourquoi RBL exclut-il naturellement les attributs non-pertinents ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (variation) : Un attribut trompeur\n",
+    "# TODO etudiant : ajoutez un attribut bruite et confirmez que RBL l'exclut.\n",
+    "\n",
+    "# Etape 1 : ajouter 'forecaster' (valeurs sans lien avec weather)\n",
+    "# forecasters = [\"Alice\", \"Bob\", \"Alice\", \"Bob\", \"Alice\", \"Bob\", \"Alice\", \"Bob\", \"Alice\", \"Bob\"]\n",
+    "# weather_noisy = [dict(row, forecaster=f) for row, f in zip(weather_data, forecasters)]\n",
+    "\n",
+    "# Etape 2 : relancer minimal_consistent_det sur les 5 attributs\n",
+    "# noisy_attrs = WEATHER_ATTRS + [\"forecaster\"]\n",
+    "# det_noisy = minimal_consistent_det(weather_noisy, noisy_attrs, \"weather\")\n",
+    "\n",
+    "# Etape 3 : la determination change-t-elle ?\n",
+    "print('Exercice a completer : attribut bruite et robustesse de RBL')\n",
+    "print('Question : pourquoi RBL exclut-il naturellement les attributs non-pertinents ?')\n",
+    "\n",
+    "# Indice : un attribut non-pertinent augmente le nombre de groupes sans reduire\n",
+    "# les violations ; la recherche par taille croissante le saute.\n",
+    "# result = None  # TODO etudiant : (determination_brute, determination_bruitee)"
    ]
   },
   {
@@ -1614,7 +1724,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "cc196778",
    "metadata": {
     "execution": {
@@ -1678,7 +1788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "8072ef89",
    "metadata": {
     "execution": {
@@ -1791,6 +1901,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b421cbe4",
    "metadata": {},
    "source": [
     "---\n",


### PR DESCRIPTION
## Summary

See #2161 (SymbolicLearning exercises → Exemples guidés). Resolves **SL-3 Exercice 1** (weather determinations) into a worked example following the proven recipe.

> **De-risk for course 18/06.** SL-3 was the last SymbolicLearning notebook with 0 resolved worked examples (3 stubs in section 7). po-2025 (partition SL-1/2/3) is 4+ cycles away from SL-3 (SL-1 Ex3/5 + SL-2 Ex2/3 first) → wouldn't reach it before the course. SL-3 is pure-Python (numpy/sklearn), no GPU/swi-prolog blocker. **[CLAIMED] transparently on the dashboard** (matches the SL-5/6 de-risk pattern ai-01 greenlit); redirigeable if po-2025 starts SL-3. Base = fresh `origin/main`, independent notebook (no collision with the SL-5/6 stack).

## Changes (1 file, +128/-17)

- **Ex1** (cell `5f23755b`): stub → **Exemple guide 1**. Keeps the enoncé's `weather_data` (10 obs). Étape 1: tests each attribute individually (none determines weather). Étape 2: `minimal_consistent_det` → `{season, humidity, wind}` at level 3 (11 subsets). Étape 3: interpretation — **pressure excluded** as non-pertinent (RBL discards noise via logical structure, no statistical model).
- **Variation** (new, after Ex1): "Un attribut trompeur" — add a 5th noisy attribute (`forecaster`), confirm RBL still excludes it. C.1-clean stub. Aligns with the course's own "Défi présentation" Ex.1 question-twist.
- **Ex2/Ex3**: `execution_count` bumped +1 (source + outputs byte-identical to base).

## Proof of execution (kernel python3)

```
Etape 1 : chaque attribut isolement -> weather : NON (tous, avec violations)
Etape 2 : Niveau 1 (4) -> Niveau 2 (6) -> Niveau 3 : TROUVE {season, humidity, wind} apres 11 tests
Etape 3 : Determination minimale : {season, humidity, wind} | EXCLU(S) : {pressure}
```

## Validation

- `nbformat.validate` OK. **C.1 = 0**, **H.3 = 0**. `execution_count` monotonic [1..15].
- **Scope**: only Ex1 code (source+outputs+ec), the 2 new variation cells, Ex2/Ex3 exec_count bumps. All infra cells (imports, `check_determination`, `minimal_consistent_det`, treillis/IM cells) + sections 1-6 are **byte-identical to `origin/main`**.
- Benign side-effect: nbformat 5.10 auto-assigned an `id` to the section-8 "Défi présentation" cell (lacked one in origin/main). Source unchanged; only an id metadata field added (standard modernization).

Co-Authored-By: Claude <noreply@anthropic.com>
