### PR TITLE
docs(sw): add Conclusion / Prochaines étapes to SemanticWeb README (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -519,6 +519,30 @@ Les smart contracts et le web sémantique convergent dans les données décentra
 
 ---
 
+## Conclusion / Prochaines étapes
+
+### Ce que vous avez appris
+
+Le fil de cette série épouse celui du Web Sémantique lui-même : **donner du sens formel à des données**, couche par couche.
+
+- **Modéliser** (Parties 1-2, .NET C#) : un domaine se découpe en triplets RDF, s'interroge en SPARQL, se structure en hiérarchies RDFS puis en ontologies OWL où le raisonneur déduit ce que vous n'avez pas écrit explicitement.
+- **Valider et échanger** (Partie 3, Python) : SHACL garantit la conformité d'un graphe, JSON-LD ponte vers le Web des APIs, RDF-Star ajoute la *provenance* — car un fait sans source n'est qu'une assertion.
+- **Fermer la boucle avec l'IA** (Partie 4) : un graphe de connaissances ancre les LLMs sur des faits vérifiables. C'est le point d'aboutissement — GraphRAG (SW-12) transforme le Web Sémantique de niche académique en garde-fou contre les hallucinations génératives.
+
+### Prochaines étapes
+
+- **Poussez l'ontologie plus loin** : SW-7 (OWL) et le bonus [SW-13-Python-Reasoners](SW-13-Python-Reasoners.ipynb) ouvrent la comparaison des raisonneurs (HermiT, owlrl, reasonable). C'est le pont naturel vers **[Tweety](../Tweety/)** — où les logiques de description (décidables, monotones) rencontrent la logique classique, le SAT solving et le raisonnement non-monotone.
+- **Branchez la planification** : un graphe de connaissances est une représentation du monde que les planificateurs peuvent exploiter. La série **[Planners](../Planners/)** (PDDL, GraphPlan, LLM planning) consomme exactement ce genre d'états initiaux et de buts que SPARQL peut extraire d'un graphe.
+- **Certifiez** : les shapes SHACL sont des invariants sur les données, analogues aux spécifications formelles. La série **[Lean](../Lean/)** pousse cette idée à son terme — prouver la correction d'un programme, pas seulement valider ses données.
+- **Allez on-chain** : les NFTs ERC-721 à métadonnées JSON-LD (SW-9) forment des graphes décentralisés. La série **[SmartContracts](../SmartContracts/)** (SC-7 Token Standards) est le terrain où RDF, identité auto-souveraine (DID) et blockchains convergent.
+- **Relisez la série sous l'angle de la représentation** : la [Lecture transversale](#lecture-transversale) ci-dessus relie ce geste — *trouver la représentation où le problème se dissolve* — à tout le dépôt CoursIA.
+
+### Le fil rouge
+
+Le titre de Berners-Lee en 2001 promettait un Web compris par les machines. Vingt ans plus tard, ce n'est plus une promesse : c'est une *technique*, du triplet RDF au GraphRAG. Les standards changent (RDF 1.2, JSON-LD 1.1), les outils changent (dotNetRDF, rdflib, kglab), mais le geste reste — **structurer, interroger, valider, raisonner**. C'est ce triptyque que vous emportez au-delà de cette série.
+
+---
+
 ## Licence
 
 Voir la licence du repository principal.


### PR DESCRIPTION
See #2651 (Partie 2 — prose README harmonization). Partial contribution to an open epic, hence `See` (no auto-close).

## Context

2nd grain of the family-wide "Conclusion / Prochaines étapes" rollout, per ai-01 directive (dashboard reply 2026-06-19T17:03Z, option 1 lightened version): add the missing Conclusion section to each of the 8/9 SymbolicAI sub-series that lack it, 1 PR per series, atomic, markdown-only. SmartContracts (#3659, merged) was first; **SemanticWeb** is second (SemanticWeb family drained this cycle, natural continuation).

## Changes

Added a `## Conclusion / Prochaines étapes` section to `SemanticWeb/README.md`, inserted before the final divider/license:

- **Ce que vous avez appris** — synthesis of the 3-part arc: RDF modeling + SPARQL + RDFS/OWL in .NET (Parts 1-2), validation/exchange via SHACL/JSON-LD/RDF-Star in Python (Part 3), and the KG+LLM closure through GraphRAG (Part 4) — echoing the 2001 Berners-Lee promise turned technique.
- **Prochaines étapes** — 5 cross-series bridges grounded in the README's existing "Connections cross-séries": Tweety (description logics vs classical/non-monotone logic), Planners (KG as world model for PDDL), Lean (SHACL invariants as a stepping stone to formal specs), SmartContracts (ERC-721 metadata + JSON-LD, DID), plus a link back to the transversal reading.
- **Le fil rouge** — closing synthesis on the structurer/interroger/valider/raisonner triptych.

Deliberately **complements** (does not duplicate) the existing rich "Lecture transversale" section and the 7 already-formalized "Acquis d'apprentissage" (G.5 — no bloat on a 524-line README).

## G.1 link verification (0 fabrication)

| Link | Target | Verified |
|------|--------|----------|
| `../Tweety/` | `SymbolicAI/Tweety/` | exists |
| `../Planners/` | `SymbolicAI/Planners/` | exists |
| `../Lean/` | `SymbolicAI/Lean/` | exists |
| `../SmartContracts/` | `SymbolicAI/SmartContracts/` | exists |
| `SW-12-Python-GraphRAG.ipynb` | notebook | exists |
| `SW-13-Python-Reasoners.ipynb` | notebook (bonus) | exists |
| `#lecture-transversale` | heading `## Lecture transversale` | valid GitHub anchor |

All `../` paths resolve (sub-series at same `SymbolicAI/` level — no path bug this time).

## Validation

- Markdown-only (**+24/-0**, purely additive, symmetric to #3659)
- No notebook touched, no catalog regen (catalog-pr-hygiene HARD 1 — catalog byte-identical to main)
- Rule-E: <50 lines but content addition to an existing rich README (524 lines), not a standalone doc → atomique HARD 3 honored
- H.3 non-triggered (no notebooks)

@ai-01: markdown-only README, forensic `git diff` suffices for H.4. Next in queue per directive: **Lean** (3rd most consulted).