### PR TITLE
chore(symbolicai): scrub .NET nuget home-root leak in OR-tools-Stiegler (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
@@ -29,14 +29,14 @@
     {
      "output_type": "display_data",
      "data": {
-      "text/plain": "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll`"
+      "text/plain": "Loading extensions from `~\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll`"
      },
      "metadata": {}
     },
     {
      "output_type": "stream",
      "name": "stderr",
-     "text": "Failed to load kernel extension \"KernelExtension\" from assembly C:\\Users\\jsboi\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll"
+     "text": "Failed to load kernel extension \"KernelExtension\" from assembly ~\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll"
     }
    ],
    "source": [


### PR DESCRIPTION
## Scrub last .NET residual leak — OR-tools-Stiegler (po-204 turf)

Closing sweep of the #3436 cross-lane scrub campaign on the po-204 .NET partition. This was the only remaining leak in my turf (GameTheory, Sudoku, Search = 0 residual; Planners-0/4 already scrubbed in #3929; Argument_Analysis + Lean are other lanes).

### G.1 root-cause lens (mandat user 2026-06-22, See #3911)

Vérifié firsthand : la fuite est le chemin de chargement de l'extension kernel .NET Interactive `C:\Users\jsboi\.nuget\packages\xplot.plotly.interactive\4.1.0\...` imprimé dans 2 champs output (text/plain + stream text). **Résolu dynamiquement par le kernel au load** (cache nuget local du contributeur), **0 hardcodage en source** → env-noise pur, pas un source-leak. Scrubbing = bon fix cause-racine (ré-exéc régénère un path nuget-cache frais ; le fix-source du mandat s'applique aux leaks hardcodés, pas aux chemins runtime-resolved). Même classe que #3880 (GT+Search nuget leaks), défendable per la distinction consolidée par ai-01.

### Change (atomique, 1 notebook)

| Avant | Après |
|-------|-------|
| \`C:\Users\jsboi\.nuget\packages\xplot.plotly.interactive\4.1.0\lib\net7.0\...\` | \`~\.nuget\packages\xplot.plotly.interactive\4.1.0\lib\net7.0\...\` |

Outil : \`scripts/notebook_tools/scrub_papermill_paths.py --outputs\` (home root → \`~\`, repo-relative tail préservé).

### Validation

- 2-dot diff : **2 lignes output-text** (text/plain + stream du même message nuget-load), source byte-identical.
- Scan résiduel : **0 leak**.
- JSON valide.

See #3436 — See #3911.

Co-Authored-By: Claude <noreply@anthropic.com>