### PR TITLE
fix(qc-py-14): replace internally-contradictory backtest blocks (See #3367)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -850,23 +850,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Resultat Backtest QC Cloud** (Cellule 21)\n",
+    "> **Resultat Backtest QC Cloud** (MeanVarianceOptimizationExample) -- *corrige (#3367, verification QC Cloud en cours, projet 33048058)*\n",
     ">\n",
     "> | Metrique | Valeur |\n",
     "> |----------|-------|\n",
-    "> | Statut | Completed |\n",
-    "> | Sharpe Ratio | 2.851 |\n",
-    "> | Sortino Ratio | 4.713 |\n",
-    "> | CAGR | 35.735% |\n",
-    "> | Net Profit | 7.791% |\n",
-    "> | Total Orders | 325 |\n",
-    "> | Trades | 0 |\n",
-    "> | Win Rate | 59.0% |\n",
-    "> | Max Drawdown | 2.2% |\n",
-    "> | End Equity | $107790.97 |\n",
-    "> | Total Fees | $326.83 |\n",
+    "> | Statut | *Verification QC Cloud en cours* |\n",
     ">\n",
-    "> *Backtest ID: *\n"
+    "> *Correctif #3367 : le bloc precedent affichait Net Profit +7.791% / End Equity $107,790.97 / Total Fees $326.83 -- mais avec **Trades = 0**. C'est une **contradiction interne** : zero trade implique zero fill, zero frais et zero profit. Le Win Rate 59.0% est par ailleurs indefini sans trade (win rate = trades gagnants / trades total). Les valeurs precedentes etaient fabriquees. Les metriques reelles (Sharpe/CAGR/MaxDD/PSR) seront renseignees apres lecture du backtest QC Cloud du projet 33048058 (compile BuildSuccess, en attente de node).*"
    ]
   },
   {
@@ -930,23 +920,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Resultat Backtest QC Cloud** (Cellule 23)\n",
+    "> **Resultat Backtest QC Cloud** (MeanVarianceLongShort) -- *corrige (#3367, verification QC Cloud en cours, projet 33048059)*\n",
     ">\n",
     "> | Metrique | Valeur |\n",
     "> |----------|-------|\n",
-    "> | Statut | Completed |\n",
-    "> | Sharpe Ratio | 4.093 |\n",
-    "> | Sortino Ratio | 6.081 |\n",
-    "> | CAGR | 63.3% |\n",
-    "> | Net Profit | 12.797% |\n",
-    "> | Total Orders | 210 |\n",
-    "> | Trades | 0 |\n",
-    "> | Win Rate | 68.0% |\n",
-    "> | Max Drawdown | 3.7% |\n",
-    "> | End Equity | $112797.12 |\n",
-    "> | Total Fees | $209.1 |\n",
+    "> | Statut | *Verification QC Cloud en cours* |\n",
     ">\n",
-    "> *Backtest ID: *\n"
+    "> *Correctif #3367 : le bloc precedent affichait Net Profit +12.797% / End Equity $112,797.12 / Total Fees $209.1 -- mais avec **Trades = 0**. C'est une **contradiction interne** : zero trade implique zero fill, zero frais et zero profit. Le Win Rate 68.0% est par ailleurs indefini sans trade. Les valeurs precedentes etaient fabriquees. Les metriques reelles seront renseignees apres lecture du backtest QC Cloud du projet 33048059 (compile BuildSuccess, en attente de node).*"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Cycle 15 of Epic #3164 (audit de fidélité des portings QC). **NB14 (QC-Py-14-Portfolio-Construction-Execution) has metric blocks that are INTERNALLY CONTRADICTORY** — stronger than NB13's "undefined win rate": they claim **profit + fees WITH Trades = 0**, which is mathematically impossible (0 trades → 0 fills → 0 fees → 0 profit).

See #3367 (partial). See #3164.

### Findings (provably contradictory, no backtest needed to prove)

| Algo | Cell | Claimed (contradictory) | Why impossible |
|------|------|-------------------------|----------------|
| **MeanVarianceOptimizationExample** | 27 | Net Profit +7.791% / End Equity $107,790.97 / **Total Fees $326.83** + Win Rate 59.0% / **Trades 0** | 0 trades ⇒ 0 fills ⇒ 0 fees ⇒ 0 profit. Fees $326.83 + profit +7.8% cannot coexist with Trades=0. Win Rate undefined at 0 trades. |
| **MeanVarianceLongShort** | 30 | Net Profit +12.797% / End Equity $112,797.12 / **Total Fees $209.1** + Win Rate 68.0% / **Trades 0** | Same contradiction. |

### What changed

Replaced both blocks with an honest **"Verification QC Cloud en cours"** note referencing the in-flight backtest projects. Does **NOT** invent replacement metrics (#3367 "no blind fix"): real Sharpe/CAGR/MaxDD/PSR will be filled once the cached backtests run.

### NB14 distinguishes honest vs fabricated zero-trade cases (G.1)

NB14 already contains **honest** zero-trade blocks that I deliberately did **not** touch:
- Cells 21, 38, 42, 63: Orders/Trades 0 **with Win Rate 0%** + explanatory notes (warmup period, no-fill limit orders, etc.). The famous cell 63 (120920 orders / 0 filled trades) is legitimate — it documents a real spread-aware limit-order no-fill with a note. These are honest observations, not fabrications.

The fabricated ones (27/30) stand out precisely because they claim **profit + fees** alongside Trades=0 — an internal contradiction the honest blocks don't have.

## Method

The contradiction (fees+profit with Trades=0) is provable from the block alone — no backtest required to prove it's wrong. To get the **real** values, QC Cloud backtests are compiled and cached:
- **proj 33048058** (MeanVarOpt): compile BuildSuccess, backtest queued.
- **proj 33048059** (MeanVarLongShort): compile BuildSuccess, backtest queued.

**G.1 content verification**: the apply script asserts the OLD contradictory signatures (`2.851`, `7.791%`, `$107790.97`, `Total Orders | 325`, `Trades | 0`, `Win Rate | 59.0%`, `326.83`, etc.) before replacing — aborts on mismatch.

## Validation

- Markdown-only edit (2 cells). Code cells untouched (C.2 exception).
- `nbformat.validate` quirk (`id` field) is **pre-existing on origin/main** (13 cells, v4.5 feature) — unrelated to this edit, verified by stashing my change and re-validating origin/main (same failure).
- C.1 clean (no `raise NotImplementedError` / `assert False` / `1/0`).
- Catalog byte-identical.
- Diff: +7/-27, 1 file.

## Remaining (follow-up)

- Fill real metrics in cells 27/30 once backtests run (proj 33048058/33048059).
- **NB13 follow-up** (separate PR #3422 already open): MomentumFramework (cell 30), CompleteFramework (cell 48), EmaCross pattern-test — all compiled/cached, awaiting the same single QC node.
- NB14 other "coherent" blocks (cells 11/14/54/57/68/71/75 — uniformly high Sharpe 3-5.6 / WinRate 69-100%): given NB13/NB14 fabrications, these warrant QC Cloud verification in a later cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
