### PR TITLE
lean(cooperative): prove banzhaf_index_pos_iff (BG-prover SUCCESS, sorry 1->0)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1326,3 +1326,12 @@ theorem banzhaf_index_dummy_zero (G : TUGame N) (i : N)
 theorem banzhaf_index_eq_zero_iff (G : TUGame N) (i : N) :
     BanzhafIndex G i = 0 ↔ BanzhafRaw G i = 0 := by
   simp [BanzhafIndex]
+
+/-- The normalized Banzhaf index is positive exactly when the raw Banzhaf index is
+    positive: the `>0` dual of `banzhaf_index_eq_zero_iff`. Together the two iff
+    theorems give a faithful characterization — the normalizer `2 ^ (card N - 1)` is
+    strictly positive, so positivity and zerohood are both preserved by the division.
+    BG-prover target (#1453, cycle 67, item 5); a positivity iff. -/
+theorem banzhaf_index_pos_iff (G : TUGame N) (i : N) :
+    0 < BanzhafIndex G i ↔ 0 < BanzhafRaw G i := by
+  sorry

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1334,4 +1334,11 @@ theorem banzhaf_index_eq_zero_iff (G : TUGame N) (i : N) :
     BG-prover target (#1453, cycle 67, item 5); a positivity iff. -/
 theorem banzhaf_index_pos_iff (G : TUGame N) (i : N) :
     0 < BanzhafIndex G i ↔ 0 < BanzhafRaw G i := by
-  sorry
+  simp only [BanzhafIndex]
+  have hden : 0 < (2 : ℝ) ^ (Fintype.card N - 1) := pow_pos (by norm_num) _
+  constructor
+  · intro h
+    have hnumreal : 0 < (BanzhafRaw G i : ℝ) := (div_pos_iff_of_pos_right hden).mp h
+    exact_mod_cast hnumreal
+  · intro h
+    exact div_pos (by exact_mod_cast h) hden

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1669,6 +1669,24 @@ DEMOS = {
         ),
         "difficulty": "medium",
     },
+    61: {
+        "name": "BANZHAF_INDEX_POS_IFF",
+        "file": str(SHAPLEY_FILE) if SHAPLEY_FILE else "",
+        "line": 1328,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "banzhaf_index_pos_iff",
+        "theorem": "banzhaf_index_pos_iff",
+        "imports": SHAPLEY_IMPORTS,
+        "goal": "0 < BanzhafIndex G i ↔ 0 < BanzhafRaw G i",
+        "description": (
+            "BG-prover target (cycle 67, item 5): the positivity dual of\n"
+            "banzhaf_index_eq_zero_iff. Since BanzhafIndex = BanzhafRaw /\n"
+            "2^(card N - 1) and the denominator is strictly positive, the\n"
+            "normalized index is positive exactly when the raw count is.\n"
+            "Replace the placeholder at L1328 of Shapley.lean."
+        ),
+        "difficulty": "medium",
+    },
 }
 # (gale_shapley_stable) was proved in PR #1194. The prover skips any DEMO
 # whose key appears in this set.


### PR DESCRIPTION
## Summary

Proves the `>0` dual of `banzhaf_index_eq_zero_iff` (#4115) via BG-prover (cycle 68). **BG SUCCESS, sorry 1→0.** Together `eq_zero_iff` + `pos_iff` give a full faithful characterization of the Banzhaf index's sign.

**Theorem**: `banzhaf_index_pos_iff (G : TUGame N) (i : N) : 0 < BanzhafIndex G i ↔ 0 < BanzhafRaw G i`

### Proof (BG-prover, TacticAgent — full explicit iff)
```lean
theorem banzhaf_index_pos_iff (G : TUGame N) (i : N) :
    0 < BanzhafIndex G i ↔ 0 < BanzhafRaw G i := by
  simp only [BanzhafIndex]
  have hden : 0 < (2 : ℝ) ^ (Fintype.card N - 1) := pow_pos (by norm_num) _
  constructor
  · intro h
    have hnumreal : 0 < (BanzhafRaw G i : ℝ) := (div_pos_iff_of_pos_right hden).mp h
    exact_mod_cast hnumreal
  · intro h
    exact div_pos (by exact_mod_cast h) hden
```
Both iff directions spelled out explicitly: `div_pos_iff_of_pos_right` forward, `div_pos` backward. My verified ref-proof (`simp [BanzhafIndex]`, the eq_zero_iff one-liner) would have been shorter — the BG chose the explicit form, which is valid and more pedagogically transparent.

### G.1 / lean-merge §B verified firsthand
- `lake build CooperativeGames` **SUCCESS** (LAKE_EXIT=0, 8435 jobs, 14s). Pre-existing unused-section-vars linter note (`Solution.finsetSumGames_insert`) — not my theorem, not an error.
- `grep -rn '^\s*sorry\s*$'` project-wide (excl `.lake`) = **0**.
- Diff clean: stub `sorry` → 8-line iff proof, 8 ins / 1 del.

### 5th BG SUCCESS
#4088 / #4095 / #4102 / #4115 / this. The iff-medium targets crack reliably (simp-provable denominators + div lemmas). Write-back fix #4075 confirmed: verified proof persisted to real file.

### Scope
- `CooperativeGames/Shapley.lean`: +1 theorem. `eq_zero_iff` proof byte-preserved (anti-regression G.1).
- `prover/config.py`: +DEMOS[61] `BANZHAF_INDEX_POS_IFF` (pure additive).

**Stacked on #4115** (base = `lean/cooperative-banzhaf-index-eq-zero-iff-bg`). Rebases onto main after #4115 merges.

See #1453.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>