### PR TITLE
docs(genai-image): add Qwen-Image scholarly anchors + precise Qwen-VL ref

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
@@ -88,7 +88,9 @@
     "pip install requests pillow matplotlib\n",
     "```\n",
     "\n",
-    "**Temps estimé**: 90-120 minutes"
+    "**Temps estimé**: 90-120 minutes",
+    "\n",
+    "**Ancrage savant.** Qwen-Image-Edit est l'un des modeles d'edition d'image de la famille Qwen-Image, dont l'architecture (VAE 16 canaux, CFG = 1.0 gere via CFGNorm, scheduler *beta*, ModelSamplingAuraFlow) est detaillee dans le **Qwen-Image Technical Report** [QwenLM, aout 2025, arXiv:2508.02324]. Le modele repose sur la base vision-langage Qwen2.5-VL [Wang et al. 2025, arXiv:2502.13923].\n"
    ]
   },
   {
@@ -2298,7 +2300,7 @@
     "- **Custom Nodes**: [https://github.com/ltdrdata/ComfyUI-Manager](https://github.com/ltdrdata/ComfyUI-Manager)\n",
     "\n",
     "#### Qwen Vision-Language Model\n",
-    "- **Paper Officiel**: *Qwen-VL: A Versatile Vision-Language Model*\n",
+    "- **Paper Officiel (Qwen-VL)** : *Qwen-VL: A Versatile Vision-Language Model* [Bai et al. 2023, arXiv:2308.12966] — modele vision-langage original (base VLM, distinct du modele d'edition Qwen-Image-Edit enseigne ici).\n",
     "- **Modèle Hugging Face**: [https://huggingface.co/Qwen/Qwen-VL](https://huggingface.co/Qwen/Qwen-VL)\n",
     "- **Documentation Technique**: [https://qwenlm.github.io/](https://qwenlm.github.io/)\n",
     "\n",
@@ -2354,7 +2356,14 @@
     "\n",
     "---\n",
     "\n",
-    "**✅ Notebook terminé! Bon apprentissage avec Qwen Image Edit! 🚀**"
+    "**✅ Notebook terminé! Bon apprentissage avec Qwen Image Edit! 🚀**",
+    "\n",
+    "### 📖 References savantes (architecture du modele)\n",
+    "\n",
+    "- **QwenLM** (2025). *Qwen-Image Technical Report*. arXiv:2508.02324. — Rapport technique officiel de Qwen-Image / Qwen-Image-Edit : architecture (VAE 16 canaux, CFGNorm, scheduler *beta*, ModelSamplingAuraFlow), rendu de texte complexe et edition d'image precise.\n",
+    "- **Wang, P. et al.** (2025). *Qwen2.5-VL Technical Report*. arXiv:2502.13923. — Base vision-langage sur laquelle s'appuie la famille Qwen-Image.\n",
+    "- **Bai, J. et al.** (2023). *Qwen-VL: A Versatile Vision-Language Model*. arXiv:2308.12966. — Precurseur VLM de la lignee Qwen-Vision.\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Audit fidelite #3164 — GenAI/Image 01-Foundation/01-5 Qwen-Image-Edit. **OMISSION + imprecision**.

## Issues found

1. **OMISSION**: The notebook teaches the critical Qwen-Image architecture (VAE 16 channels, CFG = 1.0 via CFGNorm, scheduler *beta*, ModelSamplingAuraFlow — per the Phase 29 critical config) but cites **no scholarly source**.
2. **Imprecision**: The "Qwen-VL paper" reference was bare (no arXiv id) and ambiguous — Qwen-VL (2308.12966) is the **original VLM**, distinct from the **Qwen-Image-Edit** model taught here.

## Changes (markdown-only, +13/-4, 28 cells / 13 code unchanged)

- **Cell 79be9a9e** (intro): **Ancrage savant** — Qwen-Image-Edit architecture detailed in **Qwen-Image Technical Report** [QwenLM Aug 2025, arXiv:2508.02324]; base vision-langage Qwen2.5-VL [Wang 2025, arXiv:2502.13923].
- **Cell 0a694ae8** (Ressources):
  - Completed bare Qwen-VL reference with **arXiv:2308.12966** + precision (original VLM, distinct from Qwen-Image-Edit).
  - Added **References savantes (architecture du modele)**: Qwen-Image TR (2508.02324), Qwen2.5-VL (2502.13923), Qwen-VL (2308.12966).

## G.1 verification

- **Qwen-Image Technical Report** arXiv:**2508.02324** (QwenLM, Aug 2025) — confirmed, covers Qwen-Image-Edit.
- **Qwen2.5-VL** arXiv:**2502.13923** — confirmed.
- **Qwen-VL** arXiv:**2308.12966** (Bai et al. 2023) — confirmed (original VLM).

## Validation

- [x] nbformat OK
- [x] cell-ordering scanner: 1 clean, 0 finding
- [x] C.1 check (code source): 0
- [x] Catalogue byte-identical
- [x] Markdown-only -> H.3 not triggered (C.2 exception)
- [x] Anchors in markdown cells

See #3164 (partial: GenAI/Image 01-5 grain). Not closing the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)