### PR TITLE
fix(tweety-4): repair CrMas belief-revision outputs (axis-2, JVM re-exec)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
@@ -40,10 +40,10 @@
    "id": "eff88e6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.415140Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.414900Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.561506Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.560642Z"
+     "iopub.execute_input": "2026-06-20T11:04:29.808719Z",
+     "iopub.status.busy": "2026-06-20T11:04:29.808053Z",
+     "iopub.status.idle": "2026-06-20T11:04:30.917466Z",
+     "shell.execute_reply": "2026-06-20T11:04:30.916874Z"
     },
     "papermill": {
      "duration": 0.152975,
@@ -60,7 +60,21 @@
      "output_type": "stream",
      "text": [
       "--- Verification JVM Tweety + Outils ---\n",
-      "ERREUR: JAVA_HOME non defini et JDK portable non trouve.\n"
+      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JVM demarree avec 42 JARs.\n",
+      "\n",
+      "--- Outils disponibles ---\n",
+      "  EPROVER: eprover.exe\n",
+      "  SAT_SOLVER_PYTHON: sat_solver.py\n",
+      "  MARCO: marco.py\n",
+      "\n",
+      "JVM prete. Outils: 3/5\n"
      ]
     }
    ],
@@ -304,10 +318,10 @@
    "id": "278b5928",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.604644Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.604259Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.611366Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.610677Z"
+     "iopub.execute_input": "2026-06-20T11:04:30.920883Z",
+     "iopub.status.busy": "2026-06-20T11:04:30.920696Z",
+     "iopub.status.idle": "2026-06-20T11:04:30.940584Z",
+     "shell.execute_reply": "2026-06-20T11:04:30.939990Z"
     },
     "papermill": {
      "duration": 0.013145,
@@ -324,9 +338,20 @@
      "output_type": "stream",
      "text": [
       "--- 3.1a Test des imports CrMas ---\n",
-      "ERREUR: JVM non demarree.\n",
+      "Verification des classes CrMas...\n",
+      "   OK: InformationObject (from mas)\n",
+      "   OK: CrMasBeliefSet (from mas)\n",
+      "   OK: CrMasRevisionWrapper (from mas)\n",
+      "   OK: CrMasSimpleRevisionOperator (from operators)\n",
+      "   OK: CrMasArgumentativeRevisionOperator (from operators)\n",
+      "   OK: LeviMultipleBaseRevisionOperator\n",
+      "   OK: DefaultMultipleBaseExpansionOperator\n",
+      "   OK: KernelContractionOperator, RandomIncisionFunction\n",
+      "   OK: Agent, DummyAgent, Order\n",
       "\n",
-      "CrMas_Imports_OK = False\n"
+      "==> Tous les imports CrMas reussis!\n",
+      "\n",
+      "CrMas_Imports_OK = True\n"
      ]
     }
    ],
@@ -434,10 +459,10 @@
    "id": "dda59866",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.629312Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.629095Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.636887Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.636216Z"
+     "iopub.execute_input": "2026-06-20T11:04:30.942738Z",
+     "iopub.status.busy": "2026-06-20T11:04:30.942599Z",
+     "iopub.status.idle": "2026-06-20T11:04:31.371047Z",
+     "shell.execute_reply": "2026-06-20T11:04:31.370404Z"
     },
     "papermill": {
      "duration": 0.013234,
@@ -453,8 +478,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- 3.1b Initialisation agents et base CrMas ---\n",
-      "Skipped: imports CrMas non disponibles (Tweety 1.28+ API change).\n"
+      "--- 3.1b Initialisation agents et base CrMas ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ordre de credibilite: A1 > A2 > A3\n",
+      "\n",
+      "Base initiale: { A1:p, A2:(p=>r), A3:!q, A3:!r, A2:q }\n",
+      "  A1:p, A2:q, A2:(p=>r), A3:!q, A3:!r\n",
+      "\n",
+      "Nouvelles infos: { !p (A2), s (A3) }\n",
+      "  A2:!p contredit A1:p (A1 plus credible)\n",
+      "  A3:s nouvelle info neutre\n",
+      "\n",
+      "==> Base et news prets pour la revision.\n"
      ]
     }
    ],
