### PR TITLE
docs(pymc): fidelity #3164 PyMC-4-Bayesian-Networks -- BN/CPT/D-sep/do-calculus citations + fix NUTS claim

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
@@ -31,7 +31,10 @@
     "- Comparer inference observationnelle vs interventionnelle (do-calculus)\n",
     "\n",
     "**Prerequis** : PyMC-1 a PyMC-3 (graphe de facteurs), theoreme de Bayes\n",
-    ""
+    "\n",
+    "### References fondatrices\n",
+    "\n",
+    "Les reseaux bayesiens sont formalises par **Pearl (1988)**, *Probabilistic Reasoning in Intelligent Systems* (Morgan Kaufmann). L'inference exacte par junction tree est due a **Lauritzen & Spiegelhalter (1988)**, *Local Computations with Probabilities on Graphical Structures*, JRSS B 50(2), et **Jensen, Lauritzen & Olesen (1990)**, *Bayesian updating in recursive graphical models by local computations*, SIAM J. Numer. Anal. 27(2).\n"
    ]
   },
   {
@@ -157,7 +160,9 @@
    "source": [
     "## 2. Tables de Probabilites Conditionnelles\n",
     "\n",
-    "La CPT de WetGrass a 4 entrees (combinaisons de Sprinkler et Rain) :"
+    "La CPT de WetGrass a 4 entrees (combinaisons de Sprinkler et Rain) :\n",
+    "\n",
+    "Les tables de probabilites conditionnelles (CPT) et l'inference exacte par junction tree sont decrites par Lauritzen & Spiegelhalter (1988) et Jensen, Lauritzen & Olesen (1990).\n"
    ]
   },
   {
@@ -921,7 +926,9 @@
     "\n",
     "2. **Collision** (Collider) : Sprinkler --> WetGrass <-- Rain\n",
     "   - Sans observation : S et R sont independants\n",
-    "   - En observant W : S et R deviennent dependants (explaining away)"
+    "   - En observant W : S et R deviennent dependants (explaining away)\n",
+    "\n",
+    "La D-separation est formalisee par **Pearl, Geiger & Verma (1989)** et **Verma & Pearl (1988)**, *Causal Networks: Semantics and Expressiveness*.\n"
    ]
   },
   {
@@ -1020,7 +1027,7 @@
     "- **P(Cloudy | Rain=True)** : observationnelle. Si on voit qu'il pleut, c'est probablement nuageux.\n",
     "- **P(Cloudy | do(Rain=True))** : interventionnelle. Si on FAIT pleuvoir, cela n'affecte pas les nuages.\n",
     "\n",
-    "Le do-calculus de Pearl : `do(X=x)` coupe les fleches entrantes vers X."
+    "Le **do-calculus de Pearl** (Pearl, 1995 ; Pearl, 2000, *Causality*, Cambridge University Press) : `do(X=x)` coupe les fleches entrantes vers X, transformant une requete observationnelle en intervention causale."
    ]
   },
   {
@@ -1334,11 +1341,18 @@
     "\n",
     "### Points cles\n",
     "- La d-separation identifie les independances conditionnelles\n",
-    "- L'inference exacte est NP-difficile en general (variable elimination, junction trees)\n",
-    "- L'echantillonnage MCMC (NUTS) fournit une inference approximative scalable\n",
+    "- L'inference exacte est NP-difficile en general (variable elimination : Zhang & Poole, 1994 ; bucket elimination : Dechter, 1999 ; junction trees : Lauritzen & Spiegelhalter, 1988)\n",
+    "- L'echantillonnage MCMC (ici BinaryGibbsMetropolis pour les variables discretes ; NUTS pour les variables continues) fournit une inference approximative scalable\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Pearl, J. (1988). *Probabilistic Reasoning in Intelligent Systems.* Morgan Kaufmann.\n",
+    "- Lauritzen, S. L., & Spiegelhalter, D. J. (1988). *Local Computations with Probabilities on Graphical Structures.* JRSS B 50(2).\n",
+    "- Jensen, F. V., Lauritzen, S. L., & Olesen, K. G. (1990). *Bayesian updating in recursive graphical models by local computations.* SIAM J. Numer. Anal. 27(2).\n",
+    "- Pearl, J., Geiger, D., & Verma, T. (1989). *Conditional Independence and Their Representations.* (D-separation)\n",
+    "- Pearl, J. (2000). *Causality: Models, Reasoning, and Inference.* Cambridge University Press. (do-calculus)\n",
     "\n",
     "---\n",
-    "\n",
     "**Retour au sommaire** : [Index Probas](../README.md)"
    ]
   }


