### PR TITLE
docs(sudoku): Sudoku-10 prose -- REINVENTION API CP legacy + perf non-monotone + 4 labels (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -341,18 +341,20 @@
    "source": [
     "## Implémentations des Solveurs\n",
     "\n",
-    "### Solveur par contraintes classique (CpSolver)\n",
+    "### Solveur par contraintes classique (ConstraintSolver legacy)\n",
     "\n",
-    "L'algorithme de satisfaction de contraintes (CSP) utilise les contraintes pour réduire l'espace de recherche et trouver une solution qui satisfait toutes les contraintes du problème. Nous utilisons `CpSolver` d'OR-Tools pour cette implémentation.\n",
+    "L'algorithme de satisfaction de contraintes (CSP) utilise les contraintes pour réduire l'espace de recherche et trouver une solution qui satisfait toutes les contraintes du problème. Cette première implémentation s'appuie sur le **solveur historique** d'OR-Tools, `Google.OrTools.ConstraintSolver.Solver` (l'ancien moteur CP, distinct du CP-SAT vu plus bas).\n",
     "\n",
-    "#### Étapes de la modélisation avec OR-Tools CSP\n",
+    "#### Étapes de la modélisation avec le ConstraintSolver legacy\n",
     "\n",
-    "1. **Création du modèle** : Utiliser `CpModel()` pour créer un modèle de contraintes.\n",
-    "2. **Définition des variables** : Créer une grille de variables. Chaque variable représente une cellule du Sudoku, prenant une valeur entière de 1 à 9.\n",
-    "3. **Ajout des contraintes** : Ajouter des contraintes pour les lignes, colonnes et régions. Utiliser `AddAllDifferent()` pour déclarer que chaque ensemble de variables doit contenir des valeurs différentes.\n",
-    "4. **Création du solveur** : Utiliser `CpSolver()` pour créer un solveur.\n",
-    "5. **Résolution du modèle** : Utiliser `Solve()` pour résoudre le modèle.\n",
-    "6. **Extraction des résultats** : Utiliser `solver.Value()` pour obtenir les valeurs finales de toutes les variables dans la grille.\n"
+    "1. **Création du solveur** : instancier `new Solver(\"CpSimple\")` (`Google.OrTools.ConstraintSolver.Solver`).\n",
+    "2. **Définition des variables** : créer une matrice 9x9 de variables avec `solver.MakeIntVarMatrix(9, 9, 1, 9, ...)`. Chaque variable représente une cellule du Sudoku, de domaine 1 à 9.\n",
+    "3. **Ajout des contraintes** : fixer les indices initiaux (`solver.Add(matrix[i, j] == valeur)`) puis déclarer les contraintes de lignes, colonnes et régions avec `solver.MakeAllDifferent(...)`.\n",
+    "4. **Stratégie de recherche** : construire un `DecisionBuilder` via `solver.MakePhase(variables, VariableSelectionStrategy, ValueSelectionStrategy)` -- c'est ce qui paramètre l'ordre de sélection des variables et des valeurs.\n",
+    "5. **Résolution** : lancer `solver.NewSearch(db)` puis itérer `solver.NextSolution()` jusqu'à obtenir une solution.\n",
+    "6. **Extraction des résultats** : lire chaque `matrix[i, j].Value()` pour reconstruire la grille résolue.\n",
+    "\n",
+    "> **Note** : ce moteur historique se distingue du **CP-SAT** (`CpModel` / `AddAllDifferent` / `CpSolver`, présenté plus loin), que Google recommande désormais pour les nouveaux projets. Les deux savent résoudre le Sudoku ; ils diffèrent par leur API et leur moteur interne."
    ]
   },
   {
@@ -717,18 +719,18 @@
    "source": [
     "#### Interpretation des résultats du solveur CP\n",
     "\n",
-    "Les trois Sudokus (facile, moyen, difficile) ont été résolus avec succès par le solveur CP classique.\n",
+    "Les trois Sudokus (facile, moyen, difficile) ont été résolus avec succès par le solveur CP classique (0 erreur résiduelle dans chaque cas).\n",
     "\n",
-    "| Difficulté | Statut | Observations |\n",
-    "|------------|--------|--------------|\n",
-    "| Facile | Résolu | Solution trouvée rapidement |\n",
-    "| Moyen | Résolu | Temps de résolution modéré |\n",
-    "| Difficile | Résolu | Temps de résolution plus élevé |\n",
+    "| Difficulté | Statut | Temps observé |\n",
+    "|------------|--------|---------------|\n",
+    "| Facile | Résolu | 9,84 ms (le plus lent ici) |\n",
+    "| Moyen | Résolu | 1,35 ms (le plus rapide) |\n",
+    "| Difficile | Résolu | 3,07 ms |\n",
     "\n",
     "**Points clés** :\n",
-    "1. Le solveur CP classique est capable de résoudre tous les niveaux de difficulté\n",
-    "2. Le temps de résolution augmente avec la difficulté de la grille\n",
-    "3. L'approche CSP est bien adaptée au Sudoku grâce aux contraintes `AllDifferent`\n"
+    "1. Le solveur CP classique résout tous les niveaux de difficulté sans erreur.\n",
+    "2. À cette échelle (tous les temps sont inférieurs à 10 ms), le temps **ne croît pas** avec la difficulté nominale : ici le puzzle facile est le plus lent et le puzzle moyen le plus rapide. Le premier appel (facile) paie le coût de chauffe du solveur (JIT .NET, initialisation), et la durée dépend surtout de la grille particulière plutôt que de son étiquette de difficulté.\n",
+    "3. L'approche CSP est bien adaptée au Sudoku grâce aux contraintes `AllDifferent` (lignes, colonnes, régions)."
    ]
   },
   {
@@ -1386,7 +1388,7 @@
    "source": [
     "### Interpretation des résultats de performance\n",
     "\n",
-    "Le tableau de comparaison permet d'analyser les performances relatives des différents solveurs OR-Tools sur le problème du Sudoku.\n",
+    "> **Note de lecture (sortie committée tronquée)** : la cellule de benchmark ci-dessus n'a committé que sa première ligne (« Testing MIP Solver ... on Hard sudokus... ») -- le tableau de mesures complet n'a pas été capturé dans la sortie. Les observations ci-dessous reflètent donc le **comportement canonique attendu** de chaque paradigme (corroboré par les sections précédentes), et non les chiffres de la dernière exécution committée.\n",
     "\n",
     "| Aspect | Observation | Signification |\n",
     "|--------|-------------|---------------|\n",
@@ -1399,7 +1401,7 @@
     "2. **Le paramétrage** des solveurs CP (stratégie de sélection de variables) influence notablement les performances\n",
     "3. **MIP** est moins adapté ici car la formulation binaire 3D augmente considérablement la taille du problème\n",
     "\n",
-    "> **Note technique** : Pour les problèmes de satisfaction de contraintes pures comme le Sudoku, CP-SAT est souvent préférable aux solveurs MIP.\n"
+    "> **Note technique** : Pour les problèmes de satisfaction de contraintes pures comme le Sudoku, CP-SAT est souvent préférable aux solveurs MIP."
    ]
   },
   {
@@ -1437,9 +1439,9 @@
     "tags": []
    },
    "source": [
-    "## Exemple guide\n",
+    "## Exercices\n",
     "\n",
-    "### Exemple guide 1 : Comparaison des strategies de selection de variables\n",
+    "### Exercice 1 : Comparaison des strategies de selection de variables\n",
     "\n",
     "Le solveur CP d'OR-Tools permet de parametrer la strategie de selection des variables (`VariableSelectionStrategy`) et des valeurs (`ValueSelectionStrategy`). Ces choix ont un impact significatif sur les performances.\n",
     "\n",
@@ -1534,7 +1536,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : Implémenter le Sudoku X (avec diagonales)\n",
+    "### Exercice 2 : Implémenter le Sudoku X (avec diagonales)\n",
     "\n",
     "Le **Sudoku X** est une variante ou les deux diagonales principales doivent contenir tous les chiffres 1-9.\n",
     "\n",
@@ -1630,7 +1632,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : Comparer CSP, CP-SAT et MIP sur un puzzle difficile\n",
+    "### Exercice 3 : Comparer CSP, CP-SAT et MIP sur un puzzle difficile\n",
     "\n",
     "Le notebook presente trois approches OR-Tools : CSP classique, CP-SAT, et MIP. Analysez leurs differences de performance.\n",
     "\n",
@@ -1749,7 +1751,7 @@
     "tags": []
    },
    "source": [
-    "## Exemple guide : Solveur OR-Tools pour le probleme des N-Reines\n",
+    "## Exercice : Solveur OR-Tools pour le probleme des N-Reines\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -1851,7 +1853,7 @@
     "\n",
     "OR-Tools propose **trois paradigmes** pour modeliser Sudoku :\n",
     "\n",
-    "| Paradigme | Variables | Solveur | Temps (Easy) |\n",
+    "| Paradigme | Variables | Solveur | Temps observé |\n",
     "|-----------|-----------|---------|-------------|\n",
     "| **CSP classique** | 81 IntVar | ConstraintSolver | 1,3 - 9,8 ms |\n",
     "| **CP-SAT** | 81 IntVar | SAT + CDCL | Le plus rapide |\n",


### PR DESCRIPTION
## Audit fidelite #3164 -- Sudoku-10-ORTools-Csharp

Verdict : **coeur FIDELE** (3 paradigmes OR-Tools corrects par lecture directe du code) + **5 corrections de prose markdown-only**. `Closes #3343`.

### Coeur algorithmique : correct
- **CP-SAT** (code `84a4b2c0`) : `CpModel`/`NewIntVar(1,9)`/`AddAllDifferent`/`CpSolver.Solve` -- FIDELE, prose correcte.
- **MIP** (code `57aa20ff`) : formulation 3D binaire (729 `MakeIntVar(0,1)`) + contraintes lineaires `Sum==1` (pas d'AllDifferent, correct) -- FIDELE.
- **N-Reines** (enonce `571a5cef`) : `queen[i]`=colonne, AllDifferent + diagonales, N=8 -> 92 -- canonique.

### Corrections (prose uniquement, code byte-identique)

| # | Sev | Cellule | Probleme -> Fix |
|---|-----|---------|-----------------|
| F1 | **majeur (REINVENTION)** | `e8d2c3e6` | Solveur CP « classique » decrivait l'API **CP-SAT** (`CpModel`/`AddAllDifferent`/`CpSolver`) alors que le code (`ebac1f88`) = **ConstraintSolver legacy** (`MakeIntVarMatrix`/`MakeAllDifferent`/`MakePhase`/`NewSearch`/`NextSolution`). -> 6 etapes reecrites + note legacy vs CP-SAT. |
| F2 | modere | `b91e7533` | « le temps augmente avec la difficulte » contredit par output : Easy **9,84ms** (le + lent) / Medium **1,35ms** (le + rapide) / Hard **3,07ms**. -> tableau + interpretation honnetes (non monotone, chauffe JIT). |
| F3 | mineur (label) | `52003c86` / `7d56706f` / `a439535d` / `571a5cef` | 4 titres « Exemple guide » sur du code **stub** (TODO/`"Exercice a completer"`) -> relabel « Exercices/Exercice 1-3/Exercice N-Reines » (exercise-example-labeling cas 2 ; aucun stub modifie). |
| F4 | mineur | `f3c72f85` | Colonne « Temps (Easy) » = plage cross-difficulte (1,3=Medium, 9,8=Easy) -> « Temps observé ». |
| F5 | mineur | `7ca6fb47` | Sortie committee du benchmark (`18307c5b`) **tronquee** a 1 ligne -> « Note de lecture (sortie committee tronquee) » ; claims canoniques gardes (no-pendulum). |

### Verdict NEGATIF (no-pendulum)
- **Nav `next` = « Sudoku-11 Choco C# » NON corrige** : verif empirique serie -> convention `next` **mixte**, le lien lineaire C#->C# est **majoritaire** (10/14 vs 4 jumeaux Python S2/S8/S9/S15). S10 conforme. `prev`->Sudoku-9 C# correct.

### Hors-scope (signale)
- Commentaires code `// Exemple guide N` (anti-regression markdown-only).
- Re-exec benchmark `18307c5b` (regle F).

### Validation
- `code chars delta = 0` (14 cellules code byte-identiques ; 0 ligne `execution_count`/`outputs`/`cell_type: code` au diff) -> C.2 markdown-only.
- 3 gates verts : `scan_cell_ordering` (1 clean) / `check_c2_compliance` (1/1) / `notebook_tools validate` (Errors: 0).

See #3164