### PR TITLE
fix(sudoku-4): repair SA energy bug + degenerate instance (Prong B #3164/#3801)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -349,12 +349,13 @@
     "    # TODO: Compter les conflits (doublons) uniquement dans les\n",
     "    # lignes/colonnes/blocs qui contiennent des valeurs non nulles\n",
     "    result = 0  # TODO etudiant\n",
-    "    return result\n"
+    "    return result\n",
+    "print(\"Exercice a completer\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "69b53f0e",
    "metadata": {
     "execution": {
@@ -378,7 +379,7 @@
      "output_type": "stream",
      "text": [
       "Fonction compute_energy definie.\n",
-      "Energie de la grille de test: -72\n"
+      "Energie de la grille de test: 0\n"
      ]
     }
    ],
@@ -391,14 +392,14 @@
     "    for col in range(9):\n",
     "        values = grid[:, col]\n",
     "        counts = np.bincount(values[values > 0], minlength=10)\n",
-    "        energy += np.sum(counts[1:] - 1)  # -1 car la valeur presente compte 1\n",
+    "        energy += int(np.sum(np.maximum(counts[1:] - 1, 0)))  # doublons uniquement (clamp: valeur absente = 0)\n",
     "    \n",
     "    # Doublons dans les blocs 3x3\n",
     "    for box_row in range(3):\n",
     "        for box_col in range(3):\n",
     "            block = grid[box_row*3:(box_row+1)*3, box_col*3:(box_col+1)*3].flatten()\n",
     "            counts = np.bincount(block[block > 0], minlength=10)\n",
-    "            energy += np.sum(counts[1:] - 1)\n",
+    "            energy += int(np.sum(np.maximum(counts[1:] - 1, 0)))  # doublons uniquement (clamp: valeur absente = 0)\n",
     "    \n",
     "    return energy\n",
     "\n",
@@ -419,18 +420,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : Fonction d'energie\n",
-    "\n",
-    "| Aspect | Valeur | Signification |\n",
-    "|--------|--------|---------------|\n",
-    "| Energie = 0 | Solution valide | Aucun doublon colonnes/blocs |\n",
-    "| Energie > 0 | Grille invalide | Nombre total de violations |\n",
-    "\n",
-    "L'objectif est de reduire l'energie a 0 par echanges successifs.\n",
-    "\n",
-    "> **Note de fidelite (fonction d'energie defectueuse, cf. issue #3377)** : la fonction `compute_energy` committee somme `counts[1:] - 1` sur **toutes** les valeurs 1-9, y compris celles absentes (count=0 contribue -1). Sur une grille **complete** -- l'invariant maintenu par `initialize_grid` (permutation par ligne) et le voisinage intra-ligne -- chaque doublon (+1) est exactement compense par une valeur manquante (-1). L'energie vaut donc **0 pour n'importe quelle grille complete, valide ou non** (verifie numeriquement). Les sorties committees `energie = 0` / `Solution valide: True` n'etablissent par consequent pas une solution correcte. Le correctif (`np.maximum(counts[1:] - 1, 0)`) et la re-execution complete sont suivis dans l'issue #3377."
-   ]
+   "source": "### Interpretation : Fonction d'energie\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| Energie = 0 | Solution valide | Aucun doublon colonnes/blocs |\n| Energie > 0 | Grille invalide | Nombre total de violations |\n\nL'objectif est de reduire l'energie a 0 par echanges successifs.\n\n> **Fonction d'energie** : on compte, pour chaque colonne et chaque bloc 3x3, le nombre de doublons (`counts[v] - 1` pour les valeurs presentes, `0` pour les valeurs absentes via `np.maximum(..., 0)`). Les lignes sont valides par construction (permutations de 1-9), donc seules les colonnes et les blocs peuvent porter des violations. L'energie de la grille de test (partiellement remplie) vaut **0** ci-dessus car les cellules fixees par le puzzle ne creent pas encore de conflit ; en revanche, une fois la grille completee par permutations (cellule suivante), l'energie devient positive et le recuit doit la minimiser."
   },
   {
    "cell_type": "markdown",
@@ -453,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "d8c4e44c",
    "metadata": {
     "execution": {
@@ -489,7 +479,7 @@
       "7 1 5 | 2 9 8 | 3 6 4 \n",
       "2 8 6 | 3 4 1 | 9 5 7 \n",
       "\n",
-      "Energie initiale: 0\n",
+      "Energie initiale: 29\n",
       "Objectif: energie = 0\n"
      ]
     }
@@ -541,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -558,7 +548,8 @@
     "    # TODO: Echangez deux valeurs non fixees dans un meme bloc 3x3\n",
     "    # Retournez (nouvelle_grille, position_echangee)\n",
     "    result = None  # TODO etudiant\n",
-    "    return result\n"
+    "    return result\n",
+    "print(\"Exercice a completer\")\n"
    ]
   },
   {
@@ -582,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "2bcc4c92",
    "metadata": {
     "execution": {
@@ -606,7 +597,7 @@
      "output_type": "stream",
      "text": [
       "Echange effectue : ligne 2, colonnes 4 <-> 8\n",
-      "Energie avant : 0, Energie apres : 0, Delta : 0\n"
+      "Energie avant : 29, Energie apres : 30, Delta : 1\n"
      ]
     }
    ],
@@ -668,7 +659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "adc546ec",
    "metadata": {
     "execution": {
@@ -759,7 +750,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "75893419",
    "metadata": {
     "execution": {
@@ -784,7 +775,7 @@
      "text": [
       " Temperature        Energy    Accept   Improve     Elapsed   Remaining\n",
       "\r",
-      "     1.00000          0.00                         0:00:00            \r"
+      "     1.00000         29.00                         0:00:00            \r"
      ]
     },
     {
@@ -812,7 +803,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.93325          0.00   100.00%     0.00%     0:00:00     0:00:14\r",
+      "     0.93325          7.00    23.60%     9.20%     0:00:00     0:00:12\r",
       "\r"
      ]
     },
@@ -821,7 +812,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.87096          0.00   100.00%     0.00%     0:00:00     0:00:13\r",
+      "     0.87096         13.00     9.60%     4.00%     0:00:00     0:00:12\r",
       "\r"
      ]
     },
@@ -830,7 +821,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.81283          0.00   100.00%     0.00%     0:00:00     0:00:12\r",
+      "     0.81283          9.00     8.20%     3.60%     0:00:00     0:00:11\r",
       "\r"
      ]
     },
