### PR TITLE
fix(sudoku-1-py): demote Objectif/Indice asides from H1 to bold inline (#3968 demonstrator)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -914,11 +914,11 @@
    "source": [
     "## Exercice : Comparer les performances Backtracking simple vs MRV\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comparez les performances du solveur backtracking simple et du solveur MRV\n",
     "sur les puzzles de differentes difficultes.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Utilisez la fonction `benchmark_solver` deja definie avec les deux solveurs.\n",
     "Affichez les resultats dans un tableau comparatif.\n"
    ]


### PR DESCRIPTION
## Scope
Notebook formatting directive **#3966** demonstrator — first notebook of the #3968 typographic-hierarchy rollout (261 notebooks). MAIN-track dispatch from ai-01: validate the directive on `Sudoku-1-Backtracking-Python` with a before/after font-size table.

## Defect
Cell 17 (the *Comparer backtracking simple vs MRV* exercise) wrote its asides `# Objectif` and `# Indice` as **H1**. nbconvert renders H1 at the same size as the notebook **title** — the asides were as visually loud as the title, and the doc had **3 `<h1>`** competing.

## Fix (typo-only, markdown-only)
- `# Objectif` -> `**Objectif :**`
- `# Indice` -> `**Indice :**`

The `## Exercice : ...` section heading and **all prose are untouched**. Diff = exactly **2 heading-level deltas** (`+2 / -2`). No re-execution (markdown-only).

## Visual verification (nbconvert classic -> local http.server -> Playwright `getComputedStyle().fontSize`)

| Heading | BEFORE | AFTER |
|---|---|---|
| `# Sudoku-1 : ... Backtracking` (title) | H1 **25.998px** | H1 **25.998px** (kept) |
| `Objectif` | **H1 25.998px** (= title) | **STRONG 14px** bold |
| `Indice` | **H1 25.998px** (= title) | **STRONG 14px** bold |
| total `<h1>` in doc | **3** | **1** (title only) |

`scripts/notebook_tools/scan_md_hierarchy.py`: **0 flags** after fix (was MULTI-H1 / H1-DEEP / HINT-AS-HEADING on cell 17).

See #3968
See #3966