### PR TITLE
docs(dsa-pandas): audit fidelite #3164 1.3-Pandas -- ancre McKinney 2010

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
@@ -57,7 +57,9 @@
     "Pandas fournit des structures de données et des outils d'analyse de données de haut niveau et faciles à utiliser. Les deux structures de données principales sont :\n",
     "\n",
     "*   **`Series`** : un tableau unidimensionnel avec des étiquettes (un peu comme une colonne dans une feuille de calcul).\n",
-    "*   **`DataFrame`** : une structure de données bidimensionnelle avec des étiquettes, similaire à une table de base de données ou une feuille de calcul Excel."
+    "*   **`DataFrame`** : une structure de données bidimensionnelle avec des étiquettes, similaire à une table de base de données ou une feuille de calcul Excel.\n",
+    "\n",
+    "> **Repère bibliographique.** Pandas et ses structures `Series`/`DataFrame` sont présentés dans l'article fondateur W. McKinney, *Data Structures for Statistical Computing in Python*, Proceedings of the 9th Python in Science Conference (SciPy), pp. 51-56, 2010. Le `DataFrame` y est conçu comme une structure étiquetée bidimensionnelle inspirée des *data frames* de R, optimisée pour l'analyse de données tabulaires. Voir aussi McKinney, *Python for Data Analysis*, O'Reilly, 3e éd., 2022, comme référence livresque de référence."
    ]
   },
   {
@@ -494,6 +496,17 @@
     "- Les resultats obtenus permettent de valider la comprehension\n",
     "\n",
     "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "1. W. McKinney, *Data Structures for Statistical Computing in Python*, Proceedings of the 9th Python in Science Conference (SciPy 2010), pp. 51-56, 2010. Article fondateur de Pandas : structures `Series` et `DataFrame`, conçues pour le calcul statistique sur données étiquetées.\n",
+    "2. W. McKinney, *Python for Data Analysis: Data Wrangling with Pandas, NumPy, and Jupyter*, O'Reilly Media, 3e édition, 2022. Référence livresque canonique sur l'usage pratique de Pandas (`groupby`, indexation, nettoyage).\n",
+    "3. T. Wes McKinney, *pandas: a Foundational Python Library for Data Analysis and Statistics*, 2011. Notes techniques complémentaires sur l'architecture interne de Pandas."
    ]
   }
  ],


### PR DESCRIPTION
## Audit fidélité #3164 — 1.3-Analyse_de_Donnees_avec_Pandas

**Sous-lot** : DataScienceWithAgents / 01-PythonForDataScience (famille po-2025, ai-01 ACK « sous-lots »).

**Verdict : OMISSION** (profil portage cours externe). Le notebook enseigne les structures `Series`/`DataFrame` comme objectifs d'apprentissage centraux (1-4) sans citer l'article fondateur SciPy. Aucune section References n'existait.

## Règle repair-not-consecrate (#3660) — NON TRIGGERÉE

Notebook **sain** : 8 code cells, `execution_count` 1-8, **0 erreur**, **0 output vide**. Aucune consécration de régression.

## Ancres ajoutées (markdown-only)

| # | Localisation | Concept | Citation canonique |
|---|--------------|---------|--------------------|
| 1 | Cellule 1 (Qu'est-ce que Pandas ?) | Structures `Series`/`DataFrame` | **McKinney 2010**, *Data Structures for Statistical Computing in Python*, SciPy 2010 proceedings pp. 51-56 |
| 2 | Nouvelle cellule References (fin) | Bibliographie | McKinney 2010, McKinney 2022 (*Python for Data Analysis*, O'Reilly 3e éd.), McKinney 2011 (notes techniques) |

## Yield honnête (G.5)

- **Series** + **DataFrame** = les 2 structures nommées centrales du notebook (objectifs 1-4) → **1 ancre couvrant les 2** (issues du même papier fondateur, pas 2 ancres séparées pour éviter le padding).

## Vérification G.1 (0 fabrication)

- **McKinney 2010, *Data Structures for Statistical Computing in Python*, SciPy 2010 pp. 51-56** = article fondateur Pandas, **web-vérifié** (proceedings.scipy.org, conference.scipy.org, Google Scholar 16k+ citations).
- **McKinney 2022, *Python for Data Analysis*, O'Reilly 3e éd.** = référence livresque canonique.

## Validation (gate complet)

- `notebook_tools validate` : **OK** (1 OK, 0 warning, 0 error)
- `scan_cell_ordering.py --severity HIGH` : **clean**
- **C.1** : aucune erreur volontaire dans le source
- **C.2/C.3** : markdown-only, churn `execution_count`/`outputs` = 0
- **Catalogue** : `COURSE_CATALOG.generated.{json,md}` byte-identique à `origin/main`
- **Anti-régression** : aucun code supprimé, ajout pur

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
