### PR TITLE
fix(qc-py-13): replace fabricated backtest metrics with QC Cloud values (See #3367)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
@@ -246,7 +246,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n**Resultats du backtest QC Cloud (BasicFrameworkAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | 4.907 |\n| Sortino Ratio | 8.969 |\n| CAGR | 205.139% |\n| Net Profit | 31.513% |\n| Total Orders | 100 |\n| Trades | 82 |\n| Win Rate | 64.6% |\n| Max Drawdown | 6.1% |\n| Equity finale | $131,512.64 |\n| Total Fees | $140.59 |"
+    "---\n",
+    "**Resultats du backtest QC Cloud (BasicFrameworkAlgorithm)** -- *corrige via re-run QC Cloud (#3367, projet 33046456)*\n",
+    "\n",
+    "| Metrique | Valeur |\n",
+    "|----------|--------|\n",
+    "| Statut | Completed |\n",
+    "| Periode | 2015-01-01 a 2024-12-31 ($100 000) |\n",
+    "| Sharpe Ratio | -0.213 |\n",
+    "| CAGR | -5.453% |\n",
+    "| Max Drawdown | 61.3% |\n",
+    "| Probabilistic Sharpe Ratio | 0.002% |\n",
+    "\n",
+    "*Correctif #3367 : le bloc precedent affichait Sharpe 4.907 / CAGR 205.139% / Max Drawdown 6.1% (presente comme un gagnant spectaculaire, Calmar environ 34). Le re-run QC Cloud montre que cette strategie EmaCross 12/26 sur FAANG (AAPL/MSFT/GOOGL/AMZN/META) est en fait **deficitaire** (Sharpe negatif, drawdown de 61%). Les valeurs precedentes etaient fabriquees. Les metriques non recuperables de facon fiable via l'API de resultats (Orders, Trades, Win Rate) sont omises plutot que re-affirmer des valeurs erronees.*"
    ]
   },
   {
@@ -1594,7 +1606,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n**Resultats du backtest QC Cloud (CompositeAlphaAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | -1.24 |\n| Sortino Ratio | -1.484 |\n| CAGR | -21.258% |\n| Net Profit | -5.7% |\n| Total Orders | 606 |\n| Trades | 0 |\n| Win Rate | 46.0% |\n| Max Drawdown | 11.2% |\n| Equity finale | $94,300.46 |\n| Total Fees | $624.72 |"
+    "---\n",
+    "**Resultats du backtest QC Cloud (CompositeAlphaAlgorithm)** -- *corrige via re-run QC Cloud (#3367, projet 33046536)*\n",
+    "\n",
+    "| Metrique | Valeur |\n",
+    "|----------|--------|\n",
+    "| Statut | Completed |\n",
+    "| Periode | 2015-01-01 a 2024-12-31 ($100 000) |\n",
+    "| Sharpe Ratio | -0.394 |\n",
+    "| CAGR | -7.720% |\n",
+    "| Max Drawdown | 62.0% |\n",
+    "| Probabilistic Sharpe Ratio | 0.000% |\n",
+    "\n",
+    "*Correctif #3367 : le bloc precedent affichait \"Total Orders 606 / Trades 0 / Win Rate 46.0%\" -- un **combinaison mathematiquement impossible** (un win rate est indefini sans trade : win rate = trades gagnants / trades total). Le re-run QC Cloud confirme une strategie deficitaire (Sharpe -0.394). Les valeurs Orders/Trades/Win Rate etaient fabriquees ; elles sont omises plutot que re-affirmer des valeurs incoherentes.*"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Cycle 14 of Epic #3164 (audit de fidélité des portings QC). **NB13 (QC-Py-13-Alpha-Models) contained fabricated backtest metrics.** Verified each flagged algo via QC Cloud re-run; this PR corrects the 2 algos fully verified this cycle.

See #3367 (partial — see "Remaining" below).

### Findings (QC Cloud verified)

| Algo | Cell | Notebook claimed (fabricated) | QC Cloud real | Verdict |
|------|------|-------------------------------|---------------|---------|
| **BasicFrameworkAlgorithm** | 7 | Sharpe 4.907 / CAGR 205.139% / MaxDD 6.1% / WR 64.6% (presented as spectacular winner, Calmar ~34) | **Sharpe -0.213 / CAGR -5.453% / MaxDD 61.3% / PSR 0.002%** (proj 33046456, bt `4515cf6d`) | FABRICATED — real algo is a LOSER |
| **CompositeAlphaAlgorithm** | 39 | Sharpe -1.24 + Total Orders 606 / **Trades 0 / Win Rate 46.0%** | **Sharpe -0.394 / CAGR -7.720% / MaxDD 62.0% / PSR 0.000%** (proj 33046536, bt `c300be08`) | IMPOSSIBLE combo (win rate undefined at 0 trades) + wrong Sharpe |

### What changed

Replaced both markdown metric blocks with the **reliable QC Cloud fields** (Sharpe / CAGR / MaxDD / Probabilistic Sharpe Ratio). Orders/Trades/WinRate are **omitted** rather than re-asserted: `read_backtest` does not reliably expose them for framework backtests (`totalOrders` returns 0), so re-stating any value would itself be unverifiable — see #3367 honesty.

Each replacement block carries a French correction note documenting what was wrong (anti-regression transparency).

## Method

- Deployed each algo verbatim to a dedicated QC project, compiled, backtested 2015-01-01 → 2024-12-31 ($100k), read results via MCP qc-mcp-lite.
- **G.1 content verification**: the apply script asserts the OLD fabricated signatures (`4.907`, `205.139%`, `606`, `Trades | 0`, `Win Rate | 46.0%`, `-1.24`, …) before replacing — aborts on mismatch, so only the known-wrong blocks are touched.

## Validation

- `nbformat.validate`: OK, 51 cells (unchanged count).
- **Markdown-only edit** (2 cells). Code cells untouched — the `[REFERENCE QC]` snippet cells were already non-executable reference code (copy-to-IDE pedagogy), not altered.
- Catalog byte-identical (`git diff --name-only` shows only the notebook).

## Remaining (follow-up cycles)

This PR is **partial** — `See #3367`, not `Closes`:

- **MomentumFrameworkAlgorithm (cell 30)**: same impossible combo (Trades 0 / WR 29%). QC backtest `d440c2e5` (proj 33046616) In Progress — slow custom `MomentumAlphaModel` warmup (History-per-symbol). Verify + fix next cycle.
- **CompleteFrameworkStrategy (cell 48)**: same combo (Trades 0 / WR 33%). Compile done (proj 33046719); backtest queued behind QC node serialization. Next cycle.
- **EmaCross pattern-test (proj 33046947)**: in-flight to determine whether the internally-"coherent" NB13 blocks (EmaCross/Macd/Rsi) are likewise fabricated or genuinely match.
- **NB14** (120920 orders / 0 trades — extreme case): separate cycle.

QC node serialization ("no spare nodes") serializes these framework backtests; batching all in one cycle is impractical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
