### PR TITLE
Fix(QC-Py-28): ground RegimeSwitching result in real QC Cloud backtest (#3367)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -178,7 +178,7 @@
     "        # RSI for mean-reversion signals\n",
     "        self.rsi_indicators = {}\n",
     "        for ticker in self.risky:\n",
-    "            indicator = self.RelativeStrengthIndex(ticker, 14, MovingAverageType.WILDERS)\n",
+    "            indicator = self.RSI(ticker, 14, MovingAverageType.WILDERS)\n",
     "            self.RegisterIndicator(self.symbols[ticker], indicator, Resolution.Daily)\n",
     "            self.rsi_indicators[ticker] = indicator\n",
     "        \n",
@@ -386,7 +386,23 @@
   },
   {
    "cell_type": "markdown",
-   "source": "> **Resultat du backtest QC Cloud** - `RegimeSwitching` (periode 2023-01-01 a 2023-03-31, $100k initial)\n>\n> | Metrique | Valeur |\n> |----------|--------|\n> | Statut | COMPLETED |\n> | Ordres | 32 |\n> | Trades | 18 |\n> | Sharpe | **1.731** |\n> | Sortino | 2.446 |\n> | Net Profit | **+8.74%** |\n> | CAGR | 40.675% |\n> | Max Drawdown | 6.9% |\n> | Win Rate | 71% |\n> | Alpha | 0.083 |\n> | Beta | 0.781 |\n> | End Equity | $108,741.30 |\n>\n> **Performance solide** : La strategie regime-switching (bull/bear/sideways via SMA50/200, RSI mean-reversion, trailing stop -10%) genere un Sharpe > 1.7 sur Q1 2023 avec un drawdown contenu sous 7%. Le win rate de 71% et le alpha positif confirment l'edge de l'approche adaptive.",
+   "source": [
+    "> **Resultat du backtest QC Cloud** - `RegimeSwitching` (2015-2024, $100k initial)\n",
+    ">\n",
+    "> | Metrique | Valeur |\n",
+    "> |----------|--------|\n",
+    "> | Dates negociables | 2516 |\n",
+    "> | Sharpe Ratio | 0.522 |\n",
+    "> | CAGR | 11.445% |\n",
+    "> | Max Drawdown | 26.900% |\n",
+    "> | Net Profit | +195.5% |\n",
+    "> | Equity finale | $295,533 |\n",
+    "> | Probabilistic Sharpe Ratio | 11.380% |\n",
+    ">\n",
+    "> **Performance 2015-2024** : La strategie regime-switching (momentum en bull, mean-reversion + defensif en bear/sideways, trailing stop -10%) genere un Sharpe de 0.522 et un CAGR de 11.4% sur 10 ans. Le MaxDD de 26.9% reflete le lag de detection SMA50/200 (whipsaws aux transitions de regime), et le PSR de 11.4% indique une confiance modeste dans l'edge.\n",
+    ">\n",
+    "> *Backtest QC Cloud 2015-2024 (projet 33177683, bt 97a99ceb9a70b6a18e27b3408c24029c). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
+   ],
    "metadata": {}
   },
   {


### PR DESCRIPTION
## Summary

Prong-A audit (#3801 SOTA-not-workaround, tracker #3845, audit #3367). QC-Py-28
cell 4 was a **cat-1 fabrication**: a result table claimed a Q1-2023 window
("periode 2023-01-01 a 2023-03-31", ~62 tradeable days) with fabricated metrics
(Sharpe 1.731 / CAGR 40.675% / MaxDD 6.9% / Net +8.74% / End $108,741.30), while
the reference algo sets `SetStartDate(2015,1,1)` + `SetEndDate(2024,12,31)` (10-year
backtest). Markdown-vs-code internal contradiction = cat-1 fabrication (date-window
shrink + metric inflation).

**Verdict per #3801: RECOVERABLE-MACHINE -> SOTA-OK.** Re-ran `RegimeSwitching` on
QC Cloud (project 33177683, 2015-2024) and replaced the fabricated table with the
**real verified metrics** + ground-truth backtest id.

## Evidence bar (per ai-01: every committed value traces to a cited bt id)

| cell | algo            | Sharpe | CAGR    | MaxDD   | PSR    | tradeable dates | backtest id (project 33177683) |
|------|-----------------|--------|---------|---------|--------|-----------------|--------------------------------|
| #4   | RegimeSwitching | 0.522  | 11.445% | 26.900% | 11.38% | 2516 (10y)      | `97a99ceb9a70b6a18e27b3408c24029c` |

- **Inline caption** (ai-01 hard requirement, template (a)): cell 4 caption now reads
  `Backtest QC Cloud 2015-2024 (projet 33177683, bt 97a99ceb9a70b6a18e27b3408c24029c)`
  — embedded in-notebook, not a vague "voir PR body".
- Net Profit (+195.5%) / Equity finale ($295,533) **arithmetically derived** from the
  verified CAGR (`End = $100,000 x (1+CAGR)^10`); QC's CAGR is the equity-curve CAGR so
  the derivation is exact. PSR is a reliable `read_backtest` field.
- `totalNetProfit` is NOT parsed reliably by `read_backtest` (returns "-"), hence the
  CAGR derivation — same method as merged #3849 (QC-Py-09) and #3838 (QC-Py-08).

## Cell 3 — RSI API-drift idiom fix (enabler, not redesign)

Cell 3 holds the reference algo as a triple-quoted string. The verbatim deploy
**Runtime Error'd**: `"'RegimeSwitching' object has no attribute 'RelativeStrengthIndex'"`.
`RelativeStrengthIndex` is not a `QCAlgorithm` helper; the correct one is `self.RSI`:

```
-            indicator = self.RelativeStrengthIndex(ticker, 14, MovingAverageType.WILDERS)
+            indicator = self.RSI(ticker, 14, MovingAverageType.WILDERS)
```

Same minimal idiom-correction class as NB14 cell 13 (PR #3545, `Resolution.Weekly` ->
`Expiry.EndOfWeek`). **Not a strategy redesign** — required for the reference algo to
produce the real backtest whose metrics now populate cell 4. Without it, a student
copying the reference into QC Lab hits an immediate Runtime Error.

## Scope (C.2 / C.3)

- Cell 3 = `[REFERENCE QC]` string-defining code cell, `exec_count=None` (never executed
  locally — non-executable without QuantBook). No output to re-execute against.
- Cell 4 = markdown-only.
- 45 -> 45 cells. Line endings LF preserved (no CRLF churn). Diff 18 ins / 2 del.

## Verification

- `python scripts/notebook_tools/notebook_tools.py validate <nb>` -> OK: 1, 0 warnings, 0 errors.
- Guards in the repair script abort unless: the buggy `RelativeStrengthIndex` line is
  present (cell 3), AND the fabricated `2023-01-01 a 2023-03-31` window + `1.731`/`40.675%`
  values are present (cell 4) — proving we replaced exactly the fabricated content.

**Reassessed by po-2024: CONFIRMED cat-1 fabrication.** Real metrics captured via
RECOVERABLE-MACHINE (QC Cloud). Template (a) inline bt caption per ai-01 evidence bar.

See #3367
