### PR TITLE
docs(lean): add prev/next inter-series nav breadcrumb to README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -7,7 +7,7 @@ breakdown: Lean=26
 maturity: PRODUCTION=22, BETA=4
 -->
 
-> Série [`SymbolicAI`](../README.md) › **Lean**
+[← SemanticWeb](../SemanticWeb/README.md) | [↑ SymbolicAI](../README.md) | [Planners →](../Planners/README.md)
 
 Cette serie introduit **Lean 4**, un assistant de preuves et langage de programmation fonctionnel base sur la theorie des types dependants. Le fil rouge va des fondations (types dependants, mode tactique, Mathlib) vers l'etat de l'art : assistance aux preuves par LLM et verification formelle de reseaux de neurones, ports de théorèmes phares (théorème de Kochen-Specker / 18 vecteurs Cabello ; théorème du libre arbitre de Conway-Kochen ; finitude des dérivées symboliques de Brzozowski), theorie des nœuds (mouvements de Reidemeister, tricolorabilite de Fox, noeud de Conway et preuve de Piccirillo), et hommages aux mathematiciens (Grothendieck et le langage grothendieckien dans Mathlib 4 ; John Conway, l'homme et l'oeuvre).
 


### PR DESCRIPTION
## Summary

Replace the inline breadcrumb ("> Série \`SymbolicAI\` › **Lean**") in the Lean README with the canonical inter-series nav line used by the 7 other SymbolicAI sub-series:

`[← SemanticWeb](../SemanticWeb/README.md) | [↑ SymbolicAI](../README.md) | [Planners →](../Planners/README.md)`

This was the one sub-series missing the canonical `[← prev] | [↑ hub] | [next →]` nav format (identified in the #2651 Part 2 census as a nav gap). Lean is the only sub-series with an inline `›`-style breadcrumb instead of the standard nav line.

### Canonical chain (now complete and consistent)
Per the hub's implicit ordering (SymbolicAI/README.md L14, L22-38: Web Sémantique → vérification formelle → argumentation → planification → smart contracts → analyse argumentative → apprentissage symbolique):

\`\`\`
Tweety → SemanticWeb → Lean → Planners → SmartContracts → Argument_Analysis → SymbolicLearning → SMT
\`\`\`

Verification against existing navs:
- Tweety: `↑ | SemanticWeb →` (terminal start, no `←` — correct)
- SemanticWeb: `← Tweety | ↑ | Lean →` ✓
- **Lean: `← SemanticWeb | ↑ | Planners →`** ← this PR (was inline breadcrumb)
- Planners: `← Lean | ↑ | SmartContracts →` ✓
- SmartContracts: `← Planners | ↑ | Argument_Analysis →` ✓
- Argument_Analysis: `← SmartContracts | ↑ | SymbolicLearning →` ✓
- SymbolicLearning: `← Argument_Analysis | ↑ | SMT →` ✓

## Scope
- **Single-line edit (+1/-1)**. Markdown-only. One file. One deliverable (atomique HARD 3).
- No notebook, no catalog churn (byte-identical to main).
- No `CATALOG-STATUS` marker touched (catalog-pr-hygiene HARD 1 — marker belongs to the bot).

## G.1 link verification
| Link | Target | Verified |
|------|--------|----------|
| `../SemanticWeb/README.md` | sub-series | exists |
| `../README.md` | SymbolicAI hub | exists |
| `../Planners/README.md` | sub-series | exists |

## Validation
- `check-links` CI validates anchors + relative paths (PASS expected).
- H.3 not triggered (markdown-only, C.2 exception).

See #2651