### PR TITLE
fix(tweety-2): repair basic-logics outputs (axis-2, JVM re-exec)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
@@ -44,10 +44,10 @@
    "id": "6f6136ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:22.992016Z",
-     "iopub.status.busy": "2026-06-02T21:45:22.991755Z",
-     "iopub.status.idle": "2026-06-02T21:45:23.123509Z",
-     "shell.execute_reply": "2026-06-02T21:45:23.122625Z"
+     "iopub.execute_input": "2026-06-20T11:12:58.937681Z",
+     "iopub.status.busy": "2026-06-20T11:12:58.936162Z",
+     "iopub.status.idle": "2026-06-20T11:12:59.292103Z",
+     "shell.execute_reply": "2026-06-20T11:12:59.291250Z"
     },
     "papermill": {
      "duration": 0.139503,
@@ -64,7 +64,21 @@
      "output_type": "stream",
      "text": [
       "--- Verification JVM Tweety + Outils ---\n",
-      "ERREUR: JAVA_HOME non defini et JDK portable non trouve.\n"
+      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JVM demarree avec 42 JARs.\n",
+      "\n",
+      "--- Outils disponibles ---\n",
+      "  EPROVER: eprover.exe\n",
+      "  SAT_SOLVER_PYTHON: sat_solver.py\n",
+      "  MARCO: marco.py\n",
+      "\n",
+      "JVM prete. Outils: 3/5\n"
      ]
     }
    ],
@@ -299,10 +313,10 @@
    "id": "1a766440",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:23.164238Z",
-     "iopub.status.busy": "2026-06-02T21:45:23.163810Z",
-     "iopub.status.idle": "2026-06-02T21:45:23.169348Z",
-     "shell.execute_reply": "2026-06-02T21:45:23.168707Z"
+     "iopub.execute_input": "2026-06-20T11:12:59.295605Z",
+     "iopub.status.busy": "2026-06-20T11:12:59.295239Z",
+     "iopub.status.idle": "2026-06-20T11:12:59.811252Z",
+     "shell.execute_reply": "2026-06-20T11:12:59.810341Z"
     },
     "papermill": {
      "duration": 0.014643,
@@ -318,8 +332,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- 2.1.1 Logique Propositionnelle : Setup ---\n",
-      "ERREUR: JVM non demarree. Executez d'abord la cellule d'initialisation.\n"
+      "--- 2.1.1 Logique Propositionnelle : Setup ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JVM prete.\n",
+      "Imports PL reussis. Classes disponibles:\n",
+      "  - Proposition, Negation, Conjunction, Disjunction, Implication\n",
+      "  - PlBeliefSet, PlParser, PossibleWorld\n"
      ]
     }
    ],
@@ -434,10 +457,10 @@
    "id": "c0aa5094",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:23.212204Z",
-     "iopub.status.busy": "2026-06-02T21:45:23.211896Z",
-     "iopub.status.idle": "2026-06-02T21:45:23.217625Z",
-     "shell.execute_reply": "2026-06-02T21:45:23.216819Z"
+     "iopub.execute_input": "2026-06-20T11:12:59.814549Z",
+     "iopub.status.busy": "2026-06-20T11:12:59.814208Z",
+     "iopub.status.idle": "2026-06-20T11:12:59.826452Z",
+     "shell.execute_reply": "2026-06-20T11:12:59.825573Z"
     },
     "papermill": {
      "duration": 0.014459,
@@ -453,7 +476,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cellule sautee : JVM Tweety non disponible\n"
+      "KB construite manuellement:\n",
+      "  { a&&!c, (a=>b), c||d, a, !b }\n",
+      "\n",
+      "Formules individuelles:\n",
+      "  f1 = a (proposition)\n",
+      "  f2 = !b (negation)\n",
+      "  f3 = a&&!c (conjonction)\n",
+      "  f4 = (a=>b) (implication)\n",
+      "  f5 = c||d (disjonction)\n"
      ]
     }
    ],
@@ -573,10 +604,10 @@
    "id": "e5e9ed18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:23.268806Z",
