### PR TITLE
fix(gametheory): align GT-12 Kreps-Wilson reputation claim with simulation output (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
@@ -743,7 +743,7 @@
     "- **Separateur** : Reveler son type (toujours accommoder) - perd la reputation\n",
     "- **Mixte** : Combattre avec probabilite calibree pour maintenir le doute\n",
     "\n",
-    "> **Paradoxe resolu** : Meme avec seulement 10% de chances d'etre face a un Fou, le monopole Normal peut exploiter cette incertitude pour dissuader certains entrants, gagnant plus qu'a l'equilibre d'information complete."
+    "> **Paradoxe et cout de la reputation** : Meme avec seulement 10% de chances d'etre face a un Fou, le monopole Normal exploite cette incertitude pour dissuader certains entrants (~2 marches evitees). Dans cette simulation simplifiee (strategie heuristique Fight-si-reputation < 0.5), ce cout de construction de reputation domine : le type Normal gagne en moyenne -7.00, soit MOINS que la reference en information complete (+10) — le prix a payer pour le signalement agressif. L'equilibre exact de Kreps-Wilson, avec strategies mixtes et mise a jour bayesienne fine, restaurerait le benefice net de la reputation (cf. note technique idx12)."
    ]
   },
   {


### PR DESCRIPTION
## Summary

#3164 fidelity audit — `GameTheory-12-ReputationGames.ipynb`.

**1 Class A finding (HIGH), markdown-only fix.**

### idx10 — blockquote contradicts committed simulation output

The Kreps-Wilson interpretation blockquote claimed:

> le monopole Normal peut exploiter cette incertitude pour dissuader certains entrants, **gagnant plus qu'à l'équilibre d'information complète**.

But the committed simulation output (idx11, `execution_count=6`) shows:

```
Simulation: 10 marches, epsilon=0.1, 10000 sims
  Monopole Normal - Gain moyen: -7.00
  Monopole Fou    - Gain moyen: 11.00
  Entrants        - Gain total moyen: -9.00
  Reference (info complete): Monopole = 10, Entrants = 10
```

The Normal type earns **-7.00**, dramatically LESS than the +10 complete-info reference — the opposite of "gains more".

### Why this is #3164 (not a code/regeneration issue)

The contradiction is **markdown-vs-committed-output**, not a stale simulation. The simulation genuinely produces these numbers with its simplified heuristic strategy (Normal: Fight if reputation < 0.5; Entrant: Enter if reputation < 0.5). The reputation-building cost dominates in this toy model.

The sibling cell **idx12 already states this faithfully** ("le monopole Normal perd en moyenne", table ~-7, "Note technique: la stratégie simplifiée capture l'intuition mais l'équilibre exact de Kreps-Wilson utilise des stratégies mixtes plus sophistiquées"). So idx10 was internally inconsistent with the notebook's own faithful reading.

### Fix (no-pendulum)

Reversed only the contradicted "gains more" claim → aligned on the committed output (-7.00 vs +10), while **preserving** the real Kreps-Wilson theoretical intuition:
- The deterrence mechanism IS real (~2 entrants dissuaded, epsilon=0.1 < 0.5).
- The exact Kreps-Wilson equilibrium (mixed strategies + fine Bayesian updating) would restore the net reputation benefit — pointed to via idx12's existing note technique.

Did NOT fabricate outputs, did NOT regenerate, did NOT delete the theoretical content.

## Validation
- Markdown-only: code cells + committed outputs byte-identical (verified `json.dumps(indent=1)==raw` round-trip).
- 0 error cells, C.2 preserved (idx11 exec_count=6, outputs intact).
- Surgical text-level edit: 1 insertion / 1 deletion, idx10 only.
- Catalogue + submodule byte-identical (no notebook added/removed).

## G.1 verification
Re-read cells 9-12 directly from notebook JSON before acting. Confirmed sub-agent finding: idx10 blockquote vs idx11 output contradiction is real; idx12 faithful. Cell index 10 correct.

See #3164

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>