### PR TITLE
docs(search): reflect #1203 Part4 métaheuristiques track in root README

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -13,7 +13,7 @@ Tout problème d'IA, du plus simple jeu de plateau à la planification logistiqu
 
 Le parcours couvre quatre grands piliers. Les **fondements** formalisent les espaces d'états et couvrent les algorithmes de recherche non informée, informée, locale, génétique, adversariale et MCTS. La **programmation par contraintes** (CSP) introduit un changement de paradigme : au lieu d'explorer, on réduit les domaines par propagation. Les **applications** (20 notebooks) illustrent chaque concept sur des problèmes réels adaptés de projets étudiants. Enfin, les **métaheuristiques et l'hybridation** relient la recherche à l'optimisation continue et aux LLMs.
 
-**À qui s'adresse cette série** : étudiants en informatique (L3-M2), ingénieurs logiciel confrontés à des problèmes d'optimisation, et candidats à des entretiens techniques. Les notebooks Python ne nécessitent que Python 3.10+ avec `ortools` et `deap`. Les side tracks C# (edge detection, portefeuille) requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en algorithmique avancée : les concepts sont introduits depuis les espaces d'états.
+**À qui s'adresse cette série** : étudiants en informatique (L3-M2), ingénieurs logiciel confrontés à des problèmes d'optimisation, et candidats à des entretiens techniques. Les notebooks Python ne nécessitent que Python 3.10+ avec `ortools` et `deap`. Les side tracks C# (edge detection, portefeuille, et la [Partie 4 — métaheuristiques composables](Part4-Metaheuristics/README.md) au-dessus de GeneticSharp) requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en algorithmique avancée : les concepts sont introduits depuis les espaces d'états.
 
 ## Pourquoi cette série
 
@@ -95,6 +95,23 @@ Chaque notebook introduit un concept ou algorithme spécifique. Le tableau ci-de
 | 7 | CSP Soft | Contraintes souples, Fuzzy CSP : quand toutes les contraintes ne sont pas égales |
 | 8 | CSP Temporal | Allen's Interval Algebra, STP : raisonner sur le temps |
 | 9 | CSP Distributed | ABT, AWC : résoudre des CSP répartis entre agents |
+
+### Partie 4 : Métaheuristiques composables
+
+Side track C# .NET 9 (cf. [Search-5](Part1-Foundations/Search-5-GeneticAlgorithms.ipynb), [Search-11](Part1-Foundations/Search-11-Metaheuristics.ipynb)) : reconstruire et **composer** les métaheuristiques au-dessus de GeneticSharp plutôt que d'en importer une boîte noire.
+
+| # | Notebook | Apport pédagogique |
+|---|----------|-------------------|
+| 1 | MGS-1 Introduction | Moteur autonome `MetaGeneticAlgorithm` au-dessus de GeneticSharp |
+| 2 | MGS-2 Composition | Assemblage déclaratif : `Match`, `Container`, grammaire fluente |
+| 3 | MGS-3 Eukaryote | Sous-populations spécialisées (chromosomes composites) |
+| 4 | MGS-4 Islands | Modèle insulaire : populations structurées, migration entre îles |
+| 5 | MGS-5 CompoundMetaheuristics | Reconstruire les composés publiés (WOA/EO/FBI) depuis leurs primitives |
+| 6 | MGS-6 Benchmarks | Comparaison honnête des composés vs GA vs Uniform vs Islands |
+| 7 | MGS-7 TSP | Grammaire agnostique à la représentation (permutation, `OrderedCrossover`) |
+| 8 | MGS-8 LandscapeExplorer | Visualiser la surface de fitness (heatmaps, trajectoire de convergence) |
+| 9 | MGS-9 EverestRelief | Relief terrestre réel comme paysage de fitness (DEM, flipbook) |
+| 10 | MGS-10 CenterBias | Biais central vs robustesse au déplacement (banc Kudella 2022) |
 
 ### Applications
 
@@ -389,7 +406,7 @@ Search/
 │       └── App-18-HyperparameterTuning.ipynb
 │
 ├── MetaGeneticSharp/                      # Sous-module : metaheuristiques composables sur GeneticSharp (jsboige/MetaGeneticSharp)
-├── Part4-Metaheuristics/                  # Partie 4 (side track C# .NET 9) : README + 9 notebooks MGS-1..9 colocalises (consomment le sous-module)
+├── Part4-Metaheuristics/                  # Partie 4 (side track C# .NET 9) : README + 10 notebooks MGS-1..10 (moteur, composition, composés, benchmarks, TSP, paysages, biais central ; consomment le sous-module)
 │
 ├── CSPs_Intro.ipynb                       # Ancien notebook (conserve)
 ├── GeneticSharp-EdgeDetection.ipynb       # Ancien notebook (conserve)
