### PR TITLE
docs(infer-18): add synthesized Conclusion (Valeur de l'Information) (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Decision-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Decision-Value-Information.ipynb
@@ -4446,6 +4446,46 @@
     "\n",
     "Console.WriteLine(\"Exercice a completer\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a pose le cadre de la **valeur de l'information** (VoI) : une theorie de decision qui quantifie, en esperance d'utilite, combien il vaut la peine d'acquerir une information supplementaire avant de decider.\n",
+    "\n",
+    "### La VoI, un pont entre probabilite et decision\n",
+    "\n",
+    "La VoI articule trois quantites complementaires, chacune repondant a une question differente :\n",
+    "\n",
+    "| Question pratique | Quantite | Reponse |\n",
+    "|-------------------|----------|---------|\n",
+    "| Jusqu'ou un oracle pourrait-il ameliorer ma decision ? | **EVPI** | Borne superieure de la valeur d'information |\n",
+    "| Combien vaut *ce* test concret ? | **EVSI** | Valeur reelle, a comparer au cout du test |\n",
+    "| Mon test est-il proche de l'optimal ? | **Efficiency** = EVSI / EVPI | Ratio de qualite (0 a 1) |\n",
+    "\n",
+    "### Le triptyque \"pertinence - impact - cout\"\n",
+    "\n",
+    "La condition EVSI > 0 se decompose en trois exigences cumulatives, demontrees par les exemples du notebook :\n",
+    "\n",
+    "1. **Pertinence** : le signal doit modifier les posterieurs (un test non informatif a une EVSI nulle, meme s'il est gratuit).\n",
+    "2. **Impact** : les posterieurs doivent changer la decision optimale (informer sans faire basculer l'action n'apporte rien).\n",
+    "3. **Cout** : le cout d'acquisition doit rester inferieur a l'EVSI pour que le test soit rentable.\n",
+    "\n",
+    "Le cas de la **maladie rare** (EVSI = 0 malgre un test gratuit) illustre l'echec du premier critere : un test sur un evenement de faible probabilite anterieure deplace a peine les croyances. A l'inverse, le **test sismique avant forage** satisfait les trois criteres et s'avere rentable (EVSI net de 203k).\n",
+    "\n",
+    "### Ce que Infer.NET apporte a l'analyse\n",
+    "\n",
+    "Les calculs d'EVPI et d'EVSI reposent sur des **posterieurs bayesiens** qu'Infer.NET calcule automatiquement a partir de la modelisation du graphe. La valeur ajoutee n'est pas dans la formule de VoI elle-meme (une esperance d'utilite), mais dans l'**elimination des calculs manuels de la regle de Bayes** : le practicien se concentre sur la structure du probleme (etats, actions, signaux, utilites) et laisse le moteur inferentiel propager les croyances.\n",
+    "\n",
+    "### Arc pedagogique de la serie\n",
+    "\n",
+    "Apres les fondations de l'utilite (notebooks 14-15 : axiomes VNM, CRRA/CARA), l'extension multi-attribut (16) et les reseaux de decision (17), ce notebook 18 boucle la boucle en montrant **quand l'incertitude elle-meme a un prix**. La suite immediate est la robustesse face a l'incertitude epistemique (Infer-19 : criteres minimax, Hurwicz, Laplace) puis les decisions sequentielles (Infer-20 : MDP, bandits, POMDP), ou la VoI devient dynamique -- c'est precisement le formalisme qui sous-tend l'indice de Gittins et l'exploration-exploitation.\n",
+    "\n",
+    "> **A retenir** : dans tout probleme de decision sous incertitude, se demander *quelle information pourrait changer ma decision, et a quel prix* est le reflexe fondamental que la VoI formalise. Le calcul est bayesien ; l'intuition est economique.\n",
+    ""
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Résumé

Fallback perenne **#2651** (prose pédagogique) sur la famille Python/ML (Probas/Infer). `Infer-18-Decision-Value-Information` se terminait sur le **stub de l'Exercice 3** sans conclusion synthétisée — gap HIGH confirmé G.1 (recensement sous-agent + vérification firsthand des dernières cellules).

## Gap identifié (vérifié)

- Cellule finale = code stub `// Exercice : VoI pour un Portfolio d'Investissement` (idx 52).
- `### Points clés à retenir` (idx 49) + `## 8. Resume` table (idx 50) = recaps (liste/table), **pas** une synthèse qui referme le notebook.
- Aucun heading `## Conclusion` dans le notebook (scan confirmé).

## Changement

Ajout d'une cellule markdown finale `## Conclusion` synthétisant le cadre **Valeur de l'Information** (VoI), grounded dans le contenu réel du notebook :
- triptyque **EVPI / EVSI / Efficiency** (tableau question-pratique → quantité)
- les 3 conditions cumulées pour `EVSI > 0` (pertinence / impact / coût), illustrées par les exemples du notebook (maladie rare EVSI=0 ; test sismique net 203k)
- ce qu'apporte Infer.NET (postérieurs bayésiens automatiques, élimination des calculs manuels de Bayes)
- arc pédagogique de la série (14-17 → 18 → 19-20, pont vers Gittins / exploration-exploitation)

## Validation §D

- Markdown-only : **+40/-0, 1 fichier**, 0 code cell touché → **C.2 exception markdown** (pas de re-exec kernel C#).
- `nbformat validate` OK (1 warning MissingIDField pré-existant legacy).
- 0 `execution_count`/outputs modifié, 0 C.1 introduit.
- Catalog byte-identical, base fraîche off `origin/main`.

See #2651

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>