### PR TITLE
docs(lean-gt): add Conclusion to 3 GameTheory Lean READMEs (cooperative / lean_game_defs / stable_marriage)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
@@ -27,3 +27,40 @@ Lean 4 formalization of cooperative game theory (Shapley value, core).
 - The lone `sorry` lives in `bondareva_shapley_forward.hCore` (Basic.lean L312). The proof reduces "P ⊆ {x : ∑ xᵢ ≥ v(N)}" to extracting an allocation with equality, which requires either Farkas-style hyperplane separation or a constructive minimum-existence argument over a compact convex set
 - Mathlib4 currently lacks the hyperplane-separation lemma needed; tagged **INTRACTABLE** by the multi-agent prover until that infrastructure lands (cf [LEAN_INVENTORY.md](../LEAN_INVENTORY.md) GO/NO-GO table)
 - Related to `stable_marriage_lean/` (matching theory as cooperative game)
+
+## Conclusion
+
+This project formalizes cooperative game theory in Lean 4 — the **Shapley value**
+(closed, 0 `sorry`) and the **Core** with the **Bondareva-Shapley theorem** (1 `sorry`,
+WIP). It builds with `lake build CooperativeGames` on Mathlib4 (toolchain
+`v4.30.0-rc2`).
+
+### What is proven
+
+- **Shapley value uniqueness** (`Shapley.lean`, 0 `sorry`): the Shapley value is the
+  *unique* allocation satisfying efficiency, symmetry, null-player, and additivity —
+  Shapley's (1953) axiomatic characterization.
+- **Core + Bondareva-Shapley scaffolding** (`Basic.lean`): cooperative game,
+  characteristic function, the Core, and the balanced-game condition, with the `←`
+  direction (balanced ⇒ Core nonempty) reduced to a single extraction step.
+
+### Why the lone sorry remains
+
+The one `sorry` (`Basic.lean:312`, `hb_witness`) is the **LP-dual kernel** of the
+Bondareva-Shapley backward direction: extracting from the balanced condition an
+allocation `x ∈ Core` with `∑ xᵢ ≤ v(N)`. This is a Farkas / hyperplane-separation
+argument over a cone. It is **WIP, not abandoned** — an active plan
+([`docs/BONDAREVA_FARKAS_PLAN.md`](docs/BONDAREVA_FARKAS_PLAN.md)) validates the
+infrastructure (`ProperCone.hyperplane_separation_point` via an `(Option N) → ℝ`
+encoding) and isolates the remaining translation (~150-180 lines; the
+`StrongDual → balanced weights` step is the crux). `FORMAL_STATUS.md` records it as
+WIP_HARD.
+
+### Where to go next
+
+- **Theory**: Bondareva (1963) / Shapley (1967), the Core characterizations;
+  Shapley (1953), *A Value for n-Person Games*.
+- **Active plan**: [`docs/BONDAREVA_FARKAS_PLAN.md`](docs/BONDAREVA_FARKAS_PLAN.md)
+  and [`FORMAL_STATUS.md`](FORMAL_STATUS.md).
+- **Related**: [`stable_marriage_lean/`](../stable_marriage_lean/) (Gale-Shapley
+  matching) and [`social_choice_lean/`](../social_choice_lean/) (Arrow / Sen).

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/README.md
@@ -56,3 +56,42 @@ These projects do **not** depend on `lean_game_defs/` at build time — they ven
 - [GameTheory/README.md](../README.md) — Series overview (OpenSpiel + Lean tracks)
 - [scripts/README.md](../scripts/README.md) — Lean 4 WSL kernel setup
 - [.claude/rules/wsl-kernels.md](../../../.claude/rules/wsl-kernels.md) — Kernel rules
+
+## Conclusion
+
+`lean_game_defs/` is the **introductory definition layer** of the GameTheory Lean
+track: shared Lean 4 type definitions (no proofs, 0 `sorry`) used by the teaching
+notebooks and importable by adjacent Lake projects. It is **not** a standalone Lake
+project — there is no `lakefile.lean`, no toolchain pin, and no Mathlib dependency;
+every file is core Lean 4 only.
+
+### What it provides
+
+Six reference files covering the game-theory curriculum: normal-form / finite games
+([Basic.lean](Basic.lean)), Nash equilibrium and dominance ([Nash.lean](Nash.lean)),
+combinatorial game trees with minimax ([Combinatorial.lean](Combinatorial.lean)),
+social-choice primitives and Arrow's axioms ([SocialChoice.lean](SocialChoice.lean)),
+Bayesian games and signaling ([Bayesian.lean](Bayesian.lean)), and regret
+minimization / CFR ([Regret.lean](Regret.lean)). Each maps to a specific teaching
+notebook and is self-contained.
+
+### How it is used
+
+- **Copy-paste** into a notebook cell (the typical pedagogical workflow);
+- **Import** from an adjacent Lake project via `import GameTheory.lean_game_defs.*`; or
+- **Standalone exploration** via the Lean 4 WSL kernel.
+
+For full combinatorial-game theory (`PGame`, surreals, nimbers), the track points to
+Mathlib's `SetTheory.PGame` / the [`conway_cgt_lean/`](../conway_cgt_lean/) tour
+rather than redefining it here.
+
+### Where to go next
+
+- **Buildable projects** (each vendors its own proof-tailored definitions):
+  [`social_choice_lean/`](../social_choice_lean/) (Arrow / Sen / median voter),
+  [`cooperative_games_lean/`](../cooperative_games_lean/) (Shapley value, Core),
+  [`stable_marriage_lean/`](../stable_marriage_lean/) (Gale-Shapley).
+- **CGT tour**: [`conway_cgt_lean/`](../conway_cgt_lean/) — surreals, nimbers via
+  `vihdzp/combinatorial-games`.
+- **Kernel setup**: [scripts/README.md](../scripts/README.md) and
+  [.claude/rules/wsl-kernels.md](../../../.claude/rules/wsl-kernels.md).

