### PR TITLE
fix(sudoku): scrub absolute papermill paths in 9 Sudoku-C# notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
@@ -831,8 +831,8 @@
    "end_time": "2026-05-02T18:17:16.845607+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-0-Environment-Csharp.ipynb",
-   "output_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-0-Environment-Csharp.ipynb",
+   "input_path": "Sudoku-0-Environment-Csharp.ipynb",
+   "output_path": "Sudoku-0-Environment-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:17:12.229972+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -1105,8 +1105,8 @@
    "end_time": "2026-05-02T18:17:42.932787+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-1-Backtracking-Csharp.ipynb",
-   "output_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-1-Backtracking-Csharp.ipynb",
+   "input_path": "Sudoku-1-Backtracking-Csharp.ipynb",
+   "output_path": "Sudoku-1-Backtracking-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:17:33.038247+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -3181,8 +3181,8 @@
    "end_time": "2026-04-25T14:47:55.533063",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-14-BDD-Csharp.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-14-BDD-Csharp_output.ipynb",
+   "input_path": "Sudoku-14-BDD-Csharp.ipynb",
+   "output_path": "Sudoku-14-BDD-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-04-25T14:47:46.551979",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
@@ -1456,8 +1456,8 @@
    "end_time": "2026-05-02T18:18:34.595211+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-2-DancingLinks-Csharp.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-2-DancingLinks-Csharp.ipynb",
+   "input_path": "Sudoku-2-DancingLinks-Csharp.ipynb",
+   "output_path": "Sudoku-2-DancingLinks-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:18:23.285799+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
@@ -1085,8 +1085,8 @@
    "end_time": "2026-05-02T18:19:22.310267+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-3-Genetic-Csharp.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-3-Genetic-Csharp.ipynb",
+   "input_path": "Sudoku-3-Genetic-Csharp.ipynb",
+   "output_path": "Sudoku-3-Genetic-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:18:37.100226+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -2382,8 +2382,8 @@
    "end_time": "2026-05-02T18:23:07.319245+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-5-PSO-Csharp.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-5-PSO-Csharp.ipynb",
+   "input_path": "Sudoku-5-PSO-Csharp.ipynb",
+   "output_path": "Sudoku-5-PSO-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:21:55.357600+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -1951,8 +1951,8 @@
    "end_time": "2026-05-02T18:25:16.343121+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-6-AIMA-CSP-Csharp.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-6-AIMA-CSP-Csharp.ipynb",
+   "input_path": "Sudoku-6-AIMA-CSP-Csharp.ipynb",
+   "output_path": "Sudoku-6-AIMA-CSP-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:23:09.710901+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
@@ -1492,8 +1492,8 @@
    "end_time": "2026-05-02T18:25:35.916324",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-7-Norvig-Csharp.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-7-Norvig-Csharp.ipynb",
+   "input_path": "Sudoku-7-Norvig-Csharp.ipynb",
+   "output_path": "Sudoku-7-Norvig-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:25:20.082679",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
@@ -1867,8 +1867,8 @@
    "end_time": "2026-05-02T18:26:40.096700",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Csharp.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Csharp.ipynb",
+   "input_path": "Sudoku-9-GraphColoring-Csharp.ipynb",
+   "output_path": "Sudoku-9-GraphColoring-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:26:10.670118",
    "version": "2.6.0"


### PR DESCRIPTION
## Context

Executing ai-01's TERRAIN VIERGE 1 directive ([DONE 13:12Z]): scrub papermill absolute paths on my partition (po-2024), 1 PR atomique per sub-series. The reusable tool `scrub_papermill_paths.py` is now on main (#3435 merged).

This PR covers **Sudoku-C#** (my partition). Anti-collision: Sudoku-Python is po-2025's lane (#3451).

## What changed

9 Sudoku-C# notebooks had absolute machine-local paths in `metadata.papermill.output_path` / `input_path`:

```
input_path:  "D:\dev\CoursIA\MyIA.AI.Notebooks\Sudoku\Sudoku-3-Genetic-Csharp.ipynb"
output_path: "D:\dev\CoursIA\...\Sudoku-3-Genetic-Csharp.ipynb"
```

Note `CoursIA` (no `-2`) -- some paths predate the repo rename. These leak the contributor's local dir and point to since-deleted files.

Replaced with the relative basename (`Sudoku-3-Genetic-Csharp.ipynb`) -- the target state proven by cleanly-executed notebooks (e.g. SC-10).

## Verification (G.1 + conventions)

| Gate | Result |
|------|--------|
| Tool | `scripts/notebook_tools/scrub_papermill_paths.py` (#3435), no ad-hoc |
| Method | text-level surgical edit, byte-identical outside replaced key:value |
| `git diff --stat` | 9 notebooks: 18 ins / 18 del -- metadata.papermill only |
| diff content | only `input_path`/`output_path` lines |
| JSON valid | all 9 parse, outputs intact (100% code cells retain outputs) |
| Anti-collision | Sudoku-C# only (po-2024); `-Python` excluded (po-2025 #3451); `_output`/`_executed` excluded by tool |
| Catalogue + MGS submodule | byte-identical to main |
| Post-apply scan | 0 defects remaining on the 9 |

Notebooks: Sudoku-0-Environment, -1-Backtracking, -2-DancingLinks, -3-Genetic, -5-PSO, -6-AIMA-CSP, -7-Norvig, -9-GraphColoring, -14-BDD (all -Csharp).

Atomic metadata-only single-sub-series PR. Subsequent sub-series (Search/Applications, SmartContracts remainder, GameTheory, SymbolicAI/*) to follow as separate PRs per ai-01 directive.