### PR TITLE
docs(infer-4): fix 0.43 factual error + relabel stub + Graphviz caveats (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
@@ -731,6 +731,9 @@
    "source": [
     "### Lecture du graphe de facteurs\n",
     "\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH). En son absence, `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un SVG mis en cache (potentiellement etranger au modele courant). La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe ci-dessus represente la structure compilee par Infer.NET :\n",
     "\n",
     "- **Cercles/Ovales** : Variables aleatoires (Cloudy, Sprinkler, Rain, WetGrass)\n",
@@ -1851,6 +1854,9 @@
    "source": [
     "### Impact de l'observation sur le graphe\n",
     "\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH). En son absence, `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un SVG mis en cache (potentiellement etranger au modele courant). La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Comparez ce graphe avec le precedent. L'observation `WetGrass=True` est integree directement dans la structure du modele compile. Dans Infer.NET, une variable observee n'est plus une variable aleatoire mais une constante, ce qui simplifie certains facteurs.\n",
     "\n",
     "L'inference remonte maintenant des effets vers les causes (**abduction**), mettant a jour les probabilites de Rain, Sprinkler et Cloudy."
@@ -1915,7 +1921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "66769df0",
    "metadata": {
     "dotnet_interactive": {
@@ -2015,7 +2021,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Sprinkler | WetGrass) ~ 0.43\r\n"
+      "  P(Sprinkler | WetGrass) ~ 0.40\r\n"
      ]
     },
     {
@@ -2078,7 +2084,7 @@
     "Console.WriteLine(\"=== Explaining Away ===\");\n",
     "Console.WriteLine($\"P(Sprinkler | WetGrass, Rain) = {moteur3.Infer<Bernoulli>(sprinkler3).GetProbTrue():F3}\");\n",
     "Console.WriteLine(\"\\nComparaison :\");\n",
-    "Console.WriteLine(\"  P(Sprinkler | WetGrass) ~ 0.43\");\n",
+    "Console.WriteLine(\"  P(Sprinkler | WetGrass) ~ 0.40\");  // coherent avec P=0,404 (cellule precedente)\n",
     "Console.WriteLine(\"  P(Sprinkler | WetGrass, Rain) ~ 0.19\");\n",
     "Console.WriteLine(\"\\n=> La pluie 'explique' l'herbe mouillee, reduisant P(Sprinkler)\");"
    ]
@@ -2244,6 +2250,9 @@
    },
    "source": [
     "### Structure de l'Explaining Away dans le graphe\n",
+    "\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH). En son absence, `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un SVG mis en cache (potentiellement etranger au modele courant). La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
     "\n",
     "Dans ce graphe, deux variables sont observees (Rain=True, WetGrass=True). Observez comment le graphe se simplifie :\n",
     "\n",
@@ -4264,6 +4273,9 @@
    "source": [
     "### Anatomie du modele hierarchique\n",
     "\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH). En son absence, `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un SVG mis en cache (potentiellement etranger au modele courant). La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe illustre la structure a deux niveaux du modele Rats :\n",
     "\n",
     "**Niveau population (hyperparametres)** :\n",
@@ -4726,6 +4738,9 @@
    "source": [
     "### Structure du reseau de diagnostic\n",
     "\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH). En son absence, `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un SVG mis en cache (potentiellement etranger au modele courant). La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe montre le reseau bayesien de diagnostic avec :\n",
     "\n",
     "- **Deux racines independantes** : Cold et Flu (maladies avec faibles prevalences)\n",
@@ -4885,7 +4900,7 @@
     "tags": []
    },
    "source": [
-    "## 10. Exercice : Extension du Reseau - Symptome de Fievre\n",
+    "## 11. Exercice : Extension du Reseau - Symptome de Fievre\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -4943,7 +4958,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Extension du reseau bayesien avec symptome de fievre\n",
+    "// Exercice : Extension du reseau bayesien avec symptome de fievre\n",
     "// TODO: Creer le moteur d'inference\n",
     "\n",
     "// TODO: Definir les maladies (meme structure que dans l'exemple guide)\n",


### PR DESCRIPTION
## Summary

Audit fidélité #3164 — `Infer-4-Bayesian-Networks.ipynb`. 4 types de défauts trouvés et corrigés :

| # | Type | Cellule | Défaut |
|---|------|---------|--------|
| 1 | ERREUR-FACTUELLE | `66769df0` | `Console.WriteLine("P(Sprinkler|WetGrass) ~ 0.43")` hardcodé, mais la cell `f5e89e66` calcule **0.404**. Incohérent avec `bn50qzj6wv` qui dit 0.40. |
| 2 | LABELING | `bd4e93fc` | Commentaire code `// Exemple guide` sur un **stub** (0 InferenceEngine) → c'est un Exercice (le md title le disait déjà). |
| 3 | NAVIGATION | `9c3ab892` + `58f70403` | 2 sections `## 10.` (doublon). |
| 4 | INVENTION (×5) | `ffbsq502k3` + `pqsv49ncqab` + `w0is6y503v` + `ykn7nybgejj` + `zt3bdv0hqn` | Prose décrit des factor-graphs Wet-Grass/Rats/Diagnostic mais les 5 SVG sont byte-identiques (coin-flip Beta(1,1)→biais→Bernoulli). |

## G.1 cross-check (re-exec réelle)

Re-exec `.net-csharp` 20/20 OK après les edits code. Le kernel .NET Interactive a **caché l'ancienne cellule** (source corrigée 0.43→0.40 mais output restait 0.43) → alignement surgical output pour restaurer la cohérence source/output (ec bump 8→9).

**Défaut 4 SVG** = même root cause que Infer-3 (#3467) : `FactorGraphHelper.GetLatestFactorGraphHtml()` pick `Model_*.svg` le plus récent sans associer SVG→modèle (notebooks multi-graphes) + Graphviz absent du PATH kernel. Caveats standardisés cohérents avec Infer-3 (#3469 merged). Bug helper tooling tracké dans **#3473** (cross-notebook, 20 notebooks Infer affectés potentiellement).

## Changes
- **Cell `66769df0`** : source `0.43 → 0.40` (+comment « coherent avec P=0,404 ») + output aligné.
- **Cell `bd4e93fc`** : comment `// Exemple guide → // Exercice`.
- **Cell `58f70403`** : `## 10. Exercice → ## 11. Exercice`.
- **5 cells SVG** : caveat de reproductibilité Graphviz (préfixe standardisé).

## Non-défects vérifiés (FIDÈLE, left untouched)
~20 claims numériques vérifiés ligne-par-ligne contre outputs Infer.NET : P(Cloudy)=0.5, posteriors Rain 0.784/Sprinkler 0.404/Cloudy 0.604, Explaining Away 0.194, do() P(C|Rain)=0.8 vs P(C|do(Rain))=0.5, Rats μ_α≈241.7g, Diagnostic P(Fatigue|Fever)=0.681. 0 pathology n°5 (modèles réels `InferenceEngine+.Infer<+Variable.If/Case`). 3 exercise stubs legit C.1.

## Gates
- G1 scan_cell_ordering : **1 clean, 0 finding**
- G3 validate : **OK 0, Errors 0** (Warning 1 = FP pré-existant origin/main, vérifié)
- G2 check_c2_compliance : **1/1 compliant** (20/20 code cells executed)
- G4 git diff : **20 ins / 5 del**, 1 fichier

Closes #3474
See #3164, #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)