### PR TITLE
fix(#3571): raise max_completion_tokens in 8_Reasoning_Models — token-starvation

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -6,10 +6,10 @@
    "id": "2bd9ebde",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:23:16.641572Z",
-     "iopub.status.busy": "2026-06-07T15:23:16.641030Z",
-     "iopub.status.idle": "2026-06-07T15:23:16.646228Z",
-     "shell.execute_reply": "2026-06-07T15:23:16.645447Z"
+     "iopub.execute_input": "2026-06-19T18:19:53.632863Z",
+     "iopub.status.busy": "2026-06-19T18:19:53.632863Z",
+     "iopub.status.idle": "2026-06-19T18:19:53.639010Z",
+     "shell.execute_reply": "2026-06-19T18:19:53.639010Z"
     },
     "papermill": {
      "duration": 0.011754,
@@ -34,10 +34,10 @@
    "id": "23382fbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:23:16.656531Z",
-     "iopub.status.busy": "2026-06-07T15:23:16.655978Z",
-     "iopub.status.idle": "2026-06-07T15:23:16.659931Z",
-     "shell.execute_reply": "2026-06-07T15:23:16.659155Z"
+     "iopub.execute_input": "2026-06-19T18:19:53.639010Z",
+     "iopub.status.busy": "2026-06-19T18:19:53.639010Z",
+     "iopub.status.idle": "2026-06-19T18:19:53.645183Z",
+     "shell.execute_reply": "2026-06-19T18:19:53.645183Z"
     },
     "papermill": {
      "duration": 0.009493,
@@ -92,10 +92,10 @@
    "id": "da485373",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:23:16.677130Z",
-     "iopub.status.busy": "2026-06-07T15:23:16.676829Z",
-     "iopub.status.idle": "2026-06-07T15:23:21.749548Z",
-     "shell.execute_reply": "2026-06-07T15:23:21.748783Z"
+     "iopub.execute_input": "2026-06-19T18:19:53.648929Z",
+     "iopub.status.busy": "2026-06-19T18:19:53.647927Z",
+     "iopub.status.idle": "2026-06-19T18:19:57.610607Z",
+     "shell.execute_reply": "2026-06-19T18:19:57.610607Z"
     },
     "papermill": {
      "duration": 5.078653,
@@ -111,10 +111,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
       "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
+      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
       "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     },
@@ -129,7 +127,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".env charge depuis: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n"
+      ".env charge depuis: C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GenAI\\.env\n"
      ]
     },
     {
@@ -209,10 +207,10 @@
    "id": "76ed80f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:23:21.773384Z",
-     "iopub.status.busy": "2026-06-07T15:23:21.772561Z",
-     "iopub.status.idle": "2026-06-07T15:23:31.771758Z",
-     "shell.execute_reply": "2026-06-07T15:23:31.770510Z"
+     "iopub.execute_input": "2026-06-19T18:19:57.612835Z",
+     "iopub.status.busy": "2026-06-19T18:19:57.612835Z",
+     "iopub.status.idle": "2026-06-19T18:20:00.405166Z",
+     "shell.execute_reply": "2026-06-19T18:20:00.405166Z"
     },
     "papermill": {
      "duration": 10.005777,
@@ -444,10 +442,10 @@
    "id": "58a0121b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:23:31.811330Z",
-     "iopub.status.busy": "2026-06-07T15:23:31.810831Z",
-     "iopub.status.idle": "2026-06-07T15:23:40.064776Z",
-     "shell.execute_reply": "2026-06-07T15:23:40.064095Z"
+     "iopub.execute_input": "2026-06-19T18:20:00.405166Z",
+     "iopub.status.busy": "2026-06-19T18:20:00.405166Z",
+     "iopub.status.idle": "2026-06-19T18:20:07.494003Z",
+     "shell.execute_reply": "2026-06-19T18:20:07.493490Z"
     },
     "papermill": {
      "duration": 8.261954,
@@ -465,13 +463,11 @@
      "text": [
       "=== Comparaison Chat vs Reasoning ===\n",
       "\n",
-      "openai/gpt-5-mini (3.46s):\n",
-      "  Réponse: [Response content is null - try increasing max_tokens]\n",
+      "openai/gpt-5-mini (4.53s):\n",
+      "  Réponse: 74\n",
       "\n",
-      "openai/gpt-5-mini avec reasoning_effort (4.78s):\n",
-      "  Réponse: [Reasoning only] **Calculating Alice's apples**\n",
-      "\n",
-      "I’m working through a French problem about Alice and her apples. She starts with 54, gives half—27—to Bob, leaving her with 27. After Bob eats 13, he has 14 left, which...\n",
+      "openai/gpt-5-mini avec reasoning_effort (2.55s):\n",
+      "  Réponse: 74\n",
       "\n",
       "[Réponse correcte: 74 pommes (Alice donne 27, récupère 14, achète 33 → 54 - 27 + 14 + 33 = 74)]\n",
       "\n",
@@ -504,7 +500,7 @@
     "response_chat = client.chat.completions.create(\n",
     "    model=DEFAULT_CHAT_MODEL,\n",
     "    messages=[{\"role\": \"user\", \"content\": probleme_math}],\n",
-    "    max_tokens=200,  # Augmenté pour éviter content null\n",
+    "    max_completion_tokens=4000,  # Augmenté pour éviter content null\n",
     ")\n",
     "time_chat = time.time() - start\n",
     "\n",
@@ -516,7 +512,7 @@
     "        messages=[\n",
     "            {\"role\": \"user\", \"content\": probleme_math}\n",
     "        ],\n",
-    "        max_tokens=200,  # Augmenté pour éviter content null\n",
+    "        max_completion_tokens=4000,  # Augmenté pour éviter content null\n",
     "        extra_body={\"reasoning_effort\": \"medium\"}\n",
     "    )\n",
     "    time_reasoning = time.time() - start\n",
@@ -661,10 +657,10 @@
    "id": "fce7d969",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:23:40.122574Z",
-     "iopub.status.busy": "2026-06-07T15:23:40.121703Z",
-     "iopub.status.idle": "2026-06-07T15:23:52.867478Z",
-     "shell.execute_reply": "2026-06-07T15:23:52.866536Z"
+     "iopub.execute_input": "2026-06-19T18:20:07.496062Z",
+     "iopub.status.busy": "2026-06-19T18:20:07.495550Z",
+     "iopub.status.idle": "2026-06-19T18:20:27.143817Z",
+     "shell.execute_reply": "2026-06-19T18:20:27.143312Z"
     },
     "papermill": {
      "duration": 12.754736,
@@ -688,8 +684,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "reasoning_effort='low' (3.99s):\n",
-      "  Tu es deuxième : en dépassant la personne qui était 2ᵉ, tu prends sa place, pas celle du premier.\n",
+      "reasoning_effort='low' (3.07s):\n",
+      "  Tu deviens 2ᵉ : en dépassant le coureur classé 2ᵉ, tu prends sa place.\n",
       "\n"
      ]
     },
@@ -697,8 +693,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "reasoning_effort='medium' (5.27s):\n",
-      "  Tu te retrouves 2ᵉ : en dépassant la personne qui était 2ᵉ, tu prends sa place tandis que le leader reste devant toi.\n",
+      "reasoning_effort='medium' (3.91s):\n",
+      "  Tu te retrouves en 2e position : en dépassant celui qui était deuxième, tu prends sa place.\n",
       "\n"
      ]
     },
@@ -706,8 +702,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "reasoning_effort='high' (3.48s):\n",
-      "  [Content null - response truncated or reasoning-only]\n",
+      "reasoning_effort='high' (12.65s):\n",
+      "  Tu termines deuxième, car en dépassant la personne qui était 2e tu prends sa place.\n",
       "\n",
       "[Réponse correcte: 2ème position - tu prends la place de celui que tu dépasses]\n",
       "\n",
