### PR TITLE
docs(gametheory): demote aside headings to bullet lists (typo-only, #3966)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
@@ -346,10 +346,10 @@
     "\n",
     "**Contexte** : Le jeu a 3 joueurs montre que le detenteur de la ressource rare obtient 4/6. Avec 2 gants de chaque cote, le marche est equilibre.\n",
     "\n",
-    "# Indice : Joueurs 0,1 = gants gauches, joueurs 2,3 = gants droits. v(S) = min(gauches, droites).\n",
-    "# Etape 1 : Definir glove_game_4(S).\n",
-    "# Etape 2 : Calculer shapley_value_exact(glove_game_4, 4).\n",
-    "# Etape 3 : Comparer avec le resultat a 3 joueurs (ressource rare vs equilibre)."
+    "- **Indice :** Joueurs 0,1 = gants gauches, joueurs 2,3 = gants droits. v(S) = min(gauches, droites).\n",
+    "- **Etape 1 :** Definir glove_game_4(S).\n",
+    "- **Etape 2 :** Calculer shapley_value_exact(glove_game_4, 4).\n",
+    "- **Etape 3 :** Comparer avec le resultat a 3 joueurs (ressource rare vs equilibre)."
    ]
   },
   {
@@ -1143,10 +1143,10 @@
     "\n",
     "**Contexte** : Pour les jeux convexes, Shapley est garanti dans le Core. Pour les jeux non convexes, ce n'est pas certain.\n",
     "\n",
-    "# Indice : Essayer v(S) = |S| * (|S| - 1) / 2 (jeu convexe) et v(S) = 1 si |S| >= 2 (majorite, non convexe).\n",
-    "# Etape 1 : Definir deux fonctions caracteristiques (une convexe, une non convexe).\n",
-    "# Etape 2 : Tester la convexite de chacune.\n",
-    "# Etape 3 : Calculer Shapley et verifier l'appartenance au Core."
+    "- **Indice :** Essayer v(S) = |S| * (|S| - 1) / 2 (jeu convexe) et v(S) = 1 si |S| >= 2 (majorite, non convexe).\n",
+    "- **Etape 1 :** Definir deux fonctions caracteristiques (une convexe, une non convexe).\n",
+    "- **Etape 2 :** Tester la convexite de chacune.\n",
+    "- **Etape 3 :** Calculer Shapley et verifier l'appartenance au Core."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
@@ -538,10 +538,10 @@
     "\n",
     "**Contexte** : Les encheres au premier prix et au second prix ont ete comparees ci-dessus. L'enchere all-pay est un autre format classique, utilise dans les concours de lobbying.\n",
     "\n",
-    "# Indice : Heriter de Mechanism. La methode allocate retourne l'index du gagnant, compute_payments retourne la liste des paiements (chaque joueur paie sa propre offre).\n",
-    "# Etape 1 : Definir la classe AllPayAuction avec allocate et compute_payments.\n",
-    "# Etape 2 : Tester sur des agents avec differentes evaluations.\n",
-    "# Etape 3 : Verifier is_ic = False (les joueurs ont interet a sous-encherir)."
+    "- **Indice :** Heriter de Mechanism. La methode allocate retourne l'index du gagnant, compute_payments retourne la liste des paiements (chaque joueur paie sa propre offre).\n",
+    "- **Etape 1 :** Definir la classe AllPayAuction avec allocate et compute_payments.\n",
+    "- **Etape 2 :** Tester sur des agents avec differentes evaluations.\n",
+    "- **Etape 3 :** Verifier is_ic = False (les joueurs ont interet a sous-encherir)."
    ]
   },
   {
@@ -1534,10 +1534,10 @@
     "\n",
     "**Contexte** : La stabilite d'un matching se mesure par l'absence de paires bloquantes. Gale-Shapley garantit la stabilite.\n",
     "\n",
-    "# Indice : Une paire (m, w) est bloquante si m prefere w a sa partenaire actuelle ET w prefere m a son partenaire actuel.\n",
-    "# Etape 1 : Implementer count_blocking_pairs.\n",
-    "# Etape 2 : Verifier sur le resultat de gale_shapley.\n",
-    "# Etape 3 : Creer un matching aleatoire et verifier qu'il a des paires bloquantes."
+    "- **Indice :** Une paire (m, w) est bloquante si m prefere w a sa partenaire actuelle ET w prefere m a son partenaire actuel.\n",
+    "- **Etape 1 :** Implementer count_blocking_pairs.\n",
+    "- **Etape 2 :** Verifier sur le resultat de gale_shapley.\n",
+    "- **Etape 3 :** Creer un matching aleatoire et verifier qu'il a des paires bloquantes."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
@@ -610,10 +610,10 @@
     "\n",
     "**Contexte** : L'exploitabilite mesure a quel point un adversaire optimal peut punir votre strategie. C'est la metrique cle pour evaluer les algorithmes MARL.\n",
     "\n",
-    "# Indice : L'exploitabilite = somme des gains de la meilleure reponse de chaque joueur contre la strategie de l'autre.\n",
-    "# Etape 1 : Calculer la meilleure reponse de chaque joueur contre la strategie adverse.\n",
-    "# Etape 2 : Sommer les gains esperes des meilleures reponses.\n",
-    "# Etape 3 : Verifier que la strategie uniforme a la plus faible exploitabilite."
+    "- **Indice :** L'exploitabilite = somme des gains de la meilleure reponse de chaque joueur contre la strategie de l'autre.\n",
+    "- **Etape 1 :** Calculer la meilleure reponse de chaque joueur contre la strategie adverse.\n",
+    "- **Etape 2 :** Sommer les gains esperes des meilleures reponses.\n",
+    "- **Etape 3 :** Verifier que la strategie uniforme a la plus faible exploitabilite."
    ]
   },
   {
@@ -934,10 +934,10 @@
     "\n",
     "**Contexte** : Le Fictitious Play est un algorithme ou chaque joueur joue la meilleure reponse a la frequence empirique des coups adverses. Sur les jeux a somme nulle, il converge vers Nash.\n",
     "\n",
-    "# Indice : Utiliser la classe FictitiousPlay definie ci-dessus.\n",
-    "# Etape 1 : Creer un jeu Matching Pennies avec create_matching_pennies().\n",
-    "# Etape 2 : Entrainer le FictitiousPlay pendant 1000 iterations.\n",
-    "# Etape 3 : Verifier que get_average_strategy() est proche de (0.5, 0.5)."
+    "- **Indice :** Utiliser la classe FictitiousPlay definie ci-dessus.\n",
+    "- **Etape 1 :** Creer un jeu Matching Pennies avec create_matching_pennies().\n",
+    "- **Etape 2 :** Entrainer le FictitiousPlay pendant 1000 iterations.\n",
+    "- **Etape 3 :** Verifier que get_average_strategy() est proche de (0.5, 0.5)."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
@@ -2061,10 +2061,10 @@
     "\n",
     "**Objectif** : Implementer `eliminate_weakly_dominated` qui elimine iterativement les strategies faiblement dominees et comparer le resultat avec l'IESDS.\n",
     "\n",
-    "# Indice : La difference cle avec l'IESDS est le test de dominance faible (>= partout, > au moins une fois)\n",
-    "# Etape 1 : Ecrire une fonction `is_weakly_dominated(A, row, player)` qui verifie si une strategie est faiblement dominee\n",
-    "# Etape 2 : Eliminer iterativement les strategies faiblement dominees\n",
-    "# Etape 3 : Comparer le resultat de l'IEWDS avec l'IESDS sur la matrice `A_test` fournie"
+    "- **Indice :** La difference cle avec l'IESDS est le test de dominance faible (>= partout, > au moins une fois)\n",
+    "- **Etape 1 :** Ecrire une fonction `is_weakly_dominated(A, row, player)` qui verifie si une strategie est faiblement dominee\n",
+    "- **Etape 2 :** Eliminer iterativement les strategies faiblement dominees\n",
+    "- **Etape 3 :** Comparer le resultat de l'IEWDS avec l'IESDS sur la matrice `A_test` fournie"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
@@ -397,10 +397,10 @@
     "\n",
     "**Contexte** : Dans le Dilemme du Prisonnier, Defaire domine Cooperer. Apres elimination, il ne reste qu'un seul profil : (D,D), qui est l'equilibre de Nash.\n",
     "\n",
-    "# Indice : Pour chaque joueur, comparer les gains de chaque action contre toutes les actions de l'adversaire.\n",
-    "# Etape 1 : Identifier les strategies strictement dominees pour chaque joueur.\n",
-    "# Etape 2 : Les eliminer et verifier si de nouvelles dominations apparaissent.\n",
-    "# Etape 3 : Comparer les strategies survivantes avec les equilibres de Nash."
+    "- **Indice :** Pour chaque joueur, comparer les gains de chaque action contre toutes les actions de l'adversaire.\n",
+    "- **Etape 1 :** Identifier les strategies strictement dominees pour chaque joueur.\n",
+    "- **Etape 2 :** Les eliminer et verifier si de nouvelles dominations apparaissent.\n",
+    "- **Etape 3 :** Comparer les strategies survivantes avec les equilibres de Nash."
    ]
   },
   {
@@ -1425,10 +1425,10 @@
     "\n",
     "**Contexte** : L'exemple ci-dessus montre que le RPS standard a un equilibre uniforme (1/3, 1/3, 1/3). Que se passe-t-il si on desequilibre les gains ?\n",
     "\n",
-    "# Indice : Modifier la matrice A_rps pour que la ligne Pierre (index 0) batte Ciseaux avec gain 2 au lieu de 1.\n",
-    "# Etape 1 : Construire la matrice biaisee A_biased.\n",
-    "# Etape 2 : Calculer les equilibres avec support_enumeration.\n",
-    "# Etape 3 : Verifier que les probabilites different de 1/3."
+    "- **Indice :** Modifier la matrice A_rps pour que la ligne Pierre (index 0) batte Ciseaux avec gain 2 au lieu de 1.\n",
+    "- **Etape 1 :** Construire la matrice biaisee A_biased.\n",
+    "- **Etape 2 :** Calculer les equilibres avec support_enumeration.\n",
+    "- **Etape 3 :** Verifier que les probabilites different de 1/3."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
@@ -1772,11 +1772,11 @@
     "\n",
     "**Objectif** : Implementer `verify_brouwer_hypotheses` qui verifie ces trois conditions sur des donnees discretisees et predit si un point fixe doit exister.\n",
     "\n",
-    "# Indice : Pour \"compact\", verifier que les points sont dans un rayon fini. Pour \"convexe\", verifier que le milieu de tout couple de points est dans l'enveloppe. Pour \"continue\", verifier que |f(x_{i+1}) - f(x_i)| ne fait pas de saut.\n",
-    "# Etape 1 : Implementer le test de compacite (norme maximale des points)\n",
-    "# Etape 2 : Implementer le test de convexite (enveloppe convexe via coefficient de Gini ou ratio)\n",
-    "# Etape 3 : Implementer le test de continuite (saut maximal entre points consecutifs < seuil)\n",
-    "# Etape 4 : Combiner les 3 tests et afficher le verdict"
+    "- **Indice :** Pour \"compact\", verifier que les points sont dans un rayon fini. Pour \"convexe\", verifier que le milieu de tout couple de points est dans l'enveloppe. Pour \"continue\", verifier que |f(x_{i+1}) - f(x_i)| ne fait pas de saut.\n",
+    "- **Etape 1 :** Implementer le test de compacite (norme maximale des points)\n",
+    "- **Etape 2 :** Implementer le test de convexite (enveloppe convexe via coefficient de Gini ou ratio)\n",
+    "- **Etape 3 :** Implementer le test de continuite (saut maximal entre points consecutifs < seuil)\n",
+    "- **Etape 4 :** Combiner les 3 tests et afficher le verdict"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
@@ -244,10 +244,10 @@
     "\n",
     "**Contexte** : La classification 1-2-3 montre une periodicite de 4. Avec S({1,3}), la structure change.\n",
     "\n",
-    "# Indice : Adapter classify_123_game en remplacant [1,2,3] par un ensemble parametrable.\n",
-    "# Etape 1 : Implementer classify_game(n_max, moves).\n",
-    "# Etape 2 : Identifier le motif des P-positions.\n",
-    "# Etape 3 : Calculer la periode."
+    "- **Indice :** Adapter classify_123_game en remplacant [1,2,3] par un ensemble parametrable.\n",
+    "- **Etape 1 :** Implementer classify_game(n_max, moves).\n",
+    "- **Etape 2 :** Identifier le motif des P-positions.\n",
+    "- **Etape 3 :** Calculer la periode."
    ]
   },
   {
@@ -790,10 +790,10 @@
     "\n",
     "**Contexte** : Le theoreme de Sprague-Grundy affirme que la somme de jeux impartiaux se decompose via le XOR. Verifions-le sur un exemple concret.\n",
     "\n",
-    "# Indice : Pour chaque n, calculer Grundy de G1 et G2 separement.\n",
-    "# Etape 1 : Calculer grundy_subtraction pour les deux jeux.\n",
-    "# Etape 2 : Pour la somme, le Grundy total = XOR des deux.\n",
-    "# Etape 3 : Verifier que le resultat est coherent avec la classification P/N."
+    "- **Indice :** Pour chaque n, calculer Grundy de G1 et G2 separement.\n",
+    "- **Etape 1 :** Calculer grundy_subtraction pour les deux jeux.\n",
+    "- **Etape 2 :** Pour la somme, le Grundy total = XOR des deux.\n",
+    "- **Etape 3 :** Verifier que le resultat est coherent avec la classification P/N."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
@@ -777,10 +777,10 @@
     "\n",
     "**Contexte** : Les fonctions `wythoff_p_positions`, `is_wythoff_p_position` et `wythoff_winning_move` sont deja implementees. Utilisez-les pour explorer la structure.\n",
     "\n",
-    "# Indice : Les P-positions suivent les sequences de Beatty avec le nombre d'or.\n",
-    "# Etape 1 : Generer les 15 premieres P-positions.\n",
-    "# Etape 2 : Verifier chaque position avec is_wythoff_p_position.\n",
-    "# Etape 3 : Pour les N-positions (10,15), (8,12), trouver le coup gagnant."
+    "- **Indice :** Les P-positions suivent les sequences de Beatty avec le nombre d'or.\n",
+    "- **Etape 1 :** Generer les 15 premieres P-positions.\n",
+    "- **Etape 2 :** Verifier chaque position avec is_wythoff_p_position.\n",
+    "- **Etape 3 :** Pour les N-positions (10,15), (8,12), trouver le coup gagnant."
    ]
   },
   {
@@ -987,10 +987,10 @@
     "\n",
     "**Contexte** : La classe `CompositeGame` implemente le theoreme de Sprague-Grundy pour les jeux composites. Utilisez-la pour analyser une nouvelle configuration.\n",
     "\n",
-    "# Indice : Utiliser CompositeGame avec differentes combinaisons de moves.\n",
-    "# Etape 1 : Definir 3 composantes avec des moves differents de l'exemple.\n",
-    "# Etape 2 : Calculer les Grundy individuels et le total.\n",
-    "# Etape 3 : Si N-position, trouver le coup gagnant et verifier que le nouveau Grundy = 0."
+    "- **Indice :** Utiliser CompositeGame avec differentes combinaisons de moves.\n",
+    "- **Etape 1 :** Definir 3 composantes avec des moves differents de l'exemple.\n",
+    "- **Etape 2 :** Calculer les Grundy individuels et le total.\n",
+    "- **Etape 3 :** Si N-position, trouver le coup gagnant et verifier que le nouveau Grundy = 0."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
@@ -1708,10 +1708,10 @@
     "\n",
     "**Objectif** : Implementer `solve_takeaway_game` qui resout le jeu par induction arriere et identifie les positions gagnantes.\n",
     "\n",
-    "# Indice : La position 0 est perdante (le joueur qui vient de jouer a pris le dernier). Remontez depuis la fin.\n",
-    "# Etape 1 : Initialiser un tableau positions[0..n] : position 0 = perdante\n",
-    "# Etape 2 : Pour chaque position p de 1 a n, verifier si il existe une prise t (1..max_take) telle que p-t est perdante pour l'adversaire\n",
-    "# Etape 3 : Construire le dictionnaire des prises optimales"
+    "- **Indice :** La position 0 est perdante (le joueur qui vient de jouer a pris le dernier). Remontez depuis la fin.\n",
+    "- **Etape 1 :** Initialiser un tableau positions[0..n] : position 0 = perdante\n",
+    "- **Etape 2 :** Pour chaque position p de 1 a n, verifier si il existe une prise t (1..max_take) telle que p-t est perdante pour l'adversaire\n",
+    "- **Etape 3 :** Construire le dictionnaire des prises optimales"
    ]
   },
   {


### PR DESCRIPTION
## Scope (EPIC #3966 — mise-en-forme typo-only, partition .NET/symbolic po-2025)

Mise-en-forme **typo-only** sur **9 notebooks d'exercice GameTheory non-Lean**. Les blocs `# Indice : ...` / `# Etape N : ...` en commentaire-style dans les cellules **markdown** rendaient chacun comme un titre **H1** (25.998px) → fausse **MULTI-H1** dominant visuellement les vrais titres de section (H2 21.994px). Convertis en **liste à puces** `- **Indice :** ...` / `- **Etape N :**` (directive [`notebook-formatting.md`](docs/reference/notebook-formatting.md) §1.2 : un aside n'est jamais un titre).

