### PR TITLE
docs(infer-2): relabel fake "Solution de reference" as Exercice (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
@@ -7480,7 +7480,7 @@
     "tags": []
    },
    "source": [
-    "## 14. Exemple guide : Separation de populations (soumis par Faye, Christman, Clement)\n",
+    "## 14. Exercice : Separation de populations (soumis par Faye, Christman, Clement)\n",
     "\n",
     "### Enonce original\n",
     "\n",
@@ -7490,10 +7490,15 @@
     "\n",
     "Notes observees : `{8, 11, 9, 15, 17, 12, 9, 16, 14, 8}`\n",
     "\n",
-    "Les etudiants ont implemente un melange de 2 gaussiennes avec des a priori centres sur 10 et 16,\n",
-    "infere les posterieurs des deux composantes, et estime la proportion d'etudiants dans chaque groupe.\n",
+    "L'objectif est d'inferer les posterieurs des deux composantes et la proportion d'etudiants\n",
+    "dans chaque groupe, en reutilisant un modele de melange a 2 composantes fonde sur\n",
+    "`Variable.Switch` (cf. l'Exemple guide 12 et la classe `EntrainementCyclisteMixte`).\n",
     "\n",
-    "**Solution de reference ci-dessous.**"
+    "> **Squelette fourni ci-dessous.** La classe `EntrainementMixte` est volontairement\n",
+    "> **simplifiee** : sa methode `CalculePosterieurs` renvoie des valeurs constantes\n",
+    "> (`Gaussian(9,5, 1)`, `Gaussian(15,5, 1)`, `Dirichlet(0,6 0,4)`) sans lancer de\n",
+    "> moteur d'inference. A vous de la completer pour qu'elle infere reellement les\n",
+    "> posterieurs a partir des `notes` observees, comme le fait `EntrainementCyclisteMixte`.\n"
    ]
   },
   {
@@ -7863,7 +7868,7 @@
     "| Donnees manquantes | Gestion via `Variable.Array` avec masques |\n",
     "| Initialisation | Strategie d'initialisation des composantes |\n",
     "| EM inferentiel | Inference variationnelle approchee dans Infer.NET |\n",
-    "| Visualisation | Histogrammes et densites predites |"
+    "| Visualisation | Graphes de facteurs via `FactorGraphHelper` |"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Audit fidélité #3164 — `Infer-2-Gaussian-Mixtures.ipynb`. La section 14 « Separation de populations » était étiquetée **« Exemple guide : Solution de reference »** et sa prose affirmait que les étudiants avaient **« infere les posterieurs »**. Mais la classe `EntrainementMixte.CalculePosterieurs()` fournie est un **stub creux** : aucun `InferenceEngine`, aucun `Variable.Switch`, et elle retourne littéralement des constantes codées en dur (`Gaussian(9.5,1)`, `Gaussian(15.5,1)`, `Dirichlet(0.6,0.4)`). L'output de la cellule echo ces constantes — **aucune inférence n'a eu lieu**. Pathologie n°5 (fabricated-results / INVENTION).

**G.1 cross-check (no-pendulum, vérifié contre le code source réel)** :
- `grep InferenceEngine` dans cell 75 = **false** (vs vrai modèle `EntrainementCyclisteMixte` cell 53 qui l'utilise)
- `grep Variable.Switch` dans cell 75 = **false**
- `DefinirDistributions` = no-op (`// Pas nécessaire pour cette implémentation simplifiée`)

Second défaut mineur corrigé : synthèse cell 80 annonçait « Visualisation | Histogrammes et densites predites » — le notebook ne produit **aucun** histogramme, seulement des graphes de facteurs via `FactorGraphHelper` (cells 13/36/60/70).

## Changes (prose-only, markdown-only)

1. **Cellule 74** (md `e665cf73`) : `## 14. Exemple guide : Separation de populations` → `## 14. Exercice : Separation de populations` (classification par contenu : la cellule 75 contient déjà `// EXERCICE` + `//TODO` = c'est un exercice). Remplace le mensonge « infere les posterieurs... Solution de reference » par une note honnête : la classe `EntrainementMixte` est un squelette simplifié que l'étudiant doit compléter pour inférer réellement (miroir de `EntrainementCyclisteMixte` section 12).
2. **Cellule 80** (md `761280ee`) : ligne synthèse « Histogrammes et densites predites » → « Graphes de facteurs via FactorGraphHelper ».

## Why prose-only (not re-implement)

Option B (implémenter un vrai mixture Infer.NET + re-exec) rejetée : risque d'instabilité VMP + churn code, et le notebook a déjà 3 exercices conformes (#2161). L'audit vise la **fidélité prose-vs-output**, pas l'enrichissement. Prose-only corrige le mensonge sans toucher au code existant (anti-régression), sans ré-execution (markdown-only → outputs préservés C.2).

## Non-défects vérifiés (left untouched)
Flux principal cells 1-72 **FIDÈLE** : ~40 nombres postérieurs vérifiés ligne-par-ligne contre output Infer.NET (15.07/26.69, Dirichlet 7.995/4.005, IC [11.1,19.5], P(<18)=0.89, etc.). Labeling VMP-vs-EP CORRECT. Caveats pédagogiques honnêtes (label switching, online drift) préservés.

## Gates
- G1 scan_cell_ordering : **1 clean, 0 finding**
- G3 notebook_tools validate : **OK 0, Errors 0** (Warning 1 = FP pré-existant sur origin/main, vérifié)
- G2 check_c2_compliance : **1/1 compliant** (markdown-only, outputs préservés)
- G4 git diff : **0 cellule code modifiée**, 10 ins / 5 del, 0 `raise NotImplementedError`/`assert False`/`sorry` introduit

Closes #3459
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)