### PR TITLE
fix(sudoku): reconcile Sudoku-4 SA interpretation cells with committed outputs

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -1936,7 +1936,7 @@
     "|--------|-------------|\n",
     "| Resultat | Le recuit simule trouve generalement la solution pour les puzzles faciles |\n",
     "| Temps | Plus lent que les solveurs deterministes (backtracking, OR-Tools) |\n",
-    "| Iterations | Plusieurs milliers d'iterations necessaires |\n",
+    "| Iterations | 733 sur ce puzzle facile ; de ~960 a ~2,1 millions selon le puzzle (cf. test sur 5 puzzles) |\n",
     "| Non-determinisme | Chaque execution peut donner un resultat different |\n",
     "\n",
     "> **Point cle** : contrairement au backtracking qui est **deterministe** et **garanti**, le recuit simule est **probabiliste**. Il peut echouer, notamment sur les puzzles difficiles."
@@ -2234,15 +2234,17 @@
    "source": [
     "### Interpretation : resultats des tests\n",
     "\n",
-    "| Difficulte | Taux de succes attendu | Temps typique | Observations |\n",
-    "|------------|----------------------|---------------|-------------|\n",
-    "| Easy | 60-100% | 100-2000 ms | Souvent reussi avec les parametres par defaut |\n",
-    "| Medium | 10-50% | 500-5000 ms | Resultat variable, depend de la structure du puzzle |\n",
-    "| Hard | < 10% | > 5000 ms | Rarement reussi sans ameliorations |\n",
+    "Le tableau ci-dessous confronte les valeurs **observees dans les sorties committees** des tests ci-dessus. Le recuit simule depend fortement du reglage : sur Medium, le taux observe passe de 0 % (parametres du banc de comparaison) a 67 % (reglage agressif `Alpha=0.9995`, `IterationsPerTemperature=200`, `MaxRestarts=10`).\n",
+    "\n",
+    "| Difficulte | Taux de succes observe | Temps observe | Observations |\n",
+    "|------------|------------------------|---------------|-------------|\n",
+    "| Easy | 5/5 = 100% | 2 a 3824 ms (moy. 1163 ms) | Reussi avec les parametres par defaut ; un puzzle depasse 2000 ms |\n",
+    "| Medium | 2/3 ~ 67% (reglage agressif) | ~29 a 65 s | Tres sensible aux hyperparametres (0 % avec les parametres du banc) |\n",
+    "| Hard | 0/5 = 0% (banc de comparaison) | > 20 s | Disqualifie, non resolu dans le temps imparti |\n",
     "\n",
     "**Points cles** :\n",
     "1. Le recuit simule **ne garantit pas** de trouver la solution\n",
-    "2. Les performances dependent fortement du **reglage des parametres** ($T_0$, $\\alpha$, $N_{iter}$)\n",
+    "2. Les performances dependent fortement du **reglage des parametres** ($T_0$, $\u0007lpha$, $N_{iter}$) -- sur Medium, de 0 % a 67 % selon le reglage\n",
     "3. Pour les puzzles difficiles, les solveurs CSP (OR-Tools, Z3) restent bien plus fiables"
    ]
   },
@@ -2551,7 +2553,7 @@
     "| **Backtracking** | Deterministe, garanti, rapide | Pas d'optimisation, recherche exhaustive |\n",
     "| **Recuit simule** | Elegant, applicable a tout probleme d'optimisation | Non garanti, lent, necessite du reglage |\n",
     "\n",
-    "Le recuit simule est **disqualifie** sur les puzzles difficiles car il n'arrive pas a tous les resoudre dans le temps imparti. Cela illustre une propriete fondamentale :\n",
+    "Sur ce banc de comparaison, le recuit simule est **disqualifie aux trois niveaux** (Easy 4/5, Medium 0/5, Hard 0/5) : il ne resout pas toutes les grilles dans le temps imparti, meme sur les puzzles faciles. Cela illustre une propriete fondamentale :\n",
     "\n",
     "> Pour un probleme de **satisfaction de contraintes** comme le Sudoku, les solveurs dedies (backtracking, CSP) sont generalement plus efficaces que les metaheuristiques generiques. Le recuit simule est davantage adapte aux problemes d'**optimisation** ou il n'existe pas de solution parfaite."
    ]


### PR DESCRIPTION
**Closes #3315** (audit-fidelite Epic #3164).

## Probleme
Le notebook `Sudoku-4-SimulatedAnnealing-Csharp.ipynb` a une theorie et une implementation **fideles**, mais 3 cellules d'interpretation markdown contredisaient leurs **propres sorties committees**.

## Fix (markdown-only)
Aucune cellule code modifiee -> outputs et `execution_count` preserves. C.2 exception markdown-only (verifie : 0 cellule code changee, 0 output drift). Toutes les valeurs sont **citees depuis les sorties reelles**, aucun nombre invente (no-pendulum).

| Cellule | Avant | Apres (sortie source) |
|---------|-------|------------------------|
| `c1361f55` tableau resultats | Easy "60-100% / 100-2000ms", Medium "10-50% / 500-5000ms" | Easy **5/5=100%** (2-3824 ms, un puzzle >2000 ms) ; Medium **2/3~67%** reglage agressif (~29-65 s), **0%** avec params du banc ; Hard **0/5** -- explicite la dependance forte aux hyperparametres (`45962e7f`, `4b3d14bd`) |
| `09d114d4` ligne Iterations | "Plusieurs milliers d'iterations necessaires" | **733** sur le puzzle facile, de **~960 a ~2,1 millions** selon le puzzle (`fb2094f9`, `45962e7f`) |
| `ae7ae36f` comparaison | "disqualifie sur les puzzles **difficiles**" | "disqualifie aux **trois niveaux**" (Easy 4/5, Medium 0/5, Hard 0/5) (`4be263b1`) |

## Verification
- `git diff` : 3 cellules markdown (idx 24, 29, 34), 0 cellule code, 0 output/exec_count drift.
- Catalogue + submodule MGS byte-identiques a `main`.
- G.1 : chaque finding verifie contre la sortie committee avant edition.

Note hors-scope : 3 cellules stub (idx 10/17/32) ont des outputs "Exercice a completer" stale (regle-F re-exec future, pas le scope de cette PR).