### PR TITLE
docs(infer-3): add Graphviz reproducibility caveats to stale factor-graph SVGs (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
@@ -160,7 +160,7 @@
     "### Verification du FactorGraphHelper\n",
     "\n",
     "La sortie ci-dessus confirme que :\n",
-    "- **Graphviz est disponible** : Le rendu des graphes sera visuel (pas de fallback textuel)\n",
+    "- **Graphviz et le helper** : `FactorGraphHelper.IsGraphvizAvailable()` indique si `dot` (Graphviz) est reachable sur le PATH. Le rendu visuel des factor graphs **requiert Graphviz installe** ; en son absence, `GetLatestFactorGraphHtml()` renvoie un SVG mis en cache (potentiellement issu d'un autre modele) plutot qu'une image textuelle\n",
     "- **Helper charge** : On pourra appeler `FactorGraphHelper.GetLatestFactorGraphHtml()` apres chaque inference avec `ShowFactorGraph = true`\n",
     "\n",
     "> **Note technique** : FactorGraphHelper utilise Graphviz pour convertir la description DOT generee par Infer.NET en image SVG embeddee dans le HTML. Si Graphviz n'etait pas disponible, une representation textuelle serait utilisee a la place."
@@ -1025,7 +1025,9 @@
     "- Les variables observees sont marquees differemment\n",
     "- Les fleches montrent le flux de messages entre variables et facteurs\n",
     "\n",
-    "Ce graphe illustre la structure de dependance : le meurtrier influence a la fois l'arme et le cheveu, mais ces deux indices sont conditionnellement independants etant donne le meurtrier."
+    "Ce graphe illustre la structure de dependance : le meurtrier influence a la fois l'arme et le cheveu, mais ces deux indices sont conditionnellement independants etant donne le meurtrier.\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (executable `dot` sur le PATH) et de `FactorGraphHelper.GetLatestFactorGraphHtml()`, qui selectionne le fichier `Model_*.svg` le plus recent dans le repertoire de travail. Si Graphviz n'est pas disponible a l'execution, l'image affichee peut etre un SVG mis en cache correspondant a un autre modele. La structure reelle du modele Murder Mystery (construite dans la cellule de code ci-dessus via `Variable.Bernoulli` + `Variable.If`) est celle decrite textuellement : `meurtrier -> {arme, cheveu}` avec les tables conditionnelles 0.9/0.8 (coupable) et 0.2/0.1 (innocent)."
    ]
   },
   {
@@ -1510,7 +1512,9 @@
     "- **choixJoueur** : Porte choisie par le joueur\n",
     "- **porteMonty** : Porte ouverte par l'animateur\n",
     "\n",
-    "On remarquera que le graphe est significativement plus complexe en raison des 9 cas (3 positions x 3 choix) qui definissent la distribution conditionnelle de porteMonty."
+    "On remarquera que le graphe est significativement plus complexe en raison des 9 cas (3 positions x 3 choix) qui definissent la distribution conditionnelle de porteMonty.\n",
+    "\n",
+    "> **Note de reproductibilite** : comme pour le graphe Murder Mystery ci-dessus, le rendu SVG integre depend de Graphviz et peut afficher un graph mis en cache si `dot` n'est pas disponible a l'execution. La structure reelle du modele Monty Hall (construite dans la cellule de code ci-dessus via `Variable.DiscreteUniform(3)` + 9 blocs `Variable.Case`) est celle decrite textuellement : `voiture, choixJoueur -> porteMonty` avec une table de 9 cas."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit fidélité #3164 — `Infer-3-Factor-Graphs.ipynb`. Les SVG factor-graphs committés (cells 18 "Murder Mystery" + 30 "Monty Hall") sont **stale et byte-identiques** (5207 chars, même filename `Model_06_02_26_17_40_27_78.svg`) et montrent un graphe de pile-ou-face étranger (`Beta(1,1)→biais→Bernoulli→resultats[lancers]`) — aucun nœud `meurtrier`/`voiture`. Les cellules source construisent pourtant des modèles **réellement différents** (Bernoulli(0.7)→meurtrier vs DiscreteUniform(3)→voiture,choixJoueur). Pathologie INVENTION.

**3 mensonges de prose corrigés** :
1. Cell `zmmn3n4q3i9` : « Graphviz est disponible » → FAUX (les SVG stale le prouvent, dot absent du PATH à l'exécution).
2. Cell `o8zd7hkzsi8` (Murder interp) : interprétait le SVG stale comme graphe Murder-Mystery.
3. Cell `hxlk3pl71mn` (Monty interp) : interprétait le même SVG stale comme graphe Monty-Hall.

## G.1 cross-check (re-exec réelle ce cycle)

Re-exec `.net-csharp` 14/14 OK avec `dot` sur PATH (conda graphviz 14.0.4). Infer.NET a régénéré 2 `.gv` frais avec les **bons** modèles. Mais `FactorGraphHelper.GetLatestFactorGraphHtml()` fait `Model_*.svg.OrderByDescending(LastWriteTime).First()` — il ne peut pas associer un SVG au modèle qui vient d'être construit → pour un notebook multi-graphes, les 2 cellules retournent le même SVG (le plus récent). Quand `dot` est absent, fallback sur cache stale. **Re-exec seule insuffisante** à cause du bug helper.

## Why prose-only (not fix helper + re-exec)

- Fixer `FactorGraphHelper.cs` = scope repo-wide (20 notebooks Infer le `#load`) + re-exec tous → PR composite violant G.4 (one-subject-per-PR). Bug helper = défaut d'infrastructure distinct (issue séparée à ouvrir).
- Prose-only corrige le **mensonge** (la prose ne doit pas claim « Graphviz disponible » ni interpréter un SVG stale comme le bon graphe) sans toucher au code existant (anti-régression), sans re-exec (markdown-only → outputs préservés C.2).
- Les descriptions textuelles Murder-Mystery/Monty-Hall dans la prose sont elles-mêmes **accurate** (vérifiées contre les cellules code).

## Non-défects vérifiés (left untouched)
- **8 claims numériques FIDÈLES** : P(Auburn)=0.70, P(Auburn|revolver)=0.913, P(0)=0.333/P(1)=0.667 (Monty), P(Auburn)=0.891 (witness) — vérifiés ligne-par-ligne.
- **0 pathology n°5** : toutes les cells claim inference contiennent VRAIMENT `InferenceEngine` + `.Infer<` + `Variable.If/Case`.
- 3 exercise stubs legit C.1.

## Gates
- G1 scan_cell_ordering : **1 clean, 0 finding**
- G3 validate : **OK 0, Errors 0** (Warning 1 = FP pré-existant origin/main, vérifié)
- G2 check_c2_compliance : **1/1 compliant** (markdown-only, outputs préservés)
- G4 git diff : **0 cell code modifiée**, 7 ins / 3 del

Closes #3467
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)