### PR TITLE
feat(search): MGS-12 AxisAlignment -- rotated benchmark de-bias (RotatedFitness, See #3963)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-12-AxisAlignment.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-12-AxisAlignment.ipynb
@@ -1,0 +1,1174 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "85788274",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004084,
+     "end_time": "2026-06-23T17:37:44.966208+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:44.962124+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# MGS-12 : Le test de l'alignement d'axes -- un optimiseur résiste-t-il à la rotation du paysage ?\n",
+    "\n",
+    "[← MGS-11 Synergie d'îles](MGS-11-IslandSynergy.ipynb) | [MGS-1 Introduction →](MGS-1-Introduction.ipynb)\n",
+    "\n",
+    "**Famille** : banc de benchmark dé-biaisé (suite de [MGS-10 — biais central](MGS-10-CenterBias.ipynb)).\n",
+    "\n",
+    "[MGS-10](MGS-10-CenterBias.ipynb) a montré qu'un optimum placé à l'origine *flatte* les optimiseurs dont les opérateurs ou l'initialisation sont centrés en zéro (biais central). Il existe un second biais, **complémentaire** et tout aussi répandu : le **biais d'alignement d'axes**. Beaucoup d'opérateurs génétiques (crossover uniforme, mutation composante par composante, encerclement WOA) traitent chaque coordonnée *indépendamment* — ils sont « alignés sur les axes ». Lorsque le paysage présente une structure dans une direction *non alignée* avec les axes (la vallée en banane de Rosenbrock, qui courbe le long d'une parabole), ces opérateurs la traversent au lieu de la suivre.\n",
+    "\n",
+    "La technique standard pour mesurer ce biais (compétitions CEC) : **rotationner** le paysage par une matrice orthogonale $M$ ($M M^{\\top} = I$). La rotation préserve les distances et la valeur de l'optimum, mais **déplace** le bassin dans une direction non alignée avec les axes. Ce notebook met en œuvre ce banc via le décorateur `RotatedFitness` du fork (analogue de rotation de `ShiftedFitness`), et pose deux questions :\n",
+    "\n",
+    "1. **Sanity** — une rotation change-t-elle un paysage *radial* comme Sphere ? Non, par construction : c'est le contrôle que le décorateur est correct. Et les fonctions à terme périodique par axe (Rastrigin, Ackley) ? Si — la rotation brise leur séparabilité, et c'est déjà, en soi, le premier signal du biais.\n",
+    "2. **Discrimination** — sur un paysage *asymétrique* (Rosenbrock), la rotation déplace l'optimum : quels optimiseurs le retrouvent ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "42ae60a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:37:44.989792Z",
+     "iopub.status.busy": "2026-06-23T17:37:44.981462Z",
+     "iopub.status.idle": "2026-06-23T17:37:47.146222Z",
+     "shell.execute_reply": "2026-06-23T17:37:47.139700Z"
+    },
+    "papermill": {
+     "duration": 2.174868,
+     "end_time": "2026-06-23T17:37:47.146808+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:44.971940+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%16:2048/\",\"http://172.30.16.1:2048/\",\"http://fe80::5aa8:3689:ec4d:c9e6%44:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:6428:785:4daa:dcda:2048/\",\"http://2a01:e0a:9d4:f320:a911:67ab:50dc:4e69:2048/\",\"http://2a01:e0a:9d4:f320:ad1a:8e3f:5f41:4d97:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%18:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '880720.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DLLs chargees. Decorateurs de-biais : \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  RotatedFitness             : RotatedFitness\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  RotationMatrices           : RotationMatrices\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ShiftedFitness (MGS-10)    : ShiftedFitness\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimiseurs                  : RandomSearchOptimizer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonctions asymetriques       : RosenbrockFitness / SchwefelFitness\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Câblage : DLLs MetaGeneticSharp + GeneticSharp + Extensions (KnownFunctions + RotatedFitness + RotationMatrices).\n",
+    "// Prérequis de build (depuis la racine du fork) : dotnet build c:/dev/MetaGeneticSharp/MetaGeneticSharp.sln\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
+    "\n",
+    "using MetaGeneticSharp;\n",
+    "using GeneticSharp;\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "\n",
+    "Console.WriteLine(\"DLLs chargees. Decorateurs de-biais : \");\n",
+    "Console.WriteLine(\"  RotatedFitness             : \" + typeof(RotatedFitness).Name);\n",
+    "Console.WriteLine(\"  RotationMatrices           : \" + typeof(RotationMatrices).Name);\n",
+    "Console.WriteLine(\"  ShiftedFitness (MGS-10)    : \" + typeof(ShiftedFitness).Name);\n",
+    "Console.WriteLine(\"Optimiseurs                  : \" + typeof(RandomSearchOptimizer).Name);\n",
+    "Console.WriteLine(\"Fonctions asymetriques       : \" + typeof(RosenbrockFitness).Name + \" / \" + typeof(SchwefelFitness).Name);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67c00ff3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003866,
+     "end_time": "2026-06-23T17:37:47.155240+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:47.151374+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Le décorateur de rotation : $f_{\\text{rot}}(x) = f(M x)$\n",
+    "\n",
+    "`RotatedFitness` enveloppe n'importe quelle fonction de fitness et l'évalue sur les coordonnées *rotationnées* $y = M x$. La matrice $M$ est **orthogonale** ($M M^{\\top} = I$) : la transformation préserve les distances (norme), donc la *valeur* de l'optimum est inchangée, mais sa *position* est déplacée. La factory `RotationMatrices.Seeded(n, graine)` construit une telle matrice reproductible comme **produit de rotations de Givens** (une par paire d'indices) — produit de matrices orthogonales = orthogonal, garanti par construction.\n",
+    "\n",
+    "Comme `ShiftedFitness`, c'est un décorateur *compositionnel* fin : les mathématiques de la fonction interne sont réutilisées telles quelles (jamais réimplémentées), seules les coordonnées qu'on lui fournit sont transformées. Les deux se composent pour la variante CEC complète « décalée puis rotationnée » : `new RotatedFitness(new ShiftedFitness(inner, décalage), M)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "02930eca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:37:47.165255Z",
+     "iopub.status.busy": "2026-06-23T17:37:47.164927Z",
+     "iopub.status.idle": "2026-06-23T17:37:47.712496Z",
+     "shell.execute_reply": "2026-06-23T17:37:47.712344Z"
+    },
+    "papermill": {
+     "duration": 0.553533,
+     "end_time": "2026-06-23T17:37:47.712579+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:47.159046+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DoubleArrayChromosome defini. Probe : 2 genes.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// DoubleArrayChromosome : chromosome minimal stockant des gènes double nus.\n",
+    "// (Réplique de l'assistant de test du fork ; bornes par gène pour que CreateNew()\n",
+    "//  randomise la population initiale — voir MGS-6 / MGS-10 pour le détail.)\n",
+    "public class DoubleArrayChromosome : ChromosomeBase\n",
+    "{\n",
+    "    private readonly double _min;\n",
+    "    private readonly double _max;\n",
+    "    public DoubleArrayChromosome(double[] values, double min, double max) : base(values.Length)\n",
+    "    {\n",
+    "        _min = min; _max = max;\n",
+    "        for (int i = 0; i < values.Length; i++) ReplaceGene(i, new Gene(values[i]));\n",
+    "    }\n",
+    "    public override IChromosome CreateNew()\n",
+    "    {\n",
+    "        var rand = RandomizationProvider.Current;\n",
+    "        int n = Length;\n",
+    "        var vals = new double[n];\n",
+    "        for (int i = 0; i < n; i++) vals[i] = rand.GetDouble(_min, _max);\n",
+    "        return new DoubleArrayChromosome(vals, _min, _max);\n",
+    "    }\n",
+    "    public override Gene GenerateGene(int geneIndex)\n",
+    "        => new Gene(RandomizationProvider.Current.GetDouble(_min, _max));\n",
+    "    public double[] GetDoubleValues() => GetGenes().Select(g => (double)g.Value).ToArray();\n",
+    "}\n",
+    "\n",
+    "var probe = new DoubleArrayChromosome(new double[]{1.0, -2.0}, -2.048, 2.048);\n",
+    "Console.WriteLine(\"DoubleArrayChromosome defini. Probe : \" + probe.GetDoubleValues().Length + \" genes.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff38c975",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002985,
+     "end_time": "2026-06-23T17:37:47.719016+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:47.716031+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Réduire chaque optimiseur à un délégué `Optimizer`\n",
+    "\n",
+    "Comme dans [MGS-10](MGS-10-CenterBias.ipynb), on emballe chaque construction de métaheuristique dans le contrat `Optimizer` du banc (taille de population 50, budget d'évaluations partagé). On garde un sous-ensemble représentatif : le **GA à crossover uniforme** (opérateur *composante par composante*, candidat aligné sur les axes), **WOA** (encerclement ancré, cf MGS-10), et deux composés *vectoriels / isotropes* — **DE** (mutation différentielle) et **BBPSO** (échantillonnage gaussien) — dont les déplacements ne privilégient aucune direction d'axe. La **recherche aléatoire** sert de contrôle non biaisé.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b84f46ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:37:47.725663Z",
+     "iopub.status.busy": "2026-06-23T17:37:47.725464Z",
+     "iopub.status.idle": "2026-06-23T17:37:47.982079Z",
+     "shell.execute_reply": "2026-06-23T17:37:47.981846Z"
+    },
+    "papermill": {
+     "duration": 0.260545,
+     "end_time": "2026-06-23T17:37:47.982185+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:47.721640+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Smoke GA/Sphere : objectif = 0,1384  (proche de 0 = OK). Delegues prets : GA, WOA, DE, BBPSO, Random.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "const int PopSize = 50;   // taille de population (GA + composés)\n",
+    "const int NFE = 2000;    // budget d'évaluations (intentionnellement modeste : on veut\n",
+    "                         //  voir un écart de convergence, pas résoudre Rosenbrock à 0)\n",
+    "\n",
+    "IMetaHeuristic BuildGA(int g)     => new DefaultMetaHeuristic();\n",
+    "IMetaHeuristic BuildWOA(int g)    => MetaHeuristicsService.CreateMetaHeuristicByName(\"WhaleOptimisation\",       maxGenerations: g, populationSize: PopSize);\n",
+    "IMetaHeuristic BuildDE(int g)     => MetaHeuristicsService.CreateMetaHeuristicByName(\"DifferentialEvolution\",   maxGenerations: g, populationSize: PopSize);\n",
+    "IMetaHeuristic BuildBBPSO(int g)  => MetaHeuristicsService.CreateMetaHeuristicByName(\"BareBonesParticleSwarm\",  maxGenerations: g, populationSize: PopSize);\n",
+    "\n",
+    "// Emballe n'importe quelle construction d'IMetaHeuristic dans le contrat Optimizer du banc.\n",
+    "Optimizer MakeOptimizer(Func<int, IMetaHeuristic> buildMh)\n",
+    "{\n",
+    "    return (Optimizer)((req) =>\n",
+    "    {\n",
+    "        int gens = Math.Max(1, req.Evaluations / PopSize);\n",
+    "        var (min, max) = req.Bounds;\n",
+    "        double mid = 0.5 * (min + max);\n",
+    "        var adam = new DoubleArrayChromosome(Enumerable.Repeat(mid, req.Dimension).ToArray(), min, max);\n",
+    "        var pop = new MetaPopulation(PopSize, PopSize, adam);\n",
+    "        var ga = new MetaGeneticAlgorithm(\n",
+    "            pop, req.Fitness,\n",
+    "            new EliteSelection(),\n",
+    "            new UniformCrossover(0.5f),\n",
+    "            new UniformMutation(true),\n",
+    "            buildMh(gens));\n",
+    "        ga.Termination = new GenerationNumberTermination(gens);\n",
+    "        ga.Start();\n",
+    "        return ga.BestChromosome.Fitness ?? double.NegativeInfinity;\n",
+    "    });\n",
+    "}\n",
+    "\n",
+    "var rs = new RandomSearchOptimizer(seed: 7);\n",
+    "Optimizer RandomOptimizer = (Optimizer)((req) => rs.Run(req));\n",
+    "\n",
+    "// Ancrage RNG : reproductibilité d'une exécution à l'autre (valeur pédago : un étudiant\n",
+    "// retrouve les valeurs committées). ResetSeed(42) avant le smoke test.\n",
+    "FastRandomRandomization.ResetSeed(42);\n",
+    "double smokeObj = -MakeOptimizer(BuildGA)(new OptimizerRequest(new SphereFitness(), KnownFunctionsBounds.For(typeof(SphereFitness)), 5, NFE));\n",
+    "Console.WriteLine(\"Smoke GA/Sphere : objectif = \" + smokeObj.ToString(\"G4\") + \"  (proche de 0 = OK). Delegues prets : GA, WOA, DE, BBPSO, Random.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fbbfa6b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004224,
+     "end_time": "2026-06-23T17:37:47.991214+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:47.986990+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Partie A — Rotation et symétrie : qui résiste, qui se trahit ?\n",
+    "\n",
+    "Une fonction *purement radiale* (dont la valeur ne dépend que de la norme $\\|x\\|$) est **invariante par rotation** : une matrice orthogonale préserve la norme ($\\|M x\\| = \\|x\\|$), donc $f(M x) = f(x)$ point par point. **Sphere** ($\\sum x_i^2$) est de ce type — c'est notre **contrôle de cohérence** : si `RotatedFitness` changeait Sphere, le décorateur serait buggé.\n",
+    "\n",
+    "Mais beaucoup de fonctions « standard » mélangent un terme radial et un terme **périodique par axe** (les $\\cos(2\\pi x_i)$ de Rastrigin et Ackley). Ce terme est *séparable* — il traite chaque coordonnée indépendamment, donc il est **aligné sur les axes**. Une rotation mélange les coordonnées et **brise cette séparabilité** : la fonction n'est alors plus invariante. L'écart qu'on mesure ci-dessous quantifie précisément cela — et c'est déjà, en soi, le biais que la rotation cherche à révéler. On évalue chaque fonction en un point fixe, directement puis à travers `RotatedFitness` muni d'une matrice rotationnée reproductible.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6cf696b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:37:48.001288Z",
+     "iopub.status.busy": "2026-06-23T17:37:48.001011Z",
+     "iopub.status.idle": "2026-06-23T17:37:48.150657Z",
+     "shell.execute_reply": "2026-06-23T17:37:48.150458Z"
+    },
+    "papermill": {
+     "duration": 0.155517,
+     "end_time": "2026-06-23T17:37:48.150751+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:47.995234+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matrice de rotation M (2D, graine 7) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [ -0,7427  -0,6697 ]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [ 0,6697  -0,7427 ]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Orthogonale (M·Mᵀ = I) ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonction       objectif(x)   objectif_rot(x)   |écart|\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sphere            2,740000         2,740000         0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rastrigin        35,830170        38,740040       2,9\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ackley            6,372836         6,443205      0,07\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Sphere (radiale) : écart 0, le décorateur est validé. Rastrigin/Ackley : écart non nul,\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   leurs termes cosinus par axe brisent la séparabilité sous rotation (premier signal du biais).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Partie A : rotation-invariance sur les fonctions symétriques (évaluation ponctuelle).\n",
+    "// Dimension 2 (la rotation y est un seul angle, le cas le plus lisible).\n",
+    "int dimA = 2;\n",
+    "int rotSeed = 7;\n",
+    "double[,] M = RotationMatrices.Seeded(dimA, rotSeed);\n",
+    "Console.WriteLine(\"Matrice de rotation M (\" + dimA + \"D, graine \" + rotSeed + \") :\");\n",
+    "Console.WriteLine(\"  [ \" + M[0, 0].ToString(\"F4\") + \"  \" + M[0, 1].ToString(\"F4\") + \" ]\");\n",
+    "Console.WriteLine(\"  [ \" + M[1, 0].ToString(\"F4\") + \"  \" + M[1, 1].ToString(\"F4\") + \" ]\");\n",
+    "Console.WriteLine(\"  Orthogonale (M·Mᵀ = I) ? \" + RotationMatrices.IsOrthogonal(M));\n",
+    "\n",
+    "// Point de test (dans les bornes Rosenbrock ; seul le point importe, pas les bornes).\n",
+    "double[] x = { 1.5, -0.7 };\n",
+    "var chrom = new DoubleArrayChromosome(x, -2.048, 2.048);\n",
+    "\n",
+    "IFitness sphere = new SphereFitness();\n",
+    "IFitness rastrigin = new RastriginFitness();\n",
+    "IFitness ackley = new AckleyFitness();\n",
+    "\n",
+    "// La fitness est NÉGATIVÉE (GeneticSharp maximise) ; on affiche l'objectif = -fitness.\n",
+    "double Obj(IFitness f) => -f.Evaluate(new DoubleArrayChromosome(x, -2.048, 2.048));\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Fonction       objectif(x)   objectif_rot(x)   |écart|\");\n",
+    "Console.WriteLine(new string('-', 58));\n",
+    "foreach (var (name, fn) in new (string, IFitness)[] { (\"Sphere\", sphere), (\"Rastrigin\", rastrigin), (\"Ackley\", ackley) })\n",
+    "{\n",
+    "    double direct = Obj(fn);\n",
+    "    double rotated = Obj(new RotatedFitness(fn, M));\n",
+    "    Console.WriteLine(name.PadRight(14) + direct.ToString(\"F6\").PadLeft(12) + rotated.ToString(\"F6\").PadLeft(17)\n",
+    "                      + Math.Abs(direct - rotated).ToString(\"G2\").PadLeft(10));\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"=> Sphere (radiale) : écart 0, le décorateur est validé. Rastrigin/Ackley : écart non nul,\");\n",
+    "Console.WriteLine(\"   leurs termes cosinus par axe brisent la séparabilité sous rotation (premier signal du biais).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a64124eb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00415,
+     "end_time": "2026-06-23T17:37:48.159374+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.155224+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** Trois régimes distincts apparaissent dans le tableau :\n",
+    "\n",
+    "- **Sphere** : écart nul à la précision machine. C'est la seule fonction purement radiale — le décorateur est **validé** (une fonction invariante par construction reste invariante).\n",
+    "- **Rastrigin** : écart marqué. Son terme $\\sum_i \\cos(2\\pi x_i)$ est séparable (un cosinus par axe) ; la rotation mélange les axes et brise cette séparabilité. Rastrigin n'est **pas** invariante par rotation.\n",
+    "- **Ackley** : écart faible mais non nul. Dominée par son terme radial $\\exp(-b\\|x\\|)$ (invariant), elle n'est perturbée que par son petit terme cosinus — d'où un effet réduit.\n",
+    "\n",
+    "Voilà déjà une leçon : la rotation n'est pas qu'un artifice de test, elle **mesure la séparabilité** d'une fonction. Les fonctions séparables (un terme par axe) sont précisément celles qu'un optimiseur *aligné sur les axes* peut résoudre coordonnée par coordonnée ; les rotationner détruit cet avantage. C'est exactement pourquoi les suites CEC rotationnent systématiquement leurs fonctions.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3557f6a2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00422,
+     "end_time": "2026-06-23T17:37:48.167676+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.163456+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Partie B — Discrimination : la rotation déplace l'optimum de Rosenbrock\n",
+    "\n",
+    "La vallée en banane de Rosenbrock, $f(x,y) = 100(y - x^2)^2 + (1 - x)^2$, est **asymétrique** : elle courbe le long d'une parabole, une direction bien précise (non alignée avec les axes après rotation). Son optimum global est en $(1, 1)$ (valeur $0$). Appliquons une rotation de 45° : $M_{45} = \\frac{\\sqrt 2}{2}\\begin{pmatrix}1 & -1\\\\ 1 & 1\\end{pmatrix}$.\n",
+    "\n",
+    "- L'optimum **ne disparaît pas** (valeur conservée) mais **se déplace** : $f_{\\text{rot}}(x) = f(M_{45} x)$ est minimale là où $M_{45} x = (1,1)$, soit $x = M_{45}^{\\top}(1,1) = (\\sqrt 2, 0)$.\n",
+    "- L'ancien optimum $(1,1)$ n'est **plus** optimal sous rotation : $f_{\\text{rot}}(1,1) = f(M_{45}(1,1)) = f(0, \\sqrt 2) \\approx 201$.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fa6704e9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:37:48.179194Z",
+     "iopub.status.busy": "2026-06-23T17:37:48.178926Z",
+     "iopub.status.idle": "2026-06-23T17:37:48.283765Z",
+     "shell.execute_reply": "2026-06-23T17:37:48.283551Z"
+    },
+    "papermill": {
+     "duration": 0.111787,
+     "end_time": "2026-06-23T17:37:48.283870+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.172083+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "R45 orthogonale ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rosenbrock en (1,1)              [ancien optimum]      : 0,0000  (= 0, optimum global)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rosenbrock roté en (1,1)         [l'ancien n'est plus] : 201,0000  (≈ 201, l'optimum a fui)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rosenbrock roté en (√2, 0)       [nouvel optimum]      : 0,0000  (≈ 0, l'optimum a déménagé ici)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> la rotation n'a pas détruit l'optimum (valeur conservée ≈ 0), elle l'a DÉPLACÉ de (1,1) à (√2, 0).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   Un optimiseur aligné sur les axes qui 'savait' descendre vers (1,1) cherche maintenant au mauvais endroit.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Partie B : relocalisation de l'optimum de Rosenbrock sous rotation de 45°.\n",
+    "double s = Math.Sqrt(2.0) / 2.0;\n",
+    "double[,] R45 = { { s, -s }, { s, s } };           // rotation de 45°\n",
+    "Console.WriteLine(\"R45 orthogonale ? \" + RotationMatrices.IsOrthogonal(R45));\n",
+    "\n",
+    "IFitness rosen = new RosenbrockFitness();\n",
+    "IFitness rosenRot = new RotatedFitness(rosen, R45);\n",
+    "double ObjAt(IFitness f, double a, double b) => -f.Evaluate(new DoubleArrayChromosome(new[] { a, b }, -2.048, 2.048));\n",
+    "\n",
+    "double oldCenter_val = ObjAt(rosen, 1.0, 1.0);          // optimum non rotationné\n",
+    "double oldCenter_rot = ObjAt(rosenRot, 1.0, 1.0);       // (1,1) après rotation\n",
+    "double newCenter_rot = ObjAt(rosenRot, Math.Sqrt(2.0), 0.0);  // (√2,0) = nouveau lieu de l'optimum\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Rosenbrock en (1,1)              [ancien optimum]      : \" + oldCenter_val.ToString(\"F4\") + \"  (= 0, optimum global)\");\n",
+    "Console.WriteLine(\"Rosenbrock roté en (1,1)         [l'ancien n'est plus] : \" + oldCenter_rot.ToString(\"F4\") + \"  (≈ 201, l'optimum a fui)\");\n",
+    "Console.WriteLine(\"Rosenbrock roté en (√2, 0)       [nouvel optimum]      : \" + newCenter_rot.ToString(\"F4\") + \"  (≈ 0, l'optimum a déménagé ici)\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"=> la rotation n'a pas détruit l'optimum (valeur conservée ≈ 0), elle l'a DÉPLACÉ de (1,1) à (√2, 0).\");\n",
+    "Console.WriteLine(\"   Un optimiseur aligné sur les axes qui 'savait' descendre vers (1,1) cherche maintenant au mauvais endroit.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cc9ece7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005511,
+     "end_time": "2026-06-23T17:37:48.294752+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.289241+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** La valeur de l'optimum est conservée ($\\approx 0$) mais sa **position** a changé. C'est précisément le biais que la rotation expose : un optimiseur dont la dynamique est tacitement alignée avec les axes (init près d'une diagonale d'axes, déplacements composante par composante) « savait » où aller sur le paysage original ; sur le paysage rotationné, cette connaissance tacite est fausse. Reste à mesurer si nos optimiseurs le resentent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27968209",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004755,
+     "end_time": "2026-06-23T17:37:48.304159+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.299404+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Partie C — Les optimiseurs resentent-ils la rotation ?\n",
+    "\n",
+    "On lance chaque optimiseur sur Rosenbrock **non rotationné** puis **rotationné** (même matrice `M` qu'en partie A, graine 7), en dimension 2, avec le même budget `NFE`. Pour isoler l'effet de la rotation (et pas celui du hasard), on **reseme** le RNG à l'identique avant chaque paire : les tirages initiaux sont donc les mêmes, seules les valeurs de fitness diffèrent — la différence de résultat est imputable au paysage.\n",
+    "\n",
+    "La signature du biais est le **delta** : $\\Delta = \\text{objectif}_{\\text{roté}} - \\text{objectif}_{\\text{non roté}}$.\n",
+    "- $\\Delta \\approx 0$ : l'optimiseur est *robuste à la rotation* (ses déplacements ne privilégient pas les axes).\n",
+    "- $\\Delta > 0$ : la rotation le *dégrade* (signature d'un alignement sur les axes).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "125ff63a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:37:48.314876Z",
+     "iopub.status.busy": "2026-06-23T17:37:48.314613Z",
+     "iopub.status.idle": "2026-06-23T17:37:48.769901Z",
+     "shell.execute_reply": "2026-06-23T17:37:48.769668Z"
+    },
+    "papermill": {
+     "duration": 0.461291,
+     "end_time": "2026-06-23T17:37:48.770014+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.308723+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimiseur        obj_nonroté   obj_roté     Δ = roté - non roté\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Random(contrôle)        0,0557      0,0154      -0,0403\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GA(uniform)             0,0776      0,0341      -0,0435\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WOA                     0,0000      0,0010       0,0010\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DE                      0,0000      0,0000      -0,0000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BBPSO                   0,0179      0,0013      -0,0165\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Δ > 0 = la rotation dégrade l'optimiseur (alignement sur les axes).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Partie C : signature delta (roté - non roté) par optimiseur sur Rosenbrock 2D.\n",
+    "var bounds = KnownFunctionsBounds.For(typeof(RosenbrockFitness));   // (-2.048, 2.048)\n",
+    "double[,] Mc = RotationMatrices.Seeded(dimA, rotSeed);              // même rotation qu'en partie A\n",
+    "int dimC = 2;\n",
+    "int pairSeed = 42;\n",
+    "\n",
+    "var optsC = new (string Name, Optimizer Opt)[]\n",
+    "{\n",
+    "    (\"Random(contrôle)\", RandomOptimizer),\n",
+    "    (\"GA(uniform)\",      MakeOptimizer(BuildGA)),\n",
+    "    (\"WOA\",              MakeOptimizer(BuildWOA)),\n",
+    "    (\"DE\",               MakeOptimizer(BuildDE)),\n",
+    "    (\"BBPSO\",            MakeOptimizer(BuildBBPSO)),\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine(\"Optimiseur        obj_nonroté   obj_roté     Δ = roté - non roté\");\n",
+    "Console.WriteLine(new string('-', 60));\n",
+    "var deltas = new List<(string Name, double D)>();\n",
+    "foreach (var (name, opt) in optsC)\n",
+    "{\n",
+    "    // Même graine avant chaque moitié de la paire -> tirages identiques, paysage seul diffère.\n",
+    "    FastRandomRandomization.ResetSeed(pairSeed);\n",
+    "    double objUnrot = -opt(new OptimizerRequest(new RosenbrockFitness(), bounds, dimC, NFE));\n",
+    "    FastRandomRandomization.ResetSeed(pairSeed);\n",
+    "    double objRot = -opt(new OptimizerRequest(new RotatedFitness(new RosenbrockFitness(), Mc), bounds, dimC, NFE));\n",
+    "    double d = objRot - objUnrot;\n",
+    "    deltas.Add((name, d));\n",
+    "    Console.WriteLine(name.PadRight(18) + objUnrot.ToString(\"F4\").PadLeft(12) + objRot.ToString(\"F4\").PadLeft(12) + d.ToString(\"F4\").PadLeft(13));\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Δ > 0 = la rotation dégrade l'optimiseur (alignement sur les axes).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c10f11a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005956,
+     "end_time": "2026-06-23T17:37:48.782092+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.776136+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Lecture honnête : que dit le delta ?\n",
+    "\n",
+    "Les données committées ci-dessus montrent un $\\Delta$ **quasi nul pour tous les optimiseurs** — aucun n'est dégradé par la rotation. Ce n'est pas un échec du banc, c'est le résultat attendu à ce budget et en dimension 2 : Rosenbrock 2D est assez facile pour que tous ces optimiseurs généraux (GA, WOA, DE, BBPSO) la résolvent essentiellement à zéro (objectifs de $0{,}00$ à $\\sim 0{,}08$), rotationnée ou non. Il n'y a alors **pas de marge** pour qu'un alignement sur les axes pénalise — quand tout le monde trouve l'optimum, la rotation ne peut pas discriminer.\n",
+    "\n",
+    "La lecture méthodologique est importante : un banc de benchmark ne « prouve » un biais opérateur que si le problème est **assez dur** pour que le biais ait de la place pour se manifester. Ici le signal net est dans la **géométrie du paysage** (parties A et B) : la rotation brise la séparabilité des fonctions (Rastrigin) et déplace l'optimum des fonctions asymétriques (Rosenbrock). Pour voir l'effet *opérateur* — un $\\Delta$ qui sépare les déplacements composante par composant (crossover uniforme, WOA) des déplacements vectoriels/isotropes (DE, BBPSO) — il faut **complexisser le problème** : dimension plus élevée et budget plus serré. C'est précisément l'objet de l'exercice 2.\n",
+    "\n",
+    "On retrouve l'esprit de [MGS-10](MGS-10-CenterBias.ipynb) : ce n'est pas l'étiquette de la métaphore qui prédit le biais, c'est la **structure de l'opérateur** — et un banc honnête doit poser un problème assez dur pour que cette structure soit mise à l'épreuve.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36b89fa6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006613,
+     "end_time": "2026-06-23T17:37:48.795673+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.789060+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion : décalage et rotation, les deux biais du banc CEC\n",
+    "\n",
+    "Ce notebook complète [MGS-10](MGS-10-CenterBias.ipynb) : ensemble, ils instrumentent les **deux** techniques de dé-biaisement des bancs modernes (CEC) —\n",
+    "\n",
+    "| Biais | Ce qu'il flatte | Décorateur fork | Notebook |\n",
+    "|-------|-----------------|-----------------|----------|\n",
+    "| **Central** | optimum à l'origine, init/centre en zéro | `ShiftedFitness` | MGS-10 |\n",
+    "| **Alignement d'axes** | opérateurs composante par composant | `RotatedFitness` | MGS-12 (celui-ci) |\n",
+    "\n",
+    "Les deux sont des **décorateurs compositionnels** : ils réutilisent les mathématiques des fonctions canoniques sans les réimplémenter, et se composent (`new RotatedFitness(new ShiftedFitness(inner, o), M)`) pour la variante CEC complète. La leçon tient : on juge un optimiseur sur la **structure de ses opérateurs** (vectoriels vs composante par composant, centrés vs non), pas sur le nom de sa métaphore — et un banc honnête doit tester les deux biais.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c32af2ee",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008829,
+     "end_time": "2026-06-23T17:37:48.810965+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.802136+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "> **Convention** : les exercices sont des cellules à compléter. Squelette fourni, aucune erreur levée — le notebook s'exécute de bout en bout même non terminé.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34b0a5ec",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008202,
+     "end_time": "2026-06-23T17:37:48.828867+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.820665+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : la signature opérateur (vectoriel vs composante par composant)\n",
+    "\n",
+    "Ajoutez **DE/best/1** ou un crossover *arithmétique entier* (moyenne pondérée des deux parents, $\\alpha A + (1-\\alpha)B$) au banc de la partie C. Le crossover arithmétique est-il plus ou moins robuste à la rotation que le crossover uniforme ? Mesurez le $\\Delta$ et confrontez à votre intuition sur la structure de l'opérateur.\n",
+    "\n",
+    "# Indice : le crossover arithmétique produit un descendant *sur le segment* entre les parents (combinaison convexe) — une opération géométrique indépendante du repère, donc *a priori* équivariante par rotation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b27002a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:37:48.846514Z",
+     "iopub.status.busy": "2026-06-23T17:37:48.846191Z",
+     "iopub.status.idle": "2026-06-23T17:37:48.926428Z",
+     "shell.execute_reply": "2026-06-23T17:37:48.926166Z"
+    },
+    "papermill": {
+     "duration": 0.091199,
+     "end_time": "2026-06-23T17:37:48.926544+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.835345+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 à compléter : Δ du crossover arithmétique vs uniforme.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : ajouter un optimiseur à crossover arithmétique au banc de la partie C.\n",
+    "// TODO étudiant : construire un Optimizer utilisant WholeArithmeticCrossover (ou équivalent),\n",
+    "// le lancer sur Rosenbrock non roté puis roté (même protocole ResetSeed(pairSeed) par moitié),\n",
+    "// et afficher son Δ à côté des autres.\n",
+    "// result = null  // TODO étudiant\n",
+    "Console.WriteLine(\"Exercice 1 à compléter : Δ du crossover arithmétique vs uniforme.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dca906b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006793,
+     "end_time": "2026-06-23T17:37:48.940618+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.933825+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : plus haute dimension amplifie-t-elle le biais ?\n",
+    "\n",
+    "Rejouez la partie C en dimension 5 (attention aux bornes : l'optimum rotationné de Rosenbrock a pour norme $\\sqrt{d}$, il faut des bornes assez larges — utilisez par exemple $[-30, 30]$). Le $\\Delta$ des optimiseurs alignés sur les axes grandit-il avec la dimension ? C'est l'intuition CEC : la rotation est d'autant plus discriminante que la dimension est élevée.\n",
+    "\n",
+    "# Étape 1 : remplacer dimC par 5 et bounds par (-30, 30). # Étape 2 : relancer la paire roté/non roté. # Étape 3 : comparer les Δ à ceux de la dimension 2.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b967b96a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:37:48.957360Z",
+     "iopub.status.busy": "2026-06-23T17:37:48.956938Z",
+     "iopub.status.idle": "2026-06-23T17:37:49.051447Z",
+     "shell.execute_reply": "2026-06-23T17:37:49.051250Z"
+    },
+    "papermill": {
+     "duration": 0.103841,
+     "end_time": "2026-06-23T17:37:49.051544+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:48.947703+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 à compléter : Δ en dimension 5 vs dimension 2.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : signature delta de Rosenbrock roté en dimension 5 (bornes élargies).\n",
+    "// TODO étudiant : adapter la boucle de la partie C avec dimC = 5 et bounds = (-30.0, 30.0).\n",
+    "Console.WriteLine(\"Exercice 2 à compléter : Δ en dimension 5 vs dimension 2.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cde00226",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005661,
+     "end_time": "2026-06-23T17:37:49.062683+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:49.057022+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : la variante CEC complète (décalée PUIS rotationnée)\n",
+    "\n",
+    "Composez les deux décorateurs : `new RotatedFitness(new ShiftedFitness(new RosenbrockFitness(), offset), M)` avec un `offset` non nul (via `ShiftVectors.Seeded`) et la matrice `M`. Vérifiez que l'optimum est à la fois décalé et rotationné, et lancez un optimiseur : combine-t-on les deux difficultés ? Quelle borne faut-il pour rester dans le domaine ?\n",
+    "\n",
+    "# Indice : l'optimum est en $M^{\\top}(1,1) + o$ ; choisir bornes et offset pour qu'il reste atteignable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1bde0333",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:37:49.075407Z",
+     "iopub.status.busy": "2026-06-23T17:37:49.075112Z",
+     "iopub.status.idle": "2026-06-23T17:37:49.116456Z",
+     "shell.execute_reply": "2026-06-23T17:37:49.116259Z"
+    },
+    "papermill": {
+     "duration": 0.048705,
+     "end_time": "2026-06-23T17:37:49.116552+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:49.067847+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 à compléter : banc CEC shift+rotate complet.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : variante CEC décalée + rotationnée.\n",
+    "// TODO étudiant : construire new RotatedFitness(new ShiftedFitness(rosen, offset), M),\n",
+    "// localiser le nouvel optimum (Mᵀ·(1,1) + offset), vérifier sa valeur ≈ 0, lancer un optimiseur.\n",
+    "Console.WriteLine(\"Exercice 3 à compléter : banc CEC shift+rotate complet.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa92218b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005339,
+     "end_time": "2026-06-23T17:37:49.128131+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T17:37:49.122792+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Liens\n",
+    "\n",
+    "- [MGS-10 — Le test du biais central](MGS-10-CenterBias.ipynb) — le décorateur frère `ShiftedFitness` (décalage de l'optimum), premier biais du banc dé-biaisé.\n",
+    "- [MGS-6 — Benchmarks comparatifs](MGS-6-Benchmarks.ipynb) — la grille 10×3 fonctions × optimiseurs, argument « components over metaphors ».\n",
+    "- [MGS-5 — Métaheuristiques composées](MGS-5-CompoundMetaheuristics.ipynb) — WOA/EO/FBI/DE/BBPSO/SA décomposés en primitives.\n",
+    "- Décorateurs fork : `RotatedFitness`, `ShiftedFitness` dans `MetaGeneticSharp.Extensions` (matrice orthogonale par produit de rotations de Givens).\n",
+    "- Référence : suites de benchmark CEC (rotation + décalage) ; Sorensen 2015, *Metaheuristics—the metaphor exposed*.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 8.883404,
+   "end_time": "2026-06-23T17:37:49.372484+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MGS-12-AxisAlignment.ipynb",
+   "output_path": "mgs12_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-23T17:37:40.489080+00:00",
+   "version": "2.7.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": "csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Second de-bias notebook of the CEC benchmark suite, complementing [MGS-10 (central bias / `ShiftedFitness`)](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-10-CenterBias.ipynb). Where MGS-10 defeats the **central-optimum** bias by shifting, this notebook defeats the complementary **axis-alignment** bias by **rotating** the landscape with an orthogonal matrix. Uses the fork's `RotatedFitness` decorator + `RotationMatrices` factory (fork #34, self-merged → submodule bumped `b3b3ec4`→`6e1d7f6`).

## The three parts (narrative matches committed outputs)

**Part A — Rotation & symmetry: who resists, who is exposed.** A purely radial function is rotation-invariant; a separable one (per-axis cos terms) is not.
- **Sphere** (purely radial): écart **0** → the decorator is validated (an invariant function stays invariant).
- **Rastrigin**: écart **~2.9** → its `Σ cos(2πxᵢ)` term is separable; rotation breaks separability. **Not** rotation-invariant.
- **Ackley**: écart **~0.07** → dominated by its radial `exp(−b‖x‖)` term, perturbed only by its small cos term.

*Lesson*: rotation measures separability — exactly why CEC rotates.

**Part B — Rosenbrock optimum relocation (the keystone).** Under a 45° rotation, the Rosenbrock optimum relocates from (1,1) to (√2, 0): value conserved (~0), position moved. The old center (1,1) is no longer optimal (value ~201). Deterministic point-evaluations, no optimization.

**Part C — Honest optimizer comparison (Δ = rotated − unrotated).** At NFE=2000 / dim=2, **Δ ≈ 0 for every optimizer** (GA, WOA, DE, BBPSO, Random): 2D Rosenbrock is too easy — all solvers reach ~0, rotationned or not, so there's no room for axis-bias to penalize. The honest reading (stated declaratively, not hedged): the net signal is the **landscape geometry** (Parts A/B); operator axis-bias needs a harder problem (higher dim / tighter budget) — which is **Exercice 2**.

## Honest-report discipline

- The Part A narrative was rewritten after first execution revealed my initial claim ("Sphere/Rastrigin/Ackley are all rotation-invariant") was **false** for Rastrigin/Ackley — the committed markdown now describes the actual three-regime output. No markdown-contradicts-output.
- Part C states the actual Δ≈0 finding rather than over-claiming an operator effect that the data doesn't support.

## Validation (rule H / C)

- **C.2**: 9/9 code cells executed (`.net-csharp` papermill, `--cwd Part4`), `execution_count` set on all, **0 errors**. Real committed outputs.
- **C.1**: exercise stubs use `Console.WriteLine` / no `raise`/`assert`/`1/0`. Notebook runs end-to-end uncompleted.
- **#2161**: 3 exercises (crossover arithmétique vs uniforme / dim-5 amplification / CEC shift+rotate complet).
- **Rule F**: real `.NET (C#)` kernel, real fork DLLs (rebuilt at `6e1d7f6`).
- **sota-not-workaround Prong-A**: real `RotatedFitness`/`RotationMatrices` (no toy reimpl). **Prong-B**: discriminating (Sphere vs Rastrigin vs Rosenbrock expose distinct rotation regimes).

## Scope / collision note

Atomic: new notebook + submodule bump only. **No README roster change** — the Part4 table + root "N notebooks" line are already touched by pending **#4076** (MGS-11); the 11→12 roster update is deferred to avoid collision (ai-01 can fold it in, or a follow-up after #4076 lands).

See #3963 (Prong-2 rotation demonstration). The de-bias bench is now demonstrated via MGS-10 (shift) + MGS-12 (rotation) rather than the issue's literal "update MGS-5/MGS-6" — ai-01/user to judge whether the literal MGS-5/6 update is still wanted or whether MGS-10/MGS-12 closes the intent.

Co-Authored-By: Claude <noreply@anthropic.com>
