### PR TITLE
fix(app-13): align TSP-Metaheuristics tabou interpretation + brute-force time to committed output (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
@@ -2209,7 +2209,7 @@
     "- `max_iter` : budget d'iterations total\n",
     "- `aspiration` : activer le critere de nouveau global best\n",
     "\n",
-    "La fonction `recherche_tabou` ci-dessous est implementee et comparee au recuit simule."
+    "La fonction `recherche_tabou` ci-dessous est **a implementer** (exercice), puis a comparer au recuit simule une fois completee."
    ]
   },
   {
@@ -2408,6 +2408,8 @@
    "source": [
     "### Interpretation : Recherche Tabou vs Recuit Simule\n",
     "\n",
+    "> **A valider (Exercice 4)** : la cellule precedente n'a pas encore produit de resultats (la fonction `recherche_tabou` est a implementer). Les points 2 et 3 ci-dessous sont une interpretation theorique des comportements attendus, a confronter a vos mesures une fois l'exercice complete.\n",
+    "\n",
     "**Observations** :\n",
     "\n",
     "1. **Monotonie du meilleur global** : La courbe du meilleur cout global est decroissante\n",
@@ -2504,7 +2506,7 @@
     "\n",
     "| Methode | Distance | Ratio | Temps |\n",
     "|---------|----------|-------|-------|\n",
-    "| Brute force | **277.23** | 1.00x | 0.006s |\n",
+    "| Brute force | **277.23** | 1.00x | 0.007s |\n",
     "| ACO | 473.68 | 1.71x | - |\n",
     "| Recuit simule | 480.57 | 1.73x | - |\n",
     "| 2-opt | 489.74 | 1.77x | - |\n",


### PR DESCRIPTION
Closes #3651
See #3164

Audit fidélité #3164 — App-13-TSP-Metaheuristics (Hybrid). 3 findings (2×A + 1×B).

## idx43 `634e2040` (Class A)
"recherche_tabou est implementee et comparee au recuit simule" but idx44 is a stub (idx46 output = "Exercice a completer : implementez recherche_tabou()."). Reframed → "a implementer (exercice), puis a comparer".

## idx47 `f3411921` (Class B)
Tabou-vs-SA interpretation narrated comparison results (points 2-3) above the stub. Prepended "A valider (Exercice 4)" caveat marking points 2-3 as theoretical; generic points 1/4/5 preserved.

## idx49 `4a40b74c` (Class A)
Brute-force time 0.006s → 0.007s (committed idx6 "Temps de calcul: 0.007s").

## Verification
- 4 ins / 2 del (net +2 = idx47 caveat), 0 structural churn.
- Byte-identical round-trip; 0 control chars; JSON valid.
- Catalogue + MGS submodule byte-identical (3-dot diff empty).
- Branch fresh from origin/main.
