### PR TITLE
docs(search): add Conclusion / Prochaines étapes section to README

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -465,6 +465,30 @@ Allez directement aux applications qui correspondent à votre domaine : **App-3/
 
 ---
 
+## Conclusion / Prochaines étapes
+
+### Ce que vous avez appris
+
+Cette série a pris à bras-le-corps le défi commun à toute l'IA — **explorer un espace de solutions pour trouver la meilleure** — et vous a montré qu'il existe non pas un, mais plusieurs arts de le faire, chacun avec son terrain de prédilection. L'arc pédagogique se déploie en quatre piliers :
+
+- **Le geste fondateur** — formaliser un problème en **espace d'états** (S, s0, A, T, G), puis choisir entre explorer méthodiquement (BFS, DFS), guider l'exploration par une heuristique admissible (A*), ou raisonner face à un adversaire (Minimax, Alpha-Beta, MCTS). C'est le vocabulaire de base sans lequel aucun problème combinatoire ne se laisse aborder.
+- **Le changement de paradigme** — la programmation par contraintes (CSP) inverse la perspective : au lieu d'explorer puis de filtrer, on **réduit les domaines par propagation** (AC-3, Forward Checking, CP-SAT) avant même de chercher. Un ordonnancement industriel qui demanderait des heures en backtracking se résout en millisecondes — à condition de savoir le modéliser.
+- **Les applications** — vingt notebooks ancrent chaque concept sur un problème réel : planification d'infirmiers (CHU), ordonnancement d'atelier, TSP/VRP logistique, démineur, Picross, optimisation de portefeuille. La théorie quitte l'abstrait pour devenir un outil de décision.
+- **L'hybridation** — le dernier pilier relie la recherche à l'optimisation continue, aux métaheuristiques (algorithmes génétiques, recuit simulé), et aux LLMs (LLM+CSP). Les problèmes modernes ne se résolvent pas par un seul paradigme mais par leur **combinaison** : CP pour les contraintes dures, métaheuristique pour l'exploration globale, LLM pour le brassage créatif.
+
+La thèse pratique est honnête : il n'y a pas de « meilleur algorithme de recherche » — il y a un algorithme adapté à chaque structure de problème, et savoir le choisir (explorer, contraindre, ou combiner) est précisément la compétence que cette série cherche à bâtir.
+
+### Prochaines étapes
+
+- **Maîtriser la résolution symbolique** : le solveur Z3/SMT utilisé en CSP devient, dans [SymbolicAI](../SymbolicAI/README.md), un moteur de **vérification formelle** — preuve de théorèmes, vérification de programmes, analyse de contrats intelligents. La logique modulaire pousse plus loin la réduction de l'espace initiée ici.
+- **Consolider sur un terrain connu** : [Sudoku](../Sudoku/README.md) reprend les techniques de cette série (backtracking, CSP, MRV, métaheuristiques) sur un problème NP-complet unique — un excellent terrain de révision avant d'aborder des problèmes plus vastes.
+- **Rejoindre l'optimisation sous incertitude** : l'optimisation de portefeuille (App-10) annonce [QuantConnect](../QuantConnect/README.md), où l'espace de recherche devient stochastique et où les métaheuristiques croisent l'apprentissage par renforcement.
+- Pour la pratique : reprenez une application (par exemple App-3 NurseScheduling ou App-4 JobShop) et ajoutez une couche d'hybridation — un guide LLM pour la génération de contraintes, ou une métaheuristique pour l'optimisation post-CP-SAT. C'est l'exercice le plus formateur pour saisir comment combiner garantie et flexibilité.
+
+### Le fil rouge
+
+La recherche en IA illustre une leçon centrale : face à un espace de solutions exponentiel, **le choix de la stratégie d'exploration prime souvent sur la puissance de calcul**. Cette série vous a donné le vocabulaire (espaces d'états, heuristiques, propagation, métaheuristiques), le cadre de décision (explorer, contraindre, combiner) et le terrain d'application (vingt problèmes réels) pour transformer l'exploration combinatoire en une démarche méthodique plutôt qu'en une recherche aveugle.
+
 ## Licence
 
 Voir la licence du repository principal.


### PR DESCRIPTION
See #2651

## Contexte
Partie 2 de l'issue #2651 — harmonisation des READMEs sur le gabarit ([docs/reference/readme-series-gabarit.md](docs/reference/readme-series-gabarit.md)). Steering ai-01 (08:15Z) : ajouter `## Conclusion / Prochaines étapes` aux familles CoursIA-2 sans worker actif. **Search** est la quatrième et dernière (après ML #3746, Probas #3748, Sudoku #3749).

## Changement
Ajoute la Conclusion canonique en 3 sous-sections (modèle IIT #3730) :
- `### Ce que vous avez appris` — geste fondateur (espaces d'états), changement de paradigme (CSP propagation), applications (20 notebooks réels), hybridation (métaheuristiques + LLM)
- `### Prochaines étapes` — ponts précis : Z3/SMT → SymbolicAI, CSP/MRV ↔ Sudoku, App-10 portefeuille → QuantConnect
- `### Le fil rouge` — stratégie d'exploration prime sur puissance de calcul

## Gates
- **Markdown-only** : 24 insertions, 0 deletion
- **Fidélité** : alignée sur les 4 piliers documentés (Foundations 11, CSP 9, Applications 21, Metaheuristics 9)
- **Registre** : français avec accents (consistant avec le README Search existant)
- **Catalogue** : marqueur CATALOG-STATUS non touché

## Suivi #2651 (ma lane)
4 familles CoursIA-2 livrées : ML #3746, Probas #3748, Sudoku #3749, Search (cette PR). Prochaine étape steering ai-01 : sweep axe-2 `regression_scan.py --snapshot` sur ma partition.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>