### PR TITLE
fix(infer9): Topic-Models fidelity audit #3164 -- nav, relabel stub, asymmetric-prior results, SVG caveats

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Topic-Models.ipynb
@@ -1314,6 +1314,8 @@
    "source": [
     "### Interpretation du factor graph LDA\n",
     "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
+    "\n",
     "Le graphe de facteurs ci-dessus represente la structure du modele LDA pour un seul document.\n",
     "\n",
     "**Composants du graphe** :\n",
@@ -1938,9 +1940,9 @@
     "\n",
     "| Document | Mots | Topic attendu | Résultat |\n",
     "|----------|------|---------------|----------|\n",
-    "| Doc 1 | sport, equipe, match | Sport | Sport ~90%+ |\n",
-    "| Doc 2 | politique, election, vote | Politique | Politique ~90%+ |\n",
-    "| Doc 3 | musique, concert, artiste | Musique | Musique ~90%+ |\n",
+    "| Doc 1 | sport, equipe, match | Sport | Sport ~74% |\n",
+    "| Doc 2 | politique, election, vote | Politique | Politique ~74% |\n",
+    "| Doc 3 | musique, concert, artiste | Musique | Musique ~74% |\n",
     "| Doc 4 | sport + politique | Mixte | Sport ~55%, Politique ~40% |\n",
     "| Doc 5 | musique + sport | Mixte | Musique ~55%, Sport ~40% |\n",
     "\n",
@@ -1954,7 +1956,7 @@
     "\n",
     "| Aspect | Prior symétrique | Prior asymétrique |\n",
     "|--------|------------------|-------------------|\n",
-    "| Theta Doc 1 | (0.33, 0.33, 0.33) | (~0.9, ~0.05, ~0.05) |\n",
+    "| Theta Doc 1 | (0.33, 0.33, 0.33) | (~0.74, ~0.13, ~0.13) |\n",
     "| Mode | Symétrique (dégénéré) | Correct |\n",
     "| Utilité | Aucune | Classification fonctionnelle |\n",
     "\n",
@@ -2027,6 +2029,8 @@
    },
    "source": [
     "### Interpretation du factor graph LDA avec priors asymetriques\n",
+    "\n",
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (`dot` sur le PATH du kernel .net-csharp). En son absence (ici Graphviz disponible : False), `FactorGraphHelper.GetLatestFactorGraphHtml()` renvoie un avertissement « Graphviz non disponible » a la place du graphe. La structure reelle du modele est celle decrite textuellement ci-dessous et construite dans la cellule de code precedente.\n",
     "\n",
     "Le graphe ci-dessus montre la structure du modele LDA avec **priors asymetriques** sur les distributions de mots par topic.\n",
     "\n",
@@ -3084,7 +3088,7 @@
     "tags": []
    },
    "source": [
-    "## 10. Exemple guide : Decouvrir les Topics d'un Corpus Francais\n",
+    "## 11. Exercice : Decouvrir les Topics d'un Corpus Francais\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -3132,7 +3136,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : LDA 3 topics sur corpus francais\n",
+    "// Exercice : LDA 3 topics sur corpus francais\n",
     "string[] vocab = {\n",
     "    \"recette\", \"cuisson\", \"saveur\", \"ingredient\", \"plat\",       // 0-4: Cuisine\n",
     "    \"destination\", \"hotel\", \"vol\", \"decouverte\", \"carte\",       // 5-9: Voyage\n",
@@ -3178,7 +3182,7 @@
     "tags": []
    },
    "source": [
-    "## 11. Exercice : Detecter l'Emergence d'un Nouveau Topic\n",
+    "## 12. Exercice : Detecter l'Emergence d'un Nouveau Topic\n",
     "\n",
     "### Enonce\n",
     "\n",


### PR DESCRIPTION
## Summary

Closes #3500. Fidelity audit #3164 of `Infer-9-Topic-Models.ipynb` (8th Infer notebook, LDA). Notebook GOOD QUALITY with standard Infer-series defect footprint. 6 defects, all **markdown-only** (outputs byte-identical).

## Defects fixed

1. **NAVIGATION** (cells `8e836a16`/`b7941386`): duplicate `## 10.` (Resume + Exemple guide). Renumbered 10→11, Exercice 11→12.
2. **LABELING** (cell `8e836a16` + `39a2f788`): hollow stub (0 `InferenceEngine`, 0 `.Infer<`, 3 TODO, returns placeholder) labeled "Exemple guide". Relabeled header + code comment → "Exercice" (pathology n°5, same as Infer-2 #3459 / Infer-8 #3494). Stub C.1-compliant, left intact.
3-4. **ERREUR-FACTUELLE** (cell `8k7gcy3r1fv`): asymmetric-prior results overstated. **Parent G.1 cross-check** against committed output `r4m4ks1spuf` (theta 0.742/0.743/0.743 = 74%): 3 rows claimed `~90%+`, corrected to `~74%`. theta comparison table `(~0.9,~0.05,~0.05)` → `(~0.74,~0.13,~0.13)` (off-topic components are 0.13, not 0.05). Doc 4/5 rows left as-is (within `~` tolerance).
5-6. **OMISSION ×2 SVG** (cells `gsr4n9ovnlr`/`vrkrzb9mpw`): prose "Le graphe ci-dessus" but 2 adjacent output cells show honest "Graphviz non disponible" fallback (`dot` absent from `.net-csharp` kernel PATH). Added standardized reproducibility caveat per cell (same template as Infer-3-8).

**§9 exemple guide (`486b86a1`) left untouched** — it IS genuine (computes real classification by counting, 9 real outputs, 0 TODO).

## Root cause

SVG fallback = bug `FactorGraphHelper.GetLatestFactorGraphHtml()` — issue **#3473** (cross-notebook helper, 20 Infer notebooks). Tracked separately for isolated helper fix.

## Verification (4 gates)

- **G1 cell-ordering**: 1 clean, 0 findings
- **G2 C.2**: 1/1 compliant (outputs + execution_count intact)
- **G3 validate**: OK 0, Errors 0 (Warning 1 = pre-existing LaTeX FP on origin/main, verified via `git show origin/main` + validate)
- **G4 git diff**: 11 ins / 7 del, 1 file, markdown-only

31 numerical claims FIDÈLE spot-checked (Doc 1 symmetric theta 0.333×3, VMP 50 iterations, prediction 93.7%/6.2% ratio ~15×, 10× beta ratio, vocab 9 mots/3 topics, betaPrior ones, corpus étendu Doc 5 Tech>Sport / Doc 6 Voyage>Cuisine). 2 genuine `InferenceEngine` cells (`c2f4c3c1`, `r4m4ks1spuf`). 0 pathology n°5 beyond the section-10 stub.

## Pattern

8th Infer notebook. Recurring series pattern holds: (a) navigation doublon (4/5/6/7/8/9), (b) SVG rendering broken (3-9), (c) LABELING stub (2/4/5/6/8/9), (d) ERREUR-FACTUELLE (4/6/7/8/9). Infer-9's subtype = prose overstating inference results (~90%+ vs actual 74%) — a fidelity gap where the LDA inference is genuinely correct but the prose exaggerates the sharpness of topic separation.

See #3164
See #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)