### PR TITLE
fix(qc-py-14): correct Resolution.Weekly rebalance idiom (cell 13) + real metrics (cell 14) — See #3367

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -406,13 +406,13 @@
     "        # Portfolio Construction avec rebalancement hebdomadaire\n",
     "        self.SetPortfolioConstruction(\n",
     "            EqualWeightingPortfolioConstructionModel(\n",
-    "                rebalance=Resolution.Weekly  # Rebalancer chaque semaine\n",
+    "                rebalance=Expiry.EndOfWeek  # Rebalancer chaque semaine\n",
     "            )\n",
     "        )\n",
     "        \n",
     "        # Alternatives de rebalancement:\n",
     "        # rebalance=Resolution.Daily     # Quotidien\n",
-    "        # rebalance=Resolution.Monthly   # Mensuel\n",
+    "        # rebalance=timedelta(days=30)   # Mensuel\n",
     "        # rebalance=Expiry.EndOfMonth    # Fin de mois\n",
     "        # rebalance=lambda time: time.day == 1  # Premier du mois\n",
     "        \n",
@@ -424,8 +424,8 @@
     "print(\"EqualWeightWithRebalance defini\")\n",
     "print(\"\\nOptions de rebalancement:\")\n",
     "print(\"  - Resolution.Daily\")\n",
-    "print(\"  - Resolution.Weekly\")\n",
-    "print(\"  - Resolution.Monthly\")\n",
+    "print(\"  - Expiry.EndOfWeek\")\n",
+    "print(\"  - timedelta(days=30)\")\n",
     "print(\"  - Expiry.EndOfMonth\")\n",
     "print(\"  - Custom lambda function\")"
    ]
@@ -434,13 +434,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Resultat Backtest QC Cloud** (Cellule 12) -- *corrige #3367 : strategie non executable (code de reference invalide)*\n",
+    "> **Resultat Backtest QC Cloud** (Cellule 12) -- *corrige #3367 : idiome de rebalancement corrige + metriques reelles*\n",
     ">\n",
     "> | Metrique | Valeur |\n",
     "> |----------|-------|\n",
-    "> | Statut | Runtime Error (code de reference invalide) |\n",
+    "> | Statut | Completed |\n",
+    "> | Sharpe Ratio | 0.49 |\n",
+    "> | CAGR | 9.704% |\n",
+    "> | Max Drawdown | 25.700% |\n",
+    "> | Probabilistic Sharpe Ratio | 11.723% |\n",
     ">\n",
-    "> *Correctif #3367 : le bloc precedent affichait Sharpe 1.912 / CAGR 36.493% / End Equity $107938.48 -- valeurs **fabriquees** (End Equity $107,938 sur 10 ans = +0.77% de CAGR, incompatible avec 36.493% affiche). Verification QC Cloud (projet 33072122) : le code de reference de la cellule precedente utilise `EqualWeightingPortfolioConstructionModel(rebalance=Resolution.Weekly)`, or **`Resolution.Weekly` n'existe pas** (l'enum Resolution ne contient que Tick / Second / Minute / Hour / Daily). Le backtest echoue a l'initialisation : `type object 'Resolution' has no attribute 'Weekly'`. Aucune metrique reelle ne peut etre produite sans corriger l'idiome de rebalancement (ex: `Expiry.EndOfWeek` ou `timedelta(days=7)`) -- une correction de code distincte du scope #3367 (corriger les metriques fabriquees). Cette note documente la realite verifiee plutot que d'inventer des chiffres.*"
+    "> *Correctif #3367 : le code de reference de la cellule precedente utilisait `EqualWeightingPortfolioConstructionModel(rebalance=Resolution.Weekly)`, or `Resolution.Weekly` n'existe pas (l'enum Resolution ne contient que Tick / Second / Minute / Hour / Daily) -- la strategie echouait a l'initialisation (Runtime Error, cf. correctif #3522). L'idiome est corrige en `Expiry.EndOfWeek` (rebalancement hebdomadaire aligne sur la fin de semaine). Le backtest aboutit desormais : metriques reelles ci-dessus obtenues par redeploiement de l'algorithme corrige sur QC Cloud (projet 33072122, 2015-2024, $100k). Les champs Sortino / Total Orders / Trades / Win Rate / Total Fees sont omis car non fournis de maniere fiable par l'API read_backtest. Pour memoire, le bloc d'origine affichait Sharpe 1.912 / CAGR 36.493% / End Equity $107938.48 -- des valeurs fabriquees et internement contradictoires (End Equity $107,938 sur 10 ans = +0.77% de CAGR, incompatible avec 36.493%).*\n",
+    ">\n",
+    "> *Backtest ID: 62cb1805751563f907002edd3a9fddde*"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Follow-up to #3522 (which closed the NB14 #3367 cat-3 sweep). Cell 14 was the one cell I had to leave documented as a **Runtime Error** rather than real metrics, because the cell-13 reference code used an idiom that does not exist:

