### PR TITLE
fix(tweety-8): repair JVM consecration (rule F re-exec) - EPIC #3801 Prong-A

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues.ipynb
@@ -65,7 +65,21 @@
      "output_type": "stream",
      "text": [
       "--- Verification JVM Tweety + Outils ---\n",
-      "ERREUR: JAVA_HOME non defini et JDK portable non trouve.\n"
+      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JVM demarree avec 42 JARs.\n",
+      "\n",
+      "--- Outils disponibles ---\n",
+      "  EPROVER: eprover.exe\n",
+      "  SAT_SOLVER_PYTHON: sat_solver.py\n",
+      "  MARCO: marco.py\n",
+      "\n",
+      "JVM prete. Outils: 3/5\n"
      ]
     }
    ],
@@ -353,7 +367,55 @@
      "text": [
       "\n",
       "--- 6.2 Dialogues Argumentatifs ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "JVM prete. Exploration des dialogues argumentatifs...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Import ExecutableExtension reussi.\n",
+      "\n",
+      "--- Classes disponibles dans agents.dialogues ---\n",
+      "Classes par package:\n",
+      "\n",
+      "  agents.dialogues:\n",
+      "    [OK] ExecutableExtension\n",
+      "    [OK] DialogueTrace\n",
+      "\n",
+      "  agents.dialogues.lotteries:\n",
+      "    [OK] AbstractLotteryAgent\n",
+      "    [OK] LotteryGameSystem\n",
+      "\n",
+      "  agents.dialogues.oppmodels:\n",
+      "    [OK] ArguingAgent\n",
+      "    [OK] GroundedGameProtocol\n",
+      "    [OK] GroundedGameSystem\n",
+      "    [OK] T1BeliefState\n",
+      "    [OK] T2BeliefState\n",
+      "    [OK] T3BeliefState\n",
+      "\n",
+      "--- Modele Conceptuel de Dialogue (oppmodels) ---\n",
+      "\n",
+      "Dans un dialogue argumentatif typique (package oppmodels):\n",
+      "\n",
+      "1. Deux agents (ArguingAgent) debattent sur un Dung Framework\n",
+      "2. Chaque agent a un etat de croyance (T1/T2/T3 BeliefState)\n",
+      "3. Le protocole (GroundedGameProtocol) gere les tours\n",
+      "4. Le systeme (GroundedGameSystem) coordonne le jeu\n",
+      "\n",
+      "Niveaux d'etat de croyance:\n",
+      "- T1: L'agent connait le framework complet\n",
+      "- T2: L'agent a des croyances sur les croyances adverses\n",
+      "- T3: Recursion a 3 niveaux (croyances sur croyances sur croyances)\n",
+      "\n",
+      "Coups autorises dans le jeu grounded:\n",
+      "- ASSERT(argument) : Affirmer un argument\n",
+      "- CHALLENGE(argument) : Contester un argument  \n",
+      "- RETRACT : Se retirer du debat\n",
+      "\n",
+      "Le vainqueur est determine par la semantique grounded.\n",
+      "\n"
      ]
     }
    ],
@@ -556,7 +618,36 @@
      "text": [
       "\n",
       "--- 6.3 Jeux de Loterie Argumentative ---\n",
-      "ERREUR: JVM non demarree.\n"
+      "JVM prete. Exploration des jeux de loterie...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports pour loteries reussis.\n",
+      "\n",
+      "--- Creation d'un scenario de loterie ---\n",
+      "Framework: <{ proposition_A, proposition_B, evidence_C },[(proposition_B,proposition_A), (proposition_A,proposition_B), (evidence_C,proposition_B)]>\n",
+      "\n",
+      "Scenario:\n",
+      "- Agent 1 supporte proposition_A\n",
+      "- Agent 2 supporte proposition_B  \n",
+      "- evidence_C attaque B, favorisant A\n",
+      "\n",
+      "\n",
+      "Nombre de configurations possibles: 19\n",
+      "\n",
+      "Probabilites d'acceptation (Grounded):\n",
+      "  P(proposition_A accepte) = 0.526\n",
+      "  P(proposition_B accepte) = 0.316\n",
+      "  P(evidence_C accepte)    = 0.632\n",
+      "\n",
+      "Interpretation:\n",
+      "- Si evidence_C est presente, B est attaque et A gagne\n",
+      "- La probabilite que A soit accepte (52.6%) > celle de B (31.6%)\n",
+      "- Un agent rationnel devrait investir pour maintenir C dans le debat\n",
+      "\n"
      ]
     }
    ],
