### PR TITLE
docs(qc-py-32): anchor DQN canonical RL citations (Mnih/Watkins/Double/Dueling) (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
@@ -1994,7 +1994,24 @@
     "### Prochaine etape\n",
     "\n",
     "Explorer les methodes policy-gradient (A2C, PPO) pour des espaces d'action continus\n",
-    "et un meilleur controle du risque dans le notebook suivant."
+    "et un meilleur controle du risque dans le notebook suivant.\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "Le DQN (*Deep Q-Network*) implemente ici combine plusieurs contributions canoniques de la litterature. Les nommer explicite le pedagogique des choix techniques (replay buffer, target network, Dueling, Double):\n",
+    "\n",
+    "- **Watkins, C. J. C. H.** (1989). *Learning from Delayed Rewards*. These de doctorat, Universite de Cambridge. Origine de l'algorithme Q-learning (mise a jour de la valeur d'action par l'equation de Bellman) dont DQN est une approximation par reseau de neurones.\n",
+    "- **Mnih, V., Kavukcuoglu, K., Silver, D. et al.** (2015). *Human-level control through deep reinforcement learning*. Nature, 518:529-533. https://doi.org/10.1038/nature14236. Papier fondateur du DQN : combine (1) l'approximation de Q par un CNN, (2) l'*experience replay* (rejouer des transitions passees pour decorreler les gradients) et (3) les *target networks* (reseau cible a mise a jour lente pour stabiliser les cibles). Les trois sont implementes dans ce notebook.\n",
+    "- **van Hasselt, H., Guez, A. & Silver, D.** (2016). *Deep Reinforcement Learning with Double Q-learning*. AAAI Conference on Artificial Intelligence. arXiv:1509.06461. *Double DQN* : reduit la surestimation systematique de Q en decouplant la selection et l'evaluation de l'action (le notebook utilise un agent DQN Double).\n",
+    "- **Wang, Z., Schaul, T., Hessel, M. et al.** (2016). *Dueling Network Architectures for Deep Reinforcement Learning*. ICML. arXiv:1511.06581. Architecture *Dueling* : decomposer Q(s,a) en V(s) + A(s,a) pour separer valeur d'etat et avantage de l'action (l'architecture Dueling du notebook vient d'ici).\n",
+    "- **Mnih, V., Badia, A. P., Mirza, M. et al.** (2016). *Asynchronous Methods for Deep Reinforcement Learning*. ICML. arXiv:1602.01783. Origine d'A2C/A3C (variantes policy-gradient) mentionnees en prochaine etape.\n",
+    "- **Lin, L.-J.** (1992). *Self-Improving Reactive Agents Based on Reinforcement Learning, Planning and Teaching*. Machine Learning, 8:293-321. Origine de l'*experience replay* exploite par Mnih et al. (2015).\n",
+    "\n",
+    "### Ressources complementaires\n",
+    "\n",
+    "- **Notebook QC-Py-33** : RL PPO Trading (suite policy-gradient).\n",
+    "- **Notebook QC-Py-34** : RL SAC / A2C Trading (actor-critic continus).\n",
+    "- **Documentation** : [QuantConnect Docs](https://www.quantconnect.com/docs), [PyTorch RL / Gymnasium](https://gymnasium.farama.org/)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

**Verdict OMISSION**: QC-Py-32 teaches Deep Q-Network (DQN **Dueling Double** with experience replay, target network, epsilon-greedy decay, soft update) — **54 mentions of \"DQN\"** across the notebook — but cited **NONE** of the canonical RL literature the technique derives from. The Conclusion cell named the architecture and its components without anchoring them to their origin papers.

## Changes (markdown-additive, C.3 surgical)

Added a **\"References académiques\"** section to the Conclusion cell (44), anchoring each implemented component to its canonical paper:

| Citation | Year | Anchors |
|----------|------|---------|
| **Watkins** | 1989 | Q-learning origin (PhD thesis, Cambridge) — the Bellman-update action-value algorithm DQN approximates |
| **Mnih et al.** | 2015 | *Human-level control through deep RL*, **Nature 518:529-533**, doi:10.1038/nature14236 — the DQN paper: CNN Q-approx + experience replay + target networks (all 3 implemented here) |
| **van Hasselt, Guez & Silver** | 2016 | *Deep RL with Double Q-learning*, AAAI, arXiv:1509.06461 — Double DQN (decouple selection/evaluation → reduce overestimation) |
| **Wang et al.** | 2016 | *Dueling Network Architectures for Deep RL*, ICML, arXiv:1511.06581 — Dueling V(s)+A(s,a) architecture |
| **Mnih et al.** | 2016 | *Asynchronous Methods for Deep RL*, ICML, arXiv:1602.01783 — A2C/A3C origin (next-step policy-gradient) |
| **Lin** | 1992 | *Self-Improving Reactive Agents*, Machine Learning 8:293-321 — experience replay origin |

## Validation (evidence-cited)

| Check | Result |
|-------|--------|
| `notebook_tools validate` | OK (0 error, 0 warning) |
| C.3 surgical | **+18/-1, ONLY markdown cell 44 changed**. 15/15 code cells byte-identical (source + outputs + execution_count via `git show` diff) |
| `regression_scan.py --guard` | OK (no healthy→degraded transition) |
| Catalogue byte-identical to `origin/main` | ✓ |
| Citations web-verified | Mnih 2015 (Nature 518:529-533, doi:10.1038/nature14236) + van Hasselt 2016 (AAAI, arXiv:1509.06461) confirmed against primary sources |

## Scope (atomic)

Single notebook, markdown-additive only, no code/output/exec_count change. Part of the QC-Py citation deep-queue (#3164 audit citationnel). Companions QC-Py-27/28/30/34 already faithful/anchored (verified this cycle).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)