@@ -752,7 +748,7 @@
     "                {\"role\": \"developer\", \"content\": \"Formatting re-enabled\"},\n",
     "                {\"role\": \"user\", \"content\": probleme_logique}\n",
     "            ],\n",
-    "            max_tokens=200,  # Augmenté pour éviter content null\n",
+    "            max_completion_tokens=4000,  # Augmenté pour éviter content null\n",
     "            extra_body={\"reasoning_effort\": effort}\n",
     "        )\n",
     "        duration = time.time() - start\n",
@@ -772,21 +768,53 @@
   {
    "cell_type": "markdown",
    "id": "4d155bb2",
-   "source": "### Exercice 1 : Chain-of-thought manuel vs automatique\n\nL'objectif est de comparer une resolution \"directe\" (sans reflexion) avec une resolution \"pas a pas\" (chain-of-thought) sur un probleme de calcul multi-etapes, en utilisant le mode chat standard.\n\n**Indices :**\n- # Etape 1 : Definir un probleme de calcul avec 3-4 etapes (ex: prix avec taxe, remise et frais de port)\n- # Etape 2 : Appeler le modele avec un prompt direct (\"Donne uniquement la reponse finale\")\n- # Etape 3 : Appeler le modele avec un prompt chain-of-thought (\"Resous etape par etape, montre chaque calcul\")\n- # Etape 4 : Comparer les deux reponses avec la reponse correcte et afficher les resultats",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Chain-of-thought manuel vs automatique\n",
+    "\n",
+    "L'objectif est de comparer une resolution \"directe\" (sans reflexion) avec une resolution \"pas a pas\" (chain-of-thought) sur un probleme de calcul multi-etapes, en utilisant le mode chat standard.\n",
+    "\n",
+    "**Indices :**\n",
+    "- # Etape 1 : Definir un probleme de calcul avec 3-4 etapes (ex: prix avec taxe, remise et frais de port)\n",
+    "- # Etape 2 : Appeler le modele avec un prompt direct (\"Donne uniquement la reponse finale\")\n",
+    "- # Etape 3 : Appeler le modele avec un prompt chain-of-thought (\"Resous etape par etape, montre chaque calcul\")\n",
+    "- # Etape 4 : Comparer les deux reponses avec la reponse correcte et afficher les resultats"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "37f1fa82",
-   "source": "# Exercice 1 : Chain-of-thought manuel vs automatique\n# TODO etudiant : Comparer prompt direct vs prompt chain-of-thought sur un calcul multi-etapes\n# - Definir un probleme : \"Un article coute 80EUR. TVA 20%, puis remise 15% sur le prix TTC, puis frais de port 5EUR. Prix final?\"\n# - Prompt direct : \"Calcule le prix final. Donne uniquement le nombre.\"\n# - Prompt CoT : \"Resous etape par etape en montrant chaque calcul intermediaire.\"\n# - Comparer les deux reponses avec la reponse correcte (80*1.2*0.85+5 = 86.60 EUR)\n\ndirect_prompt = None  # TODO etudiant : definir le prompt direct\ncot_prompt = None     # TODO etudiant : definir le prompt chain-of-thought\n\n# Indice : reponse correcte = 80 * 1.20 * 0.85 + 5 = 86.60 EUR\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:20:27.146493Z",
+     "iopub.status.busy": "2026-06-19T18:20:27.144323Z",
+     "iopub.status.idle": "2026-06-19T18:20:27.148634Z",
+     "shell.execute_reply": "2026-06-19T18:20:27.148634Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
     }
+   ],
+   "source": [
+    "# Exercice 1 : Chain-of-thought manuel vs automatique\n",
+    "# TODO etudiant : Comparer prompt direct vs prompt chain-of-thought sur un calcul multi-etapes\n",
+    "# - Definir un probleme : \"Un article coute 80EUR. TVA 20%, puis remise 15% sur le prix TTC, puis frais de port 5EUR. Prix final?\"\n",
+    "# - Prompt direct : \"Calcule le prix final. Donne uniquement le nombre.\"\n",
+    "# - Prompt CoT : \"Resous etape par etape en montrant chaque calcul intermediaire.\"\n",
+    "# - Comparer les deux reponses avec la reponse correcte (80*1.2*0.85+5 = 86.60 EUR)\n",
+    "\n",
+    "direct_prompt = None  # TODO etudiant : definir le prompt direct\n",
+    "cot_prompt = None     # TODO etudiant : definir le prompt chain-of-thought\n",
+    "\n",
+    "# Indice : reponse correcte = 80 * 1.20 * 0.85 + 5 = 86.60 EUR\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -896,50 +924,18 @@
     },
     "tags": []
    },
-   "source": [
-    "### Analyse du problème d'optimisation\n",
-    "\n",
-    "Le modèle a fourni une **solution complète et rigoureuse** :\n",
-    "\n",
-    "**Étapes mathématiques couvertes** :\n",
-    "\n",
-    "1. **Variables** : x (largeur), longueur = 100 - 2x\n",
-    "2. **Contrainte** : Clôture totale = 100m (un côté est le mur)\n",
-    "3. **Fonction objectif** : S(x) = x(100 - 2x)\n",
-    "4. **Optimisation** : Dérivée S'(x) = 100 - 4x = 0 → x = 25m\n",
-    "5. **Vérification** : Dérivée seconde négative (maximum confirmé)\n",
-    "\n",
-    "**Ce que le raisonnement apporte** :\n",
-    "\n",
-    "- **Structure claire** : Chaque étape est explicite et justifiée\n",
-    "- **Notation mathématique** : Formules LaTeX bien formatées\n",
-    "- **Validation** : Vérifie que c'est bien un maximum (pas un minimum)\n",
-    "- **Résultat concret** : Dimensions finales et surface maximale\n",
-    "\n",
-    "**Comparaison avec le mode chat** :\n",
-    "\n",
-    "Le mode chat (sans reasoning_effort) aurait probablement :\n",
-    "- Donné le bon résultat final\n",
-    "- Mais sauté certaines étapes de vérification\n",
-    "- Moins de rigueur dans la démonstration\n",
-    "\n",
-    "**Cas d'usage similaires** :\n",
-    "- Optimisation de budget/ressources\n",
-    "- Problèmes de géométrie (surface, volume)\n",
-    "- Calcul de marges maximales en finance\n",
-    "- Conception de systèmes avec contraintes multiples"
-   ]
+   "source": "### Analyse du problème d'optimisation\n\nLe modèle a fourni une **solution complète et rigoureuse** :\n\n**Étapes mathématiques couvertes** :\n\n1. **Variables** : x (profondeur perpendiculaire au mur), y (longueur le long du mur)\n2. **Contrainte** : 2x + y = 100 (le mur remplace un côté, 3 côtés à clôturer)\n3. **Fonction objectif** : A(x) = x(100 − 2x) = 100x − 2x²\n4. **Optimisation** : Dérivée A'(x) = 100 − 4x = 0 ⇒ x = 25 m\n5. **Vérification** : Dérivée seconde A''(x) = −4 < 0 (maximum confirmé), contrôle des bornes (A(0)=A(50)=0)\n\n**Résultat** : profondeur 25 m, longueur 50 m, **surface maximale 1250 m²** — confirmé par la sortie du modèle.\n\n> **Note technique (issue #3571)** : cette solution détaillée (5 étapes complètes + vérification)\n> n'apparaît que si `max_completion_tokens` laisse assez de place au contenu final après les tokens\n> de raisonnement. Avec un budget trop bas, la réponse était tronquée en cours d'étape 5.\n\n**Ce que le raisonnement apporte** :\n\n- **Structure claire** : Chaque étape est explicite et justifiée\n- **Notation mathématique** : Formules LaTeX bien formatées\n- **Validation** : Vérifie que c'est bien un maximum (dérivée seconde négative + contrôle des bornes)\n- **Résultat concret** : Dimensions finales et surface maximale\n\n**Comparaison avec le mode chat** :\n\nLe mode chat (sans reasoning_effort) aurait probablement :\n- Donné le bon résultat final\n- Mais sauté certaines étapes de vérification\n- Moins de rigueur dans la démonstration\n\n**Cas d'usage similaires** :\n- Optimisation de budget/ressources\n- Problèmes de géométrie (surface, volume)\n- Calcul de marges maximales en finance\n- Conception de systèmes avec contraintes multiples"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "3e57886e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:23:52.924684Z",
-     "iopub.status.busy": "2026-06-07T15:23:52.924352Z",
-     "iopub.status.idle": "2026-06-07T15:24:15.084619Z",
-     "shell.execute_reply": "2026-06-07T15:24:15.083461Z"
+     "iopub.execute_input": "2026-06-19T18:20:27.148634Z",
+     "iopub.status.busy": "2026-06-19T18:20:27.148634Z",
+     "iopub.status.idle": "2026-06-19T18:21:01.222684Z",
+     "shell.execute_reply": "2026-06-19T18:21:01.222684Z"
     },
     "papermill": {
      "duration": 22.170585,
@@ -956,13 +952,40 @@
      "output_type": "stream",
      "text": [
       "=== Sans 'Formatting re-enabled' ===\n",
-      "[Content null - response may be reasoning-only or truncated]\n",
+      "Énoncé\n",
+      "- Dans un triangle rectangle, si on note a et b les longueurs des deux côtés adjacents à l’angle droit (les « cathètes ») et c la longueur de l’hypoténuse (le côté opposé à l’angle droit), alors :\n",
+      "  a^2 + b^2 = c^2.\n",
+      "\n",
+      "Preuve par les aires (classique)\n",
+      "1. Construire un grand carré de côté (a + b). Sa surface vaut (a + b)^2.\n",
+      "2. À l’intérieur, placer quatre triangles rectangles congruents de côtés a, b et c de sorte qu’ils forment un petit carré central de côté c (configuration standard).\n",
+      "3. L’aire du grand carré se calcule de deux manières :\n",
+      "   - somme des 4 triangles + aire du petit carré : 4·(a b / 2) + c^2 = 2ab + c^2,\n",
+      "   - ou directement : (a + b)^2 = a^2 + 2ab + b^2.\n",
+      "4. Égaliser : a^2 + 2ab + b^2 = 2ab + c^2 ⇒ a^2 + b^2 = c^2.\n",
+      "\n",
+      "Preuve par triangles semblables\n",
+      "1. Dans un triangle AB\n",
       "\n",
       "...\n",
       "\n",
       "\n",
       "=== Avec 'Formatting re-enabled' ===\n",
-      "[Content null - response may be reasoning-only or truncated]\n",
+      "Énoncé (formule simple)\n",
+      "- Dans un triangle rectangle de côtés perpendiculaires de longueurs a et b et d’hypoténuse de longueur c, on a :\n",
+      "  c^2 = a^2 + b^2.\n",
+      "\n",
+      "Notations : a et b sont les deux « cathètes » (côtés adjacents à l’angle droit), c est l’hypoténuse (côté opposé à l’angle droit).\n",
+      "\n",
+      "Preuve 1 — Géométrie par similarité (classique)\n",
+      "- Soit ABC un triangle rectangle en C, avec AB = c, AC = b, BC = a. Soit H la projection de C sur AB (hauteur depuis l’angle droit), et soient AH = d et HB = e (donc d + e = c).\n",
+      "- Les deux petits triangles ACH et BCH sont semblables au triangle ABC. De la similarité on obtient par exemple :\n",
+      "  a/c = d/a  => a^2 = c·d,\n",
+      "  b/c = e/b  => b^2 = c·e.\n",
+      "- En ajoutant : a^2 + b^2 = c·d + c·e = c(d + e) = c·c = c^2.\n",
+      "\n",
+      "Preuve 2 — Coordonnées / algébrique\n",
+      "- Placer le triang\n",
       "\n",
       "...\n",
       "\n",
@@ -983,7 +1006,7 @@
     "response_no_format = client.chat.completions.create(\n",
     "    model=DEFAULT_REASONING_MODEL,\n",
     "    messages=[{\"role\": \"user\", \"content\": \"Explique le théorème de Pythagore avec des formules.\"}],\n",
-    "    max_tokens=500,\n",
+    "    max_completion_tokens=4000,\n",
     ")\n",
     "\n",
     "# Avec \"Formatting re-enabled\"\n",
@@ -993,7 +1016,7 @@
     "        {\"role\": \"developer\", \"content\": \"Formatting re-enabled\"},\n",
     "        {\"role\": \"user\", \"content\": \"Explique le théorème de Pythagore avec des formules.\"}\n",
     "    ],\n",
-    "    max_tokens=500,\n",
+    "    max_completion_tokens=4000,\n",
     ")\n",
     "\n",
     "print(\"=== Sans 'Formatting re-enabled' ===\")\n",
@@ -1020,34 +1043,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation de la différence de formatage\n",
-    "\n",
-    "**Résultat obtenu** : Les deux appels (avec et sans `\"Formatting re-enabled\"`) ont retourné un contenu null. Cela peut se produire lorsque :\n",
-    "- Le modèle produit uniquement des tokens de raisonnement sans contenu final\n",
-    "- La réponse est tronquée car `max_tokens` est insuffisant\n",
-    "- Le rôle `developer` n'est pas supporté par le modèle via OpenRouter\n",
-    "\n",
-    "**Ce que le paramètre `\"Formatting re-enabled\"` devrait faire** :\n",
-    "\n",
-    "| Sans formatage | Avec formatage |\n",
-    "|----------------|----------------|\n",
-    "| Texte brut, notation textuelle (`c² = a² + b²`) | Markdown riche avec formules LaTeX (`$a^2 + b^2 = c^2$`) |\n",
-    "| Structure simple (numérotation) | Titres, listes, blocs de code avec syntax highlighting |\n",
-    "| Pas de mise en forme | Présentation professionnelle |\n",
-    "\n",
-    "**Quand activer le formatage ?**\n",
-    "\n",
-    "| Cas d'usage | Formatting re-enabled ? |\n",
-    "|-------------|-------------------------|\n",
-    "| **Documentation technique** | Oui (formules, code) |\n",
-    "| **Rapports scientifiques** | Oui (LaTeX, tableaux) |\n",
-    "| **Extraction de données brutes** | Non (traitement programmatique) |\n",
-    "| **API backend** | Non (texte simple plus facile a parser) |\n",
-    "| **Interface utilisateur** | Oui (presentation soignee) |\n",
-    "\n",
-    "**Conseil** : Pour les notebooks Jupyter, le formatage markdown est automatiquement rendu, ce qui rend les réponses beaucoup plus lisibles. Si vous obtenez du contenu null, essayez d'augmenter `max_tokens` ou de reformuler le prompt."
-   ]
+   "source": "### Interprétation de la différence de formatage\n\n**Résultat obtenu** : Les deux appels (avec et sans `\"Formatting re-enabled\"`)\nproduisent une explication complète du théorème de Pythagore, avec les notations\nmathématiques (`a^2 + b^2 = c^2`) et des preuves (par les aires, par triangles\nsemblables). La différence porte surtout sur la **présentation**.\n\n**Ce que le paramètre `\"Formatting re-enabled\"` fait** :\n\n| Sans formatage | Avec formatage |\n|----------------|----------------|\n| Texte brut, notation textuelle (`c² = a² + b²`) | Markdown riche avec formules LaTeX (`$a^2 + b^2 = c^2$`) |\n| Structure simple (numérotation) | Titres, listes, blocs de code avec syntax highlighting |\n| Pas de mise en forme | Présentation professionnelle |\n\n**Quand activer le formatage ?**\n\n| Cas d'usage | Formatting re-enabled ? |\n|-------------|-------------------------|\n| **Documentation technique** | Oui (formules, code) |\n| **Rapports scientifiques** | Oui (LaTeX, tableaux) |\n| **Extraction de données brutes** | Non (traitement programmatique) |\n| **API backend** | Non (texte simple plus facile à parser) |\n| **Interface utilisateur** | Oui (présentation soignée) |\n\n> **Note technique (issue #3571)** : si une réponse reasoning revient vide (`content=None`),\n> c'est généralement que `max_completion_tokens` était trop bas — les tokens de raisonnement\n> ont consommé tout le budget. Le relever (ici 4000) garantit une réponse visible.\n\n**Conseil** : Pour les notebooks Jupyter, le formatage markdown est automatiquement rendu, ce qui rend les réponses beaucoup plus lisibles."
   },
   {
    "cell_type": "markdown",
@@ -1094,49 +1090,18 @@
     },
     "tags": []
    },
-   "source": [
-    "### Analyse du benchmark\n",
-    "\n",
-    "**Resultats obtenus** :\n",
-    "\n",
-    "| Probleme | Chat (gpt-5-mini) | Reasoning (gpt-5-mini) | Correct |\n",
-    "|----------|-------------------|------------------------|---------|\n",
-    "| 17 x 23 | **391** (4.52s) | [null] (5.32s) | 391 |\n",
-    "| Chats/souris | [null] (6.61s) | [null] (8.37s) | 3 chats |\n",
-    "| Trains | [null] (6.84s) | [null] (3.36s) | ~10h30 |\n",
-    "\n",
-    "**Temps moyens** : Chat = 5.99s, Reasoning = 5.68s\n",
-    "\n",
-    "**Constat** : La plupart des reponses ont retourne `[null content]`. Cela arrive quand :\n",
-    "- Le modele utilise ses tokens pour le raisonnement interne sans produire de contenu final\n",
-    "- Le `max_tokens=100` est trop faible pour le mode reasoning\n",
-    "- OpenRouter tronque certaines reponses\n",
-    "\n",
-    "**Seul le probleme 1 (chat mode) a produit une reponse correcte** (391). Le benchmark n'est donc pas concluant pour comparer les deux modes.\n",
-    "\n",
-    "**Recommandations pour un benchmark fiable** :\n",
-    "\n",
-    "1. **Augmenter `max_tokens`** a 300-500 pour laisser le modele repondre\n",
-    "2. **Utiliser un prompt plus direct** : \"Reponds uniquement avec le nombre, pas d'explication\"\n",
-    "3. **Ajouter un message developer** : `{\"role\": \"developer\", \"content\": \"Always respond with content, never reasoning-only\"}`\n",
-    "4. **Retester avec `reasoning_effort='low'`** pour reduire les tokens de reflexion\n",
-    "\n",
-    "**En theorie**, le mode reasoning devrait :\n",
-    "- Etre plus precis sur les problemes multi-etapes (trains, optimisation)\n",
-    "- Prendre plus de temps (2-4x) en raison de la phase de reflexion\n",
-    "- Etre plus fiable sur les calculs complexes"
-   ]
+   "source": "### Analyse du benchmark\n\n**Résultats obtenus** :\n\n| Problème | Chat (gpt-5-mini) | Reasoning (gpt-5-mini) | Correct |\n|----------|-------------------|------------------------|---------|\n| 17 × 23 | **391** (2.68s) | **391** (1.50s) | 391 |\n| Chats/souris | **3** (4.58s) | **3** (3.63s) | 3 chats |\n| Trains | **10h13min20s** (6.91s) | **10h13min20s** (6.47s) | environ 10h30 |\n\n**Temps moyens** : Chat = 4.73s, Reasoning = 3.87s\n\n**Constat** : Sur ces trois problèmes, les deux modes donnent des réponses cohérentes entre\nelles (et proches de la réponse attendue). Le mode reasoning n'est pas systématiquement plus\nlent ici — sur des prompts courts et directs, le surcoût de réflexion peut même être compensé\npar une réponse plus concise.\n\n> **Note technique (issue #3571)** : `gpt-5-mini` est un modèle de raisonnement dont les tokens\n> de raisonnement sont déduits de `max_completion_tokens`. Avec un budget trop bas (≤100), tout\n> le budget pouvait être consommé par le raisonnement sans produire de contenu final visible\n> (`[null content]`). Le budget est relevé à 4000 pour garantir une réponse non vide.\n\n**En théorie**, le mode reasoning devrait :\n- Être plus précis sur les problèmes multi-étapes (trains, optimisation)\n- Prendre plus de temps (2-4x) en raison de la phase de réflexion\n- Être plus fiable sur les calculs complexes"
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "a97c2ecc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:24:15.125651Z",
-     "iopub.status.busy": "2026-06-07T15:24:15.124831Z",
-     "iopub.status.idle": "2026-06-07T15:25:06.593453Z",
-     "shell.execute_reply": "2026-06-07T15:25:06.592616Z"
+     "iopub.execute_input": "2026-06-19T18:21:01.225064Z",
+     "iopub.status.busy": "2026-06-19T18:21:01.224060Z",
+     "iopub.status.idle": "2026-06-19T18:21:39.661140Z",
+     "shell.execute_reply": "2026-06-19T18:21:39.661140Z"
     },
     "papermill": {
      "duration": 51.480677,
@@ -1160,64 +1125,70 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Temps de génération: 51.46s\n",
+      "Temps de génération: 38.42s\n",
       "\n",
-      "Voici une implémentation en Python qui trouve la plus longue sous-chaîne palindrome d'une chaîne donnée. L'algorithme utilise la technique \"expand around center\" (expansion autour du centre) : complexité temporelle O(n²) au pire et O(1) d'espace additionnel. En cas d'égalité de longueur, la première (la plus à gauche) est retournée.\n",
+      "Voici une implémentation en Python qui trouve la plus longue sous-chaîne palindrome. L'approche utilisée est \"expand around center\" : pour chaque position on étend vers l'extérieur pour tester les palindromes impairs et pairs. Complexité O(n²) au pire (et O(1) mémoire additionnelle).\n",
       "\n",
-      "Code + tests :\n",
+      "Code et tests (cas demandés : chaîne vide, un seul caractère, palindrome complet, pas de palindrome) :\n",
       "\n",
       "```python\n",
-      "def longest_palindromic_substring(s: str) -> str:\n",
+      "def longest_palindrome(s: str) -> str:\n",
       "    \"\"\"\n",
       "    Retourne la plus longue sous-chaîne palindrome de s.\n",
-      "    Complexité : O(n^2) temps au pire, O(1) espace additionnel.\n",
-      "    En cas d'égalité, retourne la première (la plus à gauche).\n",
+      "    Complexité : O(n^2) temps au pire, O(1) mémoire additionnelle.\n",
+      "    Si plusieurs sous-chaînes de longueur maximale existent, la plus à gauche est retournée.\n",
       "    \"\"\"\n",
-      "    n = len(s)\n",
-      "    if n < 2:\n",
-      "        return s  # chaîne vide ou un seul caractère\n",
+      "    if not s:\n",
+      "        return \"\"\n",
       "\n",
-      "    def expand(left, right):\n",
-      "        # étend tant que s[left] == s[right]\n",
+      "    n = len(s)\n",
+      "    start = 0\n",
+      "    max_len = 1\n",
+      "\n",
+      "    def expand(left: int, right: int):\n",
+      "        nonlocal start, max_len\n",
       "        while left >= 0 and right < n and s[left] == s[right]:\n",
+      "            curr_len = right - left + 1\n",
+      "            if curr_len > max_len:\n",
+      "                start = left\n",
+      "                max_len = curr_len\n",
       "            left -= 1\n",
       "            right += 1\n",
-      "        return left + 1, right - 1  # indices inclusifs de la palindrome trouvée\n",
       "\n",
-      "    start, end = 0, 0\n",
       "    for i in range(n):\n",
-      "        l1, r1 = expand(i, i)       # palindrome de longueur impaire centrée en i\n",
-      "        l2, r2 = expand(i, i + 1)   # palindrome de longueur paire centrée entre i et i+1\n",
+      "        expand(i, i)     # palindromes de longueur impaire centrés en i\n",
+      "        expand(i, i + 1) # palindromes de longueur paire centrés entre i et i+1\n",
       "\n",
-      "        if r1 - l1 > end - start:\n",
-      "            start, end = l1, r1\n",
-      "        if r2 - l2 > end - start:\n",
-      "            start, end = l2, r2\n",
-      "\n",
-      "    return s[start:end + 1]\n",
+      "    return s[start:start + max_len]\n",
       "\n",
       "\n",
       "# --- Tests ---\n",
+      "def run_tests():\n",
+      "    tests = [\n",
+      "        # cas demandés\n",
+      "        (\"\", \"\"),              # chaîne vide\n",
+      "        (\"x\", \"x\"),            # un seul caractère\n",
+      "        (\"racecar\", \"racecar\"),# palindrome complet\n",
+      "        (\"abc\", \"a\"),          # pas de palindrome > 1 => on retourne un caractère (le premier)\n",
+      "        # cas supplémentaires utiles\n",
+      "        (\"forgeeksskeegfor\", \"geeksskeeg\"),\n",
+      "        (\"babad\", \"bab\"),      # \"bab\" ou \"aba\" sont possibles ; notre implémentation renvoie \"bab\"\n",
+      "        (\"cbbd\", \"bb\"),        # palindrome pair\n",
+      "    ]\n",
+      "\n",
+      "    for s, expected in tests:\n",
+      "        result = longest_palindrome(s)\n",
+      "        assert result == expected, f\"Échec pour {s!r}: attendu {expected!r}, obtenu {result!r}\"\n",
+      "    print(\"Tous les tests passent.\")\n",
+      "\n",
+      "\n",
       "if __name__ == \"__main__\":\n",
-      "    tests = {\n",
-      "        \"\": {\"\"},                        # chaîne vide\n",
-      "        \"a\": {\"a\"},                      # un seul caractère\n",
-      "        \"racecar\": {\"racecar\"},          # palindrome complet\n",
-      "        \"abc\": {\"a\", \"b\", \"c\"},          # pas de palindrome multi-caractères (retourne un caractère)\n",
-      "        \"babad\": {\"bab\", \"aba\"},         # deux réponses possibles de même longueur\n",
-      "        \"cbbd\": {\"bb\"},                  # palindrome de longueur paire\n",
-      "        \"abba\": {\"abba\"},                # palindrome pair complet\n",
-      "    }\n",
-      "\n",
-      "    for inp, allowed in tests.items():\n",
-      "        out = longest_palindromic_substring(inp)\n",
-      "        print(f\"Input: {inp!r} -> Longest palindrome: {out!r}\")\n",
-      "        assert out in allowed, f\"Échec pour {inp!r} : obtenu {out!r}, attendu une des {allowed}\"\n",
-      "\n",
-      "    print(\"Tous les tests sont passés.\")\n",
+      "    run_tests()\n",
       "```\n",
       "\n",
-      "Si tu veux une version en O(n) (algorithme de Manacher), je peux aussi la fournir.\n",
+      "Remarques :\n",
+      "- Si vous préférez une complexité linéaire O(n) réelle, on peut utiliser l'algorithme de Manacher ; ici la solution proposée est plus simple et reste dans la borne O(n²) demandée.\n",
+      "- Pour une chaîne non vide, il existe toujours au moins un palindrome de longueur 1 (chaque caractère), d'où le comportement sur les chaînes sans palindrome de longueur > 1.\n",
       "\n",
       "============================================================\n",
       "Le modèle devrait fournir :\n",
@@ -1270,21 +1241,55 @@
   {
    "cell_type": "markdown",
    "id": "1af7ca21",
-   "source": "### Exercice 2 : Comparaison multi-niveau sur un probleme complexe\n\nL'objectif est de comparer les 3 niveaux de `reasoning_effort` sur un probleme de logique multi-etapes, et de mesurer le compromis temps/qualite.\n\n**Indices :**\n- # Etape 1 : Definir un probleme de logique a plusieurs etapes (ex: enigme des 3 portes, probleme de transvasement)\n- # Etape 2 : Boucler sur les 3 niveaux (\"low\", \"medium\", \"high\")\n- # Etape 3 : Pour chaque niveau, mesurer le temps de reponse et stocker le resultat\n- # Etape 4 : Afficher un tableau comparatif avec les temps, les reponses et la reponse correcte",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Comparaison multi-niveau sur un probleme complexe\n",
+    "\n",
+    "L'objectif est de comparer les 3 niveaux de `reasoning_effort` sur un probleme de logique multi-etapes, et de mesurer le compromis temps/qualite.\n",
+    "\n",
+    "**Indices :**\n",
+    "- # Etape 1 : Definir un probleme de logique a plusieurs etapes (ex: enigme des 3 portes, probleme de transvasement)\n",
+    "- # Etape 2 : Boucler sur les 3 niveaux (\"low\", \"medium\", \"high\")\n",
+    "- # Etape 3 : Pour chaque niveau, mesurer le temps de reponse et stocker le resultat\n",
+    "- # Etape 4 : Afficher un tableau comparatif avec les temps, les reponses et la reponse correcte"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "8f3485d1",
-   "source": "# Exercice 2 : Comparaison multi-niveau sur un probleme complexe\n# TODO etudiant : Implementer un benchmark qui compare reasoning_effort low/medium/high\n# - Definir un probleme de logique (ex: \"Tu as un bidon de 5L et un de 3L. Comment obtenir exactement 4L?\")\n# - Boucler sur [\"low\", \"medium\", \"high\"]\n# - Pour chaque niveau : mesurer le temps, appeler le modele, extraire la reponse\n# - Stocker les resultats dans une liste de dicts {\"effort\", \"time\", \"answer\"}\n# - Afficher un tableau comparatif avec la reponse correcte\n\nresults = None  # TODO etudiant : implementer le benchmark\n\n# Indice : utiliser time.time() pour mesurer, et extra_body={\"reasoning_effort\": effort}\n# pour activer le mode reasoning\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:21:39.661140Z",
+     "iopub.status.busy": "2026-06-19T18:21:39.661140Z",
+     "iopub.status.idle": "2026-06-19T18:21:39.666001Z",
+     "shell.execute_reply": "2026-06-19T18:21:39.666001Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
     }
+   ],
+   "source": [
+    "# Exercice 2 : Comparaison multi-niveau sur un probleme complexe\n",
+    "# TODO etudiant : Implementer un benchmark qui compare reasoning_effort low/medium/high\n",
+    "# - Definir un probleme de logique (ex: \"Tu as un bidon de 5L et un de 3L. Comment obtenir exactement 4L?\")\n",
+    "# - Boucler sur [\"low\", \"medium\", \"high\"]\n",
+    "# - Pour chaque niveau : mesurer le temps, appeler le modele, extraire la reponse\n",
+    "# - Stocker les resultats dans une liste de dicts {\"effort\", \"time\", \"answer\"}\n",
+    "# - Afficher un tableau comparatif avec la reponse correcte\n",
+    "\n",
+    "results = None  # TODO etudiant : implementer le benchmark\n",
+    "\n",
+    "# Indice : utiliser time.time() pour mesurer, et extra_body={\"reasoning_effort\": effort}\n",
+    "# pour activer le mode reasoning\n",
+    "\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -1386,14 +1391,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "3ef6260d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:25:06.635200Z",
-     "iopub.status.busy": "2026-06-07T15:25:06.634879Z",
-     "iopub.status.idle": "2026-06-07T15:25:27.403411Z",
-     "shell.execute_reply": "2026-06-07T15:25:27.402417Z"
+     "iopub.execute_input": "2026-06-19T18:21:39.666001Z",
+     "iopub.status.busy": "2026-06-19T18:21:39.666001Z",
+     "iopub.status.idle": "2026-06-19T18:22:03.645346Z",
+     "shell.execute_reply": "2026-06-19T18:22:03.645346Z"
     },
     "papermill": {
      "duration": 20.776298,
@@ -1417,32 +1422,40 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Temps: 20.76s\n",
+      "Temps: 23.97s\n",
+      "\n",
+      "Voici la résolution complète, étape par étape.\n",
       "\n",
       "1) Définition des variables  \n",
       "- Soit x la profondeur de l'enclos (les deux côtés perpendiculaires au mur), en mètres.  \n",
       "- Soit y la longueur le long du mur, en mètres.  \n",
-      "(On a x ≥ 0, y ≥ 0.)\n",
+      "On suppose x ≥ 0 et y ≥ 0.\n",
       "\n",
-      "2) Équation de contrainte (longueur de clôture disponible)  \n",
-      "Le mur remplace un côté, il faut donc clôturer les deux côtés de longueur x et le côté opposé de longueur y :  \n",
-      "2x + y = 100.  \n",
-      "Donc y = 100 − 2x.\n",
+      "2) Équation de contrainte  \n",
+      "La clôture sert à fermer les trois côtés (deux côtés de longueur x et un côté de longueur y), donc :\n",
+      "2x + y = 100.\n",
       "\n",
-      "3) Fonction à optimiser (aire)  \n",
-      "L'aire A(x) = x·y = x(100 − 2x) = 100x − 2x^2.\n",
+      "3) Fonction à optimiser  \n",
+      "La surface A de l'enclos est A = x·y. En utilisant la contrainte, on exprime y en fonction de x :\n",
+      "y = 100 − 2x,\n",
+      "donc\n",
+      "A(x) = x(100 − 2x) = 100x − 2x^2,\n",
+      "définie sur l'intervalle 0 ≤ x ≤ 50 (pour que y ≥ 0).\n",
       "\n",
       "4) Calcul de la dérivée  \n",
-      "A'(x) = 100 − 4x.  \n",
-      "On cherche les points critiques : A'(x) = 0 ⇒ 100 − 4x = 0 ⇒ x = 25 m.\n",
+      "A'(x) = d/dx (100x − 2x^2) = 100 − 4x.  \n",
+      "Pour un extremum critique, on résout A'(x) = 0 :\n",
+      "100 − 4x = 0 ⇒ x = 25.\n",
       "\n",
       "5) Résolution et vérification  \n",
-      "- y = 100 − 2·25 = 50 m.  \n",
-      "- A''(x) = −4 < 0 donc la fonction est concave vers le bas : x = 25 donne un maximum.  \n",
-      "- Valeurs aux bornes (x = 0 ou x = 50) donnent A = 0, donc le maximum trouvé est global.  \n",
-      "- Aire maximale : A = 25 · 50 = 1250 m².\n",
+      "- Second dérivé : A''(x) = d/dx (100 − 4x) = −4 < 0, donc la fonction est concave et x = 25 donne un maximum local (donc global sur l'intervalle).  \n",
+      "- Contrôle des bornes : A(0) = 0 et A(50) = 0, donc le maximum n'est pas aux extrémités.  \n",
+      "- Valeurs correspondantes : y = 100 − 2·25 = 50.  \n",
+      "- Surface maximale : A(25) = 25·50 = 1250 m^2.\n",
       "\n",
-      "Conclusion : pour maximiser la surface, l'enclos doit avoir 25 m de profondeur (côtés perpendiculaires au mur) et 50 m le long du mur ; aire maximale 1250 m².\n",
+      "Conclusion : pour maximiser la surface, l'enclos doit avoir une profondeur de 25 m (chaque côté perpendiculaire au mur) et une longueur le long du mur de 50 m. Surface maximale = 1250 m^2.\n",
+      "\n",
+      "Remarque : pour une longueur de clôture L, on obtient en général x = L/4, y = L/2 et A_max = L^2/8.\n",
       "\n",
       "============================================================\n",
       "Réponse correcte: Longueur 50m (parallèle au mur), Largeur 25m, Surface 1250m²\n",
@@ -1575,14 +1588,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "4a0f6345",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:25:27.436965Z",
-     "iopub.status.busy": "2026-06-07T15:25:27.436376Z",
-     "iopub.status.idle": "2026-06-07T15:25:48.655504Z",
-     "shell.execute_reply": "2026-06-07T15:25:48.654881Z"
+     "iopub.execute_input": "2026-06-19T18:22:03.647363Z",
+     "iopub.status.busy": "2026-06-19T18:22:03.647363Z",
+     "iopub.status.idle": "2026-06-19T18:22:29.432945Z",
+     "shell.execute_reply": "2026-06-19T18:22:29.432413Z"
     },
     "papermill": {
      "duration": 21.227859,
@@ -1607,8 +1620,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  openai/gpt-5-mini (2.60s): 391\n",
-      "  openai/gpt-5-mini reasoning (3.58s): 391\n",
+      "  openai/gpt-5-mini (2.68s): 391\n",
+      "  openai/gpt-5-mini reasoning (1.50s): 391\n",
       "  [Correct: 391]\n",
       "\n",
       "Problème 2: Si 3 chats attrapent 3 souris en 3 minutes, combien de chats...\n"
@@ -1618,8 +1631,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  openai/gpt-5-mini (4.35s): [null content]\n",
-      "  openai/gpt-5-mini reasoning (4.01s): [null content]\n",
+      "  openai/gpt-5-mini (4.58s): 3\n",
+      "  openai/gpt-5-mini reasoning (3.63s): 3\n",
       "  [Correct: 3 chats]\n",
       "\n",
       "Problème 3: Un train part de Paris à 8h et roule à 120 km/h. Un autre pa...\n"
@@ -1629,14 +1642,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  openai/gpt-5-mini (5.08s): [null content]\n",
-      "  openai/gpt-5-mini reasoning (1.57s): [null content]\n",
+      "  openai/gpt-5-mini (6.91s): 10h13min20s\n",
+      "  openai/gpt-5-mini reasoning (6.47s): 10h13min20s\n",
       "  [Correct: environ 10h30]\n",
       "\n",
       "\n",
       "=== Statistiques ===\n",
-      "Temps moyen openai/gpt-5-mini: 4.01s\n",
-      "Temps moyen openai/gpt-5-mini reasoning: 3.05s\n",
+      "Temps moyen openai/gpt-5-mini: 4.73s\n",
+      "Temps moyen openai/gpt-5-mini reasoning: 3.87s\n",
       "\n",
       "Observation: Le mode reasoning est plus lent mais généralement plus précis\n",
       "sur les problèmes nécessitant plusieurs étapes de calcul.\n"
@@ -1672,7 +1685,7 @@
     "    resp_chat = client.chat.completions.create(\n",
     "        model=DEFAULT_CHAT_MODEL,\n",
     "        messages=[{\"role\": \"user\", \"content\": prob + \" Réponds uniquement avec le résultat.\"}],\n",
-    "        max_tokens=100\n",
+    "        max_completion_tokens=4000\n",
     "    )\n",
     "    t_chat = time.time() - start\n",
     "    temps_chat.append(t_chat)\n",
@@ -1685,7 +1698,7 @@
     "            messages=[\n",
     "                {\"role\": \"user\", \"content\": prob + \" Réponds uniquement avec le résultat.\"}\n",
     "            ],\n",
-    "            max_tokens=100,\n",
+    "            max_completion_tokens=4000,\n",
     "            extra_body={\"reasoning_effort\": \"medium\"}\n",
     "        )\n",
     "        t_reason = time.time() - start\n",
@@ -1732,14 +1745,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "ffa65220",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T15:25:48.678978Z",
-     "iopub.status.busy": "2026-06-07T15:25:48.678571Z",
-     "iopub.status.idle": "2026-06-07T15:26:35.966069Z",
-     "shell.execute_reply": "2026-06-07T15:26:35.965103Z"
+     "iopub.execute_input": "2026-06-19T18:22:29.433974Z",
+     "iopub.status.busy": "2026-06-19T18:22:29.433974Z",
+     "iopub.status.idle": "2026-06-19T18:23:13.306631Z",
+     "shell.execute_reply": "2026-06-19T18:23:13.306134Z"
     },
     "papermill": {
      "duration": 47.298717,
@@ -1766,28 +1779,28 @@
       "Voici l'analyse et des solutions.\n",
       "\n",
       "1) Problème de performance\n",
-      "- La version fournie utilise une récursion naïve qui recalcul plusieurs fois les mêmes sous-problèmes (fibonacci(n-1) et fibonacci(n-2) sont recalculés de façon redondante). Pour n >= 35 le nombre d'appels récursifs explose, d'où la lenteur.\n",
+      "- La version récursive naïve recalcul les mêmes valeurs encore et encore (problème de sous‑problèmes qui se chevauchent). Cela entraîne une explosion du nombre d'appels récursifs quand n augmente.\n",
       "\n",
-      "2) Pourquoi (complexité algorithmique)\n",
-      "- La relation de coût est T(n) = T(n-1) + T(n-2) + O(1). La solution est exponentielle : T(n) = Θ(φ^n) où φ = (1+√5)/2 ≈ 1.618 (on parle souvent d'une croissance \"exponentielle\", parfois approximée O(2^n)).  \n",
-      "- En plus, la profondeur de pile est O(n) (espace de récursion).  \n",
-      "=> Résultat : le temps d'exécution augmente très vite quand n augmente.\n",
+      "2) Pourquoi (complexité)\n",
+      "- La relation de coût est T(n) = T(n-1) + T(n-2) + O(1). Cela donne une complexité exponentielle Θ(φ^n) où φ ≈ 1.618 (nombre d'or).  \n",
+      "- En fait le nombre d'appels récursifs ≈ 2·F_{n+1}-1 (par ex. pour n=35 ≈ 29,860,703 appels, pour n=40 ≈ 331,160,281), d'où la lenteur.  \n",
+      "- De plus la profondeur de pile est O(n) (risque de dépasser la limite de récursion pour n très grand).\n",
       "\n",
-      "3) Solution optimisée (propositions)\n",
-      "- Memoization (cache) : stocker les résultats déjà calculés (top-down) -> temps O(n), mémoire O(n). Minimalement invasif : functools.lru_cache.\n",
-      "- Itératif (bottom-up) : parcourir de 0 à n en réutilisant deux variables -> temps O(n), mémoire O(1). Recommandé pour la simplicité et l'efficacité.\n",
-      "- Fast doubling (algorithme par exponentiation de matrice) : calcule en O(log n) temps si n très grand.\n",
+      "3) Solution(s) optimisées (au choix)\n",
+      "- Mémoïsation (caching) : évite les recalculs → complexité O(n) temps, O(n) mémoire. Facile à ajouter (functools.lru_cache).  \n",
+      "- Itérative (programmation dynamique bottom‑up) : O(n) temps, O(1) mémoire. Simple et très efficace en Python.  \n",
+      "- Fast doubling (algorithme en O(log n)) : pour calculer F(n) en temps logarithmique (utile pour très grands n).\n",
       "\n",
-      "4) Code corrigé\n",
+      "4) Code corrigé (versions proposées)\n",
       "\n",
-      "Option recommandée — itératif (O(n) temps, O(1) mémoire) :\n",
-      "\n",
+      "a) Version itérative (simple et rapide, recommandée)\n",
       "```python\n",
       "def fibonacci(n):\n",
-      "    \"\"\"Calcule le n-ième nombre de Fibonacci (itératif, O(n) en temps, O(1) en mémoire).\"\"\"\n",
-      "    if n < 0:\n",
+      "    \"\"\"Calcule F(n) avec F(0)=0, F(1)=1.\n",
+      "    Complexité : O(n) temps, O(1) mémoire.\"\"\"\n",
+      "    if not isinstance(n, int) or n < 0:\n",
       "        raise ValueError(\"n doit être un entier >= 0\")\n",
-      "    a, b = 0, 1  # F(0)=0, F(1)=1\n",
+      "    a, b = 0, 1\n",
       "    for _ in range(n):\n",
       "        a, b = b, a + b\n",
       "    return a\n",
@@ -1797,27 +1810,49 @@
       "    print(f\"F({i}) = {fibonacci(i)}\")\n",
       "```\n",
       "\n",
-      "Option alternative — conserver la récursion mais ajouter un cache (functools.lru_cache, O(n) temps, O(n) mémoire) :\n",
-      "\n",
+      "b) Version avec mémoïsation (conserve le style récursif mais rapide)\n",
       "```python\n",
       "from functools import lru_cache\n",
       "\n",
       "@lru_cache(maxsize=None)\n",
-      "def fibonacci(n):\n",
-      "    if n < 0:\n",
-      "        raise ValueError(\"n doit être un entier >= 0\")\n",
-      "    if n <= 1:\n",
-      "        return n\n",
-      "    return fibonacci(n-1) + fibonacci(n-2)\n",
+      "def fibonacci_memo(n):\n",
+      "    if n <= 0:\n",
+      "        return 0\n",
+      "    if n == 1:\n",
+      "        return 1\n",
+      "    return fibonacci_memo(n-1) + fibonacci_memo(n-2)\n",
       "\n",
       "# Test\n",
       "for i in range(40):\n",
-      "    print(f\"F({i}) = {fibonacci(i)}\")\n",
+      "    print(f\"F({i}) = {fibonacci_memo(i)}\")\n",
       "```\n",
       "\n",
-      "Si vous travaillez avec des n très grands (≥ millions), considérez l'algorithme \"fast doubling\" qui calcule F(n) en O(log n) temps.\n",
+      "c) Version fast doubling (complexité O(log n))\n",
+      "```python\n",
+      "def fibonacci_fast_doubling(n):\n",
+      "    \"\"\"Retourne F(n) en utilisant l'algorithme fast-doubling.\"\"\"\n",
+      "    if n < 0:\n",
+      "        raise ValueError(\"n doit être un entier >= 0\")\n",
       "\n",
-      "Besoin que je fournisse aussi la version fast-doubling ?\n",
+      "    def _fib(k):\n",
+      "        if k == 0:\n",
+      "            return (0, 1)\n",
+      "        a, b = _fib(k // 2)\n",
+      "        c = a * (2 * b - a)\n",
+      "        d = a * a + b * b\n",
+      "        if k % 2 == 0:\n",
+      "            return (c, d)\n",
+      "        else:\n",
+      "            return (d, c + d)\n",
+      "\n",
+      "    return _fib(n)[0]\n",
+      "\n",
+      "# Test\n",
+      "for i in range(40):\n",
+      "    print(f\"F({i}) = {fibonacci_fast_doubling(i)}\")\n",
+      "```\n",
+      "\n",
+      "Conclusion : pour résoudre le problème de lenteur, remplacez la récursion naïve par l'une des solutions ci‑dessus (itérative ou mémoïsée étant les plus simples). Si vous avez besoin de F(n) pour des n très grands, privilégiez fast doubling.\n",
       "\n",
       "============================================================\n",
       "Le modèle devrait identifier:\n",
@@ -1887,21 +1922,57 @@
   {
    "cell_type": "markdown",
    "id": "fae1bc5c",
-   "source": "### Exercice 3 : Verification de reponse par raisonnement\n\nL'objectif est de creer une fonction qui demande au modele de **verifier** si une reponse donnee a un probleme mathematique est correcte, en utilisant le mode reasoning pour valider pas a pas.\n\n**Indices :**\n- # Etape 1 : Construire un prompt qui presente le probleme ET la reponse a verifier\n- # Etape 2 : Utiliser reasoning_effort='medium' pour permettre une verification approfondie\n- # Etape 3 : Demander au modele de repondre uniquement par \"CORRECT\" ou \"INCORRECT\" suivi de la justification\n- # Etape 4 : Parser la reponse pour extraire le verdict et l'explication",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Verification de reponse par raisonnement\n",
+    "\n",
+    "L'objectif est de creer une fonction qui demande au modele de **verifier** si une reponse donnee a un probleme mathematique est correcte, en utilisant le mode reasoning pour valider pas a pas.\n",
+    "\n",
+    "**Indices :**\n",
+    "- # Etape 1 : Construire un prompt qui presente le probleme ET la reponse a verifier\n",
+    "- # Etape 2 : Utiliser reasoning_effort='medium' pour permettre une verification approfondie\n",
+    "- # Etape 3 : Demander au modele de repondre uniquement par \"CORRECT\" ou \"INCORRECT\" suivi de la justification\n",
+    "- # Etape 4 : Parser la reponse pour extraire le verdict et l'explication"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "7ad3a8ab",
-   "source": "# Exercice 3 : Verification de reponse par raisonnement\n# TODO etudiant : Implementer une fonction verify_answer(problem, claimed_answer)\n# - Construit un prompt : \"Verifie si cette reponse est correcte. Probleme: {problem}. Reponse proposee: {claimed_answer}\"\n# - Utilise le modele reasoning avec reasoning_effort='medium'\n# - Retourne un dict {\"verdict\": \"CORRECT\"|\"INCORRECT\", \"explanation\": \"...\"}\n\ndef verify_answer(problem, claimed_answer):\n    return None  # TODO etudiant : implementer\n\n# Test :\n# result = verify_answer(\"Combien font 17 * 23?\", \"391\")\n# print(f\"Verdict: {result['verdict']}, Explication: {result['explanation']}\")\n# result2 = verify_answer(\"Combien font 17 * 23?\", \"400\")\n# print(f\"Verdict: {result2['verdict']}, Explication: {result2['explanation']}\")\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
    "execution_count": 14,
+   "id": "7ad3a8ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:23:13.307635Z",
+     "iopub.status.busy": "2026-06-19T18:23:13.307635Z",
+     "iopub.status.idle": "2026-06-19T18:23:13.314970Z",
+     "shell.execute_reply": "2026-06-19T18:23:13.314970Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
     }
+   ],
+   "source": [
+    "# Exercice 3 : Verification de reponse par raisonnement\n",
+    "# TODO etudiant : Implementer une fonction verify_answer(problem, claimed_answer)\n",
+    "# - Construit un prompt : \"Verifie si cette reponse est correcte. Probleme: {problem}. Reponse proposee: {claimed_answer}\"\n",
+    "# - Utilise le modele reasoning avec reasoning_effort='medium'\n",
+    "# - Retourne un dict {\"verdict\": \"CORRECT\"|\"INCORRECT\", \"explanation\": \"...\"}\n",
+    "\n",
+    "def verify_answer(problem, claimed_answer):\n",
+    "    return None  # TODO etudiant : implementer\n",
+    "\n",
+    "# Test :\n",
+    "# result = verify_answer(\"Combien font 17 * 23?\", \"391\")\n",
+    "# print(f\"Verdict: {result['verdict']}, Explication: {result['explanation']}\")\n",
+    "# result2 = verify_answer(\"Combien font 17 * 23?\", \"400\")\n",
+    "# print(f\"Verdict: {result2['verdict']}, Explication: {result2['explanation']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -2032,7 +2103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Summary

Adds `8_Reasoning_Models.ipynb` to the **#3571 token-starvation fix** (TIER A grain), extending **PR #3663** which covered NB-2/5/9. ai-01 dispatch (18:07Z) flagged this 4th GenAI/Texte notebook was missing from the grain.

## Root cause

`gpt-5-mini` is a **reasoning model**: reasoning tokens are deducted from `max_completion_tokens`. Budgets of **100–500** were entirely consumed by reasoning, producing `[Content null]` / `[Response content is null]` outputs. The prior audit fix (#3164) had **aligned the prose on those empty outputs** — consecrating the regression instead of repairing it.

This is the same gesture as Infer #3473 / #3656, corrected by Règle-F (#3660): ask "is this a RÉCUPÉRABLE failure?" → YES (low token budget) → **REPAIR + re-exec → real output** → THEN write prose.

## Changes

**Budget bumps (`max_completion_tokens` → 4000) on 4 cells:**
- `cell8` chat-vs-reasoning comparison (was 200×2)
- `cell12` `reasoning_effort` low/medium/high sweep (was 200)
- `cell18` formatting toggle (was 500×2)
- `cell30` benchmark (was 100×2)

**Re-execution** via `nbconvert --execute --inplace` against the notebook's configured default endpoint (**OpenRouter gpt-5-mini reasoning**) — NOT an OpenAI-direct override (the notebook's `openai/`-prefixed model names are OpenRouter-coupled; OpenAI-direct rejects the prefix). EXIT=0, all 5 starved cells now produce real content:
- cell8: `74` in both modes (was `[null content]`)
- cell12: real answers at low/medium/high
- cell18: full Pythagoras theorem (was `[Content null]`)
- cell30: benchmark 391 / 3 / 10h13min20s (was `[null content]`)
- cell27 (no explicit budget, `reasoning_effort=high`): complete optimization solution — variables, constraint `2x+y=100`, `A(x)=100x−2x²`, `A'(x)=100−4x=0⇒x=25`, `A''<0` max, surface 1250 m²

**De-consecration of 3 prose cells** that documented the empty outputs as the expected result:
- `cell17`: refined (the `S'(x)=100−4x→x=25` derivation was real but truncated at `A''(x)=−4<0 donc l` — now the solution is genuinely complete; added #3571 note)
- `cell19`: rewritten — was "les deux appels...ont retourné un contenu null" → now "produisent une explication complète du théorème de Pythagore"
- `cell21`: rewritten — was benchmark table full of `[null]` with fabricated `temps moyens` → now real table (391/3/10h13min20s, Chat 4.73s / Reasoning 3.87s)

## Validation

- ✅ `nbconvert --execute --inplace` EXIT=0 via OpenRouter gpt-5-mini
- ✅ 14 code cells, **0 errors, 0 null execution_count**
- ✅ No remaining `[null]` / `[Content null]` / `[Response content is null]` in committed outputs
- ✅ Catalog byte-identical to `origin/main` (no churn, regen left to cron/CI)
- ✅ Secret scan: CLEAN (no `OPENAI_DIRECT` / `sk-` literals in diff)
- ✅ Scope strict (C.3): only `8_Reasoning_Models.ipynb` modified

## Relation to #3571

`See #3571` (companion) — **PR #3663 already carries `Closes #3571`** for NB-2/5/9. This PR adds the 4th notebook (8_Reasoning_Models) flagged in ai-01's 18:07Z dispatch extension. Not using `Closes` to avoid double-auto-close confusion; ai-01 can close #3571 once both are merged.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>