### PR TITLE
fix(qc-py-08): delete false backtest blocks verified against QC Cloud (See #3366)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
@@ -855,13 +855,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n**Resultats du backtest QC Cloud (RegimeDetectionAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 5 |\n| Sharpe Ratio | -0.091 |\n| CAGR | 5.066% |\n| Max Drawdown | 6.300% |\n| Net Profit | 1.221% |\n| Equity finale | $101,220.97 |\n\n*Regime detection (correlation-based) with adaptive allocation (SPY/TLT/GLD), Q1 2023*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "qc_backtest": true,
     "qc_cell_ref": 22
@@ -1043,13 +1036,6 @@
     "print(\"EqualWeightPortfolioAlgorithm defini\")\n",
     "print(f\"\\nAllocation: {100/6:.2f}% par actif\")\n",
     "print(\"Rebalancement: Trimestriel (Janvier, Avril, Juillet, Octobre)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n**Resultats du backtest QC Cloud (EqualWeightPortfolioAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 0 |\n| Sharpe Ratio | 0 |\n| CAGR | 0% |\n| Max Drawdown | 0% |\n| Net Profit | 0% |\n| Equity finale | $100,000.00 |\n\n*Equal weight portfolio (SPY/QQQ/TLT/IEF/GLD/USO), quarterly rebalance, Q1 2023*"
    ]
   },
   {
@@ -1345,13 +1331,6 @@
     "            self.Debug(f\"  {symbol.Value}: {weight:.2%}\")\n",
     "\n",
     "print(\"RiskParityAlgorithm defini\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n**Resultats du backtest QC Cloud (RiskParityAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 8 |\n| Sharpe Ratio | 0.114 |\n| CAGR | 7.633% |\n| Max Drawdown | 5.300% |\n| Net Profit | 1.823% |\n| Equity finale | $101,822.62 |\n\n*Risk parity (inverse vol weighting) with SPY/QQQ/TLT/IEF/GLD, monthly rebalance, Q1 2023*"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixes the double-contradictory-backtest-blocks bug in **QC-Py-08** (#3366, **partial** — NB08, 3 algos). Continues the per-algo QC Cloud verification method established in #3403 (NB05).

QC-Py-08 contained, for each of 3 algorithms, TWO backtest result blocks: a compact table "Bloc A" (a short Q1-2023 backtest, 62 tradeable dates) and a prose summary "Bloc B" (the full multi-year run). Verified each against **QC Cloud re-runs** (3 backtests, rate-limit announced).

## Verification table (G.1 — each algo verified against QC Cloud)

| Algo | QC Cloud real (Sharpe/CAGR/MaxDD/dates) | TRUE block | FALSE block deleted |
|------|-----------------------------------------|------------|---------------------|
| RegimeDetectionAlgorithm | 0.353 / 7.8% / 25.2% / 2881d | Bloc B (cell 27) | Bloc A Sharpe **-0.091**, 62d (Q1 2023) |
| EqualWeightPortfolioAlgorithm | 0.345 / 7.0% / 19.4% / 2516d | Bloc B (cell 35) | Bloc A 0 trades / $100k, 62d |
| RiskParityAlgorithm | 0.289 / 5.5% / 22.2% / 2516d | Bloc B (cell 41) | Bloc A Sharpe 0.114, 62d |

## Key finding (G.1)

NB08 pattern is **UNIFORM** (unlike NB05's mixed pattern in #3403): **Bloc A is FALSE for all 3** (short Q1-2023 backtests, 62 tradeable dates), **Bloc B is TRUE for all 3** (full multi-year runs matching the algo code's `SetStartDate(2015)` with full/default end dates). The RegimeDetection Sharpe **sign flip** (-0.091 vs +0.347) flagged in #3366 is resolved: the negative value was the short Q1-2023 run (Bloc A), the real full-period value is +0.353 (Bloc B, matching QC Cloud).

## Changes (1 notebook, +1/-22, markdown-only)

- 3 false Bloc A table blocks deleted (75→72 cells)
- Each deletion G.1-verified with content assertion before delete
- 0 code cells touched (all `[REFERENCE QC]` non-executable, exec_count=None) → C.2 markdown-only exception
- nbformat VALID, no exec-churn (C.3)

## Scope boundary (honesty G.2)

This PR fixes **NB08** (3 algos). Combined with **#3403 (NB05, 5 algos)**, this brings #3366 to **8/14 algos fixed**. Remaining: NB02 (4 algos) + NB06 (3 algos) = 6 algos in follow-up cycles. Same method (per-algo QC Cloud backtest, rate-limit ≤10/min).

## Validation

- QC Cloud: 3 backtests Completed (Sharpe/CAGR/MaxDD/tradeableDates reported above, match kept Bloc B for each algo)
- nbformat VALID, 0 code cells modified, no exec_count/outputs churned
- catalog byte-identical, base fresh from main, atomic (1 notebook)

`See #3366`
`See #3164`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
