### PR TITLE
feat(cooperative-games): prove critical_implies_mem via BG prover (warm-up, sorry 1->0; #1453)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1019,6 +1019,14 @@ noncomputable def WeightedVotingGame (weights : N → ℝ) (quota : ℝ) (hquota
 def Critical (G : TUGame N) (i : N) (S : Finset N) : Prop :=
   i ∈ S ∧ G.v S = 1 ∧ G.v (S.erase i) = 0
 
+/-- A critical player must be a member of the coalition: `Critical G i S` unfolds to
+    `i ∈ S ∧ …`, so membership is the first conjunct. Warm-up BG-prover target (#1453):
+    trivial conjunct extraction, exercises the harness on a second real target now that
+    the bullet-sorry stub format fixes GoalExtract (cycle 63). -/
+theorem critical_implies_mem (G : TUGame N) (i : N) (S : Finset N) :
+    Critical G i S → i ∈ S := by
+  sorry
+
 /-- `Critical G i` is decidable via Classical reasoning (the `TUGame.v` comparisons are
     noncomputable reals). Promoted to a global instance so that `BanzhafRaw` and any
     theorem about it synthesise the SAME instance, avoiding the

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1025,7 +1025,8 @@ def Critical (G : TUGame N) (i : N) (S : Finset N) : Prop :=
     the bullet-sorry stub format fixes GoalExtract (cycle 63). -/
 theorem critical_implies_mem (G : TUGame N) (i : N) (S : Finset N) :
     Critical G i S → i ∈ S := by
-  sorry
+  intro h
+  exact h.1
 
 /-- `Critical G i` is decidable via Classical reasoning (the `TUGame.v` comparisons are
     noncomputable reals). Promoted to a global instance so that `BanzhafRaw` and any

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1617,6 +1617,38 @@ DEMOS = {
         ),
         "context_after": "",
     },
+    57: {
+        "name": "CRITICAL_IMPLIES_MEM",
+        "file": str(SHAPLEY_FILE) if SHAPLEY_FILE else "",
+        "line": 1028,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "critical_implies_mem",
+        "theorem": "critical_implies_mem",
+        "imports": SHAPLEY_IMPORTS,
+        "description": (
+            "REPLACES the single sorry at L1028 of Shapley.lean. Warm-up BG-prover\n"
+            "target (#1453, cycle 64): the SECOND real target after `banzhaf_raw_le_univ`\n"
+            "(cycle 63 SUCCESS). Exercises the harness on a fresh easy theorem to confirm\n"
+            "the bullet-sorry stub format (`:= by` then `sorry` on its own line) reliably\n"
+            "lets GoalExtract read the goal.\n"
+            "\n"
+            "`Critical G i S` UNFOLDS to the 3-way conjunction\n"
+            "  i in S  AND  G.v S = 1  AND  G.v (S.erase i) = 0\n"
+            "so the goal is to extract the FIRST conjunct `i in S`.\n"
+            "\n"
+            "GOAL at sorry (EXACT): `i ∈ S`\n"
+            "\n"
+            "HYPOTHESES IN SCOPE:\n"
+            "  N : Type, [Fintype N], [DecidableEq N]\n"
+            "  G : TUGame N, i : N, S : Finset N\n"
+            "  (the theorem takes `Critical G i S → i ∈ S`, so after `intro h` the\n"
+            "   hypothesis `h : Critical G i S` is in scope and unfolds to the conjunction)\n"
+            "\n"
+            "PROOF STRATEGY: unfold/extract the first conjunct of the conjunction `h`.\n"
+            "Trivial conjunct extraction -- this is a warm-up, not a hard target."
+        ),
+        "difficulty": "easy",
+    },
 }
 # (gale_shapley_stable) was proved in PR #1194. The prover skips any DEMO
 # whose key appears in this set.


### PR DESCRIPTION
**Proven via BG prover — sorry 1->0.** Second successful real-target run (demo 57, warm-up). The bullet-sorry stub format (the cycle-63 lever) is confirmed reliable on a fresh theorem: the Coordinator correctly identified the goal ("extract first conjunct") and TacticAgent produced the optimal proof `intro h; exact h.1`.

## Verdict (cycle 64)

```
=== Run demo 57 (bullet-sorry format) ===
RESULT: SUCCESS
Coordinator plan: "introduire l'hypothèse Critical, déplier sa définition, extraire le premier conjoint"
TacticAgent produced: intro h; exact h.1
VerifyExecutor -> success=True (persisted)
```
Naive sorry count reported `2 -> 1` because the L1025 docstring contains the word "sorry" (in "bullet-sorry") which the harness's naive counter matches as prose. **The real tactic-sorry delta is 1 -> 0** (the one stub sorry at L1028 is gone). G.1 lesson: always verify against the source with a tactic-specific grep, not the harness count.

## The theorem (now proven)

`Critical G i S` unfolds to `i ∈ S ∧ G.v S = 1 ∧ G.v (S.erase i) = 0`, so:
```lean
theorem critical_implies_mem (G : TUGame N) (i : N) (S : Finset N) :
    Critical G i S → i ∈ S := by
  intro h
  exact h.1
```

## Verification (lean-merge-discipline section B)

- `lake build CooperativeGames` **SUCCESS** (LAKE_EXIT=0, 8435 jobs, 49s).
- `grep -c` tactic-sorry in Shapley.lean = **0** (0 project-wide in cooperative_games, excl `.lake`).
- Diff is byte-surgical (`sorry` -> `intro h` / `exact h.1`), LF-clean.

## What this confirms

The harness now works reliably on real targets with the **bullet-sorry stub format** (`:= by` then `sorry` on its own line): 2/2 real targets proven — `banzhaf_raw_le_univ` (#4088, cycle 63) and `critical_implies_mem` here (cycle 64). GoalExtract fires correctly on both, the Coordinator/Search/Tactic agents see the real goal, and write-back fix #4075 persists the verified proof.

## [ASK ai-01]

- **#4095 review-ready** (cooperative stays 0-sorry; this adds a proven lemma). Merge when convenient.
- **#4071** still OPEN (verified firsthand) — unblocks item 1 `banzhaf_index_nonneg`. Reference proof drafted this cycle: `unfold BanzhafIndex; apply div_nonneg · exact Nat.cast_nonneg _ · exact pow_pos (by norm_num) _` (denominator `2^(card N - 1) > 0` always). Ready to stub + run the moment #4071 merges.
- **#4088** still OPEN (verified firsthand) — the first proven target; merge in your sequence.

See #1453. Run log: `C:/Users/jsboi/AppData/Local/Temp/po2026_bg_critmem57.log`.

Co-Authored-By: Claude <noreply@anthropic.com>