### PR TITLE
fix(search): scrub Search-root 3 nb, 6 abs paths

### DIFF
--- a/MyIA.AI.Notebooks/Search/CSPs_Intro.ipynb
+++ b/MyIA.AI.Notebooks/Search/CSPs_Intro.ipynb
@@ -1730,8 +1730,8 @@
    "end_time": "2026-06-08T22:30:35.713823+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\CSPs_Intro.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\CSPs_Intro_output.ipynb",
+   "input_path": "CSPs_Intro.ipynb",
+   "output_path": "CSPs_Intro.ipynb",
    "parameters": {},
    "start_time": "2026-06-08T22:30:20.833059+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Portfolio_Optimization_GeneticSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Portfolio_Optimization_GeneticSharp.ipynb
@@ -894,8 +894,8 @@
    "end_time": "2026-06-03T05:29:30.115049+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Portfolio_Optimization_GeneticSharp.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Portfolio_Optimization_GeneticSharp_output.ipynb",
+   "input_path": "Portfolio_Optimization_GeneticSharp.ipynb",
+   "output_path": "Portfolio_Optimization_GeneticSharp.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T05:29:20.951930+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/PyGad-EdgeDetection.ipynb
+++ b/MyIA.AI.Notebooks/Search/PyGad-EdgeDetection.ipynb
@@ -1928,8 +1928,8 @@
    "end_time": "2026-05-02T18:36:38.727655",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\PyGad-EdgeDetection.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\PyGad-EdgeDetection.ipynb",
+   "input_path": "PyGad-EdgeDetection.ipynb",
+   "output_path": "PyGad-EdgeDetection.ipynb",
    "parameters": {},
    "start_time": "2026-05-02T18:33:33.944555",
    "version": "2.6.0"


### PR DESCRIPTION
## Contexte

Grain **scrub papermill abs-path** sous l'Epic **#3436** (scrub repo-wide par famille/partition). Retire les chemins papermill **absolus machine-locaux** injectes dans `metadata.papermill.output_path` / `input_path` par les re-execs. Etat cible = basename relatif.

## Scope

3 notebooks loose de `Search/` (racine) / 6 chemins :
- CSPs_Intro
- Portfolio_Optimization_GeneticSharp
- PyGad-EdgeDetection

## Note — 1 notebook differe (limitation outil sur nom non-ASCII)

`Exploration_non_informée_et_informée_intro.ipynb` (e accentue dans le nom) **n'est pas inclus** : l'outil construit son needle de recherche via `json.dumps(value)` (defaut `ensure_ascii=True`), qui echappe `é` en `é`, alors que le fichier brut stocke `é` litteral → le needle ne matche pas → l'outil **skip par securite** (`fixed: 0, skipped: 2`). Verifie sur le source de l'outil (`scrub_papermill_paths.py:95`). Sera traite via un fix de l'outil (`ensure_ascii=False`) qui debloque aussi tout chemin accentue repo-wide.

## Verification

- `git diff --stat` : **6 insertions(+), 6 deletions(-)** symetriques
- 3/3 notebooks parsent en JSON valide
- aucun churn outputs/exec_count (grep = 0)
- catalogue + submodule MGS **byte-identiques** a main (diff vide)
- scan post-apply sur les 3 : 0 chemin residuel

metadata-only, aucune re-execution (C.3).

See #3436