### PR TITLE
docs(lean): Lean-4 Rappel hint-heading H2 -> bold inline (EPIC #3966)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-4-Quantifiers.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-4-Quantifiers.ipynb
@@ -54,7 +54,7 @@
     "\n",
     "---\n",
     "\n",
-    "## Rappel : Types Dependants et Pi-types\n",
+    "**Rappel : Types Dependants et Pi-types**\n",
     "\n",
     "En Lean, les quantificateurs sont fondes sur les **types dependants** (Pi-types) que nous avons vus au notebook 2 :\n",
     "\n",


### PR DESCRIPTION
## What

`Lean-4-Quantifiers.ipynb` — the `## Rappel : Types Dependants et Pi-types` aside was rendered as an **H2 section heading** (~22.5 px), giving a brief reminder the same visual prominence as a real section title. Per the #3966 formatting directive ([`docs/reference/notebook-formatting.md`](docs/reference/notebook-formatting.md) §1.2), an aside (rappel / note / indice / etape / objectif) must **never** be a heading.

## Change

Single heading converted to **bold inline**:

```
- ## Rappel : Types Dependants et Pi-types
+ **Rappel : Types Dependants et Pi-types**
```

- Markdown-only typo fix (heading level only). Text preserved **verbatim** (ASCII spelling `Dependants`/`Pi-types` kept) — no prose changed, no exercise stubbed/relabelled (anti-regression).
- C.2-exempt: markdown-only edit → previous outputs valid, **no re-exec**.
- Churn-minimal text surgery (the notebook has mixed escaping `é` + raw); JSON still valid, 56 cells.

## Verification (visual, nbconvert classic render)

Mandate #3966 requires local visual proof (GitHub blob render is React-virtualised). nbconvert classic is deterministic (no dynamic JS), so the stylesheet-resolved px == rendered px:

| | AVANT (main) | APRÈS (fix) |
|---|---|---|
| DOM tag | `<h2>` | `<p><strong>` |
| font-size | `var(--jp-content-font-size4)` = 1.728em ≈ **22.5px** | body 13px (**bold**) |

- `scan_md_hierarchy.py Lean-4-Quantifiers.ipynb`: **1 → 0 flag** residual.
- Cross-check vs Lean-17 reference (#3984, measured 29px→14px via Playwright): H2 22.5px here is consistent with the H2 tier (font-size4) vs H1 (font-size5 ≈ 27px).

See #3968 (partial — Lean family #3966 rollout continues). EPIC #3966 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)