### PR TITLE
feat(search): MGS-7-TSP Config 3 — geometric crossover on permutations (Moraglio) #3964

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7-TSP.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7-TSP.ipynb
@@ -5,10 +5,10 @@
    "id": "bafc5427",
    "metadata": {
     "papermill": {
-     "duration": 0.003449,
-     "end_time": "2026-06-14T18:22:23.443937+00:00",
+     "duration": 0.006353,
+     "end_time": "2026-06-23T03:15:15.773789+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:23.440488+00:00",
+     "start_time": "2026-06-23T03:15:15.767436+00:00",
      "status": "completed"
     },
     "tags": []
@@ -32,16 +32,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T18:22:23.465364Z",
-     "iopub.status.busy": "2026-06-14T18:22:23.455875Z",
-     "iopub.status.idle": "2026-06-14T18:22:25.292293Z",
-     "shell.execute_reply": "2026-06-14T18:22:25.287356Z"
+     "iopub.execute_input": "2026-06-23T03:15:15.793601Z",
+     "iopub.status.busy": "2026-06-23T03:15:15.785667Z",
+     "iopub.status.idle": "2026-06-23T03:15:17.748093Z",
+     "shell.execute_reply": "2026-06-23T03:15:17.743447Z"
     },
     "papermill": {
-     "duration": 1.843692,
-     "end_time": "2026-06-14T18:22:25.293014+00:00",
+     "duration": 1.97063,
+     "end_time": "2026-06-23T03:15:17.748211+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:23.449322+00:00",
+     "start_time": "2026-06-23T03:15:15.777581+00:00",
      "status": "completed"
     },
     "tags": []
