### PR TITLE
docs(cooperative-games): banzhaf_raw_symmetric "in progress"->"proven" (#4037)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
@@ -87,6 +87,7 @@ Proved theorems (sorry resolved):
 - `shapley_uniqueness` (PR #1024, commit `1eb5a4a0`, 2026-05-13 — Mobius decomposition)
 - `dummy_shapley_zero` (dummy players get zero Shapley value)
 - `dummy_banzhaf_raw_zero` (PR #4011 — dummy players get zero raw Banzhaf index)
+- `banzhaf_raw_symmetric` (PR #4037, commit `ba3b169e` — symmetric players have equal raw Banzhaf indices)
 
 ## Theorem Inventory
 
@@ -112,6 +113,7 @@ Proved theorems (sorry resolved):
 | `shapley_uniqueness` | Shapley.lean | Shapley value is unique solution satisfying axioms (PR #1024) |
 | `dummy_shapley_zero` | Shapley.lean | Dummy players get zero Shapley value |
 | `dummy_banzhaf_raw_zero` | Shapley.lean | Dummy players get zero raw Banzhaf index (PR #4011) |
+| `banzhaf_raw_symmetric` | Shapley.lean | Symmetric players have equal raw Banzhaf index (PR #4037) |
 
 ### Partially Proved (contains sorry)
 
@@ -132,9 +134,9 @@ characterised, and the Farkas/cone-separation kernel lives in `ConeKernel.lean`.
 ## Remaining Work
 
 No open sorry. Possible extensions:
-- Banzhaf power index: `dummy_banzhaf_raw_zero` proved (PR #4011); a symmetry theorem
-  `banzhaf_raw_symmetric` (interchangeable players have equal raw Banzhaf indices, the
-  Banzhaf analog of `shapley_symmetric`) is in progress in PR #4037
+- Banzhaf power index: `dummy_banzhaf_raw_zero` (PR #4011) and the symmetry theorem
+  `banzhaf_raw_symmetric` (PR #4037, merged `ba3b169e`) are proved; the lineage parallels
+  the Shapley characterisation
 - Shapley value computational properties
 
 ## References
@@ -161,3 +163,4 @@ No open sorry. Possible extensions:
 | 2026-06-20 | **Correction (G.1 verify-before-claiming):** PR #1020's `bondareva_shapley_backward` "proof" was `apply?` (non-proof); PR #2959 refactored to isolate `hb_witness` LP-dual kernel as named sorry. FORMAL_STATUS corrected: 0→1 sorry, COMPLETE→WIP_HARD | po-2026 #2959 |
 | 2026-06-23 | **ConeKernel construction closes `hb_witness` (sorry 1→0):** #3933 (ConeKernel TUGame-free kernel) → #3941 (balancedUnit bridge) → #3945 (witness-decoding core) → #3951 (wire cone-separation→decoding pipeline) → #3954 (sorry 1→0). `hb_witness` now a certified `have` @ `Basic.lean:348`. FORMAL_STATUS realigned: 1→0 sorry, WIP_HARD→COMPLETE. Lake build SUCCESS (8435 jobs). | po-2026 |
 | 2026-06-23 | **Banzhaf docs anti-dérive:** FORMAL_STATUS corrected — `dummy_banzhaf_raw_zero` (PR #4011) added to proved list + inventory; stale "no theorems yet" line fixed; Shapley.lean counts 12→13 theorems / 1042→1081 lines. README.md (FR) + README.en.md document the Banzhaf framework (`Critical`/`BanzhafRaw`). See #4037 (symmetry theorem in progress). | po-2026 |
+| 2026-06-23 | **`banzhaf_raw_symmetric` PROVED follow-up** (post-#4037 merge `ba3b169e`): the symmetry theorem is now on main (`Shapley.lean:1106`, `lake build CooperativeGames` SUCCESS 8435 jobs, 0 sorry). README.md/README.en.md "En cours/In progress"→"Prouvé/Proven" + full proof sketch (`banzhafSwap` involution, 4 membership cases, `SymmetricPlayers` value-invariance, critical-coalition bijection). FORMAL_STATUS: moved to proved list + inventory, removed from Remaining Work. Shapley.lean counts 13→14 theorems / 1081→1274 lines. See #4037. | po-2026 |

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.en.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.en.md
@@ -49,11 +49,16 @@ A dummy player (`DummyPlayer`) never changes a coalition's value, so it is never
 its raw Banzhaf index is indeed zero. This is the Banzhaf-index analogue of the null-player
 theorem for the Shapley value.
 
-**In progress** (PR #4037): the symmetry theorem `banzhaf_raw_symmetric` — two
-interchangeable players (`SymmetricPlayers`) have equal raw Banzhaf indices, the Banzhaf
-analogue of `shapley_symmetric`. The proof builds an involution `banzhafSwap` that exchanges
-`i` and `j` in each coalition, shows it preserves the game's value, and transports the
-critical coalitions of `i` bijectively onto those of `j`.
+**Proven** (PR #4037, merged `ba3b169e`): the symmetry theorem `banzhaf_raw_symmetric`
+(`Shapley.lean:1106`) — two interchangeable players (`SymmetricPlayers`) have equal raw
+Banzhaf indices, the Banzhaf analogue of `shapley_symmetric`. The proof builds an involution
+`banzhafSwap` that exchanges `i` and `j` in each coalition (four cases: containing both,
+neither, or exactly one of them), shows it preserves the game's value (by `SymmetricPlayers`,
+after a case split on `S ∩ {i, j}`), and transports the critical coalitions of `i`
+bijectively onto those of `j`; the two critical-coalition filters are thus in bijection, so
+their cardinalities coincide — the raw Banzhaf indices. This power-index lineage
+(`dummy_banzhaf_raw_zero` #4011 → `banzhaf_raw_symmetric` #4037) parallels the Shapley
+characterisation.
 
 ## Notes
 

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
@@ -50,11 +50,16 @@ Un joueur dummy (`DummyPlayer`) ne change jamais la valeur d'une coalition, il n
 jamais critique : son indice de Banzhaf brut est bien nul. C'est l'analogue, pour l'indice
 de Banzhaf, du théorème de joueur nul pour la valeur de Shapley.
 
-**En cours** (PR #4037) : le théorème de symétrie `banzhaf_raw_symmetric` — deux joueurs
-interchangeables (`SymmetricPlayers`) ont des indices de Banzhaf brut égaux, l'analogue
-Banzhaf de `shapley_symmetric`. La preuve construit une involution `banzhafSwap` échangeant
-`i` et `j` dans chaque coalition, montre qu'elle préserve la valeur du jeu et qu'elle
-transporte bijectivement les coalitions critiques de `i` sur celles de `j`.
+**Prouvé** (PR #4037, merged `ba3b169e`) : le théorème de symétrie `banzhaf_raw_symmetric`
+(`Shapley.lean:1106`) — deux joueurs interchangeables (`SymmetricPlayers`) ont des indices
+de Banzhaf brut égaux, l'analogue Banzhaf de `shapley_symmetric`. La preuve construit une
+involution `banzhafSwap` échangeant `i` et `j` dans chaque coalition (quatre cas : contient
+les deux, aucun, ou exactement un des deux), montre qu'elle préserve la valeur du jeu (par
+`SymmetricPlayers`, après division en cas sur `S ∩ {i, j}`) et qu'elle transporte
+bijectivement les coalitions critiques de `i` sur celles de `j` ; les deux filtres de
+coalitions critiques sont donc en bijection, d'où l'égalité de leurs cardinaux — les indices
+de Banzhaf bruts. Cette lignée power-index (`dummy_banzhaf_raw_zero` #4011 →
+`banzhaf_raw_symmetric` #4037) parallèle la caractérisation Shapley.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Follow-up to **#4037** (merged `ba3b169e`). `banzhaf_raw_symmetric` is now **PROVED** on main (`Shapley.lean:1106`, `lake build CooperativeGames` SUCCESS 8435 jobs, **0 sorry**). Cycle 53 (#4042) had documented it as *"En cours / In progress"* because #4037 was still OPEN at the time — this corrects the drift now that the proof is merged.

## Changes (docs-only, 3 files, +26/-13)

- **`README.md` (FR)** + **`README.en.md`**: `"En cours" / "In progress"` → `"Prouvé" / "Proven"`, with the full proof sketch (`banzhafSwap` involution over the 4 membership cases, `SymmetricPlayers` value-invariance after case split on `S ∩ {i,j}`, critical-coalition bijection ⟹ equal cardinalities). Cites `Shapley.lean:1106` + merge `ba3b169e`.
- **`FORMAL_STATUS.md`**: moved `banzhaf_raw_symmetric` to the **proved list** + **inventory table**, removed it from **Remaining Work**, added a history row, counts `13→14` theorems / `1081→1274` lines.

## Verification (G.1, verify-before-claiming)

- `banzhaf_raw_symmetric` confirmed on main firsthand: `git grep` → `Shapley.lean:1106` (`theorem banzhaf_raw_symmetric (G : TUGame N) (i j : N) (h : Solution.SymmetricPlayers G i j) : BanzhafRaw G i = BanzhafRaw G j`).
- `Shapley.lean`: 1274 lines, **14 theorems** (col0), **0 sorry**.
- No `.lean` / no `CATALOG` / no notebook touched (docs-only).

## Scope

Docs anti-dérive follow-up, atomique. See #4037 (the proof PR is already merged; this syncs the docs that still marked the theorem "in progress").

🤖 Generated with [Claude Code](https://claude.com/claude-code)