### PR TITLE
docs(social-choice): sync README/FORMAL_STATUS with proof state (anti-dérive)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/FORMAL_STATUS.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/FORMAL_STATUS.md
@@ -8,9 +8,9 @@
 | Mathlib | `v4.30.0-rc2` |
 | Last CI verified | 2026-05-26 |
 | Total sorry | **0** (all production files) |
-| Total lines | 1,872 |
-| Total theorems | 62 |
-| Total definitions | 60 |
+| Total lines | 2,676 (7 modules) |
+| Total theorems/lemmas | 76 |
+| Total definitions | 53 |
 
 ## Per-File Status
 
@@ -75,21 +75,60 @@ Theorems:
 
 | Metric | Value |
 |--------|-------|
-| Lines | 340 |
-| Definitions | 20 |
-| Theorems | 14 |
-| sorry | **3** |
-| Status | FORMAL-PARTIAL |
+| Lines | 875 |
+| Definitions | 22 |
+| Theorems/lemmas | 19 |
+| sorry | **0** |
+| Status | FORMAL-CERTIFIED |
 
-Key results: margin function antisymmetry, Condorcet winner uniqueness,
-Condorcet loser disjointness, single-peaked preferences, Split Cycle, clone properties.
+Key results (all 0 sorry):
 
-Port of chasenorman/Formalized-Voting.
+- **Margins**: `margin_antisymm`, `margin_self`, `margin_pos_iff_neg_rev`, `margin_pos_of_unanimous`.
+- **Condorcet**: `condorcet_winner_unique`, `condorcet_winner_not_loser`.
+- **Single-peaked / median voter**: `single_peaked_peak_unique`, `single_peaked_peak_best`,
+  `median_voter_theorem_strict`, `median_voter_theorem`.
+- **Cycles & acyclicity**: `cycle_length_pos`, `rotate_cycle`, `lt_acyclic`, `split_cycle_condorcet`.
+- **Clone structure / tournaments**: `clone_set_nonempty`, `banks_set_subset`, `banks_set_condorcet`.
 
-Sorry locations:
-- Line 231: proof requires Finset counting + sorting machinery
-- Line 298: needs IsChain construction for rotated list
-- Line 304: needs List.IsChain contradiction on irreflexive transitive relation
+Port of chasenorman/Formalized-Voting. The three former sorries (Finset counting/sorting,
+`IsChain` construction, rotated-list cycle contradiction) — historically gating the median
+voter and single-peaked proofs — are now fully resolved (0 sorry), closed via the dedicated
+`SortedListCounting.lean` combinatorial machinery (median counting lemmas).
+
+### SocialChoice/MechanismDesign.lean — VICKREY AUCTION (MECHANISM DESIGN)
+
+| Metric | Value |
+|--------|-------|
+| Lines | 76 |
+| Definitions | 2 |
+| Theorems | 4 |
+| sorry | **0** |
+| Status | FORMAL-CERTIFIED |
+
+Truthfulness / incentive-compatibility of auction rules (extending the project beyond
+pure social choice into mechanism design):
+
+- `vickrey_truthful_bidder0`, `vickrey_truthful_bidder1` — the second-price (Vickrey)
+  auction is truthful: bidding one's true valuation is a dominant strategy.
+- `first_price_not_truthful` — the first-price auction is **not** truthful
+  (counter-example to incentive compatibility).
+- `vickrey3_truthful_bidder0` — truthfulness extends to the 3-bidder Vickrey auction.
+
+### SocialChoice/SortedListCounting.lean — MEDIAN-COUNTING LEMMAS
+
+| Metric | Value |
+|--------|-------|
+| Lines | 185 |
+| Definitions | 0 |
+| Theorems | 5 |
+| sorry | **0** |
+| Status | FORMAL-CERTIFIED |
+
+Combinatorial lemmas on sorted lists and `Finset.filter` cardinality that back the
+median-voter counting arguments in `Voting.lean`: `countP_lt_kth_le_half`,
+`countP_ge_kth_ge_half_succ`, `countP_le_kth_ge_half_succ`,
+`finset_filter_card_eq_toList_countP`, `finset_filter_lt_card_eq_toList_map_countP`.
+Decoupled from the voting module so the counting kernel is reusable.
 
 ## Theorem Inventory
 
@@ -105,12 +144,23 @@ Sorry locations:
 | `pivot_exists` | Arrow.lean | Pivotal individual exists |
 | `pivot_is_dictator_except_b` | Arrow.lean | Pivot = dictator on non-b pairs |
 | `partial_dictator_is_full_dictator` | Arrow.lean | Partial = full dictatorship |
