### PR TITLE
fix(qc-py-05): delete false backtest blocks verified against QC Cloud (See #3366)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
@@ -205,11 +205,6 @@
   },
   {
    "cell_type": "markdown",
-   "source": "> **Resultats backtest QC Cloud** : FAANGManualUniverse (2015-2024, $100k) — 9 ordres, Net Profit +38.7%, Sharpe 0.387, CAGR 8.8%, MaxDD 33.6%. Equal-weight FAANG sans rebalancement.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Avantages et limites du Manual Universe\n",
@@ -275,11 +270,6 @@
    "source": [
     "---\n**Backtest QC Cloud** : `MultiAssetManualUniverse`\n\n| Resultat | End Equity |\n|----------|------------|\n| Exploration (0 ordre) | $100,000.00 |\n\n*Multi-asset exploration, no trading*\n---"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "source": "> **Resultats backtest QC Cloud** : MultiAssetManualUniverse (2015-2024, $100k) — 1 ordre, Net Profit +118.0%, Sharpe 0.493, CAGR 11.8%, MaxDD 33.5%. Multi-asset (AAPL, MSFT, SPY, QQQ, TLT) sans rebalancement.",
-   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -1033,13 +1023,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n**Backtest QC Cloud** : `DynamicRebalancingAlgorithm`\n\n| Sharpe | CAGR | MaxDD | Net Profit | Orders | End Equity |\n|--------|------|-------|------------|--------|------------|\n| 0.2 | 6.610% | 48.800% | +37.769% | 1292 | $137,768.70 |\n\n*Dynamic rebalancing on universe change, 2020-2024*\n---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : DynamicRebalancingAlgorithm (2015-2024, $100k) — 2461 ordres, Net Profit +179.7%, Sharpe 0.406, CAGR 10.8%, MaxDD 38.7%, Win Rate 72%. Top 20 mensuel, equal-weight via OnSecuritiesChanged.",
    "metadata": {}
   },
@@ -1139,13 +1122,6 @@
     "            if abs(current_weight - target_weight) > self.tolerance:\n",
     "                self.SetHoldings(symbol, target_weight)\n",
     "                self.Debug(f\"Rebalanced {symbol.Value}: {current_weight:.1%} -> {target_weight:.1%}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n**Backtest QC Cloud** : `SmartRebalancingAlgorithm`\n\n| Sharpe | CAGR | MaxDD | Net Profit | Orders | End Equity |\n|--------|------|-------|------------|--------|------------|\n| 0.207 | 6.393% | 28.500% | +36.371% | 51 | $136,370.80 |\n\n*Tolerance-based rebalancing (5% threshold), 2020-2024*\n---"
    ]
   },
   {
@@ -1285,13 +1261,6 @@
     "            self.Log(f\"Added: {[s.Symbol.Value for s in changes.AddedSecurities]}\")\n",
     "        if len(changes.RemovedSecurities) > 0:\n",
     "            self.Log(f\"Removed: {[s.Symbol.Value for s in changes.RemovedSecurities]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n**Backtest QC Cloud** : `ScheduledRebalancingAlgorithm`\n\n| Sharpe | CAGR | MaxDD | Net Profit | Orders | End Equity |\n|--------|------|-------|------------|--------|------------|\n| 0.252 | 8.253% | 45.400% | +48.725% | 1098 | $148,725.36 |\n\n*Scheduled monthly rebalancing, 2020-2024*\n---"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixes the double-contradictory-backtest-blocks bug in **QC-Py-05** (#3366, **partial** — NB05 only, 5 algos).

QC-Py-05 contained, for each of 5 algorithms, TWO backtest result blocks that contradicted each other (compact table "Bloc A" + prose summary "Bloc B") for the same algo. Only one can be the real backtest for a given (algo, period, capital). Verified each against **QC Cloud re-runs** (5 backtests, projects created 2026-05-22, rate-limit announced on dashboard beforehand).

## Verification table (G.1 — each algo verified against QC Cloud)

| Algo | QC Cloud real (Sharpe/CAGR/MaxDD) | TRUE block | FALSE block deleted |
|------|-----------------------------------|------------|---------------------|
| FAANGManualUniverse | 0.84 / 27.5% / 50.7% | Bloc A (cell 6) | Bloc B +38.7%/0.387 |
| MultiAssetManualUniverse | 0 / 0% / 0% (0 trades) | Bloc A (cell 9) | Bloc B +118%/0.493 |
| DynamicRebalancingAlgorithm | 0.406 / 10.8% / 38.7% | Bloc B (cell 37) | Bloc A 2020-2024 +37.8%/0.2 |
| SmartRebalancingAlgorithm | 0.476 / 9.5% / 29.2% | Bloc B (cell 40) | Bloc A 2020-2024 +36.4%/0.207 |
| ScheduledRebalancingAlgorithm | 0.424 / 11.1% / 34.6% | Bloc B (cell 45) | Bloc A 2020-2024 +48.7%/0.252 |

## Key finding (G.1)

The pattern is **mixed** (2 Bloc A true, 3 Bloc B true), confirming #3366's warning that **each algo needs per-algo QC Cloud verification** — no blind "delete all Bloc B" fix was possible. Guiding principle: keep the block matching the algo's in-notebook `SetStartDate`/`SetEndDate` config (the code's intended period), which the QC Cloud re-run confirms.

For 3 of 5 algos (Dynamic/Smart/Scheduled), the FALSE block was a stale run with a **different period** (2020-2024 vs the algo code's 2015-2024) — categorized in #3366 as "misleading but not contradictory". For FAANG/MultiAsset, the FALSE block fabricated metrics for the same period.

## Changes (1 notebook, +1/-32, markdown-only)

- 5 false backtest blocks deleted (58→53 cells)
- Each deletion G.1-verified with content assertion before delete
- 0 code cells touched (all `[REFERENCE QC]` non-executable cells, exec_count=None) → C.2 markdown-only exception
- nbformat VALID, no exec-churn (C.3)

## Scope boundary (honesty G.2)

This PR fixes **NB05 only** (5 algos). NB02/06/08 (9 more algos) remain open in #3366 for follow-up cycles using the same verified method (per-algo QC Cloud backtest, rate-limit announced). Rate-limit discipline: 10/min cluster-wide.

## Validation

- QC Cloud: 5 backtests Completed (Sharpe/CAGR/MaxDD reported above, match the kept block for each algo)
- nbformat VALID, 0 code cells modified, no exec_count/outputs churned
- catalog byte-identical, base fresh from main, atomic (1 notebook)

`See #3366`
`See #3164`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
