### PR TITLE
docs(genai-audio): drop manual counts from structure tree (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -29,10 +29,10 @@ L'objectif fil rouge de cette série est de construire un podcast entièrement g
 
 ```
 Audio/
-├── 01-Foundation/     # STT, TTS, bases audio (5 notebooks)
-├── 02-Advanced/       # Voice cloning, musique, MIDI, chansons, TTS expressif (9 notebooks)
-├── 03-Orchestration/  # Multi-modèles, temps réel (3 notebooks)
-└── 04-Applications/   # Éducation, production, sync A/V, live coding, audiobook (13 notebooks)
+├── 01-Foundation/     # STT, TTS, bases audio
+├── 02-Advanced/       # Voice cloning, musique, MIDI, chansons, TTS expressif
+├── 03-Orchestration/  # Multi-modèles, temps réel
+└── 04-Applications/   # Éducation, production, sync A/V, live coding, audiobook
 ```
 
 ## Progression par niveau


### PR DESCRIPTION
## Summary

One anti-pattern resolved in one surgical edit on the **Audio README** — the only real finding from a gabarit census (G.1 cross-check, no sonnet delegation needed: I know the 5 anti-patterns after 6 prior cycles on this family). **Markdown-only** (C.2 exception). Follows ai-01 dispatch 02:03Z: \"Continue #2651 rollout famille GenAI/*\".

## Census result (honest)
The Audio README is otherwise **clean**:
- **CATALOG-STATUS block present** (L3-8) and **consistent** — `pedagogical_count: 30` matches exactly the disk count (5+9+3+13=30, verified strict `find -maxdepth 1`). No drift (unlike Image 17-vs-20).
- **3 child-side bridges** (Video, Texte, SemanticKernel) all name concrete artifacts both sides (04-4 notebook, 03-2 pipeline, Texte/2 + Texte/5, 03-1/03-2 patterns) — **richer and distinct** from the parent GenAI README L286 one-liner. No anti-2, no anti-3.
- **FAQ exactly at the 6-question bound** (GPU OOM, Whisper hallucinate, Docker unreachable, FFmpeg, TTS engine diff, audiobook pipeline). No anti-4.
- **Navigation present** at L10. No anti-5.

## Edit (+4/-4)
- **Anti-pattern 1 (gabarit L64/L76)**: structure tree carried manual per-directory counts \"(5 notebooks)\" etc. — duplicating the bot-owned CATALOG-STATUS marker. They were **numerically correct today** (30 == 30), but this is **preventive**: when the next notebook is added, the cron updates only the marker, leaving these inline counts stale. Removed the counts, kept descriptions.

## Validation
- CATALOG-STATUS byte-identical (0 hits in diff).
- check-docs-links + no-catalog-changes covered by CI.
- 1 file, +4/-4.

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)