### PR TITLE
fix(planners-3): align A*-vs-BFS interpretation with committed output (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
@@ -2001,20 +2001,23 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : L'avantage d'A* avec obstacles\n",
+    "### Interpretation : A\\* face à un corridor (quand l'heuristique n'aide pas)\n",
     "\n",
-    "L'ajout d'obstacles crée des détour obligés qui amplifient la différence entre les algorithmes.\n",
+    "Sur cette grille 5x5, les obstacles `{(1,1),(1,2),(1,3),(3,1),(3,2),(3,3)}` ne laissent qu'un seul corridor praticable le long de la colonne de droite (x=4). Le résultat committé est instructif :\n",
     "\n",
-    "| Algorithme | Noeuds explores | Cout | Observation |\n",
-    "|------------|-----------------|------|-------------|\n",
-    "| **BFS** | élevé | optimal | Explore systématiquement toutes les couches de profondeur |\n",
-    "| **A*** | réduit | optimal | L'heuristique de Manhattan guide la recherche autour des obstacles |\n",
+    "| Algorithme | Noeuds explores | Cout | Chemin |\n",
+    "|------------|-----------------|------|--------|\n",
+    "| **BFS** | 19 | 8 | le long du corridor |\n",
+    "| **A\\*** | 20 | 8 | le long du corridor |\n",
     "\n",
     "**Points cles** :\n",
-    "- En l'absence d'obstacles (grille 3x3), BFS et A* explorent un nombre similaire de noeuds\n",
-    "- Avec des obstacles, A* concentre son exploration dans la direction du but, évitant les branches qui s'en éloignent\n",
-    "- L'heuristique de Manhattan reste **admissible** avec des obstacles : elle sous-estime toujours le coût réel (le chemin réel fait au minimum la distance Manhattan)\n",
-    "- C'est précisément ce type de problème que les planificateurs PDDL rencontrent : des espaces d'états où l'heuristique informe fait toute la différence"
+    "\n",
+    "- Sur cette instance, A\\* a exploré **un nœud de plus** que BFS (économie négative de -5.3%) : l'écart est faible, et c'est précisément le cas où l'heuristique n'apporte rien.\n",
+    "- Quand un **seul chemin** relie le départ au but (corridor sans embranchement), la distance de Manhattan pousse A\\* à examiner les mêmes nœuds que BFS, voire quelques-uns de plus à cause des égalités de priorité (`f = g + h`). L'heuristique ne peut pruner que s'il existe des branches **qui s'éloignent du but** à élaguer.\n",
+    "- Les deux algorithmes trouvent bien le chemin optimal (cout = 8) : A\\* reste **admissible** (l'heuristique sous-estime toujours le coût réel), le bénéfice en exploration dépend de la topologie.\n",
+    "- C'est une leçon importante pour la planification PDDL : une heuristique admissible garantit l'optimalité, mais **le gain en nœuds explorés n'est pas automatique** — il apparaît sur les instances ramifiées où l'heuristique est informative, pas sur les corridors.\n",
+    "\n",
+    "> **Pour observer A\\* pruner réellement.** Une grille avec plusieurs branches dont certaines mènent à des impasses (labyrinthe) ferait apparaître un écart net en faveur d'A\\* : c'est ce genre de topologie que l'on retrouvera avec les heuristiques PDDL du notebook Planners-5.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit #3164 (fidélité numérique SymbolicAI executables). Found and fixed a numerical-fidelity MISMATCH in `Planners-3-State-Space.ipynb`.

**Cell `ef4f71d1`** (Interpretation) claimed A\* explores **fewer** nodes than BFS with obstacles:
> `| **A\*** | réduit | ... | L'heuristique de Manhattan guide la recherche autour des obstacles |`
> « A\* concentre son exploration dans la direction du but, évitant les branches qui s'en éloignent »

But the **committed output** (code cell 43, 5x5 grid with obstacles `{(1,1),(1,2),(1,3),(3,1),(3,2),(3,3)}`) shows the **opposite**:

```
BFS   ...  Cout: 8  Noeuds explores: 19
A*    ...  Cout: 8  Noeuds explores: 20
A* a explore -1 noeuds de moins que BFS (-5.3% d'economie)
```

A\* explored **one more node** than BFS (negative economy). The markdown narrative was written as if the ideal pedagogical outcome (A\* prunes) had occurred.

## Fix

Rewrote the interpretation to **honestly report the corridor result** (BFS 19 / A\* 20 / cost 8) and explain **why** A\* did not prune on this instance: the obstacle layout leaves a single corridor along column x=4, so the Manhattan heuristic is uninformative — it can only prune branches that move *away* from the goal. Turns a fidelity bug into a richer lesson on **when a heuristic is informative** (ramified instances vs corridors), with a forward pointer to Planners-5 PDDL heuristics.

## Preuves vérifiables (règle B/H.1)

- **0 churn code/outputs** : `git diff` touche uniquement les lignes `source` de la cellule markdown `ef4f71d1` (25 lignes, +14/-11). Aucune cellule code, aucun `execution_count`, aucun `outputs` modifié (C.3 strict).
- **H3 pre-commit** : 0 cellule code non-exécutée vide.
- **JSON valide** : `json.load` OK après édition.
- **Output cité verbatim** : `BFS 19 / A* 20 / cost 8 / -5.3%` = sorties réelles de la cellule 43, vérifiées par relecture directe (G.1).
- **Reassessment** : CONFIRMED MISMATCH — l'output se self-report lui-même (« A\* a explore -1 noeuds de moins »), le markdown disait « réduit ». Pas un faux positif.

## Méthode

Audit des notebooks Planners executables (option 1 ai-01 : fidélité numérique SymbolicAI contenu, pas citations). Planners-4 / Planners-5 = FIDELITY_OK (tous les claims chiffrés vérifiés contre outputs). Planners-3 cell `ef4f71d1` = seul finding actionnable, fixé ici.

See #3164