### PR TITLE
scrub(.NET): anonymize residual REPO checkout-root output-path leaks (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
@@ -86,7 +86,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Module cooperative_games charge depuis: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GameTheory\n",
+      "Module cooperative_games charge depuis: <repo>MyIA.AI.Notebooks\\GameTheory\n",
       "Import reussi!\n"
      ]
     }

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -88,7 +88,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Repertoire de travail: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\r\n"
+      "Repertoire de travail: <repo>MyIA.AI.Notebooks\\Sudoku\r\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
@@ -40707,7 +40707,7 @@
      "metadata": {},
      "data": {
       "text/plain": [
-       "Compiled model Assembly path : d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\CompiledModels\\RobustSudokuModel.dll"
+       "Compiled model Assembly path : <repo>MyIA.AI.Notebooks\\Sudoku\\CompiledModels\\RobustSudokuModel.dll"
       ]
      }
     },

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
@@ -2353,10 +2353,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chargement de : D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\data\\university.owl\n",
+      "Chargement de : <repo>MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\data\\university.owl\n",
       "\n",
       "Ontologie chargee : http://example.org/university#\n",
-      "Nom : D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\data\\university\n"
+      "Nom : <repo>MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\data\\university\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
@@ -689,7 +689,7 @@
       "\tSeverity: sh:Violation\n",
       "\tSource Shape: [ sh:maxCount Literal(\"1\", datatype=xsd:integer) ; sh:message Literal(\"L'email doit etre au format mailto:user@domain.tld\", lang=fr) ; sh:path foaf:mbox ; sh:pattern Literal(\"^mailto:.+@.+\\..+$\") ]\n",
       "\tFocus Node: ex:eve\n",
-      "\tValue Node: <file:///D:/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/data/not-an-email>\n",
+      "\tValue Node: <file:///<repo>MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/data/not-an-email>\n",
       "\tResult Path: foaf:mbox\n",
       "\tMessage: L'email doit etre au format mailto:user@domain.tld\n",
       "\n"

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-1-Setup.ipynb
@@ -355,7 +355,7 @@
       "======================================================================\n",
       "DOWNLOADING TWEETYPROJECT JARS\n",
       "======================================================================\n",
-      "Target directory: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\libs\n",
+      "Target directory: <repo>MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\libs\n",
       "Tweety version: 1.30\n",
       "Required modules: 39\n",
       "  Already exists: action-1.30.jar\n",
@@ -529,7 +529,7 @@
       "======================================================================\n",
       "DOWNLOADING RESOURCE FILES\n",
       "======================================================================\n",
-      "Target directory: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\resources\n",
+      "Target directory: <repo>MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\resources\n",
       "Files to download: 22\n",
       "  ✓ Already exists: birds.txt\n",
       "  ✓ Already exists: birds2.txt\n",
@@ -701,8 +701,8 @@
      "output_type": "stream",
      "text": [
       "Configuration des outils externes pour Windows\n",
-      "Repertoire ext_tools: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\ext_tools\n",
-      "Repertoire libs/native: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\libs\\native\n"
+      "Repertoire ext_tools: <repo>MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\ext_tools\n",
+      "Repertoire libs/native: <repo>MyIA.AI.Notebooks\\SymbolicAI\\libs\\native\n"
      ]
     }
    ],
@@ -1051,7 +1051,7 @@
      "output_type": "stream",
      "text": [
       "=== 3. Configuration de EProver ===\n",
-      "  OK EProver trouve: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\EProver\\eprover.exe\n"
+      "  OK EProver trouve: <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\EProver\\eprover.exe\n"
      ]
     }
    ],
@@ -1144,14 +1144,14 @@
       "=== 4. Configuration des solveurs SAT ===\n",
       "\n",
       "--- 4.1 Bibliotheques SAT natives ---\n",
