### PR TITLE
fix(search): scrub absolute papermill paths in Applications (17 nb, 33 paths)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb
@@ -2672,8 +2672,8 @@
    "end_time": "2026-06-06T08:50:10.115775",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb",
-   "output_path": "d:/tmp/h3_app1b.ipynb",
+   "input_path": "App-1-NQueens.ipynb",
+   "output_path": "App-1-NQueens.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
@@ -2583,8 +2583,8 @@
    "end_time": "2026-06-06T08:44:31.251274",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb",
-   "output_path": "d:/tmp/h3_app11b.ipynb",
+   "input_path": "App-11-Picross.ipynb",
+   "output_path": "App-11-Picross.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb
@@ -2354,8 +2354,8 @@
    "end_time": "2026-06-08T22:40:01.160224+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-15-SportsScheduling.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-15-SportsScheduling_output.ipynb",
+   "input_path": "App-15-SportsScheduling.ipynb",
+   "output_path": "App-15-SportsScheduling.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T22:39:52.186030+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb
@@ -1400,8 +1400,8 @@
    "end_time": "2026-06-02T23:06:19.116289+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-16-Crossword-CSP.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-16-Crossword-CSP_output.ipynb",
+   "input_path": "App-16-Crossword-CSP.ipynb",
+   "output_path": "App-16-Crossword-CSP.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T23:06:11.069708+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
@@ -1537,8 +1537,8 @@
    "end_time": "2026-06-03T00:10:26.256439+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-19-ProceduralGeneration-WFC.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-19-ProceduralGeneration-WFC_output.ipynb",
+   "input_path": "App-19-ProceduralGeneration-WFC.ipynb",
+   "output_path": "App-19-ProceduralGeneration-WFC.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:09:50.081657+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
@@ -2730,8 +2730,8 @@
    "end_time": "2026-06-06T08:39:13.021870",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-2-GraphColoring.ipynb",
-   "output_path": "d:\\tmp\\h3_app2b.ipynb",
+   "input_path": "App-2-GraphColoring.ipynb",
+   "output_path": "App-2-GraphColoring.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
@@ -2596,8 +2596,8 @@
    "end_time": "2026-05-14T19:46:21.726375+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-3-NurseScheduling.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-3-NurseScheduling_output.ipynb",
+   "input_path": "App-3-NurseScheduling.ipynb",
+   "output_path": "App-3-NurseScheduling.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb
@@ -3070,8 +3070,8 @@
    "end_time": "2026-06-08T22:39:49.510072+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-4-JobShopScheduling.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-4-JobShopScheduling_output.ipynb",
+   "input_path": "App-4-JobShopScheduling.ipynb",
+   "output_path": "App-4-JobShopScheduling.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T22:39:35.453184+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
@@ -2707,8 +2707,8 @@
    "end_time": "2026-06-06T08:39:43.028276",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-5-Timetabling.ipynb",
-   "output_path": "d:\\tmp\\h3_app5b.ipynb",
+   "input_path": "App-5-Timetabling.ipynb",
+   "output_path": "App-5-Timetabling.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
@@ -3139,8 +3139,8 @@
    "end_time": "2026-06-06T08:40:30.294310",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-6-Minesweeper.ipynb",
-   "output_path": "d:\\tmp\\h3_app6b.ipynb",
+   "input_path": "App-6-Minesweeper.ipynb",
+   "output_path": "App-6-Minesweeper.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
@@ -2733,8 +2733,8 @@
    "end_time": "2026-06-06T08:40:53.438707",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-7-Wordle.ipynb",
-   "output_path": "d:\\tmp\\h3_app7b.ipynb",
+   "input_path": "App-7-Wordle.ipynb",
+   "output_path": "App-7-Wordle.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
@@ -2719,8 +2719,8 @@
    "end_time": "2026-04-25T15:21:13.096151",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-8-MiniZinc.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-8-MiniZinc_output.ipynb",
+   "input_path": "App-8-MiniZinc.ipynb",
+   "output_path": "App-8-MiniZinc.ipynb",
    "parameters": {},
    "start_time": "2026-04-25T15:21:08.795176",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
@@ -1944,7 +1944,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "App-10-Portfolio.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/search_papermill/App-10-Portfolio.ipynb",
+   "output_path": "App-10-Portfolio.ipynb",
    "parameters": {},
    "start_time": "2026-06-05T16:41:08.212267+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
