### PR TITLE
feat(qc): align Cloud-VolTargeting baseline 2018-2025 (#1630 backbone #81)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/main.py
@@ -14,7 +14,9 @@ class VolTargetingAlgorithm(QCAlgorithm):
     def initialize(self):
         self.set_cash(100000)
         self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
-        self.set_start_date(2014, 1, 1)
+        # Aligned baseline period 2018-2025 (#1630). Original start was 2014;
+        # standardized to 2018-01-01 for cross-strategy comparison.
+        self.set_start_date(2018, 1, 1)
         self.set_end_date(2025, 1, 1)
 
         self.version = self.get_parameter("version", "1")


### PR DESCRIPTION
@jsboige

Part of the **QC backbone baseline sequence** (#2801/#1630). This PR = **#81 Cloud-VolTargeting** (RISK family, no-ML → deterministic, no GPU).

## Scope (1 file — main.py only, per the per-project pattern)

`projects/Cloud-VolTargeting/main.py` — align `set_start_date(2014,1,1)` → `set_start_date(2018,1,1)` (#2801 Lot 3). `set_brokerage_model(IBKR, MARGIN)` already present (#2801 Lot 1). No logic change (v1 default = single-asset SPY vol-targeting).

## Backtest result (QC Cloud, project 30823587)

| Metric | Value |
|---|---|
| Backtest ID | `179ef1c5` |
| Period | 2018-2025 (1761 tradeable dates) |
| Sharpe | **0.207** |
| CAGR | 6.717% |
| MaxDD | 38.2% |
| PSR | 2.380% |

**Verdict: weak positive → Tier 2 (Historique).** Second-highest backbone baseline so far (#77 0.22 top, #78 0.067, #79 0.027, #80 −0.029). This is **genuine vol-targeting** (unlike the mislabeled #79 "RiskParity" which was equal-weight momentum rotation): single-asset SPY, target_vol 12%, 21d realized-vol scaling, 30-150% allocation clamp, monthly rebalance.

**Notable nuance — vol-targeting did NOT reduce drawdown here.** MaxDD 38.2% is *higher* than the momentum strategies (#77 28.1%). The 150% max-allocation clamp leverages UP in low-vol regimes, then gets caught leveraged when vol spikes (COVID 2020, 2022 bear) → deeper drawdowns. So on the aligned 2018-2025 period, naive SPY vol-targeting with a high leverage cap did not deliver the drawdown-reduction its textbook rationale promises. Promoted Tier 4 (Untested) → Tier 2 (Historique).

## G.1 disclosure — totalOrders=0 wrapper artifact

qc-mcp-lite returns `totalOrders=0` + `equity={}`, but `statistics` is QC-computed. CAGR 6.7% with literally zero trades is impossible (cash → Sharpe 0), so stats are real and `totalOrders=0` is a wrapper extraction artifact. Cross-checked `list_backtests` (Completed). Same artifact as #77/#78/#79/#80; distinct from #3367.

## Doc update DEFERRED (consolidation directive)

Per ai-01 2026-06-22 directive, doc rows are consolidated into ONE doc PR per batch (main.py stacks freely per-PR, no conflict). #81 row + Tier 4 removal + Key-finding #25 will go into the next consolidated doc PR (off fresh main, once #3905 #79/#80 doc batch lands). Data recorded in memory for that PR.

## Verification

- `create_compile` → BuildSuccess (numpy as `np` available on QC Cloud). `create_backtest` → Completed, progress 1.
- Uploaded from repo canonical main.py.
- Deterministic no-ML baseline (no multi-seed; #1630 residual #7 edge-vs-σ applies to ML/DL/RL only, cf #3567).

See #1630. Does NOT close #1630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)