### PR TITLE
fix(planners1): remove fabricated warehouse claim — no such object in the model

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
@@ -1042,10 +1042,10 @@
    "source": [
     "### Exemple guide 1 : Planification de livraison\n",
     "\n",
-    "Appliquons le pattern de modelisation (types -> fluents -> actions -> etat initial -> but) a un probleme de livraison plus realiste. Un robot doit recuperer un colis au depot et le livrer a une destination, en se deplacant entre trois lieux.\n",
+    "Appliquons le pattern de modelisation (types -> fluents -> actions -> etat initial -> but) a un probleme de livraison plus realiste. Un robot doit recuperer un colis au depot et le livrer a une destination, en se deplacant entre deux lieux.\n",
     "\n",
     "**Probleme** :\n",
-    "- **Lieux** : depot, entrepot, destination\n",
+    "- **Lieux** : depot, destination\n",
     "- **Robot** : commence au depot, mains vides\n",
     "- **Colis** : se trouve au depot\n",
     "- **But** : livrer le colis a la destination\n",
@@ -1215,7 +1215,6 @@
     "| 3 | `drop(rob, pkg, dest)` | Le robot depose le colis a destination |\n",
     "\n",
     "**Analyse du plan** :\n",
-    "- Le robot ne passe pas par l'entrepot (lieu non pertinent pour ce probleme)\n",
     "- Le colis est ramasse avant le deplacement (precondition de `move` non liee au colis)\n",
     "- L'ordre `pick -> move -> drop` respecte toutes les preconditions\n",
     "\n",
@@ -1225,7 +1224,7 @@
     "3. **Fluent `carrying`** : Encode la relation \"le robot porte le colis\" -- necessaire pour eviter de prendre deux fois le meme colis\n",
     "4. **`default_initial_value=False`** : Tous les predicats sont faux par defaut, seuls les etats vrais sont declares explicitement\n",
     "\n",
-    "> **Note technique** : Le lieu `warehouse` est declare mais jamais utilise dans le plan. Le planificateur l'ignore car il n'est pas necessaire pour atteindre le but. C'est un exemple de la capacite du planificateur a raisonner uniquement sur les etats pertinents."
+    "> **Note technique** : Le modele ne declare que les objets strictement necessaires au but (`depot`, `dest`, `rob`, `pkg`). Un modele plus riche pourrait inclure des lieux supplementaires (entrepot, garage...) que le planificateur **ignorerait** car non pertinents pour atteindre le but -- le plan optimal resterait `pick -> move -> drop`. Cette instance reste minimale par souci de lisibilite : le code instancie exactement les 4 objets (`depot`, `dest`, `rob`, `pkg`) que le but `package_at(pkg, dest)` mobilise."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Corrects a fabricated claim in `Planners-1-Introduction.ipynb` (Exemple guide 1 livraison). The interpretation cell (`4bb5e2e9`) asserted *"Le lieu `warehouse` est déclaré mais jamais utilisé dans le plan. Le planificateur l'ignore"* — but **no such object exists in the model**. Part of fidelity audit #3164 (Planners family). Fixes the primary finding of #3277.

## Ground truth (verified in committed code, cell `470aedd3` ec=5)

The delivery problem declares exactly **4 objects**:

```python
depot_obj = Object('depot', Location, ...)
dest_obj  = Object('dest',  Location, ...)
rob_obj   = Object('rob',   Robot,    ...)
pkg_obj   = Object('pkg',   Package,  ...)
```

**No `warehouse` / `entrepot`** is ever instantiated — grep of the notebook source returns 0 hits outside the two prose cells that mention it. The teaching point ("the planner reasons only on relevant states") rested on an object the model never declares.

## The fix (markdown source only — C.2 exception, no re-exec)

| Cell | Change |
|------|--------|
| `76ce4db3` (intro) | "trois lieux : depot, entrepot, destination" → **"deux lieux : depot, destination"**, matching the 2 locations the code declares |
| `4bb5e2e9` (interp) | Removed fabricated *"Le robot ne passe pas par l'entrepot"* line (no entrepot exists); replaced the false *"warehouse declared but ignored"* note with a faithful reframing |

**No-pendulum:** the legitimate concept ("planners ignore irrelevant objects") is **preserved** — reframed as a general principle (a richer model *could* include irrelevant locations the planner would ignore; the optimal plan stays `pick → move → drop`) rather than a false claim that this model contains one. The concept isn't deleted; it's correctly scoped.

## Deferred (out of scope — code-cell + re-exec)

The companion finding of #3277 remains open: *"Le planificateur produit un plan en 3 actions, qui est optimal"* — the displayed plan comes from the pyperplan **`except` fallback** (pyperplan not installed; output prints *"Plan attendu (3 actions)"*, the hardcoded fallback), not from a solver run. Resolving it properly requires **installing `up-pyperplan` (rule F) + re-exec (C.2)** so the planner genuinely produces the plan. Deferred to a follow-up; this PR is the markdown-only warehouse fix.

→ `See #3277` (not `Closes`).

## Proofs

- Markdown source only (cells `76ce4db3`, `4bb5e2e9`) — **C.2 exception, no re-exec**.
- The 8 code cells are **byte-identical** (0 source/output/ec modified); ec [1-8] preserved.
- Diff: 3 insertions / 4 deletions; **0 papermill.metadata churn** (surgical json round-trip).
- `scan_cell_ordering`: 1 clean, 0 findings.
- Catalogue + submodule byte-identical to `origin/main` (fresh base `c6af57a8`); 36 cells total, unchanged.

See #3277
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)