### PR TITLE
docs(sudoku): SU-12py timing tables aligned to committed Z3 outputs + C# twin nav

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "Ce notebook implemente un solveur de Sudoku utilisant **Microsoft Z3**, un solveur **SMT** (Satisfiability Modulo Theories).\n",
     "\n",
-    "Cette approche est equivalente au notebook C# `Sudoku-13-Z3-Csharp.ipynb`.\n",
+    "Cette approche est equivalente au notebook C# `Sudoku-12-Z3-Csharp.ipynb`.\n",
     "\n",
     "## Installation\n",
     "\n",
@@ -465,11 +465,11 @@
    "source": [
     "### Interpretation : Resultat Z3 Int\n",
     "\n",
-    "Le solveur Z3 avec des entiers a resolu le puzzle difficile en 505.67 ms.\n",
+    "Le solveur Z3 avec des entiers a resolu le puzzle difficile en 340.86 ms.\n",
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| **Temps de resolution** | 505.67 ms | Performance acceptable |\n",
+    "| **Temps de resolution** | 340.86 ms | Performance acceptable |\n",
     "| **Statut** | sat | Solution trouvee |\n",
     "| **Type de variables** | Int | Entiers symboliques |\n",
     "\n",
@@ -733,11 +733,11 @@
     "\n",
     "| Puzzle | Z3 Int | Z3 BitVec | Amelioration |\n",
     "|--------|--------|-----------|--------------|\n",
-    "| Puzzle 1 | 261 ms | 119 ms | **2.2x plus rapide** |\n",
-    "| Puzzle 2 | 473 ms | 71 ms | **6.7x plus rapide** |\n",
-    "| Puzzle 3 | 161 ms | 54 ms | **3.0x plus rapide** |\n",
-    "| Puzzle 4 | 348 ms | 66 ms | **5.3x plus rapide** |\n",
-    "| Puzzle 5 | 96 ms | 62 ms | **1.5x plus rapide** |\n",
+    "| Puzzle 1 | 271.18 ms | 68.65 ms | **4.0x plus rapide** |\n",
+    "| Puzzle 2 | 462.26 ms | 71.84 ms | **6.4x plus rapide** |\n",
+    "| Puzzle 3 | 222.89 ms | 61.95 ms | **3.6x plus rapide** |\n",
+    "| Puzzle 4 | 389.18 ms | 117.54 ms | **3.3x plus rapide** |\n",
+    "| Puzzle 5 | 237.59 ms | 105.18 ms | **2.3x plus rapide** |\n",
     "\n",
     "**Points cles** :\n",
     "1. **BitVectors sont plus proches du hardware** : Z3 peut utiliser des operations bit-level\n",
@@ -1220,7 +1220,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a présenté deux approches Z3 pour modéliser et résoudre le Sudoku : les entiers symboliques (Int) et les vecteurs de bits (BitVec 4 bits). La comparaison montre que les BitVectors sont systématiquement plus rapides (1.5x à 6.7x), car leur domaine restreint (16 valeurs sur 4 bits) permet à Z3 d'utiliser des algorithmes de propagation plus efficaces. La contrainte `Distinct`, disponible nativement pour les entiers mais nécessitant une décomposition par paires pour les BitVectors, illustre le compromis entre simplicité d'API et performance. Au-delà du Sudoku, Z3 est un outil de résolution SMT polyvalent, applicable à la vérification de programmes, l'analyse de sécurité et la synthèse de code. Les exercices proposés (comptage de solutions, contraintes diagonales, coloration de graphe) montrent comment étendre le modèle de base vers des variantes plus riches."
+    "Ce notebook a présenté deux approches Z3 pour modéliser et résoudre le Sudoku : les entiers symboliques (Int) et les vecteurs de bits (BitVec 4 bits). La comparaison montre que les BitVectors sont systématiquement plus rapides (2.3x à 6.4x), car leur domaine restreint (16 valeurs sur 4 bits) permet à Z3 d'utiliser des algorithmes de propagation plus efficaces. La contrainte `Distinct`, disponible nativement pour les entiers mais nécessitant une décomposition par paires pour les BitVectors, illustre le compromis entre simplicité d'API et performance. Au-delà du Sudoku, Z3 est un outil de résolution SMT polyvalent, applicable à la vérification de programmes, l'analyse de sécurité et la synthèse de code. Les exercices proposés (comptage de solutions, contraintes diagonales, coloration de graphe) montrent comment étendre le modèle de base vers des variantes plus riches."
    ]
   }
  ],


### PR DESCRIPTION
## Resume

Audit de fidelite #3164 du notebook `Sudoku-12-Z3-Python.ipynb` (solveur Z3 SMT via `z3-solver`).

Z3 s'execute nativement -> cellules avec **vraies sorties committees**. Corps **FIDELE** (Int=`Distinct`, BitVec=decomposition par paires ; idx21 diagonale = solution complete). Defaut = prose de timing perimee contredisant les sorties.

| Cellule (interprete) | Sortie committee | Corrige |
|---|---|---|
| idx11 (<- idx10) | `340.86 ms` | "505.67 ms" (phrase + table) |
| idx15 (<- idx14) | 271.18/68.65, 462.26/71.84, 222.89/61.95, 389.18/117.54, 237.59/105.18 | table complete + ratios 4.0/6.4/3.6/3.3/2.3x |
| idx24 | suit idx15 | "1.5x a 6.7x" -> "2.3x a 6.4x" |
| idx0 (nav) | C# twin inexistant | `Sudoku-13-Z3-Csharp` -> `Sudoku-12-Z3-Csharp` (slot 13 = Automata) |

## Hors-scope (no-pendulum)
idx11 "sat" (FIDELE), idx0 prereq Sudoku-0-Environment-Csharp (cible existe). **Labeling propre** (idx20 Exemple guide sur solution complete idx21 ; idx13/19/23 Exercice sur stubs).

## Validation
- `scan_cell_ordering` : 1 clean, 0 finding
- `check_c2_compliance` : 1/1 compliant
- `notebook_tools validate` : **OK 1, 0 warnings, 0 errors**
- `git diff | grep -cE code/outputs` = **0** (markdown pur, 10 ins / 10 del, code delta = 0)

Methode : sous-agent `sonnet` evidence-cited + cross-check parent G.1 (re-dump byte-exact ; le sous-agent avait garbled le timing idx11 -> re-lecture corrective). Markdown-only -> pas de re-execution (C.2).

Closes #3400
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)