### PR TITLE
fix(#3164): GenAI/Texte 6_PDF_Web_Search — align 4 REINVENTION + model-name errors + stubs H.3

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
@@ -317,7 +317,7 @@
     "Les modèles OpenAI avec capacités vision peuvent traiter des images et, via l'Assistants API, des fichiers PDF :\n",
     "\n",
     "**Modèles compatibles :**\n",
-    "- `gpt-5-mini` et `gpt-5-mini` (avec vision)\n",
+    "- `gpt-4o-mini` et `gpt-4o` (avec vision)\n",
     "- Tous les modèles vision de la famille GPT-4\n",
     "\n",
     "**Approches pour les documents :**\n",
@@ -540,27 +540,34 @@
    "source": [
     "### Interprétation des résultats\n",
     "\n",
-    "**Ce que le modèle a fait :**\n",
+    "**Observation sur cette exécution :** le modèle a reçu l'image mais n'a renvoyé\n",
+    "aucun contenu textuel — la sortie `=== Analyse du document ===` est restée vide\n",
+    "(seul le compte de tokens, 1482, a été renvoyé). Ce comportement est typique des\n",
+    "modèles de raisonnement lorsqu'aucun texte clair n'est détecté ou que la demande\n",
+    "d'extraction échoue silencieusement : l'appel réussit (pas d'erreur) mais la\n",
+    "sortie est vide.\n",
     "\n",
-    "1. **Reconnaissance optique** : Analyse de l'image et extraction du texte visible\n",
-    "2. **Compréhension sémantique** : Identification des sections (titre, résumé, points clés)\n",
-    "3. **Extraction ciblée** : Sélection des 3 informations principales avec leurs valeurs\n",
+    "**Capacités attendues d'un modèle vision sur un document lisible :**\n",
     "\n",
-    "**Points remarquables :**\n",
+    "1. **Reconnaissance optique** : analyse de l'image et extraction du texte visible\n",
+    "2. **Compréhension sémantique** : identification des sections (titre, résumé, points clés)\n",
+    "3. **Extraction ciblée** : sélection des informations principales avec leurs valeurs\n",
     "\n",
-    "| Capacité | Exemple |\n",
-    "|----------|---------|\n",
-    "| **Lecture de texte** | \"Chiffre d'affaires: 2.5M EUR (+15%)\" |\n",
-    "| **Compréhension structure** | Différenciation titre/sections/listes |\n",
-    "| **Extraction de données** | Reconnaissance de chiffres et pourcentages |\n",
+    "**Limites potentielles (à l'origine d'une extraction vide) :**\n",
     "\n",
-    "**Limites potentielles :**\n",
+    "- **Qualité image** : basse résolution ou flou dégradent la précision\n",
+    "- **Complexité visuelle** : graphiques complexes peuvent être mal interprétés\n",
+    "- **OCR** : polices spéciales ou petites peuvent causer des erreurs ou une absence de sortie\n",
     "\n",
-    "- **Qualité image** : Basse résolution ou flou peuvent dégrader la précision\n",
-    "- **Complexité visuelle** : Graphiques complexes peuvent être mal interprétés\n",
-    "- **OCR** : Polices spéciales ou petites peuvent causer des erreurs\n",
+    "> **Note technique** : le modèle vision traite l'image en tokens visuels. OpenAI\n",
+    "> facture l'image selon un découpage en tuiles de 512×512 pixels ; une image\n",
+    "> 800×1000 couvre plusieurs tuiles et consomme ici 1482 tokens au total\n",
+    "> (usage effectif constaté sur cette exécution).\n",
     "\n",
-    "> **Note technique** : Le modèle vision traite l'image en tokens visuels. Une image 800×1000 consomme environ 1105 tokens (calcul OpenAI : `(largeur/512) × (hauteur/512) × 170`)."
+    "> **Référence** : les modèles vision-langage multimodaux qui combinent OCR et\n",
+    "> compréhension sémantique s'inspirent de travaux comme Flamingo\n",
+    "> (Alayrac et al. 2022, *Flamingo: a Visual Language Model for Few-Shot Learning*,\n",
+    "> arXiv:2204.14198)."
    ]
   },
   {
@@ -574,8 +581,14 @@
    "id": "555f6bba",
    "source": "# Exercice 1 : Analyser une image personnalisee avec l'API Vision\n# TODO etudiant : Creez une image avec un tableau de ventes et analysez-la\n\n# Etape 1 : Creer une image avec PIL contenant un tableau de ventes\n# from PIL import Image, ImageDraw, ImageFont\n# import io, base64\n#\n# img = Image.new('RGB', (600, 300), 'white')\n# draw = ImageDraw.Draw(img)\n# draw.text((50, 30), \"Ventes Mensuelles 2026\", fill='black')\n# draw.text((50, 80), \"Janvier: 120k EUR\", fill='black')\n# draw.text((50, 120), \"Fevrier: 145k EUR\", fill='black')\n# draw.text((50, 160), \"Mars: 160k EUR\", fill='black')\n# draw.text((50, 200), \"Avril: 180k EUR\", fill='black')\n#\n# buffer = io.BytesIO()\n# img.save(buffer, format='PNG')\n# img_b64 = base64.b64encode(buffer.getvalue()).decode()\n\n# Etape 2 : Envoyer l'image au modele Vision\n# response_vision = client.chat.completions.create(\n#     model=DEFAULT_MODEL,\n#     messages=[{\n#         \"role\": \"user\",\n#         \"content\": [\n#             {\"type\": \"text\", \"text\": \"Extrais les ventes mensuelles de cette image et identifie la tendance.\"},\n#             {\"type\": \"image_url\", \"image_url\": {\"url\": f\"data:image/png;base64,{img_b64}\"}}\n#         ]\n#     }],\n#     max_completion_tokens=300\n# )\n\n# Etape 3 : Afficher le resultat\n# print(response_vision.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -599,14 +612,17 @@
     "- Accès à des informations en temps réel (actualités, cours boursiers, météo, etc.)\n",
     "- **Citations automatiques** : Le modèle cite ses sources\n",
     "- Disponible via la **Responses API** (bêta)\n",
-    "- Modèles compatibles : `gpt-5-mini`, `gpt-5-mini`\n",
+    "- Modèles compatibles : `gpt-4o-mini`, `gpt-4o`\n",
     "\n",
     "**Différence avec Chat Completions :**\n",
     "- Responses API : Interface simplifiée avec `input` et `output`\n",
     "- Support natif des outils comme web_search\n",
     "- Moins de contrôle sur les paramètres avancés\n",
     "\n",
-    "**Note importante :** Cette fonctionnalité est en préversion et peut évoluer."
+    "**Note importante :** Cette fonctionnalité est en préversion et peut évoluer.\n",
+    "\n",
+    "> **Référence** : l'enrichissement d'une réponse par recherche web en temps réel s'apparente au *Retrieval-Augmented Generation* (RAG) — Lewis et al. 2020, *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks*, arXiv:2005.11401.\n",
+    ""
    ]
   },
   {
@@ -830,8 +846,14 @@
    "id": "eac64aba",
    "source": "# Exercice 2 : Comparaison multi-sources avec web search\n# TODO etudiant : Creez une requete de recherche web comparee\n\n# Etape 1 : Formuler la requete avec demande de balance\n# query_debat = \"\"\"\n# Faut-il reguler les modeles d'IA generative ?\n# Presente les arguments pour et contre, en citant au moins 3 sources distinctes.\n# \"\"\"\n\n# Etape 2 : Appeler la Responses API avec web search\n# response_debat = client.responses.create(\n#     model=DEFAULT_MODEL,\n#     tools=[{\"type\": \"web_search_preview\"}],\n#     input=query_debat\n# )\n\n# Etape 3 : Extraire le texte et les citations\n# for item in response_debat.output:\n#     if hasattr(item, 'content'):\n#         for content in item.content:\n#             if hasattr(content, 'text'):\n#                 print(content.text)\n#                 print(f\"\\nSources citees: {len(content.annotations)}\")\n#                 for ann in content.annotations:\n#                     print(f\"  - {ann.title}: {ann.url}\")\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1001,11 +1023,19 @@
     "[SYNTHÈSE] → Rapport comparatif enrichi\n",
     "```\n",
     "\n",
-    "**Pourquoi cette approche est puissante :**\n",
+    "**Observation sur cette exécution :** l'étape d'extraction (vision) a renvoyé un\n",
+    "résultat vide — les `Données extraites du document` sont restées vides, donc la\n",
+    "requête web ne contenait aucun chiffre réel à contextualiser. En conséquence, le\n",
+    "modèle a demandé à l'utilisateur de fournir les indicateurs rather que de\n",
+    "synthétiser un rapport comparatif. Le pipeline ci-dessus décrit l'architecture\n",
+    "attendue ; sur cette exécution la étape d'extraction a échoué silencieusement et\n",
+    "la synthèse n'a pas pu se produire.\n",
     "\n",
-    "1. **Données internes** (PDF) : Informations propriétaires, chiffres précis\n",
-    "2. **Contexte externe** (Web) : Comparaison sectorielle, tendances marché\n",
-    "3. **Synthèse** : Analyse comparative que ni la source PDF ni le web seuls ne peuvent fournir\n",
+    "**Pourquoi cette approche est puissante (quand l'extraction réussit) :**\n",
+    "\n",
+    "1. **Données internes** (PDF) : informations propriétaires, chiffres précis\n",
+    "2. **Contexte externe** (Web) : comparaison sectorielle, tendances marché\n",
+    "3. **Synthèse** : analyse comparative que ni la source PDF ni le web seuls ne peuvent fournir\n",
     "\n",
     "**Cas d'usage concrets :**\n",
     "\n",
@@ -1016,13 +1046,13 @@
     "| **Audit** | Vérifier conformité avec réglementations actualisées |\n",
     "| **Due diligence** | Croiser données fournies avec informations publiques |\n",
     "\n",
-    "**Coût estimé pour cette opération :**\n",
+    "**Coût indicatif du workflow :**\n",
     "\n",
-    "- **Étape 1** (Vision) : ~1105 tokens input (image) + 300 tokens output\n",
+    "- **Étape 1** (Vision) : ~1482 tokens input (image, usage constaté) + sortie variable\n",
     "- **Étape 2** (Web Search) : ~500 tokens input + 800 tokens output\n",
-    "- **Total** : ~2705 tokens avec `gpt-5-mini` ≈ $0.004\n",
+    "- **Total** : de l'ordre de ~2800 tokens avec `gpt-5-mini` ≈ $0.004\n",
     "\n",
-    "> **Optimisation** : Pour traiter des lots de documents, utiliser `batch API` pour réduire les coûts de 50%."
+    "> **Optimisation** : pour traiter des lots de documents, utiliser `batch API` pour réduire les coûts de 50%."
    ]
   },
   {
@@ -1157,10 +1187,18 @@
    "source": [
     "### Interprétation du fact-checking\n",
     "\n",
-    "**Méthodologie de vérification en 2 temps :**\n",
+    "**Observation sur cette exécution :** l'extraction d'affirmation a renvoyé une\n",
+    "chaîne vide (`Affirmation extraite:` est vide) — aucune claim spécifique n'a pu\n",
+    "être isolée depuis le document. L'étape de vérification web a tout de même tourné,\n",
+    "mais sur un sujet générique (tendances tech 2026) plutôt que sur une affirmation\n",
+    "extraite du document. Le modèle a produit une analyse sourcée (14 citations web\n",
+    "réelles), mais elle ne vérifie pas une claim du document — elle répond à défaut à\n",
+    "une requête de substitution.\n",
     "\n",
-    "1. **Extraction de l'affirmation** : Isolation de la claim spécifique du document\n",
-    "2. **Recherche contradictoire** : Vérification avec sources externes actualisées\n",
+    "**Méthodologie de vérification en 2 temps (lorsque l'extraction réussit) :**\n",
+    "\n",
+    "1. **Extraction de l'affirmation** : isolation de la claim spécifique du document\n",
+    "2. **Recherche contradictoire** : vérification avec sources externes actualisées\n",
     "\n",
     "**Indicateurs de fiabilité :**\n",
     "\n",
@@ -1198,8 +1236,14 @@
    "id": "c05d92d4",
    "source": "# Exercice 3 : Resume de recherche web sur un sujet technique\n# TODO etudiant : Creez une fonction de recherche web avec extraction des sources\n\n# Etape 1 : Definir la fonction de recherche\n# def search_and_summarize(query: str) -> str:\n#     response = client.responses.create(\n#         model=DEFAULT_MODEL,\n#         tools=[{\"type\": \"web_search_preview\"}],\n#         input=query\n#     )\n#     sources = []\n#     summary = \"\"\n#     for item in response.output:\n#         if hasattr(item, 'content'):\n#             for content in item.content:\n#                 if hasattr(content, 'text'):\n#                     summary = content.text\n#                     for ann in content.annotations:\n#                         sources.append({\"title\": ann.title, \"url\": ann.url})\n#     return summary, sources\n\n# Etape 2 : Tester avec un sujet technique\n# resume, sources = search_and_summarize(\n#     \"Quelles sont les differences entre RAG et fine-tuning pour les LLMs en 2026?\"\n# )\n\n# Etape 3 : Afficher le resume et les sources\n# print(\"=== Resume ===\")\n# print(resume)\n# print(\"\\n=== Sources ===\")\n# for i, src in enumerate(sources, 1):\n#     print(f\"{i}. {src['title']}: {src['url']}\")\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 12,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1255,7 +1299,7 @@
     "- Total pour notre workflow : ~30,000 tokens input + 500 output\n",
     "- Coût estimé : $0.045 (tarif janvier 2026)\n",
     "\n",
-    "**Recommandation :** Toujours tester avec `gpt-5-mini` avant d'utiliser `gpt-5-mini` (10× plus cher)."
+    "**Recommandation :** Toujours tester avec `gpt-4o-mini` avant d'utiliser `gpt-4o` (10× plus cher)."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit #3164 (po-2026:CoursIA-2) — `MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb`.

**Verdict: REINVENTION** (4 critical cells describe results the empty committed outputs do not produce) + 2 model-name copy-paste errors + 1 OMISSION citation + H.3 fix (3 stubs).

### REINVENTION fixes (align on committed output, no-pendulum)

**1. cell `4595cd74` (idx 8) — fabricated OCR success**
- Markdown claimed: OCR success + worked extraction table (`"Chiffre d'affaires: 2.5M EUR (+15%)"`) + token math `~1105 tokens`.
- Committed output `f77b2375` = **EMPTY**: `=== Analyse du document ===` then blank, only `Tokens utilisés: 1482`. The model received the image but produced no text.
- Fix: reworded to reflect the empty extraction (silent failure), dropped fabricated values, fixed token figure to actual `1482`. Added Flamingo citation (Alayrac 2022, arXiv:2204.14198).

**2. cell `254cf977` (idx 20) — fabricated enriched report**
- Markdown described a successful `Rapport comparatif enrichi` + propagated false `~1105`/`~2705` token figures.
- Committed output `76a872ee` = **empty extraction** + model asking user for figures (`"il me manque les chiffres Q1 2026"`).
- Fix: reworded to reflect incomplete extraction; kept the architecture teaching.

**3. cell `1af18f09` (idx 23) — fabricated claim isolation**
- Markdown claimed a 2-step fact-check that *"isoles la claim specifique du document"*.
- Committed output `e8e3f082` = **`Affirmation extraite:` EMPTY** — claim extraction returned blank; the web verification ran on a generic topic (tech-growth 2026) with 14 real citations rather than a document claim.
- Fix: reworded to reflect empty claim extraction.

**4. cell `635288f6` (idx 26) — model-name copy-paste error**
- `"tester avec gpt-5-mini avant d'utiliser gpt-5-mini (10x plus cher)"` — same model both sides.
- Fix: `gpt-4o-mini` → `gpt-4o` (consistent with `10×` and the GPT-4o-mini cost block).

### Model-name copy-paste errors (factual)

- `03c771c2` (idx 4): `gpt-5-mini et gpt-5-mini` → `gpt-4o-mini et gpt-4o`.
- `f9131c7f` (idx 11): `gpt-5-mini, gpt-5-mini` → `gpt-4o-mini, gpt-4o`.

### OMISSION (additive)

- `f9131c7f`: web-search grounding taught substantively → **Lewis et al. 2020, *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks*, arXiv:2005.11401**.

### H.3 fix (proactive — same as NB-03)

3 exercise stubs (idx 10/17/25) had `execution_count=null`. Executed locally (rule F) in one isolated kernel; captured `"Exercice a completer"` output; assigned ec `10/11/12` (non-colliding, honest "executed later"). The API code cells were NOT re-executed (rule C.3 — their source is unchanged, re-running them risks output churn from gpt-5-mini non-determinism).

## Verification (reassessed by po-2026:CoursIA-2)

- **G.1 cross-check**: all 4 REINVENTION outputs re-read directly (`f77b2375` empty, `76a872ee` empty extraction + "il me manque", `e8e3f082` empty claim + 14 generic citations, `635288f6` copy-paste). Sub-agent sonnet findings confirmed; no propagated claim.
- **C.1**: 0 violation.
- **H.3**: 0 null execution_count (3 stubs executed).
- **Scope**: markdown-only + 3 stubs. `+81/-37`. 0 code cell source changed.
- **Catalog**: byte-identical to `origin/main`.
- **abort-on-mismatch**: all 7 anchors unique (count==1).

**Reassessed by po-2026:CoursIA-2: CONFIRMED REINVENTION** (4 fabricated-result cells aligned on committed empty outputs) + 2 model-name errors.

See #3164.