### PR TITLE
fix(#3164): NB-13 Agentic_Orchestration fidelity -- truncated final-answer slice + guardrail smoke test + de-consecrate comparison

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
@@ -67,10 +67,10 @@
    "id": "a1c2ce6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:29:43.347123Z",
-     "iopub.status.busy": "2026-06-15T18:29:43.346938Z",
-     "iopub.status.idle": "2026-06-15T18:30:01.781684Z",
-     "shell.execute_reply": "2026-06-15T18:30:01.781160Z"
+     "iopub.execute_input": "2026-06-19T23:24:06.711421Z",
+     "iopub.status.busy": "2026-06-19T23:24:06.711421Z",
+     "iopub.status.idle": "2026-06-19T23:24:10.701387Z",
+     "shell.execute_reply": "2026-06-19T23:24:10.701387Z"
     },
     "papermill": {
      "duration": 18.44292,
@@ -83,6 +83,15 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -93,7 +102,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".env charge depuis : D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n",
+      ".env charge depuis : C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GenAI\\.env\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "FAST_MODEL = meta-llama/llama-3.3-70b-instruct\n",
       "BIG_MODEL  = openai/gpt-5-nano\n",
       "BATCH_MODE = False\n"
@@ -152,10 +167,10 @@
    "id": "02a857b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:30:01.790820Z",
-     "iopub.status.busy": "2026-06-15T18:30:01.790505Z",
-     "iopub.status.idle": "2026-06-15T18:30:03.099741Z",
-     "shell.execute_reply": "2026-06-15T18:30:03.097160Z"
+     "iopub.execute_input": "2026-06-19T23:24:10.701387Z",
+     "iopub.status.busy": "2026-06-19T23:24:10.701387Z",
+     "iopub.status.idle": "2026-06-19T23:24:11.614994Z",
+     "shell.execute_reply": "2026-06-19T23:24:11.614416Z"
     },
     "papermill": {
      "duration": 1.310634,
@@ -228,10 +243,10 @@
    "id": "12f431d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:30:03.119870Z",
-     "iopub.status.busy": "2026-06-15T18:30:03.119696Z",
-     "iopub.status.idle": "2026-06-15T18:30:03.124998Z",
-     "shell.execute_reply": "2026-06-15T18:30:03.124342Z"
+     "iopub.execute_input": "2026-06-19T23:24:11.616999Z",
+     "iopub.status.busy": "2026-06-19T23:24:11.616000Z",
+     "iopub.status.idle": "2026-06-19T23:24:11.623367Z",
+     "shell.execute_reply": "2026-06-19T23:24:11.622859Z"
     },
     "papermill": {
      "duration": 0.010202,
@@ -308,10 +323,10 @@
    "id": "677a2bcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:30:03.132265Z",
-     "iopub.status.busy": "2026-06-15T18:30:03.132123Z",
-     "iopub.status.idle": "2026-06-15T18:30:03.139848Z",
-     "shell.execute_reply": "2026-06-15T18:30:03.139118Z"
+     "iopub.execute_input": "2026-06-19T23:24:11.625599Z",
+     "iopub.status.busy": "2026-06-19T23:24:11.625599Z",
+     "iopub.status.idle": "2026-06-19T23:24:11.634100Z",
+     "shell.execute_reply": "2026-06-19T23:24:11.634100Z"
     },
     "papermill": {
      "duration": 0.012265,
@@ -425,10 +440,10 @@
    "id": "042baaf1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:30:03.154406Z",
-     "iopub.status.busy": "2026-06-15T18:30:03.154228Z",
-     "iopub.status.idle": "2026-06-15T18:30:03.161146Z",
-     "shell.execute_reply": "2026-06-15T18:30:03.160403Z"
+     "iopub.execute_input": "2026-06-19T23:24:11.636716Z",
+     "iopub.status.busy": "2026-06-19T23:24:11.636716Z",
+     "iopub.status.idle": "2026-06-19T23:24:11.643403Z",
+     "shell.execute_reply": "2026-06-19T23:24:11.642832Z"
     },
     "papermill": {
      "duration": 0.011088,
@@ -552,10 +567,10 @@
    "id": "6deb331f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:30:03.177393Z",
-     "iopub.status.busy": "2026-06-15T18:30:03.177204Z",
-     "iopub.status.idle": "2026-06-15T18:30:03.182506Z",
-     "shell.execute_reply": "2026-06-15T18:30:03.181964Z"
+     "iopub.execute_input": "2026-06-19T23:24:11.645050Z",
+     "iopub.status.busy": "2026-06-19T23:24:11.645050Z",
+     "iopub.status.idle": "2026-06-19T23:24:11.650653Z",
+     "shell.execute_reply": "2026-06-19T23:24:11.650086Z"
     },
     "papermill": {
      "duration": 0.01094,
@@ -584,7 +599,7 @@
     "    \"- Probleme de code ou l'erreur est systematique / conceptuelle -> resoudre_reflexion.\\n\"\n",
     "    \"- Probleme de code ou le single-shot echoue par variance -> resoudre_best_of_n.\\n\"\n",
     "    \"Tu dois invoquer UN outil, puis analyser son resultat. Si la solution est trouvee \"\n",
-    "    \"(passes==total, ou solution_trouvee==True), tu t'arretes. Sinon, tu peux essayer un autre \"\n",
+    "    \"(passes==total, ou solution_trouvee==True), tu t'arrettes. Sinon, tu peux essayer un autre \"\n",
     "    \"outil une seule fois. Sois concis.\"\n",
     ")\n",
     "\n",
@@ -600,7 +615,11 @@
     "            trace.append({\"tour\": tour, \"erreur\": \"echec appel LLM\"})\n",
     "            break\n",
     "        if not msg.tool_calls:\n",
-    "            trace.append({\"tour\": tour, \"reponse_finale\": (msg.content or \"\")[:200]})\n",
+    "            # On garde une reponse finale suffisamment large pour ne pas tronquer le code\n",
+    "            # genere en plein milieu d'une fonction (audit #3164 — grain Demo 2/3 : le slice\n",
+    "            # [:200] coupait les fonctions palindrome/fizzbuzz et donnait l'impression d'une\n",
+    "            # \"solution\" incomplete alors que l'outil sous-jacent avait reussi).\n",
+    "            trace.append({\"tour\": tour, \"reponse_finale\": (msg.content or \"\")[:600]})\n",
     "            break\n",
     "        # L'agent a demande un (ou des) outil(s) : on execute et on nourrit la conversation\n",
     "        conversation.append(msg)\n",
@@ -648,10 +667,10 @@
    "id": "139be6ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:30:03.198450Z",
-     "iopub.status.busy": "2026-06-15T18:30:03.198276Z",
-     "iopub.status.idle": "2026-06-15T18:30:18.392504Z",
-     "shell.execute_reply": "2026-06-15T18:30:18.391790Z"
+     "iopub.execute_input": "2026-06-19T23:24:11.652377Z",
+     "iopub.status.busy": "2026-06-19T23:24:11.652377Z",
+     "iopub.status.idle": "2026-06-19T23:24:34.108709Z",
+     "shell.execute_reply": "2026-06-19T23:24:34.108189Z"
     },
     "papermill": {
      "duration": 15.198815,
@@ -676,8 +695,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'tour': 1, 'outil': 'resoudre_tot_24', 'args': {'nombres': [4, 7, 8, 8]}, 'resultat': {'moteur': 'tot_24', 'solution_trouvee': True, 'nombres': [4, 7, 8, 8]}}\n",
-      "{'tour': 2, 'reponse_finale': 'Solution trouvée: (7 - (8/8)) * 4 = 24\\n\\nExplication rapide: 8/8 = 1; 7 - 1 = 6; 6 * 4 = 24. Utilise les nombres 4, 7, 8, 8 chacun une fois.'}\n"
+      "{'tour': 1, 'reponse_finale': ''}\n"
      ]
     }
    ],
