### PR TITLE
fix(probas): scrub absolute papermill output_path in Pyro_RSA_Hyperbole (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb
@@ -1584,7 +1584,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Pyro_RSA_Hyperbole.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/search_papermill/Pyro_RSA_Hyperbole.ipynb",
+   "output_path": "Pyro_RSA_Hyperbole.ipynb",
    "parameters": {},
    "start_time": "2026-06-05T18:38:01.546452+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
See #3436

Scrub the Probas slice of the repo-wide papermill-path scrub epic #3436 (tool `scrub_papermill_paths.py` from PR #3435).

## Change
`MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb` `metadata.papermill.output_path` was a machine-local temp path injected by a prior papermill re-exec via an absolute output path:
`C:/Users/jsboi/AppData/Local/Temp/search_papermill/Pyro_RSA_Hyperbole.ipynb` -> `Pyro_RSA_Hyperbole.ipynb` (basename).

- **Text-level surgical metadata-only**: 1 insertion / 1 deletion, single line. Rest of notebook byte-identical (no JSON re-serialization churn).
- Fixes reproducibility (temp path no longer exists) + local dir-structure leak.

## Partition scan (po-2025)
Scanned my full partition: ML (0), Sudoku (0), SymbolicAI/SMT (0), SymbolicAI/Argument_Analysis (0), Probas (1 = this notebook). **Pyro_RSA_Hyperbole was the only remaining Probas notebook with the defect** - closes the Probas slice of #3436 for my lane.

## Gates
- G1 scan_cell_ordering: 1 clean.
- G2 check_c2_compliance: pre-existing baseline (cells 11/14 ec-no-outputs identical on origin/main) - NOT introduced by this metadata-only scrub, out of scope.
- G3 validate: 0 Errors (1 Warning = pre-existing baseline).
- G4 git diff: 1 ins / 1 del, metadata.papermill.output_path only.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>