### PR TITLE
fix(infer-15): audit fidelite #3164 Infer-15-Decision-Utility-Money -- ERREUR/LABELING/NAV/SWAP/OMISSION

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-15-Decision-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-15-Decision-Utility-Money.ipynb
@@ -1578,6 +1578,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "affb077d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013925,
+     "end_time": "2026-06-04T06:31:06.815670",
+     "exception": false,
+     "start_time": "2026-06-04T06:31:06.801745",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : Dominance stochastique et selection de portefeuille\n",
+    "\n",
+    "**Objectif** : Utilisez la dominance stochastique pour eliminer des investissements domines sans connaitre la fonction d'utilite exacte.\n",
+    "\n",
+    "**Contexte** : Quatre fonds d'investissement sont disponibles, chacun avec une distribution de rendement differente. Avant de choisir, vous devez verifier si certains fonds sont domines stochastiquement.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Definissez les 4 fonds avec leurs distributions discretes de rendement\n",
+    "2. Verifiez la dominance de premier ordre (FSD) entre chaque paire de fonds\n",
+    "3. Identifiez les fonds non-domines (frontiere efficace)\n",
+    "4. Verifiez la dominance de second ordre (SSD) entre les fonds restants\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Pour FSD, comparez les CDFs : F_A domine F_B si F_A(x) <= F_B(x) pour tout x\n",
+    "- # Indice 2 : Utilisez la classe `DiscreteLottery` definie precedemment et sa methode `CDF()`\n",
+    "- # Indice 3 : Pour SSD, comparez les integrales des CDFs : integrale(F_A) <= integrale(F_B) pour tout x\n",
+    "- # Etape 2 : Comparez toutes les 6 paires possibles parmi 4 fonds"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "30c028bf",
@@ -1630,39 +1663,6 @@
     "// Indice : SSD verifie que la somme cumulee des CDFs est plus petite\n",
     "\n",
     "Console.WriteLine(\"Exercice a completer : dominance stochastique et selection de portefeuille\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "affb077d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.013925,
-     "end_time": "2026-06-04T06:31:06.815670",
-     "exception": false,
-     "start_time": "2026-06-04T06:31:06.801745",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Exercice : Dominance stochastique et selection de portefeuille\n",
-    "\n",
-    "**Objectif** : Utilisez la dominance stochastique pour eliminer des investissements domines sans connaitre la fonction d'utilite exacte.\n",
-    "\n",
-    "**Contexte** : Quatre fonds d'investissement sont disponibles, chacun avec une distribution de rendement differente. Avant de choisir, vous devez verifier si certains fonds sont domines stochastiquement.\n",
-    "\n",
-    "**Etapes** :\n",
-    "1. Definissez les 4 fonds avec leurs distributions discretes de rendement\n",
-    "2. Verifiez la dominance de premier ordre (FSD) entre chaque paire de fonds\n",
-    "3. Identifiez les fonds non-domines (frontiere efficace)\n",
-    "4. Verifiez la dominance de second ordre (SSD) entre les fonds restants\n",
-    "\n",
-    "**Indices** :\n",
-    "- # Indice 1 : Pour FSD, comparez les CDFs : F_A domine F_B si F_A(x) <= F_B(x) pour tout x\n",
-    "- # Indice 2 : Utilisez la classe `DiscreteLottery` definie precedemment et sa methode `CDF()`\n",
-    "- # Indice 3 : Pour SSD, comparez les integrales des CDFs : integrale(F_A) <= integrale(F_B) pour tout x\n",
-    "- # Etape 2 : Comparez toutes les 6 paires possibles parmi 4 fonds"
    ]
   },
   {
@@ -3319,7 +3319,7 @@
     "|--------|-------|-----------|----------------|\n",
     "| Distribution | Beta(2,2) | Beta(5,9) | Mise a jour bayesienne |\n",
     "| Moyenne | 0.50 | ~0.36 | Tendance averse confirmee |\n",
-    "| Intervalle 95% | [0.09, 0.91] | [0.17, 0.58] | Incertitude reduite |\n",
+    "| Intervalle 95% | [0.09, 0.91] | [0.11, 0.60] | Incertitude reduite |\n",
     "\n",
     "> **Formule de mise a jour** : Avec un prior Beta(alpha, beta) et n observations dont k succes (choix risques) :\n",
     "> $$\\text{Posterior} = \\text{Beta}(\\alpha + k, \\beta + n - k)$$\n",
@@ -3337,7 +3337,9 @@
     "- Integre l'incertitude (intervalle credible, pas juste une estimation ponctuelle)\n",
     "- Permet d'incorporer des connaissances prealables (prior informatif)\n",
     "- Converge vers le vrai parametre avec plus d'observations\n",
-    "- Fournit une distribution complete, pas seulement une moyenne"
+    "- Fournit une distribution complete, pas seulement une moyenne\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`, cf issue #3473). Le moteur genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais affiche a la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -3800,7 +3802,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Portfolio avec contraintes de risque (VaR/CVaR) via Infer.NET\n",
+    "// Exercice : Portfolio avec contraintes de risque (VaR/CVaR) via Infer.NET\n",
     "\n",
     "// Parametres des actifs\n",
     "// Actif 1 : Obligataire (rendement moyen 3%, ecart-type 2%)\n",
@@ -3848,7 +3850,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Comparaison de fonctions d'utilite pour l'investissement\n",
+    "## Exercice 3 : Comparaison de fonctions d'utilite pour l'investissement\n",
     "\n",
     "En utilisant le meme framework de 3 actifs (Obligataire/Actions/Immobilier),\n",
     "comparez les decisions d'investissement sous differentes fonctions d'utilite.\n",
@@ -3890,7 +3892,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Fonctions d'utilite et decisions d'investissement\n",
+    "// Exercice : Fonctions d'utilite et decisions d'investissement\n",
     "\n",
     "// Parametres des actifs (memes que l'exemple guide)\n",
     "// Obligataire: mu=3%, sigma=2%  |  Actions: mu=8%, sigma=15%  |  Immobilier: mu=5%, sigma=8%\n",


### PR DESCRIPTION
## Audit fidélité #3164 — Infer-15-Decision-Utility-Money

14e notebook Infer audité (2e Decision-Utility 14-20). Kernel `.net-csharp`, 50 cells (28 md / 22 code). **Substantively bon** (0 INVENTION confirmée, 9 démonstrations principales FIDÈLES). **7 défauts** (40 ins / 38 del, 0 modification de contenu `execution_count`/`outputs`).

## Défauts corrigés

### ERREUR-FACTUELLE (1)
1. **idx41** (`da38e359`) : table « Intervalle 95% Posterior = [0.17, 0.58] » contredit l'output committé idx40 `[0,11, 0,60]` (Beta(5,9), mean=0.3571). Aligné sur `[0.11, 0.60]`. Prior CI `[0.09, 0.91]` laissé (approximation pédagogique d'un prior théorique Beta(2,2), pas de contradiction output).