@@ -563,7 +603,28 @@
     },
     "tags": []
    },
-   "source": "#### La théorie AGM : postulats et triade du changement de croyance\n\nLa **théorie AGM** (Alchurrón, Gärdenfors & Makinson — *On the Logic of Theory Change*, 1985) ne définit *pas* des « opérateurs » : elle formalise comment un **agent rationnel** fait évoluer sa base de croyances $K$ (un ensemble clos par conséquence logique) face à une nouvelle information. Elle pose une **triade d'opérations** et une liste de **postulats** que ces opérations doivent satisfaire pour être « rationnelles ».\n\n**La triade AGM.** Soit $K$ la base de croyances et $A$ la nouvelle formule :\n\n| Opération | Notation | Définition |\n|-----------|----------|------------|\n| **Expansion** | $K + A$ | Ajouter $A$ à $K$ et fermer par déduction (sans rien retirer). Peut rendre $K$ incohérent. |\n| **Contraction** | $K - A$ | Retirer $A$ de $K$ de façon minimale (sans rien ajouter), en préservant la cohérence. |\n| **Révision** | $K * A$ | Intégrer $A$ **prioritairement**, en retirant le strict minimum pour rester cohérent. |\n\n**Les postulats AGM.** La révision $K*A$ doit satisfaire **8 postulats** (*clôture*, *succès* — $A \\in K*A$ ; *inclusion* ; *vacuité* ; *préservation de la cohérence* ; *extensionnalité* ; et les deux postulats de *sur/sous-expansion* liés à la conjonction) ; la contraction $K-A$ en satisfait **6** (les duaux, plus *Recovery* : $K \\subseteq (K-A)+A$). Ces postulats contraignent le changement à être **minimal et cohérent**. Aucun ne s'appelle « Levi », « Simple » ou « Argumentatif ».\n\n**Les identités de construction.** Révision et contraction ne sont pas indépendantes : chacune se construit à partir de l'autre.\n\n- **Identité de Levi** : $\\quad K * A \\;=\\; (K - \\neg A) + A$ — réviser par $A$, c'est contracter $\\neg A$ puis expanser $A$.\n- **Identité de Harper** : $\\quad K - A \\;=\\; K \\,\\cap\\, (K * \\neg A)$ — contracter $A$, c'est intersecter $K$ avec la révision par $\\neg A$ (duale de Levi).\n\n> **À ne pas confondre.** Les trois opérateurs exécutés ci-dessous (**Levi**, **Simple**, **Argumentatif**) sont des **implémentations concrètes de la bibliothèque Tweety** (modules `beliefdynamics` + CrMas multi-agents) qui *réalisent* une révision. L'« opérateur Levi » de Tweety enchaîne littéralement contraction puis expansion — c'est l'identité de Levi ci-dessus codée telle quelle. **Ce ne sont pas des postulats AGM** : les postulats sont les contraintes rationnelles que ces opérateurs s'efforcent de respecter."
+   "source": [
+    "#### La théorie AGM : postulats et triade du changement de croyance\n",
+    "\n",
+    "La **théorie AGM** (Alchurrón, Gärdenfors & Makinson — *On the Logic of Theory Change*, 1985) ne définit *pas* des « opérateurs » : elle formalise comment un **agent rationnel** fait évoluer sa base de croyances $K$ (un ensemble clos par conséquence logique) face à une nouvelle information. Elle pose une **triade d'opérations** et une liste de **postulats** que ces opérations doivent satisfaire pour être « rationnelles ».\n",
+    "\n",
+    "**La triade AGM.** Soit $K$ la base de croyances et $A$ la nouvelle formule :\n",
+    "\n",
+    "| Opération | Notation | Définition |\n",
+    "|-----------|----------|------------|\n",
+    "| **Expansion** | $K + A$ | Ajouter $A$ à $K$ et fermer par déduction (sans rien retirer). Peut rendre $K$ incohérent. |\n",
+    "| **Contraction** | $K - A$ | Retirer $A$ de $K$ de façon minimale (sans rien ajouter), en préservant la cohérence. |\n",
+    "| **Révision** | $K * A$ | Intégrer $A$ **prioritairement**, en retirant le strict minimum pour rester cohérent. |\n",
+    "\n",
+    "**Les postulats AGM.** La révision $K*A$ doit satisfaire **8 postulats** (*clôture*, *succès* — $A \\in K*A$ ; *inclusion* ; *vacuité* ; *préservation de la cohérence* ; *extensionnalité* ; et les deux postulats de *sur/sous-expansion* liés à la conjonction) ; la contraction $K-A$ en satisfait **6** (les duaux, plus *Recovery* : $K \\subseteq (K-A)+A$). Ces postulats contraignent le changement à être **minimal et cohérent**. Aucun ne s'appelle « Levi », « Simple » ou « Argumentatif ».\n",
+    "\n",
+    "**Les identités de construction.** Révision et contraction ne sont pas indépendantes : chacune se construit à partir de l'autre.\n",
+    "\n",
+    "- **Identité de Levi** : $\\quad K * A \\;=\\; (K - \\neg A) + A$ — réviser par $A$, c'est contracter $\\neg A$ puis expanser $A$.\n",
+    "- **Identité de Harper** : $\\quad K - A \\;=\\; K \\,\\cap\\, (K * \\neg A)$ — contracter $A$, c'est intersecter $K$ avec la révision par $\\neg A$ (duale de Levi).\n",
+    "\n",
+    "> **À ne pas confondre.** Les trois opérateurs exécutés ci-dessous (**Levi**, **Simple**, **Argumentatif**) sont des **implémentations concrètes de la bibliothèque Tweety** (modules `beliefdynamics` + CrMas multi-agents) qui *réalisent* une révision. L'« opérateur Levi » de Tweety enchaîne littéralement contraction puis expansion — c'est l'identité de Levi ci-dessus codée telle quelle. **Ce ne sont pas des postulats AGM** : les postulats sont les contraintes rationnelles que ces opérateurs s'efforcent de respecter."
+   ]
   },
   {
    "cell_type": "code",
@@ -571,10 +632,10 @@
    "id": "1c9fda5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.656053Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.655818Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.662742Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.662015Z"
+     "iopub.execute_input": "2026-06-20T11:04:31.374124Z",
+     "iopub.status.busy": "2026-06-20T11:04:31.373871Z",
+     "iopub.status.idle": "2026-06-20T11:04:55.354477Z",
+     "shell.execute_reply": "2026-06-20T11:04:55.353391Z"
     },
     "papermill": {
      "duration": 0.013068,
@@ -591,7 +652,25 @@
      "output_type": "stream",
      "text": [
       "--- 3.1c Operateurs de revision CrMas ---\n",
-      "Skipped: imports CrMas non disponibles (Tweety 1.28+ API change).\n"
+      "Revision de: { A1:p, A2:(p=>r), A3:!q, A3:!r, A2:q }\n",
+      "Avec: { !p (A2), s (A3) }\n",
+      "\n",
+      "1. Operateur Levi (prioritaire):\n",
+      "   Resultat: [A2:!p, A1:p, A3:!r, A2:q, A3:s]\n",
+      "\n",
+      "2. Operateur Simple (credibilite):\n",
+      "   Resultat: [A1:p, A2:(p=>r), A3:!q, A3:!r, A2:q]\n",
+      "\n",
+      "3. Operateur Argumentatif (argumentation):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   Resultat: [A1:p, A3:!r, A2:q, A3:s]\n",
+      "\n",
+      "==> Comparaison des 3 operateurs terminee.\n"
      ]
     }
    ],
