### PR TITLE
fix(ml.net): scrub machine-local paths from notebook outputs (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
@@ -251,7 +251,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "taxi-fare.csv trouvé ici : C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\ML\\ML.Net\\taxi-fare.csv\r\n"
+      "taxi-fare.csv trouvé ici : <repo>MyIA.AI.Notebooks\\ML\\ML.Net\\taxi-fare.csv\r\n"
      ]
     },
     {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
@@ -220,7 +220,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "taxi-fare.csv found here: C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\ML\\ML.Net\\taxi-fare.csv\r\n"
+     "text": "taxi-fare.csv found here: <repo>MyIA.AI.Notebooks\\ML\\ML.Net\\taxi-fare.csv\r\n"
     },
     {
      "output_type": "stream",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
@@ -229,7 +229,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Chargement des données depuis C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\ML\\ML.Net\\daily-sales.csv\r\n"
+     "text": "Chargement des données depuis <repo>MyIA.AI.Notebooks\\ML\\ML.Net\\daily-sales.csv\r\n"
     },
     {
      "output_type": "stream",


### PR DESCRIPTION
## Summary

Text-surgical scrub of absolute machine-local **dataset paths** (`C:\dev\CoursIA-2\...`, `C:\dev\CoursIA\...`) leaked into 'taxi-fare.csv found here' / 'loading from daily-sales.csv' messages in **cell outputs** across 3 ML.NET notebooks.

- **Files**: ML-2-Data&Features, ML-4-Evaluation, ML-5-TimeSeries (3 occurrences) → `<repo>`
- **Scope**: output text only. `metadata.papermill` already clean; source cells unchanged; diff 3+/3- (strictly 1:1 path substitutions)
- **Tool**: `scripts/notebook_tools/scrub_papermill_paths.py --apply <nb> --outputs` (#3435), `indent=1` preserved

**Completes the po-2025 partition** of the #3436 env-noise scrub: Probas/Infer (#3953 Infer-1..12 + #3955 Decision-* 14/15/17/20) + ML.Net (this PR). Remaining repo-wide #3436 metadata.papermill paths belong to other lanes (SymbolicAI=8, QuantConnect=1, IIT=1).

See #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)