### PR TITLE
docs(sudoku): demote exercise aside headings to bold inline (typo-only, #3968)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
@@ -748,7 +748,7 @@
     "\n",
     "Utilisez cette methode pour valider les resultats de `SudokuHelper.SolveSudoku`.\n",
     "\n",
-    "### Indices\n",
+    "**Indices :**\n",
     "\n",
     "- Parcourez les 9 lignes, 9 colonnes et 9 blocs\n",
     "- Pour chaque unite, verifiez que les 9 chiffres sont tous presents sans doublon\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -586,11 +586,11 @@
    "source": [
     "## Exercice : Verifier qu'une grille est valide\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez une methode qui verifie si une grille completement remplie\n",
     "respecte toutes les contraintes du Sudoku (lignes, colonnes, blocs uniques).\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Parcourez chaque ligne, colonne et bloc 3x3 et verifiez que chaque ensemble\n",
     "contient exactement les chiffres 1 a 9 sans doublon.\n"
    ]
@@ -867,11 +867,11 @@
    "source": [
     "## Exercice : Comparer backtracking simple et MRV\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comparez les performances du solveur simple et du solveur MRV sur\n",
     "des puzzles de differentes difficultes.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Utilisez un Stopwatch pour mesurer le temps et comptez les appels recursifs.\n"
    ]
   },
@@ -911,7 +911,7 @@
     },
     "tags": []
    },
-   "source": "## Exercice (guidé) : Backtracking avec Heuristique MRV (Minimum Remaining Values)\n\n### Enonce\n\nL'implementation actuelle de `BacktrackingDotNetSolver` choisit les cellules a remplir dans l'ordre de parcours (de gauche a droite, de haut en bas). Implementez une version amelioree avec l'heuristique **MRV** (Minimum Remaining Values) :\n\nL'heuristique MRV choisit en priorite la cellule qui a le **moins de valeurs possibles** (le domaine le plus petit). Intuitivement, on commence par les cellules les plus contraintes pour detecter les echecs plus tot et reduire l'espace de recherche.\n\nImplementez `BacktrackingMRVSolver` :\n1. Pour chaque cellule vide, calculez son domaine (valeurs 1-9 compatibles avec les contraintes)\n2. Choisissez la cellule avec le plus petit domaine non vide\n3. Si un domaine est vide, retournez `false` immediatement (echec precoce)\n4. Comparez le nombre d'appels recursifs avec `BacktrackingDotNetSolver`\n\n### Indice\n\nLe calcul du domaine consiste a retirer de {1..9} toutes les valeurs deja presentes dans la meme ligne, colonne ou bloc. L'heuristique MRV reduit drastiquement les appels recursifs sur les puzzles difficiles."
+   "source": "## Exercice (guidé) : Backtracking avec Heuristique MRV (Minimum Remaining Values)\n\n### Enonce\n\nL'implementation actuelle de `BacktrackingDotNetSolver` choisit les cellules a remplir dans l'ordre de parcours (de gauche a droite, de haut en bas). Implementez une version amelioree avec l'heuristique **MRV** (Minimum Remaining Values) :\n\nL'heuristique MRV choisit en priorite la cellule qui a le **moins de valeurs possibles** (le domaine le plus petit). Intuitivement, on commence par les cellules les plus contraintes pour detecter les echecs plus tot et reduire l'espace de recherche.\n\nImplementez `BacktrackingMRVSolver` :\n1. Pour chaque cellule vide, calculez son domaine (valeurs 1-9 compatibles avec les contraintes)\n2. Choisissez la cellule avec le plus petit domaine non vide\n3. Si un domaine est vide, retournez `false` immediatement (echec precoce)\n4. Comparez le nombre d'appels recursifs avec `BacktrackingDotNetSolver`\n\n**Indice :**\n\nLe calcul du domaine consiste a retirer de {1..9} toutes les valeurs deja presentes dans la meme ligne, colonne ou bloc. L'heuristique MRV reduit drastiquement les appels recursifs sur les puzzles difficiles."
   },
   {
    "cell_type": "code",
@@ -1011,11 +1011,11 @@
    "source": [
     "## Exercice : Compter le nombre de solutions\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Modifiez le solveur backtracking pour compter le nombre total de solutions\n",
     "d'un puzzle donne (en arretant apres un maximum pour eviter les boucles infinies).\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Ajoutez un compteur global et arretez la recherche apres `maxCount` solutions trouvees.\n"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -497,10 +497,10 @@
    "source": [
     "## Exercice : Compter les contraintes initiales\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comptez le nombre de contraintes posees par le modele OR-Tools pour un puzzle donne.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Parcourez les contraintes de ligne, colonne, bloc et cellule et comptez-les.\n"
    ]
   },
@@ -905,11 +905,11 @@
    "source": [
     "## Exercice : Verifier la validite d'une solution avec OR-Tools\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Utilisez OR-Tools pour verifier qu'une solution proposee satisfait bien\n",
     "toutes les contraintes du modele.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Creez le modele, fixez les variables aux valeurs de la solution, et verifiez la faisabilite.\n"
    ]
   },
