### PR TITLE
fix(infer-1): audit fidelite #3164 Infer-1-Setup -- NAV/LABELING/OMISSION

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
@@ -1105,7 +1105,9 @@
     "\n",
     "**Flux des messages** :\n",
     "- Durant l'inference, les messages de vraisemblance remontent des observations vers le biais\n",
-    "- Le facteur Beta combine ces messages avec le prior pour produire le posterior Beta(8,4)"
+    "- Le facteur Beta combine ces messages avec le prior pour produire le posterior Beta(8,4)\n",
+    "\n",
+    "> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (cellule de configuration Graphviz + `FactorGraphHelper` renvoient « non disponible », cf issue #3473). Infer.NET genere bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/) ou [edotor.net](https://edotor.net/)), mais affiche a la place un avertissement « Problem with converting DOT to SVG ». La description textuelle de la structure ci-dessus reste valable."
    ]
   },
   {
@@ -2103,7 +2105,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Exercice : Lancer de Deux Des\n",
+    "## 10. Exercice : Lancer de Deux Des\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -2147,7 +2149,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Modele de deux des a 6 faces\n",
+    "// Exercice : Modele de deux des a 6 faces\n",
     "\n",
     "// TODO: Creer le moteur d inference avec Roslyn\n",
     "// Indice: InferenceEngine + CompilerChoice.Roslyn\n",


### PR DESCRIPTION
## Audit fidelite #3164 — Infer-1-Setup

Closes #3626. See #3164.

**Notebook d'introduction/installation** (1er Infer, `.net-csharp`, 41 cells). Couvre setup Graphviz PATH, NuGet, imports, FactorGraphHelper, premier exemple deux pieces, distributions, piece biaisee (Beta), factor graphs, debug.

**Verdict : substantively bon** (0 INVENTION, 0 ERREUR-FACTUELLE, ~6 anchors FIDELes). 3 defauts markdown-only :

### 1. NAVIGATION — doublon `## 9.`
idx37 `## 9. Resume` + idx38 `## 9. Exercice : Lancer de Deux Des` avaient le meme numero. Fix : idx38 -> `## 10. Exercice` (ordre monotone 8 -> 8bis -> 9 -> 10 -> Conclusion).

### 2. LABELING — commentaire `// Exemple guide` sur stub
idx39 est un stub creux (4 TODOs + « Exercice a completer »). Header idx38 « Exercice » correct, commentaire interne idx39 `// Exemple guide` errone -> corrige en `// Exercice`.

### 3. OMISSION #3473 idx23
Factor-graph piece biaisee : banner fallback « dot introuvable » (bug kernel-PATH #3473). idx24 prose decrivait le graphe comme rendu -> caveat standardise.

**Worked example idx26/28 laisse** (no-pendulum) : `## 8. Exemple guide : Trois Pieces` + solution complete fonctionnelle (0.125/0.5781) = header correct par contenu, pas une pathology.

## Validation (4 gates)
- **G1** scan_cell_ordering : **1 clean, 0 finding**
- **G2** check_c2_compliance : **1/1 compliant**
- **G3** notebook_tools validate : **0 Errors** (Warning = FP LaTeX `\$`-balance, verifie identique sur `origin/main`)
- **G4** git diff : **5 ins / 3 del**, markdown + 1 commentaire, **0 execution_count/outputs touchee**, submodules non stages