### PR TITLE
chore: gitignore root-level _census_out.json scratch output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -861,6 +861,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/data/temp_*.owl
 /data/pizza_test.owl
 /results/
 /tmp_*.py
+/_census_out.json
 
 # Shared Mathlib checkout cache (NTFS junctions, scripts/lean/setup_shared_mathlib.ps1, #2611)
 /.mathlib-cache/


### PR DESCRIPTION
## Summary
`_census_out.json` is a stray root-level scratch file produced by ad-hoc axis-2 census runs (no in-repo script generates it). It recurs in `git status` across sessions and is never a deliverable. This adds it to the existing *"root-level artifacts run with wrong CWD"* `.gitignore` section so the working tree stays clean.

## Scope
- 1 line added to `.gitignore`. No code, no notebooks, no catalog.

## Notes
Deliberately **not** broadening `.claude/agent-memory/` (some sub-dirs e.g. `infer-notebook-enricher/` are intentionally tracked) and **not** touching `SymbolicAI/SMT/Z3.Linq` (deliberate Epic #1206 fork, submodule pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)