### PR TITLE
docs(iit): add synthesized Conclusion to Intro_to_PyPhi (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/Intro_to_PyPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/Intro_to_PyPhi.ipynb
@@ -1439,6 +1439,40 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a introduit l'**Integrated Information Theory** (IIT) et son implementation de reference, **PyPhi**, en suivant le fil qui mene des donnees brutes d'un systeme a une mesure de son integration causale.\n",
+    "\n",
+    "### Le pipeline PyPhi en un coup d'oeil\n",
+    "\n",
+    "| Etape | Objet PyPhi | Role |\n",
+    "|-------|-------------|------|\n",
+    "| Dynamique | `Network` (+ TPM) | Decrit comment l'etat du systeme evolue, mecanisme par mecanisme |\n",
+    "| Decoupage | `Subsystem` | Fixe un etat de fond et isole les elements analyses |\n",
+    "| Integration | $\\Phi$ | Mesure l'irreductibilite du tout a ses parties (la partition qui « coute » le moins) |\n",
+    "| Structure | CES (concepts) | Decompose *ce que* le systeme distingue : repertoires cause-effet de chaque mecanisme |\n",
+    "\n",
+    "Le point conceptuel central est que $\\Phi$ ne mesure pas une quantite d'information *transmise*, mais une information **integree** : ce qui serait perdu si l'on coupait le systeme en morceaux. Un systeme dont les parties sont independantes a un $\\Phi$ nul, meme s'il calcule des choses complexes -- l'integration, pas la performance, est le critere.\n",
+    "\n",
+    "### Ce que les exemples ont mis en evidence\n",
+    "\n",
+    "- La **TPM** (matrice de transition) est le point d'entree obligatoire : toute la causalite en decoule, d'ou l'importance de la validation `StateUnreachableError` qui protege contre l'analyse d'etats que la dynamique ne peut jamais produire.\n",
+    "- La **CES** revele la *qualite* de l'experience d'un systeme (quels concepts il porte), la ou $\\Phi$ n'en donne que la *quantite*.\n",
+    "- La **causalite actuelle** (actual causation) repond a une question differente : non pas « quelle est la structure du systeme » mais « qu'est-ce qui a effectivement cause *cette* transition ».\n",
+    "- Le **coarse-graining / blackboxing** (macro-subsystems) montre qu'un meme substrat peut etre plus integre a une echelle macro qu'a l'echelle micro -- l'echelle a laquelle $\\Phi$ est maximal est theoriquement privilegiee.\n",
+    "\n",
+    "### Limites et suite\n",
+    "\n",
+    "Le calcul de $\\Phi$ est **combinatoirement explosif** (toutes les partitions, tous les mecanismes), ce qui confine PyPhi a de petits systemes (quelques noeuds) -- une contrainte pratique a garder en tete avant toute ambition d'echelle. Les raffinements de la theorie (IIT 4.0, calcul du $\\varphi$ au niveau des distinctions et relations) et les strategies de passage a l'echelle sont approfondis dans le notebook [IIT-2 : Sujets avances](./IIT-2-AdvancedTopics.ipynb).\n",
+    "\n",
+    "> **A retenir** : l'IIT propose de mesurer la conscience comme l'**integration causale irreductible** d'un systeme sur lui-meme. PyPhi rend cette definition operationnelle : on declare une dynamique (TPM), on choisit un decoupage (Subsystem), et le moteur calcule a la fois *combien* ($\\Phi$) et *quoi* (CES) le systeme integre.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d0948bcb",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Résumé

Fallback perenne **#2651** (prose pédagogique) sur la famille Python/ML (IIT). `IIT/Intro_to_PyPhi` (pure Python / PyPhi) se terminait sur `## 7. Ressources complémentaires` (Références) **sans conclusion synthétisée**, alors que son sibling `IIT-2-AdvancedTopics` finit sur `## Bilan et perspectives` — asymétrie conspicue.

## Gap identifié (vérifié firsthand sur origin/main 80167082c)

- 30 cells, **aucun** heading `## Conclusion`/`## Synthèse`/`## Bilan`.
- Finit sur Références (idx 29), précédé d'un stub d'exercice.
- Sibling IIT-2 a une vraie section de synthèse → absence flagrante ici.

## Changement

Ajout d'une cellule markdown `## Conclusion` **avant** la section Ressources (placement pédagogique), grounded dans le contenu réel :
- le **pipeline PyPhi** (`Network`/TPM → `Subsystem` → Φ → CES) en tableau
- le cœur conceptuel : Φ mesure l'information **intégrée** (irréductibilité), pas transmise
- ce que les exemples ont montré : TPM/`StateUnreachableError`, CES (qualité) vs Φ (quantité), causalité actuelle, coarse-graining/macro-subsystems
- la **limite combinatoire** de Φ (petits systèmes) + pont vers IIT-2

## Validation §D

- Markdown-only : **+34/-0, 1 fichier**, 0 code cell touché → **C.2 exception markdown** (notebook pure-Python PyPhi intact, pas de re-exec).
- `nbformat validate` OK.
- 0 `execution_count`/outputs modifié, 0 C.1 introduit.
- Catalog byte-identical, base fraîche off `origin/main`.

See #2651

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>