### PR TITLE
docs(smartcontracts): add 01-Solidity-Foundation sub-series README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/README.md
@@ -1,0 +1,84 @@
+# 01-Solidity-Foundation - Fondements du langage Solidity
+
+**Navigation** : [Sommaire de la serie](../README.md) | [<< SC-2 Setup Web3py](../00-Foundations/SC-2-Setup-Web3py.ipynb) | [SC-7 Token Standards >>](../02-Solidity-Advanced/SC-7-Token-Standards.ipynb)
+
+Cette premiere sous-serie de code Solidity (SC-3 a SC-6) pose les fondamentaux du langage : structure d'un contrat, types et variables, fonctions et etat (data locations, visibilite, modifiers), heritage et interfaces, puis erreurs et events. Aucune ligne de Solidity serieuse ne peut etre ecrite sans ces quatres notebooks. Chaque concept est illustre par un contrat compile et deploye reellement sur `anvil` (le noeud local de test fourni par Foundry) -- pas de simulation, les adresses et les receipts dans les outputs sont authentiques.
+
+---
+
+## Notebooks
+
+| # | Notebook | Duree | Contenu |
+|---|----------|-------|---------|
+| 3 | [SC-3-Solidity-Basics](SC-3-Solidity-Basics.ipynb) | 40 min | Structure de contrat, types valeur, variables d'etat, conversions |
+| 4 | [SC-4-Functions-State](SC-4-Functions-State.ipynb) | 45 min | Data locations (storage/memory/calldata), visibilite, modifiers (view/pure/payable) |
+| 5 | [SC-5-Inheritance](SC-5-Inheritance.ipynb) | 35 min | Heritage simple et multiple, interfaces, abstract/override |
+| 6 | [SC-6-Errors-Events](SC-6-Errors-Events.ipynb) | 30 min | `require`/`revert`/`assert`, custom errors (0.8.4+), events |
+
+**Total** : 4 notebooks, ~2h30.
+
+---
+
+## Parcours d'apprentissage
+
+### Etape 1 : Syntaxe et types (SC-3, 40 min)
+
+On commence par la structure minimale d'un contrat, les types valeur (uint, address, bool, bytes), les variables d'etat vs locales, et les conversions explicites. Premier deploiement sur `anvil`.
+
+### Etape 2 : Fonctions et etat (SC-4, 45 min)
+
+Le coeur de la programmation Solidity : les trois **data locations** (storage, memory, calldata) et leur cout en gas, la visibilite (public/external/internal/private), et les modifiers qui restreignent l'acces (`view`, `pure`, `payable`).
+
+### Etape 3 : Heritage et abstraction (SC-5, 35 min)
+
+Solidity supporte l'heritage multiple avec le mot-cle `is`, les interfaces pour l'abstraction, et les contrats `abstract`. Cette etape prepare directement aux standards ERC de la sous-serie suivante (02-Solidity-Advanced).
+
+### Etape 4 : Erreurs et observabilite (SC-6, 30 min)
+
+`require` (conditions d'entree, gas rembourse), `revert` (erreurs complexes), `assert` (invariants internes), les custom errors economes en gas depuis 0.8.4, et les events pour le logging hors-chain.
+
+---
+
+## Prerequis
+
+### Par notebook
+
+| Notebook | Fondations requises | Dependances |
+|----------|---------------------|-------------|
+| SC-3 Solidity-Basics | [SC-2 Setup Web3py](../00-Foundations/SC-2-Setup-Web3py.ipynb) | `web3`, `py-solc-x` |
+| SC-4 Functions-State | SC-3 complete | idem |
+| SC-5 Inheritance | SC-3 + SC-4 completes | idem |
+| SC-6 Errors-Events | SC-3 + SC-4 + SC-5 completes | idem |
+
+### Configuration requise
+
+- **Python 3.10+** avec `pip install web3 py-solc-x`
+- **Foundry installe** : `anvil` doit etre sur le PATH. Lancez `anvil` dans un terminal avant d'executer les cellules (les quatre notebooks s'y connectent en local).
+- Aucune cle API, aucun faucet, aucun ETH reel necessaire : tout tourne sur le noeud local `anvil`.
+
+---
+
+## Ponts inter-series
+
+| Serie | Lien | Relation |
+|-------|------|----------|
+| [SmartContracts (parent)](../README.md) | Vue d'ensemble | Contexte, parcours global, glossaire |
+| [00-Foundations](../00-Foundations/) | Prerequis | SC-2 (Setup Web3py) fournit l'environnement |
+| [02-Solidity-Advanced](../02-Solidity-Advanced/) | Suite | SC-7+ (ERC-20/721/1155, DeFi, DAO, Account Abstraction) construisent sur ces fondamentaux |
+
+---
+
+## Points de vigilance (execution sur anvil)
+
+- **Lancer `anvil` avant l'execution** : chaque notebook se connecte a un noeud local. Sans `anvil` actif, les cellules de deploiement echouent en `ConnectionRefusedError`.
+- **`py-solc-x` telecharge le compilateur** au premier appel (`solcx.install_solc`) ; le versioning se fait via `foundry-lib/` au niveau de la serie.
+- Les outputs committes proviennent d'executions reelles sur `anvil` : les adresses de contrat, les gas utilises et les receipts sont authentiques (contrairement aux notebooks des sous-series 03/05 qui, pour certains, s'appuient sur des replis statiques disclosees).
+
+---
+
+## Ressources
+
+- **Foundry Book** (Foundry contributors) -- `anvil`, `forge`, `cast`. Documentation officielle : book.getfoundry.sh.
+- **Solidity Documentation officielle** (Ethereum Foundation) -- types, data locations, heritage, errors/events. docs.soliditylang.org.
+- Wood, G. (2014) -- "Ethereum: A Secure Decentralised Generalised Transaction Ledger" (Yellow Paper) : EVM, gas, modele d'execution.
+- Voir aussi les references transversales dans le [README parent de la serie](../README.md).


