### PR TITLE
fix(scan-md-hierarchy): skip fenced code blocks (false MULTI-H1/HINT on shell comments)

### DIFF
--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -15,6 +15,10 @@ Outputs a per-notebook report + a machine-readable summary line per finding.
 import json, re, sys, pathlib
 
 HEADING_RE = re.compile(r'^(#{1,6})\s+(.*\S)\s*$')
+# Fenced code block delimiter (```... or ~~~...), possibly indented. Lines inside
+# a fence are code, not markdown: a `# comment` there is a shell/python comment,
+# NOT a heading, and must not be counted as H1 / HINT-AS-HEADING.
+FENCE_RE = re.compile(r'^\s*(`{3,}|~{3,})')
 # Text that should NOT be a heading (it's an aside / hint / step / inline label)
 HINT_RE = re.compile(
     r'^(indice|astuce|hint|tip|conseil|note|remarque|attention|todo|'
@@ -37,7 +41,13 @@ def scan_notebook(path):
             src = src.splitlines(keepends=False)
         is_first_md = not first_md_seen
         first_md_seen = True
+        in_fence = False
         for line in src:
+            if FENCE_RE.match(line):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
             m = HEADING_RE.match(line.rstrip('\n'))
             if not m:
                 continue


### PR DESCRIPTION
## Problème

`scripts/notebook_tools/scan_md_hierarchy.py` (#3970) détecte les headings avec `^#{1,6}\s+` appliqué à **chaque ligne d'une cellule markdown, y compris à l'intérieur des blocs de code** ` ```...``` `. Conséquence : tout commentaire shell/python `# ...` d'un fence est compté comme un **H1** (faux `MULTI-H1` / `H1-DEEP`), et `# TODO` / `# Note` comme un faux `HINT-AS-HEADING`.

Ces faux-positifs sont un piège pour le rollout EPIC #3966 : les « corriger » reviendrait à éditer des commentaires shell (ex. `# Windows (PowerShell)`, `# Installation: pip install ...`), ce qui **corromprait les instructions d'installation** — gaming du détecteur, interdit.

## Fix

Suivre les délimiteurs de fence (` ``` ` / ` ~~~ `, éventuellement indentés) par cellule et **ignorer les lignes à l'intérieur d'un fence**. Changement chirurgical (tracking de fence uniquement) ; la détection des vrais headings markdown est inchangée.

## Impact baseline (vérifié)

| Périmètre | Avant | Après |
|-----------|-------|-------|
| Repo-wide | 261/676 | **199/667** |
| SymbolicAI | 43 | 30 |
| SmartContracts | 11 | 10 |
| Tweety | 1 | **0** (intégralement FP) |

**62 faux-positifs fence retirés repo-wide.** Les vrais flags `HINT-AS-HEADING` (ex. `### Indice`) sont conservés.

### Preuve firsthand
- `Tweety-2-Basic-Logics` cell 21 « 5 H1 » = `# Installation: pip install python-sat`, `# pySAT wraps...` dans un ` ```python ` → 0 après fix.
- `SC-1-Setup-Foundry` « `# Windows (PowerShell)` » dans ` ```bash ` ; `SC-21-Move-Sui` « `# Editer sources/mon_nft.move` » dans un fence workflow Sui.

## Scope
- 1 fichier, +8/-0. Aucun notebook touché. Tooling-only.

See #3967
See #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)