### PR TITLE
docs(pymc): fidelity #3164 PyMC-11-Sequences -- HMM/Forward-Backward/Viterbi scholarly attribution

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Sequences.ipynb
@@ -198,7 +198,12 @@
     "| NLP | POS tags | Mots |\n",
     "| Finance | Regimes de marche | Rendements |\n",
     "| Bioinformatique | Motifs ADN | Sequences nucleotides |\n",
-    "| Meteo | Soleil/Pluie | Temperature |"
+    "| Meteo | Soleil/Pluie | Temperature |\n",
+    "\n",
+    "### References historiques (HMM)\n",
+    "\n",
+    "- **Baum & Petrie (1966)** -- *Statistical Inference for Probabilistic Functions of Finite State Markov Chains*, Annals of Mathematical Statistics 37(6). Article fondateur des HMM.\n",
+    "- **Rabiner (1989)** -- *A Tutorial on Hidden Markov Models and Selected Applications in Speech Recognition*, Proceedings of the IEEE 77(2). Reference pedagogique standard pour les HMM.\n"
    ]
   },
   {
@@ -482,7 +487,9 @@
     "- **Forward** ($\\alpha$) : $P(z_t, x_{1:t})$ — probabilite de l'etat et des observations passees\n",
     "- **Backward** ($\\beta$) : $P(x_{t+1:T} | z_t)$ — probabilite des observations futures\n",
     "\n",
-    "$$P(z_t = k | x_{1:T}) \\propto \\alpha_t(k) \\cdot \\beta_t(k)$$"
+    "$$P(z_t = k | x_{1:T}) \\propto \\alpha_t(k) \\cdot \\beta_t(k)$$\n",
+    "\n",
+    "> L'algorithme Forward-Backward a ete formalise par **Baum, Petrie, Soules & Weiss (1970)** (*A Maximization Technique Occurring in the Statistical Analysis of Probabilistic Functions of Markov Chains*, Annals of Mathematical Statistics 41(1)). Il est un cas special du cadre EM general de **Dempster, Laird & Rubin (1977)** (*Maximum Likelihood from Incomplete Data via the EM Algorithm*, JRSS B 39(1)).\n"
    ]
   },
   {
@@ -1436,6 +1443,8 @@
     "\n",
     "**Objectif** : implementer l'algorithme de Viterbi par programmation dynamique.\n",
     "\n",
+    "> D'apres **Viterbi (1967)**, *Error Bounds for Convolutional Codes and an Asymptotically Optimum Decoding Algorithm*, IEEE Transactions on Information Theory 13(2).\n",
+    "\n",
     "**Indices** :\n",
     "- Initialisation : `delta[0, k] = log(pi[k]) + log(B[0, k])`\n",
     "- Recursion : `delta[t, k] = max_j(delta[t-1, j] + log(A[j,k])) + log(B[t, k])`\n",
@@ -1636,7 +1645,15 @@
     "\n",
     "**Navigation** : [PyMC-10](PyMC-10-Crowdsourcing.ipynb) | **PyMC-11** | [PyMC-12](PyMC-12-Recommenders.ipynb) | [Infer.NET original](../Infer/Infer-11-Sequences.ipynb)\n",
     "\n",
-    "**Prochaine etape** : [PyMC-12 — Systemes de Recommandation](PyMC-12-Recommenders.ipynb)"
+    "**Prochaine etape** : [PyMC-12 — Systemes de Recommandation](PyMC-12-Recommenders.ipynb)\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Baum, L. E., & Petrie, T. (1966). *Statistical Inference for Probabilistic Functions of Finite State Markov Chains.* Annals of Mathematical Statistics 37(6).\n",
+    "- Baum, L. E., Petrie, T., Soules, G., & Weiss, N. (1970). *A Maximization Technique Occurring in the Statistical Analysis of Probabilistic Functions of Markov Chains.* Annals of Mathematical Statistics 41(1).\n",
+    "- Dempster, A. P., Laird, N. M., & Rubin, D. B. (1977). *Maximum Likelihood from Incomplete Data via the EM Algorithm.* JRSS B 39(1).\n",
+    "- Viterbi, A. J. (1967). *Error Bounds for Convolutional Codes and an Asymptotically Optimum Decoding Algorithm.* IEEE Trans. Information Theory 13(2).\n",
+    "- Rabiner, L. R. (1989). *A Tutorial on Hidden Markov Models and Selected Applications in Speech Recognition.* Proceedings of the IEEE 77(2).\n"
    ]
   }
  ],


