### PR TITLE
fix(notebook_tools): scrub absolute papermill paths (script + SC 06-Real-World)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
@@ -2129,8 +2129,8 @@
    "end_time": "2026-06-03T07:41:49.669069+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\06-Real-World\\SC-23-Cross-Chain.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\06-Real-World\\SC-23-Cross-Chain_output.ipynb",
+   "input_path": "SC-23-Cross-Chain.ipynb",
+   "output_path": "SC-23-Cross-Chain.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T07:41:47.507379+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
@@ -1474,8 +1474,8 @@
    "end_time": "2026-06-03T00:15:18.355861+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\06-Real-World\\SC-24-Testnet-Deploy.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\06-Real-World\\SC-24-Testnet-Deploy_output.ipynb",
+   "input_path": "SC-24-Testnet-Deploy.ipynb",
+   "output_path": "SC-24-Testnet-Deploy.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
@@ -969,8 +969,8 @@
    "end_time": "2026-06-03T00:15:35.486460+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\06-Real-World\\SC-25-Mainnet-Deploy.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\06-Real-World\\SC-25-Mainnet-Deploy_output.ipynb",
+   "input_path": "SC-25-Mainnet-Deploy.ipynb",
+   "output_path": "SC-25-Mainnet-Deploy.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
@@ -1033,8 +1033,8 @@
    "end_time": "2026-06-02T21:40:39.244397+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\06-Real-World\\SC-26-Final-Project.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\06-Real-World\\SC-26-Final-Project_output.ipynb",
+   "input_path": "SC-26-Final-Project.ipynb",
+   "output_path": "SC-26-Final-Project.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T21:40:35.334330+00:00",
    "version": "2.7.0"

