### PR TITLE
docs(lean): Lean-9 relocate title H1 to first cell (EPIC #3966)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-9-SK-Multi-Agents.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-9-SK-Multi-Agents.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "# Lean 9 : Multi-Agents avec Semantic Kernel\n",
+    "\n",
     "**Navigation** : [← Lean-8-Agentic-Proving](Lean-8-Agentic-Proving.ipynb) | [Index](Lean-1-Setup.ipynb) | [Lean-10-LeanDojo →](Lean-10-LeanDojo.ipynb)\n",
     "\n",
     "---\n",
@@ -71,8 +73,6 @@
     "tags": []
    },
    "source": [
-    "# Lean 9 : Multi-Agents avec Semantic Kernel\n",
-    "\n",
     "## 🎯 Architecture du Système Multi-Agents\n",
     "\n",
     "### Vue d'ensemble\n",


### PR DESCRIPTION
## What

`Lean-9-SK-Multi-Agents.ipynb` — the sole H1 title `# Lean 9 : Multi-Agents avec Semantic Kernel` was placed in **cell 2** (H1-DEEP), after the navigation line (cell 0) and the `## Description du notebook` H2 (cell 1). This produced a **non-monotone heading hierarchy** (an H2 appears before the H1 title), so the document title was not visually distinct. Per the #3966 directive ([`docs/reference/notebook-formatting.md`](docs/reference/notebook-formatting.md) §1.1): a single H1 = the title, in the first markdown cell.

(Note: the scanner also briefly suggested a second H1 `# Installation` in cell 3 — confirmed a **false positive**, a Python comment `# Installation` inside a ```` ```python ```` block above `pip install`, correctly skipped by the fenced-block fix #3982. Not touched.)

## Change

Relocated the H1 title to the **top of cell 0** (before the navigation line), preserved **verbatim**. Cell 2 now starts at `## 🎯 Architecture` (H2).

- Pure move (text unchanged) — markdown-only, C.2-exempt (no re-exec).
- `json.dumps(ensure_ascii=False, indent=1)` round-trips this notebook byte-for-byte, so the format/escaping is fully preserved; diff is exactly the 2 moved source elements (+2/-2).

## Verification (visual, nbconvert classic render)

Heading order before/after:

| | AVANT (main) | APRÈS (fix) |
|---|---|---|
| order | `<h2>` Description → **`<h1>`** Lean 9 → `<h2>` Architecture | **`<h1>`** Lean 9 → `<h2>` Description → `<h2>` Architecture |
| hierarchy | non-monotone (H2 before H1) | monotone H1→H2 ✓ |
| title vs navigation | after nav | before nav ✓ |

- `scan_md_hierarchy.py`: **1 → 0 flag** residual (H1-DEEP resolved).

See #3968 (partial — Lean family #3966 rollout continues). EPIC #3966 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)