### PR TITLE
feat(lean): Bondareva #2959 — wire cone-separation→decoding pipeline (hb_strict) in Basic

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
@@ -346,7 +346,27 @@ theorem bondareva_shapley_backward :
     -- ProperCone.hyperplane_separation instantiated for this polyhedron, the
     -- existence cannot be derived here. Marked for Director escalation.
     have hb_witness : ∃ x ∈ P, ∑ i : N, x i ≤ G.v Finset.univ := by
-      -- INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION
+      -- Step A (cone-separation → decoding, PROVEN). For every `t > 0`, the bridge
+      -- `balancedUnit_notIn_augCone` (Bridge #3941) produces `balancedUnit(v(N)+t) ∉
+      -- augCone`; `hyperplane_separation_point` (Mathlib) yields a separator `f` that
+      -- is nonneg on `augCone` and negative on `balancedUnit(v(N)+t)`; the decoding core
+      -- `exists_preimputation_strict_core` (ConeKernel #3945) turns `f` into an
+      -- `x ∈ P` with `∑ x ≤ v(N) + t`. This is the full Farkas-assembled strict witness.
+      have hb_strict : ∀ t : ℝ, 0 < t → ∃ x ∈ P, ∑ i : N, x i ≤ G.v Finset.univ + t := by
+        intro t ht
+        have hNotIn : balancedUnit (G.v Finset.univ + t) ∉ augCone G.v :=
+          balancedUnit_notIn_augCone G t ht hb
+        obtain ⟨f, hfCone, hfSep⟩ :=
+          ProperCone.hyperplane_separation_point (augCone G.v) hNotIn
+        obtain ⟨x, hxP, hxle⟩ :=
+          exists_preimputation_strict_core G.v ht f hfCone hfSep
+        exact ⟨x, hxP, hxle⟩
+      -- Step B (attainment crux). The strict witnesses give `inf_P (∑x) ≤ v(N)`
+      -- (let t → 0) and grand-coalition rationality gives `inf_P (∑x) ≥ v(N)`, so
+      -- `inf_P (∑x) = v(N)`. The slice `{x ∈ P | ∑x ≤ v(N)+1}` is compact: singletons
+      -- bound each `x_i` below by `v({i})`, the sum bound bounds each `x_i` above,
+      -- and closed ∩ bounded in the finite-dimensional `N → ℝ` is compact. By
+      -- Weierstrass, `∑x` attains its infimum `v(N)` on the slice.
       sorry
     obtain ⟨x, hxP, hxle⟩ := hb_witness
     refine ⟨x, ?_, hxP⟩


### PR DESCRIPTION
## Summary

Closes the **deferred post-merge assembly**: the bridge `balancedUnit_notIn_augCone` (#3941, merged) + `ProperCone.hyperplane_separation_point` (Mathlib) + the decoding core `exists_preimputation_strict_core` (ConeKernel #3945, merged) are now **wired end-to-end** in `bondareva_shapley_backward`. This was comment-aspirational across cycles 23-25 (deferred as "post-#3941+#3945-merge"); both are now on `main`, so the assembly lands.

## Proven this PR

```lean
hb_strict : ∀ t : ℝ, 0 < t → ∃ x ∈ P, ∑ i : N, x i ≤ G.v Finset.univ + t
```

For each `t > 0`: `hb : G.Balanced` → bridge gives `balancedUnit(v(N)+t) ∉ augCone` → `hyperplane_separation_point` yields separator `f` (nonneg on `augCone`, negative on `balancedUnit(v(N)+t)`) → `exists_preimputation_strict_core` decodes `f` into a coalitionally-rational `x ∈ P` within strict budget `∑x ≤ v(N)+t`.

## Attainment crux (remaining sorry, cleanly isolated)

`hb_witness : ∃ x ∈ P, ∑ x ≤ v(N)` still carries a sorry, now with a **precise Weierstrass sketch**:
- `hb_strict` ⟹ `inf_P (∑x) ≤ v(N)` (let `t → 0`); grand-coalition rationality ⟹ `inf_P (∑x) ≥ v(N)`; so `inf = v(N)`.
- The slice `{x ∈ P | ∑x ≤ v(N)+1}` is **compact**: singletons bound each `x_i` below by `v({i})`; the sum bound + lower bounds bound each `x_i` above; closed ∩ bounded in the finite-dimensional `N → ℝ` ⟹ compact.
- The continuous `∑x` attains its infimum `v(N)` on the slice → `hb_witness`.

This is the documented hard crux (cycles 22-25); it is a focused formalization effort for a dedicated next cycle, not a blocker on the wiring.

## Verification (post-fix, genuine)

- `lake build CooperativeGames.Basic` = **0 errors** (`rm .lake/build/lib/lean/CooperativeGames/Basic.olean` + rebuild, **8432 jobs**, `.olean` mtime 18:51 > source 18:50).
- **sorry baseline 1** (the isolated attainment crux @ L370; ConeKernel stays 0).
- **Anti-régression D**: pure addition (+21), no existing proof touched. The vague `INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION` comment is replaced by the proven `hb_strict` + a precise attainment sketch.

See #2959

🤖 Generated with [Claude Code](https://claude.com/claude-code)