### PR TITLE
fix(qc-py-02): delete false backtest blocks verified against QC Cloud (#3366)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
@@ -201,27 +201,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "qc_backtest": true,
-    "qc_cell_ref": 5
-   },
-   "source": [
-    "**Résultat du Backtest QC Cloud** — `BasicLifecycleAlgorithm`",
-    "",
-    "| Métrique | Valeur |",
-    "|----------|--------|",
-    "| Période | 2015-01-01 → 2024-12-31 (2516 jours trading) |",
-    "| Ordres exécutés | 1 |",
-    "| Profit net | 239.462% |",
-    "| Sharpe Ratio | 0.534 |",
-    "| CAGR | 12.990% |",
-    "| Max Drawdown | 33.500% |",
-    "| Win Rate | 0% |",
-    "| Capital final | $339,461.95 |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** — BasicLifecycleAlgorithm (BT 517a23f820b3..., projet 31996105)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | 0.493 | 11.761% | 33.5% | 1 |"
@@ -387,27 +366,6 @@
    "metadata": {},
    "execution_count": null,
    "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "qc_backtest": true,
-    "qc_cell_ref": 11
-   },
-   "source": [
-    "**Résultat du Backtest QC Cloud** — `MultiAssetAlgorithm`",
-    "",
-    "| Métrique | Valeur |",
-    "|----------|--------|",
-    "| Période | 2015-01-01 → 2024-12-31 (3653 jours trading) |",
-    "| Ordres exécutés | 0 |",
-    "| Profit net | 0% |",
-    "| Sharpe Ratio | 0 |",
-    "| CAGR | 0% |",
-    "| Max Drawdown | 0% |",
-    "| Win Rate | 0% |",
-    "| Capital final | $100,000.00 |"
-   ]
   },
   {
    "cell_type": "markdown",
@@ -596,27 +554,6 @@
    "metadata": {},
    "execution_count": null,
    "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "qc_backtest": true,
-    "qc_cell_ref": 16
-   },
-   "source": [
-    "**Résultat du Backtest QC Cloud** — `IndicatorsAlgorithm`",
-    "",
-    "| Métrique | Valeur |",
-    "|----------|--------|",
-    "| Période | 2015-01-01 → 2024-12-31 (2516 jours trading) |",
-    "| Ordres exécutés | 0 |",
-    "| Profit net | 0% |",
-    "| Sharpe Ratio | 0 |",
-    "| CAGR | 0% |",
-    "| Max Drawdown | 0% |",
-    "| Win Rate | 0% |",
-    "| Capital final | $100,000.00 |"
-   ]
   },
   {
    "cell_type": "markdown",
@@ -851,27 +788,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "qc_backtest": true,
-    "qc_cell_ref": 21
-   },
-   "source": [
-    "**Résultat du Backtest QC Cloud** — `RSIMeanReversion`",
-    "",
-    "| Métrique | Valeur |",
-    "|----------|--------|",
-    "| Période | 2015-01-01 → 2024-12-31 (2516 jours trading) |",
-    "| Ordres exécutés | 20 |",
-    "| Profit net | 99.504% |",
-    "| Sharpe Ratio | 0.291 |",
-    "| CAGR | 7.145% |",
-    "| Max Drawdown | 28.700% |",
-    "| Win Rate | 90% |",
-    "| Capital final | $199,503.83 |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** — TradingMethodsExample (BT 0ed23be74610..., projet 31996441)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | 0.379 | 7.14% | 21.7% | 0 |"
@@ -1049,27 +965,6 @@
     "        # if self.Portfolio.Invested:\n",
     "        #     self.Liquidate(self.symbol)\n",
     "        #     self.Log(f\"Liquidate: Position fermée à ${price:.2f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "qc_backtest": true,
-    "qc_cell_ref": 26
-   },
-   "source": [
-    "**Résultat du Backtest QC Cloud** — `TradingMethodsExample`",
-    "",
-    "| Métrique | Valeur |",
-    "|----------|--------|",
-    "| Période | 2015-01-01 → 2024-12-31 (2516 jours trading) |",
-    "| Ordres exécutés | 1 |",
-    "| Profit net | 119.731% |",
-    "| Sharpe Ratio | 0.42 |",
-    "| CAGR | 8.184% |",
-    "| Max Drawdown | 21.700% |",
-    "| Win Rate | 0% |",
-    "| Capital final | $219,730.97 |"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixes the double-contradictory-backtest-blocks bug in **QC-Py-02** (#3366, **completes the issue** — NB02, 5 algos). This is the **last notebook** in #3366. Combined with #3403 (NB05), #3406 (NB08), and #3407 (NB06), this brings #3366 to **14/14 algos fixed** — the issue is fully resolved.

QC-Py-02 contained, for each of 5 algorithms, TWO backtest result blocks: a compact table "Bloc A" and a prose summary "Bloc B" that **embeds the real QC backtest IDs** from the 2026-05-22 audit. Verified each against **QC Cloud backtests** (5 backtests, all Completed).

## Verification table (G.1 — each algo verified against QC Cloud)

| Algo | QC Cloud real (Sharpe/CAGR/MaxDD/dates) | TRUE block | FALSE block deleted |
|------|-----------------------------------------|------------|---------------------|
| BasicLifecycleAlgorithm | 0.493 / 11.761% / 33.5% / 2264d | Bloc B (cell 6, BT 517a23f8) | Bloc A — Sharpe **0.534**, CAGR 12.99% |
| MultiAssetAlgorithm | 0.834 / 25.403% / 40.3% / 1462d | Bloc B (cell 10, BT c3e7f9c3) | Bloc A — **0 trades / $100k / 0%** (starkest inversion) |
| IndicatorsAlgorithm | 0 / 0% / 0% / 2516d (pure demo) | Bloc B (cell 16, "0 (demo)", BT 150fee29) | Bloc A — misleading 0/0/0 result table |
| RSIMeanReversion | 0.291 / 7.145% / 28.7% / 2516d | Bloc B (cell 22, BT 3b160a65) | Bloc A — 20 trades (real ~10; metrics otherwise agree) |
| TradingMethodsExample | 0.379 / 7.139% / 21.7% / 2264d | Bloc B (cell 28, BT 0ed23be7) | Bloc A — Sharpe 0.42, **+119.731% / $219,730** fabricated |

## Key finding (G.1)

NB02 pattern is **UNIFORM** (like NB08/NB06, unlike MIXTE NB05): **Bloc B (prose with real BT ids) is TRUE for all 5**; **Bloc A (compact table) is FALSE for all 5**. The Bloc B prose blocks carry the verifiable QC backtest IDs from the 2026-05-22 audit (projects 31996105/31996194/31996292/31996392/31996441) — these are the authoritative records. The verification was done by reading those existing Completed backtests directly (no new backtest runs needed this cycle).

**Two nuanced cases (G.1 honesty)**:
- **RSIMeanReversion**: the metrics (Sharpe 0.291 / CAGR 7.145% / MaxDD 28.7%) actually AGREE between the two blocks; only the order count differs (Bloc A: 20, Bloc B: ~10). Bloc B has the real BT id → kept as authoritative. The Bloc A table is removed because it carries the stale order count and lacks the verifiable BT id.
- **IndicatorsAlgorithm**: both blocks agree it's a 0-trade demo, but Bloc A presents a full 0/0/0 result table (misleading — looks like a failed backtest) while Bloc B honestly labels it "0 (demo)". Bloc B kept for honest framing.

## Changes (1 notebook, +1/-106, markdown-only)

- 5 false Bloc A table cells deleted (40→35 cells)
- Each deletion G.1-verified with content assertion before delete (algo name + table signature + a FALSE-specific metric)
- 0 code cells touched (all `[REFERENCE QC]` non-executable, exec_count=None) → C.2 markdown-only exception
- nbformat VALID, no exec-churn (C.3)

## Scope & issue completion

This PR fixes **NB02** (5 algos). Combined with **#3403 (NB05, 5)**, **#3406 (NB08, 3)**, and **#3407 (NB06, 3)**, this brings #3366 to **14/14 algos across all 4 notebooks fixed**. NB02 was the last notebook — **`Closes #3366`** (all acceptance criteria met: each of the 14 algos now has a single, non-contradictory, QC-Cloud-verified backtest result block).

## Validation

- QC Cloud: 5 backtests Completed (projects 31996105/31996194/31996292/31996392/31996441, backtests from 2026-05-22 audit; Sharpe/CAGR/MaxDD/tradeableDates reported above, match kept Bloc B for each algo)
- nbformat VALID, 0 code cells modified, no exec_count/outputs churned
- catalog byte-identical, base fresh from main, atomic (1 notebook)

`Closes #3366`
`See #3164`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
