### PR TITLE
docs(casestudies): add pedagogical Conclusion to Diagnostic-Medical + Oncology-Planning sub-series

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/README.md
@@ -236,6 +236,17 @@ Chaque cellule a remplir ou compléter sera évaluée pour constituer la note fi
 ✅ Analyse de complexité et optimisation
 ✅ Documentation technique et tests
 
+## Conclusion
+
+Ce cas d'étude illustre une idée centrale de l'IA appliquée : **aucun paradigme isolé ne suffit** à un problème de diagnostic réaliste. Les quatre briques se complètent au lieu de se concurrencer :
+
+- l'**agent à base de règles** encode le savoir clinique explicite et fournit une première classification interprétable ;
+- la recherche **A\*** explore efficacement l'espace des hypothèses diagnostiques en se laissant guider par une heuristique admissible ;
+- les **algorithmes génétiques** calibrent les paramètres là où l'espace de recherche est trop vaste pour une exploration exacte ;
+- le **solveur Z3** apporte la garantie formelle que le protocole thérapeutique retenu respecte toutes les contraintes médicales.
+
+La valeur pédagogique tient précisément à cette **intégration** : reconnaître, pour chaque facette d'un problème (classer, chercher, optimiser, vérifier), quel outil est le mieux adapté, puis composer ces outils en un pipeline cohérent. C'est cette capacité d'orchestration — davantage que la maîtrise de chaque algorithme pris isolément — qui distingue un système d'aide à la décision robuste.
+
 ---
 
 **Bonne chance avec votre implémentation !**

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/README.md
@@ -131,6 +131,19 @@ C'est la conception d'un **Jumeau Numérique** du patient, capable d'éclairer l
 
 ---
 
+## Conclusion
+
+Ce cas d'étude réunit deux familles d'IA que l'on oppose souvent, pour montrer qu'elles sont en réalité **complémentaires** dans une chaîne décisionnelle :
+
+- l'**IA symbolique** (ontologie des chimiothérapies, vérification de contraintes, planification CSP des cures) garantit qu'un calendrier de traitement est *valide* — conforme aux règles métier, sans violation de protocole ;
+- la **programmation probabiliste** (Pyro) prend en charge ce que le symbolique ne sait pas exprimer : l'*incertitude* sur le profil de toxicité du patient et la probabilité de devoir adapter le traitement.
+
+Leur intégration produit un **jumeau numérique** du patient, capable de simuler « et si ? » (maintenir la dose prévue, réduire de 25 %, reporter d'une semaine) et d'éclairer la décision médicale par des scénarios chiffrés plutôt que par une règle rigide.
+
+La leçon à retenir dépasse l'oncologie : un système décisionnel mûr combine le **déterministe** (ce qui doit être respecté) et le **probabiliste** (ce qui doit être estimé). Savoir où placer cette frontière — et brancher la bonne brique de chaque côté — est au cœur de la conception des systèmes d'aide à la décision sous incertitude.
+
+---
+
 ## Notes pour les enseignants
 
 ### Genèse du sujet


### PR DESCRIPTION
## Objet

Fallback perenne **#2651** (prose pedagogique des READMEs), partition po-2025:CoursIA-2 — sous-series CaseStudies.

Les deux READMEs de sous-serie CaseStudies n'avaient **pas de section Conclusion**. Ajout d'une Conclusion **francaise, conceptuelle** a chacune (markdown-only, purement additif).

## Changements

| Fichier | Ins / Del | Conclusion ajoutee |
|---|---|---|
| `CaseStudies/Diagnostic-Medical/README.md` | +11 / 0 | Comment les 4 paradigmes (agent a base de regles / A* / algorithmes genetiques / Z3) se **completent** au lieu de se concurrencer — l'orchestration comme lecon centrale. |
| `CaseStudies/Oncology-Planning/README.md` | +13 / 0 | IA **symbolique** (ontologie + planification CSP) et **probabiliste** (Pyro) comme deux moities complementaires d'une boucle decisionnelle « jumeau numerique » sous incertitude. |

## Conformite

- **FR-first** : les deux READMEs sont deja en francais, Conclusion ajoutee en francais.
- **Additif** : `git diff --numstat` = `11/0` et `13/0`, zero suppression de contenu existant.
- **Pas de fuite jury** : Conclusion purement conceptuelle, aucun bareme / critere de notation / question d'oral ajoute (cf student-pr-reviews).
- **CATALOG-STATUS** : marqueurs inchanges (aucun present dans ces sous-series).
- **No-pendulum** : warnings markdownlint pre-existants (fenced blocks sans langage, tables compactes, URLs nues) laisses tels quels — hors scope.

See #2651