### PR TITLE
docs(sudoku): fidélité Sudoku-6 AIMA-CSP -- benchmark sans output committé + cross-réf CSP + section (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -1656,18 +1656,20 @@
    "source": [
     "### Interpretation : comparaison des strategies\n",
     "\n",
-    "| Strategie | Assignations moy. | Backtracks moy. | Temps moy. (ms) | Observation |\n",
-    "|-----------|------------------|-----------------|----------------|-------------|\n",
-    "| **Backtracking Simple** | 145M | 22M | 246073 | Explosion combinatoire - ordre naif |\n",
-    "| **BT + MRV + LCV** | 527 | 27 | 59 | Reduction massive - heuristiques efficaces |\n",
-    "| **Forward Checking** | 97 | 16 | 37 | Propagation 1-niveau - meilleur que MAC ici |\n",
-    "| **MAC** | 86 | 5 | 54 | Arc-consistance - plus robuste sur puzzles difficiles |\n",
+    "> **Note de lecture (sortie committee tronquee)** : la sortie committee de la cellule ci-dessus s'arrete apres l'en-tete du tableau -- les lignes de donnees ne sont pas affichees. La strategie **Backtracking simple** (ordre naif, sans heuristique) sur 5 puzzles peut demander plusieurs minutes, ce qui interrompt souvent la cellule avant la fin de la boucle `foreach`. Les chiffres ci-dessous proviennent d'une **execution complete anterieure** et sont donnes comme **ordre de grandeur attendu**, pas comme la sortie de la derniere execution committee. Pour des mesures reproductibles rapidement, re-executez la cellule en retirant `BacktrackingSimple` de la liste (ne garder que les strategies a heuristiques).\n",
     "\n",
-    "**Points cles** :\n",
-    "- **MRV + LCV** réduit les assignations de 276x par rapport au backtracking simple\n",
-    "- **Forward Checking** est le plus rapide sur les puzzles faciles (moins d'overhead que MAC)\n",
-    "- **MAC** a le moins de backtracks (5 en moyenne) - plus stable sur les cas difficiles\n",
-    "- La difference de temps (37ms vs 54ms) s'inverse sur les puzzles difficiles où MAC excelle"
+    "| Strategie | Assignations moy. (attendu) | Backtracks moy. (attendu) | Temps moy. attendu | Observation |\n",
+    "|-----------|------------------|-----------------|----------------|-------------|\n",
+    "| **Backtracking Simple** | ~145M | ~22M | plusieurs minutes | Explosion combinatoire - ordre naif |\n",
+    "| **BT + MRV + LCV** | ~500 | ~30 | < 0,1 s | Reduction massive - heuristiques efficaces |\n",
+    "| **Forward Checking** | ~100 | ~15 | < 0,1 s | Propagation 1-niveau - peu d'overhead |\n",
+    "| **MAC** | ~85 | ~5 | < 0,1 s | Arc-consistance - moins de backtracks |\n",
+    "\n",
+    "**Points cles** (corrobores par le test MAC isole ci-dessus, qui resout un puzzle en **31 ms / 81 assignations / 0 backtrack**) :\n",
+    "- **MRV + LCV** reduit les assignations de **plusieurs ordres de grandeur** par rapport au backtracking simple (de l'ordre de la centaine contre des dizaines de millions)\n",
+    "- **Forward Checking** a peu d'overhead sur les puzzles faciles\n",
+    "- **MAC** a le moins de backtracks : la consistance d'arc complete elague le plus l'arbre de recherche, ce qui le rend plus stable sur les cas difficiles\n",
+    "- Sur les puzzles **faciles**, l'ecart de temps entre Forward Checking et MAC est faible et peut s'inverser d'une execution a l'autre ; l'avantage net de MAC se manifeste surtout sur les grilles **difficiles**"
    ]
   },
   {
@@ -1888,7 +1890,7 @@
     "tags": []
    },
    "source": [
-    "## 13. Recapitulatif\n",
+    "## 12. Recapitulatif\n",
     "\n",
     "### Algorithmes implementes\n",
     "\n",
@@ -1912,7 +1914,7 @@
     "- **Sudoku-7-Norvig** : Propagation plus poussees (naked/hidden singles)\n",
     "- **Sudoku-8-HumanStrategies** : Techniques d'inference avancees\n",
     "- **Sudoku-10-ORTools** : Bibliotheque industrielle avec propagation optimisee\n",
-    "- **Search-6/7/8** : Fondements theoriques des CSP\n",
+    "- **Search/Part2-CSP** (CSP-1-Fundamentals, CSP-2-Consistency, CSP-3-Advanced) : Fondements theoriques des CSP -- CSP-2-Consistency detaille la consistance d'arc / AC-3\n",
     "\n",
     "### References\n",
     "\n",


### PR DESCRIPTION


Closes #3319 — résout entièrement la fille (remplace le doublon PR #3328, fermé).