+| `margin_antisymm` | Voting.lean | Margin function antisymmetry |
+| `condorcet_winner_unique` | Voting.lean | Condorcet winner is unique |
+| `single_peaked_peak_unique` | Voting.lean | Single-peaked preference has a unique peak |
+| `median_voter_theorem` | Voting.lean | Majority selects the median voter's peak (single-peaked) |
+| `median_voter_theorem_strict` | Voting.lean | Strict single-peaked median voter theorem |
+| `split_cycle_condorcet` | Voting.lean | Split Cycle satisfies the Condorcet criterion |
+| `countP_lt_kth_le_half` | SortedListCounting.lean | Median-counting kernel lemma |
+| `vickrey_truthful_bidder0` | MechanismDesign.lean | Vickrey (2nd-price) auction is truthful (bidder 0) |
+| `vickrey_truthful_bidder1` | MechanismDesign.lean | Vickrey auction is truthful (bidder 1) |
+| `first_price_not_truthful` | MechanismDesign.lean | First-price auction is not truthful |
+| `vickrey3_truthful_bidder0` | MechanismDesign.lean | 3-bidder Vickrey auction is truthful |
 
 ### In Progress (contains sorry)
 
-| Theorem | File | sorry | Statement |
-|---------|------|-------|-----------|
-| Various | Voting.lean | 3 | Condorcet/sorting/IsChain proofs (see sorry locations above) |
+None — all modules are fully certified (0 sorry). The three former `Voting.lean` sorries
+gating the median-voter / single-peaked proofs were resolved via the `SortedListCounting.lean`
+counting kernel; Vickrey truthfulness (`MechanismDesign.lean`) is fully proved.
 
 ## Certification Level
 
@@ -120,9 +170,13 @@ Sorry locations:
 | Framework.lean | CERTIFIED (0 sorry) |
 | Arrow.lean | CERTIFIED (0 sorry) |
 | Sen.lean | CERTIFIED (0 sorry) |
-| Voting.lean | PARTIAL (3 sorry — in progress) |
+| Voting.lean | CERTIFIED (0 sorry) |
+| MechanismDesign.lean | CERTIFIED (0 sorry) |
+| SortedListCounting.lean | CERTIFIED (0 sorry) |
 
-**Project certification: PARTIAL** — Arrow/Sen/Basic/Framework fully certified (0 sorry), Voting.lean has 3 sorry remaining.
+**Project certification: COMPLETE** — all seven modules fully certified (0 sorry). Arrow,
+Sen and the Voting/median-voter results are all closed, and the project additionally covers
+mechanism design (Vickrey truthfulness) backed by a dedicated median-counting kernel.
 
 ## References
 
@@ -142,3 +196,4 @@ Sorry locations:
 | 2026-04-29 | Toolchain upgrade v4.28.0-rc1 -> v4.29.1 | `c1b2cde1` |
 | 2026-04-30 | FORMAL_STATUS.md created, CI cache fix | PR-G |
 | 2026-05-26 | Toolchain upgrade v4.29.1 -> v4.30.0-rc2, 0 sorry | — |
+| 2026-06-23 | **Docs anti-dérive (G.1 source-verified):** FORMAL_STATUS was stale — Voting.lean had grown 340->875 lines and its 3 historical sorries were resolved (median-counting kernel `SortedListCounting.lean`), yet the doc still said "3 sorry / FORMAL-PARTIAL". Corrected: Voting 0 sorry/CERTIFIED, project PARTIAL->COMPLETE, total lines 1,872->2,676, theorems 62->76. Added undocumented modules `MechanismDesign.lean` (Vickrey truthfulness) + `SortedListCounting.lean` to per-file status + inventory. README.md (FR) structure + counts realigned. | po-2026 |

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
@@ -1,4 +1,4 @@
-# Social Choice Theory - Lean 4 Formulations
+# Théorie du Choix Social — Formulations Lean 4
 
 Ce répertoire contient les formalisations mathématiques de la théorie du choix social en Lean 4, développées dans le cadre de la série GameTheory.
 
@@ -6,12 +6,14 @@ Ce répertoire contient les formalisations mathématiques de la théorie du choi
 
 | Statistique | Valeur |
 |-------------|--------|
-| Théorèmes formels | 3 certifiés (0 sorry) |
+| Théorèmes/Lemmas | 76 (0 sorry, 7 modules) |
 | sorry restants | 0 |
