### PR TITLE
fix(sudoku): Sudoku-15-Infer-Python -- real NumPyro run + honest prose (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
@@ -42,7 +42,7 @@
     "| **Contraintes** | Dures (`ConstrainFalse`) | Douces (`numpyro.factor`) |\n",
     "| **Variables** | `VariableArray<int>` | Dirichlet (continu) |\n",
     "| **Iterations** | 50 EP iterations | 300+ SVI iterations |\n",
-    "| **Performance (Easy)** | ~33ms (modele compile) | ~5-15s (CPU) |"
+    "| **Performance (Easy)** | ~33ms (modele compile) | ~5-6s (CPU) |"
    ]
   },
   {
@@ -87,9 +87,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Module manquant : No module named 'jax'\n",
-      "JAX requis pour ce notebook : pip install jax jaxlib numpyro\n",
-      "Les cellules de calcul seront ignorees avec un message d'information.\n"
+      "JAX version: 0.6.2\n",
+      "NumPyro version: 0.19.0\n",
+      "Backend: [CpuDevice(id=0)]\n"
      ]
     }
    ],
@@ -135,18 +135,18 @@
    "source": [
     "### Interpretation : Environnement NumPyro/JAX\n",
     "\n",
-    "**Resultats obtenus** : L'environnement est correctement configure avec JAX 0.9.0.1 et NumPyro 0.20.0 sur CPU.\n",
+    "**Resultats obtenus** : L'environnement est correctement configure avec JAX 0.6.2 et NumPyro 0.19.0 sur CPU.\n",
     "\n",
     "| Composant | Version | Backend | Role |\n",
     "|-----------|---------|---------|------|\n",
-    "| JAX | 0.9.0.1 | CpuDevice(id=0) | Calcul differenciable et compilation JIT |\n",
-    "| NumPyro | 0.20.0 | - | Programmation probabiliste sur JAX |\n",
+    "| JAX | 0.6.2 | CpuDevice(id=0) | Calcul differenciable et compilation JIT |\n",
+    "| NumPyro | 0.19.0 | - | Programmation probabiliste sur JAX |\n",
     "| Device | CPU | - | Execution sur CPU (pas de GPU requis) |\n",
     "\n",
     "**Points cles** :\n",
     "1. **JAX comme backend** : JAX fournit la differenciation automatique et la compilation JIT necessaires a NumPyro\n",
     "2. **Execution CPU** : Ce notebook fonctionne sur CPU, pas besoin de GPU (contrairement au Deep Learning)\n",
-    "3. **Version recente** : NumPyro 0.20.0 est une version stable avec SVI bien optimise\n",
+    "3. **Version recente** : NumPyro 0.19.0 est une version stable avec SVI bien optimise\n",
     "4. **Compatibilite** : Ces versions sont compatibles avec les algorithmes EP/VI presentes dans ce notebook\n",
     "\n",
     "> **Note technique** : JAX est une bibliotheque de calcul numerique qui combine NumPy avec la differenciation automatique et la compilation JIT (Just-In-Time). NumPyro s'appuie sur JAX pour implementer des algorithmes d'inference probabiliste comme MCMC (NUTS) et VI (SVI). La distinction CPU/GPU est importante : JAX peut utiliser les GPU pour accelerer les calculs, mais les algorithmes SVI pour les CSP de petite taille comme Sudoku ne beneficient pas beaucoup du GPU (surcout de transfert de donnees)."
@@ -194,7 +194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5 puzzles charges depuis MyIA.AI.Notebooks/Sudoku/Puzzles/Sudoku_Easy51.txt\n"
+      "5 puzzles charges depuis Puzzles/Sudoku_Easy51.txt\n"
      ]
     }
    ],
@@ -386,8 +386,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JAX requis : pip install jax jaxlib numpyro\n",
-      "Les modeles NumPyro (compute_constraint_penalty, dirichlet_sudoku_model, dirichlet_sudoku_guide) ne sont pas disponibles.\n"
+      "Modeles NumPyro definis : compute_constraint_penalty, dirichlet_sudoku_model, dirichlet_sudoku_guide\n"
      ]
     }
    ],
@@ -517,8 +516,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JAX requis : pip install jax jaxlib numpyro\n",
-      "La classe RobustProbabilisticSolverPy n'est pas disponible sans JAX.\n"
+      "Classe RobustProbabilisticSolverPy definie.\n"
      ]
     }
    ],
