### PR TITLE
fix(smartcontracts): scrub absolute papermill paths (18 nb, 34 paths)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
@@ -1859,8 +1859,8 @@
    "end_time": "2026-06-03T07:40:01.685234+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\00-Foundations\\SC-0-Cypherpunk-Origins.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\00-Foundations\\SC-0-Cypherpunk-Origins_output.ipynb",
+   "input_path": "SC-0-Cypherpunk-Origins.ipynb",
+   "output_path": "SC-0-Cypherpunk-Origins.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T07:39:55.772103+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
@@ -1052,7 +1052,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sc1_output.ipynb",
+   "output_path": "SC-1-Setup-Foundry.ipynb",
    "parameters": {},
    "start_time": "2026-05-26T19:15:48.167718",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
@@ -1221,7 +1221,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sc2_output.ipynb",
+   "output_path": "SC-2-Setup-Web3py.ipynb",
    "parameters": {},
    "start_time": "2026-05-26T19:15:52.308172",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
@@ -1994,8 +1994,8 @@
    "end_time": "2026-06-08T02:09:39.335344",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\01-Solidity-Foundation\\SC-3-Solidity-Basics.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\01-Solidity-Foundation\\SC-3-Solidity-Basics_output.ipynb",
+   "input_path": "SC-3-Solidity-Basics.ipynb",
+   "output_path": "SC-3-Solidity-Basics.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
@@ -1858,8 +1858,8 @@
    "end_time": "2026-06-03T00:13:52.906507+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\01-Solidity-Foundation\\SC-4-Functions-State.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\01-Solidity-Foundation\\SC-4-Functions-State_output.ipynb",
+   "input_path": "SC-4-Functions-State.ipynb",
+   "output_path": "SC-4-Functions-State.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
@@ -1671,8 +1671,8 @@
    "end_time": "2026-06-08T00:49:09.842038",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\01-Solidity-Foundation\\SC-6-Errors-Events.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\01-Solidity-Foundation\\SC-6-Errors-Events_output.ipynb",
+   "input_path": "SC-6-Errors-Events.ipynb",
+   "output_path": "SC-6-Errors-Events.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T00:48:51.432799",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -2483,8 +2483,8 @@
    "end_time": "2026-06-05T14:04:29.089957",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:/tmp/wt2474/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb",
-   "output_path": "D:/tmp/wt2474/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb",
+   "input_path": "SC-11-LLM-Assisted.ipynb",
+   "output_path": "SC-11-LLM-Assisted.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
@@ -1728,8 +1728,8 @@
    "end_time": "2026-06-08T01:02:33.255346",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\02-Solidity-Advanced\\SC-7-Token-Standards.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\02-Solidity-Advanced\\SC-7-Token-Standards_output.ipynb",
+   "input_path": "SC-7-Token-Standards.ipynb",
+   "output_path": "SC-7-Token-Standards.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T01:02:13.049674",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -1429,8 +1429,8 @@
    "end_time": "2026-06-08T00:51:25.620845",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\02-Solidity-Advanced\\SC-8-DeFi-Primitives.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\02-Solidity-Advanced\\SC-8-DeFi-Primitives_output.ipynb",
+   "input_path": "SC-8-DeFi-Primitives.ipynb",
+   "output_path": "SC-8-DeFi-Primitives.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T00:51:15.979007",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
@@ -1399,8 +1399,8 @@
    "end_time": "2026-06-08T00:53:02.079769",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\02-Solidity-Advanced\\SC-9-DAO-Governance.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\02-Solidity-Advanced\\SC-9-DAO-Governance_output.ipynb",
+   "input_path": "SC-9-DAO-Governance.ipynb",
+   "output_path": "SC-9-DAO-Governance.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T00:52:52.961626",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -2946,8 +2946,8 @@
    "end_time": "2026-06-03T07:41:08.766737+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\03-Foundry-Testing\\SC-12-Foundry-Testing.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\03-Foundry-Testing\\SC-12-Foundry-Testing_output.ipynb",
+   "input_path": "SC-12-Foundry-Testing.ipynb",
+   "output_path": "SC-12-Foundry-Testing.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T07:41:06.352905+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
@@ -1512,8 +1512,8 @@
    "end_time": "2026-06-03T07:41:14.004862+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\03-Foundry-Testing\\SC-14-Formal-Verification.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\03-Foundry-Testing\\SC-14-Formal-Verification_output.ipynb",
+   "input_path": "SC-14-Formal-Verification.ipynb",
+   "output_path": "SC-14-Formal-Verification.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
@@ -2221,8 +2221,8 @@
    "end_time": "2026-06-03T07:41:18.219661+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\04-Privacy-Cryptography\\SC-15-Zero-Knowledge-Proofs.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\04-Privacy-Cryptography\\SC-15-Zero-Knowledge-Proofs_output.ipynb",
