### PR TITLE
docs(tweety): drop stale count bandeau + dedup cross-series bridges (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -9,11 +9,9 @@ breakdown: Tweety=10
 maturity: PRODUCTION=10
 -->
 
-Série complète de 10 notebooks pour explorer [TweetyProject](https://tweetyproject.org/), une bibliothèque Java pour l'intelligence artificielle symbolique.
+Série complète de notebooks pour explorer [TweetyProject](https://tweetyproject.org/), une bibliothèque Java pour l'intelligence artificielle symbolique. Le décompte exact des notebooks et leur maturité figurent dans le catalogue généré ci-dessous ; la série cible la version **Tweety 1.30**.
 
 ## Série en quelques mots
-
-**10 notebooks** | **1 kernel** | **~6h de travail** | **Tweety 1.30**
 
 **À qui s'adresse cette série** : étudiants en IA, chercheurs en argumentation computationnelle, développeurs intéressés par le raisonnement formel, et tout curieux souhaitant comprendre les bases mathématiques derrière le raisonnement explicite. Aucun prérequis en logique formelle n'est supposé : les concepts sont introduits progressivement, des opérateurs propositionnels de base jusqu'aux sémantiques d'argumentation les plus avancées.
 
@@ -527,19 +525,10 @@ La version est configurable dans `Tweety-1-Setup.ipynb` (variable `TWEETY_VERSIO
 | **[Argument_Analysis](../Argument_Analysis/)** | Argumentation agentique | Utilise Tweety comme backend Java pour le raisonnement argumentatif. Les sémantiques de Dung (notebook 5) sont directement appliquées dans l'analyse de textes. |
 | **[Lean](../Lean/)** | Vérification formelle | Les logiques propositionnelles et FOL (notebooks 2-3) correspondent aux tactiques de preuve Lean. Les SAT solvers de Tweety complètent la vérification Lean. |
 | **[SmartContracts](../SmartContracts/)** | Méthodes formelles | La vérification formelle SC-14 (Certora/SMTChecker) utilise les mêmes solveurs SAT/SMT. La logique propositionnelle de Tweety est la base des invariants Solidity. |
+| **[SemanticWeb](../SemanticWeb/)** | Logique de Description / OWL | La logique de Description (Tweety-3) est le fondement du raisonnement OWL : les ontologies OWL DL (SW-6/SW-7) utilisent les mêmes solveurs DL que Tweety. |
 | **[GameTheory](../../GameTheory/)** | Théorie du vote | Le notebook 9 (Préférences/Vote) couvre les concepts de choix social formalisés dans `social_choice_lean/` (Arrow, Sen, Voting). |
 | **[Planners](../Planners/)** | Planification argumentative | Les dialogues argumentatifs (notebook 8) peuvent être modélisés comme des problèmes de planification PDDL. |
 | Lecture transversale | [La mer qui monte](../../../docs/grothendieckian-lens.md) | Grille de lecture grothendieckienne du dépôt : changement de représentation, certification A/B/C |
-
-## Cross-series Bridges
-
-| Série | Lien | Connection |
-| ------- | ------ | ----------- |
-| [SymbolicAI/SemanticWeb](../SemanticWeb/README.md) | OWL reasoning | La logique de Description (Tweety-3) est le fondement de l'OWL reasoning — les ontologies OWL DL utilisent les mêmes solveurs DL que Tweety |
-| [IIT](../../IIT/README.md) | Argumentation pour la consciousness | L'analyse argumentative des systèmes complexes (notebooks 5-7) partage des concepts avec l'analyse IIT — identification de sous-ensembles causaux |
-| [SymbolicAI/Planners/](../Planners/README.md) | Planification logique | Les logiques formelles (notebooks 2-3) sont la base de la planification automatisée PDDL |
-| [ML/](../../ML/README.md) | Neuro-symbolic AI | L'intersection logiques + apprentissage : vérifier les prédictions de modèles neuronaux avec des contraintes logiques |
-| [Search](../../Search/README.md) | SAT-based search | Le solving SAT (notebook 2) partage les mêmes algorithmes que la recherche par contraintes (CSP) |
 
 ## Licence
 


### PR DESCRIPTION
## Summary

Harmonization of the Tweety README to the series gabarit (`docs/reference/readme-series-gabarit.md`), Partie 2 of #2651. po-2026:CoursIA lane, descend-by-size SymbolicAI sous-series (next after SemanticWeb #3246).

Two grounded gaps identified by G.1 comparison to the gabarit (not forced, G.5):

### Gap 1 — Anti-pattern 1 (gabarit L64): stale count bandeau
Opening line `**10 notebooks** | **1 kernel** | **~6h de travail** | **Tweety 1.30**` is a manual count that drifts. G.1 found a **duration inconsistency** in the same file: L16 said `~6h`, L56 said `~6h`, but L132 said `~7 heures`. The exact count (verified: 10 notebooks, coherent with CATALOG-STATUS `pedagogical_count: 10`) and maturity already live in the bot-owned `CATALOG-STATUS` block below. The `Tweety 1.30` version info (genuinely useful) is preserved in the intro line. Bandeau replaced by a catalogue pointer.

### Gap 2 — Anti-pattern 3 (gabarit L66): duplicate cross-series bridges
The README had **two redundant bridge sections**:
- `## Ponts avec les autres séries` (6 specific bridges, all naming notebooks/concepts on both sides) — kept intact (conforms to gabarit section 9).
- `## Cross-series Bridges` (5 bridges) — **removed**:
  - **SemanticWeb / OWL** (specific, real value: Tweety-3 DL solvers ↔ OWL DL) → **fused into the canonical "Ponts" section**, improved to name SW-6/SW-7 notebooks instead of the generic README link.
  - **Planners** → already present in "Ponts" (L Planification argumentative) → legitimate deduplication.
  - **IIT, ML/, Search** → generic one-liners (the vague "partage des concepts" / "intersection" type) → the anti-pattern 3 the steering (ai-01 11:52Z) says to remove, never add.

Per the **steering** (ai-01 11:52Z): "Cross-series bridges = ANTI-PATTERN, à SUPPRIMER, jamais ajouter." Zero bridge added; one specific bridge preserved (fused, not lost).

## Validation
- **Markdown-only** → exception C.2 (no re-exec needed)
- **CATALOG-STATUS byte-identical** (`git diff | grep CATALOG-STATUS` = 0 lines touched)
- **1 file touched** (README only, no Lean path, no anti-collision risk with CoursIA-2 lane)
- **Anti-régression**: every deleted line is either replaced (bandeau → catalogue pointer) or a legit dedup (Planners already in Ponts) or an anti-pattern removal (3 generic bridges). No specific cross-series connection lost — the SemanticWeb/OWL one is fused with improvement.
- Base fresh on `origin/main` (0 commits behind)

## Rule-E transparency
+2/-13 = 15 lines changed (< 20 threshold). This is a **removal-focused** harmonization (anti-patterns 1 + 3 are explicitly *subtractive* in the gabarit), so the §E auto-reject (which targets *additive* docs padding) does not apply by intent. The change is purely structural cleanup.

`See #2651` (contribution to the prose epic, not a full close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)