### PR TITLE
feat(mgs): MGS-10 CenterBias BBPSO 7th optimizer (Kennedy 2003) + submodule bump c8bbd99

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-10-CenterBias.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-10-CenterBias.ipynb
@@ -5,10 +5,10 @@
    "id": "mgs10-c00",
    "metadata": {
     "papermill": {
-     "duration": 0.002673,
-     "end_time": "2026-06-23T02:14:15.647416+00:00",
+     "duration": 0.003011,
+     "end_time": "2026-06-23T07:08:13.270208+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:15.644743+00:00",
+     "start_time": "2026-06-23T07:08:13.267197+00:00",
      "status": "completed"
     },
     "tags": []
@@ -37,16 +37,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:14:15.661273Z",
-     "iopub.status.busy": "2026-06-23T02:14:15.656001Z",
-     "iopub.status.idle": "2026-06-23T02:14:17.866815Z",
-     "shell.execute_reply": "2026-06-23T02:14:17.861195Z"
+     "iopub.execute_input": "2026-06-23T07:08:13.285518Z",
+     "iopub.status.busy": "2026-06-23T07:08:13.279663Z",
+     "iopub.status.idle": "2026-06-23T07:08:15.227059Z",
+     "shell.execute_reply": "2026-06-23T07:08:15.217242Z"
     },
     "papermill": {
-     "duration": 2.216536,
-     "end_time": "2026-06-23T02:14:17.867520+00:00",
+     "duration": 1.953044,
+     "end_time": "2026-06-23T07:08:15.227271+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:15.650984+00:00",
+     "start_time": "2026-06-23T07:08:13.274227+00:00",
      "status": "completed"
     },
     "tags": []
