### PR TITLE
fix(sudoku-2): DLX perf interpretation realignee sur l'output committe + lien DlxLib (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "**References** :\n",
     "- [Dancing Links Algorithm](https://en.wikipedia.org/wiki/Dancing_Links)\n",
-    "- [DLXLib Documentation](https://github.com/tomerfiliba/dlx)\n",
+    "- [DlxLib - package .NET (NuGet) utilise dans ce notebook](https://github.com/taylorjg/DlxLib)\n",
     "\n",
     "### Theorie de la Couverture Exacte\n",
     "\n",
@@ -960,7 +960,7 @@
     "1. Les 324 colonnes representent les contraintes Sudoku (cell, row, col, box)\n",
     "2. La methode `cover()` supprime une colonne et ses lignes conflits\n",
     "3. La methode `uncover()` restaure en ordre inverse pour le backtrack\n",
-    "4. L'heuristique de colonne minimum minimise la profondeur de recherche\n",
+    "4. L'heuristique de colonne minimum reduit le facteur de branchement (le nombre de noeuds explores), et non la profondeur de la recherche\n",
     "\n",
     "> **Note technique** : La structure circulaire des nœuds permet d'ajouter et supprimer des elements en O(1) sans reallocation de memoire.\n"
    ]
@@ -1284,7 +1284,7 @@
     "\n",
     "**Points cles** :\n",
     "1. Les deux solveurs utilisent le meme algorithme de base (Algorithm X avec Dancing Links)\n",
-    "2. Les temps d'execution devraient etre comparables car l'algorithmique est identique\n",
+    "2. Bien que les deux solveurs partagent le meme algorithme, les temps mesures different d'un a deux ordres de grandeur (cf. tableau ci-dessus : l'implementation personnalisee est ~33x a ~91x plus rapide). L'ecart ne vient pas de l'algorithmique mais du cout de construction de la matrice : DancingLinkSolver materialise pour chaque ligne un tableau dense de 324 entrees (new int[4*9*9]) converti en ImmutableList avant que DlxLib ne rebatisse sa propre structure, la ou DlxCustomized construit directement la matrice creuse (4 noeuds par placement)\n",
     "3. L'implementation customisee permet d'adapter le code a des besoins specifiques\n",
     "\n",
     "> **Note technique** : Dancing Links est particulierement efficace pour les problemes de couverture exacte comme le Sudoku car il minimise les operations inutiles lors du backtracking.\n"
@@ -1425,7 +1425,15 @@
   {
    "cell_type": "markdown",
    "id": "bf1418a8",
-   "source": "## Resume et perspectives\n\nCe notebook a presente deux implementations de l'algorithme Dancing Links (DLX) pour la resolution de Sudoku par couverture exacte. L'approche reformule le Sudoku comme une matrice de 729 lignes (une par couple cellule-valeur) et 324 colonnes (contraintes de cellule, ligne, colonne et bloc), qu'il s'agit de couvrir exactement. La bibliotheque DlxLib offre une solution concise et maintenable, tandis que l'implementation personnalisee `DlxCustomized` demontrre la maitrise complete de la structure de listes doublement chainees circulaires avec les operations `cover` et `uncover` en O(1).\n\nLes benchmarks ont revele un contraste surprenant : l'implementation personnalisee est environ 40 a 80 fois plus rapide que DlxLib sur tous les niveaux de difficulte (3-5 ms contre 150-290 ms). Cette difference s'explique par l'optimisation de la selection de colonne minimum et l'absence d'abstraction superflue. L'exercice sur les N-Reines illustre la generalite de l'approche : tout probleme de couverture exacte peut etre resolu par DLX, des pentominos au Picross.\n\nLe notebook [Search-App-11-Picross](../Search/Applications/CSP/App-11-Picross.ipynb) approfondit l'application de Dancing Links au probleme du Picross, un autre cas d'usage spectaculaire de la couverture exacte.",
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a presente deux implementations de l'algorithme Dancing Links (DLX) pour la resolution de Sudoku par couverture exacte. L'approche reformule le Sudoku comme une matrice de 729 lignes (une par couple cellule-valeur) et 324 colonnes (contraintes de cellule, ligne, colonne et bloc), qu'il s'agit de couvrir exactement. La bibliotheque DlxLib offre une solution concise et maintenable, tandis que l'implementation personnalisee `DlxCustomized` demontrre la maitrise complete de la structure de listes doublement chainees circulaires avec les operations `cover` et `uncover` en O(1).\n",
+    "\n",
+    "Les benchmarks ont revele un contraste surprenant : l'implementation personnalisee est environ 30 a 90 fois plus rapide que DlxLib selon la difficulte (de ~33x sur les grilles difficiles a ~91x, soit 2-5 ms contre 160-290 ms). Les deux approches utilisent pourtant le meme algorithme (Algorithm X) avec la meme heuristique de colonne minimum : l'ecart ne vient donc pas de l'algorithmique mais du cout de construction de la matrice, DlxLib materialisant une matrice dense de 324 colonnes par ligne la ou l'implementation personnalisee batit directement la structure creuse, sans abstraction superflue. Ces temps murals varient d'une execution a l'autre ; seul l'ordre de grandeur de l'ecart est significatif. L'exercice sur les N-Reines illustre la generalite de l'approche : tout probleme de couverture exacte peut etre resolu par DLX, des pentominos au Picross.\n",
+    "\n",
+    "Le notebook [Search-App-11-Picross](../Search/Applications/CSP/App-11-Picross.ipynb) approfondit l'application de Dancing Links au probleme du Picross, un autre cas d'usage spectaculaire de la couverture exacte."
+   ],
    "metadata": {}
   }
  ],


