### PR TITLE
style(planners): demote hint/step asides from headings to bold inline (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/00-Environment/Planners-0-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/00-Environment/Planners-0-Setup.ipynb
@@ -1817,14 +1817,14 @@
     "\n",
     "Verifiez que votre environnement est correctement configure avant de passer aux notebooks suivants.\n",
     "\n",
-    "### Etape 1 : Verifier les imports\n",
+    "**Etape 1 : Verifier les imports**\n",
     "Importez les bibliotheques principales et affichez leurs versions.\n",
     "\n",
-    "### Etape 2 : Creer un probleme minimal\n",
+    "**Etape 2 : Creer un probleme minimal**\n",
     "Creez un probleme de planification minimal avec `unified_planning` :\n",
     "1 fluent, 1 action, 1 objectif.\n",
     "\n",
-    "### Etape 3 : Resoudre le probleme\n",
+    "**Etape 3 : Resoudre le probleme**\n",
     "Utilisez `OneshotPlanner` avec `pyperplan` et affichez le plan obtenu."
    ]
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
@@ -1943,7 +1943,7 @@
     "tags": []
    },
    "source": [
-    "### Indice : Pour aborder les exercices\n",
+    "**Indice : Pour aborder les exercices**\n",
     "\n",
     "**Conseils pour reussir** :\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
@@ -583,7 +583,7 @@
     "tags": []
    },
    "source": [
-    "### Indice : Exercice robot navigation\n",
+    "**Indice : Exercice robot navigation**\n",
     "\n",
     "**Approche suggeree** pour resoudre ce probleme :\n",
     "\n",
@@ -2241,7 +2241,7 @@
     "tags": []
    },
    "source": [
-    "### Indice : Exercice de planification temporelle\n",
+    "**Indice : Exercice de planification temporelle**\n",
     "\n",
     "**Approche suggeree** pour modeliser le probleme de chantier :\n",
     "\n",


### PR DESCRIPTION
## Scope — EPIC #3966 mise-en-forme, famille Planners (deep-queue lot 3)

Typo-only heading-level rollout per [docs/reference/notebook-formatting.md](../blob/main/docs/reference/notebook-formatting.md) §1.2. **6 asides demoted from H3 headings to bold inline labels** across 3 notebooks. No pedagogical content changed — no text edited, no exercise stubbed/relabeled. Diff = **6 heading-level deltas only (6 ins / 6 del)**.

| Notebook | Cells | From | To |
|----------|-------|------|-----|
| Planners-0-Setup (00-Environment) | 41 | 3x `### Etape N : …` | `**Etape N : …**` |
| Planners-2-PDDL-Basics (01-Foundation) | 51 | `### Indice : Pour aborder les exercices` | `**Indice : …**` |
| Planners-11-Unified-Planning (04-NeuroSymbolic) | 16/54 | 2x `### Indice : Exercice …` | `**Indice : …**` |

`## Exercice : …` section titles kept as H2 (genuine sections, not in scanner `HINT_RE`).

## Validation
- **Scanner** (fence-aware, PR #3982): the 3 edited notebooks → `0/3 flagged`.
- **Diff audit**: `git diff --stat` = 3 files, 6 ins / 6 del, all heading→bold, nothing else.
- **Visual verification** (nbconvert HTML before/after + Playwright `getComputedStyle`, Planners-2):

| | `### Indice : …` |
|---|---|
| **BEFORE** | `H3` **18.004px** |
| **AFTER** | `STRONG` **14px** (body bold), 0 still-heading |

## Notes for review
- C.2: markdown-only changes → existing outputs remain valid (no code cell touched).
- Atomic, one famille (G.4/G.5).

See #3968
See #3966