@@ -839,16 +830,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.75858          0.00   100.00%     0.00%     0:00:00     0:00:12\r",
-      "\r"
+      "     0.75858          7.00     8.40%     2.40%     0:00:00     0:00:11\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "     0.70795          0.00   100.00%     0.00%     0:00:01     0:00:12\r",
       "\r"
      ]
     },
@@ -857,7 +845,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.66069          0.00   100.00%     0.00%     0:00:01     0:00:12\r",
+      "     0.70795          4.00    12.60%     5.20%     0:00:01     0:00:11\r",
       "\r"
      ]
     },
@@ -866,7 +854,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.61660          0.00   100.00%     0.00%     0:00:01     0:00:11\r",
+      "     0.66069          2.00     6.40%     2.60%     0:00:01     0:00:10\r",
       "\r"
      ]
     },
@@ -875,7 +863,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.57544          0.00   100.00%     0.00%     0:00:01     0:00:11\r",
+      "     0.61660          0.00     4.60%     2.00%     0:00:01     0:00:10\r",
       "\r"
      ]
     },
@@ -884,16 +872,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.53703          0.00   100.00%     0.00%     0:00:01     0:00:11\r",
-      "\r"
+      "     0.57544          2.00     1.80%     0.80%     0:00:01     0:00:10\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "     0.50119          0.00   100.00%     0.00%     0:00:01     0:00:11\r",
       "\r"
      ]
     },
@@ -902,7 +887,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.46774          0.00   100.00%     0.00%     0:00:01     0:00:11\r",
+      "     0.53703          0.00     1.00%     0.60%     0:00:01     0:00:10\r",
       "\r"
      ]
     },
@@ -911,7 +896,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.43652          0.00   100.00%     0.00%     0:00:01     0:00:11\r",
+      "     0.50119          0.00     0.80%     0.40%     0:00:01     0:00:10\r",
       "\r"
      ]
     },
@@ -920,7 +905,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.40738          0.00   100.00%     0.00%     0:00:02     0:00:11\r",
+      "     0.46774          4.00     1.20%     0.40%     0:00:01     0:00:10\r",
       "\r"
      ]
     },
@@ -929,13 +914,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.38019          0.00   100.00%     0.00%     0:00:02     0:00:11\r"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "     0.43652          0.00     0.40%     0.40%     0:00:01     0:00:10\r",
       "\r"
      ]
     },
@@ -944,16 +923,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.35481          0.00   100.00%     0.00%     0:00:02     0:00:12\r",
-      "\r"
+      "     0.40738          0.00     0.80%     0.40%     0:00:01     0:00:10\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "     0.33113          0.00   100.00%     0.00%     0:00:02     0:00:11\r",
       "\r"
      ]
     },
@@ -962,7 +938,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.30903          0.00   100.00%     0.00%     0:00:02     0:00:12\r",
+      "     0.38019          0.00     0.00%     0.00%     0:00:02     0:00:09\r",
       "\r"
      ]
     },
@@ -971,22 +947,22 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.28840          0.00   100.00%     0.00%     0:00:03     0:00:12\r",
-      "\r"
+      "     0.35481          0.00     0.40%     0.20%     0:00:02     0:00:09\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "     0.26915          0.00   100.00%     0.00%     0:00:03     0:00:12\r"
+      "\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "     0.33113          0.00     0.00%     0.00%     0:00:02     0:00:09\r",
       "\r"
      ]
     },
@@ -995,7 +971,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.25119          0.00   100.00%     0.00%     0:00:03     0:00:12\r",
+      "     0.30903          0.00     0.00%     0.00%     0:00:02     0:00:09\r",
       "\r"
      ]
     },
@@ -1004,7 +980,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.23442          0.00   100.00%     0.00%     0:00:03     0:00:12\r",
+      "     0.28840          0.00     0.00%     0.00%     0:00:02     0:00:09\r",
       "\r"
      ]
     },
@@ -1013,7 +989,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.21878          0.00   100.00%     0.00%     0:00:03     0:00:12\r",
+      "     0.26915          0.00     0.00%     0.00%     0:00:02     0:00:09\r",
       "\r"
      ]
     },
@@ -1022,13 +998,16 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.20417          0.00   100.00%     0.00%     0:00:04     0:00:12\r"
+      "     0.25119          0.00     0.00%     0.00%     0:00:02     0:00:09\r",
+      "\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "     0.23442          0.00     0.00%     0.00%     0:00:02     0:00:09\r",
       "\r"
      ]
     },
@@ -1037,13 +1016,16 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.19055          0.00   100.00%     0.00%     0:00:04     0:00:12\r"
+      "     0.21878          0.00     0.00%     0.00%     0:00:02     0:00:09\r",
+      "\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "     0.20417          0.00     0.00%     0.00%     0:00:03     0:00:09\r",
       "\r"
      ]
     },
@@ -1052,7 +1034,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.17783          0.00   100.00%     0.00%     0:00:04     0:00:12\r",
+      "     0.19055          0.00     0.00%     0.00%     0:00:03     0:00:08\r",
       "\r"
      ]
     },
@@ -1061,7 +1043,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.16596          0.00   100.00%     0.00%     0:00:04     0:00:12\r",
+      "     0.17783          0.00     0.00%     0.00%     0:00:03     0:00:08\r",
       "\r"
      ]
     },
@@ -1070,13 +1052,16 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.15488          0.00   100.00%     0.00%     0:00:04     0:00:12\r"
+      "     0.16596          0.00     0.00%     0.00%     0:00:03     0:00:08\r",
+      "\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "     0.15488          0.00     0.00%     0.00%     0:00:03     0:00:08\r",
       "\r"
      ]
     },
@@ -1085,13 +1070,16 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.14454          0.00   100.00%     0.00%     0:00:05     0:00:12\r"
+      "     0.14454          0.00     0.00%     0.00%     0:00:03     0:00:08\r",
+      "\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "     0.13490          0.00     0.00%     0.00%     0:00:03     0:00:08\r",
       "\r"
      ]
     },