### PR DESCRIPTION
## Contexte

Audit fidélité #3164 (famille Probas/PyMC). Suite des corrections d'OMISSION scholarly sur la série PyMC (déjà mergées : PyMC-6 #3289, PyMC-3 #3336, PyMC-10 #3345, PyMC-12 #3355, PyMC-5 #3371, PyMC-8 #3386, PyMC-11 #3402, PyMC-2 #3405).

## Verdict : OMISSION (HIGH) + 1 correction factual (NUTS claim erroné)

`PyMC-4-Bayesian-Networks.ipynb` implémente **réellement** le réseau Wet Grass (DAG 4 nœuds via `pm.Bernoulli` + dépendances parentales, CPT via `pt.switch`, cell `96d9e8e5`) avec `pm.sample` réel (5×). **0 REINVENTION**. Inférence réelle : outputs matchent la théorie (`P(Rain|WetGrass=1)=0.707` vs ~0.71, `P(Cloudy|do(Rain=1))=0.500` = marginal, sémantique do-calculus correcte).

**Point FIDÈLE** : sampler réel = `BinaryGibbsMetropolis` (outputs confirmés 6×), correct pour latents Bernoulli discrets. C'est l'inverse de l'erreur NUTS-on-discrete.

Mais le notebook **cite aucune source scholarly formelle**. Grep cross-check G.1 : **0× pour Lauritzen, Spiegelhalter, Jensen, Dechter, Verma, Geiger, Zhang, Poole, 1988, 1990, 1995**. `Pearl`=2× mais uniquement informal (1 name-drop + 1 dans un `print()`). Même classe d'OMISSION récurrente (c).

**Bonus factual** : la conclusion dit « MCMC (NUTS) » mais le sampler réel est `BinaryGibbsMetropolis` (NUTS n'apparaît jamais dans les outputs et serait inapproprié pour les latents discrets). Correction factual incluse.

## Corrections (markdown-only, 5 cells, +21/-7)

| Cell | Contenu |
|------|---------|
| idx0 (`6ddc2b96`) intro | Références fondatrices **Pearl (1988)** *Probabilistic Reasoning in Intelligent Systems* + **Lauritzen & Spiegelhalter (1988)** JRSS B 50(2) + **Jensen/Lauritzen/Olesen (1990)** |
| idx3 (`a5c00340`) CPT intro | Source junction tree Lauritzen&Spiegelhalter (1988) + Jensen et al (1990) |
| idx17 (`4c9f1798`) D-separation | Source **Pearl/Geiger/Verma (1989)** + **Verma&Pearl (1988)** |
| idx19 (`152cc56b`) do-calculus | Citation formelle **Pearl (1995)** + **Pearl (2000)** *Causality* CUP (remplace name-drop informel) |
| idx24 (`ee571335`) Conclusion | **(a) Correction factual** « MCMC (NUTS) » → « MCMC (ici BinaryGibbsMetropolis pour les variables discrètes ; NUTS pour les continues) » ; (b) sources variable elimination/bucket elimination/junction trees ; (c) bloc References (5 citations) |

## Validation

- nbformat VALID
- C.1 clean (0 `raise NotImplementedError` / `assert False` / `1/0`)
- cell-order gate #3245 clean
- **0 ligne `execution_count`/`outputs` ajoutée** (C.3 — markdown-only, exception C.2 re-exécution)
- base fraîche `origin/main`, catalogue byte-identique

`See #3164`

Co-Authored-By: Claude <noreply@anthropic.com>