@@ -697,10 +715,10 @@
    "id": "e231d201",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:30:18.401242Z",
-     "iopub.status.busy": "2026-06-15T18:30:18.401027Z",
-     "iopub.status.idle": "2026-06-15T18:30:49.399690Z",
-     "shell.execute_reply": "2026-06-15T18:30:49.394908Z"
+     "iopub.execute_input": "2026-06-19T23:24:34.109715Z",
+     "iopub.status.busy": "2026-06-19T23:24:34.109715Z",
+     "iopub.status.idle": "2026-06-19T23:25:00.265531Z",
+     "shell.execute_reply": "2026-06-19T23:25:00.265531Z"
     },
     "papermill": {
      "duration": 31.010199,
@@ -725,8 +743,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'tour': 1, 'outil': 'resoudre_reflexion', 'args': {'id_probleme': 'palindrome', 'iterations': 3}, 'resultat': {'moteur': 'reflexion', 'passes': 3, 'total': 3, 'tokens': 116}}\n",
-      "{'tour': 2, 'reponse_finale': 'Solution trouvée par le moteur de réflexion.\\n\\nVoici une implémentation Python simple pour vérifier si une chaîne est palindrome (ignore les espaces et la casse, ne considère que les caractères alphanu'}\n"
+      "{'tour': 1, 'outil': 'resoudre_reflexion', 'args': {'id_probleme': 'palindrome', 'iterations': 3}, 'resultat': {'moteur': 'reflexion', 'passes': 3, 'total': 3, 'tokens': 110}}\n",
+      "{'tour': 2, 'reponse_finale': 'Voici une solution Python simple pour identifier un palindrome (version normalisée, ignore les espaces et la ponctuation, case-insensitive).\\n\\nCode:\\ndef is_palindrome(s: str) -> bool:\\n    s = \\'\\'.join(ch.lower() for ch in s if ch.isalnum())\\n    return s == s[::-1]\\n\\nExemples:\\n- is_palindrome(\"A man, a plan, a canal: Panama\") -> True\\n- is_palindrome(\"racecar\") -> True\\n- is_palindrome(\"Palindrome\") -> False\\n\\nSi vous souhaitez une version qui compte strictement les caractères (inclus espaces et ponctuation), utilisez:\\ndef is_palindrome_strict(s: str) -> bool:\\n    return s == s[::-1]'}\n"
      ]
     }
    ],
@@ -746,10 +764,10 @@
    "id": "e661d742",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:30:49.426919Z",
