### PR TITLE
fix(sudoku): scrub machine-local paths from Sudoku-10/18 outputs (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -84,16 +84,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: ortools in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (9.15.6755)\n",
-      "Requirement already satisfied: absl-py>=2.0.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (2.4.0)\n",
-      "Requirement already satisfied: numpy>=2.0.2 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (2.4.4)\n",
+      "Requirement already satisfied: ortools in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (9.15.6755)\n",
+      "Requirement already satisfied: absl-py>=2.0.0 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (2.4.0)\n",
+      "Requirement already satisfied: numpy>=2.0.2 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (2.4.4)\n",
       "Requirement already satisfied: pandas>=2.0.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from ortools) (3.0.3)\n",
-      "Requirement already satisfied: protobuf<6.34,>=6.33.1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (6.33.6)\n",
-      "Requirement already satisfied: typing-extensions>=4.12 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (4.15.0)\n",
-      "Requirement already satisfied: immutabledict>=3.0.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (4.3.1)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas>=2.0.0->ortools) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas>=2.0.0->ortools) (2025.3)\n",
-      "Requirement already satisfied: six>=1.5 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from python-dateutil>=2.8.2->pandas>=2.0.0->ortools) (1.17.0)\n"
+      "Requirement already satisfied: protobuf<6.34,>=6.33.1 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (6.33.6)\n",
+      "Requirement already satisfied: typing-extensions>=4.12 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (4.15.0)\n",
+      "Requirement already satisfied: immutabledict>=3.0.0 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (4.3.1)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas>=2.0.0->ortools) (2.9.0.post0)\n",
+      "Requirement already satisfied: tzdata in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas>=2.0.0->ortools) (2025.3)\n",
+      "Requirement already satisfied: six>=1.5 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from python-dateutil>=2.8.2->pandas>=2.0.0->ortools) (1.17.0)\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -1871,11 +1871,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\ipykernel_2145716\\2203822888.py:11: MatplotlibDeprecationWarning: The 'labels' parameter of boxplot() has been renamed 'tick_labels' since Matplotlib 3.9; support for the old name will be dropped in 3.11.\n",
+      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\2203822888.py:11: MatplotlibDeprecationWarning: The 'labels' parameter of boxplot() has been renamed 'tick_labels' since Matplotlib 3.9; support for the old name will be dropped in 3.11.\n",
       "  bp = ax.boxplot(data, labels=solver_names, patch_artist=True)\n",
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\ipykernel_2145716\\2203822888.py:11: MatplotlibDeprecationWarning: The 'labels' parameter of boxplot() has been renamed 'tick_labels' since Matplotlib 3.9; support for the old name will be dropped in 3.11.\n",
+      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\2203822888.py:11: MatplotlibDeprecationWarning: The 'labels' parameter of boxplot() has been renamed 'tick_labels' since Matplotlib 3.9; support for the old name will be dropped in 3.11.\n",
       "  bp = ax.boxplot(data, labels=solver_names, patch_artist=True)\n",
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\ipykernel_2145716\\2203822888.py:11: MatplotlibDeprecationWarning: The 'labels' parameter of boxplot() has been renamed 'tick_labels' since Matplotlib 3.9; support for the old name will be dropped in 3.11.\n",
+      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\2203822888.py:11: MatplotlibDeprecationWarning: The 'labels' parameter of boxplot() has been renamed 'tick_labels' since Matplotlib 3.9; support for the old name will be dropped in 3.11.\n",
       "  bp = ax.boxplot(data, labels=solver_names, patch_artist=True)\n"
      ]
     },


### PR DESCRIPTION
## Summary

Apply-batch (Sudoku family) of the output-path scrub introduced in **#3768** (`scrub_papermill_paths.py --outputs` mode, now merged). Two notebooks leaked the contributor's home directory + process ids inside output text.

| Notebook | Leak source | Leaks |
|----------|-------------|-------|
| Sudoku-10-ORTools-Python | pip `already satisfied: X in C:\Users\jsboi\AppData\Local\Packages\PythonSoftwareFoundation...\site-packages` (Windows Store Python) | 1 |
| Sudoku-18-Comparison-Python | ipykernel temp path in matplotlib `MatplotlibDeprecationWarning` (`C:\Users\jsboi\AppData\Local\Temp\claude\ipykernel_<PID>\<hash>.py:line`) | 2 |

## Why scrub (not re-exec)

These are **non-deterministic environment noise** — re-execution regenerates a fresh machine path (new PID, new temp dir). Scrubbing is the canonical fix (#3731 doctrine extended metadata→outputs by #3768). The tool anonymizes only the machine-local prefix — home root → `~`, ipykernel PID → `<pid>` — while preserving the rest of the path (package versions, cell hashes, warning messages) which carries diagnostic value.

## Verification (G.1 cross-check)

- **0 source cells changed** (byte-identical source)
- **execution_count preserved** (Sudoku-10: 11/11, Sudoku-18: 24/24)
- **0 home leaks remaining** in outputs (re-scan clean)
- **line count preserved** (delta 0) → no collateral alteration
- **H.3 clean** (0 null-ec nonempty cells), catalog byte-identical, base fresh (0 behind)
- diff is home-root → `~` substring replacements only (12 ins / 12 del, balanced)

## Scope

First apply-batch of the po-205 partition (census: 17 notebooks / 31 leaks). Per-family PRs follow (ML/ML.Net, Probas, Argument_Analysis, ML/DataScienceWithAgents) to stay under the G.4 composite threshold.

See #3436 (repo-wide scrub epic). Tool: #3768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)