### PR TITLE
docs(iit): ground README notebook tables in actual PyPhi content (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -31,8 +31,8 @@ Le premier notebook couvre le spectre fondamental : construction de graphes caus
 
 | # | Notebook | Contenu | Durée |
 |---|----------|---------|-------|
-| 1 | [Intro_to_PyPhi](Intro_to_PyPhi.ipynb) | Introduction complète à PyPhi et IIT | 60-90 min |
-| 2 | [IIT-2-AdvancedTopics](IIT-2-AdvancedTopics.ipynb) | Partitionnement MIP, répertoires, MICE, réseaux élargis | 60-90 min |
+| 1 | [Intro_to_PyPhi](Intro_to_PyPhi.ipynb) | Réseau XOR 3-nœuds : TPM, calcul de Φ, CES, états inaccessibles, causation | 60-90 min |
+| 2 | [IIT-2-AdvancedTopics](IIT-2-AdvancedTopics.ipynb) | MIP et bipartitions, répertoires cause-effet, MICE, big Φ sur réseau 4-nœuds, coarse-graining | 60-90 min |
 
 ## Parcours recommandés
 
@@ -53,7 +53,7 @@ Notebook 2 (Sujets avancés)
 
 **Phase 1 : Fondements (~90 min, notebook 1)**
 
-Vous installez PyPhi dans un environnement conda dédié (Python 3.9 obligatoire), puis construisez votre premier réseau causal binaire. Le calcul de Phi sur un réseau XOR à 3 nœuds illustre concrètement la notion d'intégration irréductible. L'exploration de la CES révèle comment un système "spécifie" sa propre géométrie informationnelle. Les 4 exercices vous font varier les sous-systèmes, les topologies de réseau et les paramètres pour développer une intuition sur ce qui fait monter ou baisser Phi.
+Vous installez PyPhi dans un environnement conda dédié (Python 3.9 obligatoire), puis construisez votre premier réseau causal binaire. Le calcul de Phi sur un réseau XOR à 3 nœuds illustre concrètement la notion d'intégration irréductible. L'exploration de la CES révèle comment un système "spécifie" sa propre géométrie informationnelle. Les 3 exercices vous font varier les sous-systèmes (partiel, porte AND) et explorer les concepts de la CES pour développer une intuition sur ce qui fait monter ou baisser Phi.
 
 **Phase 2 : Approfondissement (~90 min, notebook 2)**
 
@@ -65,26 +65,27 @@ Le deuxième notebook déconstruit le calcul de Phi : vous manipulez les biparti
 
 | Section | Contenu |
 |---------|---------|
-| Installation | Configuration PyPhi, environnement conda |
-| Réseaux | Création de circuits/graphes, nœuds binaires |
-| TPM | Transition Probability Matrices, règles d'évolution |
-| Sous-systèmes | Définition, calcul de Phi |
-| CES | Cause-Effect Structures, mécanismes |
-| Causation actuelle | Liens causaux entre éléments |
-| Macro-sous-systèmes | Coarse-graining, blackboxing |
+| Installation | `pip install pyphi`, vérification de la version de la bibliothèque |
+| Réseaux | Réseau XOR 3-nœuds de référence, inspection des `node_labels` |
+| TPM | Conversion *state-by-node*, dimensions de la matrice de transition |
+| Sous-systèmes & Φ | Calcul de Φ d'un sous-système à un état donné, boucle sur plusieurs états |
+| États inaccessibles | Validation via `StateUnreachableError`, option `VALIDATE_SUBSYSTEM_STATES` |
+| CES | `pyphi.compute.ces`, décompte des concepts d'un sous-système |
+| Causation actuelle | Liens causaux d'une transition (`account`), mécanisme d'un concept |
+| Macro-sous-systèmes | Coarse-graining, blackboxing (section conceptuelle) |
 
 ### IIT-2-AdvancedTopics.ipynb
 
 | Section | Contenu |
 |---------|---------|
-| Rappels | Reprise des concepts du notebook 1 |
-| Partitionnement MIP | Coupes minimales d'information, bipartitions |
-| Répertoires cause-effet | Distributions cause, effet, non-perturbées |
-| MICE et concepts | Mécanismes maximalement irréductibles |
-| Big Phi vs Small Phi | Comparaison niveau système vs mécanisme |
-| Réseaux élargis | Systèmes 4+ nœuds, interprétation |
-| Performance | Coarse-graining, timing, complexité |
-| IIT 4.0 | Concept-style, évolutions récentes, débats |
+| Rappels | Réseau XOR 3-nœuds, reprise des concepts du notebook 1 |
+| Partitionnement MIP | `bipartition`, décompte des partitions, interprétation de la coupe minimale |
+| Répertoires cause-effet | Répertoires cause, effet et non-perturbé d'un mécanisme donné |
+| MICE et concepts | MICE du mécanisme {A,B}, décompte des concepts de la CES |
+| Big Phi vs Small Phi | Big Phi au niveau système (SIA) face au small phi d'un mécanisme (MICE) |
+| Réseaux élargis | Réseau 4-nœuds en anneau (XOR cyclique), Φ sur système élargi |
+| Performance | Timing du calcul de CES, module `pyphi.macro` |
+| IIT 4.0 | Concept-Style SIA, limites computationnelles, débats |
 
 ## Concepts clés
 


### PR DESCRIPTION
## Summary

#2651 fidelity + grounding pass on the IIT series README. Aligns the three notebook tables with what the two notebooks **actually demonstrate** (gabarit fidelity L75 + grounding L87). Every entry verified by reading both notebooks cell-by-cell — no invented content.

## Changes

- **Top "Notebooks" table** — generic entries grounded to demonstrated content (XOR 3-nœuds, TPM, CES, états inaccessibles, causation / MIP-bipartitions, MICE, big Φ sur réseau 4-nœuds, coarse-graining).
- **Notebook 1 "Contenu détaillé"** — descriptions grounded to real functions (`pyphi.compute.ces`, `node_labels`, *state-by-node*) **+ added the missing "États inaccessibles" section** (`StateUnreachableError` / `VALIDATE_SUBSYSTEM_STATES`, notebook cells c10–c13) that was absent from the table.
- **Notebook 2 "Contenu détaillé"** — grounded to real functions/networks (`bipartition`, mécanisme {A,B}, réseau 4-nœuds en anneau, `pyphi.macro`).
- **Phase 1 parcours prose** — corrected an over-count: "Les **4** exercices" → "Les **3** exercices" (notebook 1 actually has 3: Ex1 sous-système partiel, Ex2 concepts CES, unnumbered porte-AND), and grounded the exercise descriptions.

## Verification (G.1)

- Exercise counts confirmed by direct notebook scan (not keyword heuristic): NB1 = 3 (Ex1 `c15`, Ex2 `c21`, unnumbered `c28`), NB2 = 3.
- All function names / network names in the grounded tables taken verbatim from the notebook sources (`pyphi.compute.ces`, `from pyphi.partition import bipartition`, `network.node_labels`, `tpm_4` "Réseau 4 nœuds en anneau (XOR cyclique)", `pyphi.macro`, `account`).
- Rebase onto fresh `origin/main` (d12ba1b4) — clean, 0 conflicts.

## Notes for the coordinator

- **No bridges section added.** The gabarit lists generic "Cross-series bridges" blocks as **anti-pattern 3** (to be removed, not added); PR #2829 already removed IIT's generic bridges table as part of #2651 harmonization. Adding one back would contradict the epic.
- **IIT is near-saturated for #2651**: gabarit-compliant (all obligatory sections present), both notebooks already at the 3-exercices #2161 threshold, no open PRs. This fidelity pass was the cleanest remaining grain; the QC 3-exos fallback has no clean target either (QC .ipynb are vendored partner-course / research / pipeline artifacts, not pedagogical exercise notebooks). Flagging so the lane can redirect next cycle.

README-only change → no notebook edited → no re-execution needed.

See #2651