@@ -664,8 +743,32 @@
   {
    "cell_type": "markdown",
    "id": "5bd4c0d4",
-   "source": "#### Lecture AGM du code : noyaux, fonction d'incision et enracinement\n\nLe code ci-dessus met en œuvre les briques AGM « de bas niveau ». Repérons-les dans ce que Tweety vient d'exécuter.\n\n**Contraction par noyaux (*kernel contraction*).** La ligne `LeviMultipleBaseRevisionOperator(kernel_contract, DefaultMultipleBaseExpansionOperator())` applique **littéralement l'identité de Levi** $K*A = (K-\\neg A)+A$ : elle contracte via `kernel_contract` puis expansent via `DefaultMultipleBaseExpansionOperator`. La contraction `KernelContractionOperator` repose sur deux notions AGM (Hansson, 1994) :\n\n- Un **noyau** (*kernel*) de $K$ relativement à $A$ est un sous-ensemble **minimal** de $K$ qui, uni à $A$, devient incohérent — un « point de conflit » minimal. L'opérateur calcule *tous* les noyaux.\n- La **fonction d'incision** (*incision function*, ici `RandomIncisionFunction`) choisit, dans chaque noyau, quelles formules sacrifier pour rétablir la cohérence, en coupant au plus juste. Une incision *rationnelle* est sélective (minimalité du changement) ; l'implémentation aléatoire de Tweety est un démonstrateur, pas une politique optimale.\n- La notion duale est l'**ensemble restant** (*remainder set*) : les sous-ensembles **maximaux** de $K$ restant cohérents avec $A$. Contraction par noyaux et contraction par ensembles restants sont deux routes équivalentes vers un même résultat AGM.\n\n**Enracinement épistémique (*epistemic entrenchment*) — à ne pas confondre avec la crédibilité.** Gärdenfors & Makinson (1988) montrent que toute contraction respectant les postulats AGM est caractérisée par un **ordre d'enracinement** $\\leq_E$ sur les *croyances* : $A \\leq_E B$ signifie « l'agent renonce plus volontiers à $A$ qu'à $B$ ». Le **théorème de représentation** relie cet ordre à la contraction — on retire en priorité les croyances *les moins enracinées*. Cet ordre porte sur les **croyances** elles-mêmes.\n\nOr le notebook introduit par ailleurs un **ordre de crédibilité** `Order<Agent>` (`A1 > A2 > A3`, cellule précédente). Les deux ordres sont **orthogonaux** :\n\n|  | Enracinement épistémique $\\leq_E$ | Crédibilité `Order<Agent>` |\n|---|---|---|\n| **Porte sur** | les **croyances** (formules) | les **sources** (agents) |\n| **Question** | « à quoi renoncer pour rester cohérent ? » | « qui croire quand deux sources se contredisent ? » |\n| **Utilisé par** | contraction AGM (mono-agent) | opérateurs CrMas Simple / Argumentatif (multi-agents) |\n\nUne source très crédible peut énoncer une croyance périphérique (faible enracinement) : les deux classements ne se déduisent pas l'un de l'autre. Les opérateurs **Simple** et **Argumentatif** ci-dessus raisonnent en *crédibilité* (multi-agents) ; l'opérateur **Levi**, via la contraction par noyaux, relève du courant AGM mono-agent (enracinement). Le notebook navigue ainsi entre deux familles de la révision de croyances.\n\n> **À noter.** Les sections suivantes (3.2–3.4 : mesures d'incohérence, MUS, MaxSAT) ne *révisent* plus l'incohérence : elles la *mesurent* et la *diagnostiquent*. C'est un courant de recherche complémentaire, distinct de la révision AGM — mais tout aussi utile pour décider *quoi* réviser.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "#### Lecture AGM du code : noyaux, fonction d'incision et enracinement\n",
+    "\n",
+    "Le code ci-dessus met en œuvre les briques AGM « de bas niveau ». Repérons-les dans ce que Tweety vient d'exécuter.\n",
+    "\n",
+    "**Contraction par noyaux (*kernel contraction*).** La ligne `LeviMultipleBaseRevisionOperator(kernel_contract, DefaultMultipleBaseExpansionOperator())` applique **littéralement l'identité de Levi** $K*A = (K-\\neg A)+A$ : elle contracte via `kernel_contract` puis expansent via `DefaultMultipleBaseExpansionOperator`. La contraction `KernelContractionOperator` repose sur deux notions AGM (Hansson, 1994) :\n",
+    "\n",
+    "- Un **noyau** (*kernel*) de $K$ relativement à $A$ est un sous-ensemble **minimal** de $K$ qui, uni à $A$, devient incohérent — un « point de conflit » minimal. L'opérateur calcule *tous* les noyaux.\n",
+    "- La **fonction d'incision** (*incision function*, ici `RandomIncisionFunction`) choisit, dans chaque noyau, quelles formules sacrifier pour rétablir la cohérence, en coupant au plus juste. Une incision *rationnelle* est sélective (minimalité du changement) ; l'implémentation aléatoire de Tweety est un démonstrateur, pas une politique optimale.\n",
+    "- La notion duale est l'**ensemble restant** (*remainder set*) : les sous-ensembles **maximaux** de $K$ restant cohérents avec $A$. Contraction par noyaux et contraction par ensembles restants sont deux routes équivalentes vers un même résultat AGM.\n",
+    "\n",
+    "**Enracinement épistémique (*epistemic entrenchment*) — à ne pas confondre avec la crédibilité.** Gärdenfors & Makinson (1988) montrent que toute contraction respectant les postulats AGM est caractérisée par un **ordre d'enracinement** $\\leq_E$ sur les *croyances* : $A \\leq_E B$ signifie « l'agent renonce plus volontiers à $A$ qu'à $B$ ». Le **théorème de représentation** relie cet ordre à la contraction — on retire en priorité les croyances *les moins enracinées*. Cet ordre porte sur les **croyances** elles-mêmes.\n",
+    "\n",
+    "Or le notebook introduit par ailleurs un **ordre de crédibilité** `Order<Agent>` (`A1 > A2 > A3`, cellule précédente). Les deux ordres sont **orthogonaux** :\n",
+    "\n",
+    "|  | Enracinement épistémique $\\leq_E$ | Crédibilité `Order<Agent>` |\n",
+    "|---|---|---|\n",
+    "| **Porte sur** | les **croyances** (formules) | les **sources** (agents) |\n",
+    "| **Question** | « à quoi renoncer pour rester cohérent ? » | « qui croire quand deux sources se contredisent ? » |\n",
+    "| **Utilisé par** | contraction AGM (mono-agent) | opérateurs CrMas Simple / Argumentatif (multi-agents) |\n",
+    "\n",
+    "Une source très crédible peut énoncer une croyance périphérique (faible enracinement) : les deux classements ne se déduisent pas l'un de l'autre. Les opérateurs **Simple** et **Argumentatif** ci-dessus raisonnent en *crédibilité* (multi-agents) ; l'opérateur **Levi**, via la contraction par noyaux, relève du courant AGM mono-agent (enracinement). Le notebook navigue ainsi entre deux familles de la révision de croyances.\n",
+    "\n",
+    "> **À noter.** Les sections suivantes (3.2–3.4 : mesures d'incohérence, MUS, MaxSAT) ne *révisent* plus l'incohérence : elles la *mesurent* et la *diagnostiquent*. C'est un courant de recherche complémentaire, distinct de la révision AGM — mais tout aussi utile pour décider *quoi* réviser."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -780,10 +883,10 @@
    "id": "15d97aa3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.768726Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.768503Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.777961Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.776990Z"
+     "iopub.execute_input": "2026-06-20T11:04:55.357255Z",
+     "iopub.status.busy": "2026-06-20T11:04:55.357043Z",
+     "iopub.status.idle": "2026-06-20T11:04:56.069389Z",
+     "shell.execute_reply": "2026-06-20T11:04:56.068309Z"
     },
     "papermill": {
      "duration": 0.086226,
@@ -801,7 +904,41 @@
      "text": [
       "\n",
       "--- 3.2 Mesures d'Incoherence (PL) ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "JVM prete. Execution des exemples de mesures d'incoherence...\n",
+      "   OK: Imports PL de base (PlParser from .parser)\n",
+      "   OK: Solveur d'optimisation configure (ApacheCommonsSimplex)\n",
+      "   OK: Tous les imports pour Mesures d'Incoherence reussis.\n",
+      "\n",
+      "--- Mesure Contension ---\n",
+      "KB: { !a&&b, !c||d, a, !b, !d, c, d, c||a, !c||a }\n",
+      "Valeur Contension: 3.0\n",
+      "\n",
+      "--- Mesures Basees sur Distance (Dalal) ---\n",
+      "KB pour Distance: { a&&b&&c, !a&&!b&&!c }\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Valeur DSum (Sat): 3.0\n",
+      "Valeur DMax (Sat): 2.0\n",
+      "Valeur DHit (Sat): 1.0\n",
+      "\n",
+      "--- Mesures Ma / Mcsc (basees sur MUS) ---\n",
+      "KB pour Ma/Mcsc: { !a&&!b, !a, a, b }\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Valeur Ma (Naive): 2.0\n",
+      "Valeur Mcsc (Naive): 4.0\n",
+      "\n",
+      "--- Note: FuzzyInconsistencyMeasure ---\n",
+      "FuzzyInconsistencyMeasure necessite un solveur d'optimisation non-lineaire\n",
+      "(pas disponible par defaut). Omis dans cet exemple.\n"
      ]
     }
    ],
