### PR TITLE
fix(qc-py-26): remove API key suffix masking at source (status-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -214,8 +214,8 @@
     "config = LLMConfig()\n",
     "\n",
     "print(\"Configuration LLM:\")\n",
-    "print(f\"  OpenAI Key: {'***' + config.openai_api_key[-4:] if config.openai_api_key else 'Non configuree'}\")\n",
-    "print(f\"  Anthropic Key: {'***' + config.anthropic_api_key[-4:] if config.anthropic_api_key else 'Non configuree'}\")\n",
+    "print(f\"  OpenAI Key: {'configuree' if config.openai_api_key else 'Non configuree'}\")\n",
+    "print(f\"  Anthropic Key: {'configuree' if config.anthropic_api_key else 'Non configuree'}\")\n",
     "print(f\"  OpenAI Model: {config.openai_model}\")\n",
     "print(f\"  Claude Model: {config.claude_model}\")"
    ]


### PR DESCRIPTION
## Contexte

Campagne source-leak #3911 (po-2023 GenAI DOWN, sécurité > turf). Dernier résidu du sweep que j'avais flaggé pour arbitrage ai-01 le cycle précédent. Je l'applique car : (a) **single file, single domain** (QC/Python — pas cross-domaine), (b) **précédent ai-01 déjà établi** — le rejet de #3939 (last-4-in-source = violation règle 6) + l'adoption de #3937 (status-only) comme standard tranchent la question. Fixer ici = appliquer la règle d'ai-01, pas un call unilatéral.

## Cause racine (mandat user #3911)

`QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb` cell 6 :
```python
print(f"  OpenAI Key: {'***' + config.openai_api_key[-4:] if config.openai_api_key else 'Non configuree'}")
print(f"  Anthropic Key: {'***' + config.anthropic_api_key[-4:] if config.anthropic_api_key else 'Non configuree'}")
```
→ imprime les 4 derniers caractères des clés OpenAI/Anthropic si configurées (snippet de clé = anti-pattern #3911 ; masquage last-4 = exactement ce qu'ai-01 a rejeté dans #3939).

## Fix

Source → statut uniquement, **0 fragment de clé** (même approche que #3937) :
```python
print(f"  OpenAI Key: {'configuree' if config.openai_api_key else 'Non configuree'}")
print(f"  Anthropic Key: {'configuree' if config.anthropic_api_key else 'Non configuree'}")
```
L'output committé montrait déjà `Non configuree` (notebook exécuté sans clés) → **pas de redaction output, pas de re-exec**.

## Validation

- Diff chirurgical : 2 insertions / 2 deletions, 1 fichier.
- Résiduel `api_key[-4:]` = 0.
- Note : ce notebook a une incohérence nbformat **pré-existante** (`nbformat_minor: 4` avec `id` de cellules = 4.5) présente sur origin/main — **non introduite ni corrigée ici** (hors scope, PR atomique sécurité).

Clôt le dernier site du sweep #3911 sur origin/main (00-3/Video/NotebookMaker/01-5 déjà traités).

See #3911
See #3922

🤖 Generated with [Claude Code](https://claude.com/claude-code)