### PR TITLE
docs(qc): consolidated #79/#80 baselines — Tier4 removal + Verified + Key-findings (#1630)

### DIFF
--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -281,8 +281,6 @@ Projects with `main.py` but no recorded backtest metrics. Prime candidates for t
 | 73 | Option-Wheel | OPT | Options (SPY) | yes |
 | 75 | Options-VGT | OPT | Options (VGT) | yes |
 | 76 | Crypto-LSTM-Prediction | DL | Crypto (BTC) | yes |
-| 79 | Cloud-RiskParity-Composite | RISK | Multi-asset | no |
-| 80 | Cloud-SectorRotation-Momentum | IND | Multi-asset | no |
 | 81 | Cloud-VolTargeting | RISK | Multi-asset | no |
 | 82 | GlobalMacro-Regime | RISK | Multi-asset | no |
 | 83 | HAR-RV-J-Kelly | RISK | Crypto | no |
@@ -357,6 +355,8 @@ Standardized backtest results from QC Cloud via MCP qc-mcp-lite. Period: 2018-01
 | Cloud-MeanReversion-Sectors (v1) | 33211207 | 2018-2025 | 0.067 | 3.793 | 41.7 | 1.0 | `85bcef2b` | RSI(14) mean-rev 11 sector ETFs, IBKR. v1 default (no regime filter). Near-zero aligned, PSR 1.0% noise, MaxDD 42% (no regime filter exits bears). Promoted Tier 4→2. v2/v3 (regime filter + stop-loss) variants untested |
 | PairsTrading | 28693651 | 2015-2024 | -0.280 | 1.101 | 15.9 | 0.0 | `1ed0de9d` | Confirms exploratoire. PSR 0.001% |
 | AssetClassMomentum-QC | 33209767 | 2018-2025 | 0.22 | 6.644 | 28.1 | 3.8 | `6746f155` | 5-ETF momentum top-3 (SPY/EFA/BND/VNQ/GSG, 252d), IBKR. Weak aligned, PSR 3.8% non-significant. Promoted Tier 4→2 |
+| Cloud-RiskParity-Composite | 30820857 | 2018-2025 | 0.027 | 3.504 | 24.4 | 1.2 | `b184b13e` | 6-asset rotation (SPY/TLT/GLD/EFA/EEM/DBC, SMA200+6m mom, eq-wt, IBKR). Near-flat aligned, PSR 1.2%. Promoted Tier 4→2. totalOrders=0 = wrapper extraction artifact (CAGR 3.5% ⇒ real trades) |
+| Cloud-SectorRotation-Momentum | 30821748 | 2018-2025 | -0.029 | 2.125 | 42.7 | 0.5 | `58fb0a94` | 5-ETF momentum-weighted rotation (QQQ/SPY/EFA/GLD/IWM+SHY, SMA200+6m), IBKR. First Tier-3 backbone (negative), momentum-weighting underperformed equal-weight #79. Promoted Tier 4→3 |
 
 ### Student strategies (ESGF 5BD1 cohort, See #1405)
 
@@ -468,6 +468,8 @@ ou `Sigma` est la **matrice de covariance** complete (correlations incluses). Re
 20. **AdaptiveAssetAllocation: confirmed robuste**: Sharpe 0.509, CAGR 8.0%, MaxDD 18.9% (2008-2024, 16 years). Min-var + momentum approach produces steady returns. PSR 10.6% (not significant but positive).
 21. **PairsTrading: structural failure confirmed**: Sharpe -0.28 on aligned period, PSR 0.001%. OLS hedge + cointegration still produces negative alpha. Remains exploratoire/pedagogical.
 22. **AssetClassMomentum-QC: weak aligned baseline (2026-06-22)**: 5-ETF momentum (top-3 of SPY/EFA/BND/VNQ/GSG, 252d lookback, monthly rebalance, IBKR) on 2018-2025 gives Sharpe 0.22, CAGR 6.6%, MaxDD 28.1%, PSR 3.8% (non-significant). Confirms the aligned-period momentum underperformance pattern (cf MomentumRegime 0.185, EMA-Cross-Alpha -0.010). Promoted Tier 4 (Untested) → Tier 2 (Historique). Backtest `6746f155`, project 33209767.
