### PR TITLE
docs(pymc): fidelity #3164 PyMC-2-Gaussian-Mixtures -- GMM/label-switching scholarly attribution

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
@@ -696,7 +696,11 @@
     "|---------|-----------|------|\n",
     "| Variable de melange | `Variable.Switch(idx, components)` | `pm.Mixture` ou `pm.NormalMixture` |\n",
     "| Poids du melange | `Variable.Discrete(probs)` | `pm.Categorical` (interne a Mixture) |\n",
-    "| Composantes | Array de Gaussiennes | Liste de distributions |"
+    "| Composantes | Array de Gaussiennes | Liste de distributions |\n",
+    "\n",
+    "### Origine du modele\n",
+    "\n",
+    "Les melanges de gaussiennes sont etudies depuis Pearson (1894) ; le traitement moderne de reference est **McLachlan & Peel (2000)**, *Finite Mixture Models* (Wiley), et **Titterington, Smith & Makov (1985)**, *Statistical Analysis of Finite Mixture Distributions* (Wiley). L'algorithme classique d'estimation par maximum de vraisemblance est **EM** (Dempster, Laird & Rubin, 1977) ; ici, a la place d'EM, nous inferons le modele en Bayesien via MCMC (`pm.sample`), ce qui fournit des intervalles de credibilite sur les poids et les parametres de chaque composante.\n"
    ]
   },
   {
@@ -856,7 +860,9 @@
     "- La composante \"exceptionnelle\" capture les trajets de 28 a 35 minutes\n",
     "- Les 3 observations extremes (28, 32, 35 min) correspondent bien aux evenements extraordinaires\n",
     "\n",
-    "La cellule suivante extrait les moyennes, ecarts-types et poids posterior de chaque composante, identifie les composantes par ordre de moyenne, et visualise le melange ajuste sur l'histogramme des donnees."
+    "La cellule suivante extrait les moyennes, ecarts-types et poids posterior de chaque composante, identifie les composantes par ordre de moyenne, et visualise le melange ajuste sur l'histogramme des donnees.\n",
+    "\n",
+    "Ce phenomene de permutation des etiquettes (*label switching*) est inherent a l'identifiabilite des melanges (**Redner & Walker, 1984** ; **Stephens, 2000**).\n"
    ]
   },
   {
@@ -1186,7 +1192,15 @@
     "\n",
     "---\n",
     "\n",
-    "**Retour au sommaire** : [Index Probas](../README.md)"
+    "**Retour au sommaire** : [Index Probas](../README.md)\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Dempster, A. P., Laird, N. M., & Rubin, D. B. (1977). *Maximum Likelihood from Incomplete Data via the EM Algorithm.* JRSS B 39(1). doi:10.1111/j.2517-6161.1977.tb01600.x\n",
+    "- Titterington, D. M., Smith, A. F. M., & Makov, U. E. (1985). *Statistical Analysis of Finite Mixture Distributions.* Wiley.\n",
+    "- McLachlan, G. J., & Peel, D. (2000). *Finite Mixture Models.* Wiley.\n",
+    "- Redner, R. A., & Walker, H. F. (1984). *Mixture densities, maximum likelihood and the EM algorithm.* SIAM Review 26(2).\n",
+    "- Stephens, M. (2000). *Dealing with label switching in mixture models.* JRSS B 62(4).\n"
    ]
   }
  ],


### PR DESCRIPTION
## Contexte

Audit fidélité #3164 (famille Probas/PyMC). Suite des corrections d'OMISSION scholarly sur la série PyMC (déjà mergées : PyMC-6 #3289, PyMC-3 #3336, PyMC-10 #3345, PyMC-12 #3355, PyMC-5 #3371, PyMC-8 #3386, PyMC-11 #3402 pending).

## Verdict : OMISSION (HIGH confidence)

`PyMC-2-Gaussian-Mixtures.ipynb` implémente **réellement** un GMM bayésien : modèle manuel à latent discret (cell `791be0b9`, `pm.Categorical` + index), version marginalisée via `pm.NormalMixture` (cell `bcea493b`), prior Dirichlet sur les poids, et `pm.sample` réel (4×). **0 REINVENTION, 0 erreur**.

**Point FIDÈLE notable** : le notebook gère **correctement** le latent discret — `BinaryGibbsMetropolis` pour K=2 (algorithme hybride NUTS+Gibbs, cell `61bdfe5c`). C'est l'**inverse** de l'erreur discrete-sampled-by-NUTS (qui avait affecté PyMC-3/10). Discussion honnête des 271 divergences + label-switching comme pathologie réelle d'identifiabilité.

Mais le notebook **cite aucune source scholarly**. Grep cross-check G.1 : **0× pour Dempster, Laird, Rubin, McLachlan, Peel, Titterington, Bishop, Ferguson, Redner, Stephens, doi, 1977, 2000, 2006**. `\bEM\b` word-boundary = 0× (le notebook n'utilise pas EM, il fait du MCMC bayésien — le contraste est rendu explicite dans la correction). Même classe d'OMISSION récurrente (c).

## Corrections (markdown-only, 3 cells, +17/-3)

| Cell | Contenu |
|------|---------|
| idx13 (`59fe8f27`) GMM intro | Attribution Pearson (1894) + **McLachlan & Peel (2000)** *Finite Mixture Models* + **Titterington/Smith/Makov (1985)** + contraste honnête **EM** (Dempster/Laird/Rubin 1977) vs MCMC bayésien utilisé ici |
| idx15 (`61bdfe5c`) interprétation GMM | Source label-switching **Redner & Walker (1984)** SIAM Review + **Stephens (2000)** JRSS B |
| idx22 (`7205e762`) Conclusion | Bloc References (5 citations doi) |

## Validation

- nbformat VALID
- C.1 clean (0 `raise NotImplementedError` / `assert False` / `1/0`)
- cell-order gate #3245 clean
- **0 ligne `execution_count`/`outputs` ajoutée** (C.3 — markdown-only, exception C.2 re-exécution)
- base fraîche `origin/main`, catalogue byte-identique

## Scope note (G.5)

La citation NUTS/Hoffman&Gelman (2014) n'a pas été ajoutée : c'est un nom d'échantillonneur (déjà mentionné en passant dans la narrative), pas une méthode conceptuelle portante. Le diff reste focalisé sur les méthodes GMM/label-switching.

`See #3164`

Co-Authored-By: Claude <noreply@anthropic.com>
