### PR TITLE
docs(sudoku-4): reconcile SA interpretations with committed outputs (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -1935,8 +1935,8 @@
     "| Aspect | Observation |\n",
     "|--------|-------------|\n",
     "| Resultat | Le recuit simule trouve generalement la solution pour les puzzles faciles |\n",
-    "| Temps | Plus lent que les solveurs deterministes (backtracking, OR-Tools) |\n",
-    "| Iterations | Plusieurs milliers d'iterations necessaires |\n",
+    "| Temps | Variable ; ici ~3,4 ms, mais d'autres puzzles faciles demandent plusieurs secondes (cf. test suivant) |\n",
+    "| Iterations | Tres variable selon le puzzle : 733 iterations pour ce run, mais de ~1 000 a plus de 2 millions sur l'echantillon de cellules faciles |\n",
     "| Non-determinisme | Chaque execution peut donner un resultat different |\n",
     "\n",
     "> **Point cle** : contrairement au backtracking qui est **deterministe** et **garanti**, le recuit simule est **probabiliste**. Il peut echouer, notamment sur les puzzles difficiles."
@@ -2234,16 +2234,18 @@
    "source": [
     "### Interpretation : resultats des tests\n",
     "\n",
-    "| Difficulte | Taux de succes attendu | Temps typique | Observations |\n",
-    "|------------|----------------------|---------------|-------------|\n",
-    "| Easy | 60-100% | 100-2000 ms | Souvent reussi avec les parametres par defaut |\n",
-    "| Medium | 10-50% | 500-5000 ms | Resultat variable, depend de la structure du puzzle |\n",
-    "| Hard | < 10% | > 5000 ms | Rarement reussi sans ameliorations |\n",
+    "Le tableau ci-dessous distingue le **comportement general attendu** du recuit simule de ce qui a ete **reellement observe dans les sorties committees** de ce notebook. Les deux peuvent diverger fortement car le resultat depend du reglage des hyperparametres ($T_0$, $\\alpha$, $N_{iter}$, redemarrages), qui n'est pas le meme d'une cellule de test a l'autre.\n",
+    "\n",
+    "| Difficulte | Comportement general attendu | Observe dans les sorties committees |\n",
+    "|------------|------------------------------|--------------------------------------|\n",
+    "| Easy | Souvent reussi | 5/5 resolus (test dedie), de 2 ms a ~3,8 s selon le puzzle (moyenne ~1,2 s) |\n",
+    "| Medium | Resultat variable, sensible au reglage | Tres sensible aux parametres : 2/3 resolus avec un reglage agressif ($\\alpha=0{,}9995$, 200 iter/palier, 10 redemarrages) mais en ~30 a ~65 s ; 0/5 avec les parametres du banc de comparaison |\n",
+    "| Hard | Rarement reussi sans ameliorations | 0 resolu (banc de comparaison), statut Disqualifie |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le recuit simule **ne garantit pas** de trouver la solution\n",
-    "2. Les performances dependent fortement du **reglage des parametres** ($T_0$, $\\alpha$, $N_{iter}$)\n",
-    "3. Pour les puzzles difficiles, les solveurs CSP (OR-Tools, Z3) restent bien plus fiables"
+    "1. Le recuit simule **ne garantit pas** de trouver la solution, et son taux de succes **varie enormement** selon les hyperparametres (de 0 % a 67 % sur Medium selon le reglage).\n",
+    "2. Un reglage qui augmente le taux de succes (plus d'iterations par palier, refroidissement plus lent, plus de redemarrages) **augmente aussi fortement le temps** : les puzzles Medium resolus le sont en plusieurs dizaines de secondes.\n",
+    "3. Pour les puzzles difficiles, les solveurs CSP (OR-Tools, Z3) et le backtracking restent bien plus fiables et rapides."
    ]
   },
   {
@@ -2551,9 +2553,9 @@
     "| **Backtracking** | Deterministe, garanti, rapide | Pas d'optimisation, recherche exhaustive |\n",
     "| **Recuit simule** | Elegant, applicable a tout probleme d'optimisation | Non garanti, lent, necessite du reglage |\n",
     "\n",
-    "Le recuit simule est **disqualifie** sur les puzzles difficiles car il n'arrive pas a tous les resoudre dans le temps imparti. Cela illustre une propriete fondamentale :\n",
+    "Avec les parametres du banc de comparaison ci-dessus, le recuit simule est **disqualifie aux trois niveaux** (Easy : 4/5 ; Medium : 0/5 ; Hard : 0/5), faute de resoudre la totalite des puzzles dans le temps imparti -- alors que le backtracking reste Success sur Easy et Medium. Cela illustre une propriete fondamentale :\n",
     "\n",
-    "> Pour un probleme de **satisfaction de contraintes** comme le Sudoku, les solveurs dedies (backtracking, CSP) sont generalement plus efficaces que les metaheuristiques generiques. Le recuit simule est davantage adapte aux problemes d'**optimisation** ou il n'existe pas de solution parfaite."
+    "> Pour un probleme de **satisfaction de contraintes** comme le Sudoku, les solveurs dedies (backtracking, CSP) sont generalement plus efficaces que les metaheuristiques generiques. Le recuit simule est davantage adapte aux problemes d'**optimisation** ou il n'existe pas de solution parfaite. Note : avec un reglage plus agressif (cf. test Medium dedie), le recuit simule resout une partie des puzzles Medium, mais au prix de plusieurs dizaines de secondes par grille."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit de fidelite #3164 sur `Sudoku-4-SimulatedAnnealing-Csharp.ipynb`. Verdict : **FIDELE** (theorie + implementation, critere de Metropolis exact `exp(-deltaE/T)` avec bon signe et division par T, energie coherente avec `NbErrors`, voisinage swap, cooling geometrique, reheating implemente). Le seul defaut reel : **3 cellules d'interpretation contredisent leurs propres sorties committees** (no-pendulum : on corrige les commentaires, pas la theorie).

## Findings corriges (markdown-only)

| Cell | Prose initiale | Output committe reel |
|------|----------------|----------------------|
| `c1361f55` (table tests, ligne Medium) | 10-50 % / 500-5000 ms | `4b3d14bd` : 2/3 = **67 %** en **30-65 s** (reglage agressif) |
| `09d114d4` (premier test, Iterations) | "plusieurs milliers" | `fb2094f9` : **733** iterations (plage `45962e7f` : 961..2 109 355) |
| `ae7ae36f` (comparaison) | "disqualifie sur les **difficiles**" | `4be263b1` : SA **Disqualified aux 3 niveaux** (Easy 4/5, Medium 0/5, Hard 0/5) |

Reconciliation en gardant la structure pedagogique "attendu vs observe" + explicitation de la dependance forte aux hyperparametres (0 % a 67 % sur Medium selon le reglage).

## Validation

- **Anti-regression** : `code chars delta = 0` (aucune cellule code touchee, snapshot par index car cellules sans `id`).
- **C.2** : edit markdown-only -> outputs precedents valides, pas de re-execution (`check_c2_compliance` : 1/1 compliant).
- **Ordre cellules** : `scan_cell_ordering` clean.
- Diff : +14 / -12, 3 cellules markdown uniquement.

## Note mineure (hors-scope, documentee dans l'issue)

Stubs idx 10/17/32 : output `Exercice a completer` stale vs source method-def -> future re-exec regle F (papermill casse sur `#!import` .NET cette session). Stubs conformes C.1.

Closes #3315
See #3164