### PR TITLE
docs(dsa-lab17): anchor DS-STAR pipeline integration + LLM hallucination (Ji 2023) capstone #3164

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
@@ -203,7 +203,16 @@
     "tags": []
    },
    "source": [
-    "## 3. Modules DS-STAR"
+    "## 3. Modules DS-STAR\n",
+    "\n",
+    "Ce projet final integre le pipeline **DS-STAR** complet (FileAnalyzer -> Planner -> Coder ->\n",
+    "Executor -> Verifier -> Reporter) tel que defini par Guo et al. (2025) : un systeme multi-agent\n",
+    "qui decompose un probleme de data science, genere et execute du code en sandbox, puis valide les\n",
+    "resultats avant de produire un rapport. Ce lab orchestre l'**integration end-to-end** de tous les\n",
+    "composants, par opposition a l'etude d'un composant isole (cf. Lab 10 sur le FileAnalyzer).\n",
+    "\n",
+    "> Reference : Guo, Q., et al. (2025). *DS-STAR: An Automated End-to-End Data Science Agent\n",
+    "> Based on Code Generation*. arXiv:2509.21825. https://arxiv.org/abs/2509.21825"
    ]
   },
   {
@@ -913,7 +922,30 @@
   {
    "cell_type": "markdown",
    "id": "fcbedf7f",
-   "source": "## Exercice : Amelioration du ReportGenerator Anti-Hallucination\n\nDans la section 6, nous avons observe que le ReportGenerator peut halluciner des chiffres quand il n'a pas acces aux resultats reels. L'objectif est de creer un generateur de rapport qui injecte uniquement les donnees reelles de l'Executor et evite toute invention.\n\n### Objectifs\n1. Analyser le prompt du ReportGenerator actuel pour identifier les sources d'hallucination\n2. Implementer un `SafeReportGenerator` qui n'utilise que les donnees injectees\n3. Comparer les rapports genere par les deux versions\n\n### Indice\n- Le prompt actuel demande \"genere un rapport\" sans fournir les resultats concrets\n- Injectez les outputs reels dans le prompt avec une instruction stricte \"n'invente aucun chiffre\"\n- Ajoutez un avertissement \"Si tu n'as pas de donnees pour une section, indique 'Donnees non disponibles'\"",
+   "source": [
+    "## Exercice : Amelioration du ReportGenerator Anti-Hallucination\n",
+    "\n",
+    "> Contexte methodologique : les LLM sont sujets a l'**hallucination** (generation de contenu\n",
+    "> plausible mais factuellement errone), phenomene systematise dans l'etude de reference de\n",
+    "> Ji et al. (2023). Le ReportGenerator doit donc ancrer ses chiffres sur les sorties verifiees\n",
+    "> du Verifier plutot que sur des estimations generees.\n",
+    ">\n",
+    "> Reference : Ji, Z., Lee, N., Frieske, R., et al. (2023).\n",
+    "> *Survey of Hallucination in Natural Language Generation*. ACM Computing Surveys 55.\n",
+    "> arXiv:2202.03629. https://arxiv.org/abs/2202.03629\n",
+    "\n",
+    "Dans la section 6, nous avons observe que le ReportGenerator peut halluciner des chiffres quand il n'a pas acces aux resultats reels. L'objectif est de creer un generateur de rapport qui injecte uniquement les donnees reelles de l'Executor et evite toute invention.\n",
+    "\n",
+    "### Objectifs\n",
+    "1. Analyser le prompt du ReportGenerator actuel pour identifier les sources d'hallucination\n",
+    "2. Implementer un `SafeReportGenerator` qui n'utilise que les donnees injectees\n",
+    "3. Comparer les rapports genere par les deux versions\n",
+    "\n",
+    "### Indice\n",
+    "- Le prompt actuel demande \"genere un rapport\" sans fournir les resultats concrets\n",
+    "- Injectez les outputs reels dans le prompt avec une instruction stricte \"n'invente aucun chiffre\"\n",
+    "- Ajoutez un avertissement \"Si tu n'as pas de donnees pour une section, indique 'Donnees non disponibles'\""
+   ],
    "metadata": {}
   },
   {
@@ -957,6 +989,17 @@
     "- [ ] Resultats analyses\n",
     "- [ ] Rapport final genere\n",
     "- [ ] (Bonus) Visualisations ajoutees\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- Guo, Q., et al. (2025). *DS-STAR: An Automated End-to-End Data Science Agent Based on Code Generation*. arXiv:2509.21825. https://arxiv.org/abs/2509.21825\n",
+    "- Ji, Z., Lee, N., Frieske, R., et al. (2023). *Survey of Hallucination in Natural Language Generation*. ACM Computing Surveys 55. arXiv:2202.03629. https://arxiv.org/abs/2202.03629\n",
+    "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Lab17-Final-Project (capstone Day7, fin sous-série AgenticDataScience) integre le pipeline DS-STAR complet et aborde l'anti-hallucination du ReportGenerator sans citation canonique -> profil OMISSION (classe c de l'audit #3164).

Ancres ajoutees (markdown-only, surgical, 46 ins / 3 del) :
- **DS-STAR pipeline complet** (integration end-to-end) -> Guo et al. 2025, *DS-STAR: An Automated End-to-End Data Science Agent Based on Code Generation*, arXiv:2509.21825. Capstone d'integration orchestrant FileAnalyzer->Planner->Coder->Executor->Verifier->Reporter, DISTINCT du composant isole etudie au Lab10 (FileAnalyzer). Web-verifie arXiv.
- **Hallucination LLM** (exercice ReportGenerator Anti-Hallucination) -> Ji, Lee, Frieske et al. 2023, *Survey of Hallucination in Natural Language Generation*, ACM Computing Surveys 55, arXiv:2202.03629. Survey canonique. Web-verifie (ACM + arXiv + PMC).
- Section **References** (3 entrees : Guo 2025, Ji 2023, Xi 2025).

## G.1 honesty
- DS-STAR ancre Lab10 au niveau composant (FileAnalyzer isole) ; ici au niveau **integration pipeline end-to-end** (capstone orchestrant tous les modules) = concept DISTINCT, pas duplication.
- Hallucination = concept pedagogique central de l'exercice 36 (ameliorer le ReportGenerator anti-hallucination) -> ancre legitime.
- repair-not-consecrate (#3660) NON-TRIGGERE : notebook sain (exec_count 1-17, 0 erreur, 0 output vide).

## Validation
- `notebook_tools.py validate` : OK (0 warning, 0 error)
- `scan_cell_ordering.py --severity HIGH` : clean
- C.1 : 0 `raise NotImplementedError`/`assert False`/`1/0`
- C.2/C.3 : 0 churn `execution_count`/`outputs` (markdown-only)
- `COURSE_CATALOG.generated.{json,md}` byte-identiques a origin/main
- 3 exercices + extensions bonus presents (convention 3-exos respectee)

See #3164 (audit fidelite repo-wide, contribution partielle a l'Epic).
