### PR TITLE
feat(lean-knot): colour-permutation invariance enabler for #3003 backward transfer

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -86,6 +86,59 @@ def triColorConditionAt (d : KnotDiagram) (coloring : Fin d.numEdges → TriColo
   (c1 = c2 ∧ c2 = c3) ∨
   (c1 ≠ c2 ∧ c2 ≠ c3 ∧ c1 ≠ c3)
 
+/-! ### Colour-permutation invariance — enabler for the #3003 backward transfer
+
+The Fox tricolorability condition is invariant under any injective relabelling
+of the three colours: equalities and inequalities of strand colours are both
+preserved by injectivity, and the well-formedness bounds `1 ≤ e_k ≤ numEdges`
+do not mention the colouring at all. This is the foundational fact behind the
+§9 colour-symmetry construction (`tricolorable_backward`, Epic #2874 PR3):
+given a valid `d₂` colouring whose fresh-edge colours sit outside the `d₁`
+range (the all-distinct kink mode), one permutes it to align those colours with
+a `d₁`-range colour before restricting, and Fox-validity is retained. These two
+lemmas are pure infrastructure (definition unfolding + `Function.Injective`);
+the backward construction itself (#3003, all-distinct kink) stays research.
+-/
+
+/-- Reading a strand colour commutes with post-composition by `σ`, provided the
+    diagram is non-degenerate (`numEdges ≠ 0`, so the `colorAtNat` default
+    branch is never taken). -/
+theorem KnotDiagram.colorAtNat_comp (d : KnotDiagram)
+    (coloring : Fin d.numEdges → TriColor) (σ : TriColor → TriColor) (l : Nat)
+    (hn : d.numEdges ≠ 0) :
+    d.colorAtNat (σ ∘ coloring) l = σ (d.colorAtNat coloring l) := by
+  simp only [KnotDiagram.colorAtNat, dif_neg hn, Function.comp]
+
+/-- **Fox condition is invariant under injective colour relabelling.** For an
+    injective `σ` and non-degenerate `d`, `triColorConditionAt d (σ ∘ coloring)
+    c ↔ triColorConditionAt d coloring c`. The well-formedness conjunct is
+    colour-independent; the `(c1=c2 ∧ c2=c3) ∨ (c1≠c2 ∧ c2≠c3 ∧ c1≠c3)` Fox
+    disjunction is preserved both ways by injectivity. -/
+theorem triColorConditionAt_invariant_perm (d : KnotDiagram)
+    (coloring : Fin d.numEdges → TriColor) (σ : TriColor → TriColor)
+    (hσ : Function.Injective σ) (hn : d.numEdges ≠ 0) (c : PDCrossing) :
+    triColorConditionAt d (σ ∘ coloring) c ↔ triColorConditionAt d coloring c := by
+  simp only [triColorConditionAt]
+  rw [KnotDiagram.colorAtNat_comp d coloring σ c.e1 hn,
+      KnotDiagram.colorAtNat_comp d coloring σ c.e2 hn,
+      KnotDiagram.colorAtNat_comp d coloring σ c.e3 hn]
+  refine and_congr Iff.rfl ?_
+  -- Fox disjunction on `(σ c1, σ c2, σ c3)` ↔ `(c1, c2, c3)`, via injectivity.
+  -- `σ a = σ b ↔ a = b`; the inequalities transfer by contraposition.
+  have heq : ∀ a b : TriColor, σ a = σ b ↔ a = b :=
+    fun a b => ⟨fun h => hσ h, congrArg σ⟩
+  constructor
+  · rintro (⟨h12, h23⟩ | ⟨h12, h23, h13⟩)
+    · exact Or.inl ⟨(heq _ _).mp h12, (heq _ _).mp h23⟩
+    · refine Or.inr ⟨fun heq' => h12 ((heq _ _).mpr heq'),
+                     fun heq' => h23 ((heq _ _).mpr heq'),
+                     fun heq' => h13 ((heq _ _).mpr heq')⟩
+  · rintro (⟨h12, h23⟩ | ⟨h12, h23, h13⟩)
+    · exact Or.inl ⟨(heq _ _).mpr h12, (heq _ _).mpr h23⟩
+    · refine Or.inr ⟨fun heq' => h12 ((heq _ _).mp heq'),
+                     fun heq' => h23 ((heq _ _).mp heq'),
+                     fun heq' => h13 ((heq _ _).mp heq')⟩
+
 /-- A valid tricoloring: satisfies the condition at every crossing,
 and uses at least 2 colors. -/
 def IsTriColoring (d : KnotDiagram) (coloring : TriColoring d) : Prop :=


