### PR TITLE
docs(lean-5): enrich Tactics sections 7-9 with grounded interpretation cells (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
@@ -2569,6 +2569,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b7441001",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Le point `·` (bullet) **focalise** un sous-but : chaque `·` ouvre un bloc dedie a un seul but restant, et Lean verifie qu'il est entierement clos avant de passer au suivant. C'est plus sur que d'enchainer les tactiques nues, car une tactique laissant un but ouvert est immediatement signalee. On obtient une preuve lisible ou chaque branche est isolee."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "81603479",
    "metadata": {
     "papermill": {
@@ -2670,6 +2680,16 @@
     "  case inr hq =>\n",
     "    left\n",
     "    exact hq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7461002",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "`case` (ou la syntaxe `with | nom => ...`) permet de **nommer explicitement** chaque branche issue d'un `cases`. Indispensable quand les branches appellent des tactiques differentes, ou simplement pour documenter l'intention : le lecteur voit immediatement quelle hypothese traite quel cas."
    ]
   },
   {
@@ -2781,6 +2801,21 @@
     "-- Plus lisible avec repeat\n",
     "theorem repeat_example (p : Prop) (hp : p) : p /\\ p /\\ p := by\n",
     "  refine ⟨?_, ?_, ?_⟩ <;> exact hp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7481003",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Deux combinateurs subtilement differents :\n",
+    "\n",
+    "- `t1 ; t2` execute `t1` **puis** `t2` dans le **meme** but (sequence simple).\n",
+    "- `t1 <;> t2` execute `t1`, puis applique `t2` a **chacun** des sous-buts crees par `t1` (distribution).\n",
+    "\n",
+    "`<;>` est l'outil idiomatique pour traiter uniformement tous les cas ouverts par un `cases` ou un `constructor`."
    ]
   },
   {
@@ -2935,6 +2970,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b7501004",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "`induction` genere deux sous-buts canoniques : le **cas de base** (`zero`, ici `n = 0`) et le **cas inductif** (`succ n ih`, ou `ih` est l'hypothese de recurrence portant sur `n`). C'est le squelette universel des preuves par recurrence sur `Nat` ; la meme structure s'applique aux listes, arbres et tout type inductif."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "edb2e20d",
    "metadata": {
     "papermill": {
@@ -3037,6 +3082,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b7521005",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "`decide` prouve une proposition **decidable** en l'evaluant par calcul. Puissant pour les inegalites numeriques et les proprietes finies, mais **impuissant** sur les propositions quantifiees ou non calculables (il echoue alors proprement plutot que de boucler). C'est l'equivalent preuve-par-calcul de `rfl` pour les booleens."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "636978fd",
    "metadata": {
     "papermill": {
@@ -3132,6 +3187,16 @@
     "theorem omega_complex (a b c : Nat)\n",
     "  (h1 : a + b < c) (h2 : c < 2 * a + b) : a > 0 := by\n",
     "  omega"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7541006",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "`omega` est un **decideur d'arithmetique de Presburger** : il resout automatiquement les buts melant `+`, `-`, comparaisons (`<`, `<=`, `=`) et variables entieres/naturelles. Sa limite : il **ne traite pas la multiplication de deux variables** (`n * m`). Pour l'algebre non-lineaire, il faut `ring` (Mathlib) ou `nlinarith`."
    ]
   },
   {
@@ -3360,6 +3425,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b7581007",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Le mode tactique peut s'**imbriquer** au c?ur d'un terme : `by ...` ouvre un bloc tactique n'importe ou un terme est attendu. Cela permet le style **hybride** -- construire la preuve majoritairement en mode terme (ici un couple anonyme) tout en reservant `by` aux sous-buts qui beneficient d'une approche tactique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c856651d",
    "metadata": {
     "papermill": {
@@ -3458,6 +3533,16 @@
     "theorem show_from (p q : Prop) (hp : p) (hq : q) : p /\\ q := by\n",
     "  show p /\\ q\n",
     "  exact And.intro hp hq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7601008",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Reciproquement, `exact` accepte **n'importe quel terme** en mode tactique : on peut clore un but en mode tactique avec un terme de preuve pur (le constructeur anonyme de la conjonction). Les deux modes sont donc interchangeables au niveau des feuilles de preuve ; le choix est une question de **lisibilite** et de **style**."
    ]
   },
   {


### PR DESCRIPTION
## Summary

`Lean-5-Tactics` was the **thinnest-prose** notebook in the Lean-1..17 series (scan: 228 chars of markdown per code cell, vs 1900-3700 for the Conway/Grothendieck/tribute notebooks). The thinness was concentrated in **sections 7-9** (Proof structuration, Advanced tactics, Term/tactic hybrid): the advanced tactics (`induction`, `decide`, `omega`, `ring`) and structuration (`·` bullets, `case`, `;`/`<;>` combinators) got only a one-line header each, with **zero post-code interpretation** explaining what each tactic achieves.

This PR adds **8 grounded interpretation cells** after those code cells.

Greenlit by ai-01 (COORD 2026-06-17 10:48Z): audit C.2 Lean-adjacents was CLEAN → fallback = `#2651` prose on the **bodies** of Lean-1..17 notebooks (my turf, NOT the saturated READMEs).

## Changes (1 notebook, +85/-0, pure addition)

8 new markdown cells inserted after the code cells they interpret:

| After cell | Tactic | Interpretation grounded in |
|---|---|---|
| `·` bullets | structuration | focalisation d'un sous-but, isolement des branches |
| `case` | structuration | nommage explicite des branches issues de `cases` |
| `;` / `<;>` | combinators | sequence (même but) vs distribution (tous les sous-buts) |
| `induction` | advanced | cas de base `zero` + cas inductif `succ n ih` (squelette universel) |
| `decide` | advanced | décidabilité par calcul, limite (propositions quantifiées) |
| `omega` | advanced | Presburger (linéaire), limite (multiplication de variables) |
| `by` in term | hybrid | imbrication mode tactique au cœur d'un terme |
| term in tactic | hybrid | `exact` accepte n'importe quel terme (constructeur anonyme) |

Content is **specific and grounded** in each cell's actual committed output (per the rule: interpretation cells = pédagogie spécifique, not generic "Suite du traitement").

## Verification (rule C.2 / review §D — markdown-only)

- **Markdown-only → C.2 exception** (modifs uniquement markdown, outputs précédents valides) : no re-execution required. All 34 code cells keep their committed outputs.
- **`notebook_tools validate`**: OK (0 errors, 0 warnings).
- **`check_c2_compliance`**: 1/1 notebooks compliant.
- **Anti-régression**: 85 insertions / **0 deletions** — no code or proof cell touched. Kernel `lean4` intact. 34 code cells, `execution_count` 1-34 monotone, **0 code cells lost their outputs**.
- **C.3**: only this notebook staged.

## Context

Found during the **cycle-26 C.2 audit** of Lean-adjacent families (GameTheory/Probas/Sudoku, 104 notebooks) — that audit returned **CLEAN** (0 unexecuted, 0 error-outputs, 0 silent-drops, 0 fresh-clone data-asset loads; the only ec-set+empty-output cells were 8 legit Python statements). The Lean-adjacent Lean notebooks use the native `lean4`/`lean4-wsl` kernel (rich Alectryon output), not the python3+`run_lean` wrapper of SymbolicAI/Lean — hence immune to the reader-thread silent-drop, so the systemic fix #3224 correctly does not extend to them.

Per ai-01's grain, the clean audit's fallback is `#2651` prose on Lean notebook **bodies**.

See #2651 (prose Lean notebook bodies, partial contribution).
