### PR TITLE
docs(genai-image): add scholarly anchors to Basic Image Operations (OMISSION)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
@@ -36,7 +36,9 @@
     "\n",
     "- Environment Setup (module 00) complété\n",
     "- Notions de base Python\n",
-    "- Familiarité avec les formats d'images (PNG, JPEG, etc.)"
+    "- Familiarité avec les formats d'images (PNG, JPEG, etc.)",
+    "\n",
+    "**Ancrage savant.** Ce notebook mobilise trois bibliotheques scientifiques de reference : **NumPy** (calcul matriciel / tableaux n-dimensionnels), **Matplotlib** (visualisation) et **Pillow/PIL** (E/S et traitements d'images). NumPy et Matplotlib sont des logiciels academiques peer-reviewed disposant d'un papier de citation officiel (cf. References en Section 8) ; Pillow est un logiciel libre (fork de PIL) sans papier formel.\n"
    ]
   },
   {
@@ -1748,7 +1750,12 @@
    "source": [
     "## 📚 Section 8: Récapitulatif et Ressources\n",
     "\n",
-    "Résumé des opérations couvertes et ressources supplémentaires."
+    "Résumé des opérations couvertes et ressources supplémentaires.",
+    "### 📖 References savantes\n",
+    "\n",
+    "- **Harris, C.R. et al.** (2020). *Array programming with NumPy*. Nature, 585(7825), 357-362. doi:10.1038/s41586-020-2649-2. — Papier de citation officiel de NumPy, socle matriciel utilise tout au long du notebook.\n",
+    "- **Hunter, J.D.** (2007). *Matplotlib: A 2D Graphics Environment*. Computing in Science & Engineering, 9(3), 90-95. doi:10.1109/MCSE.2007.55. — Papier de citation officiel de Matplotlib (affichage des images et histogrammes).\n",
+    "- **Pillow / PIL** — Logiciel libre (fork communautaire de la Python Imaging Library d'origine). Pas de papier academique formel ; documentation officielle : pillow.readthedocs.io.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit fidelite #3164 — GenAI/Image 01-Foundation/01-3 Basic Image Operations. **OMISSION** type: NumPy, Matplotlib and Pillow/PIL used throughout (30 PIL refs, 8 numpy, 13 matplotlib) with **zero citation** of their peer-reviewed papers and no References section.

## What was missing

The notebook teaches image manipulation via three scientific libraries but never cites their reference papers. **NumPy** and **Matplotlib** are academic software with an **official peer-reviewed citation paper** — omitting these is a real scholarly gap (not merely stylistic). Pillow/PIL has no formal paper (documented as such).

## Changes (markdown-only, +9/-2, 31 cells / 15 code unchanged)

- **Cell c7eec602** (intro): added **Ancrage savant** — NumPy/Matplotlib have peer-reviewed citation papers, Pillow is libre software without one.
- **Cell 3ddeb1f2** (Section 8 Recap): added **References savantes**:
  - **Harris, C.R. et al.** (2020). *Array programming with NumPy*. Nature 585(7825):357-362. doi:**10.1038/s41586-020-2649-2**
  - **Hunter, J.D.** (2007). *Matplotlib: A 2D Graphics Environment*. Computing in Science & Engineering 9(3):90-95. doi:**10.1109/MCSE.2007.55**
  - **Pillow/PIL** — libre software (community fork of the Python Imaging Library), no formal paper.

## G.1 verification

- NumPy Nature paper doi **10.1038/s41586-020-2649-2** — confirmed (Nature, Harris et al. 2020).
- Matplotlib CiSE paper doi **10.1109/MCSE.2007.55** — confirmed (Hunter 2007).

## Validation

- [x] nbformat OK
- [x] cell-ordering scanner: 1 clean, 0 finding
- [x] C.1 check (code source): 0
- [x] Catalogue byte-identical
- [x] Markdown-only -> H.3 not triggered (C.2 exception)
- [x] Anchors in markdown cells (verified types)

See #3164 (partial: GenAI/Image 01-3 grain). Not closing the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)