### PR TITLE
docs(lean): Lean-17 hint-heading typo — # Indice/# Etape H1 -> bold inline (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17-Knots-a-Conway-and-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17-Knots-a-Conway-and-Proofs.ipynb
@@ -258,10 +258,10 @@
     "**Objectif.** Écrire `fox_rule_satisfied(c1, c2, c3)` qui retourne `True` ssi les\n",
     "3 couleurs (chacune dans $\\{0,1,2\\}$) satisfont cette règle.\n",
     "\n",
-    "# Indice : `len({c1, c2, c3})` vaut $1$ (toutes égales), $2$ (exactement deux égales\n",
-    "# — cas interdit), ou $3$ (toutes différentes).\n",
-    "# Etape 1 : construire l'ensemble des 3 couleurs.\n",
-    "# Etape 2 : retourner `True` si sa taille est $1$ ou $3`, `False` sinon.\n"
+    "**Indice :** `len({c1, c2, c3})` vaut $1$ (toutes égales), $2$ (exactement deux égales\n",
+    "— cas interdit), ou $3$ (toutes différentes).\n",
+    "**Etape 1 :** construire l'ensemble des 3 couleurs.\n",
+    "**Etape 2 :** retourner `True` si sa taille est $1$ ou $3`, `False` sinon.\n"
    ]
   },
   {
@@ -423,11 +423,11 @@
     "**Objectif.** Écrire `is_proper_coloring(pd_code, coloring)` qui retourne `True`\n",
     "ssi tous les croisements satisfont la règle de Fox.\n",
     "\n",
-    "# Indice : pour un croisement, extrayez l'ensemble des couleurs distinctes de ses\n",
-    "# 4 labels (`{coloring[l] for l in crossing}`), puis appliquez la règle de\n",
-    "# l'Exercice 1 (taille $1$ ou $3$).\n",
-    "# Etape 1 : boucler sur chaque crossing de pd_code.\n",
-    "# Etape 2 : retourner False dès qu'un crossing a un ensemble de couleurs de taille 2.\n"
+    "**Indice :** pour un croisement, extrayez l'ensemble des couleurs distinctes de ses\n",
+    "4 labels (`{coloring[l] for l in crossing}`), puis appliquez la règle de\n",
+    "l'Exercice 1 (taille $1$ ou $3$).\n",
+    "**Etape 1 :** boucler sur chaque crossing de pd_code.\n",
+    "**Etape 2 :** retourner False dès qu'un crossing a un ensemble de couleurs de taille 2.\n"
    ]
   },
   {
@@ -915,12 +915,12 @@
     "s'il existe une coloration propre non-triviale (parcourez les\n",
     "$3^{\\text{(nombre d'arêtes)}}$ colorations possibles).\n",
     "\n",
-    "# Indice : collectez les labels d'arêtes, générez toutes les colorations avec\n",
-    "# `itertools.product([0, 1, 2], repeat=n)`, et cherchez-en une à la fois propre\n",
-    "# (Exercice 2) ET utilisant $\\geq 2$ couleurs.\n",
-    "# Etape 1 : collecter l'ensemble des labels d'aretes du PD-code.\n",
-    "# Etape 2 : iterer sur les colorations candidates ; retourner True a la premiere valide.\n",
-    "# Etape 3 : si aucune, retourner False.\n"
+    "**Indice :** collectez les labels d'arêtes, générez toutes les colorations avec\n",
+    "`itertools.product([0, 1, 2], repeat=n)`, et cherchez-en une à la fois propre\n",
+    "(Exercice 2) ET utilisant $\\geq 2$ couleurs.\n",
+    "**Etape 1 :** collecter l'ensemble des labels d'aretes du PD-code.\n",
+    "**Etape 2 :** iterer sur les colorations candidates ; retourner True a la premiere valide.\n",
+    "**Etape 3 :** si aucune, retourner False.\n"
    ]
   },
   {
@@ -1544,11 +1544,11 @@
     "\n",
     "**Objectif.** Écrire `count_sorries_in_lean_file(filepath)` qui lit un fichier `.lean` et compte le nombre d'occurrences du mot-clé `sorry` (en ignorant les commentaires `-- sorry`).\n",
     "\n",
-    "# Indice : ouvrez le fichier avec `open(filepath, 'r', encoding='utf-8')`, lisez ligne par ligne,\n",
-    "# et comptez `sorry` uniquement s'il n'est pas précédé de `--` sur la même ligne.\n",
-    "# Etape 1 : ouvrir le fichier.\n",
-    "# Etape 2 : boucler sur les lignes ; pour chaque ligne, ignorer si 'sorry' est dans un commentaire.\n",
-    "# Etape 3 : retourner le total.\n",
+    "**Indice :** ouvrez le fichier avec `open(filepath, 'r', encoding='utf-8')`, lisez ligne par ligne,\n",
+    "et comptez `sorry` uniquement s'il n'est pas précédé de `--` sur la même ligne.\n",
+    "**Etape 1 :** ouvrir le fichier.\n",
+    "**Etape 2 :** boucler sur les lignes ; pour chaque ligne, ignorer si 'sorry' est dans un commentaire.\n",
+    "**Etape 3 :** retourner le total.\n",
     "</cell_id_edit_mode"
    ]
   },
