### PR TITLE
fix(tweety): Tweety-7b real JVM re-exec + constellations + Ex1/Ex4a + 2^n fidelity (#3274)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
@@ -59,11 +59,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: JPype1 in c:\\users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages (1.6.0)\n",
-      "Requirement already satisfied: packaging in c:\\users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages (from JPype1) (25.0)\n",
+      "Requirement already satisfied: JPype1 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (1.7.0)\n",
+      "Requirement already satisfied: packaging in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from JPype1) (25.0)\n",
       "Note: you may need to restart the kernel to use updated packages.\n",
-      "C:\\Users\\jsboi\\.conda\\envs\\mcp-jupyter\\python.exe\n",
-      "3.10.18 | packaged by Anaconda, Inc. | (main, Jun  5 2025, 13:08:55) [MSC v.1929 64 bit (AMD64)]\n"
+      "C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\python.exe\n",
+      "3.13.7 (tags/v3.13.7:bcee1c3, Aug 14 2025, 14:15:11) [MSC v.1944 64 bit (AMD64)]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],
@@ -118,7 +127,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Verification JVM Tweety + Outils ---\n"
+      "--- Verification JVM Tweety + Outils ---\n",
+      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JVM demarree avec 42 JARs.\n",
+      "\n",
+      "--- Outils disponibles ---\n",
+      "  EPROVER: eprover.exe\n",
+      "  SAT_SOLVER_PYTHON: sat_solver.py\n",
+      "  MARCO: marco.py\n",
+      "\n",
+      "JVM prete. Outils: 3/5\n"
      ]
     }
    ],
@@ -376,7 +400,53 @@
      "text": [
       "\n",
       "--- 5.7 Semantiques Basees sur le Classement (Ranking) ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "JVM prete. Execution des exemples de Ranking Semantics...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports pour Ranking Semantics reussis.\n",
+      "\n",
+      "Definition des AAFs exemples...\n",
+      "   - AAF Example 1 (Bonzon) defini.\n",
+      "   - AAF Example 2 (Pu) defini.\n",
+      "   - AAF Example 5 (Delobelle) defini.\n",
+      "   - AAF Example 4a (Matt & Toni) defini.\n",
+      "\n",
+      "--- Application des Raisonneurs de Classement ---\n",
+      "\n",
+      "* Categorizer:\n",
+      "  - AAF Ex1: {a=0.38, b=1.0, c=0.5, d=0.65, e=0.53}\n",
+      "  - AAF Ex2: {x1=0.716, x2=0.397, x3=0.521, x4=1.0}\n",
+      "\n",
+      "* Burden-Based:\n",
+      "  - AAF Ex1: [b > d > c > e > a]\n",
+      "\n",
+      "* Discussion-Based:\n",
+      "  - AAF Ex1: [b > d > c > e > a]\n",
+      "\n",
+      "* Tuples*:\n",
+      "  - AAF Ex5: [j = e = a > g = f > c > h = d = b > i]\n",
+      "\n",
+      "* Strategy-Based:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - AAF Ex4a: {a=0.167, b=1.0, c=1.0, d=0.25, e=1.0, f=0.25, g=1.0}\n",
+      "\n",
+      "* SAF-Based (SimpleProduct):\n",
+      "  - AAF Ex1: {a=0.17, b=0.48, c=0.25, d=0.33, e=0.3}\n",
+      "\n",
+      "* Counting Semantics:\n",
+      "  - AAF Ex1: {a=0.18, b=1.0, c=0.51, d=0.68, e=0.66}\n",
+      "\n",
+      "* Propagation Semantics:\n",
+      "  - AAF Ex5 (e=0.75): [j = e = a > c > h = d = b > f > g > i]\n"
      ]
     }
    ],
@@ -533,18 +603,18 @@
     "\n",
     "Les resultats ci-dessus montrent comment differentes semantiques de classement produisent des ordres distincts sur le meme framework :\n",
     "\n",
-    "**Convergence des semantiques :**\n",
-    "- **Categorizer** et **Counting** produisent des scores numeriques similaires : `b` est le plus fort (score 1.0), suivi de `d`, puis `c`, `e` et enfin `a`\n",
-    "- **Burden-Based** et **Discussion-Based** convergent vers le meme ordre : `[b > d > c > e > a]`\n",
+    "**Convergence des semantiques (Ex1) :**\n",
+    "- **Categorizer** `{a=0.38, b=1.0, c=0.5, d=0.65, e=0.53}` et **Counting** `{a=0.18, b=1.0, c=0.51, d=0.68, e=0.66}` donnent des scores de meme tendance : `b` est le plus fort (score 1.0), suivi de `d`, puis `e`, `c` et enfin `a`\n",
+    "- **Burden-Based** et **Discussion-Based** convergent vers `[b > d > c > e > a]` — note : leur ordre place `c` avant `e`, alors que les scores numeriques de Categorizer/Counting placent `e` legerement au-dessus de `c`. Les deux familles ne s'accordent donc pas sur la paire `c`/`e`\n",
     "\n",
     "**Observations cles :**\n",
