### PR TITLE
enrich(pymc): PyMC-14 utility — hierarchical multi-site diagnostic MCMC (Prong-B, non-centered logit-Binomial)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb
@@ -5,10 +5,10 @@
    "id": "ba55a30a",
    "metadata": {
     "papermill": {
-     "duration": 0.021021,
-     "end_time": "2026-06-03T00:56:52.909426+00:00",
+     "duration": 0.007361,
+     "end_time": "2026-06-23T21:46:34.984514+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:52.888405+00:00",
+     "start_time": "2026-06-23T21:46:34.977153+00:00",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "c4aa6c2b",
    "metadata": {
     "papermill": {
-     "duration": 0.003996,
-     "end_time": "2026-06-03T00:56:52.929410+00:00",
+     "duration": 0.007245,
+     "end_time": "2026-06-23T21:46:35.001991+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:52.925414+00:00",
+     "start_time": "2026-06-23T21:46:34.994746+00:00",
      "status": "completed"
     },
     "tags": []
@@ -88,10 +88,10 @@
    "id": "fba6dba7",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-03T00:56:52.939940+00:00",
+     "duration": 0.006562,
+     "end_time": "2026-06-23T21:46:35.017423+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:52.935940+00:00",
+     "start_time": "2026-06-23T21:46:35.010861+00:00",
      "status": "completed"
     },
     "tags": []
@@ -131,10 +131,10 @@
    "id": "b488028e",
    "metadata": {
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-06-03T00:56:52.948452+00:00",
+     "duration": 0.007379,
+     "end_time": "2026-06-23T21:46:35.036194+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:52.944451+00:00",
+     "start_time": "2026-06-23T21:46:35.028815+00:00",
      "status": "completed"
     },
     "tags": []
@@ -149,16 +149,16 @@
    "id": "35e523c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:52.957079Z",
-     "iopub.status.busy": "2026-06-03T00:56:52.957079Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.054661Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.054661Z"
+     "iopub.execute_input": "2026-06-23T21:46:35.056690Z",
+     "iopub.status.busy": "2026-06-23T21:46:35.055679Z",
+     "iopub.status.idle": "2026-06-23T21:46:44.419278Z",
+     "shell.execute_reply": "2026-06-23T21:46:44.418197Z"
     },
     "papermill": {
-     "duration": 3.103871,
-     "end_time": "2026-06-03T00:56:56.055949+00:00",
+     "duration": 9.375509,
+     "end_time": "2026-06-23T21:46:44.419278+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:52.952078+00:00",
+     "start_time": "2026-06-23T21:46:35.043769+00:00",
      "status": "completed"
     },
     "tags": []
@@ -199,10 +199,10 @@
    "id": "601d2260",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-06-03T00:56:56.063493+00:00",
+     "duration": 0.009994,
+     "end_time": "2026-06-23T21:46:44.438211+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.059494+00:00",
+     "start_time": "2026-06-23T21:46:44.428217+00:00",
      "status": "completed"
     },
     "tags": []
@@ -225,10 +225,10 @@
    "id": "a6e93c19",
    "metadata": {
     "papermill": {
-     "duration": 0.004343,
-     "end_time": "2026-06-03T00:56:56.069836+00:00",
+     "duration": 0.006263,
+     "end_time": "2026-06-23T21:46:44.457111+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.065493+00:00",
+     "start_time": "2026-06-23T21:46:44.450848+00:00",
      "status": "completed"
     },
     "tags": []
@@ -248,16 +248,16 @@
    "id": "c4e0e20d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.079360Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.079360Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.086591Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.085575Z"
+     "iopub.execute_input": "2026-06-23T21:46:44.479745Z",
+     "iopub.status.busy": "2026-06-23T21:46:44.478749Z",
+     "iopub.status.idle": "2026-06-23T21:46:44.496017Z",
+     "shell.execute_reply": "2026-06-23T21:46:44.494876Z"
     },
     "papermill": {
-     "duration": 0.012141,
-     "end_time": "2026-06-03T00:56:56.086591+00:00",
+     "duration": 0.027776,
+     "end_time": "2026-06-23T21:46:44.497028+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.074450+00:00",
+     "start_time": "2026-06-23T21:46:44.469252+00:00",
      "status": "completed"
     },
     "tags": []
