### PR TITLE
docs(m12-hf): correct pricing-path (no lean dry-run) + data-backup convention

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M12_HF_PROPOSAL.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M12_HF_PROPOSAL.md
@@ -69,18 +69,34 @@ Le module [`scripts/m12_har_rv_j.py`](../scripts/m12_har_rv_j.py) **utilise déj
 - Conversion QC : **300 QCC = 3 USD** (source : [QC data pricing](https://www.quantconnect.com/data)).
 - Les datasets CoinAPI/Binance minute sont vendus au téléchargement ; le coût exact **par symbole / par histoire complète** n'est pas publié sur la page publique (derrière le pricing page).
 - **Bracket honnête** : datasets crypto minute QC historiquement de l'ordre de **~2-10 USD / symbole / histoire complète multi-années**. Pour les 7 coins : **~15-70 USD (~1.5k-7k QCC)**.
-- **Caveat G.1** : ce bracket est une estimation basée sur le barème QCC et des datasets comparables, **pas** un prix vérifié. Le total exact doit être confirmé par ai-01/user via `lean data download` (dry-run) ou la [page pricing Binance CoinAPI](https://www.quantconnect.com/datasets/binance-crypto-price-data/pricing) **avant** tout achat.
+- **Caveat G.1** : ce bracket est une estimation basée sur le barème QCC et des datasets comparables, **pas** un prix vérifié.
+- **Réalité du pricing vérifiée (G.1, 2026-06-23)** : `lean data download` n'a **pas** de flag `--dry-run` / d'aperçu de coût (seulement des credentials data-provider + des options de téléchargement) — il consomme les QCC à la confirmation. La [page pricing Binance CoinAPI](https://www.quantconnect.com/datasets/binance-crypto-price-data/pricing) est une SPA JS derrière login : un fetch statique ne retourne que le shell (« Algorithm Lab v3.0 »), **aucun prix public**. **Donc le prix ferme exact exige l'un des deux** : (a) login QC-web (Playwright sur le compte QC) pour consulter la grille tarifaire logged-in, OU (b) greenlight user pour un micro-achat mono-symbole qui révèle le coût au prompt de confirmation (`lean data download` l'affiche avant de débiter). Le bracket ~15-70 USD reste l'estimation courante en attendant le chiffre ferme.
 - Note : les coins à listing tardif (SOL/DOT/AVAX 2020, cf `CURRICULUM.md` Stage 3a) limitent la profondeur historique réelle — ne pas payer pour des années pré-listing.
 
 ### 4.4 Décision requise (user-blocker)
 
 L'achat est une **décision user** qu'**ai-01 escalade** (signature données = user-blocker, cf directive ai-01). Tant que le greenlight n'est pas posé : **0 QCC dépensé, 0 `lean data download`, 0 run**. Le présent doc sert de base à cette décision.
 
+### 4.5 Convention de sauvegarde + vérification pré-achat (HARD, mandat user 2026-06-23)
+
+**Sauvegarde durable (HARD).** Toute donnée achetée via `lean data download` est **sauvegardée** dans `G:\Mon Drive\MyIA\Dev\Trading\Data` (durable, réutilisable cross-projet, **ne JAMAIS re-payer** une donnée déjà acquise). Cette convention s'applique à **tous** les achats data futures du pipeline ML/trading, pas seulement M12-HF.
+
+**Vérification pré-achat (G.1, faite 2026-06-23).** Le répertoire ci-dessus a été audité **avant** tout achat. Résultat :
+
+| Élément | État |
+|---------|------|
+| `Minutes_246537_1216726_bundle_archive.zip` | **Déjà présent (gratuit)** — OHLCV minute **réel** (`time,open,close,high,low,volume`, timestamps unix-ms, incréments 60000 ms), couvrant **2013-04-01 → 2020-06-05**, pour **4 des 7 coins** : btcusd, ethusd, ltcusd, xrpusd (~2.8 M barres BTC seul) |
+| SOL-USD / ADA-USD / DOT-USD | **Absents** du bundle (listings post-2020) → à acheter |
+| Période **2020-06 → 2025** | **Absente** pour tous les coins → à acheter (c'est le segment le plus décisif : bear 2022 + momentum 2024-25) |
+| Format | Le bundle GDrive est **CSV générique** (pas LEAN QC) → conversion vers LEAN requise avant ingestion |
+
+**Conséquence sur le scope d'achat.** Le bracket ~15-70 USD (§4.3) est une **borne supérieure** : la fraction déjà couverte gratuitement (4 coins × 2018-2020) réduit le périmètre payant. Le script `minute_loader.py` du §5 devra **fusionner deux sources** : le CSV GDrive converti (2018-2020 × 4 coins) **et** le LEAN QC acheté (2020-2025 × 7 coins). Le prix ferme ne peut être isolé qu'après résolution du point §4.3 (login QC-web).
+
 ---
 
 ## 5. Changements pipeline (post-greenlight)
 
-1. **Nouveau** `scripts/minute_loader.py` (parallèle à `intraday_loader.py`) : lit les archives LEAN minute, produit des `IntradayDataset` minute + `minute_log_returns`.
+1. **Nouveau** `scripts/minute_loader.py` (parallèle à `intraday_loader.py`) : **fusionne deux sources** — (i) le bundle CSV minute GDrive converti au format LEAN (4 coins BTC/ETH/LTC/XRP × 2018-2020, cf §4.5, gratuit) **et** (ii) les archives LEAN minute QC Cloud achetées (7 coins × 2020-2025) — puis produit des `IntradayDataset` minute + `minute_log_returns`. Un adaptateur de format gère le CSV générique GDrive (normalisation pandas `time/open/high/low/close/volume` → LEAN) avant la fusion.
 2. **Sparse-sampling option** : `minute_loader` expose `sample_freq ∈ {1min, 5min}` (défaut 5min = robuste microstructure ; 1min = test liquides BTC/ETH).
 3. **Ré-utilisation** de `daily_realized_variance` / `daily_bipower_variation` / `daily_jump_component` (inchangés — ils prennent déjà une série intraday quelconque).
 4. **Nouveau** `scripts/m12_hf_har_rv_j.py` : fork de `m12_har_rv_j.py`, source = minute_loader au lieu de intraday_loader. Même sortie (`results/m12_hf/`).


### PR DESCRIPTION
## Summary

Docs-only follow-up to the M12-HF spec (#4079, merged). Three corrections to §4 (purchase plan), all verified G.1 against the live tooling this cycle. **No purchase, no run, no code executed** — spec-only, still gated on user greenlight.

## Changes

**1. §4.3 — pricing path corrected (anti-regression on spec accuracy).** The previous text claimed the firm price could be confirmed via `lean data download` (dry-run) or the pricing page. Both are false, verified this cycle:
- `lean data download` (v1.0.223) has **no** `--dry-run` / price-preview flag — only data-provider credentials + download options; it consumes QCC on confirmation.
- The Binance CoinAPI pricing page is a JS SPA behind login; a static fetch returns only the shell ("Algorithm Lab v3.0"), no public price.

So the firm price requires either (a) a QC-web login (Playwright) to read the logged-in tariff grid, or (b) a user-greenlit single-symbol micro-purchase revealing the cost at the confirmation prompt. Bracket ~15-70 USD stands as the estimate.

**2. §4.5 — data-backup convention + pre-purchase audit (HARD, mandate ai-01 2026-06-23).** Every lean_cli-purchased dataset is backed up to `G:\Mon Drive\MyIA\Dev\Trading\Data` (durable, reuse, never re-pay). Pre-purchase audit found **partial free data already present**: a minute-OHLCV bundle (4/7 coins BTC/ETH/LTC/XRP, 2013-04-01 → 2020-06-05, generic CSV) → reduces the paying scope. **Missing** (still to buy): 2020-06 → 2025 for all coins + SOL/ADA/DOT (post-2020 listings).

**3. §5 step 1 — dual-source loader (coherence).** `minute_loader.py` must fuse the CSV GDrive bundle (converted to LEAN, 2018-2020 × 4 coins) with the purchased LEAN QC data (2020-2025 × 7 coins). Required so §5 matches the §4.5 finding.

## Notes for review
- Docs-only, 1 file, 22 lines (18+/2-) — clears the §E 20-line floor on a single coherent correction.
- Item #1 (pricing) + #2 (backup convention) of ai-01's po-2024 QC deep-queue this cycle.
- **Item #1 firm-price**: this PR documents *why* the firm price needs a QC-web login; it does not itself produce the number (that's ai-01's escalation path).

See #4079