### PR TITLE
fix(csp1): correct MRV/LCV benchmark interpretation against executed outputs

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -1717,20 +1717,20 @@
    "source": [
     "### Interpretation : impact des heuristiques sur la coloration\n",
     "\n",
-    "**Sortie obtenue** : les heuristiques reduisent le nombre d'assignations.\n",
+    "**Sortie obtenue** : sur ce petit graphe, les heuristiques n'amelioresent pas le compte d'assignations.\n",
     "\n",
     "| Variante | Assignations | Commentaire |\n",
     "|----------|-------------|-------------|\n",
-    "| Backtracking simple | ~7-15 | Ordre naif des variables et valeurs |\n",
-    "| + MRV | ~7-10 | Fail-first sur les variables |\n",
-    "| + MRV + LCV | ~7 | Optimal ou quasi-optimal |\n",
+    "| Backtracking simple | 11 | Ordre naif des variables et valeurs |\n",
+    "| + MRV | 15 | Fail-first : sur-cout ici non amorti |\n",
+    "| + MRV + LCV | 15 | idem, LCV ne change rien |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Sur ce petit probleme (7 variables, 3 couleurs), l'amelioration est modeste car l'espace est deja restreint\n",
-    "2. L'impact des heuristiques devient **dramatique** sur des problemes plus grands\n",
-    "3. MRV est generalement l'heuristique la plus importante ; LCV apporte un gain supplementaire\n",
+    "1. Sur ce petit probleme (7 variables, 3 couleurs, espace deja tres contraint), l'ordre naif tombe deja sur une solution en 11 assignations ; MRV ajoute ici un sur-cout de selection (15) non amorti\n",
+    "2. L'effet des heuristiques est **instance-dependant** : nul ou negatif sur une instance facile, il devient dramatique sur des instances plus dures (cf. les 8-Reines ci-dessous : 876 -> 572 avec MRV)\n",
+    "3. Conclusion honnete : aucune heuristique n'est monotoniquement benefique, il faut mesurer et non presupposer une amelioration\n",
     "\n",
-    "> **Regle pratique** : MRV seul offre souvent le meilleur rapport cout/benefice, car le calcul de LCV a un overhead non negligeable."
+    "> **Regle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais son sur-cout n'est pas amorti sur les instances faciles comme la coloration de l'Australie."
    ]
   },
   {
@@ -1927,18 +1927,19 @@
    "source": [
     "### Interpretation : 8-Reines\n",
     "\n",
-    "**Sortie obtenue** : le backtracking avec MRV trouve une solution au probleme des 8-Reines.\n",
+    "**Sortie obtenue** : le backtracking avec MRV + LCV resout les 8-Reines en 677 assignations.\n",
     "\n",
     "| Mesure | Valeur |\n",
     "|--------|--------|\n",
     "| Espace brut | $8^8 = 16\\,777\\,216$ |\n",
-    "| Assignations (avec MRV) | typiquement < 50 |\n",
-    "| Reduction | facteur > 300 000 |\n",
+    "| Plain backtracking | 876 assignations |\n",
+    "| + MRV | 572 assignations |\n",
+    "| + MRV + LCV | 677 assignations |\n",
     "\n",
     "**Points cles** :\n",
     "1. L'echiquier montre qu'aucune reine n'est sur la meme ligne, colonne ou diagonale\n",
-    "2. La modelisation CSP (une variable par colonne) est plus efficace qu'une recherche dans l'espace complet\n",
-    "3. MRV est particulierement efficace ici car les domaines se reduisent vite a mesure que l'on place des reines"
+    "2. La modelisation CSP (une variable par colonne) resout le probleme en ~$10^3$ assignations au lieu des $16{,}8$ millions de l'espace brut\n",
+    "3. MRV (876 -> 572) reduit nettement le compte ; en revanche, ajouter LCV le remonte a 677 : l'ordonnancement des valeurs par LCV est ici moins favorable que l'ordre naif combine a MRV -- c'est un effet connu, l'ordonnancement des valeurs etant moins robuste que celui des variables"
    ]
   },
   {
@@ -2109,16 +2110,16 @@
     "\n",
     "| Variante | Coloration (assigns) | 8-Reines (assigns) | Commentaire |\n",
     "|----------|---------------------|---------------------|-------------|\n",
-    "| Plain backtracking | reference | reference | Ordre naif des variables et valeurs |\n",
-    "| + MRV | reduction moderee | reduction significative | Fail-first sur les variables |\n",
-    "| + MRV + LCV | optimal ou quasi | optimal ou quasi | Succeed-first sur les valeurs |\n",
+    "| Plain backtracking | 11 | 876 | Ordre naif des variables et valeurs |\n",
+    "| + MRV | 15 | 572 | Fail-first sur les variables |\n",
+    "| + MRV + LCV | 15 | 677 | Succeed-first sur les valeurs |\n",
     "\n",
     "**Observations** :\n",
-    "1. **MRV** est l'heuristique la plus impactante, surtout pour N-Reines ou les domaines se reduisent asymetriquement\n",
-    "2. **LCV** ajoute un gain supplementaire mais son cout de calcul peut compenser sur les petits problemes\n",
-    "3. Sur des problemes plus grands, l'ecart peut etre de plusieurs ordres de grandeur\n",
+    "1. **MRV** aide nettement sur les 8-Reines (876 -> 572), mais pas sur la coloration (11 -> 15) : son sur-cout de selection n'est pas amorti sur une instance facile\n",
+    "2. **LCV** n'apporte rien sur la coloration (15 -> 15) et fait meme regresser les 8-Reines (572 -> 677) : l'ordonnancement des valeurs est moins fiable que celui des variables\n",
+    "3. Aucune heuristique n'est universellement benefique : le benefice depend de l'instance et se mesure empiriquement\n",
     "\n",
-    "> **A retenir** : les heuristiques de selection ne changent pas la correction du backtracking, mais peuvent transformer un probleme intraitable en probleme resolvable en temps raisonnable."
+    "> **A retenir** : les heuristiques de selection ne changent pas la correction du backtracking, mais leur benefice n'est ni garanti ni monotone. Sur les instances dures (N-Reines grand), MRV transforme un probleme intraitable en probleme resolvable ; sur les instances faciles, elles peuvent meme couter plus qu'elles ne rapportent."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Corrects the three interpretation markdown cells in `CSP-1-Fundamentals.ipynb` that fabricated benchmark numbers contradicting the notebook's own committed outputs. Part of the fidelity audit #3164 (CSP family).

## Ground truth (read from executed code-cell outputs)

| Variant | Australia (assigns) | 8-Reines (assigns) |
|---------|--------------------:|-------------------:|
| Plain backtracking | **11** | **876** |
| + MRV | **15** | **572** |
| + MRV + LCV | **15** | **677** |

Sources: Australia benchmark cell `980eb07f`, comparative table cell `8b79451e`, 8-Reines resolution cell `71b13f50`.

## What the markdown said vs reality

The original text claimed "8-Reines typiquement < 50 assignations" (real: **876** plain, **572** MRV) and "optimal ou quasi" for every variant. The honest, more pedagogically interesting reality:

- **Australia**: MRV does **not** help here (11 -> 15). The naive order already wins in 11 assignments on this already-constrained 7-variable map; MRV's fail-first selection overhead is not amortized.
- **8-Reines**: MRV helps (876 -> 572), but adding **LCV regresses** (572 -> 677). Value-ordering is less robust than variable-ordering -- a known effect.
- **No heuristic is monotonically beneficial**; the gain is instance-dependent and must be measured, not presupposed (no-pendulum reformulation, not a flip to "heuristics are useless").

## Changes (markdown source only -- C.2 exception, no re-exec)

| Cell | Content |
|------|---------|
| `121b1669` | Australia heuristics impact: ~7-15/~7-10/~7 -> real 11/15/15 |
| `39daf9c3` | 8-Reines: "typiquement < 50" -> 876/572/677 |
| `f9d09728` | Comparison table: "optimal ou quasi" -> real numbers |

## Proofs

- **0 code cell** source/output/execution_count modified (markdown-only; authoritative cell-type check passed).
- Diff touches **exactly the 3 markdown cells**; **0 papermill.metadata churn** (surgical json round-trip preserves the original `0.0` duration values that NotebookEdit's serializer was coercing to int).
- `scan_cell_ordering`: 1 clean, 0 findings.
- Catalogue (`COURSE_CATALOG.generated.*`) + submodule byte-identical to `origin/main`.
- Execution counts preserved [1-29].

## Scope note

This addresses the **2 HIGH markdown findings** of #3280. The **LOW code-cell finding** (cell `1tm6ret8buk` counts rejected single-value `fail` nodes as "backtracks" -- a true backtrack is when ALL values fail and the search backs up a level, AIMA §6.3) is **deferred**: it is a code-cell change requiring re-execution per rule C.2, out of scope for this markdown-only fix.

See #3280
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)