### PR TITLE
fix(infer8): Model-Selection fidelity audit #3164 -- nav, relabel stub, data point, SVG caveats

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-8-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-8-Model-Selection.ipynb
@@ -866,6 +866,8 @@
    "source": [
     "### Lecture du graphe de facteurs - Modele 1 gaussienne\n",
     "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe montre la structure du modele a une gaussienne :\n",
     "\n",
     "- **Noeuds ovales** : variables aleatoires (`moyenne`, `precision`, `evidence1`)\n",
@@ -1470,6 +1472,8 @@
    },
    "source": [
     "### Lecture du graphe de facteurs - Modele melange\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
     "\n",
     "Le graphe du modele de melange est plus complexe :\n",
     "\n",
@@ -3376,6 +3380,8 @@
    },
    "source": [
     "### Lecture du graphe de facteurs - Modele ARD hierarchique\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
     "\n",
     "Le graphe ARD illustre la structure hierarchique a deux niveaux :\n",
     "\n",
@@ -8831,6 +8837,8 @@
    "source": [
     "### Lecture du graphe de facteurs - Modele quadratique\n",
     "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe montre la structure du modele quadratique $y = ax^2 + bx + c$ :\n",
     "\n",
     "- **a_quad, b_quad, c_quad** : les trois coefficients du polynome (priors Gaussiens)\n",
@@ -9007,7 +9015,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Exemple guide : Trouver le Meilleur Modele pour des Donnees Quadratiques\n",
+    "## 10. Exercice : Trouver le Meilleur Modele pour des Donnees Quadratiques\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -9015,7 +9023,7 @@
     "\n",
     "```\n",
     "x = {-2, -1, 0, 1, 2, 3}\n",
-    "y = {11.2, 5.9, 1.1, -0.2, 3.8, 10.1}\n",
+    "y = {14.8, 5.9, 1.1, -0.2, 3.8, 10.1}\n",
     "```\n",
     "\n",
     "Comparez 3 modeles de regression polynomiale :\n",
@@ -9056,12 +9064,12 @@
     }
    ],
    "source": [
-    "// Exemple guide : Selection de modele polynomial sur donnees quadratiques\n",
+    "// Exercice : Selection de modele polynomial sur donnees quadratiques\n",
     "Console.WriteLine(\"Exercice a completer : selection de modele polynomial\");\n",
     "\n",
-    "// Donnees quadratiques : y = x^2 + bruit\n",
+    "// Donnees quadratiques : y = 2*x^2 - 3*x + 1 + bruit\n",
     "double[] xData = { -2, -1, 0, 1, 2, 3 };\n",
-    "double[] yData = { 11.2, 5.9, 1.1, -0.2, 3.8, 10.1 };\n",
+    "double[] yData = { 14.8, 5.9, 1.1, -0.2, 3.8, 10.1 };\n",
     "\n",
     "// TODO: Construire les matrices de features polynomiales\n",
     "// Lineaire  : X[i] = [1, x_i]\n",


### PR DESCRIPTION
## Summary

Closes #3494. Fidelity audit #3164 of `Infer-8-Model-Selection.ipynb` (7th Infer notebook). High-quality notebook: 22+ numerical claims FIDÈLE, no INVENTION, no hardcoded-output literals. 7 defects, prose-only + 1 stub data-value correction.

## Defects fixed

1. **NAVIGATION** (cell `5251a551`): duplicate `## 9.` (Resume + Exemple guide). Renumbered Exemple guide 9→10.
2. **LABELING** (cell `5251a551` + `5fd34a0e`): hollow stub (0 `InferenceEngine`, 0 `.Infer<`, 4 TODO, returns placeholder) labeled "Exemple guide". Relabeled header + code comment → "Exercice" (pathology n°5, same as Infer-2 #3459). Stub C.1-compliant, left intact.
3. **ERREUR-FACTUELLE** (cell `5251a551` + `5fd34a0e`): enoncé formula `y = 2x²-3x+1+bruit` fits 5/6 data points within bruit, but x=-2 data point `y=11.2` was a 3.8 outlier (formula gives 15.0). **Parent G.1 cross-check** recomputed the formula against every data point — confirmed the single data point was wrong, not the formula. Corrected `y=11.2→14.8` (residual -0.2, matches bruit pattern). Applied in both enoncé + stub data array. Also aligned misleading stub comment `y=x²+bruit` → `y=2x²-3x+1+bruit`. Stub produces no inference output → no realignment needed.
4-7. **OMISSION ×4 SVG** (cells `rwzoc5x79i`/`uhecr4ah36`/`r9agb9kd81`/`kmporu069ea`): prose "Le graphe montre" but 4 adjacent output cells show honest "Graphviz non disponible" fallback (`dot` absent from `.net-csharp` kernel PATH). Added standardized reproducibility caveat per cell (same template as Infer-3/4/5/6/7).

**DIFFERENT from Infer-3/4**: SVGs here are **honestly absent** (fallback warning, svg_len=0), NOT stale byte-identical foreign-model SVGs (INVENTION). Same benign class as Infer-5/6/7.

**§8 exemple guide (`d90f5f02`/`2e5bf6cf`) left untouched** — it IS genuine (2 `InferenceEngine` + 2 `.Infer<Bernoulli>`, real outputs -14.03/-20.28).

## Root cause

SVG fallback = bug `FactorGraphHelper.GetLatestFactorGraphHtml()` — issue **#3473** (cross-notebook helper, 20 Infer notebooks). Tracked separately for isolated helper fix.

## Verification (4 gates)

- **G1 cell-ordering**: 1 clean, 0 findings
- **G2 C.2**: 1/1 compliant (outputs + execution_count intact)
- **G3 validate**: OK 0, Errors 0 (Warning 1 = pre-existing LaTeX FP on origin/main, verified via `git show origin/main` + validate)
- **G4 git diff**: 13 ins / 5 del, 1 file

22+ numerical claims FIDÈLE spot-checked (log evidence -16.98/-45.89/-31.35, Bayes factor 23.03 / e^14.54≈2e6 / e^6.25≈518, ARD weights 2.04/0.02/2.97 with alphas 0.49/1.49/0.28, poly evidence -14.03/-20.28, LOO -1.81). 0 pathology n°5: all 6 inference cells contain `InferenceEngine` + `.Infer<`. 3 exercise stubs legit.

## Pattern

7th Infer notebook. Recurring series pattern: (a) navigation doublon (4/5/6/7/8), (b) SVG rendering broken (3-8), (c) LABELING stub (2/4/5/6/8 — returned after Infer-7 pause), (d) ERREUR-FACTUELLE (4/6/7/8). The data-point-vs-formula error is a new subtype (Infer-4/6/7 had prose-vs-output; Infer-8 has data-vs-formula inside an enoncé).

See #3164
See #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)