### PR TITLE
feat(cooperative-games): prove banzhaf_raw_le_univ via BG prover (sorry 1->0; format fix unblocks side-track)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1035,7 +1035,8 @@ the critical coalitions are a subset of `Finset.univ`. First genuinely-provable,
 non-smoke target for the BG prover (#1453). -/
 theorem banzhaf_raw_le_univ (G : TUGame N) (i : N) :
     BanzhafRaw G i ≤ (Finset.univ : Finset (Finset N)).card := by
-  sorry
+  unfold BanzhafRaw
+  exact Finset.card_le_card (Finset.filter_subset _ _)
 
 /-- Player with veto power -/
 def VetoPlayer (G : TUGame N) (i : N) : Prop :=

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1034,7 +1034,8 @@ noncomputable def BanzhafRaw (G : TUGame N) (i : N) : ℕ :=
 the critical coalitions are a subset of `Finset.univ`. First genuinely-provable,
 non-smoke target for the BG prover (#1453). -/
 theorem banzhaf_raw_le_univ (G : TUGame N) (i : N) :
-    BanzhafRaw G i ≤ (Finset.univ : Finset (Finset N)).card := by sorry
+    BanzhafRaw G i ≤ (Finset.univ : Finset (Finset N)).card := by
+  sorry
 
 /-- Player with veto power -/
 def VetoPlayer (G : TUGame N) (i : N) : Prop :=

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1030,6 +1030,12 @@ noncomputable instance criticalDecidable (G : TUGame N) (i : N) :
 noncomputable def BanzhafRaw (G : TUGame N) (i : N) : ℕ :=
   (Finset.univ.filter fun S => Critical G i S).card
 
+/-- `BanzhafRaw G i` is bounded by the total number of coalitions (`2^|N|`):
+the critical coalitions are a subset of `Finset.univ`. First genuinely-provable,
+non-smoke target for the BG prover (#1453). -/
+theorem banzhaf_raw_le_univ (G : TUGame N) (i : N) :
+    BanzhafRaw G i ≤ (Finset.univ : Finset (Finset N)).card := by sorry
+
 /-- Player with veto power -/
 def VetoPlayer (G : TUGame N) (i : N) : Prop :=
   ∀ S : Finset N, G.v S = 1 → i ∈ S

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1578,6 +1578,45 @@ DEMOS = {
             "    refine (x, ?_, hxP)\n"
         ),
     },
+    56: {
+        "name": "BANZHAF_RAW_LE_UNIV",
+        "file": str(SHAPLEY_FILE) if SHAPLEY_FILE else "",
+        "line": 1037,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "banzhaf_raw_le_univ",
+        "theorem": "banzhaf_raw_le_univ",
+        "imports": SHAPLEY_IMPORTS,
+        "description": (
+            "REPLACES the single sorry at L1037 of Shapley.lean.\n"
+            "First genuinely-provable, NON-smoke target for the BG prover\n"
+            "(greenlit by ai-01 2026-06-23T18:12Z, #1453). Validates the\n"
+            "write-back fix #4075 on a REAL CoursIA Lean target, not a smoke.\n"
+            "\n"
+            "GOAL at sorry (EXACT):\n"
+            "  BanzhafRaw G i <= (Finset.univ : Finset (Finset N)).card\n"
+            "\n"
+            "HYPOTHESES IN SCOPE:\n"
+            "  N : Type, [Fintype N], [DecidableEq N]\n"
+            "  G : TUGame N, i : N\n"
+            "  BanzhafRaw G i := (Finset.univ.filter fun S => Critical G i S).card\n"
+            "\n"
+            "PROOF STRATEGY (~1-2 tactics):\n"
+            "  `BanzhafRaw` unfolds to `(Finset.univ.filter p).card`; a filtered\n"
+            "  finset is no larger than the original, so the bound is exactly\n"
+            "  `Finset.card_filter_le`. Suggested tactic:\n"
+            "    exact Finset.card_filter_le (fun S => Critical G i S) Finset.univ\n"
+            "  The carrier `Finset.univ : Finset (Finset N)` is fixed by the\n"
+            "  explicit annotation in the statement. Genuinely tractable,\n"
+            "  NOT a placeholder -- exercises the real proof loop."
+        ),
+        "difficulty": "easy",
+        "context_before": (
+            "/-- `BanzhafRaw G i` is bounded by the total number of coalitions. -/\n"
+            "theorem banzhaf_raw_le_univ (G : TUGame N) (i : N) :\n"
+            "    BanzhafRaw G i <= (Finset.univ : Finset (Finset N)).card := by\n"
+        ),
+        "context_after": "",
+    },
 }
 # (gale_shapley_stable) was proved in PR #1194. The prover skips any DEMO
 # whose key appears in this set.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1581,13 +1581,13 @@ DEMOS = {
     56: {
         "name": "BANZHAF_RAW_LE_UNIV",
         "file": str(SHAPLEY_FILE) if SHAPLEY_FILE else "",
-        "line": 1037,
+        "line": 1038,
         "sorry_type": "sorry_replacement",
         "theorem_name": "banzhaf_raw_le_univ",
         "theorem": "banzhaf_raw_le_univ",
         "imports": SHAPLEY_IMPORTS,
         "description": (
-            "REPLACES the single sorry at L1037 of Shapley.lean.\n"
+            "REPLACES the single sorry at L1038 of Shapley.lean.\n"
             "First genuinely-provable, NON-smoke target for the BG prover\n"
             "(greenlit by ai-01 2026-06-23T18:12Z, #1453). Validates the\n"
             "write-back fix #4075 on a REAL CoursIA Lean target, not a smoke.\n"

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -821,7 +821,7 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
         original_content = content
         real_relative = f"{subdir}/{Path(filepath).name}"
         try:
-            Path(filepath).write_text(new_content, encoding="utf-8")
+            Path(filepath).write_text(new_content, encoding="utf-8", newline="")
             real_result = verifier.verify_project_file(real_relative, force=True)
             real_output = real_result.get("raw_output", "") or ""
             # Real module must be error-free, carry no implicit-sorry warning,
@@ -833,7 +833,7 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
             sorry_dropped = (new_content.count("sorry")
                              < original_content.count("sorry"))
             if real_has_error or implicit_sorry or not sorry_dropped:
-                Path(filepath).write_text(original_content, encoding="utf-8")
+                Path(filepath).write_text(original_content, encoding="utf-8", newline="")
                 is_success = False
                 real_build_ok = False
                 error_type = "persist_build_failed"
@@ -850,7 +850,7 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
                 real_build_ok = True
         except OSError as _persist_err:
             try:
-                Path(filepath).write_text(original_content, encoding="utf-8")
+                Path(filepath).write_text(original_content, encoding="utf-8", newline="")
             except OSError:
                 pass
             is_success = False


### PR DESCRIPTION
**Run #2 SUCCEEDED — `banzhaf_raw_le_univ` proven, sorry 1->0.** The proving side-track is unblocked: the harness works on a real target once the stub uses the right format. First genuinely-provable, non-smoke target for the BG prover (#1453), greenlit by ai-01 2026-06-23T18:12Z.

## Verdict (cycle 63)

Run #1 (cycle 62) FAILED (sorry 1->1). Run #2 (cycle 63) **SUCCEEDED (sorry 1->0)**. The difference between them is **the stub FORMAT**, not a harness change.

```
=== Run #2 (sorry-on-own-line format) ===
result: { success: True, sorry_evolution: "1 -> 0" }
TacticAgent produced: unfold BanzhafRaw; exact Finset.card_le_card (Finset.filter_subset _ _)
VerifyExecutor -> verify_project_file -> success=True (persisted)
```

## The format fix = the lever (supersedes the cycle-62 "GoalExtract fundamentally limited" framing)

- **Cycle-62 stub put `sorry` on the theorem declaration line** (`:= by sorry`). GoalExtract (`lean_utils.py:188-191`) replaces the entire sorry-LINE with a probe (`exact ()`) to elicit a type-mismatch and read the goal. Replacing the declaration line breaks the declaration -> all 5 probes error -> `goal=None` -> agents work blind from the DEMOS description.
- **Cycle-63 fix: sorry on its OWN indented line** (`:= by\n  sorry`) keeps the `:= by`-terminated declaration intact, so the probe yields a clean type-mismatch revealing the goal. **Verified cheaply** via a direct `get_goal_state` call (`~90s`, not a 15-min run): goal `'BanzhafRaw G i ≤ Finset.univ.card'` extracted. **Then confirmed at full-run scale**: run-2 log shows `[GoalExtract] Probe 'exact ()': error: ... Type mismatch`.
- **Lesson (target-setup, mine — NOT a harness fix)**: BG target stubs MUST use `:= by\n  sorry` (sorry on its own line, the bullet-sorry format the harness expects per `lean_utils.py:199-200`), NEVER `:= by sorry` (sorry on the declaration line). ai-01 does NOT need to fix GoalExtract; proper stub formatting sidesteps it. The `goal` DEMOS override is consumed only in the legacy `provers.py` path, not the multi/agent path.

Run-1 had also picked the suboptimal lemma `card_le_card` (needs a subset proof) — but that was a consequence of working blind (no goal). With the goal visible, run-2 produced the subset proof `Finset.filter_subset _ _` and `card_le_card` now works fine.

## What's in this PR (3 files)

- **`Shapley.lean`** (`cbe4c9dd5`) — `banzhaf_raw_le_univ` now proven (was a stub):
  ```lean
  theorem banzhaf_raw_le_univ (G : TUGame N) (i : N) :
      BanzhafRaw G i ≤ (Finset.univ : Finset (Finset N)).card := by
    unfold BanzhafRaw
    exact Finset.card_le_card (Finset.filter_subset _ _)
  ```
  The explicit carrier annotation `(Finset.univ : Finset (Finset N))` is required (bare `Finset.univ.card` leaves the `Fintype` metavariable stuck). The `unfold BanzhafRaw; exact card_le_card (filter_subset _ _)` proof is a valid alternative to the direct `card_filter_le` (filter of univ is a subset of univ -> card_le_card).
- **`lean_utils.py`** (`4284dbc72`) — `write_text(new_content, newline="")` on the 3 real-file write-back writes (L824 new_content, L836/L853 original-content restore) so persisted proofs keep LF endings — avoids the CRLF git-diff churn flagged cycle 60. Confirmed clean: this commit's diff is `2 insertions / 1 deletion`, no whole-file CRLF noise.
- **`config.py`** (`ffb5c0753`) — DEMOS entry 56 `BANZHAF_RAW_LE_UNIV` -> `Shapley.lean:1038`, difficulty `easy`. Now a proven/calibration entry (future runs short-circuit `already_solved`, like demos 39-55). Keep or remove at ai-01's discretion.

## Verification (lean-merge-discipline section B)

- `lake build CooperativeGames` **SUCCESS** (LAKE_EXIT=0, 8435 jobs, 24s).
- `grep -cE` tactic-sorry in `Shapley.lean` = **0**.
- Diff is byte-surgical (sorry -> 2-line proof), LF-clean.
- Write-back fix #4075 confirmed working on a real target: no false-success (run-1 correctly rejected the non-compiling tactic; run-2 correctly persisted the compiling one).

## [ASK ai-01]

- **Stub-fate is now MOOT**: the stub became a real theorem, so the cooperative_games 0->1 sorry regression self-resolves (main stays 0-sorry; this branch takes it from 1-sorry-stub to 0-sorry-proof). Merge-ready once reviewed.
- **#4071** still OPEN/MERGEABLE (verified firsthand, phantom-merge trap cycle 50) — unblocks `banzhaf_index_nonneg` as the next BG target.
- **Next BG target**: with the harness working on real targets, propose `banzhaf_index_nonneg` (post-#4071) or `critical_implies_mem` (warm-up). Greenlight?

See #4088. Run-2 log: `C:/Users/jsboi/AppData/Local/Temp/po2026_bg_real56c_1782245330.log`.

Co-Authored-By: Claude <noreply@anthropic.com>