### PR TITLE
fix(infer-20): audit fidelite #3164 Infer-20-Decision-Sequential -- ERREUR/NAV/OMISSION

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-20-Decision-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-20-Decision-Sequential.ipynb
@@ -1313,7 +1313,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice : MDP Modifie - Comparaison Value Iteration et Policy Iteration\n",
+    "### Exercice 1 : MDP Modifie - Comparaison Value Iteration et Policy Iteration\n",
     "\n",
     "**Contexte** : Vous disposez du MDP grille 4x3 du cours, mais avec des recompenses modifiees. Vous allez comparer la vitesse de convergence de Value Iteration et Policy Iteration.\n",
     "\n",
@@ -2475,7 +2475,7 @@
     "\n",
     "| Strategie | Recompense | Regret | Tirages du meilleur bras |\n",
     "|-----------|------------|--------|--------------------------|\n",
-    "| ε-greedy (ε=0.1) | 686 | 14 | 884/1000 (88%) |\n",
+    "| ε-greedy (ε=0.1) | 673,7 | 26,3 | 871/1000 (87%) |\n",
     "| UCB1 | 616 | 84 | 719/1000 (72%) |\n",
     "\n",
     "**Analyse :**\n",
@@ -2508,7 +2508,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice : Strategies de Bandits - Comparaison Empirique\n",
+    "### Exercice 2 : Strategies de Bandits - Comparaison Empirique\n",
     "\n",
     "**Contexte** : Vous etes responsable d'un site web et devez choisir parmi 5 versions d'une page (A/B/n testing). Chaque version a un taux de conversion inconnu. Vous devez trouver la meilleure version tout en minimisant les pertes.\n",
     "\n",
@@ -3354,7 +3354,9 @@
     "A chaque pas de temps :\n",
     "- L'etat peut se degrader (Markov)\n",
     "- On observe un signal de capteur (bruite)\n",
-    "- On decide : continuer, maintenance preventive, ou remplacement"
+    "- On decide : continuer, maintenance preventive, ou remplacement\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (`FactorGraphHelper.IsGraphvizAvailable()` renvoie `False`, cf issue #3473). Le moteur genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/)), mais affiche a la place un avertissement « Graphviz non disponible ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -4111,7 +4113,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercice : MDP et Iteration de Valeur\n",
+    "## Exercice 3 : MDP et Iteration de Valeur\n",
     "\n",
     "**Objectifs** :\n",
     "1. Implementer un MDP simple (grille 3x3)\n",


### PR DESCRIPTION
## Audit fidelite #3164 — Infer-20-Decision-Sequential

Closes #3619. See #3164.

**19e notebook Infer, 7e Decision-Utility (14-20).** Decisions sequentielles : MDPs, Bellman, Value/Policy Iteration, bandits, POMDPs (Tiger), Reward Shaping, Infer.NET belief maintenance.

**Verdict : substantively bon** (0 INVENTION, 0 LABELING pathology, ~15 anchors FIDELes). 4 defauts markdown-only :

### 1. ERREUR-FACTUELLE idx31 (subtype stale-RNG-values)
Table d'interpretation des bandits contredisait l'output `idx30` sur la ligne **epsilon-greedy** uniquement : `686 / 14 / 884 (88%)` -> aligne sur l'output committe `673,7 / 26,3 / 871 (87%)`. Ligne UCB1 (616 / 84 / 719) deja correcte. Analyse qualitative intacte.

### 2. NAVIGATION x3
`idx18`/`idx32` `### Exercice :` -> `### Exercice 1/2 :` ; `idx49` `## Exercice :` -> `## Exercice 3 :` (exercice final de cloture, h2 legitimate).

### 3. OMISSION #3473 idx43
Factor-graph de maintenance : banner fallback « Graphviz non disponible » (bug kernel-PATH #3473). Caveat standardise sur prose `idx44` (## 10bis). Le posterior `idx43` (modele simple [0.7,0.2,0.1]) est distinct d'`idx46` (modele complet) -> LAISSE (no-pendulum).

## Validation (4 gates)
- **G1** scan_cell_ordering : **1 clean, 0 finding**
- **G2** check_c2_compliance : **1/1 compliant**
- **G3** notebook_tools validate : **0 Errors** (Warning = FP LaTeX `$`-balance, verifie identique sur `origin/main`)
- **G4** git diff : **7 ins / 5 del**, markdown-only, **0 execution_count/outputs touchee**, submodules non stages