### PR TITLE
fix(argument-analysis): re-scrub machine-local checkout-root paths from outputs (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-1-informal.ipynb
@@ -128,7 +128,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Taxonomie resolue via la shim : D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\data\\argumentum_fallacies_taxonomy.csv\n",
+      "Taxonomie resolue via la shim : <repo>MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\data\\argumentum_fallacies_taxonomy.csv\n",
       "Total lignes CSV      : 1406\n",
       "Meta-noeud depth=0    : 1 ligne(s) -> exclue(s) de la liste des familles\n",
       "Familles depth=1      : 7\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-2-formal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-2-formal.ipynb
@@ -107,7 +107,7 @@
      "text": [
       "JVM demarree avec 42 JARs.\n",
       "JVM operationnelle : True\n",
-      "Tweety charge depuis : D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\n"
+      "Tweety charge depuis : <repo>MyIA.AI.Notebooks\\SymbolicAI\\Tweety\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Executor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Executor.ipynb
@@ -154,7 +154,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CWD -> D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\n",
+      "CWD -> <repo>MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\n",
       ".env chargé: True\n"
      ]
     }

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_UI_configuration.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_UI_configuration.ipynb
@@ -123,7 +123,7 @@
       "Vérification de la phrase secrète 'TEXT_CONFIG_PASSPHRASE' dans .env...\n",
       "✅ Phrase secrète trouvée. Dérivation de la clé...\n",
       "✅ Clé de chiffrement dérivée et encodée.\n",
-      "Cache répertoire assuré : C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\text_cache\n",
+      "Cache répertoire assuré : <repo>MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\text_cache\n",
       "Configuration UI chargée. 4 sources initiales définies.\n"
      ]
     }


### PR DESCRIPTION
## Summary

Re-scrubs **4 machine-local checkout-root path leaks** that re-appeared inside cell-output text across 4 Argument_Analysis notebooks **after** PRs #3793 / #3892 (both merged). Subsequent re-execution regenerated fresh absolute-prefix leaks in the shim/CWD diagnostic prints — the documented behavior of runtime-resolved paths.

Dispatched to po-205 by po-204's cross-lane residual flag (dashboard 13:12Z) + ai-01 #3436 lane assignment (Argument_Analysis → po-205).

## What changed

Absolute machine-local checkout-root prefixes inside **output text only** → `<repo>` placeholder:
- `D:\dev\CoursIA-2\...` → `<repo>...`
- `C:\dev\CoursIA\...` → `<repo>...`

Leaked from runtime shim/CWD prints: `CWD ->`, `Taxonomie resolue via la shim`, `Tweety charge depuis`, `Cache repertoire assure`. In-repo relative tail and **all computational outputs preserved**.

## Files (4)

| Notebook | leaks fixed |
|----------|-------------|
| Argument_Analysis_Agentic-1-informal | 1 |
| Argument_Analysis_Agentic-2-formal | 1 |
| Argument_Analysis_Executor | 1 |
| Argument_Analysis_UI_configuration | 1 |

## Root-cause lens (G.1) — env-noise vs source-leak

Source-cell scan of all 4 notebooks returns **0 hardcoded machine paths** → these leaks are **env-noise** (the shim resolves the repo root at runtime, e.g. `os.getcwd()`), for which output-scrub is the *correct* fix (re-execution regenerates a fresh leak). This is **not** a source-leak (which would require a source-fix per the 2026-06-22 mandate / #3925). Distinction consistent with ai-01's cluster-wide consolidation.

## C.3 compliance

- **0** source / `cell_type` / `execution_count` / `outputs`-structure changes (4 ins / 4 del, all output-text path strings).
- Tool: `scripts/notebook_tools/scrub_papermill_paths.py --apply MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis --outputs` (enhanced tool, #3895 merged).
- Post-apply: `--scan ... --outputs` → **0 notebook(s) with 0 output path leak(s)**.

See #3436 (ongoing path-leak campaign; partial — Argument_Analysis re-leaks).