### PR TITLE
docs(qc-py-33): anchor PPO clipping + GAE citations where taught (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
@@ -2083,6 +2083,8 @@
     "4. **GAE** : L'estimation d'avantage generalisee reduit la variance tout en controlant le biais,\n",
     "   ameliorant la convergence de l'apprentissage\n",
     "\n",
+    "> **Ancre savante -- PPO & GAE** : Le *clipped surrogate objective* et l'estimation d'avantage generalisee (GAE) sont les deux contributions centrales de PPO. Schulman et al. (2017, *Proximal Policy Optimization Algorithms*, arXiv:1707.06347) introduisent l'objectif tronque qui limite le ratio de probabilite nouveau/ancien a [1-eps, 1+eps] (eps=0.2 ici) pour empecher les mises a jour destructrices -- une alternative simpler et plus robuste aux *trust regions* de TRPO (Schulman et al. 2015, *Trust Region Policy Optimization*, ICML, arXiv:1502.05477). La GAE provient de Schulman et al. (2016, *High-Dimensional Continuous Control Using Generalized Advantage Estimation*, ICLR, arXiv:1506.02438) : elle decompose l'avantage en somme exponentiallement decroissante des residus de Bellman, controlee par lambda (gae_lambda=0.95 ici), offrant un compromis biais-variance. Le cadre actor-critic et les policy gradients remontent a Sutton et al. (2000, *Policy Gradient Methods for Reinforcement Learning with Function Approximation*, NeurIPS) et Williams (1992, *Simple Statistical Gradient-Following Algorithms for Connectionist Reinforcement Learning*, Machine Learning 8:229-256).\n",
+    "\n",
     "### Resume comparatif DQN vs PPO\n",
     "\n",
     "| Aspect | DQN (QC-Py-32) | PPO (QC-Py-33) |\n",


### PR DESCRIPTION
## Summary

**Verdict OMISSION mineure**: QC-Py-33 already cited Schulman et al. (2017) PPO in the intro cell (cell 0 References line), but the **Conclusion (cell 37) TEACHES the two core PPO contributions as pedagogical concepts** — \"Clipped Objective\" (point 3) and \"GAE : L'estimation d'avantage généralisée réduit la variance\" (point 4) — without anchoring them to their origin papers. **GAE appears 29x** across the notebook (taught in cells 16, 21, 37) with no citation.

## Changes (markdown-additive, C.3 surgical)

Added a single grouped footnote after the GAE teaching point in cell 37, anchoring each PPO/GAE component to its canonical paper:

| Citation | Year | Anchors |
|----------|------|---------|
| **Schulman et al.** | 2017 | *Proximal Policy Optimization Algorithms*, arXiv:1707.06347 — the clipped surrogate objective (ratio limited to [1-ε, 1+ε], ε=0.2 here) |
| **Schulman et al.** | 2015 | *Trust Region Policy Optimization*, ICML, arXiv:1502.05477 — TRPO predecessor (PPO is the simpler/robust alternative) |
| **Schulman et al.** | 2016 | *High-Dimensional Continuous Control Using Generalized Advantage Estimation*, **ICLR, arXiv:1506.02438** — GAE (exponentially-decayed Bellman residual sum, λ=0.95 here, bias-variance tradeoff) |
| **Sutton et al. / Williams** | 2000 / 1992 | Policy gradient / actor-critic framework (NeurIPS / ML 8:229-256) |

## Validation (evidence-cited)

| Check | Result |
|-------|--------|
| `notebook_tools validate` | OK (0 error, 1 pre-existing warning) |
| C.3 surgical | **+3/-1, ONLY markdown cell 37 changed**. 16/16 code cells byte-identical (source + outputs + execution_count via `git show` diff) |
| `regression_scan.py --guard` | OK (no healthy→degraded) |
| Catalogue byte-identical to `origin/main` | ✓ |
| Citations web-verified | GAE paper (arXiv:1506.02438, Schulman/Moritz/Levine/Jordan/Abbeel, ICLR 2016) confirmed against primary source |

## Scope (atomic)

Single notebook, markdown-additive only, no code/output/exec_count change. Part of the QC-Py citation deep-queue (#3164 audit citationnel). The existing Schulman 2017 intro citation is preserved (not duplicated) — this PR adds the GAE + clipping anchors where those concepts are actually taught.

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)