### PR TITLE
docs(genai-texte): drop manual count duplicating CATALOG-STATUS (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -13,7 +13,7 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 
 ## Ce que vous apprendrez
 
-À travers ces 18 notebooks pratiques, vous acquerrez une expertise complète :
+À travers cette série pratique, vous acquerrez une expertise complète :
 - **Art du prompt engineering** : du zéro-shot au chain-of-thought
 - **Structuration des réponses** : JSON Schema, Pydantic, extraction de données
 - **Intelligence augmentée** : function calling, RAG moderne, code interpreter


### PR DESCRIPTION
## Summary

One surgical fix on `GenAI/Texte/README.md` — **anti-pattern 1** (manual count duplicating bot-owned CATALOG-STATUS). **Markdown-only** (C.2 exception). **CATALOG-STATUS byte-identical** (grep-verified). Follows dispatch ai-01 20:50Z po-2023: \"PostTraining fait. Continue : Texte/README (16 KB) puis SemanticKernel/README\".

## Edit
- **L16**: \"À travers ces **18 notebooks** pratiques\" → \"À travers cette série pratique\". The manual `18` duplicated `COURSE_CATALOG pedagogical_count: 18` and is the rust-prone manual decompte the gabarit flags (L64/L76) — it drifts silently each time a notebook is added.

## Why only 1 line (honest, G.9)

The census (sonnet evidence-cited + cross-checked G.1) found the Texte README is **otherwise already well-aligned** with the gabarit (structured recently via #3105):
- **Bridges (L161-169)**: the 5 dedicated cross-series bridges each name a concrete Texte notebook AND a concrete concept/tool on the other side (DALL-E, Whisper, Sora, SK plugins, Z3/Tweety/Lean) — **valid per gabarit L54**, not the empty generic bridges removed in PostTraining (#3275). The census initially flagged them as \"mixed/generic\"; on G.1 read they name concrete artifacts on both sides → keep.
- **FAQ**: 6 questions, exactly at the ~6 bound.
- **Navigation**: present at L10.
- **Notebook table**: faithful 18/18 (verified against disk).
- **No opening bandeau**; no parent/child verbatim duplication.

So the only real anti-pattern violation was this manual count. Inflating the PR with cosmetic edits to clear a line threshold would violate the \"no churn\" rule — the single honest fix is the right deliverable.

## Out of scope (flagged for ai-01)
The GenAI root README body still says \"Texte/ (11 notebooks)\" / \"~10h\" (parent L24, L79) while its own CATALOG-STATUS and the child both say 18 — **parent body text is stale**. Separate PR if ai-01 wants the parent harmonized (touches shared parent file, broader review).

## Validation
- CATALOG-STATUS byte-identical (grep-verified).
- check-docs-links + no-catalog-changes covered by CI.
- 1 file, +1/-1.

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)