### PR TITLE
fix(planners): scrub absolute papermill paths (12 nb, 24 paths)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
@@ -1556,8 +1556,8 @@
    "end_time": "2026-06-09T04:26:08.989648+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-1-Introduction.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-1-Introduction_output.ipynb",
+   "input_path": "Planners-1-Introduction.ipynb",
+   "output_path": "Planners-1-Introduction.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T04:26:01.400987+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
@@ -2405,8 +2405,8 @@
    "end_time": "2026-06-09T11:16:37.286948+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-2-PDDL-Basics.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-2-PDDL-Basics_output.ipynb",
+   "input_path": "Planners-2-PDDL-Basics.ipynb",
+   "output_path": "Planners-2-PDDL-Basics.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T11:16:31.084548+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
@@ -2351,8 +2351,8 @@
    "end_time": "2026-06-09T11:22:48.426049+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-3-State-Space.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-3-State-Space_output.ipynb",
+   "input_path": "Planners-3-State-Space.ipynb",
+   "output_path": "Planners-3-State-Space.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T11:22:41.482241+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb
@@ -2779,8 +2779,8 @@
    "end_time": "2026-06-09T07:16:46.196825+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\\Planners-4-Fast-Downward.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\\Planners-4-Fast-Downward_output.ipynb",
+   "input_path": "Planners-4-Fast-Downward.ipynb",
+   "output_path": "Planners-4-Fast-Downward.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T07:16:33.080171+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
@@ -2150,8 +2150,8 @@
    "end_time": "2026-06-09T06:15:24.496573+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\\Planners-5-Heuristics.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\\Planners-5-Heuristics_output.ipynb",
+   "input_path": "Planners-5-Heuristics.ipynb",
+   "output_path": "Planners-5-Heuristics.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T06:15:17.400508+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains.ipynb
@@ -3348,8 +3348,8 @@
    "end_time": "2026-06-09T12:17:41.716819+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\\Planners-6-Domains.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\\Planners-6-Domains_output.ipynb",
+   "input_path": "Planners-6-Domains.ipynb",
+   "output_path": "Planners-6-Domains.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T12:17:13.590076+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools.ipynb
@@ -2292,8 +2292,8 @@
    "end_time": "2026-06-09T13:14:58.828141+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-7-OR-Tools.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-7-OR-Tools_output.ipynb",
+   "input_path": "Planners-7-OR-Tools.ipynb",
+   "output_path": "Planners-7-OR-Tools.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T13:14:08.770887+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
@@ -2044,8 +2044,8 @@
    "end_time": "2026-06-09T13:18:43.933111+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-8-Temporal.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-8-Temporal_output.ipynb",
+   "input_path": "Planners-8-Temporal.ipynb",
+   "output_path": "Planners-8-Temporal.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T13:18:18.001647+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
@@ -2388,8 +2388,8 @@
    "end_time": "2026-06-09T16:13:58.737592+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-9-HTN.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\03-Advanced\\Planners-9-HTN_output.ipynb",
+   "input_path": "Planners-9-HTN.ipynb",
+   "output_path": "Planners-9-HTN.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T16:13:56.306179+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
@@ -2510,8 +2510,8 @@
    "end_time": "2026-06-09T05:15:26.623313+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\04-NeuroSymbolic\\Planners-11-Unified-Planning.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\04-NeuroSymbolic\\Planners-11-Unified-Planning_output.ipynb",
+   "input_path": "Planners-11-Unified-Planning.ipynb",
+   "output_path": "Planners-11-Unified-Planning.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T05:15:18.734878+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
@@ -2729,8 +2729,8 @@
    "end_time": "2026-06-09T13:31:58.827770+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\04-NeuroSymbolic\\Planners-12-LOOP.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\04-NeuroSymbolic\\Planners-12-LOOP_output.ipynb",
+   "input_path": "Planners-12-LOOP.ipynb",
+   "output_path": "Planners-12-LOOP.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T13:31:27.339695+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/archive/Fast-Downward-Legacy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/archive/Fast-Downward-Legacy.ipynb
@@ -2995,8 +2995,8 @@
    "end_time": "2026-06-02T21:47:53.678473+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\archive\\Fast-Downward-Legacy.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\archive\\Fast-Downward-Legacy_output.ipynb",
+   "input_path": "Fast-Downward-Legacy.ipynb",
+   "output_path": "Fast-Downward-Legacy.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T21:47:42.420672+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

Atomic application of `scripts/notebook_tools/scrub_papermill_paths.py` (#3435) to the **Planners** family — **12 notebooks, 24 absolute paths** scrubbed to relative basename.

Re-execs had injected absolute machine-local paths into `metadata.papermill.output_path` / `.input_path` (e.g. `C:\dev\CoursIA\...`, `D:\dev\CoursIA-2\..._output.ipynb`). These leak local machine structure and break reproducibility. Replaced with relative basename (canonical target state, proven by SC-10 in #3427).

## Scope (atomic — 1 family)

| Sub-dir | Notebooks |
|---------|-----------|
| `01-Foundation/` | 3 (Planners-1 Introduction, Planners-2 PDDL-Basics, Planners-3 State-Space) |
| `02-Classical/` | 3 (Planners-4 Fast-Downward, Planners-5 Heuristics, Planners-6 Domains) |
| `03-Advanced/` | 3 (Planners-7 OR-Tools, Planners-8 Temporal, Planners-9 HTN) |
| `04-NeuroSymbolic/` | 2 (Planners-11 Unified-Planning, Planners-12 LOOP) |
| `archive/` | 1 (Fast-Downward-Legacy) |
| **Total** | **12 notebooks, 24 paths** |

Scrub is uniform metadata-only (path-replacement) — no source touched.

## Verification

- [x] **24 ins / 24 del** across 12 notebooks — `git diff --stat`
- [x] **JSON valid**: all 19 Planners notebooks (incl `_output`/`_executed`/non-defect) parse
- [x] **Only papermill keys changed**: `grep` shows exactly 24 `input_path` + 24 `output_path`
- [x] **Outputs + execution_count untouched**: 0 matches (C.2 preserved, no re-exec)
- [x] **Catalogue byte-identical** to main
- [x] **MetaGeneticSharp submodule clean**

See #3436. Follows #3435, #3454 (Sudoku-C#), #3460 (Search/Applications), #3468 (SmartContracts), #3476 (GameTheory), #3482 (SemanticWeb).

Part of po-2024 deep-queue scrub (ai-01 directive 2026-06-18 15:00Z).

Co-Authored-By: Claude <noreply@anthropic.com>