### PR TITLE
fix(gametheory): correct Fictitious Play exploitability in GT-17 comparison table (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
@@ -1648,7 +1648,7 @@
     "| Methode | Convergence | Exploitabilite finale | Commentaire |\n",
     "|---------|-------------|----------------------|-------------|\n",
     "| **Self-Play Naif** | Non (cycles) | ~0.4 | Oscille perpetuellement, ne converge pas |\n",
-    "| **Fictitious Play** | Oui (monotone) | ~0.001 | Convergence lente mais garantie |\n",
+    "| **Fictitious Play** | Oui (monotone) | ~0.04 | Convergence lente mais garantie |\n",
     "| **NFSP** | Oui (approx) | ~1.0 | Version simplifiee sans reseaux neurones |\n",
     "| **PSRO** | Oui (exacte) | 0.000 | Convergence rapide, population explicite |\n",
     "\n",


### PR DESCRIPTION
## Summary

#3164 fidelity audit — `GameTheory-17-MultiAgent-RL.ipynb`.

**1 Class A finding (HIGH), markdown-only fix.**

### idx26 — Fictitious Play exploitability exaggerated ~40x

The comparison interpretation table stated:
```
| Fictitious Play | Oui (monotone) | ~0.001 | Convergence lente mais garantie |
```
But the committed outputs show Fictitious Play exploitability is **~0.04**, not ~0.001:
- idx14 stdout: `Exploitabilite finale: 0.039761`
- idx25 recap table (printed by code): `Fictitious Play 0.0396 Oui`

The `~0.001` value fabricated a far cleaner convergence than the actual run achieved (~40x smaller than reality). Corrected to `~0.04`.

## No-pendulum

The qualitative claims are **preserved**:
- Caption "Convergence lente mais garantie" remains accurate — Fictitious Play does converge theoretically in zero-sum games (Robinson 1951), and 0.0396 is reasonably near-Nash for the iteration budget.
- The "Converge vers Nash? Oui" verdict matches the committed recap table (idx25) exactly.
- All other rows verified faithful: Self-Play Naif ~0.4 (idx9=0.4127), NFSP ~1.0 (idx19=1.0099/idx25=0.9510), PSRO 0.000 (idx23=0.000000).

Only the single contradicted number was corrected. Did NOT reverse the convergence verdict, did NOT fabricate, did NOT regenerate.

## Validation
- Markdown-only: code cells + committed outputs byte-identical (`json.dumps(indent=1)==raw` round-trip verified).
- 0 error cells; C.2 preserved (idx14 exec=5, idx25 exec=9, all outputs intact).
- Surgical text-level edit: 1 insertion / 1 deletion, cell idx26 only.
- Catalogue + submodule byte-identical.

## G.1 verification
Re-read cells 14, 25, 26 directly from notebook JSON before acting. Confirmed sub-agent finding real; cell index 26 correct. The idx25 code-printed recap table (0.0396) independently corroborates idx14 (0.039761).

See #3164

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>