### PR TITLE
Fix(QC-Py-06): ground cell 50 CoveredCallWithRoll in real QC Cloud backtest (#3367)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -1780,7 +1780,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n**Resultats du backtest QC Cloud (CoveredCallWithRoll)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 6 |\n| Sharpe Ratio | 0.493 |\n| CAGR | 11.372% |\n| Max Drawdown | 4.200% |\n| Net Profit | +2.690% |\n| Equity finale | $56,479.50 |\n\n*Covered Call with auto-roll delta 0.30, Q1 2023*"
+    "---\n",
+    "**Resultats Backtest QC Cloud** - Backtest QC Cloud 2022-2023 (projet 33177683, bt d0e9475dfa3f3424b926e2a5d88e98b6)\n",
+    "\n",
+    "| Metrique | Valeur |\n",
+    "|----------|--------|\n",
+    "| Status | Runtime Error (OnEndOfAlgorithm) |\n",
+    "| Sharpe Ratio | -0.414 |\n",
+    "| CAGR | -1.934% |\n",
+    "| Max Drawdown | 19.600% |\n",
+    "| PSR | 3.361% |\n",
+    "| Jours boursiers | 501 |\n",
+    "| Backtest ID | d0e9475dfa3f3424b926e2a5d88e98b6 |\n",
+    "\n",
+    "> CoveredCallWithRoll — verbatim re-exec 2022-2023 (501 jours boursiers). Verdict #3801 : **RECOVERABLE-LOCAL**. La strategie a tourne sur toute la periode (2 ans) puis Runtime-Errored a la toute fin dans `OnEndOfAlgorithm` : `self.StartingCash` n'existe pas en API QC Python (bug de reporting, pas de trading). Les metriques ci-dessus (calculees sur la courbe d'equity des 501 jours) sont REELLES : la strategie PERD de l'argent (Sharpe -0.414, CAGR -1.934%) - l'inverse de la caption fabriquee d'origine (Sharpe 0.493 / +2.69% sur pretendu Q1 2023 / 62 dates). Le bug `StartingCash` = fix local trivial (tracker le cash initial en variable membre, ou `self.Portfolio.CashBook.TotalAmountInAccountCurrency`), follow-up RECOVERABLE-LOCAL.\n",
+    "\n",
+    "*Backtest QC Cloud 2022-01-01 -> 2023-12-31 (projet 33177683, bt d0e9475dfa3f3424b926e2a5d88e98b6) - 501 jours boursiers, Capital initial: $55,000*"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Prong-A QC fabrication audit (EPIC #3801, tracker #3845, audit #3367). Repairs **QC-Py-06 cell 50 (CoveredCallWithRoll)** — a double fabrication surfaced by a G.1 completeness sweep I ran after the sweep was declared closed.

## Why this cell was missed

ai-01's confirmed **FALSE-POSITIVE (DON'T-TOUCH) list** for QC-Py-06 was cells **8/13/20/39/43** — their algos run short-2023 windows matching their captions. **Cell 50 was NOT in that list** because its algo runs a **2-year window** (`SetStartDate(2022,1,1)` + `SetEndDate(2023,12,31)`), so it is a genuine cat-1 fabrication, not an FP. It fell through the cracks.

## Double fabrication (original caption)

1. **Window**: claimed "Q1 2023 / 62 dates" while the code runs 2 years.
2. **Metrics**: claimed **Sharpe 0.493 / CAGR 11.372% / Net Profit +2.69% (a WIN)** — a losing strategy misrepresented as a winner.

## Real QC Cloud re-exec (RECOVERABLE-MACHINE)

Verbatim deploy of the CoveredCallWithRoll algo (cell 49) to QC Cloud, project **33177683**, bt `d0e9475dfa3f3424b926e2a5d88e98b6`:

| Métrique | Caption (fabricated) | Real backtest |
|----------|----------------------|---------------|
| Période | Q1 2023 / 62 dates | **2022-2023 / 501 jours** |
| Sharpe | 0.493 | **-0.414** |
| CAGR | 11.372% | **-1.934%** |
| Max Drawdown | 4.200% | **19.600%** |
| Result | +2.69% (win) | **loss** |

The strategy **lost money** over the full 2-year window — the opposite of the fabricated caption. The backtest Runtime-Errored at the very end (`OnEndOfAlgorithm`: `self.StartingCash` does not exist in QC Python API) — a **reporting bug after all 501 days of trading**, so the equity-curve statistics are valid over the full intended period.

## Verdict #3801: RECOVERABLE-LOCAL

The StartingCash bug is a trivial local fix (track initial cash in a member variable, or use `self.Portfolio.CashBook.TotalAmountInAccountCurrency`) — flagged as a follow-up. The committed caption now carries the real (negative) metrics + bt-ID provenance + the honest verdict.

## Validation (C.2-exempt, markdown-only)

- 1 **markdown** cell changed (cell 50), **0 code** cells, 54 cells preserved.
- Catalog byte-identical, LF/no-BOM, fresh base off `origin/main`.
- "Q1 2023" appears once — an explanatory reference to the original fabrication (*"l'inverse de la caption fabriquée d'origine (Sharpe 0.493 / +2.69% sur prétendu Q1 2023 / 62 dates)"*), not a residual claim.

See #3367 (audit), #3845 (Prong-A tracker), #3801 (SOTA verdicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
