### PR TITLE
fix(symbolicai): scrub Tweety 6 nb, 12 abs paths

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-1-Setup.ipynb
@@ -2210,8 +2210,8 @@
    "end_time": "2026-05-20T06:43:19.860960+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-1-Setup.ipynb",
-   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-1-Setup_output.ipynb",
+   "input_path": "Tweety-1-Setup.ipynb",
+   "output_path": "Tweety-1-Setup.ipynb",
    "parameters": {},
    "start_time": "2026-05-20T06:43:12.460064+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
@@ -2916,8 +2916,8 @@
    "end_time": "2026-06-02T21:45:26.853191+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-2-Basic-Logics.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-2-Basic-Logics_output.ipynb",
+   "input_path": "Tweety-2-Basic-Logics.ipynb",
+   "output_path": "Tweety-2-Basic-Logics.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T21:45:20.645023+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
@@ -2236,8 +2236,8 @@
    "end_time": "2026-06-02T21:43:34.606142+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-3-Advanced-Logics.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-3-Advanced-Logics_output.ipynb",
+   "input_path": "Tweety-3-Advanced-Logics.ipynb",
+   "output_path": "Tweety-3-Advanced-Logics.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T21:43:31.263178+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
@@ -2096,8 +2096,8 @@
    "end_time": "2026-06-02T17:37:14.500822+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-4-Belief-Revision.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-4-Belief-Revision_output.ipynb",
+   "input_path": "Tweety-4-Belief-Revision.ipynb",
+   "output_path": "Tweety-4-Belief-Revision.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T17:37:11.084441+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues.ipynb
@@ -1315,8 +1315,8 @@
    "end_time": "2026-06-02T23:49:33.772427+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-8-Agent-Dialogues.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-8-Agent-Dialogues_output.ipynb",
+   "input_path": "Tweety-8-Agent-Dialogues.ipynb",
+   "output_path": "Tweety-8-Agent-Dialogues.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T23:49:29.918691+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
@@ -1551,8 +1551,8 @@
    "end_time": "2026-06-02T23:49:41.741576+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-9-Preferences.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-9-Preferences_output.ipynb",
+   "input_path": "Tweety-9-Preferences.ipynb",
+   "output_path": "Tweety-9-Preferences.ipynb",
    "parameters": {},
    "start_time": "2026-06-02T23:49:38.395562+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## Contexte

Grain deep-queue **scrub papermill abs-path** (directive ai-01 2026-06-18 15:00Z), 10e famille de ma partition (po-2024). Retire les chemins papermill **absolus machine-locaux** injectes dans `metadata.papermill.output_path` / `input_path` par les re-execs (fuite de structure locale + reproductibilite cassee). Etat cible = basename relatif (cf SC-10 #3427).

## Scope

6 notebooks `SymbolicAI/Tweety` / 12 chemins :
- Tweety-1-Setup
- Tweety-2-Basic-Logics
- Tweety-3-Advanced-Logics
- Tweety-4-Belief-Revision
- Tweety-8-Agent-Dialogues
- Tweety-9-Preferences

(Tweety-5/6/7/10 deja propres.)

## Methode

Outil `scripts/notebook_tools/scrub_papermill_paths.py --apply` : edit chirurgical text-level (remplace l'exact `"key": value` dans le JSON) → **byte-identique** hors le champ modifie, aucune re-serialisation.

## Verification

- `git diff --stat` : **12 insertions(+), 12 deletions(-)** symetriques
- 15/15 notebooks Tweety parsent en JSON valide
- `git diff <dir> | grep -cE '^\+.*"(execution_count|outputs)"'` = **0** (aucun churn outputs/exec_count)
- catalogue (`COURSE_CATALOG.generated.{json,md}`) + submodule MGS **byte-identiques** a main (diff vide)
- scan post-apply : **0 chemin absolu residuel**

metadata-only, aucune re-execution (C.3). Stubs d'exercice intacts.

See #3436