-      "  Repertoire libs/native: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\libs\\native\n",
+      "  Repertoire libs/native: <repo>MyIA.AI.Notebooks\\SymbolicAI\\libs\\native\n",
       "  OK Bibliotheques trouvees: lingeling.dll, minisat.dll, picosat.dll\n",
       "\n",
       "--- 4.2 Sat4j (integre) ---\n",
       "  OK Sat4j disponible (org.tweetyproject.logics.pl.sat.Sat4jSolver)\n",
       "\n",
       "--- 4.3 Wrapper Python SAT (CaDiCaL, Glucose, etc.) ---\n",
-      "  OK sat_solver.py trouve: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\sat_solver.py\n"
+      "  OK sat_solver.py trouve: <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\sat_solver.py\n"
      ]
     },
     {
@@ -1265,7 +1265,7 @@
      "output_type": "stream",
      "text": [
       "=== 5. Configuration de MARCO (MUS enumerator) ===\n",
-      "  OK MARCO trouve: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\marco.py\n"
+      "  OK MARCO trouve: <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\marco.py\n"
      ]
     },
     {
@@ -1275,18 +1275,18 @@
       "  OK Z3 disponible (version 4.16.0)\n",
       "\n",
       "=== 6. Configuration de MaxSAT ===\n",
-      "  OK MaxSAT solver trouve: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\maxsat_solver.py\n",
+      "  OK MaxSAT solver trouve: <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\maxsat_solver.py\n",
       "  OK python-sat disponible (RC2 algorithm)\n",
       "\n",
       "==================================================\n",
       "RESUME DES OUTILS EXTERNES\n",
       "==================================================\n",
       "  SAT_SOLVER        : [     OK     ] Sat4j (integre)\n",
-      "  SAT_SOLVER_PYTHON : [     OK     ] D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\...\n",
-      "  EPROVER           : [     OK     ] D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\...\n",
-      "  MARCO             : [     OK     ] D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\...\n",
-      "  OPEN_WBO          : [     OK     ] D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\...\n",
-      "  CLINGO            : [     OK     ] D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\ext...\n",
+      "  SAT_SOLVER_PYTHON : [     OK     ] <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\...\n",
+      "  EPROVER           : [     OK     ] <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\...\n",
+      "  MARCO             : [     OK     ] <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\...\n",
+      "  OPEN_WBO          : [     OK     ] <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\...\n",
+      "  CLINGO            : [     OK     ] <repo>MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\ext...\n",
       "  SPASS             : [Non configure] -\n",
       "==================================================\n"
      ]
@@ -1579,9 +1579,9 @@
      "output_type": "stream",
      "text": [
       "Recherche JDK portable dans l'arborescence projet...\n",
-      "  OK JDK portable trouve: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\jdk-17-portable\\zulu17.50.19-ca-jdk17.0.11-win_x64\n",
+      "  OK JDK portable trouve: <repo>MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\jdk-17-portable\\zulu17.50.19-ca-jdk17.0.11-win_x64\n",
       "\n",
-      "JAVA_HOME configure: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\jdk-17-portable\\zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+      "JAVA_HOME configure: <repo>MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\jdk-17-portable\\zulu17.50.19-ca-jdk17.0.11-win_x64\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
@@ -2384,7 +2384,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Configuration EProver: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\EProver\\eprover.exe\n"
+      "Configuration EProver: <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\EProver\\eprover.exe\n"
      ]
     },
     {
@@ -2728,7 +2728,7 @@
      "output_type": "stream",
      "text": [
       "--- 2.2.6 Test EProver (Optionnel) ---\n",
-      "EProver detecte: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\EProver\\eprover.exe\n",
+      "EProver detecte: <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\EProver\\eprover.exe\n",
       "Raisonneur cree: EFOLReasoner\n",
       "\n",
       "KB: 2 formules\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
@@ -1218,7 +1218,7 @@
       "   - { !a, a }\n",
       "\n",
       "--- MARCO MUS Enumerator (Script Python + Z3) ---\n",
-      "  MARCO script trouve: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\marco.py\n",
+      "  MARCO script trouve: <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\marco.py\n",
       "  Z3 disponible (version 4.15.3)\n"
      ]
     },
