### PR TITLE
fix(mgs5): update DLL load paths net8.0 -> net9.0 (#1203)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
@@ -26,7 +26,7 @@
     "2. **La reconstruction depuis les primitives** — le code réel de la lib qui assemble l'algorithme à partir de briques (`IfElse`, `Match`, `GenerationMetaHeuristic`, croisements géométriques...). Ce n'est pas une paraphrase : c'est le corps de la méthode `BuildMainHeuristic()` de la classe, lu transparentement.\n",
     "3. **Le raccourci factory** — le one-liner `MetaHeuristicsService.CreateMetaHeuristicByName(\"...\")` qui produit *exactement* cette reconstruction, et la preuve (le type racine renvoyé) que raccourci et reconstruction sont identiques.\n",
     "\n",
-    "> **Rappel C.2** : kernel `.net-csharp`. Les DLLs MetaGeneticSharp + GeneticSharp sont chargées depuis le build du fork, compilé en **net8.0** pour correspondre au kernel (`.NET 8` via dotnet-interactive). Voir la cellule de câblage ci-dessous.\n"
+    "> **Rappel C.2** : kernel `.net-csharp`. Les DLLs MetaGeneticSharp + GeneticSharp sont chargées depuis le build du fork, compilé en **net9.0** pour correspondre au kernel (`.NET 8` via dotnet-interactive). Voir la cellule de câblage ci-dessous.\n"
    ]
   },
   {
@@ -58,7 +58,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-84936.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -103,12 +103,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%15:2048/\",\"http://172.22.32.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:48c9:a891:738c:8d58:2048/\",\"http://2a01:e0a:9d4:f320:5941:d2ce:13a1:5915:2048/\",\"http://2a01:e0a:9d4:f320:7414:3eb8:9056:d1c2:2048/\",\"http://2a01:e0a:9d4:f320:e853:e403:d8e1:4c71:2048/\",\"http://2a01:e0a:9d4:f320:f13b:ae96:c480:2aa1:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%18:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::7008:836f:2d9b:5a7e%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '84936.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '1491072.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -172,7 +172,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MetaGeneticSharp + GeneticSharp chargés (build net8.0 du fork).\r\n"
+      "MetaGeneticSharp + GeneticSharp chargés (build net9.0 du fork).\r\n"
      ]
     },
     {
@@ -205,15 +205,15 @@
     }
    ],
    "source": [
-    "// Câblage : chargement des DLLs MetaGeneticSharp + GeneticSharp (build net8.0 du fork).\n",
+    "// Câblage : chargement des DLLs MetaGeneticSharp + GeneticSharp (build net9.0 du fork).\n",
     "// Prérequis de build (depuis la racine du fork) :\n",
     "//   dotnet build src/MetaGeneticSharp.Domain/MetaGeneticSharp.Domain.csproj -c Debug\n",
-    "// (net8.0 pour matcher le kernel .NET 8 ; les DLLs core + dépendances System.Drawing\n",
-    "//  sont co-localisées dans Domain/bin/Debug/net8.0/.)\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/GeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net8.0/MetaGeneticSharp.Domain.dll\"\n",
+    "// (net9.0 pour matcher le target net9.0 du csproj ; les DLLs core + dépendances System.Drawing\n",
+    "//  sont co-localisées dans Domain/bin/Debug/net9.0/.)\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
     "\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
@@ -221,7 +221,7 @@
     "using System.Collections.Generic;\n",
     "using System.Linq;\n",
     "\n",
-    "Console.WriteLine(\"MetaGeneticSharp + GeneticSharp chargés (build net8.0 du fork).\");\n",
+    "Console.WriteLine(\"MetaGeneticSharp + GeneticSharp chargés (build net9.0 du fork).\");\n",
     "Console.WriteLine(\"  MetaHeuristicsService : \" + typeof(MetaHeuristicsService).Name);\n",
     "Console.WriteLine(\"  WhaleOptimisationAlgorithm : \" + typeof(WhaleOptimisationAlgorithm).Name);\n",
     "Console.WriteLine(\"  EquilibriumOptimizer : \" + typeof(EquilibriumOptimizer).Name);\n",
@@ -700,7 +700,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WOA sur Sphere (5D, 80 gen) -> fitness = -9,3504E-11  (proche de 0 = bon)\r\n"
+      "WOA sur Sphere (5D, 80 gen) -> fitness = -2,3658E-10  (proche de 0 = bon)\r\n"
      ]
     }
    ],
