### PR TITLE
docs(qc): add scholarly anchors to QC-Py-14 Portfolio Construction (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -263,7 +263,9 @@
     "| `InsightWeightingPortfolioConstructionModel` | Ponderation par magnitude/confidence | Exploiter la conviction |\n",
     "| `MeanVarianceOptimizationPortfolioConstructionModel` | Optimisation Markowitz | Maximum Sharpe |\n",
     "| `BlackLittermanOptimizationPortfolioConstructionModel` | Black-Litterman avec views | Combine marche + alpha |\n",
-    "| `NullPortfolioConstructionModel` | Ne fait rien | Desactive le composant |"
+    "| `NullPortfolioConstructionModel` | Ne fait rien | Desactive le composant |\n",
+    "\n",
+    "> *Ancre savante -- Black, F. & Litterman, R. (1991), Asset Allocation: Combining Investor Views with Market Equilibrium, The Journal of Fixed Income 1(2):7-18. DOI 10.3905/jfi.1991.408013. (Black-Litterman : combine views investisseur + equilibre de marche.)*\n"
    ]
   },
   {
@@ -365,7 +367,9 @@
     ">\n",
     "> *Correctif #3367 : le bloc precedent affichait Sharpe 3.372 / CAGR 89.49% avec End Equity $116993.28 -- des valeurs **fabriquees et internement contradictoires** (une End Equity de $116993.28 sur 10 ans = +1.58% de CAGR, incompatible avec le CAGR de 89.49% affiche). Metriques reelles ci-dessus obtenues par redeploiement de l'algorithme verbatim sur QC Cloud (projet 33072091, 2015-2024, $100k). Les champs Sortino / Total Orders / Trades / Win Rate / Total Fees sont omis car non fournis de maniere fiable par l'API read_backtest (toujours 0 / \"-\").*\n",
     ">\n",
-    "> *Backtest ID: a764d2faa2e942a0feb3e552da0d3fdc*"
+    "> *Backtest ID: a764d2faa2e942a0feb3e552da0d3fdc*\n",
+    "\n",
+    "> *Ancre savante -- Bailey, D.H. & Lopez de Prado, M. (2012), The Sharpe Ratio Efficient Frontier, Journal of Risk 15(2):3-44. DOI 10.21314/JOR.2012.259. (Probabilistic Sharpe Ratio, corrige du biais de l'echantillon non-IID.)*\n"
    ]
   },
   {
@@ -776,7 +780,9 @@
     "| `rebalancingPeriod` | Resolution/Expiry | Frequence de rebalancement |\n",
     "| `portfolioBias` | Long, Short, LongShort | Contrainte de direction |\n",
     "| `lookback` | int | Jours pour estimer la covariance |\n",
-    "| `resolution` | Resolution | Resolution des donnees historiques |"
+    "| `resolution` | Resolution | Resolution des donnees historiques |\n",
+    "\n",
+    "> *Ancres savantes -- Markowitz, H. (1952), Portfolio Selection, The Journal of Finance 7(1):77-91. DOI 10.1111/j.1540-6261.1952.tb01525.x (theorie moderne du portefeuille MPT, optimisation Mean-Variance) ; Sharpe, W.F. (1966), Mutual Fund Performance, The Journal of Business 39(1):119-138. DOI 10.1086/294846 (ratio de Sharpe / reward-to-variability, objectif Maximum Sharpe).*\n"
    ]
   },
   {
@@ -1010,7 +1016,9 @@
     "|-------|------------|-------|-------|\n",
     "| Actions (SPY) | 20% | 5 | 27.8% |\n",
     "| Obligations (TLT) | 10% | 10 | 55.6% |\n",
-    "| Or (GLD) | 15% | 6.67 | 16.7% |"
+    "| Or (GLD) | 15% | 6.67 | 16.7% |\n",
+    "\n",
+    "> *Ancres savantes -- Qian, E. (2005), Risk Parity Portfolios: Efficient Portfolios Through True Diversification, PanAgora Asset Management Research (origine praticien du Risk Parity) ; Maillard, S., Roncalli, T. & Teiletche, J. (2010), The Properties of Equally Weighted Risk Contribution Portfolios, The Journal of Portfolio Management 36(4):60-70. DOI 10.3905/jpm.2010.36.4.060 (formalisation : egaliser la contribution au risque de chaque actif).*\n"
    ]
   },
   {
@@ -3267,7 +3275,17 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebook complete. Vous maitrisez maintenant les composants avances du Framework QuantConnect.**"
+    "**Notebook complete. Vous maitrisez maintenant les composants avances du Framework QuantConnect.**\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- Bailey, D.H. & Lopez de Prado, M. (2012). The Sharpe Ratio Efficient Frontier. Journal of Risk 15(2):3-44. DOI 10.21314/JOR.2012.259.\n",
+    "- Black, F. & Litterman, R. (1991). Asset Allocation: Combining Investor Views with Market Equilibrium. The Journal of Fixed Income 1(2):7-18. DOI 10.3905/jfi.1991.408013.\n",
+    "- Maillard, S., Roncalli, T. & Teiletche, J. (2010). The Properties of Equally Weighted Risk Contribution Portfolios. The Journal of Portfolio Management 36(4):60-70. DOI 10.3905/jpm.2010.36.4.060.\n",
+    "- Markowitz, H. (1952). Portfolio Selection. The Journal of Finance 7(1):77-91. DOI 10.1111/j.1540-6261.1952.tb01525.x.\n",
+    "- Qian, E. (2005). Risk Parity Portfolios: Efficient Portfolios Through True Diversification. PanAgora Asset Management Research.\n",
+    "- Sharpe, W.F. (1966). Mutual Fund Performance. The Journal of Business 39(1):119-138. DOI 10.1086/294846.\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Markdown-additive scholarly anchors to **QC-Py-14 Portfolio Construction & Execution** notebook (OMISSION fix under #3164). Highest-yield remaining grain (109 ML-concept hits, 0 References section pre-fix).

## Anchors added (5 cells, 5 footnotes, 6 citations + References section)

| Cell | Concept | Anchor |
|------|---------|--------|
| [8] | Black-Litterman | Black & Litterman 1991, J. Fixed Income 1(2):7-18, DOI 10.3905/jfi.1991.408013 |
| [11] | Probabilistic Sharpe Ratio | Bailey & Lopez de Prado 2012, J. Risk 15(2):3-44, DOI 10.21314/JOR.2012.259 |
| [25] | Markowitz MPT + Sharpe Maximum-Sharpe objective (grouped) | Markowitz 1952 J. Finance 7(1):77-91 DOI 10.1111/j.1540-6261.1952.tb01525.x ; Sharpe 1966 J. Business 39(1):119-138 DOI 10.1086/294846 |
| [34] | Risk Parity (grouped: practitioner + theoretical) | Qian 2005 (PanAgora) + Maillard/Roncalli/Teiletche 2010 JPM 36(4):60-70 DOI 10.3905/jpm.2010.36.4.060 |
| [81] | References section (6 entries) | — |

## Verification

- All citations web-verified against primary/strong-secondary sources (IDEAS/RePEc, SSRN, PM Research, author Stanford/PanAgora PDFs, Wiley, JSTOR).
- **VWAP execution (cell 51) intentionally NOT anchored** -- no single canonical originator (industry benchmark, not a paper invention). Marked UNVERIFIED and dropped per audit protocol (a fabricated attribution is worse than no anchor).
- 24/24 code cells byte-identical (no modifications to code).
- Only markdown cells mutated via list-direct pattern.
- 82 cells total unchanged in count/type sequence.