### PR TITLE
feat(lean-11): add 3 executable TorchLean exercise stubs (3-exos convention #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-11-TorchLean.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-11-TorchLean.ipynb
@@ -5,10 +5,10 @@
    "id": "title-cell",
    "metadata": {
     "papermill": {
-     "duration": 0.005774,
-     "end_time": "2026-05-31T14:57:21.357607+00:00",
+     "duration": 0.005161,
+     "end_time": "2026-06-18T03:11:10.105035+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:21.351833+00:00",
+     "start_time": "2026-06-18T03:11:10.099874+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,16 +178,16 @@
    "id": "verify-installation",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:21.366917Z",
-     "iopub.status.busy": "2026-05-31T14:57:21.366752Z",
-     "iopub.status.idle": "2026-05-31T14:57:22.900996Z",
-     "shell.execute_reply": "2026-05-31T14:57:22.899995Z"
+     "iopub.execute_input": "2026-06-18T03:11:10.116131Z",
+     "iopub.status.busy": "2026-06-18T03:11:10.115944Z",
+     "iopub.status.idle": "2026-06-18T03:11:11.358360Z",
+     "shell.execute_reply": "2026-06-18T03:11:11.357111Z"
     },
     "papermill": {
-     "duration": 1.539868,
-     "end_time": "2026-05-31T14:57:22.901780+00:00",
+     "duration": 1.248904,
+     "end_time": "2026-06-18T03:11:11.358883+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:21.361912+00:00",
+     "start_time": "2026-06-18T03:11:10.109979+00:00",
      "status": "completed"
     },
     "tags": []
@@ -210,7 +210,7 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- ===========================================================</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Verifier la version de Lean</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>Lean<span class=\"bp\">.</span>versionString</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"s2\">&quot;4.27.0&quot;</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>Lean<span class=\"bp\">.</span>versionString</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"s2\">&quot;4.30.0&quot;</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Verifier que Lake est disponible</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span><span class=\"s2\">&quot;Lake package manager required&quot;</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"s2\">&quot;Lake package manager required&quot;</span></blockquote></div></div></small></span></pre>\n",
@@ -229,7 +229,7 @@
        " [{\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
-       "   \"data\": \"\\\"4.27.0\\\"\"},\r\n",
+       "   \"data\": \"\\\"4.30.0\\\"\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 9, \"column\": 5},\r\n",
@@ -249,7 +249,7 @@
        "\n",
        "-- Verifier la version de Lean\n",
        "#eval Lean.versionString\n",
-       "─────▶  \"4.27.0\"\n",
+       "─────▶  \"4.30.0\"\n",
        "\n",
        "-- Verifier que Lake est disponible\n",
        "#eval \"Lake package manager required\"\n",
@@ -267,7 +267,7 @@
        " [{\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
-       "   \"data\": \"\\\"4.27.0\\\"\"},\r\n",
+       "   \"data\": \"\\\"4.30.0\\\"\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 9, \"column\": 5},\r\n",
@@ -303,10 +303,10 @@
    "id": "interpretation-installation",
    "metadata": {
     "papermill": {
-     "duration": 0.004699,
-     "end_time": "2026-05-31T14:57:22.911540+00:00",
+     "duration": 0.005114,
+     "end_time": "2026-06-18T03:11:11.369610+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:22.906841+00:00",
+     "start_time": "2026-06-18T03:11:11.364496+00:00",
      "status": "completed"
     },
     "tags": []
@@ -328,10 +328,10 @@
    "id": "import-torchlean-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.005613,
-     "end_time": "2026-05-31T14:57:22.923975+00:00",
+     "duration": 0.005478,
+     "end_time": "2026-06-18T03:11:11.380792+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:22.918362+00:00",
+     "start_time": "2026-06-18T03:11:11.375314+00:00",
      "status": "completed"
     },
     "tags": []
@@ -352,10 +352,10 @@
    "id": "import-torchlean",
    "metadata": {
     "papermill": {
-     "duration": 0.005123,
-     "end_time": "2026-05-31T14:57:22.933950+00:00",
+     "duration": 0.004991,
+     "end_time": "2026-06-18T03:11:11.391263+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:22.928827+00:00",
+     "start_time": "2026-06-18T03:11:11.386272+00:00",
      "status": "completed"
     },
     "tags": []
@@ -392,10 +392,10 @@
    "id": "interpretation-imports",
    "metadata": {
     "papermill": {
-     "duration": 0.004873,
-     "end_time": "2026-05-31T14:57:22.944371+00:00",
+     "duration": 0.004682,
+     "end_time": "2026-06-18T03:11:11.401181+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:22.939498+00:00",
+     "start_time": "2026-06-18T03:11:11.396499+00:00",
      "status": "completed"
     },
     "tags": []
@@ -421,10 +421,10 @@
    "id": "separator-1",
    "metadata": {
     "papermill": {
-     "duration": 0.006788,
-     "end_time": "2026-05-31T14:57:22.957188+00:00",
+     "duration": 0.004348,
+     "end_time": "2026-06-18T03:11:11.409979+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:22.950400+00:00",
+     "start_time": "2026-06-18T03:11:11.405631+00:00",
      "status": "completed"
     },
     "tags": []
@@ -456,10 +456,10 @@
    "id": "hhzlw6jqlq8",
    "metadata": {
     "papermill": {
-     "duration": 0.005226,
-     "end_time": "2026-05-31T14:57:22.967339+00:00",
+     "duration": 0.004248,
+     "end_time": "2026-06-18T03:11:11.418612+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:22.962113+00:00",
+     "start_time": "2026-06-18T03:11:11.414364+00:00",
      "status": "completed"
     },
     "tags": []
@@ -533,16 +533,16 @@
    "id": "tensor-basics",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:22.979424Z",
-     "iopub.status.busy": "2026-05-31T14:57:22.979237Z",
-     "iopub.status.idle": "2026-05-31T14:57:23.178337Z",
-     "shell.execute_reply": "2026-05-31T14:57:23.177398Z"
+     "iopub.execute_input": "2026-06-18T03:11:11.428989Z",
+     "iopub.status.busy": "2026-06-18T03:11:11.428829Z",
+     "iopub.status.idle": "2026-06-18T03:11:11.584628Z",
+     "shell.execute_reply": "2026-06-18T03:11:11.583872Z"
     },
     "papermill": {
-     "duration": 0.206564,
-     "end_time": "2026-05-31T14:57:23.178900+00:00",
+     "duration": 0.162461,
+     "end_time": "2026-06-18T03:11:11.585367+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:22.972336+00:00",
+     "start_time": "2026-06-18T03:11:11.422906+00:00",
      "status": "completed"
     },
     "tags": []
@@ -699,10 +699,10 @@
    "id": "interpretation-tensor-basics",
    "metadata": {
     "papermill": {
-     "duration": 0.00471,
-     "end_time": "2026-05-31T14:57:23.188554+00:00",
+     "duration": 0.005062,
+     "end_time": "2026-06-18T03:11:11.595442+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.183844+00:00",
+     "start_time": "2026-06-18T03:11:11.590380+00:00",
      "status": "completed"
     },
     "tags": []
@@ -724,10 +724,10 @@
    "id": "layers-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.005055,
-     "end_time": "2026-05-31T14:57:23.198313+00:00",
+     "duration": 0.005438,
+     "end_time": "2026-06-18T03:11:11.606316+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.193258+00:00",
+     "start_time": "2026-06-18T03:11:11.600878+00:00",
      "status": "completed"
     },
     "tags": []
@@ -749,16 +749,16 @@
    "id": "linear-layer",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:23.212150Z",
-     "iopub.status.busy": "2026-05-31T14:57:23.211878Z",
-     "iopub.status.idle": "2026-05-31T14:57:23.491911Z",
-     "shell.execute_reply": "2026-05-31T14:57:23.490568Z"
+     "iopub.execute_input": "2026-06-18T03:11:11.617439Z",
+     "iopub.status.busy": "2026-06-18T03:11:11.617268Z",
+     "iopub.status.idle": "2026-06-18T03:11:11.878541Z",
+     "shell.execute_reply": "2026-06-18T03:11:11.877860Z"
     },
     "papermill": {
-     "duration": 0.29488,
-     "end_time": "2026-05-31T14:57:23.498026+00:00",
+     "duration": 0.2736,
+     "end_time": "2026-06-18T03:11:11.884835+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.203146+00:00",
+     "start_time": "2026-06-18T03:11:11.611235+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2675,10 +2675,10 @@
    "id": "interpretation-linear-layer",
    "metadata": {
     "papermill": {
-     "duration": 0.00987,
-     "end_time": "2026-05-31T14:57:23.518675+00:00",
+     "duration": 0.010647,
+     "end_time": "2026-06-18T03:11:11.905672+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.508805+00:00",
+     "start_time": "2026-06-18T03:11:11.895025+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2703,10 +2703,10 @@
    "id": "sequential-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.010001,
-     "end_time": "2026-05-31T14:57:23.539656+00:00",
+     "duration": 0.010607,
+     "end_time": "2026-06-18T03:11:11.930477+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.529655+00:00",
+     "start_time": "2026-06-18T03:11:11.919870+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2732,16 +2732,16 @@
    "id": "sequential-model",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:23.560623Z",
-     "iopub.status.busy": "2026-05-31T14:57:23.560379Z",
-     "iopub.status.idle": "2026-05-31T14:57:23.736542Z",
-     "shell.execute_reply": "2026-05-31T14:57:23.735632Z"
+     "iopub.execute_input": "2026-06-18T03:11:11.952539Z",
+     "iopub.status.busy": "2026-06-18T03:11:11.952367Z",
+     "iopub.status.idle": "2026-06-18T03:11:12.109778Z",
+     "shell.execute_reply": "2026-06-18T03:11:12.108811Z"
     },
     "papermill": {
-     "duration": 0.18818,
-     "end_time": "2026-05-31T14:57:23.737263+00:00",
+     "duration": 0.168922,
+     "end_time": "2026-06-18T03:11:12.110708+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.549083+00:00",
+     "start_time": "2026-06-18T03:11:11.941786+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2911,10 +2911,10 @@
    "id": "interpretation-sequential",
    "metadata": {
     "papermill": {
-     "duration": 0.009751,
-     "end_time": "2026-05-31T14:57:23.757062+00:00",
+     "duration": 0.010003,
+     "end_time": "2026-06-18T03:11:12.130406+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.747311+00:00",
+     "start_time": "2026-06-18T03:11:12.120403+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2948,10 +2948,10 @@
    "id": "separator-2",
    "metadata": {
     "papermill": {
-     "duration": 0.011122,
-     "end_time": "2026-05-31T14:57:23.777579+00:00",
+     "duration": 0.010312,
+     "end_time": "2026-06-18T03:11:12.150108+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.766457+00:00",
+     "start_time": "2026-06-18T03:11:12.139796+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3002,16 +3002,16 @@
    "id": "rounding-modes",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:23.797872Z",
-     "iopub.status.busy": "2026-05-31T14:57:23.797666Z",
-     "iopub.status.idle": "2026-05-31T14:57:23.979406Z",
-     "shell.execute_reply": "2026-05-31T14:57:23.978707Z"
+     "iopub.execute_input": "2026-06-18T03:11:12.170555Z",
+     "iopub.status.busy": "2026-06-18T03:11:12.170374Z",
+     "iopub.status.idle": "2026-06-18T03:11:12.326799Z",
+     "shell.execute_reply": "2026-06-18T03:11:12.326175Z"
     },
     "papermill": {
-     "duration": 0.192976,
-     "end_time": "2026-05-31T14:57:23.979966+00:00",
+     "duration": 0.167864,
+     "end_time": "2026-06-18T03:11:12.327419+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.786990+00:00",
+     "start_time": "2026-06-18T03:11:12.159555+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3217,10 +3217,10 @@
    "id": "interpretation-rounding",
    "metadata": {
     "papermill": {
-     "duration": 0.010535,
-     "end_time": "2026-05-31T14:57:24.000664+00:00",
+     "duration": 0.010039,
+     "end_time": "2026-06-18T03:11:12.347558+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:23.990129+00:00",
+     "start_time": "2026-06-18T03:11:12.337519+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3249,16 +3249,16 @@
    "id": "float32-properties",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:24.027301Z",
-     "iopub.status.busy": "2026-05-31T14:57:24.027089Z",
-     "iopub.status.idle": "2026-05-31T14:57:24.198309Z",
-     "shell.execute_reply": "2026-05-31T14:57:24.197263Z"
+     "iopub.execute_input": "2026-06-18T03:11:12.368509Z",
+     "iopub.status.busy": "2026-06-18T03:11:12.368342Z",
+     "iopub.status.idle": "2026-06-18T03:11:12.524281Z",
+     "shell.execute_reply": "2026-06-18T03:11:12.523386Z"
     },
     "papermill": {
-     "duration": 0.185452,
-     "end_time": "2026-05-31T14:57:24.198875+00:00",
+     "duration": 0.167825,
+     "end_time": "2026-06-18T03:11:12.524882+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.013423+00:00",
+     "start_time": "2026-06-18T03:11:12.357057+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3469,10 +3469,10 @@
    "id": "interpretation-float32-theorems",
    "metadata": {
     "papermill": {
-     "duration": 0.009628,
-     "end_time": "2026-05-31T14:57:24.218409+00:00",
+     "duration": 0.010017,
+     "end_time": "2026-06-18T03:11:12.545478+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.208781+00:00",
+     "start_time": "2026-06-18T03:11:12.535461+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3499,10 +3499,10 @@
    "id": "lromuz607km",
    "metadata": {
     "papermill": {
-     "duration": 0.009947,
-     "end_time": "2026-05-31T14:57:24.237921+00:00",
+     "duration": 0.009957,
+     "end_time": "2026-06-18T03:11:12.565725+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.227974+00:00",
+     "start_time": "2026-06-18T03:11:12.555768+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3586,10 +3586,10 @@
    "id": "separator-3",
    "metadata": {
     "papermill": {
-     "duration": 0.009651,
-     "end_time": "2026-05-31T14:57:24.257351+00:00",
+     "duration": 0.010874,
+     "end_time": "2026-06-18T03:11:12.587115+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.247700+00:00",
+     "start_time": "2026-06-18T03:11:12.576241+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3642,10 +3642,10 @@
    "id": "pucaro04x5",
    "metadata": {
     "papermill": {
-     "duration": 0.010971,
-     "end_time": "2026-05-31T14:57:24.277971+00:00",
+     "duration": 0.011005,
+     "end_time": "2026-06-18T03:11:12.609224+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.267000+00:00",
+     "start_time": "2026-06-18T03:11:12.598219+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3738,16 +3738,16 @@
    "id": "ibp-implementation",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:24.300701Z",
-     "iopub.status.busy": "2026-05-31T14:57:24.300525Z",
-     "iopub.status.idle": "2026-05-31T14:57:24.451750Z",
-     "shell.execute_reply": "2026-05-31T14:57:24.450659Z"
+     "iopub.execute_input": "2026-06-18T03:11:12.630680Z",
+     "iopub.status.busy": "2026-06-18T03:11:12.630504Z",
+     "iopub.status.idle": "2026-06-18T03:11:12.766489Z",
+     "shell.execute_reply": "2026-06-18T03:11:12.765559Z"
     },
     "papermill": {
-     "duration": 0.163912,
-     "end_time": "2026-05-31T14:57:24.453001+00:00",
+     "duration": 0.147653,
+     "end_time": "2026-06-18T03:11:12.767113+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.289089+00:00",
+     "start_time": "2026-06-18T03:11:12.619460+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3905,10 +3905,10 @@
    "id": "interpretation-ibp",
    "metadata": {
     "papermill": {
-     "duration": 0.009634,
-     "end_time": "2026-05-31T14:57:24.473082+00:00",
+     "duration": 0.010148,
+     "end_time": "2026-06-18T03:11:12.788117+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.463448+00:00",
+     "start_time": "2026-06-18T03:11:12.777969+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3942,16 +3942,16 @@
    "id": "robustness-certificate",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:24.493956Z",
-     "iopub.status.busy": "2026-05-31T14:57:24.493794Z",
-     "iopub.status.idle": "2026-05-31T14:57:24.656500Z",
-     "shell.execute_reply": "2026-05-31T14:57:24.655521Z"
+     "iopub.execute_input": "2026-06-18T03:11:12.810559Z",
+     "iopub.status.busy": "2026-06-18T03:11:12.810396Z",
+     "iopub.status.idle": "2026-06-18T03:11:12.960139Z",
+     "shell.execute_reply": "2026-06-18T03:11:12.959280Z"
     },
     "papermill": {
-     "duration": 0.174264,
-     "end_time": "2026-05-31T14:57:24.657276+00:00",
+     "duration": 0.162341,
+     "end_time": "2026-06-18T03:11:12.960693+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.483012+00:00",
+     "start_time": "2026-06-18T03:11:12.798352+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4097,10 +4097,10 @@
    "id": "interpretation-certificate",
    "metadata": {
     "papermill": {
-     "duration": 0.010812,
-     "end_time": "2026-05-31T14:57:24.678579+00:00",
+     "duration": 0.010161,
+     "end_time": "2026-06-18T03:11:12.981252+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.667767+00:00",
+     "start_time": "2026-06-18T03:11:12.971091+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4135,16 +4135,16 @@
    "id": "crown-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:24.700489Z",
-     "iopub.status.busy": "2026-05-31T14:57:24.700306Z",
-     "iopub.status.idle": "2026-05-31T14:57:24.858749Z",
-     "shell.execute_reply": "2026-05-31T14:57:24.857837Z"
+     "iopub.execute_input": "2026-06-18T03:11:13.003745Z",
+     "iopub.status.busy": "2026-06-18T03:11:13.003533Z",
+     "iopub.status.idle": "2026-06-18T03:11:13.143889Z",
+     "shell.execute_reply": "2026-06-18T03:11:13.143153Z"
     },
     "papermill": {
-     "duration": 0.170689,
-     "end_time": "2026-05-31T14:57:24.859326+00:00",
+     "duration": 0.152745,
+     "end_time": "2026-06-18T03:11:13.144706+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.688637+00:00",
+     "start_time": "2026-06-18T03:11:12.991961+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4324,10 +4324,10 @@
    "id": "interpretation-methods-comparison",
    "metadata": {
     "papermill": {
-     "duration": 0.009964,
-     "end_time": "2026-05-31T14:57:24.879690+00:00",
+     "duration": 0.009993,
+     "end_time": "2026-06-18T03:11:13.165415+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.869726+00:00",
+     "start_time": "2026-06-18T03:11:13.155422+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4377,10 +4377,10 @@
    "id": "applications-table",
    "metadata": {
     "papermill": {
-     "duration": 0.011183,
-     "end_time": "2026-05-31T14:57:24.900668+00:00",
+     "duration": 0.011512,
+     "end_time": "2026-06-18T03:11:13.191642+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.889485+00:00",
+     "start_time": "2026-06-18T03:11:13.180130+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4403,16 +4403,16 @@
    "id": "python-integration",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T14:57:24.921195Z",
-     "iopub.status.busy": "2026-05-31T14:57:24.921013Z",
-     "iopub.status.idle": "2026-05-31T14:57:25.109040Z",
-     "shell.execute_reply": "2026-05-31T14:57:25.108311Z"
+     "iopub.execute_input": "2026-06-18T03:11:13.219653Z",
+     "iopub.status.busy": "2026-06-18T03:11:13.219465Z",
+     "iopub.status.idle": "2026-06-18T03:11:13.391406Z",
+     "shell.execute_reply": "2026-06-18T03:11:13.390516Z"
     },
     "papermill": {
-     "duration": 0.198842,
-     "end_time": "2026-05-31T14:57:25.109567+00:00",
+     "duration": 0.186217,
+     "end_time": "2026-06-18T03:11:13.391992+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:24.910725+00:00",
+     "start_time": "2026-06-18T03:11:13.205775+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4570,10 +4570,10 @@
    "id": "interpretation-python-integration",
    "metadata": {
     "papermill": {
-     "duration": 0.010686,
-     "end_time": "2026-05-31T14:57:25.131242+00:00",
+     "duration": 0.010521,
+     "end_time": "2026-06-18T03:11:13.413723+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:25.120556+00:00",
+     "start_time": "2026-06-18T03:11:13.403202+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4826,13 +4826,439 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e51f9628",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011497,
+     "end_time": "2026-06-18T03:11:13.437146+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T03:11:13.425649+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 (à compléter) : Borne IBP sur une couche à poids négatif\n",
+    "\n",
+    "Réutilisez les fonctions `linearIBP` et `reluIBP` de l'**exemple guidé 1** pour propager un intervalle à travers une couche **à poids négatif** suivie d'un ReLU.\n",
+    "\n",
+    "- Input : `x ∈ [-1.0, 2.0]`\n",
+    "- Layer : `weight = -3.0, bias = 1.0`\n",
+    "- Puis : `ReLU`\n",
+    "\n",
+    "**Question** : Quel est l'intervalle de sortie ? *Attention au cas `w < 0` (les bornes inférieure et supérieure s'inversent).* Complétez la cellule de code ci-dessous."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "52ca464c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-18T03:11:13.459900Z",
+     "iopub.status.busy": "2026-06-18T03:11:13.459734Z",
+     "iopub.status.idle": "2026-06-18T03:11:13.577972Z",
+     "shell.execute_reply": "2026-06-18T03:11:13.577124Z"
+    },
+    "papermill": {
+     "duration": 0.13039,
+     "end_time": "2026-06-18T03:11:13.578452+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T03:11:13.448062+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : propagation IBP à travers une couche à poids négatif puis ReLU.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Réutilise `Interval` et `reluIBP` définis plus haut (section 5, IBP).</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Seul `linearIBP` est (re)défini ici (il n&#39;apparaît que dans l&#39;exemple guidé 1).</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>linearIBP<span class=\"w\"> </span>(i<span class=\"w\"> </span>:<span class=\"w\"> </span>Interval)<span class=\"w\"> </span>(w<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>(b<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Interval<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">if</span><span class=\"w\"> </span>w<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"k\">then</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    {<span class=\"w\"> </span>lower<span class=\"w\"> </span>:=<span class=\"w\"> </span>i<span class=\"bp\">.</span>lower<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>w<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b,<span class=\"w\"> </span>upper<span class=\"w\"> </span>:=<span class=\"w\"> </span>i<span class=\"bp\">.</span>upper<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>w<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span>}</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">else</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    {<span class=\"w\"> </span>lower<span class=\"w\"> </span>:=<span class=\"w\"> </span>i<span class=\"bp\">.</span>upper<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>w<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b,<span class=\"w\"> </span>upper<span class=\"w\"> </span>:=<span class=\"w\"> </span>i<span class=\"bp\">.</span>lower<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>w<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span>}</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO étudiant : calculez la borne après Linear(w = -3.0, b = 1.0) puis ReLU.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo1_input<span class=\"w\">  </span>:<span class=\"w\"> </span>Interval<span class=\"w\"> </span>:=<span class=\"w\"> </span>{<span class=\"w\"> </span>lower<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mf\">1.0</span>,<span class=\"w\"> </span>upper<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">2.0</span><span class=\"w\"> </span>}</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo1_layer<span class=\"w\">  </span>:<span class=\"w\"> </span>Interval<span class=\"w\"> </span>:=<span class=\"w\"> </span>{<span class=\"w\"> </span>lower<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.0</span>,<span class=\"w\"> </span>upper<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.0</span><span class=\"w\"> </span>}<span class=\"w\">  </span><span class=\"c1\">-- TODO étudiant : linearIBP exo1_input (-3.0) 1.0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo1_output<span class=\"w\"> </span>:<span class=\"w\"> </span>Interval<span class=\"w\"> </span>:=<span class=\"w\"> </span>reluIBP<span class=\"w\"> </span>exo1_layer</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1a\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1a\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>exo1_output<span class=\"w\">  </span><span class=\"c1\">-- solution attendue : { lower := 0.0, upper := 4.0 }</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> {<span class=\"w\"> </span>lower<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.000000</span>,<span class=\"w\"> </span>upper<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.000000</span><span class=\"w\"> </span>}</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 10</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 1 : propagation IBP \\u00e0 travers une couche \\u00e0 poids n\\u00e9gatif puis ReLU.\\n-- R\\u00e9utilise `Interval` et `reluIBP` d\\u00e9finis plus haut (section 5, IBP).\\n-- Seul `linearIBP` est (re)d\\u00e9fini ici (il n'appara\\u00eet que dans l'exemple guid\\u00e9 1).\\ndef linearIBP (i : Interval) (w : Float) (b : Float) : Interval :=\\n  if w \\u2265 0 then\\n    { lower := i.lower * w + b, upper := i.upper * w + b }\\n  else\\n    { lower := i.upper * w + b, upper := i.lower * w + b }\\n\\n-- TODO \\u00e9tudiant : calculez la borne apr\\u00e8s Linear(w = -3.0, b = 1.0) puis ReLU.\\ndef exo1_input  : Interval := { lower := -1.0, upper := 2.0 }\\ndef exo1_layer  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO \\u00e9tudiant : linearIBP exo1_input (-3.0) 1.0\\ndef exo1_output : Interval := reluIBP exo1_layer\\n\\n#eval exo1_output  -- solution attendue : { lower := 0.0, upper := 4.0 }\", \"env\": 9}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 15, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 15, \"column\": 5},\r\n",
+       "   \"data\": \"{ lower := 0.000000, upper := 0.000000 }\"}],\r\n",
+       " \"env\": 10}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 1 : propagation IBP à travers une couche à poids négatif puis ReLU.\n",
+       "-- Réutilise `Interval` et `reluIBP` définis plus haut (section 5, IBP).\n",
+       "-- Seul `linearIBP` est (re)défini ici (il n'apparaît que dans l'exemple guidé 1).\n",
+       "def linearIBP (i : Interval) (w : Float) (b : Float) : Interval :=\n",
+       "  if w ≥ 0 then\n",
+       "    { lower := i.lower * w + b, upper := i.upper * w + b }\n",
+       "  else\n",
+       "    { lower := i.upper * w + b, upper := i.lower * w + b }\n",
+       "\n",
+       "-- TODO étudiant : calculez la borne après Linear(w = -3.0, b = 1.0) puis ReLU.\n",
+       "def exo1_input  : Interval := { lower := -1.0, upper := 2.0 }\n",
+       "def exo1_layer  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO étudiant : linearIBP exo1_input (-3.0) 1.0\n",
+       "def exo1_output : Interval := reluIBP exo1_layer\n",
+       "\n",
+       "#eval exo1_output  -- solution attendue : { lower := 0.0, upper := 4.0 }\n",
+       "─────▶  { lower := 0.000000, upper := 0.000000 }\n",
+       "--% env 10\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 1 : propagation IBP \\u00e0 travers une couche \\u00e0 poids n\\u00e9gatif puis ReLU.\\n-- R\\u00e9utilise `Interval` et `reluIBP` d\\u00e9finis plus haut (section 5, IBP).\\n-- Seul `linearIBP` est (re)d\\u00e9fini ici (il n'appara\\u00eet que dans l'exemple guid\\u00e9 1).\\ndef linearIBP (i : Interval) (w : Float) (b : Float) : Interval :=\\n  if w \\u2265 0 then\\n    { lower := i.lower * w + b, upper := i.upper * w + b }\\n  else\\n    { lower := i.upper * w + b, upper := i.lower * w + b }\\n\\n-- TODO \\u00e9tudiant : calculez la borne apr\\u00e8s Linear(w = -3.0, b = 1.0) puis ReLU.\\ndef exo1_input  : Interval := { lower := -1.0, upper := 2.0 }\\ndef exo1_layer  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO \\u00e9tudiant : linearIBP exo1_input (-3.0) 1.0\\ndef exo1_output : Interval := reluIBP exo1_layer\\n\\n#eval exo1_output  -- solution attendue : { lower := 0.0, upper := 4.0 }\", \"env\": 9}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 15, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 15, \"column\": 5},\r\n",
+       "   \"data\": \"{ lower := 0.000000, upper := 0.000000 }\"}],\r\n",
+       " \"env\": 10}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 1 : propagation IBP à travers une couche à poids négatif puis ReLU.\n",
+    "-- Réutilise `Interval` et `reluIBP` définis plus haut (section 5, IBP).\n",
+    "-- Seul `linearIBP` est (re)défini ici (il n'apparaît que dans l'exemple guidé 1).\n",
+    "def linearIBP (i : Interval) (w : Float) (b : Float) : Interval :=\n",
+    "  if w ≥ 0 then\n",
+    "    { lower := i.lower * w + b, upper := i.upper * w + b }\n",
+    "  else\n",
+    "    { lower := i.upper * w + b, upper := i.lower * w + b }\n",
+    "\n",
+    "-- TODO étudiant : calculez la borne après Linear(w = -3.0, b = 1.0) puis ReLU.\n",
+    "def exo1_input  : Interval := { lower := -1.0, upper := 2.0 }\n",
+    "def exo1_layer  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO étudiant : linearIBP exo1_input (-3.0) 1.0\n",
+    "def exo1_output : Interval := reluIBP exo1_layer\n",
+    "\n",
+    "#eval exo1_output  -- solution attendue : { lower := 0.0, upper := 4.0 }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb99dc9b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009833,
+     "end_time": "2026-06-18T03:11:13.598785+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T03:11:13.588952+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 (à compléter) : Classe certifiée et marge de robustesse\n",
+    "\n",
+    "Pour les bornes inférieures de scores `exo2_bounds` (10 classes, style MNIST), déterminez la **classe certifiée** (argmax des bornes) et la **marge** (différence entre le meilleur et le second meilleur score). Réutilisez `argmax` et `secondBest` de l'exemple guidé 2. *Indice : `best - second`.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ee293686",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-18T03:11:13.620932Z",
+     "iopub.status.busy": "2026-06-18T03:11:13.620777Z",
+     "iopub.status.idle": "2026-06-18T03:11:14.419099Z",
+     "shell.execute_reply": "2026-06-18T03:11:14.417518Z"
+    },
+    "papermill": {
+     "duration": 0.810165,
+     "end_time": "2026-06-18T03:11:14.419679+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T03:11:13.609514+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : classe certifiée et marge de robustesse.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>argmax<span class=\"w\"> </span>(scores<span class=\"w\"> </span>:<span class=\"w\"> </span>Array<span class=\"w\"> </span>Float)<span class=\"w\"> </span>(i<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(bestIdx<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">if</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">&gt;=</span><span class=\"w\"> </span>scores<span class=\"bp\">.</span>size<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span>bestIdx</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">else</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>scores[i]<span class=\"bp\">!</span><span class=\"w\"> </span><span class=\"bp\">&gt;</span><span class=\"w\"> </span>scores[bestIdx]<span class=\"bp\">!</span><span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span>argmax<span class=\"w\"> </span>scores<span class=\"w\"> </span>(i<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>i</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">else</span><span class=\"w\"> </span>argmax<span class=\"w\"> </span>scores<span class=\"w\"> </span>(i<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>bestIdx</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>secondBest<span class=\"w\"> </span>(scores<span class=\"w\"> </span>:<span class=\"w\"> </span>Array<span class=\"w\"> </span>Float)<span class=\"w\"> </span>(bestIdx<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(i<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(best2<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">if</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">&gt;=</span><span class=\"w\"> </span>scores<span class=\"bp\">.</span>size<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span>best2</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">else</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>bestIdx<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span>secondBest<span class=\"w\"> </span>scores<span class=\"w\"> </span>bestIdx<span class=\"w\"> </span>(i<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>best2</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">else</span><span class=\"w\"> </span>secondBest<span class=\"w\"> </span>scores<span class=\"w\"> </span>bestIdx<span class=\"w\"> </span>(i<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>(max<span class=\"w\"> </span>best2<span class=\"w\"> </span>scores[i]<span class=\"bp\">!</span>)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo2_bounds<span class=\"w\"> </span>:<span class=\"w\"> </span>Array<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">#</span>[<span class=\"mf\">0.1</span>,<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mf\">0.2</span>,<span class=\"w\"> </span><span class=\"mf\">0.0</span>,<span class=\"w\"> </span><span class=\"mf\">0.3</span>,<span class=\"w\"> </span><span class=\"mf\">0.05</span>,<span class=\"w\"> </span><span class=\"mf\">0.4</span>,<span class=\"w\"> </span><span class=\"mf\">0.0</span>,<span class=\"w\"> </span><span class=\"mf\">2.5</span>,<span class=\"w\"> </span><span class=\"mf\">0.1</span>,<span class=\"w\"> </span><span class=\"mf\">0.2</span>]</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO étudiant : classe certifiée (indice : argmax exo2_bounds 1 0)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo2_certified<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\">  </span><span class=\"c1\">-- TODO étudiant</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO étudiant : marge = best - second (indice : secondBest exo2_bounds ...)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo2_margin<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.0</span><span class=\"w\">  </span><span class=\"c1\">-- TODO étudiant</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1b\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>exo2_certified<span class=\"w\">  </span><span class=\"c1\">-- solution attendue : 7</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1c\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>exo2_margin<span class=\"w\">     </span><span class=\"c1\">-- solution attendue : 2.1</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.000000</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 11</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 2 : classe certifi\\u00e9e et marge de robustesse.\\ndef argmax (scores : Array Float) (i : Nat) (bestIdx : Nat) : Nat :=\\n  if i >= scores.size then bestIdx\\n  else if scores[i]! > scores[bestIdx]! then argmax scores (i + 1) i\\n  else argmax scores (i + 1) bestIdx\\n\\ndef secondBest (scores : Array Float) (bestIdx : Nat) (i : Nat) (best2 : Float) : Float :=\\n  if i >= scores.size then best2\\n  else if i == bestIdx then secondBest scores bestIdx (i + 1) best2\\n  else secondBest scores bestIdx (i + 1) (max best2 scores[i]!)\\n\\ndef exo2_bounds : Array Float :=\\n  #[0.1, -0.2, 0.0, 0.3, 0.05, 0.4, 0.0, 2.5, 0.1, 0.2]\\n\\n-- TODO \\u00e9tudiant : classe certifi\\u00e9e (indice : argmax exo2_bounds 1 0)\\ndef exo2_certified : Nat := 0  -- TODO \\u00e9tudiant\\n-- TODO \\u00e9tudiant : marge = best - second (indice : secondBest exo2_bounds ...)\\ndef exo2_margin : Float := 0.0  -- TODO \\u00e9tudiant\\n\\n#eval exo2_certified  -- solution attendue : 7\\n#eval exo2_margin     -- solution attendue : 2.1\", \"env\": 10}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 20, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 20, \"column\": 5},\r\n",
+       "   \"data\": \"0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 21, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 21, \"column\": 5},\r\n",
+       "   \"data\": \"0.000000\"}],\r\n",
+       " \"env\": 11}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 2 : classe certifiée et marge de robustesse.\n",
+       "def argmax (scores : Array Float) (i : Nat) (bestIdx : Nat) : Nat :=\n",
+       "  if i >= scores.size then bestIdx\n",
+       "  else if scores[i]! > scores[bestIdx]! then argmax scores (i + 1) i\n",
+       "  else argmax scores (i + 1) bestIdx\n",
+       "\n",
+       "def secondBest (scores : Array Float) (bestIdx : Nat) (i : Nat) (best2 : Float) : Float :=\n",
+       "  if i >= scores.size then best2\n",
+       "  else if i == bestIdx then secondBest scores bestIdx (i + 1) best2\n",
+       "  else secondBest scores bestIdx (i + 1) (max best2 scores[i]!)\n",
+       "\n",
+       "def exo2_bounds : Array Float :=\n",
+       "  #[0.1, -0.2, 0.0, 0.3, 0.05, 0.4, 0.0, 2.5, 0.1, 0.2]\n",
+       "\n",
+       "-- TODO étudiant : classe certifiée (indice : argmax exo2_bounds 1 0)\n",
+       "def exo2_certified : Nat := 0  -- TODO étudiant\n",
+       "-- TODO étudiant : marge = best - second (indice : secondBest exo2_bounds ...)\n",
+       "def exo2_margin : Float := 0.0  -- TODO étudiant\n",
+       "\n",
+       "#eval exo2_certified  -- solution attendue : 7\n",
+       "─────▶  0\n",
+       "#eval exo2_margin     -- solution attendue : 2.1\n",
+       "─────▶  0.000000\n",
+       "--% env 11\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 2 : classe certifi\\u00e9e et marge de robustesse.\\ndef argmax (scores : Array Float) (i : Nat) (bestIdx : Nat) : Nat :=\\n  if i >= scores.size then bestIdx\\n  else if scores[i]! > scores[bestIdx]! then argmax scores (i + 1) i\\n  else argmax scores (i + 1) bestIdx\\n\\ndef secondBest (scores : Array Float) (bestIdx : Nat) (i : Nat) (best2 : Float) : Float :=\\n  if i >= scores.size then best2\\n  else if i == bestIdx then secondBest scores bestIdx (i + 1) best2\\n  else secondBest scores bestIdx (i + 1) (max best2 scores[i]!)\\n\\ndef exo2_bounds : Array Float :=\\n  #[0.1, -0.2, 0.0, 0.3, 0.05, 0.4, 0.0, 2.5, 0.1, 0.2]\\n\\n-- TODO \\u00e9tudiant : classe certifi\\u00e9e (indice : argmax exo2_bounds 1 0)\\ndef exo2_certified : Nat := 0  -- TODO \\u00e9tudiant\\n-- TODO \\u00e9tudiant : marge = best - second (indice : secondBest exo2_bounds ...)\\ndef exo2_margin : Float := 0.0  -- TODO \\u00e9tudiant\\n\\n#eval exo2_certified  -- solution attendue : 7\\n#eval exo2_margin     -- solution attendue : 2.1\", \"env\": 10}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 20, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 20, \"column\": 5},\r\n",
+       "   \"data\": \"0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 21, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 21, \"column\": 5},\r\n",
+       "   \"data\": \"0.000000\"}],\r\n",
+       " \"env\": 11}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 2 : classe certifiée et marge de robustesse.\n",
+    "def argmax (scores : Array Float) (i : Nat) (bestIdx : Nat) : Nat :=\n",
+    "  if i >= scores.size then bestIdx\n",
+    "  else if scores[i]! > scores[bestIdx]! then argmax scores (i + 1) i\n",
+    "  else argmax scores (i + 1) bestIdx\n",
+    "\n",
+    "def secondBest (scores : Array Float) (bestIdx : Nat) (i : Nat) (best2 : Float) : Float :=\n",
+    "  if i >= scores.size then best2\n",
+    "  else if i == bestIdx then secondBest scores bestIdx (i + 1) best2\n",
+    "  else secondBest scores bestIdx (i + 1) (max best2 scores[i]!)\n",
+    "\n",
+    "def exo2_bounds : Array Float :=\n",
+    "  #[0.1, -0.2, 0.0, 0.3, 0.05, 0.4, 0.0, 2.5, 0.1, 0.2]\n",
+    "\n",
+    "-- TODO étudiant : classe certifiée (indice : argmax exo2_bounds 1 0)\n",
+    "def exo2_certified : Nat := 0  -- TODO étudiant\n",
+    "-- TODO étudiant : marge = best - second (indice : secondBest exo2_bounds ...)\n",
+    "def exo2_margin : Float := 0.0  -- TODO étudiant\n",
+    "\n",
+    "#eval exo2_certified  -- solution attendue : 7\n",
+    "#eval exo2_margin     -- solution attendue : 2.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e407f8cc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01003,
+     "end_time": "2026-06-18T03:11:14.457731+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T03:11:14.447701+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (à compléter) : Propagation IBP sur deux couches\n",
+    "\n",
+    "Propagez un intervalle d'entrée à travers **deux** couches linéaires (sans activation entre les deux), puis un ReLU final. *Indice : composez deux `linearIBP`, puis `reluIBP`.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3544712b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-18T03:11:14.479924Z",
+     "iopub.status.busy": "2026-06-18T03:11:14.479772Z",
+     "iopub.status.idle": "2026-06-18T03:11:14.591702Z",
+     "shell.execute_reply": "2026-06-18T03:11:14.590863Z"
+    },
+    "papermill": {
+     "duration": 0.123656,
+     "end_time": "2026-06-18T03:11:14.592229+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T03:11:14.468573+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : IBP sur deux couches linéaires + ReLU final.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- (Interval / linearIBP / reluIBP sont définis dans l&#39;exercice 1 ci-dessus.)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo3_input<span class=\"w\"> </span>:<span class=\"w\"> </span>Interval<span class=\"w\"> </span>:=<span class=\"w\"> </span>{<span class=\"w\"> </span>lower<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.0</span>,<span class=\"w\"> </span>upper<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">1.0</span><span class=\"w\"> </span>}</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO étudiant : couche 1 (w = 2.0, b = 0.5), couche 2 (w = -1.0, b = 0.0), puis ReLU.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo3_after1<span class=\"w\">  </span>:<span class=\"w\"> </span>Interval<span class=\"w\"> </span>:=<span class=\"w\"> </span>{<span class=\"w\"> </span>lower<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.0</span>,<span class=\"w\"> </span>upper<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.0</span><span class=\"w\"> </span>}<span class=\"w\">  </span><span class=\"c1\">-- TODO étudiant : linearIBP exo3_input 2.0 0.5</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo3_after2<span class=\"w\">  </span>:<span class=\"w\"> </span>Interval<span class=\"w\"> </span>:=<span class=\"w\"> </span>{<span class=\"w\"> </span>lower<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.0</span>,<span class=\"w\"> </span>upper<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.0</span><span class=\"w\"> </span>}<span class=\"w\">  </span><span class=\"c1\">-- TODO étudiant : linearIBP exo3_after1 (-1.0) 0.0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exo3_output<span class=\"w\">  </span>:<span class=\"w\"> </span>Interval<span class=\"w\"> </span>:=<span class=\"w\"> </span>reluIBP<span class=\"w\"> </span>exo3_after2</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1d\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>exo3_output<span class=\"w\">  </span><span class=\"c1\">-- solution attendue : { lower := 0.0, upper := 2.5 }</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> {<span class=\"w\"> </span>lower<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.000000</span>,<span class=\"w\"> </span>upper<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mf\">0.000000</span><span class=\"w\"> </span>}</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 12</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 3 : IBP sur deux couches lin\\u00e9aires + ReLU final.\\n-- (Interval / linearIBP / reluIBP sont d\\u00e9finis dans l'exercice 1 ci-dessus.)\\ndef exo3_input : Interval := { lower := 0.0, upper := 1.0 }\\n\\n-- TODO \\u00e9tudiant : couche 1 (w = 2.0, b = 0.5), couche 2 (w = -1.0, b = 0.0), puis ReLU.\\ndef exo3_after1  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO \\u00e9tudiant : linearIBP exo3_input 2.0 0.5\\ndef exo3_after2  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO \\u00e9tudiant : linearIBP exo3_after1 (-1.0) 0.0\\ndef exo3_output  : Interval := reluIBP exo3_after2\\n\\n#eval exo3_output  -- solution attendue : { lower := 0.0, upper := 2.5 }\", \"env\": 11}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 5},\r\n",
+       "   \"data\": \"{ lower := 0.000000, upper := 0.000000 }\"}],\r\n",
+       " \"env\": 12}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 3 : IBP sur deux couches linéaires + ReLU final.\n",
+       "-- (Interval / linearIBP / reluIBP sont définis dans l'exercice 1 ci-dessus.)\n",
+       "def exo3_input : Interval := { lower := 0.0, upper := 1.0 }\n",
+       "\n",
+       "-- TODO étudiant : couche 1 (w = 2.0, b = 0.5), couche 2 (w = -1.0, b = 0.0), puis ReLU.\n",
+       "def exo3_after1  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO étudiant : linearIBP exo3_input 2.0 0.5\n",
+       "def exo3_after2  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO étudiant : linearIBP exo3_after1 (-1.0) 0.0\n",
+       "def exo3_output  : Interval := reluIBP exo3_after2\n",
+       "\n",
+       "#eval exo3_output  -- solution attendue : { lower := 0.0, upper := 2.5 }\n",
+       "─────▶  { lower := 0.000000, upper := 0.000000 }\n",
+       "--% env 12\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 3 : IBP sur deux couches lin\\u00e9aires + ReLU final.\\n-- (Interval / linearIBP / reluIBP sont d\\u00e9finis dans l'exercice 1 ci-dessus.)\\ndef exo3_input : Interval := { lower := 0.0, upper := 1.0 }\\n\\n-- TODO \\u00e9tudiant : couche 1 (w = 2.0, b = 0.5), couche 2 (w = -1.0, b = 0.0), puis ReLU.\\ndef exo3_after1  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO \\u00e9tudiant : linearIBP exo3_input 2.0 0.5\\ndef exo3_after2  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO \\u00e9tudiant : linearIBP exo3_after1 (-1.0) 0.0\\ndef exo3_output  : Interval := reluIBP exo3_after2\\n\\n#eval exo3_output  -- solution attendue : { lower := 0.0, upper := 2.5 }\", \"env\": 11}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 5},\r\n",
+       "   \"data\": \"{ lower := 0.000000, upper := 0.000000 }\"}],\r\n",
+       " \"env\": 12}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 3 : IBP sur deux couches linéaires + ReLU final.\n",
+    "-- (Interval / linearIBP / reluIBP sont définis dans l'exercice 1 ci-dessus.)\n",
+    "def exo3_input : Interval := { lower := 0.0, upper := 1.0 }\n",
+    "\n",
+    "-- TODO étudiant : couche 1 (w = 2.0, b = 0.5), couche 2 (w = -1.0, b = 0.0), puis ReLU.\n",
+    "def exo3_after1  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO étudiant : linearIBP exo3_input 2.0 0.5\n",
+    "def exo3_after2  : Interval := { lower := 0.0, upper := 0.0 }  -- TODO étudiant : linearIBP exo3_after1 (-1.0) 0.0\n",
+    "def exo3_output  : Interval := reluIBP exo3_after2\n",
+    "\n",
+    "#eval exo3_output  -- solution attendue : { lower := 0.0, upper := 2.5 }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "t9614ys7bvc",
    "metadata": {
     "papermill": {
-     "duration": 0.012535,
-     "end_time": "2026-05-31T14:57:25.154251+00:00",
+     "duration": 0.010303,
+     "end_time": "2026-06-18T03:11:14.614324+00:00",
      "exception": false,
-     "start_time": "2026-05-31T14:57:25.141716+00:00",
+     "start_time": "2026-06-18T03:11:14.604021+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4910,14 +5336,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.957909,
-   "end_time": "2026-05-31T14:57:25.380465+00:00",
+   "duration": 7.60586,
+   "end_time": "2026-06-18T03:11:14.841429+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-11-TorchLean.ipynb",
    "output_path": "/tmp/Lean-11-TorchLean_wsl_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-31T14:57:18.422556+00:00",
+   "start_time": "2026-06-18T03:11:07.235569+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

`Lean-11-TorchLean` (kernel `lean4-wsl`) avait **3 Exemples guidés résolus** (contribution Antoine Gaillard & Ambroise Durst, PR #2399) + 1 « Exercice » — tous noyés comme blocs de code dans un **seul markdown cell**, sans **aucune** cellule code exercice exécutable. Le scanner `count_exercises` (#2161) comptait le marker markdown mais aucune cellule stub ne tournait réellement.

Per la convention **3-exercices par notebook** (#2161), cette PR ajoute **3 cellules code exercice stub** exécutables après la section Exemples guidés.

## Contenu (3 exercices, C.1-compliant)

1. **IBP sur couche à poids négatif + ReLU** — réutilise `Interval`/`reluIBP` de la section 5, ne redéfinit que `linearIBP` (qui n'existait que dans l'exemple guidé résolu)
2. **Classe certifiée + marge de robustesse** — composition `argmax` + `secondBest`
3. **IBP sur deux couches linéaires + ReLU final** — composition

Chaque stub utilise un **placeholder body** (`{lower := 0.0, upper := 0.0}`, `0`, `0.0`) qui compile et s'exécute proprement (output attendu bénin tant que l'étudiant ne complète pas), avec hints `-- TODO étudiant` inline référençant les fonctions enseignées. **0 `raise NotImplementedError` / `assert False` / `1/0`** (règle C.1).

## Cohabitation Exemple/Exercice (exercise-example-labeling)

Les **3 Exemples guidés résolus** (solutions fonctionnelles de Antoine G. & Ambroise D.) sont **préservés intacts** (anti-régression). Les Exercices stub **cohabitent** avec eux — pattern conforme.

## Validation (H / C.2)

```
$ python scripts/notebook_tools/wsl_papermill.py execute Lean-11-TorchLean.ipynb --kernel lean4-wsl --timeout 300
Executing (WSL): Lean-11-TorchLean.ipynb ...
  OK: 13/13 cells executed, 0 errors (9.5s)
```

- **C.1** : 0 error-cell. Stubs = placeholder bodies (warnings linter info uniquement, pas d'error output ❌).
- **C.2** : `execution_count: 1..13` monotone, outputs présents sur les 13 cellules code (post-Papermill in-place).
- **C.3** : seul le notebook est touché. `CATALOG-STATUS` byte-identique (0 ligne CATALOG dans le diff).
- **Anti-regression** : les 3 Exemples guidés résolus sont intacts (aucune suppression de `# Solution`).

## Cell-order (gate #3245)

2 findings pré-existants (section 2→4 gap, 3.0 après 3.1) — **confirmés sur origin/main**, non introduits par cette PR (mes cellules sont en section 7).

## Diff size note

Le diff `+575/-149` est essentiellement le **churn de re-sérialisation Papermill** (outputs HTML Alectryon du kernel `lean4_jupyter`, format verbeux) sur les cellules existantes + mes **+6 cells (+3 code)** réelles. Cell-count delta vérifié : 34→40 cells (10→13 code). Aucune cellule supprimée.

See #2161 (3-exercises convention, rollout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
