### PR TITLE
fix(infer): re-scrub machine-local repo-root paths from Infer-1..12 outputs (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
@@ -980,7 +980,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -997,7 +997,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_09_26_06_39_22_92.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_09_26_06_39_22_92.gv\"\n",
       "\r\n"
      ]
     },
@@ -1418,7 +1418,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verification Graphviz echouee : An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\r\n"
+      "Verification Graphviz echouee : An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\r\n"
      ]
     },
     {
@@ -1494,7 +1494,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1511,7 +1511,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_09_26_06_39_23_46.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_09_26_06_39_23_46.gv\"\n",
       "\r\n"
      ]
     },
@@ -1540,7 +1540,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1557,7 +1557,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Task_Graph_06_09_26_06_39_23_48.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Task_Graph_06_09_26_06_39_23_48.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Crowdsourcing.ipynb
@@ -904,7 +904,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -921,7 +921,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_23_47_05_98.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_23_47_05_98.gv\"\n",
       "\r\n"
      ]
     },
@@ -1837,7 +1837,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1854,7 +1854,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_23_47_07_52.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_23_47_07_52.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Sequences.ipynb
@@ -810,7 +810,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -827,7 +827,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_00_45_57_37.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_00_45_57_37.gv\"\n",
       "\r\n"
      ]
     },
@@ -2327,7 +2327,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2344,7 +2344,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_00_46_52_66.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_00_46_52_66.gv\"\n",
       "\r\n"
      ]
     },
@@ -4402,7 +4402,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -4419,7 +4419,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_00_47_29_34.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_00_47_29_34.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Recommenders.ipynb
@@ -887,7 +887,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -904,7 +904,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_01_46_22_49.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_01_46_22_49.gv\"\n",
       "\r\n"
      ]
     },
@@ -5189,7 +5189,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -5206,7 +5206,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_01_46_30_44.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_01_46_30_44.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
@@ -443,7 +443,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -460,7 +460,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_35_34.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_35_34.gv\"\n",
       "\r\n"
      ]
     },
@@ -1101,7 +1101,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1118,7 +1118,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_37_18.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_37_18.gv\"\n",
       "\r\n"
      ]
     },
@@ -1666,7 +1666,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1683,7 +1683,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_37_68.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_37_68.gv\"\n",
       "\r\n"
      ]
     },
@@ -2083,7 +2083,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2100,7 +2100,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_37_99.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_37_99.gv\"\n",
       "\r\n"
      ]
     },
@@ -2500,7 +2500,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2517,7 +2517,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_38_29.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_38_29.gv\"\n",
       "\r\n"
      ]
     },
@@ -3593,7 +3593,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -3610,7 +3610,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_40_27.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_40_27.gv\"\n",
       "\r\n"
      ]
     },
@@ -4228,7 +4228,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -4245,7 +4245,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_41_49.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_41_49.gv\"\n",
       "\r\n"
      ]
     },
@@ -4288,7 +4288,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -4305,7 +4305,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_41_78.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_41_78.gv\"\n",
       "\r\n"
      ]
     },
@@ -5474,7 +5474,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -5491,7 +5491,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_44_38.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_44_38.gv\"\n",
       "\r\n"
      ]
     },
@@ -6182,7 +6182,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -6199,7 +6199,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_46_00.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_46_00.gv\"\n",
       "\r\n"
      ]
     },
@@ -6746,7 +6746,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -6763,7 +6763,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_47_45.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_47_45.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
@@ -949,7 +949,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -966,7 +966,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_16_50_47_52.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_16_50_47_52.gv\"\n",
       "\r\n"
      ]
     },
@@ -1774,7 +1774,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1791,7 +1791,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_16_50_49_02.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_16_50_49_02.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
@@ -607,7 +607,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -624,7 +624,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_47_50_90.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_47_50_90.gv\"\n",
       "\r\n"
      ]
     },
@@ -1194,7 +1194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1211,7 +1211,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_47_54_27.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_47_54_27.gv\"\n",
       "\r\n"
      ]
     },
@@ -2520,7 +2520,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2537,7 +2537,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_47_55_68.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_47_55_68.gv\"\n",
       "\r\n"
      ]
     },
@@ -4415,7 +4415,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -4432,7 +4432,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_48_00_74.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_48_00_74.gv\"\n",
       "\r\n"
      ]
     },
@@ -7945,7 +7945,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -7962,7 +7962,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_48_04_75.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_48_04_75.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-5-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-5-Skills-IRT.ipynb
@@ -616,7 +616,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -633,7 +633,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_10_17.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_10_17.gv\"\n",
       "\r\n"
      ]
     },
@@ -2369,7 +2369,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2386,7 +2386,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_13_45.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_13_45.gv\"\n",
       "\r\n"
      ]
     },
@@ -2954,7 +2954,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2971,7 +2971,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_14_45.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_14_45.gv\"\n",
       "\r\n"
      ]
     },
@@ -4290,7 +4290,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -4307,7 +4307,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_15_73.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_15_73.gv\"\n",
       "\r\n"
      ]
     },
@@ -5191,7 +5191,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -5208,7 +5208,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_16_87.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_16_87.gv\"\n",
       "\r\n"
      ]
     },
