### PR TITLE
fix(gametheory): scrub absolute papermill paths (25 nb, 49 paths)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -2661,8 +2661,8 @@
    "end_time": "2026-05-14T19:28:05.998718+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb",
-   "output_path": "/tmp/GameTheory-1-Setup_wsl_output.ipynb",
+   "input_path": "GameTheory-1-Setup.ipynb",
+   "output_path": "GameTheory-1-Setup.ipynb",
    "parameters": {},
    "start_time": "2026-05-14T19:27:50.971280+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
@@ -2072,8 +2072,8 @@
    "end_time": "2026-05-23T13:26:04.577905+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb",
-   "output_path": "/tmp/GameTheory-10-ForwardInduction-SPE_wsl_output.ipynb",
+   "input_path": "GameTheory-10-ForwardInduction-SPE.ipynb",
+   "output_path": "GameTheory-10-ForwardInduction-SPE.ipynb",
    "parameters": {},
    "start_time": "2026-05-23T13:26:02.395850+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
@@ -1780,8 +1780,8 @@
    "end_time": "2026-05-14T19:33:43.716545+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb",
-   "output_path": "/tmp/GameTheory-12-ReputationGames_wsl_output.ipynb",
+   "input_path": "GameTheory-12-ReputationGames.ipynb",
+   "output_path": "GameTheory-12-ReputationGames.ipynb",
    "parameters": {},
    "start_time": "2026-05-14T19:33:41.117779+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
@@ -7326,8 +7326,8 @@
    "end_time": "2026-05-11T00:04:29.091476+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb",
-   "output_path": "/tmp/GameTheory-13-ImperfectInfo-CFR_wsl_output.ipynb",
+   "input_path": "GameTheory-13-ImperfectInfo-CFR.ipynb",
+   "output_path": "GameTheory-13-ImperfectInfo-CFR.ipynb",
    "parameters": {},
    "start_time": "2026-05-11T00:02:50.665100+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
@@ -2063,8 +2063,8 @@
    "end_time": "2026-05-13T07:48:42.834243+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb",
-   "output_path": "/tmp/GameTheory-14-DifferentialGames_wsl_output.ipynb",
+   "input_path": "GameTheory-14-DifferentialGames.ipynb",
+   "output_path": "GameTheory-14-DifferentialGames.ipynb",
    "parameters": {},
    "start_time": "2026-05-13T07:48:35.472649+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
@@ -2431,8 +2431,8 @@
    "end_time": "2026-06-07T22:16:59.000108+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-15-CooperativeGames.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-15-CooperativeGames_output.ipynb",
+   "input_path": "GameTheory-15-CooperativeGames.ipynb",
+   "output_path": "GameTheory-15-CooperativeGames.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T22:16:32.784904+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
@@ -4124,8 +4124,8 @@
    "end_time": "2026-06-07T18:52:58.574363+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb",
-   "output_path": "/tmp/GameTheory-15b-Lean-CooperativeGames_wsl_output.ipynb",
+   "input_path": "GameTheory-15b-Lean-CooperativeGames.ipynb",
+   "output_path": "GameTheory-15b-Lean-CooperativeGames.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T18:52:51.761554+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
@@ -1397,8 +1397,8 @@
    "end_time": "2026-06-02T22:36:16.520833+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-15c-CooperativeGames-Python.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-15c-CooperativeGames-Python_output.ipynb",
+   "input_path": "GameTheory-15c-CooperativeGames-Python.ipynb",
+   "output_path": "GameTheory-15c-CooperativeGames-Python.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T22:36:11.072393+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
@@ -2212,8 +2212,8 @@
    "end_time": "2026-06-04T17:59:06.785341+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb",
-   "output_path": "/tmp/GameTheory-16-MechanismDesign_wsl_output.ipynb",
+   "input_path": "GameTheory-16-MechanismDesign.ipynb",
+   "output_path": "GameTheory-16-MechanismDesign.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T17:59:01.582625+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
@@ -2163,8 +2163,8 @@
    "end_time": "2026-06-02T22:48:23.517291+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-17-MultiAgent-RL.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-17-MultiAgent-RL_output.ipynb",
