### PR TITLE
docs(ml-3): anchor LightGBM/SDCA/FastTree/AutoML citations + add References (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
@@ -157,7 +157,7 @@
    },
    "source": [
     "## Les entraîneurs dans ML.Net\n",
-    "ML.NET fournit une variété d'entraîneurs. Vous pouvez en trouver la plupart sous le [StandardTrainersCatalog](https://docs.microsoft.com/dotnet/api/microsoft.ml.standardtrainerscatalog?view=ml-dotnet). Exemples d'entraîneurs : des entraîneurs linéaires comme `SDCA`, `Lbfgs`, `LinearSvm` et des entraîneurs non linéaires basés sur les arbres comme `FastTree`, `RandomForest` et `LightGbm`. En général, les capacités de chaque entraîneur sont différentes. Les modèles non linéaires ont parfois de meilleures performances d'entraînement (perte plus faible) que les modèles linéaires, mais cela ne signifie pas toujours qu'ils sont toujours le meilleur choix. Choisir le bon entraîneur pour construire le meilleur modèle pour vos données nécessite de nombreux essais et erreurs.\n",
+    "ML.NET fournit une variété d'entraîneurs. Vous pouvez en trouver la plupart sous le [StandardTrainersCatalog](https://docs.microsoft.com/dotnet/api/microsoft.ml.standardtrainerscatalog?view=ml-dotnet). Exemples d'entraîneurs : des entraîneurs linéaires comme `SDCA` (Shalev-Shwartz & Zhang, 2013), `Lbfgs`, `LinearSvm` et des entraîneurs non linéaires basés sur les arbres comme `FastTree` (Friedman, 2001), `RandomForest` et `LightGbm` (Ke et al., 2017). En général, les capacités de chaque entraîneur sont différentes. Les modèles non linéaires ont parfois de meilleures performances d'entraînement (perte plus faible) que les modèles linéaires, mais cela ne signifie pas toujours qu'ils sont toujours le meilleur choix. Choisir le bon entraîneur pour construire le meilleur modèle pour vos données nécessite de nombreux essais et erreurs.\n",
     "\n",
     "### Surapprentissage et sous-apprentissage\n",
     "Le surapprentissage et le sous-apprentissage sont les deux problèmes les plus courants que vous rencontrez lors de l'entraînement d'un modèle. Le sous-apprentissage signifie que l'entraîneur sélectionné n'est pas assez performant pour ajuster le jeu de données d'entraînement et résulte généralement en une perte élevée pendant l'entraînement et un score/métrique faible sur le jeu de test. Pour résoudre ce problème, vous devez soit sélectionner un modèle plus puissant, soit effectuer davantage d'ingénierie des fonctionnalités. Le surapprentissage est l'inverse, ce qui se produit lorsque le modèle apprend trop bien les données d'entraînement. Cela résulte généralement en une perte faible pendant l'entraînement mais une perte élevée sur le jeu de test.\n",
@@ -446,6 +446,8 @@
    },
    "source": [
     "## Utiliser AutoML pour simplifier la sélection des entraîneurs et l'optimisation des hyper-paramètres\n",
+    "\n",
+    "L'AutoML (Hutter, Kotthoff & Vanschoren, 2019) automatise la sélection d'algorithme et l'optimisation des hyper-paramètres (HPO).\n",
     "La sélection des entraîneurs et l'optimisation des hyper-paramètres est un processus important avec beaucoup d'essais et d'erreurs. Ce processus peut être automatisé et simplifié en utilisant les capacités intégrées de `AutoMLExperiment`. `AutoMLExperiment` applique les dernières recherches de Microsoft Research pour effectuer une optimisation des hyper-paramètres rapide, précise et complète avec un budget de temps limité.\n",
     "\n",
     "Le code ci-dessous montre comment utiliser `AutoMLExperiment` pour trouver le meilleur entraîneur ainsi que ses meilleurs hyper-paramètres sur le jeu de données non linéaire utilisé dans l'Exemple 2. Tout d'abord, un `SweepableEstimatorPipeline` est créé via `context.Auto().Regression(\"y\")`, qui renvoie les régressions les plus populaires avec leur espace de recherche par défaut dans ML.Net. Ensuite, un `AutoMLExperiment` est créé. Il utilise `RootMeanSquaredError` comme métrique d'optimisation et la validation train-test pour évaluer le score des essais, et utilise `NotebookMonitor` pour présenter le processus d'entraînement. Une fois l'entraînement terminé, il renvoie le meilleur essai comme résultat.\n"
@@ -1420,8 +1422,8 @@
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
-    "| SDCA | Entraîneur linéaire (Stochastic Dual Coordinate Ascent) |\n",
-    "| LightGBM | Entraîneur non-linéaire basé sur les arbres de décision |\n",
+    "| SDCA (Shalev-Shwartz & Zhang, 2013) | Entraîneur linéaire (Stochastic Dual Coordinate Ascent) |\n",
+    "| LightGBM (Ke et al., 2017) | Entraîneur non-linéaire basé sur les arbres de décision |\n",
     "| Surapprentissage | Modèle performant sur train mais pas sur test |\n",
     "| Sous-apprentissage | Modèle insuffisamment puissant pour les données |\n",
     "| AutoMLExperiment | Recherche automatique du meilleur algorithme et hyperparamètres |\n",
@@ -1434,6 +1436,25 @@
     "- Un bon modèle minimise la perte à la fois sur le train set et le test set\n",
     "\n",
     "**Navigation** : [Index](README.md) | [<< ML-2 Data&Features](ML-2-Data%26Features.ipynb) | [Suivant >> ML-4 Evaluation](ML-4-Evaluation.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "refs-bibliography-ml3",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "**Algorithmes d'entraînement**\n",
+    "- Shalev-Shwartz, S., & Zhang, T. (2013). *Stochastic Dual Coordinate Ascent Methods for Regularized Loss Minimization*. Journal of Machine Learning Research, 14, 567-599. — algorithme SDCA, entraîneur linéaire de ML.NET.\n",
+    "- Friedman, J. H. (2001). *Greedy Function Approximation: A Gradient Boosting Machine*. Annals of Statistics, 29(5), 1189-1232. — Gradient Boosting Decision Trees (GBDT), fondement des entraîneurs `FastTree` et `RandomForest` de ML.NET.\n",
+    "- Ke, G., Meng, Q., Finley, T., Wang, T., Chen, W., Ma, W., Ye, Q., & Liu, T.-Y. (2017). *LightGBM: A Highly Efficient Gradient Boosting Decision Tree*. NeurIPS. — entraîneur `LightGbm` utilisé tout au long du notebook.\n",
+    "\n",
+    "**Automated Machine Learning (AutoML)**\n",
+    "- Hutter, F., Kotthoff, L., & Vanschoren, J. (2019). *Automated Machine Learning: Methods, Systems, Challenges*. Springer. — AutoML et optimisation des hyper-paramètres (HPO), base de l'`AutoMLExperiment` de ML.NET.\n",
+    "\n",
+    "**Framework (ML.NET)**\n",
+    "- Ahmed, Z., Ward, L., et al. (2019). *Machine Learning at Microsoft with ML.NET*. ACM SIGKDD (KDD)."
    ]
   }
  ],


### PR DESCRIPTION
## Audit fidélité #3164 — ML-3-Entrainment&AutoML (suite famille ML.Net)

3e grain **ML.Net** (après ML-7 #3543, ML-1 #3554, tous deux mergés). Ai-01 cycle :23 a confirmé : **prochain = ML-3 (meilleur yield algos-nommés)**.

### Verdict : 4 OMISSIONS (classe c) ancrées + section References créée, 0 erreur factuelle, 0 REINVENTION

**HIGH-yield grain (vs ML-1 intro)** : ML-3 est un **vrai cours d'algorithmes**. LightGBM (flagship non-linéaire), SDCA (linéaire), FastTree (GBDT), AutoML/HPO sont **tous enseignés en markdown dédié** (cell 2 catalog + cell 8 section AutoML) — pas des choix d'API en code. 0 citation, 0 References au départ.

| Point d'enseignement | Citation canonique ancrée |
|---|---|
| Catalogue entraîneurs (cell 2) : SDCA | **Shalev-Shwartz & Zhang 2013** (JMLR) |
| Catalogue entraîneurs (cell 2) : FastTree | **Friedman 2001** (Annals of Statistics, GBDT) |
| Catalogue entraîneurs (cell 2) : LightGbm | **Ke, Meng, Finley et al. 2017** (NeurIPS) |
| Section AutoML/HPO dédiée (cell 8) | **Hutter, Kotthoff & Vanschoren 2019** (Springer) |
| Table résumé (cell 18) : SDCA + LightGBM | ancrés dans la table |

**Section References ajoutée** (5 entrées, aucune n'existait) : + **Friedman 2001** (Greedy Function Approximation / Gradient Boosting — fondement de `FastTree` et `RandomForest`), **Ahmed et al. 2019** (ML.NET).

### Discipline G.5 (ce qui n'a PAS été ancré, honnêtement)
- **Surapprentissage / sous-apprentissage** (cell 2, section dédiée mais = vocabulaire intro fondamental, pas un algorithme nommé) → pas d'ancre.
- **Lbfgs / LinearSvm / RandomForest / AveragedPerceptron / OnlineGradientDescent** : mentionnés en catalog/code mais sans traitement pédagogique markdown central → References-only ou omis (RF couvert par Friedman 2001 dans References).

### Continuité familiale (pas de duplication)
SDCA (Shalev-Shwartz) et Hutter apparaissent déjà dans les References de ML-1 — c'est une **continuité correcte au sein de la famille ML.Net**, pas une duplication (même cours, même fondation citée là où chaque notebook l'enseigne).

### Validation
- **Markdown-only** (+25/-4) — 4 remplacements inline + 1 cellule References appendée.
- C.2/C.3 : **0 churn** `execution_count`/`outputs` (8 code cells intactes) · C.1 = 0 · `scan_cell_ordering` clean · catalogue **byte-identique** · branche fraîche `origin/main`.
- **Repo CI validator (`notebook_tools.py validate`) : OK** (exit 0).
- **Note hygiène (follow-up, hors scope)** : artefact papermill pré-existant sur `origin/main` (props `execution_count`/`outputs` sur cellules markdown) → fait échouer le *strict* `nbformat.validate` mais pas le validator CI. Passe hygiène dédiée famille ML.Net après l'audit (per ai-01).

### Leçon technique
Le `&` dans `ML-3-Entrainment&AutoML.ipynb` casse le parsing d'args `git add <path>` littéral et `os.path` direct. **Workaround validé** : `os.path.join()` (Python) + glob `ML-3-*.ipynb` (git add) contournent le `&`. À noter pour les futurs notebooks avec `&` dans le nom.

See #3164
