### PR TITLE
fix(tweety-3): repair advanced-logics outputs (axis-2, JVM re-exec)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
@@ -50,10 +50,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.215277Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.215062Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.476333Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.475357Z"
+     "iopub.execute_input": "2026-06-20T11:16:21.061044Z",
+     "iopub.status.busy": "2026-06-20T11:16:21.058832Z",
+     "iopub.status.idle": "2026-06-20T11:16:21.352327Z",
+     "shell.execute_reply": "2026-06-20T11:16:21.351829Z"
     },
     "id": "25a1db92-e3dd-4fb4-96e0-7db4030b5cf0",
     "outputId": "1033bbf7-96be-45e9-fc20-533f562a5346",
@@ -72,8 +72,7 @@
      "output_type": "stream",
      "text": [
       "Packages Python OK.\n",
-      "JARs Tweety OK (13 fichiers dans libs/).\n",
-      "ATTENTION : java introuvable. Installez un JDK ou executez Tweety-1-Setup.ipynb.\n"
+      "JARs Tweety OK (42 fichiers dans libs/).\n"
      ]
     }
    ],
@@ -188,10 +187,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.500925Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.500630Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.533361Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.532392Z"
+     "iopub.execute_input": "2026-06-20T11:16:21.353915Z",
+     "iopub.status.busy": "2026-06-20T11:16:21.353739Z",
+     "iopub.status.idle": "2026-06-20T11:16:21.586264Z",
+     "shell.execute_reply": "2026-06-20T11:16:21.585802Z"
     },
     "id": "c9384b5d",
     "outputId": "2d652722-71ed-4994-8bae-245477b19cc4",
@@ -210,7 +209,23 @@
      "output_type": "stream",
      "text": [
       "--- Verification JVM Tweety + Outils ---\n",
-      "ERREUR: JAVA_HOME non defini et JDK portable non trouve.\n"
+      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JVM demarree avec 42 JARs."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "JVM prete\n"
      ]
     }
    ],
@@ -381,10 +396,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.573693Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.573433Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.578991Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.578296Z"
+     "iopub.execute_input": "2026-06-20T11:16:21.595587Z",
+     "iopub.status.busy": "2026-06-20T11:16:21.594890Z",
+     "iopub.status.idle": "2026-06-20T11:16:21.968193Z",
+     "shell.execute_reply": "2026-06-20T11:16:21.967538Z"
     },
     "id": "32a3ee00",
     "outputId": "f2f8dd04-b795-42d1-c0b6-c00775c2cfcf",
@@ -403,7 +418,14 @@
      "output_type": "stream",
      "text": [
       "--- 2.3.1 Logique de Description : Imports ---\n",
-      "ERREUR: JVM non demarree. Impossible de continuer cet exemple.\n"
+      "JVM prete. Import des classes DL...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports DL reussis.\n"
      ]
     }
    ],
@@ -506,10 +528,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.612832Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.612533Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.617680Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.617061Z"
+     "iopub.execute_input": "2026-06-20T11:16:21.970202Z",
+     "iopub.status.busy": "2026-06-20T11:16:21.969995Z",
+     "iopub.status.idle": "2026-06-20T11:16:21.976106Z",
+     "shell.execute_reply": "2026-06-20T11:16:21.975499Z"
     },
     "id": "ccee3f05",
     "outputId": "67f63573-1655-4bfe-fe43-247b56ceafbd",
@@ -527,7 +549,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports DL non disponibles.\n"
+      "TBox creee:\n",
+      "  Female = Human\n",
+      "  Male = Human\n",
+      "  Female = NOT Male\n",
+      "  Male = NOT Female\n",
+      "  House = NOT Human\n"
      ]
     }
    ],
@@ -630,10 +657,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.652146Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.651898Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.657185Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.656407Z"
+     "iopub.execute_input": "2026-06-20T11:16:21.977831Z",
+     "iopub.status.busy": "2026-06-20T11:16:21.977676Z",
+     "iopub.status.idle": "2026-06-20T11:16:21.991108Z",
+     "shell.execute_reply": "2026-06-20T11:16:21.990527Z"
     },
     "id": "c219a0b0",
     "outputId": "61b9825b-ccbe-44ba-a048-db5d843e7005",
