### PR TITLE
fix(app16): align Crossword backtracking timing to committed 0.714s (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb
@@ -1364,7 +1364,7 @@
     "| Solveur | Grille 7x7 | Performance |\n",
     "|---------|------------|-------------|\n",
     "| **OR-Tools CP-SAT** | **24 mots places** | Resolution instantanee |\n",
-    "| **Backtracking naif** | Aucune solution | 50 001 noeuds, 0.49s, echec |\n",
+    "| **Backtracking naif** | Aucune solution | 50 001 noeuds, 0.714s, echec |\n",
     "\n",
     "### Lecon principale\n",
     "\n",


### PR DESCRIPTION
## Summary

Closes $ISSUE. Audit fidélité #3164 (epic, \`See #3164\`).

App-16-Crossword-CSP conclusion table idx24 stated the naive backtracking was cut at "0.49s", but the committed output idx11 (ec=6) = "Recherche coupee apres 0.714s (50001 noeuds)". Aligned the value to 0.714s.

## Changes (markdown-only, 1 line)

| Cell | Before → After | Source output |
|------|----------------|---------------|
| idx24 `24d2900a` table | "50 001 noeuds, 0.49s, echec" → "50 001 noeuds, 0.714s, echec" | idx11 ec=6: "Recherche coupee apres 0.714s (50001 noeuds)" |

## Verification

- \`git diff --stat\`: 1 ins / 1 del (symmetric)
- 0 structural churn
- 0 control chars
- JSON valid
- Catalogue + MGS submodule byte-identical to origin/main (3-dot diff = empty)
- Branch fresh from origin/main