@@ -102,12 +102,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%16:2048/\",\"http://172.30.16.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:a911:67ab:50dc:4e69:2048/\",\"http://2a01:e0a:9d4:f320:ad1a:8e3f:5f41:4d97:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%18:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::5aa8:3689:ec4d:c9e6%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%16:2048/\",\"http://172.30.16.1:2048/\",\"http://fe80::5aa8:3689:ec4d:c9e6%44:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:a911:67ab:50dc:4e69:2048/\",\"http://2a01:e0a:9d4:f320:ad1a:8e3f:5f41:4d97:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%18:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '656432.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '709776.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -201,6 +201,13 @@
      "text": [
       "  ForensicBasedInvestigation : ForensicBasedInvestigation\r\n"
      ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  BareBonesParticleSwarm    : BareBonesParticleSwarm\r\n"
+     ]
     }
    ],
    "source": [
@@ -222,7 +229,8 @@
     "Console.WriteLine(\"  ShiftedFitness             : \" + typeof(ShiftedFitness).Name);\n",
     "Console.WriteLine(\"  RandomSearchOptimizer      : \" + typeof(RandomSearchOptimizer).Name);\n",
     "Console.WriteLine(\"  KnownFunctionsBounds       : \" + typeof(KnownFunctionsBounds).Name);\n",
-    "Console.WriteLine(\"  ForensicBasedInvestigation : \" + typeof(ForensicBasedInvestigation).Name);\n"
+    "Console.WriteLine(\"  ForensicBasedInvestigation : \" + typeof(ForensicBasedInvestigation).Name);\n",
+    "Console.WriteLine(\"  BareBonesParticleSwarm    : \" + typeof(BareBonesParticleSwarm).Name);\n"
    ]
   },
   {
@@ -230,10 +238,10 @@
    "id": "mgs10-c02",
    "metadata": {
     "papermill": {
-     "duration": 0.003041,
-     "end_time": "2026-06-23T02:14:17.874115+00:00",
+     "duration": 0.00462,
+     "end_time": "2026-06-23T07:08:15.236478+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:17.871074+00:00",
+     "start_time": "2026-06-23T07:08:15.231858+00:00",
      "status": "completed"
     },
     "tags": []
@@ -267,16 +275,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:14:17.881917Z",
-     "iopub.status.busy": "2026-06-23T02:14:17.881691Z",
-     "iopub.status.idle": "2026-06-23T02:14:18.498041Z",
-     "shell.execute_reply": "2026-06-23T02:14:18.497788Z"
+     "iopub.execute_input": "2026-06-23T07:08:15.247229Z",
+     "iopub.status.busy": "2026-06-23T07:08:15.246738Z",
+     "iopub.status.idle": "2026-06-23T07:08:15.749014Z",
+     "shell.execute_reply": "2026-06-23T07:08:15.748841Z"
     },
     "papermill": {
-     "duration": 0.620856,
-     "end_time": "2026-06-23T02:14:18.498128+00:00",
+     "duration": 0.507928,
+     "end_time": "2026-06-23T07:08:15.749097+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:17.877272+00:00",
+     "start_time": "2026-06-23T07:08:15.241169+00:00",
      "status": "completed"
     },
     "tags": []
@@ -325,10 +333,10 @@
    "id": "mgs10-c04",
    "metadata": {
     "papermill": {
-     "duration": 0.003337,
-     "end_time": "2026-06-23T02:14:18.504971+00:00",
+     "duration": 0.002979,
+     "end_time": "2026-06-23T07:08:15.755608+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:18.501634+00:00",
+     "start_time": "2026-06-23T07:08:15.752629+00:00",
      "status": "completed"
     },
     "tags": []
@@ -350,16 +358,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:14:18.512663Z",
-     "iopub.status.busy": "2026-06-23T02:14:18.512412Z",
-     "iopub.status.idle": "2026-06-23T02:14:18.783695Z",
-     "shell.execute_reply": "2026-06-23T02:14:18.783567Z"
+     "iopub.execute_input": "2026-06-23T07:08:15.762540Z",
+     "iopub.status.busy": "2026-06-23T07:08:15.762336Z",
+     "iopub.status.idle": "2026-06-23T07:08:15.956788Z",
+     "shell.execute_reply": "2026-06-23T07:08:15.956644Z"
     },
     "papermill": {
-     "duration": 0.275696,
-     "end_time": "2026-06-23T02:14:18.783759+00:00",
+     "duration": 0.198483,
+     "end_time": "2026-06-23T07:08:15.956897+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:18.508063+00:00",
+     "start_time": "2026-06-23T07:08:15.758414+00:00",
      "status": "completed"
     },
     "tags": []
@@ -369,7 +377,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Smoke GA/Sphere centree     : objectif = 0,006299  (proche de 0 = OK)\r\n"
+      "Smoke GA/Sphere centree     : objectif = 0,003523  (proche de 0 = OK)\r\n"
      ]
     },
     {
@@ -383,7 +391,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Delegues Optimizer prets : GA, WOA, EO, FBI, DE, Random(control).\r\n"
+      "Delegues Optimizer prets : GA, WOA, EO, FBI, DE, BBPSO, Random(control).\r\n"
      ]
     }
    ],
@@ -397,6 +405,7 @@
     "IMetaHeuristic BuildEO(int g)  => MetaHeuristicsService.CreateMetaHeuristicByName(\"EquilibriumOptimizer\",       maxGenerations: g, populationSize: PopSize);\n",
     "IMetaHeuristic BuildFBI(int g) => MetaHeuristicsService.CreateMetaHeuristicByName(\"ForensicBasedInvestigation\", maxGenerations: g, populationSize: PopSize);\n",
     "IMetaHeuristic BuildDE(int g) => MetaHeuristicsService.CreateMetaHeuristicByName(\"DifferentialEvolution\",       maxGenerations: g, populationSize: PopSize);\n",
+    "IMetaHeuristic BuildBBPSO(int g) => MetaHeuristicsService.CreateMetaHeuristicByName(\"BareBonesParticleSwarm\",   maxGenerations: g, populationSize: PopSize);\n",
     "\n",
     "// Emballe n'importe quelle construction d'IMetaHeuristic dans le contrat Optimizer du banc.\n",
     "Optimizer MakeOptimizer(Func<int, IMetaHeuristic> buildMh)\n",