@@ -1341,11 +1341,11 @@
    "source": [
     "## Exercice : Resoudre le Sudoku X avec contraintes de diagonale\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Ajoutez des contraintes de diagonale au modele OR-Tools pour resoudre\n",
     "un Sudoku X (ou les deux diagonales doivent aussi contenir 1-9).\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Ajoutez une contrainte AllDifferent pour chaque diagonale de la grille.\n"
    ]
   },
@@ -1762,7 +1762,7 @@
     "3. Ajoutez les contraintes de diagonales : les reines ne doivent pas etre sur la meme diagonale\n",
     "4. Comptez le nombre de solutions pour N=8 (attendu : 92)\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Pour les diagonales, deux reines aux positions (i, queen[i]) et (j, queen[j]) sont en conflit si `queen[i] - queen[j] == i - j` (diagonale principale) ou `queen[i] - queen[j] == j - i` (diagonale secondaire). Ces contraintes peuvent s'exprimer avec `model.Add(queen[i] - queen[j] != i - j)` pour tous les couples (i, j)."
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -443,11 +443,11 @@
    "source": [
     "## Exercice : Comparer les strategies de recherche Choco\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comparez au moins 2 strategies de recherche Choco (InputOrder, DomOverWDeg)\n",
     "et mesurez leur impact sur le temps de resolution.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Configurez le solver avec differentes strategies et lancez les benchmarks.\n"
    ]
   },
@@ -863,11 +863,11 @@
    "source": [
     "## Exercice : Resolution avec limite de temps\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez une resolution Choco avec un timeout et analysez les resultats\n",
     "intermediaires obtenus quand le temps est depasse.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Utilisez les parametres de timeout du solver et recuperez l'etat partiel.\n"
    ]
   },
@@ -1049,10 +1049,10 @@
    "source": [
     "## Exercice : Comptage de solutions avec Choco\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Utilisez Choco pour compter le nombre total de solutions d'un puzzle Sudoku donne.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Configurez le solver pour chercher toutes les solutions et comptez-les.\n"
    ]
   },
@@ -1096,7 +1096,7 @@
     "3. Ajoute les contraintes de diagonales avec des variables temporaires\n",
     "4. Compte et affiche le nombre de solutions pour N=8\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Pour les diagonales, deux reines aux positions (i, queen[i]) et (j, queen[j]) sont en conflit si `queen[i] - queen[j] == i - j`. En Choco, vous pouvez utiliser `model.arithm()` pour chaque paire, ou introduire des variables auxiliaires `diagDiff[i][j] = queen[i] - queen[j]` et ajouter `allDifferent` sur les diagonales."
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
@@ -549,10 +549,10 @@
    "source": [
     "## Exercice : Resoudre un Killer Sudoku avec contrainte de somme\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Ajoutez une contrainte de somme sur un bloc 3x3 pour modeliser un Killer Sudoku.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Utilisez MkAdd pour sommer les variables d'un bloc et MkEq pour fixer la somme attendue.\n"
    ]
   },
