### PR TITLE
feat(qc): #1630 aligned baseline — EMATrend (converge to winner + 2018-2025)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/README.md
@@ -1,24 +1,59 @@
 # Framework_Composite_EMATrend
 
-**Asset class:** US Equities (ETF + stocks)
-**Cloud project ID:** None (local only)
+**Asset class:** US Equities (Mag7 + mega-caps)
+**Cloud project ID:** 28911253
 
 ## Description
 
-Framework composite combining EMA-Cross-Alpha with TrendStocks-Alpha. Blends EMA crossover signals with trend-following stock selection.
+Framework composite combining EMA-Cross-Alpha (5 tech/Mag7 stocks, daily
+rebalance) with TrendStocks-Alpha (15 diversified mega-caps, weekly rebalance)
+via the QC Algorithm Framework. Target allocation: EMA70/Trend30 (sweep winner).
+
+Universe overlap: the 5 Mag7 stocks (AAPL, MSFT, GOOGL, AMZN, NVDA) are
+included in both strategies; the MultiStrategyPCM additively combines weights,
+giving Mag7 higher allocation when both strategies agree on direction.
 
 ## How to Run
 
 **Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**QC Cloud:** Deployed as project 28911253 (IBKR margin, direct backtest).
 
 ## Backtest Metrics
 
-| Metric | Value |
-|--------|-------|
-| Method | Composite EMA + Trend |
-| Components | EMA-Cross-Alpha + TrendStocks-Alpha |
+| Metric | Catalog 2015-2025 | Aligned 2018-2025 |
+|--------|-------------------|-------------------|
+| Sharpe Ratio | 0.741 | **0.611** |
+| CAGR | — | 16.670% |
+| Max Drawdown | 28.0% | 27.9% |
+| PSR | 27.4% | 19.8% |
+
+Catalog backtest (2015-2025 full decade, EMA70/Trend30) = Sharpe 0.741
+(docstring claim was 0.867 → real 0.741, -14%). See `docs/qc/qc-comparative-backtests.md`.
+
+## Aligned baseline (2018-2025)
+
+Verified on the cohort-aligned window (2018-01-01 → 2025-01-01, 1761 tradeable
+dates), same EMA70/Trend30 winner config:
+
+- **Sharpe 0.611** (backtest `3095a263d5bd30df181ec002c0a52b72`, project 28911253)
+- CAGR 16.670%, MaxDD 27.9%, PSR 19.8%
+
+**Verdict: survives alignment with a mild drop** (0.741 → 0.611, -18%) — not a
+period-overfit collapse. Loses part of the 2015-2017 Mag7 pre-ramp and absorbs
+the 2022 Mag7 drawdown, but the trend signal holds. On the aligned window this is
+the **highest-Sharpe COMP (composite-framework) backbone verified to date**
+(edges composite-c2-equityfactor 0.574, FamaFrenchAllWeather 0.338,
+composite-c1-multiasset 0.258). Promoted Tier 4 (Untested) → Tier 2 (Historique).
+
+**Mag7 survivorship caveat:** the EMA sleeve is 100% Mag7, so the Sharpe is
+partly an artifact of Mag7 outperformance over the backtest decade. Highest
+Sharpe is not the same as the most robust constitution: composite-c2-equityfactor
+(0.574, factor-diversified across 25 stocks) is the more defensible COMP leader
+constitution-wise, while EMATrend is the higher-Sharpe but Mag7-concentrated one.
+See Key-finding #36 in `docs/qc/qc-comparative-backtests.md`.
 
 ## Files
 