@@ -430,7 +439,7 @@
     "Console.WriteLine(\"Smoke GA/Sphere centree     : objectif = \" + (-centeredSphere).ToString(\"G4\") + \"  (proche de 0 = OK)\");\n",
     "double rsSphere = RandomOptimizer(new OptimizerRequest(new SphereFitness(), KnownFunctionsBounds.For(typeof(SphereFitness)), 5, NFE));\n",
     "Console.WriteLine(\"Smoke Random/Sphere centree : objectif = \" + (-rsSphere).ToString(\"G4\") + \"  (moins bon, normal pour NFE=\" + NFE + \")\");\n",
-    "Console.WriteLine(\"Delegues Optimizer prets : GA, WOA, EO, FBI, DE, Random(control).\");\n"
+    "Console.WriteLine(\"Delegues Optimizer prets : GA, WOA, EO, FBI, DE, BBPSO, Random(control).\");\n"
    ]
   },
   {
@@ -438,10 +447,10 @@
    "id": "mgs10-c06",
    "metadata": {
     "papermill": {
-     "duration": 0.002784,
-     "end_time": "2026-06-23T02:14:18.789488+00:00",
+     "duration": 0.002494,
+     "end_time": "2026-06-23T07:08:15.962580+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:18.786704+00:00",
+     "start_time": "2026-06-23T07:08:15.960086+00:00",
      "status": "completed"
     },
     "tags": []
@@ -461,16 +470,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:14:18.795755Z",
-     "iopub.status.busy": "2026-06-23T02:14:18.795588Z",
-     "iopub.status.idle": "2026-06-23T02:14:21.613147Z",
-     "shell.execute_reply": "2026-06-23T02:14:21.612934Z"
+     "iopub.execute_input": "2026-06-23T07:08:15.968786Z",
+     "iopub.status.busy": "2026-06-23T07:08:15.968600Z",
+     "iopub.status.idle": "2026-06-23T07:08:18.245117Z",
+     "shell.execute_reply": "2026-06-23T07:08:18.244889Z"
     },
     "papermill": {
-     "duration": 2.821107,
-     "end_time": "2026-06-23T02:14:21.613272+00:00",
+     "duration": 2.280116,
+     "end_time": "2026-06-23T07:08:18.245216+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:18.792165+00:00",
+     "start_time": "2026-06-23T07:08:15.965100+00:00",
      "status": "completed"
     },
     "tags": []
@@ -501,42 +510,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GA(uniform)      SphereFitness    dim= 5  centered=    0,006173  shifted=    0,003176  delta=   -0,002997\r\n"
+      "GA(uniform)      SphereFitness    dim= 5  centered=    0,003150  shifted=    0,014731  delta=    0,011582\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GA(uniform)      RastriginFitness dim= 5  centered=    0,348690  shifted=    1,076063  delta=    0,727373\r\n"
+      "GA(uniform)      RastriginFitness dim= 5  centered=    1,397242  shifted=    1,982357  delta=    0,585115\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GA(uniform)      AckleyFitness    dim= 5  centered=    2,403451  shifted=    1,438027  delta=   -0,965424\r\n"
+      "GA(uniform)      AckleyFitness    dim= 5  centered=    2,866273  shifted=    2,397570  delta=   -0,468703\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WOA              SphereFitness    dim= 5  centered=    0,000000  shifted=    0,150016  delta=    0,150016\r\n"
+      "WOA              SphereFitness    dim= 5  centered=    0,000000  shifted=    0,001505  delta=    0,001505\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WOA              RastriginFitness dim= 5  centered=   11,175245  shifted=   12,201088  delta=    1,025844\r\n"
+      "WOA              RastriginFitness dim= 5  centered=    0,000000  shifted=    8,676056  delta=    8,676055\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WOA              AckleyFitness    dim= 5  centered=    0,000013  shifted=    4,292119  delta=    4,292106\r\n"
+      "WOA              AckleyFitness    dim= 5  centered=    0,000023  shifted=    2,854769  delta=    2,854746\r\n"
      ]
     },
     {
@@ -571,35 +580,56 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FBI              RastriginFitness dim= 5  centered=    0,000000  shifted=    1,990027  delta=    1,990027\r\n"
+      "FBI              RastriginFitness dim= 5  centered=    0,000000  shifted=    3,980668  delta=    3,980668\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FBI              AckleyFitness    dim= 5  centered=    0,000000  shifted=    0,000081  delta=    0,000081\r\n"
+      "FBI              AckleyFitness    dim= 5  centered=    0,000000  shifted=    0,000702  delta=    0,000702\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DE               SphereFitness    dim= 5  centered=    0,000000  shifted=    0,000000  delta=   -0,000000\r\n"
+      "DE               SphereFitness    dim= 5  centered=    0,000000  shifted=    0,000000  delta=    0,000000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DE               RastriginFitness dim= 5  centered=    1,001091  shifted=    0,094448  delta=   -0,906644\r\n"
+      "DE               RastriginFitness dim= 5  centered=    1,094348  shifted=    2,205498  delta=    1,111151\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DE               AckleyFitness    dim= 5  centered=    0,000003  shifted=    0,000001  delta=   -0,000001\r\n"
+      "DE               AckleyFitness    dim= 5  centered=    0,000002  shifted=    0,000002  delta=   -0,000001\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BBPSO            SphereFitness    dim= 5  centered=    0,000000  shifted=    0,000000  delta=   -0,000000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BBPSO            RastriginFitness dim= 5  centered=   20,894034  shifted=    3,979836  delta=  -16,914198\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BBPSO            AckleyFitness    dim= 5  centered=    0,000000  shifted=    2,814350  delta=    2,814350\r\n"
      ]
     },
     {
@@ -613,7 +643,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Suite terminee : 6 optimiseurs x 3 fonctions, chacune en centre + deplace ---\r\n"
+      "--- Suite terminee : 7 optimiseurs x 3 fonctions, chacune en centre + deplace ---\r\n"
      ]
     }
    ],