-    "1. L'argument `b` (non attaque) obtient le score maximal dans toutes les semantiques\n",
-    "2. L'argument `a` est le plus faible car il est attaque par 4 arguments (`b`, `c`, `d`, `f` dans Ex1 ou Ex4a)\n",
+    "1. L'argument `b`, non attaque dans Ex1, obtient le score maximal (1.0) dans toutes les semantiques\n",
+    "2. L'argument `a` est le plus faible dans Ex1 (Categorizer 0.38, Counting 0.18) : il y est attaque par **2** arguments (`d` et `b`). Dans Ex4a, `a` est attaque par **4** arguments (`b`, `c`, `d`, `f`), d'ou son score Strategy-Based tres bas (`a=0.167`)\n",
     "3. Les semantiques **Tuples*** revelent des equivalences : `[j = e = a]` dans Ex5 signifie que ces arguments sont incomparables\n",
     "4. **SAF-Based** (Social) produit des scores plus faibles car elle considere l'agregation sociale des votes\n",
     "\n",
     "**Choix de semantique :**\n",
-    "- Utiliser **Categorizer** pour des scores interpretables (probabilite d'acceptation)\n",
+    "- Utiliser **Categorizer** pour des scores interpretables : une **force d'acceptabilite** dans [0, 1] (et non une probabilite)\n",
     "- Utiliser **Burden-Based** pour un ordre total simple\n",
     "- Utiliser **Tuples*** pour identifier les arguments equivalents"
    ]
@@ -603,7 +673,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ERREUR: JVM non demarree.\n"
+      "Exercice a completer\n"
      ]
     }
    ],
@@ -656,7 +726,9 @@
     "- `SubgraphProbabilityFunction`: Distribution sur les sous-graphes possibles\n",
     "- `getAcceptanceProbability(arg, semantics)`: Probabilité d'acceptation\n",
     "- `Division`: Partition IN/OUT/UNDEC\n",
-    "- `ArgumentationLottery`, `UtilityFunction`: Décision et utilité attendue"
+    "- `ArgumentationLottery`, `UtilityFunction`: Décision et utilité attendue\n",
+    "\n",
+    "> **Deux écoles.** `SubgraphProbabilityFunction` relève de l'**approche par constellations** (Li, Oren & Norman, 2011) : l'incertitude porte sur la *structure* du graphe (quels arguments et attaques sont présents), et la probabilité d'acceptation d'un argument est la masse des sous-graphes dans lesquels il est accepté. Elle se distingue de l'**approche épistémique** (Hunter, 2013 ; Thimm, 2012), où le graphe est fixe et la probabilité exprime le *degré de croyance* d'un agent en chaque argument. Ce notebook illustre la première."
    ]
   },
   {
@@ -686,7 +758,36 @@
      "text": [
       "\n",
       "--- 5.8 Argumentation Probabiliste ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "JVM prete. Execution de l'exemple d'argumentation probabiliste...\n",
+      "Imports pour Argumentation Probabiliste reussis.\n",
+      "\n",
+      "1. Creation de l'AAF de base...\n",
+      "   AAF:  <{ a, b, c },[(c,b), (a,b), (b,a)]>\n",
+      "\n",
+      "2. Extensions Grounded (pour reference)...\n",
+      "   Extensions Grounded: [{a,c}]\n",
+      "\n",
+      "3. Creation d'une fonction de probabilite uniforme sur les sous-graphes...\n",
+      "   Nombre de sous-graphes possibles: 19\n",
+      "\n",
+      "4. Calcul des probabilites d'acceptation (Semantique Grounded)...\n",
+      "   P(Accepte(a)) = 0.5263\n",
+      "   P(Accepte(b)) = 0.3158\n",
+      "   P(Accepte(c)) = 0.6316\n",
+      "\n",
+      "   Calcul probabilite pour Division ({a, c}, {b})...\n",
+      "   P(Division=({a,c}, {b})) = 0.3158\n",
+      "\n",
+      "5. Loteries d'Argumentation et Utilite Attendue...\n",
+      "   Divisions standard: [({a,b}, {c}), ({c}, {a,b}), ({b}, {a,c}), ({a}, {b,c}), ({}, {a,b,c}), ({a,b,c}, {}), ({b,c}, {a}), ({a,c}, {b})]\n",
+      "\n",
+      "   Loterie basee sur les divisions standard:\n",
+      "     [ 0.05263157894736842,({a,b}, {c}) ; 0.15789473684210525,({c}, {a,b}) ; 0.10526315789473684,({b}, {a,c}) ; 0.10526315789473684,({a}, {b,c}) ; 0.10526315789473684,({}, {a,b,c}) ; 0.05263157894736842,({a,b,c}, {}) ; 0.10526315789473684,({b,c}, {a}) ; 0.3157894736842105,({a,c}, {b}) ]\n",
+      "\n",
+      "   Fonction d'utilite exemple:\n",
+      "     {({a,b}, {c})=10.0, ({c}, {a,b})=-5.0}\n",
+      "\n",
+      "   Utilite Attendue de la loterie: -0.2632\n"
      ]
     }
    ],
