### PR TITLE
fix(probas-infer): re-execute core Infer notebooks 1-12 with Graphviz — real SVG factor graphs (supersedes #3952 #3953)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
@@ -5,10 +5,10 @@
    "id": "ab8b7b64",
    "metadata": {
     "papermill": {
-     "duration": 0.060643,
-     "end_time": "2026-06-09T04:39:15.072898",
+     "duration": 0.003685,
+     "end_time": "2026-06-22T19:14:45.600100",
      "exception": false,
-     "start_time": "2026-06-09T04:39:15.012255",
+     "start_time": "2026-06-22T19:14:45.596415",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "42dba707",
    "metadata": {
     "papermill": {
-     "duration": 0.004182,
-     "end_time": "2026-06-09T04:39:15.081434",
+     "duration": 0.003065,
+     "end_time": "2026-06-22T19:14:45.606740",
      "exception": false,
-     "start_time": "2026-06-09T04:39:15.077252",
+     "start_time": "2026-06-22T19:14:45.603675",
      "status": "completed"
     },
     "tags": []
@@ -90,10 +90,10 @@
    "id": "01b459aa",
    "metadata": {
     "papermill": {
-     "duration": 0.00385,
-     "end_time": "2026-06-09T04:39:15.089132",
+     "duration": 0.003663,
+     "end_time": "2026-06-22T19:14:45.613461",
      "exception": false,
-     "start_time": "2026-06-09T04:39:15.085282",
+     "start_time": "2026-06-22T19:14:45.609798",
      "status": "completed"
     },
     "tags": []
@@ -132,10 +132,10 @@
    "id": "5b34e453",
    "metadata": {
     "papermill": {
-     "duration": 0.003784,
-     "end_time": "2026-06-09T04:39:15.096923",
+     "duration": 0.002847,
+     "end_time": "2026-06-22T19:14:45.619509",
      "exception": false,
-     "start_time": "2026-06-09T04:39:15.093139",
+     "start_time": "2026-06-22T19:14:45.616662",
      "status": "completed"
     },
     "tags": []
@@ -158,19 +158,19 @@
    "id": "cr1bl8bp3a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:15.112500Z",
-     "iopub.status.busy": "2026-06-09T04:39:15.107559Z",
-     "iopub.status.idle": "2026-06-09T04:39:16.377317Z",
-     "shell.execute_reply": "2026-06-09T04:39:16.375311Z"
+     "iopub.execute_input": "2026-06-22T19:14:45.632472Z",
+     "iopub.status.busy": "2026-06-22T19:14:45.629471Z",
+     "iopub.status.idle": "2026-06-22T19:14:46.695799Z",
+     "shell.execute_reply": "2026-06-22T19:14:46.693716Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 1.277732,
-     "end_time": "2026-06-09T04:39:16.377317",
+     "duration": 1.073242,
+     "end_time": "2026-06-22T19:14:46.695799",
      "exception": false,
-     "start_time": "2026-06-09T04:39:15.099585",
+     "start_time": "2026-06-22T19:14:45.622557",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -180,10 +180,132 @@
    },
    "outputs": [
     {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-78756.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '78756.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Graphviz non disponible (optionnel pour visualisation)\r\n"
+      "Graphviz configure : C:\\Program Files\\Graphviz\\bin\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification OK : dot - graphviz version 14.1.3 (20260303.0454)\r\n"
      ]
     }
    ],
@@ -245,10 +367,10 @@
    "id": "b85npb17cng",
    "metadata": {
     "papermill": {
-     "duration": 0.004131,
-     "end_time": "2026-06-09T04:39:16.387217",
+     "duration": 0.007321,
+     "end_time": "2026-06-22T19:14:46.709876",
      "exception": false,
-     "start_time": "2026-06-09T04:39:16.383086",
+     "start_time": "2026-06-22T19:14:46.702555",
      "status": "completed"
     },
     "tags": []
@@ -277,16 +399,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:16.392702Z",
-     "iopub.status.busy": "2026-06-09T04:39:16.392702Z",
-     "iopub.status.idle": "2026-06-09T04:39:19.276135Z",
-     "shell.execute_reply": "2026-06-09T04:39:19.276135Z"
+     "iopub.execute_input": "2026-06-22T19:14:46.726235Z",
+     "iopub.status.busy": "2026-06-22T19:14:46.725714Z",
+     "iopub.status.idle": "2026-06-22T19:14:48.273742Z",
+     "shell.execute_reply": "2026-06-22T19:14:48.273742Z"
     },
     "papermill": {
-     "duration": 2.887173,
-     "end_time": "2026-06-09T04:39:19.276135",
+     "duration": 1.556375,
+     "end_time": "2026-06-22T19:14:48.273742",
      "exception": false,
-     "start_time": "2026-06-09T04:39:16.388962",
+     "start_time": "2026-06-22T19:14:46.717367",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -316,10 +438,10 @@
    "id": "a8b9fff5",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:19.282032",
+     "duration": 0.006999,
+     "end_time": "2026-06-22T19:14:48.287867",
      "exception": false,
-     "start_time": "2026-06-09T04:39:19.282032",
+     "start_time": "2026-06-22T19:14:48.280868",
      "status": "completed"
     },
     "tags": []
@@ -337,16 +459,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:19.293231Z",
-     "iopub.status.busy": "2026-06-09T04:39:19.293231Z",
-     "iopub.status.idle": "2026-06-09T04:39:19.304881Z",
-     "shell.execute_reply": "2026-06-09T04:39:19.304881Z"
+     "iopub.execute_input": "2026-06-22T19:14:48.301167Z",
+     "iopub.status.busy": "2026-06-22T19:14:48.301167Z",
+     "iopub.status.idle": "2026-06-22T19:14:48.355152Z",
+     "shell.execute_reply": "2026-06-22T19:14:48.354642Z"
     },
     "papermill": {
-     "duration": 0.022849,
-     "end_time": "2026-06-09T04:39:19.304881",
+     "duration": 0.061283,
+     "end_time": "2026-06-22T19:14:48.355152",
      "exception": false,
-     "start_time": "2026-06-09T04:39:19.282032",
+     "start_time": "2026-06-22T19:14:48.293869",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -413,10 +535,10 @@
    "id": "7a9110ca",
    "metadata": {
     "papermill": {
-     "duration": 0.004731,
-     "end_time": "2026-06-09T04:39:19.319488",
+     "duration": 0.006933,
+     "end_time": "2026-06-22T19:14:48.368705",
      "exception": false,
-     "start_time": "2026-06-09T04:39:19.314757",
+     "start_time": "2026-06-22T19:14:48.361772",
      "status": "completed"
     },
     "tags": []
@@ -431,19 +553,19 @@
    "id": "cs20ulzhlng",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:19.324478Z",
-     "iopub.status.busy": "2026-06-09T04:39:19.324478Z",
-     "iopub.status.idle": "2026-06-09T04:39:19.576503Z",
-     "shell.execute_reply": "2026-06-09T04:39:19.576503Z"
+     "iopub.execute_input": "2026-06-22T19:14:48.383046Z",
+     "iopub.status.busy": "2026-06-22T19:14:48.382529Z",
+     "iopub.status.idle": "2026-06-22T19:14:48.895085Z",
+     "shell.execute_reply": "2026-06-22T19:14:48.895085Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.257015,
-     "end_time": "2026-06-09T04:39:19.576503",
+     "duration": 0.520244,
+     "end_time": "2026-06-22T19:14:48.895085",
      "exception": false,
-     "start_time": "2026-06-09T04:39:19.319488",
+     "start_time": "2026-06-22T19:14:48.374841",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -481,10 +603,10 @@
    "id": "dp1aijv9ox7",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:19.592582",
+     "duration": 0.007219,
+     "end_time": "2026-06-22T19:14:48.909906",
      "exception": false,
-     "start_time": "2026-06-09T04:39:19.592582",
+     "start_time": "2026-06-22T19:14:48.902687",
      "status": "completed"
     },
     "tags": []
@@ -510,10 +632,10 @@
    "id": "92dccdbd",
    "metadata": {
     "papermill": {
-     "duration": 0.003826,
-     "end_time": "2026-06-09T04:39:19.605564",
+     "duration": 0.007061,
+     "end_time": "2026-06-22T19:14:48.925197",
      "exception": false,
-     "start_time": "2026-06-09T04:39:19.601738",
+     "start_time": "2026-06-22T19:14:48.918136",
      "status": "completed"
     },
     "tags": []
@@ -541,16 +663,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:19.610807Z",
-     "iopub.status.busy": "2026-06-09T04:39:19.610807Z",
-     "iopub.status.idle": "2026-06-09T04:39:22.280444Z",
-     "shell.execute_reply": "2026-06-09T04:39:22.280444Z"
+     "iopub.execute_input": "2026-06-22T19:14:48.942700Z",
+     "iopub.status.busy": "2026-06-22T19:14:48.942181Z",
+     "iopub.status.idle": "2026-06-22T19:14:50.457228Z",
+     "shell.execute_reply": "2026-06-22T19:14:50.457228Z"
     },
     "papermill": {
-     "duration": 2.669637,
-     "end_time": "2026-06-09T04:39:22.280444",
+     "duration": 1.523759,
+     "end_time": "2026-06-22T19:14:50.457228",
      "exception": false,
-     "start_time": "2026-06-09T04:39:19.610807",
+     "start_time": "2026-06-22T19:14:48.933469",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -601,10 +723,10 @@
    "id": "j1nrzm34c2f",
    "metadata": {
     "papermill": {
-     "duration": 0.000515,
-     "end_time": "2026-06-09T04:39:22.288101",
+     "duration": 0.008085,
+     "end_time": "2026-06-22T19:14:50.473314",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.287586",
+     "start_time": "2026-06-22T19:14:50.465229",
      "status": "completed"
     },
     "tags": []
@@ -628,10 +750,10 @@
    "id": "7d81c7cb",
    "metadata": {
     "papermill": {
-     "duration": 0.002462,
-     "end_time": "2026-06-09T04:39:22.298107",
+     "duration": 0.006864,
+     "end_time": "2026-06-22T19:14:50.487399",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.295645",
+     "start_time": "2026-06-22T19:14:50.480535",
      "status": "completed"
     },
     "tags": []
@@ -677,10 +799,10 @@
    "id": "3b0d2370",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:22.301834",
+     "duration": 0.007736,
+     "end_time": "2026-06-22T19:14:50.501668",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.301834",
+     "start_time": "2026-06-22T19:14:50.493932",
      "status": "completed"
     },
     "tags": []
@@ -709,16 +831,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:22.313610Z",
-     "iopub.status.busy": "2026-06-09T04:39:22.313610Z",
-     "iopub.status.idle": "2026-06-09T04:39:22.351058Z",
-     "shell.execute_reply": "2026-06-09T04:39:22.350058Z"
+     "iopub.execute_input": "2026-06-22T19:14:50.517563Z",
+     "iopub.status.busy": "2026-06-22T19:14:50.517563Z",
+     "iopub.status.idle": "2026-06-22T19:14:50.566835Z",
+     "shell.execute_reply": "2026-06-22T19:14:50.566835Z"
     },
     "papermill": {
-     "duration": 0.039375,
-     "end_time": "2026-06-09T04:39:22.351058",
+     "duration": 0.056918,
+     "end_time": "2026-06-22T19:14:50.566835",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.311683",
+     "start_time": "2026-06-22T19:14:50.509917",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -758,10 +880,10 @@
    "id": "hifwis3sou8",
    "metadata": {
     "papermill": {
-     "duration": 0.003573,
-     "end_time": "2026-06-09T04:39:22.359160",
+     "duration": 0.004166,
+     "end_time": "2026-06-22T19:14:50.575001",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.355587",
+     "start_time": "2026-06-22T19:14:50.570835",
      "status": "completed"
     },
     "tags": []
@@ -791,10 +913,10 @@
    "id": "952806dd",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:22.361356",
+     "duration": 0.003002,
+     "end_time": "2026-06-22T19:14:50.581995",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.361356",
+     "start_time": "2026-06-22T19:14:50.578993",
      "status": "completed"
     },
     "tags": []
@@ -810,10 +932,10 @@
    "id": "kp3m20jmh8",
    "metadata": {
     "papermill": {
-     "duration": 0.006018,
-     "end_time": "2026-06-09T04:39:22.378433",
+     "duration": 0.003,
+     "end_time": "2026-06-22T19:14:50.588995",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.372415",
+     "start_time": "2026-06-22T19:14:50.585995",
      "status": "completed"
     },
     "tags": []
@@ -840,16 +962,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:22.388321Z",
-     "iopub.status.busy": "2026-06-09T04:39:22.388321Z",
-     "iopub.status.idle": "2026-06-09T04:39:22.839244Z",
-     "shell.execute_reply": "2026-06-09T04:39:22.839244Z"
+     "iopub.execute_input": "2026-06-22T19:14:50.621028Z",
+     "iopub.status.busy": "2026-06-22T19:14:50.621028Z",
+     "iopub.status.idle": "2026-06-22T19:14:51.142215Z",
+     "shell.execute_reply": "2026-06-22T19:14:51.142215Z"
     },
     "papermill": {
-     "duration": 0.457112,
-     "end_time": "2026-06-09T04:39:22.839244",
+     "duration": 0.54922,
+     "end_time": "2026-06-22T19:14:51.142215",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.382132",
+     "start_time": "2026-06-22T19:14:50.592995",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -930,10 +1052,10 @@
    "id": "12e14487",
    "metadata": {
     "papermill": {
-     "duration": 0.003998,
-     "end_time": "2026-06-09T04:39:22.848248",
+     "duration": 0.008,
+     "end_time": "2026-06-22T19:14:51.157641",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.844250",
+     "start_time": "2026-06-22T19:14:51.149641",
      "status": "completed"
     },
     "tags": []
@@ -948,19 +1070,19 @@
    "id": "1j3d7ypvqqb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:22.857785Z",
-     "iopub.status.busy": "2026-06-09T04:39:22.857785Z",
-     "iopub.status.idle": "2026-06-09T04:39:23.109731Z",
-     "shell.execute_reply": "2026-06-09T04:39:23.109731Z"
+     "iopub.execute_input": "2026-06-22T19:14:51.172929Z",
+     "iopub.status.busy": "2026-06-22T19:14:51.171923Z",
+     "iopub.status.idle": "2026-06-22T19:14:51.801955Z",
+     "shell.execute_reply": "2026-06-22T19:14:51.801955Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.256482,
-     "end_time": "2026-06-09T04:39:23.109731",
+     "duration": 0.638524,
+     "end_time": "2026-06-22T19:14:51.801955",
      "exception": false,
-     "start_time": "2026-06-09T04:39:22.853249",
+     "start_time": "2026-06-22T19:14:51.163431",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -969,38 +1091,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_09_26_06_39_22_92.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1025,10 +1115,82 @@
     {
      "data": {
       "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_06_09_26_06_39_22_92.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_14_51_25.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
+       "<!-- Generated by graphviz version 14.1.3 (20260303.0454)\r\n",
+       " -->\r\n",
+       "<!-- Title: Model Pages: 1 -->\r\n",
+       "<svg width=\"98pt\" height=\"354pt\"\r\n",
+       " viewBox=\"0.00 0.00 98.00 354.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 349.5)\">\r\n",
+       "<title>Model</title>\r\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-349.5 94.25,-349.5 94.25,4 -4,4\"/>\r\n",
+       "<!-- node0 -->\r\n",
+       "<g id=\"node1\" class=\"node\">\r\n",
+       "<title>node0</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M78.25,-345.5C78.25,-345.5 12,-345.5 12,-345.5 6,-345.5 0,-339.5 0,-333.5 0,-333.5 0,-321.5 0,-321.5 0,-315.5 6,-309.5 12,-309.5 12,-309.5 78.25,-309.5 78.25,-309.5 84.25,-309.5 90.25,-315.5 90.25,-321.5 90.25,-321.5 90.25,-333.5 90.25,-333.5 90.25,-339.5 84.25,-345.5 78.25,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"45.12\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">Beta(1,1)[mean=0,5]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1 -->\r\n",
+       "<g id=\"node2\" class=\"node\">\r\n",
+       "<title>node1</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M60.12,-263.75C60.12,-263.75 30.12,-263.75 30.12,-263.75 24.12,-263.75 18.12,-257.75 18.12,-251.75 18.12,-251.75 18.12,-239.75 18.12,-239.75 18.12,-233.75 24.12,-227.75 30.12,-227.75 30.12,-227.75 60.12,-227.75 60.12,-227.75 66.12,-227.75 72.12,-233.75 72.12,-239.75 72.12,-239.75 72.12,-251.75 72.12,-251.75 72.12,-257.75 66.12,-263.75 60.12,-263.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"45.12\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node0&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge1\" class=\"edge\">\r\n",
+       "<title>node0&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M45.12,-309.59C45.12,-299.68 45.12,-286.9 45.12,-275.46\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"48.63,-275.7 45.13,-265.7 41.63,-275.7 48.63,-275.7\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.75\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2 -->\r\n",
+       "<g id=\"node3\" class=\"node\">\r\n",
+       "<title>node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M60.12,-190.75C60.12,-190.75 30.12,-190.75 30.12,-190.75 24.12,-190.75 18.12,-184.75 18.12,-178.75 18.12,-178.75 18.12,-166.75 18.12,-166.75 18.12,-160.75 24.12,-154.75 30.12,-154.75 30.12,-154.75 60.12,-154.75 60.12,-154.75 66.12,-154.75 72.12,-160.75 72.12,-166.75 72.12,-166.75 72.12,-178.75 72.12,-178.75 72.12,-184.75 66.12,-190.75 60.12,-190.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"45.12\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">biais</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1&#45;&gt;node2 -->\r\n",
+       "<g id=\"edge2\" class=\"edge\">\r\n",
+       "<title>node1&#45;&gt;node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M45.12,-227.56C45.12,-219.98 45.12,-210.85 45.12,-202.29\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"48.63,-202.29 45.13,-192.29 41.63,-202.29 48.63,-202.29\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node3 -->\r\n",
+       "<g id=\"node4\" class=\"node\">\r\n",
+       "<title>node3</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M60.12,-109C60.12,-109 30.12,-109 30.12,-109 24.12,-109 18.12,-103 18.12,-97 18.12,-97 18.12,-85 18.12,-85 18.12,-79 24.12,-73 30.12,-73 30.12,-73 60.12,-73 60.12,-73 66.12,-73 72.12,-79 72.12,-85 72.12,-85 72.12,-97 72.12,-97 72.12,-103 66.12,-109 60.12,-109\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"45.12\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Bernoulli</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge3\" class=\"edge\">\r\n",
+       "<title>node2&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M45.12,-154.45C45.12,-144.52 45.12,-131.81 45.12,-120.45\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"48.63,-120.78 45.13,-110.78 41.63,-120.78 48.63,-120.78\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"59.75\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probTrue</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4 -->\r\n",
+       "<g id=\"node5\" class=\"node\">\r\n",
+       "<title>node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M75.25,-36C75.25,-36 15,-36 15,-36 9,-36 3,-30 3,-24 3,-24 3,-12 3,-12 3,-6 9,0 15,0 15,0 75.25,0 75.25,0 81.25,0 87.25,-6 87.25,-12 87.25,-12 87.25,-24 87.25,-24 87.25,-30 81.25,-36 75.25,-36\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"45.12\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">resultats[lancers]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3&#45;&gt;node4 -->\r\n",
+       "<g id=\"edge4\" class=\"edge\">\r\n",
+       "<title>node3&#45;&gt;node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M45.12,-72.81C45.12,-65.03 45.12,-55.62 45.12,-46.86\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"48.63,-47.05 45.13,-37.05 41.63,-47.05 48.63,-47.05\"/>\r\n",
+       "</g>\r\n",
+       "</g>\r\n",
+       "</svg>\r\n",
+       "\r\n",
+       "    </div>\r\n",
+       "</div>"
       ]
      },
      "metadata": {},
@@ -1039,7 +1201,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1074,10 +1236,10 @@
    "id": "blaktc15im5",
    "metadata": {
     "papermill": {
-     "duration": 0.015223,
-     "end_time": "2026-06-09T04:39:23.124954",
+     "duration": 0.007739,
+     "end_time": "2026-06-22T19:14:51.817693",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.109731",
+     "start_time": "2026-06-22T19:14:51.809954",
      "status": "completed"
     },
     "tags": []
@@ -1115,10 +1277,10 @@
    "id": "c23c8e87",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:23.124954",
+     "duration": 0.007046,
+     "end_time": "2026-06-22T19:14:51.832161",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.124954",
+     "start_time": "2026-06-22T19:14:51.825115",
      "status": "completed"
     },
     "tags": []
@@ -1153,10 +1315,10 @@
    "id": "d42fe2e7",
    "metadata": {
     "papermill": {
-     "duration": 0.004999,
-     "end_time": "2026-06-09T04:39:23.144695",
+     "duration": 0.007008,
+     "end_time": "2026-06-22T19:14:51.847733",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.139696",
+     "start_time": "2026-06-22T19:14:51.840725",
      "status": "completed"
     },
     "tags": []
@@ -1184,10 +1346,10 @@
    "id": "p4eyf2b3his",
    "metadata": {
     "papermill": {
-     "duration": 0.004987,
-     "end_time": "2026-06-09T04:39:23.153696",
+     "duration": 0.009715,
+     "end_time": "2026-06-22T19:14:51.864728",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.148709",
+     "start_time": "2026-06-22T19:14:51.855013",
      "status": "completed"
     },
     "tags": []
@@ -1211,16 +1373,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:23.163797Z",
-     "iopub.status.busy": "2026-06-09T04:39:23.163797Z",
-     "iopub.status.idle": "2026-06-09T04:39:23.399922Z",
-     "shell.execute_reply": "2026-06-09T04:39:23.399922Z"
+     "iopub.execute_input": "2026-06-22T19:14:51.882956Z",
+     "iopub.status.busy": "2026-06-22T19:14:51.882433Z",
+     "iopub.status.idle": "2026-06-22T19:14:52.258290Z",
+     "shell.execute_reply": "2026-06-22T19:14:52.257770Z"
     },
     "papermill": {
-     "duration": 0.242104,
-     "end_time": "2026-06-09T04:39:23.399922",
+     "duration": 0.38705,
+     "end_time": "2026-06-22T19:14:52.258290",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.157818",
+     "start_time": "2026-06-22T19:14:51.871240",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1299,10 +1461,10 @@
    "id": "sh6ls6w113e",
    "metadata": {
     "papermill": {
-     "duration": 0.00444,
-     "end_time": "2026-06-09T04:39:23.409942",
+     "duration": 0.007014,
+     "end_time": "2026-06-22T19:14:52.273496",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.405502",
+     "start_time": "2026-06-22T19:14:52.266482",
      "status": "completed"
     },
     "tags": []
@@ -1333,10 +1495,10 @@
    "id": "88j4a6u22li",
    "metadata": {
     "papermill": {
-     "duration": 0.005344,
-     "end_time": "2026-06-09T04:39:23.419742",
+     "duration": 0.008124,
+     "end_time": "2026-06-22T19:14:52.289621",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.414398",
+     "start_time": "2026-06-22T19:14:52.281497",
      "status": "completed"
     },
     "tags": []
@@ -1385,19 +1547,19 @@
    "id": "5r5yxxb87f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:23.430890Z",
-     "iopub.status.busy": "2026-06-09T04:39:23.430890Z",
-     "iopub.status.idle": "2026-06-09T04:39:23.635780Z",
-     "shell.execute_reply": "2026-06-09T04:39:23.635780Z"
+     "iopub.execute_input": "2026-06-22T19:14:52.308290Z",
+     "iopub.status.busy": "2026-06-22T19:14:52.308290Z",
+     "iopub.status.idle": "2026-06-22T19:14:52.868272Z",
+     "shell.execute_reply": "2026-06-22T19:14:52.868272Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.210919,
-     "end_time": "2026-06-09T04:39:23.635780",
+     "duration": 0.570069,
+     "end_time": "2026-06-22T19:14:52.868272",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.424861",
+     "start_time": "2026-06-22T19:14:52.298203",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1418,22 +1580,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verification Graphviz echouee : An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Graphviz non detecte - les fichiers .gv seront generes\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Visualisez-les sur : https://viz-js.com/\n",
-      "\r\n"
+      "Graphviz disponible : dot - graphviz version 14.1.3 (20260303.0454)\r\n"
      ]
     },
     {
@@ -1455,7 +1602,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2. ShowFactorGraph = true : Genere fichier DOT (SVG si Graphviz disponible)\n",
+      "2. ShowFactorGraph = true : Genere fichier DOT + SVG\n",
       "\r\n"
      ]
     },
@@ -1487,38 +1634,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_09_26_06_39_23_46.gv\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Compiling model..."
      ]
     },
@@ -1527,38 +1642,6 @@
      "output_type": "stream",
      "text": [
       "done.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Task_Graph_06_09_26_06_39_23_48.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -1666,10 +1749,10 @@
    "id": "q2l9lsexdsl",
    "metadata": {
     "papermill": {
-     "duration": 0.005001,
-     "end_time": "2026-06-09T04:39:23.647051",
+     "duration": 0.008,
+     "end_time": "2026-06-22T19:14:52.885275",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.642050",
+     "start_time": "2026-06-22T19:14:52.877275",
      "status": "completed"
     },
     "tags": []
@@ -1704,10 +1787,10 @@
    "id": "1ks1d2mjbd3",
    "metadata": {
     "papermill": {
-     "duration": 0.007906,
-     "end_time": "2026-06-09T04:39:23.659053",
+     "duration": 0.007587,
+     "end_time": "2026-06-22T19:14:52.902368",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.651147",
+     "start_time": "2026-06-22T19:14:52.894781",
      "status": "completed"
     },
     "tags": []
@@ -1756,10 +1839,10 @@
    "id": "3olme3xdb2s",
    "metadata": {
     "papermill": {
-     "duration": 0.004754,
-     "end_time": "2026-06-09T04:39:23.668836",
+     "duration": 0.008,
+     "end_time": "2026-06-22T19:14:52.917368",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.664082",
+     "start_time": "2026-06-22T19:14:52.909368",
      "status": "completed"
     },
     "tags": []
@@ -1779,19 +1862,19 @@
    "id": "nmjji4dj15m",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:23.670695Z",
-     "iopub.status.busy": "2026-06-09T04:39:23.670695Z",
-     "iopub.status.idle": "2026-06-09T04:39:23.761118Z",
-     "shell.execute_reply": "2026-06-09T04:39:23.761118Z"
+     "iopub.execute_input": "2026-06-22T19:14:52.935368Z",
+     "iopub.status.busy": "2026-06-22T19:14:52.935368Z",
+     "iopub.status.idle": "2026-06-22T19:14:53.029089Z",
+     "shell.execute_reply": "2026-06-22T19:14:53.029089Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.090423,
-     "end_time": "2026-06-09T04:39:23.761118",
+     "duration": 0.103721,
+     "end_time": "2026-06-22T19:14:53.029089",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.670695",
+     "start_time": "2026-06-22T19:14:52.925368",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2002,10 +2085,10 @@
    "id": "s86z9cewud",
    "metadata": {
     "papermill": {
-     "duration": 0.009112,
-     "end_time": "2026-06-09T04:39:23.771838",
+     "duration": 0.009,
+     "end_time": "2026-06-22T19:14:53.047089",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.762726",
+     "start_time": "2026-06-22T19:14:53.038089",
      "status": "completed"
     },
     "tags": []
@@ -2039,10 +2122,10 @@
    "id": "aaf08fae",
    "metadata": {
     "papermill": {
-     "duration": 0.006911,
-     "end_time": "2026-06-09T04:39:23.778749",
+     "duration": 0.009001,
+     "end_time": "2026-06-22T19:14:53.064091",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.771838",
+     "start_time": "2026-06-22T19:14:53.055090",
      "status": "completed"
     },
     "tags": []
@@ -2096,10 +2179,10 @@
    "id": "b99140b6",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:23.778749",
+     "duration": 0.009005,
+     "end_time": "2026-06-22T19:14:53.081097",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.778749",
+     "start_time": "2026-06-22T19:14:53.072092",
      "status": "completed"
     },
     "tags": []
@@ -2125,16 +2208,16 @@
    "id": "0dc25f62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:23.794656Z",
-     "iopub.status.busy": "2026-06-09T04:39:23.794656Z",
-     "iopub.status.idle": "2026-06-09T04:39:23.812953Z",
-     "shell.execute_reply": "2026-06-09T04:39:23.812953Z"
+     "iopub.execute_input": "2026-06-22T19:14:53.099836Z",
+     "iopub.status.busy": "2026-06-22T19:14:53.098836Z",
+     "iopub.status.idle": "2026-06-22T19:14:53.131835Z",
+     "shell.execute_reply": "2026-06-22T19:14:53.131835Z"
     },
     "papermill": {
-     "duration": 0.018297,
-     "end_time": "2026-06-09T04:39:23.812953",
+     "duration": 0.042996,
+     "end_time": "2026-06-22T19:14:53.132835",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.794656",
+     "start_time": "2026-06-22T19:14:53.089839",
      "status": "completed"
     },
     "tags": []
@@ -2176,10 +2259,10 @@
    "id": "d78060c4",
    "metadata": {
     "papermill": {
-     "duration": 0.014401,
-     "end_time": "2026-06-09T04:39:23.827354",
+     "duration": 0.010957,
+     "end_time": "2026-06-22T19:14:53.151794",
      "exception": false,
-     "start_time": "2026-06-09T04:39:23.812953",
+     "start_time": "2026-06-22T19:14:53.140837",
      "status": "completed"
     },
     "tags": []
@@ -2217,14 +2300,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 11.006987,
-   "end_time": "2026-06-09T04:39:23.953934",
+   "duration": 9.409278,
+   "end_time": "2026-06-22T19:14:53.403108",
    "environment_variables": {},
    "exception": null,
    "input_path": "Infer-1-Setup.ipynb",
    "output_path": "Infer-1-Setup.ipynb",
    "parameters": {},
-   "start_time": "2026-06-09T04:39:12.946947",
+   "start_time": "2026-06-22T19:14:43.993830",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Crowdsourcing.ipynb
@@ -5,10 +5,10 @@
    "id": "9df317ec",
    "metadata": {
     "papermill": {
-     "duration": 0.022967,
-     "end_time": "2026-06-04T06:28:50.089769",
+     "duration": 0.004507,
+     "end_time": "2026-06-22T19:17:35.765562",
      "exception": false,
-     "start_time": "2026-06-04T06:28:50.066802",
+     "start_time": "2026-06-22T19:17:35.761055",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "8976057b",
    "metadata": {
     "papermill": {
-     "duration": 0.008062,
-     "end_time": "2026-06-04T06:28:50.109114",
+     "duration": 0.003504,
+     "end_time": "2026-06-22T19:17:35.773067",
      "exception": false,
-     "start_time": "2026-06-04T06:28:50.101052",
+     "start_time": "2026-06-22T19:17:35.769563",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:50.143443Z",
-     "iopub.status.busy": "2026-06-04T06:28:50.139060Z",
-     "iopub.status.idle": "2026-06-04T06:28:53.610053Z",
-     "shell.execute_reply": "2026-06-04T06:28:53.606870Z"
+     "iopub.execute_input": "2026-06-22T19:17:35.788652Z",
+     "iopub.status.busy": "2026-06-22T19:17:35.784653Z",
+     "iopub.status.idle": "2026-06-22T19:17:38.357428Z",
+     "shell.execute_reply": "2026-06-22T19:17:38.355146Z"
     },
     "papermill": {
-     "duration": 3.486068,
-     "end_time": "2026-06-04T06:28:53.610195",
+     "duration": 2.579779,
+     "end_time": "2026-06-22T19:17:38.357428",
      "exception": false,
-     "start_time": "2026-06-04T06:28:50.124127",
+     "start_time": "2026-06-22T19:17:35.777649",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -94,7 +94,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-59160.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-42052.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -139,12 +139,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.83.164.85:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '59160.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '42052.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -241,10 +241,10 @@
    "id": "a13f2a97",
    "metadata": {
     "papermill": {
-     "duration": 0.008221,
-     "end_time": "2026-06-04T06:28:53.626200",
+     "duration": 0.007387,
+     "end_time": "2026-06-22T19:17:38.372904",
      "exception": false,
-     "start_time": "2026-06-04T06:28:53.617979",
+     "start_time": "2026-06-22T19:17:38.365517",
      "status": "completed"
     },
     "tags": []
@@ -259,16 +259,16 @@
    "id": "n6bnokfm66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:53.652683Z",
-     "iopub.status.busy": "2026-06-04T06:28:53.652342Z",
-     "iopub.status.idle": "2026-06-04T06:28:54.259605Z",
-     "shell.execute_reply": "2026-06-04T06:28:54.259270Z"
+     "iopub.execute_input": "2026-06-22T19:17:38.388392Z",
+     "iopub.status.busy": "2026-06-22T19:17:38.388392Z",
+     "iopub.status.idle": "2026-06-22T19:17:38.998677Z",
+     "shell.execute_reply": "2026-06-22T19:17:38.998677Z"
     },
     "papermill": {
-     "duration": 0.622487,
-     "end_time": "2026-06-04T06:28:54.259719",
+     "duration": 0.619275,
+     "end_time": "2026-06-22T19:17:38.998677",
      "exception": false,
-     "start_time": "2026-06-04T06:28:53.637232",
+     "start_time": "2026-06-22T19:17:38.379402",
      "status": "completed"
     },
     "tags": [],
@@ -297,10 +297,10 @@
    "id": "b4d27yfblwm",
    "metadata": {
     "papermill": {
-     "duration": 0.011265,
-     "end_time": "2026-06-04T06:28:54.281378",
+     "duration": 0.007137,
+     "end_time": "2026-06-22T19:17:39.013822",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.270113",
+     "start_time": "2026-06-22T19:17:39.006685",
      "status": "completed"
     },
     "tags": []
@@ -314,10 +314,10 @@
    "id": "vby8bp601ke",
    "metadata": {
     "papermill": {
-     "duration": 0.008355,
-     "end_time": "2026-06-04T06:28:54.297578",
+     "duration": 0.006161,
+     "end_time": "2026-06-22T19:17:39.027411",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.289223",
+     "start_time": "2026-06-22T19:17:39.021250",
      "status": "completed"
     },
     "tags": []
@@ -331,10 +331,10 @@
    "id": "4daaeec0",
    "metadata": {
     "papermill": {
-     "duration": 0.008068,
-     "end_time": "2026-06-04T06:28:54.314275",
+     "duration": 0.007352,
+     "end_time": "2026-06-22T19:17:39.042493",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.306207",
+     "start_time": "2026-06-22T19:17:39.035141",
      "status": "completed"
     },
     "tags": []
@@ -367,10 +367,10 @@
    "id": "jql66bz67ba",
    "metadata": {
     "papermill": {
-     "duration": 0.010723,
-     "end_time": "2026-06-04T06:28:54.332510",
+     "duration": 0.008983,
+     "end_time": "2026-06-22T19:17:39.060646",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.321787",
+     "start_time": "2026-06-22T19:17:39.051663",
      "status": "completed"
     },
     "tags": []
@@ -401,10 +401,10 @@
    "id": "135fb091",
    "metadata": {
     "papermill": {
-     "duration": 0.011217,
-     "end_time": "2026-06-04T06:28:54.355062",
+     "duration": 0.00856,
+     "end_time": "2026-06-22T19:17:39.084205",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.343845",
+     "start_time": "2026-06-22T19:17:39.075645",
      "status": "completed"
     },
     "tags": []
@@ -431,10 +431,10 @@
    "id": "58a8t2yac3",
    "metadata": {
     "papermill": {
-     "duration": 0.009931,
-     "end_time": "2026-06-04T06:28:54.377239",
+     "duration": 0.007526,
+     "end_time": "2026-06-22T19:17:39.102134",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.367308",
+     "start_time": "2026-06-22T19:17:39.094608",
      "status": "completed"
     },
     "tags": []
@@ -485,16 +485,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:54.396392Z",
-     "iopub.status.busy": "2026-06-04T06:28:54.395739Z",
-     "iopub.status.idle": "2026-06-04T06:28:54.546550Z",
-     "shell.execute_reply": "2026-06-04T06:28:54.542058Z"
+     "iopub.execute_input": "2026-06-22T19:17:39.126565Z",
+     "iopub.status.busy": "2026-06-22T19:17:39.126565Z",
+     "iopub.status.idle": "2026-06-22T19:17:39.238883Z",
+     "shell.execute_reply": "2026-06-22T19:17:39.235877Z"
     },
     "papermill": {
-     "duration": 0.161427,
-     "end_time": "2026-06-04T06:28:54.546654",
+     "duration": 0.126348,
+     "end_time": "2026-06-22T19:17:39.238883",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.385227",
+     "start_time": "2026-06-22T19:17:39.112535",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -817,10 +817,10 @@
    "id": "7ie7hg4819q",
    "metadata": {
     "papermill": {
-     "duration": 0.010312,
-     "end_time": "2026-06-04T06:28:54.566078",
+     "duration": 0.009771,
+     "end_time": "2026-06-22T19:17:39.258676",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.555766",
+     "start_time": "2026-06-22T19:17:39.248905",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +846,10 @@
    "id": "69h3le9i0bd",
    "metadata": {
     "papermill": {
-     "duration": 0.009975,
-     "end_time": "2026-06-04T06:28:54.585537",
+     "duration": 0.008161,
+     "end_time": "2026-06-22T19:17:39.275838",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.575562",
+     "start_time": "2026-06-22T19:17:39.267677",
      "status": "completed"
     },
     "tags": []
@@ -872,16 +872,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:54.615696Z",
-     "iopub.status.busy": "2026-06-04T06:28:54.615338Z",
-     "iopub.status.idle": "2026-06-04T06:28:57.980335Z",
-     "shell.execute_reply": "2026-06-04T06:28:57.977834Z"
+     "iopub.execute_input": "2026-06-22T19:17:39.295865Z",
+     "iopub.status.busy": "2026-06-22T19:17:39.295865Z",
+     "iopub.status.idle": "2026-06-22T19:17:41.424129Z",
+     "shell.execute_reply": "2026-06-22T19:17:41.423136Z"
     },
     "papermill": {
-     "duration": 3.376227,
-     "end_time": "2026-06-04T06:28:57.980485",
+     "duration": 2.138264,
+     "end_time": "2026-06-22T19:17:41.424129",
      "exception": false,
-     "start_time": "2026-06-04T06:28:54.604258",
+     "start_time": "2026-06-22T19:17:39.285865",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -893,38 +893,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_23_47_05_98.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1435,10 +1403,10 @@
    "id": "5ezctf7vo4s",
    "metadata": {
     "papermill": {
-     "duration": 0.018176,
-     "end_time": "2026-06-04T06:28:58.012771",
+     "duration": 0.013973,
+     "end_time": "2026-06-22T19:17:41.450122",
      "exception": false,
-     "start_time": "2026-06-04T06:28:57.994595",
+     "start_time": "2026-06-22T19:17:41.436149",
      "status": "completed"
     },
     "tags": []
@@ -1476,16 +1444,16 @@
    "id": "6ujpksjkwvb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:58.058887Z",
-     "iopub.status.busy": "2026-06-04T06:28:58.058554Z",
-     "iopub.status.idle": "2026-06-04T06:28:58.156581Z",
-     "shell.execute_reply": "2026-06-04T06:28:58.156766Z"
+     "iopub.execute_input": "2026-06-22T19:17:41.478468Z",
+     "iopub.status.busy": "2026-06-22T19:17:41.477955Z",
+     "iopub.status.idle": "2026-06-22T19:17:41.603751Z",
+     "shell.execute_reply": "2026-06-22T19:17:41.603751Z"
     },
     "papermill": {
-     "duration": 0.126559,
-     "end_time": "2026-06-04T06:28:58.156869",
+     "duration": 0.141736,
+     "end_time": "2026-06-22T19:17:41.603751",
      "exception": false,
-     "start_time": "2026-06-04T06:28:58.030310",
+     "start_time": "2026-06-22T19:17:41.462015",
      "status": "completed"
     },
     "tags": [],
@@ -1497,14 +1465,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_23_47_05_98.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_17_39_60.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"269pt\" height=\"453pt\"\r\n",
@@ -1658,8 +1626,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1671,7 +1639,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1686,10 +1654,10 @@
    "id": "ckyzp6u7hi",
    "metadata": {
     "papermill": {
-     "duration": 0.012866,
-     "end_time": "2026-06-04T06:28:58.183313",
+     "duration": 0.016,
+     "end_time": "2026-06-22T19:17:41.626744",
      "exception": false,
-     "start_time": "2026-06-04T06:28:58.170447",
+     "start_time": "2026-06-22T19:17:41.610744",
      "status": "completed"
     },
     "tags": []
@@ -1719,10 +1687,10 @@
    "id": "b275563f",
    "metadata": {
     "papermill": {
-     "duration": 0.012642,
-     "end_time": "2026-06-04T06:28:58.210636",
+     "duration": 0.019352,
+     "end_time": "2026-06-22T19:17:41.681112",
      "exception": false,
-     "start_time": "2026-06-04T06:28:58.197994",
+     "start_time": "2026-06-22T19:17:41.661760",
      "status": "completed"
     },
     "tags": []
@@ -1746,10 +1714,10 @@
    "id": "md83e1n44yp",
    "metadata": {
     "papermill": {
-     "duration": 0.020444,
-     "end_time": "2026-06-04T06:28:58.244990",
+     "duration": 0.012001,
+     "end_time": "2026-06-22T19:17:41.705464",
      "exception": false,
-     "start_time": "2026-06-04T06:28:58.224546",
+     "start_time": "2026-06-22T19:17:41.693463",
      "status": "completed"
     },
     "tags": []
@@ -1780,10 +1748,10 @@
    "id": "tasoq959b8s",
    "metadata": {
     "papermill": {
-     "duration": 0.019912,
-     "end_time": "2026-06-04T06:28:58.278765",
+     "duration": 0.013351,
+     "end_time": "2026-06-22T19:17:41.732814",
      "exception": false,
-     "start_time": "2026-06-04T06:28:58.258853",
+     "start_time": "2026-06-22T19:17:41.719463",
      "status": "completed"
     },
     "tags": []
@@ -1805,16 +1773,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:58.324751Z",
-     "iopub.status.busy": "2026-06-04T06:28:58.324126Z",
-     "iopub.status.idle": "2026-06-04T06:28:58.852697Z",
-     "shell.execute_reply": "2026-06-04T06:28:58.852462Z"
+     "iopub.execute_input": "2026-06-22T19:17:41.761546Z",
+     "iopub.status.busy": "2026-06-22T19:17:41.761546Z",
+     "iopub.status.idle": "2026-06-22T19:17:42.344155Z",
+     "shell.execute_reply": "2026-06-22T19:17:42.344155Z"
     },
     "papermill": {
-     "duration": 0.550383,
-     "end_time": "2026-06-04T06:28:58.852816",
+     "duration": 0.600057,
+     "end_time": "2026-06-22T19:17:42.344668",
      "exception": false,
-     "start_time": "2026-06-04T06:28:58.302433",
+     "start_time": "2026-06-22T19:17:41.744611",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1826,38 +1794,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_23_47_07_52.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1973,10 +1909,10 @@
    "id": "1ajq1wtiu91",
    "metadata": {
     "papermill": {
-     "duration": 0.014033,
-     "end_time": "2026-06-04T06:28:58.881814",
+     "duration": 0.011769,
+     "end_time": "2026-06-22T19:17:42.369324",
      "exception": false,
-     "start_time": "2026-06-04T06:28:58.867781",
+     "start_time": "2026-06-22T19:17:42.357555",
      "status": "completed"
     },
     "tags": []
@@ -2021,16 +1957,16 @@
    "id": "xv3xrk1f97s",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:58.918764Z",
-     "iopub.status.busy": "2026-06-04T06:28:58.918275Z",
-     "iopub.status.idle": "2026-06-04T06:28:58.978840Z",
-     "shell.execute_reply": "2026-06-04T06:28:58.979156Z"
+     "iopub.execute_input": "2026-06-22T19:17:42.394997Z",
+     "iopub.status.busy": "2026-06-22T19:17:42.394997Z",
+     "iopub.status.idle": "2026-06-22T19:17:42.496938Z",
+     "shell.execute_reply": "2026-06-22T19:17:42.496938Z"
     },
     "papermill": {
-     "duration": 0.079939,
-     "end_time": "2026-06-04T06:28:58.979318",
+     "duration": 0.115758,
+     "end_time": "2026-06-22T19:17:42.496938",
      "exception": false,
-     "start_time": "2026-06-04T06:28:58.899379",
+     "start_time": "2026-06-22T19:17:42.381180",
      "status": "completed"
     },
     "tags": [],
@@ -2042,14 +1978,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_23_47_07_52.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_17_41_84.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"160pt\" height=\"435pt\"\r\n",
@@ -2139,8 +2075,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2152,7 +2088,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -2167,10 +2103,10 @@
    "id": "25scpjj874o",
    "metadata": {
     "papermill": {
-     "duration": 0.014242,
-     "end_time": "2026-06-04T06:28:59.012286",
+     "duration": 0.012055,
+     "end_time": "2026-06-22T19:17:42.520996",
      "exception": false,
-     "start_time": "2026-06-04T06:28:58.998044",
+     "start_time": "2026-06-22T19:17:42.508941",
      "status": "completed"
     },
     "tags": []
@@ -2205,10 +2141,10 @@
    "id": "a9b5286c",
    "metadata": {
     "papermill": {
-     "duration": 0.051738,
-     "end_time": "2026-06-04T06:28:59.099375",
+     "duration": 0.012001,
+     "end_time": "2026-06-22T19:17:42.547004",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.047637",
+     "start_time": "2026-06-22T19:17:42.535003",
      "status": "completed"
     },
     "tags": []
@@ -2228,16 +2164,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:59.163840Z",
-     "iopub.status.busy": "2026-06-04T06:28:59.163266Z",
-     "iopub.status.idle": "2026-06-04T06:28:59.302984Z",
-     "shell.execute_reply": "2026-06-04T06:28:59.302637Z"
+     "iopub.execute_input": "2026-06-22T19:17:42.574007Z",
+     "iopub.status.busy": "2026-06-22T19:17:42.573007Z",
+     "iopub.status.idle": "2026-06-22T19:17:42.645131Z",
+     "shell.execute_reply": "2026-06-22T19:17:42.644609Z"
     },
     "papermill": {
-     "duration": 0.170133,
-     "end_time": "2026-06-04T06:28:59.303138",
+     "duration": 0.086127,
+     "end_time": "2026-06-22T19:17:42.645131",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.133005",
+     "start_time": "2026-06-22T19:17:42.559004",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2340,10 +2276,10 @@
    "id": "qga3lp8occ",
    "metadata": {
     "papermill": {
-     "duration": 0.015792,
-     "end_time": "2026-06-04T06:28:59.334494",
+     "duration": 0.012713,
+     "end_time": "2026-06-22T19:17:42.670294",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.318702",
+     "start_time": "2026-06-22T19:17:42.657581",
      "status": "completed"
     },
     "tags": []
@@ -2382,10 +2318,10 @@
    "id": "9d838173",
    "metadata": {
     "papermill": {
-     "duration": 0.017478,
-     "end_time": "2026-06-04T06:28:59.367187",
+     "duration": 0.014008,
+     "end_time": "2026-06-22T19:17:42.696302",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.349709",
+     "start_time": "2026-06-22T19:17:42.682294",
      "status": "completed"
     },
     "tags": []
@@ -2416,16 +2352,16 @@
    "id": "22f720ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:59.398584Z",
-     "iopub.status.busy": "2026-06-04T06:28:59.398235Z",
-     "iopub.status.idle": "2026-06-04T06:28:59.455820Z",
-     "shell.execute_reply": "2026-06-04T06:28:59.455592Z"
+     "iopub.execute_input": "2026-06-22T19:17:42.722302Z",
+     "iopub.status.busy": "2026-06-22T19:17:42.722302Z",
+     "iopub.status.idle": "2026-06-22T19:17:42.765315Z",
+     "shell.execute_reply": "2026-06-22T19:17:42.765315Z"
     },
     "papermill": {
-     "duration": 0.072996,
-     "end_time": "2026-06-04T06:28:59.455931",
+     "duration": 0.058013,
+     "end_time": "2026-06-22T19:17:42.766316",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.382935",
+     "start_time": "2026-06-22T19:17:42.708303",
      "status": "completed"
     },
     "tags": []
@@ -2461,10 +2397,10 @@
    "id": "813c411a",
    "metadata": {
     "papermill": {
-     "duration": 0.017665,
-     "end_time": "2026-06-04T06:28:59.489298",
+     "duration": 0.012261,
+     "end_time": "2026-06-22T19:17:42.791074",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.471633",
+     "start_time": "2026-06-22T19:17:42.778813",
      "status": "completed"
     },
     "tags": []
@@ -2494,10 +2430,10 @@
    "id": "1fhq2eah4f5",
    "metadata": {
     "papermill": {
-     "duration": 0.013642,
-     "end_time": "2026-06-04T06:28:59.519933",
+     "duration": 0.013022,
+     "end_time": "2026-06-22T19:17:42.817143",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.506291",
+     "start_time": "2026-06-22T19:17:42.804121",
      "status": "completed"
     },
     "tags": []
@@ -2519,16 +2455,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:59.570448Z",
-     "iopub.status.busy": "2026-06-04T06:28:59.569643Z",
-     "iopub.status.idle": "2026-06-04T06:28:59.805707Z",
-     "shell.execute_reply": "2026-06-04T06:28:59.805304Z"
+     "iopub.execute_input": "2026-06-22T19:17:42.845697Z",
+     "iopub.status.busy": "2026-06-22T19:17:42.845186Z",
+     "iopub.status.idle": "2026-06-22T19:17:42.895293Z",
+     "shell.execute_reply": "2026-06-22T19:17:42.895293Z"
     },
     "papermill": {
-     "duration": 0.268037,
-     "end_time": "2026-06-04T06:28:59.805903",
+     "duration": 0.065205,
+     "end_time": "2026-06-22T19:17:42.895293",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.537866",
+     "start_time": "2026-06-22T19:17:42.830088",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2597,10 +2533,10 @@
    "id": "s35swlefpcf",
    "metadata": {
     "papermill": {
-     "duration": 0.018634,
-     "end_time": "2026-06-04T06:28:59.848171",
+     "duration": 0.013206,
+     "end_time": "2026-06-22T19:17:42.921692",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.829537",
+     "start_time": "2026-06-22T19:17:42.908486",
      "status": "completed"
     },
     "tags": []
@@ -2637,10 +2573,10 @@
    "id": "40125ab1",
    "metadata": {
     "papermill": {
-     "duration": 0.015787,
-     "end_time": "2026-06-04T06:28:59.899777",
+     "duration": 0.013041,
+     "end_time": "2026-06-22T19:17:42.949039",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.883990",
+     "start_time": "2026-06-22T19:17:42.935998",
      "status": "completed"
     },
     "tags": []
@@ -2666,10 +2602,10 @@
    "id": "14nzxw2dqhx",
    "metadata": {
     "papermill": {
-     "duration": 0.015066,
-     "end_time": "2026-06-04T06:28:59.929485",
+     "duration": 0.013012,
+     "end_time": "2026-06-22T19:17:42.974066",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.914419",
+     "start_time": "2026-06-22T19:17:42.961054",
      "status": "completed"
     },
     "tags": []
@@ -2704,10 +2640,10 @@
    "id": "jy4ls15db6",
    "metadata": {
     "papermill": {
-     "duration": 0.022849,
-     "end_time": "2026-06-04T06:28:59.967441",
+     "duration": 0.014001,
+     "end_time": "2026-06-22T19:17:43.001347",
      "exception": false,
-     "start_time": "2026-06-04T06:28:59.944592",
+     "start_time": "2026-06-22T19:17:42.987346",
      "status": "completed"
     },
     "tags": []
@@ -2727,16 +2663,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:29:00.101571Z",
-     "iopub.status.busy": "2026-06-04T06:29:00.100685Z",
-     "iopub.status.idle": "2026-06-04T06:29:00.217167Z",
-     "shell.execute_reply": "2026-06-04T06:29:00.216923Z"
+     "iopub.execute_input": "2026-06-22T19:17:43.033596Z",
+     "iopub.status.busy": "2026-06-22T19:17:43.032597Z",
+     "iopub.status.idle": "2026-06-22T19:17:43.117503Z",
+     "shell.execute_reply": "2026-06-22T19:17:43.117503Z"
     },
     "papermill": {
-     "duration": 0.186428,
-     "end_time": "2026-06-04T06:29:00.217277",
+     "duration": 0.101057,
+     "end_time": "2026-06-22T19:17:43.117503",
      "exception": false,
-     "start_time": "2026-06-04T06:29:00.030849",
+     "start_time": "2026-06-22T19:17:43.016446",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2846,10 +2782,10 @@
    "id": "1uydzcj0s2j",
    "metadata": {
     "papermill": {
-     "duration": 0.01012,
-     "end_time": "2026-06-04T06:29:00.239669",
+     "duration": 0.016,
+     "end_time": "2026-06-22T19:17:43.148564",
      "exception": false,
-     "start_time": "2026-06-04T06:29:00.229549",
+     "start_time": "2026-06-22T19:17:43.132564",
      "status": "completed"
     },
     "tags": []
@@ -2887,10 +2823,10 @@
    "id": "38d86fc6",
    "metadata": {
     "papermill": {
-     "duration": 0.01748,
-     "end_time": "2026-06-04T06:29:00.282471",
+     "duration": 0.016003,
+     "end_time": "2026-06-22T19:17:43.177568",
      "exception": false,
-     "start_time": "2026-06-04T06:29:00.264991",
+     "start_time": "2026-06-22T19:17:43.161565",
      "status": "completed"
     },
     "tags": []
@@ -2908,10 +2844,10 @@
    "id": "h3ytns1sj6q",
    "metadata": {
     "papermill": {
-     "duration": 0.022081,
-     "end_time": "2026-06-04T06:29:00.322214",
+     "duration": 0.013,
+     "end_time": "2026-06-22T19:17:43.204309",
      "exception": false,
-     "start_time": "2026-06-04T06:29:00.300133",
+     "start_time": "2026-06-22T19:17:43.191309",
      "status": "completed"
     },
     "tags": []
@@ -2946,16 +2882,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:29:00.399354Z",
-     "iopub.status.busy": "2026-06-04T06:29:00.398376Z",
-     "iopub.status.idle": "2026-06-04T06:29:00.790736Z",
-     "shell.execute_reply": "2026-06-04T06:29:00.790101Z"
+     "iopub.execute_input": "2026-06-22T19:17:43.234118Z",
+     "iopub.status.busy": "2026-06-22T19:17:43.234118Z",
+     "iopub.status.idle": "2026-06-22T19:17:43.342480Z",
+     "shell.execute_reply": "2026-06-22T19:17:43.342480Z"
     },
     "papermill": {
-     "duration": 0.432724,
-     "end_time": "2026-06-04T06:29:00.790910",
+     "duration": 0.124753,
+     "end_time": "2026-06-22T19:17:43.342480",
      "exception": false,
-     "start_time": "2026-06-04T06:29:00.358186",
+     "start_time": "2026-06-22T19:17:43.217727",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3117,10 +3053,10 @@
    "id": "bxehgfxq8di",
    "metadata": {
     "papermill": {
-     "duration": 0.014419,
-     "end_time": "2026-06-04T06:29:00.820736",
+     "duration": 0.014008,
+     "end_time": "2026-06-22T19:17:43.371515",
      "exception": false,
-     "start_time": "2026-06-04T06:29:00.806317",
+     "start_time": "2026-06-22T19:17:43.357507",
      "status": "completed"
     },
     "tags": []
@@ -3162,10 +3098,10 @@
    "id": "51d165a2",
    "metadata": {
     "papermill": {
-     "duration": 0.014847,
-     "end_time": "2026-06-04T06:29:00.850495",
+     "duration": 0.027804,
+     "end_time": "2026-06-22T19:17:43.413820",
      "exception": false,
-     "start_time": "2026-06-04T06:29:00.835648",
+     "start_time": "2026-06-22T19:17:43.386016",
      "status": "completed"
     },
     "tags": []
@@ -3216,10 +3152,10 @@
    "id": "936ismvm29v",
    "metadata": {
     "papermill": {
-     "duration": 0.018842,
-     "end_time": "2026-06-04T06:29:00.884760",
+     "duration": 0.018811,
+     "end_time": "2026-06-22T19:17:43.450365",
      "exception": false,
-     "start_time": "2026-06-04T06:29:00.865918",
+     "start_time": "2026-06-22T19:17:43.431554",
      "status": "completed"
     },
     "tags": []
@@ -3253,10 +3189,10 @@
    "id": "b17cc710",
    "metadata": {
     "papermill": {
-     "duration": 0.04701,
-     "end_time": "2026-06-04T06:29:00.949793",
+     "duration": 0.018206,
+     "end_time": "2026-06-22T19:17:43.484080",
      "exception": false,
-     "start_time": "2026-06-04T06:29:00.902783",
+     "start_time": "2026-06-22T19:17:43.465874",
      "status": "completed"
     },
     "tags": []
@@ -3288,16 +3224,16 @@
    "id": "66737d8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:29:01.032325Z",
-     "iopub.status.busy": "2026-06-04T06:29:01.031331Z",
-     "iopub.status.idle": "2026-06-04T06:29:01.100608Z",
-     "shell.execute_reply": "2026-06-04T06:29:01.100263Z"
+     "iopub.execute_input": "2026-06-22T19:17:43.515081Z",
+     "iopub.status.busy": "2026-06-22T19:17:43.515081Z",
+     "iopub.status.idle": "2026-06-22T19:17:43.569089Z",
+     "shell.execute_reply": "2026-06-22T19:17:43.569089Z"
     },
     "papermill": {
-     "duration": 0.098458,
-     "end_time": "2026-06-04T06:29:01.100738",
+     "duration": 0.071009,
+     "end_time": "2026-06-22T19:17:43.569089",
      "exception": false,
-     "start_time": "2026-06-04T06:29:01.002280",
+     "start_time": "2026-06-22T19:17:43.498080",
      "status": "completed"
     },
     "tags": []
@@ -3338,10 +3274,10 @@
    "id": "08d17ed2",
    "metadata": {
     "papermill": {
-     "duration": 0.02006,
-     "end_time": "2026-06-04T06:29:01.138344",
+     "duration": 0.017215,
+     "end_time": "2026-06-22T19:17:43.601811",
      "exception": false,
-     "start_time": "2026-06-04T06:29:01.118284",
+     "start_time": "2026-06-22T19:17:43.584596",
      "status": "completed"
     },
     "tags": []
@@ -3377,16 +3313,16 @@
    "id": "spam-detector-exercise",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:29:01.172900Z",
-     "iopub.status.busy": "2026-06-04T06:29:01.172506Z",
-     "iopub.status.idle": "2026-06-04T06:29:01.231130Z",
-     "shell.execute_reply": "2026-06-04T06:29:01.230884Z"
+     "iopub.execute_input": "2026-06-22T19:17:43.635416Z",
+     "iopub.status.busy": "2026-06-22T19:17:43.635416Z",
+     "iopub.status.idle": "2026-06-22T19:17:43.681398Z",
+     "shell.execute_reply": "2026-06-22T19:17:43.680884Z"
     },
     "papermill": {
-     "duration": 0.0762,
-     "end_time": "2026-06-04T06:29:01.231250",
+     "duration": 0.062555,
+     "end_time": "2026-06-22T19:17:43.681398",
      "exception": false,
-     "start_time": "2026-06-04T06:29:01.155050",
+     "start_time": "2026-06-22T19:17:43.618843",
      "status": "completed"
     },
     "tags": []
@@ -3430,7 +3366,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "3f6e90f7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.018001,
+     "end_time": "2026-06-22T19:17:43.714645",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:43.696644",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "\n",
@@ -3457,8 +3403,7 @@
     "\n",
     "> Le bon modele de crowdsourcing n'est pas le plus sophistique, mais **le plus simple qui capture le bruit reellement present** dans vos donnees. Commencer par le vote majoritaire avec des *gold questions*, puis monter en complexite (Honest -> Biased -> Community) seulement quand les desaccords, biais ou le cold-start l'imposent. Dans tous les cas, garder 5-10 % d'items a verite connue reste le filet de securite qui calibre les estimations et demasque les spammeurs.\n",
     "\n",
-    "Ce raisonnement -- inferer des variables latentes (le vrai label) a partir d'observations bruitees mediees par des parametres de fiabilite -- prepare directement les modeles a etats caches du notebook suivant ([Infer-11-Sequences](Infer-11-Sequences.ipynb)), ou la structure latente devient temporelle.\n",
-    ""
+    "Ce raisonnement -- inferer des variables latentes (le vrai label) a partir d'observations bruitees mediees par des parametres de fiabilite -- prepare directement les modeles a etats caches du notebook suivant ([Infer-11-Sequences](Infer-11-Sequences.ipynb)), ou la structure latente devient temporelle.\n"
    ]
   }
  ],
@@ -3473,18 +3418,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 13.743584,
-   "end_time": "2026-06-04T06:29:01.508909",
+   "duration": 9.819226,
+   "end_time": "2026-06-22T19:17:43.967758",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-10-Crowdsourcing.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-10-Crowdsourcing.ipynb",
+   "input_path": "Infer-10-Crowdsourcing.ipynb",
+   "output_path": "Infer-10-Crowdsourcing.ipynb",
    "parameters": {},
-   "start_time": "2026-06-04T06:28:47.765325",
+   "start_time": "2026-06-22T19:17:34.148532",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Sequences.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "id": "087a352c",
    "metadata": {
+    "papermill": {
+     "duration": 0.005199,
+     "end_time": "2026-06-22T19:17:47.795976",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:47.790777",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -37,6 +44,13 @@
    "cell_type": "markdown",
    "id": "9a17f1d2",
    "metadata": {
+    "papermill": {
+     "duration": 0.003999,
+     "end_time": "2026-06-22T19:17:47.805068",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:47.801069",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -53,6 +67,19 @@
     "dotnet_interactive": {
      "language": "csharp"
     },
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:17:47.820240Z",
+     "iopub.status.busy": "2026-06-22T19:17:47.817080Z",
+     "iopub.status.idle": "2026-06-22T19:17:50.446948Z",
+     "shell.execute_reply": "2026-06-22T19:17:50.443850Z"
+    },
+    "papermill": {
+     "duration": 2.637226,
+     "end_time": "2026-06-22T19:17:50.447461",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:47.810235",
+     "status": "completed"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
     },
@@ -67,7 +94,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-51356.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-98252.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -112,12 +139,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.83.164.85:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '51356.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '98252.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -213,6 +240,13 @@
    "cell_type": "markdown",
    "id": "ecbd34b2",
    "metadata": {
+    "papermill": {
+     "duration": 0.009222,
+     "end_time": "2026-06-22T19:17:50.468030",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:50.458808",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -224,8 +258,21 @@
    "execution_count": 2,
    "id": "0hge12mjvnp",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:17:50.488014Z",
+     "iopub.status.busy": "2026-06-22T19:17:50.487014Z",
+     "iopub.status.idle": "2026-06-22T19:17:51.078456Z",
+     "shell.execute_reply": "2026-06-22T19:17:51.078456Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 0.602154,
+     "end_time": "2026-06-22T19:17:51.079455",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:50.477301",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -254,6 +301,13 @@
    "cell_type": "markdown",
    "id": "sgcbrftbblk",
    "metadata": {
+    "papermill": {
+     "duration": 0.009127,
+     "end_time": "2026-06-22T19:17:51.096575",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:51.087448",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -264,6 +318,13 @@
    "cell_type": "markdown",
    "id": "7ce638a0",
    "metadata": {
+    "papermill": {
+     "duration": 0.007992,
+     "end_time": "2026-06-22T19:17:51.112577",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:51.104585",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -300,6 +361,13 @@
    "cell_type": "markdown",
    "id": "592f5eb5",
    "metadata": {
+    "papermill": {
+     "duration": 0.008008,
+     "end_time": "2026-06-22T19:17:51.129586",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:51.121578",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -329,6 +397,19 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:17:51.148581Z",
+     "iopub.status.busy": "2026-06-22T19:17:51.148581Z",
+     "iopub.status.idle": "2026-06-22T19:17:51.233141Z",
+     "shell.execute_reply": "2026-06-22T19:17:51.233141Z"
+    },
+    "papermill": {
+     "duration": 0.094559,
+     "end_time": "2026-06-22T19:17:51.233141",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:51.138582",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -381,6 +462,13 @@
    "cell_type": "markdown",
    "id": "c0rbr2fzhha",
    "metadata": {
+    "papermill": {
+     "duration": 0.009,
+     "end_time": "2026-06-22T19:17:51.252174",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:51.243174",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -400,6 +488,13 @@
    "cell_type": "markdown",
    "id": "0mbmcsyd0qzo",
    "metadata": {
+    "papermill": {
+     "duration": 0.011006,
+     "end_time": "2026-06-22T19:17:51.273178",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:51.262172",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -429,6 +524,19 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:17:51.298254Z",
+     "iopub.status.busy": "2026-06-22T19:17:51.298254Z",
+     "iopub.status.idle": "2026-06-22T19:17:51.515570Z",
+     "shell.execute_reply": "2026-06-22T19:17:51.515056Z"
+    },
+    "papermill": {
+     "duration": 0.233393,
+     "end_time": "2026-06-22T19:17:51.515570",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:51.282177",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -482,6 +590,13 @@
    "cell_type": "markdown",
    "id": "ozkeoi9kvqn",
    "metadata": {
+    "papermill": {
+     "duration": 0.014212,
+     "end_time": "2026-06-22T19:17:51.540016",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:51.525804",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -499,6 +614,19 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:17:51.560390Z",
+     "iopub.status.busy": "2026-06-22T19:17:51.560390Z",
+     "iopub.status.idle": "2026-06-22T19:17:55.626122Z",
+     "shell.execute_reply": "2026-06-22T19:17:55.626122Z"
+    },
+    "papermill": {
+     "duration": 4.077886,
+     "end_time": "2026-06-22T19:17:55.626122",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:51.548236",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -776,6 +904,13 @@
    "cell_type": "markdown",
    "id": "2343d5fb",
    "metadata": {
+    "papermill": {
+     "duration": 0.011153,
+     "end_time": "2026-06-22T19:17:55.649304",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:55.638151",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -787,8 +922,21 @@
    "execution_count": 6,
    "id": "1wijm2ozzxe",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:17:55.672201Z",
+     "iopub.status.busy": "2026-06-22T19:17:55.672201Z",
+     "iopub.status.idle": "2026-06-22T19:17:56.142282Z",
+     "shell.execute_reply": "2026-06-22T19:17:56.142282Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 0.482271,
+     "end_time": "2026-06-22T19:17:56.142282",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:55.660011",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -799,38 +947,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_00_45_57_37.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -883,6 +999,13 @@
    "cell_type": "markdown",
    "id": "eprgrv4qwrc",
    "metadata": {
+    "papermill": {
+     "duration": 0.012007,
+     "end_time": "2026-06-22T19:17:56.167031",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:56.155024",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -915,8 +1038,21 @@
    "execution_count": 7,
    "id": "wqheiyzfuc",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:17:56.192009Z",
+     "iopub.status.busy": "2026-06-22T19:17:56.192009Z",
+     "iopub.status.idle": "2026-06-22T19:17:56.306486Z",
+     "shell.execute_reply": "2026-06-22T19:17:56.306486Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 0.127462,
+     "end_time": "2026-06-22T19:17:56.306486",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:56.179024",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -930,14 +1066,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_20_26_00_45_57_37.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_17_55_72.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"368pt\" height=\"289pt\"\r\n",
@@ -1067,8 +1203,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1080,7 +1216,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1094,6 +1230,13 @@
    "cell_type": "markdown",
    "id": "z97jpjm3ysi",
    "metadata": {
+    "papermill": {
+     "duration": 0.013001,
+     "end_time": "2026-06-22T19:17:56.332091",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:56.319090",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1115,6 +1258,13 @@
    "cell_type": "markdown",
    "id": "02dmb0xvcaoi",
    "metadata": {
+    "papermill": {
+     "duration": 0.009989,
+     "end_time": "2026-06-22T19:17:56.354091",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:56.344102",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1141,8 +1291,21 @@
    "execution_count": 8,
    "id": "z7pjabb6wh",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:17:56.382874Z",
+     "iopub.status.busy": "2026-06-22T19:17:56.381871Z",
+     "iopub.status.idle": "2026-06-22T19:17:59.984239Z",
+     "shell.execute_reply": "2026-06-22T19:17:59.984239Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 3.616474,
+     "end_time": "2026-06-22T19:17:59.984239",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:56.367765",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1469,6 +1632,13 @@
    "cell_type": "markdown",
    "id": "gcse6q4x37",
    "metadata": {
+    "papermill": {
+     "duration": 0.013398,
+     "end_time": "2026-06-22T19:18:00.010811",
+     "exception": false,
+     "start_time": "2026-06-22T19:17:59.997413",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1487,8 +1657,21 @@
    "execution_count": 9,
    "id": "61otgq0s3lc",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:00.035448Z",
+     "iopub.status.busy": "2026-06-22T19:18:00.034448Z",
+     "iopub.status.idle": "2026-06-22T19:18:00.136831Z",
+     "shell.execute_reply": "2026-06-22T19:18:00.136831Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 0.114486,
+     "end_time": "2026-06-22T19:18:00.136831",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:00.022345",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1578,6 +1761,13 @@
    "cell_type": "markdown",
    "id": "6bk7odnx5y",
    "metadata": {
+    "papermill": {
+     "duration": 0.012345,
+     "end_time": "2026-06-22T19:18:00.162318",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:00.149973",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1594,6 +1784,13 @@
    "cell_type": "markdown",
    "id": "v192d1cxszo",
    "metadata": {
+    "papermill": {
+     "duration": 0.014558,
+     "end_time": "2026-06-22T19:18:00.189667",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:00.175109",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1615,6 +1812,13 @@
    "cell_type": "markdown",
    "id": "4r3u9gqw83f",
    "metadata": {
+    "papermill": {
+     "duration": 0.012874,
+     "end_time": "2026-06-22T19:18:00.217561",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:00.204687",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1648,6 +1852,13 @@
    "cell_type": "markdown",
    "id": "infer11hmm34hdr",
    "metadata": {
+    "papermill": {
+     "duration": 0.019229,
+     "end_time": "2026-06-22T19:18:00.249508",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:00.230279",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1667,8 +1878,21 @@
    "execution_count": 10,
    "id": "infer11fhmm34code",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:00.275759Z",
+     "iopub.status.busy": "2026-06-22T19:18:00.275759Z",
+     "iopub.status.idle": "2026-06-22T19:18:30.636995Z",
+     "shell.execute_reply": "2026-06-22T19:18:30.634003Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 30.373983,
+     "end_time": "2026-06-22T19:18:30.636995",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:00.263012",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1928,6 +2152,13 @@
    "cell_type": "markdown",
    "id": "infer11hmm34interp",
    "metadata": {
+    "papermill": {
+     "duration": 0.013132,
+     "end_time": "2026-06-22T19:18:30.665131",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:30.651999",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1944,6 +2175,13 @@
    "cell_type": "markdown",
    "id": "1cbb2595",
    "metadata": {
+    "papermill": {
+     "duration": 0.013165,
+     "end_time": "2026-06-22T19:18:30.690557",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:30.677392",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1954,6 +2192,13 @@
    "cell_type": "markdown",
    "id": "sil9i09arb",
    "metadata": {
+    "papermill": {
+     "duration": 0.012596,
+     "end_time": "2026-06-22T19:18:30.716484",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:30.703888",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1972,6 +2217,19 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:30.745999Z",
+     "iopub.status.busy": "2026-06-22T19:18:30.745999Z",
+     "iopub.status.idle": "2026-06-22T19:18:32.335751Z",
+     "shell.execute_reply": "2026-06-22T19:18:32.335751Z"
+    },
+    "papermill": {
+     "duration": 1.605143,
+     "end_time": "2026-06-22T19:18:32.335751",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:30.730608",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2293,6 +2551,13 @@
    "cell_type": "markdown",
    "id": "ec204f75",
    "metadata": {
+    "papermill": {
+     "duration": 0.020496,
+     "end_time": "2026-06-22T19:18:32.373250",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.352754",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -2304,8 +2569,21 @@
    "execution_count": 12,
    "id": "z34439j0ib",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:32.414686Z",
+     "iopub.status.busy": "2026-06-22T19:18:32.414172Z",
+     "iopub.status.idle": "2026-06-22T19:18:32.657794Z",
+     "shell.execute_reply": "2026-06-22T19:18:32.657794Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 0.265083,
+     "end_time": "2026-06-22T19:18:32.657794",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.392711",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2316,38 +2594,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_00_46_52_66.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -2401,6 +2647,13 @@
    "cell_type": "markdown",
    "id": "lynx4a5sz0g",
    "metadata": {
+    "papermill": {
+     "duration": 0.014448,
+     "end_time": "2026-06-22T19:18:32.688322",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.673874",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -2422,8 +2675,21 @@
    "execution_count": 13,
    "id": "1xol5m2d983",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:32.716318Z",
+     "iopub.status.busy": "2026-06-22T19:18:32.716318Z",
+     "iopub.status.idle": "2026-06-22T19:18:32.801024Z",
+     "shell.execute_reply": "2026-06-22T19:18:32.801024Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 0.099296,
+     "end_time": "2026-06-22T19:18:32.801535",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.702239",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2437,14 +2703,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_20_26_00_46_52_66.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_18_32_44.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"385pt\" height=\"289pt\"\r\n",
@@ -2574,8 +2840,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2587,7 +2853,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -2601,6 +2867,13 @@
    "cell_type": "markdown",
    "id": "rvevktcbjtf",
    "metadata": {
+    "papermill": {
+     "duration": 0.015093,
+     "end_time": "2026-06-22T19:18:32.832761",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.817668",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -2622,6 +2895,13 @@
    "cell_type": "markdown",
    "id": "ar7q2hcf8zp",
    "metadata": {
+    "papermill": {
+     "duration": 0.017169,
+     "end_time": "2026-06-22T19:18:32.867053",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.849884",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -2634,6 +2914,13 @@
    "cell_type": "markdown",
    "id": "803d63a7",
    "metadata": {
+    "papermill": {
+     "duration": 0.014897,
+     "end_time": "2026-06-22T19:18:32.897465",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.882568",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -2673,6 +2960,19 @@
    "execution_count": 14,
    "id": "6e1d13fe",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:32.927626Z",
+     "iopub.status.busy": "2026-06-22T19:18:32.926626Z",
+     "iopub.status.idle": "2026-06-22T19:18:32.952889Z",
+     "shell.execute_reply": "2026-06-22T19:18:32.951888Z"
+    },
+    "papermill": {
+     "duration": 0.041265,
+     "end_time": "2026-06-22T19:18:32.952889",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.911624",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -2710,6 +3010,13 @@
    "cell_type": "markdown",
    "id": "d282b7c3",
    "metadata": {
+    "papermill": {
+     "duration": 0.015138,
+     "end_time": "2026-06-22T19:18:32.983019",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.967881",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -2729,6 +3036,13 @@
    "cell_type": "markdown",
    "id": "tfetkzwnq9k",
    "metadata": {
+    "papermill": {
+     "duration": 0.016157,
+     "end_time": "2026-06-22T19:18:33.014294",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:32.998137",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -2751,6 +3065,19 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:33.052542Z",
+     "iopub.status.busy": "2026-06-22T19:18:33.052022Z",
+     "iopub.status.idle": "2026-06-22T19:18:33.123687Z",
+     "shell.execute_reply": "2026-06-22T19:18:33.110017Z"
+    },
+    "papermill": {
+     "duration": 0.092634,
+     "end_time": "2026-06-22T19:18:33.123687",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:33.031053",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -3219,6 +3546,13 @@
    "cell_type": "markdown",
    "id": "a7i2j2lplw5",
    "metadata": {
+    "papermill": {
+     "duration": 0.016125,
+     "end_time": "2026-06-22T19:18:33.156813",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:33.140688",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -3236,6 +3570,19 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:33.189836Z",
+     "iopub.status.busy": "2026-06-22T19:18:33.189836Z",
+     "iopub.status.idle": "2026-06-22T19:18:43.956460Z",
+     "shell.execute_reply": "2026-06-22T19:18:43.932451Z"
+    },
+    "papermill": {
+     "duration": 10.783637,
+     "end_time": "2026-06-22T19:18:43.956460",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:33.172823",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -3979,6 +4326,13 @@
    "cell_type": "markdown",
    "id": "mt3h0rcfywa",
    "metadata": {
+    "papermill": {
+     "duration": 0.012138,
+     "end_time": "2026-06-22T19:18:43.986592",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:43.974454",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -3995,6 +4349,13 @@
    "cell_type": "markdown",
    "id": "34b2f962",
    "metadata": {
+    "papermill": {
+     "duration": 0.01929,
+     "end_time": "2026-06-22T19:18:44.032475",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:44.013185",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4009,6 +4370,13 @@
    "cell_type": "markdown",
    "id": "8ioxik0mv8y",
    "metadata": {
+    "papermill": {
+     "duration": 0.020001,
+     "end_time": "2026-06-22T19:18:44.072163",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:44.052162",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4021,6 +4389,13 @@
    "cell_type": "markdown",
    "id": "6d60b6gl9ft",
    "metadata": {
+    "papermill": {
+     "duration": 0.020208,
+     "end_time": "2026-06-22T19:18:44.113370",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:44.093162",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4040,6 +4415,19 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:44.156605Z",
+     "iopub.status.busy": "2026-06-22T19:18:44.156605Z",
+     "iopub.status.idle": "2026-06-22T19:18:45.677702Z",
+     "shell.execute_reply": "2026-06-22T19:18:45.677191Z"
+    },
+    "papermill": {
+     "duration": 1.542521,
+     "end_time": "2026-06-22T19:18:45.677702",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:44.135181",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -4368,6 +4756,13 @@
    "cell_type": "markdown",
    "id": "3c0679a3",
    "metadata": {
+    "papermill": {
+     "duration": 0.020757,
+     "end_time": "2026-06-22T19:18:45.722192",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:45.701435",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4379,8 +4774,21 @@
    "execution_count": 18,
    "id": "3nnqh8zkiod",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:45.766385Z",
+     "iopub.status.busy": "2026-06-22T19:18:45.766385Z",
+     "iopub.status.idle": "2026-06-22T19:18:46.015289Z",
+     "shell.execute_reply": "2026-06-22T19:18:46.015289Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 0.270938,
+     "end_time": "2026-06-22T19:18:46.015289",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:45.744351",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -4391,38 +4799,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_00_47_29_34.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -4474,6 +4850,13 @@
    "cell_type": "markdown",
    "id": "3fdxvm2s2rx",
    "metadata": {
+    "papermill": {
+     "duration": 0.025001,
+     "end_time": "2026-06-22T19:18:46.069162",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.044161",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4500,8 +4883,21 @@
    "execution_count": 19,
    "id": "f6x0b59hor",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:46.114422Z",
+     "iopub.status.busy": "2026-06-22T19:18:46.114422Z",
+     "iopub.status.idle": "2026-06-22T19:18:46.208750Z",
+     "shell.execute_reply": "2026-06-22T19:18:46.208750Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 0.118428,
+     "end_time": "2026-06-22T19:18:46.209750",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.091322",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -4515,14 +4911,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_20_26_00_47_29_34.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_18_45_80.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"394pt\" height=\"289pt\"\r\n",
@@ -4652,8 +5048,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -4665,7 +5061,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -4679,6 +5075,13 @@
    "cell_type": "markdown",
    "id": "p4hrpt1fnce",
    "metadata": {
+    "papermill": {
+     "duration": 0.025956,
+     "end_time": "2026-06-22T19:18:46.260794",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.234838",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4702,6 +5105,13 @@
    "cell_type": "markdown",
    "id": "y3txyxantb",
    "metadata": {
+    "papermill": {
+     "duration": 0.023094,
+     "end_time": "2026-06-22T19:18:46.306490",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.283396",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4712,6 +5122,13 @@
    "cell_type": "markdown",
    "id": "d42c6ea1",
    "metadata": {
+    "papermill": {
+     "duration": 0.028276,
+     "end_time": "2026-06-22T19:18:46.361693",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.333417",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4747,6 +5164,19 @@
    "execution_count": 20,
    "id": "08eb783b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:46.409826Z",
+     "iopub.status.busy": "2026-06-22T19:18:46.409826Z",
+     "iopub.status.idle": "2026-06-22T19:18:46.434348Z",
+     "shell.execute_reply": "2026-06-22T19:18:46.434348Z"
+    },
+    "papermill": {
+     "duration": 0.050255,
+     "end_time": "2026-06-22T19:18:46.434348",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.384093",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -4799,6 +5229,13 @@
    "cell_type": "markdown",
    "id": "e954a1ea",
    "metadata": {
+    "papermill": {
+     "duration": 0.023238,
+     "end_time": "2026-06-22T19:18:46.480312",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.457074",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4838,6 +5275,13 @@
    "cell_type": "markdown",
    "id": "5ce81347",
    "metadata": {
+    "papermill": {
+     "duration": 0.032666,
+     "end_time": "2026-06-22T19:18:46.540806",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.508140",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4867,8 +5311,21 @@
    "execution_count": 21,
    "id": "e53022de",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:18:46.599037Z",
+     "iopub.status.busy": "2026-06-22T19:18:46.598038Z",
+     "iopub.status.idle": "2026-06-22T19:18:46.626642Z",
+     "shell.execute_reply": "2026-06-22T19:18:46.626642Z"
+    },
     "language_info": {
      "name": "polyglot-notebook"
+    },
+    "papermill": {
+     "duration": 0.057245,
+     "end_time": "2026-06-22T19:18:46.626642",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.569397",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -4923,6 +5380,13 @@
    "cell_type": "markdown",
    "id": "b9605c6c",
    "metadata": {
+    "papermill": {
+     "duration": 0.02661,
+     "end_time": "2026-06-22T19:18:46.679369",
+     "exception": false,
+     "start_time": "2026-06-22T19:18:46.652759",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -4962,6 +5426,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 60.726049,
+   "end_time": "2026-06-22T19:18:46.945906",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Infer-11-Sequences.ipynb",
+   "output_path": "Infer-11-Sequences.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-22T19:17:46.219857",
+   "version": "2.6.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Recommenders.ipynb
@@ -5,10 +5,10 @@
    "id": "3e3a7357",
    "metadata": {
     "papermill": {
-     "duration": 0.022532,
-     "end_time": "2026-06-09T09:38:41.839989",
+     "duration": 0.007,
+     "end_time": "2026-06-22T19:18:50.779346",
      "exception": false,
-     "start_time": "2026-06-09T09:38:41.817457",
+     "start_time": "2026-06-22T19:18:50.772346",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "111e0303",
    "metadata": {
     "papermill": {
-     "duration": 0.02943,
-     "end_time": "2026-06-09T09:38:41.894181",
+     "duration": 0.00612,
+     "end_time": "2026-06-22T19:18:50.794377",
      "exception": false,
-     "start_time": "2026-06-09T09:38:41.864751",
+     "start_time": "2026-06-22T19:18:50.788257",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:41.981016Z",
-     "iopub.status.busy": "2026-06-09T09:38:41.972420Z",
-     "iopub.status.idle": "2026-06-09T09:38:50.147567Z",
-     "shell.execute_reply": "2026-06-09T09:38:50.138033Z"
+     "iopub.execute_input": "2026-06-22T19:18:50.814773Z",
+     "iopub.status.busy": "2026-06-22T19:18:50.810635Z",
+     "iopub.status.idle": "2026-06-22T19:18:53.393229Z",
+     "shell.execute_reply": "2026-06-22T19:18:53.390123Z"
     },
     "papermill": {
-     "duration": 8.217557,
-     "end_time": "2026-06-09T09:38:50.147858",
+     "duration": 2.592853,
+     "end_time": "2026-06-22T19:18:53.393229",
      "exception": false,
-     "start_time": "2026-06-09T09:38:41.930301",
+     "start_time": "2026-06-22T19:18:50.800376",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -94,7 +94,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-31036.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-101708.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -139,12 +139,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.83.164.85:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '31036.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '101708.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -241,10 +241,10 @@
    "id": "61b7d25a",
    "metadata": {
     "papermill": {
-     "duration": 0.026558,
-     "end_time": "2026-06-09T09:38:50.200270",
+     "duration": 0.01077,
+     "end_time": "2026-06-22T19:18:53.415275",
      "exception": false,
-     "start_time": "2026-06-09T09:38:50.173712",
+     "start_time": "2026-06-22T19:18:53.404505",
      "status": "completed"
     },
     "tags": []
@@ -259,16 +259,16 @@
    "id": "5e1c85830652",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:50.268940Z",
-     "iopub.status.busy": "2026-06-09T09:38:50.268398Z",
-     "iopub.status.idle": "2026-06-09T09:38:51.869908Z",
-     "shell.execute_reply": "2026-06-09T09:38:51.869547Z"
+     "iopub.execute_input": "2026-06-22T19:18:53.437378Z",
+     "iopub.status.busy": "2026-06-22T19:18:53.437378Z",
+     "iopub.status.idle": "2026-06-22T19:18:54.001443Z",
+     "shell.execute_reply": "2026-06-22T19:18:54.001443Z"
     },
     "papermill": {
-     "duration": 1.638368,
-     "end_time": "2026-06-09T09:38:51.870102",
+     "duration": 0.575787,
+     "end_time": "2026-06-22T19:18:54.001443",
      "exception": false,
-     "start_time": "2026-06-09T09:38:50.231734",
+     "start_time": "2026-06-22T19:18:53.425656",
      "status": "completed"
     },
     "tags": [],
@@ -297,10 +297,10 @@
    "id": "r0agasglm9l",
    "metadata": {
     "papermill": {
-     "duration": 0.016904,
-     "end_time": "2026-06-09T09:38:51.904460",
+     "duration": 0.012484,
+     "end_time": "2026-06-22T19:18:54.024767",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.887556",
+     "start_time": "2026-06-22T19:18:54.012283",
      "status": "completed"
     },
     "tags": []
@@ -321,10 +321,10 @@
    "id": "627137ed",
    "metadata": {
     "papermill": {
-     "duration": 0.018712,
-     "end_time": "2026-06-09T09:38:51.939962",
+     "duration": 0.009714,
+     "end_time": "2026-06-22T19:18:54.046921",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.921250",
+     "start_time": "2026-06-22T19:18:54.037207",
      "status": "completed"
     },
     "tags": []
@@ -360,10 +360,10 @@
    "id": "200af10a",
    "metadata": {
     "papermill": {
-     "duration": 0.023171,
-     "end_time": "2026-06-09T09:38:51.980322",
+     "duration": 0.006019,
+     "end_time": "2026-06-22T19:18:54.060713",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.957151",
+     "start_time": "2026-06-22T19:18:54.054694",
      "status": "completed"
     },
     "tags": []
@@ -399,10 +399,10 @@
    "id": "mvmlffi7lf",
    "metadata": {
     "papermill": {
-     "duration": 0.022761,
-     "end_time": "2026-06-09T09:38:52.029421",
+     "duration": 0.005023,
+     "end_time": "2026-06-22T19:18:54.071494",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.006660",
+     "start_time": "2026-06-22T19:18:54.066471",
      "status": "completed"
     },
     "tags": []
@@ -427,16 +427,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:52.095033Z",
-     "iopub.status.busy": "2026-06-09T09:38:52.094519Z",
-     "iopub.status.idle": "2026-06-09T09:38:52.306795Z",
-     "shell.execute_reply": "2026-06-09T09:38:52.306393Z"
+     "iopub.execute_input": "2026-06-22T19:18:54.100504Z",
+     "iopub.status.busy": "2026-06-22T19:18:54.100504Z",
+     "iopub.status.idle": "2026-06-22T19:18:54.198156Z",
+     "shell.execute_reply": "2026-06-22T19:18:54.197157Z"
     },
     "papermill": {
-     "duration": 0.247193,
-     "end_time": "2026-06-09T09:38:52.306989",
+     "duration": 0.115654,
+     "end_time": "2026-06-22T19:18:54.198156",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.059796",
+     "start_time": "2026-06-22T19:18:54.082502",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -562,10 +562,10 @@
    "id": "6t4pu9qx6pb",
    "metadata": {
     "papermill": {
-     "duration": 0.020396,
-     "end_time": "2026-06-09T09:38:52.346962",
+     "duration": 0.011999,
+     "end_time": "2026-06-22T19:18:54.221165",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.326566",
+     "start_time": "2026-06-22T19:18:54.209166",
      "status": "completed"
     },
     "tags": []
@@ -600,10 +600,10 @@
    "id": "ur0jmxpqu1i",
    "metadata": {
     "papermill": {
-     "duration": 0.020015,
-     "end_time": "2026-06-09T09:38:52.384386",
+     "duration": 0.011747,
+     "end_time": "2026-06-22T19:18:54.244329",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.364371",
+     "start_time": "2026-06-22T19:18:54.232582",
      "status": "completed"
     },
     "tags": []
@@ -632,16 +632,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:52.423947Z",
-     "iopub.status.busy": "2026-06-09T09:38:52.423440Z",
-     "iopub.status.idle": "2026-06-09T09:38:52.774328Z",
-     "shell.execute_reply": "2026-06-09T09:38:52.773922Z"
+     "iopub.execute_input": "2026-06-22T19:18:54.270897Z",
+     "iopub.status.busy": "2026-06-22T19:18:54.270897Z",
+     "iopub.status.idle": "2026-06-22T19:18:54.499360Z",
+     "shell.execute_reply": "2026-06-22T19:18:54.499360Z"
     },
     "papermill": {
-     "duration": 0.371611,
-     "end_time": "2026-06-09T09:38:52.774523",
+     "duration": 0.242827,
+     "end_time": "2026-06-22T19:18:54.499360",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.402912",
+     "start_time": "2026-06-22T19:18:54.256533",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -688,10 +688,10 @@
    "id": "er7occkq7c",
    "metadata": {
     "papermill": {
-     "duration": 0.022984,
-     "end_time": "2026-06-09T09:38:52.818249",
+     "duration": 0.020135,
+     "end_time": "2026-06-22T19:18:54.539533",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.795265",
+     "start_time": "2026-06-22T19:18:54.519398",
      "status": "completed"
     },
     "tags": []
@@ -727,10 +727,10 @@
    "id": "sm96ir761m",
    "metadata": {
     "papermill": {
-     "duration": 0.018724,
-     "end_time": "2026-06-09T09:38:52.857188",
+     "duration": 0.021995,
+     "end_time": "2026-06-22T19:18:54.594497",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.838464",
+     "start_time": "2026-06-22T19:18:54.572502",
      "status": "completed"
     },
     "tags": []
@@ -759,16 +759,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:52.900502Z",
-     "iopub.status.busy": "2026-06-09T09:38:52.899980Z",
-     "iopub.status.idle": "2026-06-09T09:38:53.063744Z",
-     "shell.execute_reply": "2026-06-09T09:38:53.063376Z"
+     "iopub.execute_input": "2026-06-22T19:18:54.637995Z",
+     "iopub.status.busy": "2026-06-22T19:18:54.637482Z",
+     "iopub.status.idle": "2026-06-22T19:18:54.734174Z",
+     "shell.execute_reply": "2026-06-22T19:18:54.734174Z"
     },
     "papermill": {
-     "duration": 0.185805,
-     "end_time": "2026-06-09T09:38:53.063929",
+     "duration": 0.117182,
+     "end_time": "2026-06-22T19:18:54.734174",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.878124",
+     "start_time": "2026-06-22T19:18:54.616992",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -815,10 +815,10 @@
    "id": "gftckt8jac7",
    "metadata": {
     "papermill": {
-     "duration": 0.027569,
-     "end_time": "2026-06-09T09:38:53.117523",
+     "duration": 0.013322,
+     "end_time": "2026-06-22T19:18:54.759897",
      "exception": false,
-     "start_time": "2026-06-09T09:38:53.089954",
+     "start_time": "2026-06-22T19:18:54.746575",
      "status": "completed"
     },
     "tags": []
@@ -847,16 +847,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:53.172520Z",
-     "iopub.status.busy": "2026-06-09T09:38:53.171924Z",
-     "iopub.status.idle": "2026-06-09T09:39:01.189614Z",
-     "shell.execute_reply": "2026-06-09T09:39:01.189199Z"
+     "iopub.execute_input": "2026-06-22T19:18:54.785453Z",
+     "iopub.status.busy": "2026-06-22T19:18:54.785453Z",
+     "iopub.status.idle": "2026-06-22T19:18:58.364696Z",
+     "shell.execute_reply": "2026-06-22T19:18:58.364696Z"
     },
     "papermill": {
-     "duration": 8.044175,
-     "end_time": "2026-06-09T09:39:01.189958",
+     "duration": 3.593457,
+     "end_time": "2026-06-22T19:18:58.364696",
      "exception": false,
-     "start_time": "2026-06-09T09:38:53.145783",
+     "start_time": "2026-06-22T19:18:54.771239",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -874,38 +874,6 @@
      "text": [
       "\n",
       "=== Inference ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_01_46_22_49.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -1525,10 +1493,10 @@
    "id": "e6b2h61zy1n",
    "metadata": {
     "papermill": {
-     "duration": 0.050199,
-     "end_time": "2026-06-09T09:39:01.325589",
+     "duration": 0.014788,
+     "end_time": "2026-06-22T19:18:58.396264",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.275390",
+     "start_time": "2026-06-22T19:18:58.381476",
      "status": "completed"
     },
     "tags": []
@@ -1566,10 +1534,10 @@
    "id": "6bbe575e7c97",
    "metadata": {
     "papermill": {
-     "duration": 0.043491,
-     "end_time": "2026-06-09T09:39:01.410416",
+     "duration": 0.016004,
+     "end_time": "2026-06-22T19:18:58.427271",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.366925",
+     "start_time": "2026-06-22T19:18:58.411267",
      "status": "completed"
     },
     "tags": []
@@ -1593,16 +1561,16 @@
    "id": "dce24b880838",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:01.468020Z",
-     "iopub.status.busy": "2026-06-09T09:39:01.467507Z",
-     "iopub.status.idle": "2026-06-09T09:39:01.611472Z",
-     "shell.execute_reply": "2026-06-09T09:39:01.611110Z"
+     "iopub.execute_input": "2026-06-22T19:18:58.458941Z",
+     "iopub.status.busy": "2026-06-22T19:18:58.458941Z",
+     "iopub.status.idle": "2026-06-22T19:18:58.601456Z",
+     "shell.execute_reply": "2026-06-22T19:18:58.600464Z"
     },
     "papermill": {
-     "duration": 0.173329,
-     "end_time": "2026-06-09T09:39:01.611652",
+     "duration": 0.159518,
+     "end_time": "2026-06-22T19:18:58.601456",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.438323",
+     "start_time": "2026-06-22T19:18:58.441938",
      "status": "completed"
     },
     "tags": [],
@@ -1614,14 +1582,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_20_26_01_46_22_49.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_18_54_90.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"345pt\" height=\"809pt\"\r\n",
@@ -1885,8 +1853,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1898,7 +1866,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1913,10 +1881,10 @@
    "id": "3i30sjg9a0l",
    "metadata": {
     "papermill": {
-     "duration": 0.026512,
-     "end_time": "2026-06-09T09:39:01.668011",
+     "duration": 0.014001,
+     "end_time": "2026-06-22T19:18:58.637251",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.641499",
+     "start_time": "2026-06-22T19:18:58.623250",
      "status": "completed"
     },
     "tags": []
@@ -1942,10 +1910,10 @@
    "id": "ykur4bu57gs",
    "metadata": {
     "papermill": {
-     "duration": 0.030565,
-     "end_time": "2026-06-09T09:39:01.726724",
+     "duration": 0.015524,
+     "end_time": "2026-06-22T19:18:58.668782",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.696159",
+     "start_time": "2026-06-22T19:18:58.653258",
      "status": "completed"
     },
     "tags": []
@@ -1967,16 +1935,16 @@
    "id": "9zx24xbim5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:01.799730Z",
-     "iopub.status.busy": "2026-06-09T09:39:01.799216Z",
-     "iopub.status.idle": "2026-06-09T09:39:02.026417Z",
-     "shell.execute_reply": "2026-06-09T09:39:02.004005Z"
+     "iopub.execute_input": "2026-06-22T19:18:58.706473Z",
+     "iopub.status.busy": "2026-06-22T19:18:58.706473Z",
+     "iopub.status.idle": "2026-06-22T19:18:58.789683Z",
+     "shell.execute_reply": "2026-06-22T19:18:58.781691Z"
     },
     "papermill": {
-     "duration": 0.265727,
-     "end_time": "2026-06-09T09:39:02.026606",
+     "duration": 0.10321,
+     "end_time": "2026-06-22T19:18:58.789683",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.760879",
+     "start_time": "2026-06-22T19:18:58.686473",
      "status": "completed"
     },
     "tags": [],
@@ -2319,10 +2287,10 @@
    "id": "unvld23w1oh",
    "metadata": {
     "papermill": {
-     "duration": 0.049778,
-     "end_time": "2026-06-09T09:39:02.123018",
+     "duration": 0.023119,
+     "end_time": "2026-06-22T19:18:58.832810",
      "exception": false,
-     "start_time": "2026-06-09T09:39:02.073240",
+     "start_time": "2026-06-22T19:18:58.809691",
      "status": "completed"
     },
     "tags": []
@@ -2348,16 +2316,16 @@
    "id": "mh2456tb4z",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:02.211969Z",
-     "iopub.status.busy": "2026-06-09T09:39:02.211479Z",
-     "iopub.status.idle": "2026-06-09T09:39:02.405808Z",
-     "shell.execute_reply": "2026-06-09T09:39:02.405407Z"
+     "iopub.execute_input": "2026-06-22T19:18:58.889220Z",
+     "iopub.status.busy": "2026-06-22T19:18:58.889220Z",
+     "iopub.status.idle": "2026-06-22T19:18:58.976838Z",
+     "shell.execute_reply": "2026-06-22T19:18:58.976838Z"
     },
     "papermill": {
-     "duration": 0.230791,
-     "end_time": "2026-06-09T09:39:02.405998",
+     "duration": 0.117015,
+     "end_time": "2026-06-22T19:18:58.976838",
      "exception": false,
-     "start_time": "2026-06-09T09:39:02.175207",
+     "start_time": "2026-06-22T19:18:58.859823",
      "status": "completed"
     },
     "tags": [],
@@ -2447,10 +2415,10 @@
    "id": "nf6qmv9l55s",
    "metadata": {
     "papermill": {
-     "duration": 0.032849,
-     "end_time": "2026-06-09T09:39:02.476510",
+     "duration": 0.022715,
+     "end_time": "2026-06-22T19:18:59.023554",
      "exception": false,
-     "start_time": "2026-06-09T09:39:02.443661",
+     "start_time": "2026-06-22T19:18:59.000839",
      "status": "completed"
     },
     "tags": []
@@ -2481,10 +2449,10 @@
    "id": "jz4ci2kh7ta",
    "metadata": {
     "papermill": {
-     "duration": 0.03798,
-     "end_time": "2026-06-09T09:39:02.550214",
+     "duration": 0.020546,
+     "end_time": "2026-06-22T19:18:59.065758",
      "exception": false,
-     "start_time": "2026-06-09T09:39:02.512234",
+     "start_time": "2026-06-22T19:18:59.045212",
      "status": "completed"
     },
     "tags": []
@@ -2501,16 +2469,16 @@
    "id": "24aadgud61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:02.633884Z",
-     "iopub.status.busy": "2026-06-09T09:39:02.633301Z",
-     "iopub.status.idle": "2026-06-09T09:39:05.776912Z",
-     "shell.execute_reply": "2026-06-09T09:39:05.742150Z"
+     "iopub.execute_input": "2026-06-22T19:18:59.117268Z",
+     "iopub.status.busy": "2026-06-22T19:18:59.117268Z",
+     "iopub.status.idle": "2026-06-22T19:19:00.615050Z",
+     "shell.execute_reply": "2026-06-22T19:19:00.603804Z"
     },
     "papermill": {
-     "duration": 3.187025,
-     "end_time": "2026-06-09T09:39:05.777099",
+     "duration": 1.523776,
+     "end_time": "2026-06-22T19:19:00.615050",
      "exception": false,
-     "start_time": "2026-06-09T09:39:02.590074",
+     "start_time": "2026-06-22T19:18:59.091274",
      "status": "completed"
     },
     "tags": [],
@@ -3005,10 +2973,10 @@
    "id": "0542178806a7",
    "metadata": {
     "papermill": {
-     "duration": 0.057189,
-     "end_time": "2026-06-09T09:39:05.872826",
+     "duration": 0.021821,
+     "end_time": "2026-06-22T19:19:00.658045",
      "exception": false,
-     "start_time": "2026-06-09T09:39:05.815637",
+     "start_time": "2026-06-22T19:19:00.636224",
      "status": "completed"
     },
     "tags": []
@@ -3032,16 +3000,16 @@
    "id": "01c324c1cb17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:06.001260Z",
-     "iopub.status.busy": "2026-06-09T09:39:06.000748Z",
-     "iopub.status.idle": "2026-06-09T09:39:06.114431Z",
-     "shell.execute_reply": "2026-06-09T09:39:06.114771Z"
+     "iopub.execute_input": "2026-06-22T19:19:00.732379Z",
+     "iopub.status.busy": "2026-06-22T19:19:00.732379Z",
+     "iopub.status.idle": "2026-06-22T19:19:00.827758Z",
+     "shell.execute_reply": "2026-06-22T19:19:00.827758Z"
     },
     "papermill": {
-     "duration": 0.172215,
-     "end_time": "2026-06-09T09:39:06.114943",
+     "duration": 0.139687,
+     "end_time": "2026-06-22T19:19:00.828766",
      "exception": false,
-     "start_time": "2026-06-09T09:39:05.942728",
+     "start_time": "2026-06-22T19:19:00.689079",
      "status": "completed"
     },
     "tags": [],
@@ -3053,14 +3021,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_20_26_01_46_22_49.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_18_54_90.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"345pt\" height=\"809pt\"\r\n",
@@ -3324,8 +3292,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -3337,7 +3305,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -3352,10 +3320,10 @@
    "id": "rvr5f1ahk4",
    "metadata": {
     "papermill": {
-     "duration": 0.062052,
-     "end_time": "2026-06-09T09:39:06.245504",
+     "duration": 0.026587,
+     "end_time": "2026-06-22T19:19:00.887161",
      "exception": false,
-     "start_time": "2026-06-09T09:39:06.183452",
+     "start_time": "2026-06-22T19:19:00.860574",
      "status": "completed"
     },
     "tags": []
@@ -3376,16 +3344,16 @@
    "id": "hghiozc7b0k",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:06.373651Z",
-     "iopub.status.busy": "2026-06-09T09:39:06.372998Z",
-     "iopub.status.idle": "2026-06-09T09:39:06.553459Z",
-     "shell.execute_reply": "2026-06-09T09:39:06.533321Z"
+     "iopub.execute_input": "2026-06-22T19:19:00.941792Z",
+     "iopub.status.busy": "2026-06-22T19:19:00.941792Z",
+     "iopub.status.idle": "2026-06-22T19:19:01.019893Z",
+     "shell.execute_reply": "2026-06-22T19:19:01.008894Z"
     },
     "papermill": {
-     "duration": 0.234873,
-     "end_time": "2026-06-09T09:39:06.553640",
+     "duration": 0.104699,
+     "end_time": "2026-06-22T19:19:01.019893",
      "exception": false,
-     "start_time": "2026-06-09T09:39:06.318767",
+     "start_time": "2026-06-22T19:19:00.915194",
      "status": "completed"
     },
     "tags": [],
@@ -3785,10 +3753,10 @@
    "id": "9bmicn9ogwa",
    "metadata": {
     "papermill": {
-     "duration": 0.04987,
-     "end_time": "2026-06-09T09:39:06.646426",
+     "duration": 0.023777,
+     "end_time": "2026-06-22T19:19:01.069670",
      "exception": false,
-     "start_time": "2026-06-09T09:39:06.596556",
+     "start_time": "2026-06-22T19:19:01.045893",
      "status": "completed"
     },
     "tags": []
@@ -3834,10 +3802,10 @@
    "id": "97d9f518",
    "metadata": {
     "papermill": {
-     "duration": 0.051111,
-     "end_time": "2026-06-09T09:39:06.750833",
+     "duration": 0.022,
+     "end_time": "2026-06-22T19:19:01.114673",
      "exception": false,
-     "start_time": "2026-06-09T09:39:06.699722",
+     "start_time": "2026-06-22T19:19:01.092673",
      "status": "completed"
     },
     "tags": []
@@ -3853,10 +3821,10 @@
    "id": "ncqavjm2nop",
    "metadata": {
     "papermill": {
-     "duration": 0.061408,
-     "end_time": "2026-06-09T09:39:06.875794",
+     "duration": 0.029508,
+     "end_time": "2026-06-22T19:19:01.167182",
      "exception": false,
-     "start_time": "2026-06-09T09:39:06.814386",
+     "start_time": "2026-06-22T19:19:01.137674",
      "status": "completed"
     },
     "tags": []
@@ -3876,16 +3844,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:07.030131Z",
-     "iopub.status.busy": "2026-06-09T09:39:07.029444Z",
-     "iopub.status.idle": "2026-06-09T09:39:07.189961Z",
-     "shell.execute_reply": "2026-06-09T09:39:07.166260Z"
+     "iopub.execute_input": "2026-06-22T19:19:01.228737Z",
+     "iopub.status.busy": "2026-06-22T19:19:01.228737Z",
+     "iopub.status.idle": "2026-06-22T19:19:01.289616Z",
+     "shell.execute_reply": "2026-06-22T19:19:01.283440Z"
     },
     "papermill": {
-     "duration": 0.239753,
-     "end_time": "2026-06-09T09:39:07.190171",
+     "duration": 0.09288,
+     "end_time": "2026-06-22T19:19:01.289616",
      "exception": false,
-     "start_time": "2026-06-09T09:39:06.950418",
+     "start_time": "2026-06-22T19:19:01.196736",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4164,10 +4132,10 @@
    "id": "5rjas07dwcj",
    "metadata": {
     "papermill": {
-     "duration": 0.061609,
-     "end_time": "2026-06-09T09:39:07.314059",
+     "duration": 0.02417,
+     "end_time": "2026-06-22T19:19:01.340437",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.252450",
+     "start_time": "2026-06-22T19:19:01.316267",
      "status": "completed"
     },
     "tags": []
@@ -4207,10 +4175,10 @@
    "id": "ef7b08f6",
    "metadata": {
     "papermill": {
-     "duration": 0.070333,
-     "end_time": "2026-06-09T09:39:07.452160",
+     "duration": 0.030081,
+     "end_time": "2026-06-22T19:19:01.397545",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.381827",
+     "start_time": "2026-06-22T19:19:01.367464",
      "status": "completed"
     },
     "tags": []
@@ -4231,10 +4199,10 @@
    "id": "z1vvgb32pnp",
    "metadata": {
     "papermill": {
-     "duration": 0.064596,
-     "end_time": "2026-06-09T09:39:07.598534",
+     "duration": 0.022245,
+     "end_time": "2026-06-22T19:19:01.443238",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.533938",
+     "start_time": "2026-06-22T19:19:01.420993",
      "status": "completed"
     },
     "tags": []
@@ -4265,10 +4233,10 @@
    "id": "d2jlbclb74q",
    "metadata": {
     "papermill": {
-     "duration": 0.056202,
-     "end_time": "2026-06-09T09:39:07.713053",
+     "duration": 0.030789,
+     "end_time": "2026-06-22T19:19:01.499550",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.656851",
+     "start_time": "2026-06-22T19:19:01.468761",
      "status": "completed"
     },
     "tags": []
@@ -4299,16 +4267,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:07.825486Z",
-     "iopub.status.busy": "2026-06-09T09:39:07.824512Z",
-     "iopub.status.idle": "2026-06-09T09:39:07.910840Z",
-     "shell.execute_reply": "2026-06-09T09:39:07.910454Z"
+     "iopub.execute_input": "2026-06-22T19:19:01.560007Z",
+     "iopub.status.busy": "2026-06-22T19:19:01.560007Z",
+     "iopub.status.idle": "2026-06-22T19:19:01.601195Z",
+     "shell.execute_reply": "2026-06-22T19:19:01.601195Z"
     },
     "papermill": {
-     "duration": 0.142267,
-     "end_time": "2026-06-09T09:39:07.911047",
+     "duration": 0.069778,
+     "end_time": "2026-06-22T19:19:01.601195",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.768780",
+     "start_time": "2026-06-22T19:19:01.531417",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4377,10 +4345,10 @@
    "id": "mxz8l5y7ded",
    "metadata": {
     "papermill": {
-     "duration": 0.051283,
-     "end_time": "2026-06-09T09:39:08.019721",
+     "duration": 0.029192,
+     "end_time": "2026-06-22T19:19:01.656910",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.968438",
+     "start_time": "2026-06-22T19:19:01.627718",
      "status": "completed"
     },
     "tags": []
@@ -4408,16 +4376,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:08.151044Z",
-     "iopub.status.busy": "2026-06-09T09:39:08.150516Z",
-     "iopub.status.idle": "2026-06-09T09:39:08.252441Z",
-     "shell.execute_reply": "2026-06-09T09:39:08.252073Z"
+     "iopub.execute_input": "2026-06-22T19:19:01.716311Z",
+     "iopub.status.busy": "2026-06-22T19:19:01.716311Z",
+     "iopub.status.idle": "2026-06-22T19:19:01.760661Z",
+     "shell.execute_reply": "2026-06-22T19:19:01.760661Z"
     },
     "papermill": {
-     "duration": 0.173885,
-     "end_time": "2026-06-09T09:39:08.252635",
+     "duration": 0.075572,
+     "end_time": "2026-06-22T19:19:01.761662",
      "exception": false,
-     "start_time": "2026-06-09T09:39:08.078750",
+     "start_time": "2026-06-22T19:19:01.686090",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4461,10 +4429,10 @@
    "id": "e7weqfh0y3g",
    "metadata": {
     "papermill": {
-     "duration": 0.084559,
-     "end_time": "2026-06-09T09:39:08.411242",
+     "duration": 0.034999,
+     "end_time": "2026-06-22T19:19:01.829789",
      "exception": false,
-     "start_time": "2026-06-09T09:39:08.326683",
+     "start_time": "2026-06-22T19:19:01.794790",
      "status": "completed"
     },
     "tags": []
@@ -4486,10 +4454,10 @@
    "id": "21k2m4s6mvy",
    "metadata": {
     "papermill": {
-     "duration": 0.062689,
-     "end_time": "2026-06-09T09:39:08.560223",
+     "duration": 0.035111,
+     "end_time": "2026-06-22T19:19:01.899943",
      "exception": false,
-     "start_time": "2026-06-09T09:39:08.497534",
+     "start_time": "2026-06-22T19:19:01.864832",
      "status": "completed"
     },
     "tags": []
@@ -4516,16 +4484,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:08.680261Z",
-     "iopub.status.busy": "2026-06-09T09:39:08.679749Z",
-     "iopub.status.idle": "2026-06-09T09:39:08.764740Z",
-     "shell.execute_reply": "2026-06-09T09:39:08.765099Z"
+     "iopub.execute_input": "2026-06-22T19:19:01.955225Z",
+     "iopub.status.busy": "2026-06-22T19:19:01.954226Z",
+     "iopub.status.idle": "2026-06-22T19:19:01.995989Z",
+     "shell.execute_reply": "2026-06-22T19:19:01.994988Z"
     },
     "papermill": {
-     "duration": 0.148014,
-     "end_time": "2026-06-09T09:39:08.765288",
+     "duration": 0.067493,
+     "end_time": "2026-06-22T19:19:01.995989",
      "exception": false,
-     "start_time": "2026-06-09T09:39:08.617274",
+     "start_time": "2026-06-22T19:19:01.928496",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4642,10 +4610,10 @@
    "id": "275qi7deg4o",
    "metadata": {
     "papermill": {
-     "duration": 0.056441,
-     "end_time": "2026-06-09T09:39:08.875561",
+     "duration": 0.034337,
+     "end_time": "2026-06-22T19:19:02.050339",
      "exception": false,
-     "start_time": "2026-06-09T09:39:08.819120",
+     "start_time": "2026-06-22T19:19:02.016002",
      "status": "completed"
     },
     "tags": []
@@ -4687,10 +4655,10 @@
    "id": "f78795c9",
    "metadata": {
     "papermill": {
-     "duration": 0.063434,
-     "end_time": "2026-06-09T09:39:09.014120",
+     "duration": 0.034,
+     "end_time": "2026-06-22T19:19:02.119866",
      "exception": false,
-     "start_time": "2026-06-09T09:39:08.950686",
+     "start_time": "2026-06-22T19:19:02.085866",
      "status": "completed"
     },
     "tags": []
@@ -4731,16 +4699,16 @@
    "id": "b857098f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:09.167685Z",
-     "iopub.status.busy": "2026-06-09T09:39:09.167122Z",
-     "iopub.status.idle": "2026-06-09T09:39:09.272765Z",
-     "shell.execute_reply": "2026-06-09T09:39:09.271885Z"
+     "iopub.execute_input": "2026-06-22T19:19:02.183298Z",
+     "iopub.status.busy": "2026-06-22T19:19:02.182300Z",
+     "iopub.status.idle": "2026-06-22T19:19:02.217994Z",
+     "shell.execute_reply": "2026-06-22T19:19:02.217994Z"
     },
     "papermill": {
-     "duration": 0.184924,
-     "end_time": "2026-06-09T09:39:09.272971",
+     "duration": 0.0649,
+     "end_time": "2026-06-22T19:19:02.217994",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.088047",
+     "start_time": "2026-06-22T19:19:02.153094",
      "status": "completed"
     },
     "tags": []
@@ -4791,10 +4759,10 @@
    "id": "ee734922",
    "metadata": {
     "papermill": {
-     "duration": 0.074286,
-     "end_time": "2026-06-09T09:39:09.412990",
+     "duration": 0.024,
+     "end_time": "2026-06-22T19:19:02.314196",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.338704",
+     "start_time": "2026-06-22T19:19:02.290196",
      "status": "completed"
     },
     "tags": []
@@ -4827,10 +4795,10 @@
    "id": "k9xu8ed38t",
    "metadata": {
     "papermill": {
-     "duration": 0.069641,
-     "end_time": "2026-06-09T09:39:09.562714",
+     "duration": 0.024013,
+     "end_time": "2026-06-22T19:19:02.364211",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.493073",
+     "start_time": "2026-06-22T19:19:02.340198",
      "status": "completed"
     },
     "tags": []
@@ -4852,16 +4820,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:09.700623Z",
-     "iopub.status.busy": "2026-06-09T09:39:09.700137Z",
-     "iopub.status.idle": "2026-06-09T09:39:09.784845Z",
-     "shell.execute_reply": "2026-06-09T09:39:09.782737Z"
+     "iopub.execute_input": "2026-06-22T19:19:02.419684Z",
+     "iopub.status.busy": "2026-06-22T19:19:02.418681Z",
+     "iopub.status.idle": "2026-06-22T19:19:02.458292Z",
+     "shell.execute_reply": "2026-06-22T19:19:02.457292Z"
     },
     "papermill": {
-     "duration": 0.1512,
-     "end_time": "2026-06-09T09:39:09.785047",
+     "duration": 0.066611,
+     "end_time": "2026-06-22T19:19:02.458292",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.633847",
+     "start_time": "2026-06-22T19:19:02.391681",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4962,10 +4930,10 @@
    "id": "msribrget5g",
    "metadata": {
     "papermill": {
-     "duration": 0.061078,
-     "end_time": "2026-06-09T09:39:09.909147",
+     "duration": 0.027077,
+     "end_time": "2026-06-22T19:19:02.512021",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.848069",
+     "start_time": "2026-06-22T19:19:02.484944",
      "status": "completed"
     },
     "tags": []
@@ -4988,10 +4956,10 @@
    "id": "2w4ooq3v3v2",
    "metadata": {
     "papermill": {
-     "duration": 0.069541,
-     "end_time": "2026-06-09T09:39:10.052325",
+     "duration": 0.026592,
+     "end_time": "2026-06-22T19:19:02.567158",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.982784",
+     "start_time": "2026-06-22T19:19:02.540566",
      "status": "completed"
     },
     "tags": []
@@ -5023,16 +4991,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:10.219399Z",
-     "iopub.status.busy": "2026-06-09T09:39:10.218866Z",
-     "iopub.status.idle": "2026-06-09T09:39:10.345983Z",
-     "shell.execute_reply": "2026-06-09T09:39:10.345572Z"
+     "iopub.execute_input": "2026-06-22T19:19:02.617748Z",
+     "iopub.status.busy": "2026-06-22T19:19:02.617748Z",
+     "iopub.status.idle": "2026-06-22T19:19:02.659163Z",
+     "shell.execute_reply": "2026-06-22T19:19:02.659163Z"
     },
     "papermill": {
-     "duration": 0.2131,
-     "end_time": "2026-06-09T09:39:10.346185",
+     "duration": 0.067454,
+     "end_time": "2026-06-22T19:19:02.659163",
      "exception": false,
-     "start_time": "2026-06-09T09:39:10.133085",
+     "start_time": "2026-06-22T19:19:02.591709",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -5088,10 +5056,10 @@
    "id": "96x87un3t3g",
    "metadata": {
     "papermill": {
-     "duration": 0.068841,
-     "end_time": "2026-06-09T09:39:10.480111",
+     "duration": 0.026857,
+     "end_time": "2026-06-22T19:19:02.714698",
      "exception": false,
-     "start_time": "2026-06-09T09:39:10.411270",
+     "start_time": "2026-06-22T19:19:02.687841",
      "status": "completed"
     },
     "tags": []
@@ -5121,10 +5089,10 @@
    "id": "jng5taw0ubm",
    "metadata": {
     "papermill": {
-     "duration": 0.061607,
-     "end_time": "2026-06-09T09:39:10.606644",
+     "duration": 0.031575,
+     "end_time": "2026-06-22T19:19:02.771281",
      "exception": false,
-     "start_time": "2026-06-09T09:39:10.545037",
+     "start_time": "2026-06-22T19:19:02.739706",
      "status": "completed"
     },
     "tags": []
@@ -5149,16 +5117,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:10.759187Z",
-     "iopub.status.busy": "2026-06-09T09:39:10.758666Z",
-     "iopub.status.idle": "2026-06-09T09:39:12.190126Z",
-     "shell.execute_reply": "2026-06-09T09:39:12.188922Z"
+     "iopub.execute_input": "2026-06-22T19:19:02.825046Z",
+     "iopub.status.busy": "2026-06-22T19:19:02.825046Z",
+     "iopub.status.idle": "2026-06-22T19:19:03.571696Z",
+     "shell.execute_reply": "2026-06-22T19:19:03.571696Z"
     },
     "papermill": {
-     "duration": 1.502639,
-     "end_time": "2026-06-09T09:39:12.190328",
+     "duration": 0.774137,
+     "end_time": "2026-06-22T19:19:03.571696",
      "exception": false,
-     "start_time": "2026-06-09T09:39:10.687689",
+     "start_time": "2026-06-22T19:19:02.797559",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -5176,38 +5144,6 @@
      "text": [
       "\n",
       "=== Inference Click Model ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_20_26_01_46_30_44.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -5720,10 +5656,10 @@
    "id": "v1yv6vu72ag",
    "metadata": {
     "papermill": {
-     "duration": 0.097371,
-     "end_time": "2026-06-09T09:39:12.354116",
+     "duration": 0.028001,
+     "end_time": "2026-06-22T19:19:03.629331",
      "exception": false,
-     "start_time": "2026-06-09T09:39:12.256745",
+     "start_time": "2026-06-22T19:19:03.601330",
      "status": "completed"
     },
     "tags": []
@@ -5764,10 +5700,10 @@
    "id": "a8ff4b7ac191",
    "metadata": {
     "papermill": {
-     "duration": 0.081642,
-     "end_time": "2026-06-09T09:39:12.520912",
+     "duration": 0.027088,
+     "end_time": "2026-06-22T19:19:03.683412",
      "exception": false,
-     "start_time": "2026-06-09T09:39:12.439270",
+     "start_time": "2026-06-22T19:19:03.656324",
      "status": "completed"
     },
     "tags": []
@@ -5791,16 +5727,16 @@
    "id": "843556ef647c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:12.662259Z",
-     "iopub.status.busy": "2026-06-09T09:39:12.661711Z",
-     "iopub.status.idle": "2026-06-09T09:39:12.723315Z",
-     "shell.execute_reply": "2026-06-09T09:39:12.723627Z"
+     "iopub.execute_input": "2026-06-22T19:19:03.742197Z",
+     "iopub.status.busy": "2026-06-22T19:19:03.741690Z",
+     "iopub.status.idle": "2026-06-22T19:19:03.837659Z",
+     "shell.execute_reply": "2026-06-22T19:19:03.837659Z"
     },
     "papermill": {
-     "duration": 0.116216,
-     "end_time": "2026-06-09T09:39:12.723813",
+     "duration": 0.125693,
+     "end_time": "2026-06-22T19:19:03.837659",
      "exception": false,
-     "start_time": "2026-06-09T09:39:12.607597",
+     "start_time": "2026-06-22T19:19:03.711966",
      "status": "completed"
     },
     "tags": [],
@@ -5812,14 +5748,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_20_26_01_46_30_44.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_19_02_87.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"488pt\" height=\"508pt\"\r\n",
@@ -6101,8 +6037,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -6114,7 +6050,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -6129,10 +6065,10 @@
    "id": "hjpzc1z1emj",
    "metadata": {
     "papermill": {
-     "duration": 0.052776,
-     "end_time": "2026-06-09T09:39:12.827218",
+     "duration": 0.028229,
+     "end_time": "2026-06-22T19:19:03.892904",
      "exception": false,
-     "start_time": "2026-06-09T09:39:12.774442",
+     "start_time": "2026-06-22T19:19:03.864675",
      "status": "completed"
     },
     "tags": []
@@ -6152,16 +6088,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:12.939011Z",
-     "iopub.status.busy": "2026-06-09T09:39:12.938508Z",
-     "iopub.status.idle": "2026-06-09T09:39:13.141835Z",
-     "shell.execute_reply": "2026-06-09T09:39:13.141469Z"
+     "iopub.execute_input": "2026-06-22T19:19:03.952314Z",
+     "iopub.status.busy": "2026-06-22T19:19:03.952314Z",
+     "iopub.status.idle": "2026-06-22T19:19:04.024159Z",
+     "shell.execute_reply": "2026-06-22T19:19:04.024159Z"
     },
     "papermill": {
-     "duration": 0.259074,
-     "end_time": "2026-06-09T09:39:13.142017",
+     "duration": 0.102254,
+     "end_time": "2026-06-22T19:19:04.024159",
      "exception": false,
-     "start_time": "2026-06-09T09:39:12.882943",
+     "start_time": "2026-06-22T19:19:03.921905",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6266,10 +6202,10 @@
    "id": "1ov5mwpv8be",
    "metadata": {
     "papermill": {
-     "duration": 0.062363,
-     "end_time": "2026-06-09T09:39:13.259837",
+     "duration": 0.029983,
+     "end_time": "2026-06-22T19:19:04.083684",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.197474",
+     "start_time": "2026-06-22T19:19:04.053701",
      "status": "completed"
     },
     "tags": []
@@ -6309,10 +6245,10 @@
    "id": "b0b9ad1f",
    "metadata": {
     "papermill": {
-     "duration": 0.063457,
-     "end_time": "2026-06-09T09:39:13.384023",
+     "duration": 0.028771,
+     "end_time": "2026-06-22T19:19:04.143299",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.320566",
+     "start_time": "2026-06-22T19:19:04.114528",
      "status": "completed"
     },
     "tags": []
@@ -6358,16 +6294,16 @@
    "id": "d3392b8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:13.548669Z",
-     "iopub.status.busy": "2026-06-09T09:39:13.547922Z",
-     "iopub.status.idle": "2026-06-09T09:39:13.617362Z",
-     "shell.execute_reply": "2026-06-09T09:39:13.616996Z"
+     "iopub.execute_input": "2026-06-22T19:19:04.208223Z",
+     "iopub.status.busy": "2026-06-22T19:19:04.208223Z",
+     "iopub.status.idle": "2026-06-22T19:19:04.237231Z",
+     "shell.execute_reply": "2026-06-22T19:19:04.237231Z"
     },
     "papermill": {
-     "duration": 0.155929,
-     "end_time": "2026-06-09T09:39:13.617549",
+     "duration": 0.062742,
+     "end_time": "2026-06-22T19:19:04.237231",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.461620",
+     "start_time": "2026-06-22T19:19:04.174489",
      "status": "completed"
     },
     "tags": []
@@ -6411,10 +6347,10 @@
    "id": "ex3md0000001",
    "metadata": {
     "papermill": {
-     "duration": 0.054442,
-     "end_time": "2026-06-09T09:39:13.729481",
+     "duration": 0.029074,
+     "end_time": "2026-06-22T19:19:04.294308",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.675039",
+     "start_time": "2026-06-22T19:19:04.265234",
      "status": "completed"
     },
     "tags": []
@@ -6457,16 +6393,16 @@
    "id": "ex3cd0000001",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:13.857483Z",
-     "iopub.status.busy": "2026-06-09T09:39:13.856976Z",
-     "iopub.status.idle": "2026-06-09T09:39:13.913888Z",
-     "shell.execute_reply": "2026-06-09T09:39:13.913528Z"
+     "iopub.execute_input": "2026-06-22T19:19:04.352234Z",
+     "iopub.status.busy": "2026-06-22T19:19:04.351659Z",
+     "iopub.status.idle": "2026-06-22T19:19:04.383893Z",
+     "shell.execute_reply": "2026-06-22T19:19:04.383893Z"
     },
     "papermill": {
-     "duration": 0.113479,
-     "end_time": "2026-06-09T09:39:13.914064",
+     "duration": 0.061521,
+     "end_time": "2026-06-22T19:19:04.383893",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.800585",
+     "start_time": "2026-06-22T19:19:04.322372",
      "status": "completed"
     },
     "tags": []
@@ -6529,10 +6465,10 @@
    "id": "c8a414f6",
    "metadata": {
     "papermill": {
-     "duration": 0.06213,
-     "end_time": "2026-06-09T09:39:14.036573",
+     "duration": 0.028216,
+     "end_time": "2026-06-22T19:19:04.441099",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.974443",
+     "start_time": "2026-06-22T19:19:04.412883",
      "status": "completed"
     },
     "tags": []
@@ -6550,10 +6486,10 @@
    "id": "jhb9hnfi71j",
    "metadata": {
     "papermill": {
-     "duration": 0.078558,
-     "end_time": "2026-06-09T09:39:14.186712",
+     "duration": 0.029941,
+     "end_time": "2026-06-22T19:19:04.498845",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.108154",
+     "start_time": "2026-06-22T19:19:04.468904",
      "status": "completed"
     },
     "tags": []
@@ -6583,10 +6519,10 @@
    "id": "3phruj21691",
    "metadata": {
     "papermill": {
-     "duration": 0.059196,
-     "end_time": "2026-06-09T09:39:14.306450",
+     "duration": 0.037566,
+     "end_time": "2026-06-22T19:19:04.569886",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.247254",
+     "start_time": "2026-06-22T19:19:04.532320",
      "status": "completed"
     },
     "tags": []
@@ -6616,16 +6552,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:14.431473Z",
-     "iopub.status.busy": "2026-06-09T09:39:14.430893Z",
-     "iopub.status.idle": "2026-06-09T09:39:14.589555Z",
-     "shell.execute_reply": "2026-06-09T09:39:14.585336Z"
+     "iopub.execute_input": "2026-06-22T19:19:04.638348Z",
+     "iopub.status.busy": "2026-06-22T19:19:04.637834Z",
+     "iopub.status.idle": "2026-06-22T19:19:04.726007Z",
+     "shell.execute_reply": "2026-06-22T19:19:04.725458Z"
     },
     "papermill": {
-     "duration": 0.222861,
-     "end_time": "2026-06-09T09:39:14.589942",
+     "duration": 0.120856,
+     "end_time": "2026-06-22T19:19:04.726007",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.367081",
+     "start_time": "2026-06-22T19:19:04.605151",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6867,10 +6803,10 @@
    "id": "26o8cdk585s",
    "metadata": {
     "papermill": {
-     "duration": 0.073493,
-     "end_time": "2026-06-09T09:39:14.726267",
+     "duration": 0.031526,
+     "end_time": "2026-06-22T19:19:04.790837",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.652774",
+     "start_time": "2026-06-22T19:19:04.759311",
      "status": "completed"
     },
     "tags": []
@@ -6913,10 +6849,10 @@
    "id": "20kqel1sip",
    "metadata": {
     "papermill": {
-     "duration": 0.063247,
-     "end_time": "2026-06-09T09:39:14.856503",
+     "duration": 0.031925,
+     "end_time": "2026-06-22T19:19:04.855852",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.793256",
+     "start_time": "2026-06-22T19:19:04.823927",
      "status": "completed"
     },
     "tags": []
@@ -6947,10 +6883,10 @@
    "id": "gb0ujeqyrb",
    "metadata": {
     "papermill": {
-     "duration": 0.058756,
-     "end_time": "2026-06-09T09:39:14.973588",
+     "duration": 0.029094,
+     "end_time": "2026-06-22T19:19:04.914940",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.914832",
+     "start_time": "2026-06-22T19:19:04.885846",
      "status": "completed"
     },
     "tags": []
@@ -6979,10 +6915,10 @@
    "id": "2c037f52",
    "metadata": {
     "papermill": {
-     "duration": 0.07374,
-     "end_time": "2026-06-09T09:39:15.105380",
+     "duration": 0.029149,
+     "end_time": "2026-06-22T19:19:04.974403",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.031640",
+     "start_time": "2026-06-22T19:19:04.945254",
      "status": "completed"
     },
     "tags": []
@@ -7045,10 +6981,10 @@
    "id": "1uya34v65pz",
    "metadata": {
     "papermill": {
-     "duration": 0.062143,
-     "end_time": "2026-06-09T09:39:15.243470",
+     "duration": 0.030351,
+     "end_time": "2026-06-22T19:19:05.033720",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.181327",
+     "start_time": "2026-06-22T19:19:05.003369",
      "status": "completed"
     },
     "tags": []
@@ -7087,10 +7023,10 @@
    "id": "b525409c",
    "metadata": {
     "papermill": {
-     "duration": 0.087918,
-     "end_time": "2026-06-09T09:39:15.403669",
+     "duration": 0.042109,
+     "end_time": "2026-06-22T19:19:05.110831",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.315751",
+     "start_time": "2026-06-22T19:19:05.068722",
      "status": "completed"
     },
     "tags": []
@@ -7123,16 +7059,16 @@
    "id": "f38fc327",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:15.530817Z",
-     "iopub.status.busy": "2026-06-09T09:39:15.530290Z",
-     "iopub.status.idle": "2026-06-09T09:39:15.600889Z",
-     "shell.execute_reply": "2026-06-09T09:39:15.600527Z"
+     "iopub.execute_input": "2026-06-22T19:19:05.174357Z",
+     "iopub.status.busy": "2026-06-22T19:19:05.174357Z",
+     "iopub.status.idle": "2026-06-22T19:19:05.210499Z",
+     "shell.execute_reply": "2026-06-22T19:19:05.210499Z"
     },
     "papermill": {
-     "duration": 0.135307,
-     "end_time": "2026-06-09T09:39:15.601070",
+     "duration": 0.066735,
+     "end_time": "2026-06-22T19:19:05.210499",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.465763",
+     "start_time": "2026-06-22T19:19:05.143764",
      "status": "completed"
     },
     "tags": []
@@ -7181,10 +7117,10 @@
    "id": "09e7ba15",
    "metadata": {
     "papermill": {
-     "duration": 0.062239,
-     "end_time": "2026-06-09T09:39:15.722978",
+     "duration": 0.029288,
+     "end_time": "2026-06-22T19:19:05.269298",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.660739",
+     "start_time": "2026-06-22T19:19:05.240010",
      "status": "completed"
     },
     "tags": []
@@ -7221,18 +7157,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 38.104123,
-   "end_time": "2026-06-09T09:39:16.104340",
+   "duration": 16.373246,
+   "end_time": "2026-06-22T19:19:05.534647",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-12-Recommenders.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-12-Recommenders.ipynb",
+   "input_path": "Infer-12-Recommenders.ipynb",
+   "output_path": "Infer-12-Recommenders.ipynb",
    "parameters": {},
-   "start_time": "2026-06-09T09:38:38.000217",
+   "start_time": "2026-06-22T19:18:49.161401",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
@@ -5,10 +5,10 @@
    "id": "0b71b238",
    "metadata": {
     "papermill": {
-     "duration": 0.053988,
-     "end_time": "2026-06-04T06:26:02.465922",
+     "duration": 0.006001,
+     "end_time": "2026-06-22T19:14:57.230942",
      "exception": false,
-     "start_time": "2026-06-04T06:26:02.411934",
+     "start_time": "2026-06-22T19:14:57.224941",
      "status": "completed"
     },
     "tags": []
@@ -46,10 +46,10 @@
    "id": "371477d5",
    "metadata": {
     "papermill": {
-     "duration": 0.020616,
-     "end_time": "2026-06-04T06:26:02.502562",
+     "duration": 0.007209,
+     "end_time": "2026-06-22T19:14:57.244158",
      "exception": false,
-     "start_time": "2026-06-04T06:26:02.481946",
+     "start_time": "2026-06-22T19:14:57.236949",
      "status": "completed"
     },
     "tags": []
@@ -69,16 +69,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:02.545299Z",
-     "iopub.status.busy": "2026-06-04T06:26:02.540614Z",
-     "iopub.status.idle": "2026-06-04T06:26:07.074927Z",
-     "shell.execute_reply": "2026-06-04T06:26:07.071081Z"
+     "iopub.execute_input": "2026-06-22T19:14:57.262019Z",
+     "iopub.status.busy": "2026-06-22T19:14:57.259158Z",
+     "iopub.status.idle": "2026-06-22T19:15:00.501069Z",
+     "shell.execute_reply": "2026-06-22T19:15:00.498060Z"
     },
     "papermill": {
-     "duration": 4.553021,
-     "end_time": "2026-06-04T06:26:07.075119",
+     "duration": 3.250919,
+     "end_time": "2026-06-22T19:15:00.501069",
      "exception": false,
-     "start_time": "2026-06-04T06:26:02.522098",
+     "start_time": "2026-06-22T19:14:57.250150",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -90,6 +90,121 @@
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-68372.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '68372.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/html": [
@@ -110,7 +225,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Graphviz disponible : False\r\n"
+      "Graphviz disponible : True\r\n"
      ]
     }
    ],
@@ -137,10 +252,10 @@
    "id": "b3e128fc",
    "metadata": {
     "papermill": {
-     "duration": 0.012708,
-     "end_time": "2026-06-04T06:26:07.100937",
+     "duration": 0.012,
+     "end_time": "2026-06-22T19:15:00.524728",
      "exception": false,
-     "start_time": "2026-06-04T06:26:07.088229",
+     "start_time": "2026-06-22T19:15:00.512728",
      "status": "completed"
     },
     "tags": []
@@ -175,10 +290,10 @@
    "id": "dfe88a85",
    "metadata": {
     "papermill": {
-     "duration": 0.01959,
-     "end_time": "2026-06-04T06:26:07.133583",
+     "duration": 0.012476,
+     "end_time": "2026-06-22T19:15:00.548598",
      "exception": false,
-     "start_time": "2026-06-04T06:26:07.113993",
+     "start_time": "2026-06-22T19:15:00.536122",
      "status": "completed"
     },
     "tags": []
@@ -208,10 +323,10 @@
    "id": "e797a9b2",
    "metadata": {
     "papermill": {
-     "duration": 0.025237,
-     "end_time": "2026-06-04T06:26:07.174605",
+     "duration": 0.012977,
+     "end_time": "2026-06-22T19:15:00.573464",
      "exception": false,
-     "start_time": "2026-06-04T06:26:07.149368",
+     "start_time": "2026-06-22T19:15:00.560487",
      "status": "completed"
     },
     "tags": []
@@ -227,10 +342,10 @@
    "id": "3hvxpaexqiw",
    "metadata": {
     "papermill": {
-     "duration": 0.011811,
-     "end_time": "2026-06-04T06:26:07.197769",
+     "duration": 0.011001,
+     "end_time": "2026-06-22T19:15:00.595376",
      "exception": false,
-     "start_time": "2026-06-04T06:26:07.185958",
+     "start_time": "2026-06-22T19:15:00.584375",
      "status": "completed"
     },
     "tags": []
@@ -256,16 +371,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:07.268413Z",
-     "iopub.status.busy": "2026-06-04T06:26:07.267801Z",
-     "iopub.status.idle": "2026-06-04T06:26:07.492282Z",
-     "shell.execute_reply": "2026-06-04T06:26:07.492053Z"
+     "iopub.execute_input": "2026-06-22T19:15:00.618666Z",
+     "iopub.status.busy": "2026-06-22T19:15:00.618091Z",
+     "iopub.status.idle": "2026-06-22T19:15:00.763226Z",
+     "shell.execute_reply": "2026-06-22T19:15:00.762221Z"
     },
     "papermill": {
-     "duration": 0.277791,
-     "end_time": "2026-06-04T06:26:07.492397",
+     "duration": 0.157099,
+     "end_time": "2026-06-22T19:15:00.763226",
      "exception": false,
-     "start_time": "2026-06-04T06:26:07.214606",
+     "start_time": "2026-06-22T19:15:00.606127",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -300,10 +415,10 @@
    "id": "as59jhqh7th",
    "metadata": {
     "papermill": {
-     "duration": 0.011804,
-     "end_time": "2026-06-04T06:26:07.516084",
+     "duration": 0.011899,
+     "end_time": "2026-06-22T19:15:00.788634",
      "exception": false,
-     "start_time": "2026-06-04T06:26:07.504280",
+     "start_time": "2026-06-22T19:15:00.776735",
      "status": "completed"
     },
     "tags": []
@@ -333,16 +448,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:07.541781Z",
-     "iopub.status.busy": "2026-06-04T06:26:07.541457Z",
-     "iopub.status.idle": "2026-06-04T06:26:07.594058Z",
-     "shell.execute_reply": "2026-06-04T06:26:07.593813Z"
+     "iopub.execute_input": "2026-06-22T19:15:00.816248Z",
+     "iopub.status.busy": "2026-06-22T19:15:00.816248Z",
+     "iopub.status.idle": "2026-06-22T19:15:00.866252Z",
+     "shell.execute_reply": "2026-06-22T19:15:00.865253Z"
     },
     "papermill": {
-     "duration": 0.067183,
-     "end_time": "2026-06-04T06:26:07.594175",
+     "duration": 0.064274,
+     "end_time": "2026-06-22T19:15:00.866252",
      "exception": false,
-     "start_time": "2026-06-04T06:26:07.526992",
+     "start_time": "2026-06-22T19:15:00.801978",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -380,10 +495,10 @@
    "id": "evghdc4xqho",
    "metadata": {
     "papermill": {
-     "duration": 0.01268,
-     "end_time": "2026-06-04T06:26:07.618863",
+     "duration": 0.010935,
+     "end_time": "2026-06-22T19:15:00.888457",
      "exception": false,
-     "start_time": "2026-06-04T06:26:07.606183",
+     "start_time": "2026-06-22T19:15:00.877522",
      "status": "completed"
     },
     "tags": []
@@ -411,16 +526,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:07.651679Z",
-     "iopub.status.busy": "2026-06-04T06:26:07.651319Z",
-     "iopub.status.idle": "2026-06-04T06:26:10.538215Z",
-     "shell.execute_reply": "2026-06-04T06:26:10.536737Z"
+     "iopub.execute_input": "2026-06-22T19:15:00.911984Z",
+     "iopub.status.busy": "2026-06-22T19:15:00.911984Z",
+     "iopub.status.idle": "2026-06-22T19:15:02.820028Z",
+     "shell.execute_reply": "2026-06-22T19:15:02.817465Z"
     },
     "papermill": {
-     "duration": 2.90576,
-     "end_time": "2026-06-04T06:26:10.538325",
+     "duration": 1.920438,
+     "end_time": "2026-06-22T19:15:02.820028",
      "exception": false,
-     "start_time": "2026-06-04T06:26:07.632565",
+     "start_time": "2026-06-22T19:15:00.899590",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -432,38 +547,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_35_34.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -892,10 +975,10 @@
    "id": "e2bd5870",
    "metadata": {
     "papermill": {
-     "duration": 0.015637,
-     "end_time": "2026-06-04T06:26:10.568856",
+     "duration": 0.014017,
+     "end_time": "2026-06-22T19:15:02.848597",
      "exception": false,
-     "start_time": "2026-06-04T06:26:10.553219",
+     "start_time": "2026-06-22T19:15:02.834580",
      "status": "completed"
     },
     "tags": []
@@ -910,16 +993,16 @@
    "id": "is1repzixca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:10.622379Z",
-     "iopub.status.busy": "2026-06-04T06:26:10.621787Z",
-     "iopub.status.idle": "2026-06-04T06:26:10.714524Z",
-     "shell.execute_reply": "2026-06-04T06:26:10.714719Z"
+     "iopub.execute_input": "2026-06-22T19:15:02.881941Z",
+     "iopub.status.busy": "2026-06-22T19:15:02.881352Z",
+     "iopub.status.idle": "2026-06-22T19:15:03.043142Z",
+     "shell.execute_reply": "2026-06-22T19:15:03.042630Z"
     },
     "papermill": {
-     "duration": 0.120863,
-     "end_time": "2026-06-04T06:26:10.714856",
+     "duration": 0.177575,
+     "end_time": "2026-06-22T19:15:03.043142",
      "exception": false,
-     "start_time": "2026-06-04T06:26:10.593993",
+     "start_time": "2026-06-22T19:15:02.865567",
      "status": "completed"
     },
     "tags": [],
@@ -931,10 +1014,210 @@
     {
      "data": {
       "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_06_04_26_17_56_35_34.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_01_01.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       " -->\r\n",
+       "<!-- Title: Model Pages: 1 -->\r\n",
+       "<svg width=\"296pt\" height=\"354pt\"\r\n",
+       " viewBox=\"0.00 0.00 296.00 354.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 349.5)\">\r\n",
+       "<title>Model</title>\r\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-349.5 292,-349.5 292,4 -4,4\"/>\r\n",
+       "<!-- node0 -->\r\n",
+       "<g id=\"node1\" class=\"node\">\r\n",
+       "<title>node0</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M204,-345.5C204,-345.5 174,-345.5 174,-345.5 168,-345.5 162,-339.5 162,-333.5 162,-333.5 162,-321.5 162,-321.5 162,-315.5 168,-309.5 174,-309.5 174,-309.5 204,-309.5 204,-309.5 210,-309.5 216,-315.5 216,-321.5 216,-321.5 216,-333.5 216,-333.5 216,-339.5 210,-345.5 204,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"189\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">15</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1 -->\r\n",
+       "<g id=\"node2\" class=\"node\">\r\n",
+       "<title>node1</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M222,-263.75C222,-263.75 192,-263.75 192,-263.75 186,-263.75 180,-257.75 180,-251.75 180,-251.75 180,-239.75 180,-239.75 180,-233.75 186,-227.75 192,-227.75 192,-227.75 222,-227.75 222,-227.75 228,-227.75 234,-233.75 234,-239.75 234,-239.75 234,-251.75 234,-251.75 234,-257.75 228,-263.75 222,-263.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"207\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n",
+       "</g>\r\n",
+       "<!-- node0&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge1\" class=\"edge\">\r\n",
+       "<title>node0&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M192.82,-309.59C195.08,-299.57 198,-286.63 200.6,-275.09\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"203.94,-276.19 202.73,-265.67 197.11,-274.65 203.94,-276.19\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"207.7\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3 -->\r\n",
+       "<g id=\"node4\" class=\"node\">\r\n",
+       "<title>node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M222.5,-190.75C222.5,-190.75 191.5,-190.75 191.5,-190.75 185.5,-190.75 179.5,-184.75 179.5,-178.75 179.5,-178.75 179.5,-166.75 179.5,-166.75 179.5,-160.75 185.5,-154.75 191.5,-154.75 191.5,-154.75 222.5,-154.75 222.5,-154.75 228.5,-154.75 234.5,-160.75 234.5,-166.75 234.5,-166.75 234.5,-178.75 234.5,-178.75 234.5,-184.75 228.5,-190.75 222.5,-190.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"207\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble2</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge3\" class=\"edge\">\r\n",
+       "<title>node1&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M207,-227.56C207,-219.98 207,-210.85 207,-202.29\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"210.5,-202.29 207,-192.29 203.5,-202.29 210.5,-202.29\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node2 -->\r\n",
+       "<g id=\"node3\" class=\"node\">\r\n",
+       "<title>node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M276,-345.5C276,-345.5 246,-345.5 246,-345.5 240,-345.5 234,-339.5 234,-333.5 234,-333.5 234,-321.5 234,-321.5 234,-315.5 240,-309.5 246,-309.5 246,-309.5 276,-309.5 276,-309.5 282,-309.5 288,-315.5 288,-321.5 288,-321.5 288,-333.5 288,-333.5 288,-339.5 282,-345.5 276,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"261\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">0,01</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge2\" class=\"edge\">\r\n",
+       "<title>node2&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M249.55,-309.59C242.49,-299.16 233.27,-285.55 225.22,-273.66\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"228.16,-271.76 219.66,-265.44 222.37,-275.69 228.16,-271.76\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"251.86\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4 -->\r\n",
+       "<g id=\"node5\" class=\"node\">\r\n",
+       "<title>node4</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M72,-109C72,-109 42,-109 42,-109 36,-109 30,-103 30,-97 30,-97 30,-85 30,-85 30,-79 36,-73 42,-73 42,-73 72,-73 72,-73 78,-73 84,-79 84,-85 84,-85 84,-97 84,-97 84,-103 78,-109 72,-109\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"57\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3&#45;&gt;node4 -->\r\n",
+       "<g id=\"edge4\" class=\"edge\">\r\n",
+       "<title>node3&#45;&gt;node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M179.34,-163.43C160.76,-157.3 136.05,-148.07 115.75,-136.75 105.42,-130.99 94.91,-123.57 85.68,-116.44\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"88.13,-113.91 78.13,-110.41 83.76,-119.38 88.13,-113.91\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"124.38\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n",
+       "</g>\r\n",
+       "<!-- node7 -->\r\n",
+       "<g id=\"node8\" class=\"node\">\r\n",
+       "<title>node7</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M250,-109C250,-109 220,-109 220,-109 214,-109 208,-103 208,-97 208,-97 208,-85 208,-85 208,-79 214,-73 220,-73 220,-73 250,-73 250,-73 256,-73 262,-79 262,-85 262,-85 262,-97 262,-97 262,-103 256,-109 250,-109\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"235\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3&#45;&gt;node7 -->\r\n",
+       "<g id=\"edge7\" class=\"edge\">\r\n",
+       "<title>node3&#45;&gt;node7</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M217.06,-154.34C219.93,-148.84 222.86,-142.66 225,-136.75 226.9,-131.51 228.51,-125.78 229.84,-120.23\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"233.2,-121.28 231.88,-110.77 226.35,-119.81 233.2,-121.28\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"236.66\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n",
+       "</g>\r\n",
+       "<!-- node9 -->\r\n",
+       "<g id=\"node10\" class=\"node\">\r\n",
+       "<title>node9</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M167,-109C167,-109 137,-109 137,-109 131,-109 125,-103 125,-97 125,-97 125,-85 125,-85 125,-79 131,-73 137,-73 137,-73 167,-73 167,-73 173,-73 179,-79 179,-85 179,-85 179,-97 179,-97 179,-103 173,-109 167,-109\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"152\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3&#45;&gt;node9 -->\r\n",
+       "<g id=\"edge10\" class=\"edge\">\r\n",
+       "<title>node3&#45;&gt;node9</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M199.98,-154.51C196.13,-145.9 190.92,-135.54 185,-127 182.79,-123.82 180.3,-120.64 177.7,-117.56\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"180.54,-115.48 171.24,-110.4 175.34,-120.17 180.54,-115.48\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"199.41\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n",
+       "</g>\r\n",
+       "<!-- node6 -->\r\n",
+       "<g id=\"node7\" class=\"node\">\r\n",
+       "<title>node6</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M72,-36C72,-36 42,-36 42,-36 36,-36 30,-30 30,-24 30,-24 30,-12 30,-12 30,-6 36,0 42,0 42,0 72,0 72,0 78,0 84,-6 84,-12 84,-12 84,-24 84,-24 84,-30 78,-36 72,-36\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"57\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">13</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4&#45;&gt;node6 -->\r\n",
+       "<g id=\"edge6\" class=\"edge\">\r\n",
+       "<title>node4&#45;&gt;node6</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M57,-72.81C57,-65.03 57,-55.62 57,-46.86\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"60.5,-47.05 57,-37.05 53.5,-47.05 60.5,-47.05\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node5 -->\r\n",
+       "<g id=\"node6\" class=\"node\">\r\n",
+       "<title>node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M78.5,-190.75C78.5,-190.75 47.5,-190.75 47.5,-190.75 41.5,-190.75 35.5,-184.75 35.5,-178.75 35.5,-178.75 35.5,-166.75 35.5,-166.75 35.5,-160.75 41.5,-154.75 47.5,-154.75 47.5,-154.75 78.5,-154.75 78.5,-154.75 84.5,-154.75 90.5,-160.75 90.5,-166.75 90.5,-166.75 90.5,-178.75 90.5,-178.75 90.5,-184.75 84.5,-190.75 78.5,-190.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"63\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble5</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5&#45;&gt;node4 -->\r\n",
+       "<g id=\"edge5\" class=\"edge\">\r\n",
+       "<title>node5&#45;&gt;node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M35.25,-159.54C26.06,-154 16.88,-146.47 11.75,-136.75 6.76,-127.3 12,-118.6 20.46,-111.43\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"22.4,-114.35 28.5,-105.69 18.32,-108.66 22.4,-114.35\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"26.38\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5&#45;&gt;node7 -->\r\n",
+       "<g id=\"edge8\" class=\"edge\">\r\n",
+       "<title>node5&#45;&gt;node7</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M90.98,-157.89C103.81,-151.5 119.2,-143.79 133,-136.75 141.37,-132.48 143.25,-130.99 151.75,-127 166.45,-120.1 182.89,-113.05 197.25,-107.11\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"198.44,-110.4 206.36,-103.37 195.78,-103.93 198.44,-110.4\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"166.38\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5&#45;&gt;node9 -->\r\n",
+       "<g id=\"edge11\" class=\"edge\">\r\n",
+       "<title>node5&#45;&gt;node9</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M59.02,-154.65C57.92,-145.67 58.27,-134.92 63.75,-127 69.87,-118.15 92.69,-109.23 113.6,-102.6\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"114.57,-105.97 123.12,-99.71 112.54,-99.27 114.57,-105.97\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"78.38\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n",
+       "</g>\r\n",
+       "<!-- node8 -->\r\n",
+       "<g id=\"node9\" class=\"node\">\r\n",
+       "<title>node8</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M250,-36C250,-36 220,-36 220,-36 214,-36 208,-30 208,-24 208,-24 208,-12 208,-12 208,-6 214,0 220,0 220,0 250,0 250,0 256,0 262,-6 262,-12 262,-12 262,-24 262,-24 262,-30 256,-36 250,-36\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"235\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">17</text>\r\n",
+       "</g>\r\n",
+       "<!-- node7&#45;&gt;node8 -->\r\n",
+       "<g id=\"edge9\" class=\"edge\">\r\n",
+       "<title>node7&#45;&gt;node8</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M235,-72.81C235,-65.03 235,-55.62 235,-46.86\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"238.5,-47.05 235,-37.05 231.5,-47.05 238.5,-47.05\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node10 -->\r\n",
+       "<g id=\"node11\" class=\"node\">\r\n",
+       "<title>node10</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M167,-36C167,-36 137,-36 137,-36 131,-36 125,-30 125,-24 125,-24 125,-12 125,-12 125,-6 131,0 137,0 137,0 167,0 167,0 173,0 179,-6 179,-12 179,-12 179,-24 179,-24 179,-30 173,-36 167,-36\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"152\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">16</text>\r\n",
+       "</g>\r\n",
+       "<!-- node9&#45;&gt;node10 -->\r\n",
+       "<g id=\"edge12\" class=\"edge\">\r\n",
+       "<title>node9&#45;&gt;node10</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M152,-72.81C152,-65.03 152,-55.62 152,-46.86\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"155.5,-47.05 152,-37.05 148.5,-47.05 155.5,-47.05\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node11 -->\r\n",
+       "<g id=\"node12\" class=\"node\">\r\n",
+       "<title>node11</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M42,-345.5C42,-345.5 12,-345.5 12,-345.5 6,-345.5 0,-339.5 0,-333.5 0,-333.5 0,-321.5 0,-321.5 0,-315.5 6,-309.5 12,-309.5 12,-309.5 42,-309.5 42,-309.5 48,-309.5 54,-315.5 54,-321.5 54,-321.5 54,-333.5 54,-333.5 54,-339.5 48,-345.5 42,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"27\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">2</text>\r\n",
+       "</g>\r\n",
+       "<!-- node12 -->\r\n",
+       "<g id=\"node13\" class=\"node\">\r\n",
+       "<title>node12</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M78,-263.75C78,-263.75 48,-263.75 48,-263.75 42,-263.75 36,-257.75 36,-251.75 36,-251.75 36,-239.75 36,-239.75 36,-233.75 42,-227.75 48,-227.75 48,-227.75 78,-227.75 78,-227.75 84,-227.75 90,-233.75 90,-239.75 90,-239.75 90,-251.75 90,-251.75 90,-257.75 84,-263.75 78,-263.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"63\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Sample</text>\r\n",
+       "</g>\r\n",
+       "<!-- node11&#45;&gt;node12 -->\r\n",
+       "<g id=\"edge13\" class=\"edge\">\r\n",
+       "<title>node11&#45;&gt;node12</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M34.63,-309.59C39.25,-299.37 45.24,-286.09 50.53,-274.38\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"53.58,-276.12 54.5,-265.57 47.2,-273.24 53.58,-276.12\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"56.16\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">shape</text>\r\n",
+       "</g>\r\n",
+       "<!-- node12&#45;&gt;node5 -->\r\n",
+       "<g id=\"edge15\" class=\"edge\">\r\n",
+       "<title>node12&#45;&gt;node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M63,-227.56C63,-219.98 63,-210.85 63,-202.29\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"66.5,-202.29 63,-192.29 59.5,-202.29 66.5,-202.29\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node13 -->\r\n",
+       "<g id=\"node14\" class=\"node\">\r\n",
+       "<title>node13</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M114,-345.5C114,-345.5 84,-345.5 84,-345.5 78,-345.5 72,-339.5 72,-333.5 72,-333.5 72,-321.5 72,-321.5 72,-315.5 78,-309.5 84,-309.5 84,-309.5 114,-309.5 114,-309.5 120,-309.5 126,-315.5 126,-321.5 126,-321.5 126,-333.5 126,-333.5 126,-339.5 120,-345.5 114,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"99\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">0,5</text>\r\n",
+       "</g>\r\n",
+       "<!-- node13&#45;&gt;node12 -->\r\n",
+       "<g id=\"edge14\" class=\"edge\">\r\n",
+       "<title>node13&#45;&gt;node12</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M91.37,-309.59C86.75,-299.37 80.76,-286.09 75.47,-274.38\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"78.8,-273.24 71.5,-265.57 72.42,-276.12 78.8,-273.24\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"91.41\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">scale</text>\r\n",
+       "</g>\r\n",
+       "</g>\r\n",
+       "</svg>\r\n",
+       "\r\n",
+       "    </div>\r\n",
+       "</div>"
       ]
      },
      "metadata": {},
@@ -945,7 +1228,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -960,10 +1243,10 @@
    "id": "wp3x84ecmwm",
    "metadata": {
     "papermill": {
-     "duration": 0.015318,
-     "end_time": "2026-06-04T06:26:10.744811",
+     "duration": 0.014554,
+     "end_time": "2026-06-22T19:15:03.071922",
      "exception": false,
-     "start_time": "2026-06-04T06:26:10.729493",
+     "start_time": "2026-06-22T19:15:03.057368",
      "status": "completed"
     },
     "tags": []
@@ -992,10 +1275,10 @@
    "id": "4a8uieoplpa",
    "metadata": {
     "papermill": {
-     "duration": 0.015378,
-     "end_time": "2026-06-04T06:26:10.776017",
+     "duration": 0.014012,
+     "end_time": "2026-06-22T19:15:03.099948",
      "exception": false,
-     "start_time": "2026-06-04T06:26:10.760639",
+     "start_time": "2026-06-22T19:15:03.085936",
      "status": "completed"
     },
     "tags": []
@@ -1023,10 +1306,10 @@
    "id": "263c7074",
    "metadata": {
     "papermill": {
-     "duration": 0.014227,
-     "end_time": "2026-06-04T06:26:10.804889",
+     "duration": 0.016652,
+     "end_time": "2026-06-22T19:15:03.131676",
      "exception": false,
-     "start_time": "2026-06-04T06:26:10.790662",
+     "start_time": "2026-06-22T19:15:03.115024",
      "status": "completed"
     },
     "tags": []
@@ -1040,10 +1323,10 @@
    "id": "4lc7vfku415",
    "metadata": {
     "papermill": {
-     "duration": 0.01732,
-     "end_time": "2026-06-04T06:26:10.836771",
+     "duration": 0.018005,
+     "end_time": "2026-06-22T19:15:03.166674",
      "exception": false,
-     "start_time": "2026-06-04T06:26:10.819451",
+     "start_time": "2026-06-22T19:15:03.148669",
      "status": "completed"
     },
     "tags": []
@@ -1069,16 +1352,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:10.916890Z",
-     "iopub.status.busy": "2026-06-04T06:26:10.915369Z",
-     "iopub.status.idle": "2026-06-04T06:26:11.821659Z",
-     "shell.execute_reply": "2026-06-04T06:26:11.809850Z"
+     "iopub.execute_input": "2026-06-22T19:15:03.199547Z",
+     "iopub.status.busy": "2026-06-22T19:15:03.199028Z",
+     "iopub.status.idle": "2026-06-22T19:15:03.773445Z",
+     "shell.execute_reply": "2026-06-22T19:15:03.771438Z"
     },
     "papermill": {
-     "duration": 0.960962,
-     "end_time": "2026-06-04T06:26:11.821780",
+     "duration": 0.590975,
+     "end_time": "2026-06-22T19:15:03.774438",
      "exception": false,
-     "start_time": "2026-06-04T06:26:10.860818",
+     "start_time": "2026-06-22T19:15:03.183463",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1090,38 +1373,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_37_18.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1550,10 +1801,10 @@
    "id": "kh0nkt1drvg",
    "metadata": {
     "papermill": {
-     "duration": 0.019076,
-     "end_time": "2026-06-04T06:26:11.859958",
+     "duration": 0.017015,
+     "end_time": "2026-06-22T19:15:03.807454",
      "exception": false,
-     "start_time": "2026-06-04T06:26:11.840882",
+     "start_time": "2026-06-22T19:15:03.790439",
      "status": "completed"
     },
     "tags": []
@@ -1580,10 +1831,10 @@
    "id": "a5fb3c2c",
    "metadata": {
     "papermill": {
-     "duration": 0.018749,
-     "end_time": "2026-06-04T06:26:11.897151",
+     "duration": 0.016806,
+     "end_time": "2026-06-22T19:15:03.840613",
      "exception": false,
-     "start_time": "2026-06-04T06:26:11.878402",
+     "start_time": "2026-06-22T19:15:03.823807",
      "status": "completed"
     },
     "tags": []
@@ -1597,10 +1848,10 @@
    "id": "qvuwxveua2",
    "metadata": {
     "papermill": {
-     "duration": 0.017549,
-     "end_time": "2026-06-04T06:26:11.934472",
+     "duration": 0.017503,
+     "end_time": "2026-06-22T19:15:03.875106",
      "exception": false,
-     "start_time": "2026-06-04T06:26:11.916923",
+     "start_time": "2026-06-22T19:15:03.857603",
      "status": "completed"
     },
     "tags": []
@@ -1634,16 +1885,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:11.980017Z",
-     "iopub.status.busy": "2026-06-04T06:26:11.979680Z",
-     "iopub.status.idle": "2026-06-04T06:26:13.712008Z",
-     "shell.execute_reply": "2026-06-04T06:26:13.700383Z"
+     "iopub.execute_input": "2026-06-22T19:15:03.911074Z",
+     "iopub.status.busy": "2026-06-22T19:15:03.911074Z",
+     "iopub.status.idle": "2026-06-22T19:15:05.534133Z",
+     "shell.execute_reply": "2026-06-22T19:15:05.525544Z"
     },
     "papermill": {
-     "duration": 1.752853,
-     "end_time": "2026-06-04T06:26:13.712128",
+     "duration": 1.64127,
+     "end_time": "2026-06-22T19:15:05.534133",
      "exception": false,
-     "start_time": "2026-06-04T06:26:11.959275",
+     "start_time": "2026-06-22T19:15:03.892863",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1655,38 +1906,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_37_68.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -2076,38 +2295,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_37_99.gv\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Compiling model..."
      ]
     },
@@ -2487,38 +2674,6 @@
      "output_type": "stream",
      "text": [
       "P(trajet < 15 min) = 0,44\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_38_29.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -2927,10 +3082,10 @@
    "id": "v6xlllzzb5e",
    "metadata": {
     "papermill": {
-     "duration": 0.029225,
-     "end_time": "2026-06-04T06:26:13.768369",
+     "duration": 0.02683,
+     "end_time": "2026-06-22T19:15:05.587127",
      "exception": false,
-     "start_time": "2026-06-04T06:26:13.739144",
+     "start_time": "2026-06-22T19:15:05.560297",
      "status": "completed"
     },
     "tags": []
@@ -2957,10 +3112,10 @@
    "id": "6ffff469",
    "metadata": {
     "papermill": {
-     "duration": 0.028815,
-     "end_time": "2026-06-04T06:26:13.828121",
+     "duration": 0.023089,
+     "end_time": "2026-06-22T19:15:05.633934",
      "exception": false,
-     "start_time": "2026-06-04T06:26:13.799306",
+     "start_time": "2026-06-22T19:15:05.610845",
      "status": "completed"
     },
     "tags": []
@@ -3016,10 +3171,10 @@
    "id": "ftpakk1jco9",
    "metadata": {
     "papermill": {
-     "duration": 0.031676,
-     "end_time": "2026-06-04T06:26:13.888191",
+     "duration": 0.024613,
+     "end_time": "2026-06-22T19:15:05.681054",
      "exception": false,
-     "start_time": "2026-06-04T06:26:13.856515",
+     "start_time": "2026-06-22T19:15:05.656441",
      "status": "completed"
     },
     "tags": []
@@ -3046,16 +3201,16 @@
    "id": "ask65vljw58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:13.948909Z",
-     "iopub.status.busy": "2026-06-04T06:26:13.948595Z",
-     "iopub.status.idle": "2026-06-04T06:26:14.583279Z",
-     "shell.execute_reply": "2026-06-04T06:26:14.583023Z"
+     "iopub.execute_input": "2026-06-22T19:15:05.733208Z",
+     "iopub.status.busy": "2026-06-22T19:15:05.733208Z",
+     "iopub.status.idle": "2026-06-22T19:15:06.283343Z",
+     "shell.execute_reply": "2026-06-22T19:15:06.283343Z"
     },
     "papermill": {
-     "duration": 0.664615,
-     "end_time": "2026-06-04T06:26:14.583403",
+     "duration": 0.578625,
+     "end_time": "2026-06-22T19:15:06.284344",
      "exception": false,
-     "start_time": "2026-06-04T06:26:13.918788",
+     "start_time": "2026-06-22T19:15:05.705719",
      "status": "completed"
     },
     "tags": [],
@@ -3219,10 +3374,10 @@
    "id": "ziof0ss3m1",
    "metadata": {
     "papermill": {
-     "duration": 0.030613,
-     "end_time": "2026-06-04T06:26:14.646978",
+     "duration": 0.02533,
+     "end_time": "2026-06-22T19:15:06.333684",
      "exception": false,
-     "start_time": "2026-06-04T06:26:14.616365",
+     "start_time": "2026-06-22T19:15:06.308354",
      "status": "completed"
     },
     "tags": []
@@ -3258,10 +3413,10 @@
    "id": "xsm903r9xd",
    "metadata": {
     "papermill": {
-     "duration": 0.030623,
-     "end_time": "2026-06-04T06:26:14.709804",
+     "duration": 0.025633,
+     "end_time": "2026-06-22T19:15:06.385304",
      "exception": false,
-     "start_time": "2026-06-04T06:26:14.679181",
+     "start_time": "2026-06-22T19:15:06.359671",
      "status": "completed"
     },
     "tags": []
@@ -3288,10 +3443,10 @@
    "id": "1k4hxmsgl1z",
    "metadata": {
     "papermill": {
-     "duration": 0.077935,
-     "end_time": "2026-06-04T06:26:14.842015",
+     "duration": 0.023316,
+     "end_time": "2026-06-22T19:15:06.433242",
      "exception": false,
-     "start_time": "2026-06-04T06:26:14.764080",
+     "start_time": "2026-06-22T19:15:06.409926",
      "status": "completed"
     },
     "tags": []
@@ -3324,16 +3479,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:14.903710Z",
-     "iopub.status.busy": "2026-06-04T06:26:14.903344Z",
-     "iopub.status.idle": "2026-06-04T06:26:14.978051Z",
-     "shell.execute_reply": "2026-06-04T06:26:14.977807Z"
+     "iopub.execute_input": "2026-06-22T19:15:06.484490Z",
+     "iopub.status.busy": "2026-06-22T19:15:06.484490Z",
+     "iopub.status.idle": "2026-06-22T19:15:06.548886Z",
+     "shell.execute_reply": "2026-06-22T19:15:06.548886Z"
     },
     "papermill": {
-     "duration": 0.104397,
-     "end_time": "2026-06-04T06:26:14.978169",
+     "duration": 0.089365,
+     "end_time": "2026-06-22T19:15:06.548886",
      "exception": false,
-     "start_time": "2026-06-04T06:26:14.873772",
+     "start_time": "2026-06-22T19:15:06.459521",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3406,10 +3561,10 @@
    "id": "kfwunewlw9",
    "metadata": {
     "papermill": {
-     "duration": 0.030472,
-     "end_time": "2026-06-04T06:26:15.036781",
+     "duration": 0.024,
+     "end_time": "2026-06-22T19:15:06.602531",
      "exception": false,
-     "start_time": "2026-06-04T06:26:15.006309",
+     "start_time": "2026-06-22T19:15:06.578531",
      "status": "completed"
     },
     "tags": []
@@ -3441,16 +3596,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:15.097623Z",
-     "iopub.status.busy": "2026-06-04T06:26:15.097322Z",
-     "iopub.status.idle": "2026-06-04T06:26:15.156080Z",
-     "shell.execute_reply": "2026-06-04T06:26:15.155737Z"
+     "iopub.execute_input": "2026-06-22T19:15:06.645689Z",
+     "iopub.status.busy": "2026-06-22T19:15:06.645689Z",
+     "iopub.status.idle": "2026-06-22T19:15:06.721901Z",
+     "shell.execute_reply": "2026-06-22T19:15:06.721901Z"
     },
     "papermill": {
-     "duration": 0.090044,
-     "end_time": "2026-06-04T06:26:15.156200",
+     "duration": 0.091026,
+     "end_time": "2026-06-22T19:15:06.721901",
      "exception": false,
-     "start_time": "2026-06-04T06:26:15.066156",
+     "start_time": "2026-06-22T19:15:06.630875",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3530,10 +3685,10 @@
    "id": "zxyq0phia4",
    "metadata": {
     "papermill": {
-     "duration": 0.03026,
-     "end_time": "2026-06-04T06:26:15.214905",
+     "duration": 0.025835,
+     "end_time": "2026-06-22T19:15:06.778092",
      "exception": false,
-     "start_time": "2026-06-04T06:26:15.184645",
+     "start_time": "2026-06-22T19:15:06.752257",
      "status": "completed"
     },
     "tags": []
@@ -3561,16 +3716,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:15.271062Z",
-     "iopub.status.busy": "2026-06-04T06:26:15.270710Z",
-     "iopub.status.idle": "2026-06-04T06:26:15.762210Z",
-     "shell.execute_reply": "2026-06-04T06:26:15.761935Z"
+     "iopub.execute_input": "2026-06-22T19:15:06.829441Z",
+     "iopub.status.busy": "2026-06-22T19:15:06.829441Z",
+     "iopub.status.idle": "2026-06-22T19:15:07.400614Z",
+     "shell.execute_reply": "2026-06-22T19:15:07.400614Z"
     },
     "papermill": {
-     "duration": 0.519554,
-     "end_time": "2026-06-04T06:26:15.762342",
+     "duration": 0.596903,
+     "end_time": "2026-06-22T19:15:07.400614",
      "exception": false,
-     "start_time": "2026-06-04T06:26:15.242788",
+     "start_time": "2026-06-22T19:15:06.803711",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3582,38 +3737,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_40_27.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -4031,10 +4154,10 @@
    "id": "23e2ff47",
    "metadata": {
     "papermill": {
-     "duration": 0.037354,
-     "end_time": "2026-06-04T06:26:15.833633",
+     "duration": 0.020893,
+     "end_time": "2026-06-22T19:15:07.447049",
      "exception": false,
-     "start_time": "2026-06-04T06:26:15.796279",
+     "start_time": "2026-06-22T19:15:07.426156",
      "status": "completed"
     },
     "tags": []
@@ -4049,16 +4172,16 @@
    "id": "ruvttosksid",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:15.896481Z",
-     "iopub.status.busy": "2026-06-04T06:26:15.896083Z",
-     "iopub.status.idle": "2026-06-04T06:26:15.932539Z",
-     "shell.execute_reply": "2026-06-04T06:26:15.932786Z"
+     "iopub.execute_input": "2026-06-22T19:15:07.500873Z",
+     "iopub.status.busy": "2026-06-22T19:15:07.500364Z",
+     "iopub.status.idle": "2026-06-22T19:15:07.591431Z",
+     "shell.execute_reply": "2026-06-22T19:15:07.591431Z"
     },
     "papermill": {
-     "duration": 0.068979,
-     "end_time": "2026-06-04T06:26:15.932944",
+     "duration": 0.118456,
+     "end_time": "2026-06-22T19:15:07.591431",
      "exception": false,
-     "start_time": "2026-06-04T06:26:15.863965",
+     "start_time": "2026-06-22T19:15:07.472975",
      "status": "completed"
     },
     "tags": [],
@@ -4070,10 +4193,120 @@
     {
      "data": {
       "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_06_04_26_17_56_40_27.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_06_89.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       " -->\r\n",
+       "<!-- Title: Model Pages: 1 -->\r\n",
+       "<svg width=\"232pt\" height=\"354pt\"\r\n",
+       " viewBox=\"0.00 0.00 232.00 354.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 349.5)\">\r\n",
+       "<title>Model</title>\r\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-349.5 227.62,-349.5 227.62,4 -4,4\"/>\r\n",
+       "<!-- node0 -->\r\n",
+       "<g id=\"node1\" class=\"node\">\r\n",
+       "<title>node0</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M78.25,-345.5C78.25,-345.5 12,-345.5 12,-345.5 6,-345.5 0,-339.5 0,-333.5 0,-333.5 0,-321.5 0,-321.5 0,-315.5 6,-309.5 12,-309.5 12,-309.5 78.25,-309.5 78.25,-309.5 84.25,-309.5 90.25,-315.5 90.25,-321.5 90.25,-321.5 90.25,-333.5 90.25,-333.5 90.25,-339.5 84.25,-345.5 78.25,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"45.12\" y=\"-323.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">Gaussian(15, 100)</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1 -->\r\n",
+       "<g id=\"node2\" class=\"node\">\r\n",
+       "<title>node1</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M71.12,-263.75C71.12,-263.75 41.12,-263.75 41.12,-263.75 35.12,-263.75 29.12,-257.75 29.12,-251.75 29.12,-251.75 29.12,-239.75 29.12,-239.75 29.12,-233.75 35.12,-227.75 41.12,-227.75 41.12,-227.75 71.12,-227.75 71.12,-227.75 77.12,-227.75 83.12,-233.75 83.12,-239.75 83.12,-239.75 83.12,-251.75 83.12,-251.75 83.12,-257.75 77.12,-263.75 71.12,-263.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"56.12\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node0&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge1\" class=\"edge\">\r\n",
+       "<title>node0&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M47.46,-309.59C48.82,-299.68 50.59,-286.9 52.17,-275.46\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"55.61,-276.07 53.51,-265.69 48.68,-275.12 55.61,-276.07\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"56.91\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2 -->\r\n",
+       "<g id=\"node3\" class=\"node\">\r\n",
+       "<title>node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M96.25,-190.75C96.25,-190.75 60,-190.75 60,-190.75 54,-190.75 48,-184.75 48,-178.75 48,-178.75 48,-166.75 48,-166.75 48,-160.75 54,-154.75 60,-154.75 60,-154.75 96.25,-154.75 96.25,-154.75 102.25,-154.75 108.25,-160.75 108.25,-166.75 108.25,-166.75 108.25,-178.75 108.25,-178.75 108.25,-184.75 102.25,-190.75 96.25,-190.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"78.12\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble24</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1&#45;&gt;node2 -->\r\n",
+       "<g id=\"edge2\" class=\"edge\">\r\n",
+       "<title>node1&#45;&gt;node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M61.45,-227.56C63.86,-219.8 66.76,-210.43 69.46,-201.7\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"72.78,-202.81 72.4,-192.22 66.1,-200.74 72.78,-202.81\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node3 -->\r\n",
+       "<g id=\"node4\" class=\"node\">\r\n",
+       "<title>node3</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M132.12,-109C132.12,-109 102.12,-109 102.12,-109 96.12,-109 90.12,-103 90.12,-97 90.12,-97 90.12,-85 90.12,-85 90.12,-79 96.12,-73 102.12,-73 102.12,-73 132.12,-73 132.12,-73 138.12,-73 144.12,-79 144.12,-85 144.12,-85 144.12,-97 144.12,-97 144.12,-103 138.12,-109 132.12,-109\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"117.12\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge3\" class=\"edge\">\r\n",
+       "<title>node2&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M86.59,-154.45C91.6,-144.2 98.05,-131 103.74,-119.37\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"106.77,-121.15 108.01,-110.63 100.48,-118.08 106.77,-121.15\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"108.59\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5 -->\r\n",
+       "<g id=\"node6\" class=\"node\">\r\n",
+       "<title>node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M152.88,-36C152.88,-36 81.38,-36 81.38,-36 75.38,-36 69.38,-30 69.38,-24 69.38,-24 69.38,-12 69.38,-12 69.38,-6 75.38,0 81.38,0 81.38,0 152.88,0 152.88,0 158.88,0 164.88,-6 164.88,-12 164.88,-12 164.88,-24 164.88,-24 164.88,-30 158.88,-36 152.88,-36\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"117.12\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]0[index0]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3&#45;&gt;node5 -->\r\n",
+       "<g id=\"edge5\" class=\"edge\">\r\n",
+       "<title>node3&#45;&gt;node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M117.12,-72.81C117.12,-65.03 117.12,-55.62 117.12,-46.86\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"120.63,-47.05 117.13,-37.05 113.63,-47.05 120.63,-47.05\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node4 -->\r\n",
+       "<g id=\"node5\" class=\"node\">\r\n",
+       "<title>node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M177.25,-190.75C177.25,-190.75 141,-190.75 141,-190.75 135,-190.75 129,-184.75 129,-178.75 129,-178.75 129,-166.75 129,-166.75 129,-160.75 135,-154.75 141,-154.75 141,-154.75 177.25,-154.75 177.25,-154.75 183.25,-154.75 189.25,-160.75 189.25,-166.75 189.25,-166.75 189.25,-178.75 189.25,-178.75 189.25,-184.75 183.25,-190.75 177.25,-190.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"159.12\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble25</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge4\" class=\"edge\">\r\n",
+       "<title>node4&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M150.01,-154.45C144.62,-144.2 137.66,-131 131.54,-119.37\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"134.68,-117.83 126.93,-110.61 128.49,-121.09 134.68,-117.83\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"155.26\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n",
+       "</g>\r\n",
+       "<!-- node6 -->\r\n",
+       "<g id=\"node7\" class=\"node\">\r\n",
+       "<title>node6</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M211.62,-345.5C211.62,-345.5 120.62,-345.5 120.62,-345.5 114.62,-345.5 108.62,-339.5 108.62,-333.5 108.62,-333.5 108.62,-321.5 108.62,-321.5 108.62,-315.5 114.62,-309.5 120.62,-309.5 120.62,-309.5 211.62,-309.5 211.62,-309.5 217.62,-309.5 223.62,-315.5 223.62,-321.5 223.62,-321.5 223.62,-333.5 223.62,-333.5 223.62,-339.5 217.62,-345.5 211.62,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"166.12\" y=\"-323.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">Gamma(2, 0,5)[mean=1]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node7 -->\r\n",
+       "<g id=\"node8\" class=\"node\">\r\n",
+       "<title>node7</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M180.12,-263.75C180.12,-263.75 150.12,-263.75 150.12,-263.75 144.12,-263.75 138.12,-257.75 138.12,-251.75 138.12,-251.75 138.12,-239.75 138.12,-239.75 138.12,-233.75 144.12,-227.75 150.12,-227.75 150.12,-227.75 180.12,-227.75 180.12,-227.75 186.12,-227.75 192.12,-233.75 192.12,-239.75 192.12,-239.75 192.12,-251.75 192.12,-251.75 192.12,-257.75 186.12,-263.75 180.12,-263.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"165.12\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node6&#45;&gt;node7 -->\r\n",
+       "<g id=\"edge6\" class=\"edge\">\r\n",
+       "<title>node6&#45;&gt;node7</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M165.91,-309.59C165.79,-299.68 165.63,-286.9 165.48,-275.46\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"168.99,-275.66 165.36,-265.7 161.99,-275.75 168.99,-275.66\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"171.31\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node7&#45;&gt;node4 -->\r\n",
+       "<g id=\"edge7\" class=\"edge\">\r\n",
+       "<title>node7&#45;&gt;node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M163.67,-227.56C163.02,-219.89 162.24,-210.64 161.51,-201.99\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"165.02,-201.96 160.69,-192.29 158.05,-202.55 165.02,-201.96\"/>\r\n",
+       "</g>\r\n",
+       "</g>\r\n",
+       "</svg>\r\n",
+       "\r\n",
+       "    </div>\r\n",
+       "</div>"
       ]
      },
      "metadata": {},
@@ -4084,7 +4317,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -4099,10 +4332,10 @@
    "id": "0ad3q33z94xb",
    "metadata": {
     "papermill": {
-     "duration": 0.035493,
-     "end_time": "2026-06-04T06:26:16.003470",
+     "duration": 0.026254,
+     "end_time": "2026-06-22T19:15:07.645699",
      "exception": false,
-     "start_time": "2026-06-04T06:26:15.967977",
+     "start_time": "2026-06-22T19:15:07.619445",
      "status": "completed"
     },
     "tags": []
@@ -4131,10 +4364,10 @@
    "id": "4gaiaaoqi48",
    "metadata": {
     "papermill": {
-     "duration": 0.032738,
-     "end_time": "2026-06-04T06:26:16.069915",
+     "duration": 0.026478,
+     "end_time": "2026-06-22T19:15:07.700819",
      "exception": false,
-     "start_time": "2026-06-04T06:26:16.037177",
+     "start_time": "2026-06-22T19:15:07.674341",
      "status": "completed"
     },
     "tags": []
@@ -4167,10 +4400,10 @@
    "id": "cc3knypegqj",
    "metadata": {
     "papermill": {
-     "duration": 0.032131,
-     "end_time": "2026-06-04T06:26:16.135756",
+     "duration": 0.026661,
+     "end_time": "2026-06-22T19:15:07.756111",
      "exception": false,
-     "start_time": "2026-06-04T06:26:16.103625",
+     "start_time": "2026-06-22T19:15:07.729450",
      "status": "completed"
     },
     "tags": []
@@ -4196,16 +4429,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:16.199471Z",
-     "iopub.status.busy": "2026-06-04T06:26:16.199120Z",
-     "iopub.status.idle": "2026-06-04T06:26:16.698703Z",
-     "shell.execute_reply": "2026-06-04T06:26:16.698488Z"
+     "iopub.execute_input": "2026-06-22T19:15:07.812985Z",
+     "iopub.status.busy": "2026-06-22T19:15:07.812985Z",
+     "iopub.status.idle": "2026-06-22T19:15:08.463919Z",
+     "shell.execute_reply": "2026-06-22T19:15:08.463919Z"
     },
     "papermill": {
-     "duration": 0.532268,
-     "end_time": "2026-06-04T06:26:16.698812",
+     "duration": 0.679692,
+     "end_time": "2026-06-22T19:15:08.463919",
      "exception": false,
-     "start_time": "2026-06-04T06:26:16.166544",
+     "start_time": "2026-06-22T19:15:07.784227",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4217,38 +4450,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_41_49.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -4275,38 +4476,6 @@
      "output_type": "stream",
      "text": [
       "Ecart-type : 4,14 min\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_41_78.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -4350,10 +4519,10 @@
    "id": "lrew5acmthn",
    "metadata": {
     "papermill": {
-     "duration": 0.033953,
-     "end_time": "2026-06-04T06:26:16.765987",
+     "duration": 0.029049,
+     "end_time": "2026-06-22T19:15:08.522969",
      "exception": false,
-     "start_time": "2026-06-04T06:26:16.732034",
+     "start_time": "2026-06-22T19:15:08.493920",
      "status": "completed"
     },
     "tags": []
@@ -4379,10 +4548,10 @@
    "id": "c0711e49",
    "metadata": {
     "papermill": {
-     "duration": 0.034157,
-     "end_time": "2026-06-04T06:26:16.835679",
+     "duration": 0.029002,
+     "end_time": "2026-06-22T19:15:08.579802",
      "exception": false,
-     "start_time": "2026-06-04T06:26:16.801522",
+     "start_time": "2026-06-22T19:15:08.550800",
      "status": "completed"
     },
     "tags": []
@@ -4400,10 +4569,10 @@
    "id": "torgwp4e0jr",
    "metadata": {
     "papermill": {
-     "duration": 0.031846,
-     "end_time": "2026-06-04T06:26:16.901374",
+     "duration": 0.026503,
+     "end_time": "2026-06-22T19:15:08.693315",
      "exception": false,
-     "start_time": "2026-06-04T06:26:16.869528",
+     "start_time": "2026-06-22T19:15:08.666812",
      "status": "completed"
     },
     "tags": []
@@ -4429,16 +4598,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:16.970407Z",
-     "iopub.status.busy": "2026-06-04T06:26:16.970076Z",
-     "iopub.status.idle": "2026-06-04T06:26:17.048114Z",
-     "shell.execute_reply": "2026-06-04T06:26:17.040449Z"
+     "iopub.execute_input": "2026-06-22T19:15:08.749190Z",
+     "iopub.status.busy": "2026-06-22T19:15:08.749190Z",
+     "iopub.status.idle": "2026-06-22T19:15:08.810689Z",
+     "shell.execute_reply": "2026-06-22T19:15:08.804439Z"
     },
     "papermill": {
-     "duration": 0.113395,
-     "end_time": "2026-06-04T06:26:17.048241",
+     "duration": 0.091859,
+     "end_time": "2026-06-22T19:15:08.811203",
      "exception": false,
-     "start_time": "2026-06-04T06:26:16.934846",
+     "start_time": "2026-06-22T19:15:08.719344",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4875,10 +5044,10 @@
    "id": "13z53blfgpg",
    "metadata": {
     "papermill": {
-     "duration": 0.03614,
-     "end_time": "2026-06-04T06:26:17.119716",
+     "duration": 0.040911,
+     "end_time": "2026-06-22T19:15:08.889143",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.083576",
+     "start_time": "2026-06-22T19:15:08.848232",
      "status": "completed"
     },
     "tags": []
@@ -4913,7 +5082,16 @@
   {
    "cell_type": "markdown",
    "id": "infer2-ex3-regime-md",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.041774,
+     "end_time": "2026-06-22T19:15:08.971905",
+     "exception": false,
+     "start_time": "2026-06-22T19:15:08.930131",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice : Detection d'un changement de regime par apprentissage en ligne\n",
     "\n",
@@ -4940,11 +5118,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 15,
    "id": "infer2-ex3-regime-code",
    "metadata": {
     "dotnet_repl": {
      "language": "C#"
-    }
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-22T19:15:09.036648Z",
+     "iopub.status.busy": "2026-06-22T19:15:09.036648Z",
+     "iopub.status.idle": "2026-06-22T19:15:09.067598Z",
+     "shell.execute_reply": "2026-06-22T19:15:09.067598Z"
+    },
+    "papermill": {
+     "duration": 0.062702,
+     "end_time": "2026-06-22T19:15:09.067598",
+     "exception": false,
+     "start_time": "2026-06-22T19:15:09.004896",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -4955,7 +5148,6 @@
      ]
     }
    ],
-   "execution_count": 15,
    "source": [
     "// Exercice : Detection d'un changement de regime par apprentissage en ligne\n",
     "\n",
@@ -4984,10 +5176,10 @@
    "id": "c332bbf3",
    "metadata": {
     "papermill": {
-     "duration": 0.035434,
-     "end_time": "2026-06-04T06:26:17.190445",
+     "duration": 0.031936,
+     "end_time": "2026-06-22T19:15:09.132534",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.155011",
+     "start_time": "2026-06-22T19:15:09.100598",
      "status": "completed"
     },
     "tags": []
@@ -5018,10 +5210,10 @@
    "id": "4818bed2",
    "metadata": {
     "papermill": {
-     "duration": 0.035812,
-     "end_time": "2026-06-04T06:26:17.260855",
+     "duration": 0.033753,
+     "end_time": "2026-06-22T19:15:09.203719",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.225043",
+     "start_time": "2026-06-22T19:15:09.169966",
      "status": "completed"
     },
     "tags": []
@@ -5037,10 +5229,10 @@
    "id": "iitn9jcy63",
    "metadata": {
     "papermill": {
-     "duration": 0.038906,
-     "end_time": "2026-06-04T06:26:17.335404",
+     "duration": 0.0316,
+     "end_time": "2026-06-22T19:15:09.266339",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.296498",
+     "start_time": "2026-06-22T19:15:09.234739",
      "status": "completed"
     },
     "tags": []
@@ -5072,16 +5264,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:17.408974Z",
-     "iopub.status.busy": "2026-06-04T06:26:17.408609Z",
-     "iopub.status.idle": "2026-06-04T06:26:17.471178Z",
-     "shell.execute_reply": "2026-06-04T06:26:17.471389Z"
+     "iopub.execute_input": "2026-06-22T19:15:09.339585Z",
+     "iopub.status.busy": "2026-06-22T19:15:09.339585Z",
+     "iopub.status.idle": "2026-06-22T19:15:09.403966Z",
+     "shell.execute_reply": "2026-06-22T19:15:09.404480Z"
     },
     "papermill": {
-     "duration": 0.099755,
-     "end_time": "2026-06-04T06:26:17.471502",
+     "duration": 0.103141,
+     "end_time": "2026-06-22T19:15:09.404480",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.371747",
+     "start_time": "2026-06-22T19:15:09.301339",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -5178,10 +5370,10 @@
    "id": "umwfz1ze02",
    "metadata": {
     "papermill": {
-     "duration": 0.038396,
-     "end_time": "2026-06-04T06:26:17.546119",
+     "duration": 0.030834,
+     "end_time": "2026-06-22T19:15:09.467216",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.507723",
+     "start_time": "2026-06-22T19:15:09.436382",
      "status": "completed"
     },
     "tags": []
@@ -5216,16 +5408,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:17.626522Z",
-     "iopub.status.busy": "2026-06-04T06:26:17.626205Z",
-     "iopub.status.idle": "2026-06-04T06:26:17.673594Z",
-     "shell.execute_reply": "2026-06-04T06:26:17.673402Z"
+     "iopub.execute_input": "2026-06-22T19:15:09.537692Z",
+     "iopub.status.busy": "2026-06-22T19:15:09.537692Z",
+     "iopub.status.idle": "2026-06-22T19:15:09.578567Z",
+     "shell.execute_reply": "2026-06-22T19:15:09.578052Z"
     },
     "papermill": {
-     "duration": 0.082921,
-     "end_time": "2026-06-04T06:26:17.673691",
+     "duration": 0.081778,
+     "end_time": "2026-06-22T19:15:09.578567",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.590770",
+     "start_time": "2026-06-22T19:15:09.496789",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -5297,10 +5489,10 @@
    "id": "m94rssxc87i",
    "metadata": {
     "papermill": {
-     "duration": 0.033369,
-     "end_time": "2026-06-04T06:26:17.746606",
+     "duration": 0.041156,
+     "end_time": "2026-06-22T19:15:09.657373",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.713237",
+     "start_time": "2026-06-22T19:15:09.616217",
      "status": "completed"
     },
     "tags": []
@@ -5325,16 +5517,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:17.843376Z",
-     "iopub.status.busy": "2026-06-04T06:26:17.842652Z",
-     "iopub.status.idle": "2026-06-04T06:26:17.907389Z",
-     "shell.execute_reply": "2026-06-04T06:26:17.907182Z"
+     "iopub.execute_input": "2026-06-22T19:15:09.734787Z",
+     "iopub.status.busy": "2026-06-22T19:15:09.734787Z",
+     "iopub.status.idle": "2026-06-22T19:15:09.769788Z",
+     "shell.execute_reply": "2026-06-22T19:15:09.769788Z"
     },
     "papermill": {
-     "duration": 0.122401,
-     "end_time": "2026-06-04T06:26:17.907493",
+     "duration": 0.074177,
+     "end_time": "2026-06-22T19:15:09.769788",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.785092",
+     "start_time": "2026-06-22T19:15:09.695611",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -5386,10 +5578,10 @@
    "id": "62ab012f",
    "metadata": {
     "papermill": {
-     "duration": 0.036749,
-     "end_time": "2026-06-04T06:26:17.980206",
+     "duration": 0.037721,
+     "end_time": "2026-06-22T19:15:09.844510",
      "exception": false,
-     "start_time": "2026-06-04T06:26:17.943457",
+     "start_time": "2026-06-22T19:15:09.806789",
      "status": "completed"
     },
     "tags": []
@@ -5405,10 +5597,10 @@
    "id": "1a28qrexsahj",
    "metadata": {
     "papermill": {
-     "duration": 0.035595,
-     "end_time": "2026-06-04T06:26:18.052892",
+     "duration": 0.035223,
+     "end_time": "2026-06-22T19:15:09.917008",
      "exception": false,
-     "start_time": "2026-06-04T06:26:18.017297",
+     "start_time": "2026-06-22T19:15:09.881785",
      "status": "completed"
     },
     "tags": []
@@ -5442,16 +5634,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:18.130741Z",
-     "iopub.status.busy": "2026-06-04T06:26:18.130366Z",
-     "iopub.status.idle": "2026-06-04T06:26:18.946561Z",
-     "shell.execute_reply": "2026-06-04T06:26:18.933959Z"
+     "iopub.execute_input": "2026-06-22T19:15:09.989518Z",
+     "iopub.status.busy": "2026-06-22T19:15:09.989518Z",
+     "iopub.status.idle": "2026-06-22T19:15:10.779776Z",
+     "shell.execute_reply": "2026-06-22T19:15:10.767774Z"
     },
     "papermill": {
-     "duration": 0.856121,
-     "end_time": "2026-06-04T06:26:18.946681",
+     "duration": 0.825259,
+     "end_time": "2026-06-22T19:15:10.779776",
      "exception": false,
-     "start_time": "2026-06-04T06:26:18.090560",
+     "start_time": "2026-06-22T19:15:09.954517",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -5463,38 +5655,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_44_38.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -5985,10 +6145,10 @@
    "id": "a5240d45",
    "metadata": {
     "papermill": {
-     "duration": 0.04547,
-     "end_time": "2026-06-04T06:26:19.040298",
+     "duration": 0.036757,
+     "end_time": "2026-06-22T19:15:10.851525",
      "exception": false,
-     "start_time": "2026-06-04T06:26:18.994828",
+     "start_time": "2026-06-22T19:15:10.814768",
      "status": "completed"
     },
     "tags": []
@@ -6003,16 +6163,16 @@
    "id": "krh9xrtnnx",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:19.120186Z",
-     "iopub.status.busy": "2026-06-04T06:26:19.119855Z",
-     "iopub.status.idle": "2026-06-04T06:26:19.159196Z",
-     "shell.execute_reply": "2026-06-04T06:26:19.158952Z"
+     "iopub.execute_input": "2026-06-22T19:15:10.921881Z",
+     "iopub.status.busy": "2026-06-22T19:15:10.921378Z",
+     "iopub.status.idle": "2026-06-22T19:15:11.013913Z",
+     "shell.execute_reply": "2026-06-22T19:15:11.013913Z"
     },
     "papermill": {
-     "duration": 0.080557,
-     "end_time": "2026-06-04T06:26:19.159321",
+     "duration": 0.126918,
+     "end_time": "2026-06-22T19:15:11.013913",
      "exception": false,
-     "start_time": "2026-06-04T06:26:19.078764",
+     "start_time": "2026-06-22T19:15:10.886995",
      "status": "completed"
     },
     "tags": [],
@@ -6024,10 +6184,205 @@
     {
      "data": {
       "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_06_04_26_17_56_44_38.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_10_05.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       " -->\r\n",
+       "<!-- Title: Model Pages: 1 -->\r\n",
+       "<svg width=\"361pt\" height=\"444pt\"\r\n",
+       " viewBox=\"0.00 0.00 361.00 444.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 440)\">\r\n",
+       "<title>Model</title>\r\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-440 357.25,-440 357.25,4 -4,4\"/>\r\n",
+       "<!-- node0 -->\r\n",
+       "<g id=\"node1\" class=\"node\">\r\n",
+       "<title>node0</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M341.25,-199.5C341.25,-199.5 236,-199.5 236,-199.5 230,-199.5 224,-193.5 224,-187.5 224,-187.5 224,-175.5 224,-175.5 224,-169.5 230,-163.5 236,-163.5 236,-163.5 341.25,-163.5 341.25,-163.5 347.25,-163.5 353.25,-169.5 353.25,-175.5 353.25,-175.5 353.25,-187.5 353.25,-187.5 353.25,-193.5 347.25,-199.5 341.25,-199.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"288.62\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]1[vint[]0[index2]]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1 -->\r\n",
+       "<g id=\"node2\" class=\"node\">\r\n",
+       "<title>node1</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M156.62,-117.75C156.62,-117.75 126.62,-117.75 126.62,-117.75 120.62,-117.75 114.62,-111.75 114.62,-105.75 114.62,-105.75 114.62,-93.75 114.62,-93.75 114.62,-87.75 120.62,-81.75 126.62,-81.75 126.62,-81.75 156.62,-81.75 156.62,-81.75 162.62,-81.75 168.62,-87.75 168.62,-93.75 168.62,-93.75 168.62,-105.75 168.62,-105.75 168.62,-111.75 162.62,-117.75 156.62,-117.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-97.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n",
+       "</g>\r\n",
+       "<!-- node0&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge1\" class=\"edge\">\r\n",
+       "<title>node0&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M256.73,-163.2C233.82,-150.77 202.88,-133.98 178.85,-120.94\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"180.8,-118.02 170.34,-116.33 177.46,-124.18 180.8,-118.02\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"232.55\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3 -->\r\n",
+       "<g id=\"node4\" class=\"node\">\r\n",
+       "<title>node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M129.38,-36C129.38,-36 57.88,-36 57.88,-36 51.88,-36 45.88,-30 45.88,-24 45.88,-24 45.88,-12 45.88,-12 45.88,-6 51.88,0 57.88,0 57.88,0 129.38,0 129.38,0 135.38,0 141.38,-6 141.38,-12 141.38,-12 141.38,-24 141.38,-24 141.38,-30 135.38,-36 129.38,-36\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"93.62\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]3[index2]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge3\" class=\"edge\">\r\n",
+       "<title>node1&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M131.21,-81.45C124.94,-71.03 116.83,-57.55 109.74,-45.78\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"112.79,-44.06 104.64,-37.29 106.79,-47.67 112.79,-44.06\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node2 -->\r\n",
+       "<g id=\"node3\" class=\"node\">\r\n",
+       "<title>node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M194.25,-199.5C194.25,-199.5 89,-199.5 89,-199.5 83,-199.5 77,-193.5 77,-187.5 77,-187.5 77,-175.5 77,-175.5 77,-169.5 83,-163.5 89,-163.5 89,-163.5 194.25,-163.5 194.25,-163.5 200.25,-163.5 206.25,-169.5 206.25,-175.5 206.25,-175.5 206.25,-187.5 206.25,-187.5 206.25,-193.5 200.25,-199.5 194.25,-199.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]2[vint[]0[index2]]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge2\" class=\"edge\">\r\n",
+       "<title>node2&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M141.62,-163.2C141.62,-153.27 141.62,-140.56 141.62,-129.2\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"145.13,-129.53 141.63,-119.53 138.13,-129.53 145.13,-129.53\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"156.25\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4 -->\r\n",
+       "<g id=\"node5\" class=\"node\">\r\n",
+       "<title>node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M78.75,-117.75C78.75,-117.75 24.5,-117.75 24.5,-117.75 18.5,-117.75 12.5,-111.75 12.5,-105.75 12.5,-105.75 12.5,-93.75 12.5,-93.75 12.5,-87.75 18.5,-81.75 24.5,-81.75 24.5,-81.75 78.75,-81.75 78.75,-81.75 84.75,-81.75 90.75,-87.75 90.75,-93.75 90.75,-93.75 90.75,-105.75 90.75,-105.75 90.75,-111.75 84.75,-117.75 78.75,-117.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"51.62\" y=\"-95.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vint[]0[index2]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge4\" class=\"edge\">\r\n",
+       "<title>node4&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M60.74,-81.45C66.17,-71.13 73.18,-57.82 79.33,-46.14\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"82.41,-47.81 83.97,-37.34 76.21,-44.55 82.41,-47.81\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"89.76\" y=\"-56.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">condition</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5 -->\r\n",
+       "<g id=\"node6\" class=\"node\">\r\n",
+       "<title>node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M46.62,-281.25C46.62,-281.25 16.62,-281.25 16.62,-281.25 10.62,-281.25 4.62,-275.25 4.62,-269.25 4.62,-269.25 4.62,-257.25 4.62,-257.25 4.62,-251.25 10.62,-245.25 16.62,-245.25 16.62,-245.25 46.62,-245.25 46.62,-245.25 52.62,-245.25 58.62,-251.25 58.62,-257.25 58.62,-257.25 58.62,-269.25 58.62,-269.25 58.62,-275.25 52.62,-281.25 46.62,-281.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"31.62\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vVector0</text>\r\n",
+       "</g>\r\n",
+       "<!-- node6 -->\r\n",
+       "<g id=\"node7\" class=\"node\">\r\n",
+       "<title>node6</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M46.62,-199.5C46.62,-199.5 16.62,-199.5 16.62,-199.5 10.62,-199.5 4.62,-193.5 4.62,-187.5 4.62,-187.5 4.62,-175.5 4.62,-175.5 4.62,-169.5 10.62,-163.5 16.62,-163.5 16.62,-163.5 46.62,-163.5 46.62,-163.5 52.62,-163.5 58.62,-169.5 58.62,-175.5 58.62,-175.5 58.62,-187.5 58.62,-187.5 58.62,-193.5 52.62,-199.5 46.62,-199.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"31.62\" y=\"-178.78\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5&#45;&gt;node6 -->\r\n",
+       "<g id=\"edge5\" class=\"edge\">\r\n",
+       "<title>node5&#45;&gt;node6</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M31.62,-244.95C31.62,-235.02 31.62,-222.31 31.62,-210.95\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"35.13,-211.28 31.63,-201.28 28.13,-211.28 35.13,-211.28\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"40.25\" y=\"-219.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
+       "</g>\r\n",
+       "<!-- node6&#45;&gt;node4 -->\r\n",
+       "<g id=\"edge6\" class=\"edge\">\r\n",
+       "<title>node6&#45;&gt;node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M35.96,-163.2C38.48,-153.16 41.71,-140.29 44.58,-128.84\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"47.89,-130.04 46.93,-119.49 41.1,-128.34 47.89,-130.04\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node7 -->\r\n",
+       "<g id=\"node8\" class=\"node\">\r\n",
+       "<title>node7</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M51.25,-436C51.25,-436 12,-436 12,-436 6,-436 0,-430 0,-424 0,-424 0,-412 0,-412 0,-406 6,-400 12,-400 12,-400 51.25,-400 51.25,-400 57.25,-400 63.25,-406 63.25,-412 63.25,-412 63.25,-424 63.25,-424 63.25,-430 57.25,-436 51.25,-436\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"31.62\" y=\"-414.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vDirichlet0</text>\r\n",
+       "</g>\r\n",
+       "<!-- node8 -->\r\n",
+       "<g id=\"node9\" class=\"node\">\r\n",
+       "<title>node8</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M46.62,-354.25C46.62,-354.25 16.62,-354.25 16.62,-354.25 10.62,-354.25 4.62,-348.25 4.62,-342.25 4.62,-342.25 4.62,-330.25 4.62,-330.25 4.62,-324.25 10.62,-318.25 16.62,-318.25 16.62,-318.25 46.62,-318.25 46.62,-318.25 52.62,-318.25 58.62,-324.25 58.62,-330.25 58.62,-330.25 58.62,-342.25 58.62,-342.25 58.62,-348.25 52.62,-354.25 46.62,-354.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"31.62\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node7&#45;&gt;node8 -->\r\n",
+       "<g id=\"edge7\" class=\"edge\">\r\n",
+       "<title>node7&#45;&gt;node8</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M31.62,-400.09C31.62,-390.18 31.62,-377.4 31.62,-365.96\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"35.13,-366.2 31.63,-356.2 28.13,-366.2 35.13,-366.2\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"37.25\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node8&#45;&gt;node5 -->\r\n",
+       "<g id=\"edge8\" class=\"edge\">\r\n",
+       "<title>node8&#45;&gt;node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M31.62,-318.06C31.62,-310.48 31.62,-301.35 31.62,-292.79\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"35.13,-292.79 31.63,-282.79 28.13,-292.79 35.13,-292.79\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node9 -->\r\n",
+       "<g id=\"node10\" class=\"node\">\r\n",
+       "<title>node9</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M178.88,-436C178.88,-436 104.38,-436 104.38,-436 98.38,-436 92.38,-430 92.38,-424 92.38,-424 92.38,-412 92.38,-412 92.38,-406 98.38,-400 104.38,-400 104.38,-400 178.88,-400 178.88,-400 184.88,-400 190.88,-406 190.88,-412 190.88,-412 190.88,-424 190.88,-424 190.88,-430 184.88,-436 178.88,-436\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-414.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vGamma[]0[index1]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node10 -->\r\n",
+       "<g id=\"node11\" class=\"node\">\r\n",
+       "<title>node10</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M156.62,-354.25C156.62,-354.25 126.62,-354.25 126.62,-354.25 120.62,-354.25 114.62,-348.25 114.62,-342.25 114.62,-342.25 114.62,-330.25 114.62,-330.25 114.62,-324.25 120.62,-318.25 126.62,-318.25 126.62,-318.25 156.62,-318.25 156.62,-318.25 162.62,-318.25 168.62,-324.25 168.62,-330.25 168.62,-330.25 168.62,-342.25 168.62,-342.25 168.62,-348.25 162.62,-354.25 156.62,-354.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node9&#45;&gt;node10 -->\r\n",
+       "<g id=\"edge9\" class=\"edge\">\r\n",
+       "<title>node9&#45;&gt;node10</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M141.62,-400.09C141.62,-390.18 141.62,-377.4 141.62,-365.96\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"145.13,-366.2 141.63,-356.2 138.13,-366.2 145.13,-366.2\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"147.25\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node11 -->\r\n",
+       "<g id=\"node12\" class=\"node\">\r\n",
+       "<title>node11</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M177.38,-281.25C177.38,-281.25 105.88,-281.25 105.88,-281.25 99.88,-281.25 93.88,-275.25 93.88,-269.25 93.88,-269.25 93.88,-257.25 93.88,-257.25 93.88,-251.25 99.88,-245.25 105.88,-245.25 105.88,-245.25 177.38,-245.25 177.38,-245.25 183.38,-245.25 189.38,-251.25 189.38,-257.25 189.38,-257.25 189.38,-269.25 189.38,-269.25 189.38,-275.25 183.38,-281.25 177.38,-281.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]2[index1]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node10&#45;&gt;node11 -->\r\n",
+       "<g id=\"edge10\" class=\"edge\">\r\n",
+       "<title>node10&#45;&gt;node11</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M141.62,-318.06C141.62,-310.48 141.62,-301.35 141.62,-292.79\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"145.13,-292.79 141.63,-282.79 138.13,-292.79 145.13,-292.79\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node11&#45;&gt;node2 -->\r\n",
+       "<g id=\"edge14\" class=\"edge\">\r\n",
+       "<title>node11&#45;&gt;node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M141.62,-244.95C141.62,-231.57 141.62,-213.14 141.62,-199.77\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node12 -->\r\n",
+       "<g id=\"node13\" class=\"node\">\r\n",
+       "<title>node12</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M328.88,-436C328.88,-436 248.38,-436 248.38,-436 242.38,-436 236.38,-430 236.38,-424 236.38,-424 236.38,-412 236.38,-412 236.38,-406 242.38,-400 248.38,-400 248.38,-400 328.88,-400 328.88,-400 334.88,-400 340.88,-406 340.88,-412 340.88,-412 340.88,-424 340.88,-424 340.88,-430 334.88,-436 328.88,-436\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"288.62\" y=\"-414.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vGaussian[]0[index1]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node13 -->\r\n",
+       "<g id=\"node14\" class=\"node\">\r\n",
+       "<title>node13</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M303.62,-354.25C303.62,-354.25 273.62,-354.25 273.62,-354.25 267.62,-354.25 261.62,-348.25 261.62,-342.25 261.62,-342.25 261.62,-330.25 261.62,-330.25 261.62,-324.25 267.62,-318.25 273.62,-318.25 273.62,-318.25 303.62,-318.25 303.62,-318.25 309.62,-318.25 315.62,-324.25 315.62,-330.25 315.62,-330.25 315.62,-342.25 315.62,-342.25 315.62,-348.25 309.62,-354.25 303.62,-354.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"288.62\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node12&#45;&gt;node13 -->\r\n",
+       "<g id=\"edge11\" class=\"edge\">\r\n",
+       "<title>node12&#45;&gt;node13</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M288.62,-400.09C288.62,-390.18 288.62,-377.4 288.62,-365.96\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"292.13,-366.2 288.63,-356.2 285.13,-366.2 292.13,-366.2\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"294.25\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node14 -->\r\n",
+       "<g id=\"node15\" class=\"node\">\r\n",
+       "<title>node14</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M324.38,-281.25C324.38,-281.25 252.88,-281.25 252.88,-281.25 246.88,-281.25 240.88,-275.25 240.88,-269.25 240.88,-269.25 240.88,-257.25 240.88,-257.25 240.88,-251.25 246.88,-245.25 252.88,-245.25 252.88,-245.25 324.38,-245.25 324.38,-245.25 330.38,-245.25 336.38,-251.25 336.38,-257.25 336.38,-257.25 336.38,-269.25 336.38,-269.25 336.38,-275.25 330.38,-281.25 324.38,-281.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"288.62\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]1[index1]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node13&#45;&gt;node14 -->\r\n",
+       "<g id=\"edge12\" class=\"edge\">\r\n",
+       "<title>node13&#45;&gt;node14</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M288.62,-318.06C288.62,-310.48 288.62,-301.35 288.62,-292.79\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"292.13,-292.79 288.63,-282.79 285.13,-292.79 292.13,-292.79\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node14&#45;&gt;node0 -->\r\n",
+       "<g id=\"edge13\" class=\"edge\">\r\n",
+       "<title>node14&#45;&gt;node0</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M288.62,-244.95C288.62,-231.57 288.62,-213.14 288.62,-199.77\"/>\r\n",
+       "</g>\r\n",
+       "</g>\r\n",
+       "</svg>\r\n",
+       "\r\n",
+       "    </div>\r\n",
+       "</div>"
       ]
      },
      "metadata": {},
@@ -6038,7 +6393,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -6053,10 +6408,10 @@
    "id": "vh9qawt99p",
    "metadata": {
     "papermill": {
-     "duration": 0.044042,
-     "end_time": "2026-06-04T06:26:19.245384",
+     "duration": 0.03451,
+     "end_time": "2026-06-22T19:15:11.083125",
      "exception": false,
-     "start_time": "2026-06-04T06:26:19.201342",
+     "start_time": "2026-06-22T19:15:11.048615",
      "status": "completed"
     },
     "tags": []
@@ -6091,10 +6446,10 @@
    "id": "vdgtmx7lmpl",
    "metadata": {
     "papermill": {
-     "duration": 0.043048,
-     "end_time": "2026-06-04T06:26:19.330947",
+     "duration": 0.03683,
+     "end_time": "2026-06-22T19:15:11.152970",
      "exception": false,
-     "start_time": "2026-06-04T06:26:19.287899",
+     "start_time": "2026-06-22T19:15:11.116140",
      "status": "completed"
     },
     "tags": []
@@ -6123,10 +6478,10 @@
    "id": "tnffao04tp",
    "metadata": {
     "papermill": {
-     "duration": 0.046859,
-     "end_time": "2026-06-04T06:26:19.418711",
+     "duration": 0.036016,
+     "end_time": "2026-06-22T19:15:11.222978",
      "exception": false,
-     "start_time": "2026-06-04T06:26:19.371852",
+     "start_time": "2026-06-22T19:15:11.186962",
      "status": "completed"
     },
     "tags": []
@@ -6150,16 +6505,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:19.504504Z",
-     "iopub.status.busy": "2026-06-04T06:26:19.504155Z",
-     "iopub.status.idle": "2026-06-04T06:26:20.186670Z",
-     "shell.execute_reply": "2026-06-04T06:26:20.167612Z"
+     "iopub.execute_input": "2026-06-22T19:15:11.294183Z",
+     "iopub.status.busy": "2026-06-22T19:15:11.294183Z",
+     "iopub.status.idle": "2026-06-22T19:15:11.934835Z",
+     "shell.execute_reply": "2026-06-22T19:15:11.920597Z"
     },
     "papermill": {
-     "duration": 0.727073,
-     "end_time": "2026-06-04T06:26:20.186834",
+     "duration": 0.6773,
+     "end_time": "2026-06-22T19:15:11.935843",
      "exception": false,
-     "start_time": "2026-06-04T06:26:19.459761",
+     "start_time": "2026-06-22T19:15:11.258543",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6171,38 +6526,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_46_00.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -6613,10 +6936,10 @@
    "id": "m861p6urm1",
    "metadata": {
     "papermill": {
-     "duration": 0.052596,
-     "end_time": "2026-06-04T06:26:20.291569",
+     "duration": 0.035415,
+     "end_time": "2026-06-22T19:15:12.007358",
      "exception": false,
-     "start_time": "2026-06-04T06:26:20.238973",
+     "start_time": "2026-06-22T19:15:11.971943",
      "status": "completed"
     },
     "tags": []
@@ -6648,10 +6971,10 @@
    "id": "79615172",
    "metadata": {
     "papermill": {
-     "duration": 0.049415,
-     "end_time": "2026-06-04T06:26:20.399238",
+     "duration": 0.033944,
+     "end_time": "2026-06-22T19:15:12.077330",
      "exception": false,
-     "start_time": "2026-06-04T06:26:20.349823",
+     "start_time": "2026-06-22T19:15:12.043386",
      "status": "completed"
     },
     "tags": []
@@ -6684,10 +7007,10 @@
    "id": "8vj1wcrnvd9",
    "metadata": {
     "papermill": {
-     "duration": 0.046636,
-     "end_time": "2026-06-04T06:26:20.488648",
+     "duration": 0.036867,
+     "end_time": "2026-06-22T19:15:12.150133",
      "exception": false,
-     "start_time": "2026-06-04T06:26:20.442012",
+     "start_time": "2026-06-22T19:15:12.113266",
      "status": "completed"
     },
     "tags": []
@@ -6714,16 +7037,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:20.578238Z",
-     "iopub.status.busy": "2026-06-04T06:26:20.577716Z",
-     "iopub.status.idle": "2026-06-04T06:26:21.341934Z",
-     "shell.execute_reply": "2026-06-04T06:26:21.326073Z"
+     "iopub.execute_input": "2026-06-22T19:15:12.224387Z",
+     "iopub.status.busy": "2026-06-22T19:15:12.224387Z",
+     "iopub.status.idle": "2026-06-22T19:15:12.944745Z",
+     "shell.execute_reply": "2026-06-22T19:15:12.930466Z"
     },
     "papermill": {
-     "duration": 0.811185,
-     "end_time": "2026-06-04T06:26:21.342052",
+     "duration": 0.756582,
+     "end_time": "2026-06-22T19:15:12.944745",
      "exception": false,
-     "start_time": "2026-06-04T06:26:20.530867",
+     "start_time": "2026-06-22T19:15:12.188163",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6735,38 +7058,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_04_26_17_56_47_45.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -7276,10 +7567,10 @@
    "id": "7d3a413a",
    "metadata": {
     "papermill": {
-     "duration": 0.056079,
-     "end_time": "2026-06-04T06:26:21.445683",
+     "duration": 0.044423,
+     "end_time": "2026-06-22T19:15:13.031289",
      "exception": false,
-     "start_time": "2026-06-04T06:26:21.389604",
+     "start_time": "2026-06-22T19:15:12.986866",
      "status": "completed"
     },
     "tags": []
@@ -7294,19 +7585,19 @@
    "id": "cl4o2r0qi3g",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:21.541134Z",
-     "iopub.status.busy": "2026-06-04T06:26:21.539321Z",
-     "iopub.status.idle": "2026-06-04T06:26:21.594693Z",
-     "shell.execute_reply": "2026-06-04T06:26:21.594867Z"
+     "iopub.execute_input": "2026-06-22T19:15:13.117707Z",
+     "iopub.status.busy": "2026-06-22T19:15:13.117707Z",
+     "iopub.status.idle": "2026-06-22T19:15:13.243540Z",
+     "shell.execute_reply": "2026-06-22T19:15:13.243540Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.104054,
-     "end_time": "2026-06-04T06:26:21.594968",
+     "duration": 0.168463,
+     "end_time": "2026-06-22T19:15:13.243540",
      "exception": false,
-     "start_time": "2026-06-04T06:26:21.490914",
+     "start_time": "2026-06-22T19:15:13.075077",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -7321,10 +7612,205 @@
     {
      "data": {
       "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_06_04_26_17_56_47_45.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_12_28.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       " -->\r\n",
+       "<!-- Title: Model Pages: 1 -->\r\n",
+       "<svg width=\"361pt\" height=\"444pt\"\r\n",
+       " viewBox=\"0.00 0.00 361.00 444.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 440)\">\r\n",
+       "<title>Model</title>\r\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-440 357.25,-440 357.25,4 -4,4\"/>\r\n",
+       "<!-- node0 -->\r\n",
+       "<g id=\"node1\" class=\"node\">\r\n",
+       "<title>node0</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M341.25,-199.5C341.25,-199.5 236,-199.5 236,-199.5 230,-199.5 224,-193.5 224,-187.5 224,-187.5 224,-175.5 224,-175.5 224,-169.5 230,-163.5 236,-163.5 236,-163.5 341.25,-163.5 341.25,-163.5 347.25,-163.5 353.25,-169.5 353.25,-175.5 353.25,-175.5 353.25,-187.5 353.25,-187.5 353.25,-193.5 347.25,-199.5 341.25,-199.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"288.62\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]6[vint[]1[index5]]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1 -->\r\n",
+       "<g id=\"node2\" class=\"node\">\r\n",
+       "<title>node1</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M156.62,-117.75C156.62,-117.75 126.62,-117.75 126.62,-117.75 120.62,-117.75 114.62,-111.75 114.62,-105.75 114.62,-105.75 114.62,-93.75 114.62,-93.75 114.62,-87.75 120.62,-81.75 126.62,-81.75 126.62,-81.75 156.62,-81.75 156.62,-81.75 162.62,-81.75 168.62,-87.75 168.62,-93.75 168.62,-93.75 168.62,-105.75 168.62,-105.75 168.62,-111.75 162.62,-117.75 156.62,-117.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-97.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n",
+       "</g>\r\n",
+       "<!-- node0&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge1\" class=\"edge\">\r\n",
+       "<title>node0&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M256.73,-163.2C233.82,-150.77 202.88,-133.98 178.85,-120.94\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"180.8,-118.02 170.34,-116.33 177.46,-124.18 180.8,-118.02\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"232.55\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3 -->\r\n",
+       "<g id=\"node4\" class=\"node\">\r\n",
+       "<title>node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M129.38,-36C129.38,-36 57.88,-36 57.88,-36 51.88,-36 45.88,-30 45.88,-24 45.88,-24 45.88,-12 45.88,-12 45.88,-6 51.88,0 57.88,0 57.88,0 129.38,0 129.38,0 135.38,0 141.38,-6 141.38,-12 141.38,-12 141.38,-24 141.38,-24 141.38,-30 135.38,-36 129.38,-36\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"93.62\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]8[index5]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge3\" class=\"edge\">\r\n",
+       "<title>node1&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M131.21,-81.45C124.94,-71.03 116.83,-57.55 109.74,-45.78\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"112.79,-44.06 104.64,-37.29 106.79,-47.67 112.79,-44.06\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node2 -->\r\n",
+       "<g id=\"node3\" class=\"node\">\r\n",
+       "<title>node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M194.25,-199.5C194.25,-199.5 89,-199.5 89,-199.5 83,-199.5 77,-193.5 77,-187.5 77,-187.5 77,-175.5 77,-175.5 77,-169.5 83,-163.5 89,-163.5 89,-163.5 194.25,-163.5 194.25,-163.5 200.25,-163.5 206.25,-169.5 206.25,-175.5 206.25,-175.5 206.25,-187.5 206.25,-187.5 206.25,-193.5 200.25,-199.5 194.25,-199.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]7[vint[]1[index5]]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge2\" class=\"edge\">\r\n",
+       "<title>node2&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M141.62,-163.2C141.62,-153.27 141.62,-140.56 141.62,-129.2\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"145.13,-129.53 141.63,-119.53 138.13,-129.53 145.13,-129.53\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"156.25\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4 -->\r\n",
+       "<g id=\"node5\" class=\"node\">\r\n",
+       "<title>node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M78.75,-117.75C78.75,-117.75 24.5,-117.75 24.5,-117.75 18.5,-117.75 12.5,-111.75 12.5,-105.75 12.5,-105.75 12.5,-93.75 12.5,-93.75 12.5,-87.75 18.5,-81.75 24.5,-81.75 24.5,-81.75 78.75,-81.75 78.75,-81.75 84.75,-81.75 90.75,-87.75 90.75,-93.75 90.75,-93.75 90.75,-105.75 90.75,-105.75 90.75,-111.75 84.75,-117.75 78.75,-117.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"51.62\" y=\"-95.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vint[]1[index5]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge4\" class=\"edge\">\r\n",
+       "<title>node4&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M60.74,-81.45C66.17,-71.13 73.18,-57.82 79.33,-46.14\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"82.41,-47.81 83.97,-37.34 76.21,-44.55 82.41,-47.81\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"89.76\" y=\"-56.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">condition</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5 -->\r\n",
+       "<g id=\"node6\" class=\"node\">\r\n",
+       "<title>node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M46.62,-281.25C46.62,-281.25 16.62,-281.25 16.62,-281.25 10.62,-281.25 4.62,-275.25 4.62,-269.25 4.62,-269.25 4.62,-257.25 4.62,-257.25 4.62,-251.25 10.62,-245.25 16.62,-245.25 16.62,-245.25 46.62,-245.25 46.62,-245.25 52.62,-245.25 58.62,-251.25 58.62,-257.25 58.62,-257.25 58.62,-269.25 58.62,-269.25 58.62,-275.25 52.62,-281.25 46.62,-281.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"31.62\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vVector2</text>\r\n",
+       "</g>\r\n",
+       "<!-- node6 -->\r\n",
+       "<g id=\"node7\" class=\"node\">\r\n",
+       "<title>node6</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M46.62,-199.5C46.62,-199.5 16.62,-199.5 16.62,-199.5 10.62,-199.5 4.62,-193.5 4.62,-187.5 4.62,-187.5 4.62,-175.5 4.62,-175.5 4.62,-169.5 10.62,-163.5 16.62,-163.5 16.62,-163.5 46.62,-163.5 46.62,-163.5 52.62,-163.5 58.62,-169.5 58.62,-175.5 58.62,-175.5 58.62,-187.5 58.62,-187.5 58.62,-193.5 52.62,-199.5 46.62,-199.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"31.62\" y=\"-178.78\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5&#45;&gt;node6 -->\r\n",
+       "<g id=\"edge5\" class=\"edge\">\r\n",
+       "<title>node5&#45;&gt;node6</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M31.62,-244.95C31.62,-235.02 31.62,-222.31 31.62,-210.95\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"35.13,-211.28 31.63,-201.28 28.13,-211.28 35.13,-211.28\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"40.25\" y=\"-219.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
+       "</g>\r\n",
+       "<!-- node6&#45;&gt;node4 -->\r\n",
+       "<g id=\"edge6\" class=\"edge\">\r\n",
+       "<title>node6&#45;&gt;node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M35.96,-163.2C38.48,-153.16 41.71,-140.29 44.58,-128.84\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"47.89,-130.04 46.93,-119.49 41.1,-128.34 47.89,-130.04\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node7 -->\r\n",
+       "<g id=\"node8\" class=\"node\">\r\n",
+       "<title>node7</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M51.25,-436C51.25,-436 12,-436 12,-436 6,-436 0,-430 0,-424 0,-424 0,-412 0,-412 0,-406 6,-400 12,-400 12,-400 51.25,-400 51.25,-400 57.25,-400 63.25,-406 63.25,-412 63.25,-412 63.25,-424 63.25,-424 63.25,-430 57.25,-436 51.25,-436\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"31.62\" y=\"-414.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vDirichlet2</text>\r\n",
+       "</g>\r\n",
+       "<!-- node8 -->\r\n",
+       "<g id=\"node9\" class=\"node\">\r\n",
+       "<title>node8</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M46.62,-354.25C46.62,-354.25 16.62,-354.25 16.62,-354.25 10.62,-354.25 4.62,-348.25 4.62,-342.25 4.62,-342.25 4.62,-330.25 4.62,-330.25 4.62,-324.25 10.62,-318.25 16.62,-318.25 16.62,-318.25 46.62,-318.25 46.62,-318.25 52.62,-318.25 58.62,-324.25 58.62,-330.25 58.62,-330.25 58.62,-342.25 58.62,-342.25 58.62,-348.25 52.62,-354.25 46.62,-354.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"31.62\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node7&#45;&gt;node8 -->\r\n",
+       "<g id=\"edge7\" class=\"edge\">\r\n",
+       "<title>node7&#45;&gt;node8</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M31.62,-400.09C31.62,-390.18 31.62,-377.4 31.62,-365.96\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"35.13,-366.2 31.63,-356.2 28.13,-366.2 35.13,-366.2\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"37.25\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node8&#45;&gt;node5 -->\r\n",
+       "<g id=\"edge8\" class=\"edge\">\r\n",
+       "<title>node8&#45;&gt;node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M31.62,-318.06C31.62,-310.48 31.62,-301.35 31.62,-292.79\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"35.13,-292.79 31.63,-282.79 28.13,-292.79 35.13,-292.79\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node9 -->\r\n",
+       "<g id=\"node10\" class=\"node\">\r\n",
+       "<title>node9</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M178.88,-436C178.88,-436 104.38,-436 104.38,-436 98.38,-436 92.38,-430 92.38,-424 92.38,-424 92.38,-412 92.38,-412 92.38,-406 98.38,-400 104.38,-400 104.38,-400 178.88,-400 178.88,-400 184.88,-400 190.88,-406 190.88,-412 190.88,-412 190.88,-424 190.88,-424 190.88,-430 184.88,-436 178.88,-436\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-414.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vGamma[]2[index4]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node10 -->\r\n",
+       "<g id=\"node11\" class=\"node\">\r\n",
+       "<title>node10</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M156.62,-354.25C156.62,-354.25 126.62,-354.25 126.62,-354.25 120.62,-354.25 114.62,-348.25 114.62,-342.25 114.62,-342.25 114.62,-330.25 114.62,-330.25 114.62,-324.25 120.62,-318.25 126.62,-318.25 126.62,-318.25 156.62,-318.25 156.62,-318.25 162.62,-318.25 168.62,-324.25 168.62,-330.25 168.62,-330.25 168.62,-342.25 168.62,-342.25 168.62,-348.25 162.62,-354.25 156.62,-354.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node9&#45;&gt;node10 -->\r\n",
+       "<g id=\"edge9\" class=\"edge\">\r\n",
+       "<title>node9&#45;&gt;node10</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M141.62,-400.09C141.62,-390.18 141.62,-377.4 141.62,-365.96\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"145.13,-366.2 141.63,-356.2 138.13,-366.2 145.13,-366.2\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"147.25\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node11 -->\r\n",
+       "<g id=\"node12\" class=\"node\">\r\n",
+       "<title>node11</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M177.38,-281.25C177.38,-281.25 105.88,-281.25 105.88,-281.25 99.88,-281.25 93.88,-275.25 93.88,-269.25 93.88,-269.25 93.88,-257.25 93.88,-257.25 93.88,-251.25 99.88,-245.25 105.88,-245.25 105.88,-245.25 177.38,-245.25 177.38,-245.25 183.38,-245.25 189.38,-251.25 189.38,-257.25 189.38,-257.25 189.38,-269.25 189.38,-269.25 189.38,-275.25 183.38,-281.25 177.38,-281.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.62\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]7[index4]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node10&#45;&gt;node11 -->\r\n",
+       "<g id=\"edge10\" class=\"edge\">\r\n",
+       "<title>node10&#45;&gt;node11</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M141.62,-318.06C141.62,-310.48 141.62,-301.35 141.62,-292.79\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"145.13,-292.79 141.63,-282.79 138.13,-292.79 145.13,-292.79\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node11&#45;&gt;node2 -->\r\n",
+       "<g id=\"edge14\" class=\"edge\">\r\n",
+       "<title>node11&#45;&gt;node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M141.62,-244.95C141.62,-231.57 141.62,-213.14 141.62,-199.77\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node12 -->\r\n",
+       "<g id=\"node13\" class=\"node\">\r\n",
+       "<title>node12</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M328.88,-436C328.88,-436 248.38,-436 248.38,-436 242.38,-436 236.38,-430 236.38,-424 236.38,-424 236.38,-412 236.38,-412 236.38,-406 242.38,-400 248.38,-400 248.38,-400 328.88,-400 328.88,-400 334.88,-400 340.88,-406 340.88,-412 340.88,-412 340.88,-424 340.88,-424 340.88,-430 334.88,-436 328.88,-436\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"288.62\" y=\"-414.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vGaussian[]2[index4]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node13 -->\r\n",
+       "<g id=\"node14\" class=\"node\">\r\n",
+       "<title>node13</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M303.62,-354.25C303.62,-354.25 273.62,-354.25 273.62,-354.25 267.62,-354.25 261.62,-348.25 261.62,-342.25 261.62,-342.25 261.62,-330.25 261.62,-330.25 261.62,-324.25 267.62,-318.25 273.62,-318.25 273.62,-318.25 303.62,-318.25 303.62,-318.25 309.62,-318.25 315.62,-324.25 315.62,-330.25 315.62,-330.25 315.62,-342.25 315.62,-342.25 315.62,-348.25 309.62,-354.25 303.62,-354.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"288.62\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node12&#45;&gt;node13 -->\r\n",
+       "<g id=\"edge11\" class=\"edge\">\r\n",
+       "<title>node12&#45;&gt;node13</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M288.62,-400.09C288.62,-390.18 288.62,-377.4 288.62,-365.96\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"292.13,-366.2 288.63,-356.2 285.13,-366.2 292.13,-366.2\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"294.25\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node14 -->\r\n",
+       "<g id=\"node15\" class=\"node\">\r\n",
+       "<title>node14</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M324.38,-281.25C324.38,-281.25 252.88,-281.25 252.88,-281.25 246.88,-281.25 240.88,-275.25 240.88,-269.25 240.88,-269.25 240.88,-257.25 240.88,-257.25 240.88,-251.25 246.88,-245.25 252.88,-245.25 252.88,-245.25 324.38,-245.25 324.38,-245.25 330.38,-245.25 336.38,-251.25 336.38,-257.25 336.38,-257.25 336.38,-269.25 336.38,-269.25 336.38,-275.25 330.38,-281.25 324.38,-281.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"288.62\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]6[index4]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node13&#45;&gt;node14 -->\r\n",
+       "<g id=\"edge12\" class=\"edge\">\r\n",
+       "<title>node13&#45;&gt;node14</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M288.62,-318.06C288.62,-310.48 288.62,-301.35 288.62,-292.79\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"292.13,-292.79 288.63,-282.79 285.13,-292.79 292.13,-292.79\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node14&#45;&gt;node0 -->\r\n",
+       "<g id=\"edge13\" class=\"edge\">\r\n",
+       "<title>node14&#45;&gt;node0</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M288.62,-244.95C288.62,-231.57 288.62,-213.14 288.62,-199.77\"/>\r\n",
+       "</g>\r\n",
+       "</g>\r\n",
+       "</svg>\r\n",
+       "\r\n",
+       "    </div>\r\n",
+       "</div>"
       ]
      },
      "metadata": {},
@@ -7335,7 +7821,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -7350,10 +7836,10 @@
    "id": "lorlhrlbr7",
    "metadata": {
     "papermill": {
-     "duration": 0.047779,
-     "end_time": "2026-06-04T06:26:21.692719",
+     "duration": 0.040752,
+     "end_time": "2026-06-22T19:15:13.324992",
      "exception": false,
-     "start_time": "2026-06-04T06:26:21.644940",
+     "start_time": "2026-06-22T19:15:13.284240",
      "status": "completed"
     },
     "tags": []
@@ -7379,10 +7865,10 @@
    "id": "cwwbs4wshws",
    "metadata": {
     "papermill": {
-     "duration": 0.048685,
-     "end_time": "2026-06-04T06:26:21.789862",
+     "duration": 0.045719,
+     "end_time": "2026-06-22T19:15:13.412171",
      "exception": false,
-     "start_time": "2026-06-04T06:26:21.741177",
+     "start_time": "2026-06-22T19:15:13.366452",
      "status": "completed"
     },
     "tags": []
@@ -7407,10 +7893,10 @@
    "id": "542c7095",
    "metadata": {
     "papermill": {
-     "duration": 0.049746,
-     "end_time": "2026-06-04T06:26:21.889232",
+     "duration": 0.039977,
+     "end_time": "2026-06-22T19:15:13.492290",
      "exception": false,
-     "start_time": "2026-06-04T06:26:21.839486",
+     "start_time": "2026-06-22T19:15:13.452313",
      "status": "completed"
     },
     "tags": []
@@ -7471,10 +7957,10 @@
    "id": "e665cf73",
    "metadata": {
     "papermill": {
-     "duration": 0.046395,
-     "end_time": "2026-06-04T06:26:21.979423",
+     "duration": 0.043853,
+     "end_time": "2026-06-22T19:15:13.574975",
      "exception": false,
-     "start_time": "2026-06-04T06:26:21.933028",
+     "start_time": "2026-06-22T19:15:13.531122",
      "status": "completed"
     },
     "tags": []
@@ -7507,19 +7993,19 @@
    "id": "ac70413a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:22.075384Z",
-     "iopub.status.busy": "2026-06-04T06:26:22.075049Z",
-     "iopub.status.idle": "2026-06-04T06:26:22.139518Z",
-     "shell.execute_reply": "2026-06-04T06:26:22.139250Z"
+     "iopub.execute_input": "2026-06-22T19:15:13.659840Z",
+     "iopub.status.busy": "2026-06-22T19:15:13.659840Z",
+     "iopub.status.idle": "2026-06-22T19:15:13.714757Z",
+     "shell.execute_reply": "2026-06-22T19:15:13.714238Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.115146,
-     "end_time": "2026-06-04T06:26:22.139647",
+     "duration": 0.102344,
+     "end_time": "2026-06-22T19:15:13.714757",
      "exception": false,
-     "start_time": "2026-06-04T06:26:22.024501",
+     "start_time": "2026-06-22T19:15:13.612413",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -7635,10 +8121,10 @@
    "id": "d564b129",
    "metadata": {
     "papermill": {
-     "duration": 0.048012,
-     "end_time": "2026-06-04T06:26:22.235955",
+     "duration": 0.062938,
+     "end_time": "2026-06-22T19:15:13.824029",
      "exception": false,
-     "start_time": "2026-06-04T06:26:22.187943",
+     "start_time": "2026-06-22T19:15:13.761091",
      "status": "completed"
     },
     "tags": []
@@ -7689,16 +8175,16 @@
    "id": "f17a9f9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:22.339518Z",
-     "iopub.status.busy": "2026-06-04T06:26:22.339170Z",
-     "iopub.status.idle": "2026-06-04T06:26:22.382589Z",
-     "shell.execute_reply": "2026-06-04T06:26:22.382231Z"
+     "iopub.execute_input": "2026-06-22T19:15:13.907825Z",
+     "iopub.status.busy": "2026-06-22T19:15:13.907310Z",
+     "iopub.status.idle": "2026-06-22T19:15:13.939030Z",
+     "shell.execute_reply": "2026-06-22T19:15:13.939030Z"
     },
     "papermill": {
-     "duration": 0.096286,
-     "end_time": "2026-06-04T06:26:22.382735",
+     "duration": 0.071606,
+     "end_time": "2026-06-22T19:15:13.939030",
      "exception": false,
-     "start_time": "2026-06-04T06:26:22.286449",
+     "start_time": "2026-06-22T19:15:13.867424",
      "status": "completed"
     },
     "tags": []
@@ -7759,10 +8245,10 @@
    "id": "gm-bic-exercise-md",
    "metadata": {
     "papermill": {
-     "duration": 0.052469,
-     "end_time": "2026-06-04T06:26:22.501921",
+     "duration": 0.044182,
+     "end_time": "2026-06-22T19:15:14.030627",
      "exception": false,
-     "start_time": "2026-06-04T06:26:22.449452",
+     "start_time": "2026-06-22T19:15:13.986445",
      "status": "completed"
     },
     "tags": []
@@ -7796,16 +8282,16 @@
    "id": "gm-bic-exercise-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:22.595351Z",
-     "iopub.status.busy": "2026-06-04T06:26:22.594996Z",
-     "iopub.status.idle": "2026-06-04T06:26:22.629732Z",
-     "shell.execute_reply": "2026-06-04T06:26:22.629534Z"
+     "iopub.execute_input": "2026-06-22T19:15:14.111220Z",
+     "iopub.status.busy": "2026-06-22T19:15:14.111220Z",
+     "iopub.status.idle": "2026-06-22T19:15:14.137632Z",
+     "shell.execute_reply": "2026-06-22T19:15:14.137632Z"
     },
     "papermill": {
-     "duration": 0.081659,
-     "end_time": "2026-06-04T06:26:22.629831",
+     "duration": 0.067863,
+     "end_time": "2026-06-22T19:15:14.137632",
      "exception": false,
-     "start_time": "2026-06-04T06:26:22.548172",
+     "start_time": "2026-06-22T19:15:14.069769",
      "status": "completed"
     },
     "tags": []
@@ -7849,10 +8335,10 @@
    "id": "761280ee",
    "metadata": {
     "papermill": {
-     "duration": 0.044457,
-     "end_time": "2026-06-04T06:26:22.720181",
+     "duration": 0.041422,
+     "end_time": "2026-06-22T19:15:14.226288",
      "exception": false,
-     "start_time": "2026-06-04T06:26:22.675724",
+     "start_time": "2026-06-22T19:15:14.184866",
      "status": "completed"
     },
     "tags": []
@@ -7883,18 +8369,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 23.028147,
-   "end_time": "2026-06-04T06:26:23.115158",
+   "duration": 18.877591,
+   "end_time": "2026-06-22T19:15:14.500829",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-2-Gaussian-Mixtures.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-2-Gaussian-Mixtures.ipynb",
+   "input_path": "Infer-2-Gaussian-Mixtures.ipynb",
+   "output_path": "Infer-2-Gaussian-Mixtures.ipynb",
    "parameters": {},
-   "start_time": "2026-06-04T06:26:00.087011",
+   "start_time": "2026-06-22T19:14:55.623238",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
@@ -5,10 +5,10 @@
    "id": "ab0e007e",
    "metadata": {
     "papermill": {
-     "duration": 0.008514,
-     "end_time": "2026-06-04T06:26:27.678515",
+     "duration": 0.004001,
+     "end_time": "2026-06-22T19:15:18.507470",
      "exception": false,
-     "start_time": "2026-06-04T06:26:27.670001",
+     "start_time": "2026-06-22T19:15:18.503469",
      "status": "completed"
     },
     "tags": []
@@ -46,10 +46,10 @@
    "id": "77cadd70",
    "metadata": {
     "papermill": {
-     "duration": 0.00793,
-     "end_time": "2026-06-04T06:26:27.696243",
+     "duration": 0.003991,
+     "end_time": "2026-06-22T19:15:18.515469",
      "exception": false,
-     "start_time": "2026-06-04T06:26:27.688313",
+     "start_time": "2026-06-22T19:15:18.511478",
      "status": "completed"
     },
     "tags": []
@@ -69,16 +69,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:39.669034Z",
-     "iopub.status.busy": "2026-06-19T14:50:39.665079Z",
-     "iopub.status.idle": "2026-06-19T14:50:42.967267Z",
-     "shell.execute_reply": "2026-06-19T14:50:42.963784Z"
+     "iopub.execute_input": "2026-06-22T19:15:18.528706Z",
+     "iopub.status.busy": "2026-06-22T19:15:18.524705Z",
+     "iopub.status.idle": "2026-06-22T19:15:21.151227Z",
+     "shell.execute_reply": "2026-06-22T19:15:21.148203Z"
     },
     "papermill": {
-     "duration": 3.20373,
-     "end_time": "2026-06-04T06:26:30.907604",
+     "duration": 2.632755,
+     "end_time": "2026-06-22T19:15:21.152227",
      "exception": false,
-     "start_time": "2026-06-04T06:26:27.703874",
+     "start_time": "2026-06-22T19:15:18.519472",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -95,7 +95,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-61536.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-86324.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -140,12 +140,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.14:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '61536.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '86324.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -242,10 +242,10 @@
    "id": "miyi1of7ve",
    "metadata": {
     "papermill": {
-     "duration": 0.008842,
-     "end_time": "2026-06-04T06:26:30.924909",
+     "duration": 0.007217,
+     "end_time": "2026-06-22T19:15:21.166843",
      "exception": false,
-     "start_time": "2026-06-04T06:26:30.916067",
+     "start_time": "2026-06-22T19:15:21.159626",
      "status": "completed"
     },
     "tags": []
@@ -263,10 +263,10 @@
    "id": "zmmn3n4q3i9",
    "metadata": {
     "papermill": {
-     "duration": 0.016235,
-     "end_time": "2026-06-04T06:26:30.949695",
+     "duration": 0.01072,
+     "end_time": "2026-06-22T19:15:21.185474",
      "exception": false,
-     "start_time": "2026-06-04T06:26:30.933460",
+     "start_time": "2026-06-22T19:15:21.174754",
      "status": "completed"
     },
     "tags": []
@@ -287,19 +287,19 @@
    "id": "mggh80ifx4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:42.969560Z",
-     "iopub.status.busy": "2026-06-19T14:50:42.969193Z",
-     "iopub.status.idle": "2026-06-19T14:50:43.662159Z",
-     "shell.execute_reply": "2026-06-19T14:50:43.661896Z"
+     "iopub.execute_input": "2026-06-22T19:15:21.208479Z",
+     "iopub.status.busy": "2026-06-22T19:15:21.208479Z",
+     "iopub.status.idle": "2026-06-22T19:15:21.935128Z",
+     "shell.execute_reply": "2026-06-22T19:15:21.935128Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.625153,
-     "end_time": "2026-06-04T06:26:31.598813",
+     "duration": 0.737652,
+     "end_time": "2026-06-22T19:15:21.935128",
      "exception": false,
-     "start_time": "2026-06-04T06:26:30.973660",
+     "start_time": "2026-06-22T19:15:21.197476",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -347,10 +347,10 @@
    "id": "b6d11f9e",
    "metadata": {
     "papermill": {
-     "duration": 0.016034,
-     "end_time": "2026-06-04T06:26:31.629760",
+     "duration": 0.007999,
+     "end_time": "2026-06-22T19:15:21.951133",
      "exception": false,
-     "start_time": "2026-06-04T06:26:31.613726",
+     "start_time": "2026-06-22T19:15:21.943134",
      "status": "completed"
     },
     "tags": []
@@ -392,10 +392,10 @@
    "id": "19e37cea",
    "metadata": {
     "papermill": {
-     "duration": 0.008985,
-     "end_time": "2026-06-04T06:26:31.651441",
+     "duration": 0.007648,
+     "end_time": "2026-06-22T19:15:21.965321",
      "exception": false,
-     "start_time": "2026-06-04T06:26:31.642456",
+     "start_time": "2026-06-22T19:15:21.957673",
      "status": "completed"
     },
     "tags": []
@@ -432,10 +432,10 @@
    "id": "aa782b66",
    "metadata": {
     "papermill": {
-     "duration": 0.007388,
-     "end_time": "2026-06-04T06:26:31.667016",
+     "duration": 0.00884,
+     "end_time": "2026-06-22T19:15:21.980163",
      "exception": false,
-     "start_time": "2026-06-04T06:26:31.659628",
+     "start_time": "2026-06-22T19:15:21.971323",
      "status": "completed"
     },
     "tags": []
@@ -462,16 +462,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:43.664264Z",
-     "iopub.status.busy": "2026-06-19T14:50:43.663934Z",
-     "iopub.status.idle": "2026-06-19T14:50:45.693903Z",
-     "shell.execute_reply": "2026-06-19T14:50:45.693618Z"
+     "iopub.execute_input": "2026-06-22T19:15:21.997421Z",
+     "iopub.status.busy": "2026-06-22T19:15:21.997421Z",
+     "iopub.status.idle": "2026-06-22T19:15:23.522253Z",
+     "shell.execute_reply": "2026-06-22T19:15:23.522253Z"
     },
     "papermill": {
-     "duration": 2.190186,
-     "end_time": "2026-06-04T06:26:33.864861",
+     "duration": 1.534182,
+     "end_time": "2026-06-22T19:15:23.522253",
      "exception": false,
-     "start_time": "2026-06-04T06:26:31.674675",
+     "start_time": "2026-06-22T19:15:21.988071",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -540,10 +540,10 @@
    "id": "gmwk6d9jwa8",
    "metadata": {
     "papermill": {
-     "duration": 0.012901,
-     "end_time": "2026-06-04T06:26:33.888668",
+     "duration": 0.00901,
+     "end_time": "2026-06-22T19:15:23.539297",
      "exception": false,
-     "start_time": "2026-06-04T06:26:33.875767",
+     "start_time": "2026-06-22T19:15:23.530287",
      "status": "completed"
     },
     "tags": []
@@ -561,10 +561,10 @@
    "id": "a6107f94",
    "metadata": {
     "papermill": {
-     "duration": 0.010638,
-     "end_time": "2026-06-04T06:26:33.909603",
+     "duration": 0.008614,
+     "end_time": "2026-06-22T19:15:23.555910",
      "exception": false,
-     "start_time": "2026-06-04T06:26:33.898965",
+     "start_time": "2026-06-22T19:15:23.547296",
      "status": "completed"
     },
     "tags": []
@@ -594,16 +594,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:45.696256Z",
-     "iopub.status.busy": "2026-06-19T14:50:45.695918Z",
-     "iopub.status.idle": "2026-06-19T14:50:46.662902Z",
-     "shell.execute_reply": "2026-06-19T14:50:46.662488Z"
+     "iopub.execute_input": "2026-06-22T19:15:23.574695Z",
+     "iopub.status.busy": "2026-06-22T19:15:23.574695Z",
+     "iopub.status.idle": "2026-06-22T19:15:24.011746Z",
+     "shell.execute_reply": "2026-06-22T19:15:24.011746Z"
     },
     "papermill": {
-     "duration": 0.551782,
-     "end_time": "2026-06-04T06:26:34.473565",
+     "duration": 0.447836,
+     "end_time": "2026-06-22T19:15:24.011746",
      "exception": false,
-     "start_time": "2026-06-04T06:26:33.921783",
+     "start_time": "2026-06-22T19:15:23.563910",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -688,10 +688,10 @@
    "id": "135cee1f",
    "metadata": {
     "papermill": {
-     "duration": 0.009974,
-     "end_time": "2026-06-04T06:26:34.492441",
+     "duration": 0.008001,
+     "end_time": "2026-06-22T19:15:24.028315",
      "exception": false,
-     "start_time": "2026-06-04T06:26:34.482467",
+     "start_time": "2026-06-22T19:15:24.020314",
      "status": "completed"
     },
     "tags": []
@@ -718,10 +718,10 @@
    "id": "5d113cd7",
    "metadata": {
     "papermill": {
-     "duration": 0.008919,
-     "end_time": "2026-06-04T06:26:34.510136",
+     "duration": 0.009002,
+     "end_time": "2026-06-22T19:15:24.045316",
      "exception": false,
-     "start_time": "2026-06-04T06:26:34.501217",
+     "start_time": "2026-06-22T19:15:24.036314",
      "status": "completed"
     },
     "tags": []
@@ -752,16 +752,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:46.665401Z",
-     "iopub.status.busy": "2026-06-19T14:50:46.665052Z",
-     "iopub.status.idle": "2026-06-19T14:50:47.424755Z",
-     "shell.execute_reply": "2026-06-19T14:50:47.424525Z"
+     "iopub.execute_input": "2026-06-22T19:15:24.061824Z",
+     "iopub.status.busy": "2026-06-22T19:15:24.060319Z",
+     "iopub.status.idle": "2026-06-22T19:15:24.433070Z",
+     "shell.execute_reply": "2026-06-22T19:15:24.433070Z"
     },
     "papermill": {
-     "duration": 0.489619,
-     "end_time": "2026-06-04T06:26:35.008570",
+     "duration": 0.382191,
+     "end_time": "2026-06-22T19:15:24.434511",
      "exception": false,
-     "start_time": "2026-06-04T06:26:34.518951",
+     "start_time": "2026-06-22T19:15:24.052320",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -858,10 +858,10 @@
    "id": "e2ab7aa6",
    "metadata": {
     "papermill": {
-     "duration": 0.009766,
-     "end_time": "2026-06-04T06:26:35.026926",
+     "duration": 0.010019,
+     "end_time": "2026-06-22T19:15:24.453660",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.017160",
+     "start_time": "2026-06-22T19:15:24.443641",
      "status": "completed"
     },
     "tags": []
@@ -890,10 +890,10 @@
    "id": "z0rfo6ik1qh",
    "metadata": {
     "papermill": {
-     "duration": 0.008524,
-     "end_time": "2026-06-04T06:26:35.044666",
+     "duration": 0.009502,
+     "end_time": "2026-06-22T19:15:24.473219",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.036142",
+     "start_time": "2026-06-22T19:15:24.463717",
      "status": "completed"
     },
     "tags": []
@@ -914,19 +914,19 @@
    "id": "8ilype0hrh",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:47.426996Z",
-     "iopub.status.busy": "2026-06-19T14:50:47.426637Z",
-     "iopub.status.idle": "2026-06-19T14:50:48.268133Z",
-     "shell.execute_reply": "2026-06-19T14:50:48.267875Z"
+     "iopub.execute_input": "2026-06-22T19:15:24.493706Z",
+     "iopub.status.busy": "2026-06-22T19:15:24.493182Z",
+     "iopub.status.idle": "2026-06-22T19:15:25.125411Z",
+     "shell.execute_reply": "2026-06-22T19:15:25.125411Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.554591,
-     "end_time": "2026-06-04T06:26:35.610352",
+     "duration": 0.642783,
+     "end_time": "2026-06-22T19:15:25.125411",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.055761",
+     "start_time": "2026-06-22T19:15:24.482628",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -938,38 +938,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_16_50_47_52.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -994,14 +962,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_16_50_47_52.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_24_60.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"398pt\" height=\"289pt\"\r\n",
@@ -1168,8 +1136,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1181,7 +1149,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1224,10 +1192,10 @@
    "id": "o8zd7hkzsi8",
    "metadata": {
     "papermill": {
-     "duration": 0.010826,
-     "end_time": "2026-06-04T06:26:35.633477",
+     "duration": 0.008386,
+     "end_time": "2026-06-22T19:15:25.143352",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.622651",
+     "start_time": "2026-06-22T19:15:25.134966",
      "status": "completed"
     },
     "tags": []
@@ -1251,10 +1219,10 @@
    "id": "8d35d4a7",
    "metadata": {
     "papermill": {
-     "duration": 0.008927,
-     "end_time": "2026-06-04T06:26:35.652898",
+     "duration": 0.008767,
+     "end_time": "2026-06-22T19:15:25.160119",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.643971",
+     "start_time": "2026-06-22T19:15:25.151352",
      "status": "completed"
     },
     "tags": []
@@ -1284,16 +1252,16 @@
    "id": "c60f625c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:48.270056Z",
-     "iopub.status.busy": "2026-06-19T14:50:48.269715Z",
-     "iopub.status.idle": "2026-06-19T14:50:48.311896Z",
-     "shell.execute_reply": "2026-06-19T14:50:48.311601Z"
+     "iopub.execute_input": "2026-06-22T19:15:25.179225Z",
+     "iopub.status.busy": "2026-06-22T19:15:25.179225Z",
+     "iopub.status.idle": "2026-06-22T19:15:25.214025Z",
+     "shell.execute_reply": "2026-06-22T19:15:25.214025Z"
     },
     "papermill": {
-     "duration": 0.053989,
-     "end_time": "2026-06-04T06:26:35.717101",
+     "duration": 0.046135,
+     "end_time": "2026-06-22T19:15:25.214025",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.663112",
+     "start_time": "2026-06-22T19:15:25.167890",
      "status": "completed"
     },
     "tags": []
@@ -1330,10 +1298,10 @@
    "id": "fc9fc7cc",
    "metadata": {
     "papermill": {
-     "duration": 0.016658,
-     "end_time": "2026-06-04T06:26:35.751153",
+     "duration": 0.008,
+     "end_time": "2026-06-22T19:15:25.228675",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.734495",
+     "start_time": "2026-06-22T19:15:25.220675",
      "status": "completed"
     },
     "tags": []
@@ -1362,10 +1330,10 @@
    "id": "p3vib2dlpld",
    "metadata": {
     "papermill": {
-     "duration": 0.010645,
-     "end_time": "2026-06-04T06:26:35.778899",
+     "duration": 0.007641,
+     "end_time": "2026-06-22T19:15:25.245320",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.768254",
+     "start_time": "2026-06-22T19:15:25.237679",
      "status": "completed"
     },
     "tags": []
@@ -1396,16 +1364,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:48.313847Z",
-     "iopub.status.busy": "2026-06-19T14:50:48.313506Z",
-     "iopub.status.idle": "2026-06-19T14:50:48.408040Z",
-     "shell.execute_reply": "2026-06-19T14:50:48.407521Z"
+     "iopub.execute_input": "2026-06-22T19:15:25.263977Z",
+     "iopub.status.busy": "2026-06-22T19:15:25.263977Z",
+     "iopub.status.idle": "2026-06-22T19:15:25.344488Z",
+     "shell.execute_reply": "2026-06-22T19:15:25.343969Z"
     },
     "papermill": {
-     "duration": 0.113378,
-     "end_time": "2026-06-04T06:26:35.903309",
+     "duration": 0.090168,
+     "end_time": "2026-06-22T19:15:25.344488",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.789931",
+     "start_time": "2026-06-22T19:15:25.254320",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1503,10 +1471,10 @@
    "id": "q0x6quick6h",
    "metadata": {
     "papermill": {
-     "duration": 0.010628,
-     "end_time": "2026-06-04T06:26:35.924393",
+     "duration": 0.009455,
+     "end_time": "2026-06-22T19:15:25.362680",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.913765",
+     "start_time": "2026-06-22T19:15:25.353225",
      "status": "completed"
     },
     "tags": []
@@ -1529,10 +1497,10 @@
    "id": "ipzo7eq8pj8",
    "metadata": {
     "papermill": {
-     "duration": 0.011046,
-     "end_time": "2026-06-04T06:26:35.945752",
+     "duration": 0.009859,
+     "end_time": "2026-06-22T19:15:25.381680",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.934706",
+     "start_time": "2026-06-22T19:15:25.371821",
      "status": "completed"
     },
     "tags": []
@@ -1556,16 +1524,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:48.410178Z",
-     "iopub.status.busy": "2026-06-19T14:50:48.409826Z",
-     "iopub.status.idle": "2026-06-19T14:50:48.953536Z",
-     "shell.execute_reply": "2026-06-19T14:50:48.953017Z"
+     "iopub.execute_input": "2026-06-22T19:15:25.401486Z",
+     "iopub.status.busy": "2026-06-22T19:15:25.401486Z",
+     "iopub.status.idle": "2026-06-22T19:15:25.853681Z",
+     "shell.execute_reply": "2026-06-22T19:15:25.853166Z"
     },
     "papermill": {
-     "duration": 0.553024,
-     "end_time": "2026-06-04T06:26:36.508479",
+     "duration": 0.462579,
+     "end_time": "2026-06-22T19:15:25.853681",
      "exception": false,
-     "start_time": "2026-06-04T06:26:35.955455",
+     "start_time": "2026-06-22T19:15:25.391102",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1685,10 +1653,10 @@
    "id": "sr06732og7",
    "metadata": {
     "papermill": {
-     "duration": 0.011058,
-     "end_time": "2026-06-04T06:26:36.530147",
+     "duration": 0.009502,
+     "end_time": "2026-06-22T19:15:25.873258",
      "exception": false,
-     "start_time": "2026-06-04T06:26:36.519089",
+     "start_time": "2026-06-22T19:15:25.863756",
      "status": "completed"
     },
     "tags": []
@@ -1712,10 +1680,10 @@
    "id": "hxlk3pl71mn",
    "metadata": {
     "papermill": {
-     "duration": 0.01177,
-     "end_time": "2026-06-04T06:26:36.553153",
+     "duration": 0.008997,
+     "end_time": "2026-06-22T19:15:25.893109",
      "exception": false,
-     "start_time": "2026-06-04T06:26:36.541383",
+     "start_time": "2026-06-22T19:15:25.884112",
      "status": "completed"
     },
     "tags": []
@@ -1739,19 +1707,19 @@
    "id": "tewfv8dwn9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:48.955640Z",
-     "iopub.status.busy": "2026-06-19T14:50:48.955324Z",
-     "iopub.status.idle": "2026-06-19T14:50:49.923635Z",
-     "shell.execute_reply": "2026-06-19T14:50:49.923857Z"
+     "iopub.execute_input": "2026-06-22T19:15:25.914624Z",
+     "iopub.status.busy": "2026-06-22T19:15:25.914624Z",
+     "iopub.status.idle": "2026-06-22T19:15:26.501098Z",
+     "shell.execute_reply": "2026-06-22T19:15:26.501098Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.487058,
-     "end_time": "2026-06-04T06:26:37.051903",
+     "duration": 0.596972,
+     "end_time": "2026-06-22T19:15:26.501098",
      "exception": false,
-     "start_time": "2026-06-04T06:26:36.564845",
+     "start_time": "2026-06-22T19:15:25.904126",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1763,38 +1731,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_16_50_49_02.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1826,14 +1762,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_16_50_49_02.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_25_98.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"890pt\" height=\"371pt\"\r\n",
@@ -2188,8 +2124,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2201,7 +2137,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -2254,10 +2190,10 @@
    "id": "4dda0635",
    "metadata": {
     "papermill": {
-     "duration": 0.016961,
-     "end_time": "2026-06-04T06:26:37.079564",
+     "duration": 0.010364,
+     "end_time": "2026-06-22T19:15:26.521465",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.062603",
+     "start_time": "2026-06-22T19:15:26.511101",
      "status": "completed"
     },
     "tags": []
@@ -2278,10 +2214,10 @@
    "id": "279b4b47",
    "metadata": {
     "papermill": {
-     "duration": 0.016148,
-     "end_time": "2026-06-04T06:26:37.108416",
+     "duration": 0.011686,
+     "end_time": "2026-06-22T19:15:26.542878",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.092268",
+     "start_time": "2026-06-22T19:15:26.531192",
      "status": "completed"
     },
     "tags": []
@@ -2317,16 +2253,16 @@
    "id": "136335b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:49.926292Z",
-     "iopub.status.busy": "2026-06-19T14:50:49.925834Z",
-     "iopub.status.idle": "2026-06-19T14:50:49.973280Z",
-     "shell.execute_reply": "2026-06-19T14:50:49.972933Z"
+     "iopub.execute_input": "2026-06-22T19:15:26.564195Z",
+     "iopub.status.busy": "2026-06-22T19:15:26.564195Z",
+     "iopub.status.idle": "2026-06-22T19:15:26.603278Z",
+     "shell.execute_reply": "2026-06-22T19:15:26.603278Z"
     },
     "papermill": {
-     "duration": 0.076863,
-     "end_time": "2026-06-04T06:26:37.199396",
+     "duration": 0.050152,
+     "end_time": "2026-06-22T19:15:26.603278",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.122533",
+     "start_time": "2026-06-22T19:15:26.553126",
      "status": "completed"
     },
     "tags": []
@@ -2362,10 +2298,10 @@
    "id": "1cqd0a1aivti",
    "metadata": {
     "papermill": {
-     "duration": 0.036759,
-     "end_time": "2026-06-04T06:26:37.247807",
+     "duration": 0.010249,
+     "end_time": "2026-06-22T19:15:26.624504",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.211048",
+     "start_time": "2026-06-22T19:15:26.614255",
      "status": "completed"
     },
     "tags": []
@@ -2391,10 +2327,10 @@
    "id": "49bb3283",
    "metadata": {
     "papermill": {
-     "duration": 0.015558,
-     "end_time": "2026-06-04T06:26:37.283870",
+     "duration": 0.009634,
+     "end_time": "2026-06-22T19:15:26.644334",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.268312",
+     "start_time": "2026-06-22T19:15:26.634700",
      "status": "completed"
     },
     "tags": []
@@ -2422,10 +2358,10 @@
    "id": "pfxz051sfd",
    "metadata": {
     "papermill": {
-     "duration": 0.012334,
-     "end_time": "2026-06-04T06:26:37.308510",
+     "duration": 0.009819,
+     "end_time": "2026-06-22T19:15:26.665112",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.296176",
+     "start_time": "2026-06-22T19:15:26.655293",
      "status": "completed"
     },
     "tags": []
@@ -2445,16 +2381,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:49.976034Z",
-     "iopub.status.busy": "2026-06-19T14:50:49.975645Z",
-     "iopub.status.idle": "2026-06-19T14:50:50.022182Z",
-     "shell.execute_reply": "2026-06-19T14:50:50.021820Z"
+     "iopub.execute_input": "2026-06-22T19:15:26.686571Z",
+     "iopub.status.busy": "2026-06-22T19:15:26.686571Z",
+     "iopub.status.idle": "2026-06-22T19:15:26.733356Z",
+     "shell.execute_reply": "2026-06-22T19:15:26.733356Z"
     },
     "papermill": {
-     "duration": 0.068589,
-     "end_time": "2026-06-04T06:26:37.388964",
+     "duration": 0.058609,
+     "end_time": "2026-06-22T19:15:26.733356",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.320375",
+     "start_time": "2026-06-22T19:15:26.674747",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2522,10 +2458,10 @@
    "id": "2egjynj0qhj",
    "metadata": {
     "papermill": {
-     "duration": 0.011267,
-     "end_time": "2026-06-04T06:26:37.411373",
+     "duration": 0.012132,
+     "end_time": "2026-06-22T19:15:26.760284",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.400106",
+     "start_time": "2026-06-22T19:15:26.748152",
      "status": "completed"
     },
     "tags": []
@@ -2546,10 +2482,10 @@
    "id": "388daa33",
    "metadata": {
     "papermill": {
-     "duration": 0.017691,
-     "end_time": "2026-06-04T06:26:37.440550",
+     "duration": 0.01157,
+     "end_time": "2026-06-22T19:15:26.783515",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.422859",
+     "start_time": "2026-06-22T19:15:26.771945",
      "status": "completed"
     },
     "tags": []
@@ -2590,10 +2526,10 @@
    "id": "0d6d0ba2",
    "metadata": {
     "papermill": {
-     "duration": 0.01412,
-     "end_time": "2026-06-04T06:26:37.475419",
+     "duration": 0.011426,
+     "end_time": "2026-06-22T19:15:26.805584",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.461299",
+     "start_time": "2026-06-22T19:15:26.794158",
      "status": "completed"
     },
     "tags": []
@@ -2623,10 +2559,10 @@
    "id": "679egvvkri8",
    "metadata": {
     "papermill": {
-     "duration": 0.012451,
-     "end_time": "2026-06-04T06:26:37.501662",
+     "duration": 0.011004,
+     "end_time": "2026-06-22T19:15:26.826495",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.489211",
+     "start_time": "2026-06-22T19:15:26.815491",
      "status": "completed"
     },
     "tags": []
@@ -2655,16 +2591,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:50.024541Z",
-     "iopub.status.busy": "2026-06-19T14:50:50.024217Z",
-     "iopub.status.idle": "2026-06-19T14:50:50.411359Z",
-     "shell.execute_reply": "2026-06-19T14:50:50.411033Z"
+     "iopub.execute_input": "2026-06-22T19:15:26.850102Z",
+     "iopub.status.busy": "2026-06-22T19:15:26.850102Z",
+     "iopub.status.idle": "2026-06-22T19:15:27.184364Z",
+     "shell.execute_reply": "2026-06-22T19:15:27.184364Z"
     },
     "papermill": {
-     "duration": 0.43443,
-     "end_time": "2026-06-04T06:26:37.950270",
+     "duration": 0.347182,
+     "end_time": "2026-06-22T19:15:27.184364",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.515840",
+     "start_time": "2026-06-22T19:15:26.837182",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2779,10 +2715,10 @@
    "id": "pxy35droao",
    "metadata": {
     "papermill": {
-     "duration": 0.012577,
-     "end_time": "2026-06-04T06:26:37.979364",
+     "duration": 0.009925,
+     "end_time": "2026-06-22T19:15:27.205759",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.966787",
+     "start_time": "2026-06-22T19:15:27.195834",
      "status": "completed"
     },
     "tags": []
@@ -2812,10 +2748,10 @@
    "id": "sb08nqbu2xo",
    "metadata": {
     "papermill": {
-     "duration": 0.012826,
-     "end_time": "2026-06-04T06:26:38.003682",
+     "duration": 0.01055,
+     "end_time": "2026-06-22T19:15:27.226343",
      "exception": false,
-     "start_time": "2026-06-04T06:26:37.990856",
+     "start_time": "2026-06-22T19:15:27.215793",
      "status": "completed"
     },
     "tags": []
@@ -2840,10 +2776,10 @@
    "id": "xkce0tbg37k",
    "metadata": {
     "papermill": {
-     "duration": 0.018051,
-     "end_time": "2026-06-04T06:26:38.051057",
+     "duration": 0.010557,
+     "end_time": "2026-06-22T19:15:27.247220",
      "exception": false,
-     "start_time": "2026-06-04T06:26:38.033006",
+     "start_time": "2026-06-22T19:15:27.236663",
      "status": "completed"
     },
     "tags": []
@@ -2878,10 +2814,10 @@
    "id": "6766b0f9",
    "metadata": {
     "papermill": {
-     "duration": 0.0126,
-     "end_time": "2026-06-04T06:26:38.077701",
+     "duration": 0.009811,
+     "end_time": "2026-06-22T19:15:27.267541",
      "exception": false,
-     "start_time": "2026-06-04T06:26:38.065101",
+     "start_time": "2026-06-22T19:15:27.257730",
      "status": "completed"
     },
     "tags": []
@@ -2915,10 +2851,10 @@
    "id": "gyakzydsv4",
    "metadata": {
     "papermill": {
-     "duration": 0.010535,
-     "end_time": "2026-06-04T06:26:38.100048",
+     "duration": 0.010184,
+     "end_time": "2026-06-22T19:15:27.289473",
      "exception": false,
-     "start_time": "2026-06-04T06:26:38.089513",
+     "start_time": "2026-06-22T19:15:27.279289",
      "status": "completed"
     },
     "tags": []
@@ -2951,10 +2887,10 @@
    "id": "1cab470c",
    "metadata": {
     "papermill": {
-     "duration": 0.011394,
-     "end_time": "2026-06-04T06:26:38.122976",
+     "duration": 0.010269,
+     "end_time": "2026-06-22T19:15:27.309579",
      "exception": false,
-     "start_time": "2026-06-04T06:26:38.111582",
+     "start_time": "2026-06-22T19:15:27.299310",
      "status": "completed"
     },
     "tags": []
@@ -2983,19 +2919,19 @@
    "id": "8b8b23f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T14:50:50.413805Z",
-     "iopub.status.busy": "2026-06-19T14:50:50.413441Z",
-     "iopub.status.idle": "2026-06-19T14:50:50.458586Z",
-     "shell.execute_reply": "2026-06-19T14:50:50.458091Z"
+     "iopub.execute_input": "2026-06-22T19:15:27.332859Z",
+     "iopub.status.busy": "2026-06-22T19:15:27.332341Z",
+     "iopub.status.idle": "2026-06-22T19:15:27.374270Z",
+     "shell.execute_reply": "2026-06-22T19:15:27.374270Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.07007,
-     "end_time": "2026-06-04T06:26:38.205311",
+     "duration": 0.053595,
+     "end_time": "2026-06-22T19:15:27.374270",
      "exception": false,
-     "start_time": "2026-06-04T06:26:38.135241",
+     "start_time": "2026-06-22T19:15:27.320675",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3040,10 +2976,10 @@
    "id": "9875d7fb",
    "metadata": {
     "papermill": {
-     "duration": 0.011785,
-     "end_time": "2026-06-04T06:26:38.230270",
+     "duration": 0.011,
+     "end_time": "2026-06-22T19:15:27.395787",
      "exception": false,
-     "start_time": "2026-06-04T06:26:38.218485",
+     "start_time": "2026-06-22T19:15:27.384787",
      "status": "completed"
     },
     "tags": []
@@ -3082,18 +3018,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 13.064803,
-   "end_time": "2026-06-04T06:26:38.476768",
+   "duration": 10.74214,
+   "end_time": "2026-06-22T19:15:27.642825",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-3-Factor-Graphs.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-3-Factor-Graphs.ipynb",
+   "input_path": "Infer-3-Factor-Graphs.ipynb",
+   "output_path": "Infer-3-Factor-Graphs.ipynb",
    "parameters": {},
-   "start_time": "2026-06-04T06:26:25.411965",
+   "start_time": "2026-06-22T19:15:16.900685",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
@@ -5,10 +5,10 @@
    "id": "628e4ed2",
    "metadata": {
     "papermill": {
-     "duration": 0.024565,
-     "end_time": "2026-06-04T06:26:43.165354",
+     "duration": 0.005805,
+     "end_time": "2026-06-22T19:15:31.458348",
      "exception": false,
-     "start_time": "2026-06-04T06:26:43.140789",
+     "start_time": "2026-06-22T19:15:31.452543",
      "status": "completed"
     },
     "tags": []
@@ -46,10 +46,10 @@
    "id": "58b363a7",
    "metadata": {
     "papermill": {
-     "duration": 0.01018,
-     "end_time": "2026-06-04T06:26:43.185657",
+     "duration": 0.004642,
+     "end_time": "2026-06-22T19:15:31.467636",
      "exception": false,
-     "start_time": "2026-06-04T06:26:43.175477",
+     "start_time": "2026-06-22T19:15:31.462994",
      "status": "completed"
     },
     "tags": []
@@ -69,16 +69,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:43.214635Z",
-     "iopub.status.busy": "2026-06-04T06:26:43.210106Z",
-     "iopub.status.idle": "2026-06-04T06:26:46.528776Z",
-     "shell.execute_reply": "2026-06-04T06:26:46.524454Z"
+     "iopub.execute_input": "2026-06-22T19:15:31.483716Z",
+     "iopub.status.busy": "2026-06-22T19:15:31.479567Z",
+     "iopub.status.idle": "2026-06-22T19:15:34.062358Z",
+     "shell.execute_reply": "2026-06-22T19:15:34.060361Z"
     },
     "papermill": {
-     "duration": 3.333473,
-     "end_time": "2026-06-04T06:26:46.528969",
+     "duration": 2.590036,
+     "end_time": "2026-06-22T19:15:34.062358",
      "exception": false,
-     "start_time": "2026-06-04T06:26:43.195496",
+     "start_time": "2026-06-22T19:15:31.472322",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -95,7 +95,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-18588.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-93292.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -140,12 +140,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.14:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '18588.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '93292.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -242,10 +242,10 @@
    "id": "fa28e118",
    "metadata": {
     "papermill": {
-     "duration": 0.011495,
-     "end_time": "2026-06-04T06:26:46.552017",
+     "duration": 0.008509,
+     "end_time": "2026-06-22T19:15:34.083872",
      "exception": false,
-     "start_time": "2026-06-04T06:26:46.540522",
+     "start_time": "2026-06-22T19:15:34.075363",
      "status": "completed"
     },
     "tags": []
@@ -260,19 +260,19 @@
    "id": "t0tfhjm619i",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:46.573728Z",
-     "iopub.status.busy": "2026-06-04T06:26:46.573432Z",
-     "iopub.status.idle": "2026-06-04T06:26:47.206985Z",
-     "shell.execute_reply": "2026-06-04T06:26:47.206765Z"
+     "iopub.execute_input": "2026-06-22T19:15:34.103565Z",
+     "iopub.status.busy": "2026-06-22T19:15:34.103565Z",
+     "iopub.status.idle": "2026-06-22T19:15:34.732819Z",
+     "shell.execute_reply": "2026-06-22T19:15:34.732819Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.645214,
-     "end_time": "2026-06-04T06:26:47.207097",
+     "duration": 0.639781,
+     "end_time": "2026-06-22T19:15:34.733345",
      "exception": false,
-     "start_time": "2026-06-04T06:26:46.561883",
+     "start_time": "2026-06-22T19:15:34.093564",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -304,10 +304,10 @@
    "id": "w0sp61i8kz",
    "metadata": {
     "papermill": {
-     "duration": 0.011491,
-     "end_time": "2026-06-04T06:26:47.228120",
+     "duration": 0.009413,
+     "end_time": "2026-06-22T19:15:34.752665",
      "exception": false,
-     "start_time": "2026-06-04T06:26:47.216629",
+     "start_time": "2026-06-22T19:15:34.743252",
      "status": "completed"
     },
     "tags": []
@@ -326,10 +326,10 @@
    "id": "34a6aa88",
    "metadata": {
     "papermill": {
-     "duration": 0.010365,
-     "end_time": "2026-06-04T06:26:47.248877",
+     "duration": 0.008886,
+     "end_time": "2026-06-22T19:15:34.770442",
      "exception": false,
-     "start_time": "2026-06-04T06:26:47.238512",
+     "start_time": "2026-06-22T19:15:34.761556",
      "status": "completed"
     },
     "tags": []
@@ -363,10 +363,10 @@
    "id": "10ad9e61",
    "metadata": {
     "papermill": {
-     "duration": 0.010773,
-     "end_time": "2026-06-04T06:26:47.269841",
+     "duration": 0.009572,
+     "end_time": "2026-06-22T19:15:34.788310",
      "exception": false,
-     "start_time": "2026-06-04T06:26:47.259068",
+     "start_time": "2026-06-22T19:15:34.778738",
      "status": "completed"
     },
     "tags": []
@@ -412,16 +412,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:47.293259Z",
-     "iopub.status.busy": "2026-06-04T06:26:47.292976Z",
-     "iopub.status.idle": "2026-06-04T06:26:47.564588Z",
-     "shell.execute_reply": "2026-06-04T06:26:47.563903Z"
+     "iopub.execute_input": "2026-06-22T19:15:34.808405Z",
+     "iopub.status.busy": "2026-06-22T19:15:34.808405Z",
+     "iopub.status.idle": "2026-06-22T19:15:34.986033Z",
+     "shell.execute_reply": "2026-06-22T19:15:34.986033Z"
     },
     "papermill": {
-     "duration": 0.285007,
-     "end_time": "2026-06-04T06:26:47.564891",
+     "duration": 0.188717,
+     "end_time": "2026-06-22T19:15:34.986033",
      "exception": false,
-     "start_time": "2026-06-04T06:26:47.279884",
+     "start_time": "2026-06-22T19:15:34.797316",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -509,10 +509,10 @@
    "id": "to2gkt8vl3o",
    "metadata": {
     "papermill": {
-     "duration": 0.010799,
-     "end_time": "2026-06-04T06:26:47.588497",
+     "duration": 0.016041,
+     "end_time": "2026-06-22T19:15:35.013039",
      "exception": false,
-     "start_time": "2026-06-04T06:26:47.577698",
+     "start_time": "2026-06-22T19:15:34.996998",
      "status": "completed"
     },
     "tags": []
@@ -541,10 +541,10 @@
    "id": "r7m35mp69q",
    "metadata": {
     "papermill": {
-     "duration": 0.01283,
-     "end_time": "2026-06-04T06:26:47.613188",
+     "duration": 0.008802,
+     "end_time": "2026-06-22T19:15:35.032173",
      "exception": false,
-     "start_time": "2026-06-04T06:26:47.600358",
+     "start_time": "2026-06-22T19:15:35.023371",
      "status": "completed"
     },
     "tags": []
@@ -568,16 +568,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:47.639216Z",
-     "iopub.status.busy": "2026-06-04T06:26:47.638817Z",
-     "iopub.status.idle": "2026-06-04T06:26:50.087713Z",
-     "shell.execute_reply": "2026-06-04T06:26:50.087464Z"
+     "iopub.execute_input": "2026-06-22T19:15:35.054680Z",
+     "iopub.status.busy": "2026-06-22T19:15:35.054680Z",
+     "iopub.status.idle": "2026-06-22T19:15:37.022730Z",
+     "shell.execute_reply": "2026-06-22T19:15:37.022219Z"
     },
     "papermill": {
-     "duration": 2.461889,
-     "end_time": "2026-06-04T06:26:50.087829",
+     "duration": 1.980536,
+     "end_time": "2026-06-22T19:15:37.022730",
      "exception": false,
-     "start_time": "2026-06-04T06:26:47.625940",
+     "start_time": "2026-06-22T19:15:35.042194",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -594,38 +594,6 @@
      "output_type": "stream",
      "text": [
       "=== Probabilites marginales (sans observation) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_47_50_90.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -689,10 +657,10 @@
    "id": "6e3b285d",
    "metadata": {
     "papermill": {
-     "duration": 0.010189,
-     "end_time": "2026-06-04T06:26:50.108919",
+     "duration": 0.009695,
+     "end_time": "2026-06-22T19:15:37.042623",
      "exception": false,
-     "start_time": "2026-06-04T06:26:50.098730",
+     "start_time": "2026-06-22T19:15:37.032928",
      "status": "completed"
     },
     "tags": []
@@ -707,19 +675,19 @@
    "id": "spax5m0vwt",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:50.134769Z",
-     "iopub.status.busy": "2026-06-04T06:26:50.134430Z",
-     "iopub.status.idle": "2026-06-04T06:26:50.250620Z",
-     "shell.execute_reply": "2026-06-04T06:26:50.250839Z"
+     "iopub.execute_input": "2026-06-22T19:15:37.062130Z",
+     "iopub.status.busy": "2026-06-22T19:15:37.062130Z",
+     "iopub.status.idle": "2026-06-22T19:15:37.199610Z",
+     "shell.execute_reply": "2026-06-22T19:15:37.199083Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.131786,
-     "end_time": "2026-06-04T06:26:50.250981",
+     "duration": 0.148198,
+     "end_time": "2026-06-22T19:15:37.199610",
      "exception": false,
-     "start_time": "2026-06-04T06:26:50.119195",
+     "start_time": "2026-06-22T19:15:37.051412",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -734,14 +702,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_17_47_50_90.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_35_16.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"712pt\" height=\"371pt\"\r\n",
@@ -1028,8 +996,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1041,7 +1009,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1056,10 +1024,10 @@
    "id": "ffbsq502k3",
    "metadata": {
     "papermill": {
-     "duration": 0.013552,
-     "end_time": "2026-06-04T06:26:50.276189",
+     "duration": 0.00512,
+     "end_time": "2026-06-22T19:15:37.224597",
      "exception": false,
-     "start_time": "2026-06-04T06:26:50.262637",
+     "start_time": "2026-06-22T19:15:37.219477",
      "status": "completed"
     },
     "tags": []
@@ -1082,10 +1050,10 @@
    "id": "gablmpih1mj",
    "metadata": {
     "papermill": {
-     "duration": 0.011489,
-     "end_time": "2026-06-04T06:26:50.297865",
+     "duration": 0.005453,
+     "end_time": "2026-06-22T19:15:37.235050",
      "exception": false,
-     "start_time": "2026-06-04T06:26:50.286376",
+     "start_time": "2026-06-22T19:15:37.229597",
      "status": "completed"
     },
     "tags": []
@@ -1111,10 +1079,10 @@
    "id": "jz7rru063ho",
    "metadata": {
     "papermill": {
-     "duration": 0.013102,
-     "end_time": "2026-06-04T06:26:50.321992",
+     "duration": 0.030925,
+     "end_time": "2026-06-22T19:15:37.271968",
      "exception": false,
-     "start_time": "2026-06-04T06:26:50.308890",
+     "start_time": "2026-06-22T19:15:37.241043",
      "status": "completed"
     },
     "tags": []
@@ -1134,10 +1102,10 @@
    "id": "0b7d8e44",
    "metadata": {
     "papermill": {
-     "duration": 0.013501,
-     "end_time": "2026-06-04T06:26:50.365657",
+     "duration": 0.011346,
+     "end_time": "2026-06-22T19:15:37.300319",
      "exception": false,
-     "start_time": "2026-06-04T06:26:50.352156",
+     "start_time": "2026-06-22T19:15:37.288973",
      "status": "completed"
     },
     "tags": []
@@ -1155,16 +1123,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:50.392361Z",
-     "iopub.status.busy": "2026-06-04T06:26:50.391978Z",
-     "iopub.status.idle": "2026-06-04T06:26:51.397324Z",
-     "shell.execute_reply": "2026-06-04T06:26:51.368558Z"
+     "iopub.execute_input": "2026-06-22T19:15:37.330193Z",
+     "iopub.status.busy": "2026-06-22T19:15:37.329186Z",
+     "iopub.status.idle": "2026-06-22T19:15:38.171809Z",
+     "shell.execute_reply": "2026-06-22T19:15:38.149716Z"
     },
     "papermill": {
-     "duration": 1.02029,
-     "end_time": "2026-06-04T06:26:51.397432",
+     "duration": 0.853606,
+     "end_time": "2026-06-22T19:15:38.171809",
      "exception": false,
-     "start_time": "2026-06-04T06:26:50.377142",
+     "start_time": "2026-06-22T19:15:37.318203",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1181,38 +1149,6 @@
      "output_type": "stream",
      "text": [
       "=== Inference : P(X | WetGrass=True) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_47_54_27.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -2031,10 +1967,10 @@
    "id": "c6430838",
    "metadata": {
     "papermill": {
-     "duration": 0.017721,
-     "end_time": "2026-06-04T06:26:51.432720",
+     "duration": 0.016237,
+     "end_time": "2026-06-22T19:15:38.203179",
      "exception": false,
-     "start_time": "2026-06-04T06:26:51.414999",
+     "start_time": "2026-06-22T19:15:38.186942",
      "status": "completed"
     },
     "tags": []
@@ -2049,19 +1985,19 @@
    "id": "o776l3xh7tc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:51.467844Z",
-     "iopub.status.busy": "2026-06-04T06:26:51.467525Z",
-     "iopub.status.idle": "2026-06-04T06:26:51.524808Z",
-     "shell.execute_reply": "2026-06-04T06:26:51.525006Z"
+     "iopub.execute_input": "2026-06-22T19:15:38.241081Z",
+     "iopub.status.busy": "2026-06-22T19:15:38.241081Z",
+     "iopub.status.idle": "2026-06-22T19:15:38.355956Z",
+     "shell.execute_reply": "2026-06-22T19:15:38.355956Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.075193,
-     "end_time": "2026-06-04T06:26:51.525118",
+     "duration": 0.136684,
+     "end_time": "2026-06-22T19:15:38.355956",
      "exception": false,
-     "start_time": "2026-06-04T06:26:51.449925",
+     "start_time": "2026-06-22T19:15:38.219272",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2076,14 +2012,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_17_47_54_27.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_37_40.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"684pt\" height=\"371pt\"\r\n",
@@ -2370,8 +2306,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2383,7 +2319,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -2398,10 +2334,10 @@
    "id": "pqsv49ncqab",
    "metadata": {
     "papermill": {
-     "duration": 0.017436,
-     "end_time": "2026-06-04T06:26:51.558924",
+     "duration": 0.014507,
+     "end_time": "2026-06-22T19:15:38.386476",
      "exception": false,
-     "start_time": "2026-06-04T06:26:51.541488",
+     "start_time": "2026-06-22T19:15:38.371969",
      "status": "completed"
     },
     "tags": []
@@ -2420,10 +2356,10 @@
    "id": "zom6al00ws",
    "metadata": {
     "papermill": {
-     "duration": 0.016845,
-     "end_time": "2026-06-04T06:26:51.592520",
+     "duration": 0.015232,
+     "end_time": "2026-06-22T19:15:38.418494",
      "exception": false,
-     "start_time": "2026-06-04T06:26:51.575675",
+     "start_time": "2026-06-22T19:15:38.403262",
      "status": "completed"
     },
     "tags": []
@@ -2452,10 +2388,10 @@
    "id": "df755952",
    "metadata": {
     "papermill": {
-     "duration": 0.018317,
-     "end_time": "2026-06-04T06:26:51.628353",
+     "duration": 0.014994,
+     "end_time": "2026-06-22T19:15:38.448497",
      "exception": false,
-     "start_time": "2026-06-04T06:26:51.610036",
+     "start_time": "2026-06-22T19:15:38.433503",
      "status": "completed"
     },
     "tags": []
@@ -2474,23 +2410,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "66769df0",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:51.668933Z",
-     "iopub.status.busy": "2026-06-04T06:26:51.668561Z",
-     "iopub.status.idle": "2026-06-04T06:26:52.242019Z",
-     "shell.execute_reply": "2026-06-04T06:26:52.241629Z"
+     "iopub.execute_input": "2026-06-22T19:15:38.481508Z",
+     "iopub.status.busy": "2026-06-22T19:15:38.481508Z",
+     "iopub.status.idle": "2026-06-22T19:15:39.029807Z",
+     "shell.execute_reply": "2026-06-22T19:15:39.029807Z"
     },
     "papermill": {
-     "duration": 0.592027,
-     "end_time": "2026-06-04T06:26:52.242134",
+     "duration": 0.566304,
+     "end_time": "2026-06-22T19:15:39.029807",
      "exception": false,
-     "start_time": "2026-06-04T06:26:51.650107",
+     "start_time": "2026-06-22T19:15:38.463503",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2507,38 +2443,6 @@
      "output_type": "stream",
      "text": [
       "=== Explaining Away ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_47_55_68.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -2647,10 +2551,10 @@
    "id": "fe79e76c",
    "metadata": {
     "papermill": {
-     "duration": 0.019596,
-     "end_time": "2026-06-04T06:26:52.282267",
+     "duration": 0.017694,
+     "end_time": "2026-06-22T19:15:39.063641",
      "exception": false,
-     "start_time": "2026-06-04T06:26:52.262671",
+     "start_time": "2026-06-22T19:15:39.045947",
      "status": "completed"
     },
     "tags": []
@@ -2665,19 +2569,19 @@
    "id": "1a875bl3ljl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:52.321796Z",
-     "iopub.status.busy": "2026-06-04T06:26:52.321441Z",
-     "iopub.status.idle": "2026-06-04T06:26:52.382043Z",
-     "shell.execute_reply": "2026-06-04T06:26:52.381859Z"
+     "iopub.execute_input": "2026-06-22T19:15:39.097609Z",
+     "iopub.status.busy": "2026-06-22T19:15:39.097609Z",
+     "iopub.status.idle": "2026-06-22T19:15:39.208625Z",
+     "shell.execute_reply": "2026-06-22T19:15:39.208625Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.081135,
-     "end_time": "2026-06-04T06:26:52.382145",
+     "duration": 0.129473,
+     "end_time": "2026-06-22T19:15:39.208625",
      "exception": false,
-     "start_time": "2026-06-04T06:26:52.301010",
+     "start_time": "2026-06-22T19:15:39.079152",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2692,14 +2596,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_17_47_55_68.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_38_54.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"684pt\" height=\"371pt\"\r\n",
@@ -2986,8 +2890,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2999,7 +2903,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -3014,10 +2918,10 @@
    "id": "w0is6y503v",
    "metadata": {
     "papermill": {
-     "duration": 0.019058,
-     "end_time": "2026-06-04T06:26:52.420375",
+     "duration": 0.016035,
+     "end_time": "2026-06-22T19:15:39.241500",
      "exception": false,
-     "start_time": "2026-06-04T06:26:52.401317",
+     "start_time": "2026-06-22T19:15:39.225465",
      "status": "completed"
     },
     "tags": []
@@ -3039,10 +2943,10 @@
    "id": "bn50qzj6wv",
    "metadata": {
     "papermill": {
-     "duration": 0.029487,
-     "end_time": "2026-06-04T06:26:52.468447",
+     "duration": 0.016989,
+     "end_time": "2026-06-22T19:15:39.277560",
      "exception": false,
-     "start_time": "2026-06-04T06:26:52.438960",
+     "start_time": "2026-06-22T19:15:39.260571",
      "status": "completed"
     },
     "tags": []
@@ -3070,10 +2974,10 @@
    "id": "29bc2eb0",
    "metadata": {
     "papermill": {
-     "duration": 0.019802,
-     "end_time": "2026-06-04T06:26:52.517654",
+     "duration": 0.016852,
+     "end_time": "2026-06-22T19:15:39.311519",
      "exception": false,
-     "start_time": "2026-06-04T06:26:52.497852",
+     "start_time": "2026-06-22T19:15:39.294667",
      "status": "completed"
     },
     "tags": []
@@ -3115,16 +3019,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:52.556468Z",
-     "iopub.status.busy": "2026-06-04T06:26:52.556140Z",
-     "iopub.status.idle": "2026-06-04T06:26:52.951136Z",
-     "shell.execute_reply": "2026-06-04T06:26:52.950897Z"
+     "iopub.execute_input": "2026-06-22T19:15:39.343641Z",
+     "iopub.status.busy": "2026-06-22T19:15:39.343641Z",
+     "iopub.status.idle": "2026-06-22T19:15:39.722117Z",
+     "shell.execute_reply": "2026-06-22T19:15:39.722117Z"
     },
     "papermill": {
-     "duration": 0.414515,
-     "end_time": "2026-06-04T06:26:52.951255",
+     "duration": 0.394572,
+     "end_time": "2026-06-22T19:15:39.722117",
      "exception": false,
-     "start_time": "2026-06-04T06:26:52.536740",
+     "start_time": "2026-06-22T19:15:39.327545",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3216,10 +3120,10 @@
    "id": "j6jgoiplzhi",
    "metadata": {
     "papermill": {
-     "duration": 0.019041,
-     "end_time": "2026-06-04T06:26:52.987447",
+     "duration": 0.016991,
+     "end_time": "2026-06-22T19:15:39.755534",
      "exception": false,
-     "start_time": "2026-06-04T06:26:52.968406",
+     "start_time": "2026-06-22T19:15:39.738543",
      "status": "completed"
     },
     "tags": []
@@ -3247,10 +3151,10 @@
    "id": "je9xkz3uh8j",
    "metadata": {
     "papermill": {
-     "duration": 0.020321,
-     "end_time": "2026-06-04T06:26:53.035494",
+     "duration": 0.015649,
+     "end_time": "2026-06-22T19:15:39.789532",
      "exception": false,
-     "start_time": "2026-06-04T06:26:53.015173",
+     "start_time": "2026-06-22T19:15:39.773883",
      "status": "completed"
     },
     "tags": []
@@ -3269,19 +3173,19 @@
    "id": "vpa8u5ynn6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:53.072096Z",
-     "iopub.status.busy": "2026-06-04T06:26:53.071716Z",
-     "iopub.status.idle": "2026-06-04T06:26:53.388909Z",
-     "shell.execute_reply": "2026-06-04T06:26:53.388543Z"
+     "iopub.execute_input": "2026-06-22T19:15:39.822183Z",
+     "iopub.status.busy": "2026-06-22T19:15:39.822183Z",
+     "iopub.status.idle": "2026-06-22T19:15:40.130160Z",
+     "shell.execute_reply": "2026-06-22T19:15:40.130160Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.336754,
-     "end_time": "2026-06-04T06:26:53.389090",
+     "duration": 0.324977,
+     "end_time": "2026-06-22T19:15:40.130160",
      "exception": false,
-     "start_time": "2026-06-04T06:26:53.052336",
+     "start_time": "2026-06-22T19:15:39.805183",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3374,10 +3278,10 @@
    "id": "qu27uwkf3u",
    "metadata": {
     "papermill": {
-     "duration": 0.029353,
-     "end_time": "2026-06-04T06:26:53.436896",
+     "duration": 0.017,
+     "end_time": "2026-06-22T19:15:40.164168",
      "exception": false,
-     "start_time": "2026-06-04T06:26:53.407543",
+     "start_time": "2026-06-22T19:15:40.147168",
      "status": "completed"
     },
     "tags": []
@@ -3402,10 +3306,10 @@
    "id": "0ced45f5",
    "metadata": {
     "papermill": {
-     "duration": 0.018326,
-     "end_time": "2026-06-04T06:26:53.486014",
+     "duration": 0.015903,
+     "end_time": "2026-06-22T19:15:40.195077",
      "exception": false,
-     "start_time": "2026-06-04T06:26:53.467688",
+     "start_time": "2026-06-22T19:15:40.179174",
      "status": "completed"
     },
     "tags": []
@@ -3434,16 +3338,16 @@
    "id": "da19f7c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:53.532261Z",
-     "iopub.status.busy": "2026-06-04T06:26:53.531921Z",
-     "iopub.status.idle": "2026-06-04T06:26:53.574034Z",
-     "shell.execute_reply": "2026-06-04T06:26:53.573831Z"
+     "iopub.execute_input": "2026-06-22T19:15:40.232080Z",
+     "iopub.status.busy": "2026-06-22T19:15:40.232080Z",
+     "iopub.status.idle": "2026-06-22T19:15:40.268080Z",
+     "shell.execute_reply": "2026-06-22T19:15:40.268080Z"
     },
     "papermill": {
-     "duration": 0.061149,
-     "end_time": "2026-06-04T06:26:53.574135",
+     "duration": 0.057001,
+     "end_time": "2026-06-22T19:15:40.268080",
      "exception": false,
-     "start_time": "2026-06-04T06:26:53.512986",
+     "start_time": "2026-06-22T19:15:40.211079",
      "status": "completed"
     },
     "tags": []
@@ -3478,10 +3382,10 @@
    "id": "3cf84c09",
    "metadata": {
     "papermill": {
-     "duration": 0.018281,
-     "end_time": "2026-06-04T06:26:53.614625",
+     "duration": 0.01654,
+     "end_time": "2026-06-22T19:15:40.301653",
      "exception": false,
-     "start_time": "2026-06-04T06:26:53.596344",
+     "start_time": "2026-06-22T19:15:40.285113",
      "status": "completed"
     },
     "tags": []
@@ -3509,10 +3413,10 @@
    "id": "cialw5hzwlp",
    "metadata": {
     "papermill": {
-     "duration": 0.018966,
-     "end_time": "2026-06-04T06:26:53.656418",
+     "duration": 0.018141,
+     "end_time": "2026-06-22T19:15:40.338127",
      "exception": false,
-     "start_time": "2026-06-04T06:26:53.637452",
+     "start_time": "2026-06-22T19:15:40.319986",
      "status": "completed"
     },
     "tags": []
@@ -3538,16 +3442,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:53.700983Z",
-     "iopub.status.busy": "2026-06-04T06:26:53.699487Z",
-     "iopub.status.idle": "2026-06-04T06:26:54.215749Z",
-     "shell.execute_reply": "2026-06-04T06:26:54.215464Z"
+     "iopub.execute_input": "2026-06-22T19:15:40.376197Z",
+     "iopub.status.busy": "2026-06-22T19:15:40.376197Z",
+     "iopub.status.idle": "2026-06-22T19:15:40.860860Z",
+     "shell.execute_reply": "2026-06-22T19:15:40.859860Z"
     },
     "papermill": {
-     "duration": 0.539757,
-     "end_time": "2026-06-04T06:26:54.215891",
+     "duration": 0.504376,
+     "end_time": "2026-06-22T19:15:40.860860",
      "exception": false,
-     "start_time": "2026-06-04T06:26:53.676134",
+     "start_time": "2026-06-22T19:15:40.356484",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3663,10 +3567,10 @@
    "id": "wq10ipb3q9",
    "metadata": {
     "papermill": {
-     "duration": 0.02478,
-     "end_time": "2026-06-04T06:26:54.277790",
+     "duration": 0.019506,
+     "end_time": "2026-06-22T19:15:40.898367",
      "exception": false,
-     "start_time": "2026-06-04T06:26:54.253010",
+     "start_time": "2026-06-22T19:15:40.878861",
      "status": "completed"
     },
     "tags": []
@@ -3695,10 +3599,10 @@
    "id": "c9a29e30",
    "metadata": {
     "papermill": {
-     "duration": 0.021075,
-     "end_time": "2026-06-04T06:26:54.320390",
+     "duration": 0.018108,
+     "end_time": "2026-06-22T19:15:40.938629",
      "exception": false,
-     "start_time": "2026-06-04T06:26:54.299315",
+     "start_time": "2026-06-22T19:15:40.920521",
      "status": "completed"
     },
     "tags": []
@@ -3729,16 +3633,16 @@
    "id": "4e5a56a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:54.365103Z",
-     "iopub.status.busy": "2026-06-04T06:26:54.364723Z",
-     "iopub.status.idle": "2026-06-04T06:26:54.410649Z",
-     "shell.execute_reply": "2026-06-04T06:26:54.410396Z"
+     "iopub.execute_input": "2026-06-22T19:15:40.976234Z",
+     "iopub.status.busy": "2026-06-22T19:15:40.975226Z",
+     "iopub.status.idle": "2026-06-22T19:15:41.015342Z",
+     "shell.execute_reply": "2026-06-22T19:15:41.014345Z"
     },
     "papermill": {
-     "duration": 0.068431,
-     "end_time": "2026-06-04T06:26:54.410774",
+     "duration": 0.059129,
+     "end_time": "2026-06-22T19:15:41.015342",
      "exception": false,
-     "start_time": "2026-06-04T06:26:54.342343",
+     "start_time": "2026-06-22T19:15:40.956213",
      "status": "completed"
     },
     "tags": []
@@ -3775,10 +3679,10 @@
    "id": "4c623710",
    "metadata": {
     "papermill": {
-     "duration": 0.020551,
-     "end_time": "2026-06-04T06:26:54.451984",
+     "duration": 0.018,
+     "end_time": "2026-06-22T19:15:41.051343",
      "exception": false,
-     "start_time": "2026-06-04T06:26:54.431433",
+     "start_time": "2026-06-22T19:15:41.033343",
      "status": "completed"
     },
     "tags": []
@@ -3806,16 +3710,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:54.496720Z",
-     "iopub.status.busy": "2026-06-04T06:26:54.496333Z",
-     "iopub.status.idle": "2026-06-04T06:26:56.342736Z",
-     "shell.execute_reply": "2026-06-04T06:26:56.339109Z"
+     "iopub.execute_input": "2026-06-22T19:15:41.085338Z",
+     "iopub.status.busy": "2026-06-22T19:15:41.085338Z",
+     "iopub.status.idle": "2026-06-22T19:15:42.349488Z",
+     "shell.execute_reply": "2026-06-22T19:15:42.348482Z"
     },
     "papermill": {
-     "duration": 1.871114,
-     "end_time": "2026-06-04T06:26:56.343035",
+     "duration": 1.283145,
+     "end_time": "2026-06-22T19:15:42.350488",
      "exception": false,
-     "start_time": "2026-06-04T06:26:54.471921",
+     "start_time": "2026-06-22T19:15:41.067343",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4270,10 +4174,10 @@
    "id": "upj76rdkq",
    "metadata": {
     "papermill": {
-     "duration": 0.022886,
-     "end_time": "2026-06-04T06:26:56.405984",
+     "duration": 0.022382,
+     "end_time": "2026-06-22T19:15:42.391903",
      "exception": false,
-     "start_time": "2026-06-04T06:26:56.383098",
+     "start_time": "2026-06-22T19:15:42.369521",
      "status": "completed"
     },
     "tags": []
@@ -4310,10 +4214,10 @@
    "id": "ed705418",
    "metadata": {
     "papermill": {
-     "duration": 0.02647,
-     "end_time": "2026-06-04T06:26:56.459990",
+     "duration": 0.027548,
+     "end_time": "2026-06-22T19:15:42.448114",
      "exception": false,
-     "start_time": "2026-06-04T06:26:56.433520",
+     "start_time": "2026-06-22T19:15:42.420566",
      "status": "completed"
     },
     "tags": []
@@ -4346,10 +4250,10 @@
    "id": "47fxlyok8nh",
    "metadata": {
     "papermill": {
-     "duration": 0.021292,
-     "end_time": "2026-06-04T06:26:56.503562",
+     "duration": 0.019037,
+     "end_time": "2026-06-22T19:15:42.490292",
      "exception": false,
-     "start_time": "2026-06-04T06:26:56.482270",
+     "start_time": "2026-06-22T19:15:42.471255",
      "status": "completed"
     },
     "tags": []
@@ -4376,16 +4280,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:26:56.555064Z",
-     "iopub.status.busy": "2026-06-04T06:26:56.554788Z",
-     "iopub.status.idle": "2026-06-04T06:27:00.294034Z",
-     "shell.execute_reply": "2026-06-04T06:27:00.293412Z"
+     "iopub.execute_input": "2026-06-22T19:15:42.539568Z",
+     "iopub.status.busy": "2026-06-22T19:15:42.539568Z",
+     "iopub.status.idle": "2026-06-22T19:15:45.321547Z",
+     "shell.execute_reply": "2026-06-22T19:15:45.321547Z"
     },
     "papermill": {
-     "duration": 3.768515,
-     "end_time": "2026-06-04T06:27:00.294363",
+     "duration": 2.806977,
+     "end_time": "2026-06-22T19:15:45.322547",
      "exception": false,
-     "start_time": "2026-06-04T06:26:56.525848",
+     "start_time": "2026-06-22T19:15:42.515570",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4402,38 +4306,6 @@
      "output_type": "stream",
      "text": [
       "=== Modele Hierarchique (Rats) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_48_00_74.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -4888,10 +4760,10 @@
    "id": "590efa9f",
    "metadata": {
     "papermill": {
-     "duration": 0.080269,
-     "end_time": "2026-06-04T06:27:00.477508",
+     "duration": 0.024999,
+     "end_time": "2026-06-22T19:15:45.370672",
      "exception": false,
-     "start_time": "2026-06-04T06:27:00.397239",
+     "start_time": "2026-06-22T19:15:45.345673",
      "status": "completed"
     },
     "tags": []
@@ -4906,19 +4778,19 @@
    "id": "tsksp0s81b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:27:00.571940Z",
-     "iopub.status.busy": "2026-06-04T06:27:00.570874Z",
-     "iopub.status.idle": "2026-06-04T06:27:00.625618Z",
-     "shell.execute_reply": "2026-06-04T06:27:00.625851Z"
+     "iopub.execute_input": "2026-06-22T19:15:45.421152Z",
+     "iopub.status.busy": "2026-06-22T19:15:45.421152Z",
+     "iopub.status.idle": "2026-06-22T19:15:45.565144Z",
+     "shell.execute_reply": "2026-06-22T19:15:45.565144Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.118857,
-     "end_time": "2026-06-04T06:27:00.625986",
+     "duration": 0.169481,
+     "end_time": "2026-06-22T19:15:45.565670",
      "exception": false,
-     "start_time": "2026-06-04T06:27:00.507129",
+     "start_time": "2026-06-22T19:15:45.396189",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4933,14 +4805,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_17_48_00_74.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_42_61.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"3986pt\" height=\"900pt\"\r\n",
@@ -7714,8 +7586,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -7727,7 +7599,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -7742,10 +7614,10 @@
    "id": "ykn7nybgejj",
    "metadata": {
     "papermill": {
-     "duration": 0.02753,
-     "end_time": "2026-06-04T06:27:00.703928",
+     "duration": 0.027766,
+     "end_time": "2026-06-22T19:15:45.622232",
      "exception": false,
-     "start_time": "2026-06-04T06:27:00.676398",
+     "start_time": "2026-06-22T19:15:45.594466",
      "status": "completed"
     },
     "tags": []
@@ -7775,10 +7647,10 @@
    "id": "8564d6fmi8e",
    "metadata": {
     "papermill": {
-     "duration": 0.025523,
-     "end_time": "2026-06-04T06:27:00.756992",
+     "duration": 0.025173,
+     "end_time": "2026-06-22T19:15:45.673013",
      "exception": false,
-     "start_time": "2026-06-04T06:27:00.731469",
+     "start_time": "2026-06-22T19:15:45.647840",
      "status": "completed"
     },
     "tags": []
@@ -7811,10 +7683,10 @@
    "id": "1ae3dbf2",
    "metadata": {
     "papermill": {
-     "duration": 0.026608,
-     "end_time": "2026-06-04T06:27:00.811957",
+     "duration": 0.027947,
+     "end_time": "2026-06-22T19:15:45.727775",
      "exception": false,
-     "start_time": "2026-06-04T06:27:00.785349",
+     "start_time": "2026-06-22T19:15:45.699828",
      "status": "completed"
     },
     "tags": []
@@ -7851,10 +7723,10 @@
    "id": "doc1d49u69o",
    "metadata": {
     "papermill": {
-     "duration": 0.027851,
-     "end_time": "2026-06-04T06:27:00.866650",
+     "duration": 0.023993,
+     "end_time": "2026-06-22T19:15:45.778517",
      "exception": false,
-     "start_time": "2026-06-04T06:27:00.838799",
+     "start_time": "2026-06-22T19:15:45.754524",
      "status": "completed"
     },
     "tags": []
@@ -7881,10 +7753,10 @@
    "id": "mz7t0we65y",
    "metadata": {
     "papermill": {
-     "duration": 0.028724,
-     "end_time": "2026-06-04T06:27:00.922269",
+     "duration": 0.027033,
+     "end_time": "2026-06-22T19:15:45.832268",
      "exception": false,
-     "start_time": "2026-06-04T06:27:00.893545",
+     "start_time": "2026-06-22T19:15:45.805235",
      "status": "completed"
     },
     "tags": []
@@ -7906,16 +7778,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:27:00.979113Z",
-     "iopub.status.busy": "2026-06-04T06:27:00.978780Z",
-     "iopub.status.idle": "2026-06-04T06:27:01.536286Z",
-     "shell.execute_reply": "2026-06-04T06:27:01.535988Z"
+     "iopub.execute_input": "2026-06-22T19:15:45.893022Z",
+     "iopub.status.busy": "2026-06-22T19:15:45.892499Z",
+     "iopub.status.idle": "2026-06-22T19:15:46.477580Z",
+     "shell.execute_reply": "2026-06-22T19:15:46.477580Z"
     },
     "papermill": {
-     "duration": 0.586616,
-     "end_time": "2026-06-04T06:27:01.536436",
+     "duration": 0.616344,
+     "end_time": "2026-06-22T19:15:46.477580",
      "exception": false,
-     "start_time": "2026-06-04T06:27:00.949820",
+     "start_time": "2026-06-22T19:15:45.861236",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -7932,38 +7804,6 @@
      "output_type": "stream",
      "text": [
       "=== Diagnostic Medical ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_17_48_04_75.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -8059,10 +7899,10 @@
    "id": "122ac6b9",
    "metadata": {
     "papermill": {
-     "duration": 0.027222,
-     "end_time": "2026-06-04T06:27:01.592765",
+     "duration": 0.027168,
+     "end_time": "2026-06-22T19:15:46.530462",
      "exception": false,
-     "start_time": "2026-06-04T06:27:01.565543",
+     "start_time": "2026-06-22T19:15:46.503294",
      "status": "completed"
     },
     "tags": []
@@ -8077,19 +7917,19 @@
    "id": "qgf0ecbnvsl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:27:01.652956Z",
-     "iopub.status.busy": "2026-06-04T06:27:01.652577Z",
-     "iopub.status.idle": "2026-06-04T06:27:01.691074Z",
-     "shell.execute_reply": "2026-06-04T06:27:01.690900Z"
+     "iopub.execute_input": "2026-06-22T19:15:46.584795Z",
+     "iopub.status.busy": "2026-06-22T19:15:46.584795Z",
+     "iopub.status.idle": "2026-06-22T19:15:46.677886Z",
+     "shell.execute_reply": "2026-06-22T19:15:46.677886Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.07058,
-     "end_time": "2026-06-04T06:27:01.691171",
+     "duration": 0.120915,
+     "end_time": "2026-06-22T19:15:46.677886",
      "exception": false,
-     "start_time": "2026-06-04T06:27:01.620591",
+     "start_time": "2026-06-22T19:15:46.556971",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -8104,14 +7944,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_17_48_04_75.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_45_93.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"627pt\" height=\"371pt\"\r\n",
@@ -8366,8 +8206,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -8379,7 +8219,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -8394,10 +8234,10 @@
    "id": "zt3bdv0hqn",
    "metadata": {
     "papermill": {
-     "duration": 0.025959,
-     "end_time": "2026-06-04T06:27:01.746299",
+     "duration": 0.028897,
+     "end_time": "2026-06-22T19:15:46.735766",
      "exception": false,
-     "start_time": "2026-06-04T06:27:01.720340",
+     "start_time": "2026-06-22T19:15:46.706869",
      "status": "completed"
     },
     "tags": []
@@ -8424,10 +8264,10 @@
    "id": "ills1wvc2o9",
    "metadata": {
     "papermill": {
-     "duration": 0.029938,
-     "end_time": "2026-06-04T06:27:01.803854",
+     "duration": 0.027185,
+     "end_time": "2026-06-22T19:15:46.794098",
      "exception": false,
-     "start_time": "2026-06-04T06:27:01.773916",
+     "start_time": "2026-06-22T19:15:46.766913",
      "status": "completed"
     },
     "tags": []
@@ -8458,10 +8298,10 @@
    "id": "17oeysgy3al",
    "metadata": {
     "papermill": {
-     "duration": 0.026255,
-     "end_time": "2026-06-04T06:27:01.857254",
+     "duration": 0.027569,
+     "end_time": "2026-06-22T19:15:46.850756",
      "exception": false,
-     "start_time": "2026-06-04T06:27:01.830999",
+     "start_time": "2026-06-22T19:15:46.823187",
      "status": "completed"
     },
     "tags": []
@@ -8499,10 +8339,10 @@
    "id": "9c3ab892",
    "metadata": {
     "papermill": {
-     "duration": 0.026256,
-     "end_time": "2026-06-04T06:27:01.908836",
+     "duration": 0.026633,
+     "end_time": "2026-06-22T19:15:46.904687",
      "exception": false,
-     "start_time": "2026-06-04T06:27:01.882580",
+     "start_time": "2026-06-22T19:15:46.878054",
      "status": "completed"
     },
     "tags": []
@@ -8556,10 +8396,10 @@
    "id": "58f70403",
    "metadata": {
     "papermill": {
-     "duration": 0.026676,
-     "end_time": "2026-06-04T06:27:01.963247",
+     "duration": 0.026684,
+     "end_time": "2026-06-22T19:15:46.958933",
      "exception": false,
-     "start_time": "2026-06-04T06:27:01.936571",
+     "start_time": "2026-06-22T19:15:46.932249",
      "status": "completed"
     },
     "tags": []
@@ -8590,19 +8430,19 @@
    "id": "bd4e93fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:27:02.023498Z",
-     "iopub.status.busy": "2026-06-04T06:27:02.023174Z",
-     "iopub.status.idle": "2026-06-04T06:27:02.054175Z",
-     "shell.execute_reply": "2026-06-04T06:27:02.053893Z"
+     "iopub.execute_input": "2026-06-22T19:15:47.012478Z",
+     "iopub.status.busy": "2026-06-22T19:15:47.012478Z",
+     "iopub.status.idle": "2026-06-22T19:15:47.038480Z",
+     "shell.execute_reply": "2026-06-22T19:15:47.038480Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.059413,
-     "end_time": "2026-06-04T06:27:02.054311",
+     "duration": 0.053093,
+     "end_time": "2026-06-22T19:15:47.038480",
      "exception": false,
-     "start_time": "2026-06-04T06:27:01.994898",
+     "start_time": "2026-06-22T19:15:46.985387",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -8645,10 +8485,10 @@
    "id": "09005592",
    "metadata": {
     "papermill": {
-     "duration": 0.026367,
-     "end_time": "2026-06-04T06:27:02.113316",
+     "duration": 0.025164,
+     "end_time": "2026-06-22T19:15:47.091199",
      "exception": false,
-     "start_time": "2026-06-04T06:27:02.086949",
+     "start_time": "2026-06-22T19:15:47.066035",
      "status": "completed"
     },
     "tags": []
@@ -8693,18 +8533,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 21.762584,
-   "end_time": "2026-06-04T06:27:02.492324",
+   "duration": 17.533953,
+   "end_time": "2026-06-22T19:15:47.356148",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-4-Bayesian-Networks.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-4-Bayesian-Networks.ipynb",
+   "input_path": "Infer-4-Bayesian-Networks.ipynb",
+   "output_path": "Infer-4-Bayesian-Networks.ipynb",
    "parameters": {},
-   "start_time": "2026-06-04T06:26:40.729740",
+   "start_time": "2026-06-22T19:15:29.822195",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-5-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-5-Skills-IRT.ipynb
@@ -5,10 +5,10 @@
    "id": "acede045",
    "metadata": {
     "papermill": {
-     "duration": 0.02727,
-     "end_time": "2026-06-09T09:38:42.360009",
+     "duration": 0.005585,
+     "end_time": "2026-06-22T19:15:51.123187",
      "exception": false,
-     "start_time": "2026-06-09T09:38:42.332739",
+     "start_time": "2026-06-22T19:15:51.117602",
      "status": "completed"
     },
     "tags": []
@@ -46,10 +46,10 @@
    "id": "82c317c2",
    "metadata": {
     "papermill": {
-     "duration": 0.01746,
-     "end_time": "2026-06-09T09:38:42.396540",
+     "duration": 0.00566,
+     "end_time": "2026-06-22T19:15:51.135334",
      "exception": false,
-     "start_time": "2026-06-09T09:38:42.379080",
+     "start_time": "2026-06-22T19:15:51.129674",
      "status": "completed"
     },
     "tags": []
@@ -69,16 +69,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:42.447843Z",
-     "iopub.status.busy": "2026-06-09T09:38:42.440175Z",
-     "iopub.status.idle": "2026-06-09T09:38:49.527018Z",
-     "shell.execute_reply": "2026-06-09T09:38:49.520367Z"
+     "iopub.execute_input": "2026-06-22T19:15:51.153654Z",
+     "iopub.status.busy": "2026-06-22T19:15:51.150084Z",
+     "iopub.status.idle": "2026-06-22T19:15:53.776569Z",
+     "shell.execute_reply": "2026-06-22T19:15:53.773568Z"
     },
     "papermill": {
-     "duration": 7.112498,
-     "end_time": "2026-06-09T09:38:49.527310",
+     "duration": 2.635604,
+     "end_time": "2026-06-22T19:15:53.776569",
      "exception": false,
-     "start_time": "2026-06-09T09:38:42.414812",
+     "start_time": "2026-06-22T19:15:51.140965",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -95,7 +95,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-75456.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-100524.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -140,12 +140,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.14:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '75456.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '100524.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -242,10 +242,10 @@
    "id": "b161447f",
    "metadata": {
     "papermill": {
-     "duration": 0.029756,
-     "end_time": "2026-06-09T09:38:49.580396",
+     "duration": 0.012005,
+     "end_time": "2026-06-22T19:15:53.801574",
      "exception": false,
-     "start_time": "2026-06-09T09:38:49.550640",
+     "start_time": "2026-06-22T19:15:53.789569",
      "status": "completed"
     },
     "tags": []
@@ -260,16 +260,16 @@
    "id": "ny2wcgc1uwe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:49.629569Z",
-     "iopub.status.busy": "2026-06-09T09:38:49.628574Z",
-     "iopub.status.idle": "2026-06-09T09:38:51.500215Z",
-     "shell.execute_reply": "2026-06-09T09:38:51.499782Z"
+     "iopub.execute_input": "2026-06-22T19:15:53.826608Z",
+     "iopub.status.busy": "2026-06-22T19:15:53.826608Z",
+     "iopub.status.idle": "2026-06-22T19:15:54.542940Z",
+     "shell.execute_reply": "2026-06-22T19:15:54.542940Z"
     },
     "papermill": {
-     "duration": 1.897291,
-     "end_time": "2026-06-09T09:38:51.500431",
+     "duration": 0.729883,
+     "end_time": "2026-06-22T19:15:54.543456",
      "exception": false,
-     "start_time": "2026-06-09T09:38:49.603140",
+     "start_time": "2026-06-22T19:15:53.813573",
      "status": "completed"
     },
     "tags": [],
@@ -306,10 +306,10 @@
    "id": "m107lfympo",
    "metadata": {
     "papermill": {
-     "duration": 0.018979,
-     "end_time": "2026-06-09T09:38:51.536786",
+     "duration": 0.010917,
+     "end_time": "2026-06-22T19:15:54.564409",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.517807",
+     "start_time": "2026-06-22T19:15:54.553492",
      "status": "completed"
     },
     "tags": []
@@ -331,10 +331,10 @@
    "id": "x170007hb78",
    "metadata": {
     "papermill": {
-     "duration": 0.017053,
-     "end_time": "2026-06-09T09:38:51.573789",
+     "duration": 0.010584,
+     "end_time": "2026-06-22T19:15:54.586248",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.556736",
+     "start_time": "2026-06-22T19:15:54.575664",
      "status": "completed"
     },
     "tags": []
@@ -355,10 +355,10 @@
    "id": "6e446418",
    "metadata": {
     "papermill": {
-     "duration": 0.01773,
-     "end_time": "2026-06-09T09:38:51.609556",
+     "duration": 0.011788,
+     "end_time": "2026-06-22T19:15:54.608993",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.591826",
+     "start_time": "2026-06-22T19:15:54.597205",
      "status": "completed"
     },
     "tags": []
@@ -393,10 +393,10 @@
    "id": "40c04fbd",
    "metadata": {
     "papermill": {
-     "duration": 0.015637,
-     "end_time": "2026-06-09T09:38:51.644745",
+     "duration": 0.010819,
+     "end_time": "2026-06-22T19:15:54.631166",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.629108",
+     "start_time": "2026-06-22T19:15:54.620347",
      "status": "completed"
     },
     "tags": []
@@ -430,16 +430,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:51.679668Z",
-     "iopub.status.busy": "2026-06-09T09:38:51.678783Z",
-     "iopub.status.idle": "2026-06-09T09:38:52.217867Z",
-     "shell.execute_reply": "2026-06-09T09:38:52.217485Z"
+     "iopub.execute_input": "2026-06-22T19:15:54.657348Z",
+     "iopub.status.busy": "2026-06-22T19:15:54.656842Z",
+     "iopub.status.idle": "2026-06-22T19:15:54.936156Z",
+     "shell.execute_reply": "2026-06-22T19:15:54.936156Z"
     },
     "papermill": {
-     "duration": 0.556465,
-     "end_time": "2026-06-09T09:38:52.218081",
+     "duration": 0.292713,
+     "end_time": "2026-06-22T19:15:54.936156",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.661616",
+     "start_time": "2026-06-22T19:15:54.643443",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -519,10 +519,10 @@
    "id": "frj93ftqzui",
    "metadata": {
     "papermill": {
-     "duration": 0.019107,
-     "end_time": "2026-06-09T09:38:52.258036",
+     "duration": 0.016079,
+     "end_time": "2026-06-22T19:15:54.969909",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.238929",
+     "start_time": "2026-06-22T19:15:54.953830",
      "status": "completed"
     },
     "tags": []
@@ -555,10 +555,10 @@
    "id": "9qvij59ix7n",
    "metadata": {
     "papermill": {
-     "duration": 0.017349,
-     "end_time": "2026-06-09T09:38:52.292821",
+     "duration": 0.016075,
+     "end_time": "2026-06-22T19:15:54.997326",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.275472",
+     "start_time": "2026-06-22T19:15:54.981251",
      "status": "completed"
     },
     "tags": []
@@ -584,16 +584,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:52.328502Z",
-     "iopub.status.busy": "2026-06-09T09:38:52.327778Z",
-     "iopub.status.idle": "2026-06-09T09:38:57.468053Z",
-     "shell.execute_reply": "2026-06-09T09:38:57.467669Z"
+     "iopub.execute_input": "2026-06-22T19:15:55.024966Z",
+     "iopub.status.busy": "2026-06-22T19:15:55.024455Z",
+     "iopub.status.idle": "2026-06-22T19:15:57.267318Z",
+     "shell.execute_reply": "2026-06-22T19:15:57.267318Z"
     },
     "papermill": {
-     "duration": 5.15869,
-     "end_time": "2026-06-09T09:38:57.468251",
+     "duration": 2.257345,
+     "end_time": "2026-06-22T19:15:57.267318",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.309561",
+     "start_time": "2026-06-22T19:15:55.009973",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -605,38 +605,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_10_17.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1167,10 +1135,10 @@
    "id": "1b88a77c",
    "metadata": {
     "papermill": {
-     "duration": 0.033176,
-     "end_time": "2026-06-09T09:38:57.532088",
+     "duration": 0.013005,
+     "end_time": "2026-06-22T19:15:57.294323",
      "exception": false,
-     "start_time": "2026-06-09T09:38:57.498912",
+     "start_time": "2026-06-22T19:15:57.281318",
      "status": "completed"
     },
     "tags": []
@@ -1185,16 +1153,16 @@
    "id": "nc0ppf2w6q",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:57.602113Z",
-     "iopub.status.busy": "2026-06-09T09:38:57.601321Z",
-     "iopub.status.idle": "2026-06-09T09:38:57.827254Z",
-     "shell.execute_reply": "2026-06-09T09:38:57.827561Z"
+     "iopub.execute_input": "2026-06-22T19:15:57.322850Z",
+     "iopub.status.busy": "2026-06-22T19:15:57.322850Z",
+     "iopub.status.idle": "2026-06-22T19:15:57.457950Z",
+     "shell.execute_reply": "2026-06-22T19:15:57.457950Z"
     },
     "papermill": {
-     "duration": 0.262806,
-     "end_time": "2026-06-09T09:38:57.827737",
+     "duration": 0.150604,
+     "end_time": "2026-06-22T19:15:57.457950",
      "exception": false,
-     "start_time": "2026-06-09T09:38:57.564931",
+     "start_time": "2026-06-22T19:15:57.307346",
      "status": "completed"
     },
     "tags": [],
@@ -1206,14 +1174,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_18_46_10_17.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_55_19.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"416pt\" height=\"663pt\"\r\n",
@@ -1444,8 +1412,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1457,7 +1425,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1472,10 +1440,10 @@
    "id": "vhz59h176p",
    "metadata": {
     "papermill": {
-     "duration": 0.029169,
-     "end_time": "2026-06-09T09:38:57.888137",
+     "duration": 0.013035,
+     "end_time": "2026-06-22T19:15:57.485661",
      "exception": false,
-     "start_time": "2026-06-09T09:38:57.858968",
+     "start_time": "2026-06-22T19:15:57.472626",
      "status": "completed"
     },
     "tags": []
@@ -1502,10 +1470,10 @@
    "id": "2219d280",
    "metadata": {
     "papermill": {
-     "duration": 0.029695,
-     "end_time": "2026-06-09T09:38:57.945700",
+     "duration": 0.013293,
+     "end_time": "2026-06-22T19:15:57.513572",
      "exception": false,
-     "start_time": "2026-06-09T09:38:57.916005",
+     "start_time": "2026-06-22T19:15:57.500279",
      "status": "completed"
     },
     "tags": []
@@ -1536,10 +1504,10 @@
    "id": "u7e3glgtzcm",
    "metadata": {
     "papermill": {
-     "duration": 0.03569,
-     "end_time": "2026-06-09T09:38:58.015111",
+     "duration": 0.015733,
+     "end_time": "2026-06-22T19:15:57.544831",
      "exception": false,
-     "start_time": "2026-06-09T09:38:57.979421",
+     "start_time": "2026-06-22T19:15:57.529098",
      "status": "completed"
     },
     "tags": []
@@ -1563,10 +1531,10 @@
    "id": "46lkoyw14mo",
    "metadata": {
     "papermill": {
-     "duration": 0.038522,
-     "end_time": "2026-06-09T09:38:58.092345",
+     "duration": 0.013691,
+     "end_time": "2026-06-22T19:15:57.572691",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.053823",
+     "start_time": "2026-06-22T19:15:57.559000",
      "status": "completed"
     },
     "tags": []
@@ -1589,16 +1557,16 @@
    "id": "e4imjob0vqj",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:58.161345Z",
-     "iopub.status.busy": "2026-06-09T09:38:58.160799Z",
-     "iopub.status.idle": "2026-06-09T09:38:58.473700Z",
-     "shell.execute_reply": "2026-06-09T09:38:58.473299Z"
+     "iopub.execute_input": "2026-06-22T19:15:57.603502Z",
+     "iopub.status.busy": "2026-06-22T19:15:57.603502Z",
+     "iopub.status.idle": "2026-06-22T19:15:57.761035Z",
+     "shell.execute_reply": "2026-06-22T19:15:57.761035Z"
     },
     "papermill": {
-     "duration": 0.347314,
-     "end_time": "2026-06-09T09:38:58.473891",
+     "duration": 0.175281,
+     "end_time": "2026-06-22T19:15:57.761035",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.126577",
+     "start_time": "2026-06-22T19:15:57.585754",
      "status": "completed"
     },
     "tags": [],
@@ -1770,10 +1738,10 @@
    "id": "i17w6q3o1nj",
    "metadata": {
     "papermill": {
-     "duration": 0.025805,
-     "end_time": "2026-06-09T09:38:58.525530",
+     "duration": 0.015001,
+     "end_time": "2026-06-22T19:15:57.790034",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.499725",
+     "start_time": "2026-06-22T19:15:57.775033",
      "status": "completed"
     },
     "tags": []
@@ -1810,10 +1778,10 @@
    "id": "ul9hjtw90cc",
    "metadata": {
     "papermill": {
-     "duration": 0.029558,
-     "end_time": "2026-06-09T09:38:58.582049",
+     "duration": 0.014013,
+     "end_time": "2026-06-22T19:15:57.818448",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.552491",
+     "start_time": "2026-06-22T19:15:57.804435",
      "status": "completed"
     },
     "tags": []
@@ -1829,10 +1797,10 @@
    "id": "716de205",
    "metadata": {
     "papermill": {
-     "duration": 0.026603,
-     "end_time": "2026-06-09T09:38:58.637141",
+     "duration": 0.014,
+     "end_time": "2026-06-22T19:15:57.846165",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.610538",
+     "start_time": "2026-06-22T19:15:57.832165",
      "status": "completed"
     },
     "tags": []
@@ -1862,16 +1830,16 @@
    "id": "5af1325d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:58.692043Z",
-     "iopub.status.busy": "2026-06-09T09:38:58.691476Z",
-     "iopub.status.idle": "2026-06-09T09:38:58.810130Z",
-     "shell.execute_reply": "2026-06-09T09:38:58.809764Z"
+     "iopub.execute_input": "2026-06-22T19:15:57.875165Z",
+     "iopub.status.busy": "2026-06-22T19:15:57.875165Z",
+     "iopub.status.idle": "2026-06-22T19:15:57.937855Z",
+     "shell.execute_reply": "2026-06-22T19:15:57.937855Z"
     },
     "papermill": {
-     "duration": 0.147139,
-     "end_time": "2026-06-09T09:38:58.810309",
+     "duration": 0.077689,
+     "end_time": "2026-06-22T19:15:57.937855",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.663170",
+     "start_time": "2026-06-22T19:15:57.860166",
      "status": "completed"
     },
     "tags": []
@@ -1911,10 +1879,10 @@
    "id": "3957a447",
    "metadata": {
     "papermill": {
-     "duration": 0.025145,
-     "end_time": "2026-06-09T09:38:58.859951",
+     "duration": 0.015208,
+     "end_time": "2026-06-22T19:15:57.968065",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.834806",
+     "start_time": "2026-06-22T19:15:57.952857",
      "status": "completed"
     },
     "tags": []
@@ -1946,10 +1914,10 @@
    "id": "56ikmnn0zn4",
    "metadata": {
     "papermill": {
-     "duration": 0.03938,
-     "end_time": "2026-06-09T09:38:58.942843",
+     "duration": 0.01516,
+     "end_time": "2026-06-22T19:15:57.998598",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.903463",
+     "start_time": "2026-06-22T19:15:57.983438",
      "status": "completed"
     },
     "tags": []
@@ -1975,16 +1943,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:58.998903Z",
-     "iopub.status.busy": "2026-06-09T09:38:58.998380Z",
-     "iopub.status.idle": "2026-06-09T09:38:59.135971Z",
-     "shell.execute_reply": "2026-06-09T09:38:59.135584Z"
+     "iopub.execute_input": "2026-06-22T19:15:58.029560Z",
+     "iopub.status.busy": "2026-06-22T19:15:58.029560Z",
+     "iopub.status.idle": "2026-06-22T19:15:58.090561Z",
+     "shell.execute_reply": "2026-06-22T19:15:58.090561Z"
     },
     "papermill": {
-     "duration": 0.165537,
-     "end_time": "2026-06-09T09:38:59.136170",
+     "duration": 0.076896,
+     "end_time": "2026-06-22T19:15:58.090561",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.970633",
+     "start_time": "2026-06-22T19:15:58.013665",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2107,10 +2075,10 @@
    "id": "37dr139eft",
    "metadata": {
     "papermill": {
-     "duration": 0.026223,
-     "end_time": "2026-06-09T09:38:59.191221",
+     "duration": 0.015004,
+     "end_time": "2026-06-22T19:15:58.121565",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.164998",
+     "start_time": "2026-06-22T19:15:58.106561",
      "status": "completed"
     },
     "tags": []
@@ -2141,16 +2109,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:59.245430Z",
-     "iopub.status.busy": "2026-06-09T09:38:59.244928Z",
-     "iopub.status.idle": "2026-06-09T09:38:59.367166Z",
-     "shell.execute_reply": "2026-06-09T09:38:59.366780Z"
+     "iopub.execute_input": "2026-06-22T19:15:58.155704Z",
+     "iopub.status.busy": "2026-06-22T19:15:58.155704Z",
+     "iopub.status.idle": "2026-06-22T19:15:58.213847Z",
+     "shell.execute_reply": "2026-06-22T19:15:58.213847Z"
     },
     "papermill": {
-     "duration": 0.150167,
-     "end_time": "2026-06-09T09:38:59.367354",
+     "duration": 0.076148,
+     "end_time": "2026-06-22T19:15:58.213847",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.217187",
+     "start_time": "2026-06-22T19:15:58.137699",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2265,10 +2233,10 @@
    "id": "pa9lh196gh",
    "metadata": {
     "papermill": {
-     "duration": 0.035628,
-     "end_time": "2026-06-09T09:38:59.434845",
+     "duration": 0.015007,
+     "end_time": "2026-06-22T19:15:58.244105",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.399217",
+     "start_time": "2026-06-22T19:15:58.229098",
      "status": "completed"
     },
     "tags": []
@@ -2286,10 +2254,10 @@
    "id": "7w0uplcpe3i",
    "metadata": {
     "papermill": {
-     "duration": 0.029095,
-     "end_time": "2026-06-09T09:38:59.498008",
+     "duration": 0.014999,
+     "end_time": "2026-06-22T19:15:58.273104",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.468913",
+     "start_time": "2026-06-22T19:15:58.258105",
      "status": "completed"
     },
     "tags": []
@@ -2315,16 +2283,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:59.554265Z",
-     "iopub.status.busy": "2026-06-09T09:38:59.553572Z",
-     "iopub.status.idle": "2026-06-09T09:39:00.687014Z",
-     "shell.execute_reply": "2026-06-09T09:39:00.686654Z"
+     "iopub.execute_input": "2026-06-22T19:15:58.302527Z",
+     "iopub.status.busy": "2026-06-22T19:15:58.302527Z",
+     "iopub.status.idle": "2026-06-22T19:15:58.922803Z",
+     "shell.execute_reply": "2026-06-22T19:15:58.922803Z"
     },
     "papermill": {
-     "duration": 1.161505,
-     "end_time": "2026-06-09T09:39:00.687202",
+     "duration": 0.635698,
+     "end_time": "2026-06-22T19:15:58.922803",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.525697",
+     "start_time": "2026-06-22T19:15:58.287105",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2355,38 +2323,6 @@
      "output_type": "stream",
      "text": [
       "Observation : reponse correcte\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_13_45.gv\"\n",
       "\r\n"
      ]
     },
@@ -2485,10 +2421,10 @@
    "id": "6f09167c",
    "metadata": {
     "papermill": {
-     "duration": 0.028232,
-     "end_time": "2026-06-09T09:39:00.746763",
+     "duration": 0.015763,
+     "end_time": "2026-06-22T19:15:58.954112",
      "exception": false,
-     "start_time": "2026-06-09T09:39:00.718531",
+     "start_time": "2026-06-22T19:15:58.938349",
      "status": "completed"
     },
     "tags": []
@@ -2503,16 +2439,16 @@
    "id": "rg8nejotm0r",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:00.813595Z",
-     "iopub.status.busy": "2026-06-09T09:39:00.813080Z",
-     "iopub.status.idle": "2026-06-09T09:39:00.905317Z",
-     "shell.execute_reply": "2026-06-09T09:39:00.904962Z"
+     "iopub.execute_input": "2026-06-22T19:15:58.987114Z",
+     "iopub.status.busy": "2026-06-22T19:15:58.987114Z",
+     "iopub.status.idle": "2026-06-22T19:15:59.094172Z",
+     "shell.execute_reply": "2026-06-22T19:15:59.094172Z"
     },
     "papermill": {
-     "duration": 0.126284,
-     "end_time": "2026-06-09T09:39:00.905527",
+     "duration": 0.124059,
+     "end_time": "2026-06-22T19:15:59.094172",
      "exception": false,
-     "start_time": "2026-06-09T09:39:00.779243",
+     "start_time": "2026-06-22T19:15:58.970113",
      "status": "completed"
     },
     "tags": [],
@@ -2524,14 +2460,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_18_46_13_45.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_58_37.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"338pt\" height=\"535pt\"\r\n",
@@ -2773,8 +2709,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2786,7 +2722,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -2801,10 +2737,10 @@
    "id": "i0jolbjmfoq",
    "metadata": {
     "papermill": {
-     "duration": 0.033389,
-     "end_time": "2026-06-09T09:39:00.969982",
+     "duration": 0.016003,
+     "end_time": "2026-06-22T19:15:59.126178",
      "exception": false,
-     "start_time": "2026-06-09T09:39:00.936593",
+     "start_time": "2026-06-22T19:15:59.110175",
      "status": "completed"
     },
     "tags": []
@@ -2834,10 +2770,10 @@
    "id": "kpx19prqge",
    "metadata": {
     "papermill": {
-     "duration": 0.034973,
-     "end_time": "2026-06-09T09:39:01.038578",
+     "duration": 0.016604,
+     "end_time": "2026-06-22T19:15:59.158292",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.003605",
+     "start_time": "2026-06-22T19:15:59.141688",
      "status": "completed"
     },
     "tags": []
@@ -2867,10 +2803,10 @@
    "id": "0893ac42",
    "metadata": {
     "papermill": {
-     "duration": 0.037233,
-     "end_time": "2026-06-09T09:39:01.112509",
+     "duration": 0.016,
+     "end_time": "2026-06-22T19:15:59.190296",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.075276",
+     "start_time": "2026-06-22T19:15:59.174296",
      "status": "completed"
     },
     "tags": []
@@ -2892,10 +2828,10 @@
    "id": "cwx0zd56zi",
    "metadata": {
     "papermill": {
-     "duration": 0.072135,
-     "end_time": "2026-06-09T09:39:01.231980",
+     "duration": 0.016006,
+     "end_time": "2026-06-22T19:15:59.222300",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.159845",
+     "start_time": "2026-06-22T19:15:59.206294",
      "status": "completed"
     },
     "tags": []
@@ -2922,16 +2858,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:01.356733Z",
-     "iopub.status.busy": "2026-06-09T09:39:01.356206Z",
-     "iopub.status.idle": "2026-06-09T09:39:02.893559Z",
-     "shell.execute_reply": "2026-06-09T09:39:02.893104Z"
+     "iopub.execute_input": "2026-06-22T19:15:59.256401Z",
+     "iopub.status.busy": "2026-06-22T19:15:59.256401Z",
+     "iopub.status.idle": "2026-06-22T19:15:59.972150Z",
+     "shell.execute_reply": "2026-06-22T19:15:59.971628Z"
     },
     "papermill": {
-     "duration": 1.587953,
-     "end_time": "2026-06-09T09:39:02.893766",
+     "duration": 0.733766,
+     "end_time": "2026-06-22T19:15:59.972150",
      "exception": false,
-     "start_time": "2026-06-09T09:39:01.305813",
+     "start_time": "2026-06-22T19:15:59.238384",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2943,38 +2879,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_14_45.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -3232,10 +3136,10 @@
    "id": "c7755942",
    "metadata": {
     "papermill": {
-     "duration": 0.031275,
-     "end_time": "2026-06-09T09:39:02.957255",
+     "duration": 0.017001,
+     "end_time": "2026-06-22T19:16:00.005374",
      "exception": false,
-     "start_time": "2026-06-09T09:39:02.925980",
+     "start_time": "2026-06-22T19:15:59.988373",
      "status": "completed"
     },
     "tags": []
@@ -3250,16 +3154,16 @@
    "id": "ww8hj4x0bi",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:03.015541Z",
-     "iopub.status.busy": "2026-06-09T09:39:03.015008Z",
-     "iopub.status.idle": "2026-06-09T09:39:03.110534Z",
-     "shell.execute_reply": "2026-06-09T09:39:03.110847Z"
+     "iopub.execute_input": "2026-06-22T19:16:00.040996Z",
+     "iopub.status.busy": "2026-06-22T19:16:00.040996Z",
+     "iopub.status.idle": "2026-06-22T19:16:00.150348Z",
+     "shell.execute_reply": "2026-06-22T19:16:00.149342Z"
     },
     "papermill": {
-     "duration": 0.124958,
-     "end_time": "2026-06-09T09:39:03.111043",
+     "duration": 0.126906,
+     "end_time": "2026-06-22T19:16:00.150348",
      "exception": false,
-     "start_time": "2026-06-09T09:39:02.986085",
+     "start_time": "2026-06-22T19:16:00.023442",
      "status": "completed"
     },
     "tags": [],
@@ -3271,14 +3175,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_18_46_14_45.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_59_33.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"2361pt\" height=\"526pt\"\r\n",
@@ -4083,8 +3987,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -4096,7 +4000,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -4111,10 +4015,10 @@
    "id": "qt7qfg804tg",
    "metadata": {
     "papermill": {
-     "duration": 0.039539,
-     "end_time": "2026-06-09T09:39:03.181204",
+     "duration": 0.019592,
+     "end_time": "2026-06-22T19:16:00.192447",
      "exception": false,
-     "start_time": "2026-06-09T09:39:03.141665",
+     "start_time": "2026-06-22T19:16:00.172855",
      "status": "completed"
     },
     "tags": []
@@ -4145,10 +4049,10 @@
    "id": "s8m8es9flxa",
    "metadata": {
     "papermill": {
-     "duration": 0.031787,
-     "end_time": "2026-06-09T09:39:03.245926",
+     "duration": 0.018016,
+     "end_time": "2026-06-22T19:16:00.228468",
      "exception": false,
-     "start_time": "2026-06-09T09:39:03.214139",
+     "start_time": "2026-06-22T19:16:00.210452",
      "status": "completed"
     },
     "tags": []
@@ -4179,10 +4083,10 @@
    "id": "af5487bb",
    "metadata": {
     "papermill": {
-     "duration": 0.039996,
-     "end_time": "2026-06-09T09:39:03.324871",
+     "duration": 0.017068,
+     "end_time": "2026-06-22T19:16:00.263972",
      "exception": false,
-     "start_time": "2026-06-09T09:39:03.284875",
+     "start_time": "2026-06-22T19:16:00.246904",
      "status": "completed"
     },
     "tags": []
@@ -4205,10 +4109,10 @@
    "id": "qrpczbu0bnm",
    "metadata": {
     "papermill": {
-     "duration": 0.030856,
-     "end_time": "2026-06-09T09:39:03.389827",
+     "duration": 0.024,
+     "end_time": "2026-06-22T19:16:00.304904",
      "exception": false,
-     "start_time": "2026-06-09T09:39:03.358971",
+     "start_time": "2026-06-22T19:16:00.280904",
      "status": "completed"
     },
     "tags": []
@@ -4236,16 +4140,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:03.469268Z",
-     "iopub.status.busy": "2026-06-09T09:39:03.468734Z",
-     "iopub.status.idle": "2026-06-09T09:39:04.689755Z",
-     "shell.execute_reply": "2026-06-09T09:39:04.673513Z"
+     "iopub.execute_input": "2026-06-22T19:16:00.343422Z",
+     "iopub.status.busy": "2026-06-22T19:16:00.343422Z",
+     "iopub.status.idle": "2026-06-22T19:16:01.043519Z",
+     "shell.execute_reply": "2026-06-22T19:16:01.039519Z"
     },
     "papermill": {
-     "duration": 1.262093,
-     "end_time": "2026-06-09T09:39:04.689941",
+     "duration": 0.72061,
+     "end_time": "2026-06-22T19:16:01.043519",
      "exception": false,
-     "start_time": "2026-06-09T09:39:03.427848",
+     "start_time": "2026-06-22T19:16:00.322909",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4277,38 +4181,6 @@
      "output_type": "stream",
      "text": [
       "Estimations :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_15_73.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -4780,10 +4652,10 @@
    "id": "v3r2vdr56k",
    "metadata": {
     "papermill": {
-     "duration": 0.039,
-     "end_time": "2026-06-09T09:39:04.779624",
+     "duration": 0.022001,
+     "end_time": "2026-06-22T19:16:01.085520",
      "exception": false,
-     "start_time": "2026-06-09T09:39:04.740624",
+     "start_time": "2026-06-22T19:16:01.063519",
      "status": "completed"
     },
     "tags": []
@@ -4820,10 +4692,10 @@
    "id": "vo8ev1ov9x",
    "metadata": {
     "papermill": {
-     "duration": 0.037004,
-     "end_time": "2026-06-09T09:39:04.854386",
+     "duration": 0.021004,
+     "end_time": "2026-06-22T19:16:01.127524",
      "exception": false,
-     "start_time": "2026-06-09T09:39:04.817382",
+     "start_time": "2026-06-22T19:16:01.106520",
      "status": "completed"
     },
     "tags": []
@@ -4851,16 +4723,16 @@
    "id": "n2ogxky9k6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:04.937142Z",
-     "iopub.status.busy": "2026-06-09T09:39:04.936361Z",
-     "iopub.status.idle": "2026-06-09T09:39:05.014922Z",
-     "shell.execute_reply": "2026-06-09T09:39:05.015283Z"
+     "iopub.execute_input": "2026-06-22T19:16:01.167659Z",
+     "iopub.status.busy": "2026-06-22T19:16:01.167659Z",
+     "iopub.status.idle": "2026-06-22T19:16:01.271288Z",
+     "shell.execute_reply": "2026-06-22T19:16:01.270617Z"
     },
     "papermill": {
-     "duration": 0.120458,
-     "end_time": "2026-06-09T09:39:05.015469",
+     "duration": 0.12463,
+     "end_time": "2026-06-22T19:16:01.271288",
      "exception": false,
-     "start_time": "2026-06-09T09:39:04.895011",
+     "start_time": "2026-06-22T19:16:01.146658",
      "status": "completed"
     },
     "tags": [],
@@ -4872,14 +4744,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_18_46_15_73.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_00_40.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"313pt\" height=\"535pt\"\r\n",
@@ -5083,8 +4955,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -5096,7 +4968,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -5111,10 +4983,10 @@
    "id": "21617812",
    "metadata": {
     "papermill": {
-     "duration": 0.058551,
-     "end_time": "2026-06-09T09:39:05.114979",
+     "duration": 0.021998,
+     "end_time": "2026-06-22T19:16:01.313516",
      "exception": false,
-     "start_time": "2026-06-09T09:39:05.056428",
+     "start_time": "2026-06-22T19:16:01.291518",
      "status": "completed"
     },
     "tags": []
@@ -5132,16 +5004,16 @@
    "id": "9d7o2300545",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:05.226356Z",
-     "iopub.status.busy": "2026-06-09T09:39:05.225812Z",
-     "iopub.status.idle": "2026-06-09T09:39:06.537935Z",
-     "shell.execute_reply": "2026-06-09T09:39:06.504270Z"
+     "iopub.execute_input": "2026-06-22T19:16:01.358754Z",
+     "iopub.status.busy": "2026-06-22T19:16:01.357832Z",
+     "iopub.status.idle": "2026-06-22T19:16:01.998393Z",
+     "shell.execute_reply": "2026-06-22T19:16:01.988492Z"
     },
     "papermill": {
-     "duration": 1.362654,
-     "end_time": "2026-06-09T09:39:06.538128",
+     "duration": 0.663526,
+     "end_time": "2026-06-22T19:16:01.999046",
      "exception": false,
-     "start_time": "2026-06-09T09:39:05.175474",
+     "start_time": "2026-06-22T19:16:01.335520",
      "status": "completed"
     },
     "tags": [],
@@ -5178,38 +5050,6 @@
      "output_type": "stream",
      "text": [
       "Estimations :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_16_87.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -5661,10 +5501,10 @@
    "id": "754ff5d2",
    "metadata": {
     "papermill": {
-     "duration": 0.046983,
-     "end_time": "2026-06-09T09:39:06.628765",
+     "duration": 0.024639,
+     "end_time": "2026-06-22T19:16:02.049136",
      "exception": false,
-     "start_time": "2026-06-09T09:39:06.581782",
+     "start_time": "2026-06-22T19:16:02.024497",
      "status": "completed"
     },
     "tags": []
@@ -5679,16 +5519,16 @@
    "id": "spbj44wip9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:06.746982Z",
-     "iopub.status.busy": "2026-06-09T09:39:06.746420Z",
-     "iopub.status.idle": "2026-06-09T09:39:06.836468Z",
-     "shell.execute_reply": "2026-06-09T09:39:06.836935Z"
+     "iopub.execute_input": "2026-06-22T19:16:02.098924Z",
+     "iopub.status.busy": "2026-06-22T19:16:02.098924Z",
+     "iopub.status.idle": "2026-06-22T19:16:02.199826Z",
+     "shell.execute_reply": "2026-06-22T19:16:02.199826Z"
     },
     "papermill": {
-     "duration": 0.151902,
-     "end_time": "2026-06-09T09:39:06.837142",
+     "duration": 0.126578,
+     "end_time": "2026-06-22T19:16:02.199826",
      "exception": false,
-     "start_time": "2026-06-09T09:39:06.685240",
+     "start_time": "2026-06-22T19:16:02.073248",
      "status": "completed"
     },
     "tags": [],
@@ -5700,14 +5540,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_18_46_16_87.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_01_42.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"330pt\" height=\"535pt\"\r\n",
@@ -5911,8 +5751,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -5924,7 +5764,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -5939,10 +5779,10 @@
    "id": "zmk2ata5wth",
    "metadata": {
     "papermill": {
-     "duration": 0.076379,
-     "end_time": "2026-06-09T09:39:06.971372",
+     "duration": 0.025106,
+     "end_time": "2026-06-22T19:16:02.250592",
      "exception": false,
-     "start_time": "2026-06-09T09:39:06.894993",
+     "start_time": "2026-06-22T19:16:02.225486",
      "status": "completed"
     },
     "tags": []
@@ -5967,10 +5807,10 @@
    "id": "ywp5qszj2y",
    "metadata": {
     "papermill": {
-     "duration": 0.082034,
-     "end_time": "2026-06-09T09:39:07.133634",
+     "duration": 0.024998,
+     "end_time": "2026-06-22T19:16:02.298888",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.051600",
+     "start_time": "2026-06-22T19:16:02.273890",
      "status": "completed"
     },
     "tags": []
@@ -5997,10 +5837,10 @@
    "id": "07a89284",
    "metadata": {
     "papermill": {
-     "duration": 0.060767,
-     "end_time": "2026-06-09T09:39:07.261311",
+     "duration": 0.023513,
+     "end_time": "2026-06-22T19:16:02.346402",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.200544",
+     "start_time": "2026-06-22T19:16:02.322889",
      "status": "completed"
     },
     "tags": []
@@ -6022,10 +5862,10 @@
    "id": "ojqirwmvivb",
    "metadata": {
     "papermill": {
-     "duration": 0.062553,
-     "end_time": "2026-06-09T09:39:07.383608",
+     "duration": 0.02504,
+     "end_time": "2026-06-22T19:16:02.396446",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.321055",
+     "start_time": "2026-06-22T19:16:02.371406",
      "status": "completed"
     },
     "tags": []
@@ -6058,10 +5898,10 @@
    "id": "34cb88fb",
    "metadata": {
     "papermill": {
-     "duration": 0.077079,
-     "end_time": "2026-06-09T09:39:07.523101",
+     "duration": 0.023832,
+     "end_time": "2026-06-22T19:16:02.444940",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.446022",
+     "start_time": "2026-06-22T19:16:02.421108",
      "status": "completed"
     },
     "tags": []
@@ -6086,10 +5926,10 @@
    "id": "9i2dyfdr6q9",
    "metadata": {
     "papermill": {
-     "duration": 0.055117,
-     "end_time": "2026-06-09T09:39:07.647942",
+     "duration": 0.024002,
+     "end_time": "2026-06-22T19:16:02.494947",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.592825",
+     "start_time": "2026-06-22T19:16:02.470945",
      "status": "completed"
     },
     "tags": []
@@ -6121,16 +5961,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:07.764325Z",
-     "iopub.status.busy": "2026-06-09T09:39:07.763780Z",
-     "iopub.status.idle": "2026-06-09T09:39:08.648193Z",
-     "shell.execute_reply": "2026-06-09T09:39:08.647824Z"
+     "iopub.execute_input": "2026-06-22T19:16:02.548462Z",
+     "iopub.status.busy": "2026-06-22T19:16:02.548462Z",
+     "iopub.status.idle": "2026-06-22T19:16:03.025013Z",
+     "shell.execute_reply": "2026-06-22T19:16:03.024464Z"
     },
     "papermill": {
-     "duration": 0.943179,
-     "end_time": "2026-06-09T09:39:08.648385",
+     "duration": 0.50399,
+     "end_time": "2026-06-22T19:16:03.025013",
      "exception": false,
-     "start_time": "2026-06-09T09:39:07.705206",
+     "start_time": "2026-06-22T19:16:02.521023",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6154,38 +5994,6 @@
      "output_type": "stream",
      "text": [
       "Resultats : Q1=T, Q2=T, Q3=F, Q4=T, Q5=F\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_18_46_17_98.gv\"\n",
       "\r\n"
      ]
     },
@@ -6298,10 +6106,10 @@
    "id": "diat8qdrbpt",
    "metadata": {
     "papermill": {
-     "duration": 0.053277,
-     "end_time": "2026-06-09T09:39:08.757271",
+     "duration": 0.02326,
+     "end_time": "2026-06-22T19:16:03.073749",
      "exception": false,
-     "start_time": "2026-06-09T09:39:08.703994",
+     "start_time": "2026-06-22T19:16:03.050489",
      "status": "completed"
     },
     "tags": []
@@ -6333,10 +6141,10 @@
    "id": "qlxdvvpoxyj",
    "metadata": {
     "papermill": {
-     "duration": 0.05243,
-     "end_time": "2026-06-09T09:39:08.865175",
+     "duration": 0.022215,
+     "end_time": "2026-06-22T19:16:03.118558",
      "exception": false,
-     "start_time": "2026-06-09T09:39:08.812745",
+     "start_time": "2026-06-22T19:16:03.096343",
      "status": "completed"
     },
     "tags": []
@@ -6368,19 +6176,19 @@
    "id": "qrvzgbgjpk",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:09.000400Z",
-     "iopub.status.busy": "2026-06-09T09:39:08.999918Z",
-     "iopub.status.idle": "2026-06-09T09:39:09.121364Z",
-     "shell.execute_reply": "2026-06-09T09:39:09.121015Z"
+     "iopub.execute_input": "2026-06-22T19:16:03.170812Z",
+     "iopub.status.busy": "2026-06-22T19:16:03.169812Z",
+     "iopub.status.idle": "2026-06-22T19:16:03.270002Z",
+     "shell.execute_reply": "2026-06-22T19:16:03.270002Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.189929,
-     "end_time": "2026-06-09T09:39:09.121746",
+     "duration": 0.12452,
+     "end_time": "2026-06-22T19:16:03.270002",
      "exception": false,
-     "start_time": "2026-06-09T09:39:08.931817",
+     "start_time": "2026-06-22T19:16:03.145482",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6395,14 +6203,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_18_46_17_98.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_02_60.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"855pt\" height=\"453pt\"\r\n",
@@ -6821,8 +6629,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -6834,7 +6642,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -6849,10 +6657,10 @@
    "id": "p8ydm8z0cti",
    "metadata": {
     "papermill": {
-     "duration": 0.062749,
-     "end_time": "2026-06-09T09:39:09.254863",
+     "duration": 0.024881,
+     "end_time": "2026-06-22T19:16:03.319883",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.192114",
+     "start_time": "2026-06-22T19:16:03.295002",
      "status": "completed"
     },
     "tags": []
@@ -6881,10 +6689,10 @@
    "id": "f670c385",
    "metadata": {
     "papermill": {
-     "duration": 0.06805,
-     "end_time": "2026-06-09T09:39:09.386257",
+     "duration": 0.026001,
+     "end_time": "2026-06-22T19:16:03.370673",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.318207",
+     "start_time": "2026-06-22T19:16:03.344672",
      "status": "completed"
     },
     "tags": []
@@ -6918,10 +6726,10 @@
    "id": "h7zoj7d20kv",
    "metadata": {
     "papermill": {
-     "duration": 0.067451,
-     "end_time": "2026-06-09T09:39:09.537797",
+     "duration": 0.027965,
+     "end_time": "2026-06-22T19:16:03.424677",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.470346",
+     "start_time": "2026-06-22T19:16:03.396712",
      "status": "completed"
     },
     "tags": []
@@ -6948,19 +6756,19 @@
    "id": "37ww41xdon2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:09.683560Z",
-     "iopub.status.busy": "2026-06-09T09:39:09.683048Z",
-     "iopub.status.idle": "2026-06-09T09:39:09.790372Z",
-     "shell.execute_reply": "2026-06-09T09:39:09.789977Z"
+     "iopub.execute_input": "2026-06-22T19:16:03.475223Z",
+     "iopub.status.busy": "2026-06-22T19:16:03.475223Z",
+     "iopub.status.idle": "2026-06-22T19:16:03.519569Z",
+     "shell.execute_reply": "2026-06-22T19:16:03.519569Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.180284,
-     "end_time": "2026-06-09T09:39:09.790594",
+     "duration": 0.071643,
+     "end_time": "2026-06-22T19:16:03.519569",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.610310",
+     "start_time": "2026-06-22T19:16:03.447926",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6976,7 +6784,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fichiers .gv et .svg nettoyes : 30\r\n"
+      "Fichiers .gv et .svg nettoyes : 85\r\n"
      ]
     }
    ],
@@ -6991,10 +6799,10 @@
    "id": "d6c96c7e",
    "metadata": {
     "papermill": {
-     "duration": 0.064532,
-     "end_time": "2026-06-09T09:39:09.917081",
+     "duration": 0.027001,
+     "end_time": "2026-06-22T19:16:03.571654",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.852549",
+     "start_time": "2026-06-22T19:16:03.544653",
      "status": "completed"
     },
     "tags": []
@@ -7022,19 +6830,19 @@
    "id": "fe2a415e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:10.055080Z",
-     "iopub.status.busy": "2026-06-09T09:39:10.054509Z",
-     "iopub.status.idle": "2026-06-09T09:39:10.150092Z",
-     "shell.execute_reply": "2026-06-09T09:39:10.149676Z"
+     "iopub.execute_input": "2026-06-22T19:16:03.623202Z",
+     "iopub.status.busy": "2026-06-22T19:16:03.622685Z",
+     "iopub.status.idle": "2026-06-22T19:16:03.657790Z",
+     "shell.execute_reply": "2026-06-22T19:16:03.657274Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.161382,
-     "end_time": "2026-06-09T09:39:10.150280",
+     "duration": 0.061135,
+     "end_time": "2026-06-22T19:16:03.657790",
      "exception": false,
-     "start_time": "2026-06-09T09:39:09.988898",
+     "start_time": "2026-06-22T19:16:03.596655",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -7083,10 +6891,10 @@
    "id": "44d03a9a",
    "metadata": {
     "papermill": {
-     "duration": 0.088303,
-     "end_time": "2026-06-09T09:39:10.325532",
+     "duration": 0.025126,
+     "end_time": "2026-06-22T19:16:03.711737",
      "exception": false,
-     "start_time": "2026-06-09T09:39:10.237229",
+     "start_time": "2026-06-22T19:16:03.686611",
      "status": "completed"
     },
     "tags": []
@@ -7132,16 +6940,16 @@
    "id": "d90576d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:10.465129Z",
-     "iopub.status.busy": "2026-06-09T09:39:10.464579Z",
-     "iopub.status.idle": "2026-06-09T09:39:10.550141Z",
-     "shell.execute_reply": "2026-06-09T09:39:10.549765Z"
+     "iopub.execute_input": "2026-06-22T19:16:03.760834Z",
+     "iopub.status.busy": "2026-06-22T19:16:03.760834Z",
+     "iopub.status.idle": "2026-06-22T19:16:03.789536Z",
+     "shell.execute_reply": "2026-06-22T19:16:03.789536Z"
     },
     "papermill": {
-     "duration": 0.15369,
-     "end_time": "2026-06-09T09:39:10.550324",
+     "duration": 0.05347,
+     "end_time": "2026-06-22T19:16:03.789536",
      "exception": false,
-     "start_time": "2026-06-09T09:39:10.396634",
+     "start_time": "2026-06-22T19:16:03.736066",
      "status": "completed"
     },
     "tags": []
@@ -7182,10 +6990,10 @@
    "id": "b15384df",
    "metadata": {
     "papermill": {
-     "duration": 0.073193,
-     "end_time": "2026-06-09T09:39:10.687171",
+     "duration": 0.025038,
+     "end_time": "2026-06-22T19:16:03.841759",
      "exception": false,
-     "start_time": "2026-06-09T09:39:10.613978",
+     "start_time": "2026-06-22T19:16:03.816721",
      "status": "completed"
     },
     "tags": []
@@ -7215,16 +7023,16 @@
    "id": "5b18e940",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:10.828213Z",
-     "iopub.status.busy": "2026-06-09T09:39:10.827495Z",
-     "iopub.status.idle": "2026-06-09T09:39:10.884519Z",
-     "shell.execute_reply": "2026-06-09T09:39:10.884131Z"
+     "iopub.execute_input": "2026-06-22T19:16:03.894718Z",
+     "iopub.status.busy": "2026-06-22T19:16:03.894718Z",
+     "iopub.status.idle": "2026-06-22T19:16:03.919401Z",
+     "shell.execute_reply": "2026-06-22T19:16:03.919401Z"
     },
     "papermill": {
-     "duration": 0.121473,
-     "end_time": "2026-06-09T09:39:10.884709",
+     "duration": 0.054034,
+     "end_time": "2026-06-22T19:16:03.920435",
      "exception": false,
-     "start_time": "2026-06-09T09:39:10.763236",
+     "start_time": "2026-06-22T19:16:03.866401",
      "status": "completed"
     },
     "tags": []
@@ -7270,10 +7078,10 @@
    "id": "d866a5ed",
    "metadata": {
     "papermill": {
-     "duration": 0.065279,
-     "end_time": "2026-06-09T09:39:10.994638",
+     "duration": 0.024456,
+     "end_time": "2026-06-22T19:16:03.969680",
      "exception": false,
-     "start_time": "2026-06-09T09:39:10.929359",
+     "start_time": "2026-06-22T19:16:03.945224",
      "status": "completed"
     },
     "tags": []
@@ -7317,18 +7125,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 32.758829,
-   "end_time": "2026-06-09T09:39:11.616425",
+   "duration": 14.824848,
+   "end_time": "2026-06-22T19:16:04.345504",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-5-Skills-IRT.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-5-Skills-IRT.ipynb",
+   "input_path": "Infer-5-Skills-IRT.ipynb",
+   "output_path": "Infer-5-Skills-IRT.ipynb",
    "parameters": {},
-   "start_time": "2026-06-09T09:38:38.857596",
+   "start_time": "2026-06-22T19:15:49.520656",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-6-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-6-TrueSkill.ipynb
@@ -5,10 +5,10 @@
    "id": "579661f9",
    "metadata": {
     "papermill": {
-     "duration": 0.053474,
-     "end_time": "2026-06-09T04:39:37.365859",
+     "duration": 0.013103,
+     "end_time": "2026-06-22T19:16:09.166648",
      "exception": false,
-     "start_time": "2026-06-09T04:39:37.312385",
+     "start_time": "2026-06-22T19:16:09.153545",
      "status": "completed"
     },
     "tags": []
@@ -46,10 +46,10 @@
    "id": "47689868",
    "metadata": {
     "papermill": {
-     "duration": 0.005967,
-     "end_time": "2026-06-09T04:39:37.376282",
+     "duration": 0.011642,
+     "end_time": "2026-06-22T19:16:09.192191",
      "exception": false,
-     "start_time": "2026-06-09T04:39:37.370315",
+     "start_time": "2026-06-22T19:16:09.180549",
      "status": "completed"
     },
     "tags": []
@@ -69,16 +69,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:37.393300Z",
-     "iopub.status.busy": "2026-06-09T04:39:37.390050Z",
-     "iopub.status.idle": "2026-06-09T04:39:40.016236Z",
-     "shell.execute_reply": "2026-06-09T04:39:40.010934Z"
+     "iopub.execute_input": "2026-06-22T19:16:09.228490Z",
+     "iopub.status.busy": "2026-06-22T19:16:09.222543Z",
+     "iopub.status.idle": "2026-06-22T19:16:12.211166Z",
+     "shell.execute_reply": "2026-06-22T19:16:12.208166Z"
     },
     "papermill": {
-     "duration": 2.635944,
-     "end_time": "2026-06-09T04:39:40.016236",
+     "duration": 3.008009,
+     "end_time": "2026-06-22T19:16:12.211166",
      "exception": false,
-     "start_time": "2026-06-09T04:39:37.380292",
+     "start_time": "2026-06-22T19:16:09.203157",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -95,7 +95,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-6096.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-88264.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -140,12 +140,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.83.164.85:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '6096.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '88264.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -242,10 +242,10 @@
    "id": "9ed34a0f",
    "metadata": {
     "papermill": {
-     "duration": 0.00499,
-     "end_time": "2026-06-09T04:39:40.027662",
+     "duration": 0.008,
+     "end_time": "2026-06-22T19:16:12.227164",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.022672",
+     "start_time": "2026-06-22T19:16:12.219164",
      "status": "completed"
     },
     "tags": []
@@ -260,19 +260,19 @@
    "id": "0lw5pp1r99q",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:40.039579Z",
-     "iopub.status.busy": "2026-06-09T04:39:40.039579Z",
-     "iopub.status.idle": "2026-06-09T04:39:40.450271Z",
-     "shell.execute_reply": "2026-06-09T04:39:40.450271Z"
+     "iopub.execute_input": "2026-06-22T19:16:12.246168Z",
+     "iopub.status.busy": "2026-06-22T19:16:12.246168Z",
+     "iopub.status.idle": "2026-06-22T19:16:12.868470Z",
+     "shell.execute_reply": "2026-06-22T19:16:12.868470Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.416793,
-     "end_time": "2026-06-09T04:39:40.450271",
+     "duration": 0.632305,
+     "end_time": "2026-06-22T19:16:12.868470",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.033478",
+     "start_time": "2026-06-22T19:16:12.236165",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -304,10 +304,10 @@
    "id": "0eaylal4428b",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:40.465936",
+     "duration": 0.007999,
+     "end_time": "2026-06-22T19:16:12.885469",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.465936",
+     "start_time": "2026-06-22T19:16:12.877470",
      "status": "completed"
     },
     "tags": []
@@ -331,10 +331,10 @@
    "id": "875a6a70",
    "metadata": {
     "papermill": {
-     "duration": 0.018056,
-     "end_time": "2026-06-09T04:39:40.483992",
+     "duration": 0.008,
+     "end_time": "2026-06-22T19:16:12.901470",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.465936",
+     "start_time": "2026-06-22T19:16:12.893470",
      "status": "completed"
     },
     "tags": []
@@ -374,10 +374,10 @@
    "id": "k5j8rq5fmar",
    "metadata": {
     "papermill": {
-     "duration": 0.005992,
-     "end_time": "2026-06-09T04:39:40.494998",
+     "duration": 0.007,
+     "end_time": "2026-06-22T19:16:12.916470",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.489006",
+     "start_time": "2026-06-22T19:16:12.909470",
      "status": "completed"
     },
     "tags": []
@@ -402,10 +402,10 @@
    "id": "l30e2s5e4oj",
    "metadata": {
     "papermill": {
-     "duration": 0.005097,
-     "end_time": "2026-06-09T04:39:40.505185",
+     "duration": 0.01,
+     "end_time": "2026-06-22T19:16:12.935471",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.500088",
+     "start_time": "2026-06-22T19:16:12.925471",
      "status": "completed"
     },
     "tags": []
@@ -434,16 +434,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:40.517440Z",
-     "iopub.status.busy": "2026-06-09T04:39:40.517440Z",
-     "iopub.status.idle": "2026-06-09T04:39:40.609053Z",
-     "shell.execute_reply": "2026-06-09T04:39:40.609053Z"
+     "iopub.execute_input": "2026-06-22T19:16:12.960147Z",
+     "iopub.status.busy": "2026-06-22T19:16:12.959147Z",
+     "iopub.status.idle": "2026-06-22T19:16:13.114892Z",
+     "shell.execute_reply": "2026-06-22T19:16:13.114892Z"
     },
     "papermill": {
-     "duration": 0.099017,
-     "end_time": "2026-06-09T04:39:40.609053",
+     "duration": 0.168758,
+     "end_time": "2026-06-22T19:16:13.114892",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.510036",
+     "start_time": "2026-06-22T19:16:12.946134",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -491,10 +491,10 @@
    "id": "alzcv9uqham",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:40.624917",
+     "duration": 0.010992,
+     "end_time": "2026-06-22T19:16:13.137896",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.624917",
+     "start_time": "2026-06-22T19:16:13.126904",
      "status": "completed"
     },
     "tags": []
@@ -524,10 +524,10 @@
    "id": "y6gz61p58sh",
    "metadata": {
     "papermill": {
-     "duration": 0.005726,
-     "end_time": "2026-06-09T04:39:40.645481",
+     "duration": 0.009925,
+     "end_time": "2026-06-22T19:16:13.160410",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.639755",
+     "start_time": "2026-06-22T19:16:13.150485",
      "status": "completed"
     },
     "tags": []
@@ -547,16 +547,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:40.657502Z",
-     "iopub.status.busy": "2026-06-09T04:39:40.657502Z",
-     "iopub.status.idle": "2026-06-09T04:39:41.795355Z",
-     "shell.execute_reply": "2026-06-09T04:39:41.795355Z"
+     "iopub.execute_input": "2026-06-22T19:16:13.183433Z",
+     "iopub.status.busy": "2026-06-22T19:16:13.183433Z",
+     "iopub.status.idle": "2026-06-22T19:16:14.902705Z",
+     "shell.execute_reply": "2026-06-22T19:16:14.902705Z"
     },
     "papermill": {
-     "duration": 1.143849,
-     "end_time": "2026-06-09T04:39:41.795355",
+     "duration": 1.732292,
+     "end_time": "2026-06-22T19:16:14.902705",
      "exception": false,
-     "start_time": "2026-06-09T04:39:40.651506",
+     "start_time": "2026-06-22T19:16:13.170413",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -568,38 +568,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_24_96.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -716,10 +684,10 @@
    "id": "07c124d3",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:41.800064",
+     "duration": 0.009048,
+     "end_time": "2026-06-22T19:16:14.921460",
      "exception": false,
-     "start_time": "2026-06-09T04:39:41.800064",
+     "start_time": "2026-06-22T19:16:14.912412",
      "status": "completed"
     },
     "tags": []
@@ -749,19 +717,19 @@
    "id": "3rl8qj8klra",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:41.813359Z",
-     "iopub.status.busy": "2026-06-09T04:39:41.813359Z",
-     "iopub.status.idle": "2026-06-09T04:39:41.884589Z",
-     "shell.execute_reply": "2026-06-09T04:39:41.884589Z"
+     "iopub.execute_input": "2026-06-22T19:16:14.941800Z",
+     "iopub.status.busy": "2026-06-22T19:16:14.941272Z",
+     "iopub.status.idle": "2026-06-22T19:16:15.072464Z",
+     "shell.execute_reply": "2026-06-22T19:16:15.073465Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.07123,
-     "end_time": "2026-06-09T04:39:41.884589",
+     "duration": 0.142612,
+     "end_time": "2026-06-22T19:16:15.073465",
      "exception": false,
-     "start_time": "2026-06-09T04:39:41.813359",
+     "start_time": "2026-06-22T19:16:14.930853",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -776,14 +744,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_19_46_24_96.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_13_32.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"458pt\" height=\"663pt\"\r\n",
@@ -1014,8 +982,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1027,7 +995,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1042,10 +1010,10 @@
    "id": "lay2atdwimg",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:41.888329",
+     "duration": 0.010224,
+     "end_time": "2026-06-22T19:16:15.092672",
      "exception": false,
-     "start_time": "2026-06-09T04:39:41.888329",
+     "start_time": "2026-06-22T19:16:15.082448",
      "status": "completed"
     },
     "tags": []
@@ -1078,10 +1046,10 @@
    "id": "ca5ef684",
    "metadata": {
     "papermill": {
-     "duration": 0.018829,
-     "end_time": "2026-06-09T04:39:41.907158",
+     "duration": 0.008893,
+     "end_time": "2026-06-22T19:16:15.110904",
      "exception": false,
-     "start_time": "2026-06-09T04:39:41.888329",
+     "start_time": "2026-06-22T19:16:15.102011",
      "status": "completed"
     },
     "tags": []
@@ -1101,10 +1069,10 @@
    "id": "wyc487e9t6q",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:41.907158",
+     "duration": 0.008822,
+     "end_time": "2026-06-22T19:16:15.128521",
      "exception": false,
-     "start_time": "2026-06-09T04:39:41.907158",
+     "start_time": "2026-06-22T19:16:15.119699",
      "status": "completed"
     },
     "tags": []
@@ -1124,16 +1092,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:41.929417Z",
-     "iopub.status.busy": "2026-06-09T04:39:41.929417Z",
-     "iopub.status.idle": "2026-06-09T04:39:42.153419Z",
-     "shell.execute_reply": "2026-06-09T04:39:42.153419Z"
+     "iopub.execute_input": "2026-06-22T19:16:15.152002Z",
+     "iopub.status.busy": "2026-06-22T19:16:15.152002Z",
+     "iopub.status.idle": "2026-06-22T19:16:15.652104Z",
+     "shell.execute_reply": "2026-06-22T19:16:15.652104Z"
     },
     "papermill": {
-     "duration": 0.230982,
-     "end_time": "2026-06-09T04:39:42.153419",
+     "duration": 0.513764,
+     "end_time": "2026-06-22T19:16:15.652618",
      "exception": false,
-     "start_time": "2026-06-09T04:39:41.922437",
+     "start_time": "2026-06-22T19:16:15.138854",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1145,38 +1113,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_27_52.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1266,10 +1202,10 @@
    "id": "kuhmzxafjd",
    "metadata": {
     "papermill": {
-     "duration": 0.014787,
-     "end_time": "2026-06-09T04:39:42.168206",
+     "duration": 0.009358,
+     "end_time": "2026-06-22T19:16:15.672858",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.153419",
+     "start_time": "2026-06-22T19:16:15.663500",
      "status": "completed"
     },
     "tags": []
@@ -1296,10 +1232,10 @@
    "id": "58ebbc5f",
    "metadata": {
     "papermill": {
-     "duration": 0.003286,
-     "end_time": "2026-06-09T04:39:42.175512",
+     "duration": 0.009377,
+     "end_time": "2026-06-22T19:16:15.692738",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.172226",
+     "start_time": "2026-06-22T19:16:15.683361",
      "status": "completed"
     },
     "tags": []
@@ -1329,16 +1265,16 @@
    "id": "86a9f7a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:42.188340Z",
-     "iopub.status.busy": "2026-06-09T04:39:42.188340Z",
-     "iopub.status.idle": "2026-06-09T04:39:42.207922Z",
-     "shell.execute_reply": "2026-06-09T04:39:42.207922Z"
+     "iopub.execute_input": "2026-06-22T19:16:15.715837Z",
+     "iopub.status.busy": "2026-06-22T19:16:15.715325Z",
+     "iopub.status.idle": "2026-06-22T19:16:15.763589Z",
+     "shell.execute_reply": "2026-06-22T19:16:15.763589Z"
     },
     "papermill": {
-     "duration": 0.03241,
-     "end_time": "2026-06-09T04:39:42.207922",
+     "duration": 0.061005,
+     "end_time": "2026-06-22T19:16:15.763589",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.175512",
+     "start_time": "2026-06-22T19:16:15.702584",
      "status": "completed"
     },
     "tags": []
@@ -1376,19 +1312,19 @@
    "id": "v2q81j2cud",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:42.220104Z",
-     "iopub.status.busy": "2026-06-09T04:39:42.220104Z",
-     "iopub.status.idle": "2026-06-09T04:39:42.233495Z",
-     "shell.execute_reply": "2026-06-09T04:39:42.233495Z"
+     "iopub.execute_input": "2026-06-22T19:16:15.785284Z",
+     "iopub.status.busy": "2026-06-22T19:16:15.784772Z",
+     "iopub.status.idle": "2026-06-22T19:16:15.894216Z",
+     "shell.execute_reply": "2026-06-22T19:16:15.894216Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.019609,
-     "end_time": "2026-06-09T04:39:42.233495",
+     "duration": 0.119889,
+     "end_time": "2026-06-22T19:16:15.894216",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.213886",
+     "start_time": "2026-06-22T19:16:15.774327",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1403,14 +1339,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_19_46_27_52.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_15_21.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"458pt\" height=\"745pt\"\r\n",
@@ -1693,8 +1629,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1706,7 +1642,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1721,10 +1657,10 @@
    "id": "uyluong4se",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-09T04:39:42.248703",
+     "duration": 0.010289,
+     "end_time": "2026-06-22T19:16:15.916699",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.248703",
+     "start_time": "2026-06-22T19:16:15.906410",
      "status": "completed"
     },
     "tags": []
@@ -1755,10 +1691,10 @@
    "id": "db748a66",
    "metadata": {
     "papermill": {
-     "duration": 0.006365,
-     "end_time": "2026-06-09T04:39:42.268680",
+     "duration": 0.010348,
+     "end_time": "2026-06-22T19:16:15.938212",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.262315",
+     "start_time": "2026-06-22T19:16:15.927864",
      "status": "completed"
     },
     "tags": []
@@ -1786,10 +1722,10 @@
    "id": "dekbpy6finu",
    "metadata": {
     "papermill": {
-     "duration": 0.005805,
-     "end_time": "2026-06-09T04:39:42.280204",
+     "duration": 0.010258,
+     "end_time": "2026-06-22T19:16:15.957789",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.274399",
+     "start_time": "2026-06-22T19:16:15.947531",
      "status": "completed"
     },
     "tags": []
@@ -1816,16 +1752,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:42.293245Z",
-     "iopub.status.busy": "2026-06-09T04:39:42.292246Z",
-     "iopub.status.idle": "2026-06-09T04:39:42.344053Z",
-     "shell.execute_reply": "2026-06-09T04:39:42.344053Z"
+     "iopub.execute_input": "2026-06-22T19:16:15.985178Z",
+     "iopub.status.busy": "2026-06-22T19:16:15.984664Z",
+     "iopub.status.idle": "2026-06-22T19:16:16.100837Z",
+     "shell.execute_reply": "2026-06-22T19:16:16.100837Z"
     },
     "papermill": {
-     "duration": 0.057842,
-     "end_time": "2026-06-09T04:39:42.344053",
+     "duration": 0.133276,
+     "end_time": "2026-06-22T19:16:16.100837",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.286211",
+     "start_time": "2026-06-22T19:16:15.967561",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1925,10 +1861,10 @@
    "id": "iijfn6pf7wg",
    "metadata": {
     "papermill": {
-     "duration": 0.005019,
-     "end_time": "2026-06-09T04:39:42.355576",
+     "duration": 0.01705,
+     "end_time": "2026-06-22T19:16:16.135902",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.350557",
+     "start_time": "2026-06-22T19:16:16.118852",
      "status": "completed"
     },
     "tags": []
@@ -1955,10 +1891,10 @@
    "id": "d0v4jrvltr4",
    "metadata": {
     "papermill": {
-     "duration": 0.00955,
-     "end_time": "2026-06-09T04:39:42.367937",
+     "duration": 0.012,
+     "end_time": "2026-06-22T19:16:16.159545",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.358387",
+     "start_time": "2026-06-22T19:16:16.147545",
      "status": "completed"
     },
     "tags": []
@@ -1978,16 +1914,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:42.378258Z",
-     "iopub.status.busy": "2026-06-09T04:39:42.378258Z",
-     "iopub.status.idle": "2026-06-09T04:39:43.497109Z",
-     "shell.execute_reply": "2026-06-09T04:39:43.497109Z"
+     "iopub.execute_input": "2026-06-22T19:16:16.180557Z",
+     "iopub.status.busy": "2026-06-22T19:16:16.180557Z",
+     "iopub.status.idle": "2026-06-22T19:16:18.059822Z",
+     "shell.execute_reply": "2026-06-22T19:16:18.059822Z"
     },
     "papermill": {
-     "duration": 1.123369,
-     "end_time": "2026-06-09T04:39:43.497109",
+     "duration": 1.891268,
+     "end_time": "2026-06-22T19:16:18.060825",
      "exception": false,
-     "start_time": "2026-06-09T04:39:42.373740",
+     "start_time": "2026-06-22T19:16:16.169557",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2200,10 +2136,10 @@
    "id": "0225333b",
    "metadata": {
     "papermill": {
-     "duration": 0.006205,
-     "end_time": "2026-06-09T04:39:43.518644",
+     "duration": 0.012419,
+     "end_time": "2026-06-22T19:16:18.085362",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.512439",
+     "start_time": "2026-06-22T19:16:18.072943",
      "status": "completed"
     },
     "tags": []
@@ -2237,10 +2173,10 @@
    "id": "5b01fcaf",
    "metadata": {
     "papermill": {
-     "duration": 0.006849,
-     "end_time": "2026-06-09T04:39:43.531604",
+     "duration": 0.011872,
+     "end_time": "2026-06-22T19:16:18.108167",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.524755",
+     "start_time": "2026-06-22T19:16:18.096295",
      "status": "completed"
     },
     "tags": []
@@ -2258,10 +2194,10 @@
    "id": "f581544x29m",
    "metadata": {
     "papermill": {
-     "duration": 0.006691,
-     "end_time": "2026-06-09T04:39:43.544112",
+     "duration": 0.011033,
+     "end_time": "2026-06-22T19:16:18.130330",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.537421",
+     "start_time": "2026-06-22T19:16:18.119297",
      "status": "completed"
     },
     "tags": []
@@ -2285,16 +2221,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:43.557611Z",
-     "iopub.status.busy": "2026-06-09T04:39:43.557611Z",
-     "iopub.status.idle": "2026-06-09T04:39:43.745083Z",
-     "shell.execute_reply": "2026-06-09T04:39:43.745083Z"
+     "iopub.execute_input": "2026-06-22T19:16:18.156087Z",
+     "iopub.status.busy": "2026-06-22T19:16:18.155486Z",
+     "iopub.status.idle": "2026-06-22T19:16:18.640370Z",
+     "shell.execute_reply": "2026-06-22T19:16:18.640370Z"
     },
     "papermill": {
-     "duration": 0.194784,
-     "end_time": "2026-06-09T04:39:43.745083",
+     "duration": 0.497862,
+     "end_time": "2026-06-22T19:16:18.640370",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.550299",
+     "start_time": "2026-06-22T19:16:18.142508",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2318,38 +2254,6 @@
      "output_type": "stream",
      "text": [
       "Equipe 1 (A+B) bat Equipe 2 (C+D)\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_31_01.gv\"\n",
       "\r\n"
      ]
     },
@@ -2449,10 +2353,10 @@
    "id": "dyauxp8p19",
    "metadata": {
     "papermill": {
-     "duration": 0.007001,
-     "end_time": "2026-06-09T04:39:43.759087",
+     "duration": 0.014542,
+     "end_time": "2026-06-22T19:16:18.670953",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.752086",
+     "start_time": "2026-06-22T19:16:18.656411",
      "status": "completed"
     },
     "tags": []
@@ -2484,19 +2388,19 @@
    "id": "uelhc4hpera",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:43.768103Z",
-     "iopub.status.busy": "2026-06-09T04:39:43.768103Z",
-     "iopub.status.idle": "2026-06-09T04:39:43.809905Z",
-     "shell.execute_reply": "2026-06-09T04:39:43.809905Z"
+     "iopub.execute_input": "2026-06-22T19:16:18.699733Z",
+     "iopub.status.busy": "2026-06-22T19:16:18.699733Z",
+     "iopub.status.idle": "2026-06-22T19:16:18.805291Z",
+     "shell.execute_reply": "2026-06-22T19:16:18.805291Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.047819,
-     "end_time": "2026-06-09T04:39:43.809905",
+     "duration": 0.120975,
+     "end_time": "2026-06-22T19:16:18.805291",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.762086",
+     "start_time": "2026-06-22T19:16:18.684316",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2511,14 +2415,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_19_46_31_01.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_18_22.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"633pt\" height=\"818pt\"\r\n",
@@ -2977,8 +2881,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2990,7 +2894,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -3005,10 +2909,10 @@
    "id": "iwjryyopcp",
    "metadata": {
     "papermill": {
-     "duration": 0.009851,
-     "end_time": "2026-06-09T04:39:43.834442",
+     "duration": 0.018889,
+     "end_time": "2026-06-22T19:16:18.845083",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.824591",
+     "start_time": "2026-06-22T19:16:18.826194",
      "status": "completed"
     },
     "tags": []
@@ -3053,10 +2957,10 @@
    "id": "9c685107",
    "metadata": {
     "papermill": {
-     "duration": 0.001666,
-     "end_time": "2026-06-09T04:39:43.842708",
+     "duration": 0.011394,
+     "end_time": "2026-06-22T19:16:18.869940",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.841042",
+     "start_time": "2026-06-22T19:16:18.858546",
      "status": "completed"
     },
     "tags": []
@@ -3075,10 +2979,10 @@
    "id": "wqqjqdtfsg8",
    "metadata": {
     "papermill": {
-     "duration": 0.007503,
-     "end_time": "2026-06-09T04:39:43.861246",
+     "duration": 0.012772,
+     "end_time": "2026-06-22T19:16:18.896448",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.853743",
+     "start_time": "2026-06-22T19:16:18.883676",
      "status": "completed"
     },
     "tags": []
@@ -3104,16 +3008,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:43.875798Z",
-     "iopub.status.busy": "2026-06-09T04:39:43.875798Z",
-     "iopub.status.idle": "2026-06-09T04:39:44.168937Z",
-     "shell.execute_reply": "2026-06-09T04:39:44.164659Z"
+     "iopub.execute_input": "2026-06-22T19:16:18.924646Z",
+     "iopub.status.busy": "2026-06-22T19:16:18.924106Z",
+     "iopub.status.idle": "2026-06-22T19:16:19.554571Z",
+     "shell.execute_reply": "2026-06-22T19:16:19.543982Z"
     },
     "papermill": {
-     "duration": 0.300755,
-     "end_time": "2026-06-09T04:39:44.168937",
+     "duration": 0.645353,
+     "end_time": "2026-06-22T19:16:19.554571",
      "exception": false,
-     "start_time": "2026-06-09T04:39:43.868182",
+     "start_time": "2026-06-22T19:16:18.909218",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3137,38 +3041,6 @@
      "output_type": "stream",
      "text": [
       "Classement : P1 > P2 > P3 > P4\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_19_46_31_86.gv\"\n",
       "\r\n"
      ]
     },
@@ -3616,10 +3488,10 @@
    "id": "shtyclc3of",
    "metadata": {
     "papermill": {
-     "duration": 0.007803,
-     "end_time": "2026-06-09T04:39:44.185993",
+     "duration": 0.01459,
+     "end_time": "2026-06-22T19:16:19.589529",
      "exception": false,
-     "start_time": "2026-06-09T04:39:44.178190",
+     "start_time": "2026-06-22T19:16:19.574939",
      "status": "completed"
     },
     "tags": []
@@ -3652,19 +3524,19 @@
    "id": "nvtk4uvma5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:44.206164Z",
-     "iopub.status.busy": "2026-06-09T04:39:44.205520Z",
-     "iopub.status.idle": "2026-06-09T04:39:44.243686Z",
-     "shell.execute_reply": "2026-06-09T04:39:44.243686Z"
+     "iopub.execute_input": "2026-06-22T19:16:19.620965Z",
+     "iopub.status.busy": "2026-06-22T19:16:19.620965Z",
+     "iopub.status.idle": "2026-06-22T19:16:19.718119Z",
+     "shell.execute_reply": "2026-06-22T19:16:19.718119Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.047754,
-     "end_time": "2026-06-09T04:39:44.243686",
+     "duration": 0.114127,
+     "end_time": "2026-06-22T19:16:19.719119",
      "exception": false,
-     "start_time": "2026-06-09T04:39:44.195932",
+     "start_time": "2026-06-22T19:16:19.604992",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3679,14 +3551,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_19_46_31_86.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_18_98.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"631pt\" height=\"745pt\"\r\n",
@@ -4273,8 +4145,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -4286,7 +4158,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -4301,10 +4173,10 @@
    "id": "e9ruk42t19",
    "metadata": {
     "papermill": {
-     "duration": 0.007979,
-     "end_time": "2026-06-09T04:39:44.259708",
+     "duration": 0.015007,
+     "end_time": "2026-06-22T19:16:19.749119",
      "exception": false,
-     "start_time": "2026-06-09T04:39:44.251729",
+     "start_time": "2026-06-22T19:16:19.734112",
      "status": "completed"
     },
     "tags": []
@@ -4349,10 +4221,10 @@
    "id": "6717b980",
    "metadata": {
     "papermill": {
-     "duration": 0.009523,
-     "end_time": "2026-06-09T04:39:44.277725",
+     "duration": 0.016006,
+     "end_time": "2026-06-22T19:16:19.781126",
      "exception": false,
-     "start_time": "2026-06-09T04:39:44.268202",
+     "start_time": "2026-06-22T19:16:19.765120",
      "status": "completed"
     },
     "tags": []
@@ -4366,10 +4238,10 @@
    "id": "w8v8gtwcdas",
    "metadata": {
     "papermill": {
-     "duration": 0.007915,
-     "end_time": "2026-06-09T04:39:44.293633",
+     "duration": 0.01479,
+     "end_time": "2026-06-22T19:16:19.811948",
      "exception": false,
-     "start_time": "2026-06-09T04:39:44.285718",
+     "start_time": "2026-06-22T19:16:19.797158",
      "status": "completed"
     },
     "tags": []
@@ -4397,16 +4269,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:44.310507Z",
-     "iopub.status.busy": "2026-06-09T04:39:44.310507Z",
-     "iopub.status.idle": "2026-06-09T04:39:45.999182Z",
-     "shell.execute_reply": "2026-06-09T04:39:45.999182Z"
+     "iopub.execute_input": "2026-06-22T19:16:19.846888Z",
+     "iopub.status.busy": "2026-06-22T19:16:19.846888Z",
+     "iopub.status.idle": "2026-06-22T19:16:22.245241Z",
+     "shell.execute_reply": "2026-06-22T19:16:22.245241Z"
     },
     "papermill": {
-     "duration": 1.704541,
-     "end_time": "2026-06-09T04:39:45.999182",
+     "duration": 2.415937,
+     "end_time": "2026-06-22T19:16:22.245830",
      "exception": false,
-     "start_time": "2026-06-09T04:39:44.294641",
+     "start_time": "2026-06-22T19:16:19.829893",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4708,10 +4580,10 @@
    "id": "7kyutl6wy4p",
    "metadata": {
     "papermill": {
-     "duration": 0.008993,
-     "end_time": "2026-06-09T04:39:46.023330",
+     "duration": 0.01701,
+     "end_time": "2026-06-22T19:16:22.279739",
      "exception": false,
-     "start_time": "2026-06-09T04:39:46.014337",
+     "start_time": "2026-06-22T19:16:22.262729",
      "status": "completed"
     },
     "tags": []
@@ -4749,10 +4621,10 @@
    "id": "07ec3e0a",
    "metadata": {
     "papermill": {
-     "duration": 0.009172,
-     "end_time": "2026-06-09T04:39:46.041650",
+     "duration": 0.017,
+     "end_time": "2026-06-22T19:16:22.312951",
      "exception": false,
-     "start_time": "2026-06-09T04:39:46.032478",
+     "start_time": "2026-06-22T19:16:22.295951",
      "status": "completed"
     },
     "tags": []
@@ -4777,10 +4649,10 @@
    "id": "a1rv4gbtby9",
    "metadata": {
     "papermill": {
-     "duration": 0.009942,
-     "end_time": "2026-06-09T04:39:46.061632",
+     "duration": 0.018363,
+     "end_time": "2026-06-22T19:16:22.349314",
      "exception": false,
-     "start_time": "2026-06-09T04:39:46.051690",
+     "start_time": "2026-06-22T19:16:22.330951",
      "status": "completed"
     },
     "tags": []
@@ -4807,16 +4679,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:46.084917Z",
-     "iopub.status.busy": "2026-06-09T04:39:46.084917Z",
-     "iopub.status.idle": "2026-06-09T04:39:48.546394Z",
-     "shell.execute_reply": "2026-06-09T04:39:48.546394Z"
+     "iopub.execute_input": "2026-06-22T19:16:22.390355Z",
+     "iopub.status.busy": "2026-06-22T19:16:22.390355Z",
+     "iopub.status.idle": "2026-06-22T19:16:25.517741Z",
+     "shell.execute_reply": "2026-06-22T19:16:25.517741Z"
     },
     "papermill": {
-     "duration": 2.47473,
-     "end_time": "2026-06-09T04:39:48.546394",
+     "duration": 3.149968,
+     "end_time": "2026-06-22T19:16:25.517741",
      "exception": false,
-     "start_time": "2026-06-09T04:39:46.071664",
+     "start_time": "2026-06-22T19:16:22.367773",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -5317,10 +5189,10 @@
    "id": "7a0mf202mw6",
    "metadata": {
     "papermill": {
-     "duration": 0.010534,
-     "end_time": "2026-06-09T04:39:48.567599",
+     "duration": 0.022755,
+     "end_time": "2026-06-22T19:16:25.561166",
      "exception": false,
-     "start_time": "2026-06-09T04:39:48.557065",
+     "start_time": "2026-06-22T19:16:25.538411",
      "status": "completed"
     },
     "tags": []
@@ -5353,10 +5225,10 @@
    "id": "f0ae2a09",
    "metadata": {
     "papermill": {
-     "duration": 0.011096,
-     "end_time": "2026-06-09T04:39:48.590239",
+     "duration": 0.020056,
+     "end_time": "2026-06-22T19:16:25.601922",
      "exception": false,
-     "start_time": "2026-06-09T04:39:48.579143",
+     "start_time": "2026-06-22T19:16:25.581866",
      "status": "completed"
     },
     "tags": []
@@ -5410,10 +5282,10 @@
    "id": "f045094e",
    "metadata": {
     "papermill": {
-     "duration": 0.011427,
-     "end_time": "2026-06-09T04:39:48.612669",
+     "duration": 0.020011,
+     "end_time": "2026-06-22T19:16:25.640410",
      "exception": false,
-     "start_time": "2026-06-09T04:39:48.601242",
+     "start_time": "2026-06-22T19:16:25.620399",
      "status": "completed"
     },
     "tags": []
@@ -5443,19 +5315,19 @@
    "id": "128c6231",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:48.635428Z",
-     "iopub.status.busy": "2026-06-09T04:39:48.635428Z",
-     "iopub.status.idle": "2026-06-09T04:39:48.654964Z",
-     "shell.execute_reply": "2026-06-09T04:39:48.654964Z"
+     "iopub.execute_input": "2026-06-22T19:16:25.680244Z",
+     "iopub.status.busy": "2026-06-22T19:16:25.680244Z",
+     "iopub.status.idle": "2026-06-22T19:16:25.718655Z",
+     "shell.execute_reply": "2026-06-22T19:16:25.718655Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.031048,
-     "end_time": "2026-06-09T04:39:48.654964",
+     "duration": 0.059417,
+     "end_time": "2026-06-22T19:16:25.718655",
      "exception": false,
-     "start_time": "2026-06-09T04:39:48.623916",
+     "start_time": "2026-06-22T19:16:25.659238",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -5498,10 +5370,10 @@
    "id": "7b6ab764",
    "metadata": {
     "papermill": {
-     "duration": 0.024169,
-     "end_time": "2026-06-09T04:39:48.679133",
+     "duration": 0.021934,
+     "end_time": "2026-06-22T19:16:25.764193",
      "exception": false,
-     "start_time": "2026-06-09T04:39:48.654964",
+     "start_time": "2026-06-22T19:16:25.742259",
      "status": "completed"
     },
     "tags": []
@@ -5535,16 +5407,16 @@
    "id": "5a71f244",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:48.702052Z",
-     "iopub.status.busy": "2026-06-09T04:39:48.702052Z",
-     "iopub.status.idle": "2026-06-09T04:39:48.715053Z",
-     "shell.execute_reply": "2026-06-09T04:39:48.715053Z"
+     "iopub.execute_input": "2026-06-22T19:16:25.805865Z",
+     "iopub.status.busy": "2026-06-22T19:16:25.805865Z",
+     "iopub.status.idle": "2026-06-22T19:16:25.839544Z",
+     "shell.execute_reply": "2026-06-22T19:16:25.839544Z"
     },
     "papermill": {
-     "duration": 0.025415,
-     "end_time": "2026-06-09T04:39:48.715053",
+     "duration": 0.055313,
+     "end_time": "2026-06-22T19:16:25.839544",
      "exception": false,
-     "start_time": "2026-06-09T04:39:48.689638",
+     "start_time": "2026-06-22T19:16:25.784231",
      "status": "completed"
     },
     "tags": []
@@ -5587,10 +5459,10 @@
    "id": "6a27ad43",
    "metadata": {
     "papermill": {
-     "duration": 0.00458,
-     "end_time": "2026-06-09T04:39:48.730639",
+     "duration": 0.019506,
+     "end_time": "2026-06-22T19:16:25.879151",
      "exception": false,
-     "start_time": "2026-06-09T04:39:48.726059",
+     "start_time": "2026-06-22T19:16:25.859645",
      "status": "completed"
     },
     "tags": []
@@ -5636,16 +5508,16 @@
    "id": "e8d6446a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:39:48.762583Z",
-     "iopub.status.busy": "2026-06-09T04:39:48.762583Z",
-     "iopub.status.idle": "2026-06-09T04:39:48.777922Z",
-     "shell.execute_reply": "2026-06-09T04:39:48.777922Z"
+     "iopub.execute_input": "2026-06-22T19:16:25.924410Z",
+     "iopub.status.busy": "2026-06-22T19:16:25.923418Z",
+     "iopub.status.idle": "2026-06-22T19:16:25.972885Z",
+     "shell.execute_reply": "2026-06-22T19:16:25.972885Z"
     },
     "papermill": {
-     "duration": 0.027526,
-     "end_time": "2026-06-09T04:39:48.777922",
+     "duration": 0.073424,
+     "end_time": "2026-06-22T19:16:25.972885",
      "exception": false,
-     "start_time": "2026-06-09T04:39:48.750396",
+     "start_time": "2026-06-22T19:16:25.899461",
      "status": "completed"
     },
     "tags": []
@@ -5724,10 +5596,10 @@
    "id": "82286da1",
    "metadata": {
     "papermill": {
-     "duration": 0.016172,
-     "end_time": "2026-06-09T04:39:48.809569",
+     "duration": 0.022996,
+     "end_time": "2026-06-22T19:16:26.017883",
      "exception": false,
-     "start_time": "2026-06-09T04:39:48.793397",
+     "start_time": "2026-06-22T19:16:25.994887",
      "status": "completed"
     },
     "tags": []
@@ -5769,14 +5641,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 13.797605,
-   "end_time": "2026-06-09T04:39:49.059654",
+   "duration": 19.348032,
+   "end_time": "2026-06-22T19:16:26.275965",
    "environment_variables": {},
    "exception": null,
    "input_path": "Infer-6-TrueSkill.ipynb",
    "output_path": "Infer-6-TrueSkill.ipynb",
    "parameters": {},
-   "start_time": "2026-06-09T04:39:35.262049",
+   "start_time": "2026-06-22T19:16:06.927933",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Classification.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Classification.ipynb
@@ -5,10 +5,10 @@
    "id": "7a615707",
    "metadata": {
     "papermill": {
-     "duration": 0.025067,
-     "end_time": "2026-06-04T06:28:02.496145",
+     "duration": 0.004485,
+     "end_time": "2026-06-22T19:16:30.101431",
      "exception": false,
-     "start_time": "2026-06-04T06:28:02.471078",
+     "start_time": "2026-06-22T19:16:30.096946",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "24ba6ecc",
    "metadata": {
     "papermill": {
-     "duration": 0.018343,
-     "end_time": "2026-06-04T06:28:02.534751",
+     "duration": 0.004008,
+     "end_time": "2026-06-22T19:16:30.108956",
      "exception": false,
-     "start_time": "2026-06-04T06:28:02.516408",
+     "start_time": "2026-06-22T19:16:30.104948",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:02.606693Z",
-     "iopub.status.busy": "2026-06-04T06:28:02.597961Z",
-     "iopub.status.idle": "2026-06-04T06:28:06.195975Z",
-     "shell.execute_reply": "2026-06-04T06:28:06.192467Z"
+     "iopub.execute_input": "2026-06-22T19:16:30.121957Z",
+     "iopub.status.busy": "2026-06-22T19:16:30.118956Z",
+     "iopub.status.idle": "2026-06-22T19:16:32.699077Z",
+     "shell.execute_reply": "2026-06-22T19:16:32.696077Z"
     },
     "papermill": {
-     "duration": 3.630108,
-     "end_time": "2026-06-04T06:28:06.196140",
+     "duration": 2.586129,
+     "end_time": "2026-06-22T19:16:32.699077",
      "exception": false,
-     "start_time": "2026-06-04T06:28:02.566032",
+     "start_time": "2026-06-22T19:16:30.112948",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -91,7 +91,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-36828.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-102296.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -136,12 +136,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.83.164.85:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '36828.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '102296.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -238,10 +238,10 @@
    "id": "f5ed5bb7",
    "metadata": {
     "papermill": {
-     "duration": 0.009493,
-     "end_time": "2026-06-04T06:28:06.215645",
+     "duration": 0.008,
+     "end_time": "2026-06-22T19:16:32.717096",
      "exception": false,
-     "start_time": "2026-06-04T06:28:06.206152",
+     "start_time": "2026-06-22T19:16:32.709096",
      "status": "completed"
     },
     "tags": []
@@ -256,19 +256,19 @@
    "id": "zfnap2t2rq",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:06.238368Z",
-     "iopub.status.busy": "2026-06-04T06:28:06.237937Z",
-     "iopub.status.idle": "2026-06-04T06:28:06.898884Z",
-     "shell.execute_reply": "2026-06-04T06:28:06.898163Z"
+     "iopub.execute_input": "2026-06-22T19:16:32.735709Z",
+     "iopub.status.busy": "2026-06-22T19:16:32.735709Z",
+     "iopub.status.idle": "2026-06-22T19:16:33.391455Z",
+     "shell.execute_reply": "2026-06-22T19:16:33.391455Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.67404,
-     "end_time": "2026-06-04T06:28:06.899000",
+     "duration": 0.665746,
+     "end_time": "2026-06-22T19:16:33.391455",
      "exception": false,
-     "start_time": "2026-06-04T06:28:06.224960",
+     "start_time": "2026-06-22T19:16:32.725709",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -301,10 +301,10 @@
    "id": "q8n6lx7eupr",
    "metadata": {
     "papermill": {
-     "duration": 0.009102,
-     "end_time": "2026-06-04T06:28:06.916481",
+     "duration": 0.009011,
+     "end_time": "2026-06-22T19:16:33.408273",
      "exception": false,
-     "start_time": "2026-06-04T06:28:06.907379",
+     "start_time": "2026-06-22T19:16:33.399262",
      "status": "completed"
     },
     "tags": []
@@ -332,10 +332,10 @@
    "id": "7d75b1ca",
    "metadata": {
     "papermill": {
-     "duration": 0.0083,
-     "end_time": "2026-06-04T06:28:06.934037",
+     "duration": 0.007737,
+     "end_time": "2026-06-22T19:16:33.424010",
      "exception": false,
-     "start_time": "2026-06-04T06:28:06.925737",
+     "start_time": "2026-06-22T19:16:33.416273",
      "status": "completed"
     },
     "tags": []
@@ -364,10 +364,10 @@
    "id": "64b78841",
    "metadata": {
     "papermill": {
-     "duration": 0.008025,
-     "end_time": "2026-06-04T06:28:06.951568",
+     "duration": 0.008729,
+     "end_time": "2026-06-22T19:16:33.440739",
      "exception": false,
-     "start_time": "2026-06-04T06:28:06.943543",
+     "start_time": "2026-06-22T19:16:33.432010",
      "status": "completed"
     },
     "tags": []
@@ -381,10 +381,10 @@
    "id": "4jp4i20uv3y",
    "metadata": {
     "papermill": {
-     "duration": 0.008341,
-     "end_time": "2026-06-04T06:28:06.968640",
+     "duration": 0.008008,
+     "end_time": "2026-06-22T19:16:33.456740",
      "exception": false,
-     "start_time": "2026-06-04T06:28:06.960299",
+     "start_time": "2026-06-22T19:16:33.448732",
      "status": "completed"
     },
     "tags": []
@@ -428,16 +428,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:06.988727Z",
-     "iopub.status.busy": "2026-06-04T06:28:06.988397Z",
-     "iopub.status.idle": "2026-06-04T06:28:09.833584Z",
-     "shell.execute_reply": "2026-06-04T06:28:09.833329Z"
+     "iopub.execute_input": "2026-06-22T19:16:33.474731Z",
+     "iopub.status.busy": "2026-06-22T19:16:33.474731Z",
+     "iopub.status.idle": "2026-06-22T19:16:35.646470Z",
+     "shell.execute_reply": "2026-06-22T19:16:35.645478Z"
     },
     "papermill": {
-     "duration": 2.855273,
-     "end_time": "2026-06-04T06:28:09.833706",
+     "duration": 2.181736,
+     "end_time": "2026-06-22T19:16:35.646470",
      "exception": false,
-     "start_time": "2026-06-04T06:28:06.978433",
+     "start_time": "2026-06-22T19:16:33.464734",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -446,38 +446,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_03_41.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -932,10 +900,10 @@
    "id": "u8lbgb6u8ei",
    "metadata": {
     "papermill": {
-     "duration": 0.012616,
-     "end_time": "2026-06-04T06:28:09.860232",
+     "duration": 0.012008,
+     "end_time": "2026-06-22T19:16:35.668479",
      "exception": false,
-     "start_time": "2026-06-04T06:28:09.847616",
+     "start_time": "2026-06-22T19:16:35.656471",
      "status": "completed"
     },
     "tags": []
@@ -964,19 +932,19 @@
    "id": "ulzxxtv3lj",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:09.887649Z",
-     "iopub.status.busy": "2026-06-04T06:28:09.887294Z",
-     "iopub.status.idle": "2026-06-04T06:28:09.972454Z",
-     "shell.execute_reply": "2026-06-04T06:28:09.972629Z"
+     "iopub.execute_input": "2026-06-22T19:16:35.694272Z",
+     "iopub.status.busy": "2026-06-22T19:16:35.694272Z",
+     "iopub.status.idle": "2026-06-22T19:16:35.827911Z",
+     "shell.execute_reply": "2026-06-22T19:16:35.828922Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.098006,
-     "end_time": "2026-06-04T06:28:09.972739",
+     "duration": 0.149424,
+     "end_time": "2026-06-22T19:16:35.828922",
      "exception": false,
-     "start_time": "2026-06-04T06:28:09.874733",
+     "start_time": "2026-06-22T19:16:35.679498",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -988,14 +956,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_20_52_03_41.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_33_75.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"409pt\" height=\"818pt\"\r\n",
@@ -1264,8 +1232,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1277,7 +1245,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1292,10 +1260,10 @@
    "id": "sn7d8ljyk2",
    "metadata": {
     "papermill": {
-     "duration": 0.013618,
-     "end_time": "2026-06-04T06:28:10.002027",
+     "duration": 0.011236,
+     "end_time": "2026-06-22T19:16:35.850895",
      "exception": false,
-     "start_time": "2026-06-04T06:28:09.988409",
+     "start_time": "2026-06-22T19:16:35.839659",
      "status": "completed"
     },
     "tags": []
@@ -1326,10 +1294,10 @@
    "id": "7c4008e7",
    "metadata": {
     "papermill": {
-     "duration": 0.012919,
-     "end_time": "2026-06-04T06:28:10.027124",
+     "duration": 0.010001,
+     "end_time": "2026-06-22T19:16:35.871888",
      "exception": false,
-     "start_time": "2026-06-04T06:28:10.014205",
+     "start_time": "2026-06-22T19:16:35.861887",
      "status": "completed"
     },
     "tags": []
@@ -1347,16 +1315,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:10.057815Z",
-     "iopub.status.busy": "2026-06-04T06:28:10.057473Z",
-     "iopub.status.idle": "2026-06-04T06:28:11.691657Z",
-     "shell.execute_reply": "2026-06-04T06:28:11.691414Z"
+     "iopub.execute_input": "2026-06-22T19:16:35.894909Z",
+     "iopub.status.busy": "2026-06-22T19:16:35.894909Z",
+     "iopub.status.idle": "2026-06-22T19:16:37.294560Z",
+     "shell.execute_reply": "2026-06-22T19:16:37.294560Z"
     },
     "papermill": {
-     "duration": 1.650479,
-     "end_time": "2026-06-04T06:28:11.691786",
+     "duration": 1.411671,
+     "end_time": "2026-06-22T19:16:37.294560",
      "exception": false,
-     "start_time": "2026-06-04T06:28:10.041307",
+     "start_time": "2026-06-22T19:16:35.882889",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1498,10 +1466,10 @@
    "id": "6za36pa8yso",
    "metadata": {
     "papermill": {
-     "duration": 0.013212,
-     "end_time": "2026-06-04T06:28:11.717071",
+     "duration": 0.01187,
+     "end_time": "2026-06-22T19:16:37.318643",
      "exception": false,
-     "start_time": "2026-06-04T06:28:11.703859",
+     "start_time": "2026-06-22T19:16:37.306773",
      "status": "completed"
     },
     "tags": []
@@ -1532,10 +1500,10 @@
    "id": "c6af3de6",
    "metadata": {
     "papermill": {
-     "duration": 0.01198,
-     "end_time": "2026-06-04T06:28:11.741693",
+     "duration": 0.011726,
+     "end_time": "2026-06-22T19:16:37.341153",
      "exception": false,
-     "start_time": "2026-06-04T06:28:11.729713",
+     "start_time": "2026-06-22T19:16:37.329427",
      "status": "completed"
     },
     "tags": []
@@ -1565,16 +1533,16 @@
    "id": "0e5c837e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:11.769624Z",
-     "iopub.status.busy": "2026-06-04T06:28:11.769275Z",
-     "iopub.status.idle": "2026-06-04T06:28:11.815240Z",
-     "shell.execute_reply": "2026-06-04T06:28:11.815006Z"
+     "iopub.execute_input": "2026-06-22T19:16:37.366390Z",
+     "iopub.status.busy": "2026-06-22T19:16:37.366390Z",
+     "iopub.status.idle": "2026-06-22T19:16:37.403909Z",
+     "shell.execute_reply": "2026-06-22T19:16:37.402909Z"
     },
     "papermill": {
-     "duration": 0.060724,
-     "end_time": "2026-06-04T06:28:11.815352",
+     "duration": 0.050923,
+     "end_time": "2026-06-22T19:16:37.403909",
      "exception": false,
-     "start_time": "2026-06-04T06:28:11.754628",
+     "start_time": "2026-06-22T19:16:37.352986",
      "status": "completed"
     },
     "tags": []
@@ -1610,10 +1578,10 @@
    "id": "9bc0d33b",
    "metadata": {
     "papermill": {
-     "duration": 0.013654,
-     "end_time": "2026-06-04T06:28:11.843825",
+     "duration": 0.012201,
+     "end_time": "2026-06-22T19:16:37.428616",
      "exception": false,
-     "start_time": "2026-06-04T06:28:11.830171",
+     "start_time": "2026-06-22T19:16:37.416415",
      "status": "completed"
     },
     "tags": []
@@ -1627,10 +1595,10 @@
    "id": "ll7ewym2zac",
    "metadata": {
     "papermill": {
-     "duration": 0.041517,
-     "end_time": "2026-06-04T06:28:11.906376",
+     "duration": 0.012189,
+     "end_time": "2026-06-22T19:16:37.451815",
      "exception": false,
-     "start_time": "2026-06-04T06:28:11.864859",
+     "start_time": "2026-06-22T19:16:37.439626",
      "status": "completed"
     },
     "tags": []
@@ -1659,16 +1627,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:11.935710Z",
-     "iopub.status.busy": "2026-06-04T06:28:11.935368Z",
-     "iopub.status.idle": "2026-06-04T06:28:12.642585Z",
-     "shell.execute_reply": "2026-06-04T06:28:12.633533Z"
+     "iopub.execute_input": "2026-06-22T19:16:37.476056Z",
+     "iopub.status.busy": "2026-06-22T19:16:37.476056Z",
+     "iopub.status.idle": "2026-06-22T19:16:38.160053Z",
+     "shell.execute_reply": "2026-06-22T19:16:38.154911Z"
     },
     "papermill": {
-     "duration": 0.720712,
-     "end_time": "2026-06-04T06:28:12.642710",
+     "duration": 0.697414,
+     "end_time": "2026-06-22T19:16:38.160564",
      "exception": false,
-     "start_time": "2026-06-04T06:28:11.921998",
+     "start_time": "2026-06-22T19:16:37.463150",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1677,38 +1645,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_07_00.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -2182,10 +2118,10 @@
    "id": "uf82v4btvd",
    "metadata": {
     "papermill": {
-     "duration": 0.021797,
-     "end_time": "2026-06-04T06:28:12.681736",
+     "duration": 0.014466,
+     "end_time": "2026-06-22T19:16:38.188934",
      "exception": false,
-     "start_time": "2026-06-04T06:28:12.659939",
+     "start_time": "2026-06-22T19:16:38.174468",
      "status": "completed"
     },
     "tags": []
@@ -2220,19 +2156,19 @@
    "id": "jeu5ucmvxsh",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:12.720161Z",
-     "iopub.status.busy": "2026-06-04T06:28:12.719731Z",
-     "iopub.status.idle": "2026-06-04T06:28:12.783762Z",
-     "shell.execute_reply": "2026-06-04T06:28:12.783576Z"
+     "iopub.execute_input": "2026-06-22T19:16:38.217850Z",
+     "iopub.status.busy": "2026-06-22T19:16:38.217850Z",
+     "iopub.status.idle": "2026-06-22T19:16:38.342131Z",
+     "shell.execute_reply": "2026-06-22T19:16:38.341618Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.082526,
-     "end_time": "2026-06-04T06:28:12.783880",
+     "duration": 0.139335,
+     "end_time": "2026-06-22T19:16:38.342131",
      "exception": false,
-     "start_time": "2026-06-04T06:28:12.701354",
+     "start_time": "2026-06-22T19:16:38.202796",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2244,14 +2180,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_20_52_07_00.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_37_55.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"464pt\" height=\"1046pt\"\r\n",
@@ -2574,8 +2510,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2587,7 +2523,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -2602,10 +2538,10 @@
    "id": "8xwj3opb66t",
    "metadata": {
     "papermill": {
-     "duration": 0.01627,
-     "end_time": "2026-06-04T06:28:12.820093",
+     "duration": 0.014887,
+     "end_time": "2026-06-22T19:16:38.371920",
      "exception": false,
-     "start_time": "2026-06-04T06:28:12.803823",
+     "start_time": "2026-06-22T19:16:38.357033",
      "status": "completed"
     },
     "tags": []
@@ -2637,10 +2573,10 @@
    "id": "a4c0bc0f",
    "metadata": {
     "papermill": {
-     "duration": 0.015842,
-     "end_time": "2026-06-04T06:28:12.853061",
+     "duration": 0.014134,
+     "end_time": "2026-06-22T19:16:38.400649",
      "exception": false,
-     "start_time": "2026-06-04T06:28:12.837219",
+     "start_time": "2026-06-22T19:16:38.386515",
      "status": "completed"
     },
     "tags": []
@@ -2665,10 +2601,10 @@
    "id": "c72blgkubd",
    "metadata": {
     "papermill": {
-     "duration": 0.016235,
-     "end_time": "2026-06-04T06:28:12.885329",
+     "duration": 0.013307,
+     "end_time": "2026-06-22T19:16:38.427340",
      "exception": false,
-     "start_time": "2026-06-04T06:28:12.869094",
+     "start_time": "2026-06-22T19:16:38.414033",
      "status": "completed"
     },
     "tags": []
@@ -2701,16 +2637,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:12.920514Z",
-     "iopub.status.busy": "2026-06-04T06:28:12.920180Z",
-     "iopub.status.idle": "2026-06-04T06:28:13.005117Z",
-     "shell.execute_reply": "2026-06-04T06:28:13.004915Z"
+     "iopub.execute_input": "2026-06-22T19:16:38.457671Z",
+     "iopub.status.busy": "2026-06-22T19:16:38.457671Z",
+     "iopub.status.idle": "2026-06-22T19:16:38.523383Z",
+     "shell.execute_reply": "2026-06-22T19:16:38.523383Z"
     },
     "papermill": {
-     "duration": 0.103453,
-     "end_time": "2026-06-04T06:28:13.005219",
+     "duration": 0.081715,
+     "end_time": "2026-06-22T19:16:38.523383",
      "exception": false,
-     "start_time": "2026-06-04T06:28:12.901766",
+     "start_time": "2026-06-22T19:16:38.441668",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2805,10 +2741,10 @@
    "id": "8iiyytzrwrs",
    "metadata": {
     "papermill": {
-     "duration": 0.016477,
-     "end_time": "2026-06-04T06:28:13.039058",
+     "duration": 0.014008,
+     "end_time": "2026-06-22T19:16:38.552115",
      "exception": false,
-     "start_time": "2026-06-04T06:28:13.022581",
+     "start_time": "2026-06-22T19:16:38.538107",
      "status": "completed"
     },
     "tags": []
@@ -2840,10 +2776,10 @@
    "id": "rrt7vjmte7o",
    "metadata": {
     "papermill": {
-     "duration": 0.015748,
-     "end_time": "2026-06-04T06:28:13.073316",
+     "duration": 0.016,
+     "end_time": "2026-06-22T19:16:38.583116",
      "exception": false,
-     "start_time": "2026-06-04T06:28:13.057568",
+     "start_time": "2026-06-22T19:16:38.567116",
      "status": "completed"
     },
     "tags": []
@@ -2863,16 +2799,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:13.112861Z",
-     "iopub.status.busy": "2026-06-04T06:28:13.112528Z",
-     "iopub.status.idle": "2026-06-04T06:28:13.680104Z",
-     "shell.execute_reply": "2026-06-04T06:28:13.660154Z"
+     "iopub.execute_input": "2026-06-22T19:16:38.613703Z",
+     "iopub.status.busy": "2026-06-22T19:16:38.613175Z",
+     "iopub.status.idle": "2026-06-22T19:16:39.184768Z",
+     "shell.execute_reply": "2026-06-22T19:16:39.171770Z"
     },
     "papermill": {
-     "duration": 0.590635,
-     "end_time": "2026-06-04T06:28:13.680215",
+     "duration": 0.586962,
+     "end_time": "2026-06-22T19:16:39.184768",
      "exception": false,
-     "start_time": "2026-06-04T06:28:13.089580",
+     "start_time": "2026-06-22T19:16:38.597806",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2881,38 +2817,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_08_12.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -3352,10 +3256,10 @@
    "id": "8odjsoa9nju",
    "metadata": {
     "papermill": {
-     "duration": 0.020817,
-     "end_time": "2026-06-04T06:28:13.722119",
+     "duration": 0.016014,
+     "end_time": "2026-06-22T19:16:39.217784",
      "exception": false,
-     "start_time": "2026-06-04T06:28:13.701302",
+     "start_time": "2026-06-22T19:16:39.201770",
      "status": "completed"
     },
     "tags": []
@@ -3387,19 +3291,19 @@
    "id": "cr9vd8obj6i",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:13.768617Z",
-     "iopub.status.busy": "2026-06-04T06:28:13.768240Z",
-     "iopub.status.idle": "2026-06-04T06:28:13.816236Z",
-     "shell.execute_reply": "2026-06-04T06:28:13.816469Z"
+     "iopub.execute_input": "2026-06-22T19:16:39.252508Z",
+     "iopub.status.busy": "2026-06-22T19:16:39.252508Z",
+     "iopub.status.idle": "2026-06-22T19:16:39.350445Z",
+     "shell.execute_reply": "2026-06-22T19:16:39.350445Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.070631,
-     "end_time": "2026-06-04T06:28:13.816596",
+     "duration": 0.115733,
+     "end_time": "2026-06-22T19:16:39.350445",
      "exception": false,
-     "start_time": "2026-06-04T06:28:13.745965",
+     "start_time": "2026-06-22T19:16:39.234712",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3411,14 +3315,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_20_52_08_12.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_38_65.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"574pt\" height=\"1235pt\"\r\n",
@@ -3779,8 +3683,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -3792,7 +3696,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -3807,10 +3711,10 @@
    "id": "893615jcc8i",
    "metadata": {
     "papermill": {
-     "duration": 0.024461,
-     "end_time": "2026-06-04T06:28:13.862265",
+     "duration": 0.017578,
+     "end_time": "2026-06-22T19:16:39.386161",
      "exception": false,
-     "start_time": "2026-06-04T06:28:13.837804",
+     "start_time": "2026-06-22T19:16:39.368583",
      "status": "completed"
     },
     "tags": []
@@ -3838,10 +3742,10 @@
    "id": "ff6c157e",
    "metadata": {
     "papermill": {
-     "duration": 0.021342,
-     "end_time": "2026-06-04T06:28:13.914801",
+     "duration": 0.01894,
+     "end_time": "2026-06-22T19:16:39.423855",
      "exception": false,
-     "start_time": "2026-06-04T06:28:13.893459",
+     "start_time": "2026-06-22T19:16:39.404915",
      "status": "completed"
     },
     "tags": []
@@ -3869,16 +3773,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:13.958961Z",
-     "iopub.status.busy": "2026-06-04T06:28:13.958536Z",
-     "iopub.status.idle": "2026-06-04T06:28:14.395307Z",
-     "shell.execute_reply": "2026-06-04T06:28:14.395063Z"
+     "iopub.execute_input": "2026-06-22T19:16:39.461471Z",
+     "iopub.status.busy": "2026-06-22T19:16:39.460954Z",
+     "iopub.status.idle": "2026-06-22T19:16:39.920351Z",
+     "shell.execute_reply": "2026-06-22T19:16:39.920351Z"
     },
     "papermill": {
-     "duration": 0.459659,
-     "end_time": "2026-06-04T06:28:14.395426",
+     "duration": 0.478336,
+     "end_time": "2026-06-22T19:16:39.920351",
      "exception": false,
-     "start_time": "2026-06-04T06:28:13.935767",
+     "start_time": "2026-06-22T19:16:39.442015",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3887,38 +3791,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_09_25.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -4066,10 +3938,10 @@
    "id": "d26dff6a",
    "metadata": {
     "papermill": {
-     "duration": 0.021543,
-     "end_time": "2026-06-04T06:28:14.438436",
+     "duration": 0.01893,
+     "end_time": "2026-06-22T19:16:39.956805",
      "exception": false,
-     "start_time": "2026-06-04T06:28:14.416893",
+     "start_time": "2026-06-22T19:16:39.937875",
      "status": "completed"
     },
     "tags": []
@@ -4101,19 +3973,19 @@
    "id": "wtgd89my72e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:14.484245Z",
-     "iopub.status.busy": "2026-06-04T06:28:14.483889Z",
-     "iopub.status.idle": "2026-06-04T06:28:14.530409Z",
-     "shell.execute_reply": "2026-06-04T06:28:14.530221Z"
+     "iopub.execute_input": "2026-06-22T19:16:39.993892Z",
+     "iopub.status.busy": "2026-06-22T19:16:39.993892Z",
+     "iopub.status.idle": "2026-06-22T19:16:40.093246Z",
+     "shell.execute_reply": "2026-06-22T19:16:40.093246Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.070436,
-     "end_time": "2026-06-04T06:28:14.530513",
+     "duration": 0.118353,
+     "end_time": "2026-06-22T19:16:40.093246",
      "exception": false,
-     "start_time": "2026-06-04T06:28:14.460077",
+     "start_time": "2026-06-22T19:16:39.974893",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4125,14 +3997,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_20_52_09_25.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_39_52.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"315pt\" height=\"508pt\"\r\n",
@@ -4337,8 +4209,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -4350,7 +4222,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -4365,10 +4237,10 @@
    "id": "t8zueh8k44o",
    "metadata": {
     "papermill": {
-     "duration": 0.033023,
-     "end_time": "2026-06-04T06:28:14.586340",
+     "duration": 0.017107,
+     "end_time": "2026-06-22T19:16:40.128357",
      "exception": false,
-     "start_time": "2026-06-04T06:28:14.553317",
+     "start_time": "2026-06-22T19:16:40.111250",
      "status": "completed"
     },
     "tags": []
@@ -4398,10 +4270,10 @@
    "id": "10634vpndmv",
    "metadata": {
     "papermill": {
-     "duration": 0.023781,
-     "end_time": "2026-06-04T06:28:14.633806",
+     "duration": 0.018004,
+     "end_time": "2026-06-22T19:16:40.163361",
      "exception": false,
-     "start_time": "2026-06-04T06:28:14.610025",
+     "start_time": "2026-06-22T19:16:40.145357",
      "status": "completed"
     },
     "tags": []
@@ -4428,10 +4300,10 @@
    "id": "4e52c9a4",
    "metadata": {
     "papermill": {
-     "duration": 0.022536,
-     "end_time": "2026-06-04T06:28:14.677542",
+     "duration": 0.017314,
+     "end_time": "2026-06-22T19:16:40.197741",
      "exception": false,
-     "start_time": "2026-06-04T06:28:14.655006",
+     "start_time": "2026-06-22T19:16:40.180427",
      "status": "completed"
     },
     "tags": []
@@ -4445,10 +4317,10 @@
    "id": "g0lw2yo4b9t",
    "metadata": {
     "papermill": {
-     "duration": 0.021865,
-     "end_time": "2026-06-04T06:28:14.721130",
+     "duration": 0.018402,
+     "end_time": "2026-06-22T19:16:40.235000",
      "exception": false,
-     "start_time": "2026-06-04T06:28:14.699265",
+     "start_time": "2026-06-22T19:16:40.216598",
      "status": "completed"
     },
     "tags": []
@@ -4468,16 +4340,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:14.768919Z",
-     "iopub.status.busy": "2026-06-04T06:28:14.768531Z",
-     "iopub.status.idle": "2026-06-04T06:28:16.276924Z",
-     "shell.execute_reply": "2026-06-04T06:28:16.275881Z"
+     "iopub.execute_input": "2026-06-22T19:16:40.271406Z",
+     "iopub.status.busy": "2026-06-22T19:16:40.270404Z",
+     "iopub.status.idle": "2026-06-22T19:16:41.315715Z",
+     "shell.execute_reply": "2026-06-22T19:16:41.314723Z"
     },
     "papermill": {
-     "duration": 1.532628,
-     "end_time": "2026-06-04T06:28:16.277188",
+     "duration": 1.063311,
+     "end_time": "2026-06-22T19:16:41.315715",
      "exception": false,
-     "start_time": "2026-06-04T06:28:14.744560",
+     "start_time": "2026-06-22T19:16:40.252404",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4722,10 +4594,10 @@
    "id": "my479h57vh",
    "metadata": {
     "papermill": {
-     "duration": 0.031299,
-     "end_time": "2026-06-04T06:28:16.353271",
+     "duration": 0.019272,
+     "end_time": "2026-06-22T19:16:41.354538",
      "exception": false,
-     "start_time": "2026-06-04T06:28:16.321972",
+     "start_time": "2026-06-22T19:16:41.335266",
      "status": "completed"
     },
     "tags": []
@@ -4763,10 +4635,10 @@
    "id": "ce62df2a",
    "metadata": {
     "papermill": {
-     "duration": 0.02252,
-     "end_time": "2026-06-04T06:28:16.402316",
+     "duration": 0.019866,
+     "end_time": "2026-06-22T19:16:41.393562",
      "exception": false,
-     "start_time": "2026-06-04T06:28:16.379796",
+     "start_time": "2026-06-22T19:16:41.373696",
      "status": "completed"
     },
     "tags": []
@@ -4796,16 +4668,16 @@
    "id": "a226525c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:16.448833Z",
-     "iopub.status.busy": "2026-06-04T06:28:16.448468Z",
-     "iopub.status.idle": "2026-06-04T06:28:16.486535Z",
-     "shell.execute_reply": "2026-06-04T06:28:16.486284Z"
+     "iopub.execute_input": "2026-06-22T19:16:41.439864Z",
+     "iopub.status.busy": "2026-06-22T19:16:41.438858Z",
+     "iopub.status.idle": "2026-06-22T19:16:41.470219Z",
+     "shell.execute_reply": "2026-06-22T19:16:41.469699Z"
     },
     "papermill": {
-     "duration": 0.063037,
-     "end_time": "2026-06-04T06:28:16.486656",
+     "duration": 0.055403,
+     "end_time": "2026-06-22T19:16:41.470219",
      "exception": false,
-     "start_time": "2026-06-04T06:28:16.423619",
+     "start_time": "2026-06-22T19:16:41.414816",
      "status": "completed"
     },
     "tags": []
@@ -4842,10 +4714,10 @@
    "id": "10acf573",
    "metadata": {
     "papermill": {
-     "duration": 0.023679,
-     "end_time": "2026-06-04T06:28:16.546428",
+     "duration": 0.021086,
+     "end_time": "2026-06-22T19:16:41.512618",
      "exception": false,
-     "start_time": "2026-06-04T06:28:16.522749",
+     "start_time": "2026-06-22T19:16:41.491532",
      "status": "completed"
     },
     "tags": []
@@ -4868,10 +4740,10 @@
    "id": "4vz1cpy6yhq",
    "metadata": {
     "papermill": {
-     "duration": 0.022889,
-     "end_time": "2026-06-04T06:28:16.591848",
+     "duration": 0.02107,
+     "end_time": "2026-06-22T19:16:41.554284",
      "exception": false,
-     "start_time": "2026-06-04T06:28:16.568959",
+     "start_time": "2026-06-22T19:16:41.533214",
      "status": "completed"
     },
     "tags": []
@@ -4899,16 +4771,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:16.638162Z",
-     "iopub.status.busy": "2026-06-04T06:28:16.636843Z",
-     "iopub.status.idle": "2026-06-04T06:28:17.329052Z",
-     "shell.execute_reply": "2026-06-04T06:28:17.297230Z"
+     "iopub.execute_input": "2026-06-22T19:16:41.596109Z",
+     "iopub.status.busy": "2026-06-22T19:16:41.595593Z",
+     "iopub.status.idle": "2026-06-22T19:16:42.154715Z",
+     "shell.execute_reply": "2026-06-22T19:16:42.143253Z"
     },
     "papermill": {
-     "duration": 0.715508,
-     "end_time": "2026-06-04T06:28:17.329259",
+     "duration": 0.579824,
+     "end_time": "2026-06-22T19:16:42.154715",
      "exception": false,
-     "start_time": "2026-06-04T06:28:16.613751",
+     "start_time": "2026-06-22T19:16:41.574891",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4917,38 +4789,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_20_52_11_18.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -5416,10 +5256,10 @@
    "id": "0lks9jhso2xf",
    "metadata": {
     "papermill": {
-     "duration": 0.040859,
-     "end_time": "2026-06-04T06:28:17.415108",
+     "duration": 0.022,
+     "end_time": "2026-06-22T19:16:42.199722",
      "exception": false,
-     "start_time": "2026-06-04T06:28:17.374249",
+     "start_time": "2026-06-22T19:16:42.177722",
      "status": "completed"
     },
     "tags": []
@@ -5457,19 +5297,19 @@
    "id": "1egcewx3etnj",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:17.469922Z",
-     "iopub.status.busy": "2026-06-04T06:28:17.469560Z",
-     "iopub.status.idle": "2026-06-04T06:28:17.508188Z",
-     "shell.execute_reply": "2026-06-04T06:28:17.508014Z"
+     "iopub.execute_input": "2026-06-22T19:16:42.246022Z",
+     "iopub.status.busy": "2026-06-22T19:16:42.246022Z",
+     "iopub.status.idle": "2026-06-22T19:16:42.336962Z",
+     "shell.execute_reply": "2026-06-22T19:16:42.336962Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.066794,
-     "end_time": "2026-06-04T06:28:17.508355",
+     "duration": 0.115235,
+     "end_time": "2026-06-22T19:16:42.336962",
      "exception": false,
-     "start_time": "2026-06-04T06:28:17.441561",
+     "start_time": "2026-06-22T19:16:42.221727",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -5481,14 +5321,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_20_52_11_18.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_41_65.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"896pt\" height=\"1416pt\"\r\n",
@@ -5930,8 +5770,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -5943,7 +5783,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -5958,10 +5798,10 @@
    "id": "v3oesyvwqk",
    "metadata": {
     "papermill": {
-     "duration": 0.025727,
-     "end_time": "2026-06-04T06:28:17.569084",
+     "duration": 0.02313,
+     "end_time": "2026-06-22T19:16:42.383042",
      "exception": false,
-     "start_time": "2026-06-04T06:28:17.543357",
+     "start_time": "2026-06-22T19:16:42.359912",
      "status": "completed"
     },
     "tags": []
@@ -5988,10 +5828,10 @@
    "id": "c23fa2ba",
    "metadata": {
     "papermill": {
-     "duration": 0.042657,
-     "end_time": "2026-06-04T06:28:17.639228",
+     "duration": 0.026452,
+     "end_time": "2026-06-22T19:16:42.432980",
      "exception": false,
-     "start_time": "2026-06-04T06:28:17.596571",
+     "start_time": "2026-06-22T19:16:42.406528",
      "status": "completed"
     },
     "tags": []
@@ -6047,10 +5887,10 @@
    "id": "97924a95",
    "metadata": {
     "papermill": {
-     "duration": 0.024671,
-     "end_time": "2026-06-04T06:28:17.698678",
+     "duration": 0.023761,
+     "end_time": "2026-06-22T19:16:42.480182",
      "exception": false,
-     "start_time": "2026-06-04T06:28:17.674007",
+     "start_time": "2026-06-22T19:16:42.456421",
      "status": "completed"
     },
     "tags": []
@@ -6079,19 +5919,19 @@
    "id": "d31bb853",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:28:17.761042Z",
-     "iopub.status.busy": "2026-06-04T06:28:17.760645Z",
-     "iopub.status.idle": "2026-06-04T06:28:17.809560Z",
-     "shell.execute_reply": "2026-06-04T06:28:17.809215Z"
+     "iopub.execute_input": "2026-06-22T19:16:42.530220Z",
+     "iopub.status.busy": "2026-06-22T19:16:42.530220Z",
+     "iopub.status.idle": "2026-06-22T19:16:42.562341Z",
+     "shell.execute_reply": "2026-06-22T19:16:42.561823Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.082895,
-     "end_time": "2026-06-04T06:28:17.809739",
+     "duration": 0.057577,
+     "end_time": "2026-06-22T19:16:42.562341",
      "exception": false,
-     "start_time": "2026-06-04T06:28:17.726844",
+     "start_time": "2026-06-22T19:16:42.504764",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6129,10 +5969,10 @@
    "id": "e24f4db9",
    "metadata": {
     "papermill": {
-     "duration": 0.026981,
-     "end_time": "2026-06-04T06:28:17.862829",
+     "duration": 0.024706,
+     "end_time": "2026-06-22T19:16:42.611865",
      "exception": false,
-     "start_time": "2026-06-04T06:28:17.835848",
+     "start_time": "2026-06-22T19:16:42.587159",
      "status": "completed"
     },
     "tags": []
@@ -6171,18 +6011,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 18.139946,
-   "end_time": "2026-06-04T06:28:18.270811",
+   "duration": 14.390198,
+   "end_time": "2026-06-22T19:16:42.881296",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-7-Classification.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-7-Classification.ipynb",
+   "input_path": "Infer-7-Classification.ipynb",
+   "output_path": "Infer-7-Classification.ipynb",
    "parameters": {},
-   "start_time": "2026-06-04T06:28:00.130865",
+   "start_time": "2026-06-22T19:16:28.491098",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-8-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-8-Model-Selection.ipynb
@@ -5,10 +5,10 @@
    "id": "72aac374",
    "metadata": {
     "papermill": {
-     "duration": 0.015582,
-     "end_time": "2026-06-09T09:38:51.552487",
+     "duration": 0.006322,
+     "end_time": "2026-06-22T19:16:46.781960",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.536905",
+     "start_time": "2026-06-22T19:16:46.775638",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "6528c2c1",
    "metadata": {
     "papermill": {
-     "duration": 0.013522,
-     "end_time": "2026-06-09T09:38:51.580813",
+     "duration": 0.006438,
+     "end_time": "2026-06-22T19:16:46.794634",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.567291",
+     "start_time": "2026-06-22T19:16:46.788196",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:51.632139Z",
-     "iopub.status.busy": "2026-06-09T09:38:51.625373Z",
-     "iopub.status.idle": "2026-06-09T09:38:57.340995Z",
-     "shell.execute_reply": "2026-06-09T09:38:57.328839Z"
+     "iopub.execute_input": "2026-06-22T19:16:46.815599Z",
+     "iopub.status.busy": "2026-06-22T19:16:46.810901Z",
+     "iopub.status.idle": "2026-06-22T19:16:49.282173Z",
+     "shell.execute_reply": "2026-06-22T19:16:49.279730Z"
     },
     "papermill": {
-     "duration": 5.747083,
-     "end_time": "2026-06-09T09:38:57.341240",
+     "duration": 2.481254,
+     "end_time": "2026-06-22T19:16:49.282173",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.594157",
+     "start_time": "2026-06-22T19:16:46.800919",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -94,7 +94,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-79792.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-101800.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -139,12 +139,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.83.164.85:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '79792.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '101800.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -241,10 +241,10 @@
    "id": "e2ffca21",
    "metadata": {
     "papermill": {
-     "duration": 0.029886,
-     "end_time": "2026-06-09T09:38:57.394539",
+     "duration": 0.009141,
+     "end_time": "2026-06-22T19:16:49.300811",
      "exception": false,
-     "start_time": "2026-06-09T09:38:57.364653",
+     "start_time": "2026-06-22T19:16:49.291670",
      "status": "completed"
     },
     "tags": []
@@ -259,16 +259,16 @@
    "id": "8ik5ebs1sx3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:57.443062Z",
-     "iopub.status.busy": "2026-06-09T09:38:57.442467Z",
-     "iopub.status.idle": "2026-06-09T09:38:58.675504Z",
-     "shell.execute_reply": "2026-06-09T09:38:58.675089Z"
+     "iopub.execute_input": "2026-06-22T19:16:49.319514Z",
+     "iopub.status.busy": "2026-06-22T19:16:49.319002Z",
+     "iopub.status.idle": "2026-06-22T19:16:49.919530Z",
+     "shell.execute_reply": "2026-06-22T19:16:49.919530Z"
     },
     "papermill": {
-     "duration": 1.254895,
-     "end_time": "2026-06-09T09:38:58.675674",
+     "duration": 0.610004,
+     "end_time": "2026-06-22T19:16:49.919530",
      "exception": false,
-     "start_time": "2026-06-09T09:38:57.420779",
+     "start_time": "2026-06-22T19:16:49.309526",
      "status": "completed"
     },
     "tags": [],
@@ -297,10 +297,10 @@
    "id": "qdg7zri60d8",
    "metadata": {
     "papermill": {
-     "duration": 0.018178,
-     "end_time": "2026-06-09T09:38:58.708496",
+     "duration": 0.007988,
+     "end_time": "2026-06-22T19:16:49.935835",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.690318",
+     "start_time": "2026-06-22T19:16:49.927847",
      "status": "completed"
     },
     "tags": []
@@ -318,10 +318,10 @@
    "id": "dh7jodvycpp",
    "metadata": {
     "papermill": {
-     "duration": 0.02568,
-     "end_time": "2026-06-09T09:38:58.749852",
+     "duration": 0.00774,
+     "end_time": "2026-06-22T19:16:49.952118",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.724172",
+     "start_time": "2026-06-22T19:16:49.944378",
      "status": "completed"
     },
     "tags": []
@@ -348,10 +348,10 @@
    "id": "f1fdd2fb",
    "metadata": {
     "papermill": {
-     "duration": 0.016313,
-     "end_time": "2026-06-09T09:38:58.783994",
+     "duration": 0.009002,
+     "end_time": "2026-06-22T19:16:49.968625",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.767681",
+     "start_time": "2026-06-22T19:16:49.959623",
      "status": "completed"
     },
     "tags": []
@@ -379,10 +379,10 @@
    "id": "24cacf89",
    "metadata": {
     "papermill": {
-     "duration": 0.01691,
-     "end_time": "2026-06-09T09:38:58.815930",
+     "duration": 0.008189,
+     "end_time": "2026-06-22T19:16:49.984821",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.799020",
+     "start_time": "2026-06-22T19:16:49.976632",
      "status": "completed"
     },
     "tags": []
@@ -412,16 +412,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:58.847067Z",
-     "iopub.status.busy": "2026-06-09T09:38:58.846542Z",
-     "iopub.status.idle": "2026-06-09T09:39:04.052156Z",
-     "shell.execute_reply": "2026-06-09T09:39:04.051758Z"
+     "iopub.execute_input": "2026-06-22T19:16:50.003144Z",
+     "iopub.status.busy": "2026-06-22T19:16:50.003144Z",
+     "iopub.status.idle": "2026-06-22T19:16:52.266208Z",
+     "shell.execute_reply": "2026-06-22T19:16:52.266208Z"
     },
     "papermill": {
-     "duration": 5.222302,
-     "end_time": "2026-06-09T09:39:04.052371",
+     "duration": 2.273201,
+     "end_time": "2026-06-22T19:16:52.266208",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.830069",
+     "start_time": "2026-06-22T19:16:49.993007",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -433,38 +433,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_36_51.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -896,10 +864,10 @@
    "id": "kxqr4eukslk",
    "metadata": {
     "papermill": {
-     "duration": 0.030353,
-     "end_time": "2026-06-09T09:39:04.112471",
+     "duration": 0.013344,
+     "end_time": "2026-06-22T19:16:52.292874",
      "exception": false,
-     "start_time": "2026-06-09T09:39:04.082118",
+     "start_time": "2026-06-22T19:16:52.279530",
      "status": "completed"
     },
     "tags": []
@@ -920,16 +888,16 @@
    "id": "ohu36bdkh4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:04.163434Z",
-     "iopub.status.busy": "2026-06-09T09:39:04.162942Z",
-     "iopub.status.idle": "2026-06-09T09:39:04.332515Z",
-     "shell.execute_reply": "2026-06-09T09:39:04.332156Z"
+     "iopub.execute_input": "2026-06-22T19:16:52.316587Z",
+     "iopub.status.busy": "2026-06-22T19:16:52.316069Z",
+     "iopub.status.idle": "2026-06-22T19:16:52.466708Z",
+     "shell.execute_reply": "2026-06-22T19:16:52.465708Z"
     },
     "papermill": {
-     "duration": 0.195033,
-     "end_time": "2026-06-09T09:39:04.332691",
+     "duration": 0.162493,
+     "end_time": "2026-06-22T19:16:52.466708",
      "exception": false,
-     "start_time": "2026-06-09T09:39:04.137658",
+     "start_time": "2026-06-22T19:16:52.304215",
      "status": "completed"
     },
     "tags": [],
@@ -941,14 +909,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_21_50_36_51.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_50_24.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"580pt\" height=\"354pt\"\r\n",
@@ -1301,8 +1269,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1314,7 +1282,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1329,10 +1297,10 @@
    "id": "rwzoc5x79i",
    "metadata": {
     "papermill": {
-     "duration": 0.026638,
-     "end_time": "2026-06-09T09:39:04.382666",
+     "duration": 0.010974,
+     "end_time": "2026-06-22T19:16:52.487674",
      "exception": false,
-     "start_time": "2026-06-09T09:39:04.356028",
+     "start_time": "2026-06-22T19:16:52.476700",
      "status": "completed"
     },
     "tags": []
@@ -1354,10 +1322,10 @@
    "id": "tg7grrjd7g",
    "metadata": {
     "papermill": {
-     "duration": 0.021483,
-     "end_time": "2026-06-09T09:39:04.434776",
+     "duration": 0.01,
+     "end_time": "2026-06-22T19:16:52.507682",
      "exception": false,
-     "start_time": "2026-06-09T09:39:04.413293",
+     "start_time": "2026-06-22T19:16:52.497682",
      "status": "completed"
     },
     "tags": []
@@ -1386,16 +1354,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:04.483609Z",
-     "iopub.status.busy": "2026-06-09T09:39:04.483006Z",
-     "iopub.status.idle": "2026-06-09T09:39:13.641556Z",
-     "shell.execute_reply": "2026-06-09T09:39:13.616939Z"
+     "iopub.execute_input": "2026-06-22T19:16:52.531683Z",
+     "iopub.status.busy": "2026-06-22T19:16:52.531683Z",
+     "iopub.status.idle": "2026-06-22T19:16:56.149588Z",
+     "shell.execute_reply": "2026-06-22T19:16:56.146580Z"
     },
     "papermill": {
-     "duration": 9.187875,
-     "end_time": "2026-06-09T09:39:13.641751",
+     "duration": 3.631906,
+     "end_time": "2026-06-22T19:16:56.149588",
      "exception": false,
-     "start_time": "2026-06-09T09:39:04.453876",
+     "start_time": "2026-06-22T19:16:52.517682",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1407,38 +1375,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_38_93.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1866,10 +1802,10 @@
    "id": "fc059ea9",
    "metadata": {
     "papermill": {
-     "duration": 0.024159,
-     "end_time": "2026-06-09T09:39:13.694440",
+     "duration": 0.012003,
+     "end_time": "2026-06-22T19:16:56.175203",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.670281",
+     "start_time": "2026-06-22T19:16:56.163200",
      "status": "completed"
     },
     "tags": []
@@ -1884,16 +1820,16 @@
    "id": "93l0422na3f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:13.747815Z",
-     "iopub.status.busy": "2026-06-09T09:39:13.747210Z",
-     "iopub.status.idle": "2026-06-09T09:39:13.834416Z",
-     "shell.execute_reply": "2026-06-09T09:39:13.837083Z"
+     "iopub.execute_input": "2026-06-22T19:16:56.202203Z",
+     "iopub.status.busy": "2026-06-22T19:16:56.201203Z",
+     "iopub.status.idle": "2026-06-22T19:16:56.304665Z",
+     "shell.execute_reply": "2026-06-22T19:16:56.303672Z"
     },
     "papermill": {
-     "duration": 0.11817,
-     "end_time": "2026-06-09T09:39:13.837395",
+     "duration": 0.116462,
+     "end_time": "2026-06-22T19:16:56.304665",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.719225",
+     "start_time": "2026-06-22T19:16:56.188203",
      "status": "completed"
     },
     "tags": [],
@@ -1905,14 +1841,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_21_50_38_93.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_52_60.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"1634pt\" height=\"453pt\"\r\n",
@@ -2746,8 +2682,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2759,7 +2695,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -2774,10 +2710,10 @@
    "id": "uhecr4ah36",
    "metadata": {
     "papermill": {
-     "duration": 0.026398,
-     "end_time": "2026-06-09T09:39:13.888392",
+     "duration": 0.021259,
+     "end_time": "2026-06-22T19:16:56.347924",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.861994",
+     "start_time": "2026-06-22T19:16:56.326665",
      "status": "completed"
     },
     "tags": []
@@ -2800,10 +2736,10 @@
    "id": "35652b62",
    "metadata": {
     "papermill": {
-     "duration": 0.027571,
-     "end_time": "2026-06-09T09:39:13.948285",
+     "duration": 0.014549,
+     "end_time": "2026-06-22T19:16:56.380989",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.920714",
+     "start_time": "2026-06-22T19:16:56.366440",
      "status": "completed"
     },
     "tags": []
@@ -2835,16 +2771,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:14.010229Z",
-     "iopub.status.busy": "2026-06-09T09:39:14.009489Z",
-     "iopub.status.idle": "2026-06-09T09:39:14.133789Z",
-     "shell.execute_reply": "2026-06-09T09:39:14.133406Z"
+     "iopub.execute_input": "2026-06-22T19:16:56.414958Z",
+     "iopub.status.busy": "2026-06-22T19:16:56.414958Z",
+     "iopub.status.idle": "2026-06-22T19:16:56.469034Z",
+     "shell.execute_reply": "2026-06-22T19:16:56.468037Z"
     },
     "papermill": {
-     "duration": 0.154458,
-     "end_time": "2026-06-09T09:39:14.133973",
+     "duration": 0.074045,
+     "end_time": "2026-06-22T19:16:56.469034",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.979515",
+     "start_time": "2026-06-22T19:16:56.394989",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2911,10 +2847,10 @@
    "id": "2zz6zocoea7",
    "metadata": {
     "papermill": {
-     "duration": 0.026637,
-     "end_time": "2026-06-09T09:39:14.195968",
+     "duration": 0.014186,
+     "end_time": "2026-06-22T19:16:56.497415",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.169331",
+     "start_time": "2026-06-22T19:16:56.483229",
      "status": "completed"
     },
     "tags": []
@@ -2943,10 +2879,10 @@
    "id": "c8ddb475",
    "metadata": {
     "papermill": {
-     "duration": 0.03067,
-     "end_time": "2026-06-09T09:39:14.253981",
+     "duration": 0.015501,
+     "end_time": "2026-06-22T19:16:56.529886",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.223311",
+     "start_time": "2026-06-22T19:16:56.514385",
      "status": "completed"
     },
     "tags": []
@@ -2964,10 +2900,10 @@
    "id": "uv9cebrgw1",
    "metadata": {
     "papermill": {
-     "duration": 0.024962,
-     "end_time": "2026-06-09T09:39:14.309037",
+     "duration": 0.01845,
+     "end_time": "2026-06-22T19:16:56.563535",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.284075",
+     "start_time": "2026-06-22T19:16:56.545085",
      "status": "completed"
     },
     "tags": []
@@ -2991,16 +2927,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:14.369430Z",
-     "iopub.status.busy": "2026-06-09T09:39:14.368907Z",
-     "iopub.status.idle": "2026-06-09T09:39:23.663558Z",
-     "shell.execute_reply": "2026-06-09T09:39:23.650810Z"
+     "iopub.execute_input": "2026-06-22T19:16:56.594508Z",
+     "iopub.status.busy": "2026-06-22T19:16:56.594508Z",
+     "iopub.status.idle": "2026-06-22T19:17:00.816037Z",
+     "shell.execute_reply": "2026-06-22T19:17:00.803975Z"
     },
     "papermill": {
-     "duration": 9.32573,
-     "end_time": "2026-06-09T09:39:23.663659",
+     "duration": 4.237978,
+     "end_time": "2026-06-22T19:17:00.816037",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.337929",
+     "start_time": "2026-06-22T19:16:56.578059",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3873,10 +3809,10 @@
    "id": "8z4v08m86qg",
    "metadata": {
     "papermill": {
-     "duration": 0.019093,
-     "end_time": "2026-06-09T09:39:23.701442",
+     "duration": 0.021706,
+     "end_time": "2026-06-22T19:17:00.861130",
      "exception": false,
-     "start_time": "2026-06-09T09:39:23.682349",
+     "start_time": "2026-06-22T19:17:00.839424",
      "status": "completed"
     },
     "tags": []
@@ -3903,10 +3839,10 @@
    "id": "4abedeba",
    "metadata": {
     "papermill": {
-     "duration": 0.022309,
-     "end_time": "2026-06-09T09:39:23.743193",
+     "duration": 0.023109,
+     "end_time": "2026-06-22T19:17:00.905494",
      "exception": false,
-     "start_time": "2026-06-09T09:39:23.720884",
+     "start_time": "2026-06-22T19:17:00.882385",
      "status": "completed"
     },
     "tags": []
@@ -3931,10 +3867,10 @@
    "id": "byqokwwe3av",
    "metadata": {
     "papermill": {
-     "duration": 0.033776,
-     "end_time": "2026-06-09T09:39:23.802271",
+     "duration": 0.02288,
+     "end_time": "2026-06-22T19:17:00.951987",
      "exception": false,
-     "start_time": "2026-06-09T09:39:23.768495",
+     "start_time": "2026-06-22T19:17:00.929107",
      "status": "completed"
     },
     "tags": []
@@ -3954,10 +3890,10 @@
    "id": "99fn0bnvoyc",
    "metadata": {
     "papermill": {
-     "duration": 0.021563,
-     "end_time": "2026-06-09T09:39:23.847899",
+     "duration": 0.020092,
+     "end_time": "2026-06-22T19:17:00.992517",
      "exception": false,
-     "start_time": "2026-06-09T09:39:23.826336",
+     "start_time": "2026-06-22T19:17:00.972425",
      "status": "completed"
     },
     "tags": []
@@ -3982,16 +3918,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:23.904478Z",
-     "iopub.status.busy": "2026-06-09T09:39:23.904110Z",
-     "iopub.status.idle": "2026-06-09T09:39:23.982042Z",
-     "shell.execute_reply": "2026-06-09T09:39:23.981527Z"
+     "iopub.execute_input": "2026-06-22T19:17:01.033222Z",
+     "iopub.status.busy": "2026-06-22T19:17:01.032524Z",
+     "iopub.status.idle": "2026-06-22T19:17:01.088695Z",
+     "shell.execute_reply": "2026-06-22T19:17:01.088695Z"
     },
     "papermill": {
-     "duration": 0.102567,
-     "end_time": "2026-06-09T09:39:23.982282",
+     "duration": 0.076178,
+     "end_time": "2026-06-22T19:17:01.088695",
      "exception": false,
-     "start_time": "2026-06-09T09:39:23.879715",
+     "start_time": "2026-06-22T19:17:01.012517",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4051,10 +3987,10 @@
    "id": "h9z45ebt0u",
    "metadata": {
     "papermill": {
-     "duration": 0.022227,
-     "end_time": "2026-06-09T09:39:24.025436",
+     "duration": 0.023005,
+     "end_time": "2026-06-22T19:17:01.135208",
      "exception": false,
-     "start_time": "2026-06-09T09:39:24.003209",
+     "start_time": "2026-06-22T19:17:01.112203",
      "status": "completed"
     },
     "tags": []
@@ -4082,16 +4018,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:24.073591Z",
-     "iopub.status.busy": "2026-06-09T09:39:24.073215Z",
-     "iopub.status.idle": "2026-06-09T09:39:24.724002Z",
-     "shell.execute_reply": "2026-06-09T09:39:24.723756Z"
+     "iopub.execute_input": "2026-06-22T19:17:01.179546Z",
+     "iopub.status.busy": "2026-06-22T19:17:01.179546Z",
+     "iopub.status.idle": "2026-06-22T19:17:01.726880Z",
+     "shell.execute_reply": "2026-06-22T19:17:01.726349Z"
     },
     "papermill": {
-     "duration": 0.676005,
-     "end_time": "2026-06-09T09:39:24.724121",
+     "duration": 0.569545,
+     "end_time": "2026-06-22T19:17:01.726880",
      "exception": false,
-     "start_time": "2026-06-09T09:39:24.048116",
+     "start_time": "2026-06-22T19:17:01.157335",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4103,38 +4039,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_48_38.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -4612,10 +4516,10 @@
    "id": "b5f97e90",
    "metadata": {
     "papermill": {
-     "duration": 0.023156,
-     "end_time": "2026-06-09T09:39:24.771085",
+     "duration": 0.02364,
+     "end_time": "2026-06-22T19:17:01.774341",
      "exception": false,
-     "start_time": "2026-06-09T09:39:24.747929",
+     "start_time": "2026-06-22T19:17:01.750701",
      "status": "completed"
     },
     "tags": []
@@ -4630,16 +4534,16 @@
    "id": "gwxh8zq2zlr",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:24.828310Z",
-     "iopub.status.busy": "2026-06-09T09:39:24.827919Z",
-     "iopub.status.idle": "2026-06-09T09:39:24.877091Z",
-     "shell.execute_reply": "2026-06-09T09:39:24.877450Z"
+     "iopub.execute_input": "2026-06-22T19:17:01.826207Z",
+     "iopub.status.busy": "2026-06-22T19:17:01.826207Z",
+     "iopub.status.idle": "2026-06-22T19:17:01.927635Z",
+     "shell.execute_reply": "2026-06-22T19:17:01.927635Z"
     },
     "papermill": {
-     "duration": 0.07792,
-     "end_time": "2026-06-09T09:39:24.877628",
+     "duration": 0.128655,
+     "end_time": "2026-06-22T19:17:01.927635",
      "exception": false,
-     "start_time": "2026-06-09T09:39:24.799708",
+     "start_time": "2026-06-22T19:17:01.798980",
      "status": "completed"
     },
     "tags": [],
@@ -4651,14 +4555,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_21_50_48_38.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_17_01_25.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"638pt\" height=\"1262pt\"\r\n",
@@ -5075,8 +4979,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -5088,7 +4992,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -5103,10 +5007,10 @@
    "id": "r9agb9kd81",
    "metadata": {
     "papermill": {
-     "duration": 0.032732,
-     "end_time": "2026-06-09T09:39:24.943774",
+     "duration": 0.024274,
+     "end_time": "2026-06-22T19:17:01.975248",
      "exception": false,
-     "start_time": "2026-06-09T09:39:24.911042",
+     "start_time": "2026-06-22T19:17:01.950974",
      "status": "completed"
     },
     "tags": []
@@ -5137,10 +5041,10 @@
    "id": "xdkmdixf5b",
    "metadata": {
     "papermill": {
-     "duration": 0.027251,
-     "end_time": "2026-06-09T09:39:24.999931",
+     "duration": 0.024919,
+     "end_time": "2026-06-22T19:17:02.023538",
      "exception": false,
-     "start_time": "2026-06-09T09:39:24.972680",
+     "start_time": "2026-06-22T19:17:01.998619",
      "status": "completed"
     },
     "tags": []
@@ -5172,10 +5076,10 @@
    "id": "ca7ba69f",
    "metadata": {
     "papermill": {
-     "duration": 0.024029,
-     "end_time": "2026-06-09T09:39:25.047484",
+     "duration": 0.024308,
+     "end_time": "2026-06-22T19:17:02.069868",
      "exception": false,
-     "start_time": "2026-06-09T09:39:25.023455",
+     "start_time": "2026-06-22T19:17:02.045560",
      "status": "completed"
     },
     "tags": []
@@ -5209,16 +5113,16 @@
    "id": "708fb9d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:25.094451Z",
-     "iopub.status.busy": "2026-06-09T09:39:25.093880Z",
-     "iopub.status.idle": "2026-06-09T09:39:25.132020Z",
-     "shell.execute_reply": "2026-06-09T09:39:25.131767Z"
+     "iopub.execute_input": "2026-06-22T19:17:02.125814Z",
+     "iopub.status.busy": "2026-06-22T19:17:02.125814Z",
+     "iopub.status.idle": "2026-06-22T19:17:02.153867Z",
+     "shell.execute_reply": "2026-06-22T19:17:02.153867Z"
     },
     "papermill": {
-     "duration": 0.062094,
-     "end_time": "2026-06-09T09:39:25.132134",
+     "duration": 0.05768,
+     "end_time": "2026-06-22T19:17:02.153867",
      "exception": false,
-     "start_time": "2026-06-09T09:39:25.070040",
+     "start_time": "2026-06-22T19:17:02.096187",
      "status": "completed"
     },
     "tags": []
@@ -5267,10 +5171,10 @@
    "id": "09b71176",
    "metadata": {
     "papermill": {
-     "duration": 0.022978,
-     "end_time": "2026-06-09T09:39:25.179115",
+     "duration": 0.023367,
+     "end_time": "2026-06-22T19:17:02.202973",
      "exception": false,
-     "start_time": "2026-06-09T09:39:25.156137",
+     "start_time": "2026-06-22T19:17:02.179606",
      "status": "completed"
     },
     "tags": []
@@ -5292,10 +5196,10 @@
    "id": "vra9u39ies8",
    "metadata": {
     "papermill": {
-     "duration": 0.032489,
-     "end_time": "2026-06-09T09:39:25.238369",
+     "duration": 0.024202,
+     "end_time": "2026-06-22T19:17:02.250027",
      "exception": false,
-     "start_time": "2026-06-09T09:39:25.205880",
+     "start_time": "2026-06-22T19:17:02.225825",
      "status": "completed"
     },
     "tags": []
@@ -5324,16 +5228,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:25.293974Z",
-     "iopub.status.busy": "2026-06-09T09:39:25.293267Z",
-     "iopub.status.idle": "2026-06-09T09:39:28.187545Z",
-     "shell.execute_reply": "2026-06-09T09:39:28.187344Z"
+     "iopub.execute_input": "2026-06-22T19:17:02.298230Z",
+     "iopub.status.busy": "2026-06-22T19:17:02.298230Z",
+     "iopub.status.idle": "2026-06-22T19:17:05.009068Z",
+     "shell.execute_reply": "2026-06-22T19:17:05.008529Z"
     },
     "papermill": {
-     "duration": 2.919543,
-     "end_time": "2026-06-09T09:39:28.187642",
+     "duration": 2.735549,
+     "end_time": "2026-06-22T19:17:05.009068",
      "exception": false,
-     "start_time": "2026-06-09T09:39:25.268099",
+     "start_time": "2026-06-22T19:17:02.273519",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -9195,10 +9099,10 @@
    "id": "r1j8wn479sc",
    "metadata": {
     "papermill": {
-     "duration": 0.043934,
-     "end_time": "2026-06-09T09:39:28.272876",
+     "duration": 0.043881,
+     "end_time": "2026-06-22T19:17:05.099989",
      "exception": false,
-     "start_time": "2026-06-09T09:39:28.228942",
+     "start_time": "2026-06-22T19:17:05.056108",
      "status": "completed"
     },
     "tags": []
@@ -9230,10 +9134,10 @@
    "id": "292e1625",
    "metadata": {
     "papermill": {
-     "duration": 0.04426,
-     "end_time": "2026-06-09T09:39:28.361889",
+     "duration": 0.050507,
+     "end_time": "2026-06-22T19:17:05.198497",
      "exception": false,
-     "start_time": "2026-06-09T09:39:28.317629",
+     "start_time": "2026-06-22T19:17:05.147990",
      "status": "completed"
     },
     "tags": []
@@ -9272,16 +9176,16 @@
    "id": "fcfdca03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:28.448870Z",
-     "iopub.status.busy": "2026-06-09T09:39:28.448563Z",
-     "iopub.status.idle": "2026-06-09T09:39:28.494811Z",
-     "shell.execute_reply": "2026-06-09T09:39:28.494598Z"
+     "iopub.execute_input": "2026-06-22T19:17:05.293763Z",
+     "iopub.status.busy": "2026-06-22T19:17:05.293763Z",
+     "iopub.status.idle": "2026-06-22T19:17:05.325388Z",
+     "shell.execute_reply": "2026-06-22T19:17:05.325388Z"
     },
     "papermill": {
-     "duration": 0.091431,
-     "end_time": "2026-06-09T09:39:28.494921",
+     "duration": 0.079476,
+     "end_time": "2026-06-22T19:17:05.325388",
      "exception": false,
-     "start_time": "2026-06-09T09:39:28.403490",
+     "start_time": "2026-06-22T19:17:05.245912",
      "status": "completed"
     },
     "tags": []
@@ -9354,10 +9258,10 @@
    "id": "3c3ea47c",
    "metadata": {
     "papermill": {
-     "duration": 0.055982,
-     "end_time": "2026-06-09T09:39:28.599657",
+     "duration": 0.045908,
+     "end_time": "2026-06-22T19:17:05.464528",
      "exception": false,
-     "start_time": "2026-06-09T09:39:28.543675",
+     "start_time": "2026-06-22T19:17:05.418620",
      "status": "completed"
     },
     "tags": []
@@ -9395,16 +9299,16 @@
    "id": "c38f2060",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:28.703219Z",
-     "iopub.status.busy": "2026-06-09T09:39:28.702902Z",
-     "iopub.status.idle": "2026-06-09T09:39:28.761740Z",
-     "shell.execute_reply": "2026-06-09T09:39:28.761362Z"
+     "iopub.execute_input": "2026-06-22T19:17:05.564528Z",
+     "iopub.status.busy": "2026-06-22T19:17:05.564528Z",
+     "iopub.status.idle": "2026-06-22T19:17:05.600043Z",
+     "shell.execute_reply": "2026-06-22T19:17:05.600043Z"
     },
     "papermill": {
-     "duration": 0.106955,
-     "end_time": "2026-06-09T09:39:28.761919",
+     "duration": 0.084542,
+     "end_time": "2026-06-22T19:17:05.600043",
      "exception": false,
-     "start_time": "2026-06-09T09:39:28.654964",
+     "start_time": "2026-06-22T19:17:05.515501",
      "status": "completed"
     },
     "tags": []
@@ -9489,10 +9393,10 @@
    "id": "d90f5f02",
    "metadata": {
     "papermill": {
-     "duration": 0.051288,
-     "end_time": "2026-06-09T09:39:28.856916",
+     "duration": 0.046739,
+     "end_time": "2026-06-22T19:17:05.697782",
      "exception": false,
-     "start_time": "2026-06-09T09:39:28.805628",
+     "start_time": "2026-06-22T19:17:05.651043",
      "status": "completed"
     },
     "tags": []
@@ -9515,10 +9419,10 @@
    "id": "h3k6kjvamho",
    "metadata": {
     "papermill": {
-     "duration": 0.053565,
-     "end_time": "2026-06-09T09:39:28.957674",
+     "duration": 0.048931,
+     "end_time": "2026-06-22T19:17:05.794613",
      "exception": false,
-     "start_time": "2026-06-09T09:39:28.904109",
+     "start_time": "2026-06-22T19:17:05.745682",
      "status": "completed"
     },
     "tags": []
@@ -9546,16 +9450,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:29.063174Z",
-     "iopub.status.busy": "2026-06-09T09:39:29.062831Z",
-     "iopub.status.idle": "2026-06-09T09:39:37.227724Z",
-     "shell.execute_reply": "2026-06-09T09:39:37.227523Z"
+     "iopub.execute_input": "2026-06-22T19:17:05.887121Z",
+     "iopub.status.busy": "2026-06-22T19:17:05.887121Z",
+     "iopub.status.idle": "2026-06-22T19:17:12.564919Z",
+     "shell.execute_reply": "2026-06-22T19:17:12.560919Z"
     },
     "papermill": {
-     "duration": 8.220473,
-     "end_time": "2026-06-09T09:39:37.227825",
+     "duration": 6.724306,
+     "end_time": "2026-06-22T19:17:12.564919",
      "exception": false,
-     "start_time": "2026-06-09T09:39:29.007352",
+     "start_time": "2026-06-22T19:17:05.840613",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -9579,38 +9483,6 @@
      "output_type": "stream",
      "text": [
       "Vraie relation : y = 2*x + 1\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_51_60.gv\"\n",
       "\r\n"
      ]
     },
@@ -9997,38 +9869,6 @@
      "output_type": "stream",
      "text": [
       "Modele lineaire : log evidence = -14,03\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_21_50_53_29.gv\"\n",
-      "\r\n"
      ]
     },
     {
@@ -10489,10 +10329,10 @@
    "id": "a10ac5c7",
    "metadata": {
     "papermill": {
-     "duration": 0.047532,
-     "end_time": "2026-06-09T09:39:37.321506",
+     "duration": 0.053642,
+     "end_time": "2026-06-22T19:17:12.672082",
      "exception": false,
-     "start_time": "2026-06-09T09:39:37.273974",
+     "start_time": "2026-06-22T19:17:12.618440",
      "status": "completed"
     },
     "tags": []
@@ -10507,16 +10347,16 @@
    "id": "07c3mhq0k60l",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:37.440010Z",
-     "iopub.status.busy": "2026-06-09T09:39:37.439696Z",
-     "iopub.status.idle": "2026-06-09T09:39:37.475552Z",
-     "shell.execute_reply": "2026-06-09T09:39:37.475706Z"
+     "iopub.execute_input": "2026-06-22T19:17:12.776963Z",
+     "iopub.status.busy": "2026-06-22T19:17:12.776444Z",
+     "iopub.status.idle": "2026-06-22T19:17:12.886804Z",
+     "shell.execute_reply": "2026-06-22T19:17:12.886804Z"
     },
     "papermill": {
-     "duration": 0.100614,
-     "end_time": "2026-06-09T09:39:37.475801",
+     "duration": 0.16187,
+     "end_time": "2026-06-22T19:17:12.886804",
      "exception": false,
-     "start_time": "2026-06-09T09:39:37.375187",
+     "start_time": "2026-06-22T19:17:12.724934",
      "status": "completed"
     },
     "tags": [],
@@ -10528,14 +10368,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_21_50_53_29.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_17_07_14.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"2342pt\" height=\"973pt\"\r\n",
@@ -12852,8 +12692,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -12865,7 +12705,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -12880,10 +12720,10 @@
    "id": "kmporu069ea",
    "metadata": {
     "papermill": {
-     "duration": 0.047473,
-     "end_time": "2026-06-09T09:39:37.568130",
+     "duration": 0.058512,
+     "end_time": "2026-06-22T19:17:12.999659",
      "exception": false,
-     "start_time": "2026-06-09T09:39:37.520657",
+     "start_time": "2026-06-22T19:17:12.941147",
      "status": "completed"
     },
     "tags": []
@@ -12907,10 +12747,10 @@
    "id": "h3advals0x",
    "metadata": {
     "papermill": {
-     "duration": 0.049633,
-     "end_time": "2026-06-09T09:39:37.666590",
+     "duration": 0.052975,
+     "end_time": "2026-06-22T19:17:13.111320",
      "exception": false,
-     "start_time": "2026-06-09T09:39:37.616957",
+     "start_time": "2026-06-22T19:17:13.058345",
      "status": "completed"
     },
     "tags": []
@@ -12943,10 +12783,10 @@
    "id": "ff1f079d",
    "metadata": {
     "papermill": {
-     "duration": 0.050105,
-     "end_time": "2026-06-09T09:39:37.764997",
+     "duration": 0.050008,
+     "end_time": "2026-06-22T19:17:13.215968",
      "exception": false,
-     "start_time": "2026-06-09T09:39:37.714892",
+     "start_time": "2026-06-22T19:17:13.165960",
      "status": "completed"
     },
     "tags": []
@@ -12978,10 +12818,10 @@
    "id": "emyx91kfzua",
    "metadata": {
     "papermill": {
-     "duration": 0.047233,
-     "end_time": "2026-06-09T09:39:37.858884",
+     "duration": 0.058673,
+     "end_time": "2026-06-22T19:17:13.333917",
      "exception": false,
-     "start_time": "2026-06-09T09:39:37.811651",
+     "start_time": "2026-06-22T19:17:13.275244",
      "status": "completed"
     },
     "tags": []
@@ -13023,10 +12863,10 @@
    "id": "lzrf27g1xck",
    "metadata": {
     "papermill": {
-     "duration": 0.047578,
-     "end_time": "2026-06-09T09:39:37.953454",
+     "duration": 0.055686,
+     "end_time": "2026-06-22T19:17:13.446145",
      "exception": false,
-     "start_time": "2026-06-09T09:39:37.905876",
+     "start_time": "2026-06-22T19:17:13.390459",
      "status": "completed"
     },
     "tags": []
@@ -13058,10 +12898,10 @@
    "id": "5251a551",
    "metadata": {
     "papermill": {
-     "duration": 0.044649,
-     "end_time": "2026-06-09T09:39:38.042367",
+     "duration": 0.052282,
+     "end_time": "2026-06-22T19:17:13.551943",
      "exception": false,
-     "start_time": "2026-06-09T09:39:37.997718",
+     "start_time": "2026-06-22T19:17:13.499661",
      "status": "completed"
     },
     "tags": []
@@ -13092,16 +12932,16 @@
    "id": "5fd34a0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:38.134456Z",
-     "iopub.status.busy": "2026-06-09T09:39:38.134194Z",
-     "iopub.status.idle": "2026-06-09T09:39:38.168563Z",
-     "shell.execute_reply": "2026-06-09T09:39:38.168332Z"
+     "iopub.execute_input": "2026-06-22T19:17:13.659347Z",
+     "iopub.status.busy": "2026-06-22T19:17:13.659347Z",
+     "iopub.status.idle": "2026-06-22T19:17:13.688963Z",
+     "shell.execute_reply": "2026-06-22T19:17:13.688963Z"
     },
     "papermill": {
-     "duration": 0.080062,
-     "end_time": "2026-06-09T09:39:38.168691",
+     "duration": 0.083911,
+     "end_time": "2026-06-22T19:17:13.688963",
      "exception": false,
-     "start_time": "2026-06-09T09:39:38.088629",
+     "start_time": "2026-06-22T19:17:13.605052",
      "status": "completed"
     },
     "tags": []
@@ -13143,10 +12983,10 @@
    "id": "e35b2088",
    "metadata": {
     "papermill": {
-     "duration": 0.051049,
-     "end_time": "2026-06-09T09:39:38.268647",
+     "duration": 0.05578,
+     "end_time": "2026-06-22T19:17:13.804337",
      "exception": false,
-     "start_time": "2026-06-09T09:39:38.217598",
+     "start_time": "2026-06-22T19:17:13.748557",
      "status": "completed"
     },
     "tags": []
@@ -13185,18 +13025,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 54.318054,
-   "end_time": "2026-06-09T09:39:38.738412",
+   "duration": 28.909148,
+   "end_time": "2026-06-22T19:17:14.100345",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-8-Model-Selection.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-8-Model-Selection.ipynb",
+   "input_path": "Infer-8-Model-Selection.ipynb",
+   "output_path": "Infer-8-Model-Selection.ipynb",
    "parameters": {},
-   "start_time": "2026-06-09T09:38:44.420358",
+   "start_time": "2026-06-22T19:16:45.191197",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Topic-Models.ipynb
@@ -5,10 +5,10 @@
    "id": "1452f2aa",
    "metadata": {
     "papermill": {
-     "duration": 0.024118,
-     "end_time": "2026-06-09T09:38:41.373834",
+     "duration": 0.005201,
+     "end_time": "2026-06-22T19:17:17.990612",
      "exception": false,
-     "start_time": "2026-06-09T09:38:41.349716",
+     "start_time": "2026-06-22T19:17:17.985411",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "7b2c63fe",
    "metadata": {
     "papermill": {
-     "duration": 0.020996,
-     "end_time": "2026-06-09T09:38:41.416111",
+     "duration": 0.004092,
+     "end_time": "2026-06-22T19:17:17.998803",
      "exception": false,
-     "start_time": "2026-06-09T09:38:41.395115",
+     "start_time": "2026-06-22T19:17:17.994711",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:41.467896Z",
-     "iopub.status.busy": "2026-06-09T09:38:41.459624Z",
-     "iopub.status.idle": "2026-06-09T09:38:51.743500Z",
-     "shell.execute_reply": "2026-06-09T09:38:51.738788Z"
+     "iopub.execute_input": "2026-06-22T19:17:18.013836Z",
+     "iopub.status.busy": "2026-06-22T19:17:18.010148Z",
+     "iopub.status.idle": "2026-06-22T19:17:20.473181Z",
+     "shell.execute_reply": "2026-06-22T19:17:20.470180Z"
     },
     "papermill": {
-     "duration": 10.310549,
-     "end_time": "2026-06-09T09:38:51.743740",
+     "duration": 2.470048,
+     "end_time": "2026-06-22T19:17:20.473181",
      "exception": false,
-     "start_time": "2026-06-09T09:38:41.433191",
+     "start_time": "2026-06-22T19:17:18.003133",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -94,7 +94,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-72560.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-104724.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -139,12 +139,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.83.164.85:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.47:2048/\", \"http://172.25.48.1:2048/\", \"http://172.28.0.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '72560.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '104724.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -241,10 +241,10 @@
    "id": "fc6a9eaf",
    "metadata": {
     "papermill": {
-     "duration": 0.01297,
-     "end_time": "2026-06-09T09:38:51.770255",
+     "duration": 0.010001,
+     "end_time": "2026-06-22T19:17:20.492181",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.757285",
+     "start_time": "2026-06-22T19:17:20.482180",
      "status": "completed"
     },
     "tags": []
@@ -259,16 +259,16 @@
    "id": "i3luanxjpn",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:51.799675Z",
-     "iopub.status.busy": "2026-06-09T09:38:51.799173Z",
-     "iopub.status.idle": "2026-06-09T09:38:52.724510Z",
-     "shell.execute_reply": "2026-06-09T09:38:52.724112Z"
+     "iopub.execute_input": "2026-06-22T19:17:20.513183Z",
+     "iopub.status.busy": "2026-06-22T19:17:20.513183Z",
+     "iopub.status.idle": "2026-06-22T19:17:21.178437Z",
+     "shell.execute_reply": "2026-06-22T19:17:21.178437Z"
     },
     "papermill": {
-     "duration": 0.94045,
-     "end_time": "2026-06-09T09:38:52.724702",
+     "duration": 0.676256,
+     "end_time": "2026-06-22T19:17:21.178437",
      "exception": false,
-     "start_time": "2026-06-09T09:38:51.784252",
+     "start_time": "2026-06-22T19:17:20.502181",
      "status": "completed"
     },
     "tags": [],
@@ -305,10 +305,10 @@
    "id": "jqir8e880bd",
    "metadata": {
     "papermill": {
-     "duration": 0.013156,
-     "end_time": "2026-06-09T09:38:52.751403",
+     "duration": 0.008407,
+     "end_time": "2026-06-22T19:17:21.195163",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.738247",
+     "start_time": "2026-06-22T19:17:21.186756",
      "status": "completed"
     },
     "tags": []
@@ -329,10 +329,10 @@
    "id": "ijnjw99vpqo",
    "metadata": {
     "papermill": {
-     "duration": 0.019703,
-     "end_time": "2026-06-09T09:38:52.784442",
+     "duration": 0.007645,
+     "end_time": "2026-06-22T19:17:21.211091",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.764739",
+     "start_time": "2026-06-22T19:17:21.203446",
      "status": "completed"
     },
     "tags": []
@@ -356,10 +356,10 @@
    "id": "bd8fcc4e",
    "metadata": {
     "papermill": {
-     "duration": 0.017929,
-     "end_time": "2026-06-09T09:38:52.815304",
+     "duration": 0.006992,
+     "end_time": "2026-06-22T19:17:21.226091",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.797375",
+     "start_time": "2026-06-22T19:17:21.219099",
      "status": "completed"
     },
     "tags": []
@@ -392,10 +392,10 @@
    "id": "xurlwv3ao4a",
    "metadata": {
     "papermill": {
-     "duration": 0.013812,
-     "end_time": "2026-06-09T09:38:52.844219",
+     "duration": 0.007001,
+     "end_time": "2026-06-22T19:17:21.241092",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.830407",
+     "start_time": "2026-06-22T19:17:21.234091",
      "status": "completed"
     },
     "tags": []
@@ -426,10 +426,10 @@
    "id": "b23a7695",
    "metadata": {
     "papermill": {
-     "duration": 0.015371,
-     "end_time": "2026-06-09T09:38:52.873521",
+     "duration": 0.00699,
+     "end_time": "2026-06-22T19:17:21.256091",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.858150",
+     "start_time": "2026-06-22T19:17:21.249101",
      "status": "completed"
     },
     "tags": []
@@ -470,10 +470,10 @@
    "id": "vnu6o65v85",
    "metadata": {
     "papermill": {
-     "duration": 0.013908,
-     "end_time": "2026-06-09T09:38:52.901138",
+     "duration": 0.006993,
+     "end_time": "2026-06-22T19:17:21.271093",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.887230",
+     "start_time": "2026-06-22T19:17:21.264100",
      "status": "completed"
     },
     "tags": []
@@ -505,10 +505,10 @@
    "id": "80a2fa01",
    "metadata": {
     "papermill": {
-     "duration": 0.015128,
-     "end_time": "2026-06-09T09:38:52.930528",
+     "duration": 0.008001,
+     "end_time": "2026-06-22T19:17:21.288093",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.915400",
+     "start_time": "2026-06-22T19:17:21.280092",
      "status": "completed"
     },
     "tags": []
@@ -548,16 +548,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:52.966094Z",
-     "iopub.status.busy": "2026-06-09T09:38:52.965544Z",
-     "iopub.status.idle": "2026-06-09T09:38:53.208948Z",
-     "shell.execute_reply": "2026-06-09T09:38:53.208596Z"
+     "iopub.execute_input": "2026-06-22T19:17:21.311173Z",
+     "iopub.status.busy": "2026-06-22T19:17:21.311173Z",
+     "iopub.status.idle": "2026-06-22T19:17:21.430266Z",
+     "shell.execute_reply": "2026-06-22T19:17:21.429756Z"
     },
     "papermill": {
-     "duration": 0.263424,
-     "end_time": "2026-06-09T09:38:53.209130",
+     "duration": 0.132318,
+     "end_time": "2026-06-22T19:17:21.430266",
      "exception": false,
-     "start_time": "2026-06-09T09:38:52.945706",
+     "start_time": "2026-06-22T19:17:21.297948",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -659,10 +659,10 @@
    "id": "xlhoqd285ii",
    "metadata": {
     "papermill": {
-     "duration": 0.01391,
-     "end_time": "2026-06-09T09:38:53.237361",
+     "duration": 0.009551,
+     "end_time": "2026-06-22T19:17:21.449434",
      "exception": false,
-     "start_time": "2026-06-09T09:38:53.223451",
+     "start_time": "2026-06-22T19:17:21.439883",
      "status": "completed"
     },
     "tags": []
@@ -697,16 +697,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:53.268894Z",
-     "iopub.status.busy": "2026-06-09T09:38:53.268364Z",
-     "iopub.status.idle": "2026-06-09T09:38:53.642488Z",
-     "shell.execute_reply": "2026-06-09T09:38:53.642108Z"
+     "iopub.execute_input": "2026-06-22T19:17:21.470438Z",
+     "iopub.status.busy": "2026-06-22T19:17:21.469439Z",
+     "iopub.status.idle": "2026-06-22T19:17:21.682235Z",
+     "shell.execute_reply": "2026-06-22T19:17:21.682235Z"
     },
     "papermill": {
-     "duration": 0.390448,
-     "end_time": "2026-06-09T09:38:53.642703",
+     "duration": 0.223793,
+     "end_time": "2026-06-22T19:17:21.682235",
      "exception": false,
-     "start_time": "2026-06-09T09:38:53.252255",
+     "start_time": "2026-06-22T19:17:21.458442",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -766,10 +766,10 @@
    "id": "csoow5q2v7",
    "metadata": {
     "papermill": {
-     "duration": 0.013538,
-     "end_time": "2026-06-09T09:38:53.670733",
+     "duration": 0.008,
+     "end_time": "2026-06-22T19:17:21.699236",
      "exception": false,
-     "start_time": "2026-06-09T09:38:53.657195",
+     "start_time": "2026-06-22T19:17:21.691236",
      "status": "completed"
     },
     "tags": []
@@ -803,16 +803,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:53.702127Z",
-     "iopub.status.busy": "2026-06-09T09:38:53.701596Z",
-     "iopub.status.idle": "2026-06-09T09:38:58.823379Z",
-     "shell.execute_reply": "2026-06-09T09:38:58.821472Z"
+     "iopub.execute_input": "2026-06-22T19:17:21.717403Z",
+     "iopub.status.busy": "2026-06-22T19:17:21.716404Z",
+     "iopub.status.idle": "2026-06-22T19:17:23.754203Z",
+     "shell.execute_reply": "2026-06-22T19:17:23.754203Z"
     },
     "papermill": {
-     "duration": 5.138187,
-     "end_time": "2026-06-09T09:38:58.823555",
+     "duration": 2.046966,
+     "end_time": "2026-06-22T19:17:23.754203",
      "exception": false,
-     "start_time": "2026-06-09T09:38:53.685368",
+     "start_time": "2026-06-22T19:17:21.707237",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -824,38 +824,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_47_83.gv\"\n",
-      "\r\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1327,10 +1295,10 @@
    "id": "6svtmfrylba",
    "metadata": {
     "papermill": {
-     "duration": 0.020094,
-     "end_time": "2026-06-09T09:38:58.865267",
+     "duration": 0.01164,
+     "end_time": "2026-06-22T19:17:23.777945",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.845173",
+     "start_time": "2026-06-22T19:17:23.766305",
      "status": "completed"
     },
     "tags": []
@@ -1368,16 +1336,16 @@
    "id": "999fcj0uf1g",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:58.938890Z",
-     "iopub.status.busy": "2026-06-09T09:38:58.938305Z",
-     "iopub.status.idle": "2026-06-09T09:38:59.084015Z",
-     "shell.execute_reply": "2026-06-09T09:38:59.083648Z"
+     "iopub.execute_input": "2026-06-22T19:17:23.814484Z",
+     "iopub.status.busy": "2026-06-22T19:17:23.814484Z",
+     "iopub.status.idle": "2026-06-22T19:17:24.000455Z",
+     "shell.execute_reply": "2026-06-22T19:17:24.000455Z"
     },
     "papermill": {
-     "duration": 0.181994,
-     "end_time": "2026-06-09T09:38:59.084204",
+     "duration": 0.206508,
+     "end_time": "2026-06-22T19:17:24.000455",
      "exception": false,
-     "start_time": "2026-06-09T09:38:58.902210",
+     "start_time": "2026-06-22T19:17:23.793947",
      "status": "completed"
     },
     "tags": [],
@@ -1389,14 +1357,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_22_47_47_83.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_17_21_87.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"204pt\" height=\"444pt\"\r\n",
@@ -1536,8 +1504,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -1549,7 +1517,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1564,10 +1532,10 @@
    "id": "gsr4n9ovnlr",
    "metadata": {
     "papermill": {
-     "duration": 0.024489,
-     "end_time": "2026-06-09T09:38:59.136042",
+     "duration": 0.012003,
+     "end_time": "2026-06-22T19:17:24.029796",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.111553",
+     "start_time": "2026-06-22T19:17:24.017793",
      "status": "completed"
     },
     "tags": []
@@ -1609,10 +1577,10 @@
    "id": "o57n219kxqb",
    "metadata": {
     "papermill": {
-     "duration": 0.020689,
-     "end_time": "2026-06-09T09:38:59.178973",
+     "duration": 0.011001,
+     "end_time": "2026-06-22T19:17:24.051805",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.158284",
+     "start_time": "2026-06-22T19:17:24.040804",
      "status": "completed"
     },
     "tags": []
@@ -1641,10 +1609,10 @@
    "id": "3guhtb200iz",
    "metadata": {
     "papermill": {
-     "duration": 0.021498,
-     "end_time": "2026-06-09T09:38:59.222722",
+     "duration": 0.013998,
+     "end_time": "2026-06-22T19:17:24.076797",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.201224",
+     "start_time": "2026-06-22T19:17:24.062799",
      "status": "completed"
     },
     "tags": []
@@ -1661,16 +1629,16 @@
    "id": "52jbbkuqdnp",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:59.266542Z",
-     "iopub.status.busy": "2026-06-09T09:38:59.266061Z",
-     "iopub.status.idle": "2026-06-09T09:38:59.502858Z",
-     "shell.execute_reply": "2026-06-09T09:38:59.502460Z"
+     "iopub.execute_input": "2026-06-22T19:17:24.108805Z",
+     "iopub.status.busy": "2026-06-22T19:17:24.108805Z",
+     "iopub.status.idle": "2026-06-22T19:17:24.220465Z",
+     "shell.execute_reply": "2026-06-22T19:17:24.220465Z"
     },
     "papermill": {
-     "duration": 0.259671,
-     "end_time": "2026-06-09T09:38:59.503060",
+     "duration": 0.126668,
+     "end_time": "2026-06-22T19:17:24.220465",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.243389",
+     "start_time": "2026-06-22T19:17:24.093797",
      "status": "completed"
     },
     "tags": [],
@@ -1766,10 +1734,10 @@
    "id": "57ted49ipac",
    "metadata": {
     "papermill": {
-     "duration": 0.024829,
-     "end_time": "2026-06-09T09:38:59.550397",
+     "duration": 0.012,
+     "end_time": "2026-06-22T19:17:24.245464",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.525568",
+     "start_time": "2026-06-22T19:17:24.233464",
      "status": "completed"
     },
     "tags": []
@@ -1796,16 +1764,16 @@
    "id": "r4m4ks1spuf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:38:59.608751Z",
-     "iopub.status.busy": "2026-06-09T09:38:59.608125Z",
-     "iopub.status.idle": "2026-06-09T09:39:13.596435Z",
-     "shell.execute_reply": "2026-06-09T09:39:13.596038Z"
+     "iopub.execute_input": "2026-06-22T19:17:24.272332Z",
+     "iopub.status.busy": "2026-06-22T19:17:24.271830Z",
+     "iopub.status.idle": "2026-06-22T19:17:30.207990Z",
+     "shell.execute_reply": "2026-06-22T19:17:30.207990Z"
     },
     "papermill": {
-     "duration": 14.02267,
-     "end_time": "2026-06-09T09:39:13.596655",
+     "duration": 5.949548,
+     "end_time": "2026-06-22T19:17:30.207990",
      "exception": false,
-     "start_time": "2026-06-09T09:38:59.573985",
+     "start_time": "2026-06-22T19:17:24.258442",
      "status": "completed"
     },
     "tags": [],
@@ -1819,38 +1787,6 @@
      "output_type": "stream",
      "text": [
       "=== Inference LDA Corrigee ===\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_50_40.gv\"\n",
       "\r\n"
      ]
     },
@@ -1886,38 +1822,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_50_82.gv\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Doc 2 : politique, election, vote, election, politique\r\n"
      ]
     },
@@ -1939,38 +1843,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_51_44.gv\"\n",
       "\r\n"
      ]
     },
@@ -2006,38 +1878,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_52_22.gv\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Doc 4 : sport, equipe, politique, election, sport\r\n"
      ]
     },
@@ -2059,38 +1899,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_06_19_26_22_47_53_31.gv\"\n",
       "\r\n"
      ]
     },
@@ -2184,10 +1992,10 @@
    "id": "8k7gcy3r1fv",
    "metadata": {
     "papermill": {
-     "duration": 0.030142,
-     "end_time": "2026-06-09T09:39:13.657866",
+     "duration": 0.011429,
+     "end_time": "2026-06-22T19:17:30.232427",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.627724",
+     "start_time": "2026-06-22T19:17:30.220998",
      "status": "completed"
     },
     "tags": []
@@ -2228,16 +2036,16 @@
    "id": "gu30fyfyiap",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:13.710617Z",
-     "iopub.status.busy": "2026-06-09T09:39:13.710105Z",
-     "iopub.status.idle": "2026-06-09T09:39:13.790510Z",
-     "shell.execute_reply": "2026-06-09T09:39:13.790877Z"
+     "iopub.execute_input": "2026-06-22T19:17:30.259223Z",
+     "iopub.status.busy": "2026-06-22T19:17:30.258228Z",
+     "iopub.status.idle": "2026-06-22T19:17:30.367769Z",
+     "shell.execute_reply": "2026-06-22T19:17:30.367769Z"
     },
     "papermill": {
-     "duration": 0.105963,
-     "end_time": "2026-06-09T09:39:13.791070",
+     "duration": 0.122547,
+     "end_time": "2026-06-22T19:17:30.367769",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.685107",
+     "start_time": "2026-06-22T19:17:30.245222",
      "status": "completed"
     },
     "tags": [],
@@ -2249,14 +2057,14 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_19_26_22_47_53_31.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "\r\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_17_28_65.svg</div>\r\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.5 (20260411.2331)\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"1104pt\" height=\"608pt\"\r\n",
@@ -2934,8 +2742,8 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\n",
-       "    </div>\n",
+       "\r\n",
+       "    </div>\r\n",
        "</div>"
       ]
      },
@@ -2947,7 +2755,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -2962,10 +2770,10 @@
    "id": "vrkrzb9mpw",
    "metadata": {
     "papermill": {
-     "duration": 0.029509,
-     "end_time": "2026-06-09T09:39:13.845914",
+     "duration": 0.013999,
+     "end_time": "2026-06-22T19:17:30.395822",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.816405",
+     "start_time": "2026-06-22T19:17:30.381823",
      "status": "completed"
     },
     "tags": []
@@ -3002,10 +2810,10 @@
    "id": "65b0019f",
    "metadata": {
     "papermill": {
-     "duration": 0.028494,
-     "end_time": "2026-06-09T09:39:13.900435",
+     "duration": 0.014741,
+     "end_time": "2026-06-22T19:17:30.423946",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.871941",
+     "start_time": "2026-06-22T19:17:30.409205",
      "status": "completed"
     },
     "tags": []
@@ -3034,16 +2842,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:13.965817Z",
-     "iopub.status.busy": "2026-06-09T09:39:13.965267Z",
-     "iopub.status.idle": "2026-06-09T09:39:14.058991Z",
-     "shell.execute_reply": "2026-06-09T09:39:14.059297Z"
+     "iopub.execute_input": "2026-06-22T19:17:30.455116Z",
+     "iopub.status.busy": "2026-06-22T19:17:30.455116Z",
+     "iopub.status.idle": "2026-06-22T19:17:30.504118Z",
+     "shell.execute_reply": "2026-06-22T19:17:30.504118Z"
     },
     "papermill": {
-     "duration": 0.128315,
-     "end_time": "2026-06-09T09:39:14.060212",
+     "duration": 0.065981,
+     "end_time": "2026-06-22T19:17:30.504118",
      "exception": false,
-     "start_time": "2026-06-09T09:39:13.931897",
+     "start_time": "2026-06-22T19:17:30.438137",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3160,10 +2968,10 @@
    "id": "6p8toq74n8h",
    "metadata": {
     "papermill": {
-     "duration": 0.041548,
-     "end_time": "2026-06-09T09:39:14.138456",
+     "duration": 0.013992,
+     "end_time": "2026-06-22T19:17:30.531118",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.096908",
+     "start_time": "2026-06-22T19:17:30.517126",
      "status": "completed"
     },
     "tags": []
@@ -3197,10 +3005,10 @@
    "id": "1dc820f4",
    "metadata": {
     "papermill": {
-     "duration": 0.026642,
-     "end_time": "2026-06-09T09:39:14.205880",
+     "duration": 0.013514,
+     "end_time": "2026-06-22T19:17:30.558652",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.179238",
+     "start_time": "2026-06-22T19:17:30.545138",
      "status": "completed"
     },
     "tags": []
@@ -3224,16 +3032,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:14.269343Z",
-     "iopub.status.busy": "2026-06-09T09:39:14.268793Z",
-     "iopub.status.idle": "2026-06-09T09:39:14.419552Z",
-     "shell.execute_reply": "2026-06-09T09:39:14.418132Z"
+     "iopub.execute_input": "2026-06-22T19:17:30.590172Z",
+     "iopub.status.busy": "2026-06-22T19:17:30.589647Z",
+     "iopub.status.idle": "2026-06-22T19:17:30.668442Z",
+     "shell.execute_reply": "2026-06-22T19:17:30.668442Z"
     },
     "papermill": {
-     "duration": 0.184269,
-     "end_time": "2026-06-09T09:39:14.419741",
+     "duration": 0.097029,
+     "end_time": "2026-06-22T19:17:30.669451",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.235472",
+     "start_time": "2026-06-22T19:17:30.572422",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3405,10 +3213,10 @@
    "id": "cc8aichxbkn",
    "metadata": {
     "papermill": {
-     "duration": 0.029149,
-     "end_time": "2026-06-09T09:39:14.480587",
+     "duration": 0.013991,
+     "end_time": "2026-06-22T19:17:30.699944",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.451438",
+     "start_time": "2026-06-22T19:17:30.685953",
      "status": "completed"
     },
     "tags": []
@@ -3448,10 +3256,10 @@
    "id": "ac34753e",
    "metadata": {
     "papermill": {
-     "duration": 0.027022,
-     "end_time": "2026-06-09T09:39:14.540242",
+     "duration": 0.014234,
+     "end_time": "2026-06-22T19:17:30.729179",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.513220",
+     "start_time": "2026-06-22T19:17:30.714945",
      "status": "completed"
     },
     "tags": []
@@ -3479,16 +3287,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:14.609761Z",
-     "iopub.status.busy": "2026-06-09T09:39:14.609238Z",
-     "iopub.status.idle": "2026-06-09T09:39:14.733954Z",
-     "shell.execute_reply": "2026-06-09T09:39:14.733543Z"
+     "iopub.execute_input": "2026-06-22T19:17:30.759722Z",
+     "iopub.status.busy": "2026-06-22T19:17:30.759722Z",
+     "iopub.status.idle": "2026-06-22T19:17:30.826128Z",
+     "shell.execute_reply": "2026-06-22T19:17:30.825597Z"
     },
     "papermill": {
-     "duration": 0.160378,
-     "end_time": "2026-06-09T09:39:14.734148",
+     "duration": 0.081928,
+     "end_time": "2026-06-22T19:17:30.826128",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.573770",
+     "start_time": "2026-06-22T19:17:30.744200",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3581,10 +3389,10 @@
    "id": "ddchdll6qyc",
    "metadata": {
     "papermill": {
-     "duration": 0.036178,
-     "end_time": "2026-06-09T09:39:14.800599",
+     "duration": 0.016935,
+     "end_time": "2026-06-22T19:17:30.861260",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.764421",
+     "start_time": "2026-06-22T19:17:30.844325",
      "status": "completed"
     },
     "tags": []
@@ -3619,10 +3427,10 @@
    "id": "c03e2ce8",
    "metadata": {
     "papermill": {
-     "duration": 0.028056,
-     "end_time": "2026-06-09T09:39:14.860521",
+     "duration": 0.017846,
+     "end_time": "2026-06-22T19:17:30.896656",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.832465",
+     "start_time": "2026-06-22T19:17:30.878810",
      "status": "completed"
     },
     "tags": []
@@ -3645,10 +3453,10 @@
    "id": "fjhhqs4af88",
    "metadata": {
     "papermill": {
-     "duration": 0.03066,
-     "end_time": "2026-06-09T09:39:14.920170",
+     "duration": 0.017999,
+     "end_time": "2026-06-22T19:17:30.934657",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.889510",
+     "start_time": "2026-06-22T19:17:30.916658",
      "status": "completed"
     },
     "tags": []
@@ -3678,10 +3486,10 @@
    "id": "d7c637b6",
    "metadata": {
     "papermill": {
-     "duration": 0.030445,
-     "end_time": "2026-06-09T09:39:14.982972",
+     "duration": 0.016171,
+     "end_time": "2026-06-22T19:17:30.967458",
      "exception": false,
-     "start_time": "2026-06-09T09:39:14.952527",
+     "start_time": "2026-06-22T19:17:30.951287",
      "status": "completed"
     },
     "tags": []
@@ -3699,10 +3507,10 @@
    "id": "oxub8w4irxl",
    "metadata": {
     "papermill": {
-     "duration": 0.033147,
-     "end_time": "2026-06-09T09:39:15.045190",
+     "duration": 0.01643,
+     "end_time": "2026-06-22T19:17:30.999891",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.012043",
+     "start_time": "2026-06-22T19:17:30.983461",
      "status": "completed"
     },
     "tags": []
@@ -3733,10 +3541,10 @@
    "id": "2ocnn07hu2o",
    "metadata": {
     "papermill": {
-     "duration": 0.040828,
-     "end_time": "2026-06-09T09:39:15.119453",
+     "duration": 0.015479,
+     "end_time": "2026-06-22T19:17:31.033074",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.078625",
+     "start_time": "2026-06-22T19:17:31.017595",
      "status": "completed"
     },
     "tags": []
@@ -3756,16 +3564,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:15.198907Z",
-     "iopub.status.busy": "2026-06-09T09:39:15.198404Z",
-     "iopub.status.idle": "2026-06-09T09:39:15.319852Z",
-     "shell.execute_reply": "2026-06-09T09:39:15.319444Z"
+     "iopub.execute_input": "2026-06-22T19:17:31.064210Z",
+     "iopub.status.busy": "2026-06-22T19:17:31.063697Z",
+     "iopub.status.idle": "2026-06-22T19:17:31.123560Z",
+     "shell.execute_reply": "2026-06-22T19:17:31.123031Z"
     },
     "papermill": {
-     "duration": 0.155958,
-     "end_time": "2026-06-09T09:39:15.320049",
+     "duration": 0.075916,
+     "end_time": "2026-06-22T19:17:31.123560",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.164091",
+     "start_time": "2026-06-22T19:17:31.047644",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3893,10 +3701,10 @@
    "id": "x4ns56qo67",
    "metadata": {
     "papermill": {
-     "duration": 0.039125,
-     "end_time": "2026-06-09T09:39:15.404701",
+     "duration": 0.014512,
+     "end_time": "2026-06-22T19:17:31.153716",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.365576",
+     "start_time": "2026-06-22T19:17:31.139204",
      "status": "completed"
     },
     "tags": []
@@ -3931,10 +3739,10 @@
    "id": "1cbe72e5",
    "metadata": {
     "papermill": {
-     "duration": 0.034764,
-     "end_time": "2026-06-09T09:39:15.473428",
+     "duration": 0.020001,
+     "end_time": "2026-06-22T19:17:31.194947",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.438664",
+     "start_time": "2026-06-22T19:17:31.174946",
      "status": "completed"
     },
     "tags": []
@@ -3977,10 +3785,10 @@
    "id": "yidp380kmlf",
    "metadata": {
     "papermill": {
-     "duration": 0.030926,
-     "end_time": "2026-06-09T09:39:15.539029",
+     "duration": 0.017502,
+     "end_time": "2026-06-22T19:17:31.231466",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.508103",
+     "start_time": "2026-06-22T19:17:31.213964",
      "status": "completed"
     },
     "tags": []
@@ -4020,10 +3828,10 @@
    "id": "8e836a16",
    "metadata": {
     "papermill": {
-     "duration": 0.035339,
-     "end_time": "2026-06-09T09:39:15.607464",
+     "duration": 0.016002,
+     "end_time": "2026-06-22T19:17:31.265097",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.572125",
+     "start_time": "2026-06-22T19:17:31.249095",
      "status": "completed"
     },
     "tags": []
@@ -4053,16 +3861,16 @@
    "id": "39a2f788",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:15.670729Z",
-     "iopub.status.busy": "2026-06-09T09:39:15.670109Z",
-     "iopub.status.idle": "2026-06-09T09:39:15.743168Z",
-     "shell.execute_reply": "2026-06-09T09:39:15.742623Z"
+     "iopub.execute_input": "2026-06-22T19:17:31.301151Z",
+     "iopub.status.busy": "2026-06-22T19:17:31.301151Z",
+     "iopub.status.idle": "2026-06-22T19:17:31.343172Z",
+     "shell.execute_reply": "2026-06-22T19:17:31.343172Z"
     },
     "papermill": {
-     "duration": 0.107675,
-     "end_time": "2026-06-09T09:39:15.743376",
+     "duration": 0.062073,
+     "end_time": "2026-06-22T19:17:31.343172",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.635701",
+     "start_time": "2026-06-22T19:17:31.281099",
      "status": "completed"
     },
     "tags": []
@@ -4114,10 +3922,10 @@
    "id": "b7941386",
    "metadata": {
     "papermill": {
-     "duration": 0.030094,
-     "end_time": "2026-06-09T09:39:15.803579",
+     "duration": 0.020452,
+     "end_time": "2026-06-22T19:17:31.382890",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.773485",
+     "start_time": "2026-06-22T19:17:31.362438",
      "status": "completed"
     },
     "tags": []
@@ -4159,16 +3967,16 @@
    "id": "908106ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:15.870260Z",
-     "iopub.status.busy": "2026-06-09T09:39:15.869372Z",
-     "iopub.status.idle": "2026-06-09T09:39:15.930449Z",
-     "shell.execute_reply": "2026-06-09T09:39:15.930063Z"
+     "iopub.execute_input": "2026-06-22T19:17:31.423911Z",
+     "iopub.status.busy": "2026-06-22T19:17:31.423911Z",
+     "iopub.status.idle": "2026-06-22T19:17:31.460116Z",
+     "shell.execute_reply": "2026-06-22T19:17:31.459124Z"
     },
     "papermill": {
-     "duration": 0.095056,
-     "end_time": "2026-06-09T09:39:15.930657",
+     "duration": 0.056218,
+     "end_time": "2026-06-22T19:17:31.460116",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.835601",
+     "start_time": "2026-06-22T19:17:31.403898",
      "status": "completed"
     },
     "tags": []
@@ -4225,10 +4033,10 @@
    "id": "0f07eda3",
    "metadata": {
     "papermill": {
-     "duration": 0.033118,
-     "end_time": "2026-06-09T09:39:15.996871",
+     "duration": 0.018993,
+     "end_time": "2026-06-22T19:17:31.496117",
      "exception": false,
-     "start_time": "2026-06-09T09:39:15.963753",
+     "start_time": "2026-06-22T19:17:31.477124",
      "status": "completed"
     },
     "tags": []
@@ -4270,16 +4078,16 @@
    "id": "4a80aa15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:16.063338Z",
-     "iopub.status.busy": "2026-06-09T09:39:16.062782Z",
-     "iopub.status.idle": "2026-06-09T09:39:16.142540Z",
-     "shell.execute_reply": "2026-06-09T09:39:16.142009Z"
+     "iopub.execute_input": "2026-06-22T19:17:31.533125Z",
+     "iopub.status.busy": "2026-06-22T19:17:31.532117Z",
+     "iopub.status.idle": "2026-06-22T19:17:31.569361Z",
+     "shell.execute_reply": "2026-06-22T19:17:31.569361Z"
     },
     "papermill": {
-     "duration": 0.110908,
-     "end_time": "2026-06-09T09:39:16.142724",
+     "duration": 0.055244,
+     "end_time": "2026-06-22T19:17:31.569361",
      "exception": false,
-     "start_time": "2026-06-09T09:39:16.031816",
+     "start_time": "2026-06-22T19:17:31.514117",
      "status": "completed"
     },
     "tags": []
@@ -4352,10 +4160,10 @@
    "id": "fdabb688",
    "metadata": {
     "papermill": {
-     "duration": 0.038623,
-     "end_time": "2026-06-09T09:39:16.218258",
+     "duration": 0.017719,
+     "end_time": "2026-06-22T19:17:31.604080",
      "exception": false,
-     "start_time": "2026-06-09T09:39:16.179635",
+     "start_time": "2026-06-22T19:17:31.586361",
      "status": "completed"
     },
     "tags": []
@@ -4389,16 +4197,16 @@
    "id": "54e8a060",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T09:39:16.296535Z",
-     "iopub.status.busy": "2026-06-09T09:39:16.295973Z",
-     "iopub.status.idle": "2026-06-09T09:39:16.409861Z",
-     "shell.execute_reply": "2026-06-09T09:39:16.409191Z"
+     "iopub.execute_input": "2026-06-22T19:17:31.637709Z",
+     "iopub.status.busy": "2026-06-22T19:17:31.637188Z",
+     "iopub.status.idle": "2026-06-22T19:17:31.677100Z",
+     "shell.execute_reply": "2026-06-22T19:17:31.676576Z"
     },
     "papermill": {
-     "duration": 0.160022,
-     "end_time": "2026-06-09T09:39:16.410056",
+     "duration": 0.056218,
+     "end_time": "2026-06-22T19:17:31.677100",
      "exception": false,
-     "start_time": "2026-06-09T09:39:16.250034",
+     "start_time": "2026-06-22T19:17:31.620882",
      "status": "completed"
     },
     "tags": []
@@ -4461,10 +4269,10 @@
    "id": "b72cf769",
    "metadata": {
     "papermill": {
-     "duration": 0.03671,
-     "end_time": "2026-06-09T09:39:16.479834",
+     "duration": 0.016354,
+     "end_time": "2026-06-22T19:17:31.710638",
      "exception": false,
-     "start_time": "2026-06-09T09:39:16.443124",
+     "start_time": "2026-06-22T19:17:31.694284",
      "status": "completed"
     },
     "tags": []
@@ -4503,18 +4311,18 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 39.414369,
-   "end_time": "2026-06-09T09:39:16.988602",
+   "duration": 15.570591,
+   "end_time": "2026-06-22T19:17:31.951759",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-9-Topic-Models.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-9-Topic-Models.ipynb",
+   "input_path": "Infer-9-Topic-Models.ipynb",
+   "output_path": "Infer-9-Topic-Models.ipynb",
    "parameters": {},
-   "start_time": "2026-06-09T09:38:37.574233",
+   "start_time": "2026-06-22T19:17:16.381168",
    "version": "2.6.0"
   },
   "polyglot_notebook": {


### PR DESCRIPTION
## Le vrai fix, pas un scrub de plus

Même cause racine que #3958 : **Graphviz `dot` manquait sur la machine d'exécution**. `engine.ShowFactorGraph = true` échouait (`process 'dot' ... introuvable`) et Infer.NET déversait le `cwd` absolu + le chemin `.gv` dans les outputs.

Les PR de scrub (#3952 / #3953) redactaient ces chemins — un **fix-symptôme** (secrets-hygiene règle 6 / sota-not-workaround §H) : à la prochaine ré-exécution **tout resaute**. Verdict = **RECOVERABLE-LOCAL**.

## Fix

Graphviz installé, ré-exécution des 12 notebooks via `conda run -n mcp-jupyter papermill -k .net-csharp` (le kernel hérite du PATH avec `dot`). Les **vrais graphes de facteurs SVG** s'affichent — plus rien à scrubber.

## Preuve (SVG rendus ; broken-render / outputs erreur / fuites chemin = 0 partout)

| Notebook | SVG | | Notebook | SVG |
|---|---|---|---|---|
| Infer-1-Setup | 1 | | Infer-7-Classification | 5 |
| Infer-2-Gaussian-Mixtures | 4 | | Infer-8-Model-Selection | 4 |
| Infer-3-Factor-Graphs | 2 | | Infer-9-Topic-Models | 2 |
| Infer-4-Bayesian-Networks | 5 | | Infer-10-Crowdsourcing | 2 |
| Infer-5-Skills-IRT | 6 | | Infer-11-Sequences | 3 |
| Infer-6-TrueSkill | 4 | | Infer-12-Recommenders | 3 |

**Total = 41 SVG** ; broken=0, erreurs=0, fuites=0 sur les 12.

## Anti-régression

Cellules source **byte-identiques** à l'origine (0 churn source / 0 churn code dans le diff ; seuls outputs + metadata papermill changent). Outputs présents (C.2).

## Recurrence prevention

po-2025 (lane Probas/Infer) doit installer Graphviz dans son env `mcp-jupyter` pour les futures ré-exécutions. Signalé sur le dashboard.

Supersedes #3952, #3953. See #3436.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>