### PR TITLE
style(symboliclearning): demote 2-line comment-style hint from H1 to bold inline (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-9-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-9-LLM-SymbolicLearning.ipynb
@@ -2311,8 +2311,8 @@
     "3. Proposer 3 `HornClause` : 1 parfaite, 1 consistante mais incomplete, 1 incoherente\n",
     "4. Verifier avec une cible parametree (`dehors`) et afficher le tableau TP/FP/FN/OK/Couverture\n",
     "\n",
-    "# Indice : un concept mono-attribut (un seul predicat decisif, ex `meteo=soleil`)\n",
-    "#           est le plus simple a isoler -- comme `critique=good` dans l'exemple."
+    "**Indice :** un concept mono-attribut (un seul predicat decisif, ex `meteo=soleil`)\n",
+    "est le plus simple a isoler -- comme `critique=good` dans l'exemple."
    ]
   },
   {


### PR DESCRIPTION
## Scope — EPIC #3966 mise-en-forme, famille SymbolicLearning (deep-queue lot 4)

Typo-only heading-level fix per [docs/reference/notebook-formatting.md](../blob/main/docs/reference/notebook-formatting.md) §1.2. **SL-9-LLM-SymbolicLearning cell 39**: a two-line "Indice" written comment-style (a `# ` prefix on each line) rendered as **two competing H1 headings** — the notebook had 3 H1 (title + 2 hint lines), so the real title was no longer visually distinct. Demoted to a single bold inline aside; the 2nd line becomes plain text and soft-joins into the same paragraph. No pedagogical content changed. Diff = **2 heading-level deltas (2 ins / 2 del)**.

| From | To |
|------|-----|
| `# Indice : un concept mono-attribut …` | `**Indice :** un concept mono-attribut …` |
| `#           est le plus simple a isoler …` | `est le plus simple a isoler …` (plain continuation) |

`### Exercice 1 (variation)` title kept as H3.

## Validation
- **Scanner** (fence-aware, PR #3982): SL-9 → `0/1 flagged`.
- **Diff audit**: 1 file, 2 ins / 2 del, heading-only.
- **Visual verification** (nbconvert HTML before/after + Playwright `getComputedStyle`):

| | hint lines | notebook H1 count |
|---|---|---|
| **BEFORE** | `H1` **25.998px** ×2 (largest font, hint dominates) | **3** |
| **AFTER** | `STRONG` **14px** (body bold), 0 as-heading | **1** (title only) |

## Notes for review
- C.2: markdown-only change → existing outputs remain valid (no code cell touched).
- Atomic, one notebook (G.4/G.5). Completes the **SymbolicAI non-Lean** segment of the #3966 deep-queue (Tweety FP-only · SmartContracts #3985 · SemanticWeb #3987 · Planners #3988 · SymbolicLearning here).

See #3968
See #3966