--- a/scripts/notebook_tools/scrub_papermill_paths.py
+++ b/scripts/notebook_tools/scrub_papermill_paths.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Scrub absolute machine-local paths from notebook papermill metadata.
+
+When a notebook is re-executed via papermill with an absolute output path
+(e.g. ``C:/Users/jsboi/AppData/Local/Temp/x.ipynb`` or ``D:/tmp/x.ipynb``),
+papermill records that absolute path in ``metadata.papermill.output_path``
+(and sometimes ``input_path``). This:
+
+  - leaks the contributor's local directory structure,
+  - breaks reproducibility (the temp path no longer exists),
+  - is inconsistent with cleanly-executed notebooks (e.g. SC-10), where both
+    fields carry the notebook's relative basename.
+
+The target state is a relative path equal to the notebook's own basename.
+This script replaces any absolute ``output_path``/``input_path`` value with
+the basename, using a text-level surgical edit so the rest of the notebook
+(byte-for-byte code, outputs, cell metadata) is preserved.
+
+Usage:
+    python scrub_papermill_paths.py --scan <path>      # dry-run, list only
+    python scrub_papermill_paths.py --scan-all          # dry-run repo-wide
+    python scrub_papermill_paths.py --scan-all --check  # exit 1 if defects
+    python scrub_papermill_paths.py --apply <path>      # fix in place
+    python scrub_papermill_paths.py --apply-all         # fix repo-wide
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+
+# Matches a Windows drive-absolute path (C:\, C:/, D:\ ...) or a POSIX-absolute
+# path (/tmp/...). Forward and back slashes both appear in committed notebooks.
+ABS_PATH_RE = re.compile(r'^[A-Za-z]:[\\/]|^/')
+
+
+def is_absolute(p):
+    return isinstance(p, str) and bool(ABS_PATH_RE.match(p))
+
+
+def _read_notebook(nb_path):
+    try:
+        with open(nb_path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def find_papermill_defects(nb_path):
+    """Return list of (key, current_value) for absolute papermill paths.
+
+    Only inspects ``metadata.papermill``. Returns [] if notebook is not
+    papermill-executed or has only relative paths.
+    """
+    nb = _read_notebook(nb_path)
+    if nb is None:
+        return []
+    pm = nb.get("metadata", {}).get("papermill", {})
+    if not isinstance(pm, dict):
+        return []
+    defects = []
+    for key in ("output_path", "input_path"):
+        val = pm.get(key)
+        if is_absolute(val):
+            defects.append((key, val))
+    return defects
+
+
+def scrub_notebook(nb_path, apply=False):
+    """Replace absolute papermill paths with the notebook basename.
+
+    Uses a text-level surgical edit (string replace of the exact JSON
+    key:value substring) so the rest of the file is byte-identical. No
+    JSON re-serialization = no float coercion, no metadata churn.
+
+    Returns (defects_found, defects_fixed).
+    """
+    defects = find_papermill_defects(nb_path)
+    if not defects:
+        return ([], [])
+
+    basename = os.path.basename(nb_path)
+    with open(nb_path, encoding="utf-8") as f:
+        text = f.read()
+
+    fixed = []
+    new_text = text
+    for key, old_val in defects:
+        # Match the JSON substring regardless of quote style / spacing that
+        # json.dump may have produced. The value is a JSON string literal:
+        # escape backslashes present in the raw file form.
+        raw_old = json.dumps(old_val)  # exact JSON string literal as parsed
+        raw_new = json.dumps(basename)
+        needle = '"%s": %s' % (key, raw_old)
+        replacement = '"%s": %s' % (key, raw_new)
+        count = new_text.count(needle)
+        if count == 0:
+            # The on-disk literal differs from the parsed value (e.g. single
+            # quotes, spacing). Skip rather than risk a wrong edit.
+            continue
+        if count > 1:
+            # Ambiguous: the same absolute path appears twice. Skip to stay
+            # surgical; flagged in scan output for manual review.
+            continue
+        new_text = new_text.replace(needle, replacement, 1)
+        fixed.append((key, old_val))
+
+    if apply and fixed and new_text != text:
+        with open(nb_path, "w", encoding="utf-8", newline="") as f:
+            f.write(new_text)
+
+    return (defects, fixed)
+
+
+def iter_notebooks(nb_root):
+    for path in glob.glob(os.path.join(nb_root, "**", "*.ipynb"), recursive=True):
+        if "_output" in os.path.basename(path) or "_executed" in os.path.basename(path):
+            continue
+        yield path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scrub absolute paths from notebook papermill metadata"
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--scan", metavar="PATH", help="dry-run scan a file or dir")
+    group.add_argument("--scan-all", action="store_true", help="dry-run scan repo-wide")
+    group.add_argument("--apply", metavar="PATH", help="fix a file or dir in place")
+    group.add_argument("--apply-all", action="store_true", help="fix repo-wide in place")
+    parser.add_argument("--check", action="store_true",
+                        help="with --scan-all: exit 1 if any defect found")
+    args = parser.parse_args()
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    nb_root = os.path.join(repo_root, "MyIA.AI.Notebooks")
+
+    do_apply = args.apply is not None or args.apply_all
+    target = args.apply if args.apply else (args.scan if args.scan else nb_root)
+
+    paths = []
+    if args.scan_all or args.apply_all:
+        paths = list(iter_notebooks(nb_root))
+    elif os.path.isdir(target):
+        paths = list(iter_notebooks(target))
+    elif os.path.isfile(target):
+        paths = [target]
+    else:
+        parser.error("path not found: %s" % target)
+
+    total_defects = 0
+    total_fixed = 0
+    files_with_defect = 0
+    skipped = []
+    for p in sorted(paths):
+        defects, fixed = scrub_notebook(p, apply=do_apply)
+        if not defects:
+            continue
+        files_with_defect += 1
+        total_defects += len(defects)
+        rel = os.path.relpath(p, repo_root)
+        if do_apply:
+            unfixed = [d for d in defects if d not in fixed]
+            total_fixed += len(fixed)
+            tag = "FIXED" if fixed and not unfixed else ("PARTIAL" if fixed else "SKIP")
+            print("[%s] %s" % (tag, rel))
+            for key, val in fixed:
+                print("        %s: %s -> %s" % (key, val, os.path.basename(p)))
+            for key, val in unfixed:
+                print("        [unfixed] %s: %s" % (key, val))
+                skipped.append((rel, key, val))
+        else:
+            print("[DEFECT] %s" % rel)
+            for key, val in defects:
+                print("        %s: %s" % (key, val))
+
+    mode = "apply" if do_apply else "scan"
+    print("\n%s summary: %d notebook(s) with %d absolute papermill path(s)"
+          % (mode, files_with_defect, total_defects))
+    if do_apply:
+        print("  fixed: %d   skipped: %d" % (total_fixed, len(skipped)))
+
+    if args.check and total_defects > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/notebook_tools/tests/test_scrub_papermill_paths.py
+++ b/scripts/notebook_tools/tests/test_scrub_papermill_paths.py
@@ -1,0 +1,156 @@
+"""Tests for scripts/notebook_tools/scrub_papermill_paths.py
+
+Covers: absolute path detection (Windows drive + POSIX), the basename
+replacement, byte-identical preservation of everything else via the
+text-level surgical edit, ambiguous/duplicate-value skip, and the
+no-papermill / relative-only clean cases.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+_tools_dir = str(Path(__file__).resolve().parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from scrub_papermill_paths import (
+    ABS_PATH_RE,
+    find_papermill_defects,
+    is_absolute,
+    scrub_notebook,
+)
+
+
+def _write_nb(path: Path, pm: dict | None, extra_metadata: dict | None = None) -> Path:
+    nb = {
+        "cells": [],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    if pm is not None:
+        nb["metadata"]["papermill"] = pm
+    if extra_metadata:
+        nb["metadata"].update(extra_metadata)
+    # Use indent=1 to mirror the committed-notebook canonical format.
+    path.write_text(json.dumps(nb, indent=1), encoding="utf-8")
+    return path
+
+
+def test_is_absolute_detects_windows_and_posix():
+    assert is_absolute("C:/Users/jsboi/Temp/x.ipynb")
+    assert is_absolute("D:\\tmp\\x.ipynb")
+    assert is_absolute("/tmp/x.ipynb")
+    assert not is_absolute("x.ipynb")
+    assert not is_absolute("dir/x.ipynb")
+    assert not is_absolute(None)
+    assert not is_absolute(123)
+
+
+def test_find_defects_none_when_no_papermill(tmp_path):
+    p = _write_nb(tmp_path / "nb.ipynb", pm=None)
+    assert find_papermill_defects(str(p)) == []
+
+
+def test_find_defects_none_when_relative(tmp_path):
+    p = _write_nb(tmp_path / "nb.ipynb", pm={"output_path": "nb.ipynb"})
+    assert find_papermill_defects(str(p)) == []
+
+
+def test_find_defects_flags_absolute_output_and_input(tmp_path):
+    p = _write_nb(tmp_path / "nb.ipynb", pm={
+        "output_path": "C:/Users/jsboi/AppData/Local/Temp/nb_out.ipynb",
+        "input_path": "C:/dev/repo/nb.ipynb",
+        "version": "2.6.0",
+    })
+    defects = find_papermill_defects(str(p))
+    keys = [k for k, _ in defects]
+    assert keys == ["output_path", "input_path"]
+
+
+def test_scrub_replaces_absolute_with_basename_and_preserves_rest(tmp_path):
+    p = tmp_path / "SC-1-Setup-Foundry.ipynb"
+    pm = {
+        "output_path": "C:/Users/jsboi/AppData/Local/Temp/sc1_output.ipynb",
+        "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb",
+        "duration": 2.305612,
+        "version": "2.6.0",
+        "exception": None,
+    }
+    _write_nb(p, pm=pm)
+    before = p.read_text(encoding="utf-8")
+
+    defects, fixed = scrub_notebook(str(p), apply=True)
+    assert len(fixed) == 1  # only output_path was absolute
+    assert fixed[0][0] == "output_path"
+
+    after = p.read_text(encoding="utf-8")
+    nb = json.loads(after)
+    assert nb["metadata"]["papermill"]["output_path"] == "SC-1-Setup-Foundry.ipynb"
+    # input_path was already relative -> untouched
+    assert nb["metadata"]["papermill"]["input_path"] == pm["input_path"]
+    # duration preserved exactly (no float coercion)
+    assert nb["metadata"]["papermill"]["duration"] == 2.305612
+    assert nb["metadata"]["papermill"]["version"] == "2.6.0"
+    # Everything outside the output_path substring is byte-identical.
+    assert before.replace(
+        "C:/Users/jsboi/AppData/Local/Temp/sc1_output.ipynb",
+        "SC-1-Setup-Foundry.ipynb",
+    ) == after
+
+
+def test_scrub_handles_backslash_paths(tmp_path):
+    p = tmp_path / "nb.ipynb"
+    _write_nb(p, pm={"output_path": "D:\\tmp\\nb_out.ipynb"})
+    defects, fixed = scrub_notebook(str(p), apply=True)
+    assert len(fixed) == 1
+    after = json.loads(p.read_text(encoding="utf-8"))
+    assert after["metadata"]["papermill"]["output_path"] == "nb.ipynb"
+
+
+def test_scrub_dry_run_does_not_write(tmp_path):
+    p = tmp_path / "nb.ipynb"
+    _write_nb(p, pm={"output_path": "/tmp/nb_out.ipynb"})
+    before = p.read_text(encoding="utf-8")
+    defects, fixed = scrub_notebook(str(p), apply=False)
+    assert len(defects) == 1
+    assert len(fixed) == 1  # would-fix reported even in dry-run
+    # but the file is untouched in dry-run
+    assert p.read_text(encoding="utf-8") == before
+
+
+def test_scrub_skips_ambiguous_duplicate(tmp_path):
+    """If the same key:value needle appears twice the edit is ambiguous -> skip."""
+    p = tmp_path / "nb.ipynb"
+    # Raw text with the SAME output_path key:value literally twice (invalid
+    # JSON, but exercises the count>1 guard on malformed content).
+    raw = (
+        '{\n "cells": [],\n '
+        '"metadata": {\n  "papermill": {\n'
+        '   "output_path": "C:/tmp/x.ipynb",\n'
+        '   "output_path": "C:/tmp/x.ipynb"\n  }\n },\n'
+        ' "nbformat": 4\n}\n'
+    )
+    p.write_text(raw, encoding="utf-8")
+    defects, fixed = scrub_notebook(str(p), apply=True)
+    # needle count > 1 -> skipped, file untouched
+    assert fixed == []
+    assert p.read_text(encoding="utf-8") == raw
+
+
+def test_scrub_clean_notebook_is_noop(tmp_path):
+    p = _write_nb(tmp_path / "nb.ipynb", pm={"output_path": "nb.ipynb"})
+    before = p.read_text(encoding="utf-8")
+    defects, fixed = scrub_notebook(str(p), apply=True)
+    assert defects == []
+    assert fixed == []
+    assert p.read_text(encoding="utf-8") == before
+
+
+def test_abs_path_regex():
+    assert ABS_PATH_RE.match("C:/x")
+    assert ABS_PATH_RE.match("Z:\\x")
+    assert ABS_PATH_RE.match("/x")
+    assert not ABS_PATH_RE.match("x.ipynb")
+    assert not ABS_PATH_RE.match("a/b.ipynb")


### PR DESCRIPTION
## Context

Signal from @myia-po-2025 (lane CoursIA-2, 11:06Z): re-executing notebooks with papermill injects **absolute machine-local paths** into `metadata.papermill.output_path` / `input_path`. These leak the contributor's local directory structure (`C:/Users/jsboi/AppData/Local/Temp/...`, `C:\dev\CoursIA-2\...`, `D:\dev\...`) and point to since-deleted temp files, breaking reproducibility. Some committed notebooks even carry the pre-rename path `C:\dev\CoursIA\...` (SC-26).

This PR delivers the **reusable tool** (rule F: no ad-hoc script — add to `scripts/notebook_tools/`) and a first atomic application.

## Deliverables

### 1. `scripts/notebook_tools/scrub_papermill_paths.py` (new)
- Detects absolute paths (Windows drive `C:\`/`C:/` + POSIX `/`) in `metadata.papermill.output_path` / `input_path`.
- Replaces them with the notebook's own relative **basename** — the target state proven by cleanly-executed notebooks (e.g. SC-10 carries `"output_path": "SC-10-Account-Abstraction.ipynb"`).
- **Text-level surgical edit** (exact `"key": value` JSON substring replace) → code, outputs, cell metadata and the rest of the notebook stay **byte-identical**. No JSON re-serialization = no float coercion, no metadata churn.
- Skips ambiguous cases (duplicate needle, value not found as-parsed).
- Modes: `--scan <path>`, `--scan-all [--check]`, `--apply <path>`, `--apply-all`.

### 2. `tests/test_scrub_papermill_paths.py` (new) — 10 tests, all pass
Detection (Windows/POSIX, drive + backslash), basename replacement, **byte-identical preservation** of everything outside the edited substring, backslash paths, dry-run no-write, ambiguous-duplicate skip, clean-noop, regex unit.

### 3. Application on `SmartContracts/06-Real-World` (4 notebooks)
SC-23, SC-24, SC-25, SC-26: **8 absolute paths fixed**. This sub-series is my active lane (audit #3164); SC-24/25 carried the defect (preserved through PR #3410's markdown round-trip).

## Verification (anti-regression + conventions)

| Gate | Result |
|------|--------|
| `git diff --stat` | 4 notebooks: 8 ins / 8 del — **metadata.papermill only** |
| diff content | Only `input_path`/`output_path` lines changed |
| Notebooks valid | All 4 JSON-parse, outputs intact (SC-23 11/11, SC-24 11/12, SC-25 7/8, SC-26 5/5 code cells with outputs) |
| Catalogue + MGS submodule | byte-identical to main |
| Rule C.2 / C.3 | metadata-only scrub, no source-code/output cell touched |
| Tests | `pytest test_scrub_papermill_paths.py` → 10 passed |
| Dry-run validation | `--scan-all` correctly reports 360 notebooks / 643 paths |

## Repo-wide scope (tracked separately)

The defect is systemic: **360 notebooks / 643 paths** across all families:

| Family | Notebooks | | Family | Notebooks |
|--------|-----------|---|--------|-----------|
| SymbolicAI | 92 | | ML | 22 |
| GenAI | 88 | | Probas | 19 |
| QuantConnect | 43 | | Sudoku | 19 |
| Search | 40 | | RL | 8 |
| GameTheory | 25 | | CaseStudies | 3 |
| | | | IIT | 1 |

This PR delivers the tool + one atomic family. The remaining scrub spans every partition and needs **coordinator dispatch by family/partition** to avoid collisions (a worker running `--apply-all` would touch 360 files = composite G.4 + cross-lane). The script makes each dispatched PR mechanical: `python scrub_papermill_paths.py --apply <family-dir>` + verify diff is metadata-only.

See coordination thread on workspace-CoursIA-2 dashboard (po-2025 signal 11:06Z).