### PR TITLE
fix(scrub): replace abs papermill paths in Planners-3 + SL-11 (See #3436)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
@@ -2341,8 +2341,8 @@
    "end_time": "2026-06-20T16:12:25.859956+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-3-State-Space.ipynb",
-   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-3-State-Space_output.ipynb",
+   "input_path": "Planners-3-State-Space.ipynb",
+   "output_path": "Planners-3-State-Space.ipynb",
    "parameters": {},
    "start_time": "2026-06-20T16:12:17.033775+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-11-Capstone-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-11-Capstone-NeuroSymbolic.ipynb
@@ -2056,8 +2056,8 @@
    "end_time": "2026-06-17T02:29:16.661004+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-10-Capstone-NeuroSymbolic_output.ipynb",
+   "input_path": "SL-11-Capstone-NeuroSymbolic.ipynb",
+   "output_path": "SL-11-Capstone-NeuroSymbolic.ipynb",
    "parameters": {},
    "start_time": "2026-06-17T02:29:14.167324+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## What

Scrub residual absolute machine-local papermill paths (`metadata.papermill.input_path`/`output_path`) from 2 notebooks on the CPU/.NET partition. See #3436 (partial — repo-wide remainder stays open).

| Notebook | Leaked path | Cause |
|----------|-------------|-------|
| `SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb` | `D:\CoursIA\...` | Re-executed via Prong-B weighted-terrain fix (#3771 `8905f8845`) + #3164 alignment (#3760), re-injecting abs paths after the prior scrub (#3487) |
| `SymbolicAI/SymbolicLearning/SL-11-Capstone-NeuroSymbolic.ipynb` | `C:\dev\CoursIA\...SL-10-...` | Stale pre-rename paths (file renamed SL-10 -> SL-11 in #3457 renumber `107bf3068`); also fixes the stale `SL-10-` filename reference |

## How

`scripts/notebook_tools/scrub_papermill_paths.py --apply <nb>` — text-level surgical replacement of the abs path with the notebook basename. No JSON re-serialization.

## Verification

- **Surgical / metadata-only**: `git diff --numstat` = `2 2` per notebook (4 ins / 4 del total), every changed line is a `papermill.input_path`/`output_path` metadata line -> basename. **Source, outputs, exec_count byte-identical** (no code/output change -> no re-execution warranted; this is a path-string replacement in metadata).
- **Re-scan clean**: `--scan` on both families returns 0 defects post-apply.
- **Partition scan**: of 9 scanned families, only these 2 had residuals; Search/Tweety/SemanticWeb/SmartContracts/SMT/GameTheory/Sudoku already clean.
- **No collision**: neither notebook is touched by any open PR.
- **Catalog + submodule**: untouched (byte-identical).

Partial delivery to #3436 (2 of the repo-wide residual). `See #3436` (not `Closes` — the repo-wide scrub remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)