### PR TITLE
fix(lean-14c): guard load_pattern + add fetch_rle for gitignored gemini.rle (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-14c-Conway-Game-of-Life-Golly.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-14c-Conway-Game-of-Life-Golly.ipynb
@@ -15930,16 +15930,16 @@
    "id": "c556c880",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:28:10.437365Z",
-     "iopub.status.busy": "2026-06-09T04:28:10.436852Z",
-     "iopub.status.idle": "2026-06-09T04:28:10.469661Z",
-     "shell.execute_reply": "2026-06-09T04:28:10.468426Z"
+     "iopub.execute_input": "2026-06-17T10:05:50.834049Z",
+     "iopub.status.busy": "2026-06-17T10:05:50.834049Z",
+     "iopub.status.idle": "2026-06-17T10:05:50.846859Z",
+     "shell.execute_reply": "2026-06-17T10:05:50.846354Z"
     },
     "papermill": {
-     "duration": 0.059755,
-     "end_time": "2026-06-09T04:28:10.471533",
+     "duration": 0.028178,
+     "end_time": "2026-06-17T10:05:50.846859",
      "exception": false,
-     "start_time": "2026-06-09T04:28:10.411778",
+     "start_time": "2026-06-17T10:05:50.818681",
      "status": "completed"
     },
     "tags": []
@@ -15949,7 +15949,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Module hashlife charge depuis : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\conway_lean\\scripts\n",
+      "Module hashlife charge depuis : C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\conway_lean\\scripts\n",
       "Patterns disponibles : ['.gitignore', 'gemini.rle', 'otcametapixel.rle', 'p5760unitlifecell.rle', 'README.md', 'turingmachine.rle']\n"
      ]
     }
@@ -15994,9 +15994,35 @@
     "            break\n",
     "    return list(zip(xs, ys))\n",
     "\n",
-    "def load_pattern(name):\n",
-    "    \"\"\"Charge un pattern RLE depuis conway_lean/patterns/ et retourne (quadtree, n_cells, parse_time).\"\"\"\n",
+    "def fetch_rle(name):\n",
+    "    \"\"\"Recupere un pattern RLE absent du depot (gemini.rle = 5.3 MB, gitignore pour la taille).\n",
+    "    Telecharge depuis le miroir copy.sh/life avec cache disque (voir patterns/README.md).\n",
+    "    Retourne le path local, ou None si le telechargement echoue (le pilier sera alors skippe).\"\"\"\n",
+    "    import urllib.request\n",
     "    path = os.path.join(PATTERNS_DIR, name)\n",
+    "    if os.path.exists(path):\n",
+    "        return path\n",
+    "    url = f\"https://copy.sh/life/examples/{name}\"\n",
+    "    print(f\"  {name} absent du depot -- telechargement depuis {url} ...\")\n",
+    "    try:\n",
+    "        req = urllib.request.Request(url, headers={\"User-Agent\": \"Mozilla/5.0\"})\n",
+    "        with urllib.request.urlopen(req, timeout=120) as resp, open(path, \"wb\") as out:\n",
+    "            out.write(resp.read())\n",
+    "        print(f\"  {name} : telechargement OK ({os.path.getsize(path):,} octets, caches dans patterns/)\")\n",
+    "        return path\n",
+    "    except Exception as exc:\n",
+    "        print(f\"  {name} : echec telechargement ({type(exc).__name__}). Pilier skippe (voir patterns/README.md).\")\n",
+    "        return None\n",
+    "\n",
+    "def load_pattern(name):\n",
+    "    \"\"\"Charge un pattern RLE depuis conway_lean/patterns/ et retourne (quadtree, n_cells).\n",
+    "    Recupere le fichier via fetch_rle s'il est absent (gemini.rle = 5.3 MB gitignore).\n",
+    "    Retourne (None, 0) si le fichier reste indisponible : le pilier est alors skippe proprement.\"\"\"\n",
+    "    path = os.path.join(PATTERNS_DIR, name)\n",
+    "    if not os.path.exists(path):\n",
+    "        path = fetch_rle(name)\n",
+    "        if path is None:\n",
+    "            return None, 0\n",
     "    with open(path, \"r\", encoding=\"utf-8\") as f:\n",
     "        text = f.read()\n",
     "    t0 = time.perf_counter()\n",
