### PR TITLE
docs(sudoku-5): honest PSO framing (code != canonical PSO) + real benchmarks (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -51,7 +51,7 @@
     "\n",
     "Le **Particle Swarm Optimization** (PSO) est une metaheuristique inspiree du comportement social des oiseaux et des poissons. Developpe par Kennedy et Eberhart en 1995, l'algorithme simule un essaim de particules qui explorent l'espace de recherche.\n",
     "\n",
-    "### Principes fondamentaux\n",
+    "### Principes fondamentaux (PSO canonique)\n",
     "\n",
     "1. **Particules** : Chaque particule represente une solution candidate\n",
     "2. **Position** : La position de la particule = configuration de la grille\n",
@@ -59,7 +59,7 @@
     "4. **pBest** : Meilleure position personnelle de la particule\n",
     "5. **gBest** : Meilleure position globale de l'essaim\n",
     "\n",
-    "### Equation de mise a jour\n",
+    "### Equation de mise a jour (PSO canonique, espace continu)\n",
     "\n",
     "```\n",
     "v(t+1) = w * v(t) + c1 * r1 * (pBest - x(t)) + c2 * r2 * (gBest - x(t))\n",
@@ -71,12 +71,15 @@
     "- `c1`, `c2` : coefficients d'apprentissage (cognitif et social)\n",
     "- `r1`, `r2` : nombres aleatoires [0, 1]\n",
     "\n",
-    "### Adaptation au Sudoku\n",
+    "### Adaptation au Sudoku : une variante discrete inspiree de l'essaim\n",
     "\n",
-    "Pour adapter le PSO au Sudoku, nous utilisons une variante specifique :\n",
-    "- **Workers** (90%) : Exploitent leur voisinage et convergent vers `gBest`\n",
-    "- **Explorers** (10%) : Explorent aleatoirement l'espace de recherche\n",
-    "- **Merge** : Fusion des meilleures solutions Worker et Explorer"
+    "L'equation de velocite ci-dessus est definie sur un espace **continu** : additionner une velocite a une position suppose des coordonnees reelles. Le Sudoku est un probleme **combinatoire discret** (permutations de chiffres), ou cette addition n'a pas de sens direct. Ce notebook n'implemente donc **pas** l'equation de velocite canonique ; il utilise une **heuristique d'essaim discrete** inspiree du PSO et des colonies d'organismes :\n",
+    "\n",
+    "- **Workers** (90%) : exploitent leur voisinage par **echange de deux cases** (recherche locale), en acceptant un voisin s'il reduit l'erreur (ou rarement, via un faible taux de mutation). Un worker qui stagne trop longtemps (`Age > MaxAge`) est reinitialise.\n",
+    "- **Explorers** (10%) : repartent d'une grille **aleatoire** complete a chaque iteration, pour diversifier la recherche.\n",
+    "- **Meilleure globale** : l'essaim conserve la meilleure grille rencontree (`bestError` / `bestSolution`), qui est la solution retournee.\n",
+    "\n",
+    "> **A retenir** : il n'y a ici ni champ de velocite, ni memoire `pBest` par particule, ni coefficients `w`/`c1`/`c2`. Les workers ne sont pas attires par `gBest` au sens de l'equation canonique : chaque worker se compare a sa **propre** erreur courante. C'est un exemple typique de la difficulte a transposer une metaheuristique **continue** (PSO) vers un espace **discret** : on garde l'idee d'essaim (exploration parallele + memoire de la meilleure solution), mais le mecanisme de deplacement est entierement repense (echanges locaux + redemarrages)."
    ]
   },
   {
@@ -1084,23 +1087,23 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Premiere resolution PSO\n",
+    "### Interpretation : Premiere resolution\n",
     "\n",
-    "**Sortie obtenue** : Le solveur PSO a trouve une solution valide en 45ms avec une seule tentative (Attempt 1/10).\n",
+    "**Sortie obtenue** : Le solveur a trouve une solution valide en 61ms avec une seule tentative (Attempt 1/10).\n",
     "\n",
     "| Metrique | Valeur | Signification |\n",
     "|----------|--------|---------------|\n",
-    "| Temps de resolution | 45ms | Performance tres bonne |\n",
+    "| Temps de resolution | 61ms | Performance tres bonne |\n",
     "| Tentatives | 1/10 | L'initialisation etait favorable |\n",
     "| Epoch initial error | 22 | Error initiale moyenne (0-36 typique) |\n",
     "| Solution valide | True | Toutes les contraintes Sudoku respectees |\n",
     "\n",
     "**Points cles** :\n",
     "1. **Convergence en une tentative** : L'essaim a converge vers error=0 sans redemarrage\n",
-    "2. **Performance rapide** : 45ms est tres rapide pour une metaheuristique\n",
+    "2. **Performance rapide** : 61ms est tres rapide pour une metaheuristique\n",
     "3. **Initialisation chanceuse** : La matrice aleatoire initiale etait deja proche de la solution\n",
     "\n",
-    "> **Note technique** : Cette performance exceptionnelle (45ms, 1 tentative) n'est pas representative. Le benchmark suivant montrera que le PSO peut prendre jusqu'a 25s pour resoudre un puzzle de meme difficulte. Cette variance illustre l'importance de l'initialisation aleatoire dans les metaheuristiques."
+    "> **Note technique** : Cette performance (61ms, 1 tentative) n'est pas representative. Le benchmark suivant montre que la resolution peut prendre plusieurs dizaines de secondes sur un puzzle de meme difficulte. Cette variance illustre l'importance de l'initialisation aleatoire dans les metaheuristiques."
    ]
   },
   {
@@ -1880,26 +1883,26 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Performance du PSO sur puzzles faciles\n",
+    "### Interpretation : Performance sur puzzles faciles\n",
     "\n",
     "**Sortie obtenue** : Benchmark sur 5 puzzles faciles avec 200 organismes, 3000 epochs, 10 redemarrages.\n",
     "\n",
-    "| Puzzle | Temps | Succes | Tentatives | Epochs finales |\n",
-    "|--------|-------|--------|------------|----------------|\n",
-    "| 1 | 2ms | Oui | 1 | 0 |\n",
-    "| 2 | 17439ms | Oui | 7 | 0-4 |\n",
-    "| 3 | 5645ms | Oui | 3 | 0-4 |\n",
-    "| 4 | 25271ms | Non | 10 | 2-6 |\n",
-    "| 5 | 2952ms | Oui | 2 | 0-2 |\n",
-    "| **Moyenne** | **10262ms** | **80%** | **4.6** | - |\n",
+    "| Puzzle | Temps | Succes | Tentatives |\n",
+    "|--------|-------|--------|------------|\n",
+    "| 1 | 7ms | Oui | 1 |\n",
+    "| 2 | 23152ms | Oui | 7 |\n",
+    "| 3 | 7180ms | Oui | 3 |\n",
+    "| 4 | 30922ms | Non | 10 |\n",
+    "| 5 | 3633ms | Oui | 2 |\n",
+    "| **Moyenne** | **12979ms** | **80%** | - |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Grande variance** : Les temps varient de 2ms a 25s selon la chance de l'initialisation\n",
-    "2. **Taux de succes 80%** : Un puzzle n'a pas ete resolu malgre 10 tentatives\n",
-    "3. **Convergence rapide quand chanceux** : Le puzzle 1 a converge en 0 epoch (initialisation optimale)\n",
+    "1. **Grande variance** : Les temps varient de 7ms a ~31s selon la chance de l'initialisation\n",
+    "2. **Taux de succes 80%** : Un puzzle (le 4) n'a pas ete resolu malgre 10 tentatives\n",
+    "3. **Convergence rapide quand chanceux** : Le puzzle 1 a converge des l'epoch 0 (initialisation deja sans erreur)\n",
     "4. **Stagnation typique** : L'erreur reste souvent bloquee a 2-4 (pres de la solution mais bloquee)\n",
     "\n",
-    "> **Note technique** : Le PSO pour Sudoku souffre de problemes d'optima locaux. L'erreur reste souvent bloquee a 2-4, ce qui signifie que quelques lignes/colonnes ont des doublons. Les mecanismes de \"merge\" et de reinitialisation des workers stagnants ne suffisent pas toujours a echapper a ces optima locaux."
+    "> **Note technique** : Cette heuristique d'essaim pour Sudoku souffre de problemes d'optima locaux. L'erreur reste souvent bloquee a 2-4, ce qui signifie que quelques lignes/colonnes ont des doublons. Les redemarrages et la reinitialisation des workers stagnants ne suffisent pas toujours a echapper a ces optima locaux."
    ]
   },
   {
@@ -2248,14 +2251,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercice : Optimiser les parametres PSO avec une grille de recherche\n",
+    "## Exercice : Optimiser les parametres avec une grille de recherche\n",
     "\n",
     "# Objectif\n",
-    "Implementez une recherche en grille (grid search) pour trouver les meilleurs\n",
-    "parametres (w, c1, c2) du PSO.\n",
+    "Implementez une recherche en grille (grid search) pour trouver la meilleure\n",
+    "configuration du solveur.\n",
+    "\n",
+    "> **Attention** : l'implementation de ce notebook n'utilise PAS l'equation de velocite canonique (cf. section 1), elle n'expose donc ni `w`, ni `c1`, ni `c2`. Deux variantes possibles :\n",
+    "> - **(a)** Optimisez les parametres reellement disponibles : `NumOrganisms`, `WorkerRatio`, `MutationRate`, `MaxAge`, `MaxEpochs`.\n",
+    "> - **(b)** Implementez d'abord un vrai PSO a velocite (champ de velocite, `pBest`, coefficients `w`/`c1`/`c2`), puis optimisez ces coefficients. La signature du stub ci-dessous correspond a cette variante.\n",
     "\n",
     "# Indice\n",
-    "Testez systematiquement des combinaisons de parametres sur un ensemble de puzzles.\n"
+    "Testez systematiquement des combinaisons de parametres sur un ensemble de puzzles."
    ]
   },
   {
@@ -2297,17 +2304,17 @@
    "source": [
     "### Interpretation : Influence de la configuration\n",
     "\n",
-    "**Sortie obtenue** : Les trois configurations (Conservatif, Standard, Agressif) resoulvent le puzzle en moins de 1ms avec succes.\n",
+    "**Sortie obtenue** : Les trois configurations (Conservatif, Standard, Agressif) resolvent ce puzzle en quelques millisecondes avec succes.\n",
     "\n",
     "| Configuration | Organismes | Epochs | Restarts | Temps | Succes |\n",
     "|---------------|-----------|--------|----------|-------|--------|\n",
     "| Conservatif | 100 | 2000 | 5 | 0ms | Oui |\n",
     "| Standard | 200 | 3000 | 10 | 1ms | Oui |\n",
-    "| Agressif | 300 | 5000 | 20 | 1ms | Oui |\n",
+    "| Agressif | 300 | 5000 | 20 | 2ms | Oui |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Tres grande variance** : Le meme puzzle se resout en 0ms ou 17s selon la chance de l'initialisation\n",
-    "2. **Effet de la chance** : La configuration \"Conservatif\" a eu de la chance (solution immediate)\n",
+    "1. **Tres grande variance** : selon la chance de l'initialisation, ce type de puzzle se resout en quelques ms ici, mais en plusieurs dizaines de secondes ailleurs (cf. benchmark, puzzle 4 ~31s)\n",
+    "2. **Effet de la chance** : sur ce puzzle, les trois configurations ont eu une initialisation favorable (solution quasi immediate)\n",
     "3. **Loi des grands nombres** : Sur un grand nombre de puzzles, la configuration \"Agressif\" devrait etre plus fiable\n",
     "\n",
     "> **Note technique** : Ce test illustre un probleme majeur des metaheuristiques : la grande variance des performances. Pour evaluer correctement un algorithme, il faut toujours tester sur un grand echantillon de puzzles (au moins 30) et calculer la moyenne et l'ecart-type."


### PR DESCRIPTION
## Summary

Audit de fidelite #3164 sur `Sudoku-5-PSO-Csharp.ipynb`. Verdict : **REINVENTION** — le markdown enseigne le PSO canonique (equation de velocite, pBest/gBest, inertie + coefficients) mais le code implemente une **heuristique d'essaim discrete** (Workers = recherche locale par echange, Explorers = redemarrage aleatoire, reset par age) **sans velocite ni pBest**, sans jamais le signaler. Plus les benchmarks obsoletes recurrents de cette serie.

Fix **markdown-only, no-pendulum** : on ne reecrit pas le code (qui resout effectivement des grilles), on rend le markdown honnete et on transforme l'ecart continu->discret en lecon pedagogique.

## Preuve code (lecture directe, two-pass G.1)

| Concept PSO | Markdown | Code reel |
|-------------|----------|-----------|
| Champ de velocite | enseigne | **absent** (`Organism` = {Type,Matrix,Error,Age}, cell `ff1a611f`) |
| pBest | enseigne | **absent** (grep code = 0) |
| Equation `v=w*v+c1*r1*(pBest-x)+c2*r2*(gBest-x)` | affichee | **jamais codee** ; workers = descente par echange (`18cc8378`) |
| « Workers convergent vers gBest » | affirme | **faux** : worker se compare a sa propre erreur, jamais a gBest |
| `w`/`c1`/`c2` | enseignes | **inexistants** (params = NumOrganisms/WorkerRatio/MutationRate/MaxAge) |

## Contradictions prose-vs-output committe

| Cell | Prose | Output committe |
|------|-------|-----------------|
| `4a8487ad` | 45ms | `f39f9c4d` : **61ms** |
| `83a342e9` (table) | P1 2 / P2 17439 / P3 5645 / P4 25271 / P5 2952 / moy 10262 ms | `91bdb51f` : **7 / 23152 / 7180 / 30922 / 3633 / 12979 ms** |
| `af77878b` | Agressif 1ms | `30399613` : **2ms** |
| exercice idx29 | grid search `(w,c1,c2)` | params inexistants -> exercice irrealisable |

## Validation

- **Anti-regression** : `code chars delta = 0` (aucune cellule code touchee, snapshot par index car cellules sans `id`).
- **C.2** : markdown-only -> outputs valides, pas de re-execution (`check_c2_compliance` 1/1).
- **Ordre cellules** : `scan_cell_ordering` clean.
- Diff +40 / -33, 5 cellules markdown.

## Hors-scope (documente dans l'issue)

Stub idx30 garde sa signature `(W,C1,C2)` (variante (b) de l'exercice) ; alignement complet = future re-exec regle F (papermill casse sur `#!import` .NET cette session).

Closes #3317
See #3164