### PR TITLE
docs(cooperative-games): reflect Bondareva-Shapley #2959 resolution (sorry 1->0)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
@@ -7,10 +7,10 @@ Cross-directory inventory of all Lean 4 formalization projects under `GameTheory
 | Directory | Toolchain | Production sorry | Modules | Status |
 |-----------|-----------|-----------------|---------|--------|
 | `stable_marriage_lean` | v4.30.0-rc2 | 0 | 5 files | COMPLETE |
-| `cooperative_games_lean` | v4.30.0-rc2 | 1 | 2 files | Active proving |
+| `cooperative_games_lean` | v4.30.0-rc2 | 0 | 3 files | COMPLETE |
 | `social_choice_lean` | v4.30.0-rc2 | 0 | 7 files | COMPLETE |
 | `social_choice_lean_peters` | v4.27.0-rc1 | 0 | 1 file | Reference only |
-| **Total** | — | **1** | **15 files** | — |
+| **Total** | — | **0** | **16 files** | — |
 
 Note: `_GoalExtract.lean` (former prover test file) has been removed from the repo. `SymbolicAI/Lean/examples/llm_assisted_proof.lean` (2 sorry) is a pedagogical example, not production.
 
@@ -58,12 +58,13 @@ Note: `_GoalExtract.lean` (former prover test file) has been removed from the re
 
 | File | sorry | Description |
 |------|-------|-------------|
-| `CooperativeGames/Shapley.lean` | 0 | Shapley value (uniqueness proved) |
-| `CooperativeGames/Basic.lean` | 1 | `bondareva_shapley_forward.hCore` (L309) tagged `INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION` |
+| `CooperativeGames/Shapley.lean` | 0 | Shapley value, characterization + uniqueness (Möbius decomposition) |
+| `CooperativeGames/Basic.lean` | 0 | TU games, Core, balanced games, `bondareva_shapley : Core.Nonempty ↔ Balanced` (iff, L434), `convex_core_nonempty` (L588) |
+| `CooperativeGames/ConeKernel.lean` | 0 | Cone-separation machinery (augmented incidence cone, closure, dual characterization) for the backward direction |
 
-**Build**: `lake build CooperativeGames` — SUCCESS (with `sorry` warning on Basic.lean:309)
+**Build**: `lake build CooperativeGames` — SUCCESS (0 sorry, no added axiom)
 
-**Status: Active proving (1 sorry)**. `bondareva_shapley_forward` reduces to extracting a Core allocation from the polytope `P \ K`; the body is sketched (P nonempty + closed + no element has coalition deficit) but requires Hahn-Banach / hyperplane separation in locally convex spaces (not yet ported to Mathlib for finite-dim R^n in this shape). Consumer theorem `bondareva_shapley` (iff form) transitively depends on this `sorry`.
+**Status: COMPLETE (0 sorry).** `bondareva_shapley` (`Core.Nonempty ↔ Balanced`) is fully proved. The backward direction's attainment crux `hb_witness` (formerly tagged `INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION`) was closed by PR #3954 via a compact-slice Weierstrass argument — bypassing the missing Mathlib `ProperCone.hyperplane_separation` without any added axiom. Lineage: #3933 (cone kernel) → #3941 (bridge) → #3945 (decoding) → #3951 (`hb_strict`) → #3954 (attainment). See [`cooperative_games_lean/FORMAL_STATUS.md`](cooperative_games_lean/FORMAL_STATUS.md).
 
 ---
 

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
@@ -6,13 +6,12 @@
 |------|-------|
 | Lean toolchain | `leanprover/lean4:v4.30.0-rc2` |
 | Mathlib | pinned via lake-manifest.json |
-| Total sorry | **1** (1 Basic + 0 Shapley) |
-| Honest unprovable (in Mathlib) | **1** (`hb_witness`, Farkas/LP-dual kernel) |
-| Total lines | ~1430 (Basic 388 + Shapley 1042) |
-| Total theorems | 19 |
-| Total definitions | 35 |
+| Total sorry | **0** (0 Basic + 0 Shapley + 0 ConeKernel) |
+| Honest unprovable | **0** |
+| Total lines | ~2369 (Basic 594 + Shapley 1042 + ConeKernel 733) |
+| Certification | **COMPLETE** — all theorems proved, no added axiom |
 
-**Note**: Toolchain bumped to v4.30-0-rc2 (PR #1015). PR #1020's "prove bondareva_shapley_backward" was a **`apply?` placeholder** (non-proof); PR #2959 refactored honestly to isolate the irreducible LP-dual kernel `hb_witness` (`Basic.lean:312`) as a named sorry. That kernel requires `ProperCone.hyperplane_separation` (Farkas) — WIP, not yet proved.
+**Note**: Toolchain v4.30.0-rc2 (PR #1015). PR #1020's earlier "prove bondareva_shapley_backward" was an `apply?` placeholder (non-proof); PR #2959 refactored honestly to isolate the irreducible kernel `hb_witness` (`Basic.lean:348`) as a named sorry. That kernel was **closed** by PR #3954 (2026-06-22) via a compact-slice Weierstrass argument — no `ProperCone.hyperplane_separation` (Farkas) was ultimately required. The project is now 0-sorry.
 
 ## Per-File Status
 
@@ -20,18 +19,32 @@
 
 | Metric | Value |
 |--------|-------|
-| Definitions | 12 |
-| Theorems | 7 |
-| sorry | **1** (`hb_witness` @ L312, LP-dual kernel of `bondareva_shapley_backward`) |
-| Status | WIP_HARD (Farkas required) |
+| Definitions | 9 |
+| Theorems | 8 |
+| sorry | **0** |
+| Status | COMPLETE |
 
-Key definitions: `Coalition`, `TUGame`, `Superadditive`, `Convex`, `marginalContribution`,
-`unanimityGame`, `majorityGame`, `Allocation`, `Core`, `CoreEmpty`, `Balanced`.
+Key definitions: `TUGame`, `Superadditive`, `Convex`, `Core`, `CoreEmpty`, `Balanced`, `marginalVector`, plus the Bondareva-Shapley scaffolding.
 
-Previously-proved theorems (sorry resolved):
-- `bondareva_shapley_forward` (PR #802)
-- `convex_core_nonempty` (PR #981, Route A marginal vectors)
-- `bondareva_shapley_backward` — **decomposition skeleton** (PR #2959): `hP_conv`/`hP_closed`/`hP_nonempty`/`hK_empty`/`hP_lb` all proved; only `hb_witness` (Farkas) remains open.
+Proved theorems:
+- `bondareva_shapley_forward` (PR #802) — Core nonempty implies balanced
+- `bondareva_shapley_backward` (PR #2959 skeleton → #3954 attainment) — balanced implies Core nonempty
+- `bondareva_shapley : G.Core.Nonempty ↔ G.Balanced` (L434) — bi-implication, fully certified
+- `convex_core_nonempty` (PR #981, Route A marginal vectors, L588) — convex games have nonempty Core
+- `marginalVector_mem_core` (L581)
+
+### CooperativeGames/ConeKernel.lean — CONE SEPARATION
+
+| Metric | Value |
+|--------|-------|
+| Definitions | 4 |
+| Theorems / lemmas | 12 |
+| sorry | **0** |
+| Status | COMPLETE |
+
+The finite-dimensional cone machinery powering the backward direction. Key items: `augCone` (augmented incidence cone over `(Option N) → ℝ`), `balancedUnit`, `conicHull_linearIndependent_isClosed`, `mem_cone_iff_exists_li_subset`, `finGenCone_isClosed`, `augCone_mem_iff`, `augCone_dual_iff` (dual characterization), `separatingFunctional_none_neg`. Imported by `Basic.lean` (L22).
+
+Lineage: cone kernel extraction (#3933) → bridge `balancedUnit ∉ augCone` (#3941) → decoding `exists_preimputation_strict_core` (#3945) → `hb_strict` (#3951) → attainment `hb_witness` (#3954).
 
 ### CooperativeGames/Shapley.lean — SHAPLEY VALUE
 
@@ -42,17 +55,9 @@ Previously-proved theorems (sorry resolved):
 | sorry | **0** |
 | Status | FORMAL-COMPLETE |
 
-Key definitions: `Solution`, `Efficiency`, `Symmetry`, `NullPlayerAxiom`, `Additivity`,
-`shapleyCoef`, `shapleyValue`, `shapleySolution`, `WeightedVotingGame`, `Critical`,
-`BanzhafRaw`, `VetoPlayer`, `Dictator`, `DummyPlayer`.
+Key definitions: `Solution`, `Efficiency`, `Symmetry`, `NullPlayerAxiom`, `Additivity`, `shapleyCoef`, `shapleyValue`, `shapleySolution`, `WeightedVotingGame`, `Critical`, `BanzhafRaw`, `VetoPlayer`, `Dictator`, `DummyPlayer`.
 
-Previously-proved theorems (sorry resolved):
-- `shapley_null_player` (PR earlier in 2026-04)
-- `shapley_unanimity` (PR #791)
-- `shapley_symmetric` (PR earlier in 2026-04)
-- `shapleyCoef_top` (PR #757)
-- `bondareva_shapley_forward` (PR #802)
-- `shapley_uniqueness` (PR #1024, commit `1eb5a4a0`, 2026-05-13 — Mobius decomposition)
+Proved theorems (sorry resolved): `shapley_null_player`, `shapley_unanimity` (PR #791), `shapley_symmetric`, `shapley_efficient`, `shapley_additive`, `shapleyCoef_top` (PR #757), `shapley_uniqueness` (PR #1024, Möbius decomposition), `mobius_decomposition`, `dummy_shapley_zero`.
 
 ## Theorem Inventory
 
@@ -60,37 +65,34 @@ Previously-proved theorems (sorry resolved):
 
 | Theorem | File | Statement |
 |---------|------|-----------|
-| `superadditive_empty_nonneg` | Basic.lean | v(empty) >= 0 (trivial) |
-| `superadditive_grand_coalition_nonneg_of_nonneg_singletons` | Basic.lean | Grand coalition value nonneg |
+| `bondareva_shapley` | Basic.lean (L434) | `G.Core.Nonempty ↔ G.Balanced` — Bondareva-Shapley characterization |
 | `bondareva_shapley_forward` | Basic.lean | Core nonempty implies balanced |
-| `convex_core_nonempty` | Basic.lean | Convex games have nonempty Core (PR #981) |
+| `bondareva_shapley_backward` | Basic.lean | Balanced implies Core nonempty |
+| `convex_core_nonempty` | Basic.lean (L588) | Convex games have nonempty Core (Shapley 1971) |
 | `shapley_efficient` | Shapley.lean | Shapley value is efficient |
 | `shapley_additive` | Shapley.lean | Shapley value is additive |
 | `shapley_null_player` | Shapley.lean | Shapley value = 0 for null players |
 | `shapley_unanimity` | Shapley.lean | Shapley value on unanimity games |
-| `shapley_symmetric` | Shapley.lean | Shapley value treats symmetric players equally |
-| `shapleyCoef_top` | Shapley.lean | Shapley coefficient for full coalition |
-| `shapley_uniqueness` | Shapley.lean | Shapley value is unique solution satisfying axioms (PR #1024) |
-| `dummy_shapley_zero` | Shapley.lean | Dummy players get zero Shapley value |
+| `shapley_symmetric` | Shapley.lean | Symmetric players treated equally |
+| `shapley_uniqueness` | Shapley.lean | Unique solution satisfying the four axioms (Möbius) |
+| `mobius_decomposition` | Shapley.lean | Möbius decomposition of a TU game |
 
-### Partially Proved (contains sorry)
+### Partially Proved
 
-| Theorem | File | Open kernel | Strategy |
-|---------|------|-------------|----------|
-| `bondareva_shapley_backward` | Basic.lean | `hb_witness` @ L312 (∃ x ∈ P, ∑ xᵢ ≤ v(N)) | Farkas / `ProperCone.hyperplane_separation` (WIP_HARD, ~150-200 lines, cf `BONDAREVA_SHAPLEY_HARDNESS.md`) |
+*None.* The project has no remaining `sorry`.
 
 ## Certification Level
 
 | File | Level |
 |------|-------|
-| Basic.lean | WIP_HARD (1 sorry: `hb_witness` LP-dual kernel) |
+| Basic.lean | COMPLETE (0 sorry) |
 | Shapley.lean | COMPLETE (0 sorry) |
+| ConeKernel.lean | COMPLETE (0 sorry) |
 
-**Project certification: WIP** — 1 sorry remaining (`hb_witness`, Farkas kernel). Shapley module complete.
+**Project certification: COMPLETE** — 0 sorry, no added axiom. `bondareva_shapley` (iff form) is fully proved.
 
-## Remaining Work
+## Remaining Work (extensions, not gaps)
 
-Prove `hb_witness` (Bondareva-Shapley backward, LP-dual kernel) via `ProperCone.hyperplane_separation` (Farkas). Possible extensions:
 - Banzhaf power index theorems (definitions `BanzhafRaw`/`Critical` exist, no theorems yet)
 - Shapley value computational properties
 
@@ -103,16 +105,16 @@ Prove `hb_witness` (Bondareva-Shapley backward, LP-dual kernel) via `ProperCone.
 
 ## History
 
