### PR TITLE
docs(sudoku): fidelity audit Sudoku-8-HumanStrategies-Python -- nav fix + benchmark/comparison align + labeling (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "| << Precedent | [Index](README.md) | Suivant >> |\n",
     "|-------------|---------------------|-----------|\n",
-    "| [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb) | | [Sudoku-9-GraphColoring-Python](Sudoku-9-GraphColoring-Python.ipynb) |\n",
+    "| [Sudoku-7-Norvig-Python](Sudoku-7-Norvig-Python.ipynb) | | [Sudoku-9-GraphColoring-Python](Sudoku-9-GraphColoring-Python.ipynb) |\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -1529,8 +1529,8 @@
     "| Metrique | Valeur | Signification |\n",
     "|----------|--------|---------------|\n",
     "| **Taux de reussite** | 5/5 (100%) | Tous les puzzles faciles resolus |\n",
-    "| **Temps moyen** | 2.96ms | Performance excellente |\n",
-    "| **Temps total** | 14.81ms | Meme avec 5 puzzles |\n",
+    "| **Temps moyen** | 2.20ms | Performance excellente |\n",
+    "| **Temps total** | 10.99ms | Meme avec 5 puzzles |\n",
     "| **Strategies utilisees** | 5 differentes | Toute la gamme de difficulte |\n",
     "\n",
     "**Distribution des strategies** :\n",
@@ -1541,7 +1541,7 @@
     "- **X-Wing** : 5 applications (technique avancee peu frequente)\n",
     "\n",
     "**Points cles** :\n",
-    "1. Les techniques de base (Naked/Hidden Singles) representent **96%** des deductions (240/249)\n",
+    "1. Les techniques de base (Naked/Hidden Singles) representent **87%** des deductions (240/277)\n",
     "2. Les techniques avancees (X-Wing) ne sont necessaires que pour 2% des deductions\n",
     "3. La resolution est **extremement rapide** : moins de 4ms par puzzle en moyenne\n",
     "4. Le solveur humain est **complet** : il combine automatiquement les techniques necessaires\n",
@@ -1724,7 +1724,7 @@
     "\n",
     "| Aspect | Strategies Humaines | Backtracking Simple |\n",
     "|--------|---------------------|---------------------|\n",
-    "| **Temps moyen** | 0.73 - 3.84ms | 2.12 - 21.59ms |\n",
+    "| **Temps moyen** | 0.57 - 2.66ms | 1.96 - 17.47ms |\n",
     "| **Appels recursifs** | 0 (deduction logique) | 49 - 295 appels |\n",
     "| **Efficacite** | Resolution directe | Essai-erreur |\n",
     "| **Explicabilite** | Chaîne de deductions claire | Pas de traçabilité |\n",
@@ -1732,7 +1732,7 @@
     "**Points cles** :\n",
     "1. Les strategies humaines sont **2-5x plus rapides** que le backtracking simple pour les puzzles faciles\n",
     "2. Le backtracking effectue des appels recursifs inutiles (49-295) alors que les strategies humaines resolvent directement par deduction\n",
-    "3. La difference de performance s'accroit avec la difficulte du puzzle (puzzle 3 : 3.84ms vs 21.59ms)\n",
+    "3. La difference de performance s'accroit avec la difficulte du puzzle (puzzle 3 : 2.66ms vs 17.47ms)\n",
     "4. Les strategies humaines produisent une solution explicable (chaque placement est justifie par une technique logique)\n",
     "\n",
     "> **Note technique** : Le backtracking simple ne profite pas des contraintes pour reduire l'espace de recherche. Il teste toutes les possibilites de 1 a 9 pour chaque case, meme quand une seule est valide. Les strategies humaines identifient directement cette unique possibilite."
@@ -1929,7 +1929,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 1b : Hidden Pair dans les blocs\n",
+    "### Exercice 1b : Hidden Pair dans les blocs\n",
     "\n",
     "**Enonce** : Implementez une fonction `find_hidden_pairs_blocks(self)` qui detecte les Hidden Pairs uniquement dans les 9 blocs 3x3.\n",
     "\n",
@@ -2111,7 +2111,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2b : Swordfish par colonnes\n",
+    "### Exercice 2b : Swordfish par colonnes\n",
     "\n",
     "**Enonce** : Implementez une fonction `find_swordfish_cols(self)` qui detecte les Swordfish uniquement dans l'orientation colonnes (en ignorant les lignes).\n",
     "\n",
@@ -2339,7 +2339,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3b : XY-Wing pour un pivot donne\n",
+    "### Exercice 3b : XY-Wing pour un pivot donne\n",
     "\n",
     "**Enonce** : Implementez une fonction `find_xy_wings_for_pivot(self, pivot_row, pivot_col)` qui, pour un pivot donne, cherche toutes les paires d'ailes possibles.\n",
     "\n",
@@ -2533,7 +2533,15 @@
   {
    "cell_type": "markdown",
    "id": "7f7e6a12",
-   "source": "## Resume et perspectives\n\nCe notebook a explore la resolution de Sudoku par **deduction logique progressive**, en implementant les techniques utilisees par les experts humains : **Naked Singles** et **Hidden Singles** pour les puzzles faciles, **Naked Pairs** et **Pointing Pairs** pour le niveau intermediaire, et **X-Wing** pour les grilles avancees. Les techniques supplementaires (Hidden Pairs, Swordfish, XY-Wing) ont ete presentees en exemples guides pour illustrer les strategies expert. Le benchmark sur 5 puzzles faciles a montre que les Hidden Singles dominent avec 149 applications (60% des deductions), suivis des Naked Singles (91 occurrences), tandis que les techniques avancees comme X-Wing ne representent que 2% des cas -- confirmant que la majorite des puzzles courants se resolvent par inference directe sans recours au backtracking.\n\nLa comparaison avec le backtracking simple a mis en evidence un avantage qualificatif majeur : les strategies humaines produisent une **chaine de deductions explicable**, ou chaque placement est justifie par une technique logique identifiable, tandis que le backtracking procede par essai-erreur opaque. En termes de performance, le solveur humain est 2 a 5 fois plus rapide sur les puzzles faciles et ne necessite aucun appel recursif, la ou le backtracking accumule 49 a 295 appels. Le mecanisme de fallback vers le backtracking garantit toutefois la completude du solveur sur les instances ou les techniques de deduction atteignent leurs limites.\n\nLe prochain notebook, **Sudoku-9-GraphColoring-Python**, change de paradigme en modelisant le Sudoku comme un probleme de **coloration de graphe** avec NetworkX, ou les 81 cellules deviennent des sommets et les contraintes d'exclusion des aretes, permettant de comparer des heuristiques de coloration (MRV, LCV, Welsh-Powell) sur cette structure reguliere.",
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a explore la resolution de Sudoku par **deduction logique progressive**, en implementant les techniques utilisees par les experts humains : **Naked Singles** et **Hidden Singles** pour les puzzles faciles, **Naked Pairs** et **Pointing Pairs** pour le niveau intermediaire, et **X-Wing** pour les grilles avancees. Les techniques supplementaires (Hidden Pairs, Swordfish, XY-Wing) ont ete presentees en exemples guides pour illustrer les strategies expert. Le benchmark sur 5 puzzles faciles a montre que les Hidden Singles dominent avec 149 applications (54% des deductions), suivis des Naked Singles (91 occurrences), tandis que les techniques avancees comme X-Wing ne representent que 2% des cas -- confirmant que la majorite des puzzles courants se resolvent par inference directe sans recours au backtracking.\n",
+    "\n",
+    "La comparaison avec le backtracking simple a mis en evidence un avantage qualificatif majeur : les strategies humaines produisent une **chaine de deductions explicable**, ou chaque placement est justifie par une technique logique identifiable, tandis que le backtracking procede par essai-erreur opaque. En termes de performance, le solveur humain est 2 a 5 fois plus rapide sur les puzzles faciles et ne necessite aucun appel recursif, la ou le backtracking accumule 49 a 295 appels. Le mecanisme de fallback vers le backtracking garantit toutefois la completude du solveur sur les instances ou les techniques de deduction atteignent leurs limites.\n",
+    "\n",
+    "Le prochain notebook, **Sudoku-9-GraphColoring-Python**, change de paradigme en modelisant le Sudoku comme un probleme de **coloration de graphe** avec NetworkX, ou les 81 cellules deviennent des sommets et les contraintes d'exclusion des aretes, permettant de comparer des heuristiques de coloration (MRV, LCV, Welsh-Powell) sur cette structure reguliere."
+   ],
    "metadata": {}
   },
   {
@@ -2591,7 +2599,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Sudoku-6-AIMA-CSP](Sudoku-6-AIMA-CSP-Python.ipynb) | [Index](README.md) | [Sudoku-9-GraphColoring >>](Sudoku-9-GraphColoring-Python.ipynb)"
+    "**Navigation** : [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Python.ipynb) | [Index](README.md) | [Sudoku-9-GraphColoring >>](Sudoku-9-GraphColoring-Python.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
## Résumé

