### PR TITLE
docs(lean): add References to conway_lean + grothendieck_lean tribute READMEs (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -121,3 +121,24 @@ Kochen-Specker contradiction.
 - `evolveHashlifeFast`: exponential speedup via `padCenter2` + `hashlifeResult`, validated by `native_decide`
 - MacroCell round-trip verified by `#eval` and `native_decide` theorem
 - HashlifeMemo: memoization layer for pillar witnesses, `9^k` worst case reduced to tractable
+
+## References
+
+Foundational sources for the results formalized across the three phases. Each entry maps to a module of this workspace.
+
+- **Conway, J. H.** *On Numbers and Games* (ONAG). Academic Press, 1976; 2nd ed., A K Peters, 2001. — Conway's broader framework for combinatorial games (context for the games below).
+- **Bouton, C. L.** "Nim, A Game with a Complete Mathematical Theory." *Annals of Mathematics*, 2nd ser., 3(1-4) (1901-1902): 35-39. — Foundational analysis of Nim (`Nim.lean`).
+- **Conway, J. H.** "The Weird and Wonderful Chemistry of Audioactive Decay." *Eureka* 46 (1986): 5-16. — The Look-and-Say sequence (`LookAndSay.lean`).
+- **Conway, J. H.** "FRACTRAN: A Simple Universal Programming Language for Arithmetic." In *Open Problems in Communication and Computation* (Cover & Gopinath, eds.), Springer, 1987. — FRACTRAN (`Fractran.lean`).
+- **Conway, J. H.** "The Angel Problem." In *Games of No Chance*, MSRI Publications 29, Cambridge University Press, 1996. — The Angel vs Devil problem (`Angel.lean`).
+- Conway's **Doomsday** algorithm for day-of-week computation — the calendar anchor method formalized in `Doomsday.lean`.
+- The **Collatz** (3n+1) conjecture, Lothar Collatz (1937) — bounded instances handled via `native_decide` (`CollatzLike.lean`).
+- **Gardner, M.** "The Fantastic Combinations of John Conway's New Solitaire Game 'Life'." *Scientific American* 223(4) (October 1970): 120-123. — First public presentation of the Game of Life (`Life.lean`).
+- **Rokicki, T.** "An Algorithm for Compressing Space and Time." *Dr. Dobb's Journal* (2006). — The Hashlife algorithm (`Life/Hashlife.lean`).
+- **Rendell, P.** "A Universal Turing Machine in Conway's Game of Life." In *Collision-Based Computing* (Adamatzky, ed.), Springer, 2002. — Life as universal computation (`Life/Computation.lean`).
+- **Kochen, S.; Specker, E. P.** "The Problem of Hidden Variables in Quantum Mechanics." *Journal of Mathematics and Mechanics* 17(1) (1967): 59-81. — The original 117-vector theorem (`KochenSpecker.lean`).
+- **Cabello, A.; Estebaranz, J. M.; Garcia-Alcaine, G.** "Bell-Kochen-Specker Theorem: A Proof with 18 Vectors." *Physics Letters A* 212 (1996). — The 18-vector tight proof formalized in `KochenSpecker.lean`.
+- **Conway, J. H.; Kochen, S.** "The Free Will Theorem." *Foundations of Physics* 36(10) (2006): 1443-1473. — FWT from the SPIN, TWIN, and MIN axioms (`FreeWillTheorem.lean`).
+- **Conway, J. H.; Kochen, S.** "The Strong Free Will Theorem." *Notices of the American Mathematical Society* 56(2) (2009): 226-232.
+- **Peres, A.** "Two Simple Proofs of the Kochen-Specker Theorem." *Journal of Physics A* 24(4) (1991): L175-L178.
+- **Mermin, N. D.** "Hidden Variables and the Two Theorems of John Bell." *Reviews of Modern Physics* 65(3) (1993): 803-815.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -67,6 +67,18 @@ lake build Grothendieck
 
 Aligned with other SymbolicAI/Lean projects: `leanprover/lean4:v4.30.0-rc2`
 
+## References
+
+The language toured here — Grothendieck topologies, sites, sheaves, and schemes — originates in Grothendieck's algebraic geometry. These are the canonical entry points. This workspace is a pedagogical tour indexed against Mathlib, **not** a formalization of EGA/SGA.
+
+- **Mac Lane, S.; Moerdijk, I.** *Sheaves in Geometry and Logic: A First Introduction to Topos Theory*. Springer Universitext, 1992. — Standard reference for Grothendieck topologies, sieves, sites, and sheaves (Parts 1, 6-8, 10, 13-14).
+- **Artin, M.; Grothendieck, A.; Verdier, J. L.**, eds. *Theorie des topos et cohomologie etale des schemas* (SGA 4). Springer Lecture Notes in Mathematics 269, 270, 305, 1972-1973. — Origin of sites, Grothendieck topologies, and points of a topos (Parts 1, 15, 19).
+- **Grothendieck, A.; Dieudonne, J.** *Elements de geometrie algebrique* (EGA). Publications Mathematiques de l'IHES, 1960-1967. — Origin of schemes and the Zariski site (Parts 2-3).
+- **Vakil, R.** *The Rising Sea: Foundations of Algebraic Geometry*. — Widely used pedagogical notes in the Grothendieckian spirit.
+- **The Stacks Project.** [stacks.math.columbia.edu](https://stacks.math.columbia.edu) — Reference for schemes, sheafification, and sheaf cohomology (Parts 13, 20-23).
+- **The Mathlib Community.** *Mathlib4, Category Theory and Sites*. [mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/) — The library this tour indexes (Part 4); see de Moura & Ullrich, "The Lean 4 Theorem Prover" (2021).
+- **nLab.** [ncatlab.org](https://ncatlab.org) — Entries on Grothendieck topology, sieve, site, sheaf, and sheafification.
+
 ## See also
 
 - Epic #1646 (Grothendieck tribute)


### PR DESCRIPTION
## Summary

Delivers **#2651 prose Lean Partie 2** (ai-01 queue, cycle 23). `conway_lean/README.md` and `grothendieck_lean/README.md` both lacked an academic References section — unlike their sibling `knot_lean/README.md` (## References, L205) and the top-level `SymbolicAI/Lean/README.md` (### References academiques, L233). This PR adds `## References` to both, completing the symmetry across the three Lean tribute projects.

Each citation is **mapped to the formalized `.lean` module**, verified against the Modules tables in each README (anti-duplication / verify-before-claiming):

- **`conway_lean/README.md`** (+21): 16 references across the 3 phases — Bouton (Nim → `Nim.lean`), Conway (FRACTRAN `Fractran.lean`, Audioactive/Look-and-Say `LookAndSay.lean`, Angel Problem `Angel.lean`, Doomsday `Doomsday.lean`), Collatz `CollatzLike.lean`, Gardner (Life `Life.lean`), Rokicki (Hashlife `Life/Hashlife.lean`), Rendell (Life computation `Life/Computation.lean`), Kochen-Specker / Cabello / Conway-Kochen FWT / Peres / Mermin (`KochenSpecker.lean`, `FreeWillTheorem.lean`), plus ONAG as combinatorial-game context.
- **`grothendieck_lean/README.md`** (+12): 7 references for the topos foundations — Mac Lane & Moerdijk (Parts 1/6-8/10/13-14), SGA 4 (Parts 1/15/19), EGA (Parts 2-3), Vakil, Stacks Project (Parts 13/20-23), Mathlib4 (Part 4), nLab.

## Validation

- **Scope**: 2 files, +33 insertions, 0 deletions (pure additive — anti-regression clean).
- **No catalog churn**: `git diff --name-only | grep COURSE_CATALOG` = 0 (catalog byte-identical to `origin/main`, per catalog-pr-hygiene HARD 1).
- **No Lean code touched**: 0 `.lean` files in the diff (only README markdown).
- **Markdown well-formed**: References sections have proper blank lines; the pre-existing markdownlint warnings flagged by the IDE are all on lines I did **not** touch (the Modules tables, Hall of Fame, Purpose list) — left alone to keep the PR atomic.
- **§E justification**: grouped 2 coherent Lean-tribute READMEs with real bibliographic content (23 verifiable citations), parallel to the knot_lean model. Precedent: #3221 merged +18 lines of dense references with the same §E exception.

## Notes

- `See #2651` (partial contribution to the prose epic, not a full close).
- Language: EN to match each README's existing language (both are English technical READMEs; knot_lean is the French-language sibling).
- fox/col §9.1 + Conway P4/P5 = BG-prover ai-01 — not touched.