@@ -651,7 +678,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports DL non disponibles.\n"
+      "Knowledge Base DL:\n",
+      "  TBox: [implies Female (not Male), implies House (not Human), implies Male Human, implies Female Human, implies Male (not Female)]\n",
+      "  ABox: [instance Bob Male, instance Alice Human, instance Bob Human, related Bob Alice fatherOf, instance Alice Female]\n"
      ]
     }
    ],
@@ -757,10 +786,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.692825Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.692572Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.697563Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.696870Z"
+     "iopub.execute_input": "2026-06-20T11:16:21.993361Z",
+     "iopub.status.busy": "2026-06-20T11:16:21.993139Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.005155Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.004306Z"
     },
     "id": "86f23e81",
     "outputId": "980732e0-d0c3-42e3-c2d7-907d662b8366",
@@ -778,7 +807,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports DL non disponibles.\n"
+      "Requetes DL:\n",
+      "  Female = Human ? True\n",
+      "  Tweety : Human ? True\n",
+      "  Alice : Male ? False\n"
      ]
     }
    ],
@@ -899,10 +931,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.731034Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.730787Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.735681Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.734932Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.008380Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.008096Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.044718Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.043906Z"
     },
     "id": "ca8462d9",
     "outputId": "6bbaf161-0dcb-42e2-fff9-e7264aa4ac37",
@@ -921,7 +953,7 @@
      "output_type": "stream",
      "text": [
       "--- 2.4.1 Logique Modale : Imports ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "Imports ML reussis.\n"
      ]
     }
    ],
@@ -1020,10 +1052,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.768527Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.768223Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.774023Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.773088Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.050811Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.050487Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.070453Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.069772Z"
     },
     "id": "31b9b499",
     "outputId": "46ef5a9c-d299-4707-e1ea-e4f1f09a1978",
@@ -1041,7 +1073,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports ML non disponibles.\n"
+      "Parsing des formules modales:\n",
+      "  [OK] !(<>(p))\n",
+      "  [OK] p || r\n",
+      "  [OK] !r || [](q && r)\n",
+      "  [OK] [](r && <>(p || q))\n",
+      "  [OK] !p && !q\n",
+      "\n",
+      "KB Modale: 5 formules\n"
      ]
     }
    ],
@@ -1157,10 +1196,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.803334Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.803127Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.809338Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.808678Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.083062Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.082865Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.088685Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.088123Z"
     },
     "id": "64bb4a5b",
     "outputId": "09d44228-e27e-4d23-d1dd-05b1a440c86b",
@@ -1388,10 +1427,10 @@
    "id": "d794b40f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.840062Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.839835Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.843267Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.842618Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.099084Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.098901Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.102365Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.101771Z"
     },
     "papermill": {
      "duration": 0.011239,
@@ -1462,10 +1501,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.862608Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.862433Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.866415Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.865671Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.111960Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.111650Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.142976Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.142330Z"
     },
     "id": "d437aa5e",
     "outputId": "2070cbd4-66f8-4d41-8159-679e3a074d63",
@@ -1484,7 +1523,7 @@
      "output_type": "stream",
      "text": [
       "--- 2.5.1 QBF (Quantified Boolean Formulas) ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "Imports QBF reussis.\n"
      ]
     }
    ],
@@ -1590,10 +1629,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.900594Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.900172Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.905505Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.904645Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.147114Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.146887Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.152489Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.152089Z"
     },
     "id": "3f1eb19c",
     "outputId": "98c7ad80-a908-4588-8216-2b8f1f8545cd",
@@ -1611,7 +1650,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports QBF non disponibles.\n"
+      "Formule de base: x||y\n",
+      "Formule QBF: exists x: (x||y)\n",
+      "Formule QBF imbriquee: forall y: (exists x: (x||y))\n",
+      "\n",
+      "--- Variante avec constructeur simplifie ---\n",
+      "exists z: z = exists z: (z)\n"
      ]
     }
    ],