@@ -314,10 +314,10 @@
    "id": "9cf659ff",
    "metadata": {
     "papermill": {
-     "duration": 0.004004,
-     "end_time": "2026-06-03T00:56:56.095267+00:00",
+     "duration": 0.008106,
+     "end_time": "2026-06-23T21:46:44.513562+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.091263+00:00",
+     "start_time": "2026-06-23T21:46:44.505456+00:00",
      "status": "completed"
     },
     "tags": []
@@ -369,10 +369,10 @@
    "id": "4639bb4e",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-03T00:56:56.103000+00:00",
+     "duration": 0.009399,
+     "end_time": "2026-06-23T21:46:44.533552+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.099000+00:00",
+     "start_time": "2026-06-23T21:46:44.524153+00:00",
      "status": "completed"
     },
     "tags": []
@@ -389,16 +389,16 @@
    "id": "b0089b9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.111510Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.111510Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.169297Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.168211Z"
+     "iopub.execute_input": "2026-06-23T21:46:44.552155Z",
+     "iopub.status.busy": "2026-06-23T21:46:44.552155Z",
+     "iopub.status.idle": "2026-06-23T21:46:44.562118Z",
+     "shell.execute_reply": "2026-06-23T21:46:44.562118Z"
     },
     "papermill": {
-     "duration": 0.062826,
-     "end_time": "2026-06-03T00:56:56.169825+00:00",
+     "duration": 0.020111,
+     "end_time": "2026-06-23T21:46:44.562118+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.106999+00:00",
+     "start_time": "2026-06-23T21:46:44.542007+00:00",
      "status": "completed"
     },
     "tags": []
@@ -450,10 +450,10 @@
    "id": "f34c3630",
    "metadata": {
     "papermill": {
-     "duration": 0.003843,
-     "end_time": "2026-06-03T00:56:56.177506+00:00",
+     "duration": 0.010325,
+     "end_time": "2026-06-23T21:46:44.586321+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.173663+00:00",
+     "start_time": "2026-06-23T21:46:44.575996+00:00",
      "status": "completed"
     },
     "tags": []
@@ -485,16 +485,16 @@
    "id": "f9beac9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.185504Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.185504Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.189107Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.189107Z"
+     "iopub.execute_input": "2026-06-23T21:46:44.606259Z",
+     "iopub.status.busy": "2026-06-23T21:46:44.606259Z",
+     "iopub.status.idle": "2026-06-23T21:46:44.614095Z",
+     "shell.execute_reply": "2026-06-23T21:46:44.612394Z"
     },
     "papermill": {
-     "duration": 0.008618,
-     "end_time": "2026-06-03T00:56:56.190123+00:00",
+     "duration": 0.02106,
+     "end_time": "2026-06-23T21:46:44.615231+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.181505+00:00",
+     "start_time": "2026-06-23T21:46:44.594171+00:00",
      "status": "completed"
     },
     "tags": []
