### PR TITLE
docs(posttraining): trim generic bridges + manual count (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
@@ -159,10 +159,7 @@ PT-06 documente le pipeline d'évaluation complet et produit un tableau comparat
 | Série | Connection | Details |
 |-------|------------|---------|
 | **[RL](../../RL/)** | RL classique fondamentaux | Les notebooks RL ([rl_5 MDP/Q-Learning](../../RL/rl_5_mdp_dp_qlearning.ipynb) et [rl_6c PPO from scratch](../../RL/rl_6c_ppo_from_scratch.ipynb)) établissent l'intuition policy/value que PPO/GRPO réutilisent. Recommandés comme prérequis pour PT-04. |
-| **[GenAI/Texte](../Texte/)** | Usage des LMs aligned | Les notebooks GenAI consomment des modèles déjà post-trained. Cette série explique comment ces modèles arrivent dans cet état. |
 | **[GenAI/FineTuning](../FineTuning/)** | Boîte à outils fine-tuning | Série sœur dans GenAI : LoRA/QLoRA/SFT/DPO en pratique sur 5 notebooks. PostTraining = profondeur méthodologique, FineTuning = recettes exécutables. |
-| **[ML](../../ML/)** | Tutoriels ML.NET | Pont conceptuel : ML.NET = inference de modèles déjà entraînés ; PostTraining = production de ces modèles. |
-| **[QuantConnect ML-Training-Pipeline](../../QuantConnect/ML-Training-Pipeline/)** | Pipeline training trading | Pipeline sœur sur RL/transformers pour trading (DT, PatchTST). PostTraining cible LMs, ML-Training-Pipeline cible time series. |
 
 ## Contexte industriel et historique 2017-2025
 
@@ -214,7 +211,7 @@ Pour les apprenants disposant de plus de VRAM (RTX 4090 24Go, A100 40Go), la sé
 
 ## Statut
 
-Série complète : 6 notebooks, tous exécutés avec outputs réels.
+Série complète : tous les notebooks sont exécutés avec outputs réels.
 
 Suivi : [Issue #1742](https://github.com/jsboige/CoursIA/issues/1742).
 


### PR DESCRIPTION
## Summary

Harmonize `GenAI/PostTraining/README.md` (26.6 KB — the largest GenAI README, untouched by #2651 so far) with the [readme-series-gabarit](../../docs/reference/readme-series-gabarit.md). **Markdown-only** (C.2 exception). **CATALOG-STATUS byte-identical** (bot-owned, grep-verified). Follows the dispatch ai-01 po-2023 cycle: \"#3253 débloqué ✅, puis #2651 prose GenAI descend-by-size\" — PostTraining = the largest, most likely to have accumulated gabarit drift.

## Census (evidence-cited, grounded before edit)

Delegated read-heavy census to a `sonnet` Explore agent (read-only, evidence-cited), then cross-checked the 2 edit zones myself (G.1). Findings:

| Anti-pattern (gabarit) | Finding | Action |
|---|---|---|
| **1. Count bandeau before pedagogy** (L64/L76) | No opening bandeau (clean intro). BUT a manual count at L217 \"Série complète : 6 notebooks\" duplicated CATALOG-STATUS `pedagogical_count: 6` | Reworded to preserve the useful claim (\"outputs réels\") without the rust-prone manual count |
| **2. Parent/child verbatim duplication** | None significant (PostTraining is actually *absent* from the parent GenAI README prose — a parent gap, not a child duplication) | No edit (out of scope: parent GenAI README) |
| **3. Generic cross-series bridges** (L66) | 5 bridges: 2 SPECIFIC (RL rl_5/rl_6c → PT-04 prereq; FineTuning sister-series) + 3 GENERIC (Texte, ML, QC-ML-Training-Pipeline — name no concrete artifact on either side) | Dropped the 3 generic; kept the 2 specific. **0 specific bridge lost.** |
| **4. FAQ hypertrophy** (L67) | 6 questions — exactly at the ~6 bound | No edit (correctly bounded) |
| **5. Navigation absent** (L68) | Present at L3 (parent + sibling links) | No edit |
| **Fidelity** | Table 6/6 ↔ 6 notebooks on disk ↔ CATALOG-STATUS count — perfect | No edit |

## Edits (2, surgical, removal-focused)

**1. Ponts (anti-pattern 3):** removed 3 generic bridges. The Texte bridge (\"Les notebooks GenAI consomment des modèles déjà post-trained\") is already covered by the intro framing (L12-14). The ML + QC bridges are pure domain contrasts with no notebook-to-notebook link. Rule (gabarit L54): a bridge must name a concrete notebook/concept on **both** sides; a generic line adds nothing → remove rather than keep.

**2. Statut (anti-pattern 1):** \"6 notebooks\" count → reworded without the chiffre.

## Not touched (high pedagogical value, correctly bounded)
- Contexte industriel 2017-2025 (L167-181), Compatibilité matérielle Qwen (L183-195), References académiques (L197-207) — durable content.
- Intro L1-35 (clean), FAQ (6Q at bound).

## Validation
- **CATALOG-STATUS byte-identical** (grep-verified — no lines touched).
- Kept bridge targets verified real: `RL/rl_5_mdp_dp_qlearning.ipynb`, `RL/rl_6c_ppo_from_scratch.ipynb`, `GenAI/FineTuning/README.md` all exist.
- Markdown-only, no source-code change. check-docs-links + no-catalog-changes covered by CI.
- 1 file, **+1/-4**.

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)