### PR TITLE
feat(lean): prove Bondareva-Shapley attainment crux (sorry 1->0)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
@@ -361,13 +361,67 @@ theorem bondareva_shapley_backward :
         obtain ⟨x, hxP, hxle⟩ :=
           exists_preimputation_strict_core G.v ht f hfCone hfSep
         exact ⟨x, hxP, hxle⟩
-      -- Step B (attainment crux). The strict witnesses give `inf_P (∑x) ≤ v(N)`
-      -- (let t → 0) and grand-coalition rationality gives `inf_P (∑x) ≥ v(N)`, so
-      -- `inf_P (∑x) = v(N)`. The slice `{x ∈ P | ∑x ≤ v(N)+1}` is compact: singletons
-      -- bound each `x_i` below by `v({i})`, the sum bound bounds each `x_i` above,
-      -- and closed ∩ bounded in the finite-dimensional `N → ℝ` is compact. By
-      -- Weierstrass, `∑x` attains its infimum `v(N)` on the slice.
-      sorry
+      -- Step B (attainment crux). `hb_strict` gives `inf_P (∑x) ≤ v(N)` (let t → 0)
+      -- and grand-coalition rationality (`hx Finset.univ`) gives `inf_P (∑x) ≥ v(N)`,
+      -- so the infimum is `v(N)`. We show it is ATTAINED. The sublevel slice
+      -- `S₁ = {x ∈ P | ∑x ≤ v(N)+1}` is a closed subset of the compact box
+      -- `∏ᵢ Icc (v({i})) (v(N)+1 − v(N∖{i}))` (singletons bound `x_i` below,
+      -- complement coalitions bound `x_i` above), hence compact; the continuous
+      -- functional `∑x` attains its minimum on `S₁`, and an ε-contradiction
+      -- against `hb_strict` forces that minimum to be `≤ v(N)`.
+      let S₁ : Set (N → ℝ) := { x ∈ P | ∑ i : N, x i ≤ G.v Finset.univ + 1 }
+      have hcont : Continuous (fun (x : N → ℝ) => ∑ i : N, x i) :=
+        continuous_finsetSum Finset.univ (fun i _ => continuous_apply i)
+      -- S₁ is closed: P (closed) ∩ preimage of the closed ray Iic under continuous ∑x.
+      have hS1_closed : IsClosed S₁ :=
+        hP_closed.inter (IsClosed.preimage hcont isClosed_Iic)
+      -- Compactness: S₁ sits inside the compact box ∏ᵢ Icc (v({i})) (v(N)+1 − v(N∖{i})).
+      have hS1_compact : IsCompact S₁ := by
+        have hB_compact : IsCompact
+            (Set.pi Set.univ (fun i : N =>
+              Set.Icc (G.v ({i} : Finset N)) (G.v Finset.univ + 1 - G.v (Finset.univ.erase i)))) :=
+          isCompact_univ_pi (fun _ => isCompact_Icc)
+        have hS1_subset : S₁ ⊆
+            (Set.pi Set.univ (fun i : N =>
+              Set.Icc (G.v ({i} : Finset N)) (G.v Finset.univ + 1 - G.v (Finset.univ.erase i)))) := by
+          intro x hx
+          obtain ⟨hxP, hxle⟩ := hx
+          rw [Set.mem_univ_pi]
+          intro i
+          refine ⟨?_, ?_⟩
+          · -- lower bound: singleton coalition constraint gives v({i}) ≤ x i.
+            have hi := hxP ({i} : Finset N)
+            rwa [Finset.sum_singleton] at hi
+          · -- upper bound: complement-coalition constraint + the ∑x ≤ v(N)+1 cap.
+            -- ∑ j, x j = x i + ∑ j ∈ univ.erase i, x j  (partition around i).
+            have hpart : ∑ j : N, x j = x i + ∑ j ∈ Finset.univ.erase i, x j := by
+              have key := Finset.add_sum_erase Finset.univ (fun j => x j) (Finset.mem_univ i)
+              linarith
+            have hcompl := hxP (Finset.univ.erase i)
+            linarith
+        exact IsCompact.of_isClosed_subset hB_compact hS1_closed hS1_subset
+      -- S₁ is nonempty: hb_strict with t = 1 yields a witness with ∑x ≤ v(N)+1.
+      have hS1_nonempty : S₁.Nonempty := by
+        obtain ⟨x, hxP, hxle⟩ := hb_strict (1 : ℝ) (by norm_num)
+        exact ⟨x, hxP, hxle⟩
+      -- ∑x attains its minimum on the compact slice S₁.
+      obtain ⟨m, hm_mem, hmmin⟩ :=
+        hS1_compact.exists_isMinOn hS1_nonempty hcont.continuousOn
+      obtain ⟨hmP_m, hmle_one⟩ := hm_mem
+      -- The minimum value is ≤ v(N): if ∑m > v(N), `hb_strict` with half the slack
+      -- yields `y ∈ P` with ∑y < ∑m ≤ v(N)+1 (so `y ∈ S₁`), contradicting minimality.
+      have hle : ∑ i : N, m i ≤ G.v Finset.univ := by
+        by_cases h : ∑ i : N, m i ≤ G.v Finset.univ
+        · exact h
+        · exfalso
+          simp only [not_le] at h
+          have heps : 0 < (∑ i : N, m i - G.v Finset.univ) / 2 := half_pos (by linarith)
+          obtain ⟨y, hyP, hyle⟩ := hb_strict _ heps
+          have hyS1 : y ∈ S₁ := ⟨hyP, by linarith⟩
+          have hminOn : ∀ z, z ∈ S₁ → ∑ i : N, m i ≤ ∑ i : N, z i := hmmin
+          have hmin_le : ∑ i : N, m i ≤ ∑ i : N, y i := hminOn y hyS1
+          linarith
+      exact ⟨m, hmP_m, hle⟩
     obtain ⟨x, hxP, hxle⟩ := hb_witness
     refine ⟨x, ?_, hxP⟩
     have hxge : ∑ i : N, x i ≥ G.v Finset.univ := hP_lb x hxP


