### PR TITLE
docs(sudoku): Sudoku-8 HumanStrategies (C#) audit fidélité #3164 — corrections prose

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
@@ -5,7 +5,7 @@
    "id": "5387691e",
    "metadata": {},
    "source": [
-    "**Navigation** : [Index](README.md) | [<< Sudoku-7 Python](Sudoku-7-Norvig-Python.ipynb) | [Sudoku-8 Python >>](Sudoku-8-HumanStrategies-Python.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Sudoku-7 C#](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-8 Python >>](Sudoku-8-HumanStrategies-Python.ipynb)\n",
     "\n",
     "\n",
     "# Résolution de Sudoku par Stratégies Humaines\n",
@@ -462,13 +462,15 @@
     "\n",
     "La sortie montre le fonctionnement de la classe `CandidateGrid` sur un puzzle facile :\n",
     "\n",
-    "| Metrique | Valeur attendue | Signification |\n",
+    "| Metrique | Valeur observee (puzzle ci-dessus) | Signification |\n",
     "|----------|----------------|---------------|\n",
-    "| Cellules non resolues | ~40-50 | Nombre de cases vides au depart |\n",
-    "| Candidats totaux | ~200-300 | Somme des candidats pour toutes les cellules vides |\n",
-    "| Moyenne candidats/cellule | ~4-6 | Nombre moyen de possibilites par case |\n",
+    "| Cellules non resolues | 36 | Nombre de cases vides au depart |\n",
+    "| Candidats totaux | 66 | Somme des candidats pour toutes les cellules vides |\n",
+    "| Moyenne candidats/cellule | 1,8 | Nombre moyen de possibilites par case |\n",
     "\n",
-    "**Observation** : Les cellules dans le coin superieur gauche (0,0), (0,1), (0,2), etc. affichent leurs candidats respectifs. Cette grille de candidats est la base de toutes les techniques humaines qui suivent.\n",
+    "Ce puzzle \"facile\" est tres contraint (beaucoup d'indices de depart), d'ou une moyenne de candidats faible : la plupart des cases vides n'ont deja plus qu'un ou deux candidats. Sur un puzzle plus difficile, cette moyenne serait nettement plus elevee.\n",
+    "\n",
+    "**Observation** : Les premieres cellules non resolues affichees -- (0,1) = {6, 7}, (1,1) = {7}, (1,2) = {4}, (2,1) = {3} -- montrent leurs candidats respectifs (certaines n'ont deja plus qu'un seul candidat : ce sont des *naked singles*). Cette grille de candidats est la base de toutes les techniques humaines qui suivent.\n",
     "\n",
     "> **Note technique** : La methode `Summary()` fournit une vue macroscopique de l'etat du puzzle, utile pour suivre la progression de la resolution."
    ]
@@ -1716,15 +1718,17 @@
    "source": [
     "### Interpretation : Resultats du HumanSolver\n",
     "\n",
-    "Le journal de resolution montre quelles techniques sont necessaires selon la difficulte :\n",
+    "Le journal de resolution ci-dessus montre quelles techniques sont mobilisees sur trois exemples (un par niveau) :\n",
     "\n",
-    "| Difficulte | Techniques utilisees | Backtracking |\n",
+    "| Difficulte | Techniques utilisees (journal ci-dessus) | Backtracking |\n",
     "|------------|---------------------|-------------|\n",
-    "| Easy | Naked Singles + Hidden Singles | Non |\n",
-    "| Medium | + Naked Pairs, Locked Candidates | Possible |\n",
-    "| Hard | + X-Wing | Probable |\n",
+    "| Easy | Naked Singles seuls | Non |\n",
+    "| Medium | Hidden Singles, Naked Singles, Naked Pairs, Locked Candidates | Non |\n",
+    "| Hard | Hidden Singles, Naked Singles, Naked Pairs, Locked Candidates | Non |\n",
     "\n",
-    "> **Observation attendue** : Les puzzles \"Hard\" de notre fichier de test (`Sudoku_top95.txt`) sont parmi les plus difficiles connus. Il est normal que le backtracking soit necessaire pour une partie d'entre eux, car notre solveur n'implemente pas les techniques les plus avancees (Swordfish, 3D Medusa, Unique Rectangles)."
+    "Sur ces trois grilles, les techniques humaines suffisent et le backtracking n'est jamais declenche -- y compris sur l'exemple \"Hard\", resolu sans X-Wing.\n",
+    "\n",
+    "> **Observation** : ces exemples sont favorables. Sur l'ensemble du fichier de test (`Sudoku_top95.txt`, parmi les plus difficiles connus, cf. analyse statistique plus bas), une partie des puzzles Medium et Hard necessite tout de meme le fallback backtracking, car le solveur n'implemente pas les techniques les plus avancees (Swordfish, 3D Medusa, Unique Rectangles)."
    ]
   },
   {
@@ -1734,7 +1738,7 @@
    "source": [
     "### Comparaison avec les autres solveurs\n",
     "\n",
-    "Comparons maintenant les performances du `HumanSolver` avec le `BacktrackingDotNetSolver` du notebook 1. Le solveur humain est concu pour etre **comprehensible**, pas necessairement rapide. Voyons comment il se compare en termes de temps d'execution."
+    "Comparons maintenant les performances du `HumanSolver` avec le `BacktrackingDotNetSolver` (le meme algorithme que le notebook 1, redefini inline plus bas pour eviter les conflits de type lies a l'import). Le solveur humain est concu pour etre **comprehensible**, pas necessairement rapide. Voyons comment il se compare en termes de temps d'execution."
    ]
   },
   {
@@ -2047,10 +2051,10 @@
     "\n",
     "| Solveur | Forces | Faiblesses |\n",
     "|---------|--------|------------|\n",
-    "| HumanSolver | Explicable, tracable, pedagogique | Plus lent (techniques d'elimination) |\n",
-    "| Backtracking | Simple, rapide sur puzzles faciles | Force brute, non explicable |\n",
+    "| HumanSolver | Explicable, tracable, pedagogique ; rapide par elagage de candidats | Limite aux puzzles resolubles par techniques humaines (sinon fallback backtracking) |\n",
+    "| Backtracking | Simple, robuste (resout toute grille valide) | Force brute, non explicable ; plus lent ici sur Easy/Medium |\n",
     "\n",
-    "Le `HumanSolver` sera generalement plus lent que le backtracking pur car chaque technique d'elimination a un cout. Cependant, il offre un avantage majeur : **chaque etape est explicable**. On sait exactement pourquoi une valeur a ete placee ou un candidat elimine.\n",
+    "Contrairement a ce qu'on pourrait croire, le `HumanSolver` est **plus rapide** que ce backtracking de reference sur les puzzles Easy et Medium (cf. benchmark ci-dessus : ~4 ms contre ~101 ms en Easy, ~46 ms contre ~381 ms en Medium) : l'elimination de candidats elague fortement l'arbre de recherche avant tout retour arriere. Sur les puzzles Hard les plus durs, les deux solveurs sont disqualifies (4/10, time-out), le HumanSolver restant tout de meme un peu plus rapide. Son avantage majeur n'est cependant pas la vitesse mais le fait que **chaque etape est explicable** : on sait exactement pourquoi une valeur a ete placee ou un candidat elimine.\n",
     "\n",
     "> **Note** : Dans les applications reelles (generateurs de puzzles, tutoriels interactifs), la capacite a tracer le raisonnement est plus importante que la vitesse brute. C'est ce qui permet de classer les puzzles par difficulte et d'aider les joueurs a progresser."
    ]