-     "iopub.status.busy": "2026-06-02T21:45:23.268422Z",
-     "iopub.status.idle": "2026-06-02T21:45:23.274340Z",
-     "shell.execute_reply": "2026-06-02T21:45:23.273342Z"
+     "iopub.execute_input": "2026-06-20T11:12:59.829608Z",
+     "iopub.status.busy": "2026-06-20T11:12:59.829413Z",
+     "iopub.status.idle": "2026-06-20T11:12:59.847568Z",
+     "shell.execute_reply": "2026-06-20T11:12:59.846887Z"
     },
     "papermill": {
      "duration": 0.016975,
@@ -592,7 +623,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JVM non demarree - cellule sautee\n"
+      "KB parsee depuis chaine:\n",
+      "  { !a||b, !b||c, a||b||c }\n",
+      "\n",
+      "Formule XOR: a^^b^^c\n",
+      "  Forme DNF: (!b&&a&&!c)||(!a&&b&&!c)||(!a&&!b&&c)||(a&&b&&c)\n"
      ]
     }
    ],
@@ -695,10 +730,10 @@
    "id": "e5d744d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:23.319453Z",
-     "iopub.status.busy": "2026-06-02T21:45:23.319149Z",
-     "iopub.status.idle": "2026-06-02T21:45:23.324951Z",
-     "shell.execute_reply": "2026-06-02T21:45:23.324020Z"
+     "iopub.execute_input": "2026-06-20T11:12:59.851036Z",
+     "iopub.status.busy": "2026-06-20T11:12:59.850818Z",
+     "iopub.status.idle": "2026-06-20T11:12:59.860653Z",
+     "shell.execute_reply": "2026-06-20T11:12:59.859950Z"
     },
     "papermill": {
      "duration": 0.015283,
@@ -714,7 +749,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cellule sautee : JVM Tweety non disponible\n"
+      "Monde possible w1 = [a, b]\n",
+      "  (Propositions vraies: a, b)\n",
+      "\n",
+      "Satisfaction dans w1:\n",
+      "  w1 |= 'a && !c' ? True\n",
+      "  w1 |= '!b'      ? False\n",
+      "  w1 |= 'a || c'  ? True\n",
+      "\n",
+      "Modeles de 'a ^^ b ^^ c' (XOR):\n",
+      "  [a]\n",
+      "  [b]\n",
+      "  [a, b, c]\n",
+      "  [c]\n"
      ]
     }
    ],
@@ -831,10 +878,10 @@
    "id": "3c48b5e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:23.369412Z",
-     "iopub.status.busy": "2026-06-02T21:45:23.369167Z",
-     "iopub.status.idle": "2026-06-02T21:45:23.374344Z",
-     "shell.execute_reply": "2026-06-02T21:45:23.373584Z"
+     "iopub.execute_input": "2026-06-20T11:12:59.864373Z",
+     "iopub.status.busy": "2026-06-20T11:12:59.864083Z",
+     "iopub.status.idle": "2026-06-20T11:12:59.875040Z",
+     "shell.execute_reply": "2026-06-20T11:12:59.874436Z"
     },
     "papermill": {
      "duration": 0.012919,
@@ -850,7 +897,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cellule sautee : JVM Tweety non disponible\n"
+      "KB originale: { a||b||c, a, !c, !a||(b&&d) }\n",
+      "\n",
+      "Conversion en DIMACS CNF:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  p cnf 4 5\n",
+      "  1 2 3 0\n",
+      "  1 0\n",
+      "  -3 0\n",
+      "  -1 2 0\n",
+      "  -1 4 0\n",
+      "\n",
+      "Interpretation:\n",
+      "  - 'p cnf 4 5' : 4 variables, 5 clauses\n",
+      "  - Variable 1 = a, 2 = b, 3 = c, 4 = d\n",
+      "  - '-1' signifie NOT a, '2' signifie b\n"
      ]
     }
    ],
@@ -972,10 +1038,10 @@
    "id": "020bc6a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:23.418025Z",
