### PR TITLE
fix(symbolicai): scrub Argument_Analysis 7 nb, 11 abs papermill paths

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
@@ -526,7 +526,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Argument_Analysis_Agentic-0-init.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp/0init_out.ipynb",
+   "output_path": "Argument_Analysis_Agentic-0-init.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T11:14:34.585152",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init_agent.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init_agent.ipynb
@@ -2371,8 +2371,8 @@
    "end_time": "2026-06-14T03:39:52.806309+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Agentic-0-init.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Agentic-0-init_output.ipynb",
+   "input_path": "Argument_Analysis_Agentic-0-init_agent.ipynb",
+   "output_path": "Argument_Analysis_Agentic-0-init_agent.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal.ipynb
@@ -742,7 +742,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/r1_out.ipynb",
+   "output_path": "Argument_Analysis_Agentic-1-informal.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T06:20:09.317233",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal_agent.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal_agent.ipynb
@@ -1480,8 +1480,8 @@
    "end_time": "2026-06-02T23:34:43.622137+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Agentic-1-informal_agent.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Agentic-1-informal_agent_output.ipynb",
+   "input_path": "Argument_Analysis_Agentic-1-informal_agent.ipynb",
+   "output_path": "Argument_Analysis_Agentic-1-informal_agent.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T23:34:36.221979+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-2-pl_agent.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-2-pl_agent.ipynb
@@ -1862,8 +1862,8 @@
    "end_time": "2026-06-02T23:34:55.552930+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Agentic-2-pl_agent.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Agentic-2-pl_agent_output.ipynb",
+   "input_path": "Argument_Analysis_Agentic-2-pl_agent.ipynb",
+   "output_path": "Argument_Analysis_Agentic-2-pl_agent.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T23:34:49.709480+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-4-capstone.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-4-capstone.ipynb
@@ -1167,7 +1167,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Argument_Analysis_Agentic-4-capstone.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/capstone_out.ipynb",
+   "output_path": "Argument_Analysis_Agentic-4-capstone.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T09:36:21.483591",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Executor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Executor.ipynb
@@ -4450,8 +4450,8 @@
    "end_time": "2026-06-16T13:04:33.320830+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Executor.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\Argument_Analysis_Executor_output.ipynb",
+   "input_path": "Argument_Analysis_Executor.ipynb",
+   "output_path": "Argument_Analysis_Executor.ipynb",
    "parameters": {},
    "start_time": "2026-06-16T12:56:33.635890+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Summary

9th grain of the repo-wide papermill abs-path scrub (deep-queue ai-01 [2026-06-18 15:00Z]).

Scrub absolute machine-local paths from `metadata.papermill.input_path` / `output_path` in **7 notebooks** of `SymbolicAI/Argument_Analysis/`:
- Argument_Analysis_Agentic-0-init, Agentic-0-init_agent, Agentic-1-informal, Agentic-1-informal_agent, Agentic-2-pl_agent, Agentic-4-capstone, Executor

Paths leaked local structure (`C:\Users\jsboi\AppData\Local\Temp\`, `D:\dev\CoursIA-2\`, `C:/Users/jsboi/AppData/Local/Temp/`) and broke reproducibility. Replaced with relative basenames — the proven clean state (cf. SC-10 #3427).

## Verification

- `scrub_papermill_paths.py --apply`: **11 fixed, 0 skipped**
- Post-apply scan: **0 defects residual**
- Diff: **11 ins / 11 del**, 7 files (1-4 lines each = matching path pairs)
- JSON validity: **16/16** notebooks in Argument_Analysis parse OK (incl. gitignored `_output` artifacts)
- `outputs` + `execution_count`: **0 churn** (untouched)
- Catalogue (`COURSE_CATALOG.generated.{json,md}`): **byte-identical** to main
- MetaGeneticSharp submodule: **byte-identical** to main

## Scope

Metadata-only (rule C.3): only `metadata.papermill` fields changed. No source cell, no output, no execution_count, no catalogue. Tool: `scripts/notebook_tools/scrub_papermill_paths.py` (#3435).

See #3436 (repo-wide tracking).