### PR TITLE
feat(coop-games): prove dummy_banzhaf_raw_zero (first Banzhaf theorem)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1019,10 +1019,15 @@ noncomputable def WeightedVotingGame (weights : N → ℝ) (quota : ℝ) (hquota
 def Critical (G : TUGame N) (i : N) (S : Finset N) : Prop :=
   i ∈ S ∧ G.v S = 1 ∧ G.v (S.erase i) = 0
 
-/-- Raw Banzhaf index: number of coalitions where i is critical.
-    Uses Classical.decPred since Critical involves noncomputable real comparisons. -/
+/-- `Critical G i` is decidable via Classical reasoning (the `TUGame.v` comparisons are
+    noncomputable reals). Promoted to a global instance so that `BanzhafRaw` and any
+    theorem about it synthesise the SAME instance, avoiding the
+    opaque-`Classical.decPred`-mismatch trap. -/
+noncomputable instance criticalDecidable (G : TUGame N) (i : N) :
+    DecidablePred (fun S : Finset N => Critical G i S) := Classical.decPred _
+
+/-- Raw Banzhaf index: number of coalitions where i is critical. -/
 noncomputable def BanzhafRaw (G : TUGame N) (i : N) : ℕ :=
-  haveI : DecidablePred (fun S => Critical G i S) := Classical.decPred _
   (Finset.univ.filter fun S => Critical G i S).card
 
 /-- Player with veto power -/
@@ -1041,3 +1046,37 @@ def DummyPlayer (G : TUGame N) (i : N) : Prop :=
 theorem dummy_shapley_zero (G : TUGame N) (i : N) (h : DummyPlayer G i) :
     shapleyValue G i = 0 :=
   ShapleyValue.shapley_null_player G i h
+
+/-- Dummy players are critical in no coalition, hence have a zero raw Banzhaf index.
+
+    A dummy player never changes a coalition's value, so it can never be the case that
+    `v S = 1` while `v (S.erase i) = 0`: the dummy hypothesis forces `v S = v (S.erase i)`,
+    contradicting criticality. -/
+theorem dummy_banzhaf_raw_zero (G : TUGame N) (i : N) (h : DummyPlayer G i) :
+    BanzhafRaw G i = 0 := by
+  -- A dummy player is critical in no coalition: criticality demands `v S = 1` and
+  -- `v (S.erase i) = 0`, but `DummyPlayer` gives `v S = v (S.erase i)`.
+  have hneq : ∀ S, Critical G i S → False := by
+    rintro S ⟨hmem, hone, hzero⟩
+    have hni : i ∉ S.erase i := by simp [Finset.mem_erase]
+    -- `S = (S.erase i) ∪ {i}` since `i ∈ S`.
+    have hS_eq : S = (S.erase i) ∪ {i} := by
+      ext j
+      simp only [Finset.mem_union, Finset.mem_erase, Finset.mem_singleton]
+      constructor
+      · intro hj
+        by_cases heq : j = i
+        · exact Or.inr heq
+        · exact Or.inl ⟨heq, hj⟩
+      · rintro (⟨_, hj⟩ | hj)
+        · exact hj
+        · rw [hj]; exact hmem
+    have hdummy := h (S.erase i) hni
+    rw [← hS_eq] at hdummy
+    rw [hdummy] at hone
+    linarith
+  -- `BanzhafRaw` = cardinality of the critical-coalition filter (instance now consistent
+  -- via `criticalDecidable`); the filter is empty since `hneq` refutes every criticality.
+  simp only [BanzhafRaw]
+  rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  exact fun S _ hcrit => hneq S hcrit


### PR DESCRIPTION
## Summary

Adds the **first Banzhaf power-index theorem** to `cooperative_games_lean`:

```lean
theorem dummy_banzhaf_raw_zero (G : TUGame N) (i : N) (h : DummyPlayer G i) :
    BanzhafRaw G i = 0
```

The definitions `Critical` / `BanzhafRaw` existed but had **no theorems** — this gap
is documented in `FORMAL_STATUS.md` "Remaining Work" (Banzhaf power index theorems).
This PR fills it for the dummy-player case.

### Supporting refactor (required to unblock the proof)

Promotes `Critical G i` decidability from an **internal `haveI` hidden inside
`BanzhafRaw`'s body** to a **global `noncomputable instance criticalDecidable`**.

**Root cause of why the theorem was blocked**: the hidden instance was an anonymous
`Classical.decPred _`. `Classical.decPred` is built on `Classical.choice` (the choice
axiom), so two independently-synthesised instances are **not definitionally equal**
(defeq cannot reduce choice). Any theorem-level `DecidablePred` synthesis (e.g. the
implicit `[DecidablePred f]` on `Finset.mem_filter` / `Finset.filter_eq_empty_iff`)
produced a *different* opaque instance than the one locked inside `BanzhafRaw`, and
neither `exact`, `rfl`, nor `simp` could bridge them — the classic
*"has type `{S | …} = ∅` but expected `{S | …} = ∅`"* trap (identical display, distinct
instances). The global instance makes `BanzhafRaw` and every theorem synthesise the
**same** instance, so unfolding + membership lemmas unify cleanly. `BanzhafRaw`'s body
simplifies to `(Finset.univ.filter fun S => Critical G i S).card`.

`BanzhafRaw` has **no other consumers** (grep confirms only the def + this theorem),
so the refactor is safe and in scope.

### Proof sketch

A dummy player is critical in no coalition. `Critical G i S` demands `v S = 1 ∧
v (S.erase i) = 0`, but `DummyPlayer G i` (applied to `S.erase i`, with `i ∉ S.erase i`)
forces `v ((S.erase i) ∪ {i}) = v (S.erase i)`. Since `i ∈ S`, `S = (S.erase i) ∪ {i}`
(via `Finset.ext` membership), so `v S = v (S.erase i)`, contradicting `1 = 0` (linarith).
Hence the filter of critical coalitions is empty and `BanzhafRaw = 0`.

## §B Lean verification (pr-review-discipline)

| Check | Result |
|-------|--------|
| `grep -c sorry` Shapley.lean (before/after) | 0 → 0 |
| CI prose-header filter (reproduced) | clean — lone `ConeKernel.lean:29` hit is pre-existing prose "0 sorry", **untouched** by this PR |
| `lake build CooperativeGames` | **SUCCESS (8435 jobs, 0 error)** |
| Proof integrity / added axiom | none added (instance is `Classical.decPred`, standard classical decidability) |
| Scope | single file (`Shapley.lean`), single feature — atomic |

```
$ lake build CooperativeGames
Build completed successfully (8435 jobs).
```

## Scope notes

- **Atomic**: only `CooperativeGames/Shapley.lean` (+43/-4). I intentionally do **not**
  touch `FORMAL_STATUS.md`'s "Remaining Work" Banzhaf line here — that doc has seen
  cross-lane churn recently (#4001, #4008) and a doc-only edit would risk a
  duplicate/conflict (cf. #4007 closed as dup of #4001). The gap-update can follow as a
  separate doc PR if desired.
- **`See #3973`** (cooperative_games_lean Banzhaf epic) + **`See #2959`** (Bondareva-Shapley
  / coop-games module) — partial contributions, not `Closes` (epics remain open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)