@@ -97,12 +97,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.19.208.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:2545:5f43:5adb:da74:2048/\",\"http://2a01:e0a:9d4:f320:d03e:a74e:1644:3258:2048/\",\"http://2a01:e0a:9d4:f320:e852:2309:9e8f:6292:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::42d3:d9e0:5832:437b%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%16:2048/\",\"http://172.30.16.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:a911:67ab:50dc:4e69:2048/\",\"http://2a01:e0a:9d4:f320:ad1a:8e3f:5f41:4d97:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%18:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::5aa8:3689:ec4d:c9e6%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '1023572.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '666872.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -224,10 +224,10 @@
    "id": "8f73b773",
    "metadata": {
     "papermill": {
-     "duration": 0.002525,
-     "end_time": "2026-06-14T18:22:25.298753+00:00",
+     "duration": 0.003013,
+     "end_time": "2026-06-23T03:15:17.754659+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:25.296228+00:00",
+     "start_time": "2026-06-23T03:15:17.751646+00:00",
      "status": "completed"
     },
     "tags": []
@@ -249,16 +249,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T18:22:25.305759Z",
-     "iopub.status.busy": "2026-06-14T18:22:25.305481Z",
-     "iopub.status.idle": "2026-06-14T18:22:25.494230Z",
-     "shell.execute_reply": "2026-06-14T18:22:25.494047Z"
+     "iopub.execute_input": "2026-06-23T03:15:17.761186Z",
+     "iopub.status.busy": "2026-06-23T03:15:17.761020Z",
+     "iopub.status.idle": "2026-06-23T03:15:17.944109Z",
+     "shell.execute_reply": "2026-06-23T03:15:17.943941Z"
     },
     "papermill": {
-     "duration": 0.192813,
-     "end_time": "2026-06-14T18:22:25.494315+00:00",
+     "duration": 0.187016,
+     "end_time": "2026-06-23T03:15:17.944203+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:25.301502+00:00",
+     "start_time": "2026-06-23T03:15:17.757187+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,10 +287,10 @@
    "id": "7c55e107",
    "metadata": {
     "papermill": {
-     "duration": 0.002619,
-     "end_time": "2026-06-14T18:22:25.500341+00:00",
+     "duration": 0.003593,
+     "end_time": "2026-06-23T03:15:17.951902+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:25.497722+00:00",
+     "start_time": "2026-06-23T03:15:17.948309+00:00",
      "status": "completed"
     },
     "tags": []
@@ -310,16 +310,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T18:22:25.507107Z",
-     "iopub.status.busy": "2026-06-14T18:22:25.506914Z",
-     "iopub.status.idle": "2026-06-14T18:22:25.919342Z",
-     "shell.execute_reply": "2026-06-14T18:22:25.919189Z"
+     "iopub.execute_input": "2026-06-23T03:15:17.960518Z",
+     "iopub.status.busy": "2026-06-23T03:15:17.960272Z",
+     "iopub.status.idle": "2026-06-23T03:15:18.362969Z",
+     "shell.execute_reply": "2026-06-23T03:15:18.362821Z"
     },
     "papermill": {
-     "duration": 0.416258,
-     "end_time": "2026-06-14T18:22:25.919422+00:00",
+     "duration": 0.407709,
+     "end_time": "2026-06-23T03:15:18.363042+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:25.503164+00:00",
+     "start_time": "2026-06-23T03:15:17.955333+00:00",
      "status": "completed"
     },
     "tags": []
@@ -372,10 +372,10 @@
    "id": "dcbc1d6a",
    "metadata": {
     "papermill": {
-     "duration": 0.002604,
-     "end_time": "2026-06-14T18:22:25.925187+00:00",
+     "duration": 0.003407,
+     "end_time": "2026-06-23T03:15:18.369950+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:25.922583+00:00",
+     "start_time": "2026-06-23T03:15:18.366543+00:00",
      "status": "completed"
     },
     "tags": []
@@ -395,16 +395,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T18:22:25.931634Z",
-     "iopub.status.busy": "2026-06-14T18:22:25.931449Z",
-     "iopub.status.idle": "2026-06-14T18:22:26.072196Z",
-     "shell.execute_reply": "2026-06-14T18:22:26.072026Z"
+     "iopub.execute_input": "2026-06-23T03:15:18.377747Z",
+     "iopub.status.busy": "2026-06-23T03:15:18.377545Z",
+     "iopub.status.idle": "2026-06-23T03:15:18.533905Z",
+     "shell.execute_reply": "2026-06-23T03:15:18.533772Z"
     },
     "papermill": {
-     "duration": 0.144367,
-     "end_time": "2026-06-14T18:22:26.072279+00:00",
+     "duration": 0.160613,
+     "end_time": "2026-06-23T03:15:18.533970+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:25.927912+00:00",
+     "start_time": "2026-06-23T03:15:18.373357+00:00",
      "status": "completed"
     },
     "tags": []
@@ -414,7 +414,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Baseline (panmictic)       tour final = 429,4\r\n"
+      "Baseline (panmictic)       tour final = 440,8\r\n"
      ]
     }
    ],
@@ -430,10 +430,10 @@
    "id": "9bd50e53",
    "metadata": {
     "papermill": {
-     "duration": 0.00366,
-     "end_time": "2026-06-14T18:22:26.079403+00:00",
+     "duration": 0.002822,
+     "end_time": "2026-06-23T03:15:18.539864+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.075743+00:00",
+     "start_time": "2026-06-23T03:15:18.537042+00:00",
      "status": "completed"
     },
     "tags": []
@@ -453,16 +453,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T18:22:26.087369Z",
-     "iopub.status.busy": "2026-06-14T18:22:26.087166Z",
-     "iopub.status.idle": "2026-06-14T18:22:26.286425Z",
-     "shell.execute_reply": "2026-06-14T18:22:26.286226Z"
+     "iopub.execute_input": "2026-06-23T03:15:18.546629Z",
+     "iopub.status.busy": "2026-06-23T03:15:18.546439Z",
+     "iopub.status.idle": "2026-06-23T03:15:18.682848Z",
+     "shell.execute_reply": "2026-06-23T03:15:18.682693Z"
     },
     "papermill": {
-     "duration": 0.203626,
-     "end_time": "2026-06-14T18:22:26.286509+00:00",
+     "duration": 0.140353,
+     "end_time": "2026-06-23T03:15:18.682927+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.082883+00:00",
+     "start_time": "2026-06-23T03:15:18.542574+00:00",
      "status": "completed"
     },
     "tags": []
