### PR TITLE
fix(notebook_tools): scrub_papermill_paths handles non-ASCII paths

### DIFF
--- a/MyIA.AI.Notebooks/Search/Exploration_non_informée_et_informée_intro.ipynb
+++ b/MyIA.AI.Notebooks/Search/Exploration_non_informée_et_informée_intro.ipynb
@@ -1775,8 +1775,8 @@
    "end_time": "2026-05-14T20:06:50.946001+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Exploration_non_informée_et_informée_intro.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Exploration_non_informée_et_informée_intro_output.ipynb",
+   "input_path": "Exploration_non_informée_et_informée_intro.ipynb",
+   "output_path": "Exploration_non_informée_et_informée_intro.ipynb",
    "parameters": {},
    "start_time": "2026-05-14T20:06:44.855405+00:00",
    "version": "2.6.0"

--- a/scripts/notebook_tools/scrub_papermill_paths.py
+++ b/scripts/notebook_tools/scrub_papermill_paths.py
@@ -89,22 +89,29 @@ def scrub_notebook(nb_path, apply=False):
     fixed = []
     new_text = text
     for key, old_val in defects:
-        # Match the JSON substring regardless of quote style / spacing that
-        # json.dump may have produced. The value is a JSON string literal:
-        # escape backslashes present in the raw file form.
-        raw_old = json.dumps(old_val)  # exact JSON string literal as parsed
-        raw_new = json.dumps(basename)
-        needle = '"%s": %s' % (key, raw_old)
-        replacement = '"%s": %s' % (key, raw_new)
-        count = new_text.count(needle)
-        if count == 0:
-            # The on-disk literal differs from the parsed value (e.g. single
-            # quotes, spacing). Skip rather than risk a wrong edit.
+        # Match the JSON substring as it appears on disk. The value is a JSON
+        # string literal; Jupyter/papermill may store non-ASCII characters
+        # either literally (ensure_ascii=False) or escaped as \uXXXX
+        # (ensure_ascii=True). Build both candidate needles and use whichever
+        # occurs exactly once in the file. For pure-ASCII values both encodings
+        # are identical, so this is a no-op vs. the previous single-needle form.
+        candidates = []
+        seen = set()
+        for ensure_ascii in (False, True):
+            raw_old = json.dumps(old_val, ensure_ascii=ensure_ascii)
+            raw_new = json.dumps(basename, ensure_ascii=ensure_ascii)
+            needle = '"%s": %s' % (key, raw_old)
+            if needle in seen:
+                continue
+            seen.add(needle)
+            candidates.append((needle, '"%s": %s' % (key, raw_new)))
+        # Keep only needles that occur exactly once: count==0 means the on-disk
+        # literal differs (quote/spacing); count>1 is ambiguous (same path
+        # twice). Both are skipped to stay surgical.
+        matches = [(n, r) for (n, r) in candidates if new_text.count(n) == 1]
+        if len(matches) != 1:
             continue
-        if count > 1:
-            # Ambiguous: the same absolute path appears twice. Skip to stay
-            # surgical; flagged in scan output for manual review.
-            continue
+        needle, replacement = matches[0]
         new_text = new_text.replace(needle, replacement, 1)
         fixed.append((key, old_val))
 

--- a/scripts/notebook_tools/tests/test_scrub_papermill_paths.py
+++ b/scripts/notebook_tools/tests/test_scrub_papermill_paths.py
@@ -109,6 +109,56 @@ def test_scrub_handles_backslash_paths(tmp_path):
     assert after["metadata"]["papermill"]["output_path"] == "nb.ipynb"
 
 
