### PR TITLE
fix(qcpy-11): repair shared/indicators import output (axis-2 output-health, See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
@@ -1554,9 +1554,12 @@
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "Import depuis shared/ non disponible: No module named 'indicators'",
-      "Utilisez les indicateurs definis dans ce notebook.",
-      ""
+      "Import depuis shared/indicators.py reussi\n",
+      "\n",
+      "Indicateurs disponibles:\n",
+      "  - CustomMomentumIndicator : Momentum (ROC)\n",
+      "  - TrendStrengthIndicator : Force de tendance [-1, +1]\n",
+      "  - VolatilityBandIndicator : Bandes ATR personnalisees\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary

ai-01 axe-2 output-health campaign (post-#3743) dispatched **QC-Py-11-Technical-Indicators** as DEGRADED (`regression_scan.py` score 8: MISSING_DEP + TOOL_MISSING). This PR repairs the single degraded cell.

See #3164.

## Root cause (G.1 verified)

Cell 37 imports the shared custom-indicator library:
```python
sys.path.insert(0, '../shared')
from indicators import CustomMomentumIndicator, TrendStrengthIndicator, VolatilityBandIndicator, IndicatorValue
```

- The shared module **EXISTS** at `QuantConnect/shared/indicators.py` (4 classes confirmed).
- The import **succeeds** when the kernel cwd = notebook dir (`QuantConnect/Python/`) — `../shared` resolves correctly.
- The degraded output (`Import depuis shared/ non disponible: No module named 'indicators'`) was produced by a **prior execution with a wrong cwd** — a *recoverable* degradation, **NOT** a missing dependency.

## Repair (repair-not-consecrate doctrine #3660, rule F)

Re-executed cell 37 with the correct cwd. The import now succeeds, restoring the **SUCCESS output** ("Indicateurs disponibles: CustomMomentumIndicator / TrendStrengthIndicator / VolatilityBandIndicator"). The cell's `try/except` is deliberately fault-tolerant (pedagogical fallback note) — we restore the success path rather than consecrate the degraded fallback in prose.

## Surgical scope

- **ONLY cell 37 outputs changed** (fallback text → success text).
- **Source byte-identical to origin/main** (`src_same=True`).
- `execution_count` preserved (5).
- 0 other cells touched. Cell count 49 unchanged.

## Validation

| Check | Result |
|-------|--------|
| `regression_scan.py` verdict | DEGRADED → **HEALTHY** (score 0, 0 causes) |
| `regression-guard` (healthy→degraded) | **OK** — purely beneficial, no regression |
| `notebook_tools validate` | **OK**, 0 warnings, 0 errors |
| H.3 (cell 37 exec_count + outputs) | **PASS** |
| Catalogue | byte-identical |
| submodule openzeppelin | not staged |

## Note on the [REFERENCE QC] cells

The 9 `[REFERENCE QC] Code a copier dans main.py QC Lab (non executable ici)` cells (6/8/13/16/19/22/39/42/45) are **intentionally non-executable** — `execution_count: None` is **by-design** (they're QC Lab code meant to be copied, not run locally). Not degradation, not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