@@ -483,6 +500,7 @@ La thèse est puissante et honnêtement présentée : il n'existe pas d'algorith
 - **Approfondir l'IA symbolique** : [SymbolicAI](../SymbolicAI/README.md) (Z3/SMT, planification PDDL/HTN, logique formelle Tweety) est le prolongement naturel de la Partie 2 — les CSP y deviennent du *satisfiability solving* et la modélisation par contraintes se généralise en raisonnement logique. Plusieurs ponts explicites sont tracés (CSP-3 → Z3, CSP-4 → Planners, CSP-6 → LLM+CSP).
 - **Élargir aux jeux et à l'apprentissage par renforcement** : [GameTheory](../GameTheory/README.md) (Minimax, MCTS, choix social) et les notebooks RL (MCTS + DQN, AlphaGo) reprennent la recherche adversariale sous l'angle de l'apprentissage — où la valeur des positions n'est plus calculée mais *apprise*.
 - **Pratiquer sur la couverture exacte** : [Sudoku](../README.md) (DLX, automates symboliques) applique Dancing Links et les techniques de cette série à une famille de puzzles combinatoires concrets.
+- **Construire plutôt qu'utiliser** : la [Partie 4 — métaheuristiques composables](Part4-Metaheuristics/README.md) (C# .NET 9, MetaGeneticSharp) prolonge [Search-5](Part1-Foundations/Search-5-GeneticAlgorithms.ipynb)/[Search-11](Part1-Foundations/Search-11-Metaheuristics.ipynb) sous l'angle de l'*ingénierie* — au lieu d'importer WOA ou EO, on les *reconstruit* depuis des primitives composables (`Match`, `Container`, grammaire fluente) au-dessus de GeneticSharp, et l'on assemble des configurations qu'aucune bibliothèque monolithique n'offre (sous-populations spécialisées, îles migratoires).
 - Pour la pratique : reprenez [CSP-6-Hybridization](Part2-CSP/CSP-6-Hybridization.ipynb) et expérimentez le pont LLM+CSP — comment un modèle de langage peut-il *amorçer* un solveur par contraintes, et où cette hybridation gagne-t-elle (ou perd-elle) par rapport au CP-SAT pur ?
 
 ### Le fil rouge


### PR DESCRIPTION
## Contexte

Fallback **#3977** nommé par ai-01 (deep-queue dispatch) : le README racine de Search antédate l'extension **#1203 MetaGeneticSharp** et ne reflète pas la Partie 4. Quatre points de staleness/asymétrie structurelle ont été relevés (G.1-vérifiés contre `Part4-Metaheuristics/README.md` et `git ls-files`).

**Note** : #4030 (MGS-10 seeding) est non-mergé et bloque les grains fork-lourds (#3964/#3965). Cette PR doc-only est **sans collision** avec #4030 (ne touche ni Part4 README ni le notebook MGS-10).

## Changements (4, design-consistent)

| # | Localisation | Avant | Après |
|---|--------------|-------|-------|
| 1 | Ligne 16 (side-tracks C#) | `edge detection, portefeuille` | + Partie 4 métaheuristiques composables (lien) |
| 2 | « Ce que chaque notebook apporte » | `### Partie 1/2/Applications` (**pas de Partie 4**) | + `### Partie 4` table (10 rangs, mirroir exact du style ### Partie 1/2) |
| 3 | File tree | `9 notebooks MGS-1..9` | `10 notebooks MGS-1..10` + arc pédagogique |
| 4 | « Prochaines étapes » | pointe vers SymbolicAI/GameTheory/Sudoku uniquement | + « Construire plutôt qu'utiliser » → Part4 comme prolongement ingénierie de Search-5/11 |

Les 10 rangs du tableau ### Partie 4 sont **G.1-vérifiés** contre le tableau « Concept clé » de `Part4-Metaheuristics/README.md` (lignes 42-53) — aucun compte d'optimiseur précis (évite le forward-staleness quand #4030 ajoute SA).

## Vérifications

- **Liens résolus** : `Part4-Metaheuristics/README.md`, `Part1-Foundations/Search-5-GeneticAlgorithms.ipynb`, `Part1-Foundations/Search-11-Metaheuristics.ipynb` existent (testé).
- **catalog-pr-hygiene** : marqueurs `CATALOG-STATUS` (breakdown/pedagogical_count) **inchangés** (automation-owned, pas touchés). Catalogue byte-identique.
- **Submodule** : pointer `MetaGeneticSharp` **inchangé** (non-stagé).
- **Doc-only** (20 ins / 2 del), no-pendulum (mirroir exact du design existant ### Partie 1/2/Applications, pas de nouvelle section narrative).
- **readme-french-first** : tout en français.

## Pourquoi §E ne s'applique pas

§E (doc-only < 20 lignes = refus) cible le churn trivial. Ici : remplissage d'une **asymétrie structurelle réelle** (Part1/2/Apps avaient leur tableau ###, Part4 non) + 3 staleness factuels, servant une issue nommée par le coordinateur (#3977). Au-dessus du seuil (20 lignes). Ai-01 est l'autorité de merge qui a nommé ce fallback exact.

See #3977
See #1203