### PR DESCRIPTION
## Summary

Resolves the **residual `hb_witness` sorry** in `bondareva_shapley_backward` — the single remaining sorry that merged skeleton **#2959** explicitly scoped and documented as *"the only remaining sorry, the LP-dual content of `G.Balanced` (Bondareva hyperplane-separation step)"*. **The iff theorem `bondareva_shapley : G.Core.Nonempty ↔ G.Balanced` is now fully proven, sorry-free.**

### Attainment strategy — compact-slice Weierstrass

From `hb_strict : ∀ t > 0, ∃ x ∈ P, ∑ x ≤ v(N) + t`, conclude `∃ x ∈ P, ∑ x ≤ v(N)` via the sublevel slice `S₁ = { x ∈ P | ∑ x ≤ v(N)+1 }`:

- **closed** — `P ∩ (continuous ∑xᵢ) ⁻¹' Iic`, via `hP_closed.inter (IsClosed.preimage hcont isClosed_Iic)`
- **compact** — closed subset of the compact box `∏ᵢ Icc (v({i})) (v(N)+1 − v(N∖{i}))` (singletons bound `xᵢ` below; complement coalitions bound `xᵢ` above), via `isCompact_univ_pi` + `IsCompact.of_isClosed_subset`
- **nonempty** — `hb_strict` at `t = 1`
- By `IsCompact.exists_isMinOn`, `∑x` attains its min `m ∈ S₁`. If `∑m > v(N)`, `hb_strict` at half-slack gives `y ∈ S₁` with `∑y < ∑m`, contradicting minimality → `∑m ≤ v(N)`.

This combines with the already-merged lineage on `main`: ConeKernel (#3933, 0-sorry) + separator bridge (#3941) + decoding core (#3945) + `hb_strict` wiring (#3951) + `hK_empty`. **Backward direction complete.**

## Anti-régression evidence (rule D)

- **sorry count `Basic.lean`: 1 → 0** (the scoped `hb_witness` sorry is now PROVEN, not removed/regressed)
- `git diff --stat`: 1 file, **+61 / −7** (the 7 deletions = old sorry block + dead comment; 61 insertions = the compact-slice proof)
- No `admit`, no new `axiom` declarations (proof integrity clean)
- **Anti-régression satisfied**: replaced a sorry *with a complete proof*, after 3+ tactic adaptations (`le_or_lt`→`by_cases`, `not_lt_of_le`→`linarith`, `IsMinOn` def-coercion) — every replacement is more proof content, never less.

## Pre-merge gate — §B Lean evidence (HARD)

1. **`grep -c sorry` before/after (Basic.lean):** before `1`, after `0`. Full-package sorry audit: **0 real sorry** (lone grep hit is ConeKernel.lean:29 docstring narrative; build log emits **zero** "uses 'sorry'" warnings).
2. **`Lake build SUCCESS`:** full package, **8435 jobs, `rc=0`, 0 errors** (`grep -c '^error:' = 0`). Genuine recompile (`.olean` mtime 1782151481 > source 1782151447 after `rm` of stale artifacts).
3. **Proof integrity:** no `admit`, no `axiom` (grep clean across `CooperativeGames/`).
4. **Prover Python refactor:** N/A (pure Lean proof addition, no `prover/` change).

## Files

- `MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean` (+61/−7)

See #2959

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>