### PR TITLE
fix(app-19): align WFC CP-SAT connectivity interpretation to committed 7% output (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
@@ -1489,7 +1489,7 @@
     "| Critère | Aléatoire | WFC pur | CP-SAT |\n",
     "|---------|-----------|---------|--------|\n",
     "| Violations d'adjacence | Élevées (ex: 20/12×12) | **0** | **0** |\n",
-    "| Connectivité garantie | Non (~2%) | Non (~2%) | **Oui** (contraintes globales) |\n",
+    "| Connectivité garantie | Non (~2%) | Non (~2%) | Partiellement (relaxation flow, ~7% observé) |\n",
     "| Contraintes globales (objets, difficulté) | Impossible | Impossible | **Possible** (sommes, ratios) |\n",
     "| Variété de tuiles | Maximale | Maximale | Maximale |\n",
     "| Temps de calcul | <10 ms | ~40 ms | ~1-20 s |\n",


### PR DESCRIPTION
Closes #3621
See #3164

Audit fidélité #3164 — App-19-ProceduralGeneration-WFC (CSP).

## Defect (Class A — INTERP-VS-OUTPUT)
idx33 (`626e09a2`) synthesis table marked CP-SAT connectivity as `**Oui** (contraintes globales)` (guaranteed). Committed outputs show 7%: idx16 (ec=8) `cpsat : conn=7%`, idx20 (ec=10) 7%. The cell's own idx9 admits the flow is only a `condition nécessaire` (relaxation), and the idx33 final bullet proposes a full path constraint as "plus coûteuse mais complète" — admitting the relaxation is NOT complete.

## Fix (markdown-only)
`**Oui** (contraintes globales)` → `Partiellement (relaxation flow, ~7% observé)`. No-pendulum (committed `conn=7%` values copied exactly).

## Verification
- 1 insertion / 1 deletion, 0 structural churn.
- 0 control characters, JSON valid.
- Catalogue + MGS submodule byte-identical to origin/main (3-dot diff empty).
- Branch fresh from origin/main.
