### PR TITLE
feat(mgs): MGS-12 Partie D — dim-5 reveals operator axis-bias signature (#4081 follow-up)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-12-AxisAlignment.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-12-AxisAlignment.ipynb
@@ -5,10 +5,10 @@
    "id": "85788274",
    "metadata": {
     "papermill": {
-     "duration": 0.004084,
-     "end_time": "2026-06-23T17:37:44.966208+00:00",
+     "duration": 0.006783,
+     "end_time": "2026-06-23T18:10:29.112889+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:44.962124+00:00",
+     "start_time": "2026-06-23T18:10:29.106106+00:00",
      "status": "completed"
     },
     "tags": []
@@ -34,16 +34,16 @@
    "id": "42ae60a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:37:44.989792Z",
-     "iopub.status.busy": "2026-06-23T17:37:44.981462Z",
-     "iopub.status.idle": "2026-06-23T17:37:47.146222Z",
-     "shell.execute_reply": "2026-06-23T17:37:47.139700Z"
+     "iopub.execute_input": "2026-06-23T18:10:29.140132Z",
+     "iopub.status.busy": "2026-06-23T18:10:29.127740Z",
+     "iopub.status.idle": "2026-06-23T18:10:30.894466Z",
+     "shell.execute_reply": "2026-06-23T18:10:30.889338Z"
     },
     "papermill": {
-     "duration": 2.174868,
-     "end_time": "2026-06-23T17:37:47.146808+00:00",
+     "duration": 1.777109,
+     "end_time": "2026-06-23T18:10:30.894596+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:44.971940+00:00",
+     "start_time": "2026-06-23T18:10:29.117487+00:00",
      "status": "completed"
     },
     "tags": []
@@ -104,7 +104,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '880720.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '878972.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -235,10 +235,10 @@
    "id": "67c00ff3",
    "metadata": {
     "papermill": {
-     "duration": 0.003866,
-     "end_time": "2026-06-23T17:37:47.155240+00:00",
+     "duration": 0.003164,
+     "end_time": "2026-06-23T18:10:30.901547+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:47.151374+00:00",
+     "start_time": "2026-06-23T18:10:30.898383+00:00",
      "status": "completed"
     },
     "tags": []
@@ -257,16 +257,16 @@
    "id": "02930eca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:37:47.165255Z",
-     "iopub.status.busy": "2026-06-23T17:37:47.164927Z",
-     "iopub.status.idle": "2026-06-23T17:37:47.712496Z",
-     "shell.execute_reply": "2026-06-23T17:37:47.712344Z"
+     "iopub.execute_input": "2026-06-23T18:10:30.909324Z",
+     "iopub.status.busy": "2026-06-23T18:10:30.909127Z",
+     "iopub.status.idle": "2026-06-23T18:10:31.394066Z",
+     "shell.execute_reply": "2026-06-23T18:10:31.393880Z"
     },
     "papermill": {
-     "duration": 0.553533,
-     "end_time": "2026-06-23T17:37:47.712579+00:00",
+     "duration": 0.489298,
+     "end_time": "2026-06-23T18:10:31.394164+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:47.159046+00:00",
+     "start_time": "2026-06-23T18:10:30.904866+00:00",
      "status": "completed"
     },
     "tags": []
@@ -315,10 +315,10 @@
    "id": "ff38c975",
    "metadata": {
     "papermill": {
-     "duration": 0.002985,
-     "end_time": "2026-06-23T17:37:47.719016+00:00",
+     "duration": 0.003744,
+     "end_time": "2026-06-23T18:10:31.402051+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:47.716031+00:00",
+     "start_time": "2026-06-23T18:10:31.398307+00:00",
      "status": "completed"
     },
     "tags": []
@@ -326,7 +326,14 @@
    "source": [
     "## Réduire chaque optimiseur à un délégué `Optimizer`\n",
     "\n",
-    "Comme dans [MGS-10](MGS-10-CenterBias.ipynb), on emballe chaque construction de métaheuristique dans le contrat `Optimizer` du banc (taille de population 50, budget d'évaluations partagé). On garde un sous-ensemble représentatif : le **GA à crossover uniforme** (opérateur *composante par composante*, candidat aligné sur les axes), **WOA** (encerclement ancré, cf MGS-10), et deux composés *vectoriels / isotropes* — **DE** (mutation différentielle) et **BBPSO** (échantillonnage gaussien) — dont les déplacements ne privilégient aucune direction d'axe. La **recherche aléatoire** sert de contrôle non biaisé.\n"
+    "Comme dans [MGS-10](MGS-10-CenterBias.ipynb), on emballe chaque construction de métaheuristique dans le contrat `Optimizer` du banc (taille de population 50, budget d'évaluations partagé). On garde un sous-ensemble représentatif qui couvre toute la gamme de **structure d'opérateur** :\n",
+    "\n",
+    "- **GA à crossover uniforme** — opérateur *composante par composante* (il échange des gènes), typiquement aligné sur les axes ;\n",
+    "- **BBPSO** — échantillonnage gaussien *par dimension* (une loi normale par coordonnée, covariance diagonale) : son apparence « continue » ne le rend pas isotrope, un tirage par axe reste de la structure alignée sur les axes ;\n",
+    "- **WOA** — encerclement par différence de positions, mais le coefficient d'encerclement est appliqué *composante par composante* (structure mixte) ;\n",
+    "- **DE** — mutation par *différence vectorielle* $F(a-b)$ : la seule dont le déplacement soit véritablement équivariant par rotation.\n",
+    "\n",
+    "La **recherche aléatoire** sert de contrôle non biaisé. La partie D tranchera, à dimension assez élevée, lesquels résistent vraiment.\n"
    ]
   },
   {
@@ -335,16 +342,16 @@
    "id": "b84f46ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:37:47.725663Z",
-     "iopub.status.busy": "2026-06-23T17:37:47.725464Z",
-     "iopub.status.idle": "2026-06-23T17:37:47.982079Z",
-     "shell.execute_reply": "2026-06-23T17:37:47.981846Z"
+     "iopub.execute_input": "2026-06-23T18:10:31.410881Z",
+     "iopub.status.busy": "2026-06-23T18:10:31.410637Z",
+     "iopub.status.idle": "2026-06-23T18:10:31.631560Z",
+     "shell.execute_reply": "2026-06-23T18:10:31.631370Z"
     },
     "papermill": {
-     "duration": 0.260545,
-     "end_time": "2026-06-23T17:37:47.982185+00:00",
+     "duration": 0.226111,
+     "end_time": "2026-06-23T18:10:31.631646+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:47.721640+00:00",
+     "start_time": "2026-06-23T18:10:31.405535+00:00",
      "status": "completed"
     },
     "tags": []
@@ -405,10 +412,10 @@
    "id": "9fbbfa6b",
    "metadata": {
     "papermill": {
-     "duration": 0.004224,
-     "end_time": "2026-06-23T17:37:47.991214+00:00",
+     "duration": 0.004577,
+     "end_time": "2026-06-23T18:10:31.641063+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:47.986990+00:00",
+     "start_time": "2026-06-23T18:10:31.636486+00:00",
      "status": "completed"
     },
     "tags": []
@@ -427,16 +434,16 @@
    "id": "6cf696b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:37:48.001288Z",
-     "iopub.status.busy": "2026-06-23T17:37:48.001011Z",
-     "iopub.status.idle": "2026-06-23T17:37:48.150657Z",
-     "shell.execute_reply": "2026-06-23T17:37:48.150458Z"
+     "iopub.execute_input": "2026-06-23T18:10:31.650410Z",
+     "iopub.status.busy": "2026-06-23T18:10:31.650156Z",
+     "iopub.status.idle": "2026-06-23T18:10:31.794107Z",
+     "shell.execute_reply": "2026-06-23T18:10:31.793911Z"
     },
     "papermill": {
-     "duration": 0.155517,
-     "end_time": "2026-06-23T17:37:48.150751+00:00",
+     "duration": 0.149175,
+     "end_time": "2026-06-23T18:10:31.794202+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:47.995234+00:00",
+     "start_time": "2026-06-23T18:10:31.645027+00:00",
      "status": "completed"
     },
     "tags": []
@@ -576,10 +583,10 @@
    "id": "a64124eb",
    "metadata": {
     "papermill": {
-     "duration": 0.00415,
-     "end_time": "2026-06-23T17:37:48.159374+00:00",
+     "duration": 0.004495,
+     "end_time": "2026-06-23T18:10:31.803718+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.155224+00:00",
+     "start_time": "2026-06-23T18:10:31.799223+00:00",
      "status": "completed"
     },
     "tags": []
@@ -599,10 +606,10 @@
    "id": "3557f6a2",
    "metadata": {
     "papermill": {
-     "duration": 0.00422,
-     "end_time": "2026-06-23T17:37:48.167676+00:00",
+     "duration": 0.004538,
+     "end_time": "2026-06-23T18:10:31.812767+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.163456+00:00",
+     "start_time": "2026-06-23T18:10:31.808229+00:00",
      "status": "completed"
     },
     "tags": []
@@ -622,16 +629,16 @@
    "id": "fa6704e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:37:48.179194Z",
-     "iopub.status.busy": "2026-06-23T17:37:48.178926Z",
-     "iopub.status.idle": "2026-06-23T17:37:48.283765Z",
-     "shell.execute_reply": "2026-06-23T17:37:48.283551Z"
+     "iopub.execute_input": "2026-06-23T18:10:31.823531Z",
+     "iopub.status.busy": "2026-06-23T18:10:31.823290Z",
+     "iopub.status.idle": "2026-06-23T18:10:31.918734Z",
+     "shell.execute_reply": "2026-06-23T18:10:31.918533Z"
     },
     "papermill": {
-     "duration": 0.111787,
-     "end_time": "2026-06-23T17:37:48.283870+00:00",
+     "duration": 0.101354,
+     "end_time": "2026-06-23T18:10:31.918839+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.172083+00:00",
+     "start_time": "2026-06-23T18:10:31.817485+00:00",
      "status": "completed"
     },
     "tags": []
@@ -722,10 +729,10 @@
    "id": "5cc9ece7",
    "metadata": {
     "papermill": {
-     "duration": 0.005511,
-     "end_time": "2026-06-23T17:37:48.294752+00:00",
+     "duration": 0.004937,
+     "end_time": "2026-06-23T18:10:31.928971+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.289241+00:00",
+     "start_time": "2026-06-23T18:10:31.924034+00:00",
      "status": "completed"
     },
     "tags": []
@@ -739,10 +746,10 @@
    "id": "27968209",
    "metadata": {
     "papermill": {
-     "duration": 0.004755,
-     "end_time": "2026-06-23T17:37:48.304159+00:00",
+     "duration": 0.005553,
+     "end_time": "2026-06-23T18:10:31.939681+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.299404+00:00",
+     "start_time": "2026-06-23T18:10:31.934128+00:00",
      "status": "completed"
     },
     "tags": []
@@ -763,16 +770,16 @@
    "id": "125ff63a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:37:48.314876Z",
-     "iopub.status.busy": "2026-06-23T17:37:48.314613Z",
-     "iopub.status.idle": "2026-06-23T17:37:48.769901Z",
-     "shell.execute_reply": "2026-06-23T17:37:48.769668Z"
+     "iopub.execute_input": "2026-06-23T18:10:31.952067Z",
+     "iopub.status.busy": "2026-06-23T18:10:31.951735Z",
+     "iopub.status.idle": "2026-06-23T18:10:32.331811Z",
+     "shell.execute_reply": "2026-06-23T18:10:32.331598Z"
     },
     "papermill": {
-     "duration": 0.461291,
-     "end_time": "2026-06-23T17:37:48.770014+00:00",
+     "duration": 0.386821,
+     "end_time": "2026-06-23T18:10:32.331907+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.308723+00:00",
+     "start_time": "2026-06-23T18:10:31.945086+00:00",
      "status": "completed"
     },
     "tags": []
@@ -881,22 +888,203 @@
    "id": "3c10f11a",
    "metadata": {
     "papermill": {
-     "duration": 0.005956,
-     "end_time": "2026-06-23T17:37:48.782092+00:00",
+     "duration": 0.004765,
+     "end_time": "2026-06-23T18:10:32.342267+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.776136+00:00",
+     "start_time": "2026-06-23T18:10:32.337502+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## Lecture honnête : que dit le delta ?\n",
+    "## Lecture honnête : que dit le delta ?\n\nLes données committées ci-dessus montrent un $\\Delta$ **quasi nul pour tous les optimiseurs** — aucun n'est dégradé par la rotation. Ce n'est pas un échec du banc, c'est le résultat attendu à ce budget et en dimension 2 : Rosenbrock 2D est assez facile pour que tous ces optimiseurs généraux (GA, WOA, DE, BBPSO) la résolvent essentiellement à zéro (objectifs de $0{,}00$ à $\\sim 0{,}08$), rotationnée ou non. Il n'y a alors **pas de marge** pour qu'un alignement sur les axes pénalise — quand tout le monde trouve l'optimum, la rotation ne peut pas discriminer.\n\nLa lecture méthodologique est importante : un banc de benchmark ne « prouve » un biais opérateur que si le problème est **assez dur** pour que le biais ait de la place pour se manifester. Ici le signal net est dans la **géométrie du paysage** (parties A et B) : la rotation brise la séparabilité des fonctions (Rastrigin) et déplace l'optimum des fonctions asymétriques (Rosenbrock). Pour voir l'effet *opérateur* — un $\\Delta$ qui sépare les déplacements composante par composant (crossover uniforme, WOA) des déplacements vectoriels (DE) — il faut **complexisser le problème** : dimension plus élevée et budget plus serré. C'est précisément l'objet de l'exercice 2.\n\nOn retrouve l'esprit de [MGS-10](MGS-10-CenterBias.ipynb) : ce n'est pas l'étiquette de la métaphore qui prédit le biais, c'est la **structure de l'opérateur** — et un banc honnête doit poser un problème assez dur pour que cette structure soit mise à l'épreuve.\n\n→ La **partie D** ci-après complexifie le problème (dimension 5) et révèle effectivement cette signature opérateur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1710968d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00451,
+     "end_time": "2026-06-23T18:10:32.351746+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T18:10:32.347236+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Partie D — La signature révélée : plus haute dimension\n",
     "\n",
-    "Les données committées ci-dessus montrent un $\\Delta$ **quasi nul pour tous les optimiseurs** — aucun n'est dégradé par la rotation. Ce n'est pas un échec du banc, c'est le résultat attendu à ce budget et en dimension 2 : Rosenbrock 2D est assez facile pour que tous ces optimiseurs généraux (GA, WOA, DE, BBPSO) la résolvent essentiellement à zéro (objectifs de $0{,}00$ à $\\sim 0{,}08$), rotationnée ou non. Il n'y a alors **pas de marge** pour qu'un alignement sur les axes pénalise — quand tout le monde trouve l'optimum, la rotation ne peut pas discriminer.\n",
+    "La partie C, en dimension 2, n'a montré **aucun** écart : tous les optimiseurs résolvent Rosenbrock 2D (rotationnée ou non), il n'y a pas de marge pour qu'un alignement sur les axes pénalise. C'est la leçon méthodologique rappelée plus haut : un banc ne prouve un biais opérateur que si le problème est **assez dur**.\n",
     "\n",
-    "La lecture méthodologique est importante : un banc de benchmark ne « prouve » un biais opérateur que si le problème est **assez dur** pour que le biais ait de la place pour se manifester. Ici le signal net est dans la **géométrie du paysage** (parties A et B) : la rotation brise la séparabilité des fonctions (Rastrigin) et déplace l'optimum des fonctions asymétriques (Rosenbrock). Pour voir l'effet *opérateur* — un $\\Delta$ qui sépare les déplacements composante par composant (crossover uniforme, WOA) des déplacements vectoriels/isotropes (DE, BBPSO) — il faut **complexisser le problème** : dimension plus élevée et budget plus serré. C'est précisément l'objet de l'exercice 2.\n",
+    "Montons en dimension 5, avec des bornes élargies $[-30, 30]$ (l'optimum rotationné a pour norme $\\sqrt d$, il faut de la place) et le même budget modeste. À cette dimension Rosenbrock n'est plus résolue à zéro — il reste de la marge. On rejoue le protocole (même RNG resemée avant chaque moitié de la paire) sur **5 graines** et l'on prend la médiane, pour réduire le bruit. C'est le régime CEC canonique où la rotation discrimine.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "65b2e36d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T18:10:32.361980Z",
+     "iopub.status.busy": "2026-06-23T18:10:32.361762Z",
+     "iopub.status.idle": "2026-06-23T18:10:33.205345Z",
+     "shell.execute_reply": "2026-06-23T18:10:33.205141Z"
+    },
+    "papermill": {
+     "duration": 0.849372,
+     "end_time": "2026-06-23T18:10:33.205435+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T18:10:32.356063+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dim=5 bornes=(-30,30) NFE=2000 graines=0,1,7,42,99 (médiane)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimiseur        méd_obj_nonroté   méd_obj_roté    Δ=roté-nonroté\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Random(contrôle)         1,276E+05      9,331E+04      -3,431E+04\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GA(uniform)                  763,4           3610            2847\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WOA                          6,218           1295            1289\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DE                           1,883          3,933            2,05\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BBPSO                        13,39          994,9           981,5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Δ >> 0 = la rotation dégrade l'optimiseur (signature d'alignement sur les axes).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Partie D : signature delta en dimension 5 (bornes elargies, 5 graines, mediane).\n",
+    "int dimD = 5;\n",
+    "var boundsD = (-30.0, 30.0);\n",
+    "double[,] Md = RotationMatrices.Seeded(dimD, 7);\n",
+    "int[] seedsD = { 0, 1, 7, 42, 99 };\n",
     "\n",
-    "On retrouve l'esprit de [MGS-10](MGS-10-CenterBias.ipynb) : ce n'est pas l'étiquette de la métaphore qui prédit le biais, c'est la **structure de l'opérateur** — et un banc honnête doit poser un problème assez dur pour que cette structure soit mise à l'épreuve.\n"
+    "var optsD = new (string Name, Optimizer Opt)[]\n",
+    "{\n",
+    "    (\"Random(contrôle)\", RandomOptimizer),\n",
+    "    (\"GA(uniform)\",      MakeOptimizer(BuildGA)),\n",
+    "    (\"WOA\",              MakeOptimizer(BuildWOA)),\n",
+    "    (\"DE\",               MakeOptimizer(BuildDE)),\n",
+    "    (\"BBPSO\",            MakeOptimizer(BuildBBPSO)),\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine(\"dim=\" + dimD + \" bornes=(\" + boundsD.Item1 + \",\" + boundsD.Item2 + \") NFE=\" + NFE + \" graines=\" + string.Join(\",\", seedsD) + \" (médiane)\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Optimiseur        méd_obj_nonroté   méd_obj_roté    Δ=roté-nonroté\");\n",
+    "Console.WriteLine(new string('-', 64));\n",
+    "foreach (var (name, opt) in optsD)\n",
+    "{\n",
+    "    var unrots = new List<double>();\n",
+    "    var rots = new List<double>();\n",
+    "    foreach (int sd in seedsD)\n",
+    "    {\n",
+    "        FastRandomRandomization.ResetSeed(sd);\n",
+    "        unrots.Add(-opt(new OptimizerRequest(new RosenbrockFitness(), boundsD, dimD, NFE)));\n",
+    "        FastRandomRandomization.ResetSeed(sd);\n",
+    "        rots.Add(-opt(new OptimizerRequest(new RotatedFitness(new RosenbrockFitness(), Md), boundsD, dimD, NFE)));\n",
+    "    }\n",
+    "    unrots.Sort(); rots.Sort();\n",
+    "    double medU = unrots[unrots.Count / 2];\n",
+    "    double medR = rots[rots.Count / 2];\n",
+    "    double d = medR - medU;\n",
+    "    Console.WriteLine(name.PadRight(18) + medU.ToString(\"G4\").PadLeft(16) + medR.ToString(\"G4\").PadLeft(15) + d.ToString(\"G4\").PadLeft(16));\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Δ >> 0 = la rotation dégrade l'optimiseur (signature d'alignement sur les axes).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94a72743",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005175,
+     "end_time": "2026-06-23T18:10:33.216064+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T18:10:33.210889+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** Cette fois le signal apparaît nettement. À la dimension 5 il reste de la marge (les objectifs sont loin de zéro), et la rotation **ne touche pas tous les opérateurs de la même façon** :\n",
+    "\n",
+    "- **DE** (mutation par *différence vectorielle* $F(a-b)$) est le **seul clairement robuste** ($\\Delta \\approx 2$) : son déplacement est une combinaison linéaire de positions, équivariante par rotation — la direction du pas suit le paysage, pas les axes.\n",
+    "- **GA à crossover uniforme** ($\\Delta \\approx 2847$), **WOA** ($\\Delta \\approx 1289$) et **BBPSO** ($\\Delta \\approx 981$) sont tous **dégradés** par la rotation :\n",
+    "  - le crossover uniforme *échange des composantes* (aligné sur les axes) ;\n",
+    "  - **BBPSO** *échantillonne une gaussienne par dimension* (covariance diagonale) — un tirage par axe, c'est bien de la structure alignée sur les axes ;\n",
+    "  - **WOA**, malgré son encerclement par différence de positions, applique son coefficient d'encerclement *composante par composante*, ce qui laisse assez de structure alignée sur les axes pour être pénalisé.\n",
+    "- La **recherche aléatoire** a un $\\Delta$ négatif non interprétable : ce n'est pas un optimiseur, sa « performance » n'est que du bruit d'échantillonnage.\n",
+    "\n",
+    "La leçon se précise : pour résister à la rotation, il ne suffit pas d'être « stochastique » ou « continu », il faut un opérateur *véritablement vectoriel* — un déplacement qui soit une combinaison linéaire de points du paysage (la différence différentielle de DE). Tout ce qui traite les coordonnées axe par axe (crossover uniforme, gaussienne par dimension, coefficient scalaire composante par composante) porte un alignement que la rotation révèle dès que le problème est assez dur. C'est la thèse « *components over metaphors* » de Sorensen (2015), dans sa version la plus fine : c'est la **structure géométrique du déplacement**, pas le nom de l'algorithme, qui prédit le biais.\n"
    ]
   },
   {
@@ -904,10 +1092,10 @@
    "id": "36b89fa6",
    "metadata": {
     "papermill": {
-     "duration": 0.006613,
-     "end_time": "2026-06-23T17:37:48.795673+00:00",
+     "duration": 0.006063,
+     "end_time": "2026-06-23T18:10:33.227381+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.789060+00:00",
+     "start_time": "2026-06-23T18:10:33.221318+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,7 +1110,9 @@
     "| **Central** | optimum à l'origine, init/centre en zéro | `ShiftedFitness` | MGS-10 |\n",
     "| **Alignement d'axes** | opérateurs composante par composant | `RotatedFitness` | MGS-12 (celui-ci) |\n",
     "\n",
-    "Les deux sont des **décorateurs compositionnels** : ils réutilisent les mathématiques des fonctions canoniques sans les réimplémenter, et se composent (`new RotatedFitness(new ShiftedFitness(inner, o), M)`) pour la variante CEC complète. La leçon tient : on juge un optimiseur sur la **structure de ses opérateurs** (vectoriels vs composante par composant, centrés vs non), pas sur le nom de sa métaphore — et un banc honnête doit tester les deux biais.\n"
+    "Les deux sont des **décorateurs compositionnels** : ils réutilisent les mathématiques des fonctions canoniques sans les réimplémenter, et se composent (`new RotatedFitness(new ShiftedFitness(inner, o), M)`) pour la variante CEC complète. La leçon tient : on juge un optimiseur sur la **structure de ses opérateurs** (vectoriels vs composante par composant, centrés vs non), pas sur le nom de sa métaphore — et un banc honnête doit tester les deux biais.\n",
+    "\n",
+    "La **partie D** boucle le propos : à dimension assez élevée pour qu'il reste de la marge, la rotation discrimine les optimiseurs *selon la structure de leurs opérateurs* (composante par composant vs vectoriel) — la signature que les métaphores ne prédisent pas mais que la géométrie de l'opérateur, elle, révèle."
    ]
   },
   {
@@ -930,10 +1120,10 @@
    "id": "c32af2ee",
    "metadata": {
     "papermill": {
-     "duration": 0.008829,
-     "end_time": "2026-06-23T17:37:48.810965+00:00",
+     "duration": 0.005475,
+     "end_time": "2026-06-23T18:10:33.238512+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.802136+00:00",
+     "start_time": "2026-06-23T18:10:33.233037+00:00",
      "status": "completed"
     },
     "tags": []
@@ -949,10 +1139,10 @@
    "id": "34b0a5ec",
    "metadata": {
     "papermill": {
-     "duration": 0.008202,
-     "end_time": "2026-06-23T17:37:48.828867+00:00",
+     "duration": 0.005253,
+     "end_time": "2026-06-23T18:10:33.248929+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.820665+00:00",
+     "start_time": "2026-06-23T18:10:33.243676+00:00",
      "status": "completed"
     },
     "tags": []
@@ -967,20 +1157,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "b27002a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:37:48.846514Z",
-     "iopub.status.busy": "2026-06-23T17:37:48.846191Z",
-     "iopub.status.idle": "2026-06-23T17:37:48.926428Z",
-     "shell.execute_reply": "2026-06-23T17:37:48.926166Z"
+     "iopub.execute_input": "2026-06-23T18:10:33.261437Z",
+     "iopub.status.busy": "2026-06-23T18:10:33.261189Z",
+     "iopub.status.idle": "2026-06-23T18:10:33.350442Z",
+     "shell.execute_reply": "2026-06-23T18:10:33.350307Z"
     },
     "papermill": {
-     "duration": 0.091199,
-     "end_time": "2026-06-23T17:37:48.926544+00:00",
+     "duration": 0.096485,
+     "end_time": "2026-06-23T18:10:33.350508+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.835345+00:00",
+     "start_time": "2026-06-23T18:10:33.254023+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1005,41 +1195,41 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3dca906b",
+   "id": "c83160e3",
    "metadata": {
     "papermill": {
-     "duration": 0.006793,
-     "end_time": "2026-06-23T17:37:48.940618+00:00",
+     "duration": 0.005114,
+     "end_time": "2026-06-23T18:10:33.360016+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.933825+00:00",
+     "start_time": "2026-06-23T18:10:33.354902+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 : plus haute dimension amplifie-t-elle le biais ?\n",
+    "### Exercice 2 : la dimension amplifie-t-elle encore le biais ?\n",
     "\n",
-    "Rejouez la partie C en dimension 5 (attention aux bornes : l'optimum rotationné de Rosenbrock a pour norme $\\sqrt{d}$, il faut des bornes assez larges — utilisez par exemple $[-30, 30]$). Le $\\Delta$ des optimiseurs alignés sur les axes grandit-il avec la dimension ? C'est l'intuition CEC : la rotation est d'autant plus discriminante que la dimension est élevée.\n",
+    "La partie D a révélé la signature à la dimension 5. Reprenez son protocole à la **dimension 10** (bornes $[-30, 30]$, mêmes 5 graines, médiane). Le $\\Delta$ des opérateurs alignés sur les axes (GA uniforme, BBPSO) grandit-il avec la dimension ? C'est l'intuition CEC : plus la dimension est élevée, plus la rotation est discriminante. Attention au budget : à très haute dimension tout le monde échoue et le signal disparaît — gardez un NFE où il reste de la marge.\n",
     "\n",
-    "# Étape 1 : remplacer dimC par 5 et bounds par (-30, 30). # Étape 2 : relancer la paire roté/non roté. # Étape 3 : comparer les Δ à ceux de la dimension 2.\n"
+    "# Étape 1 : remplacer dimD par 10. # Étape 2 : relancer la paire roté/non roté sur les 5 graines. # Étape 3 : comparer les Δ à ceux de la dimension 5.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "b967b96a",
+   "execution_count": 9,
+   "id": "ea85d18e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:37:48.957360Z",
-     "iopub.status.busy": "2026-06-23T17:37:48.956938Z",
-     "iopub.status.idle": "2026-06-23T17:37:49.051447Z",
-     "shell.execute_reply": "2026-06-23T17:37:49.051250Z"
+     "iopub.execute_input": "2026-06-23T18:10:33.373659Z",
+     "iopub.status.busy": "2026-06-23T18:10:33.373382Z",
+     "iopub.status.idle": "2026-06-23T18:10:33.414690Z",
+     "shell.execute_reply": "2026-06-23T18:10:33.414523Z"
     },
     "papermill": {
-     "duration": 0.103841,
-     "end_time": "2026-06-23T17:37:49.051544+00:00",
+     "duration": 0.048983,
+     "end_time": "2026-06-23T18:10:33.414772+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:48.947703+00:00",
+     "start_time": "2026-06-23T18:10:33.365789+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1049,14 +1239,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 2 à compléter : Δ en dimension 5 vs dimension 2.\r\n"
+      "Exercice 2 à compléter : Δ en dimension 10 vs dimension 5.\r\n"
      ]
     }
    ],
    "source": [
-    "// Exercice 2 : signature delta de Rosenbrock roté en dimension 5 (bornes élargies).\n",
-    "// TODO étudiant : adapter la boucle de la partie C avec dimC = 5 et bounds = (-30.0, 30.0).\n",
-    "Console.WriteLine(\"Exercice 2 à compléter : Δ en dimension 5 vs dimension 2.\");\n"
+    "// Exercice 2 : signature delta de Rosenbrock roté en dimension 10 (vs dimension 5 de la partie D).\n",
+    "// TODO étudiant : adapter la boucle de la partie D avec dimD = 10.\n",
+    "Console.WriteLine(\"Exercice 2 à compléter : Δ en dimension 10 vs dimension 5.\");\n"
    ]
   },
   {
@@ -1064,10 +1254,10 @@
    "id": "cde00226",
    "metadata": {
     "papermill": {
-     "duration": 0.005661,
-     "end_time": "2026-06-23T17:37:49.062683+00:00",
+     "duration": 0.004973,
+     "end_time": "2026-06-23T18:10:33.425357+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:49.057022+00:00",
+     "start_time": "2026-06-23T18:10:33.420384+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1082,20 +1272,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "1bde0333",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:37:49.075407Z",
-     "iopub.status.busy": "2026-06-23T17:37:49.075112Z",
-     "iopub.status.idle": "2026-06-23T17:37:49.116456Z",
-     "shell.execute_reply": "2026-06-23T17:37:49.116259Z"
+     "iopub.execute_input": "2026-06-23T18:10:33.436235Z",
+     "iopub.status.busy": "2026-06-23T18:10:33.435887Z",
+     "iopub.status.idle": "2026-06-23T18:10:33.467786Z",
+     "shell.execute_reply": "2026-06-23T18:10:33.467650Z"
     },
     "papermill": {
-     "duration": 0.048705,
-     "end_time": "2026-06-23T17:37:49.116552+00:00",
+     "duration": 0.037847,
+     "end_time": "2026-06-23T18:10:33.467851+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:49.067847+00:00",
+     "start_time": "2026-06-23T18:10:33.430004+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1121,10 +1311,10 @@
    "id": "aa92218b",
    "metadata": {
     "papermill": {
-     "duration": 0.005339,
-     "end_time": "2026-06-23T17:37:49.128131+00:00",
+     "duration": 0.004428,
+     "end_time": "2026-06-23T18:10:33.476549+00:00",
      "exception": false,
-     "start_time": "2026-06-23T17:37:49.122792+00:00",
+     "start_time": "2026-06-23T18:10:33.472121+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1155,14 +1345,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 8.883404,
-   "end_time": "2026-06-23T17:37:49.372484+00:00",
+   "duration": 7.562356,
+   "end_time": "2026-06-23T18:10:33.717795+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MGS-12-AxisAlignment.ipynb",
-   "output_path": "mgs12_exec.ipynb",
+   "input_path": "_mgs12_build.ipynb",
+   "output_path": "_mgs12_exec.ipynb",
    "parameters": {},
-   "start_time": "2026-06-23T17:37:40.489080+00:00",
+   "start_time": "2026-06-23T18:10:26.155439+00:00",
    "version": "2.7.0"
   },
   "polyglot_notebook": {


### PR DESCRIPTION
## Contexte

Suite (enhancement) de **#4081 (MERGED)**, qui a livré le notebook MGS-12 rotation (décorateur `RotatedFitness`, `See #3963` Prong-2). La partie C (dim-2) y était honnêtement caveatée : « too easy » — tous les optimiseurs résolvent Rosenbrock 2D, aucun écart, le biais d'alignement d'axes ne peut pas se manifester.

Cette PR ajoute la **Partie D** qui lève le caveat : à dimension 5 (assez dure pour laisser de la marge), la signature opérateur apparaît.

## Résultat dim-5 (5 graines, médiane)

| Optimiseur | med non-roté | med roté | Δ = roté − non-roté |
|---|---|---|---|
| Random | 1,28e5 | 9,33e4 | (bruit) |
| GA(uniform) | 763 | 3610 | **+2847** |
| WOA | 6,22 | 1295 | **+1289** |
| DE | 1,88 | 3,93 | +2,05 |
| BBPSO | 13,4 | 995 | **+981** |

**Trouvaille honnête (plus fine que prévu).** Seul **DE** (différence vectorielle $F(a-b)$, équivariante par rotation) résiste (Δ≈2). GA/uniform, WOA, BBPSO sont tous dégradés. Pour résister à la rotation, il faut un déplacement *véritablement vectoriel* — pas seulement « stochastique » ou « continu ». BBPSO (gaussienne par dimension, covariance diagonale) et WOA (coefficient d'encerclement composante par composante) portent un alignement sur les axes que la rotation révèle dès que le problème est assez dur. *Components over metaphors*, version fine (Sorensen 2015).

## Corrections de cohérence (data-driven)

Le résultat dim-5 contredit la classification cycle-19 des opérateurs (qui rangeait BBPSO parmi les « vectoriels/isotropes ») :
- **cellule 4** (factories) : BBPSO reclassé « échantillonnage gaussien par dimension » (aligné sur les axes) ; DE seul véritablement vectoriel.
- **cellule 14** (lecture Partie C) : clause « vectoriels/isotropes (DE, BBPSO) » → « vectoriels (DE) ».

Exercice 2 reframé dim-5 (désormais travaillé en Partie D) → **dim-10**.

## Conformité

- **C.2** : 10/10 cellules code exécutées (papermill `.net-csharp`), 0 erreur, outputs committés.
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`.
- **#2161** : 3 exercices (dont Exercice 2 reframé dim-10).
- Submodule + catalogue **byte-identiques** (diff = MGS-12 seul, +327/−129).

## Note churn

Partie D était en préparation quand #4081 a été mergée (18:10Z) ; mon commit a atterri sur la branche déjà-mergée (dangling), récupéré ici sur branche fraîche issue d'origin/main. Leçon consolidée sur le dashboard : sur une PR CLEAN en attente de merge, **rapporter** le renforcement proposé au coordinateur plutôt que de re-pusher unilatéralement.

See jsboige/CoursIA#3963
