### PR TITLE
docs(sudoku): fidelity audit Sudoku-9-GraphColoring-Python -- nav fix + timing/benchmark align + title (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -14,9 +14,9 @@
     "tags": []
    },
    "source": [
-    "# Sudoku-9-GraphColoring-Python : Coloration de Graphe (Python)\n",
+    "# Sudoku-9 : Coloration de Graphe (Python)\n",
     "\n",
-    "**Navigation** : [<< Human Strategies](Sudoku-8-HumanStrategies-Csharp.ipynb) | [Index](README.md) | [OR-Tools >>](Sudoku-10-ORTools-Python.ipynb)\n",
+    "**Navigation** : [<< Human Strategies](Sudoku-8-HumanStrategies-Python.ipynb) | [Index](README.md) | [OR-Tools >>](Sudoku-10-ORTools-Python.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -27,7 +27,7 @@
     "3. **Utiliser** NetworkX pour manipuler des graphes de contraintes\n",
     "4. **Comparer** l'efficacite de differentes strategies de coloration\n",
     "\n",
-    "**Duree estimee** : ~15 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb)\n",
+    "**Duree estimee** : ~15 min | **Prerequis** : Sudoku-0 Environment\n",
     "\n",
     "---\n",
     "\n",
@@ -631,11 +631,11 @@
    "source": [
     "### Interpretation : Backtracking avec MRV sur Graphe\n",
     "\n",
-    "Le solveur a resolu un puzzle facile en 2.41 ms avec seulement 37 noeuds explores et 0 backtracks.\n",
+    "Le solveur a resolu un puzzle facile en 1.88 ms avec seulement 37 noeuds explores et 0 backtracks.\n",
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| **Temps** | 2.41 ms | Resolution tres rapide |\n",
+    "| **Temps** | 1.88 ms | Resolution tres rapide |\n",
     "| **Noeuds explores** | 37 | MRV reduit l'espace de recherche |\n",
     "| **Backtracks** | 0 | Pas d'erreurs necessaires |\n",
     "\n",
@@ -863,11 +863,11 @@
     "\n",
     "| Type | Temps moyen | Analyse |\n",
     "|------|-------------|---------|\n",
-    "| **Puzzles faciles** | ~4 ms | Performance correcte |\n",
-    "| **Puzzles difficiles** | ~70 ms | Beaucoup plus lent (notez les backtracks) |\n",
+    "| **Puzzles faciles** | ~2.5 ms | Performance correcte |\n",
+    "| **Puzzles difficiles** | ~47 ms | Beaucoup plus lent (notez les backtracks) |\n",
     "\n",
     "**Comparaison avec d'autres approches** :\n",
-    "- **OR-Tools CP-SAT** : ~20 ms pour les difficiles (3.5x plus rapide)\n",
+    "- **OR-Tools CP-SAT** : nettement plus rapide pour les difficiles (voir Sudoku-10)\n",
     "- **Backtracking simple** : Plusieurs secondes pour les difficiles\n",
     "- **NetworkX** : Bon compromis simplicite/performance\n",
     "\n",
@@ -1414,7 +1414,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Human Strategies](Sudoku-8-HumanStrategies-Csharp.ipynb) | [Index](README.md) | [OR-Tools >>](Sudoku-10-ORTools-Python.ipynb)\n"
+    "**Navigation** : [<< Human Strategies](Sudoku-8-HumanStrategies-Python.ipynb) | [Index](README.md) | [OR-Tools >>](Sudoku-10-ORTools-Python.ipynb)\n"
    ]
   }
  ],


### PR DESCRIPTION
## Résumé

Audit de fidélité (Epic #3164) du notebook **Sudoku-9-GraphColoring-Python**. **Markdown uniquement** (code delta = 0, exception C.2). Le corps est FIDELE : `nx.sudoku_graph()` (81/810/degré 20), MRV backtracking, LCV (idx22) et Welsh-Powell (idx25) sont des implémentations complètes ; les 3 stubs « ## Exercice » sont corrects.

## Corrections

1. **Navigation (PRIMARY)** — en-tête (idx0) + pied (idx28) « << Human Strategies » cross-linkés vers le **jumeau C#** → `Sudoku-8-HumanStrategies-Python` (existe) ; prérequis lié à `Sudoku-0-Environment-Csharp` (aucun Sudoku-0 Python) → texte simple « Sudoku-0 Environment ». « OR-Tools >> » pointait déjà vers le Python.
2. **Titre** — filename-style → « # Sudoku-9 : Coloration de Graphe (Python) » (convention frères Sudoku-6/7/8-Python).
3. **ERREUR-FACTUELLE timing (idx13)** — « 2.41 ms » (phrase + table) → committé idx12 **1.88 ms** (nœuds 37 / backtracks 0 déjà corrects).
4. **Benchmark (idx18)** — « ~4 ms » / « ~70 ms » → moyennes committées **2.47 / 46.88 ms** (~2.5 / ~47 ms) ; claim non mesuré « OR-Tools ~20 ms (3.5x) » → référence qualitative (voir Sudoku-10).

No-pendulum : chaque nombre provient des **sorties committées du notebook** ; le claim non mesuré est retiré, pas remplacé par un autre nombre inventé.

## Validation

| Gate | Résultat |
|------|----------|
| scan_cell_ordering | 1 clean, 0 finding |
| check_c2_compliance | 1/1 compliant |
| notebook_tools validate | 0 error / 0 warning |
| git-diff code-lines | 0 (markdown-only) |

Closes #3390
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)