### PR TITLE
fix(sudoku): demote hint-as-H1 headings (Objectif/Indice/Etape) to inline bold

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -773,12 +773,12 @@
    "source": [
     "## Exercice : Ajouter une contrainte d'anti-symetrie\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Ajoutez au modele OR-Tools une contrainte qui force la premiere ligne\n",
     "a etre strictement croissante (1,2,3,4,5,6,7,8,9), eliminant ainsi\n",
     "les solutions symetriques par rotation/reflection.\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Utilisez `model.Add(cells[0][i] == i+1)` pour chaque colonne i de la ligne 0.\n"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
@@ -691,11 +691,11 @@
    "source": [
     "## Exercice : Optimiser le prompt zero-shot\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Modifiez le prompt zero-shot pour ameliorer le taux de succes.\n",
     "Testez au moins 2 variantes et comparez les resultats.\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Ajoutez des instructions plus precises sur le format de sortie attendu.\n",
     "Testez avec des puzzles faciles pour mesurer l'impact.\n"
    ]
@@ -1162,11 +1162,11 @@
    "source": [
     "## Exercice : Comparer zero-shot vs few-shot vs code interpreter\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Implementez une fonction qui teste les 3 approches sur les memes puzzles\n",
     "et retourne un tableau comparatif des taux de succes et temps de resolution.\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Utilisez les fonctions deja definies pour chaque approche et mesurez le temps\n",
     "avec `time.time()`.\n"
    ]
@@ -2208,11 +2208,11 @@
    "source": [
     "## Exercice : Analyser les erreurs du LLM\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Analysez les erreurs commises par le LLM quand il echoue a resoudre un puzzle.\n",
     "Categorisez les types d'erreurs (violation de ligne, colonne, bloc, valeur hors range).\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Comparez la grille produite par le LLM avec la solution correcte et identifiez\n",
     "les cellules en erreur, puis verifiez quelles contraintes sont violees.\n"
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -1650,11 +1650,11 @@
    "source": [
     "## Exercice : Analyser la robustesse des solveurs face aux puzzles partiels\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Testez comment chaque solveur se comporte quand on augmente progressivement\n",
     "le nombre de cases vides dans un puzzle (de 30 a 55 cases vides).\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Partez d'un puzzle resolu et supprimez aleatoirement un nombre croissant de valeurs.\n",
     "Mesurez le temps de resolution pour chaque niveau de difficulte artificielle.\n"
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
@@ -300,11 +300,11 @@
    "source": [
     "## Exercice : Construire la matrice de couverture exacte pour un mini-Sudoku\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Construisez manuellement la matrice de couverture exacte pour un Sudoku 4x4\n",
     "(et non 9x9), ou chaque ligne/colonne/bloc 2x2 doit contenir les chiffres 1 a 4.\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Identifiez les 4 types de contraintes (ligne, colonne, bloc, cellule) et\n",
     "comptez le nombre de colonnes de la matrice. Pour chaque assignation possible\n",
     "(cellule, valeur), creez une ligne dans la matrice avec des 1 aux colonnes\n",
@@ -1343,13 +1343,13 @@
    "source": [
     "## Exercice : Analyse de complexite de Dancing Links\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Analysez le nombre de noeuds explores par DLX en fonction de la difficulte\n",
     "du puzzle. Mesurez et comparez avec le backtracking simple.\n",
     "\n",
-    "# Etape 1\n",
+    "**Étape 1**\n",
     "Ajoutez un compteur de noeuds dans la classe DancingLinks.\n",
-    "# Etape 2\n",
+    "**Étape 2**\n",
     "Lancez le benchmark et collectez les donnees.\n"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
@@ -322,11 +322,11 @@
    "source": [
     "## Exercice : Calculer l'energie d'une grille partiellement remplie\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Implementez une variante de `compute_energy` qui calcule le nombre de conflits\n",
     "uniquement pour les lignes, colonnes et blocs non complets.\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Parcourir chaque ligne/colonne/bloc et compter les doublons parmi les valeurs non nulles.\n"
    ]
   },
@@ -520,11 +520,11 @@
    "source": [
     "## Exercice : Generer un voisin par echange de bloc\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Implementez un operateur de voisinage qui echange deux valeurs non fixees\n",
     "dans le meme bloc 3x3 (au lieu de la meme ligne).\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc,\n",
     "et echangez leurs valeurs.\n"
    ]
@@ -2046,12 +2046,12 @@
    "source": [
     "## Exercice : Comparer les schemas de refroidissement\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Comparez le schema de refroidissement lineaire et exponentiel sur les memes puzzles.\n",
     "\n",
-    "# Etape 1\n",
+    "**Étape 1**\n",
     "Implementez un schema de refroidissement exponentiel: T = T_init * alpha^step\n",
-    "# Etape 2\n",
+    "**Étape 2**\n",
     "Lancez les benchmarks et comparez les taux de succes.\n"
    ]
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
@@ -646,11 +646,11 @@
    "source": [
     "## Exercice : Analyser l'impact de la propagation des contraintes\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Desactivez la propagation (eliminate) dans le solveur de Norvig et comparez\n",
     "le nombre d'appels recursifs et le temps de resolution.\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Modifiez la fonction `solve` pour court-circuiter `eliminate` et mesurer\n",
     "la difference de performance sur les puzzles difficiles.\n"
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -511,11 +511,11 @@
    "source": [
     "## Exercice : Compter les naked singles par difficulte\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Comptez combien de naked singles peuvent etre trouves dans des puzzles\n",
     "de differentes difficultes (facile, moyen, difficile).\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Utilisez `find_naked_singles` sur plusieurs puzzles de chaque difficulte\n",
     "et calculez la moyenne.\n"
    ]
@@ -880,14 +880,14 @@
    "source": [
     "## Exercice : Implementer la technique Hidden Pair\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Implementez la detection des Hidden Pairs : quand deux valeurs n'apparaissent\n",
     "que dans deux cellules d'une meme unite (ligne/colonne/bloc), ces deux valeurs\n",
     "peuvent etre eliminees des candidats des autres cellules de l'unite.\n",
     "\n",
-    "# Etape 1\n",
+    "**Étape 1**\n",
     "Parcourez chaque unite et identifiez les valeurs qui n'apparaissent que 2 fois.\n",
-    "# Etape 2\n",
+    "**Étape 2**\n",
     "Verifiez si ces 2 valeurs partagent les memes 2 cellules.\n"
    ]
   },
@@ -1572,11 +1572,11 @@
    "source": [
     "## Exercice : Mesurer le taux de resolution par strategies humaines seules\n",
     "\n",
-    "# Objectif\n",
+    "**Objectif**\n",
     "Determinez quel pourcentage de puzzles peut etre resolu uniquement par\n",
     "strategies humaines (sans backtracking), par difficulte.\n",
     "\n",
-    "# Indice\n",
+    "**Indice**\n",
     "Utilisez le solveur `HumanSudokuSolver` et comptez les puzzles ou\n",
     "`solve()` retourne True sans utiliser le backtracking de secours.\n"
    ]


### PR DESCRIPTION
## Summary

7 Sudoku notebooks (Sudoku-2/4/7/8/10/17/18, all Python) had **exercise-field labels** (`# Objectif` / `# Indice` / `# Etape N`) promoted to **level-1 headings** inside `## Exercice` sections. Each notebook's document title is the only legitimate H1; these field labels created phantom top-level titles in any TOC/outline view.

Same structural-bug class as Infer-11 (#4113, Indice-as-H1) and Pyro_RSA Remarque (#4117).

## Per-notebook fix (31 headings total)

| Notebook | Headings demoted |
|----------|------------------|
| Sudoku-2-DancingLinks-Python | 5 (2× Objectif+Indice, Etape 1+2) |
| Sudoku-4-SimulatedAnnealing-Python | 7 (3× Objectif, 2× Indice, Etape 1+2) |
| Sudoku-7-Norvig-Python | 2 (Objectif, Indice) |
| Sudoku-8-HumanStrategies-Python | 7 (3× Objectif, 2× Indice, Etape 1+2) |
| Sudoku-10-ORTools-Python | 2 (Objectif, Indice) |
| Sudoku-17-LLM-Python | 6 (3× Objectif, 3× Indice) |
| Sudoku-18-Comparison-Python | 2 (Objectif, Indice) |

Normalization: `# Objectif`→`**Objectif**`, `# Indice`→`**Indice**`, `# Etape N`→`**Étape N**` (field labels → inline bold; `Etape`→`Étape` FR consistency).

## Validation (G.1 firsthand)

- **Scanner-clean**: `scan_md_hierarchy.py Sudoku` → **0 MULTI-H1 + 0 H1-DEEP** across the family after fix.
- **Source-only**: staged diff = **7 files / 32 ins / 32 del**, **ZERO drift** on `outputs` / `execution_count` / `metadata`. Markdown-only, no re-execution required.
- **Anchored**: each demote asserted on (cell index, line index, exact heading text) — no blind find-replace.
- **Pedagogy preserved**: rendered exercise cells keep field/content readability (`**Objectif**` + content on next line, same pattern as #4113 `**Indice** :`).

## Classification (honest — what was NOT touched)

- **Search family** `# Exemple`/`# Backtracking`/`# Conclusion` MULTI-H1 = **CONVENTION, not touched** (deliberate flat-H1 sectioning, like Pyro_RSA Parties — mechanical demote = pedagogy degradation).
- **`.QuantConnect` family** = **CLEAN** (0 flags).
- **SymbolicAI** H1-DEEP flags (Argument_Analysis, RDF.Net) = navigation-blockquote FP (title legitimately in cell 1).

See #3966