### PR TITLE
fix(smartcontracts): SC-8 slippage value matches its own formula (~5.0%)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -745,7 +745,7 @@
     "| Montant recu | 9496.59 USDC | (amountIn * reserve1) / (reserve0 + amountIn) |\n",
     "| Prix d'execution | 1899.32 USDC/WETH | montant_recu / montant_envoye |\n",
     "| Nouveau prix spot | 1814.32 USDC/WETH | nouvelles_reserves |\n",
-    "| Slippage | ~5.3% | (2000 - 1899) / 2000 |\n",
+    "| Slippage | ~5.0% | (2000 - 1899) / 2000 |\n",
     "\n",
     "**Points cles** :\n",
     "- La fee de 0.3% (3/1000) est deduite du montant d'entree avant le calcul — le montant effectif qui entre dans la formule x*y=k est `amountIn * 997/1000`\n",


### PR DESCRIPTION
## Contexte

Audit fidelite **#3164**, sous-serie `SymbolicAI/SmartContracts/02-Solidity-Advanced`.

Sur le critere #3164 *stricto sensu* (markdown narrant un chiffre contredit par l'output committe), **SC-7/8/9 sont FIDELE** — chaque chiffre narre dans les cellules d'interpretation se retrouve dans l'output committe (contrats reellement deployes via Foundry/anvil, adresses deterministes reelles). Cette PR corrige un **finding de classe voisine** trouve en marge : une **incoherence arithmetique interne au markdown** dans SC-8.

## Le defaut (evidence-cited)

Fichier : `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb`, cellule markdown `369f6928` (interpretation du swap AMM) :

```
| Slippage | ~5.3% | (2000 - 1899) / 2000 |
```

La valeur `~5.3%` contredit sa **propre formule** : `(2000 - 1899) / 2000` = 101/2000 = **5.05% ~= 5.0%**. Le 5.3% provient d'une division par le prix d'execution (1899.32) au lieu du prix spot (2000), ce qui contredit a la fois (a) la formule ecrite `/2000` et (b) la definition standard du slippage `(expected - executed) / expected`.

Aucun output committe n'imprime de % de slippage (l'output de `cell-3` affiche prix d'execution 1899.32 et nouveau prix 1814.32, sans pourcentage) -> ce n'est pas une fabrication output-vs-markdown, mais une incoherence interne. Corrigee en alignant la valeur sur la formule : **`~5.0%`**.

## Diff

1 ligne, markdown-only :
```diff
-| Slippage | ~5.3% | (2000 - 1899) / 2000 |
+| Slippage | ~5.0% | (2000 - 1899) / 2000 |
```

## Verifications

- Markdown-only — code et outputs **inchanges**, pas de re-execution (C.3 scope-strict respecte).
- Catalogue (`COURSE_CATALOG.generated.*` + marqueurs CATALOG-STATUS) **byte-identique** a main.
- Submodule MGS gitlink **byte-identique** a main.
- Branche fraiche depuis `origin/main`.

See #3164