### PR TITLE
docs(argument-analysis): add Conclusion / Prochaines étapes to README (See #2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -273,6 +273,31 @@ Le pipeline mobilise un vocabulaire issu de trois traditions — la rhétorique 
 
 > **Note** : Le pipeline s'exécute de bout en bout. L'`Executor` (point d'entrée Papermill/MCP) produit une validation `COMPLETE_VALIDATED` à 100 % (1 argument identifié, 4 sophismes, 1 belief set formel, 10 requêtes au solveur).
 
+## Conclusion / Prochaines étapes
+
+### Ce que vous avez appris
+
+Argument_Analysis est la série-pivot du dépôt : celle où le langage naturel rencontre le formel, médié par un LLM. En suivant le pipeline, vous avez appris à découper un texte argumentatif en couches de rigueur croissante :
+
+- **L'extraction informelle** : un LLM isole prémisses, conclusions, transitions, et confronte chaque passage suspect à la taxonomie des sophismes (1406 nœuds, 7 familles). C'est le versant *vrai mais approximatif* — rapide, contextuel, mais sans garantie.
+- **La formalisation** : les arguments informels deviennent un belief set propositionnel. Le texte fluide cède la place à des énoncés booléens que l'on peut *interroger*.
+- **La validation formelle** : Tweety (via le pont JPype) interroge ce belief set — une dizaine de requêtes SAT — pour confirmer la cohérence interne : pas de contradiction masquée, pas de conclusion tirée sans prémisse. C'est le versant *sûr mais borné* — lent, rigide, mais fiable.
+- **L'orchestration agentique** : Semantic Kernel assemble les briques en un pipeline reproductible, avec un mode *fail-loud* — si la JVM manque, le pipeline échoue bruyamment plutôt que de simuler un verdict.
+
+### Prochaines étapes
+
+- **Approfondissez le backend formel** : chaque requête SAT du pipeline s'appuie sur la théorie de l'argumentation. La série **[Tweety](../Tweety/)** (notebook 5 Dung, notebook 9 préférences/vote) est le socle logique que ce pipeline consomme.
+- **Maîtrisez le vérificateur** : la frontière « où s'arrête le LLM, où commence le formel » est aussi celle que trace la vérification formelle. La série **[Lean](../Lean/)** pousse la validation jusqu'à la preuve mathématique.
+- **Branchez les ontologies** : un belief set propositionnel est un graphe de connaissances minimal. La série **[SemanticWeb](../SemanticWeb/)** (OWL, SHACL) généralise cette idée à des raisonnements plus riches.
+- **Reliez au choix social** : les arguments de valeur et les préférences (Tweety-9) rejoignent la théorie du vote formalisée dans la série **[GameTheory](../../GameTheory/)**.
+- La [Lecture transversale](../../../docs/grothendieckian-lens.md) replace ce pipeline — *du langage naturel aux sémantiques formelles qu'on peut interroger* — dans le fil rouge du dépôt.
+
+### Le fil rouge
+
+Le titre annonce l'analyse d'arguments. Mais le geste que cette série enseigne est ailleurs : **tracer une frontière nette entre l'approximatif et le sûr**. Le LLM extrait vite mais sans garantie ; le solveur SAT valide lentement mais avec certitude. Le pipeline n'essaie pas de faire faire au LLM ce qu'il fait mal (garantir la cohérence), ni au solveur ce qu'il ne sait pas faire (lire un texte). Cette discipline du *bon outil pour la bonne tâche*, orchestrée en boucle convergente, est ce que vous emportez au-delà de cette série — et c'est le modèle le plus pragmatique, dans ce dépôt, d'une IA générative ancrée sur du vérifiable.
+
+---
+
 ## Ressources
 
 ### Références académiques


### PR DESCRIPTION
See #2651 (Partie 2 — prose README harmonization). Partial contribution to an open epic, hence `See` (no auto-close).

## Context

6th grain of the family-wide "Conclusion / Prochaines étapes" rollout, per ai-01 directive (option 1 lightened). After the trio (SmartContracts/SemanticWeb/Lean — merged), Tweety (#3678 open), Planners (#3685 open), this is the **3rd grain of the 2nd tier**: **Argument_Analysis** (the shortest SymbolicAI sub-series at 295 lines).

Argument_Analysis is the **pivot sub-series** of the repo: the only one that *assembles* LLM + formal solver + agent orchestration to turn natural-language arguments into a verifiable formal map (LLM extraction → Tweety SAT validation via JPype → Semantic Kernel orchestration, fail-loud mode).

## Changes

Added a `## Conclusion / Prochaines étapes` section, inserted before `## Ressources` (canonical position: the conclusion synthesizes the arc, then external resources follow, then license):

- **Ce que vous avez appris** — the 4 layers of increasing rigor: informal extraction (LLM isolates premises/conclusions/fallacies against the 1406-node taxonomy — *true-but-approximate*) → formalization (text becomes a propositional belief set one can query) → formal validation (Tweety SAT, ~10 queries — *safe-but-bounded* coherence check) → agent orchestration (Semantic Kernel, fail-loud if JVM missing).
- **Prochaines étapes** — 4 bridges grounded in the existing `## Ponts avec les autres séries` table: Tweety (the formal backend, notebooks 5/9), Lean (the same LLM/verifier frontier pushed to mathematical proof), SemanticWeb (belief set as a minimal knowledge graph → OWL/SHACL), GameTheory (value arguments & preferences → social choice). Plus a transversal reading pointer.
- **Le fil rouge** — closing on *a clean frontier between the approximate and the certain*: the LLM extracts fast-without-guarantee, the SAT solver validates slow-with-certainty, the pipeline assigns each tool what it does well. This good-tool-for-the-right-task discipline, orchestrated as a converging loop, is the repo's most pragmatic model of generative AI grounded on the verifiable.

## G.1 link verification (0 fabrication)

| Link | Target | Verified |
|------|--------|----------|
| `../Tweety/` | `SymbolicAI/Tweety/` | exists |
| `../Lean/` | `SymbolicAI/Lean/` | exists |
| `../SemanticWeb/` | `SymbolicAI/SemanticWeb/` | exists |
| `../../GameTheory/` | `MyIA.AI.Notebooks/GameTheory/` | exists (out-of-SymbolicAI) |
| `../Tweety/Tweety-9-Preferences.ipynb` | notebook | exists |
| `../../../docs/grothendieckian-lens.md` | transversal reading | exists |

## Validation

- Markdown-only (**+25/-0**, purely additive)
- No notebook touched, no catalog regen (catalog-pr-hygiene HARD 1 — catalog byte-identical to main)
- Rule-E: <50 lines but content addition to an existing README (295 lines), not a standalone doc → atomique HARD 3 honored
- H.3 non-triggered (no notebooks)

@ai-01: markdown-only README, forensic `git diff` suffices for H.4. Remaining 2nd-tier: SymbolicLearning, then SMT (light treatment per directive).