### PR TITLE
docs(sw-6): anchor RDFS + entailment-rules citations (fidelity audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
@@ -137,6 +137,8 @@
     "\n",
     "**RDF Schema (RDFS)** est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des donnees RDF. Tandis que RDF permet d'exprimer des faits sous forme de triplets (sujet, predicat, objet), RDFS ajoute la capacite de definir :\n",
     "\n",
+    "> **RDF Schema (RDFS)** est standardise par le **W3C** dans RDF Schema 1.1 (Brickley & Guha, W3C Recommendation 2014). C'est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des donnees RDF -- classes, hierarchies, domaines/portees de proprietes et regles d'inference.\n",
+    "\n",
     "- Des **classes** et des **hierarchies de classes**\n",
     "- Des **proprietes** avec domaine et portee\n",
     "- Des **regles d'inference** implicites\n",
@@ -957,6 +959,8 @@
     "## 4. Inference RDFS\n",
     "\n",
     "L'inference RDFS permet de **deduire automatiquement** de nouveaux triplets a partir des regles RDFS. Le mecanisme principal est la **transitivite de `rdfs:subClassOf`**.\n",
+    "\n",
+    "> Les regles d'inference RDFS presentees ci-dessous (rdfs2, rdfs3, rdfs5, rdfs9, rdfs11) sont les **regles d'entailment** formellement specifiees dans RDF 1.1 Semantics (Hayes & Patel-Schneider, W3C Recommendation 2014). Elles definissent quels triplets peuvent etre deduits a partir d'un graphe RDFS.\n",
     "\n",
     "### Regles d'inference RDFS essentielles\n",
     "\n",
@@ -2149,9 +2153,15 @@
     "\n",
     "Pour ces fonctionnalites, il faut passer a **OWL** (notebook suivant).\n",
     "\n",
+    "## References\n",
+    "\n",
+    "- **RDF Schema 1.1** -- Brickley & Guha, W3C Recommendation (2014). [w3.org/TR/rdf-schema](https://www.w3.org/TR/rdf-schema/)\n",
+    "- **RDF 1.1 Semantics** -- Hayes & Patel-Schneider, W3C Recommendation (2014). Specifie formellement les regles d'entailment rdfs2/3/5/9/11. [w3.org/TR/rdf11-mt](https://www.w3.org/TR/rdf11-mt/)\n",
+    "- **RDF 1.1 Concepts and Abstract Syntax** -- Cyganiak, Wood & Lanthaler, W3C Recommendation (2014). Modele de triplet sur lequel RDFS s'appuie.\n",
+    "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< 5-LinkedData](SW-5-CSharp-LinkedData.ipynb) | [Index](README.md) | [7-OWL >>](SW-7-CSharp-OWL.ipynb)"
+    "**Navigation** :  [<< 5-LinkedData](SW-5-CSharp-LinkedData.ipynb) | [Index](README.md) | [7-OWL >>](SW-7-CSharp-OWL.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Fidelity audit #3164 on the **SemanticWeb family** (po-2026, deep-queue). SW-6-CSharp-RDFS is the 4th HIGH-priority OMISSION (after SW-2 `#3547`, SW-7 `#3556`, SW-4 `#3568`, all MERGED): it teaches **RDFS** and the **rdfs2/rdfs3/rdfs5/rdfs9/rdfs11** inference rules **without a single canonical citation**. The rules are named by their canonical W3C identifiers but the underlying RDF 1.1 Semantics spec is never cited.

This PR closes the OMISSION with minimal, grounded anchors (same pattern as SW-2/SW-7/SW-4).

## Changes (additive, markdown-only)

- **cell 3** (RDFS intro): RDF Schema 1.1 (Brickley & Guha, W3C Rec 2014)
- **cell 16** (inference rules): RDF 1.1 Semantics (Hayes & Patel-Schneider, W3C Rec 2014) — formal source of the rdfs2/3/5/9/11 entailment rules
- **cell 34** (Résumé): **3-entry References section** (RDF Schema 1.1, RDF 1.1 Semantics, RDF 1.1 Concepts)

## Validation (G.1 grounded)
- **+11/-1, markdown-only** — 12 code cells untouched, `exec_count` preserved (C.2/C.3 = **0 churn**)
- **35 cells preserved, all cell IDs byte-identical** to origin/main
- `nbformat.validate` OK; C.1 = 0 forbidden patterns
- All citations are canonical W3C Recommendations (verified — not invented)
- No factual error, no reinvention — pure OMISSION closure

## Scope (atomic, HARD 3)
This PR touches **only SW-6**. Deep-queue order: SW-2 ✓, SW-7 ✓, SW-4 ✓, SW-6 ✓ (this PR), then **SW-13 Reasoners** (HIGH — HermiT/Pizza Ontology/OWL profiles uncited **+ internal SW-13/SW-14 title bug**), then MEDIUM notebooks.

See #3164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)