### PR TITLE
docs(pymc-15): scholarly citations for money/utility decision theory (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb
@@ -62,7 +62,7 @@
     "\n",
     "$$E[\\text{gain}] = \\sum_{n=1}^{\\infty} \\frac{1}{2^n} \\times 2^n = \\sum_{n=1}^{\\infty} 1 = \\infty$$\n",
     "\n",
-    "La valeur esperee est **infinie**, pourtant personne ne paierait plus que quelques dizaines d'euros pour jouer. La resolution vient de l'utilite marginale decroissante de l'argent."
+    "La valeur esperee est **infinie**, pourtant personne ne paierait plus que quelques dizaines d'euros pour jouer. La resolution vient de l'utilite marginale decroissante de l'argent, proposee par **Daniel Bernoulli (1738)** dans *Specimen theoriae novae de mensura sortis* (le paradoxe lui-meme etant du a **Nicolas Bernoulli, 1713**). Ce paradoxe fonde la theorie moderne de l'utilite esperee, axiomatisee plus tard par **von Neumann & Morgenstern (1944)**."
    ]
   },
   {
@@ -124,6 +124,7 @@
     "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
     "warnings.filterwarnings(\"ignore\", category=UserWarning)\n",
     "\n",
+    "# PyMC (Salvatier, Wiecki & Fonnesbeck, 2016) + ArviZ (Kumar et al., 2019)\n",
     "RANDOM_SEED = 42\n",
     "rng = np.random.default_rng(RANDOM_SEED)\n",
     "\n",
@@ -501,7 +502,7 @@
    "source": [
     "## 3. Fonctions d'Utilite CARA et CRRA\n",
     "\n",
-    "Deux familles de fonctions d'utilite sont fondamentales en economie :\n",
+    "Deux familles de fonctions d'utilite sont fondamentales (introduites par **Pratt, 1964** et **Arrow, 1965**) en economie :\n",
     "\n",
     "| Famille | Formule | Parametre | Aversion |\n",
     "|---------|---------|-----------|----------|\n",
@@ -648,7 +649,7 @@
    "source": [
     "## 4. Coefficients d'Arrow-Pratt\n",
     "\n",
-    "Les coefficients d'Arrow-Pratt mesurent l'aversion au risque d'une fonction d'utilite :\n",
+    "Les coefficients d'Arrow-Pratt (**Pratt, 1964** ; **Arrow, 1965**) mesurent l'aversion au risque d'une fonction d'utilite :\n",
     "\n",
     "- **ARA** (Absolute Risk Aversion) : $r_a(x) = -\\frac{U''(x)}{U'(x)}$\n",
     "- **RRA** (Relative Risk Aversion) : $r_r(x) = x \\cdot r_a(x) = -\\frac{x \\cdot U''(x)}{U'(x)}$\n",
@@ -1180,7 +1181,7 @@
    "source": [
     "## 6. Dominance Stochastique\n",
     "\n",
-    "La **dominance stochastique du premier ordre** (FSD) permet de comparer deux loteries sans connaitre la fonction d'utilite precise :\n",
+    "La **dominance stochastique du premier ordre** (FSD ; **Hadar & Russell, 1969** ; **Hanoch & Levy, 1969**) permet de comparer deux loteries sans connaitre la fonction d'utilite precise :\n",
     "\n",
     "> $L_1$ domine $L_2$ au premier ordre si $F_1(x) \\leq F_2(x)$ pour tout $x$, avec inegalite stricte pour au moins un $x$.\n",
     "\n",
@@ -1427,7 +1428,7 @@
    "source": [
     "## 7. Choix d'Investissement : Application\n",
     "\n",
-    "Trois actifs avec rendements differents. Un investisseur CRRA choisit en fonction de son coefficient $\\rho$."
+    "Trois actifs avec rendements differents. La cadre mean-variance de ce choix d'allocation est du a **Markowitz (1952)** (*Portfolio Selection*, Journal of Finance) — frontiere efficiente et diversification. Un investisseur CRRA choisit en fonction de son coefficient $\\rho$."
    ]
   },
   {
@@ -2761,7 +2762,7 @@
     "tags": []
    },
    "source": [
-    "**Lecture.** Le posterior se concentre autour de la vraie valeur $\\rho_{\\text{vrai}}=2.5$ : avec 60 decisions, l'inference recupere fidelement l'aversion au risque latente. L'incertitude residuelle reflete le bruit du modele de choix logistique (parametre $\\kappa$)."
+    "**Lecture.** Le posterior est **compatible** avec la vraie valeur $\\rho_{\\text{vrai}}=2.5$ (contenue dans le HDI 89%), mais la moyenne postérieure vaut $\\rho \\approx 2.99$ (biais positif de l'ordre de +20%), et $\\kappa \\approx 4.13$ vs vrai 6.0. Cet écart reflète le bruit du modèle de choix logistique avec seulement 60 décisions — l'inference identifie le bon ordre de grandeur mais n'est pas une récupération précise. Avec davantage de décisions, le posterior se resserrerait autour de la vraie valeur."
    ]
   },
   {
@@ -3316,7 +3317,7 @@
     "\n",
     "### Objectif\n",
     "\n",
-    "Calculer la **Value at Risk (VaR)** et la **Conditional VaR (CVaR)** d'un portefeuille a 2 actifs, pour differents niveaux de confiance.\n",
+    "Calculer la **Value at Risk (VaR)** (formalisee par J.P. Morgan RiskMetrics, 1996) et la **Conditional VaR (CVaR)**, une mesure de risque **coherente** au sens d'**Artzner, Delbaen, Eber & Heath (1999)** (*Coherent Measures of Risk*) d'un portefeuille a 2 actifs, pour differents niveaux de confiance.\n",
     "\n",
     "### Rappels\n",
     "\n",
@@ -3433,10 +3434,21 @@
     "\n",
     "## References\n",
     "\n",
-    "- Bernoulli (1738) : Specimen Theoriae Novae de Mensura Sortis\n",
-    "- Arrow (1965) : Aspects of the Theory of Risk-Bearing\n",
-    "- Pratt (1964) : Risk Aversion in the Small and in the Large\n",
-    "- Russell & Norvig : Artificial Intelligence, Chapter 16"
+    "**Theorie de la decision et aversion au risque**\n",
+    "- Bernoulli, D. (1738) : *Specimen Theoriae Novae de Mensura Sortis* (paradoxe de Saint-Petersbourg, utilite logarithmique)\n",
+    "- Bernoulli, N. (1713) : lettre a Montmort (formulation du paradoxe)\n",
+    "- Von Neumann, J. & Morgenstern, O. (1944) : *Theory of Games and Economic Behavior* (axiomes VNM, utilite esperee)\n",
+    "- Pratt, J. W. (1964) : *Risk Aversion in the Small and in the Large*, Econometrica 32:122-136 (coefficients ARA/RRA, prime de risque)\n",
+    "- Arrow, K. J. (1965) : *Aspects of the Theory of Risk-Bearing (CARA/CRRA)\n",
+    "- Markowitz, H. (1952) : *Portfolio Selection*, Journal of Finance 7:77-91 (mean-variance, frontiere efficiente)\n",
+    "- Hadar, J. & Russell, W. (1969) ; Hanoch, G. & Levy, H. (1969) : dominance stochastique du premier ordre\n",
+    "- Artzner, P., Delbaen, F., Eber, J.-M. & Heath, D. (1999) : *Coherent Measures of Risk*, Mathematical Finance 9:203-228 (VaR/CVaR)\n",
+    "- Kahneman, D. & Tversky, A. (1979) : *Prospect Theory*, Econometrica (limites descriptives de l'utilite esperee)\n",
+    "\n",
+    "**Implementation**\n",
+    "- Salvatier, J., Wiecki, T. V. & Fonnesbeck, C. (2016) : *Probabilistic programming in Python using PyMC3*, PeerJ Computer Science\n",
+    "- Kumar, R. et al. (2019) : *ArviZ: a unified library for exploratory analysis of Bayesian models in Python*, JOSS\n",
+    "- Russell, S. & Norvig, P. : *Artificial Intelligence: A Modern Approach*, chapitre 16"
    ]
   }
  ],


