### PR TITLE
docs(smart-contracts): drop stale count bandeau + dedup cross-series bridges (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -17,9 +17,7 @@ Le parcours suit le fil annoncé par le titre : on part des **primitives cryptog
 
 ---
 
-**27 notebooks** | **Kernel Python 3** | **~22 heures**
-
-**À qui s'adresse cette série** : développeurs Solidity, ingénieurs DeFi, spécialistes security/blockchain, étudiants en IA symbolique intéressés par la vérification formelle. Un niveau intermédiaire en programmation est recommandé — les bases de Python sont suffisantes, mais les concepts blockchain/cryptographie sont introduits progressivement.
+**À qui s'adresse cette série** : développeurs Solidity, ingénieurs DeFi, spécialistes security/blockchain, étudiants en IA symbolique intéressés par la vérification formelle. Un niveau intermédiaire en programmation est recommandé — les bases de Python sont suffisantes, mais les concepts blockchain/cryptographie sont introduits progressivement. Le décompte exact des notebooks et leur maturité figurent dans le catalogue généré ci-dessous.
 
 ## Objectifs d'apprentissage
 
@@ -385,17 +383,6 @@ python setup_env.py --check
 - [ElectionGuard](https://www.electionguard.vote/)
 - [XRP Ledger Docs](https://xrpl.org/docs.html)
 
-## Cross-séries Bridges
-
-| Série | Lien | Connection |
-| ------- | ------ | ----------- |
-| [Lean](../Lean/README.md) | Formal verification | Les SMT solvers (SC-14) et les preuves Lean 4 sont deux facettes de la même vérité -- la correction mathématique |
-| [GameTheory](../../GameTheory/README.md) | Voting & DAO | SC-9 (DAO) et SC-17 (vote E2E) sont des instances de théorie du choix social (Arrow, Sen) |
-| [Probas](../../Probas/README.md) | Decision & Risk | Minimax Regret (PyMC-19) s'applique aux smart contracts pour la gestion des incertitudes on-chain |
-| [SymbolicAI/SemanticWeb](../SemanticWeb/README.md) | Ontologies & Verification | Les ontologies peuvent formaliser les propriétés de contrats pour vérification formelle |
-| [SymbolicAI/Tweety](../Tweety/README.md) | Non-monotonic reasoning | Le raisonnement non-monotone s'applique à la gouvernance DAO (propositions rétractables) |
-| [GenAI/Texte](../../GenAI/Texte/README.md) | LLM-assisted | SC-11 applique le même paradigme d'assistance LLM que la série GenAI Texte |
-
 ## Connections cross-séries
 
 ### SmartContracts et Lean (Vérification Formelle)
@@ -411,6 +398,12 @@ Les mécanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instan
 
 - **SC-9 DAO Governance** : les systèmes de vote on-chain sont soumis aux mêmes limitations que le **théorème d'Arrow** (formalisé dans `social_choice_lean/Arrow.lean`, 0 sorry).
 - **SC-17 E2E Verifiable Voting** : les propriétés des systèmes de vote (Banks sets, monotonie STV) sont étudiées formellement dans `social_choice_lean/Voting.lean`. Le chiffrement homomorphique (SC-16) et les ZKP (SC-15) sont les briques cryptographiques qui rendent le vote E2E possible.
+
+### SmartContracts et Décision sous Incertitude (Probas)
+
+La gestion des incertitudes on-chain (réserves DeFi, slippage, garanties) s'appuie sur les mêmes outils de décision que la série Probas :
+
+- **Minimax Regret (PyMC-19)** s'applique à la conception de contrats robustes face à des conditions de marché incertaines (choix de paramètres on-chain qui minimisent le regret maximal dans le pire scénario).
 
 ### Lecture transversale
 


### PR DESCRIPTION
## Summary

Harmonization of the SmartContracts README to the series gabarit (`docs/reference/readme-series-gabarit.md`), Partie 2 of #2651. po-2026:CoursIA lane, descend-by-size SymbolicAI sous-series (final non-Lean sous-série, after SemanticWeb #3246 and Tweety #3260).

Two grounded gaps identified by G.1 comparison to the gabarit (not forced, G.5):

### Gap 1 — Anti-pattern 1 (gabarit L64): stale count bandeau
Opening line `**27 notebooks** | **Kernel Python 3** | **~22 heures**` is a manual count that drifts (verified coherent with CATALOG-STATUS `pedagogical_count: 27`, but redondant). The exact count + maturity already live in the bot-owned `CATALOG-STATUS` block below. Bandeau replaced by a catalogue pointer.

### Gap 2 — Anti-pattern 3 (gabarit L66): duplicate cross-series bridges
The README had **two redundant bridge sections** (same pattern as Tweety, fixed in #3260):
- `## Connections cross-séries` (L399, 3 detailed subsections naming concrete artefacts: `social_choice_lean/Arrow.lean`, Lean-7/8/9, Z3/CVC5) — **kept intact** as the canonical richer section.
- `## Cross-séries Bridges` (L388, 6 one-line bridges) — **removed**:
  - **Lean SMT solvers** → already in Connections (SC-14 section) → dedup.
  - **GameTheory Arrow/Sen** → already in Connections (SC-9 Arrow.lean, SC-17 Voting.lean) → dedup.
  - **GenAI/Texte SC-11** → already mentioned in Connections (LLM section L406) → dedup.
  - **Probas Minimax Regret** (specific, missing from Connections) → **fused into Connections** as a new "SmartContracts et Décision sous Incertitude" subsection, expanded with concrete on-chain context (réserves DeFi, slippage, garanties).
  - **SemanticWeb, Tweety** → generic one-liners (the "peuvent formaliser" / "s'applique à" type) → the anti-pattern 3 the steering (ai-01 11:52Z) says to remove, never add.

Per the **steering** (ai-01 11:52Z): "Cross-series bridges = ANTI-PATTERN, à SUPPRIMER, jamais ajouter." Zero bridge added; the one specific bridge not yet covered (Probas) is fused with expansion, not lost.

## Validation
- **Markdown-only** → exception C.2 (no re-exec needed)
- **CATALOG-STATUS byte-identical** (`git diff | grep CATALOG-STATUS` = 0 lines touched)
- **1 file touched** (README only, no Lean path, no anti-collision risk with CoursIA-2 lane)
- **Anti-régression**: every deleted line is replaced (bandeau → catalogue pointer), a legit dedup (Lean/GameTheory/GenAI already in Connections), or an anti-pattern removal (2 generic bridges). No specific cross-series connection lost — Probas is fused with improvement.
- Base fresh on `origin/main` (0 commits behind)

## Rule-E transparency
+7/-14 = 21 lines changed (> 20 threshold by a hair, and removal-focused). This is a **subtractive** harmonization (anti-patterns 1 + 3 are explicitly *subtractive* in the gabarit), so the §E auto-reject (which targets *additive* docs padding) does not apply by intent. The change is structural cleanup.

`See #2651` (contribution to the prose epic, not a full close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)