### PR TITLE
docs(genai): remove "Cross-series Bridges" anti-pattern from 6 READMEs (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -177,14 +177,6 @@ Le fil rouge de cette série est la création d'un podcast généré par IA. Voi
 
 4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Audio-Content.ipynb) applique le pipeline à la narration de cours. [04-2](04-Applications/04-2-Transcription-Pipeline.ipynb) gère la transcription batch pour les épisodes longs. [04-4](04-Applications/04-4-Audio-Video-Sync.ipynb) synchronise avec la piste vidéo si le podcast a une composante visuelle.
 
-## Cross-series Bridges
-
-| Série | Lien | Connection |
-|-------|------|------------|
-| [Video](../Video/README.md) | Sync audio-vidéo | [04-4](04-Applications/04-4-Audio-Video-Sync.ipynb) synchronise l'audio généré avec les pistes vidéo de la série Video |
-| [Texte](../Texte/README.md) | LLM dans le pipeline | Le pipeline podcast (03-2) enchaîne STT vers LLM vers TTS ; les prompts structurés (Texte/2) et le RAG (Texte/5) alimentent le contenu |
-| [SemanticKernel](../SemanticKernel/README.md) | Orchestration | Les pipelines multi-modèles Audio (03-1, 03-2) partagent les patterns d'orchestration avec Semantic Kernel |
-
 ## FAQ
 
 ### GPU OOM pendant un notebook TTS/STT local

--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -157,15 +157,6 @@ Le fil rouge de cette série est la création d'un système de visuels pédagogi
 
 4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Content-Generation.ipynb) applique le pipeline au contenu éducatif. Les notebooks [examples/](examples/) montrent des cas d'usage par domaine (histoire, sciences, littérature).
 
-## Cross-series Bridges
-
-| Série | Lien | Connection |
-|-------|------|------------|
-| [Video](../Video/README.md) | Image-to-video | Les visuels générés ici (DALL-E, FLUX, Qwen) servent d'images clés à animer : SVD (Video/02-4) ou le pipeline Video/03-2 les prennent en entrée |
-| [Audio](../Audio/README.md) | Sync audio-video | Audio/04-4 synchronise la piste audio avec les visuels générés |
-| [Texte](../Texte/README.md) | Prompts structurés | Les prompts DALL-E et GPT-5 Image bénéficient des techniques de prompt engineering (Texte/2) et function calling (Texte/4) |
-| [SemanticKernel](../SemanticKernel/README.md) | Orchestration | Les pipelines d'orchestration (03-2) partagent les mêmes patterns que les agents Semantic Kernel |
-
 ## FAQ
 
 ### DALL-E 3 retourne des images floues ou hors-sujet

--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -275,25 +275,3 @@ Pour le troubleshooting avancé (timeout Papermill, OOM GPU, .NET), consultez le
 | **TTS** | Text-to-Speech : synthétiser la voix depuis du texte | Audio |
 | **ComfyUI** | Interface visuelle pour chaîner les modèles génératifs en workflows | Image, Video |
 | **Playwright** | Framework de test E2E pour applications web GenAI | Playwright-OWUI |
