### PR TITLE
docs(lean): add Conclusion to Lean/examples/README (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/README.md
@@ -23,3 +23,28 @@ Fichiers `.lean` autonomes à usage pédagogique, exécutés via le kernel Jupyt
 - Ces fichiers ne sont **pas** un projet Lake — ils sont exécutés cellule par cellule via le kernel Jupyter `lean4-wsl`
 - Les 2 `sorry` dans `llm_assisted_proof.lean` sont **intentionnels** : ils illustrent le flux de preuve assistée par LLM, où le prouveur laisse des marqueurs de substitution
 - Compagnon de la série de notebooks d'introduction à Lean (Lean-1 à Lean-5)
+
+## Conclusion
+
+Les cinq fichiers de ce répertoire tracent une **progression d'apprentissage**
+des fondamentaux de Lean 4 : la **logique propositionnelle** (`basic_logic`) et
+le **raisonnement quantifié** (`quantifiers`) posent le langage ;
+`tactics_demo` expose la boîte à outils tactique (`intro` / `apply` / `rw` /
+`simp` / `decide`) ; `mathlib_examples` montre comment Mathlib automatise le
+calcul (`ring` / `linarith` / `omega`) ; et `llm_assisted_proof` ouvre sur la
+**preuve assistée par LLM**, où les 2 `sorry` intentionnels matérialisent les
+buts qu'un prouveur doit clore.
+
+L'exécution se fait **cellule par cellule** via le kernel Jupyter `lean4-wsl`,
+sans projet Lake — c'est le terrain d'expérimentation rapide de la série
+d'introduction, par contraste avec les projets Lake complets
+([`../calibration_lean/`](../calibration_lean/),
+[`../conway_lean/`](../conway_lean/),
+[`../sensitivity_lean/`](../sensitivity_lean/)) qui structurent des preuves
+volumineuses.
+
+### Où aller ensuite
+
+- **Notebooks d'introduction** : [`../Lean-1-Setup.ipynb`](../Lean-1-Setup.ipynb) — le cours guidé (Lean-1 à Lean-5) que ces fichiers illustrent.
+- **Mathlib en action** : [`../mathlib_examples/`](../mathlib_examples/) (projet Lake compagnon).
+- **Preuve assistée par LLM** : `llm_assisted_proof.lean` ici est l'amorce ; le harnais multi-agents [`../agent_tests/prover/`](../agent_tests/prover/) en est la version production.


### PR DESCRIPTION
## Summary

Epic #2651 (prose pédagogique) — `SymbolicAI/Lean/examples/README.md`.

**G.1 finding**: this README (25L) was the **only** Lean-series README without a Conclusion/Concepts section. A repo-wide scan confirmed all 12 sibling Lean READMEs (`calibration_lean`, `conway_lean`, `finiteness_lean`, `grothendieck_lean`, `knot_lean`, `mathlib_examples`, `sensitivity_lean`, `conway_cgt_lean`, `cooperative_games_lean`, `social_choice_lean`, `social_choice_lean_peters`, `stable_marriage_lean`) have at least one — `examples/` was the lone gap.

## Change (+25/-0, markdown-only)

Adds a FR `## Conclusion` section (readme-french-first HARD 1) synthesizing the 5 standalone `.lean` files as a **learning progression**:
- `basic_logic` + `quantifiers` → the logical language
- `tactics_demo` → the tactic toolkit (`intro`/`apply`/`rw`/`simp`/`decide`)
- `mathlib_examples` → Mathlib automation (`ring`/`linarith`/`omega`)
- `llm_assisted_proof` → LLM-assisted proving (the 2 intentional `sorry`)

Plus a contrast paragraph (cell-by-cell `lean4-wsl` kernel vs full Lake projects) and a `### Où aller ensuite` navigation pointing to the intro notebooks, the `mathlib_examples/` Lake companion, and the `agent_tests/prover/` production harness.

Matches the Conclusion style of sibling `mathlib_examples` (PR #3897).

## Verification

- **FR content** (readme-french-first HARD 1 — never "match surrounding language")
- **Markdown-only**, catalog `COURSE_CATALOG.generated.{md,json}` **byte-identical to main**
- **Relative link targets verified present** before commit: `../mathlib_examples`, `../agent_tests/prover`, `../calibration_lean`, `../conway_lean`, `../sensitivity_lean`, `../Lean-1-Setup.ipynb`
- Precedent: sibling Conclusion PRs (#3897 +28, #3901 +25, #3842 +30) all merged

See #2651

Co-Authored-By: Claude <noreply@anthropic.com>