### PR TITLE
feat(qc): align Vol-Ensemble-Conservative backbone to 2018-2025 + verified baseline (#1630, #85)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/README.md
@@ -24,6 +24,20 @@ Open the cloud project (local-id: 818573377), compile and run a backtest.
 |--------|-----------|----------------|
 | Ensemble GARCH+HAR (conservative max) | Weekly | Vol target 8%, SMA200 regime (-50% bear), SMA50 direction, 500-day window |
 
+### Aligned baseline (2018-2025)
+
+Standardized #1630 backbone run (QC Cloud project `33248352`, backtest `db77ae49`).
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.265 |
+| CAGR | 6.142% |
+| Max Drawdown | 10.40% |
+| Probabilistic Sharpe Ratio | 13.6% |
+| Tradeable dates | 1761 |
+
+Interpretation: MaxDD 10.40% = tightest backbone baseline yet (beats Vol-GARCH-Target 10.80%, GlobalMacro-Regime 22.8%, HAR-RV-J-Kelly 37.1%). Positive Sharpe 0.265 but below single-GARCH Vol-GARCH-Target (0.325): the conservative overlay (max-of-ensemble HAR+GARCH forecast, half vol-target 8%, SMA200 regime -50% bear, SMA50 direction) tightened the drawdown at the cost of return, and the HAR component did not add risk-adjusted value over GARCH alone. Promoted Tier 4 -> 2 (Historique). totalOrders = 0 = wrapper extraction artifact (CAGR 6.14% implies real trades).
+
 ## Files
 
 | File | Description |

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/main.py
@@ -21,7 +21,7 @@ class VolEnsembleConservativeAlgorithm(QCAlgorithm):
     """
 
     def initialize(self):
-        self.set_start_date(2015, 1, 1)
+        self.set_start_date(2018, 1, 1)
         self.set_end_date(2025, 1, 1)
         self.set_cash(100000)
 


### PR DESCRIPTION
Standardized **#1630 backbone** run of **#85 Vol-Ensemble-Conservative** on the aligned 2018-2025 period.

## Scope
- `main.py`: `set_start_date` 2015 -> 2018 (end 2025-01-01 unchanged), 1761 tradeable dates. **No-ML** ensemble (GARCH(1,1) variance-targeting MLE inline alpha/beta grid + HAR(1,5,22) OLS `np.linalg.lstsq`, both pure numpy), deterministic single-run.
- `README.md`: add "Aligned baseline (2018-2025)" section.

No catalogue touched, branch off fresh `origin/main`.

## QC Cloud ground-truth
- Project **33248352** (fresh), compile `af74944b` **BuildSuccess** (0 errors)
- Backtest `db77ae49` **Completed**, 1761 tradeable dates

| Metric | Value |
|--------|-------|
| Sharpe Ratio | 0.265 |
| CAGR | 6.142% |
| Max Drawdown | 10.40% |
| PSR | 13.6% |

## Verdict
**Promoted Tier 4 -> 2 (Historique).**

- **MaxDD 10.40% = tightest backbone baseline yet** (beats Vol-GARCH-Target 10.80%, GlobalMacro-Regime 22.8%, HAR-RV-J-Kelly 37.1%) = genuine risk budgeting.
- Sharpe **0.265 below single-GARCH Vol-GARCH-Target (0.325)**: the conservative overlay (max-of-ensemble HAR+GARCH forecast, half vol-target 8%, SMA200 regime -50% in bear, SMA50 direction) tightened the drawdown at the cost of return. The HAR component added **no risk-adjusted value over GARCH alone** here.
- PSR 13.6% non-significant. totalOrders = 0 = wrapper extraction artifact (CAGR 6.14% implies real trades; `equity` empty = same known wrapper gap).

Comparative-doc row (35th verified baseline) + Tier-4 removal + Key-finding follow in a separate `docs/qc` PR (workflow: main.py-per-project + consolidated doc, proven on prior #1630 baselines).

See #1630, #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
