### PR TITLE
feat(qc): align Vol-GARCH-Target backbone to 2018-2025 + verified baseline (#1630)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/README.md
@@ -24,6 +24,25 @@ Open the cloud project (local-id: 209093652), compile and run a backtest.
 |--------|-----------|----------------|
 | GARCH(1,1) vol targeting | Weekly (Monday) | Vol target 10%, SMA200 trend, 500-day window, refit every 22 days |
 
+### Aligned baseline (2018-2025)
+
+Verified on QC Cloud (project 33245149, backtest `a0f7a5b59e878becd574612b85791d51`).
+
+| Period | Sharpe | CAGR | MaxDD | PSR |
+|--------|--------|------|-------|-----|
+| 2018-2025 (aligned) | 0.325 | 6.97% | 10.80% | 14.9% |
+
+The strategy's strength is risk control, not return. MaxDD 10.80% is the tightest of
+the backbone baselines to date (cf GlobalMacro-Regime 22.8%, HAR-RV-J-Kelly 37.1%,
+Cloud-VolTargeting single-asset 38.2%) -- the GARCH(1,1) variance forecast, the 30%
+per-asset cap and the SMA200 trend filter combine into genuine risk budgeting that
+holds drawdowns in check. Sharpe 0.325 is positive but modest, and PSR 14.9% is
+non-significant. Notably it beats Cloud-VolTargeting (single-asset SPY, realized-vol,
+150% clamp) on both Sharpe (0.325 vs 0.207) and MaxDD (10.8% vs 38.2%): GARCH
+forecasting plus multi-asset diversification outperforms a naive realized-vol single
+asset with a leverage clamp. Promoted Tier 4 (Untested) to Tier 2 (Historique). See
+the comparative-backtests doc for the cross-strategy table.
+
 ## Files
 
 | File | Description |

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/main.py
@@ -20,7 +20,7 @@ class GarchVolTargetAlgorithm(QCAlgorithm):
     """
 
     def initialize(self):
-        self.set_start_date(2015, 1, 1)
+        self.set_start_date(2018, 1, 1)
         self.set_end_date(2025, 1, 1)
         self.set_cash(100000)
 


### PR DESCRIPTION
Backbone **Vol-GARCH-Target** (RISK family) verified on the backbone's common **2018-2025** window. Aligns `set_start_date` 2015 -> 2018.

## Strategy
GARCH(1,1) volatility targeting on 6 multi-asset ETFs (SPY/EFA/EEM/TLT/GLD/DBC). Forecasts next-day variance via rolling variance-targeting MLE, sizes each position inverse-vol with a 30% per-asset cap, SMA200 trend filter for direction, weekly Monday rebalance, refit every 22 days on a 500-day window. **NO-ML** — the GARCH(1,1) fit is an inline grid search over alpha/beta maximizing the Gaussian log-likelihood (pure numpy, no `arch` dependency). Self-contained.

## Verification (QC Cloud)
- Project **33245149**, compile **BuildSuccess** (0 errors), backtest `a0f7a5b59e878becd574612b85791d51`, status **Completed**, tradeableDates 1761.
- **Sharpe 0.325 / CAGR 6.97% / MaxDD 10.80% / PSR 14.9%**

## Verdict (honest, G.2)
Sharpe 0.325 = **positive but modest**; PSR 14.9% non-significant. The strategy's strength is **risk control**: MaxDD 10.80% is the **tightest of all backbone baselines** to date (cf GlobalMacro-Regime 22.8%, HAR-RV-J-Kelly 37.1%, Cloud-VolTargeting single-asset 38.2%). It beats single-asset Cloud-VolTargeting on both Sharpe (0.325 vs 0.207) and MaxDD (10.8% vs 38.2%) — GARCH forecast + multi-asset diversification >> realized-vol single-asset + 150% clamp. **Promoted Tier 4 (Untested) -> Tier 2 (Historique).**

## Note on `totalOrders=0`
The qc-mcp wrapper returns `totalOrders=0` but statistics (Sharpe/CAGR/MaxDD/PSR) are QC-computed and populated; CAGR 6.97% with 0 trades is impossible -> the stats are real and `totalOrders` is a wrapper extraction artifact. Cross-checked via backtest status Completed. Same artifact seen on every multi-asset baseline (#77-#83).

## Scope
Atomic: 2 files (main.py alignment + README aligned-baseline section). No catalog touched. The cross-strategy comparative-doc row is a separate PR-B (shared-file isolation).

See #1630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)