-     "iopub.status.busy": "2026-06-02T21:45:23.417615Z",
-     "iopub.status.idle": "2026-06-02T21:45:23.426985Z",
-     "shell.execute_reply": "2026-06-02T21:45:23.426215Z"
+     "iopub.execute_input": "2026-06-20T11:12:59.878535Z",
+     "iopub.status.busy": "2026-06-20T11:12:59.878347Z",
+     "iopub.status.idle": "2026-06-20T11:13:00.081147Z",
+     "shell.execute_reply": "2026-06-20T11:13:00.080599Z"
     },
     "papermill": {
      "duration": 0.020468,
@@ -992,7 +1058,41 @@
      "output_type": "stream",
      "text": [
       "--- 2.1.2 Raisonnement PL et SAT4J ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "\n",
+      "=== 1. SimplePlReasoner (Consequence Logique) ===\n",
+      "KB: { !a||b, !b||c, a||b||c }\n",
+      "\n",
+      "KB |= c ? True\n",
+      "  Explication: a=>b et b=>c impliquent que c est toujours vrai\n",
+      "\n",
+      "KB |= contradiction ? False\n",
+      "  False => la KB est consistante\n",
+      "\n",
+      "=== 2. SAT4J Solver (Satisfiabilite) ===\n",
+      "\n",
+      "KB SAT: { b||!c, a||b, !a||c }\n",
+      "  Satisfiable? True\n",
+      "\n",
+      "KB UNSAT (contradiction): { !a, a }\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Satisfiable? False\n",
+      "\n",
+      "=== 3. Enumeration des Modeles ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule: a XOR b\n",
+      "Nombre de modeles: 2\n",
+      "  Modele: [a]\n",
+      "  Modele: [b]\n"
      ]
     }
    ],
@@ -1185,10 +1285,10 @@
    "id": "bf242c03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:23.473028Z",
-     "iopub.status.busy": "2026-06-02T21:45:23.472619Z",
-     "iopub.status.idle": "2026-06-02T21:45:25.819383Z",
-     "shell.execute_reply": "2026-06-02T21:45:25.818777Z"
+     "iopub.execute_input": "2026-06-20T11:13:00.085494Z",
+     "iopub.status.busy": "2026-06-20T11:13:00.085111Z",
+     "iopub.status.idle": "2026-06-20T11:13:03.956845Z",
+     "shell.execute_reply": "2026-06-20T11:13:03.955790Z"
     },
     "papermill": {
      "duration": 2.358163,
@@ -1204,13 +1304,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- 2.1.3a Solveurs SAT Modernes (pySAT / CaDiCaL) ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "--- 2.1.3a Solveurs SAT Modernes (pySAT / CaDiCaL) ---\n",
       "pySAT installe - acces aux solveurs modernes!\n",
       "\n",
       "[Warmup des solveurs...]\n",
@@ -1224,36 +1318,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    cadical195  : UNSAT   247.40ms\n"
+      "    cadical195  : UNSAT   253.32ms\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    glucose42   : UNSAT  1618.26ms\n"
+      "    glucose42   : UNSAT  2610.59ms"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    minisat22   : UNSAT   170.28ms\n",
+      "\n",
+      "    minisat22   : UNSAT   504.09ms\n",
       "\n",
       "--- Test 2: Latin Square 13x13 (SAT combinatoire) ---\n",
       "  2197 vars, 39715 clauses\n",
-      "    cadical195  : SAT       1.39ms\n",
-      "    glucose42   : SAT       1.01ms\n",
-      "    minisat22   : SAT       1.34ms\n",
+      "    cadical195  : SAT       3.31ms\n",
+      "    glucose42   : SAT       3.03ms\n",
+      "    minisat22   : SAT       1.44ms\n",
       "\n",
       "--- Test 3: 35-Queens (SAT geometrique) ---\n",
-      "  1225 vars, 69055 clauses\n",
-      "    cadical195  : SAT      25.30ms\n",
-      "    glucose42   : SAT       2.57ms\n",
-      "    minisat22   : SAT       1.24ms\n",
+      "  1225 vars, 69055 clauses\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    cadical195  : SAT      37.33ms\n",
+      "    glucose42   : SAT       4.44ms\n",
+      "    minisat22   : SAT       1.84ms\n",
       "\n",
       "==================================================\n",
-      "Victoires: CaDiCaL=0, Glucose=1, MiniSat=2\n",
+      "Victoires: CaDiCaL=1, Glucose=0, MiniSat=2\n",
       "\n",
       "Conclusion:\n",
       "- CaDiCaL: Fort sur UNSAT difficiles (Pigeonhole)\n",
@@ -1477,10 +1578,10 @@
    "id": "04714a6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:25.851032Z",
-     "iopub.status.busy": "2026-06-02T21:45:25.850843Z",
-     "iopub.status.idle": "2026-06-02T21:45:25.858572Z",
-     "shell.execute_reply": "2026-06-02T21:45:25.857905Z"
+     "iopub.execute_input": "2026-06-20T11:13:03.959506Z",
+     "iopub.status.busy": "2026-06-20T11:13:03.959104Z",
+     "iopub.status.idle": "2026-06-20T11:13:03.976082Z",
+     "shell.execute_reply": "2026-06-20T11:13:03.974954Z"
     },
     "papermill": {
      "duration": 0.014207,
@@ -1503,6 +1604,18 @@
       "  Nombre de solutions: 2\n",
       "    Solution 1: a=True, b=False\n",
       "    Solution 2: a=False, b=True\n",
+      "\n",
+      "--- Exemple 4: Integration Tweety -> pySAT ---\n",
+      "  KB Tweety: { !a||!b, !b||!c, a||c, a||b||c }\n",
+      "  Format DIMACS:\n",
+      "    p cnf 3 4\n",
+      "    -1 -2 0\n",
+      "    -2 -3 0\n",
+      "    1 3 0\n",
+      "    1 2 3 0\n",
+      "\n",
+      "  Resultat CaDiCaL: SAT\n",
+      "    Modele: [1, -2, 3]\n",
       "\n",
       "==> pySAT est un excellent complement a Tweety pour le SAT.\n"
      ]