@@ -638,6 +668,7 @@
     "    (\"EO\",              MakeOptimizer(BuildEO)),\n",
     "    (\"FBI\",             MakeOptimizer(BuildFBI)),\n",
     "    (\"DE\",              MakeOptimizer(BuildDE)),\n",
+    "    (\"BBPSO\",          MakeOptimizer(BuildBBPSO)),\n",
     "};\n",
     "\n",
     "var rows = new List<(string Opt, CenterBiasResult R)>();\n",
@@ -651,7 +682,7 @@
     "    }\n",
     "}\n",
     "Console.WriteLine();\n",
-    "Console.WriteLine(\"--- Suite terminee : 6 optimiseurs x 3 fonctions, chacune en centre + deplace ---\");\n"
+    "Console.WriteLine(\"--- Suite terminee : 7 optimiseurs x 3 fonctions, chacune en centre + deplace ---\");\n"
    ]
   },
   {
@@ -663,16 +694,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:14:21.625248Z",
-     "iopub.status.busy": "2026-06-23T02:14:21.624928Z",
-     "iopub.status.idle": "2026-06-23T02:14:21.984917Z",
-     "shell.execute_reply": "2026-06-23T02:14:21.985040Z"
+     "iopub.execute_input": "2026-06-23T07:08:18.259331Z",
+     "iopub.status.busy": "2026-06-23T07:08:18.259073Z",
+     "iopub.status.idle": "2026-06-23T07:08:18.714358Z",
+     "shell.execute_reply": "2026-06-23T07:08:18.714518Z"
     },
     "papermill": {
-     "duration": 0.367049,
-     "end_time": "2026-06-23T02:14:21.985120+00:00",
+     "duration": 0.464039,
+     "end_time": "2026-06-23T07:08:18.714633+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:21.618071+00:00",
+     "start_time": "2026-06-23T07:08:18.250594+00:00",
      "status": "completed"
     },
     "tags": []
