### PR TITLE
docs(qc-partner-course): franciser student-presentation README (Phase 0.5 #1650)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/student-presentation/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/student-presentation/README.en.md
@@ -1,0 +1,39 @@
+# Student Presentation Template
+
+## Usage
+
+1. Copy `slides.md` into your project directory
+2. Replace `[bracketed sections]` with your content
+3. Add your charts (equity_curve.png, etc.) in the same directory
+4. Launch the presentation:
+
+```bash
+npx slidev slides.md
+```
+
+## Required Sections
+
+| Slide | Section | Expected Content |
+|-------|---------|-----------------|
+| 1 | Title | Strategy name, team |
+| 2 | Outline | Table of contents |
+| 3 | Introduction | Motivation, hypothesis |
+| 4 | Data | Assets, period, preprocessing |
+| 5 | Alpha model | Indicators, signals, risk management |
+| 6-7 | Results | Equity curve + metrics |
+| 8 | Analysis | Strengths/weaknesses, vs benchmark |
+| 9 | Robustness | Sub-periods, sensitivity |
+| 10 | Conclusion | Summary, improvements |
+
+## Timing
+
+- Target: 10 minutes +/- 1 minute
+- ~1 minute per slide (10 content slides)
+- Do not read slides: use keywords and speak naturally
+
+## Tips
+
+- Charts: always with legend, axis labels, and title
+- Metrics: comparative table with benchmark
+- Equity curve: with drawdown below
+- Do not show code in slides (except short snippet for illustration)

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/student-presentation/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/student-presentation/README.md
@@ -1,39 +1,43 @@
-# Student Presentation Template
+# Modèle de Présentation Étudiant
 
-## Usage
+## Utilisation
 
-1. Copy `slides.md` into your project directory
-2. Replace `[bracketed sections]` with your content
-3. Add your charts (equity_curve.png, etc.) in the same directory
-4. Launch the presentation:
+1. Copier `slides.md` dans le répertoire de votre projet
+2. Remplacer les `[sections entre crochets]` par votre contenu
+3. Ajouter vos graphiques (`equity_curve.png`, etc.) dans le même répertoire
+4. Lancer la présentation :
 
 ```bash
 npx slidev slides.md
 ```
 
-## Required Sections
+## Sections requises
 
-| Slide | Section | Expected Content |
-|-------|---------|-----------------|
-| 1 | Title | Strategy name, team |
-| 2 | Outline | Table of contents |
-| 3 | Introduction | Motivation, hypothesis |
-| 4 | Data | Assets, period, preprocessing |
-| 5 | Alpha model | Indicators, signals, risk management |
-| 6-7 | Results | Equity curve + metrics |
-| 8 | Analysis | Strengths/weaknesses, vs benchmark |
-| 9 | Robustness | Sub-periods, sensitivity |
-| 10 | Conclusion | Summary, improvements |
+| Diapositive | Section | Contenu attendu |
+|-------------|---------|-----------------|
+| 1 | Titre | Nom de la stratégie, équipe |
+| 2 | Plan | Table des matières |
+| 3 | Introduction | Motivation, hypothèse |
+| 4 | Données | Actifs, période, prétraitement |
+| 5 | Modèle alpha | Indicateurs, signaux, gestion du risque |
+| 6-7 | Résultats | Courbe d'équité + métriques |
+| 8 | Analyse | Forces/faiblesses, vs référence |
+| 9 | Robustesse | Sous-périodes, sensibilité |
+| 10 | Conclusion | Résumé, améliorations |
 
-## Timing
+## Gestion du temps
 
-- Target: 10 minutes +/- 1 minute
-- ~1 minute per slide (10 content slides)
-- Do not read slides: use keywords and speak naturally
+- Objectif : 10 minutes +/- 1 minute
+- environ 1 minute par diapositive (10 diapositives de contenu)
+- Ne pas lire les diapositives : utiliser des mots-clés et parler naturellement
 
-## Tips
+## Conseils
 
-- Charts: always with legend, axis labels, and title
-- Metrics: comparative table with benchmark
-- Equity curve: with drawdown below
-- Do not show code in slides (except short snippet for illustration)
+- Graphiques : toujours avec légende, étiquettes d'axes et titre
+- Métriques : tableau comparatif avec la référence
+- Courbe d'équité : avec le drawdown en dessous
+- Ne pas montrer de code dans les diapositives (sauf court extrait pour illustration)
+
+---
+
+*Version anglaise (snapshot) : [`README.en.md`](README.en.md).*


### PR DESCRIPTION
## What

Francize `QuantConnect/partner-course-quant-trading/templates/student-presentation/README.md` to French (primary doc language), per `.claude/rules/readme-french-first.md` and EPIC **#1650 Phase 0.5**. Third grain of the FR backfill (after #3872 partner-course main README merged, and #3874 kit-transitoire open). Dispatched by ai-01 (00:35Z queue: kit-transitoire -> student-presentation -> ML-Training-Pipeline).

## Mechanic (rule HARD 2)

1. `git mv README.md -> README.en.md` — EN original preserved **verbatim** (byte-identical to HEAD; verified `git diff HEAD:README.md -- README.en.md` = empty).
2. New FR `README.md` — translates the Slidev student-presentation template (Usage, 10-slide required-sections table, timing, delivery tips).
3. Separator = **point** (`README.en.md`). Adds EN-snapshot pointer at the end.

## Verification (structure + fidelity preserved)

| Check | EN snapshot | FR README |
|-------|-------------|-----------|
| H2 headers | 4 | **4** |
| Table rows (`\|^`) | 11 | **11** |
| EN snapshot vs HEAD README.md | — | **byte-identical** (git mv, diff=0) |
| EN-prose leak in FR | — | **0 lines** |

Code identifiers preserved untranslated (correct): `slides.md`, `[bracketed sections]` (-> `[sections entre crochets]`), `equity_curve.png`, `npx slidev`. "Timing" anglicism francized to "Gestion du temps"; cognates Section / Introduction / Conclusion kept (valid French words). "drawdown" kept as a technical finance term (consistent with QC family convention + kit-transitoire #3874). No `CATALOG-STATUS` marker in this file.

## Scope

- **In scope (rule Phase 0.5)**: `partner-course-quant-trading/templates/student-presentation/` pedagogical README (student-facing Slidev presentation guide). In scope.
- **Out of scope (rule hors-scope list)**: not touched.
- **1/cycle idle backfill**: this PR = student-presentation (39 EN lines). Final QC FR grain queued: `ML-Training-Pipeline/README.md` (mixed EN/FR).

Markdown-only, C.2-exempt (not a notebook), catalog byte-identical.

See #1650