@@ -804,7 +804,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "EO sur Sphere -> fitness = -9,9935E-25\r\n"
+      "EO sur Sphere -> fitness = -2,222E-25\r\n"
      ]
     },
     {
@@ -915,7 +915,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FBI sur Sphere -> fitness = -3,6435E-24\r\n"
+      "FBI sur Sphere -> fitness = -3,3816E-24\r\n"
      ]
     },
     {
@@ -1023,14 +1023,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Islands5Default sur Sphere -> fitness = -0,0027288\r\n"
+      "Islands5Default sur Sphere -> fitness = -0,0048562\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Islands5BestMixture sur Sphere -> fitness = -7,1799E-18\r\n"
+      "Islands5BestMixture sur Sphere -> fitness = -2,1498E-17\r\n"
      ]
     },
     {
@@ -1119,21 +1119,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sphere            -0,0020154     -2,0808E-09     -9,8071E-27     -2,6487E-25     -1,7594E-18\r\n"
+      "Sphere            -0,0088716     -7,6366E-13     -4,6894E-28     -3,4317E-25     -8,9913E-16\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rastrigin            -1,4704         -8,4962              -0              -0      -2,368E-07\r\n"
+      "Rastrigin           -0,75004          -7,981              -0              -0     -9,8275E-11\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rosenbrock           -7,0758         -12,029         -3,4303         -3,7274         -3,6707\r\n"
+      "Rosenbrock           -57,953         -4,8681         -3,2756         -3,5385         -3,4638\r\n"
      ]
     },
     {


### PR DESCRIPTION
## Summary

Mission ai-01 (21/06 dispatch): "MGS #1203 (submodule bump + verify NB5)". The submodule bump is already on main (gitlink `f7ec022` = fork origin/main, includes GIF encoder PRs #28/#29/#30). **The actionable part = verify NB5 (MGS-5-CompoundMetaheuristics).**

## Root cause found (verify NB5)

The MGS Domain csproj now targets **net9.0** (bumped from net8.0), so `dotnet build` produces DLLs in `bin/Debug/net9.0/`. But MGS-5 still referenced the stale `net8.0/` paths in its `#r` directives → **FileNotFound** at cell1 load time. The notebook could not execute as-committed.

## Fix

Updated the 10 `net8.0` references → `net9.0`:
- cell1: 4 `#r "...net8.0/*.dll"` directives + 3 code comments
- cell0: 1 markdown note ("build du fork")
- cell1 Console.WriteLine confirmation message + comment about kernel (corrected stale ".NET 8 kernel" → "net9.0 matches csproj target"; kernel is `.net-csharp` / .NET 10 runtime).

## Validation (rule H.1/H.4 — real execution)

```
papermill MGS-5-CompoundMetaheuristics.ipynb <out> -k .net-csharp
Executing: 100%|██████████| 26/26 [00:09<00:00, 2.86cell/s]
```
- **26/26 cells executed, 0 errors**
- 11/11 code cells with `execution_count` + outputs (rule C.2 ✓)
- cell1 output: "Catalogue KnownCompoundMetaheuristics (11 entrées)" — DLLs load, code runs
- Outputs transplanted fresh into the committed notebook

Rule F satisfied: .NET Interactive kernel 1.0.707101 + .NET 10.0.109 installed locally; MGS Domain built fresh (0 errors).

## Checklist

- [x] Root cause diagnosed (net8.0 path vs net9.0 csproj target)
- [x] Real papermill execution: 26/26 cells, 0 errors
- [x] Outputs transplanted (rule C.2), exec_count coherent
- [x] 0 `raise NotImplementedError` / voluntary errors (rule C.1)
- [x] Catalog + submodule byte-identical (catalog-pr-hygiene HARD 1-3)
- [x] Fresh branch from origin/main (`0ba6ba60`)
- [x] 0 PR open touching MGS-5 (0 collision)

## Note: same issue on MGS-1/2/3

The `net8.0` path bug affects **MGS-1, MGS-2, MGS-3** as well (4 refs each). Tracked for follow-up — not bundled here to keep this PR atomic (one notebook verified end-to-end).

See #1203