### PR TITLE
fix(#3571): raise max_completion_tokens on gpt-5-mini vision cells in 6_PDF_Web_Search — token-starvation

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
@@ -39,10 +39,10 @@
    "id": "5393353b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T21:28:24.822391Z",
-     "iopub.status.busy": "2026-06-07T21:28:24.821806Z",
-     "iopub.status.idle": "2026-06-07T21:28:33.069420Z",
-     "shell.execute_reply": "2026-06-07T21:28:33.067655Z"
+     "iopub.execute_input": "2026-06-19T19:26:18.248796Z",
+     "iopub.status.busy": "2026-06-19T19:26:18.247797Z",
+     "iopub.status.idle": "2026-06-19T19:26:22.610589Z",
+     "shell.execute_reply": "2026-06-19T19:26:22.610589Z"
     },
     "papermill": {
      "duration": 8.25766,
@@ -58,10 +58,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
       "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
+      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
       "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     },
@@ -76,7 +74,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".env charge depuis: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n"
+      ".env charge depuis: C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GenAI\\.env\n"
      ]
     },
     {
@@ -151,10 +149,10 @@
    "id": "f0485c06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T21:28:33.101272Z",
-     "iopub.status.busy": "2026-06-07T21:28:33.100432Z",
-     "iopub.status.idle": "2026-06-07T21:28:46.943187Z",
-     "shell.execute_reply": "2026-06-07T21:28:46.941765Z"
+     "iopub.execute_input": "2026-06-19T19:26:22.610589Z",
+     "iopub.status.busy": "2026-06-19T19:26:22.610589Z",
+     "iopub.status.idle": "2026-06-19T19:26:25.854184Z",
+     "shell.execute_reply": "2026-06-19T19:26:25.854184Z"
     },
     "papermill": {
      "duration": 13.853708,
@@ -337,10 +335,10 @@
    "id": "cca7e848",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T21:28:46.969654Z",
-     "iopub.status.busy": "2026-06-07T21:28:46.968867Z",
-     "iopub.status.idle": "2026-06-07T21:28:47.086354Z",
-     "shell.execute_reply": "2026-06-07T21:28:47.085064Z"
+     "iopub.execute_input": "2026-06-19T19:26:25.854184Z",
+     "iopub.status.busy": "2026-06-19T19:26:25.854184Z",
+     "iopub.status.idle": "2026-06-19T19:26:25.888352Z",
+     "shell.execute_reply": "2026-06-19T19:26:25.888352Z"
     },
     "papermill": {
      "duration": 0.126746,
@@ -357,7 +355,7 @@
      "output_type": "stream",
      "text": [
       "✓ Image de rapport créée: test_report.png\n",
-      "  Taille: 40286 octets\n"
+      "  Taille: 40235 octets\n"
      ]
     }
    ],
@@ -456,10 +454,10 @@
    "id": "f77b2375",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T21:28:47.113207Z",
-     "iopub.status.busy": "2026-06-07T21:28:47.112387Z",
-     "iopub.status.idle": "2026-06-07T21:28:53.810614Z",
-     "shell.execute_reply": "2026-06-07T21:28:53.809610Z"
+     "iopub.execute_input": "2026-06-19T19:26:25.888352Z",
+     "iopub.status.busy": "2026-06-19T19:26:25.888352Z",
+     "iopub.status.idle": "2026-06-19T19:26:34.993150Z",
+     "shell.execute_reply": "2026-06-19T19:26:34.993150Z"
     },
     "papermill": {
      "duration": 6.70743,
@@ -484,9 +482,13 @@
      "output_type": "stream",
      "text": [
       "=== Analyse du document ===\n",
+      "Voici les 3 points clés avec les chiffres associés :\n",
       "\n",
+      "1) Chiffre d'affaires : 2,5 M EUR (+15%)  \n",
+      "2) Nouveaux clients : 150 (+25%)  \n",
+      "3) Recrutement : 20 ingénieurs (renforcement des effectifs)\n",
       "\n",
-      "Tokens utilisés: 1482\n"
+      "Tokens utilisés: 1499\n"
      ]
     }
    ],
@@ -498,7 +500,11 @@
     "\n",
     "print(f\"Envoi de l'image au modèle {DEFAULT_MODEL}...\\n\")\n",
     "\n",
-    "# Envoyer au modèle avec vision\n",
+    "# Envoyer au modèle avec vision.\n",
+    "# Note: gpt-5-mini est un modèle de raisonnement — les tokens de raisonnement sont\n",
+    "# déduits de max_completion_tokens. Un budget trop bas (ex. 500) est entièrement\n",
+    "# consommé par le raisonnement et laisse le contenu visible vide. Budget relevé à\n",
+    "# 4000 pour laisser de la place à une réponse réelle (#3571).\n",
     "response = client.chat.completions.create(\n",
     "    model=DEFAULT_MODEL,\n",
     "    messages=[{\n",
@@ -516,7 +522,7 @@
     "            }\n",
     "        ]\n",
     "    }],\n",
-    "    max_completion_tokens=500\n",
+    "    max_completion_tokens=4000\n",
     ")\n",
     "\n",
     "print(\"=== Analyse du document ===\")\n",
@@ -537,57 +543,84 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation des résultats\n",
-    "\n",
-    "**Observation sur cette exécution :** le modèle a reçu l'image mais n'a renvoyé\n",
-    "aucun contenu textuel — la sortie `=== Analyse du document ===` est restée vide\n",
-    "(seul le compte de tokens, 1482, a été renvoyé). Ce comportement est typique des\n",
-    "modèles de raisonnement lorsqu'aucun texte clair n'est détecté ou que la demande\n",
-    "d'extraction échoue silencieusement : l'appel réussit (pas d'erreur) mais la\n",
-    "sortie est vide.\n",
-    "\n",
-    "**Capacités attendues d'un modèle vision sur un document lisible :**\n",
-    "\n",
-    "1. **Reconnaissance optique** : analyse de l'image et extraction du texte visible\n",
-    "2. **Compréhension sémantique** : identification des sections (titre, résumé, points clés)\n",
-    "3. **Extraction ciblée** : sélection des informations principales avec leurs valeurs\n",
-    "\n",
-    "**Limites potentielles (à l'origine d'une extraction vide) :**\n",
-    "\n",
-    "- **Qualité image** : basse résolution ou flou dégradent la précision\n",
-    "- **Complexité visuelle** : graphiques complexes peuvent être mal interprétés\n",
-    "- **OCR** : polices spéciales ou petites peuvent causer des erreurs ou une absence de sortie\n",
-    "\n",
-    "> **Note technique** : le modèle vision traite l'image en tokens visuels. OpenAI\n",
-    "> facture l'image selon un découpage en tuiles de 512×512 pixels ; une image\n",
-    "> 800×1000 couvre plusieurs tuiles et consomme ici 1482 tokens au total\n",
-    "> (usage effectif constaté sur cette exécution).\n",
-    "\n",
-    "> **Référence** : les modèles vision-langage multimodaux qui combinent OCR et\n",
-    "> compréhension sémantique s'inspirent de travaux comme Flamingo\n",
-    "> (Alayrac et al. 2022, *Flamingo: a Visual Language Model for Few-Shot Learning*,\n",
-    "> arXiv:2204.14198)."
-   ]
+   "source": "### Interprétation des résultats\n\nLe modèle vision extrait correctement les 3 points clés du rapport, avec leurs\nchiffres : chiffre d'affaires (2,5 M EUR, +15%), nouveaux clients (150, +25%) et\nrecrutement (20 ingénieurs). L'image 800×1000 est traitée en tokens visuels\n(1499 tokens au total sur cette exécution).\n\n**Capacités attendues d'un modèle vision sur un document lisible :**\n\n1. **Reconnaissance optique** : analyse de l'image et extraction du texte visible\n2. **Compréhension sémantique** : identification des sections (titre, résumé, points clés)\n3. **Extraction ciblée** : sélection des informations principales avec leurs valeurs\n\n**Limites potentielles (à l'origine d'une extraction vide) :**\n\n- **Qualité image** : basse résolution ou flou dégradent la précision\n- **Complexité visuelle** : graphiques complexes peuvent être mal interprétés\n- **OCR** : polices spéciales ou petites peuvent causer des erreurs\n\n> **Note technique** : `gpt-5-mini` est un modèle de raisonnement — les tokens de\n> raisonnement sont déduits de `max_completion_tokens`. Un budget trop bas est\n> entièrement consommé par le raisonnement et laisse le contenu visible vide ;\n> c'est pourquoi `max_completion_tokens=4000` est utilisé ici (#3571).\n\n> **Référence** : les modèles vision-langage multimodaux qui combinent OCR et\n> compréhension sémantique s'inspirent de travaux comme Flamingo\n> (Alayrac et al. 2022, *Flamingo: a Visual Language Model for Few-Shot Learning*,\n> arXiv:2204.14198).</cell>\n>"
   },
   {
    "cell_type": "markdown",
    "id": "dd7a4652",
-   "source": "### Exercice 1 : Analyser une image personnalisee avec l'API Vision\n\nEn vous basant sur l'exemple d'analyse de rapport ci-dessus, creez votre propre image de test (un graphique ou un tableau de donnees) et demandez au modele d'en extraire les informations cles.\n\n**Objectif** : Generer une image avec PIL contenant un tableau de donnees (ventes mensuelles), l'encoder en base64, et demander au modele d'en extraire les valeurs et la tendance.\n\n**Indices** :\n- Utilisez `PIL.Image`, `PIL.ImageDraw` et `PIL.ImageFont` pour creer une image avec un tableau\n- Dessinez un tableau avec 4 lignes : \"Janvier: 120k\", \"Fevrier: 145k\", \"Mars: 160k\", \"Avril: 180k\"\n- Encodez l'image en base64 avec `base64.b64encode()`\n- Envoyez au modele avec le prompt : \"Extrais les ventes mensuelles de cette image et identifie la tendance\"",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Analyser une image personnalisee avec l'API Vision\n",
+    "\n",
+    "En vous basant sur l'exemple d'analyse de rapport ci-dessus, creez votre propre image de test (un graphique ou un tableau de donnees) et demandez au modele d'en extraire les informations cles.\n",
+    "\n",
+    "**Objectif** : Generer une image avec PIL contenant un tableau de donnees (ventes mensuelles), l'encoder en base64, et demander au modele d'en extraire les valeurs et la tendance.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Utilisez `PIL.Image`, `PIL.ImageDraw` et `PIL.ImageFont` pour creer une image avec un tableau\n",
+    "- Dessinez un tableau avec 4 lignes : \"Janvier: 120k\", \"Fevrier: 145k\", \"Mars: 160k\", \"Avril: 180k\"\n",
+    "- Encodez l'image en base64 avec `base64.b64encode()`\n",
+    "- Envoyez au modele avec le prompt : \"Extrais les ventes mensuelles de cette image et identifie la tendance\""
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "555f6bba",
-   "source": "# Exercice 1 : Analyser une image personnalisee avec l'API Vision\n# TODO etudiant : Creez une image avec un tableau de ventes et analysez-la\n\n# Etape 1 : Creer une image avec PIL contenant un tableau de ventes\n# from PIL import Image, ImageDraw, ImageFont\n# import io, base64\n#\n# img = Image.new('RGB', (600, 300), 'white')\n# draw = ImageDraw.Draw(img)\n# draw.text((50, 30), \"Ventes Mensuelles 2026\", fill='black')\n# draw.text((50, 80), \"Janvier: 120k EUR\", fill='black')\n# draw.text((50, 120), \"Fevrier: 145k EUR\", fill='black')\n# draw.text((50, 160), \"Mars: 160k EUR\", fill='black')\n# draw.text((50, 200), \"Avril: 180k EUR\", fill='black')\n#\n# buffer = io.BytesIO()\n# img.save(buffer, format='PNG')\n# img_b64 = base64.b64encode(buffer.getvalue()).decode()\n\n# Etape 2 : Envoyer l'image au modele Vision\n# response_vision = client.chat.completions.create(\n#     model=DEFAULT_MODEL,\n#     messages=[{\n#         \"role\": \"user\",\n#         \"content\": [\n#             {\"type\": \"text\", \"text\": \"Extrais les ventes mensuelles de cette image et identifie la tendance.\"},\n#             {\"type\": \"image_url\", \"image_url\": {\"url\": f\"data:image/png;base64,{img_b64}\"}}\n#         ]\n#     }],\n#     max_completion_tokens=300\n# )\n\n# Etape 3 : Afficher le resultat\n# print(response_vision.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T19:26:34.995271Z",
+     "iopub.status.busy": "2026-06-19T19:26:34.995271Z",
+     "iopub.status.idle": "2026-06-19T19:26:34.998224Z",
+     "shell.execute_reply": "2026-06-19T19:26:34.998224Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
     }
