### PR TITLE
docs(sudoku-6): nav 6->7 Norvig + CBJ sur-affirmation corrigee (Python) — #3164

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "| << Precedent | [Index](README.md) | Suivant >> |\n",
     "|-------------|---------------------|-----------|\n",
-    "| [Sudoku-5-PSO-Python](Sudoku-5-PSO-Python.ipynb) | | [Sudoku-8-HumanStrategies-Python](Sudoku-8-HumanStrategies-Python.ipynb) |\n",
+    "| [Sudoku-5-PSO-Python](Sudoku-5-PSO-Python.ipynb) | | [Sudoku-7-Norvig-Python](Sudoku-7-Norvig-Python.ipynb) |\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -1713,7 +1713,7 @@
     "\n",
     "### Pourquoi cet exemple est instructif\n",
     "\n",
-    "Sur les puzzles faciles, CBJ avec MRV fonctionne bien (peu d'assignations). Mais sur les puzzles **difficiles**, CBJ sans propagation de contraintes (Forward Checking, AC-3) ne resout pas les grilles : peu d'assignations mais 0 succes. Cela illustre que **le backjumping seul ne suffit pas** -- il faut le combiner avec des heuristiques de selection de variable ET de propagation de contraintes.\n",
+    "Sur les puzzles faciles, CBJ avec MRV fonctionne bien (peu d'assignations). Mais sur les puzzles **difficiles**, le backjumping seul ne compense pas l'absence de propagation de contraintes (Forward Checking, AC-3) : c'est une limite connue de CBJ. Le benchmark ci-dessous porte sur des puzzles faciles, ou CBJ converge ; il illustre que **le backjumping seul ne suffit pas** -- il faut le combiner avec des heuristiques de selection de variable ET de propagation de contraintes.\n",
     "\n",
     "**Lecon** : ne jugez pas un algorithme seulement sur des instances faciles. Un algorithme qui semble efficace sur des problemes simples peut echouer sur des instances plus difficiles ou la propagation de contraintes est determinante.\n"
    ]
@@ -2164,7 +2164,7 @@
     "\n",
     "L'etude du Conflict-Based Backjumping (CBJ) a fourni un exemple cautionnaire instructif : bien que theoriquement superieur au backtracking chronologique, CBJ sans propagation de contraintes ne surpasse pas Forward Checking ou MAC sur les puzzles difficiles. Cette observation rappelle que le choix d'un algorithme ne se juge pas sur les instances faciles seul. L'exercice sur le coloriage de graphe permet de transferer ces competences vers un autre CSP classique avec des topologies variees.\n",
     "\n",
-    "Le notebook suivant, [Sudoku-8-HumanStrategies-Python](Sudoku-8-HumanStrategies-Python.ipynb), explore les strategies de resolution humaines (naked singles, hidden singles) qui s'inspirent des techniques de propagation avancees etudiees ici."
+    "Le notebook suivant, [Sudoku-7-Norvig-Python](Sudoku-7-Norvig-Python.ipynb), presente l'approche de Peter Norvig, qui combine la propagation de contraintes (elimination et unique candidat restant) avec une recherche en profondeur pour resoudre efficacement tout Sudoku."
    ]
   },
   {
@@ -2214,7 +2214,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Sudoku-5-PSO](Sudoku-5-PSO-Python.ipynb) | [Index](README.md) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Python.ipynb)"
+    "**Navigation** : [<< Sudoku-5-PSO](Sudoku-5-PSO-Python.ipynb) | [Index](README.md) | [Sudoku-7-Norvig >>](Sudoku-7-Norvig-Python.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
Audit de fidelite **Epic #3164** du notebook **Sudoku-6-AIMA-CSP-Python**. Markdown only, **code delta=0**, outputs intacts.

## Fidelite algorithmique : PROPRE (cross-check parent)
MRV/LCV (idx16), Forward Checking (idx20), AC-3 (idx24), MAC (idx28), CBJ (idx35) **reellement** implementes conformes a la prose (lecture du code). Benchmarks idx40 **exacts** vs output committe idx32 : `2889322` (2,9M) / `255` / `81` / `81 0` ; "quatre ordres de grandeur" coherent. Labeling propre. **Aucune REINVENTION/OMISSION.**

## Defaut 1 (PRINCIPAL) — Navigation saute Sudoku-7-Norvig
Sequence lineaire 6 -> 7 -> 8, `Sudoku-7-Norvig-Python.ipynb` **existe**, mais "Suivant" pointait vers **Sudoku-8** (saut de S7) :
| Cellule | Avant | Apres |
|--------|-------|-------|
| idx0 (`71960cdb`) table nav | next = Sudoku-8-HumanStrategies | next = **Sudoku-7-Norvig** |
| idx40 (`888465da`) "notebook suivant" | lien S8 + description S8 (naked/hidden singles) | lien **S7** + description Norvig (propagation + recherche) |
| idx41 (`ebb356b0`) pied de page | `Sudoku-8-HumanStrategies >>` | `Sudoku-7-Norvig >>` |

See-also Sudoku-8 de idx41 laisse intact (lien thematique, pas sequentiel).

## Defaut 2 — idx34 CBJ : sur-affirmation non mesuree
idx34 affirmait *"sur les puzzles difficiles ... ne resout pas les grilles : peu d'assignations mais **0 succes**"*, mais le seul benchmark CBJ (idx37, `85ba2c40`) porte sur **3 puzzles faciles** (`CONFLICT BACK JUMPING 82 1 3/3`). Le "0 succes sur difficiles" n'est jamais produit -> remplace par "limite connue de CBJ" + scope du benchmark, lecon conservee (no-pendulum).

## Hors-scope (signale)
`Sudoku-7-Norvig-Python.ipynb` a son propre en-tete degrade (legacy span + nav vers jumeaux C# seulement) -> grain distinct.

## Validation (4 gates)
- `scan_cell_ordering` : 1 clean, 0 finding
- `check_c2_compliance` : 1/1 compliant
- `notebook_tools validate` : OK 1, Warnings 0, **Errors 0**
- `git diff | grep -cE '"execution_count"|"outputs"|"cell_type": "code"'` = **0**

Closes #3383
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)