### PR TITLE
docs(pymc-16): anchor MAUT citation omissions (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "1. **Methode lexicographique** : Trier par critere le plus important, puis par le second...\n",
     "2. **Ponderation simple** : V(x) = $\\sum w_i \\times v_i(x_i)$\n",
-    "3. **Theorie de l'utilite multi-attributs (MAUT)** : Fondee sur des axiomes rigoureux"
+    "3. **Theorie de l'utilite multi-attributs (MAUT)** : Fondee sur les axiomes d'utilite esperee de **von Neumann & Morgenstern (1944)** etendue au cas multi-attributs"
    ]
   },
   {
@@ -389,6 +389,8 @@
    },
    "source": [
     "## 4. Theoreme d'Additivite (Debreu-Gorman)\n",
+    "\n",
+    "Ce resultat d'additivite est etabli par **Debreu (1960)** et generalise par **Gorman (1968)** sous l'hypothese d'independance preferentielle mutuelle des attributs.\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -728,7 +730,7 @@
    "source": [
     "## 5. Determination des Poids (Swing Weights)\n",
     "\n",
-    "La methode des swing weights compare la **valeur des ameliorations** plutot que les attributs eux-memes.\n",
+    "La methode des swing weights (cf. **von Winterfeldt & Edwards, 1986** ; **Keeney & Raiffa, 1976**) compare la **valeur des ameliorations** plutot que les attributs eux-memes.\n",
     "\n",
     "### Etapes\n",
     "\n",
@@ -929,6 +931,8 @@
     "Quand les outcomes sont **incertains**, la forme additive suppose que l'aversion au risque est la meme quel que soit le niveau des autres attributs.\n",
     "\n",
     "### Forme multiplicative (Keeney-Raiffa)\n",
+    "\n",
+    "Introduite par **Keeney & Raiffa (1976)**, cette forme ajoute un facteur d'echelle $k$ qui capture les interactions entre attributs lorsque les issues sont incertaines.\n",
     "\n",
     "$$1 + kU(x_1, x_2) = [1 + kk_1U_1(x_1)][1 + kk_2U_2(x_2)]$$\n",
     "\n",
@@ -1202,7 +1206,7 @@
     "\n",
     "### Simple Multi-Attribute Rating Technique\n",
     "\n",
-    "SMART est une methode pratique en 7 etapes :\n",
+    "SMART (**Edwards, 1971, 1977**) est une methode pratique en 7 etapes, raffinee en SMARTS puis SMARTER par **Edwards & Barron (1994)** :\n",
     "\n",
     "1. **Identifier** les attributs pertinents\n",
     "2. **Definir** les echelles pour chaque attribut\n",
@@ -1778,6 +1782,8 @@
    "source": [
     "## 9 bis. Apprentissage Bayesien des Poids avec PyMC\n",
     "\n",
+    "PyMC (**Salvatier et al., 2016**) est un framework de programmation probabiliste qui permet de specifier des modeles bayesiens en declarant les distributions comme des variables aleatoires.\n",
+    "\n",
     "### Motivation\n",
     "\n",
     "Jusqu'ici, les poids MAUT sont determines par introspection (methode des swings). Mais on peut les **inferer** a partir des choix observes d'un decideur.\n",
@@ -2154,6 +2160,8 @@
     "### Interpretation : Diagnostics et correlations\n",
     "\n",
     "Le pair plot revele une propriete fondamentale de la distribution Dirichlet : les poids sont **negativement corroles** car ils somment a 1. Augmenter le poids de la Securite reduit necessairement les poids des autres attributs.\n",
+    "\n",
+    "Les diagnostics ArviZ (**Kumar et al., 2019**) ci-dessous (R-hat, ESS, trace plot) confirment la convergence du MCMC.\n",
     "\n",
     "> **Implication pratique** : L'incertitude sur un poids se propage aux autres. Avec peu d'observations (5 choix), les intervalles de credibilite sont larges. Avec 50+ choix, le posterior se concentre et les recommandations deviennent plus fiables."
    ]
@@ -2604,9 +2612,16 @@
     "\n",
     "## References\n",
     "\n",
-    "- Keeney & Raiffa (1976) : Decisions with Multiple Objectives\n",
-    "- Edwards & Barron (1994) : SMARTS and SMARTER\n",
-    "- Russell & Norvig : AI, Chapter 16.4"
+    "- von Neumann, J., & Morgenstern, O. (1944). *Theory of Games and Economic Behavior*. Princeton University Press.\n",
+    "- Debreu, G. (1960). Topological methods in cardinal utility theory. *Mathematical Methods in the Social Sciences*.\n",
+    "- Gorman, W. M. (1968). The structure of utility functions. *Review of Economic Studies*.\n",
+    "- Keeney, R. L., & Raiffa, H. (1976). *Decisions with Multiple Objectives: Preferences and Value Tradeoffs*. Wiley.\n",
+    "- Edwards, W. (1971). Social utilities. *Engineering Economist Summer Institute Conference*. Edwards, W. (1977). How to use multiattribute utility measurement for social decisionmaking. *IEEE Trans. Systems, Man, and Cybernetics*.\n",
+    "- Edwards, W., & Barron, F. H. (1994). SMARTS and SMARTER: Improved simple methods for multiattribute utility measurement. *Organizational Behavior and Human Decision Processes*.\n",
+    "- von Winterfeldt, D., & Edwards, W. (1986). *Decision Analysis and Behavioral Research*. Cambridge University Press.\n",
+    "- Salvatier, J., Wiecki, T. V., & Fonnesbeck, C. (2016). Probabilistic programming in Python using PyMC3. *PeerJ Computer Science*.\n",
+    "- Kumar, R., Carroll, C., Hartikainen, A., & Martin, O. (2019). ArviZ a unified library for exploratory analysis of Bayesian models in Python. *Journal of Open Source Software*.\n",
+    "- Russell, S., & Norvig, P. *Artificial Intelligence: A Modern Approach*, Chapter 16.4."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit de fidélité #3164 — PyMC-16-Decision-Multi-Attribute : **classe (c) OMISSIONS de citations**. Le notebook enseignait toute la littérature MAUT (théorème d'additivité Debreu-Gorman, forme multiplicative Keeney-Raiffa, SMART/SWING, fondations vNM, frameworks PyMC/ArviZ) mais les attributions scholariales n'apparaissaient qu'en labels de section (`(Debreu-Gorman)`, `(Keeney-Raiffa)`) ou dans la cellule References, jamais ancrées comme citations author+year dans la prose du corps.

**Companion du fix REINVENTION K-bug** (PR #3466, commit `c7783bacf`) — ce grain clôt les omissions PyMC-16.

## Modifications (+22/-7, markdown-only, 0 code logic touched)

| # | Concept | Cell (id) | Citation ancrée |
|---|---------|-----------|-----------------|
| 1 | Fondations axioms MAUT | `4e063bda` (idx 1) | von Neumann & Morgenstern (1944) |
| 2 | Théorème additivité | `9521a523` (idx 10) | Debreu (1960) + Gorman (1968) |
| 3 | Swing weights | `dc96ca37` (idx 17) | von Winterfeldt & Edwards (1986) + Keeney & Raiffa (1976) |
| 4 | Forme multiplicative | `94a5d0ca` (idx 21) | Keeney & Raiffa (1976) |
| 5 | Méthode SMART | `9b433dc7` (idx 27) | Edwards (1971, 1977) + Edwards & Barron (1994) SMARTS/SMARTER |
| 6 | Framework PyMC | `25e68b63` (idx 40) | Salvatier et al. (2016) |
| 7 | Diagnostics ArviZ | `4e1ccde2` (idx 45) | Kumar et al. (2019) |
| 8 | References | `3bc2dd32` (idx 52) | 3 → 10 entries |

## Méthode G.1 (cross-check anti-peek-trompeur)

Le pré-audit montrait « Keeney-Raiffa 4 occ. / MAUT 10 occ. / Debreu-Gorman 1 occ. » suggérant un bon sourcement. **FAUX** (même profil trompeur que PyMC-14/15) :
- « Keeney-Raiffa » (4×) = header label (idx 21) + docstring (idx 22) + exercise hint (idx 25) + References (idx 52) → **zéro** citation inline ancrée.
- « MAUT » (10×) = nom de concept dans tables/prose.
- « Debreu-Gorman » (1×) = label de header uniquement.

Un sub-agent `sonnet` read-full evidence-cited a listé les 7 omissions ; j'ai vérifié les 8 cell_ids et le contenu verbatim avant édition, et corrigé la cellule 45 (blocquote cassé par insertion) post-édition.

## Validation

- nbformat : OK
- C.1 : 0 violation (`raise NotImplementedError` / `assert False` / `1/0`)
- C.2 : 24/24 code cells retain `execution_count` + `outputs`
- C.3 : 0 ligne `execution_count`/`outputs` modifiée (markdown-only)
- `scan_cell_ordering.py` : clean (0 finding)
- Catalogue byte-identique (laissé à l'automatisation)
- Branche fraîche depuis `origin/main`

See #3164 (partial delivery : clôt les omissions PyMC-16 ; l'epic reste ouverte sur PyMC-1/7 et #3346).