+   ],
+   "source": [
+    "# Exercice 1 : Analyser une image personnalisee avec l'API Vision\n",
+    "# TODO etudiant : Creez une image avec un tableau de ventes et analysez-la\n",
+    "\n",
+    "# Etape 1 : Creer une image avec PIL contenant un tableau de ventes\n",
+    "# from PIL import Image, ImageDraw, ImageFont\n",
+    "# import io, base64\n",
+    "#\n",
+    "# img = Image.new('RGB', (600, 300), 'white')\n",
+    "# draw = ImageDraw.Draw(img)\n",
+    "# draw.text((50, 30), \"Ventes Mensuelles 2026\", fill='black')\n",
+    "# draw.text((50, 80), \"Janvier: 120k EUR\", fill='black')\n",
+    "# draw.text((50, 120), \"Fevrier: 145k EUR\", fill='black')\n",
+    "# draw.text((50, 160), \"Mars: 160k EUR\", fill='black')\n",
+    "# draw.text((50, 200), \"Avril: 180k EUR\", fill='black')\n",
+    "#\n",
+    "# buffer = io.BytesIO()\n",
+    "# img.save(buffer, format='PNG')\n",
+    "# img_b64 = base64.b64encode(buffer.getvalue()).decode()\n",
+    "\n",
+    "# Etape 2 : Envoyer l'image au modele Vision\n",
+    "# response_vision = client.chat.completions.create(\n",
+    "#     model=DEFAULT_MODEL,\n",
+    "#     messages=[{\n",
+    "#         \"role\": \"user\",\n",
+    "#         \"content\": [\n",
+    "#             {\"type\": \"text\", \"text\": \"Extrais les ventes mensuelles de cette image et identifie la tendance.\"},\n",
+    "#             {\"type\": \"image_url\", \"image_url\": {\"url\": f\"data:image/png;base64,{img_b64}\"}}\n",
+    "#         ]\n",
+    "#     }],\n",
+    "#     max_completion_tokens=300\n",
+    "# )\n",
+    "\n",
+    "# Etape 3 : Afficher le resultat\n",
+    "# print(response_vision.choices[0].message.content)\n",
+    "\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -621,20 +654,19 @@
     "\n",
     "**Note importante :** Cette fonctionnalité est en préversion et peut évoluer.\n",
     "\n",
-    "> **Référence** : l'enrichissement d'une réponse par recherche web en temps réel s'apparente au *Retrieval-Augmented Generation* (RAG) — Lewis et al. 2020, *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks*, arXiv:2005.11401.\n",
-    ""
+    "> **Référence** : l'enrichissement d'une réponse par recherche web en temps réel s'apparente au *Retrieval-Augmented Generation* (RAG) — Lewis et al. 2020, *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks*, arXiv:2005.11401.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "97ff2601",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T21:28:53.839911Z",
-     "iopub.status.busy": "2026-06-07T21:28:53.839294Z",
-     "iopub.status.idle": "2026-06-07T21:29:16.594724Z",
-     "shell.execute_reply": "2026-06-07T21:29:16.593850Z"
+     "iopub.execute_input": "2026-06-19T19:26:35.000236Z",
+     "iopub.status.busy": "2026-06-19T19:26:34.999236Z",
+     "iopub.status.idle": "2026-06-19T19:27:12.433101Z",
+     "shell.execute_reply": "2026-06-19T19:27:12.433101Z"
     },
     "papermill": {
      "duration": 22.761223,
@@ -663,7 +695,13 @@
       "\n",
       "[]\n",
       "\n",
-      "[ResponseOutputText(annotations=[AnnotationURLCitation(end_index=482, start_index=369, title='Google AI announcements from January', type='url_citation', url='https://blog.google/innovation-and-ai/products/google-ai-updates-january-2026/?utm_source=openai'), AnnotationURLCitation(end_index=987, start_index=841, title=\"Anthropic revises Claude's 'Constitution,' and hints at chatbot consciousness | TechCrunch\", type='url_citation', url='https://techcrunch.com/2026/01/21/anthropic-revises-claudes-constitution-and-hints-at-chatbot-consciousness/?utm_source=openai'), AnnotationURLCitation(end_index=1411, start_index=1315, title='Strengthening the US AI supply chain through domestic manufacturing | OpenAI', type='url_citation', url='https://openai.com/index/strengthening-the-us-ai-supply-chain/?utm_source=openai'), AnnotationURLCitation(end_index=1894, start_index=1801, title='The coolest technology from Day 1 of CES 2026', type='url_citation', url='https://apnews.com/article/a3e6e4e582ff83a4aa331d1791140369?utm_source=openai'), AnnotationURLCitation(end_index=2422, start_index=2345, title='Google DeepMind Supports U.S. Department of Energy on Genesis: a National Mission to Accelerate Innovation and Scientific Discovery | BNL Newsroom', type='url_citation', url='https://www.bnl.gov/newsroom/news.php?a=222774&utm_source=openai')], text='Voici un résumé des avancées majeures en intelligence artificielle survenues en janvier 2026 (avec dates et sources) :\\n\\n1) Google / DeepMind — sortie publique de Genie 3 (Project Genie) : DeepMind/Google ont rendu accessible Genie 3, un « world model » multimodal capable de générer et simuler mondes interactifs (sortie publique via Project Genie le 29 janvier 2026). ([blog.google](https://blog.google/innovation-and-ai/products/google-ai-updates-january-2026/?utm_source=openai))\\n\\n2) Anthropic — révisions de la « Constitution » de Claude et développements pour agents : Anthropic a publié une version révisée de la « Claude Constitution » (débat public et mise à jour autour du 21 janv. 2026) et a annoncé des outils/plug‑ins et une interface mobile (Remote Control / Claude Code) pour pousser les agents et le développement applicatif. ([techcrunch.com](https://techcrunch.com/2026/01/21/anthropic-revises-claudes-constitution-and-hints-at-chatbot-consciousness/?utm_source=openai))\\n\\n3) OpenAI — investissements d’infrastructure et partenariats matériels : en janvier OpenAI a détaillé initiatives pour renforcer la chaîne d’approvisionnement AI aux États‑Unis, annoncé partenariats matériels (ex. avec Cerebras pour capacité de calcul) et esquissé priorités produit / devices pour 2026 (annonces mi‑janvier). ([openai.com](https://openai.com/index/strengthening-the-us-ai-supply-chain/?utm_source=openai))\\n\\n4) Matériel / plateformes (CES et lancements) — montée des puces « AI‑native » et laptops AI : durant et autour de CES 2026 (début janvier) les grands constructeurs (NVIDIA, AMD, Intel) ont dévoilé nouvelles plates‑formes et processeurs optimisés pour charges AI (ex. sorties/Ryzen AI 400 annoncées autour du 22 janv. 2026), confirmant la poussée matérielle pour les modèles multimodaux. ([apnews.com](https://apnews.com/article/a3e6e4e582ff83a4aa331d1791140369?utm_source=openai))\\n\\n5) Recherche & politique — collaborations nationales et mise en garde sur les risques : début janvier DeepMind a annoncé un partenariat/implication dans la mission « Genesis » du DOE (8 janv. 2026) pour accélérer la découverte scientifique par AI ; parallèlement des rapports et ateliers (FAS / Future of Life, conférences AAAI‑adjacentes en fin janvier) ont intensifié les travaux sur risques d’AGI, gouvernance et theory‑of‑mind pour les modèles. ([bnl.gov](https://www.bnl.gov/newsroom/news.php?a=222774&utm_source=openai))\\n\\nSi vous voulez, je peux :\\n- fournir des liens et extraits d’articles pour un des points ci‑dessous,  \\n- creuser un domaine précis (agents, world models, hardware, régulation),  \\n- ou dresser une timeline plus détaillée jour par jour en janvier 2026. Que préférez‑vous ?', type='output_text', logprobs=[])]\n",
+      "[]\n",
+      "\n",
+      "[]\n",
+      "\n",
+      "[]\n",
+      "\n",
+      "[ResponseOutputText(annotations=[AnnotationURLCitation(end_index=440, start_index=283, title='Published \\nJanuary 21, 2026  \\nAuthors  \\nAmanda Ask', type='url_citation', url='https://www-cdn.anthropic.com/d0636f72a9493d279ed36b33987da3430bcb5911/claudes-constitution_webPDF_26-02.02a.pdf?utm_source=openai'), AnnotationURLCitation(end_index=732, start_index=656, title='Introducing Prism | OpenAI', type='url_citation', url='https://openai.com/index/introducing-prism?utm_source=openai'), AnnotationURLCitation(end_index=1126, start_index=964, title='PYMNTS | Anthropic: New Cowork Plugins Tailor Claude to Specific Job Tasks', type='url_citation', url='https://www.pymnts.com/news/artificial-intelligence/2026/anthropic-says-new-cowork-plugins-tailor-claude-specific-job-functions/?utm_source=openai'), AnnotationURLCitation(end_index=1472, start_index=1354, title='Gemini Drops: New updates to the Gemini app, January 2026', type='url_citation', url='https://blog.google/innovation-and-ai/products/gemini-app/gemini-drop-january-2026/?utm_source=openai'), AnnotationURLCitation(end_index=1757, start_index=1677, title='OpenAI partners with Cerebras | OpenAI', type='url_citation', url='https://openai.com/index/cerebras-partnership/?utm_source=openai'), AnnotationURLCitation(end_index=2161, start_index=1998, title='Leidos, OpenAI deploying AI to transform federal operations - Leidos', type='url_citation', url='https://investors.leidos.com/news-releases/news-release-details/leidos-openai-deploying-ai-transform-federal-operations?utm_source=openai')], text='Voici un résumé concis des avancées majeures liées à l’IA durant janvier 2026 (dates précises pour chaque événement) :\\n\\n- Anthropic publie « Claude’s Constitution » — un vaste document de gouvernance pour son assistant Claude (publication et discussion publique le 21 janvier 2026). ([www-cdn.anthropic.com](https://www-cdn.anthropic.com/d0636f72a9493d279ed36b33987da3430bcb5911/claudes-constitution_webPDF_26-02.02a.pdf?utm_source=openai))\\n\\n- OpenAI lance Prism, un workspace LaTeX‑native pour la recherche scientifique (intégré à GPT‑5.2) — annoncé le 27 janvier 2026 ; objectif : intégrer les modèles directement dans le flux de rédaction scientifique. ([openai.com](https://openai.com/index/introducing-prism?utm_source=openai))\\n\\n- Anthropic met en preview « Cowork » et ouvre un système de plug‑ins pour usages enterprise (research preview et plug‑ins disponibles fin janvier 2026), positionnant Claude comme plateforme d’agents pour tâches professionnelles. ([pymnts.com](https://www.pymnts.com/news/artificial-intelligence/2026/anthropic-says-new-cowork-plugins-tailor-claude-specific-job-functions/?utm_source=openai))\\n\\n- Google publie un important « Gemini Drop » le 30 janvier 2026 — série de mises à jour/fonctionnalités pour Gemini (nouvelles capacités multimodales, intégrations avec les apps Google, modes de raisonnement améliorés, etc.). ([blog.google](https://blog.google/innovation-and-ai/products/gemini-app/gemini-drop-january-2026/?utm_source=openai))\\n\\n- OpenAI annonce un partenariat technique avec Cerebras pour accélérer l’inférence et le déploiement (annoncé le 14 janvier 2026), visant à améliorer latence et montée en charge des services temps réel. ([openai.com](https://openai.com/index/cerebras-partnership/?utm_source=openai))\\n\\n- Quelques annonces commerciales/sectorielles importantes du mois : déploiements et partenariats (ex. Leidos‑OpenAI pour usages gouvernementaux annoncés le 22 janvier 2026) qui montrent la montée en production d’IA dans les organisations. ([investors.leidos.com](https://investors.leidos.com/news-releases/news-release-details/leidos-openai-deploying-ai-transform-federal-operations?utm_source=openai))\\n\\nSi vous voulez, je peux :\\n- développer un point précis (technique, gouvernance, ou commercial) ;  \\n- fournir liens et extraits des sources originales ;  \\n- dresser une timeline plus complète (janvier 2026 semaine par semaine).', type='output_text', logprobs=[])]\n",
       "\n"
      ]
     }
