### PR TITLE
feat(sl-2): add Exercice 2 (RBL noisy attr) + Exercice 3 (EBL threshold) (#2161, #3429)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "0c89ba96",
    "metadata": {
     "papermill": {
-     "duration": 0.006,
-     "end_time": "2026-06-10T10:10:42.201942",
+     "duration": 0.024206,
+     "end_time": "2026-06-18T09:36:25.099447+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.195942",
+     "start_time": "2026-06-18T09:36:25.075241+00:00",
      "status": "completed"
     },
     "tags": []
@@ -45,16 +45,16 @@
    "id": "a0468061",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.211527Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.211527Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.227868Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.226868Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.129319Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.129057Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.146231Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.144074Z"
     },
     "papermill": {
-     "duration": 0.020847,
-     "end_time": "2026-06-10T10:10:42.227868",
+     "duration": 0.030442,
+     "end_time": "2026-06-18T09:36:25.148901+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.207021",
+     "start_time": "2026-06-18T09:36:25.118459+00:00",
      "status": "completed"
     },
     "tags": []
@@ -95,10 +95,10 @@
    "id": "6941f342",
    "metadata": {
     "papermill": {
-     "duration": 0.005503,
-     "end_time": "2026-06-10T10:10:42.237880",
+     "duration": 0.011053,
+     "end_time": "2026-06-18T09:36:25.173373+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.232377",
+     "start_time": "2026-06-18T09:36:25.162320+00:00",
      "status": "completed"
     },
     "tags": []
@@ -145,16 +145,16 @@
    "id": "5569731d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.248715Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.248715Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.257308Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.257308Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.189551Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.189371Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.197637Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.196588Z"
     },
     "papermill": {
-     "duration": 0.015764,
-     "end_time": "2026-06-10T10:10:42.258309",
+     "duration": 0.018361,
+     "end_time": "2026-06-18T09:36:25.199790+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.242545",
+     "start_time": "2026-06-18T09:36:25.181429+00:00",
      "status": "completed"
     },
     "tags": []
@@ -250,10 +250,10 @@
    "id": "a12264d8",
    "metadata": {
     "papermill": {
-     "duration": 0.004587,
-     "end_time": "2026-06-10T10:10:42.269894",
+     "duration": 0.006213,
+     "end_time": "2026-06-18T09:36:25.218840+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.265307",
+     "start_time": "2026-06-18T09:36:25.212627+00:00",
      "status": "completed"
     },
     "tags": []
@@ -276,10 +276,10 @@
    "id": "f666e94d",
    "metadata": {
     "papermill": {
-     "duration": 0.005666,
-     "end_time": "2026-06-10T10:10:42.280798",
+     "duration": 0.003259,
+     "end_time": "2026-06-18T09:36:25.226588+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.275132",
+     "start_time": "2026-06-18T09:36:25.223329+00:00",
      "status": "completed"
     },
     "tags": []
@@ -317,16 +317,16 @@
    "id": "945eff3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.292316Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.291805Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.303736Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.303139Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.233362Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.233199Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.241379Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.240737Z"
     },
     "papermill": {
-     "duration": 0.019324,
-     "end_time": "2026-06-10T10:10:42.304787",
+     "duration": 0.012701,
+     "end_time": "2026-06-18T09:36:25.242052+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.285463",
+     "start_time": "2026-06-18T09:36:25.229351+00:00",
      "status": "completed"
     },
     "tags": []
@@ -442,10 +442,10 @@
    "id": "4bb3bfc1",
    "metadata": {
     "papermill": {
-     "duration": 0.005659,
-     "end_time": "2026-06-10T10:10:42.315631",
+     "duration": 0.004566,
+     "end_time": "2026-06-18T09:36:25.251468+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.309972",
+     "start_time": "2026-06-18T09:36:25.246902+00:00",
      "status": "completed"
     },
     "tags": []
@@ -468,10 +468,10 @@
    "id": "a03df116",
    "metadata": {
     "papermill": {
-     "duration": 0.005742,
-     "end_time": "2026-06-10T10:10:42.326110",
+     "duration": 0.003632,
+     "end_time": "2026-06-18T09:36:25.258440+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.320368",
+     "start_time": "2026-06-18T09:36:25.254808+00:00",
      "status": "completed"
     },
     "tags": []
@@ -499,16 +499,16 @@
    "id": "58666a2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.339638Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.339638Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.349673Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.348583Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.266911Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.266711Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.272748Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.272204Z"
     },
     "papermill": {
-     "duration": 0.018935,
-     "end_time": "2026-06-10T10:10:42.350711",
+     "duration": 0.01059,
+     "end_time": "2026-06-18T09:36:25.273137+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.331776",
+     "start_time": "2026-06-18T09:36:25.262547+00:00",
      "status": "completed"
     },
     "tags": []
@@ -591,10 +591,10 @@
    "id": "0bbc55d8",
    "metadata": {
     "papermill": {
-     "duration": 0.005155,
-     "end_time": "2026-06-10T10:10:42.361551",
+     "duration": 0.003481,
+     "end_time": "2026-06-18T09:36:25.280246+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.356396",
+     "start_time": "2026-06-18T09:36:25.276765+00:00",
      "status": "completed"
     },
     "tags": []
@@ -609,16 +609,16 @@
    "id": "2804a17a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.373961Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.373450Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.380945Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.379627Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.301801Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.301055Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.312822Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.311411Z"
     },
     "papermill": {
-     "duration": 0.014205,
-     "end_time": "2026-06-10T10:10:42.381467",
+     "duration": 0.028207,
+     "end_time": "2026-06-18T09:36:25.314290+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.367262",
+     "start_time": "2026-06-18T09:36:25.286083+00:00",
      "status": "completed"
     },
     "tags": []
@@ -717,10 +717,10 @@
    "id": "e8a85fbd",
    "metadata": {
     "papermill": {
-     "duration": 0.005695,
-     "end_time": "2026-06-10T10:10:42.393362",
+     "duration": 0.008752,
+     "end_time": "2026-06-18T09:36:25.335971+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.387667",
+     "start_time": "2026-06-18T09:36:25.327219+00:00",
      "status": "completed"
     },
     "tags": []
@@ -744,10 +744,10 @@
    "id": "95c1f106",
    "metadata": {
     "papermill": {
-     "duration": 0.006197,
-     "end_time": "2026-06-10T10:10:42.405367",
+     "duration": 0.00305,
+     "end_time": "2026-06-18T09:36:25.345046+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.399170",
+     "start_time": "2026-06-18T09:36:25.341996+00:00",
      "status": "completed"
     },
     "tags": []
@@ -773,16 +773,16 @@
    "id": "1b6b6247",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.418875Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.417875Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.427383Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.426383Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.352997Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.352772Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.364440Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.362367Z"
     },
     "papermill": {
-     "duration": 0.017508,
-     "end_time": "2026-06-10T10:10:42.428383",
+     "duration": 0.018043,
+     "end_time": "2026-06-18T09:36:25.366224+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.410875",
+     "start_time": "2026-06-18T09:36:25.348181+00:00",
      "status": "completed"
     },
     "tags": []
@@ -883,10 +883,10 @@
    "id": "3a8e6838",
    "metadata": {
     "papermill": {
-     "duration": 0.005703,
-     "end_time": "2026-06-10T10:10:42.439910",
+     "duration": 0.008205,
+     "end_time": "2026-06-18T09:36:25.384250+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.434207",
+     "start_time": "2026-06-18T09:36:25.376045+00:00",
      "status": "completed"
     },
     "tags": []
@@ -910,10 +910,10 @@
    "id": "d5e7f465",
    "metadata": {
     "papermill": {
-     "duration": 0.005653,
-     "end_time": "2026-06-10T10:10:42.450775",
+     "duration": 0.008107,
+     "end_time": "2026-06-18T09:36:25.402295+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.445122",
+     "start_time": "2026-06-18T09:36:25.394188+00:00",
      "status": "completed"
     },
     "tags": []
@@ -945,16 +945,16 @@
    "id": "750b1f6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.463282Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.462769Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.489726Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.488725Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.417624Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.417100Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.436965Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.436410Z"
     },
     "papermill": {
-     "duration": 0.034198,
-     "end_time": "2026-06-10T10:10:42.490646",
+     "duration": 0.028562,
+     "end_time": "2026-06-18T09:36:25.437453+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.456448",
+     "start_time": "2026-06-18T09:36:25.408891+00:00",
      "status": "completed"
     },
     "tags": []
@@ -986,6 +986,16 @@
       "  1. ArithmeticUnknown(z) => Simplify(1*(0+z), (z))\n",
       "  2. ArithmeticUnknown(v) => Simplify(1*v, v)\n",
       "  3. ArithmeticUnknown(w) => Simplify(0+w, w)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<>:141: SyntaxWarning: invalid escape sequence '\\*'\n",
+      "<>:141: SyntaxWarning: invalid escape sequence '\\*'\n",
+      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_59880\\2657864012.py:141: SyntaxWarning: invalid escape sequence '\\*'\n",
+      "  Le pattern \"1*(0+z)\" devient la regex r\"1\\*\\(0\\+(\\w+)\\)\" : chaque\n"
      ]
     }
    ],
@@ -1197,10 +1207,10 @@
    "id": "c52b429c",
    "metadata": {
     "papermill": {
-     "duration": 0.007704,
-     "end_time": "2026-06-10T10:10:42.504583",
+     "duration": 0.004534,
+     "end_time": "2026-06-18T09:36:25.445756+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.496879",
+     "start_time": "2026-06-18T09:36:25.441222+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1226,10 +1236,10 @@
    "id": "149b52a3",
    "metadata": {
     "papermill": {
-     "duration": 0.004999,
-     "end_time": "2026-06-10T10:10:42.513584",
+     "duration": 0.004351,
+     "end_time": "2026-06-18T09:36:25.455299+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.508585",
+     "start_time": "2026-06-18T09:36:25.450948+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1260,16 +1270,16 @@
    "id": "1bf94123",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.527831Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.527303Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.536832Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.535832Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.463783Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.463592Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.470546Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.469343Z"
     },
     "papermill": {
-     "duration": 0.016525,
-     "end_time": "2026-06-10T10:10:42.536832",
+     "duration": 0.012726,
+     "end_time": "2026-06-18T09:36:25.471858+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.520307",
+     "start_time": "2026-06-18T09:36:25.459132+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1364,10 +1374,10 @@
    "id": "c4c050aa",
    "metadata": {
     "papermill": {
-     "duration": 0.008002,
-     "end_time": "2026-06-10T10:10:42.549340",
+     "duration": 0.003841,
+     "end_time": "2026-06-18T09:36:25.481329+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.541338",
+     "start_time": "2026-06-18T09:36:25.477488+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1395,10 +1405,10 @@
    "id": "485b6968",
    "metadata": {
     "papermill": {
-     "duration": 0.005626,
-     "end_time": "2026-06-10T10:10:42.559967",
+     "duration": 0.004326,
+     "end_time": "2026-06-18T09:36:25.490138+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.554341",
+     "start_time": "2026-06-18T09:36:25.485812+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1434,16 +1444,16 @@
    "id": "9649140c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.573192Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.572670Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.583372Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.582596Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.499292Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.499123Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.506367Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.505651Z"
     },
     "papermill": {
-     "duration": 0.018618,
-     "end_time": "2026-06-10T10:10:42.584597",
+     "duration": 0.013154,
+     "end_time": "2026-06-18T09:36:25.507201+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.565979",
+     "start_time": "2026-06-18T09:36:25.494047+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1547,10 +1557,10 @@
    "id": "b02799f6",
    "metadata": {
     "papermill": {
-     "duration": 0.006041,
-     "end_time": "2026-06-10T10:10:42.596275",
+     "duration": 0.004262,
+     "end_time": "2026-06-18T09:36:25.515443+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.590234",
+     "start_time": "2026-06-18T09:36:25.511181+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1575,10 +1585,10 @@
    "id": "7a891be0",
    "metadata": {
     "papermill": {
-     "duration": 0.00551,
-     "end_time": "2026-06-10T10:10:42.607808",
+     "duration": 0.003553,
+     "end_time": "2026-06-18T09:36:25.523440+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.602298",
+     "start_time": "2026-06-18T09:36:25.519887+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1596,10 +1606,10 @@
    "id": "d971dcd5",
    "metadata": {
     "papermill": {
-     "duration": 0.006137,
-     "end_time": "2026-06-10T10:10:42.619957",
+     "duration": 0.004483,
+     "end_time": "2026-06-18T09:36:25.546699+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.613820",
+     "start_time": "2026-06-18T09:36:25.542216+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1634,7 +1644,16 @@
   {
    "cell_type": "markdown",
    "id": "sl2-guided1-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006623,
+     "end_time": "2026-06-18T09:36:25.564679+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.558056+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exemple guidé 1 : l'EBL appliqué à la différentiation symbolique\n",
     "\n",
@@ -1649,16 +1668,16 @@
    "id": "d8492780",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.634137Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.633594Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.646340Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.645178Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.588866Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.588273Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.611134Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.609553Z"
     },
     "papermill": {
-     "duration": 0.021166,
-     "end_time": "2026-06-10T10:10:42.647387",
+     "duration": 0.038266,
+     "end_time": "2026-06-18T09:36:25.612518+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.626221",
+     "start_time": "2026-06-18T09:36:25.574252+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1787,7 +1806,16 @@
   {
    "cell_type": "markdown",
    "id": "sl2-ex1-variation-md",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00403,
+     "end_time": "2026-06-18T09:36:25.622509+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.618479+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 (variation) : EBL sur le carre d/dx(u*u)\n",
     "\n",
@@ -1802,9 +1830,24 @@
   },
   {
    "cell_type": "code",
-   "id": "sl2-ex1-variation-stub",
    "execution_count": 11,
-   "metadata": {},
+   "id": "sl2-ex1-variation-stub",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-18T09:36:25.633412Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.633138Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.638197Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.637021Z"
+    },
+    "papermill": {
+     "duration": 0.013039,
+     "end_time": "2026-06-18T09:36:25.639316+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.626277+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1829,10 +1872,10 @@
    "id": "94f38997",
    "metadata": {
     "papermill": {
-     "duration": 0.00563,
-     "end_time": "2026-06-10T10:10:42.659318",
+     "duration": 0.005971,
+     "end_time": "2026-06-18T09:36:25.653252+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.653688",
+     "start_time": "2026-06-18T09:36:25.647281+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1855,16 +1898,16 @@
    "id": "5835c6f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.673034Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.673034Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.692196Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.691083Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.662569Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.662400Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.671113Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.670312Z"
     },
     "papermill": {
-     "duration": 0.027903,
-     "end_time": "2026-06-10T10:10:42.693228",
+     "duration": 0.013759,
+     "end_time": "2026-06-18T09:36:25.671737+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.665325",
+     "start_time": "2026-06-18T09:36:25.657978+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1990,7 +2033,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8b4523f4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003603,
+     "end_time": "2026-06-18T09:36:25.679120+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.675517+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : l'EBL n'est rentable que si les regles sont reutilisees\n",
     "\n",
@@ -2009,10 +2062,10 @@
    "id": "8a44d796",
    "metadata": {
     "papermill": {
-     "duration": 0.005601,
-     "end_time": "2026-06-10T10:10:42.704526",
+     "duration": 0.003985,
+     "end_time": "2026-06-18T09:36:25.686911+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.698925",
+     "start_time": "2026-06-18T09:36:25.682926+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2034,16 +2087,16 @@
    "id": "d4d1535a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-10T10:10:42.717093Z",
-     "iopub.status.busy": "2026-06-10T10:10:42.717093Z",
-     "iopub.status.idle": "2026-06-10T10:10:42.723664Z",
-     "shell.execute_reply": "2026-06-10T10:10:42.723115Z"
+     "iopub.execute_input": "2026-06-18T09:36:25.697473Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.697132Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.725994Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.725037Z"
     },
     "papermill": {
-     "duration": 0.014614,
-     "end_time": "2026-06-10T10:10:42.724669",
+     "duration": 0.035562,
+     "end_time": "2026-06-18T09:36:25.727032+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.710055",
+     "start_time": "2026-06-18T09:36:25.691470+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2053,7 +2106,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ebl_without : 0 regle apprise (base KB seule)\n",
+      "ebl_without : 0 regle apprise (base KB seule)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "ebl_with    : 3 regles apprises\n",
       "\n",
       "Corpus : 100 expressions (34 profondes, 33 shallow, 33 nomatch)\n",
@@ -2070,22 +2130,16 @@
       "  profond    |     68 |     34 |   +34\n",
       "  shallow    |     33 |     33 |    +0\n",
       "  nomatch    |      0 |      0 |    +0\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\n",
       "=== Metrique secondaire : temps wall-clock (mediane sur 20 runs) ===\n",
-      "  Sans EBL :   517.8 us\n",
-      "  Avec EBL :   855.6 us\n",
-      "  Ratio (sans/avec) : 0.61x\n",
+      "  Sans EBL :   218.5 us\n",
+      "  Avec EBL :   492.0 us\n",
+      "  Ratio (sans/avec) : 0.44x\n",
       "  NB : bruite par la charge CPU ; le classement wall-clock peut DIFFERER\n",
       "       du classement en etapes -- voir l'interpretation ci-dessous.\n",
       "\n",
       "=== Reponses aux questions (mesure reelle) ===\n",
-      "Q1 Speedup moyen : 1.51x en ETAPES (34% de reduction). Mais en TEMPS wall-clock, l'EBL est ici plus LENT (0.61x) -- voir interpretation.\n",
+      "Q1 Speedup moyen : 1.51x en ETAPES (34% de reduction). Mais en TEMPS wall-clock, l'EBL est ici plus LENT (0.44x) -- voir interpretation.\n",
       "Q2 Depend du type : OUI. Seules les expressions PROFONDES beneficient\n",
       "   de l'EBL (34 etapes gagnees) ; les SHALLOW et NON-MATCH sont neutres (0 etape gagnee).\n",
       "Q3 Point de bascule memoire : l'EBL paie son surcout (stocker une regle)\n",
@@ -2204,7 +2258,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "0f0ca933",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004475,
+     "end_time": "2026-06-18T09:36:25.735875+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.731400+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : le speedup de l'EBL est algorithmique, pas (toujours) wall-clock\n",
     "\n",
@@ -2228,13 +2292,171 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a5b02915",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004484,
+     "end_time": "2026-06-18T09:36:25.745325+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.740841+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 (variation) : RBL robuste face a un attribut bruite\n",
+    "\n",
+    "La section 7 a montre que `nationality` **determine** seul la langue, tandis que `age` et `city` ne la determinent pas (table idx24). Une question naturelle : que se passe-t-il si l'on **ajoute** un attribut totalement decorrele (un bruit) aux donnees ? RBL doit rester robuste : la determination minimale `nationality -> language` ne doit pas changer.\n",
+    "\n",
+    "Ajoutez un 5e attribut `forecaster` (le nom du meteorologue, sans aucun lien avec la langue) a chaque ligne de `nationality_data`, puis verifiez que la determination minimale est toujours `nationality`.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Construisez `nationality_noisy` en ajoutant `forecaster` (valeurs arbitraires : `\"Alice\", \"Bob\", ...`) a chaque ligne via `dict(row, forecaster=f)`.\n",
+    "2. Ajoutez `\"forecaster\"` a `ALL_ATTRS`.\n",
+    "3. Re-testez `check_determination` sur `[\"nationality\"]`, `[\"forecaster\"]`, `[\"nationality\", \"forecaster\"]`.\n",
+    "4. Confirmez : `nationality -> language` reste **True**, `forecaster -> language` est **False**.\n",
+    "\n",
+    "**Indice** : `check_determination` groupe les lignes par les valeurs de `det_attrs`. Un attribut bruite ajoute des groupes sans reduire les violations -- la recherche par taille croissante (cf. SL-3 `MINIMAL-CONSISTENT-DET`) saute donc naturellement les attributs non pertinents. C'est le **fondement de la robustesse de RBL au bruit**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "da5d87a2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-18T09:36:25.761750Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.761560Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.765365Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.764563Z"
+    },
+    "papermill": {
+     "duration": 0.012391,
+     "end_time": "2026-06-18T09:36:25.765917+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.753526+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : robustesse de RBL face a un attribut bruite\n",
+      "Question : la determination minimale reste-t-elle nationality -> language ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (variation) : RBL robuste face a un attribut bruite\n",
+    "# TODO etudiant : ajoutez un attribut 'forecaster' decorrele et confirmez la robustesse de RBL.\n",
+    "# Etape 1 : construire nationality_noisy avec un attribut bruite 'forecaster'\n",
+    "#   forecasters = [\"MeteoA\", \"MeteoB\", \"MeteoA\", \"MeteoB\", \"MeteoA\", \"MeteoB\",\n",
+    "#                  \"MeteoA\", \"MeteoB\", \"MeteoA\", \"MeteoB\", \"MeteoA\", \"MeteoB\"]\n",
+    "#   nationality_noisy = [dict(row, forecaster=f) for row, f in zip(nationality_data, forecasters)]\n",
+    "# Etape 2 : etendre la liste des attributs candidats\n",
+    "#   noisy_attrs = ALL_ATTRS + [\"forecaster\"]\n",
+    "# Etape 3 : re-tester les determinations\n",
+    "#   print(check_determination(nationality_noisy, [\"nationality\"], \"language\"))          # attendu True\n",
+    "#   print(check_determination(nationality_noisy, [\"forecaster\"], \"language\"))           # attendu False\n",
+    "#   print(check_determination(nationality_noisy, [\"nationality\", \"forecaster\"], \"language\"))  # True (redondant)\n",
+    "# Indice : un attribut non pertinent ajoute des groupes sans eliminer de violations -> RBL l'ecarte.\n",
+    "print(\"Exercice a completer : robustesse de RBL face a un attribut bruite\")\n",
+    "print(\"Question : la determination minimale reste-t-elle nationality -> language ?\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46d50746",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006628,
+     "end_time": "2026-06-18T09:36:25.776828+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.770200+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (variation) : EBL operationalite -- faire varier le seuil de desapprentissage\n",
+    "\n",
+    "L'Exemple guide 2 a fixe `min_usage=2` et observe que la regle `0+w` (1 utilisation) est desapprise tandis que `1*(0+z)` (8) et `1*v` (2) sont conservees. Mais le seuil est un **parametre libre** : sa valeur decide quelles regles survivent. Faites-le varier et observez la frontiere d'operationalite -- c'est le **utility problem** de Minton (1990) introduit dans l'interpretation de l'Exemple guide 3.\n",
+    "\n",
+    "Reutilisez `count_rule_usage` et `prune_learned_rules` de l'Exemple guide 2, et tabulez le nombre de regles conservees pour plusieurs seuils.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Reconstruisez une instance `ArithmeticEBL` fraiche et apprenez-lui les 3 regles (`1*(0+x)`, `1*y`, `0+u`).\n",
+    "2. Recomptez les utilisations sur le **meme corpus** que l'Exemple guide 2 (12 expressions).\n",
+    "3. Pour `min_usage` dans `{1, 2, 3, 5}`, appliquez `prune_learned_rules` et affichez le nombre de regles conservees + leurs patterns.\n",
+    "4. Observez : a partir de quel seuil la regle la **plus reutilisee** (`1*(0+z)`) est-elle elle-meme desapprise ? Pourquoi cela illustre-t-il que le seuil traduit un compromis biais-variance ?\n",
+    "\n",
+    "**Indice** : chaque regle a un *compte d'utilisation fixe* sur un corpus donne. Le seuil ne fait que selectionner un *prefixe* du classement par utilisation decroissante. Un seuil trop eleve = base sous-apprise (perte de speedup) ; un seuil trop bas = proliferation (utility problem). Le seuil optimal depend du **corpus reel futur**, qui est inconnu -- d'ou l'eternel compromis.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d254f41d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-18T09:36:25.797837Z",
+     "iopub.status.busy": "2026-06-18T09:36:25.797595Z",
+     "iopub.status.idle": "2026-06-18T09:36:25.803820Z",
+     "shell.execute_reply": "2026-06-18T09:36:25.802290Z"
+    },
+    "papermill": {
+     "duration": 0.016553,
+     "end_time": "2026-06-18T09:36:25.805376+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.788823+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : frontiere d'operationalite selon le seuil de desapprentissage\n",
+      "Question : a quel seuil disparait la regle la plus reutilisee ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (variation) : faire varier le seuil de desapprentissage (utility problem)\n",
+    "# TODO etudiant : tabulez le nombre de regles conservees selon min_usage.\n",
+    "# Etape 1 : instance fraiche + 3 regles apprises\n",
+    "#   ebl = ArithmeticEBL()\n",
+    "#   ebl.learn(\"1*(0+x)\", {\"x\": \"z\"}, verbose=False)\n",
+    "#   ebl.learn(\"1*y\", {\"y\": \"v\"}, verbose=False)\n",
+    "#   ebl.learn(\"0+u\", {\"u\": \"w\"}, verbose=False)\n",
+    "# Etape 2 : recompter les utilisations sur le meme corpus (12 expressions) que l'Exemple guide 2\n",
+    "#   corpus = [\"1*(0+a)\", \"1*(0+b)\", \"1*(0+c)\", \"1*(0+d)\", \"1*(0+e)\", \"1*(0+f)\",\n",
+    "#             \"1*(0+g)\", \"1*(0+h)\", \"1*y\", \"0+w\", \"1*nomatch\", \"2+3\"]\n",
+    "#   usage = count_rule_usage(ebl, corpus)\n",
+    "# Etape 3 : tabuler pour min_usage dans {1, 2, 3, 5}\n",
+    "#   for seuil in [1, 2, 3, 5]:\n",
+    "#       conservees = prune_learned_rules(ebl, usage, min_usage=seuil)\n",
+    "#       print(f\"min_usage={seuil} : {len(conservees)} regles conservees -> \"\n",
+    "#             f\"{[r.pattern for r in conservees]}\")\n",
+    "# Question : a partir de quel seuil la regle 1*(0+z) (la plus reutilisee) est-elle desapprise ?\n",
+    "print(\"Exercice a completer : frontiere d'operationalite selon le seuil de desapprentissage\")\n",
+    "print(\"Question : a quel seuil disparait la regle la plus reutilisee ?\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "864f2055",
    "metadata": {
     "papermill": {
-     "duration": 0.006014,
-     "end_time": "2026-06-10T10:10:42.736722",
+     "duration": 0.009378,
+     "end_time": "2026-06-18T09:36:25.823170+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.730708",
+     "start_time": "2026-06-18T09:36:25.813792+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2251,7 +2473,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7a854bc0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005147,
+     "end_time": "2026-06-18T09:36:25.833909+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T09:36:25.828762+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -2274,10 +2506,10 @@
    "id": "42508ff0",
    "metadata": {
     "papermill": {
-     "duration": 0.005534,
-     "end_time": "2026-06-10T10:10:42.748339",
+     "duration": 0.00936,
+     "end_time": "2026-06-18T09:36:25.851631+00:00",
      "exception": false,
-     "start_time": "2026-06-10T10:10:42.742805",
+     "start_time": "2026-06-18T09:36:25.842271+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2314,18 +2546,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.616051,
-   "end_time": "2026-06-10T10:10:42.990659",
+   "duration": 6.509918,
+   "end_time": "2026-06-18T09:36:26.146221+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SL-2-KnowledgeBasedLearning.ipynb",
-   "output_path": "SL-2-KnowledgeBasedLearning.ipynb",
+   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-2-KnowledgeBasedLearning.ipynb",
+   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-2-KnowledgeBasedLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-10T10:10:40.374608",
+   "start_time": "2026-06-18T09:36:19.636303+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
@@ -2554,8 +2554,8 @@
    "end_time": "2026-06-18T09:36:26.146221+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-2-KnowledgeBasedLearning.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-2-KnowledgeBasedLearning_output.ipynb",
+   "input_path": "SL-2-KnowledgeBasedLearning.ipynb",
+   "output_path": "SL-2-KnowledgeBasedLearning.ipynb",
    "parameters": {},
    "start_time": "2026-06-18T09:36:19.636303+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## Convention #2161 — SL-2-KnowledgeBasedLearning : 2 exercices (variation) ajoutés

See #2161, #3429.

`SL-2-KnowledgeBasedLearning.ipynb` était le seul notebook sub-threshold (2/3) de la partition po-2025. Ses 3 exercices originaux ayant été résolus en Exemples guides (#3205/#3261/#3265), il ne restait qu'1 variation. Aligné à la convention de la série (jumeau **SL-3 = 3 exercices variation**) en ajoutant 2 stubs, **sans toucher aux exemples résolus**.

### Ajouts (entre Exemple guide 3 et Résumé)

| Exercice | Variation sur | Concept exercé |
|----------|---------------|----------------|
| **Exercice 2 (variation)** | §7 RBL determinations (`check_determination`, `nationality_data` — terrain non couvert par un exemple guide) | Robustesse de RBL à un attribut bruité — mirror du SL-3 Exercice 1 |
| **Exercice 3 (variation)** | Exemple guide 2 `prune_learned_rules(min_usage)` | Frontière d'operationalité en fonction du seuil — utility problem (Minton 1990) |

Chaque exercice : markdown (contexte + étapes numérotées + indice) + stub code C.1-conforme (`print("Exercice a completer...")` + étapes commentées, jamais `raise NotImplementedError`).

### Garanties & gates

- **Anti-régression** : 13→15 cellules code, exactement +2 stubs ; les 3 Exemples guides résolus **source byte-identique**.
- **Exécution réelle** : papermill kernel `python3`, 8s, **0 erreur** end-to-end (stubs avec `execution_count` + outputs).
- G0 `count_exercises.py` : **2/3 → 3/3 conforme**.
- G1 `scan_cell_ordering.py` : 1 clean, 0 finding.
- G2 `check_c2_compliance.py` : 1/1 compliant.
- G3 `notebook_tools.py validate` : OK 0, Errors 0 (1 warning « Cell 2 unbalanced LaTeX » **pré-existant** sur origin/main, faux-positif du validateur).

### Churn output bénin (transparence)

Ré-exécution complète (règle C.2). Nombres **déterministes identiques** (Exemple guide 3 : 101/67 etapes, 1.51x speedup, +34 profond — stables). Fluctuations non-déterministes : (a) wall-clock times de l'Exemple guide 3 (documentés « bruités » dans la prose idx36) ; (b) un `SyntaxWarning: invalid escape sequence '\*'` sur idx6 provenant d'une **docstring pré-existante** de `_match_learned` (non touchée), révélé par Python 3.12+ — cosmétique pré-existant, hors-scope, documenté sans correction.

Détail complet : #3429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