@@ -1670,10 +1783,10 @@
    "id": "75687f51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:25.890570Z",
-     "iopub.status.busy": "2026-06-02T21:45:25.890393Z",
-     "iopub.status.idle": "2026-06-02T21:45:25.893425Z",
-     "shell.execute_reply": "2026-06-02T21:45:25.892816Z"
+     "iopub.execute_input": "2026-06-20T11:13:03.979203Z",
+     "iopub.status.busy": "2026-06-20T11:13:03.978748Z",
+     "iopub.status.idle": "2026-06-20T11:13:03.984872Z",
+     "shell.execute_reply": "2026-06-20T11:13:03.983713Z"
     },
     "papermill": {
      "duration": 0.009323,
@@ -1821,10 +1934,10 @@
    "id": "0b7135d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:25.925340Z",
-     "iopub.status.busy": "2026-06-02T21:45:25.925133Z",
-     "iopub.status.idle": "2026-06-02T21:45:25.929929Z",
-     "shell.execute_reply": "2026-06-02T21:45:25.929108Z"
+     "iopub.execute_input": "2026-06-20T11:13:03.987779Z",
+     "iopub.status.busy": "2026-06-20T11:13:03.987316Z",
+     "iopub.status.idle": "2026-06-20T11:13:04.050932Z",
+     "shell.execute_reply": "2026-06-20T11:13:04.049682Z"
     },
     "papermill": {
      "duration": 0.011497,
@@ -1841,7 +1954,14 @@
      "output_type": "stream",
      "text": [
       "--- 2.2.1 Imports FOL ---\n",
-      "ERREUR: JVM non demarree. Impossible de continuer cet exemple.\n"
+      "JVM prete. Import des classes FOL...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports FOL/Commons reussis.\n"
      ]
     }
    ],
@@ -1958,10 +2078,10 @@
    "id": "b3fc694c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:25.962486Z",
-     "iopub.status.busy": "2026-06-02T21:45:25.962195Z",
-     "iopub.status.idle": "2026-06-02T21:45:25.967217Z",
-     "shell.execute_reply": "2026-06-02T21:45:25.966463Z"
+     "iopub.execute_input": "2026-06-20T11:13:04.053957Z",
+     "iopub.status.busy": "2026-06-20T11:13:04.053668Z",
+     "iopub.status.idle": "2026-06-20T11:13:04.063569Z",
+     "shell.execute_reply": "2026-06-20T11:13:04.062308Z"
     },
     "papermill": {
      "duration": 0.012047,
@@ -1977,7 +2097,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports FOL non disponibles - signature non creee.\n"
+      "Signature FOL creee:\n",
+      "[_Any = {}, City = {london, paris}, Person = {alice, bob}], [isHappy(Person), ==(_Any,_Any), /==(_Any,_Any), livesIn(Person,City), mortal(Person)], []\n"
      ]
     }
    ],
