### PR TITLE
feat(lean): Bondareva #2959 — hb→cone separation bridge (balancedUnit ∉ augCone)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
@@ -19,6 +19,7 @@ import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Tactic
 import Mathlib.Analysis.Convex.Cone.Dual
 import Mathlib.Analysis.InnerProductSpace.PiL2
+import CooperativeGames.ConeKernel
 
 /-! ## Basic Types -/
 
@@ -207,6 +208,43 @@ theorem bondareva_shapley_forward :
     _ = ∑ i : N, ∑ S ∈ Finset.univ.filter (fun S => i ∈ S), weights S * x i := h_fubini
     _ = ∑ i : N, x i * ∑ S ∈ Finset.univ.filter (fun S => i ∈ S), weights S := h_factor
     _ = ∑ i : N, x i := h_bal
+
+/-! ## Cone-separation bridge (Bondareva-Farkas witness decoding)
+
+These lemmas connect the `TUGame.Balanced` hypothesis to the TUGame-free cone
+machinery in `CooperativeGames.ConeKernel` (`BondarevaCone.augCone` and the
+`hyperplane_separation_point` separator from
+`Mathlib.Analysis.Convex.Cone.Dual`). They form the front half of the
+Bondareva-Shapley backward witness construction: from `hb : G.Balanced` we obtain
+a separating functional, then decode it into a pre-imputation. -/
+
+open BondarevaCone
+
+/-- From `hb : G.Balanced` and `t > 0`, the balanced-unit test point
+    `balancedUnit (G.v univ + t)` lies outside `augCone G.v`. Membership would
+    give nonneg weights `w` with `phiAugCont G.v w = balancedUnit ...`; the
+    `some i` coordinates force `w` to be a balanced collection (`BalancedWeights`),
+    while the `none` coordinate reads `∑ S, w S * G.v S = G.v univ + t > G.v univ`,
+    contradicting `hb`. -/
+theorem balancedUnit_notIn_augCone (t : ℝ) (ht : 0 < t) (hb : G.Balanced) :
+    balancedUnit (G.v Finset.univ + t) ∉ augCone G.v := by
+  intro hmem
+  rw [augCone_mem_iff] at hmem
+  obtain ⟨w, hw, hwmem⟩ := hmem
+  -- `some i` coordinate: ∑_{S ∋ i} w S = 1  (balanced collection).
+  have hsome (i : N) :
+      ∑ S ∈ Finset.univ.filter (fun S => i ∈ S), w S = 1 := by
+    have key := congr_fun hwmem (some i)
+    simp only [balancedUnit] at key
+    exact key
+  -- `none` coordinate: ∑ S, w S * G.v S = G.v univ + t.
+  have hnone : ∑ S : Finset N, w S * G.v S = G.v Finset.univ + t := by
+    have key := congr_fun hwmem none
+    simp only [balancedUnit] at key
+    exact key
+  -- `w` is balanced, so `hb` bounds the value sum by v(N): contradiction.
+  have hbnd := hb w ⟨hw, hsome⟩
+  linarith
 
 /-- Backward direction of Bondareva-Shapley: balanced implies Core nonempty.
     Strategy (v4.30 update): ProperCone.hyperplane_separation is now available


### PR DESCRIPTION
## Summary

Wires the `TUGame.Balanced` hypothesis to the TUGame-free cone kernel (`CooperativeGames.ConeKernel`, merged in #3933), adding the proven theorem `balancedUnit_notIn_augCone`:

```lean
theorem balancedUnit_notIn_augCone (t : ℝ) (ht : 0 < t) (hb : G.Balanced) :
    balancedUnit (G.v Finset.univ + t) ∉ augCone G.v
```

This is the front half of the Bondareva-Shapley backward witness construction — the **hb → cone-separation step** that was explicitly flagged as missing after the ConeKernel split (the import-cycle is now broken by construction, so `Basic` can `import CooperativeGames.ConeKernel`).

## Proof idea

Membership in `augCone G.v` (`augCone_mem_iff`) yields nonneg weights `w` with `phiAugCont G.v w = balancedUnit (G.v univ + t)`:
- the `some i` coordinates force `w` to be a **balanced collection** (`BalancedWeights`: `∑_{S ∋ i} w S = 1` for all `i`),
- the `none` coordinate reads `∑ S, w S * G.v S = G.v univ + t > G.v univ`,
- contradicting `hb : G.Balanced` (which bounds the weighted value sum by `v(N)`).

The defeq precedent from ConeKernel (`phiAugCont` on `some i` reduces to the filtered sum) makes the coordinate reads go through cleanly via `congr_fun` + `simp only [balancedUnit]`.

## Lean PR checklist (§B pr-review-discipline)

| Item | Status |
|------|--------|
| `grep -c sorry` before/after | **before: 1 (master `hb_witness`), after: 1** — baseline unchanged |
| `Lake build SUCCESS` | ✅ `lake build CooperativeGames.Basic` = Build completed (8432 jobs) |
| Genuine recompile (rm .olean) | ✅ `rm .lake/build/lib/lean/CooperativeGames/Basic.olean` + rebuild → `grep -c "^error:"` = **0** |
| Anti-régression | ✅ Pure addition (38 insertions, 0 deletions); no existing proof touched; no new sorry |

## Scope

This PR delivers **only** the hb→cone bridge. The full close of `hb_witness` (sorry 1→0) still requires:
- **Decoding lemma**: from the separating functional `f` (via `hyperplane_separation_point` on this bridge), decode `x : N → ℝ` with `x ∈ P` (`∀ S, v S ≤ ∑_{i∈S} x i` via `augCone_dual_iff`) and `∑x < v(N)+t`. The coalition-rationality half is pure assembly (`x i := f(some i)/(-f(none))`) — confirmed by ai-01 as unblocked.
- **Pointed-recession attainment** (crux, localized cycle 22): close the strictness gap `∑x < v(N)+t → ∃x ≤ v(N)` via compact-slice Weierstrass (`K = P ∩ {∑x ≤ v(N)+1}` compact).

See #2959 (partial: hb→cone bridge wired; decoding + attainment remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>