### PR TITLE
docs(mlnet): harmonize README to gabarit (#2651) - drop bandeau chiffres + generic bridges

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -9,21 +9,11 @@ maturity: PRODUCTION=7, ALPHA=1
 
 [← ML (série parente)](../README.md) | [DataScienceWithAgents (Python) →](../DataScienceWithAgents/README.md) | [Probas/Infer.NET →](../../Probas/Infer/README.md)
 
-Série de notebooks couvrant ML.NET, la bibliothèque open-source de Microsoft pour le Machine Learning dans l'écosystème .NET.
-
-ML.NET apporte le machine learning **nativement dans l'écosystème .NET** : on entraîne et on consomme des modèles directement en C#, sans quitter sa stack applicative ni dépendre d'un runtime Python. C'est un choix pensé pour les développeurs autant que pour les data scientists — l'AutoML abaisse la barrière d'entrée, et les modèles s'exécutent *in-process* dans des applications existantes (API web, services, desktop). L'interopérabilité **ONNX** permet d'importer des modèles entraînés ailleurs (scikit-learn, PyTorch, Hugging Face) et de les servir côté .NET : ML.NET devient ainsi un pont concret entre la recherche en Python et la production en entreprise.
+ML.NET — la bibliothèque open-source de Microsoft — apporte le machine learning **nativement dans l'écosystème .NET** : on entraîne et on consomme des modèles directement en C#, sans quitter sa stack applicative ni dépendre d'un runtime Python. C'est un choix pensé pour les développeurs autant que pour les data scientists — l'AutoML abaisse la barrière d'entrée, et les modèles s'exécutent *in-process* dans des applications existantes (API web, services, desktop). L'interopérabilité **ONNX** permet d'importer des modèles entraînés ailleurs (scikit-learn, PyTorch, Hugging Face) et de les servir côté .NET : ML.NET devient ainsi un pont concret entre la recherche en Python et la production en entreprise.
 
 Le parcours va du premier pipeline (ML-1) jusqu'à une application complète : préparation des données et feature engineering (ML-2), entraînement et AutoML (ML-3), évaluation rigoureuse par cross-validation et importance des variables (ML-4), puis les fonctionnalités avancées — prévision de séries temporelles par SSA (ML-5), interopérabilité ONNX (ML-6) et systèmes de recommandation (ML-7) — avant un TP capstone qui marie ML.NET et la régression bayésienne d'Infer.NET.
 
 > **À qui s'adresse cette série** : développeurs C#/.NET découvrant le Machine Learning, équipes enterprise souhaitant intégrer du ML sans sortir de leur stack .NET, ou data scientists souhaitant servir des modèles en production dans des applications C#. Aucun prérequis en statistiques avancées — les concepts sont introduits progressivement dans chaque notebook.
-
-## Vue d'ensemble
-
-| Statistique | Valeur |
-|-------------|--------|
-| Notebooks | 8 (5 fondamentaux + 3 avancés + 1 TP) |
-| Kernel | .NET C# |
-| Durée estimée | ~5-6h |
 
 ## Objectifs d'apprentissage
 
@@ -167,7 +157,7 @@ Avoir une intuition de ces concepts aidera, mais ils sont **expliqués dans les 
 | Régression bayésienne | Prévision avec incertitude |
 | Application | Cas d'usage ventes |
 
-### ML-5-TimeSeries (Nouveau)
+### ML-5-TimeSeries
 
 | Section | Contenu |
 |---------|---------|
@@ -176,7 +166,7 @@ Avoir une intuition de ces concepts aidera, mais ils sont **expliqués dans les 
 | AutoML | Optimisation d'hyperparamètres |
 | Intervalles de confiance | Quantification de l'incertitude |
 
-### ML-6-ONNX (Nouveau)
+### ML-6-ONNX
 
 | Section | Contenu |
 |---------|---------|
@@ -185,7 +175,7 @@ Avoir une intuition de ces concepts aidera, mais ils sont **expliqués dans les 
 | Export ML.NET | Sauvegarder en ONNX |
 | Hugging Face | Intégration BERT, Whisper |
 
-### ML-7-Recommendation (Nouveau)
+### ML-7-Recommendation
 
 | Section | Contenu |
 |---------|---------|
@@ -215,7 +205,7 @@ dotnet interactive jupyter install
 jupyter kernelspec list  # doit montrer .net-csharp
 ```
 
-## Prerequisites
+## Dépendances (packages NuGet)
 
 ```bash
 # Packages (installés via #r dans notebooks, pas de pip)
@@ -368,7 +358,4 @@ Voir la licence du repository principal.
 | Série | Lien | Connexion |
 |-------|------|------------|
 | [Probas/Infer](../../Probas/Infer/README.md) | Régression bayésienne | Le TP capstone utilise Infer.NET, le même moteur probabiliste de la série Probas |
-| [Search](../../Search/README.md) | Optimisation | L'AutoML (ML-3) et la détection de saisonnalité (ML-5) utilisent des techniques de recherche et optimisation |
-| [QuantConnect](../../QuantConnect/README.md) | Trading algorithmique | Les modèles de prévision de séries temporelles (ML-5) s'appliquent directement aux stratégies de trading |
 | [GenAI](../../GenAI/README.md) | IA générative | Les modèles ONNX (ML-6) servent à déployer des LLMs et modèles NLP (BERT, Whisper) via ONNX Runtime dans .NET |
-| [DataScienceWithAgents](../DataScienceWithAgents/README.md) | Python ML | Les mêmes concepts ML.NET existent en Python via scikit-learn dans le track DataScienceWithAgents |


### PR DESCRIPTION
## Summary

#2651 Partie 2 harmonization of the **ML.Net** sub-series README against [`docs/reference/readme-series-gabarit.md`](docs/reference/readme-series-gabarit.md). Non-destructive anti-pattern removal + dedup on a single file — follows the #2829 precedent (which harmonized ML/Search/Probas/IIT).

## Changes (5 edits, +5/-18)

1. **Pitch dedup** — the thin 1-line opener ("Série de notebooks couvrant ML.NET...") was fully subsumed by the rich pitch paragraph below it. Merged the unique detail ("open-source de Microsoft") into the pitch. Harmonized READMEs open directly on the pitch (cf. IIT exemplar).
2. **Anti-pattern 1 removed** (gabarit L30, L64, L76: "Pas de bandeau de chiffres en ouverture") — dropped the "## Vue d'ensemble" stats bandeau (manual `8 notebooks / .NET C# / ~5-6h`). The count already lives in CATALOG-STATUS (`pedagogical_count: 8`) and the parcours; manual decompts "rouilleront".
3. **Stale temporal markers** — dropped "(Nouveau)" on ML-5/ML-6/ML-7 (these 2024-2025 features are now established). Gabarit "ton sobre".
4. **French consistency** — renamed the English `## Prerequisites` header to `## Dépendances (packages NuGet)` (the README is French-primary; the knowledge prereqs section above is "Prérequis détaillés").
5. **Anti-pattern 3 trimmed** (gabarit L54, L66: a pont must name the concept *des deux côtés*) — retired 3 bridge rows whose other side is generic (Search, QuantConnect, DataScienceWithAgents); **kept** the 2 ponts specific to both sides (Probas/Infer ↔ TP capstone Infer.NET; GenAI ↔ ML-6 ONNX / BERT / Whisper).

## What I deliberately did NOT do (G.1)

- **Did NOT cut the FAQ** (76 lines) — it is genuine operational troubleshooting (install, dataset path, ONNX export, metric diagnostics), not bloat. Cutting would lose real solutions (anti-regression). Gabarit anti-pattern 4 targets bloat, not useful troubleshooting.
- **Did NOT remove the bridges block wholesale** — 2 of the 5 rows are valid specific ponts the gabarit explicitly permits (§9). Only the 3 generic rows were retired.
- **Did NOT add a "Kernel" column** to the notebooks table — single-kernel series (.NET C# for all), so it would be churn, not value.

## Verification

- `git diff --stat`: 1 file, +5/-18 (23 changed lines).
- Markdown structure intact: every "Contenu détaillé" table (ML-1 … ML-7, TP) keeps a blank line between header and table (a mid-edit `replace_all` transiently dropped 3 blanks; restored and re-verified in the final diff).
- README-only change → no notebook edited → no re-execution needed (C.2 markdown exception).
- CATALOG-STATUS marker left byte-identical (bot-owned).

See #2651
