### PR TITLE
fix(app8): reframe 6 MiniZinc "Sortie obtenue" as "Resultat attendu" (non-installed solver repli) (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
@@ -403,7 +403,7 @@
    "source": [
     "### Interpretation : premier modele\n",
     "\n",
-    "**Sortie obtenue** : le solveur trouve $x = 3, y = 7$ (ou l'inverse).\n",
+    "**Resultat attendu** (MiniZinc non execute, modele affiche uniquement) : la solution est $x = 3, y = 7$ (ou l'inverse).\n",
     "\n",
     "| Ligne | Element | Explication |\n",
     "|-------|---------|-------------|\n",
@@ -535,7 +535,7 @@
    "source": [
     "### Interpretation : optimisation\n",
     "\n",
-    "**Sortie obtenue** : 3 pieces de 25c + 2 pieces de 10c + 4 pieces de 1c = 99c, soit 9 pieces au total.\n",
+    "**Resultat attendu** (MiniZinc non execute, modele affiche uniquement) : 3 pieces de 25c + 2 pieces de 10c + 4 pieces de 1c = 99c, soit 9 pieces au total.\n",
     "\n",
     "| Element | Syntaxe MiniZinc | Description |\n",
     "|---------|------------------|-------------|\n",
@@ -694,7 +694,7 @@
    "source": [
     "### Interpretation : N-Reines declaratif\n",
     "\n",
-    "**Sortie obtenue** : une solution valide du probleme des 8-Reines.\n",
+    "**Resultat attendu** (MiniZinc non execute, modele affiche uniquement) : une solution valide du probleme des 8-Reines.\n",
     "\n",
     "| Ligne du modele | Explication |\n",
     "|-----------------|-------------|\n",
@@ -1012,7 +1012,7 @@
    "source": [
     "### Interpretation : contrainte cumulative\n",
     "\n",
-    "**Sortie obtenue** : un ordonnancement optimal avec makespan minimise.\n",
+    "**Resultat attendu** (MiniZinc non execute, modele affiche uniquement) : un ordonnancement avec makespan reduit (Makespan = 9 dans le resultat affiche).\n",
     "\n",
     "| Parametre de `cumulative` | Signification |\n",
     "|---------------------------|---------------|\n",
@@ -1142,7 +1142,7 @@
    "source": [
     "### Interpretation : contrainte circuit pour le TSP\n",
     "\n",
-    "**Sortie obtenue** : un circuit hamiltonien de distance minimale.\n",
+    "**Resultat attendu** (MiniZinc non execute, modele affiche uniquement) : un circuit hamiltonien (distance totale = 80 dans le resultat affiche).\n",
     "\n",
     "| Element | Explication |\n",
     "|---------|-------------|\n",
@@ -1832,7 +1832,7 @@
    "source": [
     "### Interpretation : Sudoku en MiniZinc\n",
     "\n",
-    "**Sortie obtenue** : la grille 4x4 completee avec toutes les contraintes satisfaites.\n",
+    "**Resultat attendu** (MiniZinc non execute, modele affiche uniquement) : une grille 4x4 completee.\n",
     "\n",
     "| Element du modele | Explication |\n",
     "|-------------------|-------------|\n",


### PR DESCRIPTION
## Summary

Closes #3602. Audit fidélité #3164 (epic, \`See #3164\`).

MiniZinc is not installed in the committed env (idx2 ec=1: "Package minizinc non installe" + "CLI minizinc non trouvee"). Each MiniZinc model cell shows the source + a \`[MiniZinc non disponible - modele affiche uniquement]\` repli + a hand-written \`Resultat attendu\` stub — but 6 interpretation markdown cells narrated these as \`**Sortie obtenue**\` ("output obtained"), fabricating solver results ("markdown-success above a committed non-config", cf SC-24 pattern).

## Changes (markdown-only, 6 cells / 6 lines)

| Cell | Before → After |
|------|----------------|
| idx7 `cell-interp-equations` | "**Sortie obtenue**: le solveur trouve..." → "**Resultat attendu (MiniZinc non execute...)**: la solution est..." |
| idx10 `cell-interp-coins` | "**Sortie obtenue**: 9 pieces" → "**Resultat attendu (MiniZinc non execute...)**: 9 pieces" |
| idx13 `cell-interp-nqueens-mzn` | "**Sortie obtenue**" → "**Resultat attendu (MiniZinc non execute...)**" |
| idx19 `cell-interp-cumulative` | "...optimal, makespan minimise" → "...makespan reduit (Makespan = 9 dans le resultat affiche)" |
| idx21 `cell-interp-circuit` | "...distance minimale" → "...(distance totale = 80 dans le resultat affiche)" |
| idx31 `cell-interp-sudoku` | "...toutes les contraintes satisfaites" → "une grille 4x4 completee" |

Illustrative values kept verbatim from committed \`Resultat attendu\` stubs (no new numbers — no-pendulum). Optimality/validity claims softened where a non-running solver cannot certify them.

## DEFERRED (out of scope, code/output defect)

The committed sudoku \`Solution attendue\` in idx30 has an invalid last row \`4 2 2 1\` (duplicate 2). Needs a rule-F MiniZinc install + re-execution, not a markdown fix. Documented in the issue body.

## Verification

- \`git diff --stat\`: 6 ins / 6 del (symmetric)
- 0 structural churn
- 0 control chars in edited cells
- JSON valid
- Catalogue + MGS submodule byte-identical to origin/main (3-dot diff = empty)
- Branch fresh from origin/main