### LABELING pathology n°5 (2)
2. **idx46** (`12e89991`) : commentaire `// Exemple guide : Portfolio VaR/CVaR` sur un **stub creux** (7 `// TODO`, `Console.WriteLine("A implementer...")`, 0 `InferenceEngine`) → relabel `// Exercice`.
   - **NB important** : la narrative idx45 décrit `exercice_portfolio.py` qui **existe réellement** (commit `9bffd460`, soumission étudiante ECE Gr02 « De Greling Infer-15 »). J'ai vérifié le fichier compagnon (282 lignes, 3 actifs, SLSQP, CVaR<5%) → **idx45 est FIDÈLE**, seul le commentaire code idx46 était inversé. (Le sub-agent avait flaggé idx45 comme INVENTION possible — **écarté par cross-check G.1 parent** : le fichier existe.)
3. **idx48** (`eb9d4e7e`) : commentaire `// Exemple guide : Fonctions d'utilite...` sur stub creux (4 TODO) → relabel `// Exercice`.

### NAVIGATION (3)
4. **idx21** (`affb077d`) `## Exercice : Dominance...` non numéroté → `## Exercice 1 :`.
5. **idx47** (`906e8477`) `## Exercice : Comparaison...` non numéroté → `## Exercice 3 :`. (idx45 `## Exercice 2` déjà numéroté → la séquence 1/2/3 devient cohérente, résout l'orphan « Exercice 2 » sans antécédent 1.)
6. **Cell-order inversion** idx20(code stub)/idx21(md intro) → **swap** (md AVANT code, convention canonique « intro markdown avant le code qu'elle introduit »). Les cellules déplacées sont **intactes** (ec/outputs byte-identiques, seule la position change — vérifié G.1).

### OMISSION SVG #3473 (1)
7. **idx42** (`536fb4f3`) factor-graph de l'inférence du profil = banner « Graphviz non disponible » (`dot` introuvable, bug kernel-PATH #3473 pré-fix-#3546). Caveat inséré sur idx41.

## Fidèle vérifié (spot-checks G.1 parent)
- St-Petersbourg ~21 EUR / CE ~4 EUR (idx6-8, seed 42 vs 123 = variance RNG légitime) ✓
- Utilité marginale 0.0500/0.0158/0.0050/0.0016 (idx10/11) ✓
- CRRA rho=0.5→CE 50.7/Prime 49.3 (idx15/16) ✓
- Arrow-Pratt ARA_CRRA 0.0200→0.0000 (idx18/19) ✓
- CE/Prime rho=2→10294/1506 (15.1%) (idx23/25) ✓
- FSD A≫B (F_A(50)=0.00 ≤ F_B(50)=0.50) (idx27/30) ✓
- Investment rho≥1.5→B (idx33-36) ✓
- Posterior Beta(5,9)[mean=0.3571] (idx40) ✓
- Beta PDF prior peak 1.5@0.5 / posterior 3.04@0.36 (idx44) ✓
- **§8 Exemple guide idx37/38** = worked example GÉNU (bisection `FindRho`, rho=1.29) intact.

## Gates
- **G1** `scan_cell_ordering` : 1 clean, 0 finding (le swap a **corrigé** l'inversion).
- **G2** `check_c2_compliance` : 1/1 compliant.
- **G3** `notebook_tools validate` : 0 Errors (Warning 1 = **FP LaTeX `$`-balance pré-existant**, baseline `origin/main` identique).
- **G4** git diff : 40 ins / 38 del, le swap réorganise les 2 cellules voisines (**ec/outputs byte-identiques préservés** — vérifié : `30c028bf` ec=9/1output inchangés, `affb077d` ec=null/0output inchangés), 0 modification de contenu execution_count/outputs, submodules `Automata`/`Z3.Linq` non stagés.

## Méthode + leçon G.1
Sous-agent `sonnet` evidence-cited (local-git-only) → **cross-check G.1 parent**. Le sub-agent était HAUTE qualité (0 hallucination d'id, a **corrigé mon pre-spot** « §6 manquant » — §6 existe bien à idx28) MAIS a **flaggé idx45 comme INVENTION possible** (blind-spot : il travaillait notebook-only). Cross-check parent : `find` → `exercice_portfolio.py` **existe** (commit `9bffd460`) → idx45 est FIDÈLE. **Leçon** : un sub-agent notebook-only peut manquer les fichiers compagnon hors-notebook (`.py`, `.csv`) référencés dans la prose — le parent doit vérifier ces références de fichiers avant de propager un verdict INVENTION.

Closes #3563
See #3164, #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
