### PR TITLE
docs(app19-wfc): document Facile FEASIBLE non-determinism honestly (#3660)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
@@ -1139,7 +1139,9 @@
    "source": [
     "### Visualisation des niveaux par difficulté\n",
     "\n",
-    "Les trois configurations (Facile, Moyen, Difficile) sont résolues. La cellule suivante affiche les grilles obtenues côte à côte, avec le compteur d'ennemis, de clés et de coffres, ainsi que le taux de connectivité et le temps de résolution."
+    "Les trois configurations (Facile, Moyen, Difficile) sont résolues. La cellule suivante affiche les grilles obtenues côte à côte, avec le compteur d'ennemis, de clés et de coffres, ainsi que le taux de connectivité et le temps de résolution.\n",
+    "\n",
+    "> **Note sur le statut du solveur** : **Moyen** et **Difficile** atteignent le statut **OPTIMAL** (solution optimale prouvée en ~1 s). **Facile**, dont l'espace de recherche est plus large (ratios de sol 45–65 %, peu d'ennemis), s'arrête au statut **FEASIBLE** : le solveur trouve une solution valide mais ne prouve pas son optimalité dans le délai imparti (20 s), et le décompte exact d'ennemis/clés peut donc **varier d'une exécution à l'autre** (le `seed` fixe ne rend déterministe que le statut OPTIMAL, pas les solutions FEASIBLE). C'est un comportement attendu de CP-SAT, et l'une des raisons pour lesquelles on utilise un timeout en production."
    ]
   },
   {


### PR DESCRIPTION
## Summary

App-19 dispatch (#3660 blast-radius) said "raise timeout" for the Facile difficulty config. **G.1 firsthand verification** confirms Facile is **timeout-dominated** but **raising the timeout does NOT prove OPTIMAL** — so this is NOT a recoverable timeout failure.

## Evidence (verified firsthand on the EXACT Facile config idx24)

Facile idx24 config: 12×12, seed=42, `min_enemy_ratio=0.02, max_enemy_ratio=0.08, min_floor_ratio=0.45, max_floor_ratio=0.65, n_keys=1, n_chests=2`. Timeout ladder (re-run 2026-06-20):

```
timeout= 20s → FEASIBLE  20.03s  ennemis=2  sol=64
timeout= 60s → FEASIBLE  60.02s  ennemis=2  sol=64
timeout=120s → FEASIBLE 120.04s  ennemis=2  sol=64
```

**Conclusion (raffinée 20/06, corrige la preuve initiale)** :
- **Facile IS timeout-dominated** — it exits exactly at the timeout (20.03s/60.02s/120.04s ≈ the limit), not because it found a solution quickly. (My earlier PR draft claimed a 60s test but that test used the wrong config — 8×8 default ratios that return OPTIMAL in 0.17s. Re-done correctly above.)
- **BUT raising the timeout does NOT prove OPTIMAL** — even at 120s, the solver stays FEASIBLE. The dispatch's lever ("raise timeout → OPTIMAL") is **disproven** by the 120s run.
- The loose Facile instance (floor 45-65%, enemy 2-8%, generous ratios) creates a search space too large for CP-SAT to prove optimality in any reasonable budget. The committed FEASIBLE output is **genuine solver behavior**, not a fixable env/timeout issue (the #3660 recoverable-failure test fails on the timeout lever).
- idx10 (Moyen/Difficile) → OPTIMAL is deterministic and reproducible at workers=4: idx10 `OPTIMAL 1.45s ennemis=3 sol=43`, Moyen `OPTIMAL 1.11s`, Difficile `OPTIMAL 0.91s`.
- Setting workers=1 would make Facile deterministic **BUT breaks** OPTIMAL on idx10/Moyen/Difficile (workers=1 too slow to prove optimality in 20s) → would regress the idx11 "solution optimale" claim.

**Verdict**: the FEASIBLE result is **genuine solver behavior** (#3660 recoverable-failure test fails: the timeout lever does not recover OPTIMAL). Markdown-only honest documentation is the correct fix.

## Fix (markdown-only, idx25)

Add an honest solver-status note explaining that Moyen/Difficile reach **OPTIMAL** while Facile stops at **FEASIBLE** (loose instance = search space too large to prove optimality in the 20s budget; exact count varies run-to-run at workers=4). **No code change, no re-exec** — the committed FEASIBLE output is a valid run, and idx25 prose was generic ("résolues") and remains true.

## What is NOT changed

- `wfc_cpsat.py` **untouched** (reverted the workers=1 experiment — would regress OPTIMAL).
- idx10/24 code source + committed outputs unchanged (valid; no re-exec needed).
- No `# Solution`/`# Exemple resolu` cell removed.

## Verification

- `git diff --stat`: 1 file, 3 ins / 1 del (only idx25 markdown source)
- `wfc_cpsat.py` NOT in diff (0)
- Catalogue + MGS submodule **byte-identical** (3-dot); JSON valid; 0 control chars
- Timeout ladder re-run on exact Facile config confirms FEASIBLE at 20/60/120s

See #3660

🤖 Generated with [Claude Code](https://claude.com/claude-code)