-| Référence commit | `v4.30.0-rc2` (main, 26/05/2026) |
+| Toolchain | `leanprover/lean4:v4.30.0-rc2` |
 | Dépendances | Mathlib4, Lake |
 
-**Statut formel** : Arrow.lean, Sen.lean et Voting.lean sont **FORMAL-CERTIFIED** (0 sorry). Voir `FORMAL_STATUS.md` pour le détail par fichier.
+**Statut formel** : les **sept** modules (Basic, Framework, Arrow, Sen, Voting,
+MechanismDesign, SortedListCounting) sont **FORMAL-CERTIFIED** (0 sorry). Voir
+[`FORMAL_STATUS.md`](FORMAL_STATUS.md) pour le détail par fichier.
 
 ## Théorèmes formalisés
 
@@ -67,12 +69,38 @@ Résultats formalisés par Peters :
   1. **Critère de Pareto faible**
   2. **Libéralisme minimal** : Certains individus sont décisifs sur certaines paires
 
-### 3. Théorème de l'Électeur Médian (Median Voter Theorem)
+### 3. Théorie du vote (Voting.lean)
 
-**Dans `SocialChoice/Voting.lean`** :
+**Dans `SocialChoice/Voting.lean`** (port de chasenorman/Formalized-Voting, 19 théorèmes,
+0 sorry). Le module couvre bien au-delà du seul électeur médian :
 
-- **Énoncé** : Pour des préférences single-peaked, la règle de la majorité sélectionne l'alternative préférée de l'électeur médian.
-- **Statut** : **FORMAL-CERTIFIED** (0 sorry). Définitions complètes (single-peaked, peak) et théorème fermé (cf [LEAN_INVENTORY.md](../LEAN_INVENTORY.md)).
+- **Marges** (`margin_pos`, `margin_antisymm`, `margin_pos_iff_neg_rev`) : la marge
+  majoritaire d'une paire encode l'écart de voix ; antisymétrie et caractérisation.
+- **Gagnant/perdant de Condorcet** : `condorcet_winner_unique` (unicité du gagnant de
+  Condorcet), `condorcet_winner_not_loser` (disjonction gagnant/perdant).
+- **Préférences single-peaked et électeur médian** : `single_peaked_peak_unique` (pic
+  unique), `single_peaked_peak_best` (le pic est le meilleur), puis
+  **`median_voter_theorem`** et sa variante stricte `median_voter_theorem_strict` — pour
+  des préférences single-peaked, la règle majoritaire sélectionne l'alternative préférée
+  de l'électeur médian. Le noyau de comptage médian vit dans `SortedListCounting.lean`.
+- **Cycles et acyclicité** : `cycle_length_pos`, `rotate_cycle`, `lt_acyclic`,
+  `split_cycle_condorcet` (la règle **Split Cycle** de Holliday-Pacuit satisfait le
+  critère de Condorcet).
+- **Clones et tournois** : `clone_set_nonempty` (structure de clones), `banks_set_subset` /
+  `banks_set_condorcet` (ensemble des gagnants de Banks).
+
+### 4. Théorie des mécanismes — Enchère de Vickrey (MechanismDesign.lean)
+
+**Dans `SocialChoice/MechanismDesign.lean`** (4 théorèmes, 0 sorry). Le projet s'étend
+au-delà du choix social pur vers la **théorie des mécanismes** (incitations et véridicité) :
+
+- **Véridicité de Vickrey** (`vickrey_truthful_bidder0`, `vickrey_truthful_bidder1`,
+  `vickrey3_truthful_bidder0`) : dans une enchère au **second prix** (Vickrey), annoncer
+  sa vraie valuation est une stratégie faiblement dominante — le mécanisme est *truthful*
+  (incitation à révéler sa vraie valeur).
+- **First-price non véridique** (`first_price_not_truthful`) : à l'inverse, l'enchère au
+  **premier prix** n'est **pas** véridique (contre-exemple direct) — l'enchérisseur a
+  intérêt à sous-évaluer sa vraie valeur.
 
 ## Structure des fichiers
 
@@ -82,12 +110,19 @@ social_choice_lean/
 ├── lakefile.lean                      # Configuration du projet Lake
 ├── lean-toolchain                     # Version de Lean (v4.30.0-rc2)
 ├── SocialChoice.lean                  # Fichier d'imports principaux
