### PR TITLE
docs(socialchoice): demote competing deep H1 to H2 + cascade (MULTI-H1, #3968)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb
@@ -2907,7 +2907,7 @@
    "source": [
     "---\n",
     "\n",
-    "# Annexe : Tour de SocialChoiceLean (Dominik Peters)\n",
+    "## Annexe : Tour de SocialChoiceLean (Dominik Peters)\n",
     "\n",
     "Cette section presente la librairie [SocialChoiceLean](https://github.com/dominikpeters/social-choice-lean) de Dominik Peters,\n",
     "qui formalise en Lean 4 (avec Mathlib) de nombreuses regles de vote et theoremes d'impossibilite.\n",
@@ -2930,7 +2930,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 1. Cadre Formel\n",
+    "### 1. Cadre Formel\n",
     "\n",
     "DominikPeters utilise un cadre base sur les **preferences strictes** (ordres lineaires stricts), ou chaque electeur a un classement sans ex aequo. Ce choix simplifie les definitions des marges et des axiomes par rapport aux preferences faibles (16b)."
    ]
@@ -3124,7 +3124,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "| Concept | Peters (Mathlib) | Ce notebook (simplifie) |\n",
     "|---------|-------------------|-------------------------|\n",
@@ -3152,7 +3152,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 2. Marges et Vainqueur de Condorcet\n",
+    "### 2. Marges et Vainqueur de Condorcet\n",
     "\n",
     "La **marge** d'un candidat sur un autre mesure l'ecart de votes : combien d'electeurs preferent a a b, moins combien preferent b a a. Un **vainqueur de Condorcet** bat tous les autres par marge positive."
    ]
@@ -3318,7 +3318,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "La **marge** est l'outil central du framework de Peters. Elle permet de definir :\n",
     "\n",
@@ -3346,7 +3346,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 3. Axiomes de Vote\n",
+    "### 3. Axiomes de Vote\n",
     "\n",
     "DominikPeters definit et utilise 15+ axiomes pour classifier les regles de vote. Chaque axiome exprime une propriete desirable : equite, robustesse, non-manipulabilite."
    ]
@@ -3532,7 +3532,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation des axiomes\n",
+    "#### Interpretation des axiomes\n",
     "\n",
     "| Axiome | Intuition | Exigence |\n",
     "|--------|-----------|----------|\n",
@@ -3559,7 +3559,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 4. Theoreme de Gibbard-Satterthwaite\n",
+    "### 4. Theoreme de Gibbard-Satterthwaite\n",
     "\n",
     "Le resultat central de la theorie du choix social : toute regle de vote resolutive, unanime et non-manipulable (pour >= 3 candidats) doit etre une dictature. Ce theoreme montre que **toute election est manipulable** (sauf dictature).\n",
     "\n",
@@ -3749,7 +3749,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "Le theoreme de Gibbard-Satterthwaite a des implications profondes :\n",
     "\n",
@@ -3757,7 +3757,7 @@
     "2. **La non-manipulabilite est une chimere** : meme les regles les plus sophistiquees (IRV, Borda, Copeland...) sont manipulables\n",
     "3. **Le choix du systeme de vote est un compromis** : on choisit quelles proprietes sacrifier\n",
     "\n",
-    "### Structure de la preuve (Peters)\n",
+    "#### Structure de la preuve (Peters)\n",
     "\n",
     "La preuve formelle suit l'approche classique par contraposition :\n",
     "1. On suppose la regle resolutive, unanime, non-manipulable et non-dictatoriale\n",
@@ -3783,7 +3783,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. Impossibilites de Condorcet\n",
+    "### 5. Impossibilites de Condorcet\n",
     "\n",
     "DominikPeters formalise 4 theoremes d'impossibilite lies a Condorcet. Chacun montre que la coherence de Condorcet entre en conflit avec un autre axiome naturel :\n",
     "\n",
@@ -3987,7 +3987,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation des impossibilites de Condorcet\n",
+    "#### Interpretation des impossibilites de Condorcet\n",
     "\n",
     "| Impossibilite | Axiomes | Resultat | Reference |\n",
     "|---------------|---------|----------|-----------|\n",
@@ -4017,7 +4017,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 6. Split Cycle (Holliday & Pacuit 2023)\n",
+    "### 6. Split Cycle (Holliday & Pacuit 2023)\n",
     "\n",
     "La regle Split Cycle est un cas particulier dans la theorie du choix social : c'est la regle la plus fine qui soit coherente avec Condorcet et acyclique. Elle resout le probleme des cycles de Condorcet en \"affaiblissant\" les marges dans les cycles."
    ]