@@ -616,8 +614,50 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JAX requis : pip install jax jaxlib numpyro\n",
-      "Test du solveur probabiliste ignore. Installez JAX pour executer cette cellule.\n"
+      "\n",
+      "Puzzle initial:\n",
+      "-------------------------\n",
+      "| 9   2 |     5 | 4   3 |\n",
+      "| 1     |   6 3 |   2 5 |\n",
+      "| 5   8 | 4   7 |   6   |\n",
+      "|-----------------------|\n",
+      "|   2 6 | 3   9 |     1 |\n",
+      "|   5 7 |   1   | 2 9   |\n",
+      "|   9   | 6 7   | 5 3   |\n",
+      "|-----------------------|\n",
+      "| 2 4   | 5 3   | 6     |\n",
+      "| 7   5 | 2     | 3   4 |\n",
+      "|   8   |   4 1 | 9 5   |\n",
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Solution (inference: 6.2s):\n",
+      "-------------------------\n",
+      "| 9 6 2 | 1 8 5 | 4 7 3 |\n",
+      "| 1 7 4 | 9 6 3 | 8 2 5 |\n",
+      "| 5 3 8 | 4 2 7 | 1 6 9 |\n",
+      "|-----------------------|\n",
+      "| 8 2 6 | 3 5 9 | 7 4 1 |\n",
+      "| 3 5 7 | 8 1 4 | 2 9 6 |\n",
+      "| 4 9 1 | 6 7 2 | 5 3 8 |\n",
+      "|-----------------------|\n",
+      "| 2 4 9 | 5 3 8 | 6 1 7 |\n",
+      "| 7 1 5 | 2 9 6 | 3 8 4 |\n",
+      "| 6 8 3 | 7 4 1 | 9 5 2 |\n",
+      "-------------------------\n",
+      "\n",
+      "Resultats:\n",
+      "  - Iterations SVI: 300\n",
+      "  - Temps inference: 6.2s\n",
+      "  - Temps total: 6.2s\n",
+      "  - Converge: True\n",
+      "  - Erreurs: 0\n"
      ]
     }
    ],
@@ -667,15 +707,15 @@
     "| Metrique | Valeur | Analyse |\n",
     "|----------|--------|---------|\n",
     "| Iterations SVI | 300 | Equivalent a ~50 EP iterations Infer.NET |\n",
-    "| Temps inference | 7.1s | ~215x plus lent que C# (33ms) |\n",
+    "| Temps inference | 6.2s | ~180x plus lent que C# (~34ms) |\n",
     "| Convergence | True | Solution valide obtenue |\n",
     "| Erreurs | 0 | Toutes les contraintes respectees |\n",
-    "| Cellules initiales | 29 | 52 cellules a determiner |\n",
+    "| Cellules initiales | 45 | 36 cellules a determiner |\n",
     "\n",
     "**Points cles** :\n",
     "1. **Mode des distributions** : Le solveur selectionne la valeur la plus probable de chaque distribution Dirichlet (argmax)\n",
     "2. **Contraintes douces** : Les penalites `numpyro.factor` encouragent la cohérence sans garantir les contraintes Sudoku\n",
-    "3. **Performance acceptable** : 7 secondes pour un puzzle Easy est raisonnable pour un prototype pedagogique\n",
+    "3. **Performance acceptable** : 6 secondes pour un puzzle Easy est raisonnable pour un prototype pedagogique\n",
     "4. **Limitation evidente** : Ce solveur echoue sur les puzzles Medium/Hard (voir benchmark plus loin)\n",
     "\n",
     "> **Note technique** : La distribution Dirichlet de dimension 9 modelise la probabilite de chaque valeur (1-9) pour chaque cellule. Le parametre de concentration `alpha` est appris par SVI. Les cellules connues sont fixees avec `alpha = 1000` (quasi-certain), les inconnues commencent avec `alpha = 1` (uniforme). L'inference ajuste progressivement ces concentrations pour maximiser la vraisemblance tout en respectant les contraintes (via `compute_constraint_penalty`)."
@@ -978,8 +1018,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JAX requis : pip install jax jaxlib numpyro\n",
-      "La classe IterativeProbabilisticSolverPy n'est pas disponible sans JAX.\n"
+      "Classe IterativeProbabilisticSolverPy definie.\n"
      ]
     }
    ],
