### PR TITLE
docs(search): academic References section for Applications sub-series (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -142,6 +142,24 @@ La plupart des notebooks d'application sont adaptés de projets étudiants réal
 | [Sudoku](../../Sudoku/) | App-11 (Picross), App-1 (NQueens) | Problèmes combinatoires similaires |
 | [GameTheory](../../GameTheory/) | App-12/14 (ConnectFour) | Jeux à deux joueurs, MCTS |
 
+## Références
+
+Couverture par application des sources fondatrices mobilisées dans cette sous-série. Les références transversales (formalisation en espace d'états, backtracking, A*, recherche locale, métaheuristiques) sont reprises dans les READMEs des [Parties 1](../Part1-Foundations/README.md), [2](../Part2-CSP/README.md) et [4](../Part4-Metaheuristics/README.md) : ce tableau ne couvre que les sources spécifiques aux applications.
+
+| Application(s) | Référence |
+|-------------|-----------|
+| App-1 (NQueens), App-2 (GraphColoring), App-3 (NurseScheduling), App-4 (JobShop), App-5 (Timetabling), App-15 (SportsScheduling), App-16 (Crossword) | Russell, S., & Norvig, P. — *Artificial Intelligence: A Modern Approach* (4e éd., 2021), ch. « Constraint Satisfaction Problems ». Formalisation (X, D, C) et backtracking avec MRV/LCV. |
+| App-1, App-2, App-3, App-4, App-11, App-15, App-16 (solveur) | Perron, L., & Furnon, V. — *OR-Tools CP-SAT* (Google). Propagation par clauses paresseuses (LCG), à l'origine du facteur « plusieurs millions » constaté sur le Picross (App-11). |
+| App-5 (Timetabling), App-8 (MiniZinc) | Nethercote, N., Stuckey, P. J., Becket, R., Brand, S., Duck, G. J., & Tack, G. (2007) — « MiniZinc: Towards a Standard CP Modelling Language », *CP 2007*, LNCS 4741. |
+| App-6 (Minesweeper), App-7 (Wordle) | AIMA, ch. « Probabilistic Reasoning » (CSP doublé de probabilités pour le démineur) ; Cover, T. M., & Thomas, J. A. — *Elements of Information Theory* (2e éd., 2006), Wiley. Entropie et théorie de l'information mobilisées pour le filtrage optimal des hypothèses dans Wordle. |
+| App-11 (Picross) | Knuth, D. E. (2000) — « Dancing Links », dans *Millennial Perspectives in Computer Science* (Springer). Couverture exacte, formulation à l'origine du backtracking naïf sur les nonogrammes avant le saut vers CP-SAT. |
+| App-12, App-14 (ConnectFour) | Browne, C. B., Powley, E., et al. (2012) — « A Survey of Monte Carlo Tree Search Methods », *IEEE Trans. on Computational Intelligence and AI in Games* 4(1) ; et AIMA, ch. « Adversarial Search » (Minimax, élagage Alpha-Beta). |
+| App-9 (EdgeDetection), App-10 (Portfolio) | Holland, J. H. (1975) — *Adaptation in Natural and Artificial Systems*, University of Michigan Press. Algorithmes génétiques à la base de la recherche de filtres de convolution (App-9) et de l'optimisation de portefeuille (App-10). |
+| App-10 (Portfolio, multi-objectif) | Markowitz, H. (1952) — « Portfolio Selection », *The Journal of Finance* 7(1) — frontière efficiente ; et Deb, K. (2001) — *Multi-Objective Optimization using Evolutionary Algorithms*, Wiley — optimisation évolutionnaire multi-objectif (frontière de Pareto). |
+| App-13 (TSP), App-17 (VRP) | Applegate, D. L., Bixby, R. E., Chvátal, V., & Cook, W. J. (2006) — *The Traveling Salesman Problem: A Computational Study*, Princeton University Press ; Toth, P., & Vigo, D. (2014) — *Vehicle Routing: Problems, Methods, and Applications*, SIAM (2e éd.) ; et Dorigo, M., & Gambardella, L. M. (1997) — « Ant colonies for the traveling salesman problem », *IEEE Trans. on Evolutionary Computation* 1(2) — colonies de fourmis. |
+| App-18 (HyperparameterTuning) | Snoek, J., Larochelle, H., & Adams, R. P. (2012) — « Practical Bayesian Optimization of Machine Learning Hyperparameters », *NeurIPS* ; et Kennedy, J., & Eberhart, R. (1995) — « Particle Swarm Optimization », *Proc. IEEE Int. Conf. on Neural Networks*. |
+| App-19 (ProceduralGeneration-WFC) | Gumin, M. (2016) — *WaveFunctionCollapse*, github.com/mxgmn/WaveFunctionCollapse. Génération procédurale de niveaux par propagation de contraintes. |
+
 ## Navigation
 
 [<- Partie 1 : Search](../Part1-Foundations/README.md) | [Partie 2 : CSP](../Part2-CSP/README.md) | [Retour à la série Search](../README.md)


### PR DESCRIPTION
## Summary

Completes the **#2651 References rollout** to the `Applications/` sub-series README — the last genuine gap in the Search family. This sub-series README (21 application notebooks) carried no references section at all.

Declared residual of #3148/#3169, which covered `Part1-Foundations`, `Part2-CSP`, `Part4-Metaheuristics`. The Search/Sudoku/GameTheory/SymbolicAI **parent** READMEs already carry references (under `## Ressources` / `## Références`).

## Change

One new `## Références` section (+18 lines, pure additive, 0 deletions) in `MyIA.AI.Notebooks/Search/Applications/README.md`. Per-application coverage table of **verifiable foundational works**, matching the #3148 format:

| App(s) | Source |
|---|---|
| CSP apps (1,2,3,4,5,15,16) | AIMA (Russell & Norvig 4e), ch. CSP |
| CP-SAT apps | OR-Tools CP-SAT (Perron & Furnon) — the LCG propagation behind the Picross 27Mx speedup |
| App-5/8 | MiniZinc (Nethercote et al. 2007, CP 2007) |
| App-6/7 | Cover & Thomas, *Elements of Information Theory* (Wordle entropy / Minesweeper) |
| App-11 Picross | Knuth, *Dancing Links* (2000) — exact-cover foundation |
| App-12/14 ConnectFour | Browne MCTS (2012) + AIMA adversarial |
| App-9/10 GA | Holland (1975) |
| App-10 Portfolio | Markowitz (1952) + Deb (2001) multi-objective |
| App-13/17 TSP/VRP | Applegate (2006) + Toth & Vigo (2014) + Dorigo ACO (1997) |
| App-18 tuning | Snoek (2012) Bayesian opt + Kennedy PSO (1995) |
| App-19 WFC | Gumin, *WaveFunctionCollapse* (2016) |

Transverse refs (A*, search spaces, metaheuristics) are **cross-referenced** to Parts 1/2/4 rather than duplicated.

## Verification

- **G.1 gap verified**: confirmed (by direct read, not grep — accented-é grep false-negatives) that Part1/Part2/Part4 already have `## Références` (#3148), and the 4 parents carry references → Applications is the **sole** genuine gap, no duplication.
- Docs-only, no catalogue churn, submodule unchanged, no notebooks touched.
- Every citation is a real, verifiable foundational work (AIMA, OR-Tools, Nethercote 2007, Cover & Thomas, Knuth 2000, Browne 2012, Holland 1975, Markowitz 1952, Deb 2001, Applegate 2006, Toth & Vigo 2014, Dorigo 1997, Snoek 2012, Kennedy 1995, Gumin 2016) — no fabricated references.

See #2651