Audit de fidélité (Epic #3164) du notebook **Sudoku-8-HumanStrategies-Python**. **Markdown uniquement** (code delta = 0, exception C.2). Le corps est FIDELE : les 5 techniques + les 3 « Exemple resolu » avancés (`find_hidden_pairs`/`find_swordfish`/`find_xy_wings`) sont des implémentations complètes authentiques ; les 3 stubs « ## Exercice » sont corrects.

## Corrections

1. **Navigation (PRIMARY)** — en-tête (idx0) + pied (idx51) « Précédent » sautaient le `Sudoku-7-Norvig-Python` existant (6→8) → corrigé vers Sudoku-7 (le jumeau C# pointe aussi vers Sudoku-7).
2. **ERREUR-FACTUELLE benchmark (idx29)** — « 2.96 / 14.81 ms » → committé **2.20 / 10.99 ms** ; « 96 % (240/249) » → **87 % (240/277)** (total stratégies committé = 149+15+91+17+5 = 277).
3. **ERREUR-FACTUELLE comparaison (idx34)** — humain « 0.73-3.84 ms » / BT « 2.12-21.59 ms » → committé **0.57-2.66** / **1.96-17.47 ms** ; « puzzle 3 : 3.84 vs 21.59 » → **2.66 vs 17.47**.
4. **ERREUR-FACTUELLE résumé (idx50)** — Hidden Singles « 60 % des déductions » → **54 %** (149/277).
5. **LABELING (cas 2)** — « ### Exemple guide 1b/2b/3b » (idx38/42/46) au-dessus de **stubs** (« # TODO ... Implementez », sortie « Exercice a completer ») → « ### Exercice 1b/2b/3b ». Les « ### Exemple guide 1/2/3 » (solutions complètes) sont conservés.

No-pendulum : chaque nombre provient des **sorties committées du notebook** ; aucun stub rempli, aucune solution stubée.

## Validation

| Gate | Résultat |
|------|----------|
| scan_cell_ordering | 1 clean, 0 finding |
| check_c2_compliance | 1/1 compliant |
| notebook_tools validate | 0 error / 0 warning |
| git-diff code-lines | 0 (markdown-only) |

Closes #3388
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)