### PR TITLE
fix(#3164): GenAI/Texte 4_Function_Calling — align 2 tool-call REINVENTION + challenge stub C.1

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -601,14 +601,14 @@
     "|-------|--------|---------------|\n",
     "| `id` | `call_XXX` | Identifiant unique pour lier la réponse de l'outil |\n",
     "| `function.name` | `get_weather` | Fonction choisie par le modèle |\n",
-    "| `function.arguments` | `{\"location\": \"Paris\", \"unit\": \"celsius\"}` | Arguments générés (JSON) |\n",
+    "| `function.arguments` | `{\"location\": \"New York, NY\", \"unit\": \"fahrenheit\"}` | Arguments générés (JSON) |\n",
     "\n",
     "**Le modèle a fait quoi exactement ?**\n",
     "\n",
-    "1. Analysé la question : \"Quelle est la météo à Paris aujourd'hui?\"\n",
+    "1. Analysé la question : \"Quelle est la météo à New York aujourd'hui?\"\n",
     "2. Reconnu qu'il a besoin de données en temps réel\n",
     "3. Choisi la fonction `get_weather` (grâce à la description)\n",
-    "4. Extrait les arguments : `location=\"Paris\"`, `unit=\"celsius\"` (valeur par défaut)\n",
+    "4. Extrait les arguments : `location=\"New York, NY\"`, `unit=\"fahrenheit\"`\n",
     "\n",
     "> **Important** : Le modèle ne **exécute PAS** la fonction. Il retourne uniquement les instructions. C'est à l'application de l'exécuter."
    ]
@@ -1716,8 +1716,8 @@
     "\n",
     "**Analyse du comportement :**\n",
     "- **Entrée** : \"Planifie ma journée demain - réveil à 7h, sport à 8h, travail à 9h\"\n",
-    "- **Décomposition automatique** : 3 appels à `create_reminder()` avec des priorités différentes\n",
-    "- **Contextualisation** : Le modèle a assigné `priority=\"high\"` au réveil (plus critique que les autres)\n",
+    "- **Réponse en langage naturel** : plutôt que d'appeler directement `create_reminder()`, le modèle a produit une proposition de planning détaillée et **demandé confirmation** avant de créer les rappels (comportement prudent typique de gpt-5-mini)\n",
+    "- **Pattern observé** : le modèle distingue « planifier » (générer un plan textuel) de « créer un rappel » (action nécessitant un appel d'outil) — il sollicite l'utilisateur pour la `priority` de chaque rappel avant d'agir\n",
     "\n",
     "**Ce pattern est fondamental pour :**\n",
     "- **Agents de productivité** : Transformation de langage naturel en actions multiples\n",
@@ -2332,7 +2332,13 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Challenge a completer\n"
+    }
+   ],
    "source": [
     "# CHALLENGE: Agent mathématique multi-outils\n",
     "# TODO: Implémentez votre agent de calcul\n",
@@ -2355,7 +2361,8 @@
     "# 4. Tester\n",
     "# result = solve_math_expression(\"(10 - 3) * 2 + 5**2\")\n",
     "# print(f\"Résultat: {result['result']}\")\n",
-    "# print(f\"Étapes: {result['steps']}\")\n"
+    "# print(f\"Étapes: {result['steps']}\")\n",
+    "print(\"Challenge a completer\")\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Audit #3164 (po-2026:CoursIA-2) — `MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb`.

**Verdict: FIDÈLE** (mechanics-first teaching of the OpenAI function-calling loop; no citation warranted — ReAct borderline, NOT added since the notebook teaches the loop pattern, not the reason-act-observe paradigm). **+ 2 genuine REINVENTION + 1 C.1 stub hygiene.**

### REINVENTION fixes (align on committed output, no-pendulum)

**1. cell `4ad3741e` — fabricated tool calls**
- Markdown claimed: *"3 appels à `create_reminder()` avec priorités différentes"* + *"priority=high au réveil"*.
- Committed output `d0b3ccbe` shows **0 tool calls** — `"Etapes executees:"` is EMPTY; the model produced a **text planning proposal** and asked confirmation.
- Fix: reworded to reflect the real behavior (text proposal + request confirmation; distinguishes *planifier* vs *créer un rappel*).

**2. cell `e4784ced` — Paris/celsius vs NYC/fahrenheit**
- Markdown table + list showed Paris/celsius but committed output `f1a10a84` shows `{"location":"New York, NY","unit":"fahrenheit"}`.
- Fix: aligned table row + list items 1 and 4 to the committed NYC run.

### C.1 hygiene (challenge stub `vgvqp2b6vjn`)

Was 100% comments, `ec=17` but `outputs=[]` (no active line). Added `print("Challenge a completer")` (ADDITIVE — solution not filled) and executed it to populate the output (stream). The cell now has a coherent execution_count + output instead of ec-with-no-output.

### ENV-BUG (NOT reinvention, correctly untouched)

2 cells (`f1a10a84` + `7d3bd0ee`) return `content=None` — known `gpt-5-mini` reasoning-model behavior (#3571). The markdown does **not** fabricate around them, so this is a genuine env bug, not a reinvention. Tracked separately.

## Verification (reassessed by po-2026:CoursIA-2)

- **G.1 cross-check**: all anchors unique (count==1), output claims re-read against committed cells (`d0b3ccbe`, `f1a10a84`).
- **C.1**: 0 violation (no `raise NotImplementedError`/`assert False`/`1/0`).
- **H.3**: challenge stub now has `execution_count` + coherent output.
- **Scope**: markdown-only + 1 stub print-add. `+15/-8`.
- **Catalog**: `COURSE_CATALOG.generated.json/md` byte-identical to `origin/main`.

**Reassessed by po-2026:CoursIA-2: CONFIRMED REINVENTION** (tool-call fabrication + Paris/NYC value mismatch) — aligned markdown on committed outputs.

See #3164.