### PR TITLE
docs(z3-nb03): add const-array + extensionality (SMT-LIB fidelity audit #3164, Closes #3251)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
@@ -577,6 +577,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6ca8f9e8",
+   "source": "### Deux autres briques de la théorie des tableaux SMT-LIB\n\nLes axiomes de McCarthy ci-dessus définissent `select` et `store`. La théorie des tableaux du standard SMT-LIB en compte deux autres, qui ne sont pas utilisées dans ce notebook mais qu'il faut connaître pour lire la littérature SMT :\n\n**Le tableau constant (`const`, ou `K` en SMT-LIB).** C'est un troisième constructeur, à côté de `select`/`store` : `const(v)` désigne le tableau dont **toutes** les positions contiennent la valeur `v`. En C# Microsoft.Z3, cela se crée par `ctx.MkConstArray(ctx.IntSort, ctx.MkInt(0))` — un tableau « entièrement à zéro ». C'est l'outil naturel pour exprimer un **état initial uniforme** : une grille vide (toutes cases à 0), un registre vidé, un buffer initialisé. On pourrait alors écrire l'état initial `[2, 2]` de l'exemple Missionnaires-Cannibales (cell `c5d6e7fe`) de façon plus concise comme `store(store(const(0), 0, 2), 1, 2)` — deux écritures par-dessus un fond uniforme de zéros — plutôt qu'en partant d'un tableau symbolique non interprété.\n\n**L'extensionalité.** C'est le quatrième axiome : deux tableaux `a` et `b` sont **égaux** si et seulement si ils coïncident sur tout indice —\n\n$$\na = b \\;\\;\\Longleftrightarrow\\;\\; \\forall i.\\; \\text{select}(a, i) = \\text{select}(b, i)\n$$\n\nCet axiome est ce qui rend l'égalité entre tableaux **décidable** : écrire `ctx.MkEq(arrA, arrB)` pousse Z3 à raisonner sur l'égalité point par point (en instanciant l'axiome d'extensionalité sous le capot). Sans lui, un tableau ne serait qu'une fonction non interprétée quelconque, et `a = b` n'aurait pas de sens calculable. C'est précisément ce qui justifie l'existence d'une **théorie dédiée** des tableaux plutôt qu'un simple encodage par fonction non interprétée (`MkFuncDecl`) : la théorie fournit gratuitement ce axiome d'extensionalité, ainsi que les axiomes read-over-write, là qu'une fonction non interprétée obligerait à tout réécrire à la main.\n\n> **Pour aller plus loin** : la spécification SMT-LIB (smt-lib.org) formalise intégralement ces quatre opérations — `select`, `store`, `const`, et l'extensionalité — et la documentation Z3 (z3prover.github.io/api) détaille leurs équivalents `MkSelect`/`MkStore`/`MkConstArray`.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "e1f2a3ba",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

Fidelity audit **Epic #3164** (verify each notebook port against its source material) found that `03_Array_Theory.ipynb` covered **2 of the 4** foundational SMT-LIB array-theory operations solidly (`select`, `store` + McCarthy read-over-write axioms, 55+24 grep matches) but had **2 central concepts completely absent** (grep = 0, no scoping note — genuine omission, not documented scoping like NB-05 MealPlanner):

| Concept | Status before | Evidence |
|---|---|---|
| `select` / `store` | ✅ covered | 55 matches, prose + code |
| McCarthy read-over-write axioms | ✅ covered | 24 matches, proven via negation+UNSAT |
| **const-array** (`K(sort,val)` / `MkConstArray`) | ❌ **absent** | 0 match (note: `MkArrayConst` present but = uninterpreted array, a *different* concept) |
| **extensionality** (`a==b ⟺ ∀i. select(a,i)==select(b,i)`) | ❌ **absent** | 0 match |

**Audit methodology**: po-2025 read-only, sub-agent `sonnet` for evidence-gathering (model explicit, local-git-only, evidence-cited) → **G.1 parent cross-check** that corrected 1 sub-agent false-positive (a too-strict regex missed that `MkArrayConst` ≠ `MkConstArray`). Verified independently before acting.

## Fix — 1 markdown cell grounded in canonical SMT-LIB material

- **const-array**: definition + C# `ctx.MkConstArray(intSort, ctx.MkInt(0))` API + the concrete payoff — a uniform initial state expressed concisely as `store(store(const(0),0,2),1,2)` instead of an uninterpreted array, with a back-reference to the Missionaries-Cannibals example (cell `c5d6e7fe`).
- **extensionality**: the axiom (LaTeX) + **why it justifies a dedicated array theory** over a plain `MkFuncDecl` uninterpreted-function encoding (Z3 gets read-over-write + extensionality for free).
- Cited sources: SMT-LIB spec (smt-lib.org) + Z3 docs (z3prover.github.io/api).

## Validation

- **Markdown-only** → C.2 exception (no re-exec).
- Forensic: `+6/0`, 1 new markdown cell, **0 code cell touched**, **0 ec/outputs modified**, 10 code cells all ec-set unchanged.
- `notebook_tools validate`: **0 error / 0 warning**.
- C.2 compliance: **0 issues before = 0 after** (notebook was already clean).

Closes #3251 (resolves the child issue fully — both omissions addressed). See #3164 (Epic, partial — other notebooks still to audit).