@@ -472,7 +472,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Islands (4 x 10, Static)   tour final = 480,7\r\n"
+      "Islands (4 x 10, Static)   tour final = 513,9\r\n"
      ]
     }
    ],
@@ -490,13 +490,83 @@
   },
   {
    "cell_type": "markdown",
+   "id": "mgs7-geo-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00384,
+     "end_time": "2026-06-23T03:15:18.690772+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T03:15:18.686932+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Config 3 — un crossover géométrique sur les permutations (Moraglio)\n",
+    "\n",
+    "La Lecture précédente (et MGS-5) présente les composés géométriques comme *typés* : WOA, EO font de l'arithmétique sur des `double`. C'est vrai pour leurs **opérateurs continus**. Mais la **théorie** du crossover géométrique (Moraglio & Poli, GECCO 2004 ; thèse Moraglio 2007) est plus générale : un crossover est *géométrique* si la progéniture se situe sur le **segment métrique** entre ses parents — et ce, dans **n'importe quel espace métrique**, pas seulement euclidien.\n",
+    "\n",
+    "Pour les permutations, la métrique naturelle est la **distance de swap** (combien de transpositions séparent deux ordres). Le `GeometricCrossover<int>` du fork, muni de son `OrderedEmbedding<int>` (`IsOrdered = true`), réalise cela concrètement :\n",
+    "\n",
+    "1. il mappe les parents (permutations d'indices de villes) vers l'espace métrique ;\n",
+    "2. applique l'opérateur géométrique (ici le centroïde par position) → une cible métrique ;\n",
+    "3. **remappe vers une permutation valide** en partant d'un clone du premier parent et en **marchant par swaps** vers la cible (`FlipGene`) — chaque transposition rapproche de la cible, la progéniture reste une permutation à chaque pas.\n",
+    "\n",
+    "C'est l'incarnation du *geodesic crossover* de Moraglio : la progéniture est un point du segment swap-distance entre les parents. Le **même** `GeometricCrossover` qui servait aux composés continus (DE/WOA/EO/FBI) s'applique donc aux permutations **via l'embedding** — c'est l'embedding (la métrique), pas l'opérateur, qui porte la géométrie.\n",
+    "\n",
+    "**Pivot deep learning géométrique.** Les indices de villes sont des *étiquettes* arbitraires, pas des coordonnées ordinales : le centroïde `(v₁ + v₂) / 2` n'a aucun sens géographique. Le deep learning géométrique (Bronstein *et al.*, *Geometric Deep Learning*) formalise cette intuition — un bon embedding doit être **équivariant par permutation** (aucun ordre de ville n'est privilégié) et refléter la **structure du problème** (ici, la géométrie euclidienne des villes dans `[0, 100]²`). Un embedding appris ou positionnel ferait mieux ; le centroïde naïf sur étiquettes est la **baseline** qui mesure précisément la limite que la théorie prédit. C'est l'angle mort signalé par le user (« on touche aux limites de ce que je comprenais à l'époque ») et que les insights récents du geometric DL permettent désormais de **nommer**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "mgs7-geo-run",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T03:15:18.698958Z",
+     "iopub.status.busy": "2026-06-23T03:15:18.698758Z",
+     "iopub.status.idle": "2026-06-23T03:15:18.798276Z",
+     "shell.execute_reply": "2026-06-23T03:15:18.798106Z"
+    },
+    "papermill": {
+     "duration": 0.104197,
+     "end_time": "2026-06-23T03:15:18.798369+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T03:15:18.694172+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Geometric (Moraglio)       tour final = 674,1\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Config 3 : crossover géométrique de Moraglio sur permutations (OrderedEmbedding swap-walking).\n",
+    "// GeometricCrossover<int>(ordered:true, 2) auto-câble un OrderedEmbedding{IsOrdered=true} :\n",
+    "// la progéniture marche par swaps vers le centroïde métrique -> permutation valide à chaque pas.\n",
+    "// Mêmes parents initiaux reproductibles (ResetRng(7) dans Run) que baseline + îles -> comparaison équitable.\n",
+    "var geometric = Run(\"Geometric (Moraglio)\", 100, 40,\n",
+    "    new GeometricCrossover<int>(ordered: true),\n",
+    "    new ReverseSequenceMutation(),\n",
+    "    new DefaultMetaHeuristic());\n",
+    "Console.WriteLine($\"{geometric.Label,-26} tour final = {geometric.FinalTourLength:F1}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d32ca4b9",
    "metadata": {
     "papermill": {
-     "duration": 0.003043,
-     "end_time": "2026-06-14T18:22:26.293103+00:00",
+     "duration": 0.003668,
+     "end_time": "2026-06-23T03:15:18.806069+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.290060+00:00",
+     "start_time": "2026-06-23T03:15:18.802401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -509,23 +579,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "5e4329ca",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T18:22:26.300659Z",
-     "iopub.status.busy": "2026-06-14T18:22:26.300457Z",
-     "iopub.status.idle": "2026-06-14T18:22:26.460365Z",
-     "shell.execute_reply": "2026-06-14T18:22:26.460180Z"
+     "iopub.execute_input": "2026-06-23T03:15:18.814624Z",
+     "iopub.status.busy": "2026-06-23T03:15:18.814391Z",
+     "iopub.status.idle": "2026-06-23T03:15:18.966574Z",
+     "shell.execute_reply": "2026-06-23T03:15:18.966424Z"
     },
     "papermill": {
-     "duration": 0.164239,
-     "end_time": "2026-06-14T18:22:26.460464+00:00",
+     "duration": 0.157036,
+     "end_time": "2026-06-23T03:15:18.966652+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.296225+00:00",
+     "start_time": "2026-06-23T03:15:18.809616+00:00",
      "status": "completed"
     },
     "tags": []
@@ -549,14 +619,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Baseline (panmictic)       |      429,4 |        0,0 %\r\n"
+      "Baseline (panmictic)       |      440,8 |        0,0 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Islands (4 x 10, Static)   |      480,7 |      -12,0 %\r\n"
+      "Islands (4 x 10, Static)   |      513,9 |      -16,6 %\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Geometric (Moraglio)       |      674,1 |      -52,9 %\r\n"
      ]
     },
     {
@@ -577,19 +654,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Baseline (panmictic)    g1=825  g26=542  g51=463  g76=447  g100=429\r\n"
+      "  Baseline (panmictic)    g1=909  g26=688  g51=551  g76=462  g100=441\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Islands (4 x 10, Static)g1=842  g26=545  g51=517  g76=517  g100=481\r\n"
+      "  Islands (4 x 10, Static)g1=897  g26=709  g51=672  g76=554  g100=514\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Geometric (Moraglio)    g1=925  g26=763  g51=716  g76=693  g100=674\r\n"
      ]
     }
    ],
    "source": [
-    "var results = new[] { baseline, island };\n",
+    "var results = new[] { baseline, island, geometric };\n",
     "Console.WriteLine($\"{\"Config\",-26} | {\"Tour final\",10} | {\"vs baseline\",12}\");\n",
     "Console.WriteLine(new string('-', 54));\n",
     "double refLen = baseline.FinalTourLength;\n",
@@ -615,10 +699,10 @@
    "id": "c6179941",
    "metadata": {
     "papermill": {
-     "duration": 0.004941,
-     "end_time": "2026-06-14T18:22:26.469981+00:00",
+     "duration": 0.003798,
+     "end_time": "2026-06-23T03:15:18.974156+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.465040+00:00",
+     "start_time": "2026-06-23T03:15:18.970358+00:00",
      "status": "completed"
     },
     "tags": []
@@ -630,7 +714,9 @@
     "\n",
     "Les métaheuristiques géométriques (WOA, EO), elles, nécessitent un `GeometricConverter<double>` précisément parce qu'elles *font* de l'arithmétique sur les gènes — c'est leur travail (centroïde, spirale, opérateur géométrique), pas celui de la couche de composition. La séparation est nette : **la composition est agnostique, les composés géométriques sont typés**. Composer ne présuppose pas le domaine.\n",
     "\n",
-    "Le fait que le modèle insulaire batte, égalise ou perde sur ce TSP de taille 20 est secondaire ; le point est ailleurs : **la même brique structure des recherches sur des représentations disjointes**. C'est ce qui distingue un composant réutilisable d'une métaphore monolithique attachée à un type de problème."
+    "Le fait que le modèle insulaire batte, égalise ou perde sur ce TSP de taille 20 est secondaire ; le point est ailleurs : **la même brique structure des recherches sur des représentations disjointes**. C'est ce qui distingue un composant réutilisable d'une métaphore monolithique attachée à un type de problème.\n",
+    "\n",
+    "**Nuance apportée par le crossover géométrique (Config 3).** Le constat « les composés géométriques sont typés » vaut pour leurs *opérateurs continus* (centroïde, spirale sur `double`). Mais la Config 3 montre que le **crossover géométrique lui-même** s'étend aux permutations dès qu'on lui fournit un embedding métrique (`OrderedEmbedding`, distance de swap). Ce n'est donc pas la *composition géométrique* qui est cantonnée aux `double`, c'est l'**espace métrique choisi** : un opérateur géométrique n'est pertinent que si son embedding reflète la structure du problème. Le centroïde naïf sur étiquettes d'indice en est la limite — d'où l'intérêt des embeddings permutation-équivariants (deep learning géométrique)."
    ]
   },
   {
@@ -638,10 +724,10 @@
    "id": "b00ffa1e",
    "metadata": {
     "papermill": {
-     "duration": 0.004652,
-     "end_time": "2026-06-14T18:22:26.479923+00:00",
+     "duration": 0.003844,
+     "end_time": "2026-06-23T03:15:18.981365+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.475271+00:00",
+     "start_time": "2026-06-23T03:15:18.977521+00:00",
      "status": "completed"
     },
     "tags": []
@@ -654,23 +740,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "02492166",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T18:22:26.490476Z",
-     "iopub.status.busy": "2026-06-14T18:22:26.490249Z",
-     "iopub.status.idle": "2026-06-14T18:22:26.537970Z",
-     "shell.execute_reply": "2026-06-14T18:22:26.537800Z"
+     "iopub.execute_input": "2026-06-23T03:15:18.990010Z",
+     "iopub.status.busy": "2026-06-23T03:15:18.989804Z",
+     "iopub.status.idle": "2026-06-23T03:15:19.050459Z",
+     "shell.execute_reply": "2026-06-23T03:15:19.050275Z"
     },
     "papermill": {
-     "duration": 0.053739,
-     "end_time": "2026-06-14T18:22:26.538059+00:00",
+     "duration": 0.065749,
+     "end_time": "2026-06-23T03:15:19.050538+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.484320+00:00",
+     "start_time": "2026-06-23T03:15:18.984789+00:00",
      "status": "completed"
     },
     "tags": []
@@ -680,7 +766,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Exercice 1] À compléter. Référence : baseline-OX1 = 429,4.\r\n"
+      "[Exercice 1] À compléter. Référence : baseline-OX1 = 440,8.\r\n"
      ]
     }
    ],