```python
EqualWeightingPortfolioConstructionModel(rebalance=Resolution.Weekly)
```

`Resolution` has no `Weekly` member (the enum is Tick/Second/Minute/Hour/Daily) → the strategy threw at init. ai-01 flagged this as the next deep-queue grain. This PR closes it.

See #3367.

### cell 13 — reference code (non-executable here): correct every invalid `Resolution.*` idiom

| Location | Before (invalid) | After (valid) |
|----------|------------------|---------------|
| active line | `rebalance=Resolution.Weekly` | `rebalance=Expiry.EndOfWeek` |
| comment | `Resolution.Monthly` | `timedelta(days=30)` |
| `print()` option list | `Resolution.Weekly` / `Resolution.Monthly` | `Expiry.EndOfWeek` / `timedelta(days=30)` |

`Resolution.Daily`, `Expiry.EndOfMonth`, and the `lambda` example were already valid → untouched.

### cell 14 — result block: real QC Cloud metrics

The corrected algorithm was redeployed verbatim to QC Cloud (project 33072122) and backtested 2015-2024 $100k:

| Metric | Fabricated (old) | Real QC Cloud |
|--------|------------------|---------------|
| Sharpe | 1.912 | **0.49** |
| CAGR | 36.493% | **9.704%** |
| Max Drawdown | 6.1% | **25.700%** |
| PSR | — | **11.723%** |

The old End Equity ($107,938 over 10y implies only +0.77% CAGR) was itself inconsistent with the claimed 36.493% — same fabrication signature as the rest of NB14. Sharpe 0.49 / CAGR 9.7% is plausible for an equal-weight 5-ETF basket (SPY/QQQ/IWM/TLT/GLD) with weekly rebalancing. Sortino/Orders/Trades/WinRate/Fees omitted (not reliably provided by `read_backtest`).

## Validation

- cell 13 keeps its **non-executable reference state** (exec_count `None`, no outputs) — it imports `AlgorithmImports` (QC-only) so it is never run locally; only the source idiom changed. `validate_pr_notebooks.py` **PASS** (21 code cells).
- Only cells 13 (code source) + 14 (markdown) changed. **0 code-cell exec/output churn**. 82 cells unchanged. C.1 clean. Catalogue byte-identical.
- G.1: invalid `Resolution.Weekly`/`Resolution.Monthly` asserted present before replace, absent after; cell 14's #3522 Runtime-Error row asserted before replace. Real metrics are ground-truth from QC Cloud (backtest `62cb1805751563f907002edd3a9fddde`), not derived from fabricated equity. Base fresh (`origin/main`).

## #3367 NB14 — fully closed (no residual non-executable cell)

cells 27/30 (#3505 Lean-drift) · cells 11/54/57/68/75 real metrics (#3522) · cell 79 honest non-exec O(n²) (#3522) · **cell 14 real metrics + idiom fix (this PR)** · cells 21/38/42/63/71 honest zero-trade/loser (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
