### PR TITLE
fix(lean-11): resolve SECTION_GAP — drop duplicate 2.4 cell + fix ## 2.3 level (#3248)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-11-TorchLean.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-11-TorchLean.ipynb
@@ -167,7 +167,7 @@
     "# require \"torchlean\" from git\n",
     "```\n",
     "\n",
-    "## 2.3 Vérification de l'installation\n",
+    "### 2.3 Vérification de l'installation\n",
     "\n",
     "Vérifions que votre environnement est correctement configuré pour TorchLean."
    ]
@@ -321,29 +321,6 @@
     "| Mathlib4 | requis | Preuves mathématiques |\n",
     "\n",
     "**Note** : Si Lake n'est pas installé, consultez [Lake Installation](https://github.com/leanprover/lake)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "import-torchlean-intro",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005478,
-     "end_time": "2026-06-18T03:11:11.380792+00:00",
-     "exception": false,
-     "start_time": "2026-06-18T03:11:11.375314+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### 2.4 Modules TorchLean — Note sur l'état du projet\n",
-    "\n",
-    "> **Ce notebook est de nature illustrative.** TorchLean est un projet de recherche en développement actif dont les modules (`Core`, `Forum.Float32`, `Verification.IBP`, `Verification.CROWN`) ne sont pas disponibles publiquement.\n",
-    ">\n",
-    "> Le code Lean présenté ci-dessous est **auto-contenu** : chaque cellule définit ses propres types et ne dépend d'aucun import TorchLean externe. Il sert à illustrer les concepts et l'architecture cible du framework.\n",
-    ">\n",
-    "> Pour une version **exécutable** avec des résultats numériques réels (IBP, CROWN, certification), consultez le notebook companion **[Lean-11-TorchLean-Python.ipynb](Lean-11-TorchLean-Python.ipynb)**."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Resolves the residual **LOW** `SECTION_GAP` finding on `Lean-11-TorchLean.ipynb`, draining the last `#3248` finding in the po-2026 domain (HIGH findings already merged: Lean-6 #3444, Lean-7 #3434, Lean-11 SECTION_ORDER #3458).

### Root cause (two compounding issues under section 2)

```
[LOW] cell#3 SECTION_GAP section 2.4 skips from 2 to 4 under parent 2 (possible omitted section)
```

**Issue 1 — Duplicate `### 2.4` cell.** Two consecutive cells carried near-identical headers on the same topic:
- `import-torchlean-intro` (cell#3): `### 2.4 Modules TorchLean — Note sur l'état du projet`
- `import-torchlean` (cell#4): `### 2.4 Modules TorchLean — État du projet`

The two prose blocks are near-verbatim duplicates ("TorchLean en dev actif, modules non disponibles, code auto-contenu, voir version Python"). Cell#4 is **more complete** (adds the target-module architecture code block + real Mathlib imports block). **Dropped the shorter duplicate cell#3**.

**Anti-regression check (G.1)**: read both cells in full. Cell#3's only content — nature illustrative, modules non disponibles, code auto-contenu, pointer to the Python companion — is entirely present in cell#4. **0 unique content lost**.

**Issue 2 — `## 2.3` header level mismatch.** `## 2.3 Vérification de l'installation` used 2 hashes (section level) while `### 2.1`/`### 2.2`/`### 2.4` used 3 (subsection level). The level break disrupted the section-2 child sequence, which is why the scanner read `### 2.4` as "skipping from 2 to 4". Fixed `## 2.3` → `### 2.3`.

### Validation
- `scan_cell_ordering.py`: **1 clean / 0 finding** (was 1 LOW SECTION_GAP). **Lean-11 fully clean** (both #3458 HIGH + this LOW resolved).
- Diff: `+1/-24`, **markdown-only** (1 cell deleted, 1 header level fixed).
- **13 code cells byte-identical**: `ec_changed=0`, `outputs_changed=0`, 0 code cells missing `execution_count`/`outputs` → **C.2/C.3 clean**.
- Transition cell#2 (`Interprétation : Environnement vérifié`, end of 2.3) → cell#3 (`### 2.4 Modules TorchLean`) remains canonically ordered.

### Verification commands
```bash
python scripts/notebook_tools/scan_cell_ordering.py MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-11-TorchLean.ipynb
# → 1 clean / 0 finding
```

This drains the entire `#3248` lane for the po-2026 domain (Lean/Search/Sudoku): all HIGH + LOW findings resolved.

See #3248