@@ -2106,10 +2227,10 @@
    "id": "2bbee30b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:26.001751Z",
-     "iopub.status.busy": "2026-06-02T21:45:26.001431Z",
-     "iopub.status.idle": "2026-06-02T21:45:26.006002Z",
-     "shell.execute_reply": "2026-06-02T21:45:26.005295Z"
+     "iopub.execute_input": "2026-06-20T11:13:04.067018Z",
+     "iopub.status.busy": "2026-06-20T11:13:04.066734Z",
+     "iopub.status.idle": "2026-06-20T11:13:04.078066Z",
+     "shell.execute_reply": "2026-06-20T11:13:04.076776Z"
     },
     "papermill": {
      "duration": 0.011677,
@@ -2125,7 +2246,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports FOL non disponibles - parsing ignore.\n"
+      "Parsing des formules FOL dans la KB...\n",
+      "  [OK] livesIn(alice, paris)\n",
+      "  [OK] livesIn(bob, london)\n",
+      "  [OK] paris /== london\n",
+      "  [OK] isHappy(alice)\n",
+      "\n",
+      "KB FOL contient 4 formules.\n"
      ]
     }
    ],
@@ -2238,10 +2365,10 @@
    "id": "afdc78c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:26.043512Z",
-     "iopub.status.busy": "2026-06-02T21:45:26.043151Z",
-     "iopub.status.idle": "2026-06-02T21:45:26.048383Z",
-     "shell.execute_reply": "2026-06-02T21:45:26.047694Z"
+     "iopub.execute_input": "2026-06-20T11:13:04.081174Z",
+     "iopub.status.busy": "2026-06-20T11:13:04.080902Z",
+     "iopub.status.idle": "2026-06-20T11:13:04.278429Z",
+     "shell.execute_reply": "2026-06-20T11:13:04.270742Z"
     },
     "papermill": {
      "duration": 0.013424,
@@ -2257,7 +2384,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "KB vide ou imports manquants - raisonnement ignore.\n"
+      "Configuration EProver: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\EProver\\eprover.exe\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  EProver configure comme raisonneur par defaut."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Raisonneur actif: EFOLReasoner\n"
      ]
     }
    ],
@@ -2354,10 +2497,10 @@
    "id": "81657d0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:26.088154Z",
-     "iopub.status.busy": "2026-06-02T21:45:26.087893Z",
-     "iopub.status.idle": "2026-06-02T21:45:26.092750Z",
-     "shell.execute_reply": "2026-06-02T21:45:26.092172Z"
+     "iopub.execute_input": "2026-06-20T11:13:04.285566Z",
+     "iopub.status.busy": "2026-06-20T11:13:04.285077Z",
+     "iopub.status.idle": "2026-06-20T11:13:05.167753Z",
+     "shell.execute_reply": "2026-06-20T11:13:05.163170Z"
     },
     "papermill": {
      "duration": 0.013475,
@@ -2373,7 +2516,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Raisonnement FOL ignore (KB vide ou imports manquants).\n"
+      "Resultats des requetes:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  livesIn(alice, paris) → True\n",
+      "  livesIn(bob, paris) → False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  isHappy(alice) → True\n",
+      "  isHappy(bob) → False\n",
+      "\n",
+      "[Note] Requete 'paris == london' retiree - voir section 2.2.1 pour EProver.\n"
      ]
     }
    ],
@@ -2484,10 +2645,10 @@
    "id": "0865459b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:26.132360Z",
