### PR TITLE
docs(qcpy-30): scholarly anchors for LSTM Training (Hochreiter/Bahdanau/AdamW/SGDR/grad-clipping) (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
@@ -1242,7 +1242,10 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : Le modele combine un LSTM profond (3 couches, 128 units) avec 4 têtes d'attention qui apprennent a ponderer differemment les pas de temps. Deux heads de prediction : regression (rendement continu) et classification (direction haussier/baissier)."
+    "**Interpretation** : Le modele combine un LSTM profond (3 couches, 128 units) avec 4 têtes d'attention qui apprennent a ponderer differemment les pas de temps. Deux heads de prediction : regression (rendement continu) et classification (direction haussier/baissier).",
+    "\n",
+    "> *Ancres savantes -- architecture.* Le reseau LSTM (Long Short-Term Memory) est forme par Hochreiter & Schmidhuber (1997), *Long Short-Term Memory*, Neural Computation **9(8), 1735-1780**, DOI 10.1162/neco.1997.9.8.1735. Le mecanisme d'attention additive (ponderation des pas de temps pertinents) est formalise par Bahdanau, Cho & Bengio (2015), *Neural Machine Translation by Jointly Learning to Align and Translate*, ICLR 2015, arXiv:1409.0473.\n",
+    ""
    ]
   },
   {
@@ -1569,7 +1572,10 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : L'entraineur utilise AdamW avec cosine annealing pour eviter les minima plats. Le gradient clipping (max_norm=1.0) previent l'explosion des gradients dans le LSTM profond. Le meilleur modele est sauvegarde par early stopping implicite (checkpoint sur val loss)."
+    "**Interpretation** : L'entraineur utilise AdamW avec cosine annealing pour eviter les minima plats. Le gradient clipping (max_norm=1.0) previent l'explosion des gradients dans le LSTM profond. Le meilleur modele est sauvegarde par early stopping implicite (checkpoint sur val loss).",
+    "\n",
+    "> *Ancres savantes -- techniques d'entrainement.* L'optimiseur **AdamW** (decoupled weight decay) est formalise par Loshchilov & Hutter (2019), *Decoupled Weight Decay Regularization*, ICLR 2019, arXiv:1711.05101. Le **cosine annealing** (planning de taux d'apprentissage) provient de Loshchilov & Hutter (2017), *SGDR: Stochastic Gradient Descent with Warm Restarts*, ICLR 2017, arXiv:1608.03983. Le **gradient clipping** contre l'explosion des gradients dans les RNN est introduit par Pascanu, Mikolov & Bengio (2013), *On the difficulty of training Recurrent Neural Networks*, ICML 2013 (PMLR vol. 28), arXiv:1211.5063.\n",
+    ""
    ]
   },
   {
@@ -2576,7 +2582,16 @@
     "tags": []
    },
    "source": [
-    "## 14. Resume et conclusions"
+    "## 14. Resume et conclusions",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- Hochreiter, S., & Schmidhuber, J. (1997). *Long Short-Term Memory.* Neural Computation, 9(8), 1735-1780. https://doi.org/10.1162/neco.1997.9.8.1735\n",
+    "- Bahdanau, D., Cho, K., & Bengio, Y. (2015). *Neural Machine Translation by Jointly Learning to Align and Translate.* International Conference on Learning Representations (ICLR). arXiv:1409.0473\n",
+    "- Pascanu, R., Mikolov, T., & Bengio, Y. (2013). *On the difficulty of training Recurrent Neural Networks.* International Conference on Machine Learning (ICML), PMLR 28. arXiv:1211.5063\n",
+    "- Loshchilov, I., & Hutter, F. (2017). *SGDR: Stochastic Gradient Descent with Warm Restarts.* International Conference on Learning Representations (ICLR). arXiv:1608.03983\n",
+    "- Loshchilov, I., & Hutter, F. (2019). *Decoupled Weight Decay Regularization.* International Conference on Learning Representations (ICLR). arXiv:1711.05101\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Summary

#3164 extended citation audit, **grain 14 — QC-Py-30-LSTM-Training**.

**Verdict: OMISSION.** Foundational architectures and training techniques named in teaching prose without scholarly anchor. Markdown-additive (no code cell touched). QC-Py = original material (Broad *Hands-On AI Trading*), not a strict #3164 portage.

See #3164.

### Changes (markdown-only, 1 file, +19/-4 content-level)

- **cell 17** (model interpretation): grouped scholarly footnote
  - Hochreiter & Schmidhuber (1997) LSTM — *Neural Computation* 9(8), 1735-1780, DOI 10.1162/neco.1997.9.8.1735
  - Bahdanau, Cho & Bengio (2015) additive attention — ICLR, arXiv:1409.0473
- **cell 23** (optimizer interpretation): grouped scholarly footnote
  - Loshchilov & Hutter (2019) AdamW decoupled weight decay — ICLR, arXiv:1711.05101
  - Loshchilov & Hutter (2017) SGDR cosine annealing — ICLR, arXiv:1608.03983
  - Pascanu, Mikolov & Bengio (2013) gradient clipping for RNN — ICML, PMLR 28, arXiv:1211.5063
- **cell 48** (conclusion): new `### References academiques` section (5 entries)

All anchors web-checked (G.1 — never cited from memory, no fabrication G.3).

## Validation

- Markdown-only edits (cells 17/23/48) → C.2 exception applies (no re-execution needed)
- JSON valid; cell count 50 unchanged
- **0 code cells changed** — 19 code cells byte-identical to `origin/main`
- Only cells 17/23/48 markdown changed (content-level verified)
- **Element-preservation**: 0 missing original source elements in annotated cells (list-direct mutation, no join+resplit — lesson from QC-Py-25 cell-7 mash)
- cell_type sequence identical to `origin/main`
- Catalogue (`COURSE_CATALOG.generated.json/.md`) byte-identical; openzeppelin submodule not staged
- Base fresh from `origin/main` (`1093c2080`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
