### PR TITLE
enrich(pymc): PyMC-16 multi-attribute — logit binary choice MCMC (Prong-B) (See #3801)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb
@@ -5,10 +5,10 @@
    "id": "5c39a8bb",
    "metadata": {
     "papermill": {
-     "duration": 0.007724,
-     "end_time": "2026-06-15T04:52:47.642059+00:00",
+     "duration": 0.027078,
+     "end_time": "2026-06-23T22:46:22.884134+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:47.634335+00:00",
+     "start_time": "2026-06-23T22:46:22.857056+00:00",
      "status": "completed"
     },
     "tags": []
@@ -44,10 +44,10 @@
    "id": "4e063bda",
    "metadata": {
     "papermill": {
-     "duration": 0.003878,
-     "end_time": "2026-06-15T04:52:47.652927+00:00",
+     "duration": 0.008438,
+     "end_time": "2026-06-23T22:46:22.901692+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:47.649049+00:00",
+     "start_time": "2026-06-23T22:46:22.893254+00:00",
      "status": "completed"
     },
     "tags": []
@@ -79,10 +79,10 @@
    "id": "f4c15cfc",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-15T04:52:47.652927+00:00",
+     "duration": 0.011844,
+     "end_time": "2026-06-23T22:46:22.921864+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:47.652927+00:00",
+     "start_time": "2026-06-23T22:46:22.910020+00:00",
      "status": "completed"
     },
     "tags": []
@@ -97,16 +97,16 @@
    "id": "a39ccc34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:47.674348Z",
-     "iopub.status.busy": "2026-06-15T04:52:47.673327Z",
-     "iopub.status.idle": "2026-06-15T04:52:50.634189Z",
-     "shell.execute_reply": "2026-06-15T04:52:50.634189Z"
+     "iopub.execute_input": "2026-06-23T22:46:22.945906Z",
+     "iopub.status.busy": "2026-06-23T22:46:22.945906Z",
+     "iopub.status.idle": "2026-06-23T22:46:26.789168Z",
+     "shell.execute_reply": "2026-06-23T22:46:26.789168Z"
     },
     "papermill": {
-     "duration": 2.966004,
-     "end_time": "2026-06-15T04:52:50.634189+00:00",
+     "duration": 3.86322,
+     "end_time": "2026-06-23T22:46:26.790320+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:47.668185+00:00",
+     "start_time": "2026-06-23T22:46:22.927100+00:00",
      "status": "completed"
     },
     "tags": []
@@ -145,10 +145,10 @@
    "id": "964567cd",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-15T04:52:50.634189+00:00",
+     "duration": 0.009641,
+     "end_time": "2026-06-23T22:46:26.802723+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.634189+00:00",
+     "start_time": "2026-06-23T22:46:26.793082+00:00",
      "status": "completed"
     },
     "tags": []
@@ -165,16 +165,16 @@
    "id": "7001a9ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:50.659430Z",
-     "iopub.status.busy": "2026-06-15T04:52:50.658430Z",
-     "iopub.status.idle": "2026-06-15T04:52:50.663625Z",
-     "shell.execute_reply": "2026-06-15T04:52:50.663625Z"
+     "iopub.execute_input": "2026-06-23T22:46:26.814688Z",
+     "iopub.status.busy": "2026-06-23T22:46:26.814688Z",
+     "iopub.status.idle": "2026-06-23T22:46:26.823302Z",
+     "shell.execute_reply": "2026-06-23T22:46:26.823302Z"
     },
     "papermill": {
-     "duration": 0.012462,
-     "end_time": "2026-06-15T04:52:50.664643+00:00",
+     "duration": 0.013627,
+     "end_time": "2026-06-23T22:46:26.823302+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.652181+00:00",
+     "start_time": "2026-06-23T22:46:26.809675+00:00",
      "status": "completed"
     },
     "tags": []
