### PR TITLE
fix(#3164): de-fabricate tables + de-consecrate void + fix summary bug in 12_Test_Time_Scaling

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
@@ -6,10 +6,10 @@
    "id": "10ffd100",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:18:39.209541Z",
-     "iopub.status.busy": "2026-06-13T23:18:39.209075Z",
-     "iopub.status.idle": "2026-06-13T23:18:39.227397Z",
-     "shell.execute_reply": "2026-06-13T23:18:39.220756Z"
+     "iopub.execute_input": "2026-06-19T22:24:28.072795Z",
+     "iopub.status.busy": "2026-06-19T22:24:28.072795Z",
+     "iopub.status.idle": "2026-06-19T22:24:28.078536Z",
+     "shell.execute_reply": "2026-06-19T22:24:28.078000Z"
     },
     "papermill": {
      "duration": 0.033189,
@@ -94,10 +94,10 @@
    "id": "04ad8197",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:18:39.276194Z",
-     "iopub.status.busy": "2026-06-13T23:18:39.275925Z",
-     "iopub.status.idle": "2026-06-13T23:18:44.340435Z",
-     "shell.execute_reply": "2026-06-13T23:18:44.336142Z"
+     "iopub.execute_input": "2026-06-19T22:24:28.079547Z",
+     "iopub.status.busy": "2026-06-19T22:24:28.079547Z",
+     "iopub.status.idle": "2026-06-19T22:24:32.133477Z",
+     "shell.execute_reply": "2026-06-19T22:24:32.133477Z"
     },
     "papermill": {
      "duration": 5.076759,
@@ -110,6 +110,15 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -120,7 +129,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".env charge depuis : D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n"
+      ".env charge depuis : C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GenAI\\.env\n"
      ]
     },
     {
@@ -188,10 +197,10 @@
    "id": "31932452",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:18:44.372053Z",
-     "iopub.status.busy": "2026-06-13T23:18:44.369343Z",
-     "iopub.status.idle": "2026-06-13T23:18:47.249309Z",
-     "shell.execute_reply": "2026-06-13T23:18:47.244281Z"
+     "iopub.execute_input": "2026-06-19T22:24:32.135482Z",
+     "iopub.status.busy": "2026-06-19T22:24:32.135482Z",
+     "iopub.status.idle": "2026-06-19T22:24:33.192067Z",
+     "shell.execute_reply": "2026-06-19T22:24:33.191622Z"
     },
     "papermill": {
      "duration": 2.89917,
@@ -212,14 +221,15 @@
     }
    ],
    "source": [
-    "def chat(prompt, system=None, model=FAST_MODEL, temperature=0.0, max_tokens=2000):\n",
+    "def chat(prompt, system=None, model=FAST_MODEL, temperature=0.0, max_tokens=4000):\n",
     "    \"\"\"Appel unique au LLM. Renvoie une chaine vide en cas d'erreur\n",
     "    (le notebook ne doit jamais casser en BATCH_MODE).\n",
     "\n",
     "    Note : gpt-5-nano est un modele raisonnant qui consomme ~500-2000\n",
-    "    tokens de raisonnement INVISIBLES (comptes dans max_tokens). max_tokens\n",
-    "    doit donc rester large (2000 par defaut, jusqu'a 4000 pour la generation\n",
-    "    de code).\n",
+    "    tokens de raisonnement INVISIBLES (comptes dans max_tokens). Un budget\n",
+    "    trop bas (ex. 2000) laisse le raisonnement manger tout le plafond et\n",
+    "    renvoyer un contenu VIDE. max_tokens=4000 par defaut laisse assez de\n",
+    "    marge pour le raisonnement + la generation de code effective.\n",
     "    \"\"\"\n",
     "    messages = []\n",
     "    if system:\n",
@@ -286,10 +296,10 @@
    "id": "b19c8063",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:18:47.279086Z",
-     "iopub.status.busy": "2026-06-13T23:18:47.278603Z",
-     "iopub.status.idle": "2026-06-13T23:18:47.291735Z",
-     "shell.execute_reply": "2026-06-13T23:18:47.290274Z"
+     "iopub.execute_input": "2026-06-19T22:24:33.193271Z",
+     "iopub.status.busy": "2026-06-19T22:24:33.193271Z",
+     "iopub.status.idle": "2026-06-19T22:24:33.198331Z",
+     "shell.execute_reply": "2026-06-19T22:24:33.198331Z"
     },
     "papermill": {
      "duration": 0.021292,
@@ -373,10 +383,10 @@
    "id": "3788f1b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:18:47.309215Z",
-     "iopub.status.busy": "2026-06-13T23:18:47.308744Z",
-     "iopub.status.idle": "2026-06-13T23:18:48.177076Z",
-     "shell.execute_reply": "2026-06-13T23:18:48.175833Z"
+     "iopub.execute_input": "2026-06-19T22:24:33.199336Z",
+     "iopub.status.busy": "2026-06-19T22:24:33.199336Z",
+     "iopub.status.idle": "2026-06-19T22:24:33.878874Z",
+     "shell.execute_reply": "2026-06-19T22:24:33.878314Z"
     },
     "papermill": {
      "duration": 0.880036,
@@ -429,10 +439,10 @@
    "id": "cf466bee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:18:48.193858Z",
-     "iopub.status.busy": "2026-06-13T23:18:48.193322Z",
-     "iopub.status.idle": "2026-06-13T23:20:58.470139Z",
-     "shell.execute_reply": "2026-06-13T23:20:58.467921Z"
+     "iopub.execute_input": "2026-06-19T22:24:33.880458Z",
+     "iopub.status.busy": "2026-06-19T22:24:33.879908Z",
+     "iopub.status.idle": "2026-06-19T22:26:51.534796Z",
+     "shell.execute_reply": "2026-06-19T22:26:51.534213Z"
     },
     "papermill": {
      "duration": 130.29274,
@@ -509,14 +519,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  p2_parite        diff=2 -> 3/3 tests, ~16 tokens\n"
+      "  p2_parite        diff=2 -> 3/3 tests, ~36 tokens\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  p3_fizzbuzz      diff=3 -> 3/3 tests, ~40 tokens\n"
+      "  p3_fizzbuzz      diff=3 -> 3/3 tests, ~42 tokens\n"
      ]
     },
     {
@@ -542,12 +552,12 @@
       "======================================================================\n",
       "Probleme         | Diff |            Cheap |              Big\n",
       "----------------------------------------------------------------------\n",
-      "p1_carre         |    1 | 3/3 ~    8tok | 3/3 ~   16tok\n",
-      "p3_fizzbuzz      |    3 | 3/3 ~   35tok | 4/4 ~   70tok\n",
-      "p5_subsets       |    5 | 3/3 ~   23tok | 2/3 ~   40tok\n",
-      "p1_carre         |    1 | 3/3 ~    8tok | 3/3 ~   16tok\n",
-      "p3_fizzbuzz      |    3 | 3/3 ~   40tok | 0/4 ~    0tok\n",
-      "p5_subsets       |    5 | 3/3 ~   33tok | 0/3 ~    0tok\n"
+      "p1_carre         |    1 | 3/3 ~    8tok | 3/3 ~    8tok\n",
+      "p2_parite        |    2 | 3/3 ~   16tok | 3/3 ~   36tok\n",
+      "p3_fizzbuzz      |    3 | 3/3 ~   35tok | 3/3 ~   42tok\n",
+      "p4_palindrome    |    4 | 4/4 ~   70tok | 0/4 ~    0tok\n",
+      "p5_subsets       |    5 | 3/3 ~   23tok | 3/3 ~   33tok\n",
+      "p6_graph         |    6 | 2/3 ~   40tok | 0/3 ~    0tok\n"
      ]
     }
    ],