-     "iopub.status.busy": "2026-06-15T18:30:49.426738Z",
-     "iopub.status.idle": "2026-06-15T18:31:17.163221Z",
-     "shell.execute_reply": "2026-06-15T18:31:17.162571Z"
+     "iopub.execute_input": "2026-06-19T23:25:00.265531Z",
+     "iopub.status.busy": "2026-06-19T23:25:00.265531Z",
+     "iopub.status.idle": "2026-06-19T23:25:38.703541Z",
+     "shell.execute_reply": "2026-06-19T23:25:38.703541Z"
     },
     "papermill": {
      "duration": 27.743512,
@@ -774,8 +792,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'tour': 1, 'outil': 'resoudre_reflexion', 'args': {'id_probleme': 'fizzbuzz', 'iterations': 3}, 'resultat': {'moteur': 'reflexion', 'passes': 2, 'total': 2, 'tokens': 35}}\n",
-      "{'tour': 2, 'reponse_finale': \"Solution trouvée avec reflexion.\\n\\nPython (FizzBuzz):\\ndef fizzbuzz(n):\\n    res = []\\n    for i in range(1, n + 1):\\n        s = ''\\n        if i % 3 == 0:\\n            s += 'Fizz'\\n        if i % 5 == 0:\\n  \"}\n"
+      "[1, 2, 'Fizz', 4, 'Buzz', 'Fizz', 7, 8, 'Fizz', 'Buzz', 11, 'Fizz', 13, 14, 'FizzBuzz', 16, 17, 'Fizz', 19, 'Buzz']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'tour': 1, 'outil': 'resoudre_best_of_n', 'args': {'id_probleme': 'fizzbuzz', 'n': 3}, 'resultat': {'moteur': 'best_of_n', 'passes': 2, 'total': 2, 'tokens': 176}}\n",
+      "{'tour': 2, 'reponse_finale': 'Solution trouvée.\\n\\nVoici une implémentation Python simple pour fizzbuzz:\\n\\ndef fizzbuzz(n):\\n    res = []\\n    for i in range(1, n + 1):\\n        s = \"\"\\n        if i % 3 == 0:\\n            s += \"Fizz\"\\n        if i % 5 == 0:\\n            s += \"Buzz\"\\n        res.append(s or str(i))\\n    return res\\n\\n# Exemple d\\'utilisation:\\nfor line in fizzbuzz(100):\\n    print(line)'}\n"
      ]
     }
    ],
@@ -822,10 +847,10 @@
    "id": "7e7bb3e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:31:17.179828Z",
