### PR TITLE
docs(dsa-lab5): anchor logistic regression + ROC references + References (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
@@ -464,7 +464,11 @@
     "tags": []
    },
    "source": [
-    "## Étape 3 : Introduction au Machine Learning - Classification"
+    "## Étape 3 : Introduction au Machine Learning - Classification\n",
+    "\n",
+    "#### Régression logistique\n",
+    "\n",
+    "Pour cette première tâche de **classification supervisée**, nous utilisons la **régression logistique** : un modèle linéaire qui estime la probabilité d'appartenance à chaque classe via la fonction logistique (sigmoïde). C'est l'un des classifieurs les plus utilisés et les plus interprétables ; introduit formellement par Cox (1958) pour la régression de variables binaires, il reste une référence pédagogique incontournable. Scikit-learn l'expose via la classe `LogisticRegression`."
    ]
   },
   {
@@ -781,7 +785,21 @@
   {
    "cell_type": "markdown",
    "id": "e9fe6ce9",
-   "source": "### Exercice 4 : Courbe ROC et evaluation visuelle du modele\n\nL'accuracy et la matrice de confusion donnent une vision globale, mais la courbe ROC (Receiver Operating Characteristic) permet de visualiser le compromis entre le taux de vrais positifs et le taux de faux positifs a differents seuils de decision. Vous allez tracer la courbe ROC pour la classification binaire (chiffre d'affaires eleve vs. bas).\n\n**Objectif** : Construire une cible binaire (`ca_eleve` = 1 si `chiffre_affaires > 50`), entrainer un `LogisticRegression`, puis tracer la courbe ROC avec `sklearn.metrics.roc_curve`.\n\n**Indices** :\n- Creez la cible binaire : `df_clean['ca_eleve'] = (df_clean['chiffre_affaires'] > 50).astype(int)`\n- Utilisez `roc_curve(y_test_bin, y_proba)` ou `y_proba = model.predict_proba(X_test_bin)[:, 1]`\n- Tracez avec `plt.plot(fpr, tpr)` et ajoutez la diagonale de reference `plt.plot([0,1], [0,1], '--', color='gray')`\n- Calculez l'AUC avec `roc_auc_score(y_test_bin, y_proba)`",
+   "source": [
+    "### Exercice 4 : Courbe ROC et evaluation visuelle du modele\n",
+    "\n",
+    "L'accuracy et la matrice de confusion donnent une vision globale, mais la courbe ROC (Receiver Operating Characteristic) permet de visualiser le compromis entre le taux de vrais positifs et le taux de faux positifs a differents seuils de decision. Vous allez tracer la courbe ROC pour la classification binaire (chiffre d'affaires eleve vs. bas).\n",
+    "\n",
+    "**Objectif** : Construire une cible binaire (`ca_eleve` = 1 si `chiffre_affaires > 50`), entrainer un `LogisticRegression`, puis tracer la courbe ROC avec `sklearn.metrics.roc_curve`.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Creez la cible binaire : `df_clean['ca_eleve'] = (df_clean['chiffre_affaires'] > 50).astype(int)`\n",
+    "- Utilisez `roc_curve(y_test_bin, y_proba)` ou `y_proba = model.predict_proba(X_test_bin)[:, 1]`\n",
+    "- Tracez avec `plt.plot(fpr, tpr)` et ajoutez la diagonale de reference `plt.plot([0,1], [0,1], '--', color='gray')`\n",
+    "- Calculez l'AUC avec `roc_auc_score(y_test_bin, y_proba)`\n",
+    "\n",
+    "> **Référence.** La courbe ROC et l'AUC sont issues de la théorie du signal (radars, années 1950) et popularisées en apprentissage automatique par Fawcett (2006), *An Introduction to ROC Analysis*, Pattern Recognition Letters 27(8):861-874. L'AUC (aire sous la courbe) résume la performance du classifieur sur tous les seuils."
+   ],
    "metadata": {}
   },
   {
@@ -798,6 +816,18 @@
       "Exercice 4 a completer : courbe ROC et AUC\n"
      ]
     }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "1. D. R. Cox, *The Regression Analysis of Binary Sequences*, Journal of the Royal Statistical Society: Series B (Methodological) 20(2), 1958, pp. 215-232. Origine formelle de la régression logistique pour les variables binaires — classifieur central de l'Étape 3 de ce laboratoire.\n",
+    "2. T. Fawcett, *An Introduction to ROC Analysis*, Pattern Recognition Letters 27(8), 2006, pp. 861-874. Référence canonique de la courbe ROC et de l'AUC (Exercice 4).\n",
+    "3. F. Pedregosa et al., *Scikit-learn: Machine Learning in Python*, JMLR 12, 2011, pp. 2825-2830. Implémentation `LogisticRegression` / `roc_curve` / `train_test_split` — référence détaillée au Lab 1.\n",
+    "4. J. W. Tukey, *Exploratory Data Analysis*, Addison-Wesley, 1977. Cadre de l'EDA (Étape 2) — référence détaillée au Lab 4.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Lab5-Viz-ML (PythonAgentsForDataScience Day3) — audit #3164 fidelity pass.

**Verdict: OMISSION repaired.** Two central named concepts were taught without canonical citation.

## Central concepts identified

1. **Logistic Regression** (Étape 3, core ML classifier, objective 3) — the lab's central supervised-classification model (`LogisticRegression` from scikit-learn).
2. **ROC curve / AUC** (Exercice 4, cell 27) — a named evaluation method with substantial pedagogical content (TPR/FPR tradeoff, AUC computation).

## Changes (markdown-only, +33/-3)

1. **Enriched cell 13** (Étape 3 header) with a pedagogical note on logistic regression + Cox 1958 citation.
2. **Enriched cell 27** (ROC exercise) with a citation note anchoring ROC/AUC to Fawcett 2006.
3. **Appended References section**: Cox 1958, Fawcett 2006, Pedregosa 2011 (scikit-learn, cross-link Lab1), Tukey 1977 (EDA, cross-link Lab4).

## Anti-padding discipline (G.5)

Honest yield = **2 genuine anchors at their teaching points**. EDA (Tukey 1977) and pandas (McKinney 2010) are NOT re-anchored — already central in Lab4/Lab1.3, cross-linked here. Confusion matrix and accuracy are standard evaluation tools mentioned without a distinct teaching point → not separately anchored (G.1).

## Validation

- nbformat JSON valid; 10 code cells unchanged (count preserved), 20 markdown cells (+1 References).
- 0 voluntary errors (`raise NotImplementedError`/`assert False`/`1/0`) in code source.
- Markdown-only patch → no code source change → existing outputs remain coherent (C.2 markdown exception). No re-execution required.
- Catalog byte-identical to `origin/main` (0 churn).
- Fresh branch from `origin/main` (no stale base).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
