### PR TITLE
fix(qc): align TermStructureCommodities-QC to 2018-2025 baseline (#1630)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/TermStructureCommodities-QC/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TermStructureCommodities-QC/main.py
@@ -16,7 +16,11 @@ from math import floor
 class CommodityTermStructureAlgorithm(QCAlgorithm):
 
     def initialize(self):
-        self.set_start_date(self.end_date - timedelta(15*365))
+        # Aligned baseline period 2018-2025 (#1630). Original used a dynamic
+        # start (end_date - 15*365 ~= 2010); standardized to 2018-01-01 for
+        # cross-strategy comparison. Also fixes the fragile self.end_date
+        # reference-before-set in the original clone.
+        self.set_start_date(2018, 1, 1)
         self.set_end_date(2025, 1, 1)  # Fixed end date for reproducibility
         self.set_cash(1000000)
         self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)


### PR DESCRIPTION
## Summary

Aligns the **Term Structure Effect in Commodities** strategy (Quantpedia #22, QC Strategy Library #26) to the standard 2018-01-01..2025-01-01 period for the #1630 backbone baseline sequence.

IND Commodities, **no-ML** (long-short futures on roll returns / backwardation-contango, top-quintile, monthly rebalance). 21 commodity futures across Softs / Grains / Meats / Energies / Metals.

## Change

`set_start_date(self.end_date - timedelta(15*365))` (dynamic, ~= 2010) replaced by an explicit `set_start_date(2018, 1, 1)`. Also fixes the fragile `self.end_date` reference-before-set in the original clone (line 19 read `self.end_date` before line 20 set it).

main.py-only + doc deferred to the next consolidated batch (established #1630 workflow — avoids adjacent-Tier-4-deletion conflicts).

## Backtest (QC Cloud, aligned 2018-2025)

QC project **33224097** · compile `5b8e19a6` BuildSuccess (0 errors) · backtest `e9f7e686` Completed

| Metric | Value |
|---|---|
| Sharpe | **-0.244** |
| CAGR | **-31.478%** |
| Max Drawdown | **96.800%** |
| PSR | 0.007% |
| Tradeable dates | 2129 |

**Verdict: Tier 4 -> 3 (Exploratoire / catastrophic).** Worst backbone baseline yet — the strategy nearly goes to zero over 2018-2025. Consistent with the published library header (OOS 5Y Sharpe -0.041, MaxDD 80.8%): the roll-yield / backwardation signal that worked historically catastrophically fails on the modern period. The 2020 COVID oil crash + 2022 energy / inflation spike dislocated term structures, breaking the long-short roll signal — the strategy was on the wrong legs through both regimes. (Contrast with the cherry-picked "Recent OOS: 1.49 1Y Sharpe" sub-period in the header — that favorable window does not survive alignment.)

**3rd Tier-3 negative** (after #80 Cloud-SectorRotation -0.029 and #86 MomentumRegime -0.729). Reinforces the #1630 finding: published headline Sharpe figures do not survive alignment to a modern, fee-aware period.

`totalOrders=0` is the known qc-mcp-lite wrapper extraction artifact (CAGR -31.478% with a 96.8% drawdown is impossible without real trades) — statistics are QC-computed; distinct from the #3367 notebook-fabricated Trades=0 / WR>0 case.

See #1630 · See #2801