@@ -1100,7 +1088,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.13490          0.00   100.00%     0.00%     0:00:05     0:00:12\r",
+      "     0.12589          0.00     0.00%     0.00%     0:00:03     0:00:08\r",
       "\r"
      ]
     },
@@ -1109,7 +1097,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.12589          0.00   100.00%     0.00%     0:00:05     0:00:12\r",
+      "     0.11749          0.00     0.00%     0.00%     0:00:03     0:00:08\r",
       "\r"
      ]
     },
@@ -1118,7 +1106,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.11749          0.00   100.00%     0.00%     0:00:05     0:00:12\r",
+      "     0.10965          0.00     0.00%     0.00%     0:00:04     0:00:08\r",
       "\r"
      ]
     },
@@ -1127,7 +1115,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.10965          0.00   100.00%     0.00%     0:00:05     0:00:11\r",
+      "     0.10233          0.00     0.00%     0.00%     0:00:04     0:00:08\r",
       "\r"
      ]
     },
@@ -1136,7 +1124,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.10233          0.00   100.00%     0.00%     0:00:05     0:00:11\r",
+      "     0.09550          0.00     0.00%     0.00%     0:00:04     0:00:07\r",
       "\r"
      ]
     },
@@ -1145,7 +1133,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.09550          0.00   100.00%     0.00%     0:00:06     0:00:11\r",
+      "     0.08913          0.00     0.00%     0.00%     0:00:04     0:00:07\r",
       "\r"
      ]
     },
@@ -1154,7 +1142,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.08913          0.00   100.00%     0.00%     0:00:06     0:00:11\r",
+      "     0.08318          0.00     0.00%     0.00%     0:00:04     0:00:07\r",
       "\r"
      ]
     },
@@ -1163,13 +1151,16 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.08318          0.00   100.00%     0.00%     0:00:06     0:00:11\r"
+      "     0.07762          0.00     0.00%     0.00%     0:00:04     0:00:07\r",
+      "\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "     0.07244          0.00     0.00%     0.00%     0:00:04     0:00:07\r",
       "\r"
      ]
     },
@@ -1178,7 +1169,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.07762          0.00   100.00%     0.00%     0:00:06     0:00:11\r",
+      "     0.06761          0.00     0.00%     0.00%     0:00:04     0:00:07\r",
       "\r"
      ]
     },
@@ -1187,7 +1178,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.07244          0.00   100.00%     0.00%     0:00:07     0:00:11\r"
+      "     0.06310          0.00     0.00%     0.00%     0:00:04     0:00:07\r"
      ]
     },
     {
@@ -1202,7 +1193,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.06761          0.00   100.00%     0.00%     0:00:07     0:00:11\r",
+      "     0.05888          0.00     0.00%     0.00%     0:00:05     0:00:07\r",
       "\r"
      ]
     },
@@ -1211,7 +1202,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.06310          0.00   100.00%     0.00%     0:00:07     0:00:10\r",
+      "     0.05495          0.00     0.00%     0.00%     0:00:05     0:00:07\r",
       "\r"
      ]
     },
@@ -1220,7 +1211,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.05888          0.00   100.00%     0.00%     0:00:07     0:00:10\r",
+      "     0.05129          0.00     0.00%     0.00%     0:00:05     0:00:06\r",
       "\r"
      ]
     },
@@ -1229,13 +1220,16 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.05495          0.00   100.00%     0.00%     0:00:07     0:00:10\r"
+      "     0.04786          0.00     0.00%     0.00%     0:00:05     0:00:06\r",
+      "\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "     0.04467          0.00     0.00%     0.00%     0:00:05     0:00:06\r",
       "\r"
      ]
     },
@@ -1244,7 +1238,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.05129          0.00   100.00%     0.00%     0:00:07     0:00:10\r",
+      "     0.04169          0.00     0.00%     0.00%     0:00:05     0:00:06\r",
       "\r"
      ]
     },
@@ -1253,7 +1247,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.04786          0.00   100.00%     0.00%     0:00:08     0:00:10\r",
+      "     0.03890          0.00     0.00%     0.00%     0:00:05     0:00:06\r",
       "\r"
      ]
     },
@@ -1262,7 +1256,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.04467          0.00   100.00%     0.00%     0:00:08     0:00:10\r",
+      "     0.03631          0.00     0.00%     0.00%     0:00:05     0:00:06\r",
       "\r"
      ]
     },
@@ -1271,7 +1265,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.04169          0.00   100.00%     0.00%     0:00:08     0:00:09\r",
+      "     0.03388          0.00     0.00%     0.00%     0:00:06     0:00:06\r",
       "\r"
      ]
     },
@@ -1280,7 +1274,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.03890          0.00   100.00%     0.00%     0:00:08     0:00:09\r",
+      "     0.03162          0.00     0.00%     0.00%     0:00:06     0:00:06\r",
       "\r"
      ]
     },
@@ -1289,7 +1283,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.03631          0.00   100.00%     0.00%     0:00:08     0:00:09\r",
+      "     0.02951          0.00     0.00%     0.00%     0:00:06     0:00:06\r",
       "\r"
      ]
     },
@@ -1298,7 +1292,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.03388          0.00   100.00%     0.00%     0:00:08     0:00:09\r",
+      "     0.02754          0.00     0.00%     0.00%     0:00:06     0:00:05\r",
       "\r"
      ]
     },
@@ -1307,7 +1301,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.03162          0.00   100.00%     0.00%     0:00:09     0:00:09\r",
+      "     0.02570          0.00     0.00%     0.00%     0:00:06     0:00:05\r",
       "\r"
      ]
     },
@@ -1316,7 +1310,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.02951          0.00   100.00%     0.00%     0:00:09     0:00:08\r",
+      "     0.02399          0.00     0.00%     0.00%     0:00:06     0:00:05\r",
       "\r"
      ]
     },
@@ -1325,7 +1319,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.02754          0.00   100.00%     0.00%     0:00:09     0:00:08\r",
+      "     0.02239          0.00     0.00%     0.00%     0:00:06     0:00:05\r",
       "\r"
      ]
     },
