### PR TITLE
fix(prover): persist verified tactic to real .lean file (#1453 false-success)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -632,7 +632,8 @@ def build_def_type_warnings(filepath: str, goal_state: str) -> str:
 
 
 def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
-                             imports: Optional[str] = None) -> dict:
+                             imports: Optional[str] = None,
+                             persist_on_success: bool = False) -> dict:
     """Verify a sorry replacement by writing modified file to disk and checking Lean.
 
     Args:
@@ -640,8 +641,20 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
         sorry_line: 1-based line number of the sorry
         replacement: Tactic(s) to replace the sorry (will be indented to match)
         imports: Unused (file already has imports)
+        persist_on_success: when True and the isolated probe succeeds, write the
+            replacement back to the REAL file and rebuild the real module to
+            confirm. The probe alone builds an isolated ``_SorryVerify.lean``
+            copy and never touches the real file, so a caller trusting
+            ``result["success"]`` would mark a proof found while the real sorry
+            count stayed flat (false success, Epic #1453). With this flag the
+            real file is only kept if its rebuild is error-free, carries no
+            implicit ``declaration uses 'sorry'`` warning, and the textual sorry
+            count strictly dropped; otherwise the original content is restored.
 
-    Returns: dict with success, errors, time_s
+    Returns: dict with success, errors, time_s, and (when persist_on_success)
+        ``persisted`` (bool: the real file now holds the replacement) and
+        ``real_build_ok`` (bool|None: real-module rebuild verdict, None if not
+        attempted).
     """
     from .verifier import get_verifier
 
@@ -794,6 +807,57 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
         error_msg = ""
         error_type = None
 
+    # Write-back on success (Epic #1453 false-success fix, 2026-06-23).
+    # Everything above only proves the replacement compiles in an isolated
+    # _SorryVerify.lean copy; the REAL file is never modified. Callers that
+    # trust result["success"] therefore saw proof_found=True while the real
+    # sorry count stayed flat. When persist_on_success is set, write the
+    # replacement to the real file and rebuild the REAL module to confirm,
+    # restoring the original content on any failure so the file is never left
+    # broken or with a regressed proof.
+    persisted = False
+    real_build_ok = None
+    if is_success and persist_on_success:
+        original_content = content
+        real_relative = f"{subdir}/{Path(filepath).name}"
+        try:
+            Path(filepath).write_text(new_content, encoding="utf-8")
+            real_result = verifier.verify_project_file(real_relative, force=True)
+            real_output = real_result.get("raw_output", "") or ""
+            # Real module must be error-free, carry no implicit-sorry warning,
+            # and the textual sorry count must strictly drop (the replacement
+            # genuinely removed a sorry rather than compiling around it or
+            # re-introducing one, e.g. a returned `simp; sorry`).
+            real_has_error = bool(re.search(r"\berror:", real_output))
+            implicit_sorry = "declaration uses 'sorry'" in real_output
+            sorry_dropped = (new_content.count("sorry")
+                             < original_content.count("sorry"))
+            if real_has_error or implicit_sorry or not sorry_dropped:
+                Path(filepath).write_text(original_content, encoding="utf-8")
+                is_success = False
+                real_build_ok = False
+                error_type = "persist_build_failed"
+                error_msg = (
+                    "Replacement compiled in isolation but the real module "
+                    "rebuild was rejected (real_error="
+                    f"{real_has_error}, implicit_sorry={implicit_sorry}, "
+                    f"sorry_dropped={sorry_dropped}). Original restored."
+                )
+                if real_output:
+                    error_msg += "\n" + real_output[:400]
+            else:
+                persisted = True
+                real_build_ok = True
+        except OSError as _persist_err:
+            try:
+                Path(filepath).write_text(original_content, encoding="utf-8")
+            except OSError:
+                pass
+            is_success = False
+            real_build_ok = False
+            error_type = "persist_io_error"
+            error_msg = f"Failed to persist replacement to real file: {_persist_err}"
+
     return {
         "success": is_success,
         "errors": error_msg,
@@ -804,6 +868,8 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
         "all_errors": result.get("errors", ""),
         "time_s": result.get("time_s", 0),
         "backend": result.get("backend", ""),
+        "persisted": persisted,  # #1453: real file now holds the replacement
+        "real_build_ok": real_build_ok,  # real-module rebuild verdict (or None)
     }
 
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -844,6 +844,8 @@ class VerifyExecutor(Executor):
             filepath=self._sorry_ctx.filepath,
             sorry_line=self._sorry_ctx.sorry_line,
             replacement=msg.tactic,
