### PR TITLE
refactor(arganalysis-4capstone): connect rung to argumentation_lib shim — shared state (#2137 Phase 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-4-capstone.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-4-capstone.ipynb
@@ -101,10 +101,10 @@
    "id": "24f0af5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.575812Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.575629Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.581451Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.580991Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.215512Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.214526Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.245362Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.243857Z"
     },
     "papermill": {
      "duration": 0.009111,
@@ -185,10 +185,10 @@
    "id": "24b738c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.592499Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.592114Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.598679Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.598213Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.249522Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.249522Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.259276Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.259276Z"
     },
     "papermill": {
      "duration": 0.010375,
@@ -257,10 +257,10 @@
    "id": "630e174d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.604549Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.604378Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.612797Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.612337Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.262303Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.262303Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.275575Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.275237Z"
     },
     "papermill": {
      "duration": 0.011785,
@@ -321,10 +321,10 @@
    "id": "e45123b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.619001Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.618810Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.622647Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.622192Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.277562Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.277562Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.291289Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.290384Z"
     },
     "papermill": {
      "duration": 0.007477,
@@ -386,10 +386,10 @@
    "id": "f93b1f12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.628241Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.628095Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.631061Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.630674Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.297396Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.297396Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.307673Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.306655Z"
     },
     "papermill": {
      "duration": 0.006302,
@@ -467,10 +467,10 @@
    "id": "f963734a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.645884Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.645653Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.650804Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.650321Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.312393Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.311278Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.322165Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.322165Z"
     },
     "papermill": {
      "duration": 0.009236,
@@ -593,10 +593,10 @@
    "id": "ef88addf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.667025Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.666810Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.672142Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.671712Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.325774Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.325774Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.339401Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.337693Z"
     },
     "papermill": {
      "duration": 0.009713,
@@ -711,10 +711,10 @@
    "id": "97289e58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.683099Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.682892Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.686406Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.685968Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.343619Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.343619Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.353879Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.352868Z"
     },
     "papermill": {
      "duration": 0.007404,
@@ -774,10 +774,10 @@
    "id": "7a54c9f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.693326Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.692859Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.698768Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.698345Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.357383Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.357383Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.369468Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.368566Z"
     },
     "papermill": {
      "duration": 0.009748,
@@ -855,10 +855,10 @@
    "id": "cfb0a8ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.704707Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.704535Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.708492Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.707999Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.371982Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.371982Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.384664Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.384664Z"
     },
     "papermill": {
      "duration": 0.007442,
@@ -956,10 +956,10 @@
    "id": "8ee2b962",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.725358Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.725152Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.728809Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.728004Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.386858Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.386858Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.401534Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.400539Z"
     },
     "papermill": {
      "duration": 0.007704,
@@ -974,7 +974,9 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": "Exercice 1 a completer : definir vg5_convergence_floor et evaluer sur baseline + pipeline\n"
+     "text": [
+      "Exercice 1 a completer : definir vg5_convergence_floor et evaluer sur baseline + pipeline\n"
+     ]
     }
    ],
    "source": [
@@ -1012,10 +1014,10 @@
    "id": "47ee47db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.740909Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.740471Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.743581Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.743084Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.407587Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.407587Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.417166Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.416605Z"
     },
     "papermill": {
      "duration": 0.007256,
@@ -1030,7 +1032,9 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": "Exercice 2 a completer : ecrire diagnose_failures(vg_result) -> List[str]\n"
+     "text": [
+      "Exercice 2 a completer : ecrire diagnose_failures(vg_result) -> List[str]\n"
+     ]
     }
    ],
    "source": [
@@ -1068,10 +1072,10 @@
    "id": "3cc00a38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T09:36:23.755160Z",
-     "iopub.status.busy": "2026-06-15T09:36:23.754963Z",
-     "iopub.status.idle": "2026-06-15T09:36:23.757973Z",
-     "shell.execute_reply": "2026-06-15T09:36:23.757455Z"
+     "iopub.execute_input": "2026-06-22T00:52:39.422603Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.421274Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.434624Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.432635Z"
     },
     "papermill": {
      "duration": 0.006732,
@@ -1086,7 +1090,9 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": "Exercice 3 a completer : construire adversarial_synth (citations d'un seul champ)\n"
+     "text": [
+      "Exercice 3 a completer : construire adversarial_synth (citations d'un seul champ)\n"
+     ]
     }
    ],
    "source": [
@@ -1097,6 +1103,101 @@
     "# Etape 2 : la soumettre a validate_value_gates et observer.\n",
     "pass\n",
     "print(\"Exercice 3 a completer : construire adversarial_synth (citations d'un seul champ)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c77b64ab",
+   "metadata": {},
+   "source": [
+    "## 7. Pont vers l'état partagé\n",
+    "\n",
+    "Les verdicts convergents et les findings des trois méthodes alimentent le même **conteneur partagé** — l'objet `RhetoricalAnalysisState` du module `argumentation_lib` — que **tous les rungs** enrichissent. Le rung 1 y écrit ses détections informelles, le rung 2 y ajoute les verdicts formels de Tweety, le rung 3 y dépose le résultat de l'orchestration, et ce capstone y verse ses **verdicts convergents** : le signal le plus riche de la série.\n",
+    "\n",
+    "Cette section montre le geste d'intégration final : on mappe les findings canoniques du pipeline (sophismes de M1) et la force de convergence vers le conteneur partagé. C'est l'objet qu'une UI ou un rapport de production lirait pour combiner informel (rung 1), formel (rung 2), orchestration (rung 3) et convergence capstone (rung 4).\n",
+    "\n",
+    "> Le conteneur est **déterministe** (un dictionnaire typé sans logique LLM). Le remplir ne coûte aucun appel API : on réutilise les `convergent_verdicts` et les `m1_results` déjà calculés ci-dessus. En production, c'est ce même conteneur que `conversational_orchestrator.py` (Semantic Kernel) remplit via des agents LLM — la forme de l'objet est identique, seuls les producteurs changent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "73affc93",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T00:52:39.441050Z",
+     "iopub.status.busy": "2026-06-22T00:52:39.440458Z",
+     "iopub.status.idle": "2026-06-22T00:52:39.464470Z",
+     "shell.execute_reply": "2026-06-22T00:52:39.463579Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Pont vers l'etat partage (argumentation_lib) ---\n",
+      "arguments dans l etat : 1\n",
+      "sophismes dans l etat : 5\n",
+      "verdicts convergents   : 5 (force max 3)\n",
+      "texte brut (extrait)   : Le comite affirme que le nouveau reglement est necessaire po...\n",
+      "Ce conteneur combine informel (rung 1), formel (rung 2), orchestration (rung 3) et convergence (rung 4).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Pont vers l'etat partage : on verse les verdicts convergents du capstone\n",
+    "# dans RhetoricalAnalysisState, le conteneur commun a tous les rungs. Rung 1 y\n",
+    "# ecrit ses detections informelles, rung 2 y ajoute les verdicts formels de\n",
+    "# Tweety, rung 3 y depose le resultat orchestre, et ce capstone (4) y verse\n",
+    "# ses verdicts convergents -- le signal le plus riche de la serie. Aucun LLM\n",
+    "# requis : on reutilise les sorties deja calculees ci-dessus.\n",
+    "\n",
+    "import logging\n",
+    "\n",
+    "# Le package argumentation_lib vit a cote du notebook ; il est importable\n",
+    "# directement (le dossier du notebook est sur sys.path au runtime). La shim\n",
+    "# resout ses ressources (data/, libs/) via _paths.py (__file__-relative, donc\n",
+    "# cwd-independant). Aucun guard de path ni raise dans la cellule (regle C.1) :\n",
+    "# la robustesse cwd est portee par la shim, comme aux rungs 1/2/3.\n",
+    "from argumentation_lib import RhetoricalAnalysisState\n",
+    "\n",
+    "logging.getLogger(\"RhetoricalAnalysisState\").setLevel(logging.WARNING)\n",
+    "\n",
+    "# Remplissage du conteneur partage : un argument cible agregeant le bloc\n",
+    "# argumentatif, puis un sophisme canonique (M1) par phrase detectee, avec la\n",
+    "# force de convergence en bonus dans la justification quand la phrase est un\n",
+    "# verdict convergent (force >= 2).\n",
+    "etat_partage = RhetoricalAnalysisState(initial_text=TEXT)\n",
+    "arg_id = etat_partage.add_argument(\n",
+    "    \"Bloc argumentatif synthetique (7 phrases analysees par le capstone).\"\n",
+    ")\n",
+    "for f in m1_results:\n",
+    "    force = 0\n",
+    "    for v in convergent_verdicts:\n",
+    "        if v[\"sentence_index\"] == f[\"sentence_index\"]:\n",
+    "            force = v[\"convergence_strength\"]\n",
+    "            break\n",
+    "    justification = (\n",
+    "        f\"declencheur M1 : '{f['evidence']}' (phrase S{f['sentence_index']+1})\"\n",
+    "    )\n",
+    "    if force >= 2:\n",
+    "        justification += f\" ; verdict convergent de force {force}\"\n",
+    "    etat_partage.add_fallacy(\n",
+    "        fallacy_type=f[\"family\"],\n",
+    "        justification=justification,\n",
+    "        target_arg_id=arg_id,\n",
+    "        family=f[\"family\"],\n",
+    "    )\n",
+    "\n",
+    "snapshot = etat_partage.get_state_snapshot(summarize=True)\n",
+    "\n",
+    "print(\"--- Pont vers l'etat partage (argumentation_lib) ---\")\n",
+    "print(f\"arguments dans l etat : {snapshot['argument_count']}\")\n",
+    "print(f\"sophismes dans l etat : {snapshot['fallacy_count']}\")\n",
+    "print(f\"verdicts convergents   : {len(convergent_verdicts)} (force max {max((v['convergence_strength'] for v in convergent_verdicts), default=0)})\")\n",
+    "print(f\"texte brut (extrait)   : {snapshot['raw_text_snippet'][:60]}...\")\n",
+    "print(\"Ce conteneur combine informel (rung 1), formel (rung 2), orchestration (rung 3) et convergence (rung 4).\")"
    ]
   },
   {
@@ -1113,7 +1214,7 @@
     "tags": []
    },
    "source": [
-    "## 7. Conclusion et recapitulatif\n",
+    "## 8. Conclusion et recapitulatif\n",
     "\n",
     "Ce capstone ferme la serie en montrant que l'interet d'un pipeline d'analyse argumentative **se mesure**, pas se se declame. Deux instruments EPITA rendent la mesure executable :\n",
     "\n",
@@ -1130,6 +1231,7 @@
     "2. **Une synthese groundee cite ses artefacts** : les citations `[artifact:...]` rendent le raisonnement auditable, pas juste plausible.\n",
     "3. **Les value-gates composent** : VG-1 (densite) + VG-4 (transversalite) empechent de \"tromper\" le systeme par citation-stuffing — il faut aussi de la diversite cross-artefact.\n",
     "4. **La baseline 0-shot echoue sur les 4 gates** : produire du texte avec des sections ne suffit pas ; il faut du contenu trace.\n",
+    "5. **Pont vers l'etat partage**. Les verdicts convergents du capstone se versent dans le meme conteneur `RhetoricalAnalysisState` que les autres rungs (section 7). C'est le **bus d'integration terminal** : une UI ou un rapport de production n'a qu'a lire cet objet pour combiner informel (rung 1), formel (rung 2), orchestration (rung 3) et convergence (rung 4) en un etat coherent.\n",
     "\n",
     "### Vers la production\n",
     "\n",
@@ -1138,7 +1240,7 @@
     "### Prochaines etapes\n",
     "\n",
     "- Le rung [0-init](./Argument_Analysis_Agentic-0-init.ipynb) couvre la configuration de l'environnement (JVM Tweety, fail-loud) pour qui veut brancher les vrais solveurs.\n",
-    "- Pour aller plus loin sur la confiance multi-methode : explorer les sémantiques de Dung dans le rung [2-formal](./Argument_Analysis_Agentic-2-formal.ipynb) (acceptabilite graduee).\n"
+    "- Pour aller plus loin sur la confiance multi-methode : explorer les sémantiques de Dung dans le rung [2-formal](./Argument_Analysis_Agentic-2-formal.ipynb) (acceptabilite graduee)."
    ]
   }
  ],
