### PR TITLE
docs(genai-image-02-2): anchor FLUX.1 underlying architecture citations (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb
@@ -83,6 +83,14 @@
     "└─────────────────────────────────────────────────────────┘\n",
     "```\n",
     "\n",
+    "> **Note savante — architecture sous-jacente.** Black Forest Labs n'a pas publié de rapport technique officiel pour FLUX.1 (annonce initiale via blog, août 2024). Les composants architecturaux ci-dessus renvoient aux travaux fondateurs suivants :\n",
+    "\n",
+    "- **DiT / MMDiT** (Diffusion Transformer, architecture transformer du débruiteur) — Peebles & Xie 2022 (DiT, arXiv:2212.09748), généralisée en MMDiT par Esser et al. 2024 (arXiv:2403.03206).\n",
+    "- **Flow Matching** (entraînement par rectified flow, alternatives aux DDPM) — Lipman et al. 2023 (arXiv:2210.02747).\n",
+    "- **Rotary Position Embeddings (RoPE)** — Su et al. 2021 (arXiv:2104.09864).\n",
+    "- **T5-XXL** (encodeur de texte) — Raffel et al. 2020 (arXiv:1910.10683).\n",
+    "- **CLIP-L** (second encodeur de texte) — Radford et al. 2021 (arXiv:2103.00020).\n",
+    "- **VAE Decoder** (latent → pixel space) — Kingma & Welling 2013 (arXiv:1312.6114).\n",
     "## Prérequis\n",
     "\n",
     "- Module 00-GenAI-Environment complété\n",
@@ -1440,7 +1448,17 @@
     "\n",
     "- [FLUX.1 on HuggingFace](https://huggingface.co/black-forest-labs)\n",
     "- [fal.ai Documentation](https://fal.ai/models/fal-ai/flux)\n",
-    "- Notebook suivant: **02-3-Stable-Diffusion-3-5**"
+    "- Notebook suivant: **02-3-Stable-Diffusion-3-5**\n",
+    "\n",
+    "### Références savantes\n",
+    "\n",
+    "- **Peebles, W., & Xie, S.** (2023). *Scalable Diffusion Models with Transformers* (DiT). ICCV 2023, arXiv:2212.09748. — Architecture Diffusion Transformer qui sous-tend le débruiteur de FLUX.1.\n",
+    "- **Esser, P., Kulal, S., Blattmann, A., et al.** (2024). *Scaling Rectified Flow Transformers for High-Resolution Image Synthesis* (MMDiT). arXiv:2403.03206. — Variante multimodale du DiT, base de la famille SD 3 / FLUX.\n",
+    "- **Lipman, Y., Chen, R. T. Q., Ben-Hamu, H., Nickel, M., & Le, M.** (2023). *Flow Matching for Generative Modeling*. ICLR 2023, arXiv:2210.02747. — Formulation du Flow Matching utilisé pour l'entraînement de FLUX.1.\n",
+    "- **Su, J., Lu, Y., Pan, S., Murtadha, A., Wen, B., & Liu, Y.** (2021). *RoFormer: Enhanced Transformer with Rotary Position Embedding* (RoPE). arXiv:2104.09864.\n",
+    "- **Raffel, C., Shazeer, N., Roberts, A., et al.** (2020). *Exploring the Limits of Transfer Learning with a Unified Text-to-Text Transformer* (T5). JMLR, arXiv:1910.10683. — T5-XXL, encodeur de texte principal de FLUX.1.\n",
+    "- **Radford, A., Kim, J. W., Hallacy, C., et al.** (2021). *Learning Transferable Visual Models From Natural Language Supervision* (CLIP). arXiv:2103.00020.\n",
+    "- **Kingma, D. P., & Welling, M.** (2013). *Auto-Encoding Variational Bayes* (VAE). ICLR 2014, arXiv:1312.6114. — Décodeur VAE latent → pixel space."
    ]
   },
   {


### PR DESCRIPTION
## Context

Audit fidélité #3164 — GenAI/Image family (po-2023 lane). **02-2-FLUX-1-Advanced-Generation** taught the FLUX.1 architecture (Multimodal DiT, Flow Matching, Rotary Position Embeddings, T5-XXL, CLIP-L, VAE Decoder) via an ASCII diagram **without any scholarly anchor**, and had no References section.

## Verdict: OMISSION (classe c) — honest absence-of-paper handling, 0 fabricated citation

**G.1 grounding:** Black Forest Labs has **not published an official technical report** for FLUX.1 (initial announcement via blog, August 2024). Anchoring the model to a non-existent paper would be fabrication (G.3). Instead, the anchors cite the **foundational works each architectural component derives from**, explicitly stating the absence of a BFL paper. This is the honest approach confirmed by ai-01 (cycle :23 directive).

## Changes (markdown-only, +19/-1)

- **cell 1 (after architecture diagram)**: scholarly note (BFL no official paper) + 7 component anchors:
  - DiT/MMDiT → Peebles & Xie 2022 (DiT) + Esser et al. 2024 (MMDiT)
  - Flow Matching → Lipman et al. 2023
  - Rotary Position Embeddings (RoPE) → Su et al. 2021
  - T5-XXL → Raffel et al. 2020
  - CLIP-L → Radford et al. 2021
  - VAE Decoder → Kingma & Welling 2013
- **cell 27**: new "Références savantes" section (7 entries)

## arXiv IDs (G.1 web-verified)

| Citation | arXiv | Venue |
|----------|-------|-------|
| Peebles & Xie 2023 — DiT | 2212.09748 | ICCV 2023 |
| Esser et al. 2024 — MMDiT | 2403.03206 | ICML 2024 |
| Lipman et al. 2023 — Flow Matching | 2210.02747 | ICLR 2023 |
| Su et al. 2021 — RoPE | 2104.09864 | — |
| Raffel et al. 2020 — T5 | 1910.10683 | JMLR |
| Radford et al. 2021 — CLIP | 2103.00020 | ICML 2021 |
| Kingma & Welling 2013 — VAE | 1312.6114 | ICLR 2014 |

## Validation

- nbformat.validate OK · **0 code cell changed** (15 code cells intact, exec_count preserved) · 29 cells
- cell-order: **0 finding** · C.1: **0** (no raise NotImplementedError)
- catalogue byte-identical (not touched)
- base fresh `origin/main` · LF format preserved (surgical raw edit, no json.dump reflow)

Markdown-only — H.3 not triggered. Forensic `git diff` suffices (H.4).

See #3164