### PR TITLE
docs(qc): add scholarly anchors to QC-Py-08 Multi-Asset + correct 1/N citation (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
@@ -109,7 +109,9 @@
     "| -0.5 | 10% | 50% |\n",
     "| -1.0 | 0% | 100% |\n",
     "\n",
-    "> **Point cle** : Meme avec une correlation de 0, on reduit la volatilite de pres de 30% sans toucher au rendement espere !"
+    "> **Point cle** : Meme avec une correlation de 0, on reduit la volatilite de pres de 30% sans toucher au rendement espere !\n",
+    "\n",
+    "> *Ancres savantes -- Markowitz, H. (1952), Portfolio Selection, The Journal of Finance 7(1):77-91. DOI 10.1111/j.1540-6261.1952.tb01525.x (theorie moderne du portefeuille MPT, frontiere efficiente, aphorisme du \"free lunch\") ; Sharpe, W.F. (1966), Mutual Fund Performance, The Journal of Business 39(1):119-138. DOI 10.1086/294846 (ratio reward-to-variability / Sharpe Ratio).*\n"
    ]
   },
   {
@@ -745,7 +747,9 @@
     "- Trimestriel : Bon compromis (utilisé ici)\n",
     "- Annuel : Trop lent, drift important\n",
     "\n",
-    "> **Études académiques** : De Graaf et al. (2019) montrent que 1/N bat souvent les stratégies optimisées en moyenne-variance, surtout quand les estimations de rendement/volatilité sont imprécises."
+    "> **Études académiques** : DeMiguel, Garlappi & Uppal (2009) montrent que 1/N bat souvent les stratégies optimisées en moyenne-variance, surtout quand les estimations de rendement/volatilité sont imprécises.\n",
+    "\n",
+    "> *Ancre savante -- DeMiguel, V., Garlappi, L. & Uppal, R. (2009), Optimal Versus Naive Diversification: How Inefficient the 1/N Portfolio Strategy?, The Review of Financial Studies 22(5):1915-1953. (Etude canonique : 1/N bat souvent l'optimisation moyenne-variance quand l'erreur d'estimation est grande. Corrige le 24-06 : la prose citait \"De Graaf et al. (2019)\" -- attribution inverifiable, remplacee par le papier originel 1/N.)*\n"
    ],
    "metadata": {}
   },
@@ -1057,7 +1061,9 @@
     "**Formule simplifiee** :\n",
     "$$w_i = \\frac{1/\\sigma_i}{\\sum_j 1/\\sigma_j}$$\n",
     "\n",
-    "ou $\\sigma_i$ est la volatilite de l'actif $i$."
+    "ou $\\sigma_i$ est la volatilite de l'actif $i$.\n",
+    "\n",
+    "> *Ancre savante -- Maillard, S., Roncalli, T. & Teiletche, J. (2010), The Properties of Equally Weighted Risk Contribution Portfolios, The Journal of Portfolio Management 36(4):60-70. DOI 10.3905/jpm.2010.36.4.060. (Formalisation du Risk Parity / contribution egale au risque.)*\n"
    ]
   },
   {
@@ -2343,7 +2349,15 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebook complete. Pret pour QC-Py-09.**"
+    "**Notebook complete. Pret pour QC-Py-09.**\n",
+    "\n",
+    "### Références académiques\n",
+    "\n",
+    "- DeMiguel, V., Garlappi, L. & Uppal, R. (2009). Optimal Versus Naive Diversification: How Inefficient the 1/N Portfolio Strategy? The Review of Financial Studies 22(5):1915-1953.\n",
+    "- Maillard, S., Roncalli, T. & Teiletche, J. (2010). The Properties of Equally Weighted Risk Contribution Portfolios. The Journal of Portfolio Management 36(4):60-70. DOI 10.3905/jpm.2010.36.4.060.\n",
+    "- Markowitz, H. (1952). Portfolio Selection. The Journal of Finance 7(1):77-91. DOI 10.1111/j.1540-6261.1952.tb01525.x.\n",
+    "- Sharpe, W.F. (1966). Mutual Fund Performance. The Journal of Business 39(1):119-138. DOI 10.1086/294846.\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Markdown-additive scholarly anchors to **QC-Py-08 Multi-Asset-Strategies** notebook (OMISSION fix under #3164). 2nd-highest-yield remaining grain (88 ML-concept hits, 0 References section pre-fix). **Includes a factual citation correction.**

## Anchors added (3 cells, 3 footnotes, 4 citations + References section)

| Cell | Concept | Anchor |
|------|---------|--------|
| [3] | Markowitz MPT + Sharpe Ratio (grouped) | Markowitz 1952 J. Finance 7(1):77-91 DOI 10.1111/j.1540-6261.1952.tb01525.x ; Sharpe 1966 J. Business 39(1):119-138 DOI 10.1086/294846 |
| [24] | **CORRECTED 1/N citation** + anchor | DeMiguel, Garlappi & Uppal 2009, RFS 22(5):1915-1953 |
| [36] | Risk Parity | Maillard/Roncalli/Teiletche 2010, JPM 36(4):60-70, DOI 10.3905/jpm.2010.36.4.060 |
| [71] | References section (4 entries) | — |

## ⚠️ Factual correction (cell 24)

The notebook prose cited **"De Graaf et al. (2019)"** to support the claim that 1/N beats mean-variance optimization. **This attribution is unverifiable** — no canonical 1/N paper by De Graaf et al. exists in 2019. The canonical study is **DeMiguel, Garlappi & Uppal (2009), "Optimal Versus Naive Diversification"** (Review of Financial Studies). The fix:
1. Inline text: "De Graaf et al. (2019)" → "DeMiguel, Garlappi & Uppal (2009)"
2. Footnote documents the correction transparently.

This is a content-level factual fix, not a cosmetic relabel.

## Verification

- All citations web-verified (Markowitz JF/MDPI, Sharpe Stanford author page, DeMiguel RFS/SSRN 1376199, Maillard JPM/Roncalli page).
- **Ray Dalio / All-Weather intentionally NOT anchored** — practitioner framework (Bridgewater marketing), no single peer-reviewed canonical paper. Anchoring would be fabrication.
- 20/20 code cells byte-identical.
- Only markdown cells mutated via list-direct pattern.
- 72 cells total unchanged in count/type.