@@ -16269,16 +16295,16 @@
    "id": "885d248e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:28:28.664760Z",
-     "iopub.status.busy": "2026-06-09T04:28:28.664401Z",
-     "iopub.status.idle": "2026-06-09T04:38:43.044858Z",
-     "shell.execute_reply": "2026-06-09T04:38:43.043695Z"
+     "iopub.execute_input": "2026-06-17T10:06:01.384363Z",
+     "iopub.status.busy": "2026-06-17T10:06:01.383365Z",
+     "iopub.status.idle": "2026-06-17T10:12:33.955832Z",
+     "shell.execute_reply": "2026-06-17T10:12:33.955832Z"
     },
     "papermill": {
-     "duration": 614.424393,
-     "end_time": "2026-06-09T04:38:43.060992",
+     "duration": 392.590143,
+     "end_time": "2026-06-17T10:12:33.957373",
      "exception": false,
-     "start_time": "2026-06-09T04:28:28.636599",
+     "start_time": "2026-06-17T10:06:01.367230",
      "status": "completed"
     },
     "tags": []
@@ -16303,7 +16329,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  gemini.rle : 846,278 cellules, quadtree k=25 (33554432x33554432), parse=1.24s, build=441.32s\n",
+      "  gemini.rle : 846,278 cellules, quadtree k=25 (33554432x33554432), parse=0.62s, build=267.55s\n",
       "Population initiale : 846,278 cellules\n",
       "\n"
      ]
@@ -16312,17 +16338,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  advance(100,000 generations) : population=846,882, temps=171.78s\n",
+      "  advance(100,000 generations) : population=846,882, temps=124.37s\n",
       "\n",
       "Resultat : apres 100,000 generations :\n",
       "  Population initiale  : 846,278\n",
       "  Population finale    : 846,882\n",
       "  Difference           : +604 cellules\n",
-      "  Temps HashLife       : 171.78s\n",
+      "  Temps HashLife       : 124.37s\n",
       "\n",
       "Pour atteindre les 33 699 586 generations completes, HashLife le peut :\n",
       "le temps croit logarithmiquement (O(log G)), pas lineairement.\n",
-      "Estimation pour 33.6M generations : ~1718s (HashLife compresse les repetitions temporelles).\n",
+      "Estimation pour 33.6M generations : ~1244s (HashLife compresse les repetitions temporelles).\n",
       "\n",
       "Gemini est le flagship : auto-replication dans la regle B3/S23.\n"
      ]
@@ -16341,26 +16367,32 @@
     "print()\n",
     "\n",
     "gemini_node, gemini_cells = load_pattern(\"gemini.rle\")\n",
-    "print(f\"Population initiale : {gemini_node.n:,} cellules\")\n",
-    "print()\n",
+    "if gemini_node is None:\n",
+    "    # gemini.rle (5.3 MB) est gitignore : absent d'un clone frais. Pilier skippe proprement\n",
+    "    # plutot que de planter (fetch_rle a deja tente le telechargement ; voir patterns/README.md).\n",
+    "    print(\"Pilier 3 skippe : gemini.rle indisponible (5.3 MB, gitignore).\")\n",
+    "    print(\"Pour l'executer : telecharger gemini.rle (voir conway_lean/patterns/README.md).\")\n",
+    "else:\n",
+    "    print(f\"Population initiale : {gemini_node.n:,} cellules\")\n",
+    "    print()\n",
     "\n",
-    "GEMINI_GENS = 100_000\n",
-    "gemini_result, gemini_time = run_hashlife(gemini_node, GEMINI_GENS)\n",
+    "    GEMINI_GENS = 100_000\n",
+    "    gemini_result, gemini_time = run_hashlife(gemini_node, GEMINI_GENS)\n",
     "\n",
