### PR TITLE
fix(planners-12): align enumeration count to committed output (13 -> 16 etats) (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
@@ -2414,7 +2414,7 @@
     "\n",
     "| Etape | Description |\n",
     "|-------|-------------|\n",
-    "| **Enumeration** | Generation exhaustive des configurations valides (13 etats) |\n",
+    "| **Enumeration** | Generation exhaustive des configurations valides (16 etats) |\n",
     "| **BFS** | Recherche des plans optimaux depuis chaque etat vers le but |\n",
     "| **Encodage** | Vecteur binaire de dimension 12 (6 predicats `on` + 3 `ontable` + 3 `clear`) |\n",
     "| **Entrainement** | 200 epochs d'imitation learning sur les paires (etat, action optimale) |\n",


### PR DESCRIPTION
## Fidelity fix #3164 — Planners-12-LOOP cell 52

**Cell** `64a95a15` (idx 52, markdown interpretation table).

### MISMATCH
The Enumeration row said:
> `| **Enumeration** | Generation exhaustive des configurations valides (13 etats) |`

But the committed output (cell 51) shows:
> `Nombre d'etats valides enumeres: 16`
with all 16 states (Etat 0 through Etat 15) explicitly listed.

**13 vs 16 = MISMATCH.**

### Fix
Surgical markdown-only edit: `(13 etats)` -> `(16 etats)`. Aligns the interpretation to the real committed output.

### Self-verify G.1 — other claims in cell 52
All other numeric claims in the same table are **FIDELITY_OK** against the committed output:
| Claim (markdown) | Committed output | Verdict |
|---|---|---|
| dimension 12 | `States: torch.Size([4, 12])` | OK |
| 200 epochs | `Epoch 200` | OK |
| 2,775 parametres | `Modele: 2,775 parametres` | OK |

Only the enumeration count was wrong.

### Validation
- JSON valid (60 cells)
- Diff: 1 line changed in a markdown cell (`13 etats` -> `16 etats`), + JSON re-normalization
- **0 churn on code cells / outputs / execution_count** (regle C.3)
- H.3 pre-commit check: 0 unexecuted-empty code cells
- Markdown-only edit -> outputs precedents valides (exception C.2)

See #3164

Co-Authored-By: Claude <noreply@anthropic.com>