### PR TITLE
docs(infer-18): add synthesized Conclusion (Valeur de l'Information) (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Decision-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Decision-Value-Information.ipynb
@@ -4446,6 +4446,46 @@
     "\n",
     "Console.WriteLine(\"Exercice a completer\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a pose le cadre de la **valeur de l'information** (VoI) : une theorie de decision qui quantifie, en esperance d'utilite, combien il vaut la peine d'acquerir une information supplementaire avant de decider.\n",
+    "\n",
+    "### La VoI, un pont entre probabilite et decision\n",
+    "\n",
+    "La VoI articule trois quantites complementaires, chacune repondant a une question differente :\n",
+    "\n",
+    "| Question pratique | Quantite | Reponse |\n",
+    "|-------------------|----------|---------|\n",
+    "| Jusqu'ou un oracle pourrait-il ameliorer ma decision ? | **EVPI** | Borne superieure de la valeur d'information |\n",
+    "| Combien vaut *ce* test concret ? | **EVSI** | Valeur reelle, a comparer au cout du test |\n",
+    "| Mon test est-il proche de l'optimal ? | **Efficiency** = EVSI / EVPI | Ratio de qualite (0 a 1) |\n",
+    "\n",
+    "### Le triptyque \"pertinence - impact - cout\"\n",
+    "\n",
+    "La condition EVSI > 0 se decompose en trois exigences cumulatives, demontrees par les exemples du notebook :\n",
+    "\n",
+    "1. **Pertinence** : le signal doit modifier les posterieurs (un test non informatif a une EVSI nulle, meme s'il est gratuit).\n",
+    "2. **Impact** : les posterieurs doivent changer la decision optimale (informer sans faire basculer l'action n'apporte rien).\n",
+    "3. **Cout** : le cout d'acquisition doit rester inferieur a l'EVSI pour que le test soit rentable.\n",
+    "\n",
+    "Le cas de la **maladie rare** (EVSI = 0 malgre un test gratuit) illustre l'echec du premier critere : un test sur un evenement de faible probabilite anterieure deplace a peine les croyances. A l'inverse, le **test sismique avant forage** satisfait les trois criteres et s'avere rentable (EVSI net de 203k).\n",
+    "\n",
+    "### Ce que Infer.NET apporte a l'analyse\n",
+    "\n",
+    "Les calculs d'EVPI et d'EVSI reposent sur des **posterieurs bayesiens** qu'Infer.NET calcule automatiquement a partir de la modelisation du graphe. La valeur ajoutee n'est pas dans la formule de VoI elle-meme (une esperance d'utilite), mais dans l'**elimination des calculs manuels de la regle de Bayes** : le practicien se concentre sur la structure du probleme (etats, actions, signaux, utilites) et laisse le moteur inferentiel propager les croyances.\n",
+    "\n",
+    "### Arc pedagogique de la serie\n",
+    "\n",
+    "Apres les fondations de l'utilite (notebooks 14-15 : axiomes VNM, CRRA/CARA), l'extension multi-attribut (16) et les reseaux de decision (17), ce notebook 18 boucle la boucle en montrant **quand l'incertitude elle-meme a un prix**. La suite immediate est la robustesse face a l'incertitude epistemique (Infer-19 : criteres minimax, Hurwicz, Laplace) puis les decisions sequentielles (Infer-20 : MDP, bandits, POMDP), ou la VoI devient dynamique -- c'est precisement le formalisme qui sous-tend l'indice de Gittins et l'exploration-exploitation.\n",
+    "\n",
+    "> **A retenir** : dans tout probleme de decision sous incertitude, se demander *quelle information pourrait changer ma decision, et a quel prix* est le reflexe fondamental que la VoI formalise. Le calcul est bayesien ; l'intuition est economique.\n",
+    ""
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Infer-18 (Decision-Value-Information) terminated on the **Exercice 3** stub with no synthesized conclusion. This PR adds a final markdown conclusion cell synthesizing the Value of Information (VoI) framework.

## Gap identified (G.1 verified firsthand)

The notebook had a `### Points clés à retenir` (cell 49) and a `## 8. Résumé` table (cell 50), but **no `## Conclusion` synthesizing section** — it ended abruptly on the exercise stub (cell 52). The Points-clés/Résumé are recaps (bullet list + table), not a synthesis connecting the concepts. Confirmed by direct read of the last cells.

## Content (grounded in the notebook's real material)

The conclusion synthesizes:
- **VoI as a bridge between probability and decision** — a 3-row table articulating EVPI / EVSI / Efficiency and the practical question each answers.
- **The triptyque pertinence–impact–coût** — the three cumulated conditions for EVSI>0, illustrated by the notebook's own examples: *maladie rare* (EVSI=0 even with a free test, failure of the pertinence criterion) and *test sismique avant forage* (rentable, EVSI net 203k).
- **What Infer.NET contributes** — the value is not the VoI formula itself (an expected utility) but the elimination of manual Bayes-rule calculations via automated Bayesian posteriors.
- **The pedagogical arc** — where notebook 18 sits (after utility foundations 14-15, multi-attribute 16, decision networks 17; before robustness 19 and sequential 20 / Gittins / exploration-exploitation).

No fabrication: every claim is anchored in the notebook's actual content (EVPI/EVSI formulas from the Résumé table, the 203k/39% examples from the Points-clés, the maladie-rare edge case, the Infer.NET integration discussion).

## Validation

- **nbformat**: OK (54 cells, `nbformat.validate` passes; the `MissingIDFieldWarning` is pre-existing on legacy cells, not introduced here).
- **Diff**: `+40/-0`, 1 file, single markdown cell appended at the end.
- **C.2 (markdown exception)**: 0 code cell touched → no re-exec needed. 0 `execution_count`/`outputs` changed.
- **C.1**: no error-introducing pattern added (pure markdown).
- **Catalog**: byte-identical (no notebook metadata / source-code change that the catalog tracks).
- **Base**: fresh off `origin/main` (`a83f67da6`).

See #2651 (prose pédagogique fallback perenne). Partial delivery to the fallback-perenne queue on the Python/ML lane.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>