### PR TITLE
enrich(pymc): PyMC-17 decision-networks — hierarchical true prevalence with imperfect test MCMC (Prong-B) (See #3801)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb
@@ -5,10 +5,10 @@
    "id": "4d1dbaac",
    "metadata": {
     "papermill": {
-     "duration": 0.021021,
-     "end_time": "2026-06-03T00:56:52.909426+00:00",
+     "duration": 0.033673,
+     "end_time": "2026-06-23T23:03:17.856884+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:52.888405+00:00",
+     "start_time": "2026-06-23T23:03:17.823211+00:00",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "d7c821db",
    "metadata": {
     "papermill": {
-     "duration": 0.004997,
-     "end_time": "2026-06-03T00:56:52.930411+00:00",
+     "duration": 0.007047,
+     "end_time": "2026-06-23T23:03:17.872979+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:52.925414+00:00",
+     "start_time": "2026-06-23T23:03:17.865932+00:00",
      "status": "completed"
     },
     "tags": []
@@ -86,10 +86,10 @@
    "id": "580d6c7f",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-03T00:56:52.940940+00:00",
+     "duration": 0.006452,
+     "end_time": "2026-06-23T23:03:17.890276+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:52.935940+00:00",
+     "start_time": "2026-06-23T23:03:17.883824+00:00",
      "status": "completed"
     },
     "tags": []
@@ -106,16 +106,16 @@
    "id": "b2487cdd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:52.951078Z",
-     "iopub.status.busy": "2026-06-03T00:56:52.951078Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.054661Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.054661Z"
+     "iopub.execute_input": "2026-06-23T23:03:17.905197Z",
+     "iopub.status.busy": "2026-06-23T23:03:17.904114Z",
+     "iopub.status.idle": "2026-06-23T23:03:22.453284Z",
+     "shell.execute_reply": "2026-06-23T23:03:22.452215Z"
     },
     "papermill": {
-     "duration": 3.110497,
-     "end_time": "2026-06-03T00:56:56.055949+00:00",
+     "duration": 4.558272,
+     "end_time": "2026-06-23T23:03:22.454270+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:52.945452+00:00",
+     "start_time": "2026-06-23T23:03:17.895998+00:00",
      "status": "completed"
     },
     "tags": []
@@ -150,10 +150,10 @@
    "id": "827a234e",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-06-03T00:56:56.063493+00:00",
+     "duration": 0.005073,
+     "end_time": "2026-06-23T23:03:22.465672+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.059494+00:00",
+     "start_time": "2026-06-23T23:03:22.460599+00:00",
      "status": "completed"
     },
     "tags": []
@@ -196,10 +196,10 @@
    "id": "969a1051",
    "metadata": {
     "papermill": {
-     "duration": 0.005077,
-     "end_time": "2026-06-03T00:56:56.072842+00:00",
+     "duration": 0.007665,
+     "end_time": "2026-06-23T23:03:22.479242+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.067765+00:00",
+     "start_time": "2026-06-23T23:03:22.471577+00:00",
      "status": "completed"
     },
     "tags": []
@@ -214,16 +214,16 @@
    "id": "f0369096",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.083686Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.082649Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.089100Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.089100Z"
+     "iopub.execute_input": "2026-06-23T23:03:22.494007Z",
+     "iopub.status.busy": "2026-06-23T23:03:22.494007Z",
+     "iopub.status.idle": "2026-06-23T23:03:22.504889Z",
+     "shell.execute_reply": "2026-06-23T23:03:22.504352Z"
     },
     "papermill": {
-     "duration": 0.012549,
-     "end_time": "2026-06-03T00:56:56.090263+00:00",
+     "duration": 0.020411,
+     "end_time": "2026-06-23T23:03:22.505909+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.077714+00:00",
+     "start_time": "2026-06-23T23:03:22.485498+00:00",
      "status": "completed"
     },
     "tags": []
@@ -284,10 +284,10 @@
    "id": "c9570105",
    "metadata": {
     "papermill": {
-     "duration": 0.004733,
-     "end_time": "2026-06-03T00:56:56.099000+00:00",
+     "duration": 0.011323,
+     "end_time": "2026-06-23T23:03:22.524903+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.094267+00:00",
+     "start_time": "2026-06-23T23:03:22.513580+00:00",
      "status": "completed"
     },
     "tags": []
@@ -313,10 +313,10 @@
    "id": "ba4230bb",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-06-03T00:56:56.106999+00:00",
+     "duration": 0.006146,
+     "end_time": "2026-06-23T23:03:22.540040+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.103000+00:00",
+     "start_time": "2026-06-23T23:03:22.533894+00:00",
      "status": "completed"
     },
     "tags": []
@@ -349,16 +349,16 @@
    "id": "b931ad69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.117023Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.117023Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.123050Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.123050Z"
+     "iopub.execute_input": "2026-06-23T23:03:22.559883Z",
+     "iopub.status.busy": "2026-06-23T23:03:22.558851Z",
+     "iopub.status.idle": "2026-06-23T23:03:22.568228Z",
+     "shell.execute_reply": "2026-06-23T23:03:22.567204Z"
     },
     "papermill": {
-     "duration": 0.01154,
-     "end_time": "2026-06-03T00:56:56.123050+00:00",
+     "duration": 0.02043,
+     "end_time": "2026-06-23T23:03:22.569245+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.111510+00:00",
+     "start_time": "2026-06-23T23:03:22.548815+00:00",
      "status": "completed"
     },
     "tags": []
