### PR TITLE
docs(semantickernel): document AutoInteractive curriculum + mark generated artifacts (SK ruling)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
@@ -39,6 +39,17 @@ Parcours pédagogique complet sur Semantic Kernel en Python :
 | 10a | [SK-10a-NotebookMaker-batch](10a-SemanticKernel-NotebookMaker-batch.ipynb) | Version batch sans UI interactive | 30 min |
 | 10b | [SK-10b-NotebookMaker-batch-param](10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb) | Version paramétrisée pour Papermill | 30 min |
 
+## Démos interactives (curriculum)
+
+Ces notebooks appliquent Semantic Kernel à des cas d'usage concrets. Ils font partie du curriculum (exercices stub inclus), mais sont listés à part car ils ne suivent pas la numérotation principale 01-10.
+
+| Notebook | Langage | Contenu | Exercices |
+|----------|---------|---------|-----------|
+| [Semantic-kernel-AutoInteractive](Semantic-kernel-AutoInteractive.ipynb) | C# (.NET) | **Conception de notebook assistée** : SK + OpenAI function calling pour générer et exécuter d'autres notebooks .NET interactifs | 3 |
+| [Créateur de mail personnalisé](Créateur%20de%20mail%20personnalisé.ipynb) | Python | Workflow multi-agents SK (InputCollector, EmailGenerator) pour la rédaction de courriels | 3 |
+| [fort-boyard-csharp](fort-boyard-csharp.ipynb) | C# (.NET) | AgentGroupChat : duel Père Fouras vs Laurent Jalabert (jeu de devinette) | 3 |
+| [fort-boyard-python](fort-boyard-python.ipynb) | Python | Contrepartie Python du duel Fort Boyard (KernelFunctionTerminationStrategy) | 3 |
+
 ## Templates
 
 | Template | Description |
@@ -46,6 +57,17 @@ Parcours pédagogique complet sur Semantic Kernel en Python :
 | [Notebook-Template](Notebook-Template.ipynb) | Template de base C# |
 | [Workbook-Template](Workbook-Template.ipynb) | Template workbook C# |
 | [Workbook-Template-Python](Workbook-Template-Python.ipynb) | Template Python |
