### PR TITLE
docs(pymc-20): add synthesized Conclusion (Dernier de la série) #2651

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb
@@ -4619,6 +4619,26 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion : de l'incertitude modélisée à la décision séquentielle\n",
+    "\n",
+    "PyMC-20 franchit le seuil qui sépare la **modélisation** de l'incertitude — le fil rouge de toute la série depuis PyMC-1 — de l'**action** sous incertitude au cours du temps. Trois idées forces structurent ce notebook.\n",
+    "\n",
+    "**1. Le MDP comme cadre formel de la planification.** Un Processus de Décision Markovien $(S, A, P, R, \\gamma)$ ramène la décision séquentielle à une équation fonctionnelle, l'équation de Bellman, résolue exactement par *Value Iteration* et *Policy Iteration* lorsque l'espace d'états reste tabulaire. La propriété de Markov — $P(s'|s,a)$ ne dépend que de l'état présent — est ce qui rend la décomposition calculable : elle transforme un horizon infini en une récurrence sur les valeurs. *RTDP* étend cette planification aux grands espaces en échantillonnant des trajectoires en ligne, et le *reward shaping* accélère la convergence sans altérer la politique optimale.\n",
+    "\n",
+    "**2. Le compromis exploration/exploitation, résolu bayésiennement.** Les bandits multi-bras concentrent la tension fondamentale de toute décision adaptative : exploiter l'option qui semble la meilleure, ou explorer pour en découvrir de meilleures. Les quatre stratégies comparées (greedy, $\\varepsilon$-greedy, UCB1, Thompson Sampling) dessinent une progression du hasard vers l'inférence. Le Thompson Sampling — qui échantillonne une action depuis le posterior du modèle — est le pont direct vers le cœur probabiliste de la série : une décision séquentielle pilotée par un modèle bayésien, implémentable via PyMC par MCMC dès que la conjugaison disparaît.\n",
+    "\n",
+    "**3. L'observabilité partielle ramène tout à l'inférence.** Dans le cas réaliste du POMDP, l'état véritable est caché : on ne décide plus sur $s$ mais sur une **croyance** $b(s)$, mise à jour à chaque observation. La boucle se referme alors sur le reste de la série : le posterior predictive de la section 10 transforme un problème de maintenance prédictive en un filtre bayésien qui ré-estime l'état de dégradation à chaque mesure, puis décide — continuer, surveiller, ou maintenir. Les mêmes outils de diagnostic (ArviZ, R-hat, ESS) qui servent à contrôler un posterior tout au long de la série servent ici à **piloter une décision**.\n",
+    "\n",
+    "**Vers l'apprentissage par renforcement.** Ce notebook suppose $P(s'|s,a)$ et $R(s,a)$ *connus*. Dès qu'ils ne le sont plus, il faut les apprendre par interaction : c'est l'objet de la série RL (Q-Learning, Deep RL, policy gradient — Sutton & Barto, 2018). PyMC-20 en fournit les fondations théoriques.\n",
+    "\n",
+    "**Arc de la série.** En vingt notebooks, le parcours est allé de l'installation de PyMC (PyMC-1) à la décision séquentielle sous observabilité partielle (PyMC-20), en passant par l'estimation, les modèles hiérarchiques, la compétence (TrueSkill, IRT), la classification, la sélection de modèle et toute la théorie de la décision (utilité, valeur de l'information, systèmes experts). Le fil rouge demeure : l'incertitude n'est pas un bruit à éliminer, mais une quantité à *représenter*, *inférer*, puis sur laquelle *agir*."
+   ],
+   "id": "conclusion-pymc20-2651"
+  },
+  {
+   "cell_type": "markdown",
    "id": "refs-bibliography-pymc20",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary

PyMC-20-Decision-Sequential ("Dernier de la série", Probas/PyMC) ended on a concepts table (`## 12. Résumé`) + `## References` with **no synthesized narrative conclusion** — gap **#2651** (prose pédagogique manquante).

Added a `## Conclusion` section (markdown-only, +21/-1) between the Résumé and References, grounded in the notebook's real content.

## Content (grounded in actual notebook content, not generic)

1. **MDP formalism** — $(S,A,P,R,\gamma)$, Bellman equation, the Markov property enabling the value recursion; Value/Policy Iteration (tabular), RTDP (large spaces), reward shaping.
2. **Exploration/exploitation** — the 4 bandit strategies compared in the notebook (greedy, ε-greedy, UCB1, Thompson Sampling); Thompson Sampling framed as the Bayesian bridge to the series' probabilistic core (PyMC/MCMC when conjugacy breaks).
3. **Partial observability** — POMDP belief states $b(s)$; the §10 posterior predictive closing the loop: a predictive-maintenance problem as a Bayesian filter re-estimating the hidden degradation state, then deciding (continue/watch/maintain). ArviZ / R-hat / ESS diagnostics repurposed from posterior-checking to decision-piloting.
4. **Transition to RL** — this notebook assumes $P,R$ known; the RL series (Q-Learning, Deep RL, policy gradient — Sutton & Barto 2018) handles the unknown case.
5. **Series arc** — PyMC-1 Setup → PyMC-20 sequential decisions under uncertainty; uncertainty as a quantity to *représenter*, *inférer*, then *agir* on.

## Validation (§D — markdown-only, C.2 exception)

- nbformat validate **OK** (67 cells, was 66); Conclusion at cell 65 → References at 66 (correct order)
- **0 code source cells changed** — markdown-only patch (C.2 markdown exception → no re-exec needed)
- **0 `execution_count`/`outputs` touched** (verified: `git diff` shows 0 lines matching code-cell exec/outputs markers)
- **0 C.1 violations introduced** (Conclusion cell has 0 `raise NotImplementedError`/`assert False`/`1/0`)
- `notebook_tools.py validate`: 0 errors, 1 warning — **pre-existing on origin/main** (MissingIDFieldWarning on legacy cells; my new cell has id `conclusion-pymc20-2651`)
- **catalog byte-identical** (only the notebook touched); base fresh off `origin/main` (1fc83f66a)

## Out of scope (noted for transparency)

Pre-existing `1/0` patterns (lines 2675, 4136) are present on origin/main — out of scope for this markdown-only PR.

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)