### PR TITLE
fix(genai-image): enforce single H1 per notebook (See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
@@ -1121,7 +1121,7 @@
    "source": [
     "---\n",
     "\n",
-    "# CHALLENGE BONUS - Génération d'Icone pour Application\n",
+    "## CHALLENGE BONUS - Génération d'Icone pour Application\n",
     "\n",
     "**Points : 0.5 pts**\n",
     "\n",


### PR DESCRIPTION
## Summary

Heading-hierarchy rollout #3966 — **GenAI/Image** family (2 notebooks fixed):

| Notebook | Cell | Before | After |
|----------|------|--------|-------|
| `01-Foundation/01-1-OpenAI-DALL-E-3.ipynb` | cell21 | `# CHALLENGE BONUS - Génération d'Icone…` | `## CHALLENGE BONUS - …` |
| `02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb` | cell2 | `# Qwen Image Edit 2509 - Édition Avancée…` (duplicate) | `## Qwen Image Edit 2509 - …` |

All 20 Image notebooks verified: each now has exactly **1 H1** (the numbered title in cell0/1).

The remaining 18 notebooks were already compliant.

## Reassessment

- Both fixes: surgical `H1 → H2` (single line demoted per notebook). Zero content removed.
- No `CHALLENGE BONUS` section removed — only heading level changed.
- No other headings touched (H2+ unchanged, list-embedded `- # Etape N` patterns are pedagogical list items, not standalone H1s).

## Test plan

- [x] Scan verified: `grep ATX column-0 '#'` count = 1 per notebook for both files
- [x] `git diff --stat`: 2 files, 2 insertions / 2 deletions
- [x] CRLF warnings expected (git autocrlf)

See #3966