### PR TITLE
feat(qc): align MomentumRegime-AdaptiveWeights baseline to 2018-2025 (#1630)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/MomentumRegime-AdaptiveWeights/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MomentumRegime-AdaptiveWeights/main.py
@@ -20,8 +20,11 @@ class MomentumRegimeAdaptiveWeights(QCAlgorithm):
     """
 
     def initialize(self):
-        self.set_start_date(2015, 1, 1)
-        self.set_end_date(2025, 12, 31)
+        # Aligned baseline period 2018-2025 (#1630). Original was 2015-01-01 to
+        # 2025-12-31; standardized to 2018-01-01..2025-01-01 for cross-strategy
+        # comparison.
+        self.set_start_date(2018, 1, 1)
+        self.set_end_date(2025, 1, 1)
         self.set_cash(100000)
         self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
 


### PR DESCRIPTION
## Summary

Part of the QC backbone baseline sequence (#2801/#1630). Aligns `MomentumRegime-AdaptiveWeights/main.py` to the standardized 2018-2025 baseline period.

## Change

- `set_start_date(2015, 1, 1)` -> `set_start_date(2018, 1, 1)`.
- `set_end_date(2025, 12, 31)` -> `set_end_date(2025, 1, 1)` (standard period; 2024-12-31 ~ 2025-01-01 trading-wise).
- IBKR brokerage already present. No other change. Modules `alpha_models.py` + `portfolio_construction.py` unchanged.

## Strategy

COMP-class framework composite, **no-ML**. `SectorMomentumAlpha` (85%) + `RegimeSwitchingAlpha` (15%) via QC Alpha/PCM models, additive combination (`MultiStrategyPCM`). Variant of `Framework_Composite_MomentumRegime` (baseline 60/40), this shifts weight toward SectorMomentum (T85/RS15) + adds QQQ to the universe.

## Backtest (QC Cloud, project 31524424)

| Metric | Value |
|--------|-------|
| Period | 2018-01-01 to 2025-01-01 (1761 tradeable dates) |
| Sharpe | **-0.729** |
| CAGR | 1.875% |
| MaxDD | 4.3% |
| PSR | 17.364% |

**Verdict: Tier 4 (Untested) -> Tier 3 (Exploratoire, <0).**

**Finding (honest, coherent):** the tiny MaxDD (4.3%) over a period that includes the 2020 COVID crash and 2022 bear reveals the composite was **overwhelmingly defensive** — the SMA200 filter (SectorMomentum) + the bear/sideways regime (RegimeSwitching) kept it mostly in IEF/GLD/cash. It avoided drawdowns but earned a meager 1.875% that **underperformed the risk-free rate** -> negative Sharpe, PSR 17% (only 17% confidence the true Sharpe > 0).

**Confirms + extends Key-finding #4** ("composites do not beat single-strategies / double-defense"): the T85/RS15 variant (-0.729) is **worse than the baseline 60/40 MomentumRegime composite (0.185)** — shifting MORE weight to SectorMomentum amplified the over-defensiveness. Contrast: standalone SectorMomentum (Tier 1 #22, 0.56) works, but wrapping it in the double-defense composite destroys the edge on the aligned period.

**totalOrders=0**: wrapper extraction artifact (qc-mcp-lite `read_backtest` does not parse `totalOrders`); CAGR 1.875% with 0 trades is impossible, so statistics are real and QC-computed. Distinct from #3367.

## Scope

main.py-only (1 file, +5/-2). Doc row deferred to the next consolidated doc batch PR per the established pattern.

See #1630. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>