-     "iopub.status.busy": "2026-06-15T18:31:17.179654Z",
-     "iopub.status.idle": "2026-06-15T18:31:33.742180Z",
-     "shell.execute_reply": "2026-06-15T18:31:33.741480Z"
+     "iopub.execute_input": "2026-06-19T23:25:38.703541Z",
+     "iopub.status.busy": "2026-06-19T23:25:38.703541Z",
+     "iopub.status.idle": "2026-06-19T23:26:01.135601Z",
+     "shell.execute_reply": "2026-06-19T23:26:01.135601Z"
     },
     "papermill": {
      "duration": 16.567857,
@@ -841,16 +866,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Tours effectues (borne a 2) : 2\n",
-      "Aucune boucle infinie -> garde-fou OK.\n"
+      "Tours nominaux (max_tours=4) : 2  <- chemin nominal (outil puis reponse)\n",
+      "Tours bornes   (max_tours=1) : 1  <- la borne arrete apres l'outil, avant la reponse\n",
+      "max_tours=1 a tronque la boucle avant la reponse finale -> garde-fou OK : True\n"
      ]
     }
    ],
    "source": [
-    "# Smoke test : l'agent respecte max_tours et ne boucle pas.\n",
-    "_trace_safety = agent_routeur(\"Resous le 24-game [1, 3, 4, 6].\", max_tours=2)\n",
-    "print(f\"Tours effectues (borne a 2) : {len(_trace_safety)}\")\n",
-    "print(\"Aucune boucle infinie -> garde-fou OK.\")"
+    "# Smoke test du garde-fou anti-boucle (max_tours).\n",
+    "# Un appel agent_routeur nominal converge en 2 tours (1 appel d'outil + 1 reponse finale).\n",
+    "# Si on borne la meme tache a max_tours=1, la boucle DOIT s'arreter des le 1er tour, avant\n",
+    "# que l'agent n'ait pu emettre sa reponse finale : c'est l'arret premature impose par la\n",
+    "# borne, exactement le mecanisme anti-boucle-infini qu'on veut demontrer.\n",
+    "_trace_nominal = agent_routeur(\"Resous le 24-game avec les nombres [1, 3, 4, 6].\", max_tours=4)\n",
+    "_trace_borne = agent_routeur(\"Resous le 24-game avec les nombres [1, 3, 4, 6].\", max_tours=1)\n",
+    "print(f\"Tours nominaux (max_tours=4) : {len(_trace_nominal)}  <- chemin nominal (outil puis reponse)\")\n",
+    "print(f\"Tours bornes   (max_tours=1) : {len(_trace_borne)}  <- la borne arrete apres l'outil, avant la reponse\")\n",
+    "_a_arret_borne = len(_trace_borne) == 1 and any(\"outil\" in e for e in _trace_borne) and not any(\"reponse_finale\" in e for e in _trace_borne)\n",
+    "print(f\"max_tours=1 a tronque la boucle avant la reponse finale -> garde-fou OK : {_a_arret_borne}\")"
    ]
   },
   {
@@ -909,10 +942,10 @@
    "id": "79539ff9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:31:33.766884Z",
-     "iopub.status.busy": "2026-06-15T18:31:33.766690Z",
-     "iopub.status.idle": "2026-06-15T18:31:33.771084Z",
-     "shell.execute_reply": "2026-06-15T18:31:33.770436Z"
+     "iopub.execute_input": "2026-06-19T23:26:01.135601Z",
+     "iopub.status.busy": "2026-06-19T23:26:01.135601Z",
+     "iopub.status.idle": "2026-06-19T23:26:01.140243Z",
+     "shell.execute_reply": "2026-06-19T23:26:01.140243Z"
     },
     "papermill": {
      "duration": 0.008569,
@@ -977,10 +1010,10 @@
    "id": "7ddcd430",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:31:33.788353Z",
-     "iopub.status.busy": "2026-06-15T18:31:33.788129Z",
-     "iopub.status.idle": "2026-06-15T18:31:33.792083Z",
-     "shell.execute_reply": "2026-06-15T18:31:33.791316Z"
+     "iopub.execute_input": "2026-06-19T23:26:01.141251Z",
+     "iopub.status.busy": "2026-06-19T23:26:01.141251Z",
+     "iopub.status.idle": "2026-06-19T23:26:01.144625Z",
+     "shell.execute_reply": "2026-06-19T23:26:01.144625Z"
     },
     "papermill": {
      "duration": 0.010082,
@@ -1045,10 +1078,10 @@
    "id": "9124c891",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T18:31:33.810638Z",
-     "iopub.status.busy": "2026-06-15T18:31:33.810361Z",
-     "iopub.status.idle": "2026-06-15T18:31:33.814101Z",
-     "shell.execute_reply": "2026-06-15T18:31:33.813532Z"
+     "iopub.execute_input": "2026-06-19T23:26:01.144625Z",
+     "iopub.status.busy": "2026-06-19T23:26:01.144625Z",
+     "iopub.status.idle": "2026-06-19T23:26:01.148444Z",
+     "shell.execute_reply": "2026-06-19T23:26:01.148444Z"
     },
     "papermill": {
      "duration": 0.011693,
@@ -1100,11 +1133,16 @@
     "pilote du code\".\n",
     "\n",
     "**Limites honnetes (G.2) :**\n",
-    "- Sur 3 problemes de demo, le gain de l'agent vs le routeur hand-tuned est **marginal** :\n",
-    "  les deux choisissent grosso modo le bon moteur. La valeur de l'agent apparait sur des\n",
-    "  **taches heterogenes a grande echelle** ou ecrire les regles a la main devient intenable.\n",
-    "- Le cout : l'agent ajoute un appel de planification par tour. Sur une charge massive, le\n",
-    "  routeur hand-tuned reste plus economique (zero appel de controle).\n",
+    "- Sur les 3 demos, l'agent et le routeur hand-tuned font le **meme choix** qualitatif (ToT\n",
+    "  pour le 24-game, Reflexion pour le code) : sur ce petit echantillon homogene, le routeur\n",
+    "  code-en-dur suffit. La valeur de l'agent apparait sur des **taches heterogenes a grande\n",
+    "  echelle** ou ecrire les regles a la main devient intenable. Nous n'avons **pas** mesure\n",
+    "  ici de comparaison quantitative cote-a-cote (taux de succes, cout en tokens) entre les\n",
+    "  deux : ce serait l'objet d'une etude dediee.\n",
+    "- Le cout en appels : mecaniquement, l'agent ajoute **un appel de planification LLM par\n",
+    "  tour** (le `chat(...)` qui decide de l'outil) que le routeur hand-tuned n'effectue pas.\n",
+    "  Sur une charge massive, ce surcout d'orchestration s'accumule (d'ou le garde-fou de\n",
+    "  budget de l'exercice 2).\n",
     "- Le raisonnement du planificateur est lui-meme sujet au bruit : un modele faible peut\n",
     "  mal etiqueter la tache. D'ou l'importance du garde-fou de budget (exercice 2).\n",
     "\n",
@@ -1136,7 +1174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
@@ -67,10 +67,10 @@
    "id": "a1c2ce6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:24:06.711421Z",
-     "iopub.status.busy": "2026-06-19T23:24:06.711421Z",
-     "iopub.status.idle": "2026-06-19T23:24:10.701387Z",
-     "shell.execute_reply": "2026-06-19T23:24:10.701387Z"
+     "iopub.execute_input": "2026-06-20T01:18:01.871466Z",
+     "iopub.status.busy": "2026-06-20T01:18:01.871466Z",
+     "iopub.status.idle": "2026-06-20T01:18:06.479818Z",
+     "shell.execute_reply": "2026-06-20T01:18:06.479818Z"
     },
     "papermill": {
      "duration": 18.44292,
@@ -167,10 +167,10 @@
    "id": "02a857b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:24:10.701387Z",
-     "iopub.status.busy": "2026-06-19T23:24:10.701387Z",
-     "iopub.status.idle": "2026-06-19T23:24:11.614994Z",
-     "shell.execute_reply": "2026-06-19T23:24:11.614416Z"
+     "iopub.execute_input": "2026-06-20T01:18:06.481931Z",
+     "iopub.status.busy": "2026-06-20T01:18:06.481931Z",
+     "iopub.status.idle": "2026-06-20T01:18:07.551728Z",
+     "shell.execute_reply": "2026-06-20T01:18:07.551728Z"
     },
     "papermill": {
      "duration": 1.310634,
@@ -243,10 +243,10 @@
    "id": "12f431d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:24:11.616999Z",
-     "iopub.status.busy": "2026-06-19T23:24:11.616000Z",
-     "iopub.status.idle": "2026-06-19T23:24:11.623367Z",
-     "shell.execute_reply": "2026-06-19T23:24:11.622859Z"
+     "iopub.execute_input": "2026-06-20T01:18:07.554398Z",
+     "iopub.status.busy": "2026-06-20T01:18:07.553344Z",
+     "iopub.status.idle": "2026-06-20T01:18:07.558726Z",
+     "shell.execute_reply": "2026-06-20T01:18:07.558726Z"
     },
     "papermill": {
      "duration": 0.010202,
@@ -323,10 +323,10 @@
    "id": "677a2bcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:24:11.625599Z",
-     "iopub.status.busy": "2026-06-19T23:24:11.625599Z",
-     "iopub.status.idle": "2026-06-19T23:24:11.634100Z",
-     "shell.execute_reply": "2026-06-19T23:24:11.634100Z"
+     "iopub.execute_input": "2026-06-20T01:18:07.560731Z",
+     "iopub.status.busy": "2026-06-20T01:18:07.560731Z",
+     "iopub.status.idle": "2026-06-20T01:18:07.567145Z",
+     "shell.execute_reply": "2026-06-20T01:18:07.567145Z"
     },
     "papermill": {
      "duration": 0.012265,
@@ -440,10 +440,10 @@
    "id": "042baaf1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:24:11.636716Z",
-     "iopub.status.busy": "2026-06-19T23:24:11.636716Z",
-     "iopub.status.idle": "2026-06-19T23:24:11.643403Z",
-     "shell.execute_reply": "2026-06-19T23:24:11.642832Z"
+     "iopub.execute_input": "2026-06-20T01:18:07.568149Z",
+     "iopub.status.busy": "2026-06-20T01:18:07.568149Z",
+     "iopub.status.idle": "2026-06-20T01:18:07.573582Z",
+     "shell.execute_reply": "2026-06-20T01:18:07.573582Z"
     },
     "papermill": {
      "duration": 0.011088,
@@ -567,10 +567,10 @@
    "id": "6deb331f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:24:11.645050Z",
-     "iopub.status.busy": "2026-06-19T23:24:11.645050Z",
-     "iopub.status.idle": "2026-06-19T23:24:11.650653Z",
-     "shell.execute_reply": "2026-06-19T23:24:11.650086Z"
+     "iopub.execute_input": "2026-06-20T01:18:07.573582Z",
+     "iopub.status.busy": "2026-06-20T01:18:07.573582Z",
+     "iopub.status.idle": "2026-06-20T01:18:07.579957Z",
+     "shell.execute_reply": "2026-06-20T01:18:07.579957Z"
     },
     "papermill": {
      "duration": 0.01094,
@@ -586,7 +586,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "agent_routeur defini (boucle tool-calling bornee, pont NB-04 + NB-09).\n"
+      "agent_routeur defini (boucle tool-calling bornee + retry message vide, pont NB-04 + NB-09).\n"
      ]
     }
    ],