-
-## Cross-series Bridges
-
-### Interne GenAI
-
-| Série | Lien | Connection |
-|-------|------|------------|
-| [Image](Image/README.md) | Source visuelle pour Video | Le pipeline Video/03-2 enchaîne génération d'images puis animation ; SVD (Video/02-4) anime une image existante |
-| [Audio](Audio/README.md) | Sync A/V + podcast | Audio/04-4 synchronise audio et vidéo ; le pipeline podcast (Audio/03-2) enchaîne STT, LLM (Texte) et TTS |
-| [Texte](Texte/README.md) | Prompts et APIs | Les prompts structurés (Texte/2) guident toute génération (Image, Audio, Video) ; function calling (Texte/4) pilote les APIs multimodales |
-| [SemanticKernel](SemanticKernel/README.md) | Orchestration | Les pipelines multi-modèles de chaque série suivent les patterns d'orchestration Semantic Kernel |
-
-### Externe
-
-| Série | Lien | Connection |
-|-------|------|-------------|
-| [QuantConnect](../QuantConnect/README.md) | Trading algorithmique | L'analyse de sentiment par LLM (Texte/8_Reasoning_Models) alimente les stratégies de trading du notebook QC-13 |
-| [Probas](../Probas/README.md) | Modèles probabilistes | Les VAE et diffusion models (Image/02-Advanced, Video/02-Advanced) partagent les fondements probabilistes couverts dans Probas/Infer |
-
-### Lecture transversale
-
-[La mer qui monte](../../docs/grothendieckian-lens.md) : une grille de lecture grothendieckienne du dépôt — GenAI comme versant *simulation* (générer, calculer, expérimenter) face au versant *preuve* des séries formelles.

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
@@ -155,17 +155,6 @@ Le fil rouge de cette série est le NotebookMaker, un système multi-agents qui 
 
 4. **NotebookMaker (09-10)** : [09](09-SemanticKernel-Building-CLR.ipynb) prépare l'interop Python/C#. [10](10-SemanticKernel-NotebookMaker.ipynb) assemble le système 3 agents (Admin, Coder, Reviewer). Les versions [10a](10a-SemanticKernel-NotebookMaker-batch.ipynb) et [10b](10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb) ajoutent le mode batch et la paramétrisation Papermill.
 
-## Cross-series Bridges
-
-| Série | Lien | Connection |
-|-------|------|------------|
-| [GenAI/Texte](../Texte/README.md) | LLMs et APIs | Les notebooks Texte couvrent les mêmes modèles (OpenAI, Anthropic) que SemanticKernel les orchestre en agents |
-| [GenAI/Image](../Image/README.md) | Génération d'images | Le notebook 07-MultiModal utilise la génération d'images DALL-E via le Kernel SK |
-| [GenAI/Audio](../Audio/README.md) | Speech et TTS | Le notebook 07-MultiModal intègre aussi le TTS (text-to-speech) via le Kernel |
-| [ML](../../ML/README.md) | Pipelines ML | Le NotebookMaker (10) génère des notebooks ML automatiquement, la validation croisée ML-4 évalue les modèles produits |
-| [QuantConnect](../../QuantConnect/README.md) | Trading algorithmique | Les agents SK peuvent être connectés à des sources de données financières via MCP (08) pour des signaux de trading LLM-augmentés |
-| [Vibe-Coding](../Vibe-Coding/README.md) | Développement avec agents | Les patterns d'orchestration multi-agents du NotebookMaker (10) s'appliquent aux workflows Vibe-Coding |
-
 ## Changelog
 
 ### Février 2026

--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -158,16 +158,6 @@ Le fil rouge de cette série est la progression de l'interaction basique avec un
 
 5. **Tier 5** (test-time scaling approfondi) : partant de [12_Test_Time_Scaling](12_Test_Time_Scaling.ipynb) (les quatre moteurs en Python pur), l'arc NB-13..18 décompose chaque facette de l'inférence au moment du test — orchestration agentique via function calling ([13](13_Agentic_Orchestration.ipynb)), mémoire persistante par similarité ([14](14_Persistent_Memory.ipynb)), Tree-of-Thoughts sur des problèmes de recherche ([15](15_Tree_of_Thoughts_Search.ipynb)), courbes de scaling de Snell ([16](16_Scaling_Test_Time_Compute.ipynb)), raisonnement natif vs scaling hand-rolled ([17](17_Native_Reasoning_vs_Scaling.ipynb)), puis intégration Semantic Kernel ([18](18_Semantic_Kernel_Plugins.ipynb)).
 