-     "iopub.status.busy": "2026-06-02T21:45:26.131945Z",
-     "iopub.status.idle": "2026-06-02T21:45:26.136258Z",
-     "shell.execute_reply": "2026-06-02T21:45:26.135225Z"
+     "iopub.execute_input": "2026-06-20T11:13:05.173230Z",
+     "iopub.status.busy": "2026-06-20T11:13:05.172325Z",
+     "iopub.status.idle": "2026-06-20T11:13:05.181110Z",
+     "shell.execute_reply": "2026-06-20T11:13:05.178818Z"
     },
     "papermill": {
      "duration": 0.012319,
@@ -2547,10 +2708,10 @@
    "id": "8d287b87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:26.168827Z",
-     "iopub.status.busy": "2026-06-02T21:45:26.168581Z",
-     "iopub.status.idle": "2026-06-02T21:45:26.176386Z",
-     "shell.execute_reply": "2026-06-02T21:45:26.175432Z"
+     "iopub.execute_input": "2026-06-20T11:13:05.185822Z",
+     "iopub.status.busy": "2026-06-20T11:13:05.185518Z",
+     "iopub.status.idle": "2026-06-20T11:13:05.345126Z",
+     "shell.execute_reply": "2026-06-20T11:13:05.344099Z"
     },
     "papermill": {
      "duration": 0.018564,
@@ -2567,7 +2728,22 @@
      "output_type": "stream",
      "text": [
       "--- 2.2.6 Test EProver (Optionnel) ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "EProver detecte: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\EProver\\eprover.exe\n",
+      "Raisonneur cree: EFOLReasoner\n",
+      "\n",
+      "KB: 2 formules\n",
+      "\n",
+      "Requetes avec EProver:\n",
+      "  human(a): True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  human(b): False\n",
+      "\n",
+      "EProver fonctionne correctement!\n"
      ]
     }
    ],
@@ -2715,10 +2891,10 @@
    "id": "l8jm9v7af8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:26.218622Z",
-     "iopub.status.busy": "2026-06-02T21:45:26.218370Z",
-     "iopub.status.idle": "2026-06-02T21:45:26.224873Z",
-     "shell.execute_reply": "2026-06-02T21:45:26.223964Z"
+     "iopub.execute_input": "2026-06-20T11:13:05.348154Z",
+     "iopub.status.busy": "2026-06-20T11:13:05.347857Z",
+     "iopub.status.idle": "2026-06-20T11:13:05.461606Z",
+     "shell.execute_reply": "2026-06-20T11:13:05.459469Z"
     },
     "papermill": {
      "duration": 0.015068,
@@ -2734,7 +2910,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exemple saute : JVM Tweety non disponible\n"
+      "Maths      → après-midi\n",
+      "Info       → après-midi\n",
+      "Physique   → matin\n",
+      "\n",
+      "Physique le matin aussi → OK\n"
      ]
     }
    ],
@@ -2820,10 +3000,10 @@
    "id": "f6b8a480",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:26.254185Z",
-     "iopub.status.busy": "2026-06-02T21:45:26.253820Z",
-     "iopub.status.idle": "2026-06-02T21:45:26.258286Z",
-     "shell.execute_reply": "2026-06-02T21:45:26.257341Z"
+     "iopub.execute_input": "2026-06-20T11:13:05.467082Z",
+     "iopub.status.busy": "2026-06-20T11:13:05.466525Z",
+     "iopub.status.idle": "2026-06-20T11:13:05.481359Z",
+     "shell.execute_reply": "2026-06-20T11:13:05.478641Z"
     },
     "papermill": {
      "duration": 0.01356,
@@ -2908,7 +3088,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Axe-2 repair per ai-01 dispatch 2026-06-20T10:02Z (Tweety deep-queue, item 1). Same root cause & fix as #3755 (Tweety-4).

## Defect (axis-2, regression_scan DEGRADED score 32)
`Tweety-2-Basic-Logics` : cells 2 and 4 printed `Cellule sautee : JVM Tweety non disponible`. JVM not started on the prior run → cascade skip.

## Root cause (G.1 firsthand)
Stale-env artifact, not an API change. Local libs = Tweety 1.30 (42 JARs); re-execution from `Tweety/` folder (relative `libs/` resolves) with miniconda python + jpype 1.7.1 + JDK 17 portable starts the JVM cleanly.

## Fix (REPARER, pas consacrer)
Real re-execution. JVM starts (42 JARs), propositional-logic + FOL examples now produce real outputs.

## Verification
| Gate | Result |
|---|---|
| Cells executed | 19/19, 0 error |
| JVM skips remaining | 0 (was 4) |
| Source content | byte-identical to origin/main (55/55 cells, 0 diff) |
| regression_scan | DEGRADED(32) → **HEALTHY(0)** |
| Scope | outputs only (291 ins / 111 del) |

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>