@@ -859,11 +859,11 @@
    "source": [
     "## Exercice : Compter le nombre de solutions avec Z3\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Utilisez Z3 pour compter le nombre total de solutions d'un puzzle en\n",
     "ajoutant iterativement des contraintes d'exclusion.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Apres chaque solution trouvee, ajoutez une contrainte qui exclut cette solution\n",
     "et relancez le solver.\n"
    ]
@@ -1003,11 +1003,11 @@
    "source": [
     "## Exercice : Coloration de graphe avec Z3\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Utilisez Z3 pour resoudre un probleme de coloration de graphe : colorier\n",
     "un graphe avec k couleurs telles que deux noeuds adjacents n'ont jamais la meme couleur.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Creez une variable entiere par noeud et ajoutez des contraintes de difference pour chaque arete.\n"
    ]
   },
@@ -1288,7 +1288,7 @@
     "\n",
     "3. Testez avec le puzzle facile : verifiez unicite et minimalite\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Pour `HasUniqueSolution`, apres avoir trouve S1 = {cells[i][j] = v[i][j]}, ajoutez la contrainte `Or(cell[i][j] != v[i][j])` pour toutes les cellules. Cette contrainte dit \"au moins une cellule differe de S1\"."
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -721,13 +721,13 @@
    "source": [
     "## Exercice 1 : une contrainte d'intersection RE#\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Ecrivez un pattern RE# qui reconnait une ligne Sudoku valide **ET** dans laquelle le chiffre **5 apparaît avant le 7** (sous-sequence `5 ... 7`).\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Composez par intersection la contrainte de ligne valide (ci-dessus) avec `.*5.*7.*` (un 5 puis, plus loin, un 7). RE# accepte l'imbrication libre de `&` dans une meme chaine.\n",
     "\n",
-    "# Etape 1\n",
+    "**Etape 1 :**\n",
     "Definissez le pattern combine dans la cellule suivante. Une permutation comme `123456789` (5 avant 7) doit passer ; `987654321` (7 avant 5) doit echouer."
    ]
   },
@@ -2479,13 +2479,13 @@
    "source": [
     "## Exercice 2 : etendre l'encodage Z3 (Sudoku diagonal)\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Le Sudoku-X ajoute deux contraintes : les deux **diagonales** principales doivent aussi contenir 1..9 (tous distincts). Etendez la fonction `ResoudreSudokuZ3` pour ajouter ces deux contraintes.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Recuperez les 9 `IntExpr` de la diagonale principale (`cells[i,i]`) et de l'anti-diagonale (`cells[i, 8-i]`), et ajoutez deux `ctx.MkDistinct(...)` supplementaires avant `s.Check()`.\n",
     "\n",
-    "# Etape 1\n",
+    "**Etape 1 :**\n",
     "Ecrivez une variante `ResoudreSudokuXZ3` dans la cellule suivante."
    ]
   },
@@ -3054,7 +3054,7 @@
    "source": [
     "## Exercice 3 : classifier recognition vs solving (conceptuel)\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Pour chacune des taches ci-dessous, indiquez quel outil convient (RE# pour la reconnaissance / verification, Z3 pour la resolution / production de temoin) et pourquoi.\n",
     "\n",
     "| Tache | Outil attendu | Pourquoi |\n",
@@ -3064,7 +3064,7 @@
     "| (c) Verifier qu'une chaine est un nombre a 9 chiffres distincts | ... | ... |\n",
     "| (d) Trouver une permutation de 1..9 maximisant un critere | ... | ... |\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Posez-vous : la tache demande-t-elle de *produire* une solution (solving -> Z3) ou seulement de *reconnaitre* si une entree donnee est valide (matching -> RE#) ?"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -338,11 +338,11 @@
    "source": [
     "## Exercice : Construire un BDD pour la contrainte \"exactement un parmi N\"\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Construisez un BDD qui encode la contrainte : parmi N variables booleennes,\n",
     "exactement une doit etre vraie.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Utilisez la negation et la conjonction pour exprimer la contrainte.\n"
    ]
   },
