### PR TITLE
feat(lean): Bondareva #2959 — witness-decoding core (separator → pre-imputation, TUGame-free)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/ConeKernel.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/ConeKernel.lean
@@ -465,6 +465,57 @@ lemma augCone_dual_iff (v : Finset N → ℝ) (f : ((Option N) → ℝ) →L[ℝ
     simp only [map_sum, map_smul, smul_eq_mul]
     exact Finset.sum_nonneg (fun S _ => mul_nonneg (hw S) (hgen S))
 
+/-! ## Generator coordinate values (witness-decoding prerequisite)
+
+The standard-basis generator `phiAugCont v (Pi.single S 1)` is the load-bearing
+object of the witness decoding: `augCone_dual_iff` reads a separating functional
+`f` off its value on these generators. Its coordinates are `1` in `some i`
+exactly when `i ∈ S` (coalition incidence) and `v S` in `none` (coalition value).
+These two facts generalize the grand-coalition special case used in
+`separatingFunctional_none_neg` to an arbitrary coalition `S`; they are the
+prerequisite for the witness-decoding lemma `exists_preimputation_strict`
+(separator `f` ⟹ pre-imputation `x i := f (some-basis i) / (-f (none-basis))`). -/
+
+/-- `some i` coordinate of the `S`-generator: the incidence indicator `1` if
+    `i ∈ S`, else `0`. Generalizes the grand-coalition special case to any `S`. -/
+lemma gen_apply_some (v : Finset N → ℝ) (S : Finset N) (i : N) :
+    (phiAugCont v (Pi.single S 1)) (some i) = if i ∈ S then (1 : ℝ) else 0 := by
+  -- defeq: `(phiAugCont v (Pi.single S 1)) (some i)` reduces to the `some`-arm
+  -- filtered incidence sum (cycle-18 defeq precedent).
+  show ∑ T ∈ Finset.univ.filter (fun T => i ∈ T),
+      (Pi.single S 1 : Finset N → ℝ) T = if i ∈ S then 1 else 0
+  by_cases hs : i ∈ S
+  · -- `i ∈ S`: the single term `T = S` (which lies in the filter) contributes `1`.
+    simp only [hs, if_true]
+    rw [Finset.sum_eq_single S
+        (fun T _ hT => by rw [Pi.single_apply, if_neg hT])
+        (fun h => (h (Finset.mem_filter.mpr ⟨Finset.mem_univ _, hs⟩)).elim),
+        Pi.single_eq_same]
+  · -- `i ∉ S`: `S` is not in the filter, and every `T` in the filter has `T ≠ S`,
+    -- so `(Pi.single S 1) T = 0`; the sum vanishes.
+    simp only [hs, if_false]
+    rw [Finset.sum_eq_zero]
+    intro T hT
+    have hiT : i ∈ T := (Finset.mem_filter.mp hT).2
+    -- `T ≠ S`: were `T = S`, then `i ∈ T` would give `i ∈ S`, contradicting `hs`.
+    -- (Pin `hTS : T = S` via `intro` so `▸` sees its type — the anonymous-lambda
+    -- form leaves the binder a metavar at `▸`-elaboration time.)
+    have hTneS : T ≠ S := by intro hTS; exact hs (hTS ▸ hiT)
+    rw [Pi.single_apply, if_neg hTneS]
+
+/-- `none` coordinate of the `S`-generator: the coalition value `v S`.
+    Generalizes the grand-coalition special case to any `S`. -/
+lemma gen_apply_none (v : Finset N → ℝ) (S : Finset N) :
+    (phiAugCont v (Pi.single S 1)) none = v S := by
+  -- defeq: the `none`-arm is `∑ T, w T * v T` with `w = Pi.single S 1`.
+  have hsum : ∑ T : Finset N, (Pi.single S 1 : Finset N → ℝ) T * v T =
+      (Pi.single S 1 : Finset N → ℝ) S * v S :=
+    Finset.sum_eq_single S
+      (fun T _ hT => by rw [Pi.single_apply, if_neg hT]; ring)
+      (fun h => by simp at h)
+  show ∑ T : Finset N, (Pi.single S 1 : Finset N → ℝ) T * v T = v S
+  rw [hsum, Pi.single_eq_same, one_mul]
+
 /-! ## Witness decoding — sign condition
 
 The separating functional `f` from `hyperplane_separation_point` (applied to a point

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/ConeKernel.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/ConeKernel.lean
@@ -516,6 +516,73 @@ lemma gen_apply_none (v : Finset N → ℝ) (S : Finset N) :
   show ∑ T : Finset N, (Pi.single S 1 : Finset N → ℝ) T * v T = v S
   rw [hsum, Pi.single_eq_same, one_mul]
 
+/-! ### Generator decomposition (linearity key)
+
+The `S`-generator `phiAugCont v (Pi.single S 1)` decomposes, as a vector of
+`Option N → ℝ`, into the incidence combination `∑ i ∈ S, Pi.single (some i) 1`
+plus the value multiple `v S • Pi.single none 1`. Applying any linear functional
+`f` then yields the *linearity identity* the witness decoding reads off:
+`f (generator S) = ∑ i ∈ S, f (some-basis i) + v S * f (none-basis)`. This identity
+is the load-bearing algebraic step of the witness-decoding lemma below: it converts
+the cone-dual inequality `0 ≤ f (generator S)` (from `augCone_dual_iff`) into the
+coalitional-rationality inequality `v S ≤ ∑_{i ∈ S} x i` for the candidate witness
+`x i := f (some-basis i) / (-f (none-basis))`. -/
+
+/-- **Generator decomposition (vector form)** — the `S`-generator equals the
+    incidence combination over `S` (one `some i` basis-vector per `i ∈ S`) plus the
+    value multiple `v S • Pi.single none 1` on the `none` axis. -/
+lemma gen_decomp (v : Finset N → ℝ) (S : Finset N) :
+    phiAugCont v (Pi.single S 1) =
+      (∑ i ∈ S, (Pi.single (some i) 1 : (Option N) → ℝ)) + v S • Pi.single none 1 := by
+  -- Mirror the `funext`/`cases` pattern of the grand-coalition identity proved
+  -- inside `separatingFunctional_none_neg`; here for an arbitrary coalition `S`.
+  funext j
+  cases j with
+  | none =>
+    -- LHS: `v S` (`gen_apply_none`). RHS: every `some i`-basis vector is `0` at
+    -- `none`; only the value multiple contributes `v S`.
+    simp only [Pi.add_apply, Pi.smul_apply, smul_eq_mul, Finset.sum_apply]
+    rw [gen_apply_none]
+    -- Each `(Pi.single (some x) 1) none = 0` since `none ≠ some x`.
+    have hzero : ∀ x ∈ S, (Pi.single (some x) 1 : (Option N) → ℝ) none = 0 := by
+      intro x _; rw [Pi.single_apply, if_neg (Option.some_ne_none x).symm]
+    rw [Finset.sum_eq_zero hzero, Pi.single_eq_same, mul_one, zero_add]
+  | some i =>
+    -- LHS: incidence indicator (`gen_apply_some`). RHS: at `some i`, only the
+    -- `i`-th `some`-basis vector can contribute `1` (and only if `i ∈ S`); the
+    -- value multiple is `0` off the `none` axis.
+    have hne : (some i : Option N) ≠ none := Option.some_ne_none i
+    simp only [Pi.add_apply, Pi.smul_apply, smul_eq_mul, Finset.sum_apply,
+      Pi.single_apply, hne, if_false]
+    rw [gen_apply_some]
+    -- Reduce the `some i = some i'`-conditions to `i = i'`, then single-out `i`.
+    have hsum : ∑ i' ∈ S, (if some i = some (i' : N) then (1 : ℝ) else 0) =
+        if i ∈ S then 1 else 0 := by
+      by_cases hs : i ∈ S
+      · simp only [hs, if_true, Option.some.injEq]
+        -- `if_neg` needs `¬(i = i')`; the supplied `hi' : i' ≠ i` is symmetric.
+        rw [Finset.sum_eq_single i
+            (fun i' _ hi' => by rw [if_neg hi'.symm])
+            (fun hi => (hi hs).elim)]
+        simp only [if_true]
+      · simp only [hs, if_false, Option.some.injEq]
+        rw [Finset.sum_eq_zero]
+        intro i' hi'
+        -- `i ≠ i'`: were `i = i'`, then `i' ∈ S` would give `i ∈ S`, contradicting `hs`.
+        have hne : i ≠ i' := by intro hss; exact hs (hss ▸ hi')
+        rw [if_neg hne]
+    rw [hsum]
+    ring
+
+/-- **Linearity identity on the `S`-generator** — for any linear functional `f`,
+    `f (generator S) = ∑ i ∈ S, f (some-basis i) + v S * f (none-basis)`. This is
+    the algebraic form the witness decoding consumes (apply `f` to `gen_decomp`). -/
+lemma gen_apply_linear (v : Finset N → ℝ) (S : Finset N)
+    (f : ((Option N) → ℝ) →L[ℝ] ℝ) :
+    f (phiAugCont v (Pi.single S 1)) =
+      ∑ i ∈ S, f (Pi.single (some i) 1) + v S * f (Pi.single none 1) := by
+  rw [gen_decomp, map_add, map_sum, map_smul, smul_eq_mul]
+
 /-! ## Witness decoding — sign condition
 
 The separating functional `f` from `hyperplane_separation_point` (applied to a point
@@ -580,5 +647,87 @@ lemma separatingFunctional_none_neg (v : Finset N → ℝ) {t : ℝ} (ht : 0 < t
   -- the goal `f (Pi.single none 1) < 0` needs dividing `t * f (...) < 0` by `t`.
   rw [hId, map_add, map_smul, smul_eq_mul] at hfSep
   nlinarith [ht, huniv]
+
+/-! ### Witness construction (separator → pre-imputation)
+
+The witness-decoding core: a separating functional `f` (non-negative on `augCone v`,
+strictly negative on `balancedUnit (v(N)+t)`) yields a pre-imputation `x : N → ℝ`
+that is coalitionally rational (`∀ S, v S ≤ ∑_{i ∈ S} x i`) and within the strict
+budget (`∑ x ≤ v(N) + t`). This is the TUGame-free decoding core: the balanced-game
+hypothesis enters only later (in `Basic.lean`, via the bridge
+`balancedUnit_notIn_augCone`, which *produces* such an `f` through
+`hyperplane_separation_point`). The candidate witness is
+`x i := f (some-basis i) / (-f (none-basis))`, well-defined because the sign lemma
+gives `f (none-basis) < 0`; coalitional rationality is read off the cone-dual
+inequality `0 ≤ f (generator S)` via the linearity identity `gen_apply_linear`. -/
+
+/-- **`balancedUnit` decomposition** — `balancedUnit (v(N)+t)` equals the grand-
+    coalition generator plus `t` times the `none`-basis vector. Under a separating
+    functional, this identity yields the strict budget `∑ x ≤ v(N) + t`. -/
+lemma balancedUnit_decomp (v : Finset N → ℝ) (t : ℝ) :
+    balancedUnit (v Finset.univ + t) =
+      phiAugCont v (Pi.single Finset.univ 1) + t • Pi.single none 1 := by
+  funext j
+  cases j with
+  | none =>
+    simp only [Pi.add_apply, Pi.smul_apply, smul_eq_mul, balancedUnit]
+    rw [gen_apply_none, Pi.single_eq_same]
+    ring
+  | some i =>
+    have hne : (some i : Option N) ≠ none := Option.some_ne_none i
+    simp only [Pi.add_apply, Pi.smul_apply, smul_eq_mul, balancedUnit]
+    rw [gen_apply_some, Pi.single_apply, if_neg hne]
+    simp only [Finset.mem_univ, if_true]
+    ring
+
+/-- **Witness decoding (TUGame-free core)** — a separating functional `f`
+    (non-negative on `augCone v`, negative on `balancedUnit (v(N)+t)`) yields a
+    pre-imputation `x` that is coalitionally rational and within budget
+    `∑ x ≤ v(N) + t`. The balanced-game hypothesis enters only later, in `Basic.lean`,
+    via the bridge that *produces* such an `f`. -/
+lemma exists_preimputation_strict_core (v : Finset N → ℝ) {t : ℝ} (ht : 0 < t)
+    (f : ((Option N) → ℝ) →L[ℝ] ℝ)
+    (hfCone : ∀ y ∈ augCone v, 0 ≤ f y)
+    (hfSep : f (balancedUnit (v Finset.univ + t)) < 0) :
+    ∃ x : N → ℝ,
+      (∀ S : Finset N, v S ≤ ∑ i ∈ S, x i) ∧
+      ∑ i : N, x i ≤ v Finset.univ + t := by
+  -- (A) Sign: `f (none-basis) < 0`, hence `den := -f(none-basis) > 0`.
+  have hfneg : f (Pi.single none 1) < 0 :=
+    separatingFunctional_none_neg v ht f hfCone hfSep
+  set den : ℝ := -f (Pi.single none 1) with hden_def
+  have hden_pos : 0 < den := by rw [hden_def]; exact neg_pos.mpr hfneg
+  have hfnone_eq : f (Pi.single none 1) = -den := by linarith
+  refine ⟨fun i => f (Pi.single (some i) 1) / den, ⟨?_, ?_⟩⟩
+  · -- (B) Coalitional rationality: `v S ≤ ∑_{i ∈ S} x i`.
+    intro S
+    have hfS : 0 ≤ f (phiAugCont v (Pi.single S 1)) :=
+      (augCone_dual_iff v f).mp hfCone S
+    rw [gen_apply_linear] at hfS
+    -- Factor the divided sum, then clear the (positive) denominator.
+    have hfactor : ∑ i ∈ S, f (Pi.single (some i) 1) / den =
+        (∑ i ∈ S, f (Pi.single (some i) 1)) / den := by rw [Finset.sum_div]
+    rw [hfactor, le_div_iff₀ hden_pos]
+    -- `0 ≤ ∑ f(g_i) + v S * f(none)` and `f(none) = -den` ⟹ `v S * den ≤ ∑ f(g_i)`.
+    nlinarith [hfS, hfnone_eq]
+  · -- (C) Budget: `∑ x i ≤ v(N) + t`.
+    -- Grand-coalition linearity identity.
+    have hGuniv : f (phiAugCont v (Pi.single Finset.univ 1)) =
+        ∑ i : N, f (Pi.single (some i) 1) + v Finset.univ * f (Pi.single none 1) :=
+      gen_apply_linear v Finset.univ f
+    -- Separation + `balancedUnit_decomp` ⟹ `f(gen univ) + t * f(none) < 0`.
+    have hsep_eq : f (balancedUnit (v Finset.univ + t)) =
+        f (phiAugCont v (Pi.single Finset.univ 1)) + t * f (Pi.single none 1) := by
+      rw [balancedUnit_decomp, map_add, map_smul, smul_eq_mul]
+    have hfGuniv : f (phiAugCont v (Pi.single Finset.univ 1)) < t * den := by
+      have key : f (phiAugCont v (Pi.single Finset.univ 1)) +
+          t * f (Pi.single none 1) < 0 := by rw [← hsep_eq]; exact hfSep
+      linarith
+    have hfactor : (∑ i : N, f (Pi.single (some i) 1) / den) =
+        (∑ i : N, f (Pi.single (some i) 1)) / den := by rw [Finset.sum_div]
+    rw [hfactor, div_le_iff₀ hden_pos]
+    -- `∑ f(g_i) = f(gen univ) + v(N) * den` (hGuniv + f(none) = -den);
+    -- `f(gen univ) < t * den` (hfGuniv) ⟹ `∑ f(g_i) ≤ (v(N) + t) * den`.
+    nlinarith [hfGuniv, hGuniv, hfnone_eq]
 
 end BondarevaCone


### PR DESCRIPTION
## Summary

Adds the **TUGame-free witness-decoding core** to `CooperativeGames.ConeKernel` — the full *"separator `f` → imputation `x`"* half of the Bondareva-Shapley proof (issue #2959). This closes the decoding half: only the balanced-game wiring remains (in `Basic.lean`, post-#3941 merge).

## Lemmas added (pure addition, +200/0 vs `main`)

| Lemma | Statement |
|-------|-----------|
| `gen_apply_some` / `gen_apply_none` (#3945 prior commit) | `S`-generator coordinates: incidence `1`/`0` at `some i`, value `v S` at `none`. |
| `gen_decomp` | `phiAugCont v (Pi.single S 1) = (∑ i ∈ S, Pi.single (some i) 1) + v S • Pi.single none 1` (vector decomposition). |
| `gen_apply_linear` | `f (generator S) = ∑ i ∈ S, f (some-basis i) + v S * f (none-basis)` (linearity identity). |
| `balancedUnit_decomp` | `balancedUnit (v(N)+t) = grand-coal generator + t • none-basis`. |
| **`exists_preimputation_strict_core`** | **A separating functional `f` (non-neg on `augCone v`, neg on `balancedUnit (v(N)+t)`) ⇒ a pre-imputation `x` that is coalitionally rational (`∀ S, v S ≤ ∑_{i∈S} x i`) and within strict budget (`∑ x ≤ v(N)+t`).** Candidate `x i := f (some-basis i) / (-f (none-basis))`. |

## Architecture — TUGame-free core, thin wiring layer

The core is **parameterized over `v : Finset N → ℝ`** (no `TUGame`). The balanced-game hypothesis enters only later in `Basic.lean`:
- **Bridge** `balancedUnit_notIn_augCone` (PR #3941, `0 < t` + `Balanced` ⟹ `balancedUnit (v(N)+t) ∉ augCone v`)
- → `hyperplane_separation_point` produces the separator `f` satisfying exactly this lemma's hypotheses
- → `exists_preimputation_strict_core` decodes `f` into the witness `x`

This depends **only on merged #3933** cone infrastructure (`augCone_dual_iff`, `separatingFunctional_none_neg`), **not** on the unmerged bridge #3941 — so the decoding half is independently mergeable.

## Verification (post-fix, genuine)

- `lake build CooperativeGames.ConeKernel` = **0 errors** (`rm .lake/build/lib/lean/CooperativeGames/ConeKernel.olean` + rebuild, 8431 jobs, `.olean` mtime > source).
- **ConeKernel stays 0 `sorry`** (anti-régression D: pure addition, no existing proof touched).
- Coalitional rationality: `augCone_dual_iff` ⟹ `0 ≤ f (generator S)`; `gen_apply_linear` + `f(none) = -den` ⟹ `v S ≤ ∑ x_i` (clearing positive denom via `le_div_iff₀`, closed by `nlinarith`).
- Budget: `balancedUnit_decomp` + `hfSep` ⟹ `f(gen univ) < t·den`; `gen_apply_linear` (S = univ) ⟹ `∑ x_i ≤ (v(N)+t)·den` (`div_le_iff₀`, `nlinarith`).

See #2959

🤖 Generated with [Claude Code](https://claude.com/claude-code)