### PR TITLE
docs(lean): fix sequential nav links in Lean-12/13/15 (#3843 residual)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Lean-12 : Le Theoreme de Sensibilite (Huang 2019)\n",
     "\n",
-    "**Navigation** : [<< Lean-11-TorchLean](Lean-11-TorchLean.ipynb) | [Index](README.md) | [Lean-15 Grothendieck >>](Lean-15-Grothendieck-Tribute.ipynb)\n",
+    "**Navigation** : [<< Lean-11-TorchLean](Lean-11-TorchLean.ipynb) | [Index](README.md) | [Lean-13 Kochen-Specker >>](Lean-13-Kochen-Specker.ipynb)\n",
     "\n",
     "**Kernel** : Python 3 (illustrations) + Lean 4 (WSL) pour la section 5\n",
     "\n",
@@ -1982,7 +1982,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Lean-11-TorchLean](Lean-11-TorchLean.ipynb) | [Index](README.md) | [Lean-15 Grothendieck >>](Lean-15-Grothendieck-Tribute.ipynb)"
+    "**Navigation** : [<< Lean-11-TorchLean](Lean-11-TorchLean.ipynb) | [Index](README.md) | [Lean-13 Kochen-Specker >>](Lean-13-Kochen-Specker.ipynb)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13-Kochen-Specker.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13-Kochen-Specker.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Lean-13 : Le Theoreme de Kochen-Specker (Cabello 18 vecteurs) + Free Will Theorem\n",
     "\n",
-    "**Navigation** : [<< Lean-16b Conway Tribute](Lean-16b-Conway-Game-of-Life-Lean.ipynb) | [Index](README.md)\n",
+    "**Navigation** : [<< Lean-12 Sensitivity](Lean-12-Sensitivity-Theorem.ipynb) | [Index](README.md) | [Lean-14 Finiteness-Derivatives >>](Lean-14-Finiteness-Derivatives.ipynb)\n",
     "\n",
     "**Kernel** : Python 3 (illustrations + verifications combinatoires) + Lean 4 (WSL) pour les sections 6-7\n",
     "\n",
@@ -1575,7 +1575,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Lean-16b Conway Tribute](Lean-16b-Conway-Game-of-Life-Lean.ipynb) | [Index](README.md)"
+    "**Navigation** : [<< Lean-12 Sensitivity](Lean-12-Sensitivity-Theorem.ipynb) | [Index](README.md) | [Lean-14 Finiteness-Derivatives >>](Lean-14-Finiteness-Derivatives.ipynb)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Grothendieck-Tribute.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Grothendieck-Tribute.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Lean-15 : Hommage a Alexandre Grothendieck -- Le langage grothendieckien dans Mathlib 4\n",
     "\n",
-    "**Navigation** : [<< Lean-12 Sensitivity](Lean-12-Sensitivity-Theorem.ipynb) | [Lean-16b Conway Tribute >>](Lean-16b-Conway-Game-of-Life-Lean.ipynb) | [Index](README.md)\n",
+    "**Navigation** : [<< Lean-14 Finiteness-Derivatives](Lean-14-Finiteness-Derivatives.ipynb) | [Lean-16b Conway Tribute >>](Lean-16b-Conway-Game-of-Life-Lean.ipynb) | [Index](README.md)\n",
     "\n",
     "**Kernel** : Python 3 (Mathlib excerpts shown via `subprocess` -> WSL `lean`)\n",
     "\n",
@@ -1812,7 +1812,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Lean-12 Sensitivity](Lean-12-Sensitivity-Theorem.ipynb) | [Lean-16b Conway Tribute >>](Lean-16b-Conway-Game-of-Life-Lean.ipynb) | [Index](README.md)"
+    "**Navigation** : [<< Lean-14 Finiteness-Derivatives](Lean-14-Finiteness-Derivatives.ipynb) | [Lean-16b Conway Tribute >>](Lean-16b-Conway-Game-of-Life-Lean.ipynb) | [Index](README.md)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Post-renumbering audit of the Lean series (after #3875 executed #3843 Option A) found **3 residual sequential nav drifts** in the header+footer navigation cells of the "théorèmes portés" arc (`12 Sensitivity → 13 Kochen-Specker → 14 Finiteness-Derivatives → 15 Grothendieck`). The atomic renumbering PR #3875 synced filenames, README, and titles, but left several internal prev/next (`<<`/`>>`) links pointing at the **old** neighbours.

### The 3 drifts fixed

| Notebook | Link | Was | Now |
|----------|------|-----|-----|
| Lean-12 | `next >>` | Lean-15 Grothendieck | **Lean-13 Kochen-Specker** (was skipping 13 + 14) |
| Lean-13 | `<< prev` | Lean-16b Conway-GoL | **Lean-12 Sensitivity** (16b comes *after* 13; pure stale renumbering link, no thematic link) |
| Lean-13 | `next >>` | *(missing)* | **Lean-14 Finiteness-Derivatives** (nav cell lacked a forward link) |
| Lean-15 | `<< prev` | Lean-12 Sensitivity | **Lean-14 Finiteness-Derivatives** (was skipping 13 + 14) |

### Why atomic (cannot split)

The Lean-12 ↔ Lean-13 next/prev pair is **mutual** — fixing Lean-12's `next` to point at Lean-13 without also fixing Lean-13's `prev` to point back at Lean-12 would create an inconsistent one-way link. Lean-15's `prev` is the same renumbering-residual class. One subject: sequential-nav consistency for the 12→13→14→15 arc.

### Validation

- **Markdown-only nav edits** to the `**Navigation**` line in cell 0 (header) + last cell (footer) of each notebook. No code cells, no `outputs`, no `execution_count` touched → **C.2-exempt** (no re-execution needed).
- **Byte-surgical edit** (`bytes.replace` of unique nav substrings) → **0 format churn**, JSON re-parsed valid for all 3 notebooks post-edit.
- Diff verified: exactly the 3 `**Navigation**` lines changed (header + footer), nothing else.
- Result: chain `12 → 13 → 14 → 15` now sequentially consistent in both directions.

### Scope note (out of scope)

Lean-14, Lean-16a, Lean-17a/b lack a nav cell entirely (pre-existing omission, distinct subject — "add missing nav coverage"). This PR fixes only the **wrong** links in notebooks that already have nav. Adding nav to nav-less notebooks is a separate enhancement.

### Related

See #3843 (closed this session — the renumbering acceptance criteria `0 doublon + Finiteness hors Conway + progression lisible` were met by #3875; this PR polishes the `progression lisible` residual on the internal prev/next links that #3875 left half-synced).

Markdown-only notebook nav edit — not subject to §E (docs/README/CLAUDE.md threshold); C.2-exempt (no execution proof needed for markdown-only).