+   "input_path": "GameTheory-17-MultiAgent-RL.ipynb",
+   "output_path": "GameTheory-17-MultiAgent-RL.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T22:47:59.097048+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
@@ -2222,7 +2222,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/gt2_reexec_1780477384.ipynb",
+   "output_path": "GameTheory-2-NormalForm.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T09:03:07.402343",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb
@@ -4108,8 +4108,8 @@
    "end_time": "2026-06-08T06:02:34.311490+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb",
-   "output_path": "/tmp/GameTheory-2b-Lean-Definitions_wsl_output.ipynb",
+   "input_path": "GameTheory-2b-Lean-Definitions.ipynb",
+   "output_path": "GameTheory-2b-Lean-Definitions.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T06:02:26.836068+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
@@ -2489,8 +2489,8 @@
    "end_time": "2026-06-02T22:25:33.958514+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-3-Topology2x2.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-3-Topology2x2_output.ipynb",
+   "input_path": "GameTheory-3-Topology2x2.ipynb",
+   "output_path": "GameTheory-3-Topology2x2.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T22:25:21.680270+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
@@ -1768,8 +1768,8 @@
    "end_time": "2026-06-02T22:35:34.136414+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-4-NashEquilibrium.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-4-NashEquilibrium_output.ipynb",
+   "input_path": "GameTheory-4-NashEquilibrium.ipynb",
+   "output_path": "GameTheory-4-NashEquilibrium.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T22:35:23.176646+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4b-Lean-NashExistence.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4b-Lean-NashExistence.ipynb
@@ -4069,8 +4069,8 @@
    "end_time": "2026-06-11T10:05:49.898569",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\Users\\MYIA\\AppData\\Local\\Temp\\pr2804\\stitched.ipynb",
-   "output_path": "C:\\Users\\MYIA\\AppData\\Local\\Temp\\pr2804\\executed2.ipynb",
+   "input_path": "GameTheory-4b-Lean-NashExistence.ipynb",
+   "output_path": "GameTheory-4b-Lean-NashExistence.ipynb",
    "parameters": {},
    "start_time": "2026-06-11T10:05:41.459334",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
@@ -1981,8 +1981,8 @@
    "end_time": "2026-06-02T22:09:40.799931+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-4c-NashExistence-Python.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-4c-NashExistence-Python_output.ipynb",
+   "input_path": "GameTheory-4c-NashExistence-Python.ipynb",
+   "output_path": "GameTheory-4c-NashExistence-Python.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T22:09:35.587860+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb
@@ -2084,8 +2084,8 @@
    "end_time": "2026-06-02T22:08:41.839171+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-6-EvolutionTrust.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-6-EvolutionTrust_output.ipynb",
+   "input_path": "GameTheory-6-EvolutionTrust.ipynb",
+   "output_path": "GameTheory-6-EvolutionTrust.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T22:08:35.300348+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
@@ -1800,8 +1800,8 @@
    "end_time": "2026-06-04T17:58:50.861552+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb",
-   "output_path": "/tmp/GameTheory-7-ExtensiveForm_wsl_output.ipynb",
+   "input_path": "GameTheory-7-ExtensiveForm.ipynb",
+   "output_path": "GameTheory-7-ExtensiveForm.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T17:58:48.302532+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
@@ -1150,8 +1150,8 @@
    "end_time": "2026-06-02T22:35:49.286220+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-8-CombinatorialGames.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-8-CombinatorialGames_output.ipynb",
+   "input_path": "GameTheory-8-CombinatorialGames.ipynb",
+   "output_path": "GameTheory-8-CombinatorialGames.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T22:35:42.372166+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8b-Lean-CombinatorialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8b-Lean-CombinatorialGames.ipynb
@@ -1465,8 +1465,8 @@
    "end_time": "2026-06-07T18:44:09.017420+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-8b-Lean-CombinatorialGames.ipynb",
-   "output_path": "/tmp/GameTheory-8b-Lean-CombinatorialGames_wsl_output.ipynb",
+   "input_path": "GameTheory-8b-Lean-CombinatorialGames.ipynb",
+   "output_path": "GameTheory-8b-Lean-CombinatorialGames.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T18:44:03.998325+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
@@ -1554,8 +1554,8 @@
    "end_time": "2026-06-07T02:51:12.763906",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-8c-CombinatorialGames-Python.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-8c-CombinatorialGames-Python_output.ipynb",