@@ -791,7 +882,93 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JVM non demarree. Re-executer la cellule 1.\n"
+      "Framework : 8 arguments, 8 attaques\n",
+      "\n",
+      "=== Trace du dialogue ===\n",
+      "Tour 1 :\n",
+      "  [acheteur ] ASSERT(prix_eleve)\n",
+      "  [vendeur  ] ASSERT(emplacement)         -- contre prix_eleve\n",
+      "  [mediateur] ASSERT(compromis)           -- affaiblit prix_eleve ET emplacement\n",
+      "Tour 2 :\n",
+      "  [acheteur ] ASSERT(travaux_necessaires)\n",
+      "  [vendeur  ] ASSERT(travaux_recents)     -- contre travaux_necessaires\n",
+      "  [mediateur] ASSERT(marche_favorable)\n",
+      "\n",
+      "=== Arguments survivants (sem. grounded) ===\n",
+      "  rejete  prix_eleve\n",
+      "  rejete  travaux_necessaires\n",
+      "  rejete  quartier_bruyant\n",
+      "  rejete  emplacement\n",
+      "  rejete  travaux_recents\n",
+      "  ACCEPTE proche_ecoles\n",
+      "  ACCEPTE compromis\n",
+      "  ACCEPTE marche_favorable\n",
+      "\n",
+      "=== Probabilites d'acceptation (sur sous-graphes) ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(prix_eleve               ) = 0.357\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(travaux_necessaires      ) = 0.429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(quartier_bruyant         ) = 0.462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(emplacement              ) = 0.357\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(travaux_recents          ) = 0.429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(proche_ecoles            ) = 0.462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(compromis                ) = 0.750\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(marche_favorable         ) = 0.615\n",
+      "\n",
+      "Analyse :\n",
+      "- Les arguments du mediateur n'etant pas attaques, ils sont 'accepte' en grounded\n",
+      "  et leurs cibles voient leur probabilite chuter.\n",
+      "- Sur l'axe travaux : conflit symetrique, donc grounded laisse les deux 'rejetes'.\n",
+      "- En probabilite (sous-graphes), les arguments neutres dominent : un compromis\n",
+      "  autour du prix median (~295000) est rationnellement defendable.\n",
+      "\n"
      ]
     }
    ],
@@ -963,7 +1140,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JVM non demarree. Re-executer la cellule 1.\n"
+      "=== Debat : Adoption d'IA generative dans le service public ===\n",
+      "\n",
+      "--- Tour 1 ---\n",
+      "  [PRO      ] ASSERT    gain_productivite\n",
+      "  [CON      ] CHALLENGE gain_productivite\n",
+      "  [CON      ] ASSERT    perte_emplois\n",
+      "  [SCEPTIQUE] ASSERT    maturite_insuffisante\n",
+      "--- Tour 2 ---\n",
+      "  [PRO      ] ASSERT    meilleur_service_usager\n",
+      "  [CON      ] ASSERT    risque_biais\n",
+      "  [SCEPTIQUE] ASSERT    cout_implementation\n",
+      "  [PRO      ] RETRACT   meilleur_service_usager\n",
+      "\n",
+      "=> Dialogue termine apres 8 moves sur 2 tours.\n",
+      "\n",
+      "=== Verdict grounded (qui survit ?) ===\n",
+      "  PRO       survivants : (aucun)\n",
+      "  CON       survivants : ['perte_emplois', 'risque_biais']\n",
+      "  SCEPTIQUE survivants : ['cout_implementation', 'maturite_insuffisante']\n",
+      "\n",
+      "=== Score moyen d'acceptation par camp ===\n",
+      "  PRO       moy = 0.339  [P(gain_productivite)=0.349, P(meilleur_service_usager)=0.330]\n",
+      "  CON       moy = 0.576  [P(perte_emplois)=0.631, P(risque_biais)=0.521]\n",
+      "  SCEPTIQUE moy = 0.620  [P(cout_implementation)=0.608, P(maturite_insuffisante)=0.631]\n",
+      "\n",
+      "=> Camp le plus convaincant (en moyenne probabiliste) : SCEPTIQUE\n",
+      "\n",
+      "Bonus - analyse de la convergence :\n",
+      "- Grounded est tres restrictif : ne garde que les arguments qu'aucune attaque\n",
+      "  ne refute. Si un argument est attaque par un autre lui-meme accepte, il tombe.\n",
+      "- Les probabilites d'acceptation lissent ce verdict en moyennant sur les\n",
+      "  sous-graphes possibles ; un camp avec des arguments souvent non attaques\n",
+      "  dans les sous-frameworks domine meme s'il n'a pas la victoire grounded.\n",
+      "- Ici, le camp avec le score moyen le plus eleve a 'persuade' au sens\n",
+      "  probabiliste : ses arguments resistent dans le plus grand nombre de\n",
+      "  configurations possibles du debat.\n",
+      "\n"
      ]
     }
    ],