-- main.py - Strategy (v1.0, EMA+Trend composite)
+- `main.py` - Strategy (EMA70/Trend30 composite, aligned 2018-2025)
+- `alpha_models.py` - EMACrossAlpha + TrendStocksAlpha
+- `portfolio_construction.py` - MultiStrategyPCM (alpha allocation blend)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/main.py
@@ -9,37 +9,39 @@ class FrameworkCompositeEMATrend(QCAlgorithm):
     """
     Framework Composite - EMA-Cross + TrendStocks
 
-    Combines EMA-Cross (5 tech stocks, daily rebalance) with TrendStocks
-    (15 diversified stocks, weekly rebalance) via QC Algorithm Framework.
+    Combines EMA-Cross (5 tech/Mag7 stocks, daily rebalance) with TrendStocks
+    (15 diversified mega-caps, weekly rebalance) via QC Algorithm Framework.
 
-    Universe overlap: The 5 tech stocks (AAPL, MSFT, GOOGL, AMZN, NVDA)
+    Target allocation: EMA70/Trend30 (sweep WINNER; matches QC Cloud project
+    28911253 + catalog baseline Sharpe 0.741 @ 2015-2025, docstring claim 0.867).
+
+    Universe overlap: the 5 tech/Mag7 stocks (AAPL, MSFT, GOOGL, AMZN, NVDA)
     are included in both strategies. This is intentional - the MultiStrategyPCM
-    will additively combine weights, giving tech stocks higher allocation
-    when both strategies agree on the direction.
-
-    Target allocation (starting point): EMA40/Trend60
-    Sweep range: EMA30/Trend70 to EMA70/Trend30
+    additively combines weights, giving Mag7 higher allocation when both
+    strategies agree on the direction. Mag7 survivorship caveat: the EMA sleeve
+    is 100% Mag7, so a decade dominated by Mag7 outperformance inflates the
+    trend signal (see docs/qc/qc-comparative-backtests.md Key-finding #36).
 
     Reference strategies:
     - EMA-Cross-Alpha: Sharpe 0.980, daily emission
     - TrendStocks-Alpha: Sharpe 0.718, weekly emission
 
     Design principles:
-    - EMA-Cross: Fast mean-reversion on tech stocks (20/50 EMA)
+    - EMA-Cross: Fast mean-reversion on tech/Mag7 stocks (20/50 EMA)
     - TrendStocks: Double-confirmation trend following (Price>SMA200 + EMA20>EMA50)
     - Complementarity: Different timeframes and confirmation logic
     """
 
     def initialize(self):
-        self.set_start_date(2015, 1, 1)
-        self.set_end_date(2025, 12, 31)
+        self.set_start_date(2018, 1, 1)
+        self.set_end_date(2025, 1, 1)
         self.set_cash(100000)
         self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
 
-        # EMA-Cross universe: 5 tech stocks
+        # EMA-Cross universe: 5 tech/Mag7 stocks
         ema_tickers = ["AAPL", "MSFT", "GOOGL", "AMZN", "NVDA"]
 
-        # TrendStocks universe: 15 stocks (includes the 5 tech)
+        # TrendStocks universe: 15 stocks (includes the 5 tech/Mag7)
         trend_tickers = [
             "AAPL", "MSFT", "GOOGL", "AMZN", "NVDA",  # Tech (overlap)
             "JPM", "V", "MA",                            # Financials
@@ -59,11 +61,11 @@ class FrameworkCompositeEMATrend(QCAlgorithm):
             TrendStocksAlpha(trend_tickers, ema_fast=20, ema_slow=50, sma_trend=200)
         ))
 
-        # Target allocation: EMA40/Trend60 (starting point for sweep)
+        # Target allocation: EMA70/Trend30 (sweep winner)
         self.set_portfolio_construction(MultiStrategyPCM(
             alpha_allocations={
-                "EMACross": 0.40,
-                "TrendStocks": 0.60,
+                "EMACross": 0.70,
+                "TrendStocks": 0.30,
             },
             rebalance=timedelta(days=7)  # Weekly rebalance to align with TrendStocks
         ))
@@ -75,5 +77,5 @@ class FrameworkCompositeEMATrend(QCAlgorithm):
 
     def on_end_of_algorithm(self):
         final = self.portfolio.total_portfolio_value