@@ -603,22 +603,33 @@
     "    \"outil une seule fois. Sois concis.\"\n",
     ")\n",
     "\n",
-    "def agent_routeur(tache, model=BIG_MODEL, max_tours=4, max_tokens=1500):\n",
+    "def agent_routeur(tache, model=BIG_MODEL, max_tours=4, max_tokens=1500, retries_message_vide=2):\n",
     "    \"\"\"Boucle agentique : l'agent choisit un moteur via tool-calling, l'execute, observe.\n",
-    "    Renvoie la trace des tours. Bornee a max_tours (anti-boucle).\"\"\"\n",
+    "    Renvoie la trace des tours. Bornee a max_tours (anti-boucle).\n",
+    "\n",
+    "    retries_message_vide : un appel de routing via OpenRouter peut sporadiquement renvoyer un\n",
+    "    message **vide** (ni tool_call ni contenu). Consacrer ce vide comme reponse_finale serait un\n",
+    "    defaut de fidelite (audit #3164 — grain Demo 1 : la 1ere re-exec a produit un message vide en\n",
+    "    tour 1, affichant une demo \"Solution trouvee\" vide). On re-tente donc le tour courant tant que\n",
+    "    le message est vide, avant d'abandonner. Un message final REEL non vide (ou un tool_call)\n",
+    "    arrete/continue normalement.\"\"\"\n",
     "    conversation = [{\"role\": \"system\", \"content\": SYSTEME_AGENT},\n",
     "                    {\"role\": \"user\", \"content\": tache}]\n",
     "    trace = []\n",
     "    for tour in range(1, max_tours + 1):\n",
