### PR TITLE
fix(app-2): align edge count with committed output (Aretes ~30 -> 37) (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
@@ -384,7 +384,7 @@
     "| Propriete | Valeur | Signification |\n",
     "|-----------|--------|---------------|\n",
     "| Sommets | 18 | 18 departements autour de l'Ile-de-France |\n",
-    "| Aretes | ~30 | Frontieres communes entre departements |\n",
+    "| Aretes | 37 | Frontieres communes entre departements |\n",
     "| Degre max | 9 (Seine-et-Marne) | Departement le plus contraint |\n",
     "| Planaire | Oui | Theoreme des 4 couleurs applicable |\n",
     "\n",


### PR DESCRIPTION
Audit fidélité #3164 — partition po-2024 Applications. Closes #3581.

idx8 (`cell-dept-interpretation`) table narrait `Aretes ~30` vs output committé idx7 `Aretes : 37`. Fix markdown-only `~30`→`37` (valeur committée exacte, no-pendulum). 1 ins / 1 del, 0 churn ec/outputs/cell_type, 0 control char, JSON valide, code/output intacts, catalogue+submodule byte-identiques, branche fraîche. G.1 parent re-déris cell id + output. Reste du notebook fidèle.

Closes #3581
See #3164