### PR TITLE
fix(smartcontracts): relabel SC-12 guided examples mislabeled as "Exercice" (Closes #3368, See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -2375,7 +2375,7 @@
     "tags": []
    },
    "source": [
-    "Exercice : écriture des tests pour le contrat SimpleVault en utilisant les cheatcodes Foundry étudiés précédemment."
+    "Écriture de la suite de tests pour le contrat SimpleVault en utilisant les cheatcodes Foundry étudiés précédemment. La solution complète ci-dessous sert d'exemple guidé résolu."
    ]
   },
   {
@@ -2669,7 +2669,7 @@
     "tags": []
    },
    "source": [
-    "Exercice : écriture des tests pour le contrat Timelock en utilisant notamment `vm.warp()` pour simuler l'écoulement du temps."
+    "Écriture de la suite de tests pour le contrat Timelock en utilisant notamment `vm.warp()` pour simuler l'écoulement du temps. La solution complète ci-dessous sert d'exemple guidé résolu."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Relabel de deux intros d'exemples guidés dans `SC-12-Foundry-Testing.ipynb`, titrées à tort « Exercice : écriture des tests... » alors qu'elles précèdent des **solutions de test complètes** (sous la section `## 6. Exemples guidés`, en-têtes `### Exemple guide 1|2`). Par contenu = Exemples (cf `.claude/rules/exercise-example-labeling.md`). Un étudiant cherchant un exercice y trouvait la solution complète = fuite.

`Closes #3368`
`See #3164` (audit fidélité — contribution partielle, l'epic reste ouverte)

## Détail

- **idx51 (`i0b08d5d8k`)** : « Exercice : écriture des tests pour le contrat SimpleVault... » → « Écriture de la suite de tests pour le contrat SimpleVault... La solution complète ci-dessous sert d'exemple guidé résolu. »
- **idx55 (`mm4vfpmukp`)** : idem pour Timelock (`vm.warp()`).

Solutions code complètes (idx52 `VAULT_TEST_SKELETON`, idx56 `TIMELOCK_TEST_SKELETON`) **byte-identiques** — elles sont correctes en tant qu'exemples ; seul le préfixe trompeur de l'intro est corrigé.

## Audit #3164 — résultat de la passe 03-Foundry-Testing

- **SC-12/13/14 = FIDELE pour #3164 stricto sensu.** Foundry n'est pas invoqué (`forge/cast/anvil: MANQUANT`), le code `print()` du Solidity, les `[PASS]` sont explicitement disclosed comme fallback statique (SC-12 idx18 `except FileNotFoundError`, idx19 markdown). La variante #3164 « markdown narre un succès par-dessus une erreur » est absente.
- Ce finding (mislabel exercice/exemple) est **hors-#3164 stricto sensu** mais réel et corrigé ici.

## Conformité

- **Markdown-only** : `git diff --stat` = `1 file changed, 2 insertions(+), 2 deletions(+)`. Aucun changement de `execution_count` / `outputs` / code.
- **#2161** : 3 vrais exercices stub préservés (idx20/33/46, ≥3).
- **Catalogue + submodule MGS** : byte-identiques à `main`.
- **No pendulum** : classification par contenu, pas de find-replace aveugle (zone `exercise-example-labeling.md`, incidents #1214/#1336).

## Validation

- 3 gates verts : C.2 (0 null-exec, 0 error-output), cell-ordering (intros markdown précèdent leurs solutions code), catalogue/submodule byte-identical.
