### PR TITLE
fix(prover): #1453 ban consecutive compile() without edit (forensic P1+P2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
@@ -85,6 +85,12 @@ INTERDIT (verifie toujours dans FAILED ATTEMPTS):
 - Repeter une tactique deja en echec (meme texte exact)
 - Utiliser sorry sur du code metier existant (anti-regression)
 - Modifier le theoreme cible ou ses hypotheses pour faire passer la preuve
+- REGLE HARD — NE JAMAIS appeler compile() deux fois de suite sans avoir edite le
+  fichier entre les deux appels. compile() est un VERIFICATEUR D'EDITION, pas un
+  outil de sondage d'etat. Si le signal STAGNATION apparait dans le resultat de
+  compile(), tu DOIS editer le fichier (file_replace_sorry / file_replace_lines /
+  file_insert_lines) avant de rappeler compile(). Appels consecutifs sans edit =
+  budget brule pour zero information nouvelle. Forensic #1453 2026-06-23.
 
 FIX PATTERNS GENERAUX (heuristiques, pas hard-codes):
 - "type mismatch" → caster (norm_cast / push_cast / Nat.cast_*) ou ajouter `show`

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -161,7 +161,9 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         "actual_iterations": result.get("iterations") if isinstance(result, dict) else None,
         "original_sorry": original_sorry,
         "final_sorry": final_sorry,
+        # Convention: sorry_delta = final - original. POSITIF = REGRESSION (plus de sorry), NEGATIF = progres. Oppose a tools.py (original - current). Forensic #1453 2026-06-23.
         "sorry_delta": final_sorry - original_sorry,
+        "sorry_reduction": original_sorry - final_sorry,  # positif = progres (lecture non ambigue)
         "elapsed_s": round(elapsed, 1),
         "result": result,
         "trace_file": trace_path,


### PR DESCRIPTION
## Summary
Forensic ping-pong on the Lean prover harness (Epic #1453, 2026-06-23) found its dominant pathology: the TacticAgent treats `compile()` as a status poller. On a verified Bondareva trace it called `compile()` 6x consecutively with **zero** file edits in between (116s = 32.6% of the run wasted). Across **24 post-baseline runs there were ZERO real sorry reductions**.

## Changes
- **P1 (`instructions.py`)** - HARD directive in `TACTIC_AGENT_INSTRUCTIONS` forbidding back-to-back `compile()` without an intervening file edit. `compile()` is an edit-verifier, not a status poller; on `STAGNATION` the agent must edit before re-compiling.
- **P2 (`run_prover_bg.py`)** - document the `sorry_delta` sign convention (positive = regression, opposite of `tools.py`) and add an unambiguous `sorry_reduction` companion field (positive = progress).

## Evidence
- `prover/traces/multi_BONDAREVA_CORE_WITNESS_openrouter.json` - 6 consecutive `compile()` calls, streak delta0 1->6, no edits between 228s and 344s.
- Forensic report (prover-forensic agent, 2026-06-23).

## Validation
A BG prover run on a previously-polling target will confirm the compile-polling episodes disappear. +8 lines, no change to the compilation pathway, no catalog/submodule touched.

See #1453

Generated with Claude Code