### PR DESCRIPTION
## Audit #3164 — PyMC-15-Decision-Utility-Money

**Verdict: OMISSIONS-MAJEURES (no REINVENTION)** — formulas and PyMC usage correct; gap is scholarly citation density (13 concepts without source attribution in the body).

### Fidelity check (G.1, no REINVENTION)
- St-Petersbourg `E[gain]=Σ(1/2ⁿ)·2ⁿ=∞` — correct
- CARA `-exp(-αx)`, CRRA `x^(1-ρ)/(1-ρ)`, ln(x) if ρ=1 — standard forms
- Arrow-Pratt ARA `-U''/U'`, RRA `x·ARA` — correct, validated for CARA (ARA=α, RRA=αx) and CRRA (ARA=ρ/x, RRA=ρ)
- Certainty equivalent `U(CE)=E[U(X)]` by bisection — correct
- Risk premium `π=E[X]-CE` + Arrow-Pratt approximation `π≈½·ARA(w₀)·Var(X)` — correct (numerically validated, <0.1% error for small stakes)
- First-order stochastic dominance `F₁(x)≤F₂(x)` — correct
- Bayesian inference: Beta-Bernoulli posterior Beta(5,9), E[θ]=5/14≈0.357 vs MCMC 0.360 — consistent
- Real PyMC (2 `pm.Model`, 3 `pm.sample`, NUTS 4 chains, ArviZ diagnostics) — not numpy-disguised

### Key G.1 finding (misleading peek)
The pre-audit peek showed "Arrow 15 occ. / Pratt 15 occ. / Bernoulli 9 occ." suggesting strong sourcing. **This was misleading:**
- **Arrow/Pratt** appear only as **concept names** ("coefficients d'Arrow-Pratt"), never with author+year in the body (only in final References).
- **Bernoulli 9 occ.** = `pm.Bernoulli` distribution (7×) + Beta-Bernoulli + a table row, **not** Daniel Bernoulli the author (never named in the St-Petersbourg body).

### Fixes (markdown + 1 code-comment citation, 0 exec/output churn)

**b1 — factual overstatement** [cell p15b-md-05]:
The markdown claimed *"l'inference recupere fidelement"* ρ_vrai=2.5, but the output (cell p15b-code-06) shows `rho = 2.990 ± 0.729 (vrai 2.5)` (bias +20%) and `kappa = 4.127 ± 1.613 (vrai 6.0)` (bias -31%). Rewritten to an honest formulation: compatible with the true value (in HDI 89%) but not a precise recovery — reflects the noise of the logistic choice model with only 60 decisions. No cherry-picking (same lesson as PyMC-13 ADVI table).

**c — Omission citations added inline** (13 concepts → sourced):
- Cell cell-1: Daniel Bernoulli (1738, *Specimen theoriae novae*) + Nicolas Bernoulli (1713) + vNM (1944) at St-Petersbourg resolution
- Cell cell-9: Pratt 1964 / Arrow 1965 at CARA/CRRA introduction
- Cell cell-12: Pratt 1964 / Arrow 1965 at ARA/RRA coefficients
- Cell cell-18: Hadar&Russell 1969 / Hanoch&Levy 1969 at stochastic dominance
- Cell cell-21: Markowitz 1952 (*Portfolio Selection*) at investment choice
- Cell cell-29: Artzner et al. 1999 (*Coherent Measures of Risk*) at VaR/CVaR
- Cell cell-3 (code comment): Salvatier 2016 PyMC + Kumar 2019 ArviZ at imports

**References block** [cell cell-31]: expanded 4 → 13 sources (+ Nicolas Bernoulli 1713, vNM 1944, Markowitz 1952, Hadar&Russell+Hanoch&Levy 1969, Artzner 1999, Kahneman&Tversky 1979, Salvatier 2016, Kumar 2019).

### Validation
| Check | Result |
|-------|--------|
| nbformat | OK (no errors) |
| scan_cell_ordering | clean (0 finding) |
| C.1 (no voluntary error) | 0 violation |
| C.3 (exec/output churn) | 0 `execution_count`/`outputs` lines added |
| Code cells outputs preserved | 28/28 retain exec_count+outputs |
| cell-3 versions output | PyMC 5.28.5 / ArviZ 0.23.4 intact (comment edit non-semantic) |
| Catalog | byte-identical (no drift) |
| Diff | +23/-11, 1 file |

Markdown + 1 code-comment citation → C.2 re-exec exception applies (comment-only edit preserves existing outputs).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