@@ -725,14 +763,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c46861d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T21:29:16.611419Z",
-     "iopub.status.busy": "2026-06-07T21:29:16.610993Z",
-     "iopub.status.idle": "2026-06-07T21:29:49.510151Z",
-     "shell.execute_reply": "2026-06-07T21:29:49.509343Z"
+     "iopub.execute_input": "2026-06-19T19:27:12.433101Z",
+     "iopub.status.busy": "2026-06-19T19:27:12.433101Z",
+     "iopub.status.idle": "2026-06-19T19:27:35.240097Z",
+     "shell.execute_reply": "2026-06-19T19:27:35.240097Z"
     },
     "papermill": {
      "duration": 32.909577,
@@ -767,9 +805,7 @@
       "\n",
       "[]\n",
       "\n",
-      "[]\n",
-      "\n",
-      "[ResponseOutputText(annotations=[AnnotationURLCitation(end_index=317, start_index=227, title='Apple (AAPL) Stock Chart and Price History 2026', type='url_citation', url='https://www.marketbeat.com/stocks/NASDAQ/AAPL/chart/?utm_source=openai'), AnnotationURLCitation(end_index=480, start_index=390, title='Apple Stock March 6 | StatMuse Money', type='url_citation', url='https://www.statmuse.com/money/ask/apple-stock-march-6?utm_source=openai')], text='Voici les chiffres au dernier cours disponible — j’ai pris le cours de clôture le plus récent (les marchés étaient fermés dimanche 7 juin 2026) :\\n\\n- Prix actuel (dernier cours de clôture) : 307,34 USD (clôture du 5 juin 2026). ([marketbeat.com](https://www.marketbeat.com/stocks/NASDAQ/AAPL/chart/?utm_source=openai))\\n\\n- Cours il y a ~3 mois (cours de clôture du 6 mars 2026) : 257,46 USD. ([statmuse.com](https://www.statmuse.com/money/ask/apple-stock-march-6?utm_source=openai))\\n\\nCalcul de la performance 3 mois :\\n- Variation absolue : +49,88 USD (307,34 − 257,46).\\n- Variation en % sur 3 mois : (307,34 / 257,46 − 1) × 100 ≈ +19,38 %.\\n\\nSi vous voulez, je peux :\\n- afficher un graphique des 3 derniers mois ;\\n- donner d’autres périodes (1 mois, 6 mois, 1 an) ;\\n- ou récupérer le cours en temps réel / after‑hours maintenant. Que préférez‑vous ?', type='output_text', logprobs=[])]\n",
+      "[ResponseOutputText(annotations=[AnnotationURLCitation(end_index=339, start_index=234, title='Historical Stock Prices for Apple (Nasdaq:AAPL) | MarketMinute', type='url_citation', url='https://www.ktiv.marketminute.com/quote/NQ%3AAAPL/historical?utm_source=openai')], text=\"Voici les chiffres demandés (valeurs en USD) :\\n\\n- Cours actuel d'AAPL : 298.01 $ (donné par le flux de marché). Dernière transaction indiquée le 19 juin 2026 à 00:15 UTC.   \\n- Cours de clôture il y a 3 mois (19 mars 2026) : 248.96 $. ([ktiv.marketminute.com](https://www.ktiv.marketminute.com/quote/NQ%3AAAPL/historical?utm_source=openai))\\n\\nPerformance sur les 3 derniers mois (19 mars 2026 → 19 juin 2026) : hausse de 49.05 $ soit +19.70 % (calculée à partir des cours ci‑dessus).\\n\\nSouhaitez‑vous un graphique historique, la performance sur d'autres périodes (1 mois, 6 mois, 1 an) ou des sources supplémentaires ?\", type='output_text', logprobs=[])]\n",
       "\n"
      ]
     }
@@ -838,21 +874,70 @@
   {
    "cell_type": "markdown",
    "id": "7203a152",
-   "source": "### Exercice 2 : Comparaison multi-sources avec web search\n\nUtilisez le web search pour comparer les informations sur un meme sujet provenant de differentes sources. Le but est de synthetiser une reponse equilibree en citant au moins 3 sources distinctes.\n\n**Objectif** : Formuler une requete de recherche web qui demande au modele de presenter les differents points de vue sur un sujet debattu, avec les sources pour chaque position.\n\n**Indices** :\n- Utilisez `client.responses.create()` avec `tools=[{\"type\": \"web_search_preview\"}]`\n- Choisissez un sujet avec des debats actifs (ex: \"Faut-il reguler les modeles d'IA generative ?\")\n- Demandez explicitement au modele de \"presenter les arguments pour et contre avec des sources\"\n- Verifiez que les annotations (`annotations`) dans la reponse citent bien des sources differentes",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Comparaison multi-sources avec web search\n",
+    "\n",
+    "Utilisez le web search pour comparer les informations sur un meme sujet provenant de differentes sources. Le but est de synthetiser une reponse equilibree en citant au moins 3 sources distinctes.\n",
+    "\n",
+    "**Objectif** : Formuler une requete de recherche web qui demande au modele de presenter les differents points de vue sur un sujet debattu, avec les sources pour chaque position.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Utilisez `client.responses.create()` avec `tools=[{\"type\": \"web_search_preview\"}]`\n",
+    "- Choisissez un sujet avec des debats actifs (ex: \"Faut-il reguler les modeles d'IA generative ?\")\n",
+    "- Demandez explicitement au modele de \"presenter les arguments pour et contre avec des sources\"\n",
+    "- Verifiez que les annotations (`annotations`) dans la reponse citent bien des sources differentes"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "eac64aba",
-   "source": "# Exercice 2 : Comparaison multi-sources avec web search\n# TODO etudiant : Creez une requete de recherche web comparee\n\n# Etape 1 : Formuler la requete avec demande de balance\n# query_debat = \"\"\"\n# Faut-il reguler les modeles d'IA generative ?\n# Presente les arguments pour et contre, en citant au moins 3 sources distinctes.\n# \"\"\"\n\n# Etape 2 : Appeler la Responses API avec web search\n# response_debat = client.responses.create(\n#     model=DEFAULT_MODEL,\n#     tools=[{\"type\": \"web_search_preview\"}],\n#     input=query_debat\n# )\n\n# Etape 3 : Extraire le texte et les citations\n# for item in response_debat.output:\n#     if hasattr(item, 'content'):\n#         for content in item.content:\n#             if hasattr(content, 'text'):\n#                 print(content.text)\n#                 print(f\"\\nSources citees: {len(content.annotations)}\")\n#                 for ann in content.annotations:\n#                     print(f\"  - {ann.title}: {ann.url}\")\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T19:27:35.240097Z",
+     "iopub.status.busy": "2026-06-19T19:27:35.240097Z",
+     "iopub.status.idle": "2026-06-19T19:27:35.245667Z",
+     "shell.execute_reply": "2026-06-19T19:27:35.245667Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
     }
