### PR TITLE
scrub(arganalysis-0init): anonymize D:\dev\CoursIA-2 checkout-root prefix in 2 outputs (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
@@ -179,7 +179,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dossier Tweety resolu via la shim : D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\n",
+      "Dossier Tweety resolu via la shim : <repo>\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\n",
       "Jars Tweety trouves : 42\n",
       "JDK portable present : True\n"
      ]
@@ -262,7 +262,7 @@
       "JVM demarree avec 42 JARs.\n",
       "\n",
       "JVM operationnelle : True\n",
-      "Classpath Tweety charge depuis : D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\libs\n",
+      "Classpath Tweety charge depuis : <repo>\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\libs\n",
       "Amorcage shim reussi : True\n"
      ]
     }


### PR DESCRIPTION
Quick-scrub executé ce cycle suite au **flag hygiène d'ai-01** dans la post-merge review de #3886 (rung 0-init, #2137 Phase 2).

## Le leak flaggé

Les outputs de #3886 contenaient **2 lignes path machine-local** avec un **nouveau prefixe** pour #3436 :

- `Dossier Tweety resolu via la shim : D:\dev\CoursIA-2\MyIA.AI.Notebooks\SymbolicAI\Tweety`
- `Classpath Tweety charge depuis : D:\dev\CoursIA-2\MyIA.AI.Notebooks\SymbolicAI\Tweety\libs`

Le prefixe `D:\dev\CoursIA-2\` est la **racine-checkout** (checkout root), **distincte** du prefixe `C:\Users\jsboi` user-temp que `scrub_papermill_paths.py --outputs` catche. C'est pourquoi le scrubber ne l'a pas attrapé lors du merge de #3886.

## Le fix

Anonymisation `D:\dev\CoursIA-2` -> `<repo>`, en gardant le path repo-relatif informatif :

- `Dossier Tweety resolu via la shim : <repo>\MyIA.AI.Notebooks\SymbolicAI\Tweety`
- `Classpath Tweety charge depuis : <repo>\MyIA.AI.Notebooks\SymbolicAI\Tweety\libs`

`<repo>` est l'analogue naturel de `~` (que po-2024 utilise pour `C:\Users\jsboi`) : un placeholder qui represente la racine du checkout, anonymisant la structure de repertoires machine-locale tout en preservant l'information pedagogique (la shim resout bien le dossier Tweety a un chemin repo-relatif coherent).

## Verification (C.3 output-text-only)

- **2 lignes changees**, toutes deux dans des blocs `output_type: stream` (stdout).
- **0 cellule source touchee** (verifie par parsing JSON : 0 `<repo>` en source, 0 `D:\dev` en source).
- **Pas de re-exec requise** (output-text-only, exec_count et structure des outputs preserves).
- **Catalog + submodules byte-identical**.
- Diff numstat `2 2` (1:1 replacement prefixe, churn minimal).

## Tool-gap (follow-up, grain separe, PAS dans cette PR)

`scrub_papermill_paths.py --outputs` a un angle mort sur 2 prefixe-classes (confirme par po-2024 sur #3891 archive Fast-Downward-Legacy : les paths Python-exception-repr double-backslash `C:\Users` echappent aussi au scan). Etendre le scrubber pour catcher (a) paths repr-escaped double-backslash, (b) prefixe racine-checkout `D:\dev\CoursIA-2\` -> grain d'infra separe (G.4 atomicite). Flag pour ai-01 / lane tooling.

See #3436