### PR TITLE
fix(infer-12): audit fidélité #3164 Infer-12-Recommenders -- NAV/LABELING/ERREUR-FACTUELLE/SVG

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Recommenders.ipynb
@@ -1432,7 +1432,7 @@
     "\n",
     "Les traits utilisateurs proches de zéro indiquent un problème :\n",
     "\n",
-    "1. **Identifiabilité** : Avec seulement 8 observations pour 4 users × 5 items × 2 traits = 18 paramètres, le modèle est sous-déterminé\n",
+    "1. **Identifiabilité** : Avec seulement 8 observations pour (4 users + 5 items) × 2 traits = 18 paramètres, le modèle est sous-déterminé\n",
     "\n",
     "2. **Warnings du compilateur** :\n",
     "   - \"GaussianProductOp... has quality band Experimental\" → opérations numériquement instables\n",
@@ -1469,7 +1469,9 @@
     "- **Observations** : `rating[obs]` sont les notes observees, conditionnees par l'affinite et la precision du bruit\n",
     "- **Hyperparametre** : `noisePrecision` controle la variance des observations\n",
     "\n",
-    "Ce modele suppose que les preferences sont expliquees par un petit nombre de **traits latents** (ici 2), permettant de generaliser a des paires (user, item) non observees."
+    "Ce modele suppose que les preferences sont expliquees par un petit nombre de **traits latents** (ici 2), permettant de generaliser a des paires (user, item) non observees.\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`). Le moteur genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais affiche a la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -2633,12 +2635,14 @@
     "\n",
     "Le graphe ci-dessous montre le modele de factorisation **ameliore** avec :\n",
     "\n",
-    "- **Plus de donnees** : 20 observations au lieu de 8, avec un pattern clair (2 groupes d'utilisateurs)\n",
+    "- **Plus de donnees** : 15 observations au lieu de 8, avec un pattern clair (2 groupes d'utilisateurs)\n",
     "- **Biais global** : `globalBias2` capture la moyenne generale des notes\n",
-    "- **Priors plus larges** : Precision 0.5 au lieu de 1.0 pour permettre plus de variation dans les traits\n",
+    "- **Priors plus larges** : Precision 0.1 au lieu de 1.0 pour permettre plus de variation dans les traits\n",
     "- **Structure identique** : Toujours `U[user,trait] * V[item,trait]` pour l'affinite\n",
     "\n",
-    "Le modele corrige devrait montrer des traits latents plus informatifs grace au ratio observations/parametres ameliore."
+    "Le modele corrige devrait montrer des traits latents plus informatifs grace au ratio observations/parametres ameliore.\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`). Le moteur genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais affiche a la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -4041,7 +4045,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Cold-Start avec un Nouvel Item\n",
+    "## 5bis. Exercice : Cold-Start avec un Nouvel Item\n",
     "\n",
     "Dans la section 5, nous avons predit les scores pour un **nouvel utilisateur**. Maintenant, traitez le cas dual : un **nouvel item** sans aucune note.\n",
     "\n",
@@ -5100,7 +5104,7 @@
     "**Observations** :\n",
     "\n",
     "1. **Cohérence sources** : Jugements et clics/échelle sont très proches → bonne calibration\n",
-    "2. **Doc 2 ajusté** : Juge=4.0, Clics/27≈3.5 → score final 3.54 (plus proche des clics car plus précis en nombre absolu)\n",
+    "2. **Doc 2 ajusté** : Juge=4.0, Clics/échelle≈3.53 → score final 3.54 (score intermédiaire entre les deux sources)\n",
     "3. **Incertitude croissante** : Les documents mieux notés ont plus d'incertitude (variance proportionnelle au score)"
    ]
   },
@@ -5127,7 +5131,9 @@
     "- **Source 2 - Clics** : `obsClic[doc]` avec precision faible (`precClic` ~ 1) et facteur d'echelle\n",
     "- **Fusion bayesienne** : Le modele pondere automatiquement les sources selon leur fiabilite\n",
     "\n",
