### PR TITLE
docs(sudoku): Sudoku-11 Choco prose fidelity #3164 -- relabel N-Reines exercise + honest IKVM init note

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -61,7 +61,7 @@
     "dotnet build ChocoIkvm.csproj\n",
     "```\n",
     "\n",
-    "Cette approche évite les problèmes d'initialisation du runtime IKVM dans .NET Interactive.\n"
+    "Cette approche (DLL pré-compilée) est la méthode de packaging recommandée pour consommer une librairie Java depuis .NET. Néanmoins, dans cet environnement notebook (.NET Interactive / .NET 10), le runtime IKVM ne parvient pas à s'initialiser : il requiert l'assembly `System.Text.Json` v8.0.0.5, absente ici (voir la sortie de la cellule de test plus bas). Le code des solveurs est correct et s'exécuterait avec un runtime IKVM complet.\n"
    ]
   },
   {
@@ -1084,7 +1084,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exemple guide : Resoudre le probleme des N-Reines avec Choco\n",
+    "## Exercice : Resoudre le probleme des N-Reines avec Choco\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -1171,7 +1171,15 @@
   {
    "id": "4fe11add",
    "cell_type": "markdown",
-   "source": "## Resume et perspectives\n\nCe notebook a explore la resolution de Sudoku par **programmation par contraintes** avec Choco-solver, une librairie Java mature appelee depuis C# via le bridge IKVM. L'implementation a couvert deux niveaux de sophistication : un solveur simple (`ChocoSimpleSolver`) posant directement les 27 contraintes `allDifferent` (9 lignes, 9 colonnes, 9 blocs), puis un solveur optimise (`ChocoSolverVariableSelector`) integrant des heuristiques de recherche avancees comme **FirstFail** (equivalent MRV, choisissant la variable au plus petit domaine) et le **noGood recording** pour eviter de revisiter des branches deja ecartees. L'exercice guide sur les N-Reines a permis de transposer le modele CSP vers un autre probleme classique, en exploitant les memes primitives Choco (`allDifferent`, `arithm`, comptage de solutions).\n\nLa comparaison theorique avec OR-Tools, Z3 et python-constraint montre que Choco se situe dans une niche intermediaire : moins performant qu'OR-Tools CP-SAT sur les instances difficiles, mais offrant un acces natif a des contraintes globales optimisees et des strategies de recherche fines (DomOverWDeg, Impact-based search). La limitation technique rencontree avec IKVM dans dotnet-interactive illustre les defis d'interoperabilite Java/.NET en environnement notebook, et confirme l'interet de approaches natives comme OR-Tools pour un usage pedagogique fluide.\n\nLe prochain notebook, **Sudoku-12-Z3-Csharp**, aborde une approche complementaire avec le solveur SMT Z3, qui represente le Sudoku non pas comme un CSP mais comme un systeme de contraintes logiques, offrant des garanties de completude et des techniques de raisonnement differentes (theorie des tableaux, resolution SAT).",
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a explore la resolution de Sudoku par **programmation par contraintes** avec Choco-solver, une librairie Java mature appelee depuis C# via le bridge IKVM. L'implementation a couvert deux niveaux de sophistication : un solveur simple (`ChocoSimpleSolver`) posant directement les 27 contraintes `allDifferent` (9 lignes, 9 colonnes, 9 blocs), puis un solveur optimise (`ChocoSolverVariableSelector`) integrant des heuristiques de recherche avancees comme **FirstFail** (equivalent MRV, choisissant la variable au plus petit domaine) et le **noGood recording** pour eviter de revisiter des branches deja ecartees. L'exercice sur les N-Reines propose de transposer le modele CSP vers un autre probleme classique, en reutilisant les memes primitives Choco (`allDifferent`, `arithm`, comptage de solutions).\n",
+    "\n",
+    "La comparaison theorique avec OR-Tools, Z3 et python-constraint montre que Choco se situe dans une niche intermediaire : moins performant qu'OR-Tools CP-SAT sur les instances difficiles, mais offrant un acces natif a des contraintes globales optimisees et des strategies de recherche fines (DomOverWDeg, Impact-based search). La limitation technique rencontree avec IKVM dans dotnet-interactive illustre les defis d'interoperabilite Java/.NET en environnement notebook, et confirme l'interet de approaches natives comme OR-Tools pour un usage pedagogique fluide.\n",
+    "\n",
+    "Le prochain notebook, **Sudoku-12-Z3-Csharp**, aborde une approche complementaire avec le solveur SMT Z3, qui represente le Sudoku non pas comme un CSP mais comme un systeme de contraintes logiques, offrant des garanties de completude et des techniques de raisonnement differentes (theorie des tableaux, resolution SAT)."
+   ],
    "metadata": {}
   },
   {


### PR DESCRIPTION
## Résumé
Audit de fidélité pédagogique **#3164**, grain **11/série** : `Sudoku-11-Choco-Csharp.ipynb` (Choco-solver via IKVM.NET). **Verdict cœur : FIDÈLE.** Édition **markdown-only** (`code chars delta = 0`, 12 cellules code byte-identiques).

`Closes #3347` · `See #3164`

## Méthode
Sous-agent `sonnet` evidence-cited (local-git-only) + cross-check parent G.1 : lecture directe des outputs committés, du code, et **de la version réelle des DLL IKVM**.

## Findings markdown-only (3)
| # | cellule | classe | correction |
|---|---------|--------|-----------|
| F1 | `fcc13536` (idx 25) | LABELING | Titre « Exemple guide : N-Reines » sur un **stub** (code `5ecf654c` = `return -1; // TODO étudiant`) → relabel titre en **« Exercice »** (case 2). |
| F2 | `3872729d` (idx 1) | ERREUR-FACTUELLE | « évite les problèmes d'initialisation IKVM » contredit par la sortie idx 21 (`Could not load … System.Text.Json v8.0.0.5 … ne peut pas s'initialiser`) → reformulation honnête (code correct, non exécutable ici). |
| F4 | `4fe11add` (idx 27) | surinterprétation | « exercice **guide** … **a permis de transposer** » (stub jamais exécuté) → « exercice … **propose de transposer** … en **réutilisant** ». |

## Négatif / hors-scope (no-pendulum, documenté)
- **F3 version IKVM** : markdown « 8.15.0 » vs code « 7.2.4630.5 ». Cross-check sur le binaire : `IKVM.Runtime.dll` = **AssemblyVersion 8.15.0.0** → **la markdown est correcte**, le mauvais string est côté **code** (hardcodé) → défaut code, **hors-scope** markdown-only. *(Le vote majoritaire 4× ≠ vérité — catch G.1.)*
- **idx 28 « typiquement 1-50 ms »** : claim général canoniquement plausible, contredit par aucune sortie → NÉGATIF.
- Stratégies de comparaison (DomOverWDeg/InputOrder/Impact) + nav links : scoping-documented / cibles existantes → NÉGATIF.

## Validation
- `scan_cell_ordering` : 1 clean, 0 finding
- `check_c2_compliance` : 1/1 compliant
- `notebook_tools validate` : Errors 0
- diff structurel (`execution_count`/`outputs`/`cell_type:code`) : **0**
- C.2 : exception markdown-only (code delta=0) ; re-exécution non requise (et non faisable localement — runtime IKVM absent).
