### PR TITLE
refactor(arganalysis-0init): connect rung to argumentation_lib shim, drop notebook raises (C.1, #2137 Phase 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
@@ -28,9 +28,9 @@
     "\n",
     "## Objectifs\n",
     "\n",
-    "Ce notebook d'initialisation verifie que l'environnement d'execution formel est operationnel : Python, la passerelle JPype vers la JVM, le JDK 17 portable et les 76 jars de TweetyProject. Il se termine par un **smoke test** qui interroge le vrai solveur propositionnel Tweety (un modus ponens meteorologique). C'est la porte d'entree de la serie : une fois ce rung valid, les rungs 1 a 4 s'appuient sur un socle formel reel.\n",
+    "Ce notebook d'initialisation verifie que l'environnement d'execution formel est operationnel : Python, la passerelle JPype vers la JVM, le JDK 17 portable et les jars de TweetyProject. Il se termine par un **smoke test** qui interroge le vrai solveur propositionnel Tweety (un modus ponens meteorologique). C'est la porte d'entree de la serie : une fois ce rung valide, les rungs 1 a 4 s'appuient sur un socle formel reel.\n",
     "\n",
-    "> **Note anti-theatre** : cette serie **refuse le mode degrade**. Si la JVM ou Tweety est absent, le notebook echoue bruyamment (`raise RuntimeError`) plutot que de simuler un raisonnement formel. Un solveur formel simule par un LLM n'est PAS un solveur formel (mandat EPITA #2137). Cette cellule d'init est donc le verrou qui garantit que les rungs suivants tournent sur du vrai.\n"
+    "> **Note anti-theatre** : cette serie **refuse le mode degrade**. Si la JVM ou Tweety est absent, le notebook echoue bruyamment (le smoke test de la section 5 ne peut pas charger les classes Tweety via JPype) plutot que de simuler un raisonnement formel. Un solveur formel simule par un LLM n'est PAS un solveur formel (mandat EPITA #2137). Cette cellule d'init est donc le verrou qui garantit que les rungs suivants tournent sur du vrai."
    ]
   },
   {
@@ -54,15 +54,15 @@
     "### Ce que ce rung fait\n",
     "\n",
     "- Verifie que `jpype` est importable (passerelle Python-Java).\n",
-    "- Localise le dossier `Tweety/` (JDK 17 portable + 76 jars), **fail-loud** s'il manque.\n",
-    "- Demarre la JVM via `init_tweety()`, **fail-loud** si elle ne s'amorce pas.\n",
+    "- Localise le dossier `Tweety/` (JDK 17 portable + les jars) via la shim `argumentation_lib`, **fail-loud** s'il manque.\n",
+    "- Demarre la JVM via la shim `argumentation_lib.initialize_jvm()`, **fail-loud** si elle ne s'amorce pas.\n",
     "- Execute un **smoke test** : un modus ponens meteorologique resolu par le vrai `SimplePlReasoner` de Tweety.\n",
     "- Recapitule l'etat de l'environnement dans une checklist.\n",
     "\n",
     "### Ce que ce rung ne fait pas\n",
     "\n",
     "- Pas d'appel LLM ni de `semantic_kernel` (le legacy `0-init_agent.ipynb` couvrait la configuration LLM/OpenAI ; ce compact se concentre sur le socle formel).\n",
-    "- Pas d'extraction informelle ni de detection de sophismes (rung 1).\n"
+    "- Pas d'extraction informelle ni de detection de sophismes (rung 1)."
    ]
   },
   {
@@ -90,10 +90,10 @@
    "id": "4f82f541",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:14:36.375737Z",
-     "iopub.status.busy": "2026-06-15T11:14:36.375221Z",
-     "iopub.status.idle": "2026-06-15T11:14:36.509586Z",
-     "shell.execute_reply": "2026-06-15T11:14:36.508981Z"
+     "iopub.execute_input": "2026-06-22T03:03:28.258923Z",
+     "iopub.status.busy": "2026-06-22T03:03:28.258923Z",
+     "iopub.status.idle": "2026-06-22T03:03:28.316244Z",
+     "shell.execute_reply": "2026-06-22T03:03:28.314770Z"
     },
     "papermill": {
      "duration": 0.138398,
@@ -109,8 +109,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Python : 3.13.3\n",
-      "JPype : 1.7.0 (passerelle Python-Java OK)\n"
+      "Python : 3.10.18\n",
+      "JPype : 1.6.0 (passerelle Python-Java OK)\n"
      ]
     }
    ],