@@ -439,10 +439,10 @@
    "id": "441dcea2",
    "metadata": {
     "papermill": {
-     "duration": 0.004491,
-     "end_time": "2026-06-03T00:56:56.132371+00:00",
+     "duration": 0.012943,
+     "end_time": "2026-06-23T23:03:22.588322+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.127880+00:00",
+     "start_time": "2026-06-23T23:03:22.575379+00:00",
      "status": "completed"
     },
     "tags": []
@@ -473,16 +473,16 @@
    "id": "2e9de413",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.141241Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.141241Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.146269Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.146269Z"
+     "iopub.execute_input": "2026-06-23T23:03:22.606011Z",
+     "iopub.status.busy": "2026-06-23T23:03:22.606011Z",
+     "iopub.status.idle": "2026-06-23T23:03:22.611967Z",
+     "shell.execute_reply": "2026-06-23T23:03:22.611422Z"
     },
     "papermill": {
-     "duration": 0.011163,
-     "end_time": "2026-06-03T00:56:56.147535+00:00",
+     "duration": 0.013476,
+     "end_time": "2026-06-23T23:03:22.613010+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.136372+00:00",
+     "start_time": "2026-06-23T23:03:22.599534+00:00",
      "status": "completed"
     },
     "tags": []
@@ -536,10 +536,10 @@
    "id": "d23b2a9c",
    "metadata": {
     "papermill": {
-     "duration": 0.004518,
-     "end_time": "2026-06-03T00:56:56.156049+00:00",
+     "duration": 0.00576,
+     "end_time": "2026-06-23T23:03:22.624927+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.151531+00:00",
+     "start_time": "2026-06-23T23:03:22.619167+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,10 +573,10 @@
    "id": "d6be8fef",
    "metadata": {
     "papermill": {
-     "duration": 0.004627,
-     "end_time": "2026-06-03T00:56:56.164199+00:00",
+     "duration": 0.006157,
+     "end_time": "2026-06-23T23:03:22.637746+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.159572+00:00",
+     "start_time": "2026-06-23T23:03:22.631589+00:00",
      "status": "completed"
     },
     "tags": []
@@ -616,16 +616,16 @@
    "id": "b7f4f877",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.174826Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.174203Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.217135Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.217135Z"
+     "iopub.execute_input": "2026-06-23T23:03:22.651872Z",
+     "iopub.status.busy": "2026-06-23T23:03:22.651022Z",
+     "iopub.status.idle": "2026-06-23T23:03:22.662058Z",
+     "shell.execute_reply": "2026-06-23T23:03:22.660991Z"
     },
     "papermill": {
-     "duration": 0.050216,
-     "end_time": "2026-06-03T00:56:56.218427+00:00",
+     "duration": 0.019144,
+     "end_time": "2026-06-23T23:03:22.663011+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.168211+00:00",
+     "start_time": "2026-06-23T23:03:22.643867+00:00",
      "status": "completed"
     },
     "tags": []
@@ -718,10 +718,10 @@
    "id": "31fcde9f",
    "metadata": {
     "papermill": {
-     "duration": 0.006998,
-     "end_time": "2026-06-03T00:56:56.227424+00:00",
+     "duration": 0.006797,
+     "end_time": "2026-06-23T23:03:22.675970+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.220426+00:00",
+     "start_time": "2026-06-23T23:03:22.669173+00:00",
      "status": "completed"
     },
     "tags": []
@@ -748,10 +748,10 @@
    "id": "1915fdfb",
    "metadata": {
     "papermill": {
-     "duration": 0.004002,
-     "end_time": "2026-06-03T00:56:56.235430+00:00",
+     "duration": 0.006585,
+     "end_time": "2026-06-23T23:03:22.689401+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.231428+00:00",
+     "start_time": "2026-06-23T23:03:22.682816+00:00",
      "status": "completed"
     },
     "tags": []
@@ -777,16 +777,16 @@
    "id": "832d820b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.245945Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.244939Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.252001Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.252001Z"
+     "iopub.execute_input": "2026-06-23T23:03:22.702960Z",
+     "iopub.status.busy": "2026-06-23T23:03:22.702960Z",
+     "iopub.status.idle": "2026-06-23T23:03:22.719494Z",
+     "shell.execute_reply": "2026-06-23T23:03:22.717077Z"
     },
     "papermill": {
-     "duration": 0.012576,
-     "end_time": "2026-06-03T00:56:56.253006+00:00",
+     "duration": 0.025043,
+     "end_time": "2026-06-23T23:03:22.720839+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.240430+00:00",
+     "start_time": "2026-06-23T23:03:22.695796+00:00",
      "status": "completed"
     },
     "tags": []
@@ -888,10 +888,10 @@
    "id": "6f9b7683",
    "metadata": {
     "papermill": {
-     "duration": 0.00451,
-     "end_time": "2026-06-03T00:56:56.262527+00:00",
+     "duration": 0.00701,
+     "end_time": "2026-06-23T23:03:22.732836+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.258017+00:00",
+     "start_time": "2026-06-23T23:03:22.725826+00:00",
      "status": "completed"
     },
     "tags": []
@@ -922,16 +922,16 @@
    "id": "655664f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.273525Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.273525Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.277531Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.277531Z"
+     "iopub.execute_input": "2026-06-23T23:03:22.747317Z",
+     "iopub.status.busy": "2026-06-23T23:03:22.746182Z",
+     "iopub.status.idle": "2026-06-23T23:03:22.752928Z",
+     "shell.execute_reply": "2026-06-23T23:03:22.751868Z"
     },
     "papermill": {
-     "duration": 0.011223,
-     "end_time": "2026-06-03T00:56:56.278749+00:00",
+     "duration": 0.015953,
+     "end_time": "2026-06-23T23:03:22.753484+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.267526+00:00",
+     "start_time": "2026-06-23T23:03:22.737531+00:00",
      "status": "completed"
     },
     "tags": []
@@ -986,10 +986,10 @@
    "id": "cc143ddb",
    "metadata": {
     "papermill": {
-     "duration": 0.005504,
-     "end_time": "2026-06-03T00:56:56.288252+00:00",
+     "duration": 0.006259,
+     "end_time": "2026-06-23T23:03:22.766417+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.282748+00:00",
+     "start_time": "2026-06-23T23:03:22.760158+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1016,10 +1016,10 @@
    "id": "761a49a0",
    "metadata": {
     "papermill": {
-     "duration": 0.005692,
-     "end_time": "2026-06-03T00:56:56.297951+00:00",
+     "duration": 0.007234,
+     "end_time": "2026-06-23T23:03:22.778866+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.292259+00:00",
+     "start_time": "2026-06-23T23:03:22.771632+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1049,16 +1049,16 @@
    "id": "2c198690",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.307957Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.307957Z",
-     "iopub.status.idle": "2026-06-03T00:56:56.315985Z",
-     "shell.execute_reply": "2026-06-03T00:56:56.314979Z"
+     "iopub.execute_input": "2026-06-23T23:03:22.792115Z",
+     "iopub.status.busy": "2026-06-23T23:03:22.792115Z",
+     "iopub.status.idle": "2026-06-23T23:03:22.803393Z",
+     "shell.execute_reply": "2026-06-23T23:03:22.802284Z"
     },
     "papermill": {
-     "duration": 0.014028,
-     "end_time": "2026-06-03T00:56:56.315985+00:00",
+     "duration": 0.01899,
+     "end_time": "2026-06-23T23:03:22.804560+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.301957+00:00",
+     "start_time": "2026-06-23T23:03:22.785570+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1144,10 +1144,10 @@
    "id": "caff3617",
    "metadata": {
     "papermill": {
-     "duration": 0.004502,
-     "end_time": "2026-06-03T00:56:56.325486+00:00",
+     "duration": 0.013797,
+     "end_time": "2026-06-23T23:03:22.833367+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.320984+00:00",
+     "start_time": "2026-06-23T23:03:22.819570+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1169,10 +1169,10 @@
    "id": "af02138e",
    "metadata": {
     "papermill": {
-     "duration": 0.004758,
-     "end_time": "2026-06-03T00:56:56.334243+00:00",
+     "duration": 0.011121,
+     "end_time": "2026-06-23T23:03:22.852973+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.329485+00:00",
+     "start_time": "2026-06-23T23:03:22.841852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1195,16 +1195,16 @@
    "id": "382b6f7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:56:56.348270Z",
-     "iopub.status.busy": "2026-06-03T00:56:56.347743Z",
-     "iopub.status.idle": "2026-06-03T00:58:23.303910Z",
-     "shell.execute_reply": "2026-06-03T00:58:23.303910Z"
+     "iopub.execute_input": "2026-06-23T23:03:22.873512Z",
+     "iopub.status.busy": "2026-06-23T23:03:22.873512Z",
+     "iopub.status.idle": "2026-06-23T23:04:39.105531Z",
+     "shell.execute_reply": "2026-06-23T23:04:39.104414Z"
     },
     "papermill": {
-     "duration": 86.965315,
-     "end_time": "2026-06-03T00:58:23.304917+00:00",
+     "duration": 76.2426,
+     "end_time": "2026-06-23T23:04:39.107417+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:56:56.339602+00:00",
+     "start_time": "2026-06-23T23:03:22.864817+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1236,7 +1236,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 40 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 27 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "BinaryGibbsMetropolis: [maladie]\n"
      ]
     },
     {
@@ -1255,21 +1269,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Multiprocess sampling (4 chains in 4 jobs)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "BinaryGibbsMetropolis: [maladie]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 37 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 46 seconds.\n"
      ]
     },
     {
@@ -1339,10 +1339,10 @@
    "id": "a414204a",
    "metadata": {
     "papermill": {
-     "duration": 0.006001,
-     "end_time": "2026-06-03T00:58:23.315429+00:00",
+     "duration": 0.009378,
+     "end_time": "2026-06-23T23:04:39.128903+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.309428+00:00",
+     "start_time": "2026-06-23T23:04:39.119525+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1376,13 +1376,199 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0b734543",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012666,
+     "end_time": "2026-06-23T23:04:39.154736+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T23:04:39.142070+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Au-dela du cas simple : prevalence hierarchique avec test imparfait\n",
+    "\n",
+    "La cellule precedente modelisait **une seule** variable binaire (maladie d'un patient)\n",
+    "et laissait PyMC l'echantillonner par `BinaryGibbsMetropolis` -- c'est-a-dire compter\n",
+    "des 0 et des 1. Pour un probleme a 2 variables binaires, le calcul analytique de Bayes\n",
+    "donne la meme reponse plus rapidement (cf. note ci-dessus) : le moteur MCMC n'etait\n",
+    "pas reellement mis a contribution.\n",
+    "\n",
+    "Pour faire valoir l'inference bayesienne par MCMC, considerons un probleme\n",
+    "**non conjugue** ou aucune forme close n'existe. **Scenario** : un reseau de cliniques\n",
+    "applique le meme test diagnostique (imparfait : sensibilite 0.92, specificite 0.88).\n",
+    "On observe, par clinique, le nombre de patients testes $n_i$ et de tests positifs $k_i$ --\n",
+    "mais **jamais le vrai etat maladie** (latent). Objectif : inferer la **vraie prevalence**\n",
+    "de chaque clinique.\n",
+    "\n",
+    "**Piege du taux apparent** : le taux de test positif naif $k_i/n_i$ **surestime** la\n",
+    "vraie prevalence, car il melange les vrais positifs (malades bien detectes) et les\n",
+    "faux positifs (patients sains malgre tout testes positifs, $1-\\text{specificite}=0{,}12$).\n",
+    "Le taux apparent verifie $p_{\\text{app}} = p\\cdot\\text{se} + (1-p)\\cdot(1-\\text{sp})$.\n",
+    "\n",
+    "**Modele hierarchique non-centre** (recette #3801) :\n",
+    "\n",
+    "$$\\text{logit}(p_i) = \\mu_{pop} + \\tau \\cdot z_i, \\quad z_i \\sim \\mathcal{N}(0,1), \\quad k_i \\sim \\text{Binomial}(n_i,\\; p_i\\cdot\\text{se} + (1-p_i)(1-\\text{sp}))$$\n",
+    "\n",
+    "Le prior logit-Normal hierarchique + le lien non-lineaire entre vraie prevalence et\n",
+    "taux apparent cassent toute conjugaison : **MCMC est requis**, et aucun calcul\n",
+    "analytique par clinique (Beta-Binomial independant) ne peut produire cette correction\n",
+    "du test imparfait ni le **shrinkage** entre cliniques.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "03792581",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T23:04:39.182417Z",
+     "iopub.status.busy": "2026-06-23T23:04:39.182417Z",
+     "iopub.status.idle": "2026-06-23T23:05:52.180098Z",
+     "shell.execute_reply": "2026-06-23T23:05:52.178510Z"
+    },
+    "papermill": {
+     "duration": 73.013921,
+     "end_time": "2026-06-23T23:05:52.181139+00:00",
+     "exception": false,
+     "start_time": "2026-06-23T23:04:39.167218+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Taux de test positif OBSERVES (apparent, naif k/n) par clinique : [0.233 0.378 0.225 0.45  0.3   0.592]\n",
+      "(ces taux apparents SURESTIMENT la vraie prevalence a cause des faux positifs)\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [mu_pop, tau, z]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 69 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inference hierarchique de la vraie prevalence (MCMC, test imparfait non-conjugue)\n",
+      "================================================================\n",
+      "Divergences NUTS : 0   (cible = 0)\n",
+      "R-hat max         : 1.000   (cible < 1.01)\n",
+      "ESS bulk min      : 1791\n",
+      "\n",
+      "Comparaison : taux apparent (naif k/n) vs vraie prevalence inferiee (corrigee)\n",
+      " clinique     n   vrai  apparent   vraie inferiee  correction\n",
+      "----------------------------------------------------------------\n",
+      "        0    60   0.12     0.233            0.169  <-- corrige (faux positifs retires)\n",
+      "        1    90   0.25     0.378            0.317  <-- corrige (faux positifs retires)\n",
+      "        2    40   0.08     0.225            0.174  <-- corrige (faux positifs retires)\n",
+      "        3   200   0.40     0.450            0.405  <-- corrige (faux positifs retires)\n",
+      "        4    70   0.15     0.300            0.230  <-- corrige (faux positifs retires)\n",
+      "        5   130   0.50     0.592            0.568  <-- corrige (faux positifs retires)\n",
+      "\n",
+      "Le moteur MCMC a inferer la VRAIE prevalence (etat maladie latent) en inversant\n",
+      "le test imparfait, avec shrinkage entre cliniques -- ce qu'aucun calcul analytique\n",
+      "(Beta-Binomial independant par clinique) ne peut produire : il donnerait seulement\n",
+      "la distribution du taux apparent, sans correction ni emprunt d'information.)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Prevalence hierarchique avec test imparfait (cas NON-CONJUGUE : MCMC requis)\n",
+    "# K cliniques, vraie prevalence inconnue, test imparfait connu (se, sp).\n",
+    "# On n'observe que les comptes de tests positifs k_i : l'etat maladie est LATENT.\n",
+    "K = 6\n",
+    "n_patients = np.array([60, 90, 40, 200, 70, 130])\n",
+    "prevalences_vraies = np.array([0.12, 0.25, 0.08, 0.40, 0.15, 0.50])  # inconnues de l'inference\n",
+    "se, sp = 0.92, 0.88  # sensibilite / specificite du test (specs constructeur, cf cellule precedente)\n",
+    "# Taux apparent reel (simule) = vraie prevalence corrigee par le test imparfait\n",
+    "p_apparent_vrai = prevalences_vraies * se + (1 - prevalences_vraies) * (1 - sp)\n",
+    "rng_obs = np.random.default_rng(7)\n",
+    "k_positifs = rng_obs.binomial(n_patients, p_apparent_vrai)\n",
+    "taux_apparent = k_positifs / n_patients\n",
+    "print(\"Taux de test positif OBSERVES (apparent, naif k/n) par clinique :\", taux_apparent.round(3))\n",
+    "print(\"(ces taux apparents SURESTIMENT la vraie prevalence a cause des faux positifs)\\n\")\n",
+    "\n",
+    "with pm.Model() as model_prevalence:\n",
+    "    # Niveau population (parametrisation NON-CENTREE : evite le funnel, recette #3801)\n",
+    "    mu_pop = pm.Normal(\"mu_pop\", mu=-1.5, sigma=1.5)   # logit-prevalence moyenne\n",
+    "    tau = pm.HalfNormal(\"tau\", sigma=1.0)              # dispersion entre cliniques\n",
+    "    z = pm.Normal(\"z\", 0.0, 1.0, shape=K)\n",
+    "    p_vraie = pm.Deterministic(\"p_vraie\", pm.math.sigmoid(mu_pop + tau * z))\n",
+    "    # Lien NON-LINEAIRE vraie prevalence -> taux apparent (casse la conjugaison)\n",
+    "    p_apparent = pm.Deterministic(\n",
+    "        \"p_apparent\", p_vraie * se + (1 - p_vraie) * (1 - sp)\n",
+    "    )\n",
+    "    # Vraisemblance binomiale sur les comptes de tests positifs observes\n",
+    "    k = pm.Binomial(\"k\", n=n_patients, p=p_apparent, observed=k_positifs)\n",
+    "    trace_prev = pm.sample(\n",
+    "        draws=2000, tune=1500, chains=4, target_accept=0.99,\n",
+    "        random_seed=42, progressbar=False, return_inferencedata=True\n",
+    "    )\n",
+    "\n",
+    "# Diagnostics MCMC (honnetete des sorties)\n",
+    "div = int(trace_prev.sample_stats[\"diverging\"].sum())\n",
+    "resume = az.summary(trace_prev, var_names=[\"mu_pop\", \"tau\", \"p_vraie\"])\n",
+    "print(\"Inference hierarchique de la vraie prevalence (MCMC, test imparfait non-conjugue)\")\n",
+    "print(\"=\" * 64)\n",
+    "print(f\"Divergences NUTS : {div}   (cible = 0)\")\n",
+    "print(f\"R-hat max         : {resume['r_hat'].max():.3f}   (cible < 1.01)\")\n",
+    "print(f\"ESS bulk min      : {int(resume['ess_bulk'].min())}\")\n",
+    "print()\n",
+    "print(\"Comparaison : taux apparent (naif k/n) vs vraie prevalence inferiee (corrigee)\")\n",
+    "print(f\"{'clinique':>9} {'n':>5} {'vrai':>6} {'apparent':>9} {'vraie inferiee':>16}  correction\")\n",
+    "print(\"-\" * 64)\n",
+    "p_post = resume.loc[[f\"p_vraie[{i}]\" for i in range(K)], \"mean\"].values\n",
+    "for i in range(K):\n",
+    "    corr = abs(taux_apparent[i] - p_post[i])\n",
+    "    marqueur = \"  <-- corrige (faux positifs retires)\" if corr > 0.02 else \"\"\n",
+    "    print(f\"{i:>9} {n_patients[i]:>5} {prevalences_vraies[i]:>6.2f} {taux_apparent[i]:>9.3f} {p_post[i]:>16.3f}{marqueur}\")\n",
+    "print()\n",
+    "print(\"Le moteur MCMC a inferer la VRAIE prevalence (etat maladie latent) en inversant\")\n",
+    "print(\"le test imparfait, avec shrinkage entre cliniques -- ce qu'aucun calcul analytique\")\n",
+    "print(\"(Beta-Binomial independant par clinique) ne peut produire : il donnerait seulement\")\n",
+    "print(\"la distribution du taux apparent, sans correction ni emprunt d'information.)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "da64c820",
    "metadata": {
     "papermill": {
-     "duration": 0.006822,
-     "end_time": "2026-06-03T00:58:23.328995+00:00",
+     "duration": 0.011321,
+     "end_time": "2026-06-23T23:05:52.203618+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.322173+00:00",
+     "start_time": "2026-06-23T23:05:52.192297+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1395,20 +1581,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "8acac63a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:58:23.341897Z",
-     "iopub.status.busy": "2026-06-03T00:58:23.341897Z",
-     "iopub.status.idle": "2026-06-03T00:58:23.349356Z",
-     "shell.execute_reply": "2026-06-03T00:58:23.348268Z"
+     "iopub.execute_input": "2026-06-23T23:05:52.229528Z",
+     "iopub.status.busy": "2026-06-23T23:05:52.229528Z",
+     "iopub.status.idle": "2026-06-23T23:05:52.244550Z",
+     "shell.execute_reply": "2026-06-23T23:05:52.242470Z"
     },
     "papermill": {
-     "duration": 0.014421,
-     "end_time": "2026-06-03T00:58:23.349919+00:00",
+     "duration": 0.029032,
+     "end_time": "2026-06-23T23:05:52.244550+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.335498+00:00",
+     "start_time": "2026-06-23T23:05:52.215518+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1419,7 +1605,7 @@
      "output_type": "stream",
      "text": [
       "Structure du DAG du modele de diagnostic :\n",
-      "<pymc.model.core.Model object at 0x0000028F103CB530>\n",
+      "<pymc.model.core.Model object at 0x000002902AE5EA50>\n",
       "\n",
       "Variables :\n",
       "  maladie ~ bernoulli\n",
@@ -1472,10 +1658,10 @@
    "id": "d6e16e08",
    "metadata": {
     "papermill": {
-     "duration": 0.00617,
-     "end_time": "2026-06-03T00:58:23.361509+00:00",
+     "duration": 0.023093,
+     "end_time": "2026-06-23T23:05:52.277907+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.355339+00:00",
+     "start_time": "2026-06-23T23:05:52.254814+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1503,20 +1689,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "ec1aa976",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:58:23.374823Z",
-     "iopub.status.busy": "2026-06-03T00:58:23.374286Z",
-     "iopub.status.idle": "2026-06-03T00:58:23.379833Z",
-     "shell.execute_reply": "2026-06-03T00:58:23.379266Z"
+     "iopub.execute_input": "2026-06-23T23:05:52.316076Z",
+     "iopub.status.busy": "2026-06-23T23:05:52.316076Z",
+     "iopub.status.idle": "2026-06-23T23:05:52.325351Z",
+     "shell.execute_reply": "2026-06-23T23:05:52.323817Z"
     },
     "papermill": {
-     "duration": 0.013857,
-     "end_time": "2026-06-03T00:58:23.380920+00:00",
+     "duration": 0.02822,
+     "end_time": "2026-06-23T23:05:52.325351+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.367063+00:00",
+     "start_time": "2026-06-23T23:05:52.297131+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1565,10 +1751,10 @@
    "id": "7d174888",
    "metadata": {
     "papermill": {
-     "duration": 0.006001,
-     "end_time": "2026-06-03T00:58:23.391765+00:00",
+     "duration": 0.011906,
+     "end_time": "2026-06-23T23:05:52.356439+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.385764+00:00",
+     "start_time": "2026-06-23T23:05:52.344533+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1588,10 +1774,10 @@
    "id": "0c6490fa",
    "metadata": {
     "papermill": {
-     "duration": 0.00521,
-     "end_time": "2026-06-03T00:58:23.401975+00:00",
+     "duration": 0.010734,
+     "end_time": "2026-06-23T23:05:52.377251+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.396765+00:00",
+     "start_time": "2026-06-23T23:05:52.366517+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1614,20 +1800,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "7883d4fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:58:23.414488Z",
-     "iopub.status.busy": "2026-06-03T00:58:23.413488Z",
-     "iopub.status.idle": "2026-06-03T00:58:23.423171Z",
-     "shell.execute_reply": "2026-06-03T00:58:23.422322Z"
+     "iopub.execute_input": "2026-06-23T23:05:52.402466Z",
+     "iopub.status.busy": "2026-06-23T23:05:52.402466Z",
+     "iopub.status.idle": "2026-06-23T23:05:52.420803Z",
+     "shell.execute_reply": "2026-06-23T23:05:52.419770Z"
     },
     "papermill": {
-     "duration": 0.016196,
-     "end_time": "2026-06-03T00:58:23.423171+00:00",
+     "duration": 0.034269,
+     "end_time": "2026-06-23T23:05:52.422908+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.406975+00:00",
+     "start_time": "2026-06-23T23:05:52.388639+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1735,10 +1921,10 @@
    "id": "5ba25065",
    "metadata": {
     "papermill": {
-     "duration": 0.004996,
-     "end_time": "2026-06-03T00:58:23.434177+00:00",
+     "duration": 0.019448,
+     "end_time": "2026-06-23T23:05:52.455398+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.429181+00:00",
+     "start_time": "2026-06-23T23:05:52.435950+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1751,20 +1937,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "30083993",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:58:23.445480Z",
-     "iopub.status.busy": "2026-06-03T00:58:23.445480Z",
-     "iopub.status.idle": "2026-06-03T00:58:23.455990Z",
-     "shell.execute_reply": "2026-06-03T00:58:23.455481Z"
+     "iopub.execute_input": "2026-06-23T23:05:52.477288Z",
+     "iopub.status.busy": "2026-06-23T23:05:52.477288Z",
+     "iopub.status.idle": "2026-06-23T23:05:52.494953Z",
+     "shell.execute_reply": "2026-06-23T23:05:52.493908Z"
     },
     "papermill": {
-     "duration": 0.018501,
-     "end_time": "2026-06-03T00:58:23.456996+00:00",
+     "duration": 0.031056,
+     "end_time": "2026-06-23T23:05:52.496604+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.438495+00:00",
+     "start_time": "2026-06-23T23:05:52.465548+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1825,10 +2011,10 @@
    "id": "c839390f",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-03T00:58:23.466995+00:00",
+     "duration": 0.016896,
+     "end_time": "2026-06-23T23:05:52.521199+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.461995+00:00",
+     "start_time": "2026-06-23T23:05:52.504303+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1858,10 +2044,10 @@
    "id": "a972fe1c",
    "metadata": {
     "papermill": {
-     "duration": 0.004968,
-     "end_time": "2026-06-03T00:58:23.477001+00:00",
+     "duration": 0.014319,
+     "end_time": "2026-06-23T23:05:52.551404+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.472033+00:00",
+     "start_time": "2026-06-23T23:05:52.537085+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1902,10 +2088,10 @@
    "id": "66a5401e",
    "metadata": {
     "papermill": {
-     "duration": 0.004508,
-     "end_time": "2026-06-03T00:58:23.485884+00:00",
+     "duration": 0.01528,
+     "end_time": "2026-06-23T23:05:52.581184+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.481376+00:00",
+     "start_time": "2026-06-23T23:05:52.565904+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1960,10 +2146,10 @@
    "id": "f7797277",
    "metadata": {
     "papermill": {
-     "duration": 0.005003,
-     "end_time": "2026-06-03T00:58:23.495887+00:00",
+     "duration": 0.013916,
+     "end_time": "2026-06-23T23:05:52.609623+00:00",
      "exception": false,
-     "start_time": "2026-06-03T00:58:23.490884+00:00",
+     "start_time": "2026-06-23T23:05:52.595707+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1999,14 +2185,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 93.457331,
-   "end_time": "2026-06-03T00:58:24.359205+00:00",
+   "duration": 160.262361,
+   "end_time": "2026-06-23T23:05:55.247871+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb",
    "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb",
    "parameters": {},
-   "start_time": "2026-06-03T00:56:50.901874+00:00",
+   "start_time": "2026-06-23T23:03:14.985510+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

PyMC-17-Decision-Networks section 7 etait **DEGENERATE** (Epic #3801) : la cellule 25 modelisait **une seule** variable binaire `pm.Bernoulli("maladie")` echantillonnee par `BinaryGibbsMetropolis` (compter des 0 et des 1, pas NUTS), avec une forme close admise dans la cellule 26 (« Pour ce probleme simple... le calcul analytique de Bayes est exact »). Le moteur MCMC n'etait pas reellement mis a contribution.

**Fix Prong-B (faire valoir le moteur)** : on PRESERVE le diagnostic simple (cell 25, baseline legitime « MCMC == analytique ») et on AJOUTE un modele de **prevalence hierarchique avec test imparfait** : K cliniques appliquent le meme test diagnostique (se=0.92, sp=0.88), on observe uniquement les comptes de tests positifs `k_i` (l'etat maladie est **latent**). Le taux apparent naif `k_i/n_i` **surestime** la vraie prevalence (faux positifs du test imparfait) ; le modele inferer la **vraie prevalence** en inversant le test imparfait, avec shrinkage hierarchique.

Le prior logit-Normal hierarchique + le lien non-lineaire vraie prevalence -> taux apparent cassent toute conjugaison : **MCMC requis**, aucune forme close. Aucune mise a jour Beta-Binomial independante par clinique ne peut produire cette correction du test imparfait (elle ne donnerait que la distribution du taux apparent, sans correction ni emprunt d'information).

Arc honnete (recette #3801 / PyMC-19) : degenere (single Bernoulli, Gibbs counting) -> prevalence hierarchique non-conjuguee (NUTS requis).

## Changements (insertion 2 cellules apres cell 26, total 40 -> 42)
- **Cell 27 (markdown, NEW)** : « Au-dela du cas simple : prevalence hierarchique avec test imparfait » (piege du taux apparent + modele non-centre + ref #3801)
- **Cell 28 (code, NEW)** : modele hierarchique non-centre `logit(p_i)=mu_pop+tau*z_i`, vraisemblance `Binomial(n_i, p_i*se+(1-p_i)*(1-sp))`, NUTS `target_accept=0.99`, 4 chains
- Cell 25 (diagnostic single-Bernoulli) **PRESERVEE** (baseline legitime)
- Cell 26 (interpretation + note honnete) **PRESERVEE** (le hook « prend tout son sens pour des modeles plus complexes » -> notre nouvelle section le delivre)

## Validation (C.2 honnete)
- Re-exec papermill end-to-end env **coursia-ml-training** (PyMC 5.28.5 CPU), **42/42 cells, 0 erreur, 0 execution_count null**
- Diagnostics MCMC : **0 divergence NUTS**, R-hat max **1.000**, ESS bulk min **1791**
- Correction visible : le taux apparent (naif k/n) surestime la vraie prevalence partout (faux positifs) ; le posterior MCMC corrige a la baisse (ex clinique 3 : apparent 0.45 -> vraie 0.405 ; clinique 0 : apparent 0.233 -> vraie 0.169)
- **0 image churn** (aucune image base64 dans le notebook ; insertion pure)
- **0 source drift** sur les 40 cellules existantes (insertion pure, ids preserves)

## Scope
1 notebook, See #3801 (epic partiel). **Dernier du cluster PyMC DEGENERATE** : PyMC-11 (PR #4098), PyMC-14 (PR #4100), PyMC-16 (PR #4106) deja livres. PyMC-18 NON-TRIVIAL honnete (laisse), PyMC-1 SETUP-exempt (laisse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)