### PR TITLE
docs(qc-projects-research): add Conclusion to projects + research READMEs

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/README.md
@@ -77,6 +77,31 @@ MonProjet/
 
 **En local** : `pip install yfinance pandas matplotlib` puis `jupyter notebook projects/MonProjet/research.ipynb`
 
+## Conclusion / Prochaines étapes
+
+### Ce que vous avez appris
+
+Ce catalogue de **116 projets** est un **zoo de stratégies backtestées**, organisé non pas par thème mais par **robustesse** (Robuste / Historique / Exploratoire). La classification elle-même est la leçon :
+
+- **La robustesse prime sur le Sharpe brut** : une stratégie à Sharpe 1.6 qui s'effondre hors-échantillon vaut moins qu'une stratégie à Sharpe 0.6 stable à travers les régimes. Le label *Robuste* (> 0.5 soutenu) est la barre pédagogique, pas le chiffre spectaculaire.
+- **Les contre-exemples sont aussi importants que les succès** : les stratégies *Exploratoire* (Sharpe < 0) et *Historique* (0-0.5) sont conservées **délibérément** pour montrer *ce qui ne marche pas* et pourquoi — PairsTrading sur ETF corrélés, ForexCarry, MeanReversion naïf. On apprend autant d'un edge négatif bien diagnostiqué que d'un edge positif.
+- **La diversité des régimes compte** : un projet backtesté 2015-2026 (bull/bull) n'a pas la même valeur probante qu'un projet backtesté 2008-2026 (incluant le GFC). La colonne *Période* est lue comme un indice de robustesse, pas comme une métadonnée.
+
+Le fil rouge : **chaque projet est reproductible** — `main.py` (ou `Main.cs`) se déploie tel quel sur QuantConnect Cloud, et `research.ipynb` documente l'exploration qui a mené à la stratégie.
+
+### Prochaines étapes
+
+1. **Parcourir par niveau** : débutant (`CSharp-BTC-EMA-Cross`, `EMA-Cross-Stocks`, `AllWeather`) avant d'aborder les avancés (`Framework_Composite_TrendWeather`, `Portfolio-Optimization-ML`).
+2. **Lire les contre-exemples** : ouvrir `PairsTrading/` et `ForexCarry/` pour comprendre *pourquoi* ils échouent — le diagnostic négatif est formateur.
+3. **Consulter le détail** : `STRATEGIES_DETAIL.md` donne le contexte complet de chaque stratégie (catégorie, ML/DL/RL, clones QC Library).
+4. **Reproduire sur QC Cloud** : créer un projet, copier le `main.py`, lancer le backtest, et comparer vos métriques au tableau ci-dessus.
+5. **Étendre un projet Robuste** : choisir une stratégie *Robuste* (ex. `RegimeSwitching`, `SectorMomentum`) et itérer — changer l'univers, ajouter un filtre de risque, tester la sensibilité aux coûts de transaction.
+6. **Voir les leçons transversales** : `docs/qc/quantconnect.md` recense les 20 patterns confirmés et les anti-patterns observés à travers ces 116 projets.
+
+> **Rappel honnête** : un Sharpe de backtest, même *Robuste*, n'est pas une garantie live. Les coûts de transaction réels, le slippage et l'impact de marché dégradent systématiquement la performance paper. La barre *Robuste* (> 0.5 soutenu sur la période) est nécessaire mais pas suffisante — le walk-forward et l'out-of-sample strict restent obligatoires avant tout déploiement.
+
+---
+
 ## Ressources
 
 - [Descriptions détaillées](STRATEGIES_DETAIL.md) — Toutes les stratégies par catégorie

--- a/MyIA.AI.Notebooks/QuantConnect/research/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/research/README.md
@@ -22,3 +22,27 @@ Independent research using local data (yfinance, pandas, sklearn). No QuantConne
 | `research_vrp_putwrite.ipynb` | VRP put-write strategy | (c) Standalone | yfinance |
 
 All 14 notebooks are type **(c) standalone research**. Executable locally with `pip install yfinance pandas matplotlib scikit-learn`.