@@ -1738,10 +1782,10 @@
    "id": "1e9afcc4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.939906Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.939682Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.943274Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.942540Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.154223Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.154098Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.156786Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.156315Z"
     },
     "papermill": {
      "duration": 0.010629,
@@ -1804,10 +1848,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:33.966412Z",
-     "iopub.status.busy": "2026-06-02T21:43:33.966209Z",
-     "iopub.status.idle": "2026-06-02T21:43:33.971366Z",
-     "shell.execute_reply": "2026-06-02T21:43:33.970508Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.158549Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.158433Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.172041Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.171578Z"
     },
     "id": "8b153a15",
     "outputId": "5d58d430-c46a-4e35-99af-3b323cc855ef",
@@ -1825,8 +1869,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- 2.5.3 Logique Conditionnelle (CL) ---\n",
-      "JVM non demarree.\n"
+      "--- 2.5.3 Logique Conditionnelle (CL) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports CL reussis.\n",
+      "\n",
+      "Conditionnel 1: (bird|flies)\n",
+      "Conditionnel 2: (penguin|!flies)\n",
+      "\n",
+      "KB Conditionnelle: { (penguin|!flies), (bird|flies) }\n"
      ]
     }
    ],
@@ -1968,10 +2023,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:34.004490Z",
-     "iopub.status.busy": "2026-06-02T21:43:34.004290Z",
-     "iopub.status.idle": "2026-06-02T21:43:34.011670Z",
-     "shell.execute_reply": "2026-06-02T21:43:34.010847Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.173825Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.173693Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.180634Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.180128Z"
     },
     "id": "w4l5v5ty69",
     "outputId": "29876fca-fa49-43ae-ebba-0e546d083fee",
@@ -1989,7 +2044,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exemple saute : JVM ou imports DL non disponibles\n"
+      "Knowledge Base:\n",
+      "  TBox: [implies Enseignant Personne, implies Etudiant Personne, implies Cours (not Personne)]\n",
+      "  ABox: [instance CoursInfo Cours, instance Alice Etudiant, related Alice CoursInfo inscritA, related Bob CoursMaths inscritA, instance Bob Etudiant, related ProfMartin CoursInfo enseigne, instance ProfMartin Enseignant, instance CoursMaths Cours]\n",
+      "\n",
+      "Requetes de raisonnement:\n",
+      "  Alice (Etudiant) : Personne ? True\n",
+      "  CoursInfo (Cours) : Personne ? False\n",
+      "  ProfMartin (Enseignant) : Etudiant ? False\n"
      ]
     }
    ],
@@ -2175,10 +2237,10 @@
    "id": "287e261a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:43:34.049843Z",
-     "iopub.status.busy": "2026-06-02T21:43:34.049644Z",
-     "iopub.status.idle": "2026-06-02T21:43:34.053017Z",
-     "shell.execute_reply": "2026-06-02T21:43:34.052430Z"
+     "iopub.execute_input": "2026-06-20T11:16:22.188426Z",
+     "iopub.status.busy": "2026-06-20T11:16:22.188183Z",
+     "iopub.status.idle": "2026-06-20T11:16:22.192569Z",
+     "shell.execute_reply": "2026-06-20T11:16:22.191875Z"
     },
     "papermill": {
      "duration": 0.009467,
@@ -2228,7 +2290,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Axe-2 repair per ai-01 dispatch 2026-06-20T10:02Z (Tweety deep-queue, item 1). Same root cause & fix as #3755/#3756.

## Defect (DEGRADED score 4)
cell 14 `Exemple saute : JVM ou imports DL non disponibles` — JVM not started on prior run.

## Root cause (G.1 firsthand)
Stale-env artifact, not an API change. Re-exec from `Tweety/` folder with miniconda python + jpype 1.7.1 + JDK 17 portable starts the JVM.

## Verification
| Gate | Result |
|---|---|
| Cells | 16/16 executed, 0 error, 0 skip remaining |
| Source | byte-identical origin/main (45/45, 0 diff) |
| regression_scan | DEGRADED(4) → **HEALTHY(0)** |
| Scope | outputs only |

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>