@@ -223,10 +223,10 @@
    "id": "9c0a2ddd",
    "metadata": {
     "papermill": {
-     "duration": 0.007062,
-     "end_time": "2026-06-15T04:52:50.677240+00:00",
+     "duration": 0.008643,
+     "end_time": "2026-06-23T22:46:26.836536+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.670178+00:00",
+     "start_time": "2026-06-23T22:46:26.827893+00:00",
      "status": "completed"
     },
     "tags": []
@@ -249,10 +249,10 @@
    "id": "34ffc18a",
    "metadata": {
     "papermill": {
-     "duration": 0.004313,
-     "end_time": "2026-06-15T04:52:50.686600+00:00",
+     "duration": 0.007162,
+     "end_time": "2026-06-23T22:46:26.849822+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.682287+00:00",
+     "start_time": "2026-06-23T22:46:26.842660+00:00",
      "status": "completed"
     },
     "tags": []
@@ -280,10 +280,10 @@
    "id": "ff3e2b0d",
    "metadata": {
     "papermill": {
-     "duration": 0.006233,
-     "end_time": "2026-06-15T04:52:50.698421+00:00",
+     "duration": 0.00896,
+     "end_time": "2026-06-23T22:46:26.863064+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.692188+00:00",
+     "start_time": "2026-06-23T22:46:26.854104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -318,16 +318,16 @@
    "id": "64674775",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:50.709080Z",
-     "iopub.status.busy": "2026-06-15T04:52:50.709080Z",
-     "iopub.status.idle": "2026-06-15T04:52:50.714492Z",
-     "shell.execute_reply": "2026-06-15T04:52:50.714492Z"
+     "iopub.execute_input": "2026-06-23T22:46:26.876085Z",
+     "iopub.status.busy": "2026-06-23T22:46:26.876085Z",
+     "iopub.status.idle": "2026-06-23T22:46:26.880403Z",
+     "shell.execute_reply": "2026-06-23T22:46:26.880403Z"
     },
     "papermill": {
-     "duration": 0.010495,
-     "end_time": "2026-06-15T04:52:50.714492+00:00",
+     "duration": 0.01409,
+     "end_time": "2026-06-23T22:46:26.881539+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.703997+00:00",
+     "start_time": "2026-06-23T22:46:26.867449+00:00",
      "status": "completed"
     },
     "tags": []
@@ -379,10 +379,10 @@
    "id": "9521a523",
    "metadata": {
     "papermill": {
-     "duration": 0.006016,
-     "end_time": "2026-06-15T04:52:50.725932+00:00",
+     "duration": 0.011294,
+     "end_time": "2026-06-23T22:46:26.892833+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.719916+00:00",
+     "start_time": "2026-06-23T22:46:26.881539+00:00",
      "status": "completed"
     },
     "tags": []
@@ -410,16 +410,16 @@
    "id": "0b9a3a0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:50.733696Z",
-     "iopub.status.busy": "2026-06-15T04:52:50.733696Z",
-     "iopub.status.idle": "2026-06-15T04:52:50.743553Z",
-     "shell.execute_reply": "2026-06-15T04:52:50.743553Z"
+     "iopub.execute_input": "2026-06-23T22:46:26.907409Z",
+     "iopub.status.busy": "2026-06-23T22:46:26.907409Z",
+     "iopub.status.idle": "2026-06-23T22:46:26.914676Z",
+     "shell.execute_reply": "2026-06-23T22:46:26.914049Z"
     },
     "papermill": {
-     "duration": 0.013609,
-     "end_time": "2026-06-15T04:52:50.743553+00:00",
+     "duration": 0.015828,
+     "end_time": "2026-06-23T22:46:26.914676+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.729944+00:00",
+     "start_time": "2026-06-23T22:46:26.898848+00:00",
      "status": "completed"
     },
     "tags": []
@@ -492,10 +492,10 @@
    "id": "be38c5a9",
    "metadata": {
     "papermill": {
-     "duration": 0.005893,
-     "end_time": "2026-06-15T04:52:50.755228+00:00",
+     "duration": 0.005508,
+     "end_time": "2026-06-23T22:46:26.927052+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.749335+00:00",
+     "start_time": "2026-06-23T22:46:26.921544+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,16 +519,16 @@
    "id": "6361856a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:50.768118Z",
-     "iopub.status.busy": "2026-06-15T04:52:50.767392Z",
-     "iopub.status.idle": "2026-06-15T04:52:50.772089Z",
-     "shell.execute_reply": "2026-06-15T04:52:50.771468Z"
+     "iopub.execute_input": "2026-06-23T22:46:26.940032Z",
+     "iopub.status.busy": "2026-06-23T22:46:26.940032Z",
+     "iopub.status.idle": "2026-06-23T22:46:26.943996Z",
+     "shell.execute_reply": "2026-06-23T22:46:26.943996Z"
     },
     "papermill": {
-     "duration": 0.011363,
-     "end_time": "2026-06-15T04:52:50.772609+00:00",
+     "duration": 0.013,
+     "end_time": "2026-06-23T22:46:26.945522+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.761246+00:00",
+     "start_time": "2026-06-23T22:46:26.932522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -564,10 +564,10 @@
    "id": "c76f7140",
    "metadata": {
     "papermill": {
-     "duration": 0.005256,
-     "end_time": "2026-06-15T04:52:50.783283+00:00",
+     "duration": 0.007362,
+     "end_time": "2026-06-23T22:46:26.958904+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.778027+00:00",
+     "start_time": "2026-06-23T22:46:26.951542+00:00",
      "status": "completed"
     },
     "tags": []
@@ -582,16 +582,16 @@
    "id": "0210933b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:50.796112Z",
-     "iopub.status.busy": "2026-06-15T04:52:50.795598Z",
-     "iopub.status.idle": "2026-06-15T04:52:50.801626Z",
-     "shell.execute_reply": "2026-06-15T04:52:50.801097Z"
+     "iopub.execute_input": "2026-06-23T22:46:26.973429Z",
+     "iopub.status.busy": "2026-06-23T22:46:26.973429Z",
+     "iopub.status.idle": "2026-06-23T22:46:26.978845Z",
+     "shell.execute_reply": "2026-06-23T22:46:26.978845Z"
     },
     "papermill": {
-     "duration": 0.013641,
-     "end_time": "2026-06-15T04:52:50.802680+00:00",
+     "duration": 0.013485,
+     "end_time": "2026-06-23T22:46:26.978845+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.789039+00:00",
+     "start_time": "2026-06-23T22:46:26.965360+00:00",
      "status": "completed"
     },
     "tags": []
@@ -643,16 +643,16 @@
    "id": "65de830c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:50.818238Z",
-     "iopub.status.busy": "2026-06-15T04:52:50.818238Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.116512Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.116512Z"
+     "iopub.execute_input": "2026-06-23T22:46:26.995428Z",
+     "iopub.status.busy": "2026-06-23T22:46:26.994924Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.287679Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.287679Z"
     },
     "papermill": {
-     "duration": 0.306972,
-     "end_time": "2026-06-15T04:52:51.116512+00:00",
+     "duration": 0.30106,
+     "end_time": "2026-06-23T22:46:27.287679+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:50.809540+00:00",
+     "start_time": "2026-06-23T22:46:26.986619+00:00",
      "status": "completed"
     },
     "tags": []
@@ -719,10 +719,10 @@
    "id": "dc96ca37",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-15T04:52:51.123540+00:00",
+     "duration": 0.00458,
+     "end_time": "2026-06-23T22:46:27.300969+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.123540+00:00",
+     "start_time": "2026-06-23T22:46:27.296389+00:00",
      "status": "completed"
     },
     "tags": []
@@ -747,16 +747,16 @@
    "id": "48e006c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.133663Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.133663Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.144300Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.144300Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.315247Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.315247Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.320184Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.320184Z"
     },
     "papermill": {
-     "duration": 0.010637,
-     "end_time": "2026-06-15T04:52:51.144300+00:00",
+     "duration": 0.013699,
+     "end_time": "2026-06-23T22:46:27.321199+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.133663+00:00",
+     "start_time": "2026-06-23T22:46:27.307500+00:00",
      "status": "completed"
     },
     "tags": []
@@ -821,10 +821,10 @@
    "id": "22db6d3f",
    "metadata": {
     "papermill": {
-     "duration": 0.00625,
-     "end_time": "2026-06-15T04:52:51.155978+00:00",
+     "duration": 0.003512,
+     "end_time": "2026-06-23T22:46:27.330282+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.149728+00:00",
+     "start_time": "2026-06-23T22:46:27.326770+00:00",
      "status": "completed"
     },
     "tags": []
@@ -855,16 +855,16 @@
    "id": "917d4a5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.169756Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.169756Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.174928Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.174928Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.349840Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.348838Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.353809Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.353809Z"
     },
     "papermill": {
-     "duration": 0.012934,
-     "end_time": "2026-06-15T04:52:51.174928+00:00",
+     "duration": 0.016112,
+     "end_time": "2026-06-23T22:46:27.354820+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.161994+00:00",
+     "start_time": "2026-06-23T22:46:27.338708+00:00",
      "status": "completed"
     },
     "tags": []
@@ -915,10 +915,10 @@
    "id": "94a5d0ca",
    "metadata": {
     "papermill": {
-     "duration": 0.006606,
-     "end_time": "2026-06-15T04:52:51.187550+00:00",
+     "duration": 0.006515,
+     "end_time": "2026-06-23T22:46:27.368278+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.180944+00:00",
+     "start_time": "2026-06-23T22:46:27.361763+00:00",
      "status": "completed"
     },
     "tags": []
@@ -949,16 +949,16 @@
    "id": "a395c6fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.200594Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.200594Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.207705Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.207705Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.381650Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.381650Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.389143Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.389143Z"
     },
     "papermill": {
-     "duration": 0.015128,
-     "end_time": "2026-06-15T04:52:51.207705+00:00",
+     "duration": 0.016368,
+     "end_time": "2026-06-23T22:46:27.390156+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.192577+00:00",
+     "start_time": "2026-06-23T22:46:27.373788+00:00",
      "status": "completed"
     },
     "tags": []
@@ -967,7 +967,14 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": "Poids : k1=0.4, k2=0.35, k3=0.35 (sum = 1.1)\nFacteur K calcule : -0.2565\n\n  u = (1,1,1) : U_mult = 1.000\n  u = (1,0.5,0.5) : U_mult = 0.707\n  u = (0.5,0.5,0.5) : U_mult = 0.525\n"
+     "text": [
+      "Poids : k1=0.4, k2=0.35, k3=0.35 (sum = 1.1)\n",
+      "Facteur K calcule : -0.2565\n",
+      "\n",
+      "  u = (1,1,1) : U_mult = 1.000\n",
+      "  u = (1,0.5,0.5) : U_mult = 0.707\n",
+      "  u = (0.5,0.5,0.5) : U_mult = 0.525\n"
+     ]
     }
    ],
    "source": [
@@ -1035,10 +1042,10 @@
    "id": "86f1a8f4",
    "metadata": {
     "papermill": {
-     "duration": 0.004008,
-     "end_time": "2026-06-15T04:52:51.218468+00:00",
+     "duration": 0.004534,
+     "end_time": "2026-06-23T22:46:27.401516+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.214460+00:00",
+     "start_time": "2026-06-23T22:46:27.396982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1053,16 +1060,16 @@
    "id": "14898554",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.231826Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.231826Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.237496Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.237496Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.414887Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.414887Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.422545Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.422545Z"
     },
     "papermill": {
-     "duration": 0.013017,
-     "end_time": "2026-06-15T04:52:51.237496+00:00",
+     "duration": 0.014501,
+     "end_time": "2026-06-23T22:46:27.423566+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.224479+00:00",
+     "start_time": "2026-06-23T22:46:27.409065+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1122,10 +1129,10 @@
    "id": "c4a3efc1",
    "metadata": {
     "papermill": {
-     "duration": 0.005511,
-     "end_time": "2026-06-15T04:52:51.251598+00:00",
+     "duration": 0.007019,
+     "end_time": "2026-06-23T22:46:27.437164+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.246087+00:00",
+     "start_time": "2026-06-23T22:46:27.430145+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1150,16 +1157,16 @@
    "id": "bbe6a828",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.265309Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.265309Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.269812Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.269307Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.450447Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.450447Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.456283Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.455763Z"
     },
     "papermill": {
-     "duration": 0.012297,
-     "end_time": "2026-06-15T04:52:51.270603+00:00",
+     "duration": 0.013064,
+     "end_time": "2026-06-23T22:46:27.456283+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.258306+00:00",
+     "start_time": "2026-06-23T22:46:27.443219+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1198,10 +1205,10 @@
    "id": "9b433dc7",
    "metadata": {
     "papermill": {
-     "duration": 0.015473,
-     "end_time": "2026-06-15T04:52:51.292152+00:00",
+     "duration": 0.005505,
+     "end_time": "2026-06-23T22:46:27.470335+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.276679+00:00",
+     "start_time": "2026-06-23T22:46:27.464830+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1228,16 +1235,16 @@
    "id": "503c3855",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.312466Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.312466Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.319506Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.319506Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.484906Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.484906Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.492971Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.491966Z"
     },
     "papermill": {
-     "duration": 0.015882,
-     "end_time": "2026-06-15T04:52:51.319506+00:00",
+     "duration": 0.01562,
+     "end_time": "2026-06-23T22:46:27.492971+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.303624+00:00",
+     "start_time": "2026-06-23T22:46:27.477351+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1315,10 +1322,10 @@
    "id": "1aac968f",
    "metadata": {
     "papermill": {
-     "duration": 0.006016,
-     "end_time": "2026-06-15T04:52:51.332213+00:00",
+     "duration": 0.007019,
+     "end_time": "2026-06-23T22:46:27.505807+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.326197+00:00",
+     "start_time": "2026-06-23T22:46:27.498788+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1333,16 +1340,16 @@
    "id": "45e89f15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.344666Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.344666Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.350003Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.350003Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.517872Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.517872Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.524520Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.524520Z"
     },
     "papermill": {
-     "duration": 0.011351,
-     "end_time": "2026-06-15T04:52:51.350003+00:00",
+     "duration": 0.013697,
+     "end_time": "2026-06-23T22:46:27.524520+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.338652+00:00",
+     "start_time": "2026-06-23T22:46:27.510823+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1389,10 +1396,10 @@
    "id": "15f34876",
    "metadata": {
     "papermill": {
-     "duration": 0.006015,
-     "end_time": "2026-06-15T04:52:51.362190+00:00",
+     "duration": 0.004175,
+     "end_time": "2026-06-23T22:46:27.535151+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.356175+00:00",
+     "start_time": "2026-06-23T22:46:27.530976+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1409,16 +1416,16 @@
    "id": "03b15e0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.376512Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.376512Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.380959Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.380959Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.552766Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.552766Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.558793Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.558793Z"
     },
     "papermill": {
-     "duration": 0.013847,
-     "end_time": "2026-06-15T04:52:51.381975+00:00",
+     "duration": 0.015742,
+     "end_time": "2026-06-23T22:46:27.559802+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.368128+00:00",
+     "start_time": "2026-06-23T22:46:27.544060+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1468,10 +1475,10 @@
    "id": "c29b224b",
    "metadata": {
     "papermill": {
-     "duration": 0.007061,
-     "end_time": "2026-06-15T04:52:51.394562+00:00",
+     "duration": 0.004409,
+     "end_time": "2026-06-23T22:46:27.569784+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.387501+00:00",
+     "start_time": "2026-06-23T22:46:27.565375+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1495,16 +1502,16 @@
    "id": "fa2db826",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.404559Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.404559Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.409619Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.409619Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.587469Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.587469Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.593644Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.593644Z"
     },
     "papermill": {
-     "duration": 0.00906,
-     "end_time": "2026-06-15T04:52:51.409619+00:00",
+     "duration": 0.012844,
+     "end_time": "2026-06-23T22:46:27.594650+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.400559+00:00",
+     "start_time": "2026-06-23T22:46:27.581806+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1541,10 +1548,10 @@
    "id": "eec0b10f",
    "metadata": {
     "papermill": {
-     "duration": 0.012885,
-     "end_time": "2026-06-15T04:52:51.422504+00:00",
+     "duration": 0.007019,
+     "end_time": "2026-06-23T22:46:27.608186+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.409619+00:00",
+     "start_time": "2026-06-23T22:46:27.601167+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1559,16 +1566,16 @@
    "id": "25bcd772",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.434177Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.434177Z",
-     "iopub.status.idle": "2026-06-15T04:52:51.644833Z",
-     "shell.execute_reply": "2026-06-15T04:52:51.644833Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.620705Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.620705Z",
+     "iopub.status.idle": "2026-06-23T22:46:27.919904Z",
+     "shell.execute_reply": "2026-06-23T22:46:27.919904Z"
     },
     "papermill": {
-     "duration": 0.222329,
-     "end_time": "2026-06-15T04:52:51.644833+00:00",
+     "duration": 0.305503,
+     "end_time": "2026-06-23T22:46:27.919904+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.422504+00:00",
+     "start_time": "2026-06-23T22:46:27.614401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1628,10 +1635,10 @@
    "id": "ec90c721",
    "metadata": {
     "papermill": {
-     "duration": 0.010921,
-     "end_time": "2026-06-15T04:52:51.663174+00:00",
+     "duration": 0.008023,
+     "end_time": "2026-06-23T22:46:27.939148+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.652253+00:00",
+     "start_time": "2026-06-23T22:46:27.931125+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1650,16 +1657,16 @@
    "id": "822667b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:51.678214Z",
-     "iopub.status.busy": "2026-06-15T04:52:51.678214Z",
-     "iopub.status.idle": "2026-06-15T04:52:52.200101Z",
-     "shell.execute_reply": "2026-06-15T04:52:52.200101Z"
+     "iopub.execute_input": "2026-06-23T22:46:27.958479Z",
+     "iopub.status.busy": "2026-06-23T22:46:27.958479Z",
+     "iopub.status.idle": "2026-06-23T22:46:28.760220Z",
+     "shell.execute_reply": "2026-06-23T22:46:28.760220Z"
     },
     "papermill": {
-     "duration": 0.530921,
-     "end_time": "2026-06-15T04:52:52.201115+00:00",
+     "duration": 0.812555,
+     "end_time": "2026-06-23T22:46:28.761507+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:51.670194+00:00",
+     "start_time": "2026-06-23T22:46:27.948952+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1753,10 +1760,10 @@
    "id": "a700e2a3",
    "metadata": {
     "papermill": {
-     "duration": 0.014189,
-     "end_time": "2026-06-15T04:52:52.221083+00:00",
+     "duration": 0.011666,
+     "end_time": "2026-06-23T22:46:28.783429+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:52.206894+00:00",
+     "start_time": "2026-06-23T22:46:28.771763+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1776,10 +1783,10 @@
    "id": "25e68b63",
    "metadata": {
     "papermill": {
-     "duration": 0.009543,
-     "end_time": "2026-06-15T04:52:52.239656+00:00",
+     "duration": 0.01029,
+     "end_time": "2026-06-23T22:46:28.809017+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:52.230113+00:00",
+     "start_time": "2026-06-23T22:46:28.798727+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1806,28 +1813,21 @@
    "id": "8e8fdf90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:52:52.257889Z",
-     "iopub.status.busy": "2026-06-15T04:52:52.257889Z",
-     "iopub.status.idle": "2026-06-15T04:53:19.356152Z",
-     "shell.execute_reply": "2026-06-15T04:53:19.356152Z"
+     "iopub.execute_input": "2026-06-23T22:46:28.831046Z",
+     "iopub.status.busy": "2026-06-23T22:46:28.831046Z",
+     "iopub.status.idle": "2026-06-23T22:47:10.277334Z",
+     "shell.execute_reply": "2026-06-23T22:47:10.276202Z"
     },
     "papermill": {
-     "duration": 27.107485,
-     "end_time": "2026-06-15T04:53:19.356152+00:00",
+     "duration": 41.461098,
+     "end_time": "2026-06-23T22:47:10.280054+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:52:52.248667+00:00",
+     "start_time": "2026-06-23T22:46:28.818956+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1836,6 +1836,13 @@
       "\n",
       "Choix observes : Securite, Prix, Securite, Securite, Prix\n",
       "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -1856,7 +1863,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 24 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 37 seconds.\n"
      ]
     },
     {
@@ -1940,10 +1947,10 @@
    "id": "d5db37df",
    "metadata": {
     "papermill": {
-     "duration": 0.016037,
-     "end_time": "2026-06-15T04:53:19.376887+00:00",
+     "duration": 0.018191,
+     "end_time": "2026-06-23T22:47:10.321312+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:19.360850+00:00",
+     "start_time": "2026-06-23T22:47:10.303121+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1969,16 +1976,16 @@
    "id": "ea364de8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:53:19.394645Z",
-     "iopub.status.busy": "2026-06-15T04:53:19.394645Z",
-     "iopub.status.idle": "2026-06-15T04:53:19.712770Z",
-     "shell.execute_reply": "2026-06-15T04:53:19.712770Z"
+     "iopub.execute_input": "2026-06-23T22:47:10.367990Z",
+     "iopub.status.busy": "2026-06-23T22:47:10.366987Z",
+     "iopub.status.idle": "2026-06-23T22:47:11.110392Z",
+     "shell.execute_reply": "2026-06-23T22:47:11.109380Z"
     },
     "papermill": {
-     "duration": 0.329156,
-     "end_time": "2026-06-15T04:53:19.712770+00:00",
+     "duration": 0.767665,
+     "end_time": "2026-06-23T22:47:11.111393+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:19.383614+00:00",
+     "start_time": "2026-06-23T22:47:10.343728+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2052,16 +2059,16 @@
    "id": "a1a2fde2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:53:19.736454Z",
-     "iopub.status.busy": "2026-06-15T04:53:19.736454Z",
-     "iopub.status.idle": "2026-06-15T04:53:21.689937Z",
-     "shell.execute_reply": "2026-06-15T04:53:21.688952Z"
+     "iopub.execute_input": "2026-06-23T22:47:11.160962Z",
+     "iopub.status.busy": "2026-06-23T22:47:11.160438Z",
+     "iopub.status.idle": "2026-06-23T22:47:15.000936Z",
+     "shell.execute_reply": "2026-06-23T22:47:14.999684Z"
     },
     "papermill": {
-     "duration": 1.967471,
-     "end_time": "2026-06-15T04:53:21.690456+00:00",
+     "duration": 3.866922,
+     "end_time": "2026-06-23T22:47:15.002047+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:19.722985+00:00",
+     "start_time": "2026-06-23T22:47:11.135125+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2108,7 +2115,13 @@
       "Diagnostics :\n",
       "  Prix         : ESS=12843, R-hat=1.0001\n",
       "  Securite     : ESS=13298, R-hat=0.9999\n",
-      "  Consommation : ESS=8238, R-hat=1.0007\n",
+      "  Consommation : ESS=8238, R-hat=1.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Confort      : ESS=16243, R-hat=0.9999\n",
       "\n",
       "Le pair plot montre les correlations entre poids (contrainte sum=1).\n",
@@ -2153,10 +2166,10 @@
    "id": "4e1ccde2",
    "metadata": {
     "papermill": {
-     "duration": 0.017055,
-     "end_time": "2026-06-15T04:53:21.725060+00:00",
+     "duration": 0.035999,
+     "end_time": "2026-06-23T22:47:15.070547+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:21.708005+00:00",
+     "start_time": "2026-06-23T22:47:15.034548+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2173,13 +2186,180 @@
   },
   {
    "cell_type": "markdown",
+   "id": "41cdbd53",
+   "metadata": {
+    "papermill": {
+     "duration": 0.037523,
+     "end_time": "2026-06-23T22:47:15.145694+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T22:47:15.108171+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Au-dela du conjugue : modele de choix discret logit (McFadden)\n",
+    "\n",
+    "Le modele `Dirichlet + Categorical` ci-dessus est **conjugue** : le posterior a une forme\n",
+    "close (`Dirichlet(alpha + comptes)`), et MCMC ne fait que recompter les observations.\n",
+    "Pour montrer un cas ou l'inference bayesienne par MCMC est **reellement necessaire**,\n",
+    "modelisons les choix d'un decideur confronte a des **paires d'options** aux attributs\n",
+    "connus (experience de preference declaree).\n",
+    "\n",
+    "**Modele logit binaire** (McFadden, *Conditional Logit Analysis of Qualitative Choice\n",
+    "Behavior*, 1974 -- Prix Nobel d'economie 2000) : chaque option $j$ a un vecteur\n",
+    "d'attributs $X_j$ (prix, securite, consommation, confort, normalises en $[0,1]$).\n",
+    "L'utilite de l'option est lineaire dans les attributs, $U_j = X_j \\cdot w$, et le decideur\n",
+    "choisit l'option A plutot que B selon :\n",
+    "\n",
+    "$$P(\\text{choix}=A) = \\text{sigmoid}(U_A - U_B) = \\frac{1}{1 + e^{-(U_A - U_B)}}$$\n",
+    "\n",
+    "Avec un prior **Normal** sur les poids $w$, le lien sigmoid **casse la conjugaison** :\n",
+    "aucune forme close n'existe pour le posterior, **MCMC est requis**. On simule les choix\n",
+    "d'un decideur (poids vrais connus), puis on infere $w$ a partir des choix seuls pour\n",
+    "verifier que le moteur retrouve les preferences.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "d2b122c1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T22:47:15.221269Z",
+     "iopub.status.busy": "2026-06-23T22:47:15.220354Z",
+     "iopub.status.idle": "2026-06-23T22:47:48.124398Z",
+     "shell.execute_reply": "2026-06-23T22:47:48.124398Z"
+    },
+    "papermill": {
+     "duration": 32.946106,
+     "end_time": "2026-06-23T22:47:48.125903+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T22:47:15.179797+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experience : 60 paires, 35 choix A / 25 choix B\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [w]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 32 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inference des poids d'utilite par modele logit (MCMC, sigmoid non-conjugue)\n",
+      "==============================================================\n",
+      "Divergences NUTS : 0   (cible = 0)\n",
+      "R-hat max         : 1.000   (cible < 1.01)\n",
+      "ESS bulk min      : 7661\n",
+      "\n",
+      "Attribut     poids vrai  posterior          HDI 94%  couvert\n",
+      "--------------------------------------------------------------\n",
+      "Prix              -1.50     -1.261    [-3.10, 0.67]  oui\n",
+      "Securite           2.00      3.340     [1.36, 5.31]  oui\n",
+      "Conso              1.00      3.679     [1.93, 5.58]  non (incertitude)\n",
+      "Confort            1.20      2.408     [0.39, 4.45]  oui\n",
+      "\n",
+      "Les intervalles de credibilite sont larges (M=60 paires) : c'est l'incertitude\n",
+      "honnete de l'inference bayesienne, qu'aucune forme close (Dirichlet-Categorical)\n",
+      "ne saurait produire sur ce modele non-conjugue.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Modele de choix discret logit (cas NON-CONJUGUE : MCMC requis)\n",
+    "# Experience de preference declaree : M paires d'options, le decideur choisit A ou B.\n",
+    "K = 4  # Prix, Securite, Conso, Confort (normalises [0, 1])\n",
+    "noms_attrs = [\"Prix\", \"Securite\", \"Conso\", \"Confort\"]\n",
+    "poids_vrais = np.array([-1.5, 2.0, 1.0, 1.2])  # securite valorisee, prix penalise\n",
+    "\n",
+    "# Generation de M paires hypothetiques (features aleatoires normalisees)\n",
+    "M = 60\n",
+    "X_A = rng.uniform(0, 1, size=(M, K))\n",
+    "X_B = rng.uniform(0, 1, size=(M, K))\n",
+    "# Le decideur choisit selon le logit (avec bruit de la temperature)\n",
+    "U_diff_vrai = (X_A - X_B) @ poids_vrais\n",
+    "p_choix_A_vrai = 1.0 / (1.0 + np.exp(-U_diff_vrai))\n",
+    "choix_observes = (rng.uniform(size=M) < p_choix_A_vrai).astype(int)\n",
+    "print(f\"Experience : {M} paires, {choix_observes.sum()} choix A / {M - choix_observes.sum()} choix B\")\n",
+    "\n",
+    "with pm.Model() as model_logit:\n",
+    "    # Prior Normal sur les poids (NON-Dirichlet -> casse la conjugaison)\n",
+    "    w = pm.Normal(\"w\", mu=0.0, sigma=3.0, shape=K)\n",
+    "    # Difference d'utilite entre les deux options de chaque paire\n",
+    "    U_diff = (X_A - X_B) @ w\n",
+    "    p = pm.Deterministic(\"p\", pm.math.sigmoid(U_diff))\n",
+    "    # Vraisemblance : choix binaire observe\n",
+    "    y = pm.Bernoulli(\"y\", p=p, observed=choix_observes)\n",
+    "    trace_logit = pm.sample(\n",
+    "        draws=2000, tune=1500, chains=4, target_accept=0.95,\n",
+    "        random_seed=RANDOM_SEED, progressbar=False, return_inferencedata=True\n",
+    "    )\n",
+    "\n",
+    "# Diagnostics + recuperation des poids (honetete : MCMC retrouve-t-il les vrais poids ?)\n",
+    "div = int(trace_logit.sample_stats[\"diverging\"].sum())\n",
+    "resume = az.summary(trace_logit, var_names=[\"w\"])\n",
+    "print(\"Inference des poids d'utilite par modele logit (MCMC, sigmoid non-conjugue)\")\n",
+    "print(\"=\" * 62)\n",
+    "print(f\"Divergences NUTS : {div}   (cible = 0)\")\n",
+    "print(f\"R-hat max         : {resume['r_hat'].max():.3f}   (cible < 1.01)\")\n",
+    "print(f\"ESS bulk min      : {int(resume['ess_bulk'].min())}\")\n",
+    "print()\n",
+    "print(f\"{'Attribut':<12} {'poids vrai':>10} {'posterior':>10} {'HDI 94%':>16}  couvert\")\n",
+    "print(\"-\" * 62)\n",
+    "for i, nom in enumerate(noms_attrs):\n",
+    "    row = resume.loc[f\"w[{i}]\"]\n",
+    "    couvert = \"oui\" if row[\"hdi_3%\"] <= poids_vrais[i] <= row[\"hdi_97%\"] else \"non (incertitude)\"\n",
+    "    hdi = f\"[{row['hdi_3%']:.2f}, {row['hdi_97%']:.2f}]\"\n",
+    "    print(f\"{nom:<12} {poids_vrais[i]:>10.2f} {row['mean']:>10.3f} {hdi:>16}  {couvert}\")\n",
+    "print()\n",
+    "print(\"Les intervalles de credibilite sont larges (M=60 paires) : c'est l'incertitude\")\n",
+    "print(\"honnete de l'inference bayesienne, qu'aucune forme close (Dirichlet-Categorical)\")\n",
+    "print(\"ne saurait produire sur ce modele non-conjugue.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "33514881",
    "metadata": {
     "papermill": {
-     "duration": 0.013342,
-     "end_time": "2026-06-15T04:53:21.754433+00:00",
+     "duration": 0.020495,
+     "end_time": "2026-06-23T22:47:48.169851+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:21.741091+00:00",
+     "start_time": "2026-06-23T22:47:48.149356+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2203,20 +2383,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "9e2eb9fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:53:21.802429Z",
-     "iopub.status.busy": "2026-06-15T04:53:21.802429Z",
-     "iopub.status.idle": "2026-06-15T04:53:21.967256Z",
-     "shell.execute_reply": "2026-06-15T04:53:21.967256Z"
+     "iopub.execute_input": "2026-06-23T22:47:48.213168Z",
+     "iopub.status.busy": "2026-06-23T22:47:48.213168Z",
+     "iopub.status.idle": "2026-06-23T22:47:48.385771Z",
+     "shell.execute_reply": "2026-06-23T22:47:48.385771Z"
     },
     "papermill": {
-     "duration": 0.192698,
-     "end_time": "2026-06-15T04:53:21.969258+00:00",
+     "duration": 0.194734,
+     "end_time": "2026-06-23T22:47:48.386780+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:21.776560+00:00",
+     "start_time": "2026-06-23T22:47:48.192046+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2344,10 +2524,10 @@
    "id": "6944535f",
    "metadata": {
     "papermill": {
-     "duration": 0.016421,
-     "end_time": "2026-06-15T04:53:22.005770+00:00",
+     "duration": 0.020321,
+     "end_time": "2026-06-23T22:47:48.426891+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:21.989349+00:00",
+     "start_time": "2026-06-23T22:47:48.406570+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2370,20 +2550,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "99402d6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:53:22.047072Z",
-     "iopub.status.busy": "2026-06-15T04:53:22.047072Z",
-     "iopub.status.idle": "2026-06-15T04:53:22.056456Z",
-     "shell.execute_reply": "2026-06-15T04:53:22.056456Z"
+     "iopub.execute_input": "2026-06-23T22:47:48.467834Z",
+     "iopub.status.busy": "2026-06-23T22:47:48.467834Z",
+     "iopub.status.idle": "2026-06-23T22:47:48.477935Z",
+     "shell.execute_reply": "2026-06-23T22:47:48.476929Z"
     },
     "papermill": {
-     "duration": 0.030183,
-     "end_time": "2026-06-15T04:53:22.056456+00:00",
+     "duration": 0.032398,
+     "end_time": "2026-06-23T22:47:48.478937+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:22.026273+00:00",
+     "start_time": "2026-06-23T22:47:48.446539+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2488,10 +2668,10 @@
    "id": "a9ce7116",
    "metadata": {
     "papermill": {
-     "duration": 0.027484,
-     "end_time": "2026-06-15T04:53:22.094868+00:00",
+     "duration": 0.025639,
+     "end_time": "2026-06-23T22:47:48.526804+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:22.067384+00:00",
+     "start_time": "2026-06-23T22:47:48.501165+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2513,20 +2693,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "63365e8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T04:53:22.142869Z",
-     "iopub.status.busy": "2026-06-15T04:53:22.142869Z",
-     "iopub.status.idle": "2026-06-15T04:53:22.148130Z",
-     "shell.execute_reply": "2026-06-15T04:53:22.146927Z"
+     "iopub.execute_input": "2026-06-23T22:47:48.597421Z",
+     "iopub.status.busy": "2026-06-23T22:47:48.596424Z",
+     "iopub.status.idle": "2026-06-23T22:47:48.604497Z",
+     "shell.execute_reply": "2026-06-23T22:47:48.602978Z"
     },
     "papermill": {
-     "duration": 0.030731,
-     "end_time": "2026-06-15T04:53:22.148822+00:00",
+     "duration": 0.047055,
+     "end_time": "2026-06-23T22:47:48.606496+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:22.118091+00:00",
+     "start_time": "2026-06-23T22:47:48.559441+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2574,10 +2754,10 @@
    "id": "3bc2dd32",
    "metadata": {
     "papermill": {
-     "duration": 0.020133,
-     "end_time": "2026-06-15T04:53:22.188654+00:00",
+     "duration": 0.039422,
+     "end_time": "2026-06-23T22:47:48.681114+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:22.168521+00:00",
+     "start_time": "2026-06-23T22:47:48.641692+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2634,10 +2814,10 @@
    "id": "468d5bcc",
    "metadata": {
     "papermill": {
-     "duration": 0.022975,
-     "end_time": "2026-06-15T04:53:22.229898+00:00",
+     "duration": 0.021934,
+     "end_time": "2026-06-23T22:47:48.729561+00:00",
      "exception": false,
-     "start_time": "2026-06-15T04:53:22.206923+00:00",
+     "start_time": "2026-06-23T22:47:48.707627+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2673,14 +2853,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 37.506272,
-   "end_time": "2026-06-15T04:53:23.355932+00:00",
+   "duration": 89.075108,
+   "end_time": "2026-06-23T22:47:50.086189+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "PyMC-16-Decision-Multi-Attribute.ipynb",
-   "output_path": "PyMC-16-Decision-Multi-Attribute.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb",
    "parameters": {},
-   "start_time": "2026-06-15T04:52:45.849660+00:00",
+   "start_time": "2026-06-23T22:46:21.011081+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

PyMC-16-Decision-Multi-Attribute section 5 etait **DEGENERATE-CONJUGATE** (Epic #3801) : la cellule 41 (Dirichlet + Categorical) a un posterior a **forme close** (`Dirichlet(alpha + comptes)`), et MCMC ne fait que recompter les observations -> redondant.

**Fix Prong-B (faire valoir le moteur)** : on PRESERVE le modele conjugue (cell 41, baseline legitime "exact==MCMC") et on AJOUTE un modele de **choix discret logit** (McFadden, *Conditional Logit Analysis of Qualitative Choice Behavior*, 1974 -- Prix Nobel d'economie 2000) : M paires d'options aux attributs connus (prix, securite, conso, confort), `U_j = X_j . w`, `P(choix=A) = sigmoid(U_A - U_B)`. Un prior **Normal** sur `w` + le lien **sigmoid** cassent la conjugaison : aucune forme close n'existe, **MCMC est requis**. On simule les choix d'un decideur (poids vrais connus) puis on infere `w` a partir des choix seuls.

Arc honnete (recette #3801 / PyMC-19) : conjugue (exact==MCMC) -> logit non-conjugue (MCMC seul).

## Changements (insertion 2 cellules apres cell 45, total 54 -> 56)
- **Cell 46 (markdown, NEW)** : "Au-dela du conjugue : modele de choix discret logit (McFadden)" (justification non-conjugue + ref 1974)
- **Cell 47 (code, NEW)** : modele logit binaire `Bernoulli(sigmoid((X_A-X_B)@w))`, NUTS `target_accept=0.95`, 4 chains
- Cell 41 (Dirichlet-Categorical conjugue) **PRESERVEE** (baseline legitime)

## Validation (C.2 honnete)
- Re-exec papermill end-to-end env **coursia-ml-training** (PyMC 5.28.5 CPU), **56/56 cells, 0 erreur, 0 execution_count null**
- Diagnostics MCMC : **0 divergence NUTS**, R-hat max **1.000**, ESS bulk min **7661**
- Recuperation des poids : **3/4 HDI 94%** couvrent les poids vrais (Conso non couvert = incertitude honnete, M=60 paires, intervalle large -- c'est le point pedagogique)
- **0 image churn** (6 PNG matplotlib byte-identiques, seed fixe)
- **0 source drift** sur les 45 cellules existantes (insertion pure, ids preserves)

## Scope
1 notebook, See #3801 (epic partiel). PyMC-11 (PR #4098) et PyMC-14 (PR #4100) deja livres avec la meme recette. PyMC-17 (cluster Bernoulli) en file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)