-| Date | Change | Commit |
-|------|--------|--------|
+| Date | Change | Commit / PR |
+|------|--------|-------------|
 | 2026-01-31 | Initial creation with TU games, Shapley value | initial |
 | 2026-04-30 | FORMAL_STATUS.md created | PR-G |
 | 2026-04-30 | `shapleyCoef_top` proved | PR #757 |
 | 2026-04-30 | `shapley_unanimity` 2->1 sorry | PR #791 |
 | 2026-05-01 | `bondareva_shapley_forward` proved | PR #802 |
-| 2026-05-12 | BG iter 3: HONEST_UNPROVABLE annotation Basic.lean L234; FORMAL_STATUS realigned (7->3 sorry) | (this PR) |
-| 2026-05-12 | Reclassified bondareva_shapley_backward: HONEST_UNPROVABLE -> WIP_HARD | Cycle 28 Track A |
-| 2026-05-13 | Toolchain bump to v4.30.0-rc2; `bondareva_shapley_backward` proved; `convex_core_nonempty` proved | PR #1015, #1020, #981 |
-| 2026-05-13 | `shapley_uniqueness` proved (Mobius decomposition) — 0 sorry Shapley.lean | PR #1024, commit `1eb5a4a0` |
-| 2026-05-14 | FORMAL_STATUS realigned: 3->0 sorry, module COMPLETE | po-2026 T-A |
-| 2026-06-20 | **Correction (G.1 verify-before-claiming):** PR #1020's `bondareva_shapley_backward` "proof" was `apply?` (non-proof); PR #2959 refactored to isolate `hb_witness` LP-dual kernel as named sorry @ L312. FORMAL_STATUS corrected: 0→1 sorry, COMPLETE→WIP_HARD | po-2026 #2959 |
+| 2026-05-12 | BG iter 3: HONEST_UNPROVABLE annotation; FORMAL_STATUS realigned (7->3 sorry) | (this PR) |
+| 2026-05-13 | Toolchain bump v4.30.0-rc2; `convex_core_nonempty` proved | PR #1015, #981 |
+| 2026-05-13 | `shapley_uniqueness` proved (Möbius) — 0 sorry Shapley.lean | PR #1024 (`1eb5a4a0`) |
+| 2026-06-20 | **G.1 correction:** PR #1020's `bondareva_shapley_backward` "proof" was `apply?` (non-proof); PR #2959 refactored to isolate `hb_witness` LP-dual kernel as named sorry @ L348. FORMAL_STATUS: 0→1 sorry | po-2026 #2959 |
+| 2026-06-20 | Cone-separation strategy: Farkas plan via `(Option N) → ℝ` documented (`docs/BONDAREVA_FARKAS_PLAN.md`) | po-2026 #2959 |
+| 2026-06-22 | **`hb_witness` attainment crux PROVEN** via compact-slice Weierstrass (Basic.lean +61/-7). `bondareva_shapley` iff now 0 sorry. Lineage: #3933 (cone kernel) → #3941 (bridge) → #3945 (decoding) → #3951 (`hb_strict`) → #3954 (attainment). Project COMPLETE. | PR #3954 (`a5288f0a7`) |

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
@@ -1,66 +1,56 @@
-# Cooperative Games Lean
+# Jeux coopératifs — Lean 4
 
