### PR TITLE
docs(pymc-1): cite foundational Bayesian/MCMC sources (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
@@ -354,7 +354,19 @@
   {
    "cell_type": "markdown",
    "id": "2a1ef25d",
-   "source": "### Interpretation de l'echantillonnage\n\nL'echantillonneur NUTS (No-U-Turn Sampler) a genere 4 chaines de 2000 echantillons chacune (plus 1000 de warmup), pour un total de 8000 tirages du posterior en 21 secondes. Le posterior analytique est **Beta(8, 4)** car le prior Beta(1,1) se combine avec 7 faces et 3 piles.\n\n| Parametre | Prior | Donnees | Posterior analytique | Estime MCMC |\n|-----------|-------|---------|---------------------|-------------|\n| alpha | 1 | +7 faces | 8 | convergent |\n| beta | 1 | +3 piles | 4 | convergent |\n| E[theta] | 0.500 | -- | 0.667 | 0.667 |\n\nLa cellule suivante affiche la distribution posterior complete via ArviZ, incluant la densite, la moyenne et l'intervalle de credibilite a 94%.",
+   "source": [
+    "### Interpretation de l'echantillonnage\n",
+    "\n",
+    "L'echantillonneur NUTS (*No-U-Turn Sampler*, Hoffman & Gelman 2014) a genere 4 chaines de 2000 echantillons chacune (plus 1000 de warmup), pour un total de 8000 tirages du posterior en 21 secondes. Le posterior analytique est **Beta(8, 4)** car le prior Beta(1,1) se combine avec 7 faces et 3 piles.\n",
+    "\n",
+    "| Parametre | Prior | Donnees | Posterior analytique | Estime MCMC |\n",
+    "|-----------|-------|---------|---------------------|-------------|\n",
+    "| alpha | 1 | +7 faces | 8 | convergent |\n",
+    "| beta | 1 | +3 piles | 4 | convergent |\n",
+    "| E[theta] | 0.500 | -- | 0.667 | 0.667 |\n",
+    "\n",
+    "La cellule suivante affiche la distribution posterior complete via ArviZ, incluant la densite, la moyenne et l'intervalle de credibilite a 94%."
+   ],
    "metadata": {}
   },
   {
@@ -416,7 +428,9 @@
     "\n",
     "$$\\text{Prior: } \\theta \\sim \\text{Beta}(\\alpha, \\beta)$$\n",
     "$$\\text{Vraisemblance: } x_i \\sim \\text{Bernoulli}(\\theta)$$\n",
-    "$$\\text{Posterior: } \\theta | x \\sim \\text{Beta}(\\alpha + \\sum x_i,\\ \\beta + n - \\sum x_i)$$"
+    "$$\\text{Posterior: } \\theta | x \\sim \\text{Beta}(\\alpha + \\sum x_i,\\ \\beta + n - \\sum x_i)$$\n",
+    "\n",
+    "Ce resultat est le cas classique de prior conjugue : le posterior reste dans la meme famille fonctionnelle que le prior (Raiffa & Schlaiffer 1961)."
    ]
   },
   {
@@ -597,7 +611,9 @@
     "| Algorithme | Expectation Propagation | NUTS (Hamiltonian Monte Carlo) |\n",
     "| Resultat | Distribution analytique exacte | Echantillons du posterior |\n",
     "| Precision | Exact pour conjugues | Monte Carlo (converge) |\n",
-    "| Scalabilite | Message passing (rapide) | MCMC (plus lent mais general) |"
+    "| Scalabilite | Message passing (rapide) | MCMC (plus lent mais general) |\n",
+    "\n",
+    "> NUTS est une variante adaptive de Hamiltonian Monte Carlo (Duane et al. 1987 ; Neal 2011). Les methodes MCMC construisent une chaine de Markov dont la loi stationnaire est le posterior (Metropolis et al. 1953 ; Hastings 1970)."
    ]
   },
   {
@@ -677,6 +693,15 @@
     "- PyMC permet de definir des modeles probabilistes de maniere declarative\n",
     "- L'inference bayesienne combine prior et vraisemblance pour obtenir le posterior\n",
     "- Les traceurs ArviZ facilitent le diagnostic et la visualisation\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Salvatier, J., Wiecki, T. V., & Fonnesbeck, C. (2016). Probabilistic programming in Python using PyMC3. *PeerJ Computer Science*, 2:e55.\n",
+    "- Kumar, R., Carroll, C., Hartikainen, A., & Martin, O. (2019). ArviZ: a unified library for exploratory analysis of Bayesian models in Python. *Journal of Open Source Software*, 4(33), 1143.\n",
+    "- Hoffman, M. D., & Gelman, A. (2014). The No-U-Turn Sampler: adaptively setting path lengths in Hamiltonian Monte Carlo. *Journal of Machine Learning Research*, 15(1), 1593-1623.\n",
+    "- Neal, R. M. (2011). MCMC using Hamiltonian dynamics. In *Handbook of Markov Chain Monte Carlo*, Chapman & Hall/CRC.\n",
+    "- Metropolis, N., Rosenbluth, A., Rosenbluth, M., Teller, A., & Teller, E. (1953). Equation of state calculations by fast computing machines. *Journal of Chemical Physics*, 21(6), 1087-1092.\n",
+    "- Hastings, W. K. (1970). Monte Carlo sampling methods using Markov chains and their applications. *Biometrika*, 57(1), 97-109.\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Contexte

Audit fidélité #3164 — série PyMC (Probas/PyMC). **PyMC-1-Setup** (11/20). Détecté via sub-agent `sonnet` evidence-cited + cross-check G.1 local (grep/read direct).

## Verdict : **OMISSION** (réelle, cross-check G.1 confirmé)

Le notebook (setup + premier modèle Beta-Binomial) **nommait trois méthodes canoniques en prose** et enseignait la bibliothèque PyMC + ArviZ **partout, avec zéro citation scientifique** (vérifié : 0 marqueur auteur/année/doi dans tout le notebook).

## OMISSIONS corrigées (4 cellules markdown, +28/-3)

| Cellule (id) | Méthode nommée | Source ajoutée |
|---|---|---|
| idx 8 `2a1ef25d` | NUTS « No-U-Turn Sampler » | Hoffman & Gelman 2014 |
| idx 10 `f1b6f5e3` | formule posterior conjugué | Raiffa & Schlaiffer 1961 |
| idx 14 `ef617c31` | HMC + MCMC (table comparatif Infer.NET) | Duane et al. 1987 + Neal 2011 (HMC), Metropolis et al. 1953 + Hastings 1970 (MCMC) |
| idx 17 `4411434a` | Conclusion → bloc References | Salvatier 2016 (PyMC), Kumar 2019 (ArviZ), Hoffman & Gelman 2014 (NUTS), Neal 2011 (HMC), Metropolis 1953, Hastings 1970 |

## Pas de REINVENTION (vérifié)

- NUTS correctement appliqué au latent **continu** θ ~ Beta (pas d'erreur NUTS-sur-discret, à l'inverse de PyMC-3/10 corrigés ailleurs)
- Inférence **réelle** : `pm.sample(2000)` exécuté, exec_count=3, output capturé « Initializing NUTS… Sampling 4 chains for 1_000 tune and 2_000 draw iterations … took 21 seconds »
- Posterior analytique Beta(8,4), E[θ]=0.667 — **correct**
- « NUTS (Hamiltonian Monte Carlo) » — correct (NUTS = variante HMC)

## Validation

- `nbformat validate` OK (18 cellules, structure inchangée)
- `scan_cell_ordering.py` : 1 clean, 0 finding (gate #3245)
- C.1 OK (aucun `raise NotImplementedError` / `assert False` / `1/0`)
- C.3 markdown-only : **0** ligne `execution_count`/`outputs` ajoutée (+28/-3 = enrichissement pur, exception re-exec C.2)
- Diff = insertions > deletions (enrichissement)

Note : notebook Setup = exception aux conventions 3-exos, mais enseigne des méthodes canoniques nommées → citations dues. Pas de bibliographie parent reportable (Probas/README n'a qu'un commentaire `# Packages`, PyMC/README a 0 référence).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)