### PR TITLE
docs(lean): add Conclusion / Prochaines étapes to Lean README (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -490,6 +490,30 @@ Les deux notebooks couvrent la theorie des nœuds sous des angles complementaire
 
 Lean-17a donne le *pourquoi* (motivation historique) ; Lean-17b donne le *comment* (calcul des invariants, port formel).
 
+## Conclusion / Prochaines étapes
+
+### Ce que vous avez appris
+
+Lean n'est pas un langage de programmation de plus : c'est le point où **le code devient une preuve**. En parcourant cette série, vous avez traversé le spectre de la vérification formelle :
+
+- **Les fondations** (Lean-1 Setup à Lean-6) : installer l'outil, manipuler les types dépendants, comprendre l'isomorphisme de Curry-Howard — un programme *est* une preuve, un type *est* une proposition.
+- **Prouver en pratique** (Lean-7 à Lean-12) : tactiques, lemmes, induction, l'art de *réduire* un énoncé jusqu'à ce que `rfl` ou `decide` le closent. Vous avez vu qu'une preuve formelle n'est pas une invention — c'est un dialogue avec un vérificateur qui n'accepte rien sur confiance.
+- **Les mathématiques vivantes** (Lean-13 à Lean-17b) : Game of Life (Hashlife), théorie des jeux sociaux (Arrow, Sen, Shapley), topologie (Grothendieck), théorie des nœuds (Piccirillo, tricolorabilité de Fox). Chaque domaine porté en Lean devient une *certification* — le `sorry` résiduel y est tracé comme une dette, pas caché.
+
+### Prochaines étapes
+
+- **Poussez un port jusqu'au bout** : le projet [`knot_lean/`](knot_lean/) est le companion formel de Lean-17b. Les invariants de nœuds (PD-codes, Reidemeister, Fox) y sont portés avec quelques `sorry` résiduels documentés — un terrain concret où une preuve formelle est *en cours*, pas achevée.
+- **Croisez avec la théorie des jeux** : les résultats formels d'Arrow/Sen/Shapley/Voting (notebooks 16b-16f) rencontrent la série **[GameTheory](../../GameTheory/)** — où le choix social est étudié à la fois formellement et computationnellement.
+- **Appliquez au monde réel** : la vérification formelle n'est pas qu'abstraite. La série **[SmartContracts](../SmartContracts/)** (SC-14) applique les mêmes principes aux smart contracts — SMT solvers automatiques bornés d'un côté, Lean interactif expressif de l'autre, même ambition : certifier la correction d'un programme exécuté.
+- **Élargissez au Web Sémantique** : les shapes SHACL sont des invariants sur les données, analogues aux spécifications Lean. La série **[SemanticWeb](../SemanticWeb/)** (SW-7 OWL, SW-8 SHACL) explore une autre face de la certification — valider la cohérence d'une base de connaissances plutôt que prouver un théorème.
+- **Relisez la série sous l'angle de la certification** : la [Lecture transversale](#lecture-transversale) relie ce geste — *certifier par changement de représentation* — à l'ensemble du dépôt CoursIA.
+
+### Le fil rouge
+
+Le titre annonce un solveur mathématique et de la vérification formelle. Mais le geste que cette série enseigne est plus profond : **ne rien laisser sur confiance**. Un `theorem` en Lean n'est pas une affirmation, c'est un objet vérifié mécaniquement ; un `sorry` n'est pas un raccourci, c'est un trou dans la chaîne de certification que l'on trace explicitement. Les domaines changent (topologie, choix social, nœuds, cellular automata), les tactiques changent (`induction`, `native_decide`, `aesop`), mais l'exigence reste — *prouver, pas supposer*. C'est elle que vous emportez au-delà de cette série.
+
+---
+
 ## Licence
 
 Voir la licence du repository principal.


### PR DESCRIPTION
See #2651 (Partie 2 — prose README harmonization). Partial contribution to an open epic, hence `See` (no auto-close).

## Context

3rd and final grain of the "most consulted" trio, per ai-01 directive (dashboard reply 2026-06-19T17:03Z, option 1 lightened): add the missing Conclusion section to each of the 8/9 SymbolicAI sub-series that lack it, 1 PR per series, atomic, markdown-only. After SmartContracts (#3659, merged) and SemanticWeb (#3667, open), **Lean** completes the trio.

## Changes

Added a `## Conclusion / Prochaines étapes` section to `Lean/README.md` (495 lines, previously ended on a one-line Licence body), inserted before `## Licence`:

- **Ce que vous avez appris** — synthesis of the verification arc: foundations (dependent types, Curry-Howard — a program *is* a proof), proving in practice (tactics, induction, the art of reducing until `rfl`/`decide` close it), and living mathematics (Game of Life/Hashlife, social choice Arrow-Sen-Shapley, Grothendieck topology, knot theory/Piccirillo) — each domain carried in Lean as a *certification* where residual `sorry` is traced debt, not hidden.
- **Prochaines étapes** — 5 bridges grounded in the README's existing "Connections cross-series": `knot_lean/` (the formal companion of Lean-17b, in-progress proofs), GameTheory (Arrow/Sen/Shapley/Voting 16b-16f), SmartContracts (SC-14 SMT-bounded vs Lean-expressive, same certification ambition), SemanticWeb (SHACL invariants as another face of certification), plus a link back to the transversal reading.
- **Le fil rouge** — closing on *ne rien laisser sur confiance*: a Lean theorem is a mechanically verified object, a `sorry` is traced debt; the demand to prove rather than assume outlives any domain or tactic.

## G.1 link verification (0 fabrication)

| Link | Target | Verified |
|------|--------|----------|
| `knot_lean/` | local project (Lean-17b companion) | exists |
| `../SmartContracts/` | `SymbolicAI/SmartContracts/` | exists |
| `../SemanticWeb/` | `SymbolicAI/SemanticWeb/` | exists |
| `../../GameTheory/` | `MyIA.AI.Notebooks/GameTheory/` | exists (out-of-SymbolicAI, same path pattern as #3659) |
| `#lecture-transversale` | heading `### Lecture transversale` (L419) | valid GitHub anchor |

## Validation

- Markdown-only (**+24/-0**, purely additive, symmetric to #3659/#3667)
- No notebook touched, no catalog regen (catalog-pr-hygiene HARD 1 — catalog byte-identical to main)
- Rule-E: <50 lines but content addition to an existing rich README (495 lines), not a standalone doc → atomique HARD 3 honored
- H.3 non-triggered (no notebooks)

@ai-01: markdown-only README, forensic `git diff` suffices for H.4. The "most consulted" trio (SmartContracts/SemanticWeb/Lean) is now complete; remaining sub-series for the Conclusion rollout: Tweety, Planners, Argument_Analysis, SymbolicLearning, plus SMT (light treatment per directive).