### PR TITLE
fix(search): scrub absolute papermill paths in Part1-Foundations (8 nb, 13 paths)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
@@ -2434,8 +2434,8 @@
    "end_time": "2026-05-14T07:40:18.332928+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-1-StateSpace.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-1-StateSpace_output.ipynb",
+   "input_path": "Search-1-StateSpace.ipynb",
+   "output_path": "Search-1-StateSpace.ipynb",
    "parameters": {},
    "start_time": "2026-05-14T07:40:09.557228+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
@@ -4132,7 +4132,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Search-10-SymbolicAutomata.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/search_papermill/Search-10-SymbolicAutomata.ipynb",
+   "output_path": "Search-10-SymbolicAutomata.ipynb",
    "parameters": {},
    "start_time": "2026-06-05T12:55:12.384405+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
@@ -33792,7 +33792,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Search-11-Metaheuristics.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/search_papermill/Search-11-Metaheuristics.ipynb",
+   "output_path": "Search-11-Metaheuristics.ipynb",
    "parameters": {},
    "start_time": "2026-06-05T12:55:40.595649+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed.ipynb
@@ -3453,8 +3453,8 @@
    "end_time": "2026-06-08T22:38:44.291926+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-2-Uninformed.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-2-Uninformed_output.ipynb",
+   "input_path": "Search-2-Uninformed.ipynb",
+   "output_path": "Search-2-Uninformed.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T22:38:32.030522+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -3437,7 +3437,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Search-3-Informed.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/search_papermill/Search-3-Informed.ipynb",
+   "output_path": "Search-3-Informed.ipynb",
    "parameters": {},
    "start_time": "2026-06-05T12:52:47.863347+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb
@@ -3021,8 +3021,8 @@
    "end_time": "2026-05-14T07:36:29.192744+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-4-LocalSearch.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-4-LocalSearch_output.ipynb",
+   "input_path": "Search-4-LocalSearch.ipynb",
+   "output_path": "Search-4-LocalSearch.ipynb",
    "parameters": {},
    "start_time": "2026-05-14T07:35:43.773391+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
@@ -2320,8 +2320,8 @@
    "end_time": "2026-06-08T22:39:55.380763+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-7-MCTS-And-Beyond.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-7-MCTS-And-Beyond_output.ipynb",
+   "input_path": "Search-7-MCTS-And-Beyond.ipynb",
+   "output_path": "Search-7-MCTS-And-Beyond.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T22:39:11.966415+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
@@ -3244,8 +3244,8 @@
    "end_time": "2026-06-02T23:26:42.926308+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-8-DancingLinks.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-8-DancingLinks_output.ipynb",
+   "input_path": "Search-8-DancingLinks.ipynb",
+   "output_path": "Search-8-DancingLinks.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T23:26:35.394174+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

Atomic application of `scripts/notebook_tools/scrub_papermill_paths.py` (#3435) to **Search/Part1-Foundations** — **8 notebooks, 13 absolute paths** scrubbed to relative basename.

Re-execs had injected absolute machine-local paths into `metadata.papermill.output_path` / `.input_path` (e.g. `D:\dev\CoursIA-2\...`, `D:\dev\CoursIA\..._output.ipynb`). These leak local machine structure and break reproducibility. Replaced with relative basename (canonical target state, proven by SC-10 in #3427).

## Scope (atomic — 1 sub-series)

| Notebooks |
|-----------|
| Search-1 StateSpace, Search-2 Uninformed, Search-3 Informed, Search-4 LocalSearch, Search-7 MCTS-And-Beyond, Search-8 DancingLinks, Search-10 SymbolicAutomata, Search-11 Metaheuristics |
| **Total: 8 notebooks, 13 paths** |

Search-5/6/9 already clean (not in scan). Scrub is uniform metadata-only (path-replacement) — no source touched.

## Verification

- [x] **13 ins / 13 del** across 8 notebooks — `git diff --stat`
- [x] **JSON valid**: all 18 Part1 notebooks (incl `_output`/`_executed`/non-defect) parse
- [x] **Only papermill keys changed**: `grep` shows only `input_path` / `output_path`
- [x] **Outputs + execution_count untouched**: 0 matches (C.2 preserved, no re-exec)
- [x] **Catalogue byte-identical** to main
- [x] **MetaGeneticSharp submodule clean**

See #3436. Follows #3435, #3454 (Sudoku-C#), #3460 (Search/Applications), #3468 (SmartContracts), #3476 (GameTheory), #3482 (SemanticWeb), #3487 (Planners).

Part of po-2024 deep-queue scrub (ai-01 directive 2026-06-18 15:00Z).

Co-Authored-By: Claude <noreply@anthropic.com>