### PR TITLE
chore(sudoku-python): scrub absolute papermill paths from 10 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -1779,7 +1779,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Sudoku-1-Backtracking-Python.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sudoku1-test.ipynb",
+   "output_path": "Sudoku-1-Backtracking-Python.ipynb",
    "parameters": {},
    "start_time": "2026-06-01T20:39:12.737056+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -1234,8 +1234,8 @@
    "end_time": "2026-06-02T21:28:57.809063+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-10-ORTools-Python.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-10-ORTools-Python_output.ipynb",
+   "input_path": "Sudoku-10-ORTools-Python.ipynb",
+   "output_path": "Sudoku-10-ORTools-Python.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T21:28:41.925174+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
@@ -1248,8 +1248,8 @@
    "end_time": "2026-06-02T21:48:54.184797+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-12-Z3-Python.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-12-Z3-Python_output.ipynb",
+   "input_path": "Sudoku-12-Z3-Python.ipynb",
+   "output_path": "Sudoku-12-Z3-Python.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T21:48:46.779751+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
@@ -3534,8 +3534,8 @@
    "end_time": "2026-04-25T14:55:48.087310",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-16-NeuralNetwork-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-16-NeuralNetwork-Python_output.ipynb",
+   "input_path": "Sudoku-16-NeuralNetwork-Python.ipynb",
+   "output_path": "Sudoku-16-NeuralNetwork-Python.ipynb",
    "parameters": {},
    "start_time": "2026-04-25T14:53:09.877900",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
@@ -2421,8 +2421,8 @@
    "end_time": "2026-06-02T13:05:17.753270+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-17-LLM-Python.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-17-LLM-Python_output.ipynb",
+   "input_path": "Sudoku-17-LLM-Python.ipynb",
+   "output_path": "Sudoku-17-LLM-Python.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T13:05:04.180983+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -2870,7 +2870,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sudoku18_exec.ipynb",
+   "output_path": "Sudoku-18-Comparison-Python.ipynb",
    "parameters": {},
    "start_time": "2026-05-30T07:33:44.059562+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
@@ -1854,7 +1854,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sudoku2.ipynb",
+   "output_path": "Sudoku-2-DancingLinks-Python.ipynb",
    "parameters": {},
    "start_time": "2026-05-13T07:58:03.197644",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
@@ -1809,8 +1809,8 @@
    "end_time": "2026-05-14T07:43:58.103191+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-3-Genetic-Python.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-3-Genetic-Python_output.ipynb",
+   "input_path": "Sudoku-3-Genetic-Python.ipynb",
+   "output_path": "Sudoku-3-Genetic-Python.ipynb",
    "parameters": {},
    "start_time": "2026-05-14T07:40:09.547119+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
@@ -2767,7 +2767,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sudoku4.ipynb",
+   "output_path": "Sudoku-4-SimulatedAnnealing-Python.ipynb",
    "parameters": {},
    "start_time": "2026-05-13T07:58:03.197644",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -2627,8 +2627,8 @@
    "end_time": "2026-05-02T18:34:37.077777",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-8-HumanStrategies-Python.ipynb",
-   "output_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-8-HumanStrategies-Python.ipynb",
+   "input_path": "Sudoku-8-HumanStrategies-Python.ipynb",
+   "output_path": "Sudoku-8-HumanStrategies-Python.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:34:34.293848",
    "version": "2.6.0"


### PR DESCRIPTION
Part of #3436 (repo-wide papermill abs-path scrub, dispatched per-family by ai-01 [DONE 13:12Z]). po-2025 partition, Sudoku **Python** family.

Applied `scripts/notebook_tools/scrub_papermill_paths.py` (tool from #3435). 16 absolute paths scrubbed to relative basenames across 10 tracked Python notebooks. Sources include both `D:\dev\CoursIA-2\...` and `D:\dev\CoursIA\...` (pre-rename).

## Anti-collision
- **C# Sudoku notebooks = po-2024 partition** (anti-collision by extension, per ai-01 directive).
- The 8 `*_output.ipynb` artifacts in `Sudoku/` are **gitignored (untracked)** — excluded from this PR (verified `git ls-files --error-unmatch` = UNTRACKED, `git check-ignore` = IGNORED).

## Verification
- **Metadata-only**: only papermill `input_path`/`output_path` keys changed. All cell sources / outputs / execution_count byte-identical (deep-compared on sample). Other papermill metadata (duration, version) preserved.
- **Post-apply scan**: 0 defect on all 10 notebooks.
- **validate**: OK, 0 errors on all 10.
- Diff: 10 files, 16 ins / 16 del.

See #3436
See #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)