### PR TITLE
docs(pymc-19): anchor expert-systems citations inline (Buchanan & Shortliffe, Salvatier, Kumar, Hoffman & Gelman)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "### Pourquoi l'evolution vers le probabiliste ?\n",
     "\n",
-    "Les systemes a base de regles (MYCIN, CLIPS) utilisaient des **facteurs de certitude** ad hoc qui violaient les axiomes de probabilite. Par exemple, MYCIN combinait deux evidences avec une formule heuristique qui pouvait donner des resultats incoherents (P(A et B) > P(A)). L'approche bayesienne (Pearl, 1988) a resolu ces problemes en :\n",
+    "Les systemes a base de regles (MYCIN, CLIPS) utilisaient des **facteurs de certitude** ad hoc (Buchanan & Shortliffe, 1984) qui violaient les axiomes de probabilite. Par exemple, MYCIN combinait deux evidences avec une formule heuristique qui pouvait donner des resultats incoherents (P(A et B) > P(A)). L'approche bayesienne (Pearl, 1988) a resolu ces problemes en :\n",
     "\n",
     "1. **Garantissant la coherence** : les probabilites satisfont les axiomes de Kolmogorov\n",
     "2. **Traitant l'incertitude** naturellement via le theoreme de Bayes\n",
@@ -2131,7 +2131,7 @@
    "source": [
     "## 9b. Inférence PyMC des fiabilités des capteurs\n",
     "\n",
-    "Plutôt que de fixer les fiabilités des sources, on peut les **inférer à partir de données historiques** grace au MCMC de PyMC. Cette approche est spécifique à la programmation probabiliste bayésienne et n'a pas d'équivalent direct en Infer.NET dans le notebook original.\n",
+    "Plutôt que de fixer les fiabilités des sources, on peut les **inférer à partir de données historiques** grace au MCMC de PyMC (Salvatier, Wiecki & Fonnesbeck, 2016). Cette approche est spécifique à la programmation probabiliste bayésienne et n'a pas d'équivalent direct en Infer.NET dans le notebook original.\n",
     "\n",
     "**Principe** : On simule un historique de diagnostics où chaque source a émis un avis, et on modélise la fiabilité (sensibilité et spécificité) de chaque capteur avec des priors Beta.\n",
     "\n",
@@ -2452,7 +2452,7 @@
    "source": [
     "### Diagnostics de convergence MCMC : R-hat et ESS\n",
     "\n",
-    "Avant d'utiliser les resultats MCMC, il faut verifier que les chaines ont **converge**. Deux diagnostics essentiels :\n",
+    "Avant d'utiliser les resultats MCMC, il faut verifier que les chaines ont **converge** (diagnostics via ArviZ, Kumar et al., 2019). Deux diagnostics essentiels :\n",
     "\n",
     "| Diagnostic | Seuil | Interpretation |\n",
     "|------------|-------|----------------|\n",
@@ -2740,7 +2740,7 @@
     "\n",
     "On reprend le mini-systeme expert de diagnostic medical (section 2) et on compare :\n",
     "1. **Bayes exact** : produit des likelihoods, normalisation analytique (O(K) ou K = nombre de maladies)\n",
-    "2. **MCMC (PyMC)** : echantillonnage par NUTS, estimation empirique des posteriors\n",
+    "2. **MCMC (PyMC)** : echantillonnage par NUTS (Hoffman & Gelman, 2014), estimation empirique des posteriors\n",
     "\n",
     "Cette comparaison illustre un principe fondamental de la programmation probabiliste : quand le modele est assez simple pour un calcul exact, le MCMC sert de **verification**. Quand le modele est trop complexe (variables latentes continues, hierarchies), le MCMC devient la **seule option**."
    ]
@@ -3054,7 +3054,11 @@
     "**References** :\n",
     "- Wald (1950), *Statistical Decision Functions*\n",
     "- Savage (1951), *The Theory of Statistical Decision*\n",
-    "- Pearl (1988), *Probabilistic Reasoning in Intelligent Systems*"
+    "- Pearl (1988), *Probabilistic Reasoning in Intelligent Systems*\n",
+    "- Buchanan, B.G. & Shortliffe, E.H. (1984), *Rule-Based Expert Systems: The MYCIN Experiments*\n",
+    "- Salvatier, J., Wiecki, T.V. & Fonnesbeck, C. (2016), *Probabilistic programming in Python using PyMC3*, PeerJ Computer Science\n",
+    "- Kumar, R., Carroll, J., Hartikainen, A. & Martin, O. (2019), *ArviZ a unified library for exploratory analysis of Bayesian models in Python*, JORS\n",
+    "- Hoffman, M.D. & Gelman, A. (2014), *The No-U-Turn Sampler*, JMLR"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit fidelity #3164 — **Decision sub-series, grain 3** (Expert Systems / Robust Decisions). Markdown-only citation anchoring (+9/-5).

PyMC-19 taught 4 foundational concepts without inline citations. Unlike PyMC-18 (where PyMC was incidental — single meta-prior cell), PyMC-19 has a **DEDICATED pedagogical section 9b** (intro + sampling cell + R-hat/ESS diagnostics + MCMC-vs-exact-Bayes comparison) = central treatment, so framework citations are warranted here.

## Fixes (5)

| # | Concept | Citation anchored | Cell |
|---|---------|-------------------|------|
| 1 | MYCIN certainty factors (rule-based expert systems) | Buchanan & Shortliffe, 1984 — *Rule-Based Expert Systems: The MYCIN Experiments* | `98371742` (idx 1) |
| 2 | PyMC framework (section 9b intro, Bayesian inference of sensor reliabilities) | Salvatier, Wiecki & Fonnesbeck, 2016 | `4e9e5acf` (idx 45) |
| 3 | ArviZ diagnostics (R-hat, ESS convergence) | Kumar et al., 2019 | `52e6159a` (idx 49) |
| 4 | NUTS sampler | Hoffman & Gelman, 2014 | `e5d870a6` (idx 53) |
| 5 | References cell | + 4 entries (3 → 7): Buchanan&Shortliffe, Salvatier, Kumar, Hoffman&Gelman | `c81a2739` (idx 58) |

## G.1 cross-check — PyMC centrality (key nuance vs PyMC-18)

The sub-agent flagged PyMC as "cells 45-54, multi-cell central". Ground-truth: PyMC appears in only **1 code cell** (idx 46), BUT section 9b is a multi-markdown pedagogical section (intro idx 45 + diagnostics idx 49 + comparison idx 53). This is **central treatment, not incidental** → Salvatier/Kumar/NUTS warranted. This decision **intentionally differs from PyMC-18** where PyMC was a single incidental meta-prior cell: **centrality governs tooling citation, not a universal rule.**

## Anti-churn G.5 — deliberately NOT flagged

- **Howard & Matheson 1984 (influence diagrams)**: prereq cell (idx 0) just navigates to PyMC-17, which anchors it canonically. Adding inline citation to a navigation line = over-enrichment. Not added to References (no anchor = would be dangling orphan).
- **Jensen 1996 (Bayesian networks textbook)**: Pearl 1988 already anchored inline + in References covers the ground.
- **Bayes/Laplace, Wald (Minimax), Hurwicz** = intro-level / named criteria.
- **Hastings/Metropolis**: MCMC used via NUTS, not taught as standalone concept.

## Already correctly anchored inline (NOT touched)

Pearl 1988 (Bayesian approach pivot) · Savage 1951 (Minimax Regret) · Von Neumann 1928 (minimax theorem) · Knight 1921 (risk vs uncertainty).

## Validation

| Check | Result |
|-------|--------|
| nbformat | OK |
| scan_cell_ordering (HIGH) | 1 clean, 0 finding |
| C.1 (no `raise NotImplementedError`/`assert False`/`1/0` in source) | 0 violation |
| C.2 (code cells retain exec_count + outputs) | 22/22 |
| C.3 (no execution_count churn) | 0 |
| Catalog | byte-identical to main |
| Branch | fresh from `origin/main` |

Forensic git diff suffices for H.4 review (markdown-only single notebook, no re-execution per C.2 markdown exception).

## Progression

Audit #3164 PyMC: **20/20 → 21/21 notebookés** (Decision sub-series grain 3). Decision sub-series: PyMC-17 ✅, PyMC-18 ✅, **PyMC-19 ✅ (this PR)**, PyMC-20 (Sequential) pending.

See #3164
