### PR TITLE
fix(tweety): real JVM re-exec Tweety-9 préférences -- Borda/Condorcet/Copeland backing-és + 42 JARs (Closes #3340)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
@@ -64,7 +64,21 @@
      "output_type": "stream",
      "text": [
       "--- Verification JVM Tweety + Outils ---\n",
-      "ERREUR: JAVA_HOME non defini et JDK portable non trouve.\n"
+      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JVM demarree avec 42 JARs.\n",
+      "\n",
+      "--- Outils disponibles ---\n",
+      "  EPROVER: eprover.exe\n",
+      "  SAT_SOLVER_PYTHON: sat_solver.py\n",
+      "  MARCO: marco.py\n",
+      "\n",
+      "JVM prete. Outils: 3/5\n"
      ]
     }
    ],
@@ -207,7 +221,7 @@
     "**Composants initialisés:**\n",
     "- **JVM avec JPype**: Interface Python-Java pour accéder aux classes Tweety\n",
     "- **JDK portable**: Zulu OpenJDK 17 (auto-détecté dans `jdk-17-portable/`)\n",
-    "- **JARs Tweety**: 35 fichiers JAR chargés depuis `libs/`\n",
+    "- **JARs Tweety**: 42 fichiers JAR chargés depuis `libs/`\n",
     "- **Outils externes**: Clingo (ASP), SPASS (Modal), EProver (FOL), pySAT, MARCO\n",
     "\n",
     "> **Note**: Cette initialisation est partagée par tous les notebooks de la série Tweety via le module `tweety_init.py`."
@@ -294,7 +308,50 @@
      "text": [
       "\n",
       "--- 7.1 Ordres de Preference ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "JVM prete. Exploration du module preferences...\n",
+      "\n",
+      "--- Exploration du package org.tweetyproject.preferences ---\n",
+      "Classes du module preferences:\n",
+      "   [OK] PreferenceOrder\n",
+      "   [OK] BinaryRelation\n",
+      "   [OK] Relation\n",
+      "   [OK] ranking.Functions\n",
+      "   [OK] ranking.LevelingFunction\n",
+      "   [OK] ranking.RankingFunction\n",
+      "   [OK] io.POParser\n",
+      "   [OK] io.POWriter\n",
+      "   [OK] update.Update\n",
+      "   [OK] aggregation.PreferenceAggregator\n",
+      "   [OK] aggregation.ScoringPreferenceAggregator\n",
+      "   [OK] aggregation.BordaScoringPreferenceAggregator\n",
+      "   [OK] aggregation.PluralityScoringPreferenceAggregator\n",
+      "   [OK] aggregation.VetoScoringPreferenceAggregator\n",
+      "\n",
+      "14 classes trouvees.\n",
+      "\n",
+      "Note sur les regles de vote:\n",
+      "- Tweety implemente Borda via BordaScoringPreferenceAggregator\n",
+      "- Copeland n'est PAS implemente nativement dans Tweety\n",
+      "- La simulation Python ci-dessous illustre ces concepts\n",
+      "\n",
+      "\n",
+      "--- Exemple Conceptuel: Election ---\n",
+      "\n",
+      "Scenario: 3 votants, 4 candidats (A, B, C, D)\n",
+      "\n",
+      "Preferences des votants:\n",
+      "- Votant 1: A > B > C > D\n",
+      "- Votant 2: B > C > D > A  \n",
+      "- Votant 3: C > D > A > B\n",
+      "\n",
+      "Questions d'agregation:\n",
+      "1. Quel candidat devrait gagner selon Borda?\n",
+      "2. Y a-t-il un gagnant de Condorcet?\n",
+      "3. Que donne la regle de Copeland?\n",
+      "\n",
+      "Ces questions sont au coeur de la theorie du choix social\n",
+      "et du theoreme d'impossibilite d'Arrow.\n",
+      "\n"
      ]
     }
    ],
@@ -480,7 +537,43 @@
      "text": [
       "\n",
       "--- 7.2 Regles d'Agregation de Preferences ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "JVM prete. Demonstration des regles de vote...\n",
+      "\n",
+      "--- Simulation Python des Regles de Vote ---\n",
+      "Candidats: ['A', 'B', 'C', 'D']\n",
+      "Nombre de votants: 5\n",
+      "\n",
+      "Preferences individuelles:\n",
+      "  Votant 1: A > B > C > D\n",
+      "  Votant 2: A > C > B > D\n",
+      "  Votant 3: B > C > D > A\n",
+      "  Votant 4: C > B > D > A\n",
+      "  Votant 5: D > C > B > A\n",
+      "\n",
+      "--- Regle de Borda ---\n",
+      "Scores Borda (points):\n",
+      "  C: 10 points\n",
+      "  B: 9 points\n",
+      "  A: 6 points\n",
+      "  D: 5 points\n",
+      "Gagnant Borda: C\n",
+      "\n",
+      "--- Methode de Condorcet ---\n",
+      "Matrice des duels (lignes battent colonnes):\n",
+      "     A  B  C  D\n",
+      "  A  -  2  2  2 \n",
+      "  B  3  -  2  4 \n",
+      "  C  3  3  -  4 \n",
+      "  D  3  1  1  - \n",
+      "Gagnant de Condorcet: C (bat tous les autres en duel)\n",
+      "\n",
+      "--- Regle de Copeland ---\n",
+      "Scores Copeland (victoires - defaites):\n",
+      "  C: +3\n",
+      "  B: +1\n",
+      "  D: -1\n",
+      "  A: -3\n",
+      "Gagnant Copeland: C\n"
      ]
     }
    ],