@@ -1334,7 +1328,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.02570          0.00   100.00%     0.00%     0:00:09     0:00:08\r",
+      "     0.02089          0.00     0.00%     0.00%     0:00:06     0:00:05\r",
       "\r"
      ]
     },
@@ -1343,13 +1337,16 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.02399          0.00   100.00%     0.00%     0:00:09     0:00:08\r"
+      "     0.01950          0.00     0.00%     0.00%     0:00:06     0:00:05\r",
+      "\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
+      "     0.01820          0.00     0.00%     0.00%     0:00:07     0:00:05\r",
       "\r"
      ]
     },
@@ -1358,7 +1355,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.02239          0.00   100.00%     0.00%     0:00:10     0:00:08\r",
+      "     0.01698          0.00     0.00%     0.00%     0:00:07     0:00:05\r",
       "\r"
      ]
     },
@@ -1367,7 +1364,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.02089          0.00   100.00%     0.00%     0:00:10     0:00:08\r",
+      "     0.01585          0.00     0.00%     0.00%     0:00:07     0:00:05\r",
       "\r"
      ]
     },
@@ -1376,7 +1373,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.01950          0.00   100.00%     0.00%     0:00:10     0:00:08\r",
+      "     0.01479          0.00     0.00%     0.00%     0:00:07     0:00:04\r",
       "\r"
      ]
     },
@@ -1385,7 +1382,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.01820          0.00   100.00%     0.00%     0:00:10     0:00:07\r",
+      "     0.01380          0.00     0.00%     0.00%     0:00:07     0:00:04\r",
       "\r"
      ]
     },
@@ -1394,7 +1391,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.01698          0.00   100.00%     0.00%     0:00:10     0:00:07\r",
+      "     0.01288          0.00     0.00%     0.00%     0:00:07     0:00:04\r",
       "\r"
      ]
     },
@@ -1403,7 +1400,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.01585          0.00   100.00%     0.00%     0:00:11     0:00:07\r",
+      "     0.01202          0.00     0.00%     0.00%     0:00:07     0:00:04\r",
       "\r"
      ]
     },
@@ -1412,7 +1409,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.01479          0.00   100.00%     0.00%     0:00:11     0:00:07\r",
+      "     0.01122          0.00     0.00%     0.00%     0:00:07     0:00:04\r",
       "\r"
      ]
     },
@@ -1421,7 +1418,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.01380          0.00   100.00%     0.00%     0:00:11     0:00:07\r",
+      "     0.01047          0.00     0.00%     0.00%     0:00:07     0:00:04\r",
       "\r"
      ]
     },
@@ -1430,16 +1427,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.01288          0.00   100.00%     0.00%     0:00:11     0:00:06\r",
-      "\r"
+      "     0.00977          0.00     0.00%     0.00%     0:00:08     0:00:04\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "     0.01202          0.00   100.00%     0.00%     0:00:11     0:00:06\r",
       "\r"
      ]
     },
@@ -1448,16 +1442,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.01122          0.00   100.00%     0.00%     0:00:11     0:00:06\r",
-      "\r"
+      "     0.00912          0.00     0.00%     0.00%     0:00:08     0:00:04\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "     0.01047          0.00   100.00%     0.00%     0:00:12     0:00:06\r",
       "\r"
      ]
     },
@@ -1466,7 +1457,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00977          0.00   100.00%     0.00%     0:00:12     0:00:06\r",
+      "     0.00851          0.00     0.00%     0.00%     0:00:08     0:00:04\r",
       "\r"
      ]
     },
@@ -1475,7 +1466,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00912          0.00   100.00%     0.00%     0:00:12     0:00:06\r",
+      "     0.00794          0.00     0.00%     0.00%     0:00:08     0:00:03\r",
       "\r"
      ]
     },
@@ -1484,16 +1475,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00851          0.00   100.00%     0.00%     0:00:12     0:00:05\r",
-      "\r"
+      "     0.00741          0.00     0.00%     0.00%     0:00:08     0:00:03\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "     0.00794          0.00   100.00%     0.00%     0:00:12     0:00:05\r",
       "\r"
      ]
     },
@@ -1502,16 +1490,13 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00741          0.00   100.00%     0.00%     0:00:12     0:00:05\r",
-      "\r"
+      "     0.00692          0.00     0.00%     0.00%     0:00:08     0:00:03\r"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "     0.00692          0.00   100.00%     0.00%     0:00:12     0:00:05\r",
       "\r"
      ]
     },
@@ -1520,7 +1505,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00646          0.00   100.00%     0.00%     0:00:12     0:00:05\r",
+      "     0.00646          0.00     0.00%     0.00%     0:00:08     0:00:03\r",
       "\r"
      ]
     },
@@ -1529,7 +1514,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00603          0.00   100.00%     0.00%     0:00:12     0:00:04\r",
+      "     0.00603          0.00     0.00%     0.00%     0:00:08     0:00:03\r",
       "\r"
      ]
     },
@@ -1538,7 +1523,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00562          0.00   100.00%     0.00%     0:00:13     0:00:04\r",
+      "     0.00562          0.00     0.00%     0.00%     0:00:09     0:00:03\r",
       "\r"
      ]
     },
@@ -1547,7 +1532,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00525          0.00   100.00%     0.00%     0:00:13     0:00:04\r",
+      "     0.00525          0.00     0.00%     0.00%     0:00:09     0:00:03\r",
       "\r"
      ]
     },
@@ -1556,7 +1541,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00490          0.00   100.00%     0.00%     0:00:13     0:00:04\r",
+      "     0.00490          0.00     0.00%     0.00%     0:00:09     0:00:03\r",
       "\r"
      ]
     },
@@ -1565,7 +1550,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00457          0.00   100.00%     0.00%     0:00:13     0:00:04\r",
+      "     0.00457          0.00     0.00%     0.00%     0:00:09     0:00:02\r",
       "\r"
      ]
     },
@@ -1574,7 +1559,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00427          0.00   100.00%     0.00%     0:00:13     0:00:03\r",
+      "     0.00427          0.00     0.00%     0.00%     0:00:09     0:00:02\r",
       "\r"
      ]
     },
@@ -1583,7 +1568,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00398          0.00   100.00%     0.00%     0:00:13     0:00:03\r",
+      "     0.00398          0.00     0.00%     0.00%     0:00:09     0:00:02\r",
       "\r"
      ]
     },
