### PR TITLE
docs(qc-py-27): anchor Kelly + Risk Parity allocation citations (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -1379,7 +1379,11 @@
     "| **Fixe** | 33%/33%/33% | Simple, debut |\n",
     "| **Risk Parity** | Selon volatilite | Equilibrer le risque |\n",
     "| **Performance** | Selon Sharpe recent | Recompenser gagnants |\n",
-    "| **Kelly** | Optimal theorique | Agressif |"
+    "| **Kelly** | Optimal theorique | Agressif |",
+    "\n",
+    "> **Ancrage théorique — allocation de capital multi-stratégies.**\n",
+    "> La ligne **Risk Parity** renvoie au *risk budgeting* où chaque stratégie reçoit un poids inversement proportionnel à sa contribution de risque, formalisé par Maillard, Roncalli & Teiletche (2010) *The Properties of Equally Weighted Risk Contribution Portfolios*, Journal of Portfolio Management 36(4):60–70 — le portefeuille de *parité de risque* équilibre les contributions de risque plutôt que les capitaux.\n",
+    "> La ligne **Kelly** renvoie au *critère de Kelly* (Kelly 1956 *A New Interpretation of Information Rate*, Bell System Technical Journal 35:917–926), qui maximise le taux de croissance attendu du log-capital et donne la fraction optimale à risquer par stratégie — théoriquement optimal sous hypothèses fortes (probabilités connues, fonction d'utilité logarithmique), d'où le qualificatif « optimal théorique » et l'usage prudent « agressif » en pratique.\n"
    ]
   },
   {
@@ -1959,6 +1963,12 @@
     "- [QuantConnect Forum](https://www.quantconnect.com/forum)\n",
     "- [LEAN Engine GitHub](https://github.com/QuantConnect/Lean)\n",
     "- [Hands-On AI Trading Book](https://www.hands-on-ai-trading.com)\n",
+    "\n",
+    "### Références\n",
+    "\n",
+    "- Kelly, J.L. Jr. (1956). *A New Interpretation of Information Rate.* Bell System Technical Journal, 35, 917–926. doi:10.1002/j.1538-7305.1956.tb03809.x\n",
+    "- Maillard, S., Roncalli, T. & Teiletche, J. (2010). *The Properties of Equally Weighted Risk Contribution Portfolios.* The Journal of Portfolio Management, 36(4), 60–70. doi:10.3905/jpm.2010.36.4.060\n",
+    "\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Summary

Audit citationnel (epic #3164) sur **QC-Py-27-Production-Deployment**. Verdict **OMISSION** : le notebook enseignait les méthodes d'allocation de capital multi-stratégies (Fixe / Risk Parity / Performance / Kelly) **par nom** mais sans ancrage académique canonique.

## Anchors added (markdown-additive, 0 code cell touched)

**Cell 27 — footnote** after the capital-allocation table:
- **Risk Parity** → Maillard, Roncalli & Teiletche (2010) *The Properties of Equally Weighted Risk Contribution Portfolios*, Journal of Portfolio Management 36(4):60–70 (equally-weighted risk contribution / risk budgeting).
- **Kelly** → Kelly, J.L. Jr. (1956) *A New Interpretation of Information Rate*, Bell System Technical Journal 35:917–926 (log-capital growth optimum — justifie le qualificatif « optimal théorique » + usage prudent « agressif »).

**Cell 35 — References section** (after Ressources Complémentaires): Kelly 1956 + Maillard et al. 2010 with DOIs.

## G.1 — non-duplication check
La cellule 35 existait déjà avec 4 *liens ressources QC* (docs/forum/LEAN/book) — mais pas de **citations académiques**. Les 2 ancres ajoutent les concepts centraux nommés sans ancage, sans dupliquer les liens existants.

## References web-verified
- Kelly 1956 : Wiley BSTJ https://onlinelibrary.wiley.com/doi/abs/10.1002/j.1538-7305.1956.tb03809.x (DOI 10.1002/j.1538-7305.1956.tb03809.x)
- Maillard 2010 : Journal of Portfolio Management 36(4):60–70 (DOI 10.3905/jpm.2010.36.4.060)

## Validation
- `notebook_tools validate` : 1 OK / 0 warning / 0 error
- `scan_cell_ordering` : clean (no HIGH)
- **C.1** : 0 forbidden error (no `raise NotImplementedError` / `assert False` / `1/0`)
- **C.3 surgical** : git diff = 2 hunks only (cell 27 footnote + cell 35 References), +12/-2, **0 code cell modified**, 0 exec_count/outputs change
- **Catalogue byte-identical** to `origin/main` (`COURSE_CATALOG.generated.json`/`.md` untouched — règle catalog HARD 1)
- Branche créée fraîche depuis `origin/main` (0 commit behind, règle catalog HARD 2)
- Pattern **LIST-DIRECT** appliqué (source = line-list, jamais join→string)

## Scope
1 notebook, 1 sujet (citations allocation multi-stratégie), markdown-only. Atomique (catalog-pr-hygiene HARD 3).

See #3164