### PR TITLE
docs(symbolic-ai): complete sous-series nav chain + unify prereq block (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -7,7 +7,7 @@ breakdown: Argument_Analysis=11
 maturity: PRODUCTION=10, ALPHA=1
 -->
 
-[← Intelligence Symbolique](../README.md)
+[← SmartContracts](../SmartContracts/README.md) | [↑ SymbolicAI](../README.md) | [SymbolicLearning →](../SymbolicLearning/README.md)
 
 Pipeline complet d'analyse argumentative combinant Semantic Kernel, TweetyProject et programmation logique pour l'identification et l'évaluation d'arguments dans des textes.
 
@@ -170,7 +170,7 @@ jupyter notebook Argument_Analysis_Agentic-0-init.ipynb
 
 ---
 
-## Prerequisites
+## Prérequis
 
 ### Python
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -231,9 +231,9 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 - **Docker** (notebooks 4-6) : exécution du conteneur Fast Downward sur le port 8200
 - **OR-Tools** (notebook 7) : modélisation de contraintes, solveur CP-SAT
 
-## Prérequis techniques
+### Prérequis techniques
 
-### 1. Environnement Python
+#### 1. Environnement Python
 
 ```bash
 # Créer un environnement virtuel
@@ -245,7 +245,7 @@ source venv/bin/activate  # Linux/Mac
 pip install unified-planning ortools numpy matplotlib networkx
 ```
 
-### 2. Docker pour Fast Downward (recommandé)
+#### 2. Docker pour Fast Downward (recommandé)
 
 ```bash
 # Télécharger l'image Docker Fast Downward (serveur HTTP port 8200)
@@ -254,7 +254,7 @@ docker pull jsboige/coursia-fast-downward:latest
 
 L'image fournit un serveur API HTTP sur le port 8200. Les notebooks appellent l'endpoint `/plan` avec un payload JSON `{domain, problem, search}` et reçoivent le plan optimal.
 
-### 3. Vérification
+#### 3. Vérification
 
 ```bash
 python -c "import unified_planning; from ortools.sat.python import cp_model; print('OK')"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -341,7 +341,7 @@ La série SemanticWeb illustre un mouvement profond du dépôt CoursIA : **prend
 
 ---
 
-## Prerequisites
+## Prérequis
 
 ### Pour les notebooks .NET (SW-1 à SW-7)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -1,6 +1,6 @@
 # Smart Contracts - Des Cypherpunks aux Blockchains Modernes
 
-[← Planners](../Planners/README.md) | [↑ SymbolicAI](../README.md)
+[← Planners](../Planners/README.md) | [↑ SymbolicAI](../README.md) | [Argument_Analysis →](../Argument_Analysis/README.md)
 
 <!-- CATALOG-STATUS
 series: SymbolicAI-SmartContracts

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -1,6 +1,6 @@
 # SymbolicLearning - Apprentissage Symbolique
 
-[↑ SymbolicAI](../README.md)
+[← Argument_Analysis](../Argument_Analysis/README.md) | [↑ SymbolicAI](../README.md) | [SMT →](../SMT/README.md)
 
 <!-- CATALOG-STATUS
 series: SymbolicAI-SymbolicLearning
@@ -300,7 +300,7 @@ Note : dans SL-5, le premier exercice de la numerotation interne est un exemple 
 | **Provenance** | Trace de derivation attachee a chaque fait infere | SL-10 |
 | **Pipeline neuro-symbolique** | LLM aux extremites, validation et inference symboliques au centre | SL-10 |
 
-## Prerequis
+## Prérequis
 
 ### Connaissances requises
 


### PR DESCRIPTION
## What

ai-01 deep-queue dispatch 2026-06-17 ~07:06Z (item 1, **#2651 Partie 2**): harmonize SymbolicAI sous-series navLat + prereq block. This PR ships the **clean, additive scope**; the fuller harmonisation is deferred (genuinely blocked/gated — see Scope honesty).

### navLat — complete the sibling chain (defect fix)
The lateral nav was **dead-ending**: SmartContracts had no `→`, Argument_Analysis had **no lateral nav at all** (navUp-only at L10), SymbolicLearning had neither `←` nor `→`. Wired additively:
- **SmartContracts**: add `Argument_Analysis →`
- **Argument_Analysis**: `← SmartContracts | ↑ SymbolicAI | SymbolicLearning →`
- **SymbolicLearning**: `← Argument_Analysis | ↑ SymbolicAI | SMT →`

**No existing link rewired, Lean untouched** (reserved to CoursIA-2 lane per dispatch). Full chain now consistent: `Tweety → SemanticWeb → Lean → Planners → SmartContracts → Argument_Analysis → SymbolicLearning → SMT` (SMT is the terminal meta-index → Z3 / Z3-Python).

### prereq — unify the block
- Section title → `## Prérequis` everywhere (Argument_Analysis & SemanticWeb were `## Prerequisites`, SymbolicLearning was `## Prerequis`).
- **Planners**: consolidate the split second `## Prérequis techniques` section into a `###` subsection under the single `## Prérequis` (fixes a structural inconsistency — two sibling `##` prereq sections).

## Validation
- Markdown-only (C.2 markdown-only exception — no notebook re-exec).
- Catalog byte-identical to main (rule HARD 1).
- No inbound anchor links to renamed sections (grep-verified); Planners heading-level demotion leaves slugs unchanged.
- Base: fresh `origin/main` `4b6578461` (rule HARD 2).

## Scope honesty (rule E)
~20 diff lines across 5 files. Low line-count because the fixes are surgical (nav-link lines, section headings) — but they close real coherence defects (dead-end nav chain, split prereq section). The **fuller harmonisation is deferred** because it is genuinely blocked, not skipped:
- **Head-rewire to root-ToC order**: root README lists `Tweety→Lean→SemanticWeb` but the established nav-chain has `Tweety→SemanticWeb→Lean` (Lean & SemanticWeb swapped). Resolving this needs (a) a canonical-order decision + (b) Lean (CoursIA-2 lane, excluded here).
- **Uniform `### Connaissances requises` sections** for the 3 series whose prereq is technical-only (Argument_Analysis, SemanticWeb, SmartContracts) needs pedagogical sign-off (subjective content authoring).

Both flagged to ai-01. This PR does not depend on either — it stands as a clean defect-fix.

See #2651.