### PR TITLE
fix(search-3): relabel item 5 title to Exercice (content-based, stub not example) (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -2724,7 +2724,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Exemple guide\n",
+    "## 9. Exemples guides et exercices\n",
     "\n",
     "### Exercice 1 : Vérifier l'admissibilité\n",
     "\n",
@@ -3216,7 +3216,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 5 : Pathfinding sur grille ponderee (couts de terrain)\n",
+    "### Exercice 5 : Pathfinding sur grille ponderee (couts de terrain)\n",
     "\n",
     "L'exemple Ex4 utilise une grille binaire (libre / obstacle) ou chaque deplacement coute 1. En pratique, les cartes ont des **terrains varies** : route rapide, herbe, boue, eau... chacun avec un cout different. A* reste optimal a condition d'utiliser une heuristique admissible **adaptee au cout minimum de terrain**.\n",
     "\n",


### PR DESCRIPTION
## Contexte
Audit fidélité #3164 — partition po-2024 Search/.NET-CPU. Closes #$ISSUE_NUM.

La section 9 « Exemple guide » mélange de vrais exemples résolus (items 2/3/4) et **un exercice** (item 5) mal titré « Exemple guide ». Par la règle classer-par-CONTENU, item 5 est un exercice (mission + stub).

## Changes (markdown-only, 2 titres)
- **idx61** (`97bc629e`) : titre `### Exemple guide 5 : …` → `### Exercice 5 : …`. Corps intact (déjà un énoncé de mission). Le code idx62 (`2a6adc42`) est un stub (output `Exercice 5 : implementez les TODO ci-dessus.`), commentaire `# --- Exercice 5 ---` déjà correct.
- **idx53** (`exercises-section`) : `## 9. Exemple guide` → `## 9. Exemples guides et exercices` (neutre).

## Décision G.1 (jugement non-délégué)
Le sous-agent sonnet a énuméré 5 findings ; j'en retiens **1** (item 5) après classification par contenu. Les items 2/3/4 (titre « Exemple guide » + solution complète) sont **cohérents** — un commentaire code résiduel `# --- Exercice N ---` n'est pas un défaut #3164 (pas un claim markdown contredit par output) et l'éditer déclencherait du churn C.2 pour 0 bénéfice (no-pendulum). Item 5 est le seul où le **titre markdown** ment (résolu sur stub), jumeau #1214/#1336.

## Validation
- Sous-agent `sonnet` evidence-cited (local-git-only) + **G.1 parent** : re-dérivation des cell ids + titres + outputs depuis le notebook réel ; lecture complète d'idx61 (confirme la structure « mission »).
- `git diff --stat` : 2 ins / 2 del ; 0 ligne `execution_count`/`outputs`/`cell_type`/`code` ajoutée ; JSON valide ; 0 caractère de contrôle.
- Stub idx62 intact (anti-régression). Catalogue + submodule MGS byte-identiques ; branche fraîche `origin/main`.
- 0 défaut INTERP-VS-OUTPUT / EXERCISE-FABRICATION dans ce notebook (cellules interprétation qualitative, stubs honnêtes).

Closes #$ISSUE_NUM
See #3164