@@ -1035,10 +1172,10 @@
    "id": "5210fa12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.815364Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.815025Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.824989Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.824393Z"
+     "iopub.execute_input": "2026-06-20T11:04:56.072238Z",
+     "iopub.status.busy": "2026-06-20T11:04:56.071908Z",
+     "iopub.status.idle": "2026-06-20T11:04:57.323525Z",
+     "shell.execute_reply": "2026-06-20T11:04:57.322503Z"
     },
     "papermill": {
      "duration": 0.016333,
@@ -1056,7 +1193,44 @@
      "text": [
       "\n",
       "--- 3.3 Enumeration de MUS (Minimal Unsatisfiable Subsets) ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "JVM prete. Execution de l'exemple MUS...\n",
+      "KB pour MUS:\n",
+      "  - !a&&!b\n",
+      "  - !a||!c\n",
+      "  - !a\n",
+      "  - a\n",
+      "  - b\n",
+      "  - !c\n",
+      "  - c\n",
+      "\n",
+      "Calcul des MUS (Naive Enumerator - peut etre lent sur grandes KB):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " - Trouve 5 MUS:\n",
+      "   - { !c, c }\n",
+      "   - { !a||!c, a, c }\n",
+      "   - { !a&&!b, a }\n",
+      "   - { !a&&!b, b }\n",
+      "   - { !a, a }\n",
+      "\n",
+      "--- MARCO MUS Enumerator (Script Python + Z3) ---\n",
+      "  MARCO script trouve: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\marco.py\n",
+      "  Z3 disponible (version 4.15.3)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Resultats MARCO:\n",
+      "    MUS: U 0 1\n",
+      "    MUS: U 0 2 3\n",
+      "    MUS: U 4 5\n",
+      "    MUS: U 0 4 6\n"
      ]
     }
    ],
