### PR TITLE
docs(genai-image-02-1): fix factual error (Qwen-VL arxiv) + anchor Qwen2.5-VL citations (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb
@@ -57,6 +57,8 @@
     "- **Édition précise de texte** dans les images\n",
     "- **Inpainting avancé** avec masques personnalisés\n",
     "- **Workflows multi-étapes** pour des transformations complexes\n",
+    "\n",
+    "> **Note savante — modèle sous-jacent.** Qwen-Image-Edit (Septembre 2025) repose sur **Qwen2.5-VL** [Wang et al. 2025], le vision-language model de la série Qwen, fine-tuné pour l'édition d'images. L'encodeur de texte utilisé (`qwen_2.5_vl_7b`) en est dérivé directement.\n",
     "- **Batch processing** pour l'efficacité\n",
     "- **Analyse comparative** des paramètres\n",
     "\n",
@@ -1876,9 +1878,11 @@
     "### Ressources\n",
     "\n",
     "- [Documentation ComfyUI](https://docs.comfy.org/)\n",
-    "- [Qwen-VL Papers](https://arxiv.org/abs/2308.12966)\n",
+    "- [Qwen-VL — VLM original 2023 (Bai et al., arXiv:2308.12966)](https://arxiv.org/abs/2308.12966) — le vision-language model fondateur de la série Qwen (ne pas confondre avec Qwen-Image-Edit 2025).\n",
+    "- [Qwen2.5-VL Technical Report (Wang et al. 2025, arXiv:2502.13923)](https://arxiv.org/abs/2502.13923) — **papier pertinent pour Qwen-Image-Edit** (VLM sous-jacent).\n",
     "- [Modeles Comfy-Org](https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI)\n",
-    "- Notebook suivant: **02-2-FLUX-1-Advanced-Generation**\n"
+    "- Notebook suivant: **02-2-FLUX-1-Advanced-Generation**\n",
+    "\n### Références savantes\n\n- **Wang, Z., et al.** (2025). *Qwen2.5-VL Technical Report*. arXiv:2502.13923. — Vision-language model sous-jacent à Qwen-Image-Edit (encodeur de texte `qwen_2.5_vl_7b`).\n- **Bai, J., Bai, S., Yang, S., et al.** (2023). *Qwen-VL: A Versatile Vision-Language Model*. arXiv:2308.12966. — VLM fondateur de la série Qwen (précédent Qwen2-VL puis Qwen2.5-VL).\n- **Esser, P., Kulal, S., Blattmann, A., et al.** (2024). *Scaling Rectified Flow Transformers for High-Resolution Image Synthesis* (MMDiT). arXiv:2403.03206. — Architecture Flow/DiT dont s'inspirent les modèles Qwen-Image (node `ModelSamplingAuraFlow`).\n"
    ]
   },
   {


### PR DESCRIPTION
## Context

Audit fidélité #3164 — GenAI/Image family (po-2023 lane). **02-1-Qwen-Image-Edit-2509** contained a **FACTUAL ERROR** plus an OMISSION.

## Verdict: ERREUR FACTUELLE (corrected) + OMISSION (anchored), 0 reinvention

**G.1 grounding:** The Ressources section linked `[Qwen-VL Papers](https://arxiv.org/abs/2308.12966)`. But arXiv:2308.12966 = **Qwen-VL** (Bai et al. Sept 2023, the ORIGINAL vision-language model), while this notebook teaches **Qwen-Image-Edit** (Sept 2025), which is built on **Qwen2.5-VL** (Wang et al. 2025, arXiv:2502.13923). The link pointed to the wrong paper.

## Changes (markdown-only, +6/-2)

- **cell 1 (intro)**: scholarly note anchoring Qwen2.5-VL [Wang et al. 2025] as the base VLM of Qwen-Image-Edit (text encoder `qwen_2.5_vl_7b` is derived from it)
- **cell 32 (recap)**: **FACTUAL ERROR CORRECTED** — relabelled the Qwen-VL link with explicit disambiguation ("VLM original 2023, do not confuse with Qwen-Image-Edit 2025") + added the **correct** Qwen2.5-VL Technical Report link (arXiv:2502.13923, the paper actually relevant here)
- **cell 32**: added "Références savantes" section (Qwen2.5-VL Wang 2025, Qwen-VL Bai 2023, Esser MMDiT 2024 for Flow/DiT architecture)

## arXiv IDs (G.1 web-verified)

| Citation | arXiv | Note |
|----------|-------|------|
| Wang et al. 2025 — Qwen2.5-VL | 2502.13923 | **Correct paper for Qwen-Image-Edit** |
| Bai et al. 2023 — Qwen-VL | 2308.12966 | Original VLM (was mislabelled) |
| Esser et al. 2024 — MMDiT | 2403.03206 | Flow/DiT architecture (AuraFlow node) |

## Validation

- nbformat.validate OK · **0 code cell changed** (15 code cells intact) · 34 cells
- cell-order: **0 finding** · C.1: **0 in code source** (Python-verified, not grep)
- catalogue byte-identical (not touched)
- base fresh `origin/main` · indent=1 format preserved (structural edit)

Markdown-only — H.3 not triggered. Forensic `git diff` suffices (H.4).

See #3164