### PR TITLE
docs(qc): align QUICK_TOUR + STRATEGIES_DETAIL to #1630 verified state

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
+++ b/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
@@ -1,14 +1,16 @@
 # QuantConnect AI Trading - Quick Tour
 
-**95+ strategies backtested | 51 notebooks Python | 20 patterns confirmes | Framework composite Sharpe 1.16**
+**95+ strategies backtested | 51 notebooks Python | 20 patterns confirmes | Composite robuste (TrendWeather Sharpe aligné 0.95)**
 
 Cette section contient un parcours complet de trading algorithmique sur **QuantConnect LEAN**, du debutant au deploiement live. Tout est executable gratuitement sur le cloud QC.
+
+> **Lecture vérifiée sous frais réels (#1630, 2018-2025).** Les Sharpes « catalogue » ci-dessous sont **pré-frais, fenêtres variables** ; elles ne résistent pas toutes à un backtest honnête sous frais IBKR réels sur une fenêtre alignée 2018-2025. Cas emblématique : **EMA-Cross-Alpha** passe de Sharpe catalogue **0.996 à -0.010 aligné** (PSR 0.5%) = overfitting sévère d'un backtest court, **pas** un top performer. Les vrais leaders vérifiés alignés : **LongShortHarvest 1.64** (PSR 98.7%, le plus robuste), **TrendWeather 0.948** (composite qui tient, PSR 56.6%), **EMATrend 0.611** / **composite-c2 0.574** (backbone no-ML). Catalogue complet + diagnostics par stratégie : [docs/qc/qc-comparative-backtests.md](../../docs/qc/qc-comparative-backtests.md) (See #1630).
 
 ## 5 arrets pour comprendre notre travail
 
 1. **[Meilleure strategie](projects/Framework_Composite_TrendWeather/)** — Composite TrendStocks + AllWeather (Sharpe 1.156, CAGR 27.4%). Architecture Algorithm Framework modulaire : AlphaModel + PortfolioConstruction + Execution.
 
-2. **[Catalogue strategies](docs/qc_strategies_catalog.md)** — 95+ projets organises par categorie (Alpha, Trend Following, ML/RL, Composites). Top performers : Long-Short Harvest (Sharpe 1.505), EMA-Cross-Alpha (0.996), TrendWeather Composite (1.156).
+2. **[Catalogue strategies](docs/qc_strategies_catalog.md)** — 95+ projets organises par categorie (Alpha, Trend Following, ML/RL, Composites). Top performers vérifiés alignés (#1630) : Long-Short Harvest (Sharpe **1.64**, PSR 98.7%), TrendWeather Composite (**0.948**, PSR 56.6%), EMATrend (**0.611**).
 
 3. **[Patterns confirmes](../../docs/quantconnect.md)** — 20 patterns valides sur 30+ iterations (risk-adjusted momentum, skip-month, stop-loss -8/-12%, monthly rebalancing, anti-overfitting) et 10 anti-patterns critiques (SPY Parking, backtests courts, yfinance != QC cloud).
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/STRATEGIES_DETAIL.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/STRATEGIES_DETAIL.md
@@ -2,6 +2,19 @@
 
 Descriptions par catégorie des 116 projets de trading algorithmique. Pour le tableau de performance résumé, voir [README.md](README.md).
 
+> **Lecture vérifiée sous frais réels (#1630, 2018-2025).** Les Sharpes ci-dessous sont des valeurs **catalogue (pré-frais, fenêtres variables)**. La campagne #1630 a re-vérifié 36+ stratégies sous frais IBKR réels sur une fenêtre alignée 2018-2025 — plusieurs s'effondrent, d'autres tiennent :
+
+| Stratégie | Sharpe catalogue | Sharpe aligné | Verdict |
+|-----------|------------------|---------------|---------|
+| HighBookToMarketFScore | 2.09 | **0.41** | effondrement -80% (MaxDD -60%) |
+| PuppiesOfTheDow | 1.99 | **0.30** | effondrement -85% |
+| ML-Trend-Scanning | 0.66 | **0.33** | effondrement -50% |
+| AllWeather | 0.67 | **0.47** | dégradation -30% |
+| LongShortHarvest | 3.39 | **1.64** | tient (PSR 98.7%, le plus robuste) |
+| TrendWeather | 1.16 | **0.948** | tient (PSR 56.6%, meilleur composite) |
+
+Leaders vérifiés alignés (backbone no-ML) : **EMATrend 0.611** / **composite-c2 0.574**. Discriminateur : la résistance aux frais dépend du *realized-turnover* (fréquence × taille par trade × homogénéité des frais du panier), pas de l'asset-class. Catalogue complet + comparatifs best-vs-aligned + diagnostics par stratégie : [docs/qc/qc-comparative-backtests.md](../../../docs/qc/qc-comparative-backtests.md) (See #1630).
+
 ## EMA Crossover (Débutant)
 
 - **EMA-Cross-Crypto** : Long BTCUSDT quand EMA20 > EMA50 ET BTC > SMA200 (filtre bull). Trailing stop 10%, position 80%. Binance Cash, daily.


### PR DESCRIPTION
## Scope

Sub-task of **#3976** (part of #3973 — *READMEs feuilles QuantConnect*, owner po-2024:CoursIA). Aligns two visitor/catalog-facing QC docs to the #1630 verified-baseline state.

## Problem

Both docs presented **catalog (pre-fee, variable-window) Sharpes** as if current, including a materially misleading claim:

- **QUICK_TOUR.md** "top performers" line cited **EMA-Cross-Alpha (Sharpe 0.996)** as a top performer. #1630 proved EMA-Cross-Alpha **collapses to -0.010 aligned** (PSR 0.5%, "severe period overfitting") — it is the overfitting *cautionary tale*, not a top performer. The headline also advertised "Framework composite Sharpe 1.16".
- **STRATEGIES_DETAIL.md** QC Library clones table lists LongShortHarvest **3.39**, HighBookToMarketFScore **2.09**, PuppiesOfTheDow **1.99** — catalog Sharpes that #1630 proved collapse to 1.64 / 0.41 / 0.30.

## Changes

- **QUICK_TOUR.md** (4 ins / 2 del):
  - Headline "Framework composite Sharpe 1.16" → "Composite robuste (TrendWeather Sharpe aligné 0.95)".
  - Added a `#1630` caveat box framing catalog Sharpes as pre-fee, citing the EMA-Cross-Alpha 0.996→-0.010 collapse and the real aligned leaders.
  - Fixed the "top performers" line: EMA-Cross-Alpha → verified aligned leaders (LongShortHarvest 1.64, TrendWeather 0.948, EMATrend 0.611).
- **STRATEGIES_DETAIL.md** (13 ins):
  - Added a `#1630` framing callout after the intro with a compact **verified collapse/leader table** (6 rows) + the realized-turnover discriminator + link.

## Properties

- **Additive only** (no catalog-row rewrites; anti-régression — catalog data preserved, honest framing layered on top).
- **G.1-grounded** — every cited figure verified against the canonical source `docs/qc/qc-comparative-backtests.md` (catalog rows + Tier-1 findings + best-vs-aligned).
- **No `CATALOG-STATUS` markers touched** (catalog-cron unaffected).
- **FR-first** (#3976 constraint; proper French accents per repo standard).
- **No collision** with #4063 (qc-comparative-backtests.md), #4067 (CURRICULUM.md), #4068 (projects/README.md) — different files.
- Coherent 2-file bundle (both are the visitor/catalog entry layer, same #1630 theme) rather than two atomized sub-20-line PRs.

## Note

Other QC sub-series READMEs remain for #3973/#3976 (docs/qc_strategies_catalog.md, BOOK_MAPPING.md). Future atomic PRs. This PR is scoped to the visitor/catalog entry layer (QUICK_TOUR + STRATEGIES_DETAIL).

See #3973, #1630
