### PR TITLE
fix(app12): align Connect-Four interp on committed outputs (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
@@ -1228,21 +1228,21 @@
    "source": [
     "### Interpretation : Effet de la profondeur\n",
     "\n",
-    "**Sortie obtenue** : Les trois profondeurs sont comparees en taux de victoire et temps de calcul.\n",
+    "**Sortie obtenue** : Les trois profondeurs remportent 10/10 contre le joueur aleatoire ; seul le temps de calcul differe.\n",
     "\n",
-    "| Profondeur | Victoires | Temps/coup | Noeuds explores (ordre de grandeur) |\n",
-    "|------------|-----------|------------|--------------------------------------|\n",
-    "| d=2 | ~8-10/10 | < 1 ms | ~50 |\n",
-    "| d=4 | ~10/10 | ~10-50 ms | ~2 500 |\n",
-    "| d=6 | ~10/10 | ~200-2000 ms | ~125 000 |\n",
+    "| Profondeur | Victoires | Temps/coup mesure | Noeuds explores (ordre de grandeur) |\n",
+    "|------------|-----------|-------------------|--------------------------------------|\n",
+    "| d=2 | 10/10 | ~24 ms | ~50 |\n",
+    "| d=4 | 10/10 | ~257 ms | ~2 500 |\n",
+    "| d=6 | 10/10 | ~2824 ms | ~125 000 |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Meme d=2 suffit souvent contre un joueur aleatoire\n",
+    "1. Meme d=2 suffit contre un joueur aleatoire (10/10 victoires)\n",
     "2. Le temps croit **exponentiellement** avec la profondeur : $O(b^d)$ ou $b \\approx 4$ en moyenne\n",
     "3. L'elagage alpha-beta reduit la complexite de $O(b^d)$ a $O(b^{d/2})$ dans le meilleur cas\n",
     "4. La profondeur d=4 offre un bon compromis pour le Puissance 4\n",
     "\n",
-    "> La vraie difference se verra dans le tournoi, ou les IA s'affrontent entre elles."
+    "> La vraie difference se verra dans le tournoi, ou les IA s'affrontent entre elles.\n"
    ]
   },
   {
@@ -1669,20 +1669,20 @@
    "source": [
     "### Interpretation : MCTS vs Minimax\n",
     "\n",
-    "**Sortie obtenue** : Le duel entre les deux approches les plus sophistiquees de ce notebook.\n",
+    "**Sortie obtenue** : MCTS(1000 iterations) bat Minimax(d=4) en 29 coups dans cette partie ; MCTS est nettement plus lent par coup.\n",
     "\n",
     "| Aspect | MCTS (1000 iter.) | Minimax (d=4) |\n",
     "|--------|-------------------|---------------|\n",
     "| Approche | Simulations Monte Carlo | Recherche exhaustive |\n",
     "| Evaluation | Rollouts aleatoires | Fonction heuristique |\n",
     "| Profondeur | Variable (adaptative) | Fixe (4 niveaux) |\n",
-    "| Temps | ~0.1-0.5s/coup | ~0.01-0.1s/coup |\n",
+    "| Temps mesure | ~1.6 s/coup | ~0.23 s/coup |\n",
     "\n",
     "**Points cles** :\n",
-    "1. MCTS et Minimax(d=4) sont generalement competitifs -- le resultat varie selon les parties\n",
-    "2. MCTS est plus lent par coup mais n'a **pas besoin de fonction d'evaluation artisanale**\n",
+    "1. Sur cette partie, MCTS(1000) l'emporte mais il est ~7x plus lent par coup que Minimax(d=4)\n",
+    "2. MCTS n'a **pas besoin de fonction d'evaluation artisanale**\n",
     "3. MCTS explore automatiquement plus profondement les lignes prometteuses\n",
-    "4. Avec plus d'iterations (5000+), MCTS tend a surpasser Minimax(d=4)"
+    "4. Avec plus d'iterations (5000+), MCTS tend a surpasser Minimax(d=4)\n"
    ]
   },
   {
@@ -2290,23 +2290,24 @@
    "source": [
     "### Interpretation : Resultats du tournoi\n",
     "\n",
-    "**Sortie obtenue** : Le classement complet des 5 IA avec scores, confrontations directes et temps de calcul.\n",
+    "**Sortie obtenue** : Classement issu du round-robin (5 IA, 6 parties par paire). Minimax(d=4) et Minimax(d=6) dominent MCTS(500) (respectivement 6W-0D-0L et 4W-0D-2L).\n",
     "\n",
     "| Rang | IA | Force | Temps/coup | Commentaire |\n",
     "|------|-----|-------|------------|-------------|\n",
     "| 1 | Minimax(d=6) | Forte | Elevee | Meilleure profondeur de recherche |\n",
-    "| 2 | Minimax(d=4) / MCTS(1000) | Bonne | Moderee | Competitifs entre eux |\n",
-    "| 3 | Greedy | Moyenne | Negligeable | Bloque les menaces immediates |\n",
-    "| 4 | Random | Nulle | Negligeable | Perd contre tout |\n",
+    "| 2 | Minimax(d=4) | Bonne | Moderee | Balaye MCTS(500) 6W-0D-0L |\n",
+    "| 3 | MCTS(500) | Moyenne | Elevee | Competitive contre Minimax(d=6) (4W-2L) mais dominee par Minimax(d=4) |\n",
+    "| 4 | Greedy | Moyenne | Negligeable | Bloque les menaces immediates |\n",
+    "| 5 | Random | Nulle | Negligeable | Perd contre tout (0W-0D-6L partout) |\n",
     "\n",
     "**Points cles** :\n",
     "1. **La profondeur compte** : Minimax(d=6) domine Minimax(d=4) car il voit plus loin\n",
-    "2. **MCTS est competitif** sans fonction d'evaluation artisanale -- avec 1000 iterations, il rivalise avec Minimax(d=4)\n",
+    "2. **MCTS(500) est competitif** sans fonction d'evaluation artisanale -- il prend meme 2 parties a Minimax(d=6)\n",
     "3. **Greedy est un bon rapport qualite/prix** : presque instantane, il bat Random a chaque fois\n",
     "4. **Le compromis temps/qualite** est clairement visible dans le graphique de droite\n",
-    "5. **L'avantage du premier joueur** est partiellement neutralise par les 10+10 parties alternees\n",
+    "5. **L'avantage du premier joueur** est partiellement neutralise par les 3+3 parties alternees\n",
     "\n",
-    "> **Observation** : Augmenter les iterations de MCTS (5000+) ou la profondeur de Minimax (d=8) ameliorerait les performances, mais au prix d'un temps de calcul significativement plus eleve."
+    "> **Observation** : Augmenter les iterations de MCTS (5000+) ou la profondeur de Minimax (d=8) ameliorerait les performances, mais au prix d'un temps de calcul significativement plus eleve.\n"
    ]
   },
   {
@@ -3469,9 +3470,9 @@
     "|----|---------|------------|------------|------------|-------|\n",
     "| Random | Baseline | 0 | N/A | <1ms | Nulle |\n",
     "| Greedy | Heuristique | 1 | Positionnelle | <1ms | Faible |\n",
-    "| Minimax(d=4) | Arbre | 4 | Alpha-beta | ~50ms | Moyenne |\n",
-    "| Minimax(d=6) | Arbre | 6 | Alpha-beta | ~500ms | Bonne |\n",
-    "| MCTS(500) | Simulation | 500 iter. | UCB | ~100ms | Bonne |\n",
+    "| Minimax(d=4) | Arbre | 4 | Alpha-beta | ~250 ms | Moyenne |\n",
+    "| Minimax(d=6) | Arbre | 6 | Alpha-beta | ~2.8 s | Bonne |\n",
+    "| MCTS(500) | Simulation | 500 iter. | UCB | ~0.8 s | Bonne |\n",
     "\n",
     "### Lecons retenues\n",
     "\n",
@@ -3490,7 +3491,7 @@
     "- **Resolution complete** : Utiliser une base de donnees d'ouvertures (solution parfaite connue depuis 1988)\n",
     "- **Apprentissage par renforcement** : Entrainer un reseau de neurones a jouer (voir serie RL)\n",
     "- **Parallelisation** : Paralleliser MCTS ou Alpha-Beta pour explorer plus de noeuds\n",
-    "- **Recherche de Monte Carlo amelioree** : Ajouter une heuristique de simulation (RAVE, etc.)"
+    "- **Recherche de Monte Carlo amelioree** : Ajouter une heuristique de simulation (RAVE, etc.)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

App-12-ConnectFour fidelity audit (Epic **#3164**, align-not-fabricate). Four markdown interpretation tables **contradicted the genuine committed outputs** (real successful results — not failures). Aligned the markdown on the exact measured values from the committed code-cell outputs.

## Findings (G.1 cross-checked against real outputs)

| Cell | Claim (markdown) | Committed output | Fix |
|------|------------------|------------------|-----|
| **idx24** (depth exp.) | d=2 `<1ms`, d=4 `~10-50ms`, d=6 `~200-2000ms` | idx23: `Minimax(d=2)=23.9ms`, `d=4=257.3ms`, `d=6=2823.9ms` | aligned to `~24/~257/~2824 ms` |
| **idx29** (MCTS vs Minimax) | MCTS `~0.1-0.5s`, Minimax `~0.01-0.1s` | idx28: `MCTS(1000)=1.622s`, `Minimax=0.229s` | aligned to `~1.6s/~0.23s` |
| **idx39** (tournament) | rang 2 `Minimax(d=4)/MCTS(1000) competitifs` | idx34: Minimax(d=4) **sweeps MCTS(500) 6W-0D-0L**, Minimax(d=6) `4W-0D-2L` | real standings — MCTS(500) not 1000, Minimax(d=4) dominates |
| **idx56** (conclusion) | MCTS(500) `~100ms`, Minimax(d=4) `~50ms`, (d=6) `~500ms` | idx28: MCTS(1000)=1.622s → MCTS(500)~0.8s; idx23: d=4~257ms, d=6~2824ms | aligned to `~0.8s / ~250ms / ~2.8s` |

## Scope

- **Markdown-only**, no-pendulum (aligned on what the output discloses; outputs are genuine successes, not failures → règle F / #3660 not applicable).
- Code cells, `outputs`, `execution_count` **byte-identical**.
- `COURSE_CATALOG.generated.*` and MGS submodule **byte-identical** (not regenerated on branch — cf catalog-pr-hygiene).
- Surgical JSON round-trip (`indent=1, ensure_ascii=False`); only the 4 targeted markdown cells touched.

## Verification

```
git diff --stat : 1 file changed, 26 insertions(+), 25 deletions(-)
code-cell source churn (execution_count/outputs +) : 0
catalogue / submodule : byte-identical
JSON parses : OK
```

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)