### PR TITLE
docs(genai-playwright): add missing CATALOG-STATUS marker (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/README.md
@@ -1,5 +1,13 @@
 # Playwright-OWUI - Tests E2E pedagogiques pour Open WebUI
 
+<!-- CATALOG-STATUS
+series: GenAI-Playwright-OWUI
+format: TypeScript (.spec.ts) -- serie non-notebook, non decomptee par le bot catalogue (.ipynb only)
+module_count: 5
+test_count: 34
+maturity: PRODUCTION=5
+-->
+
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Vibe-Coding](../Vibe-Coding/README.md)
 
 Serie pedagogique complete pour apprendre **Playwright** (framework de tests E2E) en testant une application reelle : **Open WebUI**, une plateforme de chat IA generative.


### PR DESCRIPTION
## Summary

Adds the missing `<!-- CATALOG-STATUS -->` marker to the **Playwright-OWUI README** — the only GenAI sub-series with a README but no marker (verified across all 13 `GenAI/*/README.md`). Follows ai-01 dispatch 07:15Z deep-queue: \"po-2023:CoursIA : Playwright README (14.2 KB descend-by-size)\".

## Root cause (G.1 verified)
`generate_catalog.py` `scan_all_notebooks` iterates `series_dir.rglob(\"*.ipynb\")` only (L717). Playwright-OWUI is a **TypeScript series** (`.spec.ts`) with **zero notebooks** — so:
- The catalog bot **never discovers** it (confirmed: absent from parent breakdown `Audio=30, ... Vibe-Coding=5`, absent from `COURSE_CATALOG.generated.json`).
- The cron **will never write** a marker here.
- Crucially: the cron **will never overwrite** a hand-written marker either (it only touches series it scans). So a one-time manual addition is safe and permanent.

## Census result (honest, G.9)
The README body is otherwise **clean** — I did not force a bogus fix. Gabarit census:
- **No anti-1 drift**: test counts in the README (4/8/7/7/8 = 34) are **all exact** (verified by precise grep excluding inline `test.skip()` conditionals — the word-boundary lesson, cf po-2025's `\bEM\b` fix; a naive `grep \"test(\"` over-counts to 10/18/16 because `test.skip(` inside a test body is not a new definition).
- **No anti-2/3**: the parent GenAI README mentions Playwright at 6+ places (structure tree, section, concepts, fil rouge) but the child README develops it in detail — no verbatim dup, no generic bridge.
- **FAQ exactly 6 questions**, navigation at L3.
- The only gap = the missing marker itself (gabarit L80 lists GenAI/Image and GenAI/Playwright-OWUI among series missing markers; Image was flagged cycle 7 for the bot, Playwright needs this one-time manual add since the bot can't see it).

## Edit (+8/-0)
Marker adapted to the non-notebook format, with a note explaining the bot exclusion so the absence from the parent breakdown is understood:
```
series: GenAI-Playwright-OWUI
format: TypeScript (.spec.ts) -- serie non-notebook, non decomptee par le bot catalogue (.ipynb only)
module_count: 5
test_count: 34
maturity: PRODUCTION=5
```
Matches parent claim \"5 modules, 30+ tests\" (34 >= 30). Maturity PRODUCTION per footer (revalidated OWUI v0.9.1, April 2026).

## Validation
- Markdown-only (C.2 exception).
- `COURSE_CATALOG.generated.{json,md}` untouched (this series is not tracked by the bot).
- check-links + no-catalog-changes covered by CI.
- 1 file, +8/-0.

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)