### PR TITLE
docs(pymc-1): anchor framework citations + resolve orphan anchors (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
@@ -125,7 +125,11 @@
   {
    "cell_type": "markdown",
    "id": "7235b124",
-   "source": "### Verification de l'installation\n\nPyMC 5.x et ses dependances (ArviZ, PyTensor, NumPy, SciPy) sont maintenant disponibles. La cellule suivante importe les bibliotheques necessaires et verifie les versions. PyMC utilise **PyTensor** comme backend de calcul symbolique (equivalent de TensorFlow Probability pour les modeles probabilistes) et **ArviZ** pour la visualisation et le diagnostic des chaines MCMC.",
+   "source": [
+    "### Verification de l'installation\n",
+    "\n",
+    "PyMC 5.x et ses dependances (ArviZ, PyTensor, NumPy, SciPy) sont maintenant disponibles. La cellule suivante importe les bibliotheques necessaires et verifie les versions. PyMC (**Salvatier et al., 2016**) utilise **PyTensor** comme backend de calcul symbolique (equivalent de TensorFlow Probability pour les modeles probabilistes) et **ArviZ** (**Kumar et al., 2019**) pour la visualisation et le diagnostic des chaines MCMC."
+   ],
    "metadata": {}
   },
   {
@@ -208,6 +212,8 @@
     "## 2. Programmation Probabiliste avec PyMC\n",
     "\n",
     "### Infer.NET vs PyMC\n",
+    "\n",
+    "Infer.NET (**Minka et al., 2018**) est un framework de programmation probabiliste developpe par Microsoft Research, base sur le passage de messages (Expectation Propagation, Variational Message Passing). PyMC (**Salvatier et al., 2016**) s'appuie a l'inverse sur l'echantillonnage MCMC. Le tableau suivant confronte les deux approches.\n",
     "\n",
     "| Concept | Infer.NET | PyMC |\n",
     "|---------|-----------|------|\n",
@@ -702,6 +708,9 @@
     "- Neal, R. M. (2011). MCMC using Hamiltonian dynamics. In *Handbook of Markov Chain Monte Carlo*, Chapman & Hall/CRC.\n",
     "- Metropolis, N., Rosenbluth, A., Rosenbluth, M., Teller, A., & Teller, E. (1953). Equation of state calculations by fast computing machines. *Journal of Chemical Physics*, 21(6), 1087-1092.\n",
     "- Hastings, W. K. (1970). Monte Carlo sampling methods using Markov chains and their applications. *Biometrika*, 57(1), 97-109.\n",
+    "- Duane, S., Kennedy, A. D., Pendleton, B. J., & Roweth, D. (1987). Hybrid Monte Carlo. *Physics Letters B*, 195(2), 216-222.\n",
+    "- Raiffa, H., & Schlaifer, R. (1961). *Applied Statistical Decision Theory*. Harvard University Press.\n",
+    "- Minka, T., Winn, J., Guiver, J., Webster, S., Zaykov, Y., Yangel, B., Spengler, A., & Bronskill, J. (2018). *Infer.NET 2.4, Microsoft Research Cambridge*.\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Summary

Audit de fidélité #3164 — PyMC-1-Setup : **classe (c) OMISSIONS de frameworks** + résolution d'orphelins de citation. PyMC-1 introduit PyMC, Infer.NET et ArviZ comme frameworks, mais les attributions scholariales n'apparaissaient que dans la cellule References, jamais ancrées inline à la première mention de chaque framework dans le corps. De plus, deux citations inline existantes étaient des orphelins (cités dans le corps, absents des References).

## Modifications (+10/-1, markdown-only, 0 code logic touched)

| # | Concept | Cell (id) | Action |
|---|---------|-----------|--------|
| 1 | PyMC + ArviZ | `7235b124` (idx 3) | Salvatier et al. (2016) + Kumar et al. (2019) ancrés inline |
| 2 | Infer.NET vs PyMC | `9d50c4ba` (idx 5) | Minka et al. (2018) + Salvatier (2016) ancrés inline (lead paragraph ajouté) |
| 3 | References | `4411434a` (idx 17) | 6 → 9 entries : Duane et al. (1987) HMC, Raiffa & Schlaifer (1961) conjugate priors, Minka et al. (2018) Infer.NET |

Les 3 nouveaux entries References résolvent les **2 orphelins** existants : `Duane et al. 1987` (cité cell `ef617c31` idx 14) et `Raiffa & Schlaiffer 1961` (cité cell `f1b6f5e3` idx 10) étaient déjà ancrés inline mais absents de References — désormais cohérents.

## Méthode G.1 (cross-check)

Le pré-audit montrait « Salvatier / Kumar / Hoffman / Metropolis / Hastings » dans le notebook — suggérant un bon sourcement. Vérification G.1 a affiné : **3 concepts étaient déjà correctement ancrés inline** (NUTS Hoffman&Gelman 2014 cell idx 8, conjugaison Raiffa&Schlaiffer 1961 cell idx 10, bloc MCMC/HMC Metropolis 1953 / Hastings 1970 / Duane 1987 / Neal 2011 cell idx 14) → **non retouchés**. Les vraies omissions = les 3 frameworks (PyMC, Infer.NET, ArviZ) nommés sans citation inline au point d'introduction.

**Anti-chariot G.5** : le sous-agent proposait d'ajouter Gelman BDA3 / Bayes 1763 / Laplace / sequential-updating. Trimmed comme sur-enrichissement — la conjugaison Beta-Bernoulli est déjà attribuée à Raiffa&Schlaiffer (source canonique du prior conjugué), l'inference bayésienne est un concept de niveau introductif qui n'exige pas une citation primaire dans un notebook d'intro. Scope gardé serré.

## Validation

- nbformat : OK
- C.1 : 0 violation (`raise NotImplementedError` / `assert False` / `1/0`)
- C.2 : 7/7 code cells retain `execution_count` + `outputs`
- C.3 : 0 ligne `execution_count`/`outputs` modifiée (markdown-only)
- `scan_cell_ordering.py` : clean (0 finding)
- Catalogue byte-identique (laissé à l'automatisation)
- Branche fraîche depuis `origin/main`

See #3164 (partial delivery sur la série PyMC).