@@ -890,7 +991,49 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ERREUR: JVM non demarree. Exemple guide (debat medical) non execute.\n"
+      "AAF: <{ e1, t1, e2, t2, c1 },[(c1,t2), (e1,t1), (e2,e1)]>\n",
+      "\n",
+      "Categorizer\n",
+      "{e1=0.5, t1=0.667, e2=1.0, t2=0.5, c1=1.0}\n",
+      "\n",
+      "Burden-Based\n",
+      "[c1 = e2 > t1 > t2 = e1]\n",
+      "\n",
+      "Discussion-Based\n",
+      "[c1 = e2 > t1 > t2 = e1]\n",
+      "\n",
+      "Analyse\n",
+      "Categorizer : t1=0.667, t2=0.500. Le traitement A (t1) est mieux classe que B (t2).\n",
+      "Burden-Based : [c1 = e2 > t1 > t2 = e1]. t1 est strictement au-dessus de t2.\n",
+      "Discussion-Based : [c1 = e2 > t1 > t2 = e1]. Meme ordre que Burden-Based.\n",
+      "\n",
+      "Convergence : les 3 semantiques produisent le meme ordre relatif t1 > t2.\n",
+      "Cette convergence s'explique par la structure simple du graphe (chaine d'attaques sans cycle).\n",
+      "Sur des graphes avec cycles ou attaques multiples, Categorizer et Burden peuvent diverger.\n",
+      "\n",
+      "Mecanisme : t1 est reinstaure par e2 (defenseur de t1 via e2 -> e1 -> t1).\n",
+      "En revanche, t2 est attaque par c1 (non attaque, score 1.0) sans aucun defenseur.\n",
+      "Le traitement A est donc mieux supporte que B dans les 3 semantiques.\n",
+      "\n",
+      "Bonus : ajout de e3 attaquant e2\n",
+      "AAF modifie: <{ e1, t1, e2, t2, c1, e3 },[(c1,t2), (e1,t1), (e2,e1), (e3,e2)]>\n",
+      "\n",
+      "Categorizer apres ajout e3:\n",
+      "{e1=0.667, t1=0.6, e2=0.5, t2=0.5, c1=1.0, e3=1.0}\n",
+      "\n",
+      "Burden-Based apres ajout e3:\n",
+      "[e3 = c1 > e1 > t1 > t2 = e2]\n",
+      "\n",
+      "Discussion-Based apres ajout e3:\n",
+      "[e3 = c1 > e1 > t1 > t2 = e2]\n",
+      "\n",
+      "Analyse du bonus\n",
+      "Avant e3 : Categorizer t1=0.667. Apres e3 : t1=0.600. Diminution de 0.067.\n",
+      "Avant e3 : Categorizer t2=0.500. Apres e3 : t2=0.500. Inchange.\n",
+      "e1 passe de 0.500 à 0.667 apres ajout de e3, ce qui confirme numeriquement la defense.\n",
+      "e3 défend e1 en attaquant l'attaquant de e1 (qui est e2).\n",
+      "Chaine : e3 -> e2 -> e1 -> t1. c'est une attaque de second ordre, qui annule partiellement la défense de t1 par e2\n",
+      "t1 reste au-dessus de t2 (0.600 > 0.500) mais l'ecart se reduit de 0.167 a 0.100.\n"
      ]
     }
    ],
