### PR TITLE
fix(app18-hyperparam): align convergence claim with committed table, restore FR consistency (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb
@@ -1213,16 +1213,16 @@
    "source": [
     "**Interpretation des resultats**\n",
     "\n",
-    "The visualization shows how each method explores the 2D parameter space (n_estimators vs max_depth):\n",
-    "- **Random Search** explores broadly but uniformly\n",
-    "- **Bayesian** focuses on promising regions\n",
-    "- **GA** explores across the space\n",
-    "- **PSO** shows similar exploration to Random Search\n",
-    "- **Best points**: All methods tend to find solutions in similar regions\n",
-    "- **Convergence patterns**: Random Search and GA and and PSO show faster initial convergence, Bayesian converges more gradually\n",
-    "- **Recommendations**: Use visualization to identify which method works best for your specific problem\n",
+    "La visualisation montre comment chaque methode explore l'espace 2D des parametres (n_estimators vs max_depth) :\n",
+    "- **Random Search** explore large et uniformement\n",
+    "- **Bayesian** se concentre sur les regions prometteuses\n",
+    "- **GA** explore a travers tout l'espace\n",
+    "- **PSO** montre une exploration similaire a Random Search\n",
+    "- **Meilleurs points** : toutes les methodes tendent a trouver des solutions dans des regions similaires\n",
+    "- **Convergence** : a plat sur le tableau comparatif (idx precedent), **Bayesian (custom)** atteint le meilleur score (0.9626) dans le temps le plus court (43.9 s, 50 evaluations), tandis que **PSO** est la plus lente (247.9 s pour 100 evaluations) et reste sur un score legerement inferieur (0.9604). La \"convergence rapide\" est donc ici l'atout de l'optimisation bayesienne, pas de PSO\n",
+    "- **Recommandation** : utiliser la visualisation pour identifier quelle methode convient a votre probleme specifique\n",
     "\n",
-    "**Next Steps**: Try different parameter combinations (n_estimators, max_depth) to see how performance varies across the space."
+    "**Poursuite** : testez d'autres combinaisons de parametres (n_estimators, max_depth) pour voir comment la performance varie a travers l'espace."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fidelity audit #3164 of App-18-HyperparameterTuning (read-only sonnet sub-agent + G.1 parent re-verification).

**1 finding (MED→fixed)**: idx30 "Interpretation des resultats" was (a) written in **English** — the only English cell in an otherwise French notebook — and (b) claimed *"Random Search and GA and PSO show faster initial convergence, Bayesian converges more gradually"*, which is **contradicted by the committed comparison table** (idx27):

| Method | Best Score | Time (s) | Evals |
|--------|-----------|----------|-------|
| Bayesian (custom) | **0.9626** | **43.9** | 50 |
| Random Search | 0.9626 | 78.7 | 50 |
| Genetic Algorithm | 0.9626 | 160.4 | 100 |
| Grid Search | 0.9604 | 21.4 | 50 |
| PSO | 0.9604 | **247.9** | 100 |

Bayesian reaches the **best score in the shortest time**; PSO is the **slowest** and lands on a lower score. The "PSO converges faster, Bayesian more gradually" characterization is **inverted** relative to the measured data.

## Fix (markdown-only, idx30)
- Translate back to French (consistency).
- Align the convergence bullet on the idx27 table: Bayesian's fast convergence to the top score is the asset here, not PSO's.

**No code change, no re-exec** — committed outputs are valid; idx30 is pure interpretation. Align-not-fabricate (#3164): the table output is genuine; the prose was the defect.

## What is NOT changed
- All 14 code cells + committed outputs untouched.
- idx31/idx33 recommendations/conclusion are abstract method-level pedagogical characterizations (not run claims) → left as-is (no-pendulum).

## Verification
- `git diff --stat`: 1 file, 10 ins / 10 del (idx30 markdown source only)
- Catalogue + MGS submodule **byte-identical** (3-dot); JSON valid; 0 control chars
- 3 exercise stubs (idx 11/15/21) preserved (#2161)

See #3164

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>