### PR TITLE
docs(dsa-lab2): anchor LCEL canonical reference + References (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
@@ -130,7 +130,11 @@
    "source": [
     "### Étape 2 : Créer une chaîne d'extraction d'informations\n",
     "\n",
-    "Nous allons définir un `PromptTemplate` qui guidera le LLM pour qu'il identifie précisément les points qui nous intéressent."
+    "Nous allons définir un `PromptTemplate` qui guidera le LLM pour qu'il identifie précisément les points qui nous intéressons.\n",
+    "\n",
+    "#### LCEL — LangChain Expression Language\n",
+    "\n",
+    "La chaîne est assemblée avec **LCEL** (*LangChain Expression Language*), la syntaxe déclarative introduite par LangChain en 2023 pour composer des briques (prompt, modèle, parseur) via l'opérateur tube `|`. Chaque brique implémente l'interface `Runnable`, ce qui rend la chaîne homogène et lui donne *de facto* le support du *batch*, de l'asynchrone et du *streaming*. LCEL remplace l'ancienne classe `LLMChain` : on écrit désormais `prompt | llm` plutôt qu'un objet `LLMChain(prompt, llm)`. C'est exactement ce pattern (`extraction_prompt | llm`) que nous utilisons ci-dessous. Pour le cadre général LangChain (chaînes, *tools*, mémoire), voir la référence bibliographique du Lab 8 (H. Chase, 2022)."
    ]
   },
   {
@@ -533,6 +537,16 @@
    "id": "26c0e0e2",
    "source": "### Exercice 3 : Creer une chaine d'extraction personnalisee\n\nCreez votre propre chaine LangChain en modifiant le template d'extraction pour extraire des informations differentes du document d'appel d'offre (client, budget, technologies).",
    "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "1. LangChain, *LangChain Expression Language (LCEL)*, 2023, `python.langchain.com/docs/concepts/lcel`. Syntaxe déclarative de composition de chaînes via l'opérateur tube `|` ; chaque composant implémente l'interface `Runnable` (*batch*, asynchrone, *streaming*). Primitive centrale de ce laboratoire (`extraction_prompt | llm`).\n",
+    "2. H. Chase, *LangChain*, octobre 2022, `github.com/langchain-ai/langchain`. Framework modulaire open-source pour applications LLM — chaînes composables, *tools*, mémoire. Référence bibliographique détaillée au Lab 8 (ADK Introduction).\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Lab2-RFP-Analysis (PythonAgentsForDataScience Day2) — audit #3164 fidelity pass.

**Verdict: OMISSION repaired.** The notebook taught LangChain orchestration without anchoring its central concept to a canonical source.

## Central concept identified

The teaching point of Lab2 is **LCEL** (*LangChain Expression Language*) — the declarative pipe-composition syntax `prompt | llm` introduced by cell 5 (the comment explicitly notes « Utiliser LCEL ... au lieu de LLMChain »). This is the primary code pattern the lab teaches.

## Changes (markdown-only, +16/-2)

1. **Enriched step-2 markdown** (cell 4) with a pedagogical section on LCEL: Runnable interface, batch/async/streaming support, and that it replaces the legacy `LLMChain` class.
2. **Appended References section** at notebook end:
   - LCEL → LangChain Expression Language, 2023 (`python.langchain.com/docs/concepts/lcel`)
   - LangChain framework → H. Chase, 2022 (cross-link to Lab8 bibliography — anti-duplication)

## Anti-padding discipline (G.5)

Honest yield = **1 genuine anchor at its teaching point**. The incidental RAG mention in the conclusion (« via RAG ») is NOT anchored — it is not a teaching point here, and RAG is already centrally anchored in Lab13. No padding to reach an arbitrary count.

## Validation

- nbformat JSON valid; 8 code cells unchanged (count preserved), 12 markdown cells (+1 References).
- 0 voluntary errors (`raise NotImplementedError`/`assert False`/`1/0`) in code source.
- Markdown-only patch → no code source change → existing outputs remain coherent (C.2 markdown exception). No re-execution required.
- Catalog byte-identical to `origin/main` (0 churn).
- Fresh branch from `origin/main` (no stale base).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
