### PR TITLE
feat(qc): HAR-RV-J-Kelly aligned 2018-2025 baseline (See #1630, #83)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-J-Kelly/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-J-Kelly/README.md
@@ -17,12 +17,15 @@ Open cloud project 31650567, compile and run a backtest.
 
 ## Backtest Metrics
 
-Verified on QC Cloud (project 31650567, 2020-01-01 to 2025-06-01, Binance USDT DAILY):
+Verified on QC Cloud (project 31650567, Binance USDT DAILY):
 
-| Variant | Sharpe | CAGR | Max DD | PSR |
-|---------|--------|------|--------|-----|
-| HAR-RV-J Kelly v2 (use_jumps=1) | **0.746** | 23.03% | 48.30% | 24.0% |
-| HAR Classic Baseline (use_jumps=0) | 0.642 | 27.0% | 41.1% | 15.8% |
+| Variant | Period | Sharpe | CAGR | Max DD | PSR |
+|---------|--------|--------|------|--------|-----|
+| HAR-RV-J Kelly (use_jumps=1, aligned) | 2018-01-01 → 2025-06-01 | **0.524** | 14.08% | 37.10% | 10.7% |
+| HAR-RV-J Kelly v2 (use_jumps=1) | 2020-01-01 → 2025-06-01 | 0.746 | 23.03% | 48.30% | 24.0% |
+| HAR Classic Baseline (use_jumps=0) | 2020-01-01 → 2025-06-01 | 0.642 | 27.0% | 41.1% | 15.8% |
+
+The aligned 2018-2025 row (backtest `df687834`, 2026-06-22) extends the window backward: with `train_window=500` the model accumulates through ~2018-2019 before it can forecast, so the longer period adds early-regime out-of-sample data and lowers Sharpe (0.746 → 0.524) and CAGR (23.0% → 14.1%) versus the 2020-2025 window, while *improving* MaxDD (48.3% → 37.1%) — the different coefficient path through the 2022 crypto bear produces a less-leveraged exposure. PSR 10.7% (non-significant). Promoted Tier 4 (Untested) → Tier 2 (Historique) on the aligned window; the strongest backbone baseline since GlobalMacro-Regime (0.454). See #1630.
 
 The HAR-RV-J v2 row is verified under the current Binance USDT DAILY configuration (2026-06-12, backtest `verify-har-rv-j-real-metrics`). The HAR Classic baseline retains its 2026-05-14 measurement (pre-Binance configuration); a fresh `use_jumps=0` run under the current configuration is pending for an apples-to-apples delta.
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-J-Kelly/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-J-Kelly/main.py
@@ -21,7 +21,7 @@ class HarrvjKellyAlgorithm(QCAlgorithm):
     """
 
     def initialize(self):
-        self.set_start_date(2020, 1, 1)
+        self.set_start_date(2018, 1, 1)
         self.set_end_date(2025, 6, 1)
         self.set_cash(100000)
         self.set_account_currency("USDT")


### PR DESCRIPTION
## What

Aligns the HAR-RV-J Kelly strategy to the #1630 backbone window (**2018-01-01 → 2025-06-01**) and records the verified backtest. Next unverified Tier-4 baseline in the #1630 sequence (#83, RISK / crypto, no ML).

No ML / no external training — the HAR-RV-J OLS fit (Corsi 2009 + Andersen-Bollerslev-Diebold 2007 jump component via Huang-Tauchen bipower variation) runs inline via `np.linalg.lstsq`, refit every 22 days, with 1/4-Kelly sizing on 4 Binance cryptos (BTC/ETH/LTC/BCH USDT).

## Change (2 files, +9/-6)

- `main.py`: `set_start_date` 2020-01-01 → **2018-01-01**. With `train_window=500` the model accumulates through ~2018-2019 before it can forecast, so the longer window adds early-regime out-of-sample data.
- `README.md`: adds the aligned 2018-2025 row alongside the existing 2020-2025 rows + interpretation note.

## Validation — QC Cloud (project 31650567, backtest `df687834`, 2026-06-22)

```
Sharpe 0.524 | CAGR 14.077% | MaxDD 37.100% | PSR 10.688%
tradeableDates 2709 (~7.4 years)   status: Completed
```

Compile `0530dffd` BuildSuccess. Versus the prior 2020-2025 window (Sharpe 0.746, CAGR 23.0%, MaxDD 48.3%): Sharpe and CAGR drop on the longer window, but **MaxDD improves** (48.3% → 37.1%) — the longer coefficient path through the 2022 crypto bear produces a less-leveraged exposure. PSR 10.7% (non-significant). **Sharpe 0.524 is the strongest backbone baseline since GlobalMacro-Regime (0.454)**; crypto vol-forecasting + Kelly survives alignment (cf TermStructureCommodities -0.244). Promoted Tier 4 (Untested) → Tier 2 (Historique).

`totalOrders=0` in the MCP wrapper is the known extraction artifact (CAGR 14% ⇒ real trades), cross-checked `list_backtests` status Completed.

## Scope / safety

- main.py-only (+ project README). No comparative-doc edit here — that follows in a separate consolidated doc PR per the #1630 workflow (avoids adjacent-Tier4-deletion conflicts).
- **0 catalog / CATALOG-STATUS marker touched.** No notebook (no C.2 concern).
- No secrets.

## Follow-up

Separate doc PR: add the Verified-baselines row + remove the #83 Tier-4 line + Key-finding #29 in `docs/qc/qc-comparative-backtests.md`.

See #1630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
