### PR TITLE
fix(gametheory): reconcile 03-Voting-Methods interpretation cells with committed output (Closes #3313)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
@@ -645,17 +645,17 @@
    "source": [
     "### Interpretation : Comparaison des règles sur le profil cyclique\n",
     "\n",
-    "**Résultat surprenant** : Sur le profil de Condorcet (cycle A > B > C > A), les trois règles donnent le même classement A > B > C.\n",
+    "**Résultat** : Sur le profil de Condorcet (cycle A > B > C > A), les trois règles **ne donnent pas le même classement**. Le profil étant parfaitement symétrique, chaque règle aboutit à une **égalité** que seul le départage (ordre d'énumération) tranche.\n",
     "\n",
-    "| Regle | Classement | Note |\n",
-    "|-------|------------|------|\n",
-    "| Pluralité | A > B > C | 1 vote chacun pour A, B, C en premier choix → ex æquo, ordre alphabetique par defaut |\n",
-    "| Borda | A > B > C | A: 4 pts, B: 3 pts, C: 2 pts |\n",
-    "| Copeland | A > B > C | Scores pairwise: A=0, B=-2, C=-4 |\n",
+    "| Regle | Classement (sortie) | Scores | Note |\n",
+    "|-------|---------------------|--------|------|\n",
+    "| Pluralité | C > B > A | 1, 1, 1 | Un seul premier choix pour chaque alternative → ex æquo, départagé |\n",
+    "| Borda | A > B > C | 3, 3, 3 | Chaque alternative occupe une fois chaque rang → ex æquo, départagé |\n",
+    "| Copeland | C > B > A | 0, 0, 0 | Cycle pairwise (A bat B, B bat C, C bat A) → chacun +1/-1 → ex æquo, départagé |\n",
     "\n",
-    "**Pourquoi l'accord ici ?** Bien que le profil soit cyclique en duels pairwise, chaque règle utilise une logique différente qui, par hasard, converge vers le même ordre.\n",
+    "**Pourquoi des égalités partout ?** La symétrie du cycle de Condorcet donne à chaque alternative exactement le même profil de rangs et de duels. Aucune règle ne peut donc départager sur le fond : le classement affiché ne reflète qu'un départage arbitraire (l'ordre dans lequel les alternatives sont énumérées), pas une réelle préférence collective.\n",
     "\n",
-    "> **Attention** : Ce cas est particulier. Avec d'autres profils (comme le suivant), les règles divergent significativement."
+    "> **Attention** : Avec un profil non symétrique (comme le suivant), les égalités disparaissent et les règles divergent réellement."
    ]
   },
   {
@@ -672,22 +672,15 @@
     "tags": []
    },
    "source": [
-    "### Analyse des resultats\n",
+    "### Analyse : que nous apprend ce profil cyclique ?\n",
     "\n",
-    "Avec le profil de Condorcet (cycle A > B > C > A), les trois regles donnent des resultats differents :\n",
+    "Le cycle de Condorcet illustre le coeur du **théorème d'Arrow** : il n'existe pas de règle d'agrégation qui satisfasse simultanément tous les critères de rationalité collective. Ici, aucune des trois règles ne peut désigner un vainqueur légitime — elles aboutissent toutes à une **égalité** (voir le tableau ci-dessus) que seul un départage arbitraire tranche.\n",
     "\n",
-    "| Regle | Classement | Principe |\n",
-    "|-------|------------|----------|\n",
-    "| **Pluralite** | C > A > B | Compte uniquement les premiers choix (1 chacun) |\n",
-    "| **Borda** | A > B > C | Points selon le rang (2 pts 1er, 1 pt 2e, 0 pt 3e) |\n",
-    "| **Copeland** | C > A > B | Score = victoires - defaites pairwise |\n",
+    "- Le profil est **cyclique en duels** (A bat B, B bat C, C bat A) : il n'y a **pas de gagnant de Condorcet**.\n",
+    "- Chaque règle « casse » ce cycle à sa manière, mais aucune ne le fait sur un fondement objectif.\n",
+    "- C'est précisément l'**arbitraire inhérent** que la preuve du théorème d'Arrow rend inévitable pour toute règle d'agrégation portant sur au moins trois alternatives.\n",
     "\n",
-    "**Observations** :\n",
-    "- Pluralite et Copeland coincident ici, mais Borda differe\n",
-    "- Avec un profil cyclique, **aucune regle ne peut eviter l'arbitraire**\n",
-    "- La preuve du theoreme d'Arrow montre que ce probleme est inherent a toute regle d'agregation\n",
-    "\n",
-    "> **Note** : Le choix de la regle de vote n'est pas neutre - il peut determiner le vainqueur dans les situations de preferences divisees."
+    "> **Note** : Le choix de la règle de vote n'est pas neutre — sur des préférences divisées (profil suivant), il peut déterminer le vainqueur."
    ]
   },
   {
@@ -769,18 +762,18 @@
    "source": [
     "### Interpretation : Divergence des règles de vote\n",
     "\n",
-    "**Résultat sur le profil divergent** : Les trois règles donnent des classements différents.\n",
+    "**Résultat sur le profil divergent** : les trois règles donnent des classements différents.\n",
     "\n",
-    "| Regle | Classement | Gagnant | Explication |\n",
-    "|-------|------------|---------|-------------|\n",
-    "| Pluralité | A > C > B | A | Compte les premiers choix (2 votes pour A) |\n",
-    "| Borda | B > C > A | B | Points selon le rang (B beneficie de bonnes positions) |\n",
-    "| Copeland | B > C > A | B | Score pairwise (B bat C, perd contre A; C perd contre A et B) |\n",
+    "| Regle | Classement (sortie) | Gagnant | Explication |\n",
+    "|-------|---------------------|---------|-------------|\n",
+    "| Pluralité | C > A > B | C | Premiers choix : A et C à 2 voix chacun, B à 1 → ex æquo A/C départagé vers C |\n",
+    "| Borda | B > C > A | B | Points selon le rang (6, 5, 4) : B profite de positions intermédiaires solides |\n",
+    "| Copeland | B > C > A | B | Scores pairwise : B = +2 (bat A et C), C = 0 (bat A, perd contre B), A = -2 (perd contre les deux) |\n",
     "\n",
     "**Pourquoi cette divergence ?**\n",
-    "- **Pluralité** ne regarde que les premiers choix, ignorant la profondeur des préférences\n",
-    "- **Borda** tient compte de la position complète, donc B (souvent 2e) gagne\n",
-    "- **Copeland** regarde les duels, favorisant les candidats \"consensuels\"\n",
+    "- **Pluralité** ne regarde que les premiers choix : A et C sont à égalité (2 voix), seul le départage donne C, alors que B (1 voix) est éliminé bien qu'il soit le vainqueur des deux autres règles.\n",
+    "- **Borda** tient compte de la position complète, donc B (souvent bien placé) gagne avec 6 points.\n",
+    "- **Copeland** regarde les duels : B bat A et C, ce qui en fait le vainqueur « consensuel ».\n",
     "\n",
     "> **Leçon politique** : Le choix de la règle électorale n'est pas neutre. Dans les élections réelles, la règle de vote peut changer le vainqueur lorsque les préférences sont polarisées."
    ]


### PR DESCRIPTION
## Quoi

Audit fidélité (extension #3164) sur la famille `GameTheory/`. Trois cellules markdown d'interprétation de `SocialChoice/03-Voting-Methods.ipynb` **inventaient** des classements/scores que la sortie code committée réfute. Fix **markdown-only** : les sorties code committées sont déjà correctes.

## Findings réconciliés (G.1-vérifiés par recalcul indépendant via les fonctions du notebook)

| Cellule | Claim faux | Sortie committée / vérité-terrain |
|---------|-----------|-----------------------------------|
| `184e7b7f` | « les trois règles donnent le même classement A>B>C » ; Borda 4/3/2 ; Copeland 0/-2/-4 | Pluralité **C>B>A** (1/1/1), Borda **A>B>C** (**3/3/3** ex æquo), Copeland **C>B>A** (**0/0/0**) |
| `8d31eeb8` | 2e interprétation du même output, transpose 2e/3e (C>A>B) et contredit `184e7b7f` | Recentrée sur la leçon Arrow, table fabriquée retirée |
| `82a3ae92` | Pluralité A>C>B, gagnant **A** « 2 votes pour A » ; Copeland « B perd contre A; C perd contre A » | Pluralité **C>A>B** (A/C ex æquo à 2 voix, départage → **C**) ; Copeland **B = +2** (bat A et C), C = 0, A = -2 |

`condorcet_profile` = cycle canonique `[A>B>C, B>C>A, C>A>B]` (cellule i=7) → symétrie parfaite → égalités sur les trois règles. `divergent_profile` (i=15) recalculé : Borda 6/5/4, Copeland +2/0/-2.

## Vérification
- `git diff` : 23 insertions / 30 deletions, **3 cellules markdown uniquement**.
- Aucune cellule code, `execution_count`, `outputs`, catalogue ou submodule touchés → pas de ré-exécution nécessaire (C.2 : modif markdown-only).
- Méthodo : sous-agent sonnet read-only (audit) + cross-check G.1 par po-2024 (recalcul des scores avec `borda_rule`/`copeland_rule`/`plurality_rule` du notebook).

## Hors scope (laissés au jugement coordinateur)
FINDINGS 4 (`GameTheory-8-CombinatorialGames` `44637721` « multiples de 4 » placé après l'exo S({1,3})) et 5 (`GameTheory-15-CooperativeGames` `fe519ccf` seuil 95% vs E[U]) : MED, ambiguïté placement / hypothèse de modèle. À trancher séparément.

Closes #3313