### PR TITLE
fix(#3164): Transformer citation + tokenization prose fix for 1_OpenAI_Intro

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "## Qu’est-ce que l’IA Générative ?\n",
     "\n",
-    "L’IA générative est une branche de l’apprentissage automatique qui **génère** de nouveaux contenus (texte, image, audio, code…) à partir de modèles probabilistes entraînés sur de vastes ensembles de données. Les modèles les plus avancés, appelés **Large Language Models** (LLMs), utilisent des architectures de type **Transformer** pour prédire et générer des séquences.\n",
+    "L’IA générative est une branche de l’apprentissage automatique qui **génère** de nouveaux contenus (texte, image, audio, code…) à partir de modèles probabilistes entraînés sur de vastes ensembles de données. Les modèles les plus avancés, appelés **Large Language Models** (LLMs), utilisent des architectures de type **Transformer** pour prédire et générer des séquences (architecture introduite par Vaswani et al., 2017, *« Attention Is All You Need »*, arXiv:1706.03762).\n",
     "\n",
     "Exemples concrets :\n",
     "- **ChatGPT** (OpenAI) : génération et compréhension de texte\n",
@@ -655,8 +655,14 @@
    "id": "b7fd1869",
    "source": "# Exercice 1 : Composer un system prompt pour un assistant specialise\n# TODO etudiant : Creez un system prompt pour un assistant de revision technique\n\n# Etape 1 : Definir le message system avec les contraintes\n# system_prompt = \"Tu es un assistant de revision technique qui...\"\n\n# Etape 2 : Definir la question de test\n# test_question = \"Explique-moi les avantages de Python pour la data science\"\n\n# Etape 3 : Appeler le modele avec le system prompt\n# response_ex1 = client.chat.completions.create(\n#     messages=[\n#         {\"role\": \"system\", \"content\": system_prompt},\n#         {\"role\": \"user\", \"content\": test_question},\n#     ],\n#     model=DEFAULT_MODEL,\n#     max_completion_tokens=300,\n# )\n\n# Etape 4 : Afficher la reponse et verifier le respect des contraintes\n# print(\"Reponse de l'assistant technique :\")\n# print(response_ex1.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 9,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -687,7 +693,7 @@
     "- **Optimisation** : Pour un même texte, le coût peut varier selon le modèle choisi\n",
     "\n",
     "**Exemple concret** :\n",
-    "Si `text-davinci-003` utilise 5 tokens et `gpt-5-mini` en utilise 4 pour la même phrase, cela représente une économie de 20% sur le volume de tokens à traiter.\n",
+    "Sur la même phrase, `text-davinci-003` et `gpt-5-mini` peuvent produire un **nombre identique** de tokens (cf. la sortie ci-dessous : 5 tokens chacun) mais avec des **indices de vocabulaire différents** (`[5812, 910, 460, 345, 766]` vs `[18009, 2891, 665, 481, 1921]`) : chaque modèle possède son propre vocabulaire BPE. Sur des textes plus longs ou multilingues, le compte peut diverger (cf. Exercice 2).\n",
     "\n",
     "**Recommandation** : Toujours vérifier la tokenisation avant d'envoyer de longs documents pour estimer le coût réel."
    ]
