### PR TITLE
docs(ml-4): enrich PFI/FCC explicability recipes with grounded interpretation (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
@@ -1624,6 +1624,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b416346a",
+   "source": "### Interprétation — lire les résultats de la PFI\n\nL'exécution ci-dessus produit un classement de chaque *slot* par valeur absolue de `RSquared.Mean` décroissante. Deux observations méritent un commentaire :\n\n- **Les variables catégorielles sont éclatées en bits.** `vendor_id` et `payment_type`, encodées en *One-Hot*, apparaissent sous la forme `vendor_id.Bit0`, `vendor_id.Bit1`, etc. : chaque bit est évalué séparément. Les variables continues (`trip_distance`, `trip_time_in_secs`) et ordinales (`passenger_count`, `rate_code`) gardent leur nom d'origine.\n- **Une valeur négative est attendue.** Comme la PFI mesure la *dégradation* du R² lorsqu'on permute la caractéristique, `RSquared.Mean` est presque toujours négatif : plus elle est négative (en valeur absolue), plus la caractéristique est importante pour le modèle.\n\nSur ce petit jeu de données avec `permutationCount: 3`, le classement est **instable** : les bits de `vendor_id` dominent tandis que `trip_distance`, `trip_time_in_secs` et `passenger_count` apparaissent à `0` — ce qui heurte l'intuition (la distance est évidemment prédictive du tarif). Cette instabilité est précisément la limite d'un faible `permutationCount`. En production, on l'augmente (typiquement 10 à 30) pour stabiliser l'estimation, et l'on croise le résultat avec la décomposition **locale** de la FCC ci-après.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "f3a7dd27",
    "metadata": {
     "papermill": {
@@ -2126,6 +2132,12 @@
    "source": [
     "featureContributions.First()\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15a6b3aa",
+   "source": "### Interprétation — lire une décomposition locale (FCC)\n\nContrairement à la PFI (qui moyennait l'effet d'une permutation sur tout le jeu), l'output ci-dessus décompose **une prédiction unique** — la première ligne du jeu prétraité. Chaque contribution indique dans quel sens et avec quelle intensité la caractéristique a tiré le `Score` de cette prédiction par rapport à la prédiction moyenne (la *baseline* du modèle) :\n\n- **Une contribution positive** pousse cette prédiction vers le haut (tarif prédit plus élevé que la baseline).\n- **Une contribution négative** la tire vers le bas.\n\nIci, `rate_code` (-1779,6) et `trip_distance` (-803,3) sont les contributeurs négatifs dominants : pour *cette* course, ces caractéristiques abaissent fortement le tarif prédit. À l'inverse, `payment_type.Bit1` (+19,2) et `payment_type.Bit0` (+10,6) le relèvent légèrement.\n\nC'est le complément essentiel de la PFI : une caractéristique peut être globalement peu importante (PFI faible) tout en étant déterminante sur certaines prédictions (FCC élevée sur ces lignes). On audite donc typiquement une prédiction surprenante en lisant sa décomposition FCC, puis on hiérarchise les caractéristiques au niveau du modèle avec la PFI.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

`ML-4-Evaluation` is the thinnest notebook in the ML.Net series for pedagogical prose (528 md-chars/code-cell vs 748-1628 for siblings ML-1/2/3/5/6/7). The two explicability recipes (PFI, cells 38-53 ; FCC, cells 56-73) were **17 bare procedural headers** (`define → fit → compute`) with **zero interpretation of the actual results** produced — a student runs them but never learns how to *read* the output.

Adds **2 markdown interpretation cells** grounded in the real notebook outputs:

- **After the PFI recipe**: how to read the One-Hot slot ranking (`vendor_id.Bit0..2`, `payment_type.Bit0..3`), why `RSquared.Mean` is negative (PFI measures R² *degradation*), and an **honest note** that `permutationCount: 3` yields an unstable ranking here (vendor_id.Bit2 #1 at -0.51, continuous features `trip_distance`/`trip_time_in_secs`/`passenger_count` at 0 — counter-intuitive). This is the practical reason to raise permutationCount (10-30) and cross with FCC.
- **After the FCC recipe**: how to read a single-prediction decomposition (positive vs negative contribution vs the model baseline), zooming on the dominant negative contributors `rate_code` (-1779.6) and `trip_distance` (-803.3), and the global-vs-local complementarity with PFI (a feature can be globally weak yet locally decisive).

These are **distinct** from the existing theory cell (`## Explicabilité du modèle`, which already covers global vs local + the PFI/FCC mechanism well): they interpret the concrete *results*, not the concept.

## Validation

- **Markdown-only** → C.2 exception (no re-exec required).
- Forensic: `+13/-1`, only **2 new markdown cells**, **0 code cell touched**, **0 execution_count/outputs modified**.
- `notebook_tools validate`: **0 error / 0 warning**.
- C.2 compliance: **25 "ec-set-no-outputs" issues, identical before/after** (all pre-existing — `.NET` assignment cells `var x = ...` that produce no display output; not introduced by this PR, not this PR's scope).
- PFI/FCC numerical values cited in the prose are **extracted from the actual committed cell outputs** (`text/html` .NET Interactive treeview), not assumed.

See #2651 (partial delivery — prose enrichment of notebook bodies, ML.Net family).