### PR TITLE
docs(qc): align projects/README.md to #1630 verified baseline state

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/README.md
@@ -60,6 +60,36 @@ Voir [STRATEGIES_DETAIL.md](STRATEGIES_DETAIL.md#qc-strategy-library-clones-avan
 
 ---
 
+## État vérifié sous frais réels (#1630, 2018-2025)
+
+> **Caveat important.** Les Sharpes du tableau « Robuste » ci-dessus sont des valeurs **catalogue (pré-frais, fenêtres variables)**. La campagne #1630 a re-vérifié 36+ de ces stratégies sous **frais IBKR réels** (`PercentFeeModel` explicite) sur une **fenêtre alignée 2018-2025**. Plusieurs stars du catalogue **s'effondrent** dans ces conditions — le label « Robuste » ci-dessus ne préjuge pas de la robustesse sous frais réels.
+
+### Effondrements confirmés (catalogue → aligné 2018-2025)
+
+| Stratégie | Sharpe catalogue | Sharpe aligné | Delta | Cause |
+|-----------|------------------|---------------|-------|-------|
+| HighBookToMarketFScore | 2.09 | **0.41** | -80% | Value/factor écrasé par les frais réels, MaxDD -60% |
+| PuppiesOfTheDow | 1.99 | **0.30** | -85% | Value/factor + frais réels |
+| ML-Trend-Scanning | 0.66 | **0.33** | -50% | Rebalancement quotidien SPY/TLT/GLD multi-actifs = turnover écrasé |
+| AllWeather | 0.67 | **0.47** | -30% | Sleeve bonds/gold multi-actifs = friction de panier |
+
+### Leaders vérifiés alignés (backbone no-ML)
+
+| Stratégie | Sharpe aligné | PSR | Caveat |
+|-----------|---------------|-----|--------|
+| Framework_Composite_EMATrend | **0.611** | 19.8% | Sleeve EMA 100% Mag7 → biais de survivorship ; Sharpe le plus haut mais constitution concentrée |
+| composite-c2-equityfactor | **0.574** | 25.8% | **Constitution la plus robuste** (25 actions factor-diversifiées) ; tient juste au-dessus du seuil |
+
+> **TrendFollowing** (catalogue 1.072) n'est **pas reproductible** depuis le `main.py` du dépôt : le baseline-clone (2015-2024, IBKR) donne un Sharpe bien inférieur (~0.36-0.41, PSR < 9%). Le 1.072 provient d'un état du code cloud antérieur — à citer avec ce caveat (diagnostic finding #18).
+
+### Le discriminateur (leçon durable)
+
+La résistance aux frais **n'est pas** l'asset-class ni ML-vs-indicateur : c'est le **realized-turnover** = fréquence × taille par trade × homogénéité des frais du panier. Un composite equity-only fee-homogeneous en rebalancement mensuel (**c2 0.574**) tient là où un multi-asset rotationnel (**AllWeather 0.47**) s'effondre — même architecture, c'est l'univers qui décide.
+
+Détail complet, comparatifs best-vs-aligned et diagnostics par stratégie : [docs/qc/qc-comparative-backtests.md](../../../docs/qc/qc-comparative-backtests.md) (See #1630).
+
+---
+
 ## Structure d'un Projet
 
 ```


### PR DESCRIPTION
## Scope

Sub-task of **#3976** (part of #3973 — *READMEs feuilles QuantConnect*, owner po-2024:CoursIA). Aligns `projects/README.md` to the #1630 verified-baseline state.

## Problem

The "Robuste (Sharpe > 0.5)" table in `projects/README.md` lists **catalog (pre-fee, variable-window) Sharpes**. The #1630 campaign verified 36+ of these strategies under **real IBKR fees** (`PercentFeeModel` explicit) on an **aligned 2018-2025** window, proving several "Robuste" entries **collapse** — e.g. `AllWeather` 0.67→0.47 and `ML-Trend-Scanning` 0.66→0.33 are still labeled "Robuste" in the current table. The README thus misrepresents the verified state.

## Change

Add a single new section **"État vérifié sous frais réels (#1630, 2018-2025)"** after the Performance Summary:

- A caveat that the "Robuste" Sharpes above are catalog (pre-fee) values.
- Verified collapses table (HighBookToMarketFScore 2.09→0.41, PuppiesOfTheDow 1.99→0.30, ML-Trend-Scanning 0.66→0.33, AllWeather 0.67→0.47).
- Verified aligned leaders table (Framework_Composite_EMATrend 0.611 PSR 19.8% w/ Mag7 survivorship caveat; composite-c2-equityfactor 0.574 PSR 25.8% — most robust constitution).
- TrendFollowing non-reproducibility caveat (catalog 1.072 not reproducible from repo `main.py`; baseline-clone ~0.36-0.41, PSR < 9%).
- The realized-turnover discriminator one-liner.
- Link to the canonical catalog.

## Properties

- **Additive only** — 30 insertions, 0 deletions. The existing "Robuste" table is **preserved verbatim** (anti-régression; no risky row-by-row Sharpe rewrite). The new section caveats it rather than rewriting it.
- **G.1-grounded** — every cited figure verified against the canonical source `docs/qc/qc-comparative-backtests.md` (catalog rows + Tier-1 findings).
- **No `CATALOG-STATUS` marker touched** (this README has none; the catalog-cron is unaffected).
- **FR-first** (matches the surrounding FR prose; #3976 constraint).
- **No collision** with PR #4067 (ML-Training-Pipeline/CURRICULUM.md) or #4063 (qc-comparative-backtests.md) — different file.

## Note for reviewer

More QC sub-series READMEs remain for #3973/#3976 (e.g. STRATEGIES_DETAIL.md, docs/qc_strategies_catalog.md alignment) — future atomic PRs, one per sub-series. This PR is scoped to `projects/README.md` only.

See #3973, #1630
