### PR TITLE
fix(csp): correct fidelity overstatements in CSP-3 markdown interpretations (See #3282)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
@@ -956,9 +956,9 @@
     "\n",
     "| Contrainte | Complexite propagation | Force de propagation | Cas d'usage |\n",
     "|------------|----------------------|---------------------|--------------|\n",
-    "| AllDifferent | $O(n\\sqrt{n})$ (Hopcroft-Karp) | Bounds/Domain consistency | Affectation, Sudoku |\n",
+    "| AllDifferent | $O(n^{1.5} d)$ (Regin, matching biparti) | Domain consistency | Affectation, Sudoku |\n",
     "| Cumulative | $O(n \\log n)$ (sweep) | Timetable + Edge-finding | Ordonnancement |\n",
-    "| Circuit | $O(n)$ (union-find) | Domain consistency | TSP, routage |\n",
+    "| Circuit | $O(n\\,\\alpha(n))$ (union-find, sous-tours) | Detection de sous-tours | TSP, routage |\n",
     "| Table | $O(|T| \\cdot k)$ | Arc consistency | Regles metier |"
    ]
   },
@@ -1263,20 +1263,22 @@
    "source": [
     "### Interpretation : CP-SAT vs backtracking\n",
     "\n",
-    "**Sortie obtenue** : CP-SAT resout N-Reines jusqu'a N=100 en quelques millisecondes.\n",
+    "**Sortie obtenue** : le temps de resolution croit de ~21 ms (N=8) a ~3080 ms (N=100). CP-SAT reste praticable jusqu'a N=100 (~3 secondes), la ou le backtracking devient intraitable.\n",
     "\n",
-    "| N | CP-SAT (ms) | Backtracking + MRV (estimation) | Facteur |\n",
-    "|---|------------|--------------------------------|----------|\n",
-    "| 8 | < 5 | ~1-5 ms | ~1x |\n",
-    "| 20 | < 10 | ~100 ms | ~10x |\n",
-    "| 50 | < 50 | > 10 s (estime) | > 200x |\n",
-    "| 100 | < 100 | Intraitable | -- |\n",
+    "| N | CP-SAT (ms, mesure) | Backtracking + MRV (estimation) | Verdict |\n",
+    "|---|---------------------|--------------------------------|---------|\n",
+    "| 8 | ~21 | ~1-5 ms | Backtracking plus rapide (overhead de CP-SAT) |\n",
+    "| 20 | ~65 | ~100 ms | Comparable |\n",
+    "| 50 | ~528 | > 10 s (estime) | CP-SAT nettement plus rapide |\n",
+    "| 100 | ~3080 | Intraitable | CP-SAT seul reste praticable |\n",
     "\n",
-    "**Pourquoi CP-SAT est-il si rapide ?**\n",
+    "**Pourquoi CP-SAT passe-t-il a l'echelle ?**\n",
     "1. **AllDifferent** : le propagateur specialise est beaucoup plus fort que les contraintes binaires\n",
     "2. **SAT backend** : la recherche utilise les techniques des solveurs SAT (clause learning, restarts)\n",
     "3. **Parallelisme** : CP-SAT utilise plusieurs strategies de recherche en parallele\n",
-    "4. **Propagation** : chaque assignation declenche des propagations en chaine tres efficaces"
+    "4. **Propagation** : chaque assignation declenche des propagations en chaine tres efficaces\n",
+    "\n",
+    "> **Note** : CP-SAT a un cout fixe de demarrage (~20 ms meme pour N=8) ; il devient gagnant a partir de N >= 20-30, quand le backtracking explose exponentiellement."
    ]
   },
   {
@@ -1913,22 +1915,22 @@
    "source": [
     "### Interpretation : cassage de symetries\n",
     "\n",
-    "**Sortie obtenue** : le cassage de symetries reduit le nombre de solutions et le temps de recherche.\n",
+    "**Sortie obtenue** : le cassage de symetries reduit le nombre de solutions (ratio ~2,6x) et, a partir de N=8, le temps de recherche.\n",
     "\n",
     "| N | Sans SB | Avec SB | Ratio solutions | Reduction temps |\n",
     "|---|---------|---------|----------------|------------------|\n",
-    "| 8 | 92 | ~23 | ~4x | Significative |\n",
-    "| 12 | 14 200 | ~3 550 | ~4x | Importante |\n",
+    "| 8 | 92 | 35 | ~2,6x | Significative |\n",
+    "| 12 | 14 200 | 5 564 | ~2,6x | Importante |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le ratio est d'environ **4x** car nos deux contraintes eliminent 2 symetries (reflexion + demi-rotation), sur les 8 du groupe dihedral\n",
-    "2. Le gain en temps est **superieur** au ratio de solutions car les branches symetriques eliminees auraient elles-memes genere des echecs couteux\n",
+    "1. Le ratio observe est d'environ **2,6x** : nos deux contraintes (premiere reine dans la moitie superieure, q[0] < q[n-1]) eliminent surtout les symetries de reflexion, pas les 8 symetries completes du groupe diedral (qu'on n'atteindrait qu'avec SBDS/SBDD)\n",
+    "2. Le gain en temps est **du meme ordre** que le ratio de solutions : les branches symetriques eliminees auraient elles-memes genere des echecs couteux\n",
     "3. Le cassage de symetries est d'autant plus important que le probleme est grand\n",
     "4. Des techniques plus sophistiquees (SBDS, SBDD) peuvent eliminer **toutes** les symetries automatiquement\n",
     "\n",
     "### Cas classique : le principe des tiroirs\n",
     "\n",
-    "Le **probleme des pigeons** (pigeonhole principle) illustre l'importance du cassage de symetries : placer $n+1$ pigeons dans $n$ trous, un par trou. C'est impossible, mais prouver l'infaisabilite est exponentiellement couteux sans symetries. Avec cassage de symetries (fixer l'ordre des pigeons), la preuve devient polynomiale."
+    "Le **probleme des pigeons** (pigeonhole principle) illustre le role du propagateur AllDifferent : placer $n+1$ pigeons dans $n$ trous, un par trou, est impossible. En theorie (Haken 1985), prouver cette infaisabilite est exponentiellement couteux pour les solveurs SAT **sans propagateur dedie**. En pratique, CP-SAT la detecte ici en ~0,2 ms grace a son propagateur AllDifferent : le cassage de symetries n'apporte donc **aucun gain** sur cette instance (voir le benchmark ci-dessous)."
    ]
   },
   {
@@ -2234,7 +2236,7 @@
     "- **Avantages** : Échappe aux minima locaux, explore l'espace de recherche plus efficacement\n",
     "- **Inconvénients** : Qualité dépend du choix du voisinage, pas de garantie d'optimalité\n",
     "\n",
-    "Dans cet exemple, on relaxe 3 tâches (fixées à None) et on résout le sous-problème, itérativement jusqu'à convergence ou timeout.\n"
+    "Dans cet exemple, on relaxe 4 tâches sur 12 (ratio de destruction de 40 %, soit `k_destroy = max(2, int(12 * 0.4)) = 4`) et on résout le sous-problème, itérativement jusqu'à convergence ou timeout."
    ]
   },
   {
@@ -2342,17 +2344,18 @@
    "source": [
     "### Interpretation : LNS pour l'ordonnancement\n",
     "\n",
-    "**Sortie obtenue** : la courbe de convergence montre l'amelioration progressive du makespan.\n",
+    "**Sortie obtenue** : la solution initiale (makespan = 18) atteint deja la borne inferieure $\\lceil 54/3 \\rceil = 18$. La courbe de convergence reste donc **plate** : LNS n'a aucune amelioration a apporter sur cette instance.\n",
     "\n",
     "| Mesure | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| Solution initiale | Variable | Trouvee par resolution complete |\n",
-    "| Meilleur makespan | Proche de la borne inferieure | LNS ameliore la solution |\n",
-    "| Iterations necessaires | ~5-10 | Convergence rapide |\n",
+    "| Borne inferieure | 18 | $\\lceil 54/3 \\rceil$ (somme des durees / machines) |\n",
+    "| Solution initiale | makespan = 18 | Trouvee par resolution complete, deja optimale |\n",
+    "| Meilleur makespan | 18 | Identique : aucune iteration LNS n'ameliore |\n",
+    "| Iterations utiles | 0 | La solution initiale etait deja a l'optimum |\n",
     "\n",
     "**Points cles** :\n",
-    "1. LNS converge typiquement vite au debut puis stagne\n",
-    "2. Le choix du **ratio de destruction** (ici 40%) est un parametre crucial :\n",
+    "1. Ici, la resolution complete trouve directement l'optimum : l'instance est trop facile pour mettre LNS en evidence. Sur des instances ou la resolution complete ne converge pas dans le budget de temps, LNS ameliore iterativement une solution sous-optimale.\n",
+    "2. Le choix du **ratio de destruction** (ici 40%, soit 4 taches sur 12) est un parametre crucial :\n",
     "   - Trop petit : explorations trop locales, convergence lente\n",
     "   - Trop grand : sous-probleme trop difficile, peu de gain\n",
     "3. CP-SAT utilise LNS **automatiquement** quand `num_search_workers > 1`\n",
@@ -2540,12 +2543,13 @@
     "---\n",
     "### Interprétation : Modèle complet de planification\n",
     "\n",
-    "Ce modèle combiné démontre la puissance des contraintes globales OR-Tools :\n",
-    "- **AllDifferent** : Un cours ne peut être dans deux salles simultanément\n",
-    "- **NoOverlap** : Un enseignant ne peut donner deux cours en même temps\n",
-    "- **TableConstraint** : Restrictions spécifiques (ex: certains cours ne peuvent pas être dans certaines salles)\n",
+    "Ce modèle combiné démontre la puissance des contraintes OR-Tools sur un problème de planification réel. Les contraintes effectivement utilisées dans le code sont :\n",
+    "- **AllDifferent** sur la paire encodée `(salle, créneau)` : deux cours ne peuvent occuper la même salle au même créneau\n",
+    "- **Contrainte d'inégalité** (`!=`) : Maths et Physique ne sont pas au même créneau (même enseignant)\n",
+    "- **Contrainte d'égalité** : le cours d'Info est imposé en salle C\n",
+    "- **Réification + modulo** (`only_enforce_if`, `add_modulo_equality`) : encodage des préférences (Maths le matin, éviter le mardi après-midi) pour l'objectif maximisé\n",
     "\n",
-    "La résolution trouve une assignation valide qui respecte toutes les contraintes, montrant comment les CSP modélisent des problèmes de planification réels.\n"
+    "La résolution trouve une assignation valide qui maximise les préférences (score 7/7), montrant comment les CSP modélisent des problèmes de planification réels."
    ]
   },
   {


### PR DESCRIPTION
## Scope

Audit #3164 daughter **#3282** — 6 markdown-only fidelity findings on `Search/Part2-CSP/CSP-3-Advanced.ipynb`. Atomic, markdown-only (C.2 exception: no code cell touched, no re-exec needed).

Every fix preserves the legitimate teaching concept (no-pendulum) and reframes it against the **committed cell outputs**:

| Cell | Finding | Fix |
|------|---------|-----|
| `table-interp` | AllDifferent `O(n√n)` Hopcroft-Karp / Circuit `O(n)` | `O(n^1.5 d)` Régin biparti matching / `O(n α(n))` subtour detection |
| `nqueens-scale-interp` | fabricated timings | real measured values (8≈21ms … 100≈3080ms) + honest verdict column + startup-cost note |
| `symmetry-interp` | "8× dihedral" / pigeonhole overclaim | ratio ~2.6× (reflection only); gain "du même ordre"; pigeonhole conditioned on SAT-without-propagator (Haken 1985), CP-SAT detects in ~0.2ms → SB no gain here |
| `36xj38bu0fm` / `lns-interp` | "3 tâches relaxées" + LNS improvement claim | 4 (`k_destroy=max(2,int(12*0.4))=4`); table reframed (initial already optimal makespan=18, 0 useful iterations, instance too easy), keeps general LNS theory |
| `31a8t3se5i3` | false NoOverlap/TableConstraint list | actual constraints (AllDifferent on encoded pair, `!=`, `==`, reification+modulo) + real result (score 7/7) |

## Deferred

**Finding 1 (circuit `INFEASIBLE`)** is a real code bug — `new_interval_var` end-arg forcing `start=0`, demand 6 > capacity 5 — requiring re-exec. Deferred to the rule-F install + re-exec batch, **not** this markdown-only PR.

## Verification

- `git diff` touches only 6 markdown cell `source` blocks — no code cell / output / `execution_count` lines.
- JSON valid, 59 cells (unchanged).
- Catalogue + submodule byte-identical to `main`.
- No trailing-newline churn (file ends with `}`).

See #3282