@@ -581,14 +591,17 @@
     "    (BIG_MODEL, \"big (gpt-5-nano)\"),\n",
     "])\n",
     "\n",
-    "# Affichage synthetique\n",
+    "# Affichage synthetique : on apparie cheap/big par id de probleme\n",
+    "# (resultats contient tous les cheap PUIS tous les big, il faut regrouper)\n",
     "print(\"\\n\" + \"=\" * 70)\n",
     "print(f\"{'Probleme':16s} | {'Diff':>4s} | {'Cheap':>16s} | {'Big':>16s}\")\n",
     "print(\"-\" * 70)\n",
-    "for i in range(0, len(RESULTATS_BASELINE), 2):\n",
-    "    cheap = RESULTATS_BASELINE[i]\n",
-    "    big = RESULTATS_BASELINE[i + 1]\n",
-    "    print(f\"{cheap['id']:16s} | {cheap['diff']:>4d} | {cheap['passes']}/{cheap['total']} ~{cheap['tokens']:>5d}tok | {big['passes']}/{big['total']} ~{big['tokens']:>5d}tok\")"
+    "_pids = [pb[\"id\"] for pb in _pbs]\n",
+    "for _pid in _pids:\n",
+    "    cheap = next((r for r in RESULTATS_BASELINE if r[\"id\"] == _pid and \"cheap\" in r[\"modele\"]), None)\n",
+    "    big = next((r for r in RESULTATS_BASELINE if r[\"id\"] == _pid and \"big\" in r[\"modele\"]), None)\n",
+    "    if cheap and big:\n",
+    "        print(f\"{cheap['id']:16s} | {cheap['diff']:>4d} | {cheap['passes']}/{cheap['total']} ~{cheap['tokens']:>5d}tok | {big['passes']}/{big['total']} ~{big['tokens']:>5d}tok\")"
    ]
   },
   {
@@ -604,26 +617,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : le size-scaling n'est pas toujours gagnant\n",
-    "\n",
-    "**Le signal attendu** : sur p1-p4, les deux modeles saturent (tout passe). C'est la **zone saturee** : le test-time scaling n'y ajoute rien, et le size-scaling non plus.\n",
-    "\n",
-    "**La surprise** (verifiee 2026-06-14) :\n",
-    "\n",
-    "| Probleme | Cheap (tokens) | Big (tokens) | Lecture |\n",
-    "|----------|----------------|--------------|---------|\n",
-    "| p1 a p4 | X/X | X/X | Sature : aucun gain |\n",
-    "| p5 subsets | 3/3 (~70tok) | 3/3 (~1538tok) | Big resout, mais **22x plus de tokens** |\n",
-    "| p6 graph | **2/3** (~112tok) | **0/3** (~2000tok) | **Big ECCHOUE** : le raisonnement l'enferme dans une mauvaise approche |\n",
-    "\n",
-    "**Conclusions** :\n",
-    "1. Le modele **gros raisonnant ECCHOUE** sur le probleme le plus dur, la ou le modele bon marche reussit partiellement. Le raisonnement peut etre **contre-productif** : il consomme des tokens sur une piste sterile.\n",
-    "2. Sur p5, le modele cheap resout a **70 tokens** ce que le big resout a **1538 tokens**. Le surcout de raisonnement n'achete **aucune performance supplementaire**.\n",
-    "3. L'overhead de raisonnement est un **cout**, pas un bonus gratuit.\n",
-    "\n",
-    "C'est precisement ce phenomene qui justifie le **test-time scaling** : si un modele gros peut perdre, il vaut mieux savoir **orchestrer** un modele cheap. Voyons comment."
-   ]
+   "source": "### Interpretation : le size-scaling n'est pas toujours gagnant\n\n**Le signal attendu** : sur p1-p3, les deux modeles saturent (tout passe). C'est la **zone saturee** : le test-time scaling n'y ajoute rien, et le size-scaling non plus.\n\n**Resultats mesures** (cheap = Llama-3.3-70b, big = gpt-5-nano) :\n\n| Probleme | Cheap | Big | Lecture |\n|----------|-------|-----|---------|\n| p1 a p3 | X/X (~8-35tok) | X/X (~8-42tok) | Sature : aucun gain, cout similaire |\n| p4 palindrome | 4/4 (~70tok) | **0/4 (~0tok)** | **Big ECCHOUE** (sortie vide) la ou cheap passe |\n| p5 subsets | 3/3 (~23tok) | 3/3 (~33tok) | Les deux passent, big legerement plus cher |\n| p6 graph | **2/3** (~40tok) | **0/3** (~0tok)** | **Big ECCHOUE** (sortie vide) la ou cheap reussit partiellement |\n\n**Conclusions** :\n1. Sur les problemes les plus durs (p4, p6), le modele **gros raisonnant ECCHOUE** : il renvoie une **sortie vide** (~0 tokens effectifs), la ou le modele bon marche reussit (4/4 sur p4) ou reussit partiellement (2/3 sur p6). Le surcout de raisonnement n'achete ici **aucune performance** -- au contraire.\n2. Sur p5, les deux modeles resolvent, big pour un cout legerement superieur (~33tok vs ~23tok). Le raisonnement n'est pas systematiquement contre-productif, mais il **n'apporte rien** non plus sur cette tache.\n3. L'overhead de raisonnement est un **cout**, pas un bonus gratuit -- et dans certains cas il conduit a un echec total (sortie vide).\n\n> **Note technique** : la sortie vide de gpt-5-nano (~0 tokens) sur p4/p6 n'est pas un crash : le modele raisonnant consomme son budget en tokens de raisonnement *invisibles* et ne produit pas de code extractible. C'est un echec de **formatage/generation**, pas d'incapacite brute -- mais du point de vue du benchmark, c'est bien un 0/4 et un 0/3.\n\nC'est precisement ce phenomene qui justifie le **test-time scaling** : si un modele gros peut echouer la ou un cheap reussit, il vaut mieux savoir **orchestrer** un modele cheap. Voyons comment."
   },
   {
    "cell_type": "markdown",
@@ -654,10 +648,10 @@
    "id": "81e404d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:20:58.540473Z",
-     "iopub.status.busy": "2026-06-13T23:20:58.539848Z",
-     "iopub.status.idle": "2026-06-13T23:20:58.553209Z",
-     "shell.execute_reply": "2026-06-13T23:20:58.551182Z"
+     "iopub.execute_input": "2026-06-19T22:26:51.535800Z",
+     "iopub.status.busy": "2026-06-19T22:26:51.535800Z",
+     "iopub.status.idle": "2026-06-19T22:26:51.539826Z",
+     "shell.execute_reply": "2026-06-19T22:26:51.539826Z"
     },
     "papermill": {
      "duration": 0.026828,
@@ -703,10 +697,10 @@
    "id": "4daaf185",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:20:58.577243Z",
-     "iopub.status.busy": "2026-06-13T23:20:58.576465Z",
-     "iopub.status.idle": "2026-06-13T23:22:43.119722Z",
-     "shell.execute_reply": "2026-06-13T23:22:43.117898Z"
+     "iopub.execute_input": "2026-06-19T22:26:51.541073Z",
+     "iopub.status.busy": "2026-06-19T22:26:51.541073Z",
+     "iopub.status.idle": "2026-06-19T22:28:46.436505Z",
+     "shell.execute_reply": "2026-06-19T22:28:46.435486Z"
     },
     "papermill": {
      "duration": 104.572591,
@@ -732,7 +726,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "p4_palindrome    | 4/4 ~   70tok | 4/4 ~   158tok | 4/4 ~    331tok\n"
+      "p4_palindrome    | 3/4 ~   96tok | 4/4 ~   229tok | 4/4 ~    350tok\n"
      ]
     },
     {
@@ -767,14 +761,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[(), (1,), (1, 2), (1, 2, 3), (1, 3), (2,), (2, 3), (3,)]\n"
+      "[(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[(), (1,), (1, 2), (1, 2, 3), (1, 3), (2,), (2, 3), (3,)]\n"
+      "[(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]\n"
      ]
     },
     {
@@ -796,14 +790,21 @@
      "output_type": "stream",
      "text": [
       "[(), (1,), (1, 2), (1, 2, 3), (1, 3), (2,), (2, 3), (3,)]\n",
-      "p5_subsets       | 3/3 ~   23tok | 3/3 ~    86tok | 3/3 ~    141tok\n"
+      "p5_subsets       | 3/3 ~   23tok | 3/3 ~    84tok | 3/3 ~    134tok\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "p6_graph         | 2/3 ~   45tok | 2/3 ~   120tok | 2/3 ~    289tok\n",
+      "[['A', 'C', 'F'], ['A', 'B', 'E', 'F']]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "p6_graph         | 2/3 ~   40tok | 2/3 ~   148tok | 2/3 ~    200tok\n",
       "\n",
       "(Appels API sur cette cellule : ~27)\n"
      ]
@@ -842,21 +843,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : Best-of-N ne casse pas l'erreur systematique\n",
-    "\n",
-    "**Resultats mesures** (cheap / Llama-3.3-70b) :\n",
-    "\n",
-    "| Probleme | N=1 | N=3 | N=5 |\n",
-    "|----------|-----|-----|-----|\n",
-    "| p4 palindrome | 4/4 | 4/4 | 4/4 (sature) |\n",
-    "| p5 subsets | 3/3 | 3/3 (~228tok) | 3/3 (~390tok) |\n",
-    "| p6 graph | 2/3 | 2/3 (~336tok) | 2/3 (~1045tok) |\n",
-    "\n",
-    "**Insight cible** : sur p6, le Best-of-N passe de 2/3 a... 2/3, peu importe N. Pourquoi ? Parce que l'erreur est **systematique** : le modele rate *toujours* le meme test (le tri par longueur puis lexicographique), de la meme maniere. Voter sur des tirages qui se trompent tous pareil ne change rien.\n",
-    "\n",
-    "> C'est la **lecon centrale** : la valeur du test-time scaling depend de la **structure d'erreur**. Erreur aleatoire -> BoN aide. Erreur systematique -> il faut une technique qui **corrige** (Reflexion), pas qui **vote**."
-   ]
+   "source": "### Interpretation : Best-of-N ne casse pas l'erreur systematique\n\n**Resultats mesures** (cheap / Llama-3.3-70b) :\n\n| Probleme | N=1 | N=3 | N=5 |\n|----------|-----|-----|-----|\n| p4 palindrome | 3/4 (~96tok) | 4/4 (~229tok) | 4/4 (~350tok, sature) |\n| p5 subsets | 3/3 (~23tok) | 3/3 (~84tok) | 3/3 (~134tok) |\n| p6 graph | 2/3 (~40tok) | 2/3 (~148tok) | 2/3 (~200tok) |\n\n**Insight cible** : sur p6, le Best-of-N passe de 2/3 a... 2/3, peu importe N. Pourquoi ? Parce que l'erreur est **systematique** : le modele rate *toujours* le meme test (le tri par longueur puis lexicographique), de la meme maniere. Voter sur des tirages qui se trompent tous pareil ne change rien.\n\n> C'est la **lecon centrale** : la valeur du test-time scaling depend de la **structure d'erreur**. Erreur aleatoire -> BoN aide (comme sur p4, ou l'on passe de 3/4 a 4/4). Erreur systematique -> il faut une technique qui **corrige** (Reflexion), pas qui **vote**."
   },
   {
    "cell_type": "markdown",
@@ -887,10 +874,10 @@
    "id": "5dd31d64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:22:43.280534Z",
-     "iopub.status.busy": "2026-06-13T23:22:43.279205Z",
-     "iopub.status.idle": "2026-06-13T23:22:43.296625Z",
-     "shell.execute_reply": "2026-06-13T23:22:43.295412Z"
+     "iopub.execute_input": "2026-06-19T22:28:46.437049Z",
+     "iopub.status.busy": "2026-06-19T22:28:46.437049Z",
+     "iopub.status.idle": "2026-06-19T22:28:46.442944Z",
+     "shell.execute_reply": "2026-06-19T22:28:46.442944Z"
     },
     "papermill": {
      "duration": 0.038604,
@@ -978,10 +965,10 @@
    "id": "745c8f26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:22:43.313307Z",
-     "iopub.status.busy": "2026-06-13T23:22:43.312802Z",
-     "iopub.status.idle": "2026-06-13T23:23:52.962125Z",
-     "shell.execute_reply": "2026-06-13T23:23:52.960102Z"
+     "iopub.execute_input": "2026-06-19T22:28:46.442944Z",
+     "iopub.status.busy": "2026-06-19T22:28:46.442944Z",
+     "iopub.status.idle": "2026-06-19T22:29:40.834317Z",
+     "shell.execute_reply": "2026-06-19T22:29:40.833300Z"
     },
     "papermill": {
      "duration": 69.666273,
@@ -1007,7 +994,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "p6_graph         | 2/3 ~   40tok | 2/3 ~  233tok | 2/3 ~     396tok\n",
+      "[['A', 'C', 'F'], ['A', 'B', 'E', 'F']]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "p6_graph         | 2/3 ~   40tok | 2/3 ~  244tok | 2/3 ~     475tok\n",
       "\n",
       "(Appels API : ~3 a 9 pour la Reflexion)\n"
      ]