@@ -717,14 +748,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GA(uniform)               -0,003           0,727          -0,965    -0,080\r\n"
+      "GA(uniform)                0,012           0,585          -0,469     0,043\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WOA                        0,150           1,026           4,292     1,823\r\n"
+      "WOA                        0,002           8,676           2,855     3,844\r\n"
      ]
     },
     {
@@ -738,14 +769,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FBI                        0,000           1,990           0,000     0,663\r\n"
+      "FBI                        0,000           3,981           0,001     1,327\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DE                        -0,000          -0,907          -0,000    -0,302\r\n"
+      "DE                         0,000           1,111          -0,000     0,370\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BBPSO                     -0,000         -16,914           2,814    -4,700\r\n"
      ]
     },
     {
@@ -773,42 +811,49 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Random(control)  |########################################| delta_moyen = 2,753\r\n"
+      "  Random(control)  |#############################           | delta_moyen = 2,753\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  GA(uniform)      |                                        | delta_moyen = -0,080\r\n"
+      "  GA(uniform)      |                                        | delta_moyen = 0,043\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  WOA              |##########################              | delta_moyen = 1,823\r\n"
+      "  WOA              |########################################| delta_moyen = 3,844\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  EO               |##############                          | delta_moyen = 0,995\r\n"
+      "  EO               |##########                              | delta_moyen = 0,995\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  FBI              |##########                              | delta_moyen = 0,663\r\n"
+      "  FBI              |##############                          | delta_moyen = 1,327\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  DE               |                                        | delta_moyen = -0,302\r\n"
+      "  DE               |####                                    | delta_moyen = 0,370\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  BBPSO            |                                        | delta_moyen = -4,700\r\n"
      ]
     },
     {
@@ -860,10 +905,10 @@
    "id": "mgs10-c09",
    "metadata": {
     "papermill": {
-     "duration": 0.00387,
-     "end_time": "2026-06-23T02:14:21.993563+00:00",
+     "duration": 0.005526,
+     "end_time": "2026-06-23T07:08:18.726183+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:21.989693+00:00",
+     "start_time": "2026-06-23T07:08:18.720657+00:00",
      "status": "completed"
     },
     "tags": []
@@ -889,10 +934,10 @@
    "id": "mgs10-c10",
    "metadata": {
     "papermill": {
-     "duration": 0.003893,
-     "end_time": "2026-06-23T02:14:22.001541+00:00",
+     "duration": 0.005609,
+     "end_time": "2026-06-23T07:08:18.738179+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:21.997648+00:00",
+     "start_time": "2026-06-23T07:08:18.732570+00:00",
      "status": "completed"
     },
     "tags": []
@@ -912,10 +957,10 @@
    "id": "mgs10-c11",
    "metadata": {
     "papermill": {
-     "duration": 0.00442,
-     "end_time": "2026-06-23T02:14:22.009510+00:00",
+     "duration": 0.00562,
+     "end_time": "2026-06-23T07:08:18.749472+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:22.005090+00:00",
+     "start_time": "2026-06-23T07:08:18.743852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -931,10 +976,10 @@
    "id": "mgs10-c12",
    "metadata": {
     "papermill": {
-     "duration": 0.004135,
-     "end_time": "2026-06-23T02:14:22.017635+00:00",
+     "duration": 0.005581,
+     "end_time": "2026-06-23T07:08:18.761054+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:22.013500+00:00",
+     "start_time": "2026-06-23T07:08:18.755473+00:00",
      "status": "completed"
     },
     "tags": []
@@ -954,16 +999,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:14:22.026672Z",
-     "iopub.status.busy": "2026-06-23T02:14:22.026461Z",
-     "iopub.status.idle": "2026-06-23T02:14:22.128734Z",
-     "shell.execute_reply": "2026-06-23T02:14:22.128549Z"
+     "iopub.execute_input": "2026-06-23T07:08:18.773797Z",
+     "iopub.status.busy": "2026-06-23T07:08:18.773511Z",
+     "iopub.status.idle": "2026-06-23T07:08:18.899910Z",
+     "shell.execute_reply": "2026-06-23T07:08:18.899709Z"
     },
     "papermill": {
-     "duration": 0.10725,
-     "end_time": "2026-06-23T02:14:22.128817+00:00",
+     "duration": 0.133544,
+     "end_time": "2026-06-23T07:08:18.900006+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:22.021567+00:00",
+     "start_time": "2026-06-23T07:08:18.766462+00:00",
      "status": "completed"
     },
     "tags": []
@@ -989,10 +1034,10 @@
    "id": "mgs10-c14",
    "metadata": {
     "papermill": {
-     "duration": 0.004357,
-     "end_time": "2026-06-23T02:14:22.137845+00:00",
+     "duration": 0.005538,
+     "end_time": "2026-06-23T07:08:18.911497+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:22.133488+00:00",
+     "start_time": "2026-06-23T07:08:18.905959+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1012,16 +1057,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:14:22.148225Z",
-     "iopub.status.busy": "2026-06-23T02:14:22.147972Z",
-     "iopub.status.idle": "2026-06-23T02:14:22.184134Z",
-     "shell.execute_reply": "2026-06-23T02:14:22.183993Z"
+     "iopub.execute_input": "2026-06-23T07:08:18.925086Z",
+     "iopub.status.busy": "2026-06-23T07:08:18.924833Z",
+     "iopub.status.idle": "2026-06-23T07:08:18.967076Z",
+     "shell.execute_reply": "2026-06-23T07:08:18.966837Z"
     },
     "papermill": {
-     "duration": 0.041933,
-     "end_time": "2026-06-23T02:14:22.184201+00:00",
+     "duration": 0.05043,
+     "end_time": "2026-06-23T07:08:18.967171+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:22.142268+00:00",
+     "start_time": "2026-06-23T07:08:18.916741+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1046,10 +1091,10 @@
    "id": "mgs10-c16",
    "metadata": {
     "papermill": {
-     "duration": 0.003701,
-     "end_time": "2026-06-23T02:14:22.193081+00:00",
+     "duration": 0.005757,
+     "end_time": "2026-06-23T07:08:18.978699+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:22.189380+00:00",
+     "start_time": "2026-06-23T07:08:18.972942+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1069,16 +1114,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:14:22.201476Z",
-     "iopub.status.busy": "2026-06-23T02:14:22.201286Z",
-     "iopub.status.idle": "2026-06-23T02:14:22.261942Z",
-     "shell.execute_reply": "2026-06-23T02:14:22.261760Z"
+     "iopub.execute_input": "2026-06-23T07:08:18.993357Z",
+     "iopub.status.busy": "2026-06-23T07:08:18.993085Z",
+     "iopub.status.idle": "2026-06-23T07:08:19.087433Z",
+     "shell.execute_reply": "2026-06-23T07:08:19.087242Z"
     },
     "papermill": {
-     "duration": 0.065398,
-     "end_time": "2026-06-23T02:14:22.262022+00:00",
+     "duration": 0.102867,
+     "end_time": "2026-06-23T07:08:19.087555+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:22.196624+00:00",
+     "start_time": "2026-06-23T07:08:18.984688+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1104,10 +1149,10 @@
    "id": "mgs10-c18",
    "metadata": {
     "papermill": {
-     "duration": 0.004161,
-     "end_time": "2026-06-23T02:14:22.271174+00:00",
+     "duration": 0.005509,
+     "end_time": "2026-06-23T07:08:19.098761+00:00",
      "exception": false,
-     "start_time": "2026-06-23T02:14:22.267013+00:00",
+     "start_time": "2026-06-23T07:08:19.093252+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1141,14 +1186,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.58199,
-   "end_time": "2026-06-23T02:14:22.408397+00:00",
+   "duration": 8.850848,
+   "end_time": "2026-06-23T07:08:19.346054+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MGS-10-CenterBias.ipynb",
-   "output_path": "MGS-10-CenterBias_output.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-10-CenterBias.ipynb",
+   "output_path": "MGS-10-CenterBias_out.ipynb",
    "parameters": {},
-   "start_time": "2026-06-23T02:14:11.826407+00:00",
+   "start_time": "2026-06-23T07:08:10.495206+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Wires the **BareBonesParticleSwarm** compound (Kennedy 2003, delivered on the fork as PR #32 `c8bbd99`) into the MGS-10 centered-vs-shifted benchmark as the **7th optimizer**, and bumps the `MetaGeneticSharp` submodule `7389d9d` -> `c8bbd99`. This is the CoursIA integration half of the 2-cycle fork-compound rhythm (fork compound cycle N -> CoursIA submodule bump + bench integration cycle N+1).

See #3963 (Prong 1 — compound metaheuristics). Partial contribution to the epic; not closing it.

## Changes

- **Submodule**: `MyIA.AI.Notebooks/Search/MetaGeneticSharp` `7389d9d` (DE) -> `c8bbd99` (BBPSO). Single new commit on the gitlink.
- **MGS-10-CenterBias.ipynb**, source edits in 3 code cells only:
  - **Cell 1** (wiring): smoke-test line confirming `BareBonesParticleSwarm` loads from the rebuilt DLL.
  - **Cell 5** (factory): `BuildBBPSO` delegate via `MetaHeuristicsService.CreateMetaHeuristicByName("BareBonesParticleSwarm", ...)` + updated "Delegues prets" line.
  - **Cell 7** (roster): `("BBPSO", MakeOptimizer(BuildBBPSO))` added to the optimizers tuple; suite-count line 6 -> 7.
  - Cell 8 (synthesis table + bar chart) is dynamic -- auto-includes BBPSO.

## Validation (H.1 / C.2 / #3962)

- **Real execution**: `papermill .net-csharp`, **8/8 code cells, 0 errors**, `execution_count` 1..8. Log + `_out.ipynb` auditable.
- **#3962 (no output scrubbing)**: only `metadata.papermill.output_path` normalized to basename. Every committed output is the real kernel output. (The pre-existing `CS9236` lambda-compilation hint in cell 8 stderr is preserved -- it is a benign compiler info, already present at HEAD, not an error, and not scrubbed.)
- **Catalogue**: `COURSE_CATALOG.generated.{json,md}` byte-identical to `origin/main` (catalog owned by automation).
- **Scope (C.3)**: source changes only in cells 1/5/7 (legit coherent re-exec); cells 9/10 (interpretation prose) byte-identical to HEAD.

## Measured result (Kudela 2022 protocol, NFE=5000, dim=5, seed=42, shift=2.0)

| Optimizer | Sphere | Rastrigin | Ackley | mean delta |
|---|---|---|---|---|
| Random(control) | 0.205 | 7.936 | 0.117 | 2.753 |
| GA(uniform) | 0.012 | 0.585 | -0.469 | 0.043 |
| WOA | 0.002 | 8.676 | 2.855 | **3.844** (center-bias) |
| EO | 0.000 | 2.985 | 0.000 | 0.995 |
| FBI | 0.000 | 3.981 | 0.001 | 1.327 |
| DE | 0.000 | 1.111 | -0.000 | 0.370 |
| **BBPSO** | -0.000 | **-16.914** | 2.814 | **-4.700** (reverse) |

**Honest finding (Prong-B non-triviality).** BBPSO is the only strongly *reverse*-biased optimizer: on Rastrigin it is far *worse* on the centered case (~21) than the shifted one (~4), delta = -16.9. The bare-bones Gaussian `N((x+gbest)/2, |gbest-x|)` anchored on the global best, on a multimodal landscape whose optimum sits at the symmetric center, lets gbest settle in a suboptimal basin while the large variance keeps the swarm dispersed -- a distinct operator-geometry pathology, not the center-bias shared by the metaphorical compounds (WOA/EO/FBI). This is left as a measured signature in the outputs (table + ASCII bar chart, cell 8); enriching the interpretation prose (cells 9/10) is deferred to a separate doc PR to keep this one atomic.

A positive/negative delta must be read against absolute centered performance: BBPSO's extreme negative delta signs *weakness on the centered case*, not absence of bias -- the same falsifiable reading Kudela (2022) prescribes.

## Build provenance

Fork DLLs rebuilt locally at `c8bbd99` (`dotnet build`, 0 errors, 35 pre-existing CA1416 warnings) and loaded by the notebook's existing `#r "c:/dev/MetaGeneticSharp/..."` wiring (unchanged, standard MGS pattern).

See #3963

🤖 Generated with [Claude Code](https://claude.com/claude-code)