### PR TITLE
docs(pymc-18): anchor VoI citations inline (Howard 1966, Raiffa & Schlaifer 1961, Gelman & Rubin 1992)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb
@@ -55,7 +55,7 @@
     "## 1. Information et reduction de l'incertitude\n",
     "\n",
     "En decision sequentielle, une information supplementaire peut changer l'action optimale.\n",
-    "La **valeur de l'information** mesure combien on est pret a payer pour cette information.\n",
+    "La **valeur de l'information** (Howard, 1966) mesure combien on est pret a payer pour cette information.\n",
     "\n",
     "**Cle** : l'information n'a de valeur que si elle peut **changer la decision**.\n",
     "\n",
@@ -533,7 +533,7 @@
    "source": [
     "## 4. EVSI : Valeur d'une Information Imparfaite\n",
     "\n",
-    "En pratique, l'information n'est jamais parfaite. Un test sismique donne un **signal**\n",
+    "En pratique, l'information n'est jamais parfaite (Raiffa & Schlaifer, 1961). Un test sismique donne un **signal**\n",
     "corrle avec la presence de petrole.\n",
     "\n",
     "### Test sismique\n",
@@ -2702,7 +2702,7 @@
     "Avant de faire confiance aux resultats du sampling PyMC, il est essentiel de verifier\n",
     "la qualite de la chaine MCMC. ArviZ fournit des outils de diagnostic standards :\n",
     "\n",
-    "- **R-hat** (statistique de Gelman-Rubin) : mesure la convergence entre les chaines.\n",
+    "- **R-hat** (statistique de Gelman & Rubin, 1992) : mesure la convergence entre les chaines.\n",
     "  Une valeur < 1.01 indique une bonne convergence.\n",
     "- **ESS** (Effective Sample Size) : nombre effectif d'echantillons independants.\n",
     "  Un ESS > 400 par chaine est recommande pour les estimations fiables.\n",
@@ -3506,7 +3506,8 @@
     "**References** :\n",
     "- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, Chapter 16\n",
     "- Raiffa & Schlaifer, *Applied Statistical Decision Theory* (1961)\n",
-    "- Howard, R.A., *Information Value Theory* (1966)"
+    "- Howard, R.A., *Information Value Theory* (1966)\n",
+    "- Gelman, A. & Rubin, D.B., *Inference from iterative simulation using multiple sequences*, Statistical Science (1992)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Audit fidelity #3164 — **Decision sub-series, grain PyMC-18** (Value of Information). Markdown-only citation anchoring (+5/-4).

PyMC-18 taught 3 foundational Value-of-Information concepts without inline citations. All 3 canonical citations existed **only as dangling entries in the final References cell** — never anchored at their point of introduction. Additionally the sole author name in the body (`Gelman-Rubin`) was a year-less name-drop.

## Fixes (4)

| # | Concept | Citation anchored | Cell |
|---|---------|-------------------|------|
| 1 | EVPI (Value of Information theory) | Howard, 1966 — *Information Value Theory* | `3b0146a8` (introduction) |
| 2 | EVSI (Bayesian decision theory, imperfect info) | Raiffa & Schlaifer, 1961 — *Applied Statistical Decision Theory* | `d5546018` (EVSI introduction) |
| 3 | R-hat convergence diagnostic | Gelman & Rubin, 1992 (added year to name-drop) | `b7bc368e` |
| 4 | References cell | + Gelman & Rubin 1992 entry (3 → 4) | `9905e068` |

## G.1 cross-check (deceptive peek confirmed)

Pre-audit raw counts looked massive but were **deceptive**:

| Term | Raw count | Reality |
|------|-----------|---------|
| EVPI | 215 | DataFrame column names / variables in code cells, NOT citations |
| EVSI | 84 | Same — column/variable names |
| Howard (body) | **0** | orphan — only in final References |
| Raiffa (body) | **0** | orphan — only in final References |
| Schlaifer (body) | **0** | orphan — only in final References |
| Salvatier (body) | **0** | PyMC never cited inline |
| Kumar (body) | **0** | ArviZ never cited inline |
| Gelman-Rubin (body) | 1 | year-less name-drop |

All 3 References entries (Howard / Raiffa & Schlaifer / Russell & Norvig) were dangling orphans. Method: sub-agent `sonnet` read-full evidence-cited → local G.1 cross-check (read all 4 pivot cells verbatim) → surgical markdown edits via temp `.py` file (abort-on-mismatch, `json.dump(indent=1)` only at end → notebook intact if interrupted).

## Anti-churn G.5 — deliberately NOT flagged (tangential to THIS notebook)

- **PyMC (Salvatier 2016) / ArviZ (Kumar 2019) / NUTS (Hoffman & Gelman 2014)** = tooling, used incidentally in a single meta-prior extension cell. ~95% of the notebook is pure-numpy VoI theory. Tooling attribution would be over-enrichment here.
- **Russell & Norvig (AIMA Ch16)** = generic textbook, no specific AIMA concept taught.
- **Bayes/Laplace, expected utility** = intro-level background.

Scope = TIGHT: only foundational VoI / Bayesian decision-analysis omissions. Same pattern as the PyMC series (PyMC-1/7/14/15/16/17).

## Validation

| Check | Result |
|-------|--------|
| nbformat | OK |
| scan_cell_ordering (HIGH) | 1 clean, 0 finding |
| C.1 (no `raise NotImplementedError`/`assert False`/`1/0` in source) | 0 violation |
| C.2 (code cells retain exec_count + outputs) | 26/26 |
| C.3 (no execution_count churn) | 0 |
| Catalog (`COURSE_CATALOG.generated.json`/`.md`) | byte-identical to main |
| Branch | fresh from `origin/main` |

Forensic git diff suffices for H.4 review (markdown-only single notebook, no re-execution needed per C.2 markdown exception).

## Progression

Audit #3164 PyMC: **19/20 → 20/20 notebookés**. Decision sub-series: PyMC-17 ✅, **PyMC-18 ✅ (this PR)**, PyMC-19 (Expert Systems) pending, PyMC-20 (Sequential) pending.

See #3164