@@ -1612,11 +1612,11 @@
     "\n",
     "**Objectif.** Écrire `extract_theorem_signatures(filepath)` qui retourne une liste de tuples `(theorem_name, signature)` pour tous les théorèmes définis avec `theorem ... : ... := by` ou `def ... : ... where`.\n",
     "\n",
-    "# Indice : recherchez les lignes contenant 'theorem ' ou 'def ', extrayez le nom (mot après theorem/def),\n",
-    "# et la signature (texte entre ':' et ':='). Utilisez les expressions régulières `import re`.\n",
-    "# Etape 1 : compiler deux regex : r'theorem\\s+(\\w+)\\s*:\\s*(.+?)\\s*:=' pour les théorèmes.\n",
-    "# Etape 2 : boucler sur les lignes, appliquer la regex, accumuler les matches.\n",
-    "# Etape 3 : retourner la liste des (nom, signature).\n",
+    "**Indice :** recherchez les lignes contenant 'theorem ' ou 'def ', extrayez le nom (mot après theorem/def),\n",
+    "et la signature (texte entre ':' et ':='). Utilisez les expressions régulières `import re`.\n",
+    "**Etape 1 :** compiler deux regex : r'theorem\\s+(\\w+)\\s*:\\s*(.+?)\\s*:=' pour les théorèmes.\n",
+    "**Etape 2 :** boucler sur les lignes, appliquer la regex, accumuler les matches.\n",
+    "**Etape 3 :** retourner la liste des (nom, signature).\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Summary

Fixes the #3966 mise-en-forme defect in `Lean-17-Knots-a-Conway-and-Proofs.ipynb`: exercise hint blocks used `# Indice :` and `# Etape N :` as markdown **H1**, rendering at **29px** (as big as the notebook title). Converted to **bold inline** `**Indice :**` / `**Etape N :**` (normal 14px text), per [`docs/reference/notebook-formatting.md`](docs/reference/notebook-formatting.md).

## Scope (markdown-only, C.2-exempt)

- 5 exercise cells (Exercices 1–5), **25 source lines**, heading-level deltas only.
- No prose changed (kept `Etape`, not `Étape` — text-preserving per directive).
- Outputs untouched (markdown-only → previous outputs valid, **no re-exec**).

## FP discrimination (G.1 — scanner does not understand fenced code blocks)

Every flag verified against the actual cell before fixing:
- The 25 fixed lines are **genuine markdown H1** (outside code fences).
- `cell 19 # Extrait de MathlibPrerequisites...` **left as-is** — a Python comment inside a ` ```python ` block (scanner MULTI-H1 false positive; "fixing" it would corrupt the code).

Most other H1-DEEP flags in the Lean family are also code-block comment FPs (bash `# ...` above `lake` commands, Python `# ...` comments) — each notebook needs per-cell verification before fixing.

## Visual verification (mandate #3966 — nbconvert classic + Playwright `getComputedStyle`)

| Version | Tag | Font-size |
|---------|-----|-----------|
| BEFORE (origin/main) | `<h1>` | **29.03px** |
| AFTER (this PR) | `<p>` (bold inline) | **14px** |

`scan_md_hierarchy`: **0 hint flags** on this notebook after the fix.

## Residual

14 other Lean notebooks remain flagged (separate grains, FP-discriminated per-notebook).

`See #3968` (partial — 1 of ~15 Lean notebooks). EPIC #3966 stays open.