-├── SocialChoice/                      # Module principal
-│   ├── Basic.lean                    # Définitions de base (P, I, PrefOrder, Profile)
-│   ├── Arrow.lean                   # Théorème d'Arrow (Geanakoplos 2005)
-│   ├── Sen.lean                     # Paradoxe de Sen (bidirectionnel)
-│   └── Voting.lean                  # Définitions de vote (margin, Condorcet, SCC,
-│                                     # critères de vote, single-peaked, Split Cycle, clones)
+├── SocialChoice/                      # Module principal (7 fichiers, 0 sorry)
+│   ├── Basic.lean                    # Définitions de base (P, I, PrefOrder, QuasiOrder,
+│   │                                 # lemmes de transitivité, best/maximal elements)
+│   ├── Framework.lean                # Cadre SWF (Profile, SWF, weak_pareto, IIA,
+│   │                                 # is_dictatorship, maketop/makebot/makeabove)
+│   ├── Arrow.lean                   # Théorème d'Arrow (Geanakoplos 2005, 4 étapes)
+│   ├── Sen.lean                     # Paradoxe de Sen (décisivité bidirectionnelle)
+│   ├── Voting.lean                  # Théorie du vote : margins, Condorcet (unique),
+│   │                                 # single-peaked, théorème de l'électeur médian,
+│   │                                 # Split Cycle, clones, tournois de Banks
+│   ├── MechanismDesign.lean         # Théorie des mécanismes : Vickrey (véridicité),
+│   │                                 # first-price non-véridique
+│   └── SortedListCounting.lean      # Lemmes de comptage médian (noyau du median voter)
 └── examples/
     ├── arrow_simple.lean            # Exemple simple d'Arrow
     └── sen_liberal_paradox.lean     # Exemple du paradoxe de Sen
@@ -180,21 +215,29 @@ Voir la licence du repository principal.
 
 ## Conclusion
 
-Ce projet formalise en Lean 4 (**0 `sorry`**) trois résultats fondateurs de la
-théorie du choix social : le **théorème d'impossibilité d'Arrow**, le **paradoxe
-libéral de Sen** et le **théorème de l'électeur médian**. Les trois théorèmes
-sont FORMAL-CERTIFIED et recompilables via `lake build` sur la toolchain
+Ce projet formalise en Lean 4 (**0 `sorry`**, 76 théorèmes/lemmas sur 7 modules) les
+résultats fondateurs de la théorie du choix social : le **théorème d'impossibilité
+d'Arrow**, le **paradoxe libéral de Sen**, la **théorie du vote** (Condorcet, électeur
+médian, Split Cycle) et la **véridicité de l'enchère de Vickrey** (théorie des mécanismes).
+Tous les modules sont FORMAL-CERTIFIED et recompilables via `lake build` sur la toolchain
 `v4.30.0-rc2`.
 
 ### Ce qui est prouvé
 
 - **Arrow** (`Arrow.lean`) : toute fonction de welfare social (≥ 3 alternatives)
   satisfaisant faible-Pareto + IIA est une **dictature** — preuve structurée en
-  quatre étapes à la Geanakoplos (2005), via profils manipulés `maketop`/`makebot`.
+  quatre étapes à la Geanakoplos (2005), via profils manipulés `maketop`/`makebot`
+  (`extremal_lemma` → `pivot_exists` → `pivot_is_dictator_except_b` →
+  `partial_dictator_is_full_dictator` → `arrow` / `no_perfect_swf`).
 - **Sen** (`Sen.lean`) : aucune procédure sociale ne réconcilie Pareto faible et
-  libéralisme minimal, par contre-exemple direct.
-- **Électeur médian** (`Voting.lean`) : sur préférences single-peaked, la majorité
-  sélectionne le pic de l'électeur médian.
+  libéralisme minimal (décisivité bidirectionnelle), par contre-exemple direct
+  (`sen_impossibility`, `book_paradox_demonstrates_sen`).
+- **Théorie du vote** (`Voting.lean`) : marges majoritaires, **unicité du gagnant de
+  Condorcet**, préférences single-peaked, **théorème de l'électeur médian**
+  (variante stricte comprise), acyclicité et règle **Split Cycle**, structure de clones
+  et gagnants de Banks.
+- **Théorie des mécanismes** (`MechanismDesign.lean`) : **véridicité de l'enchère de
+  Vickrey** (2 et 3 enchérisseurs) et **non-véridicité de l'enchère au premier prix**.
 
 ### Pourquoi ça marche
 


### PR DESCRIPTION
-