### PR TITLE
docs(grothendieck-lean): add Conclusion section to README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -87,3 +87,36 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - Epic #1453 (prover harness calibration)
 - Conway tribute workspace (`../conway_lean/`)
 - Lean notebook series (`../README.md`)
+
+## Conclusion
+
+This tribute is a **complete pedagogical tour** (23 modules, 3182 lines, 0 `sorry`,
+0 axiom added) showing how Grothendieck's language — sites, sheaves,
+sheafification, points, cohomology — already lives in Mathlib 4. It is
+deliberately **not** a formalization of EGA/SGA; it is a curated index that lets
+learners see the library through Grothendieckian eyes.
+
+### The arc
+
+The modules trace a coherent path: **sites and sieves** (Parts 1, 6, 8, 11, 12,
+16) → **sheaves, separation, and transfer** (7, 9, 10, 17) → **sheafification and
+its left exactness** (13, 14) → **points and conservative families** (15, 19) →
+**sheaf cohomology, Mayer-Vietoris, and Čech** (20-23), with **schemes and the
+Zariski site** (2, 3) and a **Mathlib map** (4) anchoring the tour to the library
+it indexes.
+
+### Scope, honestly
+
+Per the `## Sorry count` section above, the tour is **0 `sorry`, 0 axiom added** —
+every result is fully proven. Part 4's `#check` index is explicit about what
+Mathlib has and what it does not (yet); the tour documents that boundary rather
+than papering over it. The companion `Calibration.lean` (Part 5) feeds the prover
+harness (Epic #1453), tying this formalization to the broader proving effort.
+
+### Where to go next
+
+- **Depth**: Issue #2159 / Epic #1646 track further formalization — this tour is
+  the foundation, not the ceiling.
+- **Companions**: `conway_lean/` (Conway's mathematics), the Lean notebook series.
+- **References**: Mac Lane–Moerdijk and SGA 4 for the topos-theoretic core; Vakil
+  and the Stacks Project for schemes and cohomology.


### PR DESCRIPTION
See #2651 (partial — prose Conclusion for the grothendieck_lean sous-série,
epic ongoing).

## Context

`grothendieck_lean/README.md` (89 lines) documented the tour's purpose, 23-module
structure, build, sorry count, toolchain, and references — but had **no
Conclusion**. 2nd fallback #2651 grain (ai-01 directive 07:39Z: "knot_lean /
grothendieck_lean READMEs"; knot_lean shipped as #3829 this same cycle).

## What

Adds a `## Conclusion` section (+33 lines, single file, English to match the
README's language):

- **The arc** — the 23 modules trace sites/sieves → sheaves/transfer →
  sheafification/left-exactness → points/conservative-families → sheaf
  cohomology/Mayer-Vietoris/Čech, with schemes/Zariski-site + Mathlib map as
  anchors.
- **Scope, honestly** — anchored to the `## Sorry count` section: 0 `sorry`, 0
  axiom added; Part 4 `#check` index documents what Mathlib has/doesn't;
  `Calibration.lean` (Part 5) feeds the prover harness (Epic #1453).
- **Where to go next** — Issue #2159 / Epic #1646 for depth; `conway_lean`
  companion; references.

## G.1 grounding

Every claim anchored in the existing README: module parts from the structure
table (lines 27-49), `## Sorry count` (line 64), Part 4/5 roles (lines 30-31),
Epic #1646 / Issue #2159 / Epic #1453 (lines 84-87). Pure synthesis — no new
assertion. The README is a **complete tour** (0 sorry), so this is a
completion-style Conclusion, not a "lock" Conclusion.

## Validation

- **Markdown-only** (C.2 exception — no code/output cells touched).
- **Additive pure** `+33/-0`, single file, 89 → 122 lines.
- **Catalog byte-identical** (no churn — catalog-guard will pass).
- **Atomique** (HARD 3): one deliverable, one README.
- Fresh branch on `origin/main` (`0 0` ahead/behind at creation).

## Scope honesty (rule-E)

Proportionate to an 89-line concise tour README (~30-line Conclusion, not the
~50-line synthesis used for the meatier 226-line knot_lean #3829). #2651 batch
pattern (cf. #3817-#3826, #3829 all merged/open this sprint).

@ai-01 — review/merge. No `*.lean` touched → no Lake build required.