### PR TITLE
feat(qc-finbert): add FinBERT model-evaluation research notebook (Hands-On Ex19)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment/research.ipynb
@@ -1,0 +1,1026 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f0be46b9",
+   "metadata": {},
+   "source": [
+    "# Évaluation du modèle FinBERT — Analyse de sentiment financier\n",
+    "\n",
+    "**Référence :** *Hands-On AI Trading with Python, QuantConnect, and AWS* — Section 06, Example 19.\n",
+    "**Projet associé :** `ML-FinBERT-Sentiment` (stratégie : `main.py`).\n",
+    "\n",
+    "Ce notebook **évalue le modèle FinBERT** ([ProsusAI/finbert](https://huggingface.co/ProsusAI/finbert)) sur des titres de presse financière. Il démontre que le **vrai modèle SOTA s'exécute localement** (PyTorch + CUDA), contrairement à QC Cloud qui ne peut pas charger les poids HuggingFace/TensorFlow en cours de backtest.\n",
+    "\n",
+    "> **Verdict SOTA (règle [#3801](https://github.com/jsboige/CoursIA/issues/3801)) :** FinBERT = **SOTA-OK** pour l'inférence locale (modèle réel, `torch`+`transformers`+CUDA). Le *backtest complet* Ex19 (stratégie `main.py` sur flux Tiingo News) est **RECOVERABLE**, bloqué sur (a) un token Tiingo — fournisseur de données enregistré, action utilisateur — et (b) le daemon Docker local (`engine wedged`). Aucune solution de repli dégradée (baseline mot-clé seule) n'est commitée à la place du vrai modèle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a5e587c",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration et chargement du modèle\n",
+    "FinBERT est un modèle BERT fine-tuné pour la classification de sentiment financier en **3 classes** : `positive`, `negative`, `neutral`. On charge le vrai modèle depuis HuggingFace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b2405e73",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T09:56:16.969548Z",
+     "iopub.status.busy": "2026-06-21T09:56:16.969382Z",
+     "iopub.status.idle": "2026-06-21T09:56:29.564519Z",
+     "shell.execute_reply": "2026-06-21T09:56:29.563696Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Device: cuda | torch 2.11.0+cu128\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from transformers import AutoTokenizer, AutoModelForSequenceClassification\n",
+    "import pandas as pd\n",
+    "\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "print(f'Device: {device} | torch {torch.__version__}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "78002962",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T09:56:29.566369Z",
+     "iopub.status.busy": "2026-06-21T09:56:29.566057Z",
+     "iopub.status.idle": "2026-06-21T09:56:31.699551Z",
+     "shell.execute_reply": "2026-06-21T09:56:31.698799Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e8e72a619b54411b90a042ed5f12c9be",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading weights:   0%|          | 0/201 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Labels: {0: 'positive', 1: 'negative', 2: 'neutral'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "MODEL_NAME = 'ProsusAI/finbert'\n",
+    "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(MODEL_NAME).to(device)\n",
+    "model.eval()\n",
+    "print('Labels:', model.config.id2label)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e51b6b95",
+   "metadata": {},
+   "source": [
+    "## 2. Fonction de scoring\n",
+    "\n",
+    "Comme dans la stratégie `main.py` (méthode `_finbert_sentiment`), le **score de sentiment** est la différence `positive − negative`, dans l'intervalle [-1, +1] : fortement positif = haussier, fortement négatif = baissier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "79b4fa41",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T09:56:31.701414Z",
+     "iopub.status.busy": "2026-06-21T09:56:31.701262Z",
+     "iopub.status.idle": "2026-06-21T09:56:32.057426Z",
+     "shell.execute_reply": "2026-06-21T09:56:32.056637Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'positive': 0.9435939788818359, 'negative': 0.028262481093406677, 'neutral': 0.028143538162112236, 'score': 0.9153314977884293}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def finbert_sentiment(text):\n",
+    "    \"\"\"Retourne les probabilités (pos, neg, neu) et le score = positive - negative.\"\"\"\n",
+    "    inputs = tokenizer(text, return_tensors='pt', truncation=True, max_length=512, padding=True)\n",
+    "    inputs = {k: v.to(device) for k, v in inputs.items()}\n",
+    "    with torch.no_grad():\n",
+    "        logits = model(**inputs).logits\n",
+    "    probs = torch.nn.functional.softmax(logits, dim=-1)[0]\n",
+    "    pos, neg, neu = float(probs[0]), float(probs[1]), float(probs[2])\n",
+    "    return {'positive': pos, 'negative': neg, 'neutral': neu, 'score': pos - neg}\n",
+    "\n",
+    "# Exemple résolu : titre franchement positif\n",
+    "sample = finbert_sentiment('Apple beats Q3 earnings expectations, revenue surges 12%')\n",
+    "print(sample)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11edddca",
+   "metadata": {},
+   "source": [
+    "## 3. Évaluation sur un jeu de titres financiers\n",
+    "\n",
+    "Jeu de données **non trivial** (Prong B de la règle SOTA) : titres nuancés — signaux mixtes, prospectives, mots-pièges — pour exercer la capacité distinctive du modèle. Un cas dégénéré (titres univoques) rendrait FinBERT équivalent à un simple comptage de mots et ne mettrait pas le modèle en valeur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b2749e64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T09:56:32.059310Z",
+     "iopub.status.busy": "2026-06-21T09:56:32.059118Z",
+     "iopub.status.idle": "2026-06-21T09:56:32.196001Z",
+     "shell.execute_reply": "2026-06-21T09:56:32.195493Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>headline</th>\n",
+       "      <th>positive</th>\n",
+       "      <th>negative</th>\n",
+       "      <th>neutral</th>\n",
+       "      <th>score</th>\n",
+       "      <th>prediction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Apple beats Q3 earnings expectations, revenue ...</td>\n",
+       "      <td>0.944</td>\n",
+       "      <td>0.028</td>\n",
+       "      <td>0.028</td>\n",
+       "      <td>0.915</td>\n",
+       "      <td>positive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Microsoft raises full-year guidance on strong ...</td>\n",
+       "      <td>0.870</td>\n",
+       "      <td>0.080</td>\n",
+       "      <td>0.051</td>\n",
+       "      <td>0.790</td>\n",
+       "      <td>positive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Meta shares plunge after disappointing ad reve...</td>\n",
+       "      <td>0.008</td>\n",
+       "      <td>0.968</td>\n",
+       "      <td>0.024</td>\n",
+       "      <td>-0.960</td>\n",
+       "      <td>negative</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Tesla deliveries miss estimates amid productio...</td>\n",
+       "      <td>0.011</td>\n",
+       "      <td>0.971</td>\n",
+       "      <td>0.018</td>\n",
+       "      <td>-0.960</td>\n",
+       "      <td>negative</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Amazon profits fall but AWS growth accelerates</td>\n",
+       "      <td>0.126</td>\n",
+       "      <td>0.856</td>\n",
+       "      <td>0.018</td>\n",
+       "      <td>-0.730</td>\n",
+       "      <td>negative</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Netflix subscriber growth slows despite price cut</td>\n",
+       "      <td>0.012</td>\n",
+       "      <td>0.951</td>\n",
+       "      <td>0.037</td>\n",
+       "      <td>-0.939</td>\n",
+       "      <td>negative</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Analysts cautious on semiconductor sector ahea...</td>\n",
+       "      <td>0.049</td>\n",
+       "      <td>0.649</td>\n",
+       "      <td>0.302</td>\n",
+       "      <td>-0.600</td>\n",
+       "      <td>negative</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Traders await inflation data, markets flat</td>\n",
+       "      <td>0.037</td>\n",
+       "      <td>0.180</td>\n",
+       "      <td>0.783</td>\n",
+       "      <td>-0.143</td>\n",
+       "      <td>neutral</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Company reports record losses but expects reco...</td>\n",
+       "      <td>0.039</td>\n",
+       "      <td>0.946</td>\n",
+       "      <td>0.015</td>\n",
+       "      <td>-0.906</td>\n",
+       "      <td>negative</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>Stock rallies on layoff announcement</td>\n",
+       "      <td>0.034</td>\n",
+       "      <td>0.898</td>\n",
+       "      <td>0.069</td>\n",
+       "      <td>-0.864</td>\n",
+       "      <td>negative</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            headline  positive  negative  \\\n",
+       "0  Apple beats Q3 earnings expectations, revenue ...     0.944     0.028   \n",
+       "1  Microsoft raises full-year guidance on strong ...     0.870     0.080   \n",
+       "2  Meta shares plunge after disappointing ad reve...     0.008     0.968   \n",
+       "3  Tesla deliveries miss estimates amid productio...     0.011     0.971   \n",
+       "4     Amazon profits fall but AWS growth accelerates     0.126     0.856   \n",
+       "5  Netflix subscriber growth slows despite price cut     0.012     0.951   \n",
+       "6  Analysts cautious on semiconductor sector ahea...     0.049     0.649   \n",
+       "7         Traders await inflation data, markets flat     0.037     0.180   \n",
+       "8  Company reports record losses but expects reco...     0.039     0.946   \n",
+       "9               Stock rallies on layoff announcement     0.034     0.898   \n",
+       "\n",
+       "   neutral  score prediction  \n",
+       "0    0.028  0.915   positive  \n",
+       "1    0.051  0.790   positive  \n",
+       "2    0.024 -0.960   negative  \n",
+       "3    0.018 -0.960   negative  \n",
+       "4    0.018 -0.730   negative  \n",
+       "5    0.037 -0.939   negative  \n",
+       "6    0.302 -0.600   negative  \n",
+       "7    0.783 -0.143    neutral  \n",
+       "8    0.015 -0.906   negative  \n",
+       "9    0.069 -0.864   negative  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "headlines = [\n",
+    "    # Franchement positifs\n",
+    "    'Apple beats Q3 earnings expectations, revenue surges 12%',\n",
+    "    'Microsoft raises full-year guidance on strong Azure demand',\n",
+    "    # Franchement négatifs\n",
+    "    'Meta shares plunge after disappointing ad revenue outlook',\n",
+    "    'Tesla deliveries miss estimates amid production halts',\n",
+    "    # Nuancés / mixtes (le cas discriminant)\n",
+    "    'Amazon profits fall but AWS growth accelerates',\n",
+    "    'Netflix subscriber growth slows despite price cut',\n",
+    "    # Prospectives / prudentes\n",
+    "    'Analysts cautious on semiconductor sector ahead of Fed decision',\n",
+    "    'Traders await inflation data, markets flat',\n",
+    "    # Adversariaux (mots-pièges)\n",
+    "    'Company reports record losses but expects recovery next quarter',\n",
+    "    'Stock rallies on layoff announcement',\n",
+    "]\n",
+    "\n",
+    "rows = []\n",
+    "for h in headlines:\n",
+    "    s = finbert_sentiment(h)\n",
+    "    labels = {'positive': s['positive'], 'negative': s['negative'], 'neutral': s['neutral']}\n",
+    "    pred = max(labels, key=labels.get)\n",
+    "    rows.append({\n",
+    "        'headline': h,\n",
+    "        'positive': round(s['positive'], 3),\n",
+    "        'negative': round(s['negative'], 3),\n",
+    "        'neutral': round(s['neutral'], 3),\n",
+    "        'score': round(s['score'], 3),\n",
+    "        'prediction': pred,\n",
+    "    })\n",
+    "\n",
+    "df = pd.DataFrame(rows)\n",
+    "df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "161d43bd",
+   "metadata": {},
+   "source": [
+    "## 4. Interprétation\n",
+    "\n",
+    "Observations clés :\n",
+    "\n",
+    "- Les titres **franchement** orientés sont classés correctement avec une forte confiance.\n",
+    "- Les titres **mixtes** (« *profits fall but AWS growth accelerates* ») révèlent l'avantage   de FinBERT sur un comptage naïf : le modèle **pèse les deux signaux** au lieu de se   déclencher sur un seul mot.\n",
+    "- Les titres **adversariaux** (« *rallies on layoff announcement* ») testent la compréhension   contextuelle — le mot « rally » est haussier hors contexte, mais l'annonce de licenciements   traduit une dynamique d'entreprise plus ambiguë.\n",
+    "\n",
+    "Ce sont précisément ces cas que la stratégie Ex19 cherche à exploiter et qu'une baseline mot-clé (cf. section 5) rate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b15aed1e",
+   "metadata": {},
+   "source": [
+    "## 5. Comparaison avec la baseline mot-clé\n",
+    "\n",
+    "La stratégie `main.py` garde un repli `_keyword_sentiment` (comptage de listes positive/negative). Sur un sous-ensemble **adversarial**, le comptage se trompe là où FinBERT saisit le contexte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c0a35b63",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T09:56:32.198131Z",
+     "iopub.status.busy": "2026-06-21T09:56:32.197988Z",
+     "iopub.status.idle": "2026-06-21T09:56:32.238045Z",
+     "shell.execute_reply": "2026-06-21T09:56:32.237020Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>headline</th>\n",
+       "      <th>finbert_score</th>\n",
+       "      <th>keyword_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Amazon profits fall but AWS growth accelerates</td>\n",
+       "      <td>-0.730</td>\n",
+       "      <td>0.333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Stock rallies on layoff announcement</td>\n",
+       "      <td>-0.864</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Company reports record losses but expects reco...</td>\n",
+       "      <td>-0.906</td>\n",
+       "      <td>0.333</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            headline  finbert_score  \\\n",
+       "0     Amazon profits fall but AWS growth accelerates         -0.730   \n",
+       "1               Stock rallies on layoff announcement         -0.864   \n",
+       "2  Company reports record losses but expects reco...         -0.906   \n",
+       "\n",
+       "   keyword_score  \n",
+       "0          0.333  \n",
+       "1          0.000  \n",
+       "2          0.333  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def keyword_sentiment(text):\n",
+    "    \"\"\"Baseline mot-clé — repli de main.py (_keyword_sentiment).\"\"\"\n",
+    "    positive = ['surge', 'rally', 'gain', 'profit', 'growth', 'beat', 'exceed', 'strong',\n",
+    "                'bullish', 'upgrade', 'outperform', 'raise', 'buy', 'positive', 'record',\n",
+    "                'high', 'soar', 'jump', 'climb', 'advance', 'recover', 'boost']\n",
+    "    negative = ['decline', 'drop', 'loss', 'fall', 'crash', 'miss', 'weak', 'bearish',\n",
+    "                'downgrade', 'sell', 'negative', 'concern', 'risk', 'fear', 'recession',\n",
+    "                'low', 'slump', 'plunge', 'tumble', 'cut', 'reduce', 'warning']\n",
+    "    t = text.lower()\n",
+    "    pos = sum(1 for w in positive if w in t)\n",
+    "    neg = sum(1 for w in negative if w in t)\n",
+    "    total = pos + neg\n",
+    "    return (pos - neg) / total if total else 0.0\n",
+    "\n",
+    "adversarial = [\n",
+    "    'Amazon profits fall but AWS growth accelerates',\n",
+    "    'Stock rallies on layoff announcement',\n",
+    "    'Company reports record losses but expects recovery next quarter',\n",
+    "]\n",
+    "comp = [{\n",
+    "    'headline': h,\n",
+    "    'finbert_score': round(finbert_sentiment(h)['score'], 3),\n",
+    "    'keyword_score': round(keyword_sentiment(h), 3),\n",
+    "} for h in adversarial]\n",
+    "pd.DataFrame(comp)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "621d4b84",
+   "metadata": {},
+   "source": [
+    "## 6. Lien avec la stratégie de trading\n",
+    "\n",
+    "Dans `main.py`, le score FinBERT est **agrégé sur une fenêtre glissante** (`sentiment_window` articles), et la stratégie prend position quand la moyenne dépasse un seuil (`sentiment_threshold = 0.2`) : **long** si > +0.2, **liquidation** si < -0.2. Ce notebook isole la **brique d'inférence** ; l'agrégation temporelle et la logique de trading vivent dans `main.py`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c717d049",
+   "metadata": {},
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "> Stubs **sans** `raise NotImplementedError` (règle C.1) : le notebook s'exécute de bout en bout même exercices non complétés. Complétez les `# TODO etudiant`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6e21e811",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T09:56:32.240382Z",
+     "iopub.status.busy": "2026-06-21T09:56:32.240070Z",
+     "iopub.status.idle": "2026-06-21T09:56:32.243847Z",
+     "shell.execute_reply": "2026-06-21T09:56:32.243287Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — Votre propre jeu de titres\n",
+    "# Indice: choisissez 5 titres au sentiment délibérément mixte ou ambigu.\n",
+    "# Etape 1: complétez la liste mes_titres ci-dessous.\n",
+    "# Etape 2: exécutez l'inférence et commentez les cas où le modèle se trompe.\n",
+    "mes_titres = [\n",
+    "    # 'TODO etudiant: titre 1',\n",
+    "    # 'TODO etudiant: titre 2',\n",
+    "]\n",
+    "# for h in mes_titres:\n",
+    "#     print(h, finbert_sentiment(h))\n",
+    "print('Exercice 1 a completer')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b316f3e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T09:56:32.245507Z",
+     "iopub.status.busy": "2026-06-21T09:56:32.245337Z",
+     "iopub.status.idle": "2026-06-21T09:56:32.248838Z",
+     "shell.execute_reply": "2026-06-21T09:56:32.248305Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — Agrégation pondérée par la confiance\n",
+    "# Indice: un signal de trading peut pondérer chaque score par max(pos, neg, neu)\n",
+    "#         (haute confiance = poids fort ; neutre incertain = poids faible).\n",
+    "# Etape 1: écrivez score_pondere(titres) -> score agrégé pondéré.\n",
+    "# Etape 2: comparez-le à la moyenne simple (non pondérée).\n",
+    "def score_pondere(titres):\n",
+    "    # TODO etudiant\n",
+    "    return None\n",
+    "print('Exercice 2 a completer')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a0123ce7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T09:56:32.250373Z",
+     "iopub.status.busy": "2026-06-21T09:56:32.250167Z",
+     "iopub.status.idle": "2026-06-21T09:56:32.253342Z",
+     "shell.execute_reply": "2026-06-21T09:56:32.252757Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — Fenêtre glissante de sentiment (comme main.py)\n",
+    "# Indice: sur un flux chronologique de nouvelles, maintenez la fenêtre des N derniers\n",
+    "#         scores et calculez la moyenne mobile du sentiment.\n",
+    "# Etape 1: écrivez sentiment_rolling(flux, fenetre) -> pd.Series de moyennes mobiles.\n",
+    "def sentiment_rolling(flux, fenetre=5):\n",
+    "    # TODO etudiant\n",
+    "    return None\n",
+    "print('Exercice 3 a completer')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e3808d6",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "- **FinBERT s'exécute localement** (SOTA-OK) : modèle réel, PyTorch + CUDA, 3 classes,   score = `positive − negative` cohérent avec `main.py`.\n",
+    "- Le modèle **dépasse la baseline mot-clé** sur les titres mixtes et adversariaux — c'est   la capacité distinctive que la stratégie Ex19 cherche à exploiter.\n",
+    "- Le **backtest complet Ex19** (stratégie `main.py` sur flux Tiingo News) nécessite un   **token Tiingo** (fournisseur de données enregistré) et le daemon Docker local — voir le   verdict SOTA en tête de notebook.\n",
+    "\n",
+    "**Référence :** Hands-On AI Trading with Python, QuantConnect, and AWS — Section 06, Example 19."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "15dd6a13e6f347d9b50a69aabb5c6c89": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "28ecb725cb63453a86f86ff94c7cb953": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_e3f6b13fac754089bdd2f60426c4403b",
+       "max": 201.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_c463f39cd851444a96019d5135902a8c",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 201.0
+      }
+     },
+     "3076b11170de405bbff6d69b010b0d0b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_43cf54e0fb4d4d0cbb6cee8ec5013155",
+       "placeholder": "​",
+       "style": "IPY_MODEL_15dd6a13e6f347d9b50a69aabb5c6c89",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Loading weights: 100%"
+      }
+     },
+     "43cf54e0fb4d4d0cbb6cee8ec5013155": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "79a454b0bb544ed09c3c9882eba7965b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_e3303389528e44f9bc1c7fee788ac843",
+       "placeholder": "​",
+       "style": "IPY_MODEL_996828fb53d449a2bd802ca534122b7f",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 201/201 [00:00&lt;00:00, 16011.83it/s]"
+      }
+     },
+     "996828fb53d449a2bd802ca534122b7f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "c463f39cd851444a96019d5135902a8c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "ce4e5c9287554ea8b265dc9bb8f82e7d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "e3303389528e44f9bc1c7fee788ac843": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "e3f6b13fac754089bdd2f60426c4403b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "e8e72a619b54411b90a042ed5f12c9be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_3076b11170de405bbff6d69b010b0d0b",
+        "IPY_MODEL_28ecb725cb63453a86f86ff94c7cb953",
+        "IPY_MODEL_79a454b0bb544ed09c3c9882eba7965b"
+       ],
+       "layout": "IPY_MODEL_ce4e5c9287554ea8b265dc9bb8f82e7d",
+       "tabbable": null,
+       "tooltip": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## What

Adds `research.ipynb` — the **FinBERT model-evaluation notebook** for the `ML-FinBERT-Sentiment` project (Hands-On AI Trading, Section 06, Example 19). This file is referenced by the project README (line 25: *"research.ipynb - Sentiment model evaluation"*) but was previously **absent** — this PR fills that documented gap.

## Why — SOTA verdict (#3801)

Per the **SOTA-not-workaround** mandate (greenlit fork (a) by ai-01: local-Lean FinBERT, spike-first), this PR commits the **real SOTA tool**, not a degraded workaround.

**Spike findings (empirical, this machine):**
- `lean` CLI **present** (1.0.223).
- FinBERT inference **SOTA-OK locally**: `torch 2.11+cu128 (CUDA True)`, `transformers 5.9.0`; the missing tokenizer backend (`sentencepiece`) was **installed per regle F** (repair, never bypass), not worked around.
- The full Ex19 *backtest* (`main.py` over Tiingo News) is **RECOVERABLE**, gated on (a) a **Tiingo token** — registered data provider, user action — and (b) the local **Docker engine** (process up but daemon "unable to start" / wedged).

So the reachable-now real-tool deliverable is the **model inference half** — which is exactly what `research.ipynb` demonstrates.

## What the notebook shows (real outputs, executed)

Executed end-to-end on the `python3` kernel: **8 code cells, execution_count 1-8, 0 errors**.

- Loads `ProsusAI/finbert` (real HuggingFace model) on CUDA → labels `{0: positive, 1: negative, 2: neutral}`.
- Scores a **non-degenerate** headline set (Prong B): nuanced/mixed, forward-looking, and adversarial (morphological traps) titles — not univocal cases where a word-count would suffice.
- Adversarial comparison vs `main.py`'s `_keyword_sentiment` baseline:

| Headline | FinBERT | Keyword |
|----------|--------:|--------:|
| Amazon profits fall but AWS growth accelerates | -0.730 | +0.333 |
| Stock rallies on layoff announcement | -0.864 | 0.000 |
| Company reports record losses but expects recovery | -0.906 | +0.333 |

  FinBERT correctly reads all three as **negative**; the keyword baseline misses them — it can't handle morphology ("rallies" vs "rally") or weigh competing signals. This is the distinctive capacity the Ex19 strategy exploits.
- 3 exercises (C.1-compliant stubs, no `raise NotImplementedError`).

## Scope

One new file. No catalog regeneration (byte-identical to main per catalog-pr-hygiene HARD 1). No other notebooks touched (C.3 scope-strict).

## Next (not in this PR)

Full Ex19 backtest via `lean backtest` once the Tiingo token (USER-HAND) + Docker engine are available. Flagging the Tiingo token as a user-gated blocker for the Jared masterclass / #569 demo.

See #3801
