### PR TITLE
chore(planners): scrub checkout-root cwd leak in Planners-0/4 (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/00-Environment/Planners-0-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/00-Environment/Planners-0-Setup.ipynb
@@ -87,7 +87,7 @@
      "text": [
       "Systeme d'exploitation: Windows\n",
       "Version Python: 3.13.12\n",
-      "Repertoire de travail: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\00-Environment\n",
+      "Repertoire de travail: <repo>MyIA.AI.Notebooks\\SymbolicAI\\Planners\\00-Environment\n",
       "Executable Python: C:\\ProgramData\\miniconda3\\python.exe\n"
      ]
     }

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb
@@ -187,7 +187,7 @@
      "text": [
       "Systeme: Windows\n",
       "Python: 3.13\n",
-      "Repertoire de travail: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\n"
+      "Repertoire de travail: <repo>MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\n"
      ]
     }
    ],


### PR DESCRIPTION
## Scrub checkout-root leak — Planners-0 + Planners-4 (assigned po-204)

Routing ai-01 (cycle 22/06 ~11:24Z) : « Planners-0/4 → ASSIGNE po-204. Scrub trivial (1 leak \`D:\dev\CoursIA\\` chacun, C.3 env-noise). [CLAIMED] -> bundle/PR. »

### G.1 root-cause lens (mandat user 2026-06-22, See #3911)

Vérifié firsthand : les 2 notebooks impriment « Repertoire de travail: \`D:\dev\CoursIA\...\` » — chemin **résolu dynamiquement à l'exécution** (cwd, info environnement pour l'étudiant). **0 hardcodage en source** (scan source = néant) → c'est du bruit env, pas un source-leak. Scrubbing = le bon fix cause-racine ici (la ré-exéc régénère un cwd path frais ; le fix-source du mandat s'applique aux leaks hardcodés, pas aux chemins runtime-resolved). Distinction confirmée par l'auto-audit cause-racine po-204 (cycle 6) + ai-01 ACK.

### Changes (atomique, 2 notebooks)

| Notebook | Avant | Après |
|----------|-------|-------|
| Planners-0-Setup | `D:\dev\CoursIA\MyIA.AI.Notebooks\...\00-Environment` | `<repo>MyIA.AI.Notebooks\...\00-Environment` |
| Planners-4-Fast-Downward | `D:\dev\CoursIA\MyIA.AI.Notebooks\...\02-Classical` | `<repo>MyIA.AI.Notebooks\...\02-Classical` |

Outil : \`scripts/notebook_tools/scrub_papermill_paths.py --outputs\` (text-level surgical, regex \`_REPO_RES\` avec lookbehind négatif `(?<![a-zA-Z])` corrigeé en #3895).

### Validation

- 2-dot diff : **2 insertions / 2 suppressions** (1 ligne output par notebook), source byte-identical.
- Scan résiduel : **0 leak** sur les 2 notebooks.
- Repo-relative tail préservé (valeur diagnostique : `MyIA.AI.Notebooks\SymbolicAI\Planners\...`).
- Catalogue + submodule byte-identical.

See #3436 — See #3911.

Co-Authored-By: Claude <noreply@anthropic.com>