### PR TITLE
fix(infer): Infer-11-Sequences — demote H1 hint headings to inline bold

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Sequences.ipynb
@@ -5156,7 +5156,7 @@
     "3. Comparez les probabilites a posteriori pour les observations ambigues (12.5, 14.0, 9.8, 12.8)\n",
     "4. Expliquez pourquoi la Config B produit des sequences plus \"lisses\"\n",
     "\n",
-    "# Indice : Les valeurs 12.5 et 12.8 sont ambigues car entre les deux moyennes (9 et 13). Comparez P(Fuite) entre les deux configs pour ces valeurs - la config B devrait favoriser la continuite avec les voisins plutot que la vraisemblance seule."
+    "**Indice** : Les valeurs 12.5 et 12.8 sont ambigues car entre les deux moyennes (9 et 13). Comparez P(Fuite) entre les deux configs pour ces valeurs - la config B devrait favoriser la continuite avec les voisins plutot que la vraisemblance seule."
    ]
   },
   {
@@ -5303,7 +5303,7 @@
     "2. Parametrer les emissions gaussiennes pour chaque etat (moyenne + precision)\n",
     "3. Implementer la boucle d'inference et afficher les decisions\n",
     "\n",
-    "# Indice : Utilisez `Variable.DiscreteUniform(3)` pour 3 etats et ajoutez un troisieme bloc `Variable.Case(etat, 2)` pour l'etat \"En panne\"."
+    "**Indice** : Utilisez `Variable.DiscreteUniform(3)` pour 3 etats et ajoutez un troisieme bloc `Variable.Case(etat, 2)` pour l'etat \"En panne\"."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Infer-11-Sequences avait **3 headings H1** : le titre du document (cell 0) PLUS deux lignes d'indice par erreur au niveau 1 :
- cell 56 : `# Indice : Les valeurs 12.5 et 12.8 sont ambigues...`
- cell 59 : `# Indice : Utilisez \`Variable.DiscreteUniform(3)\`...`

Un indice rendu en heading de niveau 1 = **hiérarchie cassée** : il apparaîtrait comme une section top-level dans tout outline/TOC, équivalent au titre du document. Demote en gras inline (`**Indice** : ...`) -> le notebook a désormais un seul H1 (le titre), cohérent avec le reste de la série Infer.

## Changements
- 2 lignes uniquement (`# Indice` → `**Indice**`) dans les cells 56 et 59.
- **Markdown-only** (aucune cellule code touchée, aucune exécution requise — exception C.2 pour edits markdown purs).

## Validation
- `scan_md_hierarchy.py` : flags **MULTI-H1** + **H1-DEEP** résolus (le notebook passe de 3 H1 à 1 H1).
- Le H3 `### Etape` restant (cell 43) est une **vraie sous-section pédagogique** sous `## Exercice` -> **délibérément non touché** (les hints H3 sont une convention, pas un bug structurel comme les hints H1).
- Diff source-only 2 ins/2 del, 62 cells préservées byte-identical (regression check firsthand).

## Scope
1 notebook, 2 lignes, source-only. Probas/Infer = lane po-2025 (pas de collision). See #3966 (formatting family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)