### PR TITLE
docs(qcpy-10): anchor Sharpe/CAPM/risk-parity citations in Risk Management (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
@@ -384,7 +384,26 @@
   },
   {
    "cell_type": "markdown",
-   "source": "> **Resultats Backtest QC Cloud** (2015-2024, SPY)\n>\n> | Metrique | Valeur |\n> |----------|--------|\n> | **Sharpe Ratio** | -0.057 |\n> | **Net Profit** | +14.2% |\n> | **CAGR** | 1.73% |\n> | **Max Drawdown** | 4.2% |\n> | **Total Trades** | 40 |\n> | **Alpha** | -0.007 |\n> | **Beta** | 0.083 |\n>\n> *BT ID: `82208686e33e36bef6d4f073429fef76`* — La methode Fixed Fractional (1% risque par trade) limite efficacement les pertes (MaxDD 4.2%) mais le signal Golden/Death Cross (SMA20/SMA50) sur SPY seul ne produit pas d'edge significatif (alpha negatif). Le faible nombre de trades (40) et le beta de 0.08 montrent que la strategie est tres peu exposee au marche. Le backtest s'est termine en erreur d'execution mais a tout de meme genere des statistiques valides.",
+   "source": [
+    "> **Resultats Backtest QC Cloud** (2015-2024, SPY)\n",
+    ">\n",
+    "> | Metrique | Valeur |\n",
+    "> |----------|--------|\n",
+    "> | **Sharpe Ratio** | -0.057 |\n",
+    "> | **Net Profit** | +14.2% |\n",
+    "> | **CAGR** | 1.73% |\n",
+    "> | **Max Drawdown** | 4.2% |\n",
+    "> | **Total Trades** | 40 |\n",
+    "> | **Alpha** | -0.007 |\n",
+    "> | **Beta** | 0.083 |\n",
+    ">\n",
+    "> *BT ID: `82208686e33e36bef6d4f073429fef76`* — La methode Fixed Fractional (1% risque par trade) limite efficacement les pertes (MaxDD 4.2%) mais le signal Golden/Death Cross (SMA20/SMA50) sur SPY seul ne produit pas d'edge significatif (alpha negatif). Le faible nombre de trades (40) et le beta de 0.08 montrent que la strategie est tres peu exposee au marche. Le backtest s'est termine en erreur d'execution mais a tout de meme genere des statistiques valides.\n",
+    "\n",
+    "> *Ancres savantes (metriques de performance rapportees dans tous les backtests de ce notebook) :*\n",
+    "> - *Sharpe, W. F. (1966), « Mutual Fund Performance », Journal of Business 39(1), 119-138 -- « reward-to-variability ratio » (ancetre formel du ratio de Sharpe ; le nom « Sharpe ratio » est fixe dans Sharpe 1994, « The Sharpe Ratio », J. Portfolio Management 21(1), 49-58).*\n",
+    "> - *Sharpe, W. F. (1964), « Capital Asset Prices: A Theory of Market Equilibrium Under Conditions of Risk », Journal of Finance 19(3), 425-442 -- CAPM (Capital Asset Pricing Model) ; le **beta** y mesure l'exposition systematique d'un actif au marche. (CAPM codeveloppe independamment par Treynor 1962, Lintner 1965, Mossin 1966.)*\n",
+    ""
+   ],
    "metadata": {}
   },
   {
@@ -2340,7 +2359,10 @@
     "- # Indice : Les poids peuvent etre egaux ou bases sur la volatilite inverse\n",
     "- # Etape 1 : Calculer la volatilite de chaque position\n",
     "- # Etape 2 : Calculer les poids (inverse volatility weighting)\n",
-    "- # Etape 3 : Convertir en taille de position"
+    "- # Etape 3 : Convertir en taille de position\n",
+    "\n",
+    "> *Ancre savante -- Maillard, S., Roncalli, T. & Teiletche, J. (2010), « The Properties of Equally Weighted Risk Contribution Portfolios », The Journal of Portfolio Management 36(4), 60-70. Formalise l'allocation « Equal Risk Contribution » (ERC) et, en regime diagonal, la ponderation **inverse-volatilite** (poids proportionnels a 1/sigma) demandee a l'Etape 2 -- cadre canonique du risk budgeting.*\n",
+    ""
    ]
   },
   {
@@ -2883,6 +2905,9 @@
     "- **Grossman, S. & Zhou, Z.** (1993). *Optimal Investment Strategies for Controlling Drawdowns*. Mathematical Finance. Drawdown control (limite de perte maximale sous contrainte d'expectation).\n",
     "- **Moreira, A. & Muir, T.** (2017). *Volatility-Managed Portfolios*. Journal of Finance. Volatility scaling (reduire l'exposition quand la vol augmente augmente le Sharpe).\n",
     "- **Tharp, V. K.** (2007). *Trade Your Way to Financial Freedom*. McGraw-Hill. Position sizing (R-multiples), portfolio heat (somme des risques).\n",
+    "- **Sharpe, W. F.** (1966). *Mutual Fund Performance*. Journal of Business 39(1), 119-138. Reward-to-variability ratio (origine formelle du ratio de Sharpe).\n",
+    "- **Sharpe, W. F.** (1964). *Capital Asset Prices: A Theory of Market Equilibrium Under Conditions of Risk*. Journal of Finance 19(3), 425-442. CAPM, beta (exposition systematique au marche).\n",
+    "- **Maillard, S., Roncalli, T. & Teiletche, J.** (2010). *The Properties of Equally Weighted Risk Contribution Portfolios*. The Journal of Portfolio Management 36(4), 60-70. Risk parity / ERC, ponderation inverse-volatilite, risk budgeting.\n",
     "\n",
     "### Ressources Complementaires\n",
     "\n",


### PR DESCRIPTION
## Summary

**#3164 extended citation audit** on `QC-Py-10-Risk-Portfolio-Management.ipynb`. Ce notebook avait **DÉJÀ** une section « References academiques » solide (cell 69) avec 6 ancres (Kelly 1956, Wilder 1978, Vince 1990, Grossman & Zhou 1993, Moreira & Muir 2017, Tharp 2007) couvrant position sizing, ATR stops, drawdown control, vol scaling. Verdict = **OMISSION (mineure)** : 3 concepts fondamentaux rapportés/interprétés dans tous les backtests manquaient d'attribution.

See #3164.

### Changes (markdown-only, 1 file, +27/-2, 0 code cell touched)

| Cell | Concept | Ancre ajoutée |
|------|---------|---------------|
| 11 | Sharpe ratio + Beta/CAPM (1ère table backtest + prose analytique) | Sharpe 1966 (reward-to-variability) + Sharpe 1964 CAPM (beta, co-développé Treynor/Lintner/Mossin) |
| 59 | Exercice 3 — inverse-volatility / risk budget | Maillard, Roncalli & Teiletche 2010 (Equal Risk Contribution / risk parity) |
| 69 | References | +3 entrées (Sharpe 1966, Sharpe 1964, Maillard et al. 2010) |

### Cadrage #3164

QC-Py = matériel original (Broad, *Hands-On AI Trading*), pas portage strict → verdict OMISSION, markdown additif. **Conservateur (G.5)** : une seule footnote à la 1ère occurrence pédagogique (cell 11) ancre Sharpe + beta — la métrique apparaît dans 10+ tables de backtest mais annoter chacune serait du spam. VaR/Sortino/Calmar/Treynor/Jensen's alpha ne sont **pas** nommés dans la prose (seuls Sharpe + beta sont interprétés analytiquement), donc pas d'ancre pour eux.

## Validation

- **0 code cell touched** : 20 cellules code byte-identiques à `origin/main` (vérifié par diff json des sources).
- **Markdown-only** : 3 cellules markdown annotées (11, 59, 69), 0 ajout/suppression de cellule (70 cells avant/après).
- **nbformat valid** (4).
- **Outputs intacts** (C.2 exception markdown-only : les outputs des cellules code non-modifiées restent valides).
- **Citations web-checkées** (JSTOR/Stanford/UCLA pour Sharpe 1966 ; Wiley/JSTOR pour Sharpe 1964 CAPM ; PM-Research/ResearchGate/SCIRP/page Roncalli pour Maillard et al. 2010). **Aucune fabrication** (G.1/G.3).
- Catalogue byte-identique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