+23. **Cloud-RiskParity-Composite: near-flat aligned baseline (2026-06-22)**: 6-asset tactical rotation (SPY/TLT/GLD/EFA/EEM/DBC, SMA200 + 6m momentum dual filter, equal weight, monthly rebalance, IBKR) on 2018-2025 gives Sharpe 0.027, CAGR 3.5%, MaxDD 24.4%, PSR 1.2% (non-significant). Despite the "RiskParity" name the code is equal-weight momentum rotation (AQR Trend-Following style, not true risk-parity weighting). Extends the aligned-period rotation/momentum underperformance pattern (cf AssetClassMomentum 0.22 #22, Cloud-MeanReversion 0.067). Promoted Tier 4 (Untested) → Tier 2 (Historique). Backtest `b184b13e`, project 30820857. Note: `totalOrders=0` in the MCP wrapper is an extraction artifact (CAGR 3.5% ⇒ real trades), not a 0-trade backtest; cross-checked `list_backtests` status Completed.
+24. **Cloud-SectorRotation-Momentum: first Tier-3 (negative) aligned baseline (2026-06-22)**: 5-ETF momentum-weighted rotation (QQQ/SPY/EFA/GLD/IWM, SMA200 + 6m momentum dual filter, momentum-proportional sizing, SHY defensive, monthly rebalance, IBKR) on 2018-2025 gives Sharpe -0.029, CAGR 2.1%, MaxDD 42.7%, PSR 0.5% (non-significant). The momentum-weighted variant does *slightly worse* than the equal-weight Cloud-RiskParity-Composite #79 (-0.029 vs +0.027) — momentum-proportional sizing did not help on the aligned period. Strengthens the aligned-period momentum-underperformance finding (first baseline below zero). Promoted Tier 4 (Untested) → Tier 3 (Exploratoire). Backtest `58fb0a94`, project 30821748. Same `totalOrders=0` wrapper extraction artifact as #77/#78/#79 (CAGR 2.1% ⇒ real trades).
 
 ## Comparison: Best-vs-Aligned
 


### PR DESCRIPTION
@jsboige

**Consolidated doc PR** per your 05:20Z / 07:17Z directive (main.py per-project + doc-row batched into ONE PR per batch, to end the adjacent-Tier4 conflict tax). This PR documents the two baselines whose `main.py` alignment is handled in separate per-project PRs:

| Baseline | main.py PR | Backtest | Sharpe | CAGR | MaxDD | PSR | Tier |
|---|---|---|---|---|---|---|---|
| #79 Cloud-RiskParity-Composite | #3898 | `b184b13e` (proj 30820857) | 0.027 | 3.504% | 24.4% | 1.183% | 4→2 |
| #80 Cloud-SectorRotation-Momentum | #3900 (merged) | `58fb0a94` (proj 30821748) | −0.029 | 2.125% | 42.7% | 0.478% | 4→3 |

## Scope (1 file, +4/−2 — doc only)

`docs/qc/qc-comparative-backtests.md`:
- **+2 rows** in the "#1630 Verified baselines" table (#79 after #77, #80 after #79).
- **Remove #79 + #80 from Tier 4 (Untested)**.
- **+Key-findings #23 (#79) + #24 (#80)**.

## Findings

- **#79**: near-flat (Sharpe 0.027), Tier 4→2. 6-asset equal-weight momentum rotation (SPY/TLT/GLD/EFA/EEM/DBC) — despite the "RiskParity" name, NOT true risk-parity weighting.
- **#80**: **first Tier-3 (negative) backbone** (Sharpe −0.029), Tier 4→3. Momentum-weighted 5-ETF rotation (QQQ/SPY/EFA/GLD/IWM+SHY) underperformed equal-weight #79 (−0.029 vs +0.027) — momentum-proportional sizing did not help on the aligned period. Strengthens the documented aligned-period momentum-underperformance pattern (#77 0.22, #78 0.067, #79 0.027, #80 −0.029).

## G.1 disclosure — totalOrders=0 wrapper artifact

Both backtests return `totalOrders=0` in the qc-mcp-lite wrapper, but the `statistics` block is QC-computed and populated. A CAGR > 0 with literally zero trades is impossible (cash → Sharpe 0), so the statistics are real and `totalOrders=0` is a wrapper extraction artifact (field not parsed), cross-checked via `list_backtests` (status Completed). Same confirmed artifact as #77/#78; distinct from #3367 (fabricated notebook).

## Cross-references

- `main.py` alignments: #3898 (#79, now MERGEABLE after conflict-strip to main.py-only per the pattern), #3900 (#80, merged `38080b22`).
- See #1630. Does NOT close #1630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)