+
+---
+
+## Conclusion / Prochaines étapes
+
+### Ce que vous avez appris
+
+Ces **14 notebooks standalone** sont le **laboratoire local** de la série QuantConnect : ils ne nécessitent **pas** de compte QC Cloud ni de données payantes — `yfinance` (données gratuites) + `pandas` / `scikit-learn` suffisent. Ils illustrent deux familles de recherche :
+
+- **Recherche factorielle & allocation** (HAR-RV-J vol, FamaFrench + AllWeather composite, Momentum + Regime, Quality/LowVol, Risk Parity, VRP put-write) — on apprend que les modèles de volatilité et d'allocation robuste sont reproductibles en local sur données publiques, et que les composites (M12, M11ef) sont les briques des stratégies *Robuste* du catalogue.
+- **Recherche Reinforcement Learning** (intro, PPO, GRPO, reward shaping, multi-asset, tactical overlay) — on apprend que le RL trading se prototypé localement avant tout déploiement QC Cloud, et que le *reward shaping* est le levier le plus sensible (un reward mal spécifié fige la policy).
+
+Le fil rouge : **l'indépendance de la plateforme**. Ces notebooks prouvent que l'idéation et la validation ML peuvent se faire hors QC Cloud ; le cloud n'est requis que pour le backtest haute-fidélité sur données natives.
+
+### Prochaines étapes
+
+1. **Installer l'environnement local** : `pip install yfinance pandas matplotlib scikit-learn` puis ouvrir un notebook dans `jupyter`.
+2. **Commencer par l'intro RL** : `research_rl_intro.ipynb` avant les avancés (PPO, GRPO, reward shaping).
+3. **Reproduire un keeper** : `research_m12_har_rv_j.ipynb` (modèle de volatilité HAR-RV-J, un des 4 KEEPERS du curriculum ML-V2).
+4. **Tester le reward shaping** : `research_rl_reward_shaping.ipynb` — modifier la fonction de reward et observer l'impact sur la policy convergée.
+5. **Combiner en composite** : `research_composite_mom_regime.ipynb` montre comment assembler Momentum + Regime en une stratégie multi-signal.
+6. **Déployer le meilleur sur QC Cloud** : une fois une idée validée en local, la porter en `main.py` dans `../projects/` pour un backtest réaliste avec coûts de transaction.
+
+> **Rappel honnête** : les données `yfinance` (gratuites) ont des limitations (ajustements, splits, profondeur historique) par rapport aux données QC natives. Un edge confirmé en local doit être **re-validé** sur QC Cloud avant toute conclusion de robustesse.


### PR DESCRIPTION
## Summary

**Final two QuantConnect sub-series README Conclusions for #2651**, closing the QC family. Following:
- Main QC README → #3795 (MERGED)
- Python subseries → #3798 (MERGED)
- ML-Training-Pipeline → #3805 (MERGED)
- partner-course → #3809 (MERGED)

The last two QC sub-series without a Conclusion: `projects/README.md` (86 lines, 116-strategy catalog) and `research/README.md` (24 lines, 14 standalone notebooks).

## Content (+49 lines, additive only)

### projects/README.md (+25)
Anchors the 3 lessons specific to the 116-strategy catalog:
- **Robustesse > raw Sharpe** : the *Robuste* label (> 0.5 sustained) is the pedagogical bar, not the spectacular number.
- **Counter-examples matter** : *Exploratoire* (Sharpe < 0) and *Historique* (0-0.5) strategies are kept deliberately to show what fails and why (PairsTrading, ForexCarry, MeanReversion).
- **Regime-period diversity** : a project backtested 2008-2026 (incl. GFC) > 2015-2026 (bull/bull) as a robustness signal.
Plus 6 next-steps (parcourir par niveau, lire contre-exemples, STRATEGIES_DETAIL, reproduire QC Cloud, étendre un Robuste, leçons transversales) + honest reminder.

### research/README.md (+24)
Anchors the "local lab" nature of the 14 standalone notebooks (no QC Cloud, yfinance+pandas+sklearn):
- Two families: factor/allocation research (HAR-RV-J, FamaFrench+AllWeather, Momentum+Regime, Quality/LowVol, Risk Parity, VRP put-write) + RL research (intro, PPO, GRPO, reward shaping, multi-asset, tactical overlay).
- **Platform-independence lesson** : ideation + ML validation can happen outside QC Cloud; the cloud is only needed for high-fidelity backtests on native data.
Plus 6 next-steps + honest reminder (yfinance limitations vs QC native data — local edge must be re-validated on QC Cloud).

## Validation
- [x] Additive only (+49/-0)
- [x] Catalogue byte-identical (no `COURSE_CATALOG` touched)
- [x] 0 notebook touched
- [x] Placement: projects before Ressources footer, research after notebook table (conforms to #3795/#3798 template)
- [x] Content specific to each sub-series (not generic copy-paste)

## Closes
Closes #2651 for the QuantConnect family (all 6 sub-series + main README now have a Conclusion).

See #2651