@@ -1592,7 +1577,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00372          0.00   100.00%     0.00%     0:00:13     0:00:03\r",
+      "     0.00372          0.00     0.00%     0.00%     0:00:09     0:00:02\r",
       "\r"
      ]
     },
@@ -1601,7 +1586,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00347          0.00   100.00%     0.00%     0:00:13     0:00:03\r",
+      "     0.00347          0.00     0.00%     0.00%     0:00:09     0:00:02\r",
       "\r"
      ]
     },
@@ -1610,7 +1595,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00324          0.00   100.00%     0.00%     0:00:14     0:00:03\r",
+      "     0.00324          0.00     0.00%     0.00%     0:00:09     0:00:02\r",
       "\r"
      ]
     },
@@ -1619,7 +1604,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00302          0.00   100.00%     0.00%     0:00:14     0:00:03\r",
+      "     0.00302          0.00     0.00%     0.00%     0:00:10     0:00:02\r",
       "\r"
      ]
     },
@@ -1628,7 +1613,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00282          0.00   100.00%     0.00%     0:00:14     0:00:02\r",
+      "     0.00282          0.00     0.00%     0.00%     0:00:10     0:00:02\r",
       "\r"
      ]
     },
@@ -1637,7 +1622,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00263          0.00   100.00%     0.00%     0:00:14     0:00:02\r",
+      "     0.00263          0.00     0.00%     0.00%     0:00:10     0:00:02\r",
       "\r"
      ]
     },
@@ -1646,7 +1631,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00245          0.00   100.00%     0.00%     0:00:14     0:00:02\r",
+      "     0.00245          0.00     0.00%     0.00%     0:00:10     0:00:01\r",
       "\r"
      ]
     },
@@ -1655,7 +1640,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00229          0.00   100.00%     0.00%     0:00:14     0:00:02\r",
+      "     0.00229          0.00     0.00%     0.00%     0:00:10     0:00:01\r",
       "\r"
      ]
     },
@@ -1664,7 +1649,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00214          0.00   100.00%     0.00%     0:00:14     0:00:02\r",
+      "     0.00214          0.00     0.00%     0.00%     0:00:10     0:00:01\r",
       "\r"
      ]
     },
@@ -1673,7 +1658,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00200          0.00   100.00%     0.00%     0:00:14     0:00:02\r",
+      "     0.00200          0.00     0.00%     0.00%     0:00:10     0:00:01\r",
       "\r"
      ]
     },
@@ -1682,7 +1667,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00186          0.00   100.00%     0.00%     0:00:15     0:00:01\r",
+      "     0.00186          0.00     0.00%     0.00%     0:00:10     0:00:01\r",
       "\r"
      ]
     },
@@ -1691,7 +1676,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00174          0.00   100.00%     0.00%     0:00:15     0:00:01\r",
+      "     0.00174          0.00     0.00%     0.00%     0:00:10     0:00:01\r",
       "\r"
      ]
     },
@@ -1700,7 +1685,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00162          0.00   100.00%     0.00%     0:00:15     0:00:01\r",
+      "     0.00162          0.00     0.00%     0.00%     0:00:11     0:00:01\r",
       "\r"
      ]
     },
@@ -1709,7 +1694,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00151          0.00   100.00%     0.00%     0:00:15     0:00:01\r",
+      "     0.00151          0.00     0.00%     0.00%     0:00:11     0:00:01\r",
       "\r"
      ]
     },
@@ -1718,7 +1703,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00141          0.00   100.00%     0.00%     0:00:15     0:00:01\r",
+      "     0.00141          0.00     0.00%     0.00%     0:00:11     0:00:01\r",
       "\r"
      ]
     },
@@ -1727,7 +1712,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00132          0.00   100.00%     0.00%     0:00:15     0:00:01\r",
+      "     0.00132          0.00     0.00%     0.00%     0:00:11     0:00:00\r",
       "\r"
      ]
     },
@@ -1736,7 +1721,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00123          0.00   100.00%     0.00%     0:00:15     0:00:00\r",
+      "     0.00123          0.00     0.00%     0.00%     0:00:11     0:00:00\r",
       "\r"
      ]
     },
@@ -1745,7 +1730,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00115          0.00   100.00%     0.00%     0:00:16     0:00:00\r",
+      "     0.00115          0.00     0.00%     0.00%     0:00:11     0:00:00\r",
       "\r"
      ]
     },
@@ -1754,7 +1739,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00107          0.00   100.00%     0.00%     0:00:16     0:00:00\r",
+      "     0.00107          0.00     0.00%     0.00%     0:00:11     0:00:00\r",
       "\r"
      ]
     },
@@ -1763,7 +1748,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "     0.00100          0.00   100.00%     0.00%     0:00:16     0:00:00\r",
+      "     0.00100          0.00     0.00%     0.00%     0:00:11     0:00:00\r",
       "\r"
      ]
     },
@@ -1772,18 +1757,18 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solution trouvee en 16.00s (avec simanneal):\n",
-      "9 6 2 | 1 7 5 | 4 8 3 \n",
-      "1 7 4 | 8 6 3 | 9 2 5 \n",
-      "5 2 8 | 4 9 7 | 3 6 1 \n",
+      "Solution trouvee en 11.39s (avec simanneal):\n",
+      "9 6 2 | 1 8 5 | 4 7 3 \n",
+      "1 7 4 | 9 6 3 | 8 2 5 \n",
+      "5 3 8 | 4 2 7 | 1 6 9 \n",
       "---------------------\n",
-      "4 2 6 | 3 5 9 | 8 7 1 \n",
-      "3 5 7 | 4 1 6 | 2 9 8 \n",
-      "1 9 4 | 6 7 2 | 5 3 8 \n",
+      "8 2 6 | 3 5 9 | 7 4 1 \n",
+      "3 5 7 | 8 1 4 | 2 9 6 \n",
+      "4 9 1 | 6 7 2 | 5 3 8 \n",
       "---------------------\n",