@@ -2341,9 +2345,9 @@
     "\n",
     "Cette analyse revele la **signature de difficulte** de chaque niveau :\n",
     "\n",
-    "- **Easy** : Principalement Naked Singles et Hidden Singles. Aucun backtracking necessaire.\n",
-    "- **Medium** : Apparition des Naked Pairs et Locked Candidates. Le backtracking peut etre necessaire si les techniques avancees ne sont pas implementees.\n",
-    "- **Hard** : Les techniques avancees (X-Wing) sont mobilisees. Le taux de backtracking augmente car il faudrait des techniques expertes (Swordfish, 3D Medusa) pour eviter le fallback.\n",
+    "- **Easy** : Principalement Naked Singles et Hidden Singles. Aucun backtracking necessaire (0 %).\n",
+    "- **Medium** : Apparition des Naked Pairs et Locked Candidates, en plus des singles. Le backtracking devient frequent (~70 % des puzzles) faute de techniques plus avancees.\n",
+    "- **Hard** : Usage intensif des memes techniques de base et intermediaires (Hidden Singles ~280 %, Locked Candidates ~120 %, Naked Pairs ~40 % d'utilisations par puzzle). Le X-Wing n'est presque jamais declenche (≈5 % sur Easy, 0 % sur Medium/Hard) ; le backtracking reste eleve (~60 %, du meme ordre qu'en Medium) car il faudrait des techniques expertes (Swordfish, 3D Medusa) pour l'eviter.\n",
     "\n",
     "> **Conclusion** : Le nombre et la complexite des techniques necessaires constituent une mesure naturelle de la difficulte d'un puzzle. C'est d'ailleurs ainsi que les generateurs de puzzles classifient leurs grilles."
    ]
@@ -2464,7 +2468,7 @@
    "id": "74995405",
    "metadata": {},
    "source": [
-    "## 9. Conclusion\n",
+    "## 8. Conclusion\n",
     "\n",
     "### Resume des apprentissages\n",
     "\n",


### PR DESCRIPTION
## Contexte

Audit de fidélité pédagogique (Epic #3164) du notebook \`Sudoku-8-HumanStrategies-Csharp.ipynb\` contre la théorie canonique des techniques humaines de résolution de Sudoku (SudokuWiki / hodoku). Grain suivant de la série Sudoku C# (S1-S7 déjà audités).

## Verdict : FIDELE

Les **6 techniques implémentées** ont une logique C# **canoniquement correcte** (vérifiée par lecture directe du code, pas seulement du markdown) :
- **Naked Single** : cellule à 1 candidat → placement ✓
- **Hidden Single** : valeur avec 1 seul emplacement dans une unité → placement (distinct du Naked) ✓
- **Naked Pair** : 2 cellules mêmes 2 candidats → élimination dans l'unité ✓
- **Locked Candidates Pointing / Claiming** ✓
- **X-Wing** (lignes + colonnes, forme stricte exact-2) ✓

**0 omission** : Hidden Pairs, Naked/Hidden Triples, Swordfish, Y-Wing, 3D Medusa, Unique Rectangles sont explicitement documentés hors-scope ou délégués à des exercices (scope documenté → verdict NÉGATIF, no-pendulum).

## Corrections (prose markdown uniquement — 0 modification de code)

| # | Sévérité | Problème | Vérité (output commité) |
|---|----------|----------|-------------------------|
| 1 | modéré | Métriques « attendues » ~40-50 / ~200-300 / ~4-6 | réel **36 / 66 / 1,8** + cellules citées corrigées |
| 2 | modéré | « HumanSolver plus lent » | benchmark : **plus rapide** (~4 vs ~101 ms Easy ; ~46 vs ~381 ms Medium) |
| 3 | modéré | Ligne Hard « +X-Wing / Probable » | journal : aucun X-Wing, backtracking **NON** |
| 4 | modéré | « X-Wing mobilisées (Hard) » + « backtracking augmente » | X-Wing **0 % Hard** ; backtracking 70 %→**60 %** (diminue) |
| 5 | mineur | « du notebook 1 » | redéfini **inline** (commentaire code) |
| 6 | mineur | Nav prev → sibling Python | → C# (convention série, cf Sudoku-9) |
| 7 | mineur | Section 7 → 9 (pas de 8) | Conclusion renumérotée en 8 |

## Validation

- **Anti-régression** : 19 cellules code **byte-identiques** vs HEAD (vérifié par diff JSON).
- **C.2** : édition markdown-only → pas de re-exécution requise (exception C.2).
- **Gates** : \`scan_cell_ordering\` 1 clean / 0 finding ; \`check_c2_compliance\` 1/1 ; \`notebook_tools validate\` Err:0.
- **Méthode** : 2-pass G.1 (sous-agent \`sonnet\` evidence-cited local-git-only + cross-check parent relisant le code des techniques **et les \`outputs\` bruts** de chaque finding prose-vs-output).

## Hors-scope (grain règle-F futur)

3 stubs d'exercices affichent « Exercice a completer » (résidu de l'output du \`#!import Sudoku-0-Environment\`) — re-exécution les nettoierait. Non bloquant, stubs conformes C.1.

Closes #3331
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)