+def test_scrub_handles_nonascii_path_stored_literally(tmp_path):
+    """Non-ASCII char stored literally (ensure_ascii=False) must be scrubbed.
+
+    Regression: the previous single-needle form built the needle with
+    json.dumps default (ensure_ascii=True), escaping the accent to \\uXXXX,
+    which never matched the literal accent on disk -> silent skip.
+    """
+    name = "Exploration_informée_intro.ipynb"
+    p = tmp_path / name
+    nb = {
+        "cells": [],
+        "metadata": {"papermill": {
+            "output_path": "D:\\dev\\CoursIA\\Exploration_informée_intro_output.ipynb",
+            "input_path": "D:\\dev\\CoursIA\\Exploration_informée_intro.ipynb",
+        }},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    # ensure_ascii=False -> the accent is written literally to disk.
+    p.write_text(json.dumps(nb, indent=1, ensure_ascii=False), encoding="utf-8")
+
+    defects, fixed = scrub_notebook(str(p), apply=True)
+    assert len(fixed) == 2
+    after = json.loads(p.read_text(encoding="utf-8"))
+    assert after["metadata"]["papermill"]["output_path"] == name
+    assert after["metadata"]["papermill"]["input_path"] == name
+
+
+def test_scrub_handles_nonascii_path_stored_escaped(tmp_path):
+    """Non-ASCII char stored escaped (\\uXXXX, ensure_ascii=True) must scrub too."""
+    name = "Exploration_informée_intro.ipynb"
+    p = tmp_path / name
+    nb = {
+        "cells": [],
+        "metadata": {"papermill": {
+            "output_path": "D:\\dev\\CoursIA\\Exploration_informée_intro_output.ipynb",
+        }},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    # ensure_ascii=True (default) -> the accent is written as \uXXXX on disk.
+    p.write_text(json.dumps(nb, indent=1, ensure_ascii=True), encoding="utf-8")
+    assert "\\u00e9" in p.read_text(encoding="utf-8")  # confirm escaped on disk
+
+    defects, fixed = scrub_notebook(str(p), apply=True)
+    assert len(fixed) == 1
+    after = json.loads(p.read_text(encoding="utf-8"))
+    assert after["metadata"]["papermill"]["output_path"] == name
+
+
 def test_scrub_dry_run_does_not_write(tmp_path):
     p = tmp_path / "nb.ipynb"
     _write_nb(p, pm={"output_path": "/tmp/nb_out.ipynb"})


### PR DESCRIPTION
## Probleme (verifie sur le source)

`scrub_papermill_paths.py` (l'outil de scrub #3435, Epic #3436) construisait son needle de recherche via `json.dumps(value)` — **defaut `ensure_ascii=True`**, qui echappe les caracteres accentues en `\uXXXX` (`scrub_papermill_paths.py:95`). Or les notebooks Jupyter stockent souvent les chemins **litteralement** (`ensure_ascii=False`, accent brut). Resultat : pour un notebook dont le chemin papermill contient un accent, le needle (`...informée...`) ne matchait jamais le fichier brut (`...informée...`) → l'outil **skippait silencieusement** (`fixed: 0, skipped: 2`).

Constate sur `Search/Exploration_non_informée_et_informée_intro.ipynb` : `--apply` rapportait `skipped: 2` et le chemin absolu (`D:\dev\CoursIA\...`) restait.

## Fix

Construire **les deux** needles candidats (`ensure_ascii=False` et `True`) et utiliser celui qui apparait **exactement une fois** dans le fichier brut.

- Valeur pure-ASCII → les deux encodages sont identiques (dedupliques) → **no-op** vs l'ancienne forme (aucune regression).
- Accent stocke litteral → le needle `ensure_ascii=False` matche.
- Accent stocke echappe → le needle `ensure_ascii=True` matche.
- Garde d'ambiguite (`count>1` = meme chemin deux fois → skip) et skip silencieux (`count==0` = quote/spacing differe → skip) **preserves** (filtre `count==1`).

## Tests

- +2 tests de regression : accent stocke **litteral** (`ensure_ascii=False`) et **echappe** (`ensure_ascii=True`), tous deux scrubbes vers le basename.
- Suite scrub : **12/12 OK** (10 existants + 2 nouveaux).

## Application

Applique au notebook qui revelait le bug : `Search/Exploration_non_informée_et_informée_intro.ipynb` (2 chemins absolus retires).

- `git diff` notebook : **2 ins / 2 del** symetriques, JSON valide, 0 churn outputs/exec_count.
- catalogue + submodule MGS **byte-identiques** a main.
- Debloque tout chemin accentue repo-wide pour la suite de #3436.

See #3436