### PR TITLE
docs(genai-image): add scholarly anchors to DALL-E 3 notebook (OMISSION)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
@@ -39,7 +39,10 @@
     "\n",
     "**Note importante :** DALL-E 3 necessite l'API OpenAI directe (`api.openai.com`).\n",
     "OpenRouter ne supporte PAS le endpoint `/v1/images/generations`.\n",
-    "Si vous n'avez qu'une cle OpenRouter, passez au notebook 01-2 (GPT-5 analyse d'images).\n"
+    "Si vous n'avez qu'une cle OpenRouter, passez au notebook 01-2 (GPT-5 analyse d'images).\n",
+    "\n",
+    "\n",
+    "**Ancrage savant.** DALL-E 3 n'a pas de papier scientifique dedie ; OpenAI l'a annonce dans un billet de blog (octobre 2023) accompagne d'une *System Card* officielle. Sa principale innovation -- la **reecriture automatique des prompts** (la fameuse prompt revision enseignee plus bas) -- provient d'un modele de langage (GPT-4) qui densifie la description, et d'un **entrainement sur captions ameliorees** (recaptioning) : voir la *DALL-E 3 System Card* (OpenAI, 2023) et, pour la filiation architecturale (CLIP latents + diffusion), le papier DALL-E 2 [Ramesh et al. 2022, arXiv:2204.06125].\n"
    ]
   },
   {
@@ -1154,7 +1157,13 @@
     "\n",
     "---\n",
     "\n",
-    "**Soumission** : PR avec titre \"Challenge #4 - [Votre Nom]\", type d'app choisi, prompts et image générée"
+    "**Soumission** : PR avec titre \"Challenge #4 - [Votre Nom]\", type d'app choisi, prompts et image générée",
+    "\n",
+    "### 📖 References savantes\n",
+    "\n",
+    "- **OpenAI** (2023). *DALL-E 3 System Card*. — Documente la reecriture automatique des prompts via GPT-4 et l'entrainement sur captions ameliorees (recaptioning), caracteristiques centrales du modele enseignees dans ce notebook.\n",
+    "- **Ramesh, A. et al.** (2022). *Hierarchical Text-Conditional Image Generation with CLIP Latents* (DALL-E 2). arXiv:2204.06125. — Filiation architecturale : CLIP latents + processus de diffusion, socle sur lequel DALL-E 3 s'appuie.\n",
+    "- **OpenAI** (2021). *DALL-E: Creating Images from Text* (DALL-E 1, Ramesh et al.). arXiv:2102.12092. — Precurseur : auto-regressive transformer dVAE, origine de la lignee DALL-E.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit fidelite #3164 — GenAI/Image 01-Foundation/01-1 OpenAI DALL-E 3. **OMISSION** type: DALL-E 3 taught across 24 cells with **zero scholarly anchor** and no References section.

## What was missing

The notebook teaches DALL-E 3 as a model, including its key feature — **prompt revision** (the `revised_prompt` returned by the API, taught 2x) — and the vivid/natural/hd/standard parameters, but never:
- explains *where* prompt revision comes from (GPT-4 rewriting + improved captions via recaptioning)
- cites any scholarly source
- has a References section

## Changes (markdown-only, +11/-2, 24 cells / 12 code unchanged)

- **Cell 0** (intro): added **Ancrage savant** note — DALL-E 3 has no dedicated paper (blog Oct 2023 + System Card); prompt revision comes from GPT-4 rewriting + recaptioning; filiation to DALL-E 2 paper [Ramesh et al. 2022, arXiv:2204.06125] for CLIP latents + diffusion.
- **Cell ed100025** (markdown): added **References savantes** section:
  - **OpenAI** (2023). *DALL-E 3 System Card*. — prompt rewriting via GPT-4 + recaptioning.
  - **Ramesh, A. et al.** (2022). *DALL-E 2*. arXiv:2204.06125. — CLIP latents filiation.
  - **OpenAI** (2021). *DALL-E 1*. arXiv:2102.12092. — lineage origin.

## G.1 verification

- DALL-E 2 paper **2204.06125** (Ramesh et al. 2022, "Hierarchical Text-Conditional Image Generation with CLIP Latents") — confirmed.
- DALL-E 1 paper **2102.12092** (Ramesh et al. 2021) — confirmed.
- DALL-E 3 has **no dedicated arXiv paper** (OpenAI announced via blog + System Card Oct 2023) — documented as such, no fabricated citation.

## Validation

- [x] nbformat OK
- [x] cell-ordering scanner: 1 clean, 0 finding
- [x] C.1 check (code source): 0 `raise NotImplementedError` / `assert False` / `1/0`
- [x] Catalogue byte-identical (not regenerated)
- [x] Markdown-only -> H.3 not triggered, no re-execution required (C.2 exception)
- [x] Anchors placed in markdown cells (verified cell types), not code cells

See #3164 (partial: GenAI/Image 01-1 grain). Not closing the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)