### PR TITLE
lean(cooperative): prove banzhaf_index_nonneg (BG-prover SUCCESS, sorry 1->0, stacks on #4071)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1323,4 +1323,7 @@ theorem banzhaf_index_dummy_zero (G : TUGame N) (i : N)
     Slightly harder than the warm-ups: needs `div_nonneg` plus a positivity
     argument on the denominator. -/
 theorem banzhaf_index_nonneg (G : TUGame N) (i : N) : 0 ≤ BanzhafIndex G i := by
-  sorry
+  simp only [BanzhafIndex]
+  apply div_nonneg
+  · exact Nat.cast_nonneg _
+  · exact pow_nonneg (by norm_num) _

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1316,3 +1316,11 @@ theorem banzhaf_index_symmetric (G : TUGame N) (i j : N)
 theorem banzhaf_index_dummy_zero (G : TUGame N) (i : N)
     (h : DummyPlayer G i) : BanzhafIndex G i = 0 := by
   simp only [BanzhafIndex, dummy_banzhaf_raw_zero G i h, Nat.cast_zero, zero_div]
+
+/-- The normalized Banzhaf index is non-negative: `BanzhafRaw` is a natural count
+    (>= 0 when cast to ℝ) and the normalizing denominator `2 ^ (card N - 1) > 0`.
+    Real BG-prover target (#1453, cycle 65), stacks on #4071 (BanzhafIndex def).
+    Slightly harder than the warm-ups: needs `div_nonneg` plus a positivity
+    argument on the denominator. -/
+theorem banzhaf_index_nonneg (G : TUGame N) (i : N) : 0 ≤ BanzhafIndex G i := by
+  sorry

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1649,6 +1649,24 @@ DEMOS = {
         ),
         "difficulty": "easy",
     },
+    58: {
+        "name": "BANZHAF_INDEX_NONNEG",
+        "file": str(SHAPLEY_FILE) if SHAPLEY_FILE else "",
+        "line": 1309,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "banzhaf_index_nonneg",
+        "theorem": "banzhaf_index_nonneg",
+        "imports": SHAPLEY_IMPORTS,
+        "goal": "0 ≤ BanzhafIndex G i",
+        "description": (
+            "BG-prover target (cycle 65): the normalized Banzhaf index is\n"
+            "non-negative. Stacks on the BanzhafIndex definition (PR #4071).\n"
+            "Slightly harder than the warm-ups: needs `div_nonneg` plus a\n"
+            "positivity argument on the denominator `2 ^ (card N - 1)`.\n"
+            "Replace the placeholder at L1309 of Shapley.lean."
+        ),
+        "difficulty": "easy",
+    },
 }
 # (gale_shapley_stable) was proved in PR #1194. The prover skips any DEMO
 # whose key appears in this set.


### PR DESCRIPTION
## Summary

**BG-prover SUCCESS (cycle 65, item 1 of the proving deep-queue).** The multi-agent Lean prover harness proved `banzhaf_index_nonneg` — the normalized Banzhaf index is non-negative — in 866s, first iteration. This PR **stacks on #4071** (which defines `BanzhafIndex`); it will rebase onto `main` once #4071 merges. The diff vs #4071's branch is *only* the new theorem + its DEMOS entry.

### `CooperativeGames/Shapley.lean` — proof

```lean
/-- The normalized Banzhaf index is non-negative: `BanzhafRaw` is a natural count
    (>= 0 when cast to ℝ) and the normalizing denominator `2 ^ (card N - 1) > 0`. -/
theorem banzhaf_index_nonneg (G : TUGame N) (i : N) : 0 ≤ BanzhafIndex G i := by
  simp only [BanzhafIndex]
  apply div_nonneg
  · exact Nat.cast_nonneg _
  · exact pow_nonneg (by norm_num) _
```

The harness stub used the **bullet-sorry format** (`sorry` on its own indented line L1309, never `:= by sorry` on the declaration line) — the durable lesson from the run-2 SUCCESS (cycle 63): GoalExtract (`lean_utils.py:188-191`) replaces the sorry-*line* with a probe, so `sorry` must sit on a line of its own or the agents go blind. TacticAgent produced this proof (using `pow_nonneg` for the denominator; the reference draft had `pow_pos(...).le` — both correct for `div_nonneg`'s second arm). The Coordinator independently derived the right attack plan ("unfold `BanzhafIndex`, numerator ≥ 0 by non-negativity, denominator > 0").

### `prover/config.py`

- `DEMOS[58] = BANZHAF_INDEX_NONNEG` (`sorry_replacement`, file = `Shapley.lean`, line 1309, difficulty `easy`, goal `0 ≤ BanzhafIndex G i`). Id 58 chosen to avoid collision with 56 (#4088) and 57 (#4095).

## Verification (lean-merge §B)

- `grep -cE '^\s*sorry\s*$' Shapley.lean` = **0** (was 1 stub at L1309; tactic-specific count — no prose "sorry" in the docstring).
- `lake build CooperativeGames` → **SUCCESS** (LAKE_EXIT=0, 8435 jobs, 129s).
- Diff vs #4071 base byte-clean: 4 ins / 1 del, no CRLF churn (file's native line-endings preserved by the write-back).
- First target needing `div_nonneg` + a positivity argument on the denominator (warm-ups #4088/#4095 were single-tactic). Harness now **3/3 on real targets** (#4088, #4095, this).

## Notes

- The stub→theorem transition means the branch holds **0 sorry** — no regression vs main (the temporary 0→1 during the stub phase self-resolved).
- Part of the proving deep-queue. Next (post-greenlight): power-index theorems — `Shapley-Shubik` / Banzhaf-Shapley comparison need a new `ShapleyShubikIndex` def (architecture call, scoped to ai-01).

See #4071 (stack base). Related #1453.
