### PR TITLE
fix(sudoku7): Norvig terminology (Hidden single) + cross-refs + prose-vs-output (Closes #3323)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
@@ -16,13 +16,13 @@
    "source": [
     "# Sudoku-7 : Resolution par Propagation de Contraintes (Norvig)\n",
     "\n",
-    "**Navigation** : [<< Sudoku-6 Infer](Sudoku-15-Infer-Csharp.ipynb) | [Index](README.md) | [Sudoku-8 SimulatedAnnealing >>](Sudoku-4-SimulatedAnnealing-Csharp.ipynb)\n",
+    "**Navigation** : [<< Sudoku-6 AIMA-CSP](Sudoku-6-AIMA-CSP-Csharp.ipynb) | [Index](README.md) | [Sudoku-8 HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
     "1. Comprendre l'approche de Peter Norvig pour la resolution de Sudoku par propagation de contraintes\n",
-    "2. Implementer les strategies d'elimination et de naked singles (seul candidat)\n",
+    "2. Implementer les strategies d'elimination et de hidden singles (seul emplacement)\n",
     "3. Combiner propagation de contraintes et recherche recursive avec heuristique MRV\n",
     "4. Comparer les performances avec les solveurs precedents (Backtracking, OR-Tools)\n",
     "\n",
@@ -33,8 +33,9 @@
     "### Duree estimee : 20 minutes\n",
     "\n",
     "### Liens\n",
-    "- Voir [Search-7 CSP Consistency](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour la theorie de la propagation de contraintes\n",
-    "- [Article original de Peter Norvig (2006)](http://norvig.com/sudoku.html)\n"
+    "- Voir [CSP-2 Consistency](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour la theorie de la propagation de contraintes\n",
+    "- [Article original de Peter Norvig (2006)](http://norvig.com/sudoku.html)\n",
+    ""
    ]
   },
   {
@@ -60,13 +61,14 @@
     "| Strategie | Description | Equivalent CSP |\n",
     "|-----------|-------------|----------------|\n",
     "| **Elimination** | Si une cellule a une valeur assignee, retirer cette valeur de tous ses voisins (meme ligne, colonne, boite) | Arc-consistency |\n",
-    "| **Naked single** (seul candidat) | Si dans une unite (ligne, colonne ou boite), une valeur n'a qu'un seul emplacement possible, l'y assigner | Hidden single |\n",
+    "| **Hidden single** (seul emplacement) | Si dans une unite (ligne, colonne ou boite), une valeur n'a qu'un seul emplacement possible, l'y assigner | Hidden single |\n",
     "\n",
     "Lorsque la propagation seule ne suffit pas (typiquement sur les grilles difficiles), un mecanisme de **recherche recursive avec backtracking** prend le relais. L'heuristique **MRV** (Minimum Remaining Values) guide le choix de la prochaine cellule a explorer : on choisit celle qui a le moins de candidats, ce qui reduit l'arbre de recherche.\n",
     "\n",
     "### Importation des classes de base\n",
     "\n",
-    "Nous importons les classes definies dans le notebook d'environnement.\n"
+    "Nous importons les classes definies dans le notebook d'environnement.\n",
+    ""
    ]
   },
   {
@@ -470,7 +472,7 @@
     "\n",
     "C'est l'equivalent de la propagation d'arc-consistance dans la theorie des CSP.\n",
     "\n",
-    "### Regle 2 : Naked single (seul emplacement)\n",
+    "### Regle 2 : Hidden single (seul emplacement)\n",
     "\n",
     "> Si dans une unite (ligne, colonne ou boite), une valeur `v` n'apparait comme candidat que dans une seule cellule, alors `v` doit etre assigne a cette cellule.\n",
     "\n",
@@ -478,7 +480,8 @@
     "\n",
     "**Gestion des contradictions** : si l'elimination retire le dernier candidat d'une cellule, on a detecte une contradiction. La methode renvoie `false` pour signaler l'echec.\n",
     "\n",
-    "Implementons d'abord les methodes `Eliminate` et `Assign`, puis la boucle de propagation.\n"
+    "Implementons d'abord les methodes `Eliminate` et `Assign`, puis la boucle de propagation.\n",
+    ""
    ]
   },
   {
@@ -812,7 +815,7 @@
    "source": [
     "### Interpretation : limites de la propagation\n",
     "\n",
-    "Sur les puzzles difficiles, la propagation reduit considerablement l'espace de recherche mais ne suffit pas a resoudre la grille. Cependant, le nombre de candidats restants par cellule est generalement faible (2 ou 3), ce qui rend la recherche recursive tres efficace.\n",
+    "Sur les puzzles difficiles, la propagation reduit considerablement l'espace de recherche mais ne suffit pas a resoudre la grille. Cependant, le nombre de candidats restants par cellule reste modere (environ 4,4 en moyenne sur la grille Hard testee), ce qui rend la recherche recursive tres efficace.\n",
     "\n",
     "| Difficulte | Propagation seule | Recherche necessaire |\n",
     "|------------|-------------------|---------------------|\n",
@@ -820,7 +823,8 @@
     "| Moyen | Reduit fortement les candidats | Parfois |\n",
     "| Difficile | Reduit partiellement les candidats | Souvent |\n",
     "\n",
-    "C'est exactement ce que Norvig a observe : la propagation fait le gros du travail, et la recherche ne fait que \"combler les trous\".\n"
+    "C'est exactement ce que Norvig a observe : la propagation fait le gros du travail, et la recherche ne fait que \"combler les trous\".\n",
+    ""
    ]
   },
   {
@@ -1303,7 +1307,7 @@
     "\n",
     "**Points cles** :\n",
     "\n",
-    "1. **Puzzles faciles** : le backtracking simple est deja rapide, mais Norvig est du meme ordre de grandeur car la propagation a un leger cout d'initialisation.\n",
+    "1. **Puzzles faciles** : Norvig est deja nettement plus rapide que le backtracking simple (18,5 ms contre 93,7 ms sur les grilles Easy, soit environ 5x), la propagation seule resolvant la grille sans recherche.\n",
     "\n",
     "2. **Puzzles difficiles** : c'est la ou Norvig brille. La propagation elague massivement l'arbre de recherche, reduisant le nombre d'appels recursifs de plusieurs ordres de grandeur par rapport au backtracking brut.\n",
     "\n",
@@ -1316,7 +1320,8 @@
     "| Garantie de solution | Oui | Oui |\n",
     "| Complexite implementation | Faible | Moyenne |\n",
     "\n",
-    "> **Note** : pour une comparaison avec d'autres approches (OR-Tools, Z3, Dancing Links), voir les notebooks Sudoku-3, Sudoku-4 et Sudoku-5.\n"
+    "> **Note** : pour une comparaison avec d'autres approches (OR-Tools, Z3, Dancing Links), voir les notebooks Sudoku-10, Sudoku-12 et Sudoku-2.\n",
+    ""
    ]
   },
   {
@@ -1448,7 +1453,7 @@
     "| Composant | Role | Inspiration theorique |\n",
     "|-----------|------|----------------------|\n",
     "| Elimination | Retirer les valeurs assignees des voisins | Arc-consistance (CSP) |\n",
-    "| Naked single | Assigner une valeur qui n'a qu'un emplacement dans une unite | Consistance de domaine |\n",
+    "| Hidden single | Assigner une valeur qui n'a qu'un emplacement dans une unite | Consistance de domaine |\n",
     "| MRV | Choisir la cellule la plus contrainte pour la recherche | Heuristique de branchement |\n",
     "| Backtracking | Explorer les branches en cas d'echec | Recherche en profondeur |\n",
     "\n",
@@ -1462,14 +1467,15 @@
     "### Pour aller plus loin\n",
     "\n",
     "- **Techniques de propagation avancees** : paires nues, triples nus, X-wing, swordfish (voir Exercice 1)\n",
-    "- **Theorie de la propagation** : voir [Search-7 CSP Consistency](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour une presentation formelle de l'arc-consistance et des algorithmes AC-3, MAC\n",
-    "- **Comparaison avec les solveurs specialises** : OR-Tools (Sudoku-3) et Dancing Links (Sudoku-5) utilisent des mecanismes differents mais reposent aussi sur la propagation de contraintes\n",
+    "- **Theorie de la propagation** : voir [CSP-2 Consistency](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour une presentation formelle de l'arc-consistance et des algorithmes AC-3, MAC\n",
+    "- **Comparaison avec les solveurs specialises** : OR-Tools (Sudoku-10) et Dancing Links (Sudoku-2) utilisent des mecanismes differents mais reposent aussi sur la propagation de contraintes\n",
     "\n",
     "### Ressources\n",
     "\n",
     "- [Peter Norvig - Solving Every Sudoku Puzzle (2006)](http://norvig.com/sudoku.html)\n",
     "- [Repository de reference : Sudoku.Norvig](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-NLP)\n",
-    "- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, Chapitre 6 (CSP)\n"
+    "- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, Chapitre 6 (CSP)\n",
+    ""
    ]
   }
  ],


