### PR TITLE
fix(genai-texte-08): real-execute 3 exercise stubs for H.3 gate (unblock #3511)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -778,8 +778,14 @@
    "id": "37f1fa82",
    "source": "# Exercice 1 : Chain-of-thought manuel vs automatique\n# TODO etudiant : Comparer prompt direct vs prompt chain-of-thought sur un calcul multi-etapes\n# - Definir un probleme : \"Un article coute 80EUR. TVA 20%, puis remise 15% sur le prix TTC, puis frais de port 5EUR. Prix final?\"\n# - Prompt direct : \"Calcule le prix final. Donne uniquement le nombre.\"\n# - Prompt CoT : \"Resous etape par etape en montrant chaque calcul intermediaire.\"\n# - Comparer les deux reponses avec la reponse correcte (80*1.2*0.85+5 = 86.60 EUR)\n\ndirect_prompt = None  # TODO etudiant : definir le prompt direct\ncot_prompt = None     # TODO etudiant : definir le prompt chain-of-thought\n\n# Indice : reponse correcte = 80 * 1.20 * 0.85 + 5 = 86.60 EUR\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 1,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1270,8 +1276,14 @@
    "id": "8f3485d1",
    "source": "# Exercice 2 : Comparaison multi-niveau sur un probleme complexe\n# TODO etudiant : Implementer un benchmark qui compare reasoning_effort low/medium/high\n# - Definir un probleme de logique (ex: \"Tu as un bidon de 5L et un de 3L. Comment obtenir exactement 4L?\")\n# - Boucler sur [\"low\", \"medium\", \"high\"]\n# - Pour chaque niveau : mesurer le temps, appeler le modele, extraire la reponse\n# - Stocker les resultats dans une liste de dicts {\"effort\", \"time\", \"answer\"}\n# - Afficher un tableau comparatif avec la reponse correcte\n\nresults = None  # TODO etudiant : implementer le benchmark\n\n# Indice : utiliser time.time() pour mesurer, et extra_body={\"reasoning_effort\": effort}\n# pour activer le mode reasoning\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 1,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1881,8 +1893,14 @@
    "id": "7ad3a8ab",
    "source": "# Exercice 3 : Verification de reponse par raisonnement\n# TODO etudiant : Implementer une fonction verify_answer(problem, claimed_answer)\n# - Construit un prompt : \"Verifie si cette reponse est correcte. Probleme: {problem}. Reponse proposee: {claimed_answer}\"\n# - Utilise le modele reasoning avec reasoning_effort='medium'\n# - Retourne un dict {\"verdict\": \"CORRECT\"|\"INCORRECT\", \"explanation\": \"...\"}\n\ndef verify_answer(problem, claimed_answer):\n    return None  # TODO etudiant : implementer\n\n# Test :\n# result = verify_answer(\"Combien font 17 * 23?\", \"391\")\n# print(f\"Verdict: {result['verdict']}, Explication: {result['explanation']}\")\n# result2 = verify_answer(\"Combien font 17 * 23?\", \"400\")\n# print(f\"Verdict: {result2['verdict']}, Explication: {result2['explanation']}\")\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 1,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Context

ai-01 directive (23:11Z, burst-mode): PR **#3511** (po-2026, `docs(genai-texte-08): anchor reasoning-models inline citations` — audit #3164) is blocked by the **H.3 static-validation gate** on 3 pre-existing null-exec exercise stubs in `8_Reasoning_Models.ipynb` (cells 14/24/34). The citation diff is markdown-only and unrelated to these stubs. As GenAI/Texte family host (po-2023), I execute the stubs on main so po-2026 can rebase #3511 cleanly.

## Fix

Same pattern as #3493 (Video/02-4-SVD, merged this cycle). The 3 stubs are student exercise scaffolds whose only executable statement is `print("Exercice a completer")` module-level (plus `None` assignments and one `def` returning `None`). No GPU, no API call — they execute cleanly in plain Python.

Each stub was **REAL-executed in isolation** (not injected): `exec(compile(src, ...))` → `execution_count=1` + genuine stdout `"Exercice a completer\n"`. Honest per rule H (real execution, no complacency).

## Validation

- `validate_pr_notebooks.py origin/main <nb>`: **1/1 PASS** (14/14 cells, was the FAIL blocking #3511)
- `notebook_tools.py validate`: **OK** (0 errors)
- `nbformat.validate`: **OK**
- **C.3 by cell-id**: exactly 3 cells changed `(None, 0) -> (1, 1)`, 37=37 total cells, 0 source modification. Numstat 25/-7 = local json reflow, not content churn.
- Catalogue: untouched (byte-identical to main).

## After merge

po-2026 rebase #3511 onto main → H.3 gate green → #3511 mergeable with the citation diff.

See #3511, refs #3164, refs #2161.