@@ -1733,7 +1733,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MaxSAT script: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\maxsat_solver.py\n",
+      "MaxSAT script: <repo>MyIA.AI.Notebooks\\SymbolicAI\\ext_tools\\maxsat_solver.py\n",
       "PySAT version: 1.9.dev4\n"
      ]
     },

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
@@ -1476,7 +1476,7 @@
       "Programme 2:\n",
       " {guilty(harry). innocent(Suspect) :- motive(Suspect), not guilty(Suspect). motive(harry). motive(sally).}\n",
       "\n",
-      "Utilisation de Clingo trouve/configure a: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\ext_tools\\clingo\n",
+      "Utilisation de Clingo trouve/configure a: <repo>MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\ext_tools\\clingo\n",
       "\n",
       "Calcul des Answer Sets pour Programme 2...\n"
      ]

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks.ipynb
@@ -208,7 +208,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "java.library.path: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\libs\\native\n"
+      "java.library.path: <repo>MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\libs\\native\n"
      ]
     },
     {


### PR DESCRIPTION
## Summary

Re-scrub of the **po-204 (.NET) partition** output-text leaks that the prior HOME-only scrub campaigns (#3880/#3883) missed. These are **REPO checkout-root paths on a D: drive** (`D:\CoursIA\`, `D:\Dev\CoursIA\`, `d:\dev\CoursIA\`) — notebooks executed on a different checkout than the current `c:\dev\CoursIA-2`. Anonymized to `<repo>` (convention established by po-205 in #3892), preserving the repo-relative path for pedagogical value.

Revealed by the enhanced detection in #3895 (tool `_REPO_RES`), but the notebook fixes are independent of which branch the tool lives on — produced with the enhanced scrubber, committed on a fresh `main` branch. The tool itself (#3895) merges separately as reusable infra for the other lanes.

## Scope — 10 notebooks, 28/28 symmetric (output-text only, C.3)

| Family | Notebooks | Leaks |
|---|---|---|
| SymbolicAI/Tweety | Tweety-1/2/4/6/7a | 14 (JVM classpath + lib paths; Tweety-1 = 8) |
| SymbolicAI/SemanticWeb | SW-8, SW-11 | 3 (incl. `file://` URL — scheme preserved) |
| Sudoku (C# only) | Sudoku-11-Choco-Csharp, Sudoku-15-Infer-Csharp | 2 (.NET compiled DLL path) |
| GameTheory | GameTheory-15-CooperativeGames | 1 (module load path) |

**Turf-scoped (no collision):** excludes Lean ×10 (po-206), Argument_Analysis ×4 (po-205), Sudoku-Python ×7 (po-205), OR-tools-Stiegler (po-205 Z3/OR-Tools), Planners-0/4 (contested). All clearly po-204 (.NET / SymbolicAI-non-Lean / Sudoku-C# / GameTheory) turf.

## Verification (H.4-style, firsthand)

- **Re-scan 0 residual** on all 10 (enhanced `--scan --outputs`).
- **Output-text-only (C.3):** 0 `source` / 0 `execution_count` lines changed; 28 ins / 28 del perfectly symmetric.
- **`file://` URL preserved:** SW-8 `<file:///D:/dev/CoursIA/...>` → `<file:///<repo>...>` (scheme intact; see tool note below).
- **Catalog + MetaGeneticSharp submodule byte-identical** to `main`.
- **All 10 JSON parse** post-edit.

## Tool note for #3895 (flagged to ai-01)

While scrubbing, found the enhanced `_REPO_RES` (`[A-Za-z]:[\/]+...CoursIA...`) **over-matches URL schemes**: it matched `e:` in `file:` (→ `e:///D:/dev/CoursIA/`) and would match `p:` in `http:`. This mangled SW-8's `file://` URL (`<file:///<repo>` → broken `<fil<repo>`) — **caught by pre-commit diff inspection (G.1), fixed surgically here**. The MEMORY note on #3895 ("FP risk minimal") was optimistic. Recommend #3895 tighten `_REPO_RES` (e.g. negative lookbehind / require the drive-letter not be preceded by a URL-scheme letter) before wide campaign use. Does not block this PR (notebooks verified clean).

See #3436 (Epic non-closing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)