### PR TITLE
docs(sudoku): Sudoku-2-DancingLinks-Python — prose alignée aux sorties committées (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Sudoku-Python-DancingLinks : Dancing Links / Algorithm X (Python)\n",
     "\n",
-    "**Navigation** : [<< Python Genetic](Sudoku-3-Genetic-Python.ipynb) | [Index](README.md)\n",
+    "**Navigation** : [<< Sudoku-1 Backtracking Python](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Sudoku-3 Genetic Python >>](Sudoku-3-Genetic-Python.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -26,12 +26,12 @@
     "3. Comprendre les structures de donnees de listes doublement chainees circulaires\n",
     "4. Comparer les performances de DLX avec d'autres approches\n",
     "\n",
-    "**Duree estimee** : ~13 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir aussi [Sudoku-5 DancingLinks C#](Sudoku-2-DancingLinks-Python.ipynb)\n",
+    "**Duree estimee** : ~13 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir aussi [Sudoku-2 DancingLinks C#](Sudoku-2-DancingLinks-Csharp.ipynb)\n",
     "\n",
     "---\n",
     "\n",
     "Ce notebook implemente un solveur de Sudoku utilisant l'algorithme **Dancing Links (DLX)** de Donald Knuth.\n",
-    "C'est l'equivalent Python du notebook C# `Sudoku-5-DancingLinks.ipynb`.\n",
+    "C'est l'equivalent Python du notebook C# `Sudoku-2-DancingLinks-Csharp.ipynb`.\n",
     "\n",
     "## Table des matieres\n",
     "\n",
@@ -1143,18 +1143,18 @@
    "source": [
     "### Interpretation : Resolution du puzzle de test\n",
     "\n",
-    "Le solveur DLX a resolu le puzzle en 1.55 ms, ce qui est excellent.\n",
+    "Le solveur DLX a resolu le puzzle en 3.01 ms, ce qui est excellent.\n",
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| **Temps de resolution** | 1.55 ms | Tres rapide, meme pour un puzzle de difficulte moyenne |\n",
+    "| **Temps de resolution** | 3.01 ms | Tres rapide, meme pour un puzzle de difficulte moyenne |\n",
     "| **Solution valide** | True | L'algorithme a trouve une solution correcte |\n",
     "| **Cases vides initiales** | 51 | Puzzle relativement difficile (presque la moitie de la grille) |\n",
     "\n",
     "**Points cles** :\n",
     "1. **Performance immediatement optimale** : DLX n'a pas besoin d'heuristiques additionnelles\n",
     "2. **Resolution correcte** : La solution respecte toutes les contraintes Sudoku\n",
-    "3. **Comparaison favorable** : 1.55 ms est largement plus rapide que le backtracking simple sur des puzzles similaires\n",
+    "3. **Comparaison favorable** : 3.01 ms est largement plus rapide que le backtracking simple sur des puzzles similaires\n",
     "\n",
     "> **Note technique** : Le temps de resolution inclut la construction de la matrice de couverture exacte (324 colonnes x 729 lignes maximum) et l'execution de l'algorithme X. Malgre cette surcharge initiale, DLX reste extremement rapide car la structure de donnees est optimisee pour ce type de probleme."
    ]
@@ -1322,19 +1322,19 @@
    "source": [
     "### Interpretation : Chargement des puzzles\n",
     "\n",
-    "Les fichiers de puzzles n'ont pas ete trouves aux emplacements specifies.\n",
+    "Les fichiers de puzzles ont ete charges avec succes depuis le dossier `Puzzles/`.\n",
     "\n",
-    "| Fichier | Statut | Cause probable |\n",
+    "| Fichier | Statut | Contenu |\n",
     "|---------|--------|----------------|\n",
-    "| Sudoku_Easy51.txt | Non charge | Chemin incorrect ou fichier absent |\n",
-    "| Sudoku_hardest.txt | Non charge | Chemin incorrect ou fichier absent |\n",
+    "| Sudoku_Easy51.txt | Charge | 10 puzzles faciles |\n",
+    "| Sudoku_hardest.txt | Charge | 11 puzzles difficiles |\n",
     "\n",
-    "**Resolution du probleme** :\n",
-    "1. Verifier que le dossier `Puzzles/` existe a cote du notebook\n",
-    "2. S'assurer que les fichiers sont presents dans ce dossier\n",
-    "3. Alternativement, utiliser des puzzles integres directement dans le code\n",
+    "**Utilisation** :\n",
+    "1. Les puzzles faciles alimentent le benchmark de la section suivante\n",
+    "2. Les puzzles difficiles (Top 11) testent DLX sur des grilles plus contraintes\n",
+    "3. Un puzzle hardcode (section 6.1) reste disponible comme exemple autonome\n",
     "\n",
-    "> **Note technique** : Pour la suite du notebook, nous utilisons des puzzles hardcodes dans le code (comme le puzzle de test en section 6.1) pour garantir que les exemples fonctionnent meme sans fichiers externes."
+    "> **Note technique** : Le chargement lit les fichiers `.txt` du dossier `Puzzles/` ; un puzzle hardcode (section 6.1) reste disponible comme exemple autonome."
    ]
   },
   {
@@ -1537,13 +1537,12 @@
    "source": [
     "### Interpretation : Benchmark Dancing Links\n",
     "\n",
-    "Les benchmarks n'ont pas pu etre executes car les fichiers de puzzles n'ont pas ete trouves. Cependant, voici les resultats attendus basés sur l'analyse theorique et les comparaisons avec d'autres solveurs.\n",
+    "Les benchmarks ont ete executes sur les puzzles charges. DLX resout 21/21 puzzles (10 faciles + 11 difficiles) :\n",
     "\n",
-    "| Algorithme | Puzzle facile | Puzzle difficile | Avantage DLX |\n",
-    "|------------|---------------|------------------|--------------|\n",
-    "| Backtracking simple | 1-10 ms | 100-1000 ms | 10-100x |\n",
-    "| Backtracking + MRV | 0.5-5 ms | 10-100 ms | 5-20x |\n",
-    "| **Dancing Links** | 0.1-1 ms | 1-10 ms | **Reference** |\n",
+    "| Jeu de puzzles | Resolus | Temps moyen | Temps min / max |\n",
+    "|----------------|---------|-------------|------------------|\n",
+    "| Faciles (10) | 10/10 | 3.628 ms | 2.630 / 9.353 ms |\n",
+    "| Difficiles Top 11 (11) | 11/11 | 9.564 ms | 4.045 / 27.181 ms |\n",
     "\n",
     "**Points cles** :\n",
     "1. **Efficacite exceptionnelle** : DLX est optimise pour les problemes de couverture exacte\n",
@@ -1568,7 +1567,7 @@
     "tags": []
    },
    "source": [
-    "## Exemple : Comptage du nombre de solutions avec Dancing Links\n",
+    "## Exercice : Comptage du nombre de solutions avec Dancing Links\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -1673,7 +1672,7 @@
     "tags": []
    },
    "source": [
-    "## Exemple guide : Resoudre le probleme des N-Reines avec Dancing Links\n",
+    "## Exercice : Resoudre le probleme des N-Reines avec Dancing Links\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -1806,9 +1805,11 @@
     "|------------|---------------|------------------|\n",
     "| Backtracking simple | 1-10 ms | 100-1000 ms |\n",
     "| Backtracking + MRV | 0.5-5 ms | 10-100 ms |\n",
-    "| **Dancing Links** | 0.1-1 ms | 1-10 ms |\n",
+    "| **Dancing Links** (mesure) | ~3.6 ms | ~9.6 ms |\n",
     "| OR-Tools CP-SAT | 1-5 ms | 5-20 ms |\n",
     "| Z3 SMT | 5-20 ms | 20-100 ms |\n",
+    "\n",
+    "> Seule la ligne Dancing Links est mesuree dans ce notebook (benchmark section 6) ; les autres lignes sont des ordres de grandeur indicatifs issus de leurs notebooks respectifs.\n",
     "\n",
     "### Avantages de Dancing Links\n",
     "\n",
@@ -1824,7 +1825,7 @@
     "3. **Memoire** utilisee pour les pointeurs\n",
     "\n",
     "---\n",
-    "**Navigation** : [<< Python Genetic](Sudoku-3-Genetic-Python.ipynb) | [Index](README.md)"
+    "**Navigation** : [<< Sudoku-1 Backtracking Python](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Sudoku-3 Genetic Python >>](Sudoku-3-Genetic-Python.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
## Résumé

Audit de fidélité **#3164** sur `MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb`. Le cœur DLX (heuristique S min-size, cover/uncover par pointeurs, comptage de Sudokus valides) est **FIDELE** ; le défaut est une **prose d'interprétation périmée qui contredit les sorties que le notebook produit lui-même** (« stale failure narrative » : la prose nie des exécutions réussies visibles dans les outputs committés).

## Corrections (markdown-only, aligné sur les sorties committées)

| Cellule | Type | Avant | Après (source = output committé) |
|---------|------|-------|----------------------------------|
| idx17 | ERREUR-FACTUELLE | `1.55 ms` (absent de toute sortie) | `3.01 ms` (idx16) |
| idx22 | ERREUR-FACTUELLE (inversé) | « fichiers non trouvés » | chargés : 10 faciles / 11 difficiles (idx21) |
| idx27 | ERREUR-FACTUELLE (inversé) + tableau fabriqué | « benchmarks non exécutés » + théorie inventée | 10/10 @ 3.628 ms, 11/11 @ 9.564 ms (idx26) |
| idx32 | tableau « attendues » | ligne DLX `0.1-1 / 1-10 ms` | DLX `~3.6 / ~9.6 ms` (mesuré) + caveat |
| idx28 | LABELING | `## Exemple` sur stub | `## Exercice` (stub conservé) |
| idx30 | LABELING | `## Exemple guide` sur stubs | `## Exercice` (stubs conservés) |
| idx0 / idx32 | NAV cassée | lien C# = self Python, ref Sudoku-5 inexistante, prev=S3 | C# = jumeau `-Csharp`, prev=S1 |

## Garde-fous

- **Markdown-only** : `code chars delta = 0`, toutes les cellules code byte-identiques.
- **No-pendulum** : aucun chiffre fabriqué — tout provient des **sorties committées du notebook**.
- **4 gates verts** : cell-ordering (clean), C.2 (1/1 compliant), validate (Errors:0), diff code-output = 0.

## DEFER (hors scope markdown)

idx11 : méthode `search2` dupliquée + effet de bord `max_count -= 1` (smell qualité code, nécessiterait re-exécution — noté dans #3372 pour un grain séparé éventuel).

Closes #3372
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)