@@ -4202,13 +4202,13 @@
     "tags": []
    },
    "source": [
-    "### Interpretation de Split Cycle\n",
+    "#### Interpretation de Split Cycle\n",
     "\n",
     "L'idee cle de Split Cycle est d'**affaiblir les relations de defaite** : on ne retient la defaite de x sur y que si aucune marge dans un cycle contenant x et y n'est >= la marge de x sur y.\n",
     "\n",
     "**Intuition** : si la marge de x sur y est 3, mais qu'il existe un cycle x -> y -> z -> x avec des marges >= 3, alors la defaite de x sur y est \"bloquee\" par le cycle. On ne peut pas affirmer que x bat y sans affirmer simultanement que y bat z et z bat x.\n",
     "\n",
-    "### Axiomes verifiees pour Split Cycle (Peters)\n",
+    "#### Axiomes verifiees pour Split Cycle (Peters)\n",
     "\n",
     "| Axiome | Statut | Fichier |\n",
     "|--------|--------|---------|\n",
@@ -4240,11 +4240,11 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Regles de Vote Formalisees\n",
+    "### 7. Regles de Vote Formalisees\n",
     "\n",
     "DominikPeters verifie systematiquement les axiomes pour 15+ regles de vote, grace au meta-framework `@[scAxiom]` / `@[scRule]`.\n",
     "\n",
-    "### Tableau comparatif des regles\n",
+    "#### Tableau comparatif des regles\n",
     "\n",
     "| Regle | Axiomes verifiees |\n",
     "|-------|-------------------|\n",
@@ -4280,7 +4280,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Theoreme de Duggan-Schwartz\n",
+    "### 8. Theoreme de Duggan-Schwartz\n",
     "\n",
     "Le theoreme de Duggan-Schwartz etend Gibbard-Satterthwaite aux **regles multi-gagnants** (qui peuvent selectionner plusieurs candidats). Il utilise deux notions de non-manipulabilite : optimiste et pessimiste."
    ]
@@ -4542,7 +4542,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation de Duggan-Schwartz\n",
+    "#### Interpretation de Duggan-Schwartz\n",
     "\n",
     "Le theoreme de Duggan-Schwartz montre que meme les regles multi-gagnants sont vulnerables :\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
@@ -1763,7 +1763,7 @@
    "source": [
     "---\n",
     "\n",
-    "# Partie 2 : Verification SMT avec Z3\n",
+    "## Partie 2 : Verification SMT avec Z3\n",
     "\n",
     "Apres l'approche SAT (Partie 1), nous utilisons maintenant le solveur SMT **Z3** pour encoder\n",
     "le theoreme d'Arrow avec des **variables entieres** representant les rangs des alternatives.\n",
@@ -1786,7 +1786,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 1. Configuration et imports"
+    "### 1. Configuration et imports"
    ]
   },
   {
@@ -1848,19 +1848,19 @@
    "source": [
     "---\n",
     "\n",
-    "## 2. Encodage Arrow comme probleme SMT\n",
+    "### 2. Encodage Arrow comme probleme SMT\n",
     "\n",
     "L'idee centrale : pour chaque profil de preferences, la **fonction de bien-etre social (SWF)**\n",
     "produit un ordre social. Nous encodons cet ordre avec des **variables entieres** representant\n",
     "le rang de chaque alternative.\n",
     "\n",
-    "### Variables\n",
+    "#### Variables\n",
     "\n",
     "- `rank[pi][x]` : rang de l'alternative `x` dans l'ordre social pour le profil `pi`\n",
     "  (0 = meilleur, n_alt-1 = pire)\n",
     "- Chaque profil `pi` est un tuple de preferences individuelles\n",
     "\n",
-    "### Contraintes\n",
+    "#### Contraintes\n",
     "\n",
     "1. **Totalite + antisymetrie** : les rangs forment un ordre total (permutation de 0..n-1)\n",
     "2. **Pareto** : si tous preferent x a y, rank(x) < rank(y)\n",
@@ -2013,7 +2013,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation de l'encodage\n",
+    "#### Interpretation de l'encodage\n",
     "\n",
     "L'encodeur z3 utilise des **variables entieres** pour les rangs au lieu de variables booleennes.\n",
     "Chaque rang `r_pi_x` represente la position de l'alternative `x` dans l'ordre social pour le profil `pi`.\n",
@@ -2036,7 +2036,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 3. Verification UNSAT : Arrow prouve par z3\n",
+    "### 3. Verification UNSAT : Arrow prouve par z3\n",
     "\n",
     "Nous ajoutons les trois axiomes d'Arrow et demandons a z3 si une SWF les satisfaisant existe."
    ]
@@ -2138,7 +2138,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "z3 confirme **UNSAT** pour 3 alternatives et 2 electeurs : il n'existe aucune fonction de\n",
     "bien-etre social satisfaisant simultanement Pareto, IIA et non-dictature.\n",
@@ -2163,7 +2163,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 4. Verification SAT : 2 alternatives\n",
+    "### 4. Verification SAT : 2 alternatives\n",
     "\n",
     "Le theoreme d'Arrow suppose $|A| \\geq 3$. Verifions que pour 2 alternatives,\n",
     "le resultat est bien **SAT** (la regle majoritaire fonctionne)."
@@ -2238,7 +2238,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "Avec 2 alternatives, le resultat depend de la precision de l'encodage. Le theoreme d'Arrow\n",
     "classique ne s'applique qu'a partir de 3 alternatives. L'encodage SMT, comme l'encodage SAT,\n",
@@ -2261,7 +2261,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. Relaxation des axiomes\n",
+    "### 5. Relaxation des axiomes\n",
     "\n",
     "Le theoreme d'Arrow dit que les 3 axiomes sont **incompatibles**. Que se passe-t-il si on\n",
     "en relaxe un ? Nous devrions obtenir **SAT** dans chaque cas, confirmant que chaque axiome\n",
@@ -2379,7 +2379,7 @@
     "tags": []
    },
    "source": [
-    "### Tableau recapitulatif\n",
+    "#### Tableau recapitulatif\n",
     "\n",
     "| Axiomes | Resultat | SWF exemple |\n",
     "|---------|----------|-------------|\n",
@@ -2407,7 +2407,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 6. Passage a l'echelle : benchmarks"
+    "### 6. Passage a l'echelle : benchmarks"
    ]
   },
   {
@@ -2502,7 +2502,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Comparaison SAT vs SMT\n",
+    "### 7. Comparaison SAT vs SMT\n",
     "\n",
     "Comparons les deux approches pour l'encodage du theoreme d'Arrow."
    ]
