### PR TITLE
fix(genai-video): correct Sora model id sora -> sora-2 (renamed API)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
@@ -77,7 +77,10 @@
     "debug_level = \"INFO\"\n",
     "\n",
     "# Parametres Sora API\n",
-    "sora_model = \"sora\"                # Modele Sora a utiliser\n",
+    "# Modeles Sora valides (API OpenAI, verifies 2026-06) : sora-2, sora-2-pro.\n",
+    "# L'ancien identifiant \"sora\" a ete renomme en \"sora-2\" et n'est plus accepte\n",
+    "# par l'endpoint /v1/videos (erreur model_not_found).\n",
+    "sora_model = \"sora-2\"              # Modele Sora a utiliser (sora-2 ou sora-2-pro)\n",
     "video_resolution = \"1080p\"         # Resolution souhaitee\n",
     "video_duration_target = 5          # Duree cible en secondes\n",
     "video_fps_target = 24              # FPS cible\n",
@@ -135,10 +138,10 @@
       "WARNING: .env non trouve, utilisation variables environnement\n",
       "Helpers video importes\n",
       "Sora API - Generation Video Cloud\n",
-      "Date : 2026-05-12 11:58:55\n",
+      "Date : 2026-06-23 17:48:29\n",
       "Mode : interactive\n",
       "Resolution cible : 1080p, 5s @ 24fps\n",
-      "Sortie : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\outputs\\video\n"
+      "Sortie : d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\outputs\\video\n"
      ]
     }
    ],
@@ -249,7 +252,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".env charge depuis: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n"
+      ".env charge depuis: d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n"
      ]
     },
     {
@@ -696,7 +699,7 @@
      "text": [
       "  Status : mock\n",
       "  Frames : 120\n",
-      "  Temps : 2.25s\n",
+      "  Temps : 1.49s\n",
       "\n",
       "Generation : Urbain\n",
       "  Prompt : A busy Tokyo street at night, neon signs reflecting on wet pavement, people with...\n"
@@ -708,7 +711,7 @@
      "text": [
       "  Status : mock\n",
       "  Frames : 120\n",
-      "  Temps : 2.02s\n"
+      "  Temps : 1.41s\n"
      ]
     },
     {
@@ -1134,11 +1137,11 @@
    "id": "e7da331f",
    "source": "def calculate_breakpoint(gpu_purchase_price: float = 1600,\n                          amortization_years: float = 3,\n                          monthly_electricity: float = 50,\n                          cost_per_video_cloud: float = 0.25) -> dict:\n    \"\"\"\n    Calcule le seuil de rentabilite entre generation cloud et locale.\n    \n    Args:\n        gpu_purchase_price: Prix d'achat du GPU (USD)\n        amortization_years: Duree d'amortissement en annees\n        monthly_electricity: Cout electricite mensuel (USD)\n        cost_per_video_cloud: Cout par video sur le cloud (USD)\n    \n    Returns:\n        Dictionnaire avec:\n        - monthly_local_cost: cout fixe mensuel local\n        - breakpoint_videos: nombre de videos mensuelles au point de bascule\n        - cloud_cost_at_breakpoint: cout cloud au point de bascule\n        - recommendation: \"cloud\" ou \"local\" pour 100 videos/mois\n    \"\"\"\n    # TODO etudiant : implementer le calcul du seuil de rentabilite\n    result = None  # TODO etudiant : remplacer par l'analyse\n    return result\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": 1,
+   "execution_count": 8,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
@@ -1179,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "cell-13",
    "metadata": {
     "execution": {
@@ -1273,7 +1276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "cell-14",
    "metadata": {
     "execution": {
@@ -1365,7 +1368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "cell-15",
    "metadata": {
     "execution": {
@@ -1391,7 +1394,7 @@
       "\n",
       "--- STATISTIQUES DE SESSION ---\n",
       "========================================\n",
-      "Date : 2026-05-12 11:59:06\n",
+      "Date : 2026-06-23 17:48:38\n",
       "Mode : interactive\n",
       "API Sora disponible : True\n",
       "Mode mock : True\n",
@@ -1415,7 +1418,7 @@
       "1. Notebook 04-4 : Pipeline Video de Production (pipeline complet bout-en-bout)\n",
       "2. Revenir aux notebooks Audio pour combiner audio + video\n",
       "\n",
-      "Notebook 04-3 Sora API Cloud Video termine - 11:59:06\n"
+      "Notebook 04-3 Sora API Cloud Video termine - 17:48:38\n"
      ]
     }
    ],
@@ -1573,7 +1576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "8g227efa632",
    "metadata": {
     "execution": {
@@ -1667,7 +1670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "l285bw93tw",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

`04-3-Sora-API-Cloud-Video.ipynb` pointed at `sora_model = "sora"`. OpenAI **renamed** that model: the valid identifiers are now **`sora-2` / `sora-2-pro`**, and the old `sora` id returns `model_not_found` on `/v1/videos`. The notebook's model parameter was therefore dead.

**Fix:** set `sora_model = "sora-2"` (with a comment documenting the rename and the valid ids). This is a genuine repair of a broken model reference — not a workaround.

## Live API grounding (real, not documentary)

A live `GET /v1/models` (HTTP 200) on the project key confirms the valid Sora ids. The re-executed notebook output shows:

```
Modeles Sora disponibles : sora-2, sora-2-pro
API Sora disponible : True
```

## SOTA verdict — **RECOVERABLE-USER-HAND** (#3801, `.claude/rules/sota-not-workaround.md`)

- The `model_not_found` blocker is **repaired**; live model discovery works with the existing project key.
- **Real Sora-2 video generation** still requires a **user-hand** action: enable Sora API access/billing on the account and set `use_mock_responses=False`. Until then the notebook uses its mock fallback (honest, documented in-cell — not passed off as real generation).

**[ASK USER]** To flip this notebook to real Sora-2 generation: confirm Sora API access/billing is enabled on the OpenAI project, then I'll re-run with `use_mock_responses=False` and commit real video output.

## Validation (real re-execution)

- Papermill end-to-end, `--cwd 04-Applications --execution-timeout 700 --log-output`
- **27/27 cells, 13/13 code cells, 0 errors**, `execution_count` populated (max 13)
- **No API key in any output** (secrets-hygiene scan: `sk-proj-`/`sk-ant-`/`sk-or-`/`ghp_`/`AIza` all absent; `OPENAI_API_KEY : configuree` prints with no key)

## Scope (atomic)

- **1 source cell changed** (`parameters` cell `cell-1`): `sora_model "sora" -> "sora-2"` + rename comment (+4/-1)
- Outputs regenerated by real re-execution (timestamps, exec times)
- 27 cells (no structural drift), JSON format byte-style preserved (`indent=1`), catalog untouched, no other notebook touched

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
