### PR TITLE
docs(ml-7): anchor recommender-system citations + add References (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
@@ -535,7 +535,7 @@
    "source": [
     "## Matrix Factorization avec ML.NET\n",
     "\n",
-    "**Matrix Factorization** décompose la matrice utilisateur-item en deux matrices de plus faible rang :\n",
+    "**Matrix Factorization** (Koren, Bell & Volinsky, 2009) décompose la matrice utilisateur-item en deux matrices de plus faible rang :\n",
     "\n",
     "```\n",
     "Matrice originale (U × I) = Matrice Utilisateur (U × K) × Matrice Item (K × I)\n",
@@ -1068,7 +1068,7 @@
    },
    "outputs": [],
    "source": [
-    "## Le Cold Start Problem\n",
+    "## Le Cold Start Problem (Schein et al., 2002)\n",
     "\n",
     "**Problème** : Comment recommander à un nouvel utilisateur ou pour un nouvel item ?\n",
     "\n",
@@ -1250,7 +1250,7 @@
    "source": [
     "## Exemple 2 : Recommandation de produits E-commerce\n",
     "\n",
-    "Adaptons le système pour un scénario e-commerce avec des achats (binary : acheté/pas acheté)."
+    "Adaptons le système pour un scénario e-commerce avec des achats (binary : acheté/pas acheté) - le cadre du **feedback implicite** (Hu, Koren & Volinsky, 2008)."
    ]
   },
   {
@@ -1706,6 +1706,29 @@
     "Console.WriteLine(\"\\n=== Cold Start - Recommandations pour nouvel utilisateur ===\");\n",
     "// Utiliser la moyenne globale des livres\n",
     "List<(int bookId, float score)> topBooks = null; // Livres les mieux notés globalement"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "refs-bibliography-ml7",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "**Matrix Factorization et Collaborative Filtering**\n",
+    "- Koren, Y., Bell, R., & Volinsky, C. (2009). *Matrix Factorization Techniques for Recommender Systems*. IEEE Computer, 42(8), 30-37. — référence canonique du collaborative filtering par factorisation, issue du Netflix Prize.\n",
+    "- Hu, Y., Koren, Y., & Volinsky, C. (2008). *Collaborative Filtering for Implicit Feedback Datasets*. IEEE ICDM. — cadre du feedback implicite (achats binaires de l'Exemple 2).\n",
+    "- Sarwar, B., Karypis, G., Konstan, J., & Riedl, J. (2001). *Item-Based Collaborative Filtering Recommendation Algorithms*. WWW.\n",
+    "\n",
+    "**Problème du démarrage à froid (Cold Start)**\n",
+    "- Schein, A. I., Popescul, A., Ungar, L. H., & Pennock, D. M. (2002). *Methods and Metrics for Cold-Start Recommendations*. ACM SIGIR.\n",
+    "\n",
+    "**Implémentation (ML.NET / LIBMF)**\n",
+    "- Chin, W.-S., Zhuang, Y., Juan, Y.-C., & Lin, C.-J. (2015). *A Fast Parallel Stochastic Gradient Method for Matrix Factorization in Shared Memory Systems*. ACM TIST. — bibliothèque LIBMF, moteur du `MatrixFactorizationTrainer` de ML.NET.\n",
+    "- Ahmed, Z., et al. (2019). *Machine Learning at Microsoft with ML.NET*. ACM SIGKDD (KDD).\n",
+    "\n",
+    "**Contexte historique**\n",
+    "- Bennett, J., & Lanning, S. (2007). *The Netflix Prize*. KDD Cup and Workshop."
    ]
   }
  ],


### PR DESCRIPTION
## Audit fidélité #3164 — ML-7-Recommendation (famille ML.Net)

Premier grain **ML.Net** de l'audit #3164 (après la famille PyMC, 20/20 mergée). Profil **OMISSION pure** : le notebook enseigne des techniques nommées **sans aucune citation inline ni section References** — comme toute la famille ML.Net (peek : SDCA, LightGBM, FastTree, AutoML, SSA, Matrix Factorization → 0 citation, 0 bibliographie sur ML-1/3/5/7).

### Verdict : 3 OMISSIONS (classe c) ancrées + section References créée, 0 erreur factuelle, 0 REINVENTION

| Point d'enseignement | Citation canonique ancrée |
|---|---|
| `## Matrix Factorization` (sujet central, cell 8) | **Koren, Bell & Volinsky 2009** — la référence MF-pour-recommandeurs, issue du Netflix Prize |
| `## Le Cold Start Problem` (section dédiée, cell 18) | **Schein et al. 2002** |
| Exemple 2 e-commerce binaire acheté/pas-acheté (cell 22) | **Hu, Koren & Volinsky 2008** (feedback implicite) |

**Section References ajoutée** (7 entrées, aucune n'existait) : + Sarwar et al. 2001 (CF item-based), **Chin et al. 2015** (LIBMF — moteur réel du `MatrixFactorizationTrainer` de ML.NET), Ahmed et al. 2019 (ML.NET), Bennett & Lanning 2007 (Netflix Prize).

### Discipline G.1 / G.5
- **Centralité gouverne** : MF/Cold-Start/feedback-implicite ont un traitement pédagogique dédié (section `##`) → ancres garanties. **RMSE/MAE = métriques intro → pas d'ancre**. **ML.NET = outil incidental dans CE notebook → References-only** (pas d'ancre inline ; cohérent avec PyMC-18 incidental trimmé).
- **Point d'enseignement, pas l'intro** : pas d'ancre dans les objectifs (cell 0) ni le résumé — uniquement au lieu où la technique est définie.
- **Citations vérifiées** : toutes réelles (Koren 2009 IEEE Computer 42(8), Hu 2008 ICDM, Schein 2002 SIGIR, Sarwar 2001 WWW, Chin 2015 ACM TIST/LIBMF, Ahmed 2019 KDD, Bennett 2007). 0 erreur factuelle introduite.

### Validation
- **Markdown-only** (+27/-4) — 3 remplacements inline + 1 cellule References appendée.
- C.2/C.3 : **0 churn** `execution_count`/`outputs` (16 cellules code intactes) · C.1 = 0 · `scan_cell_ordering` clean · catalogue **byte-identique** à `origin/main` · branche fraîche `origin/main`.
- **Repo CI validator (`notebook_tools.py validate`) : OK** (exit 0).
- **Note hygiène (follow-up, hors scope)** : les 10 cellules markdown portent un artefact papermill pré-existant (`execution_count`/`outputs` sur cellules markdown) qui fait échouer le **strict** `nbformat.validate` — présent **identique sur `origin/main`**, non introduit par ce diff. À traiter en passe hygiène dédiée (atomicité).

See #3164
