### PR TITLE
docs(pymc): fidelity #3164 PyMC-8-Model-Selection -- WAIC/PSIS-LOO/ARD scholarly attribution

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection.ipynb
@@ -241,6 +241,19 @@
     "- Les deux retournent un score (plus petit = meilleur) + une incertitude\n",
     "- La difference entre modeles est mesurable via `dSE` (deviance standard error)\n",
     "\n",
+    "### Origine des methodes\n",
+    "\n",
+    "Le **WAIC** (Widely Applicable Information Criterion) est du a **Sumio Watanabe (2010)**,\n",
+    "*\"Asymptotic Equivalence of Bayes Cross Validation and Widely Applicable Information\n",
+    "Criterion in Singular Learning Theory\"*, JMLR 11 : il etend l'AIC d'Akaike (1974) aux\n",
+    "modeles singuliers (melanges, reseaux de neurones). Le **LOO** par *Pareto-smoothed\n",
+    "importance sampling* (PSIS-LOO) est decrit dans **Vehtari, Gelman & Gabry (2017)**,\n",
+    "*\"Practical Bayesian model evaluation using leave-one-out cross-validation and WAIC\"*,\n",
+    "Statistics and Computing 27(5), doi:10.1007/s11222-016-9696-4. Les deux criteres\n",
+    "estiment la meme grandeur (la log-density predictive hors-echantillon) et sont\n",
+    "asymptotiquement equivalents. Les fonctions `az.compare` et `az.loo` proviennent\n",
+    "d'**ArviZ** (Kumar et al. 2019, JOSS).\n",
+    "\n",
     "### Comparaison avec Infer.NET\n",
     "\n",
     "Infer.NET calcule l'evidence exacte via `Variable.Bernoulli(0.5)` + `Variable.If` :\n",
@@ -1118,7 +1131,11 @@
     "```\n",
     "\n",
     "**Equivalent Infer.NET** : identique, avec `Variable.GammaFromShapeAndScale(1, 1)` et\n",
-    "`Variable.GaussianFromMeanAndPrecision(0, alpha[f])`."
+    "`Variable.GaussianFromMeanAndPrecision(0, alpha[f])`.\n",
+    "\n",
+    "### Origine\n",
+    "\n",
+    "L'ARD (Automatic Relevance Determination) a ete introduite par **Michael E. Tipping (2001)**, *\"Sparse Bayesian Learning and the Relevance Vector Machine\"*, NIPS 13 : c'est le fondement du **Relevance Vector Machine**. Voir aussi Bishop (2006), *Pattern Recognition and Machine Learning*, section 7.2, et MacKay (1992) pour la forme originale du prior hierarchique en precision.\n"
    ]
   },
   {
@@ -1639,7 +1656,11 @@
     "en approximant la moyenne des performances quand on laisse chaque observation de cote.\n",
     "\n",
     "ArviZ utilise le **Pareto Smoothed Importance Sampling (PSIS)** pour une approximation\n",
-    "rapide et fiable du LOO sans re-entrainer le modele N fois."
+    "rapide et fiable du LOO sans re-entrainer le modele N fois.\n",
+    "\n",
+    "### Reference\n",
+    "\n",
+    "La methode PSIS-LOO implementee par `az.loo()` est celle de **Vehtari, Gelman & Gabry (2017)**, Statistics and Computing 27(5), doi:10.1007/s11222-016-9696-4. Le diagnostique de **Pareto k** explore ci-dessous provient de la meme reference : il mesure la qualite de l'approximation par importance sampling pour chaque observation laissee de cote (k < 0.7 = fiable, k > 0.7 = approximation fragile).\n"
    ]
   },
   {
@@ -1914,7 +1935,15 @@
     "\n",
     "---\n",
     "\n",
-    "**Retour au sommaire** : [Index Probas](../README.md)"
+    "**Retour au sommaire** : [Index Probas](../README.md)\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Akaike, H. (1974). *A new look at the statistical model identification.* IEEE Transactions on Automatic Control 19(6).\n",
+    "- Tipping, M. E. (2001). *Sparse Bayesian Learning and the Relevance Vector Machine.* NIPS 13.\n",
+    "- Watanabe, S. (2010). *Asymptotic Equivalence of Bayes Cross Validation and Widely Applicable Information Criterion in Singular Learning Theory.* JMLR 11.\n",
+    "- Vehtari, A., Gelman, A., & Gabry, J. (2017). *Practical Bayesian model evaluation using leave-one-out cross-validation and WAIC.* Statistics and Computing 27(5). doi:10.1007/s11222-016-9696-4\n",
+    "- Kumar, R., Carroll, C., Hartikainen, A., & Martin, O. (2019). *ArviZ: a unified library for exploratory analysis of Bayesian models in Python.* JOSS 4(33).\n"
    ]
   }
  ],


### PR DESCRIPTION
## Contexte

Audit fidélité #3164 (famille Probas/PyMC). Suite des corrections d'OMISSION scholarly sur la série PyMC (déjà mergées : PyMC-6 #3289, PyMC-3 #3336, PyMC-10 #3345, PyMC-12 #3355, PyMC-5 #3371).

## Verdict : OMISSION (HIGH confidence)

`PyMC-8-Model-Selection.ipynb` implémente **réellement** les méthodes canoniques de sélection de modèle bayésienne — WAIC (`az.compare(ic="waic")`), PSIS-LOO (`az.loo`), le diagnostique Pareto-k, et l'ARD (prior hiérarchique Gamma sur la précision) — avec `pm.sample` réel (cells 5/13/19) et outputs cohérents (`1-gaussien: -89.20`, `elpd_diff = 0.83`, tous `k < 0.7`). **0 REINVENTION**, NUTS légitime (tous les latents sont continus ; `NormalMixture` marginalise l'affectation discrète).

Mais le notebook **cite aucune source scholarly** pour ces méthodes. Grep cross-check G.1 : **0× pour Watanabe, Vehtari, Gelman, Gabry, Tipping, Akaike, doi:, JMLR, 2010, 2017** dans la source originale. Même classe d'OMISSION récurrente (c) que PyMC-6/10/12/5.

## Corrections (markdown-only, 4 cells, +32/-3)

| Cell | Contenu |
|------|---------|
| idx4 (`e5f6a7b4`) WAIC/LOO intro | Attribution **Watanabe (2010)** WAIC JMLR 11 (étend l'AIC d'Akaike 1974 aux modèles singuliers) + **Vehtari/Gelman/Gabry (2017)** PSIS-LOO Statistics and Computing 27(5) doi:10.1007/s11222-016-9696-4 + ArviZ (Kumar et al. 2019 JOSS) |
| idx16 (`a3b4c5d2`) ARD intro | Citation **Tipping (2001)** Relevance Vector Machine NIPS 13 + Bishop (2006) PRML §7.2 + MacKay (1992) |
| idx27 (`a9b0c1d8`) LOO/ArviZ intro | Référence Vehtari/Gelman/Gabry (2017) + explication du diagnostique Pareto k |
| idx34 (`f4a5b6c3`) Conclusion | Bloc References (5 citations) |

## Validation

- nbformat VALID
- C.1 clean (0 `raise NotImplementedError` / `assert False` / `1/0`)
- cell-order gate #3245 clean
- **0 ligne `execution_count`/`outputs` ajoutée** (C.3 — markdown-only, exception C.2 re-exécution)
- base fraîche `origin/main`, catalogue byte-identique

`See #3164`

Co-Authored-By: Claude <noreply@anthropic.com>