-        self.log(f"FRAMEWORK COMPOSITE (EMA40/Trend60): Final=${final:,.2f}, "
+        self.log(f"FRAMEWORK COMPOSITE (EMA70/Trend30): Final=${final:,.2f}, "
                  f"Return={(final - 100000) / 100000:.2%}")


### PR DESCRIPTION
## Summary

See #91, #1630. Verifies the **Framework_Composite_EMATrend** COMP framework leader on the cohort-aligned window (2018-2025), and converges the repo `main.py` to the deployed sweep-winner allocation.

## Changes

**`main.py`** (2 changes):
1. **Allocation EMA40/Trend60 → EMA70/Trend30 (the sweep WINNER).** G.1 catch: the repo had drifted to the 40/60 *"starting point"* (its own docstring: *"Target allocation (starting point): EMA40/Trend60; Sweep range EMA30/Trend70 to EMA70/Trend30"*). The deployed QC Cloud project (28911253) and the catalog entry (Sharpe 0.741, `docs/qc/qc-comparative-backtests.md` lines 36/119) both use the **70/30 winner**. Converging the repo to the winner fixes the documented drift and makes **repo == cloud == the backtested config** (single source of truth), so the aligned run is apples-to-apples vs the catalog leader.
2. **Dates 2015/2025-12-31 → 2018/2025-01-01** (cohort-aligned window, 1761 tradeable dates — same convention as #88/#89/#90).

**`README.md`**:
- Fix stale metadata (Cloud project ID **28911253**, deployed; was *"None (local only) / Not yet deployed"*).
- Add **Aligned baseline (2018-2025)** section + Mag7 survivorship caveat.

## Backtest evidence (QC Cloud, project 28911253, EMA70/Trend30, 2018-2025)

| Metric | Catalog 2015-2025 | **Aligned 2018-2025** |
|--------|-------------------|-----------------------|
| Sharpe | 0.741 | **0.611** |
| CAGR | — | 16.670% |
| MaxDD | 28.0% | 27.9% |
| PSR | 27.4% | 19.8% |

Backtest `3095a263d5bd30df181ec002c0a52b72`, 1761 tradeable dates, Completed, `compileId 70b25695…` BuildSuccess.

**Verdict: survives alignment with a mild drop** (0.741 → 0.611, -18%) — NOT a period-overfit collapse (contrast #90 FamaFrenchAllWeather 0.588 → 0.338). Loses part of the 2015-17 Mag7 pre-ramp and absorbs the 2022 Mag7 drawdown, but the trend signal holds. This is the **highest-Sharpe COMP backbone on the aligned window** to date (edges composite-c2-equityfactor 0.574, FamaFrenchAllWeather 0.338, composite-c1-multiasset 0.258). **Promoted Tier 4 (Untested) → Tier 2 (Historique).**

**Mag7 survivorship caveat:** the EMA sleeve is 100% Mag7 (AAPL/MSFT/GOOGL/AMZN/NVDA), so the Sharpe is partly an artifact of Mag7 outperformance over the decade. Highest Sharpe ≠ most robust constitution — composite-c2-equityfactor (0.574, factor-diversified across 25 stocks) is the more defensible COMP leader constitution-wise; EMATrend is the higher-Sharpe but Mag7-concentrated one. (Detailed in Key-finding #36, separate doc PR.)

## Validation

- `totalOrders=0` / `equity={}` = qc-mcp-lite wrapper extraction artifact (CAGR 16.67% ⇒ real trades; `read_backtest` does not parse `totalOrders`/`totalNetProfit`, cf catalog *Patterns appris*). Cross-checked `list_backtests` status Completed.
- Compile BuildSuccess, 0 errors (framework modules `alpha_models.py`/`portfolio_construction.py` verified present in project 28911253).
- Scope: 2 files, 1 strategy, 1 subject (baseline alignment + documented drift fix). FR translation of this README is out-of-scope (tracked under #1650 Phase 0.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>