### PR TITLE
docs(genai-image): drop manual counts + de-duplicate Video bridge from parent (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -25,11 +25,11 @@ La structure détaillée (notebooks par niveau, contenu, services utilisés) est
 
 ```
 Image/
-├── 01-Foundation/     # Modèles de base (5 notebooks)
-├── 02-Advanced/       # Modèles avancés (5 notebooks)
-├── 03-Orchestration/  # Multi-modèles (3 notebooks)
-├── 04-Applications/   # Production (4 notebooks)
-└── examples/          # Cas d'usage (3 notebooks)
+├── 01-Foundation/     # Modèles de base
+├── 02-Advanced/       # Modèles avancés
+├── 03-Orchestration/  # Multi-modèles
+├── 04-Applications/   # Production
+└── examples/          # Cas d'usage
 ```
 
 ## Progression par niveau
@@ -161,7 +161,7 @@ Le fil rouge de cette série est la création d'un système de visuels pédagogi
 
 | Série | Lien | Connection |
 |-------|------|------------|
-| [Video](../Video/README.md) | Image-to-video | SVD (Video/02-4) anime une image existante ; le pipeline Video/03-2 enchaîne génération d'images puis animation |
+| [Video](../Video/README.md) | Image-to-video | Les visuels générés ici (DALL-E, FLUX, Qwen) servent d'images clés à animer : SVD (Video/02-4) ou le pipeline Video/03-2 les prennent en entrée |
 | [Audio](../Audio/README.md) | Sync audio-video | Audio/04-4 synchronise la piste audio avec les visuels générés |
 | [Texte](../Texte/README.md) | Prompts structurés | Les prompts DALL-E et GPT-5 Image bénéficient des techniques de prompt engineering (Texte/2) et function calling (Texte/4) |
 | [SemanticKernel](../SemanticKernel/README.md) | Orchestration | Les pipelines d'orchestration (03-2) partagent les mêmes patterns que les agents Semantic Kernel |


### PR DESCRIPTION
## Summary

Two anti-patterns resolved in two surgical edits on the **Image README** — the only real findings from a gabarit census (sonnet evidence-cited + cross-checked G.1). **Markdown-only** (C.2 exception). Follows ai-01 dispatch 02:03Z: \"Continue #2651 rollout famille GenAI/* (sous-familles Video/Image suivantes)\".

## Census result (honest)
The Image README is otherwise **clean**: 0 generic bridges (all 4 dedicated bridges name concrete notebooks/models on both sides), FAQ = 6 questions (at the ~6 bound), navigation present at L3 (the gabarit's reference exemplar), notebook table faithful 20/20 (verified against disk). So the only edits are these two.

## Edits (+6/-6)
1. **Anti-pattern 1 (gabarit L64/L76)**: structure tree carried manual per-directory counts \"(5 notebooks)\" etc. — duplicating bot-owned CATALOG-STATUS, and the file already points at L22 to \"Le décompte canonique réside dans CATALOG-STATUS.json\". Removed the counts, kept descriptions.
2. **Anti-pattern 2 (gabarit L65)**: the Video bridge \"SVD (Video/02-4) anime une image existante ; le pipeline Video/03-2 enchaîne génération d'images puis animation\" was near-verbatim of the parent GenAI README L285 (same sentence, reversed clause order). Reworded to state the connection from the Image side (generated visuals become key images for Video's animation), distinct from the parent's one-line summary.

## Notes for ai-01 (bot-owned, out of scope)
- This sub-series has **no `<!-- CATALOG-STATUS -->` block** (gabarit L80 lists GenAI/Image among missing markers). The bot cycle should add it; not done manually here.
- Parent CATALOG-STATUS declares `Image=17` while the disk has **20** notebooks — catalog drift, cron-owned. Not touched.

## Validation
- check-docs-links + no-catalog-changes covered by CI.
- 1 file, +6/-6.

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)