-    "pop_diff_g = gemini_result.n - gemini_node.n\n",
-    "print()\n",
-    "print(f\"Resultat : apres {GEMINI_GENS:,} generations :\")\n",
-    "print(f\"  Population initiale  : {gemini_node.n:,}\")\n",
-    "print(f\"  Population finale    : {gemini_result.n:,}\")\n",
-    "print(f\"  Difference           : {pop_diff_g:+,} cellules\")\n",
-    "print(f\"  Temps HashLife       : {gemini_time:.2f}s\")\n",
-    "print()\n",
-    "print(f\"Pour atteindre les 33 699 586 generations completes, HashLife le peut :\")\n",
-    "print(f\"le temps croit logarithmiquement (O(log G)), pas lineairement.\")\n",
-    "print(f\"Estimation pour 33.6M generations : ~{gemini_time * 10:.0f}s \" +\n",
-    "      f\"(HashLife compresse les repetitions temporelles).\")\n",
-    "print()\n",
-    "print(\"Gemini est le flagship : auto-replication dans la regle B3/S23.\")"
+    "    pop_diff_g = gemini_result.n - gemini_node.n\n",
+    "    print()\n",
+    "    print(f\"Resultat : apres {GEMINI_GENS:,} generations :\")\n",
+    "    print(f\"  Population initiale  : {gemini_node.n:,}\")\n",
+    "    print(f\"  Population finale    : {gemini_result.n:,}\")\n",
+    "    print(f\"  Difference           : {pop_diff_g:+,} cellules\")\n",
+    "    print(f\"  Temps HashLife       : {gemini_time:.2f}s\")\n",
+    "    print()\n",
+    "    print(f\"Pour atteindre les 33 699 586 generations completes, HashLife le peut :\")\n",
+    "    print(f\"le temps croit logarithmiquement (O(log G)), pas lineairement.\")\n",
+    "    print(f\"Estimation pour 33.6M generations : ~{gemini_time * 10:.0f}s \" +\n",
+    "          f\"(HashLife compresse les repetitions temporelles).\")\n",
+    "    print()\n",
+    "    print(\"Gemini est le flagship : auto-replication dans la regle B3/S23.\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

A fresh-clone re-exec of Lean-14c crashed on the **Gemini (Pilier 3)** pillar: `gemini.rle` (5.3 MB) is gitignored for size, and `load_pattern` did a bare `open()` with no fallback. Worse, `conway_lean/patterns/README.md` documented a `fetch_rle()` helper that **did not exist**.

This PR makes the notebook robust to a fresh clone (no crash) and makes the README's documented contract true.

## Changes (2 cells, surgical — 70 insertions / 38 deletions)

- **`load_pattern` cell (`c556c880`)**:
  - Added `fetch_rle(name)` — downloads from the `copy.sh/life` mirror with disk caching (returns the cached path on subsequent runs), Mozilla UA, returns `None` on failure. Faithful to `patterns/README.md` (same mirror URL, same UA, "handles this gracefully with disk caching").
  - `load_pattern` now calls `fetch_rle` when the file is absent and returns a `(None, 0)` sentinel when it stays unavailable, instead of raising `FileNotFoundError`.
- **Gemini cell (`885d248e`)**: guards on the sentinel and skips cleanly with a pointer to `patterns/README.md`, rather than crashing.

The `otcametapixel` / `turingmachine` cells are untouched (committed files, never `None`).

## Verification (rule C.2 / review §D)

- **papermill re-exec: SUCCESS, 415s, 0 error outputs** notebook-wide.
- **Gemini simulation reproduced** (deterministic): `gemini.rle : 846,278 cellules, quadtree k=25 (33554432x33554432)` → `advance(100,000 generations) : population=846,882` (**+604**).
- OTCA (64,691→64,697) and Turing (36,549→36,286) pillars unchanged.
- **C.1**: 0 `raise NotImplementedError` / `assert False` / `1/0`.
- **C.2**: all code cells have `execution_count` 1-18 set with coherent outputs; none `ec=None`.
- **C.3**: only this notebook staged; the 46 unchanged cells are byte-identical to `main` (no papermill timestamp churn — the diff is the 2 changed cells only).

## Context

Found during the **cycle-24 broadened C.2 audit** (greenlit ai-01). The audit itself returned **CLEAN** — reader-thread was the only silent-drop mechanism, fully hunted via #3216 / #3222 / #3224; the `gemini.rle` gap is an adjacent fresh-clone robustness issue, not a silent drop.

See #2161 (robustness contribution, not a full issue resolution).
