### PR TITLE
fix(app14): align Connect-Four-Adversarial interp on committed outputs (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
@@ -781,15 +781,15 @@
     "| Meilleur coup | 3 (colonne centrale) | Controle du centre = strategie optimale |\n",
     "| Valeur | 6.00 | Score heuristique positif (avantage MAX) |\n",
     "| Noeuds explores | 2,801 | Explosion combinatoire : ~7^4 = 2401 theoriques |\n",
-    "| Temps | 0.854s | Acceptable pour d=4, mais explosera pour d>6 |\n",
+    "| Temps | 0.4375s | Acceptable pour d=4, mais explose pour d>5 (cf. benchmark) |\n",
     "\n",
     "**Points cles** :\n",
     "1. **Coup optimal** : Colonne 3 (centre) est le meilleur premier coup\n",
     "2. **Complexite** : 2,801 noeuds pour seulement 4 profondeurs\n",
-    "3. **Temps raisonnable** : 0.85s est acceptable, mais d=6 prendrait 42 secondes\n",
+    "3. **Temps raisonnable** : 0.44s est acceptable, mais le benchmark (cellule suivante) montre que d=6 prend ~23 secondes\n",
     "4. **Heuristique efficace** : Score 6.00 = avantage modere pour MAX\n",
     "\n",
-    "> **Note technique** : Le nombre de noeuds (2,801) est superieur a b^d = 7^4 = 2,401 car : (1) le facteur de branchement diminue en profondeur (colonnes se remplissent), (2) certaines branches sont plus longues que d=4, (3) l'exploration continue meme quand le plateau est presque plein. Minimax explore systematiquement TOUTES les branches jusqu'a la profondeur d, sans aucun elagage. C'est son principal defaut."
+    "> **Note technique** : Le nombre de noeuds (2,801) est superieur a b^d = 7^4 = 2,401 car : (1) le facteur de branchement diminue en profondeur (colonnes se remplissent), (2) certaines branches sont plus longues que d=4, (3) l'exploration continue meme quand le plateau est presque plein. Minimax explore systematiquement TOUTES les branches jusqu'a la profondeur d, sans aucun elagage. C'est son principal defaut.\n"
    ]
   },
   {
@@ -965,15 +965,15 @@
     "| Meilleur coup | 3 | Identique (centre) |\n",
     "| Valeur | 6.00 | Identique (optimal) |\n",
     "| Noeuds explores | 178 | **15.7x moins** |\n",
-    "| Temps | 0.0558s | **15.3x plus rapide** |\n",
+    "| Temps | 0.0215s | **~20x plus rapide** (0.4375s / 0.0215s) |\n",
     "\n",
     "**Points cles** :\n",
     "1. **Resultat identique** : Meme coup (colonne 3) et meme valeur (6.00)\n",
     "2. **Elagage massif** : 178 noeuds vs 2,801 = 94% de reduction\n",
-    "3. **Vitesse** : 0.055s vs 0.854s = 15x plus rapide\n",
+    "3. **Vitesse** : 0.0215s vs 0.4375s = ~20x plus rapide\n",
     "4. **Optimalite gardee** : Alpha-Beta ne change pas le resultat, seulement la vitesse\n",
     "\n",
-    "> **Note technique** : La reduction de 15.7x a profondeur 4 est excellente mais loin du maximum theorique. Avec un ordonnancement parfait des coups, Alpha-Beta pourrait atteindre b^(d/2) = ~7^2 = 49x de reduction. L'ordonnancement actuel (par proximite au centre) est heuristique mais non optimal. Pour ameliorer, on pourrait : (1) trier par valeur de l'iteration precedente, (2) utiliser une table de transposition, (3) ordonnancer par les coups les plus joues."
+    "> **Note technique** : La reduction de 15.7x en noeuds a profondeur 4 est excellente mais loin du maximum theorique. Avec un ordonnancement parfait des coups, Alpha-Beta pourrait atteindre b^(d/2) = environ 7^2 = 49x de reduction. L'ordonnancement actuel (par proximite au centre) est heuristique mais non optimal. Pour ameliorer, on pourrait : (1) trier par valeur de l'iteration precedente, (2) utiliser une table de transposition, (3) ordonnancer par les coups les plus joues.\n"
    ]
   },
   {
@@ -1220,18 +1220,18 @@
     "\n",
     "| Metrique | Valeur | Analyse |\n",
     "|----------|--------|---------|\n",
-    "| Meilleur coup | 2 | Colonne 2 (pas le centre 3) |\n",
-    "| Taux de victoire | 0.082 (8.2%) | Tres faible pour 1000 iterations |\n",
+    "| Meilleur coup | 3 | Colonne centrale (comme Minimax et Alpha-Beta) |\n",
+    "| Taux de victoire | 0.141 (14.1%) | Estimation bruitee pour 1000 iterations |\n",
     "| Noeuds explores | 2,000 | 1000 selections + 1000 simulations |\n",
-    "| Temps | 3.08s | Beaucoup plus lent que Alpha-Beta (0.06s) |\n",
+    "| Temps | 1.311s | Plus lent qu'Alpha-Beta (0.0215s) mais raisonnable |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Taux de victoire faible** : 8.2% seulement = MCTS n'a pas converge\n",
-    "2. **Coup different** : Colonne 2 au lieu de 3 = alea des rollouts\n",
-    "3. **Temps eleve** : 3 secondes pour 1000 iterations = 56x plus lent qu'Alpha-Beta\n",
-    "4. **Convergence lente** : MCTS necessite 10000+ iterations pour Connect Four\n",
+    "1. **Coup centre** : MCTS choisit la colonne 3, comme les approches exhaustives\n",
+    "2. **Taux de victoire modere** : 14.1% reflete le caractere bruite des rollouts aleatoires\n",
+    "3. **Temps** : 1.3s pour 1000 iterations, soit ~61x plus lent qu'Alpha-Beta(d=4)\n",
+    "4. **Convergence lente** : MCTS necessite davantage d'iterations pour affiner Connect Four\n",
     "\n",
-    "> **Note technique** : MCTS est probabiliste : chaque execution donne un resultat different. Le faible taux de victoire (8.2%) indique que les rollouts aleatoires ne sont pas efficaces sur Connect Four, qui a une structure tactique forte. MCTS brille sur les jeux a grand facteur de branchement (Go, Havannah) ou les rollouts explorent des espaces vastes. Pour Connect Four, Alpha-Beta avec une bonne heuristique est nettement superieur."
+    "> **Note technique** : MCTS est probabiliste : chaque execution donne un resultat legerement different. Le taux de victoire estime reste faible car les rollouts aleatoires exploitent mal la structure tactique forte de Connect Four. MCTS brille sur les jeux a grand facteur de branchement (Go, Havannah) ou les rollouts explorent des espaces vastes. Pour Connect Four, Alpha-Beta avec une bonne heuristique est nettement superieur.\n"
    ]
   },
   {
@@ -1456,24 +1456,24 @@
    "source": [
     "### Interpretation : Benchmark par profondeur\n",
     "\n",
-    "**Sortie obtenue** : Comparaison Minimax vs Alpha-Beta de 1 a 6 profondeurs.\n",
+    "**Sortie obtenue** : Comparaison Minimax vs Alpha-Beta de profondeur 1 a 6.\n",
     "\n",
     "| Profondeur | Minimax noeuds | Alpha-Beta noeuds | Speedup noeuds | Minimax temps | Alpha-Beta temps | Speedup temps |\n",
     "|------------|----------------|-------------------|----------------|---------------|------------------|---------------|\n",
-    "| 1 | 8 | 8 | 1.0x | 0.002s | 0.002s | 1.0x |\n",
-    "| 2 | 57 | 21 | 2.7x | 0.015s | 0.004s | 3.3x |\n",
-    "| 3 | 400 | 82 | 4.9x | 0.110s | 0.019s | 5.7x |\n",
-    "| 4 | 2,801 | 178 | 15.7x | 0.801s | 0.055s | 14.6x |\n",
-    "| 5 | 19,608 | 641 | 30.6x | 5.909s | 0.150s | 39.3x |\n",
-    "| 6 | 137,257 | 1,370 | 100.2x | 41.693s | 0.329s | 126.6x |\n",
+    "| 1 | 8 | 8 | 1.0x | 0.001s | 0.001s | 1.0x |\n",
+    "| 2 | 57 | 21 | 2.7x | 0.009s | 0.003s | 3.0x |\n",
+    "| 3 | 400 | 82 | 4.9x | 0.063s | 0.012s | 5.2x |\n",
+    "| 4 | 2,801 | 178 | 15.7x | 0.518s | 0.039s | 13.2x |\n",
+    "| 5 | 19,608 | 641 | 30.6x | 3.161s | 0.088s | 36.1x |\n",
+    "| 6 | 137,257 | 1,370 | 100.2x | 23.111s | 0.166s | 138.9x |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Acceleration exponentielle** : Le speedup augmente de 1x a 100x entre d=1 et d=6\n",
+    "1. **Acceleration exponentielle** : Le speedup augmente de 1x a 100x (noeuds) entre d=1 et d=6\n",
     "2. **Complexite Minimax** : 137k noeuds a d=6 = explosion combinatoire (b^d avec b~4-7)\n",
-    "3. **Efficacite Alpha-Beta** : Seulement 1.3k noeuds a d=6 = elagage massif\n",
-    "4. **Temps critique** : Minimax d=6 prend 42 secondes, Alpha-Beta seulement 0.33 secondes\n",
+    "3. **Efficacite Alpha-Beta** : Seulement 1.4k noeuds a d=6 = elagage massif\n",
+    "4. **Temps critique** : Minimax d=6 prend ~23 secondes, Alpha-Beta seulement ~0.17 seconde\n",
     "\n",
-    "> **Note technique** : L'elagage Alpha-Beta atteint son potentiel maximal quand les bons coups sont explores en premier. L'ordonnancement par proximite au centre (colonne 3) est crucial : il permet d'eliminer rapidement les branches inferieures. Sans ordonnancement, le speedup serait seulement de 2-3x. Avec un ordonnancement parfait (theorique), le speedup pourrait atteindre b^(d/2), soit ~400x a d=6 pour Connect Four."
+    "> **Note technique** : L'elagage Alpha-Beta atteint son potentiel maximal quand les bons coups sont explores en premier. L'ordonnancement par proximite au centre (colonne 3) est crucial : il permet d'eliminer rapidement les branches inferieures. Sans ordonnancement, le speedup serait seulement de 2-3x. Avec un ordonnancement parfait (theorique), le speedup pourrait atteindre b^(d/2), soit environ 400x a d=6 pour Connect Four.\n"
    ]
   },
   {
@@ -1786,17 +1786,17 @@
     "| Aspect | Observation | Signification |\n",
     "|--------|-------------|---------------|\n",
     "| **Noeuds explores** | Croissance exponentielle pour Minimax, lineaire pour Alpha-Beta | Elagage de plus en plus efficace avec la profondeur |\n",
-    "| **Temps execution** | Ecart critique entre d=5 et d=6 | Alpha-Beta d=6 (0.33s) vs Minimax d=6 (41.7s) = 126x plus rapide |\n",
+    "| **Temps execution** | Ecart critique entre d=5 et d=6 | Alpha-Beta d=6 (0.17s) vs Minimax d=6 (23.1s) = ~139x plus rapide |\n",
     "| **Speedup noeuds** | 1x (d=1) a 100x (d=6) | L'elagage augmente avec la profondeur |\n",
     "| **Echelle log** | Necessaire pour visualiser la difference | Difference de 2 ordres de grandeur |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Explosion combinatoire** : Minimax devient impraticable apres d=6 (41 secondes)\n",
-    "2. **Efficacite Alpha-Beta** : 100x moins de noeuds explores, 126x plus rapide a d=6\n",
+    "1. **Explosion combinatoire** : Minimax devient impraticable des d=6 (~23 secondes)\n",
+    "2. **Efficacite Alpha-Beta** : 100x moins de noeuds explores, ~139x plus rapide a d=6\n",
     "3. **Seuil pratique** : Pour Connect Four, Alpha-Beta d=6-8 est realiste, Minimax d>5 ne l'est pas\n",
-    "4. **Ordre de grandeur** : L'echelle logarithmique masque la difference reelle (137k vs 1.3k noeuds)\n",
+    "4. **Ordre de grandeur** : L'echelle logarithmique masque la difference reelle (137k vs 1.4k noeuds)\n",
     "\n",
-    "> **Note technique** : Le speedup augmente avec la profondeur car l'elagage a plus d'opportunites de couper des branches. A profondeur 1, aucun elagage n'est possible (toutes les feuilles sont au meme niveau). L'ordonnancement des coups (centre en priorite) maximise cet elagage."
+    "> **Note technique** : Le speedup augmente avec la profondeur car l'elagage a plus d'opportunites de couper des branches. A profondeur 1, aucun elagage n'est possible (toutes les feuilles sont au meme niveau). L'ordonnancement des coups (centre en priorite) maximise cet elagage.\n"
    ]
   },
   {
@@ -2193,18 +2193,18 @@
     "\n",
     "| Agent | Victoires | Defaites | Win Rate | Performance |\n",
     "|-------|-----------|----------|----------|-------------|\n",
-    "| AlphaBeta(d=4) | 15 | 3 | 83.3% | **Dominant** |\n",
+    "| AlphaBeta(d=4) | 17 | 1 | 94.4% | **Dominant** |\n",
     "| Minimax(d=4) | 9 | 9 | 50.0% | Moyen |\n",
-    "| MCTS(1000) | 9 | 9 | 50.0% | Moyen |\n",
-    "| Random | 3 | 15 | 16.7% | Faible |\n",
+    "| MCTS(1000) | 6 | 12 | 33.3% | Faible |\n",
+    "| Random | 4 | 14 | 22.2% | Faible |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Alpha-Beta domine largement** : 83% de victoires, 6-0 contre Minimax et Random\n",
-    "2. **Minimax et MCTS equivalents** : 50% de win rate, performance moyenne\n",
-    "3. **MCTS instable** : Perd contre Alpha-Beta mais bat Random 3-3\n",
-    "4. **Echantillon insuffisant** : 6 parties par match = results variables\n",
+    "1. **Alpha-Beta domine largement** : 94% de victoires, 6-0 contre Minimax et Random\n",
+    "2. **Minimax equilibre** : 50% de win rate (bat MCTS 3-3, perd contre Alpha-Beta)\n",
+    "3. **MCTS en difficulte** : Perd contre Alpha-Beta (1-5) et contre Random (2-4), egalite contre Minimax (3-3)\n",
+    "4. **Echantillon insuffisant** : 6 parties par match = resultats variables\n",
     "\n",
-    "> **Note technique** : La difference entre Minimax et Alpha-Beta devrait etre nulle (meme profondeur = meme coups). Le score 6-0 suggere soit : (1) alea dans l'implementation, (2) difference d'ordonnancement des coups, ou (3) echantillon trop petit. Avec 50+ parties, les win rates convergeraient vers ~50% pour Minimax vs Alpha-Beta."
+    "> **Note technique** : La difference entre Minimax et Alpha-Beta devrait etre nulle (meme profondeur = meme coups). Le score 6-0 suggere soit : (1) alea dans l'implementation, (2) difference d'ordonnancement des coups, ou (3) echantillon trop petit. Avec 50+ parties, les win rates convergeraient vers ~50% pour Minimax vs Alpha-Beta.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

App-14-ConnectFour-Adversarial fidelity audit (Epic **#3164**, align-not-fabricate). Six markdown interpretation tables **contradicted the genuine committed outputs** (real successful results — not failures). The dominant failure mode is **fabricated timing/score tables**: node counts were correct, but every time and time-speedup value was wrong, plus one tournament table and one MCTS narrative.

## Findings (G.1 cross-checked against real outputs)

| Cell | Claim (markdown) | Committed output | Fix |
|------|------------------|------------------|-----|
| **idx13** (Minimax) | Temps `0.854s`; "d=6 prendrait 42s" | idx12: `Temps: 0.4375s`; benchmark d=6 `23.1s` | `0.4375s`; removed 42s |
| **idx16** (Alpha-Beta) | Temps `0.0558s`, speedup `15.3x` | idx15: `Temps: 0.0215s`, `Reduction 15.7x` | `0.0215s`, ~20x (0.4375/0.0215) |
| **idx19** (MCTS) | coup `2`, taux `0.082`, temps `3.08s` | idx18: coup `3`, taux `0.141`, temps `1.3110s` | all 3 realigned; removed false "colonne 2 = alea" |
| **idx22** (benchmark) | all 6 Minimax-temps/AB-temps/Speedup-temps rows wrong (e.g. d=6 `41.693s/0.329s/126.6x`) | idx21 dataframe d=6 `23.111s/0.166s/138.9x` | full table realigned |
| **idx28** (viz) | d=6 Minimax `41.7s`, AB `0.33s`, `126x` | benchmark d=6 | `23.1s/0.17s/~139x` |
| **idx34** (tournament) | AlphaBeta `15/3/83.3%`, MCTS `9/9/50%`, Random `3/15/16.7%`; "MCTS bat Random 3-3" | idx33: `17/1/94.4%`, `6/12/33.3%`, `4/14/22.2%`; matches Random-MCTS `4-2`, Minimax-MCTS `3-3` | table realigned; inverted narrative fixed |

## Scope

- **Markdown-only**, no-pendulum (outputs are genuine successes, not failures → règle F / #3660 not applicable).
- Code cells, `outputs`, `execution_count` **byte-identical**.
- `COURSE_CATALOG.generated.*` and MGS submodule **byte-identical** (not regenerated on branch — cf catalog-pr-hygiene).
- Surgical JSON round-trip (`indent=1, ensure_ascii=False`); only the 6 targeted markdown cells touched.

## Verification

```
git diff --stat : 1 file changed, 38 insertions(+), 38 deletions(-)
code-cell source churn (execution_count/outputs +) : 0
catalogue / submodule : byte-identical
JSON parses : OK
```

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)