### PR TITLE
docs(dsa-lab3): anchor prompt-engineering / GPT-3 reference + References (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb
@@ -159,7 +159,16 @@
     "tags": []
    },
    "source": [
-    "## Étape 2 : Définir l'Agent de Recrutement IA"
+    "## Étape 2 : Définir l'Agent de Recrutement IA\n",
+    "\n",
+    "#### Prompt engineering pour l'extraction structurée\n",
+    "\n",
+    "Ce laboratoire repose sur le **prompt engineering** : on pilote le LLM uniquement par la formulation du prompt, sans aucun entraînement ni *fine-tuning*. Deux techniques sont combinées dans le template ci-dessous :\n",
+    "\n",
+    "* **Role prompting** (ou *persona prompting*) : on assigne un rôle au modèle (« Vous êtes un recruteur senior spécialisé en Data Science ») pour orienter son registre et ses critères d'évaluation.\n",
+    "* **Format de sortie structuré** : on spécifie explicitement le schéma JSON attendu (`competences_correspondantes`, `score_adequation`, …). Le `temperature=0` favorise une sortie déterministe et fidèle à ce schéma.\n",
+    "\n",
+    "Cette capacité à extraire de l'information structurée à partir de texte non structuré (les CVs) par simple instruction est l'illustration directe du paradigme du *prompting* / *in-context learning* introduit par GPT-3 (Brown et al., 2020) : un même modèle pré-entraîné accomplit des tâches variées sans mise à jour de ses poids. La chaîne LangChain (`prompt | llm`) est assemblée en LCEL — voir Lab 2 pour la primitive."
    ]
   },
   {
@@ -487,6 +496,16 @@
       "Exercice a completer\n"
      ]
     }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "1. T. B. Brown, B. Mann, N. Ryder, et al., *Language Models are Few-Shot Learners*, Advances in Neural Information Processing Systems (NeurIPS) 33, 2020, pp. 1877-1901, arXiv:2005.14165. Article fondateur de GPT-3 établissant le paradigme du *prompting* et de l'*in-context learning* : un même modèle accomplit des tâches variées (dont l'extraction structurée) sans *fine-tuning*, uniquement par instruction. Concept central de ce laboratoire.\n",
+    "2. LangChain, *LangChain Expression Language (LCEL)*, 2023, `python.langchain.com/docs/concepts/lcel`. Syntaxe de composition de chaînes (`prompt | llm`) utilisée pour assembler l'agent de recrutement — primitive détaillée au Lab 2.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Lab3-CV-Screening (PythonAgentsForDataScience Day2) — audit #3164 fidelity pass.

**Verdict: OMISSION repaired.** The notebook taught LLM-based structured extraction from unstructured documents (CVs) without anchoring its central concept.

## Central concept identified

The teaching point of Lab3 is **prompt engineering** for structured information extraction: the agent (cell 5) combines *role-prompting* ("Vous êtes un recruteur senior spécialisé en Data Science") + an explicit JSON output schema + `temperature=0`. Objective 3 makes this explicit: « Structurer la sortie du LLM en format JSON exploitable ». The entire lab is built on this technique.

## Changes (markdown-only, +21/-2)

1. **Enriched step-2 markdown** (cell 4) with a pedagogical section on prompt engineering: role-prompting, structured JSON output format, `temperature=0` for determinism, and how this instantiates the *prompting / in-context learning* paradigm.
2. **Appended References section** at notebook end:
   - Prompt engineering / in-context learning → Brown et al. 2020, *Language Models are Few-Shot Learners* (GPT-3), NeurIPS 33, pp.1877-1901, arXiv:2005.14165
   - LCEL → cross-link to Lab2 (anti-duplication)

## Anti-padding discipline (G.5)

Honest yield = **1 genuine anchor at its teaching point**. The ATS mention and the "bias reduction" claim in the conclusion are incidental industry terms/claims, NOT anchored (G.1 — not teaching points). LCEL is already anchored centrally in Lab2.

## Validation

- nbformat JSON valid; 6 code cells unchanged (count preserved), 11 markdown cells (+1 References).
- 0 voluntary errors (`raise NotImplementedError`/`assert False`/`1/0`) in code source.
- Markdown-only patch → no code source change → existing outputs remain coherent (C.2 markdown exception). No re-execution required.
- Catalog byte-identical to `origin/main` (0 churn).
- Fresh branch from `origin/main` (no stale base).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
