### PR TITLE
fix(planners-3): weighted-terrain BFS-vs-A* example (real optimality differentiator, axis-3)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.007924,
-     "end_time": "2026-06-09T11:22:43.913407+00:00",
+     "duration": 0.005805,
+     "end_time": "2026-06-20T16:12:18.895618+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:43.905483+00:00",
+     "start_time": "2026-06-20T16:12:18.889813+00:00",
      "status": "completed"
     },
     "tags": []
@@ -44,10 +44,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.005521,
-     "end_time": "2026-06-09T11:22:43.924888+00:00",
+     "duration": 0.004281,
+     "end_time": "2026-06-20T16:12:18.906086+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:43.919367+00:00",
+     "start_time": "2026-06-20T16:12:18.901805+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "cell-2",
    "metadata": {
     "papermill": {
-     "duration": 0.005729,
-     "end_time": "2026-06-09T11:22:43.936497+00:00",
+     "duration": 0.004623,
+     "end_time": "2026-06-20T16:12:18.914857+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:43.930768+00:00",
+     "start_time": "2026-06-20T16:12:18.910234+00:00",
      "status": "completed"
     },
     "tags": []
@@ -111,16 +111,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:43.949697Z",
-     "iopub.status.busy": "2026-06-09T11:22:43.949411Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.000765Z",
-     "shell.execute_reply": "2026-06-09T11:22:44.999584Z"
+     "iopub.execute_input": "2026-06-20T16:12:18.924815Z",
+     "iopub.status.busy": "2026-06-20T16:12:18.924815Z",
+     "iopub.status.idle": "2026-06-20T16:12:20.441838Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.441052Z"
     },
     "papermill": {
-     "duration": 1.059053,
-     "end_time": "2026-06-09T11:22:45.001549+00:00",
+     "duration": 1.522324,
+     "end_time": "2026-06-20T16:12:20.441838+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:43.942496+00:00",
+     "start_time": "2026-06-20T16:12:18.919514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -131,7 +131,7 @@
      "output_type": "stream",
      "text": [
       "Imports reussis\n",
-      "networkx version: 3.6.1\n"
+      "networkx version: 3.4.2\n"
      ]
     }
    ],
@@ -153,10 +153,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.006849,
-     "end_time": "2026-06-09T11:22:45.014060+00:00",
+     "duration": 0.005004,
+     "end_time": "2026-06-20T16:12:20.451347+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.007211+00:00",
+     "start_time": "2026-06-20T16:12:20.446343+00:00",
      "status": "completed"
     },
     "tags": []
@@ -173,16 +173,16 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.026688Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.026230Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.035729Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.034913Z"
+     "iopub.execute_input": "2026-06-20T16:12:20.460349Z",
+     "iopub.status.busy": "2026-06-20T16:12:20.460349Z",
+     "iopub.status.idle": "2026-06-20T16:12:20.472431Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.471866Z"
     },
     "papermill": {
-     "duration": 0.01655,
-     "end_time": "2026-06-09T11:22:45.036560+00:00",
+     "duration": 0.017082,
+     "end_time": "2026-06-20T16:12:20.472431+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.020010+00:00",
+     "start_time": "2026-06-20T16:12:20.455349+00:00",
      "status": "completed"
     },
     "tags": []
@@ -266,10 +266,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.005342,
-     "end_time": "2026-06-09T11:22:45.047260+00:00",
+     "duration": 0.004003,
+     "end_time": "2026-06-20T16:12:20.481369+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.041918+00:00",
+     "start_time": "2026-06-20T16:12:20.477366+00:00",
      "status": "completed"
     },
     "tags": []
@@ -286,16 +286,16 @@
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.058874Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.058628Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.064297Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.063645Z"
+     "iopub.execute_input": "2026-06-20T16:12:20.491370Z",
+     "iopub.status.busy": "2026-06-20T16:12:20.490371Z",
+     "iopub.status.idle": "2026-06-20T16:12:20.502374Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.502374Z"
     },
     "papermill": {
-     "duration": 0.012988,
-     "end_time": "2026-06-09T11:22:45.065234+00:00",
+     "duration": 0.018005,
+     "end_time": "2026-06-20T16:12:20.503374+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.052246+00:00",
+     "start_time": "2026-06-20T16:12:20.485369+00:00",
      "status": "completed"
     },
     "tags": []
@@ -344,10 +344,10 @@
    "id": "n2lxn6uxvq",
    "metadata": {
     "papermill": {
-     "duration": 0.005625,
-     "end_time": "2026-06-09T11:22:45.076333+00:00",
+     "duration": 0.004508,
+     "end_time": "2026-06-20T16:12:20.511881+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.070708+00:00",
+     "start_time": "2026-06-20T16:12:20.507373+00:00",
      "status": "completed"
     },
     "tags": []
@@ -362,16 +362,16 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.091203Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.090918Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.472110Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.471243Z"
+     "iopub.execute_input": "2026-06-20T16:12:20.520884Z",
+     "iopub.status.busy": "2026-06-20T16:12:20.520884Z",
+     "iopub.status.idle": "2026-06-20T16:12:20.767295Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.767295Z"
     },
     "papermill": {
-     "duration": 0.391538,
-     "end_time": "2026-06-09T11:22:45.473250+00:00",
+     "duration": 0.252415,
+     "end_time": "2026-06-20T16:12:20.768295+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.081712+00:00",
+     "start_time": "2026-06-20T16:12:20.515880+00:00",
      "status": "completed"
     },
     "tags": []
