### PR TITLE
docs(pymc-20): anchor canonical citations + add References (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb
@@ -290,7 +290,7 @@
     "\n",
     "### Intuition\n",
     "\n",
-    "L'equation de Bellman exprime un principe de **consistance temporelle** :\n",
+    "L'equation de Bellman (Bellman, 1957) exprime un principe de **consistance temporelle** :\n",
     "\n",
     "> La valeur d'un etat = recompense immediate + valeur esperee du meilleur etat futur\n",
     "\n",
@@ -791,7 +791,7 @@
     "   - **Evaluation** : Calculer $V^\\pi$ (resoudre le systeme lineaire)\n",
     "   - **Amelioration** : Mettre a jour $\\pi(s) = \\arg\\max_a Q^\\pi(s,a)$\n",
     "\n",
-    "Converge souvent **plus rapidement** que Value Iteration (moins d'iterations, mais chaque iteration est plus couteuse)."
+    "Converge souvent **plus rapidement** que Value Iteration (Howard, 1960) (moins d'iterations, mais chaque iteration est plus couteuse)."
    ]
   },
   {
@@ -962,7 +962,7 @@
     "\n",
     "### Principe\n",
     "\n",
-    "RTDP est un algorithme de **planification en ligne** qui met a jour les valeurs uniquement pour les etats **atteignables** depuis un etat de depart.\n",
+    "RTDP (Barto, Bradtke & Singh, 1995) est un algorithme de **planification en ligne** qui met a jour les valeurs uniquement pour les etats **atteignables** depuis un etat de depart.\n",
     "\n",
     "**Avantage** : pas besoin d'explorer tout l'espace d'etats. Particulierement utile quand l'espace est grand mais seul un sous-ensemble est pertinent."
    ]
@@ -1878,7 +1878,7 @@
     "\n",
     "$$a_t = \\arg\\max_i \\nu_i(t)$$\n",
     "\n",
-    "### Calcul pratique et approximation UCB1\n",
+    "### Calcul pratique et approximation UCB1 (Auer et al., 2002)\n",
     "\n",
     "Le calcul exact de l'indice de Gittins est NP-difficile dans le cas general. Heureusement, **UCB1 fournit une approximation asymptotiquement optimale** :\n",
     "\n",
@@ -2099,7 +2099,7 @@
     "- Un ensemble d'**observations** $O$\n",
     "- Une probabilite d'observation $P(o|s',a)$\n",
     "\n",
