### PR TITLE
docs(qc-py-13): fill real QC Cloud metrics for CompleteFrameworkStrategy cell 48 (See #3367)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
@@ -2026,13 +2026,20 @@
    "metadata": {},
    "source": [
     "---\n",
-    "**Resultats du backtest QC Cloud (CompleteFrameworkStrategy)** -- *corrige (#3367, verification QC Cloud en cours, projet 33046719)*\n",
+    "**Resultats du backtest QC Cloud (CompleteFrameworkStrategy)** -- *corrige (#3367, metriques reelles QC Cloud, projet 33046719, backtest CompleteFrameworkStrategy-2015-2024)*\n",
     "\n",
     "| Metrique | Valeur |\n",
     "|----------|--------|\n",
-    "| Statut | *Verification QC Cloud en cours* |\n",
+    "| Sharpe Ratio | 0.066 |\n",
+    "| Rendement annuel compose (CAGR) | 3.439% |\n",
+    "| Drawdown maximal | 25.100% |\n",
+    "| Probabilistic Sharpe Ratio (PSR) | 0.370% |\n",
     "\n",
-    "*Correctif #3367 : le bloc precedent affichait Net Profit -9.241% / Total Fees $1006.31 / Equity finale $90,759.08 -- mais avec **Trades = 0**. C'est une **contradiction interne** : zero trade implique zero fill et zero frais (or $1006.31 de frais sont reclames). Le Win Rate 33.0% est par ailleurs indefini sans trade. Les valeurs precedentes etaient fabriquees. Les metriques reelles seront renseignees apres lecture du backtest QC Cloud du projet 33046719 (compile BuildSuccess, en attente de node).*"
+    "*Verdict : strategie faible, quasi sans alpha (Sharpe < 1.0, PSR < 1%).*\n",
+    "\n",
+    "*Correctif #3367 : le bloc precedent affichait Net Profit -9.241% / Total Fees $1006.31 / Equity finale $90,759.08 -- mais avec **Trades = 0**. C'etait une **contradiction interne** (zero trade implique zero fill et zero frais). Les valeurs precedentes etaient fabriquees. Les metriques ci-dessus sont issues du backtest QC Cloud reel du projet 33046719. Conformement a la methode #3367, les champs Orders/Trades/Win Rate sont omis car non fiables pour les backtests Algorithm Framework (`read_backtest` retourne \"-\" / 0).*\n",
+    "\n",
+    "*Le bloc precedent (cellule 30 MomentumFrameworkAlgorithm) garde sa note \"Verification en cours\" : le backtest correspondant etait reste bloque sur un timeout interne (O(n^2) History-per-symbol sur 10 ans) et a ete arrete.*"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Issue #3367 (impossible metrics). **NB13 cell 48 CompleteFrameworkStrategy → real QC Cloud metrics filled.** The QC Cloud node was blocked for ~9h by a stuck MomentumFramework backtest; it was liberated cycle 24 via Playwright (the QC UI has no "Stop" button on running backtests — the `delete-icon` in the Backtest Results panel cancels/deletes the running backtest and frees the node). CompleteFramework backtest then ran to completion.

See #3367.

### Real metrics (project 33046719, backtest `e24174cc...`, Completed)

| Metric | Value |
|--------|-------|
| Sharpe Ratio | 0.066 |
| CAGR | 3.439% |
| Max Drawdown | 25.100% |
| PSR | 0.370% |

**Verdict: weak strategy, near-zero alpha (Sharpe < 1.0, PSR < 1%).**

### What changed (markdown-only, single cell 48)

Replaces the cycle-16 "Verification en cours" placeholder (PR #3433) with the real metrics above + honest verdict. The original block claimed Net Profit / Fees / Equity WITH Trades=0 (fabricated internal contradiction); real values now replace it.

Per the #3367 method: Orders/Trades/Win Rate omitted as unreliable for Algorithm Framework backtests (`read_backtest` returns "-" / 0). Only reliable fields (Sharpe/CAGR/MaxDD/PSR) reported.

## Validation

- Markdown-only (1 cell 48). 51 cells unchanged. C.1 clean. Catalogue byte-identical.
- G.1: old placeholder signature asserted (5 must-contain checks, abort on mismatch).
- C.3: no code cell touched (0 exec_count/outputs churn).

## #3367 NB13 progress

| Cell | Algo | Status |
|------|------|--------|
| 7 | BasicFramework | merged (#3422) |
| 30 | MomentumFramework | placeholder remains (backtest was stuck/aborted) |
| 39 | CompositeAlpha | merged (#3422) |
| 48 | CompleteFramework | **this PR** (real metrics) |

Remaining: cell 30 (MomentumFramework) — needs a fresh backtest (the stuck one was aborted). EmaCross pattern-test (cells 17/20/23) + NB14 MeanVar×2 (cells 27/30) also queued on the single node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
