### PR TITLE
feat(z3): full 3M/3C Missionnaires-Cannibales via Z3.Linq CollectionHandling.Array DSL

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
@@ -50,10 +50,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:28.877626Z",
-     "iopub.status.busy": "2026-06-15T17:18:28.867938Z",
-     "iopub.status.idle": "2026-06-15T17:18:30.743579Z",
-     "shell.execute_reply": "2026-06-15T17:18:30.736749Z"
+     "iopub.execute_input": "2026-06-23T13:52:09.948287Z",
+     "iopub.status.busy": "2026-06-23T13:52:09.942917Z",
+     "iopub.status.idle": "2026-06-23T13:52:11.000653Z",
+     "shell.execute_reply": "2026-06-23T13:52:10.998635Z"
     },
     "papermill": {
      "duration": 1.889662,
@@ -73,7 +73,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-46580.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-44684.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -118,12 +118,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.19.64.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://10.143.196.167:2048/\", \"http://192.168.48.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '46580.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '44684.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -288,10 +288,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:30.784072Z",
-     "iopub.status.busy": "2026-06-15T17:18:30.783742Z",
-     "iopub.status.idle": "2026-06-15T17:18:31.413443Z",
-     "shell.execute_reply": "2026-06-15T17:18:31.413141Z"
+     "iopub.execute_input": "2026-06-23T13:52:11.001848Z",
+     "iopub.status.busy": "2026-06-23T13:52:11.001669Z",
+     "iopub.status.idle": "2026-06-23T13:52:11.345612Z",
+     "shell.execute_reply": "2026-06-23T13:52:11.345418Z"
     },
     "papermill": {
      "duration": 0.638816,
@@ -438,10 +438,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:31.447282Z",
-     "iopub.status.busy": "2026-06-15T17:18:31.446995Z",
-     "iopub.status.idle": "2026-06-15T17:18:31.632641Z",
-     "shell.execute_reply": "2026-06-15T17:18:31.632446Z"
+     "iopub.execute_input": "2026-06-23T13:52:11.346859Z",
+     "iopub.status.busy": "2026-06-23T13:52:11.346666Z",
+     "iopub.status.idle": "2026-06-23T13:52:11.448838Z",
+     "shell.execute_reply": "2026-06-23T13:52:11.448642Z"
     },
     "papermill": {
      "duration": 0.191905,
@@ -578,8 +578,24 @@
   {
    "cell_type": "markdown",
    "id": "6ca8f9e8",
-   "source": "### Deux autres briques de la théorie des tableaux SMT-LIB\n\nLes axiomes de McCarthy ci-dessus définissent `select` et `store`. La théorie des tableaux du standard SMT-LIB en compte deux autres, qui ne sont pas utilisées dans ce notebook mais qu'il faut connaître pour lire la littérature SMT :\n\n**Le tableau constant (`const`, ou `K` en SMT-LIB).** C'est un troisième constructeur, à côté de `select`/`store` : `const(v)` désigne le tableau dont **toutes** les positions contiennent la valeur `v`. En C# Microsoft.Z3, cela se crée par `ctx.MkConstArray(ctx.IntSort, ctx.MkInt(0))` — un tableau « entièrement à zéro ». C'est l'outil naturel pour exprimer un **état initial uniforme** : une grille vide (toutes cases à 0), un registre vidé, un buffer initialisé. On pourrait alors écrire l'état initial `[2, 2]` de l'exemple Missionnaires-Cannibales (cell `c5d6e7fe`) de façon plus concise comme `store(store(const(0), 0, 2), 1, 2)` — deux écritures par-dessus un fond uniforme de zéros — plutôt qu'en partant d'un tableau symbolique non interprété.\n\n**L'extensionalité.** C'est le quatrième axiome : deux tableaux `a` et `b` sont **égaux** si et seulement si ils coïncident sur tout indice —\n\n$$\na = b \\;\\;\\Longleftrightarrow\\;\\; \\forall i.\\; \\text{select}(a, i) = \\text{select}(b, i)\n$$\n\nCet axiome est ce qui rend l'égalité entre tableaux **décidable** : écrire `ctx.MkEq(arrA, arrB)` pousse Z3 à raisonner sur l'égalité point par point (en instanciant l'axiome d'extensionalité sous le capot). Sans lui, un tableau ne serait qu'une fonction non interprétée quelconque, et `a = b` n'aurait pas de sens calculable. C'est précisément ce qui justifie l'existence d'une **théorie dédiée** des tableaux plutôt qu'un simple encodage par fonction non interprétée (`MkFuncDecl`) : la théorie fournit gratuitement ce axiome d'extensionalité, ainsi que les axiomes read-over-write, là qu'une fonction non interprétée obligerait à tout réécrire à la main.\n\n> **Pour aller plus loin** : la spécification SMT-LIB (smt-lib.org) formalise intégralement ces quatre opérations — `select`, `store`, `const`, et l'extensionalité — et la documentation Z3 (z3prover.github.io/api) détaille leurs équivalents `MkSelect`/`MkStore`/`MkConstArray`.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Deux autres briques de la théorie des tableaux SMT-LIB\n",
+    "\n",
+    "Les axiomes de McCarthy ci-dessus définissent `select` et `store`. La théorie des tableaux du standard SMT-LIB en compte deux autres, qui ne sont pas utilisées dans ce notebook mais qu'il faut connaître pour lire la littérature SMT :\n",
+    "\n",
+    "**Le tableau constant (`const`, ou `K` en SMT-LIB).** C'est un troisième constructeur, à côté de `select`/`store` : `const(v)` désigne le tableau dont **toutes** les positions contiennent la valeur `v`. En C# Microsoft.Z3, cela se crée par `ctx.MkConstArray(ctx.IntSort, ctx.MkInt(0))` — un tableau « entièrement à zéro ». C'est l'outil naturel pour exprimer un **état initial uniforme** : une grille vide (toutes cases à 0), un registre vidé, un buffer initialisé. On pourrait alors écrire l'état initial `[2, 2]` de l'exemple Missionnaires-Cannibales (cell `c5d6e7fe`) de façon plus concise comme `store(store(const(0), 0, 2), 1, 2)` — deux écritures par-dessus un fond uniforme de zéros — plutôt qu'en partant d'un tableau symbolique non interprété.\n",
+    "\n",
+    "**L'extensionalité.** C'est le quatrième axiome : deux tableaux `a` et `b` sont **égaux** si et seulement si ils coïncident sur tout indice —\n",
+    "\n",
+    "$$\n",
+    "a = b \\;\\;\\Longleftrightarrow\\;\\; \\forall i.\\; \\text{select}(a, i) = \\text{select}(b, i)\n",
+    "$$\n",
+    "\n",
+    "Cet axiome est ce qui rend l'égalité entre tableaux **décidable** : écrire `ctx.MkEq(arrA, arrB)` pousse Z3 à raisonner sur l'égalité point par point (en instanciant l'axiome d'extensionalité sous le capot). Sans lui, un tableau ne serait qu'une fonction non interprétée quelconque, et `a = b` n'aurait pas de sens calculable. C'est précisément ce qui justifie l'existence d'une **théorie dédiée** des tableaux plutôt qu'un simple encodage par fonction non interprétée (`MkFuncDecl`) : la théorie fournit gratuitement ce axiome d'extensionalité, ainsi que les axiomes read-over-write, là qu'une fonction non interprétée obligerait à tout réécrire à la main.\n",
+    "\n",
+    "> **Pour aller plus loin** : la spécification SMT-LIB (smt-lib.org) formalise intégralement ces quatre opérations — `select`, `store`, `const`, et l'extensionalité — et la documentation Z3 (z3prover.github.io/api) détaille leurs équivalents `MkSelect`/`MkStore`/`MkConstArray`."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -615,10 +631,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:31.667481Z",
-     "iopub.status.busy": "2026-06-15T17:18:31.667210Z",
-     "iopub.status.idle": "2026-06-15T17:18:31.929378Z",
-     "shell.execute_reply": "2026-06-15T17:18:31.929148Z"
+     "iopub.execute_input": "2026-06-23T13:52:11.450163Z",
+     "iopub.status.busy": "2026-06-23T13:52:11.449964Z",
+     "iopub.status.idle": "2026-06-23T13:52:11.572303Z",
+     "shell.execute_reply": "2026-06-23T13:52:11.572099Z"
     },
     "papermill": {
      "duration": 0.269486,
@@ -888,10 +904,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:31.967984Z",
-     "iopub.status.busy": "2026-06-15T17:18:31.967652Z",
-     "iopub.status.idle": "2026-06-15T17:18:32.239918Z",
-     "shell.execute_reply": "2026-06-15T17:18:32.239683Z"
+     "iopub.execute_input": "2026-06-23T13:52:11.573657Z",
+     "iopub.status.busy": "2026-06-23T13:52:11.573472Z",
+     "iopub.status.idle": "2026-06-23T13:52:11.707947Z",
+     "shell.execute_reply": "2026-06-23T13:52:11.707630Z"
     },
     "papermill": {
      "duration": 0.27958,
@@ -1106,6 +1122,226 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e37ae172",
+   "metadata": {},
+   "source": [
+    "### Exemple 4bis — Le problème complet 3M/3C via Z3.Linq (`CollectionHandling.Array`)\n",
+    "\n",
+    "La version Store ci-dessus ne modélise qu'**une transition** d'un problème *simplifié* (2M/2C) : elle illustre la mécanique `store`/`select`, mais ne **résout pas** le casse-tête. Passons maintenant au **problème classique complet — 3 missionnaires et 3 cannibales** — et résolvons-le **entièrement** avec le DSL Z3.Linq.\n",
+    "\n",
+    "L'idée : représenter toute la **trajectoire** par un champ `int[][] S`, où `S[t] = [M_gauche, C_gauche]` est l'état à l'étape `t`. Avec `DefaultCollectionHandling = CollectionHandling.Array`, le fork Z3.Linq compile ce tableau imbriqué en une **unique théorie des tableaux SMT** (un `ArrayExpr` + des `Select`) — exactement les briques `Select`/`Store` vues plus haut, mais **générées automatiquement** à partir d'expressions LINQ lisibles.\n",
+    "\n",
+    "Le solveur reçoit toutes les contraintes d'un coup (bornes, sécurité sur chaque rive, capacité de la barque, alternance des rives, conditions de départ et d'arrivée) et renvoie une trajectoire complète `[3,3] → … → [0,0]` si elle existe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2ba7fc05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T13:52:11.709358Z",
+     "iopub.status.busy": "2026-06-23T13:52:11.709148Z",
+     "iopub.status.idle": "2026-06-23T13:52:11.898839Z",
+     "shell.execute_reply": "2026-06-23T13:52:11.898636Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Plan de traversée 3M/3C (DSL Z3.Linq, CollectionHandling.Array) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  0 : gauche [3M,3C]  droite [0M,0C]  (barque à gauche)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  1 : gauche [2M,2C]  droite [1M,1C]  (barque à droite)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  2 : gauche [3M,2C]  droite [0M,1C]  (barque à gauche)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  3 : gauche [3M,0C]  droite [0M,3C]  (barque à droite)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  4 : gauche [3M,1C]  droite [0M,2C]  (barque à gauche)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  5 : gauche [1M,1C]  droite [2M,2C]  (barque à droite)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  6 : gauche [2M,2C]  droite [1M,1C]  (barque à gauche)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  7 : gauche [0M,2C]  droite [3M,1C]  (barque à droite)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  8 : gauche [0M,3C]  droite [3M,0C]  (barque à gauche)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape  9 : gauche [0M,1C]  droite [3M,2C]  (barque à droite)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape 10 : gauche [0M,2C]  droite [3M,1C]  (barque à gauche)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Étape 11 : gauche [0M,0C]  droite [3M,3C]  (barque à droite)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "11 traversées — solution optimale du problème classique 3M/3C.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple 4bis : Missionnaires-Cannibales COMPLET (3M/3C) via le DSL Z3.Linq.\n",
+    "// La trajectoire entière est un champ int[][] : S[t] = [M_gauche, C_gauche] à l'étape t.\n",
+    "// CollectionHandling.Array compile ce tableau imbriqué en une théorie des tableaux Z3\n",
+    "// (un ArrayExpr + des Select) - les mêmes briques que les exemples 1-4, mais générées\n",
+    "// automatiquement à partir d'expressions LINQ lisibles.\n",
+    "public class Crossing\n",
+    "{\n",
+    "    public int[][] S { get; set; } = new int[12][];\n",
+    "    public Crossing() { for (int t = 0; t < 12; t++) S[t] = new int[2]; }  // init chaque ligne (cf SudokuGrid)\n",
+    "}\n",
+    "\n",
+    "int K = 12;    // 12 états => 11 traversées\n",
+    "int N = 3;     // 3 missionnaires, 3 cannibales\n",
+    "int BOAT = 2;  // capacité de la barque\n",
+    "\n",
+    "using (var ctx = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array })\n",
+    "{\n",
+    "    var th = ctx.NewTheorem<Crossing>();\n",
+    "\n",
+    "    // Bornes + sécurité sur chaque rive, à chaque étape\n",
+    "    for (int t = 0; t < K; t++)\n",
+    "    {\n",
+    "        int t1 = t;\n",
+    "        th = th.Where(g => g.S[t1][0] >= 0 && g.S[t1][0] <= N && g.S[t1][1] >= 0 && g.S[t1][1] <= N);\n",
+    "        th = th.Where(g => g.S[t1][0] == 0 || g.S[t1][0] >= g.S[t1][1]);                    // rive gauche sûre\n",
+    "        th = th.Where(g => (N - g.S[t1][0]) == 0 || (N - g.S[t1][0]) >= (N - g.S[t1][1]));   // rive droite sûre\n",
+    "    }\n",
+    "\n",
+    "    // Conditions de bord : tout le monde à gauche au départ, tout le monde traversé à l'arrivée\n",
+    "    th = th.Where(g => g.S[0][0] == N && g.S[0][1] == N);\n",
+    "    th = th.Where(g => g.S[K - 1][0] == 0 && g.S[K - 1][1] == 0);\n",
+    "\n",
+    "    // Transitions : la barque alterne avec la parité de t ; 1 à BOAT personnes par traversée\n",
+    "    for (int t = 0; t < K - 1; t++)\n",
+    "    {\n",
+    "        int a = t, b = t + 1;\n",
+    "        if (t % 2 == 0)  // aller gauche -> droite : les compteurs de gauche baissent\n",
+    "        {\n",
+    "            th = th.Where(g => g.S[b][0] <= g.S[a][0] && g.S[b][1] <= g.S[a][1]);\n",
+    "            th = th.Where(g => (g.S[a][0] - g.S[b][0]) + (g.S[a][1] - g.S[b][1]) >= 1);\n",
+    "            th = th.Where(g => (g.S[a][0] - g.S[b][0]) + (g.S[a][1] - g.S[b][1]) <= BOAT);\n",
+    "        }\n",
+    "        else  // retour droite -> gauche : les compteurs de gauche remontent\n",
+    "        {\n",
+    "            th = th.Where(g => g.S[b][0] >= g.S[a][0] && g.S[b][1] >= g.S[a][1]);\n",
+    "            th = th.Where(g => (g.S[b][0] - g.S[a][0]) + (g.S[b][1] - g.S[a][1]) >= 1);\n",
+    "            th = th.Where(g => (g.S[b][0] - g.S[a][0]) + (g.S[b][1] - g.S[a][1]) <= BOAT);\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    var sol = th.Solve();\n",
+    "    if (sol == null)\n",
+    "    {\n",
+    "        Console.WriteLine(\"UNSAT : aucune trajectoire trouvée.\");\n",
+    "    }\n",
+    "    else\n",
+    "    {\n",
+    "        Console.WriteLine(\"=== Plan de traversée 3M/3C (DSL Z3.Linq, CollectionHandling.Array) ===\");\n",
+    "        for (int t = 0; t < K; t++)\n",
+    "        {\n",
+    "            int mL = sol.S[t][0], cL = sol.S[t][1];\n",
+    "            Console.WriteLine($\"Étape {t,2} : gauche [{mL}M,{cL}C]  droite [{N - mL}M,{N - cL}C]  ({(t % 2 == 0 ? \"barque à gauche\" : \"barque à droite\")})\");\n",
+    "        }\n",
+    "        Console.WriteLine($\"\\n{K - 1} traversées — solution optimale du problème classique 3M/3C.\");\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3535e541",
+   "metadata": {},
+   "source": [
+    "### Interprétation 4bis — `int[][]` ⇒ théorie des tableaux, et la montée en puissance du DSL\n",
+    "\n",
+    "**Sortie obtenue** : une trajectoire complète en **11 traversées**, de `[3M,3C]` (tout à gauche) à `[0M,0C]` (tout traversé). C'est le nombre **optimal** de traversées pour le problème classique 3M/3C.\n",
+    "\n",
+    "**Ce que le moteur a fait** :\n",
+    "1. Le champ `int[][] S` (12 états × 2 compteurs) est compilé par `CollectionHandling.Array` en **une seule variable de tableau Z3** indexée par `Select` — la même théorie des tableaux que les exemples 1 à 4, mais ici **dérivée du DSL** au lieu d'être écrite à la main.\n",
+    "2. Les **contraintes structurelles** (bornes `0 ≤ · ≤ N`, sécurité `M=0 ∨ M≥C` sur chaque rive, capacité `1 ≤ Δ ≤ 2`, alternance par la parité de `t`) s'expriment toutes en **LINQ pur** — `Where(g => g.S[t][0] >= g.S[t][1])` — sans aucun `MkSelect`/`MkImplies`/`MkITE` manuel.\n",
+    "3. Les conditions de bord (`S[0]=[3,3]`, `S[K-1]=[0,0]`) et le sens de traversée alterné (compteurs décroissants à l'aller, croissants au retour) suffisent à contraindre toute la trajectoire.\n",
+    "\n",
+    "| | Exemple 4 (Store brut) | Exemple 4bis (DSL `int[][]`) |\n",
+    "|--|------------------------|-------------------------------|\n",
+    "| Problème | 2M/2C, **une** transition | 3M/3C **complet**, 11 traversées |\n",
+    "| API | `MkStore`/`MkSelect`/`MkImplies` à la main | `Where(...)` LINQ, théorie des tableaux générée |\n",
+    "| Contraintes | ~30 appels bas niveau | une boucle `for` de `Where` lisibles |\n",
+    "| Ce qu'on voit | la mécanique `store` | **la capacité du solveur** sur un vrai casse-tête |\n",
+    "\n",
+    "**Leçon** : la théorie des tableaux brute (`Store`/`Select`) reste indispensable pour *comprendre* ce qui se passe sous le capot ; mais dès qu'on attaque un **vrai problème de planification multi-étapes**, le DSL `CollectionHandling.Array` exprime la même chose de façon **déclarative et concise**, en laissant Z3 faire le travail. C'est le chemin **raw → LINQ** : on apprend les briques, puis on monte d'un cran d'abstraction sans rien perdre en puissance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e7f8a9b0",
    "metadata": {
     "papermill": {
@@ -1140,17 +1376,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "f8a9b0c1",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:32.280220Z",
-     "iopub.status.busy": "2026-06-15T17:18:32.279879Z",
-     "iopub.status.idle": "2026-06-15T17:18:32.548111Z",
-     "shell.execute_reply": "2026-06-15T17:18:32.547899Z"
+     "iopub.execute_input": "2026-06-23T13:52:11.900170Z",
+     "iopub.status.busy": "2026-06-23T13:52:11.899906Z",
+     "iopub.status.idle": "2026-06-23T13:52:12.019412Z",
+     "shell.execute_reply": "2026-06-23T13:52:12.019017Z"
     },
     "papermill": {
      "duration": 0.275564,
@@ -1475,17 +1711,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c1d2e3f4",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:32.597492Z",
-     "iopub.status.busy": "2026-06-15T17:18:32.597217Z",
-     "iopub.status.idle": "2026-06-15T17:18:32.811866Z",
-     "shell.execute_reply": "2026-06-15T17:18:32.811652Z"
+     "iopub.execute_input": "2026-06-23T13:52:12.020647Z",
+     "iopub.status.busy": "2026-06-23T13:52:12.020456Z",
+     "iopub.status.idle": "2026-06-23T13:52:12.136145Z",
+     "shell.execute_reply": "2026-06-23T13:52:12.135839Z"
     },
     "papermill": {
      "duration": 0.226504,
@@ -1647,17 +1883,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "f4a5b6c7",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:32.861689Z",
-     "iopub.status.busy": "2026-06-15T17:18:32.861335Z",
-     "iopub.status.idle": "2026-06-15T17:18:32.942585Z",
-     "shell.execute_reply": "2026-06-15T17:18:32.942347Z"
+     "iopub.execute_input": "2026-06-23T13:52:12.137383Z",
+     "iopub.status.busy": "2026-06-23T13:52:12.137199Z",
+     "iopub.status.idle": "2026-06-23T13:52:12.176581Z",
+     "shell.execute_reply": "2026-06-23T13:52:12.176399Z"
     },
     "papermill": {
      "duration": 0.091128,
@@ -1725,17 +1961,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "b6c7d8e9",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:32.984155Z",
-     "iopub.status.busy": "2026-06-15T17:18:32.983592Z",
-     "iopub.status.idle": "2026-06-15T17:18:33.059834Z",
-     "shell.execute_reply": "2026-06-15T17:18:33.059143Z"
+     "iopub.execute_input": "2026-06-23T13:52:12.178433Z",
+     "iopub.status.busy": "2026-06-23T13:52:12.178017Z",
+     "iopub.status.idle": "2026-06-23T13:52:12.208083Z",
+     "shell.execute_reply": "2026-06-23T13:52:12.207658Z"
     },
     "papermill": {
      "duration": 0.093481,
@@ -1805,17 +2041,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "d8e9fa0b",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T17:18:33.093239Z",
-     "iopub.status.busy": "2026-06-15T17:18:33.092931Z",
-     "iopub.status.idle": "2026-06-15T17:18:33.137778Z",
-     "shell.execute_reply": "2026-06-15T17:18:33.137374Z"
+     "iopub.execute_input": "2026-06-23T13:52:12.209304Z",
+     "iopub.status.busy": "2026-06-23T13:52:12.209035Z",
+     "iopub.status.idle": "2026-06-23T13:52:12.232795Z",
+     "shell.execute_reply": "2026-06-23T13:52:12.232630Z"
     },
     "papermill": {
      "duration": 0.054047,


### PR DESCRIPTION
## Résumé

Premier atome de la deep-queue **#1206 Z3.Linq C#** (dispatch ai-01) : élever le DSL Z3.Linq au rang de **chemin principal** dans `SMT/Z3/03_Array_Theory.ipynb`, en faisant valoir la vraie capacité du moteur.

Le notebook avait un déséquilibre raw≫DSL : l'**Exemple 4** (Missionnaires-Cannibales) ne modélisait qu'**une transition** d'un problème *simplifié* 2M/2C via `MkStore`/`MkSelect` bas niveau, et admettait lui-même « la résolution complète [2,2] → [0,0] nécessite davantage d'étapes » (cas dégénéré, cf [sota-not-workaround §Prong B](.claude/rules/sota-not-workaround.md)).

Ce PR **ajoute** un **Exemple 4bis** qui résout le **casse-tête classique COMPLET 3 missionnaires / 3 cannibales** (11 traversées, optimal) via le DSL :
- toute la trajectoire est un champ `int[][] S` (`S[t] = [M_gauche, C_gauche]`) ;
- `DefaultCollectionHandling = CollectionHandling.Array` compile ce tableau imbriqué en **une théorie des tableaux SMT** (un `ArrayExpr` + des `Select`) — les mêmes briques que les exemples 1-4, mais **générées depuis du LINQ lisible** ;
- contraintes (bornes, sécurité par rive, capacité barque, alternance par parité de `t`, conditions de bord) toutes exprimées en `Where(...)` LINQ pur, zéro `MkSelect`/`MkImplies`/`MkITE` manuel.

## Anti-régression

- L'**Exemple 4 raw 2M/2C Store reste intact** (chemin pédagogique raw → LINQ). ADD, pas replace.
- Tous les exemples 1-6 et exercices 1-3 originaux conservés (32 cellules, +3 ajoutées).

## Validation (H.1/C.2)

- Re-exécuté end-to-end via `jupyter nbconvert --execute` (kernel `.net-csharp`, depuis le dossier `SMT/Z3/` pour les `#r` relatifs).
- **11 cellules code, 0 erreur, 0 cellule sans output/exec_count.**
- Sortie réelle de l'Exemple 4bis = plan de traversée valide en 11 étapes `[3,3] → … → [0,0]`, sécurité respectée sur chaque rive à chaque étape.
- Scan outputs : **0 fuite** (chemin machine / secret).
- Catalogue **non touché** (byte-identique à main).
- ~12 exercices déjà présents (≥3 OK).

See #1206