-    "L'agent maintient un **belief state** $b(s) = P(s|\\text{historique})$ et met a jour ce belief via le **theoreme de Bayes**."
+    "L'agent maintient un **belief state** $b(s) = P(s|\\text{historique})$ (Smallwood & Sondik, 1973) et met a jour ce belief via le **theoreme de Bayes**."
    ]
   },
   {
@@ -2456,9 +2456,9 @@
     "\n",
     "### Pourquoi PyMC pour les bandits ?\n",
     "\n",
-    "Thompson Sampling est la strategie de bandit la plus naturelle a implementer avec un echantillonneur MCMC : on maintient une distribution *a posteriori* sur les parametres de chaque bras, et a chaque tour on echantillonne depuis cette posterior pour guider le choix.\n",
+    "Thompson Sampling (Thompson, 1933) est la strategie de bandit la plus naturelle a implementer avec un echantillonneur MCMC : on maintient une distribution *a posteriori* sur les parametres de chaque bras, et a chaque tour on echantillonne depuis cette posterior pour guider le choix.\n",
     "\n",
-    "PyMC offre un cadre rigoureux pour :\n",
+    "PyMC (Salvatier, Wiecki & Fonnesbeck, 2016) offre un cadre rigoureux pour :\n",
     "- Modeles de recompenses avec priors conjugues (Beta-Bernoulli, Normal-Normal)\n",
     "- Echantillonnage MCMC quand les priors ne sont pas conjugues\n",
     "- Diagnostics de convergence via ArviZ\n",
@@ -2778,7 +2778,7 @@
     "\n",
     "Dans le cas Beta-Bernoulli, la posterior a une forme analytique. Mais pour des modeles plus complexes (recompenses gaussiennes avec variance inconnue, priors hierarchiques), PyMC devient indispensable.\n",
     "\n",
-    "Ici on illustre l'approche PyMC sur un bandit gaussien : on infere la moyenne de chaque bras via NUTS, puis on echantillonne depuis la posterior pour la selection."
+    "Ici on illustre l'approche PyMC sur un bandit gaussien : on infere la moyenne de chaque bras via NUTS (Hoffman & Gelman, 2014), puis on echantillonne depuis la posterior pour la selection."
    ]
   },
   {
@@ -3899,7 +3899,7 @@
    "source": [
     "### Diagnostics ArviZ : convergence des belief states\n",
     "\n",
-    "ArviZ fournit des outils essentiels pour verifier la qualite de l'inference MCMC. Pour le modele de maintenance predictive, on verifie :\n",
+    "ArviZ (Kumar et al., 2019) fournit des outils essentiels pour verifier la qualite de l'inference MCMC. Pour le modele de maintenance predictive, on verifie :\n",
     "- **$\\hat{R}$ (R-hat)** : convergence des chaines (objectif < 1.05)\n",
     "- **ESS (Effective Sample Size)** : nombre d'echantillons effectifs (objectif > 400)\n",
     "- **Trace plot** : visualisation du melange des chaines"
@@ -4455,7 +4455,7 @@
     "\n",
     "### Serie RL : Extension a l'apprentissage\n",
     "\n",
-    "Quand $P(s'|s,a)$ et $R(s,a)$ sont inconnus, on utilise l'apprentissage par renforcement :\n",
+    "Quand $P(s'|s,a)$ et $R(s,a)$ sont inconnus, on utilise l'apprentissage par renforcement (Sutton & Barto, 2018) :\n",
     "- **Q-Learning** : apprend $Q(s,a)$ par interaction\n",
     "- **Deep RL** : approxime Q avec un reseau de neurones\n",
     "- **Policy Gradient** : optimise directement la politique"
@@ -4615,6 +4615,39 @@
     "| [PyMC-18](PyMC-18-Decision-Value-Information.ipynb) | Valeur de l'information |\n",
     "| [PyMC-19](PyMC-19-Decision-Expert-Systems.ipynb) | Systemes experts |\n",
     "| **PyMC-20** | **MDPs, Bandits, POMDPs, Thompson Sampling, PyMC** |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "refs-bibliography-pymc20",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "### MDP et programmation dynamique\n",
+    "- **Bellman, R. (1957).** *Dynamic Programming.* Princeton University Press. (equation de Bellman, iteration de valeur)\n",
+    "- **Howard, R. A. (1960).** *Dynamic Programming and Markov Processes.* MIT Press. (iteration de politique)\n",
+    "- **Puterman, M. L. (1994).** *Markov Decision Processes: Discrete Stochastic Dynamic Programming.* Wiley. (reference MDP)\n",
+    "- **Barto, A. G., Bradtke, S. J. & Singh, S. P. (1995).** Learning to act using real-time dynamic programming. *Artificial Intelligence*, 72(1-2), 81-138. (RTDP)\n",
+    "\n",
+    "### Observabilite partielle\n",
+    "- **Smallwood, R. D. & Sondik, E. J. (1973).** The optimal control of partially observable Markov processes over a finite horizon. *Operations Research*, 21(5), 1071-1088. (POMDP)\n",
+    "\n",
+    "### Bandits et exploration\n",
+    "- **Thompson, W. R. (1933).** On the likelihood that one unknown probability exceeds another in view of the evidence of two samples. *Biometrika*, 25(3-4), 285-294. (Thompson Sampling)\n",
+    "- **Gittins, J. C. (1979).** Bandit processes and dynamic allocation indices. *Journal of the Royal Statistical Society B*, 41(2), 148-177. (indice de Gittins)\n",
+    "- **Whittle, P. (1982).** *Optimization Over Time: Dynamic Programming and Stochastic Control.* Wiley. (preuve des prevailing charges)\n",
+    "- **Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002).** Finite-time analysis of the multiarmed bandit problem. *Machine Learning*, 47, 235-256. (UCB1)\n",
+    "\n",
+    "### Reward shaping et apprentissage par renforcement\n",
+    "- **Ng, A. Y., Harada, D. & Russell, S. (1999).** Policy invariance under reward transformations: theory and application to reward shaping. *ICML*. (reward shaping)\n",
+    "- **Sutton, R. S. & Barto, A. G. (2018).** *Reinforcement Learning: An Introduction* (2e edition). MIT Press.\n",
+    "- **Russell, S. & Norvig, P. (2021).** *Artificial Intelligence: A Modern Approach* (4e edition). Pearson. (gridworld, formalisme MDP)\n",
+    "\n",
+    "### Outils\n",
+    "- **Salvatier, J., Wiecki, T. V. & Fonnesbeck, C. (2016).** Probabilistic programming in Python using PyMC3. *PeerJ Computer Science*, 2, e55.\n",
+    "- **Hoffman, M. D. & Gelman, A. (2014).** The No-U-Turn Sampler: adaptively setting path lengths in Hamiltonian Monte Carlo. *Journal of Machine Learning Research*, 15, 1593-1623. (NUTS)\n",
+    "- **Kumar, R., Carroll, C., Hartikainen, A. & Martin, O. (2019).** ArviZ: a unified library for exploratory analysis of Bayesian models in Python. *Journal of Open Source Software*, 4(33), 1143.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Audit fidelite #3164 — PyMC-20-Decision-Sequential (DERNIER grain de la famille PyMC)

**Verdict : 10 OMISSIONS ancrees + 1 section References creee (aucune n'existait), 0 erreur factuelle, REINVENTION pedagogique attribuee.**

PyMC-20 enseigne 10+ algorithmes nommes (MDP, equation de Bellman, value/policy iteration, RTDP, POMDP, UCB1, Thompson Sampling, reward shaping, lien RL) mais ne portait **que 4 citations inline** (Russell & Norvig, Ng et al. 1999, Whittle 1982, Gittins 1979) et **aucune section References**. Profil distinct des PyMC-17/18/19 : pas d'orphelins References (il n'y avait pas de References du tout) — **OMISSION pure**.

### Fixes (markdown-only, +43/-10)
10 ancres canoniques, chacune au **point d'enseignement** de l'algorithme nomme :

| Concept | Citation | Cellule |
|---------|----------|---------|
| Equation de Bellman / DP | Bellman 1957 | 7 |
| Iteration de politique | Howard 1960 | 16 |
| RTDP | Barto, Bradtke & Singh 1995 | 20 |
| UCB1 | Auer et al. 2002 | 36 |
| POMDP (belief state) | Smallwood & Sondik 1973 | 40 |
| Thompson Sampling | Thompson 1933 | 46 |
| PyMC (section 10ter dediee) | Salvatier, Wiecki & Fonnesbeck 2016 | 46 |
| NUTS | Hoffman & Gelman 2014 | 51 |
| ArviZ (diagnostics dedies) | Kumar et al. 2019 | 54 |
| Lien RL / Q-Learning | Sutton & Barto 2018 | 61 |

+ **section References** consolidant les 10 nouvelles + les 4 deja inline + Puterman 1994 (textbook MDP de reference).

### G.1 cross-check + G.5 anti-chariot
- **Ground-truth** : confirme l'absence totale de cellule References (notebook se termine cell 64 `---`, cell 63 = exercice). Source ASCII-only (sans accents) — markers verifies verbatim, abort-on-mismatch passe sur les 10 (notebook intact si mismatch).
- **Centralite (regle PyMC-18 vs PyMC-19)** : PyMC/ArviZ gardes car **centraux** ici (section 10ter dediee Thompson+PyMC + section diagnostics ArviZ), contrairement a PyMC-18 ou ils etaient incidentels et trimmes.
- **Anti-chariot** : chaque ancre cible un **algorithme nomme effectivement enseigne**, pas un concept intro-level. Concepts generiques (theoreme de Bayes, utilite esperee) non cites. REINVENTION pedagogique (VI/PI/RTDP from-scratch) attribuee a son inventeur sans toucher le code (markdown-only).
- **0 erreur factuelle** : NUTS utilise uniquement sur latents **continus** (Dirichlet/Normal), jamais sur discrets — correct.

### Validation
- nbformat OK · C.1 = 0 · **C.2 = 23/23** code cells conservent exec_count+outputs · **C.3 = 0** churn exec/outputs (markdown-only) · scan_cell_ordering 1 clean/0 finding · catalogue **byte-identique** · branche fraiche `origin/main`.

### Progression audit #3164
**Famille PyMC COMPLETE** : PyMC-17 (#3492), PyMC-18 (#3498), PyMC-19 (#3504), **PyMC-20 (cette PR) = dernier grain**. Sous-serie Decision entierement auditee.

`See #3164` — markdown-only, forensic git diff suffit (H.4).
