### PR TITLE
fix(symbolicai): scrub SMT 6 nb, 11 abs paths

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-03-Tactics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-03-Tactics.ipynb
@@ -1455,8 +1455,8 @@
    "end_time": "2026-06-13T02:45:16.183163+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-03-Tactics.ipynb",
-   "output_path": "/tmp/Z3-Python-03-Tactics_wsl_output.ipynb",
+   "input_path": "Z3-Python-03-Tactics.ipynb",
+   "output_path": "Z3-Python-03-Tactics.ipynb",
    "parameters": {},
    "start_time": "2026-06-13T02:45:05.722766+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-04-Strings-Regex.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-04-Strings-Regex.ipynb
@@ -1370,8 +1370,8 @@
    "end_time": "2026-06-13T08:07:33.251485+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-04-Strings-Regex.ipynb",
-   "output_path": "/tmp/Z3-Python-04-Strings-Regex_wsl_output.ipynb",
+   "input_path": "Z3-Python-04-Strings-Regex.ipynb",
+   "output_path": "Z3-Python-04-Strings-Regex.ipynb",
    "parameters": {},
    "start_time": "2026-06-13T08:07:26.585964+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb
@@ -1275,8 +1275,8 @@
    "end_time": "2026-06-13T08:58:01.034744+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb",
-   "output_path": "/tmp/Z3-Python-05-Quantifiers-Proofs_wsl_output.ipynb",
+   "input_path": "Z3-Python-05-Quantifiers-Proofs.ipynb",
+   "output_path": "Z3-Python-05-Quantifiers-Proofs.ipynb",
    "parameters": {},
    "start_time": "2026-06-13T08:57:59.505334+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-06-Advanced-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-06-Advanced-Optimization.ipynb
@@ -1429,7 +1429,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Z3-Python-06-Advanced-Optimization.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/z3_reexec/NB06_with_viz.ipynb",
+   "output_path": "Z3-Python-06-Advanced-Optimization.ipynb",
    "parameters": {},
    "start_time": "2026-06-14T12:24:13.958394",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
@@ -1922,8 +1922,8 @@
    "end_time": "2026-06-15T17:18:33.397211+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\03_Array_Theory.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\03_Array_Theory_output.ipynb",
+   "input_path": "03_Array_Theory.ipynb",
+   "output_path": "03_Array_Theory.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T17:18:23.651083+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
@@ -1820,8 +1820,8 @@
    "end_time": "2026-06-15T18:47:14.519719+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\05_Meal_Planner_Hierarchical.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\05_Meal_Planner_Hierarchical_output.ipynb",
+   "input_path": "05_Meal_Planner_Hierarchical.ipynb",
+   "output_path": "05_Meal_Planner_Hierarchical.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T18:47:09.271928+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Contexte

Grain **scrub papermill abs-path** sous l'Epic **#3436** (scrub repo-wide par famille/partition). La deep-queue ordonnee ai-01 (2026-06-18 15:00Z) etant epuisee sur ma partition, je poursuis #3436 sur les familles SymbolicAI non-Lean restantes. Retire les chemins papermill **absolus machine-locaux** injectes dans `metadata.papermill.output_path` / `input_path` par les re-execs (fuite de structure locale + reproductibilite cassee). Etat cible = basename relatif.

## Scope

6 notebooks `SymbolicAI/SMT` / 11 chemins :
- Z3-Python/Z3-Python-03-Tactics
- Z3-Python/Z3-Python-04-Strings-Regex
- Z3-Python/Z3-Python-05-Quantifiers-Proofs
- Z3-Python/Z3-Python-06-Advanced-Optimization
- Z3/03_Array_Theory
- Z3/05_Meal_Planner_Hierarchical

Chemins varies retires : `/tmp/...`, `/mnt/d/dev/...`, `D:\dev\CoursIA-2\...`, `C:/Users/jsboi/AppData/Local/Temp/...`.

## Methode

Outil `scripts/notebook_tools/scrub_papermill_paths.py --apply` : edit chirurgical text-level (remplace l'exact `"key": value` dans le JSON) → **byte-identique** hors le champ modifie.

## Verification

- `git diff --stat` : **11 insertions(+), 11 deletions(-)** symetriques
- 13/13 notebooks SMT parsent en JSON valide
- aucun churn outputs/exec_count (grep = 0)
- catalogue (`COURSE_CATALOG.generated.{json,md}`) + submodule MGS **byte-identiques** a main (diff vide)
- scan post-apply : **0 chemin absolu residuel**

metadata-only, aucune re-execution (C.3). Stubs d'exercice intacts.

See #3436