### PR TITLE
fix(csp-5): correct knapsack/cutting-stock interpretation errors (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
@@ -680,7 +680,7 @@
     "**Points cles** :\n",
     "1. **Capacité saturée** : Le sac est rempli à 100% de sa capacité (20/20)\n",
     "2. **Optimalité garantie** : CP-SAT garantit que 26 est la valeur maximale possible\n",
-    "3. **Stratégie de sélection** : Les objets 4, 5, 6 ne sont pas sélectionnés car leur rapport valeur/poids est moins favorable\n",
+    "3. **Stratégie de sélection** : Le choix n'est pas dicté par le seul ratio v/w — les objets 4 (1.11) et 6 (1.13) ont un meilleur ratio que l'objet 7 (1.00) retenu, mais ne tiennent pas dans la combinaison qui sature exactement la capacité (2+3+4+5+6=20). Le Knapsack 0/1 maximise la valeur sous contrainte de capacité, pas le ratio\n",
     "4. **Complexité 0/1** : Chaque objet est soit pris entièrement (1), soit laissé (0) - pas de sélection partielle\n",
     "\n",
     "> **Note technique** : Le Knapsack 0/1 est NP-hard, mais existe une version \"fractionnelle\" (où on peut prendre des fractions d'objets) qui est résoluble en O(n log n) par un algorithme glouton basé sur le ratio valeur/poids. La version 0/1 nécessite une approche CP/PLNE ou de programmation dynamique."
@@ -986,7 +986,7 @@
     "- **Barre 0** : 1×20cm + 1×25cm + 1×30cm = 75cm (25cm de perte)\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Optimalité** : 4 barres est le minimum théorique pour ces demandes (poids total des pièces : 20×5 + 25×3 + 30×4 + 40×2 = 380cm, donc au moins 4 barres de 100cm)\n",
+    "1. **Optimalité** : 4 barres est le minimum théorique pour ces demandes (poids total des pièces : 20×5 + 25×3 + 30×4 + 40×2 = 375cm, donc au moins 4 barres de 100cm)\n",
     "2. **Efficacité globale** : 375cm utilisés / 400cm disponibles = 93.75% d'efficacité\n",
     "3. **Gaspillage minimal** : Seulement 25cm perdus sur 4 barres (6.25%)\n",
     "4. **Patterns diversifiés** : Le solveur trouve 3 patterns optimaux différents pour maximiser l'efficacité\n",


### PR DESCRIPTION
## Audit fidelite #3164 — CSP-5-Optimization (Search/Part2-CSP)

Deux erreurs factuelles markdown, contredites par les **donnees de la cellule / l'output committe** (markdown-only) :

| Cellule MD | Defaut | Correction |
|-----------|--------|-----------|
| idx14 (Knapsack 0/1) | point 3 : objets 4/5/6 non retenus "car ratio v/w moins favorable" — or l'objet 7 retenu a ratio 1.00 < obj 4 (1.11) et obj 6 (1.13) ; selection committee `[0,1,2,3,7]` sature exactement la capacite (2+3+4+5+6=20) | reformule : choix **combinatoire** sous contrainte de capacite, pas un tri par ratio |
| idx21 (Cutting Stock) | point 1 : "20×5 + 25×3 + 30×4 + 40×2 = **380cm**" — somme reelle 100+75+120+80 = **375cm** (le point 2 de la meme cellule utilise deja 375cm ; output committe = 375cm utilises) | 380 → 375 |

### Verification
- `git diff --stat` : **2 insertions / 2 deletions**, 1 fichier (markdown-only).
- 0 ligne `execution_count`/`outputs`/`output_type` ; 0 cellule `code` touchee.
- Code + outputs committes **byte-identiques**.
- Catalogue + submodule MGS **byte-identiques** a `main` ; branche fraiche depuis `origin/main`.
- Valeurs cibles ancrees sur l'output committe (375cm utilises) et les donnees de la table elle-meme (ratios). No-pendulum.

### Hors scope (signale, non corrige ici)
- **idx30 (Bin Packing)** : la cellule narre "FFD trouve 3 bins < optimal CP-SAT 5 bins" — une heuristique gloutonne **ne peut pas** battre un optimal CP-SAT prouve : c'est un **bug de code** (heuristique FFD), pas un fix markdown. Issue code separee a ouvrir.

Closes #3541
See #3164