### PR TITLE
docs(dsa-lab4): anchor 80/20 rule + IQR/Tukey references + References (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
@@ -52,7 +52,9 @@
     "\n",
     "En Data Science, on dit souvent que 80% du temps est consacré à la préparation et au nettoyage des données, et seulement 20% à l'analyse et à la modélisation. Cette étape, bien que moins glamour, est absolument cruciale. Des données de mauvaise qualité mènent inévitablement à des modèles et des conclusions de mauvaise qualité ('Garbage In, Garbage Out').\n",
     "\n",
-    "Dans ce laboratoire, nous allons aborder de front ce travail de préparation en utilisant un jeu de données volontairement \"sale\"."
+    "Dans ce laboratoire, nous allons aborder de front ce travail de préparation en utilisant un jeu de données volontairement \"sale\".\n",
+    "\n",
+    "> **Origine de la règle.** Cette statistique provient du *CrowdFlower Data Science Report* (2016), une enquête auprès de data scientists popularisée par la presse spécialisée (Forbes, 2016) : environ 80% du temps de travail est consacré à la collecte, au nettoyage et à l'organisation des données, contre ~20% à la modélisation et l'analyse. Elle souligne l'importance — et la rentabilité — des compétences en *data wrangling*."
    ]
   },
   {
@@ -851,7 +853,20 @@
     },
     "tags": []
    },
-   "source": "### Exercice 2 : Detection d'anomalies (methode IQR)\n\nLes valeurs aberrantes (outliers) peuvent fausser vos analyses. Créez une fonction qui :\n1. Calcule les bornes d'une colonne numérique en utilisant la méthode de l'écart interquartile (IQR)\n2. Identifie les transactions dont le chiffre d'affaires est une anomalie (en dehors des bornes)\n3. Affiche le nombre d'anomalies détectées et leurs détails\n\n**Méthode IQR** : Borne inférieure = Q1 - 1.5×IQR, Borne supérieure = Q3 + 1.5×IQR\n\n**Indices** : Utilisez `quantile()` pour obtenir Q1 et Q3, puis un filtre booléen pour identifier les anomalies."
+   "source": [
+    "### Exercice 2 : Detection d'anomalies (methode IQR)\n",
+    "\n",
+    "Les valeurs aberrantes (outliers) peuvent fausser vos analyses. Créez une fonction qui :\n",
+    "1. Calcule les bornes d'une colonne numérique en utilisant la méthode de l'écart interquartile (IQR)\n",
+    "2. Identifie les transactions dont le chiffre d'affaires est une anomalie (en dehors des bornes)\n",
+    "3. Affiche le nombre d'anomalies détectées et leurs détails\n",
+    "\n",
+    "**Méthode IQR** : Borne inférieure = Q1 - 1.5×IQR, Borne supérieure = Q3 + 1.5×IQR\n",
+    "\n",
+    "**Indices** : Utilisez `quantile()` pour obtenir Q1 et Q3, puis un filtre booléen pour identifier les anomalies.\n",
+    "\n",
+    "> **Référence.** La méthode des bornes à 1,5×IQR et le *box-plot* (boîte à moustaches) qui l'illustre ont été introduits par John W. Tukey dans *Exploratory Data Analysis* (Addison-Wesley, 1977), ouvrage fondateur de l'analyse exploratoire de données. Sous une distribution normale, ces bornes signalent environ 0,7% des observations comme potentiellement aberrantes."
+   ]
   },
   {
    "cell_type": "code",
@@ -973,6 +988,17 @@
     "- Agréger les données avec `groupby()` pour obtenir des insights.\n",
     "\n",
     "**Lien avec l'après-midi :** Ces étapes de nettoyage et d'analyse sont exactement le type de tâches qu'un agent d'IA pourra bientôt réaliser de manière autonome. En maîtrisant ces techniques, vous comprenez la logique qu'il faudra implémenter dans les \"outils\" que nous fournirons à nos agents pour qu'ils puissent travailler efficacement avec des données du monde réel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "1. CrowdFlower, *Data Science Report*, 2016 ; vulgarisé par G. Press, *Cleaning Big Data: Most Time-Consuming, Least Enjoyable Data Science Task, Survey Says*, Forbes, 23 mars 2016. Enquête établissant la règle des 80/20 : ~80% du temps des data scientists consacré à la préparation/nettoyage des données. Concept central de l'introduction de ce laboratoire.\n",
+    "2. J. W. Tukey, *Exploratory Data Analysis*, Addison-Wesley, Reading, MA, 1977. Ouvrage fondateur de l'analyse exploratoire de données ; introduit le *box-plot* et la règle des bornes à 1,5×IQR pour la détection de valeurs aberrantes (Exercice 2).\n",
+    "3. W. McKinney, *Data Structures for Statistical Computing in Python*, Proc. SciPy 2010, pp. 51-56. Sous-jacent aux manipulations `DataFrame` de ce laboratoire (pandas) — référence détaillée au Lab 1.3.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Lab4-DataWrangling (PythonAgentsForDataScience Day3) — audit #3164 fidelity pass.

**Verdict: OMISSION repaired.** Two central named concepts were taught without canonical citation.

## Central concepts identified

1. **The 80/20 data-preparation rule** (intro framing, cell 1) — the lab opens on the statistic that ~80% of data-science time is spent on data preparation. Now carries its canonical provenance.
2. **The IQR outlier-detection method** (Exercice 2, cell 23) — a named statistical method taught with explicit formula `Q1 − 1.5×IQR` / `Q3 + 1.5×IQR`.

## Changes (markdown-only, +29/-3)

1. **Enriched cell 1** with a citation note anchoring the 80/20 rule to CrowdFlower 2016 / Press-Forbes 2016.
2. **Enriched cell 23** with a citation note anchoring the IQR/box-plot method to Tukey 1977.
3. **Appended References section**: CrowdFlower 2016, Tukey 1977, McKinney 2010 (pandas, cross-link Lab1.3).

## Anti-padding discipline (G.5)

Honest yield = **2 genuine anchors at their teaching points**. pandas is NOT re-anchored (already central in Lab1.3 / cross-linked Lab1). The "Garbage In, Garbage Out" aphorism is left as passing folklore (G.1 — not a teaching point here).

## Validation

- nbformat JSON valid; 12 code cells unchanged (count preserved), 17 markdown cells (+1 References).
- 0 voluntary errors (`raise NotImplementedError`/`assert False`/`1/0`) in code source.
- Markdown-only patch → no code source change → existing outputs remain coherent (C.2 markdown exception). No re-execution required.
- Catalog byte-identical to `origin/main` (0 churn).
- Fresh branch from `origin/main` (no stale base).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