--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
@@ -65,3 +65,41 @@ grep -c sorry StableMarriage/*.lean
 | `social_choice_lean/` | Same Mathlib-based structure, preference orderings |
 | `GameTheory/` | Matching theory as cooperative game (Shapley value) |
 | `Tweety-9-Preferences` | Preference orderings and aggregation |
+
+## Conclusion
+
+This project is a **complete, 0-`sorry`** Lean 4 formalization of the **Gale-Shapley
+Stable Marriage Theorem** (1962) and the **Knuth lattice structure** of its stable
+matchings. All twelve headline results are CLOSED (`lake build StableMarriage`
+SUCCESS, toolchain `v4.30.0-rc2`).
+
+### What is proven
+
+- **Gale-Shapley correctness** — termination in ≤ n² steps, the output is a valid
+  bijection, and no blocking pair exists (the algorithm produces a *stable* matching).
+- **Optimality** — the matching is **man-optimal** (proposers get their best achievable
+  partner) and **woman-pessimal** (receivers get their worst achievable), the latter
+  derived constructively from the former.
+- **Lattice structure** (Knuth 1976) — the set of stable matchings forms a
+  **distributive lattice** under join/meet, both operations preserving stability and
+  the spouse maps injective. Existence of a man-optimal stable matching is shown via a
+  minimal-weight argument on the join semilattice (`exists_isManOptimal`).
+
+### The honest lesson — "intractable" was "false as stated"
+
+Three former statements (`no_cross_match`, `man_optimal_key_step`,
+`doctor_optimal_eq_top`) resisted **30+ prover-harness iterations** before being
+recognized as **mathematically false**: the 3×3 latin-square instance (Knuth 1976)
+with the identity and cyclic-shift matchings refutes all three simultaneously. Their
+`sorry` placeholders were unprovable because the goals were contradictory, not hard.
+The honest replacement (`exists_isManOptimal`) proves *existence* rather than the
+contradictory constructive extraction. This is the same lesson as the Conway P4 case:
+when a proof stalls across many iterations, **refute the statement first**.
+
+### Where to go next
+
+- **Theory**: Gale & Shapley (1962); Knuth, *Marriages Stables* (1976, lattice
+  structure); Gusfield & Irving (1989).
+- **Reference port**: [mmaaz-git/stable-marriage-lean](https://github.com/mmaaz-git/stable-marriage-lean).
+- **Related**: [`social_choice_lean/`](../social_choice_lean/) (preference orderings),
+  [`cooperative_games_lean/`](../cooperative_games_lean/) (matching as cooperative game).


### PR DESCRIPTION
See #2651 — Lean-series README Conclusion rollout (fallback lane, GameTheory Lean track). Completes the GameTheory Lean README Conclusion lane.

## Summary

Adds a `## Conclusion` section to the three GameTheory Lean READMEs that still lacked one.

- **`cooperative_games_lean/README.md`** — synthesizes Shapley value uniqueness (`Shapley.lean`, 0 `sorry`, **closed**) + Core/Bondareva-Shapley scaffolding (`Basic.lean`, 1 `sorry`, WIP). **Honest framing** of the lone `hb_witness` `sorry` (`Basic.lean:312`) as **WIP with an active plan** — the `(Option N) → ℝ` Farkas / hyperplane-separation translation ([`docs/BONDAREVA_FARKAS_PLAN.md`](MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/docs/BONDAREVA_FARKAS_PLAN.md), `FORMAL_STATUS.md` = WIP_HARD), not the stale `INTRACTABLE` tag.

- **`lean_game_defs/README.md`** — synthesizes its role as the **introductory definition layer** of the GameTheory Lean track (6 files, 0 `sorry`, core Lean 4 only, **not** a standalone Lake project), how it is used (copy-paste / import / WSL kernel), and pointers to the buildable projects + the CGT tour.

- **`stable_marriage_lean/README.md`** — synthesizes the **complete 0-`sorry`** formalization (all 12 theorems CLOSED: Gale-Shapley correctness, man-optimal/woman-pessimal, Knuth distributive lattice) and the honest **"intractable = false as stated"** lesson (3 former statements refuted by Knuth's 3×3 latin-square after 30+ wasted prover iterations → replaced by `exists_isManOptimal`). Same nature as the Conway P4 case.

## Scope

- Docs-only, 3 files, **+114 / -0** (purely additive: 37 + 39 + 38 lines).
- English, to match each README's body language.
- No code, no `*.lean`, no notebook, **no catalog regeneration** (catalog left byte-identical to `main`).

## Verification

- Branch rebased onto fresh `origin/main` (0-behind before first commit).
- `git diff --stat` = exactly 3 README files, +114/-0.
- Each section grounded in its README content (Status, Modules, Theorems tables, Notes) + `FORMAL_STATUS.md` / `BONDAREVA_FARKAS_PLAN.md`.

With this PR, the GameTheory Lean README Conclusion lane is **complete** (social_choice + conway_cgt landed via #3859; these three close the remaining gap).

Part of Epic #2651 (Lean-series README Conclusion rollout). See #2651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)