### PR TITLE
fix(infer7): Classification fidelity audit #3164 -- nav, sample-size error, cross-ref, SVG caveats

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Classification.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Classification.ipynb
@@ -913,6 +913,8 @@
    "source": [
     "### Lecture du graphe de facteurs - Regression Logistique\n",
     "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe ci-dessus montre la structure du modele de classification probit :\n",
     "\n",
     "**Variables (ellipses)** :\n",
@@ -1894,6 +1896,8 @@
    "source": [
     "### Graphe de facteurs multi-features - Structure vectorielle\n",
     "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe multi-features illustre l'extension du modele a plusieurs dimensions :\n",
     "\n",
     "**Differences avec le modele 1D** :\n",
@@ -2732,6 +2736,8 @@
    "source": [
     "### Graphe de facteurs du Bayes Point Machine\n",
     "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe du BPM encapsule la classe `SimpleBPM` et montre :\n",
     "\n",
     "**Structure identique au modele multi-features** :\n",
@@ -3078,6 +3084,8 @@
    },
    "source": [
     "### Graphe de facteurs du test A/B clinique\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
     "\n",
     "Ce graphe illustre le modele comparatif Beta-Binomial :\n",
     "\n",
@@ -3448,7 +3456,7 @@
     "\n",
     "La certitude croit approximativement comme $\\sqrt{n}$ :\n",
     "- Doubler la confiance necessite quadrupler l'echantillon\n",
-    "- Passer de 67% a 99% necessite ~100x plus de donnees\n",
+    "- Passer de 67% a 99% necessite ~10x plus de donnees (n=10 -> n=100 dans le tableau ci-dessus)\n",
     "\n",
     "**Implications pratiques** :\n",
     "\n",
@@ -4224,6 +4232,8 @@
    "source": [
     "### Graphe du classificateur spam - BPM a 3 features\n",
     "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe de l'exercice spam reprend la structure du BPM multi-features avec 3 dimensions :\n",
     "\n",
     "**Features encodees** :\n",
@@ -4311,7 +4321,7 @@
     "tags": []
    },
    "source": [
-    "## 10. Exercice : Detecteur de Critiques Negatives\n",
+    "## 11. Exercice : Detecteur de Critiques Negatives\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -4325,7 +4335,7 @@
     "\n",
     "Entrainer le BPM et classer 3 nouvelles critiques : [1,0], [0,1], [3,0].\n",
     "\n",
-    "**Indice** : Reutilisez exactement la structure BPM de l'exemple guide (section 8) avec 2 features."
+    "**Indice** : Reutilisez exactement la structure BPM de la section 6 (Bayes Point Machine) avec 2 features."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Closes #3489. Fidelity audit #3164 of `Infer-7-Classification.ipynb` (6th Infer notebook). **Notably cleaner than Infer-2/3/4/5/6**: no INVENTION, no LABELING, no pathology n°5. 8 defects, all **markdown-only** (outputs byte-identical).

## Defects fixed

1. **NAVIGATION** (cell `97924a95`): duplicate `## 10.` (Resume + Exercice). Renumbered Exercice 10→11.
2. **ERREUR-FACTUELLE** (cell `my479h57vh`): prose "~100x plus de donnees" but the cell's own table shows n=10→0.670 (67%) and n=100→0.986 (99%) = **10x**, not 100x. Internally contradictory. Corrected to "~10x (n=10 → n=100)".
3. **ERREUR-FACTUELLE** (cell `97924a95`): exercise indice references "structure BPM ... (section 8)" but BPM is **section 6**; section 8 is sample-size. Corrected to "(section 6 - Bayes Point Machine)".
4-8. **OMISSION ×5 SVG** (cells `sn7d8ljyk2`/`8xwj3opb66t`/`893615jcc8i`/`t8zueh8k44o`/`v3oesyvwqk`): prose "le graphe ci-dessus montre" but 5 adjacent output cells show the honest "Graphviz non disponible" fallback (`dot` absent from `.net-csharp` kernel PATH). Added standardized reproducibility caveat per cell (same template as Infer-3/4/5/6).

**DIFFERENT from Infer-3/4**: SVGs here are **honestly absent** (fallback warning, svg_len=0), NOT stale byte-identical foreign-model SVGs (INVENTION). Same benign class as Infer-5/6.

## Root cause

SVG fallback = bug `FactorGraphHelper.GetLatestFactorGraphHtml()` — issue **#3473** (cross-notebook helper, 20 Infer notebooks). Tracked separately for isolated helper fix.

## Verification (4 gates)

- **G1 cell-ordering**: 1 clean, 0 findings
- **G2 C.2**: 1/1 compliant (outputs + execution_count intact)
- **G3 validate**: OK 0, Errors 0 (Warning 1 = pre-existing LaTeX FP on origin/main, verified via `git show origin/main` + validate)
- **G4 git diff**: 13 ins / 3 del, 1 file, markdown-only

28+ numerical claims FIDÈLE spot-checked (logistic poids 0.8144/σ=0.192, seuil 3.378/σ=0.866, multi-feature x1=0.5454/x2=1.254, BPM table 0.268/0.603/0.751/0.633, A/B Placebo 0.304 IC[0.213,0.395] P=0.986, sample-size table 0.670/0.926/0.986/1.000, spam 0.053/0.952/0.334/0.984). 0 pathology n°5: all 6 inference cells contain `InferenceEngine` + `.Infer<`; cell `30425d08` (Exemple guide Spam) delegates to `SimpleBPM` which genuinely infers.

## Pattern

6th Infer notebook. Recurring series pattern holds: (a) navigation doublon (4/5/6/7), (b) SVG rendering broken (3/4/5/6/7), (c) ERREUR-FACTUELLE numerical (4/6/7). **No LABELING defect this time** (first Infer without one) and **no INVENTION** — quality improving.

See #3164
See #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)