### PR TITLE
feat(qc): align composite-c1-multiasset backbone to 2018-2025 + verified baseline (#1630, #88)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/composite-c1-multiasset/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/composite-c1-multiasset/README.md
@@ -24,6 +24,20 @@ Create a new project, upload all `.py` files, compile and run a backtest.
 |--------|-----------|----------------|
 | Alpha Framework (3 alphas + RiskParity PCM) | Weekly | Leverage 2x, drawdown cap 12%, trailing stop 4%, VWAP 4-slice execution |
 
+### Aligned baseline (2018-2025)
+
+Standardized #1630 backbone run (QC Cloud project `32981093`, backtest `1236cf59`).
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.258 |
+| CAGR | 6.490% |
+| Max Drawdown | 17.000% |
+| Probabilistic Sharpe Ratio | 8.7% |
+| Tradeable dates | 1761 |
+
+Interpretation: weak positive Sharpe 0.258 (comparable to the simple momentum rotations AssetClassMomentum 0.22 and Vol-Ensemble-Conservative 0.265). The 3-alpha ensemble (Momentum + MACD + RelativeStrength) combined with the RiskParityPCM (weekly, 100% exposure, 40% sector cap), 12% drawdown cap + 4% trailing stop, and VWAP execution adds little over a single momentum signal on the aligned period -- the composite architecture does not dramatically beat its components. MaxDD is controlled at 17% by the drawdown cap (vs 22.8% for the uncapped GlobalMacro-Regime). Far below the framework composite leaders FamaFrenchAllWeather (0.684) and EMATrend (0.741): COMP composites vary widely (c1 weak vs AllWeather/EMATrend strong), so the component alpha/PCM choice matters more than the framework wiring itself. Notably the aligned Sharpe 0.258 is higher than the catalog-campaign figure (0.175), so alignment did not degrade this composite. PSR 8.7% non-significant. Promoted Tier 4 -> 2 (Historique). totalOrders = 0 = wrapper extraction artifact (CAGR 6.49% implies real trades).
+
 ## Files
 
 | File | Description |

--- a/MyIA.AI.Notebooks/QuantConnect/projects/composite-c1-multiasset/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/composite-c1-multiasset/main.py
@@ -17,7 +17,7 @@ class CompositeC1MultiAssetRotation(QCAlgorithm):
     """
 
     def initialize(self):
-        self.set_start_date(2015, 1, 1)
+        self.set_start_date(2018, 1, 1)
         self.set_end_date(2025, 1, 1)
         self.set_cash(100000)
         self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)


### PR DESCRIPTION
## Summary

Align the **composite-c1-multiasset** C4.1 Multi-Asset Rotation Composite (QC Alpha Framework) to the standardized **#1630 backbone window** (2018-01-01 .. 2025-01-01) and record the verified QC Cloud baseline. Part of the backbone Track 2 sequence (verifying each unverified Tier-4 baseline on the aligned period).

## Changes

- `main.py`: `set_start_date(2015,1,1)` → `(2018,1,1)` (end 2025-01-01 unchanged). Behavior-preserving date alignment only.
- `README.md`: add `### Aligned baseline (2018-2025)` section under `## Backtest Metrics`.

## QC Cloud ground-truth (aligned run)

QC Cloud project `32981093` (pre-existing, 5 framework files verified present), backtest `1236cf59`, 1761 tradeable dates (matches the aligned window).

| Metric | Value |
|--------|-------|
| Sharpe Ratio | **0.258** |
| CAGR | 6.490% |
| Max Drawdown | 17.000% |
| Probabilistic Sharpe Ratio | 8.7% |

## Verdict

**Tier 4 → 2 (Historique).** Weak positive Sharpe — the 3-alpha ensemble (Momentum + MACD + RelativeStrength) combined with RiskParityPCM (weekly, 100% exposure, 40% sector cap), 12% drawdown cap + 4% trailing stop, and VWAP execution adds little over a single momentum signal on the aligned period (comparable to AssetClassMomentum 0.22, Vol-Ensemble-Conservative 0.265). MaxDD is controlled at 17% by the drawdown cap.

Far below the framework composite leaders FamaFrenchAllWeather (0.684) and EMATrend (0.741) — **COMP composites vary widely, so the component alpha/PCM choice matters more than the framework wiring itself**. Notably the aligned Sharpe 0.258 is *higher* than the catalog-campaign figure (0.175), so alignment did not degrade this composite.

## Note

`totalOrders = 0` is the **qc-mcp-lite wrapper extraction artifact** (CAGR 6.49% with 0 trades is impossible → cash → Sharpe 0). QC-computed statistics (Sharpe/CAGR/MaxDD/PSR) are real and populated. Disclosed per G.1.

main.py-only PR (stack-free, no catalog churn, no doc edit here — the consolidated comparative-doc edit ships in a separate doc PR like #3972/#3996 to avoid adjacent-Tier-4-deletion conflicts).

See #1630, #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
