### PR TITLE
chore(pymc): scrub absolute papermill paths from 14 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Sequences.ipynb
@@ -1681,8 +1681,8 @@
    "end_time": "2026-06-03T06:00:10.488867+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-11-Sequences.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-11-Sequences_output.ipynb",
+   "input_path": "PyMC-11-Sequences.ipynb",
+   "output_path": "PyMC-11-Sequences.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T05:59:01.976284+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Recommenders.ipynb
@@ -2474,7 +2474,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "PyMC-12-Recommenders.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice1/PyMC-12-Recommenders.ipynb",
+   "output_path": "PyMC-12-Recommenders.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T03:48:30.721958+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Debugging.ipynb
@@ -2299,8 +2299,8 @@
    "end_time": "2026-06-15T04:28:40.194429+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/dev/CoursIA/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Debugging.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice2a/PyMC-13-Debugging.out.ipynb",
+   "input_path": "PyMC-13-Debugging.ipynb",
+   "output_path": "PyMC-13-Debugging.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T04:25:16.130282+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb
@@ -3464,8 +3464,8 @@
    "end_time": "2026-06-15T04:29:57.624530+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/dev/CoursIA/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice2a/PyMC-15-Decision-Utility-Money.out.ipynb",
+   "input_path": "PyMC-15-Decision-Utility-Money.ipynb",
+   "output_path": "PyMC-15-Decision-Utility-Money.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T04:28:43.260206+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb
@@ -2657,8 +2657,8 @@
    "end_time": "2026-06-15T04:53:23.355932+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/dev/CoursIA/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice2b/PyMC-16-Decision-Multi-Attribute.fix.ipynb",
+   "input_path": "PyMC-16-Decision-Multi-Attribute.ipynb",
+   "output_path": "PyMC-16-Decision-Multi-Attribute.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T04:52:45.849660+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb
@@ -3534,8 +3534,8 @@
    "end_time": "2026-06-15T04:49:47.983266+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/dev/CoursIA/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice2b/PyMC-18-Decision-Value-Information.out.ipynb",
+   "input_path": "PyMC-18-Decision-Value-Information.ipynb",
+   "output_path": "PyMC-18-Decision-Value-Information.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T04:49:18.536293+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb
@@ -3106,7 +3106,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "PyMC-19-Decision-Expert-Systems.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice1/PyMC-19-Decision-Expert-Systems.ipynb",
+   "output_path": "PyMC-19-Decision-Expert-Systems.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T03:41:29.676378+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
@@ -1228,8 +1228,8 @@
    "end_time": "2026-06-03T06:16:11.833310+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-2-Gaussian-Mixtures.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-2-Gaussian-Mixtures_output.ipynb",
+   "input_path": "PyMC-2-Gaussian-Mixtures.ipynb",
+   "output_path": "PyMC-2-Gaussian-Mixtures.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T06:11:24.868792+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb
@@ -4643,7 +4643,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "PyMC-20-Decision-Sequential.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice1/PyMC-20-Decision-Sequential.ipynb",
+   "output_path": "PyMC-20-Decision-Sequential.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T03:33:38.417359+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
@@ -830,8 +830,8 @@
    "end_time": "2026-06-03T06:18:41.287307+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-3-Factor-Graphs.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-3-Factor-Graphs_output.ipynb",
+   "input_path": "PyMC-3-Factor-Graphs.ipynb",
+   "output_path": "PyMC-3-Factor-Graphs.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T06:16:30.664832+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
@@ -1381,8 +1381,8 @@
    "end_time": "2026-06-03T06:25:01.718176+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-4-Bayesian-Networks.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-4-Bayesian-Networks_output.ipynb",
+   "input_path": "PyMC-4-Bayesian-Networks.ipynb",
+   "output_path": "PyMC-4-Bayesian-Networks.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T06:19:05.333859+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Skills-IRT.ipynb
@@ -1494,8 +1494,8 @@
    "end_time": "2026-06-03T06:27:39.794497+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-5-Skills-IRT.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-5-Skills-IRT_output.ipynb",
+   "input_path": "PyMC-5-Skills-IRT.ipynb",
+   "output_path": "PyMC-5-Skills-IRT.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T06:25:07.325466+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-TrueSkill.ipynb
@@ -1736,7 +1736,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "PyMC-6-TrueSkill.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice1/PyMC-6-TrueSkill.ipynb",
+   "output_path": "PyMC-6-TrueSkill.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T03:42:09.889843+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Classification.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Classification.ipynb
@@ -1301,7 +1301,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "PyMC-7-Classification.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pymc_slice1/PyMC-7-Classification.ipynb",
+   "output_path": "PyMC-7-Classification.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T03:37:42.985914+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
Part of #3436 (repo-wide papermill abs-path scrub, ai-01 [DONE 13:12Z]). po-2025 partition, Probas/PyMC family.

Applied `scripts/notebook_tools/scrub_papermill_paths.py` (tool from #3435). ~23 absolute paths scrubbed to relative basenames across 14 tracked notebooks.

## Verification
- **Metadata-only**: only papermill `input_path`/`output_path` keys changed. Cells/outputs/execution_count byte-identical (deep-compared on sample). Other papermill metadata (duration, version) preserved.
- **Post-apply scan**: 0 defect on all 14.
- **validate**: OK, 0 errors on all 20 PyMC notebooks.
- Diff: 14 files, 23 ins / 23 del.

Partition: po-2025:CoursIA-2 (Probas/PyMC). No collision.

See #3436
See #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)