+   "input_path": "GameTheory-8c-CombinatorialGames-Python.ipynb",
+   "output_path": "GameTheory-8c-CombinatorialGames-Python.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T02:51:08.007712",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
@@ -1873,8 +1873,8 @@
    "end_time": "2026-06-02T22:10:03.513028+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-9-BackwardInduction.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-9-BackwardInduction_output.ipynb",
+   "input_path": "GameTheory-9-BackwardInduction.ipynb",
+   "output_path": "GameTheory-9-BackwardInduction.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T22:09:57.861502+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb
@@ -4591,8 +4591,8 @@
    "end_time": "2026-06-07T20:37:20.389962+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb",
-   "output_path": "/tmp/02-Lean-SocialChoice-Formal_wsl_output.ipynb",
+   "input_path": "02-Lean-SocialChoice-Formal.ipynb",
+   "output_path": "02-Lean-SocialChoice-Formal.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T20:37:08.038323+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
@@ -2300,8 +2300,8 @@
    "end_time": "2026-05-13T07:49:40.605628+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-16c-SocialChoice-Python.ipynb",
-   "output_path": "/tmp/GameTheory-16c-SocialChoice-Python_wsl_output.ipynb",
+   "input_path": "03-Voting-Methods.ipynb",
+   "output_path": "03-Voting-Methods.ipynb",
    "parameters": {},
    "start_time": "2026-05-13T07:49:37.781964+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
@@ -2811,8 +2811,8 @@
    "end_time": "2026-05-14T19:39:57.693172+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-16d-SocialChoice-SAT.ipynb",
-   "output_path": "/tmp/GameTheory-16d-SocialChoice-SAT_wsl_output.ipynb",
+   "input_path": "04-Computational-Aggregation-SAT-Z3.ipynb",
+   "output_path": "04-Computational-Aggregation-SAT-Z3.ipynb",
    "parameters": {},
    "start_time": "2026-05-14T19:39:55.379064+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Summary

Atomic application of `scripts/notebook_tools/scrub_papermill_paths.py` (#3435) to the **GameTheory** family — **25 notebooks, 49 absolute paths** scrubbed to relative basename.

Re-execs had injected absolute machine-local paths into `metadata.papermill.output_path` / `.input_path` (e.g. `/tmp/GameTheory-16d-SocialChoice-SAT_wsl_output.ipynb`, `/mnt/d/dev/CoursIA/...`, `D:\dev\CoursIA-2\...`). These leak local machine structure (including WSL paths) and break reproducibility. Replaced with relative basename (canonical target state, proven by SC-10 in #3427).

## Scope (atomic — 1 family)

| Location | Notebooks |
|----------|-----------|
| `GameTheory/` (root) | 22 (GT-1/2/2b/3/4/4b/4c/6/7/8/8b/8c/9/10/12/13/14/15/15b/15c/16/17) |
| `GameTheory/SocialChoice/` | 3 (02-Lean, 03-Voting, 04-SAT-Z3) |
| **Total** | **25 notebooks, 49 paths** |

Mix of Lean (`*-Lean-*`), Python (`*-Python`), and standard notebooks. Scrub is uniform metadata-only (path-replacement) — no source touched, so no collision with the audit/content lanes.

## Verification

- [x] **49 ins / 49 del** across 25 notebooks — `git diff --stat`
- [x] **JSON valid**: all 45 GameTheory notebooks (incl `_output`/`_executed`/non-defect) parse
- [x] **Only papermill keys changed**: `grep` shows only `input_path` / `output_path`
- [x] **Outputs + execution_count untouched**: 0 matches (C.2 preserved, no re-exec)
- [x] **Catalogue byte-identical** to main
- [x] **MetaGeneticSharp submodule clean**

See #3436. Follows #3435 (SC-06), #3454 (Sudoku-C#), #3460 (Search/Applications), #3468 (SmartContracts).

Part of po-2024 deep-queue scrub (ai-01 directive 2026-06-18 15:00Z).

Co-Authored-By: Claude <noreply@anthropic.com>