### PR TITLE
docs(qcpy-12): anchor Jensen alpha + Grossman-Zhou drawdown citations (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -757,7 +757,10 @@
     "\n",
     "### 2.1 Calcul des Drawdowns (10 min)\n",
     "\n",
-    "Un **drawdown** represente la baisse depuis un pic de l'equity curve. C'est une mesure critique du risque."
+    "Un **drawdown** represente la baisse depuis un pic de l'equity curve. C'est une mesure critique du risque.\n",
+    "\n",
+    "> *Ancre savante -- Grossman, S. & Zhou, Z. (1993), « Optimal Investment Strategies for Controlling Drawdowns », Mathematical Finance 3(3), 241-276. Le drawdown comme mesure de risque formelle (et l'optimisation sous contrainte de drawdown maximal) y est etabli ; le Max Drawdown etudie dans cette Partie 2 en est l'avatar empirique le plus utilise.*\n",
+    ""
    ]
   },
   {
@@ -1472,7 +1475,10 @@
     "\n",
     "$$\\beta = \\frac{\\text{Cov}(R_s, R_b)}{\\text{Var}(R_b)}$$\n",
     "\n",
-    "$$\\alpha = R_s - (R_f + \\beta \\times (R_b - R_f))$$"
+    "$$\\alpha = R_s - (R_f + \\beta \\times (R_b - R_f))$$\n",
+    "\n",
+    "> *Ancre savante -- Jensen, M. C. (1968), « The Performance of Mutual Funds in the Period 1945-1964 », The Journal of Finance 23(2), 389-416. L'alpha ajuste au risque systematique (formule ci-dessus, `alpha = Rs - (Rf + beta*(Rb-Rf))`) porte son nom (« Jensen's alpha ») ; il decompose la surperformance en celle expliquee par le beta (CAPM) et le residu (habilite/alpha).*\n",
+    ""
    ]
   },
   {
@@ -2603,6 +2609,8 @@
     "- **Treynor, J. L. & Black, F.** (1973). *How to Use Security Analysis to Improve Portfolio Selection*. Journal of Business. Information Ratio (active return / tracking error).\n",
     "- **Efron, B.** (1979). *Bootstrap Methods: Another Look at the Jackknife*. Annals of Statistics. Resampling / Monte Carlo bootstrap pour la distribution des metriques.\n",
     "- **Lopez de Prado, M.** (2018). *Advances in Financial Machine Learning*. Wiley. Probabilistic Sharpe Ratio (PSR), erreurs d'inference sur ratios de performance.\n",
+    "- **Jensen, M. C.** (1968). *The Performance of Mutual Funds in the Period 1945-1964*. Journal of Finance 23(2), 389-416. Jensen's alpha (surperformance ajustee au risque systematique).\n",
+    "- **Grossman, S. & Zhou, Z.** (1993). *Optimal Investment Strategies for Controlling Drawdowns*. Mathematical Finance 3(3), 241-276. Drawdown comme mesure de risque, optimisation sous contrainte de drawdown maximal.\n",
     "\n",
     "### Ressources\n",
     "\n",


### PR DESCRIPTION
## Summary

**#3164 extended citation audit** on `QC-Py-12-Backtesting-Analysis.ipynb`. Ce notebook avait **DÉJÀ** une section « References academiques » solide (cell 83) avec 7 ancres (Sharpe 1966, Sortino & Price 1994, Young 1991 Calmar, Sharpe 1964 CAPM, Treynor & Black 1973 IR, Efron 1979 bootstrap, López de Prado 2018 PSR). Verdict = **OMISSION (mineure)** : 2 concepts fondamentaux enseignés dans des sections dédiées manquaient d'attribution.

See #3164.

### Changes (markdown-only, 1 file, +10/-2, 0 code cell touched)

| Cell | Concept | Ancre ajoutée |
|------|---------|---------------|
| 30 | Drawdown (Partie 2, « mesure critique du risque ») | Grossman & Zhou 1993 (Optimal Investment Strategies for Controlling Drawdowns, Mathematical Finance 3(3) 241-276) |
| 52 | Alpha (Partie 4, formule complète) | Jensen 1968 (The Performance of Mutual Funds in the Period 1945-1964, Journal of Finance 23(2) 389-416) |
| 83 | References | +2 entrées (Jensen 1968, Grossman & Zhou 1993) |

### Cadrage #3164

QC-Py = matériel original (Broad, *Hands-On AI Trading*), pas portage strict → verdict OMISSION, markdown additif. **Conservateur (G.5)** : 1 footnote à la 1ère occurrence (Partie 2 = 4 cells 30/32/34/39 mais annoter chacune serait spam). Skewness/kurtosis (pas d'originateur unique), Treynor ratio (pas taught-as-concept ici), VaR (code label only), win rate/profit factor (métriques génériques) correctement non flaggés.

**Observation notable (NON agie)** : PSR est dans les References (López de Prado 2018) mais **pas enseigné en prose** — l'inverse d'une omission. Laissé intact (retirer la référence = changement non-demandé, hors scope OMISSION).

## Validation

- **0 code cell touched** : 34 cellules code byte-identiques à `origin/main`.
- **Markdown-only** : 3 cellules annotées (30, 52, 83), 0 ajout/suppression (84 cells avant/après), séquence cell_type identique.
- **JSON valide**.
- **Outputs intacts** (C.2 exception markdown-only).
- **Citations web-checkées** (SSRN/performance-measurement/Sewell pour Jensen 1968 ; EconPapers/Wiley/RePEc pour Grossman & Zhou 1993). **Aucune fabrication** (G.1/G.3).
- Catalogue byte-identique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
