### PR TITLE
fix(probas-infer): scrub machine-local paths from Decision notebook outputs (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Decision-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Decision-Utility-Foundations.ipynb
@@ -1001,7 +1001,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -1018,7 +1018,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_02_45_53_59.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_02_45_53_59.gv\"\n",
       "\r\n"
      ]
     },
@@ -2009,7 +2009,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2026,7 +2026,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_02_45_54_64.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_02_45_54_64.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-15-Decision-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-15-Decision-Utility-Money.ipynb
@@ -3496,7 +3496,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -3513,7 +3513,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_03_45_50_20.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_03_45_50_20.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Decision-Networks.ipynb
@@ -2196,7 +2196,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2213,7 +2213,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_51_39.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_51_39.gv\"\n",
       "\r\n"
      ]
     },
@@ -2533,7 +2533,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -2550,7 +2550,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_52_00.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_52_00.gv\"\n",
       "\r\n"
      ]
     },
@@ -3572,7 +3572,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -3589,7 +3589,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_54_20.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_54_20.gv\"\n",
       "\r\n"
      ]
     },
@@ -3618,7 +3618,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -3635,7 +3635,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_54_35.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_54_35.gv\"\n",
       "\r\n"
      ]
     },
@@ -3664,7 +3664,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -3681,7 +3681,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_54_51.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_04_45_54_51.gv\"\n",
       "\r\n"
      ]
     },

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-20-Decision-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-20-Decision-Sequential.ipynb
@@ -3320,7 +3320,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory '<repo>MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
       "\r\n"
      ]
     },
@@ -3337,7 +3337,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_MaintenancePOMDP_06_20_26_05_54_22_61.gv\"\n",
+      "DOT file is saved to \"<repo>MyIA.AI.Notebooks\\Probas\\Infer\\Model_MaintenancePOMDP_06_20_26_05_54_22_61.gv\"\n",
       "\r\n"
      ]
     },


### PR DESCRIPTION
## Summary

Batch **2/2** of the Probas/Infer env-noise scrub (after #3953 covered Infer-1..12). Text-surgical scrub of absolute machine-local paths (`D:\dev\CoursIA-2\...`) leaked into **cell outputs** (Graphviz `dot` working-dir + .gv save messages) across the 4 Decision-* notebooks.

- **Files**: Infer-14/15/17/20 (Decision-Utility-Foundations, -Money, -Networks, -Sequential), 18 occurrences → `<repo>`
- **Scope**: output text only. `metadata.papermill` already clean; source cells unchanged; diff 18+/18- (strictly 1:1 path substitutions)
- **Tool**: `scripts/notebook_tools/scrub_papermill_paths.py --apply <nb> --outputs` (#3435), `indent=1` preserved

ML.Net (ML-2/4/5, 3 nb) handled in a separate PR (domain split, G.4).

See #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)