### PR TITLE
docs(planners): add Conclusion / Prochaines étapes to Planners README (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -637,6 +637,31 @@ Pour contribuer à cette série :
 3. Utiliser `scripts/notebook_tools/notebook_helpers.py` pour la manipulation
 4. Tester avec `python scripts/notebook_tools/notebook_tools.py validate`
 
+## Conclusion / Prochaines étapes
+
+### Ce que vous avez appris
+
+La planification automatique est le versant **décisionnel** de l'IA — là où le machine learning demande « que prédire ? », la planification demande « **que faire ?** ». Cette série en a parcouru tout le spectre :
+
+- **Les fondations classiques** (notebooks 1-4) : le triptyque État-Action-But, STRIPS, les heuristiques de recherche (A*, h-max, LM-cut). Vous avez vu qu'un plan n'est pas une prédiction — c'est une *séquence d'actions* justifiée par une structure de coût.
+- **Les standards et solveurs** (notebooks 5-7) : PDDL comme langage commun, Fast Downward, OR-Tools CP-SAT, le passage du « plan à la main » au « plan par solveur industriel ».
+- **La composition et la hiérarchie** (notebooks 8-9) : planification temporelle, réseaux de tâches hiérarchiques (HTN/SHOP2) — comment découper un but complexe en sous-but réutilisables.
+- **La synthèse neuro-symbolique** (notebooks 10-12) : plan repair par LLM, l'API unified-planning, et surtout *Learning to Plan* (notebook 12) — le point où l'apprentissage rencontre la planification, clôture naturelle de la série vers les foundation models.
+
+### Prochaines étapes
+
+- **Poussez vers l'apprentissage par renforcement** : un plan est une politique déterministe ; le RL en calcule une stochastique. Le pont vers les politiques apprises et le décisionnel sous incertitude se fait naturellement.
+- **Reliez au raisonnement formel** : les domaines PDDL formalisent un monde ; les ontologies OWL font de même. La série **[SemanticWeb](../SemanticWeb/)** offre la représentation, Planners l'exploite pour agir.
+- **Certifiez vos plans** : un plan correct n'est pas un plan sûr. La vérification formelle (séries **[Lean](../Lean/)** et **[SmartContracts](../SmartContracts/)**) s'applique aussi aux séquences d'actions critiques.
+- **Élargissez à la recherche adversariale** : la planification mono-agent rencontre la théorie des jeux multi-agents dans la série **[GameTheory](../../GameTheory/)** ; la recherche combinatoire (CSP, satisfaction de contraintes) se trouve dans la série **[Search](../../Search/)**.
+- Les tables « Ponts avec les autres séries » et « Cross-séries Bridges » ci-dessus cartographient l'ensemble de ces connexions ; la [Lecture transversale](../../../docs/grothendieckian-lens.md) les relie au fil rouge du dépôt.
+
+### Le fil rouge
+
+Le titre annonce la planification automatique. Mais le geste que cette série enseigne est plus simple : **transformer un but en action**. Les formalismes changent (STRIPS, PDDL, HTN), les solveurs changent (A*, Fast Downward, LLM), mais la structure reste — un état, un but, une séquence d'actions qui mène de l'un à l'autre. Le passage du *classique* au *neuro-symbolique* (notebook 12) ne change pas cette structure : il change qui la *cherche*. C'est elle que vous emportez au-delà de cette série.
+
+---
+
 ## Licence
 
 Voir la licence du repository principal.


### PR DESCRIPTION
See #2651 (Partie 2 — prose README harmonization). Partial contribution to an open epic, hence `See` (no auto-close).

## Context

5th grain of the family-wide "Conclusion / Prochaines étapes" rollout, per ai-01 directive (dashboard reply 2026-06-19T17:03Z, option 1 lightened). After the trio of "most consulted" (SmartContracts/SemanticWeb/Lean — merged) and Tweety (#3678, open), this is the **2nd grain of the 2nd tier**: **Planners** (the longest SymbolicAI sub-series at 646 lines).

## Changes

Added a `## Conclusion / Prochaines étapes` section to `Planners/README.md` (646 lines, previously ended on Licence + footer), inserted before `## Licence`:

- **Ce que vous avez appris** — synthesis of the arc: classical foundations (State-Action-Goal triptych, STRIPS, heuristics A*/h-max/LM-cut — *a plan is a cost-justified action sequence, not a prediction*) → standards & solvers (PDDL, Fast Downward, OR-Tools CP-SAT) → composition/hierarchy (temporal, HTN/SHOP2) → neuro-symbolic synthesis (LLM plan repair, unified-planning, *Learning to Plan* notebook 12 as the de facto capstone).
- **Prochaines étapes** — 4 bridges: RL (a policy is a stochastic plan), SemanticWeb (PDDL domains vs OWL ontologies), Lean/SmartContracts (certifying critical action sequences), GameTheory + Search (adversarial multi-agent and combinatorial CSP). Plus a pointer to the existing two cross-series tables and the transversal reading.
- **Le fil rouge** — closing on *turning a goal into an action*: the state-goal-action structure outlives any formalism (STRIPS/PDDL/HTN) or solver (A*/Fast Downward/LLM); the classical→neuro-symbolic shift (notebook 12) changes *who* searches the structure, not the structure.

**Theme angle**: Planners is the *decisional* side of AI — "que faire ?" vs "que prédire ?". Distinct from the certification angle (Lean), the explicability angle (Tweety), or the semantic angle (SemanticWeb).

## G.1 link verification (0 fabrication)

| Link | Target | Verified |
|------|--------|----------|
| `../SemanticWeb/` | `SymbolicAI/SemanticWeb/` | exists |
| `../Lean/` | `SymbolicAI/Lean/` | exists |
| `../SmartContracts/` | `SymbolicAI/SmartContracts/` | exists |
| `../../GameTheory/` | `MyIA.AI.Notebooks/GameTheory/` | exists (out-of-SymbolicAI) |
| `../../Search/` | `MyIA.AI.Notebooks/Search/` | exists (out-of-SymbolicAI) |
| `../../../docs/grothendieckian-lens.md` | transversal reading | exists |

## Scope note (G.5 / anti-churn)

The Planners README has **two redundant cross-series tables** ("Ponts avec les autres séries" L501, "Cross-séries Bridges" L512) — a pre-existing structural duplication. This PR **does not touch** those tables (out of scope for a Conclusion grain); the new section deliberately points to them rather than re-listing their bridges a third time. A future prose-quality pass could deduplicate the two tables, but that's a separate concern.

## Validation

- Markdown-only (**+25/-0**, purely additive)
- No notebook touched, no catalog regen (catalog-pr-hygiene HARD 1 — catalog byte-identical to main)
- Rule-E: <50 lines but content addition to an existing rich README (646 lines), not a standalone doc → atomique HARD 3 honored
- H.3 non-triggered (no notebooks)

@ai-01: markdown-only README, forensic `git diff` suffices for H.4. Remaining 2nd-tier: Argument_Analysis, SymbolicLearning, then SMT (light treatment per directive).