### PR TITLE
fix(infer11): Sequences fidelity audit #3164 -- false 3.3 cross-ref, nav, Graphviz caveats

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Sequences.ipynb
@@ -963,6 +963,8 @@
    "source": [
     "### Graphe de facteurs : Classification independante\n",
     "\n",
+    "> **Rendu Graphviz** : le graphe factoriel n’est pas affiché dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`). Le moteur génère bien un fichier `.gv` à côté du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais `FactorGraphHelper.GetLatestFactorGraphHtml()` affiche à la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessous reste valable.\n",
+    "\n",
     "Ce graphe represente le modele **sans dependances temporelles** :\n",
     "\n",
     "| Element | Signification |\n",
@@ -2334,6 +2336,8 @@
    "source": [
     "### Graphe de facteurs : Modele meteo (classification)\n",
     "\n",
+    "> **Rendu Graphviz** : le graphe factoriel n’est pas affiché dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`). Le moteur génère bien un fichier `.gv` à côté du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais `FactorGraphHelper.GetLatestFactorGraphHtml()` affiche à la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessous reste valable.\n",
+    "\n",
     "Structure identique a la detection d'anomalies - un modele de **melange gaussien** :\n",
     "\n",
     "| Composante | Parametres |\n",
@@ -2365,7 +2369,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Sensibilite du Modele aux Emissions Chevauchantes\n",
+    "## 4bis. Exercice : Sensibilite du Modele aux Emissions Chevauchantes\n",
     "\n",
     "Dans la section 4, les deux regimes meteo (Soleil ~22C, Pluie ~15C) sont bien separes avec un ecart de 7C pour un ecart-type de 2C. Que se passe-t-il quand les emissions se chevauchent davantage ?\n",
     "\n",
@@ -4205,7 +4209,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation des resultats de l'exercice\n",
+    "### Interpretation des resultats de l'exemple guide\n",
     "\n",
     "Le detecteur identifie correctement la **periode promotionnelle** (jours 5-8) :\n",
     "\n",
@@ -4276,6 +4280,8 @@
    "source": [
     "### Graphe de facteurs : Detection de promotions\n",
     "\n",
+    "> **Rendu Graphviz** : le graphe factoriel n’est pas affiché dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`). Le moteur génère bien un fichier `.gv` à côté du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais `FactorGraphHelper.GetLatestFactorGraphHtml()` affiche à la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessous reste valable.\n",
+    "\n",
     "Meme structure que les modeles precedents - classification par melange gaussien :\n",
     "\n",
     "| Regime | Distribution | Interpretation |\n",
@@ -4307,9 +4313,9 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Impact des Parametres de Transition sur le Lissage\n",
+    "## 6bis. Exercice : Impact des Parametres de Transition sur le Lissage\n",
     "\n",
-    "Dans la section 3.3, nous avons implemente l'algorithme Forward-Backward avec `pStay = 0.9` et observe comment le HMM lisse les decisions sur les observations ambigues (17.0, 18.0).\n",
+    "Dans la section 3.3, nous avons construit un HMM complet a transitions markoviennes (trois regimes Normal/Alerte/Critique, inference par Expectation Propagation puis decodage de Viterbi) et observe comment la matrice de transition lisse les decisions la ou la classification independante sur-segmente.\n",
     "\n",
     "Votre mission : modifiez les parametres du HMM et analysez l'impact sur les probabilites a posteriori.\n",
     "\n",
@@ -4433,7 +4439,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : HMM a 3 Etats - Detection de Pannes Machine\n",
+    "## 7bis. Exercice : HMM a 3 Etats - Detection de Pannes Machine\n",
     "\n",
     "Etendez le HMM a **3 etats** pour modeliser l'etat d'une machine industrielle :\n",
     "\n",


### PR DESCRIPTION
## Résumé
Audit fidélité (Epic #3164) de `Infer-11-Sequences.ipynb` (10e Infer audité). **Markdown-only, 11 ins / 5 del.** Sous-agent `sonnet` evidence-cited + cross-check G.1 parent.

## Défauts corrigés (5)
1. **ERREUR-FACTUELLE (HIGH)** — exercice idx56 (`d42c6ea1`) prétendait que la §3.3 implémentait un Forward-Backward avec `pStay=0.9` sur observations (17.0, 18.0). Vérifié contre le code §3.3 (`z7pjabb6wh`) : tous ces tokens = 0 occurrences. La §3.3 fait un HMM 3-régimes (means 20/35/50) par **EP + Viterbi**. Référence réécrite à partir du contenu réel du notebook (no-pendulum).
2-4. **NAVIGATION** — 3 `## Exercice` non numérotés (idx38/56/59) cassaient la séquence 1..7 → `4bis` / `6bis` / `7bis`.
5. **LABELING (mineur)** — sous-titre §6 « de l'exercice » → « de l'exemple guide » (idx49 = vraie solution, gardée).
6-8. **OMISSION ×3 SVG** — bannières Graphviz fallback (idx17/35/53, bug #3473) → 3 caveats prose. Bénin.

## Vérifications
- 30+ claims numériques FIDÈLES (HMM §3.3 means/Viterbi 99.2%, météo, motif-finding, promo).
- §6 worked-solution intacte (2 InferenceEngine, `.Infer<`).
- **Gates** : G1 ordering 1 clean / G2 C.2 1/1 / G3 validate 0 Errors (Warning 1 = FP LaTeX pré-existant sur origin/main, baseline confirmée) / G4 diff markdown-only, submodules non touchés.
- Aucun changement model/output.

Closes #3519
See #3164
See #3473