### PR TITLE
docs(sudoku,z3,lean): combler les 3 lacunes des slides Veanes 17142 (triptyque regex symbolique)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -780,6 +780,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "veanes-sud-m2lstr",
+   "metadata": {},
+   "source": [
+    "### Le troisieme langage pour dire la meme chose : la logique M2L-str\n",
+    "\n",
+    "L'exercice ci-dessus exprime \" 5 avant 7 \" comme une **intersection de regex** (`& .*5.*7.*`). Mais cette meme contrainte admet une **troisieme** ecriture - ni regex, ni systeme d'inegalites : une **formule de logique monadique du second ordre sur les chaines** (M2L-str). \" Il existe une position du 5 strictement avant une position du 7 \" s'ecrit litteralement\n",
+    "\n",
+    "$$\\exists\\, x,\\, y.\\quad x < y \\;\\wedge\\; P_5(x) \\;\\wedge\\; P_7(y)$$\n",
+    "\n",
+    "ou $P_d(i)$ signifie \" la case $i$ porte le chiffre $d$ \". C'est *mot pour mot* l'exemple introductif des slides de reference de **Margus Veanes** (Dagstuhl 17142, 2017) : `exists x,y. x<y && a(x) && b(y)`.\n",
+    "\n",
+    "L'interet de ce registre : un **compilateur de logique** (D'Antoni & Veanes, POPL'17 ; outil `s-M2L-str`) transforme automatiquement une telle formule en **automate symbolique** (SFA). On **decrit** la propriete ; la machine **fabrique** le reconnaisseur - on n'ecrit ni l'automate, ni la regex. Trois registres pour une seule et meme contrainte :\n",
+    "\n",
+    "| Registre | Ce qu'on ecrit | Qui fabrique le reconnaisseur / la solution |\n",
+    "|----------|----------------|----------------------------------------------|\n",
+    "| **Regex symbolique** (RE#, ce notebook) | `lignevalide & .*5.*7.*` | le moteur de derivees |\n",
+    "| **Logique M2L-str** (Veanes & D'Antoni) | `exists x,y. x<y && P_5(x) && P_7(y)` | le compilateur logique vers SFA |\n",
+    "| **Contraintes** (Z3, section 6) | `Distinct` + appartenances | le solveur SMT |\n",
+    "\n",
+    "> **Le meme `&`, vu d'en haut.** Les trois registres partagent l'**algebre de Boole** des langages reguliers (cf notebook [06](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb), section 3). La conjonction logique `&&` de M2L-str, l'intersection `&` de RE# et le `re.inter` SMT-LIB sont **la meme operation** dans trois notations. Mais la *forme* sous laquelle on emet cette conjonction decide si Z3 atterrit le 9x9 (section 6b) - une question que la theorie de Veanes nomme **decomposition monadique**, et que l'ordre `x < y` de cet exercice illustre justement par la negative (cf section 6b)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "edd4a220",
    "metadata": {
     "tags": []
@@ -1782,6 +1806,28 @@
     "| Z3 `Distinct` (entiers) | - | grille complete | **~38 ms (production)** |\n",
     "\n",
     "> **Murs tombes, forme d'emission decisive.** Le payoff *general* de la generation de temoin `A & ~B` est demontre dans le notebook **[06 - Generer un temoin depuis A & ~B](../SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb)** de la serie Z3. Le Sudoku, lui, montre la lecon la plus fine : ce n'est ni le moteur ni le substrat, ni meme \"appartenance vs inegalite\" qui decide, mais la **forme d'emission** du meme `&` d'appartenances - *fondu* en `re.inter` (sature au 9x9) vs *eclate* en `str.contains` natif (atterrit). Le regex *n'est pas* le mauvais outil : bien emis, il atterrit la grille 9x9 complete, sans une seule inegalite."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "veanes-sud-monadic",
+   "metadata": {},
+   "source": [
+    "### La theorie derriere la \" forme d'emission \" : la decomposition monadique (Veanes, CAV'14)\n",
+    "\n",
+    "Le tableau ci-dessus est un constat **empirique** : fondue en `re.inter`, l'appartenance sature ; eclatee en `str.contains`, elle atterrit. Cette observation porte un **nom** et possede une **theorie** chez Veanes : la **decomposition monadique** (*Monadic Decomposition*, M. Veanes, N. Bjorner, L. Nachmanson, S. Bereg, CAV 2014).\n",
+    "\n",
+    "Une contrainte a plusieurs variables est **monadiquement decomposable** si elle equivaut a une **combinaison booleenne de predicats a une seule variable** (\" monadiques \"). Quand elle l'est, on peut remplacer un **produit** (le `re.inter` qui materialise l'espace croise) par une **conjonction de tests independants** - exactement le passage de l'appartenance *fondue* aux `str.contains` *eclates* par chiffre qui fait atterrir le 9x9, sans jamais construire le produit d'automates.\n",
+    "\n",
+    "Le theoreme precise **quand** cet eclatement existe :\n",
+    "\n",
+    "| Contrainte | Monadiquement decomposable ? | Consequence pour l'emission |\n",
+    "|------------|------------------------------|------------------------------|\n",
+    "| tous-distincts par appartenances (`.*d.*` par chiffre) | **oui** | eclatable en `str.contains` -> **atterrit** |\n",
+    "| `x + (y mod 2) > 5` | oui (combinaison Cartesienne finie) | produit fini, gerable |\n",
+    "| `x < y` (ordre entre deux positions) | **non** - aucune decomposition monadique finie | reste un produit ; **sature** si emis fondu |\n",
+    "\n",
+    "> **De \" j'ai essaye \" a \" j'ai retrouve le principe \".** Le notebook a *decouvert en mesurant* que l'appartenance eclatee atterrit ; la decomposition monadique en est la **raison formelle**. Elle eclaire aussi la limite : la contrainte \" 5 avant 7 \" de l'exercice 1 repose sur `x < y`, le predicat que Veanes donne precisement comme **contre-exemple** sans decomposition finie. L'ordre ne s'eclate pas ; le tous-distincts, si. Cote *reconnaissance*, la meme economie d'etats est garantie par la **finitude des derivees** - le notebook [Lean-14](../SymbolicAI/Lean/Lean-14-Finiteness-Derivatives.ipynb), troisieme pilier du triptyque #2978."
    ]
   },
   {
@@ -3106,6 +3152,7 @@
     "- **Forme deroulee (generateur)** - Aron Griffis, *Sudoku with a Perl regular expression* (2007), domaine public : les 81 blocs explicites (lookaheads + backreferences, sans `(?R)`) que nous **regenerons et executons** en section 8 (artefact `assets/sudoku-unrolled.regex.txt`).\n",
     "- **Issue upstream** [AutomataDotNet/Automata#6](https://github.com/AutomataDotNet/Automata/issues/6) (creee 2020-12-07, toujours sans reponse) : cap du temoin a ~21 caracteres (barreau 2, mur 2).\n",
     "- **Margus Veanes et al.**, *Derivative-based nonbacktracking real-world regex matching* - [MSR-TR-2020-25](https://www.microsoft.com/en-us/research/publication/derivative-based-nonbacktracking-real-world-regex-matching-with-backtracking-semantics/) (aout 2020). Le papier contemporain de la tentative 2020.\n",
+    "- **Margus Veanes**, *Symbolic Automata* (expose de reference, [Dagstuhl Seminar 17142](https://www.dagstuhl.de/17142), avril 2017) : le programme \" automates symboliques \" au complet - SFA sur une algebre de Boole effective, **minimisation symbolique** (D'Antoni & Veanes, *Minimization of Symbolic Automata*, POPL'14 ; bisimulation-avant TACAS'17 ; le cas \" Sometimes Moore is Less \" y documente l'**explosion de determinisation**, soit le *mur 1* de ce notebook), **logique M2L-str vers SFA** (D'Antoni & Veanes POPL'17, cf exercice 1) et **decomposition monadique** (CAV'14, cf section 6b). La source primaire des trois apports theoriques relies dans ce notebook.\n",
     "- **RE#** (engine F#/.NET, MIT) - [github.com/ieviev/resharp-dotnet](https://github.com/ieviev/resharp-dotnet), NuGet `Resharp`. `&`/`~` first-class, non-backtracking, temps lineaire (barreau 3).\n",
     "- **Fork Automata** (net8.0, MyIntelligenceAgency) - [github.com/MyIntelligenceAgency/Automata](https://github.com/MyIntelligenceAgency/Automata). Modernise AutomataDotNet (gele ~2020) : son `RegexToSMTConverter` compile `&`/`~` de surface vers la theorie des chaines SMT-LIB 2.6 (`re.inter`/`re.comp`) que Z3 resout directement - cap du temoin (#6) leve, plus de produit d'automates. Consomme par le notebook 06 de la serie Z3.\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-14-Finiteness-Derivatives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-14-Finiteness-Derivatives.ipynb
@@ -439,6 +439,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "veanes-lean-program",
+   "metadata": {},
+   "source": [
+    "## 5b. Ou se situe la finitude dans le programme \" automates symboliques \"\n",
+    "\n",
+    "Le theoreme de finitude de ce notebook n'est pas isole : c'est **une brique** d'un programme de recherche plus vaste, celui des **automates symboliques** (SFA) expose par Margus Veanes ([Dagstuhl Seminar 17142](https://www.dagstuhl.de/17142), 2017). Un SFA est un automate dont les transitions portent non pas des caracteres mais des **predicats** d'une **algebre de Boole effective** - ce qui permet de traiter de grands alphabets (Unicode) sans les enumerer.\n",
+    "\n",
+    "Trois resultats de ce programme se repondent, et la finitude des derivees en est le socle cote *reconnaissance* :\n",
+    "\n",
+    "| Brique du programme | Ce qu'elle garantit | Rapport a ce notebook |\n",
+    "|---------------------|---------------------|------------------------|\n",
+    "| **Finitude des derivees** (Brzozowski ; *ce notebook*, ITP 2025) | l'ensemble des derivees est fini -> reconnaisseur a **nombre fini d'etats** | le coeur du notebook |\n",
+    "| **Minimisation symbolique** (D'Antoni & Veanes, POPL'14) | compresse ce reconnaisseur en son **minimal** | borne la taille apres construction |\n",
+    "| **Decomposition monadique** (Veanes et al., CAV'14) | quand une contrainte multi-variable s'eclate en predicats **mono-variable** | gouverne l'emission cote *resolution* (cf Sudoku-13 section 6b) |\n",
+    "\n",
+    "> **Le meme fil, trois notebooks.** La finitude (*Prouver*, ici) garantit que la reconnaissance non-backtracking de RE# (*Verifier*) termine en temps lineaire ; la decomposition monadique decide quand Z3 (*Resoudre*) atterrit la grille sans saturer. Les memes auteurs (Veanes, Ebner) signent la formalisation Lean **et** la theorie des automates symboliques : la preuve de ce notebook et le moteur du [Sudoku-13](../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) sont deux faces d'un seul programme."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a1fe6bb8",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb
@@ -823,6 +823,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "veanes-z3-monadic",
+   "metadata": {},
+   "source": [
+    "## 7c. Quand `re.inter` tient l'echelle - la decomposition monadique\n",
+    "\n",
+    "Le 7b resout `A & ~B` sur de **petits** langages (un caractere, une trentaine). Mais `re.inter` **materialise l'espace croise** des langages intersectes, et cet espace **explose** quand les contraintes se chevauchent. Le notebook [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) le mesure : l'intersection 10-way d'une ligne, emise en `re.inter` *fondu*, fait `unknown` ; la **meme** contrainte eclatee en `str.contains` par chiffre **atterrit** la grille 9x9.\n",
+    "\n",
+    "La theorie qui tranche est la **decomposition monadique** de Veanes (*Monadic Decomposition*, CAV 2014). Une formule a plusieurs variables est **monadiquement decomposable** si elle equivaut a une combinaison booleenne de predicats a **une seule variable**. Quand elle l'est, on remplace le produit (`re.inter`) par une **conjonction de tests independants** - sans jamais construire l'automate croise.\n",
+    "\n",
+    "| Forme emise | Ce que fait le solveur | Echelle |\n",
+    "|-------------|------------------------|---------|\n",
+    "| `re.inter` (intersection **fondue**) | materialise le produit des langages | sature des que les contraintes se chevauchent |\n",
+    "| conjonction de predicats **monadiques** (`str.contains`) | tests independants, pas de produit | atterrit |\n",
+    "\n",
+    "> **La lecon, des deux cotes.** Ce notebook montre `A & ~B` la ou `re.inter` est **rapide** (peu de chevauchement) ; Sudoku-13 montre l'echelle ou il faut **decomposer**. Le bon critere n'est pas \" Z3 sait-il faire ? \" mais \" la conjonction est-elle monadiquement decomposable ? \". Veanes donne le verdict exact : un tous-distincts l'est (eclatable par chiffre), un ordre `x < y` ne l'est **pas** (aucune decomposition finie)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ba38e2c5",
    "metadata": {
     "tags": []
@@ -1229,6 +1248,9 @@
     "- **Algèbre partagée** : construisez l'automate via le moteur (`CreateFromRegexes`).\n",
     "- **Émettre puis résoudre** : le SMT-LIB du fork est le dialecte réel de Z3 — `ParseSMTLIB2String` ferme la boucle et produit un témoin par résolution de contraintes.\n",
     "- **Portée honnête** : le fork lève le mur du témoin, pas l'explosion d'automate. À l'échelle (Sudoku 81), **Z3 reste le résolveur de production**.\n",
+    "- **Décomposition monadique** (Veanes, CAV'14) : le critère théorique qui décide si `re.inter` tient l'échelle. Un tous-distincts est décomposable (éclatable par chiffre, cf 7c) ; un ordre `x < y` ne l'est pas. C'est la frontière entre \" émettre \" et \" émettre dans la bonne forme \" du [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb).\n",
+    "\n",
+    "> **Source du programme.** Margus Veanes, *Symbolic Automata* - [Dagstuhl Seminar 17142](https://www.dagstuhl.de/17142) (2017) : SFA sur algèbre de Boole, minimisation symbolique (POPL'14), logique M2L-str vers SFA (POPL'17), décomposition monadique (CAV'14).\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Origine

Analyse demandee par le user : relire le notebook Sudoku « sur la question » (regex symbolique) et le croiser avec **les slides de reference de Margus Veanes** (Dagstuhl Seminar 17142, 2017) de la bibliotheque, pour reperer ce qu'on a laisse de cote. Les 80 slides ont ete lues integralement.

## Constat

Les 3 notebooks du triptyque **#2978** (`Resoudre`=Z3 / `Verifier`=RE# / `Prouver`=Lean) sont deja riches et citent le papier Veanes 2020 (MSR-TR-2020-25) + `ezhuchko/finiteness-derivatives`. Mais l'**ossature theorique** du programme « automates symboliques » manquait. Trois lacunes comblees :

1. **Branche logique M2L-str** (slide 19) — le 3e registre declaratif. L'exercice 1 « 5 avant 7 » du Sudoku **EST** l'exemple introductif de Veanes : `exists x,y. x<y && a(x) && b(y)`, compile en SFA (D'Antoni & Veanes POPL'17).
2. **Minimisation symbolique** (D'Antoni & Veanes POPL'14, « Sometimes Moore is Less ») = doc primaire de l'explosion de determinisation = le **mur 1** du notebook.
3. **Decomposition monadique** (Veanes et al., CAV'14) = la **theorie formelle** derriere l'insight empirique « forme d'emission » : un tous-distincts est decomposable (eclatable en `str.contains` par chiffre -> atterrit) ; un ordre `x < y` ne l'est **pas** (aucune decomposition finie -> `re.inter` sature). Eleve le notebook de « j'ai essaye » a « j'ai retrouve le principe ».

## Changements (markdown uniquement)

| Notebook | Ajouts |
|----------|--------|
| **Sudoku-13** | +cellule M2L-str (apres exo 1) ; +cellule decomposition monadique (apres « forme d'emission ») ; ref primaire Dagstuhl 17142 |
| **Z3-06-Witness** | +cellule « 7c : quand `re.inter` tient l'echelle » (critere de decomposabilite, pont vers Sudoku-13) ; conclusion + source |
| **Lean-14-Finiteness** | +cellule « 5b » situant la finitude des derivees dans le programme SFA (finitude -> minimisation -> decomposition monadique) |

## Validation

- **C.2/C.3 respectes** : ajouts **markdown uniquement**. Diff verifie : `exec_count_lines=0`, `outputs_lines=0` sur les 3 fichiers — **aucune cellule code ni output touche** (pas de re-execution requise).
- Validation structurelle nbformat : 49 / 31 / 19 cellules, ids uniques, schema OK.
- Liens relatifs inter-notebooks verifies (coherents avec la navigation existante).
- Attributions academiques verifiees (minimisation = POPL'14, M2L-str = POPL'17, monadic decomposition = CAV'14).

Branche partie d'un `origin/main` frais (catalogue inchange, cf catalog-pr-hygiene). Touche des notebooks des lanes po-2025:CoursIA-2 (Sudoku/Z3 C#) et po-2026 (Lean) — edits faits par ai-01 sur **mandat user direct**, claim de collision poste au dashboard.

See #2978 (triptyque regex symbolique) ; See #3801 (registre axe-2 SOTA).