### PR TITLE
fix(validate-pr-notebooks): unify H.3 gate with qc_reference metadata

### DIFF
--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -18,11 +18,14 @@ from validate_pr_notebooks import get_kernel_name, validate_notebook
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _write_nb(path: Path, cells: list[dict], kernelspec: dict | None = None) -> Path:
+def _write_nb(path: Path, cells: list[dict], kernelspec: dict | None = None,
+              extra_metadata: dict | None = None) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     metadata = {}
     if kernelspec:
         metadata["kernelspec"] = kernelspec
+    if extra_metadata:
+        metadata.update(extra_metadata)
     nb = {"cells": cells, "metadata": metadata, "nbformat": 4, "nbformat_minor": 5}
     path.write_text(json.dumps(nb), encoding="utf-8")
     return path
@@ -139,6 +142,29 @@ class TestValidateNotebookH3:
         ])
         result = validate_notebook(nb)
         assert result["passed"] is True
+
+    def test_skip_exec_for_qc_reference_metadata(self, tmp_path):
+        """A notebook flagged metadata.qc_reference=True skips H.3 even outside
+        QC_CLOUD_PATHS (content-aware unification with regression_scan.py:261,
+        #3776). E.g. partner-course reference templates."""
+        # Path deliberately OUTSIDE QuantConnect/Python|projects
+        ref_path = tmp_path / "partner-course" / "examples" / "research.ipynb"
+        nb = _write_nb(ref_path, [
+            _code("qb = QuantBook()", exec_count=None),
+        ], extra_metadata={"qc_reference": True})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+
+    def test_no_skip_exec_without_qc_reference_metadata(self, tmp_path):
+        """Without the qc_reference flag, a non-QC-path notebook with null
+        execution_count must still FAIL H.3 (content-aware check is opt-in)."""
+        ref_path = tmp_path / "partner-course" / "examples" / "research.ipynb"
+        nb = _write_nb(ref_path, [
+            _code("print('hi')", exec_count=None),
+        ])  # no qc_reference flag
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("execution_count is null" in e for e in result["errors"])
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -105,6 +105,15 @@ def validate_notebook(nb_path: Path) -> dict:
     skip_exec = any(k in kernel for k in SKIP_EXEC_KERNELS)
     normalized = rel_path.replace("\\", "/")
     skip_exec = skip_exec or any(p in normalized for p in QC_CLOUD_PATHS)
+    # Content-aware unification (#3776): a notebook explicitly flagged as a
+    # QC Cloud reference/template (metadata.qc_reference=True) is exempt from
+    # the H.3 execution_count gate for the same reason QC_CLOUD_PATHS is — it
+    # can only be executed via QC Cloud. This unifies the gate with
+    # regression_scan.py:261, which is already content-aware. Without this,
+    # the H.3 gate exempts by PATH but not by content, so a flagged reference
+    # notebook outside QuantConnect/Python|projects (e.g. partner-course
+    # examples) fails H.3 even though it is honestly non-executable-by-design.
+    skip_exec = skip_exec or data.get("metadata", {}).get("qc_reference") is True
 
     for i, cell in enumerate(data.get("cells", [])):
         if cell.get("cell_type") != "code":


### PR DESCRIPTION
## Summary

Resolves the **H.3 CI FAILURE** blocking **PR #3776** merge (ai-01 decision 2026-06-20T23:09Z, PART 1/2 dashboard).

### Problem
The H.3 execution_count gate (`validate_pr_notebooks.py`) exempted QC-Cloud-only notebooks **by PATH** (`QC_CLOUD_PATHS = QuantConnect/Python`, `QuantConnect/projects`) but **NOT by content**. Meanwhile `regression_scan.py:261` is already content-aware (`skip_structural` on `metadata.qc_reference=True`).

Result: a notebook flagged as a QC Cloud reference/template **OUTSIDE** those paths — e.g. `partner-course-quant-trading/examples/Crypto-MultiCanal/research.ipynb` (PR #3776) — **failed H.3** even though it is honestly non-executable-by-design (QuantBook runtime required, banner `> **[REFERENCE QC Cloud]**`).

This is an **incoherence of tooling, not a real regression** (ai-01 verdict).

### Fix
Unify the gate by adding the content-aware clause — so the two C.2/H.3 checkers can never diverge by path-vs-content:

\`\`\`python
skip_exec = skip_exec or data.get("metadata", {}).get("qc_reference") is True
\`\`\`

Placed right after the existing path-based skip, with an explanatory comment citing `regression_scan.py:261`.

## Validation

### Tests (+2 cases, 36/36 pass)
- `test_skip_exec_for_qc_reference_metadata`: flagged notebook outside `QC_CLOUD_PATHS` → passes (content-aware opt-in works)
- `test_no_skip_exec_without_qc_reference_metadata`: same notebook WITHOUT the flag → still fails H.3 (opt-in, not a blanket exemption)
- `_write_nb` helper extended with `extra_metadata` param

### Real notebook check (G.1)
Called `validate_notebook()` directly on the actual `research.ipynb` from PR #3776 branch (24 code cells, 0 outputs, 9+ null execution_count, `metadata.qc_reference=True`):
```
passed: True
total_code: 24
errors: []
```
Before this fix → FAIL on 9+ null execution_counts.

## Scope (atomic)

- `scripts/notebook_tools/validate_pr_notebooks.py`: +9 lines (1 clause + comment)
- `scripts/notebook_tools/tests/test_validate_pr_notebooks.py`: +27/-1 (2 tests + helper)
- 2 files, +36/-1, no notebook touched, no catalogue touched

## Why not Option (1) execute via QC-Cloud

ai-01 offered two paths. I took Option (2) — the gate-unification patch — because:
1. `research.ipynb` is a **by-design reference template** (24 cells, banner `[REFERENCE QC Cloud]`), not a research deliverable awaiting outputs. Executing it on QC Cloud and committing 24 cells of QuantBook outputs would make a **template** look like a **finished run** — misleading pedagogically.
2. The root cause was the **tooling incoherence** (path-vs-content), not a missing execution. Unifying the gate fixes it **durablement** for any future `qc_reference`-flagged notebook outside `QC_CLOUD_PATHS`, not just this one.

See #3776 (content: flag + allowlist) + #3777 (MERGED: scanner `--git-tracked-only`). This PR closes the tooling triangle.

## Checklist
- [x] Scope: 2 files, +36/-1, atomic
- [x] Tests: 36/36 pass, +2 new
- [x] G.1 real-notebook verification (not just synthetic)
- [x] No notebook/catalogue touched
- [x] Comment cites the sister check (`regression_scan.py:261`)

See #3776