### PR TITLE
docs(sc-20): relabel '6b. Exercice' as 'Exemple guide (avance)' above complete GracePeriodEscrow solution

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
@@ -2188,26 +2188,7 @@
     },
     "tags": []
    },
-   "source": [
-    "---\n",
-    "\n",
-    "## 6b. Exercice : Escrow avec penalite et delai de grace\n",
-    "\n",
-    "Etendez le systeme d'escrow precedent avec des mecanismes de protection avances.\n",
-    "\n",
-    "### Scenario\n",
-    "\n",
-    "Dans un escrow de commerce electronique, on souhaite ajouter :\n",
-    "- **Penalite** : si Bob tente de depenser via timeout mais echoue (mauvaise signature), l'escrow est bloque\n",
-    "- **Delai de grace** : apres le timeout, Bob a une fenetre de 200 blocs pour recuperer les fonds. Apres cette fenetre, Alice peut recuperer ses fonds\n",
-    "\n",
-    "### Instructions\n",
-    "\n",
-    "1. Completez la classe `GracePeriodEscrow`\n",
-    "2. Implementez `spend_grace_timeout()` pour Bob (timeout + delai de grace)\n",
-    "3. Implementez `spend_expired()` pour Alice (apres expiration du delai de grace)\n",
-    "4. Testez les scenarios de votre choix"
-   ]
+   "source": "---\n\n## 6b. Exemple guide (avance) : Escrow avec penalite et delai de grace\n\nCet exemple pousse plus loin le systeme d'escrow de la section 6 en lui ajoutant des mecanismes de protection avances : un **delai de grace** qui encadre la recuperation des fonds apres le timeout.\n\n### Scenario\n\nDans un escrow de commerce electronique, on souhaite encadrer la recuperation apres timeout :\n- **Delai de grace** : apres le `timeout_blocks`, Bob dispose d'une fenetre de `grace_period` blocs (200 par defaut) pour recuperer les fonds via sa signature\n- **Expiration** : une fois cette fenetre ecoulee, Alice peut recuperer ses fonds, Bob n'a plus acces\n\n### Implementation\n\nLa classe `GracePeriodEscrow` (cellule suivante) etend `TimelockEscrow` avec deux methodes de depense distinctes :\n- `spend_grace_timeout(sig_bob, current_block)` : Bob recupere les fonds dans la fenetre `[timeout_blocks, timeout_blocks + grace_period[`\n- `spend_expired(sig_alice, current_block)` : Alice recupere les fonds apres expiration du delai de grace\n\nChaque methode verifie l'etat de l'escrow, la position de `current_block` par rapport aux seuils, puis la signature du reclamant. Les quatre scenarios de test (recuperation dans le delai, recuperation apres expiration, rejet hors fenetre, rejet avant timeout) valident le comportement attendu.\n\n> Cet exemple guide est la suite naturelle du worked-example `TimelockEscrow` de la section 6 : il montre comment composer timelock et fenetre de recuperation pour realiser un escrow de commerce electronique realiste. Les trois exercices a completer (sections 1b, 2b, 4b) restent independants."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Closes #3404
See #3164

## Problem

In `SC-20-Bitcoin-Scripting.ipynb`, the markdown header `## 6b. Exercice : Escrow avec penalite et delai de grace` (cell `e1647c4c`, idx37) sat directly above a **complete, tested solution** -- the `GracePeriodEscrow` class (cell `a25dbe6e`, idx38, `execution_count: 14`) with all methods implemented and 4 passing scenarios (`=> Les 4 scenarios fonctionnent correctement`).

By content (`.claude/rules/exercise-example-labeling.md` -- "cellule code = solution complete => EXEMPLE"), this is an **Exemple**, not an **Exercice**. A student reading "6b. Exercice -- Completez la classe / Implementez spend_grace_timeout..." found the full solution just below. This is the structural twin of #3349 (SC-9), without the topic mismatch.

## Fix -- Option B (markdown-only relabel, issue recommendation)

Per the issue's recommendation (Option B, rule-defensible, no pendulum), relabel the header and rewrite the imperative instructions into descriptive prose:

- Header: `## 6b. Exercice : ...` -> `## 6b. Exemple guide (avance) : ...`
- Body: imperative "Instructions" ("1. Completez... 2. Implementez...") -> descriptive prose of what the worked-example demonstrates (grace window `[timeout_blocks, timeout_blocks + grace_period[`, expiration path for Alice, the two `spend_*` methods, the 4 test scenarios).
- Style aligned with the sibling worked-example in section 6 (`TimelockEscrow`, cell `exercise-intro`).

**Code and outputs are byte-identical** -- zero re-exec (C.2 markdown-only exception). The tested worked-example is preserved (anti-regression: do not strip a working demonstrated solution).

## Why Option B over Option A (stub)

Option A (stub the solution to honor the "Exercice" intent) would strip a tested, working demonstrated solution -- an anti-regression concern. Option B keeps the worked-example intact and simply makes the label honest. The 3 exercise stubs (sections 1b/2b/4b) already give students hands-on practice, so #2161 (>=3 exercises) holds independently.

## Validation

- nbformat VALID (42 cells)
- `count_exercises.py --threshold 3`: **3 exercises, conforming: True** (stubs `trace_utxo_flow` / `build_hashlock_script` / `build_inheritance_script` preserved at sections 1b/2b/4b)
- cell-order gate #3240: **clean, 0 finding**
- Code cell idx38 (`GracePeriodEscrow`) **byte-identical** (only markdown idx37 changed: `git diff` shows 0 source-line change on the code cell)
- Catalog byte-identical to `main`, base fresh from `origin/main` (`f3614ad37`), 0 behind / 1 ahead
- Markdown-only diff: 1 insertion / 20 deletions (condensed prose replaces verbose imperative block)

## Acceptance (#3404)

- [x] Title/content of idx37 and code idx38 are coherent: Exemple correctly labeled (B)
- [x] Catalog + submodule MGS byte-identical to main; no re-exec needed (markdown-only)
- [x] >=3 exercise stubs preserved (1b/2b/4b)
- [x] PR atomic markdown-only, `Closes #3404`, `See #3164`

🤖 Generated with [Claude Code](https://claude.com/claude-code)