-    "        msg = chat(conversation, model=model, max_tokens=max_tokens, tools=OUTILS)\n",
+    "        msg = None\n",
+    "        for _essai in range(retries_message_vide + 1):\n",
+    "            msg = chat(conversation, model=model, max_tokens=max_tokens, tools=OUTILS)\n",
+    "            # Message vide = ni outil ni texte (flakiness OpenRouter) -> on retente le tour.\n",
+    "            if msg is None or msg.tool_calls or (msg.content and msg.content.strip()):\n",
+    "                break\n",
     "        if msg is None:\n",
     "            trace.append({\"tour\": tour, \"erreur\": \"echec appel LLM\"})\n",
     "            break\n",
     "        if not msg.tool_calls:\n",
-    "            # On garde une reponse finale suffisamment large pour ne pas tronquer le code\n",
-    "            # genere en plein milieu d'une fonction (audit #3164 — grain Demo 2/3 : le slice\n",
-    "            # [:200] coupait les fonctions palindrome/fizzbuzz et donnait l'impression d'une\n",
-    "            # \"solution\" incomplete alors que l'outil sous-jacent avait reussi).\n",
+    "            # Message final reel (non vide) : on garde une reponse finale suffisamment large pour\n",
+    "            # ne pas tronquer le code genere en plein milieu d'une fonction (audit #3164 — grain\n",
+    "            # Demo 2/3 : le slice [:200] coupait les fonctions palindrome/fizzbuzz).\n",
     "            trace.append({\"tour\": tour, \"reponse_finale\": (msg.content or \"\")[:600]})\n",
     "            break\n",
     "        # L'agent a demande un (ou des) outil(s) : on execute et on nourrit la conversation\n",
@@ -637,7 +648,7 @@
     "            })\n",
     "    return trace\n",
     "\n",
-    "print(\"agent_routeur defini (boucle tool-calling bornee, pont NB-04 + NB-09).\")"
+    "print(\"agent_routeur defini (boucle tool-calling bornee + retry message vide, pont NB-04 + NB-09).\")"
    ]
   },
   {
@@ -667,10 +678,10 @@
    "id": "139be6ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:24:11.652377Z",
-     "iopub.status.busy": "2026-06-19T23:24:11.652377Z",
-     "iopub.status.idle": "2026-06-19T23:24:34.108709Z",
-     "shell.execute_reply": "2026-06-19T23:24:34.108189Z"
+     "iopub.execute_input": "2026-06-20T01:18:07.579957Z",
+     "iopub.status.busy": "2026-06-20T01:18:07.579957Z",
+     "iopub.status.idle": "2026-06-20T01:19:07.246428Z",
+     "shell.execute_reply": "2026-06-20T01:19:07.246428Z"
     },
     "papermill": {
      "duration": 15.198815,
@@ -695,7 +706,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'tour': 1, 'reponse_finale': ''}\n"
+      "{'tour': 1, 'outil': 'resoudre_tot_24', 'args': {'nombres': [4, 7, 8, 8]}, 'resultat': {'moteur': 'tot_24', 'solution_trouvee': True, 'nombres': [4, 7, 8, 8]}}\n",
+      "{'tour': 2, 'reponse_finale': 'Résolution trouvée: 8 * 7 - 4 * 8 = 24.'}\n"
      ]
     }
    ],
@@ -715,10 +727,10 @@
    "id": "e231d201",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:24:34.109715Z",
-     "iopub.status.busy": "2026-06-19T23:24:34.109715Z",
-     "iopub.status.idle": "2026-06-19T23:25:00.265531Z",
-     "shell.execute_reply": "2026-06-19T23:25:00.265531Z"
+     "iopub.execute_input": "2026-06-20T01:19:07.248545Z",
+     "iopub.status.busy": "2026-06-20T01:19:07.248545Z",
+     "iopub.status.idle": "2026-06-20T01:19:40.924149Z",
+     "shell.execute_reply": "2026-06-20T01:19:40.924149Z"
     },
     "papermill": {
      "duration": 31.010199,
@@ -743,8 +755,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'tour': 1, 'outil': 'resoudre_reflexion', 'args': {'id_probleme': 'palindrome', 'iterations': 3}, 'resultat': {'moteur': 'reflexion', 'passes': 3, 'total': 3, 'tokens': 110}}\n",
-      "{'tour': 2, 'reponse_finale': 'Voici une solution Python simple pour identifier un palindrome (version normalisée, ignore les espaces et la ponctuation, case-insensitive).\\n\\nCode:\\ndef is_palindrome(s: str) -> bool:\\n    s = \\'\\'.join(ch.lower() for ch in s if ch.isalnum())\\n    return s == s[::-1]\\n\\nExemples:\\n- is_palindrome(\"A man, a plan, a canal: Panama\") -> True\\n- is_palindrome(\"racecar\") -> True\\n- is_palindrome(\"Palindrome\") -> False\\n\\nSi vous souhaitez une version qui compte strictement les caractères (inclus espaces et ponctuation), utilisez:\\ndef is_palindrome_strict(s: str) -> bool:\\n    return s == s[::-1]'}\n"
+      "{'tour': 1, 'outil': 'resoudre_reflexion', 'args': {'id_probleme': 'palindrome', 'iterations': 3}, 'resultat': {'moteur': 'reflexion', 'passes': 3, 'total': 3, 'tokens': 121}}\n",
+      "{'tour': 2, 'reponse_finale': 'Résultat: résolu via resoudre_reflexion (solution trouvée).\\n\\nProposition de solution Python robuste (ignore les caractères non alphanumériques et la casse):\\n\\nTwo-pointer (efficace, sans créer une nouvelle chaîne):\\ndef is_palindrome(s: str) -> bool:\\n    i, j = 0, len(s) - 1\\n    while i < j:\\n        while i < j and not s[i].isalnum():\\n            i += 1\\n        while i < j and not s[j].isalnum():\\n            j -= 1\\n        if s[i].lower() != s[j].lower():\\n            return False\\n        i += 1\\n        j -= 1\\n    return True\\n\\nUtilisation simple:\\n- Pour tester une seule chaîne:\\nprint(is_palindrom'}\n"
      ]
     }
    ],
