### PR TITLE
fix(symboliclearning): SL-6 remove machine-path LERND defaults (root-cause, See #3911)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-ModernILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-ModernILP.ipynb
@@ -799,7 +799,7 @@
     "```\n",
     "\n",
     "Le notebook localise l'environnement via les variables `LERND_PYTHON` (l'interpreteur\n",
-    "de l'env) et `LERND_SRC` (le clone de Lernd), avec des valeurs par defaut ; si l'env\n",
+    "de l'env) et `LERND_SRC` (le clone de Lernd) ; si l'env\n",
     "est absent, la section se saute proprement (`HAS_LERND = False`)."
    ]
   },
@@ -839,8 +839,8 @@
     "import subprocess\n",
     "\n",
     "LERND_PYTHON = os.environ.get(\n",
-    "    \"LERND_PYTHON\", \"/mnt/c/Users/MYIA/miniconda3/envs/lernd-dilp/python.exe\")\n",
-    "LERND_SRC = os.environ.get(\"LERND_SRC\", r\"C:\\Users\\MYIA\\lernd-src\")\n",
+    "    \"LERND_PYTHON\")  # configurer via la variable d'environnement (pas de defaut machine-specifique)\n",
+    "LERND_SRC = os.environ.get(\"LERND_SRC\")\n",
     "\n",
     "HAS_LERND = False\n",
     "probe = (\n",
@@ -854,7 +854,7 @@
     "    print(out.stdout.strip() if HAS_LERND else \"Lernd indisponible.\")\n",
     "    if not HAS_LERND:\n",
     "        print((out.stderr or \"\").splitlines()[-1] if out.stderr else \"\")\n",
-    "except (FileNotFoundError, subprocess.TimeoutExpired) as e:\n",
+    "except (TypeError, FileNotFoundError, subprocess.TimeoutExpired) as e:  # TypeError = LERND_PYTHON None (env non configure)\n",
     "    print(f\"Interpreteur Lernd introuvable ({LERND_PYTHON}) : {e}\")\n",
     "print(f\"HAS_LERND = {HAS_LERND}\")"
    ]


### PR DESCRIPTION
## Root-cause fix — mandat user 2026-06-22 (See #3911)

Closes #3922. Routing ai-01 (cycle 22/06 ~11:24Z) : « po-204 fix SOURCE-only, re-exec NON requis. »

### Le défaut (cause-racine, pas un symptôme)

`SL-6-ModernILP.ipynb` cell 16 utilisait l'anti-pattern **interdit** `os.environ.get(VAR, <machine-path-default>)` (×2), structurellement identique à l'incident secrets-hygiene `b34e3a05` :

```python
LERND_PYTHON = os.environ.get(
    "LERND_PYTHON", "/mnt/c/Users/MYIA/miniconda3/envs/lernd-dilp/python.exe")
LERND_SRC = os.environ.get("LERND_SRC", r"C:\Users\MYIA\lernd-src")
```

Le default bake un chemin **machine-spécifique** (compte build MYIA) → (a) défaut de portabilité (silencieusement inexistant sur toute autre machine), (b) fuite de structure machine/account dans le source, (c) le scrubbing d'outputs (#3436) est **structurellement incapable** de l'adresser car le path est **source-only** (pas dans l'output committé `LERND_OK 2.7.2`). → source fix requis, exactement la distinction cause-racine vs redaction du mandat user.

### Le fix (source-only, atomique)

```python
LERND_PYTHON = os.environ.get("LERND_PYTHON")  # configurer via la variable d'environnement (pas de defaut machine-specifique)
LERND_SRC = os.environ.get("LERND_SRC")
```

**Élargissement du `except` (non-régressif)** : retirer le default introduirait une régression — `LERND_PYTHON = None` fait que `subprocess.run([None, ...])` lève `TypeError` (non attrapé par l'original `except (FileNotFoundError, ...)`) → la cellule crasherait où elle dégradait proprement avant. Le fix élargit le `except` à `(TypeError, FileNotFoundError, subprocess.TimeoutExpired)` pour préserver la dégradation gracieuse `HAS_LERND = False` quand l'env var est absente.

**Prose markdown** : « avec des valeurs par defaut » retiré (inexact post-fix).

### Validation

- `ast.parse` du source cell 16 = **VALID** (0 SyntaxError, indentation `except` col-0 alignée au `try:`).
- Scan résiduel machine-path (`/mnt/c/Users/MYIA`, `C:\Users\MYIA`, `MYIA/miniconda`, `MYIA\lernd`) dans **toutes** les cellules source = **NONE**.
- Diff chirurgical : 4 insertions / 4 suppressions, byte-identique ailleurs (round-trip `json.dumps(indent=1, ensure_ascii=False)+"\n"`).
- Catalogue + submodule byte-identical.

### Re-exec (règle C.2) — NON requis (output-neutral)

L'output committé `LERND_OK 2.7.2` / `HAS_LERND = True` **ne porte pas le path** → le fix source ne change pas la logique d'output (probe succès → `LERND_OK` ; probe échec → fallback gracieux). Le fix change le **contrat de configuration** (env var requise au lieu d'un default machine-spécifique), pas l'output. Reproduire `LERND_OK 2.7.2` = setter `LERND_PYTHON`/`LERND_SRC` vers les paths de la machine LERND. Logique identique à #3924/#3913 (source-fix output-neutral).

See #3911 — See #3436.

Co-Authored-By: Claude <noreply@anthropic.com>