### PR TITLE
chore(gitignore): drop dead stray-artifact ignore lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -834,41 +834,15 @@ right_click_context.png
 # ML training generated scripts
 MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/c2_har_rv_j_lstm_h32.py
 
-# Jupyter temp notebooks
-MyIA.AI.Notebooks/QuantConnect/Python/_executor.ipynb
-MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/test_qb.ipynb
-
-# Research scratch notebooks (not yet committed)
-MyIA.AI.Notebooks/QuantConnect/research/research_multi_layer_ema.ipynb
-MyIA.AI.Notebooks/QuantConnect/research/research_option_wheel.ipynb
-MyIA.AI.Notebooks/QuantConnect/research/research_sector_momentum.ipynb
-
-# Research result images
-MyIA.AI.Notebooks/QuantConnect/research/composite_ff_aw_results.png
-MyIA.AI.Notebooks/QuantConnect/research/composite_mom_regime_results.png
-MyIA.AI.Notebooks/QuantConnect/research/rl_multi_asset_curves.png
-
 # csproj cache files
 *.csproj.lscache
-
-# PowerShell artifact
-$null
-
-# Root-level libs/ (Tweety JARs downloaded by setup scripts — use SymbolicAI/Tweety/libs/ instead)
-/libs/
 
 # Temp OWL files from notebook execution
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/data/temp_*.owl
 
-# Stray root-level analytique output dir (should live under v4/outputs/ if persisted)
-/output_analytique/
-
-# Root-level artifacts from notebooks/scripts run with wrong CWD (canonical copies live in series dirs)
+# Root-level sudoku training output from wrong-CWD execution
+# (canonical home: MyIA.AI.Notebooks/Sudoku/sudoku_models/ — relocate, do not commit at root)
 /sudoku_models/
-/data/pizza_test.owl
-/results/
-/tmp_*.py
-/_census_out.json
 
 # Shared Mathlib checkout cache (NTFS junctions, scripts/lean/setup_shared_mathlib.ps1, #2611)
 /.mathlib-cache/


### PR DESCRIPTION
## Quoi

Suppression de lignes `.gitignore` de **complaisance** — des ignores ajoutés pour cacher des artefacts au lieu de les nettoyer. Toutes les entrées retirées pointent vers des fichiers **désormais absents** (déjà nettoyés) ou du scratch one-off sans générateur committé.

Vérifié (tous absents dans le working tree) :
- Jupyter temp notebooks : `_executor.ipynb`, `test_qb.ipynb`
- Research scratch notebooks + result images (`QuantConnect/research/`) — 6 entrées
- `$null` (PowerShell artifact), `/libs/`, `/output_analytique/`
- wrong-CWD strays : `/data/pizza_test.owl`, `/results/`, `/tmp_*.py`, `/_census_out.json`

## Gardé (légitimes, pas de la complaisance)

- `*.csproj.lscache` — cache de build VS généré
- `temp_*.owl` — glob de fichiers temp régénérés par notebook
- `/sudoku_models/` — **gardé** : 41M de sorties d'entraînement phase2 qui ne sont **PAS** dupliquées dans le dossier de série (12K seulement). L'ancien commentaire « canonical copies live in series dirs » était **faux** ; commentaire corrigé pour signaler la relocation (hors-scope de ce PR, du ressort training/po-2024).

## Preuve de préservation

- Aucun fichier supprimé du repo (entrées untracked uniquement). Diff = `.gitignore` seul (2 insertions, 28 deletions).
- `_census_out.json` (scratch local 17K, sans générateur committé) supprimé du working tree local — il n'était pas tracké.
- Aucun stray ne réapparaît en untracked après retrait des ignores (`git status` propre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)