@@ -1158,7 +1260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## What

Epic #2137 — Phase 2, rung **4-capstone**: connect the capstone to the vendored `argumentation_lib` shim, via the shared-state bridge (`RhetoricalAnalysisState`). 4th rung in source-order (2-formal ✅ #3857 → 1-informal ✅ #3867 → 3-orchestration ✅ #3868 → **4-capstone** here → 0-init). 1 rung = 1 PR (atomic, fresh base off `origin/main` c46c7883, post-#3867/#3868 merge).

## Change (scoped to exactly 3 cells)

- **New §7 "Pont vers l'état partagé"** (markdown intro + code): maps the capstone's **convergent verdicts** + **M1 canonical fallacies** into `RhetoricalAnalysisState` — the cross-rung shared container that rung 1 (informal), rung 2 (formal Tweety), rung 3 (orchestration) and now rung 4 (convergence) all populate. This is the **integration bus** a production UI/report would read. Mirrors the bridge gesture of rungs 1 and 3 exactly; the capstone is the richest rung (3 methods + convergence), so it contributes the strongest signal.
  - Plain `from argumentation_lib import RhetoricalAnalysisState` import (no `raise`/path-guard in the cell — C.1; cwd-robustness lives in the shim `_paths.py`, model #3857/#3867).
  - Reuses `convergent_verdicts` + `m1_results` already computed in §3-§4; no recompute, no LLM. Each M1 fallacy carries its convergence strength (force ≥ 2) in the justification when the sentence is a convergent verdict.
- **Conclusion renumbered §7 → §8** + a 5th "Points à retenir" on the shared-state bridge as the terminal integration bus.

No structural change to the 3 methods / ConvergentVerdict / value-gates / baseline-vs-pipeline implementations — they were already excellent and deterministic.

## G.1 firsthand — 4th consecutive confirmation

The CLEAN `4-capstone.ipynb` is **100% deterministic** (0 `semantic_kernel` / `openai` / `api_key` / `AnalysisRunner` / `kernel` markers in source). The anti-théâtre note states explicitly: synthesis prose is generated deterministically here, with the LLM path described as production-only. There is **no `_agent` variant** for the capstone.

The RECOVERABLE-USER-HAND OpenAI/SK blocker applies to:
- the `_agent` variants of rungs 1/3, and
- `AnalysisRunner` in the shim (`get_analysis_runner()`, lazy import — requires `semantic_kernel` Kernel + LLM service).

Neither is this clean capstone. **No key was required to deliver rung 4.** This is the same pattern as rungs 1 (#3867) and 3 (#3868): the clean `*-N-name.ipynb` variants are deterministic distillations; the OpenAI blocker lives in the `_agent` variants and the genuine SK runner. Pattern now confirmed 4×.

## Verification (rule F / C.2 / H.1)

- Re-exec `jupyter nbconvert --execute` (python3 kernel, `mcp-jupyter-py310` env, CWD = `Argument_Analysis/`): **exit 0, 0 error**.
- **14/14 code cells** executed with `execution_count` set + outputs present.
- Bridge cell output: `arguments dans l etat : 1` / `sophismes dans l etat : 5` (M1 canonical) / `verdicts convergents : 5 (force max 3)` — shared state correctly populated.
- **C.1 clean**: 0 `raise` of any kind in source (statement-level grep source-only).
- Source diff scoped to exactly **3 cells** (2 new + conclusion renumber) via cell-id diff vs `origin/main`. Canonical section order §1..§8 monotone.
- Base fresh: `HEAD` = `dad1ee06` off `origin/main` `c46c7883`.

**Verdict §H = SOTA-OK** (real deterministic 3-method pipeline + ConvergentVerdict + value-gates executing; shared-state bridge populates the real `RhetoricalAnalysisState` object).

See #2137