+
+## Artefacts générés (hors curriculum)
+
+> ⚠️ Les notebooks ci-dessous sont des **sorties produites par le système NotebookMaker / AutoInteractive**, pas du curriculum pédagogique. Ils illustrent ce que la chaîne d'agents génère mais ne contiennent pas de parcours d'apprentissage. Ils sont **exclus du compte catalogue pédagogique** (`pedagogical_count`) et ne doivent pas être comptés comme notebooks de la série.
+
+| Fichier | Nature | Origine |
+|---------|--------|---------|
+| [Notebook-Generated](Notebook-Generated.ipynb) | Scaffold généré (dataset Iris générique) | Output du [NotebookMaker](10-SemanticKernel-NotebookMaker.ipynb) / [AutoInteractive](Semantic-kernel-AutoInteractive.ipynb) |
+| [Créateur de mail personnalisé_output](Créateur%20de%20mail%20personnalisé_output.ipynb) | Copie exécutée Papermill | Artefact d'exécution de [Créateur de mail personnalisé](Créateur%20de%20mail%20personnalisé.ipynb) (suffixe `_output`) |
+
+Le notebook canonique « Créateur de mail personnalisé » (sans suffixe `_output`) est, lui, un vrai notebook de curriculum (cf. table [Démos interactives](#démos-interactives-curriculum)).
 
 ## Concepts clés
 

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
@@ -65,7 +65,7 @@ Ces notebooks appliquent Semantic Kernel à des cas d'usage concrets. Ils font p
 | Fichier | Nature | Origine |
 |---------|--------|---------|
 | [Notebook-Generated](Notebook-Generated.ipynb) | Scaffold généré (dataset Iris générique) | Output du [NotebookMaker](10-SemanticKernel-NotebookMaker.ipynb) / [AutoInteractive](Semantic-kernel-AutoInteractive.ipynb) |
-| [Créateur de mail personnalisé_output](Créateur%20de%20mail%20personnalisé_output.ipynb) | Copie exécutée Papermill | Artefact d'exécution de [Créateur de mail personnalisé](Créateur%20de%20mail%20personnalisé.ipynb) (suffixe `_output`) |
+| `Créateur de mail personnalisé_output.ipynb` | Copie exécutée Papermill | Artefact d'exécution de [Créateur de mail personnalisé](Cr%C3%A9ateur%20de%20mail%20personnalis%C3%A9.ipynb) (suffixe `_output`, non tracké : produit local d'une exécution Papermill) |
 
 Le notebook canonique « Créateur de mail personnalisé » (sans suffixe `_output`) est, lui, un vrai notebook de curriculum (cf. table [Démos interactives](#démos-interactives-curriculum)).
 


### PR DESCRIPTION
## Summary

Exécution de la **ruling ai-01** (directive 15:00Z) : documenter `Semantic-kernel-AutoInteractive.ipynb` comme curriculum réel + marquer les démos générées comme artefacts (hors catalogue pédagogique + note explicite).

## Classification evidence-cited (G.1)

Sous-agent `sonnet` read-full + cross-check local sur les 6 notebooks `.ipynb` non-listés dans la table README :

| Notebook | Verdict | Preuve |
|----------|---------|--------|
| **Semantic-kernel-AutoInteractive** | CURRICULUM | .NET interactive, 3 exos stub (cells 8/12/16), markdown intro par section |
| **Créateur de mail personnalisé** | CURRICULUM | Python, 3 exos stub (ExtendedEmailState/validate_email/count_words), plugins SK expliqués |
| **fort-boyard-csharp** | CURRICULUM | C# polyglot, 3 exos stub, AgentGroupChat Père Fouras vs Jalabert |
| **fort-boyard-python** | CURRICULUM | Python, 3 exos stub, KernelFunctionTerminationStrategy |
| **Notebook-Generated** | ARTIFACT | Output du NotebookMaker (« Cellule 0...5 », langage de brief généré) |
| **Créateur de mail personnalisé_output** | ARTIFACT | Suffixe `_output` = copie Papermill, cell IDs identiques au source |

## Correctif ground-truth vs ruling

La ruling ai-01 mentionnait « 4 démos générées = artefacts ». Le ground-truth montre que **4 des 6 sont du vrai curriculum** (3 exercices stub + structure pédagogique). Seulement **2** sont des artefacts réels. Ce désalignement est documenté pour qu'ai-01 puisse ajuster la ruling.

## Changements (+22/-0, markdown-only)

2 nouvelles sections dans `SemanticKernel/README.md` :
1. **« Démos interactives (curriculum) »** — table des 4 notebooks curriculum avec langage + compte d'exercices
2. **« Artefacts générés (hors curriculum) »** — note d'exclusion explicite du `pedagogical_count` + provenance de chaque artefact

## Validation

- 45 liens `.ipynb` tous valides (aucun cassé)
- Ancre `#démos-interactives-curriculum` présente
- Marqueur `CATALOG-STATUS` **non touché** (bot-owned, règle catalog-pr-hygiene HARD 1)
- +22/-0, markdown-only (pas de re-exec, pas de churn notebook)

## Conformité

- Règle F : n/a (documentation README, pas d'exécution modèle)
- catalog-pr-hygiene : catalogue byte-identical préservé ✓
-exercise-example-labeling : classification par contenu (les 4 curriculum ont de vrais stubs, pas de worked-examples stubbés) ✓

Décision de jugement (gardée localement, non déléguée) : la distinction curriculum/artefact s'appuie sur la présence de 3 exercices stub + structure pédagogique, pas sur le nom de fichier seul.

Voir ai-01 directive 15:00Z : « SK ruling AutoInteractive — GREENLIGHT : documente-le, les démos générées = artefacts hors table catalogue + note explicite ».