@@ -698,10 +784,10 @@
    "id": "3bdcaaf7",
    "metadata": {
     "papermill": {
-     "duration": 0.003622,
-     "end_time": "2026-06-14T18:22:26.545501+00:00",
+     "duration": 0.003565,
+     "end_time": "2026-06-23T03:15:19.058158+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.541879+00:00",
+     "start_time": "2026-06-23T03:15:19.054593+00:00",
      "status": "completed"
     },
     "tags": []
@@ -714,23 +800,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "b57733c3",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T18:22:26.554757Z",
-     "iopub.status.busy": "2026-06-14T18:22:26.554533Z",
-     "iopub.status.idle": "2026-06-14T18:22:26.618575Z",
-     "shell.execute_reply": "2026-06-14T18:22:26.618404Z"
+     "iopub.execute_input": "2026-06-23T03:15:19.066765Z",
+     "iopub.status.busy": "2026-06-23T03:15:19.066504Z",
+     "iopub.status.idle": "2026-06-23T03:15:19.098330Z",
+     "shell.execute_reply": "2026-06-23T03:15:19.098181Z"
     },
     "papermill": {
-     "duration": 0.069194,
-     "end_time": "2026-06-14T18:22:26.618710+00:00",
+     "duration": 0.036634,
+     "end_time": "2026-06-23T03:15:19.098444+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.549516+00:00",
+     "start_time": "2026-06-23T03:15:19.061810+00:00",
      "status": "completed"
     },
     "tags": []