+   ],
+   "source": [
+    "# Exercice 2 : Comparaison multi-sources avec web search\n",
+    "# TODO etudiant : Creez une requete de recherche web comparee\n",
+    "\n",
+    "# Etape 1 : Formuler la requete avec demande de balance\n",
+    "# query_debat = \"\"\"\n",
+    "# Faut-il reguler les modeles d'IA generative ?\n",
+    "# Presente les arguments pour et contre, en citant au moins 3 sources distinctes.\n",
+    "# \"\"\"\n",
+    "\n",
+    "# Etape 2 : Appeler la Responses API avec web search\n",
+    "# response_debat = client.responses.create(\n",
+    "#     model=DEFAULT_MODEL,\n",
+    "#     tools=[{\"type\": \"web_search_preview\"}],\n",
+    "#     input=query_debat\n",
+    "# )\n",
+    "\n",
+    "# Etape 3 : Extraire le texte et les citations\n",
+    "# for item in response_debat.output:\n",
+    "#     if hasattr(item, 'content'):\n",
+    "#         for content in item.content:\n",
+    "#             if hasattr(content, 'text'):\n",
+    "#                 print(content.text)\n",
+    "#                 print(f\"\\nSources citees: {len(content.annotations)}\")\n",
+    "#                 for ann in content.annotations:\n",
+    "#                     print(f\"  - {ann.title}: {ann.url}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -887,14 +972,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "76a872ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T21:29:49.550810Z",
-     "iopub.status.busy": "2026-06-07T21:29:49.550165Z",
-     "iopub.status.idle": "2026-06-07T21:30:00.573468Z",
-     "shell.execute_reply": "2026-06-07T21:30:00.572552Z"
+     "iopub.execute_input": "2026-06-19T19:27:35.245667Z",
+     "iopub.status.busy": "2026-06-19T19:27:35.245667Z",
+     "iopub.status.idle": "2026-06-19T19:28:09.237739Z",
+     "shell.execute_reply": "2026-06-19T19:28:09.237739Z"
     },
     "papermill": {
      "duration": 11.030202,
@@ -919,7 +1004,9 @@
      "output_type": "stream",
      "text": [
       "Données extraites du document:\n",
-      "\n",
+      "- Chiffre d'affaires : 2,5 M EUR  \n",
+      "- Taux de croissance (CA) : +15%  \n",
+      "- Perspectives Q2 : Objectif 3 M EUR (+20%)\n",
       "\n",
       "=== ÉTAPE 2 : Enrichissement avec données web ===\n",
       "\n"
@@ -932,7 +1019,9 @@
       "=== Analyse enrichie (Document + Web) ===\n",
       "[]\n",
       "\n",
-      "[ResponseOutputText(annotations=[], text=\"Merci — je peux faire ça, mais il me manque les chiffres Q1 2026 de l'entreprise. Peux‑tu coller ici les principaux indicateurs ou m’indiquer le nom de l’entreprise (je peux alors aller chercher le rapport Q1) ?\\n\\nIndique, si possible, au moins :\\n- Chiffre d’affaires (Q1 2026) et variation YoY / QoQ\\n- Résultat net / EBITDA et marge correspondante\\n- Croissance des revenus récurrents (ARR, SaaS MRR) ou KPI utilisateur (MAU/DAU) si pertinent\\n- Cash flow / trésorerie et dettes\\n- Orientation / guidance donnée pour 2026 (si fournie)\\n\\nPrécise aussi :\\n- Secteur exact (software/SaaS, semi‑conducteurs, hardware, cloud infra, fintech, etc.) ou si je dois choisir le périmètre « tech » global.\\n- Le niveau de détail voulu (brève comparaison de 1 paragraphe, ou analyse plus approfondie avec sources et graphiques).\\n\\nQuand tu auras fourni ces éléments je :\\n1) Chercherai les moyennes sectorielles 2026 et les tendances de croissance actuelles (sources publiques récentes),\\n2) Comparerai rapidement l’entreprise à ces benchmarks,\\n3) Donnerai des perspectives plausibles pour Q2 2026 en fonction des données et de la guidance.\\n\\nSouhaites‑tu que j’aille chercher les données sectorielles et la guidance (je citerai les sources) ?\", type='output_text', logprobs=[])]\n",
+      "[]\n",
+      "\n",
+      "[ResponseOutputText(annotations=[AnnotationURLCitation(end_index=653, start_index=445, title='Gartner Forecasts Worldwide IT Spending to Grow 13.5% in 2026, Totaling $6.31 Trillion', type='url_citation', url='https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai'), AnnotationURLCitation(end_index=1113, start_index=905, title='Gartner Forecasts Worldwide IT Spending to Grow 13.5% in 2026, Totaling $6.31 Trillion', type='url_citation', url='https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai'), AnnotationURLCitation(end_index=1737, start_index=1561, title='IDC - Semiconductor Market Forecast 2026: The AI Supercycle Arrives', type='url_citation', url='https://www.idc.com/resource-center/blog/semiconductor-market-to-surge-past-the-trillion-dollar-threshold-ai-infrastructure-drives-market-growth/?utm_source=openai'), AnnotationURLCitation(end_index=2256, start_index=2048, title='Gartner Forecasts Worldwide IT Spending to Grow 13.5% in 2026, Totaling $6.31 Trillion', type='url_citation', url='https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai'), AnnotationURLCitation(end_index=2657, start_index=2521, title=\"2026 will bring sharpest PC declines in over a decade — PC shipments to fall 10.4% | Tom's Hardware\", type='url_citation', url='https://www.tomshardware.com/tech-industry/2026-will-bring-sharpest-pc-declines-in-over-a-decade?utm_source=openai'), AnnotationURLCitation(end_index=3276, start_index=3068, title='Gartner Forecasts Worldwide IT Spending to Grow 13.5% in 2026, Totaling $6.31 Trillion', type='url_citation', url='https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai'), AnnotationURLCitation(end_index=4265, start_index=4057, title='Gartner Forecasts Worldwide IT Spending to Grow 13.5% in 2026, Totaling $6.31 Trillion', type='url_citation', url='https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai')], text='Merci — voici une comparaison brève et ciblée de vos chiffres Q1 2026 (CA 2,5 M€, +15% YoY ; objectif Q2 = 3,0 M€ soit +20% vs Q1).\\n\\nRésumé chiffré rapide\\n- Votre Q1: 2,5 M€, croissance +15% (YoY). Objectif Q2: 3,0 M€ (+20% séquentiel).\\n- Constat global: votre croissance Q1 (+15%) est légèrement supérieure à la dynamique moyenne du marché IT/tech en 2026, mais la situation varie fortement selon le sous‑segment (cloud/logiciels vs hardware). ([gartner.com](https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai))\\n\\n1) Comparaison avec les performances moyennes du secteur tech en 2026\\n- Panorama global IT (dépenses TI) : les analystes prévoient une croissance annuelle ~+13,5% pour les dépenses IT en 2026 — votre +15% YoY est donc au‑dessus de ce chiffre global. ([gartner.com](https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai))  \\n- Par sous‑secteur : les semiconducteurs affichent une dynamique très supérieure (croissance à deux chiffres — IDC indique un fort rebond autour de ~24% en 2026 pour certains segments liés à l’IA), tandis que les services IT traditionnels restent plutôt en croissance modérée (milieu des unités en pourcentage). Si vous êtes dans les semi/infra AI, +15% est en dessous de ce segment ; si vous êtes en services, +15% est au‑dessus de la moyenne. ([idc.com](https://www.idc.com/resource-center/blog/semiconductor-market-to-surge-past-the-trillion-dollar-threshold-ai-infrastructure-drives-market-growth/?utm_source=openai))\\n\\n2) Tendances de croissance actuelles (contexte 2026)\\n- Moteur principal : l’investissement en IA / infrastructure cloud reste le principal vecteur de croissance 2026 (forts spends en IA, cloud et logiciels). Cela profite surtout aux fournisseurs cloud, éditeurs SaaS orientés données et fournisseurs d’infra. ([gartner.com](https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai))  \\n- Risques / contre‑tendances : certains segments hardware (PC, smartphones) subissent des contractions unitaires en 2026 à cause de tensions sur la mémoire/composants — cela crée des gagnants (infra, semi, cloud) et des perdants (certain hardware grand public). ([tomshardware.com](https://www.tomshardware.com/tech-industry/2026-will-bring-sharpest-pc-declines-in-over-a-decade?utm_source=openai))\\n\\n3) Perspectives pour votre Q2 2026 (objectif +20%)\\n- Réalisme : un objectif séquentiel +20% (2,5 → 3,0 M€) est ambitieux mais plausible si (a) vous capturez de nouvelles ventes liées à l’IA/cloud, (b) vous avez un effet de saisonnalité positif ou (c) une grosse commande/contrat se concrétise. En revanche, si votre activité dépend du marché PC/consommateur, la trajectoire secteur signale un vent contraire. ([gartner.com](https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai))  \\n- Indicateurs à surveiller pour valider l’objectif Q2 : pipeline commercial (TAM/ACV), taux de conversion des leads, renouvellements/subscriptions, délais et prix des composants, marges brutes (impact des hausses de coûts composants), et guidance des clients hyperscalers si vous y vendez.\\n\\nConclusion courte\\n- Votre +15% YoY en Q1 est globalement supérieur à la croissance IT « moyenne » 2026 (~+13,5%) — c’est un bon signal. Toutefois, la comparabilité dépend du sous‑segment : certains segments (semi/IA/infrastructure) croissent beaucoup plus vite, d’autres (PC/consommateur) ralentissent fortement. L’objectif Q2 +20% est atteignable si vous bénéficiez des dynamiques AI/cloud ou d’un fort effet de contrat ; sinon, c’est élevé et mérite une validation serrée du pipeline. ([gartner.com](https://www.gartner.com/en/newsroom/press-releases/2026-04-22-gartner-forecasts-worldwide-it-spending-to-grow-13-point-5-percent-in-2026-totaling-6-point-31-trillion-dollars?utm_source=openai))\\n\\nSouhaitez‑vous que je traduise ça en un court slide en français (1 diapo) ou que j’évalue la probabilité d’atteindre le Q2 = 3,0 M€ si vous me donnez votre pipeline / mix produit ?', type='output_text', logprobs=[])]\n",
       "\n"
      ]
     }
@@ -941,7 +1030,10 @@
     "# Workflow combiné : Document Image + Web Search\n",
     "print(\"=== ÉTAPE 1 : Extraction des informations du document ===\\n\")\n",
     "\n",
-    "# Analyser le document image pour extraire les données financières\n",
+    "# Analyser le document image pour extraire les données financières.\n",
+    "# Budget relevé à 4000 : gpt-5-mini (modèle de raisonnement) consomme son budget de\n",
+    "# raisonnement dans max_completion_tokens ; à 300 l'extraction revenait vide et la\n",
+    "# cascade web n'avait aucun chiffre réel à contextualiser (#3571).\n",
     "doc_analysis = client.chat.completions.create(\n",
     "    model=DEFAULT_MODEL,\n",
     "    messages=[{\n",
@@ -957,7 +1049,7 @@
     "            }\n",
     "        ]\n",
     "    }],\n",
