### PR TITLE
fix(prover): long sessions on hard nuts — 2700s cap + build-credited timer + warm cache (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -84,6 +84,15 @@ class LeanVerifier:
 
     _cache: Dict[str, dict] = {}
 
+    # Cumulative wall-clock seconds spent inside actual `lake build` subprocess
+    # calls (cache hits never reach the builder, so they don't count). Class-level
+    # so every verifier instance — including the latch-verifier the workflow
+    # spins up — accrues to the SAME counter. The prover's wall-clock supervisor
+    # reads this to credit build time back to the reasoning budget ("pause the
+    # timer during builds", user mandate 2026-06-21): a long compile must not
+    # eat the time the agents need to reason on hard nuts.
+    _total_build_seconds: float = 0.0
+
     def __init__(self, project_dir: str = None, verbose: bool = False):
         self.project_dir = project_dir or os.getenv("LEAN_PROJECT_DIR")
         self.verbose = verbose
@@ -193,6 +202,8 @@ class LeanVerifier:
                 env=env,
             )
             duration = time.time() - start
+            # Credit this compile against the prover's reasoning budget.
+            LeanVerifier._total_build_seconds += duration
 
             output = result.stdout + "\n" + result.stderr
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -515,13 +515,52 @@ class MultiAgentSorryProver:
             # problem size; the CEILING keeps any single BG run under the cron.
             sorry_cap = max(original_sorry_count * PER_UNIT_S, PER_UNIT_S)
             workflow_timeout_s = min(iteration_cap, sorry_cap, CEILING_S)
+        # Surface the (build-credited) budget to the agents' time tool so they
+        # pace to the real ceiling instead of the 1800s default.
+        try:
+            state.max_session_seconds = float(workflow_timeout_s)
+        except Exception:
+            pass
         session_start = time.time()
         self.trace.start_session_span(demo["name"], "multi")
         proof_found = False
         try:
-            result = await _asyncio.wait_for(
-                workflow.run(initial_msg), timeout=workflow_timeout_s,
-            )
+            # Build-credited wall-clock supervisor (user mandate 2026-06-21:
+            # "mettre en pause le timer de mesure pendant les builds"). A single
+            # `asyncio.wait_for` would count `lake build` time against the cap,
+            # starving the reasoning the agents need on hard nuts. Instead we
+            # poll: the effective deadline EXTENDS by the seconds spent compiling
+            # since this session started, so `workflow_timeout_s` measures
+            # reasoning time, not compile time. Caching (content-hash + olean
+            # incremental `-R`) keeps the credited build time small; the credit
+            # covers the irreducible compiles that remain.
+            # Resolve the SAME LeanVerifier class the tools build through (the
+            # package uses a spec-based loader, not a normal import — see
+            # verifier.py), so we read the class-level build accumulator instances
+            # actually write to.
+            from .verifier import _load_lean_verifier_class
+            _LeanVerifier = _load_lean_verifier_class()
+            _build_at_start = _LeanVerifier._total_build_seconds
+            _POLL_S = 30
+            _wf_task = _asyncio.ensure_future(workflow.run(initial_msg))
+            result = None
+            while True:
+                try:
+                    result = await _asyncio.wait_for(
+                        _asyncio.shield(_wf_task), timeout=_POLL_S,
+                    )
+                    break  # workflow finished on its own
+                except _asyncio.TimeoutError:
+                    build_s = _LeanVerifier._total_build_seconds - _build_at_start
+                    reasoning_s = (time.time() - session_start) - build_s
+                    if reasoning_s > workflow_timeout_s:
+                        _wf_task.cancel()
+                        try:
+                            await _wf_task
+                        except (_asyncio.CancelledError, Exception):
+                            pass
+                        raise _asyncio.TimeoutError
+                    # else: still within reasoning budget — keep waiting.
 
             if hasattr(result, 'output') and result.output:
                 final_msg = result.output
@@ -530,7 +569,13 @@ class MultiAgentSorryProver:
 
             proof_found = getattr(final_msg, 'proof_found', False)
         except _asyncio.TimeoutError:
