### PR TITLE
fix(qc-py-06): delete false backtest blocks verified against QC Cloud (#3366)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -841,13 +841,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n**Resultats du backtest QC Cloud (CoveredCallStrategy)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 7 |\n| Sharpe Ratio | 0.061 |\n| CAGR | 7.011% |\n| Max Drawdown | 6.100% |\n| Net Profit | +1.684% |\n| Equity finale | $50,842.00 |\n\n*Covered Call SPY delta 0.30, Q1 2023*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Exercice 1 : Selection de Contrats par Greeks\n",
     "\n",
     "Dans cet exercice, vous allez implementer une fonction de selection de contrats d’options basee sur des criteres de Greeks. Cette competence est essentielle pour construire des strategies d’options reelles.\n",
@@ -1078,13 +1071,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n**Resultats du backtest QC Cloud (ProtectivePutStrategy)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 7 |\n| Sharpe Ratio | 1.948 |\n| CAGR | 23.093% |\n| Max Drawdown | 2.200% |\n| Net Profit | +5.254% |\n| Equity finale | $63,152.50 |\n\n*Protective Put ATM, Q1 2023*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : ProtectivePutStrategy (2023 H1, $60k) — 13 ordres, Net Profit +8.1%, Sharpe 1.362, CAGR 17.0%, MaxDD 2.2%, Win Rate 33%. Excelle protection : MaxDD tres faible (2.2%) grace au put de couverture. Sharpe eleve car volatilite reduite. Le cout du put limite le gain mais protege efficacement.",
    "metadata": {}
   },
@@ -1214,13 +1200,6 @@
     "        self.MarketOrder(short_call.Symbol, -1) # Vendre 1 call\n",
     "        \n",
     "        self.spread_opened = True"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n**Resultats du backtest QC Cloud (BullCallSpreadStrategy)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 4 |\n| Sharpe Ratio | -1.848 |\n| CAGR | 1.510% |\n| Max Drawdown | 0.700% |\n| Net Profit | +0.370% |\n| Equity finale | $10,037.00 |\n\n*Bull Call Spread ATM/OTM, Q1 2023*"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixes the double-contradictory-backtest-blocks bug in **QC-Py-06** (#3366, **partial** — NB06, 3 options strategies). Continues the per-algo QC Cloud verification method established in #3403 (NB05) and #3406 (NB08).

QC-Py-06 contained, for each of 3 options strategies, TWO backtest result blocks: a compact table "Bloc A" (a short Q1-2023 backtest, 62 tradeable dates) and a prose summary "Bloc B" (the full-period run). Verified each against **QC Cloud backtests** from the 2026-05-22 audit (3 backtests, all Completed).

## Verification table (G.1 — each strategy verified against QC Cloud)

| Strategy | QC Cloud real (Sharpe/CAGR/MaxDD/dates) | TRUE block | FALSE block deleted |
|----------|-----------------------------------------|------------|---------------------|
| CoveredCallStrategy | 0.608 / 13.016% / 6.1% / 250d | Bloc B (cell 28) | Bloc A Sharpe **0.061**, 62d (Q1 2023) |
| ProtectivePutStrategy | 1.362 / 16.968% / 2.2% / 124d | Bloc B (cell 33) | Bloc A Sharpe **1.948**, 62d (Q1 2023) |
| BullCallSpreadStrategy | -3.2 / 0.748% / 0.7% / 124d | Bloc B (cell 36) | Bloc A Sharpe **-1.848**, 62d (Q1 2023) |

## Key finding (G.1)

NB06 pattern is **UNIFORM** (same as NB08 in #3406, unlike NB05's mixed pattern in #3403): **Bloc A is FALSE for all 3** (short Q1-2023 backtests, 62 tradeable dates), **Bloc B is TRUE for all 3** (full-period runs matching the algo code's `SetStartDate`/`SetEndDate` config). CoveredCall runs full 2023 (250 tradeable dates); ProtectivePut and BullCallSpread run H1 2023 (124 tradeable dates).

**G.1 lesson (anti-intuition)**: for ProtectivePut, the FALSE Bloc A claimed Sharpe **1.948** — *higher* than the real Bloc B Sharpe 1.362. Intuition alone ("keep the better/longer block") would have erred. QC Cloud verification was essential: the real H1-2023 run is Sharpe 1.362 / 124d, the 62d Q1-2023 run (Bloc A) is the false truncated one. This reinforces #3366's warning that each algo must be verified individually — no blind fix.

## Changes (1 notebook, +1/-22, markdown-only)

- 3 false Bloc A table blocks deleted (57→54 cells)
- Each deletion G.1-verified with content assertion before delete
- 0 code cells touched (all `[REFERENCE QC]` non-executable, exec_count=None) → C.2 markdown-only exception
- nbformat VALID, no exec-churn (C.3)

## Scope boundary (honesty G.2)

This PR fixes **NB06** (3 strategies). Combined with **#3403 (NB05, 5 algos)** and **#3406 (NB08, 3 algos)**, this brings #3366 to **11/14 algos fixed**. Remaining: NB02 (4 algos: BasicLifecycleAlgorithm, MultiAssetAlgorithm, RSIMeanReversion, TradingMethodsExample) in a follow-up cycle. Same method (per-algo QC Cloud backtest).

## Validation

- QC Cloud: 3 backtests Completed (projects 32001837/32001838/32001839, backtests from 2026-05-22 audit; Sharpe/CAGR/MaxDD/tradeableDates reported above, match kept Bloc B for each strategy)
- nbformat VALID, 0 code cells modified, no exec_count/outputs churned
- catalog byte-identical, base fresh from main, atomic (1 notebook)

`See #3366`
`See #3164`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