-    "Ce pattern est generalizable a N sources d'information (temps de lecture, partages, etc.)."
+    "Ce pattern est generalizable a N sources d'information (temps de lecture, partages, etc.).\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`). Le moteur genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais affiche a la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -5375,7 +5381,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Ajouter une Troisieme Source au Click Model\n",
+    "## 6bis. Exercice : Ajouter une Troisieme Source au Click Model\n",
     "\n",
     "Le Click Model de la section 6 fusionne **deux sources** (jugements experts et clics). Etendez-le a une **troisieme source** : le temps de lecture moyen en secondes.\n",
     "\n",
@@ -5477,7 +5483,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Predire la Note d'un Utilisateur pour un Film Non Note\n",
+    "## 6ter. Exercice : Predire la Note d'un Utilisateur pour un Film Non Note\n",
     "\n",
     "Dans les sections 3-4, nous avons construit un modele de factorisation matricielle bayesienne et predit les notes manquantes. Utilisez cette architecture pour construire un **mini-systeme de recommandation** sur une nouvelle matrice de notes.\n",
     "\n",
@@ -6153,7 +6159,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Exemple guide : Recommandation de Musique\n",
+    "## 8bis. Exercice : Recommandation de Musique\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -6204,7 +6210,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Recommandation de musique - factorisation matricielle\n",
+    "// Exercice : Recommandation de musique - factorisation matricielle\n",
     "// Notes sur 1-5, double.NaN = non ecoute\n",
     "int nUsers = 5;\n",
     "int nSongs = 6;\n",


### PR DESCRIPTION
## Résumé

Audit fidélité prose-vs-outputs (Epic #3164) de `MyIA.AI.Notebooks/Probas/Infer/Infer-12-Recommenders.ipynb` (filtrage collaboratif bayésien, factorisation matricielle Infer.NET). **Markdown-only**, 9 défauts corrigés.

**Notebook substantively bon** : 0 INVENTION, 20+ claims FIDÈLES, modèle dégénéré honnêtement diagnostiqué.

### Défauts corrigés
- **NAVIGATION ×4** : doublon `## 8.` (idx76 Resume / idx78 Musique → `## 8bis.`) + 3 `## Exercice` non numérotés (idx48/65/67 → `## 5bis.`/`## 6bis.`/`## 6ter.`, no cascade).
- **LABELING / pathologie n°5 ×1** : idx78/79 « Exemple guide : Musique » = stub creux (3 TODO + `Console.WriteLine("Exercice a completer")`, 0 InferenceEngine) → relabel header + commentaire « Exercice ». Résout aussi le doublon `## 8.`.
- **ERREUR-FACTUELLE ×4** :
  - idx18 : `4 users × 5 items × 2 traits = 18` (4×5×2=40) → formule additive `(4 users + 5 items) × 2 traits = 18`.
  - idx29 : `20 observations` → **15** (output idx23).
  - idx29 : prior `0.5` → **0.1** (code idx25 `priorPrec=0.1`).
  - idx59 : raisonnement Click Model inversé (`precJuge 4.50` >> `precClic 0.99`, donc juges dominent) → « score intermédiaire entre les deux sources ».
- **OMISSION SVG ×3** : caveat Graphviz (idx19/29/60) pour le fallback honnête `dot` absent (#3473).

### Laissé intact
- **§7 Films (idx72)** = exemple guide génuine (réutilise les postérieurs §3, 23 outputs réels) — NE PAS stubber.

### Gates
- G1 : 1 finding `DANGLING_INTRO` cell#44 = **pré-existant origin/main** (hors scope, cellule non touchée)
- G2 : **1/1 compliant**
- G3 : **0 Errors** (1 Warning = FP LaTeX `$`-balance pré-existant cells 14/21/31)
- G4 : 18 ins / 12 del, 1 fichier, **0 ligne execution_count/outputs**, submodules non stagés

Closes #3523
See #3164
See #3473

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>