@@ -429,10 +429,10 @@
    "id": "cell-9",
    "metadata": {
     "papermill": {
-     "duration": 0.005438,
-     "end_time": "2026-06-09T11:22:45.484739+00:00",
+     "duration": 0.003999,
+     "end_time": "2026-06-20T16:12:20.777297+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.479301+00:00",
+     "start_time": "2026-06-20T16:12:20.773298+00:00",
      "status": "completed"
     },
     "tags": []
@@ -458,10 +458,10 @@
    "id": "cell-10",
    "metadata": {
     "papermill": {
-     "duration": 0.006421,
-     "end_time": "2026-06-09T11:22:45.496955+00:00",
+     "duration": 0.005034,
+     "end_time": "2026-06-20T16:12:20.787331+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.490534+00:00",
+     "start_time": "2026-06-20T16:12:20.782297+00:00",
      "status": "completed"
     },
     "tags": []
@@ -484,16 +484,16 @@
    "id": "cell-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.510432Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.510150Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.517673Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.516664Z"
+     "iopub.execute_input": "2026-06-20T16:12:20.797838Z",
+     "iopub.status.busy": "2026-06-20T16:12:20.797838Z",
+     "iopub.status.idle": "2026-06-20T16:12:20.813604Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.813604Z"
     },
     "papermill": {
-     "duration": 0.016209,
-     "end_time": "2026-06-09T11:22:45.518502+00:00",
+     "duration": 0.022765,
+     "end_time": "2026-06-20T16:12:20.814604+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.502293+00:00",
+     "start_time": "2026-06-20T16:12:20.791839+00:00",
      "status": "completed"
     },
     "tags": []
@@ -558,10 +558,10 @@
    "id": "cell-12",
    "metadata": {
     "papermill": {
-     "duration": 0.006008,
-     "end_time": "2026-06-09T11:22:45.533002+00:00",
+     "duration": 0.005507,
+     "end_time": "2026-06-20T16:12:20.824111+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.526994+00:00",
+     "start_time": "2026-06-20T16:12:20.818604+00:00",
      "status": "completed"
     },
     "tags": []
@@ -578,16 +578,16 @@
    "id": "cell-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.546557Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.546312Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.553763Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.552692Z"
+     "iopub.execute_input": "2026-06-20T16:12:20.835116Z",
+     "iopub.status.busy": "2026-06-20T16:12:20.835116Z",
+     "iopub.status.idle": "2026-06-20T16:12:20.845066Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.844384Z"
     },
     "papermill": {
-     "duration": 0.015568,
-     "end_time": "2026-06-09T11:22:45.554674+00:00",
+     "duration": 0.016471,
+     "end_time": "2026-06-20T16:12:20.845586+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.539106+00:00",
+     "start_time": "2026-06-20T16:12:20.829115+00:00",
      "status": "completed"
     },
     "tags": []
@@ -657,10 +657,10 @@
    "id": "cell-14",
    "metadata": {
     "papermill": {
-     "duration": 0.006061,
-     "end_time": "2026-06-09T11:22:45.567243+00:00",
+     "duration": 0.004769,
+     "end_time": "2026-06-20T16:12:20.855503+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.561182+00:00",
+     "start_time": "2026-06-20T16:12:20.850734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -688,16 +688,16 @@
    "id": "cell-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.581781Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.581538Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.587170Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.586345Z"
+     "iopub.execute_input": "2026-06-20T16:12:20.865502Z",
+     "iopub.status.busy": "2026-06-20T16:12:20.865502Z",
+     "iopub.status.idle": "2026-06-20T16:12:20.875506Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.875506Z"
     },
     "papermill": {
-     "duration": 0.014656,
-     "end_time": "2026-06-09T11:22:45.588183+00:00",
+     "duration": 0.017005,
+     "end_time": "2026-06-20T16:12:20.876506+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.573527+00:00",
+     "start_time": "2026-06-20T16:12:20.859501+00:00",
      "status": "completed"
     },
     "tags": []
@@ -737,10 +737,10 @@
    "id": "1e5261cd",
    "metadata": {
     "papermill": {
-     "duration": 0.005442,
-     "end_time": "2026-06-09T11:22:45.600261+00:00",
+     "duration": 0.005012,
+     "end_time": "2026-06-20T16:12:20.887517+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.594819+00:00",
+     "start_time": "2026-06-20T16:12:20.882505+00:00",
      "status": "completed"
     },
     "tags": []
@@ -767,10 +767,10 @@
    "id": "cell-16",
    "metadata": {
     "papermill": {
-     "duration": 0.006048,
-     "end_time": "2026-06-09T11:22:45.611950+00:00",
+     "duration": 0.004631,
+     "end_time": "2026-06-20T16:12:20.897484+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.605902+00:00",
+     "start_time": "2026-06-20T16:12:20.892853+00:00",
      "status": "completed"
     },
     "tags": []
@@ -795,16 +795,16 @@
    "id": "cell-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.624664Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.624293Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.630077Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.629142Z"
+     "iopub.execute_input": "2026-06-20T16:12:20.908692Z",
+     "iopub.status.busy": "2026-06-20T16:12:20.908692Z",
+     "iopub.status.idle": "2026-06-20T16:12:20.923199Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.922198Z"
     },
     "papermill": {
-     "duration": 0.01362,
-     "end_time": "2026-06-09T11:22:45.631045+00:00",
+     "duration": 0.020571,
+     "end_time": "2026-06-20T16:12:20.923199+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.617425+00:00",
+     "start_time": "2026-06-20T16:12:20.902628+00:00",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +846,10 @@
    "id": "cell-18",
    "metadata": {
     "papermill": {
-     "duration": 0.006479,
-     "end_time": "2026-06-09T11:22:45.644142+00:00",
+     "duration": 0.005002,
+     "end_time": "2026-06-20T16:12:20.933201+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.637663+00:00",
+     "start_time": "2026-06-20T16:12:20.928199+00:00",
      "status": "completed"
     },
     "tags": []
@@ -866,16 +866,16 @@
    "id": "cell-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.659364Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.659013Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.667300Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.666398Z"
+     "iopub.execute_input": "2026-06-20T16:12:20.943202Z",
+     "iopub.status.busy": "2026-06-20T16:12:20.943202Z",
+     "iopub.status.idle": "2026-06-20T16:12:20.953411Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.953411Z"
     },
     "papermill": {
-     "duration": 0.017725,
-     "end_time": "2026-06-09T11:22:45.668316+00:00",
+     "duration": 0.01721,
+     "end_time": "2026-06-20T16:12:20.954412+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.650591+00:00",
+     "start_time": "2026-06-20T16:12:20.937202+00:00",
      "status": "completed"
     },
     "tags": []
@@ -948,10 +948,10 @@
    "id": "a19716d6",
    "metadata": {
     "papermill": {
-     "duration": 0.006254,
-     "end_time": "2026-06-09T11:22:45.680545+00:00",
+     "duration": 0.005003,
+     "end_time": "2026-06-20T16:12:20.964415+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.674291+00:00",
+     "start_time": "2026-06-20T16:12:20.959412+00:00",
      "status": "completed"
     },
     "tags": []
@@ -978,10 +978,10 @@
    "id": "cell-20",
    "metadata": {
     "papermill": {
-     "duration": 0.006158,
-     "end_time": "2026-06-09T11:22:45.692696+00:00",
+     "duration": 0.005,
+     "end_time": "2026-06-20T16:12:20.973415+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.686538+00:00",
+     "start_time": "2026-06-20T16:12:20.968415+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1002,16 +1002,16 @@
    "id": "cell-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.705814Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.705573Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.714452Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.713377Z"
+     "iopub.execute_input": "2026-06-20T16:12:20.983921Z",
+     "iopub.status.busy": "2026-06-20T16:12:20.983921Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.000116Z",
+     "shell.execute_reply": "2026-06-20T16:12:20.999430Z"
     },
     "papermill": {
-     "duration": 0.016751,
-     "end_time": "2026-06-09T11:22:45.715345+00:00",
+     "duration": 0.022198,
+     "end_time": "2026-06-20T16:12:21.000116+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.698594+00:00",
+     "start_time": "2026-06-20T16:12:20.977918+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1090,10 +1090,10 @@
    "id": "cell-22",
    "metadata": {
     "papermill": {
-     "duration": 0.006713,
-     "end_time": "2026-06-09T11:22:45.728034+00:00",
+     "duration": 0.010507,
+     "end_time": "2026-06-20T16:12:21.016627+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.721321+00:00",
+     "start_time": "2026-06-20T16:12:21.006120+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1117,10 +1117,10 @@
    "id": "cell-23",
    "metadata": {
     "papermill": {
-     "duration": 0.006114,
-     "end_time": "2026-06-09T11:22:45.740221+00:00",
+     "duration": 0.005003,
+     "end_time": "2026-06-20T16:12:21.026630+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.734107+00:00",
+     "start_time": "2026-06-20T16:12:21.021627+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1149,16 +1149,16 @@
    "id": "cell-24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.754326Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.754077Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.759971Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.758904Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.037631Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.036630Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.046442Z",
+     "shell.execute_reply": "2026-06-20T16:12:21.045801Z"
     },
     "papermill": {
-     "duration": 0.014315,
-     "end_time": "2026-06-09T11:22:45.760913+00:00",
+     "duration": 0.015327,
+     "end_time": "2026-06-20T16:12:21.046958+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.746598+00:00",
+     "start_time": "2026-06-20T16:12:21.031631+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1203,10 +1203,10 @@
    "id": "cell-25",
    "metadata": {
     "papermill": {
-     "duration": 0.007078,
-     "end_time": "2026-06-09T11:22:45.774327+00:00",
+     "duration": 0.00512,
+     "end_time": "2026-06-20T16:12:21.056679+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.767249+00:00",
+     "start_time": "2026-06-20T16:12:21.051559+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1227,16 +1227,16 @@
    "id": "cell-26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.797038Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.796773Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.803907Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.803004Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.067206Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.067206Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.077457Z",
+     "shell.execute_reply": "2026-06-20T16:12:21.076457Z"
     },
     "papermill": {
-     "duration": 0.024119,
-     "end_time": "2026-06-09T11:22:45.804584+00:00",
+     "duration": 0.016158,
+     "end_time": "2026-06-20T16:12:21.077457+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.780465+00:00",
+     "start_time": "2026-06-20T16:12:21.061299+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1296,10 +1296,10 @@
    "id": "b7a761cb",
    "metadata": {
     "papermill": {
-     "duration": 0.006249,
-     "end_time": "2026-06-09T11:22:45.817403+00:00",
+     "duration": 0.004999,
+     "end_time": "2026-06-20T16:12:21.087456+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.811154+00:00",
+     "start_time": "2026-06-20T16:12:21.082457+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1325,10 +1325,10 @@
    "id": "cell-27",
    "metadata": {
     "papermill": {
-     "duration": 0.005874,
-     "end_time": "2026-06-09T11:22:45.830058+00:00",
+     "duration": 0.004626,
+     "end_time": "2026-06-20T16:12:21.097188+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.824184+00:00",
+     "start_time": "2026-06-20T16:12:21.092562+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1351,16 +1351,16 @@
    "id": "cell-28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.842589Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.842348Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.848392Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.847504Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.108570Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.108051Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.123612Z",
+     "shell.execute_reply": "2026-06-20T16:12:21.122932Z"
     },
     "papermill": {
-     "duration": 0.013588,
-     "end_time": "2026-06-09T11:22:45.849265+00:00",
+     "duration": 0.021812,
+     "end_time": "2026-06-20T16:12:21.124125+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.835677+00:00",
+     "start_time": "2026-06-20T16:12:21.102313+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1418,10 +1418,10 @@
    "id": "84b24b6e",
    "metadata": {
     "papermill": {
-     "duration": 0.006676,
-     "end_time": "2026-06-09T11:22:45.862362+00:00",
+     "duration": 0.004614,
+     "end_time": "2026-06-20T16:12:21.133877+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.855686+00:00",
+     "start_time": "2026-06-20T16:12:21.129263+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1448,10 +1448,10 @@
    "id": "cell-29",
    "metadata": {
     "papermill": {
-     "duration": 0.006829,
-     "end_time": "2026-06-09T11:22:45.875733+00:00",
+     "duration": 0.005134,
+     "end_time": "2026-06-20T16:12:21.145354+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.868904+00:00",
+     "start_time": "2026-06-20T16:12:21.140220+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1470,16 +1470,16 @@
    "id": "cell-30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.889775Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.889521Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.902967Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.902015Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.156815Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.156300Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.170372Z",
+     "shell.execute_reply": "2026-06-20T16:12:21.169198Z"
     },
     "papermill": {
-     "duration": 0.021806,
-     "end_time": "2026-06-09T11:22:45.903832+00:00",
+     "duration": 0.020907,
+     "end_time": "2026-06-20T16:12:21.170901+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.882026+00:00",
+     "start_time": "2026-06-20T16:12:21.149994+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1596,10 +1596,10 @@
    "id": "l95assxmqa",
    "metadata": {
     "papermill": {
-     "duration": 0.006614,
-     "end_time": "2026-06-09T11:22:45.917220+00:00",
+     "duration": 0.005128,
+     "end_time": "2026-06-20T16:12:21.181178+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.910606+00:00",
+     "start_time": "2026-06-20T16:12:21.176050+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1614,16 +1614,16 @@
    "id": "cell-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.933649Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.933391Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.940311Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.939087Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.193167Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.193167Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.201055Z",
+     "shell.execute_reply": "2026-06-20T16:12:21.200423Z"
     },
     "papermill": {
-     "duration": 0.016914,
-     "end_time": "2026-06-09T11:22:45.941628+00:00",
+     "duration": 0.015105,
+     "end_time": "2026-06-20T16:12:21.202088+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.924714+00:00",
+     "start_time": "2026-06-20T16:12:21.186983+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1675,10 +1675,10 @@
    "id": "cell-32",
    "metadata": {
     "papermill": {
-     "duration": 0.00612,
-     "end_time": "2026-06-09T11:22:45.955398+00:00",
+     "duration": 0.005146,
+     "end_time": "2026-06-20T16:12:21.211882+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.949278+00:00",
+     "start_time": "2026-06-20T16:12:21.206736+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1700,10 +1700,10 @@
    "id": "cell-33",
    "metadata": {
     "papermill": {
-     "duration": 0.007738,
-     "end_time": "2026-06-09T11:22:45.970826+00:00",
+     "duration": 0.005168,
+     "end_time": "2026-06-20T16:12:21.221785+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.963088+00:00",
+     "start_time": "2026-06-20T16:12:21.216617+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1722,16 +1722,16 @@
    "id": "cell-34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:45.987228Z",
-     "iopub.status.busy": "2026-06-09T11:22:45.986963Z",
-     "iopub.status.idle": "2026-06-09T11:22:45.992839Z",
-     "shell.execute_reply": "2026-06-09T11:22:45.992005Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.233779Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.233268Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.247187Z",
+     "shell.execute_reply": "2026-06-20T16:12:21.246605Z"
     },
     "papermill": {
-     "duration": 0.016621,
-     "end_time": "2026-06-09T11:22:45.994020+00:00",
+     "duration": 0.021238,
+     "end_time": "2026-06-20T16:12:21.248191+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:45.977399+00:00",
+     "start_time": "2026-06-20T16:12:21.226953+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1744,10 +1744,14 @@
       "=== Resume des Algorithmes de Recherche ===\n",
       "Algorithme                Type            Optimal    Heuristique\n",
       "-----------------------------------------------------------------\n",
-      "BFS                       Non informe     Oui        Non\n",
+      "BFS                       Non informe     Oui*       Non\n",
       "DFS                       Non informe     Non        Non\n",
       "Greedy Best-First         Informe         Non        Oui (h seulement)\n",
-      "A*                        Informe         Oui        Oui (g + h)\n"
+      "A*                        Informe         Oui        Oui (g + h)\n",
+      "-----------------------------------------------------------------\n",
+      "* BFS est optimal uniquement si tous les pas ont le meme cout. Sur un terrain\n",
+      "  pondere (couts variables), seul A* (ou Dijkstra) garantit le cout minimal :\n",
+      "  voir l'exemple guide ci-dessous.\n"
      ]
     }
    ],
@@ -1756,10 +1760,14 @@
     "print(\"=== Resume des Algorithmes de Recherche ===\")\n",
     "print(f\"{'Algorithme':<25} {'Type':<15} {'Optimal':<10} {'Heuristique'}\")\n",
     "print(\"-\" * 65)\n",
-    "print(f\"{'BFS':<25} {'Non informe':<15} {'Oui':<10} {'Non'}\")\n",
+    "print(f\"{'BFS':<25} {'Non informe':<15} {'Oui*':<10} {'Non'}\")\n",
     "print(f\"{'DFS':<25} {'Non informe':<15} {'Non':<10} {'Non'}\")\n",
     "print(f\"{'Greedy Best-First':<25} {'Informe':<15} {'Non':<10} {'Oui (h seulement)'}\")\n",
-    "print(f\"{'A*':<25} {'Informe':<15} {'Oui':<10} {'Oui (g + h)'}\")"
+    "print(f\"{'A*':<25} {'Informe':<15} {'Oui':<10} {'Oui (g + h)'}\")\n",
+    "print(\"-\" * 65)\n",
+    "print(\"* BFS est optimal uniquement si tous les pas ont le meme cout. Sur un terrain\")\n",
+    "print(\"  pondere (couts variables), seul A* (ou Dijkstra) garantit le cout minimal :\")\n",
+    "print(\"  voir l'exemple guide ci-dessous.\")"
    ]
   },
   {
@@ -1767,10 +1775,10 @@
    "id": "cell-35",
    "metadata": {
     "papermill": {
-     "duration": 0.006088,
-     "end_time": "2026-06-09T11:22:46.006469+00:00",
+     "duration": 0.005504,
+     "end_time": "2026-06-20T16:12:21.258695+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.000381+00:00",
+     "start_time": "2026-06-20T16:12:21.253191+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1806,10 +1814,10 @@
    "id": "a9e53547",
    "metadata": {
     "papermill": {
-     "duration": 0.006731,
-     "end_time": "2026-06-09T11:22:46.021048+00:00",
+     "duration": 0.005797,
+     "end_time": "2026-06-20T16:12:21.270497+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.014317+00:00",
+     "start_time": "2026-06-20T16:12:21.264700+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1834,16 +1842,16 @@
    "id": "3f7c5620",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:46.036724Z",
-     "iopub.status.busy": "2026-06-09T11:22:46.036424Z",
-     "iopub.status.idle": "2026-06-09T11:22:46.439668Z",
-     "shell.execute_reply": "2026-06-09T11:22:46.438707Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.281901Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.281385Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.509341Z",
+     "shell.execute_reply": "2026-06-20T16:12:21.508765Z"
     },
     "papermill": {
-     "duration": 0.411846,
-     "end_time": "2026-06-09T11:22:46.440538+00:00",
+     "duration": 0.234214,
+     "end_time": "2026-06-20T16:12:21.509855+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.028692+00:00",
+     "start_time": "2026-06-20T16:12:21.275641+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1853,18 +1861,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Grille 5x5 avec 6 obstacles\n",
-      "Obstacles: {(1, 2), (3, 3), (3, 1), (1, 1), (1, 3), (3, 2)}\n",
-      "Depart: (0,0) | But: (4,4)\n",
-      "\n",
-      "Graphe: 19 etats, 40 transitions\n"
+      "Grille 11x11 | marais central de 25 cases (cout 10) | depart (0,5) -> but (10,5)\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABscAAAIiCAYAAACUphadAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA3UZJREFUeJzs3QeYU8XawPF3ey+UBZbeuyiCCKJiQ2yoWFBU4Ir1ExHsYkNUROWqWBD1qteGKBZUbGDBXi4KolRBkc6yC9t7Od/zzpKQbLI92d0k/9/zBDYnJ2fOmZmTTM57ZibIsixLAAAAAAAAAAAAgAAQ3Ng7AAAAAAAAAAAAADQUgmMAAAAAAAAAAAAIGATHAAAAAAAAAAAAEDAIjgEAAAAAAAAAACBgEBwDAAAAAAAAAABAwCA4BgAAAAAAAAAAgIBBcAwAAAAAAAAAAAABg+AYAAAAAAAAAAAAAgbBMQAAAAAAAAAAAAQMgmMAAACAj7jnnnskKCjI/oiMjJQ+ffrIww8/LGVlZU7rOq7n+Hj77bft6yxYsECGDBkiCQkJEh8fb7Z1+eWXy969e716HE8//bScccYZkpSU5LJPjn788Uc55phjJCoqSlq3bi1TpkyRvLw88Se//fabyYOvvvpKfMU///xTZbkBAPzboYcear4Hvv3220rX0e+1f/3rXzXeZkFBgXTo0EE++ugj+7LjjjvOpHPhhRe6rJ+dnW3aB/r6Sy+9JN6g6Wt7xRN0H19//fUaL/ekkSNHyqxZs8Tbdu/eLbfccoscdthhEhcXJ+3bt5eLLrpItm7d6rLurl275NxzzzXrNW/e3LQ/s7KyxJ+89957pn5qu8lX6Hmr+/zLL7809q4ADYLgGAAAAOBD9EKQBo308cknn8j5558vt912mwmQVaTBJNu6tscJJ5xgXtP1x48fb4JPb775pnlMmjTJ/BjWCxbe9Morr0haWpqcdtppla6jF1JOPPFEiYmJkXfeecdc1NGLRxMmTPDqvgEAgMqtXbtWfv/9d/N3xaBOcXGxPPDAA5KTk+O0fPHixfLDDz9Uma3z58+XZs2ayemnn+60PDY2VpYsWSK5ubku2wwNDfWZomrM4Njtt98u//73vyU9Pd2r6fz666/y7rvvytixY+X999+XRx99VP744w9zI1ZqaqpTPRk1apT8+eef5ti17JcuXWoCaQDQkHznWwQAAACABAcHy9ChQ+05cfzxx5sLD3oxQoNkjjp27Oi0rqMnnnjC3NH9yCOP2JedeuqpcvPNN7v0QvM0vUCmx6F30mqgzJ3Zs2ebi2R6cSUiIsIs0+fnnXeerFq1SgYOHOjVfUTDyM/PNwFfAIBv0F7n+h0+YsQIeeutt0x7IiwszLymPU60J7q+pu2TnTt3yplnnml6Bt1///2VbtOyLLOd6667zuW14cOHm6DLBx98IOPGjbMvX7hwoZx99tny2muveelI/YeWhbahXn75ZZk2bZrX0jn66KNlw4YNTkHLo446yrRHtb134403mmXa81yDrOvXr5devXqZZbp/GjD73//+Z4Jp8G16ThcVFdnb8EBTRc8xAAAAwMfpkDR6F25t6N3DycnJbl/Ti17eVJPtawDs2GOPdfpRrRdNlN5BXpXOnTvLtddeK/PmzZNOnTqZYSP1AprjXcu23mkabNPXtYeabl8Dje7u6h4wYIAZxrJdu3Zyxx13SGlpqdNwl3pne0WJiYnmNUd6cbBNmzZm/XPOOcftEJYvvvii9OvXzwSNWrRoYS42rVixospjLiwsNHeG6/FqnukQmY53omuPQL14+dRTT9mX6UULHRpLt28LiNrybs6cOeZYo6Oj5ayzzjJDJVVF36/Hpu/X9Hv37i3PPvus0zq2fNILX8OGDTP5qWWk9AKZpmMrC+058Ndff9U7XwAAnr3grUEp7YV+ww03yL59++TTTz+1v65BEf0O+fDDD02v7y+++MIMiajfozrEXmW+/vprc8OMfidXpNvU5ZqujX6ff/755257GumwjDqMYKtWrUyg7sgjj3TaR6X7o4E8bWvojUH6vdOjR49Kb9jRYI4GcfQ7TI+94veT3px0yCGHmNf1u1ODeI7fmzo8ox6j7pttmGv9TqxsuTeOQ0ca0OCYN2m7p2JvPi13HUbbcVQCHflA21W2wJjSY9Ug6scff1xlGnq8OvqB5pMOud2yZUu59NJLXXoWantO23WaJ9q20Dq0bds2l/qsPep69uxp2i5du3aVxx57zGkdvZGsf//+TssyMjJchvPUdrgGHvUYNL3LLrvMpQelevDBB6V79+6mDaT5ctJJJ8mWLVuqPGZN75prrjHtdt3PQYMGybJly1yGb9Tzzmb//v32uuiYd5q+Dn2paevvBz0+HaK0uiFP9Xxv27at2W8dNlN7brrLJy0/bVvqftra67aRK2xloedtxfZvXfIF8ASCYwAAAICPKSkpMQ/9Mat3UusFKHcXlDRgYVtXH44BHf1h/cwzz8jzzz8ve/bskaZGf4hXvNtUgzv6w14DKdXRfNGHBl8ef/xxc/FJh5m00bzTi1J6QUnzQe8814t8GpDbvn27fT0dEkjnwdALLPoj/9ZbbzV3t2uArLY0MHXXXXeZ4Sy1zPQijF48cfTNN9+YZTrkpF5g0AtcOrykXhipig5hpMEovStbL46ccsopcskll5gLUGrw4MEmeKYXRDZu3GiW6b7oBT69WOYYsNQLHvrQYY708fPPP5tAXlW0x6FeqNKLI5pPJ598slx99dVOwThbQE4vitj2Tdf7+++/zZ3leiHHNryUXvjU49agX33yBQDg2Z7fGsTSz3H9XtQbFRxvxNB2hn6njh492nxv6Of0G2+8YT6/qxqyWQNdOt+YPtzRC/w67J5tWEDtsaZBF73RoiK9oK7pv/rqq+a7Vnue6XeHu7k9L774YvM9pMEF7ZGu32EV2xg6N6jeMKIX7/U7avPmzeY7zJFe6NfvWA1oaZtD80h7z2nbyzbXqm5f98U2zLW2LSpb7o3j0O9ZPZaKNwp5mw6dqPmjN+3YaO8yvYnGkbbvdJm+Vh1tW2zatMm0X+6++25TB++77z7769qO0/actuu0fad1cuXKlaZMHANBU6dONe+fOHGiKTvNN23n6fq1NX36dFOe2h5atGiRORcqjuigbRdte+n5oIFObYNroKmquda03aSBQ23b6RDj2rbt27evuYnIdkOX3gCmw45r3dFhy5UG05Tuk6Mnn3zS1A3NO63TWreuuOKKKo9N65e2MbUNqXVM09f54nRfHOk5rr0/r7/+enN8emxap7W9rUExHcL9ueeeMzc26Q1R9ckXwGMsAAAAAD5hxowZljbhKz4uuOACq6SkxGldd+t169bN/voff/xhde/e3f5aly5drOuuu87asmVLgx2PpqVpv/XWWy6vnXvuuVbfvn2tsrIy+7JvvvnGrH/yySdXud1OnTpZ7du3twoKCpzyLiwszCotLTXPH3/8cSsoKMhat26dfZ19+/ZZMTEx1g033GCeZ2VlWbGxsdb06dOdtj9//nwrKirKSktLs29b31dRQkKCeU1p+bRt29YaP3680zr6XI9p+fLl5vmcOXOs5s2bW7Xx5Zdfmm0sXbrUabnWiyOOOML+vLi42Bo0aJBZ9tVXX1nBwcHWs88+65J3cXFxVkZGhn3ZF198Ybb/6aefui231NRUk7e33Xab07bGjRtnJSUl2eumrf6+8cYbTutNmDDB6tq1q5Wfn29ftnfvXpP38+bNq3O+AAA865prrrEiIyPt3xFXXXWVFR0dbWVnZ5vnhYWF1qxZs8xz/V6bOHGiWf7OO+9Y33//faXb1e/1008/3WX5iBEjzHJtC+j3+vPPP2+WH3300ea7OT093Xyv/Pe//3W7Xf3O1+8+3b5+J9no+vo+23eMysnJMcdy3333OaWv3+/6nVTxvdu3b3ebpn7n7dixw+V72XYslR1jVep7HI7f3R9++KHVULTcRo0aZdo/ul822v7UulOR5sPIkSOr3KYew5AhQ5yWaT1zbONef/31pty0XWezfv160+574oknzPPNmzeb5xXbQbfeeqvVpk0be3tRt92vXz+ndSrWO01H24V33XWX03rHHnusWc/Wtp48ebJ1+OGHW7Xx4osvWqGhodbatWudlh955JHW+eefb3+u52SHDh2sMWPGWK+//rpTu80x77S97/ib4YUXXjD5oPmj9LzV9VasWGGer1692jx/5plnnLY1bNgwp2PRfNL1fvrpJ5c8OOqoo5za83osmuZHH31U53wBPIWeYwAAAIAP0SHl9I5LfXz33XfmDmW9y9LdXZ96R6xtXX3o3Z42OvSJzvegd8rqenpHp/aI0mFu9M7iylTsjVb+W1sq7aFWV3rH67p168yduHqX8+rVq2Xy5MkSEhJi7i6ujt4d7NjzTO9y1SFvbMO4fPvttyYPHO9k1qFw9O5czVfbHfI6JI4OReR4fDrUi86VtWbNmhofz44dO8wdtWPGjHFaXrHH3+GHH256UOndy5999pnk5eVVu20dWkf3XYescdxPPRbtGWcrDx3qSO9Atw01pL3LrrzySrdzk2h9sNHt6va1B5k7ulzzVvPJ0QUXXGDKTu8ad6R3O1fcf52TRvfPtu8694je/W4bNrEu+QIA8Bz9bNYeW9p7yfYdoT3I9PPYNsRaeHi46UFVcahh7UWmPZcqo0MQ6lBqldHvff1O0aEVtVfQ999/7zRcXMXvW+0JpEPK6feK9jrX75mK30VKe1vZ6JBvOjSxvt+R9mBx3DdtT9jSsdGe0Hp8mi+apm0ISXdp1pSnj0OHH1RVDZPs6Tae9ijXoTW1Z5Dul6do+8aRlonj8Wobz9Z2sdFeaTrcn62Np70VlfaAqtjG0xEVHEcRqI62q7RdWLGNp9t2pG0ZbZfpEIW6HzUZEl3LXIfs1KEfK7bxHIeW1rqnPRu1ra/DTP7f//2ffThyR9obUdvSju1QLWcd8todzUvlro2nx+I4nKX2JNXhP230s0HPVX2v1hvbvuuxaC9RxzZebfMF8BSCYwAAAIAP0eHvdIg8fegQOzp8iQ4J89///tclWKMXZ2zr6qPinAl6EUsvcs2dO9f8KNUgm/6QvffeeytNf9KkSeYCje2hw7Lo8EGOy7p161bv49SLGg899JAJ2Ol8G/rD+ZhjjjEXqSqbK63ivBcVj9U2XKPSoZl0roqKdJkGYZRtaBpN2/H4dD4PVZsLJ7aLUXosFdOreNwawNLApV7U0ItZOlSObZ/c0f3U1x33UR86vI5ehHC8EKbBQA066XCFGmx0p+I+2pZVdkHNNsxVxWOxPXfcd53DrOJFU91/rYMV918vyNjyuC75AgDwHL1Irzc86MV1HdJWH3rRXr+THYdWtNGh1BznZKrtUMoVaTBMhxTUOaF0/klN211wR2+20Avs2pZZvny5uQCv83HZvv+raytUXK+69oRuX9PU+Zj0e0qHkfvpp5+c1qktbxyHLX81iNMQbbz//Oc/Zt91OD4dXtOR3gCTmZnptj3hGNCqjLvjtQ3DXJs2ngaFtD3heHy2wJs32nh6g4/WXx0iVNu0GnTVG9SqKhPdT22jV2wj6TyvFfdR52Lt2LGjyQud+8+divuo89npPF9VtfE0vYrlosem+ec4vHXF49X3alBMh1msuP86/5tt/+uSL4CnOM+SCAAAAMDn2Ho/aeCgYgCsNjTooHfVVjWnl94F7PiDu0uXLmZCb8e7V6u7wFVTOreBBnB0Tqo2bdqYiyl6EaO6uRFqQn/k2+becpSSkmK/AGD7/91333U7D4oeu9KLChXvctXnjhOx2wJ6FScg1/Qq0rlM9KEXRN5//337RYUXXnih0mPRCwmVTWLveCFE59HQu4O1h6DOT6a9xLQ3oqOK+2hbVllQ0pZPuo7e4V7x2BwvqLjr9aeva28y2/wYjrRu1TVfAACeYwuAaa8UfTjSoJl+B7i7uaIm9Hugujkkda5UnatTe8w7zi/lSOcD00CC9p5xnNPImxfZtdec9trReaZs83du3bq1Xtv0xnHY8ld793i7jad5oj2XNDimAbeKtBeXbb4sGw20aLusYq+wutYnd20ZbZdoryXbOtom0QCkLeDpqFevXvY2ns775e6mIHdtPHftIButHxr00cfOnTvNfHw6L5m2bXXOrcqORdtsNWnr6M1yOs+a3sSl7ecvv/zSpd1VMV90Xi8NpFbVxtM2rR6ztsMdj0237RiorJiWvqbLtDepzotWka03Y13yBfAUgmMAAACAj7P1GLP9yKwJ/VFb8Q5Pveiid3HqHdmV6dy5s3lUpD3TvEGH4bHdHf7iiy+aiydjx46t93b17tq3337bXIixXQDRH/46zI5tqMFhw4aZnk46VE/FoXIq9tDTCyd//fWX/Y5qvSDhOPSQrqMXHvSCkeO2dB8qo+Wpk5Nr0KuqgKUOAfTwww+bizt6AaUyun833XSTCTpeffXVJl912ErtteVI71DXO7ptw2bpseid1o5D5TgaMmSICVLpcFvaK81GLxTqhVLbhaiq9l/rsL7Xcaif+uYLAMAztFe53pSgF7j1ArYjHYJOe3W9+eabMmXKlDptX7+HN2zYUO16esH8gw8+kIsvvtjt67bgkWOwQwNVOrRbdd9FdaVp6negY2BgwYIFLuu5681V2XJvHIf2AFO2No+32njau0/rg97IVFlgQ3vAvfbaa7Jp0yZ7b3wdflEDOzqigSfaeM8995xTQEfbe7///rs9WGfrzaZpam/Iymj7TduBesOTree79qJ0pO0pvdFI23iO7aB33nmn0u1qEE1vUtKgc3VtPG3vaM9EfVRGhwKfM2eOzJ8/34x4oG1YDSRPmzbNab0lS5bIo48+am9vaTtU6+4RRxxRaV4qbeM5DsVta/NVNVymvqb7ocenPd1qoqb5AngKwTEAAADAh+hQO7bhejQg8+uvv5ofnDrfwrHHHlvj7egPeb0YoL3FNGijd2o+9dRTpldOxQtfnvbLL7+YizR6p7myHY/2ftK5wtSWLVvMcD62gIwGaDSIo8NHOt65Wld617sO4aI9ljT/9M7gWbNmmXk9bBcS9I5XvetZg0l6YUSHiNKLCdqTTS8S6kUPDZ7pRR69AKAXgm699Vazrl6Q0G3a6Pv0op7mrQYl9c5ovbiigShHM2bMMBdqNC0NLOmd1Trcpc7DUBndlpalziGm+6oBMp0DQnsS6t3nzz//vKk3OndJ9+7dzZ3hesFN91EvEuld6dqDzEbvEtdj0v3VO831mDQA5m7uCluwSi+I6kUZPeahQ4eaCzl6YePJJ5+sNuA1c+ZMc1FGt68XXjR/9GLr119/bYbX0YtsdckXAIBn6HeeBgd0KGf9HK5Ib9DQz/y6Bsd0mGi9oUJ7qGigqTL6neWuJ5JjjyQNZuj3l96govus3x+OvXk8Tb+DtX2ix643v+iwijq8orte/tqu0eCEtrtswQ53y71xHNr20uCODk/tLRrM0ACqBrzGjx9vb9/Z2ni2G4h0nqsHHnjAzMml/2vwVW/e0TaZtjfqS3uWa3tR52K74447TPDxzjvvNEMO6hB+SoOM2rtK9/Pmm2827U2tfzqnm7bNbPP06nx52iNL652287Rtpe2qir2r9KajBx980ATJNDil8+PpTUmOrrrqKtOG1XaS/q/BTp1T113PeRsdQlqHptTzTvNI91vbZtqzUH8HzJ4927T5dD1bO0rpcesNUNo21Ppko0MuahlpmtrW1jaelofjHLyOtE2peaDtLQ3aanBVA5sajNPPhepo21CHxtY5yi688EJz3NpO1vljtS2ux1WXfAE8xgIAAADgE2bMmKEzo9sfoaGhVpcuXaxrrrnGSklJcVpXX58zZ06l25o3b551yimnWO3atbPCw8Ottm3bmudffvml149j4sSJTsdhe4wYMcK+zvbt283zhIQEKyoqyho6dKi1ZMmSGm2/U6dO1uTJk52WLV682KSxZcsW+7J//vnHOuecc6y4uDgrOjraGjlypPX777+7bG/hwoXWEUccYfYjPj7eGjhwoHXXXXdZxcXF9nU+/fRTq1+/flZkZKTZ11WrVpl91zKzKSsrs2bOnGm1atXKpHfmmWea9+l+LV++3Kyjx3jiiSdaSUlJVkREhNWtWzezDce03CksLDTb7tGjhylPff/xxx9vvfLKK+b12bNnm+WrV692et/ZZ59tdezY0crMzHTKO10/OTnZHM/o0aOtnTt32t+jeaj7/NZbb9mXlZaWWvfee6/ZVlhYmNmPZ555xiktPY6YmBi3+//nn39aY8eOtVq0aGGOu3PnztaECROsNWvW1CtfAAD1d8YZZ5jPd/0ec2fu3Lnme2Hz5s112v6ePXtMm2bZsmVOy7UdcPrpp1f6vvT0dJPuf//7X/uy//3vf+Y7W7+/9Lvo5ZdfNu0O/Y620fX1fampqU7bO/TQQ826VaWv3++O39vqoYcestq3b29vS+h3WsV22I4dO6zTTjvNSkxMNK/Z2geVLffkcSj9Lh8/frzlTbb9cfeouD963NoGi42NNcc+adIke1ukKu7at4899phZ7kjbO1oWWibaztO0tN3nSOvzk08+afXv39+0kZo3b24NGzbMevTRR53W07ZU9+7dTTtQt/nbb7+51Dtth02ZMsUci7YV9XhfffVVp7bnSy+9ZA0fPtyko+Xat29f64knnqj2mDVfrr/+ensbS9tnWmc+/PBD8/pVV11ltrlr1y77e7R9NHjwYPOwtZV0X7R9d8MNN5j1Ne+1Tjjmu9ZrXW/FihX2ZXl5eda0adOsNm3amHwaMGCA9c477zjtY8W66Ui3pftra9Nrfb766qtNW78++QJ4QpD+47lQGwAAAADAV+lwSmeccYbpRQgAQEPRXkQ6nK8OoQzP0uEFde5W7a1Tm1EG4F90+ETtyaU90ACUK58pEgAAAAAAAAAagc5PpfOW6Zyo8Cwd4liHriQwBgDOCI4BAAAAAAAAaDQ6F5bO3bV9+3ZKwcN0TqwnnniCfAWAChhWEWjiXZ510lWdNN1Tw+ToZJcvvfSSNBV6bDoJu+MIrxX386uvvjKTxOukqO4m/wUAAAAAAAAAoKboOQaf99dff8lVV10lXbt2lcjISImPjzfdxR9//HHJz8/3aFoPPPCAvPfeex7dJhov8Oju8eCDD9Zpe//617/cbq93794e33cAAAAAAAAAQN2F1uO9QKP76KOP5Pzzz5eIiAiZMGGC9O/fX4qKiuS7776Tm2++WdauXSvPPfecR4Nj5513npx99tke22agu/POO+W2225rlLRHjhxp6o2jgQMH1nl7Wg+ff/55p2U6oTAAAAAAAAAAoOkgOAaftWXLFrnwwgulU6dO8uWXX0pycrL9tcmTJ8vmzZtN8Ky+dLi/goICiYqKqve2cFBubq7ExMRIaGioeTSGnj17yiWXXOKx7elxeHJ7AADgoCFDhsjEiRNNO6+h/fPPP2a45yuvvFLatm3bYOm+8MILZjQEHSlB5ws55ZRTZNasWdKqVSv7fvXr18/cEKbDUgMAANBmos0EoGYYVhE+6+GHH5acnBxz0cAxMGbTvXt3mTp1qv35f//7XznhhBPMxQTt4dO3b1+ZP3++y/v0wsIZZ5whS5culcGDB5ug2LPPPmuGyNOAzssvv2wfMk+H0rPZuXOnTJo0SVq3bm22rxcqXnzxxRodS2FhoVx//fWSlJQkcXFxcuaZZ8qOHTvcrlufdCrav3+/3HTTTXLIIYdIbGysGZLy1FNPldWrV9fo/Tps5XXXXSctW7a077fun+aN4zxp+rcuW7dunVx00UXSrFkzOfroo51eq4uff/7ZXCTS3lnR0dEyYsQI+f7772u1DT0GDX66s379elP+FXuXac/EkJAQufXWW13eU1paKllZWbU8EgAAUJXFixebQJC2gRqDpq1zpO7atavB0nzllVfk8ssvN22dJUuWyL333isffvihjBkzxqndqqMa6By1AAAAtJloMwGoOXqOwWfpRQKdZ+yoo46q0foaCNNAkgZwtIePvv+aa66RsrIylzuQN27cKOPGjTNzmV1xxRXSq1cvefXVV80FCr0DR+8aVt26dTP/p6SkyNChQ02Q59prrzVBrk8++UQuu+wyEyiZNm1alfum233ttddM4EiPR3vCnX766S7r1Tediv7++28zh5oOTdmlSxezfQ0EapBJA1nV3RmtwcFFixbJ+PHjzX59/fXXbvfbRtPp0aOHGZ5Se+TVh+aRBvIGDRpkLggFBwfbA6DffvutKafq6B3gTz/9tNmXPn36mCEetQxsdNl9991nhujUC09adzRAqsetc4npRSpHeXl5JsCo/2sAUOvQQw89ZAKPAACg7ubOnWu+VwOpJ//rr79u2mR6Q5gjDRBu375dOnToYJ5rO/Ckk06Sf//736ZtCAAAAhdtpoNoMwGolgX4oMzMTI2sWGeddVaN35OXl+eybNSoUVbXrl2dlnXq1Mls+9NPP3VZPyYmxpo4caLL8ssuu8xKTk620tLSnJZfeOGFVkJCgtu0bX777TeT3jXXXOO0/KKLLjLLZ8yY4ZF0bMfmuP8FBQVWaWmp0zpbtmyxIiIirHvvvbfKbf36669m/6ZNm+a0/F//+pfLfuvfumzcuHEu27G9VtV+Ll++3Kyj/6uysjKrR48epvz0bxs9/i5dulgjR460qnPUUUdZc+fOtd5//31r/vz5Vv/+/U0aTz/9tNN6mj9HH3201bp1a5PvkydPtkJDQ60VK1Y4rXfbbbdZt956q/Xmm29aCxcuNPuv2xs+fLhVXFxc7f4AAAD3/v77bysoKMj65ptvXF778MMPzXd6VFSUlZiYaI0YMcJauXKl/fV//vnHOvfcc634+HgrOjraOvnkk63ff//daRv6fT1nzhynZY899pi9fWJrh1R8eNsJJ5xgnXnmmU7L3nnnHZP21q1bndoqbdq0Me0aAAAQuGgzHUSbCUBNMKwifJJt2Dodyq+mHO80zszMlLS0NHM3rvae0ueOtBfVqFGjarRdvabyzjvvyOjRo83ful3bQ7eh2165cmWl7//444/N/zo8oaOKvcDqm447Oiyj9riyDQe4b98+08tJe8pVt61PP/3U/K+97xxNmTKl0vdcffXV4gm//fabbNq0yfTy0n225YP26jrxxBPlm2++MT0Cq6LDL+qwm9obTPfr119/lf79+8vtt99uhlq00fzRHmY6hKf2VNOeZtOnTzdDbjqaPXu2PPjggzJ27FgzF56+R+cE0XTefvttjxw3AACB6IsvvjC9/iv2Cn/zzTdNu0iHzNZeVgsWLJDhw4ebIZ5Vdna2HHfccbJq1Sp55plnTC99bTcce+yxpudVTR1++OEyb94887f2Uv/xxx/NoyolJSXVPqrrRa89wrS9pe0IPRadV0zbFnrMHTt2dGqraA/+zz77rMbHBAAA/A9tJtpMAGqHYRXhk3ToOqUXCmpKgxQ6/J5ezNBh7xxpYEnnrXIMjtVUamqqZGRkyHPPPWce7uzdu7fS92/dutVc1LAN0WijASpPpuOOBpB0kncN+GzZssUEyGxatGhR5Xtt+10xr3Sut8rUJl+rooExNXHixErX0TLVoQ1rKjw83AxVaQuU2eZEU1o2OjeaDq+oAbS77rqrRtvUeeR03c8//9wEzAAAQO2tWLFCevbsaW7qsdHAks6bevLJJ5u5NWxOO+00+98ayNL2igaVdKhkpTdGaWBJhxx65JFHatzu1LlqlbYDKt4g425+spq0eXT/HOevrUhvAtIbf/T/4uJis0yHT3zjjTdc1j300EPtATwAABCYaDPRZgJQOwTH4JP0IoXOh7VmzZoarf/XX3+ZHkU6T9Sjjz5q5mjQYIj22nrsscdcehnVZj4L23svueSSSoM1AwYMqPH2GjIdnftLgzc6DrPOrdW8eXMT8NJea9X1vKoLT80TYtu3OXPmyGGHHeZ2nbrM82Wbu2P//v0ury1btsz8v2vXLnPXeZs2bWp0vBpkdLc9AABQM7t373aZS0vnh92xY0eVAS6dg1SDWbbAmNK2zsiRI+W7777zWvZrG1UvTlWnugDau+++KzfeeKNpq2lvt23btpm/tZe6zp2rc9DatGzZ0vSi1yBaWFiYR44DAAD4FtpMtJkA1A7BMfisM844w/Sg0p5gw4YNq3JdvYBQWFgoH3zwgdMwNMuXL69Vmo4XIWz0Yo0O76i9rvRu3trq1KmTCfZoAM+xt5he9PFkOu7oMD3HH3+8vPDCC07LtYeaXmSpyX5rj7MePXrYl2/evFm8zdbLToOknsoLpUNsqooX4HQoJh2qSIcy0uETr7rqKnn//fer3Z72bNQLVRW3BwAAaq6goMCp15jSG1VsgajKpKenS+vWrV2W67Ka3mBVF3oDVmU37zgKCQmp9DXtGae92a+44gqnHutdu3Y1vdu1XaK95mxs+aN5RXAMAIDARJuJNhOA2mHOMfisW265RWJiYuTyyy+XlJQUl9c12KRDBjpefHCc20GH3dPhbGpD09PAkSPd9rnnnmvmA3N3oUWHQ6yKzmOlnnjiCaflOtyPJ9NxR7dZcb6Lt956yz5XR1Vsc7LpkIyOnnzySfG2QYMGmQDZv//9bzMXWG3zwt3rGsjSPNegoG7fRoN/Opyi5r3OR6ZpapD1lVdecWqAuhviU3vjaf6ecsopdThKAABg6+1Vsf1lG/5Ze3RX9T53Q05ru1FfcwwsFRUVuQTW6kqHVdQAVXWPl19+ucq2ij4qBtkGDhxob+c60vzRoFxt5uMFAAD+hTbTQbSZANQEPcfgszQ4opOvX3DBBWa4nAkTJpihc/Tixg8//GCCPLZ5HPTOWr1goBOYa68fDaj85z//MRO4a7fzmtKgic4fpUMz6p3KOhzOkUceKQ8++KDphaZ/6x2+Oi+FDqW3cuVKs35Vw+rpRY9x48aZIJMG7I466igziaq7Hlj1Saey3nf33nuvXHrppSbdP/74w0xmr3cl1yQvNGCkASW9e1sngv/666/lzz//rLSXnafo0I/PP/+8CSz269fP7H+7du1MUE/zR3uUaW/ByuicHO+99559QnutAy+++KIZrujVV181dUVpYEuHnNThEefPn2+Waf3RAOXUqVNNrzWtB3v27DENLy1HHbpTLV261AzbqYGxs846y2t5AQCAv9Oe9RV7++uy9u3bmxuddJhBd7SHlfaS1974tt75GvTSNtOVV15pX0+3s379eqf3as8sR7a2gd4Q0xDDKmqv8+joaNPGGz9+vH25zouqOnfu7BKQ03nZAABA4KLNRJsJQC1ZgI/7888/rSuuuMLq3LmzFR4ebsXFxVnDhw+3nnzySaugoMC+3gcffGANGDDAioyMNOs+9NBD1osvvqjdpqwtW7bY1+vUqZN1+umnu01rw4YN1rHHHmtFRUWZ902cONH+WkpKijV58mSrQ4cOVlhYmNWmTRvrxBNPtJ577rlqjyE/P9+67rrrrBYtWlgxMTHW6NGjre3bt5s0ZsyY4bRufdLRY3PcZ82fG2+80UpOTjbHpPn2448/WiNGjDCP6uTm5pp9ad68uRUbG2udffbZ1saNG81+P/jgg/b19Bh0WWpqqss2bK9VtZ/Lly836+j/jlatWmWdc845Jt8iIiLM+8aOHWt98cUXVe73smXLrJEjR5q80zxMTEy0Tj75ZJf3Pf744ybdd955x2n5tm3brPj4eOu0004zz9PT061LLrnE6t69uxUdHW32pV+/ftYDDzxgFRUVVZuPAACgckuXLjXfx9o2cvTGG29YQUFBpi3w3nvvWZ988ol19913W0uWLDGvZ2VlmTZft27drIULF1qLFy+2Bg8ebL739bvc5tZbbzXf3fq9/+mnn5rv9I4dOzq1T7QNExISYl166aWmrbRixQqvF9m0adNMO0WPSdso2m7V/dI2hmMbVw0ZMsT6v//7P6/vEwAAaLpoM9FmAlA7QfpPbQNqAFCZ3377zfSieu211+Tiiy8mowAAQL3oqADaG0vn/dSe8460p7jOCbp69WqJjIyUww8/XB555BH7cIRbt26VG264wfQE03lbhw8fbl4/5JBD7NvIzc2VKVOmmPlEtXe69hLXYYluvPFGp+Gnn332WXn44YdNT/OSkhKXoak9TefL1X3VXu16HDr0s84Vq8ervd1sdOhIzZ9ly5bJCSec4NV9AgAATRdtJtpMAGqH4BiAOsvPzzdDDjrSoSz1Io4O79OhQwdyFwAA1JsGqlatWiVffvkluelmuOjHHntMNm3a5NVhrQEAQNNHm6lytJkAVERwDECdzZw508x9oXcxh4aGyieffGIeOo+H3l0NAADgCTo/aPfu3c28soceeiiZekBZWZmZ7/TOO+808+8CAIDARpvJPdpMANwJdbsUAGrgqKOOMsMU3XfffZKTkyMdO3aUe+65R+644w7yDwAAeExycrK89NJLkpqaSq462LVrl+m1f8kll5AvAACANlMlaDMBcIeeYwAAAAAAAAAAAAgYwY29AwAAAAAAAAAAAEBDITgGAAAAAAAAAACAgBHaGBMg6jivcXFxEhQU1NDJAwDgsyzLkuzsbGnbtq0EB3N/CwAAAAAAAOATwTENjHXo0KGhkwUAwG9s375d2rdv39i7AQAAAAAAAPikBg+OaY8x24W9+Pj4hk4eAACflZWVZW4wsX2XAgAAAAAAAPCB4JhtKEUNjBEcAwCg7t+lAAAAAAAAAGqPCUsAAAAAAAAAAAAQMAiOAQAAAAAAAAAAIGAQHAMAAAAAAAAAAEDAIDgGAAAAAAAAAACAgEFwDAAAAAAAAAAAAAGD4BgAAAAAAAAAAAACBsExAAAAAAAAAAAABAyCYwAAAAAAAAAAAAgYBMcAAAAAAAAAAAAQMAiOAQAAAAAAAAAAIGAQHAMAAAAAAAAAAEDAIDgGAAAAAAAAAACAgEFwDAAAAAAAAAAAAAGD4BgAAAAAAAAAAAACBsExAAAAAAAAAAAABAyCYwAAAAAAAAAAAAgYBMcAAAAAAAAAAAAQMAiOAQAAAAAAAAAAIGCEip/YnZ4qmblZjb0bPichJl6SmyVV+npmZqbk5eU16D75g+joaElISKj0dfLVO/lK3pKvvlZfAQAAAAAAADS8UH8JjN328eOSH1La2Lvic6JKQ+TB06a6DZBpAGfevHlSXFzcKPvmy8LCwmTy5MluL4yTr97JV/KWfPW1+goAAAAAAACgcfhFcEx7jGlgrH+vPtI8JrGxd8dn7M/NkDUb15v8cxcc0x5jGhgbM2aMJCVV3rsMzlJTU2Xx4sUm/9xdFCdfvZOv5C356mv1FQAAAAAAAEDj8IvgmI0GxtpUMUQg6kYDY8nJyWSfh5Gv3kPekq9AU1dSasmm/YWyPrVQNqYVSlpeqRSVlkl4SLC0jA6RXi0jpE9ShPRoHiGhIUGNvbsAAACNwiotlpKUDVK8a40U714rpdmpYpUUSlBohITEJUlYcj8Ja9tfQlv3lqCQMEoJAAAEZnAMAACgKdudXSzvrsuSd9dnSlZhmVkWGiRSYh1cx/F5fESwnNMnQc7pGy/JcVzw8SWWZUlpaamUWZYEBwVJSEiIBAUR6PQHlK3/omz9E+Xqm0oydkreLwslb8XrYhVkli8MDhUpKzm4knm+0PwZFJkg0UdcJNGDx0loYrtG2mvUBeeo/6Js/RPl6r+sAPwNS3AMAADAy3IKS2XuT2nywYZs0bZlmUMwzDEwVvG5BtBeWZ0uL/+WLmf2jpNpw5IkNjyY8mqicnLzJCU1TTKzcyQ7J9f8sLDRHxZxsTGSEBcrrZNaSmxMdKPuK2qHsvVflK1/olx9V1lBtmQtnS35KxeJaTRZZQ4vOgTGKjzXAFrud89K7rfPSNThYyV+1HQJjoxrwD1HbXCO+i/K1j9Rrv4rJ8B/wxIcAwAA8KKftufJPctTJL2gVDTuZVUIhlXHFkhbsjFbvt+WJzOOay1DO/hfo9SXpe1Pl63bd0lmdrbofXXuilh/ZGRkZklmZpZs3bFLEuLipFOHttKyebNG2GPUFGXrvyhb/0S5+rbCzd9KxuKbpSx3X/m3aW0bTQcCafmr3pLCP5dL4piHJaL7Md7ZWdQJ56j/omz9E+XqvyjbcgTHAAAAvGTRmgyZ831apQGT2gbJ9ueXypSPd8nNw1vK2P6JHtpL1FVxcbH8+dc/kpKmF/HKVVfOttc1kPb7uo3SOqmF9OzaRcLCaJY3JZSt/6Js/RPl6vtyf35Fsj6eKRIU7NxbrC6sMinLTZP9r/5L4k+7R2KOHO+p3UQdcY76L8rWP1Gu/ouydcavcAAAAC8GxsQDgbGKvchs2yVA1nhycnNl1Zr1UlxcYYinWkpJ3Sf7MzJlYP++fjlMhS+ibP0XZeufKFffl/vzq+WBMVXfwJjNge1kfXyP+Z8AWePhHPVflK1/olz9F2XrikkrAAAAvDCUoi2A5S26fU0HjfOj4tff19U7MGaj2/n197VmvHc0LsrWf1G2/oly9Y+hFG0BLG/R7Ws6aHico/6LsvVPlKv/omzdIzgGAADgQTmFpWaOsWAdS9GLdPszv0qRnCIP3WGNGg9DoT3GHCcq9gTd3qo1ngu4ofYoW/9F2fonytX3lRVkmznGzFCK3hQULBmLbzHpoeFwjvovytY/Ua7+i7KtHMExAAAAD5r7U5qkF5Tah0D0FtscZI//mOrdhOBE5xjzVgBLt/vn31vI8UZC2fovytY/Ua6+L2vpbCnL3ee5oRSrmYNM00PD4Rz1X5Stf6Jc/RdlWzmCYwAAAB6yK7tYPtiQ7fXAmI2m8/6GbNmdXdwwCQa4tP3pkpK2z6tp6Bxkmg4aFmXrvyhb/0S5+r6S9B2Sv3KR9wNjNlaZSa8kY2fDpBfgOEf9F2XrnyhX/0XZVo3gGAAAgIcsXpclQV4eTrEiTW/x+qyGTTRAbd2+y6/SQcPnOWXb8Chb/0S5+r68X98ob8Q0pKAgyftlYcOmGaA4R/0XZeufKFf/RdlWjeAYAACAB5SUWvLu+swG6zVmo+m9sy7TpA/vycnNk8zshpmrRNPR9NAwKFv/Rdn6J8rV91mlxZK34vWG6zVmT7jMpKvpw3s4R/0XZeufKFf/RdlWj+AYAACAB2zaXyhZhQ18kecATXfz/sJGSTtQpKSmSUPd3x50ID00DMrWf1G2/oly9X0lKRvEKshslLQ13ZKUjY2SdqDgHPVflK1/olz9F2VbPYJjAAAAHrA+1X1wqrQgVzbOnSiWZUnqd4vkj7tOkj9mnCwZv3/pdv2cLatlzcxT5Y+7TpRdHz1pX77pqculJLfyC0nr0wiOeVNmdo5U7JuXn5cnN0+bInl5uXLT1Gvl9JNPkGfmPVHpNjasWyuTxl8k4y88T1757wv25bfffKNkZx8cGlPTycrO8cpxoPqytZXrpj83yrVXXS6XTbhYrpo0UX5btdJt9u3auUP+7/JLTbk+9u+HzLmuHpx1r+zYvt1pXcq2aZTt9m1b5apJE+TKSyfIFf8aLz989229zllF2TZ+udrOvX1paTJ61Iny3jtvuX0/5dr4inetcbs8t6hMxr6625TlgpVZMvypbXL0vO3y2Z+5btdftbNAjpu/XY56cps8+vXB+TrHv75bMvJLa50+PIM2k/+izRR456yn20y0lxoWbabqERwDAADwgI1phRLqpmtR2veLpPmgU6U0N0P2fPa89L3jPel1/auy/e3ZYpWWuKy/7Y2Z0vWyx6T/zGWSueZrydtZfndz8yFnSuq37ufJCA0W2VBJcA71pxfpsnNcL8x9/OEHMuKEEyU0NEwmXHqZXPV/11a5nScee0TumHGvvLTgTfnfTz/K339tNstPPPlkWfLeYqd1s3Jy7Rd60bBlayvXqKhouf3ue+SFVxbI9LvukX/PnuV2G8/Nf9qU/6tvvC2ZGZny0w/fm+WjzzxbFr2xwGV9yrbxy7Z16zby1LMvyHP/fUUeevRxmfvIw27Pt9qcs4qybdxyDTowf9V/nn1aBh0xpNJtUK6Nr3j3WpHgUJflr6/MljP7xkh6fpnM/zFTll7RXt6ekCwzl+2XEjfjVt/+yT55+pxW8u3kDvLl5jxZn1Jklo85JE5e/bWS+ViDQ6V4N8Exb6HN5L9oMwXmOeuNNhPtpYZBm6lmXFsjAAAAqLW0vFIpcRPL2Pe/D6XH5Gclc923ktBvhIRExppHVHJ3yd36h8R2HWhftygjRayyEolu39s8bz74dMn8Y7lEt+sliYccLxseuUiST7naJY2SMpHU3GIpLCq/KATPKiktldJS1zvQv/h8mdz/4L8lPDxcBhw2UHbt2lXpNtLSUqW0tES6de9unh9/4kkmiNK1W3cZetTRcv21/ycXjZ9oX1/TyysokNCQEIqzgcvWVq7Nmze3L+vUubPk5+ebdUMcykR/dK5b84fMuK88cHbSyaPkxx++k2HDj5a+/Q+Rhx643+U9lG3jl214RIR9WXFRYfltzPU8ZxVl27jlqn7/bZXERMdIcnJbt++va7mWlpZJaCifx55Smp0qUuZ6g9DiNTny8oWt5au/8uXE7lESGxFsHj2SwuS3nYUyuEOkfd092SUmYNa3dfn5fFa/WPl8U670aR0uI3tGy5iXdsmUo5u5Jl5WIsVZe2kzeQltJv9FmylAz1kvtJloLzUM2kw1Q3AMAADAA4pKXecbKysulJLsNAmLbynFGXslPLG1/bWwxNZSlL7Haf3izIrrtJHsP/9n/g6JihOruEhK87PN3xXlFZVITn4BZekFJSWuF/CKiookfX+6UwClKjrMV4uWSfbnLZOSZPVvq8zfMTExUlRUKLm5ueZvm5y8fAkNpbnekGVbWbl+/+3X0qNXL6cgl8rKzJS4+Hh7jxUt17TUVPO3LmuTnCzbtv4jXbp2c3ofZdv4ZfvPli1y/z13yu7du2X6nTPsZVifc1ZRto1XrqUlJfLSC/+Re2bNlsVvux9Ssa7laln6HU9wzFOsEtfe7oUllqTmlkpSbKikZJdIm7iD33/6twbDHKVkl0qy4zrxIfLj1mLzd1xEsNledmGZ+buiksI82kxeQpvJf9FmCtxz1httJtpL3kebqWb4tQ0AAOAB4SFuLr7kZkhIdLzH8jckJlGKs/a5DY5Fh4dKbNTBO6rh2bvuKsrKypS4ONdyqKv4+ARJ37/f6UdjbHQUPccauGzdleuuXTvlufnzZPacR2u9/cTERNm3b59LcIyybfyy7dylizz/8gLZuWO7mR9uyJFDne6Orss5qyjbxivX9xa/I8cef4Ipm7qqrFyDgpiRwpOCQl3PtfT8UkmI9Fw+N4sKltScUrfBsdCIaNpMXkKbyX/RZgrcc9YbbSbaS95Hm6lmCI4BAAB4QMvoEDPnmOPQisFhEaa3lwpLbCW5//xhf604I8Wpl5hZJ6GVGVrx4Dp7JDyxldOd1sHhEW7nHEuKCZOI8HDK0gvCLcv0GHIcckSHUtS7IGuqRcuWsi+tvEeR0t5FLVq0dLpDM8LhR6amFx0Z6XJnJrxbthXLVS8O3D39Frn+plulXfsOLu+PT0iQ7KwsM7yilpWWa0uHO2crlitl23TK1kbLNTY2TrZs+Vt69e5T53NWcd42brluXL9O/vj9d1m0cIHk5ORIcHCwRERGyqmnj653uYa4uQEGdRcSl1Q+55jD0IoRoUGmt5dqHRcqq3cd7A2vvcZ0maPWcSGy26E32Z6sUmkTe7B3X2GpJZFhbr5Dg0MlLL4VbSYvoc3kv2gz+afanLOeajPRXmoYtJlqhhYeAACAB/RqGeEy51hoTKKUFReIVVoi8X2Plsy1X0tpQY4JgOXv2iQxnQeY9TY+NsEMsajBsqCgEMnbsUGsslLZ/8tHkjDgBPv2SnIyJCzBOaBmlpeJ9E6q+d17qB0NesTFxrjcAVlYWGSG8arKTVOvldTUvSZgEhwcIn9t3mx+fC7/4nMzL5VjEEZ/WNq3HxtDYKwRytaxXIuLi2XG7bfJeRdcJAMHDXZ634P3z5QN69aa9/fp18/Mq6C++GypDB0+3L7erp07pWOnzk7vpWwbv2xTUvaYCzW2eTL++ftvadMmuV7nLGXb+OV6+90zZeHbi+X1txbLuedfIP+adLk9MEa5Ni1hyf1c5hxrFhUiBSWWmUdsRLco+WJzvuQUlpnA2J+pRTKwXXk7Z+wru2R3VvmwiyFBIutSCqW0zJL31+bIyJ4H60Z6Xpm0iXMzFGZZiYQl9/f+QQYo2kz+izZTYJ6z3mgz0RZunLKlzeQePccAAAA8oE8lwam4HkMkZ8tqies+SNqcNEnWzTpLJChYOpw3XYJCQk2Pk8LUrSaQpjpeeLf8/cL1YhUXSvMjz5bodr3M8rzt60wwLSjY/b1NfVoSHPOmhLhYyczMcpqD+tDDDpP169ZK/wGHysSLLpDMjHQpKSn/QfjUM8+b8fZ37twp8fHlQ2tOuf5GmTXzbvMDc+SoU8wk1Wrzpj+ld5++ppeD0vvc4+NivXo8qLxsbeWq8yro/zpHwrtvvWlemzP3SUlISJAtf/9ln1vhiqsny/333CXznpgrhw8aLEOHlQfHMjMzJSIywqxvQ9k2jbLNysqSF//zjLmQoxcOJk+dJgmJiebzuC7nLGXbNMpVP4vdoVybnrC27oNTwzpFysodhTKkY6RcPTRBTn5uhwQHBcndI1tIaHCQKcst6SWSGFV+7s06taVc8+5e0+Ps3ENipU/r8h70a/YUmmCavrc26cMzaDP5L9pMgXfOerrNRFu4ccuWNpMrgmMAAAAe0KN5hMRHBEtWYZnT8qQRF8m+H981wbGkYy40D0cFe/6SZgNHSXB4+XxhsV0HSv8Zn7hsf9/PH0jSsePcpq3pdm9OcMybWie1lK07djktO3PMubL0k4/MBdmXXy8Pnjja+s8/csyI4yQiorxs+/brLy+++rrLep8v+1RGnzXG/tw6kB4ap2xt5apDKeqP+4ry8/PNsDJJrcqHPG3foYM888JLLust/3yZnHbGmU7LKNumU7ZHHX2My/rbtm6t0zmrKNvGL1fH4NjESZfb/6Zcm57Q1r0lKDJBrIJMp+UTB8fLotXZJjh2yaB483C0Oa1YTu8dI1Fh5RdZB7WPlK/+z3XI23d+z5HxFd5ro+mGti6/8QjeQZvJf9FmCrxz1tNtJtpLDYs2U/UYVhEAAMADQkOC5Jw+CRJc4SZlDXZpjy+9u86dqOTu0uH826vdflRyN4nvPcxluaZ3bt8Ekz68JzYmWhIcJqa2/QjUOyErK9tOnTvLNVOmVrvtTp27OA3bp+loemicsq2uXKOiouTue2dVu92YmFg5edSpTsso26ZdtnU9ZxVl23AoV98XFBIm0UdcZHrSO9Jg12FtIyo9R3skhcs9o1pUu/2eSWFydJcoNwkHm3Q1fXgPbSb/RZvJP3HO+i/aTNUjOAYAAOAh5/SNF3fXc1oOP7/e80fpNtzR9Mb0cX93NDyrU4e2Lst0Ppv6lq1tTpyq0oF3VcxzT5TryFNOlZBQ54E6KFv/KNuK56y7dOBdlKvvix48rrwRU8G4gfH1Pkd1G25ZVnm68DraTP6LNpN/4pz1X7SZqkZwDAAAwEOS48LkzN5xLr3HvEXTOat3nEkX3teyeTNp3bL6O9bro3VSC5MOGhZl678oW/9Eufq+0MR2EnX4WJfeY14TFGzS03ThfZyj/ouy9U+Uq/+ibKtGcAwAAMCDpg1LkuZRIV4PkOn2NZ2pw5K8mxCc9OzWWcLCvDNtr263Z9cu5HgjoWz9F2XrnyhX3xc/aroEx7T0foAsKNiko+mh4XCO+i/K1j9Rrv6Lsq0cwTEAAAAPig0PlhnHtZYy99NleIxuX9PR9NBwwsLCZGD/vhISEuLR7er2dLveCryhepSt/6Js/RPl6vuCI+MkcczDIlaZdxOyykw6mh4aDueo/6Js/RPl6r8o28rx69sLCkuLZcXudbJ+/1ZJzUuXgtIiCQsOlajQCIkJi5JW0c2kTUxz6deiqyRGxnpjFwAAQCMa2iFabh7eUuZ8n+a1NG45Osmkg8aZ2HjQgH6yas06KS4uqff2NCCmgTHdLhoXZeu/KFv/RLn6vojux0j8afdI1sf3eC2N+NNnmnTQ8DhH/Rdl658oV/9F2bpHcMzD0vIz5aU1H0lGYY5LwEwfunxnTqpZpoGywyJ7eHoXAABAEzC2f6L5XwNkOgSiJ3qS2bajgbHz+yXUf4Oo14+LoYcfJn/+vUVSUvfVa44xHUqRHmNNB2Xrvyhb/0S5+r6YI8eb/02ATIdY9ERPsgPb0cBYzJBL6r891BnnqP+ibP0T5eq/KFtXBMc8yLIsWbThC6fAWHRopLSJaSERIaGSV1Ioe/PSJb+k0JPJAgCAJhwg65gQLjO/SpH9+aX1CpDZ5hjToRTpMdY0aECrX68e0jqppWzdvksys7NFp5qrqphtryfExUmnDm3NBMloeihb/0XZ+ifK1T8CZKEtOkvG4lukLDetfgGyA3OM6VCK9BhrGjhH/Rdl658oV/9F2TojOOZBu3P3yS5txB3Qp3knubDPSAmpMLns7pw0+SPtb4kOi/Rk8gAAoAnSQNZbYzvK3J/S5IMN2RJUy15kGhSzLJHRveJk2rAk5hhrgjTApY+c3DxJSU2TrOwcycrJldLSUqc5xeJjYyQ+LtYE0xhC0TdQtv6LsvVPlKtv00BW0pRlkrV0tuSvXCSm0VSbIJnpLWZJ1MDzJX7UdOYYa4I4R/0XZeufKFf/RdmWIzjmQfvyM52ed05IdgmMqeTYluYBAAACQ2xEiNw5orVcdnhzWbw+S95ZlylZhbaLPZZTn6LQ4CApOfBSfESwnNs3Qcb0iZfkuLDG2n3UkAa8YmM62kcUKC0tE8sqk6CgYAkJCZYgvcgHvyjbvIICycnLl9joKImOjKRsfRjnrX/inPVdwZFxknjWAxI7YrLk/bJQ8la8LlZBpkuLqXzlUJGy8rk/gyITJPqIiyR68DgJTWzXODuPGuOz13/x+eufOGf9V2yA/84hOOZBFQNh3+z4zSzr0ayDtIhiXhAAAAKdBriuGdJCrhzUXDbvL5TP/86Rl3/LsL8eHBQkZ/aKl95JEdKnZYR0bx4hoSH+3Rj1V/ojIjQ0RFuIjb0r8EbZhoRIaGio+d/ffzAGEs5b/8Q565s0wBV/0k0Sd/xUKUnZKDnfPy8Fa5bYXw+KSpSofqdKWHJ/CWvbX0Jb95KgEG4k8kV89vovPn/9E+es/woKwN85rt2aamDevHnSuXNniYyMlCOPPFL+97//SSAqLiiSr55420RV//7+D/nzueUS5NDjP7e4QD78+wd57Nc35f4fX5JnV7wrz776grw15wVZ+/FP9vW+ffo9KcoraJyDaIIKCgrkvvvuk/z8fLn33ntl/Pjx8sorr1S6/ubNm+WGG26QKVOmyNtvv21fPnv2bMnJOTj/W6Cz5euWLVvkjjvukBtvvFFuvfVWWbt2rdv19+zZI7fddpvJ1+eee87Uc/XUU0/J7t27G3jvfSNvd+3aJbfccovcfPPN5vHLL7+4XZ86W7t8tdW99PR0mThxonz66afkK3yeBrx6J0XKiM6xTssjQoJk+rGtZEyfBPM6gTEAABDINOClwa/wjoOclock9ZCE0fdL9OALzesExgAAgNeDY2+++aYJRMyYMUNWrlwphx56qIwaNUr27t0rgWbLD2ukw+E9pSi3QDZ+/qucfsMlMrx1f7frFpQWyfbCNNnepVRWDyuVZSVrZde2nea1jkf0lr++/b2B977p+uKLL2TYsGEmSn3eeeeZ4FhVXnjhBZk6dao8/vjjsmrVKtm2bZtZfswxx8hnn33WQHvtO/mqQW0NeD3yyCPm//nz57tdf8GCBXL++efLk08+KdnZ2eZ8VyNHjpQlSw7esYeDeduyZUt54IEHZM6cOSYA+Z///Mce2HFEna1dnbXdqaJ18pBDDql0ffIVAAAAAAAAgFeCY48++qhcccUVcumll0rfvn3lmWeekejoaHnxxRfdrl9YWChZWVlOD3+x7ZcN0m5AN9mzfqu06ddZwiLD5ZReR0n/nfESFxJV5Xv3NS+VRVuWmwvnbft3ke2//tlg+93UfffddzJ48GAJCwszdSw8PLzSdffv328mu+/UqZMEBwfLUUcdJb/++qt57fDDD5cffvihAffcN/I1OTlZ2rRpY5a1a9fO9M4pK3Oe5Fjr5Z9//mny0BZotOVrz549TW+ziu8JZLa81bqqQV1VXFzsdl3qbO3zVa1bt85813TsWD4OMvkKAAAAAAAAoEGCY0VFReYC+UknnXRwA8HB5vmPP/7o9j06tF1CQoL90aFDB/EHpcUlUpCVJ5HxMZKfmSNRiQeHReohrWRc+BC5asBZcnLnIdKneSeJDHYd+zotJE+2Z6dIWFSElJaUSHF+oQQ6DShkZmZKYmJijdbXYdaaN29uf65/a/BB6YV03V5eXp4EusrydcWKFdK1a1dzHjvSnmKxsbH2HjuO+arLkpKSZMeOHQ14BL6Tt5ovOmSl9rC97LLLXMbnpc7WPl81AL5o0SIZO3ZspeuTrwAAAAAAAAC8EhxLS0szFylbt27ttFyf6/xE7kyfPt1c4LQ9tm/fLv5Ah1IMj46s9HW9IN4hvrUc2/4wubjvKPm/tqfIwH8SJLzCBLF78zLM/+ExkVKQTRBHgzIxMTEeK6e4uDhT7wKdu3xNSUmR1157TSZNmlTr7cXHx0tGRnndDXQV87Z9+/ZmyEodWvGDDz4wNxXUBnXWNV+XLl0qQ4cONQHbuiJfAQAAAAAAANiUj//lRREREebhb4LDQk1vLxWVECv7t+6RgpIiCQ4KlvwM555kKjoxTuK2F0v3Qe1k3b5/7MtDgsrjk2XFpRIS5vXiaPJ0WLrKhqNzp1mzZvYeTUr/1mU2GpioaljGQM3XnJwcefjhh+XKK6+0D7FYMZCg6+jwihroJV9rnrc2mq8a3NEbArp162ZfTp2tfZ3dvHmzbNiwwcx1l5uba3o66usnnHAC+QoAAAAAAADAuz3HWrZsKSEhIabHiSN97u4Cuz+LiImU0qISKSstkzZ9Osmetf/IzvQUmfO/BfJH9F4pTioPyHz1+NuSdyBYVhhpydYM5x52rWLKAzmFuQUmyBbotGeIBrS0h2JV7r33XhOw0eH+9EL51q1bzRxYOseYbY4ipQEex2BZoHLM15KSEtOrafTo0dK/f3+n9Z566ikTiNCAWI8ePWTlypX2uZ8GDRrkdM7rfGVwzlvtXWsL6Gj93LZtmxmCUlFn615nr7vuOnn66adl3rx5ctppp5nhFW2BMfIVAAAAAAAAQG3VqquS3qmvF8i/+OILOfvss80yDUjo82uvvVYCTVKP9rL/n93Ssls76Xni4bLitWWSf0Sp7OwiMm/1uxIdGikhXQpk+47vpGBbkWw/okDKSi37+5NjWkjbmJaSvn2vNO/UWoKCnecmClR9+/aVTZs2Se/evWXq1KmSlZVlLpBr4GvWrFkmIKbDeNqGWNNhAR9//HETlDjmmGOkY8eOZvk///xjeuxUnE8r0PN179695n+di+2jjz4yr919992mt5gGc2zBxIsvvljmzp0rL730kgmiHX744fbh7rQ3qK4P57zVYOzChQtNndPHpZdeaoag1B541Nn6fRa4Q74CAAAAAAAAqItaj+N3ww03yMSJE03vnCFDhpiL5zrMlV4EDjTdjz1Utvy01gTHuh09QEIHtJI1v39gfz2vpECkucjGjG0u702IiJULep9oeuhsXbFBuh0zoIH3vuk6+eST5auvvjIXxDXoVdGOHTvkyCOPtA+X2LNnT3n00Udd1vvmm2/MtuCcrzqU4rHHHuuSLQUFBaYHaIsWLczz5ORkeeihh1zW+/77752Gs4Nz3jr2XLTZuXMndbaenwU22muMfAUAAAAAAADQoMGxCy64QFJTU01PE+0Jcdhhh8mnn34qrVu3lkDTokuyZO7eZ5+XqVN8G5l82LmyOWOH7MjeK6n5GZJVmCtFZcUSJEESFRohraKbSa/mHWVwmz4SERJmthPfprm07lXe2wnlwS4NgNnytaL27dubAG11dL2KwwYGsuryNTIy0gS/qxMdHS3Dhw/30l76Juos+QoAAAAAAADAj4NjSodQDMRhFN3pepRz8CU5toV51GcbEI/0TKJ3k3fyxF2vM1BnvYXPAgAAAAAAAACexmRMAAAAAAAAAAAACBgExwAAAAAAAAAAABAwCI4BAAAAAAAAAAAgYBAcAwAAAAAAAAAAQMAgOAYAAAAAAAAAAICAQXAMAAAAAAAAAAAAAYPgGAAAAAAAAAAAAAIGwTEAAAAAAAAAAAAEDIJjAAAAAAAAAAAACBgExwAAAAAAAAAAABAwCI4BAAAAAAAAAAAgYBAcAwAAAAAAAAAAQMAgOAYAAAAAAAAAAICAQXAMAAAAAAAAAAAAAYPgGAAAAAAAAAAAAAIGwTEAAAAAAAAAAAAEDIJjAAAAAAAAAAAACBgExwAAAAAAAAAAABAwCI4BAAAAAAAAAAAgYBAcAwAAAAAAAAAAQMAgOAYAAAAAAAAAAICAQXAMAAAAAAAAAAAAAYPgGAAAAAAAAAAAAAIGwTEAAAAAAAAAAAAEDIJjAAAAAAAAAAAACBgExwAAAAAAAAAAABAwCI4BAAAAAAAAAAAgYBAcAwAAAAAAAAAAQMAgOAYAAAAAAAAAAICAQXAMAAAAAAAAAAAAASNU/Mj+3IzG3gW/zK/U1FSv74s/qWl+ka/eyVfylnxtCji/AQAAAAAAgKbLL4JjCTHxElUaIms2rm/sXfE5mm+af+5ER0dLWFiYLF68uMH3y9dpvmn+uUO+eidfyVvy1dfqKwAAAAAAAIDG4RfBseRmSfLgaVMlMzersXfF52hgTPPP7WsJCTJ58mTJy8tr8P3ydXpBXPPPHfLVO/lK3pKvvlZfAQAAAAAAADQOvwiOKQ3wVBbkQd3phV0u7noe+eo95C35CgAAAAAAAABVCa7yVQAAAAAAAAAAAMCPEBwDAAAAAAAAAABAwCA4BgAAAAAAAAAAgIBBcAwAAAAAAAAAAAABg+AYAAAAAAAAAAAAAkao+InMzEzJy8tr7N3wOdHR0ZKQkFDp67tTUiU9M6tB98kfNEuIl+TWSZW+Tn31Tn1V1FnP11dFnfVOfQUAAAAAAADQ8PwiOKYXbefNmyfFxcWNvSs+JywsTCZPnuz2Aq4GGc64ZLIUFZGvtRUeHiYfvjbPbcCB+uqd+qqos56vr4o66536CgAAAAAAAKBx+EVwTHuMaWBszJgxkpRUde8HHJSamiqLFy82+efu4q32GCMwVjeab5p/7oIN1Ffv1FdFnfV8fVXUWe/UVwSu3dnFsnxLruQUlUpKTonTa8Wlljz3yz7zd5vYMBnZLVaiwhgFGwAABJ7i3WulcPO3YpUUStGO1U6vlWbslOzlj5u/Q1v3lsjeIyUomDYTAAAIsOCYjQbGkpOTG3s3gBqhvsLXUGeB+tufXyIT390h6QWlbl8vsUT+82u6/flnf2XLk6e3I+sBAEBAKdq+Svb9d5xIqfuRbKysXZLz1RP25zHH/J/En3RTA+4hAADwddxWAwAA0EB+211QaWDMnZ925EtuUZlX9wkAAKCpKdj4RaWBMbfrr/vEq/sDAAD8D8ExAACABtK9RXit1m8XHyrRYUFe2x8AAICmKKxNn1qu39dr+wIAAPwTwTEAAIAG0jEhXI7vElPj9Scc2kyCggiOAQCAwBLZZ5SENO9Y4/Vjhl/h1f0BAAD+h+AYAABAA7p8UPMardcmNlRG94r3+v4AAAA0NUEhoRI74toarRvR8wQJbzfA6/sEAAD8C8ExAACABtSzRUSNeo9dOrCZhIXQawwAAASmqEPOqlHvsdjjpjTI/gAAAP9CcAwAAKCJ9R6j1xgAAAh0pvfYsZOrXIdeYwAAoK4IjgEAADSx3mP0GgMAABCJGnB2lb3H6DUGAADqiuAYAABAE+o9Rq8xAACA6nuP0WsMAADUB8ExAACARuo9Nig5ymU5vcYAAACce48FRTdzyRJ6jQEAgPogOAYAANBIrj7C+UJPWLDI6F7xlAcAAIBD77HoweOc8iM4sb2EtxtAHgEAgDojOAYAANDASkotWZ9aIH+nF0unhDCzLEhEujYLk39/nyrvrss0r+t6AAAAgcoqLZbiXX9IcFwbCY5pUb4wKESC49tK5pI7Je+XheZ1XQ8AAKA2Qmu1NgAAAOpsd3axvLsuS95dnylZhWXljbGgAxd/RGTjvmL5a3+xlByIicVHBMs5fRLknL7xkhxXHkQD0Lgsy5KS0lIpKSkx/4dblgQFHTiRATQ5nLO+qSRjpwl85a14XayCzPKFwQcuYVmlUrLtf1KyY6VI2UKzKCgyQaKPuMj0MAtNbNeIew7Ahs9fwLdYAfg7h+AYAACAl+UUlsrcn9Lkgw3Zom3LMocOYbZAmLvnGkB7ZXW6vPxbupzZO06mDUuS2HA6/gMNLSc3T1JS0yQzO0eyc3KltLTU/lpISIjExcZIQlystE5qKbEx0RQQ0Mg4Z31XWUG2ZC2dLfkrF4lpNFllDi+WVFj54HMNoOV+96zkfvuMRB0+VuJHTZfgyLgG3HMAis9fwLfkBPjvHIJjAAAAXvTT9jy5Z3mKpBeUmt5hVi1HSrQF0pZszJbvt+XJjONay9AO/tcoBZqitP3psnX7LsnMzjZDn7o7ffUHZEZmlmRmZsnWHbskIS5OOnVoKy2bO88pCMD7OGd9W+HmbyVj8c1Slruv/BO3to2mA4G0/FVvSeGfyyVxzMMS0f0Y7+wsACd8/gK+hXO2HLceAwAAeMmiNRky5eNdsj+/1Km3WF3o+3U7uj3dLgDvKS4ulrUbNsnv6zaawJiq7hS2va7r6/vWbtwkxcUVejkA8ArOWd+X+/Mrsv/Vf5UHxhx7i9WFVSZluWlme7k/v+qpXQTgBp+/gG/hnHVGzzEAAAAv0ADWnO/TzN/1jIvZ2QJstu2O7Z/ooS0DsMnJzZVVa9bXO7CVkrpP9mdkysD+ff1yCBKgqeCc9X0awMr6eGb5k/oGxmwObCfr43vM/zFHjvfMdgHY8fkL+BbOWVf0HAMAAPDCUIq2AJa36PY1HQCe/cH46+/rPNbjS7fz6+9rzVj+ADyPc9Y/hlK0BbC8Rbev6QDwHD5/Ad/COesewTEAAAAPyiksNXOMBesERV6k25/5VYrkFHnoDmsgwOkQI9pjzHESak/Q7a1a47mAG4BynLO+r6wg28wxJkFevjQVFCwZi28x6QGoPz5/Ad/COVs5gmMAAAAeNPenNEkvqP8cYzWdg+zxH1O9mxAQIP786x+vBbB0u3/+vcUr2wYCFees78taOtszc4zVcA4yTQ9A/fH5C/gWztnKERwDAADwkF3ZxfLBhmyvB8ZsNJ33N2TL7uzihkkQ8FNp+9MlJW2fV9PQOcg0HQD1xznr+0rSd0j+ykXeD4zZWGUmvZKMnQ2THuCn+PwFfAvnbNUIjgEAAHjI4nVZEuTl4RQr0vQWr89q2EQBP7N1+y6/Sgfwd5yzvi/v1zfKGzENKShI8n5Z2LBpAn6Gz1/At3DOVo3gGAAAgAeUlFry7vrMBus1ZqPpvbMu06QPoPZycvMkM7th5qHRdDQ9AHXHOev7rNJiyVvxesP1GrMnXGbS1fQB1B6fv4Bv4ZytHsExAAAAD9i0v1CyCl0v8pQW5MrGuRPFsixJ/W6R/HHXSfLHjJMl4/cv3W5n68J75Lebh8q6B8Y4b/+py6UkN9PtezTdzfsLKUegDlJS08Sx70J+Xp7cPG2KbPpzo1x71eVy2YSL5apJE+W3VSvdvv+1l/8r4849W8accYrT8gdn3Ss7tm93WhZ0ID0Anj9n9XtW7UtLk9GjTpT33nnL7fsff3SOnHvmafJ/l1/qtPz2m2+U7Gznntics95RkrJBrALXNk1uUZmMfXW3KcsFK7Nk+FPb5Oh52+WzP3Pdbmf6x2ky4JGtcsp/djgtH//6bsnIL3X7Hk23JGWjh44ECCy0mQDfQpupegTHAAAAPGB9qvvgVNr3i6T5oFOlNDdD9nz2vPS94z3pdf2rsv3t2WKVlris3/yI0dLj2uddlw85U1K/rXwooPVpBMeAusjMzhHHfpcff/iBjDjhRImKipbb775HXnhlgUy/6x759+xZbt8/eMiR8tSzrufs6DPPlkVvLHBapulkZedQUIAXztmgA0P0/efZp2XQEUMqff+JJ50ss+c86rr85JNlyXuLOWcbQPGuNW6Xv74yW87sGyPp+WUy/8dMWXpFe3l7QrLMXLZfStx0zR/TP1ZeG9fGdfkhcfLqr1m1Th9A1WgzAb6FNlP1CI4BAAB4wMa0Qgl1M3XGvv99KImHniSZ676VhH4jJCQyVsITW0tUcnfJ3fqHy/px3QdJaEyiy/LEQ46X/b985Dbt0GCRDZUE5wBUTnsnZOc490j44vNlctTRx0r7Dh2kbbv2Zlmnzp0lPz9fSktdeyL07tNXWrRs6bK8b/9D5LeVK13ek5WTa+/hAsBz56z6/bdVEhMdI126dqt0G/0HHCrx8Qkuy4cedbR89eUXLss5Zz2vePdakeBQl+WL1+TIqF7R8tVf+XJi9yiJjQiWNnGh0iMpTH7b6drOGdIxUppFu17WGtkzWt5f6763maZbvJvgGFBbtJkA30KbqWYIjgEAAHhAWl6plFS43l1WXCgl2WkSFt9SijP2mqCYTVhiaylK31Pj7YdExYlVXCSl+a5zI5WUieyrZPggAJXTwJVj8KqoqEjS96dL8+bNndb7/tuvpUevXhISElLj7NReLG2Sk2Xb1n/cpNnA8+wAAXDOlpaUyEsv/EcmXnZ5nbYdExMjRUWFkpvrHFThnPW80uxUkTLn3vOFJZak5pZKUmyopGSXmKCYjf69J9u1t31l4iKCzfay3Qx3remW5qTW7wCAAESbCfAttJlqhuAYAACABxS5udhdkpshIdHxHsvfkJhEKc7a5/a1Qo2QAaiVsgo9uLKyMiUuLs5p2a5dO+W5+fNkyrQbap27iYmJsm+f6zlrWZyvgKfP2fcWvyPHHn+C215hNaXvTd+/32U556xnWSWuvcDS80slIdJzl6iaRQVLak4l844V09seqC3aTIBvoc1UM6792AEAAFBr4SGuF3SCwyJMby8VlthKcv85OIxicUaKU0+yml5MCg6PcPtahI6tCKBWgg/MUWQTHh5ueo44Xni/e/otcv1Nt0q79h1qnbvaqyUiwvWcDQrifAU8fc5uXL9O/vj9d1m0cIHk5ORIcHCwRERGyqmnj+acbWKCQl0/FyNCg0xvL9U6LlRW7yqwv6a9xnRZbRSWWhIZFuQ+/TD3bSkAlaPNBPgW2kw1w68yNGnt27aRnz95Xf74erF5PPvvGW7Xe+6RGfZ1fv50oXRsl9zg+wpQX4HA1jI6xGXOMZ07rKy4QKzSEonve7Rkrv1aSgtypCgjRfJ3bZKYzgPMehsfm1CjIRZLcjIkLME1oKZxsRZRNR/uDUA5HSbRcahE7TVSWFhkhmcrLi6WGbffJuddcJEMHDTYKcsevH+mbFi3ttps3LVzp3Ts1NlNmvwMAzx9zt5+90xZ+PZief2txXLu+RfIvyZdbg+M3TT1WklN3Vvt9jUgXnEOQc5ZzwuJS3KZc6xZVIgUlFhSUmbJiG5R8sXmfMkpLDOBsT9Ti2Rgu/KA1thXdsnurOqHWEzPK5M2cW7aRsGhEhKb5LmDAQIEbSbAt9Bmqhl+laFJ27Frj/z76Zfsz4864jAZN+ZUp3UuOuc0GTb4MPvzR+a/JNt27m7Q/QQU9RUIbL1aRrjMOabiegyRnC2rJSy2ubQ5aZKsm3WWbHz0Eulw3nQJCgk1E+UWpm41gTS15aVbZMPDYyV/50ZZfdvRsv/XT8zyvO3rTDAtKNi1+aYjKvZO4i5ooLZ0XrC42BinZYcedpisX7dWvvryC/P/u2+9KVdeOsE8MjMzy8/Tv/+SFi3LL67+9/ln5YJzzpSc7Gzz/1tvLDTLdd2IyAhJSHAe4i0+NsakC8Cz52xl9Ht2586dEh9fPszxQ7PukylXXyF//7XZnLNfL//CLN+86U/p3aev6XHGOetdYcn9XOYcU8M6RcrKHYXSIjpErh6aICc/t0POe3m33D2yhYQGB5my3JJeIolR5WU07f29MvrFXbI+pUgGPbZVlqzLMcvX7Ck0wbSKd80bZSUSltzfy0cI+B/aTIBvoc1UMwyriCbvrSXL5LjhR8ixw8rv2J121QT5YcVq2bpjl3Rq39Y8t/nu55Wy6P2ljbi3CHTUVyBw9akkOJU04iLZ9+O7Etd9kCQdc6F5OCrY85c0GzhKgsMjzfMu/3rY7Xb2/fyBJB07rvL0WxIcA+oiIS5WMjOzxBbbPnPMubL0k4/MUIojR53isn5+fr4ZYjGpVSvz/NLLrzKPipZ/vkxOO+NMp2V6mTY+LpaCArxwzvYfcKh9nYmTLrf/vW3rVjlmxHESEVH+PXvrHXe53e7nyz6V0WeN4ZxtAGFt3QenJg6Ol0Wrs2VIx0i5ZFC8eTjanFYsp/eOkaiw8uDY3LPKP4creuf3HBlf4b01SR9A1WgzAb6FNlP16DkGnzDj4aclPSPL/B0dFSmzbr9OwsJC5YE7pkpUZPnFwIzMbLn7oacaeU8B6isQqHo0j5D4CNemVWzXgabHl97t7E5UcnfpcP7t1W4/KrmbxPce5vY1Tbd7c4JjQF20Tmppv8iu+vbrb3qPVHrORkXJ3ffOqna7MTGxcvIo5xEPrAPpAWi4c7ZT585yzZSp1W63U+cuLkOocs56R2jr3hIU6dyrVg1qHymHtY2otCx7JIXLPaNaVLv9nklhcnSXKLevabqhrXvVYa8B0GYCfAttJi8Ex7755hsZPXq0tG3b1nTPe++99yRQFRQUyH333Wcabl988YVcd911MnXqVPn111/drv/888/LFVdcIbfddpvT8tmzZ5sJg1G5tP3pcv9jz9qfH9qvlyx85mEZ0Lenfdn9jz0jqfvSycZq6uuWLVvkjjvukBtvvFFuvfVWWbvW/RAk77zzjvzf//2fXHbZZU7Ln3rqKdm9m2Erq0J99fxnrEpPT5eJEyfKp59+6nZ9PmPR2EJDguScPgkS7GYEn5bDz6/3MGq6DXc0vXP7Jpj0AdRebEy0JMTFOS3TeYrqe86OPOVUCQl1HqhD09H0ADS9c9Y2P5kjzlnvCAoJk+gjLhIJcr0kNW5gfL3LUrfhPuFgk66mD6D2aDMBvoU2kxeCY7m5uXLooYfKvHnzJNBpQGzYsGEmsPXBBx/IQw89JDNmzJBXXnlFSktLXdY/+uijZfr06S7LjznmGPnss88aaK9917KvfpAPl31tf96rexf73x999rUsXf5DI+2Zb9XXyMhImTJlijzyyCPm//nz57tdX8/zBx54wGX5yJEjZcmSJQ2wx76N+uq5Omv7cbxgwQI55JBDKl2fz1g0Bef0jZdKbnb2Gk1vTJ/Khw4CUL1OHdr6VTqAv+Oc9X3Rg8eVN2IakmWVpwugzvj8BXwL56yHg2Onnnqq3H///TJmjPNY3IHou+++k8GDB8vq1atl4MCBZoiV5s2bS7t27eSvv/5yWb93794SG+s6x8Dhhx8uP/xAYKcmHnj8Odmbtt9pWdq+dJk197l6lGRg1dfk5GRp06aNWaZ1VXvnlJWVuazfvXt3adasmcvynj17mt5m7t4DZ9RXz9RZtW7dOomOjpaOHTtWuj6fsWgKkuPC5MzecW57j3mDpnNW7ziTLoC6a9m8mbRuWf1QXfXROqmFSQdA/XHO+r7QxHYSdfhYt73HvCIo2KSn6QKoOz5/Ad/COVs1r7dCCgsLJSsry+nhD4qLiyUzM1MSExNl//79Jihmo3/rsprSC766vby8PC/trX+NlaqTCTpKiI+Vtm3cT8QL1/rqaMWKFdK1a1cJDq75R4H24klKSpIdO3aQvdTXBqmz2hN30aJFMnbs2Dpti89YNLRpw5KkeVSI1wNkun1NZ+qwJO8mBASInt06mzltvUG327PrwVEPANQf56zvix81XYJjWno/QBYUbNLR9ADUH5+/gG/hnG3E4JjOp5WQkGB/dOjQQfxBdna2xMTEeGx7cXFx5kIwKhcaEiIP3DFVIiLCnZaHhYXJ7Dumee1ihr/W15SUFHnttddk0qRJtd5efHy8ZGRkeHAP/Q/11XN1dunSpTJ06FC3PW9ris9YNKTY8GCZcVxrKfPySEG6fU1H0wNQf9qmHNi/r4SEhHg0O3V7ul3aqoBncc76vuDIOEkc87CI5eVRSawyk46mB6D++PwFfAvnbOW8fjVF59jSoI/tsX37dvEH4eHhpmeDu55i+re74eiqUlRUZLaJyl0z6ULp06Or/fnCdz+2/92jayeZctnFZF8N6qvSefIefvhhufLKK+1DLFJfPYv66rk6u3nzZjOv4+TJk+Xjjz82vci+/PLLWm2Pz1g0tKEdouXm4S29msYtRyeZdAB4dtLqQQP6eSyQpdvR7el2AXge56zvi+h+jMSfdo9X04g/faZJB4Dn8PkL+BbO2UYKjkVERJheJo4Pf6A9GPRiqw73NWDAAFm1apXk5+ebwJgON6fzNal77723RkMsarCitgG1QHJov15y6YUH57l796PP5YHH/yPvfPiZfdmEsaPl8AF9GmkPfae+lpSUyJw5c2T06NHSv39/p/WeeuopE4iojvY60/nK4B711bN19rrrrpOnn35a5s2bJ6eddpoZXvGEE04w6/EZi6ZsbP9Ee4DMU0Ms2rajgbHz+yV4ZqMAXH44Dj38MDNHWH3o+3U7BMYA7+Kc9X0xR44/GCDz1BCLB7ajgbGYIZd4ZpsAnPD5C/gWzllXjMNTD3379pVNmzaZgJ8GGm655RaZOXOmTJgwwQyfYlmW7Nmzxz4UmF7YvfPOO2Xr1q1y9dVXy48//miW//PPP9KtW7dazfsUSKIiI2TW7ddJaGj5EDc7dqfIQ0++YP5+6KkXZfvOPeZvzfNZ06+TqKjIRt3fpl5ff/jhB/P/Rx99JDfffLN56BB2atu2bfYg7RtvvGHqqQZu9f8PP/zQLNd1Neitw9TBFfXV83W2MnzGwlcCZE+e1tYjc5DZ5hjT7REYA7xLe3z169VDBvTtJQkH2jzVncK213V9fZ++n6EUgYbBOesfAbLm41/yzBxkB+YY0+0RGAO8i89fwLdwzjqr9XgheqHcsWfJli1b5LfffjNDC3bs2FECycknnyxfffWV9O7dW0466STzcLRz50458sgj7cMl6pBg7nzzzTdmW3DvpmsulU7t25q/tRfJnQ88IXn5BeZ5fn6B3P7A4/Lfx+83wbP2bdvILddOkplzniY7K6mvOpTiscce65I/BQUFZojFFi3K75K+8MILzaOi77//3t5rB9RXb3L8jLXRXmM2fMbCV+jQh2+N7Shzf0qTDzZkS1BQ+XxhtQmKWZbI6F5xMm1YEnOMAQ2oZfNm5pGTmycpqWmSlZ0jWTm5pk1qozdoxcfGSHxcrLROaklPMaARcc76Nh36MGnKMslaOlvyVy4S02iqzXxkGlSzLIkaeL7Ej5rOHGNAA+LzF/AtnLN1DI798ssvcvzxx9uf33DDDeb/iRMnyksvvSSBpGfPnmYIRe29EKSNtgrat29v8qU6ul7F4e1QbviQgTL2rFH27Hj1rSXy6+/rnLLntzUb5MWFi+XK8eeZ5+edMVK+/PZn+fanX8nGWtTXyMhI+/lclejoaBk+fDh56wb11bP4jIU/iY0IkTtHtJbLDm8ui9dnyTvrMiWr0HaxxxYp089mS0KDg6TkwEvxEcFybt8EGdMnXpLjwhpr94GAp0OQxMaU3wiobam8ggLJycuX2OgoiY6MdNu2AtB4OGd9V3BknCSe9YDEjpgseb8slLwVr4tVkOnSYipfOVSkrKR8WWSCRB9xkUQPHiehiUwBADQWPn8B3xIb4L9zah0cO+6440xGoZwnetDQC6dy3/9vlRwy4uBcY5V58vkF5gHv1zV3vc5QjvrqeXzGwt9ogOuaIS3kykHNZfP+Qvn87xx5+bcM++vBQUFyZq946Z0UIX1aRkj35hESGuLfjVHA1+gPxNCQEAkNDTX/+/sPRsDXcc76Jg1wxZ90k8QdP1VKUjZKzvfPS8GaJfbXg6ISJarfqRKW3F/C2vaX0Na9JCiEG4mApoTPX8C3BAXg75xaB8cAAABQzwZYSJD0ToqU4jJxCo5FhATJ9GNbkb0AAAB6oS4kzAS/wjsOcgqOhST1kITR95NHAACgzuo5yykAAAAAAAAAAADgOwiOAQAAAAAAAAAAIGAQHAMAAAAAAAAAAEDAIDgGAAAAAAAAAACAgEFwDAAAAAAAAAAAAAGD4BgAAAAAAAAAAAACBsExAAAAAAAAAAAABAyCYwAAAAAAAAAAAAgYBMcAAAAAAAAAAAAQMAiOAQAAAAAAAAAAIGAQHAMAAAAAAAAAAEDAIDgGAAAAAAAAAACAgEFwDAAAAAAAAAAAAAGD4BgAAAAAAAAAAAACBsExAAAAAAAAAAAABAyCYwAAAAAAAAAAAAgYBMcAAAAAAAAAAAAQMAiOAQAAAAAAAAAAIGAQHAMAAAAAAAAAAEDAIDgGAAAAAAAAAACAgEFwDAAAAAAAAAAAAAGD4BgAAAAAAAAAAAACBsExAAAAAAAAAAAABAyCYwAAAAAAAAAAAAgYBMcAAAAAAAAAAAAQMAiOAQAAAAAAAAAAIGAQHAMAAAAAAAAAAEDAIDgGAAAAAAAAAACAgEFwDAAAAAAAAAAAAAEjVPxIampqY++CTyG/yH9fQn1tfJQBeQUAAAAAAAD4A78IjkVHR0tYWJgsXry4sXfF52i+af650ywhXsLDw6SoqLjB98vXab5p/rlDffVOfVXUWc/XV0Wd9U59BQAAAAAAANA4/CI4lpCQIJMnT5a8vLzG3hWfoxduNf/cSW6dJB++Nk/SM7MafL98nQYaNP/cob56p74q6qzn66uiznqnvgIAAAAAAABoHH4RHFN6AZKLkJ6nF8yrumiOuqG+eg911juoswAAAAAAAAD8RXBj7wAAAAAAAAAAAADQUAiOAQAAAAAAAAAAIGAQHAMAAAAAAAAAAEDAIDgGAAAAAAAAAACAgEFwDAAAAAAAAAAAAAEjVPxEZmam5OXlNfZu+Jzo6GhJSEio9PXdKamSnpnVoPvkD5olxEty66RKX6e+eqe+Kuqs5+uros56p74CAAAAAAAAaHh+ERzTi7bz5s2T4uLixt4VnxMWFiaTJ092ewFXgwxnXDJZiorI19oKDw+TD1+b5zbgQH31Tn1V1FnP11dFnfVOfQUAAAAAAADQOPwiOKY9xjQwNmbMGElKqrr3Aw5KTU2VxYsXm/xzd/FWe4wRGKsbzTfNP3fBBuqrd+qros56vr4q6qx36isAAAAAAACAxuEXwTEbDYwlJyc39m4ANUJ9ha+hzgIAAAAAAADwB8GNvQMAAAAAAAAAAABAQyE4BgAAAAAAAAAAgIBBcAwAAAAAAAAAAAABg+AYAAAAAAAAAAAAAgbBMQAAAAAAAAAAAAQMgmMAAAAAAAAAAAAIGATHAAAAAAAAAAAAEDAIjgEAAAAAAAAAACBghDb2DgAAAASSrMJS+XlHnmQXlsnO7GKn10rKLHl3Xab5OzkuVI5oGy2hIUGNtKcAAACNpzRzlxRu+UmkpFCKtv3i9FpZzl7J+2Wh+Tu0dW8J7zCwkfYSAAD4KoJjAAAADSS7sFQmvLtddmaVuH29uExk9rep9uejusfK/Se2oXwAAEBAKU7ZKPteGCtWYY7b18v2b5XMJXfan8edPF1ih1/egHsIAAB8HcMqAgAANJBfduVXGhhzZ9nmHMktKvPqPgEAADQ1BWs+qjQw5k7eyje9uj8AAMD/EBwDAABoIB3iw2q1fovoEIkOY1hFAAAQWEJadKrV+qHNO3ttXwAAgH8iOAYAANBAureIkCPbR9V4/YsGJEpQEMExAAAQWKL6nSHBca1qvH7MUZO8uj8AAMD/EBwDAABoQFcMal6j9ZpFhsh5fRO8vj8AAABNTVBYhMQefXWN1g3vNETCOw/1+j4BAAD/QnAMAACgAR3aJqpGvcfGH5YoUWE01QAAQGCKHnRhjXqPxR5/HT3tAQBArXHFBQAAoIn1HqPXGAAACHQ16T1GrzEAAFBXBMcAAACaWO8xeo0BAABU33uMXmMAAKCuCI4BAAA0od5j9BoDAACovvcYvcYAAEB9EBwDAABopN5j/ZIiXJbTawwAAMC591hQRKxLltBrDAAA1AfBMQAAgEZyeYXeYyFBIuf1TaA8AAAAHHqPRQ042yk/gmKTJLzzUPIIAADUGcExAACABlZSasn61ALZm1sirWNC7Ms7JoTK3B/T5N11meZ1XQ8AACBQWaXFUrzrDwlJ6iZB4TEHlgZJSGJ7yfrwLsn7ZaF5XdcDAACojdBarQ0AAIA6251dLO+uy5J312dKVmFZeWMs6ODrWzJKZHtmlpQciInFRwTLOX0S5Jy+8ZIcF0bOA02AZVlSUloqJSUl5v9wy5KgIIcTGUCTwjnrm0oydprAV96K18UqyCxfGGy7hGVJyY5VUrLrD5GyhWZJUGSCRB9xkUQPHiehie0ab8cB2PH5C/gWKwB/5xAcAwAA8LKcwlKZ+1OafLAhW7RtWebQIcwWCHP3XANor6xOl5d/S5cze8fJtGFJEhtOx3+goeXk5klKappkZudIdk6ulJaW2l8LCQmRuNgYSYiLldZJLSU2JpoCAhoZ56zvKivIlqylsyV/5SIxjSarzOHFkgorH3yuAbTc756V3G+fkajDx0r8qOkSHBnXgHsOQPH5C/iWnAD/nUNwDAAAwIt+2p4n9yxPkfSCUtG4l1XLkRJtgbQlG7Pl+215MuO41jK0g/81SoGmKG1/umzdvksys7NF75l0d/rqD8iMzCzJzMySrTt2SUJcnHTq0FZaNm/WCHsMBDbOWd9WuPlbyVh8s5Tl7iv/xK1to+lAIC1/1VtS+OdySRzzsER0P8Y7OwvACZ+/gG/hnC3HrccAAABesmhNhkz5eJfszy916i1WF/p+3Y5uT7cLwHuKi4tl7YZN8vu6jSYwpqo7hW2v6/r6vrUbN0lxcYVeDgC8gnPW9+X+/Irsf/Vf5YExx95idWGVSVlumtle7s+vemoXAbjB5y/gWzhnndFzDAAAwAs0gDXn+zTzdz3jYna2AJttu2P7J3poywBscnJzZdWa9fUObKWk7pP9GZkysH9fvxyCBGgqOGd9nwawsj6eWf6kvoExmwPbyfr4HvN/zJHjPbNdAHZ8/gK+hXPWFT3HAAAAvDCUoi2A5S26fU0HgGd/MP76+zqP9fjS7fz6+1ozlj8Az+Oc9Y+hFG0BLG/R7Ws6ADyHz1/At3DOukdwDAAAwINyCkvNHGPBOkGRF+n2Z36VIjlFHrrDGghwOsSI9hhznITaE3R7q9Z4LuAGoBznrO8rK8g2c4xJkJcvTQUFS8biW0x6AOqPz1/At3DOVo7gGJq09m3byM+fvC5/fL3YPJ799wy36z33yAz7Oj9/ulA6tktu8H0FqK8A1Nyf0iS9oP5zjNV0DrLHf0wl4wEP+POvf7wWwNLt/vn3Fq9sGwhUnLO+L2vpbM/MMVbDOcg0PQD1x+cv4Fs4ZytHcAxN2o5de+TfT79kf37UEYfJuDGnOq1z0TmnybDBh9mfPzL/Jdm2c3eD7iegqK8AdmUXywcbsr0eGLPRdN7fkC27s4vJfKAe0vanS0raPq/moc5BpukAqD/OWd9Xkr5D8lcu8n5gzMYqM+mVZOxsmPQAP8XnL+BbOGerRnAMTd5bS5bJNz/+Yn8+7aoJ0ql9W/O3/q/Pbb77eaUsen9po+wnoKivQGBbvC5Lgrw8nGJFmt7i9VkNmyjgZ7Zu3+VX6QD+jnPW9+X9+kZ5I6YhBQVJ3i8LGzZNwM/w+Qv4Fs7ZqhEcg0+Y8fDTkp5RfuEvOipSZt1+nYSFhcoDd0yVqMgIszwjM1vufuipRt5TgPoKBKqSUkveXZ/ZYL3GbDS9d9ZlmvQB1F5Obp5kZjfMPDSajqYHoO44Z32fVVoseSteb7heY/aEy0y6mj6A2uPzF/AtnLMeDo7Nnj1bjjjiCImLi5NWrVrJ2WefLRs3bpRAVVBQIPfdd59YliVffPGFXHfddTJ16lT59ddfXdYtLCyUBx54QKZNmyY33HCDfPLJJ/bXnnrqKdm9m2EAq+sCev9jz9qfH9qvlyx85mEZ0Lenfdn9jz0jqfsYqqa6+rplyxa544475MYbb5Rbb71V1q5d63b9xx9/3NRnXe/111+3L1+4cKGsWbOmyvIKdNRXz3/GqvT0dJk4caJ8+umnLuvyGYumYNP+QskqdL3IU1qQKxvnTjR1OfW7RfLHXSfJHzNOlozfv3Rdtyhf/nzyMlkzY5SsmXmqpCx/xf7alpdukYKUf9ymrelu3l/o4SMCAkNKapo49l3Iz8uTm6dNkU1/bpRrr7pcLptwsVw1aaL8tmql2/fPmnm3TLzoArPe8888bV/+wnPPyKpfD45+oIIOpAfA8+esrc24Ly1NRo86Ud575y237cvbbrpe/nXxBTJp/EWy+O2D6zw4617ZsX0752wDKEnZIFZBpsvy3KIyGfvqblOWC1ZmyfCntsnR87bLZ3/muqybV1wmFy/YLcfM2y7Hzd8uL/zv4PamvrdX/t7nPgCm6ZakBO51LKA+aDMBvoU2k4eDY19//bVMnjxZfvrpJ/nss8+kuLhYTj75ZMnNdW2oBAINiA0bNkxycnLkgw8+kIceekhmzJghr7zyipSWlrqsr8HEuXPnmiDZ0qVLZc+ePWb5yJEjZcmSJY1wBL5l2Vc/yIfLvrY/79W9i/3vjz77WpYu/6GR9sy36mtkZKRMmTJFHnnkEfP//Pnz3a4/YsQIU1+1XmsQ3BYQ03P+/fffb+C99z3UV8/V2aADw60sWLBADjnkkErX5zMWjW19qvvgVNr3i6T5oFOlNDdD9nz2vPS94z3pdf2rsv3t2WKVlrisnzzqSuk/c6n0ufVtSf1qgRTs3WqWJx1zoez5/PnK008jOAbURWZ2jjj2u/z4ww9kxAknSlRUtNx+9z3ywisLZPpd98i/Z89y+/6Rp5wqLy14Q5598WVZu+YPe0DszLPPkTdff81pXU0nKzuHggK8cM7a2oz/efZpGXTEkErfP+7i8fLSgjdl3rPPy/uL35adO8oDYqPPPFsWvbGAc7YBFO9yf7Pl6yuz5cy+MZKeXybzf8yUpVe0l7cnJMvMZfulxE3X/GuHJ8q3kzvIR5e1k5dWZMmW/eUBsUsGxcszP2bUOn0AVaPNBPgW2kweDo7p3fr/+te/pF+/fnLooYfKSy+9JNu2bXPbUyoQfPfddzJ48GBZvXq1DBw4UKKioqR58+bSrl07+euvv5zWjYiIkL59+5q/NTjRtm1b0wtC9ezZ0/TeKStr4CEFfNADjz8ne9P2Oy1L25cus+Y+12j75Gv1NTk5Wdq0aWOWaV3Vuyfd1b3DDjvM/MAMDQ2Vzp07y/795fneokULExDPymJ+m+pQXz1TZ9W6deskOjpaOnbs6HZdPmPRFGxMK5RQN1Nn7Pvfh5J46EmSue5bSeg3QkIiYyU8sbVEJXeX3K1/OK0bEh4lcT2PLP87MkYiW3eR4sy95nlM14GSvfFnscpcb8AJDRbZUElwDkDltHdCdo7zjX5ffL5Mjjr6WGnfoYO0bdfeLOvUubPk5+e7vQFuyJHD7G2mbj16Slpqqlme1KqVZGdnS8aBNr9NVk6uvYcLAM+ds+r331ZJTHSMdOnaze379bf4oQMPN39HRUdLh46dZN++feZ53/6HyG8rV7qc55yznle8e61IcKjL8sVrcmRUr2j56q98ObF7lMRGBEubuFDpkRQmv+10budEhwXLsM5R5u+Y8GDp1iJM9maX33Q0uH2E/PBPgZS6G+s6OFSKdxMcA2qLNhPgW2gzNcCcY5mZ5d3WNSBUGR3qSi+iOz78gfaa0+NPTEw0QQPHPNC/bYEEd9LS0mTr1q3SpUt5zyf9MZ2UlCQ7duxokH33Za2TWkpCXKzTsoT4WGnbplWj7ZOv1VdHK1askK5du0pwcOUfBXohaOXKlfbgrurUqZNs2rTJq/vsD6ivnqmzeoFi0aJFMnbs2Bq9l89YNJa0vFIpqXANpqy4UEqy0yQsvqUUZ+w1QTGbsMTWUpRe3ovcnaL9uyVv50aJ7tjP3l6IaNFOCnY734CjSspE9uW7XrQHUDX9jnG8EF5UVCTp+9Ndft98/+3X0qNXLwkJCal0W3l5ufLzj9/bL7yrbt17yPp1a92kyU1xgKfP2dKSEnnphf/IxMsur9G29qakyN9/bZYePXvZv2fbJCfLtq3OQxhzznpeaXaqSJlz7/nCEktSc0slKTZUUrJLTFDMRv/ecyDw5c7OzBJZv7dIDkmOsJdl+8RQ2ZTmZmjFshIpzSm/iQFALc5b2kyAT6HN5OXgmPY00fmzhg8fLv37969ynrKEhAT7o0OHDuIP9C7QmJiYOl3w1aHqxo8fb+5as4mPj5eMjMq7/UMkNCREHrhjqkREhDtlR1hYmMy+Y5qEhbneeYbK62tKSoq89tprMmnSpCrvMpg3b54ZSrFly5ZO9dXW8xHuUV89V2d1GNqhQ4dKbKxzYNwdPmPRmIrcXOwuyc2QkOj4Wm9Lg2p/PT9V2p9zi4RERNuXh8Y2l6IDPckqKtQIGYDanWsVenBlZWWa+ZUd7dq1U56bP0+mTLuhyjbTww/cL6PPPkdatT4YBE/QG+kO9EpxXp/zFfD0Ofve4nfk2ONPkPj4hGq3o0G1++65U678v2vNCDA2emOWrScZ56z3WCWuvd3T80slIbL2l6g0qHb1Oyly10nNJTr84PtbRIeYIJvb9IvpbQ/UFm0mwLfQZqqZOkcTdO4xnYNIh72qyvTp0+WGGw7+kNSeY/4QIAsPDzcXYZXepbZ582b7a9prrFmzZm5/ND/11FNmCEa90Fuxca7bROWumXSh9OnR1f584bsfy7hzTjN/9+jaSaZcdrE8+szLZGE19VXpPHkPP/ywXHnllfYhFt3ROZ40IDF69Gin5bot6mvVqK+eq7P6+bphwwYzN6MO6ak9HfX1E044wek9fMaisYWHuF7QCQ6LEKu4yPwdlthKcv85OIxicUaKU08yx7q85aVbJKH/CDNXmaOykkIJDj94c42jCB1bEUCtBB+Yo8h+HoeHS1FRodOF97un3yLX33SrtGtf+W8YDZ7FxsbJ2Asvcm3jR5T3ZHAUFMT5Cnj6nN24fp388fvvsmjhAvN7R9uMEZGRcurpo12+Zx+ada8cOfQoGXH8CS7nrA7XzTnrXUGhrnkcERpkAl2qdVyorN5VYH9Ne43psoq0LK97b6+c2D1azugb63LTUGSY+8/aoDDX9AFUjTYT4FtoM9VMnX6VXXvttfLhhx/K8uXLpX378nH4K6MNS+1l4vjwBxow0IazdlEcMGCArFq1ygw/p4ExHR6xe/fuZr17773XPsTi66+/bvLj3HPPddme9uLR+Z/g3qH9esmlF46xP3/3o8/lgcf/I+98+Jl92YSxo+XwAX3Iwmrqa0lJicyZM8cEvCr2+tTgrS3Qu2zZMtmyZYtcfrnrsCR79uyp9twPZNRXz9bZ6667Tp5++mnTi/G0004zwyvaAmN8xqIpaRkd4jLnWGhMopQVF4hVWiLxfY+WzLVfS2lBjhRlpEj+rk0S03mAWW/jYxPsQyzufO/fJgDW9rTJLmkUpm6TqDau86hoXKxFVOXDvQFwT4dJdBwqUXucFBYWmeHZ9CaNGbffJuddcJEMHFQ+B6bNg/fPlA0Hhktc8t67snnTnzLtpltctr9r5w4zX5lrmgTHAE+fs7ffPVMWvr1YXn9rsZx7/gXyr0mX2wNjN029VlJTy3teP//sfImIiJRLJl7q5pzdKR07cc56W0hcksucY82iQqSgxJKSMktGdIuSLzbnS05hmQmM/ZlaJAPblQe0xr6yS3ZnlfcIe+CL/RIVFiTTjnW9Ofmf9BLp0TLMNfHgUAmJTfLWoQF+izYT4FtoM3mh55jelTNlyhRZvHixfPXVV/Y5swKVzsGk8y717t3bBBpuueUWc3fahAkTTAXU/NIggl7k1aEZ3n//fRNQuPnmm837L774YjnssMPM8GEaNKs4hAvKRUVGyKzbr5PQ0PIfQTt2p8hDT75g/n7oqRdlyMBDpEO7NibPZ02/Ts6ZdL3k5x+8ywzO9XXv3r3m/7y8PPnoo4/Ma3fffbepf9u2bbP3enzxxRelVatWpven0qDE8ccfb4ZU1WBu5woXekB99eZnrDt8xqKp6dUywmXOMRXXY4jkbFktcd0HSZuTJsm6WWeJBAVLh/OmS1BIqKnLhalbTSCtKH237Fn6nEQmd5e195df0Gs/5hZJ6HeMlOSkS3B4lITGul4A0hEVeydxFzRQWzovTVxsjGRkHpwX+dDDDjPzhO3evdv8r72W333rTfPanLlPmqHit/z9l7RoWX5x9Ym5j0pycrJcc0X5UNXnnDdWTjn9DHODx+5dO828Y47iY2NMugA8e872H3Co2/fo9+zOnTvNjbqpe/fKGwtelU6du8iVl04wr19x9TVyxJFDzXy3EZER5hznnPWusOR+ImULXZYP6xQpK3cUypCOkXL10AQ5+bkd5s73u0e2kNDgoPLe9eklkhgVLLuySmTeD5nSMylMTnq2fP72O09sLsd1j5b9eaUmaNY82s2NQ2UlEpZc+dQgANyjzQT4FtpMXgiO6VCK2vtJgzx6IV0DP0obj47jdAcKnYdJg4R64fakk04yD0faAD/yyCPNUA8tWrSQRYsWud3O999/7zI8GA666ZpLpVP7tuZvvchw5wNPSN6B4JcGwW5/4HH57+P3m+BZ+7Zt5JZrJ8nMOU+ThZXUVx1K8dhjj3XJn4KCAjPEotZV9cYbb7jNQ+0lOWTIEBMIhivqq3c+Y22015gNn7FoavpUEpxKGnGR7PvxXRMcSzrmQvNwVLDnL2k2cJTpLRYeniyDn9nkdjv7V3woScPPrzz9lgTHgLpIiIuVzMwsscW2zxxzriz95CMzlOLIUae4rK+jRegQi0mtWpnnn33lfpj5//30oww/ZoRTLxcNicXHVT+HJoDan7OOwbGJkw6OfrFt61Y5ZsRxprdYUqtI+eLbH91ud/nny+S0M850WsY56x1hbd0HpyYOjpdFq7NNcOySQfHm4WhzWrGc3jtGosKCzWPX3QenXXD03pocuWhgXK3TB1A12kyAb6HNVL1aXd2eP3++uZvquOOOM3dH2h5vvll+J2Wg6dmzpxk+Ue9eckd7iU2cOLHa7URHR8uIESO8sIe+b/iQgTL2rFH256++tUR+/X2d0zq/rdkgLy5cbH9+3hkj5Zihgxp0P/2hvkZGRjrND1gZDVCeccYZXthD30d99Sw+Y+FrejSPkPgI16ZVbNeBZvjEyj5/o5K7S4fzb692+yFRcdJi6MEhhh1put2bExwD6qJ1Ukv7RXbVt19/6d2nb+XnbFSU3H3vrGq3W1paIudfMM5pmXUgPQANd87q0KbXTJla7XZjYmLl5FHOc31yznpHaOveEhTp3ENPDWofKYe1jai0LHskhcs9o8pv5qxKfGSwnH+o++CYphvaulcd9hoAbSbAt9Bm8sKwinDmiR5f7nrxoNz3/1slh4xwfyHQ0ZPPLzAPeL++aq8xuEd99Tw+Y+FLQkOC5Jw+CfLK6nQpq9BkallFj6+aajH0bLfLg4NEzu2bYNIHUHuxMdGSEBcnmdnZ9mW2eYrq4+hjj3NZpuloegCa3jk78hTnwJjinPWOoJAwiT7iIsn97lkRq8zptXED6z9P/XkDKuk1FhRs0tX0AdQebSbAt9Bmqh7jogEAAHjIOX3jpaHvJdL0xvSp/4UkIJB16tDWr9IB/B3nrO+LHjyuvBHTkCyrPF0AdcbnL+BbOGerRnAMAADAQ5LjwuTM3nGmN1dD0HTO6h1n0gVQdy2bN5PWLasfqqs+Wie1MOkAqD/OWd8XmthOog4fa3pzNYigYJOepgug7vj8BXwL52zVCI4BAAB40LRhSdI8KsTrATLdvqYzdViSdxMCAkTPbp0lLKxWo87XmG63Z9cuXtk2EKg4Z31f/KjpEhzT0vsBsqBgk46mB6D++PwFfAvnbOUIjgEAAHhQbHiwzDiutcu8Y56m29d0ND0A9RcWFiYD+/eVkJAQj2anbk+3663AGxCoOGd9X3BknCSOedhl3jGPs8pMOpoegPrj8xfwLZyzleNqCgAAgIcN7RAtNw9v6dV8veXoJJMOAM9OWj1oQD+PBbJ0O7o93S4Az+Oc9X0R3Y+R+NPu8Woa8afPNOkA8Bw+fwHfwjnrHsExAAAALxjbP9EeIPPUEIu27Whg7Px+CZ7ZKACXH45DDz/MzBFWH/p+3Q6BMcC7OGd9X8yR4w8GyDw1xOKB7WhgLGbIJZ7ZJgAnfP4CvoVz1hVjewAAAHgxQNYxIVxmfpUi+/NL6zXUom2OMR1KkR5jgHdpj69+vXpI66SWsnX7LsnMzhaNTVd1CtteT4iLk04d2prJrwE0DM5Z/wiQhbboLBmLb5Gy3LT6DbV4YI4xHUqRHmOAd/H5C/gWzllnBMcAAAC8SANZb43tKHN/SpMPNmRLUFD5fGG1CYpZlsjoXnEybVgSc4wBDUgDXPrIyc2TlNQ0ycrOkaycXCktLXWaUyw+Nkbi42JNMI2eYkDj4Zz1bRrISpqyTLKWzpb8lYvENJpqEyTT3mKWJVEDz5f4UdOZYwxoQHz+Ar6Fc7YcwTEAAAAvi40IkTtHtJbLDm8ui9dnyTvrMiWr0Haxx3LqdxIaHCQlB16KjwiWc/smyJg+8ZIcF0Y5AY1EA16xMR3N35ZlSV5BgeTk5UtsdJRER0ZKkF7ABdBkcM76ruDIOEk86wGJHTFZ8n5ZKHkrXherINOlxVS+cqhIWUn5ssgEiT7iIokePE5CE9s1zs4D4PMX8DGxAf47h+AYAABAA9EA1zVDWsiVg5rL5v2F8vnfOfLybxn214ODguTMXvHSOylC+rSMkO7NIyQ0xL8bo4Cv0R+IoSEhEhoaav739x+MgK/jnPVNGuCKP+kmiTt+qpSkbJSc75+XgjVL7K8HRSVKVL9TJSy5v4S17S+hrXtJUAg3EgFNCZ+/gG8JCsDfOQTHAAAAGroBFhIkvZMipbhMnIJjESFBMv3YVpQHAACAXqgLCTPBr/COg5yCYyFJPSRh9P3kEQAAqLPgur8VAAAAAAAAAAAA8C0ExwAAAAAAAAAAABAwCI4BAAAAAAAAAAAgYBAcAwAAAAAAAAAAQMAgOAYAAAAAAAAAAICAQXAMAAAAAAAAAAAAAYPgGAAAAAAAAAAAAAIGwTEAAAAAAAAAAAAEDIJjAAAAAAAAAAAACBgExwAAAAAAAAAAABAwCI4BAAAAAAAAAAAgYBAcAwAAAAAAAAAAQMAgOAYAAAAAAAAAAICAQXAMAAAAAAAAAAAAAYPgGAAAAAAAAAAAAAIGwTEAAAAAAAAAAAAEDIJjAAAAAAAAAAAACBgExwAAAAAAAAAAABAwCI4BAAAAAAAAAAAgYISKH0lNTW3sXfAp5Bf570uor42PMiCvAAAAAAAAAH/gF8Gx6OhoCQsLk8WLFzf2rvgczTfNP3eaJcRLeHiYFBUVN/h++TrNN80/d6iv3qmvijrr+fqqqLPeqa8AAAAAAAAAGodfBMcSEhJk8uTJkpeX19i74nP0wq3mnzvJrZPkw9fmSXpmVoPvl6/TQIPmnzvUV+/UV0Wd9Xx9VdRZ79RXAAAAAAAAAI3DL4JjSi9AchHS8/SCeVUXzVE31Ffvoc56B3UWAAAAAAAAgL8IbuwdAAAAAAAAAAAAABoKwTEAAAAAAAAAAAAEDIJjAAAAAAAAAAAACBgExwAAAAAAAAAAABAwCI4BAAAAAAAAAAAgYISKn8jMzJS8vLzG3g2fEx0dLQkJCZW+vjslVdIzsxp0n/xBs4R4SW6dVOnr1Ffv1FdFnfV8fVXUWe/UVwAAAAAAAAANzy+CY3rRdt68eVJcXNzYu+JzwsLCZPLkyW4v4GqQ4YxLJktREflaW+HhYfLha/PcBhyor96pr4o66/n6qqiz3qmvAAAAAAAAABqHXwTHtMeYBsbGjBkjSUlV937AQampqbJ48WKTf+4u3mqPMQJjdaP5pvnnLthAffVOfVXUWc/XV0Wd9U59BQAAAAAAANA4/CI4ZqOBseTk5MbeDaBGqK/wNdRZAAAAAAAAAP4guLF3AAAAAAAAAAAAAGgoBMcAAAAAAAAAAAAQMAiOAQAAAAAAAAAAIGAQHAMAAAAAAAAAAEDAIDgGAAAAAAAAAACAgEFwDAAAAAAAAAAAAAGD4BgAAAAAAAAAAAACBsExAAAAAAAAAAAABAyCYwAAAAAAAAAAAAgYBMcAAAAAAAAAAAAQMAiOAQAAAAAAAAAAIGAQHAMAAAAAAAAAAEDAIDgGAAAAAAAAAACAgEFwDAAAAAAAAAAAAAGD4BgAAAAAAAAAAAACBsExAAAAAAAAAAAABAyCYwAAAAAAAAAAAAgYBMcAAAAAAAAAAAAQMEIbewcAAAACSXGpJetSCyS7sEz+yShyeq20zJLvtuaav9vEhUq3ZuESFBTUSHsKAADQeMoKc6R452qxSoqkeO+fzq/lZ0jBn8vN36GtekpoYrtG2ksAAOCrCI4BAAA0kPziMrnyg52yIa3Q7etFZSLXf7rb/vyC/gly0/AkygcAAASUkv1bZd8LF0hZTqrb18tSN0n6gsvtzxPOfkiiB57XgHsIAAB8HcMqAgAANJAVO/MrDYy58/baTMkrLvPqPgEAADQ1+avfqzQw5k7uD897dX8AAID/ITgGAADQQFpEh9Rq/djwYIkMZVhFAAAQWIJjk7y6PgAAAMExAACABtI3KUL6t4qo8frn90uQYOYcAwAAASbqkNESFJVY4/Vjjpzo1f0BAAD+h+AYAABAAwkKCpIrBjWv0box4cEybkDNLwoBAAD4i+DIOIk96rIarRua3E8iep3o9X0CAAD+heAYAABAAxrWIbpGvcfG9U+Q+IjaDcMIAADgL6KHjK9R77G4464zNyABAADUBsExAACAJtZ7jF5jAAAg0NWk9xi9xgAAQF0RHAMAAGhivcfoNQYAAFB97zF6jQEAgLoiOAYAANCEeo/RawwAAKD63mP0GgMAAPURWq93A17Wvm0beeeFRyU6Oso8/2HFb3LVTTNd1nvukRkybPBh5u+8/AI5/7IbZNvO3ZQPGhT1FUBte491bRYuf6cXOS2n1xgAAIBz77Gcb54WqzjfKVvoNQYAAOqDnmNo0nbs2iP/fvol+/OjjjhMxo051Wmdi845zR4YU4/Mf4nAGBoF9RVAbXuPTRzoPEyQTiU/bkD1E88DAAAEUu+xiL6jnJYFRSZIRK8TG22fAACA7yM4hibvrSXL5Jsff7E/n3bVBOnUvq35W//X5zbf/bxSFr2/tFH2E1DUVwA1UVJqyfrUAikotiQ+4mBzrG1cqMz7eZ+8uy7TvK7rAQAABCqrtFiKd/0hYcn9RELC7cuDE9tL1od3Sd4vC83ruh4AAEBtMKwifMKMh5+Wd/87V5olxkt0VKTMuv06uXTqnfLAHVMlKjLCrJORmS13P/RUY+8qQH0FUKnd2cXy7roseXd9pmQVlpllodpd7ICd2SXywYYsKTkQE9PA2Tl9EuScvvGSHBdGzgJNgGVZUlJaKiUlJeb/cMsyPUEBNE2cs76pJGOnCXzlrXhdrILM8oXBBy9hle5ZK3l7N4qULbT3JIs+4iKJHjxOQhPbNdZuA3DA5y/gW6wA/J1Tq+DY/PnzzeOff/4xz/v16yd33323nHqq8zB3gaKgoEDmzJkjd955p3z55Zfy/vvvmwozYcIEGTRokMv6M2bMkLy8PFPBhg8fLuedd55ZPnv2bJkyZYrExsY2wlH4hrT96XL/Y8/KIzNvNs8P7ddLFj7zsPTq3sW+zv2PPSOp+9IbcS99o75ecskl8vzzz5vnoaGhpr7quVzR3LlzZefOnVJWVia9e/eWyy67TIKDg+Wpp56Sc889V5KTkxvlOHwB9dXzn7H62Zqeni7Tpk2TcePGySmnnOKyPp+xaMpyCktl7k9p8sGGbNG2ZZlDhzBbIMzdcw2gvbI6XV7+LV3O7B0n04YlSWw4Hf+BhpaTmycpqWmSmZ0j2Tm5Ulpaan8tJCRE4mJjJCEuVlontZTYmGgKCGhknLO+q6wgW7KWzpb8lYt0DGoRq8zhxZIKKx98rgG03O+eldxvn5Gow8dK/KjpZjhGAA2Lz1/At+QE+O+cWgXH2rdvLw8++KD06NHDRBJffvllOeuss2TVqlVuL677uy+++EKGDRsmOTk58sEHH8hDDz0k+fn5MnPmTDnssMNMBXJ06623SnR0tKlkGlTUAFqXLl3kmGOOkc8++0zGjBnTaMfiC5Z99YN8uOxrOePkEea5Y2Dso8++lqXLf2jEvfOd+hoZGWmCsW3atJEdO3aYc1oDXhVdeeWVpr7quf7YY4/JL7/8IkOGDJGRI0fKkiVLzOuoHPXVc3XWdpfKggUL5JBDDql0fT5j0VT9tD1P7lmeIukFpaJxL6uWIyXaAmlLNmbL99vyZMZxrWVoB/9rlAJNkd7wsnX7LsnMzjZzAro7fbVtn5GZJZmZWbJ1xy5JiIuTTh3aSsvmzRphj4HAxjnr2wo3fysZi2+Wstx95Z+4tW00HQik5a96Swr/XC6JYx6WiO7HeGdnATjh8xfwLZyz5Wp16/Ho0aPltNNOM8Gxnj17yqxZs0xvp59++kkC0XfffSeDBw+W1atXy8CBAyUqKkqaN28u7dq1k7/++stlfQ002H5Aa+8x2wXfww8/XH74gcBOTTzw+HOyN22/07K0fekya+5zHinTQKiv2uNLA2NK66r2ztHeYZXVV32tuPjg+O167q9du9bte+CM+uqZOqvWrVtn6mTHjh0rXZ/PWDRFi9ZkyJSPd8n+/FKn3mJ1oe/X7ej2dLsAvEfbPms3bJLf1200gTFV3Slse13X1/et3bhJiosr9HIA4BWcs74v9+dXZP+r/yoPjDn2FqsLq0zKctPM9nJ/ftVTuwjADT5/Ad/COeuszuPyaIDnjTfekNzcXHNnf2UKCwslKyvL6eEvFSkzM1MSExNl//79Jihmo3/rMnd0eLDLL7/c9H7o3Lmz/YKubk+HXETVtAunduV0lBAfK23btCLralhfHa1YsUK6du1qhkt055FHHpErrrjC9DazBSk0qJuUlGR6nYH62hB1Vr9vFi1aJGPHjq32fXzGoinRANac79PM3/WMi9nZAmy6XQJkgHfk5ObKTytXS0qa9lyou5TUffLTyt/MUCUAvIdz1vdpACvr45nlT+obGLM5sJ2sj+8hQAZ4CZ+/gG/hnPVAcOyPP/4wvcUiIiLk6quvlsWLF0vfvn0rXV/n00pISLA/OnToIP4gOztbYmJiav2++++/X5599lnZunWrbNu2zb48Li7OXAhG5UJDQuSBO6ZKRES40/KwsDCZfcc0CQur1SihAcVdfU1JSZHXXntNJk2aVOn7brzxRnnuuefM0Ipr1qyxL4+Pj5eMDHotVIX66rk6u3TpUhk6dGiN5mXkMxZNaShFW2DMW3T7mg4Az/5g/PX3dR7r8aXb+fX3tQTIAC/hnPWPoRQ1gOVNun1NB4Dn8PkL+BbOWQ8Fx3r1+v/27gM6jups4/izTb1Zltwb4I4xGJviADbFQAgx4NBCD5BKDx8lkIQWOimQUEIgCYEEE0hiakIJxBA6tjHgiu24F1myeltpy3fuyJIl7a60knYl7ez/d84eaWdn547uO3d2Ne/ceydo6dKl+uijj/SDH/xAF1xwgTXcVSQ33HCDlfRpfmzevFl2kJKS0jLUXPueYub3AQMizzFghl+cMmWKVY/NGhoarG0isksu+qYmjdu75fn8f/yz5fdxe4/W5RefQ/VFcbwaZp68e++915o3rHmIxUjcbrc115jpZcbxGj2O19gds2vXrrXmdbz00kv1z3/+0+pF9tZbb0V8L+dY9LVqr9+aY8zZNHpy3Jjt37qwSNUNDHMLxIL53Pl02co2k1DHgtnep8til3AD0IQ2m/gC9VXWHGNydHtQo+g4nCpfcJ1VHoCe4/wLJBbabGTO7lywHDt2rKZPn271Ctt///31wAMPRFzf9DAzvUxaP+zA9GAwCS3zz+7UqVP16aefqq6uzkqMmeHmTB0Zt912m7XMDJnYPKSkOSDNPGVmvqfWyYqOEmrJbv99J+jCb85ref6PV/6tOx94TH9/+Y2WZeefMVcHTp3UR3uYOMerme/uvvvus+YQNEna1h588EErEWHWKS4utpaZucWWLFnS5ng1vc5aP0dbHK+xPWavuOIKPfzww3rooYeseS/N8IpHH320tR7nWPRH939YorL6ns8xFu0cZA980HS+BtAzX67bELcEltnul/9bH5dtA8mKNpv4Kl+7KzZzjEU5B5kpD0DPcf4FEgttNrIej0NnLpybecWSkRlOcs2aNZo4caKVaLjuuuusuZvOP/98uVwuayi6HTt2WBd5Ta85M3+TSTqY5WaeNpNgNDZs2KB99tkn4rxPyS49LVV33HiF3G6X9XzL9iLd85vfW7/f8+AfdPC0/TRy+BCrzu+44Qp946Ifqq6uvo/3uv8erzt37rR+moTtK6+8Yr120003WUN7mqE+TZLWJCTuv/9+1dfXt7z32GOPbRnuziS9zfoIxfEan3NsOJxj0R9tq2rUi6uqYjbHWDQJshdWVemiA/M1NNvTS6UC9lNSWtbjOcaimYPMzJ9bkM8NcUBP0WYTn69si+qWPBvDmVk7EQxY5WXNvlTuPG70BLqL8y+QWGizMUyOmSESTzjhBI0aNcq6QP70009r4cKF1nwwyei4446z/n5z4XbOnDnWo7WtW7fqkEMOsXrbFRYW6u677w67nXfeecfaFsK75pILNXrEMOt3k7T5yZ2/Vu3u5JdJgt145wP64wO3W8mzEcOG6LrLLtKt9z1MdUY4Xs1QirNmzQqpH5MIM0MsDhw40Hp+xx13hK3D9957r6XXDjhee+sc28z0GmvGORb90YIVlXI4TPK298o05S1YWalLDm46fwPouo2bt/VaOSTHgNi0pd5Am42f2sXPqC++NNUumq+cOdf0XpmAzXD+BRILbbZjXeqqZHqcmF5RZt6xY445xpqDyCTGmnuUJJvx48dbwyea3gvhjBgxwpqTrTNmvfbD26HJYQdP0xknH99SHU8995I1SXprS5et0h/mL2h5ftrXj9URhzb1ykP0x2taWpquvvrqTqssIyNDs2fPpmrD4HiNLc6xSDQ+f1D/WFkR9+EU2zPl/X1FhVU+gK6rrqlVRVXvzENjyjHlAeg+2mziC/obVfvJ0/EfTjGk4IBVrikfQNdx/gUSC202xj3Hfv/7pqHssEcsetDQCyey9z7+VPvN3jPXWCS/efwv1gPxP9bC9TpDE47X2OMci0SyptSrSm/oRR5/fY3W/vYSjb/yCZW895x2vPY7yenUyFN/pLypoeflVT8/S/66auvCTf5BJ2rYiZc3bf/Bb2uvC38hd2ZuyHtMuWtLvZpYmBanvw6wr6LiEjlaDexVV1urm268Xt+95DI98Iv7rHmF3W63fnD5lTpg2oEh77/9lpu0ccN6a7j5/aburyuuvsYaLv3uO27TuedfqBEjR7as69hdXlbmqF78C4HkaLP3/urXcjgc2lVSom+dc6Yu/u73dcqpp4e8/6rLfqCa6mpryoOjjpmj8y+82Fp+47X/pxtuulnZ2XvmSafNxoevaJWC9RUhy2saArrwr0X667lD9PSnVXr4/XIrpjcfm69jx2eGrD/viW2q8gbU6A/q5H2zdPXspmFrz3t6u34zb5Dy0pumZmjNlOsrWi3PMG5QBrqK70xAYuE7U+eY5AoAACAGVhaHn4O15L1nlT/9BPlryrXjjcc1+cfPa8IPn9Lmv92loN8Xsv64S3+nfX/6kvb96cuqWPa2ajctt5bnH3ySiv87P3L5Jck5ByzQUxVV1W1mvPnnyy9q9tHHKD09QzfedIt+/+RfdMNPb9HP7wo/5PQPr71ejz3xlB7/059VUVGu9999x1o+96RT9OwzbW/eMuVUVlUTNCAObdYkUYzHHn1Y0w86OOL777jn501t9omn9PGHH2jNl6ut5cccd5xeen7PiCS02fhp3LYs7PKnl1TppMmZKqsL6JEPKvTad0bob+cP1a2vl8oXpmv+k2cN0b+/N0Jvfn+E3lpbqy+2N30Xmrdftp5aXNnl8gF0jO9MQGLhO1PnSI4BAADEwOoSr9xN1+Xa2PXxy8rbf44qVvxXufvOlistSyl5g5U+dKxqNn4Rsr4rPdv6aRJnVvJs98W+vP2OUumiV8KW7XZKqyIk5wBEZoabrqquabPszX+/rq8cPsvq8TVs+Ahr2egxY6weZGb+2/YyM5t6MwT8fjU2mqG6mtrs5Cn7aemSJSHvqayuiTjMNYDut1nj86WfKjMjU3vtvU/EbTS3WZ/fZ/Uea06qHfqVw7XwrTdD1qfNxl7j9uWSM3QgowXLqnX8hAwtXFenY8amKyvVqSHZbo0r9Gjp1tDvOdmpTZe0TM+xxkCw+SuTjh2foReWtz1OWjjdatxOcgzoKr4zAYmF70zRITkGAAAQAyW1fvnaXe8ONHrlqyqRJ6dAjeU7raRYM0/eYDWU7Qi7rZX3nqGl1x6qnIlfUcbIyS1Js2Bjg/x1oXMj+QLSrrrQi/YAOmYSV62TVw0NDSorLVN+fn6b9d7779saN2GCXK7QIbqMW35yo049+USlp6frK4cfYS0zF9yHDB2qTRs3hCmzl+fZAZKgzfp9Pj3x+8d0wcXf7nQ7l//gOzp17ok6cMZBGjtufEvSrKHBq5qatkkV2mwc4lhVLAXa9p73+oIqrvGrMMutoiqflRRrZn7fURXa296Y+4etmvqLjTpir3RNGZLakjQz2zNDLoYI+OSvLo71nwTYHt+ZgMTCd6bokBwDAACIgYYwF7t9NeVyZeyZuyRak657Vvvf865qt6xU3dYvW5a7MvPUWLkr7Hu8JkMGoEsC7XpwVVZWKDu7qfdms23btup3jzyky6+6OuJ2brn9Tj33/Msym1uyeFHL8ry8PO3aFdpmg0HaKxDrNvv8gr9r1lFHKycndG7O9n7zyGN69vkXtW7NGq3/37qW5ea9ZaWltNk4C/pCe4GV1fmVm9b1S1QvXTRcn/5wtJbvaNCqnQ0tywekO1VcHf7GoWAjve2BruI7E5BY+M4UndB+7AAAAOiyFFfoBR2nJ9Xq7WV48gapZsOeYRQby4va9CRrzwy/mD1hpiqWv6P04eNbLiY5U5ruim4v1YytCKBLnM1jcDW345QUq+dI6wvvN91wnX54zfUaPmJkh9vyeDw6fNYsa86xGbvnOzK9WlJTQ9usw0F7BWLdZlevXKEvPv9cz87/i6qrq+V0OpWalqYTTpwbdlsZGZmaNn2GPvnow5ZhGGmzvcPhDj0vprodVm8vY3C2W59tq295zfQaM8siMcMvHr5Xuv6ztlYTB6VYy7z+oNI8jvDle8J/lwIQGd+ZgMTCd6bo8F8ZAABADBRkuELmHHNn5inQWG/NHZYz+XBVLH9b/vpqNZQXqW7bGmWOmWqtt/pX51tDLPrqqtRYtatlSMbKFe8qbcjeLdvzVZfLkxuaUDN5sYHp4Yd7AxCZGSax9VCJpteI19tgDc9m5g+7+cYf6bQzz7YuoLd29+23atWK5dZ8RUU7trcMXfLh++9p1KjRLett27pVo0aPCVMm/4YBsW6zN950q+b/bYGefm6BTj39TH3rom+3JMauufIyFRfvtJJm5WVlLYmwRR9/qJGt2qxJiA8sKKDNxpkruzBkzrEB6S7V+4LyBYKavU+63lxbp2pvwEqMfVncoGnDmxJaZzy5TdsrfaqsD2hXTVPPMJNUe3tdrcYWeFq2V1Yb0JDsMN+NnG65sgrj/ScCtsN3JiCx8J0pOvQcAwAAiIEJBakhc44Z2eMOVvX6z5Q9drqGzLlIK+44WXI4NfK0G+Rwua2Jcr3FG61EmkmMrXv0MgX9jdawa/nTT1De1KOt7dRuXmEl0xzO0IvqZkTFiYXcBQ10lZkXLDsrU+UVlS3L9j/gAK1csVzbt2+3fpr5h/7x3F+t1+67/zfKzc21hmEbWFBoJcd+dstNqq+rtYZU3H/aNM09eZ61bkVFhVLTUq31W8vJyrTKBRDbNjtl6v5h32M+Z7du3aqcnBwrMWbmCDTJb7N89lFHa+Zhh1vrrV3zpSZOmmz1OKPNxpdn6L5SYH7I8pmj07Rki1cHj0rT9w/N1XG/22Ld+X7TsQPldjqsmK0v8ykv3Wklxr79XJEa/U1DR82dnKVjx2da21m2w2sl09rfNW8J+OQZOiXOfyFgP3xnAhIL35miQ3IMAAAgBiZFSE4Vzj5buz74h5UcKzzim9ajtfod6zRg2vFypqQpdeBwTb5xQdjt7ProRRXOOity+QUkx4DuyM3OUkVFpZpz2yfNO1Wv/esVayjFY4//asj6dXV11hCLhYMGWc8f/O1jYbf7n3+/rq99/aQ2y8xl2pzsLAIFxKHNtk6OXXDRt1t+37Rxo46YfaRSU9M0eMhQPfL4H8Nu99+vv9qS3KbNxpdnWPjk1AUzcvTsZ1VWcuzc6TnWo7W1JY06cWKm0j1Ojchz6tXvjAi7nb9/Xq3z2r03mvIBdIzvTEBi4TtT5xjPAwAAIAbG5acqJzX0q1XW3tOsHl/mbudw0oeO1cjTb+x0++lD91HOxJlhXzPljs0nOQZ0x+DCgpaL7MbkfadYvUcittn0dN102x2dbjczM0vHHX9Cm2XB3eUB6L02O3rMGF1y+ZWdbnf0mL1ChlClzcaHe/BEOdLa9qo1po9I0wHDUiPGclxhim45fmCn2x9f6LHmIAvHlOsePKEbew2A70xAYuE7U+dIjgEAAMSA2+XQNyblyhlmBJ+Cw07v8TBqZhvhmPJOnZxrlQ+g67IyM5Sbnd1mmZmnqKdt9tivniCXu+1AHaYcUx6A/tdmm+cna402Gx8Ol0cZB51tDTPd3lnTcnocS7ON8AU7rXJN+QC6ju9MQGLhO1PnSI4BAADEyDcm51jzDvUmU968SZGHDgLQudEjh9mqHMDuaLOJL2PGWU1fYnpTMNhULoBu4/wLJBbabMdIjgEAAMTI0GyPTpqYHbb3WDyYck6emG2VC6D7CvIHaHBB50N19cTgwoFWOQB6jjab+Nx5w5V+4Blhe4/FhcNplWfKBdB9nH+BxEKb7RjJMQAAgBi6amah8tNdcU+Qme2bcq6cWRjfgoAkMX6fMfJ42g6DGCtmu+P33isu2waSFW028eUcf4OcmQXxT5A5nFY5pjwAPcf5F0gstNnISI4BAADEUFaKUzcfOViBOI8UZLZvyjHlAeg5j8ejaVMmy+VyxbQ6zfbMduOVeAOSFW028TnTspU3714pGIhvQcGAVY4pD0DPcf4FEgttNjKupgAAAMTYoSMzdO1hBXGt1+sOL7TKARDbSaunT903Zokssx2zPbNdALFHm018qWOPUM7XbolrGTkn3mqVAyB2OP8CiYU2Gx7JMQAAgDg4Y0peS4IsVkMsNm/HJMZO3zc3NhsFEPKP46EHHmDNEdYT5v1mOyTGgPiizSa+zEPO25Mgi9UQi7u3YxJjmQefG5ttAmiD8y+QWGizoRjbAwAAII4JslG5Kbp1YZFK6/w9GmqxeY4xM5QiPcaA+DI9vvadME6DCwu0cfM2VVRVyeSmO2rCza/nZmdr9Mhh1uTXAHoHbdYeCTL3wDEqX3CdAjUlPRtqcfccY2YoRXqMAfHF+RdILLTZtkiOAQAAxJFJZD13xijd/2GJXlxVJYejab6wriTFgkFp7oRsXTWzkDnGgF5kElzmUV1Tq6LiElVWVauyukZ+v7/NnGI5WZnKyc6ykmn0FAP6Dm02sZlEVuHlr6vytbtUt+RZWV+aupIkM73FgkGlTztdOcffwBxjQC/i/AskFtpsE5JjAAAAcZaV6tJPZg/WxQfma8HKSv19RYUqvc0Xe4Jt+p24nQ75dr+Uk+rUqZNzNW9SjoZme4gT0EdMwisrc5T1ezAYVG19vapr65SVka6MtDQ5zAVcAP0GbTZxOdOylXfyncqafalqF81X7SdPK1hfEfKNqWlltxTwNS1Ly1XGQWcrY8ZZcucN75udB8D5F0gwWUn+fw7JMQAAgF5iElyXHDxQ352er7WlXv37f9X609LyltedDodOmpCjiYWpmlSQqrH5qXK77P1lFEg05h9Et8slt9tt/bT7P4xAoqPNJiaT4MqZc42yj7pSvqLVqn7vcdUve6nldUd6ntL3PUGeoVPkGTZF7sET5HBxIxHQn3D+BRKLIwn/zyE5BgAA0NtfwFwOTSxMU2NAbZJjqS6Hbpg1iHgAAACYC3Uuj5X8Shk1vU1yzFU4Trlzb6eOAABAtzm7/1YAAAAAAAAAAAAgsZAcAwAAAAAAAAAAQNIgOQYAAAAAAAAAAICkQXIMAAAAAAAAAAAASYPkGAAAAAAAAAAAAJIGyTEAAAAAAAAAAAAkDZJjAAAAAAAAAAAASBokxwAAAAAAAAAAAJA0SI4BAAAAAAAAAAAgaZAcAwAAAAAAAAAAQNJwy0aKi4v7ehcSCvVF/ScSjte+RwyoKwAAAAAAAMAObJEcy8jIkMfj0YIFC/p6VxKOqTdTf+EMyM1RSopHDQ2Nvb5fic7Um6m/cDhe43O8GhyzsT9eDY7Z+ByvAAAAAAAAAPqGLZJjubm5uvTSS1VbW9vXu5JwzIVbU3/hDB1cqJf//JDKKip7fb8SnUk0mPoLh+M1PserwTEb++PV4JiNz/EKAAAAAAAAoG/YIjlmmAuQXISMPXPBvKOL5ugejtf44ZiND45ZAAAAAAAAAHbh7OsdAAAAAAAAAAAAAHoLyTEAAAAAAAAAAAAkDZJjAAAAAAAAAAAASBokxwAAAAAAAAAAAJA03LKJiooK1dbW9vVuJJyMjAzl5uZGfJ16pV4T6Xg1OGbjU6/lRTtUV1HRja0nr/TcXOUNHtLXuwEAAAAAAADAjskxczH8oYceUmNjY1/vSsLxeDy69NJLw14Yp16p10Q6Xg2O2fjUq0mMvf2zn8rjre9mCcmpMTVNs3/6MxJkAAAAAAAAQD9ji+SY6TFmEmPz5s1TYWFhX+9OwiguLtaCBQus+gt3UZx6pV4T6Xg1OGbjU6+mx5hJjI3bd4qyBuR3o5TkU11WqjXLl1l1R+8xAAAAAAAAoH+xRXKsmUmMDR06tK93w3aoV+o10XDMxodJjOUOHhynrQMAAAAAAABA73D2UjkAAAAAAAAAAABAnyM5BgAAAAAAAAAAgKRBcgwAAAAAAAAAAABJg+QYAAAAAAAAAAAAkgbJMQAAAAAAAAAAACQNkmMAAAAAAAAAAABIGiTHAAAAAAAAAAAAkDRIjgEAAAAAAAAAACBpkBwDAAAAAAAAAABA0iA5BgAAAAAAAAAAgKRBcgwAAAAAAAAAAABJg+QYAAAAAAAAAAAAkgbJMQAAAAAAAAAAACQNkmMAAAAAAAAAAABIGiTHAAAAAAAAAAAAkDRIjgEAAAAAAAAAACBpkBwDAAAAAAAAAABA0iA5BgAAAAAAAAAAgKRBcgwAAAAAAAAAAABJg+QYAAAAAAAAAAAAkgbJMQAAAAAAAAAAACQNkmMAAAAAAAAAAABIGiTHAAAAAAAAAAAAkDRIjgEAAAAAAAAAACBpkBwDAAAAAAAAAABA0iA5BgAAAAAAAAAAgKRBcgwAAAAAAAAAAABJw93XOwAAQLQaqipV8tkSVW/coLriIvnq6hT0++T0pCglJ0dphYOUPXKM8iZOVmpuHhULAAAAAAAAIATJMQBAvxfw+7T1rTdU9NH7Cgb8Ia/7vfWqKzaPnSpbsUybXntFM37yMzmcdJBG/xMMBrW92qcqb0CbyhvavBYIBrW6xGv9PjjLrbw0Vx/tJQAAQN8KBgLy71qvoM8rf+X2tq811Kpx+wrrd9fAMXKmZPTRXgIAgERFcgwA0K8FfI368i9PqGrj+jbLHS6XMoYMkyczy1rHW1ZqPZoEdz+A/qXBH9Q1r23XB5trw77u9Uvn/n2z9btD0g8OyteFB+b38l4CAAD0LX/VTu164lz5S9aFf33HcpX8dm7TE3eKBpz+G6VNnNO7OwkAABIayTEAQL+28V8vhSTGBh96uIbNOkrutPSQYRdLl39u9TAD+qNFW2sjJsbaM+ndxxaX6qz98pTmoRckAABIHrVLnouYGAvha1DVf+4nOQYAALqE5BgAoN+q3blDJUsXt1k27IijNPyoY8Oun5KdoyGHHq5BB82Uw8lwdOh/MrqY5PK4HNYDAAAgmXR1mERHSmbc9gUAANhTj25Dvvvuu+VwOHTVVVcpGdXX1+tnP/uZNXfIm2++qSuuuEJXXnmlFi9ueyG3tUAgoBtvvFG/+MUvWpbdddddqq6u7qW9Tpx6raur02233abzzjtPTz75ZIfvoV6jr9f169frxz/+sf7v//5P119/vZYvX97h+8yx+qMf/ajl+YMPPqjt29uO957smut227Ztuu6663Tttddaj0WLFkV8D8dsFPXa2KhXXnjBTNDUsqzO6dbKguGR6zUY1G0v/ksPv/1ey7Jfvv6WarxNczgBfW3qkDTtPSAl6vVPmZgjl5PkGAAASC5pU0+SowsJssyDzo7r/gAAAPvpdnLsk08+0aOPPqqpU6cqWZmE2MyZM63E1osvvqh77rlHN998s5XI8fv9Yd/z1ltvqbCwsM2yI444Qm+88UYv7XXi1Kvb7dZpp51mJcc6Q71GX69paWm6/PLLraSX+fnII49EfM/nn38up7PtaeLYY4/VSy+9FFUsk61uCwoKdOedd+q+++6zEpCPPfaYlTwPh2O2c29/uVYj/W2TWjX5BZIrco+wd75cq4LsrDbLZu6zl/6zak2U0QTiy+lw6DvTo5tDLNXl0HkHDCAkAAAg6bgyByrj4POiW3fgXkqb8vW47xMAALCXbiXHTDLonHPOsS78DhiQvBdt3n33Xc2YMUOfffaZpk2bpvT0dOXn52v48OFat25d2Hp7//33NWdO20liDzzwQGs52tarx+PR5MmTlZLS8R321GvXjtehQ4dqyJAh1jJzrJpeT6YXU3s+n08LFizQqaee2mb5+PHjrd5m4d6T7HVrjlWT1DUaGxsjrs8xG50P121Qut/XZllKbl7Iekt/dbc+ue1G65H51z/qoP/+S4e8+6r+98LfrNcPGDlcH63f2KWYAvF09N6ZUfUeO3VyjgoyGAEbAAAkp8yvXBxV77HsIy9nSHUAANA7ybFLL71UJ554YkiSJxyv16vKyso2DzswF74rKiqUl5en0tJSKynWzPxulrU3f/58K9HQvidORkaGtb3a2lolu9b1Gi3qtfv1anqA7r333iHHpPHyyy9r9uzZVk+z1sxQqqb345YtW6KOUTLVrakXM2Tl1VdfrYsvvtiqr/Y4ZqOoV79flXX1YY/NrkpPSbG2V9fQ0ONtAb3Ve4xeYwAAINlF03uMXmMAAKC7unzV8ZlnntGSJUusebKiYdbLzc1teYwcOVJ2UFVVpczM6Cd8NfM81dTUaN999w37enZ2tnWBPdlRr71Xr0VFRfrzn/+siy66KGR9k9w1Qyqa5Fg4OTk5Ki8vj9PeJnbdjhgxwhqy0gytaIZbbWiXkOFcEJ1qr1cZqSnyZLYdItFdF3oTQd64CUrdZ5xqsnIjbi8rNVUVdfVRlg70fe8xeo0BAAB03nuMXmMAAKBXkmObN2/WlVdeqb/85S8hvUkiueGGG6ykT/PDbMMOzPBpzcOmte8pZn5vP9zkmjVrtHLlSqvX3f3336+lS5dac7Y1MxfQOxs+MBm0rtdoUK/dq1czrN+9996r7373uy1DLLa2YcMGqwfUZZddpptuukmbNm1qkxDneO38mDX1apJm7c95HLPR8bhcVm+vrBGj2r5QtE3PL1lqzS3WbMzX56nkwMP0eWbbnpFri4pbfjfbSnFHnqsM6E+9x+g1BgAA0HnvMXqNAQCAnujSRBaLFy/Wzp07rTmymvn9fr3zzjt68MEHrSEUXa62Fx9TU1Oth91kZWVZCQLz90+dOlXPPfeczjzzTNXV1VlJhbFjx1rr3XbbbVaC4bjjjrMehpmv6dVXX9X3vve9NsmKZJ6/LVy9tj+WWqNeu1+vwWDQ6tU0d+5cTZkypc16ph1/9atftdr47373O2uZafO//OUvrUR3615nZr4ytK3bsrIyq4esmS/PJMlNUtEMQckx23Wmp1ejz6+8yVO0/d23JQWt5Rl+n87IdGvW+KZz7D3/+re+O+srOnrSeE31Vmn9i3vmFhs7uKnum3ui5WV0Pl8B0Nu9x4Znu7W1qu3cevQaAwAAaNt7rOaDP0j+tjcl0msMAAD0WnLsmGOO0RdffNFm2YUXXqiJEyfq+uuv7zCZYUeTJ0+2eoGYv98kGq677jprfpzzzz/fqguThNixY4d18bwjppfOPvvsE5O5dexWr6anopmnziQe3n//fd1xxx1WTz3qtfv1apJd5qeZ4+6VV16xXjO9w8zQniaZ01mS1gwjaBLeZn20rVuT5DbziZm2bB7m/GiGoORc0D0ThgzSdodbA/efpl2fLWlZnvbFEm0bOECDDz1cOyurlJnaca/bjbtKtXfBQKunDtCfmGPynP3zdO+7JW2Wn3cAN8sAAAC07j2WOu5IeVe9sadSUjKVNuXrVBIAAOid5Ji5GN6+p4kZNmzgwIEhy5OB6Qm2cOFCK4kzZ84c69Ha1q1bdcghh4QMl2jmHWs995jpedfcqwxt6/WBBx4IqRLTM4967f7xaoZSnDVrVsjr9fX11lCApj23NmjQIN19990tz9977z0dffTRHKoR6nbGjBkhdcO5oHtMb7B31/xP53/tZNXvKlHNlk3WcoeC2rrw39r23ts6OStXG/8+X/66OtVs2xp2Ox+sW6+jJo7nmEW/4vMHtabUayXI0twO1fuaekcWZrj02KJSTShI1aTCVI3LT5XbRWI30eK6stir1SVeldT61eAPKMXlVEGGi7jaKLY7qxtV1+hTusetQVkeYpvAaLf2RJu1j6C/Ub6iVfKMnCbv6jelYMBa7swdpspXbpZn6L7yDJsi9+CJcrg8fb276GJcG7ctU+P25fJXFSvo88rhTpUru5C42ii2jRVF8jXUqSolXfW5g4ltgqLN2lcwydtsl5JjaGv8+PFWosb0CnGE6ZEwYsQIXXDBBZ1Wm1kvGZOLkVCvfVOvZh7Bq6++utPtZGRk6LDDDovTXiYmjtn4GDuoUNvKK+RwuzXx/Iu1+fV/aufiT1r+IQ42Niq9rETlZW173RgOp1Np+U2J3mF5uZo8LHRuPaAvbK9q1D9WVOofKytU6W06lt2tTsnFtX69uKpSu3Nlykl16huTcvWNyTkamm2/L6J2j2tzHNs/J652im2j3I46YpuAaLf2RJu1D1/5VtUumq/aT55WsL6iaaHT3fK/QKB4jWp3rZcC863njrRcZRx0tjJmnCV3HlMAJFxcA62GGbeeE1e7xdYMitpIbBMObda+aLMxSo6Z3hLJLBY9aOiFQ732llgca+F6nYFzQbw0zy3mcHs0+msna8hXZqlk6WJVbVxv9Sbz1dVZ85G5UlOVkjtA6YWDlD16L+WNnyhPZlabbQB9qdrr1/0flujFVVUy9ycEWiVNWidQ2j83F+Of/KxMf1pappMmZuuqmYXKSmEY5v6CuNoXsbUvYmtPxNU+AvVVqnztLtUteVbWl6bdybCmF9vO09r6ubkYX/Puo6r572+VfuAZyjn+BjnTmAqgvyCu9kVs7Ym42hexbYueYwCAhJGaN0DDj2w7hC3Q3324uVa3/KdIZfV+mbxXsF0yrDPNibSXVlfpvU21uvnIwTp0ZEZc9hXRI672RWzti9jaE3G1D+/a/6p8wbUK1OyyboDr8pem3Ym0uk+fk/fL/yhv3r1KHXtEfHYWUSOu9kVs7Ym42hexDcWtxwAAAHHy7LJyXf7PbSqt87fpLdYd5v1mO2Z7ZrvoO8TVvoitfRFbeyKu9lHz0ZMqfepbTYmx1r3FuiMYUKCmxNpezUdPxWoX0Q3E1b6IrT0RV/situGRHAMAAIjTBbv73muaE6+HebEWzQk2s10SZH2DuNoXsbUvYmtPxNU+TAKr8p+3Nj3paWKs2e7tVP7zFhJkfYS42hextSfial/ENjKSYwAAAHEY4qk5MRYvZvumHPQe4mpfxNa+iK09EVd7DfFkEljxZLZvykHvIa72RWztibjaF7HtGMkxAACAGKr2+q05xpyO+Far2f6tC4tU3RCjO6zRIeJqX8TWvoitPRFX+wjUV1lzjMkR50tTDqfKF1xnlYf4I672RWztibjaF7HtHMkxAACAGLr/wxKV1fd8jrFo5yB74IPi+BYEC3G1L2JrX8TWnoirfVS+dlds5hiLcg4yUx7ij7jaF7G1J+JqX8S2cyTHAAAAYmRbVaNeXFUV98RYM1POC6uqtL2qsXcKtJGSWp81LFel19/pusQ1cQSCQX2+o04ri+sVDHbeEIlt4qio9+uDzTXaVeuLan1imxhMO11d4tVnO+rki+LDk7jah69si+qWPBv/xFizYMAqz1e+tXfKsxFfyXp513+gYGN95+sS14QR9Hnl/d/7VnyjQWwTh798m7zr3lPAW93pusQ1cQT9Pnk3fKzGotVR/Z9DbKPjjnI9AAAAdGLBiko5HOZiX+9VlSlvwcpKXXLwwN4rNMEtK6rX91/eKq8vqDS3Q2fsm6tz9x+gAemusOsT18Rx+9s79dLqpmGzxg9M0Xdn5GvW6Ew5TEMJg9gmhk0VDbro+S2qqA/I7ZROnpijb00boCFZnojvIbaJ4beLSvWHJWXW76NyPbr4wAE6bmy23BHGJiau9lG7+Bn1xZem2kXzlTPnmt4rM8HVfvo3VTx/vfW7M6tQWYd/TxkzzpLDkxZ+feKaEIKNXu364zfVuPVz63nquNnKOvIKpYw4IOJ7iG1iqF/ztsqe/o4U8MuRlqPMmRcp89BvyZmWHXZ94poYTDKsbP735F2z0HruGTVd2UdeqZS9vxLx/xxiGx16jgEAAMSAzx/UP1ZW9FqvsWamvL+vqLDKR3QWrKywEmNGvS+oJz8r10lPb9BvzJCYdW17khHXxGF6Ab68OzFmfLmrQde8tkPn/n2z3t5QHXKHJbFNHP/6sspKjBm+gDnnVWre/I26+787taM6tOcssU2cnp5//aK85fmmikbd/J+dOvPZTfrnl5UhPcmIq30E/Y2q/eTp3us11lJwwCrXlI/o1Hz4RMvvgepiVb56u3bef6RqPvhjSE8y4po4GjYvbkmMGd41b2vXY6eq9M8XqWHL0pD1iW3iqP34KSsxZgTrK1X9n/u181ezVLXwNyHzLhLXxOHftaElMWY0blqs0ifP164/nGn1Emz/fw6xjR7JMQAAgBhYU+pVpTf0Io+/vkar77/A+sJa/O6z+uKnc/TFzcep/PO3Im4rGAho5d2nat2jl+3Z/oPflq+mIuz6pty1pV7iGKVwcYqUJIsU19ax9ddXa/WvzteSK/fX5r/d3WHZXYktce2aKm9A4VLEkZJknbXZ2k3LtfKe07Tstq9pxR0nq3L1Rx2Wb2K64s55Lc/XP3Gd6os2hF2X2HZNuDh1lCTrLLb1O/6n5XecpOW3z9Xyn81V+WdvRiyb83H8BAJSTWNoq42UJIvmc9ZoqNipJVcdoJ3/eSpi2cS1b/mKVilYH/q5V9MQ0BlPbbdi+ZcllTrswU06/KHNeuPLmg6TrCc+vlXfea6oZdl5T29XebubXZqZcn1Fq2P0l9hfoK48dFmEJFmkuLaObbU3oDOe3Kaxd63Xra/v6rjsLsSWuHY1ruHjFClJ1lmb/WK7V1///VYd9chmHfe7LXp/Q12H5ZuYfvWxLS3Pr3x+p/63K3zSmtj2vM1GSpJF02bXljTo2N9t0ZxHmx6vrY7N+Zi49jyuHSXJovmcNYqqfBp/93r94eOKmMQ1EWPLsIoAAAAxsLI4fHKq5L1nlT/9BPlryrXjjcc1+cfPN13I++W5yt13lhyu0K9jJe89p5SBI1ru+jPyDz5Jxf+dr6Ff/X7Yct7ZWCOPK/yQCgj9pyCS5iTZX5dV6PixWRqdlxJx3ebYOlweDfv6Zarbtkbe4s0dVndXY0tco7ezpuO5qJqTZGPyPDr/gAFqjNDbsjmuztRM7XXRL5RWONqK7ZqHv6upt/8n7HsqVrwrOdsOy1l4xDe149+Pa8w5t4d9D7GNXkUHcwM2J8meX1mpo/fO1CUHFXR6Pk4ZOFyTrv+bnO4UNVaWaMUdpyh36tFhh6XhfBw/nc0x1pwke+STUp21X65SXM6Oz8W747d1wc+VM+mwDrfdnbiuLPFqYmH4oeTQNY3bloVd/vSSKp00OVNldQE98kGFXvvOCFU3BHTan7brqLEZYYfbnP9plUbkudv03J+3X7aeWlypyw8fELac+tVvSu7In+9oxR/5s7U5SVb1zkPKmHG2nJkFEddtjq35rnr17AFaXdyoDaUd9+DramyJa/T8Fds6fN0kyczDM2qGso+8Qv6yTR3GNTPFqQfnDdKYfI++LG7Q+fN36MMrRoV9z9vratW+KZ87PUe//aBc9369MOx7iG30OpobsDlJVvP+40o/4DS58oZHXLc5tqYNvnLxcKW4HCqu9un4x7bquPEZYb8z0WbjxxehDbZPkrmHTlbWEZcoUFveYVyb43fnm6WatXd6h9vuzues+Zz3DJuiREByDAAAIAZWl3jldki7R+trsevjlzXu0kdVseK/yt13tlxpWdYjfehY1Wz8Qll7T2uzvq+mXKWLXtHQE76v4refblmet99RWvWLsyNctAvqscVl1gOx4fUH9eLuIfrMP/DhruE2x9bpSVX2uIM7TYx1PbbENR42lDfqtoU7rfnmOmqznpw9F/nSho5VwFuroJm/oV0SLOBv1I5Xf6uRZ/5UG/70o5blmXtP0/o/XR/2PcQ29kyu8411NdZjcmFqh7E1bbYlfo0mkRY+ScP5uH/YUe3Trz7YZc03Z+4B8UeIq1G15mPrM9ZKfEXQnbiasleZpOukWP5lyatx+3LJ6ZYCbRMvC5ZV60/fHKyF6+p0zNh0ZaU6rce4Qo+WbvVqxsi2yUnTy/uFZdXWxbknF1e2LD92fIbmPbEt7EU7c/hUL/y19UBsBGvLVPPOQ5LD2XSjSKukc/vYprodOnR0ujaWdXxDS1djS1zjo3HTIuuCuzN7cIdttjBrz+XlcQUe60Y0fyAoV7ssmLkx6TfvlutnXy3QD1/c2bJ8xohU/fCF4rDvIbaxF/RWq/aj3UOmOlxmDL6QdZpjm2Y+AHczw9JHmiaSNts/+LavUPmzl1nzzXXUZo0PN9ZZn7Ej8yKnh7rzOWvKbdwe/iaY/ohhFQEAAGKgpNYfciHWXHT1VZVYF9kby3cqJa/pi6jhyRushrIdIdvZ+sIvNfRrlzb9o9KKKz1bwcYG+evajhWP+AuXGGsd22gR2/7F9BLsqM22Vr70DWWMmhImySUV/fsPGnjoPLlSM9ssN3dkpg4crvrt6+LzByAik8ToLLamN+Dy207U8tu+plFn3RL2DmjabP9iegn6O4hr0O/T1hcf0LC5V3S4ne7E1ZS9K8LwQeg6f1VxyAU7c9G1uMZvXWQ3wzwNyd5zsc78vqMqNJlyz1ulumrWALXvVJid6rS2Z4bbRS8yc8iFSYy1jm20iG3/Eqgq6rDNtvbq6lpNHZoakuQyHv2wQqfvn62s1Lavmc9g0zNlTQnzAfa2YJjEWPvYmt6AR/92s458ZIvu/FpB2O9MtNn+xfQS7KjNmt779y0s0zVHhu/51aO4BnzyVxcrUZAcAwAAiIEGf5g5cWrK5crIiXobZo4jX22lciYcEvZ1V2aeGivDzc/AcIq9rXdiS1z7Q1y9xZu05R/3atSZN4WsbxLclSve08CZ3wi7PXdWvjX/UShiG1eOzmObPmyc9r3pFU3+8Yva8fpju3uQ7cH5ODG0juvOhX+2hld0Z+ZFXL/7cTUXlUi0xErQ5w17d3puWvSXqMwcR+X1AX1lTPjhoAakO1VcHXrRl7Nv7+uN2BLX/hHXjWWNuv3fu3T7CaE3j22v9OmddbU6Y/+ssNsbmOGyEuPtEdv4ckQR2/GFKXrr+yP1xvdG6OH3y1Xf7vOQNpsYWsf1iU8q9fXJmRqQHnrjX08/Z41gu+/V/RnDKgIAAMRAuLlQzNBd5i50w5M3SDUbvmh5rbG8qE1PMqN6/VJVr1mkz288UgGfV4H6Gm3480805tzbWy4mOVP2DAe2h7mVnn8d4yHSkIqtYxuN7sWWuMZTbqpTFe3udmwfV3Phfe0jP9Doc36mtEGjQ7ZRu2Wl6rev1Rc/PkrBgE++6lJ9+Ztva/zlj1uvm1g7U8LNUURs48XjlPbJ92hVu7vPI7VZE1dXeo7qtn2pzNH7tSznfNz/ZLgdqm3XJbB1XGs2fK7qdYu14/XH5a+rtIZ3M+2v4LDTYxBXKbXV0FLoGYc7tI7NcHvmLnRjcLZbn23bM2+O6TVmlrW2ZKtXH2+q18EPbLLeZ+Ymu/blYt23e84iMzxymif0uxFn3zhypUj+hg5jG43uxJa4xpNDzrzhCpRv6TCu5sL7hX/doXtOLNRe+Z6QrSzf0aAvSxp1yK83W8Mn7qr169ynt+vPZw9tuQEhzXyIt0Ns4yjMsHsdtVkTV5NcWb2zUfsP23Mep832P46sQgXb9d5qHddPzXl2c70eeb9ClfUBq2dYusehs6bl9Phz1iq/1RDm/R3JMQAAgBgoyHCFzHFj7l4PNNZbQz3lTD5c2155UP76K+Wvr7GG9MocM9Vab/Wvztde37pXg2afYz2MytUfqXjhUy0X7Axfdbk8uW0TalY5TodOmpCjG2YNIpZRuPa17Vq4oabDdUblenTxgfn6dHudXl5dGTJEW+vYOlyRv1L3JLbEtWu2VjbqlPkbO012Hj82WxcdOEDzPy/Xi6vaxrZ1XIPBgNb+9hINnnORcibObLOd9X+8VoVHnmvNUZR37/vWMm/JFq373eUtiTFrWfEmpQ/ZJ2Q/iG3X3PdusZ5dXtHhOoMyXfrWtHydPDFHv3ivWGt3NUaMrenN58keaCVWGsqLVL/tS6UMbJqUnvNx7/H5g5r5eOfDjs4ananvTB+gBSsrO2yze1/8y5blW1/6tTxZA1oSYz2PqzSwg7ur0TWu7MKQi7Lm7nVruNtAULP3Sdcv3ynTtUcGrItxZkivacObLrSd8eQ2PXDKIF0wI8d6GO9vqNMfP6lsuWBnlNUGNCQ7NGYOp1sZB56u3Ll74o7Iin55uAIV2zusIs+oGco+6grVLfuX6j59LuRie+vYms+/SHoSW+LaNXXL/2XNS9QRhyddGQefp8zDvq3qt36l2iVtY9s6ruZGsov/WqTvHZqnw/dq28vkiud36sKDcjRnfIaWXt10o9Hm8kZ957milsSYsaHMZ81XFrIftNkuKXn8NDVu/rTDddxDJin7yCtUv+Zt1X36tw7b7I4qvwozXVZixdyosGpngzUEpkGb7T0Nmz/VrsdP63gll0cZ005X1hE/UPV/H+6wzT70jT3XDX6+sFT5Ga6WxFhPP2fN57sra896/R3JMQAAgBiYUJAakkAxsscdrOr1nyl77HQNmXORVtxxsjVh+cjTbrCSKsFgUN7ijR0OA2XUbl5hJdMcztA7Ks3IFhMLE+furP6sOSl23Ngs6wKOGTbk+VXh120d2y9uPk6+qlLrAm3popc16frn5Mkb0qPYEtfYaZ0UG5OXElWbbdi1RTXrl1rzDxW91TRp+YSrnpQ7a4Bqt61WSl7HyWhfdZmcKenW+iGv0WZjpnVSLMXliCq2ftMj8IVfSk6nHOZ8fMZP5MnK53zczzQnxSYWNvW+nBBmLrn25+Jw+JztfzxD95UC80OWzxydpiVbvDp4VJq+f2iujvvdFjkdDt107EDrM9nEcn2ZT3npHffiW7bDayXTzHtDBHzyDJ0Syz8naTUnxVL2+oo1B5G/dJPqFofGtX1sD39os0pr/GoMBPXi8mq9dPFwDc129Sy2xDVmWifFXJkDo2qzJtm1ZGu9Kr0BPfZR080sz5431LrgvnJnQ0jPz/ZKa/1WrxWzfghiGzPNSbHUCXOs/zsCNbtUt/iZsOs2x9b0CLznP6VWmzPfp3/21QJrCMwen4+Ja+y0Soq58oZF/TkbTjAJP2dJjgEAAMTApAjJqcLZZ2vXB/+wLtoVHvFN69Fa/Y51GjDt+JCh18x8KK3nRNn10YsqnHVW5PILSI5FqzDT3WlSrLO4to/tfre+HvJ63fa1PY4tcY1efrrLGhKk9fR/4ZJincW2Oa5mKMWBh5wc8rrfW6u0wjFKGbDnbmcjtWCEJt+4oOV56Scvq7DVcG7ENrZtNlxSrCuxzdv/mJDXOR/3LtNeTbstrfN3mBTryudss+Fzr2j5nbj2P55h4S+amTvUn/2syrpod+70HOvR2tqSRp04MVPp7YZeM/OhtJ4T5e+fV+u8du+NpnyEcmUPCek51j4pFk29to7tu5eODHl9TXFDj2NLXKPnyhkcVVKss7ptjqsZSvHUqdkhr9c2BLR3vkfDctp+jo/M8+jV74xoef78smqdPS30/Z2Vj/BttrGTpFg09do6tsdPyAx5PRbnY+LaszYbLinWWd22Phc3u+bI/KT+nCU5BgAAEAPj8lOVk+q07phsLWvvadacROYurNYXEJqlDx2rkaff2On204fuEzK0WzNT7th8kmPROntqnt7bVKNtVb6ISbHO4tobsSWuXWP+ifv+jIH67Se7rOfHRUiK9bTNulIztM93f93p/rjSs5V/0NfDvkZsu8YkwF5fW6U1pQ0alOnWt6YNCJsUa8b5ODGY9nXZIQN193+L1eAPRkyKNSOu9uEePFGOtFwF69sOlzp9RJo1hGKk8++4whTdcnzbi/bhjC/0hAzt1syU6x48oQd7n1yyj/mhyp65REFvdcSkWGdx7Y3YEteu8QzfX2lTT1b95y/IkZKhjIPODZsU62mbzUhx6tHTwlzUbycnzalTpmSFfY3Ydk3WrEvUsPFjq1eYe8hkZR95eUhSrBltNnG4cocpc+bFqvnwD2bCVWVMOy1sUqwZn7PRIzkGAAAQA26XQ9+YlKsnPyuzxt1vrXnOk56ItA2Tzzl1cq5VPqIzIsejBWeNtoZwMcOChPtnPpq4dhSXrgi3DeLaPSZpcurkHCvR2f6Ox95uswMPPSXscmLbdWaOhL+cNlK7omizBufjxDF3Qo6O2TtLgUBQWakdz+lFXO3DYe52P+hs1bz7qBRse4NC85wnPRFxGw6nVa4pH9FJ3fswDb7uYwW9NXJm7uld0NW4dhiXLgi7DeLaZQ6nSwNO/aX8x98oZ3pup20i3m32tDC9znbvKG22izxDJ2vQ/72vQF25XFkFHa5Lm00sOV+9UVmzfiCHJ0MOT8c3xvI5G72O/2MEAABA1L4xOUfBMAmUeDLlzZvU839Kk40ZH70g093pRXaDuCaW7FRXp4mxZsQ2cTi60GYNYps4MjzOThNjzYirfWTMOKvpS0xvCgabykWXONypnSbGmhHXxGKSJ9Emi4lt4jDzWneWGGtGXBOLM2NAp4mxZsQ2OiTHAAAAYmRotkcnTcy2eob0BlPOyROzrXIRP8TVvoitfRFbeyKu9uHOG670A8+weob0CofTKs+Ui/ghrvZFbO2JuNoXsY0OyTEAAIAYumpmofLTXXFPkJntm3KunFkY34JgIa72RWzti9jaE3G1j5zjb5AzsyD+CTKH0yrHlIf4I672RWztibjaF7HtHMkxAACAGMpKcermIweHnZ8qlsz2TTmmPMQfcbUvYmtfxNaeiKt9ONOylTfv3rDzU8VUMGCVY8pD/BFX+yK29kRc7YvYdo6rKQAAADF26MgMXXtYdOO8d9d1hxda5aD3EFf7Irb2RWztibjaR+rYI5TztVviWkbOibda5aD3EFf7Irb2RFzti9h2jOQYAABAHJwxJa8lQRarIRabt2MSY6fvmxubjaJLiKt9EVv7Irb2RFztI/OQ8/YkyGI1xOLu7ZjEWObB58Zmm+gS4mpfxNaeiKt9EdvISI4BAADE8cLdb742LCZzkDXPMWa2R2KsbxFX+yK29kVs7Ym42uvCXf55T8RmDrLdc4yZ7ZEY61vE1b6IrT0RV/situGRHAMAAIjz0E/PnTFKcydky+THupokM+ubt5j3P3fmaIZS7CeIq30RW/sitvZEXO019FPh5a8rfdrpJsPV9SSZtb7Der/ZDkMp9g/E1b6IrT0RV/sitqHcYZYBAAAghrJSXfrJ7MG6+MB8LVhZqb+vqFClt2nyebdT8rWah77185xUp06dnKt5k3I0NNtDTPoZ4mpfxNa+iK09EVf7cKZlK+/kO5U1+1LVLpqv2k+eVrC+YveLbinga7XynueOtFxlHHS2MmacJXfe8D7ae0RCXO2L2NoTcbUvYtsWyTEAAIBeYhJclxw8UN+dnq+1pV6tLPFqVbFXu+r88voCSnU7NTDdpYmFqZpUkKqx+alyu2I0YRnihrjaF7G1L2JrT8TVPkyCK2fONco+6kr5ilarcdsyNW5fJn91sYKNXjk8qXJlFcozdIo8w6bIPXiCHC5uJOrviKt9EVt7Iq72RWybkBwDAADoZSbhNbEwzXpoEtVvF8TVvoitfRFbeyKu9mESXib5ZR6wD+JqX8TWnoirfTmS/HPWVsmx4uLivt4FW9YX9Uq99gddOQ45ZuNTr9VlpV3YcnKjrgAAAAAAAID+yxbJsYyMDHk8Hi1YsKCvdyXhmHoz9RcO9Uq9JtLxanDMxqde03Nz1ZiapjXLl3WzhORk6szUHQAAAAAAAID+xREMBoO9WWBlZaVyc3NVUVGhnJycmG3XbK+2tjZm20sW5oK4iUck1Cv1mkjHq8ExG596LS/aobqK3RNhIyomMZY3eEhCfIYCAAAAAAAAycQ2yTEAAOyOz1AAAAAAAACg55wx2AYAAAAAAAAAAACQEEiOAQAAAAAAAAAAIGmQHAMAAAAAAAAAAEDSIDkGAAAAAAAAAACApEFyDAAAAAAAAAAAAEmD5BgAAAAAAAAAAACSBskxAAAAAAAAAAAAJA2SYwAAAAAAAAAAAEgaJMcAAAAAAAAAAACQNEiOAQAAAAAAAAAAIGmQHAMAAAAAAAAAAEDSIDkGAAAAAAAAAACApEFyDAAAAAAAAAAAAEmD5BgAAAAAAAAAAACSBskxAAAAAAAAAAAAJA2SYwAAAAAAAAAAAEgaJMcAAAAAAAAAAACQNNy9XWAwGLR+VlZW9nbRAAAktObPzubPUgAAAAAAAAAJkByrqqqyfo4cObK3iwYAwBbMZ2lubm5f7wYAAAAAAACQkBzBXr79PBAIaNu2bcrOzpbD4VAy3OVvEoGbN29WTk5OX++ObVCv1Gsi4XilXmPFfGSbxNiwYcPkdDIyMgAAAAAAAJAQPcfMxbwRI0Yo2ZjEGMkx6jVRcLxSr4kk2Y5XeowBAAAAAAAAPcNt5wAAAAAAAAAAAEgaJMcAAAAAAAAAAACQNEiOxVlqaqpuvvlm6yeo1/6O45V6TSQcrwAAAAAAAAC6wxEMBoPdeicAAAAAAAAAAACQYOg5BgAAAAAAAAAAgKRBcgwAAAAAAAAAAABJg+QYAAAAAAAAAAAAkgbJMQAAAAAAAAAAACQNkmMAAAAAAAAAAABIGiTH4uihhx7SmDFjlJaWpkMOOUQff/xxPItLCu+8847mzp2rYcOGyeFw6Pnnn+/rXbKFu+66SwcddJCys7M1aNAgnXLKKVq9enVf71bCe+SRRzR16lTl5ORYj5kzZ+pf//pXX++W7dx9993W+eCqq67q610BAAAAAAAAkABIjsXJX//6V1199dW6+eabtWTJEu2///46/vjjtXPnzngVmRRqamqsujSJR8TO22+/rUsvvVQffvih3njjDTU2Nuq4446z6hvdN2LECCtxs3jxYi1atEhHH320Tj75ZC1fvpxqjZFPPvlEjz76qJWEBAAAAAAAAIBoOILBYDCqNdElpqeY6Ynz4IMPWs8DgYBGjhypyy+/XD/60Y+ozRgwPUUWLFhg9XJCbBUXF1s9yEzSbNasWVRvDOXn5+u+++7TxRdfTL32UHV1tQ488EA9/PDDuv3223XAAQfo/vvvp14BAAAAAAAAdIieY3HQ0NBg9RSZM2fOnop2Oq3nH3zwQTyKBGKqoqKiJZGD2PD7/XrmmWes3nhmeEX0nOnteOKJJ7Y51wIAAAAAAABAZ9ydroEuKykpsS6EDx48uM1y83zVqlXUKPo108vRzN102GGHacqUKX29Ownviy++sJJh9fX1ysrKsno7Tp48ua93K+GZRKMZstYMqwgAAAAAAAAAXUFyDEBIb5xly5bp3XffpWZiYMKECVq6dKnVG+9vf/ubLrjgAmu4ShJk3bd582ZdeeWV1vx4aWlpHKcAAAAAAAAAuoTkWBwUFBTI5XKpqKiozXLzfMiQIfEoEoiJyy67TC+//LLeeecdjRgxglqNgZSUFI0dO9b6ffr06VZPpwceeECPPvoo9dtNZtjanTt3WvONNTO9dc1xa+Z59Hq91jkYAAAAAAAAAMJhzrE4XQw3F8HffPPNNkPVmefMNYT+KBgMWokxM+TfW2+9pb322quvd8m2zLnAJG/Qfcccc4w1XKXpkdf8mDFjhs455xzrdxJjAAAAAAAAADpCz7E4ufrqq63h08wF24MPPlj333+/ampqdOGFF8aryKRQXV2ttWvXtjxfv369dTE8Pz9fo0aN6tN9S/ShFJ9++mm98MILys7O1o4dO6zlubm5Sk9P7+vdS1g33HCDTjjhBOvYrKqqsup44cKFeu211/p61xKaOUbbz4eXmZmpgQMHMk8eAAAAAAAAgE6RHIuTM888U8XFxbrpppusRMMBBxygV199VYMHD45XkUlh0aJFOuqoo9okIQ2TiHziiSf6cM8S2yOPPGL9PPLII9ss/+Mf/6hvfetbfbRXic8M/Xf++edr+/btVqJx6tSpVmLs2GOP7etdAwAAAAAAAICk5Qia8dQAAAAAAAAAAACAJMCcYwAAAAAAAAAAAEgaJMcAAAAAAAAAAACQNEiOAQAAAAAAAAAAIGmQHAMAAAAAAAAAAEDSIDkGAAAAAAAAAACApEFyDAAAAAAAAAAAAEmD5BgAAAAAAAAAAACSBskxAAAAAAAAAAAAJA2SYwAAAAAAAAAAAEgaJMcAAAAAAAAAAACQNEiOAQAAAAAAAAAAQMni/wGlTULRYMbedgAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABXsAAAK8CAYAAAC+4mwYAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAg0ZJREFUeJzt3QeYXFX5OOCz6SEkIaEkhBS69FAEpBgQEERA0J+ACkhXMQqCVFEgKl0QFaSpoCCIoICogPTQOwHpvSfUFBJSSOb/fBdn/9uSbMLs7M7Z932eye7euXPvPfdMZr773VPqSqVSKQEAAAAAUNO6tPcBAAAAAADwyUn2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFzq5Cy+8MNXV1TV6LLXUUulzn/tcuvbaa5ut33Td8mPw4MH168yZMyf96U9/ShtuuGEaOHBg6tu3b1p55ZXTN7/5zXTPPfdU9Pgvu+yytPvuu6eVVlqpOI7NN998ruvOmDEjHXHEEWnIkCGpd+/exfHdcMMNFT2ezuaEE05IV111VavXn9v756STTmq03nHHHdfier169WqDUgAA1Ibf/va3RUwUcez8LLvssm1yDB988EE69thj0xe+8IUi1o/jiWuKuYlrg7PPPjutvfbaRQy++OKLpy222CKNGzeuTY4vd0888UQRK7/00kutWv/NN99MRx55ZHF9F9dlUV+33nrrXNefOXNmEeOvssoqRew9aNCgtN1226XXXnutgqUA2lK3Nt06UDN++tOfpuWWWy6VSqU0YcKEImD74he/mK655pq0/fbbN1r385//fJG4bSgCt7IDDzwwnXXWWWnHHXdMu+22W+rWrVt6+umni+Tx8ssvnz7zmc9U7LgjcHzwwQfT+uuvn9599915rrvXXnulK664Iv3gBz8oksPlMt5yyy1p0003rdgxdSYRCH71q19NO+20U6tf09L7Z5111plr/S666KL1f3ft2vUTHC0AQG3785//XCRx77vvvvTcc8+lFVdcsdHzN954Y5HUaxozXX/99WmbbbapyDG88847xbXD8OHD08iRI+eZOAz77LNPcdwR/33ve99LU6dOTQ8//HB66623KnI8nTHZO2bMmKKRS2sS+nEddvLJJxfXP2uuuWa6++6757rurFmzisTuXXfdlfbff/+01lprpffffz/de++9adKkSWno0KEVLg3QFiR7gcK2226bPv3pT9efjX333be4i3vppZc2S/ZGK91oTduSSBRHi4MIDs4777xGz51xxhnp7bffrugZv+iii9IyyyyTunTpktZYY425rhcB8V/+8pd06qmnpkMPPbRYFgFnvObwww8vAhqqY17vn6YikbzEEku0+TEBAHR0L774YhGz/v3vf0/f/va3iwRqtLAti0Yb559/fjrqqKPS7373u/rXfOc73yme22STTRrdRF9YSy+9dNFaNHr2PfDAA0Wji7n561//mv74xz8Wx/zlL3/5E++bBbfeeusVjWKiFXY0fNl5553nuu4vf/nLdNttt6U77rgjbbDBBk431CjDOAAtWmyxxYrWutEqd0FEQFkOJpsqDxExPxE8PvXUU8Wd5fkZNmxYkeidnwhsooXDt771rfpl0S0pktpxd/vVV1+d5+vjznkkhqMV8cYbb1ycm2gJfc455zTr9nTMMccUQVX//v1Tnz590mc/+9mi9XBTkXyO9aI7Vb9+/Yo77b/61a/Swoo77tFSecCAAcV+40580+3dfPPNxfHE81HH0fr6ySefbNYCuqVWAuWhFcri92iZEQF8eZiFeG1rfPjhh2n69OnzXS/eS5MnTy5+AgB0ZpHcjTgvWl7GDfH4u6GIxWKIs9NPP71I8EZM/ZWvfCWNHj06/ec//5lvojfi71deeWW+x9GzZ89GQ7jNSxxLJA0j0RvDOUTs2FoxTEGU6Re/+EWRhBwxYkQRg2+22Wbpv//9b6N1H3300SIOjV6EEePH8UWL4qY9/6ZMmVL08otYN8oR1ybR6+yhhx5KCyPKFPF2xPGx3yWXXLIY3iKS4GUfffRR+tnPfpZWWGGFYp+x7x/96EfFEHMNRVkj3m4q1i/H2NEzsZysjRbc5Rh8Xq2r41ojEr2tLUvUVdRZHPe0adMW6HwAHYNkL1CIbjnRJSta3j7++OPpgAMOKMbjaqkFZiTpYt2Gj3KwEkFYuPzyyxc6OIjWCKuuump6/fXXK1Y70VUsWpRGUrWh8h3rRx55ZL7biC5MkUyNBO0pp5xSdGOK8/SHP/yhfp1ITEZLikgOR3epCNjinEa3uYb7iLGCv/71rxcBe6wXY9bGa+68886FKl9sb9SoUUW3roMOOiiddtppRQD4z3/+s1G3vjiO6DIXx3XIIYcUrUMiMd/aMb+atqqOgDWSx/F7PKKVyfxEkBrJ5gjWV1tttXTJJZfMdd0I2CNpHkFqvBej5TgAQGcUyd1I3vbo0aOII5999tl0//33N1svGkI0vUHfGhF/Nx1q65OIuDh610XL30huRkwXCeeI76LFb2vFXCC//vWvi6R1XCdEojfG/G0YF0Ys/MILL6S99947/eY3v0lf+9rXioYVEbs3bDQQSfAYJuz//u//it6I0eMvYtKmjR9aKxqORPI4GqBETB9j40bSt+E8Jfvtt1/RGGTdddctktaRrD7xxBOLY1xQEe/HkHkhzmk5Bo+6+6TiOuKNN94oGoxEA5mI18sNSFpquAJ0YCWgU7vgggsi+mn26NmzZ+nCCy9stn5L68YjtlP2zW9+s1g2YMCA0pe//OXSL37xi9KTTz7Z6mPac889i9e/+OKLC1SW1VdfvbTZZpvN9bktttii2fLHH3+82Nc555wzz23HdmO90047rX7ZjBkzSmuvvXZpqaWWKs2cObNY9tFHHxXLG3r//fdLgwYNKu2zzz71yw466KBSv379ivU/qdjGcsstVxoxYkSxr4bmzJlT/3v5WN999936ZePGjSt16dKlqLOG5z+21dSxxx5bnIOG+vTpU6zfWhtvvHHpjDPOKF199dWls88+u7TGGmsU2/ztb3/baL1Y53vf+17pz3/+c+mKK64ozle3bt1KK620UmnSpEmt3h8AQA4eeOCBIma64YYb6mO8oUOHFjFSWSz7xje+Ufr0pz9deuSRR4p47oUXXih9/vOfLx5TpkyZ5z5i+3OLpefm/vvvb3YtUPbQQw8Vzy2++OJFLBzxXsR2G2ywQamurq507bXXznPbcS0Qr+/du3fptddeq19+7733FssPPvjg+mXTpk1r9vpLL720WG/s2LH1y/r3718aPXp0qRJuvvnmYvsHHnhgs+fKMXjUQ6yz3377NXr+0EMPLZbHNsri74i3m4p6bBhvX3755cW6t9xyywIf87xe+/e//72+viLmjjqNR/zeo0eP4roBqA1a9gKFmFAt7ojH4+KLLy5ahcZd6Bhfq6no+l9et/xoOOHDBRdckM4888ximIMrr7yyuGMed5u33HLLVrXWjZafEe9UcgbhGDYgWqE2FXfey8/PTwxp0bDlarSqiL+jpWwM7xBiqIhYXu4K9d577xVdoGI85Ibdw2IIhejGFueuEq2WY/iMaFUQ222o3JIjuvFFy+LoAtawG1fcqY+ua//+979TNUTL5Wh5/KUvfaloWRHnLYbHiJYJDesg1olWGd/4xjeKlhcx3nMMFxEtWKIVBgBAZ2vVG/NpRIxejvF23XXXovXq7Nmz65dFrBetSmPitBDxeAzhED265jeMQ8Tf85tsbUFEL8EQQylcffXVRY+4iO1uuummtPjii6ef//znrdpOTAQcc3Q07Jm34YYbNopfG04WXe6FWJ4UumkMHkOfRQvWT+pvf/tbcc4bjpvcNAYvH2Oc/4Z++MMfFj//9a9/pY6iXF8x1EXUUbyX4hG9A+O9ET0bgdog2QvUB01bbbVV8dhtt92KwCO62MeMuTEObUMxfEF53fIjJmqo/2Dp0qXoZhWJvAi0IriLCeBivNiF6a5UCREANh0XK5THjW0YIM7NkCFDiq5MDcXQEKHhMAiRlIwkaiSSI5CNsbvifMZQGWXf/e53i9fGeYnzGWOKXXfddQtVtueff774Oa8J6l5++eXi56c+9almz0UiPuppQcZQq5RIjMd7bOLEifUJ87mJi4MYfy0CTgCAziKSuZHUjURv3OB/7rnnikckPGMog0jMlcVN/Gh80FSMI1tt5fg6Es5xrGWRdN5hhx2KIR6iUcT8rLTSSs2WRRzdMP6OBhbRWCAS4rHfiL9jv6FhDB4JyxgGIoZdiOufGNoshn9Y2Bg8rg/mNR5uxOBxbbTiiis2Wh4xbSSeyzF6R1CurxjiLc5P2fDhw9Omm25qQmuoIZK9QMsfDl26FAFltAiN1pQLK5Kd0Yoz7mrH+FQxs2t7BDXlWYObKi+LQK0SolV03AGPCRh+//vfFwncaL0b44pFS9+ymAwiWtr+4x//KM5PjIMVid8999wztbe5jetWbjVSaeVgMoL01qzbmvUAAHIRDSYiZo2EbyQ+y49ddtmleL7pRG1lCzMnQyWV4+tIwDYVsXBMxlypxgZxLs4///yi51j0TIzWzOWGFA1j8FgvkrvRgyyO79RTT02rr756uvbaa1Nbau24ydWMwRe0vmL+EqA2SPYCc1W+017u0vNJxVAGoaWka1tbe+210zPPPFNMFNFQdOMqPz8/0d2raUAa2wzlISeuuOKKYtKJCDL32GOPYniLaPlcbkHctFVrtGqIYQmiZUAMCRETUERLjQURieXQdFbihsoT5z399NMtzry8xBJL1LdajknjoqVtUy0l6T9J4FpWbk0RLTDmJbqPxUXL/NYDAMhJJHMj2RYTIDd9xERtMWxaa4Ykq7ZIHkYL1paGcYu4OnrBxSS889NSw5OIwcvxdyQho3VzTI42ZsyY9OUvf7lo4Rwx+dwagUQvu6uuuqpoKR2NU44//vgFLl/E4FGOeTVEiBg8ks1NyxAtsiPeLsfoc4vBo4dl02unSsTfLVlzzTVT9+7d51pfYnCoHZK9QIviTnvcEY+E5ILM7jp+/PhiJtemIlCJIKylbkxNRUATCcg4hkr56le/WtwVP++88+qXxbAOMb5wdCtr2FVpXsnvc889t1GZ4u8IfNZbb71iWbnbXMNZfyOhfPfddzfaVoxd1lCclxj6oXxcCyJm9o1uajGubdMAsXwcEdRGQjuGmGi4TiSIo55jpuKGgWt0d3v00Ucb1UlcSDQVCeKWEsMtefvtt5stizHB4rgj2Vw+h3NbN2ZOjuXt0Q0RAKA9RBI3GhFsv/32RTzb9BHDYUU8Fb3FPqmIv1955ZVUSTGu8KuvvtponoryMG/R8y1i4PmJpGzDBGQM/xDxdfSKm1v8HSLGbCiuBRoO6RAiiR5J6QWNv0PMKxH7jARzU+VjKcfYTY/l9NNPL35ut912jWLwsWPHNlovrl2atuwtN9BobQzeWpF4j+O96667ivdC2ZNPPlksiwQ6UBu6tfcBAB1DdF0qf6nHhGOXXHJJcQc67pD369ev1dt57bXXivGvIniLCdnibn5s79JLL03jxo0rJhGLxN68HHXUUUVSMu60z2+StgiIykFRJAKj5W15sodRo0YVjxAJ3Z133rnYdhxPJJxjH9FSNIZbaI0IBE8++eTiNTFO2GWXXVYMxRBBWNwFDxGIR0AeLQoieIsynHPOOcX4xw1bSMfkd9EKIM5TjNkbrWajO1kkZBsm18vln1c3vAiSIxEarYTj9XvvvXeR3I36fPzxx9P1119frBfd1CIo3mijjdK+++5bXDzEPvv371+MV1YW4yofccQRRRkOPPDANG3atGL7UeaGE1yESNDGGLoRsMb5aTomW9NJACNYj+OMsb8igfyHP/yhuKi46KKL6ie2C9HKIS4OooVBtPqI4T+i62KUr+EkeQAAOYskbiRzY9ivlsQkZNHwIFr/Ruz0SUQMGsOutWaStpiMOZKN5YnOrrnmmuI6IHz/+98v4ssQsfdf//rXIjEak5TF8oiNo1HHCSec0Krjirg9xoyNCd4iKRuJ02iNe/jhhxfPx7VKxPwxHm9sNyZzi8YMEYc3FOcx4u5IkscEdjF2cMSx999/fzrttNPq14vyx3B2MfFawxi5qVgnevL9+te/Lq6bokFCtOK9/fbbi+ciER/7iWHa4nohzlec30hWx3VITDxXnnCvfH0Qw1DEuYrEalw7RRzf9Nop4uFIcMd1SSSvYxLquKaIxPXclK+P4togROwd8XX48Y9/XL9e1Ek00IntxXVAiPLFuMQxoTJQI0pAp3bBBRfEbedGj169epXWXnvt0tlnn12aM2dOo/Xj+dGjR891e5MnTy796le/Km2zzTaloUOHlrp3717q27dvaaONNiqdf/75zbbXkj333LPYz4svvjjfdY899thmx19+xHMNffjhh6VDDz20NHjw4FLPnj1L66+/fum6664rtcZmm21WWn311UsPPPBAUZY4RyNGjCideeaZjdaL8p1wwgnFc7GPddZZp/TPf/6zKFMsK7viiitKW2+9dWmppZYq9ejRozR8+PDSt7/97dKbb77ZaHtLLLFE6TOf+UyrjvGOO+4off7zny/Od58+fUprrbVW6Te/+U2jdW688cbSJptsUurdu3epX79+pR122KH0xBNPNNvWf/7zn9Iaa6xRHNunPvWp0sUXX1x/rht66qmnSqNGjSq2F89FOecmthnHF+c/3heLLbZYcQ5uuummZuvut99+pdVWW60oS6y74oorlo444oji/QUA0FlErBZx59SpU+e6zl577VXES++8884n2lfEchHztkbEtXOLwZvG8M8//3zpy1/+chF7Rsy4xRZblO6777757iO2E9s79dRTS6eddlpp2LBhRXz92c9+tjRu3LhG67722mvFPiK+7N+/f2nnnXcuvfHGG42uCWbMmFE67LDDSiNHjqyPl+P33/72t422dc011xSvO+ecc+Z7jB999FFxfKusskoRNy+55JKlbbfdtvTggw/WrzNr1qzSmDFjSsstt1xRT1GOo446qjR9+vRG25o9e3YR70b8v8giixTXU88991xxrpvG2HFdtfzyy5e6du1aHOstt9wyz+OcW121lBKKY99qq62K8xPnaccddyw988wz8z0XQMdRF/+0d8IZoKPbfPPNiy5n8xoXt9JiOIyYMOKf//xnoy5eAACQu+jZFr3GonfaoYceWrX9Rovh6JUY82hEq1mAWmPMXoAO6pZbbimGXJDoBQCA6sXgP/nJTyR6gZplzF6ADmr06NHFAwAAqI4YwxeglmnZCwAAAACQAWP2AgAAAABkQMteAAAAAIAMSPYCAAAAAGRAshc+gVNOOSWtssoqac6cOQv82uOOOy7V1dU5/+2kLc7/rbfeWmwzflZabDeOuSPafPPNi0dntDB1PmvWrDRs2LD029/+tk2PDQDoXNcXLLzOfm22MNcaX/va19Iuu+zSZscELDzJXlhIkydPTieffHI64ogjUpcunfu/0hNPPFEEBy+99FKb7+uNN94o9vXII4+kWnDJJZekM844o70Pgw6ke/fu6ZBDDknHH398mj59ensfDgDQQXSk64tqxvfUpnif/u1vf0vjxo1r70MBmujcGSr4BP7whz+kjz76KH3961/v9OcxgsExY8ZULdkb++qIyd5Ro0alDz/8sPhZJtmbt5bqvDX23nvv9M477xTvDwCAjnZ9Uc34nvYX8eyPf/zjBXrNOuuskz796U+n0047rc2OC1g4kr2wkC644IL0pS99KfXq1cs5zFR0n1uQlpfRAiPeD+3dEoOFN3Xq1AVaf2HrfLHFFktbb711uvDCCxfwCAGAXLm++P8iBjeUxcKJGwYzZ85coNdEPNutW7cF3lcM4/D3v/89ffDBBwv8WqDtyEjAQnjxxRfTo48+mrbaaqtGy+POd4x39Itf/CL98pe/TCNGjEi9e/dOm222Wfrvf//bqi/mn/3sZ2mFFVZIPXv2TMsuu2z60Y9+lGbMmNFovVi+/fbbpzvuuCNtsMEGxZfz8ssvn/70pz8122YcZ+w/jmPo0KHp5z//eRFIxnE2vVN/7bXXps9+9rOpT58+qW/fvmm77bZLjz/++DyPOZJVO++8c/H75z73uWK7TccwjbFJV1999aJMQ4YMSaNHj04TJ05sVqa99tprnuPBxjbXX3/9+paR5X3NL2EW5yleF+cpzu25557b4nqxre9973vpz3/+c/3xXnfddcVzDz/8cNp2221Tv3790qKLLpq23HLLdM8998xz/NY47n/961/p5Zdfrj/WKOe8RF0ffPDBackllyzqIG4ovPbaa83Wi21+97vfTZ/61KeKul188cWLemhap3FuYr933nlnMXRAbDfq98tf/nJ6++23G637wAMPpG222SYtscQSxTaXW265tM8++8zzeOdVjmOPPTatuOKKxXmMMWoPP/zwZu/llsR5W2ONNerfu4ssskixnSuuuKJ4/rbbbksbbrhhcYxR/htvvPETnZvYXqy/1FJLFf9HFmQbLY3Z++yzz6b/+7//S4MHDy7ec7HNGNNs0qRJjV77+c9/vnhvvvfeewtxhgGAznB9ESLp+atf/SqtueaaRWwR8dwXvvCFInZri+uIasb3DeOpv/zlL0Xr0mWWWaaI/2JYi3h9xN6vv/562mmnnYrfo/yHHnpomj17drPzFMOnxXFFuQYNGpS+/e1vp/fffz8trIsvvjitt956RTw4cODAIqZ79dVXWz0G8DPPPJN233331L9//+K4f/KTn6RSqVRsY8cddyyuLSJmbNo6NpK1xxxzTLHveG3E73Gddsstt8z1+jPKXq7/aJnd2m20NGbvlClT0g9+8IOiDmN7ESdH7PrQQw81el0si8YSN9xww0KcXaCtLPitGyDdddddxVlYd911WzwbESzFF2QEPXFXOoKzLbbYIj322GNF0DE3++23X/rjH/+YvvrVr6Yf/vCH6d57700nnnhievLJJ9OVV17ZaN3nnnuuWG/fffdNe+65Z9HtK4Kh+DKPACdEUFQO0I466qjiC/53v/td8YXd1EUXXVRsJ5J9MVbYtGnT0tlnn5023XTTItE5tyRldF8/8MAD069//esioFx11VWL5eWfETREF7AIXA844ID09NNPF9u9//77iwRkjF/aWrHNn/70p0XQ8q1vfasIVsLGG28819fEOY8WlBFcxbFEIBxJyLnVw80335z++te/FknfSHpGuSPhHfuKYCwSlnHMkTCOILWceGzJ0UcfXST4Ilkbyf8QAeq8xHsggspvfOMbRbnieCLp3lScv3gfRsAZycQI9OK8xjFFcBcBckPf//7304ABA4qyx7oRDEYZL7vssuL5t956q/48HXnkkUXL01gv7tQvqAi0I0kdFxFRT1FvUQ9xDiLgveqqq+a7jQjK40IkyhcXG1G2+D0S8RF4fuc73ynO0amnnlr8P4iAOZLjC3NuIqkb5Y73Vbll74JuoyyC6vg/FBdWcc4jeI//h//85z+LC6AItMvi/2oE+7GfKCsA0HnN6/oi4v1IwEbDg4gVI569/fbbi4YH0Y2+0tcR1YzvG4pkdY8ePYpEbsRS8XuIpG7EVxFzR1IzbvRHcjQSm7H/skjsxnmKRiFx/JFAP/PMM4trmYU5rphfIZKz0Xo1zm80lPjNb35TnJ/YZsTL87PrrrsW5+2kk04qGoFEw5tIGse1RFwfxnVXxLdR5micUh4aLBLdcd0WQ3rsv//+xbXl73//++I83HfffWnttddutJ9ozBPXnRF7x7Ve7GNBt9FQxNrR0CKuF1ZbbbX07rvvFrF9vJ8avkfjuUiEx/mNxiRAB1ECFtiPf/zjUvz3mTJlSqPlL774YrG8d+/epddee61++b333lssP/jgg+uXHXvsscWyskceeaT4e7/99mu0zUMPPbRYfvPNN9cvGzFiRLFs7Nix9cveeuutUs+ePUs//OEP65d9//vfL9XV1ZUefvjh+mXvvvtuaeDAgcXr43hDlGOxxRYr7b///o32PX78+FL//v2bLW/q8ssvL7Z3yy23NFoex9SjR4/S1ltvXZo9e3b98jPPPLNY/w9/+EOjMu25557Ntr3ZZpsVj7L777+/eO0FF1xQao2ddtqp1KtXr9LLL79cv+yJJ54ode3atdH5D/F3ly5dSo8//nizbUQ5nn/++fplb7zxRqlv376lUaNG1S+L8jc9D9ttt11RttYovwe++93vNlr+jW98o1ge75myadOmNXv93XffXaz3pz/9qX5ZnKdYttVWW5XmzJlTvzzei3EOJk6cWPx95ZVXFuvF+V1QTevooosuKs7j7bff3mi9c845p9jHnXfeOd/txXqXXHJJ/bKnnnqqvn7uueee+uXXX399s/fDgp6bTTfdtPTRRx81Wr+122ha5/F/Lf6O/xPzE++hWPfkk0+e77oAQOe8vohrgFh+4IEHNntNObZri+uIasb35Xhq+eWXbxaDxevjuZ/+9KeNlq+zzjql9dZbr/7viDtjvT//+c+N1rvuuutaXN5U02uzl156qYiVjz/++EbrPfbYY6Vu3bo1Wz637X3rW9+qXxbx5tChQ4vrs5NOOql++fvvv19cPzY8V7HujBkzGm0z1hs0aFBpn332aXb92a9fv6JuGmrtNkLTa424Bhw9enSpNVZeeeXStttu26p1geowjAMshLizGWMaza2VZnQxiu5HZdFFKu5E//vf/57rNsvPRVf7huLOfIg7wQ3FXdRyy9YQLROjy/kLL7xQvyyGINhoo40a3bWNu7y77bZbo21Ft5todRh3fWPSqPKja9euxXG31NWnNeKue7R0jJaYDcc0jTvL0Uq2aZkqLVoBXH/99UV9DB8+vH553F2PO9otiWED4tw23MZ//vOfYhvRxa1s6aWXLlqWxh3uuGteCeX3QLREaCjOX1NxB71s1qxZxXsyhjqIFgZNu1eFuMsfLbzL4r0TZYvhCkK5ZUK0QI3tfRKXX355cY5XWWWVRu+naL0QWvN+iv9b0aq2LN7bcYyx3YYtqcu/N3zfL+i5ifdjvNcbWtBtlJVb7sb7LlrHz0u0tA5xbgCAzm1u1xd/+9vfihguemc1VY7t2uI6oj3i+2hl3DAGa9rStKE4/obHG/FnxGExrEDD+DNaK8c5XdDrmejdFr3VolVvw+1Fr62VVlqp1duLFsFlEW9GS+zIrUar6rKIL5ue/1i33LI5jiOG/YoW3fH6lmLRGEIs6rGhBd1GQ3FM0To8Jseen4hpxbPQsUj2QhuIAKCplVdeeZ6z2UbSLQKmSCg1FAFFfNmWk3JlDZOXDb9oG45JFa9pur3QdFmMMRoiGRdBQsNHJDqji//CKB9zBC8NRdARidOmZaq06GoVM8u2VB9Nj6ksxqltuo1I2rW0fiQeI3BqzbhdrVF+D0SXtPkda5Qrhh2IsXCjq1YMORH1FUn7pmPDtvR+KScay++XSHJHkBhd8mJbMYZYdAdrzRi7TcX7KYa+aPpeiv8DoTXvpxg6oWFyOkQAH+VtuqxhORbm3DSt84XZRsNtxYVWdJmL18RNhbPOOqvF13zciOL/X6gBADT1/PPPF2PiRoONal5HzGtfbRXftxSThfI4xfM63og/I96KsWWbxqAxediCXs/E9iJWi+uIptuLoQxau72m5zpi1yhPxIlNlzc9/zEsx1prrVWsH/NHxL4jmd7aeHZBt9HQKaecUsw5E7FwNFyKoTvmdjMgzpN4FjoWY/bCQogvyrgrGuMelccJrZTWflE2bYnYNIG0IMoz3ca4vREUNrUwM7NWqtzR+nRuZW0Lc2tN0NHEeLCRjI1WFdF6OwLEOIfRGralmYvn936J18a4XDH22zXXXFO0TI3J2WI8tFg2v7GGG4r9xwQip59+eovPN03YtmRux9ua9/2CnpuW6nxBt9FQnLMY9+7qq68ubpZES+0YMy/OY3kCuFAO6JsG+wBA51OJ64v2uI6oZHw/tzi8NdcCEZ9FojfGv21J02Rxa7YXxx8TWLe0/9bGxi29tjXnP+bwiHgyehcedthhRdnidRFTxg2A1py7Bd1GQ9GiOVpPx3jPEc/GPBkxvnC0eI6xoxuKmLalxjVA+5HshYUQ3dNDDPofd0qbKreUbSgmpprbJGdhxIgRRVARry1PfhAmTJhQtCaM5xdUvCYmYGiq6bJyS9IIAFqaAXhhA7nyMcekDQ2HQIiuX3HuGu4r7s43ncE3ROuAhq9dkLvGEdRF4NNSfcQxtXYbMRlXS+s/9dRTRSuKeSUvF+R4y++BCL4atpZoad+RmI2ubg1n7o1JGVo6hwviM5/5TPGICSkuueSSYsiPmBm5YRe0+Yn307hx49KWW27ZLnf5K3FuPuk2Itkdj5hROiZc2WSTTdI555xTTMpRFv8HQsP/7wBA5zS364uIq+ImfHTBn1vr3ra4jqhmfF8JcZ5iiImIuSrReCO2F8nXaDFb7p1WTRGLxjmK5GrDumhpOI+22kYMWxcTGccjWjLHxGxxjdAw2Rs3KKKXY0zODHQchnGAhRAt/cIDDzzQ4vNXXXVVev311+v/jtlOY8yjpndBG/riF79Y/DzjjDMaLS+3jtxuu+0W+DijC/ndd9+dHnnkkfplESg2veMd68UYWyeccEKL47XGUAbz0qdPn+Jn02Augr3o0hUz+Ta8Ux2zwEbXoYZlioAqWj5GoFgW48c2HSJhbvtqSdy5jrJFfbzyyiv1y6PrVQTNrRHb2HrrrYtWmg2H4YjgOZKhm266aXHu5iaOd37dpMrK7484Xw01fU+Uj6tp64uYHThaSiyMuCPfdHvlsZ4XdCiHaAkQ7//zzz+/xeERpk6dmtpSJc7Nwm4jxm+OoLehSPrGTYGm5/HBBx8sAu/y5wkA0HnN7foihtmKmCSG2mqqHKu0xXVENeP7Soj4M+K0n/3sZ82ei9hsQRtEfOUrXyniwTjvTWPC+DvGWG5L5da/Dfcd15NxbdfW24jz2PT6JRoFxXAiTePZJ554omgQsfHGG7f6uIC2p2UvLIS4Q7rGGmsUd4+jq3tTMV5WJAEPOOCA4gsxAq/omnX44YfPdZsjR44sWhKed955RTASY6hGkjjGWYquN5/73OcW+Dhjf9F9JyYqiG7pEbTFWKIxdlQkfct3eCNZefbZZ6c99tijuGMbXdWjRWskSGNMp7hDfuaZZ851P5EUjGAiuvZEYBBjnMb4vxEUHHXUUUWQ9IUvfKG44xutAH7729+m9ddfP+2+++7124iWo3H3OdaLYC1at8axNx2/Nv6OsceilWR0cYsyxSRdcxunKvYdE9VFN6S4Kx3BXiTtVl999fToo4+26jxGa8yYxC7qNLYRw1qce+65Rd3GeFbzEpNCXHbZZcU4rlHm6PK1ww47zPU8xiR5cX7iPEbQdNNNN7XYOnv77bcvht2I4QViko0I2uL9GO+zhRHvs9jvl7/85eIcRxfCSNbGe6N8AdFa8T7661//WkykEZNXxPsngsZoCR3LI9EeE0O0lUqcm4Xdxs0335y+973vpZ133rloBRLvt9hO/P+Ii7WG4j0V52Zh6wwAyP/6Iq4BIraK5Gq03I1YOVrx3n777cVzEXe0xXVENeP7Sogyf/vb3y6GKIiGLtFYo3v37sU5i8nbfvWrX6WvfvWrrd5eHGNcA0RZo8FHnMe49ojWyzG0QUx+fOihh6a2ErFotMiN2DwS6LHfuP6JuDTGIG7LbcR1QAw9Fucr3ltx/RLvy/vvv79Rr7dyPBu9ION6E+hASsBCOf3000uLLrpoadq0afXLXnzxxbhtWjr11FNLp512WmnYsGGlnj17lj772c+Wxo0b1+j1xx57bLFuQ7NmzSqNGTOmtNxyy5W6d+9evP6oo44qTZ8+vdF6I0aMKG233XbNjmmzzTYrHg09/PDDxf7jOIYOHVo68cQTS7/+9a+LfY8fP77Rurfccktpm222KfXv37/Uq1ev0gorrFDaa6+9Sg888MB8z8f5559fWn755Utdu3Ytth3bKjvzzDNLq6yySlGmQYMGlQ444IDS+++/32wbcc6WWWaZ4lg32WSTYr8tlenqq68urbbaaqVu3boV+7rgggvmeWy33XZbab311iv16NGjOMZzzjmnxfMff48ePbrFbTz00EPFuYk6X2SRRUqf+9znSnfddVez89e07B988EHpG9/4RmmxxRYrnou6m5cPP/ywdOCBB5YWX3zxUp8+fUo77LBD6dVXXy1eG8dcFudv7733Li2xxBLFMcWxPfXUU8X299xzz/r14tzEa++///55HmuU7+tf/3pp+PDhxflfaqmlSttvv32r6r6lOpo5c2bp5JNPLq2++urF9gYMGFDUQby/J02aNN/txeuamtv7vmm9fdJzsyDbaHoeX3jhhdI+++xT/N+J/0MDBw4s3is33nhjo+1PnDixeD/+7ne/m+e5AAA69/VF+Oijj4rri4inI35YcsklS9tuu23pwQcfbNPriGrF9+V46vLLL2/2+oi7IiZuqqVYPpx33nlFzNm7d+9S3759S2uuuWbp8MMPL73xxhvN1m3N9v72t7+VNt100+IY4hFljrjz6aefbtX23n777VaVp2n8O2fOnNIJJ5xQ1Fecu3XWWaf0z3/+s3h9w+uJhtefTbV2G6HhtcaMGTNKhx12WGnkyJHFOYzjjd9/+9vfNtvHhhtuWNp9993neS6A6quLf9o74Qy1KO5wxx34aNm57777Fsvirm+0MI0B7NvyTu8nFZNORcvUuKNbzcnPgI9Fa//47IgWLrUyKSAAUP3rC+ioogV19Ap96KGH6od/AzoGY/bCQoru3TFMQiR2oytVRxVjpDYU40tFt/IYkkCiF6ovxsWOMfRi8jaJXgCg1q4vIJx00knFUA8SvdDxaNkLFdQRW/bGl+/mm29ezMwbk4rF5AlvvPFGMRbsqFGj2vvwAAAAAKgQE7RB5mJyrZgYISZsiAnZoqtNJHwlegEAAADyomUvAAAAAEAGjNkLAAAAAJAByV4AAAAAgAx0uDF7Y9bRmDyqb9++xfiiAAC0j1KplKZMmZKGDBmSunTRRqAzEpsDANRWbN7hkr2R6B02bFh7HwYAAP/z6quvpqFDhzofnZDYHACgtmLzDpfsjRa94dlnn63/va1NmDAhDRo0KOVK+WpbzvWXc9mC8tU29Ve71F3lRMuBlVZaqWoxGR2P2Lzycv6MyrlsQflqm/qrXequtqm/6sfmHS7ZWx66IQ68X79+VdnntGnTqrav9qB8tS3n+su5bEH5apv6q13qrvIMrdV5ic0rL+fPqJzLFpSvtqm/2qXuapv6q35sbvA1AAAAAIAMSPYCAAAAAGSgww3j0NpZgWfNmtVs+fjp76eJsz5Y4O1N/GBimvBO89ct1n3RNLjXgFTrZs+enWbMmNEu++7evbvZuwEAMp4VOmLNeDQlNu9YsXnXrl2Lh2FZACBv3WpxrI8Y3Lmpt2dNTt978XdpVql5oLmwutd1TWcut19asnu/mg8oYybl9hKTNCyyyCLttn8AACovGl+8/fbbafr06c0SiGLzjhebR2K+V69eackllywaZAAAeepWay16I9Hbp0+ftMQSSzQKKj+c/Eqa9ULlEr0hEseLDlosLdtveKplH330UerWrVu7BJTvvPNOUWcjRozQwhcAIBMR573++utFjLnMMssUyUOxeceNzaO+ysn5qLeIzbXwBYA81VSytzx0QyR6e/fu3ei5ntN7tsk+e/boWdwBr2Vx3trr7n3U1dSpU4tj6NmzbeoIAIDqmjlzZpFAXHrppVvswSU273ixeVw/RZL5lVdeKY6hR48eVT8GAKDt1eQEbe5C1w51BQCQry5davJyInX2+opEPQCQJ9EZAAAAAEAGJHtp5i9/+UvaddddWz3BxMiRI9OTTz7pTAIAQAWJywGABSXZ2wa22GKLYkys/v37pwEDBqS11lorHXroocWECO19XL/61a/mOwnej3/84+JRdu+996Ytt9wyLb744mngwIFp7bXXThdeeGHxXNeuXdMhhxySjj766DY/fgAAWBDicgCgs5HsbSMnnXRSmjRpUnrvvfeKO/Ix6+3666+fJkyYkKotxuSKFrit8e9//7tI6K655prF31OmTElf/OIX084775zGjx9fHP/555+fllpqqfrXfPWrX00333xzMdkDAAB0JOJyAKAzkeytwgRlq622WrroootSv3790umnn17/3EMPPVS0mF1iiSXSyiuvXCRRy8aMGZN22GGHtN9++6XFFlssfepTn0pXXnll/fP/+c9/0gYbbFC0HF5mmWXS6NGj04cfflj//PLLL18EthtvvHGxTgzLcPvtt6cjjzyyOI5I4LbkmmuuSZ/73Ofq/3766afT1KlT07e+9a1i1uB4RNK64ev79OlTLPvXv/5V0XMHAAA5xeWLLrpo2m233cTlAECbkeytkm7duqUdd9wxjR07tvg7Wslus8026dvf/nbRWvbvf/97EUjedNNN9a+5/vrriyTqO++8k37xi18UgeHzzz9fPBfDRJx77rnFc5HEvfXWW9Mvf/nLRvv84x//mC644IL07rvvpksuuSR99rOfLQLNyZMnFy14WzJu3LgigC2LYDeGo/j617+err766uK4W7LqqqsWrwUAgI6sPePyiMP/9Kc/icsBgDYj2VtFQ4YMKYZ1CBdffHER5O2yyy7FuLdrrLFG2muvvdKll17aKNEaQWcEpNGaYPPNNy+GhAjx2nXWWad4bbQWiJa3EVg29J3vfKdI3MY6PXr0aNUxvv/++0VLh7L4/c477yyGdohxh4cOHZo22mijovVDQ7FevBYAADo6cTkAkKtu7X0Anckbb7xRJE3DSy+9lK699tr6v0OMq7vpppvW/z18+PBGrx8xYkQx9m+4//77i0nRHnvssaKb2EcffdSoRW4YNmzYAh9jdD+LFgcNrbjiiunss8+uL8Phhx+edtppp/Tyyy8X3eFCvCZeCwAAHZ24HADIlZa9VRLJ2H/84x9ps802q0/ERsI0WvqWHzGhW8Nxb5tOeBZ/xzhgIbqORUvf5557Lk2cODEdf/zxxURsDXXp0mWef7dk5MiRxTi982oFccQRRxRJ53Ir5fDkk08WrwUAgI5MXA4A5EyytwqeeuqpYoiGSOYefPDBxbLdd9893XLLLelvf/tbmjVrVvF45JFHiha7Zc8880wxOUQEpJEEjvVj2IdyS9qYICImR4tE6znnnDPf41hqqaXqxxabm+23377RcBBx7KecckrREnnOnDlFYvmss84qhphYfPHFi3WmTZtWHPfcJn0DAICOQFwOAOROsreNHHnkkcXEZjG0wVe/+tU0ePDgdN9996VBgwYVz0cL3RjG4bzzzit+X3rppdP3v//9RkMoxEQR9957bzErcCSJYzKHlVZaqXguhlU47bTTirFyv/vd76Zdd911vsd00EEHFRNNxNARMQZwSyJhG5NL/Pe//y3+7tu3b3r44YeLFsmRXI6J2N5+++1israySFhHK+MYZgIAADoScTkA0Jl0ujF7h02Ymr489rX091HD0muDFmmTfdx8882tWi8mWIuZfecmJmb73e9+Vzya+vKXv1w8GjruuOPqf3/hhReavWbDDTdMjz/++DyPKSZz+/nPf148YjK4SEQ3nDSuqWjtG0nnSy65ZJ7bBQCAasfm4nIAoLPpdMne9Z5+L63+0uT0yqD32izZW+u+/vWvF4/WiHGAY/gJAABYUGJzcTkAUFmdbhiHdZ6ZWPxc+9n32/tQAACgUxObAwC0c7J37NixxXivQ4YMSXV1demqq65q9HypVErHHHNMMQZt796901ZbbZWeffbZ1BEsPnFGGvz+9OL3pd+bnhafNCN1VMcee2y68sor2/swAADooGo5Lq+l2FxcDgBkneydOnVqGjlyZDrrrLNafP6UU05Jv/71r9M555xTTC7Wp0+fYqKx6dM/DuTa01ovTExz/vd7/Fzz+Y9b+QIAQK2p5bg8iM0BADrAmL3bbrtt8WhJtB4444wz0o9//OO04447Fsv+9Kc/pUGDBhUtDb72ta81e82MGTOKR9nkyZPTwlisx6KpR5fuaeacWXNdZ2QM3VAXB5qKn2s/OzHduu6gua4f24vtAgBAR1PpuDyIzQEAaltFJ2h78cUX0/jx44suYmX9+/dPG264Ybr77rtbDCpPPPHENGbMmGbLJ0yYkKZNm9Zo2ezZs4vHRx99lGbNapzUXbJ7v/SPzcakiTM/aPHYStOmpcmn7fFxojeaNJdSWvX1qenSdQ9OpZ49i4nGmopEb2y36b5qzZw5c9qtDFFXUWfvvPNO6tq1a5u1aon3Xa5yLl/OZQvKV9vUX+1Sd5UzZcqUCm6NalqYuHxBYvN5xeVBbN45Y3Ofv7VN/dW2nOsv57IF5attUztgbF7RZG+5cNFioKH4e24FP+qoo9IhhxzSqGXvsGHDitf069evWUuDN954I3Xr1i1179692baGdx+UhqeWW+q+fct/0uQ55UEc/mf27LTM82+m/pts3uL2chHBZHuVL4LJCCSXWGKJ1LNnzzbZR7y3Bg8enHKVc/lyLltQvtqm/mqXuqucRRZZpIJbo5oWJi5fkNh8fnF5EJt3vtjc529tU3+1Lef6y7lsQflq2/gOGJtXNNm7MCLIaKskYEPv3XlbquvaNZVmz65fFn+/e+dtRbIXAAA6O7E5AEBtq2iyt5zJjm5eMetvWfy99tprV3JXacbbE9Ks995t1bqlUkrv3nFro0RvsXz27PTe7bekpXbcJXXv3rpT0X3g4qnnknMf5xcAANpbNePyIDYHAMgw2bvccssVgeVNN91UH0RG16+Y/feAAw6o5K7SU8ccliY/9kjrX1AXM7M199HUD9J/v7N7qzfTb6110sjf/jF1BHFu11tvvXTXXXelJZdcstWvi1mYDzvssEZjuAEAkI9qxuWhs8fm4nIAoKNoPivZfHzwwQfpkUceKR7lyR/i91deeSXV1dWlH/zgB+nnP/95+sc//pEee+yx9M1vfjMNGTIk7bTTThU98EHbfyXVdes210Cxxea9C7K8qbq6VNetexq03Zfnu+oWW2yRevfuXYxrFhNhrLnmmunyyy9v3X5SShdeeGFad91157ve6aefXsyu3DDRG/Ww7777FmOrxf4j0P/617+e7rzzzvp1fvSjH6Ujjjii1ccDAEDH01Hi8o4cm3e0uHznnXcuGmqUicsBgHZP9j7wwANpnXXWKR4hJnCI34855pji78MPPzx9//vfT9/61rfS+uuvXwSh1113XerVq1dFD3zwdjultc+9OPVYYqmUulR+JtlGunQthm5Y+7yLi/22xkknnVTc4Z84cWLx+x577JFefvnlis6ke/7556e99tqrfllsf4MNNigmyhg7dmyx70cffTR99atfTddcc039eqNGjSqea5gABgCgtnSUuLyjx+YdKS7fZZdd0r/+9a/69cTlAEC7J3s333zzVCqVmj3irneIVgQ//elPi9nopk+fnm688ca08sorp7aw6KdWS+v+8Yo0YP3PpLYU21/nwivSoiuvusCvjfOx3XbbpcUWWyw9/fTTc20hEH/H8ocffjh997vfLVpfRAuAeESrgKbuu+++YjbdNdZYo37Zcccdl0aOHJnOPffcouVAly5dUt++fdP//d//FYFtw2P63Oc+1ygBDABAbelIcXktxOYdIS6Plr3HH398o2MSlwMA7Zrs7Wi69+ufVj/1rDR83+9+vKCuQkX633ZG7De62H73fv0WajNz5sxJV199dfrwww9bNRlGtMb47W9/W3QxixYI8Rg+fHiz9caNG5dWWWWVRsv+85//pF133bVVx7XaaqvVd/kDAIDcY3NxOQDQGdR8sjfUdemSRuz9nbT6L36bui6ySEpdP1nXsbquXYvtrHHa2Wn4Xt8utr+gYvytgQMHFnfwYxiFo48+Oi211FKpUt5///1i2w298847xThsZTEhRxxDjB3WcHmI10Z3MgAAyDk270hxebQqHjFiRKN1xeUAQCVlkewtG/iZTdO6F16e+iy3Yusnh2iqri4tstyKxXYGbLjJQh/LCSeckN577700derU9OSTT6Y//elPRTeuShkwYECaMmVKo2VLLLFEeuONN+r/3nLLLYtjuOKKK4quew3FayPYBACAnGPzjhSXX3XVVeJyAKBNZZXsDb2WXqaYHGKJLbZZqNcvueUXitfHdiplxRVXTNtuu239ZAyLLrpomjZtWqN1Yiy1shjTa35iDLDyWGNlW221VZHYbY0nnniiVcNKAABALrG5uBwAyF12yd7QpWfPIiCMLl8LpGvX1GvpIcXrK+mll15K1157bTEOb4gk6wsvvJBuv/32YvbeU089Nb377rv16w8aNCi9+eabxTi/cxOz+4bHH3+80UQQDz74YDGRxIsvvlhM0BFJ5fvvv7/Z62+99dZiggoAAOgssXl7x+UxmVtT4nIAoJKyTPaGd2+7KZVmz16wF82end657aaK7P/II4+sn7V31KhRRdetn/zkJ/UtCk4++eS0yy67pGWWWSbNmDEjrb766vWv3WKLLdKGG26Yhg0bVozt1dKsv926dUvf+ta36mdbDjHT77333lsEkptuummx75gV+IEHHkj/+Mc/6teLYDae++xnP1uRsgIAQEeNzTtSXB7J3r///e/164nLAYBK65YyNP2N19KHr760UK/98JWX0vQ3X/9EXcVuvvnm+a5z8MEHF4+yH//4x/W/d+/evRjPa35++MMfpvXWWy8dfvjhxSRsYdlll20UaIZZs2YV2yw7/vjji6AWAAByjs07Wlxejs3LxOUAQKVlmex9966xH08CUSo1f7K8fB7Pv3fX2DTk/76eOrpoIfDss88u8Ouuu+66NjkeAADojLG5uBwA6CiyHMbh3dtviciw+RNduqZufRZNw/f+dvEz/m6uLr17+/xbAAAAAGJzAICOJLtk70dTP0iTHnkgpdKc/78wWgqklBbfdPO03qX/SCP2HV38jL8bPl8ozUmTHn4wfTRtarUPHQAAsiI2BwCoruySve/fd1cxmUPT1ryrjDk1rXbCL1OPAYsXi+Nn/B3LuzZp5Vua/VGaGNsBAADE5gAANaImk72llsbz+p/37rwtpS5dmrXmXXLLbVpcP5av/ae/N27l26VLeje2Q5vWFQAAtW3OnAa96VogNu+Y9VXXsGcjAJCVmpqgLWbDDe+8805aYoklmgUppdmz07t33BpRTOq6aN+07A+OTAM3/3yKkGb69Olz3e6cRfqk5Y85MS126w3ppTNOSrM/mFKM+/vh1KmprmtL4/rWlo8++ijNbtjauYqJ3qirhnUHAEDt69GjRxGLv/nmm2nJJZcsYj2xeceNzSMunzVrVnr77beLehKbA0C+airZ26VLlzRo0KA0YcKENHVq8zF1S5HQHbB46rHSqqnvHvunyf36p8kvvTTf7Uaw1TWSusuulBb76elpykXnp9nvvpVeevbZVNerV6p19eVrJ1FnUXcAAOQhEobLLLNMkTx8/fXXW2wpKjbvWLF5JHx79epV1JuWvQCQr5pK9oZFFlkkjRgxorgz3ZIhv/3jArfGLbcU/ngDQ1I6/vSilXAOrXqbla/KotWARC8AQH4izlt66aWL5OXcWqqKzTtObB4J5nhI9AJA3mou2RsiedizZ8+KbS+Cnkpur6PJvXwAALSPSBx269ateFRK7rFr7uUDANqXvvUAAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAy0CbJ3ilTpqQf/OAHacSIEal3795p4403Tvfff39b7AoAABCXAwDQVsne/fbbL91www3poosuSo899ljaeuut01ZbbZVef/11Jx0AAKpEXA4A0LlUPNn74Ycfpr/97W/plFNOSaNGjUorrrhiOu6444qfZ599dqV3BwAAiMsBAEgpdav0Wfjoo4/S7NmzU69evRotj+Ec7rjjjmbrz5gxo3iUTZ48WcUAAECV43KxOQBA7asrlUqlSm80xujt0aNHuuSSS9KgQYPSpZdemvbcc8+ide/TTz/daN1o9TtmzJhm2xg3blzq27dvqoapU6emPn36pFwpX23Luf5yLltQvtqm/mqXuqvsPAwjR45MkyZNSv369avglqmWBYnLg9i87eX8GZVz2YLy1Tb1V7vUXW1Tf9WPzdsk2fv888+nffbZJ40dOzZ17do1rbvuumnllVdODz74YHryySfn27J32LBhafz48VW7qIh9DR48OOVK+WpbzvWXc9mC8tU29Ve71F3lRFwWn9OSvbVrQeLyIDZvezl/RuVctqB8tU391S51V9vUX/Vj84oP4xBWWGGFdNtttxXZ+ziQpZdeOu26665p+eWXb7Zuz549iwcAANB+cbnYHACg9lV8graGogtPBJTvv/9+uv7669OOO+7YlrsDAABaIC4HAOgc2qRlbyR2Y3SIT33qU+m5555Lhx12WFpllVXS3nvv3Ra7AwAAxOUAAJ1em7TsjbEjRo8eXSR4v/nNb6ZNN920SAB37969059wAACoFnE5AEDn0iYte3fZZZfiAQAAtB9xOQBA59KmY/YCAAAAAFAdkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADLQrdIbnD17djruuOPSxRdfnMaPH5+GDBmS9tprr/TjH/841dXVVXp3AACAuJx2NPu9l9PMR/+euk94IX04aPnUY62vpK4DR2RTJ8pX29Rf7VJ30EGSvSeffHI6++yz0x//+Me0+uqrpwceeCDtvffeqX///unAAw+s9O4AAABxOe1kxqNXpg+vPTalVJe6lOakGS/dlmbce0HqteURqcdq29Z8vcx84t9p+k2nFL93KZWUr8aov9rVqeouRfnGFuXrve1PU8+1dmrvw6PGVTzZe9ddd6Udd9wxbbfddsXfyy67bLr00kvTfffdV+ldAQAA4nLasdVdkegtzSn+LvpxlkrF79NvPLF45ET5apv6q12dou7S7OLfD689JnUbtm7qOmB4Ox8VtaziY/ZuvPHG6aabbkrPPPNM8fe4cePSHXfckbbdtuU7LzNmzEiTJ09u9AAAAKobl4vNWVAxdEM5TQFAJdSlmeP+5lTSsVr2HnnkkUXCdpVVVkldu3YtxvA9/vjj02677dbi+ieeeGIaM2ZMs+UTJkxI06ZNS9UwderUYnzhXClfbcu5/nIuW1C+2qb+ape6q5wpU6ZUcGtU24LG5UFs3vZy+oyKMXpj6AbpXoDKKKVSmjbhhTQpk++J3L73aiU2r3iy969//Wv685//nC655JJizN5HHnkk/eAHPygmattzzz2brX/UUUelQw45pP7vCEiHDRuWBg0alPr165eqISpl8ODBKVfKV9tyrr+cyxaUr7apv9ql7ipnkUUWqeDWqLYFjcuD2Lzt5fQZFZOxxTia5e7VAHwydakuLTJo+dQ7k++J3L73aiU2r3iy97DDDitaEXzta18r/l5zzTXTyy+/XLQSaCmo7NmzZ/EAAADaLy4Xm7Ogeqz1lWJCoRbVdUmL7nFx6rLY0Jo9sbMnvpqmXrRH/ZjEjShfh6f+avf/X+eou93ncqOslHqM/L92OCpyUvFkbwy90KVL46GAo9vYnDkt/CcFAADahLicttZ14IjUa8sjmk+WVNelmFG+25C1aroSuiwysChHTJgU7e2ie3W0uotkjPJ1fOqvdv//dYa667XlkXP97DQ5Gx0u2bvDDjsUY4ENHz686C728MMPp9NPPz3ts88+ld4VAAAgLqcd9Vht22YJi2h1V+vJmLKea+2Uug1bt5gwKcbRjO7V0eoul2SM8tW2nOsv57J1hs9OMkv2/uY3v0k/+clP0ne/+9301ltvFWOCffvb307HHBN3ZAAAgGoQl9Nearl7dUsiudR784OLCZNyGkezTPlqW871l3PZOsNnJxkle/v27ZvOOOOM4gEAALQPcTkAQOfTeHBdAAAAAABqkmQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMdGvvA4Basv/++1d9n6NGjUpjx45NOcq5bEH5als16+/888+vyn4AICfVjs3FdrVN/dWuated2Jxap2UvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGah4snfZZZdNdXV1zR6jR4+u9K4AAABxOR3M7ImvtvchANQcn5102GTv/fffn9588836xw033FAs33nnnSu9KwAAQFxOO5r5xL+bLZt60R5pxqNXtcvxANQCn520pW6V3uCSSy7Z6O+TTjoprbDCCmmzzTar9K4AAIC5EJfT1ma/93KaftMpzZ8ozUkfXntM6jZs3dR1wHAVAeCzk1zG7J05c2a6+OKL0z777FMM5dCSGTNmpMmTJzd6AAAA1Y3LxeYs8Pvq0b/P49m6NHPc35xUAJ+d1HrL3oauuuqqNHHixLTXXnvNdZ0TTzwxjRkzptnyCRMmpGnTpqVqmDp1aho/fnzKlfJVzqhRo1K1DR06tF32Ww05ly0oX22rZv21x3dQzt8NOZet2uWbMmVKVfZD22tNXB7E5m0vp8+o7hNeSF1KpdTS7YNSKqVpE15Ik9qwrNWOI8V2tU391a5q111bf0a392dnteX0vVcrsXldqVQqtdVBbLPNNqlHjx7pmmuumes60bI3HmXRsnfYsGHFierXr1+qhtjX4MGDU66Ur3L233//VG3xpTZ27NiUo5zLFpSvtlWz/s4///xUbTl/N+RctmqXL+Ky2NekSZOqFpfRfnF5EJu3vZw+oz689Zdpxr0XFMM2NFPXNfXccK/Ue/ODs4nNxXa1Tf3VrmrXXVvH5u392VltOX3v1Ups3mYte19++eV04403pr//fV5de1Lq2bNn8QAAANovLg9icxZEj7W+8nHCokWl1GPk/zmhAD47qbI2G7P3ggsuSEsttVTabrvt2moXAADAfIjLaStdB45IvbY8ovkTdV1S721/anI2AJ+d5JLsnTNnThFU7rnnnqlbtzYdFhgAAJgLcTltrcdq2zZbtugeF6eea+3k5AP47CSXZG90E3vllVeK2X4BAID2IS6nPXRZbKgTD+Czk3bSJs1ut95669SG874BAACtIC4HAOhc2mzMXgAAAAAAqkeyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABtok2fv666+n3XffPS2++OKpd+/eac0110wPPPBAW+wKAAAQl9OBzJ74ansfAkDN8dlJh032vv/++2mTTTZJ3bt3T9dee2164okn0mmnnZYGDBhQ6V0BAADictrRzCf+3WzZ1Iv2SDMevapdjgegFvjspC11q/QGTz755DRs2LB0wQUX1C9bbrnlKr0bAABgHsTltLXZ772cpt90SvMnSnPSh9cek7oNWzd1HTBcRQD47KSWW/b+4x//SJ/+9KfTzjvvnJZaaqm0zjrrpPPPP3+u68+YMSNNnjy50QMAAKhuXC42Z0HNfPTv83i2Ls0c9zcnFcBnJ1VWVyqVSpXcYK9evYqfhxxySBFY3n///emggw5K55xzTtpzzz2brX/cccelMWPGNFs+bty41Ldv31QNU6dOTX369Em5Ur7KueGGG1K1DR06NL322mspRzmXLShfbatm/X3+859P1Zbzd0POZat2+aZMmZJGjhyZJk2alPr161eVfdJ+cXkQm7e9nD6jut92fOry4q2pLjW/pCzVdUlzlt0szdrs6Gxic7FdbVN/tavaddfWsXl7f3ZWW07fe7USm1c82dujR4+iBcFdd91Vv+zAAw8sgsu77767xZa98SiLlr0xDMT48eOrdlER+xo8eHDKlfJVzv7775+qbdSoUWns2LEpRzmXLShfbatm/c2vpV1byPm7IeeyVbt8EZfFviR7a9OCxuVBbN72cvqM+vDWX6YZ915QDNvQTF3X1HPDvVLvzQ/OJjYX29U29Ve7ql13bR2bt/dnZ7Xl9L1XK7F5xYdxWHrppdNqq63WaNmqq66aXnnllRbX79mzZ3GADR8AAEB143KxOQuqx1pfmcezpdRj5P85qQA+O6myiid7N9lkk/T00083WvbMM8+kESNGVHpXAADAXIjLaWtdB45IvbY8ovkTdV1S721/anI2AJ+d5JDsPfjgg9M999yTTjjhhPTcc8+lSy65JJ133nlp9OjRld4VAAAgLqcd9Vht22bLFt3j4tRzrZ3a5XgAaoHPTmoq2bv++uunK6+8Ml166aVpjTXWSD/72c/SGWeckXbbbbdK7woAABCX08F0WWxoex8CQM3x2UmldEttYPvtty8eAABA+xGXAwB0LhVv2QsAAAAAQPVJ9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCANSIqc8+nd466Zg09bmn2/tQAACgU5vaQWNzyV6ADuZb3/pWuvjii9PRRx/d3ocCdDDv3XZDmv7Yw+m9W29s70MBgOyJy4FajM0lewE6mLfeeis999xz6fXXX2/vQwE6mPdvv/Xjn3fc0t6HAgDZE5cDtRibd2vvAwDoDLp27Zpmz57dqnWvuuqq4gHQ0Iw3X0/TX3u5+H36qy+nGePfSD0HD3GSAEBcDlTZjA4cm2ed7H3zw/fSxJkfzHe9d6e9m96fNHO+6y3WY9G0dO+BFTo6oD398pe/TEsuuWS644470pQpU9Jmm22Wpk+fnq644or06KOPpv322y+tssoqacKECenCCy9Mzz77bBo+fHjabbfd0jLLLJP69OlTJG/feOONdP3116c777yzftsxBEO499570zrrrJPWXHPNdN9996Xzzjsvffvb304rrbRS6t+/f+revXuaOHFievDBB4v9fvjhh/XdxUaNGpWefPLJdPzxxxfLNt1007TtttumpZZaqvj7vffeSy+++GI655xz2uX8AdX3/j13pFRXl1KpVPyceM8dadBOu6gKaobYHGivuPzSSy9Nn/nMZ9I3v/lNcTmQfWzeLedgcqfbj0sz53xUsW326NItXfXZ4yR8ISMbbLBBEUzOnDkzDRw4MO27775Fd62ePXsWQeOIESPS6NGj0w9/+MMiCF111VXTu+++WwyxsMQSS6Tll18+HXDAAWnq1KnpkUceabTtT3/602nGjBnp7bffTh999PFn0brrrpvmzJlT7KNXr15p0KBBaZtttkmLLbZY+s1vftPiMUYwGwngLl26pPHjx6dZs2YV+47gVrIXOo+Jd97W6O/377y1wwSUMD9ic6A94/KvfvWrqVQqFQljcTmQe2yebbI3WvRWMtEbYnuxXa17IR/Rmvawww5Lffv2Taeddlox3EIEgEcddVT61Kc+VfyM4DFa1MY4ut/73vfS5MmTi9dGy9wTTzwxDR48uGgp0DSojPWOOOKING3atFQXd/xSKlrqvvLKK40Cz5122imtt956xfYikdtUJIQj0fvmm2+mww8/vAhUY3srr7xym58foGOYPfWDNPnRhz5uORBKpTRl3ENp9rSpqesifdr78GC+xOZAe8blkTS+4YYb0o033iguB7KPzbNN9gK0xjPPPFMkY6MVQdl///vfIrCMoLAshl2IVgLRXWy11VZL/fr1KwLQsgEDBsx12yEStGH11VcvWhxEArdHjx7163br1q0IbGN4hpa288EHH6Sll166aMkbSd9IGDfsogbkbdID96bUZNzv0uzZxfKBo7Zot+MCgFqIy2OIiGgxHMTlQO6xeZf2PgCA9lQeJzeGVmi6rBwIhmhJG0naTTbZpAgwY0ywaFFQXjda3s5t22Ubb7xxEZQOGzasCFDj9dGVrKylbYRJkyalI488shhr7LHHHku9e/dOW2yxRTr66KPTCius8InPAdDxvX/32JjpsfHCrl3TxFgOABloy7g84umGxOVAzrG5lr0ArbTiiisWP2+99db0hz/8oZgM4qSTTiqSrwvy+ghEDz744KKVwl577VW08p2XGM83Wv3+61//ql928sknF2P2xlAOzz//vDqEGjPz7bfSrPebt+RvWSlNvPv2Zq0H4u/37xqbpj7zZFz6tmpL3QcMTD2W/HiiRwDoLHF5eRi0pq8XlwM5xuaSvQCt9OqrrxbJ1c0337z4GV3EGrYymJ/yWL0RhJ5++ulFsrc1ieJI6sYYZdEiYeLEicVrYqyy8jEBtee5n/0offD4uNa/oMEFatPxwh4/4Jut3syia4xMq/3qd63fLwB0QOJyoJKeyyw2N4xDxl5578P0m9teTCePfbP4GX/nJPfyTe/eN72++Drp3+8vUfyMv3NRq2U799xz0+OPP16M9xXj7V588cXzTLY+OnXRRuW77bbb0r///e9iIolI2D755JPpb3/723z3G2OU3X333cX4ZTHpRLTyffnll9Pvfve7YhyzaqvV+mut3MuX82dnLZVtyS9+KdV16zbXQLGZud1Yau0Np7q6VNete1py2y+1/iCBipr93svpw1t/mbrfdnzxM/7O1eyJbkbTseLypnKJy8lLbp+dtfS9t2RmsXldaUGapbXCcccdl8aMGdNoWcyc+dRTT7Xq9fFhG+PujB8/vhhofWE9OemV9I27T0qVds46P0wr9x1W8e1W2nVPvJ1Ov+WF4veo4fL79YdbLJ+2WXXJVOvaq3wHH3JIqob3Fl0uvb7k+kX3gOhu9PF/07o09O370oAPXkq1LOeyBeWrbe1Vf788/fRUDTl/N9Ri2aY/93R68/gj00fvvRMDFLbdjrp0TT0WXyKt9LPTUp+VPrVAL424LC5mo2fBJ4nLaB+fNC6vhdj84nW+m1btOyR1dDOf+HeaftMpzbqT99ryiNRjtW1TLZv5yOVp+tjfNF5Y1yX13vanqedaO7Xpvvfff/9UTaNGjUpjx3aM8RjbgvLVtpzrr9plO//889t8H9MfuDhNv7HJ92JdXeq15ZE1/71Qq997U597Nj13/HFpVkyaXuOxeZsM4xCzzd94443/fyeRHc/EAX/9b6r78I1Ua8op/VNveqF45KZq5Vt+11Rddako2v8+GF9basPikYecyxaUr7ZVt/62OvPe1B5y/m6olbItsub30z6P/jmt9u5TrRzZa8H1X2+DtMLRP0/d+krWdkY5x+Vh6l/2S5M//CDVkroGH1LTbzyxeGSnNCd9eO0xqduwdVPXAcPb+2gAOpRo4VpOhDZSKmX5vVBL33vD10jpzcd6pGnvxkAIdTUbm7dJtBdBZGSaW2PGjBnFo2GWGgCgM5jWo086a7390rbP35C2f/76aFOeunx8q+GTqetSJFuW2evbachu+6S6FmYmp3NYkLg8iM2pnLo0c9zfUu/ND3ZSARqY+ejfnY8Oqmv3lJZZZ2Z674Vu6d0XyinTupqLzdsk2fvss8+mIUOGpF69eqWNNtoonXjiiWn48Jbv6MZzTbuXhQkTJqRp06Yt9DG8O+3dhX4tAEC1lOq6pH+vuE16qf/wtO+jF6Wes2emrqVP0HWsS5dU17NXWuLAI1LXtdZNE956a6E3NWXKlIU/DjqEBYnLg9icSimlUpo24YU0afz4Nu3aXU1Dhw6t+j6rSflqW871V+2yxdBFban7hBeKm/tt1auLTyY6dy6+wkepV/85RSvfObNLEbDXVGxe8TF7r7322vTBBx8U44G9+eabRSL39ddfLwYrj8HLW9N6YNiwYR12XLC6Z7dJdR8OrPh2AQAGfvhe+s7Df0jLTHlz4Vr41tWlRZZfKa3001NTz8GffBxTY/bWtgWNy2sxNj/36YfSyjU2jEOnUdc19dxwrzZt2WvM3srKeczXoHy1K7cxe2Oyshn3XphSaXab7odPbtaHdemNR3qkGR9EsreuZmLzirfs3Xbb/z/Q8lprrZU23HDDNGLEiPTXv/417bvvvs3W79mzZ/GoFWfvskaHn6DttYnT0z5/HpfmtHCN2KUupQt2G5mWWaxXqlXtWb5qTNA2o9ui6ZlhX/z4j4YzQf7vvszKr/479fyoNi9qci5bUD7115EnaMv5uyG3ss2ZuUWacMbx6YPbb1rg1w7c/PNp+cOPSV161E5sRdtZ0Li8FmPzPl/7XerXwSdoi9nVp160R9F9s5m6LmnRPS5OXRYbmmrRPMuWSqnHyP9rh6MC6Nh6rPWVNOPeC1p+ssa/F3L83hswc2Z68YxfpPdvv61mYvM2n6FhscUWSyuvvHJ67rnnUg769eqeBizSI3VkcXw/+cLK6WfXPVPcd/h4LvmPf8byNYbU9gQt7Vm+7rP/f0uXttzHiAl3pZcHbVQkQWPWynID/BET7k6LzqjdIUpyLltL5bvhB5ulZRbrnc669bn0z8summf54rNy9913T8svv3xaaqmlimV33313Ouuss5qt+5nPfCZtv/32RbfcmTNnpieeeCL95S9/SW99gu4gC1O+3OuvmuWrxvdKzt8N2ZVtkR5p2tCh6YOuXVOavQAtPrp2LVoMSPTSWeLy0KVXv9RlkY7d6y6Or/e2Py0mLPt4AtDouvvxp1Qs7zZkrVSr5lc2k7PRUfzyl79MSy65ZFpiiSXS3/8+7/FSayEup7Z1HTgi2++FHL/3uiySUq+hy6bU9Y6aic3bPNkbXceef/75tMcee7T1rmjgS2sOSusM7ZeuenR8emHCxLT8oMXSTmsNTsMG9M7iPOVevsWnPJ/6TH8rvdtvxdR/yHJp0hsvpsUnP5d6zar9sRNzLlvT8nWv+2yxbMmJTxXL5yW6YESwGIFhBIo9erSc/Ntss83quyzGuosuumjaYIMNii66P/rRj4ruHG2pM9VfjuXL+bMzt7K9f/utCxZMhtmz0/t33JKG7Te6rQ6LGicubz8919opdRu2bjFhWYxju8ig5YtWrzkkQ3MuG51TrcTl1LbcPztzK9/7NRabVzzZe+ihh6Yddtih6CL2xhtvpGOPPTZ17do1ff3rX6/0rpiPuMD9/mbLFWOsLcgszLUi9/JFcmmZdx9Oo1bvm8Y+9nDKSXuWbauttkqbb755cfd99uzZxefU73//+/TKK68Uz6+77rppu+22Kz7DunTpUjx/ww03pNtu+/9dNi6++OLi57nnnptuv/324vejjz46rbrqqsVYUtFa4Iozfli//i47bV88QrQSaEmMpfid73ynuBAvtzxoKj5Ld9111+L3++67L/36178uWh6ceuqpqX///ulLX/pSuuiii1Jby/m92RnKl/NnZy5lm/Hm62n6ay8v1Gunv/pymjH+jYqMCUbtE5d3LHGBG+PXxoRlvWv4M6qzlY3aj8vPOOOM+vW/8pWvFI9c4nJqW+6fnbmUb0YNxuYVT/a+9tprRWL33XffLT4UN91003TPPfe0+AEJUE3f/OY309Zbb10/i+XEiROLGcnj8ymCyk022SQdcMABxfPx3KxZs9Kyyy5b3LGPoO0f//hHq/bz0UcfFV1kl1tuuSIQfO+994rHvMS+4jEv0ZWsPAj7/fffX3+csa8111yzGI8RqH3v33PHx+OatzSHbnn5PJ6feM8dadBOu1TlWOnYxOVAR1XtuDwSxt27dxeXA50iNq94sjfGpwHoaGJ8rmg9UE6UnnnmmUULgpiNPAK/sPPOOxc/IyD8+c9/XgSHBx10UFp//fXTjjvumK677rqiK9f8REB63HHHpbPPPrvY/q233jrfscFaY/HFF280C2dZuYtYw+eB2jXxzrlM/tClS+q6SJ/U5/Pbpak3/CvNnjY1pTnNJ754/85bJXspiMuBjqg94vJyC11xOdAZYvMuVd0bQDuJVrHR/Sv8+9//LgLKckuCaHUbLWYj8CwHnRFQhuiZEGJm8qFDO+aMoTGRGJCH2VM/SJMffahxy4D//R8fsPFmaa0Lr0iLfXW34mf83fD5QqmUpox76ONgEwA6IHE5UCtm12hsLtkLsLAfoP9LHofevdt+EqgYHqesPJxDw98bPg/UpkkP3Nt48odoMdBn0bTCT05IK405JXUfMLBYHD/j71gez8d6ZaXZsz/eDgB0EuJyoC1MqtHYPNtk72I9Fk09ulR2lIrYXmwXqD0vvPBCmvO/LhVf+MIXirF0Q8yaO3DgwGJYhHfeeadYFt3DunX7+PMjZuINM2bMKMY+bDhsQnkCqKWXXjoNGzas2T7LrYOjVXClyhAtkcvHGGIiiBVXXLH4/dFHH63IfoD28/7dY1Oq69KsxcDim3++xfVjebOWBHVd0sTYDnQgYnOgPePy8pAP4nKgM8TmFR+zt6NYuvfAdNVnj0sTZ34w33WjNVxrxrqMIDW2C9SeCBhvvPHGYiKIDTfcsJihN4LDQYMGpbPOOqsYyuHyyy8vJoKI5GnM2hsTQZQnl7z66qvrg8THH388bbzxxumLX/xiWmGFFYoJH1oaSiHGCBswYECxz9hfBKXnnXdei8cX6/34xz+u/z2svfba6bTTTit+/+EPf1gMPfHXv/417bvvvmmDDTZIp59+ehEUR6viCIqvueaaNjt/QNuLu/4T7749pdKc1HXRvmnZg4+aayDZULklwbu33pBe+uWJafYHU9L7d40ttlf3vwtoaG9ic6A94/I33ngjLbPMMuJyoFPE5tkme8tBZWuSs+M/7JEG9//4TiCQrz/96U9FoLf55punIUOGpB49eqRXX301vf3228Xzd955Z/rwww/TdtttVwSKiyyySHrppZfSDTfckG677f8Pyv7nP/+5SLCussoqaamllipmA47EbASqDZXH/o1txdhk8xItGiLAbSj20XR4iFtuuaVozRABbZQhAt/77rsvXXbZZUVyGahdc2bOSD0HDykey/7gyPpuYa0VwWe/keull844Kc0Y/0axva69F2mz44UFJTYH2isuj+Tx8OHDi0YV4nIg99g862QvQFPRiiAec/PQQw8Vj3mJlgflFrdl//rXv5qtF8nXMWPGtLqFw+67796qde+6667iAeQlgr/Vf/vHT3THv9ySQKteADq6asblkViOFsFjx86/K7W4HKj12DzbMXsBAGpNpYJAwzcAAEDnjM0lewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADbZ7sPemkk1JdXV36wQ9+0Na7AgAA5kJcDgCQvzZN9t5///3p3HPPTWuttVZb7gYAAJgHcTkAQOfQZsneDz74IO22227p/PPPTwMGDGir3QAAAPMgLgcA6DzaLNk7evTotN1226WtttpqnuvNmDEjTZ48udEDAACoblwuNgcAqH3d2mKjf/nLX9JDDz1UdBebnxNPPDGNGTOm2fIJEyakadOmpWqYOnVqGj9+fMqV8lXOqFGjUrUNHTq0XfZbDTmXLShfbatm/bXHd1DO3w05l63a5ZsyZUpV9kPbWZC4PIjN217On1HVLlu140ixXW1Tf7Wr2nVX7c/onL8XgvJVPzaveLL31VdfTQcddFC64YYbUq9evea7/lFHHZUOOeSQ+r+jZe+wYcPSoEGDUr9+/VI1xH+qwYMHp1wpX+WMHTs2VVt8qbXHfqsh57IF5att1ay/PfbYI1Vbzt8NOZet2uVbZJFFqrIf2saCxuVBbN72cv6MqnbZqh1Hiu1qm/qrXdWuu2rH5jl/LwTlq35sXvFk74MPPpjeeuuttO6669Yvmz17dvEf88wzzyyGbejatWv9cz179iweAABA+8XlYnMAgNpX8WTvlltumR577LFGy/bee++0yiqrpCOOOKJZQAkAAFSeuBwAoPOpeLK3b9++aY011mi0rE+fPmnxxRdvthwAAGgb4nIAgM6nS3sfAAAAAAAAHbBlb0tuvfXWauwGAACYB3E5AEDetOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxUPNl79tlnp7XWWiv169eveGy00Ubp2muvrfRuAAAAcTkAAG2Z7B06dGg66aST0oMPPpgeeOCBtMUWW6Qdd9wxPf7445XeFQAAIC4HAOB/uqUK22GHHRr9ffzxxxetfe+55560+uqrV3p3AACAuBwAgLZI9jY0e/bsdPnll6epU6cWwzm0ZMaMGcWjbPLkySoGAACqHJeLzQEAal9dqVQqVXqjjz32WBFETp8+PS266KLpkksuSV/84hdbXPe4445LY8aMabZ83LhxqW/fvqkaIujt06dPypXyVc4NN9yQqi2GRnnttddSjnIuW1C+2lbN+vv85z+fqi3n74acy1bt8k2ZMiWNHDkyTZo0qZiLgdqzIHF5EJu3vZw/o6pdtmrH5mK72qb+ale1667asXnO3wtB+aofm7dJsnfmzJnplVdeKXZ+xRVXpN/97nfptttuS6uttlqrWvYOGzYsjR8/vmoXFbGvwYMHp1wpX+Xsv//+qdpGjRqVxo4dm3KUc9mC8tW2atbf+eefn6ot5++GnMtW7fJFXBb7kuytXQsSlwexedvL+TOq2mWrdmwutqtt6q92Vbvuqh2b5/y9EJSv+rF5mwzj0KNHj7TiiisWv6+33nrp/vvvT7/61a/Sueee22zdnj17Fg8AAKD94nKxOQBA7etSjZ3MmTOnUetdAACg+sTlAAB5q3jL3qOOOiptu+22afjw4cVYEjEu2K233pquv/76Su8KAAAQlwMA0FbJ3rfeeit985vfTG+++Wbq379/WmuttYpEb3tMPgMAAJ2VuBwAoPOpeLL397//faU3CQAALCBxOQBA51OVMXsBAAAAAGhbkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADJQVyqVSqkDmTx5curfv38aP3586tevX1X2GfsaPHhwypXy1bac6y/nsgXlq23qr3apu8rGZfE5PWnSpKrFZXQsYvPKy/kzKueyBeWrbeqvdqm72qb+qh+ba9kLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiqe7D3xxBPT+uuvn/r27ZuWWmqptNNOO6Wnn3660rsBAADE5QAAtGWy97bbbkujR49O99xzT7rhhhvSrFmz0tZbb52mTp1a6V0BAADicgAA/qdbqrDrrruu0d8XXnhh0cL3wQcfTKNGjar07gAAAHE5AABtkextatKkScXPgQMHtvj8jBkzikfZ5MmTVQwAAFQ5LhebAwDUvrpSqVRqq43PmTMnfelLX0oTJ05Md9xxR4vrHHfccWnMmDHNlo8bN64Y97caYoiJPn36pFwpX23Luf5yLltQvtqm/mqXuqucKVOmpJEjRxZJwn79+lVwy1Rba+LyIDZvezl/RuVctqB8tU391S51V9vUX/Vj8zZN9h5wwAHp2muvLQLKoUOHtrpl77Bhw9L48eOrdlER+xo8eHDKlfLVtpzrL+eyBeWrbeqvdqm7yom4LD6nJXtrX2vi8iA2b3s5f0blXLagfLVN/dUudVfb1F/1Y/M2G8bhe9/7XvrnP/+Zxo4dO8+AsmfPnsUDAABov7hcbA4AUPsqnuyNhsLf//7305VXXpluvfXWtNxyy1V6FwAAwHyIywEAOp+KJ3tHjx6dLrnkknT11VcXY+5Gc+3Qv3//1Lt370rvDgAAEJcDAJBS6lLps3D22WcXY0dsvvnmaemll65/XHbZZU44AABUibgcAKDzaZNhHAAAgPYlLgcA6Hwq3rIXAAAAAIDqk+wFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJCBiid7x44dm3bYYYc0ZMiQVFdXl6666qpK7wIAAGgFsTkAQOdS8WTv1KlT08iRI9NZZ51V6U0DAAALQGwOANC5dKv0BrfddtviAQAAtC+xOQBA51LxZO+CmjFjRvEomzx5crseDwAAdFZicwCA2tbuyd4TTzwxjRkzptnyCRMmpGnTplWte9v48eNTrpSvtuVcfzmXLShfbVN/tUvdVc6UKVMquDVqgdi87eX8GZVz2YLy1Tb1V7vUXW1Tf9WPzetKpVKpgvttvPG6unTllVemnXbaaYFaDwwbNqwIEvr165eqIfY1ePDglCvlq20511/OZQvKV9vUX+1Sd5UTcVl8Tk+aNKlqcRltR2zeMeT8GZVz2YLy1Tb1V7vUXW1Tf9WPzdu9ZW/Pnj2LBwAA0L7E5gAAta1Lex8AAAAAAACfXMVb9n7wwQfpueeeq//7xRdfTI888kgaOHBgGj58eKV3BwAAiM0BAGiLZO8DDzyQPve5z9X/fcghhxQ/99xzz3ThhRc66QAAUCVicwCAzqXiyd7NN988teGcbwAAQCuJzQEAOhdj9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyIBkLwAAAABABiR7AQAAAAAyINkLAAAAAJAByV4AAAAAgAxI9gIAAAAAZECyFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyECbJXvPOuustOyyy6ZevXqlDTfcMN13331ttSsAAGAuxOUAAJ1HmyR7L7vssnTIIYekY489Nj300ENp5MiRaZtttklvvfVWW+wOAAAQlwMAdHptkuw9/fTT0/7775/23nvvtNpqq6VzzjknLbLIIukPf/hDpz/hAABQLeJyAIDOpeLJ3pkzZ6YHH3wwbbXVVv9/J126FH/ffffdzdafMWNGmjx5cqMHAABQ3bhcbA4AUPu6VXqD77zzTpo9e3YaNGhQo+Xx91NPPdVs/RNPPDGNGTOm2fIJEyakadOmpWqYOnVqGj9+fMqV8tW2nOsv57IF5att6q92qbvKmTJlSgW3RrUtaFwexOZtL+fPqJzLFpSvtqm/2qXuapv6q35sXvFk74I66qijivF9y6Jl77Bhw4ogtF+/flU5hghIBg8enHKlfLUt5/rLuWxB+Wqb+qtd6q5yYhguOhexedvL+TMq57IF5att6q92qbvapv6qH5tXPNm7xBJLpK5duxYtcxuKv1v64u/Zs2fxAAAA2i8uF5sDANS+io/Z26NHj7Teeuulm266qX7ZnDlzir832mijSu8OAAAQlwMA0FbDOMSwDHvuuWf69Kc/nTbYYIN0xhlnFGN07L333k46AABUibgcAKBzaZNk76677prefvvtdMwxxxRjc6y99trpuuuuazY5BAAA0HbE5QAAnUubTdD2ve99r3gAAADtR1wOANB5VHzMXgAAAAAAqk+yFwAAAAAgA5K9AAAAAAAZkOwFAAAAAMiAZC8AAAAAQAYkewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGRAshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAABmQ7AUAAAAAyEC31MGUSqXi55QpU6q2z9jXIossknKlfLUt5/rLuWxB+Wqb+qtd6q6y57JhfEbnIzavvJw/o3IuW1C+2qb+ape6q23qr/qxeYdL9pYPfKWVVmrvQwEA4H/xWf/+/Z2LTkhsDgBQW7F5XamDNdWYM2dOeuONN1Lfvn1TXV1dm+9v8uTJadiwYenVV19N/fr1S7lRvtqWc/3lXLagfLVN/dUudVdZESZGMDlkyJDUpYvRvzojsXll5fwZlXPZgvLVNvVXu9RdbVN/7RObd7iWvXGwQ4cOrfp+IyDJMSgpU77alnP95Vy2oHy1Tf3VLnVXOVr0dm5i87aR82dUzmULylfb1F/tUne1Tf1VNzbXRAMAAAAAIAOSvQAAAAAAGej0yd6ePXumY489tviZI+WrbTnXX85lC8pX29Rf7VJ3UNv8H65d6q62qb/alnP95Vy2oHy1rWcHfX92uAnaAAAAAABYcJ2+ZS8AAAAAQA4kewEAAAAAMiDZCwAAAACQAcleAAAAAIAMSPYCAAAAAGSg0yd7zzrrrLTsssumXr16pQ033DDdd999KQdjx45NO+ywQxoyZEiqq6tLV111VcrFiSeemNZff/3Ut2/ftNRSS6WddtopPf300ykXZ599dlprrbVSv379isdGG22Urr322pSrk046qXiP/uAHP0g5OO6444ryNHysssoqKSevv/562n333dPiiy+eevfundZcc830wAMPpBzE90HT+ovH6NGjU62bPXt2+slPfpKWW265ot5WWGGF9LOf/SyVSqWUiylTphSfJSNGjCjKuPHGG6f7778/5fg9HvV2zDHHpKWXXroo61ZbbZWeffbZdjteqIRc4/IgNq9dnSk2F5fXHnF57co9NheXP9uu579TJ3svu+yydMghh6Rjjz02PfTQQ2nkyJFpm222SW+99VaqdVOnTi3KE0Fzbm677bYi8XLPPfekG264Ic2aNSttvfXWRZlzMHTo0CLQevDBB4sE2hZbbJF23HHH9Pjjj6fcRBLm3HPPLQLonKy++urpzTffrH/ccccdKRfvv/9+2mSTTVL37t2LC50nnnginXbaaWnAgAEpl/dkw7qLz5iw8847p1p38sknFxesZ555ZnryySeLv0855ZT0m9/8JuViv/32K+rsoosuSo899ljx3RBJ0LgQyu17POru17/+dTrnnHPSvffem/r06VPEMNOnT6/6sUIl5ByXB7F57eossbm4vPaIy2tb7rG5uHyb9o3LS53YBhtsUBo9enT937Nnzy4NGTKkdOKJJ5ZyEtV85ZVXlnL11ltvFWW87bbbSrkaMGBA6Xe/+10pJ1OmTCmttNJKpRtuuKG02WablQ466KBSDo499tjSyJEjS7k64ogjSptuummps4j35QorrFCaM2dOqdZtt912pX322afRsq985Sul3XbbrZSDadOmlbp27Vr65z//2Wj5uuuuWzr66KNLOX2Px/tx8ODBpVNPPbV+2cSJE0s9e/YsXXrppe10lPDJdJa4PIjNa19usbm4vDaJy2tbzrG5uHxiu8flnbZl78yZM4u7s9Hip6xLly7F33fffXe7HhsLZtKkScXPgQMHZnfqomvHX/7yl6I1SHQZy0m0zt5uu+0a/R/MRXSljq7Xyy+/fNptt93SK6+8knLxj3/8I336058uWrrGMCrrrLNOOv/881Ou3xMXX3xx2meffYpu9LUuhjS46aab0jPPPFP8PW7cuKLV+bbbbpty8NFHHxWfmdH9u6HoFpdT6/rw4osvpvHjxzf6/Ozfv3/R7V0MQy0Sl+dFbF57xOW1SVxe23KOzcXl/ds9Lu+WOql33nmnuCgcNGhQo+Xx91NPPdVux8WCmTNnTjE+Y3QrX2ONNbI5fdH9OJK70ex/0UUXTVdeeWVabbXVUi4igR1dNGt1LM15iQ/1Cy+8MH3qU58qhgEYM2ZM+uxnP5v++9//FuNM17oXXnih6G4UXW1/9KMfFXV44IEHph49eqQ999wz5STGSJ04cWLaa6+9Ug6OPPLINHny5GIM6a5duxbfgccff3xxQyIH8f8rPjdjrLNVV121+D6/9NJLiyBrxRVXTDmJRG9oKYYpPwe1RFyeD7F57RGX1y5xeW3LOTYXl6d2j8s7bbKXfO5CRxItt1ZbkSh85JFHipYRV1xxRZFEi7GKc0j4vvrqq+mggw4qxtVs2gIvBw3vxMZYxJH8jcmi/vrXv6Z999035XARFy17TzjhhOLvaNkb/wdj3NDckr2///3vi/qMVto5iPfgn//853TJJZcU40rHZ0zcLIvy5VJ3MVZvtMReZplliqB53XXXTV//+teLnjwAtD2xeW0Rl9c2cXltyz02F5e3r047jMMSSyxRXAhOmDCh0fL4e/Dgwe12XLTe9773vfTPf/4z3XLLLcXECTmJVpLREm299dZLJ554YjFJya9+9auUg0i6xGQrkYTp1q1b8YhEdkw0FL/HHc2cLLbYYmnllVdOzz33XMrB0ksv3eymQ7SizGmoivDyyy+nG2+8sZhYIBeHHXZY0YLga1/7WlpzzTXTHnvskQ4++ODiMyYXMYtxfJ588MEHxQXsfffdV0ziGUOq5KQcp4hhyIW4PA9i89ojLq9t4vLalntsLi6f0K65xU6b7I1kWiTSYoyUhnfG4u/cxkbNTcxrEcFkDG1w8803p+WWWy7lLt6bM2bMSDnYcssti2Eq4s5l+REtRaO7SvweN2FyEkmn559/vgjGchBDpjz99NONlsU4U9F6OScXXHBBMSZxjCudi2nTphVj0zcU/9/i8yU3ffr0Kf7PxSzV119/fTFrek7iey+Cx4YxTHQDvPfee8Uw1CRxeW0Tm9cucXltE5fXts4Sm4vL20enHsYhxpyM5vGRaNpggw3SGWecUUyEtffee6ccEkwNWxLGZC6RSItJzIYPH55qvXtYdHW4+uqri7FgyuOgxOQ0MRFPrTvqqKOKruNRT1OmTCnKeuuttxYJixxEnTUdXzm+ABZffPEsxl0+9NBD0w477FAkP99444107LHHFl/a0ZU8B3G3OSYTiGEcdtlll6Ll5HnnnVc8chEBViR74/shWpvnIt6XMQ5YfLZEV7GHH344nX766cWwB7mIz8lIOsRQOPEdGC0mYhy0Wvxen9/3eHTz+/nPf55WWmmlIvn7k5/8pOj2t9NOO7XrccPCyjkuD2Lz2pVzbC4ur23i8tqWe2wuLh/SvnF5qZP7zW9+Uxo+fHipR48epQ022KB0zz33lHJwyy23lKJ6mz723HPPUq1rqVzxuOCCC0o52GeffUojRowo3pNLLrlkacsttyz95z//KeVss802Kx100EGlHOy6666lpZdeuqi/ZZZZpvj7ueeeK+XkmmuuKa2xxhqlnj17llZZZZXSeeedV8rJ9ddfX3ymPP3006WcTJ48ufh/Ft95vXr1Ki2//PKlo48+ujRjxoxSLi677LKiXPH/b/DgwaXRo0eXJk6cWMrxe3zOnDmln/zkJ6VBgwYV/xfjuyK39yydT65xeRCb167OFpuLy2uLuLx25R6bi8ufbtfzXxf/tF+qGQAAAACASui0Y/YCAAAAAOREshcAAAAAIAOSvQAAAAAAGZDsBQAAAADIgGQvAAAAAEAGJHsBAAAAADIg2QsAAAAAkAHJXgAAAACADEj2AgAAAABkQLIXAAAAACADkr0AAAAAAKn2/T9sELFK/G4tPwAAAABJRU5ErkJggg==",
       "text/plain": [
-       "<Figure size 1800x550 with 3 Axes>"
+       "<Figure size 1500x700 with 2 Axes>"
       ]
      },
      "metadata": {},
@@ -1874,117 +1878,100 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Comparaison BFS vs A* sur grille 5x5 avec obstacles ===\n",
-      "Algorithme   Chemin                                   Cout   Noeuds explores\n",
-      "------------------------------------------------------------------------\n",
-      "BFS          (0,0) -> (0,1) -> (0,2) -> (0,3) -> (0,4) -> (1,4) -> (2,4) -> (3,4) -> (4,4) 8      19\n",
-      "A*           (0,0) -> (0,1) -> (0,2) -> (0,3) -> (0,4) -> (1,4) -> (2,4) -> (3,4) -> (4,4) 8      20\n",
+      "=== Terrain pondere : BFS / Greedy / A* ===\n",
+      "Algorithme           Pas    Cout   Noeuds   Traverse le marais ?\n",
+      "----------------------------------------------------------------\n",
+      "BFS                  10     55     91       oui (5 cases)\n",
+      "Greedy Best-First    10     55     11       oui (5 cases)\n",
+      "A*                   16     16     75       non\n",
       "\n",
-      "Les deux algorithmes trouvent le chemin optimal (cout = 8)\n",
-      "A* a explore -1 noeuds de moins que BFS (-5.3% d'economie)\n",
-      "\n",
-      "Chemin BFS (8 etapes) : (0,0) -> (0,1) -> (0,2) -> (0,3) -> (0,4) -> (1,4) -> (2,4) -> (3,4) -> (4,4)\n",
-      "Chemin A* (8 etapes) : (0,0) -> (0,1) -> (0,2) -> (0,3) -> (0,4) -> (1,4) -> (2,4) -> (3,4) -> (4,4)\n"
+      "BFS et Greedy minimisent le nombre de PAS (10) : un chemin court\n",
+      "en etapes, mais cher (cout 55) car il traverse le marais tout droit.\n",
+      "A* minimise le COUT reel : 16 pas (plus long en etapes) mais cout 16,\n",
+      "car il contourne le marais. Seul A* trouve le chemin le moins couteux.\n"
      ]
     }
    ],
    "source": [
-    "# Exemple guide : Grille 5x5 avec obstacles -- BFS vs A*\n",
+    "# Exemple guide : terrain pondere -- BFS/Greedy minimisent les PAS, A* le COUT\n",
+    "# C'est LE differenciateur d'optimalite : BFS trouve un chemin court en etapes,\n",
+    "# mais ce n'est PAS le chemin le moins couteux. Seul A* (cout cumule g + h) le trouve.\n",
     "\n",
-    "# 1. Definition de la grille avec obstacles\n",
-    "obstacles_5x5 = {(1, 1), (1, 2), (1, 3), (3, 1), (3, 2), (3, 3)}\n",
-    "grid_5x5 = GridWorld(5, 5, obstacles=obstacles_5x5)\n",
-    "start_5 = GridState(0, 0)\n",
-    "goal_5 = GridState(4, 4)\n",
+    "import numpy as np\n",
     "\n",
-    "print(f\"Grille 5x5 avec {len(obstacles_5x5)} obstacles\")\n",
-    "print(f\"Obstacles: {obstacles_5x5}\")\n",
-    "print(f\"Depart: {start_5} | But: {goal_5}\")\n",
+    "# 1. Grille 11x11 avec un marais central : chaque case du marais coute 10 (sinon 1)\n",
+    "W = H = 11\n",
+    "marais = {(x, y) for x in range(3, 8) for y in range(3, 8)}  # bloc central 5x5\n",
+    "COUT_MARAIS = 10\n",
+    "start_w = GridState(0, 5)\n",
+    "goal_w = GridState(10, 5)\n",
     "\n",
-    "# 2. Construction du graphe d'etats\n",
-    "graph_5x5 = build_state_graph(grid_5x5)\n",
-    "print(f\"\\nGraphe: {graph_5x5.number_of_nodes()} etats, {graph_5x5.number_of_edges()} transitions\")\n",
+    "def cout_case(x, y):\n",
+    "    \"\"\"Cout pour entrer dans la case (x, y) : terrain pondere.\"\"\"\n",
+    "    return COUT_MARAIS if (x, y) in marais else 1\n",
     "\n",
-    "# 3. Visualisation\n",
-    "fig, axes = plt.subplots(1, 3, figsize=(18, 5.5))\n",
+    "# Successeurs ponderes : le cout d'un pas depend du terrain de la case d'arrivee.\n",
+    "# (GridWorld.get_successors renvoie un cout uniforme de 1 ; ici on le pondere.)\n",
+    "ACTIONS = [(0, 1), (0, -1), (-1, 0), (1, 0)]\n",
+    "def successeurs_ponderes(state):\n",
+    "    voisins = []\n",
+    "    for dx, dy in ACTIONS:\n",
+    "        nx_, ny_ = state.x + dx, state.y + dy\n",
+    "        if 0 <= nx_ < W and 0 <= ny_ < H:\n",
+    "            voisins.append((GridState(nx_, ny_), None, cout_case(nx_, ny_)))\n",
+    "    return voisins\n",
     "\n",
-    "# --- Carte de la grille ---\n",
-    "ax = axes[0]\n",
-    "for x in range(5):\n",
-    "    for y in range(5):\n",
-    "        if (x, y) in obstacles_5x5:\n",
-    "            ax.add_patch(plt.Rectangle((x - 0.45, y - 0.45), 0.9, 0.9, color='#2c3e50'))\n",
-    "            ax.text(x, y, 'X', ha='center', va='center', color='white', fontsize=14, weight='bold')\n",
-    "        else:\n",
-    "            ax.add_patch(plt.Rectangle((x - 0.45, y - 0.45), 0.9, 0.9, fill=False, edgecolor='gray'))\n",
-    "            ax.text(x, y, f'({x},{y})', ha='center', va='center', fontsize=7, color='#555')\n",
-    "ax.add_patch(plt.Rectangle((-0.45, -0.45), 0.9, 0.9, color='#2ecc71', alpha=0.4))\n",
-    "ax.add_patch(plt.Rectangle((3.55, 3.55), 0.9, 0.9, color='#e74c3c', alpha=0.4))\n",
-    "ax.text(0, 0, 'S', ha='center', va='center', fontsize=16, weight='bold', color='#27ae60')\n",
-    "ax.text(4, 4, 'G', ha='center', va='center', fontsize=16, weight='bold', color='#c0392b')\n",
-    "ax.set_xlim(-0.7, 4.7)\n",
-    "ax.set_ylim(-0.7, 4.7)\n",
-    "ax.set_aspect('equal')\n",
-    "ax.set_title('Carte de la grille 5x5', fontsize=12)\n",
-    "ax.invert_yaxis()\n",
+    "print(f\"Grille {W}x{H} | marais central de {len(marais)} cases (cout {COUT_MARAIS}) \"\n",
+    "      f\"| depart {start_w} -> but {goal_w}\")\n",
     "\n",
-    "# 4. Resolution BFS\n",
-    "bfs_path_5, bfs_cost_5, bfs_nodes_5 = bfs(start_5, goal_5, grid_5x5.get_successors)\n",
+    "# 2. Resolution par les trois algorithmes (memes fonctions que precedemment)\n",
+    "bfs_path_w, bfs_cost_w, bfs_nodes_w = bfs(start_w, goal_w, successeurs_ponderes)\n",
+    "greedy_path_w, greedy_cost_w, greedy_nodes_w = greedy_best_first(\n",
+    "    start_w, goal_w, successeurs_ponderes, manhattan_distance)\n",
+    "astar_path_w, astar_cost_w, astar_nodes_w = a_star(\n",
+    "    start_w, goal_w, successeurs_ponderes, manhattan_distance)\n",
     "\n",
-    "# 5. Resolution A*\n",
-    "astar_path_5, astar_cost_5, astar_nodes_5 = a_star(start_5, goal_5, grid_5x5.get_successors, manhattan_distance)\n",
-    "\n",
-    "# --- Graphe BFS ---\n",
-    "ax = axes[1]\n",
-    "pos5 = {n: (n.x, n.y) for n in graph_5x5.nodes()}\n",
-    "nx.draw(graph_5x5, pos5, ax=ax, with_labels=True, node_color='#bdc3c7',\n",
-    "        node_size=400, font_size=7, arrows=False, edge_color='#ecf0f1')\n",
-    "# Surligner le chemin BFS\n",
-    "if bfs_path_5:\n",
-    "    bfs_edges = [(bfs_path_5[i], bfs_path_5[i+1]) for i in range(len(bfs_path_5)-1)]\n",
-    "    nx.draw_networkx_edges(graph_5x5, pos5, edgelist=bfs_edges, ax=ax,\n",
-    "                           edge_color='#3498db', width=3, arrows=True, arrowsize=15)\n",
-    "    bfs_path_set = set(bfs_path_5)\n",
-    "    bfs_visited_colors = ['#3498db' if n in bfs_path_set else '#bdc3c7' for n in graph_5x5.nodes()]\n",
-    "    nx.draw_networkx_nodes(graph_5x5, pos5, nodelist=bfs_path_5,\n",
-    "                           node_color='#3498db', node_size=500, ax=ax)\n",
-    "ax.set_title(f'BFS -- {bfs_nodes_5} noeuds explores\\n(cout = {bfs_cost_5})', fontsize=11)\n",
-    "ax.invert_yaxis()\n",
-    "\n",
-    "# --- Graphe A* ---\n",
-    "ax = axes[2]\n",
-    "nx.draw(graph_5x5, pos5, ax=ax, with_labels=True, node_color='#bdc3c7',\n",
-    "        node_size=400, font_size=7, arrows=False, edge_color='#ecf0f1')\n",
-    "if astar_path_5:\n",
-    "    astar_edges = [(astar_path_5[i], astar_path_5[i+1]) for i in range(len(astar_path_5)-1)]\n",
-    "    nx.draw_networkx_edges(graph_5x5, pos5, edgelist=astar_edges, ax=ax,\n",
-    "                           edge_color='#e67e22', width=3, arrows=True, arrowsize=15)\n",
-    "    nx.draw_networkx_nodes(graph_5x5, pos5, nodelist=astar_path_5,\n",
-    "                           node_color='#e67e22', node_size=500, ax=ax)\n",
-    "ax.set_title(f'A* (Manhattan) -- {astar_nodes_5} noeuds explores\\n(cout = {astar_cost_5})', fontsize=11)\n",
-    "ax.invert_yaxis()\n",
-    "\n",
+    "# 3. Visualisation : terrain pondere + chemin BFS (bleu) et chemin A* (orange)\n",
+    "terrain = np.array([[cout_case(x, y) for x in range(W)] for y in range(H)])\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(15, 7))\n",
+    "panneaux = [\n",
+    "    (f'BFS : {len(bfs_path_w) - 1} pas, cout {bfs_cost_w}\\n(plonge tout droit dans le marais)',\n",
+    "     bfs_path_w, '#2980b9'),\n",
+    "    (f'A* : {len(astar_path_w) - 1} pas, cout {astar_cost_w}\\n(contourne le marais)',\n",
+    "     astar_path_w, '#e67e22'),\n",
+    "]\n",
+    "for ax, (titre, path, couleur) in zip(axes, panneaux):\n",
+    "    ax.imshow(terrain, origin='lower', cmap='Greys', vmin=0, vmax=14)\n",
+    "    if path:\n",
+    "        ax.plot([s.x for s in path], [s.y for s in path], '-o',\n",
+    "                color=couleur, lw=3, ms=5)\n",
+    "    ax.plot(start_w.x, start_w.y, 's', color='#27ae60', ms=15, label='Depart (S)')\n",
+    "    ax.plot(goal_w.x, goal_w.y, '*', color='#c0392b', ms=22, label='But (G)')\n",
+    "    ax.text(5, 5, 'marais\\ncout 10', ha='center', va='center',\n",
+    "            color='white', fontsize=10, weight='bold')\n",
+    "    ax.set_title(titre, fontsize=12)\n",
+    "    ax.set_xticks(range(W)); ax.set_yticks(range(H))\n",
+    "    ax.grid(True, color='#cccccc', lw=0.4)\n",
+    "    ax.legend(loc='upper left', fontsize=9)\n",
     "plt.tight_layout()\n",
     "plt.show()\n",
     "\n",
-    "# 6. Comparaison detaillee\n",
-    "print(\"=== Comparaison BFS vs A* sur grille 5x5 avec obstacles ===\")\n",
-    "print(f\"{'Algorithme':<12} {'Chemin':<40} {'Cout':<6} {'Noeuds explores'}\")\n",
-    "print(\"-\" * 72)\n",
-    "bfs_str = ' -> '.join(str(s) for s in bfs_path_5) if bfs_path_5 else \"Aucun\"\n",
-    "astar_str = ' -> '.join(str(s) for s in astar_path_5) if astar_path_5 else \"Aucun\"\n",
-    "print(f\"{'BFS':<12} {bfs_str:<40} {bfs_cost_5:<6} {bfs_nodes_5}\")\n",
-    "print(f\"{'A*':<12} {astar_str:<40} {astar_cost_5:<6} {astar_nodes_5}\")\n",
+    "# 4. Comparaison detaillee\n",
+    "print(\"=== Terrain pondere : BFS / Greedy / A* ===\")\n",
+    "print(f\"{'Algorithme':<20} {'Pas':<6} {'Cout':<6} {'Noeuds':<8} {'Traverse le marais ?'}\")\n",
+    "print(\"-\" * 64)\n",
+    "for nom, path, cost, nodes in [\n",
+    "        ('BFS', bfs_path_w, bfs_cost_w, bfs_nodes_w),\n",
+    "        ('Greedy Best-First', greedy_path_w, greedy_cost_w, greedy_nodes_w),\n",
+    "        ('A*', astar_path_w, astar_cost_w, astar_nodes_w)]:\n",
+    "    n_marais = sum(1 for s in path if (s.x, s.y) in marais)\n",
+    "    etat = f'oui ({n_marais} cases)' if n_marais else 'non'\n",
+    "    print(f\"{nom:<20} {len(path) - 1:<6} {cost:<6} {nodes:<8} {etat}\")\n",
     "\n",
-    "if bfs_cost_5 == astar_cost_5:\n",
-    "    print(f\"\\nLes deux algorithmes trouvent le chemin optimal (cout = {bfs_cost_5})\")\n",
-    "    print(f\"A* a explore {bfs_nodes_5 - astar_nodes_5} noeuds de moins que BFS \"\n",
-    "          f\"({(1 - astar_nodes_5/bfs_nodes_5)*100:.1f}% d'economie)\")\n",
-    "else:\n",
-    "    print(f\"\\nBFS (cout={bfs_cost_5}) vs A* (cout={astar_cost_5})\")\n",
-    "\n",
-    "print(f\"\\nChemin BFS ({len(bfs_path_5)-1} etapes) : {bfs_str}\")\n",
-    "print(f\"Chemin A* ({len(astar_path_5)-1} etapes) : {astar_str}\")"
+    "print(f\"\\nBFS et Greedy minimisent le nombre de PAS ({len(bfs_path_w) - 1}) : un chemin court\")\n",
+    "print(f\"en etapes, mais cher (cout {bfs_cost_w}) car il traverse le marais tout droit.\")\n",
+    "print(f\"A* minimise le COUT reel : {len(astar_path_w) - 1} pas (plus long en etapes) mais cout {astar_cost_w},\")\n",
+    "print(\"car il contourne le marais. Seul A* trouve le chemin le moins couteux.\")"
    ]
   },
   {
@@ -1992,32 +1979,32 @@
    "id": "ef4f71d1",
    "metadata": {
     "papermill": {
-     "duration": 0.006552,
-     "end_time": "2026-06-09T11:22:46.453780+00:00",
+     "duration": 0.005108,
+     "end_time": "2026-06-20T16:12:21.521130+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.447228+00:00",
+     "start_time": "2026-06-20T16:12:21.516022+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Interpretation : A\\* face à un corridor (quand l'heuristique n'aide pas)\n",
+    "### Interpretation : le terrain pondere revele l'optimalite (BFS != A\\*)\n",
     "\n",
-    "Sur cette grille 5x5, les obstacles `{(1,1),(1,2),(1,3),(3,1),(3,2),(3,3)}` ne laissent qu'un seul corridor praticable le long de la colonne de droite (x=4). Le résultat committé est instructif :\n",
+    "Sur une grille a **cout uniforme** (chaque pas coute 1), BFS est deja optimal : le chemin avec le moins de pas est aussi le moins couteux, et A\\* ne peut pas faire mieux. Le differenciateur entre les algorithmes **n'apparait pas**. C'est pourquoi on introduit ici un **terrain pondere** : un marais central ou chaque case coute 10 au lieu de 1.\n",
     "\n",
-    "| Algorithme | Noeuds explores | Cout | Chemin |\n",
-    "|------------|-----------------|------|--------|\n",
-    "| **BFS** | 19 | 8 | le long du corridor |\n",
-    "| **A\\*** | 20 | 8 | le long du corridor |\n",
+    "| Algorithme | Critere minimise | Pas | **Cout** | Traverse le marais |\n",
+    "|------------|------------------|-----|----------|--------------------|\n",
+    "| **BFS** | nombre de pas | 10 | **55** | oui (tout droit) |\n",
+    "| **Greedy** | heuristique `h` seule | 10 | **55** | oui (tout droit) |\n",
+    "| **A\\*** | cout reel `g + h` | 16 | **16** | non (contourne) |\n",
     "\n",
-    "**Points cles** :\n",
+    "**La lecon centrale -- l'optimalite :**\n",
     "\n",
-    "- Sur cette instance, A\\* a exploré **un nœud de plus** que BFS (économie négative de -5.3%) : l'écart est faible, et c'est précisément le cas où l'heuristique n'apporte rien.\n",
-    "- Quand un **seul chemin** relie le départ au but (corridor sans embranchement), la distance de Manhattan pousse A\\* à examiner les mêmes nœuds que BFS, voire quelques-uns de plus à cause des égalités de priorité (`f = g + h`). L'heuristique ne peut pruner que s'il existe des branches **qui s'éloignent du but** à élaguer.\n",
-    "- Les deux algorithmes trouvent bien le chemin optimal (cout = 8) : A\\* reste **admissible** (l'heuristique sous-estime toujours le coût réel), le bénéfice en exploration dépend de la topologie.\n",
-    "- C'est une leçon importante pour la planification PDDL : une heuristique admissible garantit l'optimalité, mais **le gain en nœuds explorés n'est pas automatique** — il apparaît sur les instances ramifiées où l'heuristique est informative, pas sur les corridors.\n",
+    "- **BFS minimise le nombre de pas, pas le cout.** Il trouve un chemin *court en etapes* (10 pas) mais *cher* (cout 55), parce qu'il fonce tout droit dans le marais. **BFS ne trouve pas le chemin le moins couteux** -- c'est exactement ce qui le distingue d'A\\*.\n",
+    "- **Greedy se laisse berner de la meme facon.** Guide par la seule distance a vol d'oiseau (`h`), il vise le but en ligne droite et traverse le marais lui aussi (cout 55). Ignorer le cout deja parcouru (`g`) le rend sous-optimal.\n",
+    "- **A\\* minimise le cout reel** (`f = g + h`). Il accepte un chemin *plus long en etapes* (16 pas) pour *contourner* le marais et atteindre le cout minimal (16). Avec une heuristique de Manhattan **admissible** (elle ne surestime jamais le cout reel, car chaque pas coute au moins 1), A\\* garantit le chemin optimal.\n",
     "\n",
-    "> **Pour observer A\\* pruner réellement.** Une grille avec plusieurs branches dont certaines mènent à des impasses (labyrinthe) ferait apparaître un écart net en faveur d'A\\* : c'est ce genre de topologie que l'on retrouvera avec les heuristiques PDDL du notebook Planners-5.\n"
+    "**Pourquoi c'est le bon exemple.** Tant que tous les pas coutent pareil, « le plus court chemin » et « le moins de pas » sont la meme chose : on ne voit jamais la difference entre les algorithmes. Des qu'un terrain a des couts variables -- distances reelles, temps, energie -- seul un algorithme qui raisonne sur le **cout cumule** (A\\*, Dijkstra) trouve l'optimum. C'est precisement la situation des heuristiques PDDL du notebook Planners-5, ou chaque action a son propre cout."
    ]
   },
   {
@@ -2025,10 +2012,10 @@
    "id": "cell-36",
    "metadata": {
     "papermill": {
-     "duration": 0.007142,
-     "end_time": "2026-06-09T11:22:46.467879+00:00",
+     "duration": 0.005706,
+     "end_time": "2026-06-20T16:12:21.532624+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.460737+00:00",
+     "start_time": "2026-06-20T16:12:21.526918+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2044,10 +2031,10 @@
    "id": "cell-37",
    "metadata": {
     "papermill": {
-     "duration": 0.007135,
-     "end_time": "2026-06-09T11:22:46.481865+00:00",
+     "duration": 0.005343,
+     "end_time": "2026-06-20T16:12:21.543145+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.474730+00:00",
+     "start_time": "2026-06-20T16:12:21.537802+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2068,16 +2055,16 @@
    "id": "cell-38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:46.497195Z",
-     "iopub.status.busy": "2026-06-09T11:22:46.496964Z",
-     "iopub.status.idle": "2026-06-09T11:22:46.500437Z",
-     "shell.execute_reply": "2026-06-09T11:22:46.499659Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.555264Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.555264Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.570515Z",
+     "shell.execute_reply": "2026-06-20T16:12:21.569889Z"
     },
     "papermill": {
-     "duration": 0.012297,
-     "end_time": "2026-06-09T11:22:46.501290+00:00",
+     "duration": 0.022696,
+     "end_time": "2026-06-20T16:12:21.571027+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.488993+00:00",
+     "start_time": "2026-06-20T16:12:21.548331+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2103,10 +2090,10 @@
    "id": "cell-39",
    "metadata": {
     "papermill": {
-     "duration": 0.006536,
-     "end_time": "2026-06-09T11:22:46.514175+00:00",
+     "duration": 0.005724,
+     "end_time": "2026-06-20T16:12:21.582437+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.507639+00:00",
+     "start_time": "2026-06-20T16:12:21.576713+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2127,16 +2114,16 @@
    "id": "cell-40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:46.528991Z",
-     "iopub.status.busy": "2026-06-09T11:22:46.528753Z",
-     "iopub.status.idle": "2026-06-09T11:22:46.532800Z",
-     "shell.execute_reply": "2026-06-09T11:22:46.532058Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.593685Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.593685Z",
+     "iopub.status.idle": "2026-06-20T16:12:21.600416Z",
+     "shell.execute_reply": "2026-06-20T16:12:21.600416Z"
     },
     "papermill": {
-     "duration": 0.012816,
-     "end_time": "2026-06-09T11:22:46.533472+00:00",
+     "duration": 0.013251,
+     "end_time": "2026-06-20T16:12:21.601416+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.520656+00:00",
+     "start_time": "2026-06-20T16:12:21.588165+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2167,10 +2154,10 @@
    "id": "cell-41",
    "metadata": {
     "papermill": {
-     "duration": 0.00696,
-     "end_time": "2026-06-09T11:22:46.547296+00:00",
+     "duration": 0.005585,
+     "end_time": "2026-06-20T16:12:21.613175+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.540336+00:00",
+     "start_time": "2026-06-20T16:12:21.607590+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2189,16 +2176,16 @@
    "id": "cell-42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:46.563341Z",
-     "iopub.status.busy": "2026-06-09T11:22:46.562988Z",
-     "iopub.status.idle": "2026-06-09T11:22:47.808021Z",
-     "shell.execute_reply": "2026-06-09T11:22:47.807014Z"
+     "iopub.execute_input": "2026-06-20T16:12:21.625420Z",
+     "iopub.status.busy": "2026-06-20T16:12:21.624420Z",
+     "iopub.status.idle": "2026-06-20T16:12:25.377898Z",
+     "shell.execute_reply": "2026-06-20T16:12:25.377284Z"
     },
     "papermill": {
-     "duration": 1.254811,
-     "end_time": "2026-06-09T11:22:47.808759+00:00",
+     "duration": 3.76103,
+     "end_time": "2026-06-20T16:12:25.378925+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:46.553948+00:00",
+     "start_time": "2026-06-20T16:12:21.617895+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2227,10 +2214,10 @@
    "id": "ba8eea14ba14",
    "metadata": {
     "papermill": {
-     "duration": 0.006526,
-     "end_time": "2026-06-09T11:22:47.822055+00:00",
+     "duration": 0.006005,
+     "end_time": "2026-06-20T16:12:25.390488+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:47.815529+00:00",
+     "start_time": "2026-06-20T16:12:25.384483+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2249,16 +2236,16 @@
    "id": "ab3448fb73bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T11:22:47.838396Z",
-     "iopub.status.busy": "2026-06-09T11:22:47.838013Z",
-     "iopub.status.idle": "2026-06-09T11:22:47.841853Z",
-     "shell.execute_reply": "2026-06-09T11:22:47.841074Z"
+     "iopub.execute_input": "2026-06-20T16:12:25.402746Z",
+     "iopub.status.busy": "2026-06-20T16:12:25.402242Z",
+     "iopub.status.idle": "2026-06-20T16:12:25.408445Z",
+     "shell.execute_reply": "2026-06-20T16:12:25.407874Z"
     },
     "papermill": {
-     "duration": 0.013166,
-     "end_time": "2026-06-09T11:22:47.842600+00:00",
+     "duration": 0.012693,
+     "end_time": "2026-06-20T16:12:25.408957+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:47.829434+00:00",
+     "start_time": "2026-06-20T16:12:25.396264+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2285,10 +2272,10 @@
    "id": "cell-43",
    "metadata": {
     "papermill": {
-     "duration": 0.00722,
-     "end_time": "2026-06-09T11:22:47.856844+00:00",
+     "duration": 0.005985,
+     "end_time": "2026-06-20T16:12:25.420063+00:00",
      "exception": false,
-     "start_time": "2026-06-09T11:22:47.849624+00:00",
+     "start_time": "2026-06-20T16:12:25.414078+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2346,18 +2333,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.943808,
-   "end_time": "2026-06-09T11:22:48.426049+00:00",
+   "duration": 8.826181,
+   "end_time": "2026-06-20T16:12:25.859956+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Planners-3-State-Space.ipynb",
-   "output_path": "Planners-3-State-Space.ipynb",
+   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-3-State-Space.ipynb",
+   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-3-State-Space_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-09T11:22:41.482241+00:00",
+   "start_time": "2026-06-20T16:12:17.033775+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Problème (axis-3 : problème bien-posé ↔ concept démontrable)

L'« exemple guidé BFS vs A\* » du notebook Planners-3 utilisait une grille 5×5 à **coût uniforme**. Or, sur coût uniforme, BFS est **déjà** optimal en coût → le différenciateur d'optimalité entre BFS et A\* **ne peut pas apparaître** :
- BFS et A\* renvoyaient le **même** chemin (coût 8) ;
- A\* montrait seulement un **artefact de comptage** (20 vs 19 nœuds : `a_star` compte chaque `heappop`, y compris les re-pops d'états déjà mieux atteints ; BFS dédoublonne).

Le commit `8cb1a19a8` (#3760) avait **réécrit la prose** pour rationaliser cette sortie dégénérée (« pourquoi A\* n'aide pas ici ») au lieu de corriger l'instance mal posée. Doctrine user : BFS et A\* se différencient sur l'**optimalité du chemin** (A\* trouve le moins coûteux, pas BFS) — **rien d'autre**. Quand le différenciateur n'apparaît pas, on corrige les **données** du problème, pas l'interprétation d'une mauvaise sortie.

## Correctif — terrain pondéré sur grille plus grande

- Grille **11×11** avec un **marais central 5×5** (chaque case coûte 10 au lieu de 1).
- **BFS / Greedy** minimisent les **pas** → foncent tout droit dans le marais : **10 pas, coût 55**.
- **A\*** minimise le **coût réel** (`g + h`, Manhattan admissible car chaque pas coûte ≥ 1) → **contourne** le marais : **16 pas, coût 16** (le chemin réellement le moins cher).
- Visualisation : les deux chemins superposés sur le terrain (BFS à travers, A\* autour).

| Algorithme | Pas | Coût | Traverse le marais |
|------------|-----|------|--------------------|
| BFS | 10 | 55 | oui (tout droit) |
| Greedy | 10 | 55 | oui (tout droit) |
| A\* | 16 | **16** | non (contourne) |

## Cellules modifiées
- Exemple guidé (`3f7c5620`) : instance pondérée + heatmap deux-chemins.
- Markdown d'interprétation (`ef4f71d1`) : leçon d'**optimalité** (remplace la rationalisation du corridor).
- Tableau récap (`cell-34`) : BFS « Optimal » nuancé → *uniquement si coûts uniformes* (note de bas de tableau sur terrain pondéré).

## Validation (règle C.2 / H.1)
Ré-exécution end-to-end via `notebook_tools.py execute` (env `coursia-ml-training`, papermill, kernel `python3`) :
```
[Planners-3-State-Space.ipynb] (kernel: python3)  [+] SUCCESS  (10.5s)
```
- 21/21 cellules code, **0 erreur**, tous les `execution_count` renseignés.
- Le tableau markdown **correspond exactement** à la sortie committée (axis-1 OK).

See #3164 (campagne fidélité — axis-3 : problème bien-posé ↔ concept démontrable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)