### PR TITLE
docs(ml-5): anchor SSA citations + add References (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "## Singular Spectrum Analysis (SSA)\n",
     "\n",
-    "**ForecastBySsa** utilise l'algorithme SSA qui décompose la série temporelle en composantes :\n",
+    "**ForecastBySsa** utilise l'algorithme SSA (Broomhead & King, 1986 ; Golyandina & Zhigljavsky, 2013) qui décompose la série temporelle en composantes :\n",
     "\n",
     "```\n",
     "Série Temporelle = Trend + Saisonnalité + Bruit\n",
@@ -1317,7 +1317,7 @@
     "\n",
     "| Concept | Point clé |\n",
     "|---------|-----------|\n",
-    "| **ForecastBySsa** | Algorithme SSA pour décomposition trend/saisonnalité/bruit |\n",
+    "| **ForecastBySsa** (Broomhead & King, 1986 ; Golyandina & Zhigljavsky, 2013) | Algorithme SSA pour décomposition trend/saisonnalité/bruit |\n",
     "| **Paramètres** | windowSize capture la saisonnalité, horizon = horizon de prévision |\n",
     "| **Intervalles de confiance** | Quantifient l'incertitude des prévisions |\n",
     "| **Évaluation** | MAE et RMSE pour mesurer la précision |\n",
@@ -1563,6 +1563,24 @@
     "// Affichez les résultats\n",
     "\n",
     "// TODO: Analyse - Quelle configuration de windowSize fonctionne le mieux ?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "refs-bibliography-ml5",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "**Singular Spectrum Analysis (SSA)**\n",
+    "- Broomhead, D. S., & King, G. P. (1986). *Extracting Qualitative Dynamics from Experimental Data*. Physica D: Nonlinear Phenomena, 20(2-3), 217-236. — origine de la méthode SSA (décomposition en fonctions propres, « singular spectrum analysis »).\n",
+    "- Golyandina, N., & Zhigljavsky, A. (2013). *Singular Spectrum Analysis for Time Series*. Springer. — référence canonique moderne de la SSA, base de l'algorithme `ForecastBySsa` de ML.NET.\n",
+    "\n",
+    "**Évaluation des prévisions**\n",
+    "- Hyndman, R. J., & Koehler, A. B. (2006). *Another Look at Measures of Forecast Accuracy*. International Journal of Forecasting, 22(4), 679-688. — métriques MAE et RMSE utilisées pour l'évaluation des prévisions.\n",
+    "\n",
+    "**Framework (ML.NET)**\n",
+    "- Ahmed, Z., Ward, L., et al. (2019). *Machine Learning at Microsoft with ML.NET*. ACM SIGKDD (KDD)."
    ]
   }
  ],


### PR DESCRIPTION
## Audit fidélité #3164 — ML-5-TimeSeries (suite famille ML.Net)

4e grain **ML.Net** (après ML-7 #3543, ML-1 #3554, ML-3 #3589). Ai-01 cycle :23 : suite ML.Net, ML-5 next.

### Verdict : 2 OMISSIONS (classe c) ancrées + section References créée, 0 erreur factuelle, 0 REINVENTION

**ForecastBySsa (Singular Spectrum Analysis)** = algorithme **central** enseigné (objectif d'apprentissage #2, Partie 3 dédiée, conclusion) — SANS aucune citation ni section References.

| Point d'enseignement | Citation canonique ancrée |
|---|---|
| Section dédiée `## SSA` (cell 0) — algorithme décomposition trend/saisonnalité/bruit | **Broomhead & King 1986** (origine SSA) + **Golyandina & Zhigljavsky 2013** (textbook canonique, base du `ForecastBySsa` ML.NET) |
| Table conclusion (cell 32) : ForecastBySsa | ancré (mêmes deux sources) |

**Section References ajoutée** (4 entrées, aucune n'existait) : + **Hyndman & Koehler 2006** (Another Look at Measures of Forecast Accuracy — MAE/RMSE), **Ahmed et al. 2019** (ML.NET).

### Discipline G.5 (ce qui n'a PAS été ancré, honnêtement)
- **Intervalles de confiance** (Partie 6 dédiée, cell 24) : concept statistique intro-level, pas un algorithme nommé → References-only.
- **MAE / RMSE** (conclusion) : métriques intro → References-only (Hyndman & Koehler couvre).
- **ONNX** (next-steps) : mention incidentelle, ML-6 est le notebook ONNX dédié → pas d'ancre ici.

### Validation
- **Markdown-only** (+21/-3) — 2 remplacements inline + 1 cellule References appendée.
- C.2/C.3 : **0 churn** `execution_count`/`outputs` (15 code cells intactes) · C.1 = 0 · `scan_cell_ordering` clean · catalogue **byte-identique** · branche fraîche `origin/main`.
- **Repo CI validator (`notebook_tools.py validate`) : OK** (exit 0).
- **Note hygiène (follow-up, hors scope)** : artefact papermill pré-existant sur `origin/main` (props `execution_count`/`outputs` sur cellules markdown) → fait échouer le *strict* `nbformat.validate` mais pas le validator CI. Passe hygiène dédiée famille ML.Net après l'audit (per ai-01).

See #3164
