### PR TITLE
fix(sudoku-1): relabel MRV 'Exemple guide' stub as Exercice + align perf table to output (fidelity audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -859,30 +859,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : Performance du Backtracking\n",
-    "\n",
-    "**Sortie obtenue** : Trois puzzles de difficulte croissante ont ete resolus avec succes. Le nombre d'appels recursifs et le temps de resolution augmentent exponentiellement avec la difficulte.\n",
-    "\n",
-    "| Difficulte | Appels recursifs | Temps (ms) | Facteur d'augmentation |\n",
-    "|------------|-----------------|------------|------------------------|\n",
-    "| Facile | 122 | 0,49 | 1x (reference) |\n",
-    "| Moyen | 490 304 | 177,79 | 4 019x |\n",
-    "| Difficile | 12 625 368 | 5 762,31 | 103 489x |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. **Complexite exponentielle** : Le nombre d'appels recursifs explose littéralement entre le puzzle facile (122 appels) et le puzzle difficile (12,6 millions d'appels).\n",
-    "2. **Efficacite sur les puzzles simples** : Le backtracking naive est tres rapide (moins d'une demi-millisecond) pour les puzzles faciles.\n",
-    "3. **Limites sur les puzzles difficiles** : Plus de 5,7 secondes pour un puzzle difficile difficilement acceptable pour une application interactive.\n",
-    "4. **Tous les puzzles resolus** : L'algorithme trouve toujours une solution (completude), mais le cout en temps varie enormement.\n",
-    "\n",
-    "> **Note technique** : Le temps de resolution n'est pas lineaire par rapport au nombre d'appels recursifs. Le puzzle difficile necessite 25 fois plus d'appels que le puzzle moyen, mais prend 32 fois plus de temps. Cela s'explique par le cout de la gestion de la pile d'appels et des operations de validation.\n",
-    "\n",
-    "**Comparaison avec la theorie** : L'analyse des resultats confirme les proprietes theoriques du backtracking :\n",
-    "- **Completude** : Tous les puzzles sont resolus avec 0 erreurs restantes\n",
-    "- **Cout** : Exponentiel dans le pire cas, mais acceptable pour les instances simples\n",
-    "- **Amelioration necessaire** : Les heuristiques (MRV, Forward Checking) sont indispensables pour les puzzles difficiles"
-   ]
+   "source": "### Interpretation : Performance du Backtracking\n\n**Sortie obtenue** : Trois puzzles de difficulte croissante ont ete resolus avec succes. Le nombre d'appels recursifs et le temps de resolution augmentent exponentiellement avec la difficulte.\n\n| Difficulte | Appels recursifs | Temps (ms) | Facteur d'augmentation |\n|------------|-----------------|------------|------------------------|\n| Facile | 122 | 0,4354 | 1x (reference) |\n| Moyen | 490 304 | 141,0824 | 4 019x |\n| Difficile | 12 625 368 | 4 127,7309 | 103 489x |\n\n**Points cles** :\n1. **Complexite exponentielle** : Le nombre d'appels recursifs explose littéralement entre le puzzle facile (122 appels) et le puzzle difficile (12,6 millions d'appels).\n2. **Efficacite sur les puzzles simples** : Le backtracking naive est tres rapide (moins d'une demi-millisecond) pour les puzzles faciles.\n3. **Limites sur les puzzles difficiles** : Plus de 4 secondes pour un puzzle difficile difficilement acceptable pour une application interactive.\n4. **Tous les puzzles resolus** : L'algorithme trouve toujours une solution (completude), mais le cout en temps varie enormement.\n\n> **Note technique** : Le temps de resolution n'est pas lineaire par rapport au nombre d'appels recursifs. Le puzzle difficile necessite 25 fois plus d'appels que le puzzle moyen, mais prend 29 fois plus de temps. Cela s'explique par le cout de la gestion de la pile d'appels et des operations de validation. (Les temps sont non-deterministes : ils dependent de la machine et de la charge CPU au moment de l'execution.)\n\n**Comparaison avec la theorie** : L'analyse des resultats confirme les proprietes theoriques du backtracking :\n- **Completude** : Tous les puzzles sont resolus avec 0 erreurs restantes\n- **Cout** : Exponentiel dans le pire cas, mais acceptable pour les instances simples\n- **Amelioration necessaire** : Les heuristiques (MRV, Forward Checking) sont indispensables pour les puzzles difficiles"
   },
   {
    "cell_type": "markdown",
@@ -934,25 +911,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Exemple guide : Backtracking avec Heuristique MRV (Minimum Remaining Values)\n",
-    "\n",
-    "### Enonce\n",
-    "\n",
-    "L'implementation actuelle de `BacktrackingDotNetSolver` choisit les cellules a remplir dans l'ordre de parcours (de gauche a droite, de haut en bas). Implementez une version amelioree avec l'heuristique **MRV** (Minimum Remaining Values) :\n",
-    "\n",
-    "L'heuristique MRV choisit en priorite la cellule qui a le **moins de valeurs possibles** (le domaine le plus petit). Intuitivement, on commence par les cellules les plus contraintes pour detecter les echecs plus tot et reduire l'espace de recherche.\n",
-    "\n",
-    "Implementez `BacktrackingMRVSolver` :\n",
-    "1. Pour chaque cellule vide, calculez son domaine (valeurs 1-9 compatibles avec les contraintes)\n",
-    "2. Choisissez la cellule avec le plus petit domaine non vide\n",
-    "3. Si un domaine est vide, retournez `false` immediatement (echec precoce)\n",
-    "4. Comparez le nombre d'appels recursifs avec `BacktrackingDotNetSolver`\n",
-    "\n",
-    "### Indice\n",
-    "\n",
-    "Le calcul du domaine consiste a retirer de {1..9} toutes les valeurs deja presentes dans la meme ligne, colonne ou bloc. L'heuristique MRV reduit drastiquement les appels recursifs sur les puzzles difficiles."
-   ]
+   "source": "## Exercice (guidé) : Backtracking avec Heuristique MRV (Minimum Remaining Values)\n\n### Enonce\n\nL'implementation actuelle de `BacktrackingDotNetSolver` choisit les cellules a remplir dans l'ordre de parcours (de gauche a droite, de haut en bas). Implementez une version amelioree avec l'heuristique **MRV** (Minimum Remaining Values) :\n\nL'heuristique MRV choisit en priorite la cellule qui a le **moins de valeurs possibles** (le domaine le plus petit). Intuitivement, on commence par les cellules les plus contraintes pour detecter les echecs plus tot et reduire l'espace de recherche.\n\nImplementez `BacktrackingMRVSolver` :\n1. Pour chaque cellule vide, calculez son domaine (valeurs 1-9 compatibles avec les contraintes)\n2. Choisissez la cellule avec le plus petit domaine non vide\n3. Si un domaine est vide, retournez `false` immediatement (echec precoce)\n4. Comparez le nombre d'appels recursifs avec `BacktrackingDotNetSolver`\n\n### Indice\n\nLe calcul du domaine consiste a retirer de {1..9} toutes les valeurs deja presentes dans la meme ligne, colonne ou bloc. L'heuristique MRV reduit drastiquement les appels recursifs sur les puzzles difficiles."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Closes #3290 (child of Epic #3164, premier notebook de la série Sudoku).

