### PR TITLE
fix(search-9): delete 6 stale-duplicate interpretation cells (fabricated values vs committed outputs) (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
@@ -773,47 +773,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6336d1b5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003612,
-     "end_time": "2026-06-03T09:32:23.438947+00:00",
-     "exception": false,
-     "start_time": "2026-06-03T09:32:23.435335+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Premier exemple PuLP\n",
-    "\n",
-    "**Resultats obtenus** :\n",
-    "\n",
-    "| Element | Valeur |\n",
-    "|----------|--------|\n",
-    "| Statut | Optimal |\n",
-    "| $x_1$ (P1) | 1.0 unite |\n",
-    "| $x_2$ (P2) | 1.5 unites |\n",
-    "| Profit ($z$) | 6.0 euros |\n",
-    "\n",
-    "**Analyse** :\n",
-    "1. La solution est **optimale** (statut \"Optimal\")\n",
-    "2. Les contraintes ont des statuts differents :\n",
-    "   - **Machine** : $1 + 2 \\times 1.5 = 4$ (exactement la limite, contrainte saturee)\n",
-    "   - **Main d'oeuvre** : $2 \\times 1 + 1.5 = 3.5 < 5$ (marge de 1.5h)\n",
-    "3. Il reste 1.5 heures de main d'oeuvre non utilisees (**slack**)\n",
-    "\n",
-    "**Terminologie** :\n",
-    "- **Contrainte saturee** (active) : contrainte a la limite (egalite)\n",
-    "- **Contrainte non saturee** (inactive) : contrainte avec de la marge\n",
-    "- **Slack** (ecart) : difference entre le LHS et le RHS d'une contrainte $\\leq$\n",
-    "- **Surplus** : difference entre le LHS et le RHS d'une contrainte $\\geq$\n",
-    "\n",
-    "> **Note** : La contrainte de machine est le \"goulot d'etranglement\" (bottleneck) du systeme. Augmenter cette capacite ameliorerait le profit."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "c103d4b5",
    "metadata": {
     "papermill": {
@@ -1034,46 +993,6 @@
     "- Ce type de probleme se generalise aux problemes de melange (ration animale, industrie petroliere, etc.)\n",
     "\n",
     "> **Note technique** : Pour convertir un probleme de minimisation avec contraintes ≥ en forme standard, on peut soit utiliser la forme canonique (min avec ≥), soit transformer les contraintes (ax ≥ b → -ax ≤ -b) et le dual (min cx = max -cy avec les contraintes transformees).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cc9f563b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003853,
-     "end_time": "2026-06-03T09:32:23.574774+00:00",
-     "exception": false,
-     "start_time": "2026-06-03T09:32:23.570921+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Probleme de diet\n",
-    "\n",
-    "**Resultats** :\n",
-    "\n",
-    "| Element | Valeur |\n",
-    "|----------|--------|\n",
-    "| Cout minimal | 4.80 euros |\n",
-    "| Aliment A ($x_A$) | 2.40 unites |\n",
-    "| Aliment B ($x_B$) | 1.20 unites |\n",
-    "\n",
-    "**Analyse des contraintes** :\n",
-    "\n",
-    "| Contrainte | Valeur | Minimum | Surplus | Statut |\n",
-    "|------------|--------|----------|---------|--------|\n",
-    "| Proteines | 8.4 | 12 | 0 | Saturee |\n",
-    "| Calcium | 30.0 | 30 | 0 | Saturee |\n",
-    "| Fer | 24.0 | 20 | 4 | Non saturee |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. La solution optimale est a l'intersection des contraintes de proteines et calcium\n",
-    "2. La contrainte de fer n'est pas active (surplus de 4mg)\n",
-    "3. Le cout minimal est de 4.80 euros\n",
-    "\n",
-    "> **Remarque** : En pratique, les problemes de diet realistes ont des centaines de variables et de contraintes pour representer tous les nutriments et aliments. Les solutions doivent etre arrondies a des valeurs realistes (on ne peut pas consommer 2.4 unites)."
    ]
   },
   {
@@ -1367,47 +1286,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9358107b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003906,
-     "end_time": "2026-06-03T09:32:23.700256+00:00",
-     "exception": false,
-     "start_time": "2026-06-03T09:32:23.696350+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Probleme de transport\n",
-    "\n",
-    "**Resultats** :\n",
-    "- Cout total minimal : environ 610 euros selon la solution optimale\n",
-    "- La solution optimale utilise les routes les moins couteuses tout en satisfaisant demandes et capacites\n",
-    "\n",
-    "**Analyse de la solution** :\n",
-    "\n",
-    "| Route | Utilisation | Cout unitaire | Cout total |\n",
-    "|-------|-------------|----------------|------------|\n",
-    "| U1 -> M3 | 100 | 1€ | 100€ |\n",
-    "| U2 -> M2 | 120 | 2€ | 240€ |\n",
-    "| U2 -> M4 | 30 | 2€ | 60€ |\n",
-    "| U3 -> M1 | 80 | 3€ | 240€ |\n",
-    "| U3 -> M4 | 120 | 1€ | 120€ |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. L'algorithme privilegie les routes les moins couteuses (U1->M3 a 1€ et U3->M4 a 1€)\n",
-    "2. Toutes les capacites sont utilisees (probleme equilibre)\n",
-    "3. Toutes les demandes sont satisfaites\n",
-    "4. La route U1->M4 (4€) n'est pas utilisee car trop couteuse\n",
-    "\n",
-    "> **Remarque** : Le probleme de transport a une structure particuliere qui permet d'utiliser des algorithmes specialises plus efficaces que le simplexe general (methode du coin nord-ouest, methode de Vogel, stepping stone).\n",
-    "\n",
-    "> **Extension** : Le probleme de transport peut etre etendu au probleme de **transbordement** (avec des points de passage intermediaires) et au probleme d'**affectation** (une source vers une destination unique)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "dc85e5f4",
    "metadata": {
     "papermill": {
@@ -1669,52 +1547,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19fe31a5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003819,
-     "end_time": "2026-06-03T09:32:24.971802+00:00",
-     "exception": false,
-     "start_time": "2026-06-03T09:32:24.967983+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Analyse de sensibilite\n",
-    "\n",
-    "**Resultats observes** :\n",
-    "\n",
-    "| Contrainte | RHS original | Variation | Profit | Variation |\n",
-    "|------------|--------------|------------|--------|-----------|\n",
-    "| Machine | 4 | -1 | ~5 | -1 |\n",
-    "| Machine | 4 | +1 | ~7 | +1 |\n",
-    "| Machine | 4 | +2 | ~8 | +2 |\n",
-    "| MainOeuvre | 5 | -1 | ~6 | 0 |\n",
-    "| MainOeuvre | 5 | +1 | ~6 | 0 |\n",
-    "| MainOeuvre | 5 | +2 | ~6 | 0 |\n",
-    "\n",
-    "**Valeurs duales (shadow prices)** :\n",
-    "- **Machine** : valeur duale ≈ 1€/heure\n",
-    "  - Chaque heure supplementaire de machine augmente le profit de 1€\n",
-    "  - C'est une contrainte **active** (saturee)\n",
-    "  - C'est le goulot d'etranglement (bottleneck)\n",
-    "- **MainOeuvre** : valeur duale = 0€/heure\n",
-    "  - Augmenter la capacite de main d'oeuvre n'augmente pas le profit\n",
-    "  - C'est une contrainte **non active** (du slack existe)\n",
-    "  - Il y a deja de la marge (1.5h non utilisees)\n",
-    "\n",
-    "**Interpretation economique** :\n",
-    "1. La contrainte de machine est le **goulot d'etranglement** (bottleneck)\n",
-    "2. L'entreprise devrait envisager d'augmenter la capacite machine (si le cout marginal < 1€)\n",
-    "3. Augmenter la main d'oeuvre est inutile (il y a deja du slack)\n",
-    "4. La valeur duale indique combien on devrait payer pour une ressource supplementaire\n",
-    "\n",
-    "> **Remarque** : Les valeurs duales ne sont valides que dans une certaine plage de variation (range de sensibilite). Au-dela, la base optimale change et la valeur duale peut varier."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "91c382ad",
    "metadata": {
     "papermill": {
@@ -1906,47 +1738,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00214495",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004796,
-     "end_time": "2026-06-03T09:32:25.246325+00:00",
-     "exception": false,
-     "start_time": "2026-06-03T09:32:25.241529+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Probleme du sac a dos\n",
-    "\n",
-    "**Resultats** :\n",
-    "\n",
-    "| Objet | Selectionne | Poids | Valeur |\n",
-    "|-------|-------------|-------|--------|\n",
-    "| 1 | Oui | 2 kg | 12€ |\n",
-    "| 2 | Oui | 1 kg | 10€ |\n",
-    "| 3 | Non | 3 kg | 20€ |\n",
-    "| 4 | Oui | 2 kg | 15€ |\n",
-    "| 5 | Non | 4 kg | 25€ |\n",
-    "\n",
-    "**Solution optimale** :\n",
-    "- Objets selectionnes : 1, 2, 4\n",
-    "- Valeur totale : 37€\n",
-    "- Poids total : 5 kg\n",
-    "- Capacite restante : 2 kg\n",
-    "\n",
-    "**Analyse** :\n",
-    "1. La solution n'utilise pas toute la capacite (2 kg restants)\n",
-    "2. C'est caracteristique des problemes entiers : le polyedre discret est plus complexe\n",
-    "3. L'objet 5 (25€ pour 4kg) n'est pas selectionne car il empecherait de prendre les objets 1, 2, 4\n",
-    "4. La combinaison {1, 2, 4} est meilleure que {3, 5} car on ne peut pas prendre une fraction d'objet\n",
-    "\n",
-    "> **Comparaison** : Si on relaxait la contrainte d'integralite (PL continue), la solution pourrait inclure des fractions d'objets, donnant une valeur plus elevee (borne superieure)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "c5b66d7c",
    "metadata": {
     "papermill": {
@@ -2085,45 +1876,6 @@
     "- Pour les problemes de sac a dos avec des objets \"petits\" par rapport au sac, le gap est souvent faible\n",
     "\n",
     "> **Note technique** : Le gap d'integralite est defini comme `(Z_relax - Z_integer) / Z_integer`. Un gap nul signifie que la relaxation continue est deja entiere (cas rare en pratique).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8c21e219",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003893,
-     "end_time": "2026-06-03T09:32:25.435985+00:00",
-     "exception": false,
-     "start_time": "2026-06-03T09:32:25.432092+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Comparaison PL vs PLNE\n",
-    "\n",
-    "**Observations** :\n",
-    "\n",
-    "| Aspect | PL Continue | PLNE |\n",
-    "|--------|-------------|------|\n",
-    "| Variables | Reelles | Entieres/Binaires |\n",
-    "| Valeur optimale | Plus elevee | Moins elevee |\n",
-    "| Temps de resolution | Rapide | Plus lent |\n",
-    "| Applicabilite | Approximation | Solution exacte |\n",
-    "\n",
-    "**Gap d'integralite** :\n",
-    "- Difference entre la relaxation continue et la solution entiere\n",
-    "- Mesure la difficulte du probleme (gap faible = probleme \"facile\")\n",
-    "- Gap eleve indique que les contraintes d'integralite sont tres restrictives\n",
-    "\n",
-    "**Strategies de resolution PLNE** :\n",
-    "1. **Branch-and-bound** : exploration systematique de l'espace de solutions\n",
-    "2. **Cutting planes** : ajout de contraintes pour ameliorer la relaxation\n",
-    "3. **Branch-and-cut** : combinaison des deux (utilise par CBC)\n",
-    "4. **Heuristiques** : solutions approchees rapides\n",
-    "\n",
-    "> **Note pratique** : Pour les grands problemes PLNE, il peut etre utile de commencer par la relaxation continue pour obtenir une borne superieure rapide, puis d'appliquer des heuristiques pour trouver une solution realisable de bonne qualite."
    ]
   },
   {


### PR DESCRIPTION
## Contexte
Audit fidélité #3164 — partition po-2024 Search/.NET-CPU. Closes #$ISSUE_NUM.

Chaque section LP avait **deux** cellules d'interprétation : une canonique (alignée output) + une stale (sans sous-titre, résidu version antérieure) portant des valeurs fabriquées/recyclées. Le grain « 6 findings dont 3 stale-duplicate » de la queue Search/Part1.

## Changes (markdown-only, delete)
Suppression des 6 cellules stale : idx16 (`6336d1b5`), idx20 (`cc9f563b`), idx26 (`9358107b`), idx30 (`19fe31a5`), idx34 (`00214495`), idx38 (`8c21e219`). Détail des valeurs fausses vs outputs committés dans l'issue #$ISSUE_NUM.

## Décision G.1 — delete vs edit
**Delete** retenu : la jumelle canonique précédant chaque cellule stale couvre déjà la section et aligne sur l'output. Réécrire les chiffres serait réinventer (idx16/30 recyclent des valeurs d'un autre exemple géométrique). Supprimer retire le narré faux sans perte d'information. 0 référence croisée vers les ids supprimés (vérifié). idx38 (doublon conceptuel sans fabrication) supprimé aussi — idx37 porte déjà le gap/PLNE.

## Validation
- Sous-agent `sonnet` evidence-cited (local-git-only) + **G.1 parent** : re-déris les 6 ids + jumelles canoniques + byte-identity + absence de cross-refs.
- `git diff --stat` : **248 suppressions, 0 insertion** ; 0 ligne `execution_count`/`outputs`/`cell_type:"code"` ajoutée ; JSON valide ; 0 control char.
- 6 jumelles canoniques conservées + toutes cellules code/outputs intactes (ec=6/9/11/12). Stubs intacts (anti-régression).
- Catalogue + submodule MGS byte-identiques ; branche fraîche `origin/main`.

Closes #$ISSUE_NUM
See #3164