@@ -6168,7 +6168,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -6185,7 +6185,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_17_98.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_17_98.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-6-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-6-TrueSkill.ipynb
@@ -579,7 +579,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -596,7 +596,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_24_96.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_24_96.gv\"\n",
       "\r\n"
      ]
     },
@@ -1156,7 +1156,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1173,7 +1173,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_27_52.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_27_52.gv\"\n",
       "\r\n"
      ]
     },
@@ -2332,7 +2332,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2349,7 +2349,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_31_01.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_31_01.gv\"\n",
       "\r\n"
      ]
     },
@@ -3151,7 +3151,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -3168,7 +3168,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_31_86.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_31_86.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Classification.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Classification.ipynb
@@ -457,7 +457,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -474,7 +474,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_03_41.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_03_41.gv\"\n",
       "\r\n"
      ]
     },
@@ -1688,7 +1688,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1705,7 +1705,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_07_00.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_07_00.gv\"\n",
       "\r\n"
      ]
     },
@@ -2892,7 +2892,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2909,7 +2909,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_08_12.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_08_12.gv\"\n",
       "\r\n"
      ]
     },
@@ -3898,7 +3898,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -3915,7 +3915,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_09_25.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_09_25.gv\"\n",
       "\r\n"
      ]
     },
@@ -4928,7 +4928,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -4945,7 +4945,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_11_18.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_11_18.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-8-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-8-Model-Selection.ipynb
@@ -444,7 +444,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -461,7 +461,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_36_51.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_36_51.gv\"\n",
       "\r\n"
      ]
     },
@@ -1418,7 +1418,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1435,7 +1435,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_38_93.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_38_93.gv\"\n",
       "\r\n"
      ]
     },
@@ -4114,7 +4114,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -4131,7 +4131,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_48_38.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_48_38.gv\"\n",
       "\r\n"
      ]
     },
@@ -9593,7 +9593,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -9610,7 +9610,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_51_60.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_51_60.gv\"\n",
       "\r\n"
      ]
     },
@@ -10010,7 +10010,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -10027,7 +10027,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_53_29.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_53_29.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Topic-Models.ipynb
@@ -835,7 +835,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -852,7 +852,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_47_83.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_47_83.gv\"\n",
       "\r\n"
      ]
     },
@@ -1833,7 +1833,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1850,7 +1850,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_50_40.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_50_40.gv\"\n",
       "\r\n"
      ]
     },
@@ -1893,7 +1893,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1910,7 +1910,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_50_82.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_50_82.gv\"\n",
       "\r\n"
      ]
     },
@@ -1953,7 +1953,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1970,7 +1970,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_51_44.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_51_44.gv\"\n",
       "\r\n"
      ]
     },
@@ -2013,7 +2013,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2030,7 +2030,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_52_22.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_52_22.gv\"\n",
       "\r\n"
      ]
     },
@@ -2073,7 +2073,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2090,7 +2090,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_53_31.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_53_31.gv\"\n",
       "\r\n"
      ]
     },


### PR DESCRIPTION
## Summary

**Part 1/2** of the Infer.NET family #3436 re-scrub. Anonymizes machine-local checkout-root path leaks that re-appeared inside cell-output text across the **12 core Infer notebooks (Infer-1..12)**, regenerated by the #3164 fidelity-audit and #3473 SVG-rerender PRs.

The leaks are **Graphviz/dot fallback messages and `.gv` paths** printed by `FactorGraphHelper` at runtime (e.g. `<root>...\Probas\Infer'. Le fichier specifie est introuvable`, `...\Model_*.gv`) — the machine-local repo root → `<repo>` placeholder, in-repo relative tail preserved.

Splitting the 16-notebook family into 2 PRs keeps each ≤15 files (pr-review-discipline §A). Decision-Utility notebooks (Infer-14/15/17/20, 18 leaks) follow in Part 2.

## Files (12)

`Infer-1-Setup`, `Infer-2-Gaussian-Mixtures`, `Infer-3-Factor-Graphs`, `Infer-4-Bayesian-Networks`, `Infer-5-Skills-IRT`, `Infer-6-TrueSkill`, `Infer-7-Classification`, `Infer-8-Model-Selection`, `Infer-9-Topic-Models`, `Infer-10-Crowdsourcing`, `Infer-11-Sequences`, `Infer-12-Recommenders` — **109 leak occurrences** (1 distinct prefix each).

## Root-cause lens (G.1) — env-noise, not source-leak

Source-cell scan of all 12 notebooks returns **0 hardcoded machine paths** → these are **env-noise** (the helper resolves the repo root at runtime when dot/Graphviz isn't on PATH, the #3473 fallback). Output-scrub is the *correct* fix (re-execution regenerates a fresh leak); a source-fix does not apply. Distinction consistent with ai-01's cluster-wide consolidation (#3925).

## C.3 compliance

- **0** source / `cell_type` / `execution_count` / `outputs`-structure changes (110 ins / 110 del, all output-text path strings).
- Tool: `scripts/notebook_tools/scrub_papermill_paths.py --outputs` (enhanced, #3895 merged).
- Post-apply `--scan ... --outputs` on all 12 → **0 leaks**. No residual machine-prefix in any added line.

See #3436 (ongoing path-leak campaign; partial — Infer core re-leaks, Part 1/2).