-    "    max_completion_tokens=300\n",
+    "    max_completion_tokens=4000\n",
     ")\n",
     "\n",
     "ca_info = doc_analysis.choices[0].message.content\n",
@@ -1006,54 +1098,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation du workflow combiné\n",
-    "\n",
-    "**Architecture de l'analyse enrichie :**\n",
-    "\n",
-    "```\n",
-    "Document PDF/Image\n",
-    "    ↓\n",
-    "[EXTRACTION] → Données structurées (CA, croissance, perspectives)\n",
-    "    ↓\n",
-    "[CONTEXTUALISATION] → Requête web formulée\n",
-    "    ↓\n",
-    "[WEB SEARCH] → Tendances secteur, benchmarks, actualité\n",
-    "    ↓\n",
-    "[SYNTHÈSE] → Rapport comparatif enrichi\n",
-    "```\n",
-    "\n",
-    "**Observation sur cette exécution :** l'étape d'extraction (vision) a renvoyé un\n",
-    "résultat vide — les `Données extraites du document` sont restées vides, donc la\n",
-    "requête web ne contenait aucun chiffre réel à contextualiser. En conséquence, le\n",
-    "modèle a demandé à l'utilisateur de fournir les indicateurs rather que de\n",
-    "synthétiser un rapport comparatif. Le pipeline ci-dessus décrit l'architecture\n",
-    "attendue ; sur cette exécution la étape d'extraction a échoué silencieusement et\n",
-    "la synthèse n'a pas pu se produire.\n",
-    "\n",
-    "**Pourquoi cette approche est puissante (quand l'extraction réussit) :**\n",
-    "\n",
-    "1. **Données internes** (PDF) : informations propriétaires, chiffres précis\n",
-    "2. **Contexte externe** (Web) : comparaison sectorielle, tendances marché\n",
-    "3. **Synthèse** : analyse comparative que ni la source PDF ni le web seuls ne peuvent fournir\n",
-    "\n",
-    "**Cas d'usage concrets :**\n",
-    "\n",
-    "| Scénario | Valeur ajoutée |\n",
-    "|----------|----------------|\n",
-    "| **Rapport trimestriel** | Comparer performances entreprise vs. concurrents |\n",
-    "| **Proposition commerciale** | Enrichir avec données marché récentes |\n",
-    "| **Audit** | Vérifier conformité avec réglementations actualisées |\n",
-    "| **Due diligence** | Croiser données fournies avec informations publiques |\n",
-    "\n",
-    "**Coût indicatif du workflow :**\n",
-    "\n",
-    "- **Étape 1** (Vision) : ~1482 tokens input (image, usage constaté) + sortie variable\n",
-    "- **Étape 2** (Web Search) : ~500 tokens input + 800 tokens output\n",
-    "- **Total** : de l'ordre de ~2800 tokens avec `gpt-5-mini` ≈ $0.004\n",
-    "\n",
-    "> **Optimisation** : pour traiter des lots de documents, utiliser `batch API` pour réduire les coûts de 50%."
-   ]
+   "source": "### Interprétation du workflow combiné\n\n**Architecture de l'analyse enrichie :**\n\n```\nDocument PDF/Image\n    ↓\n[EXTRACTION] → Données structurées (CA, croissance, perspectives)\n    ↓\n[CONTEXTUALISATION] → Requête web formulée\n    ↓\n[WEB SEARCH] → Tendances secteur, benchmarks, actualité\n    ↓\n[SYNTHÈSE] → Rapport comparatif enrichi\n```\n\nL'extraction vision récupère les chiffres internes du document (CA 2,5 M EUR,\n+15%, perspectives Q2 3 M EUR +20%), puis la requête web contextualise ces\nrésultats avec les tendances secteur 2026 (ex. prévisions de dépenses IT de\nGartner). La synthèse compare les performances internes aux benchmarks externes.\n\n**Pourquoi cette approche est puissante :**\n\n1. **Données internes** (PDF) : informations propriétaires, chiffres précis\n2. **Contexte externe** (Web) : comparaison sectorielle, tendances marché\n3. **Synthèse** : analyse comparative que ni la source PDF ni le web seuls ne peuvent fournir\n\n**Cas d'usage concrets :**\n\n| Scénario | Valeur ajoutée |\n|----------|----------------|\n| **Rapport trimestriel** | Comparer performances entreprise vs. concurrents |\n| **Proposition commerciale** | Enrichir avec données marché récentes |\n| **Audit** | Vérifier conformité avec réglementations actualisées |\n| **Due diligence** | Croiser données fournies avec informations publiques |\n\n**Coût indicatif du workflow :**\n\n- **Étape 1** (Vision) : ~1499 tokens (image, usage constaté) + sortie variable\n- **Étape 2** (Web Search) : ~500 tokens input + 800 tokens output\n- **Total** : de l'ordre de ~2800 tokens avec `gpt-5-mini` ≈ $0.004\n\n> **Optimisation** : pour traiter des lots de documents, utiliser `batch API` pour réduire les coûts de 50%.</cell>\n>"
   },
   {
    "cell_type": "markdown",
@@ -1076,14 +1121,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "e8e3f082",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T21:30:00.600504Z",
-     "iopub.status.busy": "2026-06-07T21:30:00.600160Z",
-     "iopub.status.idle": "2026-06-07T21:30:53.360474Z",
-     "shell.execute_reply": "2026-06-07T21:30:53.358609Z"
+     "iopub.execute_input": "2026-06-19T19:28:09.239193Z",
+     "iopub.status.busy": "2026-06-19T19:28:09.239193Z",
+     "iopub.status.idle": "2026-06-19T19:29:14.888027Z",
+     "shell.execute_reply": "2026-06-19T19:29:14.888027Z"
     },
     "papermill": {
      "duration": 52.768417,
@@ -1107,7 +1152,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Affirmation extraite: \n",
+      "Affirmation extraite: L'affirmation principale est que la société vise une forte croissance au T2 : objectif de chiffre d'affaires de 3M EUR, soit +20% par rapport au T1, porté par le lancement du produit Alpha, l'expansion européenne et le recrutement de 20 ingénieurs.\n",
       "\n"
      ]
     },
@@ -1121,7 +1166,9 @@
       "[]\n",
       "[]\n",
       "[]\n",