@@ -1240,10 +1414,10 @@
    "id": "09f6f734",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.844839Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.844635Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.848219Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.847438Z"
+     "iopub.execute_input": "2026-06-20T11:04:57.326120Z",
+     "iopub.status.busy": "2026-06-20T11:04:57.325900Z",
+     "iopub.status.idle": "2026-06-20T11:04:57.332061Z",
+     "shell.execute_reply": "2026-06-20T11:04:57.330676Z"
     },
     "papermill": {
      "duration": 0.010265,
@@ -1343,10 +1517,10 @@
    "id": "bdb25959",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.873768Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.873496Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.877336Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.876711Z"
+     "iopub.execute_input": "2026-06-20T11:04:57.334780Z",
+     "iopub.status.busy": "2026-06-20T11:04:57.334266Z",
+     "iopub.status.idle": "2026-06-20T11:04:57.349359Z",
+     "shell.execute_reply": "2026-06-20T11:04:57.348004Z"
     },
     "papermill": {
      "duration": 0.009291,
@@ -1363,7 +1537,7 @@
      "output_type": "stream",
      "text": [
       "--- 3.4.1 MaxSAT : Configuration ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "Imports MaxSAT reussis.\n"
      ]
     }
    ],
@@ -1453,10 +1627,10 @@
    "id": "5b990eff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.908404Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.908051Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.912782Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.912001Z"