@@ -1139,11 +1139,11 @@
    "source": [
     "## Exercice : Construire un MDD pour la contrainte \"tous differents\"\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Construisez un MDD (Multi-valued Decision Diagram) qui encode la contrainte\n",
     "\"tous differents\" pour une ligne de 9 cellules avec valeurs 1-9.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Chaque niveau du MDD represente une cellule, et chaque arc represente une valeur possible\n",
     "non encore utilisee.\n"
    ]
@@ -1922,11 +1922,11 @@
    "source": [
     "## Exercice : Comparer les performances BDD vs MDD\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comparez les performances des solveurs BDD et MDD sur des puzzles de differentes\n",
     "difficultes en mesurant le temps et la taille des structures.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Mesurez la taille (nombre de noeuds) et le temps de construction et de resolution.\n"
    ]
   },
@@ -2999,7 +2999,7 @@
     "\n",
     "## Exercice : Solveur BDD avec Propagation de Contraintes\n",
     "\n",
-    "### Objectif\n",
+    "**Objectif :**\n",
     "\n",
     "Implementer un solveur Sudoku qui utilise les MDD pour propager les contraintes avant chaque affectation. Contrairement au solveur de la section 6 qui ne fait que verifier les contraintes, votre solveur devra :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
@@ -310,11 +310,11 @@
    "source": [
     "## Exercice : Compter les candidats possibles par case\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Pour chaque cellule vide, comptez le nombre de candidats possibles\n",
     "apres propagation des contraintes.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Appliquez la propagation et comptez les valeurs restantes dans le domaine de chaque cellule.\n"
    ]
   },
@@ -1554,11 +1554,11 @@
    "source": [
     "## Exercice : Verifier la reproductibilite du solver\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Lancez le solver probabiliste plusieurs fois sur le meme puzzle et\n",
     "verifiez si les resultats sont reproductibles.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Fixez le seed aleatoire et comparez les resultats sur 10 executions.\n"
    ]
   },
@@ -3195,11 +3195,11 @@
    "source": [
     "## Exercice : Comparer les trois solveurs Infer.NET\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comparez les performances du solver naive, robust et iteratif sur\n",
     "des puzzles de differentes difficultes.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Mesurez le taux de succes et le temps de resolution pour chaque solver.\n"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
@@ -497,11 +497,11 @@
    "source": [
     "## Exercice : Construire la matrice de couverture pour un mini-Sudoku\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Construisez manuellement la matrice de couverture exacte pour un Sudoku 4x4\n",
     "avec DlxLib.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Identifiez les 4 types de contraintes et creez les lignes de la matrice\n",
     "pour chaque assignation (cellule, valeur) possible.\n"
    ]
@@ -971,11 +971,11 @@
    "source": [
     "## Exercice : Mesurer le nombre de noeuds explores\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Ajoutez un compteur de noeuds dans la classe DlxCustomized pour mesurer\n",
     "le nombre de noeuds explores pendant la recherche.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Incremente le compteur a chaque appel recursif de la methode de recherche.\n"
    ]
   },
@@ -1127,11 +1127,11 @@
    "source": [
     "## Exercice : Comparer DLX avec le backtracking classique\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comparez les performances de Dancing Links (DLXLib + custom) avec le\n",
     "solveur backtracking classique sur des puzzles de differentes difficultes.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Mesurez le temps et le nombre d'operations pour chaque solveur.\n"
    ]
   },
@@ -1335,7 +1335,7 @@
     "2. Definissez les lignes (placements possibles)\n",
     "3. Comptez le nombre de solutions\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Pour le probleme des N-Reines :\n",
     "- **Colonnes obligatoires** : chaque colonne du plateau doit avoir exactement une reine (N contraintes)\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
@@ -307,11 +307,11 @@
    "source": [
     "## Exercice : Implementer une fonction de fitness ponderee\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Creez une fonction de fitness qui pondere differemment les conflits\n",
     "de lignes, colonnes et blocs (par exemple, penaliser plus les conflits de lignes).\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Au lieu de simplement compter le nombre total de conflits, multipliez chaque\n",
     "type par un coefficient et sommez.\n"
    ]