@@ -740,7 +826,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Exercice 2] À compléter. Référence : islands-Static = 480,7.\r\n"
+      "[Exercice 2] À compléter. Référence : islands-Static = 513,9.\r\n"
      ]
     }
    ],
@@ -756,10 +842,10 @@
    "id": "28693e46",
    "metadata": {
     "papermill": {
-     "duration": 0.003444,
-     "end_time": "2026-06-14T18:22:26.626064+00:00",
+     "duration": 0.003565,
+     "end_time": "2026-06-23T03:15:19.106359+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.622620+00:00",
+     "start_time": "2026-06-23T03:15:19.102794+00:00",
      "status": "completed"
     },
     "tags": []
@@ -772,23 +858,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "6b33c457",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-14T18:22:26.634450Z",
-     "iopub.status.busy": "2026-06-14T18:22:26.634225Z",
-     "iopub.status.idle": "2026-06-14T18:22:26.669977Z",
-     "shell.execute_reply": "2026-06-14T18:22:26.669817Z"
+     "iopub.execute_input": "2026-06-23T03:15:19.114192Z",
+     "iopub.status.busy": "2026-06-23T03:15:19.114016Z",
+     "iopub.status.idle": "2026-06-23T03:15:19.170123Z",
+     "shell.execute_reply": "2026-06-23T03:15:19.169952Z"
     },
     "papermill": {
-     "duration": 0.040352,
-     "end_time": "2026-06-14T18:22:26.670060+00:00",
+     "duration": 0.060391,
+     "end_time": "2026-06-23T03:15:19.170200+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.629708+00:00",
+     "start_time": "2026-06-23T03:15:19.109809+00:00",
      "status": "completed"
     },
     "tags": []
