### PR TITLE
feat(z3): 06c Meal Planner Visualization — HTML rendering of Z3 solutions (#1206 step 4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
@@ -1,0 +1,1179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "hdr-title",
+   "metadata": {},
+   "source": [
+    "# Notebook 06c - Rendu HTML des solutions Z3 : visualisation structurée d'un planificateur de repas\n",
+    "\n",
+    "**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md) | [Notebook 05 (Meal Planner)](./05_Meal_Planner_Hierarchical.ipynb) | [Notebook 06b (RecipeML)](./06b_RecipeML_Corpus.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "- Comprendre **pourquoi** le rendu d'une solution Z3 importe autant que sa résolution : un solveur n'a de valeur opérationnelle que si ses sorties sont **lisibles par un humain**\n",
+    "- Utiliser l'API `display(HTML(...))` de `Microsoft.DotNet.Interactive` pour produire des **cartes HTML** (tableaux colorés, badges, barres de progression) depuis un modèle C#\n",
+    "- Réutiliser les modèles du notebook 06b (sélection booléenne, plan `int[][]`) et **n'en changer que la couche de présentation** — le solveur reste identique\n",
+    "- Produire un **front de Pareto** rendu visuellement : le solveur explore l'espace des solutions sous plusieurs bornes de budget, et le résultat est rendu comme un tableau de compromis\n",
+    "\n",
+    "## Prérequis\n",
+    "\n",
+    "- Notebook [05 (Meal Planner Hierarchical)](./05_Meal_Planner_Hierarchical.ipynb) : pattern `int[][]`, `MkITE`, `CollectionHandling.Array`\n",
+    "- Notebook [06b (RecipeML)](./06b_RecipeML_Corpus.ipynb) : corpus RecipeML, classe `Recipe`, allergènes\n",
+    "- Concepts : `XDocument`, interpolation de chaînes C#, HTML/CSS inline\n",
+    "\n",
+    "**Durée estimée** : 40-50 minutes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intro-gap",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Introduction : la frontière solveur / communication\n",
+    "\n",
+    "Les notebooks 05 et 06b affichaient leurs solutions via `Console.WriteLine` sous forme de **tableaux plats alignés par espaces**. Cette représentation suffit pour debugger ou vérifier un résultat à l'écran d'un développeur. Mais en production — un menu affiché à un utilisateur, un planning imprimé, un rapport envoyé à un diététicien — **la sortie texte brute est inutilisable** :\n",
+    "\n",
+    "- Impossible de distinguer au premier coup d'œil une recette qui dépasse le budget d'une qui le respecte\n",
+    "- Aucune signalétique visuelle pour les allergènes (pourtant critique pour la santé)\n",
+    "- Aucune barre ni jauge pour comparer des quantités (calories, protéines, coût)\n",
+    "- Pas de mise en page pour un plan multi-jours (lignes vs colonnes)\n",
+    "\n",
+    "Ce notebook introduit la brique qui manque : un **rendu HTML structuré et coloré** de la solution Z3. Le principe est simple — l'API `display(HTML(htmlString))` de `Microsoft.DotNet.Interactive` accepte n'importe quelle chaîne HTML et la rend comme une cellule `text/html` riche. On construit cette chaîne en C# pur (interpolation `$\"...\"` ou `StringBuilder`), en injectant les valeurs issues du modèle Z3.\n",
+    "\n",
+    "### Ce que ce notebook démontre\n",
+    "\n",
+    "1. **Couplage faible solveur / rendu** (section 3) — on reprend *exactement* le modèle booléen de 06b et on ne change **que la dernière ligne** : `display(HTML(RenderMenuCard(...)))` à la place de `Console.WriteLine`. Le solveur ne sait même pas qu'il est rendu en HTML.\n",
+    "2. **Plan multi-jours rendu en grille** (section 4) — le `int[][]` de 06b est projeté en une grille HTML 7 colonnes (jours en lignes), avec **détection visuelle des répétitions**.\n",
+    "3. **Exploration de l'espace des solutions rendue visible** (section 5) — on lance le solveur sous une **série de budgets** (800 à 2000 centimes) et on rend le **front de Pareto kcal/coût** sous forme de tableau de compromis. C'est une montée en gamme (EPIC #3801 Prong-B) : un seul solve n'illustre pas la richesse du moteur ; une exploration paramétrique oui.\n",
+    "\n",
+    "> **Note technique** : `display` et `HTML` sont des helpers globaux de `Microsoft.DotNet.Interactive`. Ils ne nécessitent pas de `using` spécifique, mais on ajoutera `using Microsoft.DotNet.Interactive;` par sécurité."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "setup-imports",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T20:47:20.185578Z",
+     "iopub.status.busy": "2026-06-23T20:47:20.172622Z",
+     "iopub.status.idle": "2026-06-23T20:47:21.535690Z",
+     "shell.execute_reply": "2026-06-23T20:47:21.517925Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-34940.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://10.54.226.85:2048/\", \"http://192.168.48.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '34940.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : Z3.Linq, Microsoft.Z3, Microsoft.DotNet.Interactive (rendu HTML)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"../Z3.Linq/.deploy/Microsoft.Z3.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/ExpressionUtils.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/Z3.Linq.dll\"\n",
+    "using Microsoft.Z3;\n",
+    "using Z3.Linq;\n",
+    "using Microsoft.DotNet.Interactive;\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.Xml.Linq;\n",
+    "Console.WriteLine(\"Imports OK : Z3.Linq, Microsoft.Z3, Microsoft.DotNet.Interactive (rendu HTML)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec1-title",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Corpus RecipeML et classe de domaine\n",
+    "\n",
+    "On réutilise **le même corpus 7-recettes** que le notebook 06b (entrées / plats / desserts avec un mix pédagogique de coûts, protéines, allergènes). Pour éviter le piège du **verbatim string C#** (les guillemets XML doivent être doublés dans `@\"...\"`, sous peine de CS1003/CS1010), on construit la chaîne XML via un `StringBuilder`. Plus sûr, même résultat.\n",
+    "\n",
+    "La classe `Recipe` est identique à 06b : le rendu HTML consommera exactement les mêmes propriétés (`Kcal`, `Protein`, `CostCents`, `Allergens`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "sec1-corpus",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T20:47:21.549526Z",
+     "iopub.status.busy": "2026-06-23T20:47:21.549176Z",
+     "iopub.status.idle": "2026-06-23T20:47:22.492643Z",
+     "shell.execute_reply": "2026-06-23T20:47:22.491963Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corpus parse : 7 recettes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nom                      Cat      kcal prot   prix allergenes        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Salade de quinoa         entree    180    6  280 c none              \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Veloute de potiron       entree    120    4  220 c lactose           \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Poulet roti aux herbes   plat      520   45  850 c none              \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lasagnes bolognaise      plat      610   28  720 c gluten,lactose    \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tofu curry coco          plat      430   22  540 c none              \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Brownie aux noix         dessert   380    6  410 c gluten,lactose,nuts\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Salade de fruits frais   dessert    90    1  180 c none              \r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Construction du corpus XML via StringBuilder (evite le piege du verbatim string @\"...\",\n",
+    "// ou chaque guillemet XML devrait etre double sous peine de CS1003/CS1010).\n",
+    "var sb = new StringBuilder();\n",
+    "sb.Append(\"<recipeml>\");\n",
+    "Action<string, string, int, int, int, int, int, int, string, int> add =\n",
+    "    (name, cat, kcal, prot, carbs, fat, cost, prep, allerg, idx) =>\n",
+    "    {\n",
+    "        sb.Append($\"<recipe><head><title>{name}</title><category>{cat}</category></head>\");\n",
+    "        sb.Append($\"<nutrition kcal=\\\"{kcal}\\\" protein=\\\"{prot}\\\" carbs=\\\"{carbs}\\\" fat=\\\"{fat}\\\"/>\");\n",
+    "        sb.Append($\"<prep time=\\\"{prep}\\\"/>\");\n",
+    "        sb.Append($\"<ingredients>(cf. corpus 06b)</ingredients>\");\n",
+    "        sb.Append($\"<allergens>{allerg}</allergens>\");\n",
+    "        sb.Append($\"<cost currency=\\\"EUR\\\">{cost}</cost></recipe>\");\n",
+    "    };\n",
+    "add(\"Salade de quinoa\",     \"entree\",  180,  6, 24,  6, 280, 15, \"none\",                0);\n",
+    "add(\"Veloute de potiron\",   \"entree\",  120,  4, 18,  3, 220, 20, \"lactose\",             1);\n",
+    "add(\"Poulet roti aux herbes\",\"plat\",   520, 45,  8, 32, 850, 60, \"none\",                2);\n",
+    "add(\"Lasagnes bolognaise\",  \"plat\",    610, 28, 55, 30, 720, 75, \"gluten,lactose\",      3);\n",
+    "add(\"Tofu curry coco\",      \"plat\",    430, 22, 30, 24, 540, 35, \"none\",                4);\n",
+    "add(\"Brownie aux noix\",     \"dessert\", 380,  6, 42, 22, 410, 45, \"gluten,lactose,nuts\", 5);\n",
+    "add(\"Salade de fruits frais\",\"dessert\", 90,  1, 22,  0, 180, 10, \"none\",                6);\n",
+    "sb.Append(\"</recipeml>\");\n",
+    "string recipesXml = sb.ToString();\n",
+    "\n",
+    "public class Recipe\n",
+    "{\n",
+    "    public string Name { get; set; }\n",
+    "    public string Category { get; set; }\n",
+    "    public int Kcal { get; set; }\n",
+    "    public int Protein { get; set; }\n",
+    "    public int Carbs { get; set; }\n",
+    "    public int Fat { get; set; }\n",
+    "    public int CostCents { get; set; }\n",
+    "    public int PrepMin { get; set; }\n",
+    "    public string Allergens { get; set; }\n",
+    "    public bool HasAllergen(string a) => Allergens != \"none\" && Allergens.Split(',').Contains(a);\n",
+    "}\n",
+    "\n",
+    "var doc = XDocument.Parse(recipesXml);\n",
+    "var corpus = doc.Root.Elements(\"recipe\").Select(r => new Recipe\n",
+    "{\n",
+    "    Name = (string)r.Element(\"head\").Element(\"title\"),\n",
+    "    Category = (string)r.Element(\"head\").Element(\"category\"),\n",
+    "    Kcal = (int)r.Element(\"nutrition\").Attribute(\"kcal\"),\n",
+    "    Protein = (int)r.Element(\"nutrition\").Attribute(\"protein\"),\n",
+    "    Carbs = (int)r.Element(\"nutrition\").Attribute(\"carbs\"),\n",
+    "    Fat = (int)r.Element(\"nutrition\").Attribute(\"fat\"),\n",
+    "    CostCents = (int)r.Element(\"cost\"),\n",
+    "    PrepMin = (int)r.Element(\"prep\").Attribute(\"time\"),\n",
+    "    Allergens = (string)r.Element(\"allergens\") ?? \"none\"\n",
+    "}).ToList();\n",
+    "\n",
+    "Console.WriteLine(\"Corpus parse : \" + corpus.Count + \" recettes\");\n",
+    "Console.WriteLine(string.Format(\"{0,-24} {1,-8} {2,4} {3,4} {4,6} {5,-18}\", \"Nom\", \"Cat\", \"kcal\", \"prot\", \"prix\", \"allergenes\"));\n",
+    "foreach (var rc in corpus)\n",
+    "    Console.WriteLine(string.Format(\"{0,-24} {1,-8} {2,4} {3,4} {4,4} c {5,-18}\", rc.Name, rc.Category, rc.Kcal, rc.Protein, rc.CostCents, rc.Allergens));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec2-title",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. Helper de rendu HTML : cartes et grilles\n",
+    "\n",
+    "On définit deux helpers statiques qui prennent en entrée des **objets du domaine** (pas des expressions Z3) et retournent une **chaîne HTML**. C'est cette séparation qui rend le rendu réutilisable : le helper ne sait pas que les données viennent d'un solveur.\n",
+    "\n",
+    "### `RenderMenuCard(IEnumerable<Recipe> menu, ...)`\n",
+    "\n",
+    "Renvoie une carte HTML stylée représentant un menu complet. Encodage visuel :\n",
+    "\n",
+    "- **Calories** : badge vert si 500-900 kcal (dans la cible), orange si à proximité (400-500 ou 900-1100), rouge sinon\n",
+    "- **Protéines** : barre de progression proportionnelle (sur une base de 50 g)\n",
+    "- **Coût** : badge vert si ≤ budget, rouge sinon\n",
+    "- **Allergènes** : badge rouge avec libellé si présent, badge vert \"sans allergène\" sinon\n",
+    "\n",
+    "### `RenderWeeklyGrid(int[][] plan, List<Recipe> corpus)`\n",
+    "\n",
+    "Renvoie une grille HTML (jours en lignes, créneaux en colonnes). Les répétitions d'une même recette à travers les jours sont **détectées** et marquées d'une couleur commune, afin de révéler visuellement une violation potentielle de variété.\n",
+    "\n",
+    "Le style utilise du CSS inline (pas de feuille externe) : coins arrondis, ombres légères, en-têtes colorées. Tout est dans la chaîne renvoyée — pas d'effet de bord."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "sec2-helpers",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T20:47:22.495710Z",
+     "iopub.status.busy": "2026-06-23T20:47:22.495292Z",
+     "iopub.status.idle": "2026-06-23T20:47:22.929249Z",
+     "shell.execute_reply": "2026-06-23T20:47:22.928544Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Helpers definis : RenderMenuCard, RenderWeeklyGrid, KcalColor, AllergenBadge, ProteinBar\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Helpers de rendu HTML : ils consomment des objets du domaine (Recipe) et renvoient une\n",
+    "// chaine HTML. Aucune dependance Z3 : la couche de presentation est découplée du solveur.\n",
+    "\n",
+    "public static string KcalColor(int kcal)\n",
+    "{\n",
+    "    if (kcal >= 500 && kcal <= 900) return \"#2e7d32\";   // vert : dans la cible\n",
+    "    if ((kcal >= 400 && kcal < 500) || (kcal > 900 && kcal <= 1100)) return \"#ef6c00\"; // orange\n",
+    "    return \"#c62828\";                                    // rouge : hors cible\n",
+    "}\n",
+    "\n",
+    "public static string AllergenBadge(Recipe r)\n",
+    "{\n",
+    "    if (r.Allergens == \"none\")\n",
+    "        return \"<span style='background:#2e7d32;color:white;padding:2px 8px;border-radius:8px;font-size:11px'>sans allergene</span>\";\n",
+    "    var parts = r.Allergens.Split(',').Select(a => $\"<span style='background:#c62828;color:white;padding:2px 8px;border-radius:8px;font-size:11px;margin-right:4px'>{a}</span>\");\n",
+    "    return string.Join(\"\", parts);\n",
+    "}\n",
+    "\n",
+    "public static string ProteinBar(int protein)\n",
+    "{\n",
+    "    int pct = Math.Min(100, protein * 100 / 50);  // base 50 g = 100 %\n",
+    "    string color = protein >= 30 ? \"#2e7d32\" : \"#ef6c00\";\n",
+    "    return $\"<div style='background:#eee;border-radius:4px;width:90px;height:10px;display:inline-block;vertical-align:middle'>\" +\n",
+    "           $\"<div style='background:{color};height:10px;border-radius:4px;width:{pct}%'></div></div> \" +\n",
+    "           $\"<span style='font-size:11px'>{protein} g</span>\";\n",
+    "}\n",
+    "\n",
+    "public static string RenderMenuCard(IEnumerable<Recipe> menu, string title, int budgetCents)\n",
+    "{\n",
+    "    var list = menu.ToList();\n",
+    "    int totKcal = list.Sum(r => r.Kcal);\n",
+    "    int totProt = list.Sum(r => r.Protein);\n",
+    "    int totCost = list.Sum(r => r.CostCents);\n",
+    "    string kcalCol = KcalColor(totKcal);\n",
+    "    string costCol = totCost <= budgetCents ? \"#2e7d32\" : \"#c62828\";\n",
+    "\n",
+    "    var h = new StringBuilder();\n",
+    "    h.Append($\"<div style='font-family:sans-serif;border:1px solid #ccc;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:720px;margin:8px 0;overflow:hidden'>\");\n",
+    "    h.Append($\"<div style='background:#1565c0;color:white;padding:10px 16px;font-size:16px;font-weight:bold'>{title}</div>\");\n",
+    "    h.Append(\"<div style='padding:8px 16px'>\");\n",
+    "    h.Append(\"<table style='width:100%;border-collapse:collapse;font-size:13px'>\");\n",
+    "    h.Append(\"<tr style='background:#f5f5f5'><th style='text-align:left;padding:6px'>Categorie</th><th style='text-align:left;padding:6px'>Recette</th><th style='padding:6px'>kcal</th><th style='padding:6px'>Proteines</th><th style='padding:6px'>Prix</th><th style='padding:6px'>Allergenes</th></tr>\");\n",
+    "    foreach (var r in list)\n",
+    "    {\n",
+    "        string kc = KcalColor(r.Kcal);\n",
+    "        h.Append($\"<tr style='border-bottom:1px solid #eee'>\");\n",
+    "        h.Append($\"<td style='padding:6px'><span style='background:#455a64;color:white;padding:2px 8px;border-radius:8px;font-size:11px'>{r.Category}</span></td>\");\n",
+    "        h.Append($\"<td style='padding:6px;font-weight:600'>{r.Name}</td>\");\n",
+    "        h.Append($\"<td style='padding:6px;text-align:center'><span style='color:{kc};font-weight:bold'>{r.Kcal}</span></td>\");\n",
+    "        h.Append($\"<td style='padding:6px'>{ProteinBar(r.Protein)}</td>\");\n",
+    "        h.Append($\"<td style='padding:6px;text-align:center'>{r.CostCents/100.0:F2} E</td>\");\n",
+    "        h.Append($\"<td style='padding:6px'>{AllergenBadge(r)}</td>\");\n",
+    "        h.Append(\"</tr>\");\n",
+    "    }\n",
+    "    h.Append($\"<tr style='background:#eceff1;font-weight:bold'>\");\n",
+    "    h.Append($\"<td colspan='2' style='padding:8px'>TOTAL</td>\");\n",
+    "    h.Append($\"<td style='padding:8px;text-align:center'><span style='color:{kcalCol}'>{totKcal}</span></td>\");\n",
+    "    h.Append($\"<td style='padding:8px'>{totProt} g</td>\");\n",
+    "    h.Append($\"<td style='padding:8px;text-align:center'><span style='color:{costCol}'>{totCost/100.0:F2} E / {budgetCents/100.0:F2}</span></td>\");\n",
+    "    h.Append(\"<td></td></tr>\");\n",
+    "    h.Append(\"</table></div></div>\");\n",
+    "    return h.ToString();\n",
+    "}\n",
+    "\n",
+    "public static string RenderWeeklyGrid(int[][] plan, List<Recipe> corpus)\n",
+    "{\n",
+    "    int days = plan.Length;\n",
+    "    int slots = days > 0 ? plan[0].Length : 0;\n",
+    "    // Couleur par indice de recette pour detecter les repetitions.\n",
+    "    var palette = new[] { \"#e3f2fd\", \"#fff3e0\", \"#e8f5e9\", \"#fce4ec\", \"#f3e5f5\", \"#fffde7\", \"#efebe9\" };\n",
+    "    var h = new StringBuilder();\n",
+    "    h.Append(\"<div style='font-family:sans-serif;border:1px solid #ccc;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:760px;margin:8px 0;overflow:hidden'>\");\n",
+    "    h.Append(\"<div style='background:#6a1b9a;color:white;padding:10px 16px;font-size:16px;font-weight:bold'>Plan multi-jours</div>\");\n",
+    "    h.Append(\"<div style='padding:8px 16px'><table style='width:100%;border-collapse:collapse;font-size:13px'>\");\n",
+    "    var slotNames = new[] { \"Dejeuner\", \"Diner\", \"Extra\" };\n",
+    "    h.Append(\"<tr style='background:#f5f5f5'><th style='padding:6px'>Jour</th>\");\n",
+    "    for (int s = 0; s < slots; s++)\n",
+    "        h.Append($\"<th style='padding:6px'>{(s < slotNames.Length ? slotNames[s] : \"Creneau \" + (s+1))}</th>\");\n",
+    "    h.Append(\"</tr>\");\n",
+    "    for (int d = 0; d < days; d++)\n",
+    "    {\n",
+    "        h.Append($\"<tr>\");\n",
+    "        h.Append($\"<td style='padding:6px;font-weight:bold;background:#fafafa'>Jour {d+1}</td>\");\n",
+    "        for (int s = 0; s < slots; s++)\n",
+    "        {\n",
+    "            int idx = plan[d][s];\n",
+    "            var rc = corpus[idx];\n",
+    "            string bg = palette[idx % palette.Length];\n",
+    "            h.Append($\"<td style='padding:6px;background:{bg};border:1px solid #ddd;border-radius:4px'>{rc.Name}<br/><span style='font-size:11px;color:#555'>{rc.Kcal} kcal / {rc.Category}</span></td>\");\n",
+    "        }\n",
+    "        h.Append(\"</tr>\");\n",
+    "    }\n",
+    "    h.Append(\"</table>\");\n",
+    "    h.Append(\"<div style='font-size:11px;color:#666;margin-top:6px'>Meme couleur de fond = meme recette (repetition visible).</div>\");\n",
+    "    h.Append(\"</div></div>\");\n",
+    "    return h.ToString();\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine($\"Helpers definis : RenderMenuCard, RenderWeeklyGrid, KcalColor, AllergenBadge, ProteinBar\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec3-title",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. Modèle booléen + rendu en carte HTML\n",
+    "\n",
+    "On reprend **à l'identique** le modèle booléen de 06b section 3 : une `BoolExpr` par recette, cardinalité 1 par catégorie, agrégation nutritionnelle via `MkITE`, exclusion de l'allergène `nuts`, bornes kcal/protéines/budget. La seule différence avec 06b est la **dernière ligne** : au lieu de `Console.WriteLine`, on appelle `display(HTML(RenderMenuCard(...)))`.\n",
+    "\n",
+    "C'est la démonstration centrale du notebook : **changer le rendu ne change pas le solveur**. Le moteur SMT reste la source de vérité ; la couche de présentation est une fonction pure des objets du domaine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "sec3-solve",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T20:47:22.931940Z",
+     "iopub.status.busy": "2026-06-23T20:47:22.931541Z",
+     "iopub.status.idle": "2026-06-23T20:47:23.491970Z",
+     "shell.execute_reply": "2026-06-23T20:47:23.491617Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat solve : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style='font-family:sans-serif;border:1px solid #ccc;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:720px;margin:8px 0;overflow:hidden'><div style='background:#1565c0;color:white;padding:10px 16px;font-size:16px;font-weight:bold'>Menu equilibre sans fruits a coque (solveur Z3)</div><div style='padding:8px 16px'><table style='width:100%;border-collapse:collapse;font-size:13px'><tr style='background:#f5f5f5'><th style='text-align:left;padding:6px'>Categorie</th><th style='text-align:left;padding:6px'>Recette</th><th style='padding:6px'>kcal</th><th style='padding:6px'>Proteines</th><th style='padding:6px'>Prix</th><th style='padding:6px'>Allergenes</th></tr><tr style='border-bottom:1px solid #eee'><td style='padding:6px'><span style='background:#455a64;color:white;padding:2px 8px;border-radius:8px;font-size:11px'>entree</span></td><td style='padding:6px;font-weight:600'>Veloute de potiron</td><td style='padding:6px;text-align:center'><span style='color:#c62828;font-weight:bold'>120</span></td><td style='padding:6px'><div style='background:#eee;border-radius:4px;width:90px;height:10px;display:inline-block;vertical-align:middle'><div style='background:#ef6c00;height:10px;border-radius:4px;width:8%'></div></div> <span style='font-size:11px'>4 g</span></td><td style='padding:6px;text-align:center'>2,20 E</td><td style='padding:6px'><span style='background:#c62828;color:white;padding:2px 8px;border-radius:8px;font-size:11px;margin-right:4px'>lactose</span></td></tr><tr style='border-bottom:1px solid #eee'><td style='padding:6px'><span style='background:#455a64;color:white;padding:2px 8px;border-radius:8px;font-size:11px'>plat</span></td><td style='padding:6px;font-weight:600'>Lasagnes bolognaise</td><td style='padding:6px;text-align:center'><span style='color:#2e7d32;font-weight:bold'>610</span></td><td style='padding:6px'><div style='background:#eee;border-radius:4px;width:90px;height:10px;display:inline-block;vertical-align:middle'><div style='background:#ef6c00;height:10px;border-radius:4px;width:56%'></div></div> <span style='font-size:11px'>28 g</span></td><td style='padding:6px;text-align:center'>7,20 E</td><td style='padding:6px'><span style='background:#c62828;color:white;padding:2px 8px;border-radius:8px;font-size:11px;margin-right:4px'>gluten</span><span style='background:#c62828;color:white;padding:2px 8px;border-radius:8px;font-size:11px;margin-right:4px'>lactose</span></td></tr><tr style='border-bottom:1px solid #eee'><td style='padding:6px'><span style='background:#455a64;color:white;padding:2px 8px;border-radius:8px;font-size:11px'>dessert</span></td><td style='padding:6px;font-weight:600'>Salade de fruits frais</td><td style='padding:6px;text-align:center'><span style='color:#c62828;font-weight:bold'>90</span></td><td style='padding:6px'><div style='background:#eee;border-radius:4px;width:90px;height:10px;display:inline-block;vertical-align:middle'><div style='background:#ef6c00;height:10px;border-radius:4px;width:2%'></div></div> <span style='font-size:11px'>1 g</span></td><td style='padding:6px;text-align:center'>1,80 E</td><td style='padding:6px'><span style='background:#2e7d32;color:white;padding:2px 8px;border-radius:8px;font-size:11px'>sans allergene</span></td></tr><tr style='background:#eceff1;font-weight:bold'><td colspan='2' style='padding:8px'>TOTAL</td><td style='padding:8px;text-align:center'><span style='color:#2e7d32'>820</span></td><td style='padding:8px'>33 g</td><td style='padding:8px;text-align:center'><span style='color:#2e7d32'>11,20 E / 15,00</span></td><td></td></tr></table></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Modele booleen Z3 (identique a 06b section 3) : un BoolExpr par recette, agregation MkITE,\n",
+    "// exclusion de l'allergene 'nuts'. Rendu final en carte HTML via display(HTML(...)).\n",
+    "\n",
+    "List<Recipe> solvedMenu = null;\n",
+    "Status solveStatus;\n",
+    "\n",
+    "using (var z3ctx = new Context())\n",
+    "{\n",
+    "    var solver = z3ctx.MkSolver();\n",
+    "    var selections = corpus\n",
+    "        .Select((rc, i) => new { Recipe = rc, Index = i, Var = (BoolExpr)z3ctx.MkConst($\"sel_{i}_{rc.Name}\", z3ctx.BoolSort) })\n",
+    "        .ToList();\n",
+    "\n",
+    "    void ExactlyOne(string cat)\n",
+    "    {\n",
+    "        var catVars = selections.Where(s => s.Recipe.Category == cat).Select(s => (BoolExpr)s.Var).ToArray();\n",
+    "        solver.Add(z3ctx.MkOr(catVars));\n",
+    "        for (int a = 0; a < catVars.Length; a++)\n",
+    "            for (int b = 0; b < catVars.Length; b++)\n",
+    "                if (a != b) solver.Add(z3ctx.MkImplies(catVars[a], z3ctx.MkNot(catVars[b])));\n",
+    "    }\n",
+    "    ExactlyOne(\"entree\"); ExactlyOne(\"plat\"); ExactlyOne(\"dessert\");\n",
+    "\n",
+    "    IntExpr totalKcal = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),\n",
+    "        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.Kcal), z3ctx.MkInt(0))));\n",
+    "    IntExpr totalProt = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),\n",
+    "        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.Protein), z3ctx.MkInt(0))));\n",
+    "    IntExpr totalCost = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),\n",
+    "        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.CostCents), z3ctx.MkInt(0))));\n",
+    "\n",
+    "    int budgetCents = 1500;\n",
+    "    solver.Add(z3ctx.MkGe(totalKcal, z3ctx.MkInt(500)));\n",
+    "    solver.Add(z3ctx.MkLe(totalKcal, z3ctx.MkInt(900)));\n",
+    "    solver.Add(z3ctx.MkGe(totalProt, z3ctx.MkInt(30)));\n",
+    "    solver.Add(z3ctx.MkLe(totalCost, z3ctx.MkInt(budgetCents)));\n",
+    "\n",
+    "    string bannedAllergen = \"nuts\";\n",
+    "    foreach (var s in selections.Where(s => s.Recipe.HasAllergen(bannedAllergen)))\n",
+    "        solver.Add(z3ctx.MkNot(s.Var));\n",
+    "\n",
+    "    solveStatus = solver.Check();\n",
+    "    Console.WriteLine($\"Resultat solve : {solveStatus}\");\n",
+    "\n",
+    "    if (solveStatus == Status.SATISFIABLE)\n",
+    "    {\n",
+    "        var model = solver.Model;\n",
+    "        solvedMenu = selections.Where(s => model.Eval(s.Var, true).BoolValue == Z3_lbool.Z3_L_TRUE)\n",
+    "                               .Select(s => s.Recipe).ToList();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "if (solvedMenu != null)\n",
+    "    display(HTML(RenderMenuCard(solvedMenu, \"Menu equilibre sans fruits a coque (solveur Z3)\", 1500)));\n",
+    "else\n",
+    "    Console.WriteLine(\"Aucun menu ne satisfait les contraintes.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec3-interp",
+   "metadata": {},
+   "source": [
+    "### Interpretation : ce que l'encodage couleur revele d'un coup d'oeil\n",
+    "\n",
+    "La carte HTML ci-dessus condense en une seule image ce que le tableau `Console.WriteLine` de 06b laissait au lecteur le soin de recomposer :\n",
+    "\n",
+    "| Aspect | Console (06b) | Carte HTML (06c) |\n",
+    "|--------|---------------|------------------|\n",
+    "| Calories dans la cible 500-900 | à calculer mentalement | badge couleur sur le total |\n",
+    "| Recette qui monte en calories | pas de signal | chiffre coloré par ligne |\n",
+    "| Apport protéique | chiffre brut | barre de progression visuelle |\n",
+    "| Statut d'allergène | chaîne à lire | badge rouge/vert instantané |\n",
+    "| Dépassement de budget | soustraction manuelle | total coloré vs budget affiché |\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "1. **Le solveur n'a pas changé** — l'objet `solvedMenu` est une `List<Recipe>` conforme à la même définition qu'en 06b. Le rendu HTML est une **fonction pure** de cette liste.\n",
+    "2. **Le badge allergène rouge** rend immédiatement visible si une recette sélectionnée contient du lactose ou du gluten — utile pour le communicant qui prépare le menu, pas seulement le diététicien qui le calcule.\n",
+    "3. **L'extension est triviale** : ajouter une colonne \"temps de préparation\" consisterait à ajouter une cellule `<td>{r.PrepMin} min</td>` — sans toucher au modèle Z3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec4-title",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Plan hebdomadaire `int[][]` + grille HTML\n",
+    "\n",
+    "On étend au plan multi-jours du notebook 06b section 4 : un `int[][]` (3 jours x 2 créneaux) peuplé d'indices de recettes dans le corpus, avec contrainte de non-répétition des déjeuners via `Z3Methods.Distinct` en mode `CollectionHandling.Array`.\n",
+    "\n",
+    "### Workaround technique (rappel)\n",
+    "\n",
+    "> La cellule ci-dessous regroupe **dans le même bloc** la déclaration des bornes (`entLo`, `pltLo`, etc.), la construction du théorème `Where(...)`, **et** l'appel `.Solve()`. Ce n'est pas un hasard : c'est le **workaround validé** pour le pattern `int[][]` en kernel `.net-csharp`. Capturer dans une contrainte `Where(...)` une variable déclarée dans une cellule précédente déclenche `ArgumentException` (le `ExpressionVisitor` du fork Z3.Linq résout par réflexion les constantes cross-submission, ce qui échoue). La parade : tout garder dans le même scope."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "sec4-solve",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T20:47:23.494792Z",
+     "iopub.status.busy": "2026-06-23T20:47:23.494373Z",
+     "iopub.status.idle": "2026-06-23T20:47:23.838605Z",
+     "shell.execute_reply": "2026-06-23T20:47:23.838891Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bornes corpus -> entrees [0,1], plats [2,4], desserts [5,6]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Theoreme int[][] resolu en 74,4 ms (status : SAT)\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style='font-family:sans-serif;border:1px solid #ccc;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:760px;margin:8px 0;overflow:hidden'><div style='background:#6a1b9a;color:white;padding:10px 16px;font-size:16px;font-weight:bold'>Plan multi-jours</div><div style='padding:8px 16px'><table style='width:100%;border-collapse:collapse;font-size:13px'><tr style='background:#f5f5f5'><th style='padding:6px'>Jour</th><th style='padding:6px'>Dejeuner</th><th style='padding:6px'>Diner</th></tr><tr><td style='padding:6px;font-weight:bold;background:#fafafa'>Jour 1</td><td style='padding:6px;background:#fce4ec;border:1px solid #ddd;border-radius:4px'>Lasagnes bolognaise<br/><span style='font-size:11px;color:#555'>610 kcal / plat</span></td><td style='padding:6px;background:#e8f5e9;border:1px solid #ddd;border-radius:4px'>Poulet roti aux herbes<br/><span style='font-size:11px;color:#555'>520 kcal / plat</span></td></tr><tr><td style='padding:6px;font-weight:bold;background:#fafafa'>Jour 2</td><td style='padding:6px;background:#e8f5e9;border:1px solid #ddd;border-radius:4px'>Poulet roti aux herbes<br/><span style='font-size:11px;color:#555'>520 kcal / plat</span></td><td style='padding:6px;background:#f3e5f5;border:1px solid #ddd;border-radius:4px'>Tofu curry coco<br/><span style='font-size:11px;color:#555'>430 kcal / plat</span></td></tr><tr><td style='padding:6px;font-weight:bold;background:#fafafa'>Jour 3</td><td style='padding:6px;background:#f3e5f5;border:1px solid #ddd;border-radius:4px'>Tofu curry coco<br/><span style='font-size:11px;color:#555'>430 kcal / plat</span></td><td style='padding:6px;background:#fce4ec;border:1px solid #ddd;border-radius:4px'>Lasagnes bolognaise<br/><span style='font-size:11px;color:#555'>610 kcal / plat</span></td></tr></table><div style='font-size:11px;color:#666;margin-top:6px'>Meme couleur de fond = meme recette (repetition visible).</div></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Theoreme hierarchique int[][] sur le corpus RecipeML, rendu en grille HTML.\n",
+    "// ATTENTION (workaround confirme) : bornes + Where(...) + Solve() dans la MEME cellule.\n",
+    "\n",
+    "public class DayPlan\n",
+    "{\n",
+    "    public int[][] Sel { get; set; } = new int[3][];\n",
+    "    public DayPlan() { for (int t = 0; t < 3; t++) Sel[t] = new int[2]; }\n",
+    "}\n",
+    "\n",
+    "int entLo = corpus.FindIndex(r => r.Category == \"entree\");\n",
+    "int entHi = corpus.FindLastIndex(r => r.Category == \"entree\");\n",
+    "int pltLo = corpus.FindIndex(r => r.Category == \"plat\");\n",
+    "int pltHi = corpus.FindLastIndex(r => r.Category == \"plat\");\n",
+    "int desLo = corpus.FindIndex(r => r.Category == \"dessert\");\n",
+    "int desHi = corpus.FindLastIndex(r => r.Category == \"dessert\");\n",
+    "Console.WriteLine($\"Bornes corpus -> entrees [{entLo},{entHi}], plats [{pltLo},{pltHi}], desserts [{desLo},{desHi}]\");\n",
+    "\n",
+    "DayPlan sol = null;\n",
+    "using (var ctx = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array })\n",
+    "{\n",
+    "    var th = ctx.NewTheorem<DayPlan>();\n",
+    "    for (int t = 0; t < 3; t++)\n",
+    "    {\n",
+    "        int tt = t;\n",
+    "        th = th.Where(g => g.Sel[tt][0] >= pltLo && g.Sel[tt][0] <= pltHi);\n",
+    "        th = th.Where(g => g.Sel[tt][1] >= pltLo && g.Sel[tt][1] <= pltHi);\n",
+    "    }\n",
+    "    th = th.Where(g => Z3Methods.Distinct(g.Sel[0][0], g.Sel[1][0], g.Sel[2][0]));\n",
+    "\n",
+    "    var sw = System.Diagnostics.Stopwatch.StartNew();\n",
+    "    sol = th.Solve();\n",
+    "    sw.Stop();\n",
+    "    Console.WriteLine($\"Theoreme int[][] resolu en {sw.Elapsed.TotalMilliseconds:F1} ms (status : {(sol != null ? \"SAT\" : \"UNSAT\")})\");\n",
+    "}\n",
+    "\n",
+    "if (sol != null)\n",
+    "    display(HTML(RenderWeeklyGrid(sol.Sel, corpus)));\n",
+    "else\n",
+    "    Console.WriteLine(\"(Aucun plan realisable avec ces bornes.)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec4-interp",
+   "metadata": {},
+   "source": [
+    "### Interpretation : la grille rend la variété visible\n",
+    "\n",
+    "La grille HTML ci-dessus attribue à **chaque indice de recette** une couleur de fond stable. Sans même lire les noms, l'œil repère :\n",
+    "\n",
+    "- les **colonnes déjeuner** : trois couleurs différentes = contrainte `Distinct` satisfaite (aucune répétition cross-jour)\n",
+    "- les **colonnes dîner** : peuvent se chevaucher (pas de contrainte `Distinct` posée ici — cf. exercice 2)\n",
+    "\n",
+    "| Aspect | Rôle de la couleur |\n",
+    "|--------|---------------------|\n",
+    "| Vérifier la non-répetition | couleurs identiques = alerte immédiate |\n",
+    "| Repérer une catégorie absente | aucune cellule verte si aucun dessert |\n",
+    "| Comparer visuellement la charge kcal | lecture facile des annotations par cellule |\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "1. Le solveur trouve une **permutation complète** des trois plats du corpus sur les trois déjeuners — la contrainte `Z3Methods.Distinct` accomplit un travail qu'une simple borne ne pourrait pas exprimer (non-trivialité Prong-B).\n",
+    "2. Le rendu grille est **indépendant du contenu** : la même fonction `RenderWeeklyGrid` afficherait aussi bien un plan 7 jours x 3 créneaux. Seule la forme du `int[][]` change."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec5-title",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Front de Pareto HTML : exploration de l'espace des solutions\n",
+    "\n",
+    "Un seul solve montre qu'il **existe** une solution. Une **série de solves sous budgets décroissants** révèle la structure du compromis kcal/coût — c'est le front de Pareto. Cette section est la montée en gamme du notebook (EPIC #3801 Prong-B) : on fait valoir la capacité du moteur à **explorer** un espace paramétrique, pas seulement à trouver un point.\n",
+    "\n",
+    "On boucle sur les budgets de 800 à 2000 centimes (par pas de 200), on résout à chaque fois le modèle booléen avec le même corpus, et on collecte le couple `(kcal, cost, prot)` de la solution retenue. On rend ensuite le tout comme un **tableau stylé de compromis** où chaque ligne est un point du front."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "sec5-solve",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T20:47:23.841433Z",
+     "iopub.status.busy": "2026-06-23T20:47:23.841041Z",
+     "iopub.status.idle": "2026-06-23T20:47:24.637241Z",
+     "shell.execute_reply": "2026-06-23T20:47:24.637835Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Front de Pareto : 7 points (budgets 800 a 2000 centimes)\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style='font-family:sans-serif;border:1px solid #ccc;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:780px;margin:8px 0;overflow:hidden'><div style='background:#00695c;color:white;padding:10px 16px;font-size:16px;font-weight:bold'>Front de Pareto : compromis kcal / cout</div><div style='padding:8px 16px'><table style='width:100%;border-collapse:collapse;font-size:13px'><tr style='background:#f5f5f5'><th style='padding:6px'>Budget (E)</th><th style='padding:6px'>kcal</th><th style='padding:6px'>Jauge kcal</th><th style='padding:6px'>cout reel (E)</th><th style='padding:6px'>prot (g)</th><th style='padding:6px'>menu</th></tr><tr style='border-bottom:1px solid #eee'><td style='padding:6px;text-align:center'>20,00</td><td style='padding:6px;text-align:center;color:#2e7d32;font-weight:bold'>820</td><td style='padding:6px'><div style='background:#eee;border-radius:4px;width:140px;height:10px'><div style='background:#2e7d32;height:10px;border-radius:4px;width:100%'></div></div></td><td style='padding:6px;text-align:center'>11,20 <span style='color:#2e7d32;font-size:11px'>(marge 8,80)</span></td><td style='padding:6px;text-align:center'>33</td><td style='padding:6px;font-size:12px'>Veloute de potiron + Lasagnes bolognaise + Salade de fruits frais</td></tr><tr style='border-bottom:1px solid #eee'><td style='padding:6px;text-align:center'>18,00</td><td style='padding:6px;text-align:center;color:#2e7d32;font-weight:bold'>820</td><td style='padding:6px'><div style='background:#eee;border-radius:4px;width:140px;height:10px'><div style='background:#2e7d32;height:10px;border-radius:4px;width:100%'></div></div></td><td style='padding:6px;text-align:center'>11,20 <span style='color:#2e7d32;font-size:11px'>(marge 6,80)</span></td><td style='padding:6px;text-align:center'>33</td><td style='padding:6px;font-size:12px'>Veloute de potiron + Lasagnes bolognaise + Salade de fruits frais</td></tr><tr style='border-bottom:1px solid #eee'><td style='padding:6px;text-align:center'>16,00</td><td style='padding:6px;text-align:center;color:#2e7d32;font-weight:bold'>820</td><td style='padding:6px'><div style='background:#eee;border-radius:4px;width:140px;height:10px'><div style='background:#2e7d32;height:10px;border-radius:4px;width:100%'></div></div></td><td style='padding:6px;text-align:center'>11,20 <span style='color:#2e7d32;font-size:11px'>(marge 4,80)</span></td><td style='padding:6px;text-align:center'>33</td><td style='padding:6px;font-size:12px'>Veloute de potiron + Lasagnes bolognaise + Salade de fruits frais</td></tr><tr style='border-bottom:1px solid #eee'><td style='padding:6px;text-align:center'>14,00</td><td style='padding:6px;text-align:center;color:#2e7d32;font-weight:bold'>820</td><td style='padding:6px'><div style='background:#eee;border-radius:4px;width:140px;height:10px'><div style='background:#2e7d32;height:10px;border-radius:4px;width:100%'></div></div></td><td style='padding:6px;text-align:center'>11,20 <span style='color:#2e7d32;font-size:11px'>(marge 2,80)</span></td><td style='padding:6px;text-align:center'>33</td><td style='padding:6px;font-size:12px'>Veloute de potiron + Lasagnes bolognaise + Salade de fruits frais</td></tr><tr style='border-bottom:1px solid #eee'><td style='padding:6px;text-align:center'>12,00</td><td style='padding:6px;text-align:center;color:#2e7d32;font-weight:bold'>820</td><td style='padding:6px'><div style='background:#eee;border-radius:4px;width:140px;height:10px'><div style='background:#2e7d32;height:10px;border-radius:4px;width:100%'></div></div></td><td style='padding:6px;text-align:center'>11,20 <span style='color:#2e7d32;font-size:11px'>(marge 0,80)</span></td><td style='padding:6px;text-align:center'>33</td><td style='padding:6px;font-size:12px'>Veloute de potiron + Lasagnes bolognaise + Salade de fruits frais</td></tr><tr style='border-bottom:1px solid #eee'><td style='padding:6px;text-align:center'>10,00</td><td style='padding:6px;text-align:center;color:#2e7d32;font-weight:bold'>640</td><td style='padding:6px'><div style='background:#eee;border-radius:4px;width:140px;height:10px'><div style='background:#2e7d32;height:10px;border-radius:4px;width:78%'></div></div></td><td style='padding:6px;text-align:center'>9,40 <span style='color:#2e7d32;font-size:11px'>(marge 0,60)</span></td><td style='padding:6px;text-align:center'>27</td><td style='padding:6px;font-size:12px'>Veloute de potiron + Tofu curry coco + Salade de fruits frais</td></tr><tr><td colspan='6' style='padding:6px;color:#c62828;font-style:italic'>Budget 8,00 E : irrealisable</td></tr></table><div style='font-size:11px;color:#666;margin-top:6px'>Chaque ligne = une solution du solveur sous un budget different. La jauge kcal est relative au max observe.</div></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Front de Pareto kcal/cout : on boucle sur des budgets decroissants, on resout le modele\n",
+    "// booleen a chaque fois (brownie reste exclu), et on collecte (budget, kcal, cout, prot).\n",
+    "// Rendu final en tableau HTML style \"compromis\".\n",
+    "\n",
+    "var pareto = new List<(int BudgetCents, int Kcal, int Cost, int Prot, string Desc)>();\n",
+    "\n",
+    "foreach (int budgetCents in new[] { 2000, 1800, 1600, 1400, 1200, 1000, 800 })\n",
+    "{\n",
+    "    using (var z3ctx = new Context())\n",
+    "    {\n",
+    "        var solver = z3ctx.MkSolver();\n",
+    "        var selections = corpus\n",
+    "            .Select((rc, i) => new { Recipe = rc, Var = (BoolExpr)z3ctx.MkConst($\"s_{i}_{budgetCents}\", z3ctx.BoolSort) })\n",
+    "            .ToList();\n",
+    "\n",
+    "        void ExactlyOne(string cat)\n",
+    "        {\n",
+    "            var cv = selections.Where(s => s.Recipe.Category == cat).Select(s => (BoolExpr)s.Var).ToArray();\n",
+    "            solver.Add(z3ctx.MkOr(cv));\n",
+    "            for (int a = 0; a < cv.Length; a++)\n",
+    "                for (int b = 0; b < cv.Length; b++)\n",
+    "                    if (a != b) solver.Add(z3ctx.MkImplies(cv[a], z3ctx.MkNot(cv[b])));\n",
+    "        }\n",
+    "        ExactlyOne(\"entree\"); ExactlyOne(\"plat\"); ExactlyOne(\"dessert\");\n",
+    "\n",
+    "        IntExpr totalKcal = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),\n",
+    "            (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.Kcal), z3ctx.MkInt(0))));\n",
+    "        IntExpr totalProt = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),\n",
+    "            (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.Protein), z3ctx.MkInt(0))));\n",
+    "        IntExpr totalCost = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),\n",
+    "            (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.CostCents), z3ctx.MkInt(0))));\n",
+    "\n",
+    "        solver.Add(z3ctx.MkGe(totalKcal, z3ctx.MkInt(400)));\n",
+    "        solver.Add(z3ctx.MkGe(totalProt, z3ctx.MkInt(20)));\n",
+    "        solver.Add(z3ctx.MkLe(totalCost, z3ctx.MkInt(budgetCents)));\n",
+    "        foreach (var s in selections.Where(s => s.Recipe.HasAllergen(\"nuts\")))\n",
+    "            solver.Add(z3ctx.MkNot(s.Var));\n",
+    "\n",
+    "        if (solver.Check() == Status.SATISFIABLE)\n",
+    "        {\n",
+    "            var model = solver.Model;\n",
+    "            var chosen = selections.Where(s => model.Eval(s.Var, true).BoolValue == Z3_lbool.Z3_L_TRUE).Select(s => s.Recipe).ToList();\n",
+    "            pareto.Add((budgetCents, chosen.Sum(r => r.Kcal), chosen.Sum(r => r.CostCents), chosen.Sum(r => r.Protein),\n",
+    "                        string.Join(\" + \", chosen.Select(r => r.Name))));\n",
+    "        }\n",
+    "        else\n",
+    "        {\n",
+    "            pareto.Add((budgetCents, -1, -1, -1, \"(IRREALISABLE)\"));\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Rendu HTML du front de Pareto.\n",
+    "int maxKcal = pareto.Where(p => p.Kcal > 0).Max(p => p.Kcal);\n",
+    "var h = new StringBuilder();\n",
+    "h.Append(\"<div style='font-family:sans-serif;border:1px solid #ccc;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:780px;margin:8px 0;overflow:hidden'>\");\n",
+    "h.Append(\"<div style='background:#00695c;color:white;padding:10px 16px;font-size:16px;font-weight:bold'>Front de Pareto : compromis kcal / cout</div>\");\n",
+    "h.Append(\"<div style='padding:8px 16px'><table style='width:100%;border-collapse:collapse;font-size:13px'>\");\n",
+    "h.Append(\"<tr style='background:#f5f5f5'><th style='padding:6px'>Budget (E)</th><th style='padding:6px'>kcal</th><th style='padding:6px'>Jauge kcal</th><th style='padding:6px'>cout reel (E)</th><th style='padding:6px'>prot (g)</th><th style='padding:6px'>menu</th></tr>\");\n",
+    "foreach (var p in pareto)\n",
+    "{\n",
+    "    if (p.Kcal < 0)\n",
+    "    {\n",
+    "        h.Append($\"<tr><td colspan='6' style='padding:6px;color:#c62828;font-style:italic'>Budget {p.BudgetCents/100.0:F2} E : irrealisable</td></tr>\");\n",
+    "        continue;\n",
+    "    }\n",
+    "    int pct = maxKcal > 0 ? p.Kcal * 100 / maxKcal : 0;\n",
+    "    string col = KcalColor(p.Kcal);\n",
+    "    int margin = p.BudgetCents - p.Cost;\n",
+    "    string marginCol = margin >= 0 ? \"#2e7d32\" : \"#c62828\";\n",
+    "    h.Append(\"<tr style='border-bottom:1px solid #eee'>\");\n",
+    "    h.Append($\"<td style='padding:6px;text-align:center'>{p.BudgetCents/100.0:F2}</td>\");\n",
+    "    h.Append($\"<td style='padding:6px;text-align:center;color:{col};font-weight:bold'>{p.Kcal}</td>\");\n",
+    "    h.Append($\"<td style='padding:6px'><div style='background:#eee;border-radius:4px;width:140px;height:10px'><div style='background:{col};height:10px;border-radius:4px;width:{pct}%'></div></div></td>\");\n",
+    "    h.Append($\"<td style='padding:6px;text-align:center'>{p.Cost/100.0:F2} <span style='color:{marginCol};font-size:11px'>(marge {margin/100.0:F2})</span></td>\");\n",
+    "    h.Append($\"<td style='padding:6px;text-align:center'>{p.Prot}</td>\");\n",
+    "    h.Append($\"<td style='padding:6px;font-size:12px'>{p.Desc}</td>\");\n",
+    "    h.Append(\"</tr>\");\n",
+    "}\n",
+    "h.Append(\"</table>\");\n",
+    "h.Append(\"<div style='font-size:11px;color:#666;margin-top:6px'>Chaque ligne = une solution du solveur sous un budget different. La jauge kcal est relative au max observe.</div>\");\n",
+    "h.Append(\"</div></div>\");\n",
+    "Console.WriteLine($\"Front de Pareto : {pareto.Count} points (budgets 800 a 2000 centimes)\");\n",
+    "display(HTML(h.ToString()));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec5-interp",
+   "metadata": {},
+   "source": [
+    "### Interpretation : le solveur comme explorateur de l'espace des solutions\n",
+    "\n",
+    "Le tableau ci-dessus **ne montre pas une solution** mais un **spectre** : ce que le solveur peut atteindre à chaque niveau de budget. C'est l'argument opérationnel pour utiliser un moteur SMT plutôt qu'un algorithme glouton :\n",
+    "\n",
+    "| Observation | Lecture |\n",
+    "|-------------|---------|\n",
+    "| À budget élevé (20 EUR), kcal max | le solveur peut se permettre un menu consistant |\n",
+    "| À budget bas, bascule vers Tofu/Salade | **rotation automatique** des recettes moins chères |\n",
+    "| Palier \"irréalisable\" | le solveur prouve qu'aucun menu ne satisfait les contraintes minimales |\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "1. **Chaque ligne est un solve indépendant** — il n'y a pas d'astuce : le solveur a tourné 7 fois. Le coût calculatoire est négligeable (chaque solve prend quelques ms).\n",
+    "2. **Le rendu rend la décision possible** : un décideur qui compare visuellement les jauges et les marges peut arbitrer \"je sacrifie 100 kcal pour économiser 2 EUR\" en un coup d'œil. C'est exactement la valeur d'un solveur rendu lisiblement.\n",
+    "3. **Frontière avec l'optimisation** : on n'a pas **maximisé** ici (ce serait l'exercice 2 du notebook 06b), on a **échantillonné**. Les deux approches sont complémentaires."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "recap-title",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. Tableau récapitulatif : Console (05/06b) vs HTML (06c)\n",
+    "\n",
+    "| Critère | `Console.WriteLine` (05, 06b) | `display(HTML(...))` (06c) |\n",
+    "|---------|--------------------------------|----------------------------|\n",
+    "| Support | texte brut aligné par espaces | HTML riche rendu par le notebook |\n",
+    "| Encodage couleur | aucun | badges, jauges, codes caloriques |\n",
+    "| Détection allergène | lecture de chaîne | badge rouge/vert instantané |\n",
+    "| Plan multi-jours | liste de lignes | grille colourisée, répétitions visibles |\n",
+    "| Exploration paramétrique | fastidieuse | front de Pareto rendu en un bloc |\n",
+    "| Effort code | un `Console.WriteLine` | un helper HTML + appel `display` |\n",
+    "| Couplage au solveur | aucun | aucun (fonction pure des objets du domaine) |\n",
+    "\n",
+    "### Le point fondamental\n",
+    "\n",
+    "Le solveur n'a **pas été modifié** entre 06b et 06c. Les modèles (booléen avec `MkITE`, hiérarchique `int[][]`) sont identiques. Seule la **dernière ligne** de chaque section a changé : `Console.WriteLine` est devenu `display(HTML(...))`. C'est la preuve que l'architecture est **découplée** : le solveur produit des objets du domaine, le rendu est une fonction pure de ces objets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exercices-intro",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercices\n",
+    "\n",
+    "Les exercices ci-dessous étendent la couche de rendu HTML. Chaque stub est volontairement incomplet : remplacez les commentaires `// TODO etudiant` par votre code. Les stubs ne lèvent **pas** d'exception — le notebook s'exécute de bout en bout même exercices non remplis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exo1-title",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Badge végétarien dans la carte de menu\n",
+    "\n",
+    "Ajoutez à la fonction `RenderMenuCard` un **badge végétarien** global (en haut de la carte) : vert si **toutes** les recettes du menu sont végétariennes, rouge sinon. On considère comme non-végétariennes les recettes dont le nom contient `\"Poulet\"`, `\"boeuf\"` ou `\"Lasagnes\"`.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Etape 1` : écrivez un prédicat `bool IsVegetarian(Recipe r)` qui renvoie `false` si `r.Name` contient l'un des marqueurs.\n",
+    "- `# Etape 2` : dans `RenderMenuCard`, calculez `bool allVeg = list.All(IsVegetarian)`.\n",
+    "- `# Etape 3` : insérez dans l'en-tête de la carte un badge : vert \"100% vegetarien\" si `allVeg`, rouge \"contient de la viande\" sinon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "exo1-stub",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T20:47:24.640619Z",
+     "iopub.status.busy": "2026-06-23T20:47:24.640186Z",
+     "iopub.status.idle": "2026-06-23T20:47:24.868237Z",
+     "shell.execute_reply": "2026-06-23T20:47:24.867850Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : badge vegetarien dans la carte de menu\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : badge vegetarien global dans RenderMenuCard.\n",
+    "// TODO etudiant : modifier RenderMenuCard pour afficher un badge vegetarien en tete de carte.\n",
+    "\n",
+    "// Indice :\n",
+    "// static bool IsVegetarian(Recipe r)\n",
+    "// {\n",
+    "//     string[] nonVege = { \"Poulet\", \"boeuf\", \"Lasagnes\" };\n",
+    "//     return !nonVege.Any(k => r.Name.Contains(k));\n",
+    "// }\n",
+    "// ... dans RenderMenuCard :\n",
+    "// bool allVeg = list.All(IsVegetarian);\n",
+    "// h.Append($\"<div style='padding:4px 16px;background:{(allVeg ? \"#e8f5e9\" : \"#ffebee\")}'>\" +\n",
+    "//          $\"<span style='background:{(allVeg ? \"#2e7d32\" : \"#c62828\")};color:white;padding:2px 8px;border-radius:8px;font-size:11px'>\" +\n",
+    "//          $\"{(allVeg ? \"100% vegetarien\" : \"contient de la viande\")}</span></div>\");\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : badge vegetarien dans la carte de menu\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exo2-title",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Total kcal par jour dans la grille hebdomadaire\n",
+    "\n",
+    "Modifiez `RenderWeeklyGrid` pour ajouter une **ligne finale \"Total/jour\"** qui affiche la somme des kcal de toutes les recettes de chaque journée, avec un code couleur (`KcalColor`).\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Etape 1` : pour chaque jour `d`, calculez `int dayKcal = Enumerable.Range(0, slots).Sum(s => corpus[plan[d][s]].Kcal);`\n",
+    "- `# Etape 2` : après la boucle des jours, ajoutez une ligne `<tr>` avec une cellule \"Total kcal\" et une cellule par jour contenant le total coloré.\n",
+    "- `# Etape 3` : appelez `KcalColor(dayKcal)` pour la couleur du total."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "exo2-stub",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T20:47:24.870501Z",
+     "iopub.status.busy": "2026-06-23T20:47:24.870058Z",
+     "iopub.status.idle": "2026-06-23T20:47:24.940452Z",
+     "shell.execute_reply": "2026-06-23T20:47:24.939762Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : total kcal par jour dans la grille hebdomadaire\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : ligne \"Total kcal / jour\" dans la grille hebdomadaire.\n",
+    "// TODO etudiant : modifier RenderWeeklyGrid pour ajouter une ligne de totaux par jour.\n",
+    "\n",
+    "// Indice :\n",
+    "// h.Append(\"<tr style='background:#eceff1;font-weight:bold'><td>Total kcal</td>\");\n",
+    "// for (int d = 0; d < days; d++)\n",
+    "// {\n",
+    "//     int dayKcal = Enumerable.Range(0, slots).Sum(s => corpus[plan[d][s]].Kcal);\n",
+    "//     h.Append($\"<td style='text-align:center;color:{KcalColor(dayKcal)}'>{dayKcal}</td>\");\n",
+    "// }\n",
+    "// h.Append(\"</tr>\");\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : total kcal par jour dans la grille hebdomadaire\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exo3-title",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Front de Pareto 2D (budget × plancher protéines) rendu en heatmap\n",
+    "\n",
+    "Étendez la section 5 en faisant varier **simultanément** le budget (800..2000) **et** le plancher de protéines (10..50 g). Pour chaque couple `(budget, protFloor)`, résolvez et stockez le kcal atteint. Rendez le tout comme une **heatmap HTML 2D** : lignes = budgets, colonnes = planchers protéiques, couleur de la cellule = kcal atteint (vert = haut, rouge = bas/irréalisable).\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Etape 1` : construisez une double boucle `foreach (budget ...) foreach (protFloor ...)` qui appelle le solveur et remplit un `int[,] heatmap`.\n",
+    "- `# Etape 2` : pour la couleur, normalisez le kcal sur la plage observée (`intensity = (kcal - minKcal) / (maxKcal - minKcal)`) et mappez sur un dégradé vert→jaune→rouge (utilisez `System.Drawing.Color` ou un palette CSS).\n",
+    "- `# Etape 3` : générez un `<table>` HTML où chaque `<td>` a un `style='background:rgb(...)'` calculé depuis l'intensité, et contient la valeur kcal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "exo3-stub",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T20:47:24.943044Z",
+     "iopub.status.busy": "2026-06-23T20:47:24.942566Z",
+     "iopub.status.idle": "2026-06-23T20:47:25.004587Z",
+     "shell.execute_reply": "2026-06-23T20:47:25.003859Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : heatmap 2D du front de Pareto budget x proteines\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : heatmap 2D budget x plancher proteines (kcal atteint par cellule).\n",
+    "// TODO etudiant : double boucle de solve, stockage dans int[,], rendu heatmap HTML.\n",
+    "\n",
+    "// Indice :\n",
+    "// int[] budgets = { 800, 1000, 1200, 1400, 1600, 1800, 2000 };\n",
+    "// int[] protFloors = { 10, 20, 30, 40, 50 };\n",
+    "// int[,] heatmap = new int[budgets.Length, protFloors.Length];\n",
+    "// ... double boucle : pour chaque (i,j), resoudre, stocker heatmap[i,j] = kcal ou -1 si UNSAT\n",
+    "// ... rendu : <table> avec background calcule depuis l'intensite normalisee\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : heatmap 2D du front de Pareto budget x proteines\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "conclusion",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a démontré que la **valeur opérationnelle** d'un solveur Z3 ne se limite pas à trouver une solution : elle dépend crucialement de la capacité à **rendre cette solution lisible** à un humain (décideur, diététicien, utilisateur final). L'API `display(HTML(...))` de `Microsoft.DotNet.Interactive` ouvre la porte à un rendu riche — cartes colorées, badges d'allergènes, grilles de planification, fronts de Pareto — sans quitter le notebook .NET.\n",
+    "\n",
+    "### Points clés à retenir\n",
+    "\n",
+    "| Concept | Implémentation |\n",
+    "|---------|----------------|\n",
+    "| Affichage HTML riche | `display(HTML(htmlString))` depuis `Microsoft.DotNet.Interactive` |\n",
+    "| Construction HTML | interpolation C# `$\"...\"` ou `StringBuilder` avec CSS inline |\n",
+    "| Découplage solveur/rendu | les helpers consomment des `Recipe`, pas des expressions Z3 |\n",
+    "| Couleur comme signal | `KcalColor`, badges allergènes, jauges de protéines |\n",
+    "| Exploration paramétrique | boucle de solves sous budgets variés → front de Pareto rendu |\n",
+    "\n",
+    "### Perspective\n",
+    "\n",
+    "Les techniques de rendu vues ici se généralisent à tout solveur produisant des objets structurés : planification de personnel (grille par équipe), allocation de ressources (heatmap de charge), ordonnancement (frise temporelle HTML). Le principe reste le même : le solveur est la source de vérité, le rendu est une fonction pure de ses sorties. Pour des visualisations plus ambitieuses, on pourrait également sérialiser les solutions en JSON et les consommer depuis une cellule JavaScript (via `#!javascript`), mais le rendu HTML inline suffit à la plupart des usages pédagogiques.\n",
+    "\n",
+    "**Navigation** : [Index Z3](./README.md) | [Notebook 05 (Meal Planner)](./05_Meal_Planner_Hierarchical.ipynb) | [Notebook 06b (RecipeML)](./06b_RecipeML_Corpus.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  },
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "csharp",
+    "items": [
+     {
+      "name": "csharp"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -36,6 +36,7 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 | 05 | [Meal Planner Hierarchical](05_Meal_Planner_Hierarchical.ipynb) | Planificateur de repas : data fusion LINQ + théorème hiérarchique | ~50 min | BETA |
 | 06 | [Witness Generation Automata](06_Witness_Generation_Automata.ipynb) | **Fork Automata** : générer un *témoin* depuis `A & ~B` (intersection/complément de surface), cap des 21 caractères levé (#6), émission SMT-LIB `re.inter`/`re.comp` | ~40 min | BETA |
 | 06b | [RecipeML Corpus](06b_RecipeML_Corpus.ipynb) | Modélisation SMT sur **données externes** : corpus RecipeML (XML) parsé en classes de domaine, menu booléen avec exclusion d'allergène (`MkITE`) + plan hiérarchique multi-jours `int[][]` (`CollectionHandling.Array`) | ~40 min | BETA |
+| 06c | [Meal Planner Visualization](06c_Meal_Planner_Visualization.ipynb) | **Rendu HTML** des solutions Z3 (`display(HTML(...))`) : carte de menu color-codée (kcal/protéines/allergènes), grille hebdomadaire, front de Pareto budget↔kcal — montée en gamme du rendu plat `Console.WriteLine` | ~40 min | BETA |
 
 ### Fil pédagogique
 


### PR DESCRIPTION
## Summary

Step 4 of Z3.Linq Epic **#1206** deep-queue (dispatch ai-01 2026-06-23 20:35Z). Introduces **rich HTML rendering of Z3 solver solutions** via `display(HTML(...))` — a pedagogical upgrade from the flat `Console.WriteLine` tables in notebooks 05 and 06b. Thesis: a solver's value is in how legible its solutions are to a human (**#3801 Prong-B**: montée en gamme).

## What's new

- **Section 2 — HTML helpers**: `RenderMenuCard`, `RenderWeeklyGrid`, `KcalColor`, `AllergenBadge`, `ProteinBar` with inline-CSS color-coding (green/orange/red kcal vs target, red/green allergen badges, protein bar).
- **Section 3 — Boolean model + HTML menu card**: reuses 06b's `MkITE` aggregation + allergen exclusion, renders the SAT solution as a color-coded card. **SAT.**
- **Section 4 — Hierarchical `int[][]` + weekly grid**: multi-day plan (`CollectionHandling.Array` + `Z3Methods.Distinct`) rendered as a day×slot HTML grid with repetition coloring. **SAT, 74 ms.** Same-cell workaround applied.
- **Section 5 — Pareto front**: solver run under 7 budget caps (800..2000 cents), kcal-vs-cost tradeoff rendered as a styled HTML table. Shows the solver exploring the solution space, rendered visually — the montée-en-gamme.
- **3 exercises** (vegetarian badge, per-day kcal total in grid, 2D Pareto heatmap), C.1-compliant stubs, notebook runs end-to-end with stubs unfilled.
- **README Z3 series**: added `06c` row.

## Validation (real execution, not keywords)

- `jupyter nbconvert --execute` end-to-end **SUCCESS**, kernel `.net-csharp`, run from `SMT/Z3/`.
- **9/9 code cells**: `execution_count` 1..9, **0 error**.
- **4 cells produce real `text/html` output** (lengths 3606 / 1930 / 4766 chars) — the HTML rendering genuinely fires, not stub.
- Solver SAT outputs confirmed: §3 `SATISFIABLE`, §4 `résolu en 74,4 ms (status : SAT)`, §5 `Front de Pareto : 7 points`.
- **H.3 pre-commit PASS**: no cell with `execution_count: null` and empty outputs.
- API choice confirmed via a probe notebook beforehand (`display(HTML(...))` works, `PocketViewTags` works but less flexible — chose `display(HTML)`).

## Scope / hygiene

- **Atomic**: +1180 lines, 2 files (notebook + README), single domain (Z3 C#).
- **Catalogue byte-identique** to `origin/main`.
- **Fork `Z3.Linq` (untracked) + `Automata` submodule**: untouched (not staged).
- **Anti-régression**: notebooks 05/06b intact (new companion notebook, not a rewrite).
- **XML verbatim-string trap avoided**: corpus built via `StringBuilder` (not `@"..."`), sidestepping the CS1003/CS1010 gotcha that bit 06b.
- `display(HTML(...))` helpers confirmed via probe before notebook authoring (no wasted cycle on a non-working API).

`See #1206` (partial contribution — step 4/5; step 5 = prep PR upstream endjin/Z3.Linq FLAG-only remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)