@@ -128,11 +128,11 @@
     "    print(\"Installez avec : pip install jpype1\")\n",
     "    JPYPE_OK = False\n",
     "\n",
-    "if not JPYPE_OK:\n",
-    "    raise RuntimeError(\n",
-    "        \"JPype indisponible. La serie #2137 requiert la passerelle Python-Java \"\n",
-    "        \"pour invoquer le vrai solveur Tweety. Installez jpype1 avant de continuer.\"\n",
-    "    )\n"
+    "# Aucun guard fatal dans la cellule (regle C.1 : pas de raise). Si JPype est\n",
+    "# absent, l'amorcage de la JVM via la shim a la section 4 ne demarrera pas et le\n",
+    "# smoke test de la section 5 echouera alors bruyamment (impossible de charger les\n",
+    "# classes Tweety). Le mode degrade (simulation LLM d'un solveur formel) reste\n",
+    "# interdit par construction (anti-theatre, mandat EPITA #2137)."
    ]
   },
   {
@@ -160,10 +160,10 @@
    "id": "0e7a612d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:14:36.519434Z",
-     "iopub.status.busy": "2026-06-15T11:14:36.519097Z",
-     "iopub.status.idle": "2026-06-15T11:14:36.526568Z",
-     "shell.execute_reply": "2026-06-15T11:14:36.525882Z"
+     "iopub.execute_input": "2026-06-22T03:03:28.320137Z",
+     "iopub.status.busy": "2026-06-22T03:03:28.319137Z",
+     "iopub.status.idle": "2026-06-22T03:03:28.347062Z",
+     "shell.execute_reply": "2026-06-22T03:03:28.345607Z"
     },
     "papermill": {
      "duration": 0.011307,
@@ -179,54 +179,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dossier Tweety localise : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\n",
-      "Jars Tweety trouves : 76\n",
+      "Dossier Tweety resolu via la shim : D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\n",
+      "Jars Tweety trouves : 42\n",
       "JDK portable present : True\n"
      ]
     }
    ],
    "source": [
-    "from pathlib import Path\n",
+    "# Localisation du dossier Tweety via la shim argumentation_lib. La robustesse\n",
+    "# cwd (resolution __file__-relative, AUCUN walk manuel) est portee par la shim\n",
+    "# (_paths.py), comme aux rungs 1/2/3/4 -- aucun guard de path ni raise dans la\n",
+    "# cellule (regle C.1).\n",
+    "from argumentation_lib._paths import SYMBOLIC_AI_DIR\n",
     "\n",
-    "cwd = Path.cwd()\n",
-    "tweety_dir = None\n",
-    "candidate = cwd\n",
-    "for _ in range(6):\n",
-    "    if (candidate / \"Tweety\" / \"libs\").is_dir():\n",
-    "        tweety_dir = candidate / \"Tweety\"\n",
-    "        break\n",
-    "    if (candidate / \"libs\").is_dir() and (candidate / \"tweety_init.py\").exists():\n",
-    "        tweety_dir = candidate\n",
-    "        break\n",
-    "    if len(candidate.parts) > 1:\n",
-    "        candidate = candidate.parent\n",
-    "    else:\n",
-    "        break\n",
-    "\n",
-    "if tweety_dir is None:\n",
-    "    raise RuntimeError(\n",
-    "        \"Dossier Tweety/libs introuvable depuis %r. Lancez Papermill avec \"\n",
-    "        \"--cwd MyIA.AI.Notebooks/SymbolicAI ou executez depuis le dossier \"\n",
-    "        \"Argument_Analysis.\" % cwd\n",
-    "    )\n",
-    "\n",
-    "# Inventaire des composants attendus.\n",
-    "libs_dir = tweety_dir / \"libs\"\n",
-    "jdk_root = tweety_dir / \"jdk-17-portable\"\n",
+    "TWEETY_DIR = SYMBOLIC_AI_DIR / \"Tweety\"\n",
+    "libs_dir = TWEETY_DIR / \"libs\"\n",
+    "jdk_root = TWEETY_DIR / \"jdk-17-portable\"\n",
     "jars = sorted(libs_dir.glob(\"*.jar\"))\n",
     "\n",
-    "print(f\"Dossier Tweety localise : {tweety_dir}\")\n",
+    "print(f\"Dossier Tweety resolu via la shim : {TWEETY_DIR}\")\n",
     "print(f\"Jars Tweety trouves : {len(jars)}\")\n",
     "print(f\"JDK portable present : {jdk_root.is_dir()}\")\n",
     "\n",
-    "if len(jars) == 0 or not jdk_root.is_dir():\n",
-    "    raise RuntimeError(\n",
-    "        \"Composants Tweety manquants (jars=%d, jdk=%s). Verifiez \"\n",
-    "        \"jdk-17-portable/ et libs/*.jar sous %s. Re-executez le script \"\n",
-    "        \"d'installation du JDK si necessaire.\" % (len(jars), jdk_root.is_dir(), tweety_dir)\n",
-    "    )\n",
-    "\n",
-    "TWEETY_DIR = tweety_dir\n"
+    "# Aucun raise (regle C.1) : si les composants manquent, l'amorcage JVM de la\n",
+    "# section 4 retournera False et le smoke test de la section 5 echouera\n",
+    "# bruyamment. Le mode degrade (simulation) reste interdit (anti-theatre #2137)."
    ]
   },
   {
@@ -254,10 +231,10 @@
    "id": "8c1ef651",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:14:36.537756Z",
-     "iopub.status.busy": "2026-06-15T11:14:36.537398Z",
-     "iopub.status.idle": "2026-06-15T11:14:37.155388Z",
-     "shell.execute_reply": "2026-06-15T11:14:37.154838Z"
+     "iopub.execute_input": "2026-06-22T03:03:28.350582Z",
+     "iopub.status.busy": "2026-06-22T03:03:28.350582Z",
+     "iopub.status.idle": "2026-06-22T03:03:29.155635Z",
+     "shell.execute_reply": "2026-06-22T03:03:29.154613Z"
     },
     "papermill": {
      "duration": 0.622642,
@@ -282,38 +259,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JVM demarree avec 76 JARs.\n",
+      "JVM demarree avec 42 JARs.\n",
       "\n",
       "JVM operationnelle : True\n",
-      "Classpath Tweety charge depuis : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\libs\n"
+      "Classpath Tweety charge depuis : D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\libs\n",
+      "Amorcage shim reussi : True\n"
      ]
     }
    ],
    "source": [
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "# init_tweety() resout libs/ et jdk-17-portable/ relativement au cwd.\n",
-    "os.chdir(str(TWEETY_DIR))\n",
-    "# Rendre tweety_init importable.\n",
-    "sys.path.insert(0, str(TWEETY_DIR))\n",
-    "sys.path.insert(0, str(TWEETY_DIR.parent))\n",
-    "\n",
-    "from tweety_init import init_tweety\n",
     "import jpype\n",
     "\n",
-    "jvm_ok = init_tweety(verbose=True)\n",
-    "if not jvm_ok or not jpype.isJVMStarted():\n",
-    "    raise RuntimeError(\n",
-    "        \"JVM/Tweety non demarree. Verifiez jdk-17-portable/ et libs/*.jar \"\n",
-    "        \"sous MyIA.AI.Notebooks/SymbolicAI/Tweety/. Mode degrade (simulation \"\n",
-    "        \"LLM) INTERDIT dans cette serie (anti-theatre, mandat #2137).\"\n",
-    "    )\n",
+    "# Amorcage de la JVM via la shim argumentation_lib. La shim resout le dossier\n",
+    "# Tweety (cwd-indep), stage sys.path pour rendre Tweety.tweety_init importable,\n",
+    "# chdir dans le dossier Tweety, puis appelle init_tweety() -- elle encapsule\n",
+    "# toute la configuration manuelle (classpath, JAVA_HOME, jars). Aucun appel\n",
+    "# direct a tweety_init, aucun guard de path/raise dans la cellule (regle C.1),\n",
+    "# comme au rung 2-formal (#3857).\n",
+    "from argumentation_lib import initialize_jvm\n",
     "\n",
-    "JVM_OK = True\n",
+    "JVM_OK = initialize_jvm(verbose=True)\n",
+    "\n",
     "print(f\"\")\n",
     "print(f\"JVM operationnelle : {jpype.isJVMStarted()}\")\n",
-    "print(f\"Classpath Tweety charge depuis : {TWEETY_DIR / 'libs'}\")\n"
+    "print(f\"Classpath Tweety charge depuis : {TWEETY_DIR / 'libs'}\")\n",
+    "print(f\"Amorcage shim reussi : {JVM_OK}\")"
    ]
   },
   {
@@ -343,10 +313,10 @@
    "id": "9e03a613",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:14:37.172735Z",
-     "iopub.status.busy": "2026-06-15T11:14:37.172402Z",
-     "iopub.status.idle": "2026-06-15T11:14:37.264635Z",
-     "shell.execute_reply": "2026-06-15T11:14:37.264132Z"
+     "iopub.execute_input": "2026-06-22T03:03:29.159773Z",
+     "iopub.status.busy": "2026-06-22T03:03:29.158774Z",
+     "iopub.status.idle": "2026-06-22T03:03:29.219042Z",
+     "shell.execute_reply": "2026-06-22T03:03:29.218033Z"
     },
     "papermill": {
      "duration": 0.097645,
@@ -397,14 +367,12 @@
     "# Le smoke test est le temoin : si ces deux valeurs sont correctes, la JVM Tweety\n",
     "# resout reellement la logique propositionnelle (pas une simulation).\n",
     "SMOKE_OK = entails_wet and not entails_not_wet\n",
-    "if not SMOKE_OK:\n",
-    "    raise RuntimeError(\n",
-    "        \"Smoke test Tweety ECHOUE : le solveur ne resout pas le modus ponens \"\n",
-    "        \"attendu (wet=True, !wet=False). La JVM est demarree mais Tweety est \"\n",
-    "        \"incoherent -- verifier les versions de jars.\"\n",
-    "    )\n",
+    "# Aucun raise (regle C.1) : SMOKE_OK=False signale un probleme de coherence des\n",
+    "# jars sans interrompre le notebook. Si la JVM etait absente (section 4), cette\n",
+    "# cellule aurait deja echoue bruyamment ci-dessus : jpype.JClass ne peut pas\n",
+    "# charger les classes Tweety sans JVM demarree -- le mode degrade reste interdit.\n",
     "print(f\"\")\n",
-    "print(f\"SMOKE_OK = {SMOKE_OK} : socle formel operationnel pour les rungs suivants.\")\n"
+    "print(f\"SMOKE_OK = {SMOKE_OK} : socle formel operationnel pour les rungs suivants.\")"
    ]
   },
   {
@@ -427,8 +395,8 @@
     "|-----------|------|------|\n",
     "| Python + JPype | Passerelle Python-Java | OK |\n",
     "| JDK Zulu 17 portable | Machine virtuelle Java | OK |\n",
-    "| 76 jars Tweety | Solveurs (PL, FOL, modale, Dung) | OK |\n",
-    "| `init_tweety()` | Amorcage JVM + classpath | OK |\n",
+    "| Jars Tweety | Solveurs (PL, FOL, modale, Dung) | OK |\n",
+    "| `argumentation_lib.initialize_jvm()` | Amorcage JVM + classpath (via la shim) | OK |\n",
     "| Smoke test PL | Modus ponens resolu | OK |\n",
     "\n",
     "L'environnement formel est **pret**. Les rungs suivants peuvent maintenant invoquer le vrai solveur Tweety :\n",
@@ -440,7 +408,7 @@
     "\n",
     "### Le mode degrade est interdit\n",
     "\n",
-    "Si un jour ce notebook echoue sur le `raise RuntimeError` de la JVM, **ne contournez pas** en simulant le solveur avec un LLM. La valeur pedagogique de la serie repose sur le fait que le formel est REEL. Reinstallez le JDK portable et les jars, puis re-executez ce notebook jusqu'a `SMOKE_OK = True`.\n"
+    "Si un jour ce notebook echoue au smoke test (les classes Tweety sont introuvables via JPype, signe que la JVM ou les jars sont absents), **ne contournez pas** en simulant le solveur avec un LLM. La valeur pedagogique de la serie repose sur le fait que le formel est REEL. Reinstallez le JDK portable et les jars, puis re-executez ce notebook jusqu'a `SMOKE_OK = True`."
    ]
   },
   {
@@ -468,10 +436,10 @@
    "id": "4531cec4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:14:37.286251Z",
-     "iopub.status.busy": "2026-06-15T11:14:37.285950Z",
-     "iopub.status.idle": "2026-06-15T11:14:37.289111Z",
-     "shell.execute_reply": "2026-06-15T11:14:37.288558Z"
+     "iopub.execute_input": "2026-06-22T03:03:29.223511Z",
+     "iopub.status.busy": "2026-06-22T03:03:29.222503Z",
+     "iopub.status.idle": "2026-06-22T03:03:29.235452Z",
+     "shell.execute_reply": "2026-06-22T03:03:29.234166Z"
     },
     "papermill": {
      "duration": 0.008555,
@@ -486,7 +454,9 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": "Exercice optionnel a completer : smoke test FOL (syllogisme oiseau/vole) avec SimpleFolReasoner\n"
+     "text": [
+      "Exercice optionnel a completer : smoke test FOL (syllogisme oiseau/vole) avec SimpleFolReasoner\n"
+     ]
     }
    ],
    "source": [
@@ -517,7 +487,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Epic **#2137 Phase 2**, rung **0-init** (DERNIER rung). **Source-order COMPLETE** : 2-formal -> 1-informal -> 3-orchestration -> 4-capstone -> 0-init. Suite de #3857 / #3867 / #3868 / #3878.

## Verdict G.1 firsthand : CLEAN deterministe (5e confirmation consecutive)

`Argument_Analysis_Agentic-0-init.ipynb` = **100% deterministe** : `0` `semantic_kernel`, `0` appel OpenAI, `0` LLM. Le blocker SK/OpenAI vit **uniquement** dans les variants `_agent` + le shim `AnalysisRunner`, **PAS** dans ce rung clean. Pattern CONFIRME 5x (rungs 1, 2, 3, 4, 0-init). **Pas de signal vscode requis** (le rung n'est pas SK-gate).

## Ce que fait la PR

**Connexion shim** (mirroir exact des rungs 1/2/3/4) :
- **Section 3** (cell `0e7a612d`) : `TWEETY_DIR` resolu via `argumentation_lib._paths.SYMBOLIC_AI_DIR` (cwd-indep, `__file__`-relative). Supprime le path-walk manuel 6-niveaux + 2 `raise RuntimeError` (pattern etabli rung 1 #3867, rung 3 #3868).
- **Section 4** (cell `8c1ef651`) : JVM amorcee via `argumentation_lib.initialize_jvm(verbose=True)`, remplacant l'import direct `tweety_init` + `sys.path.insert` + `os.chdir` + `raise`. La shim stage `sys.path`, `chdir` dans le dossier Tweety, appelle `init_tweety()`.

**Cleanup C.1** : 5 `raise RuntimeError` retires des cellules code (sections 2/3/4/5). Conforme a la regle C.1 (pas de `raise` de quelque sorte que ce soit dans une cellule notebook) confirmee par le HOLD ai-01 sur #3867.

## Fail-loud PRESERVE (note de transparence pour ai-01)

La doctrine anti-theatre (mandat EPITA #2137) exige que le notebook **refuse le mode degrade** si la JVM/Tweety est absent. Apres retrait des 5 `raise`, le fail-loud est preserve **MECANIQUEMENT** :
- Si la JVM est absente, `initialize_jvm()` retourne `False` (section 4, sans interrompre).
- Le smoke test (section 5) appelle `jpype.JClass("org.tweetyproject...")` qui **leve une exception Java** si la JVM n'est pas demarree -> le notebook echoue bruyamment.

**Je n'ai PAS modifie la shim** (`initialize_jvm` retourne un bool, ne leve jamais) pour eviter tout risque sur le rung 2 deja merge (#3857) qui depend de son contrat actuel. Si ai-01 prefere que le fail-loud passe par la shim elle-meme (modifier `initialize_jvm` pour lever), il peut over-ruler : c'est un changement isole, j'ai laisse la shim intacte par prudence.

## Re-exec (regle C.2)

`jupyter nbconvert --to notebook --execute --ExecutePreprocessor.kernel_name=python3` (env `mcp-jupyter-py310`, Python 3.10.18, JPype 1.6.0), depuis le dossier du notebook (CWD pour `#load` relatif).

- **EXIT = 0**, **0 cellule en erreur**.
- **5/5 cellules code executees** (`execution_count` non-null, outputs coherents).
- **C.1 clean** : `0` occurrence de `raise` en source (G.1 source-only grep, hors outputs).
- **0 `NotImplementedError` / `assert False` / `1/0`**.
- **Section 2** : `Python : 3.10.18`, `JPype : 1.6.0`.
- **Section 3** : Dossier Tweety resolu via la shim, **42 jars** (cohérent CoursIA-2), JDK portable present.
- **Section 4** : `JVM demarree avec 42 JARs`, `JVM operationnelle : True`, `Amorcage shim reussi : True`.
- **Section 5** (smoke test vrai Tweety, verdict **SOTA-OK** Prong-A) : `wet entailed ? True`, `!wet entailed ? False`, `SMOKE_OK = True`. Le vrai `SimplePlReasoner` de Tweety resout le modus ponens meteorologique.

## Anti-regression (regle D)

PR = refactor d'allegerment sur un notebook pedagogique (PAS du code de production). Les suppressions (103) > insertions (73) correspondent au retrait du path-walk 6-niveaux et des 5 `raise` boilerplate, **remplaces par un import shim 1-ligne**. La fonctionnalite (resoudre Tweety + demarrer JVM + smoke test) est **preservee et verifiee** (SMOKE_OK=True, JVM_OK=True). La regle D vise le code metier/les preuves formelles, pas les cellules de notebook.

## Scope du commit (regle C.3)

1 fichier, 7 cellules modifiees (4 code + 3 markdown), 0 cellule ajoutee/supprimee. Base fraiche `85efa69e` (= origin/main). Submodules `SMT/Automata` et `SMT/Z3.Linq` = preexisting, exclus du staging.

See #2137