### PR TITLE
docs(dsa-lab16): anchor text-to-SQL Spider (Yu 2018) + code-gen HumanEval (Chen 2021) #3164

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb
@@ -147,7 +147,17 @@
     "tags": []
    },
    "source": [
-    "## 2. NL2SQL Translator"
+    "## 2. NL2SQL Translator\n",
+    "\n",
+    "Le **text-to-SQL** (ou NL2SQL) est la tache de traduire une question en langage naturel vers une\n",
+    "requete SQL executable sur un schema de base de donnees. C'est un probleme classique de semantic\n",
+    "parsing dont le benchmark de reference est **Spider** (Yu et al. 2018) : 10 181 questions et\n",
+    "5 693 requetes SQL complexes sur 200 bases de donnees couvrant 138 domaines, etabli pour mesurer\n",
+    "la generalisation cross-domaine des modeles.\n",
+    "\n",
+    "> Reference : Yu, T., Zhang, R., Yang, K., et al. (2018).\n",
+    "> *Spider: A Large-Scale Human-Labeled Dataset for Complex and Cross-Domain Semantic Parsing\n",
+    "> and Text-to-SQL Task*. EMNLP 2018. arXiv:1809.08887. https://arxiv.org/abs/1809.08887"
    ]
   },
   {
@@ -195,7 +205,16 @@
     "tags": []
    },
    "source": [
-    "## 3. NL2Py Translator"
+    "## 3. NL2Py Translator\n",
+    "\n",
+    "Le **NL2Py** (traduction de langage naturel vers code Python) releve de la generation de code par\n",
+    "LLM. Le benchmark de reference pour evaluer cette capacite est **HumanEval** (Chen et al. 2021),\n",
+    "qui mesure la generation de fonctions Python a partir de descriptions en langage naturel via la\n",
+    "metrique pass@k.\n",
+    "\n",
+    "> Reference : Chen, M., Tworek, J., Jun, H., et al. (2021).\n",
+    "> *Evaluating Large Language Models Trained on Code*. arXiv:2107.03374 (OpenAI).\n",
+    "> https://arxiv.org/abs/2107.03374"
    ]
   },
   {
@@ -833,6 +852,17 @@
     "- Quels types de questions echouent le plus souvent ?\n",
     "- Le mode SQL ou Python est-il plus robuste ?\n",
     "- Comment ameliorer le contexte fourni au LLM ?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- Yu, T., Zhang, R., Yang, K., et al. (2018). *Spider: A Large-Scale Human-Labeled Dataset for Complex and Cross-Domain Semantic Parsing and Text-to-SQL Task*. EMNLP 2018. arXiv:1809.08887. https://arxiv.org/abs/1809.08887\n",
+    "- Chen, M., Tworek, J., Jun, H., et al. (2021). *Evaluating Large Language Models Trained on Code*. arXiv:2107.03374 (OpenAI). https://arxiv.org/abs/2107.03374\n",
+    "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Lab16-Data-Science-Agent (Day7-Production) enseigne NL2SQL + NL2Py (traduction langage naturel vers SQL et Python) sans citation canonique -> profil OMISSION (classe c de l'audit #3164).

Ancres ajoutees (markdown-only, surgical, 33 ins / 3 del) :
- **Text-to-SQL** (NL2SQL Translator) -> Yu, Zhang, Yang et al. 2018, *Spider: A Large-Scale Human-Labeled Dataset for Complex and Cross-Domain Semantic Parsing and Text-to-SQL Task*, EMNLP 2018, arXiv:1809.08887 (Yale LILY ; 10 181 questions, 5 693 SQL, 200 DBs, 138 domains). Benchmark canonique text-to-SQL. Web-verifie (arXiv + Yale LILY + DBLP).
- **Code generation** (NL2Py Translator) -> Chen, Tworek, Jun et al. 2021, *Evaluating Large Language Models Trained on Code*, arXiv:2107.03374 (OpenAI, HumanEval, pass@k). Benchmark canonique generation de code depuis langage naturel.
- Section **References** (3 entrees : Yu 2018, Chen 2021, Xi 2025).

## G.1 honesty
- Deux concepts DISTINCTS du Lab16 = text-to-SQL (NL2SQL) + code generation NL->Python (NL2Py), chacun a son translateur dedie -> ancres legitimes, pas de padding G.5.
- repair-not-consecrate (#3660) NON-TRIGGERE : notebook sain (exec_count 1-11, 0 erreur, 0 output vide).

## Validation
- `notebook_tools.py validate` : OK (0 warning, 0 error)
- `scan_cell_ordering.py --severity HIGH` : clean
- C.1 : 0 `raise NotImplementedError`/`assert False`/`1/0`
- C.2/C.3 : 0 churn `execution_count`/`outputs` (markdown-only)
- `COURSE_CATALOG.generated.{json,md}` byte-identiques a origin/main
- 3 exercices + questions d'analyse presents (convention 3-exos respectee)

See #3164 (audit fidelite repo-wide, contribution partielle a l'Epic).
