### PR TITLE
fix(gametheory): align GT-15 NFP seats narrative with committed official data (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
@@ -1646,7 +1646,7 @@
     "- **EELV** (Europe Écologie Les Verts) : 3.26%\n",
     "- **PCF** (Parti Communiste Français) : 2.31%\n",
     "\n",
-    "Le NFP obtient **182 sièges** (1er groupe, mais sans majorité absolue de 289).\n",
+    "Le NFP obtient **177 sièges** (1er groupe, mais sans majorité absolue de 289).\n",
     "\n",
     "### Question\n",
     "\n",


### PR DESCRIPTION
## Summary

#3164 fidelity audit — `GameTheory-15-CooperativeGames.ipynb`.

**1 Class A finding (MED), markdown-only fix.**

### idx31 — NFP seats narrative contradicts committed data

Section 5 intro (idx31) stated:
> Le NFP obtient **182 sièges** (1er groupe, mais sans majorité absolue de 289).

But no committed output supports 182. The notebook's own data shows:
- **idx32** (official legislative data): `NFP | Nouveau Front Populaire | 21.45% | 177` (71+64+33+9)
- **idx34** (model analysis): `Valeur coalition complete (NFP): 180.0`
- **idx40** (scenario analysis): `NFP complet (LFI+PS+EELV+PCF): 180 sieges estimes`

The 182 reflected external/historical knowledge (the real-world NFP seat count), not the notebook's data — a classic external-knowledge fabrication vector.

## Fix (no-pendulum)

The idx31 intro cell leads directly into the idx32 official-data code cell. The coherent source-of-truth value is **177** — the sum the notebook itself presents as the official legislative fact (idx32). Corrected 182 → 177.

Did NOT pick 180 (a derived model output, not the "official fact" the narrative describes) and did NOT keep 182 (external, unsupported by any committed output). The narrative now matches the very next cell's official data.

## Validation
- Markdown-only: code cells + committed outputs byte-identical (`json.dumps(indent=1)==raw` round-trip verified).
- 0 error cells; C.2 preserved (idx32 exec=16 official-data output intact).
- Surgical text-level edit: 1 insertion / 1 deletion, cell idx31 only.
- Catalogue + submodule byte-identical.

## G.1 verification
Re-read cells 31, 32, 34, 40 directly from notebook JSON before acting. Confirmed 182 appears only in the markdown line; committed outputs use 177 (idx32) and 180 (idx34/idx40 model). Cell index 31 correct.

See #3164

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>