### PR TITLE
docs(dsa-lab6): anchor ReAct + Toolformer references + References (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
@@ -164,7 +164,9 @@
     "tags": []
    },
    "source": [
-    "Les outils sont des fonctions que l'agent peut appeler pour interagir avec le monde extérieur. La *docstring* de la fonction est cruciale, car c'est ce que le LLM lit pour comprendre l'utilité de l'outil."
+    "Les outils sont des fonctions que l'agent peut appeler pour interagir avec le monde extérieur. La *docstring* de la fonction est cruciale, car c'est ce que le LLM lit pour comprendre l'utilité de l'outil.\n",
+    "\n",
+    "> **Référence — outil-augmentation.** La capacité pour un LLM à *décider* d'appeler un outil, *quand* l'appeler et avec *quels* arguments constitue le paradigme des LLMs *tool-augmented* (ou *function calling*). Son fondement académique est Toolformer (Schick et al., 2023), qui montre qu'un modèle peut apprendre par lui-même à insérer des appels d'API. Le décorateur `@tool` de LangChain expose précisément cette interface : la *docstring* devient la description que le LLM utilise pour choisir l'outil."
    ]
   },
   {
@@ -305,7 +307,9 @@
     "tags": []
    },
    "source": [
-    "Nous assemblons maintenant tous les composants pour creer l'agent avec `create_react_agent` de LangGraph. Cette fonction cree un graphe qui gere la boucle `Pensee -> Action -> Observation` automatiquement."
+    "Nous assemblons maintenant tous les composants pour creer l'agent avec `create_react_agent` de LangGraph. Cette fonction cree un graphe qui gere la boucle `Pensee -> Action -> Observation` automatiquement.\n",
+    "\n",
+    "> **Référence — ReAct.** La boucle *Pensée → Action → Observation* est le paradigme **ReAct** (*Reasoning + Acting*) formalisé par Yao et al. (2023) : l'agent alterne un pas de raisonnement (pensée), l'appel d'un outil (action), puis l'intégration du résultat (observation), jusqu'à produire la réponse finale. `create_react_agent` de LangGraph implémente directement cette boucle. Le prolongement multi-agent (boucle Planner-Coder-Verifier) est abordé au Lab 11 (AgenticDataScience)."
    ]
   },
   {
@@ -563,6 +567,17 @@
     "\n",
     "# Exercice: Testez l'agent avec une question necessitant la puissance\n",
     "# result_exo = graph_exo.invoke({\"messages\": [(\"user\", \"Quelle est la puissance de 5 eleve au carre ?\")]})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "1. S. Yao, J. Zhao, D. Yu, et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, ICLR 2023, arXiv:2210.03629. Paradigme Reasoning+Acting (boucle Pensée → Action → Observation) implémenté par `create_react_agent` (Étape 4) — concept central de ce laboratoire.\n",
+    "2. T. Schick, J. Dwivedi-Yu, R. Dessì, et al., *Toolformer: Language Models Can Teach Themselves to Use Tools*, NeurIPS 2023, arXiv:2302.04761. Fondement académique des LLMs *tool-augmented* (décider/quand/arguments d'un appel d'outil) sous-jacent au décorateur `@tool` (Étape 2).\n",
+    "3. H. Chase, *LangChain*, 2022 ; LangGraph, `langchain-ai/langgraph`. Framework d'orchestration d'agents (graphe d'états) utilisé tout au long du laboratoire — référence bibliographique détaillée au Lab 8.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Lab6-First-Agent (PythonAgentsForDataScience Day3) — audit #3164 fidelity pass.

**Verdict: OMISSION repaired.** Two central named concepts were taught without canonical citation.

## Central concepts identified

1. **ReAct paradigm** (Étape 4, `create_react_agent`; objectives 3+4) — cell 13 describes the `Pensée → Action → Observation` loop, which IS the ReAct (Reasoning + Acting) paradigm. The lab's central agent construct.
2. **Tool-calling / tool-augmented LLMs** (Étape 2, `@tool` decorator; objective 2) — a dedicated step teaching how LLMs decide to call functions.

## Changes (markdown-only, +18/-3)

1. **Enriched cell 7** (tools intro) with a citation note anchoring tool-augmentation / function-calling to Toolformer (Schick et al. 2023).
2. **Enriched cell 13** (orchestrator) with a citation note anchoring the Thought→Action→Observation loop to ReAct (Yao et al. 2023), with a cross-link to Lab11 for the multi-agent extension.
3. **Appended References section**: Yao 2023 (ReAct), Schick 2023 (Toolformer), LangChain/LangGraph (cross-link Lab8).

## Anti-duplication / self-containment note

ReAct is also anchored in Lab11 (AgenticDataScience Day5), but that lab's distinct concept is the **multi-agent** Planner-Coder-Verifier loop. Lab6 is a **different course** (PythonAgentsForDataScience Day3) building the student's **first** agent; the ReAct citation belongs here at `create_react_agent`'s teaching point for self-containment. Cross-linked to Lab11, not redundantly re-anchored as if new. Tool-calling is genuinely new to the family.

## Validation

- nbformat JSON valid; 9 code cells unchanged (count preserved), 19 markdown cells (+1 References).
- 0 voluntary errors (`raise NotImplementedError`/`assert False`/`1/0`) in code source.
- Markdown-only patch → no code source change → existing outputs remain coherent (C.2 markdown exception). No re-execution required.
- Catalog byte-identical to `origin/main` (0 churn).
- Fresh branch from `origin/main` (no stale base).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
