### PR TITLE
fix(genai-texte-05): real-execute 3 RAG exercise stubs for H.3 gate (unblock #3528)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -892,8 +892,16 @@
    "id": "155481ca",
    "source": "# Exercice 1 - Strategie de chunking hybride\n# TODO etudiant : implementer chunk_hybrid\n\nimport re\n\ndef chunk_hybrid(text: str, target_size: int = 400, tolerance: int = 100, overlap: int = 50) -> List[str]:\n    \"\"\"\n    Chunking hybride : decoupe par phrases tout en visant une taille cible.\n    \n    Args:\n        text: Texte a decouper\n        target_size: Taille cible en caracteres\n        tolerance: Ecart acceptable par rapport a la taille cible\n        overlap: Nombre de caracteres de chevauchement entre chunks\n    \n    Returns:\n        Liste de chunks texte\n    \"\"\"\n    return None  # TODO etudiant : implementer le chunking hybride\n\n# Etape 1 : Tester la fonction sur le texte du debat\n# hybrid_chunks = chunk_hybrid(debate_text, target_size=400, tolerance=100, overlap=50)\n# print(f\"Chunking hybride: {len(hybrid_chunks)} chunks\")\n\n# Etape 2 : Comparer avec le chunking fixe\n# print(f\"Chunking fixe: {len(chunks)} chunks\")\n# print(f\"Premier chunk hybride: {hybrid_chunks[0][:200]}...\")\n\n# Etape 3 : Verifier la taille des chunks\n# sizes = [len(c) for c in hybrid_chunks]\n# print(f\"Taille min: {min(sizes)}, max: {max(sizes)}, moyenne: {sum(sizes)/len(sizes):.0f}\")\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 6,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1689,8 +1697,16 @@
    "id": "1e982498",
    "source": "# Exercice 2 - Recherche vectorielle avec seuil de confiance\n# TODO etudiant : implementer search_with_confidence\n\ndef search_with_confidence(vector_store: VectorStore, question: str, k: int = 5, min_score: float = 0.5) -> Dict[str, Any]:\n    \"\"\"\n    Recherche vectorielle avec filtrage par score et niveau de confiance.\n    \n    Args:\n        vector_store: Base vectorielle initiee\n        question: Question de l'utilisateur\n        k: Nombre de chunks a recuperer\n        min_score: Score minimum pour garder un chunk\n    \n    Returns:\n        Dict avec results, confidence, total_found, kept\n    \"\"\"\n    return None  # TODO etudiant : implementer la recherche avec confiance\n\n# Etape 1 : Tester avec une question specifique\n# result = search_with_confidence(vector_store, \"What was Lincoln's position on equality?\", k=5, min_score=0.5)\n\n# Etape 2 : Afficher les resultats et le niveau de confiance\n# print(f\"Confiance: {result['confidence']}\")\n# print(f\"Chunks trouves: {result['total_found']}, gardes: {result['kept']}\")\n# for r in result['results']:\n#     print(f\"  Score: {r['score']:.3f} - {r['text'][:100]}...\")\n\n# Etape 3 : Tester avec une question hors sujet pour observer confiance basse\n# result_off = search_with_confidence(vector_store, \"What is the recipe for chocolate cake?\", k=5, min_score=0.5)\n# print(f\"\\nQuestion hors sujet - Confiance: {result_off['confidence']}, gardes: {result_off['kept']}\")\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 11,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2670,8 +2686,16 @@
    "id": "7050cc5f",
    "source": "# Exercice 3 - Evaluation de la qualite de retrieval\n# TODO etudiant : implementer evaluate_retrieval\n\ndef evaluate_retrieval(questions_references: List[Dict], vector_store: VectorStore, k: int = 3) -> Dict[str, float]:\n    \"\"\"\n    Evalue la qualite du retrieval sur un jeu de questions de reference.\n    \n    Args:\n        questions_references: Liste de dicts {\"question\": str, \"expected_chunk_ids\": List[int]}\n        vector_store: Base vectorielle initiee\n        k: Nombre de chunks a recuperer par recherche\n    \n    Returns:\n        Dict avec precision_moyenne, recall_moyen, details_par_question\n    \"\"\"\n    pass  # TODO etudiant : implementer l'evaluation du retrieval\n\n# Etape 1 : Definir un jeu de 3 questions avec chunks attendus\n# questions_references = [\n#     {\"question\": \"What did Lincoln say about a house divided?\", \"expected_chunk_ids\": [9]},\n#     {\"question\": \"What was the audience size?\", \"expected_chunk_ids\": [0]},\n#     {\"question\": \"What did Douglas say about popular sovereignty?\", \"expected_chunk_ids\": [20, 31]},\n# ]\n\n# Etape 2 : Appeler evaluate_retrieval\n# results = evaluate_retrieval(questions_references, vector_store, k=3)\n\n# Etape 3 : Afficher les resultats\n# print(f\"Precision moyenne: {results['precision_moyenne']:.2f}\")\n# print(f\"Recall moyen: {results['recall_moyen']:.2f}\")\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 18,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Context

ai-01 directive (burst-mode, 00:23Z): PR **#3528** (po-2026, `docs(genai-texte-05): scholarly citations for 5_RAG_Modern + C.1 stub repair` — audit #3164) is **FAIL on Static validation (H.1/H.3/C.1)** because of pre-existing null-exec exercise stubs. ai-01 routed the execution pass to po-2023 (GenAI/Texte family host with the API env): « UN seul exécute. » After merge, po-2026 rebases #3528 → H.3 green.

## Why this is not the same as #3527

Unlike genai-texte-08 (stubs autosufficient, executed in isolation), the RAG stubs **cells 38/58** reference `VectorStore` (defined cell 36) and `Dict/List/Any` (imported cell 4) — names that only exist in the notebook's shared namespace, not in the stub cell alone. Isolated `exec()` raises `NameError: name 'VectorStore' is not defined` (verified). So honest execution requires the **full notebook context** via papermill, not isolated exec.

## Fix

End-to-end papermill execution (kernel `python3`, `--cwd Texte` so the notebook finds `.env`, `--execution-timeout 600`): **63/63 cells SUCCESS, 1m40s**. The 3 stubs run cleanly in-context — their only executable statement is `print("Exercice a completer")`; the rest is a `def` returning `None`/`pass` plus commented-out calls.

Patched ONLY the 3 null-exec stub cells in the main notebook:
| cell-id | Exercice | exec_count | stdout |
|---------|----------|------------|--------|
| `155481ca` (cell 19) | 1 — chunking hybride | 6 | `Exercice a completer` |
| `1e982498` (cell 38) | 2 — recherche vectorielle seuil | 11 | `Exercice a completer` |
| `7050cc5f` (cell 58) | 3 — évaluation retrieval | 18 | `Exercice a completer` |

**Source-match guard**: patched only when concatenated source matches exactly (robust to papermill's list-splitting). **0 source modification, 0 metadata churn.**

## Validation

- `validate_pr_notebooks.py origin/main <nb>`: **1/1 PASS** (19/19 cells — was the FAIL blocking #3528)
- `nbformat.validate`: OK
- **C.3**: `git diff` = 3 `execution_count` hunks (null→6/11/18) + 1 trailing newline, **0 source change**, 0 added import/def lines. Diffstat 31/-7 = 3 stubs × (ec + output stream block).
- Catalogue: byte-identical to main.

## Note on cell 19

po-2026 already executed cell 19 (ec=17 on their branch) but NOT cells 38/58 (which depend on the embeddings pipeline). My PR executes all 3 from main (ec 6/11/18). On rebase, po-2026's cell 19 (ec=17) stays coherent, cells 38/58 get the exec they lacked → H.3 passes for #3528.

See #3528, refs #3164.