### PR TITLE
scrub(archive-tweety): anonymize checkout-root paths in outputs (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/archive/Tweety.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/archive/Tweety.ipynb
@@ -309,7 +309,7 @@
       "  JARs Modules:\n",
       "    - Nouveaux téléchargés : 0\n",
       "    - Total présents       : 32 / 32\n",
-      "  Chemin du dossier libs : C:\\dev\\CoursIA\\libs\n",
+      "  Chemin du dossier libs : <repo>libs\n",
       "\n",
       "✔️ Vérification des JARs Tweety terminée. Le démarrage de la JVM peut continuer.\n"
      ]
@@ -471,7 +471,7 @@
      "text": [
       "\n",
       "--- 1.4bis Téléchargement des Fichiers de Données ---\n",
-      "ℹ️ Les fichiers de données seront téléchargés dans: C:\\dev\\CoursIA\\resources\n",
+      "ℹ️ Les fichiers de données seront téléchargés dans: <repo>resources\n",
       "\n",
       "Vérification/Téléchargement de 29 fichiers de données...\n"
      ]
@@ -503,7 +503,7 @@
      "text": [
       "\n",
       "--- Résumé Téléchargement Données ---\n",
-      "   Dossier cible          : C:\\dev\\CoursIA\\resources\n",
+      "   Dossier cible          : <repo>resources\n",
       "   Fichiers téléchargés  : 0\n",
       "   Fichiers déjà présents : 29\n",
       "   Total fichiers OK      : 29 / 29\n",
@@ -807,8 +807,8 @@
      "text": [
       "\n",
       "--- Téléchargement/Vérification Automatique des Outils Externes ---\n",
-      "INFO: Outils externes dans 'C:\\dev\\CoursIA\\ext_tools'\n",
-      "INFO: Binaires natifs Tweety dans 'C:\\dev\\CoursIA\\libs\\native'\n",
+      "INFO: Outils externes dans '<repo>ext_tools'\n",
+      "INFO: Binaires natifs Tweety dans '<repo>libs\\native'\n",
       "\n",
       "1. Vérification/Téléchargement SPASS...\n",
       "  ℹ️ Pour Windows: Installation manuelle de SPASS requise.\n",
@@ -838,11 +838,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Résumé Natifs: 0 téléchargés, 3/3 présents dans 'C:\\dev\\CoursIA\\libs\\native'.\n",
+      "  Résumé Natifs: 0 téléchargés, 3/3 présents dans '<repo>libs\\native'.\n",
       "\n",
       "  Note importante sur les binaires natifs (.dll/.so/.dylib) :\n",
       "    - ... (texte identique) ...\n",
-      "      spécifique, typiquement : -Djava.library.path=\\\"C:\\dev\\CoursIA\\libs\\native\\\"\n",
+      "      spécifique, typiquement : -Djava.library.path=\\\"<repo>libs\\native\\\"\n",
       "    - ... (texte identique) ...\n",
       "\n",
       "--- Vérification Finale des Chemins Outils Externes ---\n",


### PR DESCRIPTION
## Summary

Scrub the `C:\dev\CoursIA\` checkout-root path leaks in `archive/Tweety.ipynb` (my po-204 .NET residual grain, gated on #3895 which merged as `2aee662f`).

## Root-cause lens (per user mandate 2026-06-22 — "fix the scripts, don't just redact")

I verified firsthand (G.1) where the leak comes from: the `C:\dev\CoursIA\` paths appear **ONLY in stdout stream outputs (cells 6/7/10), NEVER in source**. The notebook prints its runtime location (`Chemin du dossier libs : …`, `Outils externes dans '…/ext_tools'`) where the dir is **dynamically resolved** (not hardcoded). This is **environmental noise** — the same class as ipykernel temp paths, .NET nuget-load lines, pip "already satisfied" — that re-execution regenerates afresh each run.

Per the user's mandate, scrubbing is the **correct root-cause fix here**, NOT a redaction-symptom. This is distinct from the key-leak case (NotebookMaker #3913 / #3911) where the source *deliberately prints secret material* — that requires a source fix. Here there is no secret-printing source to fix; the path reveals only the machine's directory structure, resolved at runtime.

## Verification (corrected tool, post-#3895 lookbehind fix)

- Re-scan: **0 residual**
- 0 mangle (`<X<repo>` = 0; the lookbehind fix preserves any URL scheme — none here anyway, plain paths)
- JSON valid
- Diff: **7/7 path-only**, 0 source / cell_type / execution_count change
- Catalogue + submodule byte-identical (only `Tweety.ipynb` touched)

\`See #3436\`

Co-Authored-By: Claude <noreply@anthropic.com>