### PR TITLE
docs(lean-4): enrich Quantifiers sections 6-7 with grounded interpretation cells (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-4-Quantifiers.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-4-Quantifiers.ipynb
@@ -2364,6 +2364,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "q4302001",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Cette preuve illustre la **substitution sous un quantificateur** : de l'egalite `a = b` et de l'hypothese universelle `∀ n, P n`, on derive `P b` (appliquer `hp`, puis reecrire par l'egalite). C'est le patron standard `intro` puis `rw` pour faire traverser une egalite sous un binder -- technique omnipresente dans les preuves sur les structures parametrees."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "77909326",
    "metadata": {
     "papermill": {
@@ -2481,6 +2491,16 @@
     "\n",
     "theorem f_eq_g : f = g :=\n",
     "  funext (fun n => Nat.add_zero n)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "q4322002",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "L'**extensionnalite fonctionnelle** (`funext`) est un **axiome** de Lean : deux fonctions `f g : A -> B` sont egales des qu'elles coincident pointwise (`∀ x, f x = g x`). Ce n'est PAS demonstrable a partir des autres axiomes -- dans le calcul des constructions, deux fonctions `fun x => ...` syntaxtiquement differentes mais extensionnellement egales ne sont pas `rfl`. `funext` est l'outil pour egaliser de telles fonctions ; sans lui, l'unicite ne vaudrait que pour les fonctions syntaxiquement identiques."
    ]
   },
   {
@@ -2631,6 +2651,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "q4342003",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "La divisibilite est encodee **existentiellement** : `a ∣ b` signifie « il existe un entier `k` tel que `b = a * k` ». Cette definition pose `divides` comme une **proposition** (`Prop`), pas un booleen -- c'est un outil de raisonnement. La notation infixe `a ∣ b` (caractere `∣`, U+2223) se lit « a divise b ». Pour prouver `a ∣ b`, on fournit le **temoin** `k` ; pour l'utiliser, on extrait `k` par analyse de l'existence."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "39eae17a",
    "metadata": {
     "papermill": {
@@ -2773,6 +2803,16 @@
     "    ⟨k1 * k2, calc c = b * k2       := hk2\n",
     "                   _ = (a * k1) * k2 := congrArg (· * k2) hk1\n",
     "                   _ = a * (k1 * k2) := Nat.mul_assoc a k1 k2⟩"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "q4362004",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "La **transitivite** (`a ∣ b -> b ∣ c -> a ∣ c`) se prouve en deroulant la definition existentielle : si `b = a * k` et `c = b * j`, alors `c = a * (k * j)`, et le temoin final est `k * j`. C'est le patron universel des transitivites sur relations definies par existence : **combiner les temoins**. La recurrence sur la structure des hypotheses produit mecaniquement le temoin composite."
    ]
   },
   {


### PR DESCRIPTION
## Summary

`Lean-4-Quantifiers` was the **2nd thinnest-prose** Lean foundational notebook (351 md-chars/code-cell). Sections 1-5 are well-prosed, but **sections 6-7** had only bare headers (cell 31 "### 6.2 Egalite fonctionnelle" = 29 chars) with **zero post-code interpretation** for the high-value concepts: function extensionality (an axiom), divisibility-as-∃, and the transitivity proof.

Continues the Lean notebook-body prose rollout (`#2651`) greenlit by ai-01 (COORD 11:55Z: "prose sur les CORPS des notebooks Lean-1..17, PAS les READMEs. Brule dans l'ordre, NE m'attends PAS"). Follows **#3235** (Lean-5-Tactics, same pattern, now CLEAN/MERGEABLE).

## Changes (1 notebook, +40/-0, pure addition)

4 new markdown interpretation cells inserted after the code cells they interpret:

| After cell | Concept | Interpretation grounded in |
|---|---|---|
| `subst_in_forall` | substitution under a binder | the `intro` + `rw` pattern to make equality cross a ∀ |
| `funext` (#check) | function extensionality | **it's an AXIOM** — pointwise equality ⇒ function equality; not provable, not `rfl`; why it's needed |
| `divides` def | divisibility as ∃ | `a ∣ b := ∃ k, b = a*k` as a `Prop` (reasoning tool), U+2223 notation, witness intro/elim |
| transitivity | `a∣b → b∣c → a∣c` | unroll ∃, **combine witnesses** (`k*j`) — the universal pattern for ∃-defined relations |

Content is specific and grounded in each cell's actual committed output.

## Verification (rule C.2 / review §D — markdown-only)

- **Markdown-only → C.2 exception**: no re-execution required. All 25 code cells keep their committed outputs.
- **`notebook_tools validate`**: OK (0 errors, 0 warnings).
- **`check_c2_compliance`**: 1/1 compliant.
- **Anti-régression**: 40 insertions / **0 deletions** — no code/proof touched. Kernel `lean4-wsl` intact. 25 code cells ec 1-25 monotone, 0 lost outputs.
- **C.3**: only this notebook staged.

## Context

Same cycle-27 grain as #3235: ai-01's `#2651` Lean notebook-body prose rollout. The thin-prose scan (code:md ratio + consecutive-code-run) ranked Lean-4-Quantifiers next after Lean-5-Tactics. Sections 6-7 (equality + quantifiers, divisibility examples) were the gap.

See #2651 (prose Lean notebook bodies, partial contribution).