@@ -2589,7 +2589,7 @@
     "tags": []
    },
    "source": [
-    "### Avantages respectifs\n",
+    "#### Avantages respectifs\n",
     "\n",
     "| Approche | Avantage principal | Quand l'utiliser |\n",
     "|----------|-------------------|-----------------|\n",
@@ -2616,7 +2616,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Exercices (suite Z3)"
+    "### 8. Exercices (suite Z3)"
    ]
   },
   {
@@ -2633,7 +2633,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 4 : Explorer l'encodeur z3\n",
+    "#### Exercice 4 : Explorer l'encodeur z3\n",
     "\n",
     "**Objectifs** : Comprendre la structure interne de l'encodeur SMT.\n",
     "\n",
@@ -2705,7 +2705,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 5 : Theoreme de Sen en SMT\n",
+    "#### Exercice 5 : Theoreme de Sen en SMT\n",
     "\n",
     "**Objectifs** : Encoder le theoreme de Sen avec z3.\n",
     "\n",
@@ -2767,7 +2767,7 @@
   {
    "cell_type": "markdown",
    "id": "319435e3",
-   "source": "## Resume et perspectives\n\nCe notebook a demontre comment les solveurs SAT et SMT permettent de verifier mecaniquement les theoremes d'impossibilite du choix social. En encodant les axiomes d'Arrow (Pareto, IIA, non-dictature) et de Sen (liberte minimale, Pareto, transitivite) sous forme de clauses CNF ou de contraintes entieres, nous avons obtenu des resultats UNSAT qui constituent des preuves formelles de ces theorems. L'approche SAT (PySAT) avec ses variables booleennes et ses milliers de clauses offre un encodage exhaustif mais verbeux, tandis que l'approche SMT (Z3) avec ses variables entieres representant les rangs sociaux produit un encodage plus compact et plus lisible, capable en prime de trouver des modeles SAT quand le theoreme ne s'applique pas (cas a 2 alternatives).\n\nL'analyse de la relaxation des axiomes a confirme que chaque condition est individuellement necessaire a l'impossibilite : retirer n'importe lequel des trois axiomes d'Arrow permet de retrouver une SWF satisfaisante (dictature, Borda, ou classement constant). Les benchmarks de performance ont egalement mis en evidence l'explosion combinatoire du nombre de profils, qui croit comme $(m!)^n$, rendant l'approche praticable uniquement pour de petites instances malgre l'utilisation de solveurs CDCL modernes comme Glucose3 et CaDiCaL.\n\nLes techniques presentees ici ouvrent la voie a des applications plus larges de la verification formelle en theorie du choix social, notamment l'analyse de theoremes de Gibbard-Satterthwaite (manipulation strategique) ou de Muller-Satterthwaite (monotonie), ainsi que l'exploration de conditions relachees ou de variations axiomatiques grace a la flexibilite de l'encodage SMT.",
+   "source": "### Resume et perspectives\n\nCe notebook a demontre comment les solveurs SAT et SMT permettent de verifier mecaniquement les theoremes d'impossibilite du choix social. En encodant les axiomes d'Arrow (Pareto, IIA, non-dictature) et de Sen (liberte minimale, Pareto, transitivite) sous forme de clauses CNF ou de contraintes entieres, nous avons obtenu des resultats UNSAT qui constituent des preuves formelles de ces theorems. L'approche SAT (PySAT) avec ses variables booleennes et ses milliers de clauses offre un encodage exhaustif mais verbeux, tandis que l'approche SMT (Z3) avec ses variables entieres representant les rangs sociaux produit un encodage plus compact et plus lisible, capable en prime de trouver des modeles SAT quand le theoreme ne s'applique pas (cas a 2 alternatives).\n\nL'analyse de la relaxation des axiomes a confirme que chaque condition est individuellement necessaire a l'impossibilite : retirer n'importe lequel des trois axiomes d'Arrow permet de retrouver une SWF satisfaisante (dictature, Borda, ou classement constant). Les benchmarks de performance ont egalement mis en evidence l'explosion combinatoire du nombre de profils, qui croit comme $(m!)^n$, rendant l'approche praticable uniquement pour de petites instances malgre l'utilisation de solveurs CDCL modernes comme Glucose3 et CaDiCaL.\n\nLes techniques presentees ici ouvrent la voie a des applications plus larges de la verification formelle en theorie du choix social, notamment l'analyse de theoremes de Gibbard-Satterthwaite (manipulation strategique) ou de Muller-Satterthwaite (monotonie), ainsi que l'exploration de conditions relachees ou de variations axiomatiques grace a la flexibilite de l'encodage SMT.",
    "metadata": {}
   },
   {


### PR DESCRIPTION
## Resume

Mise en forme **typo-only** (niveau de heading) sur `GameTheory/SocialChoice/` 02 et 04 — moitie `.NET/symbolique` de la deep-queue #3966 (item 2, arbitrage ai-01 : cascade H1->H2, sous-arbre H2->H3). Markdown-only, **0 churn code/output/execution_count/cell_type**.

Chaque notebook avait un **2e H1 geant** en concurrence avec le titre (`MULTI-H1` -> « les titres difficilement visibles », #3966) :

| Notebook | Kernel | Deep H1 demote | Subtree |
|---|---|---|---|
| `02-Lean-SocialChoice-Formal` | lean4-wsl | `# Annexe : Tour de SocialChoiceLean` -> `## ` | H2->H3 (19 headings) |
| `04-Computational-Aggregation-SAT-Z3` | python3-wsl | `# Partie 2 : Verification SMT avec Z3` -> `## ` | H2->H3 (19 headings) |

19 ins / 19 del par notebook, **tous des changements de niveau de heading** (aucune autre ligne touchee).

## Caveat Lean (02) honore

ai-01 : « 02 Lean-adjacent — verifier que chaque `#` est un vrai heading markdown, PAS une fence de code (FP) avant de demoter ». Demote **fence-aware** (suit les delimiteurs ` ``` `/`~~~`) : **0 commande Lean `#check`/`#eval`/`#print` n'a ete touchee** (verifie au rendu : `leakedLeanCmds: []`).

## Verification visuelle (obligatoire #3966 §3)

nbconvert classic + Playwright `getComputedStyle` :

| | avant | apres |
|---|---|---|
| 04 H1 count | 2 (titre + Partie 2) | **1** (titre seul) |
| 04 « Partie 2 » | H1 **25.998px** | **H2 21.994px** |
| 04 « 1. Configuration » | H2 | **H3** (cascade) |
| 02 H1 count | 2 (titre + Annexe) | **1** (titre seul) |
| 02 « Annexe » | H1 | **H2** |
| 02 « 1. Cadre Formel » | H2 | **H3** (cascade) |

Scanner `scan_md_hierarchy.py` : `MULTI-H1` **leve** sur 02 et 04.

## Hors-scope (documente)

- **01-Arrow-Impossibility-Theorem** : `H1-DEEP` **positionnel = faux-positif**. Le seul H1 EST le titre, precede d'un petit `> blockquote` de navigation (rendu petit/indente, ne concurrence PAS le titre visuellement). Reordonner/merger ne donne aucun benefice visuel et deplacerait le breadcrumb sous l'intro (= detector-gaming). **Defer ai-01** (pattern identique a GameTheory-1-Setup, deja traite en FP).
- `#3969` grilles Sudoku (moitie CSharp) : investiguee separement — **0 grille cassee** (toutes en `<pre>` monospace alignees), finding poste sur #3969.

See #3968
See #3966