### PR TITLE
fix(infer-17): audit fidelite #3164 Infer-17-Decision-Networks -- NAV/LABELING/ERREUR/OMISSION (Closes #3594)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Decision-Networks.ipynb
@@ -1279,7 +1279,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice : Reseau de decision pour un lancement de produit\n",
+    "### Exercice 1 : Reseau de decision pour un lancement de produit\n",
     "\n",
     "Une startup envisage de lancer un nouveau produit. Le marche peut etre **porteur** ou **sature**. Avant de decider, elle peut commander une **etude de marché** couteuse.\n",
     "\n",
@@ -1617,7 +1617,7 @@
     "#### Quand le test deviendrait-il rentable ?\n",
     "\n",
     "Le test serait rentable si :\n",
-    "- Son cout etait inferieur a environ 40 points, OU\n",
+    "- Son cout etait inferieur a environ 10 points, OU\n",
     "- Le prior P(maladie) etait plus eleve (ex: 40%), OU  \n",
     "- L'ecart d'utilite \"traiter malade vs pas traiter malade\" etait plus grand"
    ]
@@ -1636,7 +1636,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice : Decision sequentielle - Maintenance preventive d'une machine\n",
+    "### Exercice 2 : Decision sequentielle - Maintenance preventive d'une machine\n",
     "\n",
     "Dans cette usine, une machine critique peut etre en bon etat ou defaillant. Le responsable maintenance doit prendre **deux decisions sequentielles** :\n",
     "\n",
@@ -2495,7 +2495,10 @@
     "- Les **facteurs** (rectangles) : les distributions conditionnelles et contraintes\n",
     "- Les **aretes** : les dependances entre variables\n",
     "\n",
-    "Cette visualisation aide a comprendre la structure du modele probabiliste.\n"
+    "Cette visualisation aide a comprendre la structure du modele probabiliste.\n",
+    "\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`, cf issue #3473). Le moteur genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais affiche a la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -2610,7 +2613,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Exemple guide : Reseau de Decision Personnalise\n",
+    "## 8. Exercice : Reseau de Decision Personnalise\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -2683,7 +2686,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Reseau de decision Etudiant\n",
+    "// Exercice : Reseau de decision Etudiant\n",
     "\n",
     "// Parametres\n",
     "double pDifficile = 0.4; // P(examen difficile)\n",
@@ -2779,7 +2782,9 @@
    "source": [
     "### Visualisation du Factor Graph : Modele MAUT Multi-Attribut\n",
     "\n",
-    "Le modele MAUT ci-dessus utilise des variables independantes pour chaque attribut de chaque site. La cellule suivante genere le factor graph montrant la structure de ce modele a variables multiples."
+    "Le modele MAUT ci-dessus utilise des variables independantes pour chaque attribut de chaque site. La cellule suivante genere le factor graph montrant la structure de ce modele a variables multiples.\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`, cf issue #3473). Le moteur genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais affiche a la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -3462,7 +3467,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice : Reseau de decision avec Infer.NET - Assurance qualite\n",
+    "### Exercice 3 : Reseau de decision avec Infer.NET - Assurance qualite\n",
     "\n",
     "Une usine fabrique des composants electroniques. Chaque lot peut contenir des **pieces defectueuses** (variable de chance inobservable directement). L'agent de qualite peut :\n",
     "\n",


### PR DESCRIPTION
## Audit fidélité #3164 — Infer-17-Decision-Networks

**16e notebook Infer audité, 4e de la série Decision-Utility (14-20).** Kernel `.net-csharp`, 57 cells (40 md / 17 code). Closes #3594. See #3164.

**Verdict** : substantively bon. **0 INVENTION, 0 ERREUR-FACTUELLE numérique** — tous les anchors décisionnels (Bayes médical idx12/17, investissement idx21, séquentiel idx27, Infer.NET idx33, MAUT aéroport idx50/52) vérifiés numériquement corrects contre les outputs committés.

### Défauts (6, markdown + 1 commentaire code)

| # | Catégorie | Cell (id) | Fix |
|---|-----------|-----------|-----|
| 1 | **ERREUR-FACTUELLE** | idx28 (`8e94a662`) | seuil séquentiel "~40 points" → "~10 points" (EU_test(C)=93.6−C, rentable si C≤9.6 per output EU_test=43.6 vs EU_pasTest=84.0) |
| 2 | NAVIGATION | idx23 (`620feca5`) | `### Exercice : Lancement produit` → `### Exercice 1 :` |
| 3 | NAVIGATION | idx29 (`d047674e`) | `### Exercice : Maintenance` → `### Exercice 2 :` |
| 4 | NAVIGATION | idx53 (`8d7fff68`) | `### Exercice : Assurance qualite` → `### Exercice 3 :` |
| 5 | LABELING pathology n°5 | idx44 (`c9a81107`) + idx46 (`5302ef45`) | `## 8. Exemple guide` + `// Exemple guide` sur stub creux (4 TODOs, ec=14 output="Exercice a completer") → `## 8. Exercice :` + `// Exercice :`. §8 préservé (résout SECTION_GAP). |
| 6 | OMISSION #3473 | idx41 (`2344c618`) + idx49 (`69f45873`) | prose affirmait factor-graph rendu (cercles) mais outputs idx42/idx52 = banner fallback "Graphviz non disponible". Caveats standardisés. |

### No-pendulum decisions (borderlines déférés par sub-agent, tranchés parent G.1)

- **idx51 "~0.55/0.78/0.55"** (MAUT table arrondie) : **laissé** — la prose porte une caveat explicite "valeurs dépendent de l'exécution" + tildes, approximation pédagogique hedged ne contredisant pas l'output.
- **§8bis** (idx48 `## 8bis.`) : **laissé** — convention FR légitime, cross-référencée par idx55 recap, parallèle à `### 7.1`, pas de dup §8/§9.
- **idx40** (ASCII-art factor-graph) : **pas de caveat** — DOT→SVG error dans l'output MAIS le diagramme ASCII est rendu et interprétable (pattern Infer-16 idx47).

### Gates

- G1 scan_cell_ordering : 2 findings résiduels = cell#10/cell#13 DANGLING_INTRO **pré-existants** (FP structurels identiques origin/main). SECTION_GAP + EXERCISE_ORDER résolus.
- G2 check_c2_compliance : 1/1 compliant.
- G3 notebook_tools validate : 0 Errors (Warning 1 = FP LaTeX `$`-balance pré-existant, baseline identique).
- G4 git diff : 13 ins / 8 del, markdown + 1 commentaire code, 0 ligne execution_count/outputs touchée, ec/outputs byte-identiques préservés (idx46 ec=14 output intact). Submodules Automata/Z3.Linq non stagés.

### Pattern récurrent (16e notebook Infer)

NAVIGATION + LABELING + #3473 (absent Infer-13 où Graphviz dispo, ASCII-art Infer-16/17). ERREUR subtype nouveau : seuil de rentabilité mal calculé (flawed-threshold, parenté flawed-reasoning Infer-12/14). Prochain : Infer-18-Decision-Value-Information.

See #3164. See #3473.