### PR TITLE
fix(lean-7): renumber duplicated subsection 2.3 -> 2.6 (cell-order #3248)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-7-LLM-Integration.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-7-LLM-Integration.ipynb
@@ -370,11 +370,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### 2.3 Installation de LeanCopilot\n",
-    "\n",
-    "LeanCopilot s'installe via Lake en ajoutant la dependance au `lakefile.lean`. Il necessite un modele LLM (local ou API) et s'integre dans VS Code pour les suggestions en temps reel."
-   ]
+   "source": "### 2.6 Installation de LeanCopilot\n\nLeanCopilot s'installe via Lake en ajoutant la dependance au `lakefile.lean`. Il necessite un modele LLM (local ou API) et s'integre dans VS Code pour les suggestions en temps reel."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
See #3248

## Summary

Fixes 1 of the 13 legacy cell-order findings tracked in #3248 (Epic #3240 scanner). Targets `Lean-7-LLM-Integration.ipynb` cell#5 — a HIGH SECTION_ORDER regression in po-2026's domain (Lean).

## The finding

Section `## 2. LeanCopilot et l'Ecosysteme LeanDojo` numbered its subsections:

```
### 2.1 Presentation
### 2.2 LeanCopilot (NeurIPS 2025)
### 2.3 LeanProgress (TMLR 2025)
### 2.4 LeanAgent (ICLR 2025)
### 2.5 Architecture LeanDojo
### 2.3 Installation de LeanCopilot   <- cell#5 (regression)
```

`scan_cell_ordering` flagged: *"section 2.3 appears after 2.5 (numbering goes backwards under parent 2)"*.

## Ground-truth (#3248 procedure, step 2)

Confirmed this is a real slip, not a deliberate choice:
- The `2.1`-`2.5` block (cell `e108d20c`) is a coherent ecosystem overview (5 distinct tools).
- `### 2.3 Installation de LeanCopilot` (cell `6b51b6bc`) is a distinct practical subsection that duplicates the `2.3` number.
- No cross-reference to "section 2.3" exists elsewhere (the only other `2.3` is the legitimate LeanProgress header).

## Fix

Renumber cell `6b51b6bc` header `### 2.3` → `### 2.6`, continuing the section 2 sequence (now monotonic `2.1`..`2.6`). "Installation" as the 6th subsection (practical how-to after the conceptual overview) is pedagogically coherent.

## Validation

- **`scan_cell_ordering`**: `1 clean / 0 findings` (was `1 HIGH`).
- **Semantic diff**: only cell `6b51b6bc` line 0 changed (`2.3`→`2.6`); **0 `execution_count`/`outputs` diffs** across all 39 cells (byte-identical outputs preserved — markdown-only edit, no re-exec needed per C.2 exception).
- nbformat 4.5 valid, 39→39 cells (no structural change).

## Scope

Single notebook, single finding (atomic). `See #3248` (partial — 1 of 13; Lean-6 `EXERCISE_ORDER`, Lean-11 `SECTION_ORDER`, and Search/Sudoku findings remain for follow-up grains).