### PR TITLE
fix(csp-5): re-align stale FFD output to optimal + correct paradoxe interpretation (#3544)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
@@ -1353,8 +1353,8 @@
      "output_type": "stream",
      "text": [
       "CP-SAT optimal: 5 bins\n",
-      "FFD heuristic:  3 bins\n",
-      "Gap: -40.0%\n"
+      "FFD heuristic:  5 bins\n",
+      "Gap: 0.0%\n"
      ]
     }
    ],
@@ -1413,21 +1413,21 @@
    "source": [
     "### Interpretation : Comparaison CP-SAT vs Heuristique FFD\n",
     "\n",
-    "**Sortie obtenue** : L'heuristique First Fit Decreasing (FFD) trouve une solution avec 3 bins, meilleure que la solution optimale de CP-SAT (5 bins). Ce résultat inattendu s'explique par le fait que FFD est une heuristique gloutonne qui peut trouver des solutions différentes, parfois meilleures par hasard sur de petites instances.\n",
+    "**Sortie obtenue** : L'heuristique First Fit Decreasing (FFD) trouve une solution avec 5 bins, soit exactement la solution optimale de CP-SAT (5 bins). Sur cette instance, l'heuristique gloutonne atteint l'optimum.\n",
     "\n",
     "| Aspect | Valeur CP-SAT | Valeur FFD | Analyse |\n",
     "|--------|---------------|------------|----------|\n",
-    "| Nombre de bins | 5 | 3 | FFD meilleure sur cette instance |\n",
+    "| Nombre de bins | 5 | 5 | FFD atteint l'optimal sur cette instance |\n",
     "| Statut | OPTIMAL | HEURISTIC | CP-SAT garantit l'optimalité |\n",
-    "| Gap | - | -40.0% | FFD utilise moins de bins |\n",
+    "| Gap | - | 0.0% | FFD égale l'optimal ici |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Paradoxe apparent** : FFD (3 bins) < CP-SAT (5 bins) - c'est possible car FFD est une heuristique gloutonne qui peut trouver des solutions différentes sur les petites instances\n",
-    "2. **Garantie d'optimalité** : CP-SAT garantit que 5 bins est l'optimal pour cette formulation, mais FFD utilise une approche différente (tri décroissant + first fit)\n",
-    "3. **Performance théorique** : FFD garantit au pire 11/9 × OPT + 1 bins, donc peut être meilleure que l'optimal trouvé par une formulation CP spécifique\n",
-    "4. **Importance du benchmark** : Sur des instances plus grandes, CP-SAT trouvera systématiquement de meilleures solutions que les heuristiques\n",
+    "1. **Une heuristique ne bat jamais l'optimal** : par définition, l'optimum est le nombre minimal de bins. FFD ne peut donc qu'égaler ce minimum (gap 0 %) ou l'excéder, jamais faire mieux.\n",
+    "2. **Garantie d'optimalité** : CP-SAT prouve que 5 bins est l'optimal pour cette instance ; FFD (tri décroissant + first fit) y parvient également ici.\n",
+    "3. **Performance théorique** : FFD garantit au pire 11/9 × OPT + 1 bins. C'est une borne *supérieure* (on a toujours FFD ≥ OPT) ; sur cette instance FFD est exactement à OPT, bien en dessous de la borne.\n",
+    "4. **Importance du benchmark** : sur des instances plus grandes ou défavorables, FFD peut utiliser plus de bins que l'optimal ; CP-SAT reste la référence pour garantir le minimum.\n",
     "\n",
-    "> **Note technique** : Ce résultat illustre pourquoi les heuristiques sont utiles en pratique - elles sont rapides et peuvent trouver de bonnes solutions, mais sans garantie d'optimalité. Pour un problème de production, on utiliserait FFD pour une solution rapide, puis CP-SAT pour optimiser si nécessaire."
+    "> **Note technique** : ce résultat illustre l'intérêt des heuristiques en pratique - rapides et souvent proches (ici égales) de l'optimal, mais sans garantie. Pour un problème de production, on utiliserait FFD pour une solution rapide, puis CP-SAT pour certifier ou améliorer si nécessaire."
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Bug **code/output** isolé hors audit fidélité #3164 (markdown-only). Tracking : #3544. Jumeau de #3549 (CSP-4 SPT) : une heuristique qui « bat » l'optimal **prouvé** est mathématiquement impossible.

CSP-5 benchmark FFD (cellule idx29, id `64f599ff`) affichait un output **périmé** :
```
CP-SAT optimal: 5 bins
FFD heuristic:  3 bins      <-- 3 < 5 impossible (OPT = minimum par définition)
Gap: -40.0%
```

## Diagnostic

Contrairement à CSP-4, le **code FFD est correct** — c'est l'**output committé qui est périmé** (issu d'une version antérieure du code ou des données). Ré-exécution du code committé sur l'instance committée (`items=[4,8,5,1,2,7,3,6,4,2]`, `capacity=10`) :
```
CP-SAT optimal: 5 bins
FFD heuristic:  5 bins
Gap: 0.0%
```
FFD atteint exactement l'optimal (5 bins).

## Fix

- **idx29** : ré-alignement de l'**output uniquement** sur le résultat déterministe réel (FFD 5 bins, Gap 0.0%). **Source inchangée** (le code était déjà correct) ; `execution_count` préservé (11). Vérifié avec **ortools 9.15.6755** (python313 système, règle F).
- **idx30** (id `ae6d9851`) : réécriture de l'interprétation qui narrait le faux « **paradoxe apparent** » (FFD 3 bins < CP-SAT 5 bins) et présentait à tort la borne 11/9·OPT + 1 comme permettant à FFD de battre l'optimal. Corrigé : une heuristique ne peut qu'**égaler** (gap 0) ou **dépasser** l'optimum ; 11/9·OPT + 1 est une **borne supérieure** (FFD ≥ OPT toujours) ; ici FFD atteint OPT exactement. Structure pédagogique préservée, **no-pendulum** (aligné sur l'output réel).

## Validation

- Output FFD = sortie réelle vérifiée par exécution (pas de fabrication).
- `git diff --stat` : 10 ins / 10 del (output 2 lignes + markdown idx30).
- 0 ligne `execution_count`/`output_type`/`cell_type` ajoutée ; JSON valide.
- Catalogue (`COURSE_CATALOG.generated.{json,md}`) + submodule MGS **byte-identiques** à `main` ; branche fraîche `origin/main`.

See #3544