### PR TITLE
fix(app13-tsp): reframe fabricated 3-opt prose above three_opt stub (#3660)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
@@ -1962,9 +1962,9 @@
    "source": [
     "### Interpretation Bonus 2\n",
     "\n",
-    "Sur notre test, le **3-opt est moins performant que le 2-opt** : le cout final apres 3-opt est plus eleve que celui obtenu avec 2-opt.\n",
+    "Sur notre test, le cout affiche pour 3-opt (632.87) est **identique au cout initial NN** : `three_opt` est un **stub d'exercice** (`# TODO etudiant`) qui retourne le tour sans le modifier. Le cout \"3-opt\" ne reflete donc pas une vraie amelioration 3-opt a comparer au 2-opt (553.98).\n",
     "\n",
-    "Donc, dans cette implementation (version simple) et sur cette instance, **2-opt reste le meilleur compromis** entre qualite de solution et cout de calcul."
+    "**A vous de jouer** : completez `three_opt` (test des rearrangements de 3 aretes, complexite $O(n^3)$) et re-executez cette cellule pour comparer honnetement 3-opt vs 2-opt. La litterature indique que 3-opt produit generalement une solution au moins aussi bonne que 2-opt, au prix d'un cout de calcul plus eleve."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Grain #3660 (blast-radius ai-01 dispatch 18:07Z): App-13 `three_opt` prose, **missed by #3652**.

`App-13-TSP-Metaheuristics` idx39 said *"le 3-opt est moins performant que le 2-opt : le cout final apres 3-opt est plus eleve"*. But `three_opt` (idx38) is a **deliberate exercise stub** (`# TODO etudiant`) that returns the tour unchanged — its displayed cost (632.87) equals the **initial NN cost**, not a real 3-opt result. The prose was **fabricating an algorithmic comparison over a no-op** — same #3660 pattern as App-17/App-8 (prose commenting a stub/failure as if it were a real measurement).

## Fix (markdown-only, idx39)

Reframe to explain honestly that the displayed 3-opt cost is identical to NN because `three_opt` is an unimplemented stub, and invite the student to complete it and re-run for an honest 3-opt vs 2-opt comparison. Per dispatch: **reframe prose only — do NOT implement the stub** (it's an exercise).

## What is NOT changed
- **idx38 `three_opt` stub PRESERVED** (exercise #2161, `# TODO etudiant`). idx38 code source byte-unchanged → committed outputs (`Cout apres 3-opt: 632.87`) remain valid, **no re-exec needed**.

## Verification
- `git diff --stat`: 1 file, 2 ins / 2 del (only idx39 markdown source)
- Catalogue + MGS submodule **byte-identical** (3-dot)
- JSON valid; 0 control chars
- Real committed output confirmed: `Cout initial (NN): 632.87` / `Cout apres 2-opt: 553.98` / `Cout apres 3-opt: 632.87` (3-opt == NN = stub no-op)

See #3660

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>