### PR DESCRIPTION
## Summary

Adds two **sorry-free infrastructure lemmas** to [`Knots/Invariant.lean`](MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean), inserted right after `triColorConditionAt` (L89–139), before `IsTriColoring`:

| Lemma | Statement | Role |
|-------|-----------|------|
| `KnotDiagram.colorAtNat_comp` | `numEdges ≠ 0 → d.colorAtNat (σ ∘ coloring) l = σ (d.colorAtNat coloring l)` | colour-reading commutes with post-composition by `σ` |
| `triColorConditionAt_invariant_perm` | `Injective σ → numEdges ≠ 0 → triColorConditionAt d (σ ∘ coloring) c ↔ triColorConditionAt d coloring c` | **Fox condition invariant under injective colour relabelling** |

### Why

The Fox tricolorability condition is invariant under any injective relabelling of the three colours: the well-formedness bounds `1 ≤ e_k ≤ numEdges` are colour-independent, and the `(c1=c2 ∧ c2=c3) ∨ (c1≠c2 ∧ c2≠c3 ∧ c1≠c3)` disjunction transfers both ways by injectivity (equalities via `congrArg`, inequalities by contraposition).

This is the **foundational fact behind the §9 colour-symmetry construction** (`tricolorable_backward`, Epic #2874 PR3 stage): given a valid `d₂` colouring whose fresh-edge colours sit outside the `d₁` range (the **all-distinct kink mode**), one permutes it to align those colours with a `d₁`-range colour before restricting, and Fox-validity is retained.

This PR ships **only the pure infrastructure** (definition unfolding + `Function.Injective`). The backward construction itself (#3003, all-distinct kink — 2 sorries at `Invariant.lean` ~L1334 fox + ~L1478 col) **remains research-level** and is explicitly routed to the BG-prover. This PR does **not** close any sorry.

## §B Lean PR discipline — proofs

**1. Sorry diff (per file):**

| File | avant (origin/main) | après (branch) | Δ |
|------|---------------------|----------------|---|
| `Knots/Invariant.lean` (prose-header CI filter) | 27 | 27 | **0** |

Reproduced the exact `.github/workflows/lean-build.yml` filter (`grep "sorry" | grep -viE "sorries|sorry.s"`, summed across `Knots/*.lean`): `branch total = 27 = main total`. **No sorry introduced** — not even a stray prose mention.

**2. `lake build` — local SUCCESS:**
```
Built Knots.Invariant (5.5s)
Build completed successfully (321 jobs)
```
0 error. Native Windows `lake.exe`, toolchain `leanprover--lean4---v4.31.0-rc1`, `lake exe cache get` restored 8477 Mathlib `.olean`.

**3. Proof integrity:** the sorry-linter (`declaration uses sorry`) flags only the 4 pre-existing declarations (`tricolorable_invariant`, `trefoil_not_unknot`, `unknottingNumber`, `tricolorable_backward`); the two **new** declarations (`colorAtNat_comp`, `triColorConditionAt_invariant_perm`) are **not** flagged → sorry-free, real tactic proofs.

**4. N/A** — no prover/Python refactor.

## Scope & no collision

- **Single file, 53 insertions, 0 deletions.** Atomic.
- **Disjoint from the two pending mandate-(C) rewire PRs**:
  - #3997 (exclusion lemma `pr1_counterexample_excluded_under_connected`, §3c-bis ~L300) — untouched.
  - #3999 (`ReidemeisterStep.r1` → symmetric closure rewire, `Invariant.lean` L116/L211 + `Reidemeister.lean`) — the insertion point L89 is in the early `triColorConditionAt`/`IsTriColoring` region, disjoint from both.
- These enabler lemmas are a **prerequisite** the eventual #3003 backward proof will cite; they do not depend on the unmerged rewire.

See #2874 · See #3003

🤖 Generated with [Claude Code](https://claude.com/claude-code)