### PR TITLE
docs(infer-10): add synthesized Conclusion (Crowdsourcing) (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Crowdsourcing.ipynb
@@ -3427,6 +3427,39 @@
     "\n",
     "Console.WriteLine(\"Exercice a completer : detection de workers spammeurs\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a traite un probleme central de l'apprentissage a partir de donnees humaines : **agreger des labels bruites fournis par des annotateurs de fiabilite inconnue** pour reconstruire la verite terrain. La cle est de ne pas se contenter du label, mais d'**inferer conjointement** le vrai label de chaque item *et* la fiabilite de chaque worker.\n",
+    "\n",
+    "### Une montee en expressivite, au prix de la donnee\n",
+    "\n",
+    "Les quatre approches vues forment une progression ou chaque modele capture une source de bruit supplementaire, en echange d'un cout d'annotation croissant :\n",
+    "\n",
+    "| Modele | Ce qu'il capture | Limite levee |\n",
+    "|--------|------------------|--------------|\n",
+    "| **Vote majoritaire** | Rien (compte les voix) | Baseline naive, sensible aux spammeurs |\n",
+    "| **Honest Worker** | Une competence scalaire par worker | Pondere les workers fiables |\n",
+    "| **Biased Worker** | Une matrice de confusion par worker | Detecte les biais systematiques par classe |\n",
+    "| **Community** | Des groupes de workers (hierarchie) | Resout le cold-start via partage de force |\n",
+    "\n",
+    "Le fil conducteur est bayesien : un worker incertain voit son vote *automatiquement* dilue, et un item controverse reste a forte entropie posterieure -- ce qui alimente directement l'**apprentissage actif** (uncertainty sampling), qui concentre l'effort d'annotation la ou il reduit le plus l'incertitude.\n",
+    "\n",
+    "### Ce que Infer.NET apporte\n",
+    "\n",
+    "L'inference jointe labels + fiabilites est exactement le genre de probleme a variables latentes ou un calcul manuel (style EM) devient vite intraitable. Infer.NET **propage les croyances sur le graphe de facteurs** et restitue des posterieurs calibres sans derivation analytique : le modelisateur declare la structure (workers, items, matrices de confusion, communautes) et laisse le moteur estimer le tout simultanement. La structure hierarchique du modele Community, en particulier, illustre comment le partage de parametres entre workers regularise les estimations des nouveaux annotateurs.\n",
+    "\n",
+    "### A retenir\n",
+    "\n",
+    "> Le bon modele de crowdsourcing n'est pas le plus sophistique, mais **le plus simple qui capture le bruit reellement present** dans vos donnees. Commencer par le vote majoritaire avec des *gold questions*, puis monter en complexite (Honest -> Biased -> Community) seulement quand les desaccords, biais ou le cold-start l'imposent. Dans tous les cas, garder 5-10 % d'items a verite connue reste le filet de securite qui calibre les estimations et demasque les spammeurs.\n",
+    "\n",
+    "Ce raisonnement -- inferer des variables latentes (le vrai label) a partir d'observations bruitees mediees par des parametres de fiabilite -- prepare directement les modeles a etats caches du notebook suivant ([Infer-11-Sequences](Infer-11-Sequences.ipynb)), ou la structure latente devient temporelle.\n",
+    ""
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Résumé

Fallback perenne **#2651** (prose pédagogique) sur la famille Python/ML (Probas/Infer). `Infer-10-Crowdsourcing` se terminait sur des stubs d'exercices avec seulement un `## 9. Resume et Guide de Choix` (table comparative + recommandations), **sans conclusion synthétisée** — contrairement à Infer-3/4/6/7/8/9/11 qui finissent sur `## Conclusion`. Gap conspicu.

## Gap identifié (vérifié firsthand sur origin/main)

- 49 cells, **aucun** heading `## Conclusion`/`## Synthèse`.
- Cellule finale = code stub `// Exercice : Detection de workers spammeurs` (idx 48).
- `## 9. Resume et Guide de Choix` (idx 43) = recap (table modèles + concepts + recommandations + navigation), pas une synthèse.

## Changement

Ajout d'une cellule markdown finale `## Conclusion` synthétisant le thème de l'agrégation de labels, grounded dans le contenu réel :
- les 4 modèles comme **progression expressivité ↔ coût d'annotation** (vote majoritaire → Honest Worker → Biased Worker → Community)
- l'**inférence jointe bayésienne** labels + fiabilités des workers
- le lien vers l'**apprentissage actif** (uncertainty sampling)
- ce qu'apporte Infer.NET (propagation de croyances sur graphe de facteurs)
- pont vers Infer-11 (structure latente temporelle / HMM)

## Validation §D

- Markdown-only : **+33/-0, 1 fichier**, 0 code cell touché → **C.2 exception markdown** (pas de re-exec kernel C#).
- `nbformat validate` OK (1 warning MissingIDField pré-existant legacy).
- 0 `execution_count`/outputs modifié, 0 C.1 introduit.
- Catalog byte-identical, base fraîche off `origin/main` (80167082c).

See #2651

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>