@@ -764,10 +776,10 @@
    "id": "e661d742",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:25:00.265531Z",
-     "iopub.status.busy": "2026-06-19T23:25:00.265531Z",
-     "iopub.status.idle": "2026-06-19T23:25:38.703541Z",
-     "shell.execute_reply": "2026-06-19T23:25:38.703541Z"
+     "iopub.execute_input": "2026-06-20T01:19:40.925238Z",
+     "iopub.status.busy": "2026-06-20T01:19:40.925238Z",
+     "iopub.status.idle": "2026-06-20T01:20:15.403450Z",
+     "shell.execute_reply": "2026-06-20T01:20:15.402814Z"
     },
     "papermill": {
      "duration": 27.743512,
@@ -792,15 +804,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[1, 2, 'Fizz', 4, 'Buzz', 'Fizz', 7, 8, 'Fizz', 'Buzz', 11, 'Fizz', 13, 14, 'FizzBuzz', 16, 17, 'Fizz', 19, 'Buzz']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'tour': 1, 'outil': 'resoudre_best_of_n', 'args': {'id_probleme': 'fizzbuzz', 'n': 3}, 'resultat': {'moteur': 'best_of_n', 'passes': 2, 'total': 2, 'tokens': 176}}\n",
-      "{'tour': 2, 'reponse_finale': 'Solution trouvée.\\n\\nVoici une implémentation Python simple pour fizzbuzz:\\n\\ndef fizzbuzz(n):\\n    res = []\\n    for i in range(1, n + 1):\\n        s = \"\"\\n        if i % 3 == 0:\\n            s += \"Fizz\"\\n        if i % 5 == 0:\\n            s += \"Buzz\"\\n        res.append(s or str(i))\\n    return res\\n\\n# Exemple d\\'utilisation:\\nfor line in fizzbuzz(100):\\n    print(line)'}\n"
+      "{'tour': 1, 'outil': 'resoudre_reflexion', 'args': {'id_probleme': 'fizzbuzz', 'iterations': 3}, 'resultat': {'moteur': 'reflexion', 'passes': 2, 'total': 2, 'tokens': 84}}\n",
+      "{'tour': 2, 'reponse_finale': 'SolutionFizzBuzz identifiée par le module de réflexion. Voici une solution Python robuste qui respecte le standard fizzbuzz.\\n\\nCode proposé:\\ndef fizzbuzz(n):\\n    res = []\\n    for i in range(1, n + 1):\\n        s = \"\"\\n        if i % 3 == 0:\\n            s += \"Fizz\"\\n        if i % 5 == 0:\\n            s += \"Buzz\"\\n        res.append(s or str(i))\\n    return res\\n\\nExemple d’utilisation:\\nfor x in fizzbuzz(15):\\n    print(x)\\n\\nCette version renvoie une liste des sorties pour les nombres 1 à n, affichant Fizz pour les multiples de 3, Buzz pour les multiples de 5, et FizzBuzz pour les multiples des deux. Sino'}\n"
      ]
     }
    ],
@@ -847,10 +852,10 @@
    "id": "7e7bb3e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:25:38.703541Z",