-Formalisation en Lean 4 de la théorie des jeux coopératifs (valeur de Shapley, cœur).
+Formalisation en Lean 4 de la théorie des jeux coopératifs : **valeur de Shapley** (caractérisation axiomatique de Shapley 1953, unicité via décomposition de Möbius) et **théorème de Bondareva-Shapley** caractérisant le Cœur des jeux coopératifs par l'équilibrage.
+
+> Version anglaise préservée dans [`README.en.md`](README.en.md).
 
 ## Statut
 
-- **Toolchain** : v4.30.0-rc2
-- **Compte de sorry** : 1 en production (`Basic.lean` L312, `bondareva_shapley_forward.hCore`, taggé `INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION`)
+- **Toolchain** : `leanprover/lean4:v4.30.0-rc2`
+- **Compte de sorry** : **0** (aucun `sorry` comme tactique sur l'ensemble du projet)
 - **Build** : `lake build CooperativeGames` — SUCCESS
-- **Dépendances** : Mathlib4
+- **Dépendances** : Mathlib4 (épinglée via `lake-manifest.json`)
+- **Certification** : **COMPLETE** — tous les théorèmes annoncés sont prouvés sans axiome ajouté
 
 ## Modules
 
-| Fichier | sorry | Description |
-|---------|-------|-------------|
-| `CooperativeGames/Shapley.lean` | 0 | Définition de la valeur de Shapley et théorème d'unicité |
-| `CooperativeGames/Basic.lean` | 1 | Jeu coopératif / fonction caractéristique / Cœur / scaffolding Bondareva-Shapley |
+| Fichier | Lignes | sorry | Description |
+|---------|--------|-------|-------------|
+| `CooperativeGames/Shapley.lean` | 1042 | 0 | Valeur de Shapley, caractérisation axiomatique (efficacité, symétrie, joueur nul, additivité), unicité via décomposition de Möbius |
+| `CooperativeGames/Basic.lean` | 594 | 0 | Jeu coopératif (TU), fonction caractéristique, Cœur, jeux équilibrés, théorème de Bondareva-Shapley, jeux convexes |
+| `CooperativeGames/ConeKernel.lean` | 733 | 0 | Mécanique de séparation par cône (cône d'incidence augmenté, fermeture, caractérisation duale) pour la direction backward de Bondareva-Shapley |
 
 ## Résultats clés
 
-- **Unicité de la valeur de Shapley** : prouvé que la valeur de Shapley est l'unique valeur satisfaisant les axiomes d'efficacité, symétrie, joueur nul et additivité (Shapley.lean, 0 sorry)
-- **Définitions du Cœur** : jeu coopératif, fonction caractéristique, ensemble des joueurs, Cœur (Basic.lean)
-- **Direction `←` de Bondareva-Shapley** (balanced ⇒ Cœur non vide) : tout le scaffolding est clos sauf la dernière étape d'extraction en L312
+- **Caractérisation de Shapley** (`Shapley.lean`) : la valeur de Shapley est l'allocation *unique* satisfaisant les quatre axiomes (efficacité, symétrie, joueur nul, additivité) — Shapley (1953). L'unicité passe par la décomposition de Möbius (`mobius_decomposition`, PR #1024). 0 sorry.
+- **Théorème de Bondareva-Shapley** (`Basic.lean`, L434) :
+  ```lean
+  theorem bondareva_shapley : G.Core.Nonempty ↔ G.Balanced
+  ```
+  Bi-implication **entièrement prouvée**, 0 sorry. Bondareva (1963) / Shapley (1967).
+- **Cœur des jeux convexes non vide** (`Basic.lean`, L588) :
+  ```lean
+  theorem convex_core_nonempty (h : G.Convex) : G.Core.Nonempty
+  ```
+  Via les vecteurs marginaux (Shapley 1971), `marginalVector_mem_core`.
+
+### Comment la direction backward a été close
+
+La direction `Balanced → Cœur non vide` (`bondareva_shapley_backward`) est le sens difficile. Elle se décompose en :
+
+1. **Mécanique de cône** (`ConeKernel.lean`) : on encode les poids équilibrés dans le cône d'incidence augmenté `augCone ⊆ (Option N) → ℝ`, on prouve sa fermeture (`finGenCone_isClosed`, `conicHull_linearIndependent_isClosed`) et sa caractérisation duale (`augCone_dual_iff`). La condition équilibrée force le point « d'unité équilibrée » `balancedUnit` hors de ce cône, d'où par séparation un fonctionnel linéaire séparateur.
+2. **Décodage** (`Basic.lean`) : le fonctionnel séparateur se traduit en une allocation du Cœur (`exists_preimputation_strict_core`, cf #3945).
+3. **Noyau d'atteinte `hb_witness`** (`Basic.lean`, L348) : existence d'une allocation `x ∈ P` avec `∑ xᵢ ≤ v(N)`. Clos par un argument de **tranche compacte + Weierstrass** : la tranche de sous-niveau `S₁ = {x ∈ P | ∑x ≤ v(N)+1}` est un fermé inclus dans la boîte compacte `∏ᵢ Icc (v({i})) (v(N)+1 − v(N∖{i}))`, donc compacte ; la fonctionnelle continue `∑x` y atteint son minimum, et une ε-contradiction contre `hb_strict` force ce minimum à valoir `≤ v(N)` (PR #3954).
+
+Cette dernière étape était le seul `sorry` restant (`hb_witness`), longtemps taggé `INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION` faute d'un lemme de séparation adapté dans Mathlib ; la voie de passage retenue (séparation sur le cône fini + attainment par compacité) contourne ce lemme manquant **sans axiome ajouté**.
 
 ## Notes
 
-- Le `sorry` isolé vit dans `bondareva_shapley_forward.hCore` (Basic.lean L312). La preuve ramène « P ⊆ {x : ∑ xᵢ ≥ v(N)} » à l'extraction d'une allocation avec égalité, ce qui requiert soit une séparation d'hyperplan de type Farkas, soit un argument constructif d'existence d'un minimum sur un compact convexe
-- Mathlib4 ne dispose pas actuellement du lemme de séparation d'hyperplan requis ; taggé **INTRACTABLE** par le prouveur multi-agents en attendant que cette infrastructure arrive (cf [LEAN_INVENTORY.md](../LEAN_INVENTORY.md) table GO/NO-GO)
-- Lié à `stable_marriage_lean/` (théorie des appariements comme jeu coopératif)
+- Lié à [`stable_marriage_lean/`](../stable_marriage_lean/) (appariement Gale-Shapley) et [`social_choice_lean/`](../social_choice_lean/) (Arrow / Sen).
+- Le plan historique de séparation de Farkas [`docs/BONDAREVA_FARKAS_PLAN.md`](docs/BONDAREVA_FARKAS_PLAN.md) (2026-06-20) est **supersédé** par la résolution effective (compact-slice Weierstrass, #3954) ; conservé pour la traçabilité.
+- État formel détaillé : [`FORMAL_STATUS.md`](FORMAL_STATUS.md). Inventaire croisé Lean : [`../LEAN_INVENTORY.md`](../LEAN_INVENTORY.md).
 
-## Conclusion
+## Pour aller plus loin
 
-Ce projet formalise la théorie des jeux coopératifs en Lean 4 — la **valeur de Shapley**
-(close, 0 `sorry`) et le **Cœur** avec le **théorème de Bondareva-Shapley** (1 `sorry`,
-WIP). Il compile avec `lake build CooperativeGames` sur Mathlib4 (toolchain
-`v4.30.0-rc2`).
-
-### Ce qui est prouvé
-
-- **Unicité de la valeur de Shapley** (`Shapley.lean`, 0 `sorry`) : la valeur de Shapley
-  est l'allocation *unique* satisfaisant efficacité, symétrie, joueur nul et additivité —
-  la caractérisation axiomatique de Shapley (1953).
-- **Cœur + scaffolding Bondareva-Shapley** (`Basic.lean`) : jeu coopératif, fonction
-  caractéristique, le Cœur et la condition de jeu équilibré (balanced), avec la direction
-  `←` (balanced ⇒ Cœur non vide) ramenée à une seule étape d'extraction.
-
-### Pourquoi le sorry isolé reste
-
-L'unique `sorry` (`Basic.lean:312`, `hb_witness`) est le **noyau LP-dual** de la
-direction backward de Bondareva-Shapley : extraire de la condition équilibrée une
-allocation `x ∈ Core` avec `∑ xᵢ ≤ v(N)`. C'est un argument de Farkas / séparation
-d'hyperplan sur un cône. Il est **WIP, pas abandonné** — un plan actif
-([`docs/BONDAREVA_FARKAS_PLAN.md`](docs/BONDAREVA_FARKAS_PLAN.md)) valide
-l'infrastructure (`ProperCone.hyperplane_separation_point` via un encodage
-`(Option N) → ℝ`) et isole la traduction restante (~150-180 lignes ; l'étape
-`StrongDual → balanced weights` est le point crucial). `FORMAL_STATUS.md` l'enregistre
-comme WIP_HARD.
-
-### Où aller ensuite
-
-- **Théorie** : Bondareva (1963) / Shapley (1967), les caractérisations du Cœur ;
-  Shapley (1953), *A Value for n-Person Games*.
-- **Plan actif** : [`docs/BONDAREVA_FARKAS_PLAN.md`](docs/BONDAREVA_FARKAS_PLAN.md)
-  et [`FORMAL_STATUS.md`](FORMAL_STATUS.md).
-- **Lié** : [`stable_marriage_lean/`](../stable_marriage_lean/) (appariement Gale-Shapley)
-  et [`social_choice_lean/`](../social_choice_lean/) (Arrow / Sen).
+- **Théorie** : Shapley (1953), *A Value for n-Person Games* ; Bondareva (1963) ; Shapley (1967), *On Balanced Sets and Cores* ; Shapley (1971), *Cores of Convex Games*.
+- **Extensions possibles** : indice de pouvoir de Banzhaf (définitions `BanzhafRaw`/`Critical` présentes, théorèmes à écrire), propriétés calculatoires de la valeur de Shapley.

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/docs/BONDAREVA_FARKAS_PLAN.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/docs/BONDAREVA_FARKAS_PLAN.md
@@ -1,5 +1,14 @@
 # Bondareva-Shapley `hb_witness`: Farkas plan via `(Option N) → ℝ`
 
+> **⚠ SUPERSEDED (2026-06-22).** Ce plan Farkas / séparation d'hyperplan est **historique**.
+> Le noyau d'atteinte `hb_witness` a été **prouvé** par PR #3954 (`a5288f0a7`) via un
+> argument de **tranche compacte + Weierstrass** (`Basic.lean:348`) — qui contourne le
+> lemme `ProperCone.hyperplane_separation` manquant dans Mathlib **sans axiome ajouté**.
+> Le projet `cooperative_games_lean` est désormais **0 sorry** et `bondareva_shapley`
+> (`Core.Nonempty ↔ Balanced`) est entièrement certifié. Ce document est conservé pour
+> la traçabilité de la stratégie ; ne pas le suivre comme un plan actif. Voir
+> [`../FORMAL_STATUS.md`](../FORMAL_STATUS.md) pour l'état réel.
+
 **Agent:** po-2026 | **Date:** 2026-06-20 | **Issue:** #2959
 
 This plan **supersedes** the older `BONDAREVA_SHAPLEY_HARDNESS.md` strategy (which used a


### PR DESCRIPTION
## Summary

`cooperative_games_lean` docs were stale: they still claimed **1 sorry / INTRACTABLE / WIP_HARD** for `hb_witness`, but PR #3954 (merged `a5288f0a7`, 2026-06-22) closed that attainment crux via **compact-slice Weierstrass**. `bondareva_shapley : G.Core.Nonempty ↔ G.Balanced` is now fully certified, **0 sorry, no added axiom**. This PR aligns the repo docs with the proven state.

## Changes (4 docs files, one subject)

| File | Change |
|------|--------|
| `cooperative_games_lean/README.md` | FR rewrite — 0 sorry, iff PROVEN, `ConeKernel.lean` module documented, backward-direction technique (cone separation + Weierstrass attainment), lineage `#3933 → #3954`, `convex_core_nonempty`; `LEAN_INVENTORY` link verified. |
| `cooperative_games_lean/FORMAL_STATUS.md` | Total sorry `1 → 0`, `WIP_HARD → COMPLETE`; added `ConeKernel.lean` section; refreshed line counts (Basic 594, Shapley 1042, ConeKernel 733); History `2026-06-22` entry; per-file theorem inventory. |
| `cooperative_games_lean/docs/BONDAREVA_FARKAS_PLAN.md` | **SUPERSEDED** banner — Farkas/hyperplane plan replaced by compact-slice Weierstrass. Also fixes the stale in-source pointer at `ConeKernel.lean:29`. |
| `GameTheory/LEAN_INVENTORY.md` | `cooperative_games_lean` row: `1 → 0` sorry, `2 → 3` files, `Active proving → COMPLETE`; total `1 → 0`. |

## Verification (G.1 — facts checked firsthand against `origin/main`)

- **0 sorry confirmed**: standalone-tactic count = 0 across `Basic.lean`, `Shapley.lean`, `ConeKernel.lean`. The lone `grep "sorry"` hit in `ConeKernel.lean:29` is a **prose** comment ("All theorems proven, 0 \`sorry\`"), not a tactic.
- `bondareva_shapley` iff at `Basic.lean:434`; `convex_core_nonempty` at `Basic.lean:588`; `hb_witness` attainment at `Basic.lean:348` (compact slice `S₁`, `hS1_compact.exists_isMinOn` L409, ε-contradiction vs `hb_strict`).
- Lineage on main: #3933 (cone kernel) → #3941 (bridge) → #3945 (decoding) → #3951 (`hb_strict`) → #3954 (attainment).
- `README.en.md` (EN original) left untouched per FR-first rule §2 (preserved as-is).

Docs-only — no `.lean` / catalog / notebook changes. Diffstat: 4 files, +109/-107.

See #2959
See #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)