### PR TITLE
docs(qcpy-11): anchor Stochastic/AD/ROC citations in Technical Indicators (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
@@ -379,7 +379,10 @@
     "**CCI (Commodity Channel Index)** :\n",
     "- Mesure la variation du prix par rapport à sa moyenne statistique\n",
     "- Non-borné (peut dépasser ±100), ce qui le rend adapté aux forts mouvements\n",
-    "- Utile pour identifier les début/fin de tendance"
+    "- Utile pour identifier les début/fin de tendance\n",
+    "\n",
+    "> *Ancre savante -- Lane, G. C. (fin des annees 1950). Le Stochastic Oscillator (%K/%D) a ete developpe et popularise par George C. Lane (1921-2004), dans un groupe de traders sur futures de Chicago ; il compare le prix de cloture a la plage high-low sur une fenetre donnee.*\n",
+    ""
    ],
    "metadata": {}
   },
@@ -874,7 +877,10 @@
     "| Monte | Monte | Confirmation haussière (healthy uptrend) |\n",
     "| Monte | Baisse | Divergence bearish (affaiblissement) |\n",
     "| Baisse | Monte | Pression vendeuse (distribution) |\n",
-    "| Baisse | Baisse | Confirmation baissière (healthy downtrend) |"
+    "| Baisse | Baisse | Confirmation baissière (healthy downtrend) |\n",
+    "\n",
+    "> *Ancre savante -- Chaikin, M. (annees 1970). L'Accumulation/Distribution Line et son Money Flow Multiplier `((Close-Low)-(High-Close))/(High-Low)` (enseigne ci-dessus) sont l'oeuvre de Marc Chaikin. A ne pas confondre avec la variante Williams Accumulation/Distribution de Larry Williams.*\n",
+    ""
    ],
    "metadata": {}
   },
@@ -1405,7 +1411,10 @@
     "\n",
     "**Propriété `WarmUpPeriod`** :\n",
     "- Essentielle pour que QuantConnect sache combien de barres sont nécessaires avant que l'indicateur soit prêt\n",
-    "- Permet d'utiliser `SetWarmup()` automatiquement avec la bonne durée"
+    "- Permet d'utiliser `SetWarmup()` automatiquement avec la bonne durée\n",
+    "\n",
+    "> *Ancre savante (ouvrage de reference, non un originateur unique) -- Murphy, J. J. (1999), Technical Analysis of the Financial Markets, New York Institute of Finance. Le Rate of Change (ROC) est un indicateur de momentum classique sans auteur unique ; Murphy en donne le traitement standard dans la litterature d'analyse technique.*\n",
+    ""
    ],
    "metadata": {}
   },
@@ -2214,12 +2223,12 @@
     "\n",
     "1. **Indicateurs Built-In** :\n",
     "   - Moving Averages (SMA, EMA, WMA)\n",
-    "   - Momentum (RSI - Wilder 1978, MACD - Appel 2005, Stochastic, CCI - Lambert 1980)\n",
+    "   - Momentum (RSI - Wilder 1978, MACD - Appel 2005, Stochastic - Lane c.1957, CCI - Lambert 1980)\n",
     "   - Volatilite (Bollinger Bands - Bollinger 2002, ATR - Wilder 1978, Keltner Channels - Keltner 1960)\n",
     "\n",
     "2. **Indicateurs Avances** :\n",
     "   - Trend (ADX - Wilder 1978, Aroon - Chande 1995, Parabolic SAR - Wilder 1978)\n",
-    "   - Volume (OBV, AD, VWAP)\n",
+    "   - Volume (OBV - Granville 1963, AD - Chaikin annees 1970, VWAP)\n",
     "\n",
     "3. **Rolling Windows** :\n",
     "   - Stockage de l'historique des indicateurs\n",
@@ -2273,6 +2282,9 @@
     "- **Keltner, C.** (1960). *How to Make Money in Commodities*. Keltner Channels. Cf. reformulation Carter (1996) ATR-based.\n",
     "- **Chande, T. & Kroll, S.** (1995). *The New Technical Trader*. Aroon indicator.\n",
     "- **Granville, J.** (1963). *Granville's New Key to Stock Market Profits*. OBV (On-Balance Volume).\n",
+    "- **Lane, G. C.** (c. 1957). Stochastic Oscillator (%K/%D). Investment Educators Inc. Cf. Murphy, J. J. (1999), *Technical Analysis of the Financial Markets*, NYIF.\n",
+    "- **Chaikin, M.** (c. 1970s). Accumulation/Distribution Line (Money Flow Volume cumulatif). Cf. Pring, M. J. (1991), *Technical Analysis Explained*, McGraw-Hill.\n",
+    "- **Murphy, J. J.** (1999). *Technical Analysis of the Financial Markets*. New York Institute of Finance. (Reference survey : Rate of Change, familles d'indicateurs.)\n",
     "\n",
     "### Ressources Complementaires\n",
     "\n",


### PR DESCRIPTION
## Summary

**#3164 extended citation audit** on `QC-Py-11-Technical-Indicators.ipynb`. À la différence de QC-Py-13, ce notebook avait **DÉJÀ** une excellente section « References academiques » (cell 48) avec 7 ancres (Wilder, Appel, Bollinger, Lambert, Keltner, Chande & Kroll, Granville). Verdict = **OMISSION (partielle)** : 3 indicateurs fondamentaux nommés, enseignés comme concepts dans la prose, restaient sans attribution.

See #3164.

### Changes (markdown-only, 1 file, +17/-5, 0 code cell touched)

| Cell | Concept | Ancre ajoutée |
|------|---------|---------------|
| 9 | Stochastic Oscillator | Lane, G. C. (fin des années 1950) |
| 20 | Accumulation/Distribution + Money Flow Multiplier | Chaikin, M. (années 1970) — avec note de disambiguïsation vs variante Williams |
| 31 | Rate of Change (ROC) | Murphy (1999) *survey textbook* (NON un originateur — ROC n'a pas d'auteur unique, honnête G.3) |
| 48 | Recap momentum + volume lines | « Stochastic » → « Stochastic - Lane c.1957 », « AD » → « AD - Chaikin années 1970 » |
| 48 | References | +3 entrées (Lane, Chaikin, Murphy) |

### Cadrage #3164

QC-Py = matériel original (Broad, *Hands-On AI Trading*), pas portage strict → verdict OMISSION (concept nommé sans ancre savante), markdown additif. ROC délibérément cité comme référence de survey (Murphy 1999) et non comme originateur, puisqu'aucun n'existe — honnêteté G.3.

## Validation

- **0 code cell touched** : 18 cellules code byte-identiques à `origin/main` (vérifié par diff json des sources).
- **Markdown-only** : 4 cellules markdown annotées (9, 20, 31, 48), 0 ajout/suppression de cellule (49 cells avant/après).
- **nbformat valid** (4), notebook charge sans erreur.
- **Outputs intacts** (C.2 exception markdown-only : les outputs des cellules code non-modifiées restent valides).
- **Citations web-checkées** (Wikipedia George Lane + TrendSpider + Grokipedia pour Stochastic ; StockCharts ChartSchool + Investopedia + TradingView pour Chaikin AD/MFM). **Aucune fabrication** (G.1/G.3).
- Catalogue byte-identique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
