### PR TITLE
docs(sensitivity-lean): add Conclusion section to README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
@@ -78,3 +78,33 @@ lake build Sensitivity
   Conjecture*, Ann. Math. 190(3).
 - Nisan & Szegedy (1992), *On the degree of Boolean functions as real
   polynomials*, DIMACS.
+
+## Conclusion
+
+This mini-project formalizes in Lean 4 (0 `sorry`, 0 axiom beyond Lean core) the
+proof that **resolved the Sensitivity Conjecture** — open since 1989/1992, settled
+by Hao Huang in 2019 via a four-page combinatorial argument. The whole chain
+`s(f) ≤ bs(f) ≤ deg(f)` and Huang's degree theorem are closed.
+
+### What is proven
+
+The headline `huang_degree_theorem` (`MainTheorem.lean`): every induced subgraph
+of the `n`-cube on more than half its vertices has a vertex of degree `≥ √n`. The
+corollary is the quadratic bound `deg(f) ≤ s(f)²`, equivalently `bs(f) ≤ s(f)²` —
+sensitivity and block sensitivity are polynomially related, as the conjecture
+asked. The supporting infrastructure (hypercube `Q n`, the real vector space of
+Boolean functions, sensitivity/block-sensitivity operators) is fully built.
+
+### Why it works
+
+The argument is spectral (`exists_eigenvalue`): a signed adjacency matrix of the
+hypercube has eigenvalue `√n`, and Cauchy's interlacing theorem forces a
+high-degree vertex in any large induced subgraph. The formalization carries that
+eigenvalue/interlacing skeleton through Mathlib.
+
+### Where to go next
+
+- **Source**: Huang (2019), *Induced subgraphs of hypercubes and a proof of the
+  Sensitivity Conjecture*, Annals of Mathematics 190(3).
+- **Context**: Nisan & Szegedy (1992), the conjecture as posed.
+- **Series**: the [`SymbolicAI/Lean`](../README.md) formalization index.


### PR DESCRIPTION
See #2651 (partial — prose Conclusion for the sensitivity_lean sous-série, epic
ongoing).

## Context

`sensitivity_lean/README.md` (80 lines) documented Huang's theorem, the s/bs/deg
chain, modules, key results, and references — but had **no Conclusion**. Next
#2651 grain (fallback perenne). The 4 ai-01-named + first-extended Lean README
Conclusions are all merged (conway_lean #3824, knot_lean #3829, grothendieck_lean
#3832, finiteness_lean #3835).

## What

Adds a `## Conclusion` section (+30 lines, single file, English to match):

- **Headline** — 0 sorry / 0 axiom formalization of Huang's 2019 proof resolving
  the Sensitivity Conjecture (open 1989/1992).
- **What is proven** — `huang_degree_theorem` (induced subgraph of n-cube >
  half vertices → degree ≥ √n), corollary `deg(f) ≤ s(f)²`, full infrastructure
  (hypercube, vector space, operators).
- **Why it works** — spectral argument (`exists_eigenvalue`, eigenvalue √n +
  Cauchy interlacing) via Mathlib.
- **Where to go next** — Huang 2019 Annals, Nisan–Szegedy 1992, parent series.

## G.1 grounding

Every claim anchored in the existing README: chain `s≤bs≤deg` (line 22),
`huang_degree_theorem` (lines 33-35, 53-55), `exists_eigenvalue` spectral lemma
(lines 37-39, 56-57), modules (46-49), Status 0 sorry/0 axiom (lines 10, 14-15),
references (62-64, 77-80). Pure synthesis, no new assertion. Completion-style
(0-sorry project).

## Validation

- **Markdown-only** (C.2 exception).
- **Additive pure** `+30/-0`, single file, 80 → 110 lines.
- **Catalog byte-identical** (0 churn).
- **Atomique** (HARD 3).
- Fresh branch on `origin/main` (`0 0`; base-stale caught + fixed before commit).

@ai-01 — review/merge. No `*.lean` touched → no Lake build required.