### PR TITLE
docs(sudoku): fidelity audit Sudoku-7-Norvig-Python -- header rebuild + benchmark/resume align + labeling (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
@@ -14,15 +14,15 @@
     "tags": []
    },
    "source": [
-    "<span style=\"color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;\">Analyse, Conception et Implémentation d'Algorithmes</span>\n",
+    "# Sudoku-7 : Résolution par Propagation de Contraintes (Norvig) (Python)\n",
     "\n",
-    "---\n",
+    "**Niveau** : Programmation par contraintes | **Durée** : ~20 min | **Prérequis** : Sudoku-6 AIMA-CSP (Python)\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Sudoku-7 C#](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-8 C# >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
+    "## Navigation\n",
     "\n",
-    "# Le Sudoku comme CSP\n",
-    "\n",
-    "<span style=\"color:gray; font-style:italic;\">Les notebooks de cette section présentent différentes approches pour résoudre des puzzles Sudoku.</span>"
+    "| << Précédent | Sommaire | Suivant >> |\n",
+    "|--------------|----------|------------|\n",
+    "| [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb) | [Index](README.md) | [Sudoku-8-HumanStrategies-Python](Sudoku-8-HumanStrategies-Python.ipynb) |\n"
    ]
   },
   {
@@ -39,24 +39,12 @@
     "tags": []
    },
    "source": [
-    "# Sudoku-7-Norvig-Python : Solveur de Peter Norvig (Python)\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Objectifs\n",
+    "## Objectifs d'apprentissage\n",
     "\n",
     "- Comprendre l'approche élégante de Peter Norvig pour résoudre le Sudoku\n",
     "- Implémenter un solveur basé sur la propagation de contraintes et le backtracking\n",
-    "- Comparer les performances sur différents niveaux de difficulté\n",
-    "\n",
-    "## Prérequis\n",
-    "\n",
-    "- Python 3.10+\n",
-    "- Concepts de base en programmation par contraintes\n",
-    "\n",
-    "## Durée estimée\n",
-    "\n",
-    "15 minutes"
+    "- Combiner l'élimination des candidats (pairs et unités) avec une recherche en profondeur guidée par l'heuristique MRV\n",
+    "- Comparer les performances sur différents niveaux de difficulté\n"
    ]
   },
   {
@@ -784,8 +772,8 @@
     "\n",
     "| Type de puzzle | Temps moyen | Taux de succes | Analyse |\n",
     "|----------------|-------------|----------------|---------|\n",
-    "| **Faciles** | 3.20 ms | 100% (20/20) | Resolution quasi-instantanee |\n",
-    "| **Difficiles** | 4.55 ms | 100% (11/11) | Peu de difference faciles/difficiles |\n",
+    "| **Faciles** | 2.07 ms | 100% (20/20) | Resolution quasi-instantanee |\n",
+    "| **Difficiles** | 2.82 ms | 100% (11/11) | Peu de difference faciles/difficiles |\n",
     "\n",
     "**Points cles** :\n",
     "1. **Performance constante** : La difficulte du puzzle n'impacte que marginalement le temps\n",
@@ -903,7 +891,7 @@
     "tags": []
    },
    "source": [
-    "## Exemple : Porter l'algorithme Norvig sur un mini-Sudoku 4x4\n",
+    "## Exercice : Porter l'algorithme Norvig sur un mini-Sudoku 4x4\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -1169,7 +1157,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a presenté l'approche élégante de Peter Norvig pour résoudre le Sudoku en ~80 lignes de Python. La méthode repose sur deux piliers : la **propagation de contraintes** (élimination des candidats impossibles via les pairs et les unités) et le **backtracking** guidé par l'heuristique MRV (choisir la case avec le moins de valeurs possibles). Le benchmark montre des performances remarquables (~2 ms par puzzle en moyenne), avec une faible sensibilité à la difficulté de la grille. Cette implémentation illustre un principe fondamental en intelligence artificielle : un bon encodage du problème (représentation par dictionnaire de candidats) combiné à une heuristique pertinente (MRV) peut surpasser des approches algorithmiquement plus complexes. Les exercices proposés (mini-Sudoku 4x4, paires nues) permettent d'étendre le solveur avec des techniques de propagation avancées."
+    "Ce notebook a presenté l'approche élégante de Peter Norvig pour résoudre le Sudoku en ~80 lignes de Python. La méthode repose sur deux piliers : la **propagation de contraintes** (élimination des candidats impossibles via les pairs et les unités) et le **backtracking** guidé par l'heuristique MRV (choisir la case avec le moins de valeurs possibles). Le benchmark montre des performances remarquables (~2 à 3 ms par puzzle en moyenne), avec une faible sensibilité à la difficulté de la grille. Cette implémentation illustre un principe fondamental en intelligence artificielle : un bon encodage du problème (représentation par dictionnaire de candidats) combiné à une heuristique pertinente (MRV) peut surpasser des approches algorithmiquement plus complexes. Les exercices proposés (mini-Sudoku 4x4, paires nues) permettent d'étendre le solveur avec des techniques de propagation avancées."
    ]
   },
   {
@@ -1194,13 +1182,12 @@
     "2. **MRV** : Choix intelligent de la case suivante\n",
     "3. **Backtracking simple** : Pas de besoin d'algorithmes complexes\n",
     "\n",
-    "### Performances typiques\n",
+    "### Performances mesurées (ce notebook)\n",
     "\n",
     "| Type | Temps moyen | Taux de succès |\n",
     "|------|-------------|----------------|\n",
-    "| Facile | <1 ms | 100% |\n",
-    "| Moyen | 1-10 ms | 100% |\n",
-    "| Difficile | 10-100 ms | ~100% |\n",
+    "| Faciles (20 puzzles) | ~2.1 ms | 100% (20/20) |\n",
+    "| Difficiles (11 puzzles) | ~2.8 ms | 100% (11/11) |\n",
     "\n",
     "### Références\n",
     "\n",


### PR DESCRIPTION
## Résumé

Audit de fidélité (Epic #3164) du notebook **Sudoku-7-Norvig-Python**. **Markdown uniquement** (code delta = 0, exception C.2). Le corps est un solveur de Norvig authentique (`assign`/`eliminate` = élimination par pairs + placement unique dans une unité ; `search` = DFS guidée par MRV) — **FIDELE**, aucune REINVENTION.

## Corrections

1. **En-tête dégradé (PRIMARY)** — double en-tête : titre générique `<span>` rouge legacy + navigation vers les **jumeaux C#** + H1 parasite « # Le Sudoku comme CSP », doublé d'un H1 titre dupliqué (durée 15 min vs 20 min côté C#). → **Un seul en-tête canonique** (titre + Niveau/Durée 20 min/Prérequis + table de nav vers `Sudoku-6-AIMA-CSP-Python` ⇄ `Sudoku-8-HumanStrategies-Python`, miroir du jumeau C# et du format Sudoku-6-Python) ; 2e cellule → section « Objectifs d'apprentissage » (4 objectifs).
2. **ERREUR-FACTUELLE** — table d'interprétation benchmark « 3.20 / 4.55 ms » → sortie committée **2.07 / 2.82 ms** (taux 20/20 et 11/11 déjà corrects).
3. **Table « Performances typiques » fabriquée** — catégorie « Moyen 1-10 ms » jamais mesurée + fourchettes <1 ms / 10-100 ms contredisant le profil plat ~2-3 ms committé → ré-alignée sur les **2 catégories mesurées**, renommée « Performances mesurées (ce notebook) ».
4. **LABELING (cas 2)** — « ## Exemple : Porter ... mini-Sudoku 4x4 » au-dessus d'un **stub** (énoncé + indices, renvoie « Exercice a completer ») → titre « ## Exercice » (stub **non** rempli).
5. **Mineur** — Conclusion « ~2 ms » → « ~2 à 3 ms ».

No-pendulum : chaque nombre provient des **sorties committées du notebook lui-même**.

## Validation

| Gate | Résultat |
|------|----------|
| scan_cell_ordering | 1 clean, 0 finding |
| check_c2_compliance | 1/1 compliant |
| notebook_tools validate | 0 error / 0 warning |
| git-diff code-lines | 0 (markdown-only) |

Closes #3385
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)