### PR TITLE
Fix(QC-Py-15): ground OptimizableStrategy + OptimizedSMACrossover in real QC Cloud backtests (#3367)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -868,7 +868,19 @@
     ]
    },
    "source": [
-    "**Resultats Backtest QC Cloud** - `OptimizableStrategy`\n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | -0.286 |\n| Sortino Ratio | -0.290 |\n| CAGR | 1.8% |\n| Net Profit | 0.45% |\n| Total Orders | 2 |\n| Trades | 1 |\n| Win Rate | 100% |\n| Max Drawdown | 6.1% |\n| End Equity | $100,449.54 |\n| Total Fees | $2.65 |\n| Backtest ID | `f1c52c3c146c5d8299824b8f64a1ee20` |\n\n> SMA(10)/SMA(50) crossover with GetParameter defaults - 1 trade in Q1 2023 (warmup 50 days)\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+    "**Resultats Backtest QC Cloud** - `OptimizableStrategy` (SMA 10/50, 2015-2024, $100,000 initial)\n",
+    "\n",
+    "| Metrique | Valeur |\n",
+    "|----------|--------|\n",
+    "| Dates negociables | 2516 |\n",
+    "| Sharpe Ratio | 0.298 |\n",
+    "| CAGR | 6.564% |\n",
+    "| Max Drawdown | 16.100% |\n",
+    "| Net Profit | +88.8% |\n",
+    "| Equity finale | $188,845 |\n",
+    "| Probabilistic Sharpe Ratio | 3.805% |\n",
+    "\n",
+    "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 73ac0abcdb02288016da3c9002b23b1f). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
    ]
   },
   {
@@ -4134,7 +4146,19 @@
     ]
    },
    "source": [
-    "**Resultats Backtest QC Cloud** - `OptimizedSMACrossover`\n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.451 |\n| Sortino Ratio | 0.538 |\n| CAGR | 13.5% |\n| Net Profit | 3.16% |\n| Total Orders | 3 |\n| Trades | 1 |\n| Win Rate | 0% |\n| Max Drawdown | 7.5% |\n| End Equity | $103,159.70 |\n| Total Fees | $3.85 |\n| Backtest ID | `2222eb7ae2be7ed5ad8b3cbe6bde13d6` |\n\n> SMA(20)/SMA(200) optimized crossover - 1 trade, 0% win rate (stopped out), but unrealized gains offset to +3.16% net\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+    "**Resultats Backtest QC Cloud** - `OptimizedSMACrossover` (SMA 20/200, 2015-2024, $100,000 initial)\n",
+    "\n",
+    "| Metrique | Valeur |\n",
+    "|----------|--------|\n",
+    "| Dates negociables | 2516 |\n",
+    "| Sharpe Ratio | 0.494 |\n",
+    "| CAGR | 10.218% |\n",
+    "| Max Drawdown | 26.600% |\n",
+    "| Net Profit | +164.6% |\n",
+    "| Equity finale | $264,561 |\n",
+    "| Probabilistic Sharpe Ratio | 11.349% |\n",
+    "\n",
+    "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 41a1888d69fbda7bf164a04cd5761c86). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Prong-A audit (#3801 SOTA-not-workaround, tracker #3845, audit #3367). Two result
cells in QC-Py-15 were **cat-1 fabrications**: each claimed a Q1-2023 window
("Periode: Q1 2023 (2023-01-01 to 2023-03-31)") with fabricated metrics and a fake
"1 trade in Q1 2023" story, while the reference algos set
`SetStartDate(2015,1,1)` + `SetEndDate(2024,12,31)` (10-year backtest).
Markdown-vs-code internal contradiction = cat-1 fabrication.

**Verdict per #3801: RECOVERABLE-MACHINE -> SOTA-OK.** Re-ran both on QC Cloud
(project 33177683, 2015-2024) and replaced the fabricated tables with **real verified
metrics** + ground-truth backtest ids.

## Evidence bar (per ai-01: every committed value traces to a cited bt id)

| cell | algo                  | params     | Sharpe | CAGR    | MaxDD   | PSR    | tradeable dates | backtest id (project 33177683) |
|------|-----------------------|------------|--------|---------|---------|--------|-----------------|--------------------------------|
| #16  | OptimizableStrategy   | SMA 10/50  | 0.298  | 6.564%  | 16.100% | 3.805% | 2516 (10y)      | `73ac0abcdb02288016da3c9002b23b1f` |
| #75  | OptimizedSMACrossover | SMA 20/200 | 0.494  | 10.218% | 26.600% | 11.34% | 2516 (10y)      | `41a1888d69fbda7bf164a04cd5761c86` |

- **Inline caption** (ai-01 hard requirement, template (a)): each cell caption now
  embeds the bt id in-notebook — `Backtest QC Cloud 2015-2024 (projet 33177683, bt <id>)`,
  not a vague "voir PR body".
- **Best params verified (G.1)**: OptimizedSMACrossover's SMA(20,200) comes from the
  notebook's own optimization output (cell 72: "Meilleurs parametres: SMA(20, 200)"),
  not from the fabricated caption.
- Net Profit / Equity finale **arithmetically derived** from the verified CAGR
  (`End = $100,000 x (1+CAGR)^10`); QC's CAGR is the equity-curve CAGR so the
  derivation is exact. PSR is a reliable `read_backtest` field.
- `totalNetProfit` not parsed reliably by `read_backtest` (returns "-"), hence the
  CAGR derivation — same method as merged #3849 / #3838.

## Scope (C.2 / C.3)

- Markdown-only (cells 16 + 75). No code cell, no output changed.
- 78 -> 78 cells. LF line endings preserved. Diff 26 ins / 2 del.

## Verification

- `python scripts/notebook_tools/notebook_tools.py validate <nb>` -> OK: 1, 0 warnings, 0 errors.
- Repair-script guards abort unless the fabricated markers (Sharpe, CAGR, "2023-01-01
  to 2023-03-31") are present in each cell — proving we replaced exactly the fabricated
  content.

**Reassessed by po-2024: CONFIRMED cat-1 fabrication.** Real metrics captured via
RECOVERABLE-MACHINE (QC Cloud). Template (a) inline bt caption per ai-01 evidence bar.

See #3367
