### PR TITLE
docs(search): fix App-10b title hierarchy — single H1, install as H2 (typo-only, #3968)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
@@ -2,27 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "253c0a9e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006563,
-     "end_time": "2026-06-03T05:35:11.589858+00:00",
-     "exception": false,
-     "start_time": "2026-06-03T05:35:11.583295+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "**Navigation** : [Index](../../../README.md) | [<< App-10 Python](App-10-Portfolio.ipynb)\n",
-    "\n",
-    "#**Navigation** : [Index](../../../README.md) | [<< App-10 Python](App-10-Portfolio.ipynb)\n",
-    "\n",
-    "# Installation de GeneticSharp\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "414a6825",
    "metadata": {
     "papermill": {
@@ -55,6 +34,25 @@
     "### Duree estimee : 30 minutes\n",
     "\n",
     "> **Side track** : Voir [App-10 Python](../Hybrid/App-10-Portfolio.ipynb) pour la version PyGAD de ce probleme avec frontiere efficiente de Markowitz."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "253c0a9e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006563,
+     "end_time": "2026-06-03T05:35:11.589858+00:00",
+     "exception": false,
+     "start_time": "2026-06-03T05:35:11.583295+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Navigation** : [Index](../../../README.md) | [<< App-10 Python](App-10-Portfolio.ipynb)\n",
+    "\n",
+    "## Installation de GeneticSharp\n"
    ]
   },
   {


### PR DESCRIPTION
## Scope (typo-only, #3966/#3968 — famille Search-.NET)

`App-10b-Portfolio-CSharp` etait **le seul notebook .NET de la serie Search flague** (MULTI-H1 + H1-DEEP). Les 13 autres notebooks `.net-csharp` de Search sont propres (leurs `## Objectifs d'apprentissage` sont de vraies sections H2, pas des asides).

## Probleme

Le vrai titre `# App-10b : Optimisation de portefeuille...` etait **enterre dans le 2e cell markdown**, derriere un prelude d'installation malforme. Le 1er cell affichait **TROIS H1 concurrents a 25.998px** — le titre n'etait plus visuellement distinct (pathologie #3966 1.1) :

1. une ligne `#**Navigation**` malformee (un `#` colle a une ligne nav en double) — **non comptee par le scanner** (pas d'espace apres `#`) mais **rendue en H1 geante par nbconvert** (parser permissif `#texte`) ;
2. `# Installation de GeneticSharp` (une **section**, pas le titre) ;
3. `# App-10b : ...` (le **vrai titre**, en cell 1).

## Fix (typo + hierarchie, 0 churn code/output)

- Le **cell titre passe en tete** (reorder de 2 cells markdown ; **aucun impact sur l'ordre d'execution du code** — la cellule `#r "nuget: GeneticSharp"` reste en position 2).
- `# Installation de GeneticSharp` -> `## Installation de GeneticSharp` (section), desormais **adjacente a son code nuget**.
- Suppression de la ligne `#**Navigation**` malformee (typo + H1 parasite).
- Nav propre **conservee verbatim** (pas d'arbitrage de chemins relatifs — hors-scope).

## Verification

- `scan_md_hierarchy.py` : **0/1 flag** (MULTI-H1 + H1-DEEP resolus).
- **Visuel** (nbconvert + Playwright `getComputedStyle`) : H1 **3 -> 1** ; titre seul H1 25.998px **en tete** ; Installation H2 21.994px ; hierarchie monotone (H1 titre > H2 Objectifs > H3 Prerequis > H2 Installation > H2 Definition).
- Diff : **19 ins / 21 del**, aucune cellule code / objectifs / prerequis modifiee, aucun `execution_count` / `outputs` touche.

See #3968 See #3966