+            persist_on_success=True,  # #1453: write the verified tactic to the
+            # REAL file + confirm via real-module rebuild, else success is a lie
         )
 
         if result["success"]:
@@ -859,7 +861,8 @@ class VerifyExecutor(Executor):
                     agent="VerifyExecutor", role="verify",
                     content=f"PROOF FOUND: {msg.tactic[:80]}",
                     tool_name="verify_sorry_replacement",
-                    tool_result="success=True",
+                    tool_result=(f"success=True persisted={result.get('persisted')} "
+                                 f"real_build_ok={result.get('real_build_ok')}"),
                 )
             try:
                 self._kb.record_success(


### PR DESCRIPTION
## Problem (forensic, verified against source)

`VerifyExecutor.handle` (workflow.py:843) set `msg.proof_found = True` purely from `result["success"]` of `verify_sorry_replacement`. But that function:

1. reads the real file into `content` (lean_utils.py:648),
2. builds `new_content` with the tactic substituted at the sorry line (:696),
3. writes a **temp** `_SorryVerify.lean`, builds *it* (:699-706),
4. **`unlink()`s the temp** (:710) — the **real file is never modified**.

So `success=True` => `proof_found=True` while the real sorry count stayed **flat** (1->1). The harness reported a proof it had not committed (false success, Epic #1453). The legacy `provers.py` path *does* write `best_content` on success; the in-place latch (workflow.py 752-834) is correct but only fires when `file_replace_lines` already reduced the real count — the `verify_sorry_replacement` fallback was the leak.

## Fix (Python-only — no `.lean` touched)

- **`verify_sorry_replacement`** gains `persist_on_success: bool = False`. When set and the isolated probe succeeds, it writes the replacement to the **REAL** file and rebuilds the **REAL** module via `verify_project_file(force=True)`. The real file is kept **only** if:
  - the rebuild is error-free (`\berror:` absent),
  - no `declaration uses 'sorry'` implicit-sorry warning,
  - the **textual sorry count strictly dropped** (guards `simp; sorry`, no-op `sorry`, residual sorries).
  
  On any failure (build rejected or IO error) the **original content is restored** — the file is never left broken or proof-regressed. Returns add `persisted` (bool) and `real_build_ok` (bool|None).
- **`VerifyExecutor`** (the single commit gate) passes `persist_on_success=True` and traces `persisted`/`real_build_ok`.
- **`TacticTools.verify_sorry_replacement`** (tools.py:1898 — the exploration probe the LLM agent calls to try many candidate tactics) **intentionally keeps the default `False`**: probing must not write the real file mid-search. Clean separation — **probe freely (no persist), commit once (persist)**.

`git diff --stat`: 2 files, +73/-4. `python -m py_compile lean_utils.py workflow.py` => OK.

## Validation gate

This touches **only Python harness code, no proof file** — so per `lean-merge-discipline.md` §1 the gate is the **smoke-test ping-pong**, not a lake build.

## Hand-off to po-2026 (smoke-test re-validation)

Please run a live sorry-target through the **agent path** (not the latch) and confirm: when `proof_found` is reported, the **real** file's sorry count now actually drops, and the trace shows `persisted=True real_build_ok=True`. If a verified tactic fails to persist (real rebuild rejected), the trace shows `error_type=persist_build_failed` and the file is restored — report that case too, it is the new honest failure mode replacing the old silent false success.

See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)