### PR TITLE
docs(probas): add Conclusion / Prochaines étapes section to README

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -465,6 +465,29 @@ Le notebook `Infer-101.ipynb` est le seul a melanger les deux kernels. Il utilis
 - Von Neumann & Morgenstern (1944) - *Theory of Games and Economic Behavior*
 - Russell & Norvig - *Artificial Intelligence*, Chapter 16 (Decision Theory)
 
+## Conclusion / Prochaines étapes
+
+### Ce que vous avez appris
+
+Cette série vous a fait changer de regard sur l'incertitude : plutôt que de la fuir ou de l'ignorer, vous avez appris à la **modéliser, la quantifier et la traduire en décisions**. L'arc pédagogique se déploie en trois temps, porté par trois stacks complémentaires :
+
+- **Le geste fondateur** — remplacer une prédiction ponctuelle par une **distribution**. Un modèle probabiliste ne dit pas « la probabilité est 0.73 » mais « voici la distribution complète N(0.73, 0.12) », et cette densité porte l'information que la moyenne dissimule : la confiance, les queues, les modes multiples. C'est ce déplacement qui ouvre tout le reste.
+- **La double inference** — Infer.NET (message passing, EP/VMP) et PyMC (NUTS, MCMC) résolvent les mêmes modèles par des voies opposées. Le traverser sur des modèles jumeaux (notebook à notebook, Infer-N ↔ PyMC-N) ancre une intuition qu'aucun cours théorique ne donne : **quand l'inférence exacte est tractable, elle est déterministe et rapide ; quand elle ne l'est plus, l'échantillonnage prend le relais mais exige des diagnostics** (R-hat, effective sample size, trace plots).
+- **La décision** — la seconde moitié franchit le pas : des croyances (distributions) aux **actions**. Utilité espérée E[U], valeur de l'information (EVPI/EVSI), réseaux de décision, et enfin les MDP qui relient cette série à l'apprentissage par renforcement. Le compagnon Lean 4 (Infer-20b) pousse l'exigence jusqu'à **formaliser** les identités d'escompte de l'indice de Gittins — l'assurance que les identités numériques ne sont pas des approximations accidentelles mais des théorèmes.
+
+La thèse pratique est honnête : un modèle probabiliste est plus lourd à bâtir qu'un classifieur, mais il est le seul à pouvoir dire « je ne sais pas » — et dans le diagnostic médical, le classement sportif ou l'évaluation de compétences, cette honnêteté est précisément ce qu'on cherche.
+
+### Prochaines étapes
+
+- **Passer à la décision séquentielle** : les MDP des notebooks 17-20 préparent directement [RL](../RL/README.md), où l'agent **apprend** la politique optimale par interaction plutôt que de la calculer hors ligne — la frontière naturelle entre inférence probabiliste et apprentissage par renforcement.
+- **Croiser la théorie des jeux** : [GameTheory](../GameTheory/README.md) partage la notion de **décision sous incertitude**, mais l'incertitude y vient d'un adversaire rationnel plutôt que d'un processus stochastique. Les fonctions d'utilité multi-attributs (notebooks 15-16) trouvent leur miroir dans le choix social et l'utilité collective.
+- **Revenir au ML appliqué** : le [TP prévision de ventes](../ML/ML.Net/TP-prevision-ventes.ipynb) de la série ML est une porte d'entrée — il traite la régression bayésienne comme cas d'application ; cette série en donne le langage complet (distributions, facteurs, inférence).
+- Pour la pratique : reprenez un même modèle (par exemple TrueSkill, Infer-6 / PyMC-6) dans les deux stacks, comparez les intervalles de crédibilité, et observez comment EP (déterministe) et NUTS (stochastique) convergent vers des conclusions cohérentes — c'est l'exercice le plus formateur pour saisir le champ d'application de chaque approche.
+
+### Le fil rouge
+
+La programmation probabiliste propose un changement de posture : ne plus demander « quelle est la bonne réponse ? » mais **« à quel point suis-je sûr de cette réponse, et que dois-je faire compte tenu de cette incertitude ? »**. Cette série vous a donné les trois couches — modéliser (facteurs, distributions), inférer (message passing ou échantillonnage), décider (utilité espérée, valeur de l'information) — pour transformer une question qualitative en un calcul, en gardant à l'esprit qu'une distribution honnête vaut mieux qu'une certitude illusoire.
+
 ## Licence
 
 Voir la licence du repository principal.


### PR DESCRIPTION
See #2651

## Contexte
Partie 2 de l'issue #2651 — harmonisation des READMEs de séries sur le gabarit de référence ([docs/reference/readme-series-gabarit.md](docs/reference/readme-series-gabarit.md)). Steering ai-01 (cycle 08:15Z) : ajouter `## Conclusion / Prochaines étapes` aux familles CoursIA-2 sans worker actif. **Probas** est la deuxième (après ML #3746).

## Changement
Ajoute la Conclusion canonique en 3 sous-sections (modèle IIT #3730) :
- `### Ce que vous avez appris` — geste fondateur (distribution vs point), double inference (Infer.NET message passing / PyMC MCMC), décision (E[U], EVPI/EVSI, MDP, Lean Gittins)
- `### Prochaines étapes` — ponts précis : MDP → RL, incertitude/adversaire ↔ GameTheory, TP-ventes → ML
- `### Le fil rouge` — synthèse : modéliser / inférer / décider

## Gates
- **Markdown-only** : 23 insertions, 0 deletion
- **Fidélité** : alignée sur les 3 stacks (Infer 21 / PyMC 20 / Lean Infer-20b) et les 3 phases documentées
- **Ton sobre** : 0 jugement de valeur, 0 vocabulaire de conventions internes, 0 emoji
- **Catalogue** : marqueur CATALOG-STATUS non touché

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>