### PR TITLE
fix(search-3): repair unsolvable 8-puzzle "Moyen" instance (Prong B #3164/#3801)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -1877,7 +1877,7 @@
       "Heuristiques pour le 8-puzzle :\n",
       "==================================================\n",
       "Facile: h_misplaced=1, h_manhattan=1\n",
-      "Moyen: h_misplaced=6, h_manhattan=12\n",
+      "Moyen: h_misplaced=6, h_manhattan=10\n",
       "Difficile: h_misplaced=7, h_manhattan=21\n",
       "\n",
       "Note : h_manhattan >= h_misplaced (dominance)\n"
@@ -1978,7 +1978,9 @@
     "puzzle_easy = EightPuzzleProblem((1, 2, 3, 4, 5, 0, 7, 8, 6))\n",
     "\n",
     "# Probleme moyen (solution en ~10-15 coups)\n",
-    "puzzle_medium = EightPuzzleProblem((1, 3, 4, 8, 0, 2, 7, 6, 5))\n",
+    "# Note : seules les 2 dernieres tuiles sont inversees vs la version buggy\n",
+    "# (7,6,5) -> (7,5,6). Verifie : 8 inversions (pair) = solvable, cout optimal ~16.\n",
+    "puzzle_medium = EightPuzzleProblem((1, 3, 4, 8, 0, 2, 7, 5, 6))\n",
     "\n",
     "# Probleme difficile (solution en ~20 coups)\n",
     "puzzle_hard = EightPuzzleProblem((8, 6, 7, 2, 5, 4, 3, 0, 1))\n",
@@ -2047,28 +2049,22 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees            1        1         0.04\n",
-      "Distance Manhattan            1        1         0.03\n",
+      "Tuiles mal placees            1        1         0.03\n",
+      "Distance Manhattan            1        1         0.02\n",
       "\n",
       "Reduction des noeuds explores : 0.0%\n",
       "\n",
       "Probleme : Moyen\n",
       "----------------------------------------------------------------------\n",
-      "Etat initial : (1, 3, 4, 8, 0, 2, 7, 6, 5)\n",
-      "Etat but     : (1, 2, 3, 4, 5, 6, 7, 8, 0)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Etat initial : (1, 3, 4, 8, 0, 2, 7, 5, 6)\n",
+      "Etat but     : (1, 2, 3, 4, 5, 6, 7, 8, 0)\n",
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees       181440      inf      2120.01\n",
-      "Distance Manhattan       181440      inf      2460.47\n",
+      "Tuiles mal placees          770       16         4.65\n",
+      "Distance Manhattan          220       16         1.63\n",
       "\n",
-      "Reduction des noeuds explores : 0.0%\n",
+      "Reduction des noeuds explores : 71.4%\n",
       "\n",
       "Probleme : Difficile\n",
       "----------------------------------------------------------------------\n",
@@ -2083,8 +2079,8 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees       143839       31      1840.88\n",
-      "Distance Manhattan        20290       31       251.51\n",
+      "Tuiles mal placees       143839       31      1189.57\n",
+      "Distance Manhattan        20290       31       199.86\n",
       "\n",
       "Reduction des noeuds explores : 85.9%\n"
      ]
@@ -2092,8 +2088,8 @@
     {
      "data": {
       "text/plain": [
-       "(<__main__.SearchResult at 0x2b12931d130>,\n",
-       " <__main__.SearchResult at 0x2b14d698560>)"
+       "(<__main__.SearchResult at 0x2b6f7d9a390>,\n",
+       " <__main__.SearchResult at 0x2b6f81c6b10>)"
       ]
      },
      "execution_count": 15,


### PR DESCRIPTION
## Summary

Fix the **unsolvable** 8-puzzle "Moyen" instance in `Search-3-Informed.ipynb`. This was both a **fidelity bug** (the Moyen benchmark row was meaningless) and a **Prong B degeneracy** (the heuristic capability comparison was invisible on the Moyen instance).

## Root cause (G.1 verified)

```python
# BEFORE (buggy)
puzzle_medium = EightPuzzleProblem((1, 3, 4, 8, 0, 2, 7, 6, 5))
```

For a 3x3 sliding puzzle (odd board width), an instance is solvable **iff** its inversion count (excluding the blank) is **even**. The buggy tuple has **9 inversions** (odd) → **UNSOLVABLE**:

```
$ python inversions.py
(1,3,4,8,0,2,7,6,5): inversions=9 → UNSOLVABLE
```

### Consequence (committed output on `main`, cell 42)
```
Probleme : Moyen
Heuristique              Noeuds     Cout   Temps (ms)
Tuiles mal placees       181440      inf      2120.01
Distance Manhattan       181440      inf      2460.47
Reduction des noeuds explores : 0.0%
```

A* expanded the **entire reachable space** (`181440 = 9!/2`), wasted ~2s, and returned `Cout = inf`. The Moyen row taught nothing: both heuristics behaved identically (reduction 0.0%), and the distinctive capability of Manhattan (dominates misplaced) was only visible on the `Difficile` instance (85.9% reduction).

## Fix (minimal, pedagogy-preserving)

Swap only the two last tiles of the buggy tuple: `(7,6,5) → (7,5,6)`. The 6 first tiles are identical to the buggy version.

```python
# AFTER (solvable)
# Note : seules les 2 dernieres tuiles sont inversees vs la version buggy
# (7,6,5) -> (7,5,6). Verifie : 8 inversions (pair) = solvable, cout optimal ~16.
puzzle_medium = EightPuzzleProblem((1, 3, 4, 8, 0, 2, 7, 5, 6))
```

8 inversions (even) → **SOLVABLE**, optimal cost ~16.

### Result (re-executed output, cell 42)
```
Probleme : Moyen
Heuristique              Noeuds     Cout   Temps (ms)
Tuiles mal placees          770       16         4.65
Distance Manhattan          220       16         1.63
Reduction des noeuds explores : 71.4%
```

Now the Moyen instance shows a **real heuristic comparison**: Manhattan explores **3.5x fewer nodes** than misplaced (71.4% reduction), at the same optimal cost. The capability is exercised — not only on Difficile.

## Validation

- **H.1**: 23/23 code cells, 0 errors, 0 null-exec_count. Papermill re-exec end-to-end SUCCESS (~10s, kernel python3, `--cwd` Part1-Foundations for `search_helpers` import).
- **C.3 strict**: only cells **40** (source + outputs) and **42** (outputs) changed. All other cells byte-identical to `origin/main` (verified cell-by-cell against `git show origin/main`). Diff: 15 ins / 19 del, single file.
- **C.1**: 0 forbidden patterns (`raise NotImplementedError` / `assert False` / `1/0`).
- **C.2**: `Facile` (cost 1) and `Difficile` (cost 31, 85.9%) rows unchanged — confirms the fix is scoped to Moyen.
- **G.1**: candidate instances verified standalone before commit (inversion counts + A* optimal cost); the chosen instance `(1,3,4,8,0,2,7,5,6)` is the minimal-diff solvable variant.

## Verdict

Fidelity bug + Prong B degeneracy, both resolved. Logged to EPIC #3801 registry (BUG A).

See #3164 (partial). See #3801.