@@ -1185,7 +1398,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JVM non demarree. Re-executer la cellule 1.\n"
+      "Exercice a completer\n"
      ]
     }
    ],
@@ -1267,7 +1480,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JVM non demarree. Re-executer la cellule 1.\n"
+      "Exercice a completer\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary

**Prong-A audit finding (EPIC #3801).** `Tweety-8-Agent-Dialogues.ipynb` committed **consecrated** outputs. 7 code cells (1, 7, 11, 15, 18, 22, 24) printed `ERREUR: JVM non demarree` / `JAVA_HOME non defini` because papermill ran with the wrong working directory at authoring time — the JDK-portable lookup uses a CWD-relative path (`jdk-17-portable`/`libs/*.jar`). The markdown interpretation cells (2, 9, 12) then narrated the dialogues/results as "confirment" / "illustrent ci-dessus", presenting non-existent JVM results as real = **consecration** (sota-not-workaround §H).

## Verdict: RECOVERABLE-LOCAL

The portable JDK (`zulu17.50.19-ca-jdk17.0.11`) + 42 Tweety JARs are present (gitignored), `jpype 1.7.0` installed. Same proven recipe as Tweety-9 (#3342).

## Fix (rule F: re-exec, NOT workaround)

`papermill` re-exec with `--cwd` = Tweety dir (kernel `python3`) so the CWD-relative `jdk-17-portable` + `libs/*.jar` resolve. JVM starts with 42 JARs. Regenerates **real** Tweety outputs:

- **cell 1**: `JDK portable: zulu17.50.19...` + `JVM demarree avec 42 JARs` (was `ERREUR: JAVA_HOME non defini`)
- **cell 7**: real Tweety class exploration — `ExecutableExtension`, `DialogueTrace`, `AbstractLotteryAgent`, `LotteryGameSystem`, `ArguingAgent`, `GroundedGameProtocol`, `GroundedGameSystem`, `T1/T2/T3BeliefState` (was `ERREUR: JVM non demarree`)
- **cell 11**: real argumentation-lottery computation — `P(proposition_A accepte) = 0.526`, 19 configurations (was `ERREUR: JVM non demarree`)
- **cell 15**: real immobilier-negotiation dialogue trace — 8 args / 8 attaques, acheteur/vendeur/mediateur ASSERT moves
- **cell 18**: real gen-AI-in-public-service debate — PRO/CON/SCEPTIQUE, Tour 1/2
- **cells 22/24**: legit exercise stubs (#2161), `print("Exercice a completer")`

Markdown cells 2/9/12 were written for the success case and now **align** with the real outputs (no-pendulum: the prose was correct-for-success; the stale outputs were the only defect) → **no markdown change needed**.

Outputs transplanted via JSON round-trip — **source byte-identical**, only outputs + execution_count changed.

## Validation (H.1–H.3, C.2)

- `papermill` end-to-end: **0 errors**, all 8 code cells executed (`execution_count` [1..8])
- residual consecration markers: **0** ("JVM non demarree", "JAVA_HOME non defini")
- `JVM demarree` confirmation present (cell 1)
- No `raise NotImplementedError` / `assert False` / `1/0`
- Real Tweety JVM runs present (class exploration + lottery probabilities + dialogue traces)
- Diff atomic: 1 file, 221 ins / 8 del = **outputs only**; catalogue + submodule byte-identical to main

## Collision note

A stale branch `fix/tweety8-single-line-source` exists but its PR **#2012 is MERGED** (2026-06-01, 1500 commits behind, minor source reformat only) — it did **not** fix the JVM outputs. This PR is on a fresh branch from `origin/main`.

## Why "See #3801" (not "Closes")

Partial contribution to the SOTA/Prong-A epic (repo-wide tool-invocation audit).

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
