### PR TITLE
docs(lean): FR backfill grothendieck_lean/README (Phase 0.5 #1650)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -1,0 +1,122 @@
+# Grothendieck Tribute — Mathlib Tour
+
+Alexandre Grothendieck (1928-2014).
+
+## Purpose
+
+This workspace is a **pedagogical homage** showing how Grothendieck's mathematical
+language already lives in Mathlib 4. It is **not** an attempt to formalize EGA/SGA.
+
+The goal is to give learners a curated entry point into:
+- Categories, sieves, and Grothendieck topologies
+- Sheaves, separated presheaves, subcanonical topologies
+- Coverage generation and sheaf characterization
+- The canonical topology and subcanonical sites
+- Schemes (locally ringed spaces locally Spec R)
+- The Zariski site
+- What Mathlib has and what it doesn't (yet)
+
+## Structure
+
+The formalization spans **23 modules (Parts 1-23, 3182 lines, 0 sorry)**, imported
+in order by the umbrella `Grothendieck.lean`. Each module self-numbers via its header
+(`Grothendieck tribute — Part N`).
+
+| Part | File | Content | Lines |
+|------|------|---------|-------|
+| 1 | `Grothendieck/CategoryAndSites.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 106 |
+| 2 | `Grothendieck/SchemesTour.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 79 |
+| 3 | `Grothendieck/ZariskiSite.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 84 |
+| 4 | `Grothendieck/MathlibMap.lean` | `#check` index of Grothendieck-related Mathlib definitions | 90 |
+| 5 | `Grothendieck/Calibration.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 80 |
+| 6 | `Grothendieck/SieveLattice.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
+| 7 | `Grothendieck/SheafBasics.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 128 |
+| 8 | `Grothendieck/SieveOps.lean` | Topology ordering, covering closure, sieve composition | 124 |
+| 9 | `Grothendieck/CoverageGen.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 148 |
+| 10 | `Grothendieck/CanonicalProps.lean` | Canonical topology, subcanonicity, representable sheaves | 133 |
+| 11 | `Grothendieck/SieveGenerate.lean` | Sieve generation identities | 128 |
+| 12 | `Grothendieck/DenseTopology.lean` | The dense topology | 131 |
+| 13 | `Grothendieck/Sheafification.lean` | Sheafification (the associated sheaf functor) | 175 |
+| 14 | `Grothendieck/LeftExact.lean` | Left exactness of sheafification | 133 |
+| 15 | `Grothendieck/SitePoints.lean` | Points of a site (fiber functors) | 220 |
+| 16 | `Grothendieck/Subcanonical.lean` | Subcanonical Grothendieck topologies | 88 |
+| 17 | `Grothendieck/SheafHom.lean` | Internal hom of sheaves | 140 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
+| 19 | `Grothendieck/Conservative.lean` | Conservative families of points | 226 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | Sheaf cohomology (Ext-based) | 214 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | Mayer-Vietoris squares | 195 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | Mayer-Vietoris long exact sequence | 164 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | Čech cohomology | 123 |
+
+The extension (Parts 6-23) was developed under Issue #2159 / Epic #1646 and is
+**complete**: all 23 modules merged, 0 `sorry`, 0 axiom added.
+
+## Build
+
+```bash
+# From this directory (WSL required)
+lake build Grothendieck
+# Builds all 23 modules (3182 lines)
+```
+
+## Sorry count
+
+**0 sorry, 0 axiom** — all 23 modules are complete at creation (Parts 1-23 merged).
+
+## Toolchain
+
+Aligned with other SymbolicAI/Lean projects: `leanprover/lean4:v4.30.0-rc2`
+
+## References
+
+The language toured here — Grothendieck topologies, sites, sheaves, and schemes — originates in Grothendieck's algebraic geometry. These are the canonical entry points. This workspace is a pedagogical tour indexed against Mathlib, **not** a formalization of EGA/SGA.
+
+- **Mac Lane, S.; Moerdijk, I.** *Sheaves in Geometry and Logic: A First Introduction to Topos Theory*. Springer Universitext, 1992. — Standard reference for Grothendieck topologies, sieves, sites, and sheaves (Parts 1, 6-8, 10, 13-14).
+- **Artin, M.; Grothendieck, A.; Verdier, J. L.**, eds. *Theorie des topos et cohomologie etale des schemas* (SGA 4). Springer Lecture Notes in Mathematics 269, 270, 305, 1972-1973. — Origin of sites, Grothendieck topologies, and points of a topos (Parts 1, 15, 19).
+- **Grothendieck, A.; Dieudonne, J.** *Elements de geometrie algebrique* (EGA). Publications Mathematiques de l'IHES, 1960-1967. — Origin of schemes and the Zariski site (Parts 2-3).
+- **Vakil, R.** *The Rising Sea: Foundations of Algebraic Geometry*. — Widely used pedagogical notes in the Grothendieckian spirit.
+- **The Stacks Project.** [stacks.math.columbia.edu](https://stacks.math.columbia.edu) — Reference for schemes, sheafification, and sheaf cohomology (Parts 13, 20-23).
+- **The Mathlib Community.** *Mathlib4, Category Theory and Sites*. [mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/) — The library this tour indexes (Part 4); see de Moura & Ullrich, "The Lean 4 Theorem Prover" (2021).
+- **nLab.** [ncatlab.org](https://ncatlab.org) — Entries on Grothendieck topology, sieve, site, sheaf, and sheafification.
+
+## See also
+
+- Epic #1646 (Grothendieck tribute)
+- Issue #2159 (Grothendieck formalization depth)
+- PR #2675 (Phases 4-6: SieveOps + CoverageGen + CanonicalProps)
+- Epic #1453 (prover harness calibration)
+- Conway tribute workspace (`../conway_lean/`)
+- Lean notebook series (`../README.md`)
+
+## Conclusion
+
+This tribute is a **complete pedagogical tour** (23 modules, 3182 lines, 0 `sorry`,
+0 axiom added) showing how Grothendieck's language — sites, sheaves,
+sheafification, points, cohomology — already lives in Mathlib 4. It is
+deliberately **not** a formalization of EGA/SGA; it is a curated index that lets
+learners see the library through Grothendieckian eyes.
+
+### The arc
+
+The modules trace a coherent path: **sites and sieves** (Parts 1, 6, 8, 11, 12,
+16) → **sheaves, separation, and transfer** (7, 9, 10, 17) → **sheafification and
+its left exactness** (13, 14) → **points and conservative families** (15, 19) →
+**sheaf cohomology, Mayer-Vietoris, and Čech** (20-23), with **schemes and the
+Zariski site** (2, 3) and a **Mathlib map** (4) anchoring the tour to the library
+it indexes.
+
+### Scope, honestly
+
+Per the `## Sorry count` section above, the tour is **0 `sorry`, 0 axiom added** —
+every result is fully proven. Part 4's `#check` index is explicit about what
+Mathlib has and what it does not (yet); the tour documents that boundary rather
+than papering over it. The companion `Calibration.lean` (Part 5) feeds the prover
+harness (Epic #1453), tying this formalization to the broader proving effort.
+
+### Where to go next
+
+- **Depth**: Issue #2159 / Epic #1646 track further formalization — this tour is
+  the foundation, not the ceiling.
+- **Companions**: `conway_lean/` (Conway's mathematics), the Lean notebook series.
+- **References**: Mac Lane–Moerdijk and SGA 4 for the topos-theoretic core; Vakil
+  and the Stacks Project for schemes and cohomology.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -1,71 +1,73 @@
-# Grothendieck Tribute — Mathlib Tour
+# Hommage à Grothendieck — Visite de Mathlib
 
 Alexandre Grothendieck (1928-2014).
 
-## Purpose
+## Objectif
 
-This workspace is a **pedagogical homage** showing how Grothendieck's mathematical
-language already lives in Mathlib 4. It is **not** an attempt to formalize EGA/SGA.
+Ce workspace est un **hommage pédagogique** montrant comment le langage
+mathématique de Grothendieck vit déjà dans Mathlib 4. Ce n'est **pas** une
+tentative de formaliser EGA/SGA.
 
-The goal is to give learners a curated entry point into:
-- Categories, sieves, and Grothendieck topologies
-- Sheaves, separated presheaves, subcanonical topologies
-- Coverage generation and sheaf characterization
-- The canonical topology and subcanonical sites
-- Schemes (locally ringed spaces locally Spec R)
-- The Zariski site
-- What Mathlib has and what it doesn't (yet)
+Le but est d'offrir aux apprenants un point d'entrée curaté vers :
+- Catégories, cribles (sieves) et topologies de Grothendieck
+- Faisceaux (sheaves), prefaisceaux séparés, topologies sous-canoniques
+- Génération de recouvrements (coverage) et caractérisation des faisceaux
+- La topologie canonique et les sites sous-canoniques
+- Schémas (espaces annelés en anneaux locaux localement Spec R)
+- Le site de Zariski
+- Ce que Mathlib possède et ce qu'il n'a pas (encore)
 
 ## Structure
 
-The formalization spans **23 modules (Parts 1-23, 3182 lines, 0 sorry)**, imported
-in order by the umbrella `Grothendieck.lean`. Each module self-numbers via its header
-(`Grothendieck tribute — Part N`).
+La formalisation couvre **23 modules (Parties 1-23, 3182 lignes, 0 sorry)**,
+importés dans l'ordre par le parapluie `Grothendieck.lean`. Chaque module se
+numérote lui-même via son en-tête (`Grothendieck tribute — Part N`).
 
-| Part | File | Content | Lines |
-|------|------|---------|-------|
-| 1 | `Grothendieck/CategoryAndSites.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 106 |
-| 2 | `Grothendieck/SchemesTour.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 79 |
-| 3 | `Grothendieck/ZariskiSite.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 84 |
-| 4 | `Grothendieck/MathlibMap.lean` | `#check` index of Grothendieck-related Mathlib definitions | 90 |
-| 5 | `Grothendieck/Calibration.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 80 |
-| 6 | `Grothendieck/SieveLattice.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
-| 7 | `Grothendieck/SheafBasics.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 128 |
-| 8 | `Grothendieck/SieveOps.lean` | Topology ordering, covering closure, sieve composition | 124 |
-| 9 | `Grothendieck/CoverageGen.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 148 |
-| 10 | `Grothendieck/CanonicalProps.lean` | Canonical topology, subcanonicity, representable sheaves | 133 |
-| 11 | `Grothendieck/SieveGenerate.lean` | Sieve generation identities | 128 |
-| 12 | `Grothendieck/DenseTopology.lean` | The dense topology | 131 |
-| 13 | `Grothendieck/Sheafification.lean` | Sheafification (the associated sheaf functor) | 175 |
-| 14 | `Grothendieck/LeftExact.lean` | Left exactness of sheafification | 133 |
-| 15 | `Grothendieck/SitePoints.lean` | Points of a site (fiber functors) | 220 |
-| 16 | `Grothendieck/Subcanonical.lean` | Subcanonical Grothendieck topologies | 88 |
-| 17 | `Grothendieck/SheafHom.lean` | Internal hom of sheaves | 140 |
-| 18 | `Grothendieck/ConstantSheaf.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
-| 19 | `Grothendieck/Conservative.lean` | Conservative families of points | 226 |
-| 20 | `Grothendieck/SheafCohomology/Basic.lean` | Sheaf cohomology (Ext-based) | 214 |
-| 21 | `Grothendieck/MayerVietorisSquare.lean` | Mayer-Vietoris squares | 195 |
-| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | Mayer-Vietoris long exact sequence | 164 |
-| 23 | `Grothendieck/SheafCohomology/Cech.lean` | Čech cohomology | 123 |
+| Partie | Fichier | Contenu | Lignes |
+|--------|---------|---------|--------|
+| 1 | `Grothendieck/CategoryAndSites.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 106 |
+| 2 | `Grothendieck/SchemesTour.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 79 |
+| 3 | `Grothendieck/ZariskiSite.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 84 |
+| 4 | `Grothendieck/MathlibMap.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 90 |
+| 5 | `Grothendieck/Calibration.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 80 |
+| 6 | `Grothendieck/SieveLattice.lean` | Identités de pullback de cribles : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
+| 7 | `Grothendieck/SheafBasics.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 128 |
+| 8 | `Grothendieck/SieveOps.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 124 |
+| 9 | `Grothendieck/CoverageGen.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 148 |
+| 10 | `Grothendieck/CanonicalProps.lean` | Topologie canonique, sous-canoïcité, faisceaux représentables | 133 |
+| 11 | `Grothendieck/SieveGenerate.lean` | Identités de génération de cribles | 128 |
+| 12 | `Grothendieck/DenseTopology.lean` | La topologie dense | 131 |
+| 13 | `Grothendieck/Sheafification.lean` | Faisceautisation (le foncteur faisceau associé) | 175 |
+| 14 | `Grothendieck/LeftExact.lean` | Exactitude à gauche de la faisceautisation | 133 |
+| 15 | `Grothendieck/SitePoints.lean` | Points d'un site (foncteurs fibres) | 220 |
+| 16 | `Grothendieck/Subcanonical.lean` | Topologies de Grothendieck sous-canoniques | 88 |
+| 17 | `Grothendieck/SheafHom.lean` | Hom interne des faisceaux | 140 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 185 |
+| 19 | `Grothendieck/Conservative.lean` | Familles conservatrices de points | 226 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | Cohomologie des faisceaux (basée sur Ext) | 214 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | Carrés de Mayer-Vietoris | 195 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | Suite exacte longue de Mayer-Vietoris | 164 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | Cohomologie de Čech | 123 |
 
-The extension (Parts 6-23) was developed under Issue #2159 / Epic #1646 and is
-**complete**: all 23 modules merged, 0 `sorry`, 0 axiom added.
+L'extension (Parties 6-23) a été développée sous l'Issue #2159 / Epic #1646 et
+est **complète** : tous les 23 modules mergés, 0 `sorry`, 0 axiome ajouté.
 
 ## Build
 
 ```bash
-# From this directory (WSL required)
+# Depuis ce répertoire (WSL requis)
 lake build Grothendieck
-# Builds all 23 modules (3182 lines)
+# Compile les 23 modules (3182 lignes)
 ```
 
-## Sorry count
+## Compte de sorry
 
-**0 sorry, 0 axiom** — all 23 modules are complete at creation (Parts 1-23 merged).
+**0 sorry, 0 axiome** — tous les 23 modules sont complets à la création
+(Parties 1-23 mergées).
 
 ## Toolchain
 
-Aligned with other SymbolicAI/Lean projects: `leanprover/lean4:v4.30.0-rc2`
+Alignée avec les autres projets SymbolicAI/Lean : `leanprover/lean4:v4.30.0-rc2`
 
 ## References
 
@@ -79,44 +81,46 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - **The Mathlib Community.** *Mathlib4, Category Theory and Sites*. [mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/) — The library this tour indexes (Part 4); see de Moura & Ullrich, "The Lean 4 Theorem Prover" (2021).
 - **nLab.** [ncatlab.org](https://ncatlab.org) — Entries on Grothendieck topology, sieve, site, sheaf, and sheafification.
 
-## See also
+## Voir aussi
 
-- Epic #1646 (Grothendieck tribute)
-- Issue #2159 (Grothendieck formalization depth)
-- PR #2675 (Phases 4-6: SieveOps + CoverageGen + CanonicalProps)
-- Epic #1453 (prover harness calibration)
-- Conway tribute workspace (`../conway_lean/`)
-- Lean notebook series (`../README.md`)
+- Epic #1646 (hommage à Grothendieck)
+- Issue #2159 (profondeur de formalisation Grothendieck)
+- PR #2675 (Phases 4-6 : SieveOps + CoverageGen + CanonicalProps)
+- Epic #1453 (calibration du harnais prouveur)
+- Workspace hommage Conway (`../conway_lean/`)
+- Série de notebooks Lean (`../README.md`)
 
 ## Conclusion
 
-This tribute is a **complete pedagogical tour** (23 modules, 3182 lines, 0 `sorry`,
-0 axiom added) showing how Grothendieck's language — sites, sheaves,
-sheafification, points, cohomology — already lives in Mathlib 4. It is
-deliberately **not** a formalization of EGA/SGA; it is a curated index that lets
-learners see the library through Grothendieckian eyes.
+Cet hommage est une **visite pédagogique complète** (23 modules, 3182 lignes,
+0 `sorry`, 0 axiome ajouté) montrant comment le langage de Grothendieck — sites,
+faisceaux, faisceautisation, points, cohomologie — vit déjà dans Mathlib 4. Ce
+n'est délibérément **pas** une formalisation d'EGA/SGA ; c'est un index curaté
+qui laisse les apprenants voir la bibliothèque à travers des yeux grothendieckiens.
 
-### The arc
+### La trajectoire
 
-The modules trace a coherent path: **sites and sieves** (Parts 1, 6, 8, 11, 12,
-16) → **sheaves, separation, and transfer** (7, 9, 10, 17) → **sheafification and
-its left exactness** (13, 14) → **points and conservative families** (15, 19) →
-**sheaf cohomology, Mayer-Vietoris, and Čech** (20-23), with **schemes and the
-Zariski site** (2, 3) and a **Mathlib map** (4) anchoring the tour to the library
-it indexes.
+Les modules tracent un chemin cohérent : **sites et cribles** (Parties 1, 6, 8,
+11, 12, 16) → **faisceaux, séparation et transfert** (7, 9, 10, 17) →
+**faisceautisation et son exactitude à gauche** (13, 14) → **points et familles
+conservatrices** (15, 19) → **cohomologie des faisceaux, Mayer-Vietoris et Čech**
+(20-23), avec **schémas et site de Zariski** (2, 3) et une **carte Mathlib** (4)
+ancrant la visite à la bibliothèque qu'elle indexe.
 
-### Scope, honestly
+### Le périmètre, honnêtement
 
-Per the `## Sorry count` section above, the tour is **0 `sorry`, 0 axiom added** —
-every result is fully proven. Part 4's `#check` index is explicit about what
-Mathlib has and what it does not (yet); the tour documents that boundary rather
-than papering over it. The companion `Calibration.lean` (Part 5) feeds the prover
-harness (Epic #1453), tying this formalization to the broader proving effort.
+Selon la section `## Compte de sorry` ci-dessus, la visite est à **0 `sorry`,
+0 axiome ajouté** — chaque résultat est pleinement prouvé. L'index `#check` de la
+Partie 4 est explicite sur ce que Mathlib possède et ce qu'il n'a pas (encore) ;
+la visite documente cette frontière au lieu de la maquiller. Le module compagnon
+`Calibration.lean` (Partie 5) alimente le harnais du prouveur (Epic #1453),
+reliant cette formalisation à l'effort de preuve plus large.
 
-### Where to go next
+### Où aller ensuite
 
-- **Depth**: Issue #2159 / Epic #1646 track further formalization — this tour is
-  the foundation, not the ceiling.
-- **Companions**: `conway_lean/` (Conway's mathematics), the Lean notebook series.
-- **References**: Mac Lane–Moerdijk and SGA 4 for the topos-theoretic core; Vakil
-  and the Stacks Project for schemes and cohomology.
+- **Profondeur** : l'Issue #2159 / l'Epic #1646 suivent la formalisation
+  ultérieure — cette visite est le socle, pas le plafond.
+- **Compagnons** : `conway_lean/` (mathématiques de Conway), la série de
+  notebooks Lean.
+- **Références** : Mac Lane–Moerdijk et SGA 4 pour le cœur topos-théorique ;
+  Vakil et le Stacks Project pour les schémas et la cohomologie.


### PR DESCRIPTION
## Summary

Epic #1650 Phase 0.5 FR translation backfill — `grothendieck_lean/README.md`.

Applies [readme-french-first.md](../blob/main/.claude/rules/readme-french-first.md) **HARD 2** mechanic:
- `git mv README.md -> README.en.md` — EN golden set preserved **byte-identical** (future translation golden set)
- New `README.md` written in **French**, same structure / links / anchors / code-IDs / metrics

This is the **last remaining EN Lean README** — closes the `#3870` Lean README FR-backfill subset for good.

## Parity verification (G.1)

| Check | EN | FR |
|-------|----|----|
| H2 sections | 8 | 8 |
| H3 sections (under Conclusion) | 3 | 3 |
| Module table rows | 23 | 23 |
| Lines | 122 | 126 |

**Anchors preserved verbatim:**
- 23 module filenames + line counts (CategoryAndSites 106 → Cech 123, Σ 3182)
- Code IDs: `zariskiTopology_eq`, `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `homeoOfIso`, `Γ`
- Toolchain `leanprover/lean4:v4.30.0-rc2` (G.1 verified against `lean-toolchain`)
- Metrics: 3182 lines, 0 sorry, 0 axiom, 23 modules
- Epic/Issue/PR refs: #1646, #2159, #2675, #1453
- `lake build Grothendieck`

**References section kept verbatim EN** (bibliographic convention — Mac Lane–Moerdijk, SGA 4, EGA, Vakil, Stacks Project, Mathlib, nLab).

## Scope

- Docs-only (README.md + README.en.md), **no `.lean` touched**
- `COURSE_CATALOG.generated.{md,json}` **byte-identical to main** (catalog-pr-hygiene HARD 1)
- EN original preserved (never deleted — rule HARD 2)

See #1650
See #3870