### PR TITLE
docs(ml-1): anchor R2/SDCA citations + add References (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
@@ -641,7 +641,23 @@
   {
    "cell_type": "markdown",
    "id": "de81f76f",
-   "source": "### Interpretation : Evaluation du modele de regression\n\n**Resultat obtenu** : Le coefficient de determination R² = 0,97 indique que le modele explique 97 % de la variance des donnees de test.\n\n| Metrique | Valeur | Signification |\n|----------|--------|---------------|\n| R² | 0,97 | Ajustement excellent, proche de la perfection |\n| Donnees d'entrainement | 4 exemples | Dataset minimal pour une demonstration |\n| Donnees de test | 15 exemples | Couvrent la plage 1,1 a 8,0 en taille |\n\n**Points cles** :\n\n1. **R² proche de 1** : La relation taille-prix est fortement lineaire dans ce jeu de donnees synthetiques\n2. **Biais potentiel** : Les donnees d'entrainement et de test se chevauchent partiellement, ce qui peut surerestimer la qualite du modele\n3. **Generalisation** : Un R² eleve sur un petit dataset ne garantit pas la performance sur des donnees reelles plus complexes",
+   "source": [
+    "### Interpretation : Evaluation du modele de regression\n",
+    "\n",
+    "**Resultat obtenu** : Le coefficient de determination R² (Wright, 1921) = 0,97 indique que le modele explique 97 % de la variance des donnees de test.\n",
+    "\n",
+    "| Metrique | Valeur | Signification |\n",
+    "|----------|--------|---------------|\n",
+    "| R² | 0,97 | Ajustement excellent, proche de la perfection |\n",
+    "| Donnees d'entrainement | 4 exemples | Dataset minimal pour une demonstration |\n",
+    "| Donnees de test | 15 exemples | Couvrent la plage 1,1 a 8,0 en taille |\n",
+    "\n",
+    "**Points cles** :\n",
+    "\n",
+    "1. **R² proche de 1** : La relation taille-prix est fortement lineaire dans ce jeu de donnees synthetiques\n",
+    "2. **Biais potentiel** : Les donnees d'entrainement et de test se chevauchent partiellement, ce qui peut surerestimer la qualite du modele\n",
+    "3. **Generalisation** : Un R² eleve sur un petit dataset ne garantit pas la performance sur des donnees reelles plus complexes"
+   ],
    "metadata": {}
   },
   {
@@ -1202,10 +1218,31 @@
     "\n",
     "**Points clés** :\n",
     "- ML.NET suit un workflow en 4 étapes : Données -> Entraînement -> Evaluation -> Prédiction\n",
-    "- L'algorithme SDCA est adapté aux problèmes de régression linéaire\n",
+    "- L'algorithme SDCA (Stochastic Dual Coordinate Ascent, Shalev-Shwartz & Zhang, 2013) est adapté aux problèmes de régression linéaire\n",
     "- Le coefficient R² mesure la qualité de l'ajustement (1.0 = parfait)\n",
     "\n",
     "**Navigation** : [Index](README.md) | [Suivant >> ML-2 Data & Features](ML-2-Data%26Features.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "refs-bibliography-ml1",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "**Algorithme (SDCA)**\n",
+    "- Shalev-Shwartz, S., & Zhang, T. (2013). *Stochastic Dual Coordinate Ascent Methods for Regularized Loss Minimization*. Journal of Machine Learning Research, 14, 567-599. — algorithme SDCA, trainer linéaire par défaut de ML.NET pour la régression et la classification.\n",
+    "\n",
+    "**Métriques d'évaluation**\n",
+    "- Wright, S. (1921). *Correlation and Causation*. Journal of Agricultural Research, 20(7), 557-585. — coefficient de détermination R².\n",
+    "- Fawcett, T. (2006). *An Introduction to ROC Analysis*. Pattern Recognition Letters, 27(8), 861-874. — courbe ROC et aire sous la courbe (AUC), utilisée pour l'évaluation de la classification binaire.\n",
+    "\n",
+    "**Framework (ML.NET)**\n",
+    "- Ahmed, Z., Ward, L., et al. (2019). *Machine Learning at Microsoft with ML.NET*. ACM SIGKDD (KDD). — framework ML.NET utilisé tout au long du notebook.\n",
+    "\n",
+    "**Automated Machine Learning (AutoML)**\n",
+    "- Hutter, F., Kotthoff, L., & Vanschoren, J. (2019). *Automated Machine Learning: Methods, Systems, Challenges*. Springer. — mentionné comme approche de sélection automatique d'algorithmes."
    ]
   }
  ],


### PR DESCRIPTION
## Audit fidélité #3164 — ML-1-Introduction (suite famille ML.Net)

2e grain **ML.Net** (après ML-7-Recommendation #3543, mergé). Ai-01 cycle 4 a confirmé : **ML.Net = mon slice #3164**, enchaîner ML-1/3/5/2/4/6.

### Verdict : 2 OMISSIONS (classe c) ancrées + section References créée, 0 erreur factuelle, 0 REINVENTION

**Grain honnête (G.1/G.5 anti-cart)** : ML-1 est un notebook **d'introduction au pipeline ML.NET** (MLContext / IDataView / évaluation R²), **pas un cours d'algorithmes**. Les algos nommés (SDCA, FastTree) apparaissent comme **choix d'API trainer en code cells**, non comme concepts centraux enseignés en markdown. Forcer 3+ ancres ici = padding G.5. Les **vrais** points d'enseignement ancrables :

| Point d'enseignement | Citation canonique ancrée |
|---|---|
| Coefficient de détermination R² (cell 20, section d'interprétation **centrale** de l'éval régression) | **Wright 1921** |
| SDCA (cell 38 résumé — le **seul** algorithme nommé traité en markdown, "adapté à la régression linéaire") | **Shalev-Shwartz & Zhang 2013** (JMLR) |

**Section References ajoutée** (5 entrées, aucune n'existait) : + **Fawcett 2006** (ROC/AUC — éval classification binaire cell 30), **Ahmed et al. 2019** (ML.NET framework), **Hutter et al. 2019** (AutoML — mention one-liner cell 1, References-only).

### Discipline G.5 (ce qui n'a PAS été ancré, honnêtement)
- **AutoML** (cell 1) : aside "Spoiler Alert" d'une ligne, pas enseignement central → References-only.
- **FastTree / LightGBM** : apparaissent uniquement en **code cell** (`Trainers.FastTree`) comme choix d'API, jamais traités en markdown → pas d'ancre.
- **Accuracy / biais / surapprentissage** : métriques/concepts intro, pas d'ancre.

### Validation
- **Markdown-only** (+40/-3) — 2 remplacements inline + 1 cellule References appendée.
- C.2/C.3 : **0 churn** `execution_count`/`outputs` (16 code cells intactes) · C.1 = 0 · `scan_cell_ordering` clean · catalogue **byte-identique** · branche fraîche `origin/main`.
- **Repo CI validator (`notebook_tools.py validate`) : OK** (exit 0, 0 erreur).
- **Note hygiène (follow-up, hors scope)** : artefact papermill pré-existant sur `origin/main` (props `execution_count`/`outputs` sur cellules markdown) → fait échouer le *strict* `nbformat.validate` mais pas le validator CI. Passe hygiène dédiée famille ML.Net après l'audit (per ai-01 cycle 4).

See #3164
