### PR TITLE
fix(sudoku-3): ground genetic perf interpretation in committed output + Sudoku-GA caveat (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
@@ -1048,19 +1048,21 @@
    "source": [
     "### Interpretation des resultats\n",
     "\n",
-    "Le solveur genetique base sur les permutations de lignes montre des performances differentes selon la difficulte :\n",
+    "Le solveur genetique base sur les permutations de lignes montre des performances tres differentes selon l'encodage et la difficulte. Le tableau ci-dessous resume le **comportement attendu**, puis la lecture qui suit le confronte a la sortie reellement committee.\n",
     "\n",
-    "| Difficulte | Resultat attendu | Observations |\n",
-    "|------------|------------------|--------------|\n",
-    "| Facile | Resolution rapide | Convergence en quelques generations |\n",
-    "| Moyen | Resolution possible | Plus de generations necessaires |\n",
+    "| Difficulte | Comportement attendu | Observation sur l'execution committee |\n",
+    "|------------|----------------------|----------------------------------------|\n",
+    "| Facile | Convergence rapide | Resolu en ~39 ms, 0 erreur (encodage par permutations) |\n",
+    "| Moyen | Convergence plus difficile | Aucune resolution complete affichee (la sortie s'interrompt apres l'initialisation) |\n",
+    "\n",
+    "**Lecture de l'execution committee** : sur le puzzle facile, l'encodage par permutations de lignes resout la grille en ~39 ms, contre ~2,9 s pour l'encodage par cellules teste precedemment, soit un facteur d'environ 70. La raison est structurelle : en ne manipulant que des permutations de lignes, ce chromosome **pre-satisfait deja les contraintes de lignes**, ce qui reduit fortement l'espace de recherche laisse a la fonction de fitness (contraintes de colonnes et de blocs uniquement). Sur le puzzle moyen, en revanche, l'execution committee ne montre pas de resolution complete.\n",
     "\n",
     "**Points cles** :\n",
     "1. L'approche par permutations respecte les contraintes de lignes, reduisant l'espace de recherche\n",
     "2. La fitness negative (nombre d'erreurs) permet de guider l'evolution vers la solution\n",
-    "3. Le parallelimse accelere l'evaluation de la population\n",
+    "3. Le parallelisme accelere l'evaluation de la population\n",
     "\n",
-    "> **Note technique** : Les algorithmes genetiques sont bien adaptes aux problemes d'optimisation ou l'espace de solutions est trop grand pour une recherche exhaustive.\n"
+    "> **Note technique** : les algorithmes genetiques sont des optimiseurs generalistes adaptes aux espaces de recherche trop grands pour une enumeration exhaustive. Le Sudoku est toutefois un cas ou ils sont **notoirement peu fiables** : le couplage fort entre les contraintes cree un paysage de fitness trompeur ou l'evolution se piege facilement dans des optima locaux. C'est precisement pourquoi ce notebook a besoin de redemarrages avec doublement de la population, et pourquoi un encodage qui pre-satisfait une famille de contraintes (les permutations de lignes) change radicalement la donne. Re-executez les cellules de test pour observer la variabilite d'une execution a l'autre."
    ]
   }
  ],


### PR DESCRIPTION
## Résumé
Audit de fidélité #3164, série Sudoku — notebook `Sudoku-3-Genetic-Csharp`.

**Verdict théorie : FIDÈLE** (portage GeneticSharp fidèle, 8 piliers GA présents, 0 omission/réinvention ; sélection proportionnelle = scope documenté → `Search-5-GeneticAlgorithms`).

**Fix prose (markdown-only, cellule `6f705b5b`)** :
- L'ancienne table annonçait « Moyen : Résolution possible » alors que l'output committé (`0f5bb662`) ne montre **aucune résolution complète** du puzzle moyen (sortie interrompue après « Initialisation... »). Table recadrée : comportement attendu + observation réelle.
- Easy grounded dans les vrais chiffres : permutations ~39 ms vs cellules ~2,9 s (facteur ~70), raison structurelle (pré-satisfaction des contraintes de lignes).
- Note technique générique remplacée par le caveat canonique : GA notoirement peu fiables sur Sudoku (couplage de contraintes, optima locaux) → justifie redémarrages + doublement de population.
- typo `parallelimse` → `parallelisme`.

## Preuves
- **Markdown-only** : 0 cellule code touchée, **code chars delta = 0** (vérifié par script anti-régression), 28 cellules préservées. Exception C.2 (pas de re-exec).
- Édit chirurgical round-trip JSON, diff minimal **+9/-7**.
- Gates : **cell-order CLEAN, C.2 1/1 compliant, validate 0 erreur**.
- Catalogue + submodules byte-identical (non touchés).

## Note re-exec (hors scope)
L'output Medium committé est incomplet (run interrompu). Re-exec réel à faire dans un grain ultérieur : papermill casse sur `#!import` .NET et MCP Jupyter indispo cette session.

Closes #3305
See #3164