### PR TITLE
fix(tweety6): correct ASPIC+ attack types — undermining is a premise attack, not conclusion

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
@@ -256,7 +256,7 @@
     "    * Défaisables (`DefeasibleInferenceRule`, `=>`): Si les prémisses sont acceptées, la conclusion l'est plausiblement, mais la règle elle-même peut être attaquée (undercutting) ou la conclusion réfutée (rebutting).\n",
     "* **Préférences**: Un ordre (souvent partiel) peut être défini sur les règles défaisables pour résoudre les attaques \"rebutting\".\n",
     "* **Arguments**: Construits par chaînage de règles depuis les axiomes.\n",
-    "* **Attaques**: Peuvent viser la conclusion (rebutting), une sous-conclusion (undermining sur conclusion intermédiaire) ou une règle défaisable (undercutting).\n",
+    "* **Attaques**: ASPIC+ définit trois types d'attaque selon leur cible (Prakken 2010) : (i) **rebuttal** — la conclusion de l'argument attaqué, y compris la conclusion intermédiaire d'un sous-argument (elle-même réfutable) ; (ii) **undermining** — une **prémisse ordinaire** (un fait à la base de l'argument, et non une conclusion) ; (iii) **undercutting** — l'**application d'une règle défaisable** (le lien d'inférence lui-même, indépendamment de ses prémisses ou de sa conclusion). Viser une « sous-conclusion » intermédiaire est donc un rebuttal du sous-argument, et non un undermining.\n",
     "* **`AspicArgumentationTheory`**: Représente la théorie ASPIC+. Nécessite un `RuleFormulaGenerator` pour spécifier la logique sous-jacente (ex: `PlFormulaGenerator` pour la logique propositionnelle).\n",
     "* **Conversion vers Dung (`asDungTheory`)**: Permet d'analyser la théorie ASPIC+ en la transformant en un AAF standard, sur lequel on peut appliquer les sémantiques de Dung (Grounded, Preferred, etc.).\n",
     "\n",


### PR DESCRIPTION
## Summary

Corrects the ASPIC+ attack-types mislabel in `Tweety-6-Structured-Argumentation.ipynb` (section 4.2, cell `675ee0f8`). Part of fidelity audit #3164 (Tweety family). Fixes the primary CONFIRMED finding of #3272.

## The error

The cell stated:

> *Attaques : Peuvent viser la conclusion (rebutting), une **sous-conclusion (undermining sur conclusion intermédiaire)** ou une règle défaisable (undercutting).*

This mislabels **undermining** as an attack on an intermediate conclusion ("sous-conclusion").

## The correction (ASPIC+ canonical, Prakken 2010 §3; Modgil & Prakken 2014)

ASPIC+ distinguishes its three attack types by their **target**:

| Attack type | Target | |
|-------------|--------|-|
| **rebuttal** | the **conclusion** of an argument or sub-argument | An intermediate conclusion (conclusion of a sub-argument) is itself rebuttable → attacking a "sous-conclusion" is a **rebuttal** of that sub-argument |
| **undermining** | an **ordinary premise** | a fact at the base of the argument, **not** a conclusion |
| **undercutting** | the **application of a defeasible rule** | the inference link itself, independent of premises/conclusion |

The notebook conflated **undermining** (premise attack) with **rebuttal of a sub-argument** (intermediate-conclusion attack). The fix maps each type to its true target and explicitly notes that targeting an intermediate conclusion is a rebuttal, not an undermining.

## No-pendulum

The legitimate concept of intermediate / sub-argument conclusions is **kept** (sub-arguments do have rebuttable conclusions). Only the attack-type classification is corrected — not a flip to "intermediate conclusions don't matter".

## Downstream consistency

Cell `ky20dkhpima` (idx4) describes the ASPIC+ example attacks as **rebuttals** (Arg4 `d` vs Arg5 `!d`, conclusion-vs-conclusion) — consistent with the corrected definition. No downstream breakage.

## Scope note (honest, no inflated DONE)

This addresses the **primary CONFIRMED finding** of #3272 (the undermining mislabel). The second finding — the score mechanism in cell `5loxyfjbhxa` ("Score final : 1 - 2 = -1 puis ajusté à -2.0", where the "ajusté à -2.0" step has no explained mechanism) — is **deferred**:

- The `-2.0` is now confirmed as a **real executed output** (the Tweety-6 JVM ran successfully — cell `0c9ba855`, ec=6, prints `Query 'h' (coupable)? -2.0`), so it is no longer an unverified number.
- But explaining the exact `SimpleAccumulator` + `ClassicalCategorizer` weighting that yields `-2.0` from the pro/con arguments requires inspecting the Tweety JAR source. **Inventing a formula would be a worse fidelity error than the current gap**, so it is left for a follow-up that reads the categorizer source.

→ `See #3272` (not `Closes`): the title finding is fixed; the score-mechanism finding remains open.

## Proofs

- Markdown source only (cell `675ee0f8`) — **C.2 exception, no re-exec**.
- The 10 code cells are **byte-identical** (0 source/output/ec modified); ec [1-10] preserved.
- Diff: 1 insertion / 1 deletion; **0 papermill.metadata churn** (surgical json round-trip).
- `scan_cell_ordering`: 1 clean, 0 findings.
- Catalogue + submodule byte-identical to `origin/main` (fresh base `c6af57a8`).
- 27 cells total, unchanged.

See #3272
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)