### PR DESCRIPTION
## Contexte

Audit fidélité #3164 (famille Probas/PyMC). Suite des corrections d'OMISSION scholarly sur la série PyMC (déjà mergées : PyMC-6 #3289, PyMC-3 #3336, PyMC-10 #3345, PyMC-12 #3355, PyMC-5 #3371, PyMC-8 #3386).

## Verdict : OMISSION (HIGH confidence)

`PyMC-11-Sequences.ipynb` présente correctement les **HMM**, l'algorithme **Forward-Backward** (implémenté à la main cell `a75fe048`, récursions α/β correctes), **Baum-Welch/EM** (nommé), et **Viterbi** (exercice TODO `# Exercice a completer`). **0 REINVENTION, 0 erreur**.

**Point pédagogique notable (FIDÈLE)** : le modèle PyMC (cell `9cf446da`) est **intentionnellement NON échantillonné** (`pm.sample` absent, vérifié grep). Le notebook explique correctement le piège : les variables discrètes latentes des HMM sont difficiles à échantillonner avec MCMC (le Gibbs sampling peut rester bloqué), d'où le recours au Forward-Backward exact. C'est l'inverse de l'erreur discrete-sampled-by-NUTS (qui avait affecté PyMC-3/10) — ici le notebook fait le bon choix et l'explique.

Mais le notebook **cite aucune source scholarly**. Grep cross-check G.1 : **0× pour Petrie, Rabiner, Dempster, Laird, Rubin, doi, 1966, 1970, 1977, 1989**. `Viterbi`=9× mais uniquement comme nom d'algorithme (jamais l'auteur cité) ; `Baum`=1× dans "Baum-Welch" nommé sans attribution. Même classe d'OMISSION récurrente (c).

## Corrections (markdown-only, 4 cells, +21/-4)

| Cell | Contenu |
|------|---------|
| idx4 (`6d7d56dc`) HMM intro | Références fondatrices **Baum & Petrie (1966)** Annals Math. Stat. 37(6) + **Rabiner (1989)** tutorial Proc. IEEE 77(2) |
| idx11 (`b097fa6d`) Forward-Backward intro | Source **Baum, Petrie, Soules & Weiss (1970)** Annals Math. Stat. 41(1) + cas spécial EM **Dempster, Laird & Rubin (1977)** JRSS B 39(1) |
| idx33 (`84e2748e`) Viterbi exercice | Source **Viterbi (1967)** IEEE Trans. Info. Theory 13(2) |
| idx38 (`4d7cd001`) Conclusion | Bloc References (5 citations) |

## Validation

- nbformat VALID
- C.1 clean (0 `raise NotImplementedError` / `assert False` / `1/0`)
- cell-order gate #3245 clean
- **0 ligne `execution_count`/`outputs` ajoutée** (C.3 — markdown-only, exception C.2 re-exécution)
- base fraîche `origin/main`, catalogue byte-identique

## Note scope (G.5)

La citation `pomegranate` (Schreiber) n'a pas été ajoutée : sa référence exacte (JMLR 2018 vol. 18) n'est pas vérifiable depuis le repo et le sous-agent l'avait lui-même flaggée comme blind spot. `hmmlearn`/`pomegranate` restent nommés comme recommandation pratique (idx22) sans sur-citation non vérifiée.

`See #3164`

Co-Authored-By: Claude <noreply@anthropic.com>
