### PR TITLE
docs(dsa-pads-lab1): anchor scikit-learn (Pedregosa 2011) for ML introduction #3164

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb
@@ -555,6 +555,15 @@
    "source": [
     "## Introduction au Machine Learning\n",
     "\n",
+    "Pour cette premiere approche du Machine Learning, nous utilisons **scikit-learn** (sklearn), la\n",
+    "bibliotheque de reference en Python pour les algorithmes de ML classique (regression, classification,\n",
+    "clustering). Elle offre une API uniforme (fit / predict) et des outils d'evaluation (train_test_split,\n",
+    "r2_score). Ici, un modele de **regression lineaire** est entraite pour predire les ventes futures.\n",
+    "\n",
+    "> Reference : Pedregosa, F., Varoquaux, G., Gramfort, A., et al. (2011).\n",
+    "> *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12, pp. 2825-2830.\n",
+    "> arXiv:1201.0490. https://arxiv.org/abs/1201.0490\n",
+    "\n",
     "Le Machine Learning consiste à entraîner un 'modèle' sur des données pour qu'il puisse faire des 'prédictions' sur de nouvelles données. C'est un concept clé de l'IA. Ici, nous allons simuler une prédiction très simple."
    ]
   },
@@ -911,6 +920,17 @@
     "---\n",
     "\n",
     "**Navigation** : [Index](../../README.md) | [Suivant >> Lab 2 - RFP Analysis](../../Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- Pedregosa, F., Varoquaux, G., Gramfort, A., et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12, pp. 2825-2830. arXiv:1201.0490. https://arxiv.org/abs/1201.0490\n",
+    "- McKinney, W. (2010). *Data Structures for Statistical Computing in Python*. SciPy 2010 proceedings, pp. 51-56.\n",
+    "- Harris, C.R., Millman, K.J., et al. (2020). *Array programming with NumPy*. Nature 585, pp. 357-362."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Lab1-PythonForDataScience (PythonAgentsForDataScience Day1, lab introductif) introduit le Machine Learning via scikit-learn sans citation canonique -> profil OMISSION (classe c de l'audit #3164).

Ancres ajoutees (markdown-only, surgical, 21 ins / 1 del) :
- **scikit-learn** (Introduction au Machine Learning, cellule de code utilisant sklearn `LinearRegression` / `train_test_split` / `r2_score`) -> Pedregosa, Varoquaux, Gramfort et al. 2011, *Scikit-learn: Machine Learning in Python*, JMLR 12, pp. 2825-2830, arXiv:1201.0490. Reference canonique de la bibliotheque. Web-verifie (arXiv + JMLR + ResearchGate).
- Section **References** (3 entrees : Pedregosa 2011 scikit-learn + McKinney 2010 Pandas + Harris 2020 NumPy).

## G.1 honesty
- Concept DISTINCT du Lab1 = scikit-learn / introduction au ML (regression lineaire). Pandas deja ancre Lab1.3-Pandas (McKinney 2010), NumPy deja ancre Lab1.2-NumPy (Harris 2020) -> cites en References pour chainage, NON re-ancres (evite duplication).
- repair-not-consecrate (#3660) NON-TRIGGERE : notebook sain (exec_count 1-8, 0 erreur, 0 output vide).

## Validation
- `notebook_tools.py validate` : OK (0 warning, 0 error)
- `scan_cell_ordering.py --severity HIGH` : clean
- C.1 : 0 `raise NotImplementedError`/`assert False`/`1/0`
- C.2/C.3 : 0 churn `execution_count`/`outputs` (markdown-only)
- `COURSE_CATALOG.generated.{json,md}` byte-identiques a origin/main
- 3 exercices presents (convention 3-exos respectee)

See #3164 (audit fidelite repo-wide, contribution partielle a l'Epic).
