### PR TITLE
Fix(QC-Py-27): de-fabricate cell 13 PaperTradingAlgorithm backtest table (#3367)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -674,7 +674,13 @@
   },
   {
    "cell_type": "markdown",
-   "source": "> **Resultat du backtest QC Cloud** - `PaperTradingAlgorithm` (periode 2023-01-01 a 2023-03-31, $100k initial)\n>\n> | Metrique | Valeur |\n> |----------|--------|\n> | Statut | COMPLETED |\n> | Ordres | 2 |\n> | Sharpe | -2.16 |\n> | Net Profit | -2.46% |\n> | CAGR | -10.1% |\n> | Max Drawdown | 3.2% |\n> | End Equity | $97,537.51 |\n>\n> **Note** : SMA 10/30 crossover sur SPY, 1 trade (perte) en Q1 2023. Le cross-over simple est trop lent pour une periode courte de 3 mois. La strategie a achete en janvier et vendu a perte en mars, coherent avec le sharpe negatif.",
+   "source": [
+    "> **Note - `PaperTradingAlgorithm` (template de paper-trading).** Cet algorithme est concu pour le **paper-trading / live** : sa methode `Initialize()` ne definit **aucune date de backtest** par design (commentaire `# Mode Paper (ne pas definir de dates = live/paper)`), uniquement `SetCash(100000)`. Un template sans dates ne peut structurellement pas produire de resultat de backtest.\n",
+    ">\n",
+    "> Le tableau de metriques qui figurait ici a l'origine (pretendu backtest Q1 2023) etait **fabrique** et a ete retire. Verdict #3801 : fabrication ; fix = de-fabrication (pas de re-exec possible sur un template sans dates).\n",
+    ">\n",
+    "> Ce template illustre le **comportement attendu en live / paper trading** : logging detaille (`LogTrade`), rapports quotidiens et hebdomadaires (`DailyReport`, `WeeklyComparison`), tracking du slippage et du temps de fill (`OnOrderEvent`), alertes sur drawdown et deviation de performance (`Notify.Sms` / `Notify.Email`). Il s'agit d'une **structure de deploiement**, NON d'une performance issue d'un backtest reel."
+   ],
    "metadata": {}
   },
   {


### PR DESCRIPTION
## Summary

Prong-A QC fabrication audit (EPIC #3801, tracker #3845, audit #3367). De-fabricates **QC-Py-27 cell 13 (PaperTradingAlgorithm)** — a fabrication outside the original sweep scope (QC-Py-27 Production-Deployment was never triaged), surfaced by a G.1 completeness sweep.

## The fabrication

The cell claimed a full backtest result for `PaperTradingAlgorithm`:

> Statut COMPLETED · 2 Ordres · Sharpe -2.16 · Net Profit -2.46% · CAGR -10.1% · Max Drawdown 3.2% · End Equity $97,537.51 · "periode 2023-01-01 a 2023-03-31"

But `PaperTradingAlgorithm` **structurally cannot produce a backtest**: it is a paper-trading template whose `Initialize()` sets **no dates by design** (`# Mode Paper (ne pas definir de dates = live/paper)`, only `SetCash(100000)`). A template without `SetStartDate`/`SetEndDate` cannot generate backtest metrics, so the entire table was pure fabrication.

## Fix: DE-FABRICATION (not deploy)

Per ai-01 directive (msg-20260621T191511-mz3k7b): one cannot "re-run" a no-date template, so the honest fix is to **remove the fabricated backtest table** and replace it with a **neutral, pedagogical note**:
- the template has no backtest dates by design,
- the original table was fabricated and removed,
- the template illustrates **live/paper-trading behavior** (logging, daily/weekly reports, slippage tracking, alerts), NOT a backtest performance.

No fake metrics, no real-backtest claim. Kept neutral/pedagogical (public repo, paper-trading framing).

## Validation (C.2-exempt, markdown-only)

- 1 **markdown** cell changed (cell 13), **0 code** cells, 36 cells preserved.
- Catalog byte-identical, LF/no-BOM, fresh base off `origin/main`.

See #3367 (audit), #3845 (Prong-A tracker), #3801 (SOTA verdicts). Together with #3864 (QC-Py-06 cell 50), this closes the 2 residual fabrications from the completeness sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
