### PR TITLE
fix(app5): align Timetabling room/timing interpretation to committed outputs (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
@@ -340,13 +340,13 @@
     "| Aspect | Observation | Consequence |\n",
     "|--------|-------------|-------------|\n",
     "| Capacite Amphi_A (120) | Seule salle pour Algo (90) et IA (100) | Conflit pour l'amphi |\n",
-    "| Equipement \"labo\" | Reseaux, Securite, Web le necessitent | Seul Labo_C convient |\n",
+    "| Equipement \"labo\" | Reseaux, Securite, Web le necessitent | Labo_C ou Labo_D |\n",
     "| Dupont enseigne 2 cours | Algo + Systemes | Pas au meme creneau |\n",
     "| Martin enseigne 2 cours | Probas + IA | Idem |\n",
     "\n",
     "Ces observations font emerger les premieres contraintes :\n",
     "1. Les cours a gros effectif (Algo, IA) **doivent** aller dans Amphi_A\n",
-    "2. Les cours \"labo\" (Reseaux, Securite, Web) **doivent** aller dans Labo_C\n",
+    "2. Les cours \"labo\" (Reseaux, Securite, Web) **doivent** aller dans Labo_C ou Labo_D (Reseaux et Web uniquement dans Labo_D)\n",
     "3. Dupont et Martin ont chacun 2 cours : pas de chevauchement possible"
    ]
   },
@@ -1311,12 +1311,12 @@
    "source": [
     "### Interpretation : solution CP-SAT\n",
     "\n",
-    "**Sortie obtenue** : le solveur CP-SAT trouve une solution optimale (ou quasi-optimale) en quelques millisecondes.\n",
+    "**Sortie obtenue** : le solveur CP-SAT trouve une solution optimale (ou quasi-optimale) en une soixantaine de millisecondes (61.6 ms).\n",
     "\n",
     "| Aspect | Glouton | CP-SAT | Commentaire |\n",
     "|--------|---------|--------|-------------|\n",
     "| Faisabilite | Oui | Oui (garanti si solution existe) | CP-SAT est complet |\n",
-    "| Temps de calcul | < 1 ms | Quelques ms | Les deux sont rapides ici |\n",
+    "| Temps de calcul | < 1 ms | ~60 ms | Les deux sont rapides ici |\n",
     "| Optimisation souples | Non | Oui | Difference majeure |\n",
     "| Equilibre des jours | Mediocre | Bien meilleur | Grace a l'objectif |\n",
     "| Trous enseignants | Non minimises | Minimises | Grace aux penalites |\n",
@@ -2097,10 +2097,10 @@
     "|-------|----------|---------------|-------------|-------------|\n",
     "| Amphi_A | 120 | Algo, IA (gros effectifs) | Variable | Seule salle pour les grands groupes |\n",
     "| Salle_B | 60 | Probas, Systemes, BDD | Variable | Usage modere |\n",
-    "| Labo_C | 40 | Reseaux, Securite, Web | Variable | Contrainte d'equipement |\n",
+    "| Labo_C | 40 | Securite | Variable | Seul labo pour Securite (40 etu) avec Labo_D |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Les contraintes d'equipement creent un **goulot d'etranglement** sur Labo_C (3 cours pour 1 salle)\n",
+    "1. Les contraintes d'equipement creent un **goulot d'etranglement** sur Labo_D (Reseaux et Web ne peuvent aller qu'a Labo_D, 2 cours pour 1 salle)\n",
     "2. Amphi_A est sous-utilise en proportion mais indispensable pour les gros effectifs\n",
     "3. L'equilibre des jours depend directement de l'objectif d'optimisation"
    ]


### PR DESCRIPTION
## Summary

Closes #3587. Audit fidélité #3164 (epic, \`See #3164\`).

App-5-Timetabling had 3 Class A interpretation cells whose claims contradicted the committed room-compatibility output (idx8), room definition (idx5), and actual CP-SAT assignment (idx19).

## Changes (markdown-only, 3 cells / 6 lines)

| Cell | Before → After | Source output |
|------|----------------|---------------|
| idx6 `cell-data-interpretation` table | "Seul Labo_C convient" → "Labo_C ou Labo_D" | idx8 ec=4: Reseaux/Web → Labo_D only |
| idx6 point 2 | "aller dans Labo_C" → "Labo_C ou Labo_D (Reseaux/Web Labo_D)" | idx5 ec=3: 2 labo rooms |
| idx22 prose | "en quelques millisecondes" → "61.6 ms" | idx19 ec=9: 61.6 ms |
| idx22 table | "Quelques ms" → "~60 ms" | idx19 ec=9 |
| idx35 Labo_C row | "Reseaux, Securite, Web" → "Securite" | idx19 assignment: Reseaux/Web → Labo_D |
| idx35 point 1 | "goulot sur Labo_C (3 cours)" → "goulot sur Labo_D (Reseaux+Web, 2 cours)" | idx19 assignment |

## Verification

- \`git diff --stat\`: 6 ins / 6 del (symmetric)
- 0 structural churn
- 0 control chars in edited cells
- JSON valid
- Catalogue + MGS submodule byte-identical to origin/main (3-dot diff = empty)
- Branch fresh from origin/main