### PR TITLE
chore(infer): scrub absolute papermill paths from 4 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
@@ -2219,8 +2219,8 @@
    "end_time": "2026-06-09T04:39:23.953934",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Infer-1-Setup.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Infer-1-Setup_output.ipynb",
+   "input_path": "Infer-1-Setup.ipynb",
+   "output_path": "Infer-1-Setup.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T04:39:12.946947",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Decision-Networks.ipynb
@@ -3679,8 +3679,8 @@
    "end_time": "2026-06-09T04:40:15.825355",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Infer-17-Decision-Networks.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Infer-17-Decision-Networks_output.ipynb",
+   "input_path": "Infer-17-Decision-Networks.ipynb",
+   "output_path": "Infer-17-Decision-Networks.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T04:40:05.814322",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-20b-Lean-Gittins.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-20b-Lean-Gittins.ipynb
@@ -2901,8 +2901,8 @@
    "end_time": "2026-06-04T22:49:30.435571+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA-2/MyIA.AI.Notebooks/Probas/Infer/Infer-20b-Lean-Gittins.ipynb",
-   "output_path": "/mnt/c/Users/jsboi/AppData/Local/Temp/gittins_exec.ipynb",
+   "input_path": "Infer-20b-Lean-Gittins.ipynb",
+   "output_path": "Infer-20b-Lean-Gittins.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T22:49:20.298014+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-6-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-6-TrueSkill.ipynb
@@ -4074,8 +4074,8 @@
    "end_time": "2026-06-09T04:39:49.059654",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Infer-6-TrueSkill.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Infer-6-TrueSkill_output.ipynb",
+   "input_path": "Infer-6-TrueSkill.ipynb",
+   "output_path": "Infer-6-TrueSkill.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T04:39:35.262049",
    "version": "2.6.0"


### PR DESCRIPTION
Part of #3436 (repo-wide papermill abs-path scrub, dispatched per-family by ai-01 [DONE 13:12Z]). po-2025 partition, Probas/Infer.NET family.

Applied `scripts/notebook_tools/scrub_papermill_paths.py` (tool landed on main via #3435). 8 absolute paths scrubbed to relative basenames across 4 notebooks:

| Notebook | Before | After |
|----------|--------|-------|
| Infer-1-Setup | `C:\dev\CoursIA-2\...` (Win) | relative basename |
| Infer-17-Decision-Networks | `C:\dev\CoursIA-2\...` (Win) | relative basename |
| Infer-6-TrueSkill | `C:\dev\CoursIA-2\...` (Win) | relative basename |
| Infer-20b-Lean-Gittins | `/mnt/c/...`, `/mnt/d/...` (WSL POSIX, lean4-wsl kernel) | relative basename |

## Verification

- **Metadata-only**: only papermill `input_path`/`output_path` keys changed. All cell sources / outputs / execution_count byte-identical (deep-compared). Other papermill metadata (duration, version, start/end_time, exception) unchanged.
- **Post-apply scan**: 0 defect (`scrub_papermill_paths.py --scan MyIA.AI.Notebooks/Probas/Infer`).
- **validate**: OK 0 for all 4 notebooks.
- Diff: 4 files × 4 lines (8 ins / 8 del).

Partition: po-2025:CoursIA-2 (Probas/Infer family). No collision (Infer = unambiguously po-2025).

See #3436
See #3435 (scrub tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)