### PR TITLE
docs(z3-nb01): explain SAT/UNSAT + demo UNSAT + fix stale example (fidelity audit #3164, Closes #3262)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/01_Linq2Z3_Intro.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/01_Linq2Z3_Intro.ipynb
@@ -5,10 +5,10 @@
    "id": "bf6b6393",
    "metadata": {
     "papermill": {
-     "duration": 0.06486,
-     "end_time": "2026-06-10T21:45:54.256405+00:00",
+     "duration": 0.073675,
+     "end_time": "2026-06-17T17:53:17.974729+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:45:54.191545+00:00",
+     "start_time": "2026-06-17T17:53:17.901054+00:00",
      "status": "completed"
     },
     "tags": []
@@ -49,16 +49,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T23:04:27.117520Z",
-     "iopub.status.busy": "2026-06-14T23:04:27.111976Z",
-     "iopub.status.idle": "2026-06-14T23:04:28.280813Z",
-     "shell.execute_reply": "2026-06-14T23:04:28.278884Z"
+     "iopub.execute_input": "2026-06-17T17:53:18.322223Z",
+     "iopub.status.busy": "2026-06-17T17:53:18.305908Z",
+     "iopub.status.idle": "2026-06-17T17:53:19.219603Z",
+     "shell.execute_reply": "2026-06-17T17:53:19.214593Z"
     },
     "papermill": {
-     "duration": 13.449512,
-     "end_time": "2026-06-10T21:46:07.739349+00:00",
+     "duration": 1.105073,
+     "end_time": "2026-06-17T17:53:19.220906+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:45:54.289837+00:00",
+     "start_time": "2026-06-17T17:53:18.115833+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -72,7 +72,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-57208.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-35280.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -117,12 +117,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.102.1.197:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '57208.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '35280.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -203,10 +203,10 @@
    "id": "aa11516a",
    "metadata": {
     "papermill": {
-     "duration": 0.032004,
-     "end_time": "2026-06-10T21:46:07.791344+00:00",
+     "duration": 0.081778,
+     "end_time": "2026-06-17T17:53:19.376883+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:07.759340+00:00",
+     "start_time": "2026-06-17T17:53:19.295105+00:00",
      "status": "completed"
     },
     "tags": []
@@ -238,10 +238,10 @@
    "id": "d7e56662",
    "metadata": {
     "papermill": {
-     "duration": 0.012826,
-     "end_time": "2026-06-10T21:46:07.820810+00:00",
+     "duration": 0.041056,
+     "end_time": "2026-06-17T17:53:19.546083+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:07.807984+00:00",
+     "start_time": "2026-06-17T17:53:19.505027+00:00",
      "status": "completed"
     },
     "tags": []
@@ -259,16 +259,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T23:04:28.282105Z",
-     "iopub.status.busy": "2026-06-14T23:04:28.281901Z",
-     "iopub.status.idle": "2026-06-14T23:04:28.577769Z",
-     "shell.execute_reply": "2026-06-14T23:04:28.577538Z"
+     "iopub.execute_input": "2026-06-17T17:53:19.579878Z",
+     "iopub.status.busy": "2026-06-17T17:53:19.579589Z",
+     "iopub.status.idle": "2026-06-17T17:53:20.362125Z",
+     "shell.execute_reply": "2026-06-17T17:53:20.361763Z"
     },
     "papermill": {
-     "duration": 1.414378,
-     "end_time": "2026-06-10T21:46:09.248729+00:00",
+     "duration": 0.798463,
+     "end_time": "2026-06-17T17:53:20.362294+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:07.834351+00:00",
+     "start_time": "2026-06-17T17:53:19.563831+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -308,10 +308,10 @@
    "id": "83a2c736",
    "metadata": {
     "papermill": {
-     "duration": 0.017197,
-     "end_time": "2026-06-10T21:46:09.286693+00:00",
+     "duration": 0.014642,
+     "end_time": "2026-06-17T17:53:20.408885+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:09.269496+00:00",
+     "start_time": "2026-06-17T17:53:20.394243+00:00",
      "status": "completed"
     },
     "tags": []
@@ -337,10 +337,79 @@
     "\n",
     "**Résultat attendu:**\n",
     "\n",
-    "Le solveur Z3 trouve une solution (il peut y en avoir plusieurs):\n",
-    "- Une affectation possible: X1 = 8, X2 = 6, X3 = 2, X4 = 1, X5 = 2\n",
+    "Le solveur Z3 trouve une solution (il peut y en avoir plusieurs). L'exécution ci-dessus donne par exemple :\n",
+    "- Une affectation valide : X1 = 3, X2 = 0, X3 = 1, X4 = 0, X5 = 1\n",
     "\n",
-    "> **Note**: Z3 est un solveur SMT (Satisfiability Modulo Theories) capable de résoudre des contraintes sur des entiers, des réels, des tableaux, etc. LINQ To Z3 offre une interface C# naturelle pour exprimer ces contraintes.\n"
+    "> **Note**: Z3 est un solveur SMT (Satisfiability Modulo Theories) capable de résoudre des contraintes sur des entiers, des réels, des tableaux, etc. LINQ To Z3 offre une interface C# naturelle pour exprimer ces contraintes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c55885b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014385,
+     "end_time": "2026-06-17T17:53:20.437838+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T17:53:20.423453+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### SAT et UNSAT — le concept fondateur d'un solveur\n",
+    "\n",
+    "Jusqu'ici, chaque appel à `Solve()` a renvoyé une solution. Mais la question fondamentale que tranche un solveur SMT n'est pas « quelle est la solution ? » — c'est **« une solution existe-t-elle ? »**. C'est ce que désigne le **S** de SMT : *Satisfiability*.\n",
+    "\n",
+    "- **SAT (satisfiable)** : il existe **au moins une** affectation des variables qui satisfait toutes les contraintes simultanément. `Solve()` renvoie alors une telle affectation.\n",
+    "- **UNSAT (unsatisfiable)** : **aucune** affectation ne satisfait les contraintes — elles sont contradictoires. `Solve()` renvoie alors `null` (Z3 a *prouvé* qu'aucune solution n'existe).\n",
+    "\n",
+    "Cette distinction est centrale : l'une des réponses les plus utiles d'un solveur est **« c'est impossible »**, et cette réponse est une **preuve** (pas une absence de résultat). Par exemple, prouver qu'un planning est irréalisable sous certaines contraintes, ou qu'un invariant de sécurité ne peut jamais être violé. Le `(si elle existe)` de la section précédente prend ici tout son sens.\n",
+    "\n",
+    "L'exemple ci-dessous force un système UNSAT : la même variable ne peut pas être à la fois `> 5` **et** `< 3`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eddd42a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-17T17:53:20.480327Z",
+     "iopub.status.busy": "2026-06-17T17:53:20.479832Z",
+     "iopub.status.idle": "2026-06-17T17:53:20.794169Z",
+     "shell.execute_reply": "2026-06-17T17:53:20.793027Z"
+    },
+    "papermill": {
+     "duration": 0.342419,
+     "end_time": "2026-06-17T17:53:20.794726+00:00",
+     "exception": false,
+     "start_time": "2026-06-17T17:53:20.452307+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solve() a renvoyé : null  ->  le système est UNSAT (aucune affectation possible)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple : un système UNSAT (insatisfiable)\n",
+    "// La variable X1 doit être à la fois > 5 ET < 3 -- contradiction, aucune solution.\n",
+    "using (var ctx = new Z3Context())\n",
+    "{\n",
+    "    var theorem = ctx.NewTheorem<Symbols<int, int>>()\n",
+    "        .Where(t => t.X1 > 5)\n",
+    "        .Where(t => t.X1 < 3);\n",
+    "\n",
+    "    var solution = theorem.Solve();\n",
+    "    Console.WriteLine($\"Solve() a renvoyé : {(solution == null ? \"null  ->  le système est UNSAT (aucune affectation possible)\" : solution.ToString())}\");\n",
+    "}\n"
    ]
   },
   {
@@ -348,10 +417,10 @@
    "id": "6b7e496e",
    "metadata": {
     "papermill": {
-     "duration": 0.015595,
-     "end_time": "2026-06-10T21:46:09.318721+00:00",
+     "duration": 0.114947,
+     "end_time": "2026-06-17T17:53:20.974369+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:09.303126+00:00",
+     "start_time": "2026-06-17T17:53:20.859422+00:00",
      "status": "completed"
     },
     "tags": []
@@ -376,10 +445,10 @@
    "id": "804b5ccc",
    "metadata": {
     "papermill": {
-     "duration": 0.035514,
-     "end_time": "2026-06-10T21:46:09.368753+00:00",
+     "duration": 0.071799,
+     "end_time": "2026-06-17T17:53:21.140232+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:09.333239+00:00",
+     "start_time": "2026-06-17T17:53:21.068433+00:00",
      "status": "completed"
     },
     "tags": []
@@ -393,10 +462,10 @@
    "id": "ddea3043",
    "metadata": {
     "papermill": {
-     "duration": 0.015804,
-     "end_time": "2026-06-10T21:46:09.411220+00:00",
+     "duration": 0.01387,
+     "end_time": "2026-06-17T17:53:21.169323+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:09.395416+00:00",
+     "start_time": "2026-06-17T17:53:21.155453+00:00",
      "status": "completed"
     },
     "tags": []
@@ -448,10 +517,10 @@
    "id": "0b1a1f8a",
    "metadata": {
     "papermill": {
-     "duration": 0.023411,
-     "end_time": "2026-06-10T21:46:09.450943+00:00",
+     "duration": 0.016354,
+     "end_time": "2026-06-17T17:53:21.201592+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:09.427532+00:00",
+     "start_time": "2026-06-17T17:53:21.185238+00:00",
      "status": "completed"
     },
     "tags": []
@@ -464,23 +533,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "721b277f",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T23:04:28.579906Z",
-     "iopub.status.busy": "2026-06-14T23:04:28.579639Z",
-     "iopub.status.idle": "2026-06-14T23:04:28.878917Z",
-     "shell.execute_reply": "2026-06-14T23:04:28.878695Z"
+     "iopub.execute_input": "2026-06-17T17:53:21.232829Z",
+     "iopub.status.busy": "2026-06-17T17:53:21.232547Z",
+     "iopub.status.idle": "2026-06-17T17:53:21.778581Z",
+     "shell.execute_reply": "2026-06-17T17:53:21.778377Z"
     },
     "papermill": {
-     "duration": 0.782158,
-     "end_time": "2026-06-10T21:46:10.255881+00:00",
+     "duration": 0.562219,
+     "end_time": "2026-06-17T17:53:21.778674+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:09.473723+00:00",
+     "start_time": "2026-06-17T17:53:21.216455+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -614,10 +683,10 @@
    "id": "72f60fea",
    "metadata": {
     "papermill": {
-     "duration": 0.068481,
-     "end_time": "2026-06-10T21:46:10.374948+00:00",
+     "duration": 0.014577,
+     "end_time": "2026-06-17T17:53:21.808848+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:10.306467+00:00",
+     "start_time": "2026-06-17T17:53:21.794271+00:00",
      "status": "completed"
     },
     "tags": []
@@ -629,23 +698,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "5c3fa1be",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T23:04:28.880518Z",
-     "iopub.status.busy": "2026-06-14T23:04:28.880304Z",
-     "iopub.status.idle": "2026-06-14T23:04:29.211568Z",
-     "shell.execute_reply": "2026-06-14T23:04:29.211328Z"
+     "iopub.execute_input": "2026-06-17T17:53:21.846352Z",
+     "iopub.status.busy": "2026-06-17T17:53:21.846051Z",
+     "iopub.status.idle": "2026-06-17T17:53:22.412891Z",
+     "shell.execute_reply": "2026-06-17T17:53:22.412709Z"
     },
     "papermill": {
-     "duration": 0.781668,
-     "end_time": "2026-06-10T21:46:11.201909+00:00",
+     "duration": 0.587252,
+     "end_time": "2026-06-17T17:53:22.412979+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:10.420241+00:00",
+     "start_time": "2026-06-17T17:53:21.825727+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -657,7 +726,7 @@
     {
      "data": {
       "text/plain": [
-       "Durée Cannibales et Missionaires 00:00:00.2124906"
+       "Durée Cannibales et Missionaires 00:00:00.3588218"
       ]
      },
      "metadata": {},
@@ -733,10 +802,10 @@
    "id": "2f3a6f98",
    "metadata": {
     "papermill": {
-     "duration": 0.044983,
-     "end_time": "2026-06-10T21:46:11.317705+00:00",
+     "duration": 0.019042,
+     "end_time": "2026-06-17T17:53:22.451390+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:11.272722+00:00",
+     "start_time": "2026-06-17T17:53:22.432348+00:00",
      "status": "completed"
     },
     "tags": []
@@ -765,10 +834,10 @@
    "id": "b81a1e52",
    "metadata": {
     "papermill": {
-     "duration": 0.016919,
-     "end_time": "2026-06-10T21:46:11.350451+00:00",
+     "duration": 0.023069,
+     "end_time": "2026-06-17T17:53:22.491724+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:11.333532+00:00",
+     "start_time": "2026-06-17T17:53:22.468655+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,20 +859,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "26bfd605",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T23:04:29.212929Z",
-     "iopub.status.busy": "2026-06-14T23:04:29.212714Z",
-     "iopub.status.idle": "2026-06-14T23:04:29.248976Z",
-     "shell.execute_reply": "2026-06-14T23:04:29.248745Z"
+     "iopub.execute_input": "2026-06-17T17:53:22.530702Z",
+     "iopub.status.busy": "2026-06-17T17:53:22.530412Z",
+     "iopub.status.idle": "2026-06-17T17:53:22.569678Z",
+     "shell.execute_reply": "2026-06-17T17:53:22.569514Z"
     },
     "papermill": {
-     "duration": 0.178611,
-     "end_time": "2026-06-10T21:46:11.548417+00:00",
+     "duration": 0.060408,
+     "end_time": "2026-06-17T17:53:22.569736+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:11.369806+00:00",
+     "start_time": "2026-06-17T17:53:22.509328+00:00",
      "status": "completed"
     },
     "tags": []
@@ -843,10 +912,10 @@
    "id": "5e0ad9fc",
    "metadata": {
     "papermill": {
-     "duration": 0.024783,
-     "end_time": "2026-06-10T21:46:11.596824+00:00",
+     "duration": 0.01877,
+     "end_time": "2026-06-17T17:53:22.604199+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:11.572041+00:00",
+     "start_time": "2026-06-17T17:53:22.585429+00:00",
      "status": "completed"
     },
     "tags": []
@@ -857,23 +926,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "a5c8a9da",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T23:04:29.250192Z",
-     "iopub.status.busy": "2026-06-14T23:04:29.250022Z",
-     "iopub.status.idle": "2026-06-14T23:04:29.402039Z",
-     "shell.execute_reply": "2026-06-14T23:04:29.401835Z"
+     "iopub.execute_input": "2026-06-17T17:53:22.644673Z",
+     "iopub.status.busy": "2026-06-17T17:53:22.644313Z",
+     "iopub.status.idle": "2026-06-17T17:53:22.893401Z",
+     "shell.execute_reply": "2026-06-17T17:53:22.893177Z"
     },
     "papermill": {
-     "duration": 0.419867,
-     "end_time": "2026-06-10T21:46:12.031981+00:00",
+     "duration": 0.267743,
+     "end_time": "2026-06-17T17:53:22.893500+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:11.612114+00:00",
+     "start_time": "2026-06-17T17:53:22.625757+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -885,7 +954,7 @@
     {
      "data": {
       "text/plain": [
-       "Durée Cannibales et Missionaires 00:00:00.1110409"
+       "Durée Cannibales et Missionaires 00:00:00.1862792"
       ]
      },
      "metadata": {},
@@ -963,10 +1032,10 @@
    "id": "1763a6b4",
    "metadata": {
     "papermill": {
-     "duration": 0.019979,
-     "end_time": "2026-06-10T21:46:12.070536+00:00",
+     "duration": 0.015694,
+     "end_time": "2026-06-17T17:53:22.926557+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:12.050557+00:00",
+     "start_time": "2026-06-17T17:53:22.910863+00:00",
      "status": "completed"
     },
     "tags": []
@@ -990,23 +1059,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "2c1f373b",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T23:04:29.403626Z",
-     "iopub.status.busy": "2026-06-14T23:04:29.403449Z",
-     "iopub.status.idle": "2026-06-14T23:04:58.254305Z",
-     "shell.execute_reply": "2026-06-14T23:04:58.253862Z"
+     "iopub.execute_input": "2026-06-17T17:53:22.958447Z",
+     "iopub.status.busy": "2026-06-17T17:53:22.958129Z",
+     "iopub.status.idle": "2026-06-17T17:54:37.021400Z",
+     "shell.execute_reply": "2026-06-17T17:54:37.021222Z"
     },
     "papermill": {
-     "duration": 74.95627,
-     "end_time": "2026-06-10T21:47:27.061257+00:00",
+     "duration": 74.079661,
+     "end_time": "2026-06-17T17:54:37.021484+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:46:12.104987+00:00",
+     "start_time": "2026-06-17T17:53:22.941823+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1018,7 +1087,7 @@
     {
      "data": {
       "text/plain": [
-       "Durée Cannibales et Missionaires 00:00:28.8059603"
+       "Durée Cannibales et Missionaires 00:01:13.9623792"
       ]
      },
      "metadata": {},
@@ -1097,10 +1166,10 @@
    "id": "b6cb8246",
    "metadata": {
     "papermill": {
-     "duration": 0.01656,
-     "end_time": "2026-06-10T21:47:27.093995+00:00",
+     "duration": 0.01896,
+     "end_time": "2026-06-17T17:54:37.065909+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:47:27.077435+00:00",
+     "start_time": "2026-06-17T17:54:37.046949+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1122,20 +1191,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "1ba631d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T23:04:58.255729Z",
-     "iopub.status.busy": "2026-06-14T23:04:58.255531Z",
-     "iopub.status.idle": "2026-06-14T23:04:58.297498Z",
-     "shell.execute_reply": "2026-06-14T23:04:58.297247Z"
+     "iopub.execute_input": "2026-06-17T17:54:37.110405Z",
+     "iopub.status.busy": "2026-06-17T17:54:37.110109Z",
+     "iopub.status.idle": "2026-06-17T17:54:37.179566Z",
+     "shell.execute_reply": "2026-06-17T17:54:37.179290Z"
     },
     "papermill": {
-     "duration": 0.064798,
-     "end_time": "2026-06-10T21:47:27.174697+00:00",
+     "duration": 0.094945,
+     "end_time": "2026-06-17T17:54:37.179654+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:47:27.109899+00:00",
+     "start_time": "2026-06-17T17:54:37.084709+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1171,10 +1240,10 @@
    "id": "2142ea44",
    "metadata": {
     "papermill": {
-     "duration": 0.017043,
-     "end_time": "2026-06-10T21:47:27.206269+00:00",
+     "duration": 0.020775,
+     "end_time": "2026-06-17T17:54:37.221234+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:47:27.189226+00:00",
+     "start_time": "2026-06-17T17:54:37.200459+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1227,20 +1296,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c4eecb38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T23:04:58.298688Z",
-     "iopub.status.busy": "2026-06-14T23:04:58.298508Z",
-     "iopub.status.idle": "2026-06-14T23:04:58.332936Z",
-     "shell.execute_reply": "2026-06-14T23:04:58.332792Z"
+     "iopub.execute_input": "2026-06-17T17:54:37.340772Z",
+     "iopub.status.busy": "2026-06-17T17:54:37.338535Z",
+     "iopub.status.idle": "2026-06-17T17:54:37.426662Z",
+     "shell.execute_reply": "2026-06-17T17:54:37.426383Z"
     },
     "papermill": {
-     "duration": 0.085291,
-     "end_time": "2026-06-10T21:47:27.308172+00:00",
+     "duration": 0.167946,
+     "end_time": "2026-06-17T17:54:37.426785+00:00",
      "exception": false,
-     "start_time": "2026-06-10T21:47:27.222881+00:00",
+     "start_time": "2026-06-17T17:54:37.258839+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1298,14 +1367,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 101.777544,
-   "end_time": "2026-06-10T21:47:27.731961+00:00",
+   "duration": 81.934311,
+   "end_time": "2026-06-17T17:54:37.703525+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Z3\\01_Linq2Z3_Intro.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Z3\\01_Linq2Z3_Intro_output.ipynb",
+   "input_path": "01_Linq2Z3_Intro.ipynb",
+   "output_path": "01_Linq2Z3_Intro_out.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T21:45:45.954417+00:00",
+   "start_time": "2026-06-17T17:53:15.769214+00:00",
    "version": "2.7.0"
   },
   "polyglot_notebook": {


### PR DESCRIPTION
## Summary

Fidelity audit **Epic #3164** on \`01_Linq2Z3_Intro.ipynb\` — 4th Z3 instance. The notebook named "SMT (Satisfiability Modulo Theories)" 8× but never explained the *satisfiability* decision concept and **never showed an unsatisfiable case** — every \`Solve()\`/\`Optimize()\` returned a solution. The "(si elle existe)" hedge stayed unexplained. An intro-to-a-solver notebook that never demonstrates UNSAT implicitly teaches "Z3 always finds a solution", when one of the most important answers a solver gives is **"it's impossible"** (a proof, not an absence). SAT/UNSAT is the founding concept (grep \`SAT|UNSAT|décidab\` = 0).

## Fix — markdown + 1 executed code cell

1. **New markdown** "SAT et UNSAT — le concept fondateur d'un solveur" (after example analysis): defines SAT (≥1 model) vs UNSAT (no model, \`Solve()\` returns \`null\`), explains UNSAT is a **proof** not an absence, links the "(si elle existe)" hedge.
2. **New code cell** UNSAT demo: \`Symbols<int,int>\` with \`X1 > 5 && X1 < 3\` → \`Solve()\` returns \`null\`. Re-executed output: \`Solve() a renvoyé : null -> le système est UNSAT\`.
3. **Fix stale example** (cell \`83a2c736\`): prose said "X1=8, X2=6, X3=2…" ("Résultat attendu") but the executed output is "X1=3, X2=0, X3=1…". Both valid (multiple solutions) but the prose didn't match the output — aligned to the actual executed output.

## Scope discipline (no-pendulum)

Did **NOT** audit:
- "Hiding \`Microsoft.Z3\` behind the \`Z3Context\`/\`Theorem<T>\` facade" = legitimate **progressive disclosure** for an intro (NB-02/03 reveal the low-level API later).
- "Decision variables vs constants" = the intro says "5 variables entières", clear enough at this level.

## Validation

- **Full re-execution** via papermill (`.net-csharp` kernel, Z3.Linq `.deploy` fork): **0 error**, 10 code cells all \`execution_count\` set.
- Forensic: 1 new code cell + 1 new markdown + 1 markdown fixed; **0 existing code cell source touched** (anti-regression).
- **cell-order gate #3240**: CLEAN.
- C.2: 1 preexisting false positive (the \`CanibalsAndMissionaries\` class-declaration cell produces no output naturally — identical before/after on \`main\`, not introduced here, not a defect per the documented \`mlnet-prose-thin-and-c2-fp\` pattern).

Closes #3262 (resolves the child issue fully). See #3164 (Epic, partial — NB-04/NB-06 Z3 + Sudoku still to audit).