### PR TITLE
docs(qc-mltraining): add Conclusion / Prochaines étapes to ML-Training-Pipeline README (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -449,3 +449,27 @@ Results: `scripts/results/{l1_tsmom,l2_dual_momentum,l3_trend_long_horizon,l4_de
 - **Hyperparams**: All args saved verbatim
 - **Training history**: Loss curves per epoch
 - **Seeds**: Synthetic data uses seed=42; for production, set `PYTHONHASHSEED` and `torch.manual_seed()`
+
+---
+
+## Conclusion / Prochaines étapes
+
+### Ce que ce pipeline démontre
+
+Ce pipeline matérialise **l'empirisme honnête appliqué au ML financier** : plutôt que de revendiquer un edge sur un backtest unique, il teste systématiquement des familles de modèles (HAR-RV, LSTM, Transformer, DQN, Decision Transformer, GNN, HMM regime) sous une méthodologie stricte et publie les verdicts — y compris les échecs. L'arc pédagogique :
+
+- **La rigueur méthodologique d'abord** : walk-forward 5-fold expanding, 4-seed block bootstrap, OOS strict (2027 holdout jamais tuné), coûts de transaction réalistes (10bps rebalance + 50bps stress), univers anti-FAANG/Mag7 pour éviter le beta-loading déguisé. Ces choix sont **la condition de validité** de tout verdict — sans eux, un Sharpe spectaculaire n'est qu'un artefact.
+- **Les leçons transversales** : (1) **action-based >> forecast-based** — le Decision Transformer (classifie buy/hold/sell) surpasse massivement PatchTST (prédit la magnitude), car la couche de traduction forecast→position détruit le signal via coûts et discrétisation ; (2) **trend overlays systématiquement destructeurs** sur cet univers/période (L1/L2/L3 tous NO BEATS, le filtre TSMOM 12-1 isolé comme cause du déficit L5) ; (3) **vol-targeting = outil de risque, pas d'alpha** (atteint sa cible de vol 10.3% vs 16.6%, réduit le MaxDD, à coût Sharpe ~nul).
+- **Les 4 KEEPERS validés** (Curriculum V2) : M12 HAR-RV-J, M15 LSTM-RV, S3 HMM Regime (+0.669), S4 Inverse-vol Ridge+HMM (+0.325). Reco portfolio S3+S4 monthly = Sharpe ~1.12. Ce sont les seuls candidats ayant survécu au protocole complet.
+- **La transparence sur les échecs** : le Ladder #1409 documente publiquement que 5/6 ladder levels sont NO BEATS. C'est aussi important pédagogiquement que les keepers — **la plupart des idées ML ne battent pas le buy-and-hold**, et le savoir vaut mieux que l'illusion.
+
+### Prochaines étapes
+
+1. **Reproduire les KEEPERS** : cloner le repo, installer les dépendances (`Dependencies` ci-dessus), lancer `python scripts/dry_run_validation.py` pour valider le pipeline CPU, puis entraîner S3/S4 sur données réelles (`python scripts/s3_hmm_regime.py`).
+2. **Étendre le L4 Decision Transformer** : le seul ladder level BEATS (24/26 seeds) — le passer en multi-seed étendu (BG run ai-01) puis migration QC Cloud pour validation hors-échantillon.
+3. **Migration QC Cloud** : les keepers sont des modèles research standalone (type (c), données yfinance) ; l'étape suivante est l'intégration dans des `QCAlgorithm` déployables (cf. `../projects/` et la série QC-Py).
+4. **Surveiller la thermal safety** : tout training GPU doit passer par `shared/gpu_training.py` (MAX_TEMP=80C, AMP) — le repo RTX 3090/4090 a déjà subi des throttling thermiques.
+5. **Consulter le REGISTRY** : [`REGISTRY.md`](REGISTRY.md) catalogue les 70+ checkpoints par stage (-1/0/1/2) avec verdict BEATS/FAIL/MIXED et l'audit Anti-Bias.
+6. **Lire la méta-analyse** : [`docs/Curriculum_V2_Meta_Analysis.md`](docs/Curriculum_V2_Meta_Analysis.md) pour la synthèse cross-iteration (parcimonie vs expressivité, vol vs direction).
+
+> **Rappel honnête** : ce pipeline est un **standalone research** (type (c), données yfinance locales). Les verdicts (KEEPERS, NO BEATS) sont valables sur l'univers et la période testés. Un edge en research standalone n'est pas un edge en production — la migration QC Cloud avec vraies données, frais réels et slippage est l'étape de validation obligatoire avant tout déploiement.


### PR DESCRIPTION
## Summary

Follow-up to **#3795** (main QC README) and **#3798** (QC Python subseries), both MERGED. Part of the **#2651 README harmonization** (ai-01 directive 2026-06-19). The **ML-Training-Pipeline README** (451 lines, the largest QC subseries) was also missing a Conclusion section.

## Changes (markdown-additive)

**+24 lines, 0 deletion** — pure addition.

- **\"Ce que ce pipeline démontre\"**: recaps the empiricism-first methodology (walk-forward 5-fold, 4-seed bootstrap, OOS strict, anti-FAANG universe, tx costs), the 3 transversal lessons (action-based >> forecast-based; trend overlays destructive; vol-targeting = risk tool not alpha), the 4 Curriculum V2 KEEPERS (M12/M15/S3/S4), and the honest transparency about failures (Ladder #1409: 5/6 NO BEATS).
- **\"Prochaines étapes\"**: 6 concrete next steps (reproduce keepers, extend L4 DT, QC Cloud migration, thermal safety, REGISTRY, meta-analysis).
- **Honest reminder** that research-standalone verdicts are not production edges.

## Placement

After \"Reproducibility\", at the end of the README (no version footer in this subseries).

## Validation

| Check | Result |
|-------|--------|
| Pure markdown addition, no structural change | ✓ |
| Course catalogue byte-identical to `origin/main` | ✓ (no CATALOG-STATUS marker in this subseries README) |
| No notebook touched | ✓ |

## Scope (atomic)

Single README, markdown-additive. Closes the #2651 Conclusion gap for the QC ML-Training-Pipeline subseries. Companions: #3795 (main QC), #3798 (QC Python).

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)