### PR TITLE
docs(pymc-14): scholarly citations for decision/utility theory (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "### La valeur esperee ne suffit pas\n",
     "\n",
-    "Le **Paradoxe de Saint-Petersbourg** (1713) illustre cette limite :\n",
+    "Le **Paradoxe de Saint-Petersbourg** illustre cette limite. Formule par **Nicolas Bernoulli** en 1713 (lettre a Pierre Raymond de Montmort), il doit sa resolution a son cousin **Daniel Bernoulli (1738)** dans *Specimen theoriae novae de mensura sortis* (ou il introduit l'utilite logarithmique) :\n",
     "\n",
     "> Une piece est lancee jusqu'a obtenir Face. Si Face apparait au tour n, vous gagnez $2^n$ euros.\n",
     "> Combien paieriez-vous pour jouer ?\n",
@@ -217,7 +217,7 @@
     "| `numpy` | Calculs numeriques et generation de donnees |\n",
     "| `dataclasses` | Structure de donnees pour les loteries |\n",
     "\n",
-    "Ce notebook introduit les **fondements de la theorie de la decision**. Nous utiliserons PyMC pour l'inference bayesienne et des constructions Python pures pour les calculs d'utilite."
+    "Les packages PyMC (**Salvatier et al., 2016**) et ArviZ (**Kumar et al., 2019**) fournissent l'infrastructure d'inference bayesienne. Ce notebook introduit les **fondements de la theorie de la decision**. Nous utiliserons PyMC pour l'inference bayesienne et des constructions Python pures pour les calculs d'utilite."
    ]
   },
   {
@@ -361,7 +361,7 @@
     "> Si A > B, alors pour toute loterie C et toute probabilite p :\n",
     "> [p:A, (1-p):C] > [p:B, (1-p):C]\n",
     "\n",
-    "**Interpretation** : Les preferences ne dependent pas des alternatives non pertinentes. C'est l'axiome le plus controverse (paradoxe d'Allais, 1953)."
+    "**Interpretation** : Les preferences ne dependent pas des alternatives non pertinentes. C'est l'axiome le plus controverse : les experiences de **Maurice Allais (1953)** (*Le comportement de l'homme rationnel devant le risque*, Econometrica) ont montre que des agents rationnels le violent systematiquement, et **Daniel Ellsberg (1961)** a exhibit une aversion a l'ambiguite similaire. La Prospect Theory de **Kahneman & Tversky (1979)** proposera une refonte descriptive de ces comportements."
    ]
   },
   {
@@ -562,7 +562,7 @@
     "- B ~ C (7 = 7, indifference)\n",
     "- Donc A > C (10 > 7)\n",
     "\n",
-    "> **Note technique** : Avec une utilite concave (sqrt), la loterie B a le meme attrait que le montant certain C = 49, bien que E[B] = 98 >> 49. C'est exactement l'**aversion au risque** : l'agent prefere 49 certain a une esperance de 98 avec risque."
+    "> **Note technique** : Avec une utilite concave (sqrt), la loterie B a le meme attrait que le montant certain C = 49, bien que E[B] = 98 >> 49. C'est exactement l'**aversion au risque** (formalisee par **Pratt, 1964** et **Arrow, 1965**) : l'agent prefere 49 certain a une esperance de 98 avec risque."
    ]
   },
   {
@@ -944,7 +944,7 @@
    "source": [
     "# Calibration de l'utilite pour la decision d'assurance\n",
     "\n",
-    "# Utilite logarithmique (aversion au risque classique)\n",
+    "# Utilite logarithmique (introduite par Daniel Bernoulli, 1738 ; aversion au risque classique)\n",
     "# U(x) = log(x + 1) normalise sur [0, 10000]\n",
     "def utilite_log(x):\n",
     "    \"\"\"Utilite logarithmique normalisee.\"\"\"\n",
@@ -1085,9 +1085,11 @@
     "\n",
     "L'utilite logarithmique U(x) = log(x+1) est fortement **concave**. Perdre 10 000 EUR est catastrophique en termes d'utilite, tandis que perdre 600 EUR est marginal.\n",
     "\n",
-    "La \"prime maximale acceptable\" est le montant ou l'agent devient indifferent. C'est la **prime de risque** :\n",
+    "La \"prime maximale acceptable\" est le montant ou l'agent devient indifferent. C'est la **prime de risque** (Pratt, 1964 ; Arrow, 1965), definie comme la difference entre l'esperance du gain et l'equivalent certain :\n",
     "\n",
-    "$$\\text{Prime de risque} = E[L] - CE$$\n",
+    "$$\\text{Prime de risque} = E[X] - CE$$\n",
+    "\n",
+    "ou $X$ est le gain net de la loterie (ici la perte esperee evitee par l'assurance) et $CE$ l'equivalent certain. La formulation equivalente $U(w - \\pi) = E[U(w+X)]$ lie la prime $\\pi$ a l'utilite de la richesse $w$.\n",
     "\n",
     "Cette valeur elevee explique pourquoi les marches de l'assurance existent : les individus averses au risque sont prets a payer significativement plus que la perte esperee."
    ]
@@ -1244,7 +1246,7 @@
     "| U(E[gain]) | 35.36 | Utilite de la valeur esperee |\n",
     "| E[U(gain)] | 33.54 | Utilite esperee de la loterie |\n",
     "\n",
-    "**Inegalite de Jensen** : Pour une fonction d'utilite concave U,\n",
+    "**Inegalite de Jensen** (Jensen, 1906 ; appliquee a l'utilite par Pratt, 1964, et Arrow, 1965) : Pour une fonction d'utilite concave U,\n",
     "\n",
     "$$E[U(X)] \\leq U(E[X])$$\n",
     "\n",
@@ -1343,7 +1345,8 @@
     "EPSILON = 1.0  # Richesse minimale pour eviter U(0) = -inf\n",
     "\n",
     "def crra(x, rho):\n",
-    "    \"\"\"Utilite CRRA : U(x) = x^(1-rho) / (1-rho), ou ln(x) si rho ~ 1.\"\"\"\n",
+    "    \"\"\"Utilite CRRA (Arrow 1965 ; Pratt 1964) : U(x) = x^(1-rho) / (1-rho), ou ln(x) si rho ~ 1.\n",
+    "    Modele canonical d'aversion relative constante au risque.\"\"\"\n",
     "    x = max(x, EPSILON)\n",
     "    if abs(rho - 1.0) < 0.01:\n",
     "        return np.log(x)\n",
@@ -1458,7 +1461,7 @@
     "\n",
     "Implementer et comparer deux familles de fonctions d'utilite pour une meme loterie :\n",
     "\n",
-    "- **CARA** (Constant Absolute Risk Aversion) : U(x) = -exp(-alpha * x)\n",
+    "- **CARA** (Constant Absolute Risk Aversion, Arrow 1965 ; Pratt 1964) : U(x) = -exp(-alpha * x)\n",
     "- **CRRA** (Constant Relative Risk Aversion) : U(x) = x^(1-rho) / (1-rho)\n",
     "\n",
     "### Loterie\n",
@@ -1585,9 +1588,21 @@
     "\n",
     "## References\n",
     "\n",
-    "- Von Neumann & Morgenstern (1944) : Theory of Games and Economic Behavior\n",
-    "- Russell & Norvig : Artificial Intelligence, Chapter 16\n",
-    "- Bernoulli (1738) : Specimen Theoriae Novae de Mensura Sortis (Paradoxe de St-Petersbourg)"
+    "**Theorie de la decision et utilite esperee**\n",
+    "- Bernoulli, D. (1738) : *Specimen Theoriae Novae de Mensura Sortis* (paradoxe de Saint-Petersbourg, utilite logarithmique)\n",
+    "- Bernoulli, N. (1713) : lettre a Montmort (formulation initiale du paradoxe)\n",
+    "- Von Neumann, J. & Morgenstern, O. (1944) : *Theory of Games and Economic Behavior* (axiomes VNM, theoreme de representation)\n",
+    "- Savage, L. J. (1954) : *The Foundations of Statistics* (axiomatique subjective, sure-thing principle)\n",
+    "- Allais, M. (1953) : *Le comportement de l'homme rationnel devant le risque*, Econometrica (paradoxe d'Allais)\n",
+    "- Ellsberg, D. (1961) : *Risk, Ambiguity, and the Savage Axioms*, QJE (paradoxe d'Ellsberg)\n",
+    "- Pratt, J. W. (1964) : *Measuring Risk Aversion*, Annals of Mathematical Statistics (prime de risque, aversion absolue/relative)\n",
+    "- Arrow, K. J. (1965) : *Aspects of the Theory of Risk-Bearing* (CRRA, CARA)\n",
+    "- Kahneman, D. & Tversky, A. (1979) : *Prospect Theory*, Econometrica (aversion aux pertes)\n",
+    "\n",
+    "**Implementation**\n",
+    "- Salvatier, J., Wiecki, T. V. & Fonnesbeck, C. (2016) : *Probabilistic programming in Python using PyMC3*, PeerJ Computer Science\n",
+    "- Kumar, R. et al. (2019) : *ArviZ: a unified library for exploratory analysis of Bayesian models in Python*, JOSS\n",
+    "- Russell, S. & Norvig, P. : *Artificial Intelligence: A Modern Approach*, chapitre 16 (Making Simple Decisions)"
    ]
   },
   {


### PR DESCRIPTION
## Audit #3164 — PyMC-14-Decision-Utility-Foundations

**Verdict: OMISSIONS-MAJEURES (no REINVENTION)** — formulas and sampler choices are correct; the gap was scholarly citation density. 13 canonical decision-theory concepts were taught without source attribution.

### Fidelity check (G.1, no REINVENTION)
- VNM 4 axioms (completeness, transitivity, continuity, independence) — correctly stated
- Expected utility `EU = Σ p·u(x)` — correct
- Representation theorem "unique up to affine transform" — correct
- Jensen for concave U: `E[U(X)] ≤ U(E[X])` — correct
- CRRA `x^(1-ρ)/(1-ρ)` and CARA `-exp(-α·x)` — standard forms
- **BinaryGibbsMetropolis** for Bernoulli latents (cells 16, 27) — **correct**, no NUTS abuse on discrete latents
- Analytic Bayes check 0.659 vs MCMC 0.663 — consistent
- Real PyMC inference (2 `pm.sample` calls) — not numpy-disguised

### Fixes (markdown + 2 code-comment citations, 0 exec/output churn)

**b1 — St-Petersburg attribution (factual)** [cell c4aa6c2b]:
`Paradoxe de Saint-Petersbourg (1713)` → distinguishes Nicolas Bernoulli (1713, formulation, letter to Montmort) from Daniel Bernoulli (1738, *Specimen theoriae novae*, resolution). The bare "(1713)" was ambiguous and internally contradicted cell 34's "Bernoulli (1738)". Verified via Wikipedia + Stanford Encyclopedia of Philosophy + JSTOR + Springer (consensus: Nicolas 1713 formulated, Daniel 1738 published resolution).

**b2 — Risk premium definition (factual)** [cell 51243f3e]:
`Prime de risque = E[L] - CE` (ambiguous L=loss notation) → `Prime de risque = E[X] - CE` with the formal Pratt 1964 / Arrow 1965 definition `U(w-π) = E[U(w+X)]`. Cell 32 already used the correct form `Prime = E[gain] - CE`; this harmonizes cell 25.

**c — Omission citations added inline** (13 concepts → sourced):
- Cell 9cf659ff: Allais (1953, *Le comportement de l'homme rationnel...*, Econometrica), Ellsberg (1961), Kahneman & Tversky (1979, Prospect Theory) at the independence-axiom controversy
- Cell ad7afa3b: Pratt (1964) + Arrow (1965) at the formal "aversion au risque" introduction
- Cell 76a6c11f: Jensen (1906) + Pratt/Arrow at the certainty-equivalent/Jensen statement
- Cell ed7b5da1 (code comment): Daniel Bernoulli (1738) at log-utility
- Cell 3964b865 (code comment): Arrow 1965 / Pratt 1964 at CRRA
- Cell bfa3c403: Arrow 1965 / Pratt 1964 at CARA
- Cell 601d2260: Salvatier et al. (2016) PyMC + Kumar et al. (2019) ArviZ (packages printed in cell 4)

**References block** [cell b723b721]: expanded 3 → 12 sources (added Savage 1954, Allais 1953, Ellsberg 1961, Pratt 1964, Arrow 1965, Kahneman & Tversky 1979, Nicolas Bernoulli 1713, Salvatier 2016, Kumar 2019).

### Validation
| Check | Result |
|-------|--------|
| nbformat | OK (no errors) |
| scan_cell_ordering | clean (0 finding) |
| C.1 (no voluntary error) | 0 violation |
| C.3 (exec/output churn) | 0 `execution_count`/`outputs` lines added |
| Code cells outputs preserved | 11/11 retain exec_count+outputs |
| Insurance prime output | 3691 EUR intact (code-comment edits non-semantic) |
| Catalog | byte-identical (no drift) |
| Diff | +28/-13, 1 file |

Markdown + 2 code-comment citations → C.2 re-exec exception applies (comment-only edits preserve existing outputs).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