## Contexte — Audit fidélité #3164 (Sudoku-1 Backtracking C#)

Série Z3 complète (7/7). Extension à Sudoku (deep-queue ai-01 « Z3 + Sudoku »). Sudoku-1 = algorithme le + canonique de la série. Méthode : lecture complète + grep pivots + vérification outputs vs markdown.

## 2 findings (G.1 source-verified)

### 1. Mislabeling catégorique — « Exemple guide » MRV est un stub
Cell \`486520ad\` titrée « ## Exemple guide : Backtracking avec Heuristique MRV » mais cell \`c83254e4\` = **squelette à compléter** (\`return false; // TODO\`, \`return new HashSet<int>(); // TODO\`, \`// TODO: Implementez\`). Règle [exercise-example-labeling.md] (content-based) : un squelette avec TODOs = EXERCICE, pas un exemple résolu. **Fix** : « ## Exemple guide » → « ## Exercice (guidé) » (le qualificatif « guidé » préserve l'info de scaffolding lourd). La cellule stub \`c83254e4\` reste **intacte** (stub C.1 légitime).

### 2. Table de perf temps stale vs output (pattern markdown-vs-output, cf po-2024 CSP #3280)
Cell \`4261aa01\` colonne Temps affichait 0,49 / 177,79 / 5762,31 ms (exécution précédente) vs outputs committés **0,4354 / 141,0824 / 4127,7309 ms**. Appels (122 / 490 304 / 12 625 368) correspondent ✓ → seuls temps stale. **Fix** : aligné sur outputs + note dérivée « 32 fois » → « 29 fois » (4127/141=29, pas stale 5762/177=32) + « 5,7 secondes » → « 4 secondes » + caveat non-déterminisme.

## Validation (markdown-only, exception C.2)

- **0 cellule code source touchée** (code chars delta = **0**, anti-régression ✅). 19 cells préservées (8 code, 11 md).
- Le \`+3/-44\` du \`git diff --stat\` = **artefact de resérialisation JSON** (NotebookEdit compacte les arrays source), **pas une perte de contenu** — vérifié par comparaison char-totals (markdown +118 = mes ajouts ciblés, code +0).
- \`validate OK\` (0 erreur), \`scan_cell_ordering CLEAN\`, \`C.2 1/1 compliant\`.
- Outputs committés gelés (pas de re-exec) → l'alignement des temps est stable.

## Portée (note pour ai-01)
La série Sudoku = **~30 notebooks** (Sudoku-0 à 18, C# + Python) = un Epic entier. Sudoku-13 déjà travaillé (#3072/#3136/#3140/#3145). Sudoku-1 = 1er de la série. **[ASK ai-01]** confirmer priorité/scope Sudoku (toute la série ? sous-ensemble C# = ma partition ?) vs retour à d'autres Epics.

See #3164 (Epic parent).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>