@@ -816,10 +902,10 @@
    "id": "fcd7ca59",
    "metadata": {
     "papermill": {
-     "duration": 0.00338,
-     "end_time": "2026-06-14T18:22:26.677089+00:00",
+     "duration": 0.003582,
+     "end_time": "2026-06-23T03:15:19.177579+00:00",
      "exception": false,
-     "start_time": "2026-06-14T18:22:26.673709+00:00",
+     "start_time": "2026-06-23T03:15:19.173997+00:00",
      "status": "completed"
     },
     "tags": []
@@ -832,6 +918,13 @@
     "Les métaheuristiques géométriques (WOA, EO) restent attachées aux gènes `double` — non par limitation de la composition, mais parce que leur *mécanisme* (opérateur géométrique, centroïde, spirale) est de l'arithmétique sur des positions continues. La séparation est nette : **la composition est agnostique, les composés géométriques sont typés**.\n",
     "\n",
     "Suite logique : combiner cette agnosticité avec la structuration — un modèle insulaire où chaque île utiliserait un opérateur différent (configuration hétérogène), via la surcharge `IslandMetaHeuristic(params (int, IMetaHeuristic)[])`.\n",
+    "\n",
+    "\n",
+    "**Extension : crossover géométrique de Moraglio.** La Config 3 (`GeometricCrossover<int>` + `OrderedEmbedding`) étend la géométrie aux permutations : la progéniture marche par swaps sur le segment métrique entre parents. Le résultat empirique (tour final reporté dans la comparaison ci-dessus) se lit à l'aune de la théorie — l'opérateur centroïde agit sur des étiquettes d'indice sans signification géographique, ce qui borne ce qu'un crossover géométrique *naïf* peut atteindre et motive les embeddings permutation-équivariants du deep learning géométrique.\n",
+    "\n",
+    "**Références.**\n",
+    "- A. Moraglio & R. Poli, *Topological Interpretation of Crossover*, GECCO 2004 ; A. Moraglio, *Towards a Geometric Unification of Evolutionary Algorithms*, thèse 2007 — le cadre du crossover géométrique (segment métrique entre parents, valide en toute métrique, dont la distance de swap).\n",
+    "- M. Bronstein, J. Bruna, T. Cohen, P. Veličković, *Geometric Deep Learning* — https://geometricdeeplearning.com — équivariance par permutation et embeddings structurés.\n",
     "\n",
     "[← MGS-6 Benchmarks](MGS-6-Benchmarks.ipynb) | [↑ Série MGS](README.md) | [Fork jsboige/MetaGeneticSharp →](https://github.com/jsboige/MetaGeneticSharp)"
    ]
