### PR TITLE
fix(sw13): SemanticWeb SW-13 fidelity anchors + internal title bug

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# SW-14-Reasoners\n",
+    "# SW-13-Reasoners\n",
     "\n",
     "**Navigation** : [<< 13-GraphRAG](SW-12-Python-GraphRAG.ipynb) | [Index](README.md)\n",
     "\n",
@@ -48,6 +48,8 @@
     "## Introduction\n",
     "\n",
     "Les **raisonneurs OWL** (OWL reasoners) sont des moteurs d'inférence capables de déduire des connaissances implicites à partir d'une ontologie. Ils implémentent les règles de sémantique formelle d'OWL (Web Ontology Language).\n",
+    "\n",
+    "> Les profils OWL 2 (**DL**, **RL**, **EL**, **QL**) normalisent un compromis expressivité/complexité calculatoire. Ils sont définis dans le document **OWL 2 Profiles** (Motik, Grau, Horrocks et al., Recommandation W3C 2009/2012), lui-même ancré dans la sémantique formelle d'**OWL 2** (Motik, Patel-Schneider, Cuenca Grau, W3C Rec 2012) et la théorie des *logiques de description* (Baader, Calvanese, McGuinness, Nardi, Patel-Schneider (eds.), *The Description Logic Handbook*, Cambridge University Press, 2e éd. 2007).\n",
     "\n",
     "### Rappels sur les profils OWL 2\n",
     "\n",
@@ -222,7 +224,9 @@
    "source": [
     "## Ontologie de test\n",
     "\n",
-    "Créons une ontologie de test basée sur le domaine de la **pizza** (inspirée de la Pizza Ontology, un benchmark standard en OWL)."
+    "Créons une ontologie de test basée sur le domaine de la **pizza** (inspirée de la Pizza Ontology, un benchmark standard en OWL).\n",
+    "\n",
+    "> La **Pizza Ontology** est l'ontologie didactique de référence du Web Sémantique, popularisée par les tutoriels Protégé de l'Université de Manchester (Rector, Stevens et al.). Son usage pédagogique systématique est analysé dans Rector, Drummond, Stevens et al., *OWL pizzas: Practical experience of teaching OWL-DL — common errors, common patterns* (EKAW 2004), qui catalogue les difficultés récurrentes des apprenants OWL."
    ]
   },
   {
@@ -799,7 +803,9 @@
    "source": [
     "## Raisonneur 2: OWLReady2 + HermiT\n",
     "\n",
-    "**OWLReady2** est un package Python qui permet d'utiliser le raisonneur **HermiT** (Java) depuis Python."
+    "**OWLReady2** est un package Python qui permet d'utiliser le raisonneur **HermiT** (Java) depuis Python.\n",
+    "\n",
+    "> **HermiT** est un raisonneur **OWL 2 DL** complet, conforme à la sémantique directe d'OWL 2. Sa caractéristique distinctive est l'algorithme de *hypertableau*, qui réduit le nombre de branchements lors de la satisfiabilité. Description de référence : Glimm, Horrocks, Motik, Stoilos, Wang, *HermiT: An OWL 2 Reasoner* (Journal of Automated Reasoning, 2014)."
    ]
   },
   {
@@ -3454,6 +3460,14 @@
     "- **OWL 2 DL complet**: HermiT via OWLReady2\n",
     "- **Systèmes critiques**: Growl (vérification formelle)\n",
     "\n",
+    "### Références savantes\n",
+    "\n",
+    "- **OWL 2 Profiles** — Motik, Cuenca Grau, Horrocks et al. (Recommandation W3C, 27 octobre 2009). Définition formelle des profils OWL 2 DL/RL/EL/QL et de leurs compromis complexité.\n",
+    "- **OWL 2 Direct Semantics** — Motik, Patel-Schneider, Cuenca Grau (Recommandation W3C, 11 décembre 2012). Sémantique formelle d'OWL 2 implémentée par les raisonneurs DL (HermiT).\n",
+    "- **The Description Logic Handbook** — Baader, Calvanese, McGuinness, Nardi, Patel-Schneider (eds.), Cambridge University Press, 2e éd. 2007. Référence fondatrice des logiques de description sous-jacentes à OWL.\n",
+    "- **HermiT: An OWL 2 Reasoner** — Glimm, Horrocks, Motik, Stoilos, Wang, *Journal of Automated Reasoning* 53(4), 2014. Description du raisonneur et de l'algorithme hypertableau.\n",
+    "- **OWL pizzas** — Rector, Drummond, Stevens et al., *OWL pizzas: Practical experience of teaching OWL-DL*, EKAW 2004. Origine et analyse pédagogique de la Pizza Ontology utilisée comme ontologie de test.\n",
+    "\n",
     "### Ressources\n",
     "\n",
     "- [W3C OWL 2 RL](https://www.w3.org/TR/owl2-rl/)\n",
@@ -3503,7 +3517,7 @@
     "\n",
     "La difference majeure entre les profils OWL 2 RL et OWL 2 DL a ete illustree par les exercices : le profil RL (owlrl, reasonable) materialise efficacement les hierarchies de classes, les proprietes transitives et les inferences de base, mais ne supporte pas la classification automatique par restrictions `someValuesFrom`. Le profil DL (HermiT) detecte les incoherences ontologiques et classifie les instances selon des regles complexes, ce qui est indispensable dans les domaines critiques (medecine, industrie). Le choix du raisonneur depend donc du compromis entre expressivite requise et performances acceptables.\n",
     "\n",
-    "Ce notebook conclut la serie Semantic Web. Au fil des 14 notebooks, vous avez parcouru l'ensemble de la pile technologique : les triplets RDF (SW-1 a SW-3), les requetes SPARQL (SW-4 a SW-5), les schemas et ontologies RDFS/OWL (SW-6 a SW-7), la validation SHACL (SW-8), les formats modernes JSON-LD et RDF-Star (SW-9 a SW-10), les graphes de connaissances (SW-11), l'integration avec les LLMs via GraphRAG (SW-12), et enfin les moteurs d'inference (SW-13 et SW-14)."
+    "Ce notebook conclut la serie Semantic Web. Au fil des 13 notebooks, vous avez parcouru l'ensemble de la pile technologique : les triplets RDF (SW-1 a SW-3), les requetes SPARQL (SW-4 a SW-5), les schemas et ontologies RDFS/OWL (SW-6 a SW-7), la validation SHACL (SW-8), les formats modernes JSON-LD et RDF-Star (SW-9 a SW-10), les graphes de connaissances (SW-11), l'integration avec les LLMs via GraphRAG (SW-12), et enfin les moteurs d'inference (SW-13)."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Fidelity audit of **SW-13-Python-Reasoners** (Option A, deep-queue SemanticWeb `#3164`, 5th/last HIGH-priority grain after SW-2/SW-7/SW-4/SW-6).

SW-13 taught the four OWL reasoners (owlrl / HermiT / reasonable / Growl), the Pizza Ontology test fixture, and the OWL 2 profiles **WITHOUT a single scholarly citation**, and carried an **internal title bug**: the H1 read `# SW-14-Reasoners` while the file is `SW-13-Python-Reasoners.ipynb` (the series has 13 main notebooks SW-1..SW-13; no SW-14 file exists).

Additive markdown-only fix: 4 scholarly anchors + a 5-entry **References savantes** section + the title bug corrected in the same PR (atomic).

## Changes (markdown-only, +19/-5)

- **cell 0** (title + intro): fix H1 `# SW-14-Reasoners` → `# SW-13-Reasoners`; anchor the OWL 2 profiles comparison table to the **W3C OWL 2 Profiles** Rec (Motik, Cuenca Grau, Horrocks et al., 2009/2012), OWL 2 Direct Semantics Rec, and *The Description Logic Handbook* (Baader et al., 2nd ed. 2007).
- **cell 6** (Ontologie de test): anchor the Pizza Ontology fixture to Rector, Drummond, Stevens et al., *"OWL pizzas: Practical experience of teaching OWL-DL"* (EKAW 2004), its canonical pedagogical reference (Manchester OWL tutorials).
- **cell 22** (Raisonneur 2: HermiT): anchor HermiT to Glimm, Horrocks, Motik, Stoilos, Wang, *"HermiT: An OWL 2 Reasoner"* (Journal of Automated Reasoning, 2014), noting the hypertableau algorithm.
- **cell 85** (Conclusion): add a **Références savantes** section (5 entries: OWL 2 Profiles, OWL 2 Direct Semantics, DL Handbook, HermiT, OWL pizzas) ahead of the existing **Ressources** doc-links block (preserved).
- **cell 87** (Resume et perspectives): fix the series-conclusion count `14 notebooks` → `13 notebooks` and `(SW-13 et SW-14)` → `(SW-13)` to match the corrected title.

## G.1 verification

- 0 scholarly citation and 0 References section existed before (grep on all 88 cells: `Motik`/`Rector`/`Glimm`/`Baader`/`OWL 2 Profiles`/`Références` = 0 each).
- W3C Recs + paper titles **web-checked** (not fabricated): HermiT = Glimm et al. 2014 JAR; Pizza Ontology = Rector et al. EKAW 2004; OWL 2 Profiles = Motik et al. W3C Rec 2009.
- Title bug confirmed: `# SW-14-Reasoners` in cell[0] while file = SW-13; series has 13 main notebooks (SW-1..SW-13 + C#/b variants).

## C.2 / C.3 (anti-churn)

- **0 code cell churn**: 31 code cells, `execution_count` and `outputs` byte-preserved (verified by cell-by-cell comparison against `origin/main`).
- 88 = 88 cells, all cell IDs byte-identical.
- **C.1 = 0** (`raise NotImplementedError` / `assert False` / `1/0`).
- `nbformat.validate` OK.

## CI expectations

Markdown-only (rule-H.3 not triggered). Same pattern as the 4 prior SW fidelity PRs (#3547 SW-2, #3556 SW-7, #3568 SW-4, #3576 SW-6 — all CI 10/10 CLEAN). 10/10 CI CLEAN expected.

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)