### PR TITLE
fix(semanticweb): scrub absolute papermill paths (14 nb, 25 paths)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb
@@ -8883,7 +8883,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/rdfnet_final.ipynb",
+   "output_path": "RDF.Net.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T03:08:31.503148+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
@@ -3545,8 +3545,8 @@
    "end_time": "2026-06-07T13:26:44.624160+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-10-Python-RDFStar.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-10-Python-RDFStar_output.ipynb",
+   "input_path": "SW-10-Python-RDFStar.ipynb",
+   "output_path": "SW-10-Python-RDFStar.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T13:26:33.619774+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
@@ -5493,8 +5493,8 @@
    "end_time": "2026-06-07T13:27:05.298600+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-11-Python-KnowledgeGraphs.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-11-Python-KnowledgeGraphs_output.ipynb",
+   "input_path": "SW-11-Python-KnowledgeGraphs.ipynb",
+   "output_path": "SW-11-Python-KnowledgeGraphs.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T13:26:33.684002+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
@@ -3289,8 +3289,8 @@
    "end_time": "2026-06-07T13:26:51.607707+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-12-Python-GraphRAG.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-12-Python-GraphRAG_output.ipynb",
+   "input_path": "SW-12-Python-GraphRAG.ipynb",
+   "output_path": "SW-12-Python-GraphRAG.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T13:26:33.762442+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -3531,8 +3531,8 @@
    "end_time": "2026-06-07T08:48:46.294160+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-13-Python-Reasoners.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-13-Python-Reasoners_output.ipynb",
+   "input_path": "SW-13-Python-Reasoners.ipynb",
+   "output_path": "SW-13-Python-Reasoners.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T08:48:22.797885+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
@@ -2717,8 +2717,8 @@
    "end_time": "2026-06-03T00:03:21.883732+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-2-CSharp-RDFBasics.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-2-CSharp-RDFBasics_output.ipynb",
+   "input_path": "SW-2-CSharp-RDFBasics.ipynb",
+   "output_path": "SW-2-CSharp-RDFBasics.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:03:12.361886+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
@@ -1694,8 +1694,8 @@
    "end_time": "2026-05-25T04:09:37.118423+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-2b-Python-RDFBasics.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-2b-Python-RDFBasics_output.ipynb",
+   "input_path": "SW-2b-Python-RDFBasics.ipynb",
+   "output_path": "SW-2b-Python-RDFBasics.ipynb",
    "parameters": {},
    "start_time": "2026-05-25T04:09:34.264787+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
@@ -2108,7 +2108,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "SW-3-CSharp-GraphOperations.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sw3_v2.ipynb",
+   "output_path": "SW-3-CSharp-GraphOperations.ipynb",
    "parameters": {},
    "start_time": "2026-05-14T19:12:11.324768",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
@@ -1751,7 +1751,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "SW-4-CSharp-SPARQL.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sw4_v3.ipynb",
+   "output_path": "SW-4-CSharp-SPARQL.ipynb",
    "parameters": {},
    "start_time": "2026-05-14T19:17:27.156439",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
@@ -1917,8 +1917,8 @@
    "end_time": "2026-06-07T08:36:14.296927+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-5b-Python-LinkedData.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-5b-Python-LinkedData_output.ipynb",
+   "input_path": "SW-5b-Python-LinkedData.ipynb",
+   "output_path": "SW-5b-Python-LinkedData.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T08:33:14.692339+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
@@ -2174,8 +2174,8 @@
    "end_time": "2026-06-03T00:03:43.305287+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-6-CSharp-RDFS.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-6-CSharp-RDFS_output.ipynb",
+   "input_path": "SW-6-CSharp-RDFS.ipynb",
+   "output_path": "SW-6-CSharp-RDFS.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:03:36.906864+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb
@@ -2441,8 +2441,8 @@
    "end_time": "2026-06-03T00:03:54.716746+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-7-CSharp-OWL.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-7-CSharp-OWL_output.ipynb",
+   "input_path": "SW-7-CSharp-OWL.ipynb",
+   "output_path": "SW-7-CSharp-OWL.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:03:48.034677+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
@@ -3191,8 +3191,8 @@
    "end_time": "2026-06-07T13:26:44.006723+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-8-Python-SHACL.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-8-Python-SHACL_output.ipynb",
+   "input_path": "SW-8-Python-SHACL.ipynb",
+   "output_path": "SW-8-Python-SHACL.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T13:26:19.411126+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
@@ -5049,8 +5049,8 @@
    "end_time": "2026-06-07T13:26:53.255651+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-9-Python-JSONLD.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-9-Python-JSONLD_output.ipynb",
+   "input_path": "SW-9-Python-JSONLD.ipynb",
+   "output_path": "SW-9-Python-JSONLD.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T13:26:33.634590+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

Atomic application of `scripts/notebook_tools/scrub_papermill_paths.py` (#3435) to the **SemanticWeb** family — **14 notebooks, 25 absolute paths** scrubbed to relative basename.

Re-execs had injected absolute machine-local paths into `metadata.papermill.output_path` / `.input_path` (e.g. `D:\dev\CoursIA\...`, `D:\dev\CoursIA-2\..._output.ipynb`). These leak local machine structure and break reproducibility. Replaced with relative basename (canonical target state, proven by SC-10 in #3427).

## Scope (atomic — 1 family)

| Type | Notebooks |
|------|-----------|
| C# | 5 (SW-2, SW-3, SW-4, SW-6, SW-7) |
| Python | 8 (SW-2b, SW-5b, SW-8, SW-9, SW-10, SW-11, SW-12, SW-13) |
| RDF.Net-Legacy | 1 (RDF.Net.ipynb) |
| **Total** | **14 notebooks, 25 paths** |

Scrub is uniform metadata-only (path-replacement) — no source touched, no collision with content/audit lanes.

## Verification

- [x] **25 ins / 25 del** across 14 notebooks — `git diff --stat`
- [x] **JSON valid**: all 23 SemanticWeb notebooks (incl `_output`/`_executed`/non-defect) parse
- [x] **Only papermill keys changed**: `grep` shows only `input_path` / `output_path`
- [x] **Outputs + execution_count untouched**: 0 matches (C.2 preserved, no re-exec)
- [x] **Catalogue byte-identical** to main
- [x] **MetaGeneticSharp submodule clean**

See #3436. Follows #3435, #3454 (Sudoku-C#), #3460 (Search/Applications), #3468 (SmartContracts), #3476 (GameTheory).

Part of po-2024 deep-queue scrub (ai-01 directive 2026-06-18 15:00Z).

Co-Authored-By: Claude <noreply@anthropic.com>