### PR TITLE
fix(pymc12): add PMF attribution (Salakhutdinov & Mnih 2008) + Koren/Funk/Netflix lineage — OMISSION (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Recommenders.ipynb
@@ -202,6 +202,8 @@
    "source": [
     "## 2. Factorisation Matricielle Bayesienne\n",
     "\n",
+    "> **Origine de la methode** : la factorisation matricielle *probabiliste* implementee ici est le modele **PMF** (Probabilistic Matrix Factorization) de **Salakhutdinov & Mnih (2008)**, qui a formalise l'inference bayesienne (MCMC) des traits latents. Le principe general de factorisation pour la recommandation s'est impose lors du **Netflix Prize** (2006-2009), notamment via la decomposition SVD de **Simon Funk (2006)** et la synthese de **Koren, Bell & Volinsky (2009)**. Ce notebook suit la formulation bayesienne de PMF.\n",
+    "\n",
     "### Fondements mathematiques\n",
     "\n",
     "La factorisation matricielle decompose la matrice de notes $R$ (users $\\times$ items) en produit de deux matrices de traits latents :\n",
@@ -217,7 +219,7 @@
     "\n",
     "$$\\hat{r}_{ui} = \\mathbf{u}_u^T \\cdot \\mathbf{v}_i + \\epsilon$$\n",
     "\n",
-    "avec $\\epsilon \\sim \\mathcal{N}(0, \\sigma^2)$ le bruit d'observation."
+    "avec $\\epsilon \\sim \\mathcal{N}(0, \\sigma^2)$ le bruit d'observation. Dans PMF, les facteurs latents $\\mathbf{u}_u, \\mathbf{v}_i$ portent des priors gaussiens et l'inference (ici NUTS) estime leur posterieur — quantifiant l'incertitude sur chaque prediction."
    ]
   },
   {
@@ -2431,6 +2433,19 @@
     "---\n",
     "\n",
     "**Navigation** : [PyMC-11-Sequences](PyMC-11-Sequences.ipynb) | [Index](README.md)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ref-pmf-recommenders",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## References\n",
+    "\n",
+    "- **Salakhutdinov, R. and Mnih, A. (2008).** *Bayesian Probabilistic Matrix Factorization Using Markov Chain Monte Carlo.* In Proceedings of the 25th International Conference on Machine Learning (ICML '08), 880-887. doi:10.1145/1390156.1390267 — Le modele PMF bayesien (priors gaussiens sur les facteurs U, V, inference MCMC) implemente dans ce notebook.\n",
+    "- **Koren, Y., Bell, R. and Volinsky, C. (2009).** *Matrix Factorization Techniques for Recommender Systems.* IEEE Computer, 42(8), 30-37. doi:10.1109/MC.2009.263 — Synthese des techniques de factorisation matricielle popularisees par le Netflix Prize (biais utilisateurs/items, cold-start).\n",
+    "- **Funk, S. (2006).** *Netflix Update: Try This at Home.* (Blog) — La decomposition SVD appliquee aux recommandations, originelle du Netflix Prize."
    ]
   }
  ],


### PR DESCRIPTION
## Contexte

Audit fidélité **#3164** (perenne fallback po-2025) sur `PyMC-12-Recommenders.ipynb` — 5e notebook PyMC audité.

**Verdict : OMISSION** (confiance ÉLEVÉE, non ambiguë). Le notebook implémente le modèle génératif **exact de PMF** (Probabilistic Matrix Factorization) — priors gaussiens sur les facteurs latents U, V ; ratings ~ Normal(U·V, σ²) ; inference NUTS (confirmé output logs) — **sans jamais nommer PMF, Salakhutdinov, Mnih, Koren, Bell, Volinsky, Funk, ou Netflix** (grep : 0× pour tous). Même classe d'OMISSION que PyMC-6 (EP omis) et PyMC-10 (Dawid-Skene 1979 cité tardivement → #3345).

## G.1 — cross-check (no-pendulum)

Sub-agent `sonnet` evidence-cited (read-only, local-git). Re-validation locale par grep : `PMF`/`Salakhutdinov`/`Mnih`/`Koren`/`Bell`/`Volinsky`/`Funk`/`Netflix` = **0× chacun** confirmé. La cellule §2 « Factorisation Matricielle Bayesienne » (`7f6144d8`) dérive le modèle PMF verbatim sans attribution.

## Corrections livrées (2 ajouts markdown)

1. **Cellule §2 de dérivation (`7f6144d8`)** : ajout d'un bloc d'attribution inline citant **PMF (Salakhutdinov & Mnih 2008)** comme source du modèle bayesien de factorisation matricielle, avec le contexte **Netflix Prize / Funk 2006 / Koren-Bell-Volinsky 2009** pour la lignée MF générale.

2. **Nouvelle cellule References** (fin du notebook) avec citations complètes :
   - Salakhutdinov & Mnih 2008 (ICML, doi:10.1145/1390156.1390267) — le modèle PMF implémenté.
   - Koren, Bell & Volinsky 2009 (IEEE Computer, doi:10.1109/MC.2009.263) — synthèse MF / biais / cold-start.
   - Funk 2006 (Netflix Prize blog) — la SVD originelle pour recommandation.

## Points FIDELE confirmés (le modèle/inference sont justes, seule l'attribution manquait)
- Modèle génératif correct (cell `35dca21b`) : `pm.Normal('U',...)`, `pm.Normal('V',...)`, `ratings = pm.Normal(..., observed=rating_obs)`. Extensions justes (biais user/item `909ef32d`, cold-start hybride `dcd879f1`, fusion click `ebe0ac0d`).
- **Inference réelle exécutée** : `pm.sample` appelé 6×, `observed=` wire 6× → vraie inférence PyMC (contrairement à PyMC-10). NUTS légitime pour latents continus gaussiens (output log `NUTS: [U, V, sigma]`).
- Divergences + r-hat > 1.01 transparentment signalées (pas cachées). §3 diagnostique honnêtement le modèle sous-contraint et l'améliore (biais + prior σ serré) → pédagogiquement sain.
- RMSE évalué (cell `e04691b7`, formule correcte). 0 REINVENTION (pas d'ALS/SGD hand-rolled, tout PyMC natif).

## Validation (règles H)

| Règle | Résultat |
|-------|----------|
| Scope | 1 fichier (`PyMC-12-Recommenders.ipynb`), +16/-1, markdown-only |
| C.2 | Markdown-only → exception re-execution (pas de source code modifié) |
| C.3 | `git diff` : 0 ligne `execution_count`/`outputs` ajoutée |
| H.3 | N/A (markdown-only) |
| C.1 | 0 `raise NotImplementedError`/`assert False`/`1/0` |
| nbformat | VALID (58 cells) |
| Cell-order (gate #3245) | 1 notebook clean, 0 finding |
| Base | fraîche `origin/main` (rebase HARD 2 respecté) |
| Catalogue | byte-identique à main (pas touché) |

## Cross-refs

`See #3164` (audit fidélité, perenne fallback po-2025). Suite des corrections PyMC : #3289 (TrueSkill OMISSION EP), #3336 (Factor-Graphs NUTS→Gibbs), #3345 (Crowdsourcing NUTS + citation Dawid-Skene), cette PR (Recommenders OMISSION citation PMF).

Dispatch ai-01 2026-06-18T02:03Z : *« po-2025 : #3164 PyMC continue. Prochains : PyMC-12-Recommenders, PyMC-5-Skills-IRT, PyMC-8-Model-Selection. »*