@@ -852,14 +945,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.792182,
-   "end_time": "2026-06-14T18:22:26.909321+00:00",
+   "duration": 6.566825,
+   "end_time": "2026-06-23T03:15:19.414530+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MGS-7-TSP.ipynb",
-   "output_path": "MGS-6-TSP.output.ipynb",
+   "output_path": "MGS-7-TSP_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-14T18:22:20.117139+00:00",
+   "start_time": "2026-06-23T03:15:12.847705+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Third configuration for **MGS-7-TSP**, extending the geometric framework (DE/WOA/EO/FBI on continuous `double` genes, MGS-5) to **permutation** genes — `#3964` (B1).

**Config 3** wires `GeometricCrossover<int>` with `OrderedEmbedding<int>` (`IsOrdered=true`) + `ReverseSequenceMutation`. The offspring walks by swaps (`FlipGene`) along the **swap-distance metric segment** between parents — Moraglio's geodesic crossover — and is always a valid permutation.

### The pedagogical point (prong-B non-triviality)

The default centroid operator acts on **city-index labels**, not coordinates — so `(v₁ + v₂)/2` has no geographic meaning. The geometric crossover therefore **underperforms** OX1:

| Config | Tour final | vs baseline |
|---|---|---|
| Baseline (panmictic, OX1) | **440.8** | — |
| Islands (4×10, Static) | 513.9 | −16.6 % |
| **Geometric (Moraglio)** | **674.1** | **−52.9 %** |

This is exactly the limit that **geometric DL theory** predicts and which motivates permutation-equivariant embeddings (Bronstein *et al.*, *Geometric Deep Learning*). The naive centroid-on-labels is the **baseline that measures the predicted limit** — not a workaround, a deliberate motivating demonstration of where the SOTA abstraction already reaches, and where it needs a learned/positional embedding.

### Changes (atomic — MGS-7-TSP only)
- **+2 cells**: theory intro (Moraglio & Poli GECCO 2004 / thesis 2007; swap distance; `OrderedEmbedding` swap-walking; geometric-DL pivot) + geometric run.
- Comparison table + Lecture nuance + Conclusion extension + References — all theory-neutral, numbers from one coherent run (no pendulum).
- `#2161` met: 3 exercises preserved (cells 16/18/20); Config 3 is a guided example, not an exercise.

### Validation (H.1 — real execution)
- Full **.net-csharp papermill re-exec**: **10/10 code cells, 0 errors**.
- No `raise NotImplementedError` / `assert False` / `1/0` (C.1).
- Outputs committed (C.2); only `metadata.papermill` input/output_path normalized to basename (#3962). Zero machine paths / secrets in any cell output (scanned).
- No submodule bump (`GeometricCrossover` already in the pinned fork @ `f7ec022c`), no catalog churn (byte-identical to main).

### Geometric crossover theory
The fork abstraction + acceptance tests (`GeometricCrossoverTests.cs`: `OrderedEmbedding_Ordered_PreservesPermutationMultiset`, `FlipGene_SwapsTwoGenes`) already exist (PR#87 port). This PR is the **demonstration** that the same `GeometricCrossover` serving the continuous compounds applies to permutations via the embedding — the geometry lives in the **metric/embedding**, not the operator.

`See #3964` (partial contribution to the MGS extension epic; fork abstraction land separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)