### PR TITLE
docs(genai-texte): #3966 hierarchie typographique Texte 13-18 (6 nb)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
@@ -937,8 +937,8 @@
     "2. Implemente la fonction Python associee dans `executer_outil`.\n",
     "3. Ajoute l'outil a la liste `OUTILS` et au `SYSTEME_AGENT`.\n",
     "\n",
-    "# Indice : tu peux reutiliser moteur_best_of_n puis appliquer un Counter sur une cle\n",
-    "# extraite de chaque solution genere."
+    "**Indice :** tu peux reutiliser moteur_best_of_n puis appliquer un Counter sur une cle\n",
+    "extraite de chaque solution genere."
    ]
   },
   {
@@ -1006,7 +1006,7 @@
     "   `budget_epuise` (n'appelle plus l'API).\n",
     "3. Garde `max_tours` comme seconde borne.\n",
     "\n",
-    "# Indice : accumule les tokens dans une variable ; teste le seuil AVANT le prochain tour."
+    "**Indice :** accumule les tokens dans une variable ; teste le seuil AVANT le prochain tour."
    ]
   },
   {
@@ -1073,8 +1073,8 @@
     "2. Detecte l'echec partiel (`passes < total`) et laisse l'agent decider d'un 2eme outil.\n",
     "3. Retourne une trace qui montre le chainage (moteur A -> echec partiel -> moteur B).\n",
     "\n",
-    "# Indice : le system prompt doit explicitement autoriser le chainage ; max_tours doit\n",
-    "# etre augmente."
+    "**Indice :** le system prompt doit explicitement autoriser le chainage ; max_tours doit\n",
+    "etre augmente."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Texte/14_Persistent_Memory.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/14_Persistent_Memory.ipynb
@@ -846,8 +846,8 @@
     "branchant dans `MemoireVectorielle`, le notebook fonctionne a l'identique (seul l'embedder\n",
     "change).\n",
     "\n",
-    "# Indice : wrappe `client.embeddings.create(model=..., input=[text])` dans un try/except\n",
-    "# (les embeddings via OpenRouter peuvent echouer ; garde BoWEmbedder comme fallback)."
+    "**Indice :** wrappe `client.embeddings.create(model=..., input=[text])` dans un try/except\n",
+    "(les embeddings via OpenRouter peuvent echouer ; garde BoWEmbedder comme fallback)."
    ]
   },
   {
@@ -918,8 +918,8 @@
     "eviction de l'entree la **moins recentement utilisee** (LRU) quand on depasse. Ajoute un\n",
     "compteur `nb_acces` par entree, incremente a chaque `retroceder`.\n",
     "\n",
-    "# Indice : garde une liste ordonnee par recence d'acces ; ajoute depasse les max_entrees ->\n",
-    "# supprime la plus ancienne. Teste avec max_entrees=2 en ajoutant 3 lecons."
+    "**Indice :** garde une liste ordonnee par recence d'acces ; ajoute depasse les max_entrees ->\n",
+    "supprime la plus ancienne. Teste avec max_entrees=2 en ajoutant 3 lecons."
    ]
   },
   {
@@ -981,8 +981,8 @@
     "`retroceder`, filtre optionnellement par domaine. Etudie si une lecon apprise sur un\n",
     "domaine **transfer** vers un autre (ex: pitfall 'off-by-one' en code vs en arithmetique).\n",
     "\n",
-    "# Indice : ajoute un champ 'domaine' aux entrees ; parametre domaine=None (tous) dans\n",
-    "# retroceder. Conclus honnetement (G.2) si le transfer est reel ou illusoire."
+    "**Indice :** ajoute un champ 'domaine' aux entrees ; parametre domaine=None (tous) dans\n",
+    "retroceder. Conclus honnetement (G.2) si le transfer est reel ou illusoire."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Texte/15_Tree_of_Thoughts_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/15_Tree_of_Thoughts_Search.ipynb
@@ -670,8 +670,8 @@
     "qu une lettre est affectee, retire sa valeur des domaines des lettres encore libres (forward-\n",
     "checking), et coupe une branche des qu'un domaine devient vide.\n",
     "\n",
-    "# Indice : remplace `avail = [d for d in range(10) if d not in used]` par un suivi de\n",
-    "# domaines par lettre ; a chaque affectation, reduis les domaines ; backtrack = restaurer."
+    "**Indice :** remplace `avail = [d for d in range(10) if d not in used]` par un suivi de\n",
+    "domaines par lettre ; a chaque affectation, reduis les domaines ; backtrack = restaurer."
    ]
   },
   {
@@ -735,8 +735,8 @@
     "prometteuses d'abord), la recherche verifiant ensuite la contrainte. Compare le nombre de\n",
     "noeuds expliores vs le ToT combinatoire pur.\n",
     "\n",
-    "# Indice : a chaque colonne, demande au LLM \"propose 3 affectations pour D,E,Y telles que\n",
-    "# D+E finisse par Y\" ; essaie-les dans l'ordre ; backtrack si aucune ne valide."
+    "**Indice :** a chaque colonne, demande au LLM \"propose 3 affectations pour D,E,Y telles que\n",
+    "D+E finisse par Y\" ; essaie-les dans l'ordre ; backtrack si aucune ne valide."
    ]
   },
   {
@@ -799,8 +799,8 @@
     "partielle** : variables = cases vides, domaines = {1..9}, contraintes = ligne/colonne/carre.\n",
     "Resous une grille facile et compare avec un solveur dedie de la serie Sudoku.\n",
     "\n",
-    "# Indice : represente la grille comme un dict (ligne, col) -> valeur ; contraintes =\n",
-    "# ligne, colonne, bloc 3x3 ; DFS sur les cases vides dans l'ordre. Pont vers la serie Sudoku."
+    "**Indice :** represente la grille comme un dict (ligne, col) -> valeur ; contraintes =\n",
+    "ligne, colonne, bloc 3x3 ; DFS sur les cases vides dans l'ordre. Pont vers la serie Sudoku."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
@@ -718,8 +718,8 @@
     "difficiles** (ex : MATH/AMC) a reponse entiere verifiable, et monte n a 20+ echantillons.\n",
     "Re-affiche la courbe de scaling : les buckets difficiles devraient monter avec k.\n",
     "\n",
-    "# Indice : garde le meme format (enonce, attendu) dans PROBLEMES[\"competition\"] ; verifie\n",
-    "# la reponse attendue a la main ; relance la cellule de collecte avec N_ECHANTILLONS=20."
+    "**Indice :** garde le meme format (enonce, attendu) dans PROBLEMES[\"competition\"] ; verifie\n",
+    "la reponse attendue a la main ; relance la cellule de collecte avec N_ECHANTILLONS=20."
    ]
   },
   {
@@ -781,8 +781,8 @@
     "l'estimation sur **plusieurs trials independants** (m echantillons relances t fois) avec\n",
     "intervalle de confiance (bootstrap), pour quantifier le bruit souligne en section 4.\n",
     "\n",
-    "# Indice : pour chaque probleme, tires t jeux de n echantillons, calcule pass@k sur chaque\n",
-    "# jeu, puis moyenne + ecart-type (ou percentile bootstrap a 95%)."
+    "**Indice :** pour chaque probleme, tires t jeux de n echantillons, calcule pass@k sur chaque\n",
+    "jeu, puis moyenne + ecart-type (ou percentile bootstrap a 95%)."
    ]
   },
   {
@@ -843,8 +843,8 @@
     "calcule le taux de succes max entre BoN(B) et Reflexion(B), par bucket. Affiche la strategie\n",
     "gagante en fonction de B et de la difficulte (une heatmap bucket x B).\n",
     "\n",
-    "# Indice : boucle sur B, evalue BoN pass@B et Reflexion K=B, garde le max ; heatmap\n",
-    "# matplotlib (imshow) bucket (lignes) x B (colonnes) coloree par la strategie gagante."
+    "**Indice :** boucle sur B, evalue BoN pass@B et Reflexion K=B, garde le max ; heatmap\n",
+    "matplotlib (imshow) bucket (lignes) x B (colonnes) coloree par la strategie gagante."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
@@ -724,9 +724,9 @@
     "o3-mini, gpt-5-thinking) : chaque modele = un point. Construis la **frontiere de Pareto**\n",
     "(modeles dominates elimines) tokens-vs-succes.\n",
     "\n",
-    "# Indice : boucle sur une liste de REASONING_MODELS, collecte (tokens, succes) par bucket,\n",
-    "# trace tous les points + enveloppe de Pareto (un point est Pareto-optimal si aucun autre n'a\n",
-    "# a la fois moins de tokens ET plus de succes)."
+    "**Indice :** boucle sur une liste de REASONING_MODELS, collecte (tokens, succes) par bucket,\n",
+    "trace tous les points + enveloppe de Pareto (un point est Pareto-optimal si aucun autre n'a\n",
+    "a la fois moins de tokens ET plus de succes)."
    ]
   },
   {
@@ -788,8 +788,8 @@
     "le BoN sur r1 **mode raisonnement off** (si disponible) vs r1 raisonnement **on**, au meme\n",
     "budget tokens. Le delta isole l'apport du test-time compute natif.\n",
     "\n",
-    "# Indice : certains modeles exposent un parametre \"reasoning_effort\" (low/medium/high) ou un\n",
-    "# modele \"non-thinking\" jumeau. Compare pass@k a budget tokens egal entre effort=low et high."
+    "**Indice :** certains modeles exposent un parametre \"reasoning_effort\" (low/medium/high) ou un\n",
+    "modele \"non-thinking\" jumeau. Compare pass@k a budget tokens egal entre effort=low et high."
    ]
   },
   {
@@ -851,8 +851,8 @@
     "strategie. La frontiere tokens-vs-succes peut **inverser** en $ (si le modele a raisonnement est\n",
     "beaucoup plus cher par token).\n",
     "\n",
-    "# Indice : GET https://openrouter.ai/api/v1/models -> pricing.prompt/completion/completion_reasoning\n",
-    "# par modele ; calcule cout = tok_prompt*prompt + tok_completion*completion (+ reasoning*raisonnement)."
+    "**Indice :** GET https://openrouter.ai/api/v1/models -> pricing.prompt/completion/completion_reasoning\n",
+    "par modele ; calcule cout = tok_prompt*prompt + tok_completion*completion (+ reasoning*raisonnement)."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
@@ -684,8 +684,8 @@
     "LLM, et laisse SK appeler le bon plugin automatiquement. Compare le routing natif SK au routeur\n",
     "ad-hoc de NB-13.\n",
     "\n",
-    "# Indice : OpenAIPromptExecutionSettings(tool_call_behavior=...) + kernel.invoke avec auto-call.\n",
-    "# Cf serie SemanticKernel 03-Agents et la doc SK \"function calling\"."
+    "**Indice :** OpenAIPromptExecutionSettings(tool_call_behavior=...) + kernel.invoke avec auto-call.\n",
+    "Cf serie SemanticKernel 03-Agents et la doc SK \"function calling\"."
    ]
   },
   {
@@ -746,8 +746,8 @@
     "`memoire.retroceder(query, k)` + `memoire.ajouter(lesson)`. Le routeur peut alors injecter les\n",
     "lecons passees avant d'appeler Reflexion.\n",
     "\n",
-    "# Indice : wrap la MemoireVectorielle de NB-14 dans une classe avec @kernel_function sur\n",
-    "# retroceder/ajouter ; le routeur appelle memoire.retroceder puis reflexion."
+    "**Indice :** wrap la MemoireVectorielle de NB-14 dans une classe avec @kernel_function sur\n",
+    "retroceder/ajouter ; le routeur appelle memoire.retroceder puis reflexion."
    ]
   },
   {
@@ -808,8 +808,8 @@
     "(etats + transitions) plutot que des appels de plugins. Pont direct vers\n",
     "`SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb`.\n",
     "\n",
-    "# Indice : kernel.add_process(...) avec des steps (BoNStep, ReflexionStep, MemoryStep) et des\n",
-    "# edges ; le process orchestre les plugins sans orchestration manuelle."
+    "**Indice :** kernel.add_process(...) avec des steps (BoNStep, ReflexionStep, MemoryStep) et des\n",
+    "edges ; le process orchestre les plugins sans orchestration manuelle."
    ]
   },
   {


### PR DESCRIPTION
## Scope

Rollout **#3968** (typo-only) sur les **6 notebooks** de la sous-serie test-time scaling de `MyIA.AI.Notebooks/GenAI/Texte/` :

- `13_Agentic_Orchestration`
- `14_Persistent_Memory`
- `15_Tree_of_Thoughts_Search`
- `16_Scaling_Test_Time_Compute`
- `17_Native_Reasoning_vs_Scaling`
- `18_Semantic_Kernel_Plugins`

Un seul defaut, un seul fix uniforme (G.4 OK : 1 domaine, 6 fichiers, 36 lignes git).

## Defaut corrige

Chaque cellule d'exercice se termine par un encart `# Indice : ...` ecrit en **H1**, souvent sur 2-3 lignes prefixees `#` -> **5 a 8 H1 par notebook**, rendus aussi grands que le titre du notebook et **plus grands** que l'en-tete `### Exercice` (H3) qui les contient. Hierarchie visuelle inversee.

## Transformation (niveaux de titre uniquement)

| Avant | Apres |
|-------|-------|
| `# Indice : ...` (H1) | `**Indice :** ...` (gras inline) — ce sont des asides |
| ligne de continuation `# <suite>` | `<suite>` (prefixe `#` retire, reste dans le meme paragraphe que l'Indice via markdown soft-wrap) |

`### Exercice N` (H3), `**Etapes :**` (deja gras) et le titre `# N. ...` (seul H1 legitime) **intacts**. Aucun texte modifie, aucune cellule code/Solution touchee, aucun stub/relabel.

## Preuve — rendu reel (nbconvert classic + Playwright getComputedStyle, sur NB-13)

| Niveau | Avant | Apres |
|--------|-------|-------|
| Titre notebook (H1) | 25.998px | 25.998px (**seul H1**) |
| Section `## N.` (H2) | 21.994px | 21.994px |
| `### Exercice` (H3) | 18.004px | 18.004px |
| `Indice` | **25.998px (H1 !)** | **14px (`<strong>` gras inline)** |

`h1_count = 1`, `any_indice_heading = false`. Hierarchie monotone retablie : titre > section > exercice > indice.

**Comptage AST** : H1 5-8 -> **1** sur les 6 notebooks ; **0 MULTI-H1 / 0 hint-as-heading** residuel.

## Diff

6 fichiers, 5-7 lignes git/fichier (= `# Indice` + lignes de continuation transformees). **0 modif execution_count / outputs** ; format JSON `indent=1` + EOF preserves (round-trip byte-identique hors lignes Indice).

See #3968
See #3966