### PR TITLE
feat(qc): align GlobalMacro-Regime baseline to 2018-2025 (#1630)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/GlobalMacro-Regime/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/GlobalMacro-Regime/main.py
@@ -24,7 +24,9 @@ class GlobalMacroRegime(QCAlgorithm):
     MIN_TRENDING = 2
 
     def initialize(self):
-        self.set_start_date(2015, 1, 1)
+        # Aligned baseline period 2018-2025 (#1630). Original start was 2015;
+        # standardized to 2018-01-01 for cross-strategy comparison.
+        self.set_start_date(2018, 1, 1)
         self.set_end_date(2025, 1, 1)  # Fixed end date for reproducibility
         self.set_cash(100_000)
         self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)


### PR DESCRIPTION
## Summary

Part of the QC backbone baseline sequence (#2801/#1630). Aligns `GlobalMacro-Regime/main.py` to the standardized 2018-2025 baseline period for cross-strategy comparison.

## Change

- `set_start_date(2015, 1, 1)` -> `set_start_date(2018, 1, 1)` (with explanatory comment).
- `set_end_date(2025, 1, 1)` already aligned.
- IBKR brokerage model already present (MARGIN). No other change.

## Strategy

RISK-class, multi-asset, **no-ML**. Rank-based risk-parity + SPY regime switch (Bridgewater / Antonacci 2014 reference). Bull regime (SPY > SMA200 AND 6m mom > 0): rank-score x inverse-vol weighting over trending risky assets (SPY/EFA/EEM/TLT/GLD/DBC). Bear regime: risk-parity over defensive (BND/TLT/GLD). Monthly rebalance.

## Backtest (QC Cloud, project 30781695)

| Metric | Value |
|--------|-------|
| Period | 2018-01-01 to 2025-01-01 (1761 tradeable dates) |
| Sharpe | **0.454** |
| CAGR | 9.798% |
| MaxDD | 22.8% |
| PSR | 16.687% |

**Verdict: Tier 4 (Untested) -> Tier 2 (Historique, 0.0-0.5).** PSR 16.7% (not significant but respectable).

**Best backbone baseline so far**: 0.454 >> #81 Cloud-VolTargeting (0.207) ~ #77 AssetClassMomentum (0.22) >> #79 Cloud-RiskParity (0.027) >> #80 Cloud-SectorRotation (-0.029). The regime-switch + rank x inv_vol risk-parity dramatically outperforms simple momentum rotations, AND keeps MaxDD controlled (22.8% vs #80 42.7%, #81 38.2%). Just under Tier 1 (>0.5).

**Note**: the in-code docstring cites prior Sharpes (v3 BEST 0.607) computed on the original 2015 start; the aligned 2018-2025 value is 0.454 (period shortening effect).

**totalOrders=0**: wrapper extraction artifact (qc-mcp-lite `read_backtest` does not parse `totalOrders`/`totalNetProfit`); CAGR 9.8% with 0 trades is impossible, so statistics are real and QC-computed. Distinct from #3367 (notebook-fabricated Trades=0).

## Scope

main.py-only (1 file, +3/-1). Doc row deferred to the consolidated doc batch PR (#81 + #82) per the established pattern (main.py per-PR stacks freely, doc rows accumulated in one doc PR to avoid adjacent-Tier4-deletion conflicts).

See #1630. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>