### PR TITLE
Fix(QC-Py-09): ground 6 fabricated result cells in real QC Cloud backtests (#3367)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
@@ -395,20 +395,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "**Resultats du backtest QC Cloud (LimitOrderExample)**\n",
+    "**Resultats Backtest QC Cloud** - `LimitOrderExample` (2015-2024, $100,000 initial)\n",
     "\n",
-    "| Metrique | Valeur |\n",
-    "|----------|--------|\n",
-    "| Dates negociables | 62 |\n",
-    "| Ordres executes | 1 |\n",
-    "| Sharpe Ratio | 0 |\n",
-    "| CAGR | 0% |\n",
-    "| Max Drawdown | 0% |\n",
-    "| Net Profit | 0% |\n",
-    "| Equity finale | $100,000.00 |\n",
+    "> **Runtime Error (backtest QC Cloud, bt 94fdaf130de8f55846fcd1362d2beed3).** La strategie de reference place un limit order a -1% sous le prix, puis s'arrete, puis Runtime Error a 2015-03-20 : `'NoneType' object has no attribute 'Close'` a `data[self.spy].Close` MALGRE le guard `if not data.ContainsKey(self.spy): return` -- gotcha QC : `ContainsKey` renvoie True mais la valeur peut etre None sur certaines bars (barres auxiliaires split/dividende). Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas commitees (G.2 : aucune metrique non-verifiable). La table fabriquee d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
     "\n",
-    "*Limit order example (buy 100 SPY at 1% below price), RUNTIME ERROR: data[symbol].Close None on first bar, Q1 2023*"
+    "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 94fdaf130de8f55846fcd1362d2beed3).*"
    ]
   },
   {
@@ -958,20 +949,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "**Resultats du backtest QC Cloud (LITExample)**\n",
+    "**Resultats Backtest QC Cloud** - `LITExample` (LimitIfTouched (trigger -2%, limit -1.5%), daily, 2015-2024, $100,000 initial)\n",
     "\n",
     "| Metrique | Valeur |\n",
     "|----------|--------|\n",
-    "| Dates negociables | 62 |\n",
-    "| Ordres executes | 1 |\n",
-    "| Sharpe Ratio | 0 |\n",
-    "| CAGR | 0% |\n",
-    "| Max Drawdown | 0% |\n",
-    "| Net Profit | 0% |\n",
-    "| Equity finale | $100,000.00 |\n",
+    "| Dates negociables | 2516 |\n",
+    "| Sharpe Ratio | 0.073 |\n",
+    "| CAGR | 3.502% |\n",
+    "| Max Drawdown | 9.100% |\n",
+    "| Net Profit | +41.1% |\n",
+    "| Equity finale | $141,087 |\n",
+    "| Probabilistic Sharpe Ratio | 8.672% |\n",
     "\n",
-    "*LimitIfTouched order (trigger -2%, limit -1.5%), order placed but never filled (SPY trending up Q1 2023), daily resolution*"
+    "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 8d5fc20fc6e983aa27074181a9e1a1e8). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
    ]
   },
   {
@@ -1055,20 +1045,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "**Resultats du backtest QC Cloud (UpdateOrderExample)**\n",
+    "**Resultats Backtest QC Cloud** - `UpdateOrderExample` (2015-2024, $100,000 initial)\n",
     "\n",
-    "| Metrique | Valeur |\n",
-    "|----------|--------|\n",
-    "| Dates negociables | 62 |\n",
-    "| Ordres executes | 1 |\n",
-    "| Sharpe Ratio | 0 |\n",
-    "| CAGR | 0% |\n",
-    "| Max Drawdown | 0% |\n",
-    "| Net Profit | 0% |\n",
-    "| Equity finale | $100,000.00 |\n",
+    "> **Runtime Error (backtest QC Cloud, bt 61c83d4b9d948ac4172e011aed128170).** La strategie de reference place un limit a -2%, le met a jour a -1% apres 2 jours, l'annule apres 5, puis Runtime Error a 2015-03-20 : meme gotcha `Close None` malgre le guard `ContainsKey` (voir cellule LimitOrderExample ci-dessus). Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas commitees (G.2 : aucune metrique non-verifiable). La table fabriquee d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
     "\n",
-    "*Update order fields (limit order at -2%, update to -1% after 2 days, cancel after 5), RUNTIME ERROR: data[symbol].Close None on first bar, daily resolution, Q1 2023*"
+    "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 61c83d4b9d948ac4172e011aed128170).*"
    ]
   },
   {
@@ -1114,20 +1095,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "**Resultats du backtest QC Cloud (CancelOrderExample)**\n",
+    "**Resultats Backtest QC Cloud** - `CancelOrderExample` (2015-2024, $100,000 initial)\n",
     "\n",
     "| Metrique | Valeur |\n",
     "|----------|--------|\n",
-    "| Dates negociables | 62 |\n",
-    "| Ordres executes | 1 |\n",
+    "| Dates negociables | 2516 |\n",
+    "| Ordres executes | 0 |\n",
     "| Sharpe Ratio | 0 |\n",
     "| CAGR | 0% |\n",
     "| Max Drawdown | 0% |\n",
     "| Net Profit | 0% |\n",
     "| Equity finale | $100,000.00 |\n",
+    "| Probabilistic Sharpe Ratio | 0% |\n",
     "\n",
-    "*Cancel order demo (limit at -5%, cancel, then market buy), RUNTIME ERROR: self.Cancel() not a method, should be self.Transactions.CancelOrder(), Q1 2023*"
+    "> Demo sans trading : la methode `CancelExamples(ticket)` n'est jamais appelee (pas de `OnData`, aucun ordre place), donc aucun ordre execute. Les differentes facons d'annuler un ordre (`ticket.Cancel()`, `Transactions.CancelOpenOrders`, `Transactions.CancelOrder`) sont illustrees dans le code mais non declenchees a l'execution.\n",
+    "\n",
+    "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 37bba9607b5d1621d1c7b173a173a36f). 0 ordre execute, $100,000 inchanges.*"
    ]
   },
   {
@@ -1478,20 +1461,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "**Resultats du backtest QC Cloud (BestPracticesExample)**\n",
+    "**Resultats Backtest QC Cloud** - `BestPracticesExample` (2015-2024, $100,000 initial)\n",
     "\n",
-    "| Metrique | Valeur |\n",
-    "|----------|--------|\n",
-    "| Dates negociables | 62 |\n",
-    "| Ordres executes | 1 |\n",
-    "| Sharpe Ratio | 0 |\n",
-    "| CAGR | 5.182% |\n",
-    "| Max Drawdown | 0% |\n",
-    "| Net Profit | 0.051% |\n",
-    "| Equity finale | $100,051.00 |\n",
+    "> **Runtime Error (backtest QC Cloud, bt e966170dc9db35982cf134cf5d46018e).** La strategie de reference achete 100 SPY une seule fois (guard `order_pending`), nettoie les ordres stales via Schedule, puis Runtime Error a 2015-01-05 : `can't subtract offset-naive and offset-aware datetimes` dans `CancelStaleOrders` (`self.Time` offset-aware vs `order.CreatedTime` offset-naive) -- bug reel, non un artifice. Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas commitees (G.2 : aucune metrique non-verifiable). La table fabriquee d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
     "\n",
-    "*Race condition guard (order_pending flag) + stale order cleanup, RUNTIME ERROR: offset-naive vs offset-aware datetime in CancelStaleOrders, Q1 2023*"
+    "*Backtest QC Cloud 2015-2024 (projet 33177683, bt e966170dc9db35982cf134cf5d46018e).*"
    ]
   },
   {
@@ -1816,7 +1790,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n**Resultats du backtest QC Cloud (MeanReversionOrders)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 0 |\n| Sharpe Ratio | 0 |\n| CAGR | 0% |\n| Max Drawdown | 0% |\n| Net Profit | 0% |\n| Equity finale | $100,000.00 |\n\n*RSI mean reversion (buy RSI<30, limit -0.5%, SL -2%, TP +5%), RUNTIME ERROR: data Close None first bar, RSI never triggered before crash, Q1 2023*"
+    "**Resultats Backtest QC Cloud** - `MeanReversionOrders` (2015-2024, $100,000 initial)\n",
+    "\n",
+    "> **Runtime Error (backtest QC Cloud, bt 79864670e37067a4a1477a35d3888cc4).** La strategie de reference achat sur survente RSI<30 avec limit -0.5%, stop-loss -2%, take-profit +5%, puis Runtime Error a 2015-03-20 : meme gotcha `Close None` malgre le guard `ContainsKey` (le RSI n'a pas eu le temps de se declencher sur un marche haussier debut 2015). Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas commitees (G.2 : aucune metrique non-verifiable). La table fabriquee d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
+    "\n",
+    "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 79864670e37067a4a1477a35d3888cc4).*"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Prong-A audit (#3801 SOTA-not-workaround, tracker #3845, audit #3367). Six result cells in **QC-Py-09-Order-Types** were **cat-1 fabrications**: each claimed a `"Q1 2023 (62 dates)"` window with fabricated metrics, while the reference algos set `SetStartDate(2015,1,1)` + `SetEndDate(2024,12,31)` (10-year backtest). Markdown-vs-code contradiction = #3367 cat-1.

Deployed all 6 reference algos **verbatim** on QC Cloud (project `33177683`, 2015-2024) and replaced the fabricated tables with the real per-cell ground truth + bt ids.

## Evidence bar (per ai-01: every committed value traces to a cited bt id)

Project URL: https://www.quantconnect.com/project/33177683
Verify command: `read_backtest(project_id=33177683, backtest_id=<id>)`

| cell | algo | outcome | Sharpe | CAGR | MaxDD | PSR | backtest id |
|------|------|---------|--------|------|-------|-----|-------------|
| #37 | LITExample | **real trade** | 0.073 | 3.502% | 9.100% | 8.672% | `8d5fc20fc6e983aa27074181a9e1a1e8` |
| #42 | CancelOrderExample | **true 0-trade** | 0 | 0% | 0% | 0% | `37bba9607b5d1621d1c7b173a173a36f` |
| #15 | LimitOrderExample | Runtime Error | — | — | — | — | `94fdaf130de8f55846fcd1362d2beed3` |
| #40 | UpdateOrderExample | Runtime Error | — | — | — | — | `61c83d4b9d948ac4172e011aed128170` |
| #52 | BestPracticesExample | Runtime Error | — | — | — | — | `e966170dc9db35982cf134cf5d46018e` |
| #59 | MeanReversionOrders | Runtime Error | — | — | — | — | `79864670e37067a4a1477a35d3888cc4` |

- **Inline caption** (template (a)): each cell caption embeds the bt id in-notebook.
- **cell 37**: NP/Equity derived from verified CAGR (`End = $100,000 x (1+CAGR)^10`), exact. PSR is a reliable `read_backtest` field.

## Per-cell honesty notes

- **cell 37 (real trade)**: LIT order filled (SPY dipped 2%), held 100 SPY 10y. Real metrics table.
- **cell 42 (true 0-trade)**: the algo has no `OnData` and `CancelExamples()` is never called -> genuinely 0 orders, $100,000 unchanged. The fabricated `"RUNTIME ERROR: self.Cancel() not a method"` is removed (code uses `ticket.Cancel()`, valid; and never reached anyway).
- **cells 15/40/52/59 (Runtime Error)**: honest note + bt id, **no fabricated metrics**. Notably the original captions for 15/40/52 *claimed* a Runtime Error that is **REAL**:
  - 15/40/59: `'NoneType' object has no attribute 'Close'` at `data[self.spy].Close` **despite** the `if not data.ContainsKey(self.spy): return` guard — a QC gotcha where `ContainsKey` returns True but the value is None on auxiliary (split/dividend) bars.
  - 52: `can't subtract offset-naive and offset-aware datetimes` in `CancelStaleOrders` (`self.Time` aware vs `order.CreatedTime` naive) — a real bug.
  - Only the `"Q1 2023"` window and the fake 0-trade/metric tables were fabricated; the error narrative was real. Per **G.2** no unverifiable metric is committed: partial stats over the few weeks before each error are not a meaningful 10y result, so no metrics table for these 4 cells.

## Corrects the "cheap caption-only" framing

This was labeled "honest-zero (20) = cheap caption-only" (ai-01 msg kmmqwc). The per-cell QC Cloud deploy proved these are **hidden REAL_FAB / honest-non-exec**, same RECOVERABLE-MACHINE pattern as the greenlit REAL_FAB batch (#3852/#3853/#3854), not caption-only. The committed zero values were themselves fabricated for algos that trade (cell 37) or error (15/40/52/59); only cell 42 is a genuine no-trade.

## Scope (C.2 / C.3)

- Markdown-only (6 result cells). No code cell, no output changed.
- 64 -> 64 cells. LF line endings preserved. Catalogue byte-identical.
- Diff 32 ins / 54 del (net reduction: fabricated 9-row tables -> concise honest notes; markdown result cells, not code/proof, so anti-regression D does not apply).

## Verification

- `python scripts/notebook_tools/notebook_tools.py validate <nb>` -> OK: 1, 0 warnings, 0 errors.
- Repair-script guards abort unless each cell's unique fabricated marker is present (proves exact replacement).
- 6 bt ids above are live on QC Cloud project 33177683, reproducible via `read_backtest`.

**Reassessed by po-2024: CONFIRMED cat-1 fabrication** (37 grounded in real run; 42 true no-trade; 15/40/52/59 honest Runtime-Error, no fake fill).

See #3367