+   "input_path": "SC-15-Zero-Knowledge-Proofs.ipynb",
+   "output_path": "SC-15-Zero-Knowledge-Proofs.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T07:41:14.640285+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -2162,8 +2162,8 @@
    "end_time": "2026-06-03T07:41:29.831533+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\04-Privacy-Cryptography\\SC-16-Homomorphic-Encryption.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\04-Privacy-Cryptography\\SC-16-Homomorphic-Encryption_output.ipynb",
+   "input_path": "SC-16-Homomorphic-Encryption.ipynb",
+   "output_path": "SC-16-Homomorphic-Encryption.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T07:41:18.827789+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
@@ -1671,8 +1671,8 @@
    "end_time": "2026-06-03T07:41:33.357835+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\04-Privacy-Cryptography\\SC-17-E2E-Verifiable-Voting.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\04-Privacy-Cryptography\\SC-17-E2E-Verifiable-Voting_output.ipynb",
+   "input_path": "SC-17-E2E-Verifiable-Voting.ipynb",
+   "output_path": "SC-17-E2E-Verifiable-Voting.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T07:41:30.460569+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
@@ -1886,8 +1886,8 @@
    "end_time": "2026-06-03T07:41:36.610795+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\05-Alternative-Chains\\SC-18-Vyper.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\05-Alternative-Chains\\SC-18-Vyper_output.ipynb",
+   "input_path": "SC-18-Vyper.ipynb",
+   "output_path": "SC-18-Vyper.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T07:41:33.934588+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
@@ -2455,8 +2455,8 @@
    "end_time": "2026-06-03T07:41:41.905504+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\05-Alternative-Chains\\SC-20-Bitcoin-Scripting.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\05-Alternative-Chains\\SC-20-Bitcoin-Scripting_output.ipynb",
+   "input_path": "SC-20-Bitcoin-Scripting.ipynb",
+   "output_path": "SC-20-Bitcoin-Scripting.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T07:41:39.767586+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
@@ -1961,8 +1961,8 @@
    "end_time": "2026-06-03T07:41:46.902913+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\05-Alternative-Chains\\SC-22-Solana-Anchor.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\05-Alternative-Chains\\SC-22-Solana-Anchor_output.ipynb",
+   "input_path": "SC-22-Solana-Anchor.ipynb",
+   "output_path": "SC-22-Solana-Anchor.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T07:41:44.952673+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

Atomic application of `scripts/notebook_tools/scrub_papermill_paths.py` (#3435) to the remaining **SmartContracts** family — **18 notebooks, 34 absolute paths** scrubbed to relative basename. This completes the SmartContracts family (SC-06 was scrubbed in #3435).

Re-execs had injected absolute machine-local paths into `metadata.papermill.output_path` / `.input_path` (e.g. `C:\dev\CoursIA\...`, `D:/tmp/wt2474/...`, `D:\dev\CoursIA-2\...`, `C:/Users/jsboi/AppData/Local/Temp/...`). These leak local machine structure and break reproducibility. Replaced with relative basename (canonical target state, proven by SC-10 in #3427).

## Scope (atomic — 1 family)

| Sub-series | Notebooks | 
|------------|-----------|
| `00-Foundations` | 3 (SC-0, SC-1, SC-2) |
| `01-Solidity-Foundation` | 3 (SC-3, SC-4, SC-6) |
| `02-Solidity-Advanced` | 4 (SC-7, SC-8, SC-9, SC-11) |
| `03-Foundry-Testing` | 2 (SC-12, SC-14) |
| `04-Privacy-Cryptography` | 3 (SC-15, SC-16, SC-17) |
| `05-Alternative-Chains` | 3 (SC-18, SC-20, SC-22) |
| **Total** | **18 notebooks, 34 paths** |

Already clean (not touched): SC-5, SC-10 (#3427), SC-13, SC-19, SC-21. SC-06 (SC-23..26) scrubbed in #3435. 18 files < 15-file soft threshold is exceeded, but this is a **uniform metadata-only operation** (single subject), consistent with atomique scrub PRs #3453 (22 nb) and #3452 (14 nb) merged this batch.

## Method (no-pendulum)

Text-level surgical edit (replace exact `"key": value` JSON substring) — **no JSON re-serialization**, so zero churn on cell ordering or papermill float coercion. Reusable rule-F tool merged in #3435.

## Verification

- [x] **34 ins / 34 del** across 18 notebooks — `git diff --stat`
- [x] **JSON valid**: all 54 SmartContracts notebooks (incl `_output`/`_executed`) parse
- [x] **Only papermill keys changed**: `grep` of `+/-` lines shows only `input_path` / `output_path`
- [x] **Outputs + execution_count untouched**: 0 matches (C.2 preserved, no re-exec)
- [x] **Catalogue byte-identical** to main: `COURSE_CATALOG.generated.{json,md}` no diff
- [x] **MetaGeneticSharp submodule clean**: no gitlink drift

See #3436. Follows #3435 (SC-06, 4 nb), #3454 (Sudoku-C#, 9 nb), #3460 (Search/Applications, 17 nb).

Part of po-2024 deep-queue scrub (ai-01 directive 2026-06-18 15:00Z).

Co-Authored-By: Claude <noreply@anthropic.com>