### PR TITLE
fix(#3164): NB-14 Persistent_Memory fidelity -- de-consecrate Section 5 'accelere' title vs measured delta=0

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/14_Persistent_Memory.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/14_Persistent_Memory.ipynb
@@ -625,13 +625,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 5. Demonstration — la memoire accelere un probleme similaire\n",
-    "\n",
-    "On resout d'abord **fizzbuzz** a froid (memoire vide), on **persiste** sa lecon, puis on\n",
-    "resout **fizzbuzz_etendu** (meme pitfall : concatenation de regles modulo). On compare le\n",
-    "nombre d'iterations et le taux de reussite avec vs sans memoire retrocedee."
-   ]
+   "source": "## 5. Demonstration — le mecanisme du transfer de lecon\n\nOn resout d'abord **fizzbuzz** a froid (memoire vide), on **persiste** sa lecon, puis on\nresout **fizzbuzz_etendu** (meme pitfall : concatenation de regles modulo). On compare le\ntaux de reussite avec vs sans memoire retrocedee.\n\n> **Ce que la demo montre reellement** : le **mecanisme** (persistence cross-run +\n> retrocession par similarite + injection dans le prompt) fonctionne — les lecons survivent\n> et sont bien retrocedees (score cosine 0.599). En revanche, sur ces deux problemes simples\n> resolus en 1 iteration, le **delta mesure vaut 0** : la baseline froide resout deja\n> `fizzbuzz_etendu` seule. De plus, la lecon stockee ici est un **diagnostic de statut**\n> (\"Resolu en N iteration(s). Pitfall maitrise.\"), pas une description technique du pitfall :\n> elle ne transporte donc pas d'information exploitable par le generateur. Pour qu'un transfer\n> mesurable apparaisse, il faudrait une lecon **instructive** (ex. le feedback des tests\n> echoues) ET des problemes ou la baseline froide echoue — conditions explorees dans la\n> conclusion (G.2) et les exercices."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Fidelity audit NB-14 (`14_Persistent_Memory.ipynb`) — po-206 lane, See #3164

sonnet sub-agent scan found NB-14 **notably more honest** than the repo's documented violation history: real outputs throughout, persistence genuinely verified by reload cell, conclusion already caveats `delta memoire` honestly. **1 fidelity grain** found via G.1 cross-check against real source.

### Finding 1 — Section 5 title "accelere" contradicts measured `Delta memoire : +0` (DE-CONSECRATED)
- **Cell `d7b72813`** (Section 5 header) titled: *"la memoire **accelere** un probleme similaire"*.
- **Cell `33d92668`** real output: `fizzbuzz_etendu AVEC memoire: 3/3` / `SANS memoire: 3/3` / **`Delta memoire : +0 test(s)`**.
- **Pattern D** (misaligned success interpretation): the title promises "acceleration" that the measured `+0` does not deliver.

### Rule-F analysis (no-pendulum)
- **NOT a recoverable failure to repair + re-exec.** The mechanism genuinely works: persistence verified by reload cell `fb5a4816` (`1 entree(s) persistee(s)`), retrieval score cosine `0.599`, lecons survive cross-run. The `delta=0` is real and correct — both problems are simple enough that the cold baseline solves them in 1 iteration.
- **Did NOT redesign the stored-lesson payload** (`diagnostic = "Resolu en N iteration(s). Pitfall maitrise."`) — that would alter pedagogical design beyond fidelity scope, and the sub-agent flagged it as borderline (C/E), not a hard violation.
- **Did NOT manufacture a nonzero delta** by inserting a contrived failing problem — that would be the pendulum swing (forcing the "accelerates" story to hold).

### Fix (markdown-only de-consecration)
Retitled Section 5 to *"le mecanisme du transfer de lecon"* + honest callout grounded in the actual `0.599` and `+0` outputs: states the mechanism works, explains why delta=0 (easy problems solved in 1 iteration + stored lesson is a status diagnostic, not technical content), and points to the conclusion (G.2) + exercises for where measurable transfer would require an informative lesson AND problems where the cold baseline fails.

### Validation
- **Markdown-only change** → previous code outputs remain valid (rule C.2 exception, no re-exec needed). 1 insertion / 7 deletions (title cell replacement).
- **Secrets:** grep CLEAN.
- **Catalog:** byte-identical to main.
- **No source code changed** (no `raise NotImplementedError` etc., 3 exercises + stubs untouched).

See #3164 (partial — GenAI/Texte NB-13/14/16/17/18 epic continues). Deep-queue po-206: NB-16 next.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>