### PR TITLE
docs(genai-image-02-3): anchor MMDiT / Flow Matching / triple-encoder citations (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-3-Stable-Diffusion-3-5.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-3-Stable-Diffusion-3-5.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "**Stable Diffusion 3.5** représente la dernière génération de modèles de Stability AI, combinant une architecture MMDiT (Multimodal Diffusion Transformer) avec des encodeurs de texte avancés.\n",
+    "**Stable Diffusion 3.5** représente la dernière génération de modèles de Stability AI, combinant une architecture **MMDiT** (Multimodal Diffusion Transformer) [Esser et al. 2024] avec un entraînement par **rectified flow** (Flow Matching) [Lipman et al. 2023], et des encodeurs de texte avancés (triple encodeur CLIP-L, CLIP-G et T5).\n",
     "\n",
     "### Variantes SD 3.5\n",
     "\n",
@@ -1027,10 +1027,17 @@
     "\n",
     "### Points Clés\n",
     "\n",
-    "1. **MMDiT** pour meilleure cohérence\n",
-    "2. **Triple encodeur** (CLIP-L, CLIP-G, T5)\n",
+    "1. **MMDiT** [Esser et al. 2024] pour meilleure cohérence\n",
+    "2. **Triple encodeur** (CLIP-L, CLIP-G, T5) — CLIP [Radford et al. 2021], T5 [Raffel et al. 2020]\n",
     "3. **Turbo** pour génération rapide\n",
-    "4. **Toujours libérer** la mémoire après usage"
+    "4. **Toujours libérer** la mémoire après usage\n",
+    "\n",
+    "### Références savantes\n",
+    "\n",
+    "- **Esser, P., Kulal, S., Blattmann, A., et al.** (2024). *Scaling Rectified Flow Transformers for High-Resolution Image Synthesis*. arXiv:2403.03206. — Article fondateur de l'architecture MMDiT et de l'entraînement par rectified flow qui définissent Stable Diffusion 3 / 3.5.\n",
+    "- **Lipman, Y., Chen, R. T. Q., Ben-Hamu, H., Nickel, M., & Le, M.** (2023). *Flow Matching for Generative Modeling*. ICLR 2023, arXiv:2210.02747. — Formulation théorique du Flow Matching dont le rectified flow est un cas particulier.\n",
+    "- **Radford, A., Kim, J. W., Hallacy, C., et al.** (2021). *Learning Transferable Visual Models From Natural Language Supervision* (CLIP). arXiv:2103.00020. — Encodeurs de texte/image CLIP-L et CLIP-G utilisés par SD 3.5.\n",
+    "- **Raffel, C., Shazeer, N., Roberts, A., et al.** (2020). *Exploring the Limits of Transfer Learning with a Unified Text-to-Text Transformer* (T5). JMLR, arXiv:1910.10683. — T5-XXL, troisième encodeur de texte de SD 3.5 pour la compréhension fine des prompts."
    ]
   },
   {


### PR DESCRIPTION
## Context

Audit fidélité #3164 — GenAI/Image family (po-2023 lane, dispatched by ai-01). **02-3-Stable-Diffusion-3-5** teaches the SD 3.5 architecture but named its core scientific contributions (MMDiT, Flow Matching, triple text encoder) **without any scholarly anchor**, and had no References section.

## Verdict: OMISSION (classe c) — 3 anchors, 0 factual error, 0 reinvention

**G.1 grounding (grep on source):**
- `MMDiT` mentioned **5×** (intro + recap "Points Clés #1") with **0 citation** → Esser et al. 2024 coins the term MMDiT
- `Flow Matching` mentioned **1×** with **0 citation** → Lipman et al. 2023
- `Triple encodeur` (CLIP-L, CLIP-G, T5) recap "Point Clé #2" with **0 citation** → CLIP Radford 2021, T5 Raffel 2020
- `arXiv` / `References` / `Références` count: **0**

## Changes (markdown-only, +11/-4)

- **cell intro**: MMDiT → **[Esser et al. 2024]**, rectified flow (Flow Matching) → **[Lipman et al. 2023]**
- **cell recap Points Clés**: MMDiT + triple encoder (CLIP **[Radford 2021]**, T5 **[Raffel 2020]**)
- **new "Références savantes" section** (4 entries with pedagogical relevance)

## arXiv IDs (G.1 web-verified)

| Citation | arXiv | Source |
|----------|-------|--------|
| Esser 2024 — Scaling Rectified Flow Transformers (MMDiT) | 2403.03206 | ICML 2024, esser24a |
| Lipman 2023 — Flow Matching for Generative Modeling | 2210.02747 | ICLR 2023 |
| Radford 2021 — CLIP | 2103.00020 | ICML 2021 |
| Raffel 2020 — T5 | 1910.10683 | JMLR |

## Validation

- nbformat.validate OK · **0 code cell changed** (14 code cells intact, exec_count preserved) · 27 cells
- cell-order: **0 finding** · C.1: **0** (no raise NotImplementedError)
- catalogue byte-identical (not touched)
- base fresh `origin/main` · LF format preserved (surgical raw edit, no json.dump reflow)

Markdown-only — H.3 not triggered. Forensic `git diff` suffices (H.4).

See #3164