### PR TITLE
docs(ml-2): anchor One-Hot/N-grams citations + add References (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
@@ -505,7 +505,7 @@
     "\n",
     "### Données catégorielles\n",
     "\n",
-    "L'encodage one-hot est une transformation importante pour les données contenant des catégories. Les algorithmes ML nécessitent des données numériques, ils ne savent pas comment traiter les chaînes représentant des catégories. Les colonnes vendor_id et payment_type sont catégoriques, le fournisseur peut être \"CMD\" ou \"VST\" et le paiement peut être \"CReDit\" ou \"CaSH\". L'encodage one-hot prend les valeurs de chaîne passées et les convertit en données numériques."
+    "L'encodage one-hot (Hastie, Tibshirani & Friedman, 2009) est une transformation importante pour les données contenant des catégories. Les algorithmes ML nécessitent des données numériques, ils ne savent pas comment traiter les chaînes représentant des catégories. Les colonnes vendor_id et payment_type sont catégoriques, le fournisseur peut être \"CMD\" ou \"VST\" et le paiement peut être \"CReDit\" ou \"CaSH\". L'encodage one-hot prend les valeurs de chaîne passées et les convertit en données numériques."
    ]
   },
   {
@@ -919,7 +919,7 @@
    "source": [
     "### Exercice 1 : Featurisation de texte personnalisee\n",
     "\n",
-    "Creez un pipeline utilisant `FeaturizeText` avec des options personnalisees (n-grams de mots, n-grams de caracteres) et comparez les performances avec les parametres par defaut.\n",
+    "Creez un pipeline utilisant `FeaturizeText` (vectorisation par n-grams et hachage, Manning, Raghavan & Schütze, 2008 ; Weinberger et al., 2009) avec des options personnalisees (n-grams de mots, n-grams de caracteres) et comparez les performances avec les parametres par defaut.\n",
     "\n",
     "**Objectifs** :\n",
     "1. Preparer un jeu de donnees contenant du texte (avis clients, commentaires, etc.)\n",
@@ -1181,6 +1181,22 @@
     "- La concaténation des features prépare les données pour l'entraînement\n",
     "\n",
     "**Navigation** : [Index](README.md) | [<< ML-1 Introduction](ML-1-Introduction.ipynb) | [Suivant >> ML-3 Entrainement&AutoML](ML-3-Entrainement%26AutoML.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "refs-bibliography-ml2",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "**Transformations de features**\n",
+    "- Hastie, T., Tibshirani, R., & Friedman, J. (2009). *The Elements of Statistical Learning: Data Mining, Inference, and Prediction* (2nd ed.). Springer. — variables catégorielles et encodage one-hot (section 3.6), termes d'interaction (feature cross).\n",
+    "- Manning, C. D., Raghavan, P., & Schütze, H. (2008). *Introduction to Information Retrieval*. Cambridge University Press. — modélisation par n-grams de mots et de caractères (featurisation de texte).\n",
+    "- Weinberger, K., Dasgupta, A., Langford, J., Smola, A., & Attenberg, J. (2009). *Feature Hashing for Large Scale Multitask Learning*. ICML. — « hashing trick », sous-jacent à la vectorisation `FeaturizeText` de ML.NET.\n",
+    "\n",
+    "**Framework (ML.NET)**\n",
+    "- Ahmed, Z., Ward, L., et al. (2019). *Machine Learning at Microsoft with ML.NET*. ACM SIGKDD (KDD)."
    ]
   }
  ],


### PR DESCRIPTION
## Audit fidélité #3164 — ML-2-Data&Features (suite famille ML.Net)

5e grain **ML.Net** (après ML-7 #3543, ML-1 #3554, ML-3 #3589, ML-5 #3606). Ai-01 cycle :23 : suite ML.Net.

### Verdict : 2 OMISSIONS (classe c) ancrées + section References créée, 0 erreur factuelle, 0 REINVENTION

ML-2 = notebook de **feature engineering**. Techniques nommées enseignées avec **traitement dédié** :

| Point d'enseignement | Citation canonique ancrée |
|---|---|
| One-Hot Encoding (cell 8, section dédiée `### Données catégorielles`) | **Hastie, Tibshirani & Friedman 2009** (ESL §3.6 variables catégorielles) |
| FeaturizeText + n-grams (cell 20, exercice dédié) | **Manning, Raghavan & Schütze 2008** (IIR, n-grams) + **Weinberger et al. 2009** (feature hashing trick, sous-jacent au `FeaturizeText` ML.NET) |

**Section References ajoutée** (4 entrées, aucune n'existait) : + **Ahmed et al. 2019** (ML.NET).

### Discipline G.5 (ce qui n'a PAS été ancré, honnêtement)
- **Feature cross** (cell 22, exercice dédié) : terminologie d'ingénierie sans source de recherche unique — le concept renvoie aux termes d'interaction (couverts par ESL en References), pas un papier fondateur → References-only, pas d'ancre inline.
- **IDataView / TextLoader / Concatenate / ReplaceMissingValues** : outils ML.NET, pas des algorithmes de recherche → pas d'ancre (Ahmed 2019 couvre le framework en References).

### Yield (honnête)
ML-2 est un notebook de feature-engineering (rendement modéré, comme ML-1) — pas un cours d'algorithmes comme ML-3 (rendement élevé). Les 2 ancres (One-Hot, N-grams) sont les deux seules techniques de recherche nommées avec un traitement pédagogique dédié. Forcer davantage = remplissage G.5.

### Validation
- **Markdown-only** (+19/-3) — 2 remplacements inline + 1 cellule References appendée.
- C.2/C.3 : **0 churn** `execution_count`/`outputs` (12 code cells intactes) · C.1 = 0 · `scan_cell_ordering` clean · catalogue **byte-identique** · branche fraîche `origin/main`.
- **Repo CI validator (`notebook_tools.py validate`) : OK** (exit 0).
- **Note hygiène (follow-up, hors scope)** : artefact papermill pré-existant (props `execution_count`/`outputs` sur cellules markdown) → strict `nbformat.validate` FAIL mais pas le validator CI. Passe hygiène dédiée famille ML.Net après l'audit (per ai-01).
- **Technique** : `&` dans `ML-2-Data&Features.ipynb` contourné via glob `ML-2-*.ipynb` (git add) + `os.path`/glob (Python) — même leçon qu'au cycle ML-3.

See #3164
