### PR TITLE
lean(cooperative): prove banzhaf_index_le_two (BG failed, ref-proof fallback, sorry 1->0)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1316,3 +1316,12 @@ theorem banzhaf_index_symmetric (G : TUGame N) (i j : N)
 theorem banzhaf_index_dummy_zero (G : TUGame N) (i : N)
     (h : DummyPlayer G i) : BanzhafIndex G i = 0 := by
   simp only [BanzhafIndex, dummy_banzhaf_raw_zero G i h, Nat.cast_zero, zero_div]
+
+/-- The normalized Banzhaf index is at most 2: `BanzhafRaw` counts critical
+    coalitions, bounded by the total number of coalitions `2 ^ card N` (see
+    `banzhaf_raw_le_univ`); normalizing by `2 ^ (card N - 1)` leaves a quotient
+    of at most 2. The player `i : N` forces `0 < card N`, so the Nat-subtraction
+    `card N - 1` does not underflow.
+    BG-prover target (#1453, cycle 66, item 3); chains `banzhaf_raw_le_univ`. -/
+theorem banzhaf_index_le_two (G : TUGame N) (i : N) : BanzhafIndex G i ≤ 2 := by
+  sorry

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1324,4 +1324,16 @@ theorem banzhaf_index_dummy_zero (G : TUGame N) (i : N)
     `card N - 1` does not underflow.
     BG-prover target (#1453, cycle 66, item 3); chains `banzhaf_raw_le_univ`. -/
 theorem banzhaf_index_le_two (G : TUGame N) (i : N) : BanzhafIndex G i ≤ 2 := by
-  sorry
+  have hn : 0 < Fintype.card N := Fintype.card_pos_iff.mpr ⟨i⟩
+  have hdenom : 0 < (2 : ℝ) ^ (Fintype.card N - 1) := pow_pos (by norm_num) _
+  rw [BanzhafIndex, div_le_iff₀ hdenom]
+  have hcard : (Finset.univ : Finset (Finset N)).card = 2 ^ Fintype.card N := by
+    rw [Finset.card_univ, Fintype.card_finset]
+  have h2 : (2 : ℝ) ^ Fintype.card N = 2 * (2 : ℝ) ^ (Fintype.card N - 1) := by
+    have hkey : Fintype.card N = Fintype.card N - 1 + 1 := by omega
+    conv_lhs => rw [hkey, pow_add, pow_one]
+    ring
+  calc (BanzhafRaw G i : ℝ)
+      ≤ ((Finset.univ : Finset (Finset N)).card : ℝ) := by exact_mod_cast banzhaf_raw_le_univ G i
+    _ = (2 ^ Fintype.card N : ℝ) := by rw [hcard]; norm_cast
+    _ = 2 * (2 : ℝ) ^ (Fintype.card N - 1) := by rw [h2]

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1648,6 +1648,7 @@ DEMOS = {
             "Trivial conjunct extraction -- this is a warm-up, not a hard target."
         ),
         "difficulty": "easy",
+    },
     59: {
         "name": "BANZHAF_INDEX_LE_TWO",
         "file": str(SHAPLEY_FILE) if SHAPLEY_FILE else "",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1648,6 +1648,25 @@ DEMOS = {
             "Trivial conjunct extraction -- this is a warm-up, not a hard target."
         ),
         "difficulty": "easy",
+    59: {
+        "name": "BANZHAF_INDEX_LE_TWO",
+        "file": str(SHAPLEY_FILE) if SHAPLEY_FILE else "",
+        "line": 1318,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "banzhaf_index_le_two",
+        "theorem": "banzhaf_index_le_two",
+        "imports": SHAPLEY_IMPORTS,
+        "goal": "BanzhafIndex G i ≤ 2",
+        "description": (
+            "BG-prover target (cycle 66, item 3, greenlit by ai-01): the normalized\n"
+            "Banzhaf index is at most 2. CHAINS banzhaf_raw_le_univ (BanzhafRaw is\n"
+            "bounded by the total number of coalitions 2^card N) and divides by the\n"
+            "normalizer 2^(card N - 1). Non-trivial: needs div_le_iff0, the powerset\n"
+            "cardinality Finset.card_univ + Fintype.card_finset, and the 2^n = 2*2^(n-1)\n"
+            "arithmetic where the player i forces 0 < card N (no Nat-subtraction underflow).\n"
+            "Replace the placeholder at L1318 of Shapley.lean."
+        ),
+        "difficulty": "medium",
     },
 }
 # (gale_shapley_stable) was proved in PR #1194. The prover skips any DEMO


### PR DESCRIPTION
## Summary

**Proven (ref-proof fallback, cycle 66 item 3, ai-01 greenlight).** `banzhaf_index_le_two` — the normalized Banzhaf index is at most 2. The BG-prover **failed** on this target (expected: first genuinely non-trivial target, 5+ lemmas + Nat-subtraction trap); the verified reference proof is committed per the PR's fallback contract. The target is genuinely provable.

### `CooperativeGames/Shapley.lean` — proof

```lean
theorem banzhaf_index_le_two (G : TUGame N) (i : N) : BanzhafIndex G i ≤ 2 := by
  have hn : 0 < Fintype.card N := Fintype.card_pos_iff.mpr ⟨i⟩
  have hdenom : 0 < (2 : ℝ) ^ (Fintype.card N - 1) := pow_pos (by norm_num) _
  rw [BanzhafIndex, div_le_iff₀ hdenom]
  have hcard : (Finset.univ : Finset (Finset N)).card = 2 ^ Fintype.card N := by
    rw [Finset.card_univ, Fintype.card_finset]
  have h2 : (2 : ℝ) ^ Fintype.card N = 2 * (2 : ℝ) ^ (Fintype.card N - 1) := by
    have hkey : Fintype.card N = Fintype.card N - 1 + 1 := by omega
    conv_lhs => rw [hkey, pow_add, pow_one]
    ring
  calc (BanzhafRaw G i : ℝ)
      ≤ ((Finset.univ : Finset (Finset N)).card : ℝ) := by exact_mod_cast banzhaf_raw_le_univ G i
    _ = (2 ^ Fintype.card N : ℝ) := by rw [hcard]; norm_cast
    _ = 2 * (2 : ℝ) ^ (Fintype.card N - 1) := by rw [h2]
```

The chain: `BanzhafIndex = BanzhafRaw/2^(n-1) ≤ univ.card/2^(n-1) = 2^n/2^(n-1) = 2`, where `i : N` forces `0 < card N` (so `card N - 1` does not underflow).

### BG run — FAILED (expected diagnostic data point)

BG-prover demo 59 (all-openrouter, multi, 3 iter) **FAILED**: sorry 1→1, 500s. The write-back fix #4075 worked correctly — `FINAL VERIFY FAILED (1 compile error) → reverted the broken tactic`, no false-success (the file correctly holds the stub after the run). This is the **first genuinely non-trivial target** for the harness (the prior 3 were ≤2 tactics); the diagnostic value is that the harness's proof loop still struggles when a tactic needs 5+ coordinated lemmas + a Nat-subtraction trap. No harness fix needed — the fallback contract (verified ref proof) covers genuinely-provable targets.

### `prover/config.py`

- `DEMOS[59] = BANZHAF_INDEX_LE_TWO` (`sorry_replacement`, L1318, difficulty `medium`). Id 59 (distinct from 56/#4088, 57/#4095, 58/#4102). Kept for future BG re-runs once the harness improves.

## Verification (lean-merge §B)

- `grep tactic-sorry Shapley.lean` = **0** (was 1 stub at L1318).
- `lake build CooperativeGames` → **SUCCESS** (LAKE_EXIT=0, 8435 jobs).
- Diff vs main byte-clean: 22 ins / 1 del, native CRLF preserved (no churn).

## Notes

- The stub→proof transition means the branch holds **0 sorry** — no regression vs main.
- Part of the proving deep-queue. This is the first target chaining an existing theorem (`banzhaf_raw_le_univ` from #4088) and exercising real arithmetic + cast reasoning.

Related #1453. See #4088 (chain base).
