### PR TITLE
docs(semantic-web): drop stale count bandeau + structure learning objectives (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -11,9 +11,7 @@ maturity: PRODUCTION=18
 
 Le Web Sémantique est la promesse d'un Web où les machines comprennent la signification des données, pas seulement leur syntaxe. RDF, SPARQL, OWL, SHACL : ces standards du W3C définissent un langage commun pour décrire, interroger, valider et raisonner sur des graphes de connaissances. Cette série vous mène des fondations (.NET C# avec dotNetRDF) aux applications modernes (Python avec rdflib, pySHACL, GraphRAG), en passant par les ontologies, les données liées et les standards émergents (RDF 1.2, JSON-LD 1.1).
 
-**18 notebooks** | **2 langages** | **~10h**
-
-**À qui s'adresse cette série** : développeurs web curieux du sens caché dans leurs données, data scientists voulant structurer leurs pipelines, et étudiants en IA souhaitant comprendre comment les graphes de connaissances ancrent les LLMs. Aucun prérequis en logique formelle.
+**À qui s'adresse cette série** : développeurs web curieux du sens caché dans leurs données, data scientists voulant structurer leurs pipelines, et étudiants en IA souhaitant comprendre comment les graphes de connaissances ancrent les LLMs. Aucun prérequis en logique formelle. Le décompte exact des notebooks et leur maturité figurent dans le catalogue généré ci-dessous.
 
 ## Pourquoi cette série
 
@@ -293,13 +291,18 @@ Ce notebook bonus compare différents raisonneurs OWL (owlrl, HermiT, reasonable
 
 À l'issue de cette série, l'apprenant est capable de :
 
-- **Modéliser un domaine en RDF** (triplets, IRIs, littéraux typés, namespaces) et manipuler des graphes en C# avec dotNetRDF (`SW-2-CSharp-RDFBasics.ipynb`, `SW-3-CSharp-GraphOperations.ipynb`) ou en Python avec rdflib (`SW-2b-Python-RDFBasics.ipynb`).
-- **Interroger un graphe en SPARQL 1.1** (SELECT, CONSTRUCT, ASK, DESCRIBE, federations via SERVICE) côté .NET (`SW-4-CSharp-SPARQL.ipynb`) et Python (`SW-4b-Python-SPARQL.ipynb`), puis publier des données Linked Data résolvables (`SW-5-CSharp-LinkedData.ipynb`, `SW-5b-Python-LinkedData.ipynb`).
-- **Formaliser une ontologie en RDFS puis OWL** (classes, propriétés, restrictions, hiérarchies) et tirer parti d'un raisonneur pour matérialiser les inférences (`SW-6-CSharp-RDFS.ipynb`, `SW-7-CSharp-OWL.ipynb`, `SW-7b-Python-OWL.ipynb`, `SW-13-Python-Reasoners.ipynb`).
-- **Valider la conformité d'un graphe** avec SHACL (NodeShapes/PropertyShapes, contraintes de cardinalité et de type, rapport de validation) via pySHACL (`SW-8-Python-SHACL.ipynb`).
-- **Sérialiser et échanger des données RDF en JSON-LD** (`@context`, framing, compaction/expansion) pour interopérer avec les APIs Web modernes (`SW-9-Python-JSONLD.ipynb`).
-- **Annoter des assertions avec RDF-Star / SPARQL-Star** (citations de triplets, provenance, niveau de confiance) pour modéliser métadonnées et réification compacte (`SW-10-Python-RDFStar.ipynb`).
-- **Construire et exploiter un graphe de connaissances intégré à un LLM** (extraction de triplets, embeddings, GraphRAG) pour ancrer les réponses génératives sur des données structurées (`SW-11-Python-KnowledgeGraphs.ipynb`, `SW-12-Python-GraphRAG.ipynb`).
+**Techniques**
+
+1. **Modéliser un domaine en RDF** (triplets, IRIs, littéraux typés, namespaces) et manipuler des graphes en C# avec dotNetRDF (`SW-2-CSharp-RDFBasics.ipynb`, `SW-3-CSharp-GraphOperations.ipynb`) ou en Python avec rdflib (`SW-2b-Python-RDFBasics.ipynb`).
+2. **Interroger un graphe en SPARQL 1.1** (SELECT, CONSTRUCT, ASK, DESCRIBE, federations via SERVICE) côté .NET (`SW-4-CSharp-SPARQL.ipynb`) et Python (`SW-4b-Python-SPARQL.ipynb`), puis publier des données Linked Data résolvables (`SW-5-CSharp-LinkedData.ipynb`, `SW-5b-Python-LinkedData.ipynb`).
+3. **Formaliser une ontologie en RDFS puis OWL** (classes, propriétés, restrictions, hiérarchies) et tirer parti d'un raisonneur pour matérialiser les inférences (`SW-6-CSharp-RDFS.ipynb`, `SW-7-CSharp-OWL.ipynb`, `SW-7b-Python-OWL.ipynb`, `SW-13-Python-Reasoners.ipynb`).
+4. **Valider la conformité d'un graphe** avec SHACL (NodeShapes/PropertyShapes, contraintes de cardinalité et de type, rapport de validation) via pySHACL (`SW-8-Python-SHACL.ipynb`).
+5. **Sérialiser et échanger des données RDF en JSON-LD** (`@context`, framing, compaction/expansion) pour interopérer avec les APIs Web modernes (`SW-9-Python-JSONLD.ipynb`).
+6. **Annoter des assertions avec RDF-Star / SPARQL-Star** (citations de triplets, provenance, niveau de confiance) pour modéliser métadonnées et réification compacte (`SW-10-Python-RDFStar.ipynb`).
+
+**Applicatives**
+
+7. **Construire et exploiter un graphe de connaissances intégré à un LLM** (extraction de triplets, embeddings, GraphRAG) pour ancrer les réponses génératives sur des données structurées (`SW-11-Python-KnowledgeGraphs.ipynb`, `SW-12-Python-GraphRAG.ipynb`).
 
 ---
 


### PR DESCRIPTION
## Summary

Harmonization of the SemanticWeb README to the series gabarit (`docs/reference/readme-series-gabarit.md`), Partie 2 of #2651. po-2026:CoursIA lane, descend-by-size SymbolicAI sous-series (greenlit ai-01 09:52Z).

Two grounded gaps identified by G.1 comparison to the gabarit (not forced, G.5):

### Gap 1 — Anti-pattern 1 (gabarit L64): stale count bandeau
Opening line `**18 notebooks** | **2 langages** | **~10h**` is a manual count that drifts. Verified: there are **17** pedagogical `.ipynb` (excluding `_output.ipynb` artefacts), while `CATALOG-STATUS` declares `pedagogical_count: 18`. The exact count + maturity already live in the bot-owned `CATALOG-STATUS` block just below, so the manual bandeau is both redundant and inaccurate. Replaced with a one-line pointer to the generated catalogue.

### Gap 2 — Section 4 (gabarit L36-38): learning objectives structure
`## Acquis d'apprentissage` was 7 flat bullets. Gabarit (model `CaseStudies/README.md:81-105`) wants objectives **numbered, in categories** (techniques / méthodologiques / applicatifs). Restructured into:
- **Techniques** (objectives 1-6: RDF modelling, SPARQL, RDFS/OWL, SHACL, JSON-LD, RDF-Star)
- **Applicatives** (objective 7: KG + LLM / GraphRAG)

All 7 original objectives **preserved verbatim** — only reformatting, no content loss (anti-régression verified: every deleted line has an equivalent replacement).

## Validation
- **Markdown-only** → exception C.2 (no re-exec needed)
- **CATALOG-STATUS byte-identical** (`git diff | grep CATALOG-STATUS` = 0 lines touched)
- **1 file touched** (README only, no Lean path, no anti-collision risk with CoursIA-2 lane)
- **Anti-régression**: 521 → 524 lines (+13/-10), every deletion replaced
- **Steering respected** (ai-01 11:52Z): **0 bridge added** (the existing `Connections cross-series` section is already specific — names notebooks/concepts on both sides — and is kept as-is per gabarit section 9)
- Base fresh on `origin/main` (0 commits behind)

## Rule-E transparency
+13/-10 = 23 lines changed (>20 threshold), so the §E auto-reject does not apply. The change is a structural harmonization (2 gaps), atomically coherent — not a composite.

`See #2651` (contribution to the prose epic, not a full close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)