@@ -1043,21 +1037,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : la Reflexion attaque l'erreur systematique\n",
-    "\n",
-    "La ou le Best-of-N restait bloque a 2/3 (erreur systematique), la Reflexion dispose de l'**information supplementaire** decisive : *quel test echoue, et pourquoi*. En remontrant au modele la trace d'execution (\"ECHEC : le tri n'est pas par longueur puis lexicographique\"), on lui donne de quoi corriger la **cause** de l'erreur plutot que de la rejouer.\n",
-    "\n",
-    "**Comparaison des strategies selon la structure d'erreur** :\n",
-    "\n",
-    "| Type d'erreur | Technique efficace | Pourquoi |\n",
-    "|---------------|--------------------|----------|\n",
-    "| Aleatoire | Best-of-N (vote) | Les tirages s'annulent |\n",
-    "| Systematique | Reflexion (feedback) | On corrige la cause |\n",
-    "| Aucune (sature) | Aucune | Rien a corriger |\n",
-    "\n",
-    "> **Note** : la Reflexion peut echouer si le modele est incapable, meme avec le feedback, de voir son erreur. Le test-time scaling a ses **limites** : il depend de la capacite du modele a exploiter le signal. C'est pourquoi le **routeur adaptatif** (section suivante) choisit la bonne technique selon la tache."
-   ]
+   "source": "### Interpretation : Reflexion, et ses limites\n\nLa ou le Best-of-N restait bloque a 2/3 (erreur systematique), la Reflexion dispose theoriquement de l'**information supplementaire** decisive : *quel test echoue, et pourquoi*. En remontrant au modele la trace d'execution (\"ECHEC : le tri n'est pas par longueur puis lexicographique\"), on lui donne de quoi corriger la **cause** de l'erreur plutot que de la rejouer.\n\n**Resultat mesure** : sur p6, la Reflexion atteint elle aussi **2/3** (~475tok) -- identique au baseline (2/3, ~40tok) et au BoN=5 (2/3, ~244tok). **La Reflexion n'a pas casse l'erreur systematique non plus**, malgré le feedback explicite sur le test qui échoue.\n\n**Pourquoi la Reflexion échoue ici** : le feedback dit *quel* test échoue, mais le modèle cheap (Llama-3.3-70b) n'arrive pas, même avec cette information, à produire le tri correct (par longueur puis lexicographique). Il persiste dans une approche alternative. C'est la limite fondamentale :\n\n> **Lecon centrale** : le test-time scaling a ses **limites**. Aucune technique (BoN, ni meme Reflexion avec feedback) ne corrige une erreur que le modèle ne *comprend* pas. Le gain dépend de la **capacité du modèle à exploiter le signal**, pas seulement de la quantité de calcul dépensée. C'est précisément pourquoi un **routeur adaptatif** (section suivante) reste utile -- non pour garantir le succès, mais pour **escalader intelligemment** et savoir quand s'arrêter.\n\n**Comparaison des strategies selon la structure d'erreur** :\n\n| Type d'erreur | Technique | Efficace ? |\n|---------------|-----------|------------|\n| Aleatoire | Best-of-N (vote) | Oui -- les tirages s'annulent (cf. p4 : 3/4 -> 4/4) |\n| Systematique (corrigible) | Reflexion (feedback) | Oui, *si* le modèle exploite le signal |\n| Systematique (non-corrigible) | Aucune | Non -- p6 en est l'exemple (2/3 partout) |\n| Aucune (sature) | Aucune | Rien a corriger |"
   },
   {
    "cell_type": "markdown",
@@ -1088,10 +1068,10 @@
    "id": "fab2daf2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:23:53.043985Z",
-     "iopub.status.busy": "2026-06-13T23:23:53.043288Z",
-     "iopub.status.idle": "2026-06-13T23:23:53.079493Z",
-     "shell.execute_reply": "2026-06-13T23:23:53.077372Z"
+     "iopub.execute_input": "2026-06-19T22:29:40.835306Z",
+     "iopub.status.busy": "2026-06-19T22:29:40.835306Z",
+     "iopub.status.idle": "2026-06-19T22:29:40.847453Z",
+     "shell.execute_reply": "2026-06-19T22:29:40.846429Z"
     },
     "papermill": {
      "duration": 0.050225,
@@ -1224,10 +1204,10 @@
    "id": "3b9ec70f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:23:53.126477Z",
-     "iopub.status.busy": "2026-06-13T23:23:53.125902Z",
-     "iopub.status.idle": "2026-06-13T23:24:41.552603Z",
-     "shell.execute_reply": "2026-06-13T23:24:41.547046Z"
+     "iopub.execute_input": "2026-06-19T22:29:40.849674Z",
+     "iopub.status.busy": "2026-06-19T22:29:40.849674Z",
+     "iopub.status.idle": "2026-06-19T22:30:17.627650Z",
+     "shell.execute_reply": "2026-06-19T22:30:17.627650Z"
     },
     "papermill": {
      "duration": 48.453903,
@@ -1267,7 +1247,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "p6_graph         |         5 |      reflexion | 2/3        |     432 |      7\n",
+      "p6_graph         |         4 |      reflexion | 2/3        |     427 |      7\n",
       "\n",
       "(Appels API : ~6 a 10)\n"
      ]
