### PR TITLE
fix(smartcontracts): relabel SC-9 'Exercice 1' as Exemple guide (quorum) (Closes #3349)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
@@ -358,13 +358,20 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Simulation de delegation de votes\n",
+    "### Exemple guide : Calcul du quorum\n",
     "\n",
-    "Simulez le mecanisme de delegation d'un GovernanceToken. Un token holder peut deleguer ses votes a un representant. Implementez une classe qui gere les soldes, les delegations et calcule le pouvoir de vote effectif de chaque adresse.\n",
+    "Cette section montre comment verifier si une proposition de gouvernance atteint le **quorum**, c'est-a-dire la participation minimale requise pour qu'un vote soit valide. La fonction `check_quorum` (cellule suivante) est entierement resolue : elle calcule, a partir des voix pour / contre / abstention et de la supply totale de tokens, si le seuil de participation est franchi, puis la repartition des voix exprimees.\n",
     "\n",
-    "**Indice** : Les votes d'un delegateur sont transferes vers le delegataire. Si Alice (1000 tokens) delegue a Bob (500 tokens), Alice a 0 votes et Bob a 1500 votes.\n",
-    "- Maintenez un dictionnaire `delegates` (adresse -> delegataire)\n",
-    "- Le pouvoir de vote effectif = somme des tokens de tous les delegateurs vers cette adresse"
+    "**Logique implementee** :\n",
+    "\n",
+    "- `total_votes = for + against + abstain`\n",
+    "- `quorum_threshold = total_supply * quorum_percent / 100` (4 % par defaut, meme idee que la constante `QUORUM = 4_000_000` du `SimpleGovernor` deploye plus loin)\n",
+    "- `quorum_reached = total_votes >= quorum_threshold`\n",
+    "- `participation_percent`, `for_percent`, `against_percent` : parts relatives a la supply (participation) et aux votes exprimes (pour / contre)\n",
+    "\n",
+    "**Test resolu** : avec 3,5 M de votes pour, 1 M contre et 0,5 M d'abstention sur une supply de 100 M de tokens, la participation s'eleve a 5,00 % (seuil de quorum 4 M franchi), soit 70,0 % de voix pour et 20,0 % contre - le quorum est atteint.\n",
+    "\n",
+    "> La **delegation de votes** - transferer son pouvoir de vote vers un representant - est enseignee dans l'interpretation precedente : le contrat `GovernanceToken` deploye implemente `delegate(address)`, les checkpoints par bloc, ainsi que `getVotes` et `getPastVotes`. Les trois exercices a completer qui suivent (pouvoir de vote a un bloc passe, vote quadratique, statut d'une transaction timelockee) construisent sur ces mecanismes de gouvernance.\n"
    ]
   },
   {


### PR DESCRIPTION
## Résumé

Zone pendule `exercise-example-labeling.md` (jugement non-délégable, classification par contenu). Résout l'issue **#3349** (SC-9-DAO-Governance) — le seul finding de la passe d'audit #3164 sur `02-Solidity-Advanced` (classe voisine labeling, PAS une fabrication output-vs-markdown).

`Closes #3349` · `See #3164` (Epic, non-closing).

## Le défaut (G.1-confirmé contre les cells réelles)

- **idx5 `e4ba4214`** titrait `### Exercice 1 : Simulation de delegation de votes` avec un énoncé impératif (« Implementez une classe gerant les delegations... »).
- **idx6 `cell-9`** (code, ec=8) est une fonction `check_quorum(...)` **complètement résolue** (toutes `# Etape` remplies, 0 TODO) produisant l'output committé réel `Quorum atteint: True / Participation: 5.00% / Pour: 70.0% / Contre: 20.0%`.

Deux problèmes : (1) **mislabel** — solution complète sous « Exercice » ⇒ Exemple par contenu (case-2 règle) ; (2) **topic mismatch** — énoncé délégation vs code quorum.

## Fix — Option B (relabel, markdown-only), cohérent avec SC-20 #3408

idx5 réécrit en `### Exemple guide : Calcul du quorum` : décrit la solution résolue (logique + test résolu valeurs exactes 3,5M/1M/0,5M/100M → 5% participation, 70% pour, 20% contre, seuil 4M) + note rappelant que la **délégation reste enseignée** dans l'interprétation idx7 (contrat `GovernanceToken` : `delegate`/checkpoints/`getVotes`/`getPastVotes`). Cohérent avec le jumeau SC-20 (PR #3408 merged) : préserve un worked-example fonctionnel (anti-régression), zéro churn d'output.

## Garanties

- **markdown-only** : +12/−5 sur 1 notebook, idx5 uniquement. **idx6 `cell-9` (code) byte-identique**, outputs + métadonnées byte-identiques à `main`. Aucune re-exécution (C.3).
- **Catalogue + submodule MGS byte-identiques**.
- **3 exercices stub préservés** (Ex 2/3/4, `# TODO etudiant` + return placeholder, conforme C.1) → #2161 ≥3 tient.
- Branche fraîche off `origin/main` (`7bd67302`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)