+     "iopub.execute_input": "2026-06-20T11:04:57.352467Z",
+     "iopub.status.busy": "2026-06-20T11:04:57.352041Z",
+     "iopub.status.idle": "2026-06-20T11:04:57.370047Z",
+     "shell.execute_reply": "2026-06-20T11:04:57.368929Z"
     },
     "papermill": {
      "duration": 0.010953,
@@ -1472,7 +1646,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports MaxSAT non disponibles.\n"
+      "Clauses Dures:\n",
+      "  b||c\n",
+      "  c||d\n",
+      "  !a&&b\n",
+      "  f||(c&&g)\n",
+      "\n",
+      "Clauses Molles:\n",
+      "  a||!b (poids: 25)\n",
+      "  !c (poids: 15)\n"
      ]
     }
    ],
@@ -1532,10 +1714,10 @@
    "id": "1dae6cdf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.932462Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.932263Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.939196Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.938488Z"
+     "iopub.execute_input": "2026-06-20T11:04:57.372947Z",
+     "iopub.status.busy": "2026-06-20T11:04:57.372583Z",
+     "iopub.status.idle": "2026-06-20T11:04:57.577692Z",
+     "shell.execute_reply": "2026-06-20T11:04:57.576374Z"
     },
     "papermill": {
      "duration": 0.012827,
@@ -1551,7 +1733,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports MaxSAT non disponibles.\n"
+      "MaxSAT script: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\maxsat_solver.py\n",
+      "PySAT version: 1.9.dev4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Resultats MaxSAT:\n",
+      "  Status: OPTIMUM FOUND\n",
+      "  Cout optimal: 25\n",
+      "  Assignation: a=False, b=True, c=False, d=True, f=True, g=False\n"
      ]
     }
    ],
