### PR TITLE
docs(lean): finalize Knot-17a/17b navigation footer (#3843 step-6)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17-Knots-a-Conway-and-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17-Knots-a-Conway-and-Proofs.ipynb
@@ -1616,7 +1616,11 @@
     "# et la signature (texte entre ':' et ':='). Utilisez les expressions régulières `import re`.\n",
     "# Etape 1 : compiler deux regex : r'theorem\\s+(\\w+)\\s*:\\s*(.+?)\\s*:=' pour les théorèmes.\n",
     "# Etape 2 : boucler sur les lignes, appliquer la regex, accumuler les matches.\n",
-    "# Etape 3 : retourner la liste des (nom, signature).\n"
+    "# Etape 3 : retourner la liste des (nom, signature).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Navigation** : [<< Lean-16f — Conway Free-Will](Lean-16f-Conway-Free-Will-Theorem.ipynb) | [Index](README.md) | [Lean-17b — Invariants >>](Lean-17-Knots-b-Invariants-Companion.ipynb)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17-Knots-b-Invariants-Companion.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17-Knots-b-Invariants-Companion.ipynb
@@ -1974,15 +1974,17 @@
     "- La dichotomie Conway/K-T illustre que le polynôme d'Alexander seul ne suffit pas\n",
     "- L'invariant $s$ de Rasmussen (homologie de Khovanov) est nécessaire pour la sliceness lisse\n",
     "\n",
-    "**Notebook suivant** : `Lean-17-Knots-a-Conway-and-Proofs.ipynb` — contexte historique et formalisation Lean.\n",
-    "\n",
     "## Références\n",
     "\n",
     "1. [Knot Atlas](https://katlas.org/) — Base de données collaborative\n",
     "2. [SnapPy](https://snappy.computop.org/) — Calcul topologique 3D\n",
     "3. [SageMath Knot Theory](https://doc.sagemath.org/html/en/reference/knots/)\n",
     "4. **Piccirillo (2020)** — *The Conway knot is not slice*, Annals Math.\n",
-    "5. **Lidman (2026)** — *The unknotting number of 11n102 is 2*, arXiv:2606.12431\n"
+    "5. **Lidman (2026)** — *The unknotting number of 11n102 is 2*, arXiv:2606.12431\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Navigation** : [<< Lean-17a — Conway & Preuve de Piccirillo](Lean-17-Knots-a-Conway-and-Proofs.ipynb) | [Index](README.md)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Finalizes the navigation for the Knot-17a/17b notebooks — the deferred residual of the Lean series renumbering (**#3843**), unblocked now that Knot-17b content landed (**#3858** MERGED).

17a/17b were marked **"inchangé"** in the renumbering EXEC ([#3875](#3875)), so they never received the `**Navigation**` footer block the rest of the series uses (matching the 16f convention: `**Navigation** : [<< prev] | [Index](README.md)`).

## Two defects fixed

1. **17b — reversed nav direction (the bug).** 17b's footer said "**Notebook suivant** : `Lean-17-Knots-a-…`" — but 17a is the **précédent** (predecessor), not the suivant. 17a presents the theory first (Conway knot, Piccirillo proof, Lean formalization); 17b is the companion computing invariants of knots **"présentés dans 17a"** (17b's own intro). Reading order: 17a → 17b. The "suivant" label pointed backwards.
2. **Both — missing series nav convention.** Neither notebook had the `**Navigation**` footer that 16f and the renumbered notebooks use.

## Changes (markdown-only, 2 cells)

| Notebook | Edit |
|----------|------|
| **17a** (`Lean-17-Knots-a-…`) cell `86e3ddf4` | Append `**Navigation** : [<< Lean-16f Conway-Free-Will](Lean-16f-…) \| [Index](README.md) \| [Lean-17b Invariants >>](Lean-17-Knots-b-…)` |
| **17b** (`Lean-17-Knots-b-…`) cell `conclusion-cell` | Remove wrong "Notebook *suivant*: 17a" line **+** add `**Navigation** : [<< Lean-17a — Conway & Preuve de Piccirillo](Lean-17-Knots-a-…) \| [Index](README.md)` |

## Verification

- **nbformat VALID** both notebooks
- **Markdown-only**: 2 cells touched, code cells untouched → outputs/`execution_count` preserved (C.2 markdown exception)
- **Targeted diff**: 17a +6/−2, 17b +6/−4 — no mass-reformat (json `indent=1` matched original)
- **Catalog** `COURSE_CATALOG.generated.{md,json}` **byte-identical to main**
- **Link targets verified present**: `README.md`, `Lean-16f-Conway-Free-Will-Theorem.ipynb`, `Lean-17-Knots-a-…`, `Lean-17-Knots-b-…`
- Pre-existing: 17a has 5 code-stub cells w/o outputs (C.1 exercise stubs, expected, untouched)

See #3843

Co-Authored-By: Claude <noreply@anthropic.com>