-            print(f"  Workflow wall-clock timeout ({workflow_timeout_s}s) — aborting")
+            try:
+                _bs = _LeanVerifier._total_build_seconds - _build_at_start
+                _credit = f"; {_bs:.0f}s build credited"
+            except NameError:
+                _credit = ""
+            print(f"  Workflow reasoning-budget timeout ({workflow_timeout_s}s "
+                  f"reasoning{_credit}) — aborting")
             proof_found = False
         except Exception as e:
             print(f"  Workflow error: {e}")

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -500,15 +500,21 @@ class MultiAgentSorryProver:
         # can override.
         import asyncio as _asyncio
         if workflow_timeout_s is None:
-            # Reasoning models can spend ~5-10 min/iteration on hard goals.
-            # 600s/iter * max_iterations gives the agents room without
-            # capping a productive run mid-thinking.
-            iteration_cap = max_iterations * 600
-            # P2 (#1453 forensic): per-sorry wall-clock cap. Prevents burning
-            # hours on delta=0 runs (zai avg 59 min/run, 0 success; openrouter
-            # avg success 8.3 min). 10 min/sorry, minimum 10 min.
-            sorry_cap = max(original_sorry_count * 600, 600)
-            workflow_timeout_s = min(iteration_cap, sorry_cap)
+            # User mandate 2026-06-21: hard single-sorry nuts (e.g. the
+            # Bondareva cone-closed lemma) were STARVED by the old 600s/sorry
+            # cap. On demo-55 the agents spent ~90s planning + ~240s on the
+            # Director consult, so the FIRST Lean compile only landed at ~615s
+            # — past the 600s cap. The session timed out with 0 actual
+            # iterations and lost its traces. Long sessions are needed,
+            # especially on hard nuts. Crons fire at >= 1h, so a 45-min ceiling
+            # leaves comfortable margin for one BG run per cron tick.
+            PER_UNIT_S = 2700   # ~45 min (was 600) — room for planning + Director + several compile loops
+            CEILING_S = 2700    # hard cap, safe under the >=1h cron cadence
+            iteration_cap = max_iterations * PER_UNIT_S
+            # P2 (#1453 forensic): per-sorry wall-clock cap still scales with
+            # problem size; the CEILING keeps any single BG run under the cron.
+            sorry_cap = max(original_sorry_count * PER_UNIT_S, PER_UNIT_S)
+            workflow_timeout_s = min(iteration_cap, sorry_cap, CEILING_S)
         session_start = time.time()
         self.trace.start_session_span(demo["name"], "multi")
         proof_found = False


### PR DESCRIPTION
## Subject
Make BG-prover sessions actually long enough to crack hard single-sorry nuts (e.g. Bondareva cone-closed lemma, demo-55), per user mandate 2026-06-21.

Three coupled changes to the **prover time budget** (one subject):

1. **Raise the hard wall-clock cap 600s -> 2700s** (~45 min, safe under the >=1h cron cadence). The old 600s/sorry cap starved hard nuts: agents spend ~90s planning + ~240s on the Director consult, so the first Lean compile only landed at ~615s — past the cap → 0 iterations, lost traces.

2. **Credit `lake build` time against the reasoning budget** ("pause the timer during builds"). A class-level `_total_build_seconds` accumulator (lean_server.py) is bumped on real builds only (cache hits never reach it). The single `asyncio.wait_for` is replaced by a build-credited supervisor (provers.py) that polls every 30s and extends the effective deadline by compile seconds — so `workflow_timeout_s` measures **reasoning** time, not wall-clock.

3. **Wire `state.max_session_seconds = workflow_timeout_s`** so the agents' time-budget tool paces to the real ceiling instead of the 1800s default.

## Caching (the other half of the mandate)
Verified the Bondareva target is already cache-optimal: **7620 mathlib oleans cached** (no cold recompile), incremental `lake build -R <module>`, content-hash short-circuit on unchanged files. The build-credit covers only the irreducible single-file recompile that remains.

## Verification
- `py_compile` OK on both files.
- Build-credited supervisor unit-tested in isolation: fast-completion returns its result; a workflow running past the raw budget but with credited build time survives; runaway pure-reasoning is cancelled with TimeoutError.

Touches only `agent_tests/lean_server.py` + `agent_tests/prover/provers.py` (no notebooks, no catalogue, no `.lean` proofs). See #1453.