### PR TITLE
fix(infer-14): audit fidelite #3164 Infer-14-Decision-Utility-Foundations -- NAV/ERREUR/OMISSION

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Decision-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Decision-Utility-Foundations.ipynb
@@ -655,7 +655,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Verification de l'axiome d'independance\n",
+    "## Exercice 1 : Verification de l'axiome d'independance\n",
     "\n",
     "**Objectif** : Verifiez empiriquement l'axiome d'independance de Von Neumann-Morgenstern en construisant des loteries composees.\n",
     "\n",
@@ -976,7 +976,9 @@
     "tags": []
    },
    "source": [
-    "Affichage du graphe de facteurs du modele de diagnostic."
+    "Affichage du graphe de facteurs du modele de diagnostic.\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`, cf issue #3473). Le moteur genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais affiche a la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -1246,7 +1248,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Decision medicale avec test sequentiel\n",
+    "## Exercice 2 : Decision medicale avec test sequentiel\n",
     "\n",
     "**Objectif** : Etendez le modele de decision medicale pour gerer deux tests sequentiels et determinez si le second test est necessaire.\n",
     "\n",
@@ -1873,7 +1875,9 @@
     "tags": []
    },
    "source": [
-    "Affichage du graphe de facteurs du modele de loterie avec utilite."
+    "Affichage du graphe de facteurs du modele de loterie avec utilite.\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`, cf issue #3473). Le moteur genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais affiche a la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -2226,16 +2230,16 @@
     "\n",
     "| Equivalent certain | Interpretation | Coefficient rho |\n",
     "|-------------------|----------------|-----------------|\n",
-    "| 480 EUR | Quasi-neutralite | rho ~ 0.06 |\n",
+    "| 480 EUR | Quasi-neutre | rho ~ 0.06 |\n",
     "| 400 EUR | Faible aversion | rho ~ 0.25 |\n",
-    "| 300 EUR | Aversion moderee | rho ~ 0.44 |\n",
-    "| 200 EUR | Aversion significative | rho ~ 0.61 |\n",
+    "| 300 EUR | Quasi-neutre | rho ~ 0.44 |\n",
+    "| 200 EUR | Modere | rho ~ 0.61 |\n",
     "| < 100 EUR | Forte aversion | rho > 1.0 |\n",
     "\n",
     "> **Interpretation** : Avec CE = 400 EUR pour une loterie [50% : 1000, 50% : 1], le coefficient rho = 0.25 indique que l'agent est pret a accepter un rabais de 100 EUR (= 500 - 400) par rapport a la valeur esperee pour eliminer l'incertitude. C'est une aversion au risque modeste.\n",
     "\n",
     "**Experimentez** : Modifiez `equivalentCertain` dans la cellule precedente pour explorer :\n",
-    "- CE = 200 : profil plus prudent (rho ~ 0.6)\n",
+    "- CE = 200 : profil modere (rho ~ 0.6)\n",
     "- CE = 480 : profil quasi-neutre (rho ~ 0.06)\n",
     "- CE = 500 : neutralite parfaite (rho = 0)\n",
     "\n",
@@ -2266,7 +2270,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Exercice 3 : Comparer CARA et CRRA — Primes de risque\n",
+    "## Exercice 3 : Comparer CARA et CRRA — Primes de risque\n",
     "\n",
     "### Objectif\n",
     "\n",


### PR DESCRIPTION
## Audit fidélité #3164 — Infer-14-Decision-Utility-Foundations

13e notebook Infer audité (1er de la série Decision-Utility 14-20). Kernel `.net-csharp`, 42 cells (26 md / 16 code). **Substantively bon** (0 INVENTION, 0 LABELING, nombres tous fidèles). **6 défauts markdown-only** (13 ins / 9 del, 0 ligne `execution_count`/`outputs`).

## Défauts corrigés

### NAVIGATION (3)
1. **idx14** (`79e8dc58`) : `## Exercice : Verification de l'axiome d'independance` non numéroté → `## Exercice 1 :` (cassait la séquence §1..§8).
2. **idx25** (`b943e16e`) : `## Exercice : Decision medicale avec test sequentiel` non numéroté → `## Exercice 2 :`.
3. **idx39** (`38977f13`) : `## 8. Exercice 3 : ...` → `## Exercice 3 :` — résout le **doublon `## 8.`** avec idx41 (`## 8. Resume`) **ET** donne à Exercice 3 son antécédent 1/2 (namespace Exercice distinct des sections de contenu §1..§8, comme Infer-13).

### ERREUR-FACTUELLE (1 — flawed-reasoning self-contradictory)
4. **idx38** (`c8e03d8f`) : la table qualitative de calibration CRRA **contredisait l'output committé idx37**. Le code interp (`string interp = r < 0.5 ? "Quasi-neutre" : r < 1.5 ? "Modere" : ...`) imprime `rho=0.44`→**Quasi-neutre**, `rho=0.61`→**Modere**. Mais la prose idx38 disait `rho=0.44`→« Aversion modérée » et `rho=0.61`→« Aversion significative ». Alignée sur l'output (les nombres rho sont exacts et inchangés). + inline `CE=200 profil prudent`→`modere` (cohérent avec le ternary du code).

### OMISSION x2 SVG (#3473)
5-6. **idx19** (`a786485c`) + **idx34** (`822d7ac1`) : 2 factor-graphs (diagnostic médical + loterie) affichent le banner « Graphviz non disponible » (`Graphviz disponible : False` à idx6 — bug kernel-PATH #3473, le kernel `.net-csharp` n'hérite pas du PATH conda). Caveats standardisés insérés (la prose originale ne prétendait pas faussement un graphe rendu — fallback honnête, caveat pour parité avec Infer-3..12).

## Fidèle vérifié (spot-checks, G.1 parent)
- `P(malade|test+)=65.9%` (Bayes `0.30×0.90 / 0.41 = 0.659`) idx16/17 ✓
- `E[U(traiter)]=73.2` vs `E[U(pas traiter)]=34.1` idx22/23 ✓
- Prime d'assurance `3691 EUR` idx27/28 ✓
- `Gaussian(250, 5.625e+05)`, `EU=33.54`, `CE≈125` idx31/32 ✓
- `rho=0.25` pour `CE=400` (CRRA bisection, `U(400)=119.4424`) idx37 ✓
- 3 stubs exercice (idx13/24/40) correctement stubbés C.1 (`print("Exercice a completer")`, 0 InferenceEngine).
- **§7 Exemple guide idx37** = worked example GÉNUINE (CRRA bisection solver réel, 100 itérations) — laissé intact.

## Gates
- **G1** `scan_cell_ordering` : 1 clean, 0 finding.
- **G2** `check_c2_compliance` : 1/1 compliant.
- **G3** `notebook_tools validate` : 0 Errors (Warning 1 = **FP LaTeX `$`-balance pré-existant**, baseline `origin/main` identique).
- **G4** git diff : 13 ins / 9 del, 1 fichier markdown-only, **0 ligne `execution_count`/`outputs` touchée**, submodules `Automata`/`Z3.Linq` non stagés.

## Méthode
Sous-agent `sonnet` evidence-cited (local-git-only, 0 hallucination d'id) → **cross-check G.1 parent** : re-vérification des anchors pivots (dup `## 8.`, table qualitative idx38 contre output idx37) + tranche des borderlines. Le sub-agent avait correctement déféré le borderline idx38 au parent (« labels qualitatifs ne matchent pas le ternary du code ») — confirmé et fixé.

Closes #3557
See #3164, #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
