### PR TITLE
docs(qcpy-21): anchor Markowitz/Black-Litterman/Ledoit-Wolf/HRP/Sharpe citations (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
@@ -44,8 +44,12 @@
     "| 4 | Black-Litterman avec vues ML | 20 min |\n",
     "| 5 | Hierarchical Risk Parity (HRP) | 15 min |\n",
     "| 6 | Integration QuantConnect | 10 min |\n",
-    "| 7 | Strategie Complete ML-Optimized | 15 min |",
-    "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
+    "| 7 | Strategie Complete ML-Optimized | 15 min |\n",
+    "\n",
+    "> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n",
+    "\n",
+    "> *Ancres savantes -- les methodes enseignees dans ce notebook reposent sur une litterature classique : Markowitz (1952, Modern Portfolio Theory / Mean-Variance), Black & Litterman (1992, views-implied returns), Ledoit & Wolf (2004, covariance shrinkage), Lopez de Prado (2016, Hierarchical Risk Parity), Sharpe (1966, ratio de Sharpe). La section **References** a la fin du notebook donne les citations completes.*\n",
+    ""
    ]
   },
   {
@@ -385,7 +389,10 @@
     "| $w$ | Vecteur des poids |\n",
     "| $\\mu$ | Vecteur des rendements attendus |\n",
     "| $\\Sigma$ | Matrice de covariance |\n",
-    "| $r_f$ | Taux sans risque |"
+    "| $r_f$ | Taux sans risque |\n",
+    "\n",
+    "> *Ancres savantes -- Markowitz, H. (1952), « Portfolio Selection », The Journal of Finance 7(1), 77-91 (formalisation du compromis rendement/variance et de la frontiere efficiente, Nobel 1990). Sharpe, W. F. (1966), « Mutual Fund Performance », Journal of Business 39(1), 119-138 (le ratio maximise ci-dessus porte son nom ; origine « reward-to-variability »).*\n",
+    ""
    ]
   },
   {
@@ -942,7 +949,10 @@
     "\n",
     "$$\\Sigma_{shrunk} = (1-\\alpha) \\times \\Sigma_{sample} + \\alpha \\times \\Sigma_{target}$$\n",
     "\n",
-    "La cible est souvent la **matrice identite** (actifs non correles) ou une **matrice a correlation constante**."
+    "La cible est souvent la **matrice identite** (actifs non correles) ou une **matrice a correlation constante**.\n",
+    "\n",
+    "> *Ancre savante -- Ledoit, O. & Wolf, M. (2004), « A well-conditioned estimator for large-dimensional covariance matrices », Journal of Multivariate Analysis 88(2), 365-411. L'estimateur de shrinkage `Sigma_shrunk = (1-alpha)*Sigma_sample + alpha*Sigma_target` enseigne ci-dessus est leur formulation ; le coefficient alpha optimal minimise l'erreur de Stein (MSE de Frobenius).*\n",
+    ""
    ]
   },
   {
@@ -1539,7 +1549,10 @@
     "- $P$ : Matrice des vues (quels actifs)\n",
     "- $Q$ : Vecteur des vues (rendements attendus)\n",
     "- $\\Omega$ : Incertitude sur les vues\n",
-    "- $\\tau$ : Scaling factor (~0.05)"
+    "- $\\tau$ : Scaling factor (~0.05)\n",
+    "\n",
+    "> *Ancre savante -- Black, F. & Litterman, R. (1992), « Global Portfolio Optimization », Financial Analysts Journal 48(5), 28-43. Le modele combine un prior d'equilibre de marche `pi = delta*Sigma*w_mkt` avec les vues de l'investisseur via une mise a jour bayesienne (formule posterieure ci-dessus) -- d'ou des rendements posterieurs plus stables que l'optimisation naive.*\n",
+    ""
    ]
   },
   {
@@ -1934,7 +1947,10 @@
     "| Inversion matrice | Requise | Non requise |\n",
     "| Stabilite | Instable | Stable |\n",
     "| Concentration | Elevee | Diversifiee |\n",
-    "| Rendements attendus | Requis | Non utilises |"
+    "| Rendements attendus | Requis | Non utilises |\n",
+    "\n",
+    "> *Ancre savante -- Lopez de Prado, M. (2016), « Building Diversified Portfolios that Outperform Out-of-Sample », The Journal of Portfolio Management 42(4), 59-69 (SSRN 2708678). HRP (clustering hierarchique + quasi-diagonalisation + bisection recursive) y est introduit precisement pour eviter l'inversion instable de la matrice de covariance qui plombe le Mean-Variance.*\n",
+    ""
    ]
   },
   {
@@ -2678,6 +2694,16 @@
     "| **Black-Litterman** | Combine equilibre marche + vues ML, rendements posterieurs |\n",
     "| **HRP** | Pas d'inversion matrice, clustering hierarchique, stable |\n",
     "| **Integration QC** | MLPortfolioConstructionModel, strategie complete |\n",
+    "## References\n",
+    "\n",
+    "Les fondations theoriques des methodes de ce notebook :\n",
+    "\n",
+    "- **Markowitz, H.** (1952). « Portfolio Selection ». *The Journal of Finance* 7(1), 77-91. Modern Portfolio Theory, optimisation Mean-Variance, frontiere efficiente (Nobel d'economie 1990).\n",
+    "- **Sharpe, W. F.** (1966). « Mutual Fund Performance ». *Journal of Business* 39(1), 119-138. Ratio de Sharpe (maximisation de la pente rendement/volatilite).\n",
+    "- **Ledoit, O. & Wolf, M.** (2004). « A well-conditioned estimator for large-dimensional covariance matrices ». *Journal of Multivariate Analysis* 88(2), 365-411. Shrinkage de covariance (MSE-optimal).\n",
+    "- **Black, F. & Litterman, R.** (1992). « Global Portfolio Optimization ». *Financial Analysts Journal* 48(5), 28-43. Modele Black-Litterman (prior d'equilibre + vues bayesiennes).\n",
+    "- **Lopez de Prado, M.** (2016). « Building Diversified Portfolios that Outperform Out-of-Sample ». *The Journal of Portfolio Management* 42(4), 59-69. Hierarchical Risk Parity (SSRN 2708678).\n",
+    "\n",
     "\n",
     "### Recommandations pratiques\n",
     "\n",


### PR DESCRIPTION
## Summary

**#3164 extended citation audit** on `QC-Py-21-Portfolio-Optimization-ML.ipynb`. Ce notebook n'avait **AUCUNE** section References ni ancre savante (juste des marqueurs d'année inline 1952/1992/2016 + 2 liens Amazon livres López de Prado en Ressources). Verdict = **OMISSION (pleine)** : 5 concepts fondamentaux d'optimisation de portefeuille enseignés dans 5 sections dédiées manquaient d'attribution.

See #3164.

### Changes (markdown-only, 1 file, +33/-7, 0 code cell touched)

| Cell | Concept | Ancre ajoutée |
|------|---------|---------------|
| 0 | Vue d'ensemble (MPT/BL/LW/HRP/Sharpe) | footnote nommant les 5 méthodes + auteurs |
| 10 | Partie 1 — Markowitz + formule Sharpe | Markowitz 1952 (Portfolio Selection, Nobel 1990) + Sharpe 1966 |
| 22 | Partie 2 — Ledoit-Wolf shrinkage | Ledoit & Wolf 2004 (J. Multivariate Analysis 88(2)) |
| 36 | Partie 4 — Black-Litterman | Black & Litterman 1992 (Global Portfolio Optimization, FAJ 48(5)) |
| 45 | Partie 5 — HRP | López de Prado 2016 (J. Portfolio Management 42(4), SSRN 2708678) |
| 55 | Conclusion | nouvelle section `## References` (5 entrées) |

### Cadrage #3164

QC-Py = matériel original (Broad, *Hands-On AI Trading*), pas portage strict → verdict OMISSION, markdown additif. **Yield élevé** (OMISSION pleine comme QC-Py-13, contrairement à QC-Py-10/11 qui avaient déjà des References).

## Validation

- **0 code cell touched** : 23 cellules code byte-identiques à `origin/main` (vérifié par diff json des sources).
- **Markdown-only** : 6 cellules markdown annotées (0, 10, 22, 36, 45, 55), 0 ajout/suppression de cellule (56 cells avant/après), séquence cell_type identique.
- **JSON valide**, structurellement sain.
- **Outputs intacts** (C.2 exception markdown-only).
- **Citations web-checkées** (Tandfonline/Duke/Wikipedia pour Black-Litterman 1992 ; PM-Research/SSRN/Wikipedia pour López de Prado 2016 ; ENS-Lyon/ledoit.net/RePEc pour Ledoit-Wolf 2004 ; Markowitz 1952 + Sharpe 1966 déjà vérifiés au cycle QC-Py-10). **Aucune fabrication** (G.1/G.3).
- Catalogue byte-identique.

**Note technique** : `nbformat.validate()` strict échoue sur ce notebook, mais c'est **pré-existant sur origin/main** (6 cellules portent un champ `'id': ''` vide qui viole le schéma strict) — non introduit par cette PR. JSON valide, 56 cells préservées, 23 code cells byte-identiques. La CI repo `validate-notebooks` (parser tolérant) est passée SUCCESS sur les 3 PRs QC-Py précédentes de structure identique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
