### PR TITLE
docs(lean): FR backfill Lean/examples/README (Phase 0.5 #1650)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/README.en.md
@@ -1,0 +1,24 @@
+# Lean Examples
+
+Standalone .lean files for pedagogical use, executed via the lean4-wsl Jupyter kernel.
+
+## Status
+
+- **Type**: Standalone files (no lakefile -- executed cell-by-cell via Jupyter kernel)
+- **Sorry count**: 2 (in `llm_assisted_proof.lean` -- intentional pedagogical example)
+
+## Files
+
+| File | sorry | Description |
+|------|-------|-------------|
+| `basic_logic.lean` | 0 | Propositional logic foundations |
+| `llm_assisted_proof.lean` | 2 | LLM-assisted proving demonstration (intentional sorry) |
+| `mathlib_examples.lean` | 0 | Mathlib tactic examples |
+| `quantifiers.lean` | 0 | Quantifier reasoning patterns |
+| `tactics_demo.lean` | 0 | Lean 4 tactics showcase |
+
+## Notes
+
+- These files are NOT a Lake project -- they are executed cell-by-cell via the `lean4-wsl` Jupyter kernel
+- The 2 sorry in `llm_assisted_proof.lean` are intentional: they demonstrate the LLM-assisted proving workflow where the prover leaves placeholders
+- Companion to the intro Lean notebooks series (Lean-1 through Lean-5)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/README.md
@@ -1,24 +1,25 @@
-# Lean Examples
+# Exemples Lean
 
-Standalone .lean files for pedagogical use, executed via the lean4-wsl Jupyter kernel.
+Fichiers `.lean` autonomes à usage pédagogique, exécutés via le kernel Jupyter
+`lean4-wsl`.
 
-## Status
+## Statut
 
-- **Type**: Standalone files (no lakefile -- executed cell-by-cell via Jupyter kernel)
-- **Sorry count**: 2 (in `llm_assisted_proof.lean` -- intentional pedagogical example)
+- **Type** : Fichiers autonomes (pas de lakefile — exécutés cellule par cellule via le kernel Jupyter)
+- **Compte de sorry** : 2 (dans `llm_assisted_proof.lean` — exemple pédagogique intentionnel)
 
-## Files
+## Fichiers
 
-| File | sorry | Description |
-|------|-------|-------------|
-| `basic_logic.lean` | 0 | Propositional logic foundations |
-| `llm_assisted_proof.lean` | 2 | LLM-assisted proving demonstration (intentional sorry) |
-| `mathlib_examples.lean` | 0 | Mathlib tactic examples |
-| `quantifiers.lean` | 0 | Quantifier reasoning patterns |
-| `tactics_demo.lean` | 0 | Lean 4 tactics showcase |
+| Fichier | sorry | Description |
+|---------|-------|-------------|
+| `basic_logic.lean` | 0 | Fondements de la logique propositionnelle |
+| `llm_assisted_proof.lean` | 2 | Démonstration de preuve assistée par LLM (sorry intentionnel) |
+| `mathlib_examples.lean` | 0 | Exemples de tactiques Mathlib |
+| `quantifiers.lean` | 0 | Schémas de raisonnement sur les quantificateurs |
+| `tactics_demo.lean` | 0 | Vitrine des tactiques Lean 4 |
 
 ## Notes
 
-- These files are NOT a Lake project -- they are executed cell-by-cell via the `lean4-wsl` Jupyter kernel
-- The 2 sorry in `llm_assisted_proof.lean` are intentional: they demonstrate the LLM-assisted proving workflow where the prover leaves placeholders
-- Companion to the intro Lean notebooks series (Lean-1 through Lean-5)
+- Ces fichiers ne sont **pas** un projet Lake — ils sont exécutés cellule par cellule via le kernel Jupyter `lean4-wsl`
+- Les 2 `sorry` dans `llm_assisted_proof.lean` sont **intentionnels** : ils illustrent le flux de preuve assistée par LLM, où le prouveur laisse des marqueurs de substitution
+- Compagnon de la série de notebooks d'introduction à Lean (Lean-1 à Lean-5)


### PR DESCRIPTION
## Summary

Epic #1650 Phase 0.5 FR translation backfill — `SymbolicAI/Lean/examples/README.md`.

Applies [readme-french-first.md](../blob/main/.claude/rules/readme-french-first.md) **HARD 2**:
- `git mv README.md -> README.en.md` — EN golden set preserved **byte-identical**
- New `README.md` in French, same structure / links / anchors / metrics

**G.1 catch**: this README was missed when the `#3870` Lean README FR-backfill lane was declared "tapped" (only `social_choice_lean_peters` + `grothendieck_lean` were tracked as remaining). A direct repo re-scan (definitive FR-only vs EN-only markers) found `Lean/examples/` still EN — this PR closes that gap.

## Parity (G.1)

| Check | EN | FR |
|-------|----|----|
| H2 sections | 3 | 3 |
| File table rows | 5 | 5 |
| Lines | 24 | 25 |

**Preserved verbatim:** 5 filenames + sorry counts (`basic_logic` 0, `llm_assisted_proof` 2, `mathlib_examples` 0, `quantifiers` 0, `tactics_demo` 0), `lean4-wsl` Jupyter kernel, sorry count 2 (intentional in `llm_assisted_proof.lean`), Lean-1→Lean-5 notebook companions.

## Scope

- Docs-only (README.md + README.en.md), no `.lean` touched
- `COURSE_CATALOG.generated.{md,json}` byte-identical to main (catalog-pr-hygiene HARD 1)
- EN original preserved (never deleted — rule HARD 2)

See #1650
See #3870