### PR TITLE
feat(qc): align Cloud-SectorRotation-Momentum baseline 2018-2025 (#1630 backbone #80)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/main.py
@@ -15,7 +15,9 @@ class SectorRotationMomentum(QCAlgorithm):
     """
 
     def initialize(self):
-        self.set_start_date(2014, 1, 1)
+        # Aligned baseline period 2018-2025 (#1630). Original start was 2014;
+        # standardized to 2018-01-01 for cross-strategy comparison.
+        self.set_start_date(2018, 1, 1)
         self.set_end_date(2025, 1, 1)
         self.set_cash(100000)
         self.set_brokerage_model(


### PR DESCRIPTION
@jsboige

Part of the **QC backbone baseline sequence** (#2801/#1630), greenlit by ai-01 2026-06-22. This PR = **#80 Cloud-SectorRotation-Momentum** (IND family, no-ML → deterministic single-run, no GPU).

## Scope (1 file — main.py only)

`projects/Cloud-SectorRotation-Momentum/main.py` — align `set_start_date(2014,1,1)` → `set_start_date(2018,1,1)` for cross-strategy comparison (#2801 Lot 3). `set_brokerage_model(IBKR, MARGIN)` already present (#2801 Lot 1). No logic change.

## Backtest result (QC Cloud, project 30821748)

| Metric | Value |
|---|---|
| Backtest ID | `58fb0a94` |
| Period | 2018-2025 (1761 tradeable dates) |
| Sharpe | **−0.029** |
| CAGR | 2.125% |
| MaxDD | 42.7% |
| PSR | 0.478% |

**Verdict: negative → Tier 3 (Exploratoire).** This is the **first backbone baseline to land below zero** (#77 AssetClassMomentum 0.22, #78 Cloud-MeanReversion 0.067, #79 Cloud-RiskParity-Composite 0.027 were all marginally positive Tier 2). The momentum-**weighted** 5-ETF rotation (QQQ/SPY/EFA/GLD/IWM, SMA200 + 6m momentum dual filter, momentum-proportional sizing, SHY defensive, monthly) does *slightly worse* than the equal-weight #79 (−0.029 vs +0.027) — momentum-proportional sizing did not help on the aligned 2018-2025 period. Strengthens the documented aligned-period momentum-underperformance pattern. Promoted Tier 4 (Untested) → Tier 3 (Exploratoire).

## G.1 disclosure — totalOrders=0 wrapper artifact

The qc-mcp-lite wrapper returns `totalOrders=0` and `equity={}` empty, BUT `statistics` (Sharpe/CAGR/MaxDD/PSR) is QC-computed and populated. A CAGR of 2.1% with literally zero trades is impossible (cash → Sharpe 0), so the statistics are real and `totalOrders=0` is a wrapper extraction artifact (field not parsed), NOT a 0-trade backtest. Cross-checked via `list_backtests` (status Completed). Same confirmed artifact as #77/#78/#79; distinct from #3367 (fabricated notebook).

## Doc update DEFERRED (consolidation directive)

Per **ai-01 2026-06-22T05:20Z directive** — to avoid the recurrent adjacent-Tier4-deletion conflict — doc updates (Verified table row + Tier 4 removal + Key-finding) are **consolidated into ONE separate doc PR** rather than bundled per-baseline. The current batch (#78 #3893, #79 #3898) is still OPEN against `docs/qc/qc-comparative-backtests.md`, so a 3rd per-PR doc edit here would pile a 3rd adjacent-deletion conflict that ai-01 does not resolve blind. main.py stays per-project (stacks freely, no conflict).

The consolidated doc PR (next cycle, once #3893/#3898 land) will add #80: `| Cloud-SectorRotation-Momentum | 30821748 | 2018-2025 | -0.029 | 2.125 | 42.7 | 0.5 | \`58fb0a94\` | 5-ETF momentum-weighted rotation (QQQ/SPY/EFA/GLD/IWM + SHY, SMA200+6m), IBKR. First Tier-3 backbone (negative), momentum-weighting underperformed equal-weight #79. Promoted Tier 4→3 |` + remove #80 from Tier 4 + Key-finding #24.

## Verification (Honest metrics, G.2/G.9)

- `create_compile` → BuildSuccess (0 errors). `create_backtest` → Completed, progress 1.
- Uploaded from repo canonical main.py (cloud project aligned to avoid TrendFollowing drift).
- Deterministic no-ML baseline (no multi-seed; #1630 residual #7 edge-vs-σ applies to ML/DL/RL only, cf #3567).

See #1630. Does NOT close #1630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)