### PR DESCRIPTION
## Summary

5 of 7 SmartContracts sub-series still lack a README complementing the parent series README (only `06-Real-World` had one, #3445). This PR adds the **`01-Solidity-Foundation`** sub-series README covering **SC-3..6** (4 notebooks, ~2h30): Solidity basics, functions/state, inheritance, errors/events.

## Content (faithful, 0 invented)

Objectives, durations, prerequisites are read **directly from each notebook's first markdown cells** (SDDD: the notebooks are the source of truth, not the README):

| # | Notebook | Duration | Topics |
|---|----------|----------|--------|
| 3 | SC-3-Solidity-Basics | 40 min | Contrat structure, value types, state variables, conversions |
| 4 | SC-4-Functions-State | 45 min | data locations (storage/memory/calldata), visibility, modifiers |
| 5 | SC-5-Inheritance | 35 min | simple/multiple inheritance, interfaces, abstract/override |
| 6 | SC-6-Errors-Events | 30 min | require/revert/assert, custom errors (0.8.4+), events |

All 4 notebooks deploy **reellement sur anvil** (authentic addresses/gas/receipts in outputs), consistent with the parent series README statement.

## Structure (gabarit #3445, validated)

Follows the validated `06-Real-World` README structure:
- Navigation header (parent + predecessor SC-2 + successor SC-7)
- Notebooks table
- Parcours d'apprentissage (4 etapes)
- Prerequis (per-notebook table + configuration)
- Ponts inter-series
- Points de vigilance (anvil execution)
- Ressources

Complements (does not duplicate) the parent series README: the per-notebook prerequisites table and the anvil-specific execution guidance live here, not in the parent.

## Verification

- [x] **7/7 internal links resolve** (parent README, SC-2 predecessor, SC-7 successor, all 4 notebooks) — verified via `[ -f ]`
- [x] **Catalogue byte-identical** to main: `COURSE_CATALOG.generated.{json,md}` no diff
- [x] **MetaGeneticSharp submodule clean**: no gitlink drift
- [x] **Docs-only**: no notebook/code changes
- [x] French matching SC house style (no diacritics, consistent with parent + 06-Real-World)
- [x] 0 emoji

See #2651 (gabarit §10 sub-series READMEs). Side-track of po-2024 deep-queue scrub (5 SC sub-series READMEs remaining: 00, 02, 03, 04, 05).

Co-Authored-By: Claude <noreply@anthropic.com>