### PR TITLE
docs(harness): SOTA-not-workaround rule + bot review criterion §H (See #3801)

### DIFF
--- a/.claude/rules/pr-review-discipline.md
+++ b/.claude/rules/pr-review-discipline.md
@@ -73,3 +73,13 @@ Toute PR touchant `MyIA.AI.Notebooks/QuantConnect/projects/` **DOIT** inclure :
 1. Backtest run (`create_compile` + `create_backtest` via MCP qc-mcp)
 2. Métriques Sharpe/CAGR/MaxDD reportées dans le body
 3. Période OOS distincte de training (pas de same-period leak)
+
+### H. Notebook : vrai outil SOTA + problème non-trivial
+
+Source : mandat user 2026-06-21, EPIC #3801. Détail + 5 verdicts : [.claude/rules/sota-not-workaround.md](sota-not-workaround.md).
+
+Toute PR notebook (interne/contributeur) **DOIT** être refusée (`CHANGES_REQUESTED`) si :
+1. **Workaround dégradé sans verdict SOTA écrit** : la cellule commit une sortie de substitution (ASCII au lieu d'une image générée, réimplémentation jouet au lieu de la lib, stub au lieu d'un appel de service, sortie fabriquée au lieu d'un backtest) **alors que l'outil réel est installable/invocable/rebranchable**, sans un des 5 verdicts (SOTA-OK / RECOVERABLE-LOCAL / RECOVERABLE-MACHINE / RECOVERABLE-USER-HAND / INTRINSIC) écrit dans le body.
+2. **Problème dégénéré** : le notebook démontre un moteur/solveur/modèle sur un cas trivial où le SOTA équivaut à une baseline (ex: BFS vs A* sur graphe à coût uniforme, cf `8905f8845`) → exiger complexification du problème ou ajout d'un problème plus riche (modulo runtime raisonnable).
+
+`APPROVED` malgré 1 ou 2 = complaisance. **Exception PR étudiante** ([student-pr-reviews.md](student-pr-reviews.md)) : NE PAS appliquer H (review bienveillante).

--- a/.claude/rules/sota-not-workaround.md
+++ b/.claude/rules/sota-not-workaround.md
@@ -1,0 +1,48 @@
+# SOTA : vrai outil + probleme non-trivial — install/invoke/re-plug, faire valoir le moteur (HARD)
+
+S'applique a **tous les agents** (workers po-* + coordinateur ai-01) **ET a tous les reviewers (humains ET bots** clusterManager-Myia : Hermes primaire, NanoClaw audit). Source : mandat user 2026-06-21 (3 messages). Registre = **EPIC #3801**. Consolide et durcit : CLAUDE.md section F (reparer, jamais contourner) + [repair-not-consecrate](../../docs/reference/regles-validation-detail.md) + l'audit a 2 axes (committed <-> achievable).
+
+> [msg1] outil SOTA approprie proprement **installe ou invoque** s'il s'agit d'un service ; sinon, **le brancher avec un coup de main user**, ou **le rebrancher** s'il l'a ete dans le passe, typiquement sur une **machine particuliere avec le bon environnement**.
+> [msg2] tenir un **registre** et **resserrer le harnais ET le comportement de review des bots** (le leur signaler) — pour l'heure le **reflexe reste de chercher des workarounds degrades** plutot qu'installer et corriger ce qu'il faut.
+> [msg3] **qualite des problemes souvent trop basiques** (cf BFS vs A*) — complexifier les pbs actuels ou proposer des pbs additionnels plus complexes pour **faire valoir toutes les capacites des moteurs externes**, la ou des exemples triviaux ne les mettent pas en valeur ; **modulo un temps de traitement raisonnable**.
+
+## Prong A — Vrai outil SOTA, jamais workaround degrade
+
+Un notebook DOIT executer le **vrai outil SOTA dont il parle**. Committer une **sortie de workaround degrade** (ASCII a la place d'une image generee, reimplementation jouet a la place de la lib, stub a la place d'un appel de service, sortie fabriquee a la place d'un backtest) **alors que l'outil reel est installable / invocable / rebranchable** = **regression consacree**, INTERDIT.
+
+Avant de committer une sortie degradee, repondre **par ecrit (body PR)** par 1 des 5 verdicts :
+
+| Verdict | Definition | Action |
+|---------|-----------|--------|
+| **SOTA-OK** | Le vrai outil est proprement installe/invoque ; la sortie committee EST sa vraie sortie | merge |
+| **RECOVERABLE-LOCAL** | Outil installable/invocable sur la machine du worker (regle F) | installer + re-exec, pas de user |
+| **RECOVERABLE-MACHINE** | A marche / marche sur une machine SPECIFIQUE avec le bon env (GenAI->po-2023, GPU->po-2024/ai-01, embeddings->po-2026, Lean->WSL, QC->QC-Cloud) | router vers cette machine + re-exec |
+| **RECOVERABLE-USER-HAND** | Action user one-time (token, OAuth, creds paper-trading, acces modele gate, hardware) | signaler **EXPLICITEMENT dans vscode** ([user-blocker-signaling](user-blocker-signaling.md)), puis re-exec |
+| **INTRINSIC** | Aucun chemin SOTA reel (service externe mort, vraiment intractable) | documenter **HONNETEMENT** le plafond atteignable — explicite, jamais maquille en resultat SOTA |
+
+Le defaut paresseux (« ASCII art / reimplementation jouet / 'Java absent' / 'kernel not available locally' ») committe **sans avoir verifie RECOVERABLE-*** = manquement grave.
+
+## Prong B — Probleme non-trivial qui met le moteur en valeur
+
+Un notebook qui demontre un **moteur / solveur / modele** (search, CSP, SMT/Z3, planners, metaheuristiques, tactiques Lean, ML, GenAI) DOIT poser un probleme assez riche pour **exercer et faire valoir la capacite distinctive du moteur** — pas un **cas degenere** ou le moteur SOTA equivaut a une baseline triviale.
+
+Cas canonique : **BFS vs A*** sur un graphe a cout uniforme (A* degenere en BFS, l'heuristique ne sert a rien) -> remplacer par un terrain **pondere** ou l'heuristique discrimine (commit `8905f8845`, planners-3). Memes pieges : un Z3 sur une contrainte qu'un `if` resout, un planner sur un plan lineaire sans parallelisme, un metaheuristique sur une fonction convexe a optimum unique.
+
+Action : **complexifier le probleme existant** OU **ajouter un probleme additionnel plus riche**, de sorte que la capacite annoncee soit **visible dans la sortie**. **Modulo un temps de traitement raisonnable** : viser un probleme **discriminant mais borne**, pas un benchmark de plusieurs minutes dans un notebook pedagogique.
+
+## Comportement des bots reviewers (signaler + enforce)
+
+Les bots **DOIVENT** poster `CHANGES_REQUESTED` quand une PR notebook (interne/contributeur) :
+- (A) commit une sortie degradee **sans verdict SOTA ecrit**, ou avec un **RECOVERABLE-* non tente** ; ou
+- (B) demontre un moteur sur un **cas degenere** qui ne met pas sa capacite en valeur.
+
+`APPROVED` dessus = complaisance. Cf [pr-review-discipline.md](pr-review-discipline.md) §H.
+
+**Exception PR etudiante** (cf [student-pr-reviews.md](student-pr-reviews.md)) : NE PAS appliquer A/B — review bienveillante, pas de CHANGES_REQUESTED sur scaffolding.
+
+## Voir aussi
+- CLAUDE.md section F — env/kernel : reparer, jamais contourner
+- [pr-review-discipline.md](pr-review-discipline.md) §H — critere bots SOTA + non-trivialite
+- [anti-regression.md](anti-regression.md) — ne pas stripper le code reel
+- [three-exercises-per-notebook.md](three-exercises-per-notebook.md) — richesse pedagogique (exercices)
+- **EPIC #3801** — registre axe-2 SOTA + problem-richness, par famille (GenAI/po-2023 en tete)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Guidance pour Claude Code travaillant avec le repository CoursIA.
 - [.claude/rules/catalog-pr-hygiene.md](.claude/rules/catalog-pr-hygiene.md) - Catalogue = propriété de l'automatisation (cron main + CI par-PR + guard CI `catalog-guard.yml`), JAMAIS régén sur branche + rebase frais + atomique + `Closes #X` (mandat user 2026-06-06, #2632)
 - [.claude/rules/model-delegation.md](.claude/rules/model-delegation.md) - **Tout `Agent()` DOIT avoir un `model` explicite** (`sonnet`/`haiku` par défaut, `opus` uniquement sur justification écrite) — mandat user 2026-06-09. Déléguer le read-heavy borné vérifiable, garder la décision + cross-check, local-git-only sous fenêtre `gh auth` (consolide mandat 2026-06-07, 7 tests confirmants)
 - [.claude/rules/three-exercises-per-notebook.md](.claude/rules/three-exercises-per-notebook.md) - Convention >=3 exercices par notebook, rollout progressif (#2161)
+- [.claude/rules/sota-not-workaround.md](.claude/rules/sota-not-workaround.md) - Vrai outil SOTA jamais workaround degrade (install/invoke/re-plug machine-env-user, 5 verdicts) + probleme non-trivial qui met le moteur en valeur (BFS vs A*) ; enforce bots §H ; registre EPIC #3801 (mandat user 2026-06-21)
 
 ---
 


### PR DESCRIPTION
Resserre le harnais et le comportement des bots reviewers suite au mandat user 2026-06-21 (3 messages) : le reflexe reste de chercher des workarounds degrades plutot qu'installer/corriger les vrais outils SOTA.

## Changes (3 fichiers, +59, 1 domaine)
- **`.claude/rules/sota-not-workaround.md`** (nouveau) — regle HARD 2 prongs :
  - **Prong A** : vrai outil SOTA, jamais workaround degrade recuperable ; 5 verdicts (SOTA-OK / RECOVERABLE-LOCAL / RECOVERABLE-MACHINE / RECOVERABLE-USER-HAND / INTRINSIC) ecrits dans le body PR.
  - **Prong B** : probleme non-trivial qui met le moteur en valeur (cas canonique BFS vs A* `8905f8845`), modulo runtime raisonnable.
- **`.claude/rules/pr-review-discipline.md`** — §H : critere CHANGES_REQUESTED pour les bots (Hermes/NanoClaw) sur workaround sans verdict OU probleme degenere ; exception PR etudiante.
- **`CLAUDE.md`** — pointeur succinct vers la rule (harness-hygiene 3 tiers).

## Registre
EPIC #3801 (axis-2 SOTA ledger, per-notebook, GenAI/po-2023 en tete de file).

Docs-only, additif. See #3801.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>