@@ -1095,8 +1134,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JAX requis : pip install jax jaxlib numpyro\n",
-      "Test du solveur iteratif ignore. Installez JAX pour executer cette cellule.\n"
+      "=== Test IterativeProbabilisticSolverPy ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Puzzle 1: OK\n",
+      "  - Etapes: 36\n",
+      "  - Cellules fixees (probabiliste): 36\n",
+      "  - Temps inference: 157.0s\n",
+      "  - Temps total: 169.1s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Puzzle 2: OK\n",
+      "  - Etapes: 49\n",
+      "  - Cellules fixees (probabiliste): 49\n",
+      "  - Temps inference: 216.5s\n",
+      "  - Temps total: 231.7s\n"
      ]
     }
    ],
@@ -1148,15 +1210,15 @@
     "|----------|----------|----------|---------|\n",
     "| Etapes requises | 36 | 49 | 42.5 |\n",
     "| Cellules fixees | 36 | 49 | 42.5 |\n",
-    "| Temps inference cumule | 168.6s | 213.1s | 190.9s |\n",
-    "| Temps total | 183.6s | 230.4s | 207.0s |\n",
-    "| Temps par etape | 4.7s | 4.4s | 4.55s |\n",
+    "| Temps inference cumule | 157.0s | 216.5s | 186.8s |\n",
+    "| Temps total | 169.1s | 231.7s | 200.4s |\n",
+    "| Temps par etape | 4.7s | 4.7s | 4.7s |\n",
     "| Statut final | OK | OK | 100% succes |\n",
     "\n",
     "**Points cles** :\n",
     "1. **Processus iteratif** : Chaque etape fixe 1 cellule (parametre `cells_per_iteration=1`) et relance l'inference\n",
     "2. **Convergence garantie** : Les deux puzzles convergent vers une solution valide, contrairement au solveur robuste\n",
-    "3. **Cout temporel** : ~200 secondes par puzzle, soit ~30x plus lent que le solveur robuste (7s)\n",
+    "3. **Cout temporel** : ~200 secondes par puzzle, soit ~30x plus lent que le solveur robuste (6.2s)\n",
     "4. **Seuil de confiance** : 0.25 permet de fixer des cellules avec une confiance moderee mais suffisante\n",
     "\n",
     "> **Note technique** : L'approche iterative est plus robuste car chaque fixation reduit l'espace de recherche pour les etapes suivantes. Cependant, elle necessite de multiples passages d'inference (36-49 vs 1), ce qui explique le cout eleve. Le parametre `confidence_threshold` est critique : trop eleve (>0.5), aucune cellule n'est fixee ; trop bas (<0.1), des erreurs s'accumulent."
@@ -1340,13 +1402,46 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JAX requis : pip install jax jaxlib numpyro\n",
-      "Benchmark ignore. Installez JAX pour executer la comparaison.\n",
+      "=== Benchmark Python vs Infer.NET (RobustProbabilisticSolver) ===\n",
       "\n",
-      "Resultats de reference (C# Infer.NET) :\n",
-      "  - Easy #1 : ~33ms, Resolu\n",
-      "  - Easy #2 : ~34ms, Resolu\n",
-      "  - Medium  : ~56ms, 37 erreurs\n"
+      "Resultats Python:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Puzzle 1: OK | Temps: 4.7s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Puzzle 2: 8 erreurs | Temps: 4.8s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Puzzle 3: 8 erreurs | Temps: 4.7s\n",
+      "\n",
+      "============================================================\n",
+      "COMPARAISON PYTHON (NumPyro) vs C# (Infer.NET)\n",
+      "============================================================\n",
+      "Puzzle     Python (s)   C# (ms)      Python Status   C# Status      \n",
+      "------------------------------------------------------------\n",
+      "1          4.7          33.9         Resolu          Resolu         \n",
+      "2          4.8          33.9         8 err           Resolu         \n",
+      "3          4.7          56.7         8 err           37 err         \n",
+      "\n",
+      "Observations:\n",
+      "  - Infer.NET est ~100x plus rapide grace a:\n",
+      "    * Expectation Propagation (plus efficace que SVI pour les CSP)\n",
+      "    * Contraintes dures (ConstrainFalse) vs douces\n",
+      "    * Modele precompile une seule fois\n",
+      "  - Les deux approches echouent sur les puzzles Medium\n"
      ]
     }
    ],
