### PR TITLE
fix(infer-13): audit fidelite #3164 Infer-13-Debugging -- NAV/LABELING

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-13-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-13-Debugging.ipynb
@@ -1039,7 +1039,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Diagnostic d'un modele de melange gaussien\n",
+    "## Exercice 1 : Diagnostic d'un modele de melange gaussien\n",
     "\n",
     "**Objectif** : Identifiez et corrigez les problemes dans un modele de melange gaussien a 2 composantes.\n",
     "\n",
@@ -2107,7 +2107,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice : Impact du prior sur un diagnostic medical\n",
+    "### Exercice 2 : Impact du prior sur un diagnostic medical\n",
     "\n",
     "**Objectif** : Modeliser un test de depistage avec des priors differents et observer l'impact sur le diagnostic posterieur.\n",
     "\n",
@@ -2878,7 +2878,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Exemple guide : Deboguer un Modele Hierarchique Casse\n",
+    "## Exercice 3 : Deboguer un Modele Hierarchique Casse\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -2922,7 +2922,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Corriger ce modele hierarchique bayesien (3 erreurs)\n",
+    "// Exercice : Corriger ce modele hierarchique bayesien (3 erreurs)\n",
     "int nGroupes = 3;\n",
     "int nObs = 4;\n",
     "double[][] donneesGroupes = {\n",
@@ -3017,7 +3017,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice : Debugging d'un modele de regression bayesienne\n",
+    "### Exercice 4 : Debugging d'un modele de regression bayesienne\n",
     "\n",
     "**Objectif** : Identifiez et corrigez les problemes dans un modele de regression lineaire bayesienne qui produit des posterieurs degeneres.\n",
     "\n",


### PR DESCRIPTION
Audit de fidelite (Epic #3164) du notebook **Infer-13-Debugging**. **12e notebook Infer audite.**

## Verdict : le notebook le plus propre de la serie Infer-2..13
- **0 INVENTION**, **0 ERREUR-FACTUELLE**, **0 OMISSION**.
- Graphviz disponible (idx6 -> `True`) : les 4 graphes de facteurs (idx10/20/25/38) rendent un vrai `<svg>` -> **pas de fallback #3473**, aucun caveat necessaire (1er notebook Infer dans ce cas).
- Spot-checks fideles : idx9 (3/sqrt(1000)~0.1), idx17 (VMP var 0.077 < EP 0.081), idx30 (Beta(8,2)->0.733), idx36 (moyenne 2.73 / var 0.91), idx41 (Gaussian(49.5, prec 0.98)).

## 5 defauts corriges (markdown + 1 commentaire code, **0 execution_count/outputs touche**)
| idx | cat | correctif |
|-----|-----|-----------|
| 19 | NAV | `## Exercice` -> `## Exercice 1` |
| 32 | NAV | `### Exercice` -> `### Exercice 2` |
| 44 | NAV doublon + LABELING n5 | `## 8. Exemple guide ...` -> `## Exercice 3` (resout le doublon `## 8.` avec idx43 Resume ET le mauvais label d'un stub) |
| 45 | LABELING | commentaire `// Exemple guide ...` -> `// Exercice ...` (le code est un stub : 6 TODO + `Console.WriteLine("Exercice a completer")`, 0 inference) |
| 47 | NAV | `### Exercice` (apres Conclusion) -> `### Exercice 4` |

Les 4 exercices sont renumerotes **Exercice 1..4** (namespace distinct des sections de contenu 1..8) -> un seul schema coherent resout le doublon `## 8.`, les 3 headers non numerotes, et la pathology n5 de idx44/45.

## Cross-check G.1 (parent)
- **idx23** `Gaussian(2.5, 0.5)` = FIDELE : format Infer.NET `(mean, variance)`, variance 0.5 = 1/tau_post = 1/2, prose correcte (borderline du sub-agent leve -> KEEP).
- **idx40** = vrai exemple guide (IE=2, `.Infer<`=2, 0 TODO) laisse intact ; son `Console.WriteLine` interne **non modifie** (eviter de desyncer l'output commit -> C.2). [Le sub-agent l'avait propose ; ecarte par le parent.]

## Gates
- G1 ordering : **1 clean, 0 finding**
- G2 C.2 : **1/1 compliant**
- G3 validate : **0 Errors** (Warning 1 = FP LaTeX `$$` pre-existant idx23, baseline origin/main identique)
- exos : **conforme** (>=3)
- G4 git diff : **5 ins / 5 del, 1 fichier**, 0 ligne execution_count/outputs, submodules `Automata`/`Z3.Linq` non stages

Closes #3535
See #3164