### PR TITLE
fix(iit): scrub machine-local paths from PyPhi notebook (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/Intro_to_PyPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/Intro_to_PyPhi.ipynb
@@ -121,20 +121,20 @@
      "output_type": "stream",
      "text": [
       "Requirement already satisfied: pyphi in C:\\ProgramData\\miniconda3\\Lib\\site-packages (1.2.0)\n",
-      "Requirement already satisfied: decorator>=4.0.0 in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (5.2.1)\n",
-      "Requirement already satisfied: joblib>=0.8.0 in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (1.5.2)\n",
+      "Requirement already satisfied: decorator>=4.0.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (5.2.1)\n",
+      "Requirement already satisfied: joblib>=0.8.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (1.5.2)\n",
       "Requirement already satisfied: numpy>=1.11.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (2.2.6)\n",
       "Requirement already satisfied: psutil>=2.1.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (7.2.2)\n",
       "Requirement already satisfied: pyemd>=0.3.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (2.0.0)\n",
       "Requirement already satisfied: pymongo>=2.7.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (4.17.0)\n",
       "Requirement already satisfied: pyyaml>=3.13 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (6.0.3)\n",
       "Requirement already satisfied: redis>=2.10.5 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (7.1.1)\n",
-      "Requirement already satisfied: scipy>=0.13.3 in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (1.17.0)\n",
+      "Requirement already satisfied: scipy>=0.13.3 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (1.17.0)\n",
       "Requirement already satisfied: tblib>=1.3.2 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (3.2.2)\n",
       "Requirement already satisfied: tqdm>=4.20.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (4.67.3)\n",
       "Requirement already satisfied: pot>=0.9.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyemd>=0.3.0->pyphi) (0.9.6.post1)\n",
-      "Requirement already satisfied: dnspython<3.0.0,>=2.6.1 in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from pymongo>=2.7.1->pyphi) (2.7.0)\n",
-      "Requirement already satisfied: colorama in C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages (from tqdm>=4.20.0->pyphi) (0.4.6)\n"
+      "Requirement already satisfied: dnspython<3.0.0,>=2.6.1 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from pymongo>=2.7.1->pyphi) (2.7.0)\n",
+      "Requirement already satisfied: colorama in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from tqdm>=4.20.0->pyphi) (0.4.6)\n"
      ]
     }
    ],
@@ -1522,8 +1522,8 @@
    "end_time": "2026-06-15T05:30:36.038340",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/dev/CoursIA/MyIA.AI.Notebooks/IIT/Intro_to_PyPhi.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/iit_unify2_1781501376/Intro_to_PyPhi.smoke.ipynb",
+   "input_path": "Intro_to_PyPhi.ipynb",
+   "output_path": "Intro_to_PyPhi.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T05:29:40.020721",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

Text-surgical scrub of absolute machine-local paths in `IIT/Intro_to_PyPhi.ipynb` (Python-family / IIT):
- **`metadata.papermill`**: `input_path` (`d:/dev/CoursIA/...`) + `output_path` (`C:/Users/jsboi/AppData/Local/Temp/...`)
- **output text**: pip 'Requirement already satisfied: ... in `C:\Users\jsboi\AppData\Roaming\...`' → `~\AppData\...` home-dir redaction

- **Files**: 1 notebook, 2 papermill paths + 1 output leak, diff 7+/7- (strictly 1:1 substitutions)
- **Tool**: `scripts/notebook_tools/scrub_papermill_paths.py` (`--apply` + `--apply --outputs`, #3435), `indent=1` preserved; source cells unchanged

**Closes the po-2025 Python-family partition of #3436** (Probas/Infer: #3953 + #3955; ML.Net: #3956; IIT: this PR). Remaining repo-wide metadata.papermill hits belong to other lanes: SymbolicAI=8 (po-2026), QuantConnect=1 (po-2024).

See #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)