### PR TITLE
fix(search): scrub Part4-Metaheuristics 3 nb, 6 abs paths

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb
@@ -2347,8 +2347,8 @@
    "end_time": "2026-06-17T18:11:45.602071+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part4-Metaheuristics\\MGS-4-Islands.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part4-Metaheuristics\\MGS-4-Islands_output.ipynb",
+   "input_path": "MGS-4-Islands.ipynb",
+   "output_path": "MGS-4-Islands.ipynb",
    "parameters": {},
    "start_time": "2026-06-17T18:11:38.157366+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-8-LandscapeExplorer.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-8-LandscapeExplorer.ipynb
@@ -1657,8 +1657,8 @@
    "end_time": "2026-06-17T03:32:30.420676+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part4-Metaheuristics\\MGS-8-LandscapeExplorer.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part4-Metaheuristics\\MGS-8-LandscapeExplorer_output.ipynb",
+   "input_path": "MGS-8-LandscapeExplorer.ipynb",
+   "output_path": "MGS-8-LandscapeExplorer.ipynb",
    "parameters": {},
    "start_time": "2026-06-17T03:32:14.612330+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb
@@ -1481,8 +1481,8 @@
    "end_time": "2026-06-18T00:23:26.692241+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:/dev/CoursIA-2/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb",
-   "output_path": "C:/dev/CoursIA-2/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief_output.ipynb",
+   "input_path": "MGS-9-EverestRelief.ipynb",
+   "output_path": "MGS-9-EverestRelief.ipynb",
    "parameters": {},
    "start_time": "2026-06-18T00:23:13.783844+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Contexte

Grain deep-queue **scrub papermill abs-path** (directive ai-01 2026-06-18 15:00Z), derniere famille de ma partition (po-2024). Retire les chemins papermill **absolus machine-locaux** injectes dans `metadata.papermill.output_path` / `input_path` par les re-execs (fuite de structure locale + reproductibilite cassee). Etat cible = basename relatif.

## Scope

3 notebooks `Search/Part4-Metaheuristics` / 6 chemins :
- MGS-4-Islands
- MGS-8-LandscapeExplorer
- MGS-9-EverestRelief

(MGS-1/2/3/5/6/7 deja propres.) Ces notebooks vivent dans le repo principal (`Part4-Metaheuristics/`, emplacement canonique consolide #3169), pas dans le submodule MGS.

## Methode

Outil `scripts/notebook_tools/scrub_papermill_paths.py --apply` : edit chirurgical text-level (remplace l'exact `"key": value` dans le JSON) → **byte-identique** hors le champ modifie.

## Verification

- `git diff --stat` : **6 insertions(+), 6 deletions(-)** symetriques
- 10/10 notebooks Part4 parsent en JSON valide
- aucun churn outputs/exec_count (grep = 0)
- catalogue (`COURSE_CATALOG.generated.{json,md}`) + submodule MGS **byte-identiques** a main (diff vide)
- scan post-apply : **0 chemin absolu residuel**

metadata-only, aucune re-execution (C.3). Stubs d'exercice intacts.

See #3436