### PR TITLE
docs(lean): add Conclusion to calibration_lean + mathlib_examples + social_choice_lean_peters READMEs

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.md
@@ -33,3 +33,39 @@ Complementary, not duplicate. `social_choice_lean` uses custom `PrefOrder` (our 
 - Backend for notebook `GameTheory-16e-SocialChoiceLean-Tour.ipynb`
 - Peters' repo pinned at commit `d679d950` for reproducibility
 - Peters uses `LinearOrder` (strict, Mathlib); we use `PrefOrder` (reflexive, total, transitif)
+
+## Conclusion
+
+This project is a **reference tour** of
+[DominikPeters/SocialChoiceLean](https://github.com/DominikPeters/SocialChoiceLean),
+imported as a Lake dependency (pinned at commit `d679d950`, toolchain
+`v4.27.0-rc1`) and exhibited via `#check`s in `PetersTour.lean` — **0 `sorry`**,
+`lake build` SUCCESS. It is **not** original formalization: it presents Peters'
+results, the current reference implementation of social-choice theory in Lean 4.
+
+### What the tour covers
+
+- **Gibbard-Satterthwaite** — strategy-proofness implies dictatorship (≥ 3
+  candidates);
+- **Duggan-Schwartz** — multi-winner extension with optimist/pessimist
+  strategy-proofness;
+- **4 Condorcet impossibilities** — Participation, Reinforcement,
+  Strategy-proofness, Anon+Neutral+Resolute;
+- **15+ voting rules** with axiom verification (Split Cycle, Schulze, Copeland,
+  Black, IRV, Borda, …).
+
+### Complementary, not duplicate
+
+This project and [`social_choice_lean/`](../social_choice_lean/) cover the same
+theory through **different frameworks**: Peters uses Mathlib's strict
+`LinearOrder`, while `social_choice_lean/` uses the reflexive-total-transitive
+`PrefOrder` (closer to the welfare-economics tradition). Reading both shows how
+the framework choice shapes the definitions and proofs.
+
+### Where to go next
+
+- **Notebook**: `GameTheory-16e-SocialChoiceLean-Tour.ipynb` — the teaching
+  companion this project backs.
+- **Upstream**: [DominikPeters/SocialChoiceLean](https://github.com/DominikPeters/SocialChoiceLean) (MIT).
+- **Our proofs**: [`social_choice_lean/`](../social_choice_lean/) — Arrow / Sen /
+  median voter in the `PrefOrder` framework.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
@@ -27,3 +27,33 @@ Prover calibration targets for benchmarking the multi-agent Lean prover.
 - This module benchmarks the multi-agent Lean prover's ability to close textbook-style proofs
 - All targets now closed; module is retained as a permanent regression suite for prover changes
 - Verification: `grep -nE '^[^/]*\bsorry\b' Calibration/Nash.lean` returns 0 production hits (cf [Lean README](../Lean-1-Setup.ipynb))
+
+## Conclusion
+
+This project is a **calibration suite** for the multi-agent Lean prover: four
+textbook-style proof targets (C / D / E / F) in `Calibration/Nash.lean`, all
+**proved with 0 `sorry`** (`lake build Calibration` SUCCESS, toolchain
+`v4.30.0-rc2`).
+
+### Why it exists
+
+The targets benchmark the prover's ability to close short, self-contained
+proofs end-to-end. With all four now closed, the module is retained as a
+**permanent regression suite**: any prover change that breaks one of these
+proofs surfaces here as a build failure.
+
+### The grep false-positive lesson
+
+An earlier "4 `sorry`" count was a **measurement artefact** — the word "sorry"
+appeared inside `/-- ... -/` docstrings (prose), not as proof terms. A naive
+`grep sorry` over-counted; the correct check
+`grep -nE '^[^/]*\bsorry\b'` (excluding comments/docstrings) returns 0. The
+same distinction — `sorry` the tactic vs "sorry" the word — applies across the
+whole Lean series.
+
+### Where to go next
+
+- **Prover harness**: [`agent_tests/prover/`](../agent_tests/prover/) — the
+  multi-agent prover these targets calibrate.
+- **Production targets**: [`conway_lean/`](../conway_lean/),
+  [`knot_lean/`](../knot_lean/) — Lean projects the prover also runs against.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/README.md
@@ -24,3 +24,18 @@ Basic Mathlib usage examples for the SymbolicAI/Lean series.
 
 - Companion to notebook `Lean-6-Mathlib-Essentials.ipynb`
 - Part of the SymbolicAI/Lean pedagogical series
+
+## Conclusion
+
+A thin **reference module** of basic Mathlib usage patterns
+(`MathLibExamples/Basic.lean`, 0 `sorry`, `lake build MathLibExamples` SUCCESS),
+serving as the Lean-side companion to the `Lean-6-Mathlib-Essentials.ipynb`
+notebook. It is intentionally minimal — a starting point for students, not a
+survey.
+
+### Where to go next
+
+- **Notebook**: `Lean-6-Mathlib-Essentials.ipynb` — the teaching companion.
+- **Fuller Lean projects**: [`calibration_lean/`](../calibration_lean/),
+  [`conway_lean/`](../conway_lean/), [`sensitivity_lean/`](../sensitivity_lean/)
+  — production Lean built on Mathlib.


### PR DESCRIPTION
See #2651 — Lean-series README Conclusion rollout. This closes the remaining gap in the Lean-family README Conclusion lane: the **last 3 repo-owned Lean READMEs** that lacked a `## Conclusion` (verified absent on `origin/main`).

## Summary

- **`calibration_lean/README.md`** — synthesizes its role as the multi-agent Lean prover **calibration suite** (targets C/D/E/F, 0 `sorry`, retained as a permanent regression suite) + the **grep false-positive lesson** (the earlier "4 sorry" count was "sorry" inside `/-- ... -/` docstrings, not `sorry`-the-tactic; the correct `grep -nE '^[^/]*\bsorry\b'` returns 0).

- **`social_choice_lean_peters/README.md`** — synthesizes the **reference tour** of [DominikPeters/SocialChoiceLean](https://github.com/DominikPeters/SocialChoiceLean) (Gibbard-Satterthwaite, Duggan-Schwartz, 4 Condorcet impossibilities, 15+ voting rules) and the **complementary, not duplicate** framing vs `social_choice_lean/` (Peters' strict `LinearOrder` vs our reflexive `PrefOrder`).

- **`mathlib_examples/README.md`** — short, honest Conclusion (intentionally minimal reference module, companion to `Lean-6-Mathlib-Essentials.ipynb`) + pointers to the fuller Lean projects. Kept proportionate to a thin README (no bloat).

## Scope

- Docs-only, 3 files, **+81 / -0** (purely additive).
- English, to match each README's body language.
- No code, no `*.lean`, no notebook, **no catalog regeneration** (catalog left byte-identical to `main`).

## Verification

- Branch cut from fresh `origin/main` (0-behind / 0-ahead).
- `git diff --stat` = exactly 3 README files, +81/-0.
- Conclusion-presence checked against `origin/main` authoritatively (not a stale working tree — cf. the G.1 lesson: scan `origin/main`, never a behind branch).

With this PR (+ the pending #3863 for cooperative_games_lean / lean_game_defs / stable_marriage_lean), **every repo-owned Lean-family README has a Conclusion** — the `#2651` Lean lane is complete.

Part of Epic #2651. See #2651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)