### PR TITLE
fix(#3164): remove fabricated benchmark rows + de-consecrate empty output in 11_Quantization

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
@@ -6,10 +6,10 @@
    "id": "a1b2c3d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:15:05.167320Z",
-     "iopub.status.busy": "2026-06-06T07:15:05.166906Z",
-     "iopub.status.idle": "2026-06-06T07:15:05.172961Z",
-     "shell.execute_reply": "2026-06-06T07:15:05.172089Z"
+     "iopub.execute_input": "2026-06-19T21:28:04.783601Z",
+     "iopub.status.busy": "2026-06-19T21:28:04.783601Z",
+     "iopub.status.idle": "2026-06-19T21:28:04.788235Z",
+     "shell.execute_reply": "2026-06-19T21:28:04.788235Z"
     },
     "papermill": {
      "duration": 0.018549,
@@ -34,10 +34,10 @@
    "id": "86a62b2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:15:05.188327Z",
-     "iopub.status.busy": "2026-06-06T07:15:05.187776Z",
-     "iopub.status.idle": "2026-06-06T07:15:05.192138Z",
-     "shell.execute_reply": "2026-06-06T07:15:05.191212Z"
+     "iopub.execute_input": "2026-06-19T21:28:04.790586Z",
+     "iopub.status.busy": "2026-06-19T21:28:04.789584Z",
+     "iopub.status.idle": "2026-06-19T21:28:04.792708Z",
+     "shell.execute_reply": "2026-06-19T21:28:04.792708Z"
     },
     "papermill": {
      "duration": 0.01325,
@@ -174,10 +174,10 @@
    "id": "e5f6a7b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:15:05.257989Z",
-     "iopub.status.busy": "2026-06-06T07:15:05.257457Z",
-     "iopub.status.idle": "2026-06-06T07:17:34.165947Z",
-     "shell.execute_reply": "2026-06-06T07:17:34.164684Z"
+     "iopub.execute_input": "2026-06-19T21:28:04.794281Z",
+     "iopub.status.busy": "2026-06-19T21:28:04.794281Z",
+     "iopub.status.idle": "2026-06-19T21:29:23.990154Z",
+     "shell.execute_reply": "2026-06-19T21:29:23.990154Z"
     },
     "papermill": {
      "duration": 148.920017,
@@ -193,28 +193,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "  WARNING: The scripts hf.exe, huggingface-cli.exe and tiny-agents.exe are installed in 'C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\Scripts' which is not on PATH.\n",
-      "  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.\n",
-      "  WARNING: The script datasets-cli.exe is installed in 'C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\Scripts' which is not on PATH.\n",
-      "  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.\n",
-      "  WARNING: The script transformers.exe is installed in 'C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\Scripts' which is not on PATH.\n",
-      "  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.\n",
-      "ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "chatterbox-tts 0.1.7 requires diffusers==0.29.0, but you have diffusers 0.38.0 which is incompatible.\n",
-      "chatterbox-tts 0.1.7 requires gradio==6.8.0, but you have gradio 6.15.2 which is incompatible.\n",
-      "chatterbox-tts 0.1.7 requires safetensors==0.5.3, but you have safetensors 0.8.0rc0 which is incompatible.\n",
-      "chatterbox-tts 0.1.7 requires torch==2.6.0; python_version < \"3.14\", but you have torch 2.12.0 which is incompatible.\n",
-      "chatterbox-tts 0.1.7 requires torchaudio==2.6.0; python_version < \"3.14\", but you have torchaudio 2.11.0+cu126 which is incompatible.\n",
-      "chatterbox-tts 0.1.7 requires transformers==5.2.0, but you have transformers 5.10.2 which is incompatible.\n",
-      "nari-tts 0.1.0 requires torch==2.6.0, but you have torch 2.12.0 which is incompatible.\n",
-      "nari-tts 0.1.0 requires torchaudio==2.6.0, but you have torchaudio 2.11.0+cu126 which is incompatible.\n",
-      "qwen-tts 0.1.1 requires accelerate==1.12.0, but you have accelerate 1.13.0 which is incompatible.\n",
-      "qwen-tts 0.1.1 requires transformers==4.57.3, but you have transformers 5.10.2 which is incompatible.\n",
-      "sentence-transformers 4.1.0 requires transformers<5.0.0,>=4.41.0, but you have transformers 5.10.2 which is incompatible.\n",
       "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
+      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
       "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     },
@@ -338,10 +318,10 @@
    "id": "b8c9d0e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:34.210105Z",
-     "iopub.status.busy": "2026-06-06T07:17:34.209287Z",
-     "iopub.status.idle": "2026-06-06T07:17:34.217870Z",
-     "shell.execute_reply": "2026-06-06T07:17:34.216485Z"
+     "iopub.execute_input": "2026-06-19T21:29:23.992199Z",
+     "iopub.status.busy": "2026-06-19T21:29:23.992199Z",
+     "iopub.status.idle": "2026-06-19T21:29:23.997166Z",
+     "shell.execute_reply": "2026-06-19T21:29:23.997166Z"
     },
     "papermill": {
      "duration": 0.017846,
@@ -444,10 +424,10 @@
    "id": "145ba24f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:34.248931Z",
-     "iopub.status.busy": "2026-06-06T07:17:34.248117Z",
-     "iopub.status.idle": "2026-06-06T07:17:34.257348Z",
-     "shell.execute_reply": "2026-06-06T07:17:34.255872Z"
+     "iopub.execute_input": "2026-06-19T21:29:23.999637Z",
+     "iopub.status.busy": "2026-06-19T21:29:23.998480Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.002598Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.002598Z"
     },
     "papermill": {
      "duration": 0.017294,
@@ -632,10 +612,10 @@
    "id": "f2a3b4c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:34.314204Z",
-     "iopub.status.busy": "2026-06-06T07:17:34.313687Z",
-     "iopub.status.idle": "2026-06-06T07:17:34.322536Z",
-     "shell.execute_reply": "2026-06-06T07:17:34.321639Z"
+     "iopub.execute_input": "2026-06-19T21:29:24.004609Z",
+     "iopub.status.busy": "2026-06-19T21:29:24.004609Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.010122Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.009612Z"
     },
     "papermill": {
      "duration": 0.017746,
@@ -793,10 +773,10 @@
    "id": "c5d6e7f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:34.378543Z",
-     "iopub.status.busy": "2026-06-06T07:17:34.377819Z",
-     "iopub.status.idle": "2026-06-06T07:17:34.386611Z",
-     "shell.execute_reply": "2026-06-06T07:17:34.385444Z"
+     "iopub.execute_input": "2026-06-19T21:29:24.012128Z",
+     "iopub.status.busy": "2026-06-19T21:29:24.012128Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.016514Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.016146Z"
     },
     "papermill": {
      "duration": 0.020343,
@@ -987,10 +967,10 @@
    "id": "01c21b88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:34.416688Z",
-     "iopub.status.busy": "2026-06-06T07:17:34.416329Z",
-     "iopub.status.idle": "2026-06-06T07:17:34.423086Z",
-     "shell.execute_reply": "2026-06-06T07:17:34.422058Z"
+     "iopub.execute_input": "2026-06-19T21:29:24.018719Z",
+     "iopub.status.busy": "2026-06-19T21:29:24.017720Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.022898Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.022898Z"
     },
     "papermill": {
      "duration": 0.014718,
@@ -1153,10 +1133,10 @@
    "id": "f8a9b0c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:34.462637Z",
-     "iopub.status.busy": "2026-06-06T07:17:34.462309Z",
-     "iopub.status.idle": "2026-06-06T07:17:34.467982Z",
-     "shell.execute_reply": "2026-06-06T07:17:34.467097Z"
+     "iopub.execute_input": "2026-06-19T21:29:24.024919Z",
+     "iopub.status.busy": "2026-06-19T21:29:24.024919Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.028223Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.028223Z"
     },
     "papermill": {
      "duration": 0.015358,
@@ -1331,10 +1311,10 @@
    "id": "a20f8fa6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:34.498695Z",
-     "iopub.status.busy": "2026-06-06T07:17:34.498170Z",
-     "iopub.status.idle": "2026-06-06T07:17:34.505266Z",
-     "shell.execute_reply": "2026-06-06T07:17:34.504097Z"
+     "iopub.execute_input": "2026-06-19T21:29:24.030244Z",
+     "iopub.status.busy": "2026-06-19T21:29:24.029247Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.033750Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.033242Z"
     },
     "papermill": {
      "duration": 0.018227,
@@ -1487,10 +1467,10 @@
    "id": "c1d2e3f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:34.546947Z",
-     "iopub.status.busy": "2026-06-06T07:17:34.546383Z",
-     "iopub.status.idle": "2026-06-06T07:17:35.986680Z",
-     "shell.execute_reply": "2026-06-06T07:17:35.985630Z"
+     "iopub.execute_input": "2026-06-19T21:29:24.035202Z",
+     "iopub.status.busy": "2026-06-19T21:29:24.035202Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.660639Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.660639Z"
     },
     "papermill": {
      "duration": 1.448871,
@@ -1506,15 +1486,39 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".env charge depuis: d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n"
+      "WARNING: .env non trouve, utilisation variables environnement\n",
+      "Configurez OPENAI_API_KEY_2/3, OPENAI_BASE_URL_2/3, OPENAI_CHAT_MODEL_ID_2/3\n",
+      "Voir le fichier .env.example pour les details de configuration\n",
+      "Aucun endpoint vLLM local configure (OPENAI_BASE_URL_2/3 absents du .env).\n",
+      "Les benchmarks ci-apres proviennent de la stack de production (3x RTX 4090).\n"
      ]
     }
    ],
    "source": [
     "# Test des modeles quantifies deployes localement\n",
-    "# Utilise les endpoints configures dans .env\n",
+    "# Utilise les endpoints configures dans .env (OPENAI_API_KEY_2/3, OPENAI_BASE_URL_2/3)\n",
     "\n",
     "from openai import OpenAI\n",
+    "\n",
+    "# Chargement robuste de la configuration .env AVANT de lire les variables.\n",
+    "# On cherche le .env dans tous les parents (Papermill change le cwd).\n",
+    "env_loaded = False\n",
+    "current_path = Path.cwd()\n",
+    "for _ in range(10):\n",
+    "    env_path = current_path / \".env\"\n",
+    "    if env_path.exists():\n",
+    "        load_dotenv(env_path)\n",
+    "        env_loaded = True\n",
+    "        break\n",
+    "    current_path = current_path.parent\n",
+    "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
+    "        break\n",
+    "if env_loaded:\n",
+    "    print(f\".env charge depuis: {env_path}\")\n",
+    "else:\n",
+    "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
+    "    print(\"Configurez OPENAI_API_KEY_2/3, OPENAI_BASE_URL_2/3, OPENAI_CHAT_MODEL_ID_2/3\")\n",
+    "    print(\"Voir le fichier .env.example pour les details de configuration\")\n",
     "\n",
     "endpoints = []\n",
     "\n",
@@ -1561,27 +1565,8 @@
     "        print(f\"Erreur: {e}\")\n",
     "\n",
     "if not endpoints:\n",
-    "    pass\n",
-    "# Chargement robuste de la configuration .env\n",
-    "from dotenv import load_dotenv\n",
-    "import os\n",
-    "# Recherche du .env dans tous les parents (pour Papermill qui change le cwd)\n",
-    "current_path = Path.cwd()\n",
-    "env_loaded = False\n",
-    "for _ in range(10):\n",
-    "    env_path = current_path / \".env\"\n",
-    "    if env_path.exists():\n",
-    "        load_dotenv(env_path)\n",
-    "        print(f\".env charge depuis: {env_path}\")\n",
-    "        env_loaded = True\n",
-    "        break\n",
-    "    current_path = current_path.parent\n",
-    "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
-    "        break\n",
-    "if not env_loaded:\n",
-    "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
-    "    print(\"Configurez OPENAI_API_KEY_2/3, OPENAI_BASE_URL_2/3, OPENAI_CHAT_MODEL_ID_2/3\")\n",
-    "    print(\"Voir le fichier .env.example pour les details de configuration\")"
+    "    print(\"Aucun endpoint vLLM local configure (OPENAI_BASE_URL_2/3 absents du .env).\")\n",
+    "    print(\"Les benchmarks ci-apres proviennent de la stack de production (3x RTX 4090).\")\n"
    ]
   },
   {
@@ -1598,7 +1583,9 @@
     "tags": []
    },
    "source": [
-    "Les tests de performance sont terminés. La cellule suivante applique un correctif de compatibilité pour Pydantic 2.x, nécessaire pour les requêtes vers les endpoints de quantification via le SDK OpenAI."
+    "**Aucun endpoint vLLM local n'était configuré** (variables `OPENAI_BASE_URL_2/3` absentes du `.env`) : la cellule ci-dessus n'a donc exécuté aucun test d'inférence en direct. C'est le comportement attendu hors de la machine de production (3x RTX 4090) ; en cours, l'enseignant peut provisionner ces endpoints via `.env` pour exécuter le test live. Les benchmarks de qualité et de vitesse présentés dans la section suivante proviennent de notre stack de production, pas d'une exécution locale ici.\n",
+    "\n",
+    "La cellule suivante applique un correctif de compatibilité pour Pydantic 2.x, nécessaire pour les requêtes vers les endpoints de quantification via le SDK OpenAI."
    ]
   },
   {
@@ -1607,10 +1594,10 @@
    "id": "c52d5886",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:36.014289Z",
-     "iopub.status.busy": "2026-06-06T07:17:36.013832Z",
-     "iopub.status.idle": "2026-06-06T07:17:36.021155Z",
-     "shell.execute_reply": "2026-06-06T07:17:36.019906Z"
+     "iopub.execute_input": "2026-06-19T21:29:24.660639Z",
+     "iopub.status.busy": "2026-06-19T21:29:24.660639Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.665996Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.665996Z"
     },
     "papermill": {
      "duration": 0.016513,
@@ -1725,10 +1712,10 @@
    "id": "f4a5b6c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:36.067220Z",
-     "iopub.status.busy": "2026-06-06T07:17:36.066844Z",
-     "iopub.status.idle": "2026-06-06T07:17:36.078621Z",
-     "shell.execute_reply": "2026-06-06T07:17:36.077493Z"
+     "iopub.execute_input": "2026-06-19T21:29:24.667647Z",
+     "iopub.status.busy": "2026-06-19T21:29:24.667647Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.672370Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.672370Z"
     },
     "papermill": {
      "duration": 0.020809,
@@ -1847,14 +1834,15 @@
     "|----------|----------------|----------------|\n",
     "| Decode single-user | 86.2 tok/s | 135 tok/s |\n",
     "| Concurrent 5 users | 269.6 tok/s | 392 tok/s |\n",
-    "| TTFT 30K tokens | 0.95s | N/A |\n",
-    "| Tool calling | 893ms | N/A |\n",
+    "| Context max | 262K tokens | 131K tokens |\n",
+    "| KV cache (FP8) | 335K tokens | N/A |\n",
     "\n",
     "**Points cles** :\n",
     "1. La quantization 4-bit preserve remarquablement bien la qualite (88% sur GSM8K)\n",
     "2. ZwZ-8B (specialise vision) bat le modele 4x plus gros sur MMStar\n",
     "3. Le modele plus petit (8B, 1 GPU) est 1.5x plus rapide que le MoE (35B, 2 GPUs)\n",
-    "4. Le choix du modele depend du cas d'usage : specialise vs generaliste\n",
+    "4. Le MoE 35B tire parti du tensor-parallel (TP=2) pour doubler son contexte max\n",
+    "5. Le choix du modele depend du cas d'usage : specialise vs generaliste\n",
     "\n",
     "> **Conclusion pratique** : La quantization 4-bit est un **no-brainer** pour la production.\n",
     "> La perte de qualite est marginale, les gains en memoire et vitesse sont majeurs."
@@ -1897,10 +1885,10 @@
    "id": "c7d8e9f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-06T07:17:36.134262Z",
-     "iopub.status.busy": "2026-06-06T07:17:36.133871Z",
-     "iopub.status.idle": "2026-06-06T07:17:36.140834Z",
-     "shell.execute_reply": "2026-06-06T07:17:36.139740Z"
+     "iopub.execute_input": "2026-06-19T21:29:24.672370Z",
+     "iopub.status.busy": "2026-06-19T21:29:24.672370Z",
+     "iopub.status.idle": "2026-06-19T21:29:24.677654Z",
+     "shell.execute_reply": "2026-06-19T21:29:24.677654Z"
     },
     "papermill": {
      "duration": 0.017995,
@@ -2135,7 +2123,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Scope

Fidelity audit of `11_Quantization.ipynb` (Epic #3164, Règle-F #3660). Two fidelity grains found and fixed.

## Grains fixed

### 1. Fabricated benchmark rows (cell 33, `a5b6c7d8`) — HIGH

The **Performance (vitesse)** table cited two rows that exist in **no** committed output:
- `TTFT 30K tokens | 0.95s | N/A`
- `Tool calling | 893ms | N/A`

The data cell (`f4a5b6c7`, cell 32) prints only 4 metrics: Decode single-user, Concurrent 5 users, **Context max**, **KV cache (FP8)**. Replaced the two fabricated rows with the two real rows the data cell actually prints (`Context max 262K/131K`, `KV cache FP8 335K/N/A`). All 4 perf rows are now grounded by the cell output. (Same disease class as NB-10 LocalLlama.)

### 2. Void-consecration (cell 28, `i069zh3a5i`) — HIGH

Markdown said **« Les tests de performance sont terminés »** above a cell (27) whose only committed output was `.env charge depuis: ...`. The endpoint loop ran zero iterations.

**Root-cause (Règle-F reassessment):** this is **genuinely-external**, not recoverable. The vLLM endpoints (`OPENAI_BASE_URL_2`, `OPENAI_BASE_URL_3`) are **not provisioned** in the `.env` on non-production machines — verified directly:
```
OPENAI_API_KEY_2: MISSING
OPENAI_BASE_URL_2: MISSING
OPENAI_CHAT_MODEL_ID_2: MISSING
(same for _3)
```
So even after fixing the code bug below, the chat call would remain empty. This is NOT a token-budget/key-recoverable failure (#3571 class); it is the documented Scenario 2 already described honestly in cell 30. Rewrote cell 28 to state plainly that no local endpoint was configured and the benchmarks come from the production stack — de-consecrated the void, consistent with cell 30.

### 3. Bonus: real code-ordering bug (cell 27, `c1d2e3f4`)

`load_dotenv` (parent-walk) ran **after** the endpoint loop read `os.getenv("OPENAI_API_KEY_2/3")`, so `endpoints` was always empty even when keys were present. Moved the `.env` parent-walk **above** the getenv reads and replaced the silent `if not endpoints: pass` with an explicit message:
```
Aucun endpoint vLLM local configure (OPENAI_BASE_URL_2/3 absents du .env).
Les benchmarks ci-apres proviennent de la stack de production (3x RTX 4090).
```

## Validation (Règle C.2 + H.1)

- Re-executed via `jupyter nbconvert --execute --inplace` (BATCH_MODE=true, python3 kernel).
- **0 errors**, all 39 cells executed (`execution_count` set on every code cell).
- Cell 27 now produces honest output: `WARNING: .env non trouve...` + `Aucun endpoint vLLM local configure...`.
- 3 exercise stubs (cells 10/19/24, `# TODO etudiant`) preserved unchanged.
- No forbidden patterns (`raise NotImplementedError`, `assert False`, `1/0`): none.
- No catalog churn (`COURSE_CATALOG.generated.*` byte-identical to main).
- No secrets in diff (notebook reads only `os.getenv`, no inline literals).

## Diff scope

`1 file changed, 94 insertions(+), 106 deletions(-)` — localized to 3 cells (2 markdown + 1 code) plus re-executed outputs. Negative delta is output regeneration, not pedagogical content removal (anti-régression check passed: stubs + grounded markdown intact).

## Out of scope (intentionally not touched)

- Cell 26 (`b0c1d2e3`) reference data `206K tokens / 96-109 tok/s / 63% / ~12%` — unbacked by any cell output but framed as production-reference KV-cache config, not an interpretation of a specific cell. LOW severity; left untouched (no-pendulum — avoid over-correction).
- Cell 14 BitsAndBytes (genuinely-external GPU, already honestly hedged "Resultats attendus", "ignoree en BATCH_MODE").

See #3164