### PR TITLE
fix(smartcontracts): SC-16 align CKKS/Paillier prose to committed fallback output (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -335,18 +335,18 @@
    "source": [
     "### Interpretation : generation des cles Paillier\n",
     "\n",
-    "**Resultat obtenu** : La paire de cles est generee en 0.630 secondes avec un module n de 2048 bits, conforme au standard de securite recommande.\n",
+    "**Resultat obtenu** : La paire de cles est generee en 1.04 secondes (valeur dependante de la machine) avec un module n de 2048 bits, conforme au standard de securite recommande.\n",
     "\n",
     "| Parametre | Valeur | Rappel |\n",
     "|-----------|--------|--------|\n",
     "| Taille de n | 2048 bits | Equivalent RSA-2048 en securite |\n",
-    "| Temps de generation | 0.630 s | Principalement la recherche de grands premiers p et q |\n",
+    "| Temps de generation | ~1.04 s | Principalement la recherche de grands premiers p et q |\n",
     "| Structure | n = p * q | Deux nombres premiers de ~1024 bits chacun |\n",
     "\n",
     "**Points cles** :\n",
     "- La securite de Paillier repose sur la difficulte de factoriser n en p * q (meme hypothese que RSA)\n",
     "- En production, on utiliserait 3072 ou 4096 bits pour une securite long terme, mais 2048 bits sont suffisants pour l'apprentissage\n",
-    "- La cle publique (n) est distribuee aux chiffreurs, la cle privee (lambda, mu) est gardee secrete par le dechiffreur uniquement\n"
+    "- La cle publique (n) est distribuee aux chiffreurs, la cle privee (lambda, mu) est gardee secrete par le dechiffreur uniquement"
    ]
   },
   {
@@ -908,18 +908,12 @@
    "source": [
     "### Interpretation : operations CKKS sur des vecteurs chiffres\n",
     "\n",
-    "**Resultat obtenu** : Les trois operations chiffrees produisent des resultats proches des valeurs attendues, avec une erreur d'approximation controlee.\n",
-    "\n",
-    "| Operation | Erreur maximale | Precision relative |\n",
-    "|-----------|----------------|-------------------|\n",
-    "| Addition | 4.20e-09 | Quasi-exacte |\n",
-    "| Multiplication | 2.08e-06 | ~6 chiffres significatifs |\n",
-    "| Produit scalaire | 4.81e-06 | ~5 chiffres significatifs |\n",
+    "**Note d'execution** : TenSEAL n'etant pas installe dans cet environnement, la cellule precedente affiche un repli pedagogique (`TenSEAL non installe.`) plutot que d'executer reellement les operations CKKS. Les valeurs ci-dessous sont donc des ordres de grandeur typiques (et non un resultat mesure dans ce notebook). Avec une `global_scale = 2^40`, l'erreur d'approximation CKKS est typiquement de l'ordre de **1e-6 a 1e-4** : l'addition reste quasi-exacte tandis que l'erreur croit avec la profondeur multiplicative.\n",
     "\n",
     "**Points cles** :\n",
     "- L'erreur d'approximation provient de l'encodage CKKS qui injecte du bruit intentionnellement. La `global_scale = 2^40` controle la precision : plus la scale est elevee, plus la precision est bonne, mais moins de multiplications sont possibles avant bootstrapping\n",
     "- Le produit scalaire chiffre est l'operation fondamentale pour le ML confidentiel : il permet de calculer des produits matriciels (bases des reseaux de neurones) sans jamais voir les donnees en clair\n",
-    "- L'erreur croit avec la profondeur multiplicative : chaque multiplication double le bruit\n"
+    "- L'erreur croit avec la profondeur multiplicative : chaque multiplication double le bruit"
    ]
   },
   {
@@ -1054,19 +1048,19 @@
    "source": [
     "### Interpretation : benchmark CKKS\n",
     "\n",
-    "**Resultat obtenu** : Les temps d'operation sur un vecteur de 100 elements montrent un overhead significatif par rapport au calcul en clair.\n",
+    "**Note d'execution** : TenSEAL n'etant pas installe, la cellule precedente affiche un repli pedagogique (`TenSEAL non installe - benchmark ignore.`) au lieu de mesurer reellement les temps. Les valeurs ci-dessous sont des ordres de grandeur typiques (non mesures dans ce notebook) pour un vecteur de 100 elements :\n",
     "\n",
-    "| Operation | Temps CKKS | Temps en clair (estime) | Overhead |\n",
-    "|-----------|-----------|------------------------|----------|\n",
-    "| Chiffrement | 5.81 ms | ~0.001 ms | ~5800x |\n",
-    "| Addition chiffree | 0.10 ms | ~0.0001 ms | ~1000x |\n",
-    "| Multiplication | 5.70 ms | ~0.001 ms | ~5700x |\n",
-    "| Dechiffrement | 3.46 ms | ~0.001 ms | ~3460x |\n",
+    "| Operation | Temps typique CKKS | Remarque |\n",
+    "|-----------|--------------------|----------|\n",
+    "| Chiffrement | ~1-5 ms | |\n",
+    "| Addition chiffree | ~0.1 ms | Tres rapide (multiplication de polynomes) |\n",
+    "| Multiplication | ~1-5 ms | Multiplication tensorielle + relinearisation |\n",
+    "| Overhead total | ~1000x-10000x | vs calcul en clair |\n",
     "\n",
     "**Points cles** :\n",
-    "- L'addition chiffree est remarquablement rapide (0.10 ms) car elle ne fait que multiplier des polynomes modulo\n",
+    "- L'addition chiffree est remarquablement rapide (~0.1 ms) car elle ne fait que multiplier des polynomes modulo\n",
     "- La multiplication est plus couteuse car elle necessite une multiplication tensorielle suivie d'une operation de relinearisation\n",
-    "- Le parametre `poly_modulus_degree=8192` offre un bon compromis entre securite et performance pour des vecteurs de taille moderee\n"
+    "- Le parametre `poly_modulus_degree=8192` offre un bon compromis entre securite et performance pour des vecteurs de taille moderee"
    ]
   },
   {


### PR DESCRIPTION
## Résumé

Audit fidélité **#3164** — sous-série `SmartContracts/04-Privacy-Cryptography`. Corrige `SC-16-Homomorphic-Encryption.ipynb` : 3 cellules d'interprétation narraient des chiffres mesurés précis au-dessus d'outputs qui sont en réalité des replis statiques (TenSEAL non installé) ou des valeurs dépendantes de la machine.

`Closes #3381` · `See #3164`

## Findings corrigés (markdown-only, G.1-vérifiés contre l'output committé)

| Cellule | Narré (avant) | Output committé (réel) | Fix |
|---------|---------------|------------------------|-----|
| idx6 `22342f49` | « 0.630 secondes » / table « 0.630 s » | `Temps de generation : 1.041s` | `~1.04 s (valeur dependante de la machine)` |
| idx18 `7fe53e07` | table précision `4.20e-09 / 2.08e-06 / 4.81e-06` | `TenSEAL non installe.` (erreur typique `1e-6 a 1e-4`) | « Note d'execution » honnête citant la plage 1e-6 à 1e-4 |
| idx21 `47b715c3` | table benchmark `5.81 ms / 5700x / 3460x` | `TenSEAL non installe - benchmark ignore.` (`~1-5 ms / ~0.1 ms / ~1000x-10000x`) | disclosure citant les plages réelles du repli |

**No-pendulum** : les chiffres sont alignés sur les valeurs que l'output committé disclose lui-même, pas supprimés en bloc. Paillier et Shamir dans ce notebook sont réels (pycryptodome) ; seul le bloc CKKS/TenSEAL était en repli.

## Cadrage de la passe 04-Privacy-Cryptography

- **SC-15** (Zero-Knowledge-Proofs) : **FIDELE** (Schnorr / Chaum-Pedersen / Fiat-Shamir / R1CS réels). Pas de PR.
- **SC-17** (E2E-Verifiable-Voting) : **FIDELE** (Paillier voting, tally 3+2+2=7 corroboré ; ElectionGuard repli honnête disclosed). Pas de PR.
- **SC-16** : cette PR.

## Validation

- C.2 : 13 cellules code, 0 `execution_count: null`, 0 output `error`.
- Markdown-only : `git diff` = 14 ins / 20 del sur **SC-16 uniquement** ; code/outputs inchangés.
- Catalogue (`COURSE_CATALOG.generated.*`) + submodule MGS **byte-identiques à `origin/main`**.
- ≥3 exercices stub préservés (idx 15/33/37/40), conforme #2161.
- Branche basée sur `origin/main` frais (310dcddc).
