### PR TITLE
fix(genai-01-5): remove ComfyUI token fragment leak at source (status-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
@@ -286,7 +286,7 @@
     "    print(\"Configuration chargee\")\n",
     "    print(f\"API: {API_BASE_URL} (LOCAL_MODE={LOCAL_MODE})\")\n",
     "    print(f\"Client ID: {CLIENT_ID}\")\n",
-    "    print(f\"Token: {COMFYUI_API_TOKEN[:15]}...{COMFYUI_API_TOKEN[-5:]}\" if len(COMFYUI_API_TOKEN) > 20 else f\"Token: (court)\")"
+    "    print(\"Token: configuré\" if len(COMFYUI_API_TOKEN) > 20 else f\"Token: (court)\")"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Backlog pickup campagne source-leak #3911 (po-2023 GenAI DOWN, sécurité > turf). Scan G.1 **contre `origin/main`** (worktree frais — le working tree local était 72 commits en retard, ce qui m'a d'abord fait voir de faux positifs déjà corrigés par #3913).

## Cause racine (mandat user #3911)

> « Si des scripts produisent des snippets de clés, les "redacter" n'est pas la solution. Ce sont les scripts qui doivent être corrigés. »

`GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb` cell 3 :
```python
print(f"Token: {COMFYUI_API_TOKEN[:15]}...{COMFYUI_API_TOKEN[-5:]}" if len(COMFYUI_API_TOKEN) > 20 else f"Token: (court)")
```
→ imprime **les 15 premiers + 5 derniers caractères** du token ComfyUI (fragment substantiel, même famille que `key[:8]`/`key[0:10]` déjà corrigés).

## Fix

Source → statut uniquement, **0 fragment de token** :
```python
print("Token: configuré" if len(COMFYUI_API_TOKEN) > 20 else f"Token: (court)")
```
La logique de validation (longueur > 20) est préservée. Aucun output committé ne portait le token → fix **source-only**, pas de re-exec.

## Validation

- `nbformat.validate` OK.
- Diff chirurgical : 1 insertion / 1 deletion, 1 fichier.
- Résiduel : `COMFYUI_API_TOKEN[:15]`/`[-5:]` = 0.

## Note scan G.1 (pour ai-01)

- **NotebookMaker 10/10a/10b** : `[0:10]` source-leak **déjà corrigé sur origin/main** par #3913 (`22b77a26b`) — mon hit initial était un faux positif du working tree local stale. Aucune action.
- **`QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb`** (2 sites) : `'***' + key[-4:]` = masquage last-4 (standard industrie Stripe/AWS). Borderline règle 6 (cf rejet #3939). Je laisse à ton arbitrage plutôt que bundler un call cross-domaine — flag dans le [DONE].

See #3911
See #3922

🤖 Generated with [Claude Code](https://claude.com/claude-code)