### PR TITLE
ci(notebook-tools): per-PR cell-ordering regression gate (See #3240)

### DIFF
--- a/.github/workflows/cell-order-gate.yml
+++ b/.github/workflows/cell-order-gate.yml
@@ -1,0 +1,93 @@
+name: Cell-order gate
+
+# Purpose
+# -------
+# Per-PR REGRESSION gate for cell ordering / enchainement (Epic #3240).
+# For every notebook changed by the PR, compare its HIGH cell-ordering findings
+# (scripts/notebook_tools/scan_cell_ordering.py) between the base revision and
+# the PR revision and FAIL only on a regression -- a HIGH finding introduced by
+# the PR. Pre-existing findings in legacy notebooks (tracked under #3240) do NOT
+# block unrelated PRs. A new notebook (no base) must be clean.
+#
+# Convention: .claude/rules/notebook-conventions.md ("Enchainement et ordre
+# canonique des cellules"). Skill: /check-cell-order.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'scripts/notebook_tools/scan_cell_ordering.py'
+      - 'scripts/notebook_tools/cell_order_ci.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cell-order:
+    name: "No cell-ordering regression in changed notebooks"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Gate changed notebooks
+        run: |
+          set -uo pipefail
+          BASE="origin/${{ github.base_ref }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::notice title=Cell-order gate::Manual dispatch — nothing to diff."
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "::notice title=Cell-order gate::No notebooks changed — clean."
+            exit 0
+          fi
+
+          tmp=$(mktemp -d)
+          fail=0
+          echo "## Cell-order gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r nb; do
+            [ -z "$nb" ] && continue
+            # Skip notebooks deleted by the PR.
+            [ -f "$nb" ] || continue
+            basef="NONE"
+            if git cat-file -e "$BASE:$nb" 2>/dev/null; then
+              basef="$tmp/base.ipynb"
+              git show "$BASE:$nb" > "$basef" 2>/dev/null || basef="NONE"
+            fi
+            out=$(python scripts/notebook_tools/cell_order_ci.py --base "$basef" --head "$nb")
+            rc=$?
+            if [ $rc -ne 0 ]; then
+              echo "::error title=Cell-order regression::$nb introduces new HIGH cell-ordering finding(s)."
+              echo "$out"
+              echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "$out" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              fail=1
+            else
+              echo "  OK  $nb"
+            fi
+          done <<< "$CHANGED"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Ground-truth each finding (the signal is not a verdict, rule G.1), then re-order with \`NotebookEdit\` (bottom-up) and re-execute (C.2). See the \`/check-cell-order\` skill." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "::notice title=Cell-order gate::No ordering regression in changed notebooks."

--- a/scripts/notebook_tools/cell_order_ci.py
+++ b/scripts/notebook_tools/cell_order_ci.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Per-PR cell-ordering REGRESSION gate (Epic #3240).
+
+Compares the HIGH cell-ordering findings of a notebook between its base revision
+and its PR (head) revision and fails only on a *regression* -- a HIGH finding
+present in head that was NOT already present in base. Pre-existing HIGH findings
+in legacy notebooks therefore do NOT block unrelated PRs; they are tracked
+separately under Epic #3240. A brand-new notebook (no base) must be clean: with
+an empty base, every HIGH finding counts as a regression.
+
+A finding's identity is its (category, message) pair -- the message embeds the
+offending section/exercise numbers, so it is specific enough that moving a bug
+around does not mask a newly introduced one.
+
+Usage:
+    cell_order_ci.py --base <base.ipynb|NONE> --head <head.ipynb>
+
+Exit codes:
+    0 - no new HIGH findings in head (or head unreadable -> nothing to gate)
+    1 - one or more NEW HIGH findings introduced by head (regression)
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_cell_ordering import scan_notebook  # noqa: E402
+
+
+def high_signatures(path: str | None) -> set[tuple[str, str]]:
+    """Set of (category, message) for HIGH findings of a notebook, or empty."""
+    if not path or path == "NONE" or not Path(path).exists():
+        return set()
+    rep = scan_notebook(Path(path))
+    if rep.get("error"):
+        return set()
+    return {(f["category"], f["message"]) for f in rep["findings"] if f["severity"] == "HIGH"}
+
+
+def regressions(base_path: str | None, head_path: str | None) -> list[tuple[str, str]]:
+    """HIGH findings present in head but not in base (sorted, deterministic)."""
+    base = high_signatures(base_path)
+    head = high_signatures(head_path)
+    return sorted(head - base)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Cell-ordering per-PR regression gate.")
+    ap.add_argument("--base", help="base revision of the notebook, or NONE for a new file")
+    ap.add_argument("--head", required=True, help="head (PR) revision of the notebook")
+    args = ap.parse_args(argv)
+
+    new = regressions(args.base, args.head)
+    if not new:
+        return 0
+
+    print(f"REGRESSION in {args.head}: {len(new)} new HIGH cell-ordering finding(s):")
+    for category, message in new:
+        print(f"  [{category}] {message}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_cell_order_ci.py
+++ b/scripts/notebook_tools/tests/test_cell_order_ci.py
@@ -1,0 +1,88 @@
+"""Tests for scripts/notebook_tools/cell_order_ci.py — per-PR regression gate.
+
+The gate fails only on a *regression* (a HIGH finding in head that was not in
+base). Pre-existing findings do not block; a new notebook (no base) must be clean.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from cell_order_ci import regressions, high_signatures, main  # noqa: E402
+
+
+def _md(source: str) -> dict:
+    return {"cell_type": "markdown", "source": [source]}
+
+
+def _write(path: Path, cells: list[dict]) -> Path:
+    nb = {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+    path.write_text(json.dumps(nb), encoding="utf-8")
+    return path
+
+
+# A notebook with a genuine backwards section jump (## 2 after ## 3).
+_BAD = [_md("## 2. A"), _md("## 3. B"), _md("## 2. oops")]
+# A clean notebook.
+_CLEAN = [_md("## 1. A"), _md("## 2. B"), _md("## 3. C")]
+
+
+class TestHighSignatures:
+    def test_none_base_is_empty(self):
+        assert high_signatures("NONE") == set()
+        assert high_signatures(None) == set()
+
+    def test_missing_path_is_empty(self, tmp_path):
+        assert high_signatures(str(tmp_path / "absent.ipynb")) == set()
+
+    def test_clean_has_no_high(self, tmp_path):
+        p = _write(tmp_path / "c.ipynb", _CLEAN)
+        assert high_signatures(str(p)) == set()
+
+    def test_bad_has_high(self, tmp_path):
+        p = _write(tmp_path / "b.ipynb", _BAD)
+        sigs = high_signatures(str(p))
+        assert any(cat == "SECTION_ORDER" for cat, _ in sigs)
+
+
+class TestRegressions:
+    def test_new_clean_notebook_no_regression(self, tmp_path):
+        head = _write(tmp_path / "h.ipynb", _CLEAN)
+        assert regressions("NONE", str(head)) == []
+
+    def test_new_bad_notebook_is_regression(self, tmp_path):
+        head = _write(tmp_path / "h.ipynb", _BAD)
+        assert len(regressions("NONE", str(head))) >= 1
+
+    def test_preexisting_high_does_not_block(self, tmp_path):
+        # Same HIGH finding in base and head -> not a regression.
+        base = _write(tmp_path / "base.ipynb", _BAD)
+        head = _write(tmp_path / "head.ipynb", _BAD)
+        assert regressions(str(base), str(head)) == []
+
+    def test_new_high_introduced_is_regression(self, tmp_path):
+        base = _write(tmp_path / "base.ipynb", _CLEAN)
+        head = _write(tmp_path / "head.ipynb", _BAD)
+        assert len(regressions(str(base), str(head))) >= 1
+
+    def test_fixing_high_is_not_regression(self, tmp_path):
+        base = _write(tmp_path / "base.ipynb", _BAD)
+        head = _write(tmp_path / "head.ipynb", _CLEAN)
+        assert regressions(str(base), str(head)) == []
+
+    def test_malformed_head_is_graceful(self, tmp_path):
+        base = _write(tmp_path / "base.ipynb", _CLEAN)
+        head = tmp_path / "head.ipynb"
+        head.write_text("{not json", encoding="utf-8")
+        assert regressions(str(base), str(head)) == []
+
+
+class TestMainExitCodes:
+    def test_exit_zero_on_clean(self, tmp_path):
+        head = _write(tmp_path / "h.ipynb", _CLEAN)
+        assert main(["--base", "NONE", "--head", str(head)]) == 0
+
+    def test_exit_one_on_regression(self, tmp_path):
+        head = _write(tmp_path / "h.ipynb", _BAD)
+        assert main(["--base", "NONE", "--head", str(head)]) == 1


### PR DESCRIPTION
## Summary

Final atomic child of Epic #3240. Wires the cell-ordering scanner (merged #3243) into a **per-PR regression gate**.

- **`.github/workflows/cell-order-gate.yml`** — triggers on PRs that change `MyIA.AI.Notebooks/**/*.ipynb` (or the scanner/gate scripts). For each changed notebook it diffs HIGH findings between the base and head revisions and **fails only on a regression**.
- **`scripts/notebook_tools/cell_order_ci.py`** — the regression helper. A finding's identity is its `(category, message)` pair (the message embeds the offending numbers). Exit 1 if head has a HIGH finding not in base; graceful on malformed/absent files.
- **`scripts/notebook_tools/tests/test_cell_order_ci.py`** — 12 tests.

## Design: regression, not "fix all legacy"

A naive "fail on any HIGH" gate would block every PR that merely touches one of the 11 legacy notebooks with pre-existing findings. This gate is a **regression** gate:

| Case | Result |
|------|--------|
| New notebook, clean | pass |
| New notebook with a HIGH finding | **fail** (empty base → finding is new) |
| Pre-existing HIGH, unchanged by PR | pass (not introduced here) |
| PR introduces a new HIGH | **fail** |
| PR fixes a pre-existing HIGH | pass |
| Malformed / deleted notebook | pass (nothing to gate) |

Pre-existing findings in legacy notebooks stay tracked under Epic #3240 and do not block unrelated work.

## Verification

- 12 unit tests green (`conda run -n mcp-jupyter pytest ...test_cell_order_ci.py` → 12 passed). These also run in the `Scripts Tests (CPU)` job.
- Workflow YAML validated (`yaml.safe_load`).
- CLI smoke: clean SL-5 → exit 0; legacy Sudoku-12 as a new file → exit 1 listing its 3 real backwards-section findings.

## Epic #3240 — complete after this PR

- [x] Scanner re-runnable, FP < 5% (#3243: 0% FP at HIGH on 703 notebooks)
- [x] `/check-cell-order` skill (#3244)
- [x] Convention in `.claude/rules/notebook-conventions.md` (#3244)
- [x] Per-PR CI gate (this PR)
- [x] SL series re-scan = 0 unjustified slippage (#3243 verification)

See #3240

🤖 Generated with [Claude Code](https://claude.com/claude-code)