### PR TITLE
docs(pymc-17): anchor decision-network citations + fix Howard attribution (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb
@@ -161,7 +161,7 @@
    "source": [
     "## 2. Types de Noeuds\n",
     "\n",
-    "Les reseaux de decision utilisent une notation graphique standardisee (Howard, 1984) qui distingue clairement les differents types de noeuds. Cette convention visuelle permet de lire immediatement la structure du probleme decisionnel.\n",
+    "Les reseaux de decision utilisent une notation graphique standardisee (Howard & Matheson, 1984) qui distingue clairement les differents types de noeuds. Cette convention visuelle permet de lire immediatement la structure du probleme decisionnel.\n",
     "\n",
     "### Convention graphique\n",
     "\n",
@@ -586,7 +586,7 @@
     "\n",
     "### Algorithme Backward Induction\n",
     "\n",
-    "L'algorithme standard pour resoudre un reseau de decision est la **backward induction** (ou programmation dynamique). L'idee est de resoudre le probleme de la fin vers le debut.\n",
+    "L'algorithme standard pour resoudre un reseau de decision est la **backward induction** (ou programmation dynamique de Bellman, 1957), formalisee pour les diagrammes d'influence par Shachter (1986). L'idee est de resoudre le probleme de la fin vers le debut.\n",
     "\n",
     "### Algorithme pas a pas\n",
     "\n",
@@ -1180,7 +1180,7 @@
    "source": [
     "## 7. Implementation avec PyMC\n",
     "\n",
-    "PyMC n'a pas de support natif pour les noeuds de decision, mais nous pouvons :\n",
+    "PyMC (Salvatier et al., 2016) n'a pas de support natif pour les noeuds de decision, mais nous pouvons :\n",
     "\n",
     "1. Modeliser les variables de chance avec `pm.Bernoulli`\n",
     "2. Enumerer les decisions manuellement\n",
@@ -1354,7 +1354,7 @@
     "\n",
     "- **Echelonne** naturellement a des modeles plus complexes (variables continues, dependances multiples)\n",
     "- **Propage l'incertitude** de maniere rigoureuse via les distributions posteriors\n",
-    "- **S'integre** avec l'ecosysteme ArviZ pour le diagnostic et la visualisation\n",
+    "- **S'integre** avec l'ecosysteme ArviZ (Kumar et al., 2019) pour le diagnostic et la visualisation\n",
     "\n",
     "#### Resultats obtenus\n",
     "\n",
@@ -1609,7 +1609,7 @@
     "| **Securite** | Trafic aerien, conditions meteo | Etudes locales necessaires |\n",
     "| **Nuisances** | Bruit pour riverains, pollution | Impact environnemental |\n",
     "\n",
-    "Cet exemple combine Decision Networks et MAUT avec des attributs incertains."
+    "Cet exemple combine Decision Networks et MAUT (Keeney & Raiffa, 1976) avec des attributs incertains."
    ]
   },
   {
@@ -1946,9 +1946,13 @@
     "\n",
     "## References\n",
     "\n",
-    "- Howard & Matheson (1984) : Influence Diagrams\n",
-    "- Shachter (1986) : Evaluating Influence Diagrams\n",
-    "- Russell & Norvig : AI, Chapter 16.5"
+    "- Bellman, R. (1957). *Dynamic Programming*. Princeton University Press.\n",
+    "- Howard, R. A., & Matheson, J. E. (1984). Influence diagrams. In *Readings on the Principles and Applications of Decision Analysis*, Strategic Decisions Group.\n",
+    "- Shachter, R. D. (1986). Evaluating influence diagrams. *Operations Research*, 34(6), 871-882.\n",
+    "- Keeney, R. L., & Raiffa, H. (1976). *Decisions with Multiple Objectives: Preferences and Value Tradeoffs*. Wiley.\n",
+    "- Salvatier, J., Wiecki, T. V., & Fonnesbeck, C. (2016). Probabilistic programming in Python using PyMC3. *PeerJ Computer Science*, 2:e55.\n",
+    "- Kumar, R., Carroll, C., Hartikainen, A., & Martin, O. (2019). ArviZ: a unified library for exploratory analysis of Bayesian models in Python. *Journal of Open Source Software*, 4(33), 1143.\n",
+    "- Russell, S., & Norvig, P. *Artificial Intelligence: A Modern Approach*, Chapter 16.5."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit de fidélité #3164 — PyMC-17-Decision-Networks : **classe (c) OMISSIONS + correction d'attribution**. PyMC-17 n'avait qu'**UNE seule citation inline** dans tout le corps (« Howard, 1984 » — mal attribuée, omettant Matheson), alors que sa cellule References listait 3 entries et enseignait un ensemble riche de concepts fondateurs de decision analysis (influence diagrams, backward induction, frameworks PyMC/ArviZ, MAUT) sans attribution inline.

**Étend l'audit #3164 à la sous-série Decision (17-20)** — la deep-queue originale (PyMC-1/7) étant drained, je continue sur les notebooks Decision non-audités (17/18/19/20), légitimement dans le scope de l'audit fidélité de la série PyMC.

## Modifications (+13/-9, markdown-only, 0 code logic touched)

| # | Action | Cell (id) |
|---|--------|-----------|
| 1 | **Correction attribution** : « Howard, 1984 » → « Howard & Matheson, 1984 » | `827a234e` idx 4 |
| 2 | Backward induction : Bellman (1957) + Shachter (1986) ancrés | `d6be8fef` idx 13 |
| 3 | PyMC framework : Salvatier et al. (2016) | `af02138e` idx 24 |
| 4 | ArviZ : Kumar et al. (2019) | `a414204a` idx 26 |
| 5 | MAUT : Keeney & Raiffa (1976) | `0c6490fa` idx 32 |
| 6 | References 3 → 7 entries (+ Bellman, Keeney&Raiffa, Salvatier, Kumar) | `66a5401e` idx 38 |

Shachter (1986) était dangling dans References → désormais ancré (résolution d'orphelin, même pattern que PyMC-1/7).

## Méthode G.1 (cross-check + anti-chariot G.5)

Sous-agent `sonnet` read-full a flaggué 9 omissions potentielles. Cross-check G.1 a confirmé qu'il n'y avait qu'une seule citation inline dans tout le corps. **3 trimmées comme sur-enrichissement** : Pearl (1988) pour le « rappel » Bayes nets en une ligne, Howard (1966) pour Value-of-Information (explicitement déféré au notebook suivant PyMC-18 par le notebook lui-même), et un doublon d'intro. Gardé les 5 qui matchent le pattern de la série #3164 (frameworks + auteurs canoniques de méthodes + résolution d'orphelins References).

## Validation

- nbformat : OK
- C.1 : 0 violation (`raise NotImplementedError` / `assert False` / `1/0`)
- C.2 : 13/13 code cells retain `execution_count` + `outputs`
- C.3 : 0 ligne `execution_count`/`outputs` modifiée (markdown-only)
- `scan_cell_ordering.py` : clean (0 finding)
- Catalogue byte-identique (laissé à l'automatisation)
- Branche fraîche depuis `origin/main`

See #3164 (partial delivery — étend l'audit à la sous-série Decision).
