### PR TITLE
lean(cooperative): prove banzhaf_index_eq_zero_iff (BG-prover SUCCESS, sorry 1->0)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1325,4 +1325,4 @@ theorem banzhaf_index_dummy_zero (G : TUGame N) (i : N)
     BG-prover target (#1453, cycle 66, item 4); a `div_eq_zero_iff₀` iff proof. -/
 theorem banzhaf_index_eq_zero_iff (G : TUGame N) (i : N) :
     BanzhafIndex G i = 0 ↔ BanzhafRaw G i = 0 := by
-  sorry
+  simp [BanzhafIndex]

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1316,3 +1316,13 @@ theorem banzhaf_index_symmetric (G : TUGame N) (i j : N)
 theorem banzhaf_index_dummy_zero (G : TUGame N) (i : N)
     (h : DummyPlayer G i) : BanzhafIndex G i = 0 := by
   simp only [BanzhafIndex, dummy_banzhaf_raw_zero G i h, Nat.cast_zero, zero_div]
+
+/-- The normalized Banzhaf index is zero exactly when the raw Banzhaf index is
+    zero: `BanzhafIndex = BanzhafRaw / 2^(card N - 1)` and the normalizing
+    denominator `2 ^ (card N - 1)` is strictly positive (so division by it is
+    faithful). This strengthens `banzhaf_index_dummy_zero` (one direction) into a
+    clean structural characterization.
+    BG-prover target (#1453, cycle 66, item 4); a `div_eq_zero_iff₀` iff proof. -/
+theorem banzhaf_index_eq_zero_iff (G : TUGame N) (i : N) :
+    BanzhafIndex G i = 0 ↔ BanzhafRaw G i = 0 := by
+  sorry

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1648,6 +1648,25 @@ DEMOS = {
             "Trivial conjunct extraction -- this is a warm-up, not a hard target."
         ),
         "difficulty": "easy",
+    60: {
+        "name": "BANZHAF_INDEX_EQ_ZERO_IFF",
+        "file": str(SHAPLEY_FILE) if SHAPLEY_FILE else "",
+        "line": 1319,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "banzhaf_index_eq_zero_iff",
+        "theorem": "banzhaf_index_eq_zero_iff",
+        "imports": SHAPLEY_IMPORTS,
+        "goal": "BanzhafIndex G i = 0 ↔ BanzhafRaw G i = 0",
+        "description": (
+            "BG-prover target (cycle 66, item 4): the normalized Banzhaf index is\n"
+            "zero exactly when the raw Banzhaf index is zero. Since BanzhafIndex =\n"
+            "BanzhafRaw / 2^(card N - 1) and the denominator 2^(card N - 1) is\n"
+            "strictly positive, division is faithful. An iff proof: forward needs\n"
+            "div_mul_cancel0 (multiply both sides by the nonzero denominator),\n"
+            "backward is Nat-cast + zero_div. Strengthens banzhaf_index_dummy_zero.\n"
+            "Replace the placeholder at L1319 of Shapley.lean."
+        ),
+        "difficulty": "medium",
     },
 }
 # (gale_shapley_stable) was proved in PR #1194. The prover skips any DEMO

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1648,6 +1648,7 @@ DEMOS = {
             "Trivial conjunct extraction -- this is a warm-up, not a hard target."
         ),
         "difficulty": "easy",
+    },
     60: {
         "name": "BANZHAF_INDEX_EQ_ZERO_IFF",
         "file": str(SHAPLEY_FILE) if SHAPLEY_FILE else "",


### PR DESCRIPTION
## Summary

Proves a structural Banzhaf characterization theorem via BG-prover (cycle 67, deep-queue item 4: Veto/dummy Banzhaf structurels). **BG SUCCESS, sorry 1→0.**

**Theorem**: `banzhaf_index_eq_zero_iff (G : TUGame N) (i : N) : BanzhafIndex G i = 0 ↔ BanzhafRaw G i = 0`

### Proof (BG-prover, TacticAgent)
```lean
theorem banzhaf_index_eq_zero_iff (G : TUGame N) (i : N) :
    BanzhafIndex G i = 0 ↔ BanzhafRaw G i = 0 := by
  simp [BanzhafIndex]
```
After unfolding `BanzhafIndex = BanzhafRaw/2^(card N-1)`, simp's `div_eq_zero` closure discharges the iff — the denominator `2^(Fintype.card N-1)` is a simp-provable nonzero literal. **One line, shorter than the 8-line reference proof I had verified as fallback** (`pow_pos` + `div_mul_cancel₀` forward + `exact_mod_cast`/`zero_div` backward).

This is a clean structural iff: division by the strictly-positive normalizer `2^(card N-1)` is faithful. It strengthens `banzhaf_index_dummy_zero` (one direction) into a full characterization.

### G.1 / lean-merge §B verified firsthand
- `lake build CooperativeGames` **SUCCESS** (LAKE_EXIT=0, 8435 jobs, 39s). Pre-existing unused-section-vars linter note on `Solution.finsetSumGames_insert` (L568) — not my theorem, not an error.
- `grep -rn '^\s*sorry\s*$'` project-wide (excl `.lake`) = **0**.
- Diff clean: stub `sorry` → `simp [BanzhafIndex]`, LF-native, no CRLF churn.

### Harness capability note (4th BG SUCCESS)
This target (#4088/#4095/#4102/**#4115**) cracked in one line — simp handles the iff because the nonzero denominator is a literal. The harness ceiling observed on #4109 (5+ coordinated lemmas + Nat-sub trap) does not apply to this structural iff. Write-back fix #4075 confirmed: verified proof persisted to real file, no false-success.

### Scope
- `CooperativeGames/Shapley.lean`: +1 theorem (stub commit) then stub→proof (this commit). Pure addition, no regression (`dummy_banzhaf_raw_zero` / `banzhaf_index_dummy_zero` proofs untouched).
- `prover/config.py`: +DEMOS[60] `BANZHAF_INDEX_EQ_ZERO_IFF` (pure additive, 20 ins / 0 del).

**Bullet-sorry stub format** (`:= by` + `sorry` on own indented line) — required for GoalExtract (cycle 63 lesson).

Stacks on nothing — base=main (independent of the #4095/#4102/#4109 merge sequence).

See #1453.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>