@@ -1422,15 +1517,15 @@
     "\n",
     "| Aspect | Infer.NET (C#) | NumPyro (Python) | Facteur |\n",
     "|--------|----------------|------------------|---------|\n",
-    "| Temps Easy #1 | 33.9ms | 7.3s | ~215x plus lent |\n",
-    "| Temps Easy #2 | 33.9ms | 7.0s | ~206x plus lent |\n",
-    "| Temps Medium | 56.7ms | 6.8s | ~120x plus lent |\n",
+    "| Temps Easy #1 | 33.9ms | 4.7s | ~140x plus lent |\n",
+    "| Temps Easy #2 | 33.9ms | 4.8s | ~140x plus lent |\n",
+    "| Temps Medium | 56.7ms | 4.7s | ~83x plus lent |\n",
     "| Reussite Easy #1 | Resolu | Resolu | Identique |\n",
     "| Reussite Easy #2 | Resolu | 8 erreurs | Infer.NET superieur |\n",
     "| Reussite Medium | 37 erreurs | 8 erreurs | Python legerement meilleur |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Performance** : Infer.NET est ~200x plus rapide grace a la precompilation et Expectation Propagation\n",
+    "1. **Performance** : Infer.NET est ~100x plus rapide grace a la precompilation et Expectation Propagation\n",
     "2. **Qualite de solution** : Infer.NET reussit mieux les puzzles Easy (100% vs 50%), mais les deux echouent sur Medium\n",
     "3. **Contraintes** : Les contraintes dures d'Infer.NET (`ConstrainFalse`) sont plus efficaces que les contraintes douces de NumPyro\n",
     "4. **Variabilite** : Les resultats Python varient plus (8 erreurs vs 0 pour Easy #2, 8 vs 37 pour Medium)\n",


### PR DESCRIPTION
## Audit fidelite #3164 -- Sudoku-15-Infer-Python (env-degraded -> rule-F repair)

`Closes #3414`. `See #3164`.

### Defaut
L'env JAX/NumPyro etait **absent** au commit : tous les outputs committes etaient des messages de repli `JAX requis ...`, et **aucune inference n'avait tourne**. Pourtant 5 cellules d'interpretation fabriquaient des chiffres sans aucune sortie source :
- idx3 : "JAX **0.9.0.1** et NumPyro 0.20.0" (version JAX inexistante, contredit idx2 "module not found")
- idx13 : `7.1s / True / 0 err / 29 cellules / ~215x`
- idx22 : iteratif `36/49 etapes, 168.6/213.1s, 183.6/230.4s`
- idx26/27 : bench `Easy 7.3/7.0s, Medium 6.8s, 8 err, ~215x`
- idx0 : Performance Easy `~5-15s`

### Resolution (regle F -- REPARER, ne jamais contourner)
JAX est CPU-installable (pas l'exception GPU-only) :
1. `jax[cpu]` + `numpyro` installes dans `mcp-jupyter-py310` (Python **3.10.18**, match exact du `language_info`).
2. Notebook **re-execute end-to-end via papermill** : JAX 0.6.2 / NumPyro 0.19.0 sur CPU, **0 erreur**.
3. idx0/3/13/22/27 reecrits avec les **vrais nombres mesures** :

| Cellule | Reel mesure |
|---------|-------------|
| idx12 robuste (Easy) | 6.2s, 45 indices / 36 vides, converge True, 0 err |
| idx21 iteratif | P1 36 etapes 169.1s, P2 49 etapes 231.7s, 100% OK |
| idx26 bench | P1 4.7s OK, P2 4.8s 8 err, P3 4.7s 8 err vs C# 33.9/33.9/56.7ms |

4. Commit **avec sorties reelles** (C.2). Code source byte-identique (seuls `outputs`+`execution_count` greffes) ; labeling/navigation deja propres.

### Validation
- `scan_cell_ordering` : 1 clean, 0 finding
- `check_c2_compliance` : 1/1 compliant
- `notebook_tools validate` : OK 1, 0 warnings, **0 errors**
- Re-exec papermill : 34 cellules, 0 erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)