@@ -880,8 +886,14 @@
    "id": "43159264",
    "source": "# Exercice 2 : Comparer la tokenisation de textes multilingues\n# TODO etudiant : Comparez le nombre de tokens pour la meme phrase en 3 langues\n\n# Etape 1 : Definir les phrases dans les 3 langues\n# phrases = {\n#     \"francais\": \"L'intelligence artificielle transforme le monde\",\n#     \"anglais\": \"Artificial intelligence is transforming the world\",\n#     \"espagnol\": \"La inteligencia artificial esta transformando el mundo\",\n# }\n\n# Etape 2 : Obtenir l'encodeur et compter les tokens pour chaque phrase\n# encoder = get_encoder(DEFAULT_MODEL)\n# for langue, texte in phrases.items():\n#     nb_tokens = len(encoder.encode(texte))\n#     print(f\"{langue}: {nb_tokens} tokens\")\n\n# Etape 3 : (optionnel) Afficher les tokens individuels pour une des phrases\n# tokens = encoder.encode(phrases[\"francais\"])\n# decoded = [encoder.decode([t]) for t in tokens]\n# print(f\"Tokens francais: {decoded}\")\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1110,8 +1122,14 @@
    "id": "4fd36c5b",
    "source": "# Exercice 3 : Detecter et corriger une hallucination\n# TODO etudiant : Creez un prompt avec 2 evenements (1 vrai, 1 faux)\n# et demandez au modele d'identifier l'imposteur\n\n# Etape 1 : Formuler le prompt avec les deux evenements\n# hallucination_prompt = \"\"\"\n# Voici deux evenements historiques. L'un est vrai, l'autre est invente.\n# Evenement A: ...\n# Evenement B: ...\n# Lequel est invente ? Justifie ta reponse.\n# \"\"\"\n\n# Etape 2 : Appeler le modele\n# response_detect = client.chat.completions.create(\n#     messages=[{\"role\": \"user\", \"content\": hallucination_prompt}],\n#     model=DEFAULT_MODEL\n# )\n\n# Etape 3 : Afficher la reponse et verifier si le modele a correctement identifie l'imposteur\n# print(response_detect.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Audit fidélité #3164 on `MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb`.

**Verdict : FIDELE** with 1 OMISSION + 1 REINVENTION (markdown-only, 0 example-guide code touched).

## Changes

### OMISSION — Transformer citation (cell 2, `902813b9`)
The only concept-level architectural claim in the notebook — "LLMs utilisent des architectures de type Transformer" — had no scholarly anchor. Added **Vaswani et al. 2017**, *"Attention Is All You Need"* (arXiv:1706.03762) inline — the canonical foundational paper. Mirrors how NB-15 anchors CoT/ToT concepts.

The notebook is otherwise a pure OpenAI-API intro (installation, first prompt, system message, tokenization demo, hallucination demo, Responses API). Operational "how-to" cells legitimately need no citations — the sonnet sub-agent audit + parent G.1 cross-check confirmed no other warranted gaps. (Optional hallucination-survey pointer Ji 2023 deliberately skipped: behavioral intro cell, not a fidelity gap.)

### REINVENTION — tokenization prose drift (cell 16, `4e6b17ae`)
Markdown claimed *"Si text-davinci-003 utilise 5 tokens et gpt-5-mini en utilise 4 [...] économie de 20%"*. The **committed output** (cell 18, `8c2dd909`) shows BOTH models produce **5 tokens** (`[5812,910,460,345,766]` vs `[18009,2891,665,481,1921]`).

Reworded to align on the real output: **identical token count (5), different BPE vocab indices** — each model has its own vocabulary. No-pendulum: align on committed output, do not fabricate.

### H.3 stub execution (cells 15/21/28)
3 exercise stubs are fully autonomous (only active line = `print("Exercice a completer")`, no API/external deps) but had `execution_count=null`. Executed via python3 kernel (same resolution as NB-08 #3511):

| cell | id | ec | output | source |
|------|-----|-----|--------|--------|
| 15 | `b7fd1869` | 9 | `Exercice a completer` | unchanged (skeleton intact) |
| 21 | `43159264` | 10 | `Exercice a completer` | unchanged |
| 28 | `4fd36c5b` | 11 | `Exercice a completer` | unchanged |

## Validation (honest, post-fix)
- **G1 (C.1):** 0 violation (0 `raise NotImplementedError`/`assert False`/`1/0` in source).
- **G2 (outputs):** 3 stubs ec=9/10/11 + stream output captured.
- **G3 (catalog):** `COURSE_CATALOG.generated.*` byte-identical.
- **Abort-on-mismatch:** both markdown anchors unique (count=1) before edit; all 3 stubs confirmed autonomous + `ec=null` pre-existing.
- **G.1 parent cross-check:** sub-agent findings re-verified against real notebook (cell_ids, anchor uniqueness, committed output token counts) — all correct.

Reassessed by po-2026:CoursIA-2: **CONFIRMED OMISSION** (Transformer) + **CONFIRMED REINVENTION** (token count) — not false positives.

See #3164 (audit epic, GenAI/Texte family).