### PR TITLE
docs(lean-3): enrich Propositions-Proofs sections 6/8/9 with grounded interpretation (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-3-Propositions-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-3-Propositions-Proofs.ipynb
@@ -2539,6 +2539,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "l3283001",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Une equivalence `P <-> Q` se prouve en fournissant **deux implications** : `P -> Q` (sens direct) et `Q -> P` (sens reciproque). Le constructeur `<forward, backward>` (sucre pour `Iff.intro`) attend ces deux preuves. Ici, la commutativite de `And` : chaque direction echange les composantes (`<h.right, h.left>`). C'est le patron universel des preuves d'equivalence -- toujours **deux sens**, jamais un seul."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "10f7b7f5",
    "metadata": {
     "papermill": {
@@ -3187,6 +3197,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "l3363002",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "`calc` n'est pas limite a l'egalite : il enchaine **toute relation** munie d'une regle de transitivite (`=`, `<=`, `<`, `~`, ...). Ici, on melange `=` puis `<=` ; Lean deduit le resultat composite `a <= c` en composant les transitivites. C'est ce qui fait la puissance de `calc` : la lisibilite d'une chaine de calcul, pour tout preorder -- pas seulement l'egalite."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1cbcfc6a",
    "metadata": {
     "papermill": {
@@ -3694,6 +3714,16 @@
     "    (fun hp => Or.inr (fun hq => h ⟨hp, hq⟩))\n",
     "    (fun hnp => Or.inl hnp),\n",
     "   fun h hpq => h.elim (fun hnp => hnp hpq.left) (fun hnq => hnq hpq.right)⟩"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "l3423003",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Subtilite importante : les deux sens de `¬(p ∨ q) <-> ¬p ∧ ¬q` sont **constructifs** (pas besoin de logique classique). En revanche, l'autre loi `¬(p ∧ q) <-> ¬p ∨ ¬q` n'est constructive que dans un sens (`->`) ; le sens reciproque exige le **tiers exclu**. C'est pourquoi cette cellule ouvre `Classical` : pour le sens qui en depend. Cette distinction constructif/classique est l'un des points pedagogiques cles de Lean."
    ]
   },
   {


### PR DESCRIPTION
## Summary

`Lean-3-Propositions-Proofs` continues the Lean notebook-body prose rollout (`#2651`), descend-by-thinness. Sections 1-5 are well-prosed, but 3 **bare-header gaps** (matching the "header nu + 0 interprétation post-code" signal) had no post-code interpretation:

- cell 27 "### 6.2 Preuves d'équivalence" (29c) → cell 28 code → jumps to §7
- cell 35 "### 8.2 calc avec plusieurs relations" (37c) → cell 36 code → jumps to §9
- cell 41 "### 9.3 Lois de De Morgan" (25c) → cell 42 code → jumps to §10

Follows **#3235** (Lean-5) and **#3236** (Lean-4), both MERGED by ai-01 this cycle.

## Changes (1 notebook, +30/-0, pure addition)

3 grounded interpretation cells:

| After cell | Concept | Grounded in |
|---|---|---|
| `and_comm_iff` | equivalence proof | `↔` = **two implications** via `⟨fwd, bwd⟩` (`Iff.intro`); the universal 2-direction pattern |
| `mixed_calc` | calc beyond equality | calc composes **any transitive relation** (`=`, `≤`, `<`...); Lean infers the composite — not just for `=` |
| De Morgan | constructive vs classical | `¬(p∨q)↔¬p∧¬q` is constructive both ways; the *other* law needs `Classical` for one direction — key pedagogical point |

## Verification (C.2 / §D — markdown-only)

- Markdown-only → **C.2 exception**, no re-exec. All 25 code cells keep committed outputs.
- `notebook_tools validate`: OK (0 errors/warnings). `check_c2_compliance`: 1/1.
- Anti-régression: 30/0 pure addition, kernel `lean4` intact, 25 code cells ec 1-25 monotone, 0 lost outputs. C.3: only this notebook staged.

See #2651 (prose Lean notebook bodies, partial contribution).
