### PR TITLE
docs(sl): anchor SL-1/2/3 methods to canonical citations (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -805,6 +805,8 @@
     "\n",
     "Toute hypothese consistante se situe **entre** G et S : pour tout h consistant, il existe g dans G et s dans S tels que g >= h >= s.\n",
     "\n",
+    "> **Origine.** La theorie des *version spaces* et de l'algorithme *Candidate Elimination* (frontieres G/S) est formalisee par Mitchell, T. M. (1982), *Generalization as search*, Artificial Intelligence 18(2):203-226 --- ou l'apprentissage de concept est vu comme une recherche dans l'espace des hypotheses.\n",
+    "\n",
     "### Algorithme\n",
     "\n",
     "```\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
@@ -304,6 +304,8 @@
     "3. **Extraire la regle** a partir des feuilles de l'arbre de preuve generalise\n",
     "4. **Simplifier** --- supprimer les conditions toujours vraies\n",
     "\n",
+    "> **Origine.** Ce processus en 4 etapes (1. expliquer, 2. variabiliser, 3. extraire la regle, 4. simplifier) est la formalisation canonique de l'EBL donnee par Mitchell, T. M., Keller, R. M. & Kedar-Cabelli, S. T. (1986), *Explanation-based generalization: A unifying view*, Machine Learning 1(1):47-80. C'est le pendant complementaire (vue *generalisation*) du travail de DeJong & Mooney (1986) deja cite en Ressources (vue *apprentissage*).\n",
+    "\n",
     "### Pourquoi EBL est utile ?\n",
     "\n",
     "- Accelerer le raisonnement futur en evitant de re-construire la meme preuve\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
@@ -166,7 +166,9 @@
     "\n",
     "**Minimalite** : Une determination $X > Y$ est **minimale** si aucun sous-ensemble strict de $X$ ne determine $Y$. C'est la determination la plus petite.\n",
     "\n",
-    "**Unicite** : La determination minimale n'est pas forcement unique --- il peut exister plusieurs ensembles minimaux differents."
+    "**Unicite** : La determination minimale n'est pas forcement unique --- il peut exister plusieurs ensembles minimaux differents.\n",
+    "\n",
+    "> **Origine.** Le formalisme logique des *determinations* ($X > Y$) comme base de l'apprentissage base sur la pertinence (RBL) vient de Davies, T. R. & Russell, S. J. (1987), *A logical approach to reasoning by analogy*, Proceedings of IJCAI-87 --- qui montre comment une determination connue rend l'apprentissage independant des attributs non-pertinents."
    ]
   },
   {
@@ -619,7 +621,9 @@
     "|-----|------------|-------------|\n",
     "| Pire cas | $O(2^n)$ | Aucune determination n'existe |\n",
     "| Determination de taille $d$ | $O(n^d)$ | Arret apres niveau $d$ |\n",
-    "| $d \\ll n$ | Polynomiale | Gain majeur par rapport a l'exhaustion |"
+    "| $d \\ll n$ | Polynomiale | Gain majeur par rapport a l'exhaustion |\n",
+    "\n",
+    "> **Origine.** L'idee de chercher la determination *minimale* (moins d'attributs pertinents possible) et l'algorithme MIN-FEATURES/FOCUS sous-jacent sont dus a Almuallim, H. & Dietterich, T. G. (1991), *Learning with many irrelevant features*, Proceedings of AAAI-91, pp. 547-552 --- qui demontrent le gain de complexite quand peu d'attributs sont pertinents."
    ]
   },
   {


### PR DESCRIPTION
Audit **citation/fidelite #3164** — SymbolicLearning SL-1..SL-3. Anchor taught+implemented methods to their originating papers (previously only textbook-level AIMA references).

## Scope (3 notebooks, markdown-only)

| Notebook | Method taught+implemented | Canonical citation added |
|----------|---------------------------|--------------------------|
| SL-1 | Candidate Elimination (Version Space, G/S boundaries) | Mitchell 1982, *Generalization as search*, Artificial Intelligence 18(2):203-226 |
| SL-2 | EBL 4-step process (explain/variabilize/extract/simplify) | Mitchell, Keller & Kedar-Cabelli 1986, *Explanation-based generalization: A unifying view*, Machine Learning 1(1):47-80 |
| SL-3 | Determinations formal framework (X>Y) | Davies & Russell 1987, *A logical approach to reasoning by analogy*, IJCAI-87 |
| SL-3 | MINIMAL-CONSISTENT-DET / MIN-FEATURES | Almuallim & Dietterich 1991, *Learning with many irrelevant features*, AAAI-91, pp. 547-552 |

## Why these anchors

Each cited method was **taught and implemented** in the notebook but anchored only to AIMA textbook figures. The originating paper was missing. Notable: SL-2 already cited **DeJong & Mooney 1986** (the *learning* view of EBL) but not its twin **Mitchell-Keller-Kedar-Cabelli 1986** (the *generalization* view that defines the exact 4-step process implemented in the `ArithmeticEBL` class). This PR adds the missing twin.

## Citation verification (G.1 — no fabrication)

All 4 references verified via web search before anchoring:
- Mitchell 1982 — confirmed ScienceDirect, AI vol.18 issue 2 pp.203-226
- Mitchell-Keller-Kedar-Cabelli 1986 — confirmed Springer, DOI 10.1007/BF00116250, ML 1(1):47-80
- Davies & Russell 1987 — confirmed IJCAI Proceedings PDF + SSRN
- Almuallim & Dietterich 1991 — confirmed ACM DL + AAAI PDF, pp.547-552 (FOCUS/MIN-FEATURES algorithm)

## C.3 strict — zero notebook churn

Edits are **markdown footnote blocks only** (4 `> **Origine.**` blocks inserted into markdown cells). Verified:
- `git diff --stat`: +10/-2 across 3 notebooks
- All code cells: `execution_count` sequential and preserved, `outputs` intact (0 unexecuted-empty code cells, H.3 check pass)
- All 3 notebooks: valid JSON after edit
- Only `+` citation lines in diff — no JSON reformatting, no code/outputs touched

## Per directive

Markdown citations only, C.3 strict, 1 PR per 2-3 notebooks (this = SL-1/SL-2/SL-3). Next batch: SL-4..SL-6 (ILP/Inverse Resolution/NeuroSymbolic) → Muggleton 1991, Quinlan 1990 FOIL, Plotkin 1970, Cropper-Muggleton Popper, Evans-Grefenstette dILP.

See #3164