@@ -1045,7 +1188,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ERREUR: JVM non demarree.\n"
+      "Exercice a completer\n"
      ]
     }
    ],
@@ -1106,7 +1249,7 @@
     "\n",
     "### Argumentation Probabiliste\n",
     "\n",
-    "- **SubgraphProbabilityFunction**: Distribution sur les 2^n sous-graphes possibles\n",
+    "- **SubgraphProbabilityFunction**: Distribution sur les sous-graphes possibles (les arguments *et* les attaques varient : 19 sous-graphes pour l’exemple a 3 arguments / 3 attaques, et non 2^n)\n",
     "- **Acceptabilité probabiliste**: P(arg ∈ extension | sous-graphe)\n",
     "- **Division**: Partition (IN, OUT) représentant un état possible\n",
     "- **Loterie**: Distribution sur les divisions avec utilités attendues\n",
@@ -1202,7 +1345,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice a completer"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],


### PR DESCRIPTION
## Origine

Audit fidelite Epic **#3164** (turf po-2024 SymbolicAI/Tweety) — `Closes #3274`. Le cluster le plus risque des Tweety-6/7 (4 findings + cluster DEFER-re-exec). Suite de #3247/#3250/#3259/#3272/#3273.

## Probleme

`Tweety-7b-Ranking-Probabilistic.ipynb` etait committe avec `execution_count` 1-8 mais **6/8 cellules code en `ERREUR: JVM non demarree`** : la JVM Tweety n'avait pas demarre dans l'environnement de commit. Les cellules d'interpretation assertaient pourtant des nombres precis (`P(c)=0.632`, utilite `-0.26`, etc.) absents de tout output reel — non fiables (probleme structurel C.2).

## Correctif

Re-execution sous JVM **fonctionnelle** (regle F : JDK Zulu 17.0.11 portable + 42 JARs Tweety provisionnes via `scripts/download_tweety_tools.py`, les deux gitignored), puis transplant des outputs reels (outputs + execution_count uniquement, kernelspec `nlp-course` preserve).

| # | Finding | Fix |
|---|---------|-----|
| 1 OMISSION | approche constellations innommee, epistemic absente | `591daf12` : nomme constellations (Li, Oren & Norman 2011) + contraste epistemic (Hunter 2013 ; Thimm) |
| 2 INVENTION | « a attaque par 4 (Ex1 ou Ex4a) » | `uwblc73ap9` : Ex1 -> **2** attaquants (d, b) ; Ex4a -> **4** (b, c, d, f). Ordre c/e numerique vs positionnel explicite |
| 3 INVENTION | contradiction « 2^n » vs « 19 » | `cef18cf7` : « 2^n » -> compte reel **19** (args ET attaques varient), coherent avec `0rci5yfhdkr` |
| 4 cluster re-exec | nombres sans backing execute | run JVM reel : 19 sous-graphes, P(a)=**0.5263**, P(b)=**0.3158**, P(c)=**0.6316**, utilite **-0.2632** — confirment les nombres markdown |
| 5 LOW | Categorizer = « probabilite » | `uwblc73ap9` : requalifie en **force d'acceptabilite** dans [0,1] |

Note : l'example-guide `ihnq7d0yl8` hard-code des chaines d'analyse (`Categorizer : t1=0.667…`) — la re-exec confirme qu'elles **correspondent** a l'output reel de l'API (`{t1=0.667,…}`). Cellule fonctionnelle laissee intacte (note ⚠️, pas critere d'acceptation).

## Validation

- `8` cellules code, **0 erreur**, **0** placeholder « JVM non demarree », `execution_count` 1-8 non-null
- `python scripts/notebook_tools/scan_cell_ordering.py` : **1 clean, 0 finding**
- Catalogue (`COURSE_CATALOG.generated.*` + marqueurs) et submodule MGS **byte-identiques** a main
- Diff 169/+ 19/- (insertions > deletions : outputs reels plus riches que les placeholders d'echec — C.2, pas regression)

## Criteres d'acceptation #3274

- [x] Approche constellations nommee + contrastee avec epistemic
- [x] `uwblc73ap9` : Ex1 (2 attaquants) vs Ex4a (4) distingues
- [x] `cef18cf7` : compte de sous-graphes corrige (coherent avec `0rci5yfhdkr`)
- [x] Section probabiliste : chaque nombre backing-e par output JVM reel
- [x] Categorizer requalifie en force d'acceptabilite
- [x] 0 cellule code cassee ; gate cell-order clean
- [ ] Revue ai-01 (#3164)

See #3164, #3247, #3250, #3259, #3272, #3273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)