@@ -679,7 +772,8 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "--- 7.3 Lien avec l'Argumentation ---"
+      "--- 7.3 Lien avec l'Argumentation ---\n",
+      "JVM prete. Demonstration du lien preferences-argumentation...\n"
      ]
     },
     {
@@ -687,7 +781,32 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "ERREUR: JVM non demarree.\n"
+      "--- Scenario: Preferences sur Arguments ---\n",
+      "\n",
+      "Un debat avec 3 arguments:\n",
+      "- A: \"Le projet est rentable\" (soutenu par le directeur financier)\n",
+      "- B: \"Le projet est risque\" (soutenu par l'expert technique)\n",
+      "- C: \"Le risque est acceptable\" (soutenu par le consultant)\n",
+      "\n",
+      "Relations:\n",
+      "- A attaque B (rentabilite vs risque)\n",
+      "- B attaque A (risque vs rentabilite)\n",
+      "- C attaque B (minimise le risque)\n",
+      "\n",
+      "Question: Comment les preferences des decideurs influencent le resultat?\n",
+      "\n",
+      "Framework: <{ rentable, risque, risque_acceptable },[(rentable,risque), (risque_acceptable,risque), (risque,rentable)]>\n",
+      "\n",
+      "Extension Grounded: {rentable,risque_acceptable}\n",
+      "Extensions Preferees: [{rentable,risque_acceptable}]\n",
+      "\n",
+      "Interpretation:\n",
+      "- Sans preferences, l'extension grounded inclut C (risque_acceptable)\n",
+      "- C defend indirectement A contre B\n",
+      "- Si les decideurs preferent les arguments de l'expert technique (B),\n",
+      "  ils pourraient utiliser un framework pondere (WAF) pour ajuster les poids\n",
+      "- Voir Tweety-7a pour l'implementation des WAF\n",
+      "\n"
      ]
     }
    ],
@@ -1297,7 +1416,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ERREUR: JVM non demarree.\n"
+      "Exercice a completer\n"
      ]
     }
    ],
@@ -1381,7 +1500,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ERREUR: JVM non demarree.\n"
+      "Exercice a completer\n"
      ]
     }
    ],


### PR DESCRIPTION
## Résumé

Corrige le défaut structurel **C.2 / règle-F** de `Tweety-9-Preferences.ipynb` identifié à l'audit fidélité #3164 (issue fille #3340) : le notebook était committé avec des outputs JVM-échoué (`ERREUR: JVM non demarree` / `JAVA_HOME non defini`), tandis que 3 cellules markdown décrivaient des sorties inexistantes.

## Cause racine (audit fidélité #3164)

Méthodologie : sous-agent sonnet evidence-gathering + cross-check **G.1** parent contre la source. Cause unique = JVM non démarrée dans l'environnement de commit. Vérifié à la main : les valeurs markdown étaient **arithmétiquement correctes** pour les données du code → pas de pédagogie fabriquée, juste des outputs stub. La correction propre est une **re-exécution règle-F** (REPARER, pas contourner).

| Cellule | Sévérité | Avant (output committé) | Après re-exec |
|---|---|---|---|
| idx9 `bbcuontwdj` « les resultats ci-dessus illustrent… » | ÉLEVÉ | idx8 = `ERREUR: JVM non demarree` | idx8 = Borda C=10 / Condorcet C / Copeland +3 (matrice duels C bat A·B 3-2, D 4-1) |
| idx6 `psta253yhxr` « la sortie ci-dessus révèle l'architecture » | MOYEN | idx5 = `ERREUR: JVM non demarree` | idx5 = exploration réelle du module (PreferenceOrder…BordaScoringPreferenceAggregator) |
| idx2 `gq1eao0bobh` init JVM | FAIBLE | idx1 = `ERREUR: JAVA_HOME non defini` + « 35 JAR » | idx1 = « JVM demarree avec 42 JARs » ; markdown corrigé 35→42 |

## Ce qui a été fait

- **Re-exécution réelle** via papermill, JDK portable `zulu17.50.19` + 42 JARs (même env que Tweety-7b #3307). Les 9 cellules code produisent désormais de vraies sorties.
- **Transplant outputs-only** dans le notebook committé (pas de churn métadata papermill) → diff minimal (outputs + execution_count refreshés).
- **idx2** : `35 fichiers JAR` → `42` pour cohérence avec l'output réel (seul changement de source markdown).

## Validation (preuves)

- Papermill : 25/25 cellules exécutées, **0 erreur**.
- Structurel : 25 cellules, 9 code, **0 error-output, 0 null exec_count**.
- `scan_cell_ordering.py` : **1 clean, 0 finding**.
- Fidélité G.1 (à la main) : Borda A=6/B=9/**C=10**/D=5 ; C gagnant Condorcet (bat A 3-2, B 3-2, D 4-1) ; Copeland C=+3 — **les nombres markdown idx9 correspondent exactement** à l'output réel.
- Hygiène : `COURSE_CATALOG.generated.*` + marqueurs + submodule MGS (`f7ec022`) **byte-identical** à `origin/main`. 1 fichier touché (128 ins / 9 del = outputs refreshés + idx2).

## Critères d'acceptation #3340

- [x] 0 cellule code en `ERREUR: JVM non demarree` ; `execution_count` renseigné partout.
- [x] idx9 / idx6 : « ci-dessus » pointe sur de vraies sorties exécutées.
- [x] idx2 : décompte JAR corrigé (42) cohérent avec l'output réel.
- [x] 0 cellule code cassée ; gate cell-order clean.
- [ ] Revue ai-01 (#3164).

Closes #3340
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