**Aucun** texte modifié, **aucune** cellule code/output touchée, **aucun** relabel Exercice↔Exemple. **61 lignes, 61 ins / 61 del balancées.**

Notebooks : `GameTheory-2/4/4c/8/8c/9/15c/16/17`.

## Vérification

- **scan_md_hierarchy** (fence-aware, #3982) : **0/9 residual** (MULTI-H1 / H1-DEEP / HINT-AS-HEADING tous éliminés).
- **Diff audité heading-only** : aucun `execution_count` / `outputs` / `cell_type` touché.
- **Visuel** (nbconvert classic + Playwright `getComputedStyle`) sur **GT-15c** :
  | | avant | après |
  |---|---|---|
  | asides `# Indice`/`# Etape` (×8) | **H1 25.998px** | **`li` 14px** (label gras) |
  | H1 count | 9 (titre + 8 asides) | **1** (titre seul) |
  | sections réelles (H2 Glove/Convexes 21.994px, H3 Interpretation/Exercice 18.004px) | intactes | **intactes** |

## Exclus de ce lot

- **GameTheory-1-Setup** : flags structurels = faux positifs (cell 0 = blockquote de navigation → cell 1 titre vu `H1-DEEP` ; cell 5 `### Note sur OpenSpiel` = vraie sous-section sœur de `### Alternative recommandée`, pas un aside).
- **SocialChoice (01/02/04)** : `H1-DEEP` structurels + 02 Lean-adjacent → à arbitrer par le coordinateur.
- Sous-dossiers `*_lean` : hors partition (po-2026).

See #3968
See #3966