### PR TITLE
fix(planners): real pyperplan output + correct optimality claims in Planners-2 (Closes #3278)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
@@ -1282,22 +1282,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur: \n",
+      "Planificateur: Pyperplan\n",
+      "Resolution en cours...\n",
       "\n",
-      "Solution attendue (manuelle):\n",
+      "Solution trouvee !\n",
+      "==================================================\n",
       "  1. load(box1, truck1, depot)\n",
       "  2. drive(truck1, depot, store)\n",
       "  3. unload(box1, truck1, store)\n",
       "  4. drive(truck1, store, depot)\n",
       "  5. load(box2, truck1, depot)\n",
       "  6. drive(truck1, depot, warehouse)\n",
-      "  7. unload(box2, truck1, warehouse)\n"
+      "  7. unload(box2, truck1, warehouse)\n",
+      "==================================================\n",
+      "Longueur du plan: 7 actions\n"
      ]
     }
    ],
    "source": [
     "if UP_AVAILABLE:\n",
     "    from unified_planning.engines import PlanGenerationResultStatus\n",
+    "    from unified_planning.shortcuts import get_environment\n",
+    "    get_environment().credits_stream = None\n",
     "    \n",
     "    try:\n",
     "        # Utiliser un planificateur disponible\n",
@@ -1358,7 +1364,7 @@
     "| 6 | drive(truck1, depot, warehouse) | truck1@warehouse |\n",
     "| 7 | unload(box2, truck1, warehouse) | box2@warehouse (but 2 OK) |\n",
     "\n",
-    "> **Note** : Le plan a 7 actions n'est pas optimal en longueur mais satisfait le but. Un planificateur optimal pourrait trouver une solution plus courte."
+    "> **Note** : Ce plan de 7 actions est **optimal en longueur**. Le camion de capacite 1 (predicat `empty`) ne transporte qu'un colis a la fois : chaque colis impose donc un aller-retour (load -> drive -> unload, puis drive de retour pour aller chercher le suivant), soit 7 actions au minimum -- aucun plan plus court n'existe. pyperplan renvoie l'un des plans optimaux equivalents (l'ordre de traitement de box1/box2 peut varier d'une execution a l'autre)."
    ]
   },
   {
@@ -1781,7 +1787,7 @@
     "4. Poser ball1\n",
     "5. Poser ball2\n",
     "\n",
-    "> **Observation** : Le robot peut porter les 2 balles en meme temps ! Un planificateur qui n'utilise pas cette capacite ferait 9 actions au lieu de 5 (prendre, deplacer, poser, revenir, reprendre, deplacer, poser)."
+    "> **Observation** : Le robot peut porter les 2 balles en meme temps ! Un planificateur qui n'utilise pas cette capacite ferait 7 actions au lieu de 5 (prendre, deplacer, poser, revenir, reprendre, deplacer, poser)."
    ]
   },
   {


### PR DESCRIPTION
Fidelity audit #3164 daughter for `Planners-2-PDDL-Basics.ipynb`. Resolves the 3 findings of #3278.

## Findings fixed

| # | Cell | Before | After |
|---|------|--------|-------|
| 1 | `bfb011ec` (logistics, code) | except-branch hardcoded `Solution attendue (manuelle):` (pyperplan not installed) | **real** `OneshotPlanner` output: `Solution trouvee !` + 7-action plan + `Longueur du plan: 7 actions` |
| 2 | `5e74a1eb` (md) | `> Note : Le plan a 7 actions n'est pas optimal en longueur...` (contradicts `3c675d90` which says 7 is optimal) | `> Note : Ce plan de 7 actions est optimal en longueur` + capacity-1 reasoning (each package forces a round-trip) + note that pyperplan returns one of several equivalent optimal plans |
| 3 | `054a298d` (gripper, md) | `ferait 9 actions au lieu de 5` | `ferait 7 actions au lieu de 5` (matches its own 7-step parenthesis: naive single-ball strategy = 7 moves) |

## Rule F / C.2

- `up-pyperplan` installed locally (engine plugin for `unified-planning`) — env repaired, **not** bypassed.
- Notebook **re-executed**: all 13 code cells carry real outputs, coherent `execution_count`, **0 errors**, **0 fallback markers** in any output.
- Added 2-line credits-banner suppression (`get_environment().credits_stream = None`) to `bfb011ec`, mirroring the sibling Planners-1 cell, so the re-exec output is clean.

## Hygiene

- Diff: **11 ins / 5 del** — only the 2 markdown cells + transplanted code outputs. No papermill/temp-path metadata leak.
- `COURSE_CATALOG.generated.*` + MGS submodule **byte-identical** to main.
- `scan_cell_ordering.py` clean.

Note: pyperplan plan *order* is non-deterministic across runs (set-iteration order); plan *length* (7) is stable and optimal. The committed output's box1-first sequence matches the table in `5e74a1eb`; the note caveats that order may vary.

Closes #3278

🤖 Generated with [Claude Code](https://claude.com/claude-code)