### PR TITLE
feat(notebooks): mise-en-forme audit tooling + formatting directive (#3967)

### DIFF
--- a/docs/reference/notebook-formatting.md
+++ b/docs/reference/notebook-formatting.md
@@ -1,0 +1,70 @@
+# Mise en forme visuelle des notebooks — directives + verification de rendu
+
+Source : mandat user 2026-06-23 (EPIC #3966). Les agents editent le markdown/code **sans voir le rendu**, ce qui laisse passer des pathologies de mise en forme invisibles a l'edition. Ce document donne (1) les **directives de formatage** et (2) le **pipeline de verification visuelle**.
+
+## 1. Directives de formatage (HARD)
+
+### 1.1 Hierarchie des titres
+- **Un seul `#` (H1) par notebook = le titre**, dans le premier cell markdown. Tout le reste commence a `##`.
+- Hierarchie **monotone** : pas de `###` (H3) suivi d'un `#` (H1) plus bas. Les sections = `##`, les sous-sections = `###`, etc.
+- **Symptome a bannir** (`MULTI-H1`, `H1-DEEP`) : plusieurs H1 -> le vrai titre n'est plus visuellement distinct (« les titres sont difficilement visibles »).
+
+### 1.2 Asides d'exercice : JAMAIS un heading
+Un **indice / objectif / etape / conseil / note / remarque / attention / TODO** ne doit **jamais** etre ecrit en `#` ou `##` : il apparaitrait dans la **plus grande police** alors qu'il doit etre discret (« les indices apparaissent comme les elements de police la plus grande alors que ca devrait etre l'inverse »).
+
+| A bannir | A utiliser |
+|----------|-----------|
+| `# Indice` / `## Objectif` / `# Etape 1` | **gras inline** `**Indice :**`, `**Objectif :**`, `**Etape 1 —**` |
+| heading pour un aside court | liste a puces, ou blockquote `>` |
+| (si vraie sous-section necessaire) | au plus `####`/`#####` (H4/H5), petit |
+
+### 1.3 Grilles (Sudoku...) et sorties texte alignees
+- Une grille en ASCII / texte aligne **doit etre dans un bloc code** (clotures triple-backtick) ou un `<pre>` — **jamais** du markdown ordinaire (la police proportionnelle casse l'alignement).
+- Si la grille est une **sortie de cellule** mal alignee : corriger le **code d'affichage** (largeur fixe, separateurs, monospace) puis **re-executer** (C.2 Stop&Repair — jamais hand-editer la sortie, cf [secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md) regle 6).
+
+## 2. Detecteur source-level — `scan_md_hierarchy.py`
+
+`scripts/notebook_tools/scan_md_hierarchy.py` parse le JSON notebook (render-agnostic) et flague :
+- `HINT-AS-HEADING` — un aside ecrit en heading.
+- `H1-DEEP` — un H1 hors du premier cell markdown.
+- `MULTI-H1` — plus d'un H1 dans le notebook.
+
+```bash
+# Une famille
+python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks/Sudoku
+# Tout l'arbre
+python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks
+```
+
+Etat initial (2026-06-23) : **261/676 notebooks flagges** (GenAI 71, QuantConnect 47, SymbolicAI 43, Sudoku 28, ML 23, Probas 17, GameTheory 14, Search 11, RL 5, CaseStudies 2).
+
+## 3. Pipeline de verification VISUELLE (obligatoire apres fix)
+
+Le scanner detecte ; **la verification finale est visuelle** (exigence user). Le rendu fidele :
+
+```bash
+# 1. Rendre le notebook en HTML (env mcp-jupyter)
+conda run -n mcp-jupyter python -m nbconvert --to html \
+  --output-dir /tmp/nbrender "MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb"
+# 2. Servir en localhost (file:// est bloque dans Playwright MCP)
+cd /tmp/nbrender && python -m http.server 8899 --bind 127.0.0.1 &
+```
+
+Puis dans Playwright MCP :
+- `browser_navigate` -> `http://127.0.0.1:8899/<notebook>.html`
+- `browser_evaluate` pour **mesurer** : `[...document.querySelectorAll('h1,h2,h3,h4,h5,h6')].map(h => ({tag:h.tagName, px:getComputedStyle(h).fontSize, text:h.textContent}))` — verifie qu'aucun aside n'est plus gros qu'une section.
+- `browser_take_screenshot` pour la preuve visuelle (avant/apres).
+
+### Pourquoi pas le blob GitHub directement
+Le rendu notebook de `github.com/.../blob/...ipynb` est **React-virtualise** : seules les cellules visibles sont dans le DOM, et le scraping `querySelectorAll` ne voit que le chrome GitHub. Utile pour un **spot-check humain a l'oeil**, **pas** pour une mesure DOM fiable. Le rendu **nbconvert local** est deterministe et fidele.
+
+## 4. Garde-fous (rollout)
+- **Scope typo strict** : changer le **niveau** d'un heading n'est pas changer le **contenu** pedagogique. Ne jamais en profiter pour resoudre/stubber/relabeler un exercice (cf [exercise-example-labeling.md](../../.claude/rules/exercise-example-labeling.md), [anti-regression.md](../../.claude/rules/anti-regression.md)).
+- **C.2** : modif markdown seule -> outputs precedents valides ; cellule code modifiee -> re-exec reelle, jamais scrub.
+- **1 sujet par PR** (G.4/G.5) : rollout par famille / sous-lot, pas de composite.
+- **Verifier visuellement** apres fix, pas seulement relancer le scanner.
+
+## Voir aussi
+- EPIC #3966 (mise en forme) ; #3967 (cet outillage) ; #3968 (rollout typo) ; #3969 (grilles Sudoku).
+- [scripts-reference.md](scripts-reference.md) — catalogue scripts notebook.
+- [.claude/rules/notebook-conventions.md](../../.claude/rules/notebook-conventions.md) — C.1/C.2/C.3.

--- a/docs/reference/scripts-reference.md
+++ b/docs/reference/scripts-reference.md
@@ -78,6 +78,7 @@ python scripts/notebook_tools/notebook_tools.py execute SmartContracts --scrub-k
 | `diagnose_broken.py`, `forensic_scan.py` | Diagnostic notebooks cassés / scan forensic (HEAD, erreurs *dures* uniquement) |
 | `regression_scan.py` | Détecteur de régression **output-health** (axe-2) : marqueurs *doux* de dégradation env que `forensic_scan`/`diagnose_broken` ratent (token-starve, `Graphviz non disponible`, MiniZinc/Tweety manquant, `.env` mono-endpoint, `INFEASIBLE`/`Solution valide: False`). 3 modes : `--snapshot` (défaut, dégradés à HEAD), `--history` (git-walk `git log --follow` + `git show` par notebook → pointe le commit/date/auteur régressant + recoveries), `--guard --base <ref> --head <ref> --paths …` (CI, exit 1 si healthy→degraded). Allowlist `regression_allowlist.json` (dégradations *démontrées*/externes acquittées). Git **local-only**, stdlib pure. Ne juge PAS la fidélité prose↔sortie (axe-1 = humain/bot) |
 | `fix_string_cells.py` | Normaliser cellules `source` en string vs array |
+| `scan_md_hierarchy.py` | Audit **mise en forme** (EPIC #3966) : flague `HINT-AS-HEADING` (indice/objectif/etape en heading -> grande police), `H1-DEEP`, `MULTI-H1`. Render-agnostic (parse JSON). Verif visuelle finale via nbconvert+Playwright : cf [notebook-formatting.md](notebook-formatting.md) |
 
 ### Diagnostic / reporting / spécifiques
 | Script | Usage |

--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Audit notebook markdown cells for typographic-hierarchy pathologies.
+
+Detects (source-level, render-agnostic):
+  - HINT-AS-HEADING: a heading line (#..######) whose text reads like a hint/step/
+    comment/aside (Indice, Astuce, Etape, Conseil, TODO, Note, Remarque, Attention,
+    Solution, Exemple...) -> renders in a LARGE font when it should be small/body.
+  - H1-DEEP: an H1 (`# `) appearing in a cell that is NOT the first markdown cell
+    (multiple competing H1s / H1 used mid-notebook -> title hierarchy muddled).
+  - MULTI-H1: more than one H1 across the whole notebook.
+
+Usage: python scan_md_hierarchy.py <notebook-or-dir> [more...]
+Outputs a per-notebook report + a machine-readable summary line per finding.
+"""
+import json, re, sys, pathlib
+
+HEADING_RE = re.compile(r'^(#{1,6})\s+(.*\S)\s*$')
+# Text that should NOT be a heading (it's an aside / hint / step / inline label)
+HINT_RE = re.compile(
+    r'^(indice|astuce|hint|tip|conseil|note|remarque|attention|todo|'
+    r'etape|étape|step|rappel|warning|important|aide|piste|nb)\b',
+    re.IGNORECASE)
+
+def scan_notebook(path):
+    try:
+        nb = json.loads(pathlib.Path(path).read_text(encoding='utf-8'))
+    except Exception as e:
+        return [{'kind': 'READ_ERROR', 'detail': str(e), 'cell': -1, 'text': ''}]
+    findings = []
+    h1_cells = []
+    first_md_seen = False
+    for ci, cell in enumerate(nb.get('cells', [])):
+        if cell.get('cell_type') != 'markdown':
+            continue
+        src = cell.get('source', [])
+        if isinstance(src, str):
+            src = src.splitlines(keepends=False)
+        is_first_md = not first_md_seen
+        first_md_seen = True
+        for line in src:
+            m = HEADING_RE.match(line.rstrip('\n'))
+            if not m:
+                continue
+            level = len(m.group(1))
+            text = m.group(2).strip()
+            if level == 1:
+                h1_cells.append(ci)
+                if not is_first_md:
+                    findings.append({'kind': 'H1-DEEP', 'cell': ci, 'level': level, 'text': text[:90]})
+            if HINT_RE.match(text):
+                findings.append({'kind': 'HINT-AS-HEADING', 'cell': ci, 'level': level, 'text': text[:90]})
+    if len(h1_cells) > 1:
+        findings.insert(0, {'kind': 'MULTI-H1', 'cell': h1_cells[0], 'level': 1,
+                            'text': f'{len(h1_cells)} H1 across cells {h1_cells}'})
+    return findings
+
+def iter_notebooks(args):
+    for a in args:
+        p = pathlib.Path(a)
+        if p.is_dir():
+            yield from sorted(p.rglob('*.ipynb'))
+        elif p.suffix == '.ipynb':
+            yield p
+
+def main():
+    targets = sys.argv[1:]
+    total = 0
+    flagged = 0
+    for nb in iter_notebooks(targets):
+        if '_output' in nb.name or '.ipynb_checkpoints' in str(nb):
+            continue
+        total += 1
+        fs = scan_notebook(nb)
+        if fs:
+            flagged += 1
+            print(f'\n## {nb.as_posix()}')
+            for f in fs:
+                print(f"  [{f['kind']}] cell {f['cell']}  L{f.get('level','?')}  {f['text']}")
+    print(f'\n=== {flagged}/{total} notebooks flagged ===')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Scope
Premier livrable de l'**EPIC #3966** (mise en forme visuelle des notebooks, mandat user 2026-06-23). **Outillage + directive uniquement** — aucune modif de contenu notebook.

## Contenu
- `scripts/notebook_tools/scan_md_hierarchy.py` — detecteur source-level : `HINT-AS-HEADING` (indice/objectif/etape ecrit en `#`/`##` -> rendu en plus grande police), `H1-DEEP`, `MULTI-H1`. Parse le JSON (render-agnostic).
- `docs/reference/notebook-formatting.md` — directives de formatage (1 seul H1 = titre ; asides en **gras inline**, jamais en heading ; grilles en bloc code) + **pipeline de verification visuelle** `nbconvert -> localhost -> Playwright` (mesure `getComputedStyle().fontSize` + screenshot). Documente pourquoi le blob GitHub (React-virtualise) n'est pas fiable pour le scraping DOM.
- `docs/reference/scripts-reference.md` — entree catalogue.

## Evidence
- Scan repo : **261/676 notebooks flagges** (GenAI 71, QuantConnect 47, SymbolicAI 43, Sudoku 28, ML 23, Probas 17, GameTheory 14, Search 11, RL 5, CaseStudies 2).
- Preuve mesuree (`Sudoku-1-Backtracking-Python`, exercice « Comparer les performances ») : `Objectif` et `Indice` = **H1 29px** = meme taille que le titre du notebook, plus gros que la section H2 24px qui les contient. Verifie visuellement via Playwright (screenshot + table font-size).

## Suite (Epic)
- #3968 rollout typographique par famille (ai-01 demarre Sudoku demonstrateur).
- #3969 grilles Sudoku mal affichees.

Closes #3967. Part of #3966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)