### PR TITLE
feat(pymc-10): add functional PyMC MCMC model (Beta-Bernoulli reliability) (#3346)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing.ipynb
@@ -2156,8 +2156,8 @@
    "end_time": "2026-06-18T10:15:06.560753+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-10-Crowdsourcing.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-10-Crowdsourcing_output.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing_output.ipynb",
    "parameters": {},
    "start_time": "2026-06-18T10:14:29.842503+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing.ipynb
@@ -5,10 +5,10 @@
    "id": "6e4e70c2",
    "metadata": {
     "papermill": {
-     "duration": 0.026431,
-     "end_time": "2026-06-03T00:03:23.517096+00:00",
+     "duration": 0.023194,
+     "end_time": "2026-06-18T10:14:31.774359+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:23.490665+00:00",
+     "start_time": "2026-06-18T10:14:31.751165+00:00",
      "status": "completed"
     },
     "tags": []
@@ -39,16 +39,16 @@
    "id": "05b8c632",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:23.590492Z",
-     "iopub.status.busy": "2026-06-03T00:03:23.588367Z",
-     "iopub.status.idle": "2026-06-03T00:03:24.792926Z",
-     "shell.execute_reply": "2026-06-03T00:03:24.792926Z"
+     "iopub.execute_input": "2026-06-18T10:14:31.790945Z",
+     "iopub.status.busy": "2026-06-18T10:14:31.790945Z",
+     "iopub.status.idle": "2026-06-18T10:14:33.200443Z",
+     "shell.execute_reply": "2026-06-18T10:14:33.198384Z"
     },
     "papermill": {
-     "duration": 1.228064,
-     "end_time": "2026-06-03T00:03:24.795390+00:00",
+     "duration": 1.435114,
+     "end_time": "2026-06-18T10:14:33.219953+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:23.567326+00:00",
+     "start_time": "2026-06-18T10:14:31.784839+00:00",
      "status": "completed"
     },
     "tags": []
@@ -111,10 +111,10 @@
    "id": "c0557a38",
    "metadata": {
     "papermill": {
-     "duration": 0.007132,
-     "end_time": "2026-06-03T00:03:24.808911+00:00",
+     "duration": 0.023279,
+     "end_time": "2026-06-18T10:14:33.295665+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:24.801779+00:00",
+     "start_time": "2026-06-18T10:14:33.272386+00:00",
      "status": "completed"
     },
     "tags": []
@@ -131,16 +131,16 @@
    "id": "5bdce55d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:24.820642Z",
-     "iopub.status.busy": "2026-06-03T00:03:24.820642Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.393578Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.393578Z"
+     "iopub.execute_input": "2026-06-18T10:14:33.319708Z",
+     "iopub.status.busy": "2026-06-18T10:14:33.318588Z",
+     "iopub.status.idle": "2026-06-18T10:14:50.890916Z",
+     "shell.execute_reply": "2026-06-18T10:14:50.889896Z"
     },
     "papermill": {
-     "duration": 7.581017,
-     "end_time": "2026-06-03T00:03:32.396370+00:00",
+     "duration": 17.580017,
+     "end_time": "2026-06-18T10:14:50.892394+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:24.815353+00:00",
+     "start_time": "2026-06-18T10:14:33.312377+00:00",
      "status": "completed"
     },
     "tags": []
@@ -196,10 +196,10 @@
    "id": "ba095669",
    "metadata": {
     "papermill": {
-     "duration": 0.006303,
-     "end_time": "2026-06-03T00:03:32.408998+00:00",
+     "duration": 0.007269,
+     "end_time": "2026-06-18T10:14:50.908292+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.402695+00:00",
+     "start_time": "2026-06-18T10:14:50.901023+00:00",
      "status": "completed"
     },
     "tags": []
@@ -227,10 +227,10 @@
    "id": "44120f38",
    "metadata": {
     "papermill": {
-     "duration": 0.007856,
-     "end_time": "2026-06-03T00:03:32.423066+00:00",
+     "duration": 0.005689,
+     "end_time": "2026-06-18T10:14:50.919510+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.415210+00:00",
+     "start_time": "2026-06-18T10:14:50.913821+00:00",
      "status": "completed"
     },
     "tags": []
@@ -247,16 +247,16 @@
    "id": "a5975393",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.438366Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.437353Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.448759Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.447746Z"
+     "iopub.execute_input": "2026-06-18T10:14:50.932044Z",
+     "iopub.status.busy": "2026-06-18T10:14:50.932044Z",
+     "iopub.status.idle": "2026-06-18T10:14:50.941289Z",
+     "shell.execute_reply": "2026-06-18T10:14:50.940264Z"
     },
     "papermill": {
-     "duration": 0.02051,
-     "end_time": "2026-06-03T00:03:32.450614+00:00",
+     "duration": 0.017198,
+     "end_time": "2026-06-18T10:14:50.942608+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.430104+00:00",
+     "start_time": "2026-06-18T10:14:50.925410+00:00",
      "status": "completed"
     },
     "tags": []
@@ -326,10 +326,10 @@
    "id": "aab34424",
    "metadata": {
     "papermill": {
-     "duration": 0.006079,
-     "end_time": "2026-06-03T00:03:32.462661+00:00",
+     "duration": 0.006084,
+     "end_time": "2026-06-18T10:14:50.954357+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.456582+00:00",
+     "start_time": "2026-06-18T10:14:50.948273+00:00",
      "status": "completed"
     },
     "tags": []
@@ -352,10 +352,10 @@
    "id": "f2072d1f",
    "metadata": {
     "papermill": {
-     "duration": 0.005532,
-     "end_time": "2026-06-03T00:03:32.474286+00:00",
+     "duration": 0.00537,
+     "end_time": "2026-06-18T10:14:50.966059+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.468754+00:00",
+     "start_time": "2026-06-18T10:14:50.960689+00:00",
      "status": "completed"
     },
     "tags": []
@@ -372,16 +372,16 @@
    "id": "c765e506",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.485501Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.485501Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.493383Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.493383Z"
+     "iopub.execute_input": "2026-06-18T10:14:50.979401Z",
+     "iopub.status.busy": "2026-06-18T10:14:50.979401Z",
+     "iopub.status.idle": "2026-06-18T10:14:50.988129Z",
+     "shell.execute_reply": "2026-06-18T10:14:50.987097Z"
     },
     "papermill": {
-     "duration": 0.016621,
-     "end_time": "2026-06-03T00:03:32.496492+00:00",
+     "duration": 0.016741,
+     "end_time": "2026-06-18T10:14:50.989098+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.479871+00:00",
+     "start_time": "2026-06-18T10:14:50.972357+00:00",
      "status": "completed"
     },
     "tags": []
@@ -425,10 +425,10 @@
    "id": "2a6a8c8e",
    "metadata": {
     "papermill": {
-     "duration": 0.007241,
-     "end_time": "2026-06-03T00:03:32.510818+00:00",
+     "duration": 0.005955,
+     "end_time": "2026-06-18T10:14:51.002203+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.503577+00:00",
+     "start_time": "2026-06-18T10:14:50.996248+00:00",
      "status": "completed"
     },
     "tags": []
@@ -444,10 +444,10 @@
    "id": "6f780329",
    "metadata": {
     "papermill": {
-     "duration": 0.006508,
-     "end_time": "2026-06-03T00:03:32.524349+00:00",
+     "duration": 0.006689,
+     "end_time": "2026-06-18T10:14:51.016541+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.517841+00:00",
+     "start_time": "2026-06-18T10:14:51.009852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -471,16 +471,16 @@
    "id": "8c4a5450",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.539206Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.539206Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.545391Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.544216Z"
+     "iopub.execute_input": "2026-06-18T10:14:51.030039Z",
+     "iopub.status.busy": "2026-06-18T10:14:51.029051Z",
+     "iopub.status.idle": "2026-06-18T10:14:51.034934Z",
+     "shell.execute_reply": "2026-06-18T10:14:51.034153Z"
     },
     "papermill": {
-     "duration": 0.016274,
-     "end_time": "2026-06-03T00:03:32.547252+00:00",
+     "duration": 0.013273,
+     "end_time": "2026-06-18T10:14:51.036229+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.530978+00:00",
+     "start_time": "2026-06-18T10:14:51.022956+00:00",
      "status": "completed"
     },
     "tags": []
@@ -510,10 +510,10 @@
    "id": "72d13867",
    "metadata": {
     "papermill": {
-     "duration": 0.006827,
-     "end_time": "2026-06-03T00:03:32.561888+00:00",
+     "duration": 0.006559,
+     "end_time": "2026-06-18T10:14:51.049763+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.555061+00:00",
+     "start_time": "2026-06-18T10:14:51.043204+00:00",
      "status": "completed"
     },
     "tags": []
@@ -551,16 +551,16 @@
    "id": "c5848a1b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.576568Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.575471Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.588434Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.586927Z"
+     "iopub.execute_input": "2026-06-18T10:14:51.063015Z",
+     "iopub.status.busy": "2026-06-18T10:14:51.063015Z",
+     "iopub.status.idle": "2026-06-18T10:14:51.077445Z",
+     "shell.execute_reply": "2026-06-18T10:14:51.076914Z"
     },
     "papermill": {
-     "duration": 0.02142,
-     "end_time": "2026-06-03T00:03:32.589681+00:00",
+     "duration": 0.022913,
+     "end_time": "2026-06-18T10:14:51.079078+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.568261+00:00",
+     "start_time": "2026-06-18T10:14:51.056165+00:00",
      "status": "completed"
     },
     "tags": []
@@ -570,7 +570,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Modele Honest Worker pour Item 2 ===\n",
+      "=== Modele Honest Worker pour Item 2 ==="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "Labels observes : [1 1 0 1]\n",
       "Vrai label : 1\n",
       "\n",
@@ -649,10 +656,10 @@
    "id": "0d8c6371",
    "metadata": {
     "papermill": {
-     "duration": 0.006711,
-     "end_time": "2026-06-03T00:03:32.606579+00:00",
+     "duration": 0.007087,
+     "end_time": "2026-06-18T10:14:51.093088+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.599868+00:00",
+     "start_time": "2026-06-18T10:14:51.086001+00:00",
      "status": "completed"
     },
     "tags": []
@@ -669,16 +676,16 @@
    "id": "45706347",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.620364Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.620364Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.644356Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.644356Z"
+     "iopub.execute_input": "2026-06-18T10:14:51.106915Z",
+     "iopub.status.busy": "2026-06-18T10:14:51.106915Z",
+     "iopub.status.idle": "2026-06-18T10:14:51.127139Z",
+     "shell.execute_reply": "2026-06-18T10:14:51.125921Z"
     },
     "papermill": {
-     "duration": 0.033725,
-     "end_time": "2026-06-03T00:03:32.646969+00:00",
+     "duration": 0.02936,
+     "end_time": "2026-06-18T10:14:51.128369+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.613244+00:00",
+     "start_time": "2026-06-18T10:14:51.099009+00:00",
      "status": "completed"
     },
     "tags": []
@@ -772,10 +779,10 @@
    "id": "f6f17534",
    "metadata": {
     "papermill": {
-     "duration": 0.007455,
-     "end_time": "2026-06-03T00:03:32.662479+00:00",
+     "duration": 0.006508,
+     "end_time": "2026-06-18T10:14:51.141634+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.655024+00:00",
+     "start_time": "2026-06-18T10:14:51.135126+00:00",
      "status": "completed"
     },
     "tags": []
@@ -793,10 +800,10 @@
    "id": "4e401262",
    "metadata": {
     "papermill": {
-     "duration": 0.006906,
-     "end_time": "2026-06-03T00:03:32.677558+00:00",
+     "duration": 0.006342,
+     "end_time": "2026-06-18T10:14:51.153707+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.670652+00:00",
+     "start_time": "2026-06-18T10:14:51.147365+00:00",
      "status": "completed"
     },
     "tags": []
@@ -820,16 +827,16 @@
    "id": "8104abdd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.692932Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.692932Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.700299Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.698744Z"
+     "iopub.execute_input": "2026-06-18T10:14:51.168629Z",
+     "iopub.status.busy": "2026-06-18T10:14:51.165742Z",
+     "iopub.status.idle": "2026-06-18T10:14:51.174724Z",
+     "shell.execute_reply": "2026-06-18T10:14:51.173724Z"
     },
     "papermill": {
-     "duration": 0.016872,
-     "end_time": "2026-06-03T00:03:32.701586+00:00",
+     "duration": 0.016087,
+     "end_time": "2026-06-18T10:14:51.176080+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.684714+00:00",
+     "start_time": "2026-06-18T10:14:51.159993+00:00",
      "status": "completed"
     },
     "tags": []
@@ -860,10 +867,10 @@
    "id": "18730237",
    "metadata": {
     "papermill": {
-     "duration": 0.007263,
-     "end_time": "2026-06-03T00:03:32.715990+00:00",
+     "duration": 0.007007,
+     "end_time": "2026-06-18T10:14:51.189906+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.708727+00:00",
+     "start_time": "2026-06-18T10:14:51.182899+00:00",
      "status": "completed"
     },
     "tags": []
@@ -893,16 +900,16 @@
    "id": "0f54765a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.734760Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.734760Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.748129Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.746775Z"
+     "iopub.execute_input": "2026-06-18T10:14:51.205561Z",
+     "iopub.status.busy": "2026-06-18T10:14:51.203531Z",
+     "iopub.status.idle": "2026-06-18T10:14:51.214507Z",
+     "shell.execute_reply": "2026-06-18T10:14:51.214507Z"
     },
     "papermill": {
-     "duration": 0.02505,
-     "end_time": "2026-06-03T00:03:32.749563+00:00",
+     "duration": 0.019719,
+     "end_time": "2026-06-18T10:14:51.216615+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.724513+00:00",
+     "start_time": "2026-06-18T10:14:51.196896+00:00",
      "status": "completed"
     },
     "tags": []
@@ -982,10 +989,10 @@
    "id": "e74677fd",
    "metadata": {
     "papermill": {
-     "duration": 0.007549,
-     "end_time": "2026-06-03T00:03:32.766334+00:00",
+     "duration": 0.006054,
+     "end_time": "2026-06-18T10:14:51.228915+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.758785+00:00",
+     "start_time": "2026-06-18T10:14:51.222861+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1002,16 +1009,16 @@
    "id": "f766fae9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.785042Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.784498Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.851161Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.850024Z"
+     "iopub.execute_input": "2026-06-18T10:14:51.243692Z",
+     "iopub.status.busy": "2026-06-18T10:14:51.243692Z",
+     "iopub.status.idle": "2026-06-18T10:14:51.374109Z",
+     "shell.execute_reply": "2026-06-18T10:14:51.372533Z"
     },
     "papermill": {
-     "duration": 0.077202,
-     "end_time": "2026-06-03T00:03:32.852478+00:00",
+     "duration": 0.1409,
+     "end_time": "2026-06-18T10:14:51.375412+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.775276+00:00",
+     "start_time": "2026-06-18T10:14:51.234512+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1066,10 +1073,10 @@
    "id": "caa2469c",
    "metadata": {
     "papermill": {
-     "duration": 0.008065,
-     "end_time": "2026-06-03T00:03:32.867300+00:00",
+     "duration": 0.006803,
+     "end_time": "2026-06-18T10:14:51.388718+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.859235+00:00",
+     "start_time": "2026-06-18T10:14:51.381915+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1086,16 +1093,16 @@
    "id": "b2a766f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.886015Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.886015Z",
-     "iopub.status.idle": "2026-06-03T00:03:32.909166Z",
-     "shell.execute_reply": "2026-06-03T00:03:32.908138Z"
+     "iopub.execute_input": "2026-06-18T10:14:51.401613Z",
+     "iopub.status.busy": "2026-06-18T10:14:51.401613Z",
+     "iopub.status.idle": "2026-06-18T10:14:51.418381Z",
+     "shell.execute_reply": "2026-06-18T10:14:51.417669Z"
     },
     "papermill": {
-     "duration": 0.034729,
-     "end_time": "2026-06-03T00:03:32.910934+00:00",
+     "duration": 0.024864,
+     "end_time": "2026-06-18T10:14:51.419708+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.876205+00:00",
+     "start_time": "2026-06-18T10:14:51.394844+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1237,10 +1244,10 @@
    "id": "fda5a509",
    "metadata": {
     "papermill": {
-     "duration": 0.007156,
-     "end_time": "2026-06-03T00:03:32.925920+00:00",
+     "duration": 0.006002,
+     "end_time": "2026-06-18T10:14:51.431491+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.918764+00:00",
+     "start_time": "2026-06-18T10:14:51.425489+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1257,13 +1264,237 @@
   },
   {
    "cell_type": "markdown",
+   "id": "pymc-demo-mcmc-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008364,
+     "end_time": "2026-06-18T10:14:51.447055+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T10:14:51.438691+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Demonstration PyMC : fiabilite d'annotateur par MCMC (Beta-Bernoulli)\n",
+    "\n",
+    "Les modeles precedents (`Honest Worker`, `Biased Worker`, `Community`) sont **definis** dans PyMC (`with pm.Model() as ...`) mais leur inference reelle est confiee a l'EM Dawid-Skene, plus stable sur ce type de variables latentes discretes. Pour que le notebook demontre effectivement l'**echantillonnage MCMC** attendu d'une serie `PyMC-*`, nous ajoutons ici un modele simple **inferable par NUTS** : l'estimation de la fiabilite de chaque worker.\n",
+    "\n",
+    "**Modele** : pour chaque worker $w$, une fiabilite $\theta_w \\sim \\mathrm{Beta}(2, 1)$. Pour chaque paire (item, worker), on observe un indicateur de *match* (1 si le worker a donne le vrai label, 0 sinon) modense comme une Bernoulli de probabilite $\theta_w$. Les vrais labels etant connus ici (jeu de calibration), on obtient directement un vecteur d'observations `observed=`.\n",
+    "\n",
+    "Ce modele est la **version MCMC** de l'estimation bayesienne manuelle (cellule `Honest Worker complet`) : il retrouve les memes posterioris Beta, mais en utilisant `pm.sample` (NUTS) plutot que le calcul analytique `Beta(alpha + n_correct, beta + n_incorrect)`. Les deux approches sont **complementaires** : l'analytique est exacte pour ce modele conjugue, le MCMC se generalise aux modeles non-conjuges (comme Dawid-Skene, ou l'EM reste preferable).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "pymc-demo-mcmc-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-18T10:14:51.459922Z",
+     "iopub.status.busy": "2026-06-18T10:14:51.459922Z",
+     "iopub.status.idle": "2026-06-18T10:15:02.526149Z",
+     "shell.execute_reply": "2026-06-18T10:15:02.525016Z"
+    },
+    "papermill": {
+     "duration": 11.074097,
+     "end_time": "2026-06-18T10:15:02.527658+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T10:14:51.453561+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matrice de match (1 = worker correct) :\n",
+      "[[1 1 1 0]\n",
+      " [1 1 1 1]\n",
+      " [1 1 0 1]\n",
+      " [1 0 1 1]\n",
+      " [1 0 1 1]]\n",
+      "Corrects par worker : [5 3 4 4]\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sequential sampling (4 chains in 1 job)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 300 tune and 500 draw iterations (1_200 + 2_000 draws total) took 2 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Posterior des fiabilites (moyenne, ecart-type, HDI 94%) ===\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean</th>\n",
+       "      <th>sd</th>\n",
+       "      <th>hdi_3%</th>\n",
+       "      <th>hdi_97%</th>\n",
+       "      <th>mcse_mean</th>\n",
+       "      <th>mcse_sd</th>\n",
+       "      <th>ess_bulk</th>\n",
+       "      <th>ess_tail</th>\n",
+       "      <th>r_hat</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>theta[0]</th>\n",
+       "      <td>0.873</td>\n",
+       "      <td>0.113</td>\n",
+       "      <td>0.652</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>1524.0</td>\n",
+       "      <td>862.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>theta[1]</th>\n",
+       "      <td>0.623</td>\n",
+       "      <td>0.162</td>\n",
+       "      <td>0.307</td>\n",
+       "      <td>0.899</td>\n",
+       "      <td>0.004</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>1850.0</td>\n",
+       "      <td>1381.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>theta[2]</th>\n",
+       "      <td>0.755</td>\n",
+       "      <td>0.137</td>\n",
+       "      <td>0.501</td>\n",
+       "      <td>0.970</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>1380.0</td>\n",
+       "      <td>1165.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>theta[3]</th>\n",
+       "      <td>0.753</td>\n",
+       "      <td>0.147</td>\n",
+       "      <td>0.493</td>\n",
+       "      <td>0.992</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>1950.0</td>\n",
+       "      <td>1293.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           mean     sd  hdi_3%  hdi_97%  mcse_mean  mcse_sd  ess_bulk  \\\n",
+       "theta[0]  0.873  0.113   0.652    1.000      0.002    0.003    1524.0   \n",
+       "theta[1]  0.623  0.162   0.307    0.899      0.004    0.003    1850.0   \n",
+       "theta[2]  0.755  0.137   0.501    0.970      0.003    0.003    1380.0   \n",
+       "theta[3]  0.753  0.147   0.493    0.992      0.003    0.003    1950.0   \n",
+       "\n",
+       "          ess_tail  r_hat  \n",
+       "theta[0]     862.0    1.0  \n",
+       "theta[1]    1381.0    1.0  \n",
+       "theta[2]    1165.0    1.0  \n",
+       "theta[3]    1293.0    1.0  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Demonstration PyMC : fiabilite d'annotateur par MCMC (Beta-Bernoulli)\n",
+    "# Version echantillonnee (NUTS) de l'estimation bayesienne des capacites.\n",
+    "\n",
+    "# match[i, w] = 1 si worker w a donne le vrai label sur l'item i (calibration)\n",
+    "match = (labels == vrais_labels[:, None]).astype(int)\n",
+    "print(\"Matrice de match (1 = worker correct) :\")\n",
+    "print(match)\n",
+    "print(f\"Corrects par worker : {match.sum(axis=0)}\")\n",
+    "print()\n",
+    "\n",
+    "with pm.Model() as modele_fiabilite:\n",
+    "    # Prior Beta sur la fiabilite de chaque worker\n",
+    "    theta = pm.Beta(\"theta\", alpha=2, beta=1, shape=n_workers)\n",
+    "    # Likelihood Bernoulli : chaque (item, worker) observe un match 0/1\n",
+    "    y = pm.Bernoulli(\"y\", p=theta[None, :], observed=match,\n",
+    "                    shape=(n_items, n_workers))\n",
+    "    # Echantillonnage MCMC (NUTS) -- c'est l'inference PyMC reelle\n",
+    "    trace_fiabilite = pm.sample(500, chains=4, tune=300,\n",
+    "                               random_seed=42, progressbar=False, cores=1)\n",
+    "\n",
+    "print()\n",
+    "print(\"=== Posterior des fiabilites (moyenne, ecart-type, HDI 94%) ===\")\n",
+    "az.summary(trace_fiabilite, var_names=[\"theta\"])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c65081e8",
    "metadata": {
     "papermill": {
-     "duration": 0.010034,
-     "end_time": "2026-06-03T00:03:32.944242+00:00",
+     "duration": 0.010787,
+     "end_time": "2026-06-18T10:15:02.551542+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.934208+00:00",
+     "start_time": "2026-06-18T10:15:02.540755+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1292,20 +1523,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "dd0ab71d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:32.960944Z",
-     "iopub.status.busy": "2026-06-03T00:03:32.959823Z",
-     "iopub.status.idle": "2026-06-03T00:03:33.027393Z",
-     "shell.execute_reply": "2026-06-03T00:03:33.026737Z"
+     "iopub.execute_input": "2026-06-18T10:15:02.567088Z",
+     "iopub.status.busy": "2026-06-18T10:15:02.567088Z",
+     "iopub.status.idle": "2026-06-18T10:15:02.650850Z",
+     "shell.execute_reply": "2026-06-18T10:15:02.650850Z"
     },
     "papermill": {
-     "duration": 0.07752,
-     "end_time": "2026-06-03T00:03:33.029455+00:00",
+     "duration": 0.09411,
+     "end_time": "2026-06-18T10:15:02.653717+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:32.951935+00:00",
+     "start_time": "2026-06-18T10:15:02.559607+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1407,10 +1638,10 @@
    "id": "30cd2991",
    "metadata": {
     "papermill": {
-     "duration": 0.008768,
-     "end_time": "2026-06-03T00:03:33.047394+00:00",
+     "duration": 0.024576,
+     "end_time": "2026-06-18T10:15:02.688568+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.038626+00:00",
+     "start_time": "2026-06-18T10:15:02.663992+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1436,10 +1667,10 @@
    "id": "ae239e13",
    "metadata": {
     "papermill": {
-     "duration": 0.008506,
-     "end_time": "2026-06-03T00:03:33.063807+00:00",
+     "duration": 0.060754,
+     "end_time": "2026-06-18T10:15:02.786268+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.055301+00:00",
+     "start_time": "2026-06-18T10:15:02.725514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1460,20 +1691,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "d2ef04f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:33.081986Z",
-     "iopub.status.busy": "2026-06-03T00:03:33.080529Z",
-     "iopub.status.idle": "2026-06-03T00:03:33.467594Z",
-     "shell.execute_reply": "2026-06-03T00:03:33.466553Z"
+     "iopub.execute_input": "2026-06-18T10:15:02.847742Z",
+     "iopub.status.busy": "2026-06-18T10:15:02.846721Z",
+     "iopub.status.idle": "2026-06-18T10:15:03.241418Z",
+     "shell.execute_reply": "2026-06-18T10:15:03.237395Z"
     },
     "papermill": {
-     "duration": 0.39677,
-     "end_time": "2026-06-03T00:03:33.469280+00:00",
+     "duration": 0.424677,
+     "end_time": "2026-06-18T10:15:03.243501+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.072510+00:00",
+     "start_time": "2026-06-18T10:15:02.818824+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1559,10 +1790,10 @@
    "id": "7493dfaf",
    "metadata": {
     "papermill": {
-     "duration": 0.009567,
-     "end_time": "2026-06-03T00:03:33.487383+00:00",
+     "duration": 0.023676,
+     "end_time": "2026-06-18T10:15:03.285188+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.477816+00:00",
+     "start_time": "2026-06-18T10:15:03.261512+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1578,10 +1809,10 @@
    "id": "e115a757",
    "metadata": {
     "papermill": {
-     "duration": 0.008825,
-     "end_time": "2026-06-03T00:03:33.505436+00:00",
+     "duration": 0.037412,
+     "end_time": "2026-06-18T10:15:03.372744+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.496611+00:00",
+     "start_time": "2026-06-18T10:15:03.335332+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1594,20 +1825,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "802c1784",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:33.522428Z",
-     "iopub.status.busy": "2026-06-03T00:03:33.520999Z",
-     "iopub.status.idle": "2026-06-03T00:03:33.545389Z",
-     "shell.execute_reply": "2026-06-03T00:03:33.544361Z"
+     "iopub.execute_input": "2026-06-18T10:15:03.425080Z",
+     "iopub.status.busy": "2026-06-18T10:15:03.425080Z",
+     "iopub.status.idle": "2026-06-18T10:15:03.492046Z",
+     "shell.execute_reply": "2026-06-18T10:15:03.488139Z"
     },
     "papermill": {
-     "duration": 0.034408,
-     "end_time": "2026-06-03T00:03:33.547027+00:00",
+     "duration": 0.087556,
+     "end_time": "2026-06-18T10:15:03.495686+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.512619+00:00",
+     "start_time": "2026-06-18T10:15:03.408130+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1712,10 +1943,10 @@
    "id": "e9c77593",
    "metadata": {
     "papermill": {
-     "duration": 0.007365,
-     "end_time": "2026-06-03T00:03:33.561761+00:00",
+     "duration": 0.018981,
+     "end_time": "2026-06-18T10:15:03.531430+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.554396+00:00",
+     "start_time": "2026-06-18T10:15:03.512449+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1731,10 +1962,10 @@
    "id": "7bf9c879",
    "metadata": {
     "papermill": {
-     "duration": 0.007096,
-     "end_time": "2026-06-03T00:03:33.576515+00:00",
+     "duration": 0.028451,
+     "end_time": "2026-06-18T10:15:03.580018+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.569419+00:00",
+     "start_time": "2026-06-18T10:15:03.551567+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1777,10 +2008,10 @@
    "id": "4d3535a2",
    "metadata": {
     "papermill": {
-     "duration": 0.007828,
-     "end_time": "2026-06-03T00:03:33.591425+00:00",
+     "duration": 0.015458,
+     "end_time": "2026-06-18T10:15:03.615196+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.583597+00:00",
+     "start_time": "2026-06-18T10:15:03.599738+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1799,20 +2030,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "a3e3935e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:33.607605Z",
-     "iopub.status.busy": "2026-06-03T00:03:33.605589Z",
-     "iopub.status.idle": "2026-06-03T00:03:33.613896Z",
-     "shell.execute_reply": "2026-06-03T00:03:33.612827Z"
+     "iopub.execute_input": "2026-06-18T10:15:03.642054Z",
+     "iopub.status.busy": "2026-06-18T10:15:03.642054Z",
+     "iopub.status.idle": "2026-06-18T10:15:03.651590Z",
+     "shell.execute_reply": "2026-06-18T10:15:03.651590Z"
     },
     "papermill": {
-     "duration": 0.0172,
-     "end_time": "2026-06-03T00:03:33.615730+00:00",
+     "duration": 0.0242,
+     "end_time": "2026-06-18T10:15:03.654117+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.598530+00:00",
+     "start_time": "2026-06-18T10:15:03.629917+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1854,10 +2085,10 @@
    "id": "d8a8c164",
    "metadata": {
     "papermill": {
-     "duration": 0.008065,
-     "end_time": "2026-06-03T00:03:33.631660+00:00",
+     "duration": 0.012282,
+     "end_time": "2026-06-18T10:15:03.673455+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:03:33.623595+00:00",
+     "start_time": "2026-06-18T10:15:03.661173+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1882,7 +2113,16 @@
   {
    "cell_type": "markdown",
    "id": "ref-dawid-skene-1979",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.012988,
+     "end_time": "2026-06-18T10:15:03.702415+00:00",
+     "exception": false,
+     "start_time": "2026-06-18T10:15:03.689427+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "\n",
     "## References\n",
@@ -1912,14 +2152,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 13.259472,
-   "end_time": "2026-06-03T00:03:34.417350+00:00",
+   "duration": 36.71825,
+   "end_time": "2026-06-18T10:15:06.560753+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-10-Crowdsourcing.ipynb",
+   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-10-Crowdsourcing_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-03T00:03:21.157878+00:00",
+   "start_time": "2026-06-18T10:14:29.842503+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Closes #3346 (ruling editorial deferred from PR #3345, lane po-2025:CoursIA famille Probas/PyMC).

The `PyMC-10-Crowdsourcing` notebook **defined** 3 PyMC models (`Honest Worker`, `Biased Worker`, `Dawid-Skene` via `with pm.Model() as ...`) but **never inferred** any of them -- `pm.sample` count was 0 in the whole notebook. The actual inference was delegated to the hand-rolled EM Dawid-Skene (canonical Dawid & Skene 1979, more stable on discrete latent variables). The prose was honest about this (idx24: *"L'echantillonnage est effectue via EM dans la cellule suivante pour la stabilite"*), but a notebook of the `PyMC-*` series that never calls `pm.sample` keeps a title/content gap.

## Change

Added **2 cells** after idx26 (method comparison), before §6 Modele Community:
- **markdown** `pymc-demo-mcmc-md`: "Demonstration PyMC : fiabilite d'annotateur par MCMC (Beta-Bernoulli)" -- explains why pm.sample was missing, the model (theta_w ~ Beta(2,1), Bernoulli on match matrix), and the complementarity analytic-vs-MCMC.
- **code** `pymc-demo-mcmc-code`: `match = (labels == vrais_labels[:,None]).astype(int)`, `pm.Beta("theta", alpha=2, beta=1, shape=n_workers)`, `pm.Bernoulli("y", p=theta, observed=match)`, `pm.sample(500, chains=4, tune=300, random_seed=42)` + `az.summary(var_names=["theta"])`.

This is the **MCMC counterpart** of the manual Beta posterior estimation in the `Honest Worker complet` section (idx16, which computes `Beta(alpha+n_correct, beta+n_incorrect)` via scipy). The two coexist: the analytic is exact for this conjugate model; MCMC generalizes to non-conjugate models (like Dawid-Skene, where EM remains preferable).

## Real execution (rule C.2 / H.1)

Re-executed via papermill, kernel `coursia-ml` (pymc 5.28.5, arviz 0.23.4 -- same versions as the previously-committed outputs). The new cell produces a real MCMC trace:

```
Sampling 4 chains for 300 tune and 500 draw iterations (1_200 + 2_000 draws total) took 2 seconds.
           mean     sd  hdi_3%  hdi_97%  ess_bulk  ess_tail  r_hat
theta[0]  0.873  0.113   0.652    1.000    1524.0     862.0    1.0   (W1: 5/5 correct)
theta[1]  0.623  0.162   0.307    0.899    1850.0    1381.0    1.0   (W2: 3/5)
theta[2]  0.755  0.137   0.501    0.970    1380.0    1165.0    1.0   (W3: 4/5)
theta[3]  0.753  0.147   0.493    0.992    1950.0    1293.0    1.0   (W4: 4/5)
```

All 16 code cells have outputs, 0 errors, r_hat <= 1.0, ess_bulk > 1300.

## Anti-regression

- EM Dawid-Skene (idx25, canonical 1979) -- **byte-identical**, not touched.
- The 3 declared PyMC models (idx14/21/23) -- **source byte-identical**, not touched.
- No exercise resolved/stubbed (#3346 does not ask for an exercise; the notebook already has 3 conforming exercises).
- Output diff on existing cells: pip-install paths and a reordered blank line in idx14 Honest Worker (stdout flushing) -- cosmetic only, all factual outputs (data, computations, models) IDENTICAL to origin/main.

## Gates

- **G1** `scan_cell_ordering.py`: 1 clean, 0 finding.
- **G2** `check_c2_compliance.py`: 1/1 compliant, All clear.
- **G3** `notebook_tools.py validate`: OK 0, Warnings 1 (**pre-existing** on origin/main = FP unbalanced-$ LaTeX, not introduced).
- **G4** code-source delta: exactly **+1 code cell + 1 markdown cell**; 0 existing code cell source modified, 0 deleted.

Closes #3346
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)