### PR TITLE
docs(smartcontracts): add 05-Alternative-Chains sub-series README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/README.md
@@ -1,0 +1,98 @@
+# 05-Alternative-Chains - Au-dela d'Ethereum : Vyper, XRP, Bitcoin, Move et Solana
+
+**Navigation** : [Sommaire de la serie](../README.md) | [<< SC-17 E2E Verifiable Voting](../04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb) | [SC-23 Cross-Chain >>](../06-Real-World/SC-23-Cross-Chain.ipynb)
+
+Cette cinquieme sous-serie (SC-18 a SC-22) elargit le horizon au-dela de la EVM Ethereum : **Vyper** (le Solidity « securise par design »), le **XRP Ledger** (consensus UNL, trust lines, DEX), **Bitcoin Script** (le langage a pile de Bitcoin et son modele UTXO), **Move/Sui** (la programmation orientee ressources), et **Solana/Anchor** (Rust, PDAs, CPIs). Chaque notebook confronte le modele mental Ethereum a un paradigme different. La signature pedagogique de cette sous-serie est particuliere : plusieurs langages (Vyper, Bitcoin Script, Move, Rust) y sont presentes comme chaines de caracteres pour illustration, avec des sorties documentees honnetement selon que le CLI correspondant est installe ou non.
+
+---
+
+## Notebooks
+
+| # | Notebook | Duree | Contenu |
+|---|----------|-------|---------|
+| 18 | [SC-18-Vyper](SC-18-Vyper.ipynb) | 45 min | Philosophie Vyper vs Solidity, syntaxe, contrats de stockage et token, deploiement web3.py |
+| 19 | [SC-19-Ripple-XRP](SC-19-Ripple-XRP.ipynb) | 45 min | XRP Ledger, consensus UNL, comptes/transactions `xrpl-py`, trust lines, DEX, payment channels, Hooks |
+| 20 | [SC-20-Bitcoin-Scripting](SC-20-Bitcoin-Scripting.ipynb) | 50 min | Modele UTXO, Bitcoin Script (langage a pile), mini-interpreteur Python, multisig, timelock, P2SH |
+| 21 | [SC-21-Move-Sui](SC-21-Move-Sui.ipynb) | 40 min | Langage Move, modele objet de Sui, module Move, abilities (key/store/copy/drop) |
+| 22 | [SC-22-Solana-Anchor](SC-22-Solana-Anchor.ipynb) | 45 min | Architecture Solana, framework Anchor (Rust), PDAs, CPIs |
+
+**Total** : 5 notebooks, ~3h45.
+
+---
+
+## Parcours d'apprentissage
+
+### Etape 1 : Vyper, le Solidity securise (SC-18, 45 min)
+
+La **philosophie de conception** de Vyper : volontairement restrictif (pas d'heritage, pas d'inline assembly) pour reduire la surface d'attaque. Syntaxe des types de base, fonctions et decorateurs, ecriture d'un contrat de stockage et d'un token, deploiement via web3.py, et comparaison Vyper/Solidity sur des exemples equivalents.
+
+### Etape 2 : XRP Ledger (SC-19, 45 min)
+
+L'**architecture du XRP Ledger** et son consensus **UNL** (Unique Node List). Manipulation des comptes et transactions via `xrpl-py`, exploration des **trust lines**, **offers** et du **DEX integre**, decouverte des **payment channels** pour les micropaiements, et des **Hooks** comme equivalent smart contract du XRPL.
+
+### Etape 3 : Bitcoin et son langage a pile (SC-20, 50 min)
+
+Le **modele UTXO** de Bitcoin (vs le modele Account d'Ethereum), **Bitcoin Script** comme langage a pile non-Turing-complet, implementation d'un **mini-interpreteur Bitcoin Script** en Python, construction et signature manuelle de transactions, et scripts avances (**multisig**, **timelock**, **P2SH**).
+
+### Etape 4 : Move et Sui (SC-21, 40 min)
+
+Le langage **Move** (ne chez Meta/Diem) et sa programmation **orientee ressources**. Le **modele objet** de Sui, creation d'un module Move simple, et utilisation des **abilities** (`key`, `store`, `copy`, `drop`) qui controlent la linearite et la copie des ressources.
+
+### Etape 5 : Solana et Anchor (SC-22, 45 min)
+
+L'**architecture Solana** (accounts, programs) et le framework **Anchor** (Rust). Creation de **PDAs** (Program Derived Addresses) deterministes et implementation de **CPIs** (Cross-Program Invocations).
+
+---
+
+## Prerequis
+
+### Par notebook
+
+| Notebook | Fondations requises | Dependances |
+|----------|---------------------|-------------|
+| SC-18 Vyper | Solidity basics (SC-3..6) ; web3.py | Vyper compiler (`pip install vyper`), web3 |
+| SC-19 Ripple-XRP | Python ; notions de consensus blockchain | `xrpl-py` ; connexion internet (Testnet XRP) |
+| SC-20 Bitcoin-Scripting | Python ; arithmetique modulaire | `hashlib` (stdlib), `python-bitcoinlib` (optionnel) |
+| SC-21 Move-Sui | SC-3..6 completes (concepts) ; notions de programmation orientee ressources | Sui CLI (Move compiler) |
+| SC-22 Solana-Anchor | SC-3..6 completes (concepts) ; notions de base Rust | Solana CLI, Anchor framework, Rust toolchain |
+
+### Configuration requise
+
+- **Python 3.10+** pour les cellules d'orchestration de tous les notebooks.
+- **SC-18** : `pip install vyper web3` ; anvil (Foundry) pour le deploiement local.
+- **SC-19** : `pip install xrpl-py` ; acces au Testnet XRP (faucet).
+- **SC-20** : `pip install python-bitcoinlib` (optionnel) ; le mini-interpreteur tourne en stdlib.
+- **SC-21** : Sui CLI (installe via cargo ou binaire) ; le compilateur Move.
+- **SC-22** : Solana CLI + Anchor (`cargo install anchor-cli`) + Rust toolchain.
+- Sans ces CLI installes, les notebooks s'affranchissent proprement (sorties documentees comme illustration, audit #3164).
+
+---
+
+## Ponts inter-series
+
+| Serie | Lien | Relation |
+|-------|------|----------|
+| [SmartContracts (parent)](../README.md) | Vue d'ensemble | Contexte, parcours global, glossaire |
+| [04-Privacy-Cryptography](../04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb) | Predecesseur | SC-15..17 (ZKP, chiffrement homomorphe, vote verifiable) |
+| [06-Real-World](../06-Real-World/SC-23-Cross-Chain.ipynb) | Suite | SC-23..26 (cross-chain, deploiement public, capstone) |
+
+---
+
+## Points de vigilance (CLI multiples)
+
+- **Signature pedagogique multi-langage** : Vyper, Bitcoin Script, Move et Rust sont presentes comme chaines de caracteres dans les cellules Python, avec les sorties correspondantes documentees. Avec le CLI installe, ces operations se reproduisent ; sans lui, elles servent d'illustration honnetement disclosee (audit #3164 : SC-18 Vyper mode demo, SC-19 XRP setup-connect disclosed, SC-21 Move/Sui CLI non invoque, echos byte-identiques).
+- **SC-19 XRP** : la connexion au Testnet peut echouer dans certains environnements (`asyncio.run() from running loop`) ; le notebook le documente honnetement et bascule sur une simulation conceptuelle disclosed.
+- **SC-20 Bitcoin** : l'arithmetique (balances, tailles de script, timelocks) est exacte et verifiable dans les outputs committes.
+- **SC-22 Solana** : les PDAs (Bump 255, determinisme) sont calcules reellement via le SDK Solana Python ; la partie Anchor/Rust requiere le toolchain complet.
+- **Audit #3164** : cette sous-serie a ete auditee FIDELE (0 finding stricto sensu) — les replis sont honnetement documentes, pas masques.
+
+---
+
+## Ressources
+
+- **Vyper Documentation** (Vyper Team) -- philosophie, syntaxe, differences avec Solidity. docs.vyperlang.org.
+- **XRP Ledger Documentation** (Ripple) -- consensus UNL, trust lines, DEX, Hooks. xrpl.org.
+- **Bitcoin Developer Documentation** (Bitcoin Core) -- UTXO model, Bitcoin Script, opcodes. developer.bitcoin.org.
+- **Move Book** (Diem/Meta, 2019 ; Sui) -- programmation orientee ressources, abilities. move-language.github.io/move.
+- **Solana Documentation** + **Anchor Book** (Solana Labs / Anchor) -- accounts, PDAs, CPIs. docs.solana.com, book.anchor-lang.com.
+- Voir aussi les references transversales dans le [README parent de la serie](../README.md).


### PR DESCRIPTION
## Summary

2 of 7 SmartContracts sub-series still lack a README (06-Real-World #3445, 01 #3462, 02 #3470, 03 #3483, 04 #3488 added previously). This PR adds the **`05-Alternative-Chains`** sub-series README covering **SC-18..22** (5 notebooks, ~3h45): Vyper, Ripple-XRP, Bitcoin-Scripting, Move-Sui, Solana-Anchor.

## Content (faithful, 0 invented)

Objectives, durations, prerequisites read **directly from each notebook's first markdown cells**:

| # | Notebook | Duration | Topics |
|---|----------|----------|--------|
| 18 | SC-18-Vyper | 45 min | Vyper philosophy, syntax, storage/token contracts, web3.py deploy |
| 19 | SC-19-Ripple-XRP | 45 min | XRP Ledger, UNL consensus, xrpl-py, trust lines, DEX, Hooks |
| 20 | SC-20-Bitcoin-Scripting | 50 min | UTXO model, Bitcoin Script, mini-interpreter, multisig, timelock, P2SH |
| 21 | SC-21-Move-Sui | 40 min | Move language, Sui object model, module, abilities |
| 22 | SC-22-Solana-Anchor | 45 min | Solana architecture, Anchor (Rust), PDAs, CPIs |

Reflects the honest pedagogical signature (audit #3164): multiple languages (Vyper/Bitcoin Script/Move/Rust) as Python strings with outputs documented as illustration, fallbacks honestly disclosed.

## Verification

- [x] **12/12 internal links resolve** (direct filesystem check + full `check_docs_links.py` scan)
- [x] **Catalogue byte-identical** to main
- [x] **MetaGeneticSharp submodule clean**
- [x] **Docs-only**: no notebook/code changes
- [x] French matching SC house style (no diacritics), 0 emoji

See #2651 (gabarit §10 sub-series READMEs). Side-track of po-2024 deep-queue (1 SC sub-series README remaining: 00-Foundations).

Co-Authored-By: Claude <noreply@anthropic.com>