@@ -460,11 +460,11 @@
    "source": [
     "## Exercice : Creer un operateur de mutation swap intra-ligne\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez un operateur de mutation qui echange deux genes dans la meme ligne\n",
     "du chromosome.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Choisissez une ligne aleatoire, puis deux positions dans cette ligne, et echangez-les.\n"
    ]
   },
@@ -691,7 +691,7 @@
     "2. Generez uniquement les permutations compatibles avec les valeurs deja presentes\n",
     "3. Testez votre chromosome sur un puzzle facile et comparez avec `SudokuPermutationsChromosome`\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Un bloc 3x3 peut avoir de 0 a 9 valeurs fixes. Si un bloc a k valeurs fixes, il existe (9-k)! permutations des valeurs manquantes. Cette representation garantit les contraintes de blocs (au lieu des lignes), laissant les contraintes de lignes et colonnes a la fonction de fitness."
    ]
@@ -820,11 +820,11 @@
    "source": [
     "## Exercice : Comparer les approches par cellules vs permutations\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comparez les performances des deux types de chromosomes\n",
     "(cellules vs permutations de lignes) sur les memes puzzles.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Lancez les deux solveurs avec les memes parametres et comparez les taux de succes.\n"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -1102,11 +1102,11 @@
    "source": [
     "## Exercice : Calculer l'energie d'une grille partielle\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez une variante de la fonction d'energie qui ne compte les conflits\n",
     "que dans les lignes/colonnes/blocs contenant au moins une valeur non nulle.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Parcourez chaque unite et ignorez celles ou toutes les valeurs sont a 0.\n"
    ]
   },
@@ -1428,11 +1428,11 @@
    "source": [
     "## Exercice : Generer un voisin par echange dans un bloc\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez un operateur de voisinage qui echange deux valeurs non fixees\n",
     "dans le meme bloc 3x3 au lieu de la meme ligne.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc.\n"
    ]
   },
@@ -2273,11 +2273,11 @@
    "source": [
     "## Exercice : Comparer les schemas de refroidissement\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comparez le schema de refroidissement lineaire et exponentiel.\n",
     "Mesurez le taux de succes et le temps moyen pour chaque schema.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Pour le schema exponentiel: T = T_init * alpha^step.\n"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -1129,11 +1129,11 @@
    "source": [
     "## Exercice : Mesurer l'impact du nombre de particules\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Testez le solveur PSO avec differentes tailles d'essaim (10, 50, 100, 200)\n",
     "et analysez l'impact sur le taux de succes et le temps de resolution.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Pour chaque taille, lancez le solveur sur les memes puzzles et comparez les resultats.\n"
    ]
   },
@@ -2069,11 +2069,11 @@
    "source": [
     "## Exercice : Analyser la convergence du PSO\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Tracez la courbe de convergence (erreur minimale dans l'essaim en fonction\n",
     "des iterations) pour un puzzle facile et un puzzle difficile.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Enregistrez la meilleure fitness a chaque iteration et affichez avec un graphique.\n"
    ]
   },
@@ -2159,7 +2159,7 @@
     "- Etre plus fiable sur les puzzles difficiles\n",
     "- Potentiellement etre plus lent par epoch mais converger plus vite\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Pour `LocalSearchImprove`, essayez tous les echanges possibles dans chaque bloc (pas de melange aleatoire) et gardez celui qui reduit `error`. C'est une variante de la **recherche par descente de gradient locale** adaptee au Sudoku."
    ]
