### PR TITLE
docs(z3-nb02): name AllDifferent + clarify array C# vs SMT Array (fidelity audit #3164, Closes #3256)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02_Sudoku_Theorem_vs_Array.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02_Sudoku_Theorem_vs_Array.ipynb
@@ -1657,6 +1657,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1bc6039a",
+   "source": "### Interprétation — La contrainte AllDifferent\n\nLes trois familles de contraintes structurelles (lignes, colonnes, boîtes) reposent toutes sur la même primitive SMT : `Z3Methods.Distinct(...)`. En programmation par contraintes, cette contrainte porte un nom canonique — **AllDifferent** — qui exprime que *toutes* les valeurs d'un ensemble doivent être deux à deux distinctes. C'est l'élément central de tout puzzle Sudoku : chaque ligne, colonne et boîte 3×3 est une instance d'AllDifferent sur 9 variables.\n\n**Décomposition de AllDifferent.** Une contrainte `AllDifferent(x₁, …, xₙ)` se décompose canoniquement en **inégalités pairwise** :\n\n$$\n\\forall\\, i < j,\\;\\; x_i \\neq x_j\n$$\n\nPour `n = 9`, cela fait `n·(n−1)/2 = 36` clauses binaires par contrainte (et autant par ligne, colonne, boîte) — une croissance en **O(n²)**. C'est pourquoi AllDifferent est exposé comme une **primitive globale** (un seul appel `Distinct`) plutôt qu'à énumérer à la main : le solveur peut alors appliquer des propagations spécialisées (par ex. *bound consistency* sur le domaine des valeurs) bien plus efficaces que sur 36 clauses `≠` isolées. `Z3Methods.Distinct` n'est donc pas du sucre syntaxique anodin — c'est un raccourci vers une structure de décision exploitée par le solveur.\n\n> **Pour aller plus loin** : la contrainte AllDifferent et ses encodages alternatifs (pairwise, channeling, propagateurs dédiés) sont un sujet central de la programmation par contraintes (réf. : *Handbook of Constraint Programming*, Rossi et al., 2006, chap. 6).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "c5d6e7f8",
    "metadata": {
     "papermill": {
@@ -2664,6 +2670,12 @@
     "\n",
     "> **Note technique** : le modele implicite genere exactement le meme ensemble de contraintes SMT que le modele explicite. La difference est purement syntaxique (C#), pas semantique (Z3)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "223a2311",
+   "source": "### Précision de vocabulaire — « array » C# vs « Array » SMT\n\nPuisque nous venons d'évoquer le **niveau SMT**, il faut clarifier un point de vocabulaire qui sinon prête à confusion : le mot **« array »** dans ce notebook ne désigne **pas** la théorie des tableaux de Z3.\n\n- **Ici, « array » = `List<int>` C#.** La propriété `Cells` est une collection C#, et l'indexeur `s.Cells[i*9+j]` est un *sucre d'indexeur* que Z3.Linq traduit en **une variable de décision Z3 distincte par cellule** (81 variables au total, comme le rappelle la conclusion). Le « modèle implicite par arrays » compactifie donc le **code source C#**, pas la **représentation SMT** — d'où la note ci-dessus : les deux approches génèrent le même ensemble de contraintes.\n\n- **La théorie des tableaux SMT** (le `(Array Int Int)` de SMT-LIB, avec ses opérations `select`/`store` et les axiomes de McCarthy) est **autre chose** : là, le tableau est un *seul* symbole logique que l'on interroge par `select(arr, i)`. Cette théorie est enseignée dans le notebook [03 — Array Theory](03_Array_Theory.ipynb).\n\nLe « array » de ce notebook et l'« Array » de NB-03 sont donc deux notions différentes qui partagent un mot. Si vous cherchez à modéliser le Sudoku comme un *vrai tableau SMT* (`select`/`store`), c'est NB-03 qu'il faut voir ; la comparaison des deux modes d'encodage des collections (une variable par cellule vs un seul symbole de tableau) est elle détaillée dans le notebook [02b — Sudoku Modes Comparison](02b_Sudoku_Modes_Comparison.ipynb).",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Fidelity audit **Epic #3164** (verify each notebook against its source material) on `02_Sudoku_Theorem_vs_Array.ipynb` — 3rd Z3 instance (after NB-05 scoping-NÉGATIF, NB-03 #3251/#3252).

**NB-02 delivers its stated contract honestly** (81-properties-vs-`List<int>` transition + C# closure capture) — cell \`e7f8a9b0\` explicitly admits both models generate the same SMT constraint set. **Not a factual inversion** (unlike Tweety-4 #3250 which inverted AGM theory). The title is interpretable: "théorème" = \`Z3Theorem<T>\`, "modèle implicite" = C# indexing.

**But 2 central concepts of the source material (Sudoku as a Z3 theorem) are absent with no scoping note** (grep \`hors-scope|voir notebook\` = 0 in relevant content):

| Concept | Status before | Evidence |
|---|---|---|
| AllDifferent (named) + pairwise decomposition | ❌ black box | \`Z3Methods.Distinct\` called 9×; \`AllDifferent\` = 0 grep |
| "array" vocabulary (List<int> C# vs ArrayExpr SMT) | ❌ ambiguous | \`MkSelect\|MkStore\|Array Int Int\` = 0; title says "Arrays" but means C# `List<int>` |

## Fix — 2 markdown cells grounded in canonical material

1. **"La contrainte AllDifferent"** (after cell `b4c5d6e7`, the implicit-model builder that uses `Distinct`): names the global constraint, pairwise decomposition `x_i ≠ x_j for i<j` → `n(n-1)/2 = 36` binary clauses for n=9, explains why `Distinct` is a decision primitive (bound-consistency propagation) not syntactic sugar. Cites *Handbook of Constraint Programming* (Rossi 2006, ch.6).
2. **"Précision de vocabulaire — array C# vs Array SMT"** (after cell `e7f8a9b0`, the interpretation that just discussed the SMT level): disambiguates `List<int>` C# (1 var/cell, source-level compaction) from the SMT Array theory (single symbol, `select`/`store`, McCarthy axioms). Forward-pointers to NB-03 (*Array Theory*) and NB-02b (*Sudoku Modes Comparison*).

## Validation

- **Markdown-only** → C.2 exception (no re-exec).
- Forensic: `+13/-1` (the -1 is a JSON brace moved by insertion, not content deletion). 2 new markdown cells, **0 source code line touched**, **0 ec/outputs modified**, 13 code cells all ec-set unchanged.
- `notebook_tools validate`: **0 error / 0 warning**.
- **cell-order gate #3240** (new repo-wide CI): **CLEAN** (0 finding).
- C.2 compliance: **0 before = 0 after**.

Closes #3256 (resolves the child issue fully — both omissions addressed). See #3164 (Epic, partial — NB-01/04/06 Z3 + Sudoku/Argumentum still to audit).