### PR TITLE
fix(csp): correct AC-3 cascade overstatement in CSP-2 (See #3281)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
@@ -906,21 +906,22 @@
    "source": [
     "### Interpretation : AC-3 apres assignation\n",
     "\n",
-    "**Sortie obtenue** : cette fois, AC-3 propage l'assignation WA = Rouge et reduit les domaines des voisins.\n",
+    "**Sortie obtenue** : AC-3 propage l'assignation WA = Rouge et reduit les domaines des **voisins directs** de WA, c'est-a-dire NT et SA (2 revisions effectuees, cf. la sortie ci-dessus). Les autres variables (Q, NSW, V) restent inchangees.\n",
     "\n",
     "| Variable | Domaine avant AC-3 | Domaine apres AC-3 | Explication |\n",
     "|----------|-------------------|--------------------|--------------|\n",
     "| WA | {Rouge} | {Rouge} | Fixe par l'assignation |\n",
     "| NT | {R, V, B} | {V, B} | Voisin de WA : Rouge retire |\n",
     "| SA | {R, V, B} | {V, B} | Voisin de WA : Rouge retire |\n",
-    "| Q | {R, V, B} | (reduit selon propagation) | Depend de NT et SA |\n",
+    "| Q | {R, V, B} | {R, V, B} (inchange) | Voisin de NT/SA, mais garde un support pour chaque couleur |\n",
+    "| NSW, V | {R, V, B} | {R, V, B} (inchange) | Idem : aucune valeur n'y perd son dernier support |\n",
     "\n",
     "**Points cles** :\n",
-    "1. L'assignation de WA se propage a ses voisins NT et SA\n",
-    "2. La reduction de NT et SA peut a son tour provoquer des reductions chez leurs voisins (effet de cascade)\n",
-    "3. T (Tasmanie) reste inchangee car elle n'a aucun voisin\n",
+    "1. L'assignation de WA se propage a ses voisins directs NT et SA (Rouge retire).\n",
+    "2. En general, reduire NT et SA *pourrait* declencher d'autres reductions (effet de cascade), mais **seulement** si la reduction supprime le **dernier support** d'une valeur chez un voisin. Ici NT = {V, B} et SA = {V, B} laissent un support a chaque couleur de Q/NSW/V : la cascade s'arrete des le premier niveau (2 revisions).\n",
+    "3. T (Tasmanie) reste inchangee car elle n'a aucun voisin.\n",
     "\n",
-    "> **Observation** : AC-3 apres une assignation fait essentiellement le travail du Forward Checking (section 4) et davantage, car il propage en cascade."
+    "> **Observation** : AC-3 apres une assignation fait au moins le travail du Forward Checking (reduction des voisins directs) et peut aller plus loin par cascade. Sur cette instance, la propagation s'arrete des le premier niveau, faute de support supprime en aval."
    ]
   },
   {
@@ -1050,12 +1051,12 @@
    "source": [
     "### Interpretation : visualisation de la propagation\n",
     "\n",
-    "**Sortie obtenue** : la comparaison visuelle montre clairement l'effet de AC-3.\n",
+    "**Sortie obtenue** : la comparaison visuelle montre l'effet de AC-3 sur cette instance.\n",
     "\n",
     "**Points cles** :\n",
     "1. Les noeuds verts (singleton) representent les variables dont le domaine est reduit a une seule valeur\n",
     "2. Les noeuds jaunes montrent les variables dont le domaine a ete partiellement reduit\n",
-    "3. La propagation se fait en cascade : l'assignation de WA affecte NT et SA, qui a leur tour affectent Q, NSW et V\n",
+    "3. Sur cette instance, l'assignation de WA reduit directement NT et SA (Rouge retire) ; la propagation **s'arrete la**, car NT = {V, B} et SA = {V, B} laissent encore un support a Q, NSW et V. AC-3 peut propager plus loin sur d'autres instances, quand une reduction supprime le dernier support d'une valeur chez un voisin et declenche de nouvelles revisions.\n",
     "\n",
     "> **Resultat important** : dans certains cas, AC-3 seul peut resoudre le CSP completement (quand tous les domaines deviennent des singletons). Sinon, il faut combiner AC-3 avec le backtracking."
    ]


### PR DESCRIPTION
## Contexte

Audit de fidelite **#3164** (fille **#3281**), partition po-2024:CoursIA-2. Verdict : **INVENTION** dans l'interpretation markdown de `CSP-2-Consistency.ipynb` — le notebook decrit une propagation AC-3 en cascade qui n'a pas lieu dans la sortie reelle.

## Preuve G.1 (cell-17, ec=7, sortie commitee)

Apres `WA = Rouge`, AC-3 s'execute et affiche :
- `REVISE(NT, WA) -> D(NT) = ['Vert', 'Bleu']`
- `REVISE(SA, WA) -> D(SA) = ['Vert', 'Bleu']`
- `AC-3 termine : 2 revisions effectuees.`

Domaines finaux : **WA={Rouge}, NT={V,B}, SA={V,B}** ; **Q, NSW, V, T restent ['Rouge','Vert','Bleu'] INCHANGES**. La cascade s'arrete au premier niveau : reduire NT/SA a {V,B} ne supprime le dernier support d'aucune couleur chez leurs voisins, donc aucune revision supplementaire.

## Correction (markdown-only, no-pendulum)

| Cellule | Avant (faux) | Apres (corrige) |
|---------|--------------|------------------|
| cell-18 | `Q | (reduit selon propagation) | Depend de NT et SA` ; "propage en cascade" | `Q | {R,V,B} (inchange)` + ligne NSW/V ; cascade reformulee comme **conditionnelle** au retrait du dernier support (s'arrete au niveau 1 ici, 2 revisions) |
| cell-21 | "l'assignation de WA affecte NT et SA, **qui a leur tour affectent Q, NSW et V**" | "la propagation **s'arrete la** car NT/SA={V,B} laissent un support a Q, NSW, V ; AC-3 peut propager plus loin sur d'autres instances" |

**No-pendulum** : le concept de cascade AC-3 est **preserve** et correctement conditionne (une reduction doit supprimer le dernier support d'une valeur), pas supprime ni inverse.

## Verification

- Diff : **9 ins / 8 del**, uniquement le `source` des cellules 18 et 21 (markdown).
- JSON valide, 67 cellules intactes, catalogue + submodule **byte-identical** a main.
- **Markdown-only -> exception C.2** (aucune cellule code modifiee, outputs precedents valides).

## Findings differes (cellules code -> batch re-exec)

Restent dans #3281, traites separement car ils exigent une re-execution (C.2) :
- `tlxcmhaidl` : nombre d'arcs affiche `14` (`len(neighbors)*2`) vs reel **18** (somme des degres).
- `xql0p2h6dl` : ligne "Complexite amortie O(ed^2)" pour AC-3 (pire cas O(ed^3) ; O(ed^2) = AC-4).

See #3281