### PR TITLE
fix(#3164): GenAI/Texte 7_Code_Interpreter — align local-fallback attribution + nav + stubs H.3

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
@@ -29,7 +29,20 @@
     "\n",
     "**Prérequis :** Notebook 1 (OpenAI Intro)\n",
     "\n",
-    "**Durée estimée :** 55 minutes"
+    "**Durée estimée :** 55 minutes\n",
+    "\n",
+    "> **Note d'exécution** : ce notebook peut s'exécuter de deux façons. Via l'**API\n",
+    "> OpenAI directe**, l'Assistants API fournit un véritable Code Interpreter (sandbox\n",
+    "> Python côté serveur). Via un routeur tiers (**OpenRouter**), l'Assistants API\n",
+    "> n'étant pas supportée, le notebook bascule sur une **alternative locale**\n",
+    "> (pandas/numpy) qui reproduit les mêmes analyses. Les sorties committées reflètent\n",
+    "> le mode local. Pour activer le Code Interpreter réel, utilisez l'API OpenAI directe.\n",
+    "\n",
+    "> **Références** : le paradigme des LLM utilisant des outils externes (tool use) est\n",
+    "> formalisé par Schick et al. 2023, *Toolformer: Language Models Can Teach Themselves\n",
+    "> to Use Tools*, arXiv:2302.04761. Le Code Interpreter est documenté par OpenAI 2023,\n",
+    "> *Assistants API — Code Interpreter*, platform.openai.com/docs/assistants/tools/code-interpreter.\n",
+    ""
    ]
   },
   {
@@ -347,10 +360,10 @@
     "\n",
     "**Variables d'environnement importantes** :\n",
     "- `OPENAI_API_KEY` : Clé d'API OpenAI (obligatoire)\n",
-    "- `OPENAI_MODEL` : Modèle par défaut (recommandé: gpt-5-mini)\n",
+    "- `OPENAI_MODEL` : Modèle par défaut (l'exécution committée utilise `gpt-4.1-mini`)\n",
     "- `BATCH_MODE` : Mode batch pour exécution automatisée sans interaction\n",
     "\n",
-    "**Note** : Le Code Interpreter nécessite un modèle supportant les outils avancés (gpt-4, gpt-5-mini, gpt-4-turbo)."
+    "**Note** : Le Code Interpreter nécessite un modèle supportant les outils avancés (de la famille GPT-4 / GPT-5)."
    ]
   },
   {
@@ -576,8 +589,14 @@
    "id": "7f9078c9",
    "source": "# Exercice 1 : Generation de code avec validation\n# TODO etudiant : Implementer generate_and_validate(spec, test_cases)\n# - spec : description en francais de la fonction a generer (ex: \"fonction qui inverse une chaine de caracteres\")\n# - test_cases : liste de tuples (input, expected_output) pour valider le code genere\n# - Etape 1 : Construire un prompt qui demande UNIQUEMENT le code Python (pas d'explications)\n# - Etape 2 : Appeler client.chat.completions.create() avec le prompt\n# - Etape 3 : Extraire le code entre ```python et ``` avec une regex ou un split\n# - Etape 4 : Executer le code avec exec() dans un namespace dedie, puis tester avec test_cases\n# - Retourner {\"code\": code_extrait, \"tests_passed\": nb_passed, \"tests_total\": len(test_cases)}\n\ndef generate_and_validate(spec, test_cases):\n    return None  # TODO etudiant : implementer\n\n# Indice : utiliser re.search(r'```python\\n(.*?)```', response, re.DOTALL) pour extraire le code\n# Test :\n# result = generate_and_validate(\n#     \"Fonction is_palindrome(s) qui retourne True si s est un palindrome\",\n#     [(\"radar\", True), (\"hello\", False), (\"\", True), (\"a\", True)]\n# )\n# print(result)\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -776,7 +795,11 @@
     "- ✅ **Adaptabilité** : Fonctionne avec n'importe quel CSV similaire\n",
     "- ✅ **Explications incluses** : L'assistant interprète les chiffres\n",
     "\n",
-    "**Note importante** : Le code généré par l'assistant est exécuté dans un environnement sandbox sécurisé. Vous ne voyez pas le code Python exécuté, seulement les résultats. Pour voir le code, vous pouvez demander explicitement \"Montre-moi le code que tu as utilisé\"."
+    "**Note importante** : avec un véritable Code Interpreter OpenAI, le code généré par\n",
+    "le modèle s'exécute dans un sandbox sécurisé et l'utilisateur ne voit que les résultats.\n",
+    "Dans l'exécution committée ici (mode local fallback), le code pandas/numpy est visible\n",
+    "dans la cellule source — le comportement observé est donc l'alternative locale, qui\n",
+    "reproduit fidèlement les résultats qu'aurait produits le Code Interpreter."
    ]
   },
   {
@@ -1012,7 +1035,11 @@
    "source": [
     "### Interprétation de l'analyse automatique\n",
     "\n",
-    "Le Code Interpreter a effectué une analyse complète du fichier CSV sans code manuel. Voici ce qui s'est passé :\n",
+    "Les sorties committées ci-dessus sont produites en **mode local** (fallback pandas/numpy) :\n",
+    "comme l'environnement actuel route les appels via OpenRouter, qui ne supporte pas\n",
+    "l'Assistants API (Code Interpreter), le notebook bascule sur une alternative locale\n",
+    "qui reproduit l'analyse que ferait le Code Interpreter. Le déroulé conceptuel est\n",
+    "le suivant :\n",
     "\n",
     "**Étapes automatiques réalisées** :\n",
     "1. **Chargement** : Reconnaissance du format CSV et parsing automatique\n",
@@ -1032,7 +1059,9 @@
     "- ✅ **Formatage structuré** : Résultats présentés clairement\n",
     "- ✅ **Reproductibilité** : Même prompt → mêmes analyses\n",
     "\n",
-    "**Note technique** : Le statut `completed` confirme que l'exécution s'est terminée sans erreur dans le sandbox."
+    "**Note technique** : l'output affiche `=== Analyse terminée avec succès (mode local) ===`.\n",
+    "Pour une exécution réelle dans le sandbox OpenAI (Code Interpreter), il faut utiliser\n",
+    "l'API OpenAI directe plutôt que le routage OpenRouter."
    ]
   },
   {
@@ -1239,8 +1268,14 @@
    "id": "0f6795f0",
    "source": "# Exercice 2 : Visualisation personnalisee avec detection d'anomalies\n# TODO etudiant : Implementer plot_sales_analysis(df, value_col, group_col)\n# - Sous-figure 1 : histogramme de value_col avec lignes verticales moyenne (rouge) et mediane (bleu)\n# - Sous-figure 2 : boxplot de value_col par group_col (pour detecter les outliers)\n# - Ajouter titre, legendes et labels\n# - Sauvegarder en PNG et afficher\n\ndef plot_sales_analysis(df, value_col, group_col):\n    pass  # TODO etudiant : implementer\n\n# Indice : utiliser plt.subplots(1, 2, figsize=(12, 5))\n# Test :\n# np.random.seed(42)\n# test_df = pd.DataFrame({\n#     'ventes': np.random.randint(100, 500, 100) + np.sin(np.arange(100)*0.1)*50,\n#     'region': np.random.choice(['Nord', 'Sud', 'Est', 'Ouest'], 100)\n# })\n# plot_sales_analysis(test_df, 'ventes', 'region')\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1609,8 +1644,14 @@
    "id": "83bb0470",
    "source": "# Exercice 3 : Analyse statistique personnalisee\n# TODO etudiant : Implementer analyze_dataframe(df, columns)\n# - Pour chaque colonne numerique : moyenne, mediane, ecart-type, min, max\n# - Compter les outliers (valeurs > moyenne + 2*ecart_type ou < moyenne - 2*ecart_type)\n# - Ajouter une interpretation : \"symetrique\" si |moyenne - mediane| < 0.1 * ecart_type, sinon \"asymetrique\"\n# - Retourner un DataFrame avec une ligne par colonne analysee\n\ndef analyze_dataframe(df, columns=None):\n    return None  # TODO etudiant : implementer\n\n# Test avec le dataset de ventes :\n# np.random.seed(42)\n# test_df = pd.DataFrame({\n#     'ventes': np.random.randint(100, 500, 100),\n#     'temperature': np.random.normal(20, 5, 100)\n# })\n# rapport = analyze_dataframe(test_df, ['ventes', 'temperature'])\n# print(rapport)\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "execution_count": 12,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\n"
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1800,11 +1841,9 @@
     "\n",
     "Le nettoyage a été effectué avec succès. Voici ce qui a été supprimé :\n",
     "\n",
-    "**Ressources OpenAI** :\n",
-    "- ✅ **Assistant** : L'assistant temporaire a été supprimé (évite les coûts de stockage)\n",
-    "- ✅ **Fichier uploadé** : Le CSV a été retiré du serveur OpenAI\n",
-    "\n",
-    "**Fichiers locaux** :\n",
+    "**Fichiers locaux** (l'output committé montre uniquement le nettoyage local, car\n",
+    "l'exécution s'est faite en mode local — aucun assistant ni fichier côté serveur\n",
+    "OpenAI n'a été créé dans cette session) :\n",
     "- ✅ **Dataset** : `ventes_test.csv` supprimé\n",
     "- ✅ **Images générées** : Tous les fichiers `graphique_*.png` supprimés\n",
     "\n",
@@ -1882,7 +1921,7 @@
     "\n",
     "- [OpenAI Code Interpreter Guide](https://platform.openai.com/docs/assistants/tools/code-interpreter)\n",
     "- [Assistants API Reference](https://platform.openai.com/docs/api-reference/assistants)\n",
-    "- Notebook suivant : **8_Structured_Outputs.ipynb** (génération JSON validée)"
+    "- Notebook suivant : **8_Reasoning_Models.ipynb** (génération JSON validée)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Audit #3164 (po-2026:CoursIA-2) — `MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb`.

**Verdict: REINVENTION** (systemic misattribution) + navigation bug + model-name + 2 OMISSION citations + H.3 fix.

### Root cause (G.1 verified against committed output)

The notebook runs in **LOCAL fallback mode** (pandas/numpy) because OpenRouter does not support the Assistants API (Code Interpreter). The committed output `df5d7ff9` (idx 20) states this explicitly:
> `=== Mode OpenRouter détecté === / L'Assistants API (Code Interpreter) n'est PAS supportée par OpenRouter / Utilisation de l'alternative locale avec pandas/numpy.`

The numbers are faithful (mean 321.04, min 70.32, etc.) but the markdown interpretation cells **systematically attributed** the results to *"the Code Interpreter in an OpenAI sandbox"* — a misattribution.

### REINVENTION fixes (align on committed output, no-pendulum)

- **Disclaimer in `77be8d13` (idx 0)**: documents the two execution modes (OpenAI direct = real CI sandbox; OpenRouter = local fallback) and states the committed outputs reflect local mode.
- **`94f845c1` (idx 21)**: dropped fabricated *"statut `completed` confirme le sandbox"* (no such status in the output) + reworded attribution to local mode.
- **`9ac54107` (idx 40)**: dropped *"Ressources OpenAI: Assistant supprimé / Fichier retiré du serveur OpenAI"* (output only shows local file cleanup; no OpenAI server-side resources were created in local mode).
- **`91822051` (idx 17)**: dropped *"exécuté dans un sandbox sécurisé, vous ne voyez pas le code"* (output shows pandas code ran locally and is visible).

### Navigation bug

- **`582dddc4` (idx 41)**: conclusion pointed to `8_Structured_Outputs.ipynb` but NB-08 is actually `8_Reasoning_Models.ipynb` (verified: file exists + README). Fixed the broken next-notebook link.

### Model-name

- **`01a75244` (idx 5)**: *"recommandé: gpt-5-mini"* + list *"(gpt-4, gpt-5-mini, gpt-4-turbo)"* was inconsistent with the actual committed run (`gpt-4.1-mini`). Softened to generic *"famille GPT-4 / GPT-5"* + noted the committed model.

### OMISSION (additive citations in `77be8d13`)

- Code Interpreter concept → **OpenAI 2023**, *Assistants API — Code Interpreter*.
- Tool-use paradigm → **Schick et al. 2023**, *Toolformer*, arXiv:2302.04761.

### H.3 fix (proactive — same as NB-03/06)

3 exercise stubs (idx 12/27/35) had `execution_count=null`. Executed locally (rule F) in one isolated kernel; captured output; assigned ec `10/11/12`. API code cells NOT re-executed (rule C.3 — source unchanged, avoids output churn).

## Verification (reassessed by po-2026:CoursIA-2)

- **G.1 cross-check**: output `df5d7ff9` (idx 20) re-read directly — confirms OpenRouter detection + local pandas analysis. Sub-agent sonnet finding confirmed; the `gpt-4.1-mini` model (not reasoning) means **#3571 (content=None) does NOT apply here** — 0 ENV-BUG, all outputs are real streams.
- **C.1**: 0 violation.
- **H.3**: 0 null execution_count (3 stubs executed).
- **Scope**: markdown + 3 stubs. `+58/-19`. 0 API code cell source changed.
- **Catalog**: byte-identical to `origin/main`.
- **abort-on-mismatch**: all anchors unique (count==1).

**Reassessed by po-2026:CoursIA-2: CONFIRMED REINVENTION** (systemic local-vs-sandbox misattribution) — aligned markdown on committed local-fallback outputs.

See #3164.