@@ -1690,10 +1884,10 @@
    "id": "64a8793d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.957673Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.957439Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.960727Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.960140Z"
+     "iopub.execute_input": "2026-06-20T11:04:57.580927Z",
+     "iopub.status.busy": "2026-06-20T11:04:57.580615Z",
+     "iopub.status.idle": "2026-06-20T11:04:57.587410Z",
+     "shell.execute_reply": "2026-06-20T11:04:57.585473Z"
     },
     "papermill": {
      "duration": 0.008926,
@@ -1815,10 +2009,10 @@
    "id": "n7jccc36dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:13.986732Z",
-     "iopub.status.busy": "2026-06-02T17:37:13.986542Z",
-     "iopub.status.idle": "2026-06-02T17:37:13.993752Z",
-     "shell.execute_reply": "2026-06-02T17:37:13.992872Z"
+     "iopub.execute_input": "2026-06-20T11:04:57.590776Z",
+     "iopub.status.busy": "2026-06-20T11:04:57.590316Z",
+     "iopub.status.idle": "2026-06-20T11:05:00.093797Z",
+     "shell.execute_reply": "2026-06-20T11:05:00.092401Z"
     },
     "papermill": {
      "duration": 0.012956,
@@ -1834,7 +2028,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Skipped: JVM non demarree.\n"
+      "KB construite avec 7 formules.\n",
+      "KB consistante ? False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Nombre de MUS trouves : 2\n",
+      "  MUS 1 (taille 4) : ['soleil => sec', 'pluie => !sec', 'soleil', 'pluie']\n",
+      "  MUS 2 (taille 4) : ['soleil', 'vent => froid', 'soleil => !froid', 'vent']\n",
+      "\n",
+      "Reparation minimale : retirer 1 formule(s) -> ['soleil']\n",
+      "KB reparee consistante ? True\n"
      ]
     }
    ],