### PR DESCRIPTION
## Scope

Markdown-only fidelity fixes on `Sudoku-7-Norvig-Csharp.ipynb` (Epic #3164 audit). Algorithm verified canonically faithful (Norvig 2006); all findings are presentational. **Code cells, outputs and `execution_count` untouched** (C.2 exception — markdown-only; .NET re-exec flagged hors-scope by the issue).

### Findings fixed (all G.1-verified against source before editing)

- **F1 [modéré] terminology**: "Règle 2 / Naked single" → canonical **Hidden single**. The rule as written ("a value has a single placement in a unit") *is* the Hidden single definition; Naked single = a cell with a single candidate. The intro table's own "Équivalent CSP" column already said "Hidden single". Renamed in intro table, §3 header, recap table, learning objective 2.
- **F2 [modéré] cross-refs** (verified by `ls`): OR-Tools `Sudoku-3→10`, Z3 `Sudoku-4→12`, Dancing Links `Sudoku-5→2`; nav prev `"Sudoku-6 Infer"(→Sudoku-15) → "Sudoku-6 AIMA-CSP"(→Sudoku-6)`; nav next `"Sudoku-8 SimulatedAnnealing"(→Sudoku-4) → "Sudoku-8 HumanStrategies"(→Sudoku-8)`; CSP link label `"Search-7" → "CSP-2"`.
- **F3 [mineur] prose-vs-output** (`c04k6o5ix8g`): "candidats restants (2 ou 3)" → "environ 4,4" to match committed output `ny69swwgxbp` (`4,4` moyenne, grille Hard).
- **F4 [mineur] prose-vs-output** (`znkx90fazem`): "Norvig du même ordre de grandeur, léger coût d'initialisation" → committed benchmark `4heal8sfw7x`: Norvig Easy **18,5 ms** vs Backtracking **93,7 ms** (~5x plus rapide).

## Validation

- Diff confined to **6 markdown cells**; 0 code cells / outputs / exec_count changed (verified position-aligned diff).
- Cell count stable (36); catalogue + MGS submodule byte-identical to `main`.

Closes #3323

🤖 Generated with [Claude Code](https://claude.com/claude-code)