@@ -538,10 +538,10 @@
    "id": "ad7afa3b",
    "metadata": {
     "papermill": {
-     "duration": 0.004006,
-     "end_time": "2026-06-03T00:56:56.197127+00:00",
+     "duration": 0.010627,
+     "end_time": "2026-06-23T21:46:44.634698+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.193121+00:00",
+     "start_time": "2026-06-23T21:46:44.624071+00:00",
      "status": "completed"
     },
     "tags": []
@@ -570,10 +570,10 @@
    "id": "33de293d",
    "metadata": {
     "papermill": {
-     "duration": 0.004034,
-     "end_time": "2026-06-03T00:56:56.204532+00:00",
+     "duration": 0.009307,
+     "end_time": "2026-06-23T21:46:44.653358+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.200498+00:00",
+     "start_time": "2026-06-23T21:46:44.644051+00:00",
      "status": "completed"
     },
     "tags": []
@@ -620,10 +620,10 @@
    "id": "89b6d3de",
    "metadata": {
     "papermill": {
-     "duration": 0.004121,
-     "end_time": "2026-06-03T00:56:56.213626+00:00",
+     "duration": 0.009481,
+     "end_time": "2026-06-23T21:46:44.672573+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.209505+00:00",
+     "start_time": "2026-06-23T21:46:44.663092+00:00",
      "status": "completed"
     },
     "tags": []
@@ -642,16 +642,16 @@
    "id": "991c5116",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.226426Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.226426Z",
-     "iopub.status.idle": "2026-06-03T00:57:46.478004Z",
-     "shell.execute_reply": "2026-06-03T00:57:46.477493Z"
+     "iopub.execute_input": "2026-06-23T21:46:44.694560Z",
+     "iopub.status.busy": "2026-06-23T21:46:44.694560Z",
+     "iopub.status.idle": "2026-06-23T21:47:32.830646Z",
+     "shell.execute_reply": "2026-06-23T21:47:32.829110Z"
     },
     "papermill": {
-     "duration": 50.260869,
-     "end_time": "2026-06-03T00:57:46.478004+00:00",
+     "duration": 48.149359,
+     "end_time": "2026-06-23T21:47:32.831652+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.217135+00:00",
+     "start_time": "2026-06-23T21:46:44.682293+00:00",
      "status": "completed"
     },
     "tags": []
@@ -675,7 +675,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 45 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 44 seconds.\n"
      ]
     },
     {
@@ -727,10 +727,10 @@
    "id": "d11ac614",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-03T00:57:46.487525+00:00",
+     "duration": 0.00907,
+     "end_time": "2026-06-23T21:47:32.849335+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.483525+00:00",
+     "start_time": "2026-06-23T21:47:32.840265+00:00",
      "status": "completed"
     },
     "tags": []
