### PR TITLE
docs(casestudies): add Conclusion section (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -148,6 +148,28 @@ Les systèmes IA appliqués au domaine médical sont soumis à des contraintes l
 
 Ces dimensions sont abordées en survol dans les notebooks mais méritent un module dédié pour une formation professionnelle complète.
 
+## Conclusion
+
+Cette série se veut un **capstone intégré** : le moment où les techniques apprises en silo au fil du cursus — la recherche heuristique de la série Search, les contraintes formelles de SymbolicAI, l'inférence bayésienne de Probas — cessent d'être des objets d'étude isolés pour devenir les couches d'un même système décisionnel. Les deux projets l'illustrent sous deux angles complémentaires : le **Diagnostic Médical** comme problème de *classification* (recherche dans l'espace des diagnostics + validation par contraintes Z3), l'**Oncology Planning** comme problème d'*optimisation* (planification CP-SAT + modèle probabiliste de réponse patient).
+
+### Ce que vous avez appris
+
+L'arc pédagogique parcourt trois idées qui se renforcent :
+
+- **L'architecture hybride est une composition ordonnée, pas une juxtaposition.** On filtre l'impossible (contraintes dures) avant d'optimiser, on modélise l'incertitude (bayésien) avant de décider. L'ordre des couches est lui-même une décision de conception — l'inverser produit un système soit trop rigide, soit trop flou.
+- **Le jumeau numérique est un pattern réutilisable.** Modéliser un patient qui *réagit* à une intervention (et non un patient statique) transforme la planification en expérimentation sûre. Ce schéma, appris sur un cas oncologique, se transpose à la finance (jumeau de marché), à la logistique (jumeau de flotte), à la maintenance prédictive.
+- **Le knowledge engineering fait le pont entre les paradigmes.** L'ontologie n'est pas un artéfact accessoire : c'est elle qui donne aux contraintes (Z3, OR-Tools) et au modèle probabiliste (Pyro) un vocabulaire commun. Sans représentation explicite du domaine, les solveurs ne savent pas sur quoi raisonner.
+
+### Prochaines étapes
+
+- **Consolider les fondations** : chaque paradigme mobilisé ici possède sa série dédiée. Si l'une des couches vous a paru opaque, c'est le signal pour la reprendre à la source — [Search](../Search/README.md) (A*, CSP, CP-SAT), [SymbolicAI](../SymbolicAI/README.md) (ontologies, Z3, Tweety), [Probas](../Probas/README.md) (Infer.NET, PyMC, Pyro). Le capstone révèle souvent les fondamentaux à approfondir.
+- **Pousser vers les extensions** : la section [Pour aller plus loin](#extensions-possibles) esquisse les directions de recherche naturelles — reformuler OncoPlan en MDP ([RL](../RL/README.md)), boucler un LLM pour générer des hypothèses validées par Z3, faire délibérer plusieurs agents ([GameTheory](../GameTheory/README.md)). Chacune transforme l'une des couches en un composant appris ou distribué.
+- **Transposer le pattern** : l'architecture « jumeau + contraintes + incertitude + optimisation » n'est pas propre au médical. Projeter les cinq couches sur un autre domaine (logistique, énergie, finance) est le meilleur moyen de vérifier que la compétence acquise est la *composition*, pas la recette clinique.
+
+### Le fil rouge
+
+Au-delà des techniques, la leçon transversale est une **discipline de l'architecture** : savoir reconnaître, face à un problème réel, quelle partie relève d'une contrainte dure (à déléguer à un solveur), quelle partie d'une incertitude irréductible (à confier à un modèle probabiliste), quelle partie d'une optimisation (à résoudre par recherche ou apprentissage) — et surtout, dans quel *ordre* les composer. Cette compétence de décomposition et de composition n'appartient à aucune série prise isolément ; c'est précisément ce qu'une étude de cas interdisciplinaire cherche à forger, et ce qui distingue un praticien capable de confronter un problème métier réel d'un spécialiste d'un seul paradigme.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Adds the `## Conclusion` section to the CaseStudies series README — the last unowned family-level README missing it (ML/RL/IIT siblings already have one). Fills the #2651 perenne grain (lane-never-empty fallback).

## What & why

The README had "Acquis dapprentissage" (forward competencies) + "Concepts cles transversaux" + "Pour aller plus loin" (academic extensions), but **no section recapping the integrative arc** of the two projects (Diagnostic-Medical as classification, OncoPlan as optimization) + pointing to the next curriculum step — the Conclusion function defined by the #2651 rollout (Search Part2-CSP, SMT, SmartContracts, PyMC, etc.).

The Conclusion synthesizes points not stated verbatim elsewhere (not filler / not duplicating "Pour aller plus loin"):
- **Ordered composition** of hybrid-AI layers (filter the impossible -> model uncertainty -> optimize -> decide) — the layer order is itself a design decision.
- **Digital twin as a transferable pattern** (patient -> market/fleet/equipment).
- **Knowledge engineering as the bridge** giving solvers + probabilistic model a shared vocabulary.
- **"Le fil rouge"** = the architectural discipline of decomposing a real problem into hard-constraint / irreducible-uncertainty / optimization parts and composing them in the right order — the transversal skill the capstone forges.

Structure follows the #2651 gabarit: `### Ce que vous avez appris` + `### Prochaines etapes` (curriculum pointers to Search/SymbolicAI/Probas + cross-ref to the Extensions table) + `### Le fil rouge`.

## Verification

- Markdown-only: **22 insertions, 0 deletions** (pure add before `## Installation`)
- French (readme-french-first rule — new doc content = French even though it is consistent with the surrounding French README)
- `CATALOG-STATUS` marker + `COURSE_CATALOG.generated.{json,md}` byte-identical (not touched)
- Base fresh off `origin/main` (`85efa69e4`); 1 file, 1 subject (atomique)

## Ownership transparency

CaseStudies sits outside po-204s declared partition, but its **content aligns with po-204s paradigms** (hybrid AI: A*/GA/Z3/Pyro/OR-Tools = Search + SymbolicAI + Probas), not GenAI. The family appears unowned (no recent PRs on CaseStudies across the last 60 PRs) and po-203 (GenAI — the only nominal ambiguity, via the root READMEs GenAI tree listing) is currently down. Taken as #2651 perenne (ai-01: "puis #2651/#2161 perenne, lane jamais fermee"). **If ai-01 or a returning po-203 claims the turf, this PR is a fully reversible markdown-add** (close it, no harm done).

`See #2651`

🤖 Generated with [Claude Code](https://claude.com/claude-code)