@@ -2037,10 +2245,10 @@
    "id": "462ef462",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:37:14.035859Z",
-     "iopub.status.busy": "2026-06-02T17:37:14.035620Z",
-     "iopub.status.idle": "2026-06-02T17:37:14.039676Z",
-     "shell.execute_reply": "2026-06-02T17:37:14.038898Z"
+     "iopub.execute_input": "2026-06-20T11:05:00.097423Z",
+     "iopub.status.busy": "2026-06-20T11:05:00.097111Z",
+     "iopub.status.idle": "2026-06-20T11:05:00.102903Z",
+     "shell.execute_reply": "2026-06-20T11:05:00.101444Z"
     },
     "papermill": {
      "duration": 0.011121,
@@ -2088,7 +2296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Axe-2 repair per ai-01 dispatch 2026-06-20T10:02Z (Tweety deep-queue, item 1 — the CrMas consecration #3660 was returned to me to REPAIR, not consecrate).

## Defect (axis-2, regression_scan DEGRADED score 12)
`Tweety-4-Belief-Revision` : all CrMas multi-agent belief-revision cells printed `Skipped: imports CrMas non disponibles (Tweety 1.28+ API change)`. The JVM had not started on the last execution (JAVA_HOME / JDK portable not resolved in that run) → `CrMas_Imports_OK = False` → cascade skip.

## Root cause (verified firsthand, G.1)
**NOT an API change.** The local libs are Tweety **1.30** (42 JARs in `libs/`), and all three CrMas classes the notebook tests — `InformationObject`, `CrMasBeliefSet`, `CrMasRevisionWrapper` — resolve fine via `jpype.imports` + `startJVM`. Direct test:
```
JVM + imports OK
CrMas imports OK: org.tweetyproject.beliefdynamics.mas.InformationObject ...
```
The skip was a stale-env artifact (JVM not started on the prior run), not a 1.28+ breaking change.

## Fix (doctrine ai-01 : REPARER, pas consacrer)
Re-executed from the `Tweety/` folder (so the relative `libs/` resolves) with miniconda python + jpype 1.7.1 + JDK 17 portable auto-detected. JVM starts, CrMas imports succeed, the belief-revision operators (Levi, Simple, Argumentative) now produce **real outputs**:
- credibility order `A1 > A2 > A3`
- base initiale + nouvelles infos
- contradiction detection (`A2:!p contredit A1:p`)
- revision results

## Verification
| Gate | Result |
|---|---|
| Cells executed | 13/13, 0 error |
| CrMas skips remaining | 0 (was 3) |
| Source content | byte-identical to origin/main (39/39 cells, 0 diff) |
| regression_scan | DEGRADED(12) → **HEALTHY(0)** |
| Scope | outputs only (diff = JSON reformatting + regenerated outputs, 277 ins / 69 del) |

No consecration: the `# Tweety 1.28+ API change` comment stays as a historical note, but the skip it guarded is now lifted by a **real re-execution**, not a prose workaround (respects #3660 repair-not-consecrate).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>