### PR TITLE
fix(search): scrub Part2-CSP 8 nb, 16 abs papermill paths

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -3186,8 +3186,8 @@
    "end_time": "2026-06-09T10:29:39.482400",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-1-Fundamentals.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-1-Fundamentals_output.ipynb",
+   "input_path": "CSP-1-Fundamentals.ipynb",
+   "output_path": "CSP-1-Fundamentals.ipynb",
    "parameters": {},
    "start_time": "2026-06-09T10:29:29.375270",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
@@ -3090,8 +3090,8 @@
    "end_time": "2026-06-08T22:39:51.361513+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-3-Advanced.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-3-Advanced_output.ipynb",
+   "input_path": "CSP-3-Advanced.ipynb",
+   "output_path": "CSP-3-Advanced.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T22:38:16.500189+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb
@@ -2253,8 +2253,8 @@
    "end_time": "2026-06-04T18:49:59.073920+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb",
-   "output_path": "/tmp/CSP-4-Scheduling_wsl_output.ipynb",
+   "input_path": "CSP-4-Scheduling.ipynb",
+   "output_path": "CSP-4-Scheduling.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T18:49:53.473154+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
@@ -2589,8 +2589,8 @@
    "end_time": "2026-06-04T18:50:02.584195+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb",
-   "output_path": "/tmp/CSP-5-Optimization_wsl_output.ipynb",
+   "input_path": "CSP-5-Optimization.ipynb",
+   "output_path": "CSP-5-Optimization.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T18:50:00.215656+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
@@ -2158,8 +2158,8 @@
    "end_time": "2026-06-04T18:50:07.157862+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb",
-   "output_path": "/tmp/CSP-6-Hybridization_wsl_output.ipynb",
+   "input_path": "CSP-6-Hybridization.ipynb",
+   "output_path": "CSP-6-Hybridization.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T18:50:03.761655+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft.ipynb
@@ -2720,8 +2720,8 @@
    "end_time": "2026-06-04T18:50:11.701131+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft.ipynb",
-   "output_path": "/tmp/CSP-7-Soft_wsl_output.ipynb",
+   "input_path": "CSP-7-Soft.ipynb",
+   "output_path": "CSP-7-Soft.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T18:50:08.890808+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
@@ -2101,8 +2101,8 @@
    "end_time": "2026-06-04T18:50:16.100221+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb",
-   "output_path": "/tmp/CSP-8-Temporal_wsl_output.ipynb",
+   "input_path": "CSP-8-Temporal.ipynb",
+   "output_path": "CSP-8-Temporal.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T18:50:13.064066+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
@@ -2770,8 +2770,8 @@
    "end_time": "2026-06-04T18:50:19.814160+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb",
-   "output_path": "/tmp/CSP-9-Distributed_wsl_output.ipynb",
+   "input_path": "CSP-9-Distributed.ipynb",
+   "output_path": "CSP-9-Distributed.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T18:50:17.708956+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

8th grain of the repo-wide papermill abs-path scrub (deep-queue ai-01 [2026-06-18 15:00Z]).

Scrub absolute machine-local paths from `metadata.papermill.input_path` / `output_path` in **8 notebooks** of `Search/Part2-CSP/`:
- CSP-1-Fundamentals, CSP-3-Advanced, CSP-4-Scheduling, CSP-5-Optimization, CSP-6-Hybridization, CSP-7-Soft, CSP-8-Temporal, CSP-9-Distributed
- CSP-2/10/11/12 already clean (not touched).

Paths leaked local structure (`C:\dev\CoursIA\`, `D:\dev\CoursIA-2\`, `/mnt/d/dev/...`, `/tmp/...`) and broke reproducibility. Replaced with relative basenames — the proven clean state (cf. SC-10 #3427).

## Verification

- `scrub_papermill_paths.py --apply`: **16 fixed, 0 skipped**
- Post-apply scan: **0 defects residual**
- Diff: **16 ins / 16 del**, 8 files (4 lines each = 2 path pairs)
- JSON validity: **12/12 notebooks** in Part2-CSP parse OK
- `outputs` + `execution_count`: **0 churn** (untouched)
- Catalogue (`COURSE_CATALOG.generated.{json,md}`): **byte-identical** to main
- MetaGeneticSharp submodule: **byte-identical** to main

## Scope

Metadata-only (rule C.3): only `metadata.papermill` fields changed. No source cell, no output, no execution_count, no catalogue. Tool: `scripts/notebook_tools/scrub_papermill_paths.py` (#3435).

See #3436 (repo-wide tracking).