### PR TITLE
fix(sc12): re-execute Foundry-Testing with forge on PATH (repair stub #3743)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/.gitignore
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/.gitignore
@@ -14,3 +14,10 @@ foundry-lib/lib/
 foundry-lib/cache/
 foundry-lib/out/
 foundry-lib/src/
+
+# mon-premier-projet: forge-std installed via `forge install foundry-rs/forge-std`
+# (build-time dependency, regenerable like node_modules — not committed)
+mon-premier-projet/lib/
+mon-premier-projet/cache/
+mon-premier-projet/out/
+mon-premier-projet/broadcast/

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -181,11 +181,35 @@
      "text": [
       "Verification des outils Foundry:\n",
       "--------------------------------------------------\n",
-      "  forge: MANQUANT\n",
-      "  cast: MANQUANT\n",
-      "  anvil: MANQUANT\n",
+      "  forge: OK\n",
+      "    forge Version: 1.5.1-stable\n",
+      "Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2\n",
+      "Build Timestamp: 2025-12-22T11:40:33.870895500Z (1766403633)\n",
+      "Build Profile: maxperf\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cast: OK\n",
+      "    cast Version: 1.5.1-stable\n",
+      "Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2\n",
+      "Build Timestamp: 2025-12-22T11:40:33.870895500Z (1766403633)\n",
+      "Build Profile: maxperf\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  anvil: OK\n",
+      "    anvil Version: 1.5.1-stable\n",
+      "Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2\n",
+      "Build Timestamp: 2025-12-22T11:40:33.870895500Z (1766403633)\n",
+      "Build Profile: maxperf\n",
       "--------------------------------------------------\n",
-      "Installez Foundry: curl -L https://foundry.paradigm.xyz | bash && foundryup\n"
+      "Tous les outils sont installes !\n"
      ]
     }
    ],
@@ -817,13 +841,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "forge non installe - sortie attendue :\n",
+      "forge disponible: forge Version: 1.5.1-stable\n",
+      "Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2\n",
+      "Build Timestamp: 2025-12-22T11:40:33.870895500Z (1766403633)\n",
+      "Build Profile: maxperf\n",
       "\n",
-      "  [PASS] test_Decrement() (gas: ~28000)\n",
-      "  [PASS] test_InitialState() (gas: ~5000)\n",
-      "  [PASS] test_Increment() (gas: ~23000)\n",
-      "  [PASS] test_SetNumber() (gas: ~24000)\n",
-      "  Test result: ok. 4 passed; 0 failed\n"
+      "Pour executer les tests :\n",
+      "  mkdir test-project && cd test-project\n",
+      "  forge init\n",
+      "  # Copiez les contrats ci-dessus dans src/ et test/\n",
+      "  forge test -vvv\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary

SC-12-Foundry-Testing was **DEGRADED** on the axe-2 output-health scan. Two cells carried a recoverable-void consecration (Rule-F / #3660: repair, don't consecrate):

- **Cell 4** reported `forge: MANQUANT / cast: MANQUANT / anvil: MANQUANT` + an install prompt.
- **Cell 18** hit its `FileNotFoundError` branch and printed a **hardcoded fake "expected output"**: `forge non installe - sortie attendue : [PASS] test_Decrement() (gas: ~28000) ... 4 passed; 0 failed`.

That stubbed `[PASS]` block consecrated a void that is **recoverable**: Foundry (forge/cast/anvil `1.5.1-stable`) IS installed on this machine in `~/.foundry/bin`. The notebook's `subprocess.run([tool, "--version"])` only failed because `~/.foundry/bin` was not on the kernel PATH at last exec.

## Fix — pure re-execution (0 source cells changed)

Re-executed with `~/.foundry/bin` on PATH. Verified **0 source cells changed** (HEAD-vs-work source byte-identical). Only 2 output cells changed:

| Cell | Before | After |
|------|--------|-------|
| 4 | `forge: MANQUANT` (+ cast/anvil) + "Installez Foundry" | `forge: OK / cast: OK / anvil: OK` + real version strings (1.5.1-stable, b0a9dd9c, 2025-12-22) + "Tous les outils sont installes !" |
| 18 | fake `[PASS] test_Decrement() (gas: ~28000) ... 4 passed; 0 failed` stub | honest `forge disponible: forge Version 1.5.1-stable` + real run instructions |

23/23 code cells executed, `execution_count` 1..23 preserved.

## Honest scan caveat (G.1)

`regression_scan` still reports SC-12 score=4 with an `API_ENDPOINT` marker. This is a **false positive**: the marker fires on the bare word `"Unauthorized"`, which here is the **Solidity revert message** in cell 31's access-control test (`vm.expectRevert(bytes("Unauthorized"))`), not an API auth failure. The genuine env-degradation (forge MANQUANT + `[PASS]` stub) is repaired; the residual marker is a known soft-scan limit (revert-reason strings matching auth-failure patterns). Reported honestly — not claimed HEALTHY(0).

## Verification

- **Real `forge test` on `mon-premier-projet`** (the scaffold the notebook describes): 4 PASS (testDecrement / testDecrementZero / testIncrement / testPublicGetter) on Solc 0.8.28.
- H.3 clean: 23/23 code cells executed, 0 null-`execution_count`.
- 0 source diff, 0 abspath leak, 0 secret, catalog byte-identical, base fresh (0 behind origin/main).

## Infra

`SmartContracts/.gitignore` extended to ignore `mon-premier-projet/{lib,cache,out,broadcast}/` — forge-std is a build-time dependency regenerable via `forge install foundry-rs/forge-std` (like node_modules), not committed.

See #3743. Axe-2 deep-queue (ai-01 dispatch 10:02Z): SC compile/test Foundry item. Per doctrine "deploy testnet = user-gated Sepolia key — DO NOT deploy, only compile/test".

🤖 Generated with [Claude Code](https://claude.com/claude-code)