### PR TITLE
docs(lean): enrich mathlib_examples/README prose (intro + Concepts cles) (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/README.md
@@ -2,9 +2,18 @@
 
 Exemples d'utilisation basique de Mathlib pour la série SymbolicAI/Lean.
 
+**Mathlib** est la bibliothèque mathématique unifiée de Lean 4 : un corpus
+communautaire de définitions, de lemmes et — surtout pour l'apprenant — de
+**tactiques d'automatisation**. Ce module minimal est le « smoke test » de
+l'installation Mathlib : il ferme quatre buts représentatifs avec les tactiques
+du quotidien (`ring`, `linarith`, `omega`, `rw`), confirmant que
+`lake build MathLibExamples` compile contre une Mathlib fonctionnelle. C'est
+aussi une première prise en main des automatiseurs de Lean avant d'aborder les
+projets plus ambitieux (`calibration_lean`, `conway_lean`, `sensitivity_lean`).
+
 ## Statut
 
-- **Toolchain** : v4.27.0
+- **Toolchain** : v4.30.0-rc2
 - **Compte de sorry** : 0
 - **Build** : `lake build MathLibExamples` -- SUCCESS
 - **Dépendances** : Mathlib4
@@ -19,6 +28,24 @@ Exemples d'utilisation basique de Mathlib pour la série SymbolicAI/Lean.
 
 - Illustre les tactiques Mathlib courantes et les schémas de preuve
 - Sert de référence aux étudiants apprenant Lean 4 avec Mathlib
+
+## Concepts clés
+
+Les quatre exemples de [`MathLibExamples/Basic.lean`](MathLibExamples/Basic.lean)
+introduisent les automatiseurs les plus utilisés en Lean 4 :
+
+| Tactique | Rôle | Exemple `Basic.lean` |
+|----------|------|----------------------|
+| `ring` | Identités d'anneau commutatif (développer / factoriser) | `(a + b)^2 = a^2 + 2*a*b + b^2` sur `ℤ` |
+| `linarith` | Inégalités linéaires par combinaison (ici sur `ℚ`) | `x ≤ 3*y ∧ y ≤ 1 → x ≤ 3` |
+| `omega` | Arithmétique de Presburger sur `ℕ`/`ℤ` (Lean core depuis v4.30) | `n < n + 1` sur `ℕ` |
+| `rw` + `ring` | Substituer des égalités d'hypothèses, puis clôture algébrique | `a = b ∧ b = c → a + a = 2*c` sur `ℤ` |
+
+Ces quatre tactiques couvrent une large part des buts « calculatoires »
+rencontrés en pratique : `ring` pour l'algèbre, `linarith` et `omega` pour les
+inégalités et l'arithmétique entière, `rw` pour réécrire par égalité
+d'hypothèses. Savoir laquelle invoquer est la première compétence tactique en
+Lean, et ce module est le terrain d'entraînement minimal pour l'acquérir.
 
 ## Notes
 


### PR DESCRIPTION
## Enrichissement prose — `mathlib_examples/README` (#2651, famille Lean)

`mathlib_examples/README.md` était le README le plus mince de la série Lean (41 lignes, intro d'une seule ligne, aucune section de concepts). Cette PR comble le gap prose **intro + concepts** (au-delà de la Conclusion déjà présente depuis #3863).

### Changements (tous ancrés dans le contenu réel, pas de fabrication)

- **Intro étendue** : cadre Mathlib (bibliothèque mathématique unifiée Lean 4) + rôle pédagogique (« smoke test » des tactiques du quotidien avant d'aborder `calibration_lean`/`conway_lean`/`sensitivity_lean`).
- **Section `## Concepts clés`** : tableau des 4 tactiques démontrées dans `MathLibExamples/Basic.lean`, ancré ligne-par-ligne :
  - `ring` (L13) — `(a+b)² = a² + 2ab + b²` sur `ℤ`
  - `linarith` (L16) — `x ≤ 3·y ∧ y ≤ 1 → x ≤ 3` sur `ℚ`
  - `omega` (L19) — `n < n+1` sur `ℕ` (Lean core depuis v4.30)
  - `rw` + `ring` (L22) — `a = b ∧ b = c → a+a = 2c` sur `ℤ`
- **Fix toolchain G.1** : le README affirmait `v4.27.0` mais `lean-toolchain` réel = `v4.30.0-rc2`. Corrigé.

### Hygiène

- Docs-only, **+28/-1** (41 → 68 lignes, ~65 % de croissance — enrichissement substantiel, pas un drive-by §E).
- 0 fichier `.lean` touché, `COURSE_CATALOG.generated.{md,json}` byte-identical à main.
- Branche fraîche off `origin/main`.

Follow-up ai-01 05:20Z (STEER po-2026:CoursIA : #2651 prose pédagogique sous-séries Lean, re-scan intro/transition au-delà des Conclusions). Conway #2162 P4/P5 decomposition attempt ce cycle = research-wall confirmé (cf dashboard), pas de grain P4-free tractable restant.

See #2651