@@ -1354,28 +1334,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Synthese : size-scaling vs test-time scaling\n",
-    "\n",
-    "Le tableau ci-dessous resume les resultats mesures (2026-06-14) et incarne la **these centrale**.\n",
-    "\n",
-    "| Strategie | Probleme | Resultat | Tokens | Lecture |\n",
-    "|-----------|----------|----------|--------|---------|\n",
-    "| Single-shot cheap | p5 | 3/3 | ~70 | Resout, economique |\n",
-    "| Single-shot big | p5 | 3/3 | ~1538 | Resout, mais 22x plus cher |\n",
-    "| Single-shot cheap | p6 | **2/3** | ~112 | Erreur systematique |\n",
-    "| Single-shot big | p6 | **0/3** | ~2000 | Le raisonnement ENFERME le modele |\n",
-    "| BoN=5 cheap | p6 | 2/3 | ~1045 | Le vote ne casse pas l'erreur systematique |\n",
-    "| Reflexion cheap | p6 | 3/3 (vise) | ~300 | Le feedback corrige la cause |\n",
-    "\n",
-    "**La these en 3 points** :\n",
-    "\n",
-    "1. **Le size-scaling n'est pas universellement superieur.** Sur p6, le modele gros raisonnant *perd* contre le modele bon marche. Le raisonnement peut etre un piege.\n",
-    "2. **Le test-time scaling n'est pas un supplement universel.** Sur p1-p4 (sature), aucune strategie n'ajoute rien. Depenser du calcul la est du gaspillage.\n",
-    "3. **Le gain depend de la structure d'erreur.** Erreur aleatoire -> Best-of-N. Erreur systematique -> Reflexion (feedback). Le bon outil au bon moment.\n",
-    "\n",
-    "> **Conclusion** : optimiser un LLM, c'est naviguer un **espace 2D** (taille du modele x calcul a l'inference). Les deux axes **ne sont pas equivalents** et ne se substituent pas librement. Un modele bon marche bien orchestre peut battre un modele gros pour une fraction du cout - *sur certaines taches*."
-   ]
+   "source": "## Synthese : size-scaling vs test-time scaling\n\nLe tableau ci-dessous resume les resultats mesures et incarne la **these centrale**.\n\n| Strategie | Probleme | Resultat | Tokens | Lecture |\n|-----------|----------|----------|--------|---------|\n| Single-shot cheap | p4 | 4/4 | ~70 | Resout, economique |\n| Single-shot big | p4 | **0/4** | ~0 | Sortie vide : big echoue la ou cheap passe |\n| Single-shot cheap | p5 | 3/3 | ~23 | Resout, economique |\n| Single-shot big | p5 | 3/3 | ~33 | Resout, legerement plus cher |\n| Single-shot cheap | p6 | **2/3** | ~40 | Erreur systematique |\n| Single-shot big | p6 | **0/3** | ~0 | Sortie vide : big echoue la ou cheap reussit partiellement |\n| BoN=5 cheap | p6 | 2/3 | ~200 | Le vote ne casse pas l'erreur systematique |\n| Reflexion cheap | p6 | 2/3 | ~475 | Le feedback non plus : limite du test-time scaling |\n| Routeur cheap | p6 | 2/3 | ~427 | Escalade (baseline -> BoN -> reflexion) sans casser l'erreur |\n\n**La these en 3 points** :\n\n1. **Le size-scaling n'est pas universellement superieur.** Sur p4 et p6, le modele gros raisonnant *echoue* (sortie vide) la ou le modele bon marche reussit. Le raisonnement peut etre un piege -- voire conduire a un echec total.\n2. **Le test-time scaling n'est pas un supplement universel.** Sur p1-p3 (sature), aucune strategie n'ajoute rien. Depenser du calcul la est du gaspillage. Et sur p6, *aucune* technique test-time (BoN, Reflexion, routeur) ne casse l'erreur systematique.\n3. **Le gain depend de la structure d'erreur -- et de la capacite du modele.** Erreur aleatoire -> Best-of-N aide (p4 : 3/4 -> 4/4). Erreur systematique non-corrigible -> aucune technique n'aide (p6 : 2/3 partout).\n\n> **Conclusion** : optimiser un LLM, c'est naviguer un **espace 2D** (taille du modele x calcul a l'inference). Les deux axes **ne sont pas equivalents** et ne se substituent pas librement. Un modele bon marche bien orchestre peut battre un modele gros pour une fraction du cout - *sur certaines taches*. Mais le test-time scaling n'est pas magique : il est inutile sur les taches saturees et impuissant face aux erreurs que le modele ne comprend pas."
   },
   {
    "cell_type": "markdown",
@@ -1406,10 +1365,10 @@
    "id": "c4c525ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:24:41.676358Z",
-     "iopub.status.busy": "2026-06-13T23:24:41.675697Z",
-     "iopub.status.idle": "2026-06-13T23:24:41.690334Z",
-     "shell.execute_reply": "2026-06-13T23:24:41.686224Z"
+     "iopub.execute_input": "2026-06-19T22:30:17.629794Z",
+     "iopub.status.busy": "2026-06-19T22:30:17.629794Z",
+     "iopub.status.idle": "2026-06-19T22:30:17.634228Z",
+     "shell.execute_reply": "2026-06-19T22:30:17.634228Z"
     },
     "papermill": {
      "duration": 0.037235,
@@ -1481,10 +1440,10 @@
    "id": "e62422fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:24:41.756236Z",
-     "iopub.status.busy": "2026-06-13T23:24:41.755760Z",
-     "iopub.status.idle": "2026-06-13T23:24:41.773913Z",
-     "shell.execute_reply": "2026-06-13T23:24:41.770636Z"
+     "iopub.execute_input": "2026-06-19T22:30:17.636313Z",
+     "iopub.status.busy": "2026-06-19T22:30:17.636313Z",
+     "iopub.status.idle": "2026-06-19T22:30:17.639804Z",
+     "shell.execute_reply": "2026-06-19T22:30:17.639804Z"
     },
     "papermill": {
      "duration": 0.041314,
@@ -1564,10 +1523,10 @@
    "id": "83632a26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T23:24:41.830950Z",
-     "iopub.status.busy": "2026-06-13T23:24:41.830240Z",
-     "iopub.status.idle": "2026-06-13T23:24:41.843603Z",
-     "shell.execute_reply": "2026-06-13T23:24:41.841595Z"
+     "iopub.execute_input": "2026-06-19T22:30:17.641822Z",
+     "iopub.status.busy": "2026-06-19T22:30:17.640812Z",
+     "iopub.status.idle": "2026-06-19T22:30:17.644839Z",
+     "shell.execute_reply": "2026-06-19T22:30:17.644839Z"
     },
     "papermill": {
      "duration": 0.029854,
@@ -1688,7 +1647,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Scope

Fidelity audit of `12_Test_Time_Scaling.ipynb` (Epic #3164, Rule-F #3660). **Most severe grain in the GenAI/Texte series so far** — the 4 interpretation markdowns systematically fabricated token counts and consecrated empty/failed outputs to fit a pre-written narrative.

## Grains fixed

### 1. Fabricated token counts throughout the interpretation tables (cells 9, 13, 22) — HIGH

The interpretation markdowns cited numbers absent from (or inflated vs) the actual committed outputs:
- **cell 9**: \"~70tok / ~1538tok / 22x more\" for p5 (real ~23 / ~33, ratio ~1.4x); \"~112tok / ~2000tok\" for p6 framed as \"reasoning that traps the model\" (real ~40 / **~0 EMPTY**).
- **cell 13** (BoN): \"~228 / ~390tok\" (p5) and \"~336 / ~1045tok\" (p6) — inflated 2.7-3.6x (real ~84/134, ~148/200). Pass counts were correct.
- **cell 22** (synthesis): repeated all fabricated numbers.

All tables rewritten with the real measured numbers.

### 2. Consecration of empty outputs as causal story (cells 9, 17, 22) — HIGH

gpt-5-nano returned **EMPTY outputs (~0tok)** on p4 and p6. The original markdown dressed the void as \"2000tok of reasoning that trapped the model\" — a fabricated causal story with **no output to support it** (you cannot reason about reasoning-behavior from an empty string).

**Rule-F root cause (verified firsthand):** the `chat()` default budget was `max_tokens=2000`, which starves a reasoning model (reasoning tokens consume the budget → no extractable code). The cell-4 docstring itself warns about this. **Raised to 4000** and re-executed end-to-end against OpenRouter (`BATCH_MODE=false`, ~58 real API calls, EXIT=0).

After re-exec, gpt-5-nano **STILL** returns empty on p4/p6. **No-pendulum**: accept the real result, do not force a story. The narrative was rewritten honestly: \"big fails (empty output) where cheap succeeds\" holds for p4/p6; the fabricated \"22x cost\" does not — big p5 only costs ~1.4x cheap p5.

### 3. Central narrative fabricated a Reflexion success (cells 17, 22) — HIGH (most damaging)

The original thesis arc was: \"BoN fails on systematic error → Reflexion fixes it (**3/3 visé**)\". The **REAL committed Reflexion output is 2/3** — Reflexion ALSO failed. The whole Moteur-2 section and the synthesis row consecrated a non-existent success.

Rewritten to the honest and pedagogically **richer** lesson: \"test-time scaling has LIMITS — no technique (BoN, nor Reflexion with feedback) fixes an error the model does not understand.\" This was already a footnote in the original; elevated to the central lesson, now grounded in real 2/3 data (Baseline 2/3, BoN=5 2/3, Reflexion 2/3 — all fail on p6's systematic error).

### 4. Bonus: real summary-table bug (cell 8) — code fix

The summary table had a **real pairing bug**: it iterated `RESULTATS_BASELINE` by stride-2 assuming `[cheap_p1, big_p1, cheap_p2, ...]` order, but `mesure_baseline` emits `[cheap_p1..cheap_p6, big_p1..big_p6]`. So the summary printed p1/p3/p5 **TWICE** with inconsistent numbers and never showed p2/p4/p6. Rewrote to pair cheap/big by problem id. Now all 6 problems display correctly.

## Validation (C.2 + H.1)

- Re-exec `jupyter nbconvert --execute --inplace`, `BATCH_MODE=false`, python3 kernel, EXIT=0.
- **0 errors**, all 15 code cells have `execution_count`.
- Outputs reflect real ~58 API calls (Llama-3.3-70b + gpt-5-nano via OpenRouter).
- 3 exercise stubs (cells 24/26/28, `# TODO etudiant`) preserved unchanged.
- 0 forbidden patterns (`raise NotImplementedError`, `assert False`, `1/0`).
- Cross-check G.1: every number in the rewritten markdowns matches the committed output (\"22x\"/\"1538\"/\"3/3 visé\" all gone; \"2/3 échec\" confirmed).
- No catalog churn; no secrets in diff.

## Diff scope

`1 file changed, 117 insertions(+), 158 deletions(-)` — negative delta is fabricated-markdown removal + output regeneration, **not** pedagogical content removal. The narrative structure (size-scaling vs test-time scaling, error-structure taxonomy, router) is preserved; only the numbers and the overstated conclusions are corrected to reality.

## Out of scope (intentionally not touched)

- Theory/citation markdowns (cells 1, 2, 10, 14, 18, 20, 29, 30 — Snell/Wang/Madaan/Shinn/Yao + ICR repo): general knowledge, no contradicting measured number.
- ToT cell 19 (deterministic, real solutions, honest \"Aucun appel API\"): already clean.
- Router cell 21: already honest (2/3, no fabricated success).

See #3164