### PR TITLE
chore(prover): re-enable harness on live target — demo 55 Bondareva (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1498,6 +1498,71 @@ DEMOS = {
         ),
         "difficulty": "hard",
     },
+    55: {
+        "name": "BONDAREVA_CORE_WITNESS",
+        "file": str(BASIC_FILE) if BASIC_FILE else "",
+        "line": 312,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "bondareva_shapley_backward (hb_witness existence)",
+        "theorem": "bondareva_shapley_backward",
+        "imports": (
+            "import Mathlib.Data.Finset.Basic\n"
+            "import Mathlib.Data.Real.Basic\n"
+            "import Mathlib.Algebra.BigOperators.Group.Finset.Basic\n"
+            "import Mathlib.Tactic\n"
+            "import Mathlib.Analysis.Convex.Cone.Dual\n"
+            "import Mathlib.Analysis.InnerProductSpace.PiL2\n"
+            "import CooperativeGames.Basic\n"
+        ),
+        "description": (
+            "REPLACES the single remaining sorry at L312 of Basic.lean (the LP-dual\n"
+            "heart of Bondareva-Shapley `backward`: Balanced -> Core.Nonempty).\n"
+            "Tracked as issue #2959. The surrounding proof scaffolding is COMPLETE\n"
+            "(P convex/closed/nonempty all proven L233-268); only the witness step\n"
+            "is open.\n"
+            "\n"
+            "GOAL at sorry (EXACT):\n"
+            "  exists x in P, (sum i : N, x i) <= G.v Finset.univ\n"
+            "\n"
+            "HYPOTHESES IN SCOPE:\n"
+            "  N : Type, [Fintype N], [DecidableEq N]\n"
+            "  G : TUGame N\n"
+            "  hb : G.Balanced                          (the KEY hypothesis)\n"
+            "  P : Set (N -> R) := { x | forall S : Finset N, (sum i in S, x i) >= G.v S }\n"
+            "  hP_conv : Convex R P                     (proven above)\n"
+            "  hP_closed : IsClosed P                   (proven above)\n"
+            "  hP_nonempty : P.Nonempty                 (proven above)\n"
+            "  hP_lb : forall x in P, (sum i : N, x i) >= G.v Finset.univ\n"
+            "\n"
+            "PROOF STRATEGY (LP duality / hyperplane separation):\n"
+            "  The existence of a feasible x in P with total payoff <= v(N) is the\n"
+            "  dual content of `G.Balanced`. Two viable Mathlib routes:\n"
+            "  1. Farkas / cone duality: the balanced weights (the LP dual feasible\n"
+            "     point witnessing hb) certify that the minimum of (sum i, x i) over P\n"
+            "     does not exceed v(N). File already imports\n"
+            "     `Mathlib.Analysis.Convex.Cone.Dual` -- look for\n"
+            "     `ProperCone.hyperplane_separation` / `inner_le_iff` /\n"
+            "     `Convex.exists_ge_of_...` style separation lemmas.\n"
+            "  2. Compactness + extremum: { x in P | (sum i, x i) <= v(N)+1 } is\n"
+            "     closed and (by balancedness) nonempty/bounded -> attains its inf;\n"
+            "     show the inf <= v(N) via the balanced collection's weights.\n"
+            "\n"
+            "If a full proof is out of reach this iteration, make MEASURABLE\n"
+            "progress: split off a named sub-lemma (e.g. the balanced-weights\n"
+            "inequality) and prove it, leaving a SMALLER sorry. Do NOT close with a\n"
+            "vacuous `trivial` -- the goal is a real existence statement, not `True`."
+        ),
+        "difficulty": "very_hard",
+        "context_before": (
+            "    have hP_lb : forall x in P, (sum i : N, x i) >= G.v Finset.univ := by\n"
+            "      intro x hx\n"
+            "      exact hx Finset.univ\n"
+        ),
+        "context_after": (
+            "    obtain (x, hxP, hxle) := hb_witness\n"
+            "    refine (x, ?_, hxP)\n"
+        ),
+    },
 }
 # (gale_shapley_stable) was proved in PR #1194. The prover skips any DEMO
 # whose key appears in this set.


### PR DESCRIPTION
## Summary

Re-points the Lean prover harness (#1453) at its sole real **warm-cache open target** after the original banc d'essai was won.

- The original banc d'essai (**#1185**: Voting + Shapley uniqueness) is **fully proven** — `social_choice_lean/Voting.lean` and `cooperative_games_lean/Shapley.lean` both `grep -c sorry` = **0**. The harness DEMOS 6/8/9-14 pointed at those now-closed sorries (stale); a BG run on them would thrash (synthetic demos 1-5 `KeyError`).
- Adds **demo 55 `BONDAREVA_CORE_WITNESS`** → `cooperative_games_lean/CooperativeGames/Basic.lean:312`, the LP-dual `hb_witness` existence sorry (`Balanced → Core.Nonempty`), tracked as **#2959**. Evidence-cited description: exact goal, hypotheses in scope (P convex/closed/nonempty all proven), `ProperCone.hyperplane_separation` + compactness/extremum strategies.

## Scope — config-only, NO Lean proof claim

This PR touches **only** `agent_tests/prover/config.py` (one new DEMOS entry, +65/-0). **No `*.lean` file is modified.**

Per pr-review-discipline §B (PR touches `agent_tests/prover/`):
1. `grep -c sorry` before/after: **no `.lean` touched** — `Basic.lean` restored to HEAD, sorry count **1 → 1** (unchanged).
2. Lake build: `cooperative_games_lean` baseline **SUCCESS** (exit 0, 3327 jobs, 9.2s warm); harness kept a build-passing snapshot then auto-restored.
3. Axiom check: N/A (no proof added).
4. Refactor justification: re-enabling the banc d'essai on the live target after the originals were proven — required for the "un coup sur deux" BG ping-pong (user mandate 2026-06-20).

## BG harness run (diagnostic — lean-merge-discipline §2)

`run_prover_bg.py 55` (reasoning/fast=zai GLM-5.1, tactic=openrouter opus-4.7, max_iter=8, 1800s):
- **sorry 1 → 1** (no close) — expected: #2959 is `INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION`.
- Diagnostic value (fed to po-2026:CoursIA-2, who owns the #2959 proof PR):
  - SearchAgent surfaced `geometric_hahn_banach_closed_point`, `ProperCone.hyperplane_separation`, `IsCompact.exists_isMinOn`.
  - TacticAgent proposed a minimizer decomposition (`∃ x ∈ P, ∀ y ∈ P, ∑ x ≤ ∑ y`).

See #1453, #2959, #1185