### PR TITLE
fix(sudoku-17): relabel Few-Shot worked-example header as Exercice (#3439)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
@@ -2172,7 +2172,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Exemple guide : Few-Shot avec raisonnement guide pour Sudoku\n",
+    "## Exercice : Few-Shot avec raisonnement guide pour Sudoku\n",
     "\n",
     "### Objectif\n",
     "\n",
@@ -2270,7 +2270,7 @@
     }
    ],
    "source": [
-    "# A COMPLETER : Solveur LLM avec Few-Shot raisonne\n",
+    "# EXERCICE : Solveur LLM avec Few-Shot raisonne\n",
     "\n",
     "class FewShotReasoningSolver:\n",
     "    \"\"\"Solveur Sudoku utilisant un LLM avec few-shot et raisonnement guide.\"\"\"\n",


### PR DESCRIPTION
Closes #3439 (defect found post-merge #3421, G.1 cross-check on main).

S17 idx36 was titled `## Exemple guide : Few-Shot avec raisonnement` but the cell body is phrased as work-to-do (`### Travau demande : Implementer la classe FewShotReasoningSolver`) and the associated code cell idx39 is a stub (`# A COMPLETER`, methods `pass`, `# Exercice: Implementer...`). Classification is by content, not title (rule exercise-example-labeling, case 2): a header announcing a resolved example over a stub = mismatch. The stub is genuine (kept as-is, anti-regression) -- only the labels were wrong.

## Change (Option A, GREENLIGHT ai-01 [DONE 11:13Z])

Markdown-only relabel, **no reorder** (preserves the interleaved structure with idx37/38), **no re-exec** (API-gated LLM notebook, C.3):

| Cellule | Avant | Apres |
|---------|-------|-------|
| idx36 md (id 78722786) | `## Exemple guide : Few-Shot...` | `## Exercice : Few-Shot...` |
| idx39 code (id 3c6c33f4) | `# A COMPLETER : Solveur LLM avec Few-Shot raisonne` | `# EXERCICE : Solveur LLM avec Few-Shot raisonne` |

Consistent with the 3 other exercise pairs in S17 (idx12/13, idx20/21, idx37/38), which all use `## Exercice : <titre>` (md) + `# EXERCICE : <titre>` (code).

## Real verification

- **G1** `scan_cell_ordering.py`: 1 clean, 0 finding.
- **G2** `check_c2_compliance.py`: 1/1 compliant.
- **G3** `notebook_tools.py validate`: OK 1, Warnings 0, Errors 0.
- **G4** delta: **2 ins / 2 del** (1 markdown title + 1 code comment line). 0 changes on execution_count / outputs / metadata / papermill paths. No re-exec (C.3 markdown+comment-only).

Closes #3439
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)