### PR TITLE
docs(lean): knot_lean README — G.1 verdict par sorry (refute/research-hold/infra)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
@@ -5,7 +5,7 @@ avec sorry stratégiques commentés (références papier + prérequis Mathlib).
 
 Epic #2874 (Phase 5 en cours). Toolchain `v4.31.0-rc1`.
 
-## État des sorries (vérifié 2026-06-17, 18 réels — 16 + 2 du transfer backward PARTIEL #3124, `num` prouvé)
+## État des sorries (vérifié 2026-06-23, 18 réels — 16 + 2 du transfer backward PARTIEL #3124, `num` prouvé)
 
 Deux comptes, selon le filtre :
 
@@ -29,10 +29,10 @@ Deux comptes, selon le filtre :
   occurrences dans les commentaires de diagnostic (ex. le commentaire sur
   `KnotDiagram.wf` dans `Basic.lean`).
 
-La CI `.github/workflows/lean-knot.yml` gate sur le **prose-header baseline 28**
-(bump 25→28 dans #3124, justifié par la décomposition du transfer backward) :
-toute PR qui ajoute un sorry réel fait monter les deux comptes et échoue la CI,
-sauf justification documentée dans le body PR.
+La CI `.github/workflows/lean-knot.yml` gate sur le **prose-header baseline 27**
+(bump 25→28 dans #3124 pour la décomposition du transfer backward, puis **baissé à 27**
+après la preuve `num` #3163) : toute PR qui ajoute un sorry réel fait monter les
+deux comptes et échoue la CI, sauf justification documentée dans le body PR.
 
 ## Résultats par statut réel (vérifié contre le code)
 
@@ -66,6 +66,29 @@ sauf justification documentée dans le body PR.
 - [ ] Lidman 11n102 : unknotting number = 2 (Heegaard-Floer) — 3 sorry, scaffolding
 - [ ] `reidemeister_theorem` — équivalence Reidemeister ↔ isotopie ambiante
   (topologie PL des 3-variétés, hors portée Mathlib actuel) — 2 sorry, permanent
+
+### Verdict par sorry (audit G.1, 2026-06-23)
+
+Re-vérification firsthand contre le code (`Reidemeister.lean` + `Invariant.lean`),
+par sorry réel des 5 feuilles ouvertes d'`Invariant.lean`. Classe chaque feuille
+en **PROUVEABLE** / **REFUTÉ** / **RESEARCH-HOLD** / **INFRASTRUCTURE** — l'état
+formel réel, couple aux preuves :
+
+| Ligne | Théorème | Verdict | Débloqueur |
+|-------|----------|---------|------------|
+| L116 | `tricolorable_invariant` | **REFUTÉ tel qu'énoncé** | Contre-exemple certifié `tricolorable_invariant_fails_under_pr1_model` (Invariant.lean L211) : witness `(d₁={⟨1,2,1,2⟩,2}, d₂={⟨1,2,1,2⟩,⟨3,4,3,4⟩,4})` relié par `ReidemeisterEquiv.step (ReidemeisterStep.r1 …)` (L222), `d₁` non-tricolorable, `d₂` tricolorable. Le step R1 utilise le `Reidemeister1` **libre en ρ** (Reidemeister.lean L71). Récupération = **décision de design coord** : **(C)** câbler `Reidemeister1Connected`/`Reidemeister1'` dans `ReidemeisterStep`/`ReidemeisterEquiv` (exclut les kinks disjoints — `pr1_counterexample_excluded_under_rho_determined` L317 le prouve sur le witness), ou **(X)** accepter #2938 et reframer l'invariant. |
+| L743 | `trefoil_not_unknot` | **REFUTÉ par procuration** | Corollaire de L116. Même fork (C)/(X). Pas de chemin direct : `trefoil_crossing_number` est PROUVÉ mais l'invariance du crossing-number bute sur la même équivalence libre-en-ρ. |
+| L799 | `Knot.unknottingNumber` | **INFRASTRUCTURE (NP-dur)** | Minimisation sur les classes d'équivalence ; gated sur une `ReidemeisterEquiv` non-triviale (fork L116). Scaffolding permanent. |
+| L1330 | `fox` all-distinct §9.1 | **RESEARCH-HOLD** | Héritage Fox du crossing modifié `Y'` sous kink all-distinct. Nécessite la construction colour-symmetry / proper-arc #3003. Sous-cas **all-equal PROUVÉ** (L1280-1327, transfer par `help` per-strand). |
+| L1474 | `col` all-distinct §9.1 | **RESEARCH-HOLD** | Lift ≥ 2 couleurs : la restriction naïve `col₁` peut être **monochrome** si toute la variation chromatique de `col₂` vit sur les arêtes fraîches `{n+1, n+2}` (pathologie du kink disjoint). Nécessite #3003, **ou** un contre-exemple certifié qui réfuterait le backward (non exclu). Sous-cas **all-equal PROUVÉ** (L1421-1469, par l'absurde via `h2col₂`). |
+
+**Conclusion de l'audit.** Aucun grain de preuve tractable en 1 cycle dans
+`knot_lean` : les deux feuilles « réfutées » (L116/L743) sont un **fork de design**
+au coordinateur (décision (C) câblage vs (X) reframer), les deux résiduels §9.1
+(L1330/L1474) sont le **noyau research-level irréductible** (construction #3003,
+BG-prover ai-01), L799 est de l'infrastructure NP-dure. Le transfer R1 backward
+est en revanche **complet sur son sous-cas all-equal** (`fox`+`col` PROUVÉS) et sur
+`num` (parité `wf`, #3163) — seuls les modes all-distinct du kink restent ouverts.
 
 ## Phase 5 — Re-modélisation des mouvements de Reidemeister
 


### PR DESCRIPTION
## Summary

Re-vérification **firsthand (G.1)** des 5 sorries réels d'`Invariant.lean` contre le code source (`Reidemeister.lean` + `Invariant.lean`), documentée comme une table « Verdict par sorry » dans le README — l'état formel réel demandé par #3979 (« Knot/Grothendieck/Lean math feuilles, **couple aux preuves** : proveable vs research-HOLD »).

| Ligne | Théorème | Verdict | Débloqueur |
|-------|----------|---------|------------|
| L116 | `tricolorable_invariant` | **REFUTÉ tel qu'énoncé** | Contre-exemple certifié `tricolorable_invariant_fails_under_pr1_model` (L211) : witness relié par `ReidemeisterEquiv.step (ReidemeisterStep.r1 …)` (L222) via le `Reidemeister1` **libre en ρ** (Reidemeister.lean L71). Récupération = **fork de design coord** : (C) câbler `Reidemeister1Connected`/`Reidemeister1'` dans l'équivalence, ou (X) accepter #2938 et reframer. |
| L743 | `trefoil_not_unknot` | **REFUTÉ par procuration** | Corollaire de L116 ; même fork (C)/(X). |
| L799 | `Knot.unknottingNumber` | **INFRASTRUCTURE (NP-dur)** | Minimisation sur classes d'équivalence ; gated sur L116. |
| L1330 | `fox` all-distinct §9.1 | **RESEARCH-HOLD** | Construction #3003. Sous-cas all-equal **PROUVÉ** (L1280-1327). |
| L1474 | `col` all-distinct §9.1 | **RESEARCH-HOLD** | Lift ≥2 couleurs : `col₁` peut être monochrome (variation sur arêtes fraîches). #3003 ou contre-exemple certifié. Sous-cas all-equal **PROUVÉ** (L1421-1469). |

Corrige aussi deux staleness : baseline CI **28→27** (post-preuve `num` #3163, le yml dit déjà 27) et date d'audit 2026-06-17→2026-06-23.

## ASK coordinateur (fork de design)

Le marquee `tricolorable_invariant` (L116) n'est pas « bloqué » — il est **refuté tel qu'énoncé** sous l'équivalence courante. Deux voies, décision coord :
- **(C)** Câbler `Reidemeister1Connected` (Option C, #2980) / `Reidemeister1'` (#2956) dans `ReidemeisterStep`/`ReidemeisterEquiv` pour exclure les kinks disjoints (`pr1_counterexample_excluded_under_rho_determined` L317 prouve que ça exclut le witness). Refactor multi-cycle, haut rayon d'action.
- **(X)** Accepter #2938 et reframer l'invariant (le diagramme-tricolorability n'est PAS un invariant sous ce modèle).

Les résiduels §9.1 (L1330/L1474) sont le **noyau research-level irréductible** (construction colour-symmetry #3003) — BG-prover ai-01, pas un grain worker.

## Validation

- **.md-only** : aucun `.lean` touché → CI `lean-knot.yml` ne se déclenche pas (paths filter `.lean`/lakefile), baseline sorry 27 inchangée.
- **CATALOG-STATUS** inchangé (catalog-pr-hygiene R1).
- **FR-first** (readme-french-first règle 1).
- +28/-5 sur un seul fichier README (au-dessus du seuil docs 20 lignes).

## References

See #3979 — Knot/Grothendieck feuilles (état formel couple aux preuves)
See #2874 — Epic Knot Phase 5
See #2938 — contre-exemple kink disjoint (origines du fork L116)

🤖 Generated with [Claude Code](https://claude.com/claude-code)