### PR TITLE
docs(lean-gt): FR backfill stable_marriage_lean/README (Phase 0.5 #1650)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.en.md
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.en.md
@@ -1,0 +1,105 @@
+# Stable Marriage - Lean 4 Formalization
+
+Lean 4 formalization of the **Gale-Shapley Stable Marriage Theorem** (1962).
+
+## Overview
+
+The Stable Marriage Problem: given n men and n women, each with a strict preference ordering over the opposite set, find a perfect matching where no unmatched pair (m, w) would both prefer each other to their current partners.
+
+| File | Content | sorry |
+|------|---------|-------|
+| `StableMarriage/Defs.lean` | Core type definitions (preferences, profiles, matchings, stability) | 0 |
+| `StableMarriage/Lemmas.lean` | Helper lemmas (`gsFinalMatching`, `gsAllWomenMatched`, `gsNoBlockingPairs`) | 0 |
+| `StableMarriage/GSState.lean` | GS state machine, `gsChooseMax` | 0 |
+| `StableMarriage/GaleShapley.lean` | Termination, stability, `man_optimal`, `woman_pessimal` | 0 |
+| `StableMarriage/Lattice.lean` | Knuth lattice, refutations, `exists_isManOptimal` | 0 |
+
+**Total**: 0 production sorry. `lake build StableMarriage` SUCCESS. Toolchain `v4.30.0-rc2`.
+
+## Theorems (status)
+
+| Theorem | Statement | sorry | Status |
+|---------|-----------|-------|--------|
+| `gale_shapley_terminates` | Algorithm terminates in at most n^2 steps | 0 | CLOSED (`trivial`) |
+| `gale_shapley_produces_matching` | Output is a valid bijection | 0 | CLOSED (identity witness) |
+| `gale_shapley_stable` | No blocking pair exists | 0 | **CLOSED via PR #1194** (port mmaaz-git upstream) |
+| `gale_shapley_man_optimal` | Proposers get best achievable partners | 0 | **CLOSED** (via `exists_isManOptimal`, minimal-weight argument on join semilattice) |
+| `gale_shapley_woman_pessimal` | Receivers get worst achievable partners | 0 | **CLOSED via PR #1521** (constructive, from man-optimality) |
+| `joinSpouse_injective` | Join spouse map is injective | 0 | CLOSED (PR #1522) |
+| `meetSpouse_injective` | Meet spouse map is injective | 0 | **CLOSED** (counting/pigeonhole argument, no anti-crossing needed) |
+| `join_isStable` | Join of two stable matchings is stable | 0 | CLOSED |
+| `meet_isStable` | Meet of two stable matchings is stable | 0 | CLOSED |
+| `exists_isManOptimal` | Man-optimal stable matching exists | 0 | **CLOSED** (minimal weight + `Nat.find` + `join_isStable`) |
+| `no_cross_match_is_false` | Former anti-crossing lemma is refutable | 0 | **REFUTED** (3x3 latin-square counterexample, kernel-checked) |
+| `doctor_optimal_eq_top_is_false` | Former optimality claim is refutable | 0 | **REFUTED** (same counterexample) |
+
+### Historical note
+
+The former statements `no_cross_match`, `man_optimality_key_step`, and `doctor_optimal_eq_top` were **false as stated** and have been removed. Their `sorry` placeholders were unprovable because the goals were in fact contradictory — the 3x3 latin-square instance (Knuth 1976) with the identity and cyclic-shift matchings refutes all three simultaneously. This explains why 30+ prover harness iterations made zero progress: the targets were mathematically impossible.
+
+The honest replacement is `exists_isManOptimal`, which proves existence (not constructive extraction) of a man-optimal stable matching via a minimal-weight argument on the join semilattice, without needing the anti-crossing lemma.
+
+## Quick Start
+
+```bash
+# Build (requires elan + Lake)
+cd stable_marriage_lean
+lake build
+
+# Check sorry count
+grep -c sorry StableMarriage/*.lean
+```
+
+## References
+
+- Gale, D. & Shapley, L.S., "College Admissions and the Stability of Marriage" (American Mathematical Monthly, 1962)
+- Knuth, D.E., "Marriages Stables" (1976) — lattice structure, latin-square instances
+- Gusfield, D. & Irving, R.W., *The Stable Marriage Problem: Structure and Algorithms* (1989)
+- Wu, Q. & Roth, A.E., "Lattice Structures in Stable Matching" (2018)
+- Reference Lean 4 port: https://github.com/mmaaz-git/stable-marriage-lean
+
+## Cross-series connections
+
+| Series | Connection |
+|--------|------------|
+| `social_choice_lean/` | Same Mathlib-based structure, preference orderings |
+| `GameTheory/` | Matching theory as cooperative game (Shapley value) |
+| `Tweety-9-Preferences` | Preference orderings and aggregation |
+
+## Conclusion
+
+This project is a **complete, 0-`sorry`** Lean 4 formalization of the **Gale-Shapley
+Stable Marriage Theorem** (1962) and the **Knuth lattice structure** of its stable
+matchings. All twelve headline results are CLOSED (`lake build StableMarriage`
+SUCCESS, toolchain `v4.30.0-rc2`).
+
+### What is proven
+
+- **Gale-Shapley correctness** — termination in ≤ n² steps, the output is a valid
+  bijection, and no blocking pair exists (the algorithm produces a *stable* matching).
+- **Optimality** — the matching is **man-optimal** (proposers get their best achievable
+  partner) and **woman-pessimal** (receivers get their worst achievable), the latter
+  derived constructively from the former.
+- **Lattice structure** (Knuth 1976) — the set of stable matchings forms a
+  **distributive lattice** under join/meet, both operations preserving stability and
+  the spouse maps injective. Existence of a man-optimal stable matching is shown via a
+  minimal-weight argument on the join semilattice (`exists_isManOptimal`).
+
+### The honest lesson — "intractable" was "false as stated"
+
+Three former statements (`no_cross_match`, `man_optimal_key_step`,
+`doctor_optimal_eq_top`) resisted **30+ prover-harness iterations** before being
+recognized as **mathematically false**: the 3×3 latin-square instance (Knuth 1976)
+with the identity and cyclic-shift matchings refutes all three simultaneously. Their
+`sorry` placeholders were unprovable because the goals were contradictory, not hard.
+The honest replacement (`exists_isManOptimal`) proves *existence* rather than the
+contradictory constructive extraction. This is the same lesson as the Conway P4 case:
+when a proof stalls across many iterations, **refute the statement first**.
+
+### Where to go next
+
+- **Theory**: Gale & Shapley (1962); Knuth, *Marriages Stables* (1976, lattice
+  structure); Gusfield & Irving (1989).
+- **Reference port**: [mmaaz-git/stable-marriage-lean](https://github.com/mmaaz-git/stable-marriage-lean).
+- **Related**: [`social_choice_lean/`](../social_choice_lean/) (preference orderings),
+  [`cooperative_games_lean/`](../cooperative_games_lean/) (matching as cooperative game).

--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
@@ -1,105 +1,108 @@
-# Stable Marriage - Lean 4 Formalization
+# Stable Marriage — Formalisation Lean 4
 
-Lean 4 formalization of the **Gale-Shapley Stable Marriage Theorem** (1962).
+Formalisation en Lean 4 du **théorème de mariage stable de Gale-Shapley** (1962).
 
-## Overview
+## Vue d'ensemble
 
-The Stable Marriage Problem: given n men and n women, each with a strict preference ordering over the opposite set, find a perfect matching where no unmatched pair (m, w) would both prefer each other to their current partners.
+Le problème du mariage stable : étant donné n hommes et n femmes, chacun ayant un ordre de préférence strict sur l'ensemble opposé, trouver un couplage parfait où aucune paire non appariée (m, w) ne se préférerait mutuellement à leurs partenaires actuels.
 
-| File | Content | sorry |
-|------|---------|-------|
-| `StableMarriage/Defs.lean` | Core type definitions (preferences, profiles, matchings, stability) | 0 |
-| `StableMarriage/Lemmas.lean` | Helper lemmas (`gsFinalMatching`, `gsAllWomenMatched`, `gsNoBlockingPairs`) | 0 |
-| `StableMarriage/GSState.lean` | GS state machine, `gsChooseMax` | 0 |
-| `StableMarriage/GaleShapley.lean` | Termination, stability, `man_optimal`, `woman_pessimal` | 0 |
-| `StableMarriage/Lattice.lean` | Knuth lattice, refutations, `exists_isManOptimal` | 0 |
+| Fichier | Contenu | sorry |
+|---------|---------|-------|
+| `StableMarriage/Defs.lean` | Définitions de types fondamentales (préférences, profils, couplages, stabilité) | 0 |
+| `StableMarriage/Lemmas.lean` | Lemmes utilitaires (`gsFinalMatching`, `gsAllWomenMatched`, `gsNoBlockingPairs`) | 0 |
+| `StableMarriage/GSState.lean` | Machine d'états GS, `gsChooseMax` | 0 |
+| `StableMarriage/GaleShapley.lean` | Terminaison, stabilité, `man_optimal`, `woman_pessimal` | 0 |
+| `StableMarriage/Lattice.lean` | Treillis de Knuth, réfutations, `exists_isManOptimal` | 0 |
 
-**Total**: 0 production sorry. `lake build StableMarriage` SUCCESS. Toolchain `v4.30.0-rc2`.
+**Total** : 0 sorry en production. `lake build StableMarriage` SUCCESS. Toolchain `v4.30.0-rc2`.
 
-## Theorems (status)
+## Théorèmes (statut)
 
-| Theorem | Statement | sorry | Status |
-|---------|-----------|-------|--------|
-| `gale_shapley_terminates` | Algorithm terminates in at most n^2 steps | 0 | CLOSED (`trivial`) |
-| `gale_shapley_produces_matching` | Output is a valid bijection | 0 | CLOSED (identity witness) |
-| `gale_shapley_stable` | No blocking pair exists | 0 | **CLOSED via PR #1194** (port mmaaz-git upstream) |
-| `gale_shapley_man_optimal` | Proposers get best achievable partners | 0 | **CLOSED** (via `exists_isManOptimal`, minimal-weight argument on join semilattice) |
-| `gale_shapley_woman_pessimal` | Receivers get worst achievable partners | 0 | **CLOSED via PR #1521** (constructive, from man-optimality) |
-| `joinSpouse_injective` | Join spouse map is injective | 0 | CLOSED (PR #1522) |
-| `meetSpouse_injective` | Meet spouse map is injective | 0 | **CLOSED** (counting/pigeonhole argument, no anti-crossing needed) |
-| `join_isStable` | Join of two stable matchings is stable | 0 | CLOSED |
-| `meet_isStable` | Meet of two stable matchings is stable | 0 | CLOSED |
-| `exists_isManOptimal` | Man-optimal stable matching exists | 0 | **CLOSED** (minimal weight + `Nat.find` + `join_isStable`) |
-| `no_cross_match_is_false` | Former anti-crossing lemma is refutable | 0 | **REFUTED** (3x3 latin-square counterexample, kernel-checked) |
-| `doctor_optimal_eq_top_is_false` | Former optimality claim is refutable | 0 | **REFUTED** (same counterexample) |
+| Théorème | Énoncé | sorry | Statut |
+|----------|--------|-------|--------|
+| `gale_shapley_terminates` | L'algorithme termine en au plus n^2 étapes | 0 | CLOSED (`trivial`) |
+| `gale_shapley_produces_matching` | La sortie est une bijection valide | 0 | CLOSED (témoin identité) |
+| `gale_shapley_stable` | Aucune paire bloquante n'existe | 0 | **CLOSED via PR #1194** (port amont mmaaz-git) |
+| `gale_shapley_man_optimal` | Les proposants obtiennent les meilleurs partenaires atteignables | 0 | **CLOSED** (via `exists_isManOptimal`, argument de poids minimal sur le demi-treillis sup) |
+| `gale_shapley_woman_pessimal` | Les récepteurs obtiennent les pires partenaires atteignables | 0 | **CLOSED via PR #1521** (constructif, depuis l'optimalité-hommes) |
+| `joinSpouse_injective` | L'application join-spouse est injective | 0 | CLOSED (PR #1522) |
+| `meetSpouse_injective` | L'application meet-spouse est injective | 0 | **CLOSED** (argument de comptage/tiroirs, pas d'anti-croisement requis) |
+| `join_isStable` | Le join de deux couplages stables est stable | 0 | CLOSED |
+| `meet_isStable` | Le meet de deux couplages stables est stable | 0 | CLOSED |
+| `exists_isManOptimal` | Un couplage stable optimal-hommes existe | 0 | **CLOSED** (poids minimal + `Nat.find` + `join_isStable`) |
+| `no_cross_match_is_false` | L'ancien lemme d'anti-croisement est réfutable | 0 | **REFUTED** (contre-exemple carré latin 3x3, kernel-checked) |
+| `doctor_optimal_eq_top_is_false` | L'ancienne assertion d'optimalité est réfutable | 0 | **REFUTED** (même contre-exemple) |
 
-### Historical note
+### Note historique
 
-The former statements `no_cross_match`, `man_optimality_key_step`, and `doctor_optimal_eq_top` were **false as stated** and have been removed. Their `sorry` placeholders were unprovable because the goals were in fact contradictory — the 3x3 latin-square instance (Knuth 1976) with the identity and cyclic-shift matchings refutes all three simultaneously. This explains why 30+ prover harness iterations made zero progress: the targets were mathematically impossible.
+Les anciens énoncés `no_cross_match`, `man_optimality_key_step`, et `doctor_optimal_eq_top` étaient **faux tels qu'énoncés** et ont été retirés. Leurs placeholders `sorry` étaient improuvables car les buts étaient en fait contradictoires — l'instance carré latin 3x3 (Knuth 1976) avec les couplages identité et décalage cyclique réfute les trois simultanément. Cela explique pourquoi 30+ itérations du harnais de preuve n'ont fait aucun progrès : les cibles étaient mathématiquement impossibles.
 
-The honest replacement is `exists_isManOptimal`, which proves existence (not constructive extraction) of a man-optimal stable matching via a minimal-weight argument on the join semilattice, without needing the anti-crossing lemma.
+Le remplacement honnête est `exists_isManOptimal`, qui prouve l'existence (pas l'extraction constructive) d'un couplage stable optimal-hommes via un argument de poids minimal sur le demi-treillis sup, sans nécessiter le lemme d'anti-croisement.
 
-## Quick Start
+## Démarrage rapide
 
 ```bash
-# Build (requires elan + Lake)
+# Build (requiert elan + Lake)
 cd stable_marriage_lean
 lake build
 
-# Check sorry count
+# Compter les sorry
 grep -c sorry StableMarriage/*.lean
 ```
 
-## References
+## Références
 
 - Gale, D. & Shapley, L.S., "College Admissions and the Stability of Marriage" (American Mathematical Monthly, 1962)
 - Knuth, D.E., "Marriages Stables" (1976) — lattice structure, latin-square instances
 - Gusfield, D. & Irving, R.W., *The Stable Marriage Problem: Structure and Algorithms* (1989)
 - Wu, Q. & Roth, A.E., "Lattice Structures in Stable Matching" (2018)
-- Reference Lean 4 port: https://github.com/mmaaz-git/stable-marriage-lean
+- Port de référence Lean 4 : https://github.com/mmaaz-git/stable-marriage-lean
 
-## Cross-series connections
+## Connexions inter-séries
 
-| Series | Connection |
-|--------|------------|
-| `social_choice_lean/` | Same Mathlib-based structure, preference orderings |
-| `GameTheory/` | Matching theory as cooperative game (Shapley value) |
-| `Tweety-9-Preferences` | Preference orderings and aggregation |
+| Série | Connexion |
+|-------|-----------|
+| `social_choice_lean/` | Même structure basée Mathlib, ordres de préférence |
+| `GameTheory/` | Théorie des appariements comme jeu coopératif (valeur de Shapley) |
+| `Tweety-9-Preferences` | Ordres de préférence et agrégation |
 
 ## Conclusion
 
-This project is a **complete, 0-`sorry`** Lean 4 formalization of the **Gale-Shapley
-Stable Marriage Theorem** (1962) and the **Knuth lattice structure** of its stable
-matchings. All twelve headline results are CLOSED (`lake build StableMarriage`
-SUCCESS, toolchain `v4.30.0-rc2`).
+Ce projet est une formalisation Lean 4 **complète, à 0 `sorry`** du **théorème de
+mariage stable de Gale-Shapley** (1962) et de la **structure de treillis de Knuth** de
+ses couplages stables. Les douze résultats phares sont tous CLOSED (`lake build
+StableMarriage` SUCCESS, toolchain `v4.30.0-rc2`).
 
-### What is proven
+### Ce qui est prouvé
 
-- **Gale-Shapley correctness** — termination in ≤ n² steps, the output is a valid
-  bijection, and no blocking pair exists (the algorithm produces a *stable* matching).
-- **Optimality** — the matching is **man-optimal** (proposers get their best achievable
-  partner) and **woman-pessimal** (receivers get their worst achievable), the latter
-  derived constructively from the former.
-- **Lattice structure** (Knuth 1976) — the set of stable matchings forms a
-  **distributive lattice** under join/meet, both operations preserving stability and
-  the spouse maps injective. Existence of a man-optimal stable matching is shown via a
-  minimal-weight argument on the join semilattice (`exists_isManOptimal`).
+- **Correction de Gale-Shapley** — terminaison en ≤ n² étapes, la sortie est une
+  bijection valide, et aucune paire bloquante n'existe (l'algorithme produit un
+  couplage *stable*).
+- **Optimalité** — le couplage est **optimal-hommes** (les proposants obtiennent leur
+  meilleur partenaire atteignable) et **pessimal-femmes** (les récepteurs obtiennent
+  leur pire partenaire atteignable), ce dernier dérivé constructivement du premier.
+- **Structure de treillis** (Knuth 1976) — l'ensemble des couplages stables forme un
+  **treillis distributif** sous join/meet, les deux opérations préservant la stabilité
+  et les applications spouse injectives. L'existence d'un couplage stable optimal-hommes
+  est montrée via un argument de poids minimal sur le demi-treillis sup
+  (`exists_isManOptimal`).
 
-### The honest lesson — "intractable" was "false as stated"
+### La leçon honnête — « intractable » était « faux tel qu'énoncé »
 
-Three former statements (`no_cross_match`, `man_optimal_key_step`,
-`doctor_optimal_eq_top`) resisted **30+ prover-harness iterations** before being
-recognized as **mathematically false**: the 3×3 latin-square instance (Knuth 1976)
-with the identity and cyclic-shift matchings refutes all three simultaneously. Their
-`sorry` placeholders were unprovable because the goals were contradictory, not hard.
-The honest replacement (`exists_isManOptimal`) proves *existence* rather than the
-contradictory constructive extraction. This is the same lesson as the Conway P4 case:
-when a proof stalls across many iterations, **refute the statement first**.
+Trois anciens énoncés (`no_cross_match`, `man_optimal_key_step`,
+`doctor_optimal_eq_top`) ont résisté à **30+ itérations du harnais de preuve** avant
+d'être reconnus comme **mathématiquement faux** : l'instance carré latin 3×3 (Knuth
+1976) avec les couplages identité et décalage cyclique réfute les trois simultanément.
+Leurs placeholders `sorry` étaient improuvables car les buts étaient contradictoires,
+pas difficiles. Le remplacement honnête (`exists_isManOptimal`) prouve *l'existence*
+plutôt que l'extraction constructive contradictoire. C'est la même leçon que le cas
+Conway P4 : quand une preuve cale au fil de nombreuses itérations, **réfuter l'énoncé
+d'abord**.
 
-### Where to go next
+### Où aller ensuite
 
-- **Theory**: Gale & Shapley (1962); Knuth, *Marriages Stables* (1976, lattice
-  structure); Gusfield & Irving (1989).
-- **Reference port**: [mmaaz-git/stable-marriage-lean](https://github.com/mmaaz-git/stable-marriage-lean).
-- **Related**: [`social_choice_lean/`](../social_choice_lean/) (preference orderings),
-  [`cooperative_games_lean/`](../cooperative_games_lean/) (matching as cooperative game).
+- **Théorie** : Gale & Shapley (1962) ; Knuth, *Marriages Stables* (1976, structure de
+  treillis) ; Gusfield & Irving (1989).
+- **Port de référence** : [mmaaz-git/stable-marriage-lean](https://github.com/mmaaz-git/stable-marriage-lean).
+- **Lié** : [`social_choice_lean/`](../social_choice_lean/) (ordres de préférence),
+  [`cooperative_games_lean/`](../cooperative_games_lean/) (appariement comme jeu coopératif).


### PR DESCRIPTION
## Summary

Phase 0.5 FR backfill (#1650) of the `stable_marriage_lean` (GameTheory — Gale-Shapley stable marriage theorem + Knuth lattice) README. 2nd grain this cycle in the #3870 Lean-README FR backfill lane.

### Mechanic (readme-french-first.md HARD 2)
- `git mv README.md -> README.en.md` — clean EN snapshot, golden set.
- New `README.md` in French, same structure.

### Parity verified (FR vs EN snapshot)
| Metric | EN snapshot | FR |
|--------|------------|-----|
| Lines | 105 | 108 |
| H2 sections | 6 | 6 |
| H3 sections | 4 | 4 |
| Theorem-table rows | 12 | 12 |
| Relative links | 2 | 2 |

### Technical anchors preserved verbatim
- 5 file paths: `StableMarriage/{Defs,Lemmas,GSState,GaleShapley,Lattice}.lean`
- 12 theorem names: `gale_shapley_{terminates,produces_matching,stable,man_optimal,woman_pessimal}`, `joinSpouse_injective`, `meetSpouse_injective`, `join_isStable`, `meet_isStable`, `exists_isManOptimal`, `no_cross_match_is_false`, `doctor_optimal_eq_top_is_false`
- Helper IDs: `gsFinalMatching`, `gsAllWomenMatched`, `gsNoBlockingPairs`, `gsChooseMax`, `man_optimal`, `woman_pessimal`
- PR refs #1194/#1521/#1522; toolchain v4.30.0-rc2; `lake build StableMarriage`
- Math: n²/n^2, 3×3 latin-square; years 1962/1976/1989/2018; reference port mmaaz-git

### Language policy
- **References section** kept verbatim EN (bibliographic convention — paper titles).
- EN-prose scan of the FR body: **0 unintended English leak**.
- Lattice terms `join`/`meet` kept (used as code-identifier roots `joinSpouse`/`meetSpouse`); "demi-treillis sup" for join-semilattice.

### Catalogue hygiene
- `COURSE_CATALOG.generated.{md,json}` byte-identical to main; branch off fresh `origin/main` (0 behind); 0 `.lean` touched.

See #1650

🤖 Generated with [Claude Code](https://claude.com/claude-code)