-      "[ResponseOutputText(annotations=[AnnotationURLCitation(end_index=455, start_index=327, title='Gartner: Global AI Spending to Reach $2.5T in 2026 - HostingJournalist.com', type='url_citation', url='https://hostingjournalist.com/news/gartner-global-ai-spending-to-reach-2-5t-in-2026?utm_source=openai'), AnnotationURLCitation(end_index=760, start_index=636, title='Generative AI Market Size, Share | Industry Report, 2033', type='url_citation', url='https://www.grandviewresearch.com/industry-analysis/generative-ai-market-report?utm_source=openai'), AnnotationURLCitation(end_index=1213, start_index=1094, title='AI Capex Cycle 2026: $725B Hyperscaler Buildout — CFA Analysis', type='url_citation', url='https://alcapitaladvisory.com/research/intelligence/ai-infrastructure.html?utm_source=openai'), AnnotationURLCitation(end_index=1554, start_index=1402, title='IT spending set to hit $1.4 trillion in 2026 - but what exactly are we spending it on?', type='url_citation', url='https://www.techradar.com/pro/it-spending-set-to-hit-usd1-4-trillion-in-2026-but-what-exactly-are-we-spending-it-on?utm_source=openai'), AnnotationURLCitation(end_index=1898, start_index=1804, title='Cybersecurity Trends [2026]: Data, Threats & Predictions', type='url_citation', url='https://app.stationx.net/articles/cybersecurity-trends?utm_source=openai'), AnnotationURLCitation(end_index=2245, start_index=2158, title='5 Trends That Will Shape the Future of Tech Work in 2026 | Built In', type='url_citation', url='https://builtin.com/articles/5-tech-work-trends-2026?utm_source=openai'), AnnotationURLCitation(end_index=2807, start_index=2679, title='Gartner: Global AI Spending to Reach $2.5T in 2026 - HostingJournalist.com', type='url_citation', url='https://hostingjournalist.com/news/gartner-global-ai-spending-to-reach-2-5t-in-2026?utm_source=openai'), AnnotationURLCitation(end_index=3462, start_index=3342, title='AI INDEX REPORT 2026', type='url_citation', url='https://hai.stanford.edu/assets/files/ai_index_report_2026_chapter_4_economy.pdf?utm_source=openai'), AnnotationURLCitation(end_index=3725, start_index=3597, title='Gartner: Global AI Spending to Reach $2.5T in 2026 - HostingJournalist.com', type='url_citation', url='https://hostingjournalist.com/news/gartner-global-ai-spending-to-reach-2-5t-in-2026?utm_source=openai'), AnnotationURLCitation(end_index=3940, start_index=3821, title='AI Capex Cycle 2026: $725B Hyperscaler Buildout — CFA Analysis', type='url_citation', url='https://alcapitaladvisory.com/research/intelligence/ai-infrastructure.html?utm_source=openai'), AnnotationURLCitation(end_index=4155, start_index=4031, title='Generative AI Market Size, Share | Industry Report, 2033', type='url_citation', url='https://www.grandviewresearch.com/industry-analysis/generative-ai-market-report?utm_source=openai'), AnnotationURLCitation(end_index=4365, start_index=4245, title='AI INDEX REPORT 2026', type='url_citation', url='https://hai.stanford.edu/assets/files/ai_index_report_2026_chapter_4_economy.pdf?utm_source=openai'), AnnotationURLCitation(end_index=4579, start_index=4485, title='Cybersecurity Trends [2026]: Data, Threats & Predictions', type='url_citation', url='https://app.stationx.net/articles/cybersecurity-trends?utm_source=openai')], text='Résumé clair et vérifiable — oui, c’est réaliste, avec des nuances.\\n\\nPrincipales tendances de croissance du secteur tech en 2026 (points clés)\\n- L’intelligence artificielle (surtout le generative / agentic AI) est le moteur principal de croissance — dépenses mondiales en IA massives en 2026 (ordre de grandeur des trillions). ([hostingjournalist.com](https://hostingjournalist.com/news/gartner-global-ai-spending-to-reach-2-5t-in-2026?utm_source=openai))  \\n- Le marché du generative AI montre une forte croissance à court terme (estimations de la taille du marché en 2026 varient, p. ex. ~29–40+ milliards selon rapports commerciaux). ([grandviewresearch.com](https://www.grandviewresearch.com/industry-analysis/generative-ai-market-report?utm_source=openai))  \\n- Les hyperscalers (Amazon, Google/Alphabet, Microsoft, Meta, Oracle) lancent un cycle d’investissement massif en infrastructure IA — estimations récentes du capex IA pour 2026 ≈ $600–$725 milliards (sources d’analyses financières). Ce flux de capitaux alimente la demande en centres de données, puces spécialisées et mémoire HBM. ([alcapitaladvisory.com](https://alcapitaladvisory.com/research/intelligence/ai-infrastructure.html?utm_source=openai))  \\n- Cloud, transformation numérique et services IA-ops entraînent la hausse des dépenses IT en 2026 (croissance des budgets IT / cloud et montée des prestations de conseil technologique). ([techradar.com](https://www.techradar.com/pro/it-spending-set-to-hit-usd1-4-trillion-in-2026-but-what-exactly-are-we-spending-it-on?utm_source=openai))  \\n- Cybersécurité : budgets en forte hausse (estimates 2026 varient selon méthodologie, mais la tendance est nette — cent(s) de milliards $ alloués en 2026). La sécurité cloud, identity et MDR sont parmi les segments à la croissance la plus rapide. ([app.stationx.net](https://app.stationx.net/articles/cybersecurity-trends?utm_source=openai))  \\n- Effet sur l’emploi et les compétences : recrutement sélectif, hausse de la demande pour compétences IA (MLOps, prompt engineering, infra AI), mais ROI hétérogène — beaucoup d’organisations cherchent maintenant des résultats mesurables plutôt que des POC. ([builtin.com](https://builtin.com/articles/5-tech-work-trends-2026?utm_source=openai))\\n\\nEst-ce réaliste ?\\n- Oui : la plupart des indicateurs et rapports 2025–2026 convergent vers une année 2026 où l’IA (générative/agentique) et l’infrastructure associée sont les principaux vecteurs de croissance du secteur tech. Les hyperscalers ont confirmé (ou ajusté à la hausse) des programmes d’investissement massifs, et les dépenses des entreprises se réorientent vers IA, cloud et sécurité — ce sont des mouvements documentés. ([hostingjournalist.com](https://hostingjournalist.com/news/gartner-global-ai-spending-to-reach-2-5t-in-2026?utm_source=openai))  \\n- Nuances / risques à prendre en compte : estimations chiffrées varient fortement selon la méthodologie (quel périmètre on inclut : infra, services, logiciels, consulting, hardware?), le rendement (ROI) des projets IA reste inégal et la régulation / contraintes énergétiques / chaînes d’approvisionnement peuvent freiner ou redistribuer la croissance. Autrement dit, la tendance (IA-led growth + capex hyperscaler + sécurité + cloud) est solide — mais les chiffres précis et la répartition régionale/sectorielle restent incertains. ([hai.stanford.edu](https://hai.stanford.edu/assets/files/ai_index_report_2026_chapter_4_economy.pdf?utm_source=openai))\\n\\nSources récentes (exemples représentatifs — lectures recommandées)\\n- Gartner / analyses sur les dépenses IA et IT (prévisions 2026). ([hostingjournalist.com](https://hostingjournalist.com/news/gartner-global-ai-spending-to-reach-2-5t-in-2026?utm_source=openai))  \\n- Analyses sur le cycle d’investissement hyperscaler / capex IA (est. ~$600–725B pour 2026). ([alcapitaladvisory.com](https://alcapitaladvisory.com/research/intelligence/ai-infrastructure.html?utm_source=openai))  \\n- Grand View Research — rapport marché Generative AI (estimations de marché 2025–2026). ([grandviewresearch.com](https://www.grandviewresearch.com/industry-analysis/generative-ai-market-report?utm_source=openai))  \\n- Stanford AI Index 2026 — valeur économique et adoption (points sur ROI différencié). ([hai.stanford.edu](https://hai.stanford.edu/assets/files/ai_index_report_2026_chapter_4_economy.pdf?utm_source=openai))  \\n- Synthèses/rapports sectoriels sur cybersécurité et prévisions 2026 (Gartner / Statista / synthèses industrielles). ([app.stationx.net](https://app.stationx.net/articles/cybersecurity-trends?utm_source=openai))\\n\\nSouhaitez‑vous :\\n- que je produise un bref rapport (1–2 pages) avec chiffres comparés (Gartner / Stanford / Grand View / sources financières) ?  \\n- ou que j’affine l’analyse pour une sous‑branche précise (cloud infra, sécurité cloud, puces AI, SaaS, ou recrutement tech) avec citations détaillées et tableaux ?', type='output_text', logprobs=[])]\n"
+      "[]\n",
+      "[]\n",
+      "[ResponseOutputText(annotations=[AnnotationURLCitation(end_index=653, start_index=470, title='Gartner Forecasts Worldwide IT Spending to Grow 13.5% in 2026, Totaling $6.31 Trillion', type='url_citation', url='https://www.businesswire.com/news/home/20260422301495/en/Gartner-Forecasts-Worldwide-IT-Spending-to-Grow-13.5-in-2026-Totaling-%246.31-Trillion?utm_source=openai'), AnnotationURLCitation(end_index=1178, start_index=1039, title='McKinsey Global Tech Agenda 2026', type='url_citation', url='https://www.mckinsey.com/capabilities/mckinsey-technology/our-insights/mckinsey-global-tech-agenda-2026?utm_source=openai'), AnnotationURLCitation(end_index=1819, start_index=1721, title='SaaS Capital 2026 Bootstrapped Benchmarks — Operator Analysis', type='url_citation', url='https://stackswap.ai/saas-capital-bootstrapped-benchmarks-2026?utm_source=openai'), AnnotationURLCitation(end_index=2465, start_index=2381, title='Revenue per Engineer: benchmarks and findings from 300+ Companies', type='url_citation', url='https://getdx.com/report/revenue-per-engineer-2025/?utm_source=openai'), AnnotationURLCitation(end_index=2854, start_index=2770, title='ARR Per Employee: Benchmarks and Why They Matter — Fairview', type='url_citation', url='https://getfairview.com/blog/arr-per-employee?utm_source=openai'), AnnotationURLCitation(end_index=3390, start_index=3262, title='How to Reduce Time-to-Hire for Software Engineering Roles | daily.dev Recruiter', type='url_citation', url='https://recruiter.daily.dev/resources/reduce-time-to-hire-software-engineering-roles/?utm_source=openai'), AnnotationURLCitation(end_index=3911, start_index=3798, title='2026 Technology salary trends: The skills and roles driving growth | Robert Half', type='url_citation', url='https://www.roberthalf.com/us/en/insights/research/technology-salary-trends?utm_source=openai'), AnnotationURLCitation(end_index=5137, start_index=5009, title='How to Reduce Time-to-Hire for Software Engineering Roles | daily.dev Recruiter', type='url_citation', url='https://recruiter.daily.dev/resources/reduce-time-to-hire-software-engineering-roles/?utm_source=openai'), AnnotationURLCitation(end_index=6062, start_index=5978, title='ARR Per Employee: Benchmarks and Why They Matter — Fairview', type='url_citation', url='https://getfairview.com/blog/arr-per-employee?utm_source=openai'), AnnotationURLCitation(end_index=6356, start_index=6173, title='Gartner Forecasts Worldwide IT Spending to Grow 13.5% in 2026, Totaling $6.31 Trillion', type='url_citation', url='https://www.businesswire.com/news/home/20260422301495/en/Gartner-Forecasts-Worldwide-IT-Spending-to-Grow-13.5-in-2026-Totaling-%246.31-Trillion?utm_source=openai'), AnnotationURLCitation(end_index=6603, start_index=6464, title='McKinsey Global Tech Agenda 2026', type='url_citation', url='https://www.mckinsey.com/capabilities/mckinsey-technology/our-insights/mckinsey-global-tech-agenda-2026?utm_source=openai'), AnnotationURLCitation(end_index=6829, start_index=6731, title='SaaS Capital 2026 Bootstrapped Benchmarks — Operator Analysis', type='url_citation', url='https://stackswap.ai/saas-capital-bootstrapped-benchmarks-2026?utm_source=openai'), AnnotationURLCitation(end_index=7044, start_index=6960, title='Revenue per Engineer: benchmarks and findings from 300+ Companies', type='url_citation', url='https://getdx.com/report/revenue-per-engineer-2025/?utm_source=openai'), AnnotationURLCitation(end_index=7254, start_index=7141, title='2026 Technology salary trends: The skills and roles driving growth | Robert Half', type='url_citation', url='https://www.roberthalf.com/us/en/insights/research/technology-salary-trends?utm_source=openai')], text='Merci — je vérifie point par point. Résumé de l’affirmation et hypothèse implicite\\n- Objectif Q2 = 3,0 M€ soit +20% vs Q1. => Q1 implicite = 2,50 M€ (3,0 / 1,20).  \\n- Les leviers cités : lancement du produit \"Alpha\", expansion européenne, recrutement de 20 ingénieurs.\\n\\n1) Tendances macro / marché tech (2026)\\n- La dépense IT/tech mondiale reste en forte hausse en 2026 (Gartner prévoit +13,5 % de la dépense IT mondiale en 2026, porté par AI, cloud et infrastructure). ([businesswire.com](https://www.businesswire.com/news/home/20260422301495/en/Gartner-Forecasts-Worldwide-IT-Spending-to-Grow-13.5-in-2026-Totaling-%246.31-Trillion?utm_source=openai))  \\n- Les grandes études (McKinsey / MGI) montrent que l’IA et les infrastructures cloud sont les moteurs majeurs de croissance et d’investissement en 2026 ; l’Europe accélère ses investissements mais reste en rattrapage par rapport aux USA/Chine. Ces tendances rendent le contexte favorable aux lancements produits et expansions européennes, surtout si le produit est lié à l’IA/cloud. ([mckinsey.com](https://www.mckinsey.com/capabilities/mckinsey-technology/our-insights/mckinsey-global-tech-agenda-2026?utm_source=openai))\\n\\n2) Benchmarks de croissance pertinents (SaaS / tech scale-ups)\\n- Pour les entreprises SaaS/tech privées, les benchmarks 2025–2026 donnent des médianes annuelles variables selon le stade : beaucoup d’indices montrent une décélération relative mais des médianes still élevées (par ex. rapports synthétiques situent les croissances annuelles médianes entre ~15–30% selon le panel et stade). Une croissance séquentielle Q‑over‑Q de +20% sur un trimestre est élevée mais plausible comme saut ponctuel pour une scale-up si le pipeline est mature. ([stackswap.ai](https://stackswap.ai/saas-capital-bootstrapped-benchmarks-2026?utm_source=openai))\\n\\n3) Productivité attendue / \"revenue per engineer\" et conséquences du recrutement de 20 ingénieurs\\n- Benchmarks récents sur le \"revenue per engineer\" montrent de très fortes dispersions : top quartile >1,5 M$/ingénieur ; pour entreprises en phase de scale (~10–100 M$ ARR) des valeurs médianes se situent plus basses (quelques centaines de k$ à ~500k$ par ingénieur selon stade et modèle). Autrement dit, 20 ingénieurs n’apporteront pas mécaniquement 20× de revenu immédiat — la productivité par ingénieur prend du temps et dépend du modèle (PLG vs sales‑led). ([getdx.com](https://getdx.com/report/revenue-per-engineer-2025/?utm_source=openai))  \\n- Un benchmark \"ARR par employé\" montre qu’une entreprise autour de ~10 M$ ARR typique affiche en moyenne entre ~300k$–500k$ ARR par employé ; ajouter 20 ingénieurs sans revenu additionnel rapide réduit fortement ce ratio et pèse sur la trésorerie. (Conversion approximative selon le mix devises/ARR). ([getfairview.com](https://getfairview.com/blog/arr-per-employee?utm_source=openai))\\n\\n4) Temps et coûts d’embauche — impact opérationnel / délai d’impact commercial\\n- En 2026 le temps moyen \"time‑to‑hire\" pour ingénieurs reste long : études de recrutement indiquent des durées totales typiques de l’ordre de ~3–4 mois (≈ 12–19 semaines) pour les rôles tech en Europe dans un marché compétitif. Autrement dit, recruter 20 ingénieurs et les rendre pleinement productifs prendra plusieurs mois. ([recruiter.daily.dev](https://recruiter.daily.dev/resources/reduce-time-to-hire-software-engineering-roles/?utm_source=openai))  \\n- Les salaires/coûts varient fortement par pays européen (Nord/Ouest vs Europe de l’Est), mais les guides 2026 (ex. Robert Half + analyses sectorielles) montrent que la rémunération tech augmente modérée (≈ +1–4% selon spécialité) et que le coût total \"fully‑loaded\" par ingénieur (salaire + charges + équipement + onboarding) est significatif — engager 20 profils a donc un impact cash notable immédiat. ([roberthalf.com](https://www.roberthalf.com/us/en/insights/research/technology-salary-trends?utm_source=openai))\\n\\n5) Conclusion — l’affirmation est‑elle réaliste ?\\n- Purement chiffré : passer de 2,50 M€ à 3,00 M€ en Q2 demande +0,50 M€ (500 k€) de revenu additionnel dans le trimestre. Ce palier est atteignable en Q2 si, et seulement si, au moins un des leviers suivants est vrai au moment du lancement :  \\n  a) pipeline commercial pré‑qualifié suffisant (contrats signés/PO ou fortes opportunités proches de la clôture) ≥ 500 k€ de ventes réalisées/recognised au Q2 ;  \\n  b) Alpha est un lancement \"land and expand\" avec conversion rapide et onboarding facile (PLG / self‑serve) déjà prêt à scale ;  \\n  c) l’expansion européenne repose sur clients/partenaires locaux pré‑engagés (resellers, intégrateurs) qui convertissent immédiatement.  \\n- Ce qui rend l’objectif peu réaliste ou risqué : compter sur le recrutement de 20 ingénieurs comme moteur principal de revenu d’un trimestre. Le recrutement et la mise en productivité prennent typiquement plusieurs mois et coûtent de l’argent dès le début — ils augmentent surtout la capacité produit à moyen terme, pas le chiffre d’affaires instantané du trimestre. ([recruiter.daily.dev](https://recruiter.daily.dev/resources/reduce-time-to-hire-software-engineering-roles/?utm_source=openai))\\n\\n6) Recommandations opérationnelles (si vous devez convaincre le board / les investisseurs)\\n- Vérifier le pipeline commercial : demandez preuve (pipeline qualifié, taux de conversion, calendrier de closing) couvrant ≥ 500 k€ pour Q2. Sans preuve, réévaluer l’objectif.  \\n- Prioriser le go‑to‑market avant les grosses embauches : préférer contrats pilotes payants, partenariats locaux, ou BDRs/SDRs pour convertir Alpha rapidement.  \\n- Recrutement graduel + mix (contractors / nearshore / internal) pour accélérer time‑to‑value et limiter burn initial. Utiliser hiring sprint sur profils clés (3–5 lead engineers) avant montée à 20.  \\n- Suivre métriques claires : ARR par headcount, CAC payback, NRR/GRR, et ramp time des nouvelles recrues — et montrer scénarios (best/mid/worst) au COMEX. (Benchmarks SaaS récents utiles pour stress‑test). ([getfairview.com](https://getfairview.com/blog/arr-per-employee?utm_source=openai))\\n\\nSources principales utilisées (sélection pour vérification)\\n- Gartner — prévisions dépense IT 2026 (+13,5%). ([businesswire.com](https://www.businesswire.com/news/home/20260422301495/en/Gartner-Forecasts-Worldwide-IT-Spending-to-Grow-13.5-in-2026-Totaling-%246.31-Trillion?utm_source=openai))  \\n- McKinsey / MGI — tendances 2026 : AI, cloud, reconfiguration des investissements, position européenne. ([mckinsey.com](https://www.mckinsey.com/capabilities/mckinsey-technology/our-insights/mckinsey-global-tech-agenda-2026?utm_source=openai))  \\n- Rapports benchmarks 2025–2026 SaaS (SaaS Capital / Benchmarkit / synthèses) — médianes de croissance et attente par stade. ([stackswap.ai](https://stackswap.ai/saas-capital-bootstrapped-benchmarks-2026?utm_source=openai))  \\n- Études \"revenue per engineer\" / ARR per employee (GetDX, Cadence, Fairview) — productivité ingénierie & benchmarks par stade. ([getdx.com](https://getdx.com/report/revenue-per-engineer-2025/?utm_source=openai))  \\n- Recrutement / salaires / time‑to‑hire (Robert Half 2026 salary guide, études time‑to‑hire). ([roberthalf.com](https://www.roberthalf.com/us/en/insights/research/technology-salary-trends?utm_source=openai))\\n\\nSi vous voulez, je peux :\\n- Faire une évaluation chiffrée rapide (modèle) : scénario best/mid/worst pour Q2 (avec hypothèses : pipeline, conversion, délai d’embauche, coût par ingénieur) — il suffira que vous me donniez quelques chiffres : % du pipeline clos, mélange senior/junior des 20 ingénieurs, pays de recrutement, et si Alpha a déjà des pré‑ventes.  \\n- Ou extraire et vous remettre les passages exacts des rapports cités (Gartner, McKinsey, SaaS Capital) si vous avez besoin de citations prêtes pour le board.\\n\\nQuelle option préférez‑vous ?', type='output_text', logprobs=[])]\n"
      ]
     }
    ],