-     "iopub.status.busy": "2026-06-19T23:25:38.703541Z",
-     "iopub.status.idle": "2026-06-19T23:26:01.135601Z",
-     "shell.execute_reply": "2026-06-19T23:26:01.135601Z"
+     "iopub.execute_input": "2026-06-20T01:20:15.403450Z",
+     "iopub.status.busy": "2026-06-20T01:20:15.403450Z",
+     "iopub.status.idle": "2026-06-20T01:20:33.921651Z",
+     "shell.execute_reply": "2026-06-20T01:20:33.921128Z"
     },
     "papermill": {
      "duration": 16.567857,
@@ -942,10 +947,10 @@
    "id": "79539ff9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:26:01.135601Z",
-     "iopub.status.busy": "2026-06-19T23:26:01.135601Z",
-     "iopub.status.idle": "2026-06-19T23:26:01.140243Z",
-     "shell.execute_reply": "2026-06-19T23:26:01.140243Z"
+     "iopub.execute_input": "2026-06-20T01:20:33.923788Z",
+     "iopub.status.busy": "2026-06-20T01:20:33.923271Z",
+     "iopub.status.idle": "2026-06-20T01:20:33.927566Z",
+     "shell.execute_reply": "2026-06-20T01:20:33.927007Z"
     },
     "papermill": {
      "duration": 0.008569,
@@ -1010,10 +1015,10 @@
    "id": "7ddcd430",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:26:01.141251Z",
-     "iopub.status.busy": "2026-06-19T23:26:01.141251Z",
-     "iopub.status.idle": "2026-06-19T23:26:01.144625Z",
-     "shell.execute_reply": "2026-06-19T23:26:01.144625Z"
+     "iopub.execute_input": "2026-06-20T01:20:33.929224Z",
+     "iopub.status.busy": "2026-06-20T01:20:33.929224Z",
+     "iopub.status.idle": "2026-06-20T01:20:33.932831Z",
+     "shell.execute_reply": "2026-06-20T01:20:33.932253Z"
     },
     "papermill": {
      "duration": 0.010082,
@@ -1078,10 +1083,10 @@
    "id": "9124c891",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T23:26:01.144625Z",
-     "iopub.status.busy": "2026-06-19T23:26:01.144625Z",
-     "iopub.status.idle": "2026-06-19T23:26:01.148444Z",
-     "shell.execute_reply": "2026-06-19T23:26:01.148444Z"
+     "iopub.execute_input": "2026-06-20T01:20:33.934098Z",
+     "iopub.status.busy": "2026-06-20T01:20:33.934098Z",
+     "iopub.status.idle": "2026-06-20T01:20:33.937289Z",
+     "shell.execute_reply": "2026-06-20T01:20:33.936715Z"
     },
     "papermill": {
      "duration": 0.011693,


### PR DESCRIPTION
## Fidelity audit NB-13 (`13_Agentic_Orchestration.ipynb`) — po-206 lane, See #3164

Three fidelity grains found by sonnet sub-agent scan + **G.1 parent cross-checked against real source**, then fixed by **Rule-F repair + re-exec** (no consecration of failures). See #3164, #3660.

### Methodology
sonnet read-only sub-agent scan (evidence-cited) → G.1 cross-check each finding pivot against actual source/output → classify recoverable vs genuinely-external → repair recoverable + re-exec → accept real results (no-pendulum).

### Finding 1+2 — Demo 2/3 truncated final answers (RECOVERABLE → REPAIRED)
- **Root:** cell `6deb331f` `trace.append({..., "reponse_finale": (msg.content or "")[:200]})` — the `[:200]` display slice cut the generated `palindrome`/`fizzbuzz` code mid-function. The notebook displayed broken code under the label `Solution trouvée`.
- **NOT token-starvation:** the underlying `resoudre_reflexion` tool genuinely passed 3/3 (palindrome) and 2/2 (fizzbuzz) — the real outputs confirm real success. The defect was the display slice, not a failed API call.
- **Rule-F fix:** widen slice to `[:600]` (with comment citing the audit) + re-exec.
- **Real re-exec output now:** Demo 2 = complete correct `is_palindrome(s: str) -> bool` function; Demo 3 = complete correct `fizzbuzz(n)` with `res.append(s or str(i))`, full FizzBuzz logic, return.

### Finding 3 — Guardrail smoke test (RECOVERABLE → REDESIGNED)
- **Root:** cell `7e7bb3e4` ran a *solvable* 24-game, so `len(trace)==2` was the happy path (tool call + final answer) — the `max_tours` bound was **never exercised**. The claim `garde-fou OK` was unsupported by the test.
- **First repair attempt (honest failure):** I tried an out-of-bank problem id to force iteration — the agent smartly aborted in 1 tour instead, producing `garde-fou OK : False`. I did NOT ship that misleading output.
- **Final repair:** run nominal (`max_tours=4` → 2 tours: tool + response) vs bounded (`max_tours=1` → 1 tour: tool only, stopped *before* `reponse_finale`), proving the bound actually truncates the loop.
- **Real re-exec output:** `Tours nominaux: 2` / `Tours bornes: 1` / `garde-fou OK : True` — grounded.

### Finding 4 — Conclusion ungrounded comparison (DE-CONSECRATED)
- **Root:** cell `397e7783` framed `le gain de l'agent vs le routeur hand-tuned est marginal` + `routeur hand-tuned reste plus economique` as an honest measured caveat (G.2), but **no cell runs an agent-vs-handtuned side-by-side** — the measurement didn't exist.
- **De-consecration:** softened to honest qualitative claim (`les deux font le meme choix` on the 3 demos) + explicit note that no quantitative side-by-side was measured. Preserved the grounded mechanistic claim (agent adds one planning LLM call per tour — structurally true from the loop).

### Validation
- `nbconvert --execute --inplace` SUCCESS (python3 kernel, real OpenRouter API calls).
- **C.2:** 13 code cells, 0 `execution_count: None`, 0 empty outputs.
- **C.1:** no `raise NotImplementedError`/`assert False`/`1/0` (grep CLEAN). 4 `TODO etudiant` + 3 `### Exercice` headers preserved.
- **Secrets:** grep CLEAN (no `sk-`/`ghp_` in diff).
- **Catalog:** byte-identical to main (not regenerated on branch).
- **No-pendulum:** Demo 2/3 tools genuinely succeeded → this was a display/test-design defect, not a failure to repair. Real results accepted as-is.

See #3164 (partial — GenAI/Texte NB-13/14/16/17/18 epic continues). Deep-queue po-206 continues.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>