### PR TITLE
fix(smartcontracts): repair broken inter-notebook nav links (SC-7, SC-22)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# SC-7-Token-Standards - Standards de Tokens\n",
     "\n",
-    "[<< Precedent : Errors & Events](../01-Solidity-Foundation/../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) | [Retour au sommaire](../README.md) | [Suivant : DeFi Primitives >>](SC-8-DeFi-Primitives.ipynb)\n",
+    "[<< Precedent : Errors & Events](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) | [Retour au sommaire](../README.md) | [Suivant : DeFi Primitives >>](SC-8-DeFi-Primitives.ipynb)\n",
     "\n",
     "---\n",
     "\n",
@@ -1700,7 +1700,7 @@
    "source": [
     "---\n",
     "\n",
-    "[<< Precedent : Errors & Events](../01-Solidity-Foundation/../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) | [Retour au sommaire](../README.md) | [Suivant : DeFi Primitives >>](SC-8-DeFi-Primitives.ipynb)"
+    "[<< Precedent : Errors & Events](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) | [Retour au sommaire](../README.md) | [Suivant : DeFi Primitives >>](SC-8-DeFi-Primitives.ipynb)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# SC-22-Solana-Anchor - Solana avec Anchor\n",
     "\n",
-    "[<< Move & Sui](SC-21-Move-Sui.ipynb) | [Cross-Chain >>](../06-Real-World/../06-Real-World/SC-23-Cross-Chain.ipynb)\n",
+    "[<< Move & Sui](SC-21-Move-Sui.ipynb) | [Cross-Chain >>](../06-Real-World/SC-23-Cross-Chain.ipynb)\n",
     "\n",
     "---\n",
     "\n",
@@ -1873,7 +1873,7 @@
    "source": [
     "---\n",
     "\n",
-    "[<< Move & Sui](SC-21-Move-Sui.ipynb) | [Cross-Chain >>](../06-Real-World/../06-Real-World/SC-23-Cross-Chain.ipynb)"
+    "[<< Move & Sui](SC-21-Move-Sui.ipynb) | [Cross-Chain >>](../06-Real-World/SC-23-Cross-Chain.ipynb)"
    ]
   },
   {
@@ -1933,7 +1933,7 @@
     "\n",
     "La difference philosophique majeure entre Solana et Ethereum reside dans la separation stricte entre code (programmes stateless) et donnees (comptes independants). Ce modele enable le parallelisme natif des transactions et elimine la contention globale, mais exige une planification plus rigoureuse de la structure des comptes. Les PDAs remplacent les mappings Solidity par des adresses deterministes sans cle privee, offrant une securite inherente contre les acces non autorises. Le framework Anchor simplifie considerablement le developpement en Rust tout en preservant les garanties de securite du type system.\n",
     "\n",
-    "Le notebook suivant, [SC-23-Cross-Chain](../06-Real-World/../06-Real-World/SC-23-Cross-Chain.ipynb), aborde l'interoperabilite entre blockchains et les protocols de communication cross-chain comme Chainlink CCIP."
+    "Le notebook suivant, [SC-23-Cross-Chain](../06-Real-World/SC-23-Cross-Chain.ipynb), aborde l'interoperabilite entre blockchains et les protocols de communication cross-chain comme Chainlink CCIP."
    ]
   }
  ],


### PR DESCRIPTION
## Context

While auditing SmartContracts inter-notebook navigation links, found **2 notebooks** with broken nav headers/footers: the relative paths were doubled (`../<dir>/../<dir>/`), resolving to non-existent locations.

## Findings (G.1-verified against file tree)

| Notebook | Cell(s) | Broken link | Resolved correctly to |
|----------|---------|-------------|----------------------|
| SC-7-Token-Standards (02-Solidity-Advanced) | nav-header idx0 `cell-0` + nav-footer idx33 `9c9a4268` | `../01-Solidity-Foundation/../01-Solidity-Foundation/SC-6-Errors-Events.ipynb` | `../01-Solidity-Foundation/SC-6-Errors-Events.ipynb` (exists) |
| SC-22-Solana-Anchor (05-Alternative-Chains) | nav-header idx0 `cell-0`, nav-footer idx34 `11ed5661`, idx36 `689f6d48` | `../06-Real-World/../06-Real-World/SC-23-Cross-Chain.ipynb` | `../06-Real-World/SC-23-Cross-Chain.ipynb` (exists) |

## Fix

Markdown-only: replaced the doubled `../<dir>/../<dir>/` with the correct `../<dir>/` in each nav cell's `source` field (JSON round-trip, indent=1, byte-identical round-trip — no papermill-metadata churn).

- **5 link occurrences** fixed total (2 in SC-7, 3 in SC-22).
- Post-fix scan across all 27 SmartContracts notebooks: **0 doubled-path patterns remaining**.
- Both target links verified to resolve to existing files.

## Verification (anti-regression + conventions)

- `git diff --stat`: 2 files, 5 insertions / 5 deletions — only nav `source` lines changed.
- Code cells, `outputs`, `execution_count`, notebook metadata: **byte-identical** to main.
- `COURSE_CATALOG.generated.{json,md}` + MGS submodule: **byte-identical** to main.
- Markdown-only → rule C.2 (outputs valid), C.3 (no source-code cells touched), C.1 (no `raise NotImplementedError`) all satisfied.
- No-pendulum: aligned to the correct resolved path (the file exists), not a deletion or rewrite.

See #3164 (audit fidelity — discovered during SmartContracts nav-link structural check). Atomique: 1 subject (broken inter-notebook nav links), 1 family (SmartContracts), 2 files.