@@ -2253,7 +2253,7 @@
    "source": [
     "## Exercice : Optimiser les parametres avec une grille de recherche\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez une recherche en grille (grid search) pour trouver la meilleure\n",
     "configuration du solveur.\n",
     "\n",
@@ -2261,7 +2261,7 @@
     "> - **(a)** Optimisez les parametres reellement disponibles : `NumOrganisms`, `WorkerRatio`, `MutationRate`, `MaxAge`, `MaxEpochs`.\n",
     "> - **(b)** Implementez d'abord un vrai PSO a velocite (champ de velocite, `pBest`, coefficients `w`/`c1`/`c2`), puis optimisez ces coefficients. La signature du stub ci-dessous correspond a cette variante.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Testez systematiquement des combinaisons de parametres sur un ensemble de puzzles."
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -436,11 +436,11 @@
    "source": [
     "## Exercice : Calculer le domaine initial d'une cellule\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez une fonction qui retourne l'ensemble des valeurs possibles pour\n",
     "une cellule donnee en tenant compte des contraintes de ligne, colonne et bloc.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Parcourez la ligne, colonne et bloc de la cellule et excluez les valeurs deja presentees.\n"
    ]
   },
@@ -1126,11 +1126,11 @@
    "source": [
     "## Exercice : Pre-processing par arc-consistance\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez un pre-traitement qui applique AC-3 avant de lancer le solveur\n",
     "et mesure l'impact sur le temps de resolution.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Appliquez AC-3 pour reduire les domaines, puis lancez le backtracking sur les domaines reduits.\n"
    ]
   },
@@ -1678,11 +1678,11 @@
    "source": [
     "## Exercice : Comparer Forward Checking et MAC sur des puzzles difficiles\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comparez les performances de Forward Checking et MAC (Maintaining Arc Consistency)\n",
     "sur au moins 5 puzzles difficiles.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Mesurez le nombre d'appels recursifs et le temps pour chaque methode.\n"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
@@ -288,11 +288,11 @@
    "source": [
     "## Exercice : Compter les singletons caches (Hidden Singles)\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez la detection des Hidden Singles : une valeur qui ne peut aller\n",
     "que dans une seule cellule d'une unite (ligne/colonne/bloc).\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Pour chaque valeur 1-9, comptez dans combien de cellules d'une unite elle peut apparaitre.\n",
     "Si exactement 1, c'est un Hidden Single.\n"
    ]
@@ -764,12 +764,12 @@
    "source": [
     "## Exercice : Detection de paires nues (Naked Pairs)\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez la detection des Naked Pairs : quand deux cellules d'une meme unite\n",
     "ont exactement les memes deux candidats, ces valeurs peuvent etre eliminees\n",
     "des autres cellules de l'unite.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Parcourez chaque unite et cherchez des paires de cellules avec les memes 2 candidats.\n"
    ]
   },
@@ -1120,11 +1120,11 @@
    "source": [
     "## Exercice : Analyser l'impact de la propagation\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Desactivez l'etape de propagation dans le solveur Norvig et comparez\n",
     "les performances avec et sans propagation.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Modifiez le solveur pour court-circuiter l'etape eliminate et ne garder que assign.\n"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
@@ -507,11 +507,11 @@
    "source": [
     "## Exercice : Compter les naked singles par difficulte\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Comptez combien de naked singles peuvent etre trouves dans des puzzles\n",
     "de differentes difficultes.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Utilisez FindNakedSingles sur plusieurs puzzles et calculez la moyenne par difficulte.\n"
    ]
   },
@@ -1139,13 +1139,13 @@
    "source": [
     "## Exercice : Implementer la technique Hidden Pair\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez la detection des Hidden Pairs : quand deux valeurs n'apparaissent\n",
     "que dans deux cellules d'une meme unite, eliminez les autres candidats de ces cellules.\n",
     "\n",
-    "# Etape 1\n",
+    "**Etape 1 :**\n",
     "Parcourez chaque unite et identifiez les valeurs qui n'apparaissent que 2 fois.\n",
-    "# Etape 2\n",
+    "**Etape 2 :**\n",
     "Verifiez si ces 2 valeurs partagent les memes 2 cellules.\n"
    ]
   },
@@ -2075,11 +2075,11 @@
    "source": [
     "## Exercice : Mesurer le taux de resolution par strategies humaines\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Determinez quel pourcentage de puzzles peut etre resolu uniquement par\n",
     "strategies humaines (sans backtracking), par difficulte.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Utilisez HumanSolver et comptez les puzzles resolus sans atteindre le backtracking.\n"
    ]
   },