-## Cross-series Bridges
-
-| Série | Lien | Connection |
-|-------|------|------------|
-| [Image](../Image/README.md) | Prompts structurés | Les textes prompts guident la génération d'images (DALL-E, GPT-5 Image) — notebooks [1](1_OpenAI_Intro.ipynb) et [4](4_Function_Calling.ipynb) |
-| [Audio](../Audio/README.md) | STT/TTS + RAG podcast | Whisper STT et TTS APIs sont les bases du pipeline podcast (Audio/03-2) ; le RAG (notebook [5](5_RAG_Modern.ipynb)) alimente le contenu |
-| [Video](../Video/README.md) | GPT-5 Video + Sora prompts | La compréhension vidéo (Video/01-2) utilise les mêmes APIs texte ; Sora (Video/04-3) dépend de prompts structurés |
-| [SemanticKernel](../SemanticKernel/README.md) | Orchestration agentique | Semantic Kernel orchestre les LLMs via plugins et agents — prolonge les patterns de function calling (notebook [4](4_Function_Calling.ipynb)) |
-| [SymbolicAI](../../SymbolicAI/README.md) | Reasoning formel | Les modèles raisonnants (notebook [8](8_Reasoning_Models.ipynb)) complètent le reasoning formel (Z3, Tweety, Lean) |
-
 ## FAQ
 
 ### Chat Completions vs Responses API — laquelle utiliser ?

--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -133,15 +133,6 @@ winget install FFmpeg
 | Compréhension vidéo | 01-2, 01-3 |
 | Production complète | Tous + Audio/04-4 (sync A/V) |
 
-## Cross-series Bridges
-
-| Série | Lien | Connection |
-|-------|------|------------|
-| [Audio](../Audio/README.md) | Sync audio-vidéo | [Audio/04-4](../Audio/04-Applications/04-4-Audio-Video-Sync.ipynb) synchronise la piste audio générée avec la vidéo |
-| [Image](../Image/README.md) | Source d'images | Le pipeline Video/03-2 génère des images via les modèles Image avant de les animer ; SVD (02-4) anime une image existante |
-| [Texte](../Texte/README.md) | Prompts et APIs | La compréhension vidéo (01-2) utilise les mêmes APIs GPT-5 que Texte ; Sora (04-3) dépend de prompts structurés |
-| [SemanticKernel](../SemanticKernel/README.md) | Orchestration | Les workflows vidéo ComfyUI (03-3) partagent les patterns d'orchestration avec les agents Semantic Kernel |
-
 ## FAQ
 
 ### HunyuanVideo OOM ou génération extrêmement lente


### PR DESCRIPTION
## Summary

Removes the **"Cross-series Bridges"** section from the 6 GenAI READMEs (Audio, Image, SemanticKernel, Texte, Video, GenAI root). This section is an acknowledged anti-pattern (dashboard decision ai-01): cross-series coupling + redundant navigation (already covered by each series' Progression/Concepts tables) + stale-link risk.

Per ai-01 deep-queue 17:30Z item 3 for po-2023: `... #2161 grain 3+4 (done) -> #2651 prose GenAI`. The actionable #2651 grain was flagged on the dashboard: *"« Cross-series bridges » est un ANTI-PATTERN (à SUPPRIMER, jamais ajouter). ~12 READMEs résiduels à nettoyer."* — 6 of those are GenAI (my family).

## Changes (surgical, byte-preserving via Edit tool)
- **Audio, Image, Texte, Video**: drop the `## Cross-series Bridges` section (header + table linking to Video/Audio/Texte/SemanticKernel); FAQ section kept intact.
- **SemanticKernel**: drop the section (linked Texte/Image/Audio/ML/QuantConnect/Vibe-Coding); Changelog kept.
- **GenAI root**: drop the section incl. 3 subsections (Interne GenAI, Externe, Lecture transversale). The grothendieckian-lens doc link lived under this section — confirmed **not orphaned** (still referenced by `docs/README.md` + 8 SymbolicAI READMEs).

## Validation
- 0 "Cross-series bridges" occurrences remain in GenAI/
- `check_docs_links.py --check`: OK (0 new broken, 2276 total)
- diff: **6 files, 69 deletions, 0 insertions** (pure removal, no reflow/CRLF churn)
- All series READMEs retain FAQ/Changelog/Licence sections intact

## Scope note (G.4)
6 READMEs but ONE coherent operation (remove one anti-pattern section), ONE domain (GenAI), ONE convention (#2651) — atomic per catalog-hygiene. The remaining ~6 repo-wide Cross-series Bridges (other families) are out of scope (other workers' families); ai-01 can dispatch them.

See #2651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)