### PR TITLE
fix(csp): CSP-3 circuit-interp -- describe real fallback, not phantom optimal tour

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
@@ -761,20 +761,23 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : contrainte Circuit pour le TSP\n",
+    "### Interpretation : la contrainte Circuit pour le TSP (presentation conceptuelle)\n",
     "\n",
-    "**Sortie obtenue** : le solveur trouve le tour optimal passant par les 5 villes.\n",
+    "**A propos de la sortie** : la cellule ci-dessus n'execute **pas** la contrainte Circuit. Son commentaire `NOTE` le precise -- `add_circuit` a des soucis d'API en OR-Tools 9.x+ tel qu'utilise ici -- donc le code se rabat sur une demonstration d'`AllDifferent` (ordonner les villes) et de `Cumulative` (planification de taches) ; la contrainte `Table` y est meme laissee en commentaire. Ce modele-jouet combine renvoie ici `Statut : INFEASIBLE`. Les positions et debuts affiches (par ex. *« Lyon: position 222685189485101056 »*) ne sont donc **pas** un tour valide : ce sont les valeurs indefinies que `solver.value()` retourne sur un modele non resolu. **Aucun \"tour optimal\" n'est calcule dans cette cellule.**\n",
+    "\n",
+    "La contrainte Circuit reste un concept central pour le TSP ; on la presente ici pour memoire (sans l'executer) :\n",
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| Nombre de tours possibles | $(5-1)!/2 = 12$ | Petite instance, mais NP-difficile en general |\n",
-    "| Modelisation | 5 variables + 1 contrainte Circuit | Tres concis |\n",
-    "| Alternative sans Circuit | Sous-tour elimination (MTZ) | Beaucoup plus complexe |\n",
+    "| Tours possibles (5 villes) | $(5-1)!/2 = 12$ | Petite instance, mais NP-difficile en general |\n",
+    "| Ce que Circuit garantirait | un **unique cycle** couvrant tous les noeuds | Elimine les sous-tours automatiquement |\n",
+    "| Alternative sans Circuit | elimination de sous-tours (MTZ ou DFJ) | Beaucoup plus de contraintes a poser a la main |\n",
     "\n",
-    "**Points cles** :\n",
-    "1. La contrainte Circuit garantit un **unique cycle** sans sous-tours\n",
-    "2. Sans contrainte globale, il faudrait ajouter des contraintes d'elimination de sous-tours (formulation MTZ ou DFJ)\n",
-    "3. Pour de grandes instances, on combine Circuit avec LNS (section 5)"
+    "**Points cles (sur la contrainte Circuit en general)** :\n",
+    "1. La contrainte Circuit garantit un **unique cycle hamiltonien** sans sous-tours, en une seule contrainte globale.\n",
+    "2. Sans contrainte globale, il faudrait ajouter des contraintes d'elimination de sous-tours (formulation MTZ ou DFJ), nettement plus verbeuses.\n",
+    "3. Pour de grandes instances, on combine Circuit avec LNS (section 5).\n",
+    "4. **Forme correcte de l'API OR-Tools** : `model.add_circuit(arcs)` ou `arcs` est une liste de triplets `(depart, arrivee, litteral_booleen)` -- on modelise donc des arcs actives/desactives par des booleens, et non des positions entieres comme le tente (mal) la cellule ci-dessus. C'est ce decalage qui motive le repli documente dans le code."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Completes the **last remaining fidelity finding** of #3282 (audit Epic #3164). The other six findings landed in the already-merged #3300; this issue stayed open only on the HIGH `circuit-interp` claim.

`Closes #3282`. Markdown-only, one cell.

## The finding (INVENTION HIGH)

`circuit-demo`'s output is `Statut : INFEASIBLE` and its own `NOTE` comment admits `add_circuit` has OR-Tools 9.x API issues, so the cell falls back to `AllDifferent` + `Cumulative` (the `Table` line is commented out). The printed positions (`Lyon: position 222685189485101056`) are the undefined `solver.value()` values on an unsolved model.

Yet `circuit-interp` claimed *"le solveur trouve le tour optimal passant par les 5 villes"* + *"5 variables + 1 contrainte Circuit"* — describing a result that never happened.

## Fix (markdown-only, C.2 exception)

- States plainly that **no optimal tour is computed** here and why the printed values are meaningless (unsolved model → garbage `solver.value()`).
- Keeps the genuinely useful **conceptual** teaching about the Circuit constraint (single Hamiltonian cycle, MTZ/DFJ alternative, LNS combo for large instances).
- Documents the **correct OR-Tools API** form `model.add_circuit(arcs)` with `(tail, head, literal)` triplets — the modeling mismatch behind the code's documented fallback.

## Validation

- No code cell touched; outputs/exec_count preserved (markdown-only → C.2 exception).
- Cell order unchanged (interpretation stays right after its code cell).
- Catalogue `.json`/`.md` byte-identical to main; submodule gitlink untouched.

After merge, all 7 acceptance criteria of #3282 are met (6 via #3300 + this one).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>