-      "2 4 9 | 5 3 1 | 6 8 7 \n",
-      "7 1 5 | 2 9 8 | 3 6 4 \n",
-      "2 8 6 | 3 4 1 | 9 5 7 \n",
+      "2 4 9 | 5 3 8 | 6 1 7 \n",
+      "7 1 5 | 2 9 6 | 3 8 4 \n",
+      "6 8 3 | 7 4 1 | 9 5 2 \n",
       "\n",
       "Energie finale: 0\n",
       "Solution valide: True\n"
@@ -1833,19 +1818,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : Premier test\n",
-    "\n",
-    "| Aspect | Observation |\n",
-    "|--------|-------------|\n",
-    "| Resultat | Le recuit simule peut trouver la solution pour les puzzles faciles |\n",
-    "| Temps | Plus lent que les solveurs deterministes |\n",
-    "| Non-determinisme | Chaque execution peut donner un resultat different |\n",
-    "\n",
-    "> **Point cle** : contrairement au backtracking, le recuit simule n'est **pas garanti** de trouver la solution.\n",
-    ">\n",
-    "> **Nuance (cf. Conclusion et la note de fidelite sur la fonction d'energie)** : sur ces puzzles faciles, c'est l'initialisation par permutation qui atteint deja energie=0 avant tout recuit ; le solveur n'explore donc pas reellement l'espace ici."
-   ]
+   "source": "### Interpretation : Premier test\n\n| Aspect | Observation |\n|--------|-------------|\n| Resultat | Le recuit simule trouve la solution pour ce puzzle facile |\n| Dynamique | Energie 29 -> 0 : le solveur explore reellement le paysage |\n| Non-determinisme | Chaque execution peut donner un resultat different |\n\n> **Point cle** : contrairement au backtracking, le recuit simule n'est **pas garanti** de trouver la solution.\n>\n> **Lecture de la trace** : l'energie part de **29** (la grille initialisee par permutations viole les contraintes colonnes/blocs), puis fluctue (7, 13, 9, 7, 4, 2, 0...) tandis que la temperature baisse. Les colonnes `Accept` (taux de mouvements acceptes, y compris degradants) et `Improve` (taux de mouvements ameliorants) sont non triviales au debut (Accept ~23%, Improve ~9% a T=0.93) puis s'effondrent quand T devient petit : c'est la signature d'un vrai recuit -- exploration a haute temperature, exploitation a basse temperature. La solution finale `Energie finale: 0` est ici **veritablement valide** (fonction d'energie correcte)."
   },
   {
    "cell_type": "markdown",
@@ -1868,7 +1841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "6c8b05a9",
    "metadata": {
     "execution": {
@@ -1981,7 +1954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "5e5991f2",
    "metadata": {
     "execution": {
@@ -2004,23 +1977,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Test : Recuit Simule Manuel ===\n",
+      "=== Test : Recuit Simule Manuel ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "Resolu: True\n",
-      "Temps: 0.00s\n",
+      "Temps: 0.15s\n",
       "\n",
       "Solution:\n",
-      "9 6 2 | 1 7 5 | 4 8 3 \n",
-      "1 7 4 | 8 6 3 | 9 2 5 \n",
-      "5 2 8 | 4 9 7 | 3 6 1 \n",
+      "9 6 2 | 1 8 5 | 4 7 3 \n",
+      "1 7 4 | 9 6 3 | 8 2 5 \n",
+      "5 3 8 | 4 2 7 | 1 6 9 \n",
       "---------------------\n",
-      "4 2 6 | 3 5 9 | 8 7 1 \n",
-      "3 5 7 | 4 1 6 | 2 9 8 \n",
-      "1 9 4 | 6 7 2 | 5 3 8 \n",
+      "8 2 6 | 3 5 9 | 7 4 1 \n",
+      "3 5 7 | 8 1 4 | 2 9 6 \n",
+      "4 9 1 | 6 7 2 | 5 3 8 \n",
       "---------------------\n",
-      "2 4 9 | 5 3 1 | 6 8 7 \n",
-      "7 1 5 | 2 9 8 | 3 6 4 \n",
-      "2 8 6 | 3 4 1 | 9 5 7 \n"
+      "2 4 9 | 5 3 8 | 6 1 7 \n",
+      "7 1 5 | 2 9 6 | 3 8 4 \n",
+      "6 8 3 | 7 4 1 | 9 5 2 \n"
      ]
     }
    ],
@@ -2078,7 +2057,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -2095,12 +2074,13 @@
     "    # TODO: Generez une liste de temperatures selon le schema exponentiel\n",
     "    # T_i = T_init * alpha^i, arretez quand T < T_min\n",
     "    result = []  # TODO etudiant\n",
-    "    return result\n"
+    "    return result\n",
+    "print(\"Exercice a completer\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "4dd820e2",
    "metadata": {
     "execution": {
@@ -2124,36 +2104,38 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "=== Benchmark: Recuit Simule (5 puzzles) ===\n",
-      "  Puzzle 1: OK, 36 vides, 0.00s\n",
-      "  Puzzle 2: OK, 49 vides, 0.00s\n",
-      "  Puzzle 3: OK, 51 vides, 0.00s\n"
+      "=== Benchmark: Recuit Simule (3 puzzles) ===\n",
+      "  Puzzle 1: OK, 36 vides, 0.14s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 4: OK, 53 vides, 0.00s\n",
-      "  Puzzle 5: OK, 51 vides, 0.00s\n",
+      "  Puzzle 2: OK, 49 vides, 11.07s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Puzzle 3: OK, 51 vides, 220.92s\n",
       "\n",
       "Resume:\n",
-      "  Resolus: 5/5\n",
-      "  Temps total: 0.00s\n",
-      "  Temps moyen: 0.00s\n"
+      "  Resolus: 3/3\n",
+      "  Temps total: 232.13s\n",
+      "  Temps moyen: 77.38s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[{'solved': True, 'errors': np.int64(0), 'time': 0.0},\n",
-       " {'solved': True, 'errors': np.int64(0), 'time': 0.0010004043579101562},\n",
-       " {'solved': True, 'errors': np.int64(0), 'time': 0.0},\n",
-       " {'solved': True, 'errors': np.int64(0), 'time': 0.0},\n",
-       " {'solved': True, 'errors': np.int64(0), 'time': 0.0009999275207519531}]"
+       "[{'solved': True, 'errors': 0, 'time': 0.13814258575439453},\n",
+       " {'solved': True, 'errors': 0, 'time': 11.073346614837646},\n",
+       " {'solved': True, 'errors': 0, 'time': 220.9175570011139}]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2196,7 +2178,7 @@
     "    \n",
     "    return results\n",
     "\n",
-    "benchmark_sa(easy_puzzles, num_puzzles=5)"
+    "benchmark_sa(easy_puzzles, num_puzzles=3)  # Prong B: 3 puzzles = rich demo, bounded runtime"
    ]
   },
   {
@@ -2212,22 +2194,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : Resultats du benchmark\n",
-    "\n",
-    "| Difficulte | Taux de succes attendu | Temps typique |\n",
-    "|------------|----------------------|---------------|\n",
-    "| Easy | 60-100% | 1-5s |\n",
-    "| Medium | 10-50% | 5-20s |\n",
-    "| Hard | < 10% | > 20s |\n",
-    "\n",
-    "> Ces fourchettes sont **indicatives** (ordres de grandeur attendus) et ne sont **pas mesurees dans ce notebook** : le seul benchmark execute ici porte sur 5 puzzles faciles. Aucune grille Medium/Hard n'est evaluee (et les taux \"resolu\" mesures restent sujets a la note de fidelite sur la fonction d'energie).\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. Le recuit simule **ne garantit pas** de trouver la solution\n",
-    "2. Les performances dependent fortement du reglage des parametres\n",
-    "3. Pour les puzzles difficiles, les solveurs CSP (OR-Tools, Z3) restent plus fiables"
-   ]
+   "source": "### Interpretation : Resultats du benchmark\n\n| Puzzle | Cellules vides | Temps SA | Statut |\n|--------|---------------|----------|--------|\n| 1 | 36 | ~0.1 s | Resolu |\n| 2 | 49 | ~11 s | Resolu |\n| 3 | 51 | ~220 s | Resolu |\n\n**Lecture** : les 3 puzzles faciles sont resolus (3/3), mais le temps de resolution croit fortement avec le nombre de cellules vides (~0.1 s -> ~11 s -> ~220 s). Le recuit simule **finit par trouver** la solution sur ces instances, mais reste considerablement plus lent que le backtracking (qui resout le meme puzzle 3 en ~9 ms, voir la comparaison ci-dessous).\n\n> **Fourchettes indicatives** (au-dela du benchmark ci-dessus) : Easy 60-100% de succes en quelques secondes ; Medium 10-50% en quelques dizaines de secondes ; Hard < 10% et souvent > 20 s. Ces ordres de grandeur dependent fortement des parametres (T0, alpha, iterations) et de la fonction de voisinage.\n\n**Points cles** :\n1. Le recuit simule **ne garantit pas** de trouver la solution\n2. Les performances dependent fortement du reglage des parametres\n3. Pour les puzzles difficiles, les solveurs CSP (OR-Tools, Z3) restent plus fiables"
   },
   {
    "cell_type": "markdown",
@@ -2248,7 +2215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "fbd14051",
    "metadata": {
     "execution": {
@@ -2274,16 +2241,28 @@
       "=== Comparaison : Backtracking vs Recuit Simule ===\n",
       "\n",
       "Puzzle 1:\n",
-      "  Backtracking: 49 appels, 2.8 ms\n",
-      "  Recuit Simule: OK, 1 ms\n",
+      "  Backtracking: 49 appels, 1.0 ms\n",
+      "  Recuit Simule: OK, 131 ms\n",
       "\n",
       "Puzzle 2:\n",
-      "  Backtracking: 201 appels, 6.3 ms\n",
-      "  Recuit Simule: OK, 0 ms\n",
+      "  Backtracking: 201 appels, 5.1 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Recuit Simule: OK, 10340 ms\n",
       "\n",
       "Puzzle 3:\n",
-      "  Backtracking: 295 appels, 9.0 ms\n",
-      "  Recuit Simule: OK, 0 ms\n"
+      "  Backtracking: 295 appels, 8.6 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Recuit Simule: OK, 207723 ms\n"
      ]
     }
    ],
@@ -2386,7 +2365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "spvcsgm45gn",
    "metadata": {
     "execution": {
@@ -2482,7 +2461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "1h772bk4cim",
    "metadata": {
     "execution": {
@@ -2591,7 +2570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "ad7p1nlulxo",
    "metadata": {
     "execution": {
@@ -2710,36 +2689,7 @@
    "id": "2bf8d86f",
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "Ce notebook a applique le **recuit simule (Simulated Annealing)** a la resolution de Sudoku.\n",
-    "\n",
-    "### Formulation SA pour le Sudoku\n",
-    "\n",
-    "| Element | Choix |\n",
-    "|---------|-------|\n",
-    "| **Etat** | Grille 9x9 avec permutations par ligne |\n",
-    "| **Energie** | Doublons colonnes + blocs 3x3 (lignes valides par construction) |\n",
-    "| **Voisinage** | Echange de 2 cellules non-fixees dans la meme ligne |\n",
-    "| **Refroidissement** | T *= alpha (0.999), T0=1.0, Tmin=0.001 |\n",
-    "\n",
-    "### Resultats du benchmark\n",
-    "\n",
-    "| Methode | Puzzles | Temps | Appels |\n",
-    "|---------|---------|-------|--------|\n",
-    "| **SA manuel** | 5/5 resolus | 0-1 ms | - |\n",
-    "| **Backtracking** | 3/3 resolus | 2.8-9.0 ms | 49-295 |\n",
-    "| **simanneal (50000 steps)** | 1/1 resolu | 16.0 s | - |\n",
-    "\n",
-    "### Point methodologique important\n",
-    "\n",
-    "Les temps sub-millisecondes du SA manuel refletent le fait que l'initialisation par permutation atteint deja energie=0 sur ces puzzles faciles. Le SA n'a pas reellement explore l'espace de solutions. De plus, la fonction d'energie committee renvoie 0 pour toute grille complete (les doublons et les valeurs manquantes se compensent), si bien que les mentions `Solution valide: True` ci-dessus ne garantissent pas une grille reellement valide (voir la note de fidelite sur la fonction d'energie et l'issue #3377). Sur des instances plus difficiles, l'efficacite du SA depend crucialement des parametres T0/alpha/iterations et de la fonction de voisinage.\n",
-    "\n",
-    "Le recuit simule offre une approche **non-deterministe** sans garantie de completude, adaptee aux problemes d'optimisation combinatoire. Pour le Sudoku, les solveurs CSP (OR-Tools CP-SAT, Z3 SMT) restent plus fiables sur les instances difficiles.\n",
-    "\n",
-    "**Suite** : [Sudoku-5 - PSO](Sudoku-5-PSO-Python.ipynb) | [Sudoku-10 - OR-Tools](Sudoku-10-ORTools-Python.ipynb) | [Retour au sommaire](README.md)"
-   ]
+   "source": "## Conclusion\n\nCe notebook a applique le **recuit simule (Simulated Annealing)** a la resolution de Sudoku.\n\n### Formulation SA pour le Sudoku\n\n| Element | Choix |\n|---------|-------|\n| **Etat** | Grille 9x9 avec permutations par ligne |\n| **Energie** | Doublons colonnes + blocs 3x3 (lignes valides par construction) |\n| **Voisinage** | Echange de 2 cellules non-fixees dans la meme ligne |\n| **Refroidissement** | T *= alpha (0.999), T0=1.0, Tmin=0.001 |\n\n### Resultats du benchmark\n\n| Methode | Puzzles | Temps observe |\n|---------|---------|---------------|\n| **SA manuel** | 3/3 resolus | ~0.1 s a ~220 s (croit avec le nombre de vides) |\n| **Backtracking** | 3/3 resolus | ~1-9 ms (49-295 appels) |\n| **simanneal (50000 steps)** | 1/1 resolu | ~11 s |\n\n### Lecture comparee\n\nLe backtracking resout ces puzzles faciles en quelques millisecondes ; le recuit simule y parvient aussi mais est **considerablement plus lent** (jusqu'a ~220 s sur 51 cellules vides). La valeur du recuit simule n'est pas dans la vitesse sur ces instances faciles, mais dans sa capacite a **explorer un paysage d'energie** (acceptation de mouvements degradants a haute temperature, exploitation a basse temperature) -- une approche transferable a des problemes d'optimisation ou aucun solveur deterministe n'est disponible.\n\nLe recuit simule offre une approche **non-deterministe** sans garantie de completude, adaptee aux problemes d'optimisation combinatoire. Pour le Sudoku, les solveurs CSP (OR-Tools CP-SAT, Z3 SMT) restent plus fiables sur les instances difficiles.\n\n**Suite** : [Sudoku-5 - PSO](Sudoku-5-PSO-Python.ipynb) | [Sudoku-10 - OR-Tools](Sudoku-10-ORTools-Python.ipynb) | [Retour au sommaire](README.md)"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

SOTA **Prong B** fix (mandat user 2026-06-21, EPIC #3801, rule `sota-not-workaround.md`). The Sudoku-4-Python Simulated Annealing notebook was **doubly degenerate**: a **buggy energy function** (issue #3377) masked a **degenerate instance** where the committed output showed SA doing zero work (`Energy 0.00` / `Accept 100%` / `Improve 0%` across the whole cooling trace). Classic Prong B failure: the SOTA engine (SA) was indistinguishable from a trivial baseline.

### Root cause (G.1 self-verified)

The energy function summed `counts[1:] - 1` over **all** values 1-9, including absent ones (count=0 → contributes −1). On the complete-grid invariant maintained by row-permutation init, each duplicate (+1) was exactly cancelled by a missing value (−1), so **energy = 0 for any complete grid, valid or not**. SA could never find signal to optimize. The C# twin (`Sudoku-4-Csharp`) already had the correct clamped energy and a rich demo — the Python version was the laggard.

### Changes (211 ins / 261 del, 1 file)

| Cell | Change |
|------|--------|
| 9 (`69b53f0e`) source | `np.sum(counts[1:] - 1)` → `int(np.sum(np.maximum(counts[1:] - 1, 0)))` (clamp absent values to 0). Energy now correctly counts column/block duplicates. |
| 9 + 16 + 20 + 25 + 29 + 32 outputs | Re-executed from the corrected energy. |
| 29 (`4dd820e2`) source | Benchmark `num_puzzles=5` → `3` (rich demo, bounded runtime — Prong B \"discriminant mais borne\"). |
| 10 / 21 / 30 / Conclusion (md) | Removed stale #3377 caveats; documented the real SA dynamics (29→0 trajectory) + measured benchmark results + honest SA-vs-backtracking comparison. |
| 8 / 14 / 28 (exercise TODO cells) | Added `print(\"Exercice a completer\")` to satisfy output-systematique convention (their source lacked a print; main had stale outputs that didn't match source). |

### What the output now shows (SA capability made visible)

```
Temperature   Energy   Accept   Improve
   1.00000     29.00                      <- init by permutation: columns/blocks violated
   0.93325      7.00    23.60%    9.20%   <- high T: real exploration
   0.87096     13.00     9.60%    4.00%   <- uphill moves accepted
   ...
   0.00100      0.00     0.00%    0.00%   <- low T: converged to valid solution
Solution valide: True  (now GENUINELY valid)
```

Benchmark: **3/3 solved** (was 5/5 trivial at 0.00s) — `~0.1s / ~11s / ~220s`. Honest comparison vs backtracking (~1-9ms): SA loses on speed but the comparison is now **meaningful** (before, SA \"won\" at 0ms because it did nothing).

### Verification

- **H.1**: 18/18 cells executed, 0 errors, exec_count sequential 1..18.
- **C.2**: `check_c2_compliance.py` = 1/1 compliant (was failing on 3 exercise cells whose stale outputs didn't match source).
- **C.3**: only energy cell (source+output), benchmark cell (source+output), 4 interpretation markdown cells, and 3 exercise-cell prints changed. Catalog byte-identical to main.
- **G.1**: reproduced both energy functions standalone — buggy returns 0 on the init grid, corrected returns 29. Confirmed the degeneracy independently of the audit.

This is the textbook Prong B fix: the engine (SA) now demonstrates its distinctive power (landscape exploration via probabilistic uphill moves, escaping local minima) instead of degenerating to a baseline that solves nothing.

See #3164, #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)