### PR DESCRIPTION
## Audit fidelite #3164 — Sudoku-2 DancingLinks (C#)

**Verdict : FIDELE** sur la theorie Dancing Links / Algorithm X (5 points canoniques presents et corrects, code `DlxCustomized` = portage fidele des splices cover/uncover de Knuth, 0 omission / 0 reinvention). Mais 4 erreurs factuelles dans la prose, dont 2 **contredisent l'output committe**. Closes #3297.

## Corrections (markdown-only, ancrees dans les outputs committes)

| Cell | Avant | Apres (preuve) |
|------|-------|----------------|
| `677ae20a` Interpretation | « les temps devraient etre comparables car l'algorithmique est identique » | Recadre : meme algo mais 33-91x d'ecart (cf. output `e09bda0f`) du au cout de construction (matrice dense vs creuse) |
| `bf1418a8` Resume | « 40 a 80 fois » + cause « optimisation selection colonne minimum » | « ~33-91x » (ratios reels 84.0/90.8/33.3) + vraie cause (construction matrice dense `new int[4*9*9]`->`ImmutableList`, les 2 ont l'heuristique) + caveat non-determinisme |
| `619eb60f` References | lien `tomerfiliba/dlx` (lib Python) | `taylorjg/DlxLib` (le package .NET reellement utilise par `#r "nuget: DlxLib"`) |
| `ee2868e7` | heuristique « minimise la profondeur de recherche » | « reduit le facteur de branchement / nombre de noeuds » (S-heuristique de Knuth) |

## Ratios re-calcules (output cell `e09bda0f`, ground truth)
- Easy : 291,18 / 3,47 = **84,0x** ; Medium : 212,82 / 2,34 = **90,8x** ; Hard : 163,40 / 4,91 = **33,3x** -> plage **33-91x** (l'ancien « 40-80x » rate les deux bornes).

## Validation
- **Markdown-only** : +13/-5, **0 cellule code source touchee, code chars delta = 0** (anti-regression verifiee par script). Exception C.2 (pas de re-exec).
- 26 cellules preservees. gate **cell-order CLEAN**, **C.2 1/1 compliant**, **validate 0 erreur**.
- Edit chirurgical round-trip JSON (diff minimal, pas de churn de re-serialisation).
- Methode : sous-agent `sonnet` evidence-cited + cross-check G.1 parent (lecture complete + re-calcul ratios + verif package .NET DlxLib reel via NuGet). No-pendulum : theorie DLX correcte preservee.

See #3164