### PR TITLE
security(genai): fix key-prefix source leaks in Video notebooks

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb
@@ -314,7 +314,7 @@
     "\n",
     "openai_key = os.environ.get('OPENAI_API_KEY', '')\n",
     "if openai_key:\n",
-    "    print(f\"OPENAI_API_KEY : configure ({openai_key[:8]}...)\")\n",
+    "    print(f\"OPENAI_API_KEY : configure\")\n",
     "else:\n",
     "    print(\"OPENAI_API_KEY : non configure\")\n",
     "    if image_model == \"dall-e-3\":\n",

--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-3-ComfyUI-Video-Workflows.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-3-ComfyUI-Video-Workflows.ipynb
@@ -294,7 +294,7 @@
     "# Token d'authentification ComfyUI\n",
     "comfyui_token = os.environ.get('COMFYUI_AUTH_TOKEN', os.environ.get('COMFYUI_BEARER_TOKEN', ''))\n",
     "if comfyui_token:\n",
-    "    print(f\"Token ComfyUI : configure ({comfyui_token[:8]}...)\")\n",
+    "    print(f\"Token ComfyUI : configure\")\n",
     "else:\n",
     "    print(\"Token ComfyUI : non configure (connexion sans authentification)\")\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
@@ -260,7 +260,7 @@
       "httpx : disponible\n",
       "imageio : disponible\n",
       "\n",
-      "OPENAI_API_KEY : configuree (sk-proj-Ap3H...)\n"
+      "OPENAI_API_KEY : configuree\n"
      ]
     },
     {
@@ -341,7 +341,7 @@
     "openai_base = os.environ.get('OPENAI_BASE_URL', '')\n",
     "\n",
     "if openai_key:\n",
-    "    print(f\"\\nOPENAI_API_KEY : configuree ({openai_key[:12]}...)\")\n",
+    "    print(f\"\\nOPENAI_API_KEY : configuree\")\n",
     "    if openai_base:\n",
     "        print(f\"OPENAI_BASE_URL : {openai_base}\")\n",
     "    \n",


### PR DESCRIPTION
## Summary

Root-cause security fix per mandate #3911 (*"fix the scripts that print keys, not redact outputs"*). Backlog pickup of #3924 (po-2023 DOWN — sécurité > turf). Same pattern as merged #3913.

## What changed

3 source cells in `GenAI/Video/` printed API-key/token prefixes in a diagnostic `print()` — masked them to a bare status string (no key material):

| File | Cell | Before | After |
|------|------|--------|-------|
| `03-2-Video-Workflow-Orchestration` | cell-env | `print(f"...configure ({openai_key[:8]}...)")` | `print(f"...configure")` |
| `03-3-ComfyUI-Video-Workflows` | cell-env | `print(f"...configure ({comfyui_token[:8]}...)")` | `print(f"...configure")` |
| `04-3-Sora-API-Cloud-Video` | cell-3 | `print(f"...configuree ({openai_key[:12]}...)")` | `print(f"...configuree")` |

## Bonus site found during the fix (G.1)

The #3924 audit missed **04-3-Sora**, which is *worse* than the 2 tracked sites: not only does its source print 12 chars (`[:12]`), but its **committed cell output contained a real OpenAI key prefix** — `OPENAI_API_KEY : configuree (sk-proj-Ap3H...)`. This is the **4th site of this key** (after NotebookMaker 10/10a/10b, fixed in #3913). This PR redacts that committed output to match the fixed source.

## Why no re-execution

- **03-2 / 03-3**: committed outputs show `"non configure"` (the `else` branch); the source fix only touches the `if key:` branch print → outputs stay consistent.
- **04-3-Sora**: only the key-print line changed; the committed output was aligned to the new masked source. Other outputs (API model list, mock frames) untouched.
- Same source+output-alignment precedent as #3913.

## Acceptance (#3924) — verified
- [x] `git grep '(openai_key|comfyui_token)\[:[0-9]+\]'` in `GenAI/Video/` = **0**
- [x] `git grep 'sk-proj-Ap3H'` repo-wide = **0**
- [x] nbformat valid ×3, no CRLF churn, diff = **4 insertions / 4 deletions**
- [x] gitleaks: no `sk-` in additions (diagnostic-print source mask + redaction of an already-committed prefix)

## Separate finding (NOT in this PR — flagged for ai-01)

G.1 completeness scan found a **2nd, different key** leaking in `00-3-API-Endpoints-Configuration.ipynb` (output line 341 + markdown table line 477): `sk-proj-...EUgA` (prefix + 4-char suffix). Different notebook (00-GenAI-Environment config tutorial), different key, teaching-masking context → left for ai-01 / po-2023 judgment (+ possible separate PR).

**Key rotation** (secrets-hygiene rule 5 = rotate on any leak): two OpenAI project-key prefixes now identified in committed history — `sk-proj-Ap3H...` (04-3-Sora + NotebookMaker) and `sk-proj-...EUgA` (00-3). ai-01 already has a rotation arbitrage open with the user from #3903; these add to it.

Closes #3924
