### PR TITLE
docs(conway-lean): add Conclusion section to README (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -104,6 +104,32 @@ Kochen-Specker contradiction.
 - Conway & Kochen (2006) — 33-vector proof + Free Will Theorem
 - Peres (1991), Mermin (1993) — simplifications and pedagogy
 
+## Conclusion
+
+Ce workspace formalise en Lean 4 trois facettes de l'oeuvre de John Conway, des algorithmes classiques (Phase 1) au calcul universel du Jeu de la Vie (Phase 2) jusqu'au fondement quantique (Phase 3, Free Will Theorem). Le fil conducteur est la **certification formelle** : chaque résultat est un théorème prouvé, pas une simulation.
+
+### Ce que ce formalisme démontre
+
+- **Les algorithmes classiques** (Doomsday, FRACTRAN, Look-and-Say, Nim, Angel, Collatz) sont prouvés sur leurs instances finies via `native_decide` ou par arguments combinatoires directs (`decide`, `omega`, parité pour Kochen-Specker). Aucun `sorry`.
+- **Le Jeu de la Vie comme moteur de calcul** : règles B3/S23, vaisseaux (LWSS/MWSS/HWSS), oscillateurs (blinker, pulsar p3, pentadecathlon p15), et la méthode Hashlife à accélération exponentielle. La cross-validation sur 12 patterns + eater1 + compositions de planeurs confirme que l'implémentation rapide `evolveHashlifeFast` agree avec la référence `evolve` sur tous les cas testés.
+- **Le Free Will Theorem** (Conway-Kochen 2006/2009) est prouvé depuis les trois axiomes physiques SPIN + TWIN + MIN, en se réduisant à la contradiction 18-vecteurs de Kochen-Specker (Cabello et al. 1996). Phase 3 COMPLETE, sorry-free.
+
+### État honnête du verrou HashlifeCorrectness
+
+Le théorème central `hashlife_correct` (borné par l'hypothèse de padding `BoxAssezGrand`) n'est **pas encore prouvé en pleine généralité** : il reste **7 `sorry`** dans `HashlifeCorrectness.lean`. Le socle est solide — cas de base `k=0` prouvé (`2^16 native_decide`), cas de base `n=0` prouvé, P1/P2/P3 (padding, light-cone, locality) prouvés, `p5_small_n_fallback` prouvé — mais le pas inductif P4 (double-nine decomposition, 5 sorry) et le grand-n P5 (2 sorry, bloqué sur P4) sont **research-level**. Ce sont les cibles du BG-prover (`agent_tests/prover/`), pas des grains bornés : la composition light-cone multi-vagues résiste à l'automatisation tactique courante. Les scaffolds P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_half_steps_compose`, `p4_succ_membership`) énoncent précisément chaque sous-but dans leurs docstrings.
+
+### Leçons méthodologiques
+
+- **`List (Int × Int)` + prédicats `Bool` + `native_decide`** est l'encodage qui passe pour les grilles ; l'encodage `Finset` est bloqué par `Quot.lift`/`Eq.rec`.
+- **Le concept "intractable" cache souvent un énoncé faux** : la même intuition que pour la percée Lattice (7→0) s'applique — le contre-exemple certifié `p4_unrestricted_counterexample` montre qu'une forme d'énoncé non restreinte est fausse, orientant vers la bonne hypothèse `MacroCell.wf`.
+- **Les ingrédients additifs sorry-free** (level/wf preservation, `box_assez_grand` arithmetic) s'accumulent derrière le verrou et seront mobilisables quand P4 cédera.
+
+### Prochaines étapes
+
+1. **BG-prover sur P4** : attaquer le pas inductif double-nine via le harness multi-agent (`agent_tests/prover/`), en s'appuyant sur les scaffolds docstring-restated.
+2. **Sub-claim géométrique sorry-free** : le bound `gridBoundingBox (g').2 ≤ gridBoundingBox g .2 + 2 * jumpSize` (light-cone growth) est un grain additif sur la frame P5.2, dischargeable par arithmétique `Nat` une fois le cas light-cone borué — queueable derrière le verrou P4.
+3. **Extension des témoins** : ajouter des motifs HashlifeMemo supplémentaires (community pillars) pour renforcer le socle `native_decide`.
+
 ## Notes
 
 - Part of the GameTheory Lean series


### PR DESCRIPTION
## Summary

Add a **Conclusion** section to the `conway_lean/README.md` (144 lines, had modules + key results + references but no synthesis). This is part of the #2651 README prose fallback.

## Content (+26 lines, additive pure, 0 deletions, markdown-only)

The Conclusion synthesizes:

1. **What the formalization demonstrates** — across the 3 phases:
   - Classic algorithms (Doomsday, FRACTRAN, Look-and-Say, Nim, Angel, Collatz) proven via `native_decide` / combinatorial arguments, sorry-free.
   - Game of Life as a computation engine: B3/S23 rules, spaceships, oscillators, Hashlife exponential-speedup, cross-validated on 12 patterns.
   - Free Will Theorem (Conway-Kochen 2006/2009) proven from SPIN + TWIN + MIN, reducing to the 18-vector Kochen-Specker contradiction (Phase 3 COMPLETE, sorry-free).

2. **Honest state of the HashlifeCorrectness verrou** — 7 `sorry` remain (5 P4 inductive step + 2 P5 large-n blocked on P4), research-level BG-prover targets. Foundation solid: base case `k=0` proven (`2^16 native_decide`), base `n=0` proven, P1/P2/P3 proven, `p5_small_n_fallback` proven. The P4 scaffolds state each sub-goal precisely in their docstrings.

3. **Methodological lessons** — `List (Int × Int)` + `Bool` predicates + `native_decide` is the encoding that works (Finset blocked by `Quot.lift`/`Eq.rec`); "intractable" often hides a false statement (cf Lattice breakthrough 7→0 and `p4_unrestricted_counterexample`); sorry-free additive ingredients accumulate behind the verrou.

4. **Next steps** — BG-prover on P4 via `agent_tests/prover/`; geometric sorry-free bbox-growth sub-claim (`gridBoundingBox g'.2 ≤ gridBoundingBox g.2 + 2*jumpSize`); HashlifeMemo witness extension.

## Validation

- **Additive pure**: `git diff origin/main` = +26 / -0, single file.
- **Markdown-only**: C.2 exception (no source code change, no outputs).
- **Catalog byte-identical**: only `conway_lean/README.md` in the diff.
- **G.1 verified**: sorry count (7) cross-checked against the existing README Status section (line 8: "7 (all in HashlifeCorrectness.lean — P4 [5] + P5 [2])") and against the actual active sorry lines (1448/1458/1468/1479/1495 P4 + 1800/1809 P5).
- **Fresh branch** from `origin/main` (catalog-pr-hygiene HARD 2).

See #2651.
