### PR TITLE
fix(gametheory): correct type-H Cournot baseline in Bayesian interp (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
@@ -1091,7 +1091,7 @@
     "\n",
     "**Observations fondamentales** :\n",
     "1. **Le type a cout bas produit PLUS** (31.67 vs 30.0) car il anticipe qu'un adversaire pourrait etre inefficace (cout haut) et reduira sa quantite\n",
-    "2. **Le type a cout haut produit MOINS** (21.67 vs 30.0) car il anticipe qu'un adversaire pourrait etre tres efficace (cout bas)\n",
+    "2. **Le type a cout haut produit MOINS** (21.67 vs 23.3) car il anticipe qu'un adversaire pourrait etre tres efficace (cout bas)\n",
     "3. L'incertitude modifie le comportement de maniere contre-intuitive : le type efficient profite de l'incertitude pour produire davantage\n",
     "\n",
     "> **Note technique** : Ce resultat illustre un principe general : l'information incomplete cree de l'heterogeneite strategique, meme quand les types sont ex-ante symetriques."


### PR DESCRIPTION
## Summary

GameTheory-11-BayesianGames fidelity audit (Epic **#3164**, align-not-fabricate). One finding (MED): an interpretation cell compared the high-cost Cournot type's incomplete-info quantity against the **wrong complete-info baseline**.

## Finding (G.1 cross-checked against real output)

| Cell | Claim (markdown) | Committed output | Fix |
|------|------------------|------------------|-----|
| **idx22** (Cournot incomplete-info, point 2) | "Le type a cout haut produit MOINS (**21.67 vs 30.0**)" | cell 21: complete-info `(c1=30, c2=30) → q=23.3`; `30.0` is the **low-cost** type's (c=10) quantity, not high-cost | `21.67 vs 23.3` |

**Why this matters**: the markdown compared the high-cost type's incomplete-info quantity (21.67) to the *low-cost* type's complete-info quantity (30.0), mixing types. The correct apples-to-apples comparison is high-cost incomplete (21.67) vs high-cost complete (23.3). The qualitative conclusion ("type-H produces less under incomplete info") **remains true** — only the baseline number was wrong (no-pendulum).

The **point-1** baseline (type-L `31.67 vs 30.0`) is correct (30.0 IS the type-L complete-info quantity) and is left untouched.

## Scope

- **Markdown-only**, no-pendulum (output is a genuine Cournot solver result, not a failure).
- **Text-level surgical edit** — 1 ins / 1 del (only the one value in point 2).
- Code cells, `outputs`, `execution_count` **byte-identical**.
- `COURSE_CATALOG.generated.*` and MGS submodule **byte-identical** (3-dot).

## Verification

```
git diff --stat : 1 file, 1 ins / 1 del
code-cell source churn (execution_count/outputs +) : 0
catalogue / submodule : byte-identical (3-dot)
JSON parses : OK
```

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)