@@ -2414,7 +2414,7 @@
     "\n",
     "## Exercice : Solveur Hybride avec Techniques Expertes\n",
     "\n",
-    "### Objectif\n",
+    "**Objectif :**\n",
     "\n",
     "Enrichissez le solveur hybride fourni dans le notebook avec des techniques de niveau expert. Le solveur actuel s'arrete au X-Wing. Votre objectif est d'ajouter :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
@@ -443,11 +443,11 @@
    "source": [
     "## Exercice : Compter les contraintes par cellule\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Pour chaque cellule de la grille Sudoku, comptez le nombre de cellules contraintes\n",
     "(cellules dans la meme ligne, colonne ou bloc).\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Utilisez le graphe construit et comptez le degre de chaque noeud.\n"
    ]
   },
@@ -665,11 +665,11 @@
    "source": [
     "## Exercice : Implementer l'heuristique de degre (Degree Heuristic)\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez l'heuristique de degre qui, en cas d'egalite entre plusieurs variables\n",
     "MRV, choisit celle qui a le plus de contraintes avec les variables non assignees.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Triez les variables candidats par nombre de voisins non assignes en cas d'egalite MRV.\n"
    ]
   },
@@ -1297,11 +1297,11 @@
    "source": [
     "## Exercice : Verifier qu'une coloration est valide\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif :**\n",
     "Implementez une fonction qui verifie si une grille completement remplie\n",
     "est une solution valide du Sudoku en utilisant le graphe.\n",
     "\n",
-    "# Indice\n",
+    "**Indice :**\n",
     "Pour chaque arete du graphe, verifiez que les deux noeuds ont des couleurs differentes.\n"
    ]
   },


### PR DESCRIPTION
## Scope (typo-only, #3966/#3968)

Mise-en-forme de la famille **Sudoku-CSharp** (16 notebooks). On change le **niveau** des headings, jamais le **contenu** pedagogique.

Les cellules d'exercice ecrivaient leurs asides (`# Objectif` / `# Indice` / `# Etape N`, plus quelques `### Indice` / `### Objectif`) en **headings** — affiches dans la plus grande police alors qu'ils doivent etre discrets (directive `notebook-formatting.md` 1.2 : un aside n'est jamais un heading). Chacun devient **gras inline** `**Label :**`. Cela resout aussi le **MULTI-H1** (chaque `# Objectif`/`# Indice` etait un H1 concurrent du titre).

## Diff

- **103 asides demotes** sur 16 notebooks (**103 ins / 103 del**, equilibre).
- **Zero churn** de code / outputs / `execution_count` / `cell_type` (markdown source uniquement ; C.2 respecte, pas de re-exec, pas de scrub d'output).
- **Bonus** : `### Indices` pluriel (Sudoku-0) demote aussi -> `**Indices :**`. Le scanner `scan_md_hierarchy.py` rate le pluriel via `\b` (signale a ai-01).
- **Exclus comme faux positifs** (vraies sections, conservees) : `## Objectifs d'apprentissage` (section, pas un label), `### Prochaines etapes` (section), `## Note sur l'approche` (sous-section d'intro Sudoku-14 cell 0).

## Verification visuelle (nbconvert + Playwright `getComputedStyle`)

| Notebook | H1 avant -> apres | Asides |
|----------|-------------------|--------|
| Sudoku-1 | 8 -> 2 | 6 H1 (25.998px) + 2 H3 (18px) -> 7x gras 14px |
| Sudoku-8 | 9 -> 2 | incl. `Etape 1`/`Etape 2` -> gras 14px |

Sections reelles (`## Objectifs d'apprentissage` 21.994px, `### Prochaines etapes`) intactes. Le 2e H1 residuel au rendu = sortie markdown de cell 1 (`#!import` du titre Sudoku-0), **hors-scope typo** et non flague par le scanner source-level.

See #3968 See #3966