### PR TITLE
fix(planners-11): align solver comparison interpretation with committed output (audit #3164)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
@@ -886,16 +886,16 @@
    "source": [
     "### Interpretation : Comparaison multi-solveurs\n",
     "\n",
-    "**Sortie obtenue** : Erreur sur les deux solveurs testes (pyperplan, fast-downward).\n",
+    "**Sortie obtenue** : Sur les deux solveurs testes, **fast-downward a resolu le probleme** tandis que pyperplan a remonte une erreur.\n",
     "\n",
     "| Solveur | Statut | Temps | Plan |\n",
     "|---------|--------|-------|------|\n",
     "| pyperplan | ERROR | 0.000s | N/A |\n",
-    "| fast-downward | ERROR | 0.000s | N/A |\n",
+    "| fast-downward | **SOLVED_SATISFICING** | 0.492s | **2 actions** |\n",
     "\n",
-    "**Cause probable** : Les solveurs ne sont pas installes ou pas dans le PATH.\n",
+    "**Cause de l'erreur pyperplan** : le solveur n'est pas installe ou pas dans le PATH. Ce n'est pas bloquant : unified-planning permet de tester plusieurs solveurs, et un seul suffit a produire un plan.\n",
     "\n",
-    "**Workflow de comparaison ideal** (si solveurs disponibles) :\n",
+    "**Workflow de comparaison** :\n",
     "\n",
     "1. **Initialisation** : Creer le probleme une seule fois\n",
     "2. **Tests sequentiels** : Lancer chaque solveur avec un timeout\n",
@@ -907,7 +907,7 @@
     "- **Performance** : Trouver le solveur le plus rapide pour un type de probleme\n",
     "- **Qualite** : Comparer les qualites de plan (optimal vs satisficing)\n",
     "\n",
-    "> **Note technique** : unified-planning permet de changer de solveur en modifiant une seule ligne (`name='fast-downward'` au lieu de `name='pyperplan'`), ce qui facilite enormement le benchmarking."
+    "> **Note technique** : unified-planning permet de changer de solveur en modifiant une seule ligne (`name='fast-downward'` au lieu de `name='pyperplan'`), ce qui facilite enormement le benchmarking.\n"
    ]
   },
   {
@@ -1082,13 +1082,13 @@
    "source": [
     "### Interpretation : Comparaison des solveurs\n",
     "\n",
-    "**Sortie obtenue** : Tableau comparatif vide (aucun solveur n'a fonctionne).\n",
+    "**Sortie obtenue** : Le tableau comparatif montre **fast-downward comme vainqueur** -- plus rapide (0.492s) et plan le plus court (2 actions).\n",
     "\n",
-    "**Comparaison theorique attendue** :\n",
+    "**Comparaison theorique des solveurs unified-planning** :\n",
     "\n",
     "| Solveur | Optimalite | Vitesse | Specialites |\n",
     "|---------|------------|---------|-------------|\n",
-    "| **Pyperplan** | Satisficing | Tres rapide | Probleme simples, prototypage |\n",
+    "| **Pyperplan** | Satisficing | Tres rapide | Problemes simples, prototypage |\n",
     "| **Fast Downward** | Optimal/Satisficing | Moyenne | Heuristiques puissantes (LM-cut, FF) |\n",
     "| **Tamer** | Satisficing | Rapide | Preferences, plans avec qualite |\n",
     "| **ENHSP** | Optimal | Lent | Fluents numeriques, PDDL 2.1 |\n",
@@ -1100,7 +1100,7 @@
     "- **ENHSP** : Problemes numeriques (couts, ressources)\n",
     "- **LPG** : Planification temporelle (PDDL 2.1)\n",
     "\n",
-    "> **Note importante** : Le choix du solveur depend fortement du type de probleme. Un solveur excellent sur Block World peut etre mediocre sur Logistics. C'est tout l'interet d'unified-planning : tester facilement plusieurs solveurs."
+    "> **Note importante** : Le choix du solveur depend fortement du type de probleme. Un solveur excellent sur Block World peut etre mediocre sur Logistics. C'est tout l'interet d'unified-planning : tester facilement plusieurs solveurs.\n"
    ]
   },
   {
@@ -2135,24 +2135,22 @@
    "source": [
     "### Interpretation : Resolution robuste avec gestion d'erreurs\n",
     "\n",
-    "**Sortie obtenue** : Aucun solveur n'a reussi (erreur sur les deux tentatives).\n",
+    "**Sortie obtenue** : Apres echec de pyperplan, **fast-downward a reussi** : `SUCCES: Plan trouve! Longueur: 2 actions`. Le fallback a fonctionne.\n",
     "\n",
     "| Solveur | Statut | Temps | Plan |\n",
     "|---------|--------|-------|------|\n",
     "| pyperplan | ERROR | 0.000s | N/A |\n",
-    "| fast-downward | ERROR | 0.000s | N/A |\n",
+    "| fast-downward | **SUCCES** | -- | **2 actions** |\n",
     "\n",
-    "**Analyse des erreurs** :\n",
-    "- Les solveurs ne sont probablement pas installes sur le systeme\n",
-    "- L'erreur vide (\"\") suggere un probleme de configuration environnement\n",
+    "**Lecon** : c'est precisement l'interet du pattern solveur-preferé + fallback. Quand pyperplan n'est pas disponible, on bascule sur fast-downward, qui produit le plan attendu. L'execution robuste ne signifie pas que tous les solveurs doivent reussir, mais qu'au moins un degrade gracieusement vers une solution.\n",
     "\n",
-    "**Workflow robuste ideal** :\n",
-    "1. Essayer le solveur preferé\n",
-    "2. En cas d'echec, essayer le solveur de fallback\n",
+    "**Workflow robuste** :\n",
+    "1. Essayer le solveur preferé (ici pyperplan, leger)\n",
+    "2. En cas d'echec, essayer le solveur de fallback (ici fast-downward)\n",
     "3. Gerer les differents statuts (SOLVED, UNSOLVABLE, TIMEOUT)\n",
     "4. Afficher des statistiques detaillees si disponibles\n",
     "\n",
-    "> **Note technique** : Dans un environnement de production, il est recommande d'installer les solveurs via les packages UP (`up-fast-downward`, `up-pyperplan`) plutot que d'utiliser les installations systeme, ce qui garantit la compatibilité des versions."
+    "> **Note technique** : Dans un environnement de production, il est recommande d'installer les solveurs via les packages UP (`up-fast-downward`, `up-pyperplan`) plutot que d'utiliser les installations systeme, ce qui garantit la compatibilite des versions.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit #3164 (fidélité numérique SymbolicAI executables). Found and fixed a **lesson-inverting** numerical-fidelity MISMATCH in `Planners-11-Unified-Planning.ipynb`.

**3 markdown interpretation cells** (`c0e2d58f`/idx 22, `57676fdc`/idx 27, `3d167717`/idx 51) all claimed the solveurs failed:
> « Erreur sur les deux solveurs testes » / « Tableau comparatif vide (aucun solveur n'a fonctionne) » / « Aucun solveur n'a reussi (erreur sur les deux tentatives) »

But the **committed outputs** show the **opposite** — **fast-downward succeeded**:

| Code cell | Output (verbatim) |
|-----------|-------------------|
| cell 21 (id `cell-compare-solvers`) | `fast-downward... Statut: SOLVED_SATISFICING, Temps: 0.492s, Plan: 2 actions` |
| cell 25 (id `cell-display-comparison`) | `fast-downward \| SOLVED_SATISFICING \| 0.492s \| 2` + `Plus rapide: fast-downward (0.492s)` + `Plan le plus court: fast-downward (2 actions)` |
| cell 50 (id `cell-best-practices-code`) | `SUCCES: Plan trouve! Longueur: 2 actions` |

pyperplan did ERROR (not installed), but fast-downward solved the problem.

## Root cause

The notebook was **re-executed with fast-downward available** (fresh outputs in cells 21/25/50) but the **markdown interpretations were never updated** — they still describe the old run where both solvers were absent. This **inverts the entire pedagogical point** of the notebook: it teaches that unified-planning works and produces a plan, but the interpretations told students everything failed.

## Fix

Rewrote the 3 interpretation cells (`c0e2d58f`, `57676fdc`, `3d167717`) to faithfully report:
- **Cell 22**: fast-downward SOLVED_SATISFICING (0.492s, 2 actions) vs pyperplan ERROR (not installed) — multi-solver robustness lesson.
- **Cell 27**: the comparison table shows fast-downward as winner (fastest + shortest plan).
- **Cell 51**: the fallback pattern worked (pyperplan failed → fast-downward succeeded) — execution robustness means at least one solver degrades gracefully to a solution, not that all must succeed.

## Preuves vérifiables (règle B/H.1)

- **0 churn code/outputs** : `git diff` touche uniquement les lignes `source` des 3 cells markdown d'interprétation (36 lignes, +17/-19). Aucune cellule code, aucun `execution_count`, aucun `outputs` modifié (C.3 strict). Vérifié : `git diff | grep execution_count` = empty.
- **H3 pre-commit** : 0 cellule code non-exécutée vide.
- **JSON valide** : `json.load` OK après édition (62 cells).
- **Outputs cités verbatim** : `SOLVED_SATISFICING / 0.492s / Plan: 2 actions / SUCCES` = sorties réelles des cells 21/25/50, vérifiées par relecture directe (G.1) — le subagent de recensement a été re-vérifié cellule par cellule.
- **Reassessment** : CONFIRMED MISMATCH (lesson-inverting — les outputs montrent SUCCES, le markdown disait « aucun solveur n'a réussi »). Pas un faux positif.

## Contexte audit

Suit #3760 (Planners-3 A*-vs-BFS mismatch, cycle précédent). Audit Planners 6-12 + SemanticWeb Python via subagent sonnet (model-delegation) : 13 notebooks, plusieurs findings material identifiés. **Planners-11 = le plus grave** (lesson-inverting), fixé ici. Findings résiduels queue pour prochains cycles (SW-13 ratios déformés 10×, Planners-8 gain parallélisme 1.00x, Planners-12 compte états 13 vs 16, Planners-7 timing N-Queens).

See #3164