### PR TITLE
fix(qc-partner): flag Crypto-MultiCanal research.ipynb as qc_reference + allowlist archive (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/research.ipynb
@@ -3511,7 +3511,8 @@
      }
     ]
    }
-  }
+  },
+  "qc_reference": true
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/scripts/notebook_tools/regression_allowlist.json
+++ b/scripts/notebook_tools/regression_allowlist.json
@@ -18,6 +18,14 @@
       "reason": "Demonstrated genuine: FEASIBLE persists at 20/60/120s solve budgets; raising the timeout does NOT reach OPTIMAL. Honest caveat is defensible (not a recoverable degradation).",
       "evidence_url": "https://github.com/jsboige/CoursIA/issues/3688",
       "demonstrated_by": "ai-01 / myia-ai-01 2026-06-19"
+    },
+    {
+      "path": "MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/research_archive.ipynb",
+      "cause": "*",
+      "cell_signature": "13 NameError/KeyError residual across 33 code cells",
+      "reason": "Experimentation ARCHIVE by-design (paired with research.ipynb REFERENCE template). The 13 NameError/KeyError cells are leftover residuals from iterative prototyping on QC Cloud where cells reference variables defined/renamed in later iterations. This is NOT a degraded deliverable: it is the preserved trace of experimentation. The canonical REFERENCE notebook (research.ipynb, same dir, now flagged metadata.qc_reference=True) is the clean by-design template. Archive is committed for traceability of the Crypto-MultiCanal channel research, not as an executable pedagogical output. Greenlit by ai-01 (2026-06-20) as Option A partner-course policy.",
+      "evidence_url": "https://github.com/jsboige/CoursIA/issues/3164",
+      "demonstrated_by": "po-2024 / myia-po-2024 2026-06-20"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Implements **Option A** of the partner-course policy greenlit by ai-01 ([dashboard ack 2026-06-20T17:24Z](#)). The 2 tracked `Crypto-MultiCanal` notebooks are **by-design** QC Cloud REFERENCE / archive artifacts — not locally-executable deliverables. `regression_scan.py` axis-2 census flagged them as output-health degradations (24 STRUCTURAL markers on `research.ipynb`, 60-score DEGRADED on `research_archive.ipynb`), a **false-positive class**.

## Changes

**`research.ipynb` (TEMPLATE REFERENCE)** — +2/-1, metadata only:
- Cell 0 already self-documents `> **[REFERENCE QC Cloud]**` banner (notebook illustrates QuantConnect code to run in the Cloud IDE; local env has no QuantBook / historical data feed).
- Adding `metadata.qc_reference=True` makes the by-design intent machine-readable: `regression_scan.py` line 261 skips structural markers (`NO_OUTPUT` / `NEVER_EXEC`) → **HEALTHY score=0 n_markers=0**.
- **0 code cell touched, 0 output touched, 0 execution_count change** (C.3 surgical).

**`research_archive.ipynb` (EXPERIMENTATION ARCHIVE)** — allowlist entry (+8 lines):
- Paired archive of the channel research: 33 code cells, **13 residual `NameError`/`KeyError`** (7 + 6) from iterative QC Cloud prototyping (variables defined / renamed across iterations).
- Committed for **traceability**, NOT as an executable pedagogical output. The clean by-design template lives in `research.ipynb` (same dir, now flagged).
- `regression_allowlist.json` entry `cause:"*"` → verdict **ACKNOWLEDGED** (all 4 causes covered: `NO_OUTPUT`, `RUNTIME_ERROR`, `TOOL_MISSING`, `UNKNOWN`).
- Per `regression_allowlist.json` policy: this is NOT permission to commit a degraded output — it documents a genuinely by-design archive paired with the clean reference template, greenlit by the coordinator.

## Validation (post-fix, evidence-cited)

| Check | Result |
|-------|--------|
| `regression_scan.py` on `research.ipynb` | `HEALTHY score=0 n_markers=0` (was 24 STRUCTURAL markers) |
| `regression_scan.py` on `research_archive.ipynb` | verdict `ACKNOWLEDGED` (all 4 causes allowlisted) |
| Catalogue byte-identical to `origin/main` | ✓ (`git diff --stat COURSE_CATALOG.generated.*` = empty) |
| `research.ipynb` C.3 surgical | ✓ (+2/-1 metadata only, 0 code/output/exec_count change) |

## Scope of this PR (atomic — PR 1/2)

This is the **content** PR. A separate **tooling** PR will follow: `regression_scan.py` should exclude gitignored paths via `--git-tracked-only` (mirroring `generate_catalog.py:684`) to kill the broader FP class (3 `lean-workspace/` notebooks in the same dir are gitignored and should never enter the census). Keeping tool + content in 2 atomic PRs per catalog-pr-hygiene rule HARD 3.

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)