### PR TITLE
docs(lean-gt): add Conclusion to social_choice_lean + conway_cgt_lean READMEs (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/README.md
@@ -89,3 +89,41 @@ on top of the imported results.
 - **`knot_lean/`** — references this tour in its dependencies table (Conway game-theory foundation)
 - **`conway_lean/`** — Conway's Game of Life / Free Will Theorem (the *other* Conway series)
 - **Epic #2651** — README/structure audit (Lean-series)
+
+## Conclusion
+
+This project is a **curated tour** (`#check`-based, 0 `sorry`) of the
+combinatorial game theory now living in
+[`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games),
+imported as a Lake dependency. It exists because Mathlib's CGT modules were
+**removed in Feb 2026** (PR [#35550](https://github.com/leanprover-community/mathlib4/pull/35550)),
+and this tour points learners to where that theory now lives.
+
+### What it covers
+
+- **Combinatorial games** — `IGame` (concrete pre-games by left/right option
+  sets) and `Game` (the quotient up to equivalence `≈`), with birthday and
+  canonical form.
+- **Surreal numbers** — `Surreal` as a complete ordered field containing every
+  ordered field; the **simplicity theorem** as the key computation tool; full
+  field arithmetic; dyadic and ordinal embeddings.
+- **Nimbers** — ordinals with nim arithmetic, arising from impartial games via
+  the **Sprague-Grundy theorem**; a field of characteristic 2 (long-term goal:
+  prove the nimbers algebraically closed).
+
+### Why this exists
+
+Mathlib deprecated its CGT code (`SetTheory.Surreal/PGame/Game/Nimber`) in favor
+of the upstream repository, whose author (vihdzp) is the same maintainer. Rather
+than vendor or re-derive, the tour **cites** the upstream as a dependency and
+exhibits its results via `#check` + docstrings — original exposition on top of
+imported theorems. A Mathlib-vs-upstream comparison table documents the richer
+upstream coverage (15+ modules vs Mathlib's former 8).
+
+### Where to go next
+
+- **Upstream**: [`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games)
+  (Apache-2.0, Violeta Hernandez Palacios) — the current home of CGT in Lean.
+- **Source**: Conway, J.H. — *On Numbers and Games* (2001).
+- **Related**: `conway_lean/` (Conway's Game of Life / Free Will — the *other*
+  Conway series) and `knot_lean/` (references this tour in its deps table).

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
@@ -177,3 +177,42 @@ Ces formalisations Lean sont les bases théoriques pour les notebooks :
 ## Licence
 
 Voir la licence du repository principal.
+
+## Conclusion
+
+Ce projet formalise en Lean 4 (**0 `sorry`**) trois résultats fondateurs de la
+théorie du choix social : le **théorème d'impossibilité d'Arrow**, le **paradoxe
+libéral de Sen** et le **théorème de l'électeur médian**. Les trois théorèmes
+sont FORMAL-CERTIFIED et recompilables via `lake build` sur la toolchain
+`v4.30.0-rc2`.
+
+### Ce qui est prouvé
+
+- **Arrow** (`Arrow.lean`) : toute fonction de welfare social (≥ 3 alternatives)
+  satisfaisant faible-Pareto + IIA est une **dictature** — preuve structurée en
+  quatre étapes à la Geanakoplos (2005), via profils manipulés `maketop`/`makebot`.
+- **Sen** (`Sen.lean`) : aucune procédure sociale ne réconcilie Pareto faible et
+  libéralisme minimal, par contre-exemple direct.
+- **Électeur médian** (`Voting.lean`) : sur préférences single-peaked, la majorité
+  sélectionne le pic de l'électeur médian.
+
+### Pourquoi ça marche
+
+Le framework repose sur des **préférences faibles** `PrefOrder α` (réflexif,
+total, transitif), suivant la tradition d'économie du bien-être (Arrow 1951,
+Sen 1970) : la préférence stricte `P` et l'indifférence `I` sont dérivées d'une
+relation `R` sous-jacente, ce qui rend les définitions directement comparables
+aux textes classiques. Arrow utilise un **dictateur directionnel** (suffisant
+pour une SWF totale) ; Sen renforce l'hypothèse par une décisivité
+**bidirectionnelle**, produisant un paradoxe plus fort (tout résultat
+bidirectionnel implique l'unidirectionnel).
+
+### Où aller ensuite
+
+- **Sources** : Geanakoplos (2005), *Three Brief Proofs of Arrow's Impossibility
+  Theorem* ; Sen (1970), *The Impossibility of a Paretian Liberal*.
+- **Référence externe** : [`DominikPeters/SocialChoiceLean`](https://github.com/DominikPeters/SocialChoiceLean)
+  (Gibbard-Satterthwaite, 15+ règles de vote, framework `LinearOrder` strict) —
+  comparé dans la section « Différences de framework » ci-dessus.
+- **Série** : notebooks [`GameTheory`](../README.md) — 16b (applications Lean),
+  16c (simulations Python), 16e (tour SocialChoiceLean).


### PR DESCRIPTION
## Summary

Adds a `## Conclusion` section to the two GameTheory Lean READMEs that lacked one, following the established **#2651** Conclusion pattern (What / Why / Where-to-go-next), grounded in each project's actual content.

## Changes

- **`social_choice_lean/README.md`** (FR, +41): synthesizes the three FORMAL-CERTIFIED theorems (Arrow / Sen / Median Voter, 0 `sorry`) — the weak-preference `PrefOrder α` framework, the directional-dictator formulation in Arrow, and the bidirectional decisiveness that strengthens Sen's paradox.
- **`conway_cgt_lean/README.md`** (EN, +38): summarizes the curated `#check`-tour of `vihdzp/combinatorial-games` (surreal numbers, nimbers, Sprague-Grundy) and documents why it exists after the Mathlib CGT removal (PR [#35550](https://github.com/leanprover-community/mathlib4/pull/35550)).

## Scope

Docs-only, two READMEs in the same Epic #2651 / Lean GameTheory family (combined ~78 lines, above the docs-PR grouping threshold). Markdown-only: no code, notebook, or catalog changes (catalog byte-identical to main). Trailing newlines normalized (MD047).

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
