### PR TITLE
fix(probas): Pyro_RSA_Hyperbole — demote H1 "Remarque" to inline bold

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb
@@ -1504,7 +1504,7 @@
     "tags": []
    },
    "source": [
-    "# Remarque : Ironie et affect plus complexe\n",
+    "**Remarque** : Ironie et affect plus complexe\n",
     "\n",
     "Dans l’exemple hyperbole, on a supposé un **affect** unidimensionnel : arousal = True/False. En réalité, on peut modéliser un espace en deux dimensions : (valence, arousal). L’étude de Kao et Goodman (2015) montre que cela permet de capturer de nouveaux phénomènes comme l’**ironie** : dire un énoncé joyeux quand on est en réalité en colère, etc.\n",
     "\n",


### PR DESCRIPTION
## Summary

Pyro_RSA_Hyperbole cell 39 utilisait un heading de niveau 1 pour un aside académique :
```
# Remarque : Ironie et affect plus complexe
```

Une « Remarque » est sémantiquement un aside (citant Kao & Goodman 2015 sur l'extension du modèle hyperbole à un affect 2D pour l'ironie), **PAS une section**. L'élever en heading de niveau 1 la fait apparaître comme une section top-level équivalente au titre et aux « Partie » majeures. Demote en gras inline (`**Remarque** : ...`) pour que la remarque se lise comme une digression, pas une section.

## Décision de judgment (content-based)
Le notebook utilise **délibérément H1 pour ses parties majeures** (Partie A / Partie B / Conclusion generale) — cette convention de sectionnement plate est **laissée intacte** (choix de style, pas un bug). **Seul le hint/remark-as-H1 est corrigé** : une remarque n'est pas une Partie, quelle que soit la convention de section du notebook.

**Note honnête** : le flag scanner MULTI-H1 n'est **PAS** pleinement résolu ici (Partie A/B/Conclusion restent H1 par design). Cette PR fixe uniquement le bug structurel genuin (hint-as-H1), distinct du FP convention-multi-H1.

## Validation
- Fix basé sur le **contenu** (cf règle exercise-example-labeling, [[heading-hierarchy-h1-hint-real-vs-h3-convention]]) : un hint/remark au niveau H1 = vrai bug ; une Partie au niveau H1 = convention.
- Markdown-only (aucune cellule code touchée, aucune exécution — exception C.2 markdown-pur).
- Diff source-only 1 ins/1 del, source-drift = cell 39 uniquement (regression check firsthand, 41 cells préservées).

## Scope
1 notebook, 1 ligne, source-only. Probas/Pyro = lane po-2025 (pas de collision). See #3966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)