### PR TITLE
docs(symbolicai): remove "Ponts cross-séries" anti-pattern (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -532,51 +532,6 @@ Le setup est entierement automatisé via `Tweety-1-Setup.ipynb` :
 
 ---
 
-## Ponts cross-séries
-
-Ces connexions entre séries sont exploitees dans le curriculum IA Symbolique.
-
-### Lean <-> GameTheory (Choix social)
-
-| Concept Lean | Concept GameTheory | Notebooks |
-|-------------|-------------------|-----------|
-| Theoreme d'Arrow (preuve formelle) | Theorie du vote / Choix social | `GameTheory/social_choice_lean/SocialChoice/Arrow.lean` <-> `GameTheory/GameTheory-16-MechanismDesign.ipynb` |
-| Theoreme de Sen (preuve formelle) | Impossibilite du paretien liberal | `GameTheory/social_choice_lean/SocialChoice/Sen.lean` <-> `GameTheory/GameTheory-16-MechanismDesign.ipynb` |
-| Valeur de Shapley | Coalitions, jeux cooperatifs | `GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb` <-> `GameTheory/GameTheory-15-CooperativeGames.ipynb` |
-
-### Lean <-> SmartContracts (Verification formelle)
-
-| Concept | Pont | Notebooks |
-|---------|------|-----------|
-| Theorie des types dependants | Verification formelle de contrats | `Lean/Lean-1-Setup.ipynb` (types) <-> `SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb` |
-| Preuves LLM-assistees | Contrats LLM-assistes | `Lean/Lean-8-Agentic-Proving.ipynb` <-> `SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb` |
-| `sorry` = axiome non prouve | Bugs de contrats non detectes | Concepts paralleles d'incompletude |
-
-### Tweety <-> Argument_Analysis (Argumentation)
-
-| Concept Tweety | Concept Argument_Analysis | Notebooks |
-|---------------|--------------------------|-----------|
-| Frameworks de Dung | Argumentation multi-agents | `Tweety/Tweety-5-Abstract-Argumentation.ipynb` <-> `Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb` |
-| ASPIC+ (argumentation structuree) | Analyse LLM d'arguments | `Tweety/Tweety-6-Structured-Argumentation.ipynb` <-> `Argument_Analysis/Argument_Analysis_Agentic-3-orchestration.ipynb` |
-| Dialogues d'agents | Debat multi-agent | `Tweety/Tweety-8-Agent-Dialogues.ipynb` <-> `Argument_Analysis/Argument_Analysis_Executor.ipynb` |
-
-### SemanticWeb <-> SmartContracts (Decentralisation)
-
-| Concept | Pont | Notebooks |
-|---------|------|-----------|
-| Ontologies RDF/OWL | Gouvernance DAO (etat canonique) | `SemanticWeb/SW-7-CSharp-OWL.ipynb` <-> `SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb` |
-| GraphRAG | Indexation on-chain | `SemanticWeb/SW-12-Python-GraphRAG.ipynb` <-> SmartContracts DeFi indexing |
-| SHACL (validation) | Smart contract verification | `SemanticWeb/SW-8-Python-SHACL.ipynb` <-> `SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb` |
-
-### Planners <-> SmartContracts (Coordination)
-
-| Concept | Pont | Notebooks |
-|---------|------|-----------|
-| Planification multi-agent | MEV / auctions cross-chain | `Planners/03-Advanced/Planners-9-HTN.ipynb` <-> SmartContracts MEV |
-| CP-SAT (OR-Tools) | Optimisation sous contraintes (DeFi) | `Planners/03-Advanced/Planners-7-OR-Tools.ipynb` <-> `SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb` |
-
----
-
 ## Ressources
 
 ### References academiques


### PR DESCRIPTION
## Summary

Removes the **`## Ponts cross-séries`** section from `SymbolicAI/README.md`. This multi-family cross-coupling section (Lean↔GameTheory, Lean↔SmartContracts, Tweety↔Argument_Analysis, SemanticWeb↔SmartContracts, Planners↔SmartContracts) is an acknowledged anti-pattern — the exact "ponts copiés-collés" pattern documented as anti-pattern #3 in [`docs/reference/readme-series-gabarit.md:66`](docs/reference/readme-series-gabarit.md).

**Why remove:** cross-series coupling + redundant navigation (every notebook listed is already discoverable via its own sub-README — verified) + stale-link risk. The canonical centralized hub now lives in `MyIA.AI.Notebooks/cross-series/`.

Part of repo-wide cleanup following precedents: GenAI (`#3514`, `#3275`), SmartContracts (`#3270`).

## Changes (surgical)
- **1 file, 45 deletions, 0 insertions** — pure removal, no reflow.
- Python targeted edit preserves LF line endings (no CRLF churn).

## Validation (G.1 grounded)
- `0` "cross-séries" occurrences remain in `SymbolicAI/README.md`
- **93 internal links** in the edited README all resolve (`pathlib.exists`), **0 missing**
- **0 orphaned inbound references** to the removed section (grep repo-wide)
- Notebooks the bridges pointed to remain discoverable via their own sub-READMEs (`Lean/README.md` lists Lean-1/Learn-8; `GameTheory/README.md` lists GT-15/15b/16)

## Scope (atomic, HARD 3)
This PR touches only the `SymbolicAI/` **root** README (po-2026 direct domain). Sub-READMEs with residual `## Connections cross-series` sections (Lean, SemanticWeb, SmartContracts) and other families (GameTheory, ML, QuantConnect) are **separate PRs** — not bundled here.

See #2651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)