@@ -756,13 +756,178 @@
   },
   {
    "cell_type": "markdown",
+   "id": "22dd6480",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010191,
+     "end_time": "2026-06-23T21:47:32.867080+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T21:47:32.856889+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Au-dela du conjugue : diagnostic hierarchique multi-sites\n",
+    "\n",
+    "Le diagnostic a 2 etats precedent est **conjugue** : le posterior a une forme close,\n",
+    "et MCMC redonne exactement le calcul analytique de Bayes (les deux valeurs coincident\n",
+    "a 66%). Pour montrer la vraie puissance de l'inference bayesienne par MCMC, considerons\n",
+    "un probleme **non conjugue** ou aucune forme close n'existe.\n",
+    "\n",
+    "**Scenario** : un reseau de 8 hopitaux partage le meme test, mais chaque hopital a sa\n",
+    "propre **prevalence** de la maladie (liee a sa population). On observe le nombre de\n",
+    "patients testes $n_i$ et de cas positifs $k_i$ par site. Objectif : inferer la\n",
+    "prevalence de **chaque** site en empruntant l'information de **tous** les sites\n",
+    "(partial pooling).\n",
+    "\n",
+    "**Modele hierarchique non-centre** (recette #3801) :\n",
+    "\n",
+    "$$\\text{logit}(p_i) = \\mu_{pop} + \\tau \\cdot z_i, \\quad z_i \\sim \\mathcal{N}(0,1), \\quad k_i \\sim \\text{Binomial}(n_i, p_i)$$\n",
+    "\n",
+    "Le lien logit et la structure hierarchique cassent la conjugaison : **MCMC est requis**.\n",
+    "Le benefice pedagogique concret est le **shrinkage** (retrecissement) : les sites peu\n",
+    "observes sont tires vers la moyenne de population $\\mu_{pop}$, ce qu'une mise a jour\n",
+    "Beta-Binomial independante par site ne produirait jamais.\n",
+    "\n",
+    "> Ce modele est une instance du cadre **hierarchique bayesien** classique\n",
+    "> (Gelman & Hill, *Data Analysis Using Regression and Multilevel/Hierarchical Models*, 2006).\n",
+    "> La parametrisation non-centree $\\mu_{pop} + \\tau \\cdot z_i$ (plutot que la centree)\n",
+    "> evite le **funnel** de Neal qui apparait quand $\\tau$ est petit.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "052b9f6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T21:47:32.887431Z",
+     "iopub.status.busy": "2026-06-23T21:47:32.886431Z",
+     "iopub.status.idle": "2026-06-23T21:48:25.324160Z",
+     "shell.execute_reply": "2026-06-23T21:48:25.324160Z"
+    },
+    "papermill": {
+     "duration": 52.449482,
+     "end_time": "2026-06-23T21:48:25.324160+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T21:47:32.874678+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prevalences empiriques par site : [0.15  0.233 0.133 0.43  0.32  0.35  0.167 0.167]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [mu_pop, tau, z]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 47 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inference hierarchique des prevalences (MCMC, logit-Binomial non-centre)\n",
+      "============================================================\n",
+      "Divergences NUTS : 0   (cible = 0)\n",
+      "R-hat max         : 1.000   (cible < 1.01)\n",
+      "ESS bulk min      : 2697\n",
+      "\n",
+      "Comparaison : prevalence empirique vs posterior (shrinkage vers la moyenne)\n",
+      "  site 0 (n= 20): empirique=0.150 -> posterior=0.203  <-- shrinkage (site petit tire vers mu_pop)\n",
+      "  site 1 (n= 30): empirique=0.233 -> posterior=0.243\n",
+      "  site 2 (n= 15): empirique=0.133 -> posterior=0.206  <-- shrinkage (site petit tire vers mu_pop)\n",
+      "  site 3 (n=100): empirique=0.430 -> posterior=0.400\n",
+      "  site 4 (n= 25): empirique=0.320 -> posterior=0.294  <-- shrinkage (site petit tire vers mu_pop)\n",
+      "  site 5 (n= 40): empirique=0.350 -> posterior=0.319\n",
+      "  site 6 (n= 12): empirique=0.167 -> posterior=0.223  <-- shrinkage (site petit tire vers mu_pop)\n",
+      "  site 7 (n= 60): empirique=0.167 -> posterior=0.193\n",
+      "\n",
+      "Partial pooling : les sites peu observes sont tires vers mu_pop,\n",
+      "ce qu'aucune mise a jour conjuguee independante (Beta-Binomial par site) ne produit.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Diagnostic hierarchique multi-sites (cas NON-CONJUGUE : MCMC requis)\n",
+    "# 8 hopitaux, prevalences variables. On infer chaque prevalence avec partial pooling.\n",
+    "n_patients = np.array([20, 30, 15, 100, 25, 40, 12, 60])\n",
+    "k_positifs = np.array([3, 7, 2, 43, 8, 14, 2, 10])\n",
+    "empirique = k_positifs / n_patients\n",
+    "print(\"Prevalences empiriques par site :\", empirique.round(3))\n",
+    "\n",
+    "with pm.Model() as model_hierarchique:\n",
+    "    # Niveau population (parametrisation NON-CENTREE : evite le funnel, recette #3801)\n",
+    "    mu_pop = pm.Normal(\"mu_pop\", mu=-1.5, sigma=1.5)   # logit-prevalence moyenne\n",
+    "    tau = pm.HalfNormal(\"tau\", sigma=1.0)              # dispersion entre hopitaux\n",
+    "    z = pm.Normal(\"z\", 0.0, 1.0, shape=len(n_patients))\n",
+    "    logit_p = mu_pop + tau * z\n",
+    "    p = pm.Deterministic(\"p\", pm.math.sigmoid(logit_p))\n",
+    "    # Vraisemblance binomiale observee\n",
+    "    k = pm.Binomial(\"k\", n=n_patients, p=p, observed=k_positifs)\n",
+    "    trace_hier = pm.sample(\n",
+    "        draws=2000, tune=1500, chains=4, target_accept=0.95,\n",
+    "        random_seed=RANDOM_SEED, progressbar=False, return_inferencedata=True\n",
+    "    )\n",
+    "\n",
+    "# Diagnostics MCMC (honetete des sorties)\n",
+    "div = int(trace_hier.sample_stats[\"diverging\"].sum())\n",
+    "resume = az.summary(trace_hier, var_names=[\"mu_pop\", \"tau\", \"p\"])\n",
+    "print(\"Inference hierarchique des prevalences (MCMC, logit-Binomial non-centre)\")\n",
+    "print(\"=\" * 60)\n",
+    "print(f\"Divergences NUTS : {div}   (cible = 0)\")\n",
+    "print(f\"R-hat max         : {resume['r_hat'].max():.3f}   (cible < 1.01)\")\n",
+    "print(f\"ESS bulk min      : {int(resume['ess_bulk'].min())}\")\n",
+    "print()\n",
+    "print(\"Comparaison : prevalence empirique vs posterior (shrinkage vers la moyenne)\")\n",
+    "p_post = resume.loc[[f\"p[{i}]\" for i in range(len(n_patients))], \"mean\"].values\n",
+    "for i in range(len(n_patients)):\n",
+    "    diff = abs(p_post[i] - empirique[i])\n",
+    "    marqueur = \"  <-- shrinkage (site petit tire vers mu_pop)\" if (diff > 0.02 and n_patients[i] < 30) else \"\"\n",
+    "    print(f\"  site {i} (n={n_patients[i]:3d}): empirique={empirique[i]:.3f} -> posterior={p_post[i]:.3f}{marqueur}\")\n",
+    "print()\n",
+    "print(\"Partial pooling : les sites peu observes sont tires vers mu_pop,\")\n",
+    "print(\"ce qu'aucune mise a jour conjuguee independante (Beta-Binomial par site) ne produit.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5a397156",
    "metadata": {
     "papermill": {
-     "duration": 0.005037,
-     "end_time": "2026-06-03T00:57:46.496559+00:00",
+     "duration": 0.013428,
+     "end_time": "2026-06-23T21:48:25.354330+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.491522+00:00",
+     "start_time": "2026-06-23T21:48:25.340902+00:00",
      "status": "completed"
     },
     "tags": []
@@ -775,20 +940,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "f13409a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:57:46.505564Z",
-     "iopub.status.busy": "2026-06-03T00:57:46.505564Z",
-     "iopub.status.idle": "2026-06-03T00:57:46.511000Z",
-     "shell.execute_reply": "2026-06-03T00:57:46.511000Z"
+     "iopub.execute_input": "2026-06-23T21:48:25.396591Z",
+     "iopub.status.busy": "2026-06-23T21:48:25.395598Z",
+     "iopub.status.idle": "2026-06-23T21:48:25.413996Z",
+     "shell.execute_reply": "2026-06-23T21:48:25.412316Z"
     },
     "papermill": {
-     "duration": 0.011447,
-     "end_time": "2026-06-03T00:57:46.512010+00:00",
+     "duration": 0.047834,
+     "end_time": "2026-06-23T21:48:25.415893+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.500563+00:00",
+     "start_time": "2026-06-23T21:48:25.368059+00:00",
      "status": "completed"
     },
     "tags": []
@@ -838,10 +1003,10 @@
    "id": "c30bd229",
    "metadata": {
     "papermill": {
-     "duration": 0.004041,
-     "end_time": "2026-06-03T00:57:46.520571+00:00",
+     "duration": 0.018084,
+     "end_time": "2026-06-23T21:48:25.448084+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.516530+00:00",
+     "start_time": "2026-06-23T21:48:25.430000+00:00",
      "status": "completed"
     },
     "tags": []
@@ -865,10 +1030,10 @@
    "id": "61b1877e",
    "metadata": {
     "papermill": {
-     "duration": 0.004533,
-     "end_time": "2026-06-03T00:57:46.529148+00:00",
+     "duration": 0.006758,
+     "end_time": "2026-06-23T21:48:25.468193+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.524615+00:00",
+     "start_time": "2026-06-23T21:48:25.461435+00:00",
      "status": "completed"
     },
     "tags": []
@@ -906,20 +1071,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "ed7b5da1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:57:46.538667Z",
-     "iopub.status.busy": "2026-06-03T00:57:46.538667Z",
-     "iopub.status.idle": "2026-06-03T00:57:46.548209Z",
-     "shell.execute_reply": "2026-06-03T00:57:46.547698Z"
+     "iopub.execute_input": "2026-06-23T21:48:25.483799Z",
+     "iopub.status.busy": "2026-06-23T21:48:25.479457Z",
+     "iopub.status.idle": "2026-06-23T21:48:25.499831Z",
+     "shell.execute_reply": "2026-06-23T21:48:25.494891Z"
     },
     "papermill": {
-     "duration": 0.016554,
-     "end_time": "2026-06-03T00:57:46.549215+00:00",
+     "duration": 0.027623,
+     "end_time": "2026-06-23T21:48:25.502722+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.532661+00:00",
+     "start_time": "2026-06-23T21:48:25.475099+00:00",
      "status": "completed"
     },
     "tags": []
@@ -984,10 +1149,10 @@
    "id": "46e23c36",
    "metadata": {
     "papermill": {
-     "duration": 0.004603,
-     "end_time": "2026-06-03T00:57:46.558335+00:00",
+     "duration": 0.0207,
+     "end_time": "2026-06-23T21:48:25.535779+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.553732+00:00",
+     "start_time": "2026-06-23T21:48:25.515079+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1014,20 +1179,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "27fb7cad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:57:46.568866Z",
-     "iopub.status.busy": "2026-06-03T00:57:46.568866Z",
-     "iopub.status.idle": "2026-06-03T00:57:46.573094Z",
-     "shell.execute_reply": "2026-06-03T00:57:46.572574Z"
+     "iopub.execute_input": "2026-06-23T21:48:25.569681Z",
+     "iopub.status.busy": "2026-06-23T21:48:25.568189Z",
+     "iopub.status.idle": "2026-06-23T21:48:25.612875Z",
+     "shell.execute_reply": "2026-06-23T21:48:25.612875Z"
     },
     "papermill": {
-     "duration": 0.010228,
-     "end_time": "2026-06-03T00:57:46.573094+00:00",
+     "duration": 0.069111,
+     "end_time": "2026-06-23T21:48:25.616038+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.562866+00:00",
+     "start_time": "2026-06-23T21:48:25.546927+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1037,7 +1202,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : modele PyMC pour la loterie d'assurance\n"
+      "Exercice a completer : modele PyMC pour la loterie d'assurance"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -1067,10 +1239,10 @@
    "id": "51243f3e",
    "metadata": {
     "papermill": {
-     "duration": 0.004525,
-     "end_time": "2026-06-03T00:57:46.582784+00:00",
+     "duration": 0.047496,
+     "end_time": "2026-06-23T21:48:25.704391+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.578259+00:00",
+     "start_time": "2026-06-23T21:48:25.656895+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1099,10 +1271,10 @@
    "id": "51eb4833",
    "metadata": {
     "papermill": {
-     "duration": 0.004516,
-     "end_time": "2026-06-03T00:57:46.592298+00:00",
+     "duration": 0.051361,
+     "end_time": "2026-06-23T21:48:25.797467+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.587782+00:00",
+     "start_time": "2026-06-23T21:48:25.746106+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1121,20 +1293,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "bb9a01d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:57:46.602816Z",
-     "iopub.status.busy": "2026-06-03T00:57:46.602816Z",
-     "iopub.status.idle": "2026-06-03T00:58:16.148475Z",
-     "shell.execute_reply": "2026-06-03T00:58:16.148475Z"
+     "iopub.execute_input": "2026-06-23T21:48:25.844408Z",
+     "iopub.status.busy": "2026-06-23T21:48:25.844408Z",
+     "iopub.status.idle": "2026-06-23T21:48:46.656440Z",
+     "shell.execute_reply": "2026-06-23T21:48:46.654974Z"
     },
     "papermill": {
-     "duration": 29.552679,
-     "end_time": "2026-06-03T00:58:16.149483+00:00",
+     "duration": 20.832274,
+     "end_time": "2026-06-23T21:48:46.657076+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:57:46.596804+00:00",
+     "start_time": "2026-06-23T21:48:25.824802+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1158,7 +1330,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 26 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 21 seconds.\n"
      ]
     },
     {
@@ -1229,10 +1401,10 @@
    "id": "76a6c11f",
    "metadata": {
     "papermill": {
-     "duration": 0.004999,
-     "end_time": "2026-06-03T00:58:16.160483+00:00",
+     "duration": 0.013457,
+     "end_time": "2026-06-23T21:48:46.682573+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:16.155484+00:00",
+     "start_time": "2026-06-23T21:48:46.669116+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1266,10 +1438,10 @@
    "id": "64f6ebf1",
    "metadata": {
     "papermill": {
-     "duration": 0.005009,
-     "end_time": "2026-06-03T00:58:16.169491+00:00",
+     "duration": 0.013696,
+     "end_time": "2026-06-23T21:48:46.704325+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:16.164482+00:00",
+     "start_time": "2026-06-23T21:48:46.690629+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1293,20 +1465,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "3964b865",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:58:16.180492Z",
-     "iopub.status.busy": "2026-06-03T00:58:16.180492Z",
-     "iopub.status.idle": "2026-06-03T00:58:16.190035Z",
-     "shell.execute_reply": "2026-06-03T00:58:16.189530Z"
+     "iopub.execute_input": "2026-06-23T21:48:46.725975Z",
+     "iopub.status.busy": "2026-06-23T21:48:46.725975Z",
+     "iopub.status.idle": "2026-06-23T21:48:46.744073Z",
+     "shell.execute_reply": "2026-06-23T21:48:46.744073Z"
     },
     "papermill": {
-     "duration": 0.017549,
-     "end_time": "2026-06-03T00:58:16.192039+00:00",
+     "duration": 0.028565,
+     "end_time": "2026-06-23T21:48:46.744073+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:16.174490+00:00",
+     "start_time": "2026-06-23T21:48:46.715508+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1409,10 +1581,10 @@
    "id": "8a45858a",
    "metadata": {
     "papermill": {
-     "duration": 0.004997,
-     "end_time": "2026-06-03T00:58:16.202551+00:00",
+     "duration": 0.011577,
+     "end_time": "2026-06-23T21:48:46.768634+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:16.197554+00:00",
+     "start_time": "2026-06-23T21:48:46.757057+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1446,10 +1618,10 @@
    "id": "bfa3c403",
    "metadata": {
     "papermill": {
-     "duration": 0.005514,
-     "end_time": "2026-06-03T00:58:16.214067+00:00",
+     "duration": 0.012156,
+     "end_time": "2026-06-23T21:48:46.792795+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:16.208553+00:00",
+     "start_time": "2026-06-23T21:48:46.780639+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1479,20 +1651,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "e7c076b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:58:16.228073Z",
-     "iopub.status.busy": "2026-06-03T00:58:16.227072Z",
-     "iopub.status.idle": "2026-06-03T00:58:16.234943Z",
-     "shell.execute_reply": "2026-06-03T00:58:16.233937Z"
+     "iopub.execute_input": "2026-06-23T21:48:46.817359Z",
+     "iopub.status.busy": "2026-06-23T21:48:46.817359Z",
+     "iopub.status.idle": "2026-06-23T21:48:46.827509Z",
+     "shell.execute_reply": "2026-06-23T21:48:46.825997Z"
     },
     "papermill": {
-     "duration": 0.015935,
-     "end_time": "2026-06-03T00:58:16.236009+00:00",
+     "duration": 0.023959,
+     "end_time": "2026-06-23T21:48:46.828532+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:16.220074+00:00",
+     "start_time": "2026-06-23T21:48:46.804573+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1549,10 +1721,10 @@
    "id": "b723b721",
    "metadata": {
     "papermill": {
-     "duration": 0.004646,
-     "end_time": "2026-06-03T00:58:16.245757+00:00",
+     "duration": 0.010308,
+     "end_time": "2026-06-23T21:48:46.850379+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:16.241111+00:00",
+     "start_time": "2026-06-23T21:48:46.840071+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1610,10 +1782,10 @@
    "id": "4d292948",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-03T00:58:16.256756+00:00",
+     "duration": 0.011536,
+     "end_time": "2026-06-23T21:48:46.873995+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:16.251756+00:00",
+     "start_time": "2026-06-23T21:48:46.862459+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1649,14 +1821,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 86.604209,
-   "end_time": "2026-06-03T00:58:17.506083+00:00",
+   "duration": 136.682142,
+   "end_time": "2026-06-23T21:48:48.423677+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb",
    "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb",
    "parameters": {},
-   "start_time": "2026-06-03T00:56:50.901874+00:00",
+   "start_time": "2026-06-23T21:46:31.741535+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

PyMC-14-Decision-Utility-Foundations section 4 était **DEGENERATE-CONJUGATE** (Epic #3801) : la cellule de diagnostic médical (cell 16) est un modèle Bernoulli 2-états dont le posterior a **forme close** (Beta-Bernoulli conjugué). Le notebook imprimait lui-même la vérification analytique (MCMC 66.3% vs Bayes 65.9%) → MCMC redondant.

**Fix Prong-B (préserver baseline + ajouter non-conjugué)** : on PRESERVE le diagnostic Bayes simple (baseline conjuguée légitime "exact == MCMC") et on AJOUTE un modèle **hiérarchique multi-sites non-centré** : 8 hôpitaux, \`logit(p_i) = mu_pop + tau*z_i\`, \`k_i ~ Binomial(n_i, p_i)\`. Le lien logit + structure hiérarchique cassent la conjugaison → **MCMC requis**, aucune forme close. Le bénéfice pédagogique concret et visible est le **shrinkage** : les sites peu observés sont tirés vers \`mu_pop\`, ce qu'une mise à jour Beta-Binomial indépendante par site ne produit jamais.

Arc honnête (recette #3801 / PyMC-19) : conjugué (exact==MCMC) → hiérarchique (MCMC seul).

## Changements (insertion 2 cellules après cell 17, total 36 → 38)
- **Cell 18 (markdown, NEW)** : "Au-delà du conjugué : diagnostic hiérarchique multi-sites" (justification non-conjugué + shrinkage + ref Gelman & Hill 2006 + note funnel)
- **Cell 19 (code, NEW)** : modèle hiérarchique non-centré logit-Binomial, NUTS \`target_accept=0.95\`
- Cell 16 (diagnostic Bayes simple) **PRESERVÉE** (baseline conjuguée légitime)

## Validation (C.2 honnête)
- Re-exec **papermill end-to-end** env \`coursia-ml-training\` (PyMC 5.28.5, CPU) : **38/38 cells, 0 erreur**, exit 0, 2:16
- **Diagnostics MCMC** : **0 divergence NUTS**, R-hat max = 1.000, ESS bulk min = 2697
- **Shrinkage visible** : sites petits (n=12/15/20/25) tirés vers \`mu_pop\` (~0.25). Ex site 6 (n=12) : empirique 0.167 → posterior 0.223
- **0 source drift** : toutes les cellules existantes (0-17 + 18-35 décalées) byte-identiques à origin/main, +2 nouvelles cellules uniquement
- **0 image churn** : aucune cellule matplotlib dans ce notebook (aucun risque)

## Scope
1 notebook. \`See #3801\` (contribution partielle à l'epic, epic reste ouverte — 4 PyMC restants : -16/-17/-1 setup-exempt, cell 27 loterie laissée pour cycle séparé). 3 exercices intacts.

## Voir aussi
- PR #4098 (PyMC-11, même recette #3801, attente merge)
- Mémoire \`pymc-degenerate-3801-noncentered-fix.md\` : recette non-centrée + piège multiprocessing Windows