### PR TITLE
docs(smt): add Conclusion section to SMT parent README (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
@@ -40,3 +40,26 @@ Les deux séries traitent volontairement des **mêmes problèmes phares** (théo
 - [Search / CSP](../../Search/README.md) — programmation par contraintes et automates symboliques (prédicats Z3)
 - [Z3 Prover (upstream)](https://github.com/Z3Prover/z3) — le solveur SMT lui-même
 - [Z3.Linq (endjin)](https://github.com/endjin/Z3.Linq) — le binding C# déclaratif
+
+## Conclusion / Prochaines étapes
+
+### Ce que vous avez appris
+
+Ce répertoire vous a introduit à l'un des outils les plus puissants de l'informatique symbolique : le **solveur SMT** Z3, et au changement de regard qu'il rend possible — décrire *ce que l'on veut*, pas *comment l'obtenir*. L'arc pédagogique repose sur deux angles complémentaires du même paradigme déclaratif :
+
+- **Le saut SAT → SMT** — un solveur SAT décide une formule booléenne ; un solveur SMT raisonne directement sur des *théories* (arithmétique linéaire, tableaux, vecteurs de bits, chaînes). Plutôt qu'encoder un Sudoku ou un planificateur en variables booléennes à la main, on énonce les contraintes dans le langage naturel de la théorie, et le solveur retourne un modèle (`sat`) ou prouve l'impossibilité (`unsat`). C'est ce gain d'expressivité qui rend Z3 indispensable en vérification de programmes, en planification et en sécurité.
+- **La double porte d'entrée, délibérément juxtaposée** — le même paradigme s'atteint par deux bindings aux compromis opposés. **Z3.Linq (C#)** traduit des expressions LINQ en formules SMT : lisible, idiomatique .NET, mais à la couverture bornée (pas de tactiques ni de théories exotiques). **z3-py (Python)** expose l'API intégrale du solveur (tactiques, `BitVec`, `Array`, `Optimize`, quantificateurs) : tout puissant, mais au prix d'une syntaxe plus explicite. Comprendre les deux, c'est comprendre **quand la lisibilité déclarative suffit, et quand il faut descendre au contrôle de bas niveau**.
+- **Le fil rouge commun** — les deux séries traitent volontairement des **mêmes problèmes phares** (théorèmes linéaires, Sudoku comme CSP) afin que la comparaison déclaratif/impératif soit explicite d'un binding à l'autre. La leçon transversale : la modélisation est un art autant qu'une technique, et le choix du binding dépend moins du problème que du contexte (écosystème .NET vs recherche Python, lisibilité vs expressivité).
+
+La thèse est puissante et honnêtement présentée : il n'existe pas de « bon » binding dans l'absolu — Z3.Linq gagne en lisibilité ce qu'il perd en couverture, z3-py gagne en puissance ce qu'il perd en abstraction — et la compétence du développeur est de savoir choisir selon le problème et l'écosystème.
+
+### Prochaines étapes
+
+- **Z3 en C# déclaratif (Z3.Linq)** : la série [Z3/](Z3/README.md) (5 notebooks, .NET 9) est la porte d'entrée idéale si vous venez de l'écosystème .NET — patron `Theorem<T>`, théorie des tableaux, optimisation hiérarchique, génération de témoins.
+- **Z3 en Python (z3-py)** : la série [Z3-Python/](Z3-Python/README.md) (6 notebooks) ouvre l'API complète — tactiques, `BitVec`/`Array`/`String`, quantificateurs, preuve par réfutation, optimisation Pareto/MaxSAT.
+- **Z3 parmi d'autres paradigmes** : la [série Sudoku](../../Sudoku/README.md) compare Z3 à une dizaine d'autres approches algorithmiques (backtracking, DLX, métaheuristiques, inférence probabiliste, réseaux de neurones) sur un même problème NP-complet — le terrain idéal pour situer la résolution SMT dans le spectre des solveurs.
+- **Programmation par contraintes industrielle** : la série [Search / CSP](../../Search/README.md) généralise la modélisation par contraintes (OR-Tools CP-SAT) à une famille plus large de problèmes d'optimisation et d'ordonnancement, avec un solveur complémentaire de Z3.
+
+### Le fil rouge
+
+La résolution SMT propose un changement de regard sur la modélisation de problèmes : ne plus demander « quel algorithme écrire pour résoudre ceci ? » mais **« quelles contraintes doivent être satisfaites, et dans quelle théorie les exprimer ? »**. Ce répertoire vous a donné le concept (SMT = SAT + théories), le solveur de référence (Z3), et deux portes d'entrée aux compromis clairement cartographiés (Z3.Linq déclaratif borné vs z3-py impératif complet) — en gardant à l'esprit que Z3 n'est qu'un point du spectre des solveurs, et que savoir le situer face à un backtracking, un CP-SAT ou une métaheuristique est précisément ce que les séries voisines (Sudoku, Search/CSP) enseignent.


### PR DESCRIPTION
## Summary

Add a `## Conclusion / Prochaines étapes` section to `SymbolicAI/SMT/README.md`, the series-hub parent of the Z3 C# (#3782) and Z3-Python (#3785) child series. Matching the #3750 pedagogical canvas. The README previously ended on "Voir aussi" without a concluding synthesis.

## Content (grounded, no invention)

Built from the actual hub content (read firsthand):
- **SAT → SMT leap** — theories (linear arithmetic, arrays, bitvectors, strings) vs raw booleans; sat/unsat verdicts
- **Two complementary bindings** — Z3.Linq (C#, declarative-bounded, LINQ→SMT) vs z3-py (Python, imperative-complete, full API)
- **Shared problem thread** — both series cover the same flagship problems (linear theorems, Sudoku as CSP) to make the declaratif/imperatif comparison explicit

Three subsections matching #3750: `### Ce que vous avez appris`, `### Prochaines étapes`, `### Le fil rouge`.

## Prochaines étapes links (all verified to exist)
- `Z3/README.md` — child C# series (Conclusion added in #3782)
- `Z3-Python/README.md` — child Python series (Conclusion added in #3785)
- `../../Sudoku/README.md` — 10-paradigm Sudoku comparison
- `../../Search/README.md` — CP-SAT industrial constraint programming

## Validation
- Docs-only: 23 insertions, 0 deletions, 1 file
- Catalog + submodule byte-identical (catalog-pr-hygiene HARD 1)
- Fresh branch from `origin/main` (HARD 2)
- Atomic, single deliverable (HARD 3)
- No tables added → 0 new markdown lint warnings

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)