@@ -952,8 +952,8 @@
    "end_time": "2026-06-03T05:35:19.328224+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Applications\\Hybrid\\App-10b-Portfolio-CSharp.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Applications\\Hybrid\\App-10b-Portfolio-CSharp_output.ipynb",
+   "input_path": "App-10b-Portfolio-CSharp.ipynb",
+   "output_path": "App-10b-Portfolio-CSharp.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T05:35:08.718183+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17-VRP-Logistics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17-VRP-Logistics.ipynb
@@ -1213,8 +1213,8 @@
    "end_time": "2026-06-01T13:00:09.517020+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\Hybrid\\App-17-VRP-Logistics.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\Hybrid\\App-17-VRP-Logistics_output.ipynb",
+   "input_path": "App-17-VRP-Logistics.ipynb",
+   "output_path": "App-17-VRP-Logistics.ipynb",
    "parameters": {},
    "start_time": "2026-06-01T13:00:06.192642+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
@@ -2059,8 +2059,8 @@
    "end_time": "2026-06-03T00:16:50.990479+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Applications\\Hybrid\\App-9-EdgeDetection.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Applications\\Hybrid\\App-9-EdgeDetection_output.ipynb",
+   "input_path": "App-9-EdgeDetection.ipynb",
+   "output_path": "App-9-EdgeDetection.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:15:49.942829+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
@@ -2434,8 +2434,8 @@
    "end_time": "2026-04-25T15:37:18.689898",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\Search\\App-14-ConnectFour-Adversarial.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\Search\\App-14-ConnectFour-Adversarial_output.ipynb",
+   "input_path": "App-14-ConnectFour-Adversarial.ipynb",
+   "output_path": "App-14-ConnectFour-Adversarial.ipynb",
    "parameters": {},
    "start_time": "2026-04-25T15:32:44.763117",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

Atomic application of `scripts/notebook_tools/scrub_papermill_paths.py` (#3435) to `Search/Applications/` — **17 notebooks, 33 absolute paths** scrubbed to relative basename.

Re-execs had injected absolute machine-local paths into `metadata.papermill.output_path` / `.input_path` (e.g. `D:\dev\CoursIA\...`, `d:/tmp/h3_app1b.ipynb`, `C:/Users/jsboi/AppData/Local/Temp/search_papermill/...`). These leak local machine structure and break reproducibility. Replaced with relative basename (canonical target state, proven by SC-10 in #3427).

## Scope (atomic — 1 sub-series)

| Sub-dir | Notebooks | Paths |
|---------|-----------|-------|
| `CSP/` | 12 (App-1..8, App-11/15/16/19) | 24 |
| `Hybrid/` | 4 (App-9, App-9b, App-10 [output_path only], App-10b, App-17) | 9 |
| `Search/` | 1 (App-14-ConnectFour-Adversarial) | 2 |
| **Total** | **17** | **33** |

Note: `App-10-Portfolio` had only `output_path` (no `input_path`) — 1 path, expected.

## Method (no-pendulum)

Text-level surgical edit (replace exact `"key": value` JSON substring) — **no JSON re-serialization**, so zero churn on papermill `0.0`→`0` float coercion or cell ordering. Reusable rule-F tool merged in #3435.

## Verification

- [x] **33 ins / 33 del** across 17 notebooks — `git diff --stat`
- [x] **JSON valid**: all 39 Applications notebooks (incl `_output`) parse
- [x] **Only papermill keys changed**: `grep` of `+/-` lines shows only `input_path` / `output_path`
- [x] **Outputs + execution_count untouched**: 0 matches on `execution_count` / `"outputs"` in diff (C.2 preserved, no re-exec)
- [x] **Catalogue byte-identical** to main: `COURSE_CATALOG.generated.{json,md}` no diff
- [x] **MetaGeneticSharp submodule clean**: no gitlink drift

## Diff sample (App-1-NQueens)

```diff
-   "input_path": "d:/Dev/CoursIA/MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb",
-   "output_path": "d:/tmp/h3_app1b.ipynb",
+   "input_path": "App-1-NQueens.ipynb",
+   "output_path": "App-1-NQueens.ipynb",
```

See #3436. Follows #3435 (SC-06, 4 nb) and #3454 (Sudoku-C#, 9 nb).

Part of po-2024 deep-queue scrub (ai-01 directive 2026-06-18).

Co-Authored-By: Claude <noreply@anthropic.com>