### PR TITLE
fix(sw1): SemanticWeb SW-1 Setup fidelity anchors + References

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
@@ -50,6 +50,8 @@
     "\n",
     "### La pile technologique du W3C (\"Layer Cake\")\n",
     "\n",
+    "> L'expression **« Layer Cake »** (gâteau en couches) désigne le diagramme d'architecture du Web sémantique, popularisé par **Tim Berners-Lee** lors de son *keynote* à la conférence XML 2000 et raffiné par la suite par le **W3C Semantic Web Activity Group**. Il représente la stratification des standards (URI -> RDF -> RDFS -> SPARQL -> OWL -> SHACL -> Trust/Proof) où chaque couche s'appuie sur les précédentes.\n",
+    "\n",
     "Le W3C (World Wide Web Consortium) a defini une architecture en couches pour le Web semantique :\n",
     "\n",
     "```\n",
@@ -85,7 +87,9 @@
     "| **Ontologies** | OWL | Raisonnement logique sur les donnees | SW-7 |\n",
     "| **Contraintes** | SHACL | Valider la conformite des donnees | SW-8 |\n",
     "\n",
-    "> **Point cle** : Chaque couche s'appuie sur les precedentes. RDF est la fondation sur laquelle repose tout le reste."
+    "> **Point cle** : Chaque couche s'appuie sur les precedentes. RDF est la fondation sur laquelle repose tout le reste.\n",
+    "\n",
+    "> La couche **RDF** (Resource Description Framework) repose sur le modèle abstrait défini dans **RDF 1.1 Concepts and Abstract Syntax** (Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 février 2014) : un graphe est un ensemble de *triplets* (sujet-prédicat-objet) dont les composants sont des IRI, des blank nodes ou des littéraux. Ce modèle est celui que la bibliothèque **dotNetRDF** (`dotnetrdf.org`, open-source) implémente et que ce notebook manipule."
    ]
   },
   {
@@ -516,6 +520,19 @@
     "//   Console.WriteLine($\"Nombre de triplets : {g.Triples.Count}\");\n",
     "\n",
     "Console.WriteLine(\"Exercice a completer\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw1-refs-savantes-3164",
+   "metadata": {},
+   "source": [
+    "## References savantes\n",
+    "\n",
+    "- **The Semantic Web** - Berners-Lee, Hendler, Lassila, *Scientific American* 284(5), mai 2001. Article fondateur exposant la vision d'un Web comprehensible par les machines (deja cite dans la section 1).\n",
+    "- **RDF 1.1 Concepts and Abstract Syntax** - Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 fevrier 2014. Modele de donnees abstrait (triplets sujet-predicat-objet, IRIs, blank nodes, litteraux) qui fonde la couche RDF du Layer Cake.\n",
+    "- **Semantic Web Layer Cake** - architecture en couches popularisee par Berners-Lee (keynote XML 2000) et raffinee par le W3C Semantic Web Activity Group. Represente la stratification des standards du Web semantique.\n",
+    "- **dotNetRDF** - bibliotheque open-source .NET (`dotnetrdf.org`) pour la manipulation de graphes RDF, utilisee tout au long de cette serie de notebooks."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Fidelity audit of **SW-1-CSharp-Setup** (Option A, SemanticWeb `#3164`, 3rd and final MEDIUM-priority grain). **SemanticWeb family HIGH 5/5 + MEDIUM 3/3 = fully DRAINED** after this PR.

SW-1 introduced the Semantic Web vision (already well cited: Berners-Lee/Hendler/Lassila, *Scientific American* 2001) but left **three core concepts without scholarly attribution**: the **"Layer Cake" architecture**, the **RDF abstract data model** (triplets), and the **dotNetRDF library**. No References section existed.

Additive markdown-only fix: 2 scholarly anchors + a new 4-entry **References savantes** section.

## Changes (markdown-only, +19/-2)

- **cell 1** (La pile technologique du W3C): anchor the **"Layer Cake"** expression to Berners-Lee's **XML 2000 keynote** and its refinement by the **W3C Semantic Web Activity Group**; anchor the RDF data-model layer to Cyganiak, Wood, Lanthaler (eds.), *RDF 1.1 Concepts and Abstract Syntax* (**W3C Recommendation, 25 February 2014**), noting dotNetRDF as its .NET implementation.
- **new final cell**: a **References savantes** section (4 entries: Berners-Lee Scientific American 2001 — already cited in section 1, RDF 1.1 Concepts, Layer Cake, dotNetRDF).

## G.1 verification

- **G.1 key nuance**: the Berners-Lee/Hendler/Lassila *Scientific American* 2001 citation **ALREADY existed** in cell 1 (not duplicated — only referenced in the new References section for completeness). The **genuine omissions** were: the Layer Cake architecture (named but unattributed), the RDF 1.1 abstract model (triplets taught in detail without source), and the dotNetRDF library (used 16×, never formally cited).
- 0 References section existed before. W3C Recommendation + XML 2000 keynote provenance **web-checked** (not fabricated).

## C.2 / C.3 (anti-churn)

- **0 code cell churn**: 5 code cells **byte-identical** to `origin/main` (MD5 source-hash comparison, exec_count preserved).
- 21/21 original cell IDs preserved; +1 new markdown cell (`sw1-refs-savantes-3164`). Total 21 → 22 cells.
- **C.1 = 0** (`raise NotImplementedError` / `assert False` / `1/0`).
- `nbformat.validate` OK.

## CI expectations

Markdown-only (rule-H.3 not triggered). Same pattern as the 7 prior SW fidelity PRs (#3547, #3556, #3568, #3576, #3593, #3608, #3625). 10/10 CI CLEAN expected.

**Milestone**: with this PR, the SemanticWeb family `#3164` audit is **fully drained** (HIGH 5/5 + MEDIUM 3/3). Next lane per ai-01 (13:57Z): fallback perenne **#2651 prose READMEs**.

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)