### PR TITLE
fix(sudoku6): reframe truncated benchmark + CSP cross-ref + section numbering (Closes #3319)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -1656,18 +1656,20 @@
    "source": [
     "### Interpretation : comparaison des strategies\n",
     "\n",
-    "| Strategie | Assignations moy. | Backtracks moy. | Temps moy. (ms) | Observation |\n",
-    "|-----------|------------------|-----------------|----------------|-------------|\n",
-    "| **Backtracking Simple** | 145M | 22M | 246073 | Explosion combinatoire - ordre naif |\n",
-    "| **BT + MRV + LCV** | 527 | 27 | 59 | Reduction massive - heuristiques efficaces |\n",
-    "| **Forward Checking** | 97 | 16 | 37 | Propagation 1-niveau - meilleur que MAC ici |\n",
-    "| **MAC** | 86 | 5 | 54 | Arc-consistance - plus robuste sur puzzles difficiles |\n",
+    "> **Note de lecture** : la sortie committee de la cellule de benchmark ci-dessus est tronquee a son en-tete. Le Backtracking simple sur 5 puzzles prend plusieurs minutes et la cellule a ete interrompue avant la fin de la boucle `foreach` — aucune ligne de donnees n'a donc ete produite. Le tableau ci-dessous presente des **ordres de grandeur attendus** (illustratifs), pas des mesures committees. Le seul point de mesure reel committe dans ce notebook est le **test MAC isole** plus haut : **31 ms, 81 assignations, 0 backtrack** (cellule `8a2e903f`).\n",
+    "\n",
+    "| Strategie | Assignations (ordre de grandeur) | Backtracks | Temps | Observation |\n",
+    "|-----------|----------------------------------|-----------|-------|-------------|\n",
+    "| **Backtracking Simple** | ~10^8 | ~10^7 | plusieurs minutes | Explosion combinatoire - ordre naif |\n",
+    "| **BT + MRV + LCV** | ~10^2-10^3 | ~10^1 | < 0,1 s | Reduction massive - heuristiques efficaces |\n",
+    "| **Forward Checking** | ~10^2 | ~10^1 | dizaines de ms | Propagation 1-niveau - faible overhead |\n",
+    "| **MAC** | ~10^1-10^2 | ~10^0 | dizaines de ms | Arc-consistance - mesure isolee : 81 assign / 0 backtrack / 31 ms |\n",
     "\n",
     "**Points cles** :\n",
-    "- **MRV + LCV** réduit les assignations de 276x par rapport au backtracking simple\n",
-    "- **Forward Checking** est le plus rapide sur les puzzles faciles (moins d'overhead que MAC)\n",
-    "- **MAC** a le moins de backtracks (5 en moyenne) - plus stable sur les cas difficiles\n",
-    "- La difference de temps (37ms vs 54ms) s'inverse sur les puzzles difficiles où MAC excelle"
+    "- Les heuristiques **MRV + LCV** reduisent les assignations de **plusieurs ordres de grandeur** par rapport au backtracking simple, qui explose combinatoirement\n",
+    "- **Forward Checking** a un faible overhead par rapport a MAC sur les puzzles faciles\n",
+    "- **MAC** est le plus stable : sur le puzzle reellement teste, il resout en **31 ms avec 81 assignations et 0 backtrack** (`8a2e903f`)\n",
+    "- L'avantage de MAC s'accentue sur les puzzles difficiles, ou l'arc-consistance complete elague davantage l'espace de recherche"
    ]
   },
   {
@@ -1888,7 +1890,7 @@
     "tags": []
    },
    "source": [
-    "## 13. Recapitulatif\n",
+    "## 12. Recapitulatif\n",
     "\n",
     "### Algorithmes implementes\n",
     "\n",
@@ -1912,7 +1914,7 @@
     "- **Sudoku-7-Norvig** : Propagation plus poussees (naked/hidden singles)\n",
     "- **Sudoku-8-HumanStrategies** : Techniques d'inference avancees\n",
     "- **Sudoku-10-ORTools** : Bibliotheque industrielle avec propagation optimisee\n",
-    "- **Search-6/7/8** : Fondements theoriques des CSP\n",
+    "- **Search/Part2-CSP (CSP-1/2/3)** : Fondements theoriques des CSP (arc-consistance, AC-3, MAC)\n",
     "\n",
     "### References\n",
     "\n",


### PR DESCRIPTION
## Scope

Markdown-only fidelity fixes on `Sudoku-6-AIMA-CSP-Csharp.ipynb` (Epic #3164 audit). The 9 canonical AIMA CSP points are implemented correctly (verified); findings are presentational. **Code cells, outputs and `execution_count` untouched** (C.2 exception — .NET re-exec flagged hors-scope by the issue).

### Findings fixed (all G.1-verified against source before editing)

- **F1 [modéré] fabricated benchmark figures** (`b884248d`): the comparison table showed precise numbers (145M/22M assigns/backtracks, 246073 ms, 527/27, 97/16, 86/5) as if measured — but the benchmark cell `552dd8ca`'s committed output is **truncated to its header** (the `foreach` produced no data rows; simple Backtracking on 5 puzzles runs for minutes, cell interrupted). The "réduit de 276x" claim was also wrong (145M/527 ≈ **275 000x**). Reframed the table as **expected orders of magnitude** with an explicit reading note, removed the false precision + the 276x, and corroborated qualitatively with the **one real committed datapoint**: isolated MAC test `8a2e903f` (**31 ms / 81 assignations / 0 backtrack**). No figures invented.
- **F2 [mineur] CSP cross-ref** (`a4b30559`): "Search-6/7/8 : Fondements théoriques des CSP" was false (`ls`: Search-6=AdversarialSearch, Search-7=MCTS, Search-8=DancingLinks — none are CSP). Pointed to the real series **Search/Part2-CSP (CSP-1/2/3)**.
- **F3 [mineur] section numbering** (`a4b30559`): sections jumped 11 → 13 (no §12). Renumbered recap `## 13` → `## 12` (no other reference to §13 exists).

## Validation

- Diff confined to **2 markdown cells** (`b884248d`, `a4b30559`); 0 code cells / outputs / exec_count changed (position-aligned diff).
- Cell count stable (40); catalogue + MGS submodule byte-identical to `main`.

Closes #3319

🤖 Generated with [Claude Code](https://claude.com/claude-code)