### PR TITLE
fix(app7): align Wordle benchmark tables to committed 3.27/3.28/2.89 outputs (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
@@ -2245,13 +2245,13 @@
     "\n",
     "| Approche | Moy. tentatives | Pire cas | Taux de victoire | Temps |\n",
     "|----------|-----------------|----------|-------------------|-------|\n",
-    "| Filtrage simple | ~4-5 | 6+ | Variable | Rapide |\n",
-    "| CSP | ~4-5 | 6+ | Variable | Rapide |\n",
-    "| Entropie | ~3-4 | <= 5 | ~100% | Plus lent |\n",
+    "| Filtrage simple | ~3.3 | 6 | 100% | Rapide |\n",
+    "| CSP | ~3.3 | 6 | 100% | Rapide |\n",
+    "| Entropie | ~2.9 | 5 | 100% | Rapide |\n",
     "\n",
     "**Points cles** :\n",
     "1. **L'entropie gagne** : en moyenne ~1 tentative de moins que les approches aleatoires\n",
-    "2. **Compromis temps/qualite** : l'entropie est plus lente ($O(n^2)$ par tentative) mais plus efficace\n",
+    "2. **Compromis temps/qualite** : la complexite de l'entropie ($O(n^2)$ par tentative) est plus elevee, mais sur cette liste elle reste rapide (0.2 s sur 100 parties) et plus efficace\n",
     "3. **Filtrage vs CSP** : performances similaires car le goulot d'etranglement est le choix du mot, pas le filtrage\n",
     "4. Le pire cas de l'entropie est generalement meilleur grace au choix optimal"
    ]
@@ -2515,7 +2515,7 @@
     "tags": []
    },
    "source": [
-    "On remarque effectivement que les lettres le plus fréquentes de la langue française sont toutes présentes dans les mots avec les entropies les plus élévés"
+    "**A verifier (Exercice 2)** : en completant l'exercice, observez si les lettres les plus frequentes de la langue francaise apparaissent bien dans les mots a haute entropie"
    ]
   },
   {
@@ -2636,9 +2636,9 @@
     "\n",
     "| Approche | Moy. tentatives | Complexite par tentative | Avantage |\n",
     "|----------|-----------------|--------------------------|----------|\n",
-    "| Filtrage simple | ~4-5 | $O(n)$ | Simple et rapide |\n",
-    "| CSP | ~4-5 | $O(n)$ | Structure explicite |\n",
-    "| Entropie | ~3-4 | $O(n^2)$ | Optimal en information |\n",
+    "| Filtrage simple | ~3.3 | $O(n)$ | Simple et rapide |\n",
+    "| CSP | ~3.3 | $O(n)$ | Structure explicite |\n",
+    "| Entropie | ~2.9 | $O(n^2)$ | Optimal en information |\n",
     "\n",
     "### Ce qu'il faut retenir\n",
     "\n",
@@ -2705,7 +2705,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a modélisé le jeu Wordle comme un problème de recherche d'information et comparé trois stratégies de résolution. Le **filtrage simple** élimine les candidats incompatibles mais choisit au hasard, menant à ~4-5 tentatives en moyenne. Le **CSP** structure le problème avec des domaines par position et des contraintes déduites du feedback, offrant une visualisation claire de la propagation. L'approche par **entropie de Shannon** maximise l'information attendue de chaque tentative, réduisant la moyenne à ~3 tentatives grâce au choix optimal du mot le plus discriminant. La comparaison des distributions de feedback montre que le meilleur mot d'ouverture répartit uniformément les candidats entre les patterns, tandis qu'un mauvais mot les concentre dans un seul groupe. Cette leçon transcende le Wordle : maximiser le gain d'information est une stratégie fondamentale en diagnostic médical, dans les arbres de décision et dans tout problème de recherche avec retours partiels."
+    "Ce notebook a modélisé le jeu Wordle comme un problème de recherche d'information et comparé trois stratégies de résolution. Le **filtrage simple** élimine les candidats incompatibles mais choisit au hasard, menant à ~3.3 tentatives en moyenne. Le **CSP** structure le problème avec des domaines par position et des contraintes déduites du feedback, offrant une visualisation claire de la propagation. L'approche par **entropie de Shannon** maximise l'information attendue de chaque tentative, réduisant la moyenne à ~2.9 tentatives grâce au choix optimal du mot le plus discriminant. La comparaison des distributions de feedback montre que le meilleur mot d'ouverture répartit uniformément les candidats entre les patterns, tandis qu'un mauvais mot les concentre dans un seul groupe. Cette leçon transcende le Wordle : maximiser le gain d'information est une stratégie fondamentale en diagnostic médical, dans les arbres de décision et dans tout problème de recherche avec retours partiels."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Closes #3598. Audit fidélité #3164 (epic, \`See #3164\`).

App-7-Wordle interpretation cells narrated a weaker performance profile than the committed benchmark idx41 (ec=17): ~4-5 guesses, "Variable"/"<100%" win, "Plus lent" — while the committed output shows 3.27/3.28/2.89 at exactly 100% win, with Entropie (0.2 s) actually fastest.

## Changes (markdown-only, 4 cells / 9 lines)

| Cell | Before → After | Source output |
|------|----------------|---------------|
| idx42 `benchmark-interpretation` table | ~4-5/~3-4, Variable/win, 6+, "Plus lent" → ~3.3/~2.9, 100%, 6, "Rapide" | idx41 ec=17: 3.27/3.28/2.89 @100, 0.1/0.4/0.2 s |
| idx42 point 2 | "entropie plus lente" → "reste rapide (0.2 s)" | idx41: 0.2 s |
| idx52 `summary-section` table | ~4-5/~3-4 → ~3.3/~2.9 | idx41 ec=17 |
| idx49 `71bc8f26` (Class B) | "On remarque effectivement..." → "A verifier (Exercice 2): observez si..." | idx48 ec=20 stub "Exercice a completer" |
| idx54 `003d40e5` conclusion | ~4-5 → ~3.3 ; ~3 → ~2.9 | idx41 ec=17 |

## Verification

- \`git diff --stat\`: 9 ins / 9 del (symmetric)
- 0 structural churn
- 0 control chars in edited cells
- JSON valid
- Catalogue + MGS submodule byte-identical to origin/main (3-dot diff = empty)
- Branch fresh from origin/main