@@ -1129,7 +1176,9 @@
     "# Fact-checking : Vérifier une affirmation du document\n",
     "print(\"=== Vérification de faits ===\\n\")\n",
     "\n",
-    "# Extraire une affirmation spécifique\n",
+    "# Extraire une affirmation spécifique.\n",
+    "# Budget relevé à 4000 : à 200 l'extraction d'affirmation revenait vide, et la\n",
+    "# vérification web tournait sur un sujet générique au lieu d'une claim du document (#3571).\n",
     "claim_extraction = client.chat.completions.create(\n",
     "    model=DEFAULT_MODEL,\n",
     "    messages=[{\n",
@@ -1145,7 +1194,7 @@
     "            }\n",
     "        ]\n",
     "    }],\n",
-    "    max_completion_tokens=200\n",
+    "    max_completion_tokens=4000\n",
     ")\n",
     "\n",
     "claim = claim_extraction.choices[0].message.content\n",
@@ -1184,65 +1233,82 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation du fact-checking\n",
-    "\n",
-    "**Observation sur cette exécution :** l'extraction d'affirmation a renvoyé une\n",
-    "chaîne vide (`Affirmation extraite:` est vide) — aucune claim spécifique n'a pu\n",
-    "être isolée depuis le document. L'étape de vérification web a tout de même tourné,\n",
-    "mais sur un sujet générique (tendances tech 2026) plutôt que sur une affirmation\n",
-    "extraite du document. Le modèle a produit une analyse sourcée (14 citations web\n",
-    "réelles), mais elle ne vérifie pas une claim du document — elle répond à défaut à\n",
-    "une requête de substitution.\n",
-    "\n",
-    "**Méthodologie de vérification en 2 temps (lorsque l'extraction réussit) :**\n",
-    "\n",
-    "1. **Extraction de l'affirmation** : isolation de la claim spécifique du document\n",
-    "2. **Recherche contradictoire** : vérification avec sources externes actualisées\n",
-    "\n",
-    "**Indicateurs de fiabilité :**\n",
-    "\n",
-    "| Critère | Vérification |\n",
-    "|---------|--------------|\n",
-    "| **Nombre de sources** | ≥3 sources convergentes = forte fiabilité |\n",
-    "| **Dates des sources** | Sources < 1 mois = très fiables |\n",
-    "| **Autorité** | Sources officielles (institutions, médias réputés) |\n",
-    "| **Cohérence** | Concordance entre sources indépendantes |\n",
-    "\n",
-    "**Applications critiques :**\n",
-    "\n",
-    "- **Journalism** : Vérification automatisée de communiqués de presse\n",
-    "- **Compliance** : Détection de déclarations non conformes dans rapports\n",
-    "- **Legal** : Validation de faits dans documents contractuels\n",
-    "- **Research** : Cross-validation de données dans publications\n",
-    "\n",
-    "**Limites du fact-checking automatisé :**\n",
-    "\n",
-    "⚠️ **Biais des sources web** : Les résultats de recherche peuvent privilégier certaines sources  \n",
-    "⚠️ **Nuances manquées** : Affirmations partiellement vraies peuvent être mal évaluées  \n",
-    "⚠️ **Contexte temporel** : Une affirmation vraie en 2025 peut être fausse en 2026  \n",
-    "\n",
-    "> **Recommandation** : Toujours vérifier **manuellement** les citations fournies par le modèle. Le web search est un **outil d'aide**, pas un arbitre absolu de vérité."
-   ]
+   "source": "### Interprétation du fact-checking\n\nL'extraction isole l'affirmation principale du document (objectif CA Q2 de 3 M EUR,\n+20%, porté par le lancement du produit Alpha, l'expansion européenne et le\nrecrutement de 20 ingénieurs), puis la vérification web confronte cette claim aux\ntendances tech 2026. Le modèle produit une analyse sourcée (citations web réelles)\nqui évalue le réalisme de l'affirmation au regard du contexte sectoriel.\n\n**Méthodologie de vérification en 2 temps :**\n\n1. **Extraction de l'affirmation** : isolation de la claim spécifique du document\n2. **Recherche contradictoire** : vérification avec sources externes actualisées\n\n**Indicateurs de fiabilité :**\n\n| Critère | Vérification |\n|---------|--------------|\n| **Nombre de sources** | ≥3 sources convergentes = forte fiabilité |\n| **Dates des sources** | Sources < 1 mois = très fiables |\n| **Autorité** | Sources officielles (institutions, médias réputés) |\n| **Cohérence** | Concordance entre sources indépendantes |\n\n**Applications critiques :**\n\n- **Journalism** : Vérification automatisée de communiqués de presse\n- **Compliance** : Détection de déclarations non conformes dans rapports\n- **Legal** : Validation de faits dans documents contractuels\n- **Research** : Cross-validation de données dans publications\n\n**Limites du fact-checking automatisé :**\n\n⚠️ **Biais des sources web** : Les résultats de recherche peuvent privilégier certaines sources  \n⚠️ **Nuances manquées** : Affirmations partiellement vraies peuvent être mal évaluées  \n⚠️ **Contexte temporel** : Une affirmation vraie en 2025 peut être fausse en 2026  \n\n> **Recommandation** : Toujours vérifier **manuellement** les citations fournies par le modèle. Le web search est un **outil d'aide**, pas un arbitre absolu de vérité.</cell>\n>"
   },
   {
    "cell_type": "markdown",
    "id": "d9e38a38",
-   "source": "### Exercice 3 : Resume de recherche web sur un sujet technique\n\nCreez une fonction qui effectue une recherche web sur un sujet technique, extrait les points cles, et genere un resume structure avec les sources citees.\n\n**Objectif** : Utiliser la Responses API avec `web_search_preview` pour rechercher un sujet, puis formater la reponse avec les citations.\n\n**Indices** :\n- Utilisez `client.responses.create()` avec `tools=[{\"type\": \"web_search_preview\"}]`\n- Parcourez `response.output` pour trouver les items avec `hasattr(item, 'content')`\n- Pour chaque `ResponseOutputText`, le champ `text` contient le texte et `annotations` les citations\n- Formatez le resultat en listant : titre de la source, URL, et extrait pertinent",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Resume de recherche web sur un sujet technique\n",
+    "\n",
+    "Creez une fonction qui effectue une recherche web sur un sujet technique, extrait les points cles, et genere un resume structure avec les sources citees.\n",
+    "\n",
+    "**Objectif** : Utiliser la Responses API avec `web_search_preview` pour rechercher un sujet, puis formater la reponse avec les citations.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Utilisez `client.responses.create()` avec `tools=[{\"type\": \"web_search_preview\"}]`\n",
+    "- Parcourez `response.output` pour trouver les items avec `hasattr(item, 'content')`\n",
+    "- Pour chaque `ResponseOutputText`, le champ `text` contient le texte et `annotations` les citations\n",
+    "- Formatez le resultat en listant : titre de la source, URL, et extrait pertinent"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "c05d92d4",
-   "source": "# Exercice 3 : Resume de recherche web sur un sujet technique\n# TODO etudiant : Creez une fonction de recherche web avec extraction des sources\n\n# Etape 1 : Definir la fonction de recherche\n# def search_and_summarize(query: str) -> str:\n#     response = client.responses.create(\n#         model=DEFAULT_MODEL,\n#         tools=[{\"type\": \"web_search_preview\"}],\n#         input=query\n#     )\n#     sources = []\n#     summary = \"\"\n#     for item in response.output:\n#         if hasattr(item, 'content'):\n#             for content in item.content:\n#                 if hasattr(content, 'text'):\n#                     summary = content.text\n#                     for ann in content.annotations:\n#                         sources.append({\"title\": ann.title, \"url\": ann.url})\n#     return summary, sources\n\n# Etape 2 : Tester avec un sujet technique\n# resume, sources = search_and_summarize(\n#     \"Quelles sont les differences entre RAG et fine-tuning pour les LLMs en 2026?\"\n# )\n\n# Etape 3 : Afficher le resume et les sources\n# print(\"=== Resume ===\")\n# print(resume)\n# print(\"\\n=== Sources ===\")\n# for i, src in enumerate(sources, 1):\n#     print(f\"{i}. {src['title']}: {src['url']}\")\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T19:29:14.888027Z",
+     "iopub.status.busy": "2026-06-19T19:29:14.888027Z",
+     "iopub.status.idle": "2026-06-19T19:29:14.892909Z",
+     "shell.execute_reply": "2026-06-19T19:29:14.892909Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
     }
+   ],
+   "source": [
+    "# Exercice 3 : Resume de recherche web sur un sujet technique\n",
+    "# TODO etudiant : Creez une fonction de recherche web avec extraction des sources\n",
+    "\n",
+    "# Etape 1 : Definir la fonction de recherche\n",
+    "# def search_and_summarize(query: str) -> str:\n",
+    "#     response = client.responses.create(\n",
+    "#         model=DEFAULT_MODEL,\n",
+    "#         tools=[{\"type\": \"web_search_preview\"}],\n",
+    "#         input=query\n",
+    "#     )\n",
+    "#     sources = []\n",
+    "#     summary = \"\"\n",
+    "#     for item in response.output:\n",
+    "#         if hasattr(item, 'content'):\n",
+    "#             for content in item.content:\n",
+    "#                 if hasattr(content, 'text'):\n",
+    "#                     summary = content.text\n",
+    "#                     for ann in content.annotations:\n",
+    "#                         sources.append({\"title\": ann.title, \"url\": ann.url})\n",
+    "#     return summary, sources\n",
+    "\n",
+    "# Etape 2 : Tester avec un sujet technique\n",
+    "# resume, sources = search_and_summarize(\n",
+    "#     \"Quelles sont les differences entre RAG et fine-tuning pour les LLMs en 2026?\"\n",
+    "# )\n",
+    "\n",
+    "# Etape 3 : Afficher le resume et les sources\n",
+    "# print(\"=== Resume ===\")\n",
+    "# print(resume)\n",
+    "# print(\"\\n=== Sources ===\")\n",
+    "# for i, src in enumerate(sources, 1):\n",
+    "#     print(f\"{i}. {src['title']}: {src['url']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -1304,14 +1370,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "9701c657",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T21:30:53.396077Z",
-     "iopub.status.busy": "2026-06-07T21:30:53.395661Z",
-     "iopub.status.idle": "2026-06-07T21:30:53.401327Z",
-     "shell.execute_reply": "2026-06-07T21:30:53.400350Z"
+     "iopub.execute_input": "2026-06-19T19:29:14.894488Z",
+     "iopub.status.busy": "2026-06-19T19:29:14.894488Z",
+     "iopub.status.idle": "2026-06-19T19:29:14.897925Z",
+     "shell.execute_reply": "2026-06-19T19:29:14.897925Z"
     },
     "papermill": {
      "duration": 0.012174,
@@ -1429,7 +1495,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Summary

Adds `6_PDF_Web_Search.ipynb` to the **#3571 token-starvation fix** (5th GenAI/Texte notebook), companion to **#3663** (NB-2/5/9) and **#3666** (8_Reasoning_Models). PR **#3601** (audit #3164) had **aligned the markdown on the empty outputs** instead of repairing the cause — this de-consecrates per **Règle-F (#3660)**: « une correction plutôt que commenter des échecs ».

## Root cause

`gpt-5-mini` is a **reasoning model**. On the **3 cells that combine vision + `chat.completions`**, budgets of **200/300/500** were entirely consumed by reasoning, leaving `content` empty. The committed markdown (PR #3601) then **described the empty extraction as the expected result**.

> **Scope note:** the 2 *pure* `web_search_preview` cells (Responses API) were **NOT** token-starved — they returned sourced content already. Only the 3 **vision+chat** cells (where reasoning eats the low budget) were affected.

## Changes

**Budget bumps (`max_completion_tokens` → 4000) on 3 vision cells:**
- `f77b2375` document analysis (was 500)
- `76a872ee` document-image + web workflow, vision extraction step (was 300)
- `e8e3f082` fact-check claim extraction (was 200)

**Re-execution** via `nbconvert --execute --inplace` against **OpenAI-direct** gpt-5-mini (`OPENAI_DIRECT_API_KEY` + `https://api.openai.com/v1`). This endpoint override is **required** (not optional) because the `Responses API` + `web_search_preview` used by cells 76a872ee/e8e3f082 is **OpenAI-native and NOT supported by the OpenRouter proxy** in the repo default `.env` (verified: `responses.create` via OpenRouter fails with `'NoneType' object is not iterable`). The committed outputs carry `utm_source=openai` citations, confirming they were originally produced on OpenAI-direct — so this reproduces the canonical env faithfully.

Pre-flight verified (before full re-exec):
- vision@4000 via OpenRouter → real content ✅ (OpenRouter aliases bare `gpt-5-mini`)
- responses+web_search via OpenAI-direct → real sourced content ✅

**De-consecration of 3 markdown cells** that documented the empty extraction as expected:
- `4595cd74`: was « la sortie est restée vide » → now « le modèle extrait les 3 points clés » (CA 2,5M/+15%, 150 clients/+25%, 20 ingénieurs), added #3571 budget note
- `254cf977`: was « l'extraction a échoué silencieusement » → now describes the real pipeline (CA 2,5M/+15%/Q2 3M extracted → Gartner-sourced web contextualization)
- `1af18f09`: was « l'affirmation extraite est vide » → now describes the real claim extraction (3M EUR +20% via produit Alpha/expansion/recrutement) + web fact-check

Pedagogical structure (tables, architecture diagram, methodology) preserved — only the « Observation sur cette exécution » consecration blocks were rewritten on real outputs.

## Validation

- ✅ `nbconvert --execute --inplace` EXIT=0 (OpenAI-direct gpt-5-mini)
- ✅ 12 code cells, **0 errors, 0 null execution_count**
- ✅ **0 empty-content patterns remaining** — the 3 markers (`=== Analyse du document ===`, `Données extraites du document:`, `Affirmation extraite:`) are each followed by real content now
- ✅ Real outputs verified verbatim: cell7 « 1) CA 2,5 M EUR (+15%)… », cell19 « CA 2,5 M EUR / +15% / Q2 3M », cell22 « L'affirmation principale est que la société vise… 3M EUR +20% »
- ✅ Catalog byte-identical to `origin/main` (no churn)
- ✅ Secret scan: CLEAN (no `OPENAI_DIRECT`/`sk-` literals in diff)
- ✅ Scope strict (C.3): only `6_PDF_Web_Search.ipynb` modified

## Relation to #3571

`See #3571` (companion). The 3 GenAI/Texte token-starvation PRs now cover all affected notebooks:
- **#3663** — NB-2/5/9 (`Closes #3571`)
- **#3666** — 8_Reasoning_Models (`See #3571`)
- **#3667 (this)** — 6_PDF_Web_Search (`See #3571`)

ai-01 can close #3571 once these are merged. This is also a direct application of **#3660 (Règle-F)**: the recoverable failure (low token budget) is repaired + re-executed → real output → then prose, never aligned on the void.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>