### PR TITLE
docs(dsa-lab13): audit fidelite #3164 Lab13-Web-Search-SOTA -- ancres RAG/MLE-STAR

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb
@@ -31,7 +31,9 @@
     "- Compréhension des architectures ML\n",
     "- Configuration multi-provider active\n",
     "\n",
-    "### Durée estimée : 35-45 minutes"
+    "### Durée estimée : 35-45 minutes\n",
+    "\n",
+    "> **Repères bibliographiques.** Ce lab implémente le composant **recherche web (search)** de l'agent MLE-STAR — un agent d'ingénierie ML de Google Research (arXiv:2506.15692, *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*, 2025) qui, plutôt que de s'appuyer sur la connaissance paramétrique du LLM, recherche activement les modèles SOTA (arXiv, leaderboards) avant de générer du code. Ce principe — *augmenter* le LLM par récupération externe de connaissances — est le paradigme **RAG** (Retrieval-Augmented Generation) formalisé par P. Lewis et al., *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks*, arXiv:2005.11401, NeurIPS 2020."
    ]
   },
   {
@@ -195,7 +197,9 @@
     "tags": []
    },
    "source": [
-    "## 3. Web Search Module"
+    "## 3. Web Search Module\n",
+    "\n",
+    "Ce module incarne l'étape de **retrieval** du paradigme RAG (Lewis et al. 2020) : l'agent interroge une source externe (web, arXiv) pour obtenir un contexte fraîchement récupéré, puis le passe au LLM qui génère du code fondé sur l'état de l'art observé plutôt que sur sa mémoire paramétrique seule."
    ]
   },
   {
@@ -713,6 +717,17 @@
       "Exercice a completer\n"
      ]
     }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "1. P. Lewis et al., *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks*, arXiv:2005.11401, NeurIPS 2020. Paradigme RAG : augmenter un LLM par récupération externe de connaissances avant génération — fondement du module Web Search de ce lab.\n",
+    "2. Google Research, *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*, arXiv:2506.15692, 2025. Agent MLE dont ce lab implémente le composant recherche SOTA (combinaison recherche + raffinement ciblé).\n",
+    "3. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM (suite Labs 8-12)."
    ]
   }
  ],


### PR DESCRIPTION
## Audit fidélité #3164 — Lab13-Web-Search-SOTA

**Sous-lot** : DataScienceWithAgents / AgenticDataScience / Day6-MLE-Star (1er lab de la 4e journée, famille po-2025).

**Verdict : OMISSION** (profil portage cours externe). Le notebook implémente le composant **recherche web** de l'agent MLE-STAR (objectifs 1-4) sans citer le paradigme RAG canonique ni le papier MLE-STAR. Aucune section References n'existait.

## Règle repair-not-consecrate (#3660) — NON TRIGGERÉE

Notebook **sain** : 12 code cells, `execution_count` 1-12, **0 erreur**, **0 output vide**. Aucune consécration de régression.

## Ancres ajoutées (markdown-only)

| # | Localisation | Concept | Citation canonique |
|---|--------------|---------|--------------------|
| 1 | Cellule 0 (objectifs) | Agent search-augmented | **RAG** → Lewis et al. 2020 arXiv:2005.11401 NeurIPS ; **MLE-STAR** → Google Research arXiv:2506.15692 (2025) |
| 2 | Cellule 7 (Web Search Module) | Étape retrieval du RAG | Lewis et al. 2020 |
| 3 | Nouvelle cellule References (fin) | Bibliographie | Lewis 2020 RAG, MLE-STAR arXiv:2506.15692, Xi 2025 agents-survey |

## Yield honnête (G.5) + anti-duplication

- **Lab13 = concept DISTINCT** = retrieval-augmented agent (RAG) vs Lab10=DS-STAR File Analyzer, Lab11=multi-agent loop, Lab12=capstone.
- **RAG + MLE-STAR** = paradigmes/papiers NON cités dans Labs précédents → ancres propres.
- **MLE-STAR** cité en biblio Lab8 via billet blog → Lab13 porte sur le **COMPOSANT recherche** + papier académique arXiv:2506.15692 (plus canonique).

## Vérification G.1 (0 fabrication)

- **Lewis et al. 2020, arXiv:2005.11401, NeurIPS 2020** = papier fondateur RAG, **web-vérifié** (arXiv, NeurIPS proceedings).
- **MLE-STAR arXiv:2506.15692** = papier académique Google Research 2025, **web-vérifié** (arXiv, research.google/blog) — le titre même du papier (« Search and Targeted Refinement ») correspond au sujet de ce lab.

## Validation (gate complet)

- `notebook_tools validate` : **OK** (1 OK, 0 warning, 0 error)
- `scan_cell_ordering.py --severity HIGH` : **clean**
- **C.1** : aucune erreur volontaire dans le source
- **C.2/C.3** : markdown-only, churn `execution_count`/`outputs` = 0
- **Catalogue** : `COURSE_CATALOG.generated.{json,md}` byte-identique à `origin/main`
- **Anti-régression** : aucun code supprimé, ajout pur

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
