### PR TITLE
fix(infer-16): audit fidelite #3164 Infer-16-Decision-Multi-Attribute -- ERREUR/NAV/LABELING

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Decision-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Decision-Multi-Attribute.ipynb
@@ -1152,7 +1152,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Determination de swing weights pour un choix d'appartement\n",
+    "## Exercice 1 : Determination de swing weights pour un choix d'appartement\n",
     "\n",
     "**Objectif** : Appliquez la methode des swing weights pour determiner les poids d'une decision d'achat d'appartement.\n",
     "\n",
@@ -1533,7 +1533,30 @@
   {
    "cell_type": "markdown",
    "id": "ef7a7098",
-   "source": "## Exercice : Forme multiplicative pour un choix d'investissement\n\n**Objectif** : Utilisez la forme multiplicative de l'utilite pour comparer des options d'investissement avec interactions entre attributs.\n\n**Contexte** : Vous choisissez entre 3 investissements avec les profils suivants (utilites normalisees 0-1) :\n\n| Investissement | Rendement (u1) | Risque (u2, 0=sur) | Liquidite (u3) |\n|----------------|----------------|---------------------|----------------|\n| Obligations    | 0.3            | 0.9                 | 0.7            |\n| Actions        | 0.8            | 0.3                 | 0.5            |\n| Immobilier     | 0.6            | 0.5                 | 0.2            |\n\n**Etapes** :\n1. Creez une instance de `MultiplicativeUtility` avec des poids {0.4, 0.35, 0.35}\n2. Calculez U_mult pour chaque investissement\n3. Comparez avec la forme additive (U_add = somme wi * ui)\n4. Interpretez le signe de K : les attributs sont-ils complements ou substituts ?\n\n**Indices** :\n- # Indice 1 : K < 0 signifie que les attributs sont substituts (un bon compense un mauvais)\n- # Indice 2 : La difference entre U_mult et U_add est maximale quand les attributs sont extremes (0 ou 1)\n- # Indice 3 : Si K est proche de 0, la forme additive est une bonne approximation",
+   "source": [
+    "## Exercice 2 : Forme multiplicative pour un choix d'investissement\n",
+    "\n",
+    "**Objectif** : Utilisez la forme multiplicative de l'utilite pour comparer des options d'investissement avec interactions entre attributs.\n",
+    "\n",
+    "**Contexte** : Vous choisissez entre 3 investissements avec les profils suivants (utilites normalisees 0-1) :\n",
+    "\n",
+    "| Investissement | Rendement (u1) | Risque (u2, 0=sur) | Liquidite (u3) |\n",
+    "|----------------|----------------|---------------------|----------------|\n",
+    "| Obligations    | 0.3            | 0.9                 | 0.7            |\n",
+    "| Actions        | 0.8            | 0.3                 | 0.5            |\n",
+    "| Immobilier     | 0.6            | 0.5                 | 0.2            |\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Creez une instance de `MultiplicativeUtility` avec des poids {0.4, 0.35, 0.35}\n",
+    "2. Calculez U_mult pour chaque investissement\n",
+    "3. Comparez avec la forme additive (U_add = somme wi * ui)\n",
+    "4. Interpretez le signe de K : les attributs sont-ils complements ou substituts ?\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : K < 0 signifie que les attributs sont substituts (un bon compense un mauvais)\n",
+    "- # Indice 2 : La difference entre U_mult et U_add est maximale quand les attributs sont extremes (0 ou 1)\n",
+    "- # Indice 3 : Si K est proche de 0, la forme additive est une bonne approximation"
+   ],
    "metadata": {}
   },
   {
@@ -2587,7 +2610,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Analyse de sensibilite multi-attributs\n",
+    "## Exercice 3 : Analyse de sensibilite multi-attributs\n",
     "\n",
     "**Objectif** : Realisez une analyse de sensibilite complete pour determiner quel poids est le plus critique dans un choix de carriere.\n",
     "\n",
@@ -2824,10 +2847,10 @@
     "\n",
     "| Projet | E[U] | Interpretation |\n",
     "|--------|------|----------------|\n",
-    "| **A** | ~0.514 | Gagnant |\n",
-    "| B | ~0.490 | Perdant |\n",
+    "| **A** | 0.5055 | Gagnant |\n",
+    "| B | 0.4828 | Perdant |\n",
     "\n",
-    "**Ecart** : environ 4.9% en faveur du Projet A\n",
+    "**Ecart** : environ 4.5% en faveur du Projet A\n",
     "\n",
     "### Decomposition de la decision\n",
     "\n",
@@ -3583,7 +3606,7 @@
     "tags": []
    },
    "source": [
-    "## 11. Exemple guide : Decision Multi-Criteres avec Incertitude\n",
+    "## Exercice 4 : Decision Multi-Criteres avec Incertitude\n",
     "\n",
     "### Objectif\n",
     "\n",
@@ -3650,7 +3673,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Decision SMART avec attributs incertains via Infer.NET\n",
+    "// Exercice : Decision SMART avec attributs incertains via Infer.NET\n",
     "\n",
     "// Poids SMART (repris de la section 7)\n",
     "double w_sal = 0.30;\n",


### PR DESCRIPTION
## Audit fidélité #3164 — Infer-16-Decision-Multi-Attribute

15e notebook Infer audité (3e Decision-Utility 14-20). Kernel `.net-csharp`, 51 cells (28 md / 23 code). **Substantively bon** (0 INVENTION, 30+ FIDÈLES, arithmétique MAUT/SMART/Dirichlet interne cohérente). **6 défauts** (31 ins / 8 del, 0 ligne `execution_count`/`outputs`).

## Défauts corrigés

### ERREUR-FACTUELLE (1)
1. **idx39** (`89a2b891`) : table E[U] `A ~0.514 / B ~0.490` + écart « ~4.9% » contredisait l'output committé idx38 `E[U(A)] = 0,5055 / E[U(B)] = 0,4828`. Aligné sur `0.5055 / 0.4828` (gap réel 4.5% relatif au gagnant). Valeurs gonflées vraisemblablement issues d'une run Monte-Carlo antérieure non re-syncée.

### NAVIGATION (3)
2. **idx20** (`6495d3f3`) `## Exercice : Determination de swing weights...` non numéroté → `## Exercice 1 :`.
3. **idx26** (`ef7a7098`) `## Exercice : Forme multiplicative...` non numéroté → `## Exercice 2 :`.
4. **idx36** (`ed5e5674`) `## Exercice : Analyse de sensibilite...` non numéroté → `## Exercice 3 :`.

### NAVIGATION + LABELING pathology n°5 (1 — fix combiné)
5. **idx48** (`43c800a8`) `## 11. Exemple guide : Decision Multi-Criteres avec Incertitude` → `## Exercice 4 : ...` — **résout le doublon `## 11.`** (avec idx50 `## 11. Resume`) **ET** la pathology n°5 (header "Exemple guide" sur stub creux idx49) en un seul edit.

### LABELING (1)
6. **idx49** (`ec011188`) commentaire `// Exemple guide : Decision SMART...` sur **stub creux** (7 TODO, `Console.WriteLine("A implementer...")`, 0 InferenceEngine) → `// Exercice :`.

## Fidèle vérifié (spot-checks G.1 parent)
- Voitures : Hybride D=0.768 best, Economique A=0.750, Familiale B=0.732, Sport C=0.358 (idx14) ✓
- Décomposition contributions somment aux V (idx16) ✓
- Swing weights Securite=35.7% / Prix=32.1% / Conso=17.9% / Confort=14.3% (idx18) ✓
- U_mult K=−0.2565, formule Debreu-Gorman `(prod(1+K·ki·ui)−1)/K` exacte (idx22) ✓
- SMART career Freelance V=0.650 best (idx28/30) ✓
- Sensibilité Freelance domine w_salaire>25% (idx32/34) ✓
- Infer.NET decision Projet A E[U]=0.5055 > 0.4828 (idx38) ✓
- Dirichlet posterior (3,4,1,1) choix {1,0,1,1,0} (idx43) ✓
- **§10 Exemple guide idx41** = worked example GÉNU (3 options V=0.705/0.665/0.750) intact.

**#3473 N/A** : idx47 factor-graph = **ASCII-art délibéré** (`ShowFactorGraph` commenté « peut causer un crash du kernel »), PAS un fallback Graphviz → aucun caveat nécessaire (bonne observation sub-agent).

## Gates
- **G1** `scan_cell_ordering` : 1 clean, 0 finding.
- **G2** `check_c2_compliance` : 1/1 compliant.
- **G3** `notebook_tools validate` : 0 Errors (Warning 1 = **FP LaTeX `$`-balance pré-existant**, baseline `origin/main` identique).
- **G4** git diff : 31 ins / 8 del, markdown + 1 commentaire code, **0 ligne `execution_count`/`outputs`** (ec/outputs byte-identiques préservés sur les 6 cells éditées — vérifié G.1), submodules `Automata`/`Z3.Linq` non stagés.

## Méthode
Sous-agent `sonnet` evidence-cited (local-git-only, 0 hallucination d'id) → **cross-check G.1 parent** : re-vérification de l'output idx38 (E[U]=0.5055/0.4828) contre la prose idx39, et décision sobre sur les borderlines (§10bis laissé = intentionnel cross-référencé ; idx34/idx44 arrondis mineurs = pas de contradiction output, non touchés = no-pendulum). Le sub-agent a correctement identifié que #3473 ne s'applique pas (ASCII-art, pas fallback).

Closes #3590
See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
