### PR TITLE
fix(app-9): align EdgeDetection fitness/labeling interpretations to committed output (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
@@ -577,12 +577,14 @@
    "source": [
     "### Interpretation : calibration de la fitness\n",
     "\n",
-    "**Sortie obtenue** : Le noyau aleatoire obtient une fitness faible, tandis que le Sobel (cible ideale) obtient un score eleve.\n",
+    "**Sortie obtenue** : Le noyau aleatoire obtient une fitness de 362.26, tandis que le Sobel (dans un noyau 7x7) obtient 75.82.\n",
     "\n",
     "| Noyau | Fitness | Signification |\n",
     "|-------|---------|---------------|\n",
-    "| Aleatoire | ~0-200 | Correlation faible ou nulle avec la reference |\n",
-    "| Sobel 3x3 (dans 7x7) | ~700-1000 | Borne superieure approximative |\n",
+    "| Aleatoire | 362.26 | Penalite faible (variance elevee), score brut eleve |\n",
+    "| Sobel 3x3 (dans 7x7) | 75.82 | Penalite x10 (variance faible), cible ideale du GA |\n",
+    "\n",
+    "**Pourquoi le Sobel a-t-il un score plus bas ?** La fonction `compute_fitness` applique une penalite de x10 aux noyaux de faible variance (comme le Sobel, dont les coefficients sont concentres). Le score brut de 75.82 est donc la **cible** que le GA doit approcher, et non une borne superieure. Un noyau aleatoire (variance elevee) esquive la penalite mais ne detecte pas les bords : le GA doit donc trouver un noyau structure (proche du Sobel) malgre la penalite.\n",
     "\n",
     "**Points cles** :\n",
     "1. L'espace de recherche contient $41^{49} \\approx 10^{79}$ solutions candidates (chaque gene peut prendre 41 valeurs de -20 a 20)\n",
@@ -1659,9 +1661,9 @@
     "tags": []
    },
    "source": [
-    "## 7. Exemple guide\n",
+    "## 7. Exercices\n",
     "\n",
-    "### Exemple guide 1 : Evoluer un filtre Laplacien\n",
+    "### Exercice 1 : Evoluer un filtre Laplacien\n",
     "\n",
     "Le filtre Laplacien detecte les bords en calculant la derivee seconde de l'image. Contrairement au Sobel, il est **isotrope** (meme sensibilite dans toutes les directions).\n",
     "\n",
@@ -1953,13 +1955,11 @@
    "source": [
     "### Interpretation : effet du taux de mutation\n",
     "\n",
-    "**Sortie obtenue** : Trois courbes de convergence avec differents taux de mutation.\n",
+    "**A verifier (Exercice 3)** : Une fois la boucle sur les taux de mutation implementee, comparez vos trois courbes de convergence. Voici les comportements generaux attendus en fonction du taux :\n",
     "\n",
-    "| Taux de mutation | Comportement attendu |\n",
-    "|-----------------|---------------------|\n",
-    "| 5% (faible) | Convergence lente mais stable, risque de piege dans un optimum local |\n",
-    "| 15% (moyen) | Bon compromis entre exploration et exploitation |\n",
-    "| 30% (eleve) | Exploration forte mais instabilite, peut \"detruire\" de bonnes solutions |\n",
+    "- **5% (faible)** : convergence plus lente mais plus stable, risque de piege dans un optimum local.\n",
+    "- **15% (moyen)** : compromis entre exploration et exploitation.\n",
+    "- **30% (eleve)** : exploration forte mais plus d'instabilite, peut \"detruire\" de bonnes solutions.\n",
     "\n",
     "**Lecon** : Le taux de mutation controle l'equilibre entre **exploration** (decouvrir de nouvelles regions) et **exploitation** (affiner les bonnes solutions). C'est un hyper-parametre critique des algorithmes genetiques."
    ]


### PR DESCRIPTION
Closes #3628
See #3164

Audit fidélité #3164 — App-9-EdgeDetection (Hybrid). 3 findings (Class A + B + C).

## Class A — idx13 (fitness table INVERTED)
Table claimed "Aleatoire ~0-200 (faible), Sobel ~700-1000 (eleve)". Committed idx12 output is opposite: `Aleatoire = 362.26`, `Sobel = 75.82`, target ≈ 76. The Sobel scores lower because `compute_fitness` applies a x10 penalty to low-variance kernels. Aligned table + prose to committed values + explained the penalty.

## Class C — idx35 ("Exemple guide" section above stubs)
`## 7. Exemple guide` above exercise stubs (idx34/38/40 are `TODO etudiant`/`Exercice a completer`, idx36 is an open task). Relabeled → `## 7. Exercices` / `### Exercice 1`.

## Class B — idx41 (fabricated result above stub)
"Sortie obtenue : Trois courbes..." + 5%/15%/30% verdict table above idx40 stub (output = "Exercice 3 : implementez..."). Reframed → "A verifier (Exercice 3)" open prompt; kept the general exploration/exploitation lesson.

## Verification
- 11 ins / 11 del, 0 structural churn.
- 0 control chars, JSON valid.
- Catalogue + MGS submodule byte-identical (3-dot diff empty).
- Branch fresh from origin/main.
