### PR TITLE
docs(genai-video): drop manual count + de-duplicate opening from parent (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -9,7 +9,7 @@ maturity: PRODUCTION=10, ALPHA=3, BETA=2, DRAFT=2
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Audio Sync](../Audio/04-Applications/04-4-Audio-Video-Sync.ipynb)
 
-La vidéo est la modalité générative la plus exigeante : elle combine l'analyse d'images, la compréhension du temps, la synchronisation audio, et la création de mouvement cohérent. Cette série couvre l'ensemble de la chaîne vidéo IA : compréhension de séquences existantes, génération à partir de texte ou d'images, orchestration de pipelines multi-modèles, et workflows de production. 17 notebooks répartis sur 4 niveaux progressifs.
+La vidéo combine quatre difficultés simultanées que les autres modalités traitent séparément : l'analyse d'images, la compréhension du temps, la synchronisation audio, et la création de mouvement cohérent. Cette série couvre l'ensemble de la chaîne vidéo IA : compréhension de séquences existantes, génération à partir de texte ou d'images, orchestration de pipelines multi-modèles, et workflows de production. Les notebooks sont répartis sur 4 niveaux progressifs.
 
 ## Fil rouge : construire un pipeline texte vers vidéo pédagogique
 


### PR DESCRIPTION
## Summary

Two anti-patterns resolved in one surgical edit on the **Video README intro (L12)** — the only real findings from a gabarit census (sonnet evidence-cited + cross-checked G.1). **Markdown-only** (C.2 exception). **CATALOG-STATUS byte-identical** (grep-verified). Follows ai-01 dispatch 03:00Z: \"Continue #2651 rollout famille GenAI/* (sous-familles Video/Image suivantes)\".

## Census result (honest)
The Video README is otherwise **clean**: 0 generic bridges (all 4 dedicated bridges name concrete notebooks/tools on both sides — Audio/04-4 sync, Video/03-2 + SVD, GPT-5 APIs + Sora, ComfyUI + SK agents), FAQ = 6 questions (at the ~6 bound), navigation present (L10), notebook table faithful 17/17 (verified against disk). So the only edits are these two in the intro.

## Edits (1 line, +1/-1)
1. **Anti-pattern 1 (gabarit L64/L76)**: \"17 notebooks répartis sur 4 niveaux\" duplicated bot-owned CATALOG-STATUS `pedagogical_count: 17` — the rust-prone manual decompte. Removed; reader gets the count from CATALOG-STATUS.
2. **Anti-pattern 2 (gabarit L65)**: the opening \"La vidéo est la modalité [générative] la plus exigeante\" echoed the parent GenAI README L67 (\"La vidéo est la modalité la plus exigeante en ressources mais aussi la plus spectaculaire\"). Reworded to lead with the pedagogical point (four simultaneous difficulties) rather than the superlative, so the child opens distinctly from the parent's one-line summary.

Pedagogical content preserved (the four difficulties: image analysis, time, audio sync, coherent motion; the four-stage pipeline coverage).

## Validation
- CATALOG-STATUS byte-identical (grep